### PR TITLE
Reformat all files consistently and using spaces

### DIFF
--- a/.black
+++ b/.black
@@ -1,0 +1,5 @@
+
+[tool.black]
+line-length=80
+target-version=["py311"]
+

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate code style to Black
+a158d613bf979c152338f6c407ec6de75d9a9c1a

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,12 @@
+name: lint
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          options: "--check --config=.black"
+          src: "./src"
+

--- a/src/brand/bhyve/boot.py
+++ b/src/brand/bhyve/boot.py
@@ -17,8 +17,17 @@
 
 import bundle
 import bootlib
-from bootlib import fatal, error, debug, info, warning, boolv, diskpath, \
-    expandopts, collapseopts
+from bootlib import (
+    fatal,
+    error,
+    debug,
+    info,
+    warning,
+    boolv,
+    diskpath,
+    expandopts,
+    collapseopts,
+)
 import getopt
 import logging
 import os
@@ -33,6 +42,8 @@ import ucred
 from pprint import pprint, pformat
 
 import uefi.vars as uefivars
+
+# fmt: off
 
 STATEDIR        = '/var/run/bhyve'
 RSRVRCTL        = '/usr/lib/rsrvrctl'
@@ -115,6 +126,8 @@ VIRTFS_SLOT     = 11
 CINIT_SLOT      = 29
 VNC_SLOT        = 30
 LPC_SLOT_WIN    = 31
+
+# fmt: off
 
 ##############################################################################
 
@@ -665,6 +678,8 @@ if jsonmode:
     from itertools import zip_longest
     import json
 
+    # fmt: off
+
     data = {
         'zonename':     z.name,
         'zonepath':     z.zonepath,
@@ -687,6 +702,8 @@ if jsonmode:
         'opts':         opts,
         'config':       {},
     }
+
+    # fmt: on
 
     for line in p.stdout.splitlines():
         if line.startswith('config.dump'): continue

--- a/src/brand/bhyve/bootlib.py
+++ b/src/brand/bhyve/bootlib.py
@@ -28,38 +28,48 @@ from pprint import pformat
 
 log_quiet = False
 
+
 def log_stdout(level):
     logging.basicConfig(stream=sys.stdout, level=level)
 
+
 def log_file(file, level):
     os.makedirs(os.path.dirname(file), mode=0o711, exist_ok=True)
-    logging.basicConfig(filename=file, filemode='a', level=level, force=True)
+    logging.basicConfig(filename=file, filemode="a", level=level, force=True)
+
 
 def set_quiet(val):
     global log_quiet
     log_quiet = val
+
 
 def fatal(msg):
     logging.error(msg)
     print(msg, file=sys.stderr)
     sys.exit(1)
 
+
 def error(msg):
     logging.error(msg)
+
 
 def debug(msg):
     if not log_quiet:
         logging.debug(msg)
 
+
 def info(msg):
     if not log_quiet:
         logging.info(msg)
+
 
 def warning(msg):
     if not log_quiet:
         logging.warning(msg)
 
+
 ##############################################################################
+
 
 class Zone:
     xmlfile = None
@@ -70,11 +80,11 @@ class Zone:
         self.xmlfile = xmlfile
 
         if not os.path.isfile(xmlfile):
-            fatal(f'Cannot find zone XML file at {xmlfile}')
+            fatal(f"Cannot find zone XML file at {xmlfile}")
         try:
             self.xmlcfg = etree.parse(xmlfile)
         except:
-            fatal(f'Could not parse {xmlfile}')
+            fatal(f"Could not parse {xmlfile}")
 
         self.xmlroot = self.xmlcfg.getroot()
 
@@ -83,7 +93,7 @@ class Zone:
 
     @property
     def zoneroot(self):
-        return f'{self.zonepath}/root'
+        return f"{self.zonepath}/root"
 
     def find(self, path):
         return self.xmlroot.find(path)
@@ -101,22 +111,22 @@ class Zone:
             return self.find(f'./attr[@name="{attr}"]')
 
     def iterattr(self, regex):
-        for dev in self.findall('./attr[@name]'):
-            if m := re.search(regex, dev.get('name').strip()):
+        for dev in self.findall("./attr[@name]"):
+            if m := re.search(regex, dev.get("name").strip()):
                 yield dev, m
 
     def parseopt(self, tag, opts, aliases):
         try:
             el = self.findattr(tag)
-            opts[tag] = el.get('value').strip()
+            opts[tag] = el.get("value").strip()
             debug(f'Found custom {tag} attribute - "{opts[tag]}"')
             if tag in aliases:
                 val = opts[tag]
                 if (bt := boolv(val, tag, ignore=True)) is not None:
-                    val = 'on' if bt else 'off'
+                    val = "on" if bt else "off"
                 try:
                     opts[tag] = aliases[tag][val]
-                    debug(f'  Alias expanded to {opts[tag]}')
+                    debug(f"  Alias expanded to {opts[tag]}")
                 except KeyError:
                     pass
         except:
@@ -124,9 +134,9 @@ class Zone:
 
     def uuid(self):
         try:
-            with open(f'{z.zoneroot}/etc/uuid') as file:
+            with open(f"{z.zoneroot}/etc/uuid") as file:
                 uuid = file.read().strip()
-                info('Zone UUID: {0}'.format(id))
+                info("Zone UUID: {0}".format(id))
         except:
             uuid = str(uuidlib.uuid4())
         return uuid
@@ -135,161 +145,174 @@ class Zone:
     # generate a list.
     def build_devlist(self, type, maxval, plain=True):
         devlist = {}
-        for dev, m in self.iterattr(rf'^{type}(\d+)$'):
+        for dev, m in self.iterattr(rf"^{type}(\d+)$"):
             k = int(m.group(1))
             if k in devlist:
-                fatal(f'{type}{k} appears more than once in configuration')
-            if (k >= maxval):
-                fatal(f'{type}{k} slot out of range')
-            devlist[k] = dev.get('value').strip()
+                fatal(f"{type}{k} appears more than once in configuration")
+            if k >= maxval:
+                fatal(f"{type}{k} slot out of range")
+            devlist[k] = dev.get("value").strip()
 
         if plain:
             # Now insert plain <type> tags into the list, using available slots
             # in order
-            avail = sorted(set(range(0, maxval)).
-                difference(sorted(devlist.keys())))
+            avail = sorted(
+                set(range(0, maxval)).difference(sorted(devlist.keys()))
+            )
             for dev in self.findattr(type, True):
                 try:
                     k = avail.pop(0)
                 except IndexError:
-                    fatal(f'{type}: no more available slots')
-                devlist[k] = dev.get('value').strip()
+                    fatal(f"{type}: no more available slots")
+                devlist[k] = dev.get("value").strip()
 
-        debug('{} list: \n{}'.format(type, pformat(devlist)))
+        debug("{} list: \n{}".format(type, pformat(devlist)))
 
         return sorted(devlist.items())
 
     def build_cloudinit_image(self, uuid, src, testmode):
-        info('Generating cloud-init data')
+        info("Generating cloud-init data")
 
         #### Metadata
 
         meta_data = {
-            'instance-id':      uuid,
-            'local-hostname':   self.name,
+            "instance-id": uuid,
+            "local-hostname": self.name,
         }
 
         #### Userdata
 
         user_data = {
-            'hostname':         self.name,
-            'disable_root':     False,
+            "hostname": self.name,
+            "disable_root": False,
         }
 
-        if (v := self.findattr('password')) is not None:
-            user_data['password'] = file_or_string(v.get('value'))
-            user_data['chpasswd'] = { 'expire': False }
-            user_data['ssh-pwauth'] = True
+        if (v := self.findattr("password")) is not None:
+            user_data["password"] = file_or_string(v.get("value"))
+            user_data["chpasswd"] = {"expire": False}
+            user_data["ssh-pwauth"] = True
 
-        if (v := self.findattr('sshkey')) is not None:
-            v = file_or_string(v.get('value'))
-            user_data['ssh_authorized_keys'] = [v]
-            user_data['users'] = [
-                'default',
-                {'name': 'root', 'ssh_authorized_keys': [v]}
+        if (v := self.findattr("sshkey")) is not None:
+            v = file_or_string(v.get("value"))
+            user_data["ssh_authorized_keys"] = [v]
+            user_data["users"] = [
+                "default",
+                {"name": "root", "ssh_authorized_keys": [v]},
             ]
 
         #### Network
 
         network_data = {}
 
-        addresses = self.findall('./network[@allowed-address]')
+        addresses = self.findall("./network[@allowed-address]")
         if addresses is not None:
             nsdone = False
-            network_data['version'] = 2
-            network_data['ethernets'] = {}
+            network_data["version"] = 2
+            network_data["ethernets"] = {}
 
             for a in addresses:
-                vnic = a.get('physical')
-                addr = a.get('allowed-address')
-                rtr = a.get('defrouter')
+                vnic = a.get("physical")
+                addr = a.get("allowed-address")
+                rtr = a.get("defrouter")
 
                 mac = get_mac(vnic)
                 if mac is None:
                     continue
 
                 data = {
-                    'match':        { 'macaddress': mac },
-                    'set-name':     vnic,
-                    'addresses':    [addr],
+                    "match": {"macaddress": mac},
+                    "set-name": vnic,
+                    "addresses": [addr],
                 }
                 if rtr:
-                    data['gateway4'] = rtr
+                    data["gateway4"] = rtr
 
                 if not nsdone:
-                    domain = self.findattr('dns-domain')
-                    resolvers = self.findattr('resolvers')
+                    domain = self.findattr("dns-domain")
+                    resolvers = self.findattr("resolvers")
                     if resolvers is not None or domain is not None:
                         nsdata = {}
                         if domain is not None:
-                            nsdata['search'] = [domain.get('value').strip()]
+                            nsdata["search"] = [domain.get("value").strip()]
                         if resolvers is not None:
-                            nsdata['addresses'] = \
-                                resolvers.get('value').strip().split(',')
-                        data['nameservers'] = nsdata
+                            nsdata["addresses"] = (
+                                resolvers.get("value").strip().split(",")
+                            )
+                        data["nameservers"] = nsdata
                     nsdone = True
 
-                network_data['ethernets'][vnic] = data
+                network_data["ethernets"][vnic] = data
 
         import yaml
-        debug('Metadata:\n' + yaml.dump(meta_data))
-        debug('Userdata:\n' + yaml.dump(user_data))
-        debug('Netdata:\n' + yaml.dump(network_data))
+
+        debug("Metadata:\n" + yaml.dump(meta_data))
+        debug("Userdata:\n" + yaml.dump(user_data))
+        debug("Netdata:\n" + yaml.dump(network_data))
 
         if testmode:
             return
 
-        dir = tempfile.mkdtemp(dir=f'{self.zoneroot}', prefix='cloud-init.')
+        dir = tempfile.mkdtemp(dir=f"{self.zoneroot}", prefix="cloud-init.")
 
-        with open(f'{dir}/meta-data', 'w') as fh:
+        with open(f"{dir}/meta-data", "w") as fh:
             yaml.dump(meta_data, fh)
 
         if os.path.isabs(src) and os.path.isfile(src):
-            info(f'Using supplied cloud-init user-data file from {src}')
-            shutil.copyfile(src, f'{dir}/user-data')
+            info(f"Using supplied cloud-init user-data file from {src}")
+            shutil.copyfile(src, f"{dir}/user-data")
         else:
-            with open(f'{dir}/user-data', 'w') as fh:
-                fh.write('#cloud-config\n')
+            with open(f"{dir}/user-data", "w") as fh:
+                fh.write("#cloud-config\n")
                 yaml.dump(user_data, fh)
 
         if network_data:
-            with open(f'{dir}/network-config', 'w') as fh:
+            with open(f"{dir}/network-config", "w") as fh:
                 yaml.dump(network_data, fh)
 
         #### Build image
 
-        cidir = f'{self.zoneroot}/cloud-init'
-        seed = f'{self.zoneroot}/cloud-init.iso'
+        cidir = f"{self.zoneroot}/cloud-init"
+        seed = f"{self.zoneroot}/cloud-init.iso"
         if os.path.exists(cidir):
             shutil.rmtree(cidir)
         os.rename(dir, cidir)
-        info('Building cloud-init ISO image')
+        info("Building cloud-init ISO image")
         try:
-            ret = subprocess.run([
-                '/usr/bin/mkisofs',
-                '-full-iso9660-filenames',
-                '-untranslated-filenames',
-                '-rock',
-                '-volid', 'CIDATA',
-                '-o', seed,
-                cidir
-            ], text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            ret = subprocess.run(
+                [
+                    "/usr/bin/mkisofs",
+                    "-full-iso9660-filenames",
+                    "-untranslated-filenames",
+                    "-rock",
+                    "-volid",
+                    "CIDATA",
+                    "-o",
+                    seed,
+                    cidir,
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
             for l in ret.stdout.splitlines():
                 info(l)
             os.chmod(seed, mode=0o644)
         except Exception as e:
-            fatal(f'Could not create cloud-init ISO image: {e}')
+            fatal(f"Could not create cloud-init ISO image: {e}")
+
 
 ##############################################################################
 
+
 def boolv(s, var, ignore=False):
-    if s in ['true', 'yes', 'on', '1']:
+    if s in ["true", "yes", "on", "1"]:
         return True
-    if s in ['false', 'no', 'off', '0']:
+    if s in ["false", "no", "off", "0"]:
         return False
     if not ignore:
-        fatal(f'Invalid value {s} for boolean variable {var}')
+        fatal(f"Invalid value {s} for boolean variable {var}")
     return None
+
 
 def file_or_string(f):
     if os.path.isabs(f) and os.path.isfile(f):
@@ -297,39 +320,40 @@ def file_or_string(f):
             with open(f) as fh:
                 f = fh.read()
         except Exception as e:
-            fatal(f'Could not read from {f}: {e}')
+            fatal(f"Could not read from {f}: {e}")
     return f.strip()
 
+
 def expandopts(opt):
-    """ Expand a comma-separated option string out into a dictionary.
-        For example:
-            on,password=fred,wait,w=1234
-        becomes:
-            {'on': '', 'password': 'fred', 'wait': '', 'w': '1234'}
+    """Expand a comma-separated option string out into a dictionary.
+    For example:
+        on,password=fred,wait,w=1234
+    becomes:
+        {'on': '', 'password': 'fred', 'wait': '', 'w': '1234'}
     """
     return {
-        k: v
-        for (k, v, *_)
-        in [
-            (o + '=').split('=')
-            for o in opt.split(',')
-        ]
+        k: v for (k, v, *_) in [(o + "=").split("=") for o in opt.split(",")]
     }
 
+
 def collapseopts(opts):
-    """ The reverse of expandopts. Convert a dictionary back into an option
-        string. """
-    return ','.join([f'{k}={v}'.rstrip('=') for k, v in opts.items()])
+    """The reverse of expandopts. Convert a dictionary back into an option
+    string."""
+    return ",".join([f"{k}={v}".rstrip("=") for k, v in opts.items()])
+
 
 def diskpath(arg):
-    if arg.startswith('/'):
+    if arg.startswith("/"):
         return arg
-    return '/dev/zvol/rdsk/{0}'.format(arg)
+    return "/dev/zvol/rdsk/{0}".format(arg)
 
-ram_shift = { 'e': 60, 'p': 50, 't': 40, 'g': 30, 'm': 20, 'k': 10, 'b': 0 }
+
+ram_shift = {"e": 60, "p": 50, "t": 40, "g": 30, "m": 20, "k": 10, "b": 0}
+
+
 def parse_ram(v):
     # Parse a string representing an amount of RAM into bytes
-    m = re.search(rf'^(\d+)(.?)$', v)
+    m = re.search(rf"^(\d+)(.?)$", v)
     if not m:
         fatal(f'Could not parse ram value "{v}"')
     (mem, suffix) = m.groups()
@@ -338,27 +362,31 @@ def parse_ram(v):
     if not suffix:
         # If the memory size specified as a plain number is less than a
         # mebibyte then interpret it as being in units of MiB.
-        suffix = 'm' if mem < MiB else 'b'
+        suffix = "m" if mem < MiB else "b"
 
     try:
         shift = ram_shift[suffix.lower()]
     except KeyError:
-        fatal(f'Unknown RAM suffix, {suffix}')
+        fatal(f"Unknown RAM suffix, {suffix}")
 
     mem <<= shift
 
-    debug(f'parse_ram({v}) = {mem}')
+    debug(f"parse_ram({v}) = {mem}")
     return mem
 
+
 def get_mac(ifname):
-    p = subprocess.run(['/usr/sbin/dladm', 'show-vnic',
-        '-p', '-o', 'macaddress', ifname], stdout=subprocess.PIPE)
+    p = subprocess.run(
+        ["/usr/sbin/dladm", "show-vnic", "-p", "-o", "macaddress", ifname],
+        stdout=subprocess.PIPE,
+    )
     if p.returncode != 0:
-        warning(f'Could not find MAC address for VNIC {ifname}')
+        warning(f"Could not find MAC address for VNIC {ifname}")
         return None
-    mac = p.stdout.decode('utf-8').strip()
+    mac = p.stdout.decode("utf-8").strip()
     # Need to zero-pad the bytes
-    return ':'.join(l.zfill(2) for l in mac.split(':'))
+    return ":".join(l.zfill(2) for l in mac.split(":"))
+
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/brand/bhyve/bundle.py
+++ b/src/brand/bhyve/bundle.py
@@ -20,11 +20,14 @@ import os, sys, platform
 
 # If PYTHONPATH is set in the environment and the environment is not
 # being ignored, then don't adjust the path.
-if 'PYTHONPATH' not in os.environ or getattr(sys.flags, 'ignore_environment'):
+if "PYTHONPATH" not in os.environ or getattr(sys.flags, "ignore_environment"):
     sys.path, remainder = sys.path[:2], sys.path[2:]
-    addsitedir("{}/python{}".format(
-        os.path.dirname(__file__),
-        '.'.join(platform.python_version_tuple()[:2])))
+    addsitedir(
+        "{}/python{}".format(
+            os.path.dirname(__file__),
+            ".".join(platform.python_version_tuple()[:2]),
+        )
+    )
     sys.path.extend(remainder)
 
 # Vim hints

--- a/src/brand/bhyve/uefi/align.py
+++ b/src/brand/bhyve/uefi/align.py
@@ -1,4 +1,3 @@
-
 # {{{ CDDL HEADER
 #
 # This file and its contents are supplied under the terms of the
@@ -20,8 +19,13 @@
 #
 # See https://github.com/construct/construct/issues/980
 
-from construct import Aligned as _Aligned, \
-    stream_tell, stream_read, stream_write
+from construct import (
+    Aligned as _Aligned,
+    stream_tell,
+    stream_read,
+    stream_write,
+)
+
 
 class Aligned(_Aligned):
     def _pad(self, stream, path):
@@ -41,4 +45,3 @@ class Aligned(_Aligned):
         pad = self._pad(stream, path)
         stream_write(stream, self.pattern * pad, pad, path)
         return buildret
-

--- a/src/brand/bhyve/uefi/vars.py
+++ b/src/brand/bhyve/uefi/vars.py
@@ -22,8 +22,8 @@ from uuid import UUID
 from . import align
 
 setGlobalPrintFullStrings(True)
-#setGlobalPrintFalseFlags(True)
-#setGlobalPrintPrivateEntries(True)
+# setGlobalPrintFalseFlags(True)
+# setGlobalPrintPrivateEntries(True)
 
 # The uefi-edk2 nvram firmware volume is divided into sections as follows:
 #
@@ -34,24 +34,26 @@ setGlobalPrintFullStrings(True)
 #
 # This is valid for firmware generated with an FD_SIZE of 1024 or 2048.
 
-VAR_STORE_VOLUME_SIZE = 0xe000
+VAR_STORE_VOLUME_SIZE = 0xE000
 
-VAR_STORE_FORMATTED = 0x5a
-VAR_STORE_HEALTHY = 0xfe
+VAR_STORE_FORMATTED = 0x5A
+VAR_STORE_HEALTHY = 0xFE
 
-VARIABLE_DATA = 0x55aa
+VARIABLE_DATA = 0x55AA
 
-VAR_ADDED = 0x3f
-VAR_DELETED = 0xfd
-VAR_IN_DELETED_TRANSITION = 0xfe
-VAR_HEADER_VALID_ONLY = 0x7f
+VAR_ADDED = 0x3F
+VAR_DELETED = 0xFD
+VAR_IN_DELETED_TRANSITION = 0xFE
+VAR_HEADER_VALID_ONLY = 0x7F
 VAR_ADDED_TRANSITION = VAR_ADDED & VAR_IN_DELETED_TRANSITION
 VAR_DELETED_TRANSITION = VAR_ADDED & VAR_DELETED & VAR_IN_DELETED_TRANSITION
 
 GLOBAL_VARIABLE_GUID = "8be4df61-93ca-11d2-aa0d-00e098032b8c"
 
-EfiGuid = Union(0,
-    "efiguid" / Struct(
+EfiGuid = Union(
+    0,
+    "efiguid"
+    / Struct(
         "data1" / Hex(Int32ul),
         "data2" / Hex(Int16ul),
         "data3" / Hex(Int16ul),
@@ -68,11 +70,11 @@ EfiTime = Struct(
     "hour" / Int8ul,
     "min" / Int8ul,
     "sec" / Int8ul,
-    "_pad1" / Int8ul, # padding
+    "_pad1" / Int8ul,  # padding
     "nanosec" / Int32ul,
     "tz" / Int16ul,
     "daylight" / Int8ul,
-    "_pad2" / Int8ul, # padding
+    "_pad2" / Int8ul,  # padding
 )
 
 BlockMapEntry = Struct(
@@ -85,22 +87,24 @@ VariableStoreHeader = Struct(
     "size" / Int32ul,
     "format" / Const(VAR_STORE_FORMATTED, Int8ul),
     "state" / Const(VAR_STORE_HEALTHY, Int8ul),
-    "_rsvd1" / Int16ul, # reserved
-    "_rsvd1" / Int32ul, # reserved
+    "_rsvd1" / Int16ul,  # reserved
+    "_rsvd1" / Int32ul,  # reserved
 )
 
 AuthVariable = Struct(
     "offset" / Hex(Tell),
     "startid" / Int16ul,
     "state" / Hex(Int8ul),
-    "_rsvd1" / Int8ul,         # reserved
-    "attributes" / FlagsEnum(Int32ul,
-        EFI_VARIABLE_NON_VOLATILE = 0x00000001,
-        EFI_VARIABLE_BOOTSERVICE_ACCESS = 0x00000002,
-        EFI_VARIABLE_RUNTIME_ACCESS = 0x00000004,
-        EFI_VARIABLE_HARDWARE_ERROR_RECORD = 0x00000008,
-        EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS = 0x00000020,
-        EFI_VARIABLE_APPEND_WRITE = 0x00000040,
+    "_rsvd1" / Int8ul,  # reserved
+    "attributes"
+    / FlagsEnum(
+        Int32ul,
+        EFI_VARIABLE_NON_VOLATILE=0x00000001,
+        EFI_VARIABLE_BOOTSERVICE_ACCESS=0x00000002,
+        EFI_VARIABLE_RUNTIME_ACCESS=0x00000004,
+        EFI_VARIABLE_HARDWARE_ERROR_RECORD=0x00000008,
+        EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS=0x00000020,
+        EFI_VARIABLE_APPEND_WRITE=0x00000040,
     ),
     "count" / Int64ul,
     "timestamp" / EfiTime,
@@ -109,7 +113,7 @@ AuthVariable = Struct(
     "datalen" / Int32ul,
     "guid" / EfiGuid,
     "name" / CString("utf_16_le"),
-    "data" / align.Aligned(4, Bytes(this.datalen), pattern=b'\xff'),
+    "data" / align.Aligned(4, Bytes(this.datalen), pattern=b"\xff"),
     "next" / Peek(Int16ul),
 )
 
@@ -117,12 +121,12 @@ Volume = Struct(
     "zero_vector" / Array(2, Int64ul),
     "guid" / EfiGuid,
     "volsize" / Int64ul,
-    "signature" / Const(b'_FVH'),
+    "signature" / Const(b"_FVH"),
     "attributes" / Int32ul,
     "headerlen" / Int16ul,
     "checksum" / Int16ul,
     "ext_hdr_ofset" / Const(0, Int16ul),
-    "_rsvd1" / Int8ul, # reserved
+    "_rsvd1" / Int8ul,  # reserved
     "revision" / Const(2, Int8ul),
     "maps" / RepeatUntil(obj_.num == 0 and obj_.len == 0, BlockMapEntry),
     "header" / VariableStoreHeader,
@@ -141,18 +145,21 @@ DevicePath = Struct(
 )
 
 BootEntry = Struct(
-    "attributes" / FlagsEnum(Int32ul,
-        LOAD_OPTION_ACTIVE = 0x00000001,
-        LOAD_OPTION_FORCE_RECONNECT = 0x00000002,
-        LOAD_OPTION_HIDDEN = 0x00000008,
-        LOAD_OPTION_CATEGORY_APP = 0x00000100,
+    "attributes"
+    / FlagsEnum(
+        Int32ul,
+        LOAD_OPTION_ACTIVE=0x00000001,
+        LOAD_OPTION_FORCE_RECONNECT=0x00000002,
+        LOAD_OPTION_HIDDEN=0x00000008,
+        LOAD_OPTION_CATEGORY_APP=0x00000100,
     ),
     "fplen" / Int16ul,
     "title" / CString("utf_16_le"),
-    "paths" / RepeatUntil(obj_.type == 0x7f and obj_.subtype == 0xff,
-        DevicePath),
+    "paths"
+    / RepeatUntil(obj_.type == 0x7F and obj_.subtype == 0xFF, DevicePath),
     "data" / GreedyRange(Byte),
 )
+
 
 class UEFIVars:
     path = None
@@ -164,7 +171,7 @@ class UEFIVars:
     def __init__(self, path):
         self.path = path
 
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             self._data = f.read(VAR_STORE_VOLUME_SIZE)
 
         self.volume = Volume.parse(self._data)
@@ -173,15 +180,14 @@ class UEFIVars:
         self._parse_bootoptions()
 
     def _parse_bootoptions(self):
-
         def be_index(x):
-            return int(x.name[4:], 16) if x.name.startswith('Boot0') else 255
+            return int(x.name[4:], 16) if x.name.startswith("Boot0") else 255
 
         def is_be(x):
             return (
-                x.state == VAR_ADDED and
-                x.guid.str == GLOBAL_VARIABLE_GUID and
-                x.name.startswith('Boot0')
+                x.state == VAR_ADDED
+                and x.guid.str == GLOBAL_VARIABLE_GUID
+                and x.name.startswith("Boot0")
             )
 
         fmap = {}
@@ -190,15 +196,17 @@ class UEFIVars:
             index = be_index(v)
             data = BootEntry.parse(v.data)
 
-            if (not data.attributes.LOAD_OPTION_ACTIVE or
-              data.attributes.LOAD_OPTION_HIDDEN):
+            if (
+                not data.attributes.LOAD_OPTION_ACTIVE
+                or data.attributes.LOAD_OPTION_HIDDEN
+            ):
                 continue
 
             guid = pci = path = None
             uri = False
             for p in data.paths:
                 if p.type == 1 and p.subtype == 1 and p.datalen == 2:
-                    pci = '{1}.{0}'.format(*p.data)
+                    pci = "{1}.{0}".format(*p.data)
                 if p.type == 4 and p.subtype == 6 and p.datalen == 16:
                     # App, read GUID
                     guid = EfiGuid.parse(p.data).str
@@ -209,13 +217,13 @@ class UEFIVars:
 
             entry = None
             if pci and uri:
-                entry = ('pci', pci, 'http')
+                entry = ("pci", pci, "http")
             elif pci:
-                entry = ('pci', pci)
+                entry = ("pci", pci)
             elif guid:
-                entry = ('app', guid)
+                entry = ("app", guid)
             elif path:
-                entry = ('path', path)
+                entry = ("path", path)
                 paths.append(index)
 
             if entry:
@@ -225,30 +233,30 @@ class UEFIVars:
         self.bootrmap = {v: k for k, v in fmap.items()}
 
         for i in fmap.keys():
-            self.bootrmap[('boot', i)] = i
+            self.bootrmap[("boot", i)] = i
 
         if paths:
-            self.bootrmap[('path',)] = paths[0]
+            self.bootrmap[("path",)] = paths[0]
             for i, pi in enumerate(paths):
-                self.bootrmap[('path', i)] = pi
+                self.bootrmap[("path", i)] = pi
 
     def print_vars(self):
         i = 0
         for v in self.vars:
             if v.state == VAR_ADDED:
-                s = '   '
+                s = "   "
             else:
-                s = 'DEL'
-            print(f'[{i:2}] {s} {v.name} size {v.datalen}')
+                s = "DEL"
+            print(f"[{i:2}] {s} {v.name} size {v.datalen}")
             i += 1
 
     def _find_var(self, name, guid):
         """Looks for a variable with the provided 'name' and 'guid'.
-           This function will return the active variable if it exists,
-           otherwise it will return the last found variable, which may be
-           in the deleted state. If no variable is found, a new one will
-           be created, initialised with defaults and added to the in-memory
-           variable list."""
+        This function will return the active variable if it exists,
+        otherwise it will return the last found variable, which may be
+        in the deleted state. If no variable is found, a new one will
+        be created, initialised with defaults and added to the in-memory
+        variable list."""
         last = None
         for v in self.vars:
             if v.name != name or v.guid.str != guid:
@@ -262,13 +270,13 @@ class UEFIVars:
             return last
 
         # Build new variable
-        v = AuthVariable.parse(b'\x00' * 0x100)
-        v.startid = VARIABLE_DATA;
+        v = AuthVariable.parse(b"\x00" * 0x100)
+        v.startid = VARIABLE_DATA
         v.state = VAR_ADDED
         v.attributes.EFI_VARIABLE_NON_VOLATILE = True
         v.attributes.EFI_VARIABLE_BOOTSERVICE_ACCESS = True
         v.attributes.EFI_VARIABLE_RUNTIME_ACCESS = True
-        v.name = name;
+        v.name = name
         v.namelen = (len(name) + 1) * 2
         v.guid = EfiGuid.parse(UUID(guid).bytes_le)
 
@@ -295,20 +303,26 @@ class UEFIVars:
         #   name.
 
         # Build a list of existing VAR_ADDED variables
-        added = [f'{v.guid.str}/{v.name}'
-            for v in self.vars if v.state == VAR_ADDED]
+        added = [
+            f"{v.guid.str}/{v.name}" for v in self.vars if v.state == VAR_ADDED
+        ]
 
-        vars = [v for v in self.vars
-            if v.state == VAR_ADDED or
-            (v.state == (VAR_ADDED & VAR_IN_DELETED_TRANSITION) and
-             f'{v.guid.str}/{v.name}' not in added)]
+        vars = [
+            v
+            for v in self.vars
+            if v.state == VAR_ADDED
+            or (
+                v.state == (VAR_ADDED & VAR_IN_DELETED_TRANSITION)
+                and f"{v.guid.str}/{v.name}" not in added
+            )
+        ]
 
         # Now promote any remaining ADDED/IN_DELETED_TRANSITION entries
         for v in vars:
             v.state = VAR_ADDED
 
         # Mark the new last element as the terminator
-        self.vars[-1].next = 0xffff
+        self.vars[-1].next = 0xFFFF
 
         self.volume.vars = ListContainer(vars)
 
@@ -322,9 +336,12 @@ class UEFIVars:
     def write(self, path=None):
         if not path:
             path = self.path
-        with tempfile.NamedTemporaryFile(mode='w+b',
-          dir=os.path.dirname(self.path), prefix='uefivars.',
-          delete=False) as fh:
+        with tempfile.NamedTemporaryFile(
+            mode="w+b",
+            dir=os.path.dirname(self.path),
+            prefix="uefivars.",
+            delete=False,
+        ) as fh:
             pad = self.write_volume(fh)
             if pad < 0:
                 # Variable store overflow into event log section.
@@ -332,8 +349,8 @@ class UEFIVars:
                 pad = self.write_volume(fh)
 
             if pad < 0:
-                raise OverflowError('Variable store too large')
-            fh.write(b'\xff' * pad)
+                raise OverflowError("Variable store too large")
+            fh.write(b"\xff" * pad)
 
             tf = fh.name
 
@@ -351,20 +368,21 @@ class UEFIVars:
         if not len(order):
             raise KeyError
 
-        v = self._find_var('BootOrder', GLOBAL_VARIABLE_GUID)
+        v = self._find_var("BootOrder", GLOBAL_VARIABLE_GUID)
 
         v.state = VAR_ADDED
         v.data = Array(len(order), Int16ul).build(order)
         v.datalen = len(v.data)
 
     def set_bootnext(self, opt):
-        opt = self.bootrmap[opt]    # can raise KeyError
+        opt = self.bootrmap[opt]  # can raise KeyError
 
-        v = self._find_var('BootNext', GLOBAL_VARIABLE_GUID)
+        v = self._find_var("BootNext", GLOBAL_VARIABLE_GUID)
 
         v.state = VAR_ADDED
         v.data = Int16ul.build(opt)
         v.datalen = len(v.data)
+
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/brand/emu/boot.py
+++ b/src/brand/emu/boot.py
@@ -17,8 +17,17 @@
 
 import getopt
 import bootlib
-from bootlib import fatal, error, debug, info, warning, boolv, diskpath, \
-    expandopts, collapseopts
+from bootlib import (
+    fatal,
+    error,
+    debug,
+    info,
+    warning,
+    boolv,
+    diskpath,
+    expandopts,
+    collapseopts,
+)
 import logging
 import os
 import re
@@ -32,7 +41,9 @@ import ucred
 from itertools import zip_longest
 from pprint import pprint, pformat
 
-QEMUROOT = '/opt/ooce/qemu'
+QEMUROOT = "/opt/ooce/qemu"
+
+# fmt: off
 
 # Default values
 opts = {
@@ -68,102 +79,110 @@ aliases = {
     }
 }
 
+# fmt: on
+
 ##############################################################################
 
-testmode        = False
-jsonmode        = False
-name            = None
-xmlfile         = None
+testmode = False
+jsonmode = False
+name = None
+xmlfile = None
 
 uc = ucred.get(os.getpid())
 if not uc.has_priv("Effective", "sys_config"):
     testmode = True
 
+
 def usage(msg=None):
-    print('''
+    print(
+        """
 boot [-t] [-x xml] <[-z] zone>
    -t   Test mode - just show what would be done
    -j   Output the computed zone data in JSON format
    -x   Path to zone's XML file
    -z   Name of zone
-''')
+"""
+    )
 
-    if msg: print(msg)
+    if msg:
+        print(msg)
     sys.exit(2)
+
 
 try:
     cliopts, args = getopt.getopt(sys.argv[1:], "jtx:z:")
 except getopt.GetoptError:
     usage()
 for opt, arg in cliopts:
-    if opt == '-t':
+    if opt == "-t":
         testmode = True
-    elif opt == '-j':
+    elif opt == "-j":
         jsonmode = True
         testmode = True
         bootlib.set_quiet(True)
-    elif opt == '-x':
+    elif opt == "-x":
         xmlfile = arg
-    elif opt == '-z':
+    elif opt == "-z":
         name = arg
     else:
-        fatal(f'unhandled option, {opt}')
+        fatal(f"unhandled option, {opt}")
 
 if not name and len(args):
     name = args.pop(0)
 
 if len(args):
-    usage('Unexpected arguments')
+    usage("Unexpected arguments")
 
 if not name:
-    usage('No zone name supplied')
+    usage("No zone name supplied")
 
 bootlib.log_stdout(logging.DEBUG)
 
 if not xmlfile:
-    xmlfile = f'/etc/zones/{name}.xml'
+    xmlfile = f"/etc/zones/{name}.xml"
 
 z = bootlib.Zone(xmlfile)
 
 if z.name != name:
-    fatal(f'Zone name {name} does not match XML file {z.name}')
+    fatal(f"Zone name {name} does not match XML file {z.name}")
 
 if not testmode and not os.path.isdir(z.zoneroot):
-    fatal(f'Could not find zone root {z.zoneroot}')
+    fatal(f"Could not find zone root {z.zoneroot}")
 
 if not testmode:
     try:
-        os.unlink(f'{z.zoneroot}/tmp/init.log')
+        os.unlink(f"{z.zoneroot}/tmp/init.log")
     except:
         pass
-    bootlib.log_file(f'{z.zonepath}/log/zone.log', logging.DEBUG)
+    bootlib.log_file(f"{z.zonepath}/log/zone.log", logging.DEBUG)
 
-info(f'Zone name: {name}')
+info(f"Zone name: {name}")
 
 ##############################################################################
 
 for tag in opts.keys():
     z.parseopt(tag, opts, aliases)
 
-for a in ['arch', 'cpu']:
+for a in ["arch", "cpu"]:
     if not opts[a]:
         fatal(f'The "{a}" attribute is required')
 
 qemu = f'{QEMUROOT}/bin/qemu-system-{opts["arch"]}'
 if not os.path.exists(qemu):
-    fatal('{qemu} not found')
+    fatal("{qemu} not found")
 
 # UUID
-uuid = opts['uuid'] if opts['uuid'] else z.uuid()
-debug(f'Final uuid: {uuid}')
+uuid = opts["uuid"] if opts["uuid"] else z.uuid()
+debug(f"Final uuid: {uuid}")
 
 ##############################################################################
 
-def add_disk(path, boot=False, intf=None, media='disk', index=-1):
+
+def add_disk(path, boot=False, intf=None, media="disk", index=-1):
     global args
 
     if not intf:
-        intf = opts['diskif']
+        intf = opts["diskif"]
 
     if index < 0:
         index = add_disk.index
@@ -172,182 +191,212 @@ def add_disk(path, boot=False, intf=None, media='disk', index=-1):
         add_disk.index = index
 
     if media == "cdrom":
-        args.extend(['-cdrom', path])
+        args.extend(["-cdrom", path])
     else:
-        node = f'{media}{index}'
+        node = f"{media}{index}"
         path = diskpath(path)
-        devstr = f'{intf},drive={node},serial={node}'
-        #if boot:
+        devstr = f"{intf},drive={node},serial={node}"
+        # if boot:
         #    devstr += ',boot=on'
-        args.extend([
-            '-blockdev',
-            f'driver=host_device,filename={path},node-name={node},discard=unmap',
-            '-device', devstr,
-        ])
+        args.extend(
+            [
+                "-blockdev",
+                f"driver=host_device,filename={path},node-name={node},discard=unmap",
+                "-device",
+                devstr,
+            ]
+        )
+
+
 add_disk.index = 0
 
 ##############################################################################
 
 args = []
 
-args.extend(['-name', name])
+args.extend(["-name", name])
 
-args.extend([
-    '-L', f'{QEMUROOT}/share/qemu',
-    '-smp', opts['vcpus'],
-    '-m', opts['ram'],
-    '-rtc', opts['rtc'],
-    '-pidfile', '/tmp/vm.pid',
-    '-monitor', 'unix:/tmp/vm.monitor,server,nowait,nodelay',
-    '-cpu', opts['cpu'],
-])
+args.extend(
+    [
+        "-L",
+        f"{QEMUROOT}/share/qemu",
+        "-smp",
+        opts["vcpus"],
+        "-m",
+        opts["ram"],
+        "-rtc",
+        opts["rtc"],
+        "-pidfile",
+        "/tmp/vm.pid",
+        "-monitor",
+        "unix:/tmp/vm.monitor,server,nowait,nodelay",
+        "-cpu",
+        opts["cpu"],
+    ]
+)
 
 ser = uuid
 
-if boolv(opts['cloud-init'], 'cloud-init', ignore=True) is not False:
-    if opts['cloud-init'].startswith(('http://', 'https://')):
-        ser = 'ds=nocloud-net;s={};i={}'.format(opts['cloud-init'], uuid)
+if boolv(opts["cloud-init"], "cloud-init", ignore=True) is not False:
+    if opts["cloud-init"].startswith(("http://", "https://")):
+        ser = "ds=nocloud-net;s={};i={}".format(opts["cloud-init"], uuid)
     else:
-        z.build_cloudinit_image(uuid, opts['cloud-init'], testmode)
-        ser = f'ds=nocloud;i={uuid}'
-        add_disk('/cloud-init.iso', boot=False, intf='ide', media='cdrom')
+        z.build_cloudinit_image(uuid, opts["cloud-init"], testmode)
+        ser = f"ds=nocloud;i={uuid}"
+        add_disk("/cloud-init.iso", boot=False, intf="ide", media="cdrom")
 
-args.extend(['-smbios',
-    'type=1,manufacturer={},product={},version={},serial={},uuid={},family={}'
-        .format('OmniOS', 'OmniOS HVM', '1.0', ser, uuid, 'Virtual Machine')
-])
+args.extend(
+    [
+        "-smbios",
+        "type=1,manufacturer={},product={},version={},serial={},uuid={},family={}".format(
+            "OmniOS", "OmniOS HVM", "1.0", ser, uuid, "Virtual Machine"
+        ),
+    ]
+)
 
 if uuid:
-    args.extend(['-uuid', uuid])
+    args.extend(["-uuid", uuid])
 
 # Console
 
-args.extend([
-    '-chardev', opts['console'],
-    '-serial', 'chardev:console0',
-]);
+args.extend(
+    [
+        "-chardev",
+        opts["console"],
+        "-serial",
+        "chardev:console0",
+    ]
+)
 
 # CDROM
 
-for i, v in z.build_devlist('cdrom', 5):
-    add_disk(v, boot=False, intf='ide', media='cdrom')
+for i, v in z.build_devlist("cdrom", 5):
+    add_disk(v, boot=False, intf="ide", media="cdrom")
 
 # If the disks are not using IDE, then reset their index as there is no need
 # to leave room for the CDROM.
-if opts['diskif'] != 'ide':
+if opts["diskif"] != "ide":
     add_disk.index = 0
 
 # Network
 
 vlan = 0
-for f in z.findall('./network[@physical]'):
-    ifname = f.get('physical').strip()
+for f in z.findall("./network[@physical]"):
+    ifname = f.get("physical").strip()
     mac = bootlib.get_mac(ifname)
-    if not mac: continue
+    if not mac:
+        continue
 
-    if opts['netif'] == 'e1000':
+    if opts["netif"] == "e1000":
         # Unlikely to be right yet
-        args.extend([
-            '-net',
-            'nic,name=net{2},model={0},macaddr={1}'
-                .format(opts['netif'], mac, vlan),
-        ])
+        args.extend(
+            [
+                "-net",
+                "nic,name=net{2},model={0},macaddr={1}".format(
+                    opts["netif"], mac, vlan
+                ),
+            ]
+        )
     else:
-        args.extend([
-            '-device',
-            f'{opts["netif"]},netdev=net{vlan},mac={mac}'
-        ])
+        args.extend(["-device", f'{opts["netif"]},netdev=net{vlan},mac={mac}'])
 
-
-    args.extend([
-        '-netdev', f'vnic,id=net{vlan},ifname={ifname}',
-    ])
+    args.extend(
+        [
+            "-netdev",
+            f"vnic,id=net{vlan},ifname={ifname}",
+        ]
+    )
 
     vlan += 1
 
 # Bootdisk
 
 try:
-    bootdisk = z.findattr('bootdisk')
-    add_disk(bootdisk.get('value').strip(), boot=True)
+    bootdisk = z.findattr("bootdisk")
+    add_disk(bootdisk.get("value").strip(), boot=True)
 except:
     pass
 
 # Additional Disks
 
-for i, v in z.build_devlist('disk', 16):
+for i, v in z.build_devlist("disk", 16):
     add_disk(v)
 
 # Display
 
-if boolv(opts['vga'], 'vga', ignore=True) is False:
-    args.append('-nographic')
-elif boolv(opts['vnc'], 'vnc', ignore=True) is False:
-    args.extend(['-display', 'none'])
+if boolv(opts["vga"], "vga", ignore=True) is False:
+    args.append("-nographic")
+elif boolv(opts["vnc"], "vnc", ignore=True) is False:
+    args.extend(["-display", "none"])
 else:
-    args.extend(['-display', 'vnc=0'])
-    args.extend(['-vnc', opts['vnc']])
+    args.extend(["-display", "vnc=0"])
+    args.extend(["-vnc", opts["vnc"]])
 
 # RNG
 
-if boolv(opts['rng'], 'rng'):
-    args.extend([
-        '-object', 'rng-builtin,id=random',
-    ])
+if boolv(opts["rng"], "rng"):
+    args.extend(
+        [
+            "-object",
+            "rng-builtin,id=random",
+        ]
+    )
 
 # Extra options
 
-for i, v in z.build_devlist('extra', 16):
+for i, v in z.build_devlist("extra", 16):
     args.extend(shlex.split(v))
 
 ##############################################################################
 
-debug(f'Final arguments:\n{qemu} {pformat(args)}')
+debug(f"Final arguments:\n{qemu} {pformat(args)}")
 info(qemu)
-info('{0}'.format(' '.join(map(
-    lambda s: f'"{s}"' if ' ' in s else s, args))))
+info("{0}".format(" ".join(map(lambda s: f'"{s}"' if " " in s else s, args))))
+
 
 def writecfg(fh, arg, nl=True):
-    end='\n' if nl else ' '
+    end = "\n" if nl else " "
     if testmode:
-            print(arg, end=end)
+        print(arg, end=end)
     else:
-        fh.write(f'{arg}\n')
+        fh.write(f"{arg}\n")
+
 
 fh = None
 if not testmode:
     try:
-        fh = tempfile.NamedTemporaryFile(mode='w', dir=f'{z.zoneroot}/etc',
-            prefix='emu.', delete=False)
+        fh = tempfile.NamedTemporaryFile(
+            mode="w", dir=f"{z.zoneroot}/etc", prefix="emu.", delete=False
+        )
     except Exception as e:
-        fatal(f'Could not create temporary file: {e}')
+        fatal(f"Could not create temporary file: {e}")
     else:
-        debug(f'Created temporary file at {fh.name}')
+        debug(f"Created temporary file at {fh.name}")
 
     try:
-        os.unlink(f'{z.zoneroot}/qemu-system')
+        os.unlink(f"{z.zoneroot}/qemu-system")
     except:
         pass
 
-    os.symlink(qemu, f'{z.zoneroot}/qemu-system')
+    os.symlink(qemu, f"{z.zoneroot}/qemu-system")
 
-writecfg(fh, '#\n# Generated from zone configuration\n#')
+writecfg(fh, "#\n# Generated from zone configuration\n#")
 
-for (arg, narg) in zip_longest(args, args[1:]):
-    writecfg(fh, arg, not narg or narg.startswith('-'))
+for arg, narg in zip_longest(args, args[1:]):
+    writecfg(fh, arg, not narg or narg.startswith("-"))
 
-#if vncpassword:
+# if vncpassword:
 #    writecfg(fh, f'pci.0.{VNC_SLOT}.0.password={vncpassword}')
 
 if not testmode:
     tf = fh.name
     fh.close()
     try:
-        os.rename(tf, f'{z.zoneroot}/etc/qemu.cfg')
+        os.rename(tf, f"{z.zoneroot}/etc/qemu.cfg")
     except Exception as e:
-        fatal(f'Could not create qemu.cfg from temporary file: {e}')
+        fatal(f"Could not create qemu.cfg from temporary file: {e}")
     else:
-        info(f'Successfully created {z.zoneroot}/etc/qemu.cfg')
+        info(f"Successfully created {z.zoneroot}/etc/qemu.cfg")
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/brand/ipkg/fmri_compare.py
+++ b/src/brand/ipkg/fmri_compare.py
@@ -28,36 +28,40 @@ from __future__ import print_function
 import pkg.fmri
 import sys
 
+
 def usage():
-        print("usage: %s <fmri1> <fmri2>".format(sys.argv[0]), file=sys.stderr)
-        sys.exit(2)
+    print("usage: %s <fmri1> <fmri2>".format(sys.argv[0]), file=sys.stderr)
+    sys.exit(2)
+
 
 if len(sys.argv) != 3:
-        usage()
+    usage()
 
 try:
-        x = pkg.fmri.PkgFmri(sys.argv[1])
-        y = pkg.fmri.PkgFmri(sys.argv[2])
+    x = pkg.fmri.PkgFmri(sys.argv[1])
+    y = pkg.fmri.PkgFmri(sys.argv[2])
 except pkg.fmri.FmriError as e:
-        print ("error: %s" % str(e) , file=sys.stderr)
-        sys.exit(1)
+    print("error: %s" % str(e), file=sys.stderr)
+    sys.exit(1)
 
 if not x.is_same_pkg(y):
-        print ("error: can only compare two versions of the same package.",
-            file=sys.stderr)
-        sys.exit(1)
+    print(
+        "error: can only compare two versions of the same package.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 if x < y:
-        print("<")
+    print("<")
 elif x > y:
-        print(">")
+    print(">")
 elif x == y:
-        print("=")
+    print("=")
 else:
-        print ("panic", file=sys.stderr)
-        sys.exit(1)
+    print("panic", file=sys.stderr)
+    sys.exit(1)
 
 sys.exit(0)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/brand/kvm/init.py
+++ b/src/brand/kvm/init.py
@@ -19,8 +19,8 @@ import logging, os, subprocess, sys, time, re, getopt, shlex
 import xml.etree.ElementTree as etree
 from pprint import pprint, pformat
 
-zonexml = '/etc/zone.xml'
-uuidfile = '/etc/uuid'
+zonexml = "/etc/zone.xml"
+uuidfile = "/etc/uuid"
 testmode = False
 
 try:
@@ -29,18 +29,21 @@ except getopt.GetoptError:
     print("init [-t] [-x <xml file>] [-u <uuid file>]")
     sys.exit(2)
 for opt, arg in opts:
-    if opt == '-t':
+    if opt == "-t":
         testmode = True
-    elif opt == '-x':
+    elif opt == "-x":
         zonexml = arg
-    elif opt == '-u':
+    elif opt == "-u":
         uuidfile = arg
 
 if testmode:
     logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 else:
-    logging.basicConfig(filename='/tmp/init.log', filemode='a',
-        level=logging.DEBUG)
+    logging.basicConfig(
+        filename="/tmp/init.log", filemode="a", level=logging.DEBUG
+    )
+
+# fmt: off
 
 # Default values
 opts = {
@@ -70,79 +73,90 @@ aliases = {
     }
 }
 
+# fmt: on
+
 try:
     with open(uuidfile) as file:
         uuid = file.read().strip()
-        logging.info('Zone UUID: {0}'.format(uuid))
+        logging.info("Zone UUID: {0}".format(uuid))
 except:
     uuid = None
 
 try:
     cfg = etree.parse(zonexml)
 except:
-    logging.error('Could not parse {0}'.format(zonexml))
+    logging.error("Could not parse {0}".format(zonexml))
     sys.exit(1)
 root = cfg.getroot()
-logging.info('Parsed {0}'.format(zonexml))
+logging.info("Parsed {0}".format(zonexml))
 
 ##############################################################################
+
 
 def fatal(msg):
     logging.error(msg)
     print(msg, file=sys.stderr)
     sys.exit(1)
 
+
 def boolv(s, var, ignore=False):
-    if s in ['true', 'yes', 'on', '1']:
+    if s in ["true", "yes", "on", "1"]:
         return True
-    if s in ['false', 'no', 'off', '0']:
+    if s in ["false", "no", "off", "0"]:
         return False
     if not ignore:
-        fatal(f'Invalid value {s} for boolean variable {var}')
+        fatal(f"Invalid value {s} for boolean variable {var}")
     return None
+
 
 def opt(tag):
     global opts, root
     try:
         el = root.find('./attr[@name="{0}"]'.format(tag))
-        opts[tag] = el.get('value').strip()
-        logging.debug('Found custom {0} attribute - "{1}"'
-            .format(tag, opts[tag]))
+        opts[tag] = el.get("value").strip()
+        logging.debug(
+            'Found custom {0} attribute - "{1}"'.format(tag, opts[tag])
+        )
         if tag in aliases:
             val = opts[tag]
             if (bt := boolv(val, tag, ignore=True)) is not None:
-                val = 'on' if bt else 'off'
+                val = "on" if bt else "off"
             try:
                 opts[tag] = aliases[tag][val]
-                logging.debug('  Alias expanded to {0}'.format(opts[tag]))
+                logging.debug("  Alias expanded to {0}".format(opts[tag]))
             except KeyError:
                 pass
     except:
         pass
 
+
 def diskpath(arg):
-    if arg.startswith('/dev'):
+    if arg.startswith("/dev"):
         return arg
-    return '/dev/zvol/rdsk/{0}'.format(arg)
+    return "/dev/zvol/rdsk/{0}".format(arg)
+
 
 for tag in opts.keys():
     opt(tag)
 
+
 # Look for attributes of the form <type> or <type>N and generate a list.
 def build_devlist(type, maxval):
     devlist = {}
-    for dev in root.findall('./attr[@name]'):
-        m = re.search(rf'^{type}(\d+)$', dev.get('name').strip())
-        if not m: continue
+    for dev in root.findall("./attr[@name]"):
+        m = re.search(rf"^{type}(\d+)$", dev.get("name").strip())
+        if not m:
+            continue
         k = int(m.group(1))
         if k in devlist:
             logging.error(
-                '{}{} appears more than once in configuration'.format(type, k))
+                "{}{} appears more than once in configuration".format(type, k)
+            )
             sys.exit(1)
-        if (k > maxval):
-            logging.error('{}{} slot out of range'.format(type, k))
+        if k > maxval:
+            logging.error("{}{} slot out of range".format(type, k))
             sys.exit(1)
-        devlist[k] = dev.get('value').strip()
+        devlist[k] = dev.get("value").strip()
 
     # Now insert plain <type> tags into the list, using available slots in order
     avail = sorted(set(range(0, maxval)).difference(sorted(devlist.keys())))
@@ -150,46 +164,60 @@ def build_devlist(type, maxval):
         try:
             k = avail.pop(0)
         except IndexError:
-            logging.error('{}: no more available slots'.format(type))
+            logging.error("{}: no more available slots".format(type))
             sys.exit(1)
-        devlist[k] = dev.get('value').strip()
+        devlist[k] = dev.get("value").strip()
 
-    logging.debug('{} list: \n{}'.format(type, pformat(devlist)))
+    logging.debug("{} list: \n{}".format(type, pformat(devlist)))
 
     return devlist
 
+
 ##############################################################################
 
-args = ['/usr/bin/qemu-system-x86_64']
+args = ["/usr/bin/qemu-system-x86_64"]
 
-name = root.get('name')
-args.extend(['-name', name])
+name = root.get("name")
+args.extend(["-name", name])
 
 if uuid:
-    args.extend(['-uuid', uuid])
+    args.extend(["-uuid", uuid])
 
-args.extend([
-    '-enable-kvm',
-    '-no-hpet',
-    '-m', opts['ram'],
-    '-smp', opts['vcpus'],
-    '-cpu', opts['cpu'],
-    '-rtc', opts['rtc'],
-    '-pidfile', '/tmp/vm.pid',
-    '-monitor', 'unix:/tmp/vm.monitor,server,nowait,nodelay',
-    '-vga', 'std',
-    '-chardev', opts['console'],
-    '-serial', 'chardev:console0',
-    '-boot', 'order={0}'.format(opts['bootorder']),
-])
+args.extend(
+    [
+        "-enable-kvm",
+        "-no-hpet",
+        "-m",
+        opts["ram"],
+        "-smp",
+        opts["vcpus"],
+        "-cpu",
+        opts["cpu"],
+        "-rtc",
+        opts["rtc"],
+        "-pidfile",
+        "/tmp/vm.pid",
+        "-monitor",
+        "unix:/tmp/vm.monitor,server,nowait,nodelay",
+        "-vga",
+        "std",
+        "-chardev",
+        opts["console"],
+        "-serial",
+        "chardev:console0",
+        "-boot",
+        "order={0}".format(opts["bootorder"]),
+    ]
+)
 
 # Disks
 
-def add_disk(path, boot=False, intf=None, media='disk', index=-1):
+
+def add_disk(path, boot=False, intf=None, media="disk", index=-1):
     global args
 
     if not intf:
-        intf = opts['diskif']
+        intf = opts["diskif"]
 
     if index < 0:
         index = add_disk.index
@@ -197,99 +225,111 @@ def add_disk(path, boot=False, intf=None, media='disk', index=-1):
     elif index > add_disk.index:
         add_disk.index = index
 
-    if media == "disk": path = diskpath(path)
-    str = (
-        'file={0},if={1},media={2},index={3},cache=none'
-            .format(path, intf, media, index)
+    if media == "disk":
+        path = diskpath(path)
+    str = "file={0},if={1},media={2},index={3},cache=none".format(
+        path, intf, media, index
     )
-    if ',serial=' not in str:
-        str += ',serial={}{}'.format(media, index)
+    if ",serial=" not in str:
+        str += ",serial={}{}".format(media, index)
     if boot:
-        str += ',boot=on'
-    args.extend(['-drive', str])
+        str += ",boot=on"
+    args.extend(["-drive", str])
+
+
 add_disk.index = 0
 
-for i, v in build_devlist('cdrom', 5).items():
-    add_disk(v, boot=False, intf='ide', media='cdrom')
+for i, v in build_devlist("cdrom", 5).items():
+    add_disk(v, boot=False, intf="ide", media="cdrom")
 
 # If the disks are not using IDE, then reset their index as there is no need
 # to leave room for the CDROM.
-if opts['diskif'] != 'ide':
+if opts["diskif"] != "ide":
     add_disk.index = 0
 
 try:
     bootdisk = root.find('./attr[@name="bootdisk"]')
-    add_disk(bootdisk.get('value').strip(), boot=True)
+    add_disk(bootdisk.get("value").strip(), boot=True)
 except:
     pass
 
-for i, v in build_devlist('disk', 10).items():
+for i, v in build_devlist("disk", 10).items():
     add_disk(v)
 
 # Network
 
+
 def get_mac(ifname):
-    ret = subprocess.run(['/usr/sbin/dladm', 'show-vnic',
-        '-p', '-o', 'macaddress', ifname], stdout=subprocess.PIPE)
-    mac = ret.stdout.decode('utf-8').strip()
+    ret = subprocess.run(
+        ["/usr/sbin/dladm", "show-vnic", "-p", "-o", "macaddress", ifname],
+        stdout=subprocess.PIPE,
+    )
+    mac = ret.stdout.decode("utf-8").strip()
     # Need to zero-pad the bytes
-    return ':'.join(l.zfill(2) for l in mac.split(':'))
+    return ":".join(l.zfill(2) for l in mac.split(":"))
+
 
 vlan = 0
-for f in root.findall('./network[@physical]'):
-    ifname = f.get('physical').strip()
+for f in root.findall("./network[@physical]"):
+    ifname = f.get("physical").strip()
     mac = get_mac(ifname)
-    if not len(mac): continue
+    if not len(mac):
+        continue
 
-    if opts['netif'] == 'e1000':
+    if opts["netif"] == "e1000":
         # -net nic,vlan=0,name=net0,model=e1000,macaddr=00:..
-        args.extend([
-            '-net',
-            'nic,vlan={2},name=net{2},model={0},macaddr={1}'
-                .format(opts['netif'], mac, vlan),
-        ])
+        args.extend(
+            [
+                "-net",
+                "nic,vlan={2},name=net{2},model={0},macaddr={1}".format(
+                    opts["netif"], mac, vlan
+                ),
+            ]
+        )
     else:
-    # -device <dev>,mac=00:.,tx=timer,x-txtimer=200000,x-txburst=128,vlan=0
-        args.extend([
-            '-device',
-            '{0},mac={1},tx=timer,x-txtimer=200000,x-txburst=128,vlan={2}'
-                .format(opts['netif'], mac, vlan),
-        ])
-
+        # -device <dev>,mac=00:.,tx=timer,x-txtimer=200000,x-txburst=128,vlan=0
+        args.extend(
+            [
+                "-device",
+                "{0},mac={1},tx=timer,x-txtimer=200000,x-txburst=128,vlan={2}".format(
+                    opts["netif"], mac, vlan
+                ),
+            ]
+        )
 
     # -net vnic,vlan=0,name=net0,ifname=vnic22
-    args.extend([
-        '-net',
-        'vnic,vlan={0},name=net{0},ifname={1}'
-            .format(vlan, ifname)
-    ])
+    args.extend(
+        ["-net", "vnic,vlan={0},name=net{0},ifname={1}".format(vlan, ifname)]
+    )
 
     vlan += 1
 
 # VNC
 
-args.extend(['-vnc', opts['vnc']])
+args.extend(["-vnc", opts["vnc"]])
 
 # Extra options
 
-for i, v in build_devlist('extra', 16):
+for i, v in build_devlist("extra", 16):
     args.extend(shlex.split(v))
 
-logging.info('Final arguments: {0}'.format(pformat(args)))
-logging.info('{0}'.format(' '.join(args)))
+logging.info("Final arguments: {0}".format(pformat(args)))
+logging.info("{0}".format(" ".join(args)))
 
 if testmode:
     sys.exit(0)
 
 errcnt = 0
 while errcnt < 10:
-    logging.info('Starting kvm')
+    logging.info("Starting kvm")
     ret = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     logging.info("KVM exited {0}".format(ret.returncode))
     logging.error("Error {0}".format(ret.stderr))
     logging.debug("Output {0}".format(ret.stdout))
-    if ret.returncode == 0: break
-    if ret.returncode == 1: errcnt += 1
+    if ret.returncode == 0:
+        break
+    if ret.returncode == 1:
+        errcnt += 1
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/cffi_src/build_arch.py
+++ b/src/cffi_src/build_arch.py
@@ -29,13 +29,17 @@ from cffi import FFI
 
 ffi = FFI()
 
-ffi.set_source("_arch", """
+ffi.set_source(
+    "_arch",
+    """
 /* Includes */
 #include <sys/systeminfo.h>
 #include <stdlib.h>
-""")
+""",
+)
 
-ffi.cdef("""
+ffi.cdef(
+    """
 /* Macros */
 #define	SI_RELEASE  3            /* return release of operating system */
 #define	SI_ARCHITECTURE_32  516  /* basic 32-bit SI_ARCHITECTURE */
@@ -47,10 +51,11 @@ void *malloc(size_t);
 void *realloc(void *, size_t);
 void free(void *);
 int sysinfo(int, char *, long);
-""")
+"""
+)
 
 if __name__ == "__main__":
-        ffi.emit_c_code("cffi_src/_arch.c")
+    ffi.emit_c_code("cffi_src/_arch.c")
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/cffi_src/build_pspawn.py
+++ b/src/cffi_src/build_pspawn.py
@@ -29,7 +29,9 @@ from cffi import FFI
 
 ffi = FFI()
 
-ffi.set_source("_pspawn", """
+ffi.set_source(
+    "_pspawn",
+    """
 /* Includes */
 #include <spawn.h>
 #include <sys/types.h>
@@ -40,9 +42,11 @@ typedef struct {
     int start_fd;
     posix_spawn_file_actions_t *fap;
 } walk_data;
-""")
+""",
+)
 
-ffi.cdef("""
+ffi.cdef(
+    """
 /* Types */
 typedef	int... mode_t;  /* file attribute type */
 typedef int... pid_t;   /* process id type */
@@ -77,10 +81,11 @@ int posix_spawnp(
     const posix_spawnattr_t *,
     char *const [],
     char *const []);
-""")
+"""
+)
 
 if __name__ == "__main__":
-        ffi.emit_c_code("cffi_src/_pspawn.c")
+    ffi.emit_c_code("cffi_src/_pspawn.c")
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/cffi_src/build_sha512_t.py
+++ b/src/cffi_src/build_sha512_t.py
@@ -30,13 +30,17 @@ from cffi import FFI
 
 ffi = FFI()
 
-ffi.set_source("_sha512_t", """
+ffi.set_source(
+    "_sha512_t",
+    """
 /* Includes */
 #include <sys/sha2.h>
 #include <string.h>
-""")
+""",
+)
 
-ffi.cdef("""
+ffi.cdef(
+    """
 #define	SHA512_224 9
 #define	SHA512_256 10
 
@@ -63,10 +67,11 @@ void SHA2Init(uint64_t t_bits, SHA2_CTX *ctx);
 void SHA2Update(SHA2_CTX *ctx, const void *buf, size_t bufsz);
 void SHA2Final(void *digest, SHA2_CTX *ctx);
 void *memcpy(void *restrict s1, const void *restrict s2, size_t n);
-""")
+"""
+)
 
 if __name__ == "__main__":
-        ffi.emit_c_code("cffi_src/_sha512_t.c")
+    ffi.emit_c_code("cffi_src/_sha512_t.c")
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/cffi_src/build_sysattr.py
+++ b/src/cffi_src/build_sysattr.py
@@ -29,16 +29,20 @@ from cffi import FFI
 
 ffi = FFI()
 
-ffi.set_source("_sysattr", """
+ffi.set_source(
+    "_sysattr",
+    """
 /* Includes */
 #include <attr.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include <sys/nvpair.h>
-""")
+""",
+)
 
-ffi.cdef("""
+ffi.cdef(
+    """
 /* Macros */
 #define	NV_UNIQUE_NAME 0x1
 
@@ -143,10 +147,11 @@ nvpair_t *nvlist_next_nvpair(nvlist_t *, nvpair_t *);
 char *nvpair_name(nvpair_t *);
 data_type_t nvpair_type(nvpair_t *);
 int nvpair_value_boolean_value(nvpair_t *, boolean_t *);
-""")
+"""
+)
 
 if __name__ == "__main__":
-        ffi.emit_c_code("cffi_src/_sysattr.c")
+    ffi.emit_c_code("cffi_src/_sysattr.c")
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/cffi_src/build_syscallat.py
+++ b/src/cffi_src/build_syscallat.py
@@ -29,15 +29,19 @@ from cffi import FFI
 
 ffi = FFI()
 
-ffi.set_source("_syscallat", """
+ffi.set_source(
+    "_syscallat",
+    """
 /* Includes */
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-""")
+""",
+)
 
-ffi.cdef("""
+ffi.cdef(
+    """
 /* Types */
 typedef	int... mode_t; /* file attribute type */
 
@@ -46,10 +50,11 @@ int mkdirat(int, const char *, mode_t);
 int openat(int, const char *, int, mode_t);
 int renameat(int, const char *, int, const char *);
 int unlinkat(int, const char *, int);
-""")
+"""
+)
 
 if __name__ == "__main__":
-        ffi.emit_c_code("cffi_src/_syscallat.c")
+    ffi.emit_c_code("cffi_src/_syscallat.c")
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/client.py
+++ b/src/client.py
@@ -49,75 +49,88 @@ except ImportError:
     import sys
 
     if sys.platform == "sunos5":
-        print("""
+        print(
+            """
 The Python environment on this system is damaged and missing a critical core
 component (pkg.site_paths) and can not be repaired with pkg(1).
 
 To recover this system reboot and select an alternate Boot Environment (BE)
 from the boot menu. From the alternate BE mount and run 'pkg fix' on this BE.
-""")
+"""
+        )
         sys.exit(1)
 
 pkg.site_paths.init()
 
 try:
-        import calendar
-        import collections
-        import datetime
-        import errno
-        import getopt
-        import gettext
-        import itertools
-        import locale
-        import logging
-        import os
-        import re
-        import six
-        import socket
-        import sys
-        import tempfile
-        import textwrap
-        import time
-        import traceback
-        import pycurl
-        import atexit
-        import shutil
-        from six.moves.urllib.parse import urlparse, unquote
+    import calendar
+    import collections
+    import datetime
+    import errno
+    import getopt
+    import gettext
+    import itertools
+    import locale
+    import logging
+    import os
+    import re
+    import six
+    import socket
+    import sys
+    import tempfile
+    import textwrap
+    import time
+    import traceback
+    import pycurl
+    import atexit
+    import shutil
+    from six.moves.urllib.parse import urlparse, unquote
 
-        import pkg
-        import pkg.actions as actions
-        import pkg.client.api as api
-        import pkg.client.api_errors as api_errors
-        import pkg.client.bootenv as bootenv
-        import pkg.client.client_api as client_api
-        import pkg.client.progress as progress
-        import pkg.client.linkedimage as li
-        import pkg.client.publisher as publisher
-        import pkg.client.transport.transport as transport
-        import pkg.client.options as options
-        import pkg.fmri as fmri
-        import pkg.json as json
-        import pkg.misc as misc
-        import pkg.pipeutils as pipeutils
-        import pkg.portable as portable
-        import pkg.version as version
+    import pkg
+    import pkg.actions as actions
+    import pkg.client.api as api
+    import pkg.client.api_errors as api_errors
+    import pkg.client.bootenv as bootenv
+    import pkg.client.client_api as client_api
+    import pkg.client.progress as progress
+    import pkg.client.linkedimage as li
+    import pkg.client.publisher as publisher
+    import pkg.client.transport.transport as transport
+    import pkg.client.options as options
+    import pkg.fmri as fmri
+    import pkg.json as json
+    import pkg.misc as misc
+    import pkg.pipeutils as pipeutils
+    import pkg.portable as portable
+    import pkg.version as version
 
-        from importlib import reload
-        from pkg.client import global_settings
-        from pkg.client.api import (IMG_TYPE_ENTIRE, IMG_TYPE_PARTIAL,
-            IMG_TYPE_USER, RESULT_CANCELED, RESULT_FAILED_BAD_REQUEST,
-            RESULT_FAILED_CONFIGURATION, RESULT_FAILED_CONSTRAINED,
-            RESULT_FAILED_LOCKED, RESULT_FAILED_STORAGE, RESULT_NOTHING_TO_DO,
-            RESULT_SUCCEEDED, RESULT_FAILED_TRANSPORT, RESULT_FAILED_UNKNOWN,
-            RESULT_FAILED_OUTOFMEMORY, RESULT_FAILED_DISKSPACE)
-        from pkg.client.debugvalues import DebugValues
-        from pkg.client.pkgdefs import *
-        from pkg.misc import EmptyI, msg, emsg, PipeError
-        from pkg.client.plandesc import (OP_STAGE_PREP, OP_STAGE_EXEC,
-            OP_STAGE_PLAN)
+    from importlib import reload
+    from pkg.client import global_settings
+    from pkg.client.api import (
+        IMG_TYPE_ENTIRE,
+        IMG_TYPE_PARTIAL,
+        IMG_TYPE_USER,
+        RESULT_CANCELED,
+        RESULT_FAILED_BAD_REQUEST,
+        RESULT_FAILED_CONFIGURATION,
+        RESULT_FAILED_CONSTRAINED,
+        RESULT_FAILED_LOCKED,
+        RESULT_FAILED_STORAGE,
+        RESULT_NOTHING_TO_DO,
+        RESULT_SUCCEEDED,
+        RESULT_FAILED_TRANSPORT,
+        RESULT_FAILED_UNKNOWN,
+        RESULT_FAILED_OUTOFMEMORY,
+        RESULT_FAILED_DISKSPACE,
+    )
+    from pkg.client.debugvalues import DebugValues
+    from pkg.client.pkgdefs import *
+    from pkg.misc import EmptyI, msg, emsg, PipeError
+    from pkg.client.plandesc import OP_STAGE_PREP, OP_STAGE_EXEC, OP_STAGE_PLAN
 except KeyboardInterrupt:
-        import sys
-        sys.exit(1)
+    import sys
+
+    sys.exit(1)
 
 CLIENT_API_VERSION = 83
 PKG_CLIENT_NAME = "pkg"
@@ -139,388 +152,452 @@ all_formats = ("default", "json", "tsv")
 
 default_attrs = {}
 for atype, aclass in six.iteritems(actions.types):
-        default_attrs[atype] = [aclass.key_attr]
-        if atype == "depend":
-                default_attrs[atype].insert(0, "type")
-        if atype == "set":
-                default_attrs[atype].append("value")
+    default_attrs[atype] = [aclass.key_attr]
+    if atype == "depend":
+        default_attrs[atype].insert(0, "type")
+    if atype == "set":
+        default_attrs[atype].append("value")
 
 _api_inst = None
 
 tmpdirs = []
 tmpfiles = []
 
+
 @atexit.register
 def cleanup():
-        """To be called at program finish."""
-        for d in tmpdirs:
-                shutil.rmtree(d, True)
-        for f in tmpfiles:
-                os.unlink(f)
+    """To be called at program finish."""
+    for d in tmpdirs:
+        shutil.rmtree(d, True)
+    for f in tmpfiles:
+        os.unlink(f)
+
 
 def notes_block(release_url=None):
-        url = "https://omnios.org/"
-        if release_url is None:
-                release_url = misc.get_release_notes_url()
-        msg("\n" + "-" * 79)
-        msg("{:42} {}".format("Find release notes:", release_url))
-        msg("-" * 79)
-        msg("{:42} {}{}".format("Get a support contract:", url, "support"))
-        msg("{:42} {}{}".format("Sponsor OmniOS development:", url, "patron"))
-        msg("{:42} {}{}".format("Contribute to OmniOS:", url, "joinus"))
-        msg("-" * 79 + "\n")
+    url = "https://omnios.org/"
+    if release_url is None:
+        release_url = misc.get_release_notes_url()
+    msg("\n" + "-" * 79)
+    msg("{:42} {}".format("Find release notes:", release_url))
+    msg("-" * 79)
+    msg("{:42} {}{}".format("Get a support contract:", url, "support"))
+    msg("{:42} {}{}".format("Sponsor OmniOS development:", url, "patron"))
+    msg("{:42} {}{}".format("Contribute to OmniOS:", url, "joinus"))
+    msg("-" * 79 + "\n")
+
 
 def format_update_error(e):
-        # This message is displayed to the user whenever an
-        # ImageFormatUpdateNeeded exception is encountered.
-        logger.error("\n")
-        logger.error(str(e))
-        logger.error(_("To continue, execute 'pkg update-format' as a "
+    # This message is displayed to the user whenever an
+    # ImageFormatUpdateNeeded exception is encountered.
+    logger.error("\n")
+    logger.error(str(e))
+    logger.error(
+        _(
+            "To continue, execute 'pkg update-format' as a "
             "privileged user and then try again.  Please note that updating "
             "the format of the image will render it unusable with older "
-            "versions of the pkg(7) system."))
+            "versions of the pkg(7) system."
+        )
+    )
+
 
 def error(text, cmd=None):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        if not isinstance(text, six.string_types):
-                # Assume it's an object that can be stringified.
-                text = str(text)
+    if not isinstance(text, six.string_types):
+        # Assume it's an object that can be stringified.
+        text = str(text)
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        if cmd:
-                text_nows = "{0}: {1}".format(cmd, text_nows)
-                pkg_cmd = "pkg "
-        else:
-                pkg_cmd = "pkg: "
+    if cmd:
+        text_nows = "{0}: {1}".format(cmd, text_nows)
+        pkg_cmd = "pkg "
+    else:
+        pkg_cmd = "pkg: "
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        logger.error(ws + pkg_cmd + text_nows)
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    logger.error(ws + pkg_cmd + text_nows)
 
-def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT, full=False,
-    verbose=False, unknown_cmd=None):
-        """Emit a usage message and optionally prefix it with a more
-            specific error message.  Causes program to exit. """
 
-        if usage_error:
-                error(usage_error, cmd=cmd)
+def usage(
+    usage_error=None,
+    cmd=None,
+    retcode=EXIT_BADOPT,
+    full=False,
+    verbose=False,
+    unknown_cmd=None,
+):
+    """Emit a usage message and optionally prefix it with a more
+    specific error message.  Causes program to exit."""
 
-        basic_usage = {}
-        adv_usage = {}
-        priv_usage = {}
+    if usage_error:
+        error(usage_error, cmd=cmd)
 
-        basic_cmds = ["refresh", "install", "uninstall", "update",
-            "apply-hot-fix", "autoremove", "list", "version"]
+    basic_usage = {}
+    adv_usage = {}
+    priv_usage = {}
 
-        beopts = (
-            "            [--no-be-activate] [--temp-be-activate]\n"
-            "            [--no-backup-be | --require-backup-be] [--backup-be-name name]\n"
-            "            [--deny-new-be | --require-new-be] [--be-name name]\n"
-        )
+    basic_cmds = [
+        "refresh",
+        "install",
+        "uninstall",
+        "update",
+        "apply-hot-fix",
+        "autoremove",
+        "list",
+        "version",
+    ]
 
-        recurseopts = (
-            "            [-R | -r [-z zonename... | -Z zonename...]]\n"
-        )
+    beopts = (
+        "            [--no-be-activate] [--temp-be-activate]\n"
+        "            [--no-backup-be | --require-backup-be] [--backup-be-name name]\n"
+        "            [--deny-new-be | --require-new-be] [--be-name name]\n"
+    )
 
-        # For those operations that do not recurse by default, even with
-        # the default-recurse image property set to true, -R makes no sense
-        recurseoptsnoR = (
-            "            [-r [-z zonename... | -Z zonename...]]\n"
-        )
+    recurseopts = "            [-R | -r [-z zonename... | -Z zonename...]]\n"
 
-        basic_usage["install"] = _(
-            "[-nvq] [-C n] [-g path_or_uri ...]\n"
-            "            [--no-index] [--no-refresh] [--licenses] [--accept]\n"
-            + beopts + recurseoptsnoR +
-            "            [--sync-actuators | --sync-actuators-timeout timeout]\n"
-            "            [--reject pkg_fmri_pattern ... ] pkg_fmri_pattern ...")
-        basic_usage["uninstall"] = _(
-            "[-nvq] [-C n] [--ignore-missing] [--no-index]\n"
-            + beopts + recurseoptsnoR +
-            "            [--sync-actuators | --sync-actuators-timeout timeout]\n"
-            "            pkg_fmri_pattern ...")
-        basic_usage["update"] = _(
-            "[-fnvq] [-C n] [-g path_or_uri ...] [--ignore-missing]\n"
-            "            [--no-index] [--no-refresh] [--licenses] [--accept]\n"
-            + beopts + recurseopts +
-            "            [--sync-actuators | --sync-actuators-timeout timeout]\n"
-            "            [--reject pkg_fmri_pattern ...] [pkg_fmri_pattern ...]")
-        basic_usage["apply-hot-fix"] = _(
-            "[-nvq]\n"
-            + beopts + recurseopts +
-            "            <path_or_uri> [pkg_fmri_pattern ...]")
+    # For those operations that do not recurse by default, even with
+    # the default-recurse image property set to true, -R makes no sense
+    recurseoptsnoR = "            [-r [-z zonename... | -Z zonename...]]\n"
 
-        basic_usage["autoremove"] = _(
-            "[-nvq] [-C n] [--ignore-missing] [--no-index]\n"
-            + beopts + recurseoptsnoR +
-            "            [--sync-actuators | --sync-actuators-timeout timeout]"
-        )
+    basic_usage["install"] = _(
+        "[-nvq] [-C n] [-g path_or_uri ...]\n"
+        "            [--no-index] [--no-refresh] [--licenses] [--accept]\n"
+        + beopts
+        + recurseoptsnoR
+        + "            [--sync-actuators | --sync-actuators-timeout timeout]\n"
+        "            [--reject pkg_fmri_pattern ... ] pkg_fmri_pattern ..."
+    )
+    basic_usage["uninstall"] = _(
+        "[-nvq] [-C n] [--ignore-missing] [--no-index]\n"
+        + beopts
+        + recurseoptsnoR
+        + "            [--sync-actuators | --sync-actuators-timeout timeout]\n"
+        "            pkg_fmri_pattern ..."
+    )
+    basic_usage["update"] = _(
+        "[-fnvq] [-C n] [-g path_or_uri ...] [--ignore-missing]\n"
+        "            [--no-index] [--no-refresh] [--licenses] [--accept]\n"
+        + beopts
+        + recurseopts
+        + "            [--sync-actuators | --sync-actuators-timeout timeout]\n"
+        "            [--reject pkg_fmri_pattern ...] [pkg_fmri_pattern ...]"
+    )
+    basic_usage["apply-hot-fix"] = _(
+        "[-nvq]\n"
+        + beopts
+        + recurseopts
+        + "            <path_or_uri> [pkg_fmri_pattern ...]"
+    )
 
-        basic_usage["list"] = _(
-            "[-HafiMmnqRrsuv] [-g path_or_uri ...] [--no-refresh]\n"
-            "            [-F format] [-o column[,column]]\n"
-            "            [pkg_fmri_pattern ...]")
-        basic_usage["refresh"] = _("[-q] [--full] [publisher ...]")
-        basic_usage["version"] = ""
+    basic_usage["autoremove"] = _(
+        "[-nvq] [-C n] [--ignore-missing] [--no-index]\n"
+        + beopts
+        + recurseoptsnoR
+        + "            [--sync-actuators | --sync-actuators-timeout timeout]"
+    )
 
-        advanced_cmds = [
-            "info",
-            "contents",
-            "search",
-            "",
-            "verify",
-            "fix",
-            "revert",
-            "",
-            "mediator",
-            "set-mediator",
-            "unset-mediator",
-            "",
-            "variant",
-            "change-variant",
-            "",
-            "facet",
-            "change-facet",
-            "",
-            "avoid",
-            "unavoid",
-            "",
-            "freeze",
-            "unfreeze",
-            "",
-            "property",
-            "set-property",
-            "add-property-value",
-            "remove-property-value",
-            "unset-property",
-            "",
-            "publisher",
-            "set-publisher",
-            "unset-publisher",
-            "",
-            "history",
-            "purge-history",
-            "",
-            "rebuild-index",
-            "update-format",
-            "image-create",
-            "exact-install",
-            "",
-            "dehydrate",
-            "rehydrate",
-            "",
-            "flag",
-            "clean",
-        ]
+    basic_usage["list"] = _(
+        "[-HafiMmnqRrsuv] [-g path_or_uri ...] [--no-refresh]\n"
+        "            [-F format] [-o column[,column]]\n"
+        "            [pkg_fmri_pattern ...]"
+    )
+    basic_usage["refresh"] = _("[-q] [--full] [publisher ...]")
+    basic_usage["version"] = ""
 
-        adv_usage["info"] = \
-            _("[-lqr] [-g path_or_uri ...] [--license] [pkg_fmri_pattern ...]")
-        adv_usage["contents"] = _(
-            "[-Hmr] [-a attribute=pattern]... [-g path_or_uri]...\n"
-            "            [-o attribute[,attribute]...]... [-s sort_key]\n"
-            "            [-t action_name[,action_name]...]...\n"
-            "            [pkg_fmri_pattern ...]")
-        adv_usage["search"] = _(
-            "[-HIaflpr] [-o attribute ...] [-s repo_uri] query")
+    advanced_cmds = [
+        "info",
+        "contents",
+        "search",
+        "",
+        "verify",
+        "fix",
+        "revert",
+        "",
+        "mediator",
+        "set-mediator",
+        "unset-mediator",
+        "",
+        "variant",
+        "change-variant",
+        "",
+        "facet",
+        "change-facet",
+        "",
+        "avoid",
+        "unavoid",
+        "",
+        "freeze",
+        "unfreeze",
+        "",
+        "property",
+        "set-property",
+        "add-property-value",
+        "remove-property-value",
+        "unset-property",
+        "",
+        "publisher",
+        "set-publisher",
+        "unset-publisher",
+        "",
+        "history",
+        "purge-history",
+        "",
+        "rebuild-index",
+        "update-format",
+        "image-create",
+        "exact-install",
+        "",
+        "dehydrate",
+        "rehydrate",
+        "",
+        "flag",
+        "clean",
+    ]
 
-        adv_usage["verify"] = _("[-Hqv] [-p path]... [--parsable version]\n"
-            "            [--unpackaged] [--unpackaged-only] [pkg_fmri_pattern ...]")
-        adv_usage["fix"] = _(
-            "[-nvq]\n"
-            + beopts +
-            "            [--accept] [--licenses] [--parsable version] [--unpackaged]\n"
-            "            [pkg_fmri_pattern ...]")
-        adv_usage["revert"] = _(
-            "[-nv]\n"
-            + beopts +
-            "            (--tagged tag-name ... | path-to-file ...)")
+    adv_usage["info"] = _(
+        "[-lqr] [-g path_or_uri ...] [--license] [pkg_fmri_pattern ...]"
+    )
+    adv_usage["contents"] = _(
+        "[-Hmr] [-a attribute=pattern]... [-g path_or_uri]...\n"
+        "            [-o attribute[,attribute]...]... [-s sort_key]\n"
+        "            [-t action_name[,action_name]...]...\n"
+        "            [pkg_fmri_pattern ...]"
+    )
+    adv_usage["search"] = _("[-HIaflpr] [-o attribute ...] [-s repo_uri] query")
 
-        adv_usage["image-create"] = _(
-            "[-FPUfz] [--force] [--full|--partial|--user] [--zone]\n"
-            "            [-k ssl_key] [-c ssl_cert] [--no-refresh]\n"
-            "            [--variant <variant_spec>=<instance> ...]\n"
-            "            [-g uri|--origin=uri ...] [-m uri|--mirror=uri ...]\n"
-            "            [--facet <facet_spec>=(True|False) ...]\n"
-            "            [(-p|--publisher) [<name>=]<repo_uri>] dir")
-        adv_usage["change-variant"] = _(
-            "[-nvq] [-C n] [-g path_or_uri ...] [--accept]\n"
-            "            [--licenses] [--no-index] [--no-refresh]\n"
-            + beopts + recurseopts +
-            "            [--sync-actuators | --sync-actuators-timeout timeout]\n"
-            "            [--reject pkg_fmri_pattern ... ]\n"
-            "            <variant_spec>=<instance> ...")
+    adv_usage["verify"] = _(
+        "[-Hqv] [-p path]... [--parsable version]\n"
+        "            [--unpackaged] [--unpackaged-only] [pkg_fmri_pattern ...]"
+    )
+    adv_usage["fix"] = _(
+        "[-nvq]\n"
+        + beopts
+        + "            [--accept] [--licenses] [--parsable version] [--unpackaged]\n"
+        "            [pkg_fmri_pattern ...]"
+    )
+    adv_usage["revert"] = _(
+        "[-nv]\n"
+        + beopts
+        + "            (--tagged tag-name ... | path-to-file ...)"
+    )
 
-        adv_usage["change-facet"] = _(
-            "[-nvq] [-C n] [-g path_or_uri ...] [--accept]\n"
-            "            [--licenses] [--no-index] [--no-refresh]\n"
-            + beopts + recurseopts +
-            "            [--sync-actuators | --sync-actuators-timeout timeout]\n"
-            "            [--reject pkg_fmri_pattern ... ]\n"
-            "            <facet_spec>=[True|False|None] ...")
+    adv_usage["image-create"] = _(
+        "[-FPUfz] [--force] [--full|--partial|--user] [--zone]\n"
+        "            [-k ssl_key] [-c ssl_cert] [--no-refresh]\n"
+        "            [--variant <variant_spec>=<instance> ...]\n"
+        "            [-g uri|--origin=uri ...] [-m uri|--mirror=uri ...]\n"
+        "            [--facet <facet_spec>=(True|False) ...]\n"
+        "            [(-p|--publisher) [<name>=]<repo_uri>] dir"
+    )
+    adv_usage["change-variant"] = _(
+        "[-nvq] [-C n] [-g path_or_uri ...] [--accept]\n"
+        "            [--licenses] [--no-index] [--no-refresh]\n"
+        + beopts
+        + recurseopts
+        + "            [--sync-actuators | --sync-actuators-timeout timeout]\n"
+        "            [--reject pkg_fmri_pattern ... ]\n"
+        "            <variant_spec>=<instance> ..."
+    )
 
-        adv_usage["mediator"] = _("[-aH] [-F format] [<mediator> ...]")
-        adv_usage["set-mediator"] = _(
-            "[-nv] [-I <implementation>]\n"
-            "            [-V <version>]\n"
-            + beopts +
-            "            <mediator> ...")
-        adv_usage["unset-mediator"] = _("[-nvIV]\n"
-            + beopts +
-            "            <mediator> ...")
+    adv_usage["change-facet"] = _(
+        "[-nvq] [-C n] [-g path_or_uri ...] [--accept]\n"
+        "            [--licenses] [--no-index] [--no-refresh]\n"
+        + beopts
+        + recurseopts
+        + "            [--sync-actuators | --sync-actuators-timeout timeout]\n"
+        "            [--reject pkg_fmri_pattern ... ]\n"
+        "            <facet_spec>=[True|False|None] ..."
+    )
 
-        adv_usage["variant"] = _("[-Haiv] [-F format] [<variant_pattern> ...]")
-        adv_usage["facet"] = ("[-Haim] [-F format] [<facet_pattern> ...]")
-        adv_usage["avoid"] = _("[pkg_fmri_pattern] ...")
-        adv_usage["unavoid"] = _("[pkg_fmri_pattern] ...")
-        adv_usage["freeze"] = _("[-n] [-c reason] [pkg_fmri_pattern] ...")
-        adv_usage["unfreeze"] = _("[-n] [pkg_name_pattern] ...")
-        adv_usage["set-property"] = _("propname propvalue")
-        adv_usage["add-property-value"] = _("propname propvalue")
-        adv_usage["remove-property-value"] = _("propname propvalue")
-        adv_usage["unset-property"] = _("propname ...")
-        adv_usage["property"] = _("[-H] [propname ...]")
+    adv_usage["mediator"] = _("[-aH] [-F format] [<mediator> ...]")
+    adv_usage["set-mediator"] = _(
+        "[-nv] [-I <implementation>]\n"
+        "            [-V <version>]\n" + beopts + "            <mediator> ..."
+    )
+    adv_usage["unset-mediator"] = _(
+        "[-nvIV]\n" + beopts + "            <mediator> ..."
+    )
 
-        adv_usage["set-publisher"] = _("[-Pedv] [-k ssl_key] [-c ssl_cert]\n"
-            "            [-O origin_to_set|--origin-uri=origin_to_set ...]\n"
-            "            [-g origin_to_add|--add-origin=origin_to_add ...]\n"
-            "            [-G origin_to_remove|--remove-origin=origin_to_remove ...]\n"
-            "            [-m mirror_to_add|--add-mirror=mirror_to_add ...]\n"
-            "            [-M mirror_to_remove|--remove-mirror=mirror_to_remove ...]\n"
-            "            [-p repo_uri] [--enable] [--disable] [--no-refresh]\n"
-            + recurseopts +
-            "            [--reset-uuid] [--non-sticky] [--sticky]\n"
-            "            [--search-after=publisher]\n"
-            "            [--search-before=publisher]\n"
-            "            [--search-first]\n"
-            "            [--approve-ca-cert=path_to_CA]\n"
-            "            [--revoke-ca-cert=hash_of_CA_to_revoke]\n"
-            "            [--unset-ca-cert=hash_of_CA_to_unset]\n"
-            "            [--set-property name_of_property=value]\n"
-            "            [--add-property-value name_of_property=value_to_add]\n"
-            "            [--remove-property-value name_of_property=value_to_remove]\n"
-            "            [--unset-property name_of_property_to_delete]\n"
-            "            [--proxy proxy to use]\n"
-            "            [publisher]")
+    adv_usage["variant"] = _("[-Haiv] [-F format] [<variant_pattern> ...]")
+    adv_usage["facet"] = "[-Haim] [-F format] [<facet_pattern> ...]"
+    adv_usage["avoid"] = _("[pkg_fmri_pattern] ...")
+    adv_usage["unavoid"] = _("[pkg_fmri_pattern] ...")
+    adv_usage["freeze"] = _("[-n] [-c reason] [pkg_fmri_pattern] ...")
+    adv_usage["unfreeze"] = _("[-n] [pkg_name_pattern] ...")
+    adv_usage["set-property"] = _("propname propvalue")
+    adv_usage["add-property-value"] = _("propname propvalue")
+    adv_usage["remove-property-value"] = _("propname propvalue")
+    adv_usage["unset-property"] = _("propname ...")
+    adv_usage["property"] = _("[-H] [propname ...]")
 
-        adv_usage["unset-publisher"] = _("publisher ...")
-        adv_usage["publisher"] = _("[-HPn] [-F format] [publisher ...]")
-        adv_usage["history"] = _("[-HNl] [-t [time|time-time],...] [-n number] [-o column,...]")
-        adv_usage["purge-history"] = ""
-        adv_usage["rebuild-index"] = ""
-        adv_usage["update-format"] = ""
-        adv_usage["exact-install"] = _("[-nvq] [-C n] [-g path_or_uri ...] [--accept]\n"
-            "            [--licenses] [--no-index] [--no-refresh]\n"
-            + beopts +
-            "            [--reject pkg_fmri_pattern ... ] pkg_fmri_pattern ...")
-        adv_usage["dehydrate"] = _("[-nvq] [-p publisher ...]")
-        adv_usage["rehydrate"] = _("[-nvq] [-p publisher ...]")
-        adv_usage["flag"] = _("[-mM] [pkg_fmri_pattern ...]")
-        adv_usage["clean"] = "[-v]"
+    adv_usage["set-publisher"] = _(
+        "[-Pedv] [-k ssl_key] [-c ssl_cert]\n"
+        "            [-O origin_to_set|--origin-uri=origin_to_set ...]\n"
+        "            [-g origin_to_add|--add-origin=origin_to_add ...]\n"
+        "            [-G origin_to_remove|--remove-origin=origin_to_remove ...]\n"
+        "            [-m mirror_to_add|--add-mirror=mirror_to_add ...]\n"
+        "            [-M mirror_to_remove|--remove-mirror=mirror_to_remove ...]\n"
+        "            [-p repo_uri] [--enable] [--disable] [--no-refresh]\n"
+        + recurseopts
+        + "            [--reset-uuid] [--non-sticky] [--sticky]\n"
+        "            [--search-after=publisher]\n"
+        "            [--search-before=publisher]\n"
+        "            [--search-first]\n"
+        "            [--approve-ca-cert=path_to_CA]\n"
+        "            [--revoke-ca-cert=hash_of_CA_to_revoke]\n"
+        "            [--unset-ca-cert=hash_of_CA_to_unset]\n"
+        "            [--set-property name_of_property=value]\n"
+        "            [--add-property-value name_of_property=value_to_add]\n"
+        "            [--remove-property-value name_of_property=value_to_remove]\n"
+        "            [--unset-property name_of_property_to_delete]\n"
+        "            [--proxy proxy to use]\n"
+        "            [publisher]"
+    )
 
-        priv_usage["remote"] = _(
-            "--ctlfd=file_descriptor --progfd=file_descriptor")
-        priv_usage["list-linked"] = _("-H")
-        priv_usage["attach-linked"] = _(
-            "[-fnvq] [-C n] [--accept] [--licenses] [--no-index]\n"
-            "            [--no-refresh] [--no-pkg-updates] [--linked-md-only]\n"
-            "            [--allow-relink]\n"
-            "            [--prop-linked <propname>=<propvalue> ...]\n"
-            "            (-c|-p) <li-name> <dir>")
-        priv_usage["detach-linked"] = _(
-            "[-fnvq] [-a|-l <li-name>] [--no-pkg-updates] [--linked-md-only]")
-        priv_usage["property-linked"] = _("[-H] [-l <li-name>] [propname ...]")
-        priv_usage["audit-linked"] = _(
-            "[-H] [-a|-l <li-name>] [--no-parent-sync]")
-        priv_usage["pubcheck-linked"] = ""
-        priv_usage["clean-up-hot-fix"] = ""
-        priv_usage["sync-linked"] = _(
-            "[-nvq] [-C n] [--accept] [--licenses] [--no-index]\n"
-            "            [--no-refresh] [--no-parent-sync] [--no-pkg-updates]\n"
-            "            [--linked-md-only] [-a|-l <name>]")
-        priv_usage["set-property-linked"] = _(
-            "[-nvq] [--accept] [--licenses] [--no-index] [--no-refresh]\n"
-            "            [--no-parent-sync] [--no-pkg-updates]\n"
-            "            [--linked-md-only] <propname>=<propvalue> ...")
-        priv_usage["copy-publishers-from"] = _("<dir>")
-        priv_usage["list-uuids"] = ""
+    adv_usage["unset-publisher"] = _("publisher ...")
+    adv_usage["publisher"] = _("[-HPn] [-F format] [publisher ...]")
+    adv_usage["history"] = _(
+        "[-HNl] [-t [time|time-time],...] [-n number] [-o column,...]"
+    )
+    adv_usage["purge-history"] = ""
+    adv_usage["rebuild-index"] = ""
+    adv_usage["update-format"] = ""
+    adv_usage["exact-install"] = _(
+        "[-nvq] [-C n] [-g path_or_uri ...] [--accept]\n"
+        "            [--licenses] [--no-index] [--no-refresh]\n"
+        + beopts
+        + "            [--reject pkg_fmri_pattern ... ] pkg_fmri_pattern ..."
+    )
+    adv_usage["dehydrate"] = _("[-nvq] [-p publisher ...]")
+    adv_usage["rehydrate"] = _("[-nvq] [-p publisher ...]")
+    adv_usage["flag"] = _("[-mM] [pkg_fmri_pattern ...]")
+    adv_usage["clean"] = "[-v]"
 
-        def print_cmds(cmd_list, cmd_dic):
-                for cmd in cmd_list:
-                        if cmd == "":
-                                logger.error("")
-                        else:
-                                if cmd not in cmd_dic:
-                                        # this should never happen - callers
-                                        # should check for valid subcommands
-                                        # before calling usage(..)
-                                        raise ValueError(
-                                            "Unable to find usage str for "
-                                            "{0}".format(cmd))
-                                use_txt = cmd_dic[cmd]
-                                if use_txt != "":
-                                        logger.error(
-                                            "        pkg {cmd} "
-                                            "{use_txt}".format(**locals()))
-                                else:
-                                        logger.error("        pkg "
-                                            "{0}".format(cmd))
-        if not full and cmd:
-                if cmd not in priv_usage:
-                        logger.error(_("Usage:"))
+    priv_usage["remote"] = _("--ctlfd=file_descriptor --progfd=file_descriptor")
+    priv_usage["list-linked"] = _("-H")
+    priv_usage["attach-linked"] = _(
+        "[-fnvq] [-C n] [--accept] [--licenses] [--no-index]\n"
+        "            [--no-refresh] [--no-pkg-updates] [--linked-md-only]\n"
+        "            [--allow-relink]\n"
+        "            [--prop-linked <propname>=<propvalue> ...]\n"
+        "            (-c|-p) <li-name> <dir>"
+    )
+    priv_usage["detach-linked"] = _(
+        "[-fnvq] [-a|-l <li-name>] [--no-pkg-updates] [--linked-md-only]"
+    )
+    priv_usage["property-linked"] = _("[-H] [-l <li-name>] [propname ...]")
+    priv_usage["audit-linked"] = _("[-H] [-a|-l <li-name>] [--no-parent-sync]")
+    priv_usage["pubcheck-linked"] = ""
+    priv_usage["clean-up-hot-fix"] = ""
+    priv_usage["sync-linked"] = _(
+        "[-nvq] [-C n] [--accept] [--licenses] [--no-index]\n"
+        "            [--no-refresh] [--no-parent-sync] [--no-pkg-updates]\n"
+        "            [--linked-md-only] [-a|-l <name>]"
+    )
+    priv_usage["set-property-linked"] = _(
+        "[-nvq] [--accept] [--licenses] [--no-index] [--no-refresh]\n"
+        "            [--no-parent-sync] [--no-pkg-updates]\n"
+        "            [--linked-md-only] <propname>=<propvalue> ..."
+    )
+    priv_usage["copy-publishers-from"] = _("<dir>")
+    priv_usage["list-uuids"] = ""
+
+    def print_cmds(cmd_list, cmd_dic):
+        for cmd in cmd_list:
+            if cmd == "":
+                logger.error("")
+            else:
+                if cmd not in cmd_dic:
+                    # this should never happen - callers
+                    # should check for valid subcommands
+                    # before calling usage(..)
+                    raise ValueError(
+                        "Unable to find usage str for " "{0}".format(cmd)
+                    )
+                use_txt = cmd_dic[cmd]
+                if use_txt != "":
+                    logger.error(
+                        "        pkg {cmd} " "{use_txt}".format(**locals())
+                    )
                 else:
-                        logger.error(_("Private subcommand usage, options "
-                            "subject to change at any time:"))
-                combined = {}
-                combined.update(basic_usage)
-                combined.update(adv_usage)
-                combined.update(priv_usage)
-                print_cmds([cmd], combined)
-                sys.exit(retcode)
+                    logger.error("        pkg " "{0}".format(cmd))
 
-        elif not full:
-                # The full list of subcommands isn't desired.
-                known_words = ["help"]
-                known_words.extend(basic_cmds)
-                known_words.extend(w for w in advanced_cmds if w)
-                candidates = misc.suggest_known_words(unknown_cmd, known_words)
-                if candidates:
-                        # Suggest correct subcommands if we can.
-                        words = ", ". join(candidates)
-                        logger.error(_("Did you mean:\n    {0}\n").format(words))
-                logger.error(_("For a full list of subcommands, run: pkg help"))
-                sys.exit(retcode)
+    if not full and cmd:
+        if cmd not in priv_usage:
+            logger.error(_("Usage:"))
+        else:
+            logger.error(
+                _(
+                    "Private subcommand usage, options "
+                    "subject to change at any time:"
+                )
+            )
+        combined = {}
+        combined.update(basic_usage)
+        combined.update(adv_usage)
+        combined.update(priv_usage)
+        print_cmds([cmd], combined)
+        sys.exit(retcode)
 
-        if verbose:
-                # Display a verbose usage message of subcommands.
-                logger.error(_("""\
+    elif not full:
+        # The full list of subcommands isn't desired.
+        known_words = ["help"]
+        known_words.extend(basic_cmds)
+        known_words.extend(w for w in advanced_cmds if w)
+        candidates = misc.suggest_known_words(unknown_cmd, known_words)
+        if candidates:
+            # Suggest correct subcommands if we can.
+            words = ", ".join(candidates)
+            logger.error(_("Did you mean:\n    {0}\n").format(words))
+        logger.error(_("For a full list of subcommands, run: pkg help"))
+        sys.exit(retcode)
+
+    if verbose:
+        # Display a verbose usage message of subcommands.
+        logger.error(
+            _(
+                """\
 Usage:
         pkg [options] command [cmd_options] [operands]
-"""))
-                logger.error(_("Basic subcommands:"))
-                print_cmds(basic_cmds, basic_usage)
+"""
+            )
+        )
+        logger.error(_("Basic subcommands:"))
+        print_cmds(basic_cmds, basic_usage)
 
-                logger.error(_("\nAdvanced subcommands:"))
-                print_cmds(advanced_cmds, adv_usage)
+        logger.error(_("\nAdvanced subcommands:"))
+        print_cmds(advanced_cmds, adv_usage)
 
-                logger.error(_("""
+        logger.error(
+            _(
+                """
 Options:
         -R dir
         --no-network-cache
         --help or -?
 
 Environment:
-        PKG_IMAGE"""))
-        else:
-                # Display the full list of subcommands.
-                logger.error(_("""\
-Usage:    pkg [options] command [cmd_options] [operands]"""))
-                logger.error(_("The following commands are supported:"))
-                logger.error(_("""
+        PKG_IMAGE"""
+            )
+        )
+    else:
+        # Display the full list of subcommands.
+        logger.error(
+            _(
+                """\
+Usage:    pkg [options] command [cmd_options] [operands]"""
+            )
+        )
+        logger.error(_("The following commands are supported:"))
+        logger.error(
+            _(
+                """
 Package Information  : list           search         info      contents
 Package Transitions  : update         install        uninstall
                        history        exact-install  apply-hot-fix
@@ -535,5216 +612,6571 @@ Image Configuration  : refresh        rebuild-index  purge-history
                        property       set-property   add-property-value
                        unset-property remove-property-value
 Miscellaneous        : image-create   dehydrate      rehydrate     clean
-For more info, run: pkg help <command>"""))
-        sys.exit(retcode)
+For more info, run: pkg help <command>"""
+            )
+        )
+    sys.exit(retcode)
+
 
 def get_fmri_args(api_inst, pargs, cmd=None):
-        """ Convenience routine to check that input args are valid fmris. """
+    """Convenience routine to check that input args are valid fmris."""
 
-        res = []
-        errors = []
-        for pat, err, pfmri, matcher in api_inst.parse_fmri_patterns(pargs):
-                if not err:
-                        res.append((pat, err, pfmri, matcher))
-                        continue
-                if isinstance(err, version.VersionError):
-                        # For version errors, include the pattern so
-                        # that the user understands why it failed.
-                        errors.append("Illegal FMRI '{0}': {1}".format(pat,
-                            err))
-                else:
-                        # Including the pattern is redundant for other
-                        # exceptions.
-                        errors.append(err)
-        if errors:
-                error("\n".join(str(e) for e in errors), cmd=cmd)
-        return len(errors) == 0, res
+    res = []
+    errors = []
+    for pat, err, pfmri, matcher in api_inst.parse_fmri_patterns(pargs):
+        if not err:
+            res.append((pat, err, pfmri, matcher))
+            continue
+        if isinstance(err, version.VersionError):
+            # For version errors, include the pattern so
+            # that the user understands why it failed.
+            errors.append("Illegal FMRI '{0}': {1}".format(pat, err))
+        else:
+            # Including the pattern is redundant for other
+            # exceptions.
+            errors.append(err)
+    if errors:
+        error("\n".join(str(e) for e in errors), cmd=cmd)
+    return len(errors) == 0, res
+
 
 def calc_fmtstr(attrs, data):
-        widths = [0] * len(data[0])
+    widths = [0] * len(data[0])
 
-        for entry in data:
-                for i, field in enumerate(attrs):
-                        if len(entry.get(field)) > widths[i]:
-                                widths[i] = len(entry.get(field))
+    for entry in data:
+        for i, field in enumerate(attrs):
+            if len(entry.get(field)) > widths[i]:
+                widths[i] = len(entry.get(field))
 
-        fmt = ''
-        for i, w in enumerate(widths):
-                fmt += '{' + f'{i}:{w+1}' + '}'
-        return fmt
+    fmt = ""
+    for i, w in enumerate(widths):
+        fmt += "{" + f"{i}:{w+1}" + "}"
+    return fmt
+
 
 def format_output(attrs, fields, data, output_format, fmt_str, omit_headers):
-        field_data = { a: [all_formats, fields.get(a), ""] for a in attrs }
-        order = [ fields.get(a) for a in attrs ]
+    field_data = {a: [all_formats, fields.get(a), ""] for a in attrs}
+    order = [fields.get(a) for a in attrs]
 
-        sys.stdout.write(misc.get_listing(
-                order, field_data, data, output_format, fmt_str, omit_headers,
-                False))
+    sys.stdout.write(
+        misc.get_listing(
+            order, field_data, data, output_format, fmt_str, omit_headers, False
+        )
+    )
 
-def list_inventory(op, api_inst, pargs,
-    li_parent_sync, list_all, list_installed_newest, list_newest,
-    list_upgradable, omit_headers, output_format, output_fields, origins, quiet,
-    refresh_catalogs, summary, list_removable, list_all_removable, list_manual,
-    list_not_manual, list_installable, verbose):
-        """List packages."""
 
-        def gen(meta=False):
-                fields = {
-                    "fmri": {
-                        "header": "FMRI",
-                        "display": lambda x:
-                            f"pkg://{x['pub']}/{x['pkg']}@{short_ver}:{ts}"
-                    },
-                    "version": {
-                        "header": "VERSION",
-                        "display": lambda x: short_ver
-                    },
-                    "release": {
-                        "header": "RELEASE",
-                        "display": lambda x: release
-                    },
-                    "osrelease": {
-                        "header": "OS RELEASE",
-                        "display": lambda x: build_release
-                    },
-                    "branch": {
-                        "header": "BRANCH",
-                        "display": lambda x: branch
-                    },
-                    "timestamp": {
-                        "header": "TIMESTAMP",
-                        "display": lambda x: ts
-                    },
-                    "flags": {
-                        "header": "IFO",
-                        "display": lambda x: status
-                    },
-                    "name": {
-                        "header": "NAME",
-                        "display": lambda x: x.get('pkg')
-                    },
-                    "publisher": {
-                        "header": "PUBLISHER",
-                        "display": lambda x: x.get('pub')
-                    },
-                    "namepub": {
-                        "header": "NAME (PUBLISHER)",
-                        "display": lambda x:
-                            x.get('pkg') + (
-                                f" ({x['pub']})" if x['pub'] != ppub else ''
-                            )
-                    },
-                    "summary": {
-                        "header": "SUMMARY",
-                        "display": lambda x: x.get('summary')
-                    },
-                }
+def list_inventory(
+    op,
+    api_inst,
+    pargs,
+    li_parent_sync,
+    list_all,
+    list_installed_newest,
+    list_newest,
+    list_upgradable,
+    omit_headers,
+    output_format,
+    output_fields,
+    origins,
+    quiet,
+    refresh_catalogs,
+    summary,
+    list_removable,
+    list_all_removable,
+    list_manual,
+    list_not_manual,
+    list_installable,
+    verbose,
+):
+    """List packages."""
 
-                if meta:
-                        yield {k: fields[k].get('header')
-                               for k in fields.keys()}
-                        return
+    def gen(meta=False):
+        fields = {
+            "fmri": {
+                "header": "FMRI",
+                "display": lambda x: f"pkg://{x['pub']}/{x['pkg']}@{short_ver}:{ts}",
+            },
+            "version": {"header": "VERSION", "display": lambda x: short_ver},
+            "release": {"header": "RELEASE", "display": lambda x: release},
+            "osrelease": {
+                "header": "OS RELEASE",
+                "display": lambda x: build_release,
+            },
+            "branch": {"header": "BRANCH", "display": lambda x: branch},
+            "timestamp": {"header": "TIMESTAMP", "display": lambda x: ts},
+            "flags": {"header": "IFO", "display": lambda x: status},
+            "name": {"header": "NAME", "display": lambda x: x.get("pkg")},
+            "publisher": {
+                "header": "PUBLISHER",
+                "display": lambda x: x.get("pub"),
+            },
+            "namepub": {
+                "header": "NAME (PUBLISHER)",
+                "display": lambda x: x.get("pkg")
+                + (f" ({x['pub']})" if x["pub"] != ppub else ""),
+            },
+            "summary": {
+                "header": "SUMMARY",
+                "display": lambda x: x.get("summary"),
+            },
+        }
 
-                if not "data" in out_json:
-                        return
-                data = out_json["data"]
-
-                ppub = api_inst.get_highest_ranked_publisher()
-                if ppub:
-                        ppub = ppub.prefix
-
-                state_map = [
-                    [
-                        ("installed", "i")
-                    ],
-                    [
-                        ("frozen", "f"),
-                        ("optional", "S"),
-                        ("manual", "m")
-                    ],
-                    [
-                        ("obsolete", "o"),
-                        ("renamed", "r"),
-                        ("legacy", "l")
-                    ],
-                ]
-
-                if quiet:
-                        return
-
-                for entry in data:
-                        if (list_removable and not list_all_removable and
-                            'optional' in entry['states']):
-                                continue
-
-                        if list_manual and 'manual' not in entry['states']:
-                                continue
-
-                        if list_not_manual and 'manual' in entry['states']:
-                                continue
-
-                        if (list_installable and
-                            not set(['installed', 'obsolete', 'renamed'])
-                            .isdisjoint(entry['states'])):
-                                continue
-
-                        status = ""
-                        for sentry in state_map:
-                                for s, v in sentry:
-                                        if s in entry["states"]:
-                                                st = v
-                                                break
-                                        else:
-                                                st = "-"
-                                status += st
-
-                        # Use class method instead of creating an object for
-                        # performance reasons.
-                        (release, build_release, branch, ts), \
-                            short_ver = version.Version.split(entry['version'])
-
-                        yield { a: fields[a].get('display')(entry)
-                                for a in attrs
-                        }
-
-        fields = list(gen(True))[0]
-
-        accumulate = False
-        fmt_str = "{0}"
-        if output_fields:
-                if verbose or summary:
-                        usage("-o cannot be used with -v or -s")
-                attrs = list(dict.fromkeys(output_fields.lower().split(",")))
-                unknown = [a for a in attrs if not fields.get(a)]
-                if len(unknown):
-                        usage(
-                            "Unknown output field(s): {}\n".format(
-                                ', '.join(unknown)) +
-                            "Known fields are: {}".format(
-                                ', '.join(sorted(fields.keys()))))
-                if len(attrs) == 0:
-                        usage("No fields specified. Known fields are: {}"
-                              .format(', '.join(sorted(fields.keys()))))
-                # If there is more than one field selected, we need to
-                # accumulate all results in order to determine the column
-                # widths.
-                if len(attrs) > 1:
-                        accumulate = True
-        elif verbose:
-                fmt_str = "{0:76} {1}"
-                attrs = ["fmri", "flags"]
-        elif summary:
-                fmt_str = "{0:55} {1}"
-                attrs = ["namepub", "summary"]
-        else:
-                fmt_str = "{0:49} {1:26} {2}"
-                attrs = ["namepub", "version", "flags"]
-
-        # getting json output.
-        out_json = client_api._list_inventory(op, api_inst, pargs,
-            li_parent_sync, list_all, list_installed_newest, list_newest,
-            list_upgradable, origins, quiet, refresh_catalogs,
-            list_removable=list_removable)
-
-        errors = None
-        if "errors" in out_json:
-                errors = out_json["errors"]
-                errors = _generate_error_messages(out_json["status"], errors,
-                    selected_type=["catalog_refresh", "catalog_refresh_failed"])
-
-        if accumulate:
-                data = list(gen())
-                fmt_str = calc_fmtstr(attrs, data)
-        else:
-                data = list(gen())
-
-        if len(data) == 0:
-                omit_headers = True
-
-        format_output(attrs, fields, data, output_format, fmt_str, omit_headers)
-
-        # Print errors left.
-        if errors:
-                _generate_error_messages(out_json["status"], errors)
-
-        return out_json["status"]
-
-def get_tracker():
-        if global_settings.client_output_parsable_version is not None:
-                progresstracker = progress.NullProgressTracker()
-        elif global_settings.client_output_quiet:
-                progresstracker = progress.QuietProgressTracker()
-        elif global_settings.client_output_progfd:
-                # This logic handles linked images: for linked children
-                # we elide the progress output.
-                output_file = os.fdopen(global_settings.client_output_progfd,
-                    "w")
-                child_tracker = progress.LinkedChildProgressTracker(
-                    output_file=output_file)
-                dot_tracker = progress.DotProgressTracker(
-                    output_file=output_file)
-                progresstracker = progress.MultiProgressTracker(
-                    [child_tracker, dot_tracker])
-        else:
-                try:
-                        progresstracker = progress.FancyUNIXProgressTracker()
-                except progress.ProgressTrackerException:
-                        progresstracker = progress.CommandLineProgressTracker()
-
-        return progresstracker
-
-def accept_plan_licenses(api_inst):
-        """Helper function that marks all licenses for the current plan as
-        accepted if they require acceptance."""
-
-        plan = api_inst.describe()
-        for pfmri, src, dest, accepted, displayed in plan.get_licenses():
-                if not dest.must_accept:
-                        continue
-                api_inst.set_plan_license_status(pfmri, dest.license,
-                    accepted=True)
-
-display_plan_options = ["basic", "fmris", "variants/facets", "services",
-    "actions", "boot-archive"]
-
-def __display_plan(api_inst, verbose, noexecute, op=None):
-        """Helper function to display plan to the desired degree.
-        Verbose can either be a numerical value, or a list of
-        items to display"""
-
-        if isinstance(verbose, int):
-                disp = ["basic"]
-
-                if verbose == 0 and noexecute:
-                        disp.append("release-notes")
-                if verbose > 0:
-                        disp.extend(["fmris", "mediators", "services",
-                                     "variants/facets", "boot-archive",
-                                     "release-notes", "editable", "actuators"])
-                if verbose > 1:
-                        disp.append("actions")
-                if verbose > 2:
-                        disp.append("solver-errors")
-        else:
-                disp = verbose
-
-        if DebugValues["plan"] and "solver-errors" not in disp:
-                disp.append("solver-errors")
-
-        plan = api_inst.describe()
-
-        if not plan:
+        if meta:
+            yield {k: fields[k].get("header") for k in fields.keys()}
             return
 
-        if plan.must_display_notes():
-                disp.append("release-notes")
+        if not "data" in out_json:
+            return
+        data = out_json["data"]
 
-        if api_inst.is_liveroot and not api_inst.is_active_liveroot_be:
-                # Warn the user since this isn't likely what they wanted.
-                if plan.new_be:
-                        logger.warning(_("""\
+        ppub = api_inst.get_highest_ranked_publisher()
+        if ppub:
+            ppub = ppub.prefix
+
+        state_map = [
+            [("installed", "i")],
+            [("frozen", "f"), ("optional", "S"), ("manual", "m")],
+            [("obsolete", "o"), ("renamed", "r"), ("legacy", "l")],
+        ]
+
+        if quiet:
+            return
+
+        for entry in data:
+            if (
+                list_removable
+                and not list_all_removable
+                and "optional" in entry["states"]
+            ):
+                continue
+
+            if list_manual and "manual" not in entry["states"]:
+                continue
+
+            if list_not_manual and "manual" in entry["states"]:
+                continue
+
+            if list_installable and not set(
+                ["installed", "obsolete", "renamed"]
+            ).isdisjoint(entry["states"]):
+                continue
+
+            status = ""
+            for sentry in state_map:
+                for s, v in sentry:
+                    if s in entry["states"]:
+                        st = v
+                        break
+                    else:
+                        st = "-"
+                status += st
+
+            # Use class method instead of creating an object for
+            # performance reasons.
+            (
+                release,
+                build_release,
+                branch,
+                ts,
+            ), short_ver = version.Version.split(entry["version"])
+
+            yield {a: fields[a].get("display")(entry) for a in attrs}
+
+    fields = list(gen(True))[0]
+
+    accumulate = False
+    fmt_str = "{0}"
+    if output_fields:
+        if verbose or summary:
+            usage("-o cannot be used with -v or -s")
+        attrs = list(dict.fromkeys(output_fields.lower().split(",")))
+        unknown = [a for a in attrs if not fields.get(a)]
+        if len(unknown):
+            usage(
+                "Unknown output field(s): {}\n".format(", ".join(unknown))
+                + "Known fields are: {}".format(
+                    ", ".join(sorted(fields.keys()))
+                )
+            )
+        if len(attrs) == 0:
+            usage(
+                "No fields specified. Known fields are: {}".format(
+                    ", ".join(sorted(fields.keys()))
+                )
+            )
+        # If there is more than one field selected, we need to
+        # accumulate all results in order to determine the column
+        # widths.
+        if len(attrs) > 1:
+            accumulate = True
+    elif verbose:
+        fmt_str = "{0:76} {1}"
+        attrs = ["fmri", "flags"]
+    elif summary:
+        fmt_str = "{0:55} {1}"
+        attrs = ["namepub", "summary"]
+    else:
+        fmt_str = "{0:49} {1:26} {2}"
+        attrs = ["namepub", "version", "flags"]
+
+    # getting json output.
+    out_json = client_api._list_inventory(
+        op,
+        api_inst,
+        pargs,
+        li_parent_sync,
+        list_all,
+        list_installed_newest,
+        list_newest,
+        list_upgradable,
+        origins,
+        quiet,
+        refresh_catalogs,
+        list_removable=list_removable,
+    )
+
+    errors = None
+    if "errors" in out_json:
+        errors = out_json["errors"]
+        errors = _generate_error_messages(
+            out_json["status"],
+            errors,
+            selected_type=["catalog_refresh", "catalog_refresh_failed"],
+        )
+
+    if accumulate:
+        data = list(gen())
+        fmt_str = calc_fmtstr(attrs, data)
+    else:
+        data = list(gen())
+
+    if len(data) == 0:
+        omit_headers = True
+
+    format_output(attrs, fields, data, output_format, fmt_str, omit_headers)
+
+    # Print errors left.
+    if errors:
+        _generate_error_messages(out_json["status"], errors)
+
+    return out_json["status"]
+
+
+def get_tracker():
+    if global_settings.client_output_parsable_version is not None:
+        progresstracker = progress.NullProgressTracker()
+    elif global_settings.client_output_quiet:
+        progresstracker = progress.QuietProgressTracker()
+    elif global_settings.client_output_progfd:
+        # This logic handles linked images: for linked children
+        # we elide the progress output.
+        output_file = os.fdopen(global_settings.client_output_progfd, "w")
+        child_tracker = progress.LinkedChildProgressTracker(
+            output_file=output_file
+        )
+        dot_tracker = progress.DotProgressTracker(output_file=output_file)
+        progresstracker = progress.MultiProgressTracker(
+            [child_tracker, dot_tracker]
+        )
+    else:
+        try:
+            progresstracker = progress.FancyUNIXProgressTracker()
+        except progress.ProgressTrackerException:
+            progresstracker = progress.CommandLineProgressTracker()
+
+    return progresstracker
+
+
+def accept_plan_licenses(api_inst):
+    """Helper function that marks all licenses for the current plan as
+    accepted if they require acceptance."""
+
+    plan = api_inst.describe()
+    for pfmri, src, dest, accepted, displayed in plan.get_licenses():
+        if not dest.must_accept:
+            continue
+        api_inst.set_plan_license_status(pfmri, dest.license, accepted=True)
+
+
+display_plan_options = [
+    "basic",
+    "fmris",
+    "variants/facets",
+    "services",
+    "actions",
+    "boot-archive",
+]
+
+
+def __display_plan(api_inst, verbose, noexecute, op=None):
+    """Helper function to display plan to the desired degree.
+    Verbose can either be a numerical value, or a list of
+    items to display"""
+
+    if isinstance(verbose, int):
+        disp = ["basic"]
+
+        if verbose == 0 and noexecute:
+            disp.append("release-notes")
+        if verbose > 0:
+            disp.extend(
+                [
+                    "fmris",
+                    "mediators",
+                    "services",
+                    "variants/facets",
+                    "boot-archive",
+                    "release-notes",
+                    "editable",
+                    "actuators",
+                ]
+            )
+        if verbose > 1:
+            disp.append("actions")
+        if verbose > 2:
+            disp.append("solver-errors")
+    else:
+        disp = verbose
+
+    if DebugValues["plan"] and "solver-errors" not in disp:
+        disp.append("solver-errors")
+
+    plan = api_inst.describe()
+
+    if not plan:
+        return
+
+    if plan.must_display_notes():
+        disp.append("release-notes")
+
+    if api_inst.is_liveroot and not api_inst.is_active_liveroot_be:
+        # Warn the user since this isn't likely what they wanted.
+        if plan.new_be:
+            logger.warning(
+                _(
+                    """\
 
 ******************************************************************************
 WARNING: The boot environment being modified is not the active one.
          Changes made in the active BE will not be reflected on the next boot.
 ******************************************************************************
 
-"""))
-                else:
-                        logger.warning(_("""\
+"""
+                )
+            )
+        else:
+            logger.warning(
+                _(
+                    """\
 
 ******************************************************************************
 WARNING: The boot environment being modified is not the active one.
          Changes made will not be reflected on the next boot.
 ******************************************************************************
 
-"""))
+"""
+                )
+            )
 
-        # a = change(!!!) (due to fix or mediator/variant/facet)
-        # c = update
-        # r = remove
-        # i = install
-        a, r, i, c = [], [], [], []
-        for src, dest in plan.get_changes():
-                if dest is None:
-                        r.append((src, dest))
-                elif src is None:
-                        i.append((src, dest))
-                elif src != dest:
-                        c.append((src, dest))
-                else:
-                        # Changing or repairing package content (e.g. fix,
-                        # change-facet, etc.)
-                        a.append((dest, dest))
+    # a = change(!!!) (due to fix or mediator/variant/facet)
+    # c = update
+    # r = remove
+    # i = install
+    a, r, i, c = [], [], [], []
+    for src, dest in plan.get_changes():
+        if dest is None:
+            r.append((src, dest))
+        elif src is None:
+            i.append((src, dest))
+        elif src != dest:
+            c.append((src, dest))
+        else:
+            # Changing or repairing package content (e.g. fix,
+            # change-facet, etc.)
+            a.append((dest, dest))
 
-        def bool_str(val):
-                if val:
-                        return _("Yes")
-                return _("No")
+    def bool_str(val):
+        if val:
+            return _("Yes")
+        return _("No")
 
-        status = []
-        varcets = plan.get_varcets()
-        mediators = plan.get_mediators()
-        if "basic" in disp:
-                def cond_show(s1, s2, v):
-                        if v:
-                                status.append((s1, s2.format(v)))
+    status = []
+    varcets = plan.get_varcets()
+    mediators = plan.get_mediators()
+    if "basic" in disp:
 
-                cond_show(_("Packages to remove:"), "{0:d}", len(r))
-                cond_show(_("Packages to install:"), "{0:d}", len(i))
-                cond_show(_("Packages to update:"), "{0:d}", len(c))
-                if varcets or mediators:
-                        cond_show(_("Packages to change:"), "{0:d}", len(a))
-                else:
-                        cond_show(_("Packages to fix:"), "{0:d}", len(a))
-                cond_show(_("Mediators to change:"), "{0:d}", len(mediators))
-                cond_show(_("Variants/Facets to change:"), "{0:d}",
-                    len(varcets))
-                if not plan.new_be:
-                        cond_show(_("Services to change:"), "{0:d}",
-                            len(plan.services))
+        def cond_show(s1, s2, v):
+            if v:
+                status.append((s1, s2.format(v)))
 
-                if verbose:
-                        # Only show space information in verbose mode.
-                        abytes = plan.bytes_added
-                        if abytes:
-                                status.append((_("Estimated space available:"),
-                                    misc.bytes_to_str(plan.bytes_avail)))
-                                status.append((
-                                    _("Estimated space to be consumed:"),
-                                    misc.bytes_to_str(plan.bytes_added)))
+        cond_show(_("Packages to remove:"), "{0:d}", len(r))
+        cond_show(_("Packages to install:"), "{0:d}", len(i))
+        cond_show(_("Packages to update:"), "{0:d}", len(c))
+        if varcets or mediators:
+            cond_show(_("Packages to change:"), "{0:d}", len(a))
+        else:
+            cond_show(_("Packages to fix:"), "{0:d}", len(a))
+        cond_show(_("Mediators to change:"), "{0:d}", len(mediators))
+        cond_show(_("Variants/Facets to change:"), "{0:d}", len(varcets))
+        if not plan.new_be:
+            cond_show(_("Services to change:"), "{0:d}", len(plan.services))
 
-                # only display BE information if we're operating on the
-                # liveroot environment (since otherwise we'll never be
-                # manipulating BEs).
-                if api_inst.is_liveroot:
-                        status.append((_("Create boot environment:"),
-                            bool_str(plan.new_be)))
+        if verbose:
+            # Only show space information in verbose mode.
+            abytes = plan.bytes_added
+            if abytes:
+                status.append(
+                    (
+                        _("Estimated space available:"),
+                        misc.bytes_to_str(plan.bytes_avail),
+                    )
+                )
+                status.append(
+                    (
+                        _("Estimated space to be consumed:"),
+                        misc.bytes_to_str(plan.bytes_added),
+                    )
+                )
 
-                        if plan.new_be:
-                                status.append((_("Activate boot environment:"),
-                                    'Next boot only'
-                                    if plan.activate_be == 'bootnext'
-                                    else bool_str(plan.activate_be)))
-                        # plan.be_name can be undefined in the uninstall case
-                        # so test it before trying to print it out.
-                        if plan.be_name:
-                                status.append((_("Name of boot environment:"),
-                                    plan.be_name))
+        # only display BE information if we're operating on the
+        # liveroot environment (since otherwise we'll never be
+        # manipulating BEs).
+        if api_inst.is_liveroot:
+            status.append(
+                (_("Create boot environment:"), bool_str(plan.new_be))
+            )
 
-                        status.append((_("Create backup boot environment:"),
-                            bool_str(plan.backup_be)))
+            if plan.new_be:
+                status.append(
+                    (
+                        _("Activate boot environment:"),
+                        "Next boot only"
+                        if plan.activate_be == "bootnext"
+                        else bool_str(plan.activate_be),
+                    )
+                )
+            # plan.be_name can be undefined in the uninstall case
+            # so test it before trying to print it out.
+            if plan.be_name:
+                status.append((_("Name of boot environment:"), plan.be_name))
 
-        if "boot-archive" in disp:
-                status.append((_("Rebuild boot archive:"),
-                    bool_str(plan.update_boot_archive)))
+            status.append(
+                (_("Create backup boot environment:"), bool_str(plan.backup_be))
+            )
 
-        # Right-justify all status strings based on length of longest string.
-        if status:
-                rjust_status = max(len(s[0]) for s in status)
-                rjust_value = max(len(s[1]) for s in status)
-                for s in status:
-                        logger.info("{0} {1}".format(s[0].rjust(rjust_status),
-                            s[1].rjust(rjust_value)))
+    if "boot-archive" in disp:
+        status.append(
+            (_("Rebuild boot archive:"), bool_str(plan.update_boot_archive))
+        )
 
-        # Display list of removed packages in the default output.
-        # Verbose output already has this in a different form.
-        if not verbose and r and op in [PKG_OP_INSTALL, PKG_OP_UPDATE]:
-                logger.info(_("\nRemoved Packages:\n"))
-                removals = [src.pkg_stem for src, dest in r]
-                if len(r) <= 5:
-                        logger.info("  " + "\n  ".join(removals))
-                else:
-                        logger.info("  " + "\n  ".join(removals[:5]))
-                        logger.info("  ...")
-                        logger.info("  {0:d} additional removed package(s). "
-                                    "Use 'pkg history' to view "
-                                    "the full list.".format(len(r) - 5))
+    # Right-justify all status strings based on length of longest string.
+    if status:
+        rjust_status = max(len(s[0]) for s in status)
+        rjust_value = max(len(s[1]) for s in status)
+        for s in status:
+            logger.info(
+                "{0} {1}".format(
+                    s[0].rjust(rjust_status), s[1].rjust(rjust_value)
+                )
+            )
 
+    # Display list of removed packages in the default output.
+    # Verbose output already has this in a different form.
+    if not verbose and r and op in [PKG_OP_INSTALL, PKG_OP_UPDATE]:
+        logger.info(_("\nRemoved Packages:\n"))
+        removals = [src.pkg_stem for src, dest in r]
+        if len(r) <= 5:
+            logger.info("  " + "\n  ".join(removals))
+        else:
+            logger.info("  " + "\n  ".join(removals[:5]))
+            logger.info("  ...")
+            logger.info(
+                "  {0:d} additional removed package(s). "
+                "Use 'pkg history' to view "
+                "the full list.".format(len(r) - 5)
+            )
+
+    need_blank = True
+    if "mediators" in disp and mediators:
+        if need_blank:
+            logger.info("")
+
+        logger.info(_("Changed mediators:"))
+        for x in mediators:
+            logger.info("  {0}".format(x))
+        # output has trailing blank
+        need_blank = False
+
+    if "variants/facets" in disp and varcets:
+        if need_blank:
+            logger.info("")
         need_blank = True
-        if "mediators" in disp and mediators:
-                if need_blank:
-                        logger.info("")
 
-                logger.info(_("Changed mediators:"))
-                for x in mediators:
-                        logger.info("  {0}".format(x))
-                # output has trailing blank
-                need_blank = False
+        logger.info(_("Changed variants/facets:"))
+        for x in varcets:
+            logger.info("  {0}".format(x))
 
-        if "variants/facets" in disp and varcets:
+    if "solver-errors" in disp:
+        first = True
+        for l in plan.get_solver_errors():
+            if first:
                 if need_blank:
-                        logger.info("")
+                    logger.info("")
                 need_blank = True
+                logger.info(_("Solver dependency errors:"))
+                first = False
+            logger.info(l)
 
-                logger.info(_("Changed variants/facets:"))
-                for x in varcets:
-                        logger.info("  {0}".format(x))
-
-        if "solver-errors" in disp:
-                first = True
-                for l in plan.get_solver_errors():
-                        if first:
-                                if need_blank:
-                                        logger.info("")
-                                need_blank = True
-                                logger.info(_("Solver dependency errors:"))
-                                first = False
-                        logger.info(l)
-
-        if "fmris" in disp:
-                changed = collections.defaultdict(list)
-                for src, dest in itertools.chain(r, i, c, a):
-                        if src and dest:
-                                if src.publisher != dest.publisher:
-                                        pparent = "{0} -> {1}".format(
-                                            src.publisher, dest.publisher)
-                                else:
-                                        pparent = dest.publisher
-                                pname = dest.pkg_stem
-
-                                # Only display timestamp if version is same and
-                                # timestamp is not between the two fmris.
-                                sver = src.fmri.version
-                                dver = dest.fmri.version
-                                ssver = sver.get_short_version()
-                                dsver = dver.get_short_version()
-                                include_ts = (ssver == dsver and
-                                    sver.timestr != dver.timestr)
-                                if include_ts:
-                                        pver = sver.get_version(
-                                            include_build=False)
-                                else:
-                                        pver = ssver
-
-                                if src != dest:
-                                        if include_ts:
-                                                pver += " -> {0}".format(
-                                                    dver.get_version(
-                                                        include_build=False))
-                                        else:
-                                                pver += " -> {0}".format(dsver)
-
-                        elif dest:
-                                pparent = dest.publisher
-                                pname = dest.pkg_stem
-                                pver = "None -> {0}".format(
-                                    dest.fmri.version.get_short_version())
-                        else:
-                                pparent = src.publisher
-                                pname = src.pkg_stem
-                                pver = "{0} -> None".format(
-                                    src.fmri.version.get_short_version())
-
-                        changed[pparent].append((pname, pver))
-
-                if changed:
-                        if need_blank:
-                                logger.info("")
-                        need_blank = True
-
-                        logger.info(_("Changed packages:"))
-                        last_parent = None
-                        for pparent, pname, pver in (
-                            (pparent, pname, pver)
-                            for pparent in sorted(changed)
-                            for pname, pver in changed[pparent]
-                        ):
-                                if pparent != last_parent:
-                                        logger.info(pparent)
-
-                                logger.info("  {0}".format(pname))
-                                logger.info("    {0}".format(pver))
-                                last_parent = pparent
-
-                if "actuators" in disp:
-                        # print pkg which have been altered due to pkg actuators
-                        # e.g:
-                        #
-                        # Package-triggered Operations:
-                        # TriggerPackage
-                        #     update
-                        #         PackageA
-                        #         PackageB
-                        #     uninstall
-                        #         PackageC
-
-                        first = True
-                        for trigger_pkg, act_dict in plan.gen_pkg_actuators():
-                                if first:
-                                        first = False
-                                        if need_blank:
-                                                logger.info("")
-                                        need_blank = True
-                                        logger.info(
-                                            _("Package-triggered Operations:"))
-                                logger.info(trigger_pkg)
-                                for exec_op in sorted(act_dict):
-                                        logger.info("    {0}".format(exec_op))
-                                        for pkg in sorted(act_dict[exec_op]):
-                                                logger.info(
-                                                    "        {0}".format(pkg))
-
-        if "services" in disp and not plan.new_be:
-                last_action = None
-                for action, smf_fmri in plan.services:
-                        if last_action is None:
-                                if need_blank:
-                                        logger.info("")
-                                need_blank = True
-                                logger.info(_("Services:"))
-                        if action != last_action:
-                                logger.info("  {0}:".format(action))
-                        logger.info("    {0}".format(smf_fmri))
-                        last_action = action
-
-        # Displaying editable file list is redundant for pkg fix.
-        if "editable" in disp and op != PKG_OP_FIX:
-                moved, removed, installed, updated = plan.get_editable_changes()
-
-                cfg_change_fmt = "    {0}"
-                cfg_changes = []
-                first = True
-
-                def add_cfg_changes(changes, chg_hdr, chg_fmt=cfg_change_fmt):
-                        first = True
-                        for chg in changes:
-                                if first:
-                                        cfg_changes.append("  {0}".format(
-                                            chg_hdr))
-                                        first = False
-                                cfg_changes.append(chg_fmt.format(*chg))
-
-                add_cfg_changes((entry for entry in moved),
-                    _("Move:"), chg_fmt="    {0} -> {1}")
-
-                add_cfg_changes(((src,) for (src, dest) in removed),
-                    _("Remove:"))
-
-                add_cfg_changes(((dest,) for (src, dest) in installed),
-                    _("Install:"))
-
-                add_cfg_changes(((dest,) for (src, dest) in updated),
-                    _("Update:"))
-
-                if cfg_changes:
-                        if need_blank:
-                                logger.info("")
-                        need_blank = True
-                        logger.info(_("Editable files to change:"))
-                        for l in cfg_changes:
-                                logger.info(l)
-
-        if "actions" in disp:
-                if need_blank:
-                        logger.info("")
-                need_blank = True
-
-                logger.info(_("Actions:"))
-                for a in plan.get_actions():
-                        logger.info("  {0}".format(a))
-
-                seen = False
-                for (o, n) in plan.get_elided_actions():
-                        if not seen:
-                                logger.info("")
-                                logger.info(_(
-                                    "Elided due to image exclusions:"))
-                                seen = True
-
-                        logger.info(f'  {o} -> {n}')
-
-        if plan.has_release_notes():
-                if need_blank:
-                        logger.info("")
-                need_blank = True
-
-                if "release-notes" in disp:
-                        logger.info(_("Release Notes:"))
-                        for a in plan.get_release_notes():
-                                logger.info("  %s", a)
+    if "fmris" in disp:
+        changed = collections.defaultdict(list)
+        for src, dest in itertools.chain(r, i, c, a):
+            if src and dest:
+                if src.publisher != dest.publisher:
+                    pparent = "{0} -> {1}".format(src.publisher, dest.publisher)
                 else:
-                        if not plan.new_be and api_inst.is_liveroot and not DebugValues["GenerateNotesFile"]:
-                                logger.info(_("Release notes can be viewed with 'pkg history -n 1 -N'"))
-                        else:
-                                tmp_path = __write_tmp_release_notes(plan)
-                                if tmp_path:
-                                        logger.info(_("Release notes can be found in {0} before "
-                                            "rebooting.").format(tmp_path))
-                                logger.info(_("After rebooting, use 'pkg history -n 1 -N' to view release notes."))
+                    pparent = dest.publisher
+                pname = dest.pkg_stem
+
+                # Only display timestamp if version is same and
+                # timestamp is not between the two fmris.
+                sver = src.fmri.version
+                dver = dest.fmri.version
+                ssver = sver.get_short_version()
+                dsver = dver.get_short_version()
+                include_ts = ssver == dsver and sver.timestr != dver.timestr
+                if include_ts:
+                    pver = sver.get_version(include_build=False)
+                else:
+                    pver = ssver
+
+                if src != dest:
+                    if include_ts:
+                        pver += " -> {0}".format(
+                            dver.get_version(include_build=False)
+                        )
+                    else:
+                        pver += " -> {0}".format(dsver)
+
+            elif dest:
+                pparent = dest.publisher
+                pname = dest.pkg_stem
+                pver = "None -> {0}".format(
+                    dest.fmri.version.get_short_version()
+                )
+            else:
+                pparent = src.publisher
+                pname = src.pkg_stem
+                pver = "{0} -> None".format(
+                    src.fmri.version.get_short_version()
+                )
+
+            changed[pparent].append((pname, pver))
+
+        if changed:
+            if need_blank:
+                logger.info("")
+            need_blank = True
+
+            logger.info(_("Changed packages:"))
+            last_parent = None
+            for pparent, pname, pver in (
+                (pparent, pname, pver)
+                for pparent in sorted(changed)
+                for pname, pver in changed[pparent]
+            ):
+                if pparent != last_parent:
+                    logger.info(pparent)
+
+                logger.info("  {0}".format(pname))
+                logger.info("    {0}".format(pver))
+                last_parent = pparent
+
+        if "actuators" in disp:
+            # print pkg which have been altered due to pkg actuators
+            # e.g:
+            #
+            # Package-triggered Operations:
+            # TriggerPackage
+            #     update
+            #         PackageA
+            #         PackageB
+            #     uninstall
+            #         PackageC
+
+            first = True
+            for trigger_pkg, act_dict in plan.gen_pkg_actuators():
+                if first:
+                    first = False
+                    if need_blank:
+                        logger.info("")
+                    need_blank = True
+                    logger.info(_("Package-triggered Operations:"))
+                logger.info(trigger_pkg)
+                for exec_op in sorted(act_dict):
+                    logger.info("    {0}".format(exec_op))
+                    for pkg in sorted(act_dict[exec_op]):
+                        logger.info("        {0}".format(pkg))
+
+    if "services" in disp and not plan.new_be:
+        last_action = None
+        for action, smf_fmri in plan.services:
+            if last_action is None:
+                if need_blank:
+                    logger.info("")
+                need_blank = True
+                logger.info(_("Services:"))
+            if action != last_action:
+                logger.info("  {0}:".format(action))
+            logger.info("    {0}".format(smf_fmri))
+            last_action = action
+
+    # Displaying editable file list is redundant for pkg fix.
+    if "editable" in disp and op != PKG_OP_FIX:
+        moved, removed, installed, updated = plan.get_editable_changes()
+
+        cfg_change_fmt = "    {0}"
+        cfg_changes = []
+        first = True
+
+        def add_cfg_changes(changes, chg_hdr, chg_fmt=cfg_change_fmt):
+            first = True
+            for chg in changes:
+                if first:
+                    cfg_changes.append("  {0}".format(chg_hdr))
+                    first = False
+                cfg_changes.append(chg_fmt.format(*chg))
+
+        add_cfg_changes(
+            (entry for entry in moved), _("Move:"), chg_fmt="    {0} -> {1}"
+        )
+
+        add_cfg_changes(((src,) for (src, dest) in removed), _("Remove:"))
+
+        add_cfg_changes(((dest,) for (src, dest) in installed), _("Install:"))
+
+        add_cfg_changes(((dest,) for (src, dest) in updated), _("Update:"))
+
+        if cfg_changes:
+            if need_blank:
+                logger.info("")
+            need_blank = True
+            logger.info(_("Editable files to change:"))
+            for l in cfg_changes:
+                logger.info(l)
+
+    if "actions" in disp:
+        if need_blank:
+            logger.info("")
+        need_blank = True
+
+        logger.info(_("Actions:"))
+        for a in plan.get_actions():
+            logger.info("  {0}".format(a))
+
+        seen = False
+        for o, n in plan.get_elided_actions():
+            if not seen:
+                logger.info("")
+                logger.info(_("Elided due to image exclusions:"))
+                seen = True
+
+            logger.info(f"  {o} -> {n}")
+
+    if plan.has_release_notes():
+        if need_blank:
+            logger.info("")
+        need_blank = True
+
+        if "release-notes" in disp:
+            logger.info(_("Release Notes:"))
+            for a in plan.get_release_notes():
+                logger.info("  %s", a)
+        else:
+            if (
+                not plan.new_be
+                and api_inst.is_liveroot
+                and not DebugValues["GenerateNotesFile"]
+            ):
+                logger.info(
+                    _("Release notes can be viewed with 'pkg history -n 1 -N'")
+                )
+            else:
+                tmp_path = __write_tmp_release_notes(plan)
+                if tmp_path:
+                    logger.info(
+                        _(
+                            "Release notes can be found in {0} before "
+                            "rebooting."
+                        ).format(tmp_path)
+                    )
+                logger.info(
+                    _(
+                        "After rebooting, use 'pkg history -n 1 -N' to view release notes."
+                    )
+                )
+
 
 def __write_tmp_release_notes(plan):
-        """try to write release notes out to a file in /tmp and return the name"""
-        if plan.has_release_notes:
-                try:
-                        fd, path = tempfile.mkstemp(suffix=".txt", prefix="release-notes")
-                        # make file world readable
-                        os.chmod(path, 0o644)
-                        tmpfile = os.fdopen(fd, "w+")
-                        for a in plan.get_release_notes():
-                                a = misc.force_str(a)
-                                print(a, file=tmpfile)
-                        tmpfile.close()
-                        return path
-                except Exception:
-                        pass
+    """try to write release notes out to a file in /tmp and return the name"""
+    if plan.has_release_notes:
+        try:
+            fd, path = tempfile.mkstemp(suffix=".txt", prefix="release-notes")
+            # make file world readable
+            os.chmod(path, 0o644)
+            tmpfile = os.fdopen(fd, "w+")
+            for a in plan.get_release_notes():
+                a = misc.force_str(a)
+                print(a, file=tmpfile)
+            tmpfile.close()
+            return path
+        except Exception:
+            pass
+
 
 def __display_parsable_plan(api_inst, parsable_version, child_images=None):
-        """Display the parsable version of the plan."""
+    """Display the parsable version of the plan."""
 
-        assert parsable_version == 0, "parsable_version was {0!r}".format(
-            parsable_version)
-        plan = api_inst.describe()
-        # Set the default values.
-        added_fmris = []
-        removed_fmris = []
-        changed_fmris = []
-        affected_fmris = []
-        backup_be_created = False
-        new_be_created = False
-        backup_be_name = None
-        be_name = None
-        boot_archive_rebuilt = False
-        be_activated = True
-        space_available = None
-        space_required = None
-        facets_changed = []
-        variants_changed = []
-        services_affected = []
-        mediators_changed = []
-        editables_changed = []
-        pkg_actuators = {}
-        item_messages = {}
-        licenses = []
-        if child_images is None:
-                child_images = []
-        release_notes = []
+    assert parsable_version == 0, "parsable_version was {0!r}".format(
+        parsable_version
+    )
+    plan = api_inst.describe()
+    # Set the default values.
+    added_fmris = []
+    removed_fmris = []
+    changed_fmris = []
+    affected_fmris = []
+    backup_be_created = False
+    new_be_created = False
+    backup_be_name = None
+    be_name = None
+    boot_archive_rebuilt = False
+    be_activated = True
+    space_available = None
+    space_required = None
+    facets_changed = []
+    variants_changed = []
+    services_affected = []
+    mediators_changed = []
+    editables_changed = []
+    pkg_actuators = {}
+    item_messages = {}
+    licenses = []
+    if child_images is None:
+        child_images = []
+    release_notes = []
 
-        if plan:
-                for rem, add in plan.get_changes():
-                        assert rem is not None or add is not None
-                        if rem is not None and add is not None:
-                                # Lists of lists are used here becuase json will
-                                # convert lists of tuples into lists of lists
-                                # anyway.
-                                if rem.fmri == add.fmri:
-                                        affected_fmris.append(str(rem))
-                                else:
-                                        changed_fmris.append(
-                                            [str(rem), str(add)])
-                        elif rem is not None:
-                                removed_fmris.append(str(rem))
-                        else:
-                                added_fmris.append(str(add))
-                variants_changed, facets_changed = plan.varcets
-                backup_be_created = plan.backup_be
-                new_be_created = plan.new_be
-                backup_be_name = plan.backup_be_name
-                be_name = plan.be_name
-                boot_archive_rebuilt = plan.update_boot_archive
-                be_activated = plan.activate_be
-                space_available = plan.bytes_avail
-                space_required = plan.bytes_added
-                services_affected = plan.services
-                mediators_changed = plan.mediators
-                pkg_actuators = [(p, a) for (p, a) in plan.gen_pkg_actuators()]
+    if plan:
+        for rem, add in plan.get_changes():
+            assert rem is not None or add is not None
+            if rem is not None and add is not None:
+                # Lists of lists are used here becuase json will
+                # convert lists of tuples into lists of lists
+                # anyway.
+                if rem.fmri == add.fmri:
+                    affected_fmris.append(str(rem))
+                else:
+                    changed_fmris.append([str(rem), str(add)])
+            elif rem is not None:
+                removed_fmris.append(str(rem))
+            else:
+                added_fmris.append(str(add))
+        variants_changed, facets_changed = plan.varcets
+        backup_be_created = plan.backup_be
+        new_be_created = plan.new_be
+        backup_be_name = plan.backup_be_name
+        be_name = plan.be_name
+        boot_archive_rebuilt = plan.update_boot_archive
+        be_activated = plan.activate_be
+        space_available = plan.bytes_avail
+        space_required = plan.bytes_added
+        services_affected = plan.services
+        mediators_changed = plan.mediators
+        pkg_actuators = [(p, a) for (p, a) in plan.gen_pkg_actuators()]
 
-                emoved, eremoved, einstalled, eupdated = \
-                    plan.get_editable_changes()
+        emoved, eremoved, einstalled, eupdated = plan.get_editable_changes()
 
-                # Lists of lists are used here to ensure a consistent ordering
-                # and because tuples will be convereted to lists anyway; a
-                # dictionary would be more logical for the top level entries,
-                # but would make testing more difficult and this is a small,
-                # known set anyway.
-                emoved = [[e for e in entry] for entry in emoved]
-                eremoved = [src for (src, dest) in eremoved]
-                einstalled = [dest for (src, dest) in einstalled]
-                eupdated = [dest for (src, dest) in eupdated]
-                if emoved:
-                        editables_changed.append(["moved", emoved])
-                if eremoved:
-                        editables_changed.append(["removed", eremoved])
-                if einstalled:
-                        editables_changed.append(["installed", einstalled])
-                if eupdated:
-                        editables_changed.append(["updated", eupdated])
+        # Lists of lists are used here to ensure a consistent ordering
+        # and because tuples will be convereted to lists anyway; a
+        # dictionary would be more logical for the top level entries,
+        # but would make testing more difficult and this is a small,
+        # known set anyway.
+        emoved = [[e for e in entry] for entry in emoved]
+        eremoved = [src for (src, dest) in eremoved]
+        einstalled = [dest for (src, dest) in einstalled]
+        eupdated = [dest for (src, dest) in eupdated]
+        if emoved:
+            editables_changed.append(["moved", emoved])
+        if eremoved:
+            editables_changed.append(["removed", eremoved])
+        if einstalled:
+            editables_changed.append(["installed", einstalled])
+        if eupdated:
+            editables_changed.append(["updated", eupdated])
 
-                for n in plan.get_release_notes():
-                        release_notes.append(n)
+        for n in plan.get_release_notes():
+            release_notes.append(n)
 
-                for dfmri, src_li, dest_li, acc, disp in \
-                    plan.get_licenses():
-                        src_tup = ()
-                        if src_li:
-                                src_tup = (str(src_li.fmri), src_li.license,
-                                    src_li.get_text(), src_li.must_accept,
-                                    src_li.must_display)
-                        dest_tup = ()
-                        if dest_li:
-                                dest_tup = (str(dest_li.fmri), dest_li.license,
-                                    dest_li.get_text(), dest_li.must_accept,
-                                    dest_li.must_display)
-                        licenses.append(
-                            (str(dfmri), src_tup, dest_tup))
-                        api_inst.set_plan_license_status(dfmri, dest_li.license,
-                            displayed=True)
-                item_messages = plan.get_parsable_item_messages()
+        for dfmri, src_li, dest_li, acc, disp in plan.get_licenses():
+            src_tup = ()
+            if src_li:
+                src_tup = (
+                    str(src_li.fmri),
+                    src_li.license,
+                    src_li.get_text(),
+                    src_li.must_accept,
+                    src_li.must_display,
+                )
+            dest_tup = ()
+            if dest_li:
+                dest_tup = (
+                    str(dest_li.fmri),
+                    dest_li.license,
+                    dest_li.get_text(),
+                    dest_li.must_accept,
+                    dest_li.must_display,
+                )
+            licenses.append((str(dfmri), src_tup, dest_tup))
+            api_inst.set_plan_license_status(
+                dfmri, dest_li.license, displayed=True
+            )
+        item_messages = plan.get_parsable_item_messages()
 
-        ret = {
-            "activate-be": be_activated,
-            "add-packages": sorted(added_fmris),
-            "affect-packages": sorted(affected_fmris),
-            "affect-services": sorted(services_affected),
-            "backup-be-name": backup_be_name,
-            "be-name": be_name,
-            "boot-archive-rebuild": boot_archive_rebuilt,
-            "change-facets": sorted(facets_changed),
-            "change-editables": editables_changed,
-            "change-mediators": sorted(mediators_changed),
-            "change-packages": sorted(changed_fmris),
-            "change-variants": sorted(variants_changed),
-            "child-images": child_images,
-            "create-backup-be": backup_be_created,
-            "create-new-be": new_be_created,
-            "image-name": None,
-            "item-messages": item_messages,
-            "licenses": sorted(licenses, key=lambda x: (x[0], x[1], x[2])),
-            "release-notes": release_notes,
-            "remove-packages": sorted(removed_fmris),
-            "space-available": space_available,
-            "space-required": space_required,
-            "version": parsable_version,
-        }
+    ret = {
+        "activate-be": be_activated,
+        "add-packages": sorted(added_fmris),
+        "affect-packages": sorted(affected_fmris),
+        "affect-services": sorted(services_affected),
+        "backup-be-name": backup_be_name,
+        "be-name": be_name,
+        "boot-archive-rebuild": boot_archive_rebuilt,
+        "change-facets": sorted(facets_changed),
+        "change-editables": editables_changed,
+        "change-mediators": sorted(mediators_changed),
+        "change-packages": sorted(changed_fmris),
+        "change-variants": sorted(variants_changed),
+        "child-images": child_images,
+        "create-backup-be": backup_be_created,
+        "create-new-be": new_be_created,
+        "image-name": None,
+        "item-messages": item_messages,
+        "licenses": sorted(licenses, key=lambda x: (x[0], x[1], x[2])),
+        "release-notes": release_notes,
+        "remove-packages": sorted(removed_fmris),
+        "space-available": space_available,
+        "space-required": space_required,
+        "version": parsable_version,
+    }
 
-        if pkg_actuators:
-                ret["package-actuators"] = pkg_actuators
+    if pkg_actuators:
+        ret["package-actuators"] = pkg_actuators
 
-        # The image name for the parent image is always None.  If this image is
-        # a child image, then the image name will be set when the parent image
-        # processes this dictionary.
-        logger.info(json.dumps(ret))
+    # The image name for the parent image is always None.  If this image is
+    # a child image, then the image name will be set when the parent image
+    # processes this dictionary.
+    logger.info(json.dumps(ret))
+
 
 def display_plan_licenses(api_inst, show_all=False, show_req=True):
-        """Helper function to display licenses for the current plan.
+    """Helper function to display licenses for the current plan.
 
-        'show_all' is an optional boolean value indicating whether all licenses
-        should be displayed or only those that have must-display=true."""
+    'show_all' is an optional boolean value indicating whether all licenses
+    should be displayed or only those that have must-display=true."""
 
-        plan = api_inst.describe()
-        for pfmri, src, dest, accepted, displayed in plan.get_licenses():
-                if not show_all and not dest.must_display:
-                        continue
+    plan = api_inst.describe()
+    for pfmri, src, dest, accepted, displayed in plan.get_licenses():
+        if not show_all and not dest.must_display:
+            continue
 
-                if not show_all and dest.must_display and displayed:
-                        # License already displayed, so doesn't need to be
-                        # displayed again.
-                        continue
+        if not show_all and dest.must_display and displayed:
+            # License already displayed, so doesn't need to be
+            # displayed again.
+            continue
 
-                lic = dest.license
-                if show_req:
-                        logger.info("-" * 60)
-                        logger.info(_("Package: {0}").format(pfmri.get_fmri(
-                            include_build=False)))
-                        logger.info(_("License: {0}\n").format(lic))
-                        logger.info(dest.get_text())
-                        logger.info("\n")
+        lic = dest.license
+        if show_req:
+            logger.info("-" * 60)
+            logger.info(
+                _("Package: {0}").format(pfmri.get_fmri(include_build=False))
+            )
+            logger.info(_("License: {0}\n").format(lic))
+            logger.info(dest.get_text())
+            logger.info("\n")
 
-                # Mark license as having been displayed.
-                api_inst.set_plan_license_status(pfmri, lic, displayed=True)
+        # Mark license as having been displayed.
+        api_inst.set_plan_license_status(pfmri, lic, displayed=True)
 
-def display_plan(api_inst, child_image_plans, noexecute, omit_headers, op,
-    parsable_version, quiet, quiet_plan, show_licenses, stage, verbose):
-        """Display plan function."""
 
-        plan = api_inst.describe()
-        if not plan:
-                return
+def display_plan(
+    api_inst,
+    child_image_plans,
+    noexecute,
+    omit_headers,
+    op,
+    parsable_version,
+    quiet,
+    quiet_plan,
+    show_licenses,
+    stage,
+    verbose,
+):
+    """Display plan function."""
 
-        if stage not in [API_STAGE_DEFAULT, API_STAGE_PLAN] and not quiet_plan:
-                # we should have displayed licenses earlier so mark all
-                # licenses as having been displayed.
-                display_plan_licenses(api_inst, show_req=False)
-                return
+    plan = api_inst.describe()
+    if not plan:
+        return
 
-        if not quiet and parsable_version is None and \
-            api_inst.planned_nothingtodo(li_ignore_all=True) and not quiet_plan:
-                # nothing todo
-                if op == PKG_OP_UPDATE:
-                        s = _("No updates available for this image.")
-                else:
-                        s = _("No updates necessary for this image.")
-                if api_inst.ischild():
-                        s += " ({0})".format(api_inst.get_linked_name())
-                msg(s)
+    if stage not in [API_STAGE_DEFAULT, API_STAGE_PLAN] and not quiet_plan:
+        # we should have displayed licenses earlier so mark all
+        # licenses as having been displayed.
+        display_plan_licenses(api_inst, show_req=False)
+        return
 
-                if op != PKG_OP_FIX or not verbose:
-                        # Even nothingtodo, but need to continue to display INFO
-                        # message if verbose is True.
-                        return
-
-        if parsable_version is None and not quiet_plan:
-                display_plan_licenses(api_inst, show_all=show_licenses)
-
-        if not quiet and not quiet_plan:
-                __display_plan(api_inst, verbose, noexecute, op=op)
-
-        if parsable_version is not None:
-                __display_parsable_plan(api_inst, parsable_version,
-                    child_image_plans)
-        elif not quiet:
-                if not quiet_plan:
-                        # Ensure a blank line is inserted before the message
-                        # output.
-                        msg()
-
-                last_item_id = None
-                for item_id, parent_id, msg_time, msg_level, msg_type, \
-                    msg_text in plan.gen_item_messages(ordered=True):
-                        ntd = api_inst.planned_nothingtodo(li_ignore_all=True)
-                        if last_item_id is None or last_item_id != item_id:
-                                last_item_id = item_id
-                                if op == PKG_OP_FIX and not noexecute and \
-                                    msg_type == MSG_ERROR:
-                                        if ntd:
-                                                msg(_("Could not repair: {0:50}"
-                                                    ).format(item_id))
-                                        else:
-                                                msg(_("Repairing: {0:50}"
-                                                    ).format(item_id))
-
-                        if op == PKG_OP_FIX:
-                                if not verbose and msg_type == MSG_INFO:
-                                        # If verbose is False, don't display
-                                        # any INFO messages.
-                                        continue
-
-                                if not omit_headers:
-                                        omit_headers = True
-                                        msg(_("{pkg_name:70} {result:>7}").format(
-                                            pkg_name=_("PACKAGE"),
-                                            result=_("STATUS")))
-
-                        msg(msg_text)
-
-def __print_verify_result(op, api_inst, plan, noexecute, omit_headers,
-    verbose, print_packaged=True):
-        did_print_something = False
-        if print_packaged:
-                last_item_id = None
-                ntd = api_inst.planned_nothingtodo(li_ignore_all=True)
-                for item_id, parent_id, msg_time, msg_level, msg_type, \
-                    msg_text in plan.gen_item_messages(ordered=True):
-                        if msg_type == MSG_UNPACKAGED:
-                                continue
-                        if parent_id is None and last_item_id != item_id:
-                                if op == PKG_OP_FIX and not noexecute and \
-                                    msg_level == MSG_ERROR:
-                                        if ntd:
-                                                msg(_("Could not repair: {0:50}"
-                                                    ).format(item_id))
-                                        else:
-                                                msg(_("Repairing: {0:50}"
-                                                    ).format(item_id))
-
-                        if op in [PKG_OP_FIX, PKG_OP_VERIFY]:
-                                if not verbose and msg_level == MSG_INFO:
-                                        # If verbose is False, don't display
-                                        # any INFO messages.
-                                        continue
-
-                                if not omit_headers:
-                                        omit_headers = True
-                                        msg(_("{pkg_name:70} {result:>7}"
-                                            ).format(pkg_name=_("PACKAGE"),
-                                            result=_("STATUS")))
-
-                        # Top level message.
-                        if not parent_id:
-                                msg(msg_text)
-                        elif last_item_id != item_id:
-                                # A new action id; we need to print it out and
-                                # then group its subsequent messages.
-                                msg(_("\t{0}").format(item_id))
-                                if msg_text:
-                                        msg(_("\t\t{0}").format(msg_text))
-                        else:
-                                if msg_text:
-                                        msg(_("\t\t{0}").format(msg_text))
-                        last_item_id = item_id
-                        did_print_something = True
+    if (
+        not quiet
+        and parsable_version is None
+        and api_inst.planned_nothingtodo(li_ignore_all=True)
+        and not quiet_plan
+    ):
+        # nothing todo
+        if op == PKG_OP_UPDATE:
+            s = _("No updates available for this image.")
         else:
+            s = _("No updates necessary for this image.")
+        if api_inst.ischild():
+            s += " ({0})".format(api_inst.get_linked_name())
+        msg(s)
+
+        if op != PKG_OP_FIX or not verbose:
+            # Even nothingtodo, but need to continue to display INFO
+            # message if verbose is True.
+            return
+
+    if parsable_version is None and not quiet_plan:
+        display_plan_licenses(api_inst, show_all=show_licenses)
+
+    if not quiet and not quiet_plan:
+        __display_plan(api_inst, verbose, noexecute, op=op)
+
+    if parsable_version is not None:
+        __display_parsable_plan(api_inst, parsable_version, child_image_plans)
+    elif not quiet:
+        if not quiet_plan:
+            # Ensure a blank line is inserted before the message
+            # output.
+            msg()
+
+        last_item_id = None
+        for (
+            item_id,
+            parent_id,
+            msg_time,
+            msg_level,
+            msg_type,
+            msg_text,
+        ) in plan.gen_item_messages(ordered=True):
+            ntd = api_inst.planned_nothingtodo(li_ignore_all=True)
+            if last_item_id is None or last_item_id != item_id:
+                last_item_id = item_id
+                if op == PKG_OP_FIX and not noexecute and msg_type == MSG_ERROR:
+                    if ntd:
+                        msg(_("Could not repair: {0:50}").format(item_id))
+                    else:
+                        msg(_("Repairing: {0:50}").format(item_id))
+
+            if op == PKG_OP_FIX:
+                if not verbose and msg_type == MSG_INFO:
+                    # If verbose is False, don't display
+                    # any INFO messages.
+                    continue
+
                 if not omit_headers:
-                        msg(_("UNPACKAGED CONTENTS"))
+                    omit_headers = True
+                    msg(
+                        _("{pkg_name:70} {result:>7}").format(
+                            pkg_name=_("PACKAGE"), result=_("STATUS")
+                        )
+                    )
 
-                # Print warning messages at the beginning.
-                for item_id, parent_id, msg_time, msg_level, msg_type, \
-                    msg_text in plan.gen_item_messages():
-                        if msg_type != MSG_UNPACKAGED:
-                                continue
-                        if msg_level == MSG_WARNING:
-                                msg(_("WARNING: {0}").format(msg_text))
-                # Print the rest of messages.
-                for item_id, parent_id, msg_time, msg_level, msg_type, \
-                    msg_text in plan.gen_item_messages(ordered=True):
-                        if msg_type != MSG_UNPACKAGED:
-                                continue
-                        if msg_level == MSG_INFO:
-                                msg(_("{0}:\n\t{1}").format(
-                                    item_id, msg_text))
-                        elif msg_level == MSG_ERROR:
-                                msg(_("ERROR: {0}").format(msg_text))
-                        did_print_something = True
-        return did_print_something
+            msg(msg_text)
 
-def display_plan_cb(api_inst, child_image_plans=None, noexecute=False,
-    omit_headers=False, op=None, parsable_version=None, quiet=False,
-    quiet_plan=False, show_licenses=False, stage=None, verbose=None,
-    unpackaged=False, unpackaged_only=False, plan_only=False):
-        """Callback function for displaying plan."""
 
-        if plan_only:
-                __display_plan(api_inst, verbose, noexecute)
-                return
+def __print_verify_result(
+    op, api_inst, plan, noexecute, omit_headers, verbose, print_packaged=True
+):
+    did_print_something = False
+    if print_packaged:
+        last_item_id = None
+        ntd = api_inst.planned_nothingtodo(li_ignore_all=True)
+        for (
+            item_id,
+            parent_id,
+            msg_time,
+            msg_level,
+            msg_type,
+            msg_text,
+        ) in plan.gen_item_messages(ordered=True):
+            if msg_type == MSG_UNPACKAGED:
+                continue
+            if parent_id is None and last_item_id != item_id:
+                if (
+                    op == PKG_OP_FIX
+                    and not noexecute
+                    and msg_level == MSG_ERROR
+                ):
+                    if ntd:
+                        msg(_("Could not repair: {0:50}").format(item_id))
+                    else:
+                        msg(_("Repairing: {0:50}").format(item_id))
 
-        plan = api_inst.describe()
-        if not plan:
-                return
+            if op in [PKG_OP_FIX, PKG_OP_VERIFY]:
+                if not verbose and msg_level == MSG_INFO:
+                    # If verbose is False, don't display
+                    # any INFO messages.
+                    continue
 
-        if stage not in [API_STAGE_DEFAULT, API_STAGE_PLAN] and not quiet_plan:
-                # we should have displayed licenses earlier so mark all
-                # licenses as having been displayed.
-                display_plan_licenses(api_inst, show_req=False)
-                return
+                if not omit_headers:
+                    omit_headers = True
+                    msg(
+                        _("{pkg_name:70} {result:>7}").format(
+                            pkg_name=_("PACKAGE"), result=_("STATUS")
+                        )
+                    )
 
-        if not quiet and parsable_version is None and \
-            api_inst.planned_nothingtodo(li_ignore_all=True) and not quiet_plan:
-                # nothing todo
-                if op == PKG_OP_UPDATE:
-                        s = _("No updates available for this image.")
-                else:
-                        s = _("No updates necessary for this image.")
-                if api_inst.ischild():
-                        s += " ({0})".format(api_inst.get_linked_name())
-                msg(s)
+            # Top level message.
+            if not parent_id:
+                msg(msg_text)
+            elif last_item_id != item_id:
+                # A new action id; we need to print it out and
+                # then group its subsequent messages.
+                msg(_("\t{0}").format(item_id))
+                if msg_text:
+                    msg(_("\t\t{0}").format(msg_text))
+            else:
+                if msg_text:
+                    msg(_("\t\t{0}").format(msg_text))
+            last_item_id = item_id
+            did_print_something = True
+    else:
+        if not omit_headers:
+            msg(_("UNPACKAGED CONTENTS"))
 
-                if op not in [PKG_OP_FIX, PKG_OP_VERIFY] or not verbose:
-                        # Even nothingtodo, but need to continue to display INFO
-                        # message if verbose is True.
-                        return
+        # Print warning messages at the beginning.
+        for (
+            item_id,
+            parent_id,
+            msg_time,
+            msg_level,
+            msg_type,
+            msg_text,
+        ) in plan.gen_item_messages():
+            if msg_type != MSG_UNPACKAGED:
+                continue
+            if msg_level == MSG_WARNING:
+                msg(_("WARNING: {0}").format(msg_text))
+        # Print the rest of messages.
+        for (
+            item_id,
+            parent_id,
+            msg_time,
+            msg_level,
+            msg_type,
+            msg_text,
+        ) in plan.gen_item_messages(ordered=True):
+            if msg_type != MSG_UNPACKAGED:
+                continue
+            if msg_level == MSG_INFO:
+                msg(_("{0}:\n\t{1}").format(item_id, msg_text))
+            elif msg_level == MSG_ERROR:
+                msg(_("ERROR: {0}").format(msg_text))
+            did_print_something = True
+    return did_print_something
 
-        if parsable_version is None and not quiet_plan:
-                display_plan_licenses(api_inst, show_all=show_licenses)
 
-        if not quiet and not quiet_plan:
-                __display_plan(api_inst, verbose, noexecute, op=op)
+def display_plan_cb(
+    api_inst,
+    child_image_plans=None,
+    noexecute=False,
+    omit_headers=False,
+    op=None,
+    parsable_version=None,
+    quiet=False,
+    quiet_plan=False,
+    show_licenses=False,
+    stage=None,
+    verbose=None,
+    unpackaged=False,
+    unpackaged_only=False,
+    plan_only=False,
+):
+    """Callback function for displaying plan."""
 
-        if parsable_version is not None:
-                parsable_plan = plan.get_parsable_plan(parsable_version,
-                    child_image_plans, api_inst=api_inst)
-                logger.info(json.dumps(parsable_plan))
-        elif not quiet:
-                if not quiet_plan:
-                        # Ensure a blank line is inserted before the message
-                        # output.
-                        msg()
+    if plan_only:
+        __display_plan(api_inst, verbose, noexecute)
+        return
 
-                # Message print for package verification result.
-                if not unpackaged_only:
-                        did_print = __print_verify_result(op, api_inst, plan,
-                            noexecute, omit_headers, verbose)
+    plan = api_inst.describe()
+    if not plan:
+        return
 
-                        # Print an extra line to separate output between
-                        # packaged and unpackaged content.
-                        if did_print and unpackaged and any(entry[4] ==
-                            MSG_UNPACKAGED for entry in
-                            plan.gen_item_messages()):
-                                msg("".join(["-"] * 80))
+    if stage not in [API_STAGE_DEFAULT, API_STAGE_PLAN] and not quiet_plan:
+        # we should have displayed licenses earlier so mark all
+        # licenses as having been displayed.
+        display_plan_licenses(api_inst, show_req=False)
+        return
 
-                if unpackaged or unpackaged_only:
-                        __print_verify_result(op, api_inst, plan, noexecute,
-                            omit_headers, verbose, print_packaged=False)
+    if (
+        not quiet
+        and parsable_version is None
+        and api_inst.planned_nothingtodo(li_ignore_all=True)
+        and not quiet_plan
+    ):
+        # nothing todo
+        if op == PKG_OP_UPDATE:
+            s = _("No updates available for this image.")
+        else:
+            s = _("No updates necessary for this image.")
+        if api_inst.ischild():
+            s += " ({0})".format(api_inst.get_linked_name())
+        msg(s)
+
+        if op not in [PKG_OP_FIX, PKG_OP_VERIFY] or not verbose:
+            # Even nothingtodo, but need to continue to display INFO
+            # message if verbose is True.
+            return
+
+    if parsable_version is None and not quiet_plan:
+        display_plan_licenses(api_inst, show_all=show_licenses)
+
+    if not quiet and not quiet_plan:
+        __display_plan(api_inst, verbose, noexecute, op=op)
+
+    if parsable_version is not None:
+        parsable_plan = plan.get_parsable_plan(
+            parsable_version, child_image_plans, api_inst=api_inst
+        )
+        logger.info(json.dumps(parsable_plan))
+    elif not quiet:
+        if not quiet_plan:
+            # Ensure a blank line is inserted before the message
+            # output.
+            msg()
+
+        # Message print for package verification result.
+        if not unpackaged_only:
+            did_print = __print_verify_result(
+                op, api_inst, plan, noexecute, omit_headers, verbose
+            )
+
+            # Print an extra line to separate output between
+            # packaged and unpackaged content.
+            if (
+                did_print
+                and unpackaged
+                and any(
+                    entry[4] == MSG_UNPACKAGED
+                    for entry in plan.gen_item_messages()
+                )
+            ):
+                msg("".join(["-"] * 80))
+
+        if unpackaged or unpackaged_only:
+            __print_verify_result(
+                op,
+                api_inst,
+                plan,
+                noexecute,
+                omit_headers,
+                verbose,
+                print_packaged=False,
+            )
+
 
 def __display_plan_messages(api_inst, stages=None):
-        """Print out any messages generated during the specified
-        stages."""
-        if not isinstance(stages, frozenset):
-                stages = frozenset([stages])
-        plan = api_inst.describe()
-        if not plan:
-                return
-        for item_id, parent_id, msg_time, msg_level, msg_type, msg_text in \
-            plan.gen_item_messages(ordered=True, stages=stages):
-                if msg_level == MSG_INFO:
-                        msg("\n" + _("{0}").format(msg_text))
-                elif msg_level == MSG_WARNING:
-                        emsg("\n" + _("WARNING: {0}").format(msg_text))
-                else:
-                        emsg("\n" + _("ERROR: {0}").format(msg_text))
+    """Print out any messages generated during the specified
+    stages."""
+    if not isinstance(stages, frozenset):
+        stages = frozenset([stages])
+    plan = api_inst.describe()
+    if not plan:
+        return
+    for (
+        item_id,
+        parent_id,
+        msg_time,
+        msg_level,
+        msg_type,
+        msg_text,
+    ) in plan.gen_item_messages(ordered=True, stages=stages):
+        if msg_level == MSG_INFO:
+            msg("\n" + _("{0}").format(msg_text))
+        elif msg_level == MSG_WARNING:
+            emsg("\n" + _("WARNING: {0}").format(msg_text))
+        else:
+            emsg("\n" + _("ERROR: {0}").format(msg_text))
+
 
 def __api_prepare_plan(operation, api_inst):
-        """Prepare plan."""
+    """Prepare plan."""
 
-        # Exceptions which happen here are printed in the above level, with
-        # or without some extra decoration done here.
-        # XXX would be nice to kick the progress tracker.
-        try:
-                api_inst.prepare()
-        except (api_errors.PermissionsException, api_errors.UnknownErrors) as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                error("\n" + str(e))
-                return EXIT_OOPS
-        except api_errors.TransportError as e:
-                # move past the progress tracker line.
-                msg("\n")
-                raise e
-        except api_errors.PlanLicenseErrors as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                logger.error("\n")
-                error(_("The following packages require their "
-                    "licenses to be accepted before they can be installed "
-                    "or updated: "))
-                logger.error(str(e))
-                logger.error(_("To indicate that you agree to and accept the "
-                    "terms of the licenses of the packages listed above, "
-                    "use the --accept option.  To display all of the related "
-                    "licenses, use the --licenses option."))
-                return EXIT_LICENSE
-        except api_errors.InvalidPlanError as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                error("\n" + str(e))
-                return EXIT_OOPS
-        except api_errors.ImageFormatUpdateNeeded as e:
-                format_update_error(e)
-                return EXIT_OOPS
-        except api_errors.ImageInsufficentSpace as e:
-                error(str(e))
-                return EXIT_OOPS
-        except KeyboardInterrupt:
-                raise
-        except:
-                error(_("\nAn unexpected error happened while preparing for "
-                    "{0}:").format(operation))
-                raise
-        finally:
-                __display_plan_messages(api_inst, OP_STAGE_PREP)
-        return EXIT_OK
+    # Exceptions which happen here are printed in the above level, with
+    # or without some extra decoration done here.
+    # XXX would be nice to kick the progress tracker.
+    try:
+        api_inst.prepare()
+    except (api_errors.PermissionsException, api_errors.UnknownErrors) as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        error("\n" + str(e))
+        return EXIT_OOPS
+    except api_errors.TransportError as e:
+        # move past the progress tracker line.
+        msg("\n")
+        raise e
+    except api_errors.PlanLicenseErrors as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        logger.error("\n")
+        error(
+            _(
+                "The following packages require their "
+                "licenses to be accepted before they can be installed "
+                "or updated: "
+            )
+        )
+        logger.error(str(e))
+        logger.error(
+            _(
+                "To indicate that you agree to and accept the "
+                "terms of the licenses of the packages listed above, "
+                "use the --accept option.  To display all of the related "
+                "licenses, use the --licenses option."
+            )
+        )
+        return EXIT_LICENSE
+    except api_errors.InvalidPlanError as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        error("\n" + str(e))
+        return EXIT_OOPS
+    except api_errors.ImageFormatUpdateNeeded as e:
+        format_update_error(e)
+        return EXIT_OOPS
+    except api_errors.ImageInsufficentSpace as e:
+        error(str(e))
+        return EXIT_OOPS
+    except KeyboardInterrupt:
+        raise
+    except:
+        error(
+            _(
+                "\nAn unexpected error happened while preparing for " "{0}:"
+            ).format(operation)
+        )
+        raise
+    finally:
+        __display_plan_messages(api_inst, OP_STAGE_PREP)
+    return EXIT_OK
+
 
 def __api_execute_plan(operation, api_inst):
-        """Execute plan."""
+    """Execute plan."""
 
-        rval = None
+    rval = None
+    try:
+        api_inst.execute_plan()
+        pd = api_inst.describe()
+        if pd.actuator_timed_out:
+            rval = EXIT_ACTUATOR
+        else:
+            rval = EXIT_OK
+    except RuntimeError as e:
+        error(_("{operation} failed: {err}").format(operation=operation, err=e))
+        rval = EXIT_OOPS
+    except (
+        api_errors.InvalidPlanError,
+        api_errors.ActionExecutionError,
+        api_errors.InvalidPackageErrors,
+        api_errors.PlanExclusionError,
+    ) as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        error("\n" + str(e))
+        rval = EXIT_OOPS
+    except api_errors.LinkedImageException as e:
+        error(
+            _(
+                "{operation} failed (linked image exception(s)):\n" "{err}"
+            ).format(operation=operation, err=e)
+        )
+        rval = e.lix_exitrv
+    except api_errors.ImageUpdateOnLiveImageException:
+        error(_("{0} cannot be done on live image").format(operation))
+        rval = EXIT_NOTLIVE
+    except api_errors.RebootNeededOnLiveImageException:
+        error(
+            _(
+                'Requested "{0}" operation would affect files that '
+                "cannot be modified in live image.\n"
+                "Please retry this operation on an alternate boot "
+                "environment."
+            ).format(operation)
+        )
+        rval = EXIT_NOTLIVE
+    except api_errors.CorruptedIndexException as e:
+        error(
+            "The search index appears corrupted.  Please rebuild the "
+            "index with 'pkg rebuild-index'."
+        )
+        rval = EXIT_OOPS
+    except api_errors.ProblematicPermissionsIndexException as e:
+        error(str(e))
+        error(
+            _(
+                "\n(Failure to consistently execute pkg commands as a "
+                "privileged user is often a source of this problem.)"
+            )
+        )
+        rval = EXIT_OOPS
+    except (api_errors.PermissionsException, api_errors.UnknownErrors) as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        error("\n" + str(e))
+        rval = EXIT_OOPS
+    except api_errors.ImageFormatUpdateNeeded as e:
+        format_update_error(e)
+        rval = EXIT_OOPS
+    except api_errors.BEException as e:
+        error(e)
+        rval = EXIT_OOPS
+    except api_errors.WrapSuccessfulIndexingException:
+        raise
+    except api_errors.ImageInsufficentSpace as e:
+        error(str(e))
+        rval = EXIT_OOPS
+    except Exception as e:
+        error(
+            _(
+                "An unexpected error happened during " "{operation}: {err}"
+            ).format(operation=operation, err=e)
+        )
+        raise
+    finally:
+        exc_type = exc_value = exc_tb = None
+        if rval is None:
+            # Store original exception so that the real cause of
+            # failure can be raised if this fails.
+            exc_type, exc_value, exc_tb = sys.exc_info()
+
+        __display_plan_messages(api_inst, OP_STAGE_EXEC)
+
         try:
-                api_inst.execute_plan()
-                pd = api_inst.describe()
-                if pd.actuator_timed_out:
-                        rval = EXIT_ACTUATOR
-                else:
-                        rval = EXIT_OK
-        except RuntimeError as e:
-                error(_("{operation} failed: {err}").format(
-                    operation=operation, err=e))
-                rval = EXIT_OOPS
-        except (api_errors.InvalidPlanError,
-            api_errors.ActionExecutionError,
-            api_errors.InvalidPackageErrors,
-            api_errors.PlanExclusionError) as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                error("\n" + str(e))
-                rval = EXIT_OOPS
-        except (api_errors.LinkedImageException) as e:
-                error(_("{operation} failed (linked image exception(s)):\n"
-                    "{err}").format(operation=operation, err=e))
-                rval = e.lix_exitrv
-        except api_errors.ImageUpdateOnLiveImageException:
-                error(_("{0} cannot be done on live image").format(operation))
-                rval = EXIT_NOTLIVE
-        except api_errors.RebootNeededOnLiveImageException:
-                error(_("Requested \"{0}\" operation would affect files that "
-                    "cannot be modified in live image.\n"
-                    "Please retry this operation on an alternate boot "
-                    "environment.").format(operation))
-                rval = EXIT_NOTLIVE
-        except api_errors.CorruptedIndexException as e:
-                error("The search index appears corrupted.  Please rebuild the "
-                    "index with 'pkg rebuild-index'.")
-                rval = EXIT_OOPS
-        except api_errors.ProblematicPermissionsIndexException as e:
-                error(str(e))
-                error(_("\n(Failure to consistently execute pkg commands as a "
-                    "privileged user is often a source of this problem.)"))
-                rval = EXIT_OOPS
-        except (api_errors.PermissionsException, api_errors.UnknownErrors) as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                error("\n" + str(e))
-                rval = EXIT_OOPS
-        except api_errors.ImageFormatUpdateNeeded as e:
-                format_update_error(e)
-                rval = EXIT_OOPS
-        except api_errors.BEException as e:
-                error(e)
-                rval = EXIT_OOPS
-        except api_errors.WrapSuccessfulIndexingException:
+            salvaged = api_inst.describe().salvaged
+            newbe = api_inst.describe().new_be
+            if salvaged and (rval == EXIT_OK or not newbe):
+                # Only show salvaged file list if populated
+                # and operation was successful, or if operation
+                # failed and a new BE was not created for
+                # the operation.
+                logger.error("")
+                logger.error(
+                    _(
+                        "The following unexpected or "
+                        "editable files and directories were\n"
+                        "salvaged while executing the requested "
+                        "package operation; they\nhave been moved "
+                        "to the displayed location in the image:\n"
+                    )
+                )
+                for opath, spath in salvaged:
+                    logger.error("  {0} -> {1}".format(opath, spath))
+        except Exception:
+            if rval is not None:
+                # Only raise exception encountered here if the
+                # exception previously raised was suppressed.
                 raise
-        except api_errors.ImageInsufficentSpace as e:
-                error(str(e))
-                rval = EXIT_OOPS
-        except Exception as e:
-                error(_("An unexpected error happened during "
-                    "{operation}: {err}").format(
-                    operation=operation, err=e))
-                raise
-        finally:
-                exc_type = exc_value = exc_tb = None
-                if rval is None:
-                        # Store original exception so that the real cause of
-                        # failure can be raised if this fails.
-                        exc_type, exc_value, exc_tb = sys.exc_info()
 
-                __display_plan_messages(api_inst, OP_STAGE_EXEC)
+        if exc_value or exc_tb:
+            if six.PY2:
+                six.reraise(exc_value, None, exc_tb)
+            else:
+                raise exc_value
 
-                try:
-                        salvaged = api_inst.describe().salvaged
-                        newbe = api_inst.describe().new_be
-                        if salvaged and (rval == EXIT_OK or not newbe):
-                                # Only show salvaged file list if populated
-                                # and operation was successful, or if operation
-                                # failed and a new BE was not created for
-                                # the operation.
-                                logger.error("")
-                                logger.error(_("The following unexpected or "
-                                    "editable files and directories were\n"
-                                    "salvaged while executing the requested "
-                                    "package operation; they\nhave been moved "
-                                    "to the displayed location in the image:\n"))
-                                for opath, spath in salvaged:
-                                        logger.error("  {0} -> {1}".format(
-                                            opath, spath))
-                except Exception:
-                        if rval is not None:
-                                # Only raise exception encountered here if the
-                                # exception previously raised was suppressed.
-                                raise
+    return rval
 
-                if exc_value or exc_tb:
-                        if six.PY2:
-                                six.reraise(exc_value, None, exc_tb)
-                        else:
-                                raise exc_value
-
-        return rval
 
 def __api_alloc(imgdir, exact_match, pkg_image_used):
-        """Allocate API instance."""
+    """Allocate API instance."""
 
-        progresstracker = get_tracker()
-        try:
-                return api.ImageInterface(imgdir, CLIENT_API_VERSION,
-                    progresstracker, None, PKG_CLIENT_NAME,
-                    exact_match=exact_match)
-        except api_errors.ImageNotFoundException as e:
-                if e.user_specified:
-                        if pkg_image_used:
-                                error(_("No image rooted at '{0}' "
-                                    "(set by $PKG_IMAGE)").format(e.user_dir))
-                        else:
-                                error(_("No image rooted at '{0}'").format(
-                                    e.user_dir))
-                else:
-                        error(_("No image found."))
-                return
-        except api_errors.PermissionsException as e:
-                error(e)
-                return
-        except api_errors.ImageFormatUpdateNeeded as e:
-                format_update_error(e)
-                return
+    progresstracker = get_tracker()
+    try:
+        return api.ImageInterface(
+            imgdir,
+            CLIENT_API_VERSION,
+            progresstracker,
+            None,
+            PKG_CLIENT_NAME,
+            exact_match=exact_match,
+        )
+    except api_errors.ImageNotFoundException as e:
+        if e.user_specified:
+            if pkg_image_used:
+                error(
+                    _("No image rooted at '{0}' " "(set by $PKG_IMAGE)").format(
+                        e.user_dir
+                    )
+                )
+            else:
+                error(_("No image rooted at '{0}'").format(e.user_dir))
+        else:
+            error(_("No image found."))
+        return
+    except api_errors.PermissionsException as e:
+        error(e)
+        return
+    except api_errors.ImageFormatUpdateNeeded as e:
+        format_update_error(e)
+        return
+
 
 def __api_plan_exception(op, noexecute, verbose, api_inst):
-        """Handle plan exception."""
+    """Handle plan exception."""
 
-        e_type, e, e_traceback = sys.exc_info()
+    e_type, e, e_traceback = sys.exc_info()
 
-        if e_type == api_errors.ImageNotFoundException:
-                error(_("No image rooted at '{0}'").format(e.user_dir), cmd=op)
-                return EXIT_OOPS
-        if e_type == api_errors.InventoryException:
-                error("\n" + _("{operation} failed (inventory exception):\n"
-                    "{err}").format(operation=op, err=e))
-                return EXIT_OOPS
-        if isinstance(e, api_errors.LinkedImageException):
-                error(_("{operation} failed (linked image exception(s)):\n"
-                    "{err}").format(operation=op, err=e))
-                return e.lix_exitrv
-        if e_type == api_errors.IpkgOutOfDateException:
-                msg(_("""\
+    if e_type == api_errors.ImageNotFoundException:
+        error(_("No image rooted at '{0}'").format(e.user_dir), cmd=op)
+        return EXIT_OOPS
+    if e_type == api_errors.InventoryException:
+        error(
+            "\n"
+            + _("{operation} failed (inventory exception):\n" "{err}").format(
+                operation=op, err=e
+            )
+        )
+        return EXIT_OOPS
+    if isinstance(e, api_errors.LinkedImageException):
+        error(
+            _(
+                "{operation} failed (linked image exception(s)):\n" "{err}"
+            ).format(operation=op, err=e)
+        )
+        return e.lix_exitrv
+    if e_type == api_errors.IpkgOutOfDateException:
+        msg(
+            _(
+                """\
 WARNING: pkg(7) appears to be out of date, and should be updated before
 running {op}.  Please update pkg(7) by executing 'pkg install
 pkg:/package/pkg' as a privileged user and then retry the {op}."""
-                    ).format(**locals()))
-                return EXIT_OOPS
-        if e_type == api_errors.NonLeafPackageException:
-                error("\n" + str(e), cmd=op)
-                return EXIT_OOPS
-        if e_type == api_errors.CatalogRefreshException:
-                display_catalog_failures(e)
-                return EXIT_OOPS
-        if e_type == api_errors.ConflictingActionErrors or \
-            e_type == api_errors.ImageBoundaryErrors:
-                if verbose:
-                        __display_plan(api_inst, verbose, noexecute)
-                error("\n" + str(e), cmd=op)
-                return EXIT_OOPS
-        if e_type in (api_errors.InvalidPlanError,
-            api_errors.ReadOnlyFileSystemException,
-            api_errors.ActionExecutionError,
-            api_errors.InvalidPackageErrors,
-            api_errors.PlanExclusionError):
-                error("\n" + str(e), cmd=op)
-                return EXIT_OOPS
-        if e_type == api_errors.ImageFormatUpdateNeeded:
-                format_update_error(e)
-                return EXIT_OOPS
+            ).format(**locals())
+        )
+        return EXIT_OOPS
+    if e_type == api_errors.NonLeafPackageException:
+        error("\n" + str(e), cmd=op)
+        return EXIT_OOPS
+    if e_type == api_errors.CatalogRefreshException:
+        display_catalog_failures(e)
+        return EXIT_OOPS
+    if (
+        e_type == api_errors.ConflictingActionErrors
+        or e_type == api_errors.ImageBoundaryErrors
+    ):
+        if verbose:
+            __display_plan(api_inst, verbose, noexecute)
+        error("\n" + str(e), cmd=op)
+        return EXIT_OOPS
+    if e_type in (
+        api_errors.InvalidPlanError,
+        api_errors.ReadOnlyFileSystemException,
+        api_errors.ActionExecutionError,
+        api_errors.InvalidPackageErrors,
+        api_errors.PlanExclusionError,
+    ):
+        error("\n" + str(e), cmd=op)
+        return EXIT_OOPS
+    if e_type == api_errors.ImageFormatUpdateNeeded:
+        format_update_error(e)
+        return EXIT_OOPS
 
-        if e_type == api_errors.ImageUpdateOnLiveImageException:
-                error("\n" + _("The proposed operation cannot be performed on "
-                    "a live image."), cmd=op)
-                return EXIT_NOTLIVE
+    if e_type == api_errors.ImageUpdateOnLiveImageException:
+        error(
+            "\n"
+            + _(
+                "The proposed operation cannot be performed on " "a live image."
+            ),
+            cmd=op,
+        )
+        return EXIT_NOTLIVE
 
-        if issubclass(e_type, api_errors.BEException):
-                error("\n" + str(e), cmd=op)
-                return EXIT_OOPS
+    if issubclass(e_type, api_errors.BEException):
+        error("\n" + str(e), cmd=op)
+        return EXIT_OOPS
 
-        if e_type == api_errors.PlanCreationException:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                txt = str(e)
-                if e.multiple_matches:
-                        txt += "\n\n" + _("Please provide one of the package "
-                            "FMRIs listed above to the install command.")
-                error("\n" + txt, cmd=op)
-                if verbose:
-                        logger.error("\n".join(e.verbose_info))
-                if e.invalid_mediations:
-                        # Bad user input for mediation.
-                        return EXIT_BADOPT
-                return EXIT_OOPS
+    if e_type == api_errors.PlanCreationException:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        txt = str(e)
+        if e.multiple_matches:
+            txt += "\n\n" + _(
+                "Please provide one of the package "
+                "FMRIs listed above to the install command."
+            )
+        error("\n" + txt, cmd=op)
+        if verbose:
+            logger.error("\n".join(e.verbose_info))
+        if e.invalid_mediations:
+            # Bad user input for mediation.
+            return EXIT_BADOPT
+        return EXIT_OOPS
 
-        if isinstance(e, (api_errors.CertificateError,
+    if isinstance(
+        e,
+        (
+            api_errors.CertificateError,
             api_errors.UnknownErrors,
             api_errors.PermissionsException,
             api_errors.InvalidPropertyValue,
-            api_errors.InvalidResourceLocation)):
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                error("\n" + str(e), cmd=op)
-                return EXIT_OOPS
-        if e_type == fmri.IllegalFmri:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                error("\n" + str(e), cmd=op)
-                return EXIT_OOPS
-        if isinstance(e, api_errors.SigningException):
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                error("\n" + str(e), cmd=op)
-                return EXIT_OOPS
-        if isinstance(e, (api_errors.UnsupportedVariantGlobbing,
-            api_errors.InvalidVarcetNames, api_errors.UnsupportedFacetChange)):
-                error(str(e), cmd=op)
-                return EXIT_OOPS
+            api_errors.InvalidResourceLocation,
+        ),
+    ):
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        error("\n" + str(e), cmd=op)
+        return EXIT_OOPS
+    if e_type == fmri.IllegalFmri:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        error("\n" + str(e), cmd=op)
+        return EXIT_OOPS
+    if isinstance(e, api_errors.SigningException):
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        error("\n" + str(e), cmd=op)
+        return EXIT_OOPS
+    if isinstance(
+        e,
+        (
+            api_errors.UnsupportedVariantGlobbing,
+            api_errors.InvalidVarcetNames,
+            api_errors.UnsupportedFacetChange,
+        ),
+    ):
+        error(str(e), cmd=op)
+        return EXIT_OOPS
 
-        # if we didn't deal with the exception above, pass it on.
-        raise
-        # NOTREACHED
+    # if we didn't deal with the exception above, pass it on.
+    raise
+    # NOTREACHED
 
-def __api_plan(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
-    _omit_headers=False, _origins=None, _parsable_version=None, _quiet=False,
-    _quiet_plan=False, _review_release_notes=False, _show_licenses=False,
-    _stage=API_STAGE_DEFAULT, _verbose=0, **kwargs):
-        """API plan invocation entry."""
 
-        # All the api interface functions that we invoke have some
-        # common arguments.  Set those up now.
-        if _op not in (PKG_OP_REVERT, PKG_OP_FIX, PKG_OP_DEHYDRATE,
-            PKG_OP_REHYDRATE):
-                kwargs["li_ignore"] = _li_ignore
-        kwargs["noexecute"] = _noexecute
-        if _origins:
-                kwargs["repos"] = _origins
-        if _stage != API_STAGE_DEFAULT:
-                kwargs["pubcheck"] = False
+def __api_plan(
+    _op,
+    _api_inst,
+    _accept=False,
+    _li_ignore=None,
+    _noexecute=False,
+    _omit_headers=False,
+    _origins=None,
+    _parsable_version=None,
+    _quiet=False,
+    _quiet_plan=False,
+    _review_release_notes=False,
+    _show_licenses=False,
+    _stage=API_STAGE_DEFAULT,
+    _verbose=0,
+    **kwargs,
+):
+    """API plan invocation entry."""
 
-        # display plan debugging information
-        if _verbose > 2:
-                DebugValues.set_value("plan", "True")
+    # All the api interface functions that we invoke have some
+    # common arguments.  Set those up now.
+    if _op not in (
+        PKG_OP_REVERT,
+        PKG_OP_FIX,
+        PKG_OP_DEHYDRATE,
+        PKG_OP_REHYDRATE,
+    ):
+        kwargs["li_ignore"] = _li_ignore
+    kwargs["noexecute"] = _noexecute
+    if _origins:
+        kwargs["repos"] = _origins
+    if _stage != API_STAGE_DEFAULT:
+        kwargs["pubcheck"] = False
 
-        # plan the requested operation
-        stuff_to_do = None
+    # display plan debugging information
+    if _verbose > 2:
+        DebugValues.set_value("plan", "True")
 
-        if _op == PKG_OP_ATTACH:
-                api_plan_func = _api_inst.gen_plan_attach
-        elif _op in [PKG_OP_CHANGE_FACET, PKG_OP_CHANGE_VARIANT]:
-                api_plan_func = _api_inst.gen_plan_change_varcets
-        elif _op == PKG_OP_DEHYDRATE:
-                api_plan_func = _api_inst.gen_plan_dehydrate
-        elif _op == PKG_OP_DETACH:
-                api_plan_func = _api_inst.gen_plan_detach
-        elif _op == PKG_OP_EXACT_INSTALL:
-                api_plan_func = _api_inst.gen_plan_exact_install
-        elif _op == PKG_OP_FIX:
-                api_plan_func = _api_inst.gen_plan_fix
-        elif _op == PKG_OP_INSTALL:
-                api_plan_func = _api_inst.gen_plan_install
-        elif _op == PKG_OP_REHYDRATE:
-                api_plan_func = _api_inst.gen_plan_rehydrate
-        elif _op == PKG_OP_REVERT:
-                api_plan_func = _api_inst.gen_plan_revert
-        elif _op == PKG_OP_SYNC:
-                api_plan_func = _api_inst.gen_plan_sync
-        elif _op == PKG_OP_UNINSTALL:
-                api_plan_func = _api_inst.gen_plan_uninstall
-        elif _op == PKG_OP_UPDATE:
-                api_plan_func = _api_inst.gen_plan_update
-        else:
-                raise RuntimeError("__api_plan() invalid op: {0}".format(_op))
+    # plan the requested operation
+    stuff_to_do = None
 
-        planned_self = False
-        child_plans = []
-        try:
-                for pd in api_plan_func(**kwargs):
-                        if planned_self:
-                                # we don't display anything for child images
-                                # since they currently do their own display
-                                # work (unless parsable output is requested).
-                                child_plans.append(pd)
-                                continue
+    if _op == PKG_OP_ATTACH:
+        api_plan_func = _api_inst.gen_plan_attach
+    elif _op in [PKG_OP_CHANGE_FACET, PKG_OP_CHANGE_VARIANT]:
+        api_plan_func = _api_inst.gen_plan_change_varcets
+    elif _op == PKG_OP_DEHYDRATE:
+        api_plan_func = _api_inst.gen_plan_dehydrate
+    elif _op == PKG_OP_DETACH:
+        api_plan_func = _api_inst.gen_plan_detach
+    elif _op == PKG_OP_EXACT_INSTALL:
+        api_plan_func = _api_inst.gen_plan_exact_install
+    elif _op == PKG_OP_FIX:
+        api_plan_func = _api_inst.gen_plan_fix
+    elif _op == PKG_OP_INSTALL:
+        api_plan_func = _api_inst.gen_plan_install
+    elif _op == PKG_OP_REHYDRATE:
+        api_plan_func = _api_inst.gen_plan_rehydrate
+    elif _op == PKG_OP_REVERT:
+        api_plan_func = _api_inst.gen_plan_revert
+    elif _op == PKG_OP_SYNC:
+        api_plan_func = _api_inst.gen_plan_sync
+    elif _op == PKG_OP_UNINSTALL:
+        api_plan_func = _api_inst.gen_plan_uninstall
+    elif _op == PKG_OP_UPDATE:
+        api_plan_func = _api_inst.gen_plan_update
+    else:
+        raise RuntimeError("__api_plan() invalid op: {0}".format(_op))
 
-                        # the first plan description is always for ourself.
-                        planned_self = True
-                        pkg_timer.record("planning", logger=logger)
+    planned_self = False
+    child_plans = []
+    try:
+        for pd in api_plan_func(**kwargs):
+            if planned_self:
+                # we don't display anything for child images
+                # since they currently do their own display
+                # work (unless parsable output is requested).
+                child_plans.append(pd)
+                continue
 
-                        # if we're in parsable mode don't display anything
-                        # until after we finish planning for all children
-                        if _parsable_version is None:
-                                display_plan(_api_inst, [], _noexecute,
-                                    _omit_headers, _op, _parsable_version,
-                                    _quiet, _quiet_plan, _show_licenses, _stage,
-                                    _verbose)
+            # the first plan description is always for ourself.
+            planned_self = True
+            pkg_timer.record("planning", logger=logger)
 
-                        # if requested accept licenses for child images.  we
-                        # have to do this before recursing into children.
-                        if _accept:
-                                accept_plan_licenses(_api_inst)
-        except:
-                rv = __api_plan_exception(_op, _noexecute, _verbose, _api_inst)
-                if rv != EXIT_OK:
-                        pkg_timer.record("planning", logger=logger)
-                        return rv
+            # if we're in parsable mode don't display anything
+            # until after we finish planning for all children
+            if _parsable_version is None:
+                display_plan(
+                    _api_inst,
+                    [],
+                    _noexecute,
+                    _omit_headers,
+                    _op,
+                    _parsable_version,
+                    _quiet,
+                    _quiet_plan,
+                    _show_licenses,
+                    _stage,
+                    _verbose,
+                )
 
-        if not planned_self:
-                # if we got an exception we didn't do planning for children
-                pkg_timer.record("planning", logger=logger)
-
-        elif _api_inst.isparent(_li_ignore):
-                # if we didn't get an exception and we're a parent image then
-                # we should have done planning for child images.
-                pkg_timer.record("planning children", logger=logger)
-
-        # if we didn't display our own plan (due to an exception), or if we're
-        # in parsable mode, then display our plan now.
-        if not planned_self or _parsable_version is not None:
-                try:
-                        display_plan(_api_inst, child_plans, _noexecute,
-                            _omit_headers, _op, _parsable_version, _quiet,
-                            _quiet_plan, _show_licenses, _stage, _verbose)
-                except api_errors.ApiException as e:
-                        error(e, cmd=_op)
-                        return EXIT_OOPS
-
-        # if we didn't accept licenses (due to an exception) then do that now.
-        if not planned_self and _accept:
+            # if requested accept licenses for child images.  we
+            # have to do this before recursing into children.
+            if _accept:
                 accept_plan_licenses(_api_inst)
+    except:
+        rv = __api_plan_exception(_op, _noexecute, _verbose, _api_inst)
+        if rv != EXIT_OK:
+            pkg_timer.record("planning", logger=logger)
+            return rv
 
-        return EXIT_OK
+    if not planned_self:
+        # if we got an exception we didn't do planning for children
+        pkg_timer.record("planning", logger=logger)
+
+    elif _api_inst.isparent(_li_ignore):
+        # if we didn't get an exception and we're a parent image then
+        # we should have done planning for child images.
+        pkg_timer.record("planning children", logger=logger)
+
+    # if we didn't display our own plan (due to an exception), or if we're
+    # in parsable mode, then display our plan now.
+    if not planned_self or _parsable_version is not None:
+        try:
+            display_plan(
+                _api_inst,
+                child_plans,
+                _noexecute,
+                _omit_headers,
+                _op,
+                _parsable_version,
+                _quiet,
+                _quiet_plan,
+                _show_licenses,
+                _stage,
+                _verbose,
+            )
+        except api_errors.ApiException as e:
+            error(e, cmd=_op)
+            return EXIT_OOPS
+
+    # if we didn't accept licenses (due to an exception) then do that now.
+    if not planned_self and _accept:
+        accept_plan_licenses(_api_inst)
+
+    return EXIT_OK
+
 
 def __api_plan_file(api_inst):
-        """Return the path to the PlanDescription save file."""
+    """Return the path to the PlanDescription save file."""
 
-        plandir = api_inst.img_plandir
-        return os.path.join(plandir, "plandesc")
+    plandir = api_inst.img_plandir
+    return os.path.join(plandir, "plandesc")
+
 
 def __api_plan_save(api_inst):
-        """Save an image plan to a file."""
+    """Save an image plan to a file."""
 
-        # get a pointer to the plan
-        plan = api_inst.describe()
+    # get a pointer to the plan
+    plan = api_inst.describe()
 
-        # save the PlanDescription to a file
-        path = __api_plan_file(api_inst)
-        oflags = os.O_CREAT | os.O_TRUNC | os.O_WRONLY
-        try:
-                fd = os.open(path, oflags, 0o644)
-                with os.fdopen(fd, "w") as fobj:
-                        plan._save(fobj)
+    # save the PlanDescription to a file
+    path = __api_plan_file(api_inst)
+    oflags = os.O_CREAT | os.O_TRUNC | os.O_WRONLY
+    try:
+        fd = os.open(path, oflags, 0o644)
+        with os.fdopen(fd, "w") as fobj:
+            plan._save(fobj)
 
-                # cleanup any old style imageplan save files
-                for f in os.listdir(api_inst.img_plandir):
-                        path = os.path.join(api_inst.img_plandir, f)
-                        if re.search(r"^actions\.[0-9]+\.json$", f):
-                                os.unlink(path)
-                        if re.search(r"^pkgs\.[0-9]+\.json$", f):
-                                os.unlink(path)
-        except OSError as e:
-                raise api_errors._convert_error(e)
+        # cleanup any old style imageplan save files
+        for f in os.listdir(api_inst.img_plandir):
+            path = os.path.join(api_inst.img_plandir, f)
+            if re.search(r"^actions\.[0-9]+\.json$", f):
+                os.unlink(path)
+            if re.search(r"^pkgs\.[0-9]+\.json$", f):
+                os.unlink(path)
+    except OSError as e:
+        raise api_errors._convert_error(e)
 
-        pkg_timer.record("saving plan", logger=logger)
+    pkg_timer.record("saving plan", logger=logger)
+
 
 def __api_plan_load(api_inst, stage, origins):
-        """Loan an image plan from a file."""
+    """Loan an image plan from a file."""
 
-        # load an existing plan
-        path = __api_plan_file(api_inst)
-        plan = api.PlanDescription()
-        try:
-                with open(path) as fobj:
-                        plan._load(fobj)
-        except OSError as e:
-                raise api_errors._convert_error(e)
+    # load an existing plan
+    path = __api_plan_file(api_inst)
+    plan = api.PlanDescription()
+    try:
+        with open(path) as fobj:
+            plan._load(fobj)
+    except OSError as e:
+        raise api_errors._convert_error(e)
 
-        pkg_timer.record("loading plan", logger=logger)
+    pkg_timer.record("loading plan", logger=logger)
 
-        api_inst.reset()
-        api_inst.set_alt_repos(origins)
-        api_inst.load_plan(plan, prepared=(stage == API_STAGE_EXECUTE))
-        pkg_timer.record("re-initializing plan", logger=logger)
+    api_inst.reset()
+    api_inst.set_alt_repos(origins)
+    api_inst.load_plan(plan, prepared=(stage == API_STAGE_EXECUTE))
+    pkg_timer.record("re-initializing plan", logger=logger)
 
-        if stage == API_STAGE_EXECUTE:
-                __api_plan_delete(api_inst)
+    if stage == API_STAGE_EXECUTE:
+        __api_plan_delete(api_inst)
+
 
 def __api_plan_delete(api_inst):
-        """Delete an image plan file."""
+    """Delete an image plan file."""
 
-        path = __api_plan_file(api_inst)
-        try:
-                os.unlink(path)
-        except OSError as e:
-                raise api_errors._convert_error(e)
+    path = __api_plan_file(api_inst)
+    try:
+        os.unlink(path)
+    except OSError as e:
+        raise api_errors._convert_error(e)
+
 
 def _verify_exit_code(api_inst):
-        """Determine the exit code of pkg verify, which should be based on
-        whether we find errors."""
+    """Determine the exit code of pkg verify, which should be based on
+    whether we find errors."""
 
-        plan = api_inst.describe()
-        for item_id, parent_id, msg_time, msg_level, msg_type, msg_text in \
-            plan.gen_item_messages():
-                if msg_type == MSG_ERROR:
-                        return EXIT_OOPS
-        return EXIT_OK
+    plan = api_inst.describe()
+    for (
+        item_id,
+        parent_id,
+        msg_time,
+        msg_level,
+        msg_type,
+        msg_text,
+    ) in plan.gen_item_messages():
+        if msg_type == MSG_ERROR:
+            return EXIT_OOPS
+    return EXIT_OK
 
-def __api_op(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
-    _omit_headers=False, _origins=None, _parsable_version=None, _quiet=False,
-    _quiet_plan=False, _review_release_notes=False, _show_licenses=False,
-    _stage=API_STAGE_DEFAULT, _verbose=0, **kwargs):
-        """Do something that involves the api.
 
-        Arguments prefixed with '_' are primarily used within this
-        function.  All other arguments must be specified via keyword
-        assignment and will be passed directly on to the api
-        interfaces being invoked."""
+def __api_op(
+    _op,
+    _api_inst,
+    _accept=False,
+    _li_ignore=None,
+    _noexecute=False,
+    _omit_headers=False,
+    _origins=None,
+    _parsable_version=None,
+    _quiet=False,
+    _quiet_plan=False,
+    _review_release_notes=False,
+    _show_licenses=False,
+    _stage=API_STAGE_DEFAULT,
+    _verbose=0,
+    **kwargs,
+):
+    """Do something that involves the api.
 
-        if _stage in [API_STAGE_DEFAULT, API_STAGE_PLAN]:
-                # create a new plan
-                rv = __api_plan(_op=_op, _api_inst=_api_inst,
-                    _accept=_accept, _li_ignore=_li_ignore,
-                    _noexecute=_noexecute, _omit_headers=_omit_headers,
-                    _origins=_origins, _parsable_version=_parsable_version,
-                    _quiet=_quiet, _quiet_plan=_quiet_plan,
-                    _review_release_notes=_review_release_notes,
-                    _show_licenses=_show_licenses, _stage=_stage,
-                    _verbose=_verbose, **kwargs)
+    Arguments prefixed with '_' are primarily used within this
+    function.  All other arguments must be specified via keyword
+    assignment and will be passed directly on to the api
+    interfaces being invoked."""
 
-                if rv != EXIT_OK:
-                        return rv
-                if not _noexecute and _stage == API_STAGE_PLAN:
-                        # We always save the plan, even if it is a noop.  We
-                        # do this because we want to be able to verify that we
-                        # can load and execute a noop plan.  (This mimics
-                        # normal api behavior which doesn't prevent an api
-                        # consumer from creating a noop plan and then
-                        # preparing and executing it.)
-                        __api_plan_save(_api_inst)
-                # for pkg verify
-                if _op == PKG_OP_FIX and _noexecute and _quiet_plan:
-                        return _verify_exit_code(_api_inst)
-                if _api_inst.planned_nothingtodo():
-                        return EXIT_NOP
-                if _noexecute or _stage == API_STAGE_PLAN:
-                        return EXIT_OK
-        else:
-                assert _stage in [API_STAGE_PREPARE, API_STAGE_EXECUTE]
-                __api_plan_load(_api_inst, _stage, _origins)
+    if _stage in [API_STAGE_DEFAULT, API_STAGE_PLAN]:
+        # create a new plan
+        rv = __api_plan(
+            _op=_op,
+            _api_inst=_api_inst,
+            _accept=_accept,
+            _li_ignore=_li_ignore,
+            _noexecute=_noexecute,
+            _omit_headers=_omit_headers,
+            _origins=_origins,
+            _parsable_version=_parsable_version,
+            _quiet=_quiet,
+            _quiet_plan=_quiet_plan,
+            _review_release_notes=_review_release_notes,
+            _show_licenses=_show_licenses,
+            _stage=_stage,
+            _verbose=_verbose,
+            **kwargs,
+        )
 
-        # Exceptions which happen here are printed in the above level,
-        # with or without some extra decoration done here.
-        if _stage in [API_STAGE_DEFAULT, API_STAGE_PREPARE]:
-                ret_code = __api_prepare_plan(_op, _api_inst)
-                pkg_timer.record("preparing", logger=logger)
+        if rv != EXIT_OK:
+            return rv
+        if not _noexecute and _stage == API_STAGE_PLAN:
+            # We always save the plan, even if it is a noop.  We
+            # do this because we want to be able to verify that we
+            # can load and execute a noop plan.  (This mimics
+            # normal api behavior which doesn't prevent an api
+            # consumer from creating a noop plan and then
+            # preparing and executing it.)
+            __api_plan_save(_api_inst)
+        # for pkg verify
+        if _op == PKG_OP_FIX and _noexecute and _quiet_plan:
+            return _verify_exit_code(_api_inst)
+        if _api_inst.planned_nothingtodo():
+            return EXIT_NOP
+        if _noexecute or _stage == API_STAGE_PLAN:
+            return EXIT_OK
+    else:
+        assert _stage in [API_STAGE_PREPARE, API_STAGE_EXECUTE]
+        __api_plan_load(_api_inst, _stage, _origins)
 
-                if ret_code != EXIT_OK:
-                        return ret_code
-                if _stage == API_STAGE_PREPARE:
-                        return EXIT_OK
+    # Exceptions which happen here are printed in the above level,
+    # with or without some extra decoration done here.
+    if _stage in [API_STAGE_DEFAULT, API_STAGE_PREPARE]:
+        ret_code = __api_prepare_plan(_op, _api_inst)
+        pkg_timer.record("preparing", logger=logger)
 
-        ret_code = __api_execute_plan(_op, _api_inst)
-        pkg_timer.record("executing", logger=logger)
+        if ret_code != EXIT_OK:
+            return ret_code
+        if _stage == API_STAGE_PREPARE:
+            return EXIT_OK
 
-        if _review_release_notes and ret_code == EXIT_OK and \
-            _stage == API_STAGE_DEFAULT and _api_inst.solaris_image():
-                notes_block(misc.get_release_notes_url())
+    ret_code = __api_execute_plan(_op, _api_inst)
+    pkg_timer.record("executing", logger=logger)
 
-        return ret_code
+    if (
+        _review_release_notes
+        and ret_code == EXIT_OK
+        and _stage == API_STAGE_DEFAULT
+        and _api_inst.solaris_image()
+    ):
+        notes_block(misc.get_release_notes_url())
+
+    return ret_code
+
 
 class RemoteDispatch(object):
-        """RPC Server Class which invoked by the PipedRPCServer when a RPC
-        request is recieved."""
+    """RPC Server Class which invoked by the PipedRPCServer when a RPC
+    request is recieved."""
 
-        def __dispatch(self, op, pwargs):
+    def __dispatch(self, op, pwargs):
+        pkg_timer.record("rpc dispatch wait", logger=logger)
 
-                pkg_timer.record("rpc dispatch wait", logger=logger)
+        # if we were called with no arguments then pwargs will be []
+        if pwargs == []:
+            pwargs = {}
 
-                # if we were called with no arguments then pwargs will be []
-                if pwargs == []:
-                        pwargs = {}
+        op_supported = [
+            PKG_OP_AUDIT_LINKED,
+            PKG_OP_DETACH,
+            PKG_OP_PUBCHECK,
+            PKG_OP_SYNC,
+            PKG_OP_UPDATE,
+            PKG_OP_INSTALL,
+            PKG_OP_CHANGE_FACET,
+            PKG_OP_CHANGE_VARIANT,
+            PKG_OP_UNINSTALL,
+            PKG_OP_HOTFIX_CLEANUP,
+        ]
+        if op not in op_supported:
+            raise Exception('method "{0}" is not supported'.format(op))
 
-                op_supported = [
-                    PKG_OP_AUDIT_LINKED,
-                    PKG_OP_DETACH,
-                    PKG_OP_PUBCHECK,
-                    PKG_OP_SYNC,
-                    PKG_OP_UPDATE,
-                    PKG_OP_INSTALL,
-                    PKG_OP_CHANGE_FACET,
-                    PKG_OP_CHANGE_VARIANT,
-                    PKG_OP_UNINSTALL,
-                    PKG_OP_HOTFIX_CLEANUP
-                ]
-                if op not in op_supported:
-                        raise Exception(
-                            'method "{0}" is not supported'.format(op))
+        # if a stage was specified, get it.
+        stage = pwargs.get("stage", API_STAGE_DEFAULT)
+        assert stage in api_stage_values
 
-                # if a stage was specified, get it.
-                stage = pwargs.get("stage", API_STAGE_DEFAULT)
-                assert stage in api_stage_values
+        # if we're starting a new operation, reset the api.  we do
+        # this just in case our parent updated our linked image
+        # metadata.
+        if stage in [API_STAGE_DEFAULT, API_STAGE_PLAN]:
+            _api_inst.reset()
 
-                # if we're starting a new operation, reset the api.  we do
-                # this just in case our parent updated our linked image
-                # metadata.
-                if stage in [API_STAGE_DEFAULT, API_STAGE_PLAN]:
-                        _api_inst.reset()
+        if "pargs" not in pwargs:
+            pwargs["pargs"] = []
 
-                if "pargs" not in pwargs:
-                        pwargs["pargs"] = []
+        op_func = cmds[op][0]
 
-                op_func = cmds[op][0]
+        rv = op_func(op, _api_inst, **pwargs)
 
-                rv = op_func(op, _api_inst, **pwargs)
+        if DebugValues["timings"]:
+            msg(str(pkg_timer))
+        pkg_timer.reset()
 
-                if DebugValues["timings"]:
-                        msg(str(pkg_timer))
-                pkg_timer.reset()
+        return rv
 
-                return rv
+    def _dispatch(self, op, pwargs):
+        """Primary RPC dispatch function.
 
-        def _dispatch(self, op, pwargs):
-                """Primary RPC dispatch function.
+        This function must be kept super simple because if we take an
+        exception here then no output will be generated and this
+        package remote process will silently exit with a non-zero
+        return value (and the lack of an exception message makes this
+        failure very difficult to debug).  Hence we wrap the real
+        remote dispatch routine with a call to handle_errors(), which
+        will catch and display any exceptions encountered."""
 
-                This function must be kept super simple because if we take an
-                exception here then no output will be generated and this
-                package remote process will silently exit with a non-zero
-                return value (and the lack of an exception message makes this
-                failure very difficult to debug).  Hence we wrap the real
-                remote dispatch routine with a call to handle_errors(), which
-                will catch and display any exceptions encountered."""
+        # flush output before and after every operation.
+        misc.flush_output()
+        misc.truncate_file(sys.stdout)
+        misc.truncate_file(sys.stderr)
+        rv = handle_errors(self.__dispatch, True, op, pwargs)
+        misc.flush_output()
+        return rv
 
-                # flush output before and after every operation.
-                misc.flush_output()
-                misc.truncate_file(sys.stdout)
-                misc.truncate_file(sys.stderr)
-                rv = handle_errors(self.__dispatch, True, op, pwargs)
-                misc.flush_output()
-                return rv
 
 def remote(op, api_inst, pargs, ctlfd):
-        """Execute commands from a remote pipe"""
+    """Execute commands from a remote pipe"""
 
-        #
-        # this is kinda a gross hack.  SocketServer.py uses select.select()
-        # which doesn't support file descriptors larger than FD_SETSIZE.
-        # Since ctlfd may have been allocated in a parent process with many
-        # file descriptors, it may be larger than FD_SETSIZE.  Here in the
-        # child, though, the majority of those have been closed, so os.dup()
-        # should return a lower-numbered descriptor which will work with
-        # select.select().
-        #
-        ctlfd_new = os.dup(ctlfd)
-        os.close(ctlfd)
-        ctlfd = ctlfd_new
+    #
+    # this is kinda a gross hack.  SocketServer.py uses select.select()
+    # which doesn't support file descriptors larger than FD_SETSIZE.
+    # Since ctlfd may have been allocated in a parent process with many
+    # file descriptors, it may be larger than FD_SETSIZE.  Here in the
+    # child, though, the majority of those have been closed, so os.dup()
+    # should return a lower-numbered descriptor which will work with
+    # select.select().
+    #
+    ctlfd_new = os.dup(ctlfd)
+    os.close(ctlfd)
+    ctlfd = ctlfd_new
 
-        rpc_server = pipeutils.PipedRPCServer(ctlfd)
-        rpc_server.register_introspection_functions()
-        rpc_server.register_instance(RemoteDispatch())
+    rpc_server = pipeutils.PipedRPCServer(ctlfd)
+    rpc_server.register_introspection_functions()
+    rpc_server.register_instance(RemoteDispatch())
 
-        pkg_timer.record("rpc startup", logger=logger)
-        rpc_server.serve_forever()
+    pkg_timer.record("rpc startup", logger=logger)
+    rpc_server.serve_forever()
 
-def change_variant(op, api_inst, pargs,
-    accept, act_timeout, backup_be, backup_be_name, be_activate, be_name,
-    li_ignore, li_parent_sync, li_erecurse, new_be, noexecute, origins,
-    parsable_version, quiet, refresh_catalogs, reject_pats, show_licenses,
-    stage, update_index, verbose):
-        """Attempt to change a variant associated with an image, updating
-        the image contents as necessary."""
 
-        xrval, xres = get_fmri_args(api_inst, reject_pats, cmd=op)
-        if not xrval:
-                return EXIT_OOPS
+def change_variant(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    act_timeout,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    li_ignore,
+    li_parent_sync,
+    li_erecurse,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    stage,
+    update_index,
+    verbose,
+):
+    """Attempt to change a variant associated with an image, updating
+    the image contents as necessary."""
 
-        if not pargs:
-                usage(_("{0}: no variants specified").format(op))
+    xrval, xres = get_fmri_args(api_inst, reject_pats, cmd=op)
+    if not xrval:
+        return EXIT_OOPS
 
-        variants = dict()
-        for arg in pargs:
-                # '=' is not allowed in variant names or values
-                if (len(arg.split('=')) != 2):
-                        usage(_("{0}: variants must to be of the form "
-                            "'<name>=<value>'.").format(op))
+    if not pargs:
+        usage(_("{0}: no variants specified").format(op))
 
-                # get the variant name and value
-                name, value = arg.split('=')
-                if not name.startswith("variant."):
-                        name = "variant.{0}".format(name)
+    variants = dict()
+    for arg in pargs:
+        # '=' is not allowed in variant names or values
+        if len(arg.split("=")) != 2:
+            usage(
+                _(
+                    "{0}: variants must to be of the form " "'<name>=<value>'."
+                ).format(op)
+            )
 
-                # forcibly lowercase for 'true' or 'false'
-                if not value.islower() and value.lower() in ("true", "false"):
-                        value = value.lower()
+        # get the variant name and value
+        name, value = arg.split("=")
+        if not name.startswith("variant."):
+            name = "variant.{0}".format(name)
 
-                # make sure the user didn't specify duplicate variants
-                if name in variants:
-                        usage(_("{subcmd}: duplicate variant specified: "
-                            "{variant}").format(subcmd=op, variant=name))
-                variants[name] = value
+        # forcibly lowercase for 'true' or 'false'
+        if not value.islower() and value.lower() in ("true", "false"):
+            value = value.lower()
 
-        return __api_op(op, api_inst, _accept=accept, _li_ignore=li_ignore,
-            _noexecute=noexecute, _origins=origins,
-            _parsable_version=parsable_version, _quiet=quiet,
-            _show_licenses=show_licenses, _stage=stage, _verbose=verbose,
-            act_timeout=act_timeout, backup_be=backup_be,
-            backup_be_name=backup_be_name, be_activate=be_activate,
-            be_name=be_name, li_erecurse=li_erecurse,
-            li_parent_sync=li_parent_sync, new_be=new_be,
-            refresh_catalogs=refresh_catalogs, reject_list=reject_pats,
-            update_index=update_index, variants=variants)
+        # make sure the user didn't specify duplicate variants
+        if name in variants:
+            usage(
+                _("{subcmd}: duplicate variant specified: " "{variant}").format(
+                    subcmd=op, variant=name
+                )
+            )
+        variants[name] = value
 
-def change_facet(op, api_inst, pargs,
-    accept, act_timeout, backup_be, backup_be_name, be_activate, be_name,
-    li_ignore, li_erecurse, li_parent_sync, new_be, noexecute, origins,
-    parsable_version, quiet, refresh_catalogs, reject_pats, show_licenses,
-    stage, update_index, verbose):
-        """Attempt to change the facets as specified, updating
-        image as necessary"""
+    return __api_op(
+        op,
+        api_inst,
+        _accept=accept,
+        _li_ignore=li_ignore,
+        _noexecute=noexecute,
+        _origins=origins,
+        _parsable_version=parsable_version,
+        _quiet=quiet,
+        _show_licenses=show_licenses,
+        _stage=stage,
+        _verbose=verbose,
+        act_timeout=act_timeout,
+        backup_be=backup_be,
+        backup_be_name=backup_be_name,
+        be_activate=be_activate,
+        be_name=be_name,
+        li_erecurse=li_erecurse,
+        li_parent_sync=li_parent_sync,
+        new_be=new_be,
+        refresh_catalogs=refresh_catalogs,
+        reject_list=reject_pats,
+        update_index=update_index,
+        variants=variants,
+    )
 
-        xrval, xres = get_fmri_args(api_inst, reject_pats, cmd=op)
-        if not xrval:
-                return EXIT_OOPS
 
-        if not pargs:
-                usage(_("{0}: no facets specified").format(op))
+def change_facet(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    act_timeout,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    li_ignore,
+    li_erecurse,
+    li_parent_sync,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    stage,
+    update_index,
+    verbose,
+):
+    """Attempt to change the facets as specified, updating
+    image as necessary"""
 
-        facets = {}
-        allowed_values = {
-            "TRUE" : True,
-            "FALSE": False,
-            "NONE" : None
-        }
+    xrval, xres = get_fmri_args(api_inst, reject_pats, cmd=op)
+    if not xrval:
+        return EXIT_OOPS
 
-        for arg in pargs:
+    if not pargs:
+        usage(_("{0}: no facets specified").format(op))
 
-                # '=' is not allowed in facet names or values
-                if (len(arg.split('=')) != 2):
-                        usage(_("{0}: facets must to be of the form "
-                            "'facet....=[True|False|None]'").format(op))
+    facets = {}
+    allowed_values = {"TRUE": True, "FALSE": False, "NONE": None}
 
-                # get the facet name and value
-                name, value = arg.split('=')
-                if not name.startswith("facet."):
-                        name = "facet." + name
+    for arg in pargs:
+        # '=' is not allowed in facet names or values
+        if len(arg.split("=")) != 2:
+            usage(
+                _(
+                    "{0}: facets must to be of the form "
+                    "'facet....=[True|False|None]'"
+                ).format(op)
+            )
 
-                if value.upper() not in allowed_values:
-                        usage(_("{0}: facets must to be of the form "
-                            "'facet....=[True|False|None]'.").format(op))
+        # get the facet name and value
+        name, value = arg.split("=")
+        if not name.startswith("facet."):
+            name = "facet." + name
 
-                facets[name] = allowed_values[value.upper()]
+        if value.upper() not in allowed_values:
+            usage(
+                _(
+                    "{0}: facets must to be of the form "
+                    "'facet....=[True|False|None]'."
+                ).format(op)
+            )
 
-        return __api_op(op, api_inst, _accept=accept, _li_ignore=li_ignore,
-            _noexecute=noexecute, _origins=origins,
-            _parsable_version=parsable_version, _quiet=quiet,
-            _show_licenses=show_licenses, _stage=stage, _verbose=verbose,
-            act_timeout=act_timeout, backup_be=backup_be,
-            backup_be_name=backup_be_name, be_activate=be_activate,
-            be_name=be_name, facets=facets, li_erecurse=li_erecurse,
-            li_parent_sync=li_parent_sync, new_be=new_be,
-            refresh_catalogs=refresh_catalogs, reject_list=reject_pats,
-            update_index=update_index)
+        facets[name] = allowed_values[value.upper()]
+
+    return __api_op(
+        op,
+        api_inst,
+        _accept=accept,
+        _li_ignore=li_ignore,
+        _noexecute=noexecute,
+        _origins=origins,
+        _parsable_version=parsable_version,
+        _quiet=quiet,
+        _show_licenses=show_licenses,
+        _stage=stage,
+        _verbose=verbose,
+        act_timeout=act_timeout,
+        backup_be=backup_be,
+        backup_be_name=backup_be_name,
+        be_activate=be_activate,
+        be_name=be_name,
+        facets=facets,
+        li_erecurse=li_erecurse,
+        li_parent_sync=li_parent_sync,
+        new_be=new_be,
+        refresh_catalogs=refresh_catalogs,
+        reject_list=reject_pats,
+        update_index=update_index,
+    )
+
 
 def __handle_client_json_api_output(out_json, op, api_inst):
-        """This is the main client_json_api output handling function used for
-        install, update and uninstall and so on."""
+    """This is the main client_json_api output handling function used for
+    install, update and uninstall and so on."""
 
-        if "errors" in out_json:
-                _generate_error_messages(out_json["status"],
-                    out_json["errors"], cmd=op)
+    if "errors" in out_json:
+        _generate_error_messages(out_json["status"], out_json["errors"], cmd=op)
 
-        if "data" in out_json and "release_notes_url" in out_json["data"]:
-                notes_block(out_json["data"]["release_notes_url"])
+    if "data" in out_json and "release_notes_url" in out_json["data"]:
+        notes_block(out_json["data"]["release_notes_url"])
 
-        if "data" in out_json and "repo_status" in out_json["data"]:
-                display_repo_failures(out_json["data"]["repo_status"])
+    if "data" in out_json and "repo_status" in out_json["data"]:
+        display_repo_failures(out_json["data"]["repo_status"])
 
-        __display_plan_messages(api_inst, frozenset([OP_STAGE_PREP,
-            OP_STAGE_EXEC]))
-        return out_json["status"]
+    __display_plan_messages(api_inst, frozenset([OP_STAGE_PREP, OP_STAGE_EXEC]))
+    return out_json["status"]
 
-def _emit_error_general_cb(status, err, cmd=None, selected_type=[],
-    add_info=misc.EmptyDict):
-        """Callback for emitting general errors."""
 
-        if status == EXIT_BADOPT:
-                # Usage errors are not in any specific type, print it only
-                # there is no selected type.
-                if not selected_type:
-                        usage(err["reason"], cmd=cmd)
-                else:
-                        return False
-        elif "errtype" in err:
-                if err["errtype"] == "format_update":
-                        # if the selected_type is specified and err not in selected type,
-                        # Don't print and return False.
-                        if selected_type and err["errtype"] not in selected_type:
-                                return False
-                        emsg("\n")
-                        emsg(err["reason"])
-                        emsg(_("To continue, execute 'pkg update-format' as a "
-                            "privileged user and then try again.  Please note "
-                            "that updating the format of the image will render "
-                            "it unusable with older versions of the pkg(7) "
-                            "system."))
-                elif err["errtype"] == "catalog_refresh":
-                        if selected_type and err["errtype"] not in selected_type:
-                                return False
+def _emit_error_general_cb(
+    status, err, cmd=None, selected_type=[], add_info=misc.EmptyDict
+):
+    """Callback for emitting general errors."""
 
-                        if "reason" in err:
-                                emsg(err["reason"])
-                        elif "info" in err:
-                                msg(err["info"])
-                elif err["errtype"] == "catalog_refresh_failed":
-                        if selected_type and err["errtype"] not in selected_type:
-                                return False
+    if status == EXIT_BADOPT:
+        # Usage errors are not in any specific type, print it only
+        # there is no selected type.
+        if not selected_type:
+            usage(err["reason"], cmd=cmd)
+        else:
+            return False
+    elif "errtype" in err:
+        if err["errtype"] == "format_update":
+            # if the selected_type is specified and err not in selected type,
+            # Don't print and return False.
+            if selected_type and err["errtype"] not in selected_type:
+                return False
+            emsg("\n")
+            emsg(err["reason"])
+            emsg(
+                _(
+                    "To continue, execute 'pkg update-format' as a "
+                    "privileged user and then try again.  Please note "
+                    "that updating the format of the image will render "
+                    "it unusable with older versions of the pkg(7) "
+                    "system."
+                )
+            )
+        elif err["errtype"] == "catalog_refresh":
+            if selected_type and err["errtype"] not in selected_type:
+                return False
 
-                        if "reason" in err:
-                                emsg(" ")
-                                emsg(err["reason"])
-                elif err["errtype"] == "publisher_set":
-                        if selected_type and err["errtype"] not in selected_type:
-                                return False
+            if "reason" in err:
+                emsg(err["reason"])
+            elif "info" in err:
+                msg(err["info"])
+        elif err["errtype"] == "catalog_refresh_failed":
+            if selected_type and err["errtype"] not in selected_type:
+                return False
 
-                        emsg(err["reason"])
-                elif err["errtype"] == "plan_license":
-                        if selected_type and err["errtype"] not in selected_type:
-                                return False
+            if "reason" in err:
+                emsg(" ")
+                emsg(err["reason"])
+        elif err["errtype"] == "publisher_set":
+            if selected_type and err["errtype"] not in selected_type:
+                return False
 
-                        emsg(err["reason"])
-                        emsg(_("To indicate that you "
-                            "agree to and accept the terms of the licenses of "
-                            "the packages listed above, use the --accept "
-                            "option. To display all of the related licenses, "
-                            "use the --licenses option."))
-                elif err["errtype"] in ["inventory", "inventory_extra"]:
-                        if selected_type and err["errtype"] not in selected_type:
-                                return False
+            emsg(err["reason"])
+        elif err["errtype"] == "plan_license":
+            if selected_type and err["errtype"] not in selected_type:
+                return False
 
-                        emsg(" ")
-                        emsg(err["reason"])
-                        if err["errtype"] == "inventory_extra":
-                                emsg("Use -af to allow all versions.")
-                elif err["errtype"] == "unsupported_repo_op":
-                        if selected_type and err["errtype"] not in selected_type:
-                                return False
+            emsg(err["reason"])
+            emsg(
+                _(
+                    "To indicate that you "
+                    "agree to and accept the terms of the licenses of "
+                    "the packages listed above, use the --accept "
+                    "option. To display all of the related licenses, "
+                    "use the --licenses option."
+                )
+            )
+        elif err["errtype"] in ["inventory", "inventory_extra"]:
+            if selected_type and err["errtype"] not in selected_type:
+                return False
 
-                        emsg(_("""
+            emsg(" ")
+            emsg(err["reason"])
+            if err["errtype"] == "inventory_extra":
+                emsg("Use -af to allow all versions.")
+        elif err["errtype"] == "unsupported_repo_op":
+            if selected_type and err["errtype"] not in selected_type:
+                return False
+
+            emsg(
+                _(
+                    """
 To add a publisher using this repository, execute the following command as a
 privileged user:
 
 pkg set-publisher -g {0} <publisher>
-""").format(add_info["repo_uri"]))
-                elif "info" in err:
-                        msg(err["info"])
-                elif "reason" in err:
-                        emsg(err["reason"])
-        else:
-                if selected_type:
-                        return False
+"""
+                ).format(add_info["repo_uri"])
+            )
+        elif "info" in err:
+            msg(err["info"])
+        elif "reason" in err:
+            emsg(err["reason"])
+    else:
+        if selected_type:
+            return False
 
-                if "reason" in err:
-                        emsg(err["reason"])
-                elif "info" in err:
-                        msg(err["info"])
-        return True
+        if "reason" in err:
+            emsg(err["reason"])
+        elif "info" in err:
+            msg(err["info"])
+    return True
 
-def _generate_error_messages(status, err_list,
-    msg_cb=_emit_error_general_cb, selected_type=[], cmd=None,
-    add_info=misc.EmptyDict):
-        """Generate error messages."""
 
-        errs_left = [err for err in err_list if not msg_cb(status, err,
-            selected_type=selected_type, cmd=cmd, add_info=add_info)]
-        # Return errors not being printed.
-        return errs_left
+def _generate_error_messages(
+    status,
+    err_list,
+    msg_cb=_emit_error_general_cb,
+    selected_type=[],
+    cmd=None,
+    add_info=misc.EmptyDict,
+):
+    """Generate error messages."""
 
-def exact_install(op, api_inst, pargs,
-    accept, backup_be, backup_be_name, be_activate, be_name, li_ignore,
-    li_parent_sync, new_be, noexecute, origins, parsable_version, quiet,
-    refresh_catalogs, reject_pats, show_licenses, update_index, verbose):
-        """Attempt to take package specified to INSTALLED state.
-        The operands are interpreted as glob patterns."""
+    errs_left = [
+        err
+        for err in err_list
+        if not msg_cb(
+            status, err, selected_type=selected_type, cmd=cmd, add_info=add_info
+        )
+    ]
+    # Return errors not being printed.
+    return errs_left
 
-        out_json = client_api._exact_install(op, api_inst, pargs, accept,
-            backup_be, backup_be_name, be_activate, be_name, li_ignore,
-            li_parent_sync, new_be, noexecute, origins, parsable_version,
-            quiet, refresh_catalogs, reject_pats, show_licenses, update_index,
-            verbose, display_plan_cb=display_plan_cb, logger=logger)
 
-        return  __handle_client_json_api_output(out_json, op, api_inst)
+def exact_install(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    li_ignore,
+    li_parent_sync,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    update_index,
+    verbose,
+):
+    """Attempt to take package specified to INSTALLED state.
+    The operands are interpreted as glob patterns."""
 
-def install(op, api_inst, pargs,
-    accept, act_timeout, backup_be, backup_be_name, be_activate, be_name,
-    li_ignore, li_erecurse, li_parent_sync, new_be, noexecute, origins,
-    parsable_version, quiet, refresh_catalogs, reject_pats, show_licenses,
-    stage, update_index, verbose):
-        """Attempt to take package specified to INSTALLED state.  The operands
-        are interpreted as glob patterns."""
+    out_json = client_api._exact_install(
+        op,
+        api_inst,
+        pargs,
+        accept,
+        backup_be,
+        backup_be_name,
+        be_activate,
+        be_name,
+        li_ignore,
+        li_parent_sync,
+        new_be,
+        noexecute,
+        origins,
+        parsable_version,
+        quiet,
+        refresh_catalogs,
+        reject_pats,
+        show_licenses,
+        update_index,
+        verbose,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
 
-        out_json = client_api._install(op, api_inst, pargs,
-            accept, act_timeout, backup_be, backup_be_name, be_activate,
-            be_name, li_ignore, li_erecurse, li_parent_sync, new_be, noexecute,
-            origins, parsable_version, quiet, refresh_catalogs, reject_pats,
-            show_licenses, stage, update_index, verbose,
-            display_plan_cb=display_plan_cb, logger=logger)
+    return __handle_client_json_api_output(out_json, op, api_inst)
 
-        return  __handle_client_json_api_output(out_json, op, api_inst)
 
-def update(op, api_inst, pargs, accept, act_timeout, backup_be, backup_be_name,
-    be_activate, be_name, force, ignore_missing, li_ignore, li_erecurse,
-    li_parent_sync, new_be, noexecute, origins, parsable_version, quiet,
-    refresh_catalogs, reject_pats, show_licenses, stage, update_index, verbose):
-        """Attempt to take all installed packages specified to latest
-        version."""
+def install(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    act_timeout,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    li_ignore,
+    li_erecurse,
+    li_parent_sync,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    stage,
+    update_index,
+    verbose,
+):
+    """Attempt to take package specified to INSTALLED state.  The operands
+    are interpreted as glob patterns."""
 
-        if verbose > 1:
-                # Special mode where we determine the latest version of each
-                # requested package, and pass that explicitly to the backend
-                # to elicit more meaningful error messages to aid with
-                # troubleshooting.
+    out_json = client_api._install(
+        op,
+        api_inst,
+        pargs,
+        accept,
+        act_timeout,
+        backup_be,
+        backup_be_name,
+        be_activate,
+        be_name,
+        li_ignore,
+        li_erecurse,
+        li_parent_sync,
+        new_be,
+        noexecute,
+        origins,
+        parsable_version,
+        quiet,
+        refresh_catalogs,
+        reject_pats,
+        show_licenses,
+        stage,
+        update_index,
+        verbose,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
 
-                msg("Retrieving package list...")
+    return __handle_client_json_api_output(out_json, op, api_inst)
 
-                packages = client_api._list_inventory(op='list',
-                    api_inst=api_inst, pargs=pargs, li_parent_sync=False,
-                    list_all=False, list_installed_newest=False,
-                    list_newest=True, list_upgradable=True,
-                    origins=set([]), quiet=True, refresh_catalogs=False);
 
-                msg("Retrieving list of packages to update...")
+def update(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    act_timeout,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    force,
+    ignore_missing,
+    li_ignore,
+    li_erecurse,
+    li_parent_sync,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    stage,
+    update_index,
+    verbose,
+):
+    """Attempt to take all installed packages specified to latest
+    version."""
 
-                updates = client_api._list_inventory(op='list',
-                    api_inst=api_inst, pargs=pargs, li_parent_sync=False,
-                    list_all=False, list_installed_newest=False,
-                    list_newest=False, list_upgradable=True,
-                    origins=set([]), quiet=True, refresh_catalogs=False);
+    if verbose > 1:
+        # Special mode where we determine the latest version of each
+        # requested package, and pass that explicitly to the backend
+        # to elicit more meaningful error messages to aid with
+        # troubleshooting.
 
-                if "data" in updates and "data" in packages:
+        msg("Retrieving package list...")
 
-                        # Build dictionary of packages to the latest version
-                        latestver = {
-                                'pkg://{0}/{1}'.format(e['pub'], e['pkg']) :
-                                e['version']
-                                for e in packages['data']
-                        }
+        packages = client_api._list_inventory(
+            op="list",
+            api_inst=api_inst,
+            pargs=pargs,
+            li_parent_sync=False,
+            list_all=False,
+            list_installed_newest=False,
+            list_newest=True,
+            list_upgradable=True,
+            origins=set([]),
+            quiet=True,
+            refresh_catalogs=False,
+        )
 
-                        # Build list of packages to update
-                        updatelist = [ 'pkg://{0}/{1}'.format(
-                            e['pub'], e['pkg'])
-                                for e in updates['data'] ]
+        msg("Retrieving list of packages to update...")
 
-                        pargs = [
-                                '{}@{}'.format(u, latestver[u])
-                                for u in updatelist
-                                if u in latestver
-                        ]
+        updates = client_api._list_inventory(
+            op="list",
+            api_inst=api_inst,
+            pargs=pargs,
+            li_parent_sync=False,
+            list_all=False,
+            list_installed_newest=False,
+            list_newest=False,
+            list_upgradable=True,
+            origins=set([]),
+            quiet=True,
+            refresh_catalogs=False,
+        )
 
-        out_json = client_api._update(op, api_inst, pargs, accept, act_timeout,
-            backup_be, backup_be_name, be_activate, be_name, force,
-            ignore_missing, li_ignore, li_erecurse, li_parent_sync, new_be,
-            noexecute, origins, parsable_version, quiet, refresh_catalogs,
-            reject_pats, show_licenses, stage, update_index, verbose,
-            display_plan_cb=display_plan_cb, logger=logger)
+        if "data" in updates and "data" in packages:
+            # Build dictionary of packages to the latest version
+            latestver = {
+                "pkg://{0}/{1}".format(e["pub"], e["pkg"]): e["version"]
+                for e in packages["data"]
+            }
 
-        return __handle_client_json_api_output(out_json, op, api_inst)
+            # Build list of packages to update
+            updatelist = [
+                "pkg://{0}/{1}".format(e["pub"], e["pkg"])
+                for e in updates["data"]
+            ]
+
+            pargs = [
+                "{}@{}".format(u, latestver[u])
+                for u in updatelist
+                if u in latestver
+            ]
+
+    out_json = client_api._update(
+        op,
+        api_inst,
+        pargs,
+        accept,
+        act_timeout,
+        backup_be,
+        backup_be_name,
+        be_activate,
+        be_name,
+        force,
+        ignore_missing,
+        li_ignore,
+        li_erecurse,
+        li_parent_sync,
+        new_be,
+        noexecute,
+        origins,
+        parsable_version,
+        quiet,
+        refresh_catalogs,
+        reject_pats,
+        show_licenses,
+        stage,
+        update_index,
+        verbose,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
+
+    return __handle_client_json_api_output(out_json, op, api_inst)
+
 
 def apply_hot_fix(**args):
-        """Attempt to install updates from specified hot-fix"""
+    """Attempt to install updates from specified hot-fix"""
 
-        if not args['pargs']:
-               usage(_("Source URL or file must be specified"), cmd=args['op'])
+    if not args["pargs"]:
+        usage(_("Source URL or file must be specified"), cmd=args["op"])
 
-        err = hotfix_cleanup(op=None, api_inst=args['api_inst'], pargs=None)
-        if err != EXIT_OK:
-                return err
+    err = hotfix_cleanup(op=None, api_inst=args["api_inst"], pargs=None)
+    if err != EXIT_OK:
+        return err
 
-        origin = misc.parse_uri(args['pargs'].pop(0), cwd=orig_cwd)
+    origin = misc.parse_uri(args["pargs"].pop(0), cwd=orig_cwd)
 
-        if args['verbose']:
-                msg("Resolved URL to: {0}".format(origin))
+    if args["verbose"]:
+        msg("Resolved URL to: {0}".format(origin))
 
-        base = os.path.basename(origin)
-        if not base.endswith('.p5p'): base = base + '.p5p'
-        tmp_fd, tmp_pth = tempfile.mkstemp(prefix='pkg_hfa_', suffix="_" + base)
-        tmpfiles.append(tmp_pth)
+    base = os.path.basename(origin)
+    if not base.endswith(".p5p"):
+        base = base + ".p5p"
+    tmp_fd, tmp_pth = tempfile.mkstemp(prefix="pkg_hfa_", suffix="_" + base)
+    tmpfiles.append(tmp_pth)
 
-        ######################################################################
-        # Get list of installed packages
+    ######################################################################
+    # Get list of installed packages
 
-        if args['verbose']:
-                msg("Retrieving installed package list...")
+    if args["verbose"]:
+        msg("Retrieving installed package list...")
 
-        out_json = client_api._list_inventory(op=PKG_OP_LIST,
-            api_inst=args['api_inst'], pargs='', li_parent_sync=False,
-            list_all=False, list_installed_newest=False, list_newest=False,
-            list_upgradable=False, origins=set([]), quiet=True,
-            refresh_catalogs=False);
+    out_json = client_api._list_inventory(
+        op=PKG_OP_LIST,
+        api_inst=args["api_inst"],
+        pargs="",
+        li_parent_sync=False,
+        list_all=False,
+        list_installed_newest=False,
+        list_newest=False,
+        list_upgradable=False,
+        origins=set([]),
+        quiet=True,
+        refresh_catalogs=False,
+    )
 
-        if "data" in out_json:
-                pkglist = [ 'pkg://{0}/{1}'.format(entry['pub'], entry['pkg'])
-                    for entry in out_json["data"] ]
-        else:
-                error("Could not retrieve installed package list.")
-                return EXIT_OOPS
+    if "data" in out_json:
+        pkglist = [
+            "pkg://{0}/{1}".format(entry["pub"], entry["pkg"])
+            for entry in out_json["data"]
+        ]
+    else:
+        error("Could not retrieve installed package list.")
+        return EXIT_OOPS
 
-        ######################################################################
-        # Find hot-fix archive
+    ######################################################################
+    # Find hot-fix archive
 
-        if origin.startswith("file:///"):
-                filepath = urlparse(origin, "file", allow_fragments=0)[2]
-                try:
-                        shutil.copy2(unquote(filepath), tmp_pth)
-                except Exception as e:
-                        error(e)
-                        return EXIT_OOPS
-                origin = misc.parse_uri(tmp_pth, cwd=orig_cwd)
-        elif origin.startswith("http://") or origin.startswith("https://") or \
-            origin.startswith("ftp://"):
-                # Download file to temporary area
+    if origin.startswith("file:///"):
+        filepath = urlparse(origin, "file", allow_fragments=0)[2]
+        try:
+            shutil.copy2(unquote(filepath), tmp_pth)
+        except Exception as e:
+            error(e)
+            return EXIT_OOPS
+        origin = misc.parse_uri(tmp_pth, cwd=orig_cwd)
+    elif (
+        origin.startswith("http://")
+        or origin.startswith("https://")
+        or origin.startswith("ftp://")
+    ):
+        # Download file to temporary area
 
-                if not args['quiet']:
-                        msg("Downloading hot-fix from {0}".format(origin))
-                if args['verbose']:
-                        msg("    -> {0}".format(tmp_pth))
+        if not args["quiet"]:
+            msg("Downloading hot-fix from {0}".format(origin))
+        if args["verbose"]:
+            msg("    -> {0}".format(tmp_pth))
 
-                with os.fdopen(tmp_fd, "wb") as fh:
-                        hdl = pycurl.Curl()
-                        hdl.setopt(pycurl.URL, origin)
-                        hdl.setopt(pycurl.WRITEDATA, fh)
-                        hdl.setopt(pycurl.FAILONERROR, 1)
-                        hdl.setopt(pycurl.CONNECTTIMEOUT,
-                            global_settings.PKG_CLIENT_CONNECT_TIMEOUT)
-                        #hdl.setopt(pycurl.VERBOSE, True)
-                        hdl.setopt(pycurl.USERAGENT,
-                            misc.user_agent_str(None, 'hotfix'))
-                        if args['verbose']:
-                                hdl.setopt(pycurl.NOPROGRESS, False)
-                        try:
-                                hdl.perform()
-                        except pycurl.error as err:
-                                errno, errstr = err
-                                msg("An error occurred: {0}".format(errstr))
-                                return
+        with os.fdopen(tmp_fd, "wb") as fh:
+            hdl = pycurl.Curl()
+            hdl.setopt(pycurl.URL, origin)
+            hdl.setopt(pycurl.WRITEDATA, fh)
+            hdl.setopt(pycurl.FAILONERROR, 1)
+            hdl.setopt(
+                pycurl.CONNECTTIMEOUT,
+                global_settings.PKG_CLIENT_CONNECT_TIMEOUT,
+            )
+            # hdl.setopt(pycurl.VERBOSE, True)
+            hdl.setopt(pycurl.USERAGENT, misc.user_agent_str(None, "hotfix"))
+            if args["verbose"]:
+                hdl.setopt(pycurl.NOPROGRESS, False)
+            try:
+                hdl.perform()
+            except pycurl.error as err:
+                errno, errstr = err
+                msg("An error occurred: {0}".format(errstr))
+                return
 
-                origin = misc.parse_uri(tmp_pth, cwd=orig_cwd)
+        origin = misc.parse_uri(tmp_pth, cwd=orig_cwd)
 
-                if not args['quiet']:
-                        msg("Download complete.\n")
-        else:
-               usage(_("Invalid URL"), cmd=args['op'])
+        if not args["quiet"]:
+            msg("Download complete.\n")
+    else:
+        usage(_("Invalid URL"), cmd=args["op"])
 
-        ######################################################################
-        # Determine packages held within the .p5p archive
+    ######################################################################
+    # Determine packages held within the .p5p archive
 
-        if args['verbose']:
-                msg("Scanning package archive...")
+    if args["verbose"]:
+        msg("Scanning package archive...")
 
-        # Create a transport & transport config
-        repo_uri = publisher.RepositoryURI(origin)
-        tmp_dir = tempfile.mkdtemp()
-        incoming_dir = tempfile.mkdtemp()
-        cache_dir = tempfile.mkdtemp()
-        tmpdirs.extend([tmp_dir, incoming_dir, cache_dir])
+    # Create a transport & transport config
+    repo_uri = publisher.RepositoryURI(origin)
+    tmp_dir = tempfile.mkdtemp()
+    incoming_dir = tempfile.mkdtemp()
+    cache_dir = tempfile.mkdtemp()
+    tmpdirs.extend([tmp_dir, incoming_dir, cache_dir])
 
-        xport, xport_cfg = transport.setup_transport()
-        xport_cfg.add_cache(cache_dir, readonly=False)
-        xport_cfg.incoming_root = incoming_dir
-        xport_cfg.pkg_root = tmp_dir
+    xport, xport_cfg = transport.setup_transport()
+    xport_cfg.add_cache(cache_dir, readonly=False)
+    xport_cfg.incoming_root = incoming_dir
+    xport_cfg.pkg_root = tmp_dir
 
-        # Configure target publisher.
-        xpub = transport.setup_publisher(origin, "target", xport, xport_cfg)
-        pub_data = xport.get_publisherdata(xpub)
+    # Configure target publisher.
+    xpub = transport.setup_publisher(origin, "target", xport, xport_cfg)
+    pub_data = xport.get_publisherdata(xpub)
 
-        updatelist = []
-        prefix = None
-        for p in pub_data:
-                # Refresh publisher data
-                p.repository = xpub.repository
-                p.meta_root = tempfile.mkdtemp()
-                tmpdirs.append(p.meta_root)
-                p.transport = xport
-                p.refresh(True, True)
-                if prefix and p.prefix != prefix:
-                        error("Hot-fix contains packages from multiple publishers")
-                        return EXIT_OOPS
-                prefix = p.prefix
+    updatelist = []
+    prefix = None
+    for p in pub_data:
+        # Refresh publisher data
+        p.repository = xpub.repository
+        p.meta_root = tempfile.mkdtemp()
+        tmpdirs.append(p.meta_root)
+        p.transport = xport
+        p.refresh(True, True)
+        if prefix and p.prefix != prefix:
+            error("Hot-fix contains packages from multiple publishers")
+            return EXIT_OOPS
+        prefix = p.prefix
 
-                cat = p.catalog
-                for f, states, attrs in cat.gen_packages(pubs=[p.prefix],
-                    return_fmris=True):
-                        fmri = f.get_fmri(include_build=False)
-                        try:
-                                bfmri = fmri.split('@')[0]
-                                if bfmri in pkglist:
-                                        updatelist.append(fmri)
-                                elif args['verbose']:
-                                        msg("     {0} not installed, skipping."
-                                            .format(bfmri))
-                        except:
-                                pass
+        cat = p.catalog
+        for f, states, attrs in cat.gen_packages(
+            pubs=[p.prefix], return_fmris=True
+        ):
+            fmri = f.get_fmri(include_build=False)
+            try:
+                bfmri = fmri.split("@")[0]
+                if bfmri in pkglist:
+                    updatelist.append(fmri)
+                elif args["verbose"]:
+                    msg("     {0} not installed, skipping.".format(bfmri))
+            except:
+                pass
 
-        if args['verbose']:
-                for pkg in updatelist:
-                        msg("    {0} will be updated.".format(pkg))
-                msg("")
+    if args["verbose"]:
+        for pkg in updatelist:
+            msg("    {0} will be updated.".format(pkg))
+        msg("")
 
-        op = 'update'
-        if len(updatelist) < 1:
-                if not args['pargs']:
-                        error("None of the packages in this hot-fix are installed.")
-                        return EXIT_OOPS
-                op = 'install'
-        else:
-                args['pargs'] = updatelist
+    op = "update"
+    if len(updatelist) < 1:
+        if not args["pargs"]:
+            error("None of the packages in this hot-fix are installed.")
+            return EXIT_OOPS
+        op = "install"
+    else:
+        args["pargs"] = updatelist
 
-        ######################################################################
-        # Add the hot-fix archive to the publisher
+    ######################################################################
+    # Add the hot-fix archive to the publisher
 
-        pubargs = {}
+    pubargs = {}
 
-        pubargs['api_inst'] = args['api_inst']
-        pubargs['op'] = 'set-publisher'
-        pubargs['add_origins'] = set([origin])
-        pubargs['pargs'] = [prefix]
+    pubargs["api_inst"] = args["api_inst"]
+    pubargs["op"] = "set-publisher"
+    pubargs["add_origins"] = set([origin])
+    pubargs["pargs"] = [prefix]
 
-        pubargs['ssl_key'] = None
-        pubargs['unset_ca_certs'] = []
-        pubargs['approved_ca_certs'] = []
-        pubargs['search_before'] = None
-        pubargs['sticky'] = None
-        pubargs['add_prop_values'] = {}
-        pubargs['revoked_ca_certs'] = []
-        pubargs['search_first'] = False
-        pubargs['refresh_allowed'] = True
-        pubargs['add_mirrors'] = set([])
-        pubargs['search_after'] = None
-        pubargs['disable'] = None
-        pubargs['set_props'] = {}
-        pubargs['reset_uuid'] = False
-        pubargs['remove_mirrors'] = set([])
-        pubargs['ssl_cert'] = None
-        pubargs['remove_prop_values'] = {}
-        pubargs['proxy_uri'] = None
-        pubargs['origin_uri'] = None
-        pubargs['remove_origins'] = set([])
-        pubargs['enable_origins'] = set([])
-        pubargs['disable_origins'] = set([])
-        pubargs['repo_uri'] = None
-        pubargs['unset_props'] = set([])
-        pubargs['verbose'] = args['verbose']
-        pubargs['li_erecurse'] = set([
-                lin
-                for lin, rel, path in args['api_inst'].list_linked()
-                if rel == "child"
-        ])
+    pubargs["ssl_key"] = None
+    pubargs["unset_ca_certs"] = []
+    pubargs["approved_ca_certs"] = []
+    pubargs["search_before"] = None
+    pubargs["sticky"] = None
+    pubargs["add_prop_values"] = {}
+    pubargs["revoked_ca_certs"] = []
+    pubargs["search_first"] = False
+    pubargs["refresh_allowed"] = True
+    pubargs["add_mirrors"] = set([])
+    pubargs["search_after"] = None
+    pubargs["disable"] = None
+    pubargs["set_props"] = {}
+    pubargs["reset_uuid"] = False
+    pubargs["remove_mirrors"] = set([])
+    pubargs["ssl_cert"] = None
+    pubargs["remove_prop_values"] = {}
+    pubargs["proxy_uri"] = None
+    pubargs["origin_uri"] = None
+    pubargs["remove_origins"] = set([])
+    pubargs["enable_origins"] = set([])
+    pubargs["disable_origins"] = set([])
+    pubargs["repo_uri"] = None
+    pubargs["unset_props"] = set([])
+    pubargs["verbose"] = args["verbose"]
+    pubargs["li_erecurse"] = set(
+        [
+            lin
+            for lin, rel, path in args["api_inst"].list_linked()
+            if rel == "child"
+        ]
+    )
 
-        publisher_set(**pubargs)
-        atexit.register(hotfix_cleanup, op=None, api_inst=args['api_inst'],
-            pargs=None)
+    publisher_set(**pubargs)
+    atexit.register(
+        hotfix_cleanup, op=None, api_inst=args["api_inst"], pargs=None
+    )
 
-        ######################################################################
-        # Pass off to pkg update
+    ######################################################################
+    # Pass off to pkg update
 
-        args['op'] = op
-        args['origins'] = set([])
+    args["op"] = op
+    args["origins"] = set([])
 
-        # These are options for update which are not exposed for apply-hot-fix
-        # Set to default values for this transaction, except for 'force' which
-        # is true to allow hot-fixes to be applied to pkg itself.
-        args['parsable_version'] = None
-        args['accept'] = False
-        args['reject_pats'] = []
-        args['act_timeout'] = 0
-        args['refresh_catalogs'] = True
-        args['update_index'] = True
-        args['li_ignore'] = None
-        args['stage'] = 'default'
-        args['li_parent_sync'] = True
-        args['show_licenses'] = False
-        if op == 'update':
-                args['force'] = True
-                args['ignore_missing'] = False
+    # These are options for update which are not exposed for apply-hot-fix
+    # Set to default values for this transaction, except for 'force' which
+    # is true to allow hot-fixes to be applied to pkg itself.
+    args["parsable_version"] = None
+    args["accept"] = False
+    args["reject_pats"] = []
+    args["act_timeout"] = 0
+    args["refresh_catalogs"] = True
+    args["update_index"] = True
+    args["li_ignore"] = None
+    args["stage"] = "default"
+    args["li_parent_sync"] = True
+    args["show_licenses"] = False
+    if op == "update":
+        args["force"] = True
+        args["ignore_missing"] = False
 
-        if op == 'install':
-                return install(**args)
-        else:
-                return update(**args)
+    if op == "install":
+        return install(**args)
+    else:
+        return update(**args)
 
-def uninstall(op, api_inst, pargs,
-    act_timeout, backup_be, backup_be_name, be_activate, be_name,
-    ignore_missing, li_ignore, li_erecurse, li_parent_sync, new_be, noexecute,
-    parsable_version, quiet, stage, update_index, verbose):
-        """Attempt to take package specified to DELETED state."""
 
-        out_json = client_api._uninstall(op, api_inst, pargs,
-            act_timeout, backup_be, backup_be_name, be_activate, be_name,
-            ignore_missing, li_ignore, li_erecurse, li_parent_sync, new_be,
-            noexecute, parsable_version, quiet, stage, update_index, verbose,
-            display_plan_cb=display_plan_cb, logger=logger)
+def uninstall(
+    op,
+    api_inst,
+    pargs,
+    act_timeout,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    ignore_missing,
+    li_ignore,
+    li_erecurse,
+    li_parent_sync,
+    new_be,
+    noexecute,
+    parsable_version,
+    quiet,
+    stage,
+    update_index,
+    verbose,
+):
+    """Attempt to take package specified to DELETED state."""
 
-        return __handle_client_json_api_output(out_json, op, api_inst)
+    out_json = client_api._uninstall(
+        op,
+        api_inst,
+        pargs,
+        act_timeout,
+        backup_be,
+        backup_be_name,
+        be_activate,
+        be_name,
+        ignore_missing,
+        li_ignore,
+        li_erecurse,
+        li_parent_sync,
+        new_be,
+        noexecute,
+        parsable_version,
+        quiet,
+        stage,
+        update_index,
+        verbose,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
 
-def autoremove(op, api_inst, pargs,
-    act_timeout, backup_be, backup_be_name, be_activate, be_name,
-    ignore_missing, li_ignore, li_erecurse, li_parent_sync, new_be, noexecute,
-    parsable_version, quiet, stage, update_index, verbose):
-        """Attempt to take automatically installed packages to DELETED state."""
+    return __handle_client_json_api_output(out_json, op, api_inst)
 
-        if len(pargs):
-                usage(usage_error=_("No packages can be specified."),
-                    cmd="autoremove")
 
-        # Build pargs from the list of orphaned packages that were not
-        # manually installed.
+def autoremove(
+    op,
+    api_inst,
+    pargs,
+    act_timeout,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    ignore_missing,
+    li_ignore,
+    li_erecurse,
+    li_parent_sync,
+    new_be,
+    noexecute,
+    parsable_version,
+    quiet,
+    stage,
+    update_index,
+    verbose,
+):
+    """Attempt to take automatically installed packages to DELETED state."""
 
-        out_json = client_api._list_inventory(PKG_OP_LIST, api_inst, [],
-            li_parent_sync=False, list_all=False,
-            list_installed_newest=False, list_newest=False,
-            list_upgradable=False, origins=[], quiet=quiet,
-            refresh_catalogs=False, list_removable=True)
+    if len(pargs):
+        usage(usage_error=_("No packages can be specified."), cmd="autoremove")
 
-        errors = None
-        if "errors" in out_json:
-                _generate_error_messages(out_json["status"],
-                    out_json["errors"])
-                return out_json["status"]
+    # Build pargs from the list of orphaned packages that were not
+    # manually installed.
 
-        if "data" in out_json:
-                for entry in out_json["data"]:
-                        if 'optional' in entry['states']:
-                                continue
-                        if 'manual' in entry['states']:
-                                continue
+    out_json = client_api._list_inventory(
+        PKG_OP_LIST,
+        api_inst,
+        [],
+        li_parent_sync=False,
+        list_all=False,
+        list_installed_newest=False,
+        list_newest=False,
+        list_upgradable=False,
+        origins=[],
+        quiet=quiet,
+        refresh_catalogs=False,
+        list_removable=True,
+    )
 
-                        pargs.append(entry["pkg"]);
+    errors = None
+    if "errors" in out_json:
+        _generate_error_messages(out_json["status"], out_json["errors"])
+        return out_json["status"]
 
-        if not pargs:
-                msg(_("No removable packages for this image."))
-                return EXIT_NOP
+    if "data" in out_json:
+        for entry in out_json["data"]:
+            if "optional" in entry["states"]:
+                continue
+            if "manual" in entry["states"]:
+                continue
 
-        out_json = client_api._uninstall(PKG_OP_UNINSTALL, api_inst, pargs,
-            act_timeout, backup_be, backup_be_name, be_activate, be_name,
-            ignore_missing, li_ignore, li_erecurse, li_parent_sync, new_be,
-            noexecute, parsable_version, quiet, stage, update_index, verbose,
-            display_plan_cb=display_plan_cb, logger=logger)
+            pargs.append(entry["pkg"])
 
-        return __handle_client_json_api_output(out_json, op, api_inst)
+    if not pargs:
+        msg(_("No removable packages for this image."))
+        return EXIT_NOP
+
+    out_json = client_api._uninstall(
+        PKG_OP_UNINSTALL,
+        api_inst,
+        pargs,
+        act_timeout,
+        backup_be,
+        backup_be_name,
+        be_activate,
+        be_name,
+        ignore_missing,
+        li_ignore,
+        li_erecurse,
+        li_parent_sync,
+        new_be,
+        noexecute,
+        parsable_version,
+        quiet,
+        stage,
+        update_index,
+        verbose,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
+
+    return __handle_client_json_api_output(out_json, op, api_inst)
+
 
 def clean_image(api_inst, args):
-        opts, pargs = getopt.getopt(args, "v")
-        verbose = False
-        for opt, arg in opts:
-                if opt == "-v":
-                        verbose = True
-        try:
-                api_inst.cleanup_cached_content(verbose=verbose)
-                return EXIT_OK
-        except:
-                return __api_plan_exception("clean", False, 0, api_inst)
+    opts, pargs = getopt.getopt(args, "v")
+    verbose = False
+    for opt, arg in opts:
+        if opt == "-v":
+            verbose = True
+    try:
+        api_inst.cleanup_cached_content(verbose=verbose)
+        return EXIT_OK
+    except:
+        return __api_plan_exception("clean", False, 0, api_inst)
 
-def verify(op, api_inst, pargs, omit_headers, parsable_version, quiet, verbose,
-    unpackaged, unpackaged_only, verify_paths):
-        """Determine if installed packages match manifests."""
 
-        out_json = client_api._verify(op, api_inst, pargs, omit_headers,
-            parsable_version, quiet, verbose, unpackaged, unpackaged_only,
-            display_plan_cb=display_plan_cb, logger=logger,
-            verify_paths=verify_paths)
+def verify(
+    op,
+    api_inst,
+    pargs,
+    omit_headers,
+    parsable_version,
+    quiet,
+    verbose,
+    unpackaged,
+    unpackaged_only,
+    verify_paths,
+):
+    """Determine if installed packages match manifests."""
 
-        # Print error messages.
-        if "errors" in out_json:
-                _generate_error_messages(out_json["status"],
-                    out_json["errors"], cmd=op)
+    out_json = client_api._verify(
+        op,
+        api_inst,
+        pargs,
+        omit_headers,
+        parsable_version,
+        quiet,
+        verbose,
+        unpackaged,
+        unpackaged_only,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+        verify_paths=verify_paths,
+    )
 
-        # Since the verify output has been handled by display_plan_cb, only
-        # status code needs to be returned.
-        return out_json["status"]
+    # Print error messages.
+    if "errors" in out_json:
+        _generate_error_messages(out_json["status"], out_json["errors"], cmd=op)
 
-def revert(op, api_inst, pargs,
-    backup_be, backup_be_name, be_activate, be_name, new_be, noexecute,
-    parsable_version, quiet, tagged, verbose):
-        """Attempt to revert files to their original state, either
-        via explicit path names or via tagged contents."""
+    # Since the verify output has been handled by display_plan_cb, only
+    # status code needs to be returned.
+    return out_json["status"]
 
-        if not pargs:
-                usage(_("at least one file path or tag name required"), cmd=op)
 
-        return __api_op(op, api_inst, _noexecute=noexecute, _quiet=quiet,
-            _verbose=verbose, backup_be=backup_be, be_activate=be_activate,
-            backup_be_name=backup_be_name, be_name=be_name, new_be=new_be,
-            _parsable_version=parsable_version, args=pargs, tagged=tagged)
+def revert(
+    op,
+    api_inst,
+    pargs,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    new_be,
+    noexecute,
+    parsable_version,
+    quiet,
+    tagged,
+    verbose,
+):
+    """Attempt to revert files to their original state, either
+    via explicit path names or via tagged contents."""
+
+    if not pargs:
+        usage(_("at least one file path or tag name required"), cmd=op)
+
+    return __api_op(
+        op,
+        api_inst,
+        _noexecute=noexecute,
+        _quiet=quiet,
+        _verbose=verbose,
+        backup_be=backup_be,
+        be_activate=be_activate,
+        backup_be_name=backup_be_name,
+        be_name=be_name,
+        new_be=new_be,
+        _parsable_version=parsable_version,
+        args=pargs,
+        tagged=tagged,
+    )
+
 
 def dehydrate(op, api_inst, pargs, noexecute, publishers, quiet, verbose):
-        """Minimize image size for later redeployment."""
+    """Minimize image size for later redeployment."""
 
-        return __api_op(op, api_inst, _noexecute=noexecute, _quiet=quiet,
-            _verbose=verbose, publishers=publishers)
+    return __api_op(
+        op,
+        api_inst,
+        _noexecute=noexecute,
+        _quiet=quiet,
+        _verbose=verbose,
+        publishers=publishers,
+    )
+
 
 def rehydrate(op, api_inst, pargs, noexecute, publishers, quiet, verbose):
-        """Restore content removed from a dehydrated image."""
+    """Restore content removed from a dehydrated image."""
 
-        return __api_op(op, api_inst, _noexecute=noexecute, _quiet=quiet,
-            _verbose=verbose, publishers=publishers)
+    return __api_op(
+        op,
+        api_inst,
+        _noexecute=noexecute,
+        _quiet=quiet,
+        _verbose=verbose,
+        publishers=publishers,
+    )
 
-def fix(op, api_inst, pargs, accept, backup_be, backup_be_name, be_activate,
-    be_name, new_be, noexecute, omit_headers, parsable_version, quiet,
-    show_licenses, verbose, unpackaged):
-        """Fix packaging errors found in the image."""
 
-        out_json = client_api._fix(op, api_inst, pargs, accept, backup_be,
-            backup_be_name, be_activate, be_name, new_be, noexecute,
-            omit_headers, parsable_version, quiet, show_licenses, verbose,
-            unpackaged, display_plan_cb=display_plan_cb, logger=logger)
+def fix(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    new_be,
+    noexecute,
+    omit_headers,
+    parsable_version,
+    quiet,
+    show_licenses,
+    verbose,
+    unpackaged,
+):
+    """Fix packaging errors found in the image."""
 
-        # Print error messages.
-        if "errors" in out_json:
-                _generate_error_messages(out_json["status"],
-                    out_json["errors"], cmd=op)
+    out_json = client_api._fix(
+        op,
+        api_inst,
+        pargs,
+        accept,
+        backup_be,
+        backup_be_name,
+        be_activate,
+        be_name,
+        new_be,
+        noexecute,
+        omit_headers,
+        parsable_version,
+        quiet,
+        show_licenses,
+        verbose,
+        unpackaged,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
 
-        return out_json["status"]
+    # Print error messages.
+    if "errors" in out_json:
+        _generate_error_messages(out_json["status"], out_json["errors"], cmd=op)
 
-def list_mediators(op, api_inst, pargs, omit_headers, output_format,
-    list_available):
-        """Display configured or available mediator version(s) and
-        implementation(s)."""
+    return out_json["status"]
 
-        subcommand = "mediator"
-        if output_format is None:
-                output_format = "default"
 
-        # mediator information is returned as a dictionary of dictionaries
-        # of version and implementation indexed by mediator name.
-        mediations = collections.defaultdict(list)
-        if list_available:
-                gen_mediators = api_inst.gen_available_mediators()
-        else:
-                # Configured mediator information
-                gen_mediators = (
-                    (mediator, mediation)
-                    for mediator, mediation in six.iteritems(api_inst.mediators)
-                )
+def list_mediators(
+    op, api_inst, pargs, omit_headers, output_format, list_available
+):
+    """Display configured or available mediator version(s) and
+    implementation(s)."""
 
-        # Set minimum widths for mediator and version columns by using the
-        # length of the column headers and values to be displayed.
-        mediators = set()
-        max_mname_len = len(_("MEDIATOR"))
-        max_vsrc_len = len(_("VER. SRC."))
-        max_version_len = len(_("VERSION"))
-        max_isrc_len = len(_("IMPL. SRC."))
-        for mname, values in gen_mediators:
-                max_mname_len = max(max_mname_len, len(mname))
-                med_version = values.get("version", "")
-                max_version_len = max(max_version_len, len(med_version))
-                mediators.add(mname)
-                mediations[mname].append(values)
+    subcommand = "mediator"
+    if output_format is None:
+        output_format = "default"
 
-        requested_mediators = set(pargs)
-        if requested_mediators:
-                found = mediators & requested_mediators
-                notfound = requested_mediators - found
-        else:
-                found = mediators
-                notfound = set()
+    # mediator information is returned as a dictionary of dictionaries
+    # of version and implementation indexed by mediator name.
+    mediations = collections.defaultdict(list)
+    if list_available:
+        gen_mediators = api_inst.gen_available_mediators()
+    else:
+        # Configured mediator information
+        gen_mediators = (
+            (mediator, mediation)
+            for mediator, mediation in six.iteritems(api_inst.mediators)
+        )
 
-        def gen_listing():
-                for mediator, mediation in (
-                    (mname, mentry)
-                    for mname in sorted(found)
-                    for mentry in mediations[mname]
-                ):
-                        med_impl = mediation.get("implementation")
-                        med_impl_ver = mediation.get("implementation-version")
-                        if output_format == "default" and med_impl and \
-                            med_impl_ver:
-                                med_impl += "(@{0})".format(med_impl_ver)
-                        yield {
-                            "mediator": mediator,
-                            "version": mediation.get("version"),
-                            "version-source": mediation.get("version-source"),
-                            "implementation": med_impl,
-                            "implementation-source": mediation.get(
-                                "implementation-source"),
-                            "implementation-version": med_impl_ver,
-                        }
+    # Set minimum widths for mediator and version columns by using the
+    # length of the column headers and values to be displayed.
+    mediators = set()
+    max_mname_len = len(_("MEDIATOR"))
+    max_vsrc_len = len(_("VER. SRC."))
+    max_version_len = len(_("VERSION"))
+    max_isrc_len = len(_("IMPL. SRC."))
+    for mname, values in gen_mediators:
+        max_mname_len = max(max_mname_len, len(mname))
+        med_version = values.get("version", "")
+        max_version_len = max(max_version_len, len(med_version))
+        mediators.add(mname)
+        mediations[mname].append(values)
 
-        #    MEDIATOR VER. SRC.  VERSION IMPL. SRC. IMPLEMENTATION IMPL. VER.
-        #    <med_1>  <src_1>    <ver_1> <src_1>    <impl_1_value> <impl_1_ver>
-        #    <med_2>  <src_2>    <ver_2> <src_2>    <impl_2_value> <impl_2_ver>
-        #    ...
-        field_data = {
-            "mediator" : [("default", "json", "tsv"), _("MEDIATOR"), ""],
-            "version" : [("default", "json", "tsv"), _("VERSION"), ""],
-            "version-source": [("default", "json", "tsv"), _("VER. SRC."), ""],
-            "implementation" : [("default", "json", "tsv"), _("IMPLEMENTATION"),
-                ""],
-            "implementation-source": [("default", "json", "tsv"),
-                _("IMPL. SRC."), ""],
-            "implementation-version" : [("json", "tsv"), _("IMPL. VER."), ""],
-        }
-        desired_field_order = (_("MEDIATOR"), _("VER. SRC."), _("VERSION"),
-            _("IMPL. SRC."), _("IMPLEMENTATION"), _("IMPL. VER."))
+    requested_mediators = set(pargs)
+    if requested_mediators:
+        found = mediators & requested_mediators
+        notfound = requested_mediators - found
+    else:
+        found = mediators
+        notfound = set()
 
-        # Default output formatting.
-        def_fmt = "{0:" + str(max_mname_len) + "} {1:" + str(max_vsrc_len) + \
-            "} {2:" + str(max_version_len) + "} {3:" + str(max_isrc_len) + \
-            "} {4}"
+    def gen_listing():
+        for mediator, mediation in (
+            (mname, mentry)
+            for mname in sorted(found)
+            for mentry in mediations[mname]
+        ):
+            med_impl = mediation.get("implementation")
+            med_impl_ver = mediation.get("implementation-version")
+            if output_format == "default" and med_impl and med_impl_ver:
+                med_impl += "(@{0})".format(med_impl_ver)
+            yield {
+                "mediator": mediator,
+                "version": mediation.get("version"),
+                "version-source": mediation.get("version-source"),
+                "implementation": med_impl,
+                "implementation-source": mediation.get("implementation-source"),
+                "implementation-version": med_impl_ver,
+            }
 
-        if api_inst.get_dehydrated_publishers():
-                msg(_("WARNING: pkg mediators may not be accurately shown "
-                    "when one or more publishers have been dehydrated. The "
-                    "correct mediation will be applied when the publishers "
-                    "are rehydrated."))
+    #    MEDIATOR VER. SRC.  VERSION IMPL. SRC. IMPLEMENTATION IMPL. VER.
+    #    <med_1>  <src_1>    <ver_1> <src_1>    <impl_1_value> <impl_1_ver>
+    #    <med_2>  <src_2>    <ver_2> <src_2>    <impl_2_value> <impl_2_ver>
+    #    ...
+    field_data = {
+        "mediator": [("default", "json", "tsv"), _("MEDIATOR"), ""],
+        "version": [("default", "json", "tsv"), _("VERSION"), ""],
+        "version-source": [("default", "json", "tsv"), _("VER. SRC."), ""],
+        "implementation": [("default", "json", "tsv"), _("IMPLEMENTATION"), ""],
+        "implementation-source": [
+            ("default", "json", "tsv"),
+            _("IMPL. SRC."),
+            "",
+        ],
+        "implementation-version": [("json", "tsv"), _("IMPL. VER."), ""],
+    }
+    desired_field_order = (
+        _("MEDIATOR"),
+        _("VER. SRC."),
+        _("VERSION"),
+        _("IMPL. SRC."),
+        _("IMPLEMENTATION"),
+        _("IMPL. VER."),
+    )
 
-        if found or (not requested_mediators and output_format == "default"):
-                sys.stdout.write(misc.get_listing(desired_field_order,
-                    field_data, gen_listing(), output_format, def_fmt,
-                    omit_headers, escape_output=False))
+    # Default output formatting.
+    def_fmt = (
+        "{0:"
+        + str(max_mname_len)
+        + "} {1:"
+        + str(max_vsrc_len)
+        + "} {2:"
+        + str(max_version_len)
+        + "} {3:"
+        + str(max_isrc_len)
+        + "} {4}"
+    )
 
-        if found and notfound:
-                return EXIT_PARTIAL
-        if requested_mediators and not found:
-                if output_format == "default":
-                        # Don't pollute other output formats.
-                        error(_("no matching mediators found"),
-                            cmd=subcommand)
+    if api_inst.get_dehydrated_publishers():
+        msg(
+            _(
+                "WARNING: pkg mediators may not be accurately shown "
+                "when one or more publishers have been dehydrated. The "
+                "correct mediation will be applied when the publishers "
+                "are rehydrated."
+            )
+        )
+
+    if found or (not requested_mediators and output_format == "default"):
+        sys.stdout.write(
+            misc.get_listing(
+                desired_field_order,
+                field_data,
+                gen_listing(),
+                output_format,
+                def_fmt,
+                omit_headers,
+                escape_output=False,
+            )
+        )
+
+    if found and notfound:
+        return EXIT_PARTIAL
+    if requested_mediators and not found:
+        if output_format == "default":
+            # Don't pollute other output formats.
+            error(_("no matching mediators found"), cmd=subcommand)
+        return EXIT_OOPS
+    return EXIT_OK
+
+
+def set_mediator(
+    op,
+    api_inst,
+    pargs,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    med_implementation,
+    med_version,
+    new_be,
+    noexecute,
+    parsable_version,
+    quiet,
+    update_index,
+    verbose,
+):
+    """Set the version and/or implementation for the specified
+    mediator(s)."""
+
+    if not pargs:
+        usage(_("at least one mediator must be specified"), cmd=op)
+    if not (med_version or med_implementation):
+        usage(
+            _(
+                "a mediator version and/or implementation must be "
+                "specified using -V and -I"
+            ),
+            cmd=op,
+        )
+
+    if verbose > 2:
+        DebugValues.set_value("plan", "True")
+
+    # Now set version and/or implementation for all matching mediators.
+    # The user may specify 'None' as a special value to explicitly
+    # request mediations that do not have the related component.
+    mediators = collections.defaultdict(dict)
+    for m in pargs:
+        if med_version == "":
+            # Request reset of version.
+            mediators[m]["version"] = None
+        elif med_version == "None":
+            # Explicit selection of no version.
+            mediators[m]["version"] = ""
+        elif med_version:
+            mediators[m]["version"] = med_version
+
+        if med_implementation == "":
+            # Request reset of implementation.
+            mediators[m]["implementation"] = None
+        elif med_implementation == "None":
+            # Explicit selection of no implementation.
+            mediators[m]["implementation"] = ""
+        elif med_implementation:
+            mediators[m]["implementation"] = med_implementation
+
+    stuff_to_do = None
+    try:
+        for pd in api_inst.gen_plan_set_mediators(
+            mediators,
+            noexecute=noexecute,
+            backup_be=backup_be,
+            backup_be_name=backup_be_name,
+            be_name=be_name,
+            new_be=new_be,
+            be_activate=be_activate,
+        ):
+            continue
+        stuff_to_do = not api_inst.planned_nothingtodo()
+    except:
+        ret_code = __api_plan_exception(op, api_inst, noexecute, verbose)
+        if ret_code != EXIT_OK:
+            return ret_code
+
+    if not stuff_to_do:
+        if verbose:
+            __display_plan(api_inst, verbose, noexecute)
+        if parsable_version is not None:
+            try:
+                __display_parsable_plan(api_inst, parsable_version)
+            except api_errors.ApiException as e:
+                error(e, cmd=op)
                 return EXIT_OOPS
+        else:
+            msg(_("No changes required."))
+        return EXIT_NOP
+
+    if api_inst.get_dehydrated_publishers():
+        msg(
+            _(
+                "WARNING: pkg mediators may not be accurately shown "
+                "when one or more publishers have been dehydrated. The "
+                "correct mediation will be applied when the publishers "
+                "are rehydrated."
+            )
+        )
+
+    if not quiet:
+        __display_plan(api_inst, verbose, noexecute)
+    if parsable_version is not None:
+        try:
+            __display_parsable_plan(api_inst, parsable_version)
+        except api_errors.ApiException as e:
+            error(e, cmd=op)
+            return EXIT_OOPS
+
+    if noexecute:
         return EXIT_OK
 
-def set_mediator(op, api_inst, pargs,
-    backup_be, backup_be_name, be_activate, be_name, med_implementation,
-    med_version, new_be, noexecute, parsable_version, quiet, update_index,
-    verbose):
-        """Set the version and/or implementation for the specified
-        mediator(s)."""
-
-        if not pargs:
-                usage(_("at least one mediator must be specified"),
-                    cmd=op)
-        if not (med_version or med_implementation):
-                usage(_("a mediator version and/or implementation must be "
-                    "specified using -V and -I"), cmd=op)
-
-        if verbose > 2:
-                DebugValues.set_value("plan", "True")
-
-        # Now set version and/or implementation for all matching mediators.
-        # The user may specify 'None' as a special value to explicitly
-        # request mediations that do not have the related component.
-        mediators = collections.defaultdict(dict)
-        for m in pargs:
-                if med_version == "":
-                        # Request reset of version.
-                        mediators[m]["version"] = None
-                elif med_version == "None":
-                        # Explicit selection of no version.
-                        mediators[m]["version"] = ""
-                elif med_version:
-                        mediators[m]["version"] = med_version
-
-                if med_implementation == "":
-                        # Request reset of implementation.
-                        mediators[m]["implementation"] = None
-                elif med_implementation == "None":
-                        # Explicit selection of no implementation.
-                        mediators[m]["implementation"] = ""
-                elif med_implementation:
-                        mediators[m]["implementation"] = med_implementation
-
-        stuff_to_do = None
-        try:
-                for pd in api_inst.gen_plan_set_mediators(mediators,
-                    noexecute=noexecute, backup_be=backup_be,
-                    backup_be_name=backup_be_name, be_name=be_name,
-                    new_be=new_be, be_activate=be_activate):
-                        continue
-                stuff_to_do = not api_inst.planned_nothingtodo()
-        except:
-                ret_code = __api_plan_exception(op, api_inst, noexecute,
-                    verbose)
-                if ret_code != EXIT_OK:
-                        return ret_code
-
-        if not stuff_to_do:
-                if verbose:
-                        __display_plan(api_inst, verbose, noexecute)
-                if parsable_version is not None:
-                        try:
-                                __display_parsable_plan(api_inst,
-                                    parsable_version)
-                        except api_errors.ApiException as e:
-                                error(e, cmd=op)
-                                return EXIT_OOPS
-                else:
-                        msg(_("No changes required."))
-                return EXIT_NOP
-
-        if api_inst.get_dehydrated_publishers():
-                msg(_("WARNING: pkg mediators may not be accurately shown "
-                    "when one or more publishers have been dehydrated. The "
-                    "correct mediation will be applied when the publishers "
-                    "are rehydrated."))
-
-        if not quiet:
-                __display_plan(api_inst, verbose, noexecute)
-        if parsable_version is not None:
-                try:
-                        __display_parsable_plan(api_inst, parsable_version)
-                except api_errors.ApiException as e:
-                        error(e, cmd=op)
-                        return EXIT_OOPS
-
-        if noexecute:
-                return EXIT_OK
-
-        ret_code = __api_prepare_plan(op, api_inst)
-        if ret_code != EXIT_OK:
-                return ret_code
-
-        ret_code = __api_execute_plan(op, api_inst)
-
+    ret_code = __api_prepare_plan(op, api_inst)
+    if ret_code != EXIT_OK:
         return ret_code
 
-def unset_mediator(op, api_inst, pargs,
-    backup_be, backup_be_name, be_activate, be_name, med_implementation,
-    med_version, new_be, noexecute, parsable_version, quiet, update_index,
-    verbose):
-        """Unset the version and/or implementation for the specified
-        mediator(s)."""
+    ret_code = __api_execute_plan(op, api_inst)
 
-        if not pargs:
-                usage(_("at least one mediator must be specified"),
-                    cmd=op)
-        if verbose > 2:
-                DebugValues.set_value("plan", "True")
+    return ret_code
 
-        # Build dictionary of mediators to unset based on input.
-        mediators = collections.defaultdict(dict)
-        if not (med_version or med_implementation):
-                # Unset both if nothing specific requested.
-                med_version = True
-                med_implementation = True
 
-        # Now unset version and/or implementation for all matching mediators.
-        for m in pargs:
-                if med_version:
-                        mediators[m]["version"] = None
-                if med_implementation:
-                        mediators[m]["implementation"] = None
+def unset_mediator(
+    op,
+    api_inst,
+    pargs,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    med_implementation,
+    med_version,
+    new_be,
+    noexecute,
+    parsable_version,
+    quiet,
+    update_index,
+    verbose,
+):
+    """Unset the version and/or implementation for the specified
+    mediator(s)."""
 
-        stuff_to_do = None
-        try:
-                for pd in api_inst.gen_plan_set_mediators(mediators,
-                    noexecute=noexecute, backup_be=backup_be,
-                    backup_be_name=backup_be_name, be_name=be_name,
-                    new_be=new_be, be_activate=be_activate):
-                        continue
-                stuff_to_do = not api_inst.planned_nothingtodo()
-        except:
-                ret_code = __api_plan_exception(op, api_inst, noexecute,
-                    verbose)
-                if ret_code != EXIT_OK:
-                        return ret_code
+    if not pargs:
+        usage(_("at least one mediator must be specified"), cmd=op)
+    if verbose > 2:
+        DebugValues.set_value("plan", "True")
 
-        if not stuff_to_do:
-                if verbose:
-                        __display_plan(api_inst, verbose, noexecute)
-                if parsable_version is not None:
-                        try:
-                                __display_parsable_plan(api_inst,
-                                    parsable_version)
-                        except api_errors.ApiException as e:
-                                error(e, cmd=op)
-                                return EXIT_OOPS
-                else:
-                        msg(_("No changes required."))
-                return EXIT_NOP
+    # Build dictionary of mediators to unset based on input.
+    mediators = collections.defaultdict(dict)
+    if not (med_version or med_implementation):
+        # Unset both if nothing specific requested.
+        med_version = True
+        med_implementation = True
 
-        if not quiet:
-                __display_plan(api_inst, verbose, noexecute)
-        if parsable_version is not None:
-                try:
-                        __display_parsable_plan(api_inst, parsable_version)
-                except api_errors.ApiException as e:
-                        error(e, cmd=op)
-                        return EXIT_OOPS
+    # Now unset version and/or implementation for all matching mediators.
+    for m in pargs:
+        if med_version:
+            mediators[m]["version"] = None
+        if med_implementation:
+            mediators[m]["implementation"] = None
 
-        if noexecute:
-                return EXIT_OK
-
-        ret_code = __api_prepare_plan(op, api_inst)
+    stuff_to_do = None
+    try:
+        for pd in api_inst.gen_plan_set_mediators(
+            mediators,
+            noexecute=noexecute,
+            backup_be=backup_be,
+            backup_be_name=backup_be_name,
+            be_name=be_name,
+            new_be=new_be,
+            be_activate=be_activate,
+        ):
+            continue
+        stuff_to_do = not api_inst.planned_nothingtodo()
+    except:
+        ret_code = __api_plan_exception(op, api_inst, noexecute, verbose)
         if ret_code != EXIT_OK:
-                return ret_code
+            return ret_code
 
-        ret_code = __api_execute_plan(op, api_inst)
+    if not stuff_to_do:
+        if verbose:
+            __display_plan(api_inst, verbose, noexecute)
+        if parsable_version is not None:
+            try:
+                __display_parsable_plan(api_inst, parsable_version)
+            except api_errors.ApiException as e:
+                error(e, cmd=op)
+                return EXIT_OOPS
+        else:
+            msg(_("No changes required."))
+        return EXIT_NOP
 
+    if not quiet:
+        __display_plan(api_inst, verbose, noexecute)
+    if parsable_version is not None:
+        try:
+            __display_parsable_plan(api_inst, parsable_version)
+        except api_errors.ApiException as e:
+            error(e, cmd=op)
+            return EXIT_OOPS
+
+    if noexecute:
+        return EXIT_OK
+
+    ret_code = __api_prepare_plan(op, api_inst)
+    if ret_code != EXIT_OK:
         return ret_code
+
+    ret_code = __api_execute_plan(op, api_inst)
+
+    return ret_code
+
 
 def avoid(api_inst, args):
-        """Place the specified packages on the avoid list"""
-        if not args:
-                return __display_avoids(api_inst)
+    """Place the specified packages on the avoid list"""
+    if not args:
+        return __display_avoids(api_inst)
 
-        try:
-                api_inst.avoid_pkgs(args)
-                return EXIT_OK
-        except:
-                return __api_plan_exception("avoid", False, 0, api_inst)
+    try:
+        api_inst.avoid_pkgs(args)
+        return EXIT_OK
+    except:
+        return __api_plan_exception("avoid", False, 0, api_inst)
+
 
 def unavoid(api_inst, args):
-        """Remove the specified packages from the avoid list"""
-        if not args:
-                return __display_avoids(api_inst)
+    """Remove the specified packages from the avoid list"""
+    if not args:
+        return __display_avoids(api_inst)
 
-        try:
-                api_inst.avoid_pkgs(args, unavoid=True)
-                return EXIT_OK
-        except:
-                return __api_plan_exception("unavoid", False, 0, api_inst)
+    try:
+        api_inst.avoid_pkgs(args, unavoid=True)
+        return EXIT_OK
+    except:
+        return __api_plan_exception("unavoid", False, 0, api_inst)
+
 
 def __display_avoids(api_inst):
-        """Display the current avoid list, and the pkgs that are tracking
-        that pkg"""
-        for a in api_inst.get_avoid_list():
-                tracking = " ".join(a[1])
-                if tracking:
-                        logger.info(_(
-                            "    {avoid_pkg} (group dependency of "
-                            "'{tracking_pkg}')")
-                           .format(avoid_pkg=a[0], tracking_pkg=tracking))
-                else:
-                        logger.info("    {0}".format(a[0]))
+    """Display the current avoid list, and the pkgs that are tracking
+    that pkg"""
+    for a in api_inst.get_avoid_list():
+        tracking = " ".join(a[1])
+        if tracking:
+            logger.info(
+                _(
+                    "    {avoid_pkg} (group dependency of " "'{tracking_pkg}')"
+                ).format(avoid_pkg=a[0], tracking_pkg=tracking)
+            )
+        else:
+            logger.info("    {0}".format(a[0]))
 
-        return EXIT_OK
+    return EXIT_OK
+
 
 def freeze(api_inst, args):
-        """Place the specified packages on the frozen list"""
+    """Place the specified packages on the frozen list"""
 
-        opts, pargs = getopt.getopt(args, "Hc:n")
-        comment = None
-        display_headers = True
-        dry_run = False
-        for opt, arg in opts:
-                if opt == "-H":
-                        display_headers = False
-                elif opt == "-c":
-                        comment = arg
-                elif opt == "-n":
-                        dry_run = True
+    opts, pargs = getopt.getopt(args, "Hc:n")
+    comment = None
+    display_headers = True
+    dry_run = False
+    for opt, arg in opts:
+        if opt == "-H":
+            display_headers = False
+        elif opt == "-c":
+            comment = arg
+        elif opt == "-n":
+            dry_run = True
 
-        if comment and not pargs:
-                usage(usage_error=_("At least one package to freeze must be "
-                    "given when -c is used."), cmd="freeze")
-        if not display_headers and pargs:
-                usage(usage_error=_("-H may only be specified when listing the "
-                    "currently frozen packages."))
-        if not pargs:
-                return __display_cur_frozen(api_inst, display_headers)
+    if comment and not pargs:
+        usage(
+            usage_error=_(
+                "At least one package to freeze must be "
+                "given when -c is used."
+            ),
+            cmd="freeze",
+        )
+    if not display_headers and pargs:
+        usage(
+            usage_error=_(
+                "-H may only be specified when listing the "
+                "currently frozen packages."
+            )
+        )
+    if not pargs:
+        return __display_cur_frozen(api_inst, display_headers)
 
-        try:
-                pfmris = api_inst.freeze_pkgs(pargs, dry_run=dry_run,
-                    comment=comment)
-                for pfmri in pfmris:
-                        vertext = pfmri.version.get_short_version()
-                        ts = pfmri.version.get_timestamp()
-                        if ts:
-                                vertext += ":" + pfmri.version.timestr
-                        logger.info(_("{name} was frozen at {ver}").format(
-                            name=pfmri.pkg_name, ver=vertext))
-                return EXIT_OK
-        except api_errors.FreezePkgsException as e:
-                error("\n{0}".format(e), cmd="freeze")
-                return EXIT_OOPS
-        except:
-                return __api_plan_exception("freeze", False, 0, api_inst)
+    try:
+        pfmris = api_inst.freeze_pkgs(pargs, dry_run=dry_run, comment=comment)
+        for pfmri in pfmris:
+            vertext = pfmri.version.get_short_version()
+            ts = pfmri.version.get_timestamp()
+            if ts:
+                vertext += ":" + pfmri.version.timestr
+            logger.info(
+                _("{name} was frozen at {ver}").format(
+                    name=pfmri.pkg_name, ver=vertext
+                )
+            )
+        return EXIT_OK
+    except api_errors.FreezePkgsException as e:
+        error("\n{0}".format(e), cmd="freeze")
+        return EXIT_OOPS
+    except:
+        return __api_plan_exception("freeze", False, 0, api_inst)
+
 
 def unfreeze(api_inst, args):
-        """Remove the specified packages from the frozen list"""
+    """Remove the specified packages from the frozen list"""
 
-        opts, pargs = getopt.getopt(args, "Hn")
-        display_headers = True
-        dry_run = False
-        for opt, arg in opts:
-                if opt == "-H":
-                        display_headers = False
-                elif opt == "-n":
-                        dry_run = True
+    opts, pargs = getopt.getopt(args, "Hn")
+    display_headers = True
+    dry_run = False
+    for opt, arg in opts:
+        if opt == "-H":
+            display_headers = False
+        elif opt == "-n":
+            dry_run = True
 
-        if not pargs:
-                return __display_cur_frozen(api_inst, display_headers)
+    if not pargs:
+        return __display_cur_frozen(api_inst, display_headers)
 
-        try:
-                pkgs = api_inst.freeze_pkgs(pargs, unfreeze=True,
-                    dry_run=dry_run)
-                if not pkgs:
-                        return EXIT_NOP
-                for s in pkgs:
-                        logger.info(_("{0} was unfrozen.").format(s))
-                return EXIT_OK
-        except:
-                return __api_plan_exception("unfreeze", False, 0, api_inst)
+    try:
+        pkgs = api_inst.freeze_pkgs(pargs, unfreeze=True, dry_run=dry_run)
+        if not pkgs:
+            return EXIT_NOP
+        for s in pkgs:
+            logger.info(_("{0} was unfrozen.").format(s))
+        return EXIT_OK
+    except:
+        return __api_plan_exception("unfreeze", False, 0, api_inst)
+
 
 def __display_cur_frozen(api_inst, display_headers):
-        """Display the current frozen list"""
+    """Display the current frozen list"""
 
-        try:
-                lst = sorted(api_inst.get_frozen_list())
-        except api_errors.ApiException as e:
-                error(e)
-                return EXIT_OOPS
-        if len(lst) == 0:
-                return EXIT_OK
-
-        fmt = "{name:18} {ver:27} {time:24} {comment}"
-        if display_headers:
-                logger.info(fmt.format(
-                    name=_("NAME"),
-                    ver=_("VERSION"),
-                    time=_("DATE"),
-                    comment=_("COMMENT")
-                ))
-
-        for pfmri, comment, timestamp in lst:
-                vertext = pfmri.version.get_short_version()
-                ts = pfmri.version.get_timestamp()
-                if ts:
-                        vertext += ":" + pfmri.version.timestr
-                if not comment:
-                        comment = "None"
-                logger.info(fmt.format(
-                    name=pfmri.pkg_name,
-                    comment=comment,
-                    time=time.strftime("%d %b %Y %H:%M:%S %Z",
-                                time.localtime(timestamp)),
-                    ver=vertext
-                ))
+    try:
+        lst = sorted(api_inst.get_frozen_list())
+    except api_errors.ApiException as e:
+        error(e)
+        return EXIT_OOPS
+    if len(lst) == 0:
         return EXIT_OK
 
+    fmt = "{name:18} {ver:27} {time:24} {comment}"
+    if display_headers:
+        logger.info(
+            fmt.format(
+                name=_("NAME"),
+                ver=_("VERSION"),
+                time=_("DATE"),
+                comment=_("COMMENT"),
+            )
+        )
+
+    for pfmri, comment, timestamp in lst:
+        vertext = pfmri.version.get_short_version()
+        ts = pfmri.version.get_timestamp()
+        if ts:
+            vertext += ":" + pfmri.version.timestr
+        if not comment:
+            comment = "None"
+        logger.info(
+            fmt.format(
+                name=pfmri.pkg_name,
+                comment=comment,
+                time=time.strftime(
+                    "%d %b %Y %H:%M:%S %Z", time.localtime(timestamp)
+                ),
+                ver=vertext,
+            )
+        )
+    return EXIT_OK
+
+
 def __convert_output(a_str, match):
-        """Converts a string to a three tuple with the information to fill
-        the INDEX, ACTION, and VALUE columns.
+    """Converts a string to a three tuple with the information to fill
+    the INDEX, ACTION, and VALUE columns.
 
-        The "a_str" parameter is the string representation of an action.
+    The "a_str" parameter is the string representation of an action.
 
-        The "match" parameter is a string whose precise interpretation is given
-        below.
+    The "match" parameter is a string whose precise interpretation is given
+    below.
 
-        For most action types, match defines which attribute the query matched
-        with.  For example, it states whether the basename or path attribute of
-        a file action matched the query.  Attribute (set) actions are treated
-        differently because they only have one attribute, and many values
-        associated with that attribute.  For those actions, the match parameter
-        states which value matched the query."""
+    For most action types, match defines which attribute the query matched
+    with.  For example, it states whether the basename or path attribute of
+    a file action matched the query.  Attribute (set) actions are treated
+    differently because they only have one attribute, and many values
+    associated with that attribute.  For those actions, the match parameter
+    states which value matched the query."""
 
-        a = actions.fromstr(a_str.rstrip())
-        if isinstance(a, actions.attribute.AttributeAction):
-                return a.attrs.get(a.key_attr), a.name, match
-        return match, a.name, a.attrs.get(a.key_attr)
+    a = actions.fromstr(a_str.rstrip())
+    if isinstance(a, actions.attribute.AttributeAction):
+        return a.attrs.get(a.key_attr), a.name, match
+    return match, a.name, a.attrs.get(a.key_attr)
+
 
 def produce_matching_token(action, match):
-        """Given an action and a match value (see convert_output for more
-        details on this parameter), return the token which matched the query."""
+    """Given an action and a match value (see convert_output for more
+    details on this parameter), return the token which matched the query."""
 
-        if isinstance(action, actions.attribute.AttributeAction):
-                return match
-        if match == "basename":
-                return action.attrs.get("path")
-        r = action.attrs.get(match)
-        if r:
-                return r
-        return action.attrs.get(action.key_attr)
+    if isinstance(action, actions.attribute.AttributeAction):
+        return match
+    if match == "basename":
+        return action.attrs.get("path")
+    r = action.attrs.get(match)
+    if r:
+        return r
+    return action.attrs.get(action.key_attr)
+
 
 def produce_matching_type(action, match):
-        """Given an action and a match value (see convert_output for more
-        details on this parameter), return the kind of match this was.  For
-        example, if the query matched a portion of a path of an action, this
-        will return 'path'.  If the action is an attribute action, it returns
-        the name set in the action. """
+    """Given an action and a match value (see convert_output for more
+    details on this parameter), return the kind of match this was.  For
+    example, if the query matched a portion of a path of an action, this
+    will return 'path'.  If the action is an attribute action, it returns
+    the name set in the action."""
 
-        if not isinstance(action, actions.attribute.AttributeAction):
-                return match
-        return action.attrs.get("name")
+    if not isinstance(action, actions.attribute.AttributeAction):
+        return match
+    return action.attrs.get("name")
+
 
 def v1_extract_info(tup, return_type, pub):
-        """Given a result from search, massages the information into a form
-        useful for pkg.misc.list_actions_by_attrs.
+    """Given a result from search, massages the information into a form
+    useful for pkg.misc.list_actions_by_attrs.
 
-        The "return_type" parameter is an enumeration that describes the type
-        of the information that will be converted.
+    The "return_type" parameter is an enumeration that describes the type
+    of the information that will be converted.
 
-        The type of the "tup" parameter depends on the value of "return_type".
-        If "return_type" is action information, "tup" is a three-tuple of the
-        fmri name, the match, and a string representation of the action.  In
-        the case where "return_type" is package information, "tup" is a one-
-        tuple containing the fmri name.
+    The type of the "tup" parameter depends on the value of "return_type".
+    If "return_type" is action information, "tup" is a three-tuple of the
+    fmri name, the match, and a string representation of the action.  In
+    the case where "return_type" is package information, "tup" is a one-
+    tuple containing the fmri name.
 
-        The "pub" parameter contains information about the publisher from which
-        the result was obtained."""
+    The "pub" parameter contains information about the publisher from which
+    the result was obtained."""
 
-        action = None
-        match = None
-        match_type = None
+    action = None
+    match = None
+    match_type = None
 
-        if return_type == api.Query.RETURN_ACTIONS:
-                try:
-                        pfmri, match, action = tup
-                except ValueError:
-                        error(_("The repository returned a malformed result.\n"
-                            "The problematic structure:{0!r}").format(tup))
-                        return False
-                try:
-                        action = actions.fromstr(action.rstrip())
-                except actions.ActionError as e:
-                        error(_("The repository returned an invalid or "
-                            "unsupported action.\n{0}").format(e))
-                        return False
-                match_type = produce_matching_type(action, match)
-                match = produce_matching_token(action, match)
-        else:
-                pfmri = tup
-        return pfmri, action, pub, match, match_type
+    if return_type == api.Query.RETURN_ACTIONS:
+        try:
+            pfmri, match, action = tup
+        except ValueError:
+            error(
+                _(
+                    "The repository returned a malformed result.\n"
+                    "The problematic structure:{0!r}"
+                ).format(tup)
+            )
+            return False
+        try:
+            action = actions.fromstr(action.rstrip())
+        except actions.ActionError as e:
+            error(
+                _(
+                    "The repository returned an invalid or "
+                    "unsupported action.\n{0}"
+                ).format(e)
+            )
+            return False
+        match_type = produce_matching_type(action, match)
+        match = produce_matching_token(action, match)
+    else:
+        pfmri = tup
+    return pfmri, action, pub, match, match_type
+
 
 def search(api_inst, args):
-        """Search for the given query."""
+    """Search for the given query."""
 
-        # Constants which control the paging behavior for search output.
-        page_timeout = .5
-        max_timeout = 5
-        min_page_size = 5
+    # Constants which control the paging behavior for search output.
+    page_timeout = 0.5
+    max_timeout = 5
+    min_page_size = 5
 
-        search_attrs = valid_special_attrs[:]
-        search_attrs.extend(["search.match", "search.match_type"])
+    search_attrs = valid_special_attrs[:]
+    search_attrs.extend(["search.match", "search.match_type"])
 
-        search_prefixes = valid_special_prefixes[:]
-        search_prefixes.extend(["search."])
+    search_prefixes = valid_special_prefixes[:]
+    search_prefixes.extend(["search."])
 
-        opts, pargs = getopt.getopt(args, "Haflo:prs:I")
+    opts, pargs = getopt.getopt(args, "Haflo:prs:I")
 
-        default_attrs_action = ["search.match_type", "action.name",
-            "search.match", "pkg.shortfmri"]
+    default_attrs_action = [
+        "search.match_type",
+        "action.name",
+        "search.match",
+        "pkg.shortfmri",
+    ]
 
-        default_attrs_package = ["pkg.shortfmri", "pkg.publisher"]
+    default_attrs_package = ["pkg.shortfmri", "pkg.publisher"]
 
-        local = remote = case_sensitive = False
-        servers = []
-        attrs = []
+    local = remote = case_sensitive = False
+    servers = []
+    attrs = []
 
-        display_headers = True
-        prune_versions = True
-        return_actions = True
-        use_default_attrs = True
+    display_headers = True
+    prune_versions = True
+    return_actions = True
+    use_default_attrs = True
 
-        for opt, arg in opts:
-                if opt == "-H":
-                        display_headers = False
-                elif opt == "-a":
-                        return_actions = True
-                elif opt == "-f":
-                        prune_versions = False
-                elif opt == "-l":
-                        local = True
-                elif opt == "-o":
-                        attrs.extend(arg.split(","))
-                        use_default_attrs = False
-                elif opt == "-p":
-                        return_actions = False
-                elif opt == "-r":
-                        remote = True
-                elif opt == "-s":
-                        remote = True
-                        servers.append({
-                            "origin": misc.parse_uri(arg, cwd=orig_cwd) })
-                elif opt == "-I":
-                        case_sensitive = True
+    for opt, arg in opts:
+        if opt == "-H":
+            display_headers = False
+        elif opt == "-a":
+            return_actions = True
+        elif opt == "-f":
+            prune_versions = False
+        elif opt == "-l":
+            local = True
+        elif opt == "-o":
+            attrs.extend(arg.split(","))
+            use_default_attrs = False
+        elif opt == "-p":
+            return_actions = False
+        elif opt == "-r":
+            remote = True
+        elif opt == "-s":
+            remote = True
+            servers.append({"origin": misc.parse_uri(arg, cwd=orig_cwd)})
+        elif opt == "-I":
+            case_sensitive = True
 
-        if not local and not remote:
-                remote = True
+    if not local and not remote:
+        remote = True
 
-        if not pargs:
-                usage(_("at least one search term must be provided"),
-                    cmd="search")
+    if not pargs:
+        usage(_("at least one search term must be provided"), cmd="search")
 
-        check_attrs(attrs, "search", reference=search_attrs,
-            prefixes=search_prefixes)
+    check_attrs(
+        attrs, "search", reference=search_attrs, prefixes=search_prefixes
+    )
 
-        action_attr = False
-        for a in attrs:
-                if a.startswith("action.") or a.startswith("search.match"):
-                        action_attr = True
-                        if not return_actions:
-                                usage(_("action level options ('{0}') to -o "
-                                    "cannot be used with the -p "
-                                    "option").format(a), cmd="search")
-                        break
+    action_attr = False
+    for a in attrs:
+        if a.startswith("action.") or a.startswith("search.match"):
+            action_attr = True
+            if not return_actions:
+                usage(
+                    _(
+                        "action level options ('{0}') to -o "
+                        "cannot be used with the -p "
+                        "option"
+                    ).format(a),
+                    cmd="search",
+                )
+            break
 
-        searches = []
+    searches = []
 
-        # Strip pkg:/ or pkg:/// from the fmri.
-        # If fmri has pkg:// then strip the prefix
-        # from 'pkg://' upto the first slash.
+    # Strip pkg:/ or pkg:/// from the fmri.
+    # If fmri has pkg:// then strip the prefix
+    # from 'pkg://' upto the first slash.
 
-        qtext = re.sub(r"pkg:///|pkg://[^/]*/|pkg:/", "", " ".join(pargs))
+    qtext = re.sub(r"pkg:///|pkg://[^/]*/|pkg:/", "", " ".join(pargs))
 
-        try:
-                query = [api.Query(qtext, case_sensitive,
-                    return_actions)]
-        except api_errors.BooleanQueryException as e:
-                error(e)
-                return EXIT_OOPS
-        except api_errors.ParseError as e:
-                error(e)
-                return EXIT_OOPS
+    try:
+        query = [api.Query(qtext, case_sensitive, return_actions)]
+    except api_errors.BooleanQueryException as e:
+        error(e)
+        return EXIT_OOPS
+    except api_errors.ParseError as e:
+        error(e)
+        return EXIT_OOPS
 
-        good_res = False
-        bad_res = False
+    good_res = False
+    bad_res = False
 
-        try:
-                if local:
-                        searches.append(api_inst.local_search(query))
-                if remote:
-                        searches.append(api_inst.remote_search(query,
-                            servers=servers, prune_versions=prune_versions))
-                # By default assume we don't find anything.
-                retcode = EXIT_OOPS
+    try:
+        if local:
+            searches.append(api_inst.local_search(query))
+        if remote:
+            searches.append(
+                api_inst.remote_search(
+                    query, servers=servers, prune_versions=prune_versions
+                )
+            )
+        # By default assume we don't find anything.
+        retcode = EXIT_OOPS
 
-                # get initial set of results
-                justs = calc_justs(attrs)
-                page_again = True
-                widths = []
-                st = None
-                err = None
-                header_attrs = attrs
-                last_line = None
-                shown_headers = False
-                while page_again:
-                        unprocessed_res = []
-                        page_again = False
-                        # Indexless search raises a slow search exception. In
-                        # that case, catch the exception, finish processing the
-                        # results, then propogate the error.
-                        try:
-                                for raw_value in itertools.chain(*searches):
-                                        if not st:
-                                                st = time.time()
-                                        try:
-                                                query_num, pub, \
-                                                    (v, return_type, tmp) = \
-                                                    raw_value
-                                        except ValueError as e:
-                                                error(_("The repository "
-                                                    "returned a malformed "
-                                                    "result:{0!r}").format(
-                                                    raw_value))
-                                                bad_res = True
-                                                continue
-                                        # This check is necessary since a
-                                        # a pacakge search can be specified
-                                        # using the <> operator.
-                                        if action_attr and \
-                                            return_type != \
-                                            api.Query.RETURN_ACTIONS:
-                                                usage(_("action level options "
-                                                    "to -o cannot be used with "
-                                                    "the queries that return "
-                                                    "packages"), cmd="search")
-                                        if use_default_attrs and not justs:
-                                                if return_type == \
-                                                    api.Query.RETURN_ACTIONS:
-                                                        attrs = \
-                                                            default_attrs_action
-                                                        header_attrs = \
-                                                            ["index", "action",
-                                                            "value", "package"]
-                                                else:
-                                                        attrs = default_attrs_package
-                                                        header_attrs = \
-                                                            ["package",
-                                                            "publisher"]
-                                                justs = calc_justs(attrs)
-                                        ret = v1_extract_info(
-                                            tmp, return_type, pub)
-                                        bad_res |= isinstance(ret, bool)
-                                        if ret:
-                                                good_res = True
-                                                unprocessed_res.append(ret)
-                                        # Check whether the paging timeout
-                                        # should be increased.
-                                        if time.time() - st > page_timeout:
-                                                if len(unprocessed_res) > \
-                                                    min_page_size:
-                                                        page_again = True
-                                                        break
-                                                else:
-                                                        page_timeout = min(
-                                                            page_timeout * 2,
-                                                            max_timeout)
-                        except api_errors.ApiException as e:
-                                err = e
-                        lines = list(misc.list_actions_by_attrs(unprocessed_res,
-                            attrs, show_all=True, remove_consec_dup_lines=True,
-                            last_res=last_line))
-                        if not lines:
-                                continue
-                        old_widths = widths[:]
-                        widths = calc_widths(lines, attrs, widths)
-                        # If headers are being displayed and the layout of the
-                        # columns have changed, print the headers again using
-                        # the new widths.
-                        if display_headers and (not shown_headers or
-                            old_widths[:-1] != widths[:-1]):
-                                shown_headers = True
-                                print_headers(header_attrs, widths, justs)
-                        for line in lines:
-                                msg((create_output_format(display_headers,
-                                    widths, justs, line).format(
-                                    *line)).rstrip())
-                                last_line = line
+        # get initial set of results
+        justs = calc_justs(attrs)
+        page_again = True
+        widths = []
+        st = None
+        err = None
+        header_attrs = attrs
+        last_line = None
+        shown_headers = False
+        while page_again:
+            unprocessed_res = []
+            page_again = False
+            # Indexless search raises a slow search exception. In
+            # that case, catch the exception, finish processing the
+            # results, then propogate the error.
+            try:
+                for raw_value in itertools.chain(*searches):
+                    if not st:
                         st = time.time()
-                if err:
-                        raise err
+                    try:
+                        query_num, pub, (v, return_type, tmp) = raw_value
+                    except ValueError as e:
+                        error(
+                            _(
+                                "The repository "
+                                "returned a malformed "
+                                "result:{0!r}"
+                            ).format(raw_value)
+                        )
+                        bad_res = True
+                        continue
+                    # This check is necessary since a
+                    # a pacakge search can be specified
+                    # using the <> operator.
+                    if action_attr and return_type != api.Query.RETURN_ACTIONS:
+                        usage(
+                            _(
+                                "action level options "
+                                "to -o cannot be used with "
+                                "the queries that return "
+                                "packages"
+                            ),
+                            cmd="search",
+                        )
+                    if use_default_attrs and not justs:
+                        if return_type == api.Query.RETURN_ACTIONS:
+                            attrs = default_attrs_action
+                            header_attrs = [
+                                "index",
+                                "action",
+                                "value",
+                                "package",
+                            ]
+                        else:
+                            attrs = default_attrs_package
+                            header_attrs = ["package", "publisher"]
+                        justs = calc_justs(attrs)
+                    ret = v1_extract_info(tmp, return_type, pub)
+                    bad_res |= isinstance(ret, bool)
+                    if ret:
+                        good_res = True
+                        unprocessed_res.append(ret)
+                    # Check whether the paging timeout
+                    # should be increased.
+                    if time.time() - st > page_timeout:
+                        if len(unprocessed_res) > min_page_size:
+                            page_again = True
+                            break
+                        else:
+                            page_timeout = min(page_timeout * 2, max_timeout)
+            except api_errors.ApiException as e:
+                err = e
+            lines = list(
+                misc.list_actions_by_attrs(
+                    unprocessed_res,
+                    attrs,
+                    show_all=True,
+                    remove_consec_dup_lines=True,
+                    last_res=last_line,
+                )
+            )
+            if not lines:
+                continue
+            old_widths = widths[:]
+            widths = calc_widths(lines, attrs, widths)
+            # If headers are being displayed and the layout of the
+            # columns have changed, print the headers again using
+            # the new widths.
+            if display_headers and (
+                not shown_headers or old_widths[:-1] != widths[:-1]
+            ):
+                shown_headers = True
+                print_headers(header_attrs, widths, justs)
+            for line in lines:
+                msg(
+                    (
+                        create_output_format(
+                            display_headers, widths, justs, line
+                        ).format(*line)
+                    ).rstrip()
+                )
+                last_line = line
+            st = time.time()
+        if err:
+            raise err
 
+    except (
+        api_errors.IncorrectIndexFileHash,
+        api_errors.InconsistentIndexException,
+    ):
+        error(
+            _(
+                "The search index appears corrupted.  Please "
+                "rebuild the index with 'pkg rebuild-index'."
+            )
+        )
+        return EXIT_OOPS
+    except api_errors.ProblematicSearchServers as e:
+        error(e)
+        bad_res = True
+    except api_errors.SlowSearchUsed as e:
+        error(e)
+    except (
+        api_errors.IncorrectIndexFileHash,
+        api_errors.InconsistentIndexException,
+    ):
+        error(
+            _(
+                "The search index appears corrupted.  Please "
+                "rebuild the index with 'pkg rebuild-index'."
+            )
+        )
+        return EXIT_OOPS
+    except api_errors.ImageFormatUpdateNeeded as e:
+        format_update_error(e)
+        return EXIT_OOPS
+    except api_errors.ApiException as e:
+        error(e)
+        return EXIT_OOPS
+    if good_res and bad_res:
+        retcode = EXIT_PARTIAL
+    elif bad_res:
+        retcode = EXIT_OOPS
+    elif good_res:
+        retcode = EXIT_OK
+    return retcode
 
-        except (api_errors.IncorrectIndexFileHash,
-            api_errors.InconsistentIndexException):
-                error(_("The search index appears corrupted.  Please "
-                    "rebuild the index with 'pkg rebuild-index'."))
-                return EXIT_OOPS
-        except api_errors.ProblematicSearchServers as e:
-                error(e)
-                bad_res = True
-        except api_errors.SlowSearchUsed as e:
-                error(e)
-        except (api_errors.IncorrectIndexFileHash,
-            api_errors.InconsistentIndexException):
-                error(_("The search index appears corrupted.  Please "
-                    "rebuild the index with 'pkg rebuild-index'."))
-                return EXIT_OOPS
-        except api_errors.ImageFormatUpdateNeeded as e:
-                format_update_error(e)
-                return EXIT_OOPS
-        except api_errors.ApiException as e:
-                error(e)
-                return EXIT_OOPS
-        if good_res and bad_res:
-                retcode = EXIT_PARTIAL
-        elif bad_res:
-                retcode = EXIT_OOPS
-        elif good_res:
-                retcode = EXIT_OK
-        return retcode
 
 def flag(api_inst, args):
-        """Flag/unflag installed packages in the local image.
-        """
+    """Flag/unflag installed packages in the local image."""
 
-        opts, pargs = getopt.getopt(args, "Mm")
-        flag = None
-        for opt, arg in opts:
-                if opt == "-M":
-                        flag = 'manual'
-                        value = False
-                if opt == "-m":
-                        flag = 'manual'
-                        value = True
+    opts, pargs = getopt.getopt(args, "Mm")
+    flag = None
+    for opt, arg in opts:
+        if opt == "-M":
+            flag = "manual"
+            value = False
+        if opt == "-m":
+            flag = "manual"
+            value = True
 
-        if not flag:
-                usage(usage_error="One of -m or -M must be provided.",
-                    cmd="flag")
+    if not flag:
+        usage(usage_error="One of -m or -M must be provided.", cmd="flag")
 
-        if not len(pargs):
-                usage(usage_error=_("At least one package to update must be "
-                    "provided."), cmd="flag")
+    if not len(pargs):
+        usage(
+            usage_error=_(
+                "At least one package to update must be " "provided."
+            ),
+            cmd="flag",
+        )
 
-        try:
-                api_inst.flag_pkgs(pargs, flag=flag, value=value)
-                return EXIT_OK
-        except:
-                return __api_plan_exception("flag", False, 0, api_inst)
+    try:
+        api_inst.flag_pkgs(pargs, flag=flag, value=value)
+        return EXIT_OK
+    except:
+        return __api_plan_exception("flag", False, 0, api_inst)
 
-def info(op, api_inst, pargs, display_license, info_local, info_remote,
-    origins, quiet):
-        """Display information about a package or packages.
-        """
 
-        ret_json = client_api._info(op, api_inst, pargs, display_license,
-            info_local, info_remote, origins, quiet)
+def info(
+    op,
+    api_inst,
+    pargs,
+    display_license,
+    info_local,
+    info_remote,
+    origins,
+    quiet,
+):
+    """Display information about a package or packages."""
 
-        if "data" in ret_json:
-                # display_license is true.
-                if "licenses" in ret_json["data"]:
-                        data_type = "licenses"
-                elif "package_attrs" in ret_json["data"]:
-                        data_type = "package_attrs"
+    ret_json = client_api._info(
+        op,
+        api_inst,
+        pargs,
+        display_license,
+        info_local,
+        info_remote,
+        origins,
+        quiet,
+    )
 
-                for i, pis in enumerate(ret_json["data"][data_type]):
-                        if not quiet and i > 0:
-                                msg("")
+    if "data" in ret_json:
+        # display_license is true.
+        if "licenses" in ret_json["data"]:
+            data_type = "licenses"
+        elif "package_attrs" in ret_json["data"]:
+            data_type = "package_attrs"
 
-                        if display_license and not quiet:
-                                for lic in pis[1]:
-                                        msg(lic)
-                                continue
+        for i, pis in enumerate(ret_json["data"][data_type]):
+            if not quiet and i > 0:
+                msg("")
 
-                        try:
-                                max_width = max(
-                                    len(attr[0])
-                                    for attr in pis
-                                )
-                        except ValueError:
-                                # Only display header if there are
-                                # other attributes to show.
-                                continue
-                        for attr_l in pis:
-                                attr, kval = tuple(attr_l)
-                                label = "{0}: ".format(attr.rjust(max_width))
-                                res = "\n".join(item for item in kval)
-                                if res:
-                                        wrapper = textwrap.TextWrapper(
-                                            initial_indent=label,
-                                            break_on_hyphens=False,
-                                            break_long_words=False,
-                                            subsequent_indent=(max_width + 2) \
-                                            * " ", width=80)
-                                        msg(wrapper.fill(res))
+            if display_license and not quiet:
+                for lic in pis[1]:
+                    msg(lic)
+                continue
 
-        if "errors" in ret_json:
-                _generate_error_messages(ret_json["status"], ret_json["errors"],
-                    cmd="info")
+            try:
+                max_width = max(len(attr[0]) for attr in pis)
+            except ValueError:
+                # Only display header if there are
+                # other attributes to show.
+                continue
+            for attr_l in pis:
+                attr, kval = tuple(attr_l)
+                label = "{0}: ".format(attr.rjust(max_width))
+                res = "\n".join(item for item in kval)
+                if res:
+                    wrapper = textwrap.TextWrapper(
+                        initial_indent=label,
+                        break_on_hyphens=False,
+                        break_long_words=False,
+                        subsequent_indent=(max_width + 2) * " ",
+                        width=80,
+                    )
+                    msg(wrapper.fill(res))
 
-        return ret_json["status"]
+    if "errors" in ret_json:
+        _generate_error_messages(
+            ret_json["status"], ret_json["errors"], cmd="info"
+        )
+
+    return ret_json["status"]
+
 
 def calc_widths(lines, attrs, widths=None):
-        """Given a set of lines and a set of attributes, calculate the minimum
-        width each column needs to hold its contents."""
+    """Given a set of lines and a set of attributes, calculate the minimum
+    width each column needs to hold its contents."""
 
-        if not widths:
-                widths = [ len(attr) - attr.find(".") - 1 for attr in attrs ]
-        for l in lines:
-                for i, a in enumerate(l):
-                        if len(str(a)) > widths[i]:
-                                widths[i] = len(str(a))
-        return widths
+    if not widths:
+        widths = [len(attr) - attr.find(".") - 1 for attr in attrs]
+    for l in lines:
+        for i, a in enumerate(l):
+            if len(str(a)) > widths[i]:
+                widths[i] = len(str(a))
+    return widths
+
 
 def calc_justs(attrs):
-        """Given a set of output attributes, find any attributes with known
-        justification directions and assign them."""
+    """Given a set of output attributes, find any attributes with known
+    justification directions and assign them."""
 
-        def __chose_just(attr):
-                if attr in ["action.name", "action.key", "action.raw",
-                    "pkg.name", "pkg.fmri", "pkg.shortfmri", "pkg.publisher"]:
-                        return JUST_LEFT
-                return JUST_UNKNOWN
-        return [ __chose_just(attr) for attr in attrs ]
+    def __chose_just(attr):
+        if attr in [
+            "action.name",
+            "action.key",
+            "action.raw",
+            "pkg.name",
+            "pkg.fmri",
+            "pkg.shortfmri",
+            "pkg.publisher",
+        ]:
+            return JUST_LEFT
+        return JUST_UNKNOWN
+
+    return [__chose_just(attr) for attr in attrs]
+
 
 def default_left(v):
-        """For a given justification "v", use the default of left justification
-        if "v" is JUST_UNKNOWN."""
+    """For a given justification "v", use the default of left justification
+    if "v" is JUST_UNKNOWN."""
 
-        if v == JUST_UNKNOWN:
-                return JUST_LEFT
-        return v
+    if v == JUST_UNKNOWN:
+        return JUST_LEFT
+    return v
+
 
 def print_headers(attrs, widths, justs):
-        """Print out the headers for the columns in the output.
+    """Print out the headers for the columns in the output.
 
-        The "attrs" parameter provides the headings that should be used.
+    The "attrs" parameter provides the headings that should be used.
 
-        The "widths" parameter provides the current estimates of the width
-        for each column. These may be changed due to the length of the headers.
-        This function does modify the values contained in "widths" outside this
-        function.
+    The "widths" parameter provides the current estimates of the width
+    for each column. These may be changed due to the length of the headers.
+    This function does modify the values contained in "widths" outside this
+    function.
 
-        The "justs" parameter contains the justifications to use with each
-        header."""
+    The "justs" parameter contains the justifications to use with each
+    header."""
 
-        headers = []
-        for i, attr in enumerate(attrs):
-                headers.append(str(attr.upper()))
-                widths[i] = max(widths[i], len(attr))
+    headers = []
+    for i, attr in enumerate(attrs):
+        headers.append(str(attr.upper()))
+        widths[i] = max(widths[i], len(attr))
 
+    # Now that we know all the widths, multiply them by the
+    # justification values to get positive or negative numbers to
+    # pass to the format specifier.
+    widths = [e[0] * default_left(e[1]) for e in zip(widths, justs)]
+    fmt = ""
+    for n in range(len(widths)):
+        if widths[n] < 0:
+            fmt += "{{{0}:<{1:d}}} ".format(n, -widths[n])
+        else:
+            fmt += "{{{0}:>{1:d}}} ".format(n, widths[n])
+
+    msg(fmt.format(*headers).rstrip())
+
+
+def guess_unknown(j, v):
+    """If the justificaton to use for a value is unknown, assume that if
+    it is an integer, the output should be right justified, otherwise it
+    should be left justified."""
+
+    if j != JUST_UNKNOWN:
+        return j
+    try:
+        int(v)
+        return JUST_RIGHT
+    except (ValueError, TypeError):
+        # attribute is non-numeric or is something like
+        # a list.
+        return JUST_LEFT
+
+
+def create_output_format(display_headers, widths, justs, line):
+    """Produce a format string that can be used to display results.
+
+    The "display_headers" parameter is whether headers have been displayed
+    or not. If they have not, then use a simple tab system. If they
+    have, use the information in the other parameters to control the
+    formatting of the line.
+
+    The "widths" parameter contains the width to use for each column.
+
+    The "justs" parameter contains the justifications to use for each
+    column.
+
+    The "line" parameter contains the information that will be displayed
+    using the resulting format. It's needed so that a choice can be made
+    about columns with unknown justifications.
+    """
+
+    fmt = ""
+    if display_headers:
         # Now that we know all the widths, multiply them by the
         # justification values to get positive or negative numbers to
         # pass to the format specifier.
-        widths = [ e[0] * default_left(e[1]) for e in zip(widths, justs) ]
-        fmt = ""
-        for n in range(len(widths)):
-                if widths[n] < 0:
-                        fmt += "{{{0}:<{1:d}}} ".format(n, -widths[n])
-                else:
-                        fmt += "{{{0}:>{1:d}}} ".format(n, widths[n])
-
-        msg(fmt.format(*headers).rstrip())
-
-def guess_unknown(j, v):
-        """If the justificaton to use for a value is unknown, assume that if
-        it is an integer, the output should be right justified, otherwise it
-        should be left justified."""
-
-        if j != JUST_UNKNOWN:
-                return j
-        try:
-                int(v)
-                return JUST_RIGHT
-        except (ValueError, TypeError):
-                # attribute is non-numeric or is something like
-                # a list.
-                return JUST_LEFT
-
-def create_output_format(display_headers, widths, justs, line):
-        """Produce a format string that can be used to display results.
-
-        The "display_headers" parameter is whether headers have been displayed
-        or not. If they have not, then use a simple tab system. If they
-        have, use the information in the other parameters to control the
-        formatting of the line.
-
-        The "widths" parameter contains the width to use for each column.
-
-        The "justs" parameter contains the justifications to use for each
-        column.
-
-        The "line" parameter contains the information that will be displayed
-        using the resulting format. It's needed so that a choice can be made
-        about columns with unknown justifications.
-        """
-
-        fmt = ""
-        if display_headers:
-                # Now that we know all the widths, multiply them by the
-                # justification values to get positive or negative numbers to
-                # pass to the format specifier.
-                line_widths = [
-                    w * guess_unknown(j, a)
-                    for w, j, a in zip(widths, justs, line)
-                ]
-                for n in range(len(line_widths)):
-                        if line_widths[n] < 0:
-                                fmt += "{{{0}!s:<{1}}} ".format(n,
-                                    -line_widths[n])
-                        else:
-                                fmt += "{{{0}!s:>{1}}} ".format(n,
-                                    line_widths[n])
-                return fmt
-        for n in range(len(widths)):
-                fmt += "{{{0}!s}}\t".format(n)
-        fmt.rstrip("\t")
+        line_widths = [
+            w * guess_unknown(j, a) for w, j, a in zip(widths, justs, line)
+        ]
+        for n in range(len(line_widths)):
+            if line_widths[n] < 0:
+                fmt += "{{{0}!s:<{1}}} ".format(n, -line_widths[n])
+            else:
+                fmt += "{{{0}!s:>{1}}} ".format(n, line_widths[n])
         return fmt
+    for n in range(len(widths)):
+        fmt += "{{{0}!s}}\t".format(n)
+    fmt.rstrip("\t")
+    return fmt
+
 
 def display_contents_results(actionlist, attrs, sort_attrs, display_headers):
-        """Print results of a "list" operation.  Returns False if no output
-        was produced."""
+    """Print results of a "list" operation.  Returns False if no output
+    was produced."""
 
-        justs = calc_justs(attrs)
-        lines = list(misc.list_actions_by_attrs(actionlist, attrs))
-        widths = calc_widths(lines, attrs)
+    justs = calc_justs(attrs)
+    lines = list(misc.list_actions_by_attrs(actionlist, attrs))
+    widths = calc_widths(lines, attrs)
 
-        if sort_attrs:
-                sortidx = 0
-                for i, attr in enumerate(attrs):
-                        if attr == sort_attrs[0]:
-                                sortidx = i
-                                break
+    if sort_attrs:
+        sortidx = 0
+        for i, attr in enumerate(attrs):
+            if attr == sort_attrs[0]:
+                sortidx = i
+                break
 
-                # Sort numeric columns numerically.
-                if justs[sortidx] == JUST_RIGHT:
-                        def key_extract(x):
-                                try:
-                                        return int(x[sortidx])
-                                except (ValueError, TypeError):
-                                        return 0
-                else:
-                        # typecast all the list elements to string else
-                        # the sorted function fails if there are any
-                        # string and list comparision.
-                        key_extract = lambda x: str(x[sortidx])
-                line_gen = sorted(lines, key=key_extract)
+        # Sort numeric columns numerically.
+        if justs[sortidx] == JUST_RIGHT:
+
+            def key_extract(x):
+                try:
+                    return int(x[sortidx])
+                except (ValueError, TypeError):
+                    return 0
+
         else:
-                line_gen = lines
+            # typecast all the list elements to string else
+            # the sorted function fails if there are any
+            # string and list comparision.
+            key_extract = lambda x: str(x[sortidx])
+        line_gen = sorted(lines, key=key_extract)
+    else:
+        line_gen = lines
 
-        printed_output = False
-        for line in line_gen:
-                text = (create_output_format(display_headers, widths, justs,
-                    line).format(*line)).rstrip()
-                if not text:
-                        continue
-                if not printed_output and display_headers:
-                        print_headers(attrs, widths, justs)
-                printed_output = True
-                msg(text)
-        return printed_output
+    printed_output = False
+    for line in line_gen:
+        text = (
+            create_output_format(display_headers, widths, justs, line).format(
+                *line
+            )
+        ).rstrip()
+        if not text:
+            continue
+        if not printed_output and display_headers:
+            print_headers(attrs, widths, justs)
+        printed_output = True
+        msg(text)
+    return printed_output
+
 
 def check_attrs(attrs, cmd, reference=None, prefixes=None):
-        """For a set of output attributes ("attrs") passed to a command ("cmd"),
-        if the attribute lives in a known name space, check whether it is valid.
-        """
+    """For a set of output attributes ("attrs") passed to a command ("cmd"),
+    if the attribute lives in a known name space, check whether it is valid.
+    """
 
-        if reference is None:
-                reference = valid_special_attrs
-        if prefixes is None:
-                prefixes = valid_special_prefixes
-        for a in attrs:
-                for p in prefixes:
-                        if a.startswith(p) and a not in reference:
-                                usage(_("Invalid attribute '{0}'").format(a),
-                                    cmd)
+    if reference is None:
+        reference = valid_special_attrs
+    if prefixes is None:
+        prefixes = valid_special_prefixes
+    for a in attrs:
+        for p in prefixes:
+            if a.startswith(p) and a not in reference:
+                usage(_("Invalid attribute '{0}'").format(a), cmd)
+
 
 def list_contents(api_inst, args):
-        """List package contents.
+    """List package contents.
 
-        If no arguments are given, display for all locally installed packages.
-        With -H omit headers and use a tab-delimited format; with -o select
-        attributes to display; with -s, specify attributes to sort on; with -t,
-        specify which action types to list."""
+    If no arguments are given, display for all locally installed packages.
+    With -H omit headers and use a tab-delimited format; with -o select
+    attributes to display; with -s, specify attributes to sort on; with -t,
+    specify which action types to list."""
 
-        opts, pargs = getopt.getopt(args, "Ha:g:o:s:t:mfr")
+    opts, pargs = getopt.getopt(args, "Ha:g:o:s:t:mfr")
 
-        subcommand = "contents"
-        display_headers = True
-        display_raw = False
-        origins = set()
-        output_fields = False
-        remote = False
-        local = False
-        attrs = []
-        sort_attrs = []
-        action_types = []
-        attr_match = {}
-        for opt, arg in opts:
-                if opt == "-H":
-                        display_headers = False
-                elif opt == "-a":
-                        try:
-                                attr, match = arg.split("=", 1)
-                        except ValueError:
-                                usage(_("-a takes an argument of the form "
-                                    "<attribute>=<pattern>"), cmd=subcommand)
-                        attr_match.setdefault(attr, []).append(match)
-                elif opt == "-g":
-                        origins.add(misc.parse_uri(arg, cwd=orig_cwd))
-                elif opt == "-o":
-                        output_fields = True
-                        attrs.extend(arg.split(","))
-                elif opt == "-s":
-                        sort_attrs.append(arg)
-                elif opt == "-t":
-                        action_types.extend(arg.split(","))
-                elif opt == "-r":
-                        remote = True
-                elif opt == "-m":
-                        display_raw = True
+    subcommand = "contents"
+    display_headers = True
+    display_raw = False
+    origins = set()
+    output_fields = False
+    remote = False
+    local = False
+    attrs = []
+    sort_attrs = []
+    action_types = []
+    attr_match = {}
+    for opt, arg in opts:
+        if opt == "-H":
+            display_headers = False
+        elif opt == "-a":
+            try:
+                attr, match = arg.split("=", 1)
+            except ValueError:
+                usage(
+                    _(
+                        "-a takes an argument of the form "
+                        "<attribute>=<pattern>"
+                    ),
+                    cmd=subcommand,
+                )
+            attr_match.setdefault(attr, []).append(match)
+        elif opt == "-g":
+            origins.add(misc.parse_uri(arg, cwd=orig_cwd))
+        elif opt == "-o":
+            output_fields = True
+            attrs.extend(arg.split(","))
+        elif opt == "-s":
+            sort_attrs.append(arg)
+        elif opt == "-t":
+            action_types.extend(arg.split(","))
+        elif opt == "-r":
+            remote = True
+        elif opt == "-m":
+            display_raw = True
 
-        if origins:
-                remote = True
-        elif not remote:
-                local = True
+    if origins:
+        remote = True
+    elif not remote:
+        local = True
 
-        if remote and not pargs:
-                usage(_("contents: must request remote contents for specific "
-                   "packages"), cmd=subcommand)
+    if remote and not pargs:
+        usage(
+            _(
+                "contents: must request remote contents for specific "
+                "packages"
+            ),
+            cmd=subcommand,
+        )
 
-        if display_raw:
-                display_headers = False
-                attrs = ["action.raw"]
+    if display_raw:
+        display_headers = False
+        attrs = ["action.raw"]
 
-                invalid = set(("-H", "-o", "-t", "-s", "-a")). \
-                    intersection(set([x[0] for x in opts]))
+        invalid = set(("-H", "-o", "-t", "-s", "-a")).intersection(
+            set([x[0] for x in opts])
+        )
 
-                if len(invalid) > 0:
-                        usage(_("-m and {0} may not be specified at the same "
-                            "time").format(invalid.pop()), cmd=subcommand)
+        if len(invalid) > 0:
+            usage(
+                _("-m and {0} may not be specified at the same " "time").format(
+                    invalid.pop()
+                ),
+                cmd=subcommand,
+            )
 
-        if action_types:
-                invalid_atype = [atype
-                    for atype in action_types
-                    if atype not in default_attrs]
-                if invalid_atype == action_types:
-                        usage(_("no valid action types specified"),
-                            cmd=subcommand)
-                elif invalid_atype:
-                        emsg(_("""\
+    if action_types:
+        invalid_atype = [
+            atype for atype in action_types if atype not in default_attrs
+        ]
+        if invalid_atype == action_types:
+            usage(_("no valid action types specified"), cmd=subcommand)
+        elif invalid_atype:
+            emsg(
+                _(
+                    """\
 WARNING: invalid action types specified: {0}
-""".format(",".join(invalid_atype))))
-
-        check_attrs(attrs, subcommand)
-
-        api_inst.progresstracker.set_purpose(
-            api_inst.progresstracker.PURPOSE_LISTING)
-
-        api_inst.log_operation_start(subcommand)
-        if local:
-                pkg_list = api.ImageInterface.LIST_INSTALLED
-        elif remote:
-                pkg_list = api.ImageInterface.LIST_NEWEST
-
-        #
-        # If the user specifies no specific attrs, and no specific
-        # sort order, then we fill in some defaults.
-        #
-        if not attrs:
-                if not action_types:
-                        # XXX Possibly have multiple exclusive attributes per
-                        # column? If listing dependencies and files, you could
-                        # have a path/fmri column which would list paths for
-                        # files and fmris for dependencies.
-                        attrs = ["path"]
-                else:
-                        # Choose default attrs based on specified action
-                        # types. A list is used here instead of a set is
-                        # because we want to maintain the order of the
-                        # attributes in which the users specify.
-                        for attr in itertools.chain.from_iterable(
-                            default_attrs.get(atype, EmptyI)
-                            for atype in action_types):
-                                    if attr not in attrs:
-                                            attrs.append(attr)
-
-        if not sort_attrs and not display_raw:
-                # XXX reverse sorting
-                # Most likely want to sort by path, so don't force people to
-                # make it explicit
-                if "path" in attrs:
-                        sort_attrs = ["path"]
-                else:
-                        sort_attrs = attrs[:1]
-
-        # if we want a raw display (contents -m), disable the automatic
-        # variant filtering that normally limits working set.
-        if display_raw:
-                excludes = EmptyI
-        else:
-                excludes = api_inst.excludes
-
-        # Now get the matching list of packages and display it.
-        processed = False
-        notfound = EmptyI
-        try:
-                res = api_inst.get_pkg_list(pkg_list, patterns=pargs,
-                    raise_unmatched=True, ranked=remote, return_fmris=True,
-                    variants=True, repos=origins)
-                manifests = []
-
-                for pfmri, summ, cats, states, pattrs in res:
-                        manifests.append(api_inst.get_manifest(pfmri,
-                            all_variants=display_raw, repos=origins))
-        except api_errors.ImageFormatUpdateNeeded as e:
-                format_update_error(e)
-                return EXIT_OOPS
-        except api_errors.InvalidPackageErrors as e:
-                error(str(e), cmd=subcommand)
-                api_inst.log_operation_end(
-                    result=RESULT_FAILED_UNKNOWN)
-                return EXIT_OOPS
-        except api_errors.CatalogRefreshException as e:
-                display_catalog_failures(e)
-                return EXIT_OOPS
-        except api_errors.InventoryException as e:
-                if e.illegal:
-                        for i in e.illegal:
-                                error(i)
-                        api_inst.log_operation_end(
-                            result=RESULT_FAILED_BAD_REQUEST)
-                        return EXIT_OOPS
-                notfound = e.notfound
-        else:
-                if local and not manifests and not pargs:
-                        error(_("no packages installed"), cmd=subcommand)
-                        api_inst.log_operation_end(
-                            result=RESULT_NOTHING_TO_DO)
-                        return EXIT_OOPS
-
-        # Build a generator expression based on whether specific action types
-        # were provided.
-        if action_types:
-                # If query is limited to specific action types, use the more
-                # efficient type-based generation mechanism.
-                gen_expr = (
-                    (m.fmri, a, None, None, None)
-                    for m in manifests
-                    for a in m.gen_actions_by_types(action_types,
-                        attr_match=attr_match, excludes=excludes)
+""".format(
+                        ",".join(invalid_atype)
+                    )
                 )
+            )
+
+    check_attrs(attrs, subcommand)
+
+    api_inst.progresstracker.set_purpose(
+        api_inst.progresstracker.PURPOSE_LISTING
+    )
+
+    api_inst.log_operation_start(subcommand)
+    if local:
+        pkg_list = api.ImageInterface.LIST_INSTALLED
+    elif remote:
+        pkg_list = api.ImageInterface.LIST_NEWEST
+
+    #
+    # If the user specifies no specific attrs, and no specific
+    # sort order, then we fill in some defaults.
+    #
+    if not attrs:
+        if not action_types:
+            # XXX Possibly have multiple exclusive attributes per
+            # column? If listing dependencies and files, you could
+            # have a path/fmri column which would list paths for
+            # files and fmris for dependencies.
+            attrs = ["path"]
         else:
-                gen_expr = (
-                    (m.fmri, a, None, None, None)
-                    for m in manifests
-                    for a in m.gen_actions(attr_match=attr_match,
-                        excludes=excludes)
+            # Choose default attrs based on specified action
+            # types. A list is used here instead of a set is
+            # because we want to maintain the order of the
+            # attributes in which the users specify.
+            for attr in itertools.chain.from_iterable(
+                default_attrs.get(atype, EmptyI) for atype in action_types
+            ):
+                if attr not in attrs:
+                    attrs.append(attr)
+
+    if not sort_attrs and not display_raw:
+        # XXX reverse sorting
+        # Most likely want to sort by path, so don't force people to
+        # make it explicit
+        if "path" in attrs:
+            sort_attrs = ["path"]
+        else:
+            sort_attrs = attrs[:1]
+
+    # if we want a raw display (contents -m), disable the automatic
+    # variant filtering that normally limits working set.
+    if display_raw:
+        excludes = EmptyI
+    else:
+        excludes = api_inst.excludes
+
+    # Now get the matching list of packages and display it.
+    processed = False
+    notfound = EmptyI
+    try:
+        res = api_inst.get_pkg_list(
+            pkg_list,
+            patterns=pargs,
+            raise_unmatched=True,
+            ranked=remote,
+            return_fmris=True,
+            variants=True,
+            repos=origins,
+        )
+        manifests = []
+
+        for pfmri, summ, cats, states, pattrs in res:
+            manifests.append(
+                api_inst.get_manifest(
+                    pfmri, all_variants=display_raw, repos=origins
                 )
+            )
+    except api_errors.ImageFormatUpdateNeeded as e:
+        format_update_error(e)
+        return EXIT_OOPS
+    except api_errors.InvalidPackageErrors as e:
+        error(str(e), cmd=subcommand)
+        api_inst.log_operation_end(result=RESULT_FAILED_UNKNOWN)
+        return EXIT_OOPS
+    except api_errors.CatalogRefreshException as e:
+        display_catalog_failures(e)
+        return EXIT_OOPS
+    except api_errors.InventoryException as e:
+        if e.illegal:
+            for i in e.illegal:
+                error(i)
+            api_inst.log_operation_end(result=RESULT_FAILED_BAD_REQUEST)
+            return EXIT_OOPS
+        notfound = e.notfound
+    else:
+        if local and not manifests and not pargs:
+            error(_("no packages installed"), cmd=subcommand)
+            api_inst.log_operation_end(result=RESULT_NOTHING_TO_DO)
+            return EXIT_OOPS
 
-        # Determine if the query returned any results by "peeking" at the first
-        # value returned from the generator expression.
-        try:
-                found = next(gen_expr)
-        except StopIteration:
-                found = None
-                actionlist = []
+    # Build a generator expression based on whether specific action types
+    # were provided.
+    if action_types:
+        # If query is limited to specific action types, use the more
+        # efficient type-based generation mechanism.
+        gen_expr = (
+            (m.fmri, a, None, None, None)
+            for m in manifests
+            for a in m.gen_actions_by_types(
+                action_types, attr_match=attr_match, excludes=excludes
+            )
+        )
+    else:
+        gen_expr = (
+            (m.fmri, a, None, None, None)
+            for m in manifests
+            for a in m.gen_actions(attr_match=attr_match, excludes=excludes)
+        )
 
-        if found:
-                # If any matching entries were found, create a new generator
-                # expression using itertools.chain that includes the first
-                # result.
-                actionlist = itertools.chain([found], gen_expr)
+    # Determine if the query returned any results by "peeking" at the first
+    # value returned from the generator expression.
+    try:
+        found = next(gen_expr)
+    except StopIteration:
+        found = None
+        actionlist = []
 
-        rval = EXIT_OK
-        if attr_match and manifests and not found:
-                rval = EXIT_OOPS
-                logger.error(_("""\
-pkg: contents: no matching actions found in the listed packages"""))
+    if found:
+        # If any matching entries were found, create a new generator
+        # expression using itertools.chain that includes the first
+        # result.
+        actionlist = itertools.chain([found], gen_expr)
 
-        if manifests and rval == EXIT_OK:
-                displayed_results = display_contents_results(actionlist, attrs,
-                    sort_attrs, display_headers)
+    rval = EXIT_OK
+    if attr_match and manifests and not found:
+        rval = EXIT_OOPS
+        logger.error(
+            _(
+                """\
+pkg: contents: no matching actions found in the listed packages"""
+            )
+        )
 
-                if not displayed_results:
-                        if output_fields:
-                                error(gettext.ngettext("""\
+    if manifests and rval == EXIT_OK:
+        displayed_results = display_contents_results(
+            actionlist, attrs, sort_attrs, display_headers
+        )
+
+        if not displayed_results:
+            if output_fields:
+                error(
+                    gettext.ngettext(
+                        """\
 This package contains no actions with the fields specified using the -o
 option. Please specify other fields, or use the -m option to show the raw
-package manifests.""", """\
+package manifests.""",
+                        """\
 These packages contain no actions with the fields specified using the -o
 option. Please specify other fields, or use the -m option to show the raw
-package manifests.""", len(pargs)))
-                        elif not actionlist:
-                                error(gettext.ngettext("""\
+package manifests.""",
+                        len(pargs),
+                    )
+                )
+            elif not actionlist:
+                error(
+                    gettext.ngettext(
+                        """\
 This package contains no actions specified using the -t option. Please
 specify other fields, or use the -m option to show the raw package
-manifests.""", """\
+manifests.""",
+                        """\
 These package contains no actions specified using the -t option. Please
 specify other fields, or use the -m option to show the raw package
-manifests.""", len(pargs)))
-                        else:
-                                error(gettext.ngettext("""\
+manifests.""",
+                        len(pargs),
+                    )
+                )
+            else:
+                error(
+                    gettext.ngettext(
+                        """\
 This package delivers no filesystem content, but may contain metadata. Use
 the -o option to specify fields other than 'path', or use the -m option to show
-the raw package manifests.""", """\
+the raw package manifests.""",
+                        """\
 These packages deliver no filesystem content, but may contain metadata. Use
 the -o option to specify fields other than 'path', or use the -m option to show
-the raw package manifests.""", len(pargs)))
+the raw package manifests.""",
+                        len(pargs),
+                    )
+                )
 
-        if notfound:
-                rval = EXIT_OOPS
-                if manifests:
-                        logger.error("")
-                if local:
-                        logger.error(_("""\
+    if notfound:
+        rval = EXIT_OOPS
+        if manifests:
+            logger.error("")
+        if local:
+            logger.error(
+                _(
+                    """\
 pkg: contents: no packages matching the following patterns you specified are
-installed on the system.  Try specifying -r to query remotely:"""))
-                elif remote:
-                        logger.error(_("""\
+installed on the system.  Try specifying -r to query remotely:"""
+                )
+            )
+        elif remote:
+            logger.error(
+                _(
+                    """\
 pkg: contents: no packages matching the following patterns you specified were
 found in the catalog.  Try relaxing the patterns, refreshing, and/or
-examining the catalogs:"""))
-                logger.error("")
-                for p in notfound:
-                        logger.error("        {0}".format(p))
-                api_inst.log_operation_end(result=RESULT_NOTHING_TO_DO)
-        else:
-                api_inst.log_operation_end(result=RESULT_SUCCEEDED)
-        return rval
+examining the catalogs:"""
+                )
+            )
+        logger.error("")
+        for p in notfound:
+            logger.error("        {0}".format(p))
+        api_inst.log_operation_end(result=RESULT_NOTHING_TO_DO)
+    else:
+        api_inst.log_operation_end(result=RESULT_SUCCEEDED)
+    return rval
 
 
 def display_catalog_failures(cre, ignore_perms_failure=False):
-        total = cre.total
-        succeeded = cre.succeeded
-        partial = 0
-        refresh_errstr = ""
+    total = cre.total
+    succeeded = cre.succeeded
+    partial = 0
+    refresh_errstr = ""
 
-        for pub, err in cre.failed:
-                if isinstance(err, api_errors.CatalogOriginRefreshException):
-                        if len(err.failed) < err.total:
-                                partial += 1
+    for pub, err in cre.failed:
+        if isinstance(err, api_errors.CatalogOriginRefreshException):
+            if len(err.failed) < err.total:
+                partial += 1
 
-                        refresh_errstr += _("\n{0}/{1} repositories for " \
-                            "publisher '{2}' could not be reached for " \
-                            "catalog refresh.\n").format(
-                            len(err.failed), err.total, pub)
-                        for o, e in err.failed:
-                                refresh_errstr += "\n"
-                                refresh_errstr += str(e)
+            refresh_errstr += _(
+                "\n{0}/{1} repositories for "
+                "publisher '{2}' could not be reached for "
+                "catalog refresh.\n"
+            ).format(len(err.failed), err.total, pub)
+            for o, e in err.failed:
+                refresh_errstr += "\n"
+                refresh_errstr += str(e)
 
-                        refresh_errstr += "\n"
-                else:
-                        refresh_errstr += "\n   \n" + str(err)
-
-
-        partial_str = ":"
-        if partial:
-                partial_str = _(" ({0} partial):").format(str(partial))
-
-        txt = _("pkg: {succeeded}/{total} catalogs successfully "
-            "updated{partial}").format(succeeded=succeeded, total=total,
-            partial=partial_str)
-        if cre.failed:
-                # This ensures that the text gets printed before the errors.
-                logger.error(txt)
+            refresh_errstr += "\n"
         else:
-                msg(txt)
+            refresh_errstr += "\n   \n" + str(err)
 
-        for pub, err in cre.failed:
-                if ignore_perms_failure and \
-                    not isinstance(err, api_errors.PermissionsException):
-                        # If any errors other than a permissions exception are
-                        # found, then don't ignore them.
-                        ignore_perms_failure = False
-                        break
+    partial_str = ":"
+    if partial:
+        partial_str = _(" ({0} partial):").format(str(partial))
 
-        if cre.failed and ignore_perms_failure:
-                # Consider those that failed to have succeeded and add them
-                # to the actual successful total.
-                return succeeded + partial + len(cre.failed)
+    txt = _(
+        "pkg: {succeeded}/{total} catalogs successfully " "updated{partial}"
+    ).format(succeeded=succeeded, total=total, partial=partial_str)
+    if cre.failed:
+        # This ensures that the text gets printed before the errors.
+        logger.error(txt)
+    else:
+        msg(txt)
 
-        logger.error(refresh_errstr)
+    for pub, err in cre.failed:
+        if ignore_perms_failure and not isinstance(
+            err, api_errors.PermissionsException
+        ):
+            # If any errors other than a permissions exception are
+            # found, then don't ignore them.
+            ignore_perms_failure = False
+            break
 
-        if cre.errmessage:
-                logger.error(cre.errmessage)
+    if cre.failed and ignore_perms_failure:
+        # Consider those that failed to have succeeded and add them
+        # to the actual successful total.
+        return succeeded + partial + len(cre.failed)
 
-        return succeeded + partial
+    logger.error(refresh_errstr)
+
+    if cre.errmessage:
+        logger.error(cre.errmessage)
+
+    return succeeded + partial
 
 
 def display_repo_failures(fail_dict):
-
-        outstr = """
+    outstr = """
 
 WARNING: Errors were encountered when attempting to retrieve package
 catalog information. Packages added to the affected publisher repositories since
 the last retrieval may not be available.
 
 """
-        for pub in fail_dict:
-                failed = fail_dict[pub]
+    for pub in fail_dict:
+        failed = fail_dict[pub]
 
-                if failed is None or "errors" not in failed:
-                        # This pub did not have any repo problems, ignore.
-                        continue
+        if failed is None or "errors" not in failed:
+            # This pub did not have any repo problems, ignore.
+            continue
 
-                assert type(failed) == dict
-                total = failed["total"]
-                if int(total) == 1:
-                        repo_str = _("repository")
-                else:
-                        repo_str = _("{0} of {1} repositories").format(
-                            len(failed["errors"]), total)
+        assert type(failed) == dict
+        total = failed["total"]
+        if int(total) == 1:
+            repo_str = _("repository")
+        else:
+            repo_str = _("{0} of {1} repositories").format(
+                len(failed["errors"]), total
+            )
 
-                outstr += _("Errors were encountered when attempting to " \
-                    "contact {0} for publisher '{1}'.\n").format(repo_str, pub)
-                for err in failed["errors"]:
-                        outstr += "\n"
-                        outstr += str(err)
-                outstr += "\n"
+        outstr += _(
+            "Errors were encountered when attempting to "
+            "contact {0} for publisher '{1}'.\n"
+        ).format(repo_str, pub)
+        for err in failed["errors"]:
+            outstr += "\n"
+            outstr += str(err)
+        outstr += "\n"
 
-        msg(outstr)
+    msg(outstr)
+
 
 def __refresh(api_inst, pubs, full_refresh=False):
-        """Private helper method for refreshing publisher data."""
+    """Private helper method for refreshing publisher data."""
 
-        try:
-                # The user explicitly requested this refresh, so set the
-                # refresh to occur immediately.
-                api_inst.refresh(full_refresh=full_refresh,
-                    ignore_unreachable=False, immediate=True, pubs=pubs)
-        except api_errors.ImageFormatUpdateNeeded as e:
-                format_update_error(e)
-                return EXIT_OOPS
-        except api_errors.PublisherError as e:
-                error(e)
-                error(_("'pkg publisher' will show a list of publishers."))
-                return EXIT_OOPS
-        except (api_errors.UnknownErrors, api_errors.PermissionsException) as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                error("\n" + str(e))
-                return EXIT_OOPS
-        except api_errors.CatalogRefreshException as e:
-                if display_catalog_failures(e) == 0:
-                        return EXIT_OOPS
-                return EXIT_PARTIAL
-        return EXIT_OK
+    try:
+        # The user explicitly requested this refresh, so set the
+        # refresh to occur immediately.
+        api_inst.refresh(
+            full_refresh=full_refresh,
+            ignore_unreachable=False,
+            immediate=True,
+            pubs=pubs,
+        )
+    except api_errors.ImageFormatUpdateNeeded as e:
+        format_update_error(e)
+        return EXIT_OOPS
+    except api_errors.PublisherError as e:
+        error(e)
+        error(_("'pkg publisher' will show a list of publishers."))
+        return EXIT_OOPS
+    except (api_errors.UnknownErrors, api_errors.PermissionsException) as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        error("\n" + str(e))
+        return EXIT_OOPS
+    except api_errors.CatalogRefreshException as e:
+        if display_catalog_failures(e) == 0:
+            return EXIT_OOPS
+        return EXIT_PARTIAL
+    return EXIT_OK
+
 
 def publisher_refresh(api_inst, args):
-        """Update metadata for the image's publishers."""
+    """Update metadata for the image's publishers."""
 
-        # XXX will need to show available content series for each package
-        full_refresh = False
-        opts, pargs = getopt.getopt(args, "q", ["full"])
-        for opt, arg in opts:
-                if opt == "-q":
-                        global_settings.client_output_quiet = True
-                if opt == "--full":
-                        full_refresh = True
-        # Reset the progress tracker here, because we may have
-        # to switch to a different tracker due to the options parse.
-        _api_inst.progresstracker = get_tracker()
-        # suppress phase information since we're doing just one thing.
-        api_inst.progresstracker.set_major_phase(
-            api_inst.progresstracker.PHASE_UTILITY)
-        return __refresh(api_inst, pargs, full_refresh=full_refresh)
+    # XXX will need to show available content series for each package
+    full_refresh = False
+    opts, pargs = getopt.getopt(args, "q", ["full"])
+    for opt, arg in opts:
+        if opt == "-q":
+            global_settings.client_output_quiet = True
+        if opt == "--full":
+            full_refresh = True
+    # Reset the progress tracker here, because we may have
+    # to switch to a different tracker due to the options parse.
+    _api_inst.progresstracker = get_tracker()
+    # suppress phase information since we're doing just one thing.
+    api_inst.progresstracker.set_major_phase(
+        api_inst.progresstracker.PHASE_UTILITY
+    )
+    return __refresh(api_inst, pargs, full_refresh=full_refresh)
+
 
 def copy_publishers_from(api_inst, args):
-        """pkg copy-publishers-from <dir>"""
-        opts, pargs = getopt.getopt(args, "")
-        if len(pargs) != 1:
-                usage(_("directory to copy from must be specified"),
-                      cmd="copy-publishers-from")
-        src_api_inst = __api_alloc(pargs[0], True, False)
-        if not src_api_inst:
-                return EXIT_OOPS
-        for n, pub in enumerate(src_api_inst.get_publishers()):
-                search_first = True if n == 0 else False
-                if api_inst.has_publisher(prefix=pub.prefix, alias=pub.prefix):
-                        api_inst.remove_publisher(prefix=pub.prefix,
-                                                  alias=pub.prefix)
-                pub.reset_client_uuid()
-                api_inst.add_publisher(pub, refresh_allowed=False,
-                                       search_first=search_first)
-        api_inst.refresh()
-        return EXIT_OK
+    """pkg copy-publishers-from <dir>"""
+    opts, pargs = getopt.getopt(args, "")
+    if len(pargs) != 1:
+        usage(
+            _("directory to copy from must be specified"),
+            cmd="copy-publishers-from",
+        )
+    src_api_inst = __api_alloc(pargs[0], True, False)
+    if not src_api_inst:
+        return EXIT_OOPS
+    for n, pub in enumerate(src_api_inst.get_publishers()):
+        search_first = True if n == 0 else False
+        if api_inst.has_publisher(prefix=pub.prefix, alias=pub.prefix):
+            api_inst.remove_publisher(prefix=pub.prefix, alias=pub.prefix)
+        pub.reset_client_uuid()
+        api_inst.add_publisher(
+            pub, refresh_allowed=False, search_first=search_first
+        )
+    api_inst.refresh()
+    return EXIT_OK
+
 
 def list_uuids(api_inst, args):
-        """pkg list-uuids"""
-        for n, pub in enumerate(api_inst.get_publishers()):
-                msg("{0:18} {1} {2}".format(pub.prefix,
-                    pub.client_uuid, pub.client_uuid_time));
-        return EXIT_OK
+    """pkg list-uuids"""
+    for n, pub in enumerate(api_inst.get_publishers()):
+        msg(
+            "{0:18} {1} {2}".format(
+                pub.prefix, pub.client_uuid, pub.client_uuid_time
+            )
+        )
+    return EXIT_OK
+
 
 def _get_ssl_cert_key(root, is_zone, ssl_cert, ssl_key):
-        if ssl_cert is not None or ssl_key is not None:
-                # In the case of zones, the ssl cert given is assumed to
-                # be relative to the root of the image, not truly absolute.
-                if is_zone:
-                        if ssl_cert is not None:
-                                ssl_cert = os.path.abspath(
-                                    root + os.sep + ssl_cert)
-                        if ssl_key is not None:
-                                ssl_key = os.path.abspath(
-                                    root + os.sep + ssl_key)
-                elif orig_cwd:
-                        if ssl_cert and not os.path.isabs(ssl_cert):
-                                ssl_cert = os.path.normpath(os.path.join(
-                                    orig_cwd, ssl_cert))
-                        if ssl_key and not os.path.isabs(ssl_key):
-                                ssl_key = os.path.normpath(os.path.join(
-                                    orig_cwd, ssl_key))
-        return ssl_cert, ssl_key
+    if ssl_cert is not None or ssl_key is not None:
+        # In the case of zones, the ssl cert given is assumed to
+        # be relative to the root of the image, not truly absolute.
+        if is_zone:
+            if ssl_cert is not None:
+                ssl_cert = os.path.abspath(root + os.sep + ssl_cert)
+            if ssl_key is not None:
+                ssl_key = os.path.abspath(root + os.sep + ssl_key)
+        elif orig_cwd:
+            if ssl_cert and not os.path.isabs(ssl_cert):
+                ssl_cert = os.path.normpath(os.path.join(orig_cwd, ssl_cert))
+            if ssl_key and not os.path.isabs(ssl_key):
+                ssl_key = os.path.normpath(os.path.join(orig_cwd, ssl_key))
+    return ssl_cert, ssl_key
+
 
 def _set_pub_error_wrap(func, pfx, raise_errors, *args, **kwargs):
-        """Helper function to wrap set-publisher private methods.  Returns
-        a tuple of (return value, message).  Callers should check the return
-        value for errors."""
+    """Helper function to wrap set-publisher private methods.  Returns
+    a tuple of (return value, message).  Callers should check the return
+    value for errors."""
 
-        try:
-                return func(*args, **kwargs)
-        except api_errors.CatalogRefreshException as e:
-                for entry in raise_errors:
-                        if isinstance(e, entry):
-                                raise
-                txt = _("Could not refresh the catalog for {0}\n").format(
-                    pfx)
-                for pub, err in e.failed:
-                        txt += "   \n{0}".format(err)
-                return EXIT_OOPS, txt
-        except api_errors.InvalidDepotResponseException as e:
-                for entry in raise_errors:
-                        if isinstance(e, entry):
-                                raise
-                if pfx:
-                        return EXIT_OOPS, _("The origin URIs for '{pubname}' "
-                            "do not appear to point to a valid pkg repository."
-                            "\nPlease verify the repository's location and the "
-                            "client's network configuration."
-                            "\nAdditional details:\n\n{details}").format(
-                            pubname=pfx, details=str(e))
-                return EXIT_OOPS, _("The specified URI does not appear to "
-                    "point to a valid pkg repository.\nPlease check the URI "
-                    "and the client's network configuration."
-                    "\nAdditional details:\n\n{0}").format(str(e))
-        except api_errors.ImageFormatUpdateNeeded as e:
-                for entry in raise_errors:
-                        if isinstance(e, entry):
-                                raise
-                format_update_error(e)
-                return EXIT_OOPS, ""
-        except api_errors.ApiException as e:
-                for entry in raise_errors:
-                        if isinstance(e, entry):
-                                raise
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                return EXIT_OOPS, ("\n" + str(e))
+    try:
+        return func(*args, **kwargs)
+    except api_errors.CatalogRefreshException as e:
+        for entry in raise_errors:
+            if isinstance(e, entry):
+                raise
+        txt = _("Could not refresh the catalog for {0}\n").format(pfx)
+        for pub, err in e.failed:
+            txt += "   \n{0}".format(err)
+        return EXIT_OOPS, txt
+    except api_errors.InvalidDepotResponseException as e:
+        for entry in raise_errors:
+            if isinstance(e, entry):
+                raise
+        if pfx:
+            return EXIT_OOPS, _(
+                "The origin URIs for '{pubname}' "
+                "do not appear to point to a valid pkg repository."
+                "\nPlease verify the repository's location and the "
+                "client's network configuration."
+                "\nAdditional details:\n\n{details}"
+            ).format(pubname=pfx, details=str(e))
+        return EXIT_OOPS, _(
+            "The specified URI does not appear to "
+            "point to a valid pkg repository.\nPlease check the URI "
+            "and the client's network configuration."
+            "\nAdditional details:\n\n{0}"
+        ).format(str(e))
+    except api_errors.ImageFormatUpdateNeeded as e:
+        for entry in raise_errors:
+            if isinstance(e, entry):
+                raise
+        format_update_error(e)
+        return EXIT_OOPS, ""
+    except api_errors.ApiException as e:
+        for entry in raise_errors:
+            if isinstance(e, entry):
+                raise
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        return EXIT_OOPS, ("\n" + str(e))
 
-def publisher_set(op, api_inst, pargs, ssl_key, ssl_cert, origin_uri,
-    reset_uuid, add_mirrors, remove_mirrors, add_origins, remove_origins,
-    enable_origins, disable_origins, refresh_allowed, disable, sticky,
-    search_before, search_after, search_first, approved_ca_certs,
-    revoked_ca_certs, unset_ca_certs, set_props, add_prop_values,
-    remove_prop_values, unset_props, repo_uri, proxy_uri,
-    li_erecurse, verbose):
-        """pkg set-publisher [-Pedv] [-k ssl_key] [-c ssl_cert] [--reset-uuid]
-            [-O|--origin_uri origin to set]
-            [-g|--add-origin origin to add] [-G|--remove-origin origin to
-            remove] [-m|--add-mirror mirror to add] [-M|--remove-mirror mirror
-            to remove] [-p repo_uri] [--enable] [--disable] [--no-refresh]
-            [-R | -r [-z zonename... | -Z zonename...]]
-            [--sticky] [--non-sticky ] [--search-before=publisher]
-            [--search-after=publisher]
-            [--approve-ca-cert path to CA]
-            [--revoke-ca-cert hash of CA to remove]
-            [--unset-ca-cert hash of CA to unset]
-            [--set-property name of property=value]
-            [--add-property-value name of property=value to add]
-            [--remove-property-value name of property=value to remove]
-            [--unset-property name of property to delete]
-            [--proxy proxy to use]
-            [publisher] """
 
-        if origin_uri:
-                origin_uri = misc.parse_uri(origin_uri, cwd=orig_cwd)
+def publisher_set(
+    op,
+    api_inst,
+    pargs,
+    ssl_key,
+    ssl_cert,
+    origin_uri,
+    reset_uuid,
+    add_mirrors,
+    remove_mirrors,
+    add_origins,
+    remove_origins,
+    enable_origins,
+    disable_origins,
+    refresh_allowed,
+    disable,
+    sticky,
+    search_before,
+    search_after,
+    search_first,
+    approved_ca_certs,
+    revoked_ca_certs,
+    unset_ca_certs,
+    set_props,
+    add_prop_values,
+    remove_prop_values,
+    unset_props,
+    repo_uri,
+    proxy_uri,
+    li_erecurse,
+    verbose,
+):
+    """pkg set-publisher [-Pedv] [-k ssl_key] [-c ssl_cert] [--reset-uuid]
+    [-O|--origin_uri origin to set]
+    [-g|--add-origin origin to add] [-G|--remove-origin origin to
+    remove] [-m|--add-mirror mirror to add] [-M|--remove-mirror mirror
+    to remove] [-p repo_uri] [--enable] [--disable] [--no-refresh]
+    [-R | -r [-z zonename... | -Z zonename...]]
+    [--sticky] [--non-sticky ] [--search-before=publisher]
+    [--search-after=publisher]
+    [--approve-ca-cert path to CA]
+    [--revoke-ca-cert hash of CA to remove]
+    [--unset-ca-cert hash of CA to unset]
+    [--set-property name of property=value]
+    [--add-property-value name of property=value to add]
+    [--remove-property-value name of property=value to remove]
+    [--unset-property name of property to delete]
+    [--proxy proxy to use]
+    [publisher]"""
 
-        out_json = client_api._publisher_set(op, api_inst, pargs, ssl_key,
-            ssl_cert, origin_uri, reset_uuid, add_mirrors, remove_mirrors,
-            add_origins, remove_origins, enable_origins, disable_origins,
-            refresh_allowed, disable, sticky, search_before, search_after,
-            search_first, approved_ca_certs, revoked_ca_certs, unset_ca_certs,
-            set_props, add_prop_values, remove_prop_values, unset_props,
-            repo_uri, proxy_uri)
+    if origin_uri:
+        origin_uri = misc.parse_uri(origin_uri, cwd=orig_cwd)
 
-        errors = None
-        if "errors" in out_json:
-                errors = out_json["errors"]
-                errors = _generate_error_messages(out_json["status"], errors,
-                    selected_type=["publisher_set"])
-        elif li_erecurse is not None:
-                for li_name, li_rel, li_path in api_inst.list_linked():
-                        if li_rel != "child": continue
-                        if li_name not in li_erecurse: continue
-                        if verbose:
-                                print("Updating publisher on", li_name)
-                        li_api = __api_alloc(li_path, True, False)
-                        if not li_api: continue
-                        li_json = client_api._publisher_set(op, li_api,
-                            pargs, ssl_key, ssl_cert, origin_uri, reset_uuid,
-                            add_mirrors, remove_mirrors, add_origins,
-                            remove_origins, enable_origins, disable_origins,
-                            refresh_allowed, disable, sticky,
-                            search_before, search_after, search_first,
-                            approved_ca_certs, revoked_ca_certs, unset_ca_certs,
-                            set_props, add_prop_values, remove_prop_values,
-                            unset_props, repo_uri, proxy_uri)
-                        if "errors" in li_json:
-                                if not errors: errors = []
-                                errors.append(_generate_error_messages(
-                                    li_json["status"], li_json["errors"],
-                                        selected_type=["publisher_set"]))
+    out_json = client_api._publisher_set(
+        op,
+        api_inst,
+        pargs,
+        ssl_key,
+        ssl_cert,
+        origin_uri,
+        reset_uuid,
+        add_mirrors,
+        remove_mirrors,
+        add_origins,
+        remove_origins,
+        enable_origins,
+        disable_origins,
+        refresh_allowed,
+        disable,
+        sticky,
+        search_before,
+        search_after,
+        search_first,
+        approved_ca_certs,
+        revoked_ca_certs,
+        unset_ca_certs,
+        set_props,
+        add_prop_values,
+        remove_prop_values,
+        unset_props,
+        repo_uri,
+        proxy_uri,
+    )
 
-        if "data" in out_json:
-                if "header" in out_json["data"]:
-                        logger.info(out_json["data"]["header"])
-                if "added" in out_json["data"]:
-                        logger.info(_("  Added publisher(s): {0}").format(
-                            ", ".join(out_json["data"]["added"])))
-                if "updated" in out_json["data"]:
-                        logger.info(_("  Updated publisher(s): {0}").format(
-                            ", ".join(out_json["data"]["updated"])))
+    errors = None
+    if "errors" in out_json:
+        errors = out_json["errors"]
+        errors = _generate_error_messages(
+            out_json["status"], errors, selected_type=["publisher_set"]
+        )
+    elif li_erecurse is not None:
+        for li_name, li_rel, li_path in api_inst.list_linked():
+            if li_rel != "child":
+                continue
+            if li_name not in li_erecurse:
+                continue
+            if verbose:
+                print("Updating publisher on", li_name)
+            li_api = __api_alloc(li_path, True, False)
+            if not li_api:
+                continue
+            li_json = client_api._publisher_set(
+                op,
+                li_api,
+                pargs,
+                ssl_key,
+                ssl_cert,
+                origin_uri,
+                reset_uuid,
+                add_mirrors,
+                remove_mirrors,
+                add_origins,
+                remove_origins,
+                enable_origins,
+                disable_origins,
+                refresh_allowed,
+                disable,
+                sticky,
+                search_before,
+                search_after,
+                search_first,
+                approved_ca_certs,
+                revoked_ca_certs,
+                unset_ca_certs,
+                set_props,
+                add_prop_values,
+                remove_prop_values,
+                unset_props,
+                repo_uri,
+                proxy_uri,
+            )
+            if "errors" in li_json:
+                if not errors:
+                    errors = []
+                errors.append(
+                    _generate_error_messages(
+                        li_json["status"],
+                        li_json["errors"],
+                        selected_type=["publisher_set"],
+                    )
+                )
 
-        if errors:
-                _generate_error_messages(out_json["status"], errors,
-                    cmd="set-publisher", add_info={"repo_uri": repo_uri})
+    if "data" in out_json:
+        if "header" in out_json["data"]:
+            logger.info(out_json["data"]["header"])
+        if "added" in out_json["data"]:
+            logger.info(
+                _("  Added publisher(s): {0}").format(
+                    ", ".join(out_json["data"]["added"])
+                )
+            )
+        if "updated" in out_json["data"]:
+            logger.info(
+                _("  Updated publisher(s): {0}").format(
+                    ", ".join(out_json["data"]["updated"])
+                )
+            )
 
-        return out_json["status"]
+    if errors:
+        _generate_error_messages(
+            out_json["status"],
+            errors,
+            cmd="set-publisher",
+            add_info={"repo_uri": repo_uri},
+        )
+
+    return out_json["status"]
+
 
 def publisher_unset(api_inst, pargs):
-        """pkg unset-publisher publisher ..."""
+    """pkg unset-publisher publisher ..."""
 
-        opts, pargs = getopt.getopt(pargs, "")
-        out_json = client_api._publisher_unset("unset-publisher", api_inst,
-            pargs)
+    opts, pargs = getopt.getopt(pargs, "")
+    out_json = client_api._publisher_unset("unset-publisher", api_inst, pargs)
 
-        if "errors" in out_json:
-                _generate_error_messages(out_json["status"],
-                    out_json["errors"], cmd="unset-publisher")
+    if "errors" in out_json:
+        _generate_error_messages(
+            out_json["status"], out_json["errors"], cmd="unset-publisher"
+        )
 
-        return out_json["status"]
+    return out_json["status"]
 
-def publisher_list(op, api_inst, pargs, omit_headers, preferred_only,
-    inc_disabled, output_format):
-        """pkg publishers."""
 
-        ret_json = client_api._publisher_list(op, api_inst, pargs, omit_headers,
-            preferred_only, inc_disabled, output_format)
-        retcode = ret_json["status"]
+def publisher_list(
+    op,
+    api_inst,
+    pargs,
+    omit_headers,
+    preferred_only,
+    inc_disabled,
+    output_format,
+):
+    """pkg publishers."""
 
-        if len(pargs) == 0:
-                # Create a formatting string for the default output
-                # format.
-                if output_format == "default":
-                        fmt = "{0:14} {1:12} {2:8} {3:2} {4} {5}"
+    ret_json = client_api._publisher_list(
+        op,
+        api_inst,
+        pargs,
+        omit_headers,
+        preferred_only,
+        inc_disabled,
+        output_format,
+    )
+    retcode = ret_json["status"]
 
-                # Create a formatting string for the tsv output
-                # format.
-                if output_format == "tsv":
-                        fmt = "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}"
+    if len(pargs) == 0:
+        # Create a formatting string for the default output
+        # format.
+        if output_format == "default":
+            fmt = "{0:14} {1:12} {2:8} {3:2} {4} {5}"
 
-                # Output an header if desired.
-                if not omit_headers:
-                        msg(fmt.format(*ret_json["data"]["headers"]))
+        # Create a formatting string for the tsv output
+        # format.
+        if output_format == "tsv":
+            fmt = "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}"
 
-                for p in ret_json["data"]["publishers"]:
-                        msg(fmt.format(*p))
-        else:
-                def display_signing_certs(p):
-                        if "Approved CAs" in p:
-                                msg(_("         Approved CAs:"),
-                                    p["Approved CAs"][0])
-                                for h in p["Approved CAs"][1:]:
-                                        msg(_("                     :"), h)
-                        if "Revoked CAs" in p:
-                                msg(_("          Revoked CAs:"),
-                                    p["Revoked CAs"][0])
-                                for h in p["Revoked CAs"][1:]:
-                                        msg(_("                     :"), h)
+        # Output an header if desired.
+        if not omit_headers:
+            msg(fmt.format(*ret_json["data"]["headers"]))
 
-                def display_ssl_info(uri_data):
-                        msg(_("              SSL Key:"), uri_data["SSL Key"])
-                        msg(_("             SSL Cert:"), uri_data["SSL Cert"])
+        for p in ret_json["data"]["publishers"]:
+            msg(fmt.format(*p))
+    else:
 
-                        if "errors" in ret_json:
-                                for e in ret_json["errors"]:
-                                        if "errtype" in e and \
-                                            e["errtype"] == "cert_info":
-                                                emsg(e["reason"])
+        def display_signing_certs(p):
+            if "Approved CAs" in p:
+                msg(_("         Approved CAs:"), p["Approved CAs"][0])
+                for h in p["Approved CAs"][1:]:
+                    msg(_("                     :"), h)
+            if "Revoked CAs" in p:
+                msg(_("          Revoked CAs:"), p["Revoked CAs"][0])
+                for h in p["Revoked CAs"][1:]:
+                    msg(_("                     :"), h)
 
-                        if "Cert. Effective Date" in uri_data:
-                                msg(_(" Cert. Effective Date:"),
-                                    uri_data["Cert. Effective Date"])
-                                msg(_("Cert. Expiration Date:"),
-                                    uri_data["Cert. Expiration Date"])
+        def display_ssl_info(uri_data):
+            msg(_("              SSL Key:"), uri_data["SSL Key"])
+            msg(_("             SSL Cert:"), uri_data["SSL Cert"])
 
-                if "data" not in ret_json or "publisher_details" not in \
-                    ret_json["data"]:
-                        return retcode
+            if "errors" in ret_json:
+                for e in ret_json["errors"]:
+                    if "errtype" in e and e["errtype"] == "cert_info":
+                        emsg(e["reason"])
 
-                for pub in ret_json["data"]["publisher_details"]:
-                        msg("")
-                        msg(_("            Publisher:"), pub["Publisher"])
-                        msg(_("                Alias:"), pub["Alias"])
+            if "Cert. Effective Date" in uri_data:
+                msg(
+                    _(" Cert. Effective Date:"),
+                    uri_data["Cert. Effective Date"],
+                )
+                msg(
+                    _("Cert. Expiration Date:"),
+                    uri_data["Cert. Expiration Date"],
+                )
 
-                        if "origins" in pub:
-                                for od in pub["origins"]:
-                                        msg(_("           Origin URI:"),
-                                            od["Origin URI"])
-                                        msg(_("        Origin Status:"),
-                                            od["Status"])
-                                        if "Proxy" in od:
-                                                msg(_("                Proxy:"),
-                                                    ", ".join(od["Proxy"]))
-                                        display_ssl_info(od)
+        if (
+            "data" not in ret_json
+            or "publisher_details" not in ret_json["data"]
+        ):
+            return retcode
 
-                        if "mirrors" in pub:
-                                for md in pub["mirrors"]:
-                                        msg(_("           Mirror URI:"),
-                                            md["Mirror URI"])
-                                        msg(_("           Mirror Status:"),
-                                            md["Status"])
-                                        if "Proxy" in md:
-                                                msg(_("                Proxy:"),
-                                                    ", ".join(md["Proxy"]))
-                                        display_ssl_info(md)
+        for pub in ret_json["data"]["publisher_details"]:
+            msg("")
+            msg(_("            Publisher:"), pub["Publisher"])
+            msg(_("                Alias:"), pub["Alias"])
 
-                        msg(_("          Client UUID:"),
-                            pub["Client UUID"])
-                        msg(_("      Catalog Updated:"),
-                            pub["Catalog Updated"])
-                        display_signing_certs(pub)
-                        msg(_("    Publisher enabled:"),
-                            _(pub["enabled"]))
+            if "origins" in pub:
+                for od in pub["origins"]:
+                    msg(_("           Origin URI:"), od["Origin URI"])
+                    msg(_("        Origin Status:"), od["Status"])
+                    if "Proxy" in od:
+                        msg(_("                Proxy:"), ", ".join(od["Proxy"]))
+                    display_ssl_info(od)
 
-                        if "Properties" not in pub:
-                                continue
-                        pub_items = sorted(
-                            six.iteritems(pub["Properties"]))
-                        property_padding = "                      "
-                        properties_displayed = False
-                        for k, v in pub_items:
-                                if not v:
-                                        continue
-                                if not properties_displayed:
-                                        msg(_("           Properties:"))
-                                        properties_displayed = True
-                                if not isinstance(v, six.string_types):
-                                        v = ", ".join(sorted(v))
-                                msg(property_padding, k + " =", str(v))
-        return retcode
+            if "mirrors" in pub:
+                for md in pub["mirrors"]:
+                    msg(_("           Mirror URI:"), md["Mirror URI"])
+                    msg(_("           Mirror Status:"), md["Status"])
+                    if "Proxy" in md:
+                        msg(_("                Proxy:"), ", ".join(md["Proxy"]))
+                    display_ssl_info(md)
+
+            msg(_("          Client UUID:"), pub["Client UUID"])
+            msg(_("      Catalog Updated:"), pub["Catalog Updated"])
+            display_signing_certs(pub)
+            msg(_("    Publisher enabled:"), _(pub["enabled"]))
+
+            if "Properties" not in pub:
+                continue
+            pub_items = sorted(six.iteritems(pub["Properties"]))
+            property_padding = "                      "
+            properties_displayed = False
+            for k, v in pub_items:
+                if not v:
+                    continue
+                if not properties_displayed:
+                    msg(_("           Properties:"))
+                    properties_displayed = True
+                if not isinstance(v, six.string_types):
+                    v = ", ".join(sorted(v))
+                msg(property_padding, k + " =", str(v))
+    return retcode
+
 
 def property_add_value(api_inst, args):
-        """pkg add-property-value propname propvalue"""
+    """pkg add-property-value propname propvalue"""
 
-        # ensure no options are passed in
-        subcommand = "add-property-value"
-        opts, pargs = getopt.getopt(args, "")
-        try:
-                propname, propvalue = pargs
-        except ValueError:
-                usage(_("requires a property name and value"), cmd=subcommand)
+    # ensure no options are passed in
+    subcommand = "add-property-value"
+    opts, pargs = getopt.getopt(args, "")
+    try:
+        propname, propvalue = pargs
+    except ValueError:
+        usage(_("requires a property name and value"), cmd=subcommand)
 
-        # XXX image property management should be in pkg.client.api
-        try:
-                img.add_property_value(propname, propvalue)
-        except api_errors.ImageFormatUpdateNeeded as e:
-                format_update_error(e)
-                return EXIT_OOPS
-        except api_errors.ApiException as e:
-                error(str(e), cmd=subcommand)
-                return EXIT_OOPS
-        return EXIT_OK
+    # XXX image property management should be in pkg.client.api
+    try:
+        img.add_property_value(propname, propvalue)
+    except api_errors.ImageFormatUpdateNeeded as e:
+        format_update_error(e)
+        return EXIT_OOPS
+    except api_errors.ApiException as e:
+        error(str(e), cmd=subcommand)
+        return EXIT_OOPS
+    return EXIT_OK
+
 
 def property_remove_value(api_inst, args):
-        """pkg remove-property-value propname propvalue"""
+    """pkg remove-property-value propname propvalue"""
 
-        # ensure no options are passed in
-        subcommand = "remove-property-value"
-        opts, pargs = getopt.getopt(args, "")
-        try:
-                propname, propvalue = pargs
-        except ValueError:
-                usage(_("requires a property name and value"), cmd=subcommand)
+    # ensure no options are passed in
+    subcommand = "remove-property-value"
+    opts, pargs = getopt.getopt(args, "")
+    try:
+        propname, propvalue = pargs
+    except ValueError:
+        usage(_("requires a property name and value"), cmd=subcommand)
 
-        # XXX image property management should be in pkg.client.api
-        try:
-                img.remove_property_value(propname, propvalue)
-        except api_errors.ImageFormatUpdateNeeded as e:
-                format_update_error(e)
-                return EXIT_OOPS
-        except api_errors.ApiException as e:
-                error(str(e), cmd=subcommand)
-                return EXIT_OOPS
-        return EXIT_OK
+    # XXX image property management should be in pkg.client.api
+    try:
+        img.remove_property_value(propname, propvalue)
+    except api_errors.ImageFormatUpdateNeeded as e:
+        format_update_error(e)
+        return EXIT_OOPS
+    except api_errors.ApiException as e:
+        error(str(e), cmd=subcommand)
+        return EXIT_OOPS
+    return EXIT_OK
+
 
 def property_set(api_inst, args):
-        """pkg set-property propname propvalue [propvalue ...]"""
+    """pkg set-property propname propvalue [propvalue ...]"""
 
-        # ensure no options are passed in
-        subcommand = "set-property"
-        opts, pargs = getopt.getopt(args, "")
-        try:
-                propname = pargs[0]
-                propvalues = pargs[1:]
-        except IndexError:
-                propvalues = []
-        if len(propvalues) == 0:
-                usage(_("requires a property name and at least one value"),
-                    cmd=subcommand)
-        elif propname not in ("publisher-search-order",
-            "signature-policy", "signature-required-names") and \
-            len(propvalues) == 1:
-                # All other properties are single value, so if only one (or no)
-                # value was specified, transform it.  If multiple values were
-                # specified, allow the value to be passed on so that the
-                # configuration classes can re-raise the appropriate error.
-                propvalues = propvalues[0]
+    # ensure no options are passed in
+    subcommand = "set-property"
+    opts, pargs = getopt.getopt(args, "")
+    try:
+        propname = pargs[0]
+        propvalues = pargs[1:]
+    except IndexError:
+        propvalues = []
+    if len(propvalues) == 0:
+        usage(
+            _("requires a property name and at least one value"), cmd=subcommand
+        )
+    elif (
+        propname
+        not in (
+            "publisher-search-order",
+            "signature-policy",
+            "signature-required-names",
+        )
+        and len(propvalues) == 1
+    ):
+        # All other properties are single value, so if only one (or no)
+        # value was specified, transform it.  If multiple values were
+        # specified, allow the value to be passed on so that the
+        # configuration classes can re-raise the appropriate error.
+        propvalues = propvalues[0]
 
-        props = { propname: propvalues }
-        if propname == "signature-policy":
-                policy = propvalues[0]
-                props[propname] = policy
-                params = propvalues[1:]
-                if policy != "require-names" and len(params):
-                        usage(_("Signature-policy {0} doesn't allow additional "
-                            "parameters.").format(policy), cmd=subcommand)
-                elif policy == "require-names":
-                        props["signature-required-names"] = params
+    props = {propname: propvalues}
+    if propname == "signature-policy":
+        policy = propvalues[0]
+        props[propname] = policy
+        params = propvalues[1:]
+        if policy != "require-names" and len(params):
+            usage(
+                _(
+                    "Signature-policy {0} doesn't allow additional "
+                    "parameters."
+                ).format(policy),
+                cmd=subcommand,
+            )
+        elif policy == "require-names":
+            props["signature-required-names"] = params
 
-        # XXX image property management should be in pkg.client.api
-        try:
-                img.set_properties(props)
-        except api_errors.ImageFormatUpdateNeeded as e:
-                format_update_error(e)
-                return EXIT_OOPS
-        except api_errors.ApiException as e:
-                error(str(e), cmd=subcommand)
-                return EXIT_OOPS
-        return EXIT_OK
+    # XXX image property management should be in pkg.client.api
+    try:
+        img.set_properties(props)
+    except api_errors.ImageFormatUpdateNeeded as e:
+        format_update_error(e)
+        return EXIT_OOPS
+    except api_errors.ApiException as e:
+        error(str(e), cmd=subcommand)
+        return EXIT_OOPS
+    return EXIT_OK
+
 
 def property_unset(api_inst, args):
-        """pkg unset-property propname ..."""
+    """pkg unset-property propname ..."""
 
-        # is this an existing property in our image?
-        # if so, delete it
-        # if not, error
+    # is this an existing property in our image?
+    # if so, delete it
+    # if not, error
 
-        # ensure no options are passed in
-        subcommand = "unset-property"
-        opts, pargs = getopt.getopt(args, "")
-        if not pargs:
-                usage(_("requires at least one property name"),
-                    cmd=subcommand)
+    # ensure no options are passed in
+    subcommand = "unset-property"
+    opts, pargs = getopt.getopt(args, "")
+    if not pargs:
+        usage(_("requires at least one property name"), cmd=subcommand)
 
-        # XXX image property management should be in pkg.client.api
-        for p in pargs:
-                try:
-                        img.delete_property(p)
-                except api_errors.ImageFormatUpdateNeeded as e:
-                        format_update_error(e)
-                        return EXIT_OOPS
-                except api_errors.ApiException as e:
-                        error(str(e), cmd=subcommand)
-                        return EXIT_OOPS
+    # XXX image property management should be in pkg.client.api
+    for p in pargs:
+        try:
+            img.delete_property(p)
+        except api_errors.ImageFormatUpdateNeeded as e:
+            format_update_error(e)
+            return EXIT_OOPS
+        except api_errors.ApiException as e:
+            error(str(e), cmd=subcommand)
+            return EXIT_OOPS
 
-        return EXIT_OK
+    return EXIT_OK
+
 
 def property_list(api_inst, args):
-        """pkg property [-H] [propname ...]"""
-        omit_headers = False
+    """pkg property [-H] [propname ...]"""
+    omit_headers = False
 
-        subcommand = "property"
-        opts, pargs = getopt.getopt(args, "H")
-        for opt, arg in opts:
-                if opt == "-H":
-                        omit_headers = True
+    subcommand = "property"
+    opts, pargs = getopt.getopt(args, "H")
+    for opt, arg in opts:
+        if opt == "-H":
+            omit_headers = True
 
-        # XXX image property management should be in pkg.client.api
-        for p in pargs:
-                if not img.has_property(p):
-                        error(_("no such property: {0}").format(p),
-                            cmd=subcommand)
-                        return EXIT_OOPS
+    # XXX image property management should be in pkg.client.api
+    for p in pargs:
+        if not img.has_property(p):
+            error(_("no such property: {0}").format(p), cmd=subcommand)
+            return EXIT_OOPS
 
-        if not pargs:
-                # If specific properties were named, list them in the order
-                # requested; otherwise, list them sorted.
-                pargs = sorted(list(img.properties()))
+    if not pargs:
+        # If specific properties were named, list them in the order
+        # requested; otherwise, list them sorted.
+        pargs = sorted(list(img.properties()))
 
-        width = max(max([len(p) for p in pargs]), 8)
-        fmt = "{{0:{0}}} {{1}}".format(width)
-        if not omit_headers:
-                msg(fmt.format("PROPERTY", "VALUE"))
+    width = max(max([len(p) for p in pargs]), 8)
+    fmt = "{{0:{0}}} {{1}}".format(width)
+    if not omit_headers:
+        msg(fmt.format("PROPERTY", "VALUE"))
 
-        for p in pargs:
-                msg(fmt.format(p, img.get_property(p)))
+    for p in pargs:
+        msg(fmt.format(p, img.get_property(p)))
 
-        return EXIT_OK
+    return EXIT_OK
 
-def list_variant(op, api_inst, pargs, omit_headers, output_format,
-    list_all_items, list_installed, verbose):
-        """pkg variant [-Haiv] [-F format] [<variant_pattern> ...]"""
 
-        subcommand = "variant"
-        if output_format is None:
-                output_format = "default"
+def list_variant(
+    op,
+    api_inst,
+    pargs,
+    omit_headers,
+    output_format,
+    list_all_items,
+    list_installed,
+    verbose,
+):
+    """pkg variant [-Haiv] [-F format] [<variant_pattern> ...]"""
 
-        # To work around Python 2.x's scoping limits, a list is used.
-        found = [False]
-        req_variants = set(pargs)
+    subcommand = "variant"
+    if output_format is None:
+        output_format = "default"
 
-        # If user explicitly provides variants, display implicit value even if
-        # not explicitly set in the image or found in a package.
-        implicit = req_variants and True or False
+    # To work around Python 2.x's scoping limits, a list is used.
+    found = [False]
+    req_variants = set(pargs)
 
-        def gen_current():
-                for (name, val, pvals) in api_inst.gen_variants(variant_list,
-                    implicit=implicit, patterns=req_variants):
-                        if output_format == "default":
-                                name_list = name.split(".")[1:]
-                                name = ".".join(name_list)
-                        found[0] = True
-                        yield {
-                            "variant": name,
-                            "value": val
-                        }
+    # If user explicitly provides variants, display implicit value even if
+    # not explicitly set in the image or found in a package.
+    implicit = req_variants and True or False
 
-        def gen_possible():
-                for (name, val, pvals) in api_inst.gen_variants(variant_list,
-                    implicit=implicit, patterns=req_variants):
-                        if output_format == "default":
-                                name_list = name.split(".")[1:]
-                                name = ".".join(name_list)
-                        found[0] = True
-                        for pval in pvals:
-                                yield {
-                                    "variant": name,
-                                    "value": pval
-                                }
+    def gen_current():
+        for name, val, pvals in api_inst.gen_variants(
+            variant_list, implicit=implicit, patterns=req_variants
+        ):
+            if output_format == "default":
+                name_list = name.split(".")[1:]
+                name = ".".join(name_list)
+            found[0] = True
+            yield {"variant": name, "value": val}
 
+    def gen_possible():
+        for name, val, pvals in api_inst.gen_variants(
+            variant_list, implicit=implicit, patterns=req_variants
+        ):
+            if output_format == "default":
+                name_list = name.split(".")[1:]
+                name = ".".join(name_list)
+            found[0] = True
+            for pval in pvals:
+                yield {"variant": name, "value": pval}
+
+    if verbose:
+        gen_listing = gen_possible
+    else:
+        gen_listing = gen_current
+
+    if list_all_items:
         if verbose:
-                gen_listing = gen_possible
+            variant_list = api_inst.VARIANT_ALL_POSSIBLE
         else:
-                gen_listing = gen_current
-
-        if list_all_items:
-                if verbose:
-                        variant_list = api_inst.VARIANT_ALL_POSSIBLE
-                else:
-                        variant_list = api_inst.VARIANT_ALL
-        elif list_installed:
-                if verbose:
-                        variant_list = api_inst.VARIANT_INSTALLED_POSSIBLE
-                else:
-                        variant_list = api_inst.VARIANT_INSTALLED
+            variant_list = api_inst.VARIANT_ALL
+    elif list_installed:
+        if verbose:
+            variant_list = api_inst.VARIANT_INSTALLED_POSSIBLE
         else:
-                if verbose:
-                        variant_list = api_inst.VARIANT_IMAGE_POSSIBLE
-                else:
-                        variant_list = api_inst.VARIANT_IMAGE
+            variant_list = api_inst.VARIANT_INSTALLED
+    else:
+        if verbose:
+            variant_list = api_inst.VARIANT_IMAGE_POSSIBLE
+        else:
+            variant_list = api_inst.VARIANT_IMAGE
 
-        #    VARIANT VALUE
-        #    <variant> <value>
-        #    <variant_2> <value_2>
-        #    ...
-        field_data = {
-            "variant" : [("default", "json", "tsv"), _("VARIANT"), ""],
-            "value" : [("default", "json", "tsv"), _("VALUE"), ""],
-        }
-        desired_field_order = (_("VARIANT"), _("VALUE"))
+    #    VARIANT VALUE
+    #    <variant> <value>
+    #    <variant_2> <value_2>
+    #    ...
+    field_data = {
+        "variant": [("default", "json", "tsv"), _("VARIANT"), ""],
+        "value": [("default", "json", "tsv"), _("VALUE"), ""],
+    }
+    desired_field_order = (_("VARIANT"), _("VALUE"))
 
-        # Default output formatting.
-        def_fmt = "{0:70} {1}"
+    # Default output formatting.
+    def_fmt = "{0:70} {1}"
 
-        # print without trailing newline.
-        sys.stdout.write(misc.get_listing(desired_field_order,
-            field_data, gen_listing(), output_format, def_fmt,
-            omit_headers))
+    # print without trailing newline.
+    sys.stdout.write(
+        misc.get_listing(
+            desired_field_order,
+            field_data,
+            gen_listing(),
+            output_format,
+            def_fmt,
+            omit_headers,
+        )
+    )
 
-        if not found[0] and req_variants:
-                if output_format == "default":
-                        # Don't pollute other output formats.
-                        error(_("no matching variants found"),
-                            cmd=subcommand)
-                return EXIT_OOPS
+    if not found[0] and req_variants:
+        if output_format == "default":
+            # Don't pollute other output formats.
+            error(_("no matching variants found"), cmd=subcommand)
+        return EXIT_OOPS
 
-        # Successful if no variants exist or if at least one matched.
-        return EXIT_OK
+    # Successful if no variants exist or if at least one matched.
+    return EXIT_OK
 
-def list_facet(op, api_inst, pargs, omit_headers, output_format, list_all_items,
-    list_masked, list_installed):
-        """pkg facet [-Hai] [-F format] [<facet_pattern> ...]"""
 
-        subcommand = "facet"
-        if output_format is None:
-                output_format = "default"
+def list_facet(
+    op,
+    api_inst,
+    pargs,
+    omit_headers,
+    output_format,
+    list_all_items,
+    list_masked,
+    list_installed,
+):
+    """pkg facet [-Hai] [-F format] [<facet_pattern> ...]"""
 
-        # To work around Python 2.x's scoping limits, a list is used.
-        found = [False]
-        req_facets = set(pargs)
+    subcommand = "facet"
+    if output_format is None:
+        output_format = "default"
 
-        facet_list = api_inst.FACET_IMAGE
-        if list_all_items:
-                facet_list = api_inst.FACET_ALL
-        elif list_installed:
-                facet_list = api_inst.FACET_INSTALLED
+    # To work around Python 2.x's scoping limits, a list is used.
+    found = [False]
+    req_facets = set(pargs)
 
-        # If user explicitly provides facets, display implicit value even if
-        # not explicitly set in the image or found in a package.
-        implicit = req_facets and True or False
+    facet_list = api_inst.FACET_IMAGE
+    if list_all_items:
+        facet_list = api_inst.FACET_ALL
+    elif list_installed:
+        facet_list = api_inst.FACET_INSTALLED
 
-        def gen_listing():
-                for (name, val, src, masked) in \
-                    api_inst.gen_facets(facet_list, implicit=implicit,
-                        patterns=req_facets):
-                        if output_format == "default":
-                                name_list = name.split(".")[1:]
-                                name = ".".join(name_list)
-                        found[0] = True
+    # If user explicitly provides facets, display implicit value even if
+    # not explicitly set in the image or found in a package.
+    implicit = req_facets and True or False
 
-                        if not list_masked and masked:
-                                continue
+    def gen_listing():
+        for name, val, src, masked in api_inst.gen_facets(
+            facet_list, implicit=implicit, patterns=req_facets
+        ):
+            if output_format == "default":
+                name_list = name.split(".")[1:]
+                name = ".".join(name_list)
+            found[0] = True
 
-                        # "value" and "masked" are intentionally not _().
-                        yield {
-                            "facet": name,
-                            "value": val and "True" or "False",
-                            "src": src,
-                            "masked": masked and "True" or "False",
-                        }
+            if not list_masked and masked:
+                continue
 
-        #    FACET VALUE
-        #    <facet> <value> <src>
-        #    <facet_2> <value_2> <src2>
-        #    ...
-        field_data = {
-            "facet"  : [("default", "json", "tsv"), _("FACET"), ""],
-            "value"  : [("default", "json", "tsv"), _("VALUE"), ""],
-            "src"    : [("default", "json", "tsv"), _("SRC"), ""],
-        }
-        desired_field_order = (_("FACET"), _("VALUE"), _("SRC"))
-        def_fmt = "{0:64} {1:5} {2}"
+            # "value" and "masked" are intentionally not _().
+            yield {
+                "facet": name,
+                "value": val and "True" or "False",
+                "src": src,
+                "masked": masked and "True" or "False",
+            }
 
-        if list_masked:
-                # if we're displaying masked facets, we should also mark which
-                # facets are masked in the output.
-                field_data["masked"] = \
-                    [("default", "json", "tsv"), _("MASKED"), ""]
-                desired_field_order += (_("MASKED"),)
-                def_fmt = "{0:57} {1:5} {2:6} {3}"
+    #    FACET VALUE
+    #    <facet> <value> <src>
+    #    <facet_2> <value_2> <src2>
+    #    ...
+    field_data = {
+        "facet": [("default", "json", "tsv"), _("FACET"), ""],
+        "value": [("default", "json", "tsv"), _("VALUE"), ""],
+        "src": [("default", "json", "tsv"), _("SRC"), ""],
+    }
+    desired_field_order = (_("FACET"), _("VALUE"), _("SRC"))
+    def_fmt = "{0:64} {1:5} {2}"
 
-        # print without trailing newline.
-        sys.stdout.write(misc.get_listing(desired_field_order,
-            field_data, gen_listing(), output_format, def_fmt,
-            omit_headers))
+    if list_masked:
+        # if we're displaying masked facets, we should also mark which
+        # facets are masked in the output.
+        field_data["masked"] = [("default", "json", "tsv"), _("MASKED"), ""]
+        desired_field_order += (_("MASKED"),)
+        def_fmt = "{0:57} {1:5} {2:6} {3}"
 
-        if not found[0] and req_facets:
-                if output_format == "default":
-                        # Don't pollute other output formats.
-                        error(_("no matching facets found"),
-                            cmd=subcommand)
-                return EXIT_OOPS
+    # print without trailing newline.
+    sys.stdout.write(
+        misc.get_listing(
+            desired_field_order,
+            field_data,
+            gen_listing(),
+            output_format,
+            def_fmt,
+            omit_headers,
+        )
+    )
 
-        # Successful if no facets exist or if at least one matched.
-        return EXIT_OK
+    if not found[0] and req_facets:
+        if output_format == "default":
+            # Don't pollute other output formats.
+            error(_("no matching facets found"), cmd=subcommand)
+        return EXIT_OOPS
+
+    # Successful if no facets exist or if at least one matched.
+    return EXIT_OK
+
 
 def list_linked(op, api_inst, pargs, li_ignore, omit_headers):
-        """pkg list-linked [-H]
+    """pkg list-linked [-H]
 
-        List all the linked images known to the current image."""
+    List all the linked images known to the current image."""
 
-        api_inst.progresstracker.set_purpose(
-            api_inst.progresstracker.PURPOSE_LISTING)
+    api_inst.progresstracker.set_purpose(
+        api_inst.progresstracker.PURPOSE_LISTING
+    )
 
-        li_list = api_inst.list_linked(li_ignore)
-        if len(li_list) == 0:
-                return EXIT_OK
-
-        fmt = ""
-        li_header = [_("NAME"), _("RELATIONSHIP"), _("PATH")]
-        for col in range(0, len(li_header)):
-                width = max([len(row[col]) for row in li_list])
-                width = max(width, len(li_header[col]))
-                if (fmt != ''):
-                        fmt += "\t"
-                fmt += "{{{0}!s:{1}}}".format(col, width)
-
-        if not omit_headers:
-                msg(fmt.format(*li_header))
-        for row in li_list:
-                msg(fmt.format(*row))
+    li_list = api_inst.list_linked(li_ignore)
+    if len(li_list) == 0:
         return EXIT_OK
+
+    fmt = ""
+    li_header = [_("NAME"), _("RELATIONSHIP"), _("PATH")]
+    for col in range(0, len(li_header)):
+        width = max([len(row[col]) for row in li_list])
+        width = max(width, len(li_header[col]))
+        if fmt != "":
+            fmt += "\t"
+        fmt += "{{{0}!s:{1}}}".format(col, width)
+
+    if not omit_headers:
+        msg(fmt.format(*li_header))
+    for row in li_list:
+        msg(fmt.format(*row))
+    return EXIT_OK
+
 
 def pubcheck_linked(op, api_inst, pargs):
-        """If we're a child image, verify that the parent image
-        publisher configuration is a subset of our publisher configuration.
-        If we have any children, recurse into them and perform a publisher
-        check."""
+    """If we're a child image, verify that the parent image
+    publisher configuration is a subset of our publisher configuration.
+    If we have any children, recurse into them and perform a publisher
+    check."""
 
-        try:
-                api_inst.linked_publisher_check()
-        except api_errors.ImageLockedError as e:
-                error(e)
-                return EXIT_LOCKED
-        except api_errors.ImageMissingKeyFile as e:
-                error(e)
-                return EXIT_EACCESS
+    try:
+        api_inst.linked_publisher_check()
+    except api_errors.ImageLockedError as e:
+        error(e)
+        return EXIT_LOCKED
+    except api_errors.ImageMissingKeyFile as e:
+        error(e)
+        return EXIT_EACCESS
 
-        return EXIT_OK
+    return EXIT_OK
+
 
 def hotfix_cleanup(op, api_inst, pargs):
-        try:
-                api_inst.hotfix_origin_cleanup()
-        except api_errors.ImageLockedError as e:
-                error(e)
-                return EXIT_LOCKED
-        except api_errors.ImageMissingKeyFile as e:
-                error(e)
-                return EXIT_EACCESS
-        except api_errors.UnprivilegedUserError as e:
-                error(e)
-                return EXIT_OOPS
+    try:
+        api_inst.hotfix_origin_cleanup()
+    except api_errors.ImageLockedError as e:
+        error(e)
+        return EXIT_LOCKED
+    except api_errors.ImageMissingKeyFile as e:
+        error(e)
+        return EXIT_EACCESS
+    except api_errors.UnprivilegedUserError as e:
+        error(e)
+        return EXIT_OOPS
 
-        return EXIT_OK
+    return EXIT_OK
+
 
 def __parse_linked_props(args, op):
-        """"Parse linked image property options that were specified on the
-        command line into a dictionary.  Make sure duplicate properties were
-        not specified."""
+    """ "Parse linked image property options that were specified on the
+    command line into a dictionary.  Make sure duplicate properties were
+    not specified."""
 
-        linked_props = dict()
-        for pv in args:
-                try:
-                        p, v = pv.split("=", 1)
-                except ValueError:
-                        usage(_("linked image property arguments must be of "
-                            "the form '<name>=<value>'."), cmd=op)
+    linked_props = dict()
+    for pv in args:
+        try:
+            p, v = pv.split("=", 1)
+        except ValueError:
+            usage(
+                _(
+                    "linked image property arguments must be of "
+                    "the form '<name>=<value>'."
+                ),
+                cmd=op,
+            )
 
-                if p not in li.prop_values:
-                        usage(_("invalid linked image property: "
-                            "'{0}'.").format(p), cmd=op)
+        if p not in li.prop_values:
+            usage(
+                _("invalid linked image property: " "'{0}'.").format(p), cmd=op
+            )
 
-                if p in linked_props:
-                        usage(_("linked image property specified multiple "
-                            "times: '{0}'.").format(p), cmd=op)
+        if p in linked_props:
+            usage(
+                _(
+                    "linked image property specified multiple " "times: '{0}'."
+                ).format(p),
+                cmd=op,
+            )
 
-                linked_props[p] = v
+        linked_props[p] = v
 
-        return linked_props
+    return linked_props
 
-def list_property_linked(op, api_inst, pargs,
-    li_name, omit_headers):
-        """pkg property-linked [-H] [-l <li-name>] [propname ...]
 
-        List the linked image properties associated with a child or parent
-        image."""
+def list_property_linked(op, api_inst, pargs, li_name, omit_headers):
+    """pkg property-linked [-H] [-l <li-name>] [propname ...]
 
-        api_inst.progresstracker.set_purpose(
-            api_inst.progresstracker.PURPOSE_LISTING)
+    List the linked image properties associated with a child or parent
+    image."""
 
-        lin = None
-        if li_name:
-                lin = api_inst.parse_linked_name(li_name)
-        props = api_inst.get_linked_props(lin=lin)
+    api_inst.progresstracker.set_purpose(
+        api_inst.progresstracker.PURPOSE_LISTING
+    )
 
-        for p in pargs:
-                if p not in props.keys():
-                        error(_("{op}: no such property: {p}").format(
-                            op=op, p=p))
-                        return EXIT_OOPS
+    lin = None
+    if li_name:
+        lin = api_inst.parse_linked_name(li_name)
+    props = api_inst.get_linked_props(lin=lin)
 
-        if len(props) == 0:
-                return EXIT_OK
+    for p in pargs:
+        if p not in props.keys():
+            error(_("{op}: no such property: {p}").format(op=op, p=p))
+            return EXIT_OOPS
 
-        if not pargs:
-                pargs = props.keys()
-
-        width = max(max([len(p) for p in pargs if props[p]]), 8)
-        fmt = "{{0:{0}}}\t{{1}}".format(width)
-        if not omit_headers:
-                msg(fmt.format("PROPERTY", "VALUE"))
-        for p in sorted(pargs):
-                if not props[p]:
-                        continue
-                msg(fmt.format(p, props[p]))
-
+    if len(props) == 0:
         return EXIT_OK
 
-def set_property_linked(op, api_inst, pargs,
-    accept, backup_be, backup_be_name, be_activate, be_name, li_ignore,
-    li_md_only, li_name, li_parent_sync, li_pkg_updates, new_be, noexecute,
-    origins, parsable_version, quiet, refresh_catalogs, reject_pats,
-    show_licenses, update_index, verbose):
-        """pkg set-property-linked
-            [-nvq] [--accept] [--licenses] [--no-index] [--no-refresh]
-            [--no-parent-sync] [--no-pkg-updates]
-            [--linked-md-only] <propname>=<propvalue> ...
+    if not pargs:
+        pargs = props.keys()
 
-        Change the specified linked image properties.  This may result in
-        updating the package contents of a child image."""
+    width = max(max([len(p) for p in pargs if props[p]]), 8)
+    fmt = "{{0:{0}}}\t{{1}}".format(width)
+    if not omit_headers:
+        msg(fmt.format("PROPERTY", "VALUE"))
+    for p in sorted(pargs):
+        if not props[p]:
+            continue
+        msg(fmt.format(p, props[p]))
 
-        api_inst.progresstracker.set_purpose(
-            api_inst.progresstracker.PURPOSE_LISTING)
+    return EXIT_OK
 
-        # make sure we're a child image
-        if li_name:
-                lin = api_inst.parse_linked_name(li_name)
-        else:
-                lin = api_inst.get_linked_name()
 
-        xrval, xres = get_fmri_args(api_inst, reject_pats, cmd=op)
-        if not xrval:
-                return EXIT_OOPS
+def set_property_linked(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    li_ignore,
+    li_md_only,
+    li_name,
+    li_parent_sync,
+    li_pkg_updates,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    update_index,
+    verbose,
+):
+    """pkg set-property-linked
+        [-nvq] [--accept] [--licenses] [--no-index] [--no-refresh]
+        [--no-parent-sync] [--no-pkg-updates]
+        [--linked-md-only] <propname>=<propvalue> ...
 
-        return EXIT_OK
+    Change the specified linked image properties.  This may result in
+    updating the package contents of a child image."""
 
-def audit_linked(op, api_inst, pargs,
+    api_inst.progresstracker.set_purpose(
+        api_inst.progresstracker.PURPOSE_LISTING
+    )
+
+    # make sure we're a child image
+    if li_name:
+        lin = api_inst.parse_linked_name(li_name)
+    else:
+        lin = api_inst.get_linked_name()
+
+    xrval, xres = get_fmri_args(api_inst, reject_pats, cmd=op)
+    if not xrval:
+        return EXIT_OOPS
+
+    return EXIT_OK
+
+
+def audit_linked(
+    op,
+    api_inst,
+    pargs,
     li_parent_sync,
     li_target_all,
     li_target_list,
     omit_headers,
-    quiet):
-        """pkg audit-linked [-a|-l <li-name>]
+    quiet,
+):
+    """pkg audit-linked [-a|-l <li-name>]
 
-        Audit one or more child images to see if they are in sync
-        with their parent image."""
+    Audit one or more child images to see if they are in sync
+    with their parent image."""
 
-        api_inst.progresstracker.set_purpose(
-            api_inst.progresstracker.PURPOSE_LISTING)
+    api_inst.progresstracker.set_purpose(
+        api_inst.progresstracker.PURPOSE_LISTING
+    )
 
+    # audit the requested child image(s)
+    if not li_target_all and not li_target_list:
+        # audit the current image
+        rvdict = api_inst.audit_linked(li_parent_sync=li_parent_sync)
+    else:
         # audit the requested child image(s)
-        if not li_target_all and not li_target_list:
-                # audit the current image
-                rvdict = api_inst.audit_linked(li_parent_sync=li_parent_sync)
-        else:
-                # audit the requested child image(s)
-                rvdict = api_inst.audit_linked_children(li_target_list)
-                if not rvdict:
-                        # may not have had any children
-                        return EXIT_OK
+        rvdict = api_inst.audit_linked_children(li_target_list)
+        if not rvdict:
+            # may not have had any children
+            return EXIT_OK
 
-        # display audit return values
-        width = max(max([len(k) for k in rvdict.keys()]), 8)
-        fmt = "{{0!s:{0}}}\t{{1}}".format(width)
-        if not omit_headers:
-                msg(fmt.format("NAME", "STATUS"))
+    # display audit return values
+    width = max(max([len(k) for k in rvdict.keys()]), 8)
+    fmt = "{{0!s:{0}}}\t{{1}}".format(width)
+    if not omit_headers:
+        msg(fmt.format("NAME", "STATUS"))
 
-        if not quiet:
-                for k, (rv, err, p_dict) in rvdict.items():
-                        if rv == EXIT_OK:
-                                msg(fmt.format(k, _("synced")))
-                        elif rv == EXIT_DIVERGED:
-                                msg(fmt.format(k, _("diverged")))
+    if not quiet:
+        for k, (rv, err, p_dict) in rvdict.items():
+            if rv == EXIT_OK:
+                msg(fmt.format(k, _("synced")))
+            elif rv == EXIT_DIVERGED:
+                msg(fmt.format(k, _("diverged")))
 
-        rv, err, p_dicts = api_inst.audit_linked_rvdict2rv(rvdict)
-        if err:
-                error(err, cmd=op)
-        return rv
+    rv, err, p_dicts = api_inst.audit_linked_rvdict2rv(rvdict)
+    if err:
+        error(err, cmd=op)
+    return rv
 
-def sync_linked(op, api_inst, pargs, accept, backup_be, backup_be_name,
-    be_activate, be_name, li_ignore, li_md_only, li_parent_sync,
-    li_pkg_updates, li_target_all, li_target_list, new_be, noexecute, origins,
-    parsable_version, quiet, refresh_catalogs, reject_pats, show_licenses,
-    stage, update_index, verbose):
-        """pkg sync-linked [-a|-l <li-name>]
-            [-nvq] [--accept] [--licenses] [--no-index] [--no-refresh]
-            [--no-parent-sync] [--no-pkg-updates]
-            [--linked-md-only] [-a|-l <name>]
 
-        Sync one or more child images with their parent image."""
+def sync_linked(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    li_ignore,
+    li_md_only,
+    li_parent_sync,
+    li_pkg_updates,
+    li_target_all,
+    li_target_list,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    stage,
+    update_index,
+    verbose,
+):
+    """pkg sync-linked [-a|-l <li-name>]
+        [-nvq] [--accept] [--licenses] [--no-index] [--no-refresh]
+        [--no-parent-sync] [--no-pkg-updates]
+        [--linked-md-only] [-a|-l <name>]
 
-        xrval, xres = get_fmri_args(api_inst, reject_pats, cmd=op)
-        if not xrval:
-                return EXIT_OOPS
+    Sync one or more child images with their parent image."""
 
-        if not li_target_all and not li_target_list:
-                # sync the current image
-                return __api_op(op, api_inst, _accept=accept,
-                    _li_ignore=li_ignore, _noexecute=noexecute,
-                    _origins=origins, _parsable_version=parsable_version,
-                    _quiet=quiet, _show_licenses=show_licenses, _stage=stage,
-                    _verbose=verbose, backup_be=backup_be,
-                    backup_be_name=backup_be_name, be_activate=be_activate,
-                    be_name=be_name, li_md_only=li_md_only,
-                    li_parent_sync=li_parent_sync,
-                    li_pkg_updates=li_pkg_updates, new_be=new_be,
-                    refresh_catalogs=refresh_catalogs,
-                    reject_list=reject_pats,
-                    update_index=update_index)
+    xrval, xres = get_fmri_args(api_inst, reject_pats, cmd=op)
+    if not xrval:
+        return EXIT_OOPS
 
-        # sync the requested child image(s)
-        api_inst.progresstracker.set_major_phase(
-            api_inst.progresstracker.PHASE_UTILITY)
-        rvdict = api_inst.sync_linked_children(li_target_list,
-            noexecute=noexecute, accept=accept, show_licenses=show_licenses,
-            refresh_catalogs=refresh_catalogs, update_index=update_index,
-            li_pkg_updates=li_pkg_updates, li_md_only=li_md_only)
+    if not li_target_all and not li_target_list:
+        # sync the current image
+        return __api_op(
+            op,
+            api_inst,
+            _accept=accept,
+            _li_ignore=li_ignore,
+            _noexecute=noexecute,
+            _origins=origins,
+            _parsable_version=parsable_version,
+            _quiet=quiet,
+            _show_licenses=show_licenses,
+            _stage=stage,
+            _verbose=verbose,
+            backup_be=backup_be,
+            backup_be_name=backup_be_name,
+            be_activate=be_activate,
+            be_name=be_name,
+            li_md_only=li_md_only,
+            li_parent_sync=li_parent_sync,
+            li_pkg_updates=li_pkg_updates,
+            new_be=new_be,
+            refresh_catalogs=refresh_catalogs,
+            reject_list=reject_pats,
+            update_index=update_index,
+        )
 
-        rv, err, p_dicts = api_inst.sync_linked_rvdict2rv(rvdict)
-        if err:
-                error(err, cmd=op)
-        if parsable_version is not None and rv == EXIT_OK:
-                try:
-                        __display_parsable_plan(api_inst, parsable_version,
-                            p_dicts)
-                except api_errors.ApiException as e:
-                        error(e, cmd=op)
-                        return EXIT_OOPS
-        return rv
+    # sync the requested child image(s)
+    api_inst.progresstracker.set_major_phase(
+        api_inst.progresstracker.PHASE_UTILITY
+    )
+    rvdict = api_inst.sync_linked_children(
+        li_target_list,
+        noexecute=noexecute,
+        accept=accept,
+        show_licenses=show_licenses,
+        refresh_catalogs=refresh_catalogs,
+        update_index=update_index,
+        li_pkg_updates=li_pkg_updates,
+        li_md_only=li_md_only,
+    )
 
-def attach_linked(op, api_inst, pargs,
-    accept, allow_relink, attach_child, attach_parent, be_activate,
-    backup_be, backup_be_name, be_name, force, li_ignore, li_md_only,
-    li_parent_sync, li_pkg_updates, li_props, new_be, noexecute, origins,
-    parsable_version, quiet, refresh_catalogs, reject_pats, show_licenses,
-    update_index, verbose):
-        """pkg attach-linked
-            [-fnvq] [--accept] [--licenses] [--no-index] [--no-refresh]
-            [--no-pkg-updates] [--linked-md-only]
-            [--allow-relink]
-            [--parsable-version=<version>]
-            [--prop-linked <propname>=<propvalue> ...]
-            (-c|-p) <li-name> <dir>
+    rv, err, p_dicts = api_inst.sync_linked_rvdict2rv(rvdict)
+    if err:
+        error(err, cmd=op)
+    if parsable_version is not None and rv == EXIT_OK:
+        try:
+            __display_parsable_plan(api_inst, parsable_version, p_dicts)
+        except api_errors.ApiException as e:
+            error(e, cmd=op)
+            return EXIT_OOPS
+    return rv
 
-        Attach a child linked image.  The child could be this image attaching
-        itself to a parent, or another image being attach as a child with
-        this image being the parent."""
 
-        for k, v in li_props:
-                if k in [li.PROP_PATH, li.PROP_NAME, li.PROP_MODEL]:
-                        usage(_("cannot specify linked image property: "
-                            "'{0}'").format(k), cmd=op)
+def attach_linked(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    allow_relink,
+    attach_child,
+    attach_parent,
+    be_activate,
+    backup_be,
+    backup_be_name,
+    be_name,
+    force,
+    li_ignore,
+    li_md_only,
+    li_parent_sync,
+    li_pkg_updates,
+    li_props,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    update_index,
+    verbose,
+):
+    """pkg attach-linked
+        [-fnvq] [--accept] [--licenses] [--no-index] [--no-refresh]
+        [--no-pkg-updates] [--linked-md-only]
+        [--allow-relink]
+        [--parsable-version=<version>]
+        [--prop-linked <propname>=<propvalue> ...]
+        (-c|-p) <li-name> <dir>
 
-        if len(pargs) < 2:
-                usage(_("a linked image name and path must be specified"),
-                    cmd=op)
+    Attach a child linked image.  The child could be this image attaching
+    itself to a parent, or another image being attach as a child with
+    this image being the parent."""
 
-        li_name = pargs[0]
-        li_path = pargs[1]
+    for k, v in li_props:
+        if k in [li.PROP_PATH, li.PROP_NAME, li.PROP_MODEL]:
+            usage(
+                _("cannot specify linked image property: " "'{0}'").format(k),
+                cmd=op,
+            )
 
-        # parse the specified name
-        lin = api_inst.parse_linked_name(li_name, allow_unknown=True)
+    if len(pargs) < 2:
+        usage(_("a linked image name and path must be specified"), cmd=op)
 
-        xrval, xres = get_fmri_args(api_inst, reject_pats, cmd=op)
-        if not xrval:
-                return EXIT_OOPS
+    li_name = pargs[0]
+    li_path = pargs[1]
 
-        if attach_parent:
-                # attach the current image to a parent
-                return __api_op(op, api_inst, _accept=accept,
-                    _li_ignore=li_ignore, _noexecute=noexecute,
-                    _origins=origins, _parsable_version=parsable_version,
-                    _quiet=quiet, _show_licenses=show_licenses,
-                    _verbose=verbose, allow_relink=allow_relink,
-                    backup_be=backup_be, backup_be_name=backup_be_name,
-                    be_activate=be_activate, be_name=be_name, force=force,
-                    li_md_only=li_md_only, li_path=li_path,
-                    li_pkg_updates=li_pkg_updates, li_props=li_props,
-                    lin=lin, new_be=new_be, refresh_catalogs=refresh_catalogs,
-                    reject_list=reject_pats, update_index=update_index)
+    # parse the specified name
+    lin = api_inst.parse_linked_name(li_name, allow_unknown=True)
 
-        # attach the requested child image
-        api_inst.progresstracker.set_major_phase(
-            api_inst.progresstracker.PHASE_UTILITY)
-        (rv, err, p_dict) = api_inst.attach_linked_child(lin, li_path, li_props,
-            accept=accept, allow_relink=allow_relink, force=force,
-            li_md_only=li_md_only, li_pkg_updates=li_pkg_updates,
-            noexecute=noexecute, refresh_catalogs=refresh_catalogs,
-            reject_list=reject_pats, show_licenses=show_licenses,
-            update_index=update_index)
+    xrval, xres = get_fmri_args(api_inst, reject_pats, cmd=op)
+    if not xrval:
+        return EXIT_OOPS
 
-        if err:
-                error(err, cmd=op)
-        if parsable_version is not None and rv == EXIT_OK:
-                assert p_dict is not None
-                try:
-                        __display_parsable_plan(api_inst, parsable_version,
-                            [p_dict])
-                except api_errors.ApiException as e:
-                        error(e, cmd=op)
-                        return EXIT_OOPS
-        return rv
+    if attach_parent:
+        # attach the current image to a parent
+        return __api_op(
+            op,
+            api_inst,
+            _accept=accept,
+            _li_ignore=li_ignore,
+            _noexecute=noexecute,
+            _origins=origins,
+            _parsable_version=parsable_version,
+            _quiet=quiet,
+            _show_licenses=show_licenses,
+            _verbose=verbose,
+            allow_relink=allow_relink,
+            backup_be=backup_be,
+            backup_be_name=backup_be_name,
+            be_activate=be_activate,
+            be_name=be_name,
+            force=force,
+            li_md_only=li_md_only,
+            li_path=li_path,
+            li_pkg_updates=li_pkg_updates,
+            li_props=li_props,
+            lin=lin,
+            new_be=new_be,
+            refresh_catalogs=refresh_catalogs,
+            reject_list=reject_pats,
+            update_index=update_index,
+        )
 
-def detach_linked(op, api_inst, pargs, force, li_md_only, li_pkg_updates,
-    li_target_all, li_target_list, noexecute, quiet, verbose):
-        """pkg detach-linked
-            [-fnvq] [-a|-l <li-name>] [--linked-md-only]
+    # attach the requested child image
+    api_inst.progresstracker.set_major_phase(
+        api_inst.progresstracker.PHASE_UTILITY
+    )
+    (rv, err, p_dict) = api_inst.attach_linked_child(
+        lin,
+        li_path,
+        li_props,
+        accept=accept,
+        allow_relink=allow_relink,
+        force=force,
+        li_md_only=li_md_only,
+        li_pkg_updates=li_pkg_updates,
+        noexecute=noexecute,
+        refresh_catalogs=refresh_catalogs,
+        reject_list=reject_pats,
+        show_licenses=show_licenses,
+        update_index=update_index,
+    )
 
-        Detach one or more child linked images."""
+    if err:
+        error(err, cmd=op)
+    if parsable_version is not None and rv == EXIT_OK:
+        assert p_dict is not None
+        try:
+            __display_parsable_plan(api_inst, parsable_version, [p_dict])
+        except api_errors.ApiException as e:
+            error(e, cmd=op)
+            return EXIT_OOPS
+    return rv
 
-        if not li_target_all and not li_target_list:
-                # detach the current image
-                return __api_op(op, api_inst, _noexecute=noexecute,
-                    _quiet=quiet, _verbose=verbose, force=force,
-                    li_md_only=li_md_only, li_pkg_updates=li_pkg_updates)
 
-        api_inst.progresstracker.set_major_phase(
-            api_inst.progresstracker.PHASE_UTILITY)
-        rvdict = api_inst.detach_linked_children(li_target_list, force=force,
-            li_md_only=li_md_only, li_pkg_updates=li_pkg_updates,
-            noexecute=noexecute)
+def detach_linked(
+    op,
+    api_inst,
+    pargs,
+    force,
+    li_md_only,
+    li_pkg_updates,
+    li_target_all,
+    li_target_list,
+    noexecute,
+    quiet,
+    verbose,
+):
+    """pkg detach-linked
+        [-fnvq] [-a|-l <li-name>] [--linked-md-only]
 
-        rv, err, p_dicts = api_inst.detach_linked_rvdict2rv(rvdict)
-        if err:
-                error(err, cmd=op)
-        return rv
+    Detach one or more child linked images."""
+
+    if not li_target_all and not li_target_list:
+        # detach the current image
+        return __api_op(
+            op,
+            api_inst,
+            _noexecute=noexecute,
+            _quiet=quiet,
+            _verbose=verbose,
+            force=force,
+            li_md_only=li_md_only,
+            li_pkg_updates=li_pkg_updates,
+        )
+
+    api_inst.progresstracker.set_major_phase(
+        api_inst.progresstracker.PHASE_UTILITY
+    )
+    rvdict = api_inst.detach_linked_children(
+        li_target_list,
+        force=force,
+        li_md_only=li_md_only,
+        li_pkg_updates=li_pkg_updates,
+        noexecute=noexecute,
+    )
+
+    rv, err, p_dicts = api_inst.detach_linked_rvdict2rv(rvdict)
+    if err:
+        error(err, cmd=op)
+    return rv
+
 
 def image_create(args):
-        """Create an image of the requested kind, at the given path.  Load
-        catalog for initial publisher for convenience.
+    """Create an image of the requested kind, at the given path.  Load
+    catalog for initial publisher for convenience.
 
-        At present, it is legitimate for a user image to specify that it will be
-        deployed in a zone.  An easy example would be a program with an optional
-        component that consumes global zone-only information, such as various
-        kernel statistics or device information."""
+    At present, it is legitimate for a user image to specify that it will be
+    deployed in a zone.  An easy example would be a program with an optional
+    component that consumes global zone-only information, such as various
+    kernel statistics or device information."""
 
-        cmd_name = "image-create"
+    cmd_name = "image-create"
 
-        force = False
-        imgtype = IMG_TYPE_USER
-        is_zone = False
-        add_mirrors = set()
-        add_origins = set()
-        pub_name = None
-        pub_url = None
-        refresh_allowed = True
-        ssl_key = None
-        ssl_cert = None
-        variants = {}
-        facets = pkg.facet.Facets()
-        set_props = {}
-        version = None
+    force = False
+    imgtype = IMG_TYPE_USER
+    is_zone = False
+    add_mirrors = set()
+    add_origins = set()
+    pub_name = None
+    pub_url = None
+    refresh_allowed = True
+    ssl_key = None
+    ssl_cert = None
+    variants = {}
+    facets = pkg.facet.Facets()
+    set_props = {}
+    version = None
 
-        opts, pargs = getopt.getopt(args, "fFPUzg:m:p:k:c:",
-            ["force", "full", "partial", "user", "zone", "facet=", "mirror=",
-                "origin=", "publisher=", "no-refresh", "variant=",
-                "set-property="])
+    opts, pargs = getopt.getopt(
+        args,
+        "fFPUzg:m:p:k:c:",
+        [
+            "force",
+            "full",
+            "partial",
+            "user",
+            "zone",
+            "facet=",
+            "mirror=",
+            "origin=",
+            "publisher=",
+            "no-refresh",
+            "variant=",
+            "set-property=",
+        ],
+    )
 
-        for opt, arg in opts:
-                if opt in ("-p", "--publisher"):
-                        if pub_url:
-                                usage(_("The -p option can be specified only "
-                                    "once."), cmd=cmd_name)
-                        try:
-                                pub_name, pub_url = arg.split("=", 1)
-                        except ValueError:
-                                pub_name = None
-                                pub_url = arg
-                        if pub_url:
-                                pub_url = misc.parse_uri(pub_url, cwd=orig_cwd)
-                elif opt == "-c":
-                        ssl_cert = arg
-                elif opt == "-f" or opt == "--force":
-                        force = True
-                elif opt in ("-g", "--origin"):
-                        add_origins.add(misc.parse_uri(arg, cwd=orig_cwd))
-                elif opt == "-k":
-                        ssl_key = arg
-                elif opt in ("-m", "--mirror"):
-                        add_mirrors.add(misc.parse_uri(arg, cwd=orig_cwd))
-                elif opt == "-z" or opt == "--zone":
-                        is_zone = True
-                        imgtype = IMG_TYPE_ENTIRE
-                elif opt == "-F" or opt == "--full":
-                        imgtype = IMG_TYPE_ENTIRE
-                elif opt == "-P" or opt == "--partial":
-                        imgtype = IMG_TYPE_PARTIAL
-                elif opt == "-U" or opt == "--user":
-                        imgtype = IMG_TYPE_USER
-                elif opt == "--facet":
-                        allow = { "TRUE": True, "FALSE": False }
-                        try:
-                                f_name, f_value = arg.split("=", 1)
-                        except ValueError:
-                                f_name = arg
-                                f_value = ""
-                        if not f_name.startswith("facet."):
-                                f_name = "facet.{0}".format(f_name)
-                        if not f_name or f_value.upper() not in allow:
-                                usage(_("Facet arguments must be of the "
-                                    "form '<name>=(True|False)'"),
-                                    cmd=cmd_name)
-                        facets[f_name] = allow[f_value.upper()]
-                elif opt == "--no-refresh":
-                        refresh_allowed = False
-                elif opt == "--set-property":
-                        t = arg.split("=", 1)
-                        if len(t) < 2:
-                                usage(_("properties to be set must be of the "
-                                    "form '<name>=<value>'. This is what was "
-                                    "given: {0}").format(arg), cmd=cmd_name)
-                        if t[0] in set_props:
-                                usage(_("a property may only be set once in a "
-                                    "command. {0} was set twice").format(t[0]),
-                                    cmd=cmd_name)
-                        set_props[t[0]] = t[1]
-                elif opt == "--variant":
-                        try:
-                                v_name, v_value = arg.split("=", 1)
-                                if not v_name.startswith("variant."):
-                                        v_name = "variant.{0}".format(v_name)
-                        except ValueError:
-                                usage(_("variant arguments must be of the "
-                                    "form '<name>=<value>'."),
-                                    cmd=cmd_name)
-                        variants[v_name] = v_value
+    for opt, arg in opts:
+        if opt in ("-p", "--publisher"):
+            if pub_url:
+                usage(
+                    _("The -p option can be specified only " "once."),
+                    cmd=cmd_name,
+                )
+            try:
+                pub_name, pub_url = arg.split("=", 1)
+            except ValueError:
+                pub_name = None
+                pub_url = arg
+            if pub_url:
+                pub_url = misc.parse_uri(pub_url, cwd=orig_cwd)
+        elif opt == "-c":
+            ssl_cert = arg
+        elif opt == "-f" or opt == "--force":
+            force = True
+        elif opt in ("-g", "--origin"):
+            add_origins.add(misc.parse_uri(arg, cwd=orig_cwd))
+        elif opt == "-k":
+            ssl_key = arg
+        elif opt in ("-m", "--mirror"):
+            add_mirrors.add(misc.parse_uri(arg, cwd=orig_cwd))
+        elif opt == "-z" or opt == "--zone":
+            is_zone = True
+            imgtype = IMG_TYPE_ENTIRE
+        elif opt == "-F" or opt == "--full":
+            imgtype = IMG_TYPE_ENTIRE
+        elif opt == "-P" or opt == "--partial":
+            imgtype = IMG_TYPE_PARTIAL
+        elif opt == "-U" or opt == "--user":
+            imgtype = IMG_TYPE_USER
+        elif opt == "--facet":
+            allow = {"TRUE": True, "FALSE": False}
+            try:
+                f_name, f_value = arg.split("=", 1)
+            except ValueError:
+                f_name = arg
+                f_value = ""
+            if not f_name.startswith("facet."):
+                f_name = "facet.{0}".format(f_name)
+            if not f_name or f_value.upper() not in allow:
+                usage(
+                    _(
+                        "Facet arguments must be of the "
+                        "form '<name>=(True|False)'"
+                    ),
+                    cmd=cmd_name,
+                )
+            facets[f_name] = allow[f_value.upper()]
+        elif opt == "--no-refresh":
+            refresh_allowed = False
+        elif opt == "--set-property":
+            t = arg.split("=", 1)
+            if len(t) < 2:
+                usage(
+                    _(
+                        "properties to be set must be of the "
+                        "form '<name>=<value>'. This is what was "
+                        "given: {0}"
+                    ).format(arg),
+                    cmd=cmd_name,
+                )
+            if t[0] in set_props:
+                usage(
+                    _(
+                        "a property may only be set once in a "
+                        "command. {0} was set twice"
+                    ).format(t[0]),
+                    cmd=cmd_name,
+                )
+            set_props[t[0]] = t[1]
+        elif opt == "--variant":
+            try:
+                v_name, v_value = arg.split("=", 1)
+                if not v_name.startswith("variant."):
+                    v_name = "variant.{0}".format(v_name)
+            except ValueError:
+                usage(
+                    _(
+                        "variant arguments must be of the "
+                        "form '<name>=<value>'."
+                    ),
+                    cmd=cmd_name,
+                )
+            variants[v_name] = v_value
 
-        if not pargs:
-                usage(_("an image directory path must be specified"),
-                    cmd=cmd_name)
-        elif len(pargs) > 1:
-                usage(_("only one image directory path may be specified"),
-                    cmd=cmd_name)
-        image_dir = pargs[0]
+    if not pargs:
+        usage(_("an image directory path must be specified"), cmd=cmd_name)
+    elif len(pargs) > 1:
+        usage(_("only one image directory path may be specified"), cmd=cmd_name)
+    image_dir = pargs[0]
 
-        if pub_url and not pub_name and not refresh_allowed:
-                usage(_("--no-refresh cannot be used with -p unless a "
-                    "publisher prefix is provided."), cmd=cmd_name)
+    if pub_url and not pub_name and not refresh_allowed:
+        usage(
+            _(
+                "--no-refresh cannot be used with -p unless a "
+                "publisher prefix is provided."
+            ),
+            cmd=cmd_name,
+        )
 
-        if not pub_url and (add_origins or add_mirrors):
-                usage(_("A publisher must be specified if -g or -m are used."),
-                    cmd=cmd_name)
+    if not pub_url and (add_origins or add_mirrors):
+        usage(
+            _("A publisher must be specified if -g or -m are used."),
+            cmd=cmd_name,
+        )
 
-        if not refresh_allowed and pub_url:
-                # Auto-config can't be done if refresh isn't allowed, so treat
-                # this as a manual configuration case.
-                add_origins.add(pub_url)
-                repo_uri = None
+    if not refresh_allowed and pub_url:
+        # Auto-config can't be done if refresh isn't allowed, so treat
+        # this as a manual configuration case.
+        add_origins.add(pub_url)
+        repo_uri = None
+    else:
+        repo_uri = pub_url
+
+    # Get sanitized SSL Cert/Key input values.
+    ssl_cert, ssl_key = _get_ssl_cert_key(image_dir, is_zone, ssl_cert, ssl_key)
+
+    progtrack = get_tracker()
+    progtrack.set_major_phase(progtrack.PHASE_UTILITY)
+    global _api_inst
+    global img
+    try:
+        _api_inst = api.image_create(
+            PKG_CLIENT_NAME,
+            CLIENT_API_VERSION,
+            image_dir,
+            imgtype,
+            is_zone,
+            facets=facets,
+            force=force,
+            mirrors=list(add_mirrors),
+            origins=list(add_origins),
+            prefix=pub_name,
+            progtrack=progtrack,
+            refresh_allowed=refresh_allowed,
+            ssl_cert=ssl_cert,
+            ssl_key=ssl_key,
+            repo_uri=repo_uri,
+            variants=variants,
+            props=set_props,
+        )
+        img = _api_inst.img
+    except api_errors.InvalidDepotResponseException as e:
+        # Ensure messages are displayed after the spinner.
+        logger.error("\n")
+        error(
+            _(
+                "The URI '{pub_url}' does not appear to point to a "
+                "valid pkg repository.\nPlease check the repository's "
+                "location and the client's network configuration."
+                "\nAdditional details:\n\n{error}"
+            ).format(pub_url=pub_url, error=e),
+            cmd=cmd_name,
+        )
+        print_proxy_config()
+        return EXIT_OOPS
+    except api_errors.CatalogRefreshException as cre:
+        # Ensure messages are displayed after the spinner.
+        error("", cmd=cmd_name)
+        if display_catalog_failures(cre) == 0:
+            return EXIT_OOPS
         else:
-                repo_uri = pub_url
+            return EXIT_PARTIAL
+    except api_errors.ApiException as e:
+        error(str(e), cmd=cmd_name)
+        return EXIT_OOPS
+    finally:
+        # Normally this would get flushed by handle_errors
+        # but that won't happen if the above code throws, because
+        # _api_inst will be None.
+        progtrack.flush()
 
-        # Get sanitized SSL Cert/Key input values.
-        ssl_cert, ssl_key = _get_ssl_cert_key(image_dir, is_zone, ssl_cert,
-            ssl_key)
+    return EXIT_OK
 
-        progtrack = get_tracker()
-        progtrack.set_major_phase(progtrack.PHASE_UTILITY)
-        global _api_inst
-        global img
-        try:
-                _api_inst = api.image_create(PKG_CLIENT_NAME, CLIENT_API_VERSION,
-                    image_dir, imgtype, is_zone, facets=facets, force=force,
-                    mirrors=list(add_mirrors), origins=list(add_origins),
-                    prefix=pub_name, progtrack=progtrack,
-                    refresh_allowed=refresh_allowed, ssl_cert=ssl_cert,
-                    ssl_key=ssl_key, repo_uri=repo_uri, variants=variants,
-                    props=set_props)
-                img = _api_inst.img
-        except api_errors.InvalidDepotResponseException as e:
-                # Ensure messages are displayed after the spinner.
-                logger.error("\n")
-                error(_("The URI '{pub_url}' does not appear to point to a "
-                    "valid pkg repository.\nPlease check the repository's "
-                    "location and the client's network configuration."
-                    "\nAdditional details:\n\n{error}").format(
-                    pub_url=pub_url, error=e),
-                    cmd=cmd_name)
-                print_proxy_config()
-                return EXIT_OOPS
-        except api_errors.CatalogRefreshException as cre:
-                # Ensure messages are displayed after the spinner.
-                error("", cmd=cmd_name)
-                if display_catalog_failures(cre) == 0:
-                        return EXIT_OOPS
-                else:
-                        return EXIT_PARTIAL
-        except api_errors.ApiException as e:
-                error(str(e), cmd=cmd_name)
-                return EXIT_OOPS
-        finally:
-                # Normally this would get flushed by handle_errors
-                # but that won't happen if the above code throws, because
-                # _api_inst will be None.
-                progtrack.flush()
-
-        return EXIT_OK
 
 def rebuild_index(api_inst, pargs):
-        """pkg rebuild-index
+    """pkg rebuild-index
 
-        Forcibly rebuild the search indexes. Will remove existing indexes
-        and build new ones from scratch."""
+    Forcibly rebuild the search indexes. Will remove existing indexes
+    and build new ones from scratch."""
 
-        if pargs:
-                usage(_("command does not take operands ('{0}')").format(
-                    " ".join(pargs)), cmd="rebuild-index")
+    if pargs:
+        usage(
+            _("command does not take operands ('{0}')").format(" ".join(pargs)),
+            cmd="rebuild-index",
+        )
 
-        try:
-                api_inst.rebuild_search_index()
-        except api_errors.ImageFormatUpdateNeeded as e:
-                format_update_error(e)
-                return EXIT_OOPS
-        except api_errors.CorruptedIndexException:
-                error("The search index appears corrupted.  Please rebuild the "
-                    "index with 'pkg rebuild-index'.", cmd="rebuild-index")
-                return EXIT_OOPS
-        except api_errors.ProblematicPermissionsIndexException as e:
-                error(str(e))
-                error(_("\n(Failure to consistently execute pkg commands as a "
-                    "privileged user is often a source of this problem.)"))
-                return EXIT_OOPS
-        else:
-                return EXIT_OK
+    try:
+        api_inst.rebuild_search_index()
+    except api_errors.ImageFormatUpdateNeeded as e:
+        format_update_error(e)
+        return EXIT_OOPS
+    except api_errors.CorruptedIndexException:
+        error(
+            "The search index appears corrupted.  Please rebuild the "
+            "index with 'pkg rebuild-index'.",
+            cmd="rebuild-index",
+        )
+        return EXIT_OOPS
+    except api_errors.ProblematicPermissionsIndexException as e:
+        error(str(e))
+        error(
+            _(
+                "\n(Failure to consistently execute pkg commands as a "
+                "privileged user is often a source of this problem.)"
+            )
+        )
+        return EXIT_OOPS
+    else:
+        return EXIT_OK
+
 
 def history_list(api_inst, args):
-        """Display history about the current image.
-        """
+    """Display history about the current image."""
 
-        # define column name, header, field width and <History> attribute name
-        # we compute 'reason', 'time' and 'release_note' columns ourselves
-        history_cols = {
-            "be": (_("BE"), "20", "operation_be"),
-            "be_uuid": (_("BE UUID"), "41", "operation_be_uuid"),
-            "client": (_("CLIENT"), "19", "client_name"),
-            "client_ver": (_("VERSION"), "15", "client_version"),
-            "command": (_("COMMAND"), "", "client_args"),
-            "finish": (_("FINISH"), "25", "operation_end_time"),
-            "id": (_("ID"), "10", "operation_userid"),
-            "new_be": (_("NEW BE"), "20", "operation_new_be"),
-            "new_be_uuid": (_("NEW BE UUID"), "41", "operation_new_be_uuid"),
-            "operation": (_("OPERATION"), "25", "operation_name"),
-            "outcome": (_("OUTCOME"), "12", "operation_result"),
-            "reason": (_("REASON"), "10", None),
-            "release_notes": (_("RELEASE NOTES"), "12", None),
-            "snapshot": (_("SNAPSHOT"), "20", "operation_snapshot"),
-            "start": (_("START"), "25", "operation_start_time"),
-            "time": (_("TIME"), "10", None),
-            "user": (_("USER"), "10", "operation_username"),
-            # omitting start state, end state, errors for now
-            # as these don't nicely fit into columns
-        }
+    # define column name, header, field width and <History> attribute name
+    # we compute 'reason', 'time' and 'release_note' columns ourselves
+    history_cols = {
+        "be": (_("BE"), "20", "operation_be"),
+        "be_uuid": (_("BE UUID"), "41", "operation_be_uuid"),
+        "client": (_("CLIENT"), "19", "client_name"),
+        "client_ver": (_("VERSION"), "15", "client_version"),
+        "command": (_("COMMAND"), "", "client_args"),
+        "finish": (_("FINISH"), "25", "operation_end_time"),
+        "id": (_("ID"), "10", "operation_userid"),
+        "new_be": (_("NEW BE"), "20", "operation_new_be"),
+        "new_be_uuid": (_("NEW BE UUID"), "41", "operation_new_be_uuid"),
+        "operation": (_("OPERATION"), "25", "operation_name"),
+        "outcome": (_("OUTCOME"), "12", "operation_result"),
+        "reason": (_("REASON"), "10", None),
+        "release_notes": (_("RELEASE NOTES"), "12", None),
+        "snapshot": (_("SNAPSHOT"), "20", "operation_snapshot"),
+        "start": (_("START"), "25", "operation_start_time"),
+        "time": (_("TIME"), "10", None),
+        "user": (_("USER"), "10", "operation_username"),
+        # omitting start state, end state, errors for now
+        # as these don't nicely fit into columns
+    }
 
-        omit_headers = False
-        long_format = False
-        column_format = False
-        show_notes = False
-        display_limit = None    # Infinite
-        time_vals = [] # list of timestamps for which we want history events
-        columns = ["start", "operation", "client", "outcome"]
+    omit_headers = False
+    long_format = False
+    column_format = False
+    show_notes = False
+    display_limit = None  # Infinite
+    time_vals = []  # list of timestamps for which we want history events
+    columns = ["start", "operation", "client", "outcome"]
 
-        opts, pargs = getopt.getopt(args, "HNln:o:t:")
-        for opt, arg in opts:
-                if opt == "-H":
-                        omit_headers = True
-                elif opt == "-N":
-                        show_notes = True
-                elif opt == "-l":
-                        long_format = True
-                elif opt == "-n":
-                        try:
-                                display_limit = int(arg)
-                        except ValueError:
-                                logger.error(
-                                    _("Argument to -n must be numeric"))
-                                return EXIT_BADOPT
+    opts, pargs = getopt.getopt(args, "HNln:o:t:")
+    for opt, arg in opts:
+        if opt == "-H":
+            omit_headers = True
+        elif opt == "-N":
+            show_notes = True
+        elif opt == "-l":
+            long_format = True
+        elif opt == "-n":
+            try:
+                display_limit = int(arg)
+            except ValueError:
+                logger.error(_("Argument to -n must be numeric"))
+                return EXIT_BADOPT
 
-                        if display_limit <= 0:
-                                logger.error(
-                                    _("Argument to -n must be positive"))
-                                return EXIT_BADOPT
-                elif opt == "-o":
-                        column_format = True
-                        columns = arg.split(",")
+            if display_limit <= 0:
+                logger.error(_("Argument to -n must be positive"))
+                return EXIT_BADOPT
+        elif opt == "-o":
+            column_format = True
+            columns = arg.split(",")
 
-                        # 'command' and 'reason' are multi-field columns, we
-                        # insist they be the last item in the -o output,
-                        # otherwise scripts could be broken by different numbers
-                        # of output fields
-                        if "command" in columns and "reason" in columns:
-                                # Translators: 'command' and 'reason' are
-                                # keywords and should not be translated
-                                logger.error(_("'command' and 'reason' columns "
-                                    "cannot be used together."))
-                                return EXIT_BADOPT
+            # 'command' and 'reason' are multi-field columns, we
+            # insist they be the last item in the -o output,
+            # otherwise scripts could be broken by different numbers
+            # of output fields
+            if "command" in columns and "reason" in columns:
+                # Translators: 'command' and 'reason' are
+                # keywords and should not be translated
+                logger.error(
+                    _(
+                        "'command' and 'reason' columns "
+                        "cannot be used together."
+                    )
+                )
+                return EXIT_BADOPT
 
-                        for col in ["command", "reason"]:
-                                if col in columns and \
-                                    columns.index(col) != len(columns) - 1:
-                                        logger.error(
-                                            _("The '{0}' column must be the "
-                                            "last item in the -o list").format(
-                                            col))
-                                        return EXIT_BADOPT
+            for col in ["command", "reason"]:
+                if col in columns and columns.index(col) != len(columns) - 1:
+                    logger.error(
+                        _(
+                            "The '{0}' column must be the "
+                            "last item in the -o list"
+                        ).format(col)
+                    )
+                    return EXIT_BADOPT
 
-                        for col in columns:
-                                if col not in history_cols:
-                                        logger.error(
-                                            _("Unknown output column "
-                                            "'{0}'").format(col))
-                                        return EXIT_BADOPT
-                        if not __unique_columns(columns):
-                                return EXIT_BADOPT
+            for col in columns:
+                if col not in history_cols:
+                    logger.error(
+                        _("Unknown output column " "'{0}'").format(col)
+                    )
+                    return EXIT_BADOPT
+            if not __unique_columns(columns):
+                return EXIT_BADOPT
 
-                elif opt == "-t":
-                        time_vals.extend(arg.split(","))
+        elif opt == "-t":
+            time_vals.extend(arg.split(","))
 
-        if omit_headers and long_format:
-                usage(_("-H and -l may not be combined"), cmd="history")
+    if omit_headers and long_format:
+        usage(_("-H and -l may not be combined"), cmd="history")
 
-        if column_format and long_format:
-                usage(_("-o and -l may not be combined"), cmd="history")
+    if column_format and long_format:
+        usage(_("-o and -l may not be combined"), cmd="history")
 
-        if time_vals and display_limit:
-                usage(_("-n and -t may not be combined"), cmd="history")
+    if time_vals and display_limit:
+        usage(_("-n and -t may not be combined"), cmd="history")
 
-        if column_format and show_notes:
-                usage(_("-o and -N may not be combined"), cmd="history")
+    if column_format and show_notes:
+        usage(_("-o and -N may not be combined"), cmd="history")
 
-        if long_format and show_notes:
-                usage(_("-l and -N may not be combined"), cmd="history")
+    if long_format and show_notes:
+        usage(_("-l and -N may not be combined"), cmd="history")
 
-        history_fmt = None
+    history_fmt = None
 
-        if not long_format and not show_notes:
-                headers = []
-                # build our format string
-                for i, col in enumerate(columns):
-                        # no need for trailing space for our last column
-                        if columns.index(col) == len(columns) - 1:
-                                fmt = ""
-                        else:
-                                fmt = history_cols[col][1]
-                        if history_fmt:
-                                history_fmt += "{{{0:d}!s:{1}}}".format(i, fmt)
-                        else:
-                                history_fmt = "{{0!s:{0}}}".format(fmt)
-                        headers.append(history_cols[col][0])
-                if not omit_headers:
-                        msg(history_fmt.format(*headers))
+    if not long_format and not show_notes:
+        headers = []
+        # build our format string
+        for i, col in enumerate(columns):
+            # no need for trailing space for our last column
+            if columns.index(col) == len(columns) - 1:
+                fmt = ""
+            else:
+                fmt = history_cols[col][1]
+            if history_fmt:
+                history_fmt += "{{{0:d}!s:{1}}}".format(i, fmt)
+            else:
+                history_fmt = "{{0!s:{0}}}".format(fmt)
+            headers.append(history_cols[col][0])
+        if not omit_headers:
+            msg(history_fmt.format(*headers))
 
-        def gen_entries():
-                """Error handler for history generation; avoids need to indent
-                and clobber formatting of logic below."""
-                try:
-                        for he in api_inst.gen_history(limit=display_limit,
-                            times=time_vals):
-                                yield he
-                except api_errors.HistoryException as e:
-                        error(str(e), cmd="history")
-                        sys.exit(EXIT_OOPS)
+    def gen_entries():
+        """Error handler for history generation; avoids need to indent
+        and clobber formatting of logic below."""
+        try:
+            for he in api_inst.gen_history(
+                limit=display_limit, times=time_vals
+            ):
+                yield he
+        except api_errors.HistoryException as e:
+            error(str(e), cmd="history")
+            sys.exit(EXIT_OOPS)
 
-        if show_notes:
-                for he in gen_entries():
-                        start_time = misc.timestamp_to_time(
-                            he.operation_start_time)
-                        start_time = datetime.datetime.fromtimestamp(
-                            start_time).isoformat()
-                        if he.operation_release_notes:
-                                msg(_("{0}: Release notes:").format(start_time))
-                                for a in he.notes:
-                                        msg("    {0}".format(a))
-                        else:
-                                msg(_("{0}: Release notes: None").format(
-                                    start_time))
-
-                return EXIT_OK
-
+    if show_notes:
         for he in gen_entries():
-                # populate a dictionary containing our output
-                output = {}
-                for col in history_cols:
-                        if not history_cols[col][2]:
-                                continue
-                        output[col] = getattr(he, history_cols[col][2], None)
+            start_time = misc.timestamp_to_time(he.operation_start_time)
+            start_time = datetime.datetime.fromtimestamp(start_time).isoformat()
+            if he.operation_release_notes:
+                msg(_("{0}: Release notes:").format(start_time))
+                for a in he.notes:
+                    msg("    {0}".format(a))
+            else:
+                msg(_("{0}: Release notes: None").format(start_time))
 
-                # format some of the History object attributes ourselves
-                output["start"] = misc.timestamp_to_time(
-                    he.operation_start_time)
-                output["start"] = datetime.datetime.fromtimestamp(
-                    output["start"]).isoformat()
-                output["finish"] = misc.timestamp_to_time(
-                    he.operation_end_time)
-                output["finish"] = datetime.datetime.fromtimestamp(
-                    output["finish"]).isoformat()
-
-                dt_start = misc.timestamp_to_datetime(he.operation_start_time)
-                dt_end = misc.timestamp_to_datetime(he.operation_end_time)
-                if dt_start > dt_end:
-                        output["finish"] = \
-                            _("{0} (clock drift detected)").format(
-                            output["finish"])
-
-                output["time"] = dt_end - dt_start
-                # We can't use timedelta's str() method, since when
-                # output["time"].days > 0, it prints eg. "4 days, 3:12:54"
-                # breaking our field separation, so we need to do this by hand.
-                total_time = output["time"]
-                secs = total_time.seconds
-                add_hrs = total_time.days * 24
-                mins, secs = divmod(secs, 60)
-                hrs, mins = divmod(mins, 60)
-                output["time"] = "{0}:{1:02d}:{2:02d}".format(
-                    add_hrs + hrs, mins, secs)
-
-                output["command"] = " ".join(he.client_args)
-
-                # Where we weren't able to lookup the current name, add a '*' to
-                # the entry, indicating the boot environment is no longer
-                # present.
-                if he.operation_be and he.operation_current_be:
-                        output["be"] = he.operation_current_be
-                elif he.operation_be_uuid:
-                        output["be"] = "{0}*".format(he.operation_be)
-                else:
-                        output["be"] = he.operation_be
-
-                if he.operation_new_be and he.operation_current_new_be:
-                        output["new_be"] = he.operation_current_new_be
-                elif he.operation_new_be_uuid:
-                        output["new_be"] = "{0}*".format(he.operation_new_be)
-                else:
-                        output["new_be"] = "{0}".format(he.operation_new_be)
-
-                if he.operation_release_notes:
-                        output["release_notes"] = _("Yes")
-                else:
-                        output["release_notes"] = _("No")
-
-                outcome, reason = he.operation_result_text
-                output["outcome"] = outcome
-                output["reason"] = reason
-                output["snapshot"] = he.operation_snapshot
-
-                # be, snapshot and new_be use values in parenthesis
-                # since these cannot appear in valid BE or snapshot names
-                if not output["be"]:
-                        output["be"] = _("(Unknown)")
-
-                if not output["be_uuid"]:
-                        output["be_uuid"] = _("(Unknown)")
-
-                if not output["snapshot"]:
-                        output["snapshot"] = _("(None)")
-
-                if not output["new_be"]:
-                        output["new_be"] = _("(None)")
-
-                if not output["new_be_uuid"]:
-                        output["new_be_uuid"] = _("(None)")
-
-                enc = locale.getlocale(locale.LC_CTYPE)[1]
-                if not enc:
-                        enc = locale.getpreferredencoding()
-
-                if long_format:
-                        data = __get_long_history_data(he, output)
-                        for field, value in data:
-                                field = misc.force_str(field, encoding=enc)
-                                value = misc.force_str(value, encoding=enc)
-                                msg("{0!s:>18}: {1!s}".format(field, value))
-
-                        # Separate log entries with a blank line.
-                        msg("")
-                else:
-                        items = []
-                        for col in columns:
-                                item = output[col]
-                                item = misc.force_str(item, encoding=enc)
-                                items.append(item)
-                        msg(history_fmt.format(*items))
         return EXIT_OK
+
+    for he in gen_entries():
+        # populate a dictionary containing our output
+        output = {}
+        for col in history_cols:
+            if not history_cols[col][2]:
+                continue
+            output[col] = getattr(he, history_cols[col][2], None)
+
+        # format some of the History object attributes ourselves
+        output["start"] = misc.timestamp_to_time(he.operation_start_time)
+        output["start"] = datetime.datetime.fromtimestamp(
+            output["start"]
+        ).isoformat()
+        output["finish"] = misc.timestamp_to_time(he.operation_end_time)
+        output["finish"] = datetime.datetime.fromtimestamp(
+            output["finish"]
+        ).isoformat()
+
+        dt_start = misc.timestamp_to_datetime(he.operation_start_time)
+        dt_end = misc.timestamp_to_datetime(he.operation_end_time)
+        if dt_start > dt_end:
+            output["finish"] = _("{0} (clock drift detected)").format(
+                output["finish"]
+            )
+
+        output["time"] = dt_end - dt_start
+        # We can't use timedelta's str() method, since when
+        # output["time"].days > 0, it prints eg. "4 days, 3:12:54"
+        # breaking our field separation, so we need to do this by hand.
+        total_time = output["time"]
+        secs = total_time.seconds
+        add_hrs = total_time.days * 24
+        mins, secs = divmod(secs, 60)
+        hrs, mins = divmod(mins, 60)
+        output["time"] = "{0}:{1:02d}:{2:02d}".format(add_hrs + hrs, mins, secs)
+
+        output["command"] = " ".join(he.client_args)
+
+        # Where we weren't able to lookup the current name, add a '*' to
+        # the entry, indicating the boot environment is no longer
+        # present.
+        if he.operation_be and he.operation_current_be:
+            output["be"] = he.operation_current_be
+        elif he.operation_be_uuid:
+            output["be"] = "{0}*".format(he.operation_be)
+        else:
+            output["be"] = he.operation_be
+
+        if he.operation_new_be and he.operation_current_new_be:
+            output["new_be"] = he.operation_current_new_be
+        elif he.operation_new_be_uuid:
+            output["new_be"] = "{0}*".format(he.operation_new_be)
+        else:
+            output["new_be"] = "{0}".format(he.operation_new_be)
+
+        if he.operation_release_notes:
+            output["release_notes"] = _("Yes")
+        else:
+            output["release_notes"] = _("No")
+
+        outcome, reason = he.operation_result_text
+        output["outcome"] = outcome
+        output["reason"] = reason
+        output["snapshot"] = he.operation_snapshot
+
+        # be, snapshot and new_be use values in parenthesis
+        # since these cannot appear in valid BE or snapshot names
+        if not output["be"]:
+            output["be"] = _("(Unknown)")
+
+        if not output["be_uuid"]:
+            output["be_uuid"] = _("(Unknown)")
+
+        if not output["snapshot"]:
+            output["snapshot"] = _("(None)")
+
+        if not output["new_be"]:
+            output["new_be"] = _("(None)")
+
+        if not output["new_be_uuid"]:
+            output["new_be_uuid"] = _("(None)")
+
+        enc = locale.getlocale(locale.LC_CTYPE)[1]
+        if not enc:
+            enc = locale.getpreferredencoding()
+
+        if long_format:
+            data = __get_long_history_data(he, output)
+            for field, value in data:
+                field = misc.force_str(field, encoding=enc)
+                value = misc.force_str(value, encoding=enc)
+                msg("{0!s:>18}: {1!s}".format(field, value))
+
+            # Separate log entries with a blank line.
+            msg("")
+        else:
+            items = []
+            for col in columns:
+                item = output[col]
+                item = misc.force_str(item, encoding=enc)
+                items.append(item)
+            msg(history_fmt.format(*items))
+    return EXIT_OK
+
 
 def __unique_columns(columns):
-        """Return true if each entry in the provided list of columns only
-        appears once."""
+    """Return true if each entry in the provided list of columns only
+    appears once."""
 
-        seen_cols = set()
-        dup_cols = set()
-        for col in columns:
-                if col in seen_cols:
-                        dup_cols.add(col)
-                seen_cols.add(col)
-        for col in dup_cols:
-                logger.error(_("Duplicate column specified: {0}").format(col))
-        return not dup_cols
+    seen_cols = set()
+    dup_cols = set()
+    for col in columns:
+        if col in seen_cols:
+            dup_cols.add(col)
+        seen_cols.add(col)
+    for col in dup_cols:
+        logger.error(_("Duplicate column specified: {0}").format(col))
+    return not dup_cols
+
 
 def __get_long_history_data(he, hist_info):
-        """Return an array of tuples containing long_format history info"""
-        data = []
-        data.append((_("Operation"), hist_info["operation"]))
+    """Return an array of tuples containing long_format history info"""
+    data = []
+    data.append((_("Operation"), hist_info["operation"]))
 
-        data.append((_("Outcome"), hist_info["outcome"]))
-        data.append((_("Reason"), hist_info["reason"]))
-        data.append((_("Client"), hist_info["client"]))
-        data.append((_("Version"), hist_info["client_ver"]))
+    data.append((_("Outcome"), hist_info["outcome"]))
+    data.append((_("Reason"), hist_info["reason"]))
+    data.append((_("Client"), hist_info["client"]))
+    data.append((_("Version"), hist_info["client_ver"]))
 
-        data.append((_("User"), "{0} ({1})".format(hist_info["user"],
-            hist_info["id"])))
+    data.append(
+        (_("User"), "{0} ({1})".format(hist_info["user"], hist_info["id"]))
+    )
 
-        if hist_info["be"]:
-                data.append((_("Boot Env."), hist_info["be"]))
-        if hist_info["be_uuid"]:
-                data.append((_("Boot Env. UUID"), hist_info["be_uuid"]))
-        if hist_info["new_be"]:
-                data.append((_("New Boot Env."), hist_info["new_be"]))
-        if hist_info["new_be_uuid"]:
-                data.append((_("New Boot Env. UUID"),
-                    hist_info["new_be_uuid"]))
-        if hist_info["snapshot"]:
-                data.append((_("Snapshot"), hist_info["snapshot"]))
+    if hist_info["be"]:
+        data.append((_("Boot Env."), hist_info["be"]))
+    if hist_info["be_uuid"]:
+        data.append((_("Boot Env. UUID"), hist_info["be_uuid"]))
+    if hist_info["new_be"]:
+        data.append((_("New Boot Env."), hist_info["new_be"]))
+    if hist_info["new_be_uuid"]:
+        data.append((_("New Boot Env. UUID"), hist_info["new_be_uuid"]))
+    if hist_info["snapshot"]:
+        data.append((_("Snapshot"), hist_info["snapshot"]))
 
-        data.append((_("Start Time"), hist_info["start"]))
-        data.append((_("End Time"), hist_info["finish"]))
-        data.append((_("Total Time"), hist_info["time"]))
-        data.append((_("Command"), hist_info["command"]))
-        data.append((_("Release Notes"), hist_info["release_notes"]))
+    data.append((_("Start Time"), hist_info["start"]))
+    data.append((_("End Time"), hist_info["finish"]))
+    data.append((_("Total Time"), hist_info["time"]))
+    data.append((_("Command"), hist_info["command"]))
+    data.append((_("Release Notes"), hist_info["release_notes"]))
 
-        state = he.operation_start_state
-        if state:
-                data.append((_("Start State"), "\n" + state))
+    state = he.operation_start_state
+    if state:
+        data.append((_("Start State"), "\n" + state))
 
-        state = he.operation_end_state
-        if state:
-                data.append((_("End State"), "\n" + state))
+    state = he.operation_end_state
+    if state:
+        data.append((_("End State"), "\n" + state))
 
-        errors = "\n".join(he.operation_errors)
-        if errors:
-                data.append((_("Errors"), "\n" + errors))
-        return data
+    errors = "\n".join(he.operation_errors)
+    if errors:
+        data.append((_("Errors"), "\n" + errors))
+    return data
+
 
 def history_purge(api_inst, pargs):
-        """Purge image history"""
-        api_inst.purge_history()
-        msg(_("History purged."))
+    """Purge image history"""
+    api_inst.purge_history()
+    msg(_("History purged."))
+
 
 def print_proxy_config():
-        """If the user has configured http_proxy or https_proxy in the
-        environment, print out the values.  Some transport errors are
-        not debuggable without this information handy."""
+    """If the user has configured http_proxy or https_proxy in the
+    environment, print out the values.  Some transport errors are
+    not debuggable without this information handy."""
 
-        http_proxy = os.environ.get("http_proxy", None)
-        https_proxy = os.environ.get("https_proxy", None)
+    http_proxy = os.environ.get("http_proxy", None)
+    https_proxy = os.environ.get("https_proxy", None)
 
-        if not http_proxy and not https_proxy:
-                return
+    if not http_proxy and not https_proxy:
+        return
 
-        logger.error(_("\nThe following proxy configuration is set in the"
-            " environment:\n"))
-        if http_proxy:
-                logger.error(_("http_proxy: {0}\n").format(http_proxy))
-        if https_proxy:
-                logger.error(_("https_proxy: {0}\n").format(https_proxy))
+    logger.error(
+        _("\nThe following proxy configuration is set in the" " environment:\n")
+    )
+    if http_proxy:
+        logger.error(_("http_proxy: {0}\n").format(http_proxy))
+    if https_proxy:
+        logger.error(_("https_proxy: {0}\n").format(https_proxy))
+
 
 def update_format(api_inst, pargs):
-        """Update image to newest format."""
+    """Update image to newest format."""
 
-        try:
-                res = api_inst.update_format()
-        except api_errors.ApiException as e:
-                error(str(e), cmd="update-format")
-                return EXIT_OOPS
+    try:
+        res = api_inst.update_format()
+    except api_errors.ApiException as e:
+        error(str(e), cmd="update-format")
+        return EXIT_OOPS
 
-        if res:
-                logger.info(_("Image format updated."))
-                return EXIT_OK
+    if res:
+        logger.info(_("Image format updated."))
+        return EXIT_OK
 
-        logger.info(_("Image format already current."))
-        return EXIT_NOP
+    logger.info(_("Image format already current."))
+    return EXIT_NOP
+
 
 def print_version(pargs):
-        if pargs:
-                usage(_("version: command does not take operands "
-                    "('{0}')").format(" ".join(pargs)), cmd="version")
-        msg(pkg.VERSION)
-        return EXIT_OK
+    if pargs:
+        usage(
+            _("version: command does not take operands " "('{0}')").format(
+                " ".join(pargs)
+            ),
+            cmd="version",
+        )
+    msg(pkg.VERSION)
+    return EXIT_OK
+
 
 # To allow exception handler access to the image.
 _api_inst = None
@@ -5757,7 +7189,8 @@ orig_cwd = None
 #
 # {option_name: (short, long)}
 #
-#
+
+# fmt: off
 
 opts_mapping = {
     "backup_be_name" :    ("",  "backup-be-name"),
@@ -5994,19 +7427,25 @@ valid_opt_values = {
     "output_format":        ["default", "tsv", "json", "json-formatted"]
 }
 
+# fmt: on
+
 # These tables are an addendum to the pkg_op_opts/opts_* lists in
 # modules/client/options.py. They contain all the options for functions which
 # are not represented in options.py but go through common option processing.
 # This list should get shortened and eventually removed by moving more/all
 # functions out of client.py.
 
-def opts_cb_remote(op, api_inst, opts, opts_new):
-        options.opts_cb_fd("ctlfd", api_inst, opts, opts_new)
-        options.opts_cb_fd("progfd", api_inst, opts, opts_new)
 
-        # move progfd from opts_new into a global
-        global_settings.client_output_progfd = opts_new["progfd"]
-        del opts_new["progfd"]
+def opts_cb_remote(op, api_inst, opts, opts_new):
+    options.opts_cb_fd("ctlfd", api_inst, opts, opts_new)
+    options.opts_cb_fd("progfd", api_inst, opts, opts_new)
+
+    # move progfd from opts_new into a global
+    global_settings.client_output_progfd = opts_new["progfd"]
+    del opts_new["progfd"]
+
+
+# fmt: off
 
 opts_remote = [
     opts_cb_remote,
@@ -6014,11 +7453,18 @@ opts_remote = [
     ("progfd",               None),
 ]
 
+# fmt: on
+
+
 def opts_cb_varcet(op, api_inst, opts, opts_new):
-        if opts_new["list_all_items"] and opts_new["list_installed"]:
-                raise api_errors.InvalidOptionError(
-                    api_errors.InvalidOptionError.INCOMPAT,
-                    ["list_all_items", "list_installed"])
+    if opts_new["list_all_items"] and opts_new["list_installed"]:
+        raise api_errors.InvalidOptionError(
+            api_errors.InvalidOptionError.INCOMPAT,
+            ["list_all_items", "list_installed"],
+        )
+
+
+# fmt: off
 
 opts_list_varcet = \
     options.opts_table_no_headers + \
@@ -6065,470 +7511,526 @@ cmd_opts = {
     "variant"           : opts_list_variant,
 }
 
+# fmt: on
+
 
 def main_func():
-        global_settings.client_name = PKG_CLIENT_NAME
+    global_settings.client_name = PKG_CLIENT_NAME
 
-        global _api_inst
-        global img
-        global orig_cwd
-        global pargs
+    global _api_inst
+    global img
+    global orig_cwd
+    global pargs
 
+    try:
+        orig_cwd = os.getcwd()
+    except OSError as e:
         try:
-                orig_cwd = os.getcwd()
-        except OSError as e:
+            orig_cwd = os.environ["PWD"]
+            if not orig_cwd or orig_cwd[0] != "/":
+                orig_cwd = None
+        except KeyError:
+            orig_cwd = None
+
+    try:
+        opts, pargs = getopt.getopt(
+            sys.argv[1:],
+            "R:D:?",
+            ["debug=", "help", "runid=", "notes", "no-network-cache"],
+        )
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
+
+    runid = None
+    show_usage = False
+    for opt, arg in opts:
+        if opt == "-D" or opt == "--debug":
+            if arg in ["plan", "transport", "exclude", "actions"]:
+                key = arg
+                value = "True"
+            else:
                 try:
-                        orig_cwd = os.environ["PWD"]
-                        if not orig_cwd or orig_cwd[0] != "/":
-                                orig_cwd = None
-                except KeyError:
-                        orig_cwd = None
+                    key, value = arg.split("=", 1)
+                except (AttributeError, ValueError):
+                    usage(
+                        _(
+                            "{opt} takes argument of form "
+                            "name=value, not {arg}"
+                        ).format(opt=opt, arg=arg)
+                    )
+            DebugValues.set_value(key, value)
+        elif opt == "-R":
+            mydir = arg
+        elif opt == "--runid":
+            runid = arg
+        elif opt in ("--help", "-?"):
+            show_usage = True
+        elif opt == "--notes":
+            notes_block()
+            return EXIT_OK
+        elif opt == "--no-network-cache":
+            global_settings.client_no_network_cache = True
 
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "R:D:?",
-                    ["debug=", "help", "runid=", "notes", "no-network-cache"])
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
+    # The globals in pkg.digest can be influenced by debug flags
+    if DebugValues:
+        reload(pkg.digest)
 
-        runid = None
-        show_usage = False
-        for opt, arg in opts:
-                if opt == "-D" or opt == "--debug":
-                        if arg in ["plan", "transport", "exclude", "actions"]:
-                                key = arg
-                                value = "True"
-                        else:
-                                try:
-                                        key, value = arg.split("=", 1)
-                                except (AttributeError, ValueError):
-                                        usage(_("{opt} takes argument of form "
-                                            "name=value, not {arg}").format(
-                                            opt=opt, arg=arg))
-                        DebugValues.set_value(key, value)
-                elif opt == "-R":
-                        mydir = arg
-                elif opt == "--runid":
-                        runid = arg
-                elif opt in ("--help", "-?"):
-                        show_usage = True
-                elif opt == "--notes":
-                        notes_block()
-                        return EXIT_OK
-                elif opt == "--no-network-cache":
-                        global_settings.client_no_network_cache = True
-
-        # The globals in pkg.digest can be influenced by debug flags
-        if DebugValues:
-                reload(pkg.digest)
-
-        subcommand = None
-        if pargs:
-                subcommand = pargs.pop(0)
-                if subcommand in aliases:
-                        subcommand = aliases[subcommand]
-                if subcommand == "help":
-                        if pargs:
-                                sub = pargs.pop(0)
-                                if sub in cmds and \
-                                    sub not in ["help", "-?", "--help"]:
-                                        usage(retcode=0, full=False, cmd=sub)
-                                elif sub == "-v":
-                                        # Only display the long usage message
-                                        # in the verbose mode.
-                                        usage(retcode=0, full=True,
-                                            verbose=True)
-                                elif sub not in ["help", "-?", "--help"]:
-                                        usage(_("unknown subcommand "
-                                            "'{0}'").format(sub), unknown_cmd=sub)
-                                else:
-                                        usage(retcode=0, full=True)
-                        else:
-                                usage(retcode=0, full=True)
-
-        # A gauntlet of tests to see if we need to print usage information
-        if subcommand in cmds and show_usage:
-                usage(retcode=0, cmd=subcommand, full=False)
-        if subcommand and subcommand not in cmds:
-                usage(_("unknown subcommand '{0}'").format(subcommand),
-                    unknown_cmd=subcommand)
-        if show_usage:
+    subcommand = None
+    if pargs:
+        subcommand = pargs.pop(0)
+        if subcommand in aliases:
+            subcommand = aliases[subcommand]
+        if subcommand == "help":
+            if pargs:
+                sub = pargs.pop(0)
+                if sub in cmds and sub not in ["help", "-?", "--help"]:
+                    usage(retcode=0, full=False, cmd=sub)
+                elif sub == "-v":
+                    # Only display the long usage message
+                    # in the verbose mode.
+                    usage(retcode=0, full=True, verbose=True)
+                elif sub not in ["help", "-?", "--help"]:
+                    usage(
+                        _("unknown subcommand " "'{0}'").format(sub),
+                        unknown_cmd=sub,
+                    )
+                else:
+                    usage(retcode=0, full=True)
+            else:
                 usage(retcode=0, full=True)
-        if not subcommand:
-                usage(_("no subcommand specified"), full=True)
-        if runid is not None:
-                try:
-                        runid = int(runid)
-                except:
-                        usage(_("runid must be an integer"))
-                global_settings.client_runid = runid
 
-        for opt in ["--help", "-?"]:
-                if opt in pargs:
-                        usage(retcode=0, full=False, cmd=subcommand)
-
-        # This call only affects sockets created by Python.  The transport
-        # framework uses the defaults in global_settings, which may be
-        # overridden in the environment.  The default socket module should
-        # only be used in rare cases by ancillary code, making it safe to
-        # code the value here, at least for now.
-        socket.setdefaulttimeout(30) # in secs
-
-        cmds_no_image = {
-                "version"        : print_version,
-                "image-create"   : image_create,
-        }
-        func = cmds_no_image.get(subcommand, None)
-        if func:
-                if "mydir" in locals():
-                        usage(_("-R not allowed for {0} subcommand").format(
-                              subcommand), cmd=subcommand)
-                try:
-                        pkg_timer.record("client startup", logger=logger)
-                        ret = func(pargs)
-                except getopt.GetoptError as e:
-                        usage(_("illegal option -- {0}").format(e.opt),
-                            cmd=subcommand)
-                return ret
-
-        provided_image_dir = True
-        pkg_image_used = False
-        if "mydir" not in locals():
-                mydir, provided_image_dir = api.get_default_image_root(
-                    orig_cwd=orig_cwd)
-                if os.environ.get("PKG_IMAGE"):
-                        # It's assumed that this has been checked by the above
-                        # function call and hasn't been removed from the
-                        # environment.
-                        pkg_image_used = True
-
-        if not mydir:
-                error(_("Could not find image.  Use the -R option or set "
-                    "$PKG_IMAGE to the\nlocation of an image."))
-                return EXIT_OOPS
-
-        # Get ImageInterface and image object.
-        api_inst = __api_alloc(mydir, provided_image_dir, pkg_image_used)
-        if api_inst is None:
-                return EXIT_OOPS
-        _api_inst = api_inst
-        img = api_inst.img
-
-        # Find subcommand and execute operation.
-        func = cmds[subcommand][0]
-        pargs_limit = None
-        if len(cmds[subcommand]) > 1:
-                pargs_limit = cmds[subcommand][1]
-
-        pkg_timer.record("client startup", logger=logger)
-
-        # Get the available options for the requested operation to create the
-        # getopt parsing strings.
-        valid_opts = options.get_pkg_opts(subcommand, add_table=cmd_opts)
-        if valid_opts is None:
-                # if there are no options for an op, it has its own processing
-                try:
-                        return func(api_inst, pargs)
-                except getopt.GetoptError as e:
-                        usage(_("illegal option -- {0}").format(e.opt),
-                            cmd=subcommand)
-
+    # A gauntlet of tests to see if we need to print usage information
+    if subcommand in cmds and show_usage:
+        usage(retcode=0, cmd=subcommand, full=False)
+    if subcommand and subcommand not in cmds:
+        usage(
+            _("unknown subcommand '{0}'").format(subcommand),
+            unknown_cmd=subcommand,
+        )
+    if show_usage:
+        usage(retcode=0, full=True)
+    if not subcommand:
+        usage(_("no subcommand specified"), full=True)
+    if runid is not None:
         try:
-                # Parse CLI arguments into dictionary containing corresponding
-                # options and values.
-                opt_dict, pargs = misc.opts_parse(subcommand, pargs, valid_opts,
-                    opts_mapping, usage)
+            runid = int(runid)
+        except:
+            usage(_("runid must be an integer"))
+        global_settings.client_runid = runid
 
-                if pargs_limit is not None and len(pargs) > pargs_limit:
-                        usage(_("illegal argument -- {0}").format(
-                            pargs[pargs_limit]), cmd=subcommand)
+    for opt in ["--help", "-?"]:
+        if opt in pargs:
+            usage(retcode=0, full=False, cmd=subcommand)
 
-                opts = options.opts_assemble(subcommand, api_inst, opt_dict,
-                    add_table=cmd_opts, cwd=orig_cwd)
+    # This call only affects sockets created by Python.  The transport
+    # framework uses the defaults in global_settings, which may be
+    # overridden in the environment.  The default socket module should
+    # only be used in rare cases by ancillary code, making it safe to
+    # code the value here, at least for now.
+    socket.setdefaulttimeout(30)  # in secs
 
-        except api_errors.InvalidOptionError as e:
+    cmds_no_image = {
+        "version": print_version,
+        "image-create": image_create,
+    }
+    func = cmds_no_image.get(subcommand, None)
+    if func:
+        if "mydir" in locals():
+            usage(
+                _("-R not allowed for {0} subcommand").format(subcommand),
+                cmd=subcommand,
+            )
+        try:
+            pkg_timer.record("client startup", logger=logger)
+            ret = func(pargs)
+        except getopt.GetoptError as e:
+            usage(_("illegal option -- {0}").format(e.opt), cmd=subcommand)
+        return ret
 
-                # We can't use the string representation of the exception since
-                # it references internal option names. We substitute the CLI
-                # options and create a new exception to make sure the messages
-                # are correct.
+    provided_image_dir = True
+    pkg_image_used = False
+    if "mydir" not in locals():
+        mydir, provided_image_dir = api.get_default_image_root(
+            orig_cwd=orig_cwd
+        )
+        if os.environ.get("PKG_IMAGE"):
+            # It's assumed that this has been checked by the above
+            # function call and hasn't been removed from the
+            # environment.
+            pkg_image_used = True
 
-                # Convert the internal options to CLI options. We make sure that
-                # when there is a short and a long version for the same option
-                # we print both to avoid confusion.
-                def get_cli_opt(option):
-                        try:
-                                s, l = opts_mapping[option]
-                                if l and not s:
-                                        return "--{0}".format(l)
-                                elif s and not l:
-                                        return "-{0}".format(s)
-                                else:
-                                        return "-{0}/--{1}".format(s, l)
-                        except KeyError:
-                                # ignore if we can't find a match
-                                # (happens for repeated arguments or invalid
-                                # arguments)
-                                return option
-                        except TypeError:
-                                # ignore if we can't find a match
-                                # (happens for an invalid arguments list)
-                                return option
-                cli_opts = []
-                opt_def = []
+    if not mydir:
+        error(
+            _(
+                "Could not find image.  Use the -R option or set "
+                "$PKG_IMAGE to the\nlocation of an image."
+            )
+        )
+        return EXIT_OOPS
 
-                for o in e.options:
-                        cli_opts.append(get_cli_opt(o))
+    # Get ImageInterface and image object.
+    api_inst = __api_alloc(mydir, provided_image_dir, pkg_image_used)
+    if api_inst is None:
+        return EXIT_OOPS
+    _api_inst = api_inst
+    img = api_inst.img
 
-                        # collect the default value (see comment below)
-                        opt_def.append(options.get_pkg_opts_defaults(subcommand,
-                            o, add_table=cmd_opts))
+    # Find subcommand and execute operation.
+    func = cmds[subcommand][0]
+    pargs_limit = None
+    if len(cmds[subcommand]) > 1:
+        pargs_limit = cmds[subcommand][1]
 
-                # Prepare for headache:
-                # If we have an option 'b' which is set to True by default it
-                # will be toggled to False if the users specifies the according
-                # option on the CLI.
-                # If we now have an option 'a' which requires option 'b' to be
-                # set, we can't say "'a' requires 'b'" because the user can only
-                # specify 'not b'. So the correct message would be:
-                # "'a' is incompatible with 'not b'".
-                # We can get there by just changing the type of the exception
-                # for all cases where the default value of one of the options is
-                # True.
-                if e.err_type == api_errors.InvalidOptionError.REQUIRED:
-                        if len(opt_def) == 2 and (opt_def[0] or opt_def[1]):
-                                e.err_type = \
-                                    api_errors.InvalidOptionError.INCOMPAT
+    pkg_timer.record("client startup", logger=logger)
 
-                # This new exception will have the CLI options, so can be passed
-                # directly to usage().
-                new_e = api_errors.InvalidOptionError(err_type=e.err_type,
-                    options=cli_opts, msg=e.msg, valid_args=e.valid_args)
+    # Get the available options for the requested operation to create the
+    # getopt parsing strings.
+    valid_opts = options.get_pkg_opts(subcommand, add_table=cmd_opts)
+    if valid_opts is None:
+        # if there are no options for an op, it has its own processing
+        try:
+            return func(api_inst, pargs)
+        except getopt.GetoptError as e:
+            usage(_("illegal option -- {0}").format(e.opt), cmd=subcommand)
 
-                usage(str(new_e), cmd=subcommand)
+    try:
+        # Parse CLI arguments into dictionary containing corresponding
+        # options and values.
+        opt_dict, pargs = misc.opts_parse(
+            subcommand, pargs, valid_opts, opts_mapping, usage
+        )
 
-        # Reset the progress tracker here, because we may have
-        # to switch to a different tracker due to the options parse.
-        _api_inst.progresstracker = get_tracker()
+        if pargs_limit is not None and len(pargs) > pargs_limit:
+            usage(
+                _("illegal argument -- {0}").format(pargs[pargs_limit]),
+                cmd=subcommand,
+            )
 
-        return func(op=subcommand, api_inst=api_inst,
-            pargs=pargs, **opts)
+        opts = options.opts_assemble(
+            subcommand, api_inst, opt_dict, add_table=cmd_opts, cwd=orig_cwd
+        )
+
+    except api_errors.InvalidOptionError as e:
+        # We can't use the string representation of the exception since
+        # it references internal option names. We substitute the CLI
+        # options and create a new exception to make sure the messages
+        # are correct.
+
+        # Convert the internal options to CLI options. We make sure that
+        # when there is a short and a long version for the same option
+        # we print both to avoid confusion.
+        def get_cli_opt(option):
+            try:
+                s, l = opts_mapping[option]
+                if l and not s:
+                    return "--{0}".format(l)
+                elif s and not l:
+                    return "-{0}".format(s)
+                else:
+                    return "-{0}/--{1}".format(s, l)
+            except KeyError:
+                # ignore if we can't find a match
+                # (happens for repeated arguments or invalid
+                # arguments)
+                return option
+            except TypeError:
+                # ignore if we can't find a match
+                # (happens for an invalid arguments list)
+                return option
+
+        cli_opts = []
+        opt_def = []
+
+        for o in e.options:
+            cli_opts.append(get_cli_opt(o))
+
+            # collect the default value (see comment below)
+            opt_def.append(
+                options.get_pkg_opts_defaults(subcommand, o, add_table=cmd_opts)
+            )
+
+        # Prepare for headache:
+        # If we have an option 'b' which is set to True by default it
+        # will be toggled to False if the users specifies the according
+        # option on the CLI.
+        # If we now have an option 'a' which requires option 'b' to be
+        # set, we can't say "'a' requires 'b'" because the user can only
+        # specify 'not b'. So the correct message would be:
+        # "'a' is incompatible with 'not b'".
+        # We can get there by just changing the type of the exception
+        # for all cases where the default value of one of the options is
+        # True.
+        if e.err_type == api_errors.InvalidOptionError.REQUIRED:
+            if len(opt_def) == 2 and (opt_def[0] or opt_def[1]):
+                e.err_type = api_errors.InvalidOptionError.INCOMPAT
+
+        # This new exception will have the CLI options, so can be passed
+        # directly to usage().
+        new_e = api_errors.InvalidOptionError(
+            err_type=e.err_type,
+            options=cli_opts,
+            msg=e.msg,
+            valid_args=e.valid_args,
+        )
+
+        usage(str(new_e), cmd=subcommand)
+
+    # Reset the progress tracker here, because we may have
+    # to switch to a different tracker due to the options parse.
+    _api_inst.progresstracker = get_tracker()
+
+    return func(op=subcommand, api_inst=api_inst, pargs=pargs, **opts)
+
 
 #
 # Establish a specific exit status which means: "python barfed an exception"
 # so that we can more easily detect these in testing of the CLI commands.
 #
 def handle_errors(func, non_wrap_print=True, *args, **kwargs):
-        traceback_str = misc.get_traceback_message()
+    traceback_str = misc.get_traceback_message()
+    try:
+        # Out of memory errors can be raised as EnvironmentErrors with
+        # an errno of ENOMEM, so in order to handle those exceptions
+        # with other errnos, we nest this try block and have the outer
+        # one handle the other instances.
         try:
-                # Out of memory errors can be raised as EnvironmentErrors with
-                # an errno of ENOMEM, so in order to handle those exceptions
-                # with other errnos, we nest this try block and have the outer
-                # one handle the other instances.
-                try:
-                        __ret = func(*args, **kwargs)
-                except (MemoryError, EnvironmentError) as __e:
-                        if isinstance(__e, EnvironmentError) and \
-                            __e.errno != errno.ENOMEM:
-                                raise
-                        if _api_inst:
-                                _api_inst.abort(
-                                    result=RESULT_FAILED_OUTOFMEMORY)
-                        error("\n" + misc.out_of_memory())
-                        __ret = EXIT_OOPS
-        except SystemExit as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
-                raise __e
-        except (PipeError, KeyboardInterrupt):
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_CANCELED)
-                # We don't want to display any messages here to prevent
-                # possible further broken pipe (EPIPE) errors.
-                __ret = EXIT_OOPS
-        except api_errors.ImageInsufficentSpace as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_DISKSPACE)
-                error(__e)
-                __ret = EXIT_OOPS
-        except api_errors.LinkedImageException as __e:
-                error(_("Linked image exception(s):\n{0}").format(
-                      str(__e)))
-                __ret = __e.lix_exitrv
-        except api_errors.PlanCreationException as __e:
-                error(__e)
-                __ret = EXIT_OOPS
-        except api_errors.CertificateError as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_CONFIGURATION)
-                error(__e)
-                __ret = EXIT_OOPS
-        except api_errors.PublisherError as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_BAD_REQUEST)
-                error(__e)
-                __ret = EXIT_OOPS
-        except api_errors.ImageLockedError as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_LOCKED)
-                error(__e)
-                __ret = EXIT_LOCKED
-        except api_errors.ImageMissingKeyFile as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_LOCKED)
-                error(__e)
-                __ret = EXIT_EACCESS
-        except api_errors.TransportError as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_TRANSPORT)
-                logger.error(_("\nErrors were encountered while attempting "
-                    "to retrieve package or file data for\nthe requested "
-                    "operation."))
-                logger.error(_("Details follow:\n\n{0}").format(__e))
-                print_proxy_config()
-                __ret = EXIT_OOPS
-        except api_errors.InvalidCatalogFile as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_STORAGE)
-                logger.error(_("""
+            __ret = func(*args, **kwargs)
+        except (MemoryError, EnvironmentError) as __e:
+            if isinstance(__e, EnvironmentError) and __e.errno != errno.ENOMEM:
+                raise
+            if _api_inst:
+                _api_inst.abort(result=RESULT_FAILED_OUTOFMEMORY)
+            error("\n" + misc.out_of_memory())
+            __ret = EXIT_OOPS
+    except SystemExit as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
+        raise __e
+    except (PipeError, KeyboardInterrupt):
+        if _api_inst:
+            _api_inst.abort(result=RESULT_CANCELED)
+        # We don't want to display any messages here to prevent
+        # possible further broken pipe (EPIPE) errors.
+        __ret = EXIT_OOPS
+    except api_errors.ImageInsufficentSpace as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_DISKSPACE)
+        error(__e)
+        __ret = EXIT_OOPS
+    except api_errors.LinkedImageException as __e:
+        error(_("Linked image exception(s):\n{0}").format(str(__e)))
+        __ret = __e.lix_exitrv
+    except api_errors.PlanCreationException as __e:
+        error(__e)
+        __ret = EXIT_OOPS
+    except api_errors.CertificateError as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_CONFIGURATION)
+        error(__e)
+        __ret = EXIT_OOPS
+    except api_errors.PublisherError as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_BAD_REQUEST)
+        error(__e)
+        __ret = EXIT_OOPS
+    except api_errors.ImageLockedError as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_LOCKED)
+        error(__e)
+        __ret = EXIT_LOCKED
+    except api_errors.ImageMissingKeyFile as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_LOCKED)
+        error(__e)
+        __ret = EXIT_EACCESS
+    except api_errors.TransportError as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_TRANSPORT)
+        logger.error(
+            _(
+                "\nErrors were encountered while attempting "
+                "to retrieve package or file data for\nthe requested "
+                "operation."
+            )
+        )
+        logger.error(_("Details follow:\n\n{0}").format(__e))
+        print_proxy_config()
+        __ret = EXIT_OOPS
+    except api_errors.InvalidCatalogFile as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_STORAGE)
+        logger.error(
+            _(
+                """
 An error was encountered while attempting to read image state information
-to perform the requested operation.  Details follow:\n\n{0}""").format(__e))
-                __ret = EXIT_OOPS
-        except api_errors.InvalidDepotResponseException as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_TRANSPORT)
-                logger.error(_("\nUnable to contact a valid package "
-                    "repository. This may be due to a problem with the "
-                    "repository, network misconfiguration, or an incorrect "
-                    "pkg client configuration.  Please verify the client's "
-                    "network configuration and repository's location."))
-                logger.error(_("\nAdditional details:\n\n{0}").format(__e))
-                print_proxy_config()
-                __ret = EXIT_OOPS
-        except api_errors.HistoryLoadException as __e:
-                # Since a history related error occurred, discard all
-                # information about the current operation(s) in progress.
-                if _api_inst:
-                        _api_inst.clear_history()
-                error(_("An error was encountered while attempting to load "
-                    "history information\nabout past client operations."))
-                error(__e)
-                __ret = EXIT_OOPS
-        except api_errors.HistoryStoreException as __e:
-                # Since a history related error occurred, discard all
-                # information about the current operation(s) in progress.
-                if _api_inst:
-                        _api_inst.clear_history()
-                error(_("An error was encountered while attempting to store "
-                    "information about the\ncurrent operation in client "
-                    "history."))
-                error(__e)
-                __ret = EXIT_OOPS
-        except api_errors.HistoryPurgeException as __e:
-                # Since a history related error occurred, discard all
-                # information about the current operation(s) in progress.
-                if _api_inst:
-                        _api_inst.clear_history()
-                error(_("An error was encountered while attempting to purge "
-                    "client history."))
-                error(__e)
-                __ret = EXIT_OOPS
-        except api_errors.VersionException as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
-                error(_("The pkg command appears out of sync with the libraries"
-                    " provided\nby pkg:/package/pkg. The client version is "
-                    "{client} while the library\nAPI version is {api}.").format(
-                    client=__e.received_version,
-                    api=__e.expected_version
-                    ))
-                __ret = EXIT_OOPS
-        except api_errors.WrapSuccessfulIndexingException as __e:
-                __ret = EXIT_OK
-        except api_errors.WrapIndexingException as __e:
-                def _wrapper():
-                        raise __e.wrapped
-                __ret = handle_errors(_wrapper, non_wrap_print=False)
-                s = ""
-                if __ret == 99:
-                        s += _("\n{err}{stacktrace}").format(
-                        err=__e, stacktrace=traceback_str)
+to perform the requested operation.  Details follow:\n\n{0}"""
+            ).format(__e)
+        )
+        __ret = EXIT_OOPS
+    except api_errors.InvalidDepotResponseException as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_TRANSPORT)
+        logger.error(
+            _(
+                "\nUnable to contact a valid package "
+                "repository. This may be due to a problem with the "
+                "repository, network misconfiguration, or an incorrect "
+                "pkg client configuration.  Please verify the client's "
+                "network configuration and repository's location."
+            )
+        )
+        logger.error(_("\nAdditional details:\n\n{0}").format(__e))
+        print_proxy_config()
+        __ret = EXIT_OOPS
+    except api_errors.HistoryLoadException as __e:
+        # Since a history related error occurred, discard all
+        # information about the current operation(s) in progress.
+        if _api_inst:
+            _api_inst.clear_history()
+        error(
+            _(
+                "An error was encountered while attempting to load "
+                "history information\nabout past client operations."
+            )
+        )
+        error(__e)
+        __ret = EXIT_OOPS
+    except api_errors.HistoryStoreException as __e:
+        # Since a history related error occurred, discard all
+        # information about the current operation(s) in progress.
+        if _api_inst:
+            _api_inst.clear_history()
+        error(
+            _(
+                "An error was encountered while attempting to store "
+                "information about the\ncurrent operation in client "
+                "history."
+            )
+        )
+        error(__e)
+        __ret = EXIT_OOPS
+    except api_errors.HistoryPurgeException as __e:
+        # Since a history related error occurred, discard all
+        # information about the current operation(s) in progress.
+        if _api_inst:
+            _api_inst.clear_history()
+        error(
+            _(
+                "An error was encountered while attempting to purge "
+                "client history."
+            )
+        )
+        error(__e)
+        __ret = EXIT_OOPS
+    except api_errors.VersionException as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
+        error(
+            _(
+                "The pkg command appears out of sync with the libraries"
+                " provided\nby pkg:/package/pkg. The client version is "
+                "{client} while the library\nAPI version is {api}."
+            ).format(client=__e.received_version, api=__e.expected_version)
+        )
+        __ret = EXIT_OOPS
+    except api_errors.WrapSuccessfulIndexingException as __e:
+        __ret = EXIT_OK
+    except api_errors.WrapIndexingException as __e:
 
-                s += _("\n\nDespite the error while indexing, the operation "
-                    "has completed successfuly.")
-                error(s)
-        except api_errors.ReadOnlyFileSystemException as __e:
-                __ret = EXIT_OOPS
-        except api_errors.UnexpectedLinkError as __e:
-                error("\n" + str(__e))
-                __ret = EXIT_OOPS
-        except api_errors.UnrecognizedCatalogPart as __e:
-                error("\n" + str(__e))
-                __ret = EXIT_OOPS
-        except api_errors.InvalidConfigFile as __e:
-                error("\n" + str(__e))
-                __ret = EXIT_OOPS
-        except (api_errors.PkgUnicodeDecodeError, UnicodeEncodeError) as __e:
-                error("\n" + str(__e))
-                error("the locale environment (LC_ALL, LC_CTYPE) must be"
-                      " a UTF-8 locale or C.")
-                __ret = EXIT_OOPS
-        except:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
-                if non_wrap_print:
-                        traceback.print_exc()
-                        error(traceback_str)
-                __ret = 99
-        return __ret
+        def _wrapper():
+            raise __e.wrapped
+
+        __ret = handle_errors(_wrapper, non_wrap_print=False)
+        s = ""
+        if __ret == 99:
+            s += _("\n{err}{stacktrace}").format(
+                err=__e, stacktrace=traceback_str
+            )
+
+        s += _(
+            "\n\nDespite the error while indexing, the operation "
+            "has completed successfuly."
+        )
+        error(s)
+    except api_errors.ReadOnlyFileSystemException as __e:
+        __ret = EXIT_OOPS
+    except api_errors.UnexpectedLinkError as __e:
+        error("\n" + str(__e))
+        __ret = EXIT_OOPS
+    except api_errors.UnrecognizedCatalogPart as __e:
+        error("\n" + str(__e))
+        __ret = EXIT_OOPS
+    except api_errors.InvalidConfigFile as __e:
+        error("\n" + str(__e))
+        __ret = EXIT_OOPS
+    except (api_errors.PkgUnicodeDecodeError, UnicodeEncodeError) as __e:
+        error("\n" + str(__e))
+        error(
+            "the locale environment (LC_ALL, LC_CTYPE) must be"
+            " a UTF-8 locale or C."
+        )
+        __ret = EXIT_OOPS
+    except:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
+        if non_wrap_print:
+            traceback.print_exc()
+            error(traceback_str)
+        __ret = 99
+    return __ret
 
 
 def handle_sighupterm(signum, frame):
-        """Attempt to gracefully handle SIGHUP and SIGTERM by telling the api
-        to abort and record the cancellation before exiting."""
+    """Attempt to gracefully handle SIGHUP and SIGTERM by telling the api
+    to abort and record the cancellation before exiting."""
 
-        try:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_CANCELED)
-        except:
-                # If history operation fails for some reason, drive on.
-                pass
+    try:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_CANCELED)
+    except:
+        # If history operation fails for some reason, drive on.
+        pass
 
-        # Use os module to immediately exit (bypasses standard exit handling);
-        # this is preferred over raising a KeyboardInterupt as whatever module
-        # we interrupted may not expect that if they disabled SIGINT handling.
-        os._exit(EXIT_OOPS)
+    # Use os module to immediately exit (bypasses standard exit handling);
+    # this is preferred over raising a KeyboardInterupt as whatever module
+    # we interrupted may not expect that if they disabled SIGINT handling.
+    os._exit(EXIT_OOPS)
 
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        # Make all warnings be errors.
-        import warnings
-        warnings.simplefilter('error')
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
+    # Make all warnings be errors.
+    import warnings
 
-        # Attempt to handle SIGHUP/SIGTERM gracefully.
-        import signal
-        if portable.osname != "windows":
-                # SIGHUP not supported on windows; will cause exception.
-                signal.signal(signal.SIGHUP, handle_sighupterm)
-        signal.signal(signal.SIGTERM, handle_sighupterm)
+    warnings.simplefilter("error")
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
 
-        __retval = handle_errors(main_func)
-        if DebugValues["timings"]:
-                def __display_timings():
-                        msg(str(pkg_timer))
-                handle_errors(__display_timings)
-        try:
-                logging.shutdown()
-        except IOError:
-                # Ignore python's spurious pipe problems.
-                pass
-        sys.exit(__retval)
+    # Attempt to handle SIGHUP/SIGTERM gracefully.
+    import signal
+
+    if portable.osname != "windows":
+        # SIGHUP not supported on windows; will cause exception.
+        signal.signal(signal.SIGHUP, handle_sighupterm)
+    signal.signal(signal.SIGTERM, handle_sighupterm)
+
+    __retval = handle_errors(main_func)
+    if DebugValues["timings"]:
+
+        def __display_timings():
+            msg(str(pkg_timer))
+
+        handle_errors(__display_timings)
+    try:
+        logging.shutdown()
+    except IOError:
+        # Ignore python's spurious pipe problems.
+        pass
+    sys.exit(__retval)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/depot-config.py
+++ b/src/depot-config.py
@@ -25,7 +25,9 @@
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 import errno
 import getopt
 import gettext
@@ -42,7 +44,18 @@ import warnings
 
 from mako.template import Template
 from mako.lookup import TemplateLookup
-from OpenSSL.crypto import TYPE_RSA, TYPE_DSA, PKey, load_privatekey, dump_privatekey, load_certificate, dump_certificate, X509, X509Extension, FILETYPE_PEM
+from OpenSSL.crypto import (
+    TYPE_RSA,
+    TYPE_DSA,
+    PKey,
+    load_privatekey,
+    dump_privatekey,
+    load_certificate,
+    dump_certificate,
+    X509,
+    X509Extension,
+    FILETYPE_PEM,
+)
 
 import pkg
 import pkg.client.api_errors as apx
@@ -62,15 +75,15 @@ from pkg.misc import msg, PipeError
 logger = global_settings.logger
 
 # exit codes
-EXIT_OK      = 0
-EXIT_OOPS    = 1
-EXIT_BADOPT  = 2
+EXIT_OK = 0
+EXIT_OOPS = 1
+EXIT_BADOPT = 2
 
 DEPOT_HTTP_TEMPLATE = "depot_httpd.conf.mako"
 DEPOT_FRAGMENT_TEMPLATE = "depot.conf.mako"
 
 DEPOT_HTTP_FILENAME = "depot_httpd.conf"
-DEPOT_FRAGMENT_FILENAME= "depot.conf"
+DEPOT_FRAGMENT_FILENAME = "depot.conf"
 
 DEPOT_PUB_FILENAME = "index.html"
 DEPOT_HTDOCS_DIRNAME = "htdocs"
@@ -94,50 +107,58 @@ catalog 1
 file 1
 manifest 0
 status 0
-""".format(pkg.VERSION)
+""".format(
+    pkg.VERSION
+)
 
 # versions response used when we provide search capability
 DEPOT_VERSIONS_STR = """{0}admin 0
 search 0 1
-""".format(DEPOT_FRAGMENT_VERSIONS_STR)
+""".format(
+    DEPOT_FRAGMENT_VERSIONS_STR
+)
 
 DEPOT_USER = "pkg5srv"
 DEPOT_GROUP = "pkg5srv"
 
+
 class DepotException(Exception):
-        pass
+    pass
 
 
 def error(text, cmd=None):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        if cmd:
-                text = "{0}: {1}".format(cmd, text)
-                pkg_cmd = "pkg.depot-config "
-        else:
-                pkg_cmd = "pkg.depot-config: "
+    if cmd:
+        text = "{0}: {1}".format(cmd, text)
+        pkg_cmd = "pkg.depot-config "
+    else:
+        pkg_cmd = "pkg.depot-config: "
 
-                # If we get passed something like an Exception, we can convert
-                # it down to a string.
-                text = str(text)
+        # If we get passed something like an Exception, we can convert
+        # it down to a string.
+        text = str(text)
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        logger.error(ws + pkg_cmd + text_nows)
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    logger.error(ws + pkg_cmd + text_nows)
+
 
 def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT):
-        """Emit a usage message and optionally prefix it with a more
-        specific error message.  Causes program to exit.
-        """
+    """Emit a usage message and optionally prefix it with a more
+    specific error message.  Causes program to exit.
+    """
 
-        if usage_error:
-                error(usage_error, cmd=cmd)
-        msg(_("""\
+    if usage_error:
+        error(usage_error, cmd=cmd)
+    msg(
+        _(
+            """\
 Usage:
         pkg.depot-config ( -d repository_dir | -S ) -r runtime_dir
                 [-c cache_dir] [-s cache_size] [-p port] [-h hostname]
@@ -148,854 +169,1030 @@ Usage:
                 --cert-key-dir cert_key_directory ) [ (--ca-cert ca_cert_file
                 --ca-key ca_key_file ) ]
                 [--smf-fmri smf_pkg_depot_fmri] ] )
-"""))
-        sys.exit(retcode)
+"""
+        )
+    )
+    sys.exit(retcode)
+
 
 def _chown_dir(dir):
-        """Sets ownership for the given directory to pkg5srv:pkg5srv"""
+    """Sets ownership for the given directory to pkg5srv:pkg5srv"""
 
-        uid = portable.get_user_by_name(DEPOT_USER, None, False)
-        gid = portable.get_group_by_name(DEPOT_GROUP, None, False)
-        try:
-                os.chown(dir, uid, gid)
-        except OSError as err:
-                if not os.environ.get("PKG5_TEST_ENV", None):
-                        raise DepotException(_("Unable to chown {dir} to "
-                            "{user}:{group}: {err}").format(
-                            dir=dir, user=DEPOT_USER,
-                            group=DEPOT_GROUP, err=err))
+    uid = portable.get_user_by_name(DEPOT_USER, None, False)
+    gid = portable.get_group_by_name(DEPOT_GROUP, None, False)
+    try:
+        os.chown(dir, uid, gid)
+    except OSError as err:
+        if not os.environ.get("PKG5_TEST_ENV", None):
+            raise DepotException(
+                _("Unable to chown {dir} to " "{user}:{group}: {err}").format(
+                    dir=dir, user=DEPOT_USER, group=DEPOT_GROUP, err=err
+                )
+            )
+
 
 def _get_publishers(root):
-        """Given a repository root, return the list of available publishers,
-        along with the default publisher/prefix."""
+    """Given a repository root, return the list of available publishers,
+    along with the default publisher/prefix."""
 
+    try:
+        # we don't set writable_root, as we don't want to take the hit
+        # on potentially building an index here.
+        repository = sr.Repository(root=root, read_only=True)
+
+        if repository.version != 4:
+            raise DepotException(
+                _("pkg.depot-config only supports v4 repositories")
+            )
+    except Exception as e:
+        raise DepotException(e)
+
+    all_pubs = [pub.prefix for pub in repository.get_publishers()]
+    try:
+        default_pub = repository.cfg.get_property("publisher", "prefix")
+    except cfg.UnknownPropertyError:
+        default_pub = None
+    return all_pubs, default_pub, repository.get_status()
+
+
+def _write_httpd_conf(
+    pubs,
+    default_pubs,
+    runtime_dir,
+    log_dir,
+    template_dir,
+    cache_dir,
+    cache_size,
+    host,
+    port,
+    sroot,
+    fragment=False,
+    allow_refresh=False,
+    ssl_cert_file="",
+    ssl_key_file="",
+    ssl_cert_chain_file="",
+):
+    """Writes the webserver configuration for the depot.
+
+    pubs            repository and publisher information, a list in the form
+                    [(publisher_prefix, repo_dir, repo_prefix,
+                        writable_root), ... ]
+    default_pubs    default publishers, per repository, a list in the form
+                    [(default_publisher_prefix, repo_dir, repo_prefix) ... ]
+
+    runtime_dir     where we write httpd.conf files
+    log_dir         where Apache should write its log files
+    template_dir    where we find our Mako templates
+    cache_dir       where Apache should write its cache and wsgi search idx
+    cache_size      how large our cache can grow
+    host            our hostname, needed to set ServerName properly
+    port            the port on which Apache should listen
+    sroot           the prefix into the server namespace,
+                    ignored if fragment==False
+    fragment        True if we should only write a file to drop into conf.d/
+                    (i.e. a partial server configuration)
+
+    allow_refresh   True if we allow the 'refresh' or 'refresh-indexes'
+                    admin/0 operations
+
+    The URI namespace we create on the web server looks like this:
+
+    <sroot>/<repo_prefix>/<publisher>/<file, catalog etc.>/<version>/
+    <sroot>/<repo_prefix>/<file, catalog etc.>/<version>/
+
+    'sroot' is only used when the Apache server is serving other content
+    and we want to separate pkg(7) resources from the other resources
+    provided.
+
+    'repo_prefix' exists so that we can disambiguate between multiple
+    repositories that provide the same publisher.
+
+    'ssl_cert_file' the location of the server certificate file.
+
+    'ssl_key_file' the location of the server key file.
+
+    'ssl_cert_chain_file' the location of the certificate chain file if the
+        the server certificate is not signed by the top level CA.
+    """
+
+    try:
+        # check our hostname
+        socket.getaddrinfo(host, None)
+
+        # Apache needs IPv6 addresses wrapped in square brackets
+        if ":" in host:
+            host = "[{0}]".format(host)
+
+        # check our directories
+        dirs = [runtime_dir]
+        if not fragment:
+            dirs.append(log_dir)
+        if cache_dir:
+            dirs.append(cache_dir)
+        for dir in dirs + [template_dir]:
+            if os.path.exists(dir) and not os.path.isdir(dir):
+                raise DepotException(_("{0} is not a directory").format(dir))
+
+        for dir in dirs:
+            misc.makedirs(dir)
+
+        # check our port
+        if not fragment:
+            try:
+                num = int(port)
+                if num <= 0 or num >= 65535:
+                    raise DepotException(_("invalid port: {0}").format(port))
+            except ValueError:
+                raise DepotException(_("invalid port: {0}").format(port))
+
+        # check our cache size
         try:
-                # we don't set writable_root, as we don't want to take the hit
-                # on potentially building an index here.
-                repository = sr.Repository(root=root, read_only=True)
-
-                if repository.version != 4:
-                        raise DepotException(
-                            _("pkg.depot-config only supports v4 repositories"))
-        except Exception as e:
-                raise DepotException(e)
-
-        all_pubs = [pub.prefix for pub in repository.get_publishers()]
-        try:
-                default_pub = repository.cfg.get_property("publisher", "prefix")
-        except cfg.UnknownPropertyError:
-                default_pub = None
-        return all_pubs, default_pub, repository.get_status()
-
-def _write_httpd_conf(pubs, default_pubs, runtime_dir, log_dir, template_dir,
-        cache_dir, cache_size, host, port, sroot,
-        fragment=False, allow_refresh=False, ssl_cert_file="",
-        ssl_key_file="", ssl_cert_chain_file=""):
-        """Writes the webserver configuration for the depot.
-
-        pubs            repository and publisher information, a list in the form
-                        [(publisher_prefix, repo_dir, repo_prefix,
-                            writable_root), ... ]
-        default_pubs    default publishers, per repository, a list in the form
-                        [(default_publisher_prefix, repo_dir, repo_prefix) ... ]
-
-        runtime_dir     where we write httpd.conf files
-        log_dir         where Apache should write its log files
-        template_dir    where we find our Mako templates
-        cache_dir       where Apache should write its cache and wsgi search idx
-        cache_size      how large our cache can grow
-        host            our hostname, needed to set ServerName properly
-        port            the port on which Apache should listen
-        sroot           the prefix into the server namespace,
-                        ignored if fragment==False
-        fragment        True if we should only write a file to drop into conf.d/
-                        (i.e. a partial server configuration)
-
-        allow_refresh   True if we allow the 'refresh' or 'refresh-indexes'
-                        admin/0 operations
-
-        The URI namespace we create on the web server looks like this:
-
-        <sroot>/<repo_prefix>/<publisher>/<file, catalog etc.>/<version>/
-        <sroot>/<repo_prefix>/<file, catalog etc.>/<version>/
-
-        'sroot' is only used when the Apache server is serving other content
-        and we want to separate pkg(7) resources from the other resources
-        provided.
-
-        'repo_prefix' exists so that we can disambiguate between multiple
-        repositories that provide the same publisher.
-
-        'ssl_cert_file' the location of the server certificate file.
-
-        'ssl_key_file' the location of the server key file.
-
-        'ssl_cert_chain_file' the location of the certificate chain file if the
-            the server certificate is not signed by the top level CA.
-        """
-
-        try:
-                # check our hostname
-                socket.getaddrinfo(host, None)
-
-                # Apache needs IPv6 addresses wrapped in square brackets
-                if ":" in host:
-                        host = "[{0}]".format(host)
-
-                # check our directories
-                dirs = [runtime_dir]
-                if not fragment:
-                        dirs.append(log_dir)
-                if cache_dir:
-                        dirs.append(cache_dir)
-                for dir in dirs + [template_dir]:
-                        if os.path.exists(dir) and not os.path.isdir(dir):
-                                raise DepotException(
-                                    _("{0} is not a directory").format(dir))
-
-                for dir in dirs:
-                        misc.makedirs(dir)
-
-                # check our port
-                if not fragment:
-                        try:
-                                num = int(port)
-                                if num <= 0 or num >= 65535:
-                                        raise DepotException(
-                                            _("invalid port: {0}").format(port))
-                        except ValueError:
-                                raise DepotException(
-                                    _("invalid port: {0}").format(port))
-
-                # check our cache size
-                try:
-                        num = int(cache_size)
-                        if num < 0:
-                                raise DepotException(_("invalid cache size: "
-                                   "{0}").format(num))
-                except ValueError:
-                        raise DepotException(
-                            _("invalid cache size: {0}").format(cache_size))
-
-                httpd_conf_template_path = os.path.join(template_dir,
-                    DEPOT_HTTP_TEMPLATE)
-                fragment_conf_template_path = os.path.join(template_dir,
-                    DEPOT_FRAGMENT_TEMPLATE)
-
-                conf_lookup = TemplateLookup(directories=[template_dir])
-                if fragment:
-                        conf_template = Template(
-                            filename=fragment_conf_template_path,
-                            lookup=conf_lookup)
-                        conf_path = os.path.join(runtime_dir,
-                            DEPOT_FRAGMENT_FILENAME)
-                else:
-                        conf_template = Template(
-                            filename=httpd_conf_template_path,
-                            lookup=conf_lookup)
-                        conf_path = os.path.join(runtime_dir,
-                            DEPOT_HTTP_FILENAME)
-
-                conf_text = conf_template.render(
-                    pubs=pubs,
-                    default_pubs=default_pubs,
-                    log_dir=log_dir,
-                    cache_dir=cache_dir,
-                    cache_size=cache_size,
-                    runtime_dir=runtime_dir,
-                    template_dir=template_dir,
-                    ipv6_addr="::1",
-                    host=host,
-                    port=port,
-                    sroot=sroot,
-                    allow_refresh=allow_refresh,
-                    ssl_cert_file=ssl_cert_file,
-                    ssl_key_file=ssl_key_file,
-                    ssl_cert_chain_file=ssl_cert_chain_file
+            num = int(cache_size)
+            if num < 0:
+                raise DepotException(
+                    _("invalid cache size: " "{0}").format(num)
                 )
+        except ValueError:
+            raise DepotException(
+                _("invalid cache size: {0}").format(cache_size)
+            )
 
-                with open(conf_path, "w") as conf_file:
-                        conf_file.write(conf_text)
+        httpd_conf_template_path = os.path.join(
+            template_dir, DEPOT_HTTP_TEMPLATE
+        )
+        fragment_conf_template_path = os.path.join(
+            template_dir, DEPOT_FRAGMENT_TEMPLATE
+        )
 
-        except (socket.gaierror, UnicodeError) as err:
-                # socket.getaddrinfo raise UnicodeDecodeError in Python 3
-                # for some input, such as '.'
-                raise DepotException(
-                    _("Unable to write Apache configuration: {host}: "
-                    "{err}").format(**locals()))
-        except (OSError, IOError, EnvironmentError, apx.ApiException) as err:
-                traceback.print_exc()
-                raise DepotException(
-                    _("Unable to write depot_httpd.conf: {0}").format(err))
+        conf_lookup = TemplateLookup(directories=[template_dir])
+        if fragment:
+            conf_template = Template(
+                filename=fragment_conf_template_path, lookup=conf_lookup
+            )
+            conf_path = os.path.join(runtime_dir, DEPOT_FRAGMENT_FILENAME)
+        else:
+            conf_template = Template(
+                filename=httpd_conf_template_path, lookup=conf_lookup
+            )
+            conf_path = os.path.join(runtime_dir, DEPOT_HTTP_FILENAME)
+
+        conf_text = conf_template.render(
+            pubs=pubs,
+            default_pubs=default_pubs,
+            log_dir=log_dir,
+            cache_dir=cache_dir,
+            cache_size=cache_size,
+            runtime_dir=runtime_dir,
+            template_dir=template_dir,
+            ipv6_addr="::1",
+            host=host,
+            port=port,
+            sroot=sroot,
+            allow_refresh=allow_refresh,
+            ssl_cert_file=ssl_cert_file,
+            ssl_key_file=ssl_key_file,
+            ssl_cert_chain_file=ssl_cert_chain_file,
+        )
+
+        with open(conf_path, "w") as conf_file:
+            conf_file.write(conf_text)
+
+    except (socket.gaierror, UnicodeError) as err:
+        # socket.getaddrinfo raise UnicodeDecodeError in Python 3
+        # for some input, such as '.'
+        raise DepotException(
+            _("Unable to write Apache configuration: {host}: " "{err}").format(
+                **locals()
+            )
+        )
+    except (OSError, IOError, EnvironmentError, apx.ApiException) as err:
+        traceback.print_exc()
+        raise DepotException(
+            _("Unable to write depot_httpd.conf: {0}").format(err)
+        )
+
 
 def _write_versions_response(htdocs_path, fragment=False):
-        """Writes a static versions/0 response for the Apache depot."""
+    """Writes a static versions/0 response for the Apache depot."""
 
-        try:
-                versions_path = os.path.join(htdocs_path,
-                    *DEPOT_VERSIONS_DIRNAME)
-                misc.makedirs(versions_path)
+    try:
+        versions_path = os.path.join(htdocs_path, *DEPOT_VERSIONS_DIRNAME)
+        misc.makedirs(versions_path)
 
-                with open(os.path.join(versions_path, "index.html"), "w") as \
-                    versions_file:
-                        versions_file.write(
-                            fragment and DEPOT_FRAGMENT_VERSIONS_STR or
-                            DEPOT_VERSIONS_STR)
+        with open(
+            os.path.join(versions_path, "index.html"), "w"
+        ) as versions_file:
+            versions_file.write(
+                fragment and DEPOT_FRAGMENT_VERSIONS_STR or DEPOT_VERSIONS_STR
+            )
 
-                versions_file.close()
-        except (OSError, apx.ApiException) as err:
-                raise DepotException(
-                    _("Unable to write versions response: {0}").format(err))
+        versions_file.close()
+    except (OSError, apx.ApiException) as err:
+        raise DepotException(
+            _("Unable to write versions response: {0}").format(err)
+        )
+
 
 def _write_publisher_response(pubs, htdocs_path, repo_prefix):
-        """Writes a static publisher/0 response for the depot."""
-        try:
-                # convert our list of strings to a list of Publishers
-                pub_objs = [pkg.client.publisher.Publisher(pub) for pub in pubs]
+    """Writes a static publisher/0 response for the depot."""
+    try:
+        # convert our list of strings to a list of Publishers
+        pub_objs = [pkg.client.publisher.Publisher(pub) for pub in pubs]
 
-                # write individual reponses for the publishers
-                for pub in pub_objs:
-                        pub_path = os.path.join(htdocs_path,
-                            os.path.sep.join(
-                               [repo_prefix, pub.prefix] + DEPOT_PUB_DIRNAME))
-                        misc.makedirs(pub_path)
-                        with open(os.path.join(pub_path, "index.html"), "w") as\
-                            pub_file:
-                                p5i.write(pub_file, [pub])
+        # write individual reponses for the publishers
+        for pub in pub_objs:
+            pub_path = os.path.join(
+                htdocs_path,
+                os.path.sep.join([repo_prefix, pub.prefix] + DEPOT_PUB_DIRNAME),
+            )
+            misc.makedirs(pub_path)
+            with open(os.path.join(pub_path, "index.html"), "w") as pub_file:
+                p5i.write(pub_file, [pub])
 
-                # write a response that contains all publishers
-                pub_path = os.path.join(htdocs_path,
-                    os.path.sep.join([repo_prefix] + DEPOT_PUB_DIRNAME))
-                os.makedirs(pub_path)
-                with open(os.path.join(pub_path, "index.html"), "w") as \
-                    pub_file:
-                        p5i.write(pub_file, pub_objs)
+        # write a response that contains all publishers
+        pub_path = os.path.join(
+            htdocs_path, os.path.sep.join([repo_prefix] + DEPOT_PUB_DIRNAME)
+        )
+        os.makedirs(pub_path)
+        with open(os.path.join(pub_path, "index.html"), "w") as pub_file:
+            p5i.write(pub_file, pub_objs)
 
-        except (OSError, apx.ApiException) as err:
-                raise DepotException(
-                    _("Unable to write publisher response: {0}").format(err))
+    except (OSError, apx.ApiException) as err:
+        raise DepotException(
+            _("Unable to write publisher response: {0}").format(err)
+        )
+
 
 def _write_status_response(status, htdocs_path, repo_prefix):
-        """Writes a status status/0 response for the depot."""
-        try:
-                status_path = os.path.join(htdocs_path, repo_prefix,
-                    os.path.sep.join(DEPOT_STATUS_DIRNAME), "index.html")
-                misc.makedirs(os.path.dirname(status_path))
-                with open(status_path, "w") as status_file:
-                        status_file.write(json.dumps(status, ensure_ascii=False,
-                            indent=2, sort_keys=True))
-        except OSError as err:
+    """Writes a status status/0 response for the depot."""
+    try:
+        status_path = os.path.join(
+            htdocs_path,
+            repo_prefix,
+            os.path.sep.join(DEPOT_STATUS_DIRNAME),
+            "index.html",
+        )
+        misc.makedirs(os.path.dirname(status_path))
+        with open(status_path, "w") as status_file:
+            status_file.write(
+                json.dumps(status, ensure_ascii=False, indent=2, sort_keys=True)
+            )
+    except OSError as err:
+        raise DepotException(
+            _("Unable to write status response: {0}").format(err)
+        )
+
+
+def _createCertificateKey(
+    serial,
+    CN,
+    starttime,
+    endtime,
+    dump_cert_path,
+    dump_key_path,
+    issuerCert=None,
+    issuerKey=None,
+    key_type=TYPE_RSA,
+    key_bits=1024,
+    digest="sha256",
+):
+    """Generate a certificate given a certificate request.
+
+    'serial' is the serial number for the certificate
+
+    'CN' is the subject common name of the certificate.
+
+    'starttime' is the timestamp when the certificate starts
+                      being valid. 0 means now.
+
+    'endtime' is the timestamp when the certificate stops being
+                    valid
+
+    'dump_cert_path' is the file the generated certificate gets dumped.
+
+    'dump_key_path' is the file the generated key gets dumped.
+
+    'issuerCert' is the certificate object of the issuer.
+
+    'issuerKey' is the key object of the issuer.
+
+    'key_type' is the key type. allowed value: TYPE_RSA and TYPE_DSA.
+
+    'key_bits' is number of bits to use in the key.
+
+    'digest' is the digestion method to use for signing.
+    """
+
+    key = PKey()
+    key.generate_key(key_type, key_bits)
+
+    cert = X509()
+    cert.set_serial_number(serial)
+    cert.gmtime_adj_notBefore(starttime)
+    cert.gmtime_adj_notAfter(endtime)
+
+    cert.get_subject().C = "US"
+    cert.get_subject().ST = "California"
+    cert.get_subject().L = "Santa Clara"
+    cert.get_subject().O = "pkg5"
+
+    cert.set_pubkey(key)
+    # If a issuer is specified, set the issuer. otherwise set cert
+    # itself as a issuer.
+    if issuerCert:
+        cert.get_subject().CN = CN
+        cert.set_issuer(issuerCert.get_subject())
+    else:
+        cert.get_subject().CN = "Depot Test CA"
+        cert.set_issuer(cert.get_subject())
+
+    # If there is a issuer key, sign with that key. Otherwise,
+    # create a self-signed cert.
+    # Cert requires bytes.
+    if issuerKey:
+        cert.add_extensions(
+            [X509Extension(b"basicConstraints", True, b"CA:FALSE")]
+        )
+        cert.sign(issuerKey, digest)
+    else:
+        cert.add_extensions(
+            [X509Extension(b"basicConstraints", True, b"CA:TRUE")]
+        )
+        cert.sign(key, digest)
+    with open(dump_cert_path, "wb") as f:
+        f.write(dump_certificate(FILETYPE_PEM, cert))
+    with open(dump_key_path, "wb") as f:
+        f.write(dump_privatekey(FILETYPE_PEM, key))
+    return (cert, key)
+
+
+def _generate_server_cert_key(
+    host, port, ca_cert_file="", ca_key_file="", output_dir="/tmp"
+):
+    """Generate certificate and key files for https service."""
+    if os.path.exists(output_dir):
+        if not os.path.isdir(output_dir):
+            raise DepotException(_("{0} is not a directory").format(output_dir))
+    else:
+        misc.makedirs(output_dir)
+    server_id = "{0}_{1}".format(host, port)
+
+    cs_prefix = "server_{0}".format(server_id)
+    server_cert_file = os.path.join(
+        output_dir, "{0}_cert.pem".format(cs_prefix)
+    )
+    server_key_file = os.path.join(output_dir, "{0}_key.pem".format(cs_prefix))
+
+    # If the cert and key files do not exist, then generate one.
+    if not os.path.exists(server_cert_file) or not os.path.exists(
+        server_key_file
+    ):
+        # Used as a factor to easily specify a year.
+        year_factor = 60 * 60 * 24 * 365
+
+        # If user specifies ca_cert_file and ca_key_file, just load
+        # the files. Otherwise, generate new ca_cert and ca_key.
+        if not ca_cert_file or not ca_key_file:
+            ca_cert_file = os.path.join(
+                output_dir, "ca_{0}_cert.pem".format(server_id)
+            )
+            ca_key_file = os.path.join(
+                output_dir, "ca_{0}_key.pem".format(server_id)
+            )
+            ca_cert, ca_key = _createCertificateKey(
+                1, host, 0, year_factor * 10, ca_cert_file, ca_key_file
+            )
+        else:
+            if not os.path.exists(ca_cert_file):
                 raise DepotException(
-                    _("Unable to write status response: {0}").format(err))
+                    _(
+                        "Cannot find user " "provided CA certificate file: {0}"
+                    ).format(ca_cert_file)
+                )
+            if not os.path.exists(ca_key_file):
+                raise DepotException(
+                    _("Cannot find user " "provided CA key file: {0}").format(
+                        ca_key_file
+                    )
+                )
+            with open(ca_cert_file, "r") as fr:
+                ca_cert = load_certificate(FILETYPE_PEM, fr.read())
+            with open(ca_key_file, "r") as fr:
+                ca_key = load_privatekey(FILETYPE_PEM, fr.read())
 
-def _createCertificateKey(serial, CN, starttime, endtime,
-    dump_cert_path, dump_key_path, issuerCert=None, issuerKey=None,
-    key_type=TYPE_RSA, key_bits=1024, digest="sha256"):
-        """Generate a certificate given a certificate request.
+        _createCertificateKey(
+            2,
+            host,
+            0,
+            year_factor * 10,
+            server_cert_file,
+            server_key_file,
+            issuerCert=ca_cert,
+            issuerKey=ca_key,
+        )
 
-        'serial' is the serial number for the certificate
+    return (ca_cert_file, ca_key_file, server_cert_file, server_key_file)
 
-        'CN' is the subject common name of the certificate.
-
-        'starttime' is the timestamp when the certificate starts
-                          being valid. 0 means now.
-
-        'endtime' is the timestamp when the certificate stops being
-                        valid
-
-        'dump_cert_path' is the file the generated certificate gets dumped.
-
-        'dump_key_path' is the file the generated key gets dumped.
-
-        'issuerCert' is the certificate object of the issuer.
-
-        'issuerKey' is the key object of the issuer.
-
-        'key_type' is the key type. allowed value: TYPE_RSA and TYPE_DSA.
-
-        'key_bits' is number of bits to use in the key.
-
-        'digest' is the digestion method to use for signing.
-        """
-
-        key = PKey()
-        key.generate_key(key_type, key_bits)
-
-        cert = X509()
-        cert.set_serial_number(serial)
-        cert.gmtime_adj_notBefore(starttime)
-        cert.gmtime_adj_notAfter(endtime)
-
-        cert.get_subject().C = "US"
-        cert.get_subject().ST = "California"
-        cert.get_subject().L = "Santa Clara"
-        cert.get_subject().O = "pkg5"
-
-        cert.set_pubkey(key)
-        # If a issuer is specified, set the issuer. otherwise set cert
-        # itself as a issuer.
-        if issuerCert:
-                cert.get_subject().CN = CN
-                cert.set_issuer(issuerCert.get_subject())
-        else:
-                cert.get_subject().CN = "Depot Test CA"
-                cert.set_issuer(cert.get_subject())
-
-        # If there is a issuer key, sign with that key. Otherwise,
-        # create a self-signed cert.
-        # Cert requires bytes.
-        if issuerKey:
-                cert.add_extensions([X509Extension(b"basicConstraints", True,
-                    b"CA:FALSE")])
-                cert.sign(issuerKey, digest)
-        else:
-                cert.add_extensions([X509Extension(b"basicConstraints", True,
-                    b"CA:TRUE")])
-                cert.sign(key, digest)
-        with open(dump_cert_path, "wb") as f:
-                f.write(dump_certificate(FILETYPE_PEM, cert))
-        with open(dump_key_path, "wb") as f:
-                f.write(dump_privatekey(FILETYPE_PEM, key))
-        return (cert, key)
-
-def _generate_server_cert_key(host, port, ca_cert_file="", ca_key_file="",
-    output_dir="/tmp"):
-        """ Generate certificate and key files for https service."""
-        if os.path.exists(output_dir):
-                if not os.path.isdir(output_dir):
-                        raise DepotException(
-                            _("{0} is not a directory").format(output_dir))
-        else:
-                misc.makedirs(output_dir)
-        server_id = "{0}_{1}".format(host, port)
-
-        cs_prefix = "server_{0}".format(server_id)
-        server_cert_file = os.path.join(output_dir, "{0}_cert.pem".format(
-            cs_prefix))
-        server_key_file = os.path.join(output_dir, "{0}_key.pem".format(
-            cs_prefix))
-
-        # If the cert and key files do not exist, then generate one.
-        if not os.path.exists(server_cert_file) or not os.path.exists(
-            server_key_file):
-                # Used as a factor to easily specify a year.
-                year_factor = 60 * 60 * 24 * 365
-
-                # If user specifies ca_cert_file and ca_key_file, just load
-                # the files. Otherwise, generate new ca_cert and ca_key.
-                if not ca_cert_file or not ca_key_file:
-                        ca_cert_file = os.path.join(output_dir,
-                            "ca_{0}_cert.pem".format(server_id))
-                        ca_key_file = os.path.join(output_dir,
-                            "ca_{0}_key.pem".format(server_id))
-                        ca_cert, ca_key = _createCertificateKey(1, host,
-                            0, year_factor * 10, ca_cert_file, ca_key_file)
-                else:
-                        if not os.path.exists(ca_cert_file):
-                                raise DepotException(_("Cannot find user "
-                                    "provided CA certificate file: {0}").format(
-                                    ca_cert_file))
-                        if not os.path.exists(ca_key_file):
-                                raise DepotException(_("Cannot find user "
-                                    "provided CA key file: {0}").format(
-                                    ca_key_file))
-                        with open(ca_cert_file, "r") as fr:
-                                ca_cert = load_certificate(FILETYPE_PEM,
-                                    fr.read())
-                        with open(ca_key_file, "r") as fr:
-                                ca_key = load_privatekey(FILETYPE_PEM,
-                                    fr.read())
-
-                _createCertificateKey(2, host, 0, year_factor * 10,
-                    server_cert_file, server_key_file, issuerCert=ca_cert,
-                    issuerKey=ca_key)
-
-        return (ca_cert_file, ca_key_file, server_cert_file, server_key_file)
 
 def cleanup_htdocs(htdocs_dir):
-        """Destroy any existing "htdocs" directory."""
-        try:
-                shutil.rmtree(htdocs_dir, ignore_errors=True)
-        except OSError as err:
-                raise DepotException(
-                    _("Unable to remove an existing 'htdocs' directory "
-                    "in the runtime directory: {0}").format(err))
+    """Destroy any existing "htdocs" directory."""
+    try:
+        shutil.rmtree(htdocs_dir, ignore_errors=True)
+    except OSError as err:
+        raise DepotException(
+            _(
+                "Unable to remove an existing 'htdocs' directory "
+                "in the runtime directory: {0}"
+            ).format(err)
+        )
 
-def refresh_conf(repo_info, log_dir, host, port, runtime_dir,
-            template_dir, cache_dir, cache_size, sroot, fragment=False,
-            allow_refresh=False, ssl_cert_file="", ssl_key_file="",
-            ssl_cert_chain_file=""):
-        """Creates a new configuration for the depot."""
-        try:
-                ret = EXIT_OK
-                if not repo_info:
-                        raise DepotException(_("no repositories found"))
 
-                htdocs_path = os.path.join(runtime_dir, DEPOT_HTDOCS_DIRNAME,
-                    sroot)
-                cleanup_htdocs(htdocs_path)
-                misc.makedirs(htdocs_path)
+def refresh_conf(
+    repo_info,
+    log_dir,
+    host,
+    port,
+    runtime_dir,
+    template_dir,
+    cache_dir,
+    cache_size,
+    sroot,
+    fragment=False,
+    allow_refresh=False,
+    ssl_cert_file="",
+    ssl_key_file="",
+    ssl_cert_chain_file="",
+):
+    """Creates a new configuration for the depot."""
+    try:
+        ret = EXIT_OK
+        if not repo_info:
+            raise DepotException(_("no repositories found"))
 
-                # pubs and default_pubs are lists of tuples of the form:
-                # (publisher prefix, repository root dir, repository prefix,
-                #     writable_root)
-                pubs = []
-                default_pubs = []
-                errors = []
+        htdocs_path = os.path.join(runtime_dir, DEPOT_HTDOCS_DIRNAME, sroot)
+        cleanup_htdocs(htdocs_path)
+        misc.makedirs(htdocs_path)
 
-                # Query each repository for its publisher information.
-                for (repo_root, repo_prefix, writable_root) in repo_info:
-                        try:
-                                publishers, default_pub, status = \
-                                    _get_publishers(repo_root)
-                                for pub in publishers:
-                                        pubs.append(
-                                            (pub, repo_root,
-                                            repo_prefix, writable_root))
-                                default_pubs.append((default_pub,
-                                    repo_root, repo_prefix))
-                                _write_status_response(status, htdocs_path,
-                                    repo_prefix)
-                                # The writable root must exist and must be
-                                # owned by pkg5srv:pkg5srv
-                                if writable_root:
-                                        misc.makedirs(writable_root)
-                                        _chown_dir(writable_root)
+        # pubs and default_pubs are lists of tuples of the form:
+        # (publisher prefix, repository root dir, repository prefix,
+        #     writable_root)
+        pubs = []
+        default_pubs = []
+        errors = []
 
-                        except DepotException as err:
-                                errors.append(str(err))
-                if errors:
-                        raise DepotException(_("Unable to write configuration: "
-                            "{0}").format("\n".join(errors)))
+        # Query each repository for its publisher information.
+        for repo_root, repo_prefix, writable_root in repo_info:
+            try:
+                publishers, default_pub, status = _get_publishers(repo_root)
+                for pub in publishers:
+                    pubs.append((pub, repo_root, repo_prefix, writable_root))
+                default_pubs.append((default_pub, repo_root, repo_prefix))
+                _write_status_response(status, htdocs_path, repo_prefix)
+                # The writable root must exist and must be
+                # owned by pkg5srv:pkg5srv
+                if writable_root:
+                    misc.makedirs(writable_root)
+                    _chown_dir(writable_root)
 
-                # Write the publisher/0 response for each repository
-                pubs_by_repo = {}
-                for pub_prefix, repo_root, repo_prefix, writable_root in pubs:
-                        pubs_by_repo.setdefault(repo_prefix, []).append(
-                            pub_prefix)
-                for repo_prefix in pubs_by_repo:
-                        _write_publisher_response(
-                            pubs_by_repo[repo_prefix], htdocs_path, repo_prefix)
+            except DepotException as err:
+                errors.append(str(err))
+        if errors:
+            raise DepotException(
+                _("Unable to write configuration: " "{0}").format(
+                    "\n".join(errors)
+                )
+            )
 
-                _write_httpd_conf(pubs, default_pubs, runtime_dir, log_dir,
-                    template_dir, cache_dir, cache_size, host, port, sroot,
-                    fragment=fragment, allow_refresh=allow_refresh,
-                    ssl_cert_file=ssl_cert_file, ssl_key_file=ssl_key_file,
-                    ssl_cert_chain_file=ssl_cert_chain_file)
-                _write_versions_response(htdocs_path, fragment=fragment)
-                # If we're writing a configuration fragment, then the web server
-                # is probably not running as DEPOT_USER:DEPOT_GROUP
-                if not fragment:
-                        _chown_dir(runtime_dir)
-                        _chown_dir(cache_dir)
-                else:
-                        msg(_("Created {0}/depot.conf").format(runtime_dir))
-        except (DepotException, OSError, apx.ApiException) as err:
-                error(err)
-                ret = EXIT_OOPS
-        return ret
+        # Write the publisher/0 response for each repository
+        pubs_by_repo = {}
+        for pub_prefix, repo_root, repo_prefix, writable_root in pubs:
+            pubs_by_repo.setdefault(repo_prefix, []).append(pub_prefix)
+        for repo_prefix in pubs_by_repo:
+            _write_publisher_response(
+                pubs_by_repo[repo_prefix], htdocs_path, repo_prefix
+            )
+
+        _write_httpd_conf(
+            pubs,
+            default_pubs,
+            runtime_dir,
+            log_dir,
+            template_dir,
+            cache_dir,
+            cache_size,
+            host,
+            port,
+            sroot,
+            fragment=fragment,
+            allow_refresh=allow_refresh,
+            ssl_cert_file=ssl_cert_file,
+            ssl_key_file=ssl_key_file,
+            ssl_cert_chain_file=ssl_cert_chain_file,
+        )
+        _write_versions_response(htdocs_path, fragment=fragment)
+        # If we're writing a configuration fragment, then the web server
+        # is probably not running as DEPOT_USER:DEPOT_GROUP
+        if not fragment:
+            _chown_dir(runtime_dir)
+            _chown_dir(cache_dir)
+        else:
+            msg(_("Created {0}/depot.conf").format(runtime_dir))
+    except (DepotException, OSError, apx.ApiException) as err:
+        error(err)
+        ret = EXIT_OOPS
+    return ret
+
 
 def get_smf_repo_info():
-        """Return a list of repo_info from the online instances of pkg/server
-        which are marked as pkg/standalone = False and pkg/readonly = True."""
+    """Return a list of repo_info from the online instances of pkg/server
+    which are marked as pkg/standalone = False and pkg/readonly = True."""
 
-        smf_instances = smf.check_fmris(None, "{0}:*".format(PKG_SERVER_SVC))
-        repo_info = []
-        for fmri in smf_instances:
-                repo_prefix = fmri.split(":")[-1]
-                repo_root = smf.get_prop(fmri, "pkg/inst_root")
-                writable_root = smf.get_prop(fmri, "pkg/writable_root")
-                if not writable_root or writable_root == '""':
-                        writable_root = None
-                state = smf.get_prop(fmri, "restarter/state")
-                readonly = smf.get_prop(fmri, "pkg/readonly")
-                standalone = smf.get_prop(fmri, "pkg/standalone")
+    smf_instances = smf.check_fmris(None, "{0}:*".format(PKG_SERVER_SVC))
+    repo_info = []
+    for fmri in smf_instances:
+        repo_prefix = fmri.split(":")[-1]
+        repo_root = smf.get_prop(fmri, "pkg/inst_root")
+        writable_root = smf.get_prop(fmri, "pkg/writable_root")
+        if not writable_root or writable_root == '""':
+            writable_root = None
+        state = smf.get_prop(fmri, "restarter/state")
+        readonly = smf.get_prop(fmri, "pkg/readonly")
+        standalone = smf.get_prop(fmri, "pkg/standalone")
 
-                if (state == "online" and
-                    readonly == "true" and
-                    standalone == "false"):
-                        repo_info.append((repo_root,
-                            _affix_slash(repo_prefix), writable_root))
-        if not repo_info:
-                raise DepotException(_(
-                    "No online, readonly, non-standalone instances of "
-                    "{0} found.").format(PKG_SERVER_SVC))
-        return repo_info
+        if state == "online" and readonly == "true" and standalone == "false":
+            repo_info.append(
+                (repo_root, _affix_slash(repo_prefix), writable_root)
+            )
+    if not repo_info:
+        raise DepotException(
+            _(
+                "No online, readonly, non-standalone instances of " "{0} found."
+            ).format(PKG_SERVER_SVC)
+        )
+    return repo_info
+
 
 def _check_unique_repo_properties(repo_info):
-        """Determine whether the repository root, and supplied prefixes are
-        unique.  The prefixes allow two or more repositories that both contain
-        the same publisher to be differentiated in the Apache configuration, so
-        that requests are routed to the correct repository."""
+    """Determine whether the repository root, and supplied prefixes are
+    unique.  The prefixes allow two or more repositories that both contain
+    the same publisher to be differentiated in the Apache configuration, so
+    that requests are routed to the correct repository."""
 
-        prefixes = set()
-        roots = set()
-        writable_roots = set()
-        errors = []
-        for root, prefix, writable_root in repo_info:
-                if prefix in prefixes:
-                        errors.append(_("prefix {0} cannot be used more than "
-                            "once in a given depot configuration").format(
-                            prefix))
-                prefixes.add(prefix)
-                if root in roots:
-                        errors.append(_("repo_root {0} cannot be used more "
-                            "than once in a given depot configuration").format(
-                            root))
-                roots.add(root)
-                if writable_root and writable_root in writable_roots:
-                        errors.append(_("writable_root {0} cannot be used more "
-                            "than once in a given depot configuration").format(
-                            writable_root))
-                writable_roots.add(writable_root)
-        if errors:
-                raise DepotException("\n".join(errors))
-        return True
+    prefixes = set()
+    roots = set()
+    writable_roots = set()
+    errors = []
+    for root, prefix, writable_root in repo_info:
+        if prefix in prefixes:
+            errors.append(
+                _(
+                    "prefix {0} cannot be used more than "
+                    "once in a given depot configuration"
+                ).format(prefix)
+            )
+        prefixes.add(prefix)
+        if root in roots:
+            errors.append(
+                _(
+                    "repo_root {0} cannot be used more "
+                    "than once in a given depot configuration"
+                ).format(root)
+            )
+        roots.add(root)
+        if writable_root and writable_root in writable_roots:
+            errors.append(
+                _(
+                    "writable_root {0} cannot be used more "
+                    "than once in a given depot configuration"
+                ).format(writable_root)
+            )
+        writable_roots.add(writable_root)
+    if errors:
+        raise DepotException("\n".join(errors))
+    return True
+
 
 def _affix_slash(str):
-        val = str.lstrip("/").rstrip("/")
-        if "/" in str:
-                raise DepotException(_("cannot use '/' chars in prefixes"))
-        # An RE that matches valid SMF instance names works for prefixes
-        if not re.match(r"^([A-Za-z][_A-Za-z0-9.-]*,)?[A-Za-z][_A-Za-z0-9-]*$",
-            str):
-                raise DepotException(_("%s is not a valid prefix"))
-        return "{0}/".format(val)
+    val = str.lstrip("/").rstrip("/")
+    if "/" in str:
+        raise DepotException(_("cannot use '/' chars in prefixes"))
+    # An RE that matches valid SMF instance names works for prefixes
+    if not re.match(
+        r"^([A-Za-z][_A-Za-z0-9.-]*,)?[A-Za-z][_A-Za-z0-9-]*$", str
+    ):
+        raise DepotException(_("%s is not a valid prefix"))
+    return "{0}/".format(val)
+
 
 def _update_smf_props(smf_fmri, prop_list, orig, dest):
-        """Update the smf props after the new prop values are generated."""
+    """Update the smf props after the new prop values are generated."""
 
-        smf_instances = smf.check_fmris(None, smf_fmri)
-        for fmri in smf_instances:
-                refresh = False
-                for i in range(len(prop_list)):
-                        if orig[i] != dest[i]:
-                                smf.set_prop(fmri, prop_list[i], dest[i])
-                                refresh = True
-                if refresh:
-                        smf.refresh(fmri)
+    smf_instances = smf.check_fmris(None, smf_fmri)
+    for fmri in smf_instances:
+        refresh = False
+        for i in range(len(prop_list)):
+            if orig[i] != dest[i]:
+                smf.set_prop(fmri, prop_list[i], dest[i])
+                refresh = True
+        if refresh:
+            smf.refresh(fmri)
+
 
 def main_func():
+    # some sensible defaults
+    host = "0.0.0.0"
+    # the port we listen on
+    port = None
+    # a list of (repo_dir, repo_prefix) tuples
+    repo_info = []
+    # the path where we store disk caches
+    cache_dir = None
+    # our maximum cache size, in megabytes
+    cache_size = 0
+    # whether we're writing a full httpd.conf, or just a fragment
+    fragment = False
+    # Whether we support https service.
+    https = False
+    # The location of server certificate file.
+    ssl_cert_file = ""
+    # The location of server key file.
+    ssl_key_file = ""
+    # The location of the server ca certificate file.
+    ssl_ca_cert_file = ""
+    # The location of the server ca key file.
+    ssl_ca_key_file = ""
+    # Directory for storing generated certificates and keys
+    cert_key_dir = ""
+    # SSL certificate chain file path if the server certificate is not
+    # signed by the top level CA.
+    ssl_cert_chain_file = ""
+    # The pkg/depot smf instance fmri.
+    smf_fmri = ""
+    # an optional url-prefix, used to separate pkg5 services from the rest
+    # of the webserver url namespace, only used when running in fragment
+    # mode, otherwise we assume we're the only service running on this
+    # web server instance, and control the entire server URL namespace.
+    sroot = ""
+    # the path where our Mako templates and wsgi scripts are stored
+    template_dir = "/etc/pkg/depot"
+    # a volatile directory used at runtime for storing state
+    runtime_dir = None
+    # where logs are written
+    log_dir = "/var/log/pkg/depot"
+    # whether we should pull configuration from
+    # svc:/application/pkg/server instances
+    use_smf_instances = False
+    # whether we allow admin/0 operations to rebuild the index
+    allow_refresh = False
+    # the current server_type
+    server_type = "apache2"
 
-        # some sensible defaults
-        host = "0.0.0.0"
-        # the port we listen on
-        port = None
-        # a list of (repo_dir, repo_prefix) tuples
-        repo_info = []
-        # the path where we store disk caches
-        cache_dir = None
-        # our maximum cache size, in megabytes
-        cache_size = 0
-        # whether we're writing a full httpd.conf, or just a fragment
-        fragment = False
-        # Whether we support https service.
-        https = False
-        # The location of server certificate file.
-        ssl_cert_file = ""
-        # The location of server key file.
-        ssl_key_file = ""
-        # The location of the server ca certificate file.
-        ssl_ca_cert_file = ""
-        # The location of the server ca key file.
-        ssl_ca_key_file = ""
-        # Directory for storing generated certificates and keys
-        cert_key_dir = ""
-        # SSL certificate chain file path if the server certificate is not
-        # signed by the top level CA.
-        ssl_cert_chain_file = ""
-        # The pkg/depot smf instance fmri.
-        smf_fmri = ""
-        # an optional url-prefix, used to separate pkg5 services from the rest
-        # of the webserver url namespace, only used when running in fragment
-        # mode, otherwise we assume we're the only service running on this
-        # web server instance, and control the entire server URL namespace.
-        sroot = ""
-        # the path where our Mako templates and wsgi scripts are stored
-        template_dir = "/etc/pkg/depot"
-        # a volatile directory used at runtime for storing state
-        runtime_dir = None
-        # where logs are written
-        log_dir = "/var/log/pkg/depot"
-        # whether we should pull configuration from
-        # svc:/application/pkg/server instances
-        use_smf_instances = False
-        # whether we allow admin/0 operations to rebuild the index
-        allow_refresh = False
-        # the current server_type
-        server_type = "apache2"
-
-        writable_root_set = False
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:],
-                    "Ac:d:Fh:l:P:p:r:Ss:t:T:?", ["help", "debug=", "https",
-                    "cert=", "key=", "ca-cert=", "ca-key=", "cert-chain=",
-                    "cert-key-dir=", "smf-fmri="])
-                for opt, arg in opts:
-                        if opt == "--help":
-                                usage()
-                        elif opt == "-h":
-                                host = arg
-                        elif opt == "-c":
-                                cache_dir = arg
-                        elif opt == "-s":
-                                cache_size = arg
-                        elif opt == "-l":
-                                log_dir = arg
-                        elif opt == "-p":
-                                port = arg
-                        elif opt == "-r":
-                                runtime_dir = arg
-                        elif opt == "-T":
-                                template_dir = arg
-                        elif opt == "-t":
-                                server_type = arg
-                        elif opt == "-d":
-                                if "=" not in arg:
-                                        usage(_("-d arguments must be in the "
-                                            "form <prefix>=<repo path>"
-                                            "[=writable root]"))
-                                components = arg.split("=", 2)
-                                if len(components) == 3:
-                                        prefix, root, writable_root = components
-                                        writable_root_set = True
-                                elif len(components) == 2:
-                                        prefix, root = components
-                                        writable_root = None
-                                repo_info.append((root, _affix_slash(prefix),
-                                    writable_root))
-                        elif opt == "-P":
-                                sroot = _affix_slash(arg)
-                        elif opt == "-F":
-                                fragment = True
-                        elif opt == "-S":
-                                use_smf_instances = True
-                        elif opt == "-A":
-                                allow_refresh = True
-                        elif opt == "--https":
-                                https = True
-                        elif opt == "--cert":
-                                ssl_cert_file = arg
-                        elif opt == "--key":
-                                ssl_key_file = arg
-                        elif opt == "--ca-cert":
-                                ssl_ca_cert_file = arg
-                        elif opt == "--ca-key":
-                                ssl_ca_key_file = arg
-                        elif opt == "--cert-chain":
-                                ssl_cert_chain_file = arg
-                        elif opt == "--cert-key-dir":
-                                cert_key_dir = arg
-                        elif opt == "--smf-fmri":
-                                smf_fmri = arg
-                        elif opt == "--debug":
-                                try:
-                                        key, value = arg.split("=", 1)
-                                except (AttributeError, ValueError):
-                                        usage(
-                                            _("{opt} takes argument of form "
-                                            "name=value, not {arg}").format(
-                                            opt=opt, arg=arg))
-                                DebugValues.set_value(key, value)
-                        else:
-                                usage("unknown option {0}".format(opt))
-
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
-
-        if not runtime_dir:
-                usage(_("required runtime dir option -r missing."))
-
-        # we need a cache_dir to store the SSLSessionCache
-        if not cache_dir and not fragment:
-                usage(_("cache_dir option -c is required if -F is not used."))
-
-        if not fragment and not port:
-                usage(_("required port option -p missing."))
-
-        if not use_smf_instances and not repo_info:
-                usage(_("at least one -d option is required if -S is "
-                    "not used."))
-
-        if repo_info and use_smf_instances:
-                usage(_("cannot use -d and -S together."))
-
-        if https:
-                if fragment:
-                        usage(_("https configuration is not supported in "
-                            "fragment mode."))
-                if bool(ssl_cert_file) != bool(ssl_key_file):
-                        usage(_("certificate and key files must be presented "
-                            "at the same time."))
-                elif not ssl_cert_file and not ssl_key_file:
-                        if not cert_key_dir:
-                                usage(_("cert-key-dir option is require to "
-                                    "store the generated certificates and keys"))
-                        if ssl_cert_chain_file:
-                                usage(_("Cannot use --cert-chain without "
-                                    "--cert and --key"))
-                        if bool(ssl_ca_cert_file) != bool(ssl_ca_key_file):
-                                usage(_("server CA certificate and key files "
-                                    "must be presented at the same time."))
-                        # If fmri is specified for pkg/depot instance, we need
-                        # record the proporty values for updating.
-                        if smf_fmri:
-                                orig = (ssl_ca_cert_file, ssl_ca_key_file,
-                                    ssl_cert_file, ssl_key_file)
-                        try:
-                                ssl_ca_cert_file, ssl_ca_key_file, ssl_cert_file, \
-                                    ssl_key_file = \
-                                    _generate_server_cert_key(host, port,
-                                    ca_cert_file=ssl_ca_cert_file,
-                                    ca_key_file=ssl_ca_key_file,
-                                    output_dir=cert_key_dir)
-                                if ssl_ca_cert_file:
-                                        msg(_("Server CA certificate is "
-                                            "located at {0}. Please deploy it "
-                                            "into /etc/certs/CA directory of "
-                                            "each client.").format(
-                                            ssl_ca_cert_file))
-                        except (DepotException, EnvironmentError) as e:
-                                    error(e)
-                                    return EXIT_OOPS
-
-                        # Update the pkg/depot instance smf properties if
-                        # anything changes.
-                        if smf_fmri:
-                                dest = (ssl_ca_cert_file, ssl_ca_key_file,
-                                    ssl_cert_file, ssl_key_file)
-                                if orig != dest:
-                                        prop_list = ["config/ssl_ca_cert_file",
-                                            "config/ssl_ca_key_file",
-                                            "config/ssl_cert_file",
-                                            "config/ssl_key_file"]
-                                        try:
-                                                _update_smf_props(smf_fmri, prop_list,
-                                                    orig, dest)
-                                        except (smf.NonzeroExitException,
-                                            RuntimeError) as e:
-                                                error(e)
-                                                return EXIT_OOPS
-                else:
-                        if not os.path.exists(ssl_cert_file):
-                                error(_("User provided server certificate "
-                                    "file {0} does not exist.").format(
-                                    ssl_cert_file))
-                                return EXIT_OOPS
-                        if not os.path.exists(ssl_key_file):
-                                error(_("User provided server key file {0} "
-                                    "does not exist.").format(ssl_key_file))
-                                return EXIT_OOPS
-                        if ssl_cert_chain_file and not os.path.exists(
-                            ssl_cert_chain_file):
-                                error(_("User provided certificate chain file "
-                                    "{0} does not exist.").format(
-                                    ssl_cert_chain_file))
-                                return EXIT_OOPS
-        else:
-                if ssl_cert_file or ssl_key_file or ssl_ca_cert_file \
-                    or ssl_ca_key_file or ssl_cert_chain_file:
-                        usage(_("certificate or key files are given before "
-                            "https service is turned on. Use --https to turn "
-                            "on the service."))
-                if smf_fmri:
-                        usage(_("cannot use --smf-fmri without --https."))
-
-        # We can't support httpd.conf fragments with writable root, because
-        # we don't have the mod_wsgi app that can build the index or serve
-        # search requests everywhere the fragments might be used. (eg. on
-        # non-Solaris systems)
-        if writable_root_set and fragment:
-                usage(_("cannot use -d with writable roots and -F together."))
-
-        if fragment and port:
-                usage(_("cannot use -F and -p together."))
-
-        if fragment and allow_refresh:
-                usage(_("cannot use -F and -A together."))
-
-        if sroot and not fragment:
-                usage(_("cannot use -P without -F."))
-
-        if use_smf_instances:
+    writable_root_set = False
+    try:
+        opts, pargs = getopt.getopt(
+            sys.argv[1:],
+            "Ac:d:Fh:l:P:p:r:Ss:t:T:?",
+            [
+                "help",
+                "debug=",
+                "https",
+                "cert=",
+                "key=",
+                "ca-cert=",
+                "ca-key=",
+                "cert-chain=",
+                "cert-key-dir=",
+                "smf-fmri=",
+            ],
+        )
+        for opt, arg in opts:
+            if opt == "--help":
+                usage()
+            elif opt == "-h":
+                host = arg
+            elif opt == "-c":
+                cache_dir = arg
+            elif opt == "-s":
+                cache_size = arg
+            elif opt == "-l":
+                log_dir = arg
+            elif opt == "-p":
+                port = arg
+            elif opt == "-r":
+                runtime_dir = arg
+            elif opt == "-T":
+                template_dir = arg
+            elif opt == "-t":
+                server_type = arg
+            elif opt == "-d":
+                if "=" not in arg:
+                    usage(
+                        _(
+                            "-d arguments must be in the "
+                            "form <prefix>=<repo path>"
+                            "[=writable root]"
+                        )
+                    )
+                components = arg.split("=", 2)
+                if len(components) == 3:
+                    prefix, root, writable_root = components
+                    writable_root_set = True
+                elif len(components) == 2:
+                    prefix, root = components
+                    writable_root = None
+                repo_info.append((root, _affix_slash(prefix), writable_root))
+            elif opt == "-P":
+                sroot = _affix_slash(arg)
+            elif opt == "-F":
+                fragment = True
+            elif opt == "-S":
+                use_smf_instances = True
+            elif opt == "-A":
+                allow_refresh = True
+            elif opt == "--https":
+                https = True
+            elif opt == "--cert":
+                ssl_cert_file = arg
+            elif opt == "--key":
+                ssl_key_file = arg
+            elif opt == "--ca-cert":
+                ssl_ca_cert_file = arg
+            elif opt == "--ca-key":
+                ssl_ca_key_file = arg
+            elif opt == "--cert-chain":
+                ssl_cert_chain_file = arg
+            elif opt == "--cert-key-dir":
+                cert_key_dir = arg
+            elif opt == "--smf-fmri":
+                smf_fmri = arg
+            elif opt == "--debug":
                 try:
-                        repo_info = get_smf_repo_info()
-                except DepotException as e:
-                        error(e)
+                    key, value = arg.split("=", 1)
+                except (AttributeError, ValueError):
+                    usage(
+                        _(
+                            "{opt} takes argument of form "
+                            "name=value, not {arg}"
+                        ).format(opt=opt, arg=arg)
+                    )
+                DebugValues.set_value(key, value)
+            else:
+                usage("unknown option {0}".format(opt))
 
-        # In the future we may produce configuration for different
-        # HTTP servers. For now, we only support "apache2"
-        if server_type not in KNOWN_SERVER_TYPES:
-                usage(_("unknown server type {type}. "
-                    "Known types are: {known}").format(
-                    type=server_type,
-                    known=", ".join(KNOWN_SERVER_TYPES)))
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
 
-        try:
-                _check_unique_repo_properties(repo_info)
-        except DepotException as e:
+    if not runtime_dir:
+        usage(_("required runtime dir option -r missing."))
+
+    # we need a cache_dir to store the SSLSessionCache
+    if not cache_dir and not fragment:
+        usage(_("cache_dir option -c is required if -F is not used."))
+
+    if not fragment and not port:
+        usage(_("required port option -p missing."))
+
+    if not use_smf_instances and not repo_info:
+        usage(_("at least one -d option is required if -S is " "not used."))
+
+    if repo_info and use_smf_instances:
+        usage(_("cannot use -d and -S together."))
+
+    if https:
+        if fragment:
+            usage(
+                _("https configuration is not supported in " "fragment mode.")
+            )
+        if bool(ssl_cert_file) != bool(ssl_key_file):
+            usage(
+                _(
+                    "certificate and key files must be presented "
+                    "at the same time."
+                )
+            )
+        elif not ssl_cert_file and not ssl_key_file:
+            if not cert_key_dir:
+                usage(
+                    _(
+                        "cert-key-dir option is require to "
+                        "store the generated certificates and keys"
+                    )
+                )
+            if ssl_cert_chain_file:
+                usage(_("Cannot use --cert-chain without " "--cert and --key"))
+            if bool(ssl_ca_cert_file) != bool(ssl_ca_key_file):
+                usage(
+                    _(
+                        "server CA certificate and key files "
+                        "must be presented at the same time."
+                    )
+                )
+            # If fmri is specified for pkg/depot instance, we need
+            # record the proporty values for updating.
+            if smf_fmri:
+                orig = (
+                    ssl_ca_cert_file,
+                    ssl_ca_key_file,
+                    ssl_cert_file,
+                    ssl_key_file,
+                )
+            try:
+                (
+                    ssl_ca_cert_file,
+                    ssl_ca_key_file,
+                    ssl_cert_file,
+                    ssl_key_file,
+                ) = _generate_server_cert_key(
+                    host,
+                    port,
+                    ca_cert_file=ssl_ca_cert_file,
+                    ca_key_file=ssl_ca_key_file,
+                    output_dir=cert_key_dir,
+                )
+                if ssl_ca_cert_file:
+                    msg(
+                        _(
+                            "Server CA certificate is "
+                            "located at {0}. Please deploy it "
+                            "into /etc/certs/CA directory of "
+                            "each client."
+                        ).format(ssl_ca_cert_file)
+                    )
+            except (DepotException, EnvironmentError) as e:
                 error(e)
+                return EXIT_OOPS
 
-        ret = refresh_conf(repo_info, log_dir, host, port, runtime_dir,
-            template_dir, cache_dir, cache_size, sroot, fragment=fragment,
-            allow_refresh=allow_refresh, ssl_cert_file=ssl_cert_file,
-            ssl_key_file=ssl_key_file, ssl_cert_chain_file=ssl_cert_chain_file)
-        return ret
+            # Update the pkg/depot instance smf properties if
+            # anything changes.
+            if smf_fmri:
+                dest = (
+                    ssl_ca_cert_file,
+                    ssl_ca_key_file,
+                    ssl_cert_file,
+                    ssl_key_file,
+                )
+                if orig != dest:
+                    prop_list = [
+                        "config/ssl_ca_cert_file",
+                        "config/ssl_ca_key_file",
+                        "config/ssl_cert_file",
+                        "config/ssl_key_file",
+                    ]
+                    try:
+                        _update_smf_props(smf_fmri, prop_list, orig, dest)
+                    except (smf.NonzeroExitException, RuntimeError) as e:
+                        error(e)
+                        return EXIT_OOPS
+        else:
+            if not os.path.exists(ssl_cert_file):
+                error(
+                    _(
+                        "User provided server certificate "
+                        "file {0} does not exist."
+                    ).format(ssl_cert_file)
+                )
+                return EXIT_OOPS
+            if not os.path.exists(ssl_key_file):
+                error(
+                    _(
+                        "User provided server key file {0} " "does not exist."
+                    ).format(ssl_key_file)
+                )
+                return EXIT_OOPS
+            if ssl_cert_chain_file and not os.path.exists(ssl_cert_chain_file):
+                error(
+                    _(
+                        "User provided certificate chain file "
+                        "{0} does not exist."
+                    ).format(ssl_cert_chain_file)
+                )
+                return EXIT_OOPS
+    else:
+        if (
+            ssl_cert_file
+            or ssl_key_file
+            or ssl_ca_cert_file
+            or ssl_ca_key_file
+            or ssl_cert_chain_file
+        ):
+            usage(
+                _(
+                    "certificate or key files are given before "
+                    "https service is turned on. Use --https to turn "
+                    "on the service."
+                )
+            )
+        if smf_fmri:
+            usage(_("cannot use --smf-fmri without --https."))
+
+    # We can't support httpd.conf fragments with writable root, because
+    # we don't have the mod_wsgi app that can build the index or serve
+    # search requests everywhere the fragments might be used. (eg. on
+    # non-Solaris systems)
+    if writable_root_set and fragment:
+        usage(_("cannot use -d with writable roots and -F together."))
+
+    if fragment and port:
+        usage(_("cannot use -F and -p together."))
+
+    if fragment and allow_refresh:
+        usage(_("cannot use -F and -A together."))
+
+    if sroot and not fragment:
+        usage(_("cannot use -P without -F."))
+
+    if use_smf_instances:
+        try:
+            repo_info = get_smf_repo_info()
+        except DepotException as e:
+            error(e)
+
+    # In the future we may produce configuration for different
+    # HTTP servers. For now, we only support "apache2"
+    if server_type not in KNOWN_SERVER_TYPES:
+        usage(
+            _("unknown server type {type}. " "Known types are: {known}").format(
+                type=server_type, known=", ".join(KNOWN_SERVER_TYPES)
+            )
+        )
+
+    try:
+        _check_unique_repo_properties(repo_info)
+    except DepotException as e:
+        error(e)
+
+    ret = refresh_conf(
+        repo_info,
+        log_dir,
+        host,
+        port,
+        runtime_dir,
+        template_dir,
+        cache_dir,
+        cache_size,
+        sroot,
+        fragment=fragment,
+        allow_refresh=allow_refresh,
+        ssl_cert_file=ssl_cert_file,
+        ssl_key_file=ssl_key_file,
+        ssl_cert_chain_file=ssl_cert_chain_file,
+    )
+    return ret
+
 
 #
 # Establish a specific exit status which means: "python barfed an exception"
 # so that we can more easily detect these in testing of the CLI commands.
 #
 def handle_errors(func, *args, **kwargs):
-        """Catch exceptions raised by the main program function and then print
-        a message and/or exit with an appropriate return code.
-        """
+    """Catch exceptions raised by the main program function and then print
+    a message and/or exit with an appropriate return code.
+    """
 
-        traceback_str = misc.get_traceback_message()
+    traceback_str = misc.get_traceback_message()
 
+    try:
+        # Out of memory errors can be raised as EnvironmentErrors with
+        # an errno of ENOMEM, so in order to handle those exceptions
+        # with other errnos, we nest this try block and have the outer
+        # one handle the other instances.
         try:
-                # Out of memory errors can be raised as EnvironmentErrors with
-                # an errno of ENOMEM, so in order to handle those exceptions
-                # with other errnos, we nest this try block and have the outer
-                # one handle the other instances.
-                try:
-                        __ret = func(*args, **kwargs)
-                except (MemoryError, EnvironmentError) as __e:
-                        if isinstance(__e, EnvironmentError) and \
-                            __e.errno != errno.ENOMEM:
-                                raise
-                        error("\n" + misc.out_of_memory())
-                        __ret = EXIT_OOPS
-        except SystemExit as __e:
-                raise __e
-        except (PipeError, KeyboardInterrupt):
-                # Don't display any messages here to prevent possible further
-                # broken pipe (EPIPE) errors.
-                __ret = EXIT_OOPS
-        except:
-                traceback.print_exc()
-                error(traceback_str)
-                __ret = 99
-        return __ret
+            __ret = func(*args, **kwargs)
+        except (MemoryError, EnvironmentError) as __e:
+            if isinstance(__e, EnvironmentError) and __e.errno != errno.ENOMEM:
+                raise
+            error("\n" + misc.out_of_memory())
+            __ret = EXIT_OOPS
+    except SystemExit as __e:
+        raise __e
+    except (PipeError, KeyboardInterrupt):
+        # Don't display any messages here to prevent possible further
+        # broken pipe (EPIPE) errors.
+        __ret = EXIT_OOPS
+    except:
+        traceback.print_exc()
+        error(traceback_str)
+        __ret = 99
+    return __ret
 
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
 
-        # Make all warnings be errors.
-        warnings.simplefilter('error')
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
+    # Make all warnings be errors.
+    warnings.simplefilter("error")
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
 
-        __retval = handle_errors(main_func)
-        try:
-                logging.shutdown()
-        except IOError:
-                # Ignore python's spurious pipe problems.
-                pass
-        sys.exit(__retval)
+    __retval = handle_errors(main_func)
+    try:
+        logging.shutdown()
+    except IOError:
+        # Ignore python's spurious pipe problems.
+        pass
+    sys.exit(__retval)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/depot.py
+++ b/src/depot.py
@@ -23,7 +23,9 @@
 #
 
 from __future__ import print_function
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 
 # pkg.depotd - package repository daemon
 
@@ -84,15 +86,18 @@ from importlib import reload
 from six.moves.urllib.parse import urlparse, urlunparse
 
 try:
-        import cherrypy
-        version = cherrypy.__version__.split('.')
-        # comparison requires same type, therefore list conversion is needed
-        if list(map(int, version)) < [3, 1, 0]:
-                raise ImportError
+    import cherrypy
+
+    version = cherrypy.__version__.split(".")
+    # comparison requires same type, therefore list conversion is needed
+    if list(map(int, version)) < [3, 1, 0]:
+        raise ImportError
 except ImportError:
-        print("""cherrypy 3.1.0 or greater is required to use this program.""",
-            file=sys.stderr)
-        sys.exit(2)
+    print(
+        """cherrypy 3.1.0 or greater is required to use this program.""",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 import cherrypy.process.servers
 from cherrypy.process.plugins import Daemonizer
@@ -115,41 +120,43 @@ import pkg.server.repository as sr
 # converting the hyphen symbol.
 punc = string.punctuation.replace("-", "_")
 if six.PY2:
-        translate = string.maketrans(punc, "_" * len(string.punctuation))
+    translate = string.maketrans(punc, "_" * len(string.punctuation))
 else:
-        translate = str.maketrans(punc, "_" * len(string.punctuation))
+    translate = str.maketrans(punc, "_" * len(string.punctuation))
+
+
 class Pkg5Dispatcher(Dispatcher):
-        def __init__(self, **args):
-                Dispatcher.__init__(self, translate=translate)
+    def __init__(self, **args):
+        Dispatcher.__init__(self, translate=translate)
 
 
 class LogSink(object):
-        """This is a dummy object that we can use to discard log entries
-        without relying on non-portable interfaces such as /dev/null."""
+    """This is a dummy object that we can use to discard log entries
+    without relying on non-portable interfaces such as /dev/null."""
 
-        def write(self, *args, **kwargs):
-                """Discard the bits."""
-                pass
+    def write(self, *args, **kwargs):
+        """Discard the bits."""
+        pass
 
-        def flush(self, *args, **kwargs):
-                """Discard the bits."""
-                pass
+    def flush(self, *args, **kwargs):
+        """Discard the bits."""
+        pass
 
 
 def usage(text=None, retcode=2, full=False):
-        """Optionally emit a usage message and then exit using the specified
-        exit code."""
+    """Optionally emit a usage message and then exit using the specified
+    exit code."""
 
-        if text:
-                emsg(text)
+    if text:
+        emsg(text)
 
-        if not full:
-                # The full usage message isn't desired.
-                emsg(_("Try `pkg.depotd --help or -?' for more "
-                    "information."))
-                sys.exit(retcode)
+    if not full:
+        # The full usage message isn't desired.
+        emsg(_("Try `pkg.depotd --help or -?' for more " "information."))
+        sys.exit(retcode)
 
-        print("""\
+    print(
+        """\
 Usage: /usr/lib/pkg.depotd [-a address] [-d inst_root] [-p port] [-s threads]
            [-t socket_timeout] [--cfg] [--content-root]
            [--disable-ops op[/1][,...]] [--debug feature_list]
@@ -244,745 +251,811 @@ Options:
 Environment:
         PKG_REPO                Used as default inst_root if -d not provided.
         PKG_DEPOT_CONTENT       Used as default content_root if --content-root
-                                not provided.""")
-        sys.exit(retcode)
+                                not provided."""
+    )
+    sys.exit(retcode)
+
 
 class OptionError(Exception):
-        """Option exception. """
+    """Option exception."""
 
-        def __init__(self, *args):
-                Exception.__init__(self, *args)
+    def __init__(self, *args):
+        Exception.__init__(self, *args)
 
-        @cherrypy.tools.register('before_finalize', priority=60)
-        def secureheaders():
-            headers = cherrypy.response.headers
-            headers['X-Frame-Options'] = 'SAMEORIGIN'
-            headers['X-XSS-Protection'] = '1; mode=block'
-            headers['Content-Security-Policy'] = "default-src 'self';"
+    @cherrypy.tools.register("before_finalize", priority=60)
+    def secureheaders():
+        headers = cherrypy.response.headers
+        headers["X-Frame-Options"] = "SAMEORIGIN"
+        headers["X-XSS-Protection"] = "1; mode=block"
+        headers["Content-Security-Policy"] = "default-src 'self';"
+
 
 if __name__ == "__main__":
+    setlocale(locale.LC_ALL, "")
+    gettext.install("pkg", "/usr/share/locale")
 
-        setlocale(locale.LC_ALL, "")
-        gettext.install("pkg", "/usr/share/locale")
+    add_content = False
+    exit_ready = False
+    rebuild = False
+    reindex = False
+    nasty = False
 
-        add_content = False
-        exit_ready = False
-        rebuild = False
-        reindex = False
-        nasty = False
+    # Track initial configuration values.
+    ivalues = {"pkg": {}, "nasty": {}}
+    if "PKG_REPO" in os.environ:
+        ivalues["pkg"]["inst_root"] = os.environ["PKG_REPO"]
 
-        # Track initial configuration values.
-        ivalues = { "pkg": {}, "nasty": {} }
-        if "PKG_REPO" in os.environ:
-                ivalues["pkg"]["inst_root"] = os.environ["PKG_REPO"]
-
+    try:
+        content_root = os.environ["PKG_DEPOT_CONTENT"]
+        ivalues["pkg"]["content_root"] = content_root
+    except KeyError:
         try:
-                content_root = os.environ["PKG_DEPOT_CONTENT"]
-                ivalues["pkg"]["content_root"] = content_root
+            content_root = os.path.join(os.environ["PKG_HOME"], "share/lib/pkg")
+            ivalues["pkg"]["content_root"] = content_root
         except KeyError:
-                try:
-                        content_root = os.path.join(os.environ['PKG_HOME'],
-                            'share/lib/pkg')
-                        ivalues["pkg"]["content_root"] = content_root
-                except KeyError:
-                        pass
+            pass
 
-        opt = None
-        addresses = set()
-        debug_features = []
-        disable_ops = []
-        repo_props = {}
-        socket_path = ""
-        user_cfg = None
-        try:
-                long_opts = ["add-content", "cfg=", "cfg-file=",
-                    "content-root=", "debug=", "disable-ops=", "exit-ready",
-                    "help", "image-root=", "log-access=", "log-errors=",
-                    "llmirror", "mirror", "nasty=", "nasty-sleep=",
-                    "proxy-base=", "readonly", "rebuild", "refresh-index",
-                    "set-property=", "ssl-cert-file=", "ssl-dialog=",
-                    "ssl-key-file=", "sort-file-max-size=", "writable-root="]
+    opt = None
+    addresses = set()
+    debug_features = []
+    disable_ops = []
+    repo_props = {}
+    socket_path = ""
+    user_cfg = None
+    try:
+        long_opts = [
+            "add-content",
+            "cfg=",
+            "cfg-file=",
+            "content-root=",
+            "debug=",
+            "disable-ops=",
+            "exit-ready",
+            "help",
+            "image-root=",
+            "log-access=",
+            "log-errors=",
+            "llmirror",
+            "mirror",
+            "nasty=",
+            "nasty-sleep=",
+            "proxy-base=",
+            "readonly",
+            "rebuild",
+            "refresh-index",
+            "set-property=",
+            "ssl-cert-file=",
+            "ssl-dialog=",
+            "ssl-key-file=",
+            "sort-file-max-size=",
+            "writable-root=",
+        ]
 
-                opts, pargs = getopt.getopt(sys.argv[1:], "a:d:np:s:t:?",
-                    long_opts)
+        opts, pargs = getopt.getopt(sys.argv[1:], "a:d:np:s:t:?", long_opts)
 
-                show_usage = False
-                for opt, arg in opts:
-                        if opt == "-a":
-                                addresses.add(arg)
-                        elif opt == "-n":
-                                sys.exit(0)
-                        elif opt == "-d":
-                                ivalues["pkg"]["inst_root"] = arg
-                        elif opt == "-p":
-                                ivalues["pkg"]["port"] = arg
-                        elif opt == "-s":
-                                threads = int(arg)
-                                if threads < THREADS_MIN:
-                                        raise OptionError(
-                                            "minimum value is {0:d}".format(
-                                            THREADS_MIN))
-                                if threads > THREADS_MAX:
-                                        raise OptionError(
-                                            "maximum value is {0:d}".format(
-                                            THREADS_MAX))
-                                ivalues["pkg"]["threads"] = threads
-                        elif opt == "-t":
-                                ivalues["pkg"]["socket_timeout"] = arg
-                        elif opt == "--add-content":
-                                add_content = True
-                        elif opt == "--cfg":
-                                user_cfg  = arg
-                        elif opt == "--cfg-file":
-                                ivalues["pkg"]["cfg_file"] = arg
-                        elif opt == "--content-root":
-                                ivalues["pkg"]["content_root"] = arg
-                        elif opt == "--debug":
-                                if arg is None or arg == "":
-                                        continue
-
-                                # A list of features can be specified using a
-                                # "," or any whitespace character as separators.
-                                if "," in arg:
-                                        features = arg.split(",")
-                                else:
-                                        features = arg.split()
-                                debug_features.extend(features)
-
-                                # We also allow key=value debug flags, which
-                                # get set in pkg.client.debugvalues
-                                for feature in features:
-                                        try:
-                                                key, val = feature.split("=", 1)
-                                                DebugValues.set_value(key, val)
-                                        except (AttributeError, ValueError):
-                                                pass
-
-                        elif opt == "--disable-ops":
-                                if arg is None or arg == "":
-                                        raise OptionError(
-                                            "An argument must be specified.")
-
-                                disableops = arg.split(",")
-                                for s in disableops:
-                                        if "/" in s:
-                                                op, ver = s.rsplit("/", 1)
-                                        else:
-                                                op = s
-                                                ver = "*"
-
-                                        if op not in \
-                                            ds.DepotHTTP.REPO_OPS_DEFAULT:
-                                                raise OptionError(
-                                                    "Invalid operation "
-                                                    "'{0}'.".format(s))
-                                        disable_ops.append(s)
-                        elif opt == "--exit-ready":
-                                exit_ready = True
-                        elif opt == "--image-root":
-                                ivalues["pkg"]["image_root"] = arg
-                        elif opt.startswith("--log-"):
-                                prop = "log_{0}".format(opt.lstrip("--log-"))
-                                ivalues["pkg"][prop] = arg
-                        elif opt in ("--help", "-?"):
-                                show_usage = True
-                        elif opt == "--mirror":
-                                ivalues["pkg"]["mirror"] = True
-                        elif opt == "--llmirror":
-                                ivalues["pkg"]["mirror"] = True
-                                ivalues["pkg"]["ll_mirror"] = True
-                                ivalues["pkg"]["readonly"] = True
-                        elif opt == "--nasty":
-                                # ValueError is caught by caller.
-                                nasty_value = int(arg)
-                                if (nasty_value > 100 or nasty_value < 1):
-                                        raise OptionError("Invalid value "
-                                            "for nasty option.\n Please "
-                                            "choose a value between 1 and 100.")
-                                nasty = True
-                                ivalues["nasty"]["nasty_level"] = nasty_value
-                        elif opt == "--nasty-sleep":
-                                # ValueError is caught by caller.
-                                sleep_value = int(arg)
-                                ivalues["nasty"]["nasty_sleep"] = sleep_value
-                        elif opt == "--proxy-base":
-                                # Attempt to decompose the url provided into
-                                # its base parts.  This is done so we can
-                                # remove any scheme information since we
-                                # don't need it.
-                                scheme, netloc, path, params, query, \
-                                    fragment = urlparse(arg,
-                                    "http", allow_fragments=0)
-
-                                if not netloc:
-                                        raise OptionError("Unable to "
-                                            "determine the hostname from "
-                                            "the provided URL; please use a "
-                                            "fully qualified URL.")
-
-                                scheme = scheme.lower()
-                                if scheme not in ("http", "https"):
-                                        raise OptionError("Invalid URL; http "
-                                            "and https are the only supported "
-                                            "schemes.")
-
-                                # Rebuild the url with the sanitized components.
-                                ivalues["pkg"]["proxy_base"] = \
-                                    urlunparse((scheme, netloc, path,
-                                    params, query, fragment))
-                        elif opt == "--readonly":
-                                ivalues["pkg"]["readonly"] = True
-                        elif opt == "--rebuild":
-                                rebuild = True
-                        elif opt == "--refresh-index":
-                                # Note: This argument is for internal use
-                                # only.
-                                #
-                                # This flag is purposefully omitted in usage.
-                                # The supported way to forcefully reindex is to
-                                # kill any pkg.depot using that directory,
-                                # remove the index directory, and restart the
-                                # pkg.depot process. The index will be rebuilt
-                                # automatically on startup.
-                                reindex = True
-                                exit_ready = True
-                        elif opt == "--set-property":
-                                try:
-                                        prop, p_value = arg.split("=", 1)
-                                        p_sec, p_name = prop.split(".", 1)
-                                except ValueError:
-                                        usage(_("property arguments must be of "
-                                            "the form '<section.property>="
-                                            "<value>'."))
-                                repo_props.setdefault(p_sec, {})
-                                repo_props[p_sec][p_name] = p_value
-                        elif opt == "--ssl-cert-file":
-                                if arg == "none" or arg == "":
-                                        # Assume this is an override to clear
-                                        # the value.
-                                        arg = ""
-                                elif not os.path.isabs(arg):
-                                        raise OptionError("The path to "
-                                           "the Certificate file must be "
-                                           "absolute.")
-                                elif not os.path.exists(arg):
-                                        raise OptionError("The specified "
-                                            "file does not exist.")
-                                elif not os.path.isfile(arg):
-                                        raise OptionError("The specified "
-                                            "pathname is not a file.")
-                                ivalues["pkg"]["ssl_cert_file"] = arg
-                        elif opt == "--ssl-key-file":
-                                if arg == "none" or arg == "":
-                                        # Assume this is an override to clear
-                                        # the value.
-                                        arg = ""
-                                elif not os.path.isabs(arg):
-                                        raise OptionError("The path to "
-                                           "the Private Key file must be "
-                                           "absolute.")
-                                elif not os.path.exists(arg):
-                                        raise OptionError("The specified "
-                                            "file does not exist.")
-                                elif not os.path.isfile(arg):
-                                        raise OptionError("The specified "
-                                            "pathname is not a file.")
-                                ivalues["pkg"]["ssl_key_file"] = arg
-                        elif opt == "--ssl-dialog":
-                                if arg != "builtin" and \
-                                    arg != "smf" and not \
-                                    arg.startswith("exec:/") and not \
-                                    arg.startswith("svc:"):
-                                        raise OptionError("Invalid value "
-                                            "specified.  Expected: builtin, "
-                                            "exec:/path/to/program, smf, or "
-                                            "an SMF FMRI.")
-
-                                if arg.startswith("exec:"):
-                                        if os_util.get_canonical_os_type() != \
-                                          "unix":
-                                                # Don't allow a somewhat
-                                                # insecure authentication method
-                                                # on some platforms.
-                                                raise OptionError("exec is "
-                                                    "not a supported dialog "
-                                                    "type for this operating "
-                                                    "system.")
-
-                                        f = os.path.abspath(arg.split(
-                                            "exec:")[1])
-                                        if not os.path.isfile(f):
-                                                raise OptionError("Invalid "
-                                                    "file path specified for "
-                                                    "exec.")
-                                ivalues["pkg"]["ssl_dialog"] = arg
-                        elif opt == "--sort-file-max-size":
-                                ivalues["pkg"]["sort_file_max_size"] = arg
-                        elif opt == "--writable-root":
-                                ivalues["pkg"]["writable_root"] = arg
-
-                # Set accumulated values.
-                if debug_features:
-                        ivalues["pkg"]["debug"] = debug_features
-                if disable_ops:
-                        ivalues["pkg"]["disable_ops"] = disable_ops
-                if addresses:
-                        ivalues["pkg"]["address"] = list(addresses)
-
-                if DebugValues:
-                        reload(pkg.digest)
-
-                # Build configuration object.
-                dconf = ds.DepotConfig(target=user_cfg, overrides=ivalues)
-        except getopt.GetoptError as _e:
-                usage("pkg.depotd: {0}".format(_e.msg))
-        except api_errors.ApiException as _e:
-                usage("pkg.depotd: {0}".format(str(_e)))
-        except OptionError as _e:
-                usage("pkg.depotd: option: {0} -- {1}".format(opt, _e))
-        except (ArithmeticError, ValueError):
-                usage("pkg.depotd: illegal option value: {0} specified " \
-                    "for option: {1}".format(arg, opt))
-
-        if show_usage:
-                usage(retcode=0, full=True)
-
-        if not dconf.get_property("pkg", "log_errors"):
-                dconf.set_property("pkg", "log_errors", "stderr")
-
-        # If stdout is a tty, then send access output there by default instead
-        # of discarding it.
-        if not dconf.get_property("pkg", "log_access"):
-                if os.isatty(sys.stdout.fileno()):
-                        dconf.set_property("pkg", "log_access", "stdout")
-                else:
-                        dconf.set_property("pkg", "log_access", "none")
-
-        # Check for invalid option combinations.
-        image_root = dconf.get_property("pkg", "image_root")
-        inst_root = dconf.get_property("pkg", "inst_root")
-        mirror = dconf.get_property("pkg", "mirror")
-        ll_mirror = dconf.get_property("pkg", "ll_mirror")
-        readonly = dconf.get_property("pkg", "readonly")
-        writable_root = dconf.get_property("pkg", "writable_root")
-        if rebuild and add_content:
-                usage("--add-content cannot be used with --rebuild")
-        if rebuild and reindex:
-                usage("--refresh-index cannot be used with --rebuild")
-        if (rebuild or add_content) and (readonly or mirror):
-                usage("--readonly and --mirror cannot be used with --rebuild "
-                    "or --add-content")
-        if reindex and mirror:
-                usage("--mirror cannot be used with --refresh-index")
-        if reindex and readonly and not writable_root:
-                usage("--readonly can only be used with --refresh-index if "
-                    "--writable-root is used")
-        if image_root and not ll_mirror:
-                usage("--image-root can only be used with --llmirror.")
-        if image_root and writable_root:
-                usage("--image_root and --writable-root cannot be used "
-                    "together.")
-        if image_root and inst_root:
-                usage("--image-root and -d cannot be used together.")
-
-        # If the image format changes this may need to be reexamined.
-        if image_root:
-                inst_root = os.path.join(image_root, "var", "pkg")
-
-        # Set any values using defaults if they weren't provided.
-
-        # Only use the first value for now; multiple bind addresses may be
-        # supported later.
-        address = dconf.get_property("pkg", "address")
-        if address:
-                address = address[0]
-        elif not address:
-                dconf.set_property("pkg", "address", [HOST_DEFAULT])
-                address = dconf.get_property("pkg", "address")[0]
-
-        if not inst_root:
-                usage("Either PKG_REPO or -d must be provided")
-
-        content_root = dconf.get_property("pkg", "content_root")
-        if not content_root:
-                dconf.set_property("pkg", "content_root", CONTENT_PATH_DEFAULT)
-                content_root = dconf.get_property("pkg", "content_root")
-
-        port = dconf.get_property("pkg", "port")
-        ssl_cert_file = dconf.get_property("pkg", "ssl_cert_file")
-        ssl_key_file = dconf.get_property("pkg", "ssl_key_file")
-        if (ssl_cert_file and not ssl_key_file) or (ssl_key_file and not
-            ssl_cert_file):
-                usage("The --ssl-cert-file and --ssl-key-file options must "
-                    "must both be provided when using either option.")
-        elif not port:
-                if ssl_cert_file and ssl_key_file:
-                        dconf.set_property("pkg", "port", SSL_PORT_DEFAULT)
-                else:
-                        dconf.set_property("pkg", "port", PORT_DEFAULT)
-                port = dconf.get_property("pkg", "port")
-
-        socket_timeout = dconf.get_property("pkg", "socket_timeout")
-        if not socket_timeout:
-                dconf.set_property("pkg", "socket_timeout",
-                    SOCKET_TIMEOUT_DEFAULT)
-                socket_timeout = dconf.get_property("pkg", "socket_timeout")
-
-        threads = dconf.get_property("pkg", "threads")
-        if not threads:
-                dconf.set_property("pkg", "threads", THREADS_DEFAULT)
-                threads = dconf.get_property("pkg", "threads")
-
-        # If the program is going to reindex, the port is irrelevant since
-        # the program will not bind to a port.
-        if not exit_ready:
-                try:
-                        portend.Checker().assert_free(address, port)
-                except Exception as e:
-                        emsg("pkg.depotd: unable to bind to the specified "
-                            "port: {0:d}. Reason: {1}".format(port, e))
-                        sys.exit(1)
-        else:
-                # Not applicable if we're not going to serve content
-                dconf.set_property("pkg", "content_root", "")
-
-        # Any relative paths should be made absolute using pkg_root.  'pkg_root'
-        # is a special property that was added to enable internal deployment of
-        # multiple disparate versions of the pkg.depotd software.
-        pkg_root = dconf.get_property("pkg", "pkg_root")
-
-        repo_config_file = dconf.get_property("pkg", "cfg_file")
-        if repo_config_file and not os.path.isabs(repo_config_file):
-                repo_config_file = os.path.join(pkg_root, repo_config_file)
-
-        if content_root and not os.path.isabs(content_root):
-                content_root = os.path.join(pkg_root, content_root)
-
-        if inst_root and not os.path.isabs(inst_root):
-                inst_root = os.path.join(pkg_root, inst_root)
-
-        if ssl_cert_file:
-                if ssl_cert_file == "none":
-                        ssl_cert_file = None
-                elif not os.path.isabs(ssl_cert_file):
-                        ssl_cert_file = os.path.join(pkg_root, ssl_cert_file)
-
-        if ssl_key_file:
-                if ssl_key_file == "none":
-                        ssl_key_file = None
-                elif not os.path.isabs(ssl_key_file):
-                        ssl_key_file = os.path.join(pkg_root, ssl_key_file)
-
-        if writable_root and not os.path.isabs(writable_root):
-                writable_root = os.path.join(pkg_root, writable_root)
-
-        # Setup SSL if requested.
-        key_data = None
-        ssl_dialog = dconf.get_property("pkg", "ssl_dialog")
-        if not exit_ready and ssl_cert_file and ssl_key_file and \
-            ssl_dialog != "builtin":
-                cmdline = None
-                def get_ssl_passphrase(*ignored):
-                        p = None
-                        try:
-                                if cmdline:
-                                        cmdargs = shlex.split(cmdline)
-                                else:
-                                        cmdargs = []
-                                p = subprocess.Popen(cmdargs,
-                                        stdout=subprocess.PIPE,
-                                        stderr=None)
-                                p.wait()
-                        except Exception as __e:
-                                emsg("pkg.depotd: an error occurred while "
-                                    "executing [{0}]; unable to obtain the "
-                                    "passphrase needed to decrypt the SSL "
-                                    "private key file: {1}".format(cmdline,
-                                    __e))
-                                sys.exit(1)
-                        return p.stdout.read().strip(b"\n")
-
-                if ssl_dialog.startswith("exec:"):
-                        exec_path = ssl_dialog.split("exec:")[1]
-                        if not os.path.isabs(exec_path):
-                                exec_path = os.path.join(pkg_root, exec_path)
-                        cmdline = "{0} {1} {2:d}".format(exec_path, "''", port)
-                elif ssl_dialog == "smf" or ssl_dialog.startswith("svc:"):
-                        if ssl_dialog == "smf":
-                                # Assume the configuration target was an SMF
-                                # FMRI and let svcprop fail with an error if
-                                # it wasn't.
-                                svc_fmri = dconf.target
-                        else:
-                                svc_fmri = ssl_dialog
-                        cmdline = "/usr/bin/svcprop -p " \
-                            "pkg_secure/ssl_key_passphrase {0}".format(svc_fmri)
-
-                # The key file requires decryption, but the user has requested
-                # exec-based authentication, so it will have to be decoded first
-                # to an un-named temporary file.
-                try:
-                        with open(ssl_key_file, "rb") as key_file:
-                                pkey = crypto.load_privatekey(
-                                    crypto.FILETYPE_PEM, key_file.read(),
-                                    get_ssl_passphrase)
-
-                        key_data = tempfile.NamedTemporaryFile(dir=pkg_root,
-                            delete=True)
-                        key_data.write(crypto.dump_privatekey(
-                            crypto.FILETYPE_PEM, pkey))
-                        key_data.seek(0)
-                except EnvironmentError as _e:
-                        emsg("pkg.depotd: unable to read the SSL private key "
-                            "file: {0}".format(_e))
-                        sys.exit(1)
-                except crypto.Error as _e:
-                        emsg("pkg.depotd: authentication or cryptography "
-                            "failure while attempting to decode\nthe SSL "
-                            "private key file: {0}".format(_e))
-                        sys.exit(1)
-                else:
-                        # Redirect the server to the decrypted key file.
-                        ssl_key_file = key_data.name
-
-        # Setup our global configuration.
-        gconf = {
-            "checker.on": True,
-            "environment": "production",
-            "log.screen": False,
-            "server.max_request_body_size": MAX_REQUEST_BODY_SIZE,
-            "server.shutdown_timeout": 0,
-            "server.socket_host": address,
-            "server.socket_port": port,
-            "server.socket_timeout": socket_timeout,
-            "server.ssl_certificate": ssl_cert_file,
-            "server.ssl_private_key": ssl_key_file,
-            "server.thread_pool": threads,
-            "tools.log_headers.on": True,
-            "tools.encode.on": True,
-            "tools.encode.encoding": "utf-8",
-            "tools.secureheaders.on" : True,
-        }
-
-        if "headers" in dconf.get_property("pkg", "debug"):
-                # Despite its name, this only logs headers when there is an
-                # error; it's redundant with the debug feature enabled.
-                gconf["tools.log_headers.on"] = False
-
-                # Causes the headers of every request to be logged to the error
-                # log; even if an exception occurs.
-                gconf["tools.log_headers_always.on"] = True
-                cherrypy.tools.log_headers_always = cherrypy.Tool(
-                    "on_start_resource",
-                    cherrypy.lib.cptools.log_request_headers)
-
-        log_cfg = {
-            "access": dconf.get_property("pkg", "log_access"),
-            "errors": dconf.get_property("pkg", "log_errors")
-        }
-
-        # If stdin is not a tty and the pkgdepot controller isn't being used,
-        # then assume process will be daemonized and redirect output.
-        if not os.environ.get("PKGDEPOT_CONTROLLER") and \
-            not os.isatty(sys.stdin.fileno()):
-                # Ensure log handlers are setup to use the file descriptors for
-                # stdout and stderr as the Daemonizer (used for test suite and
-                # SMF service) requires this.
-                if log_cfg["access"] == "stdout":
-                        log_cfg["access"] = "/dev/fd/{0:d}".format(
-                            sys.stdout.fileno())
-                elif log_cfg["access"] == "stderr":
-                        log_cfg["access"] = "/dev/fd/{0:d}".format(
-                            sys.stderr.fileno())
-                elif log_cfg["access"] == "none":
-                        log_cfg["access"] = "/dev/null"
-
-                if log_cfg["errors"] == "stderr":
-                        log_cfg["errors"] = "/dev/fd/{0:d}".format(
-                            sys.stderr.fileno())
-                elif log_cfg["errors"] == "stdout":
-                        log_cfg["errors"] = "/dev/fd/{0:d}".format(
-                            sys.stdout.fileno())
-                elif log_cfg["errors"] == "none":
-                        log_cfg["errors"] = "/dev/null"
-
-        log_type_map = {
-            "errors": {
-                "param": "log.error_file",
-                "attr": "error_log"
-            },
-            "access": {
-                "param": "log.access_file",
-                "attr": "access_log"
-            }
-        }
-
-        for log_type in log_type_map:
-                dest = log_cfg[log_type]
-                if dest in ("stdout", "stderr", "none"):
-                        if dest == "none":
-                                h = logging.StreamHandler(LogSink())
-                        else:
-                                h = logging.StreamHandler(eval("sys.{0}".format(
-                                    dest)))
-
-                        h.setLevel(logging.DEBUG)
-                        h.setFormatter(cherrypy._cplogging.logfmt)
-                        log_obj = eval("cherrypy.log.{0}".format(
-                            log_type_map[log_type]["attr"]))
-                        log_obj.addHandler(h)
-                        # Since we've replaced cherrypy's log handler with our
-                        # own, we don't want the output directed to a file.
-                        dest = ""
-                elif dest:
-                        if not os.path.isabs(dest):
-                                dest = os.path.join(pkg_root, dest)
-                gconf[log_type_map[log_type]["param"]] = dest
-
-        cherrypy.config.update(gconf)
-
-        # Now that our logging, etc. has been setup, it's safe to perform any
-        # remaining preparation.
-
-        # Initialize repository state.
-        if not readonly:
-                # Not readonly, so assume a new repository should be created.
-                try:
-                        sr.repository_create(inst_root, properties=repo_props)
-                except sr.RepositoryExistsError:
-                        # Already exists, nothing to do.
-                        pass
-                except (api_errors.ApiException, sr.RepositoryError) as _e:
-                        emsg("pkg.depotd: {0}".format(_e))
-                        sys.exit(1)
-
-        try:
-                sort_file_max_size = dconf.get_property("pkg",
-                    "sort_file_max_size")
-
-                repo = sr.Repository(cfgpathname=repo_config_file,
-                    log_obj=cherrypy, mirror=mirror, properties=repo_props,
-                    read_only=readonly, root=inst_root,
-                    sort_file_max_size=sort_file_max_size,
-                    writable_root=writable_root)
-        except (RuntimeError, sr.RepositoryError) as _e:
-                emsg("pkg.depotd: {0}".format(_e))
-                sys.exit(1)
-        except search_errors.IndexingException as _e:
-                emsg("pkg.depotd: {0}".format(str(_e)), "INDEX")
-                sys.exit(1)
-        except api_errors.ApiException as _e:
-                emsg("pkg.depotd: {0}".format(str(_e)))
-                sys.exit(1)
-
-        if not rebuild and not add_content and not repo.mirror and \
-            not (repo.read_only and not repo.writable_root):
-                # Automatically update search indexes on startup if not already
-                # told to, and not in readonly/mirror mode.
-                reindex = True
-
-        if reindex:
-                try:
-                        # Only execute a index refresh here if --exit-ready was
-                        # requested; it will be handled later in the setup
-                        # process for other cases.
-                        if repo.root and exit_ready:
-                                repo.refresh_index()
-                except (sr.RepositoryError, search_errors.IndexingException,
-                    api_errors.ApiException) as e:
-                        emsg(str(e), "INDEX")
-                        sys.exit(1)
-        elif rebuild:
-                try:
-                        repo.rebuild(build_index=True)
-                except sr.RepositoryError as e:
-                        emsg(str(e), "REBUILD")
-                        sys.exit(1)
-                except (search_errors.IndexingException,
-                    api_errors.UnknownErrors,
-                    api_errors.PermissionsException) as e:
-                        emsg(str(e), "INDEX")
-                        sys.exit(1)
-        elif add_content:
-                try:
-                        repo.add_content()
-                        repo.refresh_index()
-                except sr.RepositoryError as e:
-                        emsg(str(e), "ADD_CONTENT")
-                        sys.exit(1)
-                except (search_errors.IndexingException,
-                    api_errors.UnknownErrors,
-                    api_errors.PermissionsException) as e:
-                        emsg(str(e), "INDEX")
-                        sys.exit(1)
-
-        # Ready to start depot; exit now if requested.
-        if exit_ready:
+        show_usage = False
+        for opt, arg in opts:
+            if opt == "-a":
+                addresses.add(arg)
+            elif opt == "-n":
                 sys.exit(0)
+            elif opt == "-d":
+                ivalues["pkg"]["inst_root"] = arg
+            elif opt == "-p":
+                ivalues["pkg"]["port"] = arg
+            elif opt == "-s":
+                threads = int(arg)
+                if threads < THREADS_MIN:
+                    raise OptionError(
+                        "minimum value is {0:d}".format(THREADS_MIN)
+                    )
+                if threads > THREADS_MAX:
+                    raise OptionError(
+                        "maximum value is {0:d}".format(THREADS_MAX)
+                    )
+                ivalues["pkg"]["threads"] = threads
+            elif opt == "-t":
+                ivalues["pkg"]["socket_timeout"] = arg
+            elif opt == "--add-content":
+                add_content = True
+            elif opt == "--cfg":
+                user_cfg = arg
+            elif opt == "--cfg-file":
+                ivalues["pkg"]["cfg_file"] = arg
+            elif opt == "--content-root":
+                ivalues["pkg"]["content_root"] = arg
+            elif opt == "--debug":
+                if arg is None or arg == "":
+                    continue
 
-        # Next, initialize depot.
-        if nasty:
-                depot = ds.NastyDepotHTTP(repo, dconf)
-        else:
-                depot = ds.DepotHTTP(repo, dconf)
+                # A list of features can be specified using a
+                # "," or any whitespace character as separators.
+                if "," in arg:
+                    features = arg.split(",")
+                else:
+                    features = arg.split()
+                debug_features.extend(features)
 
-        # Now build our site configuration.
-        conf = {
-            "/": {},
-            "/robots.txt": {
-                "tools.staticfile.on": True,
-                "tools.staticfile.filename": os.path.join(depot.web_root,
-                    "robots.txt")
-            },
-        }
-        if list(map(int, version)) >= [3, 2, 0]:
-                conf["/"]["request.dispatch"] = Pkg5Dispatcher()
+                # We also allow key=value debug flags, which
+                # get set in pkg.client.debugvalues
+                for feature in features:
+                    try:
+                        key, val = feature.split("=", 1)
+                        DebugValues.set_value(key, val)
+                    except (AttributeError, ValueError):
+                        pass
 
-        proxy_base = dconf.get_property("pkg", "proxy_base")
-        if proxy_base:
-                # This changes the base URL for our server, and is primarily
-                # intended to allow our depot process to operate behind Apache
-                # or some other webserver process.
+            elif opt == "--disable-ops":
+                if arg is None or arg == "":
+                    raise OptionError("An argument must be specified.")
+
+                disableops = arg.split(",")
+                for s in disableops:
+                    if "/" in s:
+                        op, ver = s.rsplit("/", 1)
+                    else:
+                        op = s
+                        ver = "*"
+
+                    if op not in ds.DepotHTTP.REPO_OPS_DEFAULT:
+                        raise OptionError(
+                            "Invalid operation " "'{0}'.".format(s)
+                        )
+                    disable_ops.append(s)
+            elif opt == "--exit-ready":
+                exit_ready = True
+            elif opt == "--image-root":
+                ivalues["pkg"]["image_root"] = arg
+            elif opt.startswith("--log-"):
+                prop = "log_{0}".format(opt.lstrip("--log-"))
+                ivalues["pkg"][prop] = arg
+            elif opt in ("--help", "-?"):
+                show_usage = True
+            elif opt == "--mirror":
+                ivalues["pkg"]["mirror"] = True
+            elif opt == "--llmirror":
+                ivalues["pkg"]["mirror"] = True
+                ivalues["pkg"]["ll_mirror"] = True
+                ivalues["pkg"]["readonly"] = True
+            elif opt == "--nasty":
+                # ValueError is caught by caller.
+                nasty_value = int(arg)
+                if nasty_value > 100 or nasty_value < 1:
+                    raise OptionError(
+                        "Invalid value "
+                        "for nasty option.\n Please "
+                        "choose a value between 1 and 100."
+                    )
+                nasty = True
+                ivalues["nasty"]["nasty_level"] = nasty_value
+            elif opt == "--nasty-sleep":
+                # ValueError is caught by caller.
+                sleep_value = int(arg)
+                ivalues["nasty"]["nasty_sleep"] = sleep_value
+            elif opt == "--proxy-base":
+                # Attempt to decompose the url provided into
+                # its base parts.  This is done so we can
+                # remove any scheme information since we
+                # don't need it.
+                scheme, netloc, path, params, query, fragment = urlparse(
+                    arg, "http", allow_fragments=0
+                )
+
+                if not netloc:
+                    raise OptionError(
+                        "Unable to "
+                        "determine the hostname from "
+                        "the provided URL; please use a "
+                        "fully qualified URL."
+                    )
+
+                scheme = scheme.lower()
+                if scheme not in ("http", "https"):
+                    raise OptionError(
+                        "Invalid URL; http "
+                        "and https are the only supported "
+                        "schemes."
+                    )
+
+                # Rebuild the url with the sanitized components.
+                ivalues["pkg"]["proxy_base"] = urlunparse(
+                    (scheme, netloc, path, params, query, fragment)
+                )
+            elif opt == "--readonly":
+                ivalues["pkg"]["readonly"] = True
+            elif opt == "--rebuild":
+                rebuild = True
+            elif opt == "--refresh-index":
+                # Note: This argument is for internal use
+                # only.
                 #
-                # Visit the following URL for more information:
-                #    http://cherrypy.org/wiki/BuiltinTools#tools.proxy
-                proxy_conf = {
-                        "tools.proxy.on": True,
-                        "tools.proxy.local": "",
-                        "tools.proxy.base": proxy_base
-                }
+                # This flag is purposefully omitted in usage.
+                # The supported way to forcefully reindex is to
+                # kill any pkg.depot using that directory,
+                # remove the index directory, and restart the
+                # pkg.depot process. The index will be rebuilt
+                # automatically on startup.
+                reindex = True
+                exit_ready = True
+            elif opt == "--set-property":
+                try:
+                    prop, p_value = arg.split("=", 1)
+                    p_sec, p_name = prop.split(".", 1)
+                except ValueError:
+                    usage(
+                        _(
+                            "property arguments must be of "
+                            "the form '<section.property>="
+                            "<value>'."
+                        )
+                    )
+                repo_props.setdefault(p_sec, {})
+                repo_props[p_sec][p_name] = p_value
+            elif opt == "--ssl-cert-file":
+                if arg == "none" or arg == "":
+                    # Assume this is an override to clear
+                    # the value.
+                    arg = ""
+                elif not os.path.isabs(arg):
+                    raise OptionError(
+                        "The path to "
+                        "the Certificate file must be "
+                        "absolute."
+                    )
+                elif not os.path.exists(arg):
+                    raise OptionError("The specified " "file does not exist.")
+                elif not os.path.isfile(arg):
+                    raise OptionError(
+                        "The specified " "pathname is not a file."
+                    )
+                ivalues["pkg"]["ssl_cert_file"] = arg
+            elif opt == "--ssl-key-file":
+                if arg == "none" or arg == "":
+                    # Assume this is an override to clear
+                    # the value.
+                    arg = ""
+                elif not os.path.isabs(arg):
+                    raise OptionError(
+                        "The path to "
+                        "the Private Key file must be "
+                        "absolute."
+                    )
+                elif not os.path.exists(arg):
+                    raise OptionError("The specified " "file does not exist.")
+                elif not os.path.isfile(arg):
+                    raise OptionError(
+                        "The specified " "pathname is not a file."
+                    )
+                ivalues["pkg"]["ssl_key_file"] = arg
+            elif opt == "--ssl-dialog":
+                if (
+                    arg != "builtin"
+                    and arg != "smf"
+                    and not arg.startswith("exec:/")
+                    and not arg.startswith("svc:")
+                ):
+                    raise OptionError(
+                        "Invalid value "
+                        "specified.  Expected: builtin, "
+                        "exec:/path/to/program, smf, or "
+                        "an SMF FMRI."
+                    )
 
-                # Now merge or add our proxy configuration information into the
-                # existing configuration.
-                for entry in proxy_conf:
-                        conf["/"][entry] = proxy_conf[entry]
+                if arg.startswith("exec:"):
+                    if os_util.get_canonical_os_type() != "unix":
+                        # Don't allow a somewhat
+                        # insecure authentication method
+                        # on some platforms.
+                        raise OptionError(
+                            "exec is "
+                            "not a supported dialog "
+                            "type for this operating "
+                            "system."
+                        )
 
-        if ll_mirror:
-                ds.DNSSD_Plugin(cherrypy.engine, gconf).subscribe()
+                    f = os.path.abspath(arg.split("exec:")[1])
+                    if not os.path.isfile(f):
+                        raise OptionError(
+                            "Invalid " "file path specified for " "exec."
+                        )
+                ivalues["pkg"]["ssl_dialog"] = arg
+            elif opt == "--sort-file-max-size":
+                ivalues["pkg"]["sort_file_max_size"] = arg
+            elif opt == "--writable-root":
+                ivalues["pkg"]["writable_root"] = arg
 
-        if reindex:
-                # Tell depot to update search indexes when possible;
-                # this is done as a background task so that packages
-                # can be served immediately while search indexes are
-                # still being updated.
-                depot._queue_refresh_index()
+        # Set accumulated values.
+        if debug_features:
+            ivalues["pkg"]["debug"] = debug_features
+        if disable_ops:
+            ivalues["pkg"]["disable_ops"] = disable_ops
+        if addresses:
+            ivalues["pkg"]["address"] = list(addresses)
 
-        # If stdin is not a tty and the pkgdepot controller isn't being used,
-        # then assume process should be daemonized.
-        if not os.environ.get("PKGDEPOT_CONTROLLER") and \
-            not os.isatty(sys.stdin.fileno()):
-                # Translate the values in log_cfg into paths.
-                Daemonizer(cherrypy.engine, stderr=log_cfg["errors"],
-                    stdout=log_cfg["access"]).subscribe()
+        if DebugValues:
+            reload(pkg.digest)
 
+        # Build configuration object.
+        dconf = ds.DepotConfig(target=user_cfg, overrides=ivalues)
+    except getopt.GetoptError as _e:
+        usage("pkg.depotd: {0}".format(_e.msg))
+    except api_errors.ApiException as _e:
+        usage("pkg.depotd: {0}".format(str(_e)))
+    except OptionError as _e:
+        usage("pkg.depotd: option: {0} -- {1}".format(opt, _e))
+    except (ArithmeticError, ValueError):
+        usage(
+            "pkg.depotd: illegal option value: {0} specified "
+            "for option: {1}".format(arg, opt)
+        )
+
+    if show_usage:
+        usage(retcode=0, full=True)
+
+    if not dconf.get_property("pkg", "log_errors"):
+        dconf.set_property("pkg", "log_errors", "stderr")
+
+    # If stdout is a tty, then send access output there by default instead
+    # of discarding it.
+    if not dconf.get_property("pkg", "log_access"):
+        if os.isatty(sys.stdout.fileno()):
+            dconf.set_property("pkg", "log_access", "stdout")
+        else:
+            dconf.set_property("pkg", "log_access", "none")
+
+    # Check for invalid option combinations.
+    image_root = dconf.get_property("pkg", "image_root")
+    inst_root = dconf.get_property("pkg", "inst_root")
+    mirror = dconf.get_property("pkg", "mirror")
+    ll_mirror = dconf.get_property("pkg", "ll_mirror")
+    readonly = dconf.get_property("pkg", "readonly")
+    writable_root = dconf.get_property("pkg", "writable_root")
+    if rebuild and add_content:
+        usage("--add-content cannot be used with --rebuild")
+    if rebuild and reindex:
+        usage("--refresh-index cannot be used with --rebuild")
+    if (rebuild or add_content) and (readonly or mirror):
+        usage(
+            "--readonly and --mirror cannot be used with --rebuild "
+            "or --add-content"
+        )
+    if reindex and mirror:
+        usage("--mirror cannot be used with --refresh-index")
+    if reindex and readonly and not writable_root:
+        usage(
+            "--readonly can only be used with --refresh-index if "
+            "--writable-root is used"
+        )
+    if image_root and not ll_mirror:
+        usage("--image-root can only be used with --llmirror.")
+    if image_root and writable_root:
+        usage("--image_root and --writable-root cannot be used " "together.")
+    if image_root and inst_root:
+        usage("--image-root and -d cannot be used together.")
+
+    # If the image format changes this may need to be reexamined.
+    if image_root:
+        inst_root = os.path.join(image_root, "var", "pkg")
+
+    # Set any values using defaults if they weren't provided.
+
+    # Only use the first value for now; multiple bind addresses may be
+    # supported later.
+    address = dconf.get_property("pkg", "address")
+    if address:
+        address = address[0]
+    elif not address:
+        dconf.set_property("pkg", "address", [HOST_DEFAULT])
+        address = dconf.get_property("pkg", "address")[0]
+
+    if not inst_root:
+        usage("Either PKG_REPO or -d must be provided")
+
+    content_root = dconf.get_property("pkg", "content_root")
+    if not content_root:
+        dconf.set_property("pkg", "content_root", CONTENT_PATH_DEFAULT)
+        content_root = dconf.get_property("pkg", "content_root")
+
+    port = dconf.get_property("pkg", "port")
+    ssl_cert_file = dconf.get_property("pkg", "ssl_cert_file")
+    ssl_key_file = dconf.get_property("pkg", "ssl_key_file")
+    if (ssl_cert_file and not ssl_key_file) or (
+        ssl_key_file and not ssl_cert_file
+    ):
+        usage(
+            "The --ssl-cert-file and --ssl-key-file options must "
+            "must both be provided when using either option."
+        )
+    elif not port:
+        if ssl_cert_file and ssl_key_file:
+            dconf.set_property("pkg", "port", SSL_PORT_DEFAULT)
+        else:
+            dconf.set_property("pkg", "port", PORT_DEFAULT)
+        port = dconf.get_property("pkg", "port")
+
+    socket_timeout = dconf.get_property("pkg", "socket_timeout")
+    if not socket_timeout:
+        dconf.set_property("pkg", "socket_timeout", SOCKET_TIMEOUT_DEFAULT)
+        socket_timeout = dconf.get_property("pkg", "socket_timeout")
+
+    threads = dconf.get_property("pkg", "threads")
+    if not threads:
+        dconf.set_property("pkg", "threads", THREADS_DEFAULT)
+        threads = dconf.get_property("pkg", "threads")
+
+    # If the program is going to reindex, the port is irrelevant since
+    # the program will not bind to a port.
+    if not exit_ready:
         try:
-                root = cherrypy.Application(depot)
-                cherrypy.quickstart(root, config=conf)
-        except Exception as _e:
-                emsg("pkg.depotd: unknown error starting depot server, " \
-                    "illegal option value specified?")
-                emsg(_e)
+            portend.Checker().assert_free(address, port)
+        except Exception as e:
+            emsg(
+                "pkg.depotd: unable to bind to the specified "
+                "port: {0:d}. Reason: {1}".format(port, e)
+            )
+            sys.exit(1)
+    else:
+        # Not applicable if we're not going to serve content
+        dconf.set_property("pkg", "content_root", "")
+
+    # Any relative paths should be made absolute using pkg_root.  'pkg_root'
+    # is a special property that was added to enable internal deployment of
+    # multiple disparate versions of the pkg.depotd software.
+    pkg_root = dconf.get_property("pkg", "pkg_root")
+
+    repo_config_file = dconf.get_property("pkg", "cfg_file")
+    if repo_config_file and not os.path.isabs(repo_config_file):
+        repo_config_file = os.path.join(pkg_root, repo_config_file)
+
+    if content_root and not os.path.isabs(content_root):
+        content_root = os.path.join(pkg_root, content_root)
+
+    if inst_root and not os.path.isabs(inst_root):
+        inst_root = os.path.join(pkg_root, inst_root)
+
+    if ssl_cert_file:
+        if ssl_cert_file == "none":
+            ssl_cert_file = None
+        elif not os.path.isabs(ssl_cert_file):
+            ssl_cert_file = os.path.join(pkg_root, ssl_cert_file)
+
+    if ssl_key_file:
+        if ssl_key_file == "none":
+            ssl_key_file = None
+        elif not os.path.isabs(ssl_key_file):
+            ssl_key_file = os.path.join(pkg_root, ssl_key_file)
+
+    if writable_root and not os.path.isabs(writable_root):
+        writable_root = os.path.join(pkg_root, writable_root)
+
+    # Setup SSL if requested.
+    key_data = None
+    ssl_dialog = dconf.get_property("pkg", "ssl_dialog")
+    if (
+        not exit_ready
+        and ssl_cert_file
+        and ssl_key_file
+        and ssl_dialog != "builtin"
+    ):
+        cmdline = None
+
+        def get_ssl_passphrase(*ignored):
+            p = None
+            try:
+                if cmdline:
+                    cmdargs = shlex.split(cmdline)
+                else:
+                    cmdargs = []
+                p = subprocess.Popen(
+                    cmdargs, stdout=subprocess.PIPE, stderr=None
+                )
+                p.wait()
+            except Exception as __e:
+                emsg(
+                    "pkg.depotd: an error occurred while "
+                    "executing [{0}]; unable to obtain the "
+                    "passphrase needed to decrypt the SSL "
+                    "private key file: {1}".format(cmdline, __e)
+                )
                 sys.exit(1)
+            return p.stdout.read().strip(b"\n")
+
+        if ssl_dialog.startswith("exec:"):
+            exec_path = ssl_dialog.split("exec:")[1]
+            if not os.path.isabs(exec_path):
+                exec_path = os.path.join(pkg_root, exec_path)
+            cmdline = "{0} {1} {2:d}".format(exec_path, "''", port)
+        elif ssl_dialog == "smf" or ssl_dialog.startswith("svc:"):
+            if ssl_dialog == "smf":
+                # Assume the configuration target was an SMF
+                # FMRI and let svcprop fail with an error if
+                # it wasn't.
+                svc_fmri = dconf.target
+            else:
+                svc_fmri = ssl_dialog
+            cmdline = (
+                "/usr/bin/svcprop -p "
+                "pkg_secure/ssl_key_passphrase {0}".format(svc_fmri)
+            )
+
+        # The key file requires decryption, but the user has requested
+        # exec-based authentication, so it will have to be decoded first
+        # to an un-named temporary file.
+        try:
+            with open(ssl_key_file, "rb") as key_file:
+                pkey = crypto.load_privatekey(
+                    crypto.FILETYPE_PEM, key_file.read(), get_ssl_passphrase
+                )
+
+            key_data = tempfile.NamedTemporaryFile(dir=pkg_root, delete=True)
+            key_data.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey))
+            key_data.seek(0)
+        except EnvironmentError as _e:
+            emsg(
+                "pkg.depotd: unable to read the SSL private key "
+                "file: {0}".format(_e)
+            )
+            sys.exit(1)
+        except crypto.Error as _e:
+            emsg(
+                "pkg.depotd: authentication or cryptography "
+                "failure while attempting to decode\nthe SSL "
+                "private key file: {0}".format(_e)
+            )
+            sys.exit(1)
+        else:
+            # Redirect the server to the decrypted key file.
+            ssl_key_file = key_data.name
+
+    # Setup our global configuration.
+    gconf = {
+        "checker.on": True,
+        "environment": "production",
+        "log.screen": False,
+        "server.max_request_body_size": MAX_REQUEST_BODY_SIZE,
+        "server.shutdown_timeout": 0,
+        "server.socket_host": address,
+        "server.socket_port": port,
+        "server.socket_timeout": socket_timeout,
+        "server.ssl_certificate": ssl_cert_file,
+        "server.ssl_private_key": ssl_key_file,
+        "server.thread_pool": threads,
+        "tools.log_headers.on": True,
+        "tools.encode.on": True,
+        "tools.encode.encoding": "utf-8",
+        "tools.secureheaders.on": True,
+    }
+
+    if "headers" in dconf.get_property("pkg", "debug"):
+        # Despite its name, this only logs headers when there is an
+        # error; it's redundant with the debug feature enabled.
+        gconf["tools.log_headers.on"] = False
+
+        # Causes the headers of every request to be logged to the error
+        # log; even if an exception occurs.
+        gconf["tools.log_headers_always.on"] = True
+        cherrypy.tools.log_headers_always = cherrypy.Tool(
+            "on_start_resource", cherrypy.lib.cptools.log_request_headers
+        )
+
+    log_cfg = {
+        "access": dconf.get_property("pkg", "log_access"),
+        "errors": dconf.get_property("pkg", "log_errors"),
+    }
+
+    # If stdin is not a tty and the pkgdepot controller isn't being used,
+    # then assume process will be daemonized and redirect output.
+    if not os.environ.get("PKGDEPOT_CONTROLLER") and not os.isatty(
+        sys.stdin.fileno()
+    ):
+        # Ensure log handlers are setup to use the file descriptors for
+        # stdout and stderr as the Daemonizer (used for test suite and
+        # SMF service) requires this.
+        if log_cfg["access"] == "stdout":
+            log_cfg["access"] = "/dev/fd/{0:d}".format(sys.stdout.fileno())
+        elif log_cfg["access"] == "stderr":
+            log_cfg["access"] = "/dev/fd/{0:d}".format(sys.stderr.fileno())
+        elif log_cfg["access"] == "none":
+            log_cfg["access"] = "/dev/null"
+
+        if log_cfg["errors"] == "stderr":
+            log_cfg["errors"] = "/dev/fd/{0:d}".format(sys.stderr.fileno())
+        elif log_cfg["errors"] == "stdout":
+            log_cfg["errors"] = "/dev/fd/{0:d}".format(sys.stdout.fileno())
+        elif log_cfg["errors"] == "none":
+            log_cfg["errors"] = "/dev/null"
+
+    log_type_map = {
+        "errors": {"param": "log.error_file", "attr": "error_log"},
+        "access": {"param": "log.access_file", "attr": "access_log"},
+    }
+
+    for log_type in log_type_map:
+        dest = log_cfg[log_type]
+        if dest in ("stdout", "stderr", "none"):
+            if dest == "none":
+                h = logging.StreamHandler(LogSink())
+            else:
+                h = logging.StreamHandler(eval("sys.{0}".format(dest)))
+
+            h.setLevel(logging.DEBUG)
+            h.setFormatter(cherrypy._cplogging.logfmt)
+            log_obj = eval(
+                "cherrypy.log.{0}".format(log_type_map[log_type]["attr"])
+            )
+            log_obj.addHandler(h)
+            # Since we've replaced cherrypy's log handler with our
+            # own, we don't want the output directed to a file.
+            dest = ""
+        elif dest:
+            if not os.path.isabs(dest):
+                dest = os.path.join(pkg_root, dest)
+        gconf[log_type_map[log_type]["param"]] = dest
+
+    cherrypy.config.update(gconf)
+
+    # Now that our logging, etc. has been setup, it's safe to perform any
+    # remaining preparation.
+
+    # Initialize repository state.
+    if not readonly:
+        # Not readonly, so assume a new repository should be created.
+        try:
+            sr.repository_create(inst_root, properties=repo_props)
+        except sr.RepositoryExistsError:
+            # Already exists, nothing to do.
+            pass
+        except (api_errors.ApiException, sr.RepositoryError) as _e:
+            emsg("pkg.depotd: {0}".format(_e))
+            sys.exit(1)
+
+    try:
+        sort_file_max_size = dconf.get_property("pkg", "sort_file_max_size")
+
+        repo = sr.Repository(
+            cfgpathname=repo_config_file,
+            log_obj=cherrypy,
+            mirror=mirror,
+            properties=repo_props,
+            read_only=readonly,
+            root=inst_root,
+            sort_file_max_size=sort_file_max_size,
+            writable_root=writable_root,
+        )
+    except (RuntimeError, sr.RepositoryError) as _e:
+        emsg("pkg.depotd: {0}".format(_e))
+        sys.exit(1)
+    except search_errors.IndexingException as _e:
+        emsg("pkg.depotd: {0}".format(str(_e)), "INDEX")
+        sys.exit(1)
+    except api_errors.ApiException as _e:
+        emsg("pkg.depotd: {0}".format(str(_e)))
+        sys.exit(1)
+
+    if (
+        not rebuild
+        and not add_content
+        and not repo.mirror
+        and not (repo.read_only and not repo.writable_root)
+    ):
+        # Automatically update search indexes on startup if not already
+        # told to, and not in readonly/mirror mode.
+        reindex = True
+
+    if reindex:
+        try:
+            # Only execute a index refresh here if --exit-ready was
+            # requested; it will be handled later in the setup
+            # process for other cases.
+            if repo.root and exit_ready:
+                repo.refresh_index()
+        except (
+            sr.RepositoryError,
+            search_errors.IndexingException,
+            api_errors.ApiException,
+        ) as e:
+            emsg(str(e), "INDEX")
+            sys.exit(1)
+    elif rebuild:
+        try:
+            repo.rebuild(build_index=True)
+        except sr.RepositoryError as e:
+            emsg(str(e), "REBUILD")
+            sys.exit(1)
+        except (
+            search_errors.IndexingException,
+            api_errors.UnknownErrors,
+            api_errors.PermissionsException,
+        ) as e:
+            emsg(str(e), "INDEX")
+            sys.exit(1)
+    elif add_content:
+        try:
+            repo.add_content()
+            repo.refresh_index()
+        except sr.RepositoryError as e:
+            emsg(str(e), "ADD_CONTENT")
+            sys.exit(1)
+        except (
+            search_errors.IndexingException,
+            api_errors.UnknownErrors,
+            api_errors.PermissionsException,
+        ) as e:
+            emsg(str(e), "INDEX")
+            sys.exit(1)
+
+    # Ready to start depot; exit now if requested.
+    if exit_ready:
+        sys.exit(0)
+
+    # Next, initialize depot.
+    if nasty:
+        depot = ds.NastyDepotHTTP(repo, dconf)
+    else:
+        depot = ds.DepotHTTP(repo, dconf)
+
+    # Now build our site configuration.
+    conf = {
+        "/": {},
+        "/robots.txt": {
+            "tools.staticfile.on": True,
+            "tools.staticfile.filename": os.path.join(
+                depot.web_root, "robots.txt"
+            ),
+        },
+    }
+    if list(map(int, version)) >= [3, 2, 0]:
+        conf["/"]["request.dispatch"] = Pkg5Dispatcher()
+
+    proxy_base = dconf.get_property("pkg", "proxy_base")
+    if proxy_base:
+        # This changes the base URL for our server, and is primarily
+        # intended to allow our depot process to operate behind Apache
+        # or some other webserver process.
+        #
+        # Visit the following URL for more information:
+        #    http://cherrypy.org/wiki/BuiltinTools#tools.proxy
+        proxy_conf = {
+            "tools.proxy.on": True,
+            "tools.proxy.local": "",
+            "tools.proxy.base": proxy_base,
+        }
+
+        # Now merge or add our proxy configuration information into the
+        # existing configuration.
+        for entry in proxy_conf:
+            conf["/"][entry] = proxy_conf[entry]
+
+    if ll_mirror:
+        ds.DNSSD_Plugin(cherrypy.engine, gconf).subscribe()
+
+    if reindex:
+        # Tell depot to update search indexes when possible;
+        # this is done as a background task so that packages
+        # can be served immediately while search indexes are
+        # still being updated.
+        depot._queue_refresh_index()
+
+    # If stdin is not a tty and the pkgdepot controller isn't being used,
+    # then assume process should be daemonized.
+    if not os.environ.get("PKGDEPOT_CONTROLLER") and not os.isatty(
+        sys.stdin.fileno()
+    ):
+        # Translate the values in log_cfg into paths.
+        Daemonizer(
+            cherrypy.engine, stderr=log_cfg["errors"], stdout=log_cfg["access"]
+        ).subscribe()
+
+    try:
+        root = cherrypy.Application(depot)
+        cherrypy.quickstart(root, config=conf)
+    except Exception as _e:
+        emsg(
+            "pkg.depotd: unknown error starting depot server, "
+            "illegal option value specified?"
+        )
+        emsg(_e)
+        sys.exit(1)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/__init__.py
+++ b/src/modules/__init__.py
@@ -26,4 +26,4 @@
 VERSION = "unknown"
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/__init__.py
+++ b/src/modules/actions/__init__.py
@@ -49,9 +49,9 @@ import os
 # All modules in this package (all python files except __init__.py with their
 # extensions stripped off).
 __all__ = [
-        f[:-3]
-            for f in os.listdir(__path__[0])
-            if f.endswith(".py") and f != "__init__.py"
+    f[:-3]
+    for f in os.listdir(__path__[0])
+    if f.endswith(".py") and f != "__init__.py"
 ]
 
 # A dictionary of all the types in this package, mapping to the classes that
@@ -64,364 +64,406 @@ types = {}
 payload_types = {}
 
 for modname in __all__:
-        module = __import__("{0}.{1}".format(__name__, modname),
-            globals(), locals(), [modname])
+    module = __import__(
+        "{0}.{1}".format(__name__, modname), globals(), locals(), [modname]
+    )
 
-        nvlist = inspect.getmembers(module, inspect.isclass)
+    nvlist = inspect.getmembers(module, inspect.isclass)
 
-        # Pull the class objects out of nvlist, keeping only those that are
-        # actually defined in this package.
-        classes = [
-                c[1]
-                    for c in nvlist
-                    if '.'.join(c[1].__module__.split('.')[:-1]) == __name__
-        ]
-        for cls in classes:
-                if hasattr(cls, "name"):
-                        types[cls.name] = cls
-                if hasattr(cls, "has_payload") and cls.has_payload:
-                        payload_types[cls.name] = cls
+    # Pull the class objects out of nvlist, keeping only those that are
+    # actually defined in this package.
+    classes = [
+        c[1]
+        for c in nvlist
+        if ".".join(c[1].__module__.split(".")[:-1]) == __name__
+    ]
+    for cls in classes:
+        if hasattr(cls, "name"):
+            types[cls.name] = cls
+        if hasattr(cls, "has_payload") and cls.has_payload:
+            payload_types[cls.name] = cls
 
 # Clean up after ourselves
 del modname, module, nvlist, classes, cls
 
 
 class ActionError(Exception):
-        """Base exception class for Action errors."""
+    """Base exception class for Action errors."""
 
-        def __str__(self):
-                raise NotImplementedError()
+    def __str__(self):
+        raise NotImplementedError()
+
 
 class ActionRetry(ActionError):
-        def __init__(self, *args):
-                ActionError.__init__(self)
-                self.actionstr = str(args[0])
+    def __init__(self, *args):
+        ActionError.__init__(self)
+        self.actionstr = str(args[0])
 
-        def __str__(self):
-                return _("Need to try installing {action} again").format(
-                    action=self.actionstr)
+    def __str__(self):
+        return _("Need to try installing {action} again").format(
+            action=self.actionstr
+        )
+
 
 class UnknownActionError(ActionError):
-        def __init__(self, *args):
-                ActionError.__init__(self)
-                self.actionstr = args[0]
-                self.type = args[1]
+    def __init__(self, *args):
+        ActionError.__init__(self)
+        self.actionstr = args[0]
+        self.type = args[1]
 
-        def __str__(self):
-                if hasattr(self, "fmri") and self.fmri is not None:
-                        return _("unknown action type '{type}' in package "
-                            "'{fmri}' in action '{action}'").format(
-                            type=self.type, fmri=self.fmri,
-                            action=self.actionstr)
-                return _("unknown action type '{type}' in action "
-                    "'{action}'").format(type=self.type,
-                    action=self.actionstr)
+    def __str__(self):
+        if hasattr(self, "fmri") and self.fmri is not None:
+            return _(
+                "unknown action type '{type}' in package "
+                "'{fmri}' in action '{action}'"
+            ).format(type=self.type, fmri=self.fmri, action=self.actionstr)
+        return _("unknown action type '{type}' in action " "'{action}'").format(
+            type=self.type, action=self.actionstr
+        )
+
 
 class MalformedActionError(ActionError):
-        def __init__(self, *args):
-                ActionError.__init__(self)
-                self.actionstr = args[0]
-                self.position = args[1]
-                self.errorstr = args[2]
+    def __init__(self, *args):
+        ActionError.__init__(self)
+        self.actionstr = args[0]
+        self.position = args[1]
+        self.errorstr = args[2]
 
-        def __str__(self):
-                marker = " " * (4 + self.position) + "^"
-                if hasattr(self, "fmri") and self.fmri is not None:
-                        return _("Malformed action in package '{fmri}' at "
-                            "position: {pos:d}: {error}:\n    {action}\n"
-                            "{marker}").format(fmri=self.fmri,
-                            pos=self.position, action=self.actionstr,
-                            marker=marker, error=self.errorstr)
-                return _("Malformed action at position: {pos:d}: {error}:\n    "
-                    "{action}\n{marker}").format(pos=self.position,
-                    action=self.actionstr, marker=marker,
-                    error=self.errorstr)
+    def __str__(self):
+        marker = " " * (4 + self.position) + "^"
+        if hasattr(self, "fmri") and self.fmri is not None:
+            return _(
+                "Malformed action in package '{fmri}' at "
+                "position: {pos:d}: {error}:\n    {action}\n"
+                "{marker}"
+            ).format(
+                fmri=self.fmri,
+                pos=self.position,
+                action=self.actionstr,
+                marker=marker,
+                error=self.errorstr,
+            )
+        return _(
+            "Malformed action at position: {pos:d}: {error}:\n    "
+            "{action}\n{marker}"
+        ).format(
+            pos=self.position,
+            action=self.actionstr,
+            marker=marker,
+            error=self.errorstr,
+        )
 
 
 class ActionDataError(ActionError):
-        """Used to indicate that a file-related error occuring during action
-        initialization."""
+    """Used to indicate that a file-related error occuring during action
+    initialization."""
 
-        def __init__(self, *args, **kwargs):
-                ActionError.__init__(self)
-                self.error = args[0]
-                self.path = kwargs.get("path", None)
+    def __init__(self, *args, **kwargs):
+        ActionError.__init__(self)
+        self.error = args[0]
+        self.path = kwargs.get("path", None)
 
-        def __str__(self):
-                return str(self.error)
+    def __str__(self):
+        return str(self.error)
 
 
 class InvalidActionError(ActionError):
-        """Used to indicate that attributes provided were invalid, or required
-        attributes were missing for an action."""
+    """Used to indicate that attributes provided were invalid, or required
+    attributes were missing for an action."""
 
-        def __init__(self, *args):
-                ActionError.__init__(self)
-                self.actionstr = args[0]
-                self.errorstr = args[1]
+    def __init__(self, *args):
+        ActionError.__init__(self)
+        self.actionstr = args[0]
+        self.errorstr = args[1]
 
-        def __str__(self):
-                if hasattr(self, "fmri") and self.fmri is not None:
-                        return _("invalid action in package {fmri}: "
-                            "{action}: {error}").format(fmri=self.fmri,
-                            action=self.actionstr, error=self.errorstr)
-                return _("invalid action, '{action}': {error}").format(
-                        action=self.actionstr, error=self.errorstr)
+    def __str__(self):
+        if hasattr(self, "fmri") and self.fmri is not None:
+            return _(
+                "invalid action in package {fmri}: " "{action}: {error}"
+            ).format(fmri=self.fmri, action=self.actionstr, error=self.errorstr)
+        return _("invalid action, '{action}': {error}").format(
+            action=self.actionstr, error=self.errorstr
+        )
 
 
 class MissingKeyAttributeError(InvalidActionError):
-        """Used to indicate that an action's key attribute is missing."""
+    """Used to indicate that an action's key attribute is missing."""
 
-        def __init__(self, *args):
-                InvalidActionError.__init__(self, str(args[0]),
-                    _("no value specified for key attribute '{0}'").format(
-                    args[1]))
+    def __init__(self, *args):
+        InvalidActionError.__init__(
+            self,
+            str(args[0]),
+            _("no value specified for key attribute '{0}'").format(args[1]),
+        )
 
 
 class KeyAttributeMultiValueError(InvalidActionError):
-        """Used to indicate that an action's key attribute was specified
-        multiple times for an action that expects it only once."""
+    """Used to indicate that an action's key attribute was specified
+    multiple times for an action that expects it only once."""
 
-        def __init__(self, *args):
-                InvalidActionError.__init__(self, str(args[0]),
-                    _("{0} attribute may only be specified once").format(
-                    args[1]))
+    def __init__(self, *args):
+        InvalidActionError.__init__(
+            self,
+            str(args[0]),
+            _("{0} attribute may only be specified once").format(args[1]),
+        )
 
 
 class InvalidPathAttributeError(InvalidActionError):
-        """Used to indicate that an action's path attribute value was either
-        empty, '/', or not a string."""
+    """Used to indicate that an action's path attribute value was either
+    empty, '/', or not a string."""
 
-        def __init__(self, *args):
-                InvalidActionError.__init__(self, str(args[0]),
-                    _("Empty or invalid path attribute"))
+    def __init__(self, *args):
+        InvalidActionError.__init__(
+            self, str(args[0]), _("Empty or invalid path attribute")
+        )
 
 
 class InvalidActionAttributesError(ActionError):
-        """Used to indicate that one or more action attributes were invalid."""
+    """Used to indicate that one or more action attributes were invalid."""
 
-        def __init__(self, act, errors, fmri=None):
-                """'act' is an Action (object or string).
+    def __init__(self, act, errors, fmri=None):
+        """'act' is an Action (object or string).
 
-                'errors' is a list of tuples of the form (name, error) where
-                'name' is the action attribute name, and 'error' is a string
-                indicating what attribute is invalid and why.
+        'errors' is a list of tuples of the form (name, error) where
+        'name' is the action attribute name, and 'error' is a string
+        indicating what attribute is invalid and why.
 
-                'fmri' is an optional package FMRI (object or string)
-                indicating what package contained the actions with invalid
-                attributes."""
+        'fmri' is an optional package FMRI (object or string)
+        indicating what package contained the actions with invalid
+        attributes."""
 
-                ActionError.__init__(self)
-                self.action = act
-                self.errors = errors
-                self.fmri = fmri
+        ActionError.__init__(self)
+        self.action = act
+        self.errors = errors
+        self.fmri = fmri
 
-        def __str__(self):
-                act_errors = "\n  ".join(err for name, err in self.errors)
-                if self.fmri:
-                        return _("The action '{action}' in package "
-                            "'{fmri}' has invalid attribute(s):\n"
-                            "  {act_errors}").format(action=self.action,
-                            fmri=self.fmri, act_errors=act_errors)
-                return _("The action '{action}' has invalid attribute(s):\n"
-                    "  {act_errors}").format(action=self.action,
-                    act_errors=act_errors)
+    def __str__(self):
+        act_errors = "\n  ".join(err for name, err in self.errors)
+        if self.fmri:
+            return _(
+                "The action '{action}' in package "
+                "'{fmri}' has invalid attribute(s):\n"
+                "  {act_errors}"
+            ).format(action=self.action, fmri=self.fmri, act_errors=act_errors)
+        return _(
+            "The action '{action}' has invalid attribute(s):\n" "  {act_errors}"
+        ).format(action=self.action, act_errors=act_errors)
 
 
 # This must be imported *after* all of the exception classes are defined as
 # _actions module init needs the exception objects.
 from ._actions import fromstr
 
-def attrsfromstr(string):
-        """Create an attribute dict given a string w/ key=value pairs.
 
-        Raises MalformedActionError if the attributes have syntactic problems.
-        """
-        return fromstr("unknown {0}".format(string)).attrs
+def attrsfromstr(string):
+    """Create an attribute dict given a string w/ key=value pairs.
+
+    Raises MalformedActionError if the attributes have syntactic problems.
+    """
+    return fromstr("unknown {0}".format(string)).attrs
+
 
 def internalizelist(atype, args, ahash=None, basedirs=None):
-        """Create an action instance based on a sequence of "key=value" strings.
-        This function also translates external representations of actions with
-        payloads (like file and license which can use NOHASH or file paths to
-        point to the payload) to an internal representation which sets the
-        data field of the action returned.
+    """Create an action instance based on a sequence of "key=value" strings.
+    This function also translates external representations of actions with
+    payloads (like file and license which can use NOHASH or file paths to
+    point to the payload) to an internal representation which sets the
+    data field of the action returned.
 
-        The "atype" parameter is the type of action to be built.
+    The "atype" parameter is the type of action to be built.
 
-        The "args" parameter is the sequence of "key=value" strings.
+    The "args" parameter is the sequence of "key=value" strings.
 
-        The "ahash" parameter is used to set the hash value for the action.
+    The "ahash" parameter is used to set the hash value for the action.
 
-        The "basedirs" parameter is the list of directories to look in to find
-        any payload for the action.
+    The "basedirs" parameter is the list of directories to look in to find
+    any payload for the action.
 
-        Raises MalformedActionError if the attribute strings are malformed.
-        """
+    Raises MalformedActionError if the attribute strings are malformed.
+    """
 
-        if atype not in types:
-                raise UnknownActionError(("{0} {1}".format(atype,
-                    " ".join(args))).strip(), atype)
+    if atype not in types:
+        raise UnknownActionError(
+            ("{0} {1}".format(atype, " ".join(args))).strip(), atype
+        )
 
-        data = None
+    data = None
 
-        if atype in ("file", "license"):
-                data = args.pop(0)
+    if atype in ("file", "license"):
+        data = args.pop(0)
 
-        attrs = {}
+    attrs = {}
 
-        try:
-                # list comprehension in Python 3 doesn't leak loop control
-                # variable to surrounding variable, so use a regular loop
-                for kv in args:
-                        a, v = kv.split("=", 1)
-                        if v == '' or a == '':
-                                kvi = args.index(kv) + 1
-                                p1 = " ".join(args[:kvi])
-                                p2 = " ".join(args[kvi:])
-                                raise MalformedActionError(
-                                    "{0} {1} {2}".format(atype, p1, p2),
-                                    len(p1) + 1,
-                                    "attribute '{0}'".format(kv))
-
-                        # This is by far the common case-- an attribute with
-                        # a single value.
-                        if a not in attrs:
-                                attrs[a] = v
-                        else:
-                                av = attrs[a]
-                                if isinstance(av, list):
-                                        attrs[a].append(v)
-                                else:
-                                        attrs[a] = [ av, v ]
-        except ValueError:
-                # We're only here if the for: statement above throws a
-                # MalformedActionError.  That can happen if split yields a
-                # single element, which is possible if e.g. an attribute lacks
-                # an =.
+    try:
+        # list comprehension in Python 3 doesn't leak loop control
+        # variable to surrounding variable, so use a regular loop
+        for kv in args:
+            a, v = kv.split("=", 1)
+            if v == "" or a == "":
                 kvi = args.index(kv) + 1
                 p1 = " ".join(args[:kvi])
                 p2 = " ".join(args[kvi:])
-                raise MalformedActionError("{0} {1} {2}".format(atype, p1, p2),
-                    len(p1) + 2, "attribute '{0}'".format(kv))
+                raise MalformedActionError(
+                    "{0} {1} {2}".format(atype, p1, p2),
+                    len(p1) + 1,
+                    "attribute '{0}'".format(kv),
+                )
 
-        # keys called 'data' cause problems due to the named parameter being
-        # passed to the action constructor below. Check for these. Note that
-        # _fromstr also checks for this.
-        if "data" in attrs:
-                astr = atype + " " + " ".join(args)
-                raise InvalidActionError(astr,
-                        "{0} action cannot have a 'data' attribute".format(
-                        atype))
+            # This is by far the common case-- an attribute with
+            # a single value.
+            if a not in attrs:
+                attrs[a] = v
+            else:
+                av = attrs[a]
+                if isinstance(av, list):
+                    attrs[a].append(v)
+                else:
+                    attrs[a] = [av, v]
+    except ValueError:
+        # We're only here if the for: statement above throws a
+        # MalformedActionError.  That can happen if split yields a
+        # single element, which is possible if e.g. an attribute lacks
+        # an =.
+        kvi = args.index(kv) + 1
+        p1 = " ".join(args[:kvi])
+        p2 = " ".join(args[kvi:])
+        raise MalformedActionError(
+            "{0} {1} {2}".format(atype, p1, p2),
+            len(p1) + 2,
+            "attribute '{0}'".format(kv),
+        )
 
-        action = types[atype](data, **attrs)
-        if ahash:
-                action.hash = ahash
+    # keys called 'data' cause problems due to the named parameter being
+    # passed to the action constructor below. Check for these. Note that
+    # _fromstr also checks for this.
+    if "data" in attrs:
+        astr = atype + " " + " ".join(args)
+        raise InvalidActionError(
+            astr, "{0} action cannot have a 'data' attribute".format(atype)
+        )
 
-        local_path, used_basedir = set_action_data(data, action,
-            basedirs=basedirs)
-        return action, local_path
+    action = types[atype](data, **attrs)
+    if ahash:
+        action.hash = ahash
+
+    local_path, used_basedir = set_action_data(data, action, basedirs=basedirs)
+    return action, local_path
+
 
 def internalizestr(string, basedirs=None, load_data=True):
-        """Create an action instance based on a sequence of strings.
-        This function also translates external representations of actions with
-        payloads (like file and license which can use NOHASH or file paths to
-        point to the payload) to an internal representation which sets the
-        data field of the action returned.
+    """Create an action instance based on a sequence of strings.
+    This function also translates external representations of actions with
+    payloads (like file and license which can use NOHASH or file paths to
+    point to the payload) to an internal representation which sets the
+    data field of the action returned.
 
-        In general, each string should be in the form of "key=value". The
-        exception is a payload for certain actions which should be the first
-        item in the sequence.
+    In general, each string should be in the form of "key=value". The
+    exception is a payload for certain actions which should be the first
+    item in the sequence.
 
-        Raises MalformedActionError if the attribute strings are malformed.
-        """
+    Raises MalformedActionError if the attribute strings are malformed.
+    """
 
-        action = fromstr(string)
+    action = fromstr(string)
 
-        if action.name not in ("file", "license") or not load_data:
-                return action, None, None
+    if action.name not in ("file", "license") or not load_data:
+        return action, None, None
 
-        local_path, used_basedir = set_action_data(action.hash, action,
-            basedirs=basedirs)
-        return action, local_path, used_basedir
+    local_path, used_basedir = set_action_data(
+        action.hash, action, basedirs=basedirs
+    )
+    return action, local_path, used_basedir
+
 
 def set_action_data(payload, action, basedirs=None, bundles=None):
-        """Sets the data field of an action using the information in the
-        payload and returns the actual path used to set the data and the
-        source used to find the data (this may be a path or a bundle
-        object).
+    """Sets the data field of an action using the information in the
+    payload and returns the actual path used to set the data and the
+    source used to find the data (this may be a path or a bundle
+    object).
 
-        The "payload" parameter is the representation of the data to assign to
-        the action's data field. It can either be NOHASH or a path to the file.
+    The "payload" parameter is the representation of the data to assign to
+    the action's data field. It can either be NOHASH or a path to the file.
 
-        The "action" parameter is the action to modify.
+    The "action" parameter is the action to modify.
 
-        The "basedirs" parameter contains the directories to examine to find the
-        payload in.
+    The "basedirs" parameter contains the directories to examine to find the
+    payload in.
 
-        The "bundles" parameter contains a list of bundle objects to find the
-        payload in.
+    The "bundles" parameter contains a list of bundle objects to find the
+    payload in.
 
-        "basedirs" and/or "bundles" must be specified.
-        """
+    "basedirs" and/or "bundles" must be specified.
+    """
 
-        if not payload:
-                return None, None
+    if not payload:
+        return None, None
 
-        if payload == "NOHASH":
-                try:
-                        filepath = os.path.sep + action.attrs["path"]
-                except KeyError:
-                        raise InvalidPathAttributeError(action)
-        else:
-                filepath = payload
+    if payload == "NOHASH":
+        try:
+            filepath = os.path.sep + action.attrs["path"]
+        except KeyError:
+            raise InvalidPathAttributeError(action)
+    else:
+        filepath = payload
 
-        if not basedirs:
-                basedirs = []
-        if not bundles:
-                bundles = []
+    if not basedirs:
+        basedirs = []
+    if not bundles:
+        bundles = []
 
-        # Attempt to find directory or bundle containing source of file data.
-        data = None
-        used_src = None
-        path = filepath.lstrip(os.path.sep)
-        for bd in basedirs:
-                # look for file in specified dir
-                npath = os.path.join(bd, path)
-                if os.path.isfile(npath):
-                        used_src = bd
-                        data = npath
-                        break
-        else:
-                for bundle in bundles:
-                        act = bundle.get_action(path)
-                        if act:
-                                data = act.data
-                                used_src = bundle
-                                action.attrs["pkg.size"] = \
-                                    act.attrs["pkg.size"]
-                                break
+    # Attempt to find directory or bundle containing source of file data.
+    data = None
+    used_src = None
+    path = filepath.lstrip(os.path.sep)
+    for bd in basedirs:
+        # look for file in specified dir
+        npath = os.path.join(bd, path)
+        if os.path.isfile(npath):
+            used_src = bd
+            data = npath
+            break
+    else:
+        for bundle in bundles:
+            act = bundle.get_action(path)
+            if act:
+                data = act.data
+                used_src = bundle
+                action.attrs["pkg.size"] = act.attrs["pkg.size"]
+                break
 
-                if not data and basedirs:
-                        raise ActionDataError(_("Action payload '{name}' "
-                            "was not found in any of the provided locations:"
-                            "\n{basedirs}").format(name=filepath,
-                            basedirs="\n".join(basedirs)), path=filepath)
-                elif not data and bundles:
-                        raise ActionDataError(_("Action payload '{name}' was "
-                            "not found in any of the provided sources:"
-                            "\n{sources}").format(name=filepath,
-                            sources="\n".join(b.filename for b in bundles)),
-                            path=filepath)
-                elif not data:
-                        # Only if no explicit sources were provided should a
-                        # fallback to filepath be performed.
-                        data = filepath
+        if not data and basedirs:
+            raise ActionDataError(
+                _(
+                    "Action payload '{name}' "
+                    "was not found in any of the provided locations:"
+                    "\n{basedirs}"
+                ).format(name=filepath, basedirs="\n".join(basedirs)),
+                path=filepath,
+            )
+        elif not data and bundles:
+            raise ActionDataError(
+                _(
+                    "Action payload '{name}' was "
+                    "not found in any of the provided sources:"
+                    "\n{sources}"
+                ).format(
+                    name=filepath,
+                    sources="\n".join(b.filename for b in bundles),
+                ),
+                path=filepath,
+            )
+        elif not data:
+            # Only if no explicit sources were provided should a
+            # fallback to filepath be performed.
+            data = filepath
 
-        # This relies on data having a value set by the code above so that an
-        # ActionDataError will be raised if the file doesn't exist or is not
-        # accessible.
-        action.set_data(data)
-        return data, used_src
+    # This relies on data having a value set by the code above so that an
+    # ActionDataError will be raised if the file doesn't exist or is not
+    # accessible.
+    action.set_data(data)
+    return data, used_src
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/attribute.py
+++ b/src/modules/actions/attribute.py
@@ -35,152 +35,159 @@ import pkg.fmri
 import pkg.actions
 import six
 
+
 class AttributeAction(generic.Action):
-        """Class representing a package attribute."""
+    """Class representing a package attribute."""
 
-        __slots__ = ["value"]
+    __slots__ = ["value"]
 
-        name = "set"
-        key_attr = "name"
-        ordinality = generic._orderdict[name]
+    name = "set"
+    key_attr = "name"
+    ordinality = generic._orderdict[name]
 
-        def __init__(self, data=None, **attrs):
-                generic.Action.__init__(self, data, **attrs)
+    def __init__(self, data=None, **attrs):
+        generic.Action.__init__(self, data, **attrs)
 
+        try:
+            self.attrs["name"]
+            self.attrs["value"]
+        except KeyError:
+            # For convenience, we allow people to express attributes as
+            # "<name>=<value>", rather than "name=<name> value=<value>", but
+            # we always convert to the latter.
+            try:
+                if len(attrs) == 1:
+                    (
+                        self.attrs["name"],
+                        self.attrs["value"],
+                    ) = self.attrs.popitem()
+                    return
+            except KeyError:
+                pass
+            raise pkg.actions.InvalidActionError(
+                str(self), 'Missing "name" or "value" attribute'
+            )
+
+    def generate_indices(self):
+        """Generates the indices needed by the search dictionary.  See
+        generic.py for a more detailed explanation."""
+
+        if self.has_category_info():
+            try:
+                return [
+                    (
+                        self.name,
+                        self.attrs["name"],
+                        [all_levels]
+                        + [t.split() for t in all_levels.split("/")],
+                        all_levels,
+                    )
+                    for scheme, all_levels in self.parse_category_info()
+                ]
+            except ValueError:
+                pass
+
+        if isinstance(self.attrs["value"], list):
+            tmp = []
+            for v in self.attrs["value"]:
+                assert isinstance(v, six.string_types)
+                if " " in v:
+                    words = v.split()
+                    for w in words:
+                        tmp.append((self.name, self.attrs["name"], w, v))
+                else:
+                    tmp.append((self.name, self.attrs["name"], v, None))
+            return tmp
+        elif self.attrs["name"] in ("fmri", "pkg.fmri"):
+            fmri_obj = pkg.fmri.PkgFmri(self.attrs["value"])
+
+            lst = [
+                fmri_obj.get_pkg_stem(include_scheme=False),
+                str(fmri_obj.version.build_release),
+                str(fmri_obj.version.release),
+                str(fmri_obj.version.timestr),
+            ]
+            lst.extend(fmri_obj.hierarchical_names())
+            return [
+                (
+                    self.name,
+                    self.attrs["name"],
+                    w,
+                    fmri_obj.get_pkg_stem(include_scheme=False),
+                )
+                for w in lst
+            ]
+
+        elif " " in self.attrs["value"]:
+            v = self.attrs["value"]
+            return [(self.name, self.attrs["name"], w, v) for w in v.split()]
+        else:
+            return [(self.name, self.attrs["name"], self.attrs["value"], None)]
+
+    def has_category_info(self):
+        return self.attrs["name"] == "info.classification"
+
+    def parse_category_info(self):
+        rval = []
+        # Some logic is inlined here for performance reasons.
+        if self.attrs["name"] != "info.classification":
+            return rval
+
+        for val in self.attrlist("value"):
+            if ":" in val:
+                scheme, cats = val.split(":", 1)
+            else:
+                scheme = ""
+                cats = val
+            rval.append((scheme, cats))
+        return rval
+
+    def validate(self, fmri=None):
+        """Performs additional validation of action attributes that
+        for performance or other reasons cannot or should not be done
+        during Action object creation.  An ActionError exception (or
+        subclass of) will be raised if any attributes are not valid.
+        This is primarily intended for use during publication or during
+        error handling to provide additional diagonostics.
+
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action.
+        """
+
+        name = self.attrs["name"]
+        if name in (
+            "pkg.summary",
+            "pkg.obsolete",
+            "pkg.renamed",
+            "pkg.legacy",
+            "pkg.description",
+            "pkg.depend.explicit-install",
+        ):
+            # If set action is for any of the above, only a single
+            # value is permitted.
+            generic.Action._validate(self, fmri=fmri, single_attrs=("value",))
+        elif name.startswith("pkg.additional-"):
+            # For pkg actuators, just test that the values are valid
+            # FMRIs. We want to prevent the system from failing when
+            # newer, currently unknown actuators are encountered.
+            errors = []
+            fmris = self.attrlist("value")
+            for f in fmris:
                 try:
-                        self.attrs["name"]
-                        self.attrs["value"]
-                except KeyError:
-                        # For convenience, we allow people to express attributes as
-                        # "<name>=<value>", rather than "name=<name> value=<value>", but
-                        # we always convert to the latter.
-                        try:
-                                if len(attrs) == 1:
-                                        self.attrs["name"], self.attrs["value"] = \
-                                            self.attrs.popitem()
-                                        return
-                        except KeyError:
-                                pass
-                        raise pkg.actions.InvalidActionError(str(self),
-                            'Missing "name" or "value" attribute')
+                    pkg.fmri.PkgFmri(f)
+                except pkg.fmri.IllegalFmri as e:
+                    errors.append((name, str(e)))
+            if errors:
+                raise pkg.actions.InvalidActionAttributesError(
+                    self, errors, fmri=fmri
+                )
 
-        def generate_indices(self):
-                """Generates the indices needed by the search dictionary.  See
-                generic.py for a more detailed explanation."""
+            generic.Action._validate(self, fmri=fmri)
+        else:
+            # In all other cases, multiple values are assumed to be
+            # permissible.
+            generic.Action._validate(self, fmri=fmri)
 
-                if self.has_category_info():
-                        try:
-
-                                return [
-                                    (self.name, self.attrs["name"],
-                                    [all_levels] +
-                                    [t.split() for t in all_levels.split("/")],
-                                    all_levels)
-                                    for scheme, all_levels
-                                    in self.parse_category_info()
-                                ]
-                        except ValueError:
-                                pass
-
-                if isinstance(self.attrs["value"], list):
-                        tmp = []
-                        for v in self.attrs["value"]:
-                                assert isinstance(v, six.string_types)
-                                if " " in v:
-                                        words = v.split()
-                                        for w in words:
-                                                tmp.append((self.name,
-                                                    self.attrs["name"], w,
-                                                    v))
-                                else:
-                                        tmp.append((self.name,
-                                            self.attrs["name"], v, None))
-                        return  tmp
-                elif self.attrs["name"] in ("fmri", "pkg.fmri"):
-                        fmri_obj = pkg.fmri.PkgFmri(self.attrs["value"])
-
-                        lst = [
-                            fmri_obj.get_pkg_stem(include_scheme=False),
-                            str(fmri_obj.version.build_release),
-                            str(fmri_obj.version.release),
-                            str(fmri_obj.version.timestr)
-                        ]
-                        lst.extend(fmri_obj.hierarchical_names())
-                        return [
-                            (self.name, self.attrs["name"], w,
-                            fmri_obj.get_pkg_stem(include_scheme=False))
-                            for w in lst
-                        ]
-
-                elif " " in self.attrs["value"]:
-                        v = self.attrs["value"]
-                        return [
-                            (self.name, self.attrs["name"], w, v)
-                            for w in v.split()
-                        ]
-                else:
-                        return [
-                            (self.name, self.attrs["name"],
-                            self.attrs["value"], None)
-                        ]
-
-        def has_category_info(self):
-                return self.attrs["name"] == "info.classification"
-
-        def parse_category_info(self):
-                rval = []
-                # Some logic is inlined here for performance reasons.
-                if self.attrs["name"] != "info.classification":
-                        return rval
-
-                for val in self.attrlist("value"):
-                        if ":" in val:
-                                scheme, cats = val.split(":", 1)
-                        else:
-                                scheme = ""
-                                cats = val
-                        rval.append((scheme, cats))
-                return rval
-
-        def validate(self, fmri=None):
-                """Performs additional validation of action attributes that
-                for performance or other reasons cannot or should not be done
-                during Action object creation.  An ActionError exception (or
-                subclass of) will be raised if any attributes are not valid.
-                This is primarily intended for use during publication or during
-                error handling to provide additional diagonostics.
-
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action.
-                """
-
-                name = self.attrs["name"]
-                if name in ("pkg.summary", "pkg.obsolete", "pkg.renamed",
-                    "pkg.legacy", "pkg.description", "pkg.depend.explicit-install"):
-                        # If set action is for any of the above, only a single
-                        # value is permitted.
-                        generic.Action._validate(self, fmri=fmri,
-                            single_attrs=("value",))
-                elif name.startswith("pkg.additional-"):
-                        # For pkg actuators, just test that the values are valid
-                        # FMRIs. We want to prevent the system from failing when
-                        # newer, currently unknown actuators are encountered.
-                        errors = []
-                        fmris = self.attrlist("value")
-                        for f in fmris:
-                                try:
-                                        pkg.fmri.PkgFmri(f)
-                                except pkg.fmri.IllegalFmri as e:
-                                        errors.append((name, str(e)))
-                        if errors:
-                                raise pkg.actions.InvalidActionAttributesError(
-                                    self, errors, fmri=fmri)
-
-                        generic.Action._validate(self, fmri=fmri)
-                else:
-                        # In all other cases, multiple values are assumed to be
-                        # permissible.
-                        generic.Action._validate(self, fmri=fmri)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/directory.py
+++ b/src/modules/actions/directory.py
@@ -37,262 +37,281 @@ import pkg.actions
 import pkg.client.api_errors as apx
 import stat
 
+
 class DirectoryAction(generic.Action):
-        """Class representing a directory-type packaging object."""
+    """Class representing a directory-type packaging object."""
 
-        __slots__ = []
+    __slots__ = []
 
-        name = "dir"
-        key_attr = "path"
-        unique_attrs = "path", "mode", "owner", "group"
-        globally_identical = True
-        refcountable = True
-        namespace_group = "path"
-        ordinality = generic._orderdict[name]
+    name = "dir"
+    key_attr = "path"
+    unique_attrs = "path", "mode", "owner", "group"
+    globally_identical = True
+    refcountable = True
+    namespace_group = "path"
+    ordinality = generic._orderdict[name]
 
-        def compare(self, other):
-                return (self.attrs["path"] > other.attrs["path"]) - \
-                    (self.attrs["path"] < other.attrs["path"])
+    def compare(self, other):
+        return (self.attrs["path"] > other.attrs["path"]) - (
+            self.attrs["path"] < other.attrs["path"]
+        )
 
-        def differences(self, other):
-                """Returns a list of attributes that have different values
-                between 'other' and 'self'.  This differs from the generic
-                Action's differences() method in that it normalizes the 'mode'
-                attribute so that, say, '0755' and '755' are treated as
-                identical."""
+    def differences(self, other):
+        """Returns a list of attributes that have different values
+        between 'other' and 'self'.  This differs from the generic
+        Action's differences() method in that it normalizes the 'mode'
+        attribute so that, say, '0755' and '755' are treated as
+        identical."""
 
-                diffs = generic.Action.differences(self, other)
+        diffs = generic.Action.differences(self, other)
 
-                if "mode" in diffs and \
-                    int(self.attrs.get("mode", "0"), 8) == int(other.attrs.get("mode", "0"), 8):
-                        diffs.remove("mode")
+        if "mode" in diffs and int(self.attrs.get("mode", "0"), 8) == int(
+            other.attrs.get("mode", "0"), 8
+        ):
+            diffs.remove("mode")
 
-                return diffs
+        return diffs
 
-        def directory_references(self):
-                return [os.path.normpath(self.attrs["path"])]
+    def directory_references(self):
+        return [os.path.normpath(self.attrs["path"])]
 
-        def __create_directory(self, pkgplan, path, mode, **kwargs):
-                """Create a directory."""
+    def __create_directory(self, pkgplan, path, mode, **kwargs):
+        """Create a directory."""
 
-                try:
-                        self.makedirs(path, mode=mode,
-                            fmri=pkgplan.destination_fmri, **kwargs)
-                except OSError as e:
-                        if e.filename != path:
-                                # makedirs failed for some component
-                                # of the path.
-                                raise
+        try:
+            self.makedirs(
+                path, mode=mode, fmri=pkgplan.destination_fmri, **kwargs
+            )
+        except OSError as e:
+            if e.filename != path:
+                # makedirs failed for some component
+                # of the path.
+                raise
 
-                        fs = os.lstat(path)
-                        fs_mode = stat.S_IFMT(fs.st_mode)
-                        if e.errno == errno.EROFS:
-                                # Treat EROFS like EEXIST if both are
-                                # applicable, since we'll end up with
-                                # EROFS instead.
-                                if stat.S_ISDIR(fs_mode):
-                                        return
-                                raise
-                        elif e.errno != errno.EEXIST:
-                                raise
+            fs = os.lstat(path)
+            fs_mode = stat.S_IFMT(fs.st_mode)
+            if e.errno == errno.EROFS:
+                # Treat EROFS like EEXIST if both are
+                # applicable, since we'll end up with
+                # EROFS instead.
+                if stat.S_ISDIR(fs_mode):
+                    return
+                raise
+            elif e.errno != errno.EEXIST:
+                raise
 
-                        if stat.S_ISLNK(fs_mode):
-                                # User has replaced directory with a
-                                # link, or a package has been poorly
-                                # implemented.  It isn't safe to
-                                # simply re-create the directory as
-                                # that won't restore the files that
-                                # are supposed to be contained within.
-                                err_txt = _("Unable to create "
-                                    "directory {0}; it has been "
-                                    "replaced with a link.  To "
-                                    "continue, please remove the "
-                                    "link or restore the directory "
-                                    "to its original location and "
-                                    "try again.").format(path)
-                                raise apx.ActionExecutionError(
-                                    self, details=err_txt, error=e,
-                                    fmri=pkgplan.destination_fmri)
-                        elif stat.S_ISREG(fs_mode):
-                                # User has replaced directory with a
-                                # file, or a package has been poorly
-                                # implemented.  Salvage what's there,
-                                # and drive on.
-                                pkgplan.salvage(path)
-                                os.mkdir(path, mode)
-                        elif stat.S_ISDIR(fs_mode):
-                                # The directory already exists, but
-                                # ensure that the mode matches what's
-                                # expected.
-                                os.chmod(path, mode)
+            if stat.S_ISLNK(fs_mode):
+                # User has replaced directory with a
+                # link, or a package has been poorly
+                # implemented.  It isn't safe to
+                # simply re-create the directory as
+                # that won't restore the files that
+                # are supposed to be contained within.
+                err_txt = _(
+                    "Unable to create "
+                    "directory {0}; it has been "
+                    "replaced with a link.  To "
+                    "continue, please remove the "
+                    "link or restore the directory "
+                    "to its original location and "
+                    "try again."
+                ).format(path)
+                raise apx.ActionExecutionError(
+                    self,
+                    details=err_txt,
+                    error=e,
+                    fmri=pkgplan.destination_fmri,
+                )
+            elif stat.S_ISREG(fs_mode):
+                # User has replaced directory with a
+                # file, or a package has been poorly
+                # implemented.  Salvage what's there,
+                # and drive on.
+                pkgplan.salvage(path)
+                os.mkdir(path, mode)
+            elif stat.S_ISDIR(fs_mode):
+                # The directory already exists, but
+                # ensure that the mode matches what's
+                # expected.
+                os.chmod(path, mode)
 
-        def install(self, pkgplan, orig):
-                """Client-side method that installs a directory."""
+    def install(self, pkgplan, orig):
+        """Client-side method that installs a directory."""
 
-                mode = None
-                try:
-                        mode = int(self.attrs.get("mode", None), 8)
-                except (TypeError, ValueError):
-                        # Mode isn't valid, so let validate raise a more
-                        # informative error.
-                        self.validate(fmri=pkgplan.destination_fmri)
+        mode = None
+        try:
+            mode = int(self.attrs.get("mode", None), 8)
+        except (TypeError, ValueError):
+            # Mode isn't valid, so let validate raise a more
+            # informative error.
+            self.validate(fmri=pkgplan.destination_fmri)
 
-                omode = oowner = ogroup = None
-                owner, group = self.get_fsobj_uid_gid(pkgplan,
-                        pkgplan.destination_fmri)
-                if orig:
-                        try:
-                                omode = int(orig.attrs.get("mode", None), 8)
-                        except (TypeError, ValueError):
-                                # Mode isn't valid, so let validate raise a more
-                                # informative error.
-                                orig.validate(fmri=pkgplan.origin_fmri)
-                        oowner, ogroup = orig.get_fsobj_uid_gid(pkgplan,
-                            pkgplan.origin_fmri)
+        omode = oowner = ogroup = None
+        owner, group = self.get_fsobj_uid_gid(pkgplan, pkgplan.destination_fmri)
+        if orig:
+            try:
+                omode = int(orig.attrs.get("mode", None), 8)
+            except (TypeError, ValueError):
+                # Mode isn't valid, so let validate raise a more
+                # informative error.
+                orig.validate(fmri=pkgplan.origin_fmri)
+            oowner, ogroup = orig.get_fsobj_uid_gid(
+                pkgplan, pkgplan.origin_fmri
+            )
 
-                path = self.get_installed_path(pkgplan.image.get_root())
+        path = self.get_installed_path(pkgplan.image.get_root())
 
-                # Don't allow installation through symlinks.
-                self.fsobj_checkpath(pkgplan, path)
+        # Don't allow installation through symlinks.
+        self.fsobj_checkpath(pkgplan, path)
 
-                # XXX Hack!  (See below comment.)
-                if not portable.is_admin():
-                        mode |= stat.S_IWUSR
+        # XXX Hack!  (See below comment.)
+        if not portable.is_admin():
+            mode |= stat.S_IWUSR
 
-                if not orig:
-                        self.__create_directory(pkgplan, path, mode)
+        if not orig:
+            self.__create_directory(pkgplan, path, mode)
 
-                # The downside of chmodding the directory is that as a non-root
-                # user, if we set perms u-w, we won't be able to put anything in
-                # it, which is often not what we want at install time.  We save
-                # the chmods for the postinstall phase, but it's always possible
-                # that a later package install will want to place something in
-                # this directory and then be unable to.  So perhaps we need to
-                # (in all action types) chmod the parent directory to u+w on
-                # failure, and chmod it back aftwards.  The trick is to
-                # recognize failure due to missing file_dac_write in contrast to
-                # other failures.  Or can we require that everyone simply have
-                # file_dac_write who wants to use the tools.  Probably not.
-                elif mode != omode:
-                        try:
-                                os.chmod(path, mode)
-                        except Exception as e:
-                                if e.errno != errno.EPERM and e.errno != \
-                                    errno.ENOSYS:
-                                        # Assume chmod failed due to a
-                                        # recoverable error.
-                                        self.__create_directory(pkgplan, path,
-                                            mode)
-                                        omode = oowner = ogroup = None
+        # The downside of chmodding the directory is that as a non-root
+        # user, if we set perms u-w, we won't be able to put anything in
+        # it, which is often not what we want at install time.  We save
+        # the chmods for the postinstall phase, but it's always possible
+        # that a later package install will want to place something in
+        # this directory and then be unable to.  So perhaps we need to
+        # (in all action types) chmod the parent directory to u+w on
+        # failure, and chmod it back aftwards.  The trick is to
+        # recognize failure due to missing file_dac_write in contrast to
+        # other failures.  Or can we require that everyone simply have
+        # file_dac_write who wants to use the tools.  Probably not.
+        elif mode != omode:
+            try:
+                os.chmod(path, mode)
+            except Exception as e:
+                if e.errno != errno.EPERM and e.errno != errno.ENOSYS:
+                    # Assume chmod failed due to a
+                    # recoverable error.
+                    self.__create_directory(pkgplan, path, mode)
+                    omode = oowner = ogroup = None
 
-                # if we're salvaging contents, move 'em now.
-                # directories with "salvage-from" attribute
-                # set will scavenge any available contents
-                # that matches specified directory and
-                # move it underneath itself on install or update.
-                # This is here to support directory rename
-                # when old directory has unpackaged contents, or
-                # consolidation of content from older directories.
-                for salvage_from in self.attrlist("salvage-from"):
-                        pkgplan.salvage_from(salvage_from, path)
+        # if we're salvaging contents, move 'em now.
+        # directories with "salvage-from" attribute
+        # set will scavenge any available contents
+        # that matches specified directory and
+        # move it underneath itself on install or update.
+        # This is here to support directory rename
+        # when old directory has unpackaged contents, or
+        # consolidation of content from older directories.
+        for salvage_from in self.attrlist("salvage-from"):
+            pkgplan.salvage_from(salvage_from, path)
 
-                if not orig or oowner != owner or ogroup != group:
-                        try:
-                                portable.chown(path, owner, group)
-                        except OSError as e:
-                                if e.errno != errno.EPERM and \
-                                    e.errno != errno.ENOSYS:
-                                        # Assume chown failed due to a
-                                        # recoverable error.
-                                        self.__create_directory(pkgplan, path,
-                                            mode, uid=owner, gid=group)
+        if not orig or oowner != owner or ogroup != group:
+            try:
+                portable.chown(path, owner, group)
+            except OSError as e:
+                if e.errno != errno.EPERM and e.errno != errno.ENOSYS:
+                    # Assume chown failed due to a
+                    # recoverable error.
+                    self.__create_directory(
+                        pkgplan, path, mode, uid=owner, gid=group
+                    )
 
-        def verify(self, img, **args):
-                """Returns a tuple of lists of the form (errors, warnings,
-                info).  The error list will be empty if the action has been
-                correctly installed in the given image."""
+    def verify(self, img, **args):
+        """Returns a tuple of lists of the form (errors, warnings,
+        info).  The error list will be empty if the action has been
+        correctly installed in the given image."""
 
-                lstat, errors, warnings, info, abort = \
-                    self.verify_fsobj_common(img, stat.S_IFDIR)
-                return errors, warnings, info
+        lstat, errors, warnings, info, abort = self.verify_fsobj_common(
+            img, stat.S_IFDIR
+        )
+        return errors, warnings, info
 
-        def remove(self, pkgplan):
-                path = self.get_installed_path(pkgplan.image.get_root())
-                try:
-                        os.rmdir(path)
-                except OSError as e:
-                        if e.errno == errno.EINVAL and path == '/':
-                                # This is ok, illumos will return EINVAL
-                                # for attempts to remove /
-                                pass
-                        elif e.errno == errno.ENOENT:
-                                pass
-                        elif e.errno in (errno.EEXIST, errno.ENOTEMPTY):
-                                # Cannot remove directory since it's
-                                # not empty.
-                                pkgplan.salvage(path)
-                        elif e.errno == errno.ENOTDIR:
-                                # Either the user or another package has changed
-                                # this directory into a link or file.  Salvage
-                                # what's there and drive on.
-                                pkgplan.salvage(path)
-                        elif e.errno == errno.EBUSY and os.path.ismount(path):
-                                # User has replaced directory with mountpoint,
-                                # or a package has been poorly implemented.
-                                if not self.attrs.get("implicit"):
-                                        err_txt = _("Unable to remove {0}; it is "
-                                            "in use as a mountpoint. To "
-                                            "continue, please unmount the "
-                                            "filesystem at the target "
-                                            "location and try again.").format(
-                                            path)
-                                        raise apx.ActionExecutionError(self,
-                                            details=err_txt, error=e,
-                                            fmri=pkgplan.origin_fmri) 
-                        elif e.errno == errno.EBUSY:
-                                # os.path.ismount() is broken for lofs
-                                # filesystems, so give a more generic
-                                # error.
-                                if not self.attrs.get("implicit"):
-                                        err_txt = _("Unable to remove {0}; it "
-                                            "is in use by the system, another "
-                                            "process, or as a "
-                                            "mountpoint.").format(path)
-                                        raise apx.ActionExecutionError(self,
-                                            details=err_txt, error=e,
-                                            fmri=pkgplan.origin_fmri)
-                        elif e.errno != errno.EACCES: # this happens on Windows
-                                raise
+    def remove(self, pkgplan):
+        path = self.get_installed_path(pkgplan.image.get_root())
+        try:
+            os.rmdir(path)
+        except OSError as e:
+            if e.errno == errno.EINVAL and path == "/":
+                # This is ok, illumos will return EINVAL
+                # for attempts to remove /
+                pass
+            elif e.errno == errno.ENOENT:
+                pass
+            elif e.errno in (errno.EEXIST, errno.ENOTEMPTY):
+                # Cannot remove directory since it's
+                # not empty.
+                pkgplan.salvage(path)
+            elif e.errno == errno.ENOTDIR:
+                # Either the user or another package has changed
+                # this directory into a link or file.  Salvage
+                # what's there and drive on.
+                pkgplan.salvage(path)
+            elif e.errno == errno.EBUSY and os.path.ismount(path):
+                # User has replaced directory with mountpoint,
+                # or a package has been poorly implemented.
+                if not self.attrs.get("implicit"):
+                    err_txt = _(
+                        "Unable to remove {0}; it is "
+                        "in use as a mountpoint. To "
+                        "continue, please unmount the "
+                        "filesystem at the target "
+                        "location and try again."
+                    ).format(path)
+                    raise apx.ActionExecutionError(
+                        self, details=err_txt, error=e, fmri=pkgplan.origin_fmri
+                    )
+            elif e.errno == errno.EBUSY:
+                # os.path.ismount() is broken for lofs
+                # filesystems, so give a more generic
+                # error.
+                if not self.attrs.get("implicit"):
+                    err_txt = _(
+                        "Unable to remove {0}; it "
+                        "is in use by the system, another "
+                        "process, or as a "
+                        "mountpoint."
+                    ).format(path)
+                    raise apx.ActionExecutionError(
+                        self, details=err_txt, error=e, fmri=pkgplan.origin_fmri
+                    )
+            elif e.errno != errno.EACCES:  # this happens on Windows
+                raise
 
-        def generate_indices(self):
-                """Generates the indices needed by the search dictionary.  See
-                generic.py for a more detailed explanation."""
+    def generate_indices(self):
+        """Generates the indices needed by the search dictionary.  See
+        generic.py for a more detailed explanation."""
 
-                return [
-                    (self.name, "basename",
-                    os.path.basename(self.attrs["path"].rstrip(os.path.sep)),
-                    None),
-                    (self.name, "path", os.path.sep + self.attrs["path"],
-                    None)
-                ]
+        return [
+            (
+                self.name,
+                "basename",
+                os.path.basename(self.attrs["path"].rstrip(os.path.sep)),
+                None,
+            ),
+            (self.name, "path", os.path.sep + self.attrs["path"], None),
+        ]
 
-        def validate(self, fmri=None):
-                """Performs additional validation of action attributes that
-                for performance or other reasons cannot or should not be done
-                during Action object creation.  An ActionError exception (or
-                subclass of) will be raised if any attributes are not valid.
-                This is primarily intended for use during publication or during
-                error handling to provide additional diagonostics.
+    def validate(self, fmri=None):
+        """Performs additional validation of action attributes that
+        for performance or other reasons cannot or should not be done
+        during Action object creation.  An ActionError exception (or
+        subclass of) will be raised if any attributes are not valid.
+        This is primarily intended for use during publication or during
+        error handling to provide additional diagonostics.
 
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action."""
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action."""
 
-                errors = generic.Action._validate(self, fmri=fmri,
-                    raise_errors=False, required_attrs=("owner", "group"))
-                errors.extend(self._validate_fsobj_common())
-                if errors:
-                        raise pkg.actions.InvalidActionAttributesError(self,
-                            errors, fmri=fmri)
+        errors = generic.Action._validate(
+            self,
+            fmri=fmri,
+            raise_errors=False,
+            required_attrs=("owner", "group"),
+        )
+        errors.extend(self._validate_fsobj_common())
+        if errors:
+            raise pkg.actions.InvalidActionAttributesError(
+                self, errors, fmri=fmri
+            )
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/driver.py
+++ b/src/modules/actions/driver.py
@@ -40,232 +40,241 @@ from tempfile import mkstemp
 import pkg.pkgsubprocess as subprocess
 from pkg.client.debugvalues import DebugValues
 
+
 class DriverAction(generic.Action):
-        """Class representing a driver-type packaging object."""
+    """Class representing a driver-type packaging object."""
 
-        __slots__ = []
+    __slots__ = []
 
-        name = "driver"
-        key_attr = "name"
-        globally_identical = True
-        ordinality = generic._orderdict[name]
+    name = "driver"
+    key_attr = "name"
+    globally_identical = True
+    ordinality = generic._orderdict[name]
 
-        usr_sbin = None
-        add_drv = None
-        rem_drv = None
-        update_drv = None
+    usr_sbin = None
+    add_drv = None
+    rem_drv = None
+    update_drv = None
 
-        def __init__(self, data=None, **attrs):
-                generic.Action.__init__(self, data, **attrs)
+    def __init__(self, data=None, **attrs):
+        generic.Action.__init__(self, data, **attrs)
 
-                if not self.__class__.usr_sbin:
-                        self.__usr_sbin_init()
+        if not self.__class__.usr_sbin:
+            self.__usr_sbin_init()
 
-                #
-                # Clean up clone_perms.  This attribute may been specified either as:
-                #     <minorname> <mode> <owner> <group>
-                # or
-                #     <mode> <owner> <group>
-                #
-                # In the latter case, the <minorname> is assumed to be
-                # the same as the driver name.  Correct any such instances
-                # here so that there is only one form, so that we can cleanly
-                # compare, verify, etc.
-                #
-                if not self.attrlist("clone_perms"):
-                        return
+        #
+        # Clean up clone_perms.  This attribute may been specified either as:
+        #     <minorname> <mode> <owner> <group>
+        # or
+        #     <mode> <owner> <group>
+        #
+        # In the latter case, the <minorname> is assumed to be
+        # the same as the driver name.  Correct any such instances
+        # here so that there is only one form, so that we can cleanly
+        # compare, verify, etc.
+        #
+        if not self.attrlist("clone_perms"):
+            return
 
-                new_cloneperms = []
-                for cp in self.attrlist("clone_perms"):
-                        # If we're given three fields, assume the minor node
-                        # name is the same as the driver name.
-                        if len(cp.split()) == 3:
-                                new_cloneperms.append(
-                                    self.attrs["name"] + " " + cp)
-                        else:
-                                new_cloneperms.append(cp)
-                if len(new_cloneperms) == 1:
-                        self.attrs["clone_perms"] = new_cloneperms[0]
-                else:
-                        self.attrs["clone_perms"] = new_cloneperms
+        new_cloneperms = []
+        for cp in self.attrlist("clone_perms"):
+            # If we're given three fields, assume the minor node
+            # name is the same as the driver name.
+            if len(cp.split()) == 3:
+                new_cloneperms.append(self.attrs["name"] + " " + cp)
+            else:
+                new_cloneperms.append(cp)
+        if len(new_cloneperms) == 1:
+            self.attrs["clone_perms"] = new_cloneperms[0]
+        else:
+            self.attrs["clone_perms"] = new_cloneperms
 
-        def compare(self, other):
-                """Compare with other driver instance; defined to force
-                clone driver to be removed last"""
+    def compare(self, other):
+        """Compare with other driver instance; defined to force
+        clone driver to be removed last"""
 
-                ret = (self.attrs["name"] > other.attrs["name"]) - \
-                    (self.attrs["name"] < other.attrs["name"])
+        ret = (self.attrs["name"] > other.attrs["name"]) - (
+            self.attrs["name"] < other.attrs["name"]
+        )
 
-                if ret == 0:
-                        return 0
+        if ret == 0:
+            return 0
 
-                if self.attrs["name"] == "clone":
-                        return -1
-                elif other.attrs["name"] == "clone":
-                        return 1
-                return ret
+        if self.attrs["name"] == "clone":
+            return -1
+        elif other.attrs["name"] == "clone":
+            return 1
+        return ret
 
-        @staticmethod
-        def __usr_sbin_init():
-                """Initialize paths to device management commands that we will
-                execute when handling package driver actions"""
+    @staticmethod
+    def __usr_sbin_init():
+        """Initialize paths to device management commands that we will
+        execute when handling package driver actions"""
 
-                usr_sbin = DebugValues.get("driver-cmd-dir", "/usr/sbin") + "/"
-                DriverAction.usr_sbin = usr_sbin
-                DriverAction.add_drv = usr_sbin + "add_drv"
-                DriverAction.rem_drv = usr_sbin + "rem_drv"
-                DriverAction.update_drv = usr_sbin + "update_drv"
+        usr_sbin = DebugValues.get("driver-cmd-dir", "/usr/sbin") + "/"
+        DriverAction.usr_sbin = usr_sbin
+        DriverAction.add_drv = usr_sbin + "add_drv"
+        DriverAction.rem_drv = usr_sbin + "rem_drv"
+        DriverAction.update_drv = usr_sbin + "update_drv"
 
-        @staticmethod
-        def __call(args, fmt, fmtargs):
-                proc = subprocess.Popen(args, stdout = subprocess.PIPE,
-                    stderr = subprocess.STDOUT)
-                buf = proc.stdout.read()
-                ret = proc.wait()
+    @staticmethod
+    def __call(args, fmt, fmtargs):
+        proc = subprocess.Popen(
+            args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        buf = proc.stdout.read()
+        ret = proc.wait()
 
-                if ret != 0:
-                        fmtargs["retcode"] = ret
-                        # XXX Module printing
-                        print()
-                        fmt += " failed with return code {retcode}"
-                        print(_(fmt).format(**fmtargs))
-                        print(("command run was:"), " ".join(args))
-                        print("command output was:")
-                        print("-" * 60)
-                        print(buf, end=" ")
-                        print("-" * 60)
+        if ret != 0:
+            fmtargs["retcode"] = ret
+            # XXX Module printing
+            print()
+            fmt += " failed with return code {retcode}"
+            print(_(fmt).format(**fmtargs))
+            print(("command run was:"), " ".join(args))
+            print("command output was:")
+            print("-" * 60)
+            print(buf, end=" ")
+            print("-" * 60)
 
-        @staticmethod
-        def remove_aliases(driver_name, aliases, image):
-                if not DriverAction.update_drv:
-                        DriverAction.__usr_sbin_init()
-		# This should not happen in non-global zones.
-                if image.is_zone():
-                        return
-                rem_base = (DriverAction.update_drv, "-b", image.get_root(), "-d")
-                for i in aliases:
-                        args = rem_base + ("-i", '{0}'.format(i), driver_name)
-                        DriverAction.__call(args, "driver ({name}) upgrade (removal "
-                            "of alias '{alias}')",
-                            {"name": driver_name, "alias": i})
+    @staticmethod
+    def remove_aliases(driver_name, aliases, image):
+        if not DriverAction.update_drv:
+            DriverAction.__usr_sbin_init()
+        # This should not happen in non-global zones.
+        if image.is_zone():
+            return
+        rem_base = (DriverAction.update_drv, "-b", image.get_root(), "-d")
+        for i in aliases:
+            args = rem_base + ("-i", "{0}".format(i), driver_name)
+            DriverAction.__call(
+                args,
+                "driver ({name}) upgrade (removal " "of alias '{alias}')",
+                {"name": driver_name, "alias": i},
+            )
 
-        @classmethod
-        def __activate_drivers(cls):
-                cls.__call([cls.usr_sbin + "devfsadm", "-u"],
-                    "Driver activation failed", {})
+    @classmethod
+    def __activate_drivers(cls):
+        cls.__call(
+            [cls.usr_sbin + "devfsadm", "-u"], "Driver activation failed", {}
+        )
 
-        def install(self, pkgplan, orig):
-                image = pkgplan.image
+    def install(self, pkgplan, orig):
+        image = pkgplan.image
 
-                if image.is_zone():
-                        return
+        if image.is_zone():
+            return
 
-                # See if it's installed
-                major = False
-                try:
-                        for fields in DriverAction.__gen_read_binding_file(
-                            image, "etc/name_to_major", minfields=2,
-                            maxfields=2):
-                                if fields[0] == self.attrs["name"]:
-                                        major = True
-                                        break
-                except IOError:
-                        pass
+        # See if it's installed
+        major = False
+        try:
+            for fields in DriverAction.__gen_read_binding_file(
+                image, "etc/name_to_major", minfields=2, maxfields=2
+            ):
+                if fields[0] == self.attrs["name"]:
+                    major = True
+                    break
+        except IOError:
+            pass
 
-                # Iterate through driver_aliases and the driver actions of the
-                # target image to see if this driver will bind to an alias that
-                # some other driver will bind to.  If we find that it will, and
-                # it's unclaimed by any other driver action, then we want to
-                # comment out (for easier recovery) the entry from the file.  If
-                # it's claimed by another driver action, then we should fail
-                # installation, as if two driver actions tried to deliver the
-                # same driver.  If it's unclaimed, but appears to belong to a
-                # driver of the same name as this one, we'll safely slurp it in
-                # with __get_image_data().
-                #
-                # XXX This check should be done in imageplan preexecution.
+        # Iterate through driver_aliases and the driver actions of the
+        # target image to see if this driver will bind to an alias that
+        # some other driver will bind to.  If we find that it will, and
+        # it's unclaimed by any other driver action, then we want to
+        # comment out (for easier recovery) the entry from the file.  If
+        # it's claimed by another driver action, then we should fail
+        # installation, as if two driver actions tried to deliver the
+        # same driver.  If it's unclaimed, but appears to belong to a
+        # driver of the same name as this one, we'll safely slurp it in
+        # with __get_image_data().
+        #
+        # XXX This check should be done in imageplan preexecution.
 
-                file_db = {}
-                alias_lines = {}
-                alias_conflict = None
-                lines = []
-                try:
-                        for fields in DriverAction.__gen_read_binding_file(
-                            image, "etc/driver_aliases", raw=True, minfields=2,
-                            maxfields=2):
-                                if isinstance(fields, str):
-                                        lines.append(fields + "\n")
-                                        continue
+        file_db = {}
+        alias_lines = {}
+        alias_conflict = None
+        lines = []
+        try:
+            for fields in DriverAction.__gen_read_binding_file(
+                image, "etc/driver_aliases", raw=True, minfields=2, maxfields=2
+            ):
+                if isinstance(fields, str):
+                    lines.append(fields + "\n")
+                    continue
 
-                                name, alias = fields
-                                file_db.setdefault(name, set()).add(alias)
-                                alias_lines.setdefault(alias, []).append(
-                                    (name, len(lines)))
-                                lines.append("{0} \"{1}\"\n".format(*fields))
-                except IOError:
-                        pass
+                name, alias = fields
+                file_db.setdefault(name, set()).add(alias)
+                alias_lines.setdefault(alias, []).append((name, len(lines)))
+                lines.append('{0} "{1}"\n'.format(*fields))
+        except IOError:
+            pass
 
-                a2d = getattr(image.imageplan, "alias_to_driver", None)
-                driver_actions = image.imageplan.get_actions("driver")
-                if a2d is None:
-                        # For all the drivers we know will be in the final
-                        # image, remove them from the db we made by slurping in
-                        # the aliases file.  What's left is what we should be
-                        # checking for dups against, along with the rest of the
-                        # drivers.
-                        for name in driver_actions:
-                                file_db.pop(name, None)
+        a2d = getattr(image.imageplan, "alias_to_driver", None)
+        driver_actions = image.imageplan.get_actions("driver")
+        if a2d is None:
+            # For all the drivers we know will be in the final
+            # image, remove them from the db we made by slurping in
+            # the aliases file.  What's left is what we should be
+            # checking for dups against, along with the rest of the
+            # drivers.
+            for name in driver_actions:
+                file_db.pop(name, None)
 
-                        # Build a mapping of aliases to driver names based on
-                        # the target image's driver actions.
-                        a2d = {}
-                        for alias, name in (
-                            (a, n)
-                            for n, act_list in six.iteritems(driver_actions)
-                            for act in act_list
-                            for a in act.attrlist("alias")
-                        ):
-                                a2d.setdefault(alias, set()).add(name)
+            # Build a mapping of aliases to driver names based on
+            # the target image's driver actions.
+            a2d = {}
+            for alias, name in (
+                (a, n)
+                for n, act_list in six.iteritems(driver_actions)
+                for act in act_list
+                for a in act.attrlist("alias")
+            ):
+                a2d.setdefault(alias, set()).add(name)
 
-                        # Enhance that mapping with data from driver_aliases.
-                        for name, aliases in six.iteritems(file_db):
-                                for alias in aliases:
-                                        a2d.setdefault(alias, set()).add(name)
+            # Enhance that mapping with data from driver_aliases.
+            for name, aliases in six.iteritems(file_db):
+                for alias in aliases:
+                    a2d.setdefault(alias, set()).add(name)
 
-                        # Stash this on the imageplan so we don't have to do the
-                        # work again.
-                        image.imageplan.alias_to_driver = a2d
+            # Stash this on the imageplan so we don't have to do the
+            # work again.
+            image.imageplan.alias_to_driver = a2d
 
-                for alias in self.attrlist("alias"):
-                        names = a2d[alias]
-                        assert self.attrs["name"] in names
-                        if len(names) > 1:
-                                alias_conflict = alias
-                                break
+        for alias in self.attrlist("alias"):
+            names = a2d[alias]
+            assert self.attrs["name"] in names
+            if len(names) > 1:
+                alias_conflict = alias
+                break
 
-                if alias_conflict:
-                        be_name = getattr(image.bootenv, "be_name_clone", None)
-                        name, line = alias_lines[alias_conflict][0]
-                        errdict = {
-                            "new": self.attrs["name"],
-                            "old": name,
-                            "alias": alias_conflict,
-                            "line": line,
-                            "be": be_name,
-                            "imgroot": image.get_root()
-                        }
-                        if name in driver_actions:
-                                raise RuntimeError("\
+        if alias_conflict:
+            be_name = getattr(image.bootenv, "be_name_clone", None)
+            name, line = alias_lines[alias_conflict][0]
+            errdict = {
+                "new": self.attrs["name"],
+                "old": name,
+                "alias": alias_conflict,
+                "line": line,
+                "be": be_name,
+                "imgroot": image.get_root(),
+            }
+            if name in driver_actions:
+                raise RuntimeError(
+                    "\
 The '{new}' driver shares the alias '{alias}' with the '{old}'\n\
 driver; both drivers cannot be installed simultaneously.  Please remove\n\
 the package delivering '{old}' or ensure that the package delivering\n\
-'{new}' will not be installed, and try the operation again.".format(**errdict))
-                        else:
-                                comment = "# pkg(7): "
-                                lines[line] = comment + lines[line]
-                                # XXX Module printing
-                                if be_name:
-                                        print("\
+'{new}' will not be installed, and try the operation again.".format(
+                        **errdict
+                    )
+                )
+            else:
+                comment = "# pkg(7): "
+                lines[line] = comment + lines[line]
+                # XXX Module printing
+                if be_name:
+                    print(
+                        "\
 The '{new}' driver shares the alias '{alias}' with the '{old}'\n\
 driver, but the system cannot determine how the latter was delivered.\n\
 Its entry on line {line:d} in /etc/driver_aliases has been commented\n\
@@ -274,734 +283,837 @@ into the '{be}' boot environment and invoking 'rem_drv {old}'\n\
 as well as removing line {line:d} from /etc/driver_aliases or, before\n\
 rebooting, mounting the '{be}' boot environment and running\n\
 'rem_drv -b <mountpoint> {old}' and removing line {line:d} from\n\
-<mountpoint>/etc/driver_aliases.".format(**errdict))
-                                else:
-                                        print("\
+<mountpoint>/etc/driver_aliases.".format(
+                            **errdict
+                        )
+                    )
+                else:
+                    print(
+                        "\
 The '{new}' driver shares the  alias '{alias}' with the '{old}'\n\
 driver, but the system cannot determine how the latter was delivered.\n\
 Its entry on line {line:d} in /etc/driver_aliases has been commented\n\
 out.  If this driver is no longer needed, it may be removed by invoking\n\
 'rem_drv -b {imgroot} {old}' as well as removing line {line:d}\n\
-from {imgroot}/etc/driver_aliases.".format(**errdict))
-
-                        dap = image.get_root() + "/etc/driver_aliases"
-                        datd, datp = mkstemp(suffix=".driver_aliases",
-                            dir=image.get_root() + "/etc")
-                        f = os.fdopen(datd, "w")
-                        f.writelines(lines)
-                        f.close()
-                        st = os.stat(dap)
-                        os.chmod(datp, st.st_mode)
-                        os.chown(datp, st.st_uid, st.st_gid)
-                        os.rename(datp, dap)
-
-                # In the case where the packaging system thinks the driver
-                # is installed and the driver database doesn't, do a fresh
-                # install instead of an update.  If the system thinks the driver
-                # is installed but the packaging has no previous knowledge of
-                # it, read the driver files to construct what *should* have been
-                # there, and proceed.
-                #
-                # XXX Log that this occurred.
-                if major and not orig:
-                        orig = self.__get_image_data(image, self.attrs["name"])
-                elif orig and not major:
-                        orig = None
-
-                if orig:
-                        return self.__update_install(image, orig)
-
-                if image.is_liveroot():
-                        args = ( self.add_drv, "-u" )
-                        image.imageplan.add_actuator("install",
-                            "activate-drivers", self.__activate_drivers)
-                else:
-                        args = ( self.add_drv, "-n", "-b", image.get_root() )
-
-                if "alias" in self.attrs:
-                        args += (
-                            "-i",
-                            " ".join([ '"{0}"'.format(x) for x in self.attrlist("alias") ])
+from {imgroot}/etc/driver_aliases.".format(
+                            **errdict
                         )
-                if "class" in self.attrs:
-                        args += (
-                            "-c",
-                            " ".join(self.attrlist("class"))
-                        )
-                if "perms" in self.attrs:
-                        args += (
-                            "-m",
-                            ",".join(self.attrlist("perms"))
-                        )
-                if "policy" in self.attrs:
-                        args += (
-                            "-p",
-                            " ".join(self.attrlist("policy"))
-                        )
-                if "privs" in self.attrs:
-                        args += (
-                            "-P",
-                            ",".join(self.attrlist("privs"))
-                        )
-
-                args += ( self.attrs["name"], )
-
-                self.__call(args, "driver ({name}) install",
-                    {"name": self.attrs["name"]})
-
-                for cp in self.attrlist("clone_perms"):
-                        args = (
-                            self.update_drv, "-b", image.get_root(), "-a",
-                            "-m", cp, "clone"
-                        )
-                        self.__call(args, "driver ({name}) clone permission "
-                            "update", {"name": self.attrs["name"]})
-
-                if "devlink" in self.attrs:
-                        dlp = os.path.normpath(os.path.join(
-                            image.get_root(), "etc/devlink.tab"))
-                        dlf = open(dlp)
-                        dllines = dlf.readlines()
-                        dlf.close()
-                        st = os.stat(dlp)
-
-                        dlt, dltp = mkstemp(suffix=".devlink.tab",
-                            dir=image.get_root() + "/etc")
-                        dlt = os.fdopen(dlt, "w")
-                        dlt.writelines(dllines)
-                        dlt.writelines((
-                            s.replace("\\t", "\t") + "\n"
-                            for s in self.attrlist("devlink")
-                            if s.replace("\\t", "\t") + "\n" not in dllines
-                        ))
-                        dlt.close()
-                        os.chmod(dltp, st.st_mode)
-                        os.chown(dltp, st.st_uid, st.st_gid)
-                        os.rename(dltp, dlp)
-
-        def __update_install(self, image, orig):
-                add_base = ( self.update_drv, "-b", image.get_root(), "-a" )
-                rem_base = ( self.update_drv, "-b", image.get_root(), "-d" )
-
-                add_alias = set(self.attrlist("alias")) - \
-                    set(orig.attrlist("alias"))
-
-                nclass = set(self.attrlist("class"))
-                oclass = set(orig.attrlist("class"))
-                add_class = nclass - oclass
-                rem_class = oclass - nclass
-
-                nperms = set(self.attrlist("perms"))
-                operms = set(orig.attrlist("perms"))
-                add_perms = nperms - operms
-                rem_perms = operms - nperms
-
-                nprivs = set(self.attrlist("privs"))
-                oprivs = set(orig.attrlist("privs"))
-                add_privs = nprivs - oprivs
-                rem_privs = oprivs - nprivs
-
-                npolicy = set(self.attrlist("policy"))
-                opolicy = set(orig.attrlist("policy"))
-                add_policy = npolicy - opolicy
-                rem_policy = opolicy - npolicy
-
-                nclone = set(self.attrlist("clone_perms"))
-                oclone = set(orig.attrlist("clone_perms"))
-                add_clone = nclone - oclone
-                rem_clone = oclone - nclone
-
-                for i in add_alias:
-                        args = add_base + ("-i", '{0}'.format(i),
-                            self.attrs["name"])
-                        self.__call(args, "driver ({name}) upgrade (addition "
-                            "of alias '{alias}')",
-                            {"name": self.attrs["name"], "alias": i})
-
-                # Removing aliases has already been taken care of in
-                # imageplan.execute by calling remove_aliases.
-
-                # update_drv doesn't do anything with classes, so we have to
-                # futz with driver_classes by hand.
-                def update_classes(add_class, rem_class):
-                        dcp = os.path.normpath(os.path.join(
-                            image.get_root(), "etc/driver_classes"))
-
-                        try:
-                                dcf = open(dcp, "r")
-                                lines = dcf.readlines()
-                                dcf.close()
-                        except IOError as e:
-                                e.args += ("reading",)
-                                raise
-
-                        for i, l in enumerate(lines):
-                                arr = l.split()
-                                if len(arr) == 2 and \
-                                    arr[0] == self.attrs["name"] and \
-                                    arr[1] in rem_class:
-                                        del lines[i]
-
-                        for i in add_class:
-                                lines += ["{0}\t{1}\n".format(
-                                    self.attrs["name"], i)]
-
-                        try:
-                                dcf = open(dcp, "w")
-                                dcf.writelines(lines)
-                                dcf.close()
-                        except IOError as e:
-                                e.args += ("writing",)
-                                raise
-
-                if add_class or rem_class:
-                        try:
-                                update_classes(add_class, rem_class)
-                        except IOError as e:
-                                print("{0} ({1}) upgrade (classes modification) "
-                                    "failed {2} etc/driver_classes with error: "
-                                    "{3} ({4})".format(self.name,
-                                    self.attrs["name"], e.args[1],
-                                    e.args[0], e.args[2]))
-                                print("tried to add {0} and remove {1}".format(
-                                    add_class, rem_class))
-
-                # We have to update devlink.tab by hand, too.
-                def update_devlinks():
-                        dlp = os.path.normpath(os.path.join(
-                            image.get_root(), "etc/devlink.tab"))
-
-                        try:
-                                dlf = open(dlp)
-                                lines = dlf.readlines()
-                                dlf.close()
-                                st = os.stat(dlp)
-                        except IOError as e:
-                                e.args += ("reading",)
-                                raise
-
-                        olines = set(orig.attrlist("devlink"))
-                        nlines = set(self.attrlist("devlink"))
-                        add_lines = nlines - olines
-                        rem_lines = olines - nlines
-
-                        missing_entries = []
-                        for line in rem_lines:
-                                try:
-                                        lineno = lines.index(line.replace("\\t", "\t") + "\n")
-                                except ValueError:
-                                        missing_entries.append(line.replace("\\t", "\t"))
-                                        continue
-                                del lines[lineno]
-
-                        # Don't put in duplicates.  Because there's no way to
-                        # tell what driver owns what line, this means that if
-                        # two drivers try to own the same line, one of them will
-                        # be unhappy if the other is uninstalled.  So don't do
-                        # that.
-                        lines.extend((
-                            s.replace("\\t", "\t") + "\n"
-                            for s in add_lines
-                            if s.replace("\\t", "\t") + "\n" not in lines
-                        ))
-
-                        try:
-                                dlt, dltp = mkstemp(suffix=".devlink.tab",
-                                    dir=image.get_root() + "/etc")
-                                dlt = os.fdopen(dlt, "w")
-                                dlt.writelines(lines)
-                                dlt.close()
-                                os.chmod(dltp, st.st_mode)
-                                os.chown(dltp, st.st_uid, st.st_gid)
-                                os.rename(dltp, dlp)
-                        except EnvironmentError as e:
-                                e.args += ("writing",)
-                                raise
-
-                        if missing_entries:
-                                raise RuntimeError(missing_entries)
-
-                if "devlink" in orig.attrs or "devlink" in self.attrs:
-                        try:
-                                update_devlinks()
-                        except IOError as e:
-                                print("{0} ({1}) upgrade (devlinks modification) "
-                                    "failed {2} etc/devlink.tab with error: "
-                                    "{3} ({4})".format(self.name,
-                                    self.attrs["name"], e.args[1],
-                                    e.args[0], e.args[2]))
-                        except RuntimeError as e:
-                                print("{0} ({1}) upgrade (devlinks modification) "
-                                    "failed modifying\netc/devlink.tab.  The "
-                                    "following entries were to be removed, "
-                                    "but were\nnot found:\n    ".format(
-                                    self.name, self.attrs["name"]) +
-                                    "\n    ".join(e.args[0]))
-
-                # For perms, we do removes first because of a busted starting
-                # point in build 79, where smbsrv has perms of both "* 666" and
-                # "* 640".  The actions move us from 666 to 640, but if we add
-                # first, the 640 overwrites the 666 in the file, and then the
-                # deletion of 666 complains and fails.
-                #
-                # We can get around it by removing the 666 first, and then
-                # adding the 640, which overwrites the existing 640.
-                #
-                # XXX Need to think if there are any cases where this might be
-                # the wrong order, and whether the other attributes should be
-                # done in this order, too.
-                for i in rem_perms:
-                        args = rem_base + ("-m", i, self.attrs["name"])
-                        self.__call(args, "driver ({name}) upgrade (removal "
-                            "of minor perm '{perm}')",
-                            {"name": self.attrs["name"], "perm": i})
-
-                for i in add_perms:
-                        args = add_base + ("-m", i, self.attrs["name"])
-                        self.__call(args, "driver ({name}) upgrade (addition "
-                            "of minor perm '{perm}')",
-                            {"name": self.attrs["name"], "perm": i})
-
-                for i in add_privs:
-                        args = add_base + ("-P", i, self.attrs["name"])
-                        self.__call(args, "driver ({name}) upgrade (addition "
-                            "of privilege '{priv}')",
-                            {"name": self.attrs["name"], "priv": i})
-
-                for i in rem_privs:
-                        args = rem_base + ("-P", i, self.attrs["name"])
-                        self.__call(args, "driver ({name}) upgrade (removal "
-                            "of privilege '{priv}')",
-                            {"name": self.attrs["name"], "priv": i})
-
-                # We remove policies before adding them, since removing a policy
-                # for a driver/minor combination removes it completely from the
-                # policy file, not just the subset you might have specified.
-                #
-                # Also, when removing a policy, there is no way to convince
-                # update_drv to remove it unless there's a minor node associated
-                # with it.
-                for i in rem_policy:
-                        spec = i.split()
-                        # Test if there is a minor node and if so use it
-                        # for the policy removal. Otherwise, if none is
-                        # supplied, then use the wild card to match.
-                        if len(spec) == 3:
-                                minornode = spec[0]
-                        elif len(spec) == 2:
-                                # This can happen when the policy is defined
-                                # in the package manifest without an associated
-                                # minor node.
-                                minornode = "*"
-                        else:
-                                print("driver ({0}) update (removal of "
-                                    "policy '{1}') failed: invalid policy "
-                                    "spec.".format(self.attrs["name"], i))
-                                continue
-
-                        args = rem_base + ("-p", minornode, self.attrs["name"])
-                        self.__call(args, "driver ({name}) upgrade (removal "
-                            "of policy '{policy}')",
-                            {"name": self.attrs["name"], "policy": i})
-
-                for i in add_policy:
-                        args = add_base + ("-p", i, self.attrs["name"])
-                        self.__call(args, "driver ({name}) upgrade (addition "
-                            "of policy '{policy}')",
-                            {"name": self.attrs["name"], "policy": i})
-
-                for i in rem_clone:
-                        args = rem_base + ("-m", i, "clone")
-                        self.__call(args, "driver ({name}) upgrade (removal "
-                            "of clone permission '{perm}')",
-                            {"name": self.attrs["name"], "perm": i})
-
-                for i in add_clone:
-                        args = add_base + ("-m", i, "clone")
-                        self.__call(args, "driver ({name}) upgrade (addition "
-                            "of clone permission '{perm}')",
-                            {"name": self.attrs["name"], "perm": i})
-
-        @staticmethod
-        def __gen_read_binding_file(img, path, minfields=None, maxfields=None,
-            raw=False):
-
-                myfile = open(os.path.normpath(os.path.join(
-                    img.get_root(), path)))
-                for line in myfile:
-                        line = line.strip()
-                        fields = line.split()
-                        result_fields = []
-                        for field in fields:
-                                # This is a compromise, for now.  In fact,
-                                # comments can begin anywhere in the line,
-                                # except inside of quoted material.
-                                if field[0] == "#":
-                                        break
-                                field = field.strip('"')
-                                result_fields.append(field)
-
-                        if minfields is not None:
-                                if len(result_fields) < minfields:
-                                        if raw:
-                                                yield line
-                                        continue
-
-                        if maxfields is not None:
-                                if len(result_fields) > maxfields:
-                                        if raw:
-                                                yield line
-                                        continue
-
-                        if result_fields:
-                                yield result_fields
-                        elif raw:
-                                yield line
-                myfile.close()
-
-
-        @classmethod
-        def __get_image_data(cls, img, name, collect_errs = False):
-                """Construct a driver action from image information.
-
-                Setting 'collect_errs' to True will collect all caught
-                exceptions and return them in a tuple with the action.
-                """
-
-                errors = []
-
-                # See if it's installed
-                found_major = 0
-                try:
-                        for fields in DriverAction.__gen_read_binding_file(img,
-                             "etc/name_to_major", minfields=2, maxfields=2):
-                                if fields[0] == name:
-                                        found_major += 1
-                except IOError as e:
-                        e.args += ("etc/name_to_major",)
-                        if collect_errs:
-                                errors.append(e)
-                        else:
-                                raise
-
-                if found_major == 0:
-                        if collect_errs:
-                                return None, []
-                        else:
-                                return None
-
-                if found_major > 1:
-                        try:
-                                raise RuntimeError(
-                                    "More than one entry for driver '{0}' in "
-                                    "/etc/name_to_major".format(name))
-                        except RuntimeError as e:
-                                if collect_errs:
-                                        errors.append(e)
-                                else:
-                                        raise
-
-                act = cls(name=name)
-
-                # Grab aliases
-                try:
-                        act.attrs["alias"] = []
-                        for fields in DriverAction.__gen_read_binding_file(img,
-                             "etc/driver_aliases", minfields=2, maxfields=2):
-                                if fields[0] == name:
-                                        act.attrs["alias"].append(fields[1])
-                except IOError as e:
-                        e.args += ("etc/driver_aliases",)
-                        if collect_errs:
-                                errors.append(e)
-                        else:
-                                raise
-
-                # Grab classes
-                try:
-                        act.attrs["class"] = []
-                        for fields in DriverAction.__gen_read_binding_file(img,
-                             "etc/driver_classes", minfields=2, maxfields=2):
-                                if fields[0] == name:
-                                        act.attrs["class"].append(fields[1])
-                except IOError as e:
-                        e.args += ("etc/driver_classes",)
-                        if collect_errs:
-                                errors.append(e)
-                        else:
-                                raise
-
-                # Grab minor node permissions.  Note that the clone driver
-                # action doesn't actually own its minor node perms; those are
-                # owned by other driver actions, through their clone_perms
-                # attributes.
-                try:
-                        act.attrs["perms"] = []
-                        act.attrs["clone_perms"] = []
-                        for fields in DriverAction.__gen_read_binding_file(img,
-                             "etc/minor_perm", minfields=4, maxfields=4):
-                                # Break first field into pieces.
-                                namefields = fields[0].split(":")
-                                if len(namefields) != 2:
-                                        continue
-                                major = namefields[0]
-                                minor = namefields[1]
-                                if major == name and name != "clone":
-                                        act.attrs["perms"].append(
-                                            minor + " " + " ".join(fields[1:]))
-                                elif major == "clone" and minor == name:
-                                        act.attrs["clone_perms"].append(
-                                            minor + " " + " ".join(fields[1:]))
-                except IOError as e:
-                        e.args += ("etc/minor_perm",)
-                        if collect_errs:
-                                errors.append(e)
-                        else:
-                                raise
-
-                # Grab device policy
-                try:
-                        dpf = open(os.path.normpath(os.path.join(
-                            img.get_root(), "etc/security/device_policy")))
-                except IOError as e:
-                        e.args += ("etc/security/device_policy",)
-                        if collect_errs:
-                                errors.append(e)
-                        else:
-                                raise
-                else:
-                        act.attrs["policy"] = [ ]
-                        for line in dpf:
-                                line = line.strip()
-                                if line.startswith("#"):
-                                        continue
-                                fields = line.split()
-                                if len(fields) < 2:
-                                        continue
-                                n = ""
-                                try:
-                                        n, c = fields[0].split(":", 1)
-                                        fields[0] = c
-                                except ValueError:
-                                        # If there is no minor node
-                                        # specificition then set it to the
-                                        # wildcard but saving the driver
-                                        # name first.
-                                        n = fields[0]
-                                        fields[0] = "*"
-                                except IndexError:
-                                        pass
-
-                                if n == name:
-                                        act.attrs["policy"].append(
-                                            " ".join(fields)
-                                        )
-                        dpf.close()
-
-                # Grab device privileges
-                try:
-                        dpf = open(os.path.normpath(os.path.join(
-                            img.get_root(), "etc/security/extra_privs")))
-                except IOError as e:
-                        e.args += ("etc/security/extra_privs",)
-                        if collect_errs:
-                                errors.append(e)
-                        else:
-                                raise
-                else:
-                        act.attrs["privs"] = [ ]
-                        for line in dpf:
-                                line = line.strip()
-                                if line.startswith("#"):
-                                        continue
-                                fields = line.split(":", 1)
-                                if len(fields) != 2:
-                                        continue
-                                if fields[0] == name:
-                                        act.attrs["privs"].append(fields[1])
-                        dpf.close()
-
-                if collect_errs:
-                        return act, errors
-                else:
-                        return act
-
-        def verify(self, img, **args):
-                """Returns a tuple of lists of the form (errors, warnings,
-                info).  The error list will be empty if the action has been
-                correctly installed in the given image."""
-
-                errors = []
-                warnings = []
-                info = []
-                if img.is_zone():
-                        return errors, warnings, info
-
-                name = self.attrs["name"]
-
-                onfs, errors = \
-                    self.__get_image_data(img, name, collect_errs = True)
-
-                for i, err in enumerate(errors):
-                        if isinstance(err, IOError):
-                                errors[i] = "{0}: {1}".format(err.args[2], err)
-                        elif isinstance(err, RuntimeError):
-                                errors[i] = _("etc/name_to_major: more than "
-                                    "one entry for '{0}' is present").format(
-                                    name)
-
-                if not onfs:
-                        errors[0:0] = [
-                            _("etc/name_to_major: '{0}' entry not present").format(
-                            name)
-                        ]
-                        return errors, warnings, info
-
-                onfs_aliases = set(onfs.attrlist("alias"))
-                mfst_aliases = set(self.attrlist("alias"))
-                for a in onfs_aliases - mfst_aliases:
-                        warnings.append(_("extra alias '{0}' found in "
-                            "etc/driver_aliases").format(a))
-                for a in mfst_aliases - onfs_aliases:
-                        errors.append(_("alias '{0}' missing from "
-                        "etc/driver_aliases").format(a))
-
-                onfs_classes = set(onfs.attrlist("class"))
-                mfst_classes = set(self.attrlist("class"))
-                for a in onfs_classes - mfst_classes:
-                        warnings.append(_("extra class '{0}' found in "
-                            "etc/driver_classes").format(a))
-                for a in mfst_classes - onfs_classes:
-                        errors.append(_("class '{0}' missing from "
-                            "etc/driver_classes").format(a))
-
-                onfs_perms = set(onfs.attrlist("perms"))
-                mfst_perms = set(self.attrlist("perms"))
-                for a in onfs_perms - mfst_perms:
-                        warnings.append(_("extra minor node permission '{0}' "
-                            "found in etc/minor_perm").format(a))
-                for a in mfst_perms - onfs_perms:
-                        errors.append(_("minor node permission '{0}' missing "
-                            "from etc/minor_perm").format(a))
-
-                # Canonicalize "*" minorspecs to empty
-                policylist = list(onfs.attrlist("policy"))
-                for i, p in enumerate(policylist):
-                        f = p.split()
-                        if f[0] == "*":
-                                policylist[i] = " ".join(f[1:])
-                onfs_policy = set(policylist)
-
-                policylist = self.attrlist("policy")
-                for i, p in enumerate(policylist):
-                        f = p.split()
-                        if f[0] == "*":
-                                policylist[i] = " ".join(f[1:])
-                mfst_policy = set(policylist)
-                for a in onfs_policy - mfst_policy:
-                        warnings.append(_("extra device policy '{0}' found in "
-                            "etc/security/device_policy").format(a))
-                for a in mfst_policy - onfs_policy:
-                        errors.append(_("device policy '{0}' missing from "
-                            "etc/security/device_policy").format(a))
-
-                onfs_privs = set(onfs.attrlist("privs"))
-                mfst_privs = set(self.attrlist("privs"))
-                for a in onfs_privs - mfst_privs:
-                        warnings.append(_("extra device privilege '{0}' found "
-                            "in etc/security/extra_privs").format(a))
-                for a in mfst_privs - onfs_privs:
-                        errors.append(_("device privilege '{0}' missing from "
-                            "etc/security/extra_privs").format(a))
-
-                return errors, warnings, info
-
-        def remove(self, pkgplan):
-                image = pkgplan.image
-
-                if image.is_zone():
-                        return
-
-                args = (
-                    self.rem_drv,
-                    "-b",
-                    image.get_root(),
-                    self.attrs["name"]
+                    )
+
+            dap = image.get_root() + "/etc/driver_aliases"
+            datd, datp = mkstemp(
+                suffix=".driver_aliases", dir=image.get_root() + "/etc"
+            )
+            f = os.fdopen(datd, "w")
+            f.writelines(lines)
+            f.close()
+            st = os.stat(dap)
+            os.chmod(datp, st.st_mode)
+            os.chown(datp, st.st_uid, st.st_gid)
+            os.rename(datp, dap)
+
+        # In the case where the packaging system thinks the driver
+        # is installed and the driver database doesn't, do a fresh
+        # install instead of an update.  If the system thinks the driver
+        # is installed but the packaging has no previous knowledge of
+        # it, read the driver files to construct what *should* have been
+        # there, and proceed.
+        #
+        # XXX Log that this occurred.
+        if major and not orig:
+            orig = self.__get_image_data(image, self.attrs["name"])
+        elif orig and not major:
+            orig = None
+
+        if orig:
+            return self.__update_install(image, orig)
+
+        if image.is_liveroot():
+            args = (self.add_drv, "-u")
+            image.imageplan.add_actuator(
+                "install", "activate-drivers", self.__activate_drivers
+            )
+        else:
+            args = (self.add_drv, "-n", "-b", image.get_root())
+
+        if "alias" in self.attrs:
+            args += (
+                "-i",
+                " ".join(['"{0}"'.format(x) for x in self.attrlist("alias")]),
+            )
+        if "class" in self.attrs:
+            args += ("-c", " ".join(self.attrlist("class")))
+        if "perms" in self.attrs:
+            args += ("-m", ",".join(self.attrlist("perms")))
+        if "policy" in self.attrs:
+            args += ("-p", " ".join(self.attrlist("policy")))
+        if "privs" in self.attrs:
+            args += ("-P", ",".join(self.attrlist("privs")))
+
+        args += (self.attrs["name"],)
+
+        self.__call(
+            args, "driver ({name}) install", {"name": self.attrs["name"]}
+        )
+
+        for cp in self.attrlist("clone_perms"):
+            args = (
+                self.update_drv,
+                "-b",
+                image.get_root(),
+                "-a",
+                "-m",
+                cp,
+                "clone",
+            )
+            self.__call(
+                args,
+                "driver ({name}) clone permission " "update",
+                {"name": self.attrs["name"]},
+            )
+
+        if "devlink" in self.attrs:
+            dlp = os.path.normpath(
+                os.path.join(image.get_root(), "etc/devlink.tab")
+            )
+            dlf = open(dlp)
+            dllines = dlf.readlines()
+            dlf.close()
+            st = os.stat(dlp)
+
+            dlt, dltp = mkstemp(
+                suffix=".devlink.tab", dir=image.get_root() + "/etc"
+            )
+            dlt = os.fdopen(dlt, "w")
+            dlt.writelines(dllines)
+            dlt.writelines(
+                (
+                    s.replace("\\t", "\t") + "\n"
+                    for s in self.attrlist("devlink")
+                    if s.replace("\\t", "\t") + "\n" not in dllines
+                )
+            )
+            dlt.close()
+            os.chmod(dltp, st.st_mode)
+            os.chown(dltp, st.st_uid, st.st_gid)
+            os.rename(dltp, dlp)
+
+    def __update_install(self, image, orig):
+        add_base = (self.update_drv, "-b", image.get_root(), "-a")
+        rem_base = (self.update_drv, "-b", image.get_root(), "-d")
+
+        add_alias = set(self.attrlist("alias")) - set(orig.attrlist("alias"))
+
+        nclass = set(self.attrlist("class"))
+        oclass = set(orig.attrlist("class"))
+        add_class = nclass - oclass
+        rem_class = oclass - nclass
+
+        nperms = set(self.attrlist("perms"))
+        operms = set(orig.attrlist("perms"))
+        add_perms = nperms - operms
+        rem_perms = operms - nperms
+
+        nprivs = set(self.attrlist("privs"))
+        oprivs = set(orig.attrlist("privs"))
+        add_privs = nprivs - oprivs
+        rem_privs = oprivs - nprivs
+
+        npolicy = set(self.attrlist("policy"))
+        opolicy = set(orig.attrlist("policy"))
+        add_policy = npolicy - opolicy
+        rem_policy = opolicy - npolicy
+
+        nclone = set(self.attrlist("clone_perms"))
+        oclone = set(orig.attrlist("clone_perms"))
+        add_clone = nclone - oclone
+        rem_clone = oclone - nclone
+
+        for i in add_alias:
+            args = add_base + ("-i", "{0}".format(i), self.attrs["name"])
+            self.__call(
+                args,
+                "driver ({name}) upgrade (addition " "of alias '{alias}')",
+                {"name": self.attrs["name"], "alias": i},
+            )
+
+        # Removing aliases has already been taken care of in
+        # imageplan.execute by calling remove_aliases.
+
+        # update_drv doesn't do anything with classes, so we have to
+        # futz with driver_classes by hand.
+        def update_classes(add_class, rem_class):
+            dcp = os.path.normpath(
+                os.path.join(image.get_root(), "etc/driver_classes")
+            )
+
+            try:
+                dcf = open(dcp, "r")
+                lines = dcf.readlines()
+                dcf.close()
+            except IOError as e:
+                e.args += ("reading",)
+                raise
+
+            for i, l in enumerate(lines):
+                arr = l.split()
+                if (
+                    len(arr) == 2
+                    and arr[0] == self.attrs["name"]
+                    and arr[1] in rem_class
+                ):
+                    del lines[i]
+
+            for i in add_class:
+                lines += ["{0}\t{1}\n".format(self.attrs["name"], i)]
+
+            try:
+                dcf = open(dcp, "w")
+                dcf.writelines(lines)
+                dcf.close()
+            except IOError as e:
+                e.args += ("writing",)
+                raise
+
+        if add_class or rem_class:
+            try:
+                update_classes(add_class, rem_class)
+            except IOError as e:
+                print(
+                    "{0} ({1}) upgrade (classes modification) "
+                    "failed {2} etc/driver_classes with error: "
+                    "{3} ({4})".format(
+                        self.name,
+                        self.attrs["name"],
+                        e.args[1],
+                        e.args[0],
+                        e.args[2],
+                    )
+                )
+                print(
+                    "tried to add {0} and remove {1}".format(
+                        add_class, rem_class
+                    )
                 )
 
-                self.__call(args, "driver ({name}) removal",
-                    {"name": self.attrs["name"]})
+        # We have to update devlink.tab by hand, too.
+        def update_devlinks():
+            dlp = os.path.normpath(
+                os.path.join(image.get_root(), "etc/devlink.tab")
+            )
 
-                for cp in self.attrlist("clone_perms"):
-                        args = (
-                            self.update_drv, "-b", image.get_root(),
-                            "-d", "-m", cp, "clone"
-                        )
-                        self.__call(args, "driver ({name}) clone permission "
-                            "update", {"name": self.attrs["name"]})
+            try:
+                dlf = open(dlp)
+                lines = dlf.readlines()
+                dlf.close()
+                st = os.stat(dlp)
+            except IOError as e:
+                e.args += ("reading",)
+                raise
 
-                if "devlink" in self.attrs:
-                        dlp = os.path.normpath(os.path.join(
-                            image.get_root(), "etc/devlink.tab"))
+            olines = set(orig.attrlist("devlink"))
+            nlines = set(self.attrlist("devlink"))
+            add_lines = nlines - olines
+            rem_lines = olines - nlines
 
-                        try:
-                                dlf = open(dlp)
-                                lines = dlf.readlines()
-                                dlf.close()
-                                st = os.stat(dlp)
-                        except IOError as e:
-                                print("{0} ({1}) removal (devlinks modification) "
-                                    "failed reading etc/devlink.tab with error: "
-                                    "{2} ({3})".format(self.name,
-                                    self.attrs["name"], e.args[0], e.args[1]))
-                                return
+            missing_entries = []
+            for line in rem_lines:
+                try:
+                    lineno = lines.index(line.replace("\\t", "\t") + "\n")
+                except ValueError:
+                    missing_entries.append(line.replace("\\t", "\t"))
+                    continue
+                del lines[lineno]
 
-                        devlinks = self.attrlist("devlink")
+            # Don't put in duplicates.  Because there's no way to
+            # tell what driver owns what line, this means that if
+            # two drivers try to own the same line, one of them will
+            # be unhappy if the other is uninstalled.  So don't do
+            # that.
+            lines.extend(
+                (
+                    s.replace("\\t", "\t") + "\n"
+                    for s in add_lines
+                    if s.replace("\\t", "\t") + "\n" not in lines
+                )
+            )
 
-                        missing_entries = []
-                        for line in devlinks:
-                                try:
-                                        lineno = lines.index(line.replace("\\t", "\t") + "\n")
-                                except ValueError:
-                                        missing_entries.append(line.replace("\\t", "\t"))
-                                        continue
-                                del lines[lineno]
+            try:
+                dlt, dltp = mkstemp(
+                    suffix=".devlink.tab", dir=image.get_root() + "/etc"
+                )
+                dlt = os.fdopen(dlt, "w")
+                dlt.writelines(lines)
+                dlt.close()
+                os.chmod(dltp, st.st_mode)
+                os.chown(dltp, st.st_uid, st.st_gid)
+                os.rename(dltp, dlp)
+            except EnvironmentError as e:
+                e.args += ("writing",)
+                raise
 
-                        if missing_entries:
-                                print("{0} ({1}) removal (devlinks modification) "
-                                    "failed modifying\netc/devlink.tab.  The "
-                                    "following entries were to be removed, "
-                                    "but were\nnot found:\n    ".format(
-                                    self.name, self.attrs["name"]) +
-                                    "\n    ".join(missing_entries))
+            if missing_entries:
+                raise RuntimeError(missing_entries)
 
-                        try:
-                                dlt, dltp = mkstemp(suffix=".devlink.tab",
-                                    dir=image.get_root() + "/etc")
-                                dlt = os.fdopen(dlt, "w")
-                                dlt.writelines(lines)
-                                dlt.close()
-                                os.chmod(dltp, st.st_mode)
-                                os.chown(dltp, st.st_uid, st.st_gid)
-                                os.rename(dltp, dlp)
-                        except EnvironmentError as e:
-                                print("{0} ({1}) removal (devlinks modification) "
-                                    "failed writing etc/devlink.tab with error: "
-                                    "{2} ({3})".format(self.name,
-                                    self.attrs["name"], e.args[0], e.args[1]))
+        if "devlink" in orig.attrs or "devlink" in self.attrs:
+            try:
+                update_devlinks()
+            except IOError as e:
+                print(
+                    "{0} ({1}) upgrade (devlinks modification) "
+                    "failed {2} etc/devlink.tab with error: "
+                    "{3} ({4})".format(
+                        self.name,
+                        self.attrs["name"],
+                        e.args[1],
+                        e.args[0],
+                        e.args[2],
+                    )
+                )
+            except RuntimeError as e:
+                print(
+                    "{0} ({1}) upgrade (devlinks modification) "
+                    "failed modifying\netc/devlink.tab.  The "
+                    "following entries were to be removed, "
+                    "but were\nnot found:\n    ".format(
+                        self.name, self.attrs["name"]
+                    )
+                    + "\n    ".join(e.args[0])
+                )
 
-        def generate_indices(self):
-                """Generates the indices needed by the search dictionary.  See
-                generic.py for a more detailed explanation."""
+        # For perms, we do removes first because of a busted starting
+        # point in build 79, where smbsrv has perms of both "* 666" and
+        # "* 640".  The actions move us from 666 to 640, but if we add
+        # first, the 640 overwrites the 666 in the file, and then the
+        # deletion of 666 complains and fails.
+        #
+        # We can get around it by removing the 666 first, and then
+        # adding the 640, which overwrites the existing 640.
+        #
+        # XXX Need to think if there are any cases where this might be
+        # the wrong order, and whether the other attributes should be
+        # done in this order, too.
+        for i in rem_perms:
+            args = rem_base + ("-m", i, self.attrs["name"])
+            self.__call(
+                args,
+                "driver ({name}) upgrade (removal " "of minor perm '{perm}')",
+                {"name": self.attrs["name"], "perm": i},
+            )
 
-                ret = []
-                if "name" in self.attrs:
-                        ret.append(("driver", "driver_name", self.attrs["name"],
-                            None))
-                if "alias" in self.attrs:
-                        ret.append(("driver", "alias", self.attrs["alias"],
-                            None))
-                return ret
+        for i in add_perms:
+            args = add_base + ("-m", i, self.attrs["name"])
+            self.__call(
+                args,
+                "driver ({name}) upgrade (addition " "of minor perm '{perm}')",
+                {"name": self.attrs["name"], "perm": i},
+            )
+
+        for i in add_privs:
+            args = add_base + ("-P", i, self.attrs["name"])
+            self.__call(
+                args,
+                "driver ({name}) upgrade (addition " "of privilege '{priv}')",
+                {"name": self.attrs["name"], "priv": i},
+            )
+
+        for i in rem_privs:
+            args = rem_base + ("-P", i, self.attrs["name"])
+            self.__call(
+                args,
+                "driver ({name}) upgrade (removal " "of privilege '{priv}')",
+                {"name": self.attrs["name"], "priv": i},
+            )
+
+        # We remove policies before adding them, since removing a policy
+        # for a driver/minor combination removes it completely from the
+        # policy file, not just the subset you might have specified.
+        #
+        # Also, when removing a policy, there is no way to convince
+        # update_drv to remove it unless there's a minor node associated
+        # with it.
+        for i in rem_policy:
+            spec = i.split()
+            # Test if there is a minor node and if so use it
+            # for the policy removal. Otherwise, if none is
+            # supplied, then use the wild card to match.
+            if len(spec) == 3:
+                minornode = spec[0]
+            elif len(spec) == 2:
+                # This can happen when the policy is defined
+                # in the package manifest without an associated
+                # minor node.
+                minornode = "*"
+            else:
+                print(
+                    "driver ({0}) update (removal of "
+                    "policy '{1}') failed: invalid policy "
+                    "spec.".format(self.attrs["name"], i)
+                )
+                continue
+
+            args = rem_base + ("-p", minornode, self.attrs["name"])
+            self.__call(
+                args,
+                "driver ({name}) upgrade (removal " "of policy '{policy}')",
+                {"name": self.attrs["name"], "policy": i},
+            )
+
+        for i in add_policy:
+            args = add_base + ("-p", i, self.attrs["name"])
+            self.__call(
+                args,
+                "driver ({name}) upgrade (addition " "of policy '{policy}')",
+                {"name": self.attrs["name"], "policy": i},
+            )
+
+        for i in rem_clone:
+            args = rem_base + ("-m", i, "clone")
+            self.__call(
+                args,
+                "driver ({name}) upgrade (removal "
+                "of clone permission '{perm}')",
+                {"name": self.attrs["name"], "perm": i},
+            )
+
+        for i in add_clone:
+            args = add_base + ("-m", i, "clone")
+            self.__call(
+                args,
+                "driver ({name}) upgrade (addition "
+                "of clone permission '{perm}')",
+                {"name": self.attrs["name"], "perm": i},
+            )
+
+    @staticmethod
+    def __gen_read_binding_file(
+        img, path, minfields=None, maxfields=None, raw=False
+    ):
+        myfile = open(os.path.normpath(os.path.join(img.get_root(), path)))
+        for line in myfile:
+            line = line.strip()
+            fields = line.split()
+            result_fields = []
+            for field in fields:
+                # This is a compromise, for now.  In fact,
+                # comments can begin anywhere in the line,
+                # except inside of quoted material.
+                if field[0] == "#":
+                    break
+                field = field.strip('"')
+                result_fields.append(field)
+
+            if minfields is not None:
+                if len(result_fields) < minfields:
+                    if raw:
+                        yield line
+                    continue
+
+            if maxfields is not None:
+                if len(result_fields) > maxfields:
+                    if raw:
+                        yield line
+                    continue
+
+            if result_fields:
+                yield result_fields
+            elif raw:
+                yield line
+        myfile.close()
+
+    @classmethod
+    def __get_image_data(cls, img, name, collect_errs=False):
+        """Construct a driver action from image information.
+
+        Setting 'collect_errs' to True will collect all caught
+        exceptions and return them in a tuple with the action.
+        """
+
+        errors = []
+
+        # See if it's installed
+        found_major = 0
+        try:
+            for fields in DriverAction.__gen_read_binding_file(
+                img, "etc/name_to_major", minfields=2, maxfields=2
+            ):
+                if fields[0] == name:
+                    found_major += 1
+        except IOError as e:
+            e.args += ("etc/name_to_major",)
+            if collect_errs:
+                errors.append(e)
+            else:
+                raise
+
+        if found_major == 0:
+            if collect_errs:
+                return None, []
+            else:
+                return None
+
+        if found_major > 1:
+            try:
+                raise RuntimeError(
+                    "More than one entry for driver '{0}' in "
+                    "/etc/name_to_major".format(name)
+                )
+            except RuntimeError as e:
+                if collect_errs:
+                    errors.append(e)
+                else:
+                    raise
+
+        act = cls(name=name)
+
+        # Grab aliases
+        try:
+            act.attrs["alias"] = []
+            for fields in DriverAction.__gen_read_binding_file(
+                img, "etc/driver_aliases", minfields=2, maxfields=2
+            ):
+                if fields[0] == name:
+                    act.attrs["alias"].append(fields[1])
+        except IOError as e:
+            e.args += ("etc/driver_aliases",)
+            if collect_errs:
+                errors.append(e)
+            else:
+                raise
+
+        # Grab classes
+        try:
+            act.attrs["class"] = []
+            for fields in DriverAction.__gen_read_binding_file(
+                img, "etc/driver_classes", minfields=2, maxfields=2
+            ):
+                if fields[0] == name:
+                    act.attrs["class"].append(fields[1])
+        except IOError as e:
+            e.args += ("etc/driver_classes",)
+            if collect_errs:
+                errors.append(e)
+            else:
+                raise
+
+        # Grab minor node permissions.  Note that the clone driver
+        # action doesn't actually own its minor node perms; those are
+        # owned by other driver actions, through their clone_perms
+        # attributes.
+        try:
+            act.attrs["perms"] = []
+            act.attrs["clone_perms"] = []
+            for fields in DriverAction.__gen_read_binding_file(
+                img, "etc/minor_perm", minfields=4, maxfields=4
+            ):
+                # Break first field into pieces.
+                namefields = fields[0].split(":")
+                if len(namefields) != 2:
+                    continue
+                major = namefields[0]
+                minor = namefields[1]
+                if major == name and name != "clone":
+                    act.attrs["perms"].append(
+                        minor + " " + " ".join(fields[1:])
+                    )
+                elif major == "clone" and minor == name:
+                    act.attrs["clone_perms"].append(
+                        minor + " " + " ".join(fields[1:])
+                    )
+        except IOError as e:
+            e.args += ("etc/minor_perm",)
+            if collect_errs:
+                errors.append(e)
+            else:
+                raise
+
+        # Grab device policy
+        try:
+            dpf = open(
+                os.path.normpath(
+                    os.path.join(img.get_root(), "etc/security/device_policy")
+                )
+            )
+        except IOError as e:
+            e.args += ("etc/security/device_policy",)
+            if collect_errs:
+                errors.append(e)
+            else:
+                raise
+        else:
+            act.attrs["policy"] = []
+            for line in dpf:
+                line = line.strip()
+                if line.startswith("#"):
+                    continue
+                fields = line.split()
+                if len(fields) < 2:
+                    continue
+                n = ""
+                try:
+                    n, c = fields[0].split(":", 1)
+                    fields[0] = c
+                except ValueError:
+                    # If there is no minor node
+                    # specificition then set it to the
+                    # wildcard but saving the driver
+                    # name first.
+                    n = fields[0]
+                    fields[0] = "*"
+                except IndexError:
+                    pass
+
+                if n == name:
+                    act.attrs["policy"].append(" ".join(fields))
+            dpf.close()
+
+        # Grab device privileges
+        try:
+            dpf = open(
+                os.path.normpath(
+                    os.path.join(img.get_root(), "etc/security/extra_privs")
+                )
+            )
+        except IOError as e:
+            e.args += ("etc/security/extra_privs",)
+            if collect_errs:
+                errors.append(e)
+            else:
+                raise
+        else:
+            act.attrs["privs"] = []
+            for line in dpf:
+                line = line.strip()
+                if line.startswith("#"):
+                    continue
+                fields = line.split(":", 1)
+                if len(fields) != 2:
+                    continue
+                if fields[0] == name:
+                    act.attrs["privs"].append(fields[1])
+            dpf.close()
+
+        if collect_errs:
+            return act, errors
+        else:
+            return act
+
+    def verify(self, img, **args):
+        """Returns a tuple of lists of the form (errors, warnings,
+        info).  The error list will be empty if the action has been
+        correctly installed in the given image."""
+
+        errors = []
+        warnings = []
+        info = []
+        if img.is_zone():
+            return errors, warnings, info
+
+        name = self.attrs["name"]
+
+        onfs, errors = self.__get_image_data(img, name, collect_errs=True)
+
+        for i, err in enumerate(errors):
+            if isinstance(err, IOError):
+                errors[i] = "{0}: {1}".format(err.args[2], err)
+            elif isinstance(err, RuntimeError):
+                errors[i] = _(
+                    "etc/name_to_major: more than "
+                    "one entry for '{0}' is present"
+                ).format(name)
+
+        if not onfs:
+            errors[0:0] = [
+                _("etc/name_to_major: '{0}' entry not present").format(name)
+            ]
+            return errors, warnings, info
+
+        onfs_aliases = set(onfs.attrlist("alias"))
+        mfst_aliases = set(self.attrlist("alias"))
+        for a in onfs_aliases - mfst_aliases:
+            warnings.append(
+                _("extra alias '{0}' found in " "etc/driver_aliases").format(a)
+            )
+        for a in mfst_aliases - onfs_aliases:
+            errors.append(
+                _("alias '{0}' missing from " "etc/driver_aliases").format(a)
+            )
+
+        onfs_classes = set(onfs.attrlist("class"))
+        mfst_classes = set(self.attrlist("class"))
+        for a in onfs_classes - mfst_classes:
+            warnings.append(
+                _("extra class '{0}' found in " "etc/driver_classes").format(a)
+            )
+        for a in mfst_classes - onfs_classes:
+            errors.append(
+                _("class '{0}' missing from " "etc/driver_classes").format(a)
+            )
+
+        onfs_perms = set(onfs.attrlist("perms"))
+        mfst_perms = set(self.attrlist("perms"))
+        for a in onfs_perms - mfst_perms:
+            warnings.append(
+                _(
+                    "extra minor node permission '{0}' "
+                    "found in etc/minor_perm"
+                ).format(a)
+            )
+        for a in mfst_perms - onfs_perms:
+            errors.append(
+                _(
+                    "minor node permission '{0}' missing " "from etc/minor_perm"
+                ).format(a)
+            )
+
+        # Canonicalize "*" minorspecs to empty
+        policylist = list(onfs.attrlist("policy"))
+        for i, p in enumerate(policylist):
+            f = p.split()
+            if f[0] == "*":
+                policylist[i] = " ".join(f[1:])
+        onfs_policy = set(policylist)
+
+        policylist = self.attrlist("policy")
+        for i, p in enumerate(policylist):
+            f = p.split()
+            if f[0] == "*":
+                policylist[i] = " ".join(f[1:])
+        mfst_policy = set(policylist)
+        for a in onfs_policy - mfst_policy:
+            warnings.append(
+                _(
+                    "extra device policy '{0}' found in "
+                    "etc/security/device_policy"
+                ).format(a)
+            )
+        for a in mfst_policy - onfs_policy:
+            errors.append(
+                _(
+                    "device policy '{0}' missing from "
+                    "etc/security/device_policy"
+                ).format(a)
+            )
+
+        onfs_privs = set(onfs.attrlist("privs"))
+        mfst_privs = set(self.attrlist("privs"))
+        for a in onfs_privs - mfst_privs:
+            warnings.append(
+                _(
+                    "extra device privilege '{0}' found "
+                    "in etc/security/extra_privs"
+                ).format(a)
+            )
+        for a in mfst_privs - onfs_privs:
+            errors.append(
+                _(
+                    "device privilege '{0}' missing from "
+                    "etc/security/extra_privs"
+                ).format(a)
+            )
+
+        return errors, warnings, info
+
+    def remove(self, pkgplan):
+        image = pkgplan.image
+
+        if image.is_zone():
+            return
+
+        args = (self.rem_drv, "-b", image.get_root(), self.attrs["name"])
+
+        self.__call(
+            args, "driver ({name}) removal", {"name": self.attrs["name"]}
+        )
+
+        for cp in self.attrlist("clone_perms"):
+            args = (
+                self.update_drv,
+                "-b",
+                image.get_root(),
+                "-d",
+                "-m",
+                cp,
+                "clone",
+            )
+            self.__call(
+                args,
+                "driver ({name}) clone permission " "update",
+                {"name": self.attrs["name"]},
+            )
+
+        if "devlink" in self.attrs:
+            dlp = os.path.normpath(
+                os.path.join(image.get_root(), "etc/devlink.tab")
+            )
+
+            try:
+                dlf = open(dlp)
+                lines = dlf.readlines()
+                dlf.close()
+                st = os.stat(dlp)
+            except IOError as e:
+                print(
+                    "{0} ({1}) removal (devlinks modification) "
+                    "failed reading etc/devlink.tab with error: "
+                    "{2} ({3})".format(
+                        self.name, self.attrs["name"], e.args[0], e.args[1]
+                    )
+                )
+                return
+
+            devlinks = self.attrlist("devlink")
+
+            missing_entries = []
+            for line in devlinks:
+                try:
+                    lineno = lines.index(line.replace("\\t", "\t") + "\n")
+                except ValueError:
+                    missing_entries.append(line.replace("\\t", "\t"))
+                    continue
+                del lines[lineno]
+
+            if missing_entries:
+                print(
+                    "{0} ({1}) removal (devlinks modification) "
+                    "failed modifying\netc/devlink.tab.  The "
+                    "following entries were to be removed, "
+                    "but were\nnot found:\n    ".format(
+                        self.name, self.attrs["name"]
+                    )
+                    + "\n    ".join(missing_entries)
+                )
+
+            try:
+                dlt, dltp = mkstemp(
+                    suffix=".devlink.tab", dir=image.get_root() + "/etc"
+                )
+                dlt = os.fdopen(dlt, "w")
+                dlt.writelines(lines)
+                dlt.close()
+                os.chmod(dltp, st.st_mode)
+                os.chown(dltp, st.st_uid, st.st_gid)
+                os.rename(dltp, dlp)
+            except EnvironmentError as e:
+                print(
+                    "{0} ({1}) removal (devlinks modification) "
+                    "failed writing etc/devlink.tab with error: "
+                    "{2} ({3})".format(
+                        self.name, self.attrs["name"], e.args[0], e.args[1]
+                    )
+                )
+
+    def generate_indices(self):
+        """Generates the indices needed by the search dictionary.  See
+        generic.py for a more detailed explanation."""
+
+        ret = []
+        if "name" in self.attrs:
+            ret.append(("driver", "driver_name", self.attrs["name"], None))
+        if "alias" in self.attrs:
+            ret.append(("driver", "alias", self.attrs["alias"], None))
+        return ret
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/file.py
+++ b/src/modules/actions/file.py
@@ -52,915 +52,994 @@ from pkg.client.api_errors import ActionExecutionError
 from pkg.client.debugvalues import DebugValues
 
 try:
-        import pkg.elf as elf
-        haveelf = True
+    import pkg.elf as elf
+
+    haveelf = True
 except ImportError:
-        haveelf = False
+    haveelf = False
+
 
 class FileAction(generic.Action):
-        """Class representing a file-type packaging object."""
+    """Class representing a file-type packaging object."""
 
-        __slots__ = ["hash", "replace_required"]
+    __slots__ = ["hash", "replace_required"]
 
-        name = "file"
-        key_attr = "path"
-        unique_attrs = "path", "mode", "owner", "group", "preserve", "sysattr"
-        globally_identical = True
-        namespace_group = "path"
-        ordinality = generic._orderdict[name]
+    name = "file"
+    key_attr = "path"
+    unique_attrs = "path", "mode", "owner", "group", "preserve", "sysattr"
+    globally_identical = True
+    namespace_group = "path"
+    ordinality = generic._orderdict[name]
 
-        has_payload = True
+    has_payload = True
 
-        # __init__ is provided as a native function (see end of class
-        # declaration).
+    # __init__ is provided as a native function (see end of class
+    # declaration).
 
-        # this check is only needed on Windows
-        if portable.ostype == "windows":
-                def preinstall(self, pkgplan, orig):
-                        """If the file exists, check if it is in use."""
-                        if not orig:
-                                return
-                        path = orig.get_installed_path(pkgplan.image.get_root())
-                        if os.path.isfile(path) and self.in_use(path):
-                                raise api_errors.FileInUseException(path)
+    # this check is only needed on Windows
+    if portable.ostype == "windows":
 
-                def preremove(self, pkgplan):
-                        path = self.get_installed_path(pkgplan.image.get_root())
-                        if os.path.isfile(path) and self.in_use(path):
-                                raise api_errors.FileInUseException(path)
+        def preinstall(self, pkgplan, orig):
+            """If the file exists, check if it is in use."""
+            if not orig:
+                return
+            path = orig.get_installed_path(pkgplan.image.get_root())
+            if os.path.isfile(path) and self.in_use(path):
+                raise api_errors.FileInUseException(path)
 
-                def in_use(self, path):
-                        """Determine if a file is in use (locked) by trying
-                        to rename the file to itself."""
-                        try:
-                                os.rename(path, path)
-                        except OSError as err:
-                                if err.errno != errno.EACCES:
-                                        raise
-                                return True
-                        return False
+        def preremove(self, pkgplan):
+            path = self.get_installed_path(pkgplan.image.get_root())
+            if os.path.isfile(path) and self.in_use(path):
+                raise api_errors.FileInUseException(path)
 
-        def __set_data(self, pkgplan):
-                """Private helper function to set the data field of the
-                action."""
+        def in_use(self, path):
+            """Determine if a file is in use (locked) by trying
+            to rename the file to itself."""
+            try:
+                os.rename(path, path)
+            except OSError as err:
+                if err.errno != errno.EACCES:
+                    raise
+                return True
+            return False
 
-                hash_attr, hash_attr_val, hash_func = \
-                    digest.get_least_preferred_hash(self)
+    def __set_data(self, pkgplan):
+        """Private helper function to set the data field of the
+        action."""
 
-                retrieved = pkgplan.image.imageplan._retrieved
-                retrieved.add(self.get_installed_path(
-                    pkgplan.image.get_root()))
-                if len(retrieved) > 50 or \
-                    DebugValues['max-plan-execute-retrievals'] == 1:
-                        raise api_errors.PlanExecutionError(retrieved)
+        hash_attr, hash_attr_val, hash_func = digest.get_least_preferred_hash(
+            self
+        )
 
-                # This is an unexpected file retrieval, so the retrieved file
-                # will be streamed directly from the source to the final
-                # destination and will not be stored in the image download
-                # cache.
-                try:
-                        pub = pkgplan.image.get_publisher(
-                            pkgplan.destination_fmri.publisher)
-                        data = pkgplan.image.transport.get_datastream(pub,
-                            hash_attr_val)
-                        return lambda: data
-                finally:
-                        pkgplan.image.cleanup_downloads()
+        retrieved = pkgplan.image.imageplan._retrieved
+        retrieved.add(self.get_installed_path(pkgplan.image.get_root()))
+        if (
+            len(retrieved) > 50
+            or DebugValues["max-plan-execute-retrievals"] == 1
+        ):
+            raise api_errors.PlanExecutionError(retrieved)
 
+        # This is an unexpected file retrieval, so the retrieved file
+        # will be streamed directly from the source to the final
+        # destination and will not be stored in the image download
+        # cache.
+        try:
+            pub = pkgplan.image.get_publisher(
+                pkgplan.destination_fmri.publisher
+            )
+            data = pkgplan.image.transport.get_datastream(pub, hash_attr_val)
+            return lambda: data
+        finally:
+            pkgplan.image.cleanup_downloads()
 
-        def install(self, pkgplan, orig):
-                """Client-side method that installs a file."""
+    def install(self, pkgplan, orig):
+        """Client-side method that installs a file."""
 
-                mode = None
-                try:
-                        mode = int(self.attrs.get("mode", None), 8)
-                except (TypeError, ValueError):
-                        # Mode isn't valid, so let validate raise a more
-                        # informative error.
-                        self.validate(fmri=pkgplan.destination_fmri)
+        mode = None
+        try:
+            mode = int(self.attrs.get("mode", None), 8)
+        except (TypeError, ValueError):
+            # Mode isn't valid, so let validate raise a more
+            # informative error.
+            self.validate(fmri=pkgplan.destination_fmri)
 
-                owner, group = self.get_fsobj_uid_gid(pkgplan,
-                    pkgplan.destination_fmri)
+        owner, group = self.get_fsobj_uid_gid(pkgplan, pkgplan.destination_fmri)
 
-                final_path = self.get_installed_path(pkgplan.image.get_root())
+        final_path = self.get_installed_path(pkgplan.image.get_root())
 
-                # Don't allow installation through symlinks.
-                self.fsobj_checkpath(pkgplan, final_path)
+        # Don't allow installation through symlinks.
+        self.fsobj_checkpath(pkgplan, final_path)
 
-                if not os.path.exists(os.path.dirname(final_path)):
-                        self.makedirs(os.path.dirname(final_path),
-                            mode=misc.PKG_DIR_MODE,
-                            fmri=pkgplan.destination_fmri)
-                elif (not orig and not pkgplan.origin_fmri and
-                    "preserve" in self.attrs and
-                    self.attrs["preserve"] not in ("abandon",
-                        "install-only") and os.path.isfile(final_path)):
-                        # Unpackaged editable file is already present during
-                        # initial install; salvage it before continuing.
-                        pkgplan.salvage(final_path)
+        if not os.path.exists(os.path.dirname(final_path)):
+            self.makedirs(
+                os.path.dirname(final_path),
+                mode=misc.PKG_DIR_MODE,
+                fmri=pkgplan.destination_fmri,
+            )
+        elif (
+            not orig
+            and not pkgplan.origin_fmri
+            and "preserve" in self.attrs
+            and self.attrs["preserve"] not in ("abandon", "install-only")
+            and os.path.isfile(final_path)
+        ):
+            # Unpackaged editable file is already present during
+            # initial install; salvage it before continuing.
+            pkgplan.salvage(final_path)
 
-                # XXX If we're upgrading, do we need to preserve file perms from
-                # existing file?
+        # XXX If we're upgrading, do we need to preserve file perms from
+        # existing file?
 
-                # check if we have a save_file active; if so, simulate file
-                # being already present rather than installed from scratch
+        # check if we have a save_file active; if so, simulate file
+        # being already present rather than installed from scratch
 
-                if "save_file" in self.attrs:
-                        orig = self.restore_file(pkgplan.image)
+        if "save_file" in self.attrs:
+            orig = self.restore_file(pkgplan.image)
 
-                # See if we need to preserve the file, and if so, set that up.
+        # See if we need to preserve the file, and if so, set that up.
+        #
+        # XXX What happens when we transition from preserve to
+        # non-preserve or vice versa? Do we want to treat a preserve
+        # attribute as turning the action into a critical action?
+        #
+        # XXX We should save the originally installed file.  It can be
+        # used as an ancestor for a three-way merge, for example.  Where
+        # should it be stored?
+        pres_type = self._check_preserve(orig, pkgplan)
+        do_content = True
+        old_path = None
+        if pres_type == True or (
+            pres_type and pkgplan.origin_fmri == pkgplan.destination_fmri
+        ):
+            # File is marked to be preserved and exists so don't
+            # reinstall content.
+            do_content = False
+        elif pres_type == "legacy":
+            # Only rename old file if this is a transition to
+            # preserve=legacy from something else.
+            if orig.attrs.get("preserve", None) != "legacy":
+                old_path = final_path + ".legacy"
+        elif pres_type == "renameold.update":
+            old_path = final_path + ".update"
+        elif pres_type == "renameold":
+            old_path = final_path + ".old"
+        elif pres_type == "renamenew":
+            final_path = final_path + ".new"
+        elif pres_type == "abandon":
+            return
+
+        # If it is a directory (and not empty) then we should
+        # salvage the contents.
+        if (
+            os.path.exists(final_path)
+            and not os.path.islink(final_path)
+            and os.path.isdir(final_path)
+        ):
+            try:
+                os.rmdir(final_path)
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    pass
+                elif e.errno in (errno.EEXIST, errno.ENOTEMPTY):
+                    pkgplan.salvage(final_path)
+                elif e.errno != errno.EACCES:
+                    # this happens on Windows
+                    raise
+
+        # XXX This needs to be modularized.
+        if do_content and self.needsdata(orig, pkgplan):
+            tfilefd, temp = tempfile.mkstemp(dir=os.path.dirname(final_path))
+            if not self.data:
+                # The state of the filesystem changed after the
+                # plan was prepared; attempt a one-off
+                # retrieval of the data.
+                self.data = self.__set_data(pkgplan)
+            stream = self.data()
+            tfile = os.fdopen(tfilefd, "wb")
+            try:
+                # Always verify using the most preferred hash
+                hash_attr, hash_val, hash_func = digest.get_preferred_hash(self)
+                shasum = misc.gunzip_from_stream(stream, tfile, hash_func)
+            except zlib.error as e:
+                raise ActionExecutionError(
+                    self,
+                    details=_("Error decompressing payload: " "{0}").format(
+                        " ".join([str(a) for a in e.args])
+                    ),
+                    error=e,
+                )
+            finally:
+                tfile.close()
+                stream.close()
+
+            if shasum != hash_val:
+                raise ActionExecutionError(
+                    self,
+                    details=_(
+                        "Action data hash verification "
+                        "failure: expected: {expected} computed: "
+                        "{actual} action: {action}"
+                    ).format(expected=hash_val, actual=shasum, action=self),
+                )
+
+        else:
+            temp = final_path
+
+        try:
+            os.chmod(temp, mode)
+        except OSError as e:
+            # If the file didn't exist, assume that's intentional,
+            # and drive on.
+            if e.errno != errno.ENOENT:
+                raise
+            else:
+                return
+
+        try:
+            portable.chown(temp, owner, group)
+        except OSError as e:
+            if e.errno != errno.EPERM:
+                raise
+
+        # XXX There's a window where final_path doesn't exist, but we
+        # probably don't care.
+        if do_content and old_path:
+            try:
+                portable.rename(final_path, old_path)
+            except OSError as e:
+                if e.errno != errno.ENOENT:
+                    # Only care if file isn't gone already.
+                    raise
+
+        # This is safe even if temp == final_path.
+        try:
+            portable.rename(temp, final_path)
+        except OSError as e:
+            raise api_errors.FileInUseException(final_path)
+
+        # Handle timestamp if specified (and content was installed).
+        if do_content and "timestamp" in self.attrs:
+            t = misc.timestamp_to_time(self.attrs["timestamp"])
+            try:
+                os.utime(final_path, (t, t))
+            except OSError as e:
+                if e.errno != errno.EACCES:
+                    raise
+
+                # On Windows, the time cannot be changed on a
+                # read-only file
+                os.chmod(final_path, stat.S_IRUSR | stat.S_IWUSR)
+                os.utime(final_path, (t, t))
+                os.chmod(final_path, mode)
+
+        # Handle system attributes.
+        sattr = self.attrs.get("sysattr")
+        if sattr:
+            if isinstance(sattr, list):
+                sattr = ",".join(sattr)
+            sattrs = sattr.split(",")
+            if (
+                len(sattrs) == 1
+                and sattrs[0] not in portable.get_sysattr_dict()
+            ):
+                # not a verbose attr, try as a compact attr seq
+                arg = sattrs[0]
+            else:
+                arg = sattrs
+
+            try:
+                portable.fsetattr(final_path, arg)
+            except OSError as e:
+                if e.errno != errno.EINVAL:
+                    raise
+                warn = _(
+                    "System attributes are not supported "
+                    "on the target image filesystem; 'sysattr'"
+                    " ignored for {0}"
+                ).format(self.attrs["path"])
+                pkgplan.image.imageplan.pd.add_item_message(
+                    pkgplan.destination_fmri,
+                    misc.time_to_timestamp(time.time()),
+                    MSG_WARNING,
+                    warn,
+                )
+            except ValueError as e:
+                warn = _(
+                    "Could not set system attributes for {path}"
+                    "'{attrlist}': {err}"
+                ).format(attrlist=sattr, err=e, path=self.attrs["path"])
+                pkgplan.image.imageplan.pd.add_item_message(
+                    pkgplan.destination_fmri,
+                    misc.time_to_timestamp(time.time()),
+                    MSG_WARNING,
+                    warn,
+                )
+
+    def verify(self, img, **args):
+        """Returns a tuple of lists of the form (errors, warnings,
+        info).  The error list will be empty if the action has been
+        correctly installed in the given image.
+
+        In detail, this verifies that the file is present, and if
+        the preserve attribute is not present, that the hashes
+        and other attributes of the file match."""
+
+        if self.attrs.get("preserve") == "abandon":
+            return [], [], []
+
+        path = self.get_installed_path(img.get_root())
+
+        lstat, errors, warnings, info, abort = self.verify_fsobj_common(
+            img, stat.S_IFREG
+        )
+        if lstat:
+            if not stat.S_ISREG(lstat.st_mode):
+                self.replace_required = True
+
+        if abort:
+            assert errors
+            self.replace_required = True
+            return errors, warnings, info
+
+        if path.lower().endswith("/bobcat") and args["verbose"] == True:
+            # Returned as a purely informational (untranslated)
+            # message so that no client should interpret it as a
+            # reason to fail verification.
+            info.append(
+                "Warning: package may contain bobcat!  "
+                "(http://xkcd.com/325/)"
+            )
+
+        preserve = self.attrs.get("preserve")
+
+        if (
+            preserve is None
+            and "timestamp" in self.attrs
+            and lstat.st_mtime
+            != misc.timestamp_to_time(self.attrs["timestamp"])
+        ):
+            errors.append(
+                _("Timestamp: {found} should be " "{expected}").format(
+                    found=misc.time_to_timestamp(lstat.st_mtime),
+                    expected=self.attrs["timestamp"],
+                )
+            )
+
+        # avoid checking pkg.size if we have any content-hashes present;
+        # different size files may have the same content-hash
+        pkg_size = int(self.attrs.get("pkg.size", 0))
+        if (
+            preserve is None
+            and pkg_size > 0
+            and not set(digest.DEFAULT_GELF_HASH_ATTRS).intersection(
+                set(self.attrs.keys())
+            )
+            and lstat.st_size != pkg_size
+        ):
+            errors.append(
+                _("Size: {found:d} bytes should be " "{expected:d}").format(
+                    found=lstat.st_size, expected=pkg_size
+                )
+            )
+
+        if preserve is not None and args["verbose"] == False or lstat is None:
+            return errors, warnings, info
+
+        if args["forever"] != True:
+            return errors, warnings, info
+
+        #
+        # Check file contents.
+        #
+        try:
+            # This is a generic mechanism, but only used for libc on
+            # x86, where the "best" version of libc is lofs-mounted
+            # on the canonical path, foiling the standard verify
+            # checks.
+            is_mtpt = self.attrs.get("mountpoint", "").lower() == "true"
+            elfhash = None
+            elferror = None
+            (
+                elf_hash_attr,
+                elf_hash_val,
+                elf_hash_func,
+            ) = digest.get_preferred_hash(self, hash_type=pkg.digest.HASH_GELF)
+            if elf_hash_attr and haveelf and not is_mtpt:
                 #
-                # XXX What happens when we transition from preserve to
-                # non-preserve or vice versa? Do we want to treat a preserve
-                # attribute as turning the action into a critical action?
+                # It's possible for the elf module to
+                # throw while computing the hash,
+                # especially if the file is badly
+                # corrupted or truncated.
                 #
-                # XXX We should save the originally installed file.  It can be
-                # used as an ancestor for a three-way merge, for example.  Where
-                # should it be stored?
-                pres_type = self._check_preserve(orig, pkgplan)
-                do_content = True
-                old_path = None
-                if pres_type == True or (pres_type and
-                    pkgplan.origin_fmri == pkgplan.destination_fmri):
-                        # File is marked to be preserved and exists so don't
-                        # reinstall content.
-                        do_content = False
-                elif pres_type == "legacy":
-                        # Only rename old file if this is a transition to
-                        # preserve=legacy from something else.
-                        if orig.attrs.get("preserve", None) != "legacy":
-                                old_path = final_path + ".legacy"
-                elif pres_type == "renameold.update":
-                        old_path = final_path + ".update"
-                elif pres_type == "renameold":
-                        old_path = final_path + ".old"
-                elif pres_type == "renamenew":
-                        final_path = final_path + ".new"
-                elif pres_type == "abandon":
-                        return
-
-                # If it is a directory (and not empty) then we should
-                # salvage the contents.
-                if os.path.exists(final_path) and \
-                    not os.path.islink(final_path) and \
-                    os.path.isdir(final_path):
-                        try:
-                                os.rmdir(final_path)
-                        except OSError as e:
-                                if e.errno == errno.ENOENT:
-                                        pass
-                                elif e.errno in (errno.EEXIST, errno.ENOTEMPTY):
-                                        pkgplan.salvage(final_path)
-                                elif e.errno != errno.EACCES:
-                                        # this happens on Windows
-                                        raise
-
-                # XXX This needs to be modularized.
-                if do_content and self.needsdata(orig, pkgplan):
-                        tfilefd, temp = tempfile.mkstemp(dir=os.path.dirname(
-                            final_path))
-                        if not self.data:
-                                # The state of the filesystem changed after the
-                                # plan was prepared; attempt a one-off
-                                # retrieval of the data.
-                                self.data = self.__set_data(pkgplan)
-                        stream = self.data()
-                        tfile = os.fdopen(tfilefd, "wb")
-                        try:
-                                # Always verify using the most preferred hash
-                                hash_attr, hash_val, hash_func  = \
-                                    digest.get_preferred_hash(self)
-                                shasum = misc.gunzip_from_stream(stream, tfile,
-                                    hash_func)
-                        except zlib.error as e:
-                                raise ActionExecutionError(self,
-                                    details=_("Error decompressing payload: "
-                                        "{0}").format(
-                                        " ".join([str(a) for a in e.args])),
-                                        error=e)
-                        finally:
-                                tfile.close()
-                                stream.close()
-
-                        if shasum != hash_val:
-                                raise ActionExecutionError(self,
-                                    details=_("Action data hash verification "
-                                    "failure: expected: {expected} computed: "
-                                    "{actual} action: {action}").format(
-                                        expected=hash_val,
-                                        actual=shasum,
-                                        action=self
-                                   ))
-
-                else:
-                        temp = final_path
-
                 try:
-                        os.chmod(temp, mode)
-                except OSError as e:
-                        # If the file didn't exist, assume that's intentional,
-                        # and drive on.
-                        if e.errno != errno.ENOENT:
-                                raise
-                        else:
-                                return
+                    # On path, only calculate the
+                    # content hash that matches
+                    # the preferred one on the
+                    # action
+                    get_elfhash = elf_hash_attr == "elfhash"
+                    get_sha256 = (
+                        not get_elfhash
+                        and elf_hash_func
+                        == digest.GELF_HASH_ALGS["gelf:sha256"]
+                    )
+                    get_sha512t_256 = (
+                        not get_elfhash
+                        and elf_hash_func
+                        == digest.GELF_HASH_ALGS["gelf:sha512t_256"]
+                    )
+                    elfhash = elf.get_hashes(
+                        path,
+                        elfhash=get_elfhash,
+                        sha256=get_sha256,
+                        sha512t_256=get_sha512t_256,
+                    )[elf_hash_attr]
 
-                try:
-                        portable.chown(temp, owner, group)
-                except OSError as e:
-                        if e.errno != errno.EPERM:
-                                raise
+                    if get_elfhash:
+                        elfhash = [elfhash]
+                    else:
+                        elfhash = list(digest.ContentHash(elfhash).values())
+                except elf.ElfError as e:
+                    # Any ELF error means there is something bad
+                    # with the file, mark as needing to be replaced.
+                    elferror = _("ELF failure: {0}").format(e)
 
-                # XXX There's a window where final_path doesn't exist, but we
-                # probably don't care.
-                if do_content and old_path:
-                        try:
-                                portable.rename(final_path, old_path)
-                        except OSError as e:
-                                if e.errno != errno.ENOENT:
-                                        # Only care if file isn't gone already.
-                                        raise
+                if elfhash is not None and elf_hash_val != elfhash[0]:
+                    elferror = _(
+                        "ELF content hash: " "{found} " "should be {expected}"
+                    ).format(found=elfhash[0], expected=elf_hash_val)
 
-                # This is safe even if temp == final_path.
-                try:
-                        portable.rename(temp, final_path)
-                except OSError as e:
-                        raise api_errors.FileInUseException(final_path)
-
-                # Handle timestamp if specified (and content was installed).
-                if do_content and "timestamp" in self.attrs:
-                        t = misc.timestamp_to_time(self.attrs["timestamp"])
-                        try:
-                                os.utime(final_path, (t, t))
-                        except OSError as e:
-                                if e.errno != errno.EACCES:
-                                        raise
-
-                                # On Windows, the time cannot be changed on a
-                                # read-only file
-                                os.chmod(final_path, stat.S_IRUSR|stat.S_IWUSR)
-                                os.utime(final_path, (t, t))
-                                os.chmod(final_path, mode)
-
-                # Handle system attributes.
-                sattr = self.attrs.get("sysattr")
-                if sattr:
-                        if isinstance(sattr, list):
-                                sattr = ",".join(sattr)
-                        sattrs = sattr.split(",")
-                        if len(sattrs) == 1 and \
-                            sattrs[0] not in portable.get_sysattr_dict():
-                                # not a verbose attr, try as a compact attr seq
-                                arg = sattrs[0]
-                        else:
-                                arg = sattrs
-
-                        try:
-                                portable.fsetattr(final_path, arg)
-                        except OSError as e:
-                                if e.errno != errno.EINVAL:
-                                        raise
-                                warn = _("System attributes are not supported "
-                                    "on the target image filesystem; 'sysattr'"
-                                    " ignored for {0}").format(
-                                        self.attrs["path"])
-                                pkgplan.image.imageplan.pd.add_item_message(
-                                    pkgplan.destination_fmri,
-                                    misc.time_to_timestamp(time.time()),
-                                    MSG_WARNING, warn)
-                        except ValueError as e:
-                                warn = _("Could not set system attributes for {path}"
-                                    "'{attrlist}': {err}").format(
-                                        attrlist=sattr,
-                                        err=e,
-                                        path=self.attrs["path"]
-                                    )
-                                pkgplan.image.imageplan.pd.add_item_message(
-                                    pkgplan.destination_fmri,
-                                    misc.time_to_timestamp(time.time()),
-                                    MSG_WARNING, warn)
-
-        def verify(self, img, **args):
-                """Returns a tuple of lists of the form (errors, warnings,
-                info).  The error list will be empty if the action has been
-                correctly installed in the given image.
-
-                In detail, this verifies that the file is present, and if
-                the preserve attribute is not present, that the hashes
-                and other attributes of the file match."""
-
-                if self.attrs.get("preserve") == "abandon":
-                        return [], [], []
-
-                path = self.get_installed_path(img.get_root())
-
-                lstat, errors, warnings, info, abort = \
-                    self.verify_fsobj_common(img, stat.S_IFREG)
-                if lstat:
-                        if not stat.S_ISREG(lstat.st_mode):
-                                self.replace_required = True
-
-                if abort:
-                        assert errors
+            # Always check on the file hash because the ELF hash
+            # check only checks on the ELF parts and does not
+            # check for some other file integrity issues.
+            if not is_mtpt:
+                hash_attr, hash_val, hash_func = digest.get_preferred_hash(self)
+                sha_hash, data = misc.get_data_digest(path, hash_func=hash_func)
+                if sha_hash != hash_val:
+                    # Prefer the ELF content hash error message.
+                    if preserve is not None:
+                        info.append(_("editable file has " "been changed"))
+                    elif elferror:
+                        errors.append(elferror)
                         self.replace_required = True
-                        return errors, warnings, info
+                    else:
+                        errors.append(
+                            _(
+                                "Hash: " "{found} should be " "{expected}"
+                            ).format(found=sha_hash, expected=hash_val)
+                        )
+                        self.replace_required = True
 
-                if path.lower().endswith("/bobcat") and args["verbose"] == True:
-                        # Returned as a purely informational (untranslated)
-                        # message so that no client should interpret it as a
-                        # reason to fail verification.
-                        info.append("Warning: package may contain bobcat!  "
-                            "(http://xkcd.com/325/)")
+            # Check system attributes.
+            # Since some attributes like 'archive' or 'av_modified'
+            # are set automatically by the FS, it makes no sense to
+            # check for 1:1 matches. So we only check that the
+            # system attributes specified in the action are still
+            # set on the file.
+            sattr = self.attrs.get("sysattr", None)
+            if sattr:
+                if isinstance(sattr, list):
+                    sattr = ",".join(sattr)
+                sattrs = sattr.split(",")
+                if (
+                    len(sattrs) == 1
+                    and sattrs[0] not in portable.get_sysattr_dict()
+                ):
+                    # not a verbose attr, try as a compact
+                    set_attrs = portable.fgetattr(path, compact=True)
+                    sattrs = sattrs[0]
+                else:
+                    set_attrs = portable.fgetattr(path)
 
-                preserve = self.attrs.get("preserve")
+                for a in sattrs:
+                    if a not in set_attrs:
+                        errors.append(
+                            _("System attribute '{0}' " "not set").format(a)
+                        )
 
-                if (preserve is None and
-                    "timestamp" in self.attrs and lstat.st_mtime !=
-                    misc.timestamp_to_time(self.attrs["timestamp"])):
-                        errors.append(_("Timestamp: {found} should be "
-                            "{expected}").format(
-                            found=misc.time_to_timestamp(lstat.st_mtime),
-                            expected=self.attrs["timestamp"]))
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                errors.append(_("Skipping: Permission Denied"))
+            else:
+                errors.append(_("Unexpected Error: {0}").format(e))
+        except Exception as e:
+            errors.append(_("Unexpected Exception: {0}").format(e))
 
-                # avoid checking pkg.size if we have any content-hashes present;
-                # different size files may have the same content-hash
-                pkg_size = int(self.attrs.get("pkg.size", 0))
-                if preserve is None and pkg_size > 0 and \
-                    not set(digest.DEFAULT_GELF_HASH_ATTRS).intersection(
-                    set(self.attrs.keys())) and \
-                    lstat.st_size != pkg_size:
-                        errors.append(_("Size: {found:d} bytes should be "
-                            "{expected:d}").format(found=lstat.st_size,
-                            expected=pkg_size))
+        return errors, warnings, info
 
-                if (preserve is not None and args["verbose"] == False or
-                    lstat is None):
-                        return errors, warnings, info
+    def __check_preserve_version(self, orig):
+        """Any action that can have a 'preserve' attribute should also
+        be able to have a 'preserve-version' attribute (that
+        represents a simple package FMRI release version; no
+        timestamp, etc., just 'X.n.n...').
 
-                if args["forever"] != True:
-                        return errors, warnings, info
+        In the absence of a 'preserve-version' attribute, '0' will be
+        assumed.
 
-                #
-                # Check file contents.
-                #
-                try:
-                        # This is a generic mechanism, but only used for libc on
-                        # x86, where the "best" version of libc is lofs-mounted
-                        # on the canonical path, foiling the standard verify
-                        # checks.
-                        is_mtpt = self.attrs.get("mountpoint", "").lower() == "true"
-                        elfhash = None
-                        elferror = None
-                        elf_hash_attr, elf_hash_val, \
-                            elf_hash_func = \
-                            digest.get_preferred_hash(self,
-                                hash_type=pkg.digest.HASH_GELF)
-                        if elf_hash_attr and haveelf and not is_mtpt:
-                                #
-                                # It's possible for the elf module to
-                                # throw while computing the hash,
-                                # especially if the file is badly
-                                # corrupted or truncated.
-                                #
-                                try:
-                                        # On path, only calculate the
-                                        # content hash that matches
-                                        # the preferred one on the
-                                        # action
-                                        get_elfhash = \
-                                            elf_hash_attr == "elfhash"
-                                        get_sha256 = (not get_elfhash and
-                                            elf_hash_func ==
-                                            digest.GELF_HASH_ALGS["gelf:sha256"])
-                                        get_sha512t_256 = (not get_elfhash and
-                                            elf_hash_func ==
-                                            digest.GELF_HASH_ALGS["gelf:sha512t_256"])
-                                        elfhash = elf.get_hashes(
-                                            path, elfhash=get_elfhash,
-                                            sha256=get_sha256,
-                                            sha512t_256=get_sha512t_256
-                                        )[elf_hash_attr]
+        When performing downgrades, if the installed editable file has
+        been modified (compared to the proposed packaged version), the
+        behavior will be as follows:
 
-                                        if get_elfhash:
-                                                elfhash = [elfhash]
-                                        else:
-                                                elfhash = list(digest.ContentHash(elfhash).values())
-                                except elf.ElfError as e:
-                                        # Any ELF error means there is something bad
-                                        # with the file, mark as needing to be replaced.
-                                        elferror = _("ELF failure: {0}").format(e)
+        if the installed action's 'preserve-version' is greater than
+        the proposed 'preserve-version', the installed file will be
+        renamed with '.update' and the proposed file will be
+        installed.
 
-                                if (elfhash is not None and
-                                     elf_hash_val != elfhash[0]):
-                                        elferror = _("ELF content hash: "
-                                            "{found} "
-                                            "should be {expected}").format(
-                                            found=elfhash[0],
-                                            expected=elf_hash_val)
+        if the installed action's 'preserve-version' is equal to or
+        less than the proposed 'preserve-version', the installed file
+        content will not be modified."""
 
-                        # Always check on the file hash because the ELF hash
-                        # check only checks on the ELF parts and does not
-                        # check for some other file integrity issues.
-                        if not is_mtpt:
-                                hash_attr, hash_val, hash_func = \
-                                    digest.get_preferred_hash(self)
-                                sha_hash, data = misc.get_data_digest(path,
-                                    hash_func=hash_func)
-                                if sha_hash != hash_val:
-                                        # Prefer the ELF content hash error message.
-                                        if preserve is not None:
-                                                info.append(_(
-                                                    "editable file has "
-                                                    "been changed"))
-                                        elif elferror:
-                                                errors.append(elferror)
-                                                self.replace_required = True
-                                        else:
-                                                errors.append(_("Hash: "
-                                                    "{found} should be "
-                                                    "{expected}").format(
-                                                    found=sha_hash,
-                                                    expected=hash_val))
-                                                self.replace_required = True
+        orig_preserve_ver = version.Version("0")
+        preserve_ver = version.Version("0")
 
-                        # Check system attributes.
-                        # Since some attributes like 'archive' or 'av_modified'
-                        # are set automatically by the FS, it makes no sense to
-                        # check for 1:1 matches. So we only check that the
-                        # system attributes specified in the action are still
-                        # set on the file.
-                        sattr = self.attrs.get("sysattr", None)
-                        if sattr:
-                                if isinstance(sattr, list):
-                                        sattr = ",".join(sattr)
-                                sattrs = sattr.split(",")
-                                if len(sattrs) == 1 and \
-                                    sattrs[0] not in portable.get_sysattr_dict():
-                                        # not a verbose attr, try as a compact
-                                        set_attrs = portable.fgetattr(path,
-                                            compact=True)
-                                        sattrs = sattrs[0]
-                                else:
-                                        set_attrs = portable.fgetattr(path)
+        try:
+            ver = orig.attrs["preserve-version"]
+            orig_preserve_ver = version.Version(ver)
+        except KeyError:
+            pass
 
-                                for a in sattrs:
-                                        if a not in set_attrs:
-                                                errors.append(
-                                                    _("System attribute '{0}' "
-                                                    "not set").format(a))
+        try:
+            ver = self.attrs["preserve-version"]
+            preserve_ver = version.Version(ver)
+        except KeyError:
+            pass
 
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                errors.append(_("Skipping: Permission Denied"))
-                        else:
-                                errors.append(_("Unexpected Error: {0}").format(
-                                    e))
-                except Exception as e:
-                        errors.append(_("Unexpected Exception: {0}").format(e))
+        if orig_preserve_ver > preserve_ver:
+            # .old is intentionally avoided here to prevent
+            # accidental collisions with the normal install
+            # process.
+            return "renameold.update"
 
-                return errors, warnings, info
+        return True
 
-        def __check_preserve_version(self, orig):
-                """Any action that can have a 'preserve' attribute should also
-                be able to have a 'preserve-version' attribute (that
-                represents a simple package FMRI release version; no
-                timestamp, etc., just 'X.n.n...').
+    def _check_preserve(self, orig, pkgplan, orig_path=None):
+        """Return the type of preservation needed for this action.
 
-                In the absence of a 'preserve-version' attribute, '0' will be
-                assumed.
+        Returns None if preservation is not defined by the action.
+        Returns False if it is, but no preservation is necessary.
+        Returns True for the normal preservation form.  Returns one of
+        the strings 'renameold', 'renameold.update', 'renamenew',
+        'legacy', or 'abandon' for each of the respective forms of
+        preservation.
+        """
 
-                When performing downgrades, if the installed editable file has
-                been modified (compared to the proposed packaged version), the
-                behavior will be as follows:
+        # If the logic in this function ever changes, all callers will
+        # need to be updated to reflect how they interpret return
+        # values.
 
-                if the installed action's 'preserve-version' is greater than
-                the proposed 'preserve-version', the installed file will be
-                renamed with '.update' and the proposed file will be
-                installed.
+        try:
+            pres_type = self.attrs["preserve"]
+        except KeyError:
+            return
 
-                if the installed action's 'preserve-version' is equal to or
-                less than the proposed 'preserve-version', the installed file
-                content will not be modified."""
+        # Should ultimately be conditioned on file type
+        if "elfhash" in self.attrs:
+            # Don't allow preserve logic to be applied to elf files;
+            # if we ever stop tagging elf binaries with this
+            # attribute, this will need to be updated.
+            return
 
-                orig_preserve_ver = version.Version("0")
-                preserve_ver = version.Version("0")
+        if pres_type == "abandon":
+            return pres_type
 
-                try:
-                        ver = orig.attrs["preserve-version"]
-                        orig_preserve_ver = version.Version(ver)
-                except KeyError:
-                        pass
+        final_path = self.get_installed_path(pkgplan.image.get_root())
 
-                try:
-                        ver = self.attrs["preserve-version"]
-                        preserve_ver = version.Version(ver)
-                except KeyError:
-                        pass
+        # 'legacy' preservation is very different than other forms of
+        # preservation as it doesn't account for the on-disk state of
+        # the action's payload.
+        if pres_type == "legacy":
+            if not orig:
+                # This is an initial install or a repair, so
+                # there's nothing to deliver.
+                return True
+            return pres_type
 
-                if orig_preserve_ver > preserve_ver:
-                        # .old is intentionally avoided here to prevent
-                        # accidental collisions with the normal install
-                        # process.
-                        return "renameold.update"
+        # If action has been marked with a preserve attribute, the
+        # hash of the preserved file has changed between versions,
+        # and the package being installed is older than the package
+        # that was installed, and the version on disk is different
+        # than the installed package's original version, then preserve
+        # the installed file by renaming it.
+        #
+        # If pkgplan.origin_fmri isn't set, but there is an orig action,
+        # then this file is moving between packages and it can't be
+        # a downgrade since that isn't allowed across rename or obsolete
+        # boundaries.
+        is_file = os.path.isfile(final_path)
+
+        # 'install-only' preservation has very specific semantics as
+        # well; if there's an 'orig' or this is an initial install and
+        # the file exists, we should not modify the file content.
+        if pres_type == "install-only":
+            if orig or is_file:
+                return True
+            return False
+
+        changed_hash = False
+        if orig:
+            # We must use the same hash algorithm when comparing old
+            # and new actions. Look for the most-preferred common
+            # hash between old and new. Since the two actions may
+            # not share a common hash (in which case, we get a tuple
+            # of 'None' objects) we also need to know the preferred
+            # hash to use when examining the old action on its own.
+            (
+                common_hash_attr,
+                common_hash_val,
+                common_orig_hash_val,
+                common_hash_func,
+            ) = digest.get_common_preferred_hash(self, orig)
+
+            hattr, orig_hash_val, orig_hash_func = digest.get_preferred_hash(
+                orig
+            )
+
+            if common_orig_hash_val and common_hash_val:
+                changed_hash = common_hash_val != common_orig_hash_val
+            else:
+                # we don't have a common hash, so we must treat
+                # this as a changed action
+                changed_hash = True
+
+            if (
+                pkgplan.destination_fmri
+                and changed_hash
+                and pkgplan.origin_fmri
+                and pkgplan.destination_fmri.version
+                < pkgplan.origin_fmri.version
+            ):
+                # Installed, preserved file is for a package
+                # newer than what will be installed. So check if
+                # the version on disk is different than what
+                # was originally delivered, and if so, preserve
+                # it.
+                if not is_file:
+                    return False
+
+                preserve_version = self.__check_preserve_version(orig)
+                if not preserve_version:
+                    return False
+
+                ihash, cdata = misc.get_data_digest(
+                    final_path, hash_func=orig_hash_func
+                )
+                if ihash != orig_hash_val:
+                    return preserve_version
 
                 return True
 
-        def _check_preserve(self, orig, pkgplan, orig_path=None):
-                """Return the type of preservation needed for this action.
+        if orig and orig_path:
+            # Comparison will be based on a file being moved.
+            is_file = os.path.isfile(orig_path)
 
-                Returns None if preservation is not defined by the action.
-                Returns False if it is, but no preservation is necessary.
-                Returns True for the normal preservation form.  Returns one of
-                the strings 'renameold', 'renameold.update', 'renamenew',
-                'legacy', or 'abandon' for each of the respective forms of
-                preservation.
-                """
+        # If the action has been marked with a preserve attribute, and
+        # the file exists and has a content hash different from what the
+        # system expected it to be, then we preserve the original file
+        # in some way, depending on the value of preserve.
+        if is_file:
+            # if we had an action installed, then we know what hash
+            # function was used to compute it's hash attribute.
+            if orig:
+                if not orig_path:
+                    orig_path = final_path
+                chash, cdata = misc.get_data_digest(
+                    orig_path, hash_func=orig_hash_func
+                )
+            if not orig or chash != orig_hash_val:
+                if pres_type in ("renameold", "renamenew"):
+                    return pres_type
+                return True
+            elif not changed_hash and chash == orig_hash_val:
+                # If packaged content has not changed since last
+                # version and on-disk content matches the last
+                # version, preserve on-disk file.
+                return True
 
-                # If the logic in this function ever changes, all callers will
-                # need to be updated to reflect how they interpret return
-                # values.
+        return False
 
+    # If we're not upgrading, or the file contents have changed,
+    # retrieve the file and write it to a temporary location.
+    # For files with content-hash attributes, only write the new file if the
+    # content-hash changed.
+    def needsdata(self, orig, pkgplan):
+        if self.replace_required:
+            return True
+
+        # import goes here to prevent circular import
+        from pkg.client.imageconfig import CONTENT_UPDATE_POLICY
+
+        use_content_hash = (
+            orig
+            and pkgplan.image.cfg.get_policy_str(CONTENT_UPDATE_POLICY)
+            == "when-required"
+        )
+
+        # If content update policy allows it, check for a common
+        # preferred content hash.
+        if use_content_hash:
+            (
+                content_hash_attr,
+                content_hash_val,
+                orig_content_hash_val,
+                content_hash_func,
+            ) = digest.get_common_preferred_hash(
+                self, orig, hash_type=digest.HASH_GELF
+            )
+
+        (
+            hash_attr,
+            hash_val,
+            orig_hash_val,
+            hash_func,
+        ) = digest.get_common_preferred_hash(self, orig)
+
+        if not orig:
+            changed_hash = True
+        elif orig and (orig_hash_val is None or hash_val is None):
+            # we have no common hash so we have to treat this as a
+            # changed action
+            changed_hash = True
+        else:
+            changed_hash = hash_val != orig_hash_val
+
+        if changed_hash and (
+            not use_content_hash or content_hash_val != orig_content_hash_val
+        ):
+            if "preserve" not in self.attrs or not pkgplan.origin_fmri:
+                return True
+        elif orig:
+            # It's possible that the file content hasn't changed
+            # for an upgrade case, but the file is missing.  This
+            # ensures that for cases where the mode or some other
+            # attribute of the file has changed that the file will
+            # be installed.
+            path = self.get_installed_path(pkgplan.image.get_root())
+            if not os.path.isfile(path):
+                return True
+
+        pres_type = self._check_preserve(orig, pkgplan)
+        if pres_type not in (None, True, "abandon"):
+            # Preserved files only need data if they're being
+            # changed (e.g. "renameold", etc.).
+            return True
+
+        return False
+
+    def remove(self, pkgplan):
+        path = self.get_installed_path(pkgplan.image.get_root())
+
+        # Are we supposed to save this file to restore it elsewhere
+        # or in another pkg? 'save_file' is set by the imageplan.
+        save_file = self.attrs.get("save_file")
+        if save_file:
+            # 'save_file' contains a tuple of (orig_name,
+            # remove_file).
+            remove = save_file[1]
+            self.save_file(pkgplan.image, path)
+            if remove != "true":
+                # File must be left in place (this file is
+                # likely overlaid and is moving).
+                return
+
+        if self.attrs.get("preserve") in ("abandon", "install-only"):
+            return
+
+        if (
+            not pkgplan.destination_fmri
+            and self.attrs.get("preserve", "false").lower() != "false"
+        ):
+            # Preserved files are salvaged if they have been
+            # modified since they were installed and this is
+            # not an upgrade.
+            try:
+                hash_attr, hash_val, hash_func = digest.get_preferred_hash(self)
+                ihash, cdata = misc.get_data_digest(path, hash_func=hash_func)
+                if ihash != hash_val:
+                    pkgplan.salvage(path)
+                    # Nothing more to do.
+                    return
+            except EnvironmentError as e:
+                if e.errno == errno.ENOENT:
+                    # Already gone; don't care.
+                    return
+                raise
+
+        # Attempt to remove the file.
+        rm_exc = None
+        try:
+            self.remove_fsobj(pkgplan, path)
+            return
+        except Exception as e:
+            if e.errno != errno.EACCES:
+                raise
+            rm_exc = e
+
+        # There are only two likely reasons we couldn't remove the file;
+        # either because the parent directory isn't writable, or
+        # because the file is read-only and the OS isn't allowing its
+        # removal.  Assume both and try making both the parent directory
+        # and the file writable, removing the file, and finally
+        # resetting the directory to its original mode.
+        pdir = os.path.dirname(path)
+        pmode = None
+        try:
+            if pdir != pkgplan.image.get_root():
+                # Parent directory is not image root (e.g. '/').
+                ps = os.lstat(pdir)
+                pmode = ps.st_mode
+                os.chmod(pdir, misc.PKG_DIR_MODE)
+
+            # Make file writable and try removing it again; required
+            # on some operating systems or potentially for some
+            # filesystems?
+            os.chmod(path, stat.S_IWRITE | stat.S_IREAD)
+            self.remove_fsobj(pkgplan, path)
+        except Exception as e:
+            # Raise new exception chained to old.
+            six.raise_from(e, rm_exc)
+        finally:
+            # If parent directory wasn't image root, then assume
+            # mode needs reset.
+            if pmode is not None:
                 try:
-                        pres_type = self.attrs["preserve"]
-                except KeyError:
-                        return
-
-                # Should ultimately be conditioned on file type
-                if "elfhash" in self.attrs:
-                        # Don't allow preserve logic to be applied to elf files;
-                        # if we ever stop tagging elf binaries with this
-                        # attribute, this will need to be updated.
-                        return
-
-                if pres_type == "abandon":
-                        return pres_type
-
-                final_path = self.get_installed_path(pkgplan.image.get_root())
-
-                # 'legacy' preservation is very different than other forms of
-                # preservation as it doesn't account for the on-disk state of
-                # the action's payload.
-                if pres_type == "legacy":
-                        if not orig:
-                                # This is an initial install or a repair, so
-                                # there's nothing to deliver.
-                                return True
-                        return pres_type
-
-                # If action has been marked with a preserve attribute, the
-                # hash of the preserved file has changed between versions,
-                # and the package being installed is older than the package
-                # that was installed, and the version on disk is different
-                # than the installed package's original version, then preserve
-                # the installed file by renaming it.
-                #
-                # If pkgplan.origin_fmri isn't set, but there is an orig action,
-                # then this file is moving between packages and it can't be
-                # a downgrade since that isn't allowed across rename or obsolete
-                # boundaries.
-                is_file = os.path.isfile(final_path)
-
-                # 'install-only' preservation has very specific semantics as
-                # well; if there's an 'orig' or this is an initial install and
-                # the file exists, we should not modify the file content.
-                if pres_type == "install-only":
-                        if orig or is_file:
-                                return True
-                        return False
-
-                changed_hash = False
-                if orig:
-                        # We must use the same hash algorithm when comparing old
-                        # and new actions. Look for the most-preferred common
-                        # hash between old and new. Since the two actions may
-                        # not share a common hash (in which case, we get a tuple
-                        # of 'None' objects) we also need to know the preferred
-                        # hash to use when examining the old action on its own.
-                        common_hash_attr, common_hash_val, \
-                            common_orig_hash_val, common_hash_func = \
-                            digest.get_common_preferred_hash(self, orig)
-
-                        hattr, orig_hash_val, orig_hash_func = \
-                            digest.get_preferred_hash(orig)
-
-                        if common_orig_hash_val and common_hash_val:
-                                changed_hash = common_hash_val != common_orig_hash_val
-                        else:
-                                # we don't have a common hash, so we must treat
-                                # this as a changed action
-                                changed_hash = True
-
-                        if pkgplan.destination_fmri and \
-                            changed_hash and \
-                            pkgplan.origin_fmri and \
-                            pkgplan.destination_fmri.version < pkgplan.origin_fmri.version:
-                                # Installed, preserved file is for a package
-                                # newer than what will be installed. So check if
-                                # the version on disk is different than what
-                                # was originally delivered, and if so, preserve
-                                # it.
-                                if not is_file:
-                                        return False
-
-                                preserve_version = self.__check_preserve_version(orig)
-                                if not preserve_version:
-                                        return False
-
-                                ihash, cdata = misc.get_data_digest(
-                                    final_path,
-                                    hash_func=orig_hash_func)
-                                if ihash != orig_hash_val:
-                                        return preserve_version
-
-                                return True
-
-                if (orig and orig_path):
-                        # Comparison will be based on a file being moved.
-                        is_file = os.path.isfile(orig_path)
-
-                # If the action has been marked with a preserve attribute, and
-                # the file exists and has a content hash different from what the
-                # system expected it to be, then we preserve the original file
-                # in some way, depending on the value of preserve.
-                if is_file:
-                        # if we had an action installed, then we know what hash
-                        # function was used to compute it's hash attribute.
-                        if orig:
-                                if not orig_path:
-                                        orig_path = final_path
-                                chash, cdata = misc.get_data_digest(orig_path,
-                                    hash_func=orig_hash_func)
-                        if not orig or chash != orig_hash_val:
-                                if pres_type in ("renameold", "renamenew"):
-                                        return pres_type
-                                return True
-                        elif not changed_hash and chash == orig_hash_val:
-                                # If packaged content has not changed since last
-                                # version and on-disk content matches the last
-                                # version, preserve on-disk file.
-                                return True
-
-                return False
-
-        # If we're not upgrading, or the file contents have changed,
-        # retrieve the file and write it to a temporary location.
-        # For files with content-hash attributes, only write the new file if the
-        # content-hash changed.
-        def needsdata(self, orig, pkgplan):
-                if self.replace_required:
-                        return True
-
-                # import goes here to prevent circular import
-                from pkg.client.imageconfig import CONTENT_UPDATE_POLICY
-
-                use_content_hash = orig and pkgplan.image.cfg.get_policy_str(
-                    CONTENT_UPDATE_POLICY) == "when-required"
-
-                # If content update policy allows it, check for a common
-                # preferred content hash.
-                if use_content_hash:
-                        content_hash_attr, content_hash_val, \
-                        orig_content_hash_val, content_hash_func = \
-                            digest.get_common_preferred_hash(
-                                self, orig, hash_type=digest.HASH_GELF)
-
-                hash_attr, hash_val, orig_hash_val, hash_func = \
-                    digest.get_common_preferred_hash(self, orig)
-
-                if not orig:
-                        changed_hash = True
-                elif orig and (orig_hash_val is None or
-                    hash_val is None):
-                        # we have no common hash so we have to treat this as a
-                        # changed action
-                        changed_hash = True
-                else:
-                        changed_hash = hash_val != orig_hash_val
-
-                if (changed_hash and
-                    (not use_content_hash or
-                     content_hash_val != orig_content_hash_val)):
-                        if ("preserve" not in self.attrs or
-                            not pkgplan.origin_fmri):
-                                return True
-                elif orig:
-                        # It's possible that the file content hasn't changed
-                        # for an upgrade case, but the file is missing.  This
-                        # ensures that for cases where the mode or some other
-                        # attribute of the file has changed that the file will
-                        # be installed.
-                        path = self.get_installed_path(pkgplan.image.get_root())
-                        if not os.path.isfile(path):
-                                return True
-
-                pres_type = self._check_preserve(orig, pkgplan)
-                if pres_type not in (None, True, "abandon"):
-                        # Preserved files only need data if they're being
-                        # changed (e.g. "renameold", etc.).
-                        return True
-
-                return False
-
-        def remove(self, pkgplan):
-                path = self.get_installed_path(pkgplan.image.get_root())
-
-                # Are we supposed to save this file to restore it elsewhere
-                # or in another pkg? 'save_file' is set by the imageplan.
-                save_file = self.attrs.get("save_file")
-                if save_file:
-                        # 'save_file' contains a tuple of (orig_name,
-                        # remove_file).
-                        remove = save_file[1]
-                        self.save_file(pkgplan.image, path)
-                        if remove != "true":
-                                # File must be left in place (this file is
-                                # likely overlaid and is moving).
-                                return
-
-                if self.attrs.get("preserve") in ("abandon", "install-only"):
-                        return
-
-                if not pkgplan.destination_fmri and \
-                    self.attrs.get("preserve", "false").lower() != "false":
-                        # Preserved files are salvaged if they have been
-                        # modified since they were installed and this is
-                        # not an upgrade.
-                        try:
-                                hash_attr, hash_val, hash_func  = \
-                                    digest.get_preferred_hash(self)
-                                ihash, cdata = misc.get_data_digest(path,
-                                    hash_func=hash_func)
-                                if ihash != hash_val:
-                                        pkgplan.salvage(path)
-                                        # Nothing more to do.
-                                        return
-                        except EnvironmentError as e:
-                                if e.errno == errno.ENOENT:
-                                        # Already gone; don't care.
-                                        return
-                                raise
-
-                # Attempt to remove the file.
-                rm_exc = None
-                try:
-                        self.remove_fsobj(pkgplan, path)
-                        return
+                    os.chmod(pdir, pmode)
                 except Exception as e:
-                        if e.errno != errno.EACCES:
-                                raise
-                        rm_exc = e
+                    # Ignore failure to reset parent mode.
+                    pass
 
-                # There are only two likely reasons we couldn't remove the file;
-                # either because the parent directory isn't writable, or
-                # because the file is read-only and the OS isn't allowing its
-                # removal.  Assume both and try making both the parent directory
-                # and the file writable, removing the file, and finally
-                # resetting the directory to its original mode.
-                pdir = os.path.dirname(path)
-                pmode = None
-                try:
-                        if pdir != pkgplan.image.get_root():
-                                # Parent directory is not image root (e.g. '/').
-                                ps = os.lstat(pdir)
-                                pmode = ps.st_mode
-                                os.chmod(pdir, misc.PKG_DIR_MODE)
+    def generate_indices(self):
+        """Generates the indices needed by the search dictionary.  See
+        generic.py for a more detailed explanation."""
 
-                        # Make file writable and try removing it again; required
-                        # on some operating systems or potentially for some
-                        # filesystems?
-                        os.chmod(path, stat.S_IWRITE|stat.S_IREAD)
-                        self.remove_fsobj(pkgplan, path)
-                except Exception as e:
-                        # Raise new exception chained to old.
-                        six.raise_from(e, rm_exc)
-                finally:
-                        # If parent directory wasn't image root, then assume
-                        # mode needs reset.
-                        if pmode is not None:
-                                try:
-                                        os.chmod(pdir, pmode)
-                                except Exception as e:
-                                        # Ignore failure to reset parent mode.
-                                        pass
+        index_list = [
+            # this entry shows the hash as the 'index', and the
+            # file path as the 'value' when showing results when the
+            # user has searched for the SHA-1 hash. This seems unusual,
+            # but maintains the behaviour we had for S11.
+            ("file", "content", self.hash, self.hash),
+            # This will result in a 2nd row of output when searching for
+            # the SHA-1 hash, but is consistent with our behaviour for
+            # the other hash attributes.
+            ("file", "hash", self.hash, None),
+            ("file", "basename", os.path.basename(self.attrs["path"]), None),
+            ("file", "path", os.path.sep + self.attrs["path"], None),
+        ]
+        for attr in digest.DEFAULT_HASH_ATTRS:
+            # We already have an index entry for self.hash;
+            # we only want hash attributes other than "hash".
+            hash = self.attrs.get(attr)
+            if attr != "hash" and hash is not None:
+                index_list.append(("file", attr, hash, None))
+        return index_list
 
-        def generate_indices(self):
-                """Generates the indices needed by the search dictionary.  See
-                generic.py for a more detailed explanation."""
+    def save_file(self, image, full_path):
+        """Save a file for later installation (in same process
+        invocation, if it exists)."""
 
-                index_list = [
-                    # this entry shows the hash as the 'index', and the
-                    # file path as the 'value' when showing results when the
-                    # user has searched for the SHA-1 hash. This seems unusual,
-                    # but maintains the behaviour we had for S11.
-                    ("file", "content", self.hash, self.hash),
-                    # This will result in a 2nd row of output when searching for
-                    # the SHA-1 hash, but is consistent with our behaviour for
-                    # the other hash attributes.
-                    ("file", "hash", self.hash, None),
-                    ("file", "basename", os.path.basename(self.attrs["path"]),
-                    None),
-                    ("file", "path", os.path.sep + self.attrs["path"], None)
-                ]
-                for attr in digest.DEFAULT_HASH_ATTRS:
-                        # We already have an index entry for self.hash;
-                        # we only want hash attributes other than "hash".
-                        hash = self.attrs.get(attr)
-                        if attr != "hash" and hash is not None:
-                                index_list.append(("file", attr, hash, None))
-                return index_list
+        saved_name = image.temporary_file()
+        try:
+            misc.copyfile(full_path, saved_name)
+        except OSError as err:
+            if err.errno != errno.ENOENT:
+                raise
 
-        def save_file(self, image, full_path):
-                """Save a file for later installation (in same process
-                invocation, if it exists)."""
+            # If the file doesn't exist, it can't be saved, so
+            # be certain consumers of this information know there
+            # isn't an original to restore.
+            saved_name = None
 
-                saved_name = image.temporary_file()
-                try:
-                        misc.copyfile(full_path, saved_name)
-                except OSError as err:
-                        if err.errno != errno.ENOENT:
-                                raise
+        ip = image.imageplan
+        ip.saved_files[self.attrs["save_file"][0]] = (self, saved_name)
 
-                        # If the file doesn't exist, it can't be saved, so
-                        # be certain consumers of this information know there
-                        # isn't an original to restore.
-                        saved_name = None
+    def restore_file(self, image):
+        """restore a previously saved file; return cached action"""
 
-                ip = image.imageplan
-                ip.saved_files[self.attrs["save_file"][0]] = (self, saved_name)
+        ip = image.imageplan
+        orig, saved_name = ip.saved_files[self.attrs["save_file"][0]]
+        if saved_name is None:
+            # Nothing to restore; original file is missing.
+            return
 
-        def restore_file(self, image):
-                """restore a previously saved file; return cached action """
+        full_path = self.get_installed_path(image.get_root())
+        assert not os.path.exists(full_path)
 
-                ip = image.imageplan
-                orig, saved_name = ip.saved_files[self.attrs["save_file"][0]]
-                if saved_name is None:
-                        # Nothing to restore; original file is missing.
-                        return
+        misc.copyfile(saved_name, full_path)
+        os.unlink(saved_name)
 
-                full_path = self.get_installed_path(image.get_root())
-                assert not os.path.exists(full_path)
+        return orig
 
-                misc.copyfile(saved_name, full_path)
-                os.unlink(saved_name)
+    def validate(self, fmri=None):
+        """Performs additional validation of action attributes that
+        for performance or other reasons cannot or should not be done
+        during Action object creation.  An ActionError exception (or
+        subclass of) will be raised if any attributes are not valid.
+        This is primarily intended for use during publication or during
+        error handling to provide additional diagonostics.
 
-                return orig
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action."""
 
-        def validate(self, fmri=None):
-                """Performs additional validation of action attributes that
-                for performance or other reasons cannot or should not be done
-                during Action object creation.  An ActionError exception (or
-                subclass of) will be raised if any attributes are not valid.
-                This is primarily intended for use during publication or during
-                error handling to provide additional diagonostics.
+        errors = generic.Action._validate(
+            self,
+            fmri=fmri,
+            numeric_attrs=("pkg.csize", "pkg.size"),
+            raise_errors=False,
+            required_attrs=("owner", "group"),
+            single_attrs=(
+                "chash",
+                "preserve",
+                "overlay",
+                "elfarch",
+                "elfbits",
+                "elfhash",
+                "original_name",
+                "preserve-version",
+            ),
+        )
+        errors.extend(self._validate_fsobj_common())
 
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action."""
+        preserve = self.attrs.get("preserve")
+        preserve_version = self.attrs.get("preserve-version")
 
-                errors = generic.Action._validate(self, fmri=fmri,
-                    numeric_attrs=("pkg.csize", "pkg.size"), raise_errors=False,
-                    required_attrs=("owner", "group"), single_attrs=("chash",
-                    "preserve", "overlay", "elfarch", "elfbits", "elfhash",
-                    "original_name", "preserve-version"))
-                errors.extend(self._validate_fsobj_common())
+        if preserve_version:
+            if not preserve:
+                errors.append(
+                    (
+                        "preserve-version",
+                        _(
+                            "preserve must be 'true' if a "
+                            "preserve-version is specified"
+                        ),
+                    )
+                )
 
-                preserve = self.attrs.get("preserve")
-                preserve_version = self.attrs.get("preserve-version")
+            (
+                release,
+                build_release,
+                branch,
+                timestr,
+            ), ignored = version.Version.split(str(preserve_version))
+            if not release:
+                errors.append(
+                    (
+                        "preserve-version",
+                        _("preserve-version must specify " "the release"),
+                    )
+                )
+            if build_release != "":
+                errors.append(
+                    (
+                        "preserve-version",
+                        _("preserve-version must specify " "the release"),
+                    )
+                )
+            if branch:
+                errors.append(
+                    (
+                        "preserve-version",
+                        _("preserve-version must not specify " "the branch"),
+                    )
+                )
+            if timestr:
+                errors.append(
+                    (
+                        "preserve-version",
+                        _("preserve-version must not specify " "the timestamp"),
+                    )
+                )
 
-                if preserve_version:
-                        if not preserve:
-                                errors.append(("preserve-version",
-                                    _("preserve must be 'true' if a "
-                                    "preserve-version is specified")))
+        if errors:
+            raise pkg.actions.InvalidActionAttributesError(
+                self, errors, fmri=fmri
+            )
 
-                        (release, build_release, branch, timestr), ignored = \
-                            version.Version.split(str(preserve_version))
-                        if not release:
-                                errors.append(("preserve-version",
-                                    _("preserve-version must specify "
-                                      "the release")))
-                        if build_release != "":
-                                errors.append(("preserve-version",
-                                    _("preserve-version must specify "
-                                      "the release")))
-                        if branch:
-                                errors.append(("preserve-version",
-                                    _("preserve-version must not specify "
-                                      "the branch")))
-                        if timestr:
-                                errors.append(("preserve-version",
-                                    _("preserve-version must not specify "
-                                      "the timestamp")))
+    if six.PY3:
 
-                if errors:
-                        raise pkg.actions.InvalidActionAttributesError(self,
-                            errors, fmri=fmri)
+        def __init__(self, data, **attrs):
+            _common._file_init(self, data, **attrs)
 
-        if six.PY3:
-                def __init__(self, data, **attrs):
-                        _common._file_init(self, data, **attrs)
 
 if six.PY2:
-        FileAction.__init__ = types.MethodType(_common._file_init, None, FileAction)
+    FileAction.__init__ = types.MethodType(_common._file_init, None, FileAction)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/generic.py
+++ b/src/modules/actions/generic.py
@@ -33,10 +33,10 @@ import errno
 import os
 
 try:
-        # Some versions of python don't have these constants.
-        os.SEEK_SET
+    # Some versions of python don't have these constants.
+    os.SEEK_SET
 except AttributeError:
-        os.SEEK_SET, os.SEEK_CUR, os.SEEK_END = range(3)
+    os.SEEK_SET, os.SEEK_CUR, os.SEEK_END = range(3)
 import six
 import stat
 import types
@@ -57,1226 +57,1304 @@ from pkg.misc import EmptyDict, CMP_ALL, CMP_UNSIGNED
 # users and groups that may be delivered during the same operation); this
 # implies that /etc/group and /etc/passwd file ownership needs to be part of
 # initial contents of those files.
-_orderdict = dict((k, i) for i, k in enumerate((
-    "set",
-    "depend",
-    "group",
-    "user",
-    "dir",
-    "file",
-    "hardlink",
-    "link",
-    "driver",
-    "unknown",
-    "license",
-    "legacy",
-    "signature"
-)))
+_orderdict = dict(
+    (k, i)
+    for i, k in enumerate(
+        (
+            "set",
+            "depend",
+            "group",
+            "user",
+            "dir",
+            "file",
+            "hardlink",
+            "link",
+            "driver",
+            "unknown",
+            "license",
+            "legacy",
+            "signature",
+        )
+    )
+)
 
 # EmptyI for argument defaults; no import to avoid pkg.misc dependency.
 EmptyI = tuple()
 
-def quote_attr_value(s):
-        """Returns a properly quoted version of the provided string suitable for
-        use as an attribute value for actions in string form."""
 
-        if " " in s or "'" in s or "\"" in s or s == "":
-                if "\"" not in s:
-                        return '"{0}"'.format(s)
-                elif "'" not in s:
-                        return "'{0}'".format(s)
-                return '"{0}"'.format(s.replace("\"", "\\\""))
-        return s
+def quote_attr_value(s):
+    """Returns a properly quoted version of the provided string suitable for
+    use as an attribute value for actions in string form."""
+
+    if " " in s or "'" in s or '"' in s or s == "":
+        if '"' not in s:
+            return '"{0}"'.format(s)
+        elif "'" not in s:
+            return "'{0}'".format(s)
+        return '"{0}"'.format(s.replace('"', '\\"'))
+    return s
+
 
 class NSG(type):
-        """This metaclass automatically assigns a subclass of Action a
-        namespace_group member if it hasn't already been specified.  This is a
-        convenience for classes which are the sole members of their group and
-        don't want to hardcode something arbitrary and unique."""
+    """This metaclass automatically assigns a subclass of Action a
+    namespace_group member if it hasn't already been specified.  This is a
+    convenience for classes which are the sole members of their group and
+    don't want to hardcode something arbitrary and unique."""
 
-        __nsg = 0
-        def __new__(mcs, name, bases, dict):
-                nsg = None
+    __nsg = 0
 
-                # We only look at subclasses of Action, and we ignore multiple
-                # inheritance.
-                if name != "Action" and issubclass(bases[0], Action):
-                        # Iterate through the inheritance chain to see if any
-                        # parent class has a namespace_group member, and grab
-                        # its value.
-                        for c in bases[0].__mro__:
-                                if c == Action:
-                                        break
-                                nsg = getattr(c, "namespace_group", None)
-                                if nsg is not None:
-                                        break
+    def __new__(mcs, name, bases, dict):
+        nsg = None
 
-                        # If the class didn't have a namespace_group member
-                        # already, assign one.  If we found one in our traversal
-                        # above, use that, otherwise make one up.
-                        if "namespace_group" not in dict:
-                                if not nsg:
-                                        nsg = NSG.__nsg
-                                        # Prepare for the next class.
-                                        NSG.__nsg += 1
-                                dict["namespace_group"] = nsg
+        # We only look at subclasses of Action, and we ignore multiple
+        # inheritance.
+        if name != "Action" and issubclass(bases[0], Action):
+            # Iterate through the inheritance chain to see if any
+            # parent class has a namespace_group member, and grab
+            # its value.
+            for c in bases[0].__mro__:
+                if c == Action:
+                    break
+                nsg = getattr(c, "namespace_group", None)
+                if nsg is not None:
+                    break
 
-                return type.__new__(mcs, name, bases, dict)
+            # If the class didn't have a namespace_group member
+            # already, assign one.  If we found one in our traversal
+            # above, use that, otherwise make one up.
+            if "namespace_group" not in dict:
+                if not nsg:
+                    nsg = NSG.__nsg
+                    # Prepare for the next class.
+                    NSG.__nsg += 1
+                dict["namespace_group"] = nsg
 
-        @staticmethod
-        def getstate(obj, je_state=None):
-                """Returns the serialized state of this object in a format
-                that that can be easily stored using JSON, pickle, etc."""
-                return str(obj)
+        return type.__new__(mcs, name, bases, dict)
 
-        @staticmethod
-        def fromstate(state, jd_state=None):
-                """Allocate a new object using previously serialized state
-                obtained via getstate()."""
-                return pkg.actions.fromstr(state)
+    @staticmethod
+    def getstate(obj, je_state=None):
+        """Returns the serialized state of this object in a format
+        that that can be easily stored using JSON, pickle, etc."""
+        return str(obj)
+
+    @staticmethod
+    def fromstate(state, jd_state=None):
+        """Allocate a new object using previously serialized state
+        obtained via getstate()."""
+        return pkg.actions.fromstr(state)
 
 
 # metaclass-assignment; pylint: disable=W1623
 @six.add_metaclass(NSG)
 class Action(object):
-        """Class representing a generic packaging object.
+    """Class representing a generic packaging object.
 
-        An Action is a very simple wrapper around two dictionaries: a named set
-        of data streams and a set of attributes.  Data streams generally
-        represent files on disk, and attributes represent metadata about those
-        files.
+    An Action is a very simple wrapper around two dictionaries: a named set
+    of data streams and a set of attributes.  Data streams generally
+    represent files on disk, and attributes represent metadata about those
+    files.
+    """
+
+    __slots__ = ["attrs", "data"]
+
+    # 'name' is the name of the action, as specified in a manifest.
+    name = "generic"
+    # 'key_attr' is the name of the attribute whose value must be unique in
+    # the namespace of objects represented by a particular action.  For
+    # instance, a file's key_attr would be its pathname.  Or a driver's
+    # key_attr would be the driver name.  When 'key_attr' is None, it means
+    # that all attributes of the action are distinguishing.
+    key_attr = None
+    # 'globally_identical' is True if all actions representing a single
+    # object on a system must be identical.
+    globally_identical = False
+    # 'refcountable' is True if the action type can safely be delivered
+    # multiple times.
+    refcountable = False
+    # 'namespace_group' is a string whose value is shared by actions which
+    # share a common namespace.  As a convenience to the classes which are
+    # the sole members of their group, this is set to a non-None value for
+    # subclasses by the NSG metaclass.
+    namespace_group = None
+    # 'ordinality' is a numeric value that is used during action comparison
+    # to determine action sorting.
+    ordinality = _orderdict["unknown"]
+    # 'unique_attrs' is a tuple listing the attributes which must be
+    # identical in order for an action to be safely delivered multiple times
+    # (for those that can be).
+    unique_attrs = ()
+
+    # The version of signature used.
+    sig_version = 0
+    # Most types of actions do not have a payload.
+    has_payload = False
+
+    # Python 3 will ignore the __metaclass__ field, but it's still useful
+    # for class attribute access.
+    __metaclass__ = NSG
+
+    # __init__ is provided as a native function (see end of class
+    # declaration).
+
+    def set_data(self, data):
+        """This function sets the data field of the action.
+
+        The "data" parameter is the file to use to set the data field.
+        It can be a string which is the path to the file, a function
+        which provides the file when called, or a file handle to the
+        file."""
+
+        if data is None:
+            self.data = None
+            return
+
+        if isinstance(data, six.string_types):
+            if not os.path.exists(data):
+                raise pkg.actions.ActionDataError(
+                    _("No such file: '{0}'.").format(data), path=data
+                )
+            elif os.path.isdir(data):
+                raise pkg.actions.ActionDataError(
+                    _("'{0}' is not a file.").format(data), path=data
+                )
+
+            def file_opener():
+                return open(data, "rb")
+
+            self.data = file_opener
+            if "pkg.size" not in self.attrs:
+                try:
+                    fs = os.stat(data)
+                    self.attrs["pkg.size"] = str(fs.st_size)
+                except EnvironmentError as e:
+                    raise pkg.actions.ActionDataError(e, path=data)
+            return
+
+        if hasattr(data, "__call__"):
+            # Data is not None, and is callable.
+            self.data = data
+            return
+
+        if "pkg.size" in self.attrs:
+            self.data = lambda: data
+            return
+
+        try:
+            sz = data.size
+        except AttributeError:
+            try:
+                try:
+                    sz = os.fstat(data.fileno()).st_size
+                except (AttributeError, TypeError):
+                    try:
+                        try:
+                            data.seek(0, os.SEEK_END)
+                            sz = data.tell()
+                            data.seek(0)
+                        except (AttributeError, TypeError):
+                            d = data.read()
+                            sz = len(d)
+                            data = BytesIO(d)
+                    except (AttributeError, TypeError):
+                        # Raw data was provided; fake a
+                        # file object.
+                        sz = len(data)
+                        data = BytesIO(data)
+            except EnvironmentError as e:
+                raise pkg.actions.ActionDataError(e)
+
+        self.attrs["pkg.size"] = str(sz)
+        self.data = lambda: data
+
+    def __str__(self):
+        """Serialize the action into manifest form.
+
+        The form is the name, followed by the SHA1 hash, if it exists,
+        (this use of a positional SHA1 hash is deprecated, with
+        pkg.*hash.* attributes being preferred over positional hashes)
+        followed by attributes in the form 'key=value'.  All fields are
+        space-separated; fields with spaces in the values are quoted.
+
+        Note that an object with a datastream may have been created in
+        such a way that the hash field is not populated, or not
+        populated with real data.  The action classes do not guarantee
+        that at the time that __str__() is called, the hash is properly
+        computed.  This may need to be done externally.
         """
 
-        __slots__ = ["attrs", "data"]
+        sattrs = list(self.attrs.keys())
+        out = self.name
+        try:
+            h = self.hash
+            if h:
+                if "=" not in h and " " not in h and '"' not in h:
+                    out += " " + h
+                else:
+                    sattrs.append("hash")
+        except AttributeError:
+            # No hash to stash.
+            pass
 
-        # 'name' is the name of the action, as specified in a manifest.
-        name = "generic"
-        # 'key_attr' is the name of the attribute whose value must be unique in
-        # the namespace of objects represented by a particular action.  For
-        # instance, a file's key_attr would be its pathname.  Or a driver's
-        # key_attr would be the driver name.  When 'key_attr' is None, it means
-        # that all attributes of the action are distinguishing.
-        key_attr = None
-        # 'globally_identical' is True if all actions representing a single
-        # object on a system must be identical.
-        globally_identical = False
-        # 'refcountable' is True if the action type can safely be delivered
-        # multiple times.
-        refcountable = False
-        # 'namespace_group' is a string whose value is shared by actions which
-        # share a common namespace.  As a convenience to the classes which are
-        # the sole members of their group, this is set to a non-None value for
-        # subclasses by the NSG metaclass.
-        namespace_group = None
-        # 'ordinality' is a numeric value that is used during action comparison
-        # to determine action sorting.
-        ordinality = _orderdict["unknown"]
-        # 'unique_attrs' is a tuple listing the attributes which must be
-        # identical in order for an action to be safely delivered multiple times
-        # (for those that can be).
-        unique_attrs = ()
+        # Sort so that we get consistent action attribute ordering.
+        # We pay a performance penalty to do so, but it seems worth it.
+        sattrs.sort()
 
-        # The version of signature used.
-        sig_version = 0
-        # Most types of actions do not have a payload.
-        has_payload = False
+        for k in sattrs:
+            # Octal literal in Python 3 begins with "0o", such as
+            # "0o755", but we want to keep "0755" in the output.
+            if (
+                k == "mode"
+                and isinstance(self.attrs[k], str)
+                and self.attrs[k].startswith("0o")
+            ):
+                self.attrs[k] = "0" + self.attrs[k][2:]
+            try:
+                v = self.attrs[k]
+            except KeyError:
+                # If we can't find the attribute, it must be the
+                # hash. 'h' will only be in scope if the block
+                # at the start succeeded.
+                v = h
 
-        # Python 3 will ignore the __metaclass__ field, but it's still useful
-        # for class attribute access.
-        __metaclass__ = NSG
+            if type(v) is list or type(v) is set:
+                out += " " + " ".join(
+                    ["=".join((k, quote_attr_value(lmt))) for lmt in v]
+                )
+            # Quote values containing whitespaces or macros
+            elif " " in v or "'" in v or '"' in v or v == "" or "$(" in v:
+                if '"' not in v:
+                    out += " " + k + '="' + v + '"'
+                elif "'" not in v:
+                    out += " " + k + "='" + v + "'"
+                else:
+                    out += " " + k + '="' + v.replace('"', '\\"') + '"'
+            else:
+                out += " " + k + "=" + v
 
-        # __init__ is provided as a native function (see end of class
-        # declaration).
+        return out
 
-        def set_data(self, data):
-                """This function sets the data field of the action.
+    def __repr__(self):
+        return "<{0} object at {1:#x}: {2}>".format(
+            self.__class__, id(self), self
+        )
 
-                The "data" parameter is the file to use to set the data field.
-                It can be a string which is the path to the file, a function
-                which provides the file when called, or a file handle to the
-                file."""
+    def sig_str(self, a, ver):
+        """Create a stable string representation of an action that
+        is deterministic in its creation.  If creating a string from an
+        action is non-deterministic, then manifest signing cannot work.
 
-                if data is None:
-                        self.data = None
-                        return
+        The parameter "a" is the signature action that's going to use
+        the string produced.  It's needed for the signature string
+        action, and is here to keep the method signature the same.
+        """
 
-                if isinstance(data, six.string_types):
-                        if not os.path.exists(data):
-                                raise pkg.actions.ActionDataError(
-                                    _("No such file: '{0}'.").format(data),
-                                    path=data)
-                        elif os.path.isdir(data):
-                                raise pkg.actions.ActionDataError(
-                                    _("'{0}' is not a file.").format(data),
-                                    path=data)
+        # Any changes to this function or any subclasses sig_str mean
+        # Action.sig_version must be incremented.
 
-                        def file_opener():
-                                return open(data, "rb")
-                        self.data = file_opener
-                        if "pkg.size" not in self.attrs:
-                                try:
-                                        fs = os.stat(data)
-                                        self.attrs["pkg.size"] = str(fs.st_size)
-                                except EnvironmentError as e:
-                                        raise \
-                                            pkg.actions.ActionDataError(
-                                            e, path=data)
-                        return
+        if ver != Action.sig_version:
+            raise apx.UnsupportedSignatureVersion(ver, sig=self)
 
-                if hasattr(data, "__call__"):
-                        # Data is not None, and is callable.
-                        self.data = data
-                        return
+        out = self.name
+        if hasattr(self, "hash") and self.hash is not None:
+            out += " " + self.hash
 
-                if "pkg.size" in self.attrs:
-                        self.data = lambda: data
-                        return
+        def q(s):
+            if " " in s or "'" in s or '"' in s or s == "" or "$(" in s:
+                if '"' not in s:
+                    return '"{0}"'.format(s)
+                elif "'" not in s:
+                    return "'{0}'".format(s)
+                else:
+                    return '"{0}"'.format(s.replace('"', '\\"'))
+            else:
+                return s
 
-                try:
-                        sz = data.size
-                except AttributeError:
-                        try:
-                                try:
-                                        sz = os.fstat(data.fileno()).st_size
-                                except (AttributeError, TypeError):
-                                        try:
-                                                try:
-                                                        data.seek(0,
-                                                            os.SEEK_END)
-                                                        sz = data.tell()
-                                                        data.seek(0)
-                                                except (AttributeError,
-                                                    TypeError):
-                                                        d = data.read()
-                                                        sz = len(d)
-                                                        data = BytesIO(d)
-                                        except (AttributeError, TypeError):
-                                                # Raw data was provided; fake a
-                                                # file object.
-                                                sz = len(data)
-                                                data = BytesIO(data)
-                        except EnvironmentError as e:
-                                raise pkg.actions.ActionDataError(e)
+        # Sort so that we get consistent action attribute ordering.
+        # We pay a performance penalty to do so, but it seems worth it.
+        for k in sorted(self.attrs.keys()):
+            v = self.attrs[k]
+            # Octal literal in Python 3 begins with "0o", such as
+            # "0o755", but we want to keep "0755" in the output.
+            if k == "mode" and v.startswith("0o"):
+                self.attrs[k] = "0" + v[2:]
+            if type(v) is list:
+                out += " " + " ".join(
+                    ["{0}={1}".format(k, q(lmt)) for lmt in sorted(v)]
+                )
+            elif " " in v or "'" in v or '"' in v or v == "" or "$(" in v:
+                if '"' not in v:
+                    out += " " + k + '="' + v + '"'
+                elif "'" not in v:
+                    out += " " + k + "='" + v + "'"
+                else:
+                    out += " " + k + '="' + v.replace('"', '\\"') + '"'
+            else:
+                out += " " + k + "=" + v
 
-                self.attrs["pkg.size"] = str(sz)
-                self.data = lambda: data
+        return out
 
-        def __str__(self):
-                """Serialize the action into manifest form.
+    def __eq__(self, other):
+        if (
+            self.name == other.name
+            and getattr(self, "hash", None) == getattr(other, "hash", None)
+            and self.attrs == other.attrs
+        ):
+            return True
+        return False
 
-                The form is the name, followed by the SHA1 hash, if it exists,
-                (this use of a positional SHA1 hash is deprecated, with
-                pkg.*hash.* attributes being preferred over positional hashes)
-                followed by attributes in the form 'key=value'.  All fields are
-                space-separated; fields with spaces in the values are quoted.
+    def __ne__(self, other):
+        if (
+            self.name == other.name
+            and getattr(self, "hash", None) == getattr(other, "hash", None)
+            and self.attrs == other.attrs
+        ):
+            return False
+        return True
 
-                Note that an object with a datastream may have been created in
-                such a way that the hash field is not populated, or not
-                populated with real data.  The action classes do not guarantee
-                that at the time that __str__() is called, the hash is properly
-                computed.  This may need to be done externally.
-                """
+    def __hash__(self):
+        return hash(id(self))
 
-                sattrs = list(self.attrs.keys())
-                out = self.name
-                try:
-                        h = self.hash
-                        if h:
-                                if "=" not in h and " " not in h and \
-                                    '"' not in h:
-                                        out += " " + h
-                                else:
-                                        sattrs.append("hash")
-                except AttributeError:
-                        # No hash to stash.
-                        pass
+    def compare(self, other):
+        return (id(self) > id(other)) - (id(self) < id(other))
 
-                # Sort so that we get consistent action attribute ordering.
-                # We pay a performance penalty to do so, but it seems worth it.
-                sattrs.sort()
-
-                for k in sattrs:
-                        # Octal literal in Python 3 begins with "0o", such as
-                        # "0o755", but we want to keep "0755" in the output.
-                        if k == "mode" and isinstance(self.attrs[k], str) and \
-                            self.attrs[k].startswith("0o"):
-                                self.attrs[k] = "0" + self.attrs[k][2:]
-                        try:
-                               v = self.attrs[k]
-                        except KeyError:
-                                # If we can't find the attribute, it must be the
-                                # hash. 'h' will only be in scope if the block
-                                # at the start succeeded.
-                                v = h
-
-                        if type(v) is list or type(v) is set:
-                                out += " " + " ".join([
-                                    "=".join((k, quote_attr_value(lmt)))
-                                    for lmt in v
-                                ])
-                        # Quote values containing whitespaces or macros
-                        elif " " in v or "'" in v or "\"" in v or v == "" or "$(" in v:
-                                if "\"" not in v:
-                                        out += " " + k + "=\"" + v + "\""
-                                elif "'" not in v:
-                                        out += " " + k + "='" + v + "'"
-                                else:
-                                        out += " " + k + "=\"" + \
-                                            v.replace("\"", "\\\"") + "\""
-                        else:
-                                out += " " + k + "=" + v
-
-                return out
-
-        def __repr__(self):
-                return "<{0} object at {1:#x}: {2}>".format(self.__class__,
-                    id(self), self)
-
-        def sig_str(self, a, ver):
-                """Create a stable string representation of an action that
-                is deterministic in its creation.  If creating a string from an
-                action is non-deterministic, then manifest signing cannot work.
-
-                The parameter "a" is the signature action that's going to use
-                the string produced.  It's needed for the signature string
-                action, and is here to keep the method signature the same.
-                """
-
-                # Any changes to this function or any subclasses sig_str mean
-                # Action.sig_version must be incremented.
-
-                if ver != Action.sig_version:
-                        raise apx.UnsupportedSignatureVersion(ver, sig=self)
-
-                out = self.name
-                if hasattr(self, "hash") and self.hash is not None:
-                        out += " " + self.hash
-
-                def q(s):
-                        if " " in s or "'" in s or "\"" in s or s == "" or "$(" in s:
-                                if "\"" not in s:
-                                        return '"{0}"'.format(s)
-                                elif "'" not in s:
-                                        return "'{0}'".format(s)
-                                else:
-                                        return '"{0}"'.format(
-                                            s.replace("\"", "\\\""))
-                        else:
-                                return s
-
-                # Sort so that we get consistent action attribute ordering.
-                # We pay a performance penalty to do so, but it seems worth it.
-                for k in sorted(self.attrs.keys()):
-                        v = self.attrs[k]
-                        # Octal literal in Python 3 begins with "0o", such as
-                        # "0o755", but we want to keep "0755" in the output.
-                        if k == "mode" and v.startswith("0o"):
-                                self.attrs[k] = "0" + v[2:]
-                        if type(v) is list:
-                                out += " " + " ".join([
-                                    "{0}={1}".format(k, q(lmt)) for lmt in sorted(v)
-                                ])
-                        elif " " in v or "'" in v or "\"" in v or v == "" or "$(" in v:
-                                if "\"" not in v:
-                                        out += " " + k + "=\"" + v + "\""
-                                elif "'" not in v:
-                                        out += " " + k + "='" + v + "'"
-                                else:
-                                        out += " " + k + "=\"" + \
-                                            v.replace("\"", "\\\"") + "\""
-                        else:
-                                out += " " + k + "=" + v
-
-                return out
-
-        def __eq__(self, other):
-                if self.name == other.name and \
-                    getattr(self, "hash", None) == \
-                        getattr(other, "hash", None) and \
-                    self.attrs == other.attrs:
-                        return True
-                return False
-
-        def __ne__(self, other):
-                if self.name == other.name and \
-                    getattr(self, "hash", None) == \
-                        getattr(other, "hash", None) and \
-                    self.attrs == other.attrs:
-                        return False
+    def __lt__(self, other):
+        if self.ordinality == other.ordinality:
+            if self.compare(other) < 0:  # often subclassed
                 return True
-
-        def __hash__(self):
-                return hash(id(self))
-
-        def compare(self, other):
-                return (id(self) > id(other)) - (id(self) < id(other))
-
-        def __lt__(self, other):
-                if self.ordinality == other.ordinality:
-                        if self.compare(other) < 0: # often subclassed
-                                return True
-                        else:
-                                return False
-                return self.ordinality < other.ordinality
-
-        def __gt__(self, other):
-                if self.ordinality == other.ordinality:
-                        if self.compare(other) > 0: # often subclassed
-                                return True
-                        else:
-                                return False
-                return self.ordinality > other.ordinality
-
-        def __le__(self, other):
-                return self == other or self < other
-
-        def __ge__(self, other):
-                return self == other or self > other
-
-        def different(self, other, pkgplan=None, cmp_policy=None):
-                """Returns True if other represents a non-ignorable change from
-                self.  By default, this means two actions are different if any
-                of their attributes are different.
-
-                When cmp_policy is CMP_UNSIGNED, check the unsigned versions
-                of hashes instead of signed versions of hashes on both actions.
-                This prevents comparing all hash attributes as simple value
-                comparisons, and instead compares only non-hash attributes,
-                then tests the most preferred hash for equivalence.  When
-                cmp_policy is CMP_ALL, compare using all attributes.
-                """
-
-                if self.has_payload != other.has_payload:
-                        # Comparing different action types.
-                        return True
-
-                sattrs = self.attrs
-                oattrs = other.attrs
-
-                # Are all attributes identical? Most actions don't change, so
-                # a simple equality comparison should be sufficient.
-                if sattrs == oattrs:
-                        if self.has_payload:
-                                # If payload present, must also compare some
-                                # object attributes.
-                                if self.hash == other.hash:
-                                        return False
-                        else:
-                                return False
-
-                # If action has payload, perform hash comparison first. For
-                # actions with a payload, hash attributes usually change, but
-                # other attributes do not.
-                hash_type = digest.HASH
-                if self.has_payload:
-                        if "elfarch" in self.attrs and "elfarch" in other.attrs:
-                                # If both actions are for elf files, determine
-                                # if we should compare based on elf content
-                                # hash.
-                                if cmp_policy == CMP_UNSIGNED and not pkgplan:
-                                        # If caller requested unsigned
-                                        # comparison, and no policy is
-                                        # available, compare based on elf
-                                        # content hash.
-                                        hash_type = digest.HASH_GELF
-                                elif pkgplan:
-                                        # Avoid circular import.
-                                        from pkg.client.imageconfig \
-                                                import CONTENT_UPDATE_POLICY
-
-                                        if pkgplan.image.cfg.get_policy_str(
-                                            CONTENT_UPDATE_POLICY) == \
-                                            "when-required":
-                                                # If policy is available and
-                                                # allows it, then compare based
-                                                # on elf content hash.
-                                                hash_type = digest.HASH_GELF
-
-                        # digest.get_common_preferred_hash() tries to return the
-                        # most preferred hash attribute and falls back to
-                        # returning the action.hash values if there are no other
-                        # common hash attributes, and will throw an
-                        # AttributeError if one or the other actions don't have
-                        # an action.hash attribute.
-                        try:
-                                hash_attr, shash, ohash, hash_func = \
-                                    digest.get_common_preferred_hash(
-                                        self, other, hash_type=hash_type,
-                                        cmp_policy=cmp_policy)
-                                if shash != ohash:
-                                        return True
-                                # If there's no common preferred hash, we have
-                                # to treat these actions as different.
-                                if shash is None and ohash is None:
-                                        return True
-                        except AttributeError:
-                                # If action.hash is set on exactly one of self
-                                # and other, then we're trying to compare
-                                # actions of disparate subclasses.
-                                if hasattr(self, "hash") ^ hasattr(other,
-                                    "hash"):
-                                        raise AssertionError(
-                                            "attempt to compare a "
-                                            "{0} action to a {1} action".format(
-                                            self.name, other.name))
-
-                if self.has_payload and cmp_policy != CMP_ALL:
-                        sset = frozenset(
-                            a for a in sattrs if not digest.is_hash_attr(a))
-                        oset = frozenset(
-                            a for a in oattrs if not digest.is_hash_attr(a))
-                else:
-                        sset = frozenset(sattrs)
-                        oset = frozenset(oattrs)
-
-                # If hashes were equal or not applicable, then compare remaining
-                # attributes.
-                if sset.symmetric_difference(oset):
-                        return True
-
-                for a in sset:
-                        x = sattrs[a]
-                        y = oattrs[a]
-                        if x != y:
-                                if len(x) == len(y) and \
-                                    type(x) is list and type(y) is list:
-                                        if sorted(x) != sorted(y):
-                                                return True
-                                else:
-                                        return True
-
+            else:
                 return False
-
-        def differences(self, other):
-                """Returns the attributes that have different values between
-                other and self."""
-                sset = set(self.attrs.keys())
-                oset = set(other.attrs.keys())
-                l = sset.symmetric_difference(oset)
-                for k in sset & oset: # over attrs in both dicts
-                        if type(self.attrs[k]) == list and \
-                            type(other.attrs[k]) == list:
-                                if sorted(self.attrs[k]) != sorted(other.attrs[k]):
-                                        l.add(k)
-                        elif self.attrs[k] != other.attrs[k]:
-                                l.add(k)
-                return (l)
-
-        def consolidate_attrs(self):
-                """Removes duplicate values from values which are lists."""
-                for k in self.attrs:
-                        if isinstance(self.attrs[k], list):
-                                self.attrs[k] = list(set(self.attrs[k]))
-
-        def generate_indices(self):
-                """Generate the information needed to index this action.
-
-                This method, and the overriding methods in subclasses, produce
-                a list of four-tuples.  The tuples are of the form
-                (action_name, key, token, full value).  action_name is the
-                string representation of the kind of action generating the
-                tuple.  'file' and 'depend' are two examples.  It is required to
-                not be None.  Key is the string representation of the name of
-                the attribute being indexed.  Examples include 'basename' and
-                'path'.  Token is the token to be searched against.  Full value
-                is the value to display to the user in the event this token
-                matches their query.  This is useful for things like categories
-                where what matched the query may be a substring of what the
-                desired user output is.
-                """
-
-                # Indexing based on the SHA-1 hash is enough for the generic
-                # case.
-                if hasattr(self, "hash"):
-                        return [
-                            (self.name, "content", self.hash, self.hash),
-                        ]
-                return []
-
-        def get_installed_path(self, img_root):
-                """Given an image root, return the installed path of the action
-                if it has a installable payload (i.e. 'path' attribute)."""
-                try:
-                        return os.path.normpath(os.path.join(img_root,
-                            self.attrs["path"]))
-                except KeyError:
-                        return
-
-        def distinguished_name(self):
-                """ Return the distinguishing name for this action,
-                    preceded by the type of the distinguishing name.  For
-                    example, for a file action, 'path' might be the
-                    key_attr.  So, the distinguished name might be
-                    "path: usr/lib/libc.so.1".
-                """
-
-                if self.key_attr is None:
-                        return str(self)
-                return "{0}: {1}".format(
-                    self.name, self.attrs.get(self.key_attr, "???"))
-
-        def makedirs(self, path, **kw):
-                """Make directory specified by 'path' with given permissions, as
-                well as all missing parent directories.  Permissions are
-                specified by the keyword arguments 'mode', 'uid', and 'gid'.
-
-                The difference between this and os.makedirs() is that the
-                permissions specify only those of the leaf directory.  Missing
-                parent directories inherit the permissions of the deepest
-                existing directory.  The leaf directory will also inherit any
-                permissions not explicitly set."""
-
-                # generate the components of the path.  The first
-                # element will be empty since all absolute paths
-                # always start with a root specifier.
-                pathlist = portable.split_path(path)
-
-                # Fill in the first path with the root of the filesystem
-                # (this ends up being something like C:\ on windows systems,
-                # and "/" on unix.
-                pathlist[0] = portable.get_root(path)
-
-                g = enumerate(pathlist)
-                for i, e in g:
-                        # os.path.isdir() follows links, which isn't
-                        # desirable here.
-                        p = os.path.join(*pathlist[:i + 1])
-                        try:
-                                fs = os.lstat(p)
-                        except OSError as e:
-                                if e.errno == errno.ENOENT:
-                                        break
-                                raise
-
-                        if not stat.S_ISDIR(fs.st_mode):
-                                if p == path:
-                                        # Allow caller to handle target by
-                                        # letting the operation continue,
-                                        # and whatever error is encountered
-                                        # being raised to the caller.
-                                        break
-
-                                err_txt = _("Unable to create {path}; a "
-                                    "parent directory {p} has been replaced "
-                                    "with a file or link.  Please restore the "
-                                    "parent directory and try again.").format(
-                                    **locals())
-                                raise apx.ActionExecutionError(self,
-                                    details=err_txt, error=e,
-                                    fmri=kw.get("fmri"))
-                else:
-                        # XXX Because the filelist codepath may create
-                        # directories with incorrect permissions (see
-                        # pkgtarfile.py), we need to correct those permissions
-                        # here.  Note that this solution relies on all
-                        # intermediate directories being explicitly created by
-                        # the packaging system; otherwise intermediate
-                        # directories will not get their permissions corrected.
-                        fs = os.lstat(path)
-                        mode = kw.get("mode", fs.st_mode)
-                        uid = kw.get("uid", fs.st_uid)
-                        gid = kw.get("gid", fs.st_gid)
-                        try:
-                                if mode != fs.st_mode:
-                                        os.chmod(path, mode)
-                                if uid != fs.st_uid or gid != fs.st_gid:
-                                        portable.chown(path, uid, gid)
-                        except  OSError as e:
-                                if e.errno != errno.EPERM and \
-                                    e.errno != errno.ENOSYS:
-                                        raise
-                        return
-
-                fs = os.stat(os.path.join(*pathlist[:i]))
-                for i, e in g:
-                        p = os.path.join(*pathlist[:i])
-                        try:
-                                os.mkdir(p, fs.st_mode)
-                        except OSError as e:
-                                if e.errno != errno.ENOTDIR:
-                                        raise
-                                err_txt = _("Unable to create {path}; a "
-                                    "parent directory {p} has been replaced "
-                                    "with a file or link.  Please restore the "
-                                    "parent directory and try again.").format(
-                                    **locals())
-                                raise apx.ActionExecutionError(self,
-                                    details=err_txt, error=e,
-                                    fmri=kw.get("fmri"))
-
-                        os.chmod(p, fs.st_mode)
-                        try:
-                                portable.chown(p, fs.st_uid, fs.st_gid)
-                        except OSError as e:
-                                if e.errno != errno.EPERM:
-                                        raise
-
-                # Create the leaf with any requested permissions, substituting
-                # missing perms with the parent's perms.
-                mode = kw.get("mode", fs.st_mode)
-                uid = kw.get("uid", fs.st_uid)
-                gid = kw.get("gid", fs.st_gid)
-                os.mkdir(path, mode)
-                os.chmod(path, mode)
-                try:
-                        portable.chown(path, uid, gid)
-                except OSError as e:
-                        if e.errno != errno.EPERM:
-                                raise
-
-        def get_varcet_keys(self):
-                """Return the names of any facet or variant tags in this
-                action."""
-
-                # Hot path; grab reference to attrs and use list comprehensions
-                # to construct the results.  This is faster than iterating over
-                # attrs once and appending to two lists separately.
-                attrs = self.attrs
-                return [k for k in attrs if k[:8] == "variant."], \
-                    [k for k in attrs if k[:6] == "facet."]
-
-        def get_variant_template(self):
-                """Return the VariantCombinationTemplate that the variant tags
-                of this action define."""
-
-                return variant.VariantCombinationTemplate(dict((
-                    (v, self.attrs[v]) for v in self.get_varcet_keys()[0]
-                )))
-
-        def strip(self, preserve=EmptyDict):
-                """Strip actions of attributes which are unnecessary once
-                those actions have been installed in an image.  Stripped
-                actions are saved in an images stripped action cache and used
-                for conflicting actions checks during image planning
-                operations."""
-
-                for key in list(self.attrs.keys()):
-                        # strip out variant and facet information
-                        if key[:8] == "variant." or key[:6] == "facet.":
-                                del self.attrs[key]
-                                continue
-                        # keep unique attributes
-                        if not self.unique_attrs or key in self.unique_attrs:
-                                continue
-                        # keep file action overlay attributes
-                        if self.name == "file" and key == "overlay":
-                                continue
-                        # keep file action overlay-attributes attributes
-                        if self.name == "file" and key == "overlay-attributes":
-                                continue
-                        # keep specified keys
-                        if key in preserve.get(self.name, []):
-                                continue
-                        # keep link/hardlink action mediator attributes
-                        if (self.name == "link" or self.name == "hardlink") \
-                            and key[:8] == "mediator":
-                                continue
-                        del self.attrs[key]
-
-        def strip_variants(self):
-                """Remove all variant tags from the attrs dictionary."""
-
-                for k in list(self.attrs.keys()):
-                        if k.startswith("variant."):
-                                del self.attrs[k]
-
-        def verify(self, img, **args):
-                """Returns a tuple of lists of the form (errors, warnings,
-                info).  The error list will be empty if the action has been
-                correctly installed in the given image."""
-                return [], [], []
-
-        def _validate_fsobj_common(self):
-                """Private, common validation logic for filesystem objects that
-                returns a list of tuples of the form (attr_name, error_message).
-                """
-
-                errors = []
-
-                bad_mode = False
-                raw_mode = self.attrs.get("mode")
-                if not raw_mode or isinstance(raw_mode, list):
-                        bad_mode = True
-                else:
-                        mlen = len(raw_mode)
-                        # Common case for our packages is 4 so place that first.
-                        if not (mlen == 4 or mlen == 3 or mlen == 5):
-                                bad_mode = True
-                        elif mlen == 5 and raw_mode[0] != "0":
-                                bad_mode = True
-
-                # The group, mode, and owner attributes are intentionally only
-                # required during publication as it is anticipated that the
-                # there will eventually be defaults for these (possibly parent
-                # directory, etc.).  By only requiring these attributes here,
-                # it prevents publication of packages for which no default
-                # currently exists, while permitting future changes to remove
-                # that limitaiton and use sane defaults.
-                if not bad_mode:
-                        try:
-                                mode = str(int(raw_mode, 8))
-                        except (TypeError, ValueError):
-                                bad_mode = True
-                        else:
-                                bad_mode = mode == ""
-
-                if bad_mode:
-                        if not raw_mode:
-                                errors.append(("mode", _("mode is required; "
-                                    "value must be of the form '644', "
-                                    "'0644', or '04755'.")))
-                        elif isinstance(raw_mode, list):
-                                errors.append(("mode", _("mode may only be "
-                                    "specified once")))
-                        else:
-                                errors.append(("mode", _("'{0}' is not a valid "
-                                    "mode; value must be of the form '644', "
-                                    "'0644', or '04755'.").format(raw_mode)))
-
-                try:
-                        owner = self.attrs.get("owner", "").rstrip()
-                except AttributeError:
-                        errors.append(("owner", _("owner may only be specified "
-                            "once")))
-
-                try:
-                        group = self.attrs.get("group", "").rstrip()
-                except AttributeError:
-                        errors.append(("group", _("group may only be specified "
-                            "once")))
-
-                return errors
-
-        def get_fsobj_uid_gid(self, pkgplan, fmri):
-                """Returns a tuple of the form (owner, group) containing the uid
-                and gid of the filesystem object.  If the attributes are missing
-                or invalid, an InvalidActionAttributesError exception will be
-                raised."""
-
-                path = self.get_installed_path(pkgplan.image.get_root())
-
-                # The attribute may be missing.
-                owner = self.attrs.get("owner", "").rstrip()
-
-                # Now attempt to determine the uid and raise an appropriate
-                # exception if it can't be.
-                try:
-                        owner = pkgplan.image.get_user_by_name(owner)
-                except KeyError:
-                        if not owner:
-                                # Owner was missing; let validate raise a more
-                                # informative error.
-                                self.validate(fmri=fmri)
-
-                        # Otherwise, the user is unknown; attempt to report why.
-                        pd = pkgplan.image.imageplan.pd
-                        if owner in pd.removed_users:
-                                # What package owned the user that was removed?
-                                src_fmri = pd.removed_users[owner]
-
-                                raise pkg.actions.InvalidActionAttributesError(
-                                    self, [("owner", _("'{path}' cannot be "
-                                    "installed; the owner '{owner}' was "
-                                    "removed by '{src_fmri}'.").format(
-                                    path=path, owner=owner,
-                                    src_fmri=src_fmri))],
-                                    fmri=fmri)
-                        elif owner in pd.added_users:
-                                # This indicates an error on the part of the
-                                # caller; the user should have been added
-                                # before attempting to install the file.
-                                raise
-
-                        # If this spot was reached, the user wasn't part of
-                        # the operation plan and is completely unknown or
-                        # invalid.
-                        raise pkg.actions.InvalidActionAttributesError(
-                            self, [("owner", _("'{path}' cannot be "
-                                    "installed; '{owner}' is an unknown "
-                                    "or invalid user.").format(path=path,
-                                    owner=owner))],
-                                    fmri=fmri)
-
-                # The attribute may be missing.
-                group = self.attrs.get("group", "").rstrip()
-
-                # Now attempt to determine the gid and raise an appropriate
-                # exception if it can't be.
-                try:
-                        group = pkgplan.image.get_group_by_name(group)
-                except KeyError:
-                        if not group:
-                                # Group was missing; let validate raise a more
-                                # informative error.
-                                self.validate(fmri=pkgplan.destination_fmri)
-
-                        # Otherwise, the group is unknown; attempt to report
-                        # why.
-                        pd = pkgplan.image.imageplan.pd
-                        if group in pd.removed_groups:
-                                # What package owned the group that was removed?
-                                src_fmri = pd.removed_groups[group]
-
-                                raise pkg.actions.InvalidActionAttributesError(
-                                    self, [("group", _("'{path}' cannot be "
-                                    "installed; the group '{group}' was "
-                                    "removed by '{src_fmri}'.").format(
-                                    path=path, group=group,
-                                    src_fmri=src_fmri))],
-                                    fmri=pkgplan.destination_fmri)
-                        elif group in pd.added_groups:
-                                # This indicates an error on the part of the
-                                # caller; the group should have been added
-                                # before attempting to install the file.
-                                raise
-
-                        # If this spot was reached, the group wasn't part of
-                        # the operation plan and is completely unknown or
-                        # invalid.
-                        raise pkg.actions.InvalidActionAttributesError(
-                            self, [("group", _("'{path}' cannot be "
-                                    "installed; '{group}' is an unknown "
-                                    "or invalid group.").format(path=path,
-                                    group=group))],
-                                    fmri=pkgplan.destination_fmri)
-
-                return owner, group
-
-        def verify_fsobj_common(self, img, ftype):
-                """Common verify logic for filesystem objects."""
-
-                errors = []
-                warnings = []
-                info = []
-
-                abort = False
-                def ftype_to_name(ftype):
-                        assert ftype is not None
-                        tmap = {
-                                stat.S_IFIFO: "fifo",
-                                stat.S_IFCHR: "character device",
-                                stat.S_IFDIR: "directory",
-                                stat.S_IFBLK: "block device",
-                                stat.S_IFREG: "regular file",
-                                stat.S_IFLNK: "symbolic link",
-                                stat.S_IFSOCK: "socket",
-                        }
-                        if ftype in tmap:
-                                return tmap[ftype]
-                        else:
-                                return "Unknown (0x{0:x})".format(ftype)
-
-                mode = owner = group = None
-                if ftype != stat.S_IFLNK:
-                        if "mode" in self.attrs:
-                                mode = int(self.attrs["mode"], 8)
-                        if "owner" in self.attrs:
-                                owner = self.attrs["owner"]
-                                try:
-                                        owner = img.get_user_by_name(owner)
-                                except KeyError:
-                                        errors.append(
-                                            _("owner: {0} is unknown").format(
-                                            owner))
-                                        owner = None
-                        if "group" in self.attrs:
-                                group = self.attrs["group"]
-                                try:
-                                        group = img.get_group_by_name(group)
-                                except KeyError:
-                                        errors.append(
-                                            _("group: {0} is unknown ").format(
-                                            group))
-                                        group = None
-
-                path = self.get_installed_path(img.get_root())
-
-                lstat = None
-                try:
-                        lstat = os.lstat(path)
-                except OSError as e:
-                        if e.errno == errno.ENOENT:
-                                if self.attrs.get("preserve", "") == "legacy":
-                                        # It's acceptable for files with
-                                        # preserve=legacy to be missing;
-                                        # nothing more to validate.
-                                        return (lstat, errors, warnings, info,
-                                            abort)
-                                errors.append(
-                                    _("missing: {0} does not exist").format(
-                                    ftype_to_name(ftype)))
-                        elif e.errno == errno.EACCES:
-                                errors.append(_("skipping: permission denied"))
-                        else:
-                                errors.append(
-                                    _("unexpected error: {0}").format(e))
-                        abort = True
-
-                if abort:
-                        return lstat, errors, warnings, info, abort
-
-                if ftype is not None and ftype != stat.S_IFMT(lstat.st_mode):
-                        errors.append(_("file type: '{found}' should be "
-                            "'{expected}'").format(
-                            found=ftype_to_name(stat.S_IFMT(lstat.st_mode)),
-                            expected=ftype_to_name(ftype)))
-                        abort = True
-
-                if owner is not None and lstat.st_uid != owner:
-                        errors.append(_("owner: '{found_name} "
-                            "({found_id:d})' should be '{expected_name} "
-                            "({expected_id:d})'").format(
-                            found_name=img.get_name_by_uid(lstat.st_uid,
-                            True), found_id=lstat.st_uid,
-                            expected_name=self.attrs["owner"],
-                            expected_id=owner))
-
-                if group is not None and lstat.st_gid != group:
-                        errors.append(_("group: '{found_name} "
-                            "({found_id})' should be '{expected_name} "
-                            "({expected_id})'").format(
-                            found_name=img.get_name_by_gid(lstat.st_gid,
-                            True), found_id=lstat.st_gid,
-                            expected_name=self.attrs["group"],
-                            expected_id=group))
-
-                if mode is not None and stat.S_IMODE(lstat.st_mode) != mode:
-                        errors.append(_("mode: {found:04o} should be "
-                            "{expected:04o}").format(
-                            found=stat.S_IMODE(lstat.st_mode),
-                            expected=mode))
-                return lstat, errors, warnings, info, abort
-
-        def needsdata(self, orig, pkgplan):
-                """Returns True if the action transition requires a
-                datastream."""
-                return False
-
-        def get_size(self):
-                return int(self.attrs.get("pkg.size", "0"))
-
-        def attrlist(self, name):
-                """return list containing value of named attribute."""
-                try:
-                        value = self.attrs[name]
-                except KeyError:
-                        return []
-                if type(value) is not list:
-                        return [value]
-                return value
-
-        def directory_references(self):
-                """Returns references to paths in action."""
-                if "path" in self.attrs:
-                        return [os.path.dirname(os.path.normpath(
-                            self.attrs["path"]))]
-                return []
-
-        def preinstall(self, pkgplan, orig):
-                """Client-side method that performs pre-install actions."""
-                pass
-
-        def install(self, pkgplan, orig):
-                """Client-side method that installs the object."""
-                pass
-
-        def postinstall(self, pkgplan, orig):
-                """Client-side method that performs post-install actions."""
-                pass
-
-        def preremove(self, pkgplan):
-                """Client-side method that performs pre-remove actions."""
-                pass
-
-        def remove(self, pkgplan):
-                """Client-side method that removes the object."""
-                pass
-
-        def remove_fsobj(self, pkgplan, path):
-                """Shared logic for removing file and link objects."""
-
-                # Necessary since removal logic is reused by install.
-                fmri = pkgplan.destination_fmri
-                if not fmri:
-                        fmri = pkgplan.origin_fmri
-
-                try:
-                        portable.remove(path)
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                # Already gone; don't care.
-                                return
-                        elif e.errno == errno.EBUSY and os.path.ismount(path):
-                                # User has replaced item with mountpoint, or a
-                                # package has been poorly implemented.
-                                err_txt = _("Unable to remove {0}; it is in use "
-                                    "as a mountpoint.  To continue, please "
-                                    "unmount the filesystem at the target "
-                                    "location and try again.").format(path)
-                                raise apx.ActionExecutionError(self,
-                                    details=err_txt, error=e, fmri=fmri)
-                        elif e.errno == errno.EBUSY:
-                                # os.path.ismount() is broken for lofs
-                                # filesystems, so give a more generic
-                                # error.
-                                err_txt = _("Unable to remove {0}; it is in "
-                                    "use by the system, another process, or "
-                                    "as a mountpoint.").format(path)
-                                raise apx.ActionExecutionError(self,
-                                    details=err_txt, error=e, fmri=fmri)
-                        elif e.errno == errno.EPERM and \
-                            not stat.S_ISDIR(os.lstat(path).st_mode):
-                                # Was expecting a directory in this failure
-                                # case, it is not, so raise the error.
-                                raise
-                        elif e.errno in (errno.EACCES, errno.EROFS):
-                                # Raise these permissions exceptions as-is.
-                                raise
-                        elif e.errno != errno.EPERM:
-                                # An unexpected error.
-                                raise apx.ActionExecutionError(self, error=e,
-                                    fmri=fmri)
-
-                        # Attempting to remove a directory as performed above
-                        # gives EPERM.  First, try to remove the directory,
-                        # if it isn't empty, salvage it.
-                        try:
-                                os.rmdir(path)
-                        except OSError as e:
-                                if e.errno in (errno.EPERM, errno.EACCES):
-                                        # Raise permissions exceptions as-is.
-                                        raise
-                                elif e.errno not in (errno.EEXIST,
-                                    errno.ENOTEMPTY):
-                                        # An unexpected error.
-                                        raise apx.ActionExecutionError(self,
-                                            error=e, fmri=fmri)
-
-                                pkgplan.salvage(path)
-
-        def postremove(self, pkgplan):
-                """Client-side method that performs post-remove actions."""
-                pass
-
-        def include_this(self, excludes, publisher=None):
-                """Callables in excludes list returns True
-                if action is to be included, False if
-                not"""
-                for c in excludes:
-                        if not c(self, publisher=publisher):
-                                return False
+        return self.ordinality < other.ordinality
+
+    def __gt__(self, other):
+        if self.ordinality == other.ordinality:
+            if self.compare(other) > 0:  # often subclassed
                 return True
+            else:
+                return False
+        return self.ordinality > other.ordinality
 
-        def validate(self, fmri=None):
-                """Performs additional validation of action attributes that
-                for performance or other reasons cannot or should not be done
-                during Action object creation.  An ActionError exception (or
-                subclass of) will be raised if any attributes are not valid.
-                This is primarily intended for use during publication or during
-                error handling to provide additional diagonostics.
+    def __le__(self, other):
+        return self == other or self < other
 
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action.
-                """
+    def __ge__(self, other):
+        return self == other or self > other
 
-                self._validate(fmri=fmri)
+    def different(self, other, pkgplan=None, cmp_policy=None):
+        """Returns True if other represents a non-ignorable change from
+        self.  By default, this means two actions are different if any
+        of their attributes are different.
 
-        def _validate(self, fmri=None, numeric_attrs=EmptyI,
-             raise_errors=True, required_attrs=EmptyI, single_attrs=EmptyI):
-                """Common validation logic for all action types.
+        When cmp_policy is CMP_UNSIGNED, check the unsigned versions
+        of hashes instead of signed versions of hashes on both actions.
+        This prevents comparing all hash attributes as simple value
+        comparisons, and instead compares only non-hash attributes,
+        then tests the most preferred hash for equivalence.  When
+        cmp_policy is CMP_ALL, compare using all attributes.
+        """
 
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action.
+        if self.has_payload != other.has_payload:
+            # Comparing different action types.
+            return True
 
-                'numeric_attrs' is a list of attributes that must have an
-                integer value.
+        sattrs = self.attrs
+        oattrs = other.attrs
 
-                'raise_errors' is a boolean indicating whether errors should be
-                raised as an exception or returned as a list of tuples of the
-                form (attr_name, error_message).
+        # Are all attributes identical? Most actions don't change, so
+        # a simple equality comparison should be sufficient.
+        if sattrs == oattrs:
+            if self.has_payload:
+                # If payload present, must also compare some
+                # object attributes.
+                if self.hash == other.hash:
+                    return False
+            else:
+                return False
 
-                'single_attrs' is a list of attributes that should only be
-                specified once.
-                """
+        # If action has payload, perform hash comparison first. For
+        # actions with a payload, hash attributes usually change, but
+        # other attributes do not.
+        hash_type = digest.HASH
+        if self.has_payload:
+            if "elfarch" in self.attrs and "elfarch" in other.attrs:
+                # If both actions are for elf files, determine
+                # if we should compare based on elf content
+                # hash.
+                if cmp_policy == CMP_UNSIGNED and not pkgplan:
+                    # If caller requested unsigned
+                    # comparison, and no policy is
+                    # available, compare based on elf
+                    # content hash.
+                    hash_type = digest.HASH_GELF
+                elif pkgplan:
+                    # Avoid circular import.
+                    from pkg.client.imageconfig import CONTENT_UPDATE_POLICY
 
-                errors = []
-                for attr in self.attrs:
-                        if ((attr.startswith("facet.") or
-                            attr == "reboot-needed" or attr in single_attrs) and
-                            type(self.attrs[attr]) is list):
-                                errors.append((attr, _("{0} may only be "
-                                    "specified once").format(attr)))
-                        elif attr in numeric_attrs:
-                                try:
-                                        int(self.attrs[attr])
-                                except (TypeError, ValueError):
-                                        errors.append((attr, _("{0} must be an "
-                                            "integer").format(attr)))
+                    if (
+                        pkgplan.image.cfg.get_policy_str(CONTENT_UPDATE_POLICY)
+                        == "when-required"
+                    ):
+                        # If policy is available and
+                        # allows it, then compare based
+                        # on elf content hash.
+                        hash_type = digest.HASH_GELF
 
-                for attr in required_attrs:
-                        val = self.attrs.get(attr)
-                        if not val or \
-                            (isinstance(val, six.string_types) and not val.strip()):
-                                errors.append((attr,
-                                    _("{0} is required").format(attr)))
+            # digest.get_common_preferred_hash() tries to return the
+            # most preferred hash attribute and falls back to
+            # returning the action.hash values if there are no other
+            # common hash attributes, and will throw an
+            # AttributeError if one or the other actions don't have
+            # an action.hash attribute.
+            try:
+                (
+                    hash_attr,
+                    shash,
+                    ohash,
+                    hash_func,
+                ) = digest.get_common_preferred_hash(
+                    self, other, hash_type=hash_type, cmp_policy=cmp_policy
+                )
+                if shash != ohash:
+                    return True
+                # If there's no common preferred hash, we have
+                # to treat these actions as different.
+                if shash is None and ohash is None:
+                    return True
+            except AttributeError:
+                # If action.hash is set on exactly one of self
+                # and other, then we're trying to compare
+                # actions of disparate subclasses.
+                if hasattr(self, "hash") ^ hasattr(other, "hash"):
+                    raise AssertionError(
+                        "attempt to compare a "
+                        "{0} action to a {1} action".format(
+                            self.name, other.name
+                        )
+                    )
 
-                if raise_errors and errors:
-                        raise pkg.actions.InvalidActionAttributesError(self,
-                            errors, fmri=fmri)
-                return errors
+        if self.has_payload and cmp_policy != CMP_ALL:
+            sset = frozenset(a for a in sattrs if not digest.is_hash_attr(a))
+            oset = frozenset(a for a in oattrs if not digest.is_hash_attr(a))
+        else:
+            sset = frozenset(sattrs)
+            oset = frozenset(oattrs)
 
-        def fsobj_checkpath(self, pkgplan, final_path):
-                """Verifies that the specified path doesn't contain one or more
-                symlinks relative to the image root.  Raises an
-                ActionExecutionError exception if path check fails."""
+        # If hashes were equal or not applicable, then compare remaining
+        # attributes.
+        if sset.symmetric_difference(oset):
+            return True
 
-                valid_dirs = pkgplan.image.imageplan.valid_directories
-                parent_path = os.path.dirname(final_path)
-                if parent_path in valid_dirs:
-                        return
+        for a in sset:
+            x = sattrs[a]
+            y = oattrs[a]
+            if x != y:
+                if len(x) == len(y) and type(x) is list and type(y) is list:
+                    if sorted(x) != sorted(y):
+                        return True
+                else:
+                    return True
 
-                real_parent_path = os.path.realpath(parent_path)
-                if parent_path == real_parent_path:
-                        valid_dirs.add(parent_path)
-                        return
+        return False
 
-                fmri = pkgplan.destination_fmri
+    def differences(self, other):
+        """Returns the attributes that have different values between
+        other and self."""
+        sset = set(self.attrs.keys())
+        oset = set(other.attrs.keys())
+        l = sset.symmetric_difference(oset)
+        for k in sset & oset:  # over attrs in both dicts
+            if type(self.attrs[k]) == list and type(other.attrs[k]) == list:
+                if sorted(self.attrs[k]) != sorted(other.attrs[k]):
+                    l.add(k)
+            elif self.attrs[k] != other.attrs[k]:
+                l.add(k)
+        return l
 
-                # Now test each component of the parent path until one is found
-                # to be a link.  When found, that's the parent that has been
-                # redirected to some other location.
-                tmp = parent_path
-                img_root = pkgplan.image.root.rstrip(os.path.sep)
-                while 1:
-                        if tmp == img_root:
-                                # No parent directories up to the root were
-                                # found to be links, so assume this is ok.
-                                valid_dirs.add(parent_path)
-                                return
+    def consolidate_attrs(self):
+        """Removes duplicate values from values which are lists."""
+        for k in self.attrs:
+            if isinstance(self.attrs[k], list):
+                self.attrs[k] = list(set(self.attrs[k]))
 
-                        if os.path.islink(tmp):
-                                # We've found the parent that changed locations.
-                                break
-                        # Drop the final component.
-                        tmp = os.path.split(tmp)[0]
+    def generate_indices(self):
+        """Generate the information needed to index this action.
 
-                parent_dir = tmp
-                parent_target = os.path.realpath(parent_dir)
-                err_txt = _("Cannot install '{final_path}'; parent directory "
-                    "{parent_dir} is a link to {parent_target}.  To "
-                    "continue, move the directory to its original location and "
-                    "try again.").format(**locals())
-                raise apx.ActionExecutionError(self, details=err_txt,
-                    fmri=fmri)
+        This method, and the overriding methods in subclasses, produce
+        a list of four-tuples.  The tuples are of the form
+        (action_name, key, token, full value).  action_name is the
+        string representation of the kind of action generating the
+        tuple.  'file' and 'depend' are two examples.  It is required to
+        not be None.  Key is the string representation of the name of
+        the attribute being indexed.  Examples include 'basename' and
+        'path'.  Token is the token to be searched against.  Full value
+        is the value to display to the user in the event this token
+        matches their query.  This is useful for things like categories
+        where what matched the query may be a substring of what the
+        desired user output is.
+        """
 
-        if six.PY3:
-                def __init__(self, data=None, **attrs):
-                        # create a bound method (no unbound method in Python 3)
-                        _common._generic_init(self, data, **attrs)
+        # Indexing based on the SHA-1 hash is enough for the generic
+        # case.
+        if hasattr(self, "hash"):
+            return [
+                (self.name, "content", self.hash, self.hash),
+            ]
+        return []
+
+    def get_installed_path(self, img_root):
+        """Given an image root, return the installed path of the action
+        if it has a installable payload (i.e. 'path' attribute)."""
+        try:
+            return os.path.normpath(os.path.join(img_root, self.attrs["path"]))
+        except KeyError:
+            return
+
+    def distinguished_name(self):
+        """Return the distinguishing name for this action,
+        preceded by the type of the distinguishing name.  For
+        example, for a file action, 'path' might be the
+        key_attr.  So, the distinguished name might be
+        "path: usr/lib/libc.so.1".
+        """
+
+        if self.key_attr is None:
+            return str(self)
+        return "{0}: {1}".format(
+            self.name, self.attrs.get(self.key_attr, "???")
+        )
+
+    def makedirs(self, path, **kw):
+        """Make directory specified by 'path' with given permissions, as
+        well as all missing parent directories.  Permissions are
+        specified by the keyword arguments 'mode', 'uid', and 'gid'.
+
+        The difference between this and os.makedirs() is that the
+        permissions specify only those of the leaf directory.  Missing
+        parent directories inherit the permissions of the deepest
+        existing directory.  The leaf directory will also inherit any
+        permissions not explicitly set."""
+
+        # generate the components of the path.  The first
+        # element will be empty since all absolute paths
+        # always start with a root specifier.
+        pathlist = portable.split_path(path)
+
+        # Fill in the first path with the root of the filesystem
+        # (this ends up being something like C:\ on windows systems,
+        # and "/" on unix.
+        pathlist[0] = portable.get_root(path)
+
+        g = enumerate(pathlist)
+        for i, e in g:
+            # os.path.isdir() follows links, which isn't
+            # desirable here.
+            p = os.path.join(*pathlist[: i + 1])
+            try:
+                fs = os.lstat(p)
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    break
+                raise
+
+            if not stat.S_ISDIR(fs.st_mode):
+                if p == path:
+                    # Allow caller to handle target by
+                    # letting the operation continue,
+                    # and whatever error is encountered
+                    # being raised to the caller.
+                    break
+
+                err_txt = _(
+                    "Unable to create {path}; a "
+                    "parent directory {p} has been replaced "
+                    "with a file or link.  Please restore the "
+                    "parent directory and try again."
+                ).format(**locals())
+                raise apx.ActionExecutionError(
+                    self, details=err_txt, error=e, fmri=kw.get("fmri")
+                )
+        else:
+            # XXX Because the filelist codepath may create
+            # directories with incorrect permissions (see
+            # pkgtarfile.py), we need to correct those permissions
+            # here.  Note that this solution relies on all
+            # intermediate directories being explicitly created by
+            # the packaging system; otherwise intermediate
+            # directories will not get their permissions corrected.
+            fs = os.lstat(path)
+            mode = kw.get("mode", fs.st_mode)
+            uid = kw.get("uid", fs.st_uid)
+            gid = kw.get("gid", fs.st_gid)
+            try:
+                if mode != fs.st_mode:
+                    os.chmod(path, mode)
+                if uid != fs.st_uid or gid != fs.st_gid:
+                    portable.chown(path, uid, gid)
+            except OSError as e:
+                if e.errno != errno.EPERM and e.errno != errno.ENOSYS:
+                    raise
+            return
+
+        fs = os.stat(os.path.join(*pathlist[:i]))
+        for i, e in g:
+            p = os.path.join(*pathlist[:i])
+            try:
+                os.mkdir(p, fs.st_mode)
+            except OSError as e:
+                if e.errno != errno.ENOTDIR:
+                    raise
+                err_txt = _(
+                    "Unable to create {path}; a "
+                    "parent directory {p} has been replaced "
+                    "with a file or link.  Please restore the "
+                    "parent directory and try again."
+                ).format(**locals())
+                raise apx.ActionExecutionError(
+                    self, details=err_txt, error=e, fmri=kw.get("fmri")
+                )
+
+            os.chmod(p, fs.st_mode)
+            try:
+                portable.chown(p, fs.st_uid, fs.st_gid)
+            except OSError as e:
+                if e.errno != errno.EPERM:
+                    raise
+
+        # Create the leaf with any requested permissions, substituting
+        # missing perms with the parent's perms.
+        mode = kw.get("mode", fs.st_mode)
+        uid = kw.get("uid", fs.st_uid)
+        gid = kw.get("gid", fs.st_gid)
+        os.mkdir(path, mode)
+        os.chmod(path, mode)
+        try:
+            portable.chown(path, uid, gid)
+        except OSError as e:
+            if e.errno != errno.EPERM:
+                raise
+
+    def get_varcet_keys(self):
+        """Return the names of any facet or variant tags in this
+        action."""
+
+        # Hot path; grab reference to attrs and use list comprehensions
+        # to construct the results.  This is faster than iterating over
+        # attrs once and appending to two lists separately.
+        attrs = self.attrs
+        return [k for k in attrs if k[:8] == "variant."], [
+            k for k in attrs if k[:6] == "facet."
+        ]
+
+    def get_variant_template(self):
+        """Return the VariantCombinationTemplate that the variant tags
+        of this action define."""
+
+        return variant.VariantCombinationTemplate(
+            dict(((v, self.attrs[v]) for v in self.get_varcet_keys()[0]))
+        )
+
+    def strip(self, preserve=EmptyDict):
+        """Strip actions of attributes which are unnecessary once
+        those actions have been installed in an image.  Stripped
+        actions are saved in an images stripped action cache and used
+        for conflicting actions checks during image planning
+        operations."""
+
+        for key in list(self.attrs.keys()):
+            # strip out variant and facet information
+            if key[:8] == "variant." or key[:6] == "facet.":
+                del self.attrs[key]
+                continue
+            # keep unique attributes
+            if not self.unique_attrs or key in self.unique_attrs:
+                continue
+            # keep file action overlay attributes
+            if self.name == "file" and key == "overlay":
+                continue
+            # keep file action overlay-attributes attributes
+            if self.name == "file" and key == "overlay-attributes":
+                continue
+            # keep specified keys
+            if key in preserve.get(self.name, []):
+                continue
+            # keep link/hardlink action mediator attributes
+            if (self.name == "link" or self.name == "hardlink") and key[
+                :8
+            ] == "mediator":
+                continue
+            del self.attrs[key]
+
+    def strip_variants(self):
+        """Remove all variant tags from the attrs dictionary."""
+
+        for k in list(self.attrs.keys()):
+            if k.startswith("variant."):
+                del self.attrs[k]
+
+    def verify(self, img, **args):
+        """Returns a tuple of lists of the form (errors, warnings,
+        info).  The error list will be empty if the action has been
+        correctly installed in the given image."""
+        return [], [], []
+
+    def _validate_fsobj_common(self):
+        """Private, common validation logic for filesystem objects that
+        returns a list of tuples of the form (attr_name, error_message).
+        """
+
+        errors = []
+
+        bad_mode = False
+        raw_mode = self.attrs.get("mode")
+        if not raw_mode or isinstance(raw_mode, list):
+            bad_mode = True
+        else:
+            mlen = len(raw_mode)
+            # Common case for our packages is 4 so place that first.
+            if not (mlen == 4 or mlen == 3 or mlen == 5):
+                bad_mode = True
+            elif mlen == 5 and raw_mode[0] != "0":
+                bad_mode = True
+
+        # The group, mode, and owner attributes are intentionally only
+        # required during publication as it is anticipated that the
+        # there will eventually be defaults for these (possibly parent
+        # directory, etc.).  By only requiring these attributes here,
+        # it prevents publication of packages for which no default
+        # currently exists, while permitting future changes to remove
+        # that limitaiton and use sane defaults.
+        if not bad_mode:
+            try:
+                mode = str(int(raw_mode, 8))
+            except (TypeError, ValueError):
+                bad_mode = True
+            else:
+                bad_mode = mode == ""
+
+        if bad_mode:
+            if not raw_mode:
+                errors.append(
+                    (
+                        "mode",
+                        _(
+                            "mode is required; "
+                            "value must be of the form '644', "
+                            "'0644', or '04755'."
+                        ),
+                    )
+                )
+            elif isinstance(raw_mode, list):
+                errors.append(("mode", _("mode may only be " "specified once")))
+            else:
+                errors.append(
+                    (
+                        "mode",
+                        _(
+                            "'{0}' is not a valid "
+                            "mode; value must be of the form '644', "
+                            "'0644', or '04755'."
+                        ).format(raw_mode),
+                    )
+                )
+
+        try:
+            owner = self.attrs.get("owner", "").rstrip()
+        except AttributeError:
+            errors.append(("owner", _("owner may only be specified " "once")))
+
+        try:
+            group = self.attrs.get("group", "").rstrip()
+        except AttributeError:
+            errors.append(("group", _("group may only be specified " "once")))
+
+        return errors
+
+    def get_fsobj_uid_gid(self, pkgplan, fmri):
+        """Returns a tuple of the form (owner, group) containing the uid
+        and gid of the filesystem object.  If the attributes are missing
+        or invalid, an InvalidActionAttributesError exception will be
+        raised."""
+
+        path = self.get_installed_path(pkgplan.image.get_root())
+
+        # The attribute may be missing.
+        owner = self.attrs.get("owner", "").rstrip()
+
+        # Now attempt to determine the uid and raise an appropriate
+        # exception if it can't be.
+        try:
+            owner = pkgplan.image.get_user_by_name(owner)
+        except KeyError:
+            if not owner:
+                # Owner was missing; let validate raise a more
+                # informative error.
+                self.validate(fmri=fmri)
+
+            # Otherwise, the user is unknown; attempt to report why.
+            pd = pkgplan.image.imageplan.pd
+            if owner in pd.removed_users:
+                # What package owned the user that was removed?
+                src_fmri = pd.removed_users[owner]
+
+                raise pkg.actions.InvalidActionAttributesError(
+                    self,
+                    [
+                        (
+                            "owner",
+                            _(
+                                "'{path}' cannot be "
+                                "installed; the owner '{owner}' was "
+                                "removed by '{src_fmri}'."
+                            ).format(path=path, owner=owner, src_fmri=src_fmri),
+                        )
+                    ],
+                    fmri=fmri,
+                )
+            elif owner in pd.added_users:
+                # This indicates an error on the part of the
+                # caller; the user should have been added
+                # before attempting to install the file.
+                raise
+
+            # If this spot was reached, the user wasn't part of
+            # the operation plan and is completely unknown or
+            # invalid.
+            raise pkg.actions.InvalidActionAttributesError(
+                self,
+                [
+                    (
+                        "owner",
+                        _(
+                            "'{path}' cannot be "
+                            "installed; '{owner}' is an unknown "
+                            "or invalid user."
+                        ).format(path=path, owner=owner),
+                    )
+                ],
+                fmri=fmri,
+            )
+
+        # The attribute may be missing.
+        group = self.attrs.get("group", "").rstrip()
+
+        # Now attempt to determine the gid and raise an appropriate
+        # exception if it can't be.
+        try:
+            group = pkgplan.image.get_group_by_name(group)
+        except KeyError:
+            if not group:
+                # Group was missing; let validate raise a more
+                # informative error.
+                self.validate(fmri=pkgplan.destination_fmri)
+
+            # Otherwise, the group is unknown; attempt to report
+            # why.
+            pd = pkgplan.image.imageplan.pd
+            if group in pd.removed_groups:
+                # What package owned the group that was removed?
+                src_fmri = pd.removed_groups[group]
+
+                raise pkg.actions.InvalidActionAttributesError(
+                    self,
+                    [
+                        (
+                            "group",
+                            _(
+                                "'{path}' cannot be "
+                                "installed; the group '{group}' was "
+                                "removed by '{src_fmri}'."
+                            ).format(path=path, group=group, src_fmri=src_fmri),
+                        )
+                    ],
+                    fmri=pkgplan.destination_fmri,
+                )
+            elif group in pd.added_groups:
+                # This indicates an error on the part of the
+                # caller; the group should have been added
+                # before attempting to install the file.
+                raise
+
+            # If this spot was reached, the group wasn't part of
+            # the operation plan and is completely unknown or
+            # invalid.
+            raise pkg.actions.InvalidActionAttributesError(
+                self,
+                [
+                    (
+                        "group",
+                        _(
+                            "'{path}' cannot be "
+                            "installed; '{group}' is an unknown "
+                            "or invalid group."
+                        ).format(path=path, group=group),
+                    )
+                ],
+                fmri=pkgplan.destination_fmri,
+            )
+
+        return owner, group
+
+    def verify_fsobj_common(self, img, ftype):
+        """Common verify logic for filesystem objects."""
+
+        errors = []
+        warnings = []
+        info = []
+
+        abort = False
+
+        def ftype_to_name(ftype):
+            assert ftype is not None
+            tmap = {
+                stat.S_IFIFO: "fifo",
+                stat.S_IFCHR: "character device",
+                stat.S_IFDIR: "directory",
+                stat.S_IFBLK: "block device",
+                stat.S_IFREG: "regular file",
+                stat.S_IFLNK: "symbolic link",
+                stat.S_IFSOCK: "socket",
+            }
+            if ftype in tmap:
+                return tmap[ftype]
+            else:
+                return "Unknown (0x{0:x})".format(ftype)
+
+        mode = owner = group = None
+        if ftype != stat.S_IFLNK:
+            if "mode" in self.attrs:
+                mode = int(self.attrs["mode"], 8)
+            if "owner" in self.attrs:
+                owner = self.attrs["owner"]
+                try:
+                    owner = img.get_user_by_name(owner)
+                except KeyError:
+                    errors.append(_("owner: {0} is unknown").format(owner))
+                    owner = None
+            if "group" in self.attrs:
+                group = self.attrs["group"]
+                try:
+                    group = img.get_group_by_name(group)
+                except KeyError:
+                    errors.append(_("group: {0} is unknown ").format(group))
+                    group = None
+
+        path = self.get_installed_path(img.get_root())
+
+        lstat = None
+        try:
+            lstat = os.lstat(path)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                if self.attrs.get("preserve", "") == "legacy":
+                    # It's acceptable for files with
+                    # preserve=legacy to be missing;
+                    # nothing more to validate.
+                    return (lstat, errors, warnings, info, abort)
+                errors.append(
+                    _("missing: {0} does not exist").format(
+                        ftype_to_name(ftype)
+                    )
+                )
+            elif e.errno == errno.EACCES:
+                errors.append(_("skipping: permission denied"))
+            else:
+                errors.append(_("unexpected error: {0}").format(e))
+            abort = True
+
+        if abort:
+            return lstat, errors, warnings, info, abort
+
+        if ftype is not None and ftype != stat.S_IFMT(lstat.st_mode):
+            errors.append(
+                _("file type: '{found}' should be " "'{expected}'").format(
+                    found=ftype_to_name(stat.S_IFMT(lstat.st_mode)),
+                    expected=ftype_to_name(ftype),
+                )
+            )
+            abort = True
+
+        if owner is not None and lstat.st_uid != owner:
+            errors.append(
+                _(
+                    "owner: '{found_name} "
+                    "({found_id:d})' should be '{expected_name} "
+                    "({expected_id:d})'"
+                ).format(
+                    found_name=img.get_name_by_uid(lstat.st_uid, True),
+                    found_id=lstat.st_uid,
+                    expected_name=self.attrs["owner"],
+                    expected_id=owner,
+                )
+            )
+
+        if group is not None and lstat.st_gid != group:
+            errors.append(
+                _(
+                    "group: '{found_name} "
+                    "({found_id})' should be '{expected_name} "
+                    "({expected_id})'"
+                ).format(
+                    found_name=img.get_name_by_gid(lstat.st_gid, True),
+                    found_id=lstat.st_gid,
+                    expected_name=self.attrs["group"],
+                    expected_id=group,
+                )
+            )
+
+        if mode is not None and stat.S_IMODE(lstat.st_mode) != mode:
+            errors.append(
+                _("mode: {found:04o} should be " "{expected:04o}").format(
+                    found=stat.S_IMODE(lstat.st_mode), expected=mode
+                )
+            )
+        return lstat, errors, warnings, info, abort
+
+    def needsdata(self, orig, pkgplan):
+        """Returns True if the action transition requires a
+        datastream."""
+        return False
+
+    def get_size(self):
+        return int(self.attrs.get("pkg.size", "0"))
+
+    def attrlist(self, name):
+        """return list containing value of named attribute."""
+        try:
+            value = self.attrs[name]
+        except KeyError:
+            return []
+        if type(value) is not list:
+            return [value]
+        return value
+
+    def directory_references(self):
+        """Returns references to paths in action."""
+        if "path" in self.attrs:
+            return [os.path.dirname(os.path.normpath(self.attrs["path"]))]
+        return []
+
+    def preinstall(self, pkgplan, orig):
+        """Client-side method that performs pre-install actions."""
+        pass
+
+    def install(self, pkgplan, orig):
+        """Client-side method that installs the object."""
+        pass
+
+    def postinstall(self, pkgplan, orig):
+        """Client-side method that performs post-install actions."""
+        pass
+
+    def preremove(self, pkgplan):
+        """Client-side method that performs pre-remove actions."""
+        pass
+
+    def remove(self, pkgplan):
+        """Client-side method that removes the object."""
+        pass
+
+    def remove_fsobj(self, pkgplan, path):
+        """Shared logic for removing file and link objects."""
+
+        # Necessary since removal logic is reused by install.
+        fmri = pkgplan.destination_fmri
+        if not fmri:
+            fmri = pkgplan.origin_fmri
+
+        try:
+            portable.remove(path)
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                # Already gone; don't care.
+                return
+            elif e.errno == errno.EBUSY and os.path.ismount(path):
+                # User has replaced item with mountpoint, or a
+                # package has been poorly implemented.
+                err_txt = _(
+                    "Unable to remove {0}; it is in use "
+                    "as a mountpoint.  To continue, please "
+                    "unmount the filesystem at the target "
+                    "location and try again."
+                ).format(path)
+                raise apx.ActionExecutionError(
+                    self, details=err_txt, error=e, fmri=fmri
+                )
+            elif e.errno == errno.EBUSY:
+                # os.path.ismount() is broken for lofs
+                # filesystems, so give a more generic
+                # error.
+                err_txt = _(
+                    "Unable to remove {0}; it is in "
+                    "use by the system, another process, or "
+                    "as a mountpoint."
+                ).format(path)
+                raise apx.ActionExecutionError(
+                    self, details=err_txt, error=e, fmri=fmri
+                )
+            elif e.errno == errno.EPERM and not stat.S_ISDIR(
+                os.lstat(path).st_mode
+            ):
+                # Was expecting a directory in this failure
+                # case, it is not, so raise the error.
+                raise
+            elif e.errno in (errno.EACCES, errno.EROFS):
+                # Raise these permissions exceptions as-is.
+                raise
+            elif e.errno != errno.EPERM:
+                # An unexpected error.
+                raise apx.ActionExecutionError(self, error=e, fmri=fmri)
+
+            # Attempting to remove a directory as performed above
+            # gives EPERM.  First, try to remove the directory,
+            # if it isn't empty, salvage it.
+            try:
+                os.rmdir(path)
+            except OSError as e:
+                if e.errno in (errno.EPERM, errno.EACCES):
+                    # Raise permissions exceptions as-is.
+                    raise
+                elif e.errno not in (errno.EEXIST, errno.ENOTEMPTY):
+                    # An unexpected error.
+                    raise apx.ActionExecutionError(self, error=e, fmri=fmri)
+
+                pkgplan.salvage(path)
+
+    def postremove(self, pkgplan):
+        """Client-side method that performs post-remove actions."""
+        pass
+
+    def include_this(self, excludes, publisher=None):
+        """Callables in excludes list returns True
+        if action is to be included, False if
+        not"""
+        for c in excludes:
+            if not c(self, publisher=publisher):
+                return False
+        return True
+
+    def validate(self, fmri=None):
+        """Performs additional validation of action attributes that
+        for performance or other reasons cannot or should not be done
+        during Action object creation.  An ActionError exception (or
+        subclass of) will be raised if any attributes are not valid.
+        This is primarily intended for use during publication or during
+        error handling to provide additional diagonostics.
+
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action.
+        """
+
+        self._validate(fmri=fmri)
+
+    def _validate(
+        self,
+        fmri=None,
+        numeric_attrs=EmptyI,
+        raise_errors=True,
+        required_attrs=EmptyI,
+        single_attrs=EmptyI,
+    ):
+        """Common validation logic for all action types.
+
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action.
+
+        'numeric_attrs' is a list of attributes that must have an
+        integer value.
+
+        'raise_errors' is a boolean indicating whether errors should be
+        raised as an exception or returned as a list of tuples of the
+        form (attr_name, error_message).
+
+        'single_attrs' is a list of attributes that should only be
+        specified once.
+        """
+
+        errors = []
+        for attr in self.attrs:
+            if (
+                attr.startswith("facet.")
+                or attr == "reboot-needed"
+                or attr in single_attrs
+            ) and type(self.attrs[attr]) is list:
+                errors.append(
+                    (attr, _("{0} may only be " "specified once").format(attr))
+                )
+            elif attr in numeric_attrs:
+                try:
+                    int(self.attrs[attr])
+                except (TypeError, ValueError):
+                    errors.append(
+                        (attr, _("{0} must be an " "integer").format(attr))
+                    )
+
+        for attr in required_attrs:
+            val = self.attrs.get(attr)
+            if not val or (
+                isinstance(val, six.string_types) and not val.strip()
+            ):
+                errors.append((attr, _("{0} is required").format(attr)))
+
+        if raise_errors and errors:
+            raise pkg.actions.InvalidActionAttributesError(
+                self, errors, fmri=fmri
+            )
+        return errors
+
+    def fsobj_checkpath(self, pkgplan, final_path):
+        """Verifies that the specified path doesn't contain one or more
+        symlinks relative to the image root.  Raises an
+        ActionExecutionError exception if path check fails."""
+
+        valid_dirs = pkgplan.image.imageplan.valid_directories
+        parent_path = os.path.dirname(final_path)
+        if parent_path in valid_dirs:
+            return
+
+        real_parent_path = os.path.realpath(parent_path)
+        if parent_path == real_parent_path:
+            valid_dirs.add(parent_path)
+            return
+
+        fmri = pkgplan.destination_fmri
+
+        # Now test each component of the parent path until one is found
+        # to be a link.  When found, that's the parent that has been
+        # redirected to some other location.
+        tmp = parent_path
+        img_root = pkgplan.image.root.rstrip(os.path.sep)
+        while 1:
+            if tmp == img_root:
+                # No parent directories up to the root were
+                # found to be links, so assume this is ok.
+                valid_dirs.add(parent_path)
+                return
+
+            if os.path.islink(tmp):
+                # We've found the parent that changed locations.
+                break
+            # Drop the final component.
+            tmp = os.path.split(tmp)[0]
+
+        parent_dir = tmp
+        parent_target = os.path.realpath(parent_dir)
+        err_txt = _(
+            "Cannot install '{final_path}'; parent directory "
+            "{parent_dir} is a link to {parent_target}.  To "
+            "continue, move the directory to its original location and "
+            "try again."
+        ).format(**locals())
+        raise apx.ActionExecutionError(self, details=err_txt, fmri=fmri)
+
+    if six.PY3:
+
+        def __init__(self, data=None, **attrs):
+            # create a bound method (no unbound method in Python 3)
+            _common._generic_init(self, data, **attrs)
+
 
 if six.PY2:
-        # create an unbound method
-        Action.__init__ = types.MethodType(_common._generic_init, None, Action)
+    # create an unbound method
+    Action.__init__ = types.MethodType(_common._generic_init, None, Action)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/group.py
+++ b/src/modules/actions/group.py
@@ -31,229 +31,236 @@ packaging object.  This contains the attributes necessary to create
 a new user."""
 
 from . import generic
+
 try:
-        from pkg.cfgfiles import *
-        have_cfgfiles = True
+    from pkg.cfgfiles import *
+
+    have_cfgfiles = True
 except ImportError:
-        have_cfgfiles = False
+    have_cfgfiles = False
 
 import pkg.client.api_errors as apx
 import pkg.actions
 
+
 class GroupAction(generic.Action):
-        """Class representing a group packaging object.
-        note that grouplist members are selected via the user action,
-        although they are stored in the /etc/group file.  Use of
-        group passwds is not supported."""
+    """Class representing a group packaging object.
+    note that grouplist members are selected via the user action,
+    although they are stored in the /etc/group file.  Use of
+    group passwds is not supported."""
 
-        __slots__ = []
+    __slots__ = []
 
-        name = "group"
-        key_attr = "groupname"
-        globally_identical = True
-        ordinality = generic._orderdict[name]
+    name = "group"
+    key_attr = "groupname"
+    globally_identical = True
+    ordinality = generic._orderdict[name]
 
-        def extract(self, attrlist):
-                """ return a dictionary containing attrs in attr list
-                from self.attrs; omit if no such attrs in self.attrs"""
-                return dict((a, self.attrs[a])
-                             for a in self.attrs
-                             if a in attrlist)
+    def extract(self, attrlist):
+        """return a dictionary containing attrs in attr list
+        from self.attrs; omit if no such attrs in self.attrs"""
+        return dict((a, self.attrs[a]) for a in self.attrs if a in attrlist)
 
-        def install(self, pkgplan, orig, retry=False):
-                """client-side method that adds the group
-                   use gid from disk if different"""
-                if not have_cfgfiles:
-                        # the group action is ignored if cfgfiles is not
-                        # available.
-                        return
+    def install(self, pkgplan, orig, retry=False):
+        """client-side method that adds the group
+        use gid from disk if different"""
+        if not have_cfgfiles:
+            # the group action is ignored if cfgfiles is not
+            # available.
+            return
 
-                template = self.extract(["groupname", "gid"])
+        template = self.extract(["groupname", "gid"])
 
-                root = pkgplan.image.get_root()
+        root = pkgplan.image.get_root()
+        try:
+            pw = PasswordFile(root, lock=True)
+        except EnvironmentError as e:
+            if e.errno != errno.ENOENT:
+                raise
+            pw = None
+
+        gr = GroupFile(pkgplan.image)
+
+        cur_attrs = gr.getvalue(template)
+
+        # check for (wrong) pre-existing definition
+        # if so, rewrite entry using existing defs but new group entry
+        #        (XXX this doesn't chown any files on-disk)
+        # else, nothing to do
+        if cur_attrs:
+            if "gid" not in self.attrs:
+                self.attrs["gid"] = cur_attrs["gid"]
+            elif self.attrs["gid"] != cur_attrs["gid"]:
+                cur_gid = cur_attrs["gid"]
+                template = cur_attrs
+                template["gid"] = self.attrs["gid"]
+                # Update the user database with the new gid
+                # as well in case group is someone's primary
+                # group.
+                usernames = pkgplan.image.get_usernames_by_gid(cur_gid)
                 try:
-                        pw = PasswordFile(root, lock=True)
-                except EnvironmentError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
-                        pw = None
+                    for username in usernames:
+                        user_entry = pw.getuser(username)
+                        user_entry["gid"] = self.attrs["gid"]
+                        pw.setvalue(user_entry)
+                except Exception as e:
+                    if pw:
+                        pw.unlock()
+                        txt = _(
+                            "Group cannot be installed. "
+                            "Updating related user entries "
+                            "failed."
+                        )
+                        raise apx.ActionExecutionError(
+                            self,
+                            error=e,
+                            details=txt,
+                            fmri=pkgplan.destination_fmri,
+                        )
 
-                gr = GroupFile(pkgplan.image)
+            # Deal with other columns in the group row.
+            #
+            # pkg has no support for the legacy password field
+            # in the group table and thus requires it to be
+            # empty for any pkg delivered group.  So there is
+            # explicitly no support for updating
+            # template["password"] since we require it to be empty.
+            #
+            # If the admin has assigned any users to a group that is
+            # delivered as an action we preserve that list without
+            # attempting to validate it in any way.
+            if cur_attrs["user-list"]:
+                template["user-list"] = cur_attrs["user-list"]
 
-                cur_attrs = gr.getvalue(template)
+        gr.setvalue(template)
+        try:
+            gr.writefile()
+            if pw:
+                pw.writefile()
+        except EnvironmentError as e:
+            if e.errno != errno.ENOENT:
+                raise
+            # If we're in the postinstall phase and the
+            # files *still* aren't there, bail gracefully.
+            if retry:
+                txt = _(
+                    "Group cannot be installed "
+                    "without group database files "
+                    "present."
+                )
+                raise apx.ActionExecutionError(
+                    self, error=e, details=txt, fmri=pkgplan.destination_fmri
+                )
+            img = pkgplan.image
+            img._groups.add(self)
+            if "gid" in self.attrs:
+                img._groupsbyname[self.attrs["groupname"]] = int(
+                    self.attrs["gid"]
+                )
+            raise pkg.actions.ActionRetry(self)
+        finally:
+            if pw:
+                pw.unlock()
 
-                # check for (wrong) pre-existing definition
-                # if so, rewrite entry using existing defs but new group entry
-                #        (XXX this doesn't chown any files on-disk)
-                # else, nothing to do
-                if cur_attrs:
-                        if "gid" not in self.attrs:
-                                self.attrs["gid"] = cur_attrs["gid"]
-                        elif self.attrs["gid"] != cur_attrs["gid"]:
-                                cur_gid = cur_attrs["gid"]
-                                template = cur_attrs;
-                                template["gid"] = self.attrs["gid"]
-                                # Update the user database with the new gid
-                                # as well in case group is someone's primary
-                                # group.
-                                usernames = pkgplan.image.get_usernames_by_gid(
-                                    cur_gid)
-                                try:
-                                        for username in usernames:
-                                                user_entry = pw.getuser(
-                                                        username)
-                                                user_entry["gid"] = self.attrs[
-                                                        "gid"]
-                                                pw.setvalue(user_entry)
-                                except Exception as e:
-                                        if pw:
-                                                pw.unlock()
-                                                txt = _("Group cannot be installed. "
-                                                        "Updating related user entries "
-                                                        "failed.")
-                                                raise apx.ActionExecutionError(self,
-                                                    error=e, details=txt,
-                                                    fmri=pkgplan.destination_fmri)
+    def retry(self, pkgplan, orig):
+        groups = pkgplan.image._groups
+        if groups:
+            assert self in groups
+            self.install(pkgplan, orig, retry=True)
 
-                        # Deal with other columns in the group row.
-                        #
-                        # pkg has no support for the legacy password field
-                        # in the group table and thus requires it to be
-                        # empty for any pkg delivered group.  So there is
-                        # explicitly no support for updating
-                        # template["password"] since we require it to be empty.
-                        #
-                        # If the admin has assigned any users to a group that is
-                        # delivered as an action we preserve that list without
-                        # attempting to validate it in any way.
-                        if cur_attrs["user-list"]:
-                            template["user-list"] = cur_attrs["user-list"]
+    def verify(self, img, **args):
+        """Returns a tuple of lists of the form (errors, warnings,
+        info).  The error list will be empty if the action has been
+        correctly installed in the given image."""
 
-                gr.setvalue(template)
-                try:
-                        gr.writefile()
-                        if pw:
-                                pw.writefile()
-                except EnvironmentError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
-                        # If we're in the postinstall phase and the
-                        # files *still* aren't there, bail gracefully.
-                        if retry:
-                                txt = _("Group cannot be installed "
-                                    "without group database files "
-                                    "present.")
-                                raise apx.ActionExecutionError(self, error=e,
-                                    details=txt, fmri=pkgplan.destination_fmri)
-                        img = pkgplan.image
-                        img._groups.add(self)
-                        if "gid" in self.attrs:
-                                img._groupsbyname[self.attrs["groupname"]] = \
-                                    int(self.attrs["gid"])
-                        raise pkg.actions.ActionRetry(self)
-                finally:
-                        if pw:
-                                pw.unlock()
+        errors = []
+        warnings = []
+        info = []
+        if not have_cfgfiles:
+            # The user action is ignored if cfgfiles is not
+            # available.
+            return errors, warnings, info
 
-        def retry(self, pkgplan, orig):
-                groups = pkgplan.image._groups
-                if groups:
-                        assert self in groups
-                        self.install(pkgplan, orig, retry=True)
+        gr = GroupFile(img)
 
-        def verify(self, img, **args):
-                """Returns a tuple of lists of the form (errors, warnings,
-                info).  The error list will be empty if the action has been
-                correctly installed in the given image."""
+        cur_attrs = gr.getvalue(self.attrs)
 
-                errors = []
-                warnings = []
-                info = []
-                if not have_cfgfiles:
-                        # The user action is ignored if cfgfiles is not
-                        # available.
-                        return errors, warnings, info
+        # Get the default values if they're non-empty
+        grdefval = dict(
+            ((k, v) for k, v in six.iteritems(gr.getdefaultvalues()) if v != "")
+        )
 
-                gr = GroupFile(img)
+        # If "gid" is set dynamically, ignore what's on disk.
+        if "gid" not in self.attrs:
+            cur_attrs["gid"] = ""
 
-                cur_attrs = gr.getvalue(self.attrs)
+        should_be = grdefval.copy()
+        should_be.update(self.attrs)
+        # Note where attributes are missing
+        for k in should_be:
+            cur_attrs.setdefault(k, "<missing>")
+        # Note where attributes should be empty
+        for k in cur_attrs:
+            if cur_attrs[k]:
+                should_be.setdefault(k, "<empty>")
+        # Ignore "user-list", as it is only modified by user actions
+        should_be.pop("user-list", None)
 
-                # Get the default values if they're non-empty
-                grdefval = dict((
-                    (k, v)
-                    for k, v in six.iteritems(gr.getdefaultvalues())
-                    if v != ""
-                ))
+        errors = [
+            _("{entry}: '{found}' should be '{expected}'").format(
+                entry=a, found=cur_attrs[a], expected=should_be[a]
+            )
+            for a in should_be
+            if cur_attrs[a] != should_be[a]
+        ]
+        return errors, warnings, info
 
-                # If "gid" is set dynamically, ignore what's on disk.
-                if "gid" not in self.attrs:
-                        cur_attrs["gid"] = ""
+    def remove(self, pkgplan):
+        """client-side method that removes this group"""
+        if not have_cfgfiles:
+            # The user action is ignored if cfgfiles is not
+            # available.
+            return
+        gr = GroupFile(pkgplan.image)
+        try:
+            gr.removevalue(self.attrs)
+        except KeyError as e:
+            # Already gone; don't care.
+            pass
+        else:
+            gr.writefile()
 
-                should_be = grdefval.copy()
-                should_be.update(self.attrs)
-                # Note where attributes are missing
-                for k in should_be:
-                        cur_attrs.setdefault(k, "<missing>")
-                # Note where attributes should be empty
-                for k in cur_attrs:
-                        if cur_attrs[k]:
-                                should_be.setdefault(k, "<empty>")
-                # Ignore "user-list", as it is only modified by user actions
-                should_be.pop("user-list", None)
+    def generate_indices(self):
+        """Generates the indices needed by the search dictionary.  See
+        generic.py for a more detailed explanation."""
 
-                errors = [
-                    _("{entry}: '{found}' should be '{expected}'").format(
-                        entry=a, found=cur_attrs[a],
-                        expected=should_be[a])
-                    for a in should_be
-                    if cur_attrs[a] != should_be[a]
-                ]
-                return errors, warnings, info
+        return [("group", "name", self.attrs["groupname"], None)]
 
-        def remove(self, pkgplan):
-                """client-side method that removes this group"""
-                if not have_cfgfiles:
-                        # The user action is ignored if cfgfiles is not
-                        # available.
-                        return
-                gr = GroupFile(pkgplan.image)
-                try:
-                        gr.removevalue(self.attrs)
-                except KeyError as e:
-                        # Already gone; don't care.
-                        pass
-                else:
-                        gr.writefile()
+    def validate(self, fmri=None):
+        """Performs additional validation of action attributes that
+        for performance or other reasons cannot or should not be done
+        during Action object creation.  An ActionError exception (or
+        subclass of) will be raised if any attributes are not valid.
+        This is primarily intended for use during publication or during
+        error handling to provide additional diagonostics.
 
-        def generate_indices(self):
-                """Generates the indices needed by the search dictionary.  See
-                generic.py for a more detailed explanation."""
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action.
+        """
 
-                return [("group", "name", self.attrs["groupname"], None)]
+        generic.Action._validate(
+            self, fmri=fmri, numeric_attrs=("gid",), single_attrs=("gid",)
+        )
 
-        def validate(self, fmri=None):
-                """Performs additional validation of action attributes that
-                for performance or other reasons cannot or should not be done
-                during Action object creation.  An ActionError exception (or
-                subclass of) will be raised if any attributes are not valid.
-                This is primarily intended for use during publication or during
-                error handling to provide additional diagonostics.
+    def compare(self, other):
+        """Arrange for group actions to be installed in gid order.  This
+        will only hold true for actions installed at one time, but that's
+        generally what we need on initial install."""
+        # put unspecifed gids at the end
+        a = int(self.attrs.get("gid", 1024))
+        b = int(other.attrs.get("gid", 1024))
+        return (a > b) - (a < b)
 
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action.
-                """
-
-                generic.Action._validate(self, fmri=fmri,
-                    numeric_attrs=("gid",), single_attrs=("gid",))
-
-        def compare(self, other):
-                """Arrange for group actions to be installed in gid order.  This
-                will only hold true for actions installed at one time, but that's
-                generally what we need on initial install."""
-                # put unspecifed gids at the end
-                a = int(self.attrs.get("gid", 1024))
-                b = int(other.attrs.get("gid", 1024))
-                return (a > b) - (a < b)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/hardlink.py
+++ b/src/modules/actions/hardlink.py
@@ -37,108 +37,120 @@ import stat
 from pkg import misc
 from pkg.client.api_errors import ActionExecutionError
 
+
 class HardLinkAction(link.LinkAction):
-        """Class representing a hardlink-type packaging object."""
+    """Class representing a hardlink-type packaging object."""
 
-        __slots__ = []
+    __slots__ = []
 
-        name = "hardlink"
-        ordinality = generic._orderdict[name]
+    name = "hardlink"
+    ordinality = generic._orderdict[name]
 
-        def compare(self, other):
-                return ((self.attrs["path"] > other.attrs["path"]) -
-                    (self.attrs["path"] < other.attrs["path"]))
+    def compare(self, other):
+        return (self.attrs["path"] > other.attrs["path"]) - (
+            self.attrs["path"] < other.attrs["path"]
+        )
 
-        def get_target_path(self):
-                """ return a path for target that is relative to image"""
+    def get_target_path(self):
+        """return a path for target that is relative to image"""
 
-                target = self.attrs["target"]
+        target = self.attrs["target"]
 
-                # paths are either relative to path or absolute;
-                # both need to be passed through os.path.normpath to ensure
-                # that all ".." are removed to constrain target to image
+        # paths are either relative to path or absolute;
+        # both need to be passed through os.path.normpath to ensure
+        # that all ".." are removed to constrain target to image
 
-                if target[0] != "/":
-                        path = self.attrs["path"]
-                        target = os.path.normpath(
-                            os.path.join(os.path.split(path)[0], target))
-                else:
-                        target = os.path.normpath(target)[1:]
+        if target[0] != "/":
+            path = self.attrs["path"]
+            target = os.path.normpath(
+                os.path.join(os.path.split(path)[0], target)
+            )
+        else:
+            target = os.path.normpath(target)[1:]
 
-                return target
+        return target
 
-        def install(self, pkgplan, orig):
-                """Client-side method that installs a hard link."""
+    def install(self, pkgplan, orig):
+        """Client-side method that installs a hard link."""
 
-                target = self.get_target_path()
-                path = self.get_installed_path(pkgplan.image.get_root())
+        target = self.get_target_path()
+        path = self.get_installed_path(pkgplan.image.get_root())
 
-                # Don't allow installation through symlinks.
-                self.fsobj_checkpath(pkgplan, path)
+        # Don't allow installation through symlinks.
+        self.fsobj_checkpath(pkgplan, path)
 
-                if not os.path.exists(os.path.dirname(path)):
-                        self.makedirs(os.path.dirname(path),
-                            mode=misc.PKG_DIR_MODE,
-                            fmri=pkgplan.destination_fmri)
-                elif os.path.exists(path):
-                        self.remove(pkgplan)
+        if not os.path.exists(os.path.dirname(path)):
+            self.makedirs(
+                os.path.dirname(path),
+                mode=misc.PKG_DIR_MODE,
+                fmri=pkgplan.destination_fmri,
+            )
+        elif os.path.exists(path):
+            self.remove(pkgplan)
 
-                fulltarget = os.path.normpath(os.path.sep.join(
-                    (pkgplan.image.get_root(), target)))
+        fulltarget = os.path.normpath(
+            os.path.sep.join((pkgplan.image.get_root(), target))
+        )
 
-                try:
-                        os.link(fulltarget, path)
-                except EnvironmentError as e:
-                        if e.errno != errno.ENOENT:
-                                raise ActionExecutionError(self, error=e)
+        try:
+            os.link(fulltarget, path)
+        except EnvironmentError as e:
+            if e.errno != errno.ENOENT:
+                raise ActionExecutionError(self, error=e)
 
-                        # User or another process has removed target for
-                        # hardlink, a package hasn't declared correct
-                        # dependencies, or the target hasn't been installed
-                        # yet.
-                        err_txt = _("Unable to create hard link {path}; "
-                            "target {target} is missing.").format(
-                            path=path, target=fulltarget)
-                        raise ActionExecutionError(self, details=err_txt,
-                            error=e, fmri=pkgplan.destination_fmri)
+            # User or another process has removed target for
+            # hardlink, a package hasn't declared correct
+            # dependencies, or the target hasn't been installed
+            # yet.
+            err_txt = _(
+                "Unable to create hard link {path}; "
+                "target {target} is missing."
+            ).format(path=path, target=fulltarget)
+            raise ActionExecutionError(
+                self, details=err_txt, error=e, fmri=pkgplan.destination_fmri
+            )
 
-        def verify(self, img, **args):
-                """Returns a tuple of lists of the form (errors, warnings,
-                info).  The error list will be empty if the action has been
-                correctly installed in the given image."""
+    def verify(self, img, **args):
+        """Returns a tuple of lists of the form (errors, warnings,
+        info).  The error list will be empty if the action has been
+        correctly installed in the given image."""
 
-                #
-                # We only allow hard links to regular files, so the hard
-                # link should lstat() as a regular file.
-                #
-                lstat, errors, warnings, info, abort = \
-                    self.verify_fsobj_common(img, stat.S_IFREG)
-                if abort:
-                        assert errors
-                        return errors, warnings, info
+        #
+        # We only allow hard links to regular files, so the hard
+        # link should lstat() as a regular file.
+        #
+        lstat, errors, warnings, info, abort = self.verify_fsobj_common(
+            img, stat.S_IFREG
+        )
+        if abort:
+            assert errors
+            return errors, warnings, info
 
-                target = self.get_target_path()
-                path = self.get_installed_path(img.get_root())
-                target = os.path.normpath(os.path.sep.join(
-                    (img.get_root(), target)))
+        target = self.get_target_path()
+        path = self.get_installed_path(img.get_root())
+        target = os.path.normpath(os.path.sep.join((img.get_root(), target)))
 
-                if not os.path.exists(target):
-                        errors.append(_("Target '{0}' does not exist").format(
-                            self.attrs["target"]))
+        if not os.path.exists(target):
+            errors.append(
+                _("Target '{0}' does not exist").format(self.attrs["target"])
+            )
 
-                # No point in continuing if no target
-                if errors:
-                        return errors, warnings, info
+        # No point in continuing if no target
+        if errors:
+            return errors, warnings, info
 
-                try:
-                        if os.stat(path).st_ino != os.stat(target).st_ino:
-                                errors.append(_("Broken: Path and Target ({0}) "
-                                    "inodes not the same").format(
-                                    self.get_target_path()))
-                except OSError as e:
-                        errors.append(_("Unexpected Error: {0}").format(e))
+        try:
+            if os.stat(path).st_ino != os.stat(target).st_ino:
+                errors.append(
+                    _(
+                        "Broken: Path and Target ({0}) " "inodes not the same"
+                    ).format(self.get_target_path())
+                )
+        except OSError as e:
+            errors.append(_("Unexpected Error: {0}").format(e))
 
-                return errors, warnings, info
+        return errors, warnings, info
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/legacy.py
+++ b/src/modules/actions/legacy.py
@@ -39,167 +39,197 @@ import time
 from . import generic
 from pkg import misc
 
+
 class LegacyAction(generic.Action):
-        """Class representing a legacy SVr4 packaging object."""
+    """Class representing a legacy SVr4 packaging object."""
 
-        __slots__ = []
+    __slots__ = []
 
-        name = "legacy"
-        key_attr = "pkg"
-        unique_attrs = ("category", "desc", "hotline", "name", "pkg", "vendor",
-            "version", "basedir", "pkginst", "pstamp", "sunw_prodvers")
-        refcountable = True
-        globally_identical = True
-        ordinality = generic._orderdict[name]
+    name = "legacy"
+    key_attr = "pkg"
+    unique_attrs = (
+        "category",
+        "desc",
+        "hotline",
+        "name",
+        "pkg",
+        "vendor",
+        "version",
+        "basedir",
+        "pkginst",
+        "pstamp",
+        "sunw_prodvers",
+    )
+    refcountable = True
+    globally_identical = True
+    ordinality = generic._orderdict[name]
 
-        def directory_references(self):
-                return [os.path.normpath(os.path.join("var/sadm/pkg",
-                    self.attrs["pkg"]))]
+    def directory_references(self):
+        return [
+            os.path.normpath(os.path.join("var/sadm/pkg", self.attrs["pkg"]))
+        ]
 
-        def install(self, pkgplan, orig):
-                """Client-side method that installs the dummy package files.
-                Use per-pkg hardlinks to create reference count for pkginfo
-                file"""
+    def install(self, pkgplan, orig):
+        """Client-side method that installs the dummy package files.
+        Use per-pkg hardlinks to create reference count for pkginfo
+        file"""
 
-                pkgdir = os.path.join(pkgplan.image.get_root(), "var/sadm/pkg",
-                    self.attrs["pkg"])
+        pkgdir = os.path.join(
+            pkgplan.image.get_root(), "var/sadm/pkg", self.attrs["pkg"]
+        )
 
-                if not os.path.isdir(pkgdir):
-                        os.makedirs(pkgdir, misc.PKG_DIR_MODE)
+        if not os.path.isdir(pkgdir):
+            os.makedirs(pkgdir, misc.PKG_DIR_MODE)
 
-                pkginfo = os.path.join(pkgdir, "pkginfo")
+        pkginfo = os.path.join(pkgdir, "pkginfo")
 
-                self.__old_refcount_cleanup(pkginfo, pkgdir)
+        self.__old_refcount_cleanup(pkginfo, pkgdir)
 
-                pkg_summary = pkgplan.pkg_summary
-                if len(pkg_summary) > 256:
-                        # The len check is done to avoid slice creation.
-                        pkg_summary = pkg_summary[:256]
+        pkg_summary = pkgplan.pkg_summary
+        if len(pkg_summary) > 256:
+            # The len check is done to avoid slice creation.
+            pkg_summary = pkg_summary[:256]
 
-                svr4attrs = {
-                    "arch": pkgplan.image.get_arch(),
-                    "basedir": "/",
-                    "category": "system",
-                    "desc": None,
-                    "hotline": None,
-                    "name": pkg_summary,
-                    "pkg": self.attrs["pkg"],
-                    "pkginst": self.attrs["pkg"],
-                    "pstamp": None,
-                    "sunw_prodvers": None,
-                    "vendor": None,
-                    "version": str(pkgplan.destination_fmri.version),
-                }
+        svr4attrs = {
+            "arch": pkgplan.image.get_arch(),
+            "basedir": "/",
+            "category": "system",
+            "desc": None,
+            "hotline": None,
+            "name": pkg_summary,
+            "pkg": self.attrs["pkg"],
+            "pkginst": self.attrs["pkg"],
+            "pstamp": None,
+            "sunw_prodvers": None,
+            "vendor": None,
+            "version": str(pkgplan.destination_fmri.version),
+        }
 
-                attrs = [
-                    (a.upper(), b)
-                    for a in svr4attrs
-                    for b in ( self.attrs.get(a, svr4attrs[a]), )
-                    if b
-                ]
-                # Always overwrite installation timestamp
-                attrs.append(("INSTDATE",
-                    time.strftime("%b %d %Y %H:%M")))
+        attrs = [
+            (a.upper(), b)
+            for a in svr4attrs
+            for b in (self.attrs.get(a, svr4attrs[a]),)
+            if b
+        ]
+        # Always overwrite installation timestamp
+        attrs.append(("INSTDATE", time.strftime("%b %d %Y %H:%M")))
 
-                with open(pkginfo, "w") as pfile:
-                        for k, v in attrs:
-                                pfile.write("{0}={1}\n".format(k, v))
+        with open(pkginfo, "w") as pfile:
+            for k, v in attrs:
+                pfile.write("{0}={1}\n".format(k, v))
 
-                # the svr4 pkg commands need contents file to work, but the
-                # needed directories are in the SUNWpkgcmds package....
-                # Since this file is always of zero length, we can let this
-                # fail until those directories (and the commands that
-                # need them) appear.
+        # the svr4 pkg commands need contents file to work, but the
+        # needed directories are in the SUNWpkgcmds package....
+        # Since this file is always of zero length, we can let this
+        # fail until those directories (and the commands that
+        # need them) appear.
 
-                try:
-                        open(os.path.join(pkgplan.image.get_root(),
-                            "var/sadm/install/contents"), "a").close()
-                except IOError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
+        try:
+            open(
+                os.path.join(
+                    pkgplan.image.get_root(), "var/sadm/install/contents"
+                ),
+                "a",
+            ).close()
+        except IOError as e:
+            if e.errno != errno.ENOENT:
+                raise
 
-                os.chmod(pkginfo, misc.PKG_FILE_MODE)
+        os.chmod(pkginfo, misc.PKG_FILE_MODE)
 
-        def __old_refcount_cleanup(self, pkginfo, pkgdir):
-                """Clean up the turds of the old refcounting implementation."""
+    def __old_refcount_cleanup(self, pkginfo, pkgdir):
+        """Clean up the turds of the old refcounting implementation."""
 
-                # Don't assume that the hardlinks are still in place; just
-                # remove all consecutively numbered files.
-                for i in itertools.count(2):
-                        lfile = os.path.join(pkgdir, "pkginfo.{0:d}".format(i))
-                        try:
-                                os.unlink(lfile)
-                        except OSError as e:
-                                if e.errno == errno.ENOENT:
-                                        break
-                                raise
+        # Don't assume that the hardlinks are still in place; just
+        # remove all consecutively numbered files.
+        for i in itertools.count(2):
+            lfile = os.path.join(pkgdir, "pkginfo.{0:d}".format(i))
+            try:
+                os.unlink(lfile)
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    break
+                raise
 
-        def verify(self, img, **args):
-                """Returns a tuple of lists of the form (errors, warnings,
-                info).  The error list will be empty if the action has been
-                correctly installed in the given image."""
+    def verify(self, img, **args):
+        """Returns a tuple of lists of the form (errors, warnings,
+        info).  The error list will be empty if the action has been
+        correctly installed in the given image."""
 
-                errors = []
-                warnings = []
-                info = []
+        errors = []
+        warnings = []
+        info = []
 
-                pkgdir = os.path.join(img.get_root(), "var/sadm/pkg",
-                    self.attrs["pkg"])
+        pkgdir = os.path.join(img.get_root(), "var/sadm/pkg", self.attrs["pkg"])
 
-                # XXX this could be a better check & exactly validate pkginfo
-                # contents
-                if not os.path.isdir(pkgdir):
-                        errors.append(
-                            _("Missing directory var/sadm/pkg/{0}").format(
-                            self.attrs["pkg"]))
-                        return errors, warnings, info
+        # XXX this could be a better check & exactly validate pkginfo
+        # contents
+        if not os.path.isdir(pkgdir):
+            errors.append(
+                _("Missing directory var/sadm/pkg/{0}").format(
+                    self.attrs["pkg"]
+                )
+            )
+            return errors, warnings, info
 
-                if not os.path.isfile(os.path.join(pkgdir, "pkginfo")):
-                        errors.append(_("Missing file "
-                            "var/sadm/pkg/{0}/pkginfo").format(
-                            self.attrs["pkg"]))
-                return errors, warnings, info
+        if not os.path.isfile(os.path.join(pkgdir, "pkginfo")):
+            errors.append(
+                _("Missing file " "var/sadm/pkg/{0}/pkginfo").format(
+                    self.attrs["pkg"]
+                )
+            )
+        return errors, warnings, info
 
-        def remove(self, pkgplan):
+    def remove(self, pkgplan):
+        # pkg directory is removed via implicit directory removal
 
-                # pkg directory is removed via implicit directory removal
+        pkgdir = os.path.join(
+            pkgplan.image.get_root(), "var/sadm/pkg", self.attrs["pkg"]
+        )
 
-                pkgdir = os.path.join(pkgplan.image.get_root(), "var/sadm/pkg",
-                    self.attrs["pkg"])
+        pkginfo = os.path.join(pkgdir, "pkginfo")
 
-                pkginfo = os.path.join(pkgdir, "pkginfo")
+        self.__old_refcount_cleanup(pkginfo, pkgdir)
 
-                self.__old_refcount_cleanup(pkginfo, pkgdir)
+        try:
+            os.unlink(pkginfo)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
 
-                try:
-                        os.unlink(pkginfo)
-                except OSError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
+    def generate_indices(self):
+        """Generates the indices needed by the search dictionary.  See
+        generic.py for a more detailed explanation."""
 
-        def generate_indices(self):
-                """Generates the indices needed by the search dictionary.  See
-                generic.py for a more detailed explanation."""
+        return [
+            ("legacy", "legacy_pkg", self.attrs["pkg"], None),
+            ("legacy", "pkg", self.attrs["pkg"], None),
+        ]
 
-                return [
-                    ("legacy", "legacy_pkg", self.attrs["pkg"], None),
-                    ("legacy", "pkg", self.attrs["pkg"], None)
-                ]
+    def validate(self, fmri=None):
+        """Performs additional validation of action attributes that
+        for performance or other reasons cannot or should not be done
+        during Action object creation.  An ActionError exception (or
+        subclass of) will be raised if any attributes are not valid.
+        This is primarily intended for use during publication or during
+        error handling to provide additional diagonostics.
 
-        def validate(self, fmri=None):
-                """Performs additional validation of action attributes that
-                for performance or other reasons cannot or should not be done
-                during Action object creation.  An ActionError exception (or
-                subclass of) will be raised if any attributes are not valid.
-                This is primarily intended for use during publication or during
-                error handling to provide additional diagonostics.
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action."""
 
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action."""
+        generic.Action._validate(
+            self,
+            fmri=fmri,
+            single_attrs=(
+                "category",
+                "desc",
+                "hotline",
+                "name",
+                "vendor",
+                "version",
+            ),
+        )
 
-                generic.Action._validate(self, fmri=fmri,
-                    single_attrs=("category", "desc", "hotline", "name",
-                    "vendor", "version"))
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/license.py
+++ b/src/modules/actions/license.py
@@ -44,233 +44,259 @@ import zlib
 from pkg.client.api_errors import ActionExecutionError
 from six.moves.urllib.parse import quote
 
+
 class LicenseAction(generic.Action):
-        """Class representing a license packaging object."""
+    """Class representing a license packaging object."""
 
-        __slots__ = ["hash"]
+    __slots__ = ["hash"]
 
-        name = "license"
-        key_attr = "license"
-        unique_attrs = ("license", )
-        reverse_indices = ("license", )
-        refcountable = True
-        globally_identical = True
-        ordinality = generic._orderdict[name]
+    name = "license"
+    key_attr = "license"
+    unique_attrs = ("license",)
+    reverse_indices = ("license",)
+    refcountable = True
+    globally_identical = True
+    ordinality = generic._orderdict[name]
 
-        has_payload = True
+    has_payload = True
 
-        def __init__(self, data=None, **attrs):
-                generic.Action.__init__(self, data, **attrs)
-                self.hash = "NOHASH"
+    def __init__(self, data=None, **attrs):
+        generic.Action.__init__(self, data, **attrs)
+        self.hash = "NOHASH"
 
-        def preinstall(self, pkgplan, orig):
-                # Set attrs["path"] so filelist can handle this action;
-                # the path must be relative to the root of the image.
-                self.attrs["path"] = misc.relpath(os.path.join(
-                    pkgplan.image.get_license_dir(pkgplan.destination_fmri),
-                    "license." + quote(self.attrs["license"], "")),
-                    pkgplan.image.get_root())
+    def preinstall(self, pkgplan, orig):
+        # Set attrs["path"] so filelist can handle this action;
+        # the path must be relative to the root of the image.
+        self.attrs["path"] = misc.relpath(
+            os.path.join(
+                pkgplan.image.get_license_dir(pkgplan.destination_fmri),
+                "license." + quote(self.attrs["license"], ""),
+            ),
+            pkgplan.image.get_root(),
+        )
 
-        def install(self, pkgplan, orig):
-                """Client-side method that installs the license."""
-                owner = 0
-                group = 0
+    def install(self, pkgplan, orig):
+        """Client-side method that installs the license."""
+        owner = 0
+        group = 0
 
-                # ensure "path" is initialized.  it may not be if we've loaded
-                # a plan that was previously prepared.
-                self.preinstall(pkgplan, orig)
+        # ensure "path" is initialized.  it may not be if we've loaded
+        # a plan that was previously prepared.
+        self.preinstall(pkgplan, orig)
 
-                stream = self.data()
+        stream = self.data()
 
-                path = self.get_installed_path(pkgplan.image.get_root())
+        path = self.get_installed_path(pkgplan.image.get_root())
 
-                # make sure the directory exists and the file is writable
-                if not os.path.exists(os.path.dirname(path)):
-                        self.makedirs(os.path.dirname(path),
-                            mode=misc.PKG_DIR_MODE,
-                            fmri=pkgplan.destination_fmri)
-                elif os.path.exists(path):
-                        os.chmod(path, misc.PKG_FILE_MODE)
+        # make sure the directory exists and the file is writable
+        if not os.path.exists(os.path.dirname(path)):
+            self.makedirs(
+                os.path.dirname(path),
+                mode=misc.PKG_DIR_MODE,
+                fmri=pkgplan.destination_fmri,
+            )
+        elif os.path.exists(path):
+            os.chmod(path, misc.PKG_FILE_MODE)
 
-                lfile = open(path, "wb")
-                try:
-                        hash_attr, hash_val, hash_func = \
-                            digest.get_preferred_hash(self)
-                        shasum = misc.gunzip_from_stream(stream, lfile,
-                            hash_func=hash_func)
-                except zlib.error as e:
-                        raise ActionExecutionError(self, details=_("Error "
-                            "decompressing payload: {0}").format(
-                            " ".join([str(a) for a in e.args])), error=e)
-                finally:
-                        lfile.close()
-                        stream.close()
+        lfile = open(path, "wb")
+        try:
+            hash_attr, hash_val, hash_func = digest.get_preferred_hash(self)
+            shasum = misc.gunzip_from_stream(stream, lfile, hash_func=hash_func)
+        except zlib.error as e:
+            raise ActionExecutionError(
+                self,
+                details=_("Error " "decompressing payload: {0}").format(
+                    " ".join([str(a) for a in e.args])
+                ),
+                error=e,
+            )
+        finally:
+            lfile.close()
+            stream.close()
 
-                if shasum != hash_val:
-                        raise ActionExecutionError(self, details=_("Action "
-                            "data hash verification failure: expected: "
-                            "{expected} computed: {actual} action: "
-                            "{action}").format(
-                                expected=hash_val,
-                                actual=shasum,
-                                action=self
-                           ))
+        if shasum != hash_val:
+            raise ActionExecutionError(
+                self,
+                details=_(
+                    "Action "
+                    "data hash verification failure: expected: "
+                    "{expected} computed: {actual} action: "
+                    "{action}"
+                ).format(expected=hash_val, actual=shasum, action=self),
+            )
 
-                os.chmod(path, misc.PKG_RO_FILE_MODE)
+        os.chmod(path, misc.PKG_RO_FILE_MODE)
 
-                try:
-                        portable.chown(path, owner, group)
-                except OSError as e:
-                        if e.errno != errno.EPERM:
-                                raise
+        try:
+            portable.chown(path, owner, group)
+        except OSError as e:
+            if e.errno != errno.EPERM:
+                raise
 
-        def needsdata(self, orig, pkgplan):
-                # We always want to download the license
-                return True
+    def needsdata(self, orig, pkgplan):
+        # We always want to download the license
+        return True
 
-        def verify(self, img, pfmri, **args):
-                """Returns a tuple of lists of the form (errors, warnings,
-                info).  The error list will be empty if the action has been
-                correctly installed in the given image."""
+    def verify(self, img, pfmri, **args):
+        """Returns a tuple of lists of the form (errors, warnings,
+        info).  The error list will be empty if the action has been
+        correctly installed in the given image."""
 
-                errors = []
-                warnings = []
-                info = []
+        errors = []
+        warnings = []
+        info = []
 
-                path = os.path.join(img.get_license_dir(pfmri),
-                    "license." + quote(self.attrs["license"], ""))
+        path = os.path.join(
+            img.get_license_dir(pfmri),
+            "license." + quote(self.attrs["license"], ""),
+        )
 
-                hash_attr, hash_val, hash_func = \
-                    digest.get_preferred_hash(self)
-                if args["forever"] == True:
-                        try:
-                                chash, cdata = misc.get_data_digest(path,
-                                    hash_func=hash_func)
-                        except EnvironmentError as e:
-                                if e.errno == errno.ENOENT:
-                                        errors.append(_("License file {0} does "
-                                            "not exist.").format(path))
-                                        return errors, warnings, info
-                                raise
+        hash_attr, hash_val, hash_func = digest.get_preferred_hash(self)
+        if args["forever"] == True:
+            try:
+                chash, cdata = misc.get_data_digest(path, hash_func=hash_func)
+            except EnvironmentError as e:
+                if e.errno == errno.ENOENT:
+                    errors.append(
+                        _("License file {0} does " "not exist.").format(path)
+                    )
+                    return errors, warnings, info
+                raise
 
-                        if chash != hash_val:
-                                errors.append(_("Hash: '{found}' should be "
-                                    "'{expected}'").format(found=chash,
-                                    expected=hash_val))
-                return errors, warnings, info
+            if chash != hash_val:
+                errors.append(
+                    _("Hash: '{found}' should be " "'{expected}'").format(
+                        found=chash, expected=hash_val
+                    )
+                )
+        return errors, warnings, info
 
-        def remove(self, pkgplan):
-                path = os.path.join(
-                    pkgplan.image.get_license_dir(pkgplan.origin_fmri),
-                    "license." + quote(self.attrs["license"], ""))
+    def remove(self, pkgplan):
+        path = os.path.join(
+            pkgplan.image.get_license_dir(pkgplan.origin_fmri),
+            "license." + quote(self.attrs["license"], ""),
+        )
 
-                try:
-                        # Make file writable so it can be deleted
-                        os.chmod(path, S_IWRITE|S_IREAD)
-                        os.unlink(path)
-                except OSError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
+        try:
+            # Make file writable so it can be deleted
+            os.chmod(path, S_IWRITE | S_IREAD)
+            os.unlink(path)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
 
-        def generate_indices(self):
-                """Generates the indices needed by the search dictionary.  See
-                generic.py for a more detailed explanation."""
+    def generate_indices(self):
+        """Generates the indices needed by the search dictionary.  See
+        generic.py for a more detailed explanation."""
 
-                indices = [("license", idx, self.attrs[idx], None)
-                           for idx in self.reverse_indices]
-                if hasattr(self, "hash"):
-                        indices.append(("license", "hash", self.hash, None))
-                        indices.append(("license", "content", self.hash, None))
-                for attr in digest.DEFAULT_HASH_ATTRS:
-                        # we already have an index entry for self.hash
-                        if attr == "hash":
-                                continue
-                        hash = self.attrs[attr]
-                        indices.append(("license", attr, hash, None))
-                return indices
+        indices = [
+            ("license", idx, self.attrs[idx], None)
+            for idx in self.reverse_indices
+        ]
+        if hasattr(self, "hash"):
+            indices.append(("license", "hash", self.hash, None))
+            indices.append(("license", "content", self.hash, None))
+        for attr in digest.DEFAULT_HASH_ATTRS:
+            # we already have an index entry for self.hash
+            if attr == "hash":
+                continue
+            hash = self.attrs[attr]
+            indices.append(("license", attr, hash, None))
+        return indices
 
-        def get_text(self, img, pfmri, alt_pub=None):
-                """Retrieves and returns the payload of the license (which
-                should be text).  This may require remote retrieval of
-                resources and so this could raise a TransportError or other
-                ApiException.
-                If there are UTF-8 encoding errors in the text replace them
-                so that we still have a license to show rather than failing
-                the entire operation.  The copy saved on disk is left as is.
+    def get_text(self, img, pfmri, alt_pub=None):
+        """Retrieves and returns the payload of the license (which
+        should be text).  This may require remote retrieval of
+        resources and so this could raise a TransportError or other
+        ApiException.
+        If there are UTF-8 encoding errors in the text replace them
+        so that we still have a license to show rather than failing
+        the entire operation.  The copy saved on disk is left as is.
 
-                'alt_pub' is an optional alternate Publisher to use for
-                any required transport operations.
-                """
+        'alt_pub' is an optional alternate Publisher to use for
+        any required transport operations.
+        """
 
-                path = self.get_local_path(img, pfmri)
-                hash_attr, hash_attr_val, hash_func = \
-                    digest.get_least_preferred_hash(self)
-                try:
-                        with open(path, "rb") as fh:
-                                length = os.stat(path).st_size
-                                chash, txt = misc.get_data_digest(fh,
-                                    length=length, return_content=True,
-                                    hash_func=hash_func)
-                                if chash == hash_attr_val:
-                                        return misc.force_str(txt,
-                                            errors='replace')
-                except EnvironmentError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
-                try:
-                        if not alt_pub:
-                                alt_pub = img.get_publisher(pfmri.publisher)
-                        assert pfmri.publisher == alt_pub.prefix
-                        return img.transport.get_content(alt_pub, hash_attr_val,
-                            fmri=pfmri, hash_func=hash_func, errors="replace")
-                finally:
-                        img.cleanup_downloads()
+        path = self.get_local_path(img, pfmri)
+        hash_attr, hash_attr_val, hash_func = digest.get_least_preferred_hash(
+            self
+        )
+        try:
+            with open(path, "rb") as fh:
+                length = os.stat(path).st_size
+                chash, txt = misc.get_data_digest(
+                    fh, length=length, return_content=True, hash_func=hash_func
+                )
+                if chash == hash_attr_val:
+                    return misc.force_str(txt, errors="replace")
+        except EnvironmentError as e:
+            if e.errno != errno.ENOENT:
+                raise
+        try:
+            if not alt_pub:
+                alt_pub = img.get_publisher(pfmri.publisher)
+            assert pfmri.publisher == alt_pub.prefix
+            return img.transport.get_content(
+                alt_pub,
+                hash_attr_val,
+                fmri=pfmri,
+                hash_func=hash_func,
+                errors="replace",
+            )
+        finally:
+            img.cleanup_downloads()
 
-        def get_local_path(self, img, pfmri):
-                """Return an opener for the license text from the local disk or
-                None if the data for the text is not on-disk."""
+    def get_local_path(self, img, pfmri):
+        """Return an opener for the license text from the local disk or
+        None if the data for the text is not on-disk."""
 
-                if img.version <= 3:
-                        # Older images stored licenses without accounting for
-                        # '/', spaces, etc. properly.
-                        path = os.path.join(img.get_license_dir(pfmri),
-                            "license." + self.attrs["license"])
-                else:
-                        # Newer images ensure licenses are stored with encoded
-                        # name so that '/', spaces, etc. are properly handled.
-                        path = os.path.join(img.get_license_dir(pfmri),
-                            "license." + quote(self.attrs["license"],
-                            ""))
-                return path
+        if img.version <= 3:
+            # Older images stored licenses without accounting for
+            # '/', spaces, etc. properly.
+            path = os.path.join(
+                img.get_license_dir(pfmri), "license." + self.attrs["license"]
+            )
+        else:
+            # Newer images ensure licenses are stored with encoded
+            # name so that '/', spaces, etc. are properly handled.
+            path = os.path.join(
+                img.get_license_dir(pfmri),
+                "license." + quote(self.attrs["license"], ""),
+            )
+        return path
 
-        @property
-        def must_accept(self):
-                """Returns a boolean value indicating whether this license
-                action requires acceptance of its payload by clients."""
+    @property
+    def must_accept(self):
+        """Returns a boolean value indicating whether this license
+        action requires acceptance of its payload by clients."""
 
-                return self.attrs.get("must-accept", "").lower() == "true"
+        return self.attrs.get("must-accept", "").lower() == "true"
 
-        @property
-        def must_display(self):
-                """Returns a boolean value indicating whether this license
-                action requires its payload to be displayed by clients."""
+    @property
+    def must_display(self):
+        """Returns a boolean value indicating whether this license
+        action requires its payload to be displayed by clients."""
 
-                return self.attrs.get("must-display", "").lower() == "true"
+        return self.attrs.get("must-display", "").lower() == "true"
 
-        def validate(self, fmri=None):
-                """Performs additional validation of action attributes that
-                for performance or other reasons cannot or should not be done
-                during Action object creation.  An ActionError exception (or
-                subclass of) will be raised if any attributes are not valid.
-                This is primarily intended for use during publication or during
-                error handling to provide additional diagonostics.
+    def validate(self, fmri=None):
+        """Performs additional validation of action attributes that
+        for performance or other reasons cannot or should not be done
+        during Action object creation.  An ActionError exception (or
+        subclass of) will be raised if any attributes are not valid.
+        This is primarily intended for use during publication or during
+        error handling to provide additional diagonostics.
 
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action."""
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action."""
 
-                generic.Action._validate(self, fmri=fmri,
-                    numeric_attrs=("pkg.csize", "pkg.size"),
-                    single_attrs=("chash", "must-accept", "must-display"))
+        generic.Action._validate(
+            self,
+            fmri=fmri,
+            numeric_attrs=("pkg.csize", "pkg.size"),
+            single_attrs=("chash", "must-accept", "must-display"),
+        )
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/link.py
+++ b/src/modules/actions/link.py
@@ -41,181 +41,209 @@ import pkg.mediator as med
 from pkg import misc
 from pkg.client.api_errors import ActionExecutionError
 
+
 class LinkAction(generic.Action):
-        """Class representing a link-type packaging object."""
+    """Class representing a link-type packaging object."""
 
-        __slots__ = []
+    __slots__ = []
 
-        name = "link"
-        key_attr = "path"
-        unique_attrs = "path", "target"
-        globally_identical = True
-        refcountable = True
-        namespace_group = "path"
-        ordinality = generic._orderdict[name]
+    name = "link"
+    key_attr = "path"
+    unique_attrs = "path", "target"
+    globally_identical = True
+    refcountable = True
+    namespace_group = "path"
+    ordinality = generic._orderdict[name]
 
-        def install(self, pkgplan, orig):
-                """Client-side method that installs a link."""
+    def install(self, pkgplan, orig):
+        """Client-side method that installs a link."""
 
-                target = self.attrs["target"]
-                path = self.get_installed_path(pkgplan.image.get_root())
+        target = self.attrs["target"]
+        path = self.get_installed_path(pkgplan.image.get_root())
 
-                # Don't allow installation through symlinks.
-                self.fsobj_checkpath(pkgplan, path)
+        # Don't allow installation through symlinks.
+        self.fsobj_checkpath(pkgplan, path)
 
-                if orig and self.attrs.get('preserve', None) == 'true':
-                        # Preserved links are not installed if this is an
-                        # update (orig set) and:
-                        # - the link has been removed
-                        if not os.path.lexists(path):
-                                return
-                        # - the link has been changed
-                        atarget = os.readlink(path)
-                        if atarget != orig.attrs.get('target', None):
-                                return
+        if orig and self.attrs.get("preserve", None) == "true":
+            # Preserved links are not installed if this is an
+            # update (orig set) and:
+            # - the link has been removed
+            if not os.path.lexists(path):
+                return
+            # - the link has been changed
+            atarget = os.readlink(path)
+            if atarget != orig.attrs.get("target", None):
+                return
 
-                if not os.path.exists(os.path.dirname(path)):
-                        self.makedirs(os.path.dirname(path),
-                            mode=misc.PKG_DIR_MODE,
-                            fmri=pkgplan.destination_fmri)
+        if not os.path.exists(os.path.dirname(path)):
+            self.makedirs(
+                os.path.dirname(path),
+                mode=misc.PKG_DIR_MODE,
+                fmri=pkgplan.destination_fmri,
+            )
 
-                # XXX The exists-unlink-symlink path appears to be as safe as it
-                # gets to modify a link with the current symlink(2) interface.
-                if os.path.lexists(path):
-                        self.remove(pkgplan)
-                os.symlink(target, path)
+        # XXX The exists-unlink-symlink path appears to be as safe as it
+        # gets to modify a link with the current symlink(2) interface.
+        if os.path.lexists(path):
+            self.remove(pkgplan)
+        os.symlink(target, path)
 
-        def verify(self, img, **args):
-                """Returns a tuple of lists of the form (errors, warnings,
-                info).  The error list will be empty if the action has been
-                correctly installed in the given image."""
+    def verify(self, img, **args):
+        """Returns a tuple of lists of the form (errors, warnings,
+        info).  The error list will be empty if the action has been
+        correctly installed in the given image."""
 
-                target = self.attrs["target"]
-                path = self.get_installed_path(img.get_root())
-                preserve = self.attrs.get('preserve', None)
+        target = self.attrs["target"]
+        path = self.get_installed_path(img.get_root())
+        preserve = self.attrs.get("preserve", None)
 
-                # It's acceptable for links with preserve=true to be
-                # missing.
-                if preserve == 'true':
-                        try:
-                                os.lstat(path)
-                        except OSError as e:
-                                if e.errno == errno.ENOENT:
-                                        return [], [], []
+        # It's acceptable for links with preserve=true to be
+        # missing.
+        if preserve == "true":
+            try:
+                os.lstat(path)
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    return [], [], []
 
-                lstat, errors, warnings, info, abort = \
-                    self.verify_fsobj_common(img, stat.S_IFLNK)
+        lstat, errors, warnings, info, abort = self.verify_fsobj_common(
+            img, stat.S_IFLNK
+        )
 
-                if abort:
-                        assert errors
-                        return errors, warnings, info
+        if abort:
+            assert errors
+            return errors, warnings, info
 
-                # It's acceptable for links with preserve=true to point
-                # elsewhere.
-                if preserve != 'true':
-                        atarget = os.readlink(path)
+        # It's acceptable for links with preserve=true to point
+        # elsewhere.
+        if preserve != "true":
+            atarget = os.readlink(path)
 
-                        if target != atarget:
-                                errors.append(_("Target: '{found}' should be "
-                                    "'{expected}'").format(found=atarget,
-                                    expected=target))
-                return errors, warnings, info
+            if target != atarget:
+                errors.append(
+                    _("Target: '{found}' should be " "'{expected}'").format(
+                        found=atarget, expected=target
+                    )
+                )
+        return errors, warnings, info
 
-        def remove(self, pkgplan):
-                """Removes the installed link from the system.  If something
-                other than a link is found at the destination location, it
-                will be removed or salvaged."""
+    def remove(self, pkgplan):
+        """Removes the installed link from the system.  If something
+        other than a link is found at the destination location, it
+        will be removed or salvaged."""
 
-                path = self.get_installed_path(pkgplan.image.get_root())
-                return self.remove_fsobj(pkgplan, path)
+        path = self.get_installed_path(pkgplan.image.get_root())
+        return self.remove_fsobj(pkgplan, path)
 
-        def generate_indices(self):
-                """Generates the indices needed by the search dictionary.  See
-                generic.py for a more detailed explanation."""
+    def generate_indices(self):
+        """Generates the indices needed by the search dictionary.  See
+        generic.py for a more detailed explanation."""
 
-                rval = [
-                    (self.name, "basename", os.path.basename(self.attrs["path"]),
-                    None),
-                    (self.name, "path", os.path.sep + self.attrs["path"], None),
-                ]
-                if "mediator" in self.attrs:
-                        rval.extend(
-                            (self.name, k, v, None)
-                            for k, v in six.iteritems(self.attrs)
-                            if k.startswith("mediator")
-                        )
-                return rval
+        rval = [
+            (self.name, "basename", os.path.basename(self.attrs["path"]), None),
+            (self.name, "path", os.path.sep + self.attrs["path"], None),
+        ]
+        if "mediator" in self.attrs:
+            rval.extend(
+                (self.name, k, v, None)
+                for k, v in six.iteritems(self.attrs)
+                if k.startswith("mediator")
+            )
+        return rval
 
-        def validate(self, fmri=None):
-                """Performs additional validation of action attributes that
-                for performance or other reasons cannot or should not be done
-                during Action object creation.  An ActionError exception (or
-                subclass of) will be raised if any attributes are not valid.
-                This is primarily intended for use during publication or during
-                error handling to provide additional diagonostics.
+    def validate(self, fmri=None):
+        """Performs additional validation of action attributes that
+        for performance or other reasons cannot or should not be done
+        during Action object creation.  An ActionError exception (or
+        subclass of) will be raised if any attributes are not valid.
+        This is primarily intended for use during publication or during
+        error handling to provide additional diagonostics.
 
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action."""
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action."""
 
-                errors = generic.Action._validate(self, fmri=fmri,
-                    raise_errors=False, required_attrs=("target",),
-                    single_attrs=("target", "mediator", "mediator-version",
-                    "mediator-implementation", "mediator-priority"))
+        errors = generic.Action._validate(
+            self,
+            fmri=fmri,
+            raise_errors=False,
+            required_attrs=("target",),
+            single_attrs=(
+                "target",
+                "mediator",
+                "mediator-version",
+                "mediator-implementation",
+                "mediator-priority",
+            ),
+        )
 
-                if "mediator" not in self.attrs and \
-                    "mediator-version" not in self.attrs and \
-                    "mediator-implementation" not in self.attrs and \
-                    "mediator-priority" not in self.attrs:
-                        if errors:
-                                raise pkg.actions.InvalidActionAttributesError(
-                                    self, errors, fmri=fmri)
-                        return
+        if (
+            "mediator" not in self.attrs
+            and "mediator-version" not in self.attrs
+            and "mediator-implementation" not in self.attrs
+            and "mediator-priority" not in self.attrs
+        ):
+            if errors:
+                raise pkg.actions.InvalidActionAttributesError(
+                    self, errors, fmri=fmri
+                )
+            return
 
-                mediator = self.attrs.get("mediator")
-                med_version = self.attrs.get("mediator-version")
-                med_implementation = self.attrs.get("mediator-implementation")
-                med_priority = self.attrs.get("mediator-priority")
+        mediator = self.attrs.get("mediator")
+        med_version = self.attrs.get("mediator-version")
+        med_implementation = self.attrs.get("mediator-implementation")
+        med_priority = self.attrs.get("mediator-priority")
 
-                if not mediator and (med_version or med_implementation or
-                    med_priority):
-                        errors.append(("mediator", _("a mediator must be "
-                            "provided when mediator-version, "
-                            "mediator-implementation, or mediator-priority "
-                            "is specified")))
-                elif mediator is not None and \
-                    not isinstance(mediator, list):
-                        valid, error = med.valid_mediator(mediator)
-                        if not valid:
-                                errors.append(("mediator", error))
+        if not mediator and (med_version or med_implementation or med_priority):
+            errors.append(
+                (
+                    "mediator",
+                    _(
+                        "a mediator must be "
+                        "provided when mediator-version, "
+                        "mediator-implementation, or mediator-priority "
+                        "is specified"
+                    ),
+                )
+            )
+        elif mediator is not None and not isinstance(mediator, list):
+            valid, error = med.valid_mediator(mediator)
+            if not valid:
+                errors.append(("mediator", error))
 
-                if not (med_version or med_implementation):
-                        errors.append(("mediator", _("a mediator-version or "
-                            "mediator-implementation must be provided if a "
-                            "mediator is specified")))
+        if not (med_version or med_implementation):
+            errors.append(
+                (
+                    "mediator",
+                    _(
+                        "a mediator-version or "
+                        "mediator-implementation must be provided if a "
+                        "mediator is specified"
+                    ),
+                )
+            )
 
-                if med_version is not None and \
-                    not isinstance(med_version, list):
-                        valid, error = med.valid_mediator_version(med_version)
-                        if not valid:
-                                errors.append(("mediator-version", error))
+        if med_version is not None and not isinstance(med_version, list):
+            valid, error = med.valid_mediator_version(med_version)
+            if not valid:
+                errors.append(("mediator-version", error))
 
-                if med_implementation is not None and \
-                    not isinstance(med_implementation, list):
-                        valid, error = med.valid_mediator_implementation(
-                            med_implementation)
-                        if not valid:
-                                errors.append(("mediator-implementation",
-                                    error))
+        if med_implementation is not None and not isinstance(
+            med_implementation, list
+        ):
+            valid, error = med.valid_mediator_implementation(med_implementation)
+            if not valid:
+                errors.append(("mediator-implementation", error))
 
-                if med_priority is not None and \
-                    not isinstance(med_priority, list):
-                        valid, error = med.valid_mediator_priority(med_priority)
-                        if not valid:
-                                errors.append(("mediator-priority", error))
+        if med_priority is not None and not isinstance(med_priority, list):
+            valid, error = med.valid_mediator_priority(med_priority)
+            if not valid:
+                errors.append(("mediator-priority", error))
 
-                if errors:
-                        raise pkg.actions.InvalidActionAttributesError(self,
-                            errors, fmri=fmri)
+        if errors:
+            raise pkg.actions.InvalidActionAttributesError(
+                self, errors, fmri=fmri
+            )
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/signature.py
+++ b/src/modules/actions/signature.py
@@ -46,597 +46,674 @@ import pkg.misc as misc
 valid_hash_algs = ("sha256", "sha384", "sha512")
 valid_sig_algs = ("rsa",)
 
-if list(map(int, _cver.split('.'))) >= [3, 4, 0]:
-        # In cryptography 3.4, the hash classes moved to subclasses of
-        # hashes.hashAlgorithm
-        hash_registry = hashes.HashAlgorithm.__subclasses__()
+if list(map(int, _cver.split("."))) >= [3, 4, 0]:
+    # In cryptography 3.4, the hash classes moved to subclasses of
+    # hashes.hashAlgorithm
+    hash_registry = hashes.HashAlgorithm.__subclasses__()
 else:
-        # For cryptography < 3.4.0
-        import abc
+    # For cryptography < 3.4.0
+    import abc
 
-        hash_registry = [
-            ref()
-            for ref in abc._get_dump(hashes.HashAlgorithm)[0]
-            if ref()
-        ]
+    hash_registry = [
+        ref() for ref in abc._get_dump(hashes.HashAlgorithm)[0] if ref()
+    ]
+
 
 class SignatureAction(generic.Action):
-        """Class representing the signature-type packaging object."""
-
-        __slots__ = ["hash", "hash_alg", "sig_alg", "cert_ident",
-            "chain_cert_openers"]
-
-        name = "signature"
-        key_attr = "value"
-        ordinality = generic._orderdict[name]
-
-        def __init__(self, data, **attrs):
-                generic.Action.__init__(self, data, **attrs)
-
-                self.hash = None
-                self.chain_cert_openers = []
-
-                try:
-                        self.sig_alg, self.hash_alg = self.decompose_sig_alg(
-                            self.attrs["algorithm"])
-                except KeyError:
-                        raise pkg.actions.InvalidActionError(str(self),
-                            _("Missing algorithm attribute"))
-                if "value" not in self.attrs:
-                        self.attrs["value"] = ""
-                if "version" not in self.attrs:
-                        self.attrs["version"] = \
-                            str(generic.Action.sig_version)
-
-        @property
-        def has_payload(self):
-                # If there's a hash, then there's a certificate to deliver
-                # with this action.
-                if not self.hash:
-                        return False
-                return True
-
-        def needsdata(self, orig, pkgplan):
-                return self.has_payload
-
-        @staticmethod
-        def make_opener(pth):
-                def file_opener():
-                        return open(pth, "rb")
-                return file_opener
-
-        def __set_chain_certs_data(self, chain_certs, chash_dir):
-                """Store the information about the certs needed to validate
-                this signature in the signature.
-
-                The 'chain_certs' parameter is a list of paths to certificates.
-                """
-
-                self.chain_cert_openers = []
-
-                # chain_hshes and chain_chshes are dictionaries which map a
-                # given hash or compressed hash attribute to a list of the hash
-                # values for each path in chain_certs.
-                chain_hshes = {}
-                chain_chshes = {}
-                chain_csizes = []
-                chain_sizes = []
-
-                for attr in digest.DEFAULT_CHAIN_ATTRS:
-                        chain_hshes[attr] = []
-                for attr in digest.DEFAULT_CHAIN_CHASH_ATTRS:
-                        chain_chshes[attr] = []
-
-                for pth in chain_certs:
-                        if not os.path.exists(pth):
-                                raise pkg.actions.ActionDataError(
-                                    _("No such file: '{0}'.").format(pth),
-                                    path=pth)
-                        elif os.path.isdir(pth):
-                                raise pkg.actions.ActionDataError(
-                                    _("'{0}' is not a file.").format(pth),
-                                    path=pth)
-                        file_opener = self.make_opener(pth)
-                        self.chain_cert_openers.append(file_opener)
-                        self.attrs.setdefault("chain.sizes", [])
-                        self.attrs.setdefault("chain.csizes", [])
-
-                        try:
-                                fs = os.stat(pth)
-                                chain_sizes.append(str(fs.st_size))
-                        except EnvironmentError as e:
-                                raise pkg.actions.ActionDataError(e, path=pth)
-                        # misc.get_data_digest takes care of closing the file
-                        # that's opened below.
-                        with file_opener() as fh:
-                                hshes, data = misc.get_data_digest(fh,
-                                    length=fs.st_size, return_content=True,
-                                    hash_attrs=digest.DEFAULT_CHAIN_ATTRS,
-                                    hash_algs=digest.CHAIN_ALGS)
-
-                        for attr in hshes:
-                                chain_hshes[attr].append(hshes[attr])
-
-                        # We need a filename to use for the uncompressed chain
-                        # cert, so get the preferred chain hash value from the
-                        # chain_hshes
-                        alg = digest.PREFERRED_HASH
-                        if alg == "sha1":
-                                attr = "chain"
-                        else:
-                                attr = "pkg.chain.{0}".format(alg)
-                        chain_val = hshes.get(attr)
-
-                        csize, chashes = misc.compute_compressed_attrs(
-                            chain_val, None, data, fs.st_size, chash_dir,
-                            chash_attrs=digest.DEFAULT_CHAIN_CHASH_ATTRS,
-                            chash_algs=digest.CHAIN_CHASH_ALGS)
-
-                        chain_csizes.append(csize)
-                        for attr in chashes:
-                                chain_chshes[attr].append(chashes[attr])
-
-                # Remove any unused hash attributes.
-                for cattrs in (chain_hshes, chain_chshes):
-                        for attr in list(cattrs.keys()):
-                                if not cattrs[attr]:
-                                        cattrs.pop(attr, None)
-
-                if chain_hshes:
-                        # These attributes are stored as a single value with
-                        # spaces in it rather than multiple values to ensure
-                        # the ordering remains consistent.
-                        self.attrs["chain.sizes"] = " ".join(chain_sizes)
-                        self.attrs["chain.csizes"] = " ".join(chain_csizes)
-
-                        for attr in digest.DEFAULT_CHAIN_ATTRS:
-                                self.attrs[attr] = " ".join(chain_hshes[attr])
-                        for attr in digest.DEFAULT_CHAIN_CHASH_ATTRS:
-                                self.attrs[attr] = " ".join(chain_chshes[attr])
-
-        def __get_hash_by_name(self, name):
-                """Get the cryptopgraphy Hash() class based on the OpenSSL
-                algorithm name."""
-                global hash_registry
-
-                for h in hash_registry:
-                        if h.name == name:
-                                return h
-
-        def get_size(self):
-                res = generic.Action.get_size(self)
-                for s in self.attrs.get("chain.sizes", "").split():
-                        res += int(s)
-                return res
-
-        def get_action_chain_csize(self):
-                res = 0
-                for s in self.attrs.get("chain.csizes", "").split():
-                        res += int(s)
-                return res
-
-        def get_chain_csize(self, chain):
-                # The length of 'chain' is also going to be the length
-                # of pkg.chain.<hash alg>, so there's no need to look for
-                # other hash attributes here.
-                for c, s in zip(self.attrs.get("chain", "").split(),
-                    self.attrs.get("chain.csizes", "").split()):
-                        if c == chain:
-                                return int(s)
-                return None
-
-        def get_chain_size(self, chain):
-                for c, s in zip(self.attrs.get("chain", "").split(),
-                    self.attrs.get("chain.sizes", "").split()):
-                        if c == chain:
-                                return int(s)
-                return None
-
-        def sig_str(self, a, version):
-                """Create a stable string representation of an action that
-                is deterministic in its creation.  If creating a string from an
-                action is non-deterministic, then manifest signing cannot work.
-
-                The parameter 'a' is the signature action that's going to use
-                the string produced.  It's needed for the signature string
-                action, and is here to keep the method signature the same.
-                """
-
-                # Any changes to this function mean Action.sig_version must be
-                # incremented.
-
-                if version != generic.Action.sig_version:
-                        raise apx.UnsupportedSignatureVersion(version, sig=self)
-                # Signature actions don't sign other signature actions.  So if
-                # the action that's doing the signing isn't ourself, return
-                # nothing.
-                if str(a) != str(self):
-                        return None
-
-                # It's necessary to sign the action as the client will see it,
-                # post publication.  To do that, it's necessary to simulate the
-                # publication process on a copy of the action, converting
-                # paths to hashes and adding size information.
-                tmp_a = SignatureAction(None, **self.attrs)
-                # The signature action can't sign the value of the value
-                # attribute, but it can sign that attribute's name.
-                tmp_a.attrs["value"] = ""
-                if hasattr(self.data, "__call__"):
-                        size = int(self.attrs.get("pkg.size", 0))
-                        tmp_dir = tempfile.mkdtemp()
-                        with self.data() as fh:
-                                hashes, data = misc.get_data_digest(fh,
-                                    size, return_content=True,
-                                    hash_attrs=digest.DEFAULT_HASH_ATTRS,
-                                    hash_algs=digest.HASH_ALGS)
-                                tmp_a.attrs.update(hashes)
-                                # "hash" is special since it shouldn't appear in
-                                # the action attributes, it gets set as a member
-                                # instead.
-                                if "hash" in tmp_a.attrs:
-                                        tmp_a.hash = tmp_a.attrs["hash"]
-                                        del tmp_a.attrs["hash"]
-
-                        # The use of self.hash here is just to point to a
-                        # filename, the type of hash used for self.hash is
-                        # irrelevant. Note that our use of self.hash for the
-                        # basename will need to be modified when we finally move
-                        # off SHA-1 hashes.
-                        csize, chashes = misc.compute_compressed_attrs(
-                            os.path.basename(self.hash), self.hash, data, size,
-                            tmp_dir)
-                        shutil.rmtree(tmp_dir)
-                        tmp_a.attrs["pkg.csize"] = csize
-                        for attr in chashes:
-                                tmp_a.attrs[attr] = chashes[attr]
-                elif self.hash:
-                        tmp_a.hash = self.hash
-                        for attr in digest.DEFAULT_HASH_ATTRS:
-                                if attr in self.attrs:
-                                        tmp_a.attrs[attr] = self.attrs[attr]
-
-                csizes = []
-                chain_hashes = {}
-                chain_chashes = {}
-                for attr in digest.DEFAULT_CHAIN_ATTRS:
-                        chain_hashes[attr] = []
-                for attr in digest.DEFAULT_CHAIN_CHASH_ATTRS:
-                        chain_chashes[attr] = []
-
-                sizes = self.attrs.get("chain.sizes", "").split()
-                for i, c in enumerate(self.chain_cert_openers):
-                        size = int(sizes[i])
-                        tmp_dir = tempfile.mkdtemp()
-                        hshes, data = misc.get_data_digest(c(), size,
-                            return_content=True,
-                            hash_attrs=digest.DEFAULT_CHAIN_ATTRS,
-                            hash_algs=digest.CHAIN_ALGS)
-
-                        for attr in hshes:
-                            chain_hashes[attr].append(hshes[attr])
-
-                        csize, chashes = misc.compute_compressed_attrs("tmp",
-                            None, data, size, tmp_dir,
-                            chash_attrs=digest.DEFAULT_CHAIN_CHASH_ATTRS,
-                            chash_algs=digest.CHAIN_CHASH_ALGS)
-                        shutil.rmtree(tmp_dir)
-                        csizes.append(csize)
-                        for attr in chashes:
-                                chain_chashes[attr].append(chashes[attr])
-
-                if chain_hashes:
-                        for attr in digest.DEFAULT_CHAIN_ATTRS:
-                                if chain_hashes[attr]:
-                                        tmp_a.attrs[attr] = " ".join(
-                                            chain_hashes[attr])
-
-                # Now that tmp_a looks like the post-published action, transform
-                # it into a string using the generic sig_str method.
-                return generic.Action.sig_str(tmp_a, tmp_a, version)
-
-        def actions_to_str(self, acts, version):
-                """Transforms a collection of actions into a string that is
-                used to sign those actions."""
-
-                # If a is None, then the action was another signature action so
-                # discard it from the information to be signed.
-                return "\n".join(sorted(
-                    (a for a in
-                     (b.sig_str(self, version) for b in acts)
-                     if a is not None)))
-
-        def retrieve_chain_certs(self, pub):
-                """Retrieve the chain certificates needed to validate this
-                signature."""
-
-                chain_attr, chain_val, hash_func = \
-                    digest.get_least_preferred_hash(self,
-                    hash_type=digest.CHAIN)
-                # We may not have any chain certs for this signature
-                if not chain_val:
-                        return
-                for c in chain_val.split():
-                        pub.get_cert_by_hash(c, only_retrieve=True,
-                            hash_func=hash_func)
-
-        def get_chain_certs(self, least_preferred=False):
-                """Return a list of the chain certificates needed to validate
-                this signature. When retrieving the content from the
-                repository, we use the "least preferred" hash for backwards
-                compatibility, but when verifying the content, we use the
-                "most preferred" hash."""
-
-                if least_preferred:
-                        chain_attr, chain_val, hash_func = \
-                            digest.get_least_preferred_hash(self,
-                            hash_type=digest.CHAIN)
-                else:
-                        chain_attr, chain_val, hash_func = \
-                            digest.get_preferred_hash(self,
-                            hash_type=digest.CHAIN)
-                if not chain_val:
-                        return []
-                return chain_val.split()
-
-        def get_chain_certs_chashes(self, least_preferred=False):
-                """Return a list of the chain certificates needed to validate
-                this signature."""
-
-                if least_preferred:
-                        chain_chash_attr, chain_chash_val, hash_func = \
-                            digest.get_least_preferred_hash(self,
-                            hash_type=digest.CHAIN_CHASH)
-                else:
-                        chain_chash_attr, chain_chash_val, hash_func = \
-                            digest.get_preferred_hash(self,
-                            hash_type=digest.CHAIN_CHASH)
-                if not chain_chash_val:
-                        return []
-                return chain_chash_val.split()
-
-        def is_signed(self):
-                """Returns True if this action is signed using a key, instead
-                of simply being a hash.  Since variant tagged signature
-                actions are not handled yet, it also returns False in that
-                case."""
-
-                return self.hash is not None and not self.get_variant_template()
-
-        @staticmethod
-        def decompose_sig_alg(val):
-                """Split the sig_alg attribute up in to something useful."""
-
-                for s in valid_sig_algs:
-                        for h in valid_hash_algs:
-                                t = "{0}-{1}".format(s, h)
-                                if val == t:
-                                        return s, h
-                for h in valid_hash_algs:
-                        if h == val:
-                                return None, h
-                return None, None
-
-        def verify_sig(self, acts, pub, trust_anchors, use_crls,
-            required_names=None):
-                """Try to verify this signature.  It can return True or
-                None.  None means we didn't know how to verify this signature.
-                If we do know how to verify the signature but it doesn't verify,
-                then an exception is raised.
-
-                The 'acts' parameter is the iterable of actions against which
-                to verify the signature.
-
-                The 'pub' parameter is the publisher that published the
-                package this action signed.
-
-                The 'trust_anchors' parameter contains the trust anchors to use
-                when verifying the signature.
-
-                The 'required_names' parameter is a set of strings that must
-                be seen as a CN in the chain of trust for the certificate."""
-
-                ver = int(self.attrs["version"])
-                # If this signature is tagged with variants, if the version is
-                # higher than one we know about, or it uses an unrecognized
-                # hash algorithm, we can't handle it yet.
-                if self.get_variant_template() or \
-                    ver > generic.Action.sig_version or not self.hash_alg:
-                        return None
-                # Turning this into a list makes debugging vastly more
-                # tractable.
-                acts = list(acts)
-                # If self.hash is None, then the signature is storing a hash
-                # of the actions, not a signed value.
-                if self.hash is None:
-                        assert self.sig_alg is None
-                        h = hashlib.new(self.hash_alg)
-                        h.update(misc.force_bytes(self.actions_to_str(
-                            acts, ver)))
-                        computed_hash = h.digest()
-                        # The attrs value is stored in hex so that it's easy
-                        # to read.
-                        if misc.hex_to_binary(self.attrs["value"]) != \
-                            computed_hash:
-                                raise apx.UnverifiedSignature(self,
-                                    _("The signature value did not match the "
-                                    "expected value. action: {0}").format(self))
-                        return True
-                # Verify a signature that's not just a hash.
-                if self.sig_alg is None:
-                        return None
-                # Get the certificate paired with the key which signed this
-                # action.
-                attr, hash_val, hash_func = \
-                    digest.get_least_preferred_hash(self)
-                cert = pub.get_cert_by_hash(hash_val, verify_hash=True,
-                    hash_func=hash_func)
-                # Make sure that the intermediate certificates that are needed
-                # to validate this signature are present.
-                self.retrieve_chain_certs(pub)
-                try:
-                        # This import is placed here to break a circular
-                        # import seen when merge.py is used.
-                        from pkg.client.publisher import CODE_SIGNING_USE
-                        # Verify the certificate whose key created this
-                        # signature action.
-                        pub.verify_chain(cert, trust_anchors, 0, use_crls,
-                            required_names=required_names,
-                            usages=CODE_SIGNING_USE)
-                except apx.SigningException as e:
-                        e.act = self
-                        raise
-                # Check that the certificate verifies against this signature.
-                pub_key = cert.public_key()
-                hhash = self.__get_hash_by_name(self.hash_alg)
-                try:
-                        pub_key.verify(
-                            misc.hex_to_binary(self.attrs["value"]),
-                            misc.force_bytes(self.actions_to_str(acts, ver)),
-                            padding.PKCS1v15(),
-                            hhash())
-                except InvalidSignature:
-                        raise apx.UnverifiedSignature(self,
-                            _("The signature value did not match the expected "
-                            "value."))
-
-                return True
-
-        def set_signature(self, acts, key_path=None, chain_paths=misc.EmptyI,
-            chash_dir=None):
-                """Sets the signature value for this action.
-
-                The 'acts' parameter is the iterable of actions this action
-                should sign.
-
-                The 'key_path' parameter is the path to the file containing the
-                private key which is used to sign the actions.
-
-                The 'chain_paths' parameter is an iterable of paths to
-                certificates which are needed to form the chain of trust from
-                the certificate associated with the key in 'key_path' to one of
-                the CAs for the publisher of the actions.
-
-                The 'chash_dir' parameter is the temporary directory to use
-                while calculating the compressed hashes for chain certs."""
-
-                # Turning this into a list makes debugging vastly more
-                # tractable.
-                acts = list(acts)
-
-                # If key_path is None, then set value to be the hash
-                # of the actions.
-                if key_path is None:
-                        # If no private key is set, then no certificate should
-                        # have been given.
-                        assert self.data is None
-                        h = hashlib.new(self.hash_alg)
-                        h.update(misc.force_bytes(self.actions_to_str(acts,
-                            generic.Action.sig_version)))
-                        self.attrs["value"] = h.hexdigest()
-                else:
-                        # If a private key is used, then the certificate it's
-                        # paired with must be provided.
-                        assert self.data is not None
-                        self.__set_chain_certs_data(chain_paths, chash_dir)
-
-                        try:
-                                with open(key_path, "rb") as f:
-                                        priv_key = serialization.load_pem_private_key(
-                                            f.read(), password=None,
-                                            backend=default_backend())
-                        except ValueError:
-                                raise apx.BadFileFormat(_("{0} was expected to "
-                                    "be a RSA key but could not be read "
-                                    "correctly.").format(key_path))
-
-                        hhash = self.__get_hash_by_name(self.hash_alg)
-                        self.attrs["value"] = misc.binary_to_hex(priv_key.sign(
-                                misc.force_bytes(self.actions_to_str(acts,
-                                    generic.Action.sig_version)),
-                                padding.PKCS1v15(),
-                                hhash()
-                        ))
-
-        def generate_indices(self):
-                """Generates the indices needed by the search dictionary.  See
-                generic.py for a more detailed explanation."""
-
-                res = []
-                if self.hash is not None:
-                        res.append((self.name, "certificate", self.hash,
-                            self.hash))
-                res.append((self.name, "algorithm",
-                    self.attrs["algorithm"], self.attrs["algorithm"]))
-                res.append((self.name, "signature", self.attrs["value"],
-                    self.attrs["value"]))
-                for attr in digest.DEFAULT_HASH_ATTRS:
-                        # We already have an index entry for self.hash;
-                        # we only want hash attributes other than "hash".
-                        hash = self.attrs.get(attr)
-                        if attr != "hash" and hash is not None:
-                                res.append((self.name, attr, hash, None))
-                return res
-
-        def identical(self, other, hsh):
-                """Check whether another action is identical to this
-                signature."""
-                # Only signature actions can be identical to other signature
-                # actions.
-                if self.name != other.name:
-                        return False
-                # If the code signing certs are identical, the more checking is
-                # needed.
-                # Determine if we share any hash attribute values with the other
-                # action.
-                matching_hash_attrs = set()
-                for attr in digest.DEFAULT_HASH_ATTRS:
-                        if attr == "hash":
-                                # we deal with the 'hash' member later
-                                continue
-                        if attr in self.attrs and attr in other.attrs and \
-                            self.attrs[attr] == other.attrs[attr] and \
-                            self.assrs[attr]:
-                                    matching_hash_attrs.add(attr)
-                        if hsh and hsh == other.attrs.get(attr):
-                                # Technically 'hsh' isn't a hash attr, it's
-                                # a hash attr value, but that's enough for us
-                                # to consider it as potentially identical.
-                                matching_hash_attrs.add(hsh)
-
-                if hsh == other.hash or self.hash == other.hash or \
-                    matching_hash_attrs:
-                        # If the algorithms are using different algorithms or
-                        # have different versions, then they're not identical.
-                        if self.attrs["algorithm"]  != \
-                            other.attrs["algorithm"] or \
-                            self.attrs["version"] != other.attrs["version"]:
-                                return False
-                        # If the values are the same, then they're identical.
-                        if self.attrs["value"] == other.attrs["value"]:
-                                return True
-                        raise apx.AlmostIdentical(hsh,
-                            self.attrs["algorithm"], self.attrs["version"])
+    """Class representing the signature-type packaging object."""
+
+    __slots__ = [
+        "hash",
+        "hash_alg",
+        "sig_alg",
+        "cert_ident",
+        "chain_cert_openers",
+    ]
+
+    name = "signature"
+    key_attr = "value"
+    ordinality = generic._orderdict[name]
+
+    def __init__(self, data, **attrs):
+        generic.Action.__init__(self, data, **attrs)
+
+        self.hash = None
+        self.chain_cert_openers = []
+
+        try:
+            self.sig_alg, self.hash_alg = self.decompose_sig_alg(
+                self.attrs["algorithm"]
+            )
+        except KeyError:
+            raise pkg.actions.InvalidActionError(
+                str(self), _("Missing algorithm attribute")
+            )
+        if "value" not in self.attrs:
+            self.attrs["value"] = ""
+        if "version" not in self.attrs:
+            self.attrs["version"] = str(generic.Action.sig_version)
+
+    @property
+    def has_payload(self):
+        # If there's a hash, then there's a certificate to deliver
+        # with this action.
+        if not self.hash:
+            return False
+        return True
+
+    def needsdata(self, orig, pkgplan):
+        return self.has_payload
+
+    @staticmethod
+    def make_opener(pth):
+        def file_opener():
+            return open(pth, "rb")
+
+        return file_opener
+
+    def __set_chain_certs_data(self, chain_certs, chash_dir):
+        """Store the information about the certs needed to validate
+        this signature in the signature.
+
+        The 'chain_certs' parameter is a list of paths to certificates.
+        """
+
+        self.chain_cert_openers = []
+
+        # chain_hshes and chain_chshes are dictionaries which map a
+        # given hash or compressed hash attribute to a list of the hash
+        # values for each path in chain_certs.
+        chain_hshes = {}
+        chain_chshes = {}
+        chain_csizes = []
+        chain_sizes = []
+
+        for attr in digest.DEFAULT_CHAIN_ATTRS:
+            chain_hshes[attr] = []
+        for attr in digest.DEFAULT_CHAIN_CHASH_ATTRS:
+            chain_chshes[attr] = []
+
+        for pth in chain_certs:
+            if not os.path.exists(pth):
+                raise pkg.actions.ActionDataError(
+                    _("No such file: '{0}'.").format(pth), path=pth
+                )
+            elif os.path.isdir(pth):
+                raise pkg.actions.ActionDataError(
+                    _("'{0}' is not a file.").format(pth), path=pth
+                )
+            file_opener = self.make_opener(pth)
+            self.chain_cert_openers.append(file_opener)
+            self.attrs.setdefault("chain.sizes", [])
+            self.attrs.setdefault("chain.csizes", [])
+
+            try:
+                fs = os.stat(pth)
+                chain_sizes.append(str(fs.st_size))
+            except EnvironmentError as e:
+                raise pkg.actions.ActionDataError(e, path=pth)
+            # misc.get_data_digest takes care of closing the file
+            # that's opened below.
+            with file_opener() as fh:
+                hshes, data = misc.get_data_digest(
+                    fh,
+                    length=fs.st_size,
+                    return_content=True,
+                    hash_attrs=digest.DEFAULT_CHAIN_ATTRS,
+                    hash_algs=digest.CHAIN_ALGS,
+                )
+
+            for attr in hshes:
+                chain_hshes[attr].append(hshes[attr])
+
+            # We need a filename to use for the uncompressed chain
+            # cert, so get the preferred chain hash value from the
+            # chain_hshes
+            alg = digest.PREFERRED_HASH
+            if alg == "sha1":
+                attr = "chain"
+            else:
+                attr = "pkg.chain.{0}".format(alg)
+            chain_val = hshes.get(attr)
+
+            csize, chashes = misc.compute_compressed_attrs(
+                chain_val,
+                None,
+                data,
+                fs.st_size,
+                chash_dir,
+                chash_attrs=digest.DEFAULT_CHAIN_CHASH_ATTRS,
+                chash_algs=digest.CHAIN_CHASH_ALGS,
+            )
+
+            chain_csizes.append(csize)
+            for attr in chashes:
+                chain_chshes[attr].append(chashes[attr])
+
+        # Remove any unused hash attributes.
+        for cattrs in (chain_hshes, chain_chshes):
+            for attr in list(cattrs.keys()):
+                if not cattrs[attr]:
+                    cattrs.pop(attr, None)
+
+        if chain_hshes:
+            # These attributes are stored as a single value with
+            # spaces in it rather than multiple values to ensure
+            # the ordering remains consistent.
+            self.attrs["chain.sizes"] = " ".join(chain_sizes)
+            self.attrs["chain.csizes"] = " ".join(chain_csizes)
+
+            for attr in digest.DEFAULT_CHAIN_ATTRS:
+                self.attrs[attr] = " ".join(chain_hshes[attr])
+            for attr in digest.DEFAULT_CHAIN_CHASH_ATTRS:
+                self.attrs[attr] = " ".join(chain_chshes[attr])
+
+    def __get_hash_by_name(self, name):
+        """Get the cryptopgraphy Hash() class based on the OpenSSL
+        algorithm name."""
+        global hash_registry
+
+        for h in hash_registry:
+            if h.name == name:
+                return h
+
+    def get_size(self):
+        res = generic.Action.get_size(self)
+        for s in self.attrs.get("chain.sizes", "").split():
+            res += int(s)
+        return res
+
+    def get_action_chain_csize(self):
+        res = 0
+        for s in self.attrs.get("chain.csizes", "").split():
+            res += int(s)
+        return res
+
+    def get_chain_csize(self, chain):
+        # The length of 'chain' is also going to be the length
+        # of pkg.chain.<hash alg>, so there's no need to look for
+        # other hash attributes here.
+        for c, s in zip(
+            self.attrs.get("chain", "").split(),
+            self.attrs.get("chain.csizes", "").split(),
+        ):
+            if c == chain:
+                return int(s)
+        return None
+
+    def get_chain_size(self, chain):
+        for c, s in zip(
+            self.attrs.get("chain", "").split(),
+            self.attrs.get("chain.sizes", "").split(),
+        ):
+            if c == chain:
+                return int(s)
+        return None
+
+    def sig_str(self, a, version):
+        """Create a stable string representation of an action that
+        is deterministic in its creation.  If creating a string from an
+        action is non-deterministic, then manifest signing cannot work.
+
+        The parameter 'a' is the signature action that's going to use
+        the string produced.  It's needed for the signature string
+        action, and is here to keep the method signature the same.
+        """
+
+        # Any changes to this function mean Action.sig_version must be
+        # incremented.
+
+        if version != generic.Action.sig_version:
+            raise apx.UnsupportedSignatureVersion(version, sig=self)
+        # Signature actions don't sign other signature actions.  So if
+        # the action that's doing the signing isn't ourself, return
+        # nothing.
+        if str(a) != str(self):
+            return None
+
+        # It's necessary to sign the action as the client will see it,
+        # post publication.  To do that, it's necessary to simulate the
+        # publication process on a copy of the action, converting
+        # paths to hashes and adding size information.
+        tmp_a = SignatureAction(None, **self.attrs)
+        # The signature action can't sign the value of the value
+        # attribute, but it can sign that attribute's name.
+        tmp_a.attrs["value"] = ""
+        if hasattr(self.data, "__call__"):
+            size = int(self.attrs.get("pkg.size", 0))
+            tmp_dir = tempfile.mkdtemp()
+            with self.data() as fh:
+                hashes, data = misc.get_data_digest(
+                    fh,
+                    size,
+                    return_content=True,
+                    hash_attrs=digest.DEFAULT_HASH_ATTRS,
+                    hash_algs=digest.HASH_ALGS,
+                )
+                tmp_a.attrs.update(hashes)
+                # "hash" is special since it shouldn't appear in
+                # the action attributes, it gets set as a member
+                # instead.
+                if "hash" in tmp_a.attrs:
+                    tmp_a.hash = tmp_a.attrs["hash"]
+                    del tmp_a.attrs["hash"]
+
+            # The use of self.hash here is just to point to a
+            # filename, the type of hash used for self.hash is
+            # irrelevant. Note that our use of self.hash for the
+            # basename will need to be modified when we finally move
+            # off SHA-1 hashes.
+            csize, chashes = misc.compute_compressed_attrs(
+                os.path.basename(self.hash), self.hash, data, size, tmp_dir
+            )
+            shutil.rmtree(tmp_dir)
+            tmp_a.attrs["pkg.csize"] = csize
+            for attr in chashes:
+                tmp_a.attrs[attr] = chashes[attr]
+        elif self.hash:
+            tmp_a.hash = self.hash
+            for attr in digest.DEFAULT_HASH_ATTRS:
+                if attr in self.attrs:
+                    tmp_a.attrs[attr] = self.attrs[attr]
+
+        csizes = []
+        chain_hashes = {}
+        chain_chashes = {}
+        for attr in digest.DEFAULT_CHAIN_ATTRS:
+            chain_hashes[attr] = []
+        for attr in digest.DEFAULT_CHAIN_CHASH_ATTRS:
+            chain_chashes[attr] = []
+
+        sizes = self.attrs.get("chain.sizes", "").split()
+        for i, c in enumerate(self.chain_cert_openers):
+            size = int(sizes[i])
+            tmp_dir = tempfile.mkdtemp()
+            hshes, data = misc.get_data_digest(
+                c(),
+                size,
+                return_content=True,
+                hash_attrs=digest.DEFAULT_CHAIN_ATTRS,
+                hash_algs=digest.CHAIN_ALGS,
+            )
+
+            for attr in hshes:
+                chain_hashes[attr].append(hshes[attr])
+
+            csize, chashes = misc.compute_compressed_attrs(
+                "tmp",
+                None,
+                data,
+                size,
+                tmp_dir,
+                chash_attrs=digest.DEFAULT_CHAIN_CHASH_ATTRS,
+                chash_algs=digest.CHAIN_CHASH_ALGS,
+            )
+            shutil.rmtree(tmp_dir)
+            csizes.append(csize)
+            for attr in chashes:
+                chain_chashes[attr].append(chashes[attr])
+
+        if chain_hashes:
+            for attr in digest.DEFAULT_CHAIN_ATTRS:
+                if chain_hashes[attr]:
+                    tmp_a.attrs[attr] = " ".join(chain_hashes[attr])
+
+        # Now that tmp_a looks like the post-published action, transform
+        # it into a string using the generic sig_str method.
+        return generic.Action.sig_str(tmp_a, tmp_a, version)
+
+    def actions_to_str(self, acts, version):
+        """Transforms a collection of actions into a string that is
+        used to sign those actions."""
+
+        # If a is None, then the action was another signature action so
+        # discard it from the information to be signed.
+        return "\n".join(
+            sorted(
+                (
+                    a
+                    for a in (b.sig_str(self, version) for b in acts)
+                    if a is not None
+                )
+            )
+        )
+
+    def retrieve_chain_certs(self, pub):
+        """Retrieve the chain certificates needed to validate this
+        signature."""
+
+        chain_attr, chain_val, hash_func = digest.get_least_preferred_hash(
+            self, hash_type=digest.CHAIN
+        )
+        # We may not have any chain certs for this signature
+        if not chain_val:
+            return
+        for c in chain_val.split():
+            pub.get_cert_by_hash(c, only_retrieve=True, hash_func=hash_func)
+
+    def get_chain_certs(self, least_preferred=False):
+        """Return a list of the chain certificates needed to validate
+        this signature. When retrieving the content from the
+        repository, we use the "least preferred" hash for backwards
+        compatibility, but when verifying the content, we use the
+        "most preferred" hash."""
+
+        if least_preferred:
+            chain_attr, chain_val, hash_func = digest.get_least_preferred_hash(
+                self, hash_type=digest.CHAIN
+            )
+        else:
+            chain_attr, chain_val, hash_func = digest.get_preferred_hash(
+                self, hash_type=digest.CHAIN
+            )
+        if not chain_val:
+            return []
+        return chain_val.split()
+
+    def get_chain_certs_chashes(self, least_preferred=False):
+        """Return a list of the chain certificates needed to validate
+        this signature."""
+
+        if least_preferred:
+            (
+                chain_chash_attr,
+                chain_chash_val,
+                hash_func,
+            ) = digest.get_least_preferred_hash(
+                self, hash_type=digest.CHAIN_CHASH
+            )
+        else:
+            (
+                chain_chash_attr,
+                chain_chash_val,
+                hash_func,
+            ) = digest.get_preferred_hash(self, hash_type=digest.CHAIN_CHASH)
+        if not chain_chash_val:
+            return []
+        return chain_chash_val.split()
+
+    def is_signed(self):
+        """Returns True if this action is signed using a key, instead
+        of simply being a hash.  Since variant tagged signature
+        actions are not handled yet, it also returns False in that
+        case."""
+
+        return self.hash is not None and not self.get_variant_template()
+
+    @staticmethod
+    def decompose_sig_alg(val):
+        """Split the sig_alg attribute up in to something useful."""
+
+        for s in valid_sig_algs:
+            for h in valid_hash_algs:
+                t = "{0}-{1}".format(s, h)
+                if val == t:
+                    return s, h
+        for h in valid_hash_algs:
+            if h == val:
+                return None, h
+        return None, None
+
+    def verify_sig(
+        self, acts, pub, trust_anchors, use_crls, required_names=None
+    ):
+        """Try to verify this signature.  It can return True or
+        None.  None means we didn't know how to verify this signature.
+        If we do know how to verify the signature but it doesn't verify,
+        then an exception is raised.
+
+        The 'acts' parameter is the iterable of actions against which
+        to verify the signature.
+
+        The 'pub' parameter is the publisher that published the
+        package this action signed.
+
+        The 'trust_anchors' parameter contains the trust anchors to use
+        when verifying the signature.
+
+        The 'required_names' parameter is a set of strings that must
+        be seen as a CN in the chain of trust for the certificate."""
+
+        ver = int(self.attrs["version"])
+        # If this signature is tagged with variants, if the version is
+        # higher than one we know about, or it uses an unrecognized
+        # hash algorithm, we can't handle it yet.
+        if (
+            self.get_variant_template()
+            or ver > generic.Action.sig_version
+            or not self.hash_alg
+        ):
+            return None
+        # Turning this into a list makes debugging vastly more
+        # tractable.
+        acts = list(acts)
+        # If self.hash is None, then the signature is storing a hash
+        # of the actions, not a signed value.
+        if self.hash is None:
+            assert self.sig_alg is None
+            h = hashlib.new(self.hash_alg)
+            h.update(misc.force_bytes(self.actions_to_str(acts, ver)))
+            computed_hash = h.digest()
+            # The attrs value is stored in hex so that it's easy
+            # to read.
+            if misc.hex_to_binary(self.attrs["value"]) != computed_hash:
+                raise apx.UnverifiedSignature(
+                    self,
+                    _(
+                        "The signature value did not match the "
+                        "expected value. action: {0}"
+                    ).format(self),
+                )
+            return True
+        # Verify a signature that's not just a hash.
+        if self.sig_alg is None:
+            return None
+        # Get the certificate paired with the key which signed this
+        # action.
+        attr, hash_val, hash_func = digest.get_least_preferred_hash(self)
+        cert = pub.get_cert_by_hash(
+            hash_val, verify_hash=True, hash_func=hash_func
+        )
+        # Make sure that the intermediate certificates that are needed
+        # to validate this signature are present.
+        self.retrieve_chain_certs(pub)
+        try:
+            # This import is placed here to break a circular
+            # import seen when merge.py is used.
+            from pkg.client.publisher import CODE_SIGNING_USE
+
+            # Verify the certificate whose key created this
+            # signature action.
+            pub.verify_chain(
+                cert,
+                trust_anchors,
+                0,
+                use_crls,
+                required_names=required_names,
+                usages=CODE_SIGNING_USE,
+            )
+        except apx.SigningException as e:
+            e.act = self
+            raise
+        # Check that the certificate verifies against this signature.
+        pub_key = cert.public_key()
+        hhash = self.__get_hash_by_name(self.hash_alg)
+        try:
+            pub_key.verify(
+                misc.hex_to_binary(self.attrs["value"]),
+                misc.force_bytes(self.actions_to_str(acts, ver)),
+                padding.PKCS1v15(),
+                hhash(),
+            )
+        except InvalidSignature:
+            raise apx.UnverifiedSignature(
+                self,
+                _("The signature value did not match the expected " "value."),
+            )
+
+        return True
+
+    def set_signature(
+        self, acts, key_path=None, chain_paths=misc.EmptyI, chash_dir=None
+    ):
+        """Sets the signature value for this action.
+
+        The 'acts' parameter is the iterable of actions this action
+        should sign.
+
+        The 'key_path' parameter is the path to the file containing the
+        private key which is used to sign the actions.
+
+        The 'chain_paths' parameter is an iterable of paths to
+        certificates which are needed to form the chain of trust from
+        the certificate associated with the key in 'key_path' to one of
+        the CAs for the publisher of the actions.
+
+        The 'chash_dir' parameter is the temporary directory to use
+        while calculating the compressed hashes for chain certs."""
+
+        # Turning this into a list makes debugging vastly more
+        # tractable.
+        acts = list(acts)
+
+        # If key_path is None, then set value to be the hash
+        # of the actions.
+        if key_path is None:
+            # If no private key is set, then no certificate should
+            # have been given.
+            assert self.data is None
+            h = hashlib.new(self.hash_alg)
+            h.update(
+                misc.force_bytes(
+                    self.actions_to_str(acts, generic.Action.sig_version)
+                )
+            )
+            self.attrs["value"] = h.hexdigest()
+        else:
+            # If a private key is used, then the certificate it's
+            # paired with must be provided.
+            assert self.data is not None
+            self.__set_chain_certs_data(chain_paths, chash_dir)
+
+            try:
+                with open(key_path, "rb") as f:
+                    priv_key = serialization.load_pem_private_key(
+                        f.read(), password=None, backend=default_backend()
+                    )
+            except ValueError:
+                raise apx.BadFileFormat(
+                    _(
+                        "{0} was expected to "
+                        "be a RSA key but could not be read "
+                        "correctly."
+                    ).format(key_path)
+                )
+
+            hhash = self.__get_hash_by_name(self.hash_alg)
+            self.attrs["value"] = misc.binary_to_hex(
+                priv_key.sign(
+                    misc.force_bytes(
+                        self.actions_to_str(acts, generic.Action.sig_version)
+                    ),
+                    padding.PKCS1v15(),
+                    hhash(),
+                )
+            )
+
+    def generate_indices(self):
+        """Generates the indices needed by the search dictionary.  See
+        generic.py for a more detailed explanation."""
+
+        res = []
+        if self.hash is not None:
+            res.append((self.name, "certificate", self.hash, self.hash))
+        res.append(
+            (
+                self.name,
+                "algorithm",
+                self.attrs["algorithm"],
+                self.attrs["algorithm"],
+            )
+        )
+        res.append(
+            (self.name, "signature", self.attrs["value"], self.attrs["value"])
+        )
+        for attr in digest.DEFAULT_HASH_ATTRS:
+            # We already have an index entry for self.hash;
+            # we only want hash attributes other than "hash".
+            hash = self.attrs.get(attr)
+            if attr != "hash" and hash is not None:
+                res.append((self.name, attr, hash, None))
+        return res
+
+    def identical(self, other, hsh):
+        """Check whether another action is identical to this
+        signature."""
+        # Only signature actions can be identical to other signature
+        # actions.
+        if self.name != other.name:
+            return False
+        # If the code signing certs are identical, the more checking is
+        # needed.
+        # Determine if we share any hash attribute values with the other
+        # action.
+        matching_hash_attrs = set()
+        for attr in digest.DEFAULT_HASH_ATTRS:
+            if attr == "hash":
+                # we deal with the 'hash' member later
+                continue
+            if (
+                attr in self.attrs
+                and attr in other.attrs
+                and self.attrs[attr] == other.attrs[attr]
+                and self.assrs[attr]
+            ):
+                matching_hash_attrs.add(attr)
+            if hsh and hsh == other.attrs.get(attr):
+                # Technically 'hsh' isn't a hash attr, it's
+                # a hash attr value, but that's enough for us
+                # to consider it as potentially identical.
+                matching_hash_attrs.add(hsh)
+
+        if hsh == other.hash or self.hash == other.hash or matching_hash_attrs:
+            # If the algorithms are using different algorithms or
+            # have different versions, then they're not identical.
+            if (
+                self.attrs["algorithm"] != other.attrs["algorithm"]
+                or self.attrs["version"] != other.attrs["version"]
+            ):
                 return False
+            # If the values are the same, then they're identical.
+            if self.attrs["value"] == other.attrs["value"]:
+                return True
+            raise apx.AlmostIdentical(
+                hsh, self.attrs["algorithm"], self.attrs["version"]
+            )
+        return False
 
-        def validate(self, fmri=None):
-                """Performs additional validation of action attributes that
-                for performance or other reasons cannot or should not be done
-                during Action object creation.  An ActionError exception (or
-                subclass of) will be raised if any attributes are not valid.
-                This is primarily intended for use during publication or during
-                error handling to provide additional diagonostics.
+    def validate(self, fmri=None):
+        """Performs additional validation of action attributes that
+        for performance or other reasons cannot or should not be done
+        during Action object creation.  An ActionError exception (or
+        subclass of) will be raised if any attributes are not valid.
+        This is primarily intended for use during publication or during
+        error handling to provide additional diagonostics.
 
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action.
-                """
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action.
+        """
 
-                # 'value' can only be required at publication time since signing
-                # relies on the ability to construct actions without one despite
-                # the fact that it is the key attribute.
-                generic.Action._validate(self, fmri=fmri,
-                    numeric_attrs=("pkg.csize", "pkg.size"),
-                    required_attrs=("value",), single_attrs=("algorithm",
-                    "chash", "value"))
+        # 'value' can only be required at publication time since signing
+        # relies on the ability to construct actions without one despite
+        # the fact that it is the key attribute.
+        generic.Action._validate(
+            self,
+            fmri=fmri,
+            numeric_attrs=("pkg.csize", "pkg.size"),
+            required_attrs=("value",),
+            single_attrs=("algorithm", "chash", "value"),
+        )
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/unknown.py
+++ b/src/modules/actions/unknown.py
@@ -33,13 +33,15 @@ object it is.  No datastreams or attributes aside from a path are stored."""
 
 from . import generic
 
+
 class UnknownAction(generic.Action):
-        """Class representing a unknown type of packaging object."""
+    """Class representing a unknown type of packaging object."""
 
-        __slots__ = []
+    __slots__ = []
 
-        name = "unknown"
-        ordinality = generic._orderdict[name]
+    name = "unknown"
+    ordinality = generic._orderdict[name]
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/actions/user.py
+++ b/src/modules/actions/user.py
@@ -31,347 +31,386 @@ packaging object.  This contains the attributes necessary to create
 a new user."""
 
 from . import generic
+
 try:
-        from pkg.cfgfiles import *
-        have_cfgfiles = True
+    from pkg.cfgfiles import *
+
+    have_cfgfiles = True
 except ImportError:
-        have_cfgfiles = False
+    have_cfgfiles = False
 
 import pkg.client.api_errors as apx
 import pkg.actions
 
+
 class UserAction(generic.Action):
-        """Class representing a user packaging object."""
+    """Class representing a user packaging object."""
 
-        __slots__ = []
+    __slots__ = []
 
-        name = "user"
-        key_attr = "username"
-        globally_identical = True
-        ordinality = generic._orderdict[name]
+    name = "user"
+    key_attr = "username"
+    globally_identical = True
+    ordinality = generic._orderdict[name]
 
-        # if these values are different on disk than in action
-        # prefer on-disk version for actual login accounts (root)
-        use_existing_attrs = [ "password", "lastchg", "min",
-                               "max", "expire", "flag",
-                               "warn", "inactive"]
-        mutable_passwords = frozenset(("UP", ""))
+    # if these values are different on disk than in action
+    # prefer on-disk version for actual login accounts (root)
+    use_existing_attrs = [
+        "password",
+        "lastchg",
+        "min",
+        "max",
+        "expire",
+        "flag",
+        "warn",
+        "inactive",
+    ]
+    mutable_passwords = frozenset(("UP", ""))
 
-        def as_set(self, item):
-                if isinstance(item, list):
-                        return set(item)
-                return set([item])
+    def as_set(self, item):
+        if isinstance(item, list):
+            return set(item)
+        return set([item])
 
-        def merge(self, old_plan, on_disk):
-                """ three way attribute merge between old manifest,
-                what's on disk and new manifest.  For any values
-                on disk that are not in the new plan, use the values
-                on disk.  Use new plan values unless attribute is
-                in self.use_existing_attrs, or if old manifest and
-                on-disk copy match...."""
+    def merge(self, old_plan, on_disk):
+        """three way attribute merge between old manifest,
+        what's on disk and new manifest.  For any values
+        on disk that are not in the new plan, use the values
+        on disk.  Use new plan values unless attribute is
+        in self.use_existing_attrs, or if old manifest and
+        on-disk copy match...."""
 
-                out = self.attrs.copy()
+        out = self.attrs.copy()
 
-                for attr in on_disk:
-                        if (attr in out and
-                            attr not in self.use_existing_attrs) or \
-                            (attr in old_plan and
-                            old_plan[attr] == on_disk[attr]):
-                                continue
+        for attr in on_disk:
+            if (attr in out and attr not in self.use_existing_attrs) or (
+                attr in old_plan and old_plan[attr] == on_disk[attr]
+            ):
+                continue
 
-                        # preserve UID if not specified explicitly
-                        if attr == "uid" and attr not in out:
-                                out[attr] = on_disk[attr]
-                                continue
-                        
-                        # prefer manifest version if not mutable password
-                        if attr == "password" and \
-                           out[attr] not in self.mutable_passwords:
-                                continue
+            # preserve UID if not specified explicitly
+            if attr == "uid" and attr not in out:
+                out[attr] = on_disk[attr]
+                continue
 
-                        # Only prefer on-disk entries if password is
-                        # user-settable (e.g. '' or UP).
-                        if "password" not in out or out["password"] not in \
-                           self.mutable_passwords:
-                                continue
+            # prefer manifest version if not mutable password
+            if attr == "password" and out[attr] not in self.mutable_passwords:
+                continue
 
-                        if attr != "group-list":
-                                out[attr] = on_disk[attr]
-                        else:
-                                out[attr] = list(
-                                    self.as_set(out.get(attr, [])) |
-                                    self.as_set(on_disk[attr]))
-                return out
+            # Only prefer on-disk entries if password is
+            # user-settable (e.g. '' or UP).
+            if (
+                "password" not in out
+                or out["password"] not in self.mutable_passwords
+            ):
+                continue
 
-        def readstate(self, image, username, lock=False):
-                """read state of user from files.  May raise KeyError"""
-                root = image.get_root()
-                pw = PasswordFile(root, lock)
-                gr = GroupFile(image)
-                ftp = FtpusersFile(root)
-
-                username = self.attrs["username"]
-
-                cur_attrs = pw.getuser(username)
-                if "gid" in cur_attrs:
-                        cur_attrs["group"] = \
-                            image.get_name_by_gid(int(cur_attrs["gid"]))
-
-                grps = gr.getgroups(username)
-                if grps:
-                        cur_attrs["group-list"] = grps
-
-                cur_attrs["ftpuser"] = str(ftp.getuser(username)).lower()
-
-                return (pw, gr, ftp, cur_attrs)
-
-
-        def install(self, pkgplan, orig, retry=False):
-                """client-side method that adds the user...
-                   update any attrs that changed from orig
-                   unless the on-disk stuff was changed"""
-
-                if not have_cfgfiles:
-                        # The user action is ignored if cfgfiles is not
-                        # available.
-                        return
-
-                username = self.attrs["username"]
-
-                try:
-                        pw, gr, ftp, cur_attrs = \
-                            self.readstate(pkgplan.image, username, lock=True)
-
-                        self.attrs["gid"] = str(pkgplan.image.get_group_by_name(
-                            self.attrs["group"]))
-
-                        orig_attrs = {}
-                        default_attrs = pw.getdefaultvalues()
-                        if orig:
-                                # Grab default values from files, extend by
-                                # specifics from original manifest for
-                                # comparisons sake.
-                                orig_attrs.update(default_attrs)
-                                orig_attrs["group-list"] = []
-                                orig_attrs["ftpuser"] = "true"
-                                orig_attrs.update(orig.attrs)
-                        else:
-                                # If we're installing a user for the first time,
-                                # we want to override whatever value might be
-                                # represented by the presence or absence of the
-                                # user in the ftpusers file.  Remove the value
-                                # from the representation of the file so that
-                                # the new value takes precedence in the merge.
-                                del cur_attrs["ftpuser"]
-
-                        # add default values to new attrs if not present
-                        for attr in default_attrs:
-                                if attr not in self.attrs:
-                                        self.attrs[attr] = default_attrs[attr]
-
-                        self.attrs["group-list"] = self.attrlist("group-list")
-                        final_attrs = self.merge(orig_attrs, cur_attrs)
-
-                        pw.setvalue(final_attrs)
-
-                        if "group-list" in final_attrs:
-                                gr.setgroups(username,
-                                    final_attrs["group-list"])
-
-                        ftp.setuser(username,
-                            final_attrs.get("ftpuser", "true") == "true")
-
-                        pw.writefile()
-                        gr.writefile()
-                        ftp.writefile()
-                except EnvironmentError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
-                        # If we're in the postinstall phase and the files
-                        # *still* aren't there, bail gracefully.
-                        if retry:
-                                txt = _("User cannot be installed without user "
-                                    "database files present.")
-                                raise apx.ActionExecutionError(self, error=e,
-                                    details=txt, fmri=pkgplan.destination_fmri)
-                        img = pkgplan.image
-                        img._users.add(self)
-                        if "uid" in self.attrs:
-                                img._usersbyname[self.attrs["username"]] = \
-                                    int(self.attrs["uid"])
-                        raise pkg.actions.ActionRetry(self)
-                except KeyError as e:
-                        # cannot find group
-                        self.validate() # should raise error if no group in action
-                        txt = _("{group} is an unknown or invalid group").format(
-                            group=self.attrs.get("group", "None"))
-                        raise apx.ActionExecutionError(self,
-                            details=txt, fmri=pkgplan.destination_fmri)
-
-                finally:
-                        if "pw" in locals():
-                                pw.unlock()
-
-        def retry(self, pkgplan, orig):
-                users = pkgplan.image._users
-                if users:
-                        assert self in users
-                        self.install(pkgplan, orig, retry=True)
-
-        def verify(self, img, **args):
-                """Returns a tuple of lists of the form (errors, warnings,
-                info).  The error list will be empty if the action has been
-                correctly installed in the given image."""
-
-                errors = []
-                warnings = []
-                info = []
-
-                if not have_cfgfiles:
-                        # The user action is ignored if cfgfiles is not
-                        # available.
-                        return errors, warnings, info
-
-                username = self.attrs["username"]
-
-                try:
-                        pw, gr, ftp, cur_attrs = self.readstate(img, username)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                errors.append(_("Skipping: Permission denied"))
-                        else:
-                                errors.append(_("Unexpected Error: {0}").format(e))
-                        return errors, warnings, info
-                except KeyError as e:
-                        errors.append(_("{group} is an unknown or invalid group").format(
-                            group=self.attrs.get("group", "None")))
-                        return errors, warnings, info
-
-                if "group-list" in self.attrs:
-                        self.attrs["group-list"] = \
-                            sorted(self.attrlist("group-list"))
-
-                # Get the default values if they're non-empty
-                pwdefval = dict((
-                    (k, v)
-                    for k, v in six.iteritems(pw.getdefaultvalues())
-                    if v != ""
-                ))
-
-                # Certain defaults are dynamic, so we need to ignore what's on
-                # disk
-                if "gid" not in self.attrs:
-                        cur_attrs["gid"] = ""
-                if "uid" not in self.attrs:
-                        cur_attrs["uid"] = ""
-                if "lastchg" not in self.attrs:
-                        cur_attrs["lastchg"] = ""
-                if "login-shell" not in self.attrs:
-                        cur_attrs["login-shell"] = ""
-
-                pwdefval["ftpuser"] = "true"
-                should_be = pwdefval.copy()
-                should_be.update(self.attrs)
-
-                # ignore changes in certain fields if password is
-                # mutable; this indicates that this account is used
-                # by a human and logins, timeouts, etc. are changable.
-                if should_be["password"] in self.mutable_passwords:
-                        for attr in self.use_existing_attrs:
-                                if attr in should_be:
-                                        cur_attrs[attr] = should_be[attr]
-                                else:
-                                        if attr in cur_attrs:
-                                                del cur_attrs[attr]
-
-                if "shell-change-ok" in self.attrs:
-                        del should_be["shell-change-ok"]
-                        if self.attrs["shell-change-ok"].lower() == "true":
-                                cur_attrs["login-shell"] = should_be["login-shell"]
-
-                # always ignore flag
-                if "flag" in cur_attrs:
-                        del cur_attrs["flag"]
-                # Note where attributes are missing
-                for k in should_be:
-                        cur_attrs.setdefault(k, "<missing>")
-                # Note where attributes should be empty
-                for k in cur_attrs:
-                        if cur_attrs[k]:
-                                should_be.setdefault(k, "<empty>")
-
-                errors.extend(
-                    _("{entry}: '{found}' should be '{expected}'").format(
-                        entry=a, found=cur_attrs[a],
-                        expected=should_be[a])
-                    for a in should_be
-                    if cur_attrs[a] != should_be[a]
+            if attr != "group-list":
+                out[attr] = on_disk[attr]
+            else:
+                out[attr] = list(
+                    self.as_set(out.get(attr, [])) | self.as_set(on_disk[attr])
                 )
-                return errors, warnings, info
+        return out
 
-        def remove(self, pkgplan):
-                """client-side method that removes this user"""
-                if not have_cfgfiles:
-                        # The user action is ignored if cfgfiles is not
-                        # available.
-                        return
+    def readstate(self, image, username, lock=False):
+        """read state of user from files.  May raise KeyError"""
+        root = image.get_root()
+        pw = PasswordFile(root, lock)
+        gr = GroupFile(image)
+        ftp = FtpusersFile(root)
 
-                root = pkgplan.image.get_root()
-                pw = PasswordFile(root, lock=True)
-                try:
-                        gr = GroupFile(pkgplan.image)
-                        ftp = FtpusersFile(root)
+        username = self.attrs["username"]
 
-                        pw.removevalue(self.attrs)
-                        gr.removeuser(self.attrs["username"])
+        cur_attrs = pw.getuser(username)
+        if "gid" in cur_attrs:
+            cur_attrs["group"] = image.get_name_by_gid(int(cur_attrs["gid"]))
 
-                        # negative logic
-                        ftp.setuser(self.attrs["username"], True)
+        grps = gr.getgroups(username)
+        if grps:
+            cur_attrs["group-list"] = grps
 
-                        pw.writefile()
-                        gr.writefile()
-                        ftp.writefile()
-                except KeyError as e:
-                        # Already gone; don't care.
-                        if e.args[0] != (self.attrs["username"],):
-                                raise
-                finally:
-                        pw.unlock()
+        cur_attrs["ftpuser"] = str(ftp.getuser(username)).lower()
 
-        def generate_indices(self):
-                """Generates the indices needed by the search dictionary.  See
-                generic.py for a more detailed explanation."""
+        return (pw, gr, ftp, cur_attrs)
 
-                return [("user", "name", self.attrs["username"], None)]
+    def install(self, pkgplan, orig, retry=False):
+        """client-side method that adds the user...
+        update any attrs that changed from orig
+        unless the on-disk stuff was changed"""
 
-        def validate(self, fmri=None):
-                """Performs additional validation of action attributes that
-                for performance or other reasons cannot or should not be done
-                during Action object creation.  An ActionError exception (or
-                subclass of) will be raised if any attributes are not valid.
-                This is primarily intended for use during publication or during
-                error handling to provide additional diagonostics.
+        if not have_cfgfiles:
+            # The user action is ignored if cfgfiles is not
+            # available.
+            return
 
-                'fmri' is an optional package FMRI (object or string) indicating
-                what package contained this action.
-                """
+        username = self.attrs["username"]
 
-                generic.Action._validate(self, fmri=fmri,
-                    numeric_attrs=("uid", "lastchg", "min", "max", "warn",
-                    "inactive","expire", "flag"), single_attrs=("password",
-                    "uid", "group", "gcos-field", "home-dir", "login-shell",
-                    "ftpuser", "lastchg", "min", "max", "warn", "inactive",
-                    "expire", "flag"),
-                    required_attrs=("group",))
+        try:
+            pw, gr, ftp, cur_attrs = self.readstate(
+                pkgplan.image, username, lock=True
+            )
 
-        def compare(self, other):
-                """Arrange for user actions to be installed in uid order.  This
-                will only hold true for actions installed at one time, but that's
-                generally what we need on initial install."""
-                # put unspecified uids at the end
-                a = int(self.attrs.get("uid", 1024))
-                b = int(other.attrs.get("uid", 1024))
-                return (a > b) - (a < b)
+            self.attrs["gid"] = str(
+                pkgplan.image.get_group_by_name(self.attrs["group"])
+            )
+
+            orig_attrs = {}
+            default_attrs = pw.getdefaultvalues()
+            if orig:
+                # Grab default values from files, extend by
+                # specifics from original manifest for
+                # comparisons sake.
+                orig_attrs.update(default_attrs)
+                orig_attrs["group-list"] = []
+                orig_attrs["ftpuser"] = "true"
+                orig_attrs.update(orig.attrs)
+            else:
+                # If we're installing a user for the first time,
+                # we want to override whatever value might be
+                # represented by the presence or absence of the
+                # user in the ftpusers file.  Remove the value
+                # from the representation of the file so that
+                # the new value takes precedence in the merge.
+                del cur_attrs["ftpuser"]
+
+            # add default values to new attrs if not present
+            for attr in default_attrs:
+                if attr not in self.attrs:
+                    self.attrs[attr] = default_attrs[attr]
+
+            self.attrs["group-list"] = self.attrlist("group-list")
+            final_attrs = self.merge(orig_attrs, cur_attrs)
+
+            pw.setvalue(final_attrs)
+
+            if "group-list" in final_attrs:
+                gr.setgroups(username, final_attrs["group-list"])
+
+            ftp.setuser(username, final_attrs.get("ftpuser", "true") == "true")
+
+            pw.writefile()
+            gr.writefile()
+            ftp.writefile()
+        except EnvironmentError as e:
+            if e.errno != errno.ENOENT:
+                raise
+            # If we're in the postinstall phase and the files
+            # *still* aren't there, bail gracefully.
+            if retry:
+                txt = _(
+                    "User cannot be installed without user "
+                    "database files present."
+                )
+                raise apx.ActionExecutionError(
+                    self, error=e, details=txt, fmri=pkgplan.destination_fmri
+                )
+            img = pkgplan.image
+            img._users.add(self)
+            if "uid" in self.attrs:
+                img._usersbyname[self.attrs["username"]] = int(
+                    self.attrs["uid"]
+                )
+            raise pkg.actions.ActionRetry(self)
+        except KeyError as e:
+            # cannot find group
+            self.validate()  # should raise error if no group in action
+            txt = _("{group} is an unknown or invalid group").format(
+                group=self.attrs.get("group", "None")
+            )
+            raise apx.ActionExecutionError(
+                self, details=txt, fmri=pkgplan.destination_fmri
+            )
+
+        finally:
+            if "pw" in locals():
+                pw.unlock()
+
+    def retry(self, pkgplan, orig):
+        users = pkgplan.image._users
+        if users:
+            assert self in users
+            self.install(pkgplan, orig, retry=True)
+
+    def verify(self, img, **args):
+        """Returns a tuple of lists of the form (errors, warnings,
+        info).  The error list will be empty if the action has been
+        correctly installed in the given image."""
+
+        errors = []
+        warnings = []
+        info = []
+
+        if not have_cfgfiles:
+            # The user action is ignored if cfgfiles is not
+            # available.
+            return errors, warnings, info
+
+        username = self.attrs["username"]
+
+        try:
+            pw, gr, ftp, cur_attrs = self.readstate(img, username)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                errors.append(_("Skipping: Permission denied"))
+            else:
+                errors.append(_("Unexpected Error: {0}").format(e))
+            return errors, warnings, info
+        except KeyError as e:
+            errors.append(
+                _("{group} is an unknown or invalid group").format(
+                    group=self.attrs.get("group", "None")
+                )
+            )
+            return errors, warnings, info
+
+        if "group-list" in self.attrs:
+            self.attrs["group-list"] = sorted(self.attrlist("group-list"))
+
+        # Get the default values if they're non-empty
+        pwdefval = dict(
+            ((k, v) for k, v in six.iteritems(pw.getdefaultvalues()) if v != "")
+        )
+
+        # Certain defaults are dynamic, so we need to ignore what's on
+        # disk
+        if "gid" not in self.attrs:
+            cur_attrs["gid"] = ""
+        if "uid" not in self.attrs:
+            cur_attrs["uid"] = ""
+        if "lastchg" not in self.attrs:
+            cur_attrs["lastchg"] = ""
+        if "login-shell" not in self.attrs:
+            cur_attrs["login-shell"] = ""
+
+        pwdefval["ftpuser"] = "true"
+        should_be = pwdefval.copy()
+        should_be.update(self.attrs)
+
+        # ignore changes in certain fields if password is
+        # mutable; this indicates that this account is used
+        # by a human and logins, timeouts, etc. are changable.
+        if should_be["password"] in self.mutable_passwords:
+            for attr in self.use_existing_attrs:
+                if attr in should_be:
+                    cur_attrs[attr] = should_be[attr]
+                else:
+                    if attr in cur_attrs:
+                        del cur_attrs[attr]
+
+        if "shell-change-ok" in self.attrs:
+            del should_be["shell-change-ok"]
+            if self.attrs["shell-change-ok"].lower() == "true":
+                cur_attrs["login-shell"] = should_be["login-shell"]
+
+        # always ignore flag
+        if "flag" in cur_attrs:
+            del cur_attrs["flag"]
+        # Note where attributes are missing
+        for k in should_be:
+            cur_attrs.setdefault(k, "<missing>")
+        # Note where attributes should be empty
+        for k in cur_attrs:
+            if cur_attrs[k]:
+                should_be.setdefault(k, "<empty>")
+
+        errors.extend(
+            _("{entry}: '{found}' should be '{expected}'").format(
+                entry=a, found=cur_attrs[a], expected=should_be[a]
+            )
+            for a in should_be
+            if cur_attrs[a] != should_be[a]
+        )
+        return errors, warnings, info
+
+    def remove(self, pkgplan):
+        """client-side method that removes this user"""
+        if not have_cfgfiles:
+            # The user action is ignored if cfgfiles is not
+            # available.
+            return
+
+        root = pkgplan.image.get_root()
+        pw = PasswordFile(root, lock=True)
+        try:
+            gr = GroupFile(pkgplan.image)
+            ftp = FtpusersFile(root)
+
+            pw.removevalue(self.attrs)
+            gr.removeuser(self.attrs["username"])
+
+            # negative logic
+            ftp.setuser(self.attrs["username"], True)
+
+            pw.writefile()
+            gr.writefile()
+            ftp.writefile()
+        except KeyError as e:
+            # Already gone; don't care.
+            if e.args[0] != (self.attrs["username"],):
+                raise
+        finally:
+            pw.unlock()
+
+    def generate_indices(self):
+        """Generates the indices needed by the search dictionary.  See
+        generic.py for a more detailed explanation."""
+
+        return [("user", "name", self.attrs["username"], None)]
+
+    def validate(self, fmri=None):
+        """Performs additional validation of action attributes that
+        for performance or other reasons cannot or should not be done
+        during Action object creation.  An ActionError exception (or
+        subclass of) will be raised if any attributes are not valid.
+        This is primarily intended for use during publication or during
+        error handling to provide additional diagonostics.
+
+        'fmri' is an optional package FMRI (object or string) indicating
+        what package contained this action.
+        """
+
+        generic.Action._validate(
+            self,
+            fmri=fmri,
+            numeric_attrs=(
+                "uid",
+                "lastchg",
+                "min",
+                "max",
+                "warn",
+                "inactive",
+                "expire",
+                "flag",
+            ),
+            single_attrs=(
+                "password",
+                "uid",
+                "group",
+                "gcos-field",
+                "home-dir",
+                "login-shell",
+                "ftpuser",
+                "lastchg",
+                "min",
+                "max",
+                "warn",
+                "inactive",
+                "expire",
+                "flag",
+            ),
+            required_attrs=("group",),
+        )
+
+    def compare(self, other):
+        """Arrange for user actions to be installed in uid order.  This
+        will only hold true for actions installed at one time, but that's
+        generally what we need on initial install."""
+        # put unspecified uids at the end
+        a = int(self.attrs.get("uid", 1024))
+        b = int(other.attrs.get("uid", 1024))
+        return (a > b) - (a < b)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/altroot.py
+++ b/src/modules/altroot.py
@@ -44,367 +44,379 @@ import stat
 # has native support for all the *at(2) system calls we use below.
 import pkg.syscallat as sat
 
+
 # ---------------------------------------------------------------------------
 # Misc Functions
 #
 def __path_abs_to_relative(path):
-        """Strip the leading '/' from a path using os.path.split()."""
+    """Strip the leading '/' from a path using os.path.split()."""
 
-        path_new = None
-        while True:
-                (path, tail) = os.path.split(path)
-                if not tail:
-                        break
-                if path_new:
-                        path_new = os.path.join(tail, path_new)
-                else:
-                        path_new = tail
-        return path_new
+    path_new = None
+    while True:
+        (path, tail) = os.path.split(path)
+        if not tail:
+            break
+        if path_new:
+            path_new = os.path.join(tail, path_new)
+        else:
+            path_new = tail
+    return path_new
+
 
 def __fd_to_path(fd):
-        """Given a file descriptor return the path to that file descriptor."""
+    """Given a file descriptor return the path to that file descriptor."""
 
-        path = "/proc/{0:d}/path/{1:d}".format(os.getpid(), fd)
-        return os.readlink(path)
+    path = "/proc/{0:d}/path/{1:d}".format(os.getpid(), fd)
+    return os.readlink(path)
+
 
 # ---------------------------------------------------------------------------
 # Functions for accessing files in an alternate image
 #
-def ar_open(root, path, flags,
-    mode=None, create=False, truncate=False):
-        """A function similar to os.open() that ensures that the path
-        we're accessing resides within a specified directory subtree.
+def ar_open(root, path, flags, mode=None, create=False, truncate=False):
+    """A function similar to os.open() that ensures that the path
+    we're accessing resides within a specified directory subtree.
 
-        'root' is a directory that path must reside in.
+    'root' is a directory that path must reside in.
 
-        'path' is a path that is interpreted relative to 'root'.  i.e., 'root'
-        is prepended to path.  'path' can not contain any symbolic links that
-        would cause an access to be redirected outside of 'root'.  If this
-        happens we'll raise an OSError exception with errno set to EREMOTE
+    'path' is a path that is interpreted relative to 'root'.  i.e., 'root'
+    is prepended to path.  'path' can not contain any symbolic links that
+    would cause an access to be redirected outside of 'root'.  If this
+    happens we'll raise an OSError exception with errno set to EREMOTE
 
-        'mode' optional permissions mask used if we create 'path'
+    'mode' optional permissions mask used if we create 'path'
 
-        'create' optional flag indicating if we should create 'path'
+    'create' optional flag indicating if we should create 'path'
 
-        'truncate' optional flag indicating if we should truncate 'path' after
-        opening it."""
+    'truncate' optional flag indicating if we should truncate 'path' after
+    opening it."""
 
-        # all paths must be absolute
-        assert os.path.isabs(root)
+    # all paths must be absolute
+    assert os.path.isabs(root)
 
-        # only allow read/write flags
-        assert (flags & ~(os.O_WRONLY|os.O_RDONLY)) == 0
+    # only allow read/write flags
+    assert (flags & ~(os.O_WRONLY | os.O_RDONLY)) == 0
 
-        # we can't truncate a file unless we open it for writing
-        assert not truncate or (flags & os.O_WRONLY)
+    # we can't truncate a file unless we open it for writing
+    assert not truncate or (flags & os.O_WRONLY)
 
-        # if create is true the user must supply a mode mask
-        assert not create or mode != None
+    # if create is true the user must supply a mode mask
+    assert not create or mode != None
 
-        # we're going to update root and path so prepare an error
-        # message with the existing values now.
-        eremote = _("Path outside alternate root: root={root}, "
-            "path={path}").format(root=root, path=path)
+    # we're going to update root and path so prepare an error
+    # message with the existing values now.
+    eremote = _(
+        "Path outside alternate root: root={root}, " "path={path}"
+    ).format(root=root, path=path)
 
-        # make target into a relative path
-        if os.path.isabs(path):
-                path = __path_abs_to_relative(path)
+    # make target into a relative path
+    if os.path.isabs(path):
+        path = __path_abs_to_relative(path)
 
-        # now open the alternate root and get its path
-        # done to eliminate any links/mounts/etc in the path
-        root_fd = os.open(root, os.O_RDONLY)
+    # now open the alternate root and get its path
+    # done to eliminate any links/mounts/etc in the path
+    root_fd = os.open(root, os.O_RDONLY)
+    try:
+        root = __fd_to_path(root_fd)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            os.close(root_fd)
+            raise e
+    os.close(root_fd)
+
+    # now open the target file, get its path, and make sure it
+    # lives in the alternate root
+    path_fd = None
+    try:
+        path_tmp = os.path.join(root, path)
+        path_fd = os.open(path_tmp, flags)
+    except OSError as e:
+        if e.errno != errno.ENOENT or not create:
+            raise e
+
+    assert path_fd or create
+    if not path_fd:
+        # the file doesn't exist so we should try to create it.
+        # we'll do this by first opening the directory which
+        # will contain the file and then using openat within
+        # that directory.
+        path_dir = os.path.dirname(path)
+        path_file = os.path.basename(path)
         try:
-                root = __fd_to_path(root_fd)
+            path_dir_fd = ar_open(root, path_dir, os.O_RDONLY)
         except OSError as e:
-                if e.errno != errno.ENOENT:
-                        os.close(root_fd)
-                        raise e
-        os.close(root_fd)
+            if e.errno != errno.EREMOTE:
+                raise e
+            raise OSError(errno.EREMOTE, eremote)
 
-        # now open the target file, get its path, and make sure it
-        # lives in the alternate root
-        path_fd = None
+        # we opened the directory, now create the file
         try:
-                path_tmp = os.path.join(root, path)
-                path_fd = os.open(path_tmp, flags)
+            path_fd = sat.openat(
+                path_dir_fd, path_file, flags | os.O_CREAT | os.O_EXCL, mode
+            )
         except OSError as e:
-                if e.errno != errno.ENOENT or not create:
-                        raise e
+            os.close(path_dir_fd)
+            raise e
 
-        assert path_fd or create
-        if not path_fd:
-                # the file doesn't exist so we should try to create it.
-                # we'll do this by first opening the directory which
-                # will contain the file and then using openat within
-                # that directory.
-                path_dir = os.path.dirname(path)
-                path_file = os.path.basename(path)
-                try:
-                        path_dir_fd = \
-                            ar_open(root, path_dir, os.O_RDONLY)
-                except OSError as e:
-                        if e.errno != errno.EREMOTE:
-                                raise e
-                        raise OSError(errno.EREMOTE, eremote)
+        # we created the file
+        assert path_fd
+        os.close(path_dir_fd)
 
-                # we opened the directory, now create the file
-                try:
-                        path_fd = sat.openat(path_dir_fd, path_file,
-                            flags|os.O_CREAT|os.O_EXCL, mode)
-                except OSError as e:
-                        os.close(path_dir_fd)
-                        raise e
+    # verify that the file we opened lives in the alternate root
+    try:
+        path = __fd_to_path(path_fd)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            os.close(path_fd)
+            raise e
+        path = os.path.join(root, path)
 
-                # we created the file
-                assert path_fd
-                os.close(path_dir_fd)
+    if not path.startswith(root):
+        os.close(path_fd)
+        raise OSError(errno.EREMOTE, eremote)
 
-        # verify that the file we opened lives in the alternate root
+    if truncate:
+        # the user wanted us to truncate the file
         try:
-                path = __fd_to_path(path_fd)
+            os.ftruncate(path_fd, 0)
         except OSError as e:
-                if e.errno != errno.ENOENT:
-                        os.close(path_fd)
-                        raise e
-                path = os.path.join(root, path)
+            os.close(path_fd)
+            raise e
 
-        if not path.startswith(root):
-                os.close(path_fd)
-                raise OSError(errno.EREMOTE, eremote)
+    return path_fd
 
-        if truncate:
-                # the user wanted us to truncate the file
-                try:
-                        os.ftruncate(path_fd, 0)
-                except OSError as e:
-                        os.close(path_fd)
-                        raise e
-
-        return path_fd
 
 def ar_unlink(root, path, noent_ok=False):
-        """A function similar to os.unlink() that ensures that the path
-        we're accessing resides within a specified directory subtree.
+    """A function similar to os.unlink() that ensures that the path
+    we're accessing resides within a specified directory subtree.
 
-        'noent_ok' optional flag indicating if it's ok for 'path' to be
-        missing.
+    'noent_ok' optional flag indicating if it's ok for 'path' to be
+    missing.
 
-        For all other parameters, refer to the 'ar_open' function
-        for an explanation of their usage and effects."""
+    For all other parameters, refer to the 'ar_open' function
+    for an explanation of their usage and effects."""
 
-        # all paths must be absolute
-        assert os.path.isabs(root)
+    # all paths must be absolute
+    assert os.path.isabs(root)
 
-        # make target into a relative path
-        if os.path.isabs(path):
-                path = __path_abs_to_relative(path)
+    # make target into a relative path
+    if os.path.isabs(path):
+        path = __path_abs_to_relative(path)
 
-        path_dir = os.path.dirname(path)
-        path_file = os.path.basename(path)
+    path_dir = os.path.dirname(path)
+    path_file = os.path.basename(path)
 
-        try:
-                path_dir_fd = ar_open(root, path_dir, os.O_RDONLY)
-        except OSError as e:
-                if noent_ok and e.errno == errno.ENOENT:
-                        return
-                raise e
+    try:
+        path_dir_fd = ar_open(root, path_dir, os.O_RDONLY)
+    except OSError as e:
+        if noent_ok and e.errno == errno.ENOENT:
+            return
+        raise e
 
-        try:
-                sat.unlinkat(path_dir_fd, path_file, 0)
-        except OSError as e:
-                os.close(path_dir_fd)
-                if noent_ok and e.errno == errno.ENOENT:
-                        return
-                raise e
-
+    try:
+        sat.unlinkat(path_dir_fd, path_file, 0)
+    except OSError as e:
         os.close(path_dir_fd)
-        return
+        if noent_ok and e.errno == errno.ENOENT:
+            return
+        raise e
+
+    os.close(path_dir_fd)
+    return
+
 
 def ar_rename(root, src, dst):
-        """A function similar to os.rename() that ensures that the path
-        we're accessing resides within a specified directory subtree.
+    """A function similar to os.rename() that ensures that the path
+    we're accessing resides within a specified directory subtree.
 
-        'src' and 'dst' are paths that are interpreted relative to 'root'.
-        i.e., 'root' is prepended to both.  'src' and 'dst' can not contain
-        any symbolic links that would cause an access to be redirected outside
-        of 'root'.  If this happens we'll raise an OSError exception with
-        errno set to EREMOTE
+    'src' and 'dst' are paths that are interpreted relative to 'root'.
+    i.e., 'root' is prepended to both.  'src' and 'dst' can not contain
+    any symbolic links that would cause an access to be redirected outside
+    of 'root'.  If this happens we'll raise an OSError exception with
+    errno set to EREMOTE
 
-        For all other parameters, refer to the 'ar_open' function
-        for an explanation of their usage and effects."""
+    For all other parameters, refer to the 'ar_open' function
+    for an explanation of their usage and effects."""
 
-        # all paths must be absolute
-        assert os.path.isabs(root)
+    # all paths must be absolute
+    assert os.path.isabs(root)
 
-        # make target into a relative path
-        if os.path.isabs(src):
-                src = __path_abs_to_relative(src)
-        if os.path.isabs(dst):
-                dst = __path_abs_to_relative(dst)
+    # make target into a relative path
+    if os.path.isabs(src):
+        src = __path_abs_to_relative(src)
+    if os.path.isabs(dst):
+        dst = __path_abs_to_relative(dst)
 
-        src_dir = os.path.dirname(src)
-        src_file = os.path.basename(src)
-        dst_dir = os.path.dirname(dst)
-        dst_file = os.path.basename(dst)
+    src_dir = os.path.dirname(src)
+    src_file = os.path.basename(src)
+    dst_dir = os.path.dirname(dst)
+    dst_file = os.path.basename(dst)
 
-        src_dir_fd = ar_open(root, src_dir, os.O_RDONLY)
-        try:
-                dst_dir_fd = ar_open(root, dst_dir, os.O_RDONLY)
-        except OSError as e:
-                os.close(src_dir_fd)
-                raise e
+    src_dir_fd = ar_open(root, src_dir, os.O_RDONLY)
+    try:
+        dst_dir_fd = ar_open(root, dst_dir, os.O_RDONLY)
+    except OSError as e:
+        os.close(src_dir_fd)
+        raise e
 
-        try:
-                sat.renameat(src_dir_fd, src_file, dst_dir_fd, dst_file)
-        except OSError as e:
-                os.close(src_dir_fd)
-                os.close(dst_dir_fd)
-                raise e
-
+    try:
+        sat.renameat(src_dir_fd, src_file, dst_dir_fd, dst_file)
+    except OSError as e:
         os.close(src_dir_fd)
         os.close(dst_dir_fd)
-        return
+        raise e
+
+    os.close(src_dir_fd)
+    os.close(dst_dir_fd)
+    return
+
 
 def ar_mkdir(root, path, mode, exists_is_ok=False):
-        """A function similar to os.mkdir() that ensures that the path we're
-        opening resides within a specified directory subtree.
+    """A function similar to os.mkdir() that ensures that the path we're
+    opening resides within a specified directory subtree.
 
-        For all other parameters, refer to the 'ar_open' function
-        for an explanation of their usage and effects."""
+    For all other parameters, refer to the 'ar_open' function
+    for an explanation of their usage and effects."""
 
-        # all paths must be absolute
-        assert os.path.isabs(root)
+    # all paths must be absolute
+    assert os.path.isabs(root)
 
-        # make target into a relative path
-        if os.path.isabs(path):
-                path = __path_abs_to_relative(path)
+    # make target into a relative path
+    if os.path.isabs(path):
+        path = __path_abs_to_relative(path)
 
-        path_dir = os.path.dirname(path)
-        path_file = os.path.basename(path)
+    path_dir = os.path.dirname(path)
+    path_file = os.path.basename(path)
 
-        path_dir_fd = ar_open(root, path_dir, os.O_RDONLY)
-        try:
-                sat.mkdirat(path_dir_fd, path_file, mode)
-        except OSError as e:
-                os.close(path_dir_fd)
-                if exists_is_ok and e.errno == errno.EEXIST:
-                        return
-                raise e
-
+    path_dir_fd = ar_open(root, path_dir, os.O_RDONLY)
+    try:
+        sat.mkdirat(path_dir_fd, path_file, mode)
+    except OSError as e:
         os.close(path_dir_fd)
-        return
+        if exists_is_ok and e.errno == errno.EEXIST:
+            return
+        raise e
+
+    os.close(path_dir_fd)
+    return
+
 
 def ar_stat(root, path):
-        """A function similar to os.stat() that ensures that the path
-        we're accessing resides within a specified directory subtree.
+    """A function similar to os.stat() that ensures that the path
+    we're accessing resides within a specified directory subtree.
 
-        For all other parameters, refer to the 'ar_open' function
-        for an explanation of their usage and effects."""
+    For all other parameters, refer to the 'ar_open' function
+    for an explanation of their usage and effects."""
 
-        try:
-                fd = ar_open(root, path, os.O_RDONLY)
-        except OSError as e:
-                raise e
-        si = os.fstat(fd)
-        os.close(fd)
-        return si
+    try:
+        fd = ar_open(root, path, os.O_RDONLY)
+    except OSError as e:
+        raise e
+    si = os.fstat(fd)
+    os.close(fd)
+    return si
+
 
 def ar_isdir(root, path):
-        """A function similar to os.path.isdir() that ensures that the path
-        we're accessing resides within a specified directory subtree.
+    """A function similar to os.path.isdir() that ensures that the path
+    we're accessing resides within a specified directory subtree.
 
-        For all other parameters, refer to the 'ar_open' function
-        for an explanation of their usage and effects."""
+    For all other parameters, refer to the 'ar_open' function
+    for an explanation of their usage and effects."""
 
-        try:
-                si = ar_stat(root, path)
-        except OSError as e:
-                if e.errno == errno.ENOENT:
-                        return False
-                raise e
+    try:
+        si = ar_stat(root, path)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            return False
+        raise e
 
-        if stat.S_ISDIR(si.st_mode):
-                return True
-        return False
+    if stat.S_ISDIR(si.st_mode):
+        return True
+    return False
+
 
 def ar_exists(root, path):
-        """A function similar to os.path.exists() that ensures that the path
-        we're accessing resides within a specified directory subtree.
+    """A function similar to os.path.exists() that ensures that the path
+    we're accessing resides within a specified directory subtree.
 
-        For all other parameters, refer to the 'ar_open' function
-        for an explanation of their usage and effects."""
+    For all other parameters, refer to the 'ar_open' function
+    for an explanation of their usage and effects."""
 
-        try:
-                fd = ar_open(root, path, os.O_RDONLY)
-        except OSError as e:
-                if e.errno == errno.ENOENT:
-                        return False
-                raise e
-        os.close(fd)
-        return True
+    try:
+        fd = ar_open(root, path, os.O_RDONLY)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            return False
+        raise e
+    os.close(fd)
+    return True
+
 
 def ar_diff(root, path1, path2):
-        """A function similar to filecmp.cmp() that ensures that the path
-        we're accessing resides within a specified directory subtree.
+    """A function similar to filecmp.cmp() that ensures that the path
+    we're accessing resides within a specified directory subtree.
 
-        For all other parameters, refer to the 'ar_open' function
-        for an explanation of their usage and effects."""
+    For all other parameters, refer to the 'ar_open' function
+    for an explanation of their usage and effects."""
 
-        fd1 = fd2 = None
+    fd1 = fd2 = None
 
-        diff = False
-        try:
-                fd1 = ar_open(root, path1, os.O_RDONLY)
-                fd2 = ar_open(root, path2, os.O_RDONLY)
+    diff = False
+    try:
+        fd1 = ar_open(root, path1, os.O_RDONLY)
+        fd2 = ar_open(root, path2, os.O_RDONLY)
 
-                while True:
-                        b1 = os.read(fd1, 1024)
-                        b2 = os.read(fd2, 1024)
-                        if len(b1) == 0 and len(b2) == 0:
-                                # we're done
-                                break
-                        if len(b1) != len(b2) or b1 != b2:
-                                diff = True
-                                break
-        except OSError as e:
-                if fd1:
-                        os.close(fd1)
-                if fd2:
-                        os.close(fd2)
-                raise e
+        while True:
+            b1 = os.read(fd1, 1024)
+            b2 = os.read(fd2, 1024)
+            if len(b1) == 0 and len(b2) == 0:
+                # we're done
+                break
+            if len(b1) != len(b2) or b1 != b2:
+                diff = True
+                break
+    except OSError as e:
+        if fd1:
+            os.close(fd1)
+        if fd2:
+            os.close(fd2)
+        raise e
 
-        os.close(fd1)
-        os.close(fd2)
-        return diff
+    os.close(fd1)
+    os.close(fd2)
+    return diff
+
 
 def ar_img_prefix(root):
-        """A function that attempts to determine if a user or root pkg(7)
-        managed image can be found at 'root'.  If 'root' does point to a
-        pkg(7) image, then we return the relative path to the image metadata
-        directory."""
+    """A function that attempts to determine if a user or root pkg(7)
+    managed image can be found at 'root'.  If 'root' does point to a
+    pkg(7) image, then we return the relative path to the image metadata
+    directory."""
 
-        import pkg.client.image as image
+    import pkg.client.image as image
 
-        user_img = False
-        root_img = False
+    user_img = False
+    root_img = False
 
-        if ar_isdir(root, image.img_user_prefix):
-                user_img = True
+    if ar_isdir(root, image.img_user_prefix):
+        user_img = True
 
-        if ar_isdir(root, image.img_root_prefix):
-                root_img = True
+    if ar_isdir(root, image.img_root_prefix):
+        root_img = True
 
-        if user_img and root_img:
-                #
-                # why would an image have two pkg metadata directories.
-                # is this image corrupt?
-                #
-                return None
-        if user_img:
-                return image.img_user_prefix
-        if root_img:
-                return image.img_root_prefix
+    if user_img and root_img:
+        #
+        # why would an image have two pkg metadata directories.
+        # is this image corrupt?
+        #
         return None
+    if user_img:
+        return image.img_user_prefix
+    if root_img:
+        return image.img_root_prefix
+    return None
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/api_common.py
+++ b/src/modules/api_common.py
@@ -36,228 +36,267 @@ import pkg.client.pkgdefs as pkgdefs
 import pkg.fmri as fmri
 import pkg.misc as misc
 
+
 class LicenseInfo(object):
-        """A class representing the license information a package
-        provides.  Not intended for instantiation by API consumers."""
+    """A class representing the license information a package
+    provides.  Not intended for instantiation by API consumers."""
 
-        def __init__(self, pfmri, act, img=None, text=None, alt_pub=None):
-                self.__action = act
-                self.__alt_pub = alt_pub
-                self.__fmri = pfmri
-                self.__img = img
-                self.__text = text
+    def __init__(self, pfmri, act, img=None, text=None, alt_pub=None):
+        self.__action = act
+        self.__alt_pub = alt_pub
+        self.__fmri = pfmri
+        self.__img = img
+        self.__text = text
 
-        def __str__(self):
-                return self.get_text()
+    def __str__(self):
+        return self.get_text()
 
-        def get_text(self):
-                """Retrieves and returns the payload of the license (which
-                should be text).  This may require remote retrieval of
-                resources and so this could raise a TransportError or other
-                ApiException."""
+    def get_text(self):
+        """Retrieves and returns the payload of the license (which
+        should be text).  This may require remote retrieval of
+        resources and so this could raise a TransportError or other
+        ApiException."""
 
-                if not self.__img:
-                        return self.__text
-                return self.__action.get_text(self.__img, self.__fmri,
-                    alt_pub=self.__alt_pub)
+        if not self.__img:
+            return self.__text
+        return self.__action.get_text(
+            self.__img, self.__fmri, alt_pub=self.__alt_pub
+        )
 
-        @property
-        def fmri(self):
-                """The FMRI of the package this license is for."""
+    @property
+    def fmri(self):
+        """The FMRI of the package this license is for."""
 
-                return self.__fmri
+        return self.__fmri
 
-        @property
-        def license(self):
-                """The keyword identifying this license within its related
-                package."""
+    @property
+    def license(self):
+        """The keyword identifying this license within its related
+        package."""
 
-                return self.__action.attrs["license"]
+        return self.__action.attrs["license"]
 
-        @property
-        def must_accept(self):
-                """A boolean value indicating whether the license requires
-                acceptance."""
+    @property
+    def must_accept(self):
+        """A boolean value indicating whether the license requires
+        acceptance."""
 
-                return self.__action.must_accept
+        return self.__action.must_accept
 
-        @property
-        def must_display(self):
-                """A boolean value indicating whether the license must be
-                displayed during install or update operations."""
+    @property
+    def must_display(self):
+        """A boolean value indicating whether the license must be
+        displayed during install or update operations."""
 
-                return self.__action.must_display
+        return self.__action.must_display
 
 
 class PackageCategory(object):
-        """Represents the scheme and category of an info.classification entry
-        for a package."""
+    """Represents the scheme and category of an info.classification entry
+    for a package."""
 
-        scheme = None
-        category = None
+    scheme = None
+    category = None
 
-        def __init__(self, scheme, category):
-                self.scheme = scheme
-                self.category = category
+    def __init__(self, scheme, category):
+        self.scheme = scheme
+        self.category = category
 
-        def __str__(self, verbose=False):
-                if verbose:
-                        return "{0} ({1})".format(self.category, self.scheme)
-                else:
-                        return "{0}".format(self.category)
+    def __str__(self, verbose=False):
+        if verbose:
+            return "{0} ({1})".format(self.category, self.scheme)
+        else:
+            return "{0}".format(self.category)
 
 
 class PackageInfo(object):
-        """A class capturing the information about packages that a client
-        could need. The fmri is guaranteed to be set. All other values may
-        be None, depending on how the PackageInfo instance was created."""
+    """A class capturing the information about packages that a client
+    could need. The fmri is guaranteed to be set. All other values may
+    be None, depending on how the PackageInfo instance was created."""
 
-        # Possible package states; these constants should match the values used
-        # by the Image class.  Constants with negative values are not currently
-        # available.
-        INCORPORATED = -2
-        EXCLUDES = -3
-        KNOWN = pkgdefs.PKG_STATE_KNOWN
-        INSTALLED = pkgdefs.PKG_STATE_INSTALLED
-        UPGRADABLE = pkgdefs.PKG_STATE_UPGRADABLE
-        OBSOLETE = pkgdefs.PKG_STATE_OBSOLETE
-        RENAMED = pkgdefs.PKG_STATE_RENAMED
-        LEGACY = pkgdefs.PKG_STATE_LEGACY
-        UNSUPPORTED = pkgdefs.PKG_STATE_UNSUPPORTED
-        FROZEN = pkgdefs.PKG_STATE_FROZEN
-        OPTIONAL = pkgdefs.PKG_STATE_OPTIONAL
-        MANUAL = pkgdefs.PKG_STATE_MANUAL
+    # Possible package states; these constants should match the values used
+    # by the Image class.  Constants with negative values are not currently
+    # available.
+    INCORPORATED = -2
+    EXCLUDES = -3
+    KNOWN = pkgdefs.PKG_STATE_KNOWN
+    INSTALLED = pkgdefs.PKG_STATE_INSTALLED
+    UPGRADABLE = pkgdefs.PKG_STATE_UPGRADABLE
+    OBSOLETE = pkgdefs.PKG_STATE_OBSOLETE
+    RENAMED = pkgdefs.PKG_STATE_RENAMED
+    LEGACY = pkgdefs.PKG_STATE_LEGACY
+    UNSUPPORTED = pkgdefs.PKG_STATE_UNSUPPORTED
+    FROZEN = pkgdefs.PKG_STATE_FROZEN
+    OPTIONAL = pkgdefs.PKG_STATE_OPTIONAL
+    MANUAL = pkgdefs.PKG_STATE_MANUAL
 
-        __NUM_PROPS = 13
-        IDENTITY, SUMMARY, CATEGORIES, STATE, SIZE, LICENSES, LINKS, \
-            HARDLINKS, FILES, DIRS, DEPENDENCIES, DESCRIPTION, \
-            ALL_ATTRIBUTES = range(__NUM_PROPS)
-        ALL_OPTIONS = frozenset(range(__NUM_PROPS))
-        ACTION_OPTIONS = frozenset([LINKS, HARDLINKS, FILES, DIRS,
-            DEPENDENCIES])
+    __NUM_PROPS = 13
+    (
+        IDENTITY,
+        SUMMARY,
+        CATEGORIES,
+        STATE,
+        SIZE,
+        LICENSES,
+        LINKS,
+        HARDLINKS,
+        FILES,
+        DIRS,
+        DEPENDENCIES,
+        DESCRIPTION,
+        ALL_ATTRIBUTES,
+    ) = range(__NUM_PROPS)
+    ALL_OPTIONS = frozenset(range(__NUM_PROPS))
+    ACTION_OPTIONS = frozenset([LINKS, HARDLINKS, FILES, DIRS, DEPENDENCIES])
 
-        def __init__(self, pfmri, pkg_stem=None, summary=None,
-            category_info_list=None, states=None, publisher=None,
-            version=None, build_release=None, branch=None, packaging_date=None,
-            size=None, csize=None, licenses=None, links=None, hardlinks=None,
-            files=None, dirs=None, dependencies=None, description=None,
-            attrs=None, last_update=None, last_install=None):
-                self.pkg_stem = pkg_stem
+    def __init__(
+        self,
+        pfmri,
+        pkg_stem=None,
+        summary=None,
+        category_info_list=None,
+        states=None,
+        publisher=None,
+        version=None,
+        build_release=None,
+        branch=None,
+        packaging_date=None,
+        size=None,
+        csize=None,
+        licenses=None,
+        links=None,
+        hardlinks=None,
+        files=None,
+        dirs=None,
+        dependencies=None,
+        description=None,
+        attrs=None,
+        last_update=None,
+        last_install=None,
+    ):
+        self.pkg_stem = pkg_stem
 
-                self.summary = summary
-                if category_info_list is None:
-                        category_info_list = []
-                self.category_info_list = category_info_list
-                self.states = states
-                self.publisher = publisher
-                self.version = version
-                self.build_release = build_release
-                self.branch = branch
-                self.packaging_date = packaging_date
-                self.size = size
-                self.csize = csize
-                self.fmri = pfmri
-                self.licenses = licenses
-                self.links = links
-                self.hardlinks = hardlinks
-                self.files = files
-                self.dirs = dirs
-                self.dependencies = dependencies
-                self.description = description
-                self.attrs = attrs or {}
-                self.last_update = last_update
-                self.last_install = last_install
+        self.summary = summary
+        if category_info_list is None:
+            category_info_list = []
+        self.category_info_list = category_info_list
+        self.states = states
+        self.publisher = publisher
+        self.version = version
+        self.build_release = build_release
+        self.branch = branch
+        self.packaging_date = packaging_date
+        self.size = size
+        self.csize = csize
+        self.fmri = pfmri
+        self.licenses = licenses
+        self.links = links
+        self.hardlinks = hardlinks
+        self.files = files
+        self.dirs = dirs
+        self.dependencies = dependencies
+        self.description = description
+        self.attrs = attrs or {}
+        self.last_update = last_update
+        self.last_install = last_install
 
-        def __str__(self):
-                return str(self.fmri)
+    def __str__(self):
+        return str(self.fmri)
 
-        @staticmethod
-        def build_from_fmri(f):
-                if not f:
-                        return f
-                pub, name, version = f.tuple()
-                pub = fmri.strip_pub_pfx(pub)
-                return PackageInfo(pkg_stem=name, publisher=pub,
-                    version=version.release,
-                    build_release=version.build_release, branch=version.branch,
-                    packaging_date=version.get_timestamp().strftime("%c"),
-                    pfmri=f)
+    @staticmethod
+    def build_from_fmri(f):
+        if not f:
+            return f
+        pub, name, version = f.tuple()
+        pub = fmri.strip_pub_pfx(pub)
+        return PackageInfo(
+            pkg_stem=name,
+            publisher=pub,
+            version=version.release,
+            build_release=version.build_release,
+            branch=version.branch,
+            packaging_date=version.get_timestamp().strftime("%c"),
+            pfmri=f,
+        )
 
-        def get_attr_values(self, name, modifiers=()):
-                """Returns a list of the values of the package attribute 'name'.
+    def get_attr_values(self, name, modifiers=()):
+        """Returns a list of the values of the package attribute 'name'.
 
-                The 'modifiers' parameter, if present, is a dict containing
-                key/value pairs, all of which must be present on an action in
-                order for the values to be returned.
+        The 'modifiers' parameter, if present, is a dict containing
+        key/value pairs, all of which must be present on an action in
+        order for the values to be returned.
 
-                Returns an empty list if there are no values.
-                """
+        Returns an empty list if there are no values.
+        """
 
-                # XXX should the modifiers parameter be allowed to be a subset
-                # of an action's modifiers?
-                if isinstance(modifiers, dict):
-                        modifiers = tuple(
-                            (k, isinstance(modifiers[k], six.string_types) and
-                                tuple([sorted(modifiers[k])]) or
-                                tuple(sorted(modifiers[k])))
-                            for k in sorted(six.iterkeys(modifiers))
-                        )
-                return self.attrs.get(name, {modifiers: []}).get(
-                    modifiers, [])
+        # XXX should the modifiers parameter be allowed to be a subset
+        # of an action's modifiers?
+        if isinstance(modifiers, dict):
+            modifiers = tuple(
+                (
+                    k,
+                    isinstance(modifiers[k], six.string_types)
+                    and tuple([sorted(modifiers[k])])
+                    or tuple(sorted(modifiers[k])),
+                )
+                for k in sorted(six.iterkeys(modifiers))
+            )
+        return self.attrs.get(name, {modifiers: []}).get(modifiers, [])
 
 
-def _get_pkg_cat_data(cat, info_needed, actions=None,
-    excludes=misc.EmptyI, pfmri=None):
-        """This is a private method and not intended for
-        external consumers."""
+def _get_pkg_cat_data(
+    cat, info_needed, actions=None, excludes=misc.EmptyI, pfmri=None
+):
+    """This is a private method and not intended for
+    external consumers."""
 
-        # XXX this doesn't handle locale.
-        get_summ = summ = desc = cat_info = deps = None
-        cat_data = []
-        get_summ = PackageInfo.SUMMARY in info_needed
-        if PackageInfo.CATEGORIES in info_needed:
-                cat_info = []
-        if PackageInfo.DEPENDENCIES in info_needed:
-                cat_data.append(cat.DEPENDENCY)
-                deps = []
+    # XXX this doesn't handle locale.
+    get_summ = summ = desc = cat_info = deps = None
+    cat_data = []
+    get_summ = PackageInfo.SUMMARY in info_needed
+    if PackageInfo.CATEGORIES in info_needed:
+        cat_info = []
+    if PackageInfo.DEPENDENCIES in info_needed:
+        cat_data.append(cat.DEPENDENCY)
+        deps = []
 
-        if deps is None or len(info_needed) != 1:
-                # Anything other than dependency data
-                # requires summary data.
-                cat_data.append(cat.SUMMARY)
+    if deps is None or len(info_needed) != 1:
+        # Anything other than dependency data
+        # requires summary data.
+        cat_data.append(cat.SUMMARY)
 
-        if actions is None:
-                actions = cat.get_entry_actions(pfmri, cat_data,
-                    excludes=excludes)
+    if actions is None:
+        actions = cat.get_entry_actions(pfmri, cat_data, excludes=excludes)
 
-        for a in actions:
-                if deps is not None and a.name == "depend":
-                        deps.append(a.attrs.get(a.key_attr))
-                        continue
-                elif a.name != "set":
-                        continue
+    for a in actions:
+        if deps is not None and a.name == "depend":
+            deps.append(a.attrs.get(a.key_attr))
+            continue
+        elif a.name != "set":
+            continue
 
-                attr_name = a.attrs["name"]
-                if attr_name == "pkg.summary":
-                        if get_summ:
-                                summ = a.attrs["value"]
-                elif attr_name == "description":
-                        if get_summ and summ is None:
-                                # Historical summary field.
-                                summ = a.attrs["value"]
-                elif attr_name == "pkg.description":
-                        desc = a.attrs["value"]
-                elif cat_info != None and a.has_category_info():
-                        cat_info.extend(a.parse_category_info())
+        attr_name = a.attrs["name"]
+        if attr_name == "pkg.summary":
+            if get_summ:
+                summ = a.attrs["value"]
+        elif attr_name == "description":
+            if get_summ and summ is None:
+                # Historical summary field.
+                summ = a.attrs["value"]
+        elif attr_name == "pkg.description":
+            desc = a.attrs["value"]
+        elif cat_info != None and a.has_category_info():
+            cat_info.extend(a.parse_category_info())
 
-        if get_summ and summ is None:
-                if desc is None:
-                        summ = ""
-                else:
-                        summ = desc
-        if not PackageInfo.DESCRIPTION in info_needed:
-                desc = None
-        return summ, desc, cat_info, deps
+    if get_summ and summ is None:
+        if desc is None:
+            summ = ""
+        else:
+            summ = desc
+    if not PackageInfo.DESCRIPTION in info_needed:
+        desc = None
+    return summ, desc, cat_info, deps
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/arch.py
+++ b/src/modules/arch.py
@@ -72,6 +72,7 @@ def get_isainfo():
         buf = buf1
 
     from pkg.misc import force_text
+
     # ffi.string returns a bytes
     if buf == NULL:
         buf1 = force_text(ffi.string(ffi.cast("char *", buf1)))
@@ -90,6 +91,7 @@ def get_release():
     if buf == NULL:
         return
     from pkg.misc import force_text
+
     return force_text(ffi.string(ffi.cast("char *", buf)))
 
 
@@ -99,7 +101,9 @@ def get_platform():
     if buf == NULL:
         return
     from pkg.misc import force_text
+
     return force_text(ffi.string(ffi.cast("char *", buf)))
 
+
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/bundle/DirectoryBundle.py
+++ b/src/modules/bundle/DirectoryBundle.py
@@ -35,113 +35,129 @@ import pkg.actions.file
 import pkg.actions.link
 import pkg.actions.hardlink
 
+
 class DirectoryBundle(pkg.bundle.Bundle):
-        """The DirectoryBundle class assists in the conversion of a directory
-        tree to a pkg(7) package by traversing the tree and emitting actions for
-        all files, directories, and links found therein.
+    """The DirectoryBundle class assists in the conversion of a directory
+    tree to a pkg(7) package by traversing the tree and emitting actions for
+    all files, directories, and links found therein.
 
-        Paths are published relative to the given directory.  Hardlinks are
-        resolved as long as their companions are in the tree as well.
+    Paths are published relative to the given directory.  Hardlinks are
+    resolved as long as their companions are in the tree as well.
 
-        All owners are set to "root" and groups to "bin", as the ownership
-        information is not considered to be valid.  These can be set by the
-        caller once the action has been emitted.
-        """
+    All owners are set to "root" and groups to "bin", as the ownership
+    information is not considered to be valid.  These can be set by the
+    caller once the action has been emitted.
+    """
 
-        def __init__(self, path, targetpaths=(), use_default_owner=True):
-                # XXX This could be more intelligent.  Or get user input.  Or
-                # extend API to take FMRI.
-                path = os.path.normpath(path)
-                self.filename = path
-                self.rootdir = path
-                self.pkgname = os.path.basename(self.rootdir)
-                self.inodes = None
-                self.targetpaths = targetpaths
-                self.pkg = None
-                self.use_default_owner = use_default_owner
+    def __init__(self, path, targetpaths=(), use_default_owner=True):
+        # XXX This could be more intelligent.  Or get user input.  Or
+        # extend API to take FMRI.
+        path = os.path.normpath(path)
+        self.filename = path
+        self.rootdir = path
+        self.pkgname = os.path.basename(self.rootdir)
+        self.inodes = None
+        self.targetpaths = targetpaths
+        self.pkg = None
+        self.use_default_owner = use_default_owner
 
-        def _walk_bundle(self):
-                # Pre-populate self.inodes with the paths of known targets
-                if self.inodes is None:
-                        self.inodes = {}
-                        for p in self.targetpaths:
-                                fp = os.path.join(self.rootdir, p)
-                                pstat = os.lstat(fp)
-                                self.inodes[pstat.st_ino] = fp
+    def _walk_bundle(self):
+        # Pre-populate self.inodes with the paths of known targets
+        if self.inodes is None:
+            self.inodes = {}
+            for p in self.targetpaths:
+                fp = os.path.join(self.rootdir, p)
+                pstat = os.lstat(fp)
+                self.inodes[pstat.st_ino] = fp
 
-                for root, dirs, files in os.walk(self.rootdir):
-                        for obj in dirs + files:
-                                path = os.path.join(root, obj)
-                                yield path, (path,)
+        for root, dirs, files in os.walk(self.rootdir):
+            for obj in dirs + files:
+                path = os.path.join(root, obj)
+                yield path, (path,)
 
-        def __iter__(self):
-                for path, data in self._walk_bundle():
-                        act = self.action(*data)
-                        if act:
-                                yield act
+    def __iter__(self):
+        for path, data in self._walk_bundle():
+            act = self.action(*data)
+            if act:
+                yield act
 
-        def action(self, path):
-                rootdir = self.rootdir
-                pubpath = pkg.misc.relpath(path, rootdir)
-                pstat = os.lstat(path)
-                mode = oct(stat.S_IMODE(pstat.st_mode))
-                timestamp = pkg.misc.time_to_timestamp(pstat.st_mtime)
+    def action(self, path):
+        rootdir = self.rootdir
+        pubpath = pkg.misc.relpath(path, rootdir)
+        pstat = os.lstat(path)
+        mode = oct(stat.S_IMODE(pstat.st_mode))
+        timestamp = pkg.misc.time_to_timestamp(pstat.st_mtime)
 
-                # Set default root and group.
-                owner = "root"
-                group = "bin"
+        # Set default root and group.
+        owner = "root"
+        group = "bin"
 
-                # Check whether need to change owner.
-                if not self.use_default_owner:
-                        try:
-                                owner = pwd.getpwuid(pstat.st_uid).pw_name
-                        except KeyError as e:
-                                owner = None
-                        try:
-                                group = grp.getgrgid(pstat.st_gid).gr_name
-                        except KeyError as e:
-                                group = None
+        # Check whether need to change owner.
+        if not self.use_default_owner:
+            try:
+                owner = pwd.getpwuid(pstat.st_uid).pw_name
+            except KeyError as e:
+                owner = None
+            try:
+                group = grp.getgrgid(pstat.st_gid).gr_name
+            except KeyError as e:
+                group = None
 
-                        if not owner and not group:
-                                raise pkg.bundle.InvalidOwnershipException(
-                                    path, uid=pstat.st_uid, gid=pstat.st_gid)
-                        elif not owner:
-                                raise pkg.bundle.InvalidOwnershipException(
-                                    path, uid=pstat.st_uid)
-                        elif not group:
-                                 raise pkg.bundle.InvalidOwnershipException(
-                                    path, gid=pstat.st_gid)
+            if not owner and not group:
+                raise pkg.bundle.InvalidOwnershipException(
+                    path, uid=pstat.st_uid, gid=pstat.st_gid
+                )
+            elif not owner:
+                raise pkg.bundle.InvalidOwnershipException(
+                    path, uid=pstat.st_uid
+                )
+            elif not group:
+                raise pkg.bundle.InvalidOwnershipException(
+                    path, gid=pstat.st_gid
+                )
 
-                if stat.S_ISREG(pstat.st_mode):
-                        inode = pstat.st_ino
-                        # Any inode in self.inodes will either have been visited
-                        # before or will have been pre-populated from the list
-                        # of known targets.  Create file actions for known
-                        # targets and unvisited inodes.
-                        if pubpath in self.targetpaths or \
-                            inode not in self.inodes:
-                                if pstat.st_nlink > 1:
-                                        self.inodes.setdefault(inode, path)
-                                return pkg.actions.file.FileAction(
-                                    open(path, "rb"), mode=mode, owner=owner,
-                                    group=group, path=pubpath,
-                                    timestamp=timestamp)
-                        else:
-                                # Find the relative path to the link target.
-                                target = pkg.misc.relpath(self.inodes[inode],
-                                    os.path.dirname(path))
-                                return pkg.actions.hardlink.HardLinkAction(
-                                    path=pubpath, target=target)
-                elif stat.S_ISLNK(pstat.st_mode):
-                        return pkg.actions.link.LinkAction(
-                            target=os.readlink(path), path=pubpath)
-                elif stat.S_ISDIR(pstat.st_mode):
-                        return pkg.actions.directory.DirectoryAction(
-                            timestamp=timestamp, mode=mode, owner=owner,
-                            group=group, path=pubpath)
+        if stat.S_ISREG(pstat.st_mode):
+            inode = pstat.st_ino
+            # Any inode in self.inodes will either have been visited
+            # before or will have been pre-populated from the list
+            # of known targets.  Create file actions for known
+            # targets and unvisited inodes.
+            if pubpath in self.targetpaths or inode not in self.inodes:
+                if pstat.st_nlink > 1:
+                    self.inodes.setdefault(inode, path)
+                return pkg.actions.file.FileAction(
+                    open(path, "rb"),
+                    mode=mode,
+                    owner=owner,
+                    group=group,
+                    path=pubpath,
+                    timestamp=timestamp,
+                )
+            else:
+                # Find the relative path to the link target.
+                target = pkg.misc.relpath(
+                    self.inodes[inode], os.path.dirname(path)
+                )
+                return pkg.actions.hardlink.HardLinkAction(
+                    path=pubpath, target=target
+                )
+        elif stat.S_ISLNK(pstat.st_mode):
+            return pkg.actions.link.LinkAction(
+                target=os.readlink(path), path=pubpath
+            )
+        elif stat.S_ISDIR(pstat.st_mode):
+            return pkg.actions.directory.DirectoryAction(
+                timestamp=timestamp,
+                mode=mode,
+                owner=owner,
+                group=group,
+                path=pubpath,
+            )
+
 
 def test(filename):
-        return stat.S_ISDIR(os.stat(filename).st_mode)
+    return stat.S_ISDIR(os.stat(filename).st_mode)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/bundle/SolarisPackageDatastreamBundle.py
+++ b/src/modules/bundle/SolarisPackageDatastreamBundle.py
@@ -34,180 +34,198 @@ from pkg.bundle.SolarisPackageDirBundle import SolarisPackageDirBundle
 from pkg.bundle import InvalidBundleException
 
 typemap = {
-        stat.S_IFBLK: "block-special",
-        stat.S_IFCHR: "character-special",
-        stat.S_IFDIR: "directory",
-        stat.S_IFIFO: "fifo",
-        stat.S_IFLNK: "link",
-        stat.S_IFREG: "file",
-        stat.S_IFSOCK: "socket"
+    stat.S_IFBLK: "block-special",
+    stat.S_IFCHR: "character-special",
+    stat.S_IFDIR: "directory",
+    stat.S_IFIFO: "fifo",
+    stat.S_IFLNK: "link",
+    stat.S_IFREG: "file",
+    stat.S_IFSOCK: "socket",
 }
 
+
 class SolarisPackageDatastreamBundle(SolarisPackageDirBundle):
-        """XXX Need a class comment."""
+    """XXX Need a class comment."""
 
-        def __init__(self, filename, **kwargs):
-                filename = os.path.normpath(filename)
-                self.pkg = SolarisPackage(filename)
-                self.pkgname = self.pkg.pkginfo["PKG"]
-                self.filename = filename
+    def __init__(self, filename, **kwargs):
+        filename = os.path.normpath(filename)
+        self.pkg = SolarisPackage(filename)
+        self.pkgname = self.pkg.pkginfo["PKG"]
+        self.filename = filename
 
-                # map the path name to the SVR4 class it belongs to and
-                # maintain a set of pre/post install/remove and class action
-                # scripts this package uses.
-                self.class_actions_dir = {}
-                self.class_action_names = set()
-                self.scripts = set()
+        # map the path name to the SVR4 class it belongs to and
+        # maintain a set of pre/post install/remove and class action
+        # scripts this package uses.
+        self.class_actions_dir = {}
+        self.class_action_names = set()
+        self.scripts = set()
 
-                self.hollow = self.pkg.pkginfo.get("SUNW_PKG_HOLLOW",
-                    "").lower() == "true"
-                self.pkginfo_actions = self.get_pkginfo_actions(
-                    self.pkg.pkginfo)
+        self.hollow = (
+            self.pkg.pkginfo.get("SUNW_PKG_HOLLOW", "").lower() == "true"
+        )
+        self.pkginfo_actions = self.get_pkginfo_actions(self.pkg.pkginfo)
 
-                # SolarisPackage.manifest is a list.  Cache it into a dictionary
-                # based on pathname.  The cpio archive contains the files as
-                # they would be in the directory structure -- that is, under
-                # install, reloc, or root, depending on whether they're i-type
-                # files, relocatable files, or unrelocatable files.  Make sure
-                # we find the right object, even though the filenames in the
-                # package map don't have these directory names.
-                self.pkgmap = {}
+        # SolarisPackage.manifest is a list.  Cache it into a dictionary
+        # based on pathname.  The cpio archive contains the files as
+        # they would be in the directory structure -- that is, under
+        # install, reloc, or root, depending on whether they're i-type
+        # files, relocatable files, or unrelocatable files.  Make sure
+        # we find the right object, even though the filenames in the
+        # package map don't have these directory names.
+        self.pkgmap = {}
 
-                for p in self.pkg.manifest:
-                        if p.type in "fevdsl":
-                                if p.pathname[0] == "/":
-                                        d = "root"
-                                else:
-                                        d = "reloc/"
-                                self.pkgmap[d + p.pathname] = p
-                                self.class_actions_dir[p.pathname] = p.klass
-                                self.class_action_names.add(p.klass)
-                        elif p.type == "i":
-                                self.pkgmap["install/" + p.pathname] = p
-
-        def _walk_bundle(self):
-                for act in self.pkginfo_actions:
-                        yield act.attrs.get("path"), act
-
-                for p in self.pkg.datastream:
-                        yield p.name, (self.pkgmap, p, p.name)
-
-                # for some reason, some packages may have directories specified
-                # in the pkgmap that don't exist in the archive.  They need to
-                # be found and iterated as well.
-                #
-                # Some of the blastwave packages also have directories in the
-                # archive that don't exist in the package metadata.  I don't see
-                # a whole lot of point in faking those up.
-                for p in self.pkg.manifest:
-                        if p.type not in "lsd":
-                                continue
-
-                        if p.pathname[0] == "/":
-                                d = "root"
-                        else:
-                                d = "reloc/"
-                        path = d + p.pathname
-                        if (p.type == "d" and path not in self.pkg.datastream) or \
-                            p.type in "ls":
-                                yield path, (self.pkgmap, None, path)
-
-        def __iter__(self):
-                """Iterate through the datastream.
-
-                   This is different than the directory-format package bundle,
-                   which iterates through the package map.  We do it this way
-                   because the cpio archive might not be in the same order as
-                   the package map, and we want never to seek backwards.  This
-                   implies that we're going to have to look up the meta info for
-                   each file from the package map.  We could get the file type
-                   from the archive, but it's probably safe to assume that the
-                   file type in the archive is the same as the file type in the
-                   package map.
-                """
-                for path, data in self._walk_bundle():
-                        if type(data) != tuple:
-                                yield data
-                                continue
-
-                        act = self.action(*data)
-                        if act:
-                                yield act
-
-        def action(self, pkgmap, ci, path):
-                try:
-                        mapline = pkgmap[path]
-                except KeyError:
-                        # XXX Return an unknown instead of a missing, for now.
-                        return unknown.UnknownAction(path=path)
-
-                act = None
-
-                # If any one of the mode, owner, or group is "?", then we're
-                # clearly not capable of delivering the object correctly, so
-                # ignore it.
-                if mapline.type in "fevdx" and (mapline.mode == "?" or
-                    mapline.owner == "?" or mapline.group == "?"):
-                        return None
-
-                if mapline.type in "fev":
-                        # false positive
-                        # file-builtin; pylint: disable=W1607
-                        act = file.FileAction(ci.extractfile(),
-                            mode=mapline.mode, owner=mapline.owner,
-                            group=mapline.group, path=mapline.pathname,
-                            timestamp=misc.time_to_timestamp(int(mapline.modtime)))
-                elif mapline.type in "dx":
-                        act = directory.DirectoryAction(mode = mapline.mode,
-                            owner=mapline.owner, group=mapline.group,
-                            path=mapline.pathname)
-                elif mapline.type == "s":
-                        act = link.LinkAction(path=mapline.pathname,
-                            target=mapline.target)
-                elif mapline.type == "l":
-                        act = hardlink.HardLinkAction(path=mapline.pathname,
-                            target=mapline.target)
-                elif mapline.type == "i" and mapline.pathname == "copyright":
-                        act = license.LicenseAction(ci.extractfile(),
-                            license="{0}.copyright".format(self.pkgname))
-                        act.hash = "install/copyright"
-                elif mapline.type == "i":
-                        if mapline.pathname not in ["depend", "pkginfo"]:
-                                # check to see if we've seen this script
-                                # before
-                                script = mapline.pathname
-                                if script.startswith("i.") and \
-                                    script.replace("i.", "", 1) in \
-                                    self.class_action_names:
-                                        pass
-                                elif script.startswith("r.") and \
-                                    script.replace("r.", "", 1) in \
-                                    self.class_action_names:
-                                        pass
-                                else:
-                                        self.scripts.add(script)
-                        return None
+        for p in self.pkg.manifest:
+            if p.type in "fevdsl":
+                if p.pathname[0] == "/":
+                    d = "root"
                 else:
-                        act = unknown.UnknownAction(path=mapline.pathname)
+                    d = "reloc/"
+                self.pkgmap[d + p.pathname] = p
+                self.class_actions_dir[p.pathname] = p.klass
+                self.class_action_names.add(p.klass)
+            elif p.type == "i":
+                self.pkgmap["install/" + p.pathname] = p
 
-                if self.hollow and act:
-                        act.attrs[self.hollow_attr] = "true"
-                return act
+    def _walk_bundle(self):
+        for act in self.pkginfo_actions:
+            yield act.attrs.get("path"), act
+
+        for p in self.pkg.datastream:
+            yield p.name, (self.pkgmap, p, p.name)
+
+        # for some reason, some packages may have directories specified
+        # in the pkgmap that don't exist in the archive.  They need to
+        # be found and iterated as well.
+        #
+        # Some of the blastwave packages also have directories in the
+        # archive that don't exist in the package metadata.  I don't see
+        # a whole lot of point in faking those up.
+        for p in self.pkg.manifest:
+            if p.type not in "lsd":
+                continue
+
+            if p.pathname[0] == "/":
+                d = "root"
+            else:
+                d = "reloc/"
+            path = d + p.pathname
+            if (
+                p.type == "d" and path not in self.pkg.datastream
+            ) or p.type in "ls":
+                yield path, (self.pkgmap, None, path)
+
+    def __iter__(self):
+        """Iterate through the datastream.
+
+        This is different than the directory-format package bundle,
+        which iterates through the package map.  We do it this way
+        because the cpio archive might not be in the same order as
+        the package map, and we want never to seek backwards.  This
+        implies that we're going to have to look up the meta info for
+        each file from the package map.  We could get the file type
+        from the archive, but it's probably safe to assume that the
+        file type in the archive is the same as the file type in the
+        package map.
+        """
+        for path, data in self._walk_bundle():
+            if type(data) != tuple:
+                yield data
+                continue
+
+            act = self.action(*data)
+            if act:
+                yield act
+
+    def action(self, pkgmap, ci, path):
+        try:
+            mapline = pkgmap[path]
+        except KeyError:
+            # XXX Return an unknown instead of a missing, for now.
+            return unknown.UnknownAction(path=path)
+
+        act = None
+
+        # If any one of the mode, owner, or group is "?", then we're
+        # clearly not capable of delivering the object correctly, so
+        # ignore it.
+        if mapline.type in "fevdx" and (
+            mapline.mode == "?" or mapline.owner == "?" or mapline.group == "?"
+        ):
+            return None
+
+        if mapline.type in "fev":
+            # false positive
+            # file-builtin; pylint: disable=W1607
+            act = file.FileAction(
+                ci.extractfile(),
+                mode=mapline.mode,
+                owner=mapline.owner,
+                group=mapline.group,
+                path=mapline.pathname,
+                timestamp=misc.time_to_timestamp(int(mapline.modtime)),
+            )
+        elif mapline.type in "dx":
+            act = directory.DirectoryAction(
+                mode=mapline.mode,
+                owner=mapline.owner,
+                group=mapline.group,
+                path=mapline.pathname,
+            )
+        elif mapline.type == "s":
+            act = link.LinkAction(path=mapline.pathname, target=mapline.target)
+        elif mapline.type == "l":
+            act = hardlink.HardLinkAction(
+                path=mapline.pathname, target=mapline.target
+            )
+        elif mapline.type == "i" and mapline.pathname == "copyright":
+            act = license.LicenseAction(
+                ci.extractfile(), license="{0}.copyright".format(self.pkgname)
+            )
+            act.hash = "install/copyright"
+        elif mapline.type == "i":
+            if mapline.pathname not in ["depend", "pkginfo"]:
+                # check to see if we've seen this script
+                # before
+                script = mapline.pathname
+                if (
+                    script.startswith("i.")
+                    and script.replace("i.", "", 1) in self.class_action_names
+                ):
+                    pass
+                elif (
+                    script.startswith("r.")
+                    and script.replace("r.", "", 1) in self.class_action_names
+                ):
+                    pass
+                else:
+                    self.scripts.add(script)
+            return None
+        else:
+            act = unknown.UnknownAction(path=mapline.pathname)
+
+        if self.hollow and act:
+            act.attrs[self.hollow_attr] = "true"
+        return act
+
 
 def test(filename):
-        if not os.path.isfile(filename):
-                return False
+    if not os.path.isfile(filename):
+        return False
 
-        try:
-                SolarisPackage(filename)
-                return True
-        except MultiPackageDatastreamException:
-                raise InvalidBundleException(
-                    _("Multi-package datastreams are not supported.\n"
-                    "Please use pkgtrans(1) to convert this bundle to "
-                    "multiple\nfilesystem format packages."))
-        except:
-                return False
+    try:
+        SolarisPackage(filename)
+        return True
+    except MultiPackageDatastreamException:
+        raise InvalidBundleException(
+            _(
+                "Multi-package datastreams are not supported.\n"
+                "Please use pkgtrans(1) to convert this bundle to "
+                "multiple\nfilesystem format packages."
+            )
+        )
+    except:
+        return False
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/bundle/SolarisPackageDirBundle.py
+++ b/src/modules/bundle/SolarisPackageDirBundle.py
@@ -38,273 +38,294 @@ from pkg.sysvpkg import SolarisPackage
 
 
 class SolarisPackageDirBundle(pkg.bundle.Bundle):
+    hollow_attr = "pkg.send.convert.sunw-pkg-hollow"
 
-        hollow_attr = "pkg.send.convert.sunw-pkg-hollow"
+    def __init__(self, filename, data=True, **kwargs):
+        filename = os.path.normpath(filename)
+        self.pkg = SolarisPackage(filename)
+        self.pkgname = self.pkg.pkginfo["PKG"]
+        self.filename = filename
+        self.data = data
 
-        def __init__(self, filename, data=True, **kwargs):
-                filename = os.path.normpath(filename)
-                self.pkg = SolarisPackage(filename)
-                self.pkgname = self.pkg.pkginfo["PKG"]
-                self.filename = filename
-                self.data = data
+        # map the path name to the SVR4 class it belongs to and
+        # maintain a set of pre/post install/remove and class action
+        # scripts this package uses.
+        self.class_actions_dir = {}
+        self.class_action_names = set()
+        self.scripts = set()
 
-                # map the path name to the SVR4 class it belongs to and
-                # maintain a set of pre/post install/remove and class action
-                # scripts this package uses.
-                self.class_actions_dir = {}
-                self.class_action_names = set()
-                self.scripts = set()
+        self.hollow = (
+            self.pkg.pkginfo.get("SUNW_PKG_HOLLOW", "").lower() == "true"
+        )
+        # A list of pkg.action.AttributeActions with pkginfo
+        # attributes for items that don't map to pkg(7) equivalents
+        self.pkginfo_actions = self.get_pkginfo_actions(self.pkg.pkginfo)
 
-                self.hollow = self.pkg.pkginfo.get("SUNW_PKG_HOLLOW",
-                    "").lower() == "true"
-                # A list of pkg.action.AttributeActions with pkginfo
-                # attributes for items that don't map to pkg(7) equivalents
-                self.pkginfo_actions = self.get_pkginfo_actions(self.pkg.pkginfo)
+    def _walk_bundle(self):
+        faspac = []
+        if "faspac" in self.pkg.pkginfo:
+            faspac = self.pkg.pkginfo["faspac"]
 
-        def _walk_bundle(self):
-                faspac = []
-                if "faspac" in self.pkg.pkginfo:
-                        faspac = self.pkg.pkginfo["faspac"]
+        # Want to access the manifest as a dict.
+        pkgmap = {}
+        for p in self.pkg.manifest:
+            pkgmap[p.pathname] = p
+            self.class_actions_dir[p.pathname] = p.klass
+            self.class_action_names.add(p.klass)
 
-                # Want to access the manifest as a dict.
-                pkgmap = {}
-                for p in self.pkg.manifest:
-                        pkgmap[p.pathname] = p
-                        self.class_actions_dir[p.pathname] = p.klass
-                        self.class_action_names.add(p.klass)
+        for act in self.pkginfo_actions:
+            yield act.attrs.get("path"), act
 
-                for act in self.pkginfo_actions:
-                        yield act.attrs.get("path"), act
+        if not self.data:
+            for p in self.pkg.manifest:
+                act = self.action(p, None)
+                if act:
+                    yield act.attrs.get("path"), act
+            return
 
-                if not self.data:
-                        for p in self.pkg.manifest:
-                                act = self.action(p, None)
-                                if act:
-                                        yield act.attrs.get("path"), act
-                        return
+        def j(path):
+            return os.path.join(self.pkg.basedir, path)
 
-                def j(path):
-                        return os.path.join(self.pkg.basedir, path)
+        faspac_contents = set()
 
-                faspac_contents = set()
+        for klass in faspac:
+            fpath = os.path.join(self.filename, "archive", klass)
+            # We accept either bz2 or 7zip'd files
+            for x in [".bz2", ".7z"]:
+                if os.path.exists(fpath + x):
+                    cf = CpioFile.open(fpath + x)
+                    break
 
-                for klass in faspac:
-                        fpath = os.path.join(self.filename, "archive", klass)
-                        # We accept either bz2 or 7zip'd files
-                        for x in [".bz2", ".7z"]:
-                                if os.path.exists(fpath + x):
-                                        cf = CpioFile.open(fpath + x)
-                                        break
+            for ci in cf:
+                faspac_contents.add(j(ci.name))
+                act = self.action(pkgmap[j(ci.name)], ci.extractfile())
+                if act:
+                    yield act.attrs.get("path"), act
 
-                        for ci in cf:
-                                faspac_contents.add(j(ci.name))
-                                act = self.action(pkgmap[j(ci.name)],
-                                    ci.extractfile())
-                                if act:
-                                        yield act.attrs.get("path"), act
+        # Remove BASEDIR from a relocatable path.  The extra work is
+        # because if BASEDIR is not empty (non-"/"), then we probably
+        # need to strip an extra slash from the beginning of the path,
+        # but if BASEDIR is "" ("/" in the pkginfo file), then we don't
+        # need to do anything extra.
+        def r(path, ptype):
+            if ptype == "i":
+                return path
+            if path[0] == "/":
+                return path[1:]
+            p = path[len(self.pkg.basedir) :]
+            if p[0] == "/":
+                p = p[1:]
+            return p
 
-                # Remove BASEDIR from a relocatable path.  The extra work is
-                # because if BASEDIR is not empty (non-"/"), then we probably
-                # need to strip an extra slash from the beginning of the path,
-                # but if BASEDIR is "" ("/" in the pkginfo file), then we don't
-                # need to do anything extra.
-                def r(path, ptype):
-                        if ptype == "i":
-                                return path
-                        if path[0] == "/":
-                                return path[1:]
-                        p = path[len(self.pkg.basedir):]
-                        if p[0] == "/":
-                                p = p[1:]
-                        return p
+        for p in self.pkg.manifest:
+            # Just do the files that remain.  Only regular file
+            # types end up compressed; so skip them and only them.
+            # Files with special characters in their names may not
+            # end up in the faspac archive, so we still need to emit
+            # the ones that aren't.
+            if (
+                p.type in "fev"
+                and p.klass in faspac
+                and p.pathname in faspac_contents
+            ):
+                continue
 
-                for p in self.pkg.manifest:
-                        # Just do the files that remain.  Only regular file
-                        # types end up compressed; so skip them and only them.
-                        # Files with special characters in their names may not
-                        # end up in the faspac archive, so we still need to emit
-                        # the ones that aren't.
-                        if p.type in "fev" and p.klass in faspac and \
-                            p.pathname in faspac_contents:
-                                continue
-
-                        # These are the only valid file types in SysV packages
-                        if p.type in "ifevbcdxpls":
-                                if p.type == "i":
-                                        d = "install"
-                                elif p.pathname[0] == "/":
-                                        d = "root"
-                                else:
-                                        d = "reloc"
-                                act = self.action(p, os.path.join(self.filename,
-                                    d, r(p.pathname, p.type)))
-                                if act:
-                                        if act.name == "license":
-                                                # This relies on the fact that
-                                                # license actions have their
-                                                # hash set to the package path.
-                                                yield act.hash, act
-                                        else:
-                                                yield os.path.join(d, act.attrs.get(
-                                                    "path", "")), act
-
-        def __iter__(self):
-                for entry in self._walk_bundle():
-                        yield entry[-1]
-
-        def action(self, mapline, data):
-                preserve_dict = {
-                    "renameold": "renameold",
-                    "renamenew": "renamenew",
-                    "preserve": "true",
-                    "svmpreserve": "true"
-                }
-
-                act = None
-
-                # If any one of the mode, owner, or group is "?", then we're
-                # clearly not capable of delivering the object correctly, so
-                # ignore it.
-                if mapline.type in "fevdx" and (mapline.mode == "?" or
-                    mapline.owner == "?" or mapline.group == "?"):
-                        return None
-
-                if mapline.type in "fev":
-                        # false positive
-                        # file-builtin; pylint: disable=W1607
-                        act = file.FileAction(data, mode=mapline.mode,
-                            owner=mapline.owner, group=mapline.group,
-                            path=mapline.pathname,
-                            timestamp=misc.time_to_timestamp(int(mapline.modtime)))
-
-                        # Add a preserve attribute if klass is known to be used
-                        # for preservation.  For editable and volatile files,
-                        # always do at least basic preservation.
-                        preserve = preserve_dict.get(mapline.klass, None)
-                        if preserve or mapline.type in "ev":
-                                if not preserve:
-                                        preserve = "true"
-                                act.attrs["preserve"] = preserve
-
-                        if act.hash == "NOHASH" and \
-                            isinstance(data, six.string_types) and \
-                            data.startswith(self.filename):
-                                act.hash = data[len(self.filename) + 1:]
-                elif mapline.type in "dx":
-                        act = directory.DirectoryAction(mode=mapline.mode,
-                            owner=mapline.owner, group=mapline.group,
-                            path=mapline.pathname)
-                elif mapline.type == "s":
-                        act = link.LinkAction(path=mapline.pathname,
-                            target=mapline.target)
-                elif mapline.type == "l":
-                        act = hardlink.HardLinkAction(path=mapline.pathname,
-                            target=mapline.target)
-                elif mapline.type == "i" and mapline.pathname == "copyright":
-                        act = license.LicenseAction(data,
-                            license="{0}.copyright".format(self.pkgname))
-                        if act.hash == "NOHASH" and \
-                            isinstance(data, six.string_types) and \
-                            data.startswith(self.filename):
-                                act.hash = data[len(self.filename) + 1:]
-                elif mapline.type == "i":
-                        if mapline.pathname not in ["depend", "pkginfo"]:
-                                # check to see if we've seen this script
-                                # before
-                                script = mapline.pathname
-                                if script.startswith("i.") and \
-                                    script.replace("i.", "", 1) \
-                                    in self.class_action_names:
-                                        pass
-                                elif script.startswith("r.") and \
-                                    script.replace("r.", "", 1) in \
-                                    self.class_action_names:
-                                        pass
-                                else:
-                                        self.scripts.add(script)
-                        return None
+            # These are the only valid file types in SysV packages
+            if p.type in "ifevbcdxpls":
+                if p.type == "i":
+                    d = "install"
+                elif p.pathname[0] == "/":
+                    d = "root"
                 else:
-                        act = unknown.UnknownAction(path=mapline.pathname)
+                    d = "reloc"
+                act = self.action(
+                    p, os.path.join(self.filename, d, r(p.pathname, p.type))
+                )
+                if act:
+                    if act.name == "license":
+                        # This relies on the fact that
+                        # license actions have their
+                        # hash set to the package path.
+                        yield act.hash, act
+                    else:
+                        yield os.path.join(d, act.attrs.get("path", "")), act
 
-                if self.hollow and act:
-                        act.attrs["pkg.send.convert.sunw-pkg-hollow"] = "true"
-                return act
+    def __iter__(self):
+        for entry in self._walk_bundle():
+            yield entry[-1]
 
-        def get_pkginfo_actions(self, pkginfo):
-                """Creates a list of pkg.action.AttributeActions corresponding
-                to pkginfo fields that aren't directly mapped to pkg(7)
-                equivalents."""
+    def action(self, mapline, data):
+        preserve_dict = {
+            "renameold": "renameold",
+            "renamenew": "renamenew",
+            "preserve": "true",
+            "svmpreserve": "true",
+        }
 
-                # these keys get converted to a legacy action
-                legacy_keys = [
-                    "arch",
-                    "category",
-                    "name",
-                    "desc",
-                    "hotline",
-                    "pkg",
-                    "vendor",
-                    "version"
-                ]
+        act = None
 
-                # parameters defined in pkginfo(5) that we always ignore.
-                # by default, we also ignore SUNW_*
-                ignored_keys = [
-                    "pstamp",
-                    "pkginst",
-                    "maxinst",
-                    "classes",
-                    "basedir",
-                    "intonly",
-                    "istates",
-                    "order",
-                    "rstates",
-                    "ulimit",
-                    # XXX pkg.sysvpkg adds this, ignoring for now.
-                    "pkg.plat",
-                ]
-                ignored_keys.extend(legacy_keys)
+        # If any one of the mode, owner, or group is "?", then we're
+        # clearly not capable of delivering the object correctly, so
+        # ignore it.
+        if mapline.type in "fevdx" and (
+            mapline.mode == "?" or mapline.owner == "?" or mapline.group == "?"
+        ):
+            return None
 
-                actions = []
-                for key in pkginfo:
-                        if not pkginfo[key]:
-                                continue
+        if mapline.type in "fev":
+            # false positive
+            # file-builtin; pylint: disable=W1607
+            act = file.FileAction(
+                data,
+                mode=mapline.mode,
+                owner=mapline.owner,
+                group=mapline.group,
+                path=mapline.pathname,
+                timestamp=misc.time_to_timestamp(int(mapline.modtime)),
+            )
 
-                        name = key.lower()
-                        if name in ignored_keys or "SUNW_" in key:
-                                continue
-                        name = "pkg.send.convert.{0}".format(name)
-                        name = name.replace("_", "-")
-                        actions.append(AttributeAction(name=name,
-                            value=pkginfo[key]))
+            # Add a preserve attribute if klass is known to be used
+            # for preservation.  For editable and volatile files,
+            # always do at least basic preservation.
+            preserve = preserve_dict.get(mapline.klass, None)
+            if preserve or mapline.type in "ev":
+                if not preserve:
+                    preserve = "true"
+                act.attrs["preserve"] = preserve
 
-                legacy_attrs = {}
-                for key in pkginfo:
-                        name = key.lower()
-                        if name in legacy_keys:
-                                name = name.replace("_", "-")
-                                legacy_attrs[name] = pkginfo[key]
+            if (
+                act.hash == "NOHASH"
+                and isinstance(data, six.string_types)
+                and data.startswith(self.filename)
+            ):
+                act.hash = data[len(self.filename) + 1 :]
+        elif mapline.type in "dx":
+            act = directory.DirectoryAction(
+                mode=mapline.mode,
+                owner=mapline.owner,
+                group=mapline.group,
+                path=mapline.pathname,
+            )
+        elif mapline.type == "s":
+            act = link.LinkAction(path=mapline.pathname, target=mapline.target)
+        elif mapline.type == "l":
+            act = hardlink.HardLinkAction(
+                path=mapline.pathname, target=mapline.target
+            )
+        elif mapline.type == "i" and mapline.pathname == "copyright":
+            act = license.LicenseAction(
+                data, license="{0}.copyright".format(self.pkgname)
+            )
+            if (
+                act.hash == "NOHASH"
+                and isinstance(data, six.string_types)
+                and data.startswith(self.filename)
+            ):
+                act.hash = data[len(self.filename) + 1 :]
+        elif mapline.type == "i":
+            if mapline.pathname not in ["depend", "pkginfo"]:
+                # check to see if we've seen this script
+                # before
+                script = mapline.pathname
+                if (
+                    script.startswith("i.")
+                    and script.replace("i.", "", 1) in self.class_action_names
+                ):
+                    pass
+                elif (
+                    script.startswith("r.")
+                    and script.replace("r.", "", 1) in self.class_action_names
+                ):
+                    pass
+                else:
+                    self.scripts.add(script)
+            return None
+        else:
+            act = unknown.UnknownAction(path=mapline.pathname)
 
-                actions.append(LegacyAction(**legacy_attrs))
+        if self.hollow and act:
+            act.attrs["pkg.send.convert.sunw-pkg-hollow"] = "true"
+        return act
 
-                if "DESC" in pkginfo:
-                        actions.append(AttributeAction(name="pkg.description",
-                            value=pkginfo["DESC"]))
-                if "NAME" in pkginfo:
-                        actions.append(AttributeAction(name="pkg.summary",
-                            value=pkginfo["NAME"]))
-                if self.hollow:
-                        for act in actions:
-                                act.attrs[self.hollow_attr] = "true"
+    def get_pkginfo_actions(self, pkginfo):
+        """Creates a list of pkg.action.AttributeActions corresponding
+        to pkginfo fields that aren't directly mapped to pkg(7)
+        equivalents."""
 
-                return actions
+        # these keys get converted to a legacy action
+        legacy_keys = [
+            "arch",
+            "category",
+            "name",
+            "desc",
+            "hotline",
+            "pkg",
+            "vendor",
+            "version",
+        ]
+
+        # parameters defined in pkginfo(5) that we always ignore.
+        # by default, we also ignore SUNW_*
+        ignored_keys = [
+            "pstamp",
+            "pkginst",
+            "maxinst",
+            "classes",
+            "basedir",
+            "intonly",
+            "istates",
+            "order",
+            "rstates",
+            "ulimit",
+            # XXX pkg.sysvpkg adds this, ignoring for now.
+            "pkg.plat",
+        ]
+        ignored_keys.extend(legacy_keys)
+
+        actions = []
+        for key in pkginfo:
+            if not pkginfo[key]:
+                continue
+
+            name = key.lower()
+            if name in ignored_keys or "SUNW_" in key:
+                continue
+            name = "pkg.send.convert.{0}".format(name)
+            name = name.replace("_", "-")
+            actions.append(AttributeAction(name=name, value=pkginfo[key]))
+
+        legacy_attrs = {}
+        for key in pkginfo:
+            name = key.lower()
+            if name in legacy_keys:
+                name = name.replace("_", "-")
+                legacy_attrs[name] = pkginfo[key]
+
+        actions.append(LegacyAction(**legacy_attrs))
+
+        if "DESC" in pkginfo:
+            actions.append(
+                AttributeAction(name="pkg.description", value=pkginfo["DESC"])
+            )
+        if "NAME" in pkginfo:
+            actions.append(
+                AttributeAction(name="pkg.summary", value=pkginfo["NAME"])
+            )
+        if self.hollow:
+            for act in actions:
+                act.attrs[self.hollow_attr] = "true"
+
+        return actions
+
 
 def test(filename):
-        if os.path.isfile(os.path.join(filename, "pkginfo")) and \
-            os.path.isfile(os.path.join(filename, "pkgmap")):
-                return True
+    if os.path.isfile(os.path.join(filename, "pkginfo")) and os.path.isfile(
+        os.path.join(filename, "pkgmap")
+    ):
+        return True
 
-        return False
+    return False
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/bundle/TarBundle.py
+++ b/src/modules/bundle/TarBundle.py
@@ -31,53 +31,60 @@ import pkg.bundle
 import pkg.misc as misc
 from pkg.actions import *
 
+
 class TarBundle(pkg.bundle.Bundle):
+    def __init__(self, filename, **kwargs):
+        # XXX This could be more intelligent.  Or get user input.  Or
+        # extend API to take FMRI.
+        filename = os.path.normpath(filename)
+        self.tf = tarfile.open(filename)
+        self.filename = filename
+        self.pkgname = os.path.basename(filename)
+        self.pkg = None
 
-        def __init__(self, filename, **kwargs):
-                # XXX This could be more intelligent.  Or get user input.  Or
-                # extend API to take FMRI.
-                filename = os.path.normpath(filename)
-                self.tf = tarfile.open(filename)
-                self.filename = filename
-                self.pkgname = os.path.basename(filename)
-                self.pkg = None
+    def __del__(self):
+        self.tf.close()
 
-        def __del__(self):
-                self.tf.close()
+    def _walk_bundle(self):
+        for f in self.tf:
+            yield f.name, (self.tf, f)
 
-        def _walk_bundle(self):
-                for f in self.tf:
-                        yield f.name, (self.tf, f)
+    def __iter__(self):
+        for path, data in self._walk_bundle():
+            yield self.action(*data)
 
-        def __iter__(self):
-                for path, data in self._walk_bundle():
-                        yield self.action(*data)
+    def action(self, tarfile, tarinfo):
+        if tarinfo.isreg():
+            # false positive
+            # file-builtin; pylint: disable=W1607
+            return file.FileAction(
+                tarfile.extractfile(tarinfo),
+                mode=oct(stat.S_IMODE(tarinfo.mode)),
+                owner=tarinfo.uname,
+                group=tarinfo.gname,
+                path=tarinfo.name,
+                timestamp=misc.time_to_timestamp(tarinfo.mtime),
+            )
+        elif tarinfo.isdir():
+            return directory.DirectoryAction(
+                mode=oct(stat.S_IMODE(tarinfo.mode)),
+                owner=tarinfo.uname,
+                group=tarinfo.gname,
+                path=tarinfo.name,
+            )
+        elif tarinfo.issym():
+            return link.LinkAction(path=tarinfo.name, target=tarinfo.linkname)
+        elif tarinfo.islnk():
+            return hardlink.HardLinkAction(
+                path=tarinfo.name, target=tarinfo.linkname
+            )
+        else:
+            return unknown.UnknownAction(path=tarinfo.name)
 
-        def action(self, tarfile, tarinfo):
-                if tarinfo.isreg():
-                        # false positive
-                        # file-builtin; pylint: disable=W1607
-                        return file.FileAction(tarfile.extractfile(tarinfo),
-                            mode=oct(stat.S_IMODE(tarinfo.mode)),
-                            owner=tarinfo.uname, group=tarinfo.gname,
-                            path=tarinfo.name,
-                            timestamp=misc.time_to_timestamp(tarinfo.mtime))
-                elif tarinfo.isdir():
-                        return directory.DirectoryAction(
-                            mode=oct(stat.S_IMODE(tarinfo.mode)),
-                            owner=tarinfo.uname, group=tarinfo.gname,
-                            path=tarinfo.name)
-                elif tarinfo.issym():
-                        return link.LinkAction(path=tarinfo.name,
-                            target=tarinfo.linkname)
-                elif tarinfo.islnk():
-                        return hardlink.HardLinkAction(path=tarinfo.name,
-                            target=tarinfo.linkname)
-                else:
-                        return unknown.UnknownAction(path=tarinfo.name)
 
 def test(filename):
-        return tarfile.is_tarfile(filename)
+    return tarfile.is_tarfile(filename)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/bundle/__init__.py
+++ b/src/modules/bundle/__init__.py
@@ -33,84 +33,90 @@ __all__ = [
     "SolarisPackageDirBundle",
     "DirectoryBundle",
     "SolarisPackageDatastreamBundle",
-    "TarBundle"
+    "TarBundle",
 ]
 
 import os
 import sys
 
+
 class InvalidBundleException(Exception):
-        pass
+    pass
 
 
 class InvalidOwnershipException(InvalidBundleException):
-        """Raised when gid or uid lookup fails for a file during bundle
-        generation."""
+    """Raised when gid or uid lookup fails for a file during bundle
+    generation."""
 
-        def __init__(self, fname, uid=None, gid=None):
-                InvalidBundleException.__init__(self)
-                self.fname = fname
-                msg = []
-                if uid:
-                        msg.append("UID {uid} is not associated with a user "
-                            "name (file: {fname})".format(uid=uid, fname=fname))
-                if gid:
-                        msg.append("GID {gid} is not associated with a group "
-                            "name (file: {fname})".format(gid=gid, fname=fname))
-                self.msg = '\n'.join(msg)
+    def __init__(self, fname, uid=None, gid=None):
+        InvalidBundleException.__init__(self)
+        self.fname = fname
+        msg = []
+        if uid:
+            msg.append(
+                "UID {uid} is not associated with a user "
+                "name (file: {fname})".format(uid=uid, fname=fname)
+            )
+        if gid:
+            msg.append(
+                "GID {gid} is not associated with a group "
+                "name (file: {fname})".format(gid=gid, fname=fname)
+            )
+        self.msg = "\n".join(msg)
 
-        def __str__(self):
-                return self.msg
+    def __str__(self):
+        return self.msg
 
 
 class Bundle(object):
-        """Base bundle class."""
+    """Base bundle class."""
 
-        def get_action(self, path):
-                """Return the first action that matches the provided path or
-                None."""
-                for apath, data in self._walk_bundle():
-                        if not apath:
-                                continue
-                        npath = apath.lstrip(os.path.sep)
-                        if path == npath:
-                                if type(data) == tuple:
-                                        # Construct action on demand.
-                                        return self.action(*data)
-                                # Action was returned.
-                                return data
+    def get_action(self, path):
+        """Return the first action that matches the provided path or
+        None."""
+        for apath, data in self._walk_bundle():
+            if not apath:
+                continue
+            npath = apath.lstrip(os.path.sep)
+            if path == npath:
+                if type(data) == tuple:
+                    # Construct action on demand.
+                    return self.action(*data)
+                # Action was returned.
+                return data
+
 
 def make_bundle(filename, **kwargs):
-        """Determines what kind of bundle is at the given filename, and returns
-        the appropriate bundle object.
-        """
+    """Determines what kind of bundle is at the given filename, and returns
+    the appropriate bundle object.
+    """
 
-        for btype in __all__:
-                bname = "pkg.bundle.{0}".format(btype)
-                bmodule = __import__(bname)
+    for btype in __all__:
+        bname = "pkg.bundle.{0}".format(btype)
+        bmodule = __import__(bname)
 
-                bmodule = sys.modules[bname]
-                if bmodule.test(filename):
-                        bundle_create = getattr(bmodule, btype)
-                        return bundle_create(filename, **kwargs)
+        bmodule = sys.modules[bname]
+        if bmodule.test(filename):
+            bundle_create = getattr(bmodule, btype)
+            return bundle_create(filename, **kwargs)
 
-        raise TypeError("Unknown bundle type for '{0}'".format(filename))
+    raise TypeError("Unknown bundle type for '{0}'".format(filename))
 
 
 if __name__ == "__main__":
-        try:
-                b = make_bundle(sys.argv[1])
-        except TypeError as e:
-                print(e)
-                sys.exit(1)
+    try:
+        b = make_bundle(sys.argv[1])
+    except TypeError as e:
+        print(e)
+        sys.exit(1)
 
-        for file in b:
-                print(file.type, file.attrs)
-                try:
-                        print(file.attrs["file"])
-                        print(os.stat(file.attrs["file"]))
-                except:
-                        pass
+    for file in b:
+        print(file.type, file.attrs)
+        try:
+            print(file.attrs["file"])
+            print(os.stat(file.attrs["file"]))
+        except:
+            pass
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/catalog.py
+++ b/src/modules/catalog.py
@@ -25,7 +25,7 @@
 """Interfaces and implementation for the Catalog object, as well as functions
 that operate on lists of package FMRIs."""
 
-from __future__ import  print_function
+from __future__ import print_function
 import copy
 import calendar
 import collections
@@ -53,3960 +53,4037 @@ import pkg.version
 
 from pkg.misc import EmptyDict, EmptyI
 
-FEATURE_UTF8 = 'ooce:utf8'
+FEATURE_UTF8 = "ooce:utf8"
+
 
 class _JSONWriter(object):
-        """Private helper class used to serialize catalog data and generate
-        signatures."""
+    """Private helper class used to serialize catalog data and generate
+    signatures."""
 
-        def __init__(self, data, pathname=None, sign=True):
-                self.__data = data
-                self.__fileobj = None
+    def __init__(self, data, pathname=None, sign=True):
+        self.__data = data
+        self.__fileobj = None
 
-                # catalog signatures *must* use sha-1 only since clients
-                # compare entire dictionaries against the reported hash from
-                # the catalog in the various <CatalogPartBase>.validate()
-                # methods rather than just attributes within those dictionaries.
-                # If old clients are to interoperate with new repositories, the
-                # computed and expected dictionaries must be identical at
-                # present, so we must use sha-1.
-                if sign:
-                        if not pathname:
-                                # Only needed if not writing to __fileobj.
-                                self.__sha_1 = hashlib.sha1()
-                        self.__sha_1_value = None
+        # catalog signatures *must* use sha-1 only since clients
+        # compare entire dictionaries against the reported hash from
+        # the catalog in the various <CatalogPartBase>.validate()
+        # methods rather than just attributes within those dictionaries.
+        # If old clients are to interoperate with new repositories, the
+        # computed and expected dictionaries must be identical at
+        # present, so we must use sha-1.
+        if sign:
+            if not pathname:
+                # Only needed if not writing to __fileobj.
+                self.__sha_1 = hashlib.sha1()
+            self.__sha_1_value = None
 
-                self.__sign = sign
-                self.pathname = pathname
+        self.__sign = sign
+        self.pathname = pathname
 
-                if not pathname:
-                        return
+        if not pathname:
+            return
 
-                try:
-                        tfile = open(pathname, "wb")
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise api_errors.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
-                self.__fileobj = tfile
+        try:
+            tfile = open(pathname, "wb")
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise api_errors.ReadOnlyFileSystemException(e.filename)
+            raise
+        self.__fileobj = tfile
 
-        def signatures(self):
-                """Returns a dictionary mapping digest algorithms to the
-                hex-encoded digest values of the text of the catalog."""
+    def signatures(self):
+        """Returns a dictionary mapping digest algorithms to the
+        hex-encoded digest values of the text of the catalog."""
 
-                if not self.__sign:
-                        return {}
-                return { "sha-1": self.__sha_1_value }
+        if not self.__sign:
+            return {}
+        return {"sha-1": self.__sha_1_value}
 
-        def _feature(self, feature):
-                return ('_FEATURE' in self.__data
-                    and feature in self.__data['_FEATURE'])
+    def _feature(self, feature):
+        return "_FEATURE" in self.__data and feature in self.__data["_FEATURE"]
 
-        def _dump(self, obj, fp, skipkeys=False, ensure_ascii=True,
-            allow_nan=True, indent=None, default=None, **kw):
+    def _dump(
+        self,
+        obj,
+        fp,
+        skipkeys=False,
+        ensure_ascii=True,
+        allow_nan=True,
+        indent=None,
+        default=None,
+        **kw,
+    ):
+        if not self._feature(FEATURE_UTF8):
+            kw["ensure_ascii"] = True
+        json.dump(obj=obj, stream=fp, indent=None, **kw)
 
-                if not self._feature(FEATURE_UTF8):
-                        kw['ensure_ascii'] = True
-                json.dump(obj=obj, stream=fp, indent=None, **kw)
+    def save(self):
+        """Serializes and stores the provided data in JSON format."""
 
-        def save(self):
-                """Serializes and stores the provided data in JSON format."""
+        # sort_keys is necessary to ensure consistent signature
+        # generation.  It has a minimal performance cost as well (on
+        # on SPARC and x86), so shouldn't be an issue.  However, it
+        # is only needed if the caller has indicated that the content
+        # should be signed.
 
-                # sort_keys is necessary to ensure consistent signature
-                # generation.  It has a minimal performance cost as well (on
-                # on SPARC and x86), so shouldn't be an issue.  However, it
-                # is only needed if the caller has indicated that the content
-                # should be signed.
+        # Whenever possible, avoid using the write wrapper (self) as
+        # this can greatly increase write times.
+        out = self.__fileobj
+        if not out:
+            out = self
 
-                # Whenever possible, avoid using the write wrapper (self) as
-                # this can greatly increase write times.
-                out = self.__fileobj
-                if not out:
-                        out = self
+        self._dump(self.__data, out, sort_keys=self.__sign)
+        out.write(b"\n")
 
-                self._dump(self.__data, out, sort_keys=self.__sign)
-                out.write(b"\n")
+        if self.__fileobj:
+            self.__fileobj.close()
 
-                if self.__fileobj:
-                        self.__fileobj.close()
+        if not self.__sign or not self.__fileobj:
+            # Can't sign unless a file object is provided.  And if
+            # one is provided, but no signing is to be done, then
+            # ensure the fileobject is discarded.
+            self.__fileobj = None
+            if self.__sign:
+                self.__sha_1_value = self.__sha_1.hexdigest()
+            return
 
-                if not self.__sign or not self.__fileobj:
-                        # Can't sign unless a file object is provided.  And if
-                        # one is provided, but no signing is to be done, then
-                        # ensure the fileobject is discarded.
-                        self.__fileobj = None
-                        if self.__sign:
-                                self.__sha_1_value = self.__sha_1.hexdigest()
-                        return
+        # Ensure file object goes out of scope.
+        self.__fileobj = None
 
-                # Ensure file object goes out of scope.
-                self.__fileobj = None
+        # Calculating sha-1 this way is much faster than intercepting
+        # write calls because of the excessive number of write calls
+        # that json.dump() triggers (1M+ for /dev catalog files).
+        self.__sha_1_value = misc.get_data_digest(
+            self.pathname, hash_func=hashlib.sha1
+        )[0]
 
-                # Calculating sha-1 this way is much faster than intercepting
-                # write calls because of the excessive number of write calls
-                # that json.dump() triggers (1M+ for /dev catalog files).
-                self.__sha_1_value = misc.get_data_digest(self.pathname,
-                    hash_func=hashlib.sha1)[0]
+        # Open the JSON file so that the signature data can be added.
+        with open(self.pathname, "rb+") as sfile:
+            # The last bytes should be "}\n", which is where the
+            # signature data structure needs to be appended.
+            sfile.seek(-2, os.SEEK_END)
 
-                # Open the JSON file so that the signature data can be added.
-                with open(self.pathname, "rb+") as sfile:
-                        # The last bytes should be "}\n", which is where the
-                        # signature data structure needs to be appended.
-                        sfile.seek(-2, os.SEEK_END)
+            # Add the signature data and close.
+            sfoffset = sfile.tell()
+            if sfoffset > 1:
+                # Catalog is not empty, so a separator is
+                # needed.
+                sfile.write(b",")
+            sfile.write(b'"_SIGNATURE":')
+            self._dump(self.signatures(), sfile)
+            sfile.write(b"}\n")
 
-                        # Add the signature data and close.
-                        sfoffset = sfile.tell()
-                        if sfoffset > 1:
-                                # Catalog is not empty, so a separator is
-                                # needed.
-                                sfile.write(b",")
-                        sfile.write(b'"_SIGNATURE":')
-                        self._dump(self.signatures(), sfile)
-                        sfile.write(b"}\n")
+    def write(self, data):
+        """Wrapper function that should not be called by external
+        consumers."""
 
-        def write(self, data):
-                """Wrapper function that should not be called by external
-                consumers."""
+        if self.__sign:
+            self.__sha_1.update(data)
 
-                if self.__sign:
-                        self.__sha_1.update(data)
+    def writelines(self, iterable):
+        """Wrapper function that should not be called by external
+        consumers."""
 
-        def writelines(self, iterable):
-                """Wrapper function that should not be called by external
-                consumers."""
+        for l in iterable:
+            self.__sha_1.update(l)
 
-                for l in iterable:
-                        self.__sha_1.update(l)
+    def __str__(self):
+        if self.pathname:
+            return "JSONWriter to {}".format(self.pathname)
+        return "JSONWriter to memory"
 
-        def __str__(self):
-                if self.pathname:
-                        return 'JSONWriter to {}'.format(self.pathname)
-                return 'JSONWriter to memory'
 
 class CatalogPartBase(object):
-        """A CatalogPartBase object is an abstract class containing core
-        functionality shared between CatalogPart and CatalogAttrs."""
+    """A CatalogPartBase object is an abstract class containing core
+    functionality shared between CatalogPart and CatalogAttrs."""
 
-        # The file mode to be used for all catalog files.
-        __file_mode = stat.S_IRUSR|stat.S_IWUSR|stat.S_IRGRP|stat.S_IROTH
+    # The file mode to be used for all catalog files.
+    __file_mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
 
-        __meta_root = None
-        last_modified = None
-        loaded = False
-        name = None
-        sign = True
-        signatures = None
-        features = None
+    __meta_root = None
+    last_modified = None
+    loaded = False
+    name = None
+    sign = True
+    signatures = None
+    features = None
 
-        def __init__(self, name, meta_root=None, sign=True):
-                """Initializes a CatalogPartBase object."""
+    def __init__(self, name, meta_root=None, sign=True):
+        """Initializes a CatalogPartBase object."""
 
-                self.meta_root = meta_root
-                # Sanity check: part names can't be pathname-ish.
-                if name != os.path.basename(name):
-                        raise UnrecognizedCatalogPart(name)
-                self.name = name
-                self.sign = sign
-                self.signatures = {}
-                self.features = []
+        self.meta_root = meta_root
+        # Sanity check: part names can't be pathname-ish.
+        if name != os.path.basename(name):
+            raise UnrecognizedCatalogPart(name)
+        self.name = name
+        self.sign = sign
+        self.signatures = {}
+        self.features = []
 
-                if not self.meta_root or not self.exists:
-                        # Operations shouldn't attempt to load the part data
-                        # unless meta_root is defined and the data exists.
-                        self.loaded = True
-                        self.last_modified = datetime.datetime.utcnow()
-                else:
-                        self.last_modified = self.__last_modified()
+        if not self.meta_root or not self.exists:
+            # Operations shouldn't attempt to load the part data
+            # unless meta_root is defined and the data exists.
+            self.loaded = True
+            self.last_modified = datetime.datetime.utcnow()
+        else:
+            self.last_modified = self.__last_modified()
 
-        @staticmethod
-        def _gen_signatures(data):
-                f = _JSONWriter(data)
-                f.save()
-                return f.signatures()
+    @staticmethod
+    def _gen_signatures(data):
+        f = _JSONWriter(data)
+        f.save()
+        return f.signatures()
 
-        def __get_meta_root(self):
-                return self.__meta_root
+    def __get_meta_root(self):
+        return self.__meta_root
 
-        def __last_modified(self):
-                """A UTC datetime object representing the time the file used to
-                to store object metadata was modified, or None if it does not
-                exist yet."""
+    def __last_modified(self):
+        """A UTC datetime object representing the time the file used to
+        to store object metadata was modified, or None if it does not
+        exist yet."""
 
-                if not self.exists:
-                        return None
+        if not self.exists:
+            return None
 
+        try:
+            mod_time = os.stat(self.pathname).st_mtime
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                return None
+            raise
+        return datetime.datetime.utcfromtimestamp(mod_time)
+
+    def __set_meta_root(self, path):
+        if path:
+            path = os.path.abspath(path)
+        self.__meta_root = path
+
+    def destroy(self):
+        """Removes any on-disk files that exist for the catalog part and
+        discards all content."""
+
+        if self.pathname:
+            if os.path.exists(self.pathname):
                 try:
-                        mod_time = os.stat(self.pathname).st_mtime
+                    portable.remove(self.pathname)
                 except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                return None
-                        raise
-                return datetime.datetime.utcfromtimestamp(mod_time)
+                    if e.errno == errno.EACCES:
+                        raise api_errors.PermissionsException(e.filename)
+                    if e.errno == errno.EROFS:
+                        raise api_errors.ReadOnlyFileSystemException(e.filename)
+                    raise
+        self.signatures = {}
+        self.features = []
+        self.loaded = False
+        self.last_modified = None
 
-        def __set_meta_root(self, path):
-                if path:
-                        path = os.path.abspath(path)
-                self.__meta_root = path
+    @property
+    def exists(self):
+        """A boolean value indicating wheher a file for the catalog part
+        exists at <self.meta_root>/<self.name>."""
 
-        def destroy(self):
-                """Removes any on-disk files that exist for the catalog part and
-                discards all content."""
+        if not self.pathname:
+            return False
+        return os.path.exists(self.pathname)
 
-                if self.pathname:
-                        if os.path.exists(self.pathname):
-                                try:
-                                        portable.remove(self.pathname)
-                                except EnvironmentError as e:
-                                        if e.errno == errno.EACCES:
-                                                raise api_errors.PermissionsException(
-                                                    e.filename)
-                                        if e.errno == errno.EROFS:
-                                                raise api_errors.ReadOnlyFileSystemException(
-                                                    e.filename)
-                                        raise
-                self.signatures = {}
-                self.features = []
-                self.loaded = False
-                self.last_modified = None
+    def load(self):
+        """Load the serialized data for the catalog part and return the
+        resulting structure."""
 
-        @property
-        def exists(self):
-                """A boolean value indicating wheher a file for the catalog part
-                exists at <self.meta_root>/<self.name>."""
+        location = os.path.join(self.meta_root, self.name)
 
-                if not self.pathname:
-                        return False
-                return os.path.exists(self.pathname)
+        try:
+            fobj = open(location, "rb")
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                raise api_errors.RetrievalError(e, location=location)
+            if e.errno == errno.EROFS:
+                raise api_errors.ReadOnlyFileSystemException(e.filename)
+            if e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(e.filename)
+            raise
 
-        def load(self):
-                """Load the serialized data for the catalog part and return the
-                resulting structure."""
+        try:
+            struct = json.load(fobj)
+        except EnvironmentError as e:
+            raise api_errors.RetrievalError(e)
+        except ValueError as e:
+            # Not a valid catalog file.
+            raise api_errors.InvalidCatalogFile(location)
 
-                location = os.path.join(self.meta_root, self.name)
+        fobj.close()
 
-                try:
-                        fobj = open(location, "rb")
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                raise api_errors.RetrievalError(e,
-                                    location=location)
-                        if e.errno == errno.EROFS:
-                                raise api_errors.ReadOnlyFileSystemException(
-                                    e.filename)
-                        if e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    e.filename)
-                        raise
+        self.loaded = True
+        # Signature data, if present, should be removed from the struct
+        # on load and then stored in the signatures object property.
+        self.signatures = struct.pop("_SIGNATURE", {})
+        if "_FEATURE" in struct:
+            self.features = struct["_FEATURE"]
+        return struct
 
-                try:
-                        struct = json.load(fobj)
-                except EnvironmentError as e:
-                        raise api_errors.RetrievalError(e)
-                except ValueError as e:
-                        # Not a valid catalog file.
-                        raise api_errors.InvalidCatalogFile(location)
+    @property
+    def pathname(self):
+        """The absolute path of the file used to store the data for
+        this part or None if meta_root or name is not set."""
 
-                fobj.close()
+        if not self.meta_root or not self.name:
+            return None
+        return os.path.join(self.meta_root, self.name)
 
-                self.loaded = True
-                # Signature data, if present, should be removed from the struct
-                # on load and then stored in the signatures object property.
-                self.signatures = struct.pop("_SIGNATURE", {})
-                if "_FEATURE" in struct:
-                        self.features = struct["_FEATURE"]
-                return struct
+    def save(self, data):
+        """Serialize and store the transformed catalog part's 'data' in
+        a file using the pathname <self.meta_root>/<self.name>.
 
-        @property
-        def pathname(self):
-                """The absolute path of the file used to store the data for
-                this part or None if meta_root or name is not set."""
+        'data' must be a dict."""
 
-                if not self.meta_root or not self.name:
-                        return None
-                return os.path.join(self.meta_root, self.name)
+        f = _JSONWriter(data, pathname=self.pathname, sign=self.sign)
+        f.save()
 
-        def save(self, data):
-                """Serialize and store the transformed catalog part's 'data' in
-                a file using the pathname <self.meta_root>/<self.name>.
+        # Update in-memory copy to reflect stored data.
+        self.signatures = f.signatures()
 
-                'data' must be a dict."""
+        # Ensure the permissions on the new file are correct.
+        try:
+            os.chmod(self.pathname, self.__file_mode)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise api_errors.ReadOnlyFileSystemException(e.filename)
+            raise
 
-                f = _JSONWriter(data, pathname=self.pathname, sign=self.sign)
-                f.save()
+        # Finally, set the file times to match the last catalog change.
+        if self.last_modified:
+            mtime = calendar.timegm(self.last_modified.utctimetuple())
+            os.utime(self.pathname, (mtime, mtime))
 
-                # Update in-memory copy to reflect stored data.
-                self.signatures = f.signatures()
+    def set_feature(self, feature, state):
+        if state:
+            if feature not in self.features:
+                self.features.append(feature)
+        else:
+            if feature in self.features:
+                self.features.remove(feature)
 
-                # Ensure the permissions on the new file are correct.
-                try:
-                        os.chmod(self.pathname, self.__file_mode)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise api_errors.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
+    def feature(self, feature):
+        return feature in self.features
 
-                # Finally, set the file times to match the last catalog change.
-                if self.last_modified:
-                        mtime = calendar.timegm(
-                            self.last_modified.utctimetuple())
-                        os.utime(self.pathname, (mtime, mtime))
-
-        def set_feature(self, feature, state):
-                if state:
-                        if feature not in self.features:
-                                self.features.append(feature)
-                else:
-                        if feature in self.features:
-                                self.features.remove(feature)
-
-        def feature(self, feature):
-                return feature in self.features
-
-        meta_root = property(__get_meta_root, __set_meta_root)
+    meta_root = property(__get_meta_root, __set_meta_root)
 
 
 class CatalogPart(CatalogPartBase):
-        """A CatalogPart object is the representation of a subset of the package
-        FMRIs available from a package repository."""
+    """A CatalogPart object is the representation of a subset of the package
+    FMRIs available from a package repository."""
 
-        __data = None
-        ordered = None
+    __data = None
+    ordered = None
 
-        def __init__(self, name, meta_root=None, ordered=True, sign=True):
-                """Initializes a CatalogPart object."""
+    def __init__(self, name, meta_root=None, ordered=True, sign=True):
+        """Initializes a CatalogPart object."""
 
-                self.__data = {}
-                self.ordered = ordered
-                if not name.startswith("catalog."):
-                        raise UnrecognizedCatalogPart(name)
-                CatalogPartBase.__init__(self, name, meta_root=meta_root,
-                    sign=sign)
+        self.__data = {}
+        self.ordered = ordered
+        if not name.startswith("catalog."):
+            raise UnrecognizedCatalogPart(name)
+        CatalogPartBase.__init__(self, name, meta_root=meta_root, sign=sign)
 
-        def __iter_entries(self, last=False, ordered=False, pubs=EmptyI):
-                """Private generator function to iterate over catalog entries.
+    def __iter_entries(self, last=False, ordered=False, pubs=EmptyI):
+        """Private generator function to iterate over catalog entries.
 
-                'last' is a boolean value that indicates only the last entry
-                for each package on a per-publisher basis should be returned.
-                As long as the CatalogPart has been saved since the last
-                modifying operation, or sort() has has been called, this will
-                also be the newest version of the package.
+        'last' is a boolean value that indicates only the last entry
+        for each package on a per-publisher basis should be returned.
+        As long as the CatalogPart has been saved since the last
+        modifying operation, or sort() has has been called, this will
+        also be the newest version of the package.
 
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
 
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
 
-                self.load()
-                if ordered:
-                        stems = self.pkg_names(pubs=pubs)
-                else:
-                        stems = (
-                            (pub, stem)
-                            for pub in self.publishers(pubs=pubs)
-                            for stem in self.__data[pub]
-                        )
+        self.load()
+        if ordered:
+            stems = self.pkg_names(pubs=pubs)
+        else:
+            stems = (
+                (pub, stem)
+                for pub in self.publishers(pubs=pubs)
+                for stem in self.__data[pub]
+            )
 
-                if last:
-                        return (
-                            (pub, stem, self.__data[pub][stem][-1])
-                            for pub, stem in stems
-                        )
+        if last:
+            return (
+                (pub, stem, self.__data[pub][stem][-1]) for pub, stem in stems
+            )
 
-                if ordered:
-                        return (
-                            (pub, stem, entry)
-                            for pub, stem in stems
-                            for entry in reversed(self.__data[pub][stem])
-                        )
-                return (
-                    (pub, stem, entry)
-                    for pub, stem in stems
-                    for entry in self.__data[pub][stem]
+        if ordered:
+            return (
+                (pub, stem, entry)
+                for pub, stem in stems
+                for entry in reversed(self.__data[pub][stem])
+            )
+        return (
+            (pub, stem, entry)
+            for pub, stem in stems
+            for entry in self.__data[pub][stem]
+        )
+
+    def add(
+        self,
+        pfmri=None,
+        metadata=None,
+        op_time=None,
+        pub=None,
+        stem=None,
+        ver=None,
+    ):
+        """Add a catalog entry for a given FMRI or FMRI components.
+
+        'metadata' is an optional dict containing the catalog
+        metadata that should be stored for the specified FMRI.
+
+        The dict representing the entry is returned to callers,
+        but should not be modified.
+        """
+
+        assert pfmri or (pub and stem and ver)
+        if pfmri and not pfmri.publisher:
+            raise api_errors.AnarchicalCatalogFMRI(str(pfmri))
+
+        if not self.loaded:
+            # Hot path, so avoid calling load unless necessary, even
+            # though it performs this check already.
+            self.load()
+
+        if pfmri:
+            pub, stem, ver = pfmri.tuple()
+            ver = str(ver)
+
+        pkg_list = self.__data.setdefault(pub, {})
+        ver_list = pkg_list.setdefault(stem, [])
+        for entry in ver_list:
+            if entry["version"] == ver:
+                if not pfmri:
+                    pfmri = "pkg://{0}/{1}@{2}".format(pub, stem, ver)
+                raise api_errors.DuplicateCatalogEntry(
+                    pfmri, operation="add", catalog_name=self.pathname
                 )
 
-        def add(self, pfmri=None, metadata=None, op_time=None, pub=None,
-            stem=None, ver=None):
-                """Add a catalog entry for a given FMRI or FMRI components.
+        if metadata is not None:
+            entry = metadata
+        else:
+            entry = {}
+        entry["version"] = ver
 
-                'metadata' is an optional dict containing the catalog
-                metadata that should be stored for the specified FMRI.
+        ver_list.append(entry)
+        if self.ordered:
+            self.sort(pfmris=set([pfmri]))
 
-                The dict representing the entry is returned to callers,
-                but should not be modified.
-                """
+        if not op_time:
+            op_time = datetime.datetime.utcnow()
+        self.last_modified = op_time
+        self.signatures = {}
+        return entry
 
-                assert pfmri or (pub and stem and ver)
-                if pfmri and not pfmri.publisher:
-                        raise api_errors.AnarchicalCatalogFMRI(str(pfmri))
+    def destroy(self):
+        """Removes any on-disk files that exist for the catalog part and
+        discards all content."""
 
-                if not self.loaded:
-                        # Hot path, so avoid calling load unless necessary, even
-                        # though it performs this check already.
-                        self.load()
+        self.__data = {}
+        return CatalogPartBase.destroy(self)
 
-                if pfmri:
-                        pub, stem, ver = pfmri.tuple()
-                        ver = str(ver)
+    def entries(self, cb=None, last=False, ordered=False, pubs=EmptyI):
+        """A generator function that produces tuples of the form
+        (fmri, entry) as it iterates over the contents of the catalog
+        part (where entry is the related catalog entry for the fmri).
+        Callers should not modify any of the data that is returned.
 
-                pkg_list = self.__data.setdefault(pub, {})
-                ver_list = pkg_list.setdefault(stem, [])
-                for entry in ver_list:
-                        if entry["version"] == ver:
-                                if not pfmri:
-                                        pfmri = "pkg://{0}/{1}@{2}".format(pub,
-                                            stem, ver)
-                                raise api_errors.DuplicateCatalogEntry(
-                                    pfmri, operation="add",
-                                    catalog_name=self.pathname)
+        'cb' is an optional callback function that will be executed for
+        each package. It must accept two arguments: 'pkg' and 'entry'.
+        'pkg' is an FMRI object and 'entry' is the dictionary structure
+        of the catalog entry for the package.  If the callback returns
+        False, then the entry will not be included in the results.
 
-                if metadata is not None:
-                        entry = metadata
-                else:
-                        entry = {}
-                entry["version"] = ver
+        'last' is a boolean value that indicates only the last entry
+        for each package on a per-publisher basis should be returned.
+        As long as the CatalogPart has been saved since the last
+        modifying operation, or sort() has has been called, this will
+        also be the newest version of the package.
 
-                ver_list.append(entry)
-                if self.ordered:
-                        self.sort(pfmris=set([pfmri]))
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
 
-                if not op_time:
-                        op_time = datetime.datetime.utcnow()
-                self.last_modified = op_time
-                self.signatures = {}
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to.
+
+        Results are always in catalog version order on a per-
+        publisher, per-stem basis.
+        """
+
+        for pub, stem, entry in self.__iter_entries(
+            last=last, ordered=ordered, pubs=pubs
+        ):
+            f = fmri.PkgFmri(name=stem, publisher=pub, version=entry["version"])
+            if cb is None or cb(f, entry):
+                yield f, entry
+
+    def entries_by_version(self, name, pubs=EmptyI):
+        """A generator function that produces tuples of (version,
+        entries), where entries is a list of tuples of the format
+        (fmri, entry) where entry is the catalog entry for the
+        FMRI) as it iterates over the CatalogPart contents.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        self.load()
+
+        versions = {}
+        entries = {}
+        for pub in self.publishers(pubs=pubs):
+            ver_list = self.__data[pub].get(name, ())
+            for entry in ver_list:
+                sver = entry["version"]
+                pfmri = fmri.PkgFmri(name=name, publisher=pub, version=sver)
+
+                versions[sver] = pfmri.version
+                entries.setdefault(sver, [])
+                entries[sver].append((pfmri, entry))
+
+        for key, ver in sorted(six.iteritems(versions), key=itemgetter(1)):
+            yield ver, entries[key]
+
+    def fmris(self, last=False, objects=True, ordered=False, pubs=EmptyI):
+        """A generator function that produces FMRIs as it iterates
+        over the contents of the catalog part.
+
+        'last' is a boolean value that indicates only the last fmri
+        for each package on a per-publisher basis should be returned.
+        As long as the CatalogPart has been saved since the last
+        modifying operation, or sort() has has been called, this will
+        also be the newest version of the package.
+
+        'objects' is an optional boolean value indicating whether
+        FMRIs should be returned as FMRI objects or as strings.
+
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to.
+
+        Results are always in catalog version order on a per-
+        publisher, per-stem basis."""
+
+        if objects:
+            for pub, stem, entry in self.__iter_entries(
+                last=last, ordered=ordered, pubs=pubs
+            ):
+                yield fmri.PkgFmri(
+                    name=stem, publisher=pub, version=entry["version"]
+                )
+            return
+
+        for pub, stem, entry in self.__iter_entries(
+            last=last, ordered=ordered, pubs=pubs
+        ):
+            yield "pkg://{0}/{1}@{2}".format(pub, stem, entry["version"])
+        return
+
+    def fmris_by_version(self, name, pubs=EmptyI):
+        """A generator function that produces tuples of (version,
+        fmris), where fmris is a list of the fmris related to the
+        version.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        self.load()
+
+        versions = {}
+        entries = {}
+        for pub in self.publishers(pubs=pubs):
+            ver_list = self.__data[pub].get(name, None)
+            if not ver_list:
+                continue
+
+            for entry in ver_list:
+                sver = entry["version"]
+                pfmri = fmri.PkgFmri(name=name, publisher=pub, version=sver)
+
+                versions[sver] = pfmri.version
+                entries.setdefault(sver, [])
+                entries[sver].append(pfmri)
+
+        for key, ver in sorted(six.iteritems(versions), key=itemgetter(1)):
+            yield ver, entries[key]
+
+    def get_entry(self, pfmri=None, pub=None, stem=None, ver=None):
+        """Returns the catalog part entry for the given package FMRI or
+        FMRI components."""
+
+        assert pfmri or (pub and stem and ver)
+        if pfmri and not pfmri.publisher:
+            raise api_errors.AnarchicalCatalogFMRI(str(pfmri))
+
+        # Since this is a hot path, this function checks for loaded
+        # status before attempting to call the load function.
+        if not self.loaded:
+            self.load()
+
+        if pfmri:
+            pub, stem, ver = pfmri.tuple()
+            ver = str(ver)
+
+        pkg_list = self.__data.get(pub, None)
+        if not pkg_list:
+            return
+
+        ver_list = pkg_list.get(stem, ())
+        for entry in ver_list:
+            if entry["version"] == ver:
                 return entry
 
-        def destroy(self):
-                """Removes any on-disk files that exist for the catalog part and
-                discards all content."""
+    def get_package_counts(self):
+        """Returns a tuple of integer values (package_count,
+        package_version_count).  The first is the number of
+        unique packages (per-publisher), and the second is the
+        number of unique package versions (per-publisher and
+        stem)."""
 
-                self.__data = {}
-                return CatalogPartBase.destroy(self)
+        self.load()
+        package_count = 0
+        package_version_count = 0
+        for pub in self.publishers():
+            for stem in self.__data[pub]:
+                package_count += 1
+                package_version_count += len(self.__data[pub][stem])
+        return (package_count, package_version_count)
 
-        def entries(self, cb=None, last=False, ordered=False, pubs=EmptyI):
-                """A generator function that produces tuples of the form
-                (fmri, entry) as it iterates over the contents of the catalog
-                part (where entry is the related catalog entry for the fmri).
-                Callers should not modify any of the data that is returned.
+    def get_package_counts_by_pub(self, pubs=EmptyI):
+        """Returns a generator of tuples of the form (pub,
+        package_count, package_version_count).  'pub' is the publisher
+        prefix, 'package_count' is the number of unique packages for the
+        publisher, and 'package_version_count' is the number of unique
+        package versions for the publisher.
+        """
 
-                'cb' is an optional callback function that will be executed for
-                each package. It must accept two arguments: 'pkg' and 'entry'.
-                'pkg' is an FMRI object and 'entry' is the dictionary structure
-                of the catalog entry for the package.  If the callback returns
-                False, then the entry will not be included in the results.
+        self.load()
+        for pub in self.publishers(pubs=pubs):
+            package_count = 0
+            package_version_count = 0
+            for stem in self.__data[pub]:
+                package_count += 1
+                package_version_count += len(self.__data[pub][stem])
+            yield pub, package_count, package_version_count
 
-                'last' is a boolean value that indicates only the last entry
-                for each package on a per-publisher basis should be returned.
-                As long as the CatalogPart has been saved since the last
-                modifying operation, or sort() has has been called, this will
-                also be the newest version of the package.
+    def load(self):
+        """Load and transform the catalog part's data, preparing it
+        for use."""
 
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
+        if self.loaded:
+            # Already loaded, or only in-memory.
+            return
+        self.__data = CatalogPartBase.load(self)
 
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to.
+    def names(self, pubs=EmptyI):
+        """Returns a set containing the names of all the packages in
+        the CatalogPart.
 
-                Results are always in catalog version order on a per-
-                publisher, per-stem basis.
-                """
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
 
-                for pub, stem, entry in self.__iter_entries(last=last,
-                    ordered=ordered, pubs=pubs):
-                        f = fmri.PkgFmri(name=stem, publisher=pub,
-                            version=entry["version"])
-                        if cb is None or cb(f, entry):
-                                yield f, entry
+        self.load()
+        return set(
+            (
+                stem
+                for pub in self.publishers(pubs=pubs)
+                for stem in self.__data[pub]
+            )
+        )
 
-        def entries_by_version(self, name, pubs=EmptyI):
-                """A generator function that produces tuples of (version,
-                entries), where entries is a list of tuples of the format
-                (fmri, entry) where entry is the catalog entry for the
-                FMRI) as it iterates over the CatalogPart contents.
+    def pkg_names(self, pubs=EmptyI):
+        """A generator function that produces package tuples of the form
+        (pub, stem) as it iterates over the contents of the CatalogPart.
 
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to.  If specified, publishers will be sorted in
+        the order given.
 
-                self.load()
+        Results are always returned sorted by stem and then by
+        publisher."""
 
-                versions = {}
-                entries = {}
-                for pub in self.publishers(pubs=pubs):
-                        ver_list = self.__data[pub].get(name, ())
-                        for entry in ver_list:
-                                sver = entry["version"]
-                                pfmri = fmri.PkgFmri(name=name, publisher=pub,
-                                    version=sver)
+        self.load()
 
-                                versions[sver] = pfmri.version
-                                entries.setdefault(sver, [])
-                                entries[sver].append((pfmri, entry))
+        # Results have to be sorted by stem first, and by
+        # publisher prefix second.
+        pkg_list = [
+            "{0}!{1}".format(stem, pub)
+            for pub in self.publishers(pubs=pubs)
+            for stem in self.__data[pub]
+        ]
 
-                for key, ver in sorted(six.iteritems(versions), key=itemgetter(1)):
-                        yield ver, entries[key]
+        pub_sort = None
+        if pubs:
+            pos = dict((p, i) for (i, p) in enumerate(pubs))
 
-        def fmris(self, last=False, objects=True, ordered=False, pubs=EmptyI):
-                """A generator function that produces FMRIs as it iterates
-                over the contents of the catalog part.
+            def pub_key(a):
+                astem, apub = a.split("!", 1)
+                return (astem, pos[apub])
 
-                'last' is a boolean value that indicates only the last fmri
-                for each package on a per-publisher basis should be returned.
-                As long as the CatalogPart has been saved since the last
-                modifying operation, or sort() has has been called, this will
-                also be the newest version of the package.
+            pub_sort = pub_key
 
-                'objects' is an optional boolean value indicating whether
-                FMRIs should be returned as FMRI objects or as strings.
+        for entry in sorted(pkg_list, key=pub_sort):
+            stem, pub = entry.split("!", 1)
+            yield pub, stem
 
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
+    def publishers(self, pubs=EmptyI):
+        """A generator function that returns publisher prefixes as it
+        iterates over the package data in the CatalogPart.
 
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to.
+        'pubs' is an optional list that contains the prefixes of the
+        publishers to restrict the results to."""
 
-                Results are always in catalog version order on a per-
-                publisher, per-stem basis."""
+        self.load()
+        for pub in self.__data:
+            # Any entries starting with "_" are part of the
+            # reserved catalog namespace.
+            if not pub[0] == "_" and (not pubs or pub in pubs):
+                yield pub
 
-                if objects:
-                        for pub, stem, entry in self.__iter_entries(last=last,
-                            ordered=ordered, pubs=pubs):
-                                yield fmri.PkgFmri(name=stem, publisher=pub,
-                                    version=entry["version"])
-                        return
+    def remove(self, pfmri, op_time=None):
+        """Remove a package and its metadata."""
 
-                for pub, stem, entry in self.__iter_entries(last=last,
-                    ordered=ordered, pubs=pubs):
-                        yield "pkg://{0}/{1}@{2}".format(pub,
-                            stem, entry["version"])
-                return
+        if not pfmri.publisher:
+            raise api_errors.AnarchicalCatalogFMRI(pfmri.get_fmri())
 
-        def fmris_by_version(self, name, pubs=EmptyI):
-                """A generator function that produces tuples of (version,
-                fmris), where fmris is a list of the fmris related to the
-                version.
+        self.load()
+        pkg_list = self.__data.get(pfmri.publisher, None)
+        if not pkg_list:
+            raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
 
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                self.load()
-
-                versions = {}
-                entries = {}
-                for pub in self.publishers(pubs=pubs):
-                        ver_list = self.__data[pub].get(name, None)
-                        if not ver_list:
-                                continue
-
-                        for entry in ver_list:
-                                sver = entry["version"]
-                                pfmri = fmri.PkgFmri(name=name, publisher=pub,
-                                    version=sver)
-
-                                versions[sver] = pfmri.version
-                                entries.setdefault(sver, [])
-                                entries[sver].append(pfmri)
-
-                for key, ver in sorted(six.iteritems(versions), key=itemgetter(1)):
-                        yield ver, entries[key]
-
-        def get_entry(self, pfmri=None, pub=None, stem=None, ver=None):
-                """Returns the catalog part entry for the given package FMRI or
-                FMRI components."""
-
-                assert pfmri or (pub and stem and ver)
-                if pfmri and not pfmri.publisher:
-                        raise api_errors.AnarchicalCatalogFMRI(str(pfmri))
-
-                # Since this is a hot path, this function checks for loaded
-                # status before attempting to call the load function.
-                if not self.loaded:
-                        self.load()
-
-                if pfmri:
-                        pub, stem, ver = pfmri.tuple()
-                        ver = str(ver)
-
-                pkg_list = self.__data.get(pub, None)
+        ver = str(pfmri.version)
+        ver_list = pkg_list.get(pfmri.pkg_name, [])
+        for i, entry in enumerate(ver_list):
+            if entry["version"] == ver:
+                # Safe to do this since a 'break' is done
+                # immediately after removals are performed.
+                del ver_list[i]
+                if not ver_list:
+                    # When all version entries for a
+                    # package are removed, its stem
+                    # should be also.
+                    del pkg_list[pfmri.pkg_name]
                 if not pkg_list:
-                        return
+                    # When all package stems for a
+                    # publisher have been removed,
+                    # it should be also.
+                    del self.__data[pfmri.publisher]
+                break
+        else:
+            raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
 
-                ver_list = pkg_list.get(stem, ())
-                for entry in ver_list:
-                        if entry["version"] == ver:
-                                return entry
+        if not op_time:
+            op_time = datetime.datetime.utcnow()
+        self.last_modified = op_time
+        self.signatures = {}
 
-        def get_package_counts(self):
-                """Returns a tuple of integer values (package_count,
-                package_version_count).  The first is the number of
-                unique packages (per-publisher), and the second is the
-                number of unique package versions (per-publisher and
-                stem)."""
+    def save(self):
+        """Transform and store the catalog part's data in a file using
+        the pathname <self.meta_root>/<self.name>."""
 
-                self.load()
-                package_count = 0
-                package_version_count = 0
-                for pub in self.publishers():
-                        for stem in self.__data[pub]:
-                                package_count += 1
-                                package_version_count += \
-                                    len(self.__data[pub][stem])
-                return (package_count, package_version_count)
+        if not self.meta_root:
+            # Assume this is in-memory only.
+            return
 
-        def get_package_counts_by_pub(self, pubs=EmptyI):
-                """Returns a generator of tuples of the form (pub,
-                package_count, package_version_count).  'pub' is the publisher
-                prefix, 'package_count' is the number of unique packages for the
-                publisher, and 'package_version_count' is the number of unique
-                package versions for the publisher.
-                """
+        # Ensure content is loaded before attempting save.
+        self.load()
 
-                self.load()
-                for pub in self.publishers(pubs=pubs):
-                        package_count = 0
-                        package_version_count = 0
-                        for stem in self.__data[pub]:
-                                package_count += 1
-                                package_version_count += \
-                                    len(self.__data[pub][stem])
-                        yield pub, package_count, package_version_count
+        if len(self.features):
+            self.__data["_FEATURE"] = self.features
+        CatalogPartBase.save(self, self.__data)
 
-        def load(self):
-                """Load and transform the catalog part's data, preparing it
-                for use."""
+    def sort(self, pfmris=None, pubs=None):
+        """Re-sorts the contents of the CatalogPart such that version
+        entries for each package stem are in ascending order.
 
-                if self.loaded:
-                        # Already loaded, or only in-memory.
-                        return
-                self.__data = CatalogPartBase.load(self)
+        'pfmris' is an optional set of FMRIs to restrict the sort to.
+        This is useful during catalog operations as only entries for
+        the corresponding package stem(s) need to be sorted.
 
-        def names(self, pubs=EmptyI):
-                """Returns a set containing the names of all the packages in
-                the CatalogPart.
+        'pubs' is an optional set of publisher prefixes to restrict
+        the sort to.  This is useful during catalog operations as only
+        entries for the corresponding publisher stem(s) need to be
+        sorted.  This option has no effect if 'pfmris' is also
+        provided.
 
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
+        If neither 'pfmris' or 'pubs' is provided, all entries will be
+        sorted."""
 
-                self.load()
-                return set((
-                    stem
-                    for pub in self.publishers(pubs=pubs)
-                    for stem in self.__data[pub]
-                ))
+        def key_func(item):
+            return pkg.version.Version(item["version"])
 
-        def pkg_names(self, pubs=EmptyI):
-                """A generator function that produces package tuples of the form
-                (pub, stem) as it iterates over the contents of the CatalogPart.
+        self.load()
+        if pfmris is not None:
+            processed = set()
+            for f in pfmris:
+                pkg_stem = f.get_pkg_stem()
+                if pkg_stem in processed:
+                    continue
+                processed.add(pkg_stem)
 
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to.  If specified, publishers will be sorted in
-                the order given.
+                # The specified FMRI may not exist in this
+                # CatalogPart, so continue if it does not
+                # exist.
+                pkg_list = self.__data.get(f.publisher, None)
+                if pkg_list:
+                    ver_list = pkg_list.get(f.pkg_name, None)
+                    if ver_list:
+                        ver_list.sort(key=key_func)
+            return
 
-                Results are always returned sorted by stem and then by
-                publisher."""
+        for pub in self.publishers(pubs=pubs):
+            for stem in self.__data[pub]:
+                self.__data[pub][stem].sort(key=key_func)
 
-                self.load()
+    def tuples(self, last=False, ordered=False, pubs=EmptyI):
+        """A generator function that produces FMRI tuples as it
+        iterates over the contents of the catalog part.
 
-                # Results have to be sorted by stem first, and by
-                # publisher prefix second.
-                pkg_list = [
-                        "{0}!{1}".format(stem, pub)
-                        for pub in self.publishers(pubs=pubs)
-                        for stem in self.__data[pub]
-                ]
+        'last' is a boolean value that indicates only the last FMRI
+        tuple for each package on a per-publisher basis should be
+        returned.  As long as the CatalogPart has been saved since
+        the last modifying operation, or sort() has has been called,
+        this will also be the newest version of the package.
 
-                pub_sort = None
-                if pubs:
-                        pos = dict((p, i) for (i, p) in enumerate(pubs))
-                        def pub_key(a):
-                                astem, apub = a.split("!", 1)
-                                return (astem, pos[apub])
-                        pub_sort = pub_key
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
 
-                for entry in sorted(pkg_list, key=pub_sort):
-                        stem, pub = entry.split("!", 1)
-                        yield pub, stem
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
 
-        def publishers(self, pubs=EmptyI):
-                """A generator function that returns publisher prefixes as it
-                iterates over the package data in the CatalogPart.
+        return (
+            (pub, stem, entry["version"])
+            for pub, stem, entry in self.__iter_entries(
+                last=last, ordered=ordered, pubs=pubs
+            )
+        )
 
-                'pubs' is an optional list that contains the prefixes of the
-                publishers to restrict the results to."""
+    def tuple_entries(self, cb=None, last=False, ordered=False, pubs=EmptyI):
+        """A generator function that produces tuples of the form ((pub,
+        stem, version), entry) as it iterates over the contents of the
+        catalog part (where entry is the related catalog entry for the
+        fmri).  Callers should not modify any of the data that is
+        returned.
 
-                self.load()
-                for pub in self.__data:
-                        # Any entries starting with "_" are part of the
-                        # reserved catalog namespace.
-                        if not pub[0] == "_" and (not pubs or pub in pubs):
-                                yield pub
+        'cb' is an optional callback function that will be executed for
+        each package. It must accept two arguments: 'pkg' and 'entry'.
+        'pkg' is an FMRI tuple and 'entry' is the dictionary structure
+        of the catalog entry for the package.  If the callback returns
+        False, then the entry will not be included in the results.
 
-        def remove(self, pfmri, op_time=None):
-                """Remove a package and its metadata."""
+        'last' is a boolean value that indicates only the last entry
+        for each package on a per-publisher basis should be returned.
+        As long as the CatalogPart has been saved since the last
+        modifying operation, or sort() has has been called, this will
+        also be the newest version of the package.
 
-                if not pfmri.publisher:
-                        raise api_errors.AnarchicalCatalogFMRI(pfmri.get_fmri())
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
 
-                self.load()
-                pkg_list = self.__data.get(pfmri.publisher, None)
-                if not pkg_list:
-                        raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to.
 
-                ver = str(pfmri.version)
-                ver_list = pkg_list.get(pfmri.pkg_name, [])
-                for i, entry in enumerate(ver_list):
-                        if entry["version"] == ver:
-                                # Safe to do this since a 'break' is done
-                                # immediately after removals are performed.
-                                del ver_list[i]
-                                if not ver_list:
-                                        # When all version entries for a
-                                        # package are removed, its stem
-                                        # should be also.
-                                        del pkg_list[pfmri.pkg_name]
-                                if not pkg_list:
-                                        # When all package stems for a
-                                        # publisher have been removed,
-                                        # it should be also.
-                                        del self.__data[pfmri.publisher]
-                                break
-                else:
-                        raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+        Results are always in catalog version order on a per-publisher,
+        per-stem basis."""
 
-                if not op_time:
-                        op_time = datetime.datetime.utcnow()
-                self.last_modified = op_time
-                self.signatures = {}
+        for pub, stem, entry in self.__iter_entries(
+            last=last, ordered=ordered, pubs=pubs
+        ):
+            t = (pub, stem, entry["version"])
+            if cb is None or cb(t, entry):
+                yield t, entry
 
-        def save(self):
-                """Transform and store the catalog part's data in a file using
-                the pathname <self.meta_root>/<self.name>."""
+    def validate(self, signatures=None, require_signatures=False):
+        """Verifies whether the signatures for the contents of the
+        CatalogPart match the specified signature data, or if not
+        provided, the current signature data.  Raises the exception
+        named 'BadCatalogSignatures' on failure."""
 
-                if not self.meta_root:
-                        # Assume this is in-memory only.
-                        return
+        if not self.signatures and not signatures and not require_signatures:
+            # Nothing to validate, and we're not required to.
+            return
 
-                # Ensure content is loaded before attempting save.
-                self.load()
+        # Ensure content is loaded before attempting to retrieve
+        # or generate signature data.
+        self.load()
+        if not signatures:
+            signatures = self.signatures
 
-                if len(self.features):
-                        self.__data['_FEATURE'] = self.features
-                CatalogPartBase.save(self, self.__data)
-
-        def sort(self, pfmris=None, pubs=None):
-                """Re-sorts the contents of the CatalogPart such that version
-                entries for each package stem are in ascending order.
-
-                'pfmris' is an optional set of FMRIs to restrict the sort to.
-                This is useful during catalog operations as only entries for
-                the corresponding package stem(s) need to be sorted.
-
-                'pubs' is an optional set of publisher prefixes to restrict
-                the sort to.  This is useful during catalog operations as only
-                entries for the corresponding publisher stem(s) need to be
-                sorted.  This option has no effect if 'pfmris' is also
-                provided.
-
-                If neither 'pfmris' or 'pubs' is provided, all entries will be
-                sorted."""
-
-                def key_func(item):
-                        return pkg.version.Version(item["version"])
-
-                self.load()
-                if pfmris is not None:
-                        processed = set()
-                        for f in pfmris:
-                                pkg_stem = f.get_pkg_stem()
-                                if pkg_stem in processed:
-                                        continue
-                                processed.add(pkg_stem)
-
-                                # The specified FMRI may not exist in this
-                                # CatalogPart, so continue if it does not
-                                # exist.
-                                pkg_list = self.__data.get(f.publisher, None)
-                                if pkg_list:
-                                        ver_list = pkg_list.get(f.pkg_name,
-                                            None)
-                                        if ver_list:
-                                                ver_list.sort(key=key_func)
-                        return
-
-                for pub in self.publishers(pubs=pubs):
-                        for stem in self.__data[pub]:
-                                self.__data[pub][stem].sort(key=key_func)
-
-        def tuples(self, last=False, ordered=False, pubs=EmptyI):
-                """A generator function that produces FMRI tuples as it
-                iterates over the contents of the catalog part.
-
-                'last' is a boolean value that indicates only the last FMRI
-                tuple for each package on a per-publisher basis should be
-                returned.  As long as the CatalogPart has been saved since
-                the last modifying operation, or sort() has has been called,
-                this will also be the newest version of the package.
-
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                return (
-                    (pub, stem, entry["version"])
-                    for pub, stem, entry in self.__iter_entries(last=last,
-                        ordered=ordered, pubs=pubs)
-                )
-
-        def tuple_entries(self, cb=None, last=False, ordered=False, pubs=EmptyI):
-                """A generator function that produces tuples of the form ((pub,
-                stem, version), entry) as it iterates over the contents of the
-                catalog part (where entry is the related catalog entry for the
-                fmri).  Callers should not modify any of the data that is
-                returned.
-
-                'cb' is an optional callback function that will be executed for
-                each package. It must accept two arguments: 'pkg' and 'entry'.
-                'pkg' is an FMRI tuple and 'entry' is the dictionary structure
-                of the catalog entry for the package.  If the callback returns
-                False, then the entry will not be included in the results.
-
-                'last' is a boolean value that indicates only the last entry
-                for each package on a per-publisher basis should be returned.
-                As long as the CatalogPart has been saved since the last
-                modifying operation, or sort() has has been called, this will
-                also be the newest version of the package.
-
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to.
-
-                Results are always in catalog version order on a per-publisher,
-                per-stem basis."""
-
-                for pub, stem, entry in self.__iter_entries(last=last,
-                    ordered=ordered, pubs=pubs):
-                        t = (pub, stem, entry["version"])
-                        if cb is None or cb(t, entry):
-                                yield t, entry
-
-        def validate(self, signatures=None, require_signatures=False):
-                """Verifies whether the signatures for the contents of the
-                CatalogPart match the specified signature data, or if not
-                provided, the current signature data.  Raises the exception
-                named 'BadCatalogSignatures' on failure."""
-
-                if not self.signatures and not signatures and \
-                    not require_signatures:
-                        # Nothing to validate, and we're not required to.
-                        return
-
-                # Ensure content is loaded before attempting to retrieve
-                # or generate signature data.
-                self.load()
-                if not signatures:
-                        signatures = self.signatures
-
-                new_signatures = self._gen_signatures(self.__data)
-                if new_signatures != signatures:
-                        raise api_errors.BadCatalogSignatures(self.pathname)
+        new_signatures = self._gen_signatures(self.__data)
+        if new_signatures != signatures:
+            raise api_errors.BadCatalogSignatures(self.pathname)
 
 
 class CatalogUpdate(CatalogPartBase):
-        """A CatalogUpdate object is an augmented representation of a subset
-        of the package data contained within a Catalog."""
+    """A CatalogUpdate object is an augmented representation of a subset
+    of the package data contained within a Catalog."""
 
-        # Properties.
-        __data = None
-        last_modified = None
+    # Properties.
+    __data = None
+    last_modified = None
 
-        # Operation constants.
-        ADD = "add"
-        REMOVE = "remove"
+    # Operation constants.
+    ADD = "add"
+    REMOVE = "remove"
 
-        def __init__(self, name, meta_root=None, sign=True):
-                """Initializes a CatalogUpdate object."""
+    def __init__(self, name, meta_root=None, sign=True):
+        """Initializes a CatalogUpdate object."""
 
-                self.__data = {}
-                if not name.startswith("update."):
-                        raise UnrecognizedCatalogPart(name)
-                CatalogPartBase.__init__(self, name, meta_root=meta_root,
-                    sign=sign)
+        self.__data = {}
+        if not name.startswith("update."):
+            raise UnrecognizedCatalogPart(name)
+        CatalogPartBase.__init__(self, name, meta_root=meta_root, sign=sign)
 
-        def add(self, pfmri, operation, op_time, metadata=None):
-                """Records the specified catalog operation and any related
-                catalog metadata for the specified package FMRI.
+    def add(self, pfmri, operation, op_time, metadata=None):
+        """Records the specified catalog operation and any related
+        catalog metadata for the specified package FMRI.
 
-                'operation' must be one of the following constant values
-                provided by the CatalogUpdate class:
-                    ADD
-                    REMOVE
+        'operation' must be one of the following constant values
+        provided by the CatalogUpdate class:
+            ADD
+            REMOVE
 
-                'op_time' is a UTC datetime object indicating the time
-                the catalog operation was performed.
+        'op_time' is a UTC datetime object indicating the time
+        the catalog operation was performed.
 
-                'metadata' is an optional dict containing the catalog
-                metadata that should be stored for the specified FMRI
-                indexed by catalog part (e.g. "dependency", "summary",
-                etc.)."""
+        'metadata' is an optional dict containing the catalog
+        metadata that should be stored for the specified FMRI
+        indexed by catalog part (e.g. "dependency", "summary",
+        etc.)."""
 
-                if not pfmri.publisher:
-                        raise api_errors.AnarchicalCatalogFMRI(pfmri.get_fmri())
+        if not pfmri.publisher:
+            raise api_errors.AnarchicalCatalogFMRI(pfmri.get_fmri())
 
-                if operation not in (self.ADD, self.REMOVE):
-                        raise api_errors.UnknownUpdateType(operation)
+        if operation not in (self.ADD, self.REMOVE):
+            raise api_errors.UnknownUpdateType(operation)
 
-                self.load()
-                self.__data.setdefault(pfmri.publisher, {})
-                pkg_list = self.__data[pfmri.publisher]
+        self.load()
+        self.__data.setdefault(pfmri.publisher, {})
+        pkg_list = self.__data[pfmri.publisher]
 
-                pkg_list.setdefault(pfmri.pkg_name, [])
-                ver_list = pkg_list[pfmri.pkg_name]
+        pkg_list.setdefault(pfmri.pkg_name, [])
+        ver_list = pkg_list[pfmri.pkg_name]
 
-                if metadata is not None:
-                        entry = metadata
-                else:
-                        entry = {}
-                entry["op-time"] = datetime_to_basic_ts(op_time)
-                entry["op-type"] = operation
-                entry["version"] = str(pfmri.version)
-                ver_list.append(entry)
+        if metadata is not None:
+            entry = metadata
+        else:
+            entry = {}
+        entry["op-time"] = datetime_to_basic_ts(op_time)
+        entry["op-type"] = operation
+        entry["version"] = str(pfmri.version)
+        ver_list.append(entry)
 
-                # To ensure the update log is viewed as having been updated
-                # at the exact same time as the catalog, the last_modified
-                # time of the update log must match the operation time.
-                self.last_modified = op_time
-                self.signatures = {}
+        # To ensure the update log is viewed as having been updated
+        # at the exact same time as the catalog, the last_modified
+        # time of the update log must match the operation time.
+        self.last_modified = op_time
+        self.signatures = {}
 
-        def load(self):
-                """Load and transform the catalog update's data, preparing it
-                for use."""
+    def load(self):
+        """Load and transform the catalog update's data, preparing it
+        for use."""
 
-                if self.loaded:
-                        # Already loaded, or only in-memory.
-                        return
-                self.__data = CatalogPartBase.load(self)
+        if self.loaded:
+            # Already loaded, or only in-memory.
+            return
+        self.__data = CatalogPartBase.load(self)
 
-        def publishers(self):
-                """A generator function that returns publisher prefixes as it
-                iterates over the package data in the CatalogUpdate."""
+    def publishers(self):
+        """A generator function that returns publisher prefixes as it
+        iterates over the package data in the CatalogUpdate."""
 
-                self.load()
-                for pub in self.__data:
-                        # Any entries starting with "_" are part of the
-                        # reserved catalog namespace.
-                        if not pub[0] == "_":
-                                yield pub
+        self.load()
+        for pub in self.__data:
+            # Any entries starting with "_" are part of the
+            # reserved catalog namespace.
+            if not pub[0] == "_":
+                yield pub
 
-        def save(self):
-                """Transform and store the catalog update's data in a file using
-                the pathname <self.meta_root>/<self.name>."""
+    def save(self):
+        """Transform and store the catalog update's data in a file using
+        the pathname <self.meta_root>/<self.name>."""
 
-                if not self.meta_root:
-                        # Assume this is in-memory only.
-                        return
+        if not self.meta_root:
+            # Assume this is in-memory only.
+            return
 
-                # Ensure content is loaded before attempting save.
-                self.load()
+        # Ensure content is loaded before attempting save.
+        self.load()
 
-                if len(self.features):
-                        self.__data['_FEATURE'] = self.features
-                CatalogPartBase.save(self, self.__data)
+        if len(self.features):
+            self.__data["_FEATURE"] = self.features
+        CatalogPartBase.save(self, self.__data)
 
-        def updates(self):
-                """A generator function that produces tuples of the format
-                (fmri, op_type, op_time, metadata).  Where:
+    def updates(self):
+        """A generator function that produces tuples of the format
+        (fmri, op_type, op_time, metadata).  Where:
 
-                    * 'fmri' is a PkgFmri object for the package.
+            * 'fmri' is a PkgFmri object for the package.
 
-                    * 'op_type' is a CatalogUpdate constant indicating
-                      the catalog operation performed.
+            * 'op_type' is a CatalogUpdate constant indicating
+              the catalog operation performed.
 
-                    * 'op_time' is a UTC datetime object representing the
-                      time time the catalog operation was performed.
+            * 'op_time' is a UTC datetime object representing the
+              time time the catalog operation was performed.
 
-                    * 'metadata' is a dict containing the catalog metadata
-                      for the FMRI indexed by catalog part name.
+            * 'metadata' is a dict containing the catalog metadata
+              for the FMRI indexed by catalog part name.
 
-                Results are always in ascending operation time order on a
-                per-publisher, per-stem basis.
-                """
+        Results are always in ascending operation time order on a
+        per-publisher, per-stem basis.
+        """
 
-                self.load()
+        self.load()
 
-                def get_update(pub, stem, entry):
-                        mdata = {}
-                        for key in entry:
-                                if key.startswith("catalog."):
-                                        mdata[key] = entry[key]
-                        op_time = basic_ts_to_datetime(entry["op-time"])
-                        pfmri = fmri.PkgFmri(name=stem, publisher=pub,
-                            version=entry["version"])
-                        return (pfmri, entry["op-type"], op_time, mdata)
+        def get_update(pub, stem, entry):
+            mdata = {}
+            for key in entry:
+                if key.startswith("catalog."):
+                    mdata[key] = entry[key]
+            op_time = basic_ts_to_datetime(entry["op-time"])
+            pfmri = fmri.PkgFmri(
+                name=stem, publisher=pub, version=entry["version"]
+            )
+            return (pfmri, entry["op-type"], op_time, mdata)
 
-                for pub in self.publishers():
-                        for stem in self.__data[pub]:
-                                for entry in self.__data[pub][stem]:
-                                        yield get_update(pub, stem, entry)
-                return
+        for pub in self.publishers():
+            for stem in self.__data[pub]:
+                for entry in self.__data[pub][stem]:
+                    yield get_update(pub, stem, entry)
+        return
 
-        def validate(self, signatures=None, require_signatures=False):
-                """Verifies whether the signatures for the contents of the
-                CatalogUpdate match the specified signature data, or if not
-                provided, the current signature data.  Raises the exception
-                named 'BadCatalogSignatures' on failure."""
+    def validate(self, signatures=None, require_signatures=False):
+        """Verifies whether the signatures for the contents of the
+        CatalogUpdate match the specified signature data, or if not
+        provided, the current signature data.  Raises the exception
+        named 'BadCatalogSignatures' on failure."""
 
-                if not self.signatures and not signatures and \
-                    not require_signatures:
-                        # Nothing to validate, and we're not required to.
-                        return
+        if not self.signatures and not signatures and not require_signatures:
+            # Nothing to validate, and we're not required to.
+            return
 
-                # Ensure content is loaded before attempting to retrieve
-                # or generate signature data.
-                self.load()
-                if not signatures:
-                        signatures = self.signatures
+        # Ensure content is loaded before attempting to retrieve
+        # or generate signature data.
+        self.load()
+        if not signatures:
+            signatures = self.signatures
 
-                new_signatures = self._gen_signatures(self.__data)
-                if new_signatures != signatures:
-                        raise api_errors.BadCatalogSignatures(self.pathname)
+        new_signatures = self._gen_signatures(self.__data)
+        if new_signatures != signatures:
+            raise api_errors.BadCatalogSignatures(self.pathname)
 
 
 class CatalogAttrs(CatalogPartBase):
-        """A CatalogAttrs object is the representation of the attributes of a
-        Catalog object."""
+    """A CatalogAttrs object is the representation of the attributes of a
+    Catalog object."""
 
-        # Properties.
-        __data = None
+    # Properties.
+    __data = None
 
-        # This structure defines defaults (for use in __init__) as well as
-        # the set of required elements for this catalog part.  See also the
-        # logic in load().
-        __DEFAULT_ELEMS = {
-            "created": None,
-            "last-modified": None,
-            "package-count": 0,
-            "package-version-count": 0,
-            "parts": {},
-            "updates": {},
-            "version": 1,
-        }
+    # This structure defines defaults (for use in __init__) as well as
+    # the set of required elements for this catalog part.  See also the
+    # logic in load().
+    __DEFAULT_ELEMS = {
+        "created": None,
+        "last-modified": None,
+        "package-count": 0,
+        "package-version-count": 0,
+        "parts": {},
+        "updates": {},
+        "version": 1,
+    }
 
-        def __init__(self, meta_root=None, sign=True):
-                """Initializes a CatalogAttrs object."""
+    def __init__(self, meta_root=None, sign=True):
+        """Initializes a CatalogAttrs object."""
 
-                self.__data = {}
-                CatalogPartBase.__init__(self, name="catalog.attrs",
-                    meta_root=meta_root, sign=sign)
+        self.__data = {}
+        CatalogPartBase.__init__(
+            self, name="catalog.attrs", meta_root=meta_root, sign=sign
+        )
 
-                if self.loaded:
-                        # If the data is already seen as 'loaded' during init,
-                        # this is actually a new object, so setup some sane
-                        # defaults.
-                        created = self.__data["last-modified"]
-                        self.__data = copy.deepcopy(self.__DEFAULT_ELEMS)
-                        self.__data["created"] = created
-                        self.__data["last-modified"] = created
-                else:
-                        # Assume that the attributes of the catalog can be
-                        # obtained from a file.
-                        self.load()
+        if self.loaded:
+            # If the data is already seen as 'loaded' during init,
+            # this is actually a new object, so setup some sane
+            # defaults.
+            created = self.__data["last-modified"]
+            self.__data = copy.deepcopy(self.__DEFAULT_ELEMS)
+            self.__data["created"] = created
+            self.__data["last-modified"] = created
+        else:
+            # Assume that the attributes of the catalog can be
+            # obtained from a file.
+            self.load()
 
-        def __get_created(self):
-                return self.__data["created"]
+    def __get_created(self):
+        return self.__data["created"]
 
-        def __get_last_modified(self):
-                return self.__data["last-modified"]
+    def __get_last_modified(self):
+        return self.__data["last-modified"]
 
-        def __get_package_count(self):
-                return self.__data["package-count"]
+    def __get_package_count(self):
+        return self.__data["package-count"]
 
-        def __get_package_version_count(self):
-                return self.__data["package-version-count"]
+    def __get_package_version_count(self):
+        return self.__data["package-version-count"]
 
-        def __get_parts(self):
-                return self.__data["parts"]
+    def __get_parts(self):
+        return self.__data["parts"]
 
-        def __get_updates(self):
-                return self.__data["updates"]
+    def __get_updates(self):
+        return self.__data["updates"]
 
-        def __get_version(self):
-                return self.__data["version"]
+    def __get_version(self):
+        return self.__data["version"]
 
-        def __set_created(self, value):
-                self.__data["created"] = value
-                self.signatures = {}
+    def __set_created(self, value):
+        self.__data["created"] = value
+        self.signatures = {}
 
-        def __set_last_modified(self, value):
-                self.__data["last-modified"] = value
-                self.signatures = {}
+    def __set_last_modified(self, value):
+        self.__data["last-modified"] = value
+        self.signatures = {}
 
-        def __set_package_count(self, value):
-                self.__data["package-count"] = value
-                self.signatures = {}
+    def __set_package_count(self, value):
+        self.__data["package-count"] = value
+        self.signatures = {}
 
-        def __set_package_version_count(self, value):
-                self.__data["package-version-count"] = value
-                self.signatures = {}
+    def __set_package_version_count(self, value):
+        self.__data["package-version-count"] = value
+        self.signatures = {}
 
-        def __set_parts(self, value):
-                self.__data["parts"] = value
-                self.signatures = {}
+    def __set_parts(self, value):
+        self.__data["parts"] = value
+        self.signatures = {}
 
-        def __set_updates(self, value):
-                self.__data["updates"] = value
-                self.signatures = {}
+    def __set_updates(self, value):
+        self.__data["updates"] = value
+        self.signatures = {}
 
-        def __set_version(self, value):
-                self.__data["version"] = value
-                self.signatures = {}
+    def __set_version(self, value):
+        self.__data["version"] = value
+        self.signatures = {}
 
-        def __transform(self):
-                """Duplicate and transform 'self.__data' for saving."""
+    def __transform(self):
+        """Duplicate and transform 'self.__data' for saving."""
 
-                # Use a copy to prevent the in-memory version from being
-                # affected by the transformations.
-                struct = copy.deepcopy(self.__data)
-                for key, val in six.iteritems(struct):
-                        if isinstance(val, datetime.datetime):
-                                # Convert datetime objects to an ISO-8601
-                                # basic format string.
-                                struct[key] = datetime_to_basic_ts(val)
-                                continue
+        # Use a copy to prevent the in-memory version from being
+        # affected by the transformations.
+        struct = copy.deepcopy(self.__data)
+        for key, val in six.iteritems(struct):
+            if isinstance(val, datetime.datetime):
+                # Convert datetime objects to an ISO-8601
+                # basic format string.
+                struct[key] = datetime_to_basic_ts(val)
+                continue
 
-                        if key in ("parts", "updates"):
-                                for e in val:
-                                        lm = val[e].get("last-modified", None)
-                                        if lm:
-                                                lm = datetime_to_basic_ts(lm)
-                                                val[e]["last-modified"] = lm
-                return struct
+            if key in ("parts", "updates"):
+                for e in val:
+                    lm = val[e].get("last-modified", None)
+                    if lm:
+                        lm = datetime_to_basic_ts(lm)
+                        val[e]["last-modified"] = lm
+        return struct
 
-        def load(self):
-                """Load and transform the catalog attribute data."""
+    def load(self):
+        """Load and transform the catalog attribute data."""
 
-                if self.loaded:
-                        # Already loaded, or only in-memory.
-                        return
-                location = os.path.join(self.meta_root, self.name)
+        if self.loaded:
+            # Already loaded, or only in-memory.
+            return
+        location = os.path.join(self.meta_root, self.name)
 
-                struct = CatalogPartBase.load(self)
-                # Check to see that struct is as we expect: it must be a dict
-                # and have all of the elements in self.__DEFAULT_ELEMS.
-                if type(struct) != dict or \
-                    not (set(self.__DEFAULT_ELEMS.keys()) <= \
-                    set(struct.keys())):
-                        raise api_errors.InvalidCatalogFile(location)
+        struct = CatalogPartBase.load(self)
+        # Check to see that struct is as we expect: it must be a dict
+        # and have all of the elements in self.__DEFAULT_ELEMS.
+        if type(struct) != dict or not (
+            set(self.__DEFAULT_ELEMS.keys()) <= set(struct.keys())
+        ):
+            raise api_errors.InvalidCatalogFile(location)
 
-                def cat_ts_to_datetime(val):
-                        try:
-                                return basic_ts_to_datetime(val)
-                        except ValueError:
-                                raise api_errors.InvalidCatalogFile(location)
+        def cat_ts_to_datetime(val):
+            try:
+                return basic_ts_to_datetime(val)
+            except ValueError:
+                raise api_errors.InvalidCatalogFile(location)
 
-                for key, val in six.iteritems(struct):
-                        if key in ("created", "last-modified"):
-                                # Convert ISO-8601 basic format strings to
-                                # datetime objects.  These dates can be
-                                # 'null' due to v0 catalog transformations.
-                                if val:
-                                        struct[key] = cat_ts_to_datetime(val)
-                                continue
+        for key, val in six.iteritems(struct):
+            if key in ("created", "last-modified"):
+                # Convert ISO-8601 basic format strings to
+                # datetime objects.  These dates can be
+                # 'null' due to v0 catalog transformations.
+                if val:
+                    struct[key] = cat_ts_to_datetime(val)
+                continue
 
-                        if key in ("parts", "updates"):
-                                if type(val) != dict:
-                                        raise api_errors.InvalidCatalogFile(
-                                            location)
+            if key in ("parts", "updates"):
+                if type(val) != dict:
+                    raise api_errors.InvalidCatalogFile(location)
 
-                                # 'parts' and 'updates' have a more complex
-                                # structure.  Check that all of the subparts
-                                # look sane.
-                                for subpart in val:
-                                        if subpart != os.path.basename(subpart):
-                                                raise api_errors.\
-                                                    UnrecognizedCatalogPart(
-                                                    "{0} {{{1}: {2}}}".format(
-                                                    self.name, key, subpart))
+                # 'parts' and 'updates' have a more complex
+                # structure.  Check that all of the subparts
+                # look sane.
+                for subpart in val:
+                    if subpart != os.path.basename(subpart):
+                        raise api_errors.UnrecognizedCatalogPart(
+                            "{0} {{{1}: {2}}}".format(self.name, key, subpart)
+                        )
 
-                                # Build datetimes from timestamps.
-                                for e in val:
-                                        lm = val[e].get("last-modified", None)
-                                        if lm:
-                                                lm = cat_ts_to_datetime(lm)
-                                                val[e]["last-modified"] = lm
+                # Build datetimes from timestamps.
+                for e in val:
+                    lm = val[e].get("last-modified", None)
+                    if lm:
+                        lm = cat_ts_to_datetime(lm)
+                        val[e]["last-modified"] = lm
 
-                self.__data = struct
+        self.__data = struct
 
-        def save(self):
-                """Transform and store the catalog attribute data in a file
-                using the pathname <self.meta_root>/<self.name>."""
+    def save(self):
+        """Transform and store the catalog attribute data in a file
+        using the pathname <self.meta_root>/<self.name>."""
 
-                if not self.meta_root:
-                        # Assume this is in-memory only.
-                        return
+        if not self.meta_root:
+            # Assume this is in-memory only.
+            return
 
-                # Ensure content is loaded before attempting save.
-                self.load()
+        # Ensure content is loaded before attempting save.
+        self.load()
 
-                if len(self.features):
-                        self.__data['_FEATURE'] = self.features
-                CatalogPartBase.save(self, self.__transform())
+        if len(self.features):
+            self.__data["_FEATURE"] = self.features
+        CatalogPartBase.save(self, self.__transform())
 
-        def validate(self, signatures=None, require_signatures=False):
-                """Verifies whether the signatures for the contents of the
-                CatalogAttrs match the specified signature data, or if not
-                provided, the current signature data.  Raises the exception
-                named 'BadCatalogSignatures' on failure."""
+    def validate(self, signatures=None, require_signatures=False):
+        """Verifies whether the signatures for the contents of the
+        CatalogAttrs match the specified signature data, or if not
+        provided, the current signature data.  Raises the exception
+        named 'BadCatalogSignatures' on failure."""
 
-                if not self.signatures and not signatures and \
-                    not require_signatures:
-                        # Nothing to validate, and we're not required to.
-                        return
+        if not self.signatures and not signatures and not require_signatures:
+            # Nothing to validate, and we're not required to.
+            return
 
-                # Ensure content is loaded before attempting to retrieve
-                # or generate signature data.
-                self.load()
-                if not signatures:
-                        signatures = self.signatures
+        # Ensure content is loaded before attempting to retrieve
+        # or generate signature data.
+        self.load()
+        if not signatures:
+            signatures = self.signatures
 
-                new_signatures = self._gen_signatures(self.__transform())
-                if new_signatures != signatures:
-                        raise api_errors.BadCatalogSignatures(self.pathname)
+        new_signatures = self._gen_signatures(self.__transform())
+        if new_signatures != signatures:
+            raise api_errors.BadCatalogSignatures(self.pathname)
 
-        created = property(__get_created, __set_created)
+    created = property(__get_created, __set_created)
 
-        last_modified = property(__get_last_modified, __set_last_modified)
+    last_modified = property(__get_last_modified, __set_last_modified)
 
-        package_count = property(__get_package_count, __set_package_count)
+    package_count = property(__get_package_count, __set_package_count)
 
-        package_version_count = property(__get_package_version_count,
-            __set_package_version_count)
+    package_version_count = property(
+        __get_package_version_count, __set_package_version_count
+    )
 
-        parts = property(__get_parts, __set_parts)
+    parts = property(__get_parts, __set_parts)
 
-        updates = property(__get_updates, __set_updates)
+    updates = property(__get_updates, __set_updates)
 
-        version = property(__get_version, __set_version)
+    version = property(__get_version, __set_version)
 
 
 class Catalog(object):
-        """A Catalog is the representation of the package FMRIs available from
-        a package repository."""
+    """A Catalog is the representation of the package FMRIs available from
+    a package repository."""
 
-        __BASE_PART = "catalog.base.C"
-        __DEPS_PART = "catalog.dependency.C"
-        __SUMM_PART_PFX = "catalog.summary"
+    __BASE_PART = "catalog.base.C"
+    __DEPS_PART = "catalog.dependency.C"
+    __SUMM_PART_PFX = "catalog.summary"
 
-        # The file mode to be used for all catalog files.
-        __file_mode = stat.S_IRUSR|stat.S_IWUSR|stat.S_IRGRP|stat.S_IROTH
+    # The file mode to be used for all catalog files.
+    __file_mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
 
-        # These properties are declared here so that they show up in the pydoc
-        # documentation as private, and for clarity in the property declarations
-        # found near the end of the class definition.
-        _attrs = None
-        __batch_mode = None
-        __lock = None
-        __manifest_cb = None
-        __meta_root = None
-        __sign = None
+    # These properties are declared here so that they show up in the pydoc
+    # documentation as private, and for clarity in the property declarations
+    # found near the end of the class definition.
+    _attrs = None
+    __batch_mode = None
+    __lock = None
+    __manifest_cb = None
+    __meta_root = None
+    __sign = None
 
-        # These are used to cache or store CatalogPart and CatalogUpdate objects
-        # as they are used.  It should not be confused with the CatalogPart
-        # names and CatalogUpdate names stored in the CatalogAttrs object.
-        __parts = None
-        __updates = None
+    # These are used to cache or store CatalogPart and CatalogUpdate objects
+    # as they are used.  It should not be confused with the CatalogPart
+    # names and CatalogUpdate names stored in the CatalogAttrs object.
+    __parts = None
+    __updates = None
 
-        # Class Constants
-        DEPENDENCY, SUMMARY = range(2)
+    # Class Constants
+    DEPENDENCY, SUMMARY = range(2)
 
-        def __init__(self, batch_mode=False, meta_root=None, log_updates=False,
-            manifest_cb=None, read_only=False, sign=True):
-                """Initializes a Catalog object.
+    def __init__(
+        self,
+        batch_mode=False,
+        meta_root=None,
+        log_updates=False,
+        manifest_cb=None,
+        read_only=False,
+        sign=True,
+    ):
+        """Initializes a Catalog object.
 
-                'batch_mode' is an optional boolean value that indicates that
-                the caller intends to perform multiple modifying operations on
-                catalog before saving.  This is useful for performance reasons
-                as the contents of the catalog will not be sorted after each
-                change, and the package counts will not be updated (except at
-                save()).  By default this value is False.  If this value is
-                True, callers are responsible for calling finalize() to ensure
-                that catalog entries are in the correct order and package counts
-                accurately reflect the catalog contents.
+        'batch_mode' is an optional boolean value that indicates that
+        the caller intends to perform multiple modifying operations on
+        catalog before saving.  This is useful for performance reasons
+        as the contents of the catalog will not be sorted after each
+        change, and the package counts will not be updated (except at
+        save()).  By default this value is False.  If this value is
+        True, callers are responsible for calling finalize() to ensure
+        that catalog entries are in the correct order and package counts
+        accurately reflect the catalog contents.
 
-                'meta_root' is an optional absolute pathname of a directory
-                that catalog metadata can be written to and read from, and
-                must already exist.  If no path is supplied, then it is
-                assumed that the catalog object will be used for in-memory
-                operations only.
+        'meta_root' is an optional absolute pathname of a directory
+        that catalog metadata can be written to and read from, and
+        must already exist.  If no path is supplied, then it is
+        assumed that the catalog object will be used for in-memory
+        operations only.
 
-                'log_updates' is an optional boolean value indicating whether
-                updates to the catalog should be logged.  This enables consumers
-                of the catalog to perform incremental updates.
+        'log_updates' is an optional boolean value indicating whether
+        updates to the catalog should be logged.  This enables consumers
+        of the catalog to perform incremental updates.
 
-                'manifest_cb' is an optional callback used by actions() and
-                get_entry_actions() to lazy-load Manifest Actions if the catalog
-                does not have the actions data for a requested package entry.
+        'manifest_cb' is an optional callback used by actions() and
+        get_entry_actions() to lazy-load Manifest Actions if the catalog
+        does not have the actions data for a requested package entry.
 
-                'read_only' is an optional boolean value that indicates if
-                operations that modify the catalog are allowed (an assertion
-                error will be raised if one is attempted and this is True).
+        'read_only' is an optional boolean value that indicates if
+        operations that modify the catalog are allowed (an assertion
+        error will be raised if one is attempted and this is True).
 
-                'sign' is an optional boolean value that indicates that the
-                the catalog data should have signature data generated and
-                embedded when serialized.  This option is primarily a matter
-                of convenience for callers that wish to trade integrity checks
-                for improved catalog serialization performance."""
+        'sign' is an optional boolean value that indicates that the
+        the catalog data should have signature data generated and
+        embedded when serialized.  This option is primarily a matter
+        of convenience for callers that wish to trade integrity checks
+        for improved catalog serialization performance."""
 
-                self.__batch_mode = batch_mode
-                self.__manifest_cb = manifest_cb
-                self.__parts = {}
-                self.__updates = {}
+        self.__batch_mode = batch_mode
+        self.__manifest_cb = manifest_cb
+        self.__parts = {}
+        self.__updates = {}
 
-                # Must be set after the above.
-                self.log_updates = log_updates
-                self.meta_root = meta_root
-                self.read_only = read_only
-                self.sign = sign
+        # Must be set after the above.
+        self.log_updates = log_updates
+        self.meta_root = meta_root
+        self.read_only = read_only
+        self.sign = sign
 
-                # Must be set after the above.
-                self._attrs = CatalogAttrs(meta_root=self.meta_root, sign=sign)
+        # Must be set after the above.
+        self._attrs = CatalogAttrs(meta_root=self.meta_root, sign=sign)
 
-                # This lock is used to protect the catalog file from multiple
-                # threads writing to it at the same time.
-                self.__lock = threading.Lock()
+        # This lock is used to protect the catalog file from multiple
+        # threads writing to it at the same time.
+        self.__lock = threading.Lock()
 
-                # Must be done last.
-                self.__set_perms()
+        # Must be done last.
+        self.__set_perms()
 
-        def __actions(self, info_needed, excludes=EmptyI, cb=None, locales=None,
-            last_version=False, ordered=False, pubs=EmptyI):
-                assert info_needed
-                if not locales:
-                        locales = set(("C",))
+    def __actions(
+        self,
+        info_needed,
+        excludes=EmptyI,
+        cb=None,
+        locales=None,
+        last_version=False,
+        ordered=False,
+        pubs=EmptyI,
+    ):
+        assert info_needed
+        if not locales:
+            locales = set(("C",))
+        else:
+            locales = set(locales)
+
+        for f, entry in self.__entries(
+            cb=cb,
+            info_needed=info_needed,
+            locales=locales,
+            last_version=last_version,
+            ordered=ordered,
+            pubs=pubs,
+        ):
+            try:
+                yield f, self.__gen_actions(f, entry["actions"], excludes)
+            except KeyError:
+                if self.__manifest_cb:
+                    yield f, self.__gen_lazy_actions(
+                        f, info_needed, locales, excludes
+                    )
                 else:
-                        locales = set(locales)
-
-                for f, entry in self.__entries(cb=cb, info_needed=info_needed,
-                    locales=locales, last_version=last_version,
-                    ordered=ordered, pubs=pubs):
-                        try:
-                                yield f, self.__gen_actions(f, entry["actions"],
-                                    excludes)
-                        except KeyError:
-                                if self.__manifest_cb:
-                                        yield f, self.__gen_lazy_actions(f,
-                                            info_needed, locales, excludes)
-                                else:
-                                        yield f, EmptyI
-
-        def __append(self, src, cb=None, pfmri=None, pubs=EmptyI):
-                """Private version; caller responsible for locking."""
-
-                base = self.get_part(self.__BASE_PART)
-                src_base = src.get_part(self.__BASE_PART, must_exist=True)
-                if src_base is None:
-                        if pfmri:
-                                raise api_errors.UnknownCatalogEntry(pfmri)
-                        # Nothing to do
-                        return
-
-                # Use the same operation time and date for all operations so
-                # that the last modification times will be synchronized.  This
-                # also has the benefit of avoiding extra datetime object
-                # instantiations.
-                op_time = datetime.datetime.utcnow()
-
-                # For each entry in the 'src' catalog, add its BASE entry to the
-                # current catalog along and then add it to the 'd'iscard dict if
-                # 'cb' is defined and returns False.
-                if pfmri:
-                        entry = src_base.get_entry(pfmri)
-                        if entry is None:
-                                raise api_errors.UnknownCatalogEntry(
-                                    pfmri.get_fmri())
-                        entries = [(pfmri, entry)]
-                else:
-                        entries = src_base.entries()
-
-                d = {}
-                for f, entry in entries:
-                        if pubs and f.publisher not in pubs:
-                                continue
-
-                        nentry = copy.deepcopy(entry)
-                        if cb is not None:
-                                merge, mdata = cb(src, f, entry)
-                                if not merge:
-                                        pub = d.setdefault(f.publisher, {})
-                                        plist = pub.setdefault(f.pkg_name,
-                                            set())
-                                        plist.add(f.version)
-                                        continue
-
-                                if mdata:
-                                        if "metadata" in nentry:
-                                                nentry["metadata"].update(mdata)
-                                        else:
-                                                nentry["metadata"] = mdata
-                        base.add(f, metadata=nentry, op_time=op_time)
-
-                if d and pfmri:
-                        # If the 'd'iscards dict is populated and pfmri is
-                        # defined, then there is nothing more to do.
-                        return
-
-                # Finally, merge any catalog part entries that exist unless the
-                # FMRI is found in the 'd'iscard dict.
-                for name in src.parts.keys():
-                        if name == self.__BASE_PART:
-                                continue
-
-                        part = src.get_part(name, must_exist=True)
-                        if part is None:
-                                # Part doesn't exist in-memory or on-disk, so
-                                # skip it.
-                                continue
-
-                        if pfmri:
-                                entry = part.get_entry(pfmri)
-                                if entry is None:
-                                        # Package isn't in this part; skip it.
-                                        continue
-                                entries = [(pfmri, entry)]
-                        else:
-                                entries = part.entries()
-
-                        npart = self.get_part(name)
-                        for f, entry in entries:
-                                if pubs and f.publisher not in pubs:
-                                        continue
-                                if f.publisher in d and \
-                                    f.pkg_name in d[f.publisher] and \
-                                    f.version in d[f.publisher][f.pkg_name]:
-                                        # Skip this package.
-                                        continue
-
-                                nentry = copy.deepcopy(entry)
-                                npart.add(f, metadata=nentry, op_time=op_time)
-
-        def __entries(self, cb=None, info_needed=EmptyI,
-            last_version=False, locales=None, ordered=False, pubs=EmptyI,
-            tuples=False):
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        # Catalog contains nothing.
-                        return
-
-                if not locales:
-                        locales = set(("C",))
-                else:
-                        locales = set(locales)
-
-                parts = []
-                if self.DEPENDENCY in info_needed:
-                        part = self.get_part(self.__DEPS_PART, must_exist=True)
-                        if part is not None:
-                                parts.append(part)
-
-                if self.SUMMARY in info_needed:
-                        for locale in locales:
-                                part = self.get_part(
-                                    "{0}.{1}".format(self.__SUMM_PART_PFX,
-                                    locale), must_exist=True)
-                                if part is None:
-                                        # Data not available for this
-                                        # locale.
-                                        continue
-                                parts.append(part)
-
-                def merge_entry(src, dest):
-                        for k, v in six.iteritems(src):
-                                if k == "actions":
-                                        dest.setdefault(k, [])
-                                        dest[k] += v
-                                elif k != "version":
-                                        dest[k] = v
-
-                if tuples:
-                        for r, bentry in base.tuple_entries(cb=cb,
-                            last=last_version, ordered=ordered, pubs=pubs):
-                                pub, stem, ver = r
-                                mdata = {}
-                                merge_entry(bentry, mdata)
-                                for part in parts:
-                                        entry = part.get_entry(pub=pub,
-                                            stem=stem, ver=ver)
-                                        if entry is None:
-                                                # Part doesn't have this FMRI,
-                                                # so skip it.
-                                                continue
-                                        for k, v in six.iteritems(entry):
-                                                if k == "actions":
-                                                        mdata.setdefault(k, [])
-                                                        mdata[k] += v
-                                                elif k != "version":
-                                                        mdata[k] = v
-                                yield r, mdata
-                        return
-
-                for f, bentry in base.entries(cb=cb, last=last_version,
-                    ordered=ordered, pubs=pubs):
-                        mdata = {}
-                        merge_entry(bentry, mdata)
-                        for part in parts:
-                                entry = part.get_entry(f)
-                                if entry is None:
-                                        # Part doesn't have this FMRI,
-                                        # so skip it.
-                                        continue
-                                for k, v in six.iteritems(entry):
-                                        if k == "actions":
-                                                mdata.setdefault(k, [])
-                                                mdata[k] += v
-                                        elif k != "version":
-                                                mdata[k] = v
-                        yield f, mdata
-
-        def __finalize(self, pfmris=None, pubs=None, sort=True):
-                """Private finalize method; exposes additional controls for
-                internal callers."""
-
-                package_count = 0
-                package_version_count = 0
-
-                part = self.get_part(self.__BASE_PART, must_exist=True)
-                if part is not None:
-                        # If the base Catalog didn't exist (in-memory or on-
-                        # disk) that implies there is nothing to sort and
-                        # there are no packages (since the base catalog part
-                        # must always exist for packages to be present).
-                        package_count, package_version_count = \
-                            part.get_package_counts()
-
-                        if sort:
-                                # Some operations don't need this, such as
-                                # remove...
-                                for part in self.__parts.values():
-                                        part.sort(pfmris=pfmris, pubs=pubs)
-
-                self._attrs.package_count = package_count
-                self._attrs.package_version_count = \
-                    package_version_count
-
-        @staticmethod
-        def __gen_actions(pfmri, actions, excludes=EmptyI):
-                errors = None
-                if not isinstance(pfmri, fmri.PkgFmri):
-                        # pfmri is assumed to be a FMRI tuple.
-                        pub, stem, ver = pfmri
-                else:
-                        pub = pfmri.publisher
-                for astr in actions:
-                        try:
-                                a = pkg.actions.fromstr(astr)
-                        except pkg.actions.ActionError as e:
-                                # Accumulate errors and continue so that as
-                                # much of the action data as possible can be
-                                # parsed.
-                                if errors is None:
-                                        # Allocate this here to avoid overhead
-                                        # of list allocation/deallocation.
-                                        errors = []
-                                if not isinstance(pfmri, fmri.PkgFmri):
-                                        pfmri = fmri.PkgFmri(name=stem,
-                                            publisher=pub, version=ver)
-                                e.fmri = pfmri
-                                errors.append(e)
-                                continue
-
-                        if a.name == "set" and \
-                            (a.attrs["name"].startswith("facet") or
-                            a.attrs["name"].startswith("variant")):
-                                # Don't filter actual facet or variant
-                                # set actions.
-                                yield a
-                        elif a.include_this(excludes,
-                            publisher=pub):
-                                yield a
-
-                if errors is not None:
-                        raise api_errors.InvalidPackageErrors(errors)
-
-        def __gen_lazy_actions(self, f, info_needed, locales=EmptyI,
-            excludes=EmptyI):
-                # Note that the logic below must be kept in sync with
-                # group_actions found in add_package.
-                m = self.__manifest_cb(self, f)
-                if not m:
-                        # If the manifest callback returns None, then
-                        # assume there is no action data to yield.
-                        return
-
-                if Catalog.DEPENDENCY in info_needed:
-                        atypes = ("depend", "set")
-                elif Catalog.SUMMARY in info_needed:
-                        atypes = ("set",)
-                else:
-                        raise RuntimeError(_("Unknown info_needed "
-                            "type: {0}".format(info_needed)))
-
-                for a, attr_name in self.__gen_manifest_actions(m, atypes,
-                    excludes):
-                        if (a.name == "depend" or \
-                            attr_name.startswith("variant") or \
-                            attr_name.startswith("facet") or \
-                            attr_name.startswith("pkg.depend.") or \
-                            attr_name in ("pkg.obsolete",
-                                "pkg.renamed")):
-                                if Catalog.DEPENDENCY in info_needed:
-                                        yield a
-                        elif Catalog.SUMMARY in info_needed and a.name == "set":
-                                if attr_name in ("fmri", "pkg.fmri",
-                                    "publisher") or attr_name.startswith((
-                                    "info.source-url", "pkg.debug",
-                                    "pkg.linted")):
-                                        continue
-
-                                comps = attr_name.split(":")
-                                if len(comps) > 1:
-                                        # 'set' is locale-specific.
-                                        if comps[1] not in locales:
-                                                continue
-                                yield a
-
-        @staticmethod
-        def __gen_manifest_actions(m, atypes, excludes):
-                """Private helper function to iterate over a Manifest's actions
-                by action type, returning tuples of (action, attr_name)."""
-                pub = m.publisher
-                for atype in atypes:
-                        for a in m.gen_actions_by_type(atype):
-                                if not a.include_this(excludes,
-                                    publisher=pub):
-                                        continue
-
-                                if atype == "set":
-                                        yield a, a.attrs["name"]
-                                else:
-                                        yield a, None
-
-        def __get_batch_mode(self):
-                return self.__batch_mode
-
-        def __get_last_modified(self):
-                return self._attrs.last_modified
-
-        def __get_meta_root(self):
-                return self.__meta_root
-
-        def __get_sign(self):
-                return self.__sign
-
-        def __get_update(self, name, cache=True, must_exist=False):
-                # First, check if the update has already been cached,
-                # and if so, return it.
-                ulog = self.__updates.get(name, None)
-                if ulog is not None:
-                        return ulog
-                elif not self.meta_root and must_exist:
-                        return
-
-                # Next, if the update hasn't been cached,
-                # create an object for it.
-                ulog = CatalogUpdate(name, meta_root=self.meta_root,
-                    sign=self.__sign)
-                if self.meta_root and must_exist and not ulog.exists:
-                        # Update doesn't exist on-disk,
-                        # so don't return anything.
-                        return
-                if cache:
-                        self.__updates[name] = ulog
-                return ulog
-
-        def __get_version(self):
-                return self._attrs.version
-
-        def __lock_catalog(self):
-                """Locks the catalog preventing multiple threads or external
-                consumers of the catalog from modifying it during operations.
-                """
-
-                # XXX need filesystem lock too?
-                self.__lock.acquire()
-
-        def __log_update(self, pfmri, operation, op_time, entries=None):
-                """Helper function to log catalog changes."""
-
-                if not self.__batch_mode:
-                        # The catalog.attrs needs to be updated to reflect
-                        # the changes made.  A sort doesn't need to be done
-                        # here as the individual parts will automatically do
-                        # that as needed in this case.
-                        self.__finalize(sort=False)
-
-                # This must be set to exactly the same time as the update logs
-                # so that the changes in the update logs are not marked as
-                # being newer than the catalog or vice versa.
-                attrs = self._attrs
-                attrs.last_modified = op_time
-
-                if not self.log_updates:
-                        return
-
-                updates = {}
-                for pname in entries:
-                        # The last component of the updatelog filename is the
-                        # related locale.
-                        locale = pname.split(".", 2)[2]
-                        updates.setdefault(locale, {})
-                        parts = updates[locale]
-                        parts[pname] = entries[pname]
-
-                logdate = datetime_to_update_ts(op_time)
-                for locale, metadata in six.iteritems(updates):
-                        name = "update.{0}.{1}".format(logdate, locale)
-                        ulog = self.__get_update(name)
-                        ulog.add(pfmri, operation, metadata=metadata,
-                            op_time=op_time)
-                        attrs.updates[name] = {
-                            "last-modified": op_time
-                        }
-
-                for name, part in six.iteritems(self.__parts):
-                        # Signature data for each part needs to be cleared,
-                        # and will only be available again after save().
-                        attrs.parts[name] = {
-                            "last-modified": part.last_modified
-                        }
-
-        @staticmethod
-        def __parse_fmri_patterns(patterns):
-                """A generator function that yields a list of tuples of the form
-                (pattern, error, fmri, matcher) based on the provided patterns,
-                where 'error' is any exception encountered while parsing the
-                pattern, 'fmri' is the resulting FMRI object, and 'matcher' is
-                one of the following pkg.fmri matching functions:
-
-                        pkg.fmri.exact_name_match
-                                Indicates that the name portion of the pattern
-                                must match exactly and the version (if provided)
-                                must be considered a successor or equal to the
-                                target FMRI.
-
-                        pkg.fmri.fmri_match
-                                Indicates that the name portion of the pattern
-                                must be a proper subset and the version (if
-                                provided) must be considered a successor or
-                                equal to the target FMRI.
-
-                        pkg.fmri.glob_match
-                                Indicates that the name portion of the pattern
-                                uses fnmatch rules for pattern matching (shell-
-                                style wildcards) and that the version can either
-                                match exactly, match partially, or contain
-                                wildcards.
-                """
-
-                for pat in patterns:
-                        error = None
-                        matcher = None
-                        npat = None
-                        try:
-                                parts = pat.split("@", 1)
-                                pat_stem = parts[0]
-                                pat_ver = None
-                                if len(parts) > 1:
-                                        pat_ver = parts[1]
-
-                                if "*" in pat_stem or "?" in pat_stem:
-                                        matcher = fmri.glob_match
-                                elif pat_stem.startswith("pkg:/") or \
-                                    pat_stem.startswith("/"):
-                                        matcher = fmri.exact_name_match
-                                else:
-                                        matcher = fmri.fmri_match
-
-                                if matcher == fmri.glob_match:
-                                        npat = fmri.MatchingPkgFmri(pat_stem)
-                                else:
-                                        npat = fmri.PkgFmri(pat_stem)
-
-                                if not pat_ver:
-                                        # Do nothing.
-                                        pass
-                                elif "*" in pat_ver or "?" in pat_ver or \
-                                    pat_ver == "latest":
-                                        npat.version = \
-                                            pkg.version.MatchingVersion(pat_ver)
-                                else:
-                                        npat.version = \
-                                            pkg.version.Version(pat_ver)
-
-                        except (fmri.FmriError, pkg.version.VersionError) as e:
-                                # Whatever the error was, return it.
-                                error = e
-                        yield (pat, error, npat, matcher)
-
-        def __save(self, fmt='utf8'):
-                """Private save function.  Caller is responsible for locking
-                the catalog."""
-
-                attrs = self._attrs
-                if self.log_updates:
-                        for name, ulog in six.iteritems(self.__updates):
-                                ulog.load()
-                                ulog.set_feature(FEATURE_UTF8, fmt == 'utf8')
-                                ulog.save()
-
-                                # Replace the existing signature data
-                                # with the new signature data.
-                                entry = attrs.updates[name] = {
-                                    "last-modified": ulog.last_modified
-                                }
-                                for n, v in six.iteritems(ulog.signatures):
-                                        entry["signature-{0}".format(n)] = v
-
-                # Save any CatalogParts that are currently in-memory,
-                # updating their related information in catalog.attrs
-                # as they are saved.
-                for name, part in six.iteritems(self.__parts):
-                        # Must save first so that signature data is
-                        # current.
-
-                        # single-pass encoding is not used for summary part as
-                        # it increases memory usage substantially (30MB at
-                        # current for /dev).  No significant difference is
-                        # detectable for other parts though.
-                        part.load()
-                        part.set_feature(FEATURE_UTF8, fmt == 'utf8')
-                        part.save()
-
-                        # Now replace the existing signature data with
-                        # the new signature data.
-                        entry = attrs.parts[name] = {
-                            "last-modified": part.last_modified
-                        }
-                        for n, v in six.iteritems(part.signatures):
-                                entry["signature-{0}".format(n)] = v
-
-                # Finally, save the catalog attributes.
-                attrs.load()
-                attrs.set_feature(FEATURE_UTF8, fmt == 'utf8')
-                attrs.save()
-
-        def __set_batch_mode(self, value):
-                self.__batch_mode = value
-                for part in self.__parts.values():
-                        part.ordered = not self.__batch_mode
-
-        def __set_last_modified(self, value):
-                self._attrs.last_modified = value
-
-        def __set_meta_root(self, pathname):
-                if pathname:
-                        pathname = os.path.abspath(pathname)
-                self.__meta_root = pathname
-
-                # If the Catalog's meta_root changes, the meta_root of all of
-                # its parts must be changed too.
-                if self._attrs:
-                        self._attrs.meta_root = pathname
-
-                for part in self.__parts.values():
-                        part.meta_root = pathname
-
-                for ulog in self.__updates.values():
-                        ulog.meta_root = pathname
-
-        def __set_perms(self):
-                """Sets permissions on attrs and parts if not read_only and if
-                the current user can do so; raises BadCatalogPermissions if the
-                permissions are wrong and cannot be corrected."""
-
-                if not self.meta_root:
-                        # Nothing to do.
-                        return
-
-                files = [self._attrs.name]
-                files.extend(self._attrs.parts.keys())
-                files.extend(self._attrs.updates.keys())
-
-                # Force file_mode, so that unprivileged users can read these.
-                bad_modes = []
-                for name in files:
-                        pathname = os.path.join(self.meta_root, name)
-                        try:
-                                if self.read_only:
-                                        fmode = stat.S_IMODE(os.stat(
-                                            pathname).st_mode)
-                                        if fmode != self.__file_mode:
-                                                bad_modes.append((pathname,
-                                                    "{0:o}".format(
-                                                    self.__file_mode),
-                                                    "{0:o}".format(fmode)))
-                                else:
-                                        os.chmod(pathname, self.__file_mode)
-                        except EnvironmentError as e:
-                                # If the file doesn't exist yet, move on.
-                                if e.errno == errno.ENOENT:
-                                        continue
-
-                                # If the mode change failed for another reason,
-                                # check to see if we actually needed to change
-                                # it, and if so, add it to bad_modes.
-                                fmode = stat.S_IMODE(os.stat(
-                                    pathname).st_mode)
-                                if fmode != self.__file_mode:
-                                        bad_modes.append((pathname,
-                                            "{0:o}".format(self.__file_mode),
-                                            "{0:o}".format(fmode)))
-
-                if bad_modes:
-                        raise api_errors.BadCatalogPermissions(bad_modes)
-
-        def __set_sign(self, value):
-                self.__sign = value
-
-                # If the Catalog's sign property changes, the value of that
-                # property for its attributes, etc. must be changed too.
-                if self._attrs:
-                        self._attrs.sign = value
-
-                for part in self.__parts.values():
-                        part.sign = value
-
-                for ulog in self.__updates.values():
-                        ulog.sign = value
-
-        def __set_version(self, value):
-                self._attrs.version = value
-
-        def __unlock_catalog(self):
-                """Unlocks the catalog allowing other catalog consumers to
-                modify it."""
-
-                # XXX need filesystem unlock too?
-                self.__lock.release()
-
-        def actions(self, info_needed, excludes=EmptyI, cb=None,
-            last=False, locales=None, ordered=False, pubs=EmptyI):
-                """A generator function that produces tuples of the format
-                (fmri, actions) as it iterates over the contents of the
-                catalog (where 'actions' is a generator that returns the
-                Actions corresponding to the requested information).
-
-                If the catalog doesn't contain any action data for the package
-                entry, and manifest_cb was defined at Catalog creation time,
-                the action data will be lazy-loaded by the actions generator;
-                otherwise it will return an empty iterator.  This means that
-                the manifest_cb will be executed even for packages that don't
-                actually have any actions corresponding to info_needed.  For
-                example, if a package doesn't have any dependencies, the
-                manifest_cb will still be executed.  This was considered a
-                reasonable compromise as packages are generally expected to
-                have DEPENDENCY and SUMMARY information.
-
-                'excludes' is a list of variants which will be used to determine
-                what should be allowed by the actions generator in addition to
-                what is specified by 'info_needed'.
-
-                'cb' is an optional callback function that will be executed for
-                each package before its action data is retrieved. It must accept
-                two arguments: 'pkg' and 'entry'.  'pkg' is an FMRI object and
-                'entry' is the dictionary structure of the catalog entry for the
-                package.  If the callback returns False, then the entry will not
-                be included in the results.  This can significantly improve
-                performance by avoiding action data retrieval for results that
-                will not be used.
-
-                'info_needed' is a set of one or more catalog constants
-                indicating the types of catalog data that will be returned
-                in 'actions' in addition to the above:
-
-                        DEPENDENCY
-                                Depend and set Actions for package obsoletion,
-                                renaming, variants.
-
-                        SUMMARY
-                                Any remaining set Actions not listed above, such
-                                as pkg.summary, pkg.description, etc.
-
-                'last' is a boolean value that indicates only the last entry
-                for each package on a per-publisher basis should be returned.
-                As long as the catalog has been saved since the last modifying
-                operation, or finalize() has has been called, this will also be
-                the newest version of the package.
-
-                'locales' is an optional set of locale names for which Actions
-                should be returned.  The default is set(('C',)) if not provided.
-
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
-
-                'pfmri' is an optional FMRI to limit the returned results to.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                return self.__actions(info_needed, excludes=excludes,
-                    cb=cb, last_version=last, locales=locales, ordered=ordered,
-                    pubs=pubs)
-
-        def add_package(self, pfmri, manifest=None, metadata=None):
-                """Add a package and its related metadata to the catalog and
-                its parts as needed.
-
-                'manifest' is an optional Manifest object that will be used
-                to retrieve the metadata related to the package.
-
-                'metadata' is an optional dict of additional metadata to store
-                with the package's BASE record."""
-
-                assert not self.read_only
-
-                def group_actions(actions):
-                        dep_acts = { "C": [] }
-                        # Summary actions are grouped by locale, since each
-                        # goes to a locale-specific catalog part.
-                        sum_acts = { "C": [] }
-                        for act in actions:
-                                if act.name == "depend":
-                                        dep_acts["C"].append(str(act))
-                                        continue
-
-                                name = act.attrs["name"]
-                                if name.startswith("variant") or \
-                                    name.startswith("facet") or \
-                                    name.startswith("pkg.depend.") or \
-                                    name in ("pkg.obsolete", "pkg.renamed", "pkg.legacy"):
-                                        # variant and facet data goes to the
-                                        # dependency catalog part.
-                                        dep_acts["C"].append(str(act))
-                                        continue
-                                elif name in ("fmri", "pkg.fmri"):
-                                        # Redundant in the case of the catalog.
-                                        continue
-
-                                if name in ("fmri", "pkg.fmri",
-                                    "publisher") or name.startswith((
-                                    "info.source-url", "pkg.debug",
-                                    "pkg.linted")):
-                                        continue
-
-                                # All other set actions go to the summary
-                                # catalog parts, grouped by locale.  To
-                                # determine the locale, the set attribute's
-                                # name is split by ':' into its field and
-                                # locale components.  If ':' is not present,
-                                # then the 'C' locale is assumed.
-                                comps = name.split(":")
-                                if len(comps) > 1:
-                                        locale = comps[1]
-                                else:
-                                        locale = "C"
-                                if locale not in sum_acts:
-                                        sum_acts[locale] = []
-                                sum_acts[locale].append(str(act))
-
-                        return {
-                            "dependency": dep_acts,
-                            "summary": sum_acts,
-                        }
-
-                self.__lock_catalog()
-                try:
-                        entries = {}
-                        # Use the same operation time and date for all
-                        # operations so that the last modification times
-                        # of all catalog parts and update logs will be
-                        # synchronized.
-                        op_time = datetime.datetime.utcnow()
-
-                        # Always add packages to the base catalog.
-                        entry = {}
-                        if metadata:
-                                entry["metadata"] = metadata
-                        if manifest:
-                                for k, v in six.iteritems(manifest.signatures):
-                                        entry["signature-{0}".format(k)] = v
-                        part = self.get_part(self.__BASE_PART)
-                        entries[part.name] = part.add(pfmri, metadata=entry,
-                            op_time=op_time)
-
-                        if manifest:
-                                # Without a manifest, only the base catalog data
-                                # can be populated.
-
-                                # Only dependency and set actions are currently
-                                # used by the remaining catalog parts.
-                                actions = []
-                                for atype in "depend", "set":
-                                        actions += manifest.gen_actions_by_type(
-                                            atype)
-
-                                gacts = group_actions(actions)
-                                for ctype in gacts:
-                                        for locale in gacts[ctype]:
-                                                acts = gacts[ctype][locale]
-                                                if not acts:
-                                                        # Catalog entries only
-                                                        # added if actions are
-                                                        # present for this
-                                                        # ctype.
-                                                        continue
-
-                                                part = self.get_part("catalog"
-                                                    ".{0}.{1}".format(ctype,
-                                                    locale))
-                                                entry = { "actions": acts }
-                                                entries[part.name] = part.add(
-                                                    pfmri, metadata=entry,
-                                                    op_time=op_time)
-
-                        self.__log_update(pfmri, CatalogUpdate.ADD, op_time,
-                            entries=entries)
-                finally:
-                        self.__unlock_catalog()
-
-        def append(self, src, cb=None, pfmri=None, pubs=EmptyI):
-                """Appends the entries in the specified 'src' catalog to that
-                of the current catalog.  The caller is responsible for ensuring
-                that no duplicates exist and must call finalize() afterwards to
-                to ensure consistent catalog state.  This function cannot be
-                used when log_updates or read_only is enabled.
-
-                'cb' is an optional callback function that must accept src,
-                an FMRI, and entry.  Where 'src' is the source catalog the
-                FMRI's entry is being copied from, and entry is the source
-                catalog entry.  It must return a tuple of the form (append,
-                metadata), where 'append' is a boolean value indicating if
-                the specified package should be appended, and 'metadata' is
-                a dict of additional metadata to store with the package's
-                BASE record.
-
-                'pfmri' is an optional FMRI of a package to append.  If not
-                provided, all FMRIs in the 'src' catalog will be appended.
-                This filtering is applied before any provided callback.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the append operation to.  FRMIs that have a publisher not in
-                the list will be skipped.  This filtering is applied before
-                any provided callback.  If not provided, no publisher
-                filtering will be applied."""
-
-                assert not self.log_updates and not self.read_only
-
-                self.__lock_catalog()
-                try:
-                        # Append operations are much slower if batch mode is
-                        # not enabled.  This ensures that the current state
-                        # is stored and then reset on completion or failure.
-                        # Since append() is never used as part of the
-                        # publication process (log_updates == True),
-                        # this is safe.
-                        old_batch_mode = self.batch_mode
-                        self.batch_mode = True
-                        self.__append(src, cb=cb, pfmri=pfmri, pubs=pubs)
-                finally:
-                        self.batch_mode = old_batch_mode
-                        self.__unlock_catalog()
-
-        def apply_updates(self, path):
-                """Apply any CatalogUpdates available to the catalog based on
-                the list returned by get_updates_needed.  The caller must
-                retrieve all of the resources indicated by get_updates_needed
-                and place them in the directory indicated by 'path'."""
-
-                if not self.meta_root:
-                        raise api_errors.CatalogUpdateRequirements()
-
-                # Used to store the original time each part was modified
-                # as a basis for determining whether to apply specific
-                # updates.
-                old_parts = self._attrs.parts
-                def apply_incremental(name):
-                        # Load the CatalogUpdate from the path specified.
-                        # (Which is why __get_update is not used.)
-                        ulog = CatalogUpdate(name, meta_root=path)
-                        for pfmri, op_type, op_time, metadata in ulog.updates():
-                                for pname, pdata in six.iteritems(metadata):
-                                        part = self.get_part(pname,
-                                            must_exist=True)
-                                        if part is None:
-                                                # Part doesn't exist; skip.
-                                                continue
-
-                                        lm = old_parts[pname]["last-modified"]
-                                        if op_time <= lm:
-                                                # Only add updates to the part
-                                                # that occurred after the last
-                                                # time it was originally
-                                                # modified.
-                                                continue
-
-                                        if op_type == CatalogUpdate.ADD:
-                                                part.add(pfmri, metadata=pdata,
-                                                    op_time=op_time)
-                                        elif op_type == CatalogUpdate.REMOVE:
-                                                part.remove(pfmri,
-                                                    op_time=op_time)
-                                        else:
-                                                raise api_errors.UnknownUpdateType(
-                                                    op_type)
-
-                def apply_full(name):
-                        src = os.path.join(path, name)
-                        dest = os.path.join(self.meta_root, name)
-                        portable.copyfile(src, dest)
-
-                self.__lock_catalog()
-                try:
-                        old_batch_mode = self.batch_mode
-                        self.batch_mode = True
-
-                        updates = self.get_updates_needed(path)
-                        if updates == None:
-                                # Nothing has changed, so nothing to do.
-                                return
-
-                        for name in updates:
-                                if name.startswith("update."):
-                                        # The provided update is an incremental.
-                                        apply_incremental(name)
-                                else:
-                                        # The provided update is a full update.
-                                        apply_full(name)
-
-                        # Next, verify that all of the updated parts have a
-                        # signature that matches the new catalog.attrs file.
-                        new_attrs = CatalogAttrs(meta_root=path)
-                        new_sigs = {}
-                        for name, mdata in six.iteritems(new_attrs.parts):
-                                new_sigs[name] = {}
-                                for key in mdata:
-                                        if not key.startswith("signature-"):
-                                                continue
-                                        sig = key.split("signature-")[1]
-                                        new_sigs[name][sig] = mdata[key]
-
-                        # This must be done to ensure that the catalog
-                        # signature matches that of the source.
-                        self.batch_mode = old_batch_mode
-                        self.finalize()
-
-                        for name, part in six.iteritems(self.__parts):
-                                part.validate(signatures=new_sigs[name])
-
-                        # Finally, save the catalog, and then copy the new
-                        # catalog attributes file into place and reload it.
-                        self.__save()
-                        apply_full(self._attrs.name)
-
-                        self._attrs = CatalogAttrs(meta_root=self.meta_root)
-                        self.__set_perms()
-                finally:
-                        self.batch_mode = old_batch_mode
-                        self.__unlock_catalog()
-
-        def categories(self, excludes=EmptyI, pubs=EmptyI):
-                """Returns a set of tuples of the form (scheme, category)
-                containing the names of all categories in use by the last
-                version of each unique package in the catalog on a per-
-                publisher basis.
-
-                'excludes' is a list of variants which will be used to
-                determine what category actions will be checked.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                acts = self.__actions([self.SUMMARY], excludes=excludes,
-                    last_version=True, pubs=pubs)
-                return set((
-                    sc
-                    for f, acts in acts
-                    for a in acts
-                    if a.has_category_info()
-                    for sc in a.parse_category_info()
-                ))
-
-        @property
-        def created(self):
-                """A UTC datetime object indicating the time the catalog was
-                created."""
-                return self._attrs.created
-
-        def destroy(self):
-                """Removes any on-disk files that exist for the catalog and
-                discards all content."""
-
-                for name in self._attrs.parts:
-                        part = self.get_part(name)
-                        part.destroy()
-
-                for name in self._attrs.updates:
-                        ulog = self.__get_update(name, cache=False)
-                        ulog.destroy()
-
-                self._attrs = CatalogAttrs(meta_root=self.meta_root,
-                    sign=self.__sign)
-                self.__parts = {}
-                self.__updates = {}
-                self._attrs.destroy()
-
-                if not self.meta_root or not os.path.exists(self.meta_root):
-                        return
-
-                # Finally, ensure that if there are any leftover files from
-                # an interrupted destroy in the past that they are removed
-                # as well.
-                for fname in os.listdir(self.meta_root):
-                        if not fname.startswith("catalog.") and \
-                            not fname.startswith("update."):
-                                continue
-
-                        pname = os.path.join(self.meta_root, fname)
-                        if not os.path.isfile(pname):
-                                continue
-
-                        try:
-                                portable.remove(pname)
-                        except EnvironmentError as e:
-                                if e.errno == errno.EACCES:
-                                        raise api_errors.PermissionsException(
-                                            e.filename)
-                                if e.errno == errno.EROFS:
-                                        raise api_errors.ReadOnlyFileSystemException(
-                                            e.filename)
-                                raise
-
-        def entries(self, info_needed=EmptyI, last=False, locales=None,
-            ordered=False, pubs=EmptyI):
-                """A generator function that produces tuples of the format
-                (fmri, metadata) as it iterates over the contents of the
-                catalog (where 'metadata' is a dict containing the requested
-                information).
-
-                'metadata' always contains the following information at a
-                 minimum:
-
-                        BASE
-                                'metadata' will be populated with Manifest
-                                signature data, if available, using key-value
-                                pairs of the form 'signature-<name>': value.
-
-                'info_needed' is an optional list of one or more catalog
-                constants indicating the types of catalog data that will
-                be returned in 'metadata' in addition to the above:
-
-                        DEPENDENCY
-                                'metadata' will contain depend and set Actions
-                                for package obsoletion, renaming, variants,
-                                and facets stored in a list under the
-                                key 'actions'.
-
-                        SUMMARY
-                                'metadata' will contain any remaining Actions
-                                not listed above, such as pkg.summary,
-                                pkg.description, etc. in a list under the key
-                                'actions'.
-
-                'last' is a boolean value that indicates only the last entry
-                for each package on a per-publisher basis should be returned.
-                As long as the catalog has been saved since the last modifying
-                operation, or finalize() has has been called, this will also be
-                the newest version of the package.
-
-                'locales' is an optional set of locale names for which Actions
-                should be returned.  The default is set(('C',)) if not provided.
-                Note that unlike actions(), catalog entries will not lazy-load
-                action data if it is missing from the catalog.
-
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                return self.__entries(info_needed=info_needed,
-                    last_version=last, locales=locales, ordered=ordered,
-                    pubs=pubs)
-
-        def entries_by_version(self, name, info_needed=EmptyI, locales=None,
-            pubs=EmptyI):
-                """A generator function that produces tuples of the format
-                (version, entries) as it iterates over the contents of the
-                the catalog, where entries is a list of tuples of the format
-                (fmri, metadata) and metadata is a dict containing the
-                requested information.
-
-                'metadata' always contains the following information at a
-                 minimum:
-
-                        BASE
-                                'metadata' will be populated with Manifest
-                                signature data, if available, using key-value
-                                pairs of the form 'signature-<name>': value.
-
-                'info_needed' is an optional list of one or more catalog
-                constants indicating the types of catalog data that will
-                be returned in 'metadata' in addition to the above:
-
-                        DEPENDENCY
-                                'metadata' will contain depend and set Actions
-                                for package obsoletion, renaming, variants,
-                                and facets stored in a list under the
-                                key 'actions'.
-
-                        SUMMARY
-                                'metadata' will contain any remaining Actions
-                                not listed above, such as pkg.summary,
-                                pkg.description, etc. in a list under the key
-                                'actions'.
-
-                'locales' is an optional set of locale names for which Actions
-                should be returned.  The default is set(('C',)) if not provided.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        # Catalog contains nothing.
-                        return
-
-                if not locales:
-                        locales = set(("C",))
-                else:
-                        locales = set(locales)
-
-                parts = []
-                if self.DEPENDENCY in info_needed:
-                        part = self.get_part(self.__DEPS_PART, must_exist=True)
-                        if part is not None:
-                                parts.append(part)
-
-                if self.SUMMARY in info_needed:
-                        for locale in locales:
-                                part = self.get_part(
-                                    "{0}.{1}".format(self.__SUMM_PART_PFX,
-                                    locale), must_exist=True)
-                                if part is None:
-                                        # Data not available for this
-                                        # locale.
-                                        continue
-                                parts.append(part)
-
-                def merge_entry(src, dest):
-                        for k, v in six.iteritems(src):
-                                if k == "actions":
-                                        dest.setdefault(k, [])
-                                        dest[k] += v
-                                elif k != "version":
-                                        dest[k] = v
-
-                for ver, entries in base.entries_by_version(name, pubs=pubs):
-                        nentries = []
-                        for f, bentry in entries:
-                                mdata = {}
-                                merge_entry(bentry, mdata)
-                                for part in parts:
-                                        entry = part.get_entry(f)
-                                        if entry is None:
-                                                # Part doesn't have this FMRI,
-                                                # so skip it.
-                                                continue
-                                        merge_entry(entry, mdata)
-                                nentries.append((f, mdata))
-                        yield ver, nentries
-
-        def entry_actions(self, info_needed, excludes=EmptyI, cb=None,
-            last=False, locales=None, ordered=False, pubs=EmptyI):
-                """A generator function that produces tuples of the format
-                ((pub, stem, version), entry, actions) as it iterates over
-                the contents of the catalog (where 'actions' is a generator
-                that returns the Actions corresponding to the requested
-                information).
-
-                If the catalog doesn't contain any action data for the package
-                entry, and manifest_cb was defined at Catalog creation time,
-                the action data will be lazy-loaded by the actions generator;
-                otherwise it will return an empty iterator.  This means that
-                the manifest_cb will be executed even for packages that don't
-                actually have any actions corresponding to info_needed.  For
-                example, if a package doesn't have any dependencies, the
-                manifest_cb will still be executed.  This was considered a
-                reasonable compromise as packages are generally expected to
-                have DEPENDENCY and SUMMARY information.
-
-                'excludes' is a list of variants which will be used to determine
-                what should be allowed by the actions generator in addition to
-                what is specified by 'info_needed'.
-
-                'cb' is an optional callback function that will be executed for
-                each package before its action data is retrieved. It must accept
-                two arguments: 'pkg' and 'entry'.  'pkg' is an FMRI object and
-                'entry' is the dictionary structure of the catalog entry for the
-                package.  If the callback returns False, then the entry will not
-                be included in the results.  This can significantly improve
-                performance by avoiding action data retrieval for results that
-                will not be used.
-
-                'info_needed' is a set of one or more catalog constants
-                indicating the types of catalog data that will be returned
-                in 'actions' in addition to the above:
-
-                        DEPENDENCY
-                                Depend and set Actions for package obsoletion,
-                                renaming, variants.
-
-                        SUMMARY
-                                Any remaining set Actions not listed above, such
-                                as pkg.summary, pkg.description, etc.
-
-                'last' is a boolean value that indicates only the last entry
-                for each package on a per-publisher basis should be returned.
-                As long as the catalog has been saved since the last modifying
-                operation, or finalize() has has been called, this will also be
-                the newest version of the package.
-
-                'locales' is an optional set of locale names for which Actions
-                should be returned.  The default is set(('C',)) if not provided.
-
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
-
-                'pfmri' is an optional FMRI to limit the returned results to.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                for r, entry in self.__entries(cb=cb, info_needed=info_needed,
-                    locales=locales, last_version=last, ordered=ordered,
-                    pubs=pubs, tuples=True):
-                        try:
-                                yield (r, entry,
-                                    self.__gen_actions(r, entry["actions"],
-                                    excludes))
-                        except KeyError:
-                                if self.__manifest_cb:
-                                        pub, stem, ver = r
-                                        f = fmri.PkgFmri(name=stem, publisher=pub,
-                                            version=ver)
-                                        yield (r, entry,
-                                            self.__gen_lazy_actions(f, info_needed,
-                                            locales, excludes))
-                                else:
-                                        yield r, entry, EmptyI
-
-        @property
-        def exists(self):
-                """A boolean value indicating whether the Catalog exists
-                on-disk."""
-
-                # If the Catalog attrs file exists on-disk,
-                # then the catalog does.
-                attrs = self._attrs
-                return attrs.exists
-
-        def finalize(self, pfmris=None, pubs=None):
-                """This function re-sorts the contents of the Catalog so that
-                version entries are in the correct order and sets the package
-                counts for the Catalog based on its current contents.
-
-                'pfmris' is an optional set of FMRIs that indicate what package
-                entries have been changed since this function was last called.
-                It is used to optimize the finalization process.
-
-                'pubs' is an optional set of publisher prefixes that indicate
-                what publisher has had package entries changed.  It is used
-                to optimize the finalization process.  This option has no effect
-                if 'pfmris' is also provided."""
-
-                return self.__finalize(pfmris=pfmris, pubs=pubs)
-
-        def fmris(self, last=False, objects=True, ordered=False, pubs=EmptyI):
-                """A generator function that produces FMRIs as it iterates
-                over the contents of the catalog.
-
-                'last' is a boolean value that indicates only the last FMRI
-                for each package on a per-publisher basis should be returned.
-                As long as the catalog has been saved since the last modifying
-                operation, or finalize() has has been called, this will also be
-                the newest version of the package.
-
-                'objects' is an optional boolean value indicating whether
-                FMRIs should be returned as FMRI objects or as strings.
-
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        # Catalog contains nothing.
-
-                        # This construction is necessary to get python to
-                        # return no results properly to callers expecting
-                        # a generator function.
-                        return iter(())
-                return base.fmris(last=last, objects=objects, ordered=ordered,
-                    pubs=pubs)
-
-        def fmris_by_version(self, name, pubs=EmptyI):
-                """A generator function that produces tuples of (version,
-                fmris), where fmris is a of the fmris related to the
-                version, for the given package name.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        # Catalog contains nothing.
-
-                        # This construction is necessary to get python to
-                        # return no results properly to callers expecting
-                        # a generator function.
-                        return iter(())
-                return base.fmris_by_version(name, pubs=pubs)
-
-        def get_entry(self, pfmri, info_needed=EmptyI, locales=None):
-                """Returns a dict containing the metadata for the specified
-                FMRI containing the requested information.  If the specified
-                FMRI does not exist in the catalog, a value of None will be
-                returned.
-
-                'metadata' always contains the following information at a
-                 minimum:
-
-                        BASE
-                                'metadata' will be populated with Manifest
-                                signature data, if available, using key-value
-                                pairs of the form 'signature-<name>': value.
-
-                'info_needed' is an optional list of one or more catalog
-                constants indicating the types of catalog data that will
-                be returned in 'metadata' in addition to the above:
-
-                        DEPENDENCY
-                                'metadata' will contain depend and set Actions
-                                for package obsoletion, renaming, variants,
-                                and facets stored in a list under the
-                                key 'actions'.
-
-                        SUMMARY
-                                'metadata' will contain any remaining Actions
-                                not listed above, such as pkg.summary,
-                                pkg.description, etc. in a list under the key
-                                'actions'.
-
-                'locales' is an optional set of locale names for which Actions
-                should be returned.  The default is set(('C',)) if not provided.
-                """
-
-                def merge_entry(src, dest):
-                        for k, v in six.iteritems(src):
-                                if k == "actions":
-                                        dest.setdefault(k, [])
-                                        dest[k] += v
-                                elif k != "version":
-                                        dest[k] = v
-
-                parts = []
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        return
-
-                if not locales:
-                        locales = set(("C",))
-                else:
-                        locales = set(locales)
-
-                # Always attempt to retrieve the BASE entry as FMRIs
-                # must be present in the BASE catalog part.
-                mdata = {}
-                bentry = base.get_entry(pfmri)
-                if bentry is None:
-                        return
-                merge_entry(bentry, mdata)
-
-                if self.DEPENDENCY in info_needed:
-                        part = self.get_part(self.__DEPS_PART,
-                            must_exist=True)
-                        if part is not None:
-                                parts.append(part)
-
-                if self.SUMMARY in info_needed:
-                        for locale in locales:
-                                part = self.get_part(
-                                    "{0}.{1}".format(self.__SUMM_PART_PFX,
-                                    locale), must_exist=True)
-                                if part is None:
-                                        # Data not available for this
-                                        # locale.
-                                        continue
-                                parts.append(part)
-
-                for part in parts:
-                        entry = part.get_entry(pfmri)
-                        if entry is None:
-                                # Part doesn't have this FMRI,
-                                # so skip it.
-                                continue
-                        merge_entry(entry, mdata)
-                return mdata
-
-        def get_entry_actions(self, pfmri, info_needed, excludes=EmptyI,
-            locales=None):
-                """A generator function that produces Actions as it iterates
-                over the catalog entry of the specified FMRI corresponding to
-                the requested information).  If the catalog doesn't contain
-                any action data for the package entry, and manifest_cb was
-                defined at Catalog creation time, the action data will be
-                lazy-loaded by the actions generator; otherwise it will
-                return an empty iterator.
-
-                'excludes' is a list of variants which will be used to determine
-                what should be allowed by the actions generator in addition to
-                what is specified by 'info_needed'.  If not provided, only
-                'info_needed' will determine what actions are returned.
-
-                'info_needed' is a set of one or more catalog constants
-                indicating the types of catalog data that will be returned
-                in 'actions' in addition to the above:
-
-                        DEPENDENCY
-                                Depend and set Actions for package obsoletion,
-                                renaming, variants.
-
-                        SUMMARY
-                                Any remaining set Actions not listed above, such
-                                as pkg.summary, pkg.description, etc.
-
-                'locales' is an optional set of locale names for which Actions
-                should be returned.  The default is set(('C',)) if not provided.
-                """
-
-                assert info_needed
-                if not locales:
-                        locales = set(("C",))
-                else:
-                        locales = set(locales)
-
-                entry = self.get_entry(pfmri, info_needed=info_needed,
-                    locales=locales)
+                    yield f, EmptyI
+
+    def __append(self, src, cb=None, pfmri=None, pubs=EmptyI):
+        """Private version; caller responsible for locking."""
+
+        base = self.get_part(self.__BASE_PART)
+        src_base = src.get_part(self.__BASE_PART, must_exist=True)
+        if src_base is None:
+            if pfmri:
+                raise api_errors.UnknownCatalogEntry(pfmri)
+            # Nothing to do
+            return
+
+        # Use the same operation time and date for all operations so
+        # that the last modification times will be synchronized.  This
+        # also has the benefit of avoiding extra datetime object
+        # instantiations.
+        op_time = datetime.datetime.utcnow()
+
+        # For each entry in the 'src' catalog, add its BASE entry to the
+        # current catalog along and then add it to the 'd'iscard dict if
+        # 'cb' is defined and returns False.
+        if pfmri:
+            entry = src_base.get_entry(pfmri)
+            if entry is None:
+                raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+            entries = [(pfmri, entry)]
+        else:
+            entries = src_base.entries()
+
+        d = {}
+        for f, entry in entries:
+            if pubs and f.publisher not in pubs:
+                continue
+
+            nentry = copy.deepcopy(entry)
+            if cb is not None:
+                merge, mdata = cb(src, f, entry)
+                if not merge:
+                    pub = d.setdefault(f.publisher, {})
+                    plist = pub.setdefault(f.pkg_name, set())
+                    plist.add(f.version)
+                    continue
+
+                if mdata:
+                    if "metadata" in nentry:
+                        nentry["metadata"].update(mdata)
+                    else:
+                        nentry["metadata"] = mdata
+            base.add(f, metadata=nentry, op_time=op_time)
+
+        if d and pfmri:
+            # If the 'd'iscards dict is populated and pfmri is
+            # defined, then there is nothing more to do.
+            return
+
+        # Finally, merge any catalog part entries that exist unless the
+        # FMRI is found in the 'd'iscard dict.
+        for name in src.parts.keys():
+            if name == self.__BASE_PART:
+                continue
+
+            part = src.get_part(name, must_exist=True)
+            if part is None:
+                # Part doesn't exist in-memory or on-disk, so
+                # skip it.
+                continue
+
+            if pfmri:
+                entry = part.get_entry(pfmri)
                 if entry is None:
-                        raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+                    # Package isn't in this part; skip it.
+                    continue
+                entries = [(pfmri, entry)]
+            else:
+                entries = part.entries()
 
-                try:
-                        return self.__gen_actions(pfmri, entry["actions"],
-                            excludes)
-                except KeyError:
-                        if self.__manifest_cb:
-                                return self.__gen_lazy_actions(pfmri,
-                                    info_needed, locales, excludes)
-                        else:
-                                return EmptyI
+            npart = self.get_part(name)
+            for f, entry in entries:
+                if pubs and f.publisher not in pubs:
+                    continue
+                if (
+                    f.publisher in d
+                    and f.pkg_name in d[f.publisher]
+                    and f.version in d[f.publisher][f.pkg_name]
+                ):
+                    # Skip this package.
+                    continue
 
-        def get_entry_all_variants(self, pfmri):
-                """A generator function that yields tuples of the format
-                (var_name, variants); where var_name is the name of the
-                variant and variants is a list of the variants for that
-                name."""
+                nentry = copy.deepcopy(entry)
+                npart.add(f, metadata=nentry, op_time=op_time)
 
-                info_needed = [self.DEPENDENCY]
-                entry = self.get_entry(pfmri, info_needed=info_needed)
-                if entry is None:
-                        raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+    def __entries(
+        self,
+        cb=None,
+        info_needed=EmptyI,
+        last_version=False,
+        locales=None,
+        ordered=False,
+        pubs=EmptyI,
+        tuples=False,
+    ):
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            # Catalog contains nothing.
+            return
 
-                try:
-                        actions = self.__gen_actions(pfmri, entry["actions"])
-                except KeyError:
-                        if self.__manifest_cb:
-                                actions = self.__gen_lazy_actions(pfmri,
-                                    info_needed)
-                        else:
-                                return
+        if not locales:
+            locales = set(("C",))
+        else:
+            locales = set(locales)
 
-                for a in actions:
-                        if a.name != "set":
-                                continue
+        parts = []
+        if self.DEPENDENCY in info_needed:
+            part = self.get_part(self.__DEPS_PART, must_exist=True)
+            if part is not None:
+                parts.append(part)
 
-                        attr_name = a.attrs["name"]
-                        if not attr_name.startswith("variant"):
-                                continue
-                        yield attr_name, a.attrs["value"]
-
-        def get_entry_signatures(self, pfmri):
-                """A generator function that yields tuples of the form (sig,
-                value) where 'sig' is the name of the signature, and 'value' is
-                the raw catalog value for the signature.  Please note that the
-                data type of 'value' is dependent on the signature, so it may
-                be a string, list, dict, etc."""
-
-                entry = self.get_entry(pfmri)
-                if entry is None:
-                        raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
-                return (
-                    (k.split("signature-")[1], v)
-                    for k, v in six.iteritems(entry)
-                    if k.startswith("signature-")
+        if self.SUMMARY in info_needed:
+            for locale in locales:
+                part = self.get_part(
+                    "{0}.{1}".format(self.__SUMM_PART_PFX, locale),
+                    must_exist=True,
                 )
+                if part is None:
+                    # Data not available for this
+                    # locale.
+                    continue
+                parts.append(part)
 
-        def get_entry_variants(self, pfmri, name):
-                """A generator function that returns the variants for the
-                specified variant name.  If no variants exist for the
-                specified name, None will be returned."""
+        def merge_entry(src, dest):
+            for k, v in six.iteritems(src):
+                if k == "actions":
+                    dest.setdefault(k, [])
+                    dest[k] += v
+                elif k != "version":
+                    dest[k] = v
 
-                for var_name, values in self.get_entry_all_variants(pfmri):
-                        if var_name == name:
-                                # A package can only have one set of values
-                                # for a single variant name, so return it.
-                                return values
-                return None
+        if tuples:
+            for r, bentry in base.tuple_entries(
+                cb=cb, last=last_version, ordered=ordered, pubs=pubs
+            ):
+                pub, stem, ver = r
+                mdata = {}
+                merge_entry(bentry, mdata)
+                for part in parts:
+                    entry = part.get_entry(pub=pub, stem=stem, ver=ver)
+                    if entry is None:
+                        # Part doesn't have this FMRI,
+                        # so skip it.
+                        continue
+                    for k, v in six.iteritems(entry):
+                        if k == "actions":
+                            mdata.setdefault(k, [])
+                            mdata[k] += v
+                        elif k != "version":
+                            mdata[k] = v
+                yield r, mdata
+            return
 
-        def gen_packages(self, collect_attrs=False, matched=None,
-            patterns=EmptyI, pubs=EmptyI, unmatched=None, return_fmris=False):
-                """A generator function that produces tuples of the form:
+        for f, bentry in base.entries(
+            cb=cb, last=last_version, ordered=ordered, pubs=pubs
+        ):
+            mdata = {}
+            merge_entry(bentry, mdata)
+            for part in parts:
+                entry = part.get_entry(f)
+                if entry is None:
+                    # Part doesn't have this FMRI,
+                    # so skip it.
+                    continue
+                for k, v in six.iteritems(entry):
+                    if k == "actions":
+                        mdata.setdefault(k, [])
+                        mdata[k] += v
+                    elif k != "version":
+                        mdata[k] = v
+            yield f, mdata
 
-                    (
+    def __finalize(self, pfmris=None, pubs=None, sort=True):
+        """Private finalize method; exposes additional controls for
+        internal callers."""
+
+        package_count = 0
+        package_version_count = 0
+
+        part = self.get_part(self.__BASE_PART, must_exist=True)
+        if part is not None:
+            # If the base Catalog didn't exist (in-memory or on-
+            # disk) that implies there is nothing to sort and
+            # there are no packages (since the base catalog part
+            # must always exist for packages to be present).
+            package_count, package_version_count = part.get_package_counts()
+
+            if sort:
+                # Some operations don't need this, such as
+                # remove...
+                for part in self.__parts.values():
+                    part.sort(pfmris=pfmris, pubs=pubs)
+
+        self._attrs.package_count = package_count
+        self._attrs.package_version_count = package_version_count
+
+    @staticmethod
+    def __gen_actions(pfmri, actions, excludes=EmptyI):
+        errors = None
+        if not isinstance(pfmri, fmri.PkgFmri):
+            # pfmri is assumed to be a FMRI tuple.
+            pub, stem, ver = pfmri
+        else:
+            pub = pfmri.publisher
+        for astr in actions:
+            try:
+                a = pkg.actions.fromstr(astr)
+            except pkg.actions.ActionError as e:
+                # Accumulate errors and continue so that as
+                # much of the action data as possible can be
+                # parsed.
+                if errors is None:
+                    # Allocate this here to avoid overhead
+                    # of list allocation/deallocation.
+                    errors = []
+                if not isinstance(pfmri, fmri.PkgFmri):
+                    pfmri = fmri.PkgFmri(name=stem, publisher=pub, version=ver)
+                e.fmri = pfmri
+                errors.append(e)
+                continue
+
+            if a.name == "set" and (
+                a.attrs["name"].startswith("facet")
+                or a.attrs["name"].startswith("variant")
+            ):
+                # Don't filter actual facet or variant
+                # set actions.
+                yield a
+            elif a.include_this(excludes, publisher=pub):
+                yield a
+
+        if errors is not None:
+            raise api_errors.InvalidPackageErrors(errors)
+
+    def __gen_lazy_actions(
+        self, f, info_needed, locales=EmptyI, excludes=EmptyI
+    ):
+        # Note that the logic below must be kept in sync with
+        # group_actions found in add_package.
+        m = self.__manifest_cb(self, f)
+        if not m:
+            # If the manifest callback returns None, then
+            # assume there is no action data to yield.
+            return
+
+        if Catalog.DEPENDENCY in info_needed:
+            atypes = ("depend", "set")
+        elif Catalog.SUMMARY in info_needed:
+            atypes = ("set",)
+        else:
+            raise RuntimeError(
+                _("Unknown info_needed " "type: {0}".format(info_needed))
+            )
+
+        for a, attr_name in self.__gen_manifest_actions(m, atypes, excludes):
+            if (
+                a.name == "depend"
+                or attr_name.startswith("variant")
+                or attr_name.startswith("facet")
+                or attr_name.startswith("pkg.depend.")
+                or attr_name in ("pkg.obsolete", "pkg.renamed")
+            ):
+                if Catalog.DEPENDENCY in info_needed:
+                    yield a
+            elif Catalog.SUMMARY in info_needed and a.name == "set":
+                if attr_name in (
+                    "fmri",
+                    "pkg.fmri",
+                    "publisher",
+                ) or attr_name.startswith(
+                    ("info.source-url", "pkg.debug", "pkg.linted")
+                ):
+                    continue
+
+                comps = attr_name.split(":")
+                if len(comps) > 1:
+                    # 'set' is locale-specific.
+                    if comps[1] not in locales:
+                        continue
+                yield a
+
+    @staticmethod
+    def __gen_manifest_actions(m, atypes, excludes):
+        """Private helper function to iterate over a Manifest's actions
+        by action type, returning tuples of (action, attr_name)."""
+        pub = m.publisher
+        for atype in atypes:
+            for a in m.gen_actions_by_type(atype):
+                if not a.include_this(excludes, publisher=pub):
+                    continue
+
+                if atype == "set":
+                    yield a, a.attrs["name"]
+                else:
+                    yield a, None
+
+    def __get_batch_mode(self):
+        return self.__batch_mode
+
+    def __get_last_modified(self):
+        return self._attrs.last_modified
+
+    def __get_meta_root(self):
+        return self.__meta_root
+
+    def __get_sign(self):
+        return self.__sign
+
+    def __get_update(self, name, cache=True, must_exist=False):
+        # First, check if the update has already been cached,
+        # and if so, return it.
+        ulog = self.__updates.get(name, None)
+        if ulog is not None:
+            return ulog
+        elif not self.meta_root and must_exist:
+            return
+
+        # Next, if the update hasn't been cached,
+        # create an object for it.
+        ulog = CatalogUpdate(name, meta_root=self.meta_root, sign=self.__sign)
+        if self.meta_root and must_exist and not ulog.exists:
+            # Update doesn't exist on-disk,
+            # so don't return anything.
+            return
+        if cache:
+            self.__updates[name] = ulog
+        return ulog
+
+    def __get_version(self):
+        return self._attrs.version
+
+    def __lock_catalog(self):
+        """Locks the catalog preventing multiple threads or external
+        consumers of the catalog from modifying it during operations.
+        """
+
+        # XXX need filesystem lock too?
+        self.__lock.acquire()
+
+    def __log_update(self, pfmri, operation, op_time, entries=None):
+        """Helper function to log catalog changes."""
+
+        if not self.__batch_mode:
+            # The catalog.attrs needs to be updated to reflect
+            # the changes made.  A sort doesn't need to be done
+            # here as the individual parts will automatically do
+            # that as needed in this case.
+            self.__finalize(sort=False)
+
+        # This must be set to exactly the same time as the update logs
+        # so that the changes in the update logs are not marked as
+        # being newer than the catalog or vice versa.
+        attrs = self._attrs
+        attrs.last_modified = op_time
+
+        if not self.log_updates:
+            return
+
+        updates = {}
+        for pname in entries:
+            # The last component of the updatelog filename is the
+            # related locale.
+            locale = pname.split(".", 2)[2]
+            updates.setdefault(locale, {})
+            parts = updates[locale]
+            parts[pname] = entries[pname]
+
+        logdate = datetime_to_update_ts(op_time)
+        for locale, metadata in six.iteritems(updates):
+            name = "update.{0}.{1}".format(logdate, locale)
+            ulog = self.__get_update(name)
+            ulog.add(pfmri, operation, metadata=metadata, op_time=op_time)
+            attrs.updates[name] = {"last-modified": op_time}
+
+        for name, part in six.iteritems(self.__parts):
+            # Signature data for each part needs to be cleared,
+            # and will only be available again after save().
+            attrs.parts[name] = {"last-modified": part.last_modified}
+
+    @staticmethod
+    def __parse_fmri_patterns(patterns):
+        """A generator function that yields a list of tuples of the form
+        (pattern, error, fmri, matcher) based on the provided patterns,
+        where 'error' is any exception encountered while parsing the
+        pattern, 'fmri' is the resulting FMRI object, and 'matcher' is
+        one of the following pkg.fmri matching functions:
+
+                pkg.fmri.exact_name_match
+                        Indicates that the name portion of the pattern
+                        must match exactly and the version (if provided)
+                        must be considered a successor or equal to the
+                        target FMRI.
+
+                pkg.fmri.fmri_match
+                        Indicates that the name portion of the pattern
+                        must be a proper subset and the version (if
+                        provided) must be considered a successor or
+                        equal to the target FMRI.
+
+                pkg.fmri.glob_match
+                        Indicates that the name portion of the pattern
+                        uses fnmatch rules for pattern matching (shell-
+                        style wildcards) and that the version can either
+                        match exactly, match partially, or contain
+                        wildcards.
+        """
+
+        for pat in patterns:
+            error = None
+            matcher = None
+            npat = None
+            try:
+                parts = pat.split("@", 1)
+                pat_stem = parts[0]
+                pat_ver = None
+                if len(parts) > 1:
+                    pat_ver = parts[1]
+
+                if "*" in pat_stem or "?" in pat_stem:
+                    matcher = fmri.glob_match
+                elif pat_stem.startswith("pkg:/") or pat_stem.startswith("/"):
+                    matcher = fmri.exact_name_match
+                else:
+                    matcher = fmri.fmri_match
+
+                if matcher == fmri.glob_match:
+                    npat = fmri.MatchingPkgFmri(pat_stem)
+                else:
+                    npat = fmri.PkgFmri(pat_stem)
+
+                if not pat_ver:
+                    # Do nothing.
+                    pass
+                elif "*" in pat_ver or "?" in pat_ver or pat_ver == "latest":
+                    npat.version = pkg.version.MatchingVersion(pat_ver)
+                else:
+                    npat.version = pkg.version.Version(pat_ver)
+
+            except (fmri.FmriError, pkg.version.VersionError) as e:
+                # Whatever the error was, return it.
+                error = e
+            yield (pat, error, npat, matcher)
+
+    def __save(self, fmt="utf8"):
+        """Private save function.  Caller is responsible for locking
+        the catalog."""
+
+        attrs = self._attrs
+        if self.log_updates:
+            for name, ulog in six.iteritems(self.__updates):
+                ulog.load()
+                ulog.set_feature(FEATURE_UTF8, fmt == "utf8")
+                ulog.save()
+
+                # Replace the existing signature data
+                # with the new signature data.
+                entry = attrs.updates[name] = {
+                    "last-modified": ulog.last_modified
+                }
+                for n, v in six.iteritems(ulog.signatures):
+                    entry["signature-{0}".format(n)] = v
+
+        # Save any CatalogParts that are currently in-memory,
+        # updating their related information in catalog.attrs
+        # as they are saved.
+        for name, part in six.iteritems(self.__parts):
+            # Must save first so that signature data is
+            # current.
+
+            # single-pass encoding is not used for summary part as
+            # it increases memory usage substantially (30MB at
+            # current for /dev).  No significant difference is
+            # detectable for other parts though.
+            part.load()
+            part.set_feature(FEATURE_UTF8, fmt == "utf8")
+            part.save()
+
+            # Now replace the existing signature data with
+            # the new signature data.
+            entry = attrs.parts[name] = {"last-modified": part.last_modified}
+            for n, v in six.iteritems(part.signatures):
+                entry["signature-{0}".format(n)] = v
+
+        # Finally, save the catalog attributes.
+        attrs.load()
+        attrs.set_feature(FEATURE_UTF8, fmt == "utf8")
+        attrs.save()
+
+    def __set_batch_mode(self, value):
+        self.__batch_mode = value
+        for part in self.__parts.values():
+            part.ordered = not self.__batch_mode
+
+    def __set_last_modified(self, value):
+        self._attrs.last_modified = value
+
+    def __set_meta_root(self, pathname):
+        if pathname:
+            pathname = os.path.abspath(pathname)
+        self.__meta_root = pathname
+
+        # If the Catalog's meta_root changes, the meta_root of all of
+        # its parts must be changed too.
+        if self._attrs:
+            self._attrs.meta_root = pathname
+
+        for part in self.__parts.values():
+            part.meta_root = pathname
+
+        for ulog in self.__updates.values():
+            ulog.meta_root = pathname
+
+    def __set_perms(self):
+        """Sets permissions on attrs and parts if not read_only and if
+        the current user can do so; raises BadCatalogPermissions if the
+        permissions are wrong and cannot be corrected."""
+
+        if not self.meta_root:
+            # Nothing to do.
+            return
+
+        files = [self._attrs.name]
+        files.extend(self._attrs.parts.keys())
+        files.extend(self._attrs.updates.keys())
+
+        # Force file_mode, so that unprivileged users can read these.
+        bad_modes = []
+        for name in files:
+            pathname = os.path.join(self.meta_root, name)
+            try:
+                if self.read_only:
+                    fmode = stat.S_IMODE(os.stat(pathname).st_mode)
+                    if fmode != self.__file_mode:
+                        bad_modes.append(
+                            (
+                                pathname,
+                                "{0:o}".format(self.__file_mode),
+                                "{0:o}".format(fmode),
+                            )
+                        )
+                else:
+                    os.chmod(pathname, self.__file_mode)
+            except EnvironmentError as e:
+                # If the file doesn't exist yet, move on.
+                if e.errno == errno.ENOENT:
+                    continue
+
+                # If the mode change failed for another reason,
+                # check to see if we actually needed to change
+                # it, and if so, add it to bad_modes.
+                fmode = stat.S_IMODE(os.stat(pathname).st_mode)
+                if fmode != self.__file_mode:
+                    bad_modes.append(
                         (
-                            pub,    - (string) the publisher of the package
-                            stem,   - (string) the name of the package
-                            version - (string) the version of the package
-                        ),
-                        states,     - (list) states
-                        attributes  - (dict) package attributes
+                            pathname,
+                            "{0:o}".format(self.__file_mode),
+                            "{0:o}".format(fmode),
+                        )
                     )
 
-                Results are always sorted by stem, publisher, and then in
-                descending version order.
-
-                'collect_attrs' is an optional boolean that indicates whether
-                all package attributes should be collected and returned in the
-                fifth element of the return tuple.  If False, that element will
-                be an empty dictionary.
-
-                'matched' is an optional set to add matched patterns to.
-
-                'patterns' is an optional list of FMRI wildcard strings to
-                filter results by.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to.
-
-                'unmatched' is an optional set to add unmatched patterns to.
-
-                'return_fmris' is an optional boolean value that indicates that
-                an FMRI object should be returned in place of the (pub, stem,
-                ver) tuple that is normally returned."""
-
-                # Each pattern in patterns can be a partial or full FMRI, so
-                # extract the individual components for use in filtering.
-                newest = False
-                illegals = []
-                pat_tuples = {}
-                latest_pats = set()
-                seen = set()
-                npatterns = set()
-                for pat, error, pfmri, matcher in self.__parse_fmri_patterns(
-                    patterns):
-                        if error:
-                                illegals.append(error)
-                                continue
-
-                        # Duplicate patterns are ignored.
-                        sfmri = str(pfmri)
-                        if sfmri in seen:
-                                # A different form of the same pattern
-                                # was specified already; ignore this
-                                # one (e.g. pkg:/network/ping,
-                                # /network/ping).
-                                continue
-
-                        # Track used patterns.
-                        seen.add(sfmri)
-                        npatterns.add(pat)
-
-                        if getattr(pfmri.version, "match_latest", None):
-                                latest_pats.add(pat)
-                        pat_tuples[pat] = (pfmri.tuple(), matcher)
-
-                patterns = npatterns
-                del npatterns, seen
-
-                if illegals:
-                        raise api_errors.PackageMatchErrors(illegal=illegals)
-
-                # Keep track of listed stems for all other packages on a
-                # per-publisher basis.
-                nlist = collections.defaultdict(int)
-
-                # Track matching patterns.
-                matched_pats = set()
-                pkg_matching_pats = None
-
-                # Need dependency and summary actions.
-                cat_info = frozenset([self.DEPENDENCY, self.SUMMARY])
-
-                for t, entry, actions in self.entry_actions(cat_info,
-                    ordered=True, pubs=pubs):
-                        pub, stem, ver = t
-
-                        omit_ver = False
-                        omit_package = None
-
-                        pkg_stem = "!".join((pub, stem))
-                        if newest and pkg_stem in nlist:
-                                # A newer version has already been listed, so
-                                # any additional entries need to be marked for
-                                # omission before continuing.
-                                omit_package = True
-                        else:
-                                nlist[pkg_stem] += 1
-
-                        if matched is not None or unmatched is not None:
-                                pkg_matching_pats = set()
-                        if not omit_package:
-                                ever = None
-                                for pat in patterns:
-                                        (pat_pub, pat_stem, pat_ver), matcher = \
-                                            pat_tuples[pat]
-
-                                        if pat_pub is not None and \
-                                            pub != pat_pub:
-                                                # Publisher doesn't match.
-                                                if omit_package is None:
-                                                        omit_package = True
-                                                continue
-
-                                        if matcher == fmri.exact_name_match:
-                                                if pat_stem != stem:
-                                                        # Stem doesn't match.
-                                                        if omit_package is None:
-                                                                omit_package = \
-                                                                    True
-                                                        continue
-                                        elif matcher == fmri.fmri_match:
-                                                if not ("/" + stem).endswith(
-                                                    "/" + pat_stem):
-                                                        # Stem doesn't match.
-                                                        if omit_package is None:
-                                                                omit_package = \
-                                                                    True
-                                                        continue
-                                        elif matcher == fmri.glob_match:
-                                                if not fnmatch.fnmatchcase(stem,
-                                                    pat_stem):
-                                                        # Stem doesn't match.
-                                                        if omit_package is None:
-                                                                omit_package = \
-                                                                    True
-                                                        continue
-
-                                        if pat_ver is not None:
-                                                if ever is None:
-                                                        # Avoid constructing a
-                                                        # version object more
-                                                        # than once for each
-                                                        # entry.
-                                                        ever = pkg.version.Version(ver)
-                                                if not ever.is_successor(pat_ver,
-                                                    pkg.version.CONSTRAINT_AUTO):
-                                                        if omit_package is None:
-                                                                omit_package = \
-                                                                    True
-                                                        omit_ver = True
-                                                        continue
-
-                                        if pat in latest_pats and \
-                                            nlist[pkg_stem] > 1:
-                                                # Package allowed by pattern,
-                                                # but isn't the "latest"
-                                                # version.
-                                                if omit_package is None:
-                                                        omit_package = True
-                                                omit_ver = True
-                                                continue
-
-                                        # If this entry matched at least one
-                                        # pattern, then ensure it is returned.
-                                        omit_package = False
-                                        if (matched is None and
-                                            unmatched is None):
-                                                # It's faster to stop as soon
-                                                # as a match is found.
-                                                break
-
-                                        # If caller has requested other match
-                                        # cases be returned, then all patterns
-                                        # must be tested for every entry.  This
-                                        # is slower, so only done if necessary.
-                                        pkg_matching_pats.add(pat)
-
-                        if omit_package:
-                                # Package didn't match critera; skip it.
-                                continue
-
-                        # Collect attribute data if requested.
-                        summ = None
-
-                        omit_var = False
-                        states = set()
-                        if collect_attrs:
-                                # use OrderedDict to get a deterministic output
-                                attrs = collections.defaultdict(
-                                    lambda: OrderedDict([]))
-                        else:
-                                attrs = EmptyDict
-
-                        try:
-                                for a in actions:
-                                        if a.name != "set":
-                                                continue
-
-                                        atname = a.attrs["name"]
-                                        atvalue = a.attrs["value"]
-                                        if collect_attrs:
-                                                atvlist = a.attrlist("value")
-                                                # mods = frozenset(
-                                                #   (k1, frozenset([k1_1, k1_2]))
-                                                #   (k2, frozenset([k2_1, k2_2]))
-                                                # )
-                                                # will later be converted by the
-                                                # caller into a dict like:
-                                                # {
-                                                #    k1: frozenset([k1_1, k1_2]),
-                                                #    k2: frozenset([k2_1, k2_2])
-                                                # }
-                                                mods = frozenset(
-                                                    (k, frozenset(a.attrlist(k)))
-                                                    for k in six.iterkeys(a.attrs)
-                                                    if k not in ("name", "value")
-                                                )
-                                                if mods not in attrs[atname]:
-                                                        attrs[atname][mods] = atvlist
-                                                else:
-                                                        attrs[atname][mods].extend(
-                                                            atvlist)
-
-                                        if atname == "pkg.summary":
-                                                summ = atvalue
-                                                continue
-
-                                        if atname == "description":
-                                                if summ is not None:
-                                                        continue
-
-                                                # Historical summary field.
-                                                summ = atvalue
-                                                if collect_attrs:
-                                                        if mods not in \
-                                                            attrs["pkg.summary"]:
-                                                                attrs["pkg.summary"]\
-                                                                    [mods] = atvlist
-                                                        else:
-                                                                attrs["pkg.summary"]\
-                                                                    [mods].extend(
-                                                                        atvlist)
-                                                continue
-
-                                        if atname == "pkg.renamed":
-                                                if atvalue == "true":
-                                                        states.add(
-                                                            pkgdefs.PKG_STATE_RENAMED)
-                                                continue
-                                        if atname == "pkg.obsolete":
-                                                if atvalue == "true":
-                                                        states.add(
-                                                            pkgdefs.PKG_STATE_OBSOLETE)
-                                                continue
-                                        if atname == "pkg.legacy":
-                                                if atvalue == "true":
-                                                        states.add(
-                                                            pkgdefs.PKG_STATE_LEGACY)
-                        except api_errors.InvalidPackageErrors:
-                                # Ignore errors for packages that have invalid
-                                # or unsupported metadata.
-                                states.add(pkgdefs.PKG_STATE_UNSUPPORTED)
-
-                        if omit_package:
-                                # Package didn't match criteria; skip it.
-                                if omit_ver and nlist[pkg_stem] == 1:
-                                        del nlist[pkg_stem]
-                                continue
-
-                        if matched is not None or unmatched is not None:
-                                # Only after all other filtering has been
-                                # applied are the patterns that the package
-                                # matched considered "matching".
-                                matched_pats.update(pkg_matching_pats)
-
-                        # Return the requested package data.
-                        if return_fmris:
-                                pfmri = fmri.PkgFmri(name=stem, publisher=pub,
-                                    version=ver)
-                                yield (pfmri, states, attrs)
-                        else:
-                                yield (t, states, attrs)
-
-                if matched is not None:
-                        # Caller has requested that matched patterns be
-                        # returned.
-                        matched.update(matched_pats)
-                if unmatched is not None:
-                        # Caller has requested that unmatched patterns be
-                        # returned.
-                        unmatched.update(set(pat_tuples.keys()) - matched_pats)
-
-        def get_matching_fmris(self, patterns):
-                """Given a user-specified list of FMRI pattern strings, return
-                a tuple of ('matching', 'references', 'unmatched'), where
-                matching is a dict of matching fmris, references is a dict of
-                the patterns indexed by matching FMRI, and unmatched is a set of
-                the patterns that did not match any FMRIs respectively:
-
-                {
-                 pkgname: [fmri1, fmri2, ...],
-                 pkgname: [fmri1, fmri2, ...],
-                 ...
-                }
-
-                {
-                 fmri1: [pat1, pat2, ...],
-                 fmri2: [pat1, pat2, ...],
-                 ...
-                }
-
-                set(['unmatched1', 'unmatchedN'])
-
-                'patterns' is the list of package patterns to match.
-
-                Constraint used is always AUTO as per expected UI behavior when
-                determining successor versions.
-
-                Note that patterns starting w/ pkg:/ require an exact match;
-                patterns containing '*' will using fnmatch rules; the default
-                trailing match rules are used for remaining patterns.
-
-                Exactly duplicated patterns are ignored.
-
-                Routine raises PackageMatchErrors if errors occur: it is
-                illegal to specify multiple different patterns that match the
-                same package name.  Only patterns that contain wildcards are
-                allowed to match multiple packages.
-                """
-
-                # problems we check for
-                illegals = []
-                unmatched = set()
-                multimatch = []
-                multispec = []
-                pat_data = []
-                wildcard_patterns = set()
-
-                # Each pattern in patterns can be a partial or full FMRI, so
-                # extract the individual components for use in filtering.
-                latest_pats = set()
-                seen = set()
-                npatterns = set()
-                for pat, error, pfmri, matcher in self.__parse_fmri_patterns(
-                    patterns):
-                        if error:
-                                illegals.append(error)
-                                continue
-
-                        # Duplicate patterns are ignored.
-                        sfmri = str(pfmri)
-                        if sfmri in seen:
-                                # A different form of the same pattern
-                                # was specified already; ignore this
-                                # one (e.g. pkg:/network/ping,
-                                # /network/ping).
-                                continue
-
-                        # Track used patterns.
-                        seen.add(sfmri)
-                        npatterns.add(pat)
-                        if "*" in pfmri.pkg_name or "?" in pfmri.pkg_name:
-                                wildcard_patterns.add(pat)
-
-                        if getattr(pfmri.version, "match_latest", None):
-                                latest_pats.add(pat)
-                        pat_data.append((pat, matcher, pfmri))
-
-                patterns = npatterns
-                del npatterns, seen
-
-                if illegals:
-                        raise api_errors.PackageMatchErrors(illegal=illegals)
-
-                # Create a dictionary of patterns, with each value being a
-                # dictionary of pkg names & fmris that match that pattern.
-                ret = dict(zip(patterns, [dict() for i in patterns]))
-
-                for name in self.names():
-                        for pat, matcher, pfmri in pat_data:
-                                pub = pfmri.publisher
-                                version = pfmri.version
-                                if not matcher(name, pfmri.pkg_name):
-                                        continue # name doesn't match
-                                for ver, entries in \
-                                    self.entries_by_version(name):
-                                        if version and not ver.is_successor(
-                                            version,
-                                            pkg.version.CONSTRAINT_AUTO):
-                                                continue # version doesn't match
-                                        for f, metadata in entries:
-                                                fpub = f.publisher
-                                                if pub and pub != fpub:
-                                                        # specified pubs
-                                                        # conflict
-                                                        continue
-                                                ret[pat].setdefault(f.pkg_name,
-                                                    []).append(f)
-
-                # Discard all but the newest version of each match.
-                if latest_pats:
-                        # Rebuild ret based on latest version of every package.
-                        latest = {}
-                        nret = {}
-                        for p in patterns:
-                                if p not in latest_pats or not ret[p]:
-                                        nret[p] = ret[p]
-                                        continue
-
-                                nret[p] = {}
-                                for pkg_name in ret[p]:
-                                        nret[p].setdefault(pkg_name, [])
-                                        for f in ret[p][pkg_name]:
-                                                nver = latest.get(f.pkg_name,
-                                                    None)
-                                                if nver > f.version:
-                                                        # Not the newest.
-                                                        continue
-                                                if nver == f.version:
-                                                        # Allow for multiple
-                                                        # FMRIs of the same
-                                                        # latest version.
-                                                        nret[p][pkg_name].append(
-                                                            f)
-                                                        continue
-
-                                                latest[f.pkg_name] = f.version
-                                                nret[p][pkg_name] = [f]
-
-                        # Assign new version of ret and discard latest list.
-                        ret = nret
-                        del latest
-
-                # Determine match failures.
-                matchdict = {}
-                for p in patterns:
-                        l = len(ret[p])
-                        if l == 0: # no matches at all
-                                unmatched.add(p)
-                        elif l > 1 and p not in wildcard_patterns:
-                                # multiple matches
-                                multimatch.append((p, [
-                                    ret[p][n][0].get_pkg_stem()
-                                    for n in ret[p]
-                                ]))
-                        else:
-                                # single match or wildcard
-                                for k in ret[p].keys():
-                                        # for each matching package name
-                                        matchdict.setdefault(k, []).append(p)
-
-                if multimatch:
-                        raise api_errors.PackageMatchErrors(
-                            multiple_matches=multimatch)
-
-                # Group the matching patterns by package name and allow multiple
-                # fmri matches.
-                proposed_dict = {}
-                for d in ret.values():
-                        for k, l in six.iteritems(d):
-                                proposed_dict.setdefault(k, []).extend(l)
-
-                # construct references so that we can know which pattern
-                # generated which fmris...
-                references = dict([
-                    (f, p)
-                    for p in ret.keys()
-                    for flist in ret[p].values()
-                    for f in flist
-                ])
-
-                return proposed_dict, references, unmatched
-
-        def get_package_counts_by_pub(self, pubs=EmptyI):
-                """Returns a generator of tuples of the form (pub,
-                package_count, package_version_count).  'pub' is the publisher
-                prefix, 'package_count' is the number of unique packages for the
-                publisher, and 'package_version_count' is the number of unique
-                package versions for the publisher.
-                """
-
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        # Catalog contains nothing.
-
-                        # This construction is necessary to get python to
-                        # return no results properly to callers expecting
-                        # a generator function.
-                        return iter(())
-                return base.get_package_counts_by_pub(pubs=pubs)
-
-        def get_part(self, name, must_exist=False):
-                """Returns the CatalogPart object for the named catalog part.
-
-                'must_exist' is an optional boolean value that indicates that
-                the catalog part must already exist in-memory or on-disk, if
-                not a value of None will be returned."""
-
-                # First, check if the part has already been cached, and if so,
-                # return it.
-                part = self.__parts.get(name, None)
-                if part is not None:
-                        return part
-                elif not self.meta_root and must_exist:
-                        return
-
-                # If the caller said the part must_exist, then it must already
-                # be part of the catalog attributes to be valid.
-                aparts = self._attrs.parts
-                if must_exist and name not in aparts:
-                        return
-
-                # Next, since the part hasn't been cached, create an object
-                # for it and add it to catalog attributes.
-                part = CatalogPart(name, meta_root=self.meta_root,
-                    ordered=not self.__batch_mode, sign=self.__sign)
-                if must_exist and self.meta_root and not part.exists:
-                        # This is a double-check for the client case where
-                        # there is a part that is known to the catalog but
-                        # that the client has purposefully not retrieved.
-                        # (Think locale specific data.)
-                        return
-
-                self.__parts[name] = part
-
-                if name not in aparts:
-                        # Add a new entry to the catalog attributes for this new
-                        # part since it didn't exist previously.
-                        aparts[name] = {
-                            "last-modified": part.last_modified
-                        }
-                return part
-
-        def get_updates_needed(self, path):
-                """Returns a list of the catalog files needed to update
-                the existing catalog parts, based on the contents of the
-                catalog.attrs file in the directory indicated by 'path'.
-                A value of None will be returned if the catalog has
-                not been modified, while an empty list will be returned
-                if no catalog parts need to be updated, but the catalog
-                itself has changed."""
-
-                new_attrs = CatalogAttrs(meta_root=path)
-                if not new_attrs.exists:
-                        # No updates needed (not even to attrs), so return None.
-                        return None
-
-                old_attrs = self._attrs
-                if old_attrs.created != new_attrs.created:
-                        # It's very likely that the catalog has been recreated
-                        # or this is a completely different catalog than was
-                        # expected.  In either case, an update isn't possible.
-                        raise api_errors.BadCatalogUpdateIdentity(path)
-
-                if new_attrs.last_modified == old_attrs.last_modified:
-                        # No updates needed (not even to attrs), so return None.
-                        return None
-
-                # First, verify that all of the catalog parts the client has
-                # still exist.  If they no longer exist, the catalog is no
-                # longer valid and cannot be updated.
-                parts = {}
-                incremental = True
-                for name in old_attrs.parts:
-                        if name not in new_attrs.parts:
-                                raise api_errors.BadCatalogUpdateIdentity(path)
-
-                        old_lm = old_attrs.parts[name]["last-modified"]
-                        new_lm = new_attrs.parts[name]["last-modified"]
-
-                        if new_lm == old_lm:
-                                # Part hasn't changed.
-                                continue
-                        elif new_lm < old_lm:
-                                raise api_errors.ObsoleteCatalogUpdate(path)
-
-                        # The last component of the update name is the locale.
-                        locale = name.split(".", 2)[2]
-
-                        # Now check to see if an update log is still offered for
-                        # the last time this catalog part was updated.  If it
-                        # does not, then an incremental update cannot be safely
-                        # performed since updates may be missing.
-                        logdate = datetime_to_update_ts(old_lm)
-                        logname = "update.{0}.{1}".format(logdate, locale)
-
-                        if logname not in new_attrs.updates:
-                                incremental = False
-
-                        parts.setdefault(locale, set())
-                        parts[locale].add(name)
-
-                # XXX in future, add current locale to this.  For now, just
-                # ensure that all of the locales of parts that were changed
-                # and exist on-disk are included.
-                locales = set(("C",))
-                locales.update(set(parts.keys()))
-
-                # Now determine if there are any new parts for this locale that
-                # this version of the API knows how to use that the client
-                # doesn't already have.
-                for name in new_attrs.parts:
-                        if name in parts or name in old_attrs.parts:
-                                continue
-
-                        # The last component of the name is the locale.
-                        locale = name.split(".", 2)[2]
-                        if locale not in locales:
-                                continue
-
-                        # Currently, only these parts are used by the client,
-                        # so only they need to be retrieved.
-                        if name == self.__BASE_PART or \
-                            name == self.__DEPS_PART or \
-                            name.startswith(self.__SUMM_PART_PFX):
-                                incremental = False
-
-                                # If a new part has been added for the current
-                                # locale, then incremental updates can't be
-                                # performed since updates for this locale can
-                                # only be applied to parts that already exist.
-                                parts.setdefault(locale, set())
-                                parts[locale].add(name)
-
-                if not parts:
-                        # No updates needed to catalog parts on-disk, but
-                        # catalog has changed.
-                        return []
-                elif not incremental:
-                        # Since an incremental update cannot be performed,
-                        # just return the updated parts for retrieval.
-                        updates = set()
-                        for locale in parts:
-                                updates.update(parts[locale])
-                        return updates
-
-                # Finally, determine the update logs needed based on the catalog
-                # parts that need updating on a per-locale basis.
-                updates = set()
-                for locale in parts:
-                        # Determine the newest catalog part for a given locale,
-                        # this will be used to determine which update logs are
-                        # needed for an incremental update.
-                        last_lm = None
-                        for name in parts[locale]:
-                                if name not in old_attrs.parts:
-                                        continue
-
-                                lm = old_attrs.parts[name]["last-modified"]
-                                if not last_lm or lm > last_lm:
-                                        last_lm = lm
-
-                        for name, uattrs in six.iteritems(new_attrs.updates):
-                                up_lm = uattrs["last-modified"]
-
-                                # The last component of the update name is the
-                                # locale.
-                                up_locale = name.split(".", 2)[2]
-
-                                if not up_locale == locale:
-                                        # This update log doesn't apply to the
-                                        # locale being evaluated for updates.
-                                        continue
-
-                                if up_lm <= last_lm:
-                                        # Older or same as newest catalog part
-                                        # for this locale; so skip.
-                                        continue
-
-                                # If this updatelog was changed after the
-                                # newest catalog part for this locale, then
-                                # it is needed to update one or more catalog
-                                # parts for this locale.
-                                updates.add(name)
-
-                # Ensure updates are in chronological ascending order.
-                return sorted(updates)
-
-        def names(self, pubs=EmptyI):
-                """Returns a set containing the names of all the packages in
-                the Catalog.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        # Catalog contains nothing.
-                        return set()
-                return base.names(pubs=pubs)
-
-        @property
-        def package_count(self):
-                """The number of unique packages in the catalog."""
-                return self._attrs.package_count
-
-        @property
-        def package_version_count(self):
-                """The number of unique package versions in the catalog."""
-                return self._attrs.package_version_count
-
-        @property
-        def parts(self):
-                """A dict containing the list of CatalogParts that the catalog
-                is composed of along with information about each part."""
-
-                return self._attrs.parts
-
-        def pkg_names(self, pubs=EmptyI):
-                """A generator function that produces package tuples of the form
-                (pub, stem) as it iterates over the contents of the catalog.
-
-                'pubs' is an optional list that contains the prefixes of the
-                publishers to restrict the results to."""
-
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        # Catalog contains nothing.
-
-                        # This construction is necessary to get python to
-                        # return no results properly to callers expecting
-                        # a generator function.
-                        return iter(())
-                return base.pkg_names(pubs=pubs)
-
-        def publishers(self):
-                """Returns a set containing the prefixes of all the publishers
-                in the Catalog."""
-
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        # Catalog contains nothing.
-                        return set()
-                return set(p for p in base.publishers())
-
-        def remove_package(self, pfmri):
-                """Remove a package and its metadata."""
-
-                assert not self.read_only
-
-                self.__lock_catalog()
-                try:
-                        # The package has to be removed from every known part.
-                        entries = {}
-
-                        # Use the same operation time and date for all
-                        # operations so that the last modification times
-                        # of all catalog parts and update logs will be
-                        # synchronized.
-                        op_time = datetime.datetime.utcnow()
-
-                        for name in self._attrs.parts:
-                                part = self.get_part(name)
-                                if part is None:
-                                        continue
-
-                                pkg_entry = part.get_entry(pfmri)
-                                if pkg_entry is None:
-                                        if name == self.__BASE_PART:
-                                                # Entry should exist in at least
-                                                # the base part.
-                                                raise api_errors.UnknownCatalogEntry(
-                                                    pfmri.get_fmri())
-                                        # Skip; package's presence is optional
-                                        # in other parts.
-                                        continue
-
-                                part.remove(pfmri, op_time=op_time)
-                                if self.log_updates:
-                                        entries[part.name] = pkg_entry
-
-                        self.__log_update(pfmri, CatalogUpdate.REMOVE, op_time,
-                            entries=entries)
-                finally:
-                        self.__unlock_catalog()
-
-        def save(self, fmt='utf8'):
-                """Finalize current state and save to file if possible."""
-
-                self.__lock_catalog()
-                try:
-                        self.__save(fmt)
-                finally:
-                        self.__unlock_catalog()
-
-        @property
-        def signatures(self):
-                """Returns a dict of the files the catalog is composed of along
-                with the last known signatures of each if they are available."""
-
-                attrs = self._attrs
-                sigs = {
-                    attrs.name: attrs.signatures
-                }
-
-                for items in (attrs.parts, attrs.updates):
-                        for name in items:
-                                entry = sigs[name] = {}
-                                for k in items[name]:
-                                        try:
-                                                sig = k.split("signature-")[1]
-                                                entry[sig] = items[name][k]
-                                        except IndexError:
-                                                # Not a signature entry.
-                                                continue
-                return sigs
-
-        def tuples(self, last=False, ordered=False, pubs=EmptyI):
-                """A generator function that produces FMRI tuples as it
-                iterates over the contents of the catalog.
-
-                'last' is a boolean value that indicates only the last FMRI
-                tuple for each package on a per-publisher basis should be
-                returned.  As long as the catalog has been saved since the
-                last modifying operation, or finalize() has has been called,
-                this will also be the newest version of the package.
-
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        # Catalog contains nothing.
-
-                        # This construction is necessary to get python to
-                        # return no results properly to callers expecting
-                        # a generator function.
-                        return iter(())
-                return base.tuples(last=last, ordered=ordered, pubs=pubs)
-
-        def tuple_entries(self, info_needed=EmptyI, last=False, locales=None,
-            ordered=False, pubs=EmptyI):
-                """A generator function that produces tuples of the format
-                ((pub, stem, version), entry, actions) as it iterates over
-                the contents of the catalog (where 'metadata' is a dict
-                containing the requested information).
-
-                'metadata' always contains the following information at a
-                 minimum:
-
-                        BASE
-                                'metadata' will be populated with Manifest
-                                signature data, if available, using key-value
-                                pairs of the form 'signature-<name>': value.
-
-                'info_needed' is an optional list of one or more catalog
-                constants indicating the types of catalog data that will
-                be returned in 'metadata' in addition to the above:
-
-                        DEPENDENCY
-                                'metadata' will contain depend and set Actions
-                                for package obsoletion, renaming, variants,
-                                and facets stored in a list under the
-                                key 'actions'.
-
-                        SUMMARY
-                                'metadata' will contain any remaining Actions
-                                not listed above, such as pkg.summary,
-                                pkg.description, etc. in a list under the key
-                                'actions'.
-
-                'last' is a boolean value that indicates only the last entry
-                for each package on a per-publisher basis should be returned.
-                As long as the catalog has been saved since the last modifying
-                operation, or finalize() has has been called, this will also be
-                the newest version of the package.
-
-                'locales' is an optional set of locale names for which Actions
-                should be returned.  The default is set(('C',)) if not provided.
-                Note that unlike actions(), catalog entries will not lazy-load
-                action data if it is missing from the catalog.
-
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to."""
-
-                return self.__entries(info_needed=info_needed,
-                    locales=locales, last_version=last, ordered=ordered,
-                    pubs=pubs, tuples=True)
-
-        @property
-        def updates(self):
-                """A dict containing the list of known updates for the catalog
-                along with information about each update."""
-
-                return self._attrs.updates
-
-        def update_entry(self, metadata, pfmri=None, pub=None, stem=None,
-            ver=None):
-                """Updates the metadata stored in a package's BASE catalog
-                record for the specified package.  Cannot be used when read_only
-                or log_updates is enabled; should never be used with a Catalog
-                intended for incremental update usage.
-
-                'metadata' must be a dict of additional metadata to store with
-                the package's BASE record.
-
-                'pfmri' is the FMRI of the package to update the entry for.
-
-                'pub' is the publisher of the package.
-
-                'stem' is the stem of the package.
-
-                'ver' is the version string of the package.
-
-                'pfmri' or 'pub', 'stem', and 'ver' must be provided.
-                """
-
-                assert pfmri or (pub and stem and ver)
-                assert not self.log_updates and not self.read_only
-
-                base = self.get_part(self.__BASE_PART, must_exist=True)
-                if base is None:
-                        if not pfmri:
-                                pfmri = fmri.PkgFmri(name=stem, publisher=pub,
-                                    version=ver)
-                        raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
-
-                # get_entry returns the actual catalog entry, so updating it
-                # simply requires reassignment.
-                entry = base.get_entry(pfmri=pfmri, pub=pub, stem=stem, ver=ver)
-                if entry is None:
-                        if not pfmri:
-                                pfmri = fmri.PkgFmri(name=stem, publisher=pub,
-                                    version=ver)
-                        raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
-                if metadata is None:
-                        if "metadata" in entry:
-                                del entry["metadata"]
-                        return
+        if bad_modes:
+            raise api_errors.BadCatalogPermissions(bad_modes)
+
+    def __set_sign(self, value):
+        self.__sign = value
+
+        # If the Catalog's sign property changes, the value of that
+        # property for its attributes, etc. must be changed too.
+        if self._attrs:
+            self._attrs.sign = value
+
+        for part in self.__parts.values():
+            part.sign = value
+
+        for ulog in self.__updates.values():
+            ulog.sign = value
+
+    def __set_version(self, value):
+        self._attrs.version = value
+
+    def __unlock_catalog(self):
+        """Unlocks the catalog allowing other catalog consumers to
+        modify it."""
+
+        # XXX need filesystem unlock too?
+        self.__lock.release()
+
+    def actions(
+        self,
+        info_needed,
+        excludes=EmptyI,
+        cb=None,
+        last=False,
+        locales=None,
+        ordered=False,
+        pubs=EmptyI,
+    ):
+        """A generator function that produces tuples of the format
+        (fmri, actions) as it iterates over the contents of the
+        catalog (where 'actions' is a generator that returns the
+        Actions corresponding to the requested information).
+
+        If the catalog doesn't contain any action data for the package
+        entry, and manifest_cb was defined at Catalog creation time,
+        the action data will be lazy-loaded by the actions generator;
+        otherwise it will return an empty iterator.  This means that
+        the manifest_cb will be executed even for packages that don't
+        actually have any actions corresponding to info_needed.  For
+        example, if a package doesn't have any dependencies, the
+        manifest_cb will still be executed.  This was considered a
+        reasonable compromise as packages are generally expected to
+        have DEPENDENCY and SUMMARY information.
+
+        'excludes' is a list of variants which will be used to determine
+        what should be allowed by the actions generator in addition to
+        what is specified by 'info_needed'.
+
+        'cb' is an optional callback function that will be executed for
+        each package before its action data is retrieved. It must accept
+        two arguments: 'pkg' and 'entry'.  'pkg' is an FMRI object and
+        'entry' is the dictionary structure of the catalog entry for the
+        package.  If the callback returns False, then the entry will not
+        be included in the results.  This can significantly improve
+        performance by avoiding action data retrieval for results that
+        will not be used.
+
+        'info_needed' is a set of one or more catalog constants
+        indicating the types of catalog data that will be returned
+        in 'actions' in addition to the above:
+
+                DEPENDENCY
+                        Depend and set Actions for package obsoletion,
+                        renaming, variants.
+
+                SUMMARY
+                        Any remaining set Actions not listed above, such
+                        as pkg.summary, pkg.description, etc.
+
+        'last' is a boolean value that indicates only the last entry
+        for each package on a per-publisher basis should be returned.
+        As long as the catalog has been saved since the last modifying
+        operation, or finalize() has has been called, this will also be
+        the newest version of the package.
+
+        'locales' is an optional set of locale names for which Actions
+        should be returned.  The default is set(('C',)) if not provided.
+
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
+
+        'pfmri' is an optional FMRI to limit the returned results to.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        return self.__actions(
+            info_needed,
+            excludes=excludes,
+            cb=cb,
+            last_version=last,
+            locales=locales,
+            ordered=ordered,
+            pubs=pubs,
+        )
+
+    def add_package(self, pfmri, manifest=None, metadata=None):
+        """Add a package and its related metadata to the catalog and
+        its parts as needed.
+
+        'manifest' is an optional Manifest object that will be used
+        to retrieve the metadata related to the package.
+
+        'metadata' is an optional dict of additional metadata to store
+        with the package's BASE record."""
+
+        assert not self.read_only
+
+        def group_actions(actions):
+            dep_acts = {"C": []}
+            # Summary actions are grouped by locale, since each
+            # goes to a locale-specific catalog part.
+            sum_acts = {"C": []}
+            for act in actions:
+                if act.name == "depend":
+                    dep_acts["C"].append(str(act))
+                    continue
+
+                name = act.attrs["name"]
+                if (
+                    name.startswith("variant")
+                    or name.startswith("facet")
+                    or name.startswith("pkg.depend.")
+                    or name in ("pkg.obsolete", "pkg.renamed", "pkg.legacy")
+                ):
+                    # variant and facet data goes to the
+                    # dependency catalog part.
+                    dep_acts["C"].append(str(act))
+                    continue
+                elif name in ("fmri", "pkg.fmri"):
+                    # Redundant in the case of the catalog.
+                    continue
+
+                if name in ("fmri", "pkg.fmri", "publisher") or name.startswith(
+                    ("info.source-url", "pkg.debug", "pkg.linted")
+                ):
+                    continue
+
+                # All other set actions go to the summary
+                # catalog parts, grouped by locale.  To
+                # determine the locale, the set attribute's
+                # name is split by ':' into its field and
+                # locale components.  If ':' is not present,
+                # then the 'C' locale is assumed.
+                comps = name.split(":")
+                if len(comps) > 1:
+                    locale = comps[1]
+                else:
+                    locale = "C"
+                if locale not in sum_acts:
+                    sum_acts[locale] = []
+                sum_acts[locale].append(str(act))
+
+            return {
+                "dependency": dep_acts,
+                "summary": sum_acts,
+            }
+
+        self.__lock_catalog()
+        try:
+            entries = {}
+            # Use the same operation time and date for all
+            # operations so that the last modification times
+            # of all catalog parts and update logs will be
+            # synchronized.
+            op_time = datetime.datetime.utcnow()
+
+            # Always add packages to the base catalog.
+            entry = {}
+            if metadata:
                 entry["metadata"] = metadata
+            if manifest:
+                for k, v in six.iteritems(manifest.signatures):
+                    entry["signature-{0}".format(k)] = v
+            part = self.get_part(self.__BASE_PART)
+            entries[part.name] = part.add(
+                pfmri, metadata=entry, op_time=op_time
+            )
 
-                op_time = datetime.datetime.utcnow()
-                attrs = self._attrs
-                attrs.last_modified = op_time
-                attrs.parts[base.name] = {
-                    "last-modified": op_time
-                }
-                base.last_modified = op_time
+            if manifest:
+                # Without a manifest, only the base catalog data
+                # can be populated.
 
-        def validate(self, require_signatures=False):
-                """Verifies whether the signatures for the contents of the
-                catalog match the current signature data.  Raises the
-                exception named 'BadCatalogSignatures' on failure."""
+                # Only dependency and set actions are currently
+                # used by the remaining catalog parts.
+                actions = []
+                for atype in "depend", "set":
+                    actions += manifest.gen_actions_by_type(atype)
 
-                self._attrs.validate(require_signatures=require_signatures)
+                gacts = group_actions(actions)
+                for ctype in gacts:
+                    for locale in gacts[ctype]:
+                        acts = gacts[ctype][locale]
+                        if not acts:
+                            # Catalog entries only
+                            # added if actions are
+                            # present for this
+                            # ctype.
+                            continue
 
-                def get_sigs(mdata):
-                        sigs = {}
-                        for key in mdata:
-                                if not key.startswith("signature-"):
-                                        continue
-                                sig = key.split("signature-")[1]
-                                sigs[sig] = mdata[key]
-                        if not sigs:
-                                # Allow validate() to perform its own fallback
-                                # logic if signature data isn't available.
-                                return None
-                        return sigs
+                        part = self.get_part(
+                            "catalog" ".{0}.{1}".format(ctype, locale)
+                        )
+                        entry = {"actions": acts}
+                        entries[part.name] = part.add(
+                            pfmri, metadata=entry, op_time=op_time
+                        )
 
-                for name, mdata in six.iteritems(self._attrs.parts):
-                        part = self.get_part(name, must_exist=True)
-                        if part is None:
-                                # Part does not exist; no validation needed.
-                                continue
-                        part.validate(signatures=get_sigs(mdata),
-                            require_signatures=require_signatures)
+            self.__log_update(
+                pfmri, CatalogUpdate.ADD, op_time, entries=entries
+            )
+        finally:
+            self.__unlock_catalog()
 
-                for name, mdata in six.iteritems(self._attrs.updates):
-                        ulog = self.__get_update(name, cache=False,
-                            must_exist=True)
-                        if ulog is None:
-                                # Update does not exist; no validation needed.
-                                continue
-                        ulog.validate(signatures=get_sigs(mdata),
-                            require_signatures=require_signatures)
+    def append(self, src, cb=None, pfmri=None, pubs=EmptyI):
+        """Appends the entries in the specified 'src' catalog to that
+        of the current catalog.  The caller is responsible for ensuring
+        that no duplicates exist and must call finalize() afterwards to
+        to ensure consistent catalog state.  This function cannot be
+        used when log_updates or read_only is enabled.
 
-        batch_mode = property(__get_batch_mode, __set_batch_mode)
-        last_modified = property(__get_last_modified, __set_last_modified,
-            doc="A UTC datetime object indicating the last time the catalog "
-            "was modified.")
-        meta_root = property(__get_meta_root, __set_meta_root)
-        sign = property(__get_sign, __set_sign)
-        version = property(__get_version, __set_version)
+        'cb' is an optional callback function that must accept src,
+        an FMRI, and entry.  Where 'src' is the source catalog the
+        FMRI's entry is being copied from, and entry is the source
+        catalog entry.  It must return a tuple of the form (append,
+        metadata), where 'append' is a boolean value indicating if
+        the specified package should be appended, and 'metadata' is
+        a dict of additional metadata to store with the package's
+        BASE record.
+
+        'pfmri' is an optional FMRI of a package to append.  If not
+        provided, all FMRIs in the 'src' catalog will be appended.
+        This filtering is applied before any provided callback.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the append operation to.  FRMIs that have a publisher not in
+        the list will be skipped.  This filtering is applied before
+        any provided callback.  If not provided, no publisher
+        filtering will be applied."""
+
+        assert not self.log_updates and not self.read_only
+
+        self.__lock_catalog()
+        try:
+            # Append operations are much slower if batch mode is
+            # not enabled.  This ensures that the current state
+            # is stored and then reset on completion or failure.
+            # Since append() is never used as part of the
+            # publication process (log_updates == True),
+            # this is safe.
+            old_batch_mode = self.batch_mode
+            self.batch_mode = True
+            self.__append(src, cb=cb, pfmri=pfmri, pubs=pubs)
+        finally:
+            self.batch_mode = old_batch_mode
+            self.__unlock_catalog()
+
+    def apply_updates(self, path):
+        """Apply any CatalogUpdates available to the catalog based on
+        the list returned by get_updates_needed.  The caller must
+        retrieve all of the resources indicated by get_updates_needed
+        and place them in the directory indicated by 'path'."""
+
+        if not self.meta_root:
+            raise api_errors.CatalogUpdateRequirements()
+
+        # Used to store the original time each part was modified
+        # as a basis for determining whether to apply specific
+        # updates.
+        old_parts = self._attrs.parts
+
+        def apply_incremental(name):
+            # Load the CatalogUpdate from the path specified.
+            # (Which is why __get_update is not used.)
+            ulog = CatalogUpdate(name, meta_root=path)
+            for pfmri, op_type, op_time, metadata in ulog.updates():
+                for pname, pdata in six.iteritems(metadata):
+                    part = self.get_part(pname, must_exist=True)
+                    if part is None:
+                        # Part doesn't exist; skip.
+                        continue
+
+                    lm = old_parts[pname]["last-modified"]
+                    if op_time <= lm:
+                        # Only add updates to the part
+                        # that occurred after the last
+                        # time it was originally
+                        # modified.
+                        continue
+
+                    if op_type == CatalogUpdate.ADD:
+                        part.add(pfmri, metadata=pdata, op_time=op_time)
+                    elif op_type == CatalogUpdate.REMOVE:
+                        part.remove(pfmri, op_time=op_time)
+                    else:
+                        raise api_errors.UnknownUpdateType(op_type)
+
+        def apply_full(name):
+            src = os.path.join(path, name)
+            dest = os.path.join(self.meta_root, name)
+            portable.copyfile(src, dest)
+
+        self.__lock_catalog()
+        try:
+            old_batch_mode = self.batch_mode
+            self.batch_mode = True
+
+            updates = self.get_updates_needed(path)
+            if updates == None:
+                # Nothing has changed, so nothing to do.
+                return
+
+            for name in updates:
+                if name.startswith("update."):
+                    # The provided update is an incremental.
+                    apply_incremental(name)
+                else:
+                    # The provided update is a full update.
+                    apply_full(name)
+
+            # Next, verify that all of the updated parts have a
+            # signature that matches the new catalog.attrs file.
+            new_attrs = CatalogAttrs(meta_root=path)
+            new_sigs = {}
+            for name, mdata in six.iteritems(new_attrs.parts):
+                new_sigs[name] = {}
+                for key in mdata:
+                    if not key.startswith("signature-"):
+                        continue
+                    sig = key.split("signature-")[1]
+                    new_sigs[name][sig] = mdata[key]
+
+            # This must be done to ensure that the catalog
+            # signature matches that of the source.
+            self.batch_mode = old_batch_mode
+            self.finalize()
+
+            for name, part in six.iteritems(self.__parts):
+                part.validate(signatures=new_sigs[name])
+
+            # Finally, save the catalog, and then copy the new
+            # catalog attributes file into place and reload it.
+            self.__save()
+            apply_full(self._attrs.name)
+
+            self._attrs = CatalogAttrs(meta_root=self.meta_root)
+            self.__set_perms()
+        finally:
+            self.batch_mode = old_batch_mode
+            self.__unlock_catalog()
+
+    def categories(self, excludes=EmptyI, pubs=EmptyI):
+        """Returns a set of tuples of the form (scheme, category)
+        containing the names of all categories in use by the last
+        version of each unique package in the catalog on a per-
+        publisher basis.
+
+        'excludes' is a list of variants which will be used to
+        determine what category actions will be checked.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        acts = self.__actions(
+            [self.SUMMARY], excludes=excludes, last_version=True, pubs=pubs
+        )
+        return set(
+            (
+                sc
+                for f, acts in acts
+                for a in acts
+                if a.has_category_info()
+                for sc in a.parse_category_info()
+            )
+        )
+
+    @property
+    def created(self):
+        """A UTC datetime object indicating the time the catalog was
+        created."""
+        return self._attrs.created
+
+    def destroy(self):
+        """Removes any on-disk files that exist for the catalog and
+        discards all content."""
+
+        for name in self._attrs.parts:
+            part = self.get_part(name)
+            part.destroy()
+
+        for name in self._attrs.updates:
+            ulog = self.__get_update(name, cache=False)
+            ulog.destroy()
+
+        self._attrs = CatalogAttrs(meta_root=self.meta_root, sign=self.__sign)
+        self.__parts = {}
+        self.__updates = {}
+        self._attrs.destroy()
+
+        if not self.meta_root or not os.path.exists(self.meta_root):
+            return
+
+        # Finally, ensure that if there are any leftover files from
+        # an interrupted destroy in the past that they are removed
+        # as well.
+        for fname in os.listdir(self.meta_root):
+            if not fname.startswith("catalog.") and not fname.startswith(
+                "update."
+            ):
+                continue
+
+            pname = os.path.join(self.meta_root, fname)
+            if not os.path.isfile(pname):
+                continue
+
+            try:
+                portable.remove(pname)
+            except EnvironmentError as e:
+                if e.errno == errno.EACCES:
+                    raise api_errors.PermissionsException(e.filename)
+                if e.errno == errno.EROFS:
+                    raise api_errors.ReadOnlyFileSystemException(e.filename)
+                raise
+
+    def entries(
+        self,
+        info_needed=EmptyI,
+        last=False,
+        locales=None,
+        ordered=False,
+        pubs=EmptyI,
+    ):
+        """A generator function that produces tuples of the format
+        (fmri, metadata) as it iterates over the contents of the
+        catalog (where 'metadata' is a dict containing the requested
+        information).
+
+        'metadata' always contains the following information at a
+         minimum:
+
+                BASE
+                        'metadata' will be populated with Manifest
+                        signature data, if available, using key-value
+                        pairs of the form 'signature-<name>': value.
+
+        'info_needed' is an optional list of one or more catalog
+        constants indicating the types of catalog data that will
+        be returned in 'metadata' in addition to the above:
+
+                DEPENDENCY
+                        'metadata' will contain depend and set Actions
+                        for package obsoletion, renaming, variants,
+                        and facets stored in a list under the
+                        key 'actions'.
+
+                SUMMARY
+                        'metadata' will contain any remaining Actions
+                        not listed above, such as pkg.summary,
+                        pkg.description, etc. in a list under the key
+                        'actions'.
+
+        'last' is a boolean value that indicates only the last entry
+        for each package on a per-publisher basis should be returned.
+        As long as the catalog has been saved since the last modifying
+        operation, or finalize() has has been called, this will also be
+        the newest version of the package.
+
+        'locales' is an optional set of locale names for which Actions
+        should be returned.  The default is set(('C',)) if not provided.
+        Note that unlike actions(), catalog entries will not lazy-load
+        action data if it is missing from the catalog.
+
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        return self.__entries(
+            info_needed=info_needed,
+            last_version=last,
+            locales=locales,
+            ordered=ordered,
+            pubs=pubs,
+        )
+
+    def entries_by_version(
+        self, name, info_needed=EmptyI, locales=None, pubs=EmptyI
+    ):
+        """A generator function that produces tuples of the format
+        (version, entries) as it iterates over the contents of the
+        the catalog, where entries is a list of tuples of the format
+        (fmri, metadata) and metadata is a dict containing the
+        requested information.
+
+        'metadata' always contains the following information at a
+         minimum:
+
+                BASE
+                        'metadata' will be populated with Manifest
+                        signature data, if available, using key-value
+                        pairs of the form 'signature-<name>': value.
+
+        'info_needed' is an optional list of one or more catalog
+        constants indicating the types of catalog data that will
+        be returned in 'metadata' in addition to the above:
+
+                DEPENDENCY
+                        'metadata' will contain depend and set Actions
+                        for package obsoletion, renaming, variants,
+                        and facets stored in a list under the
+                        key 'actions'.
+
+                SUMMARY
+                        'metadata' will contain any remaining Actions
+                        not listed above, such as pkg.summary,
+                        pkg.description, etc. in a list under the key
+                        'actions'.
+
+        'locales' is an optional set of locale names for which Actions
+        should be returned.  The default is set(('C',)) if not provided.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            # Catalog contains nothing.
+            return
+
+        if not locales:
+            locales = set(("C",))
+        else:
+            locales = set(locales)
+
+        parts = []
+        if self.DEPENDENCY in info_needed:
+            part = self.get_part(self.__DEPS_PART, must_exist=True)
+            if part is not None:
+                parts.append(part)
+
+        if self.SUMMARY in info_needed:
+            for locale in locales:
+                part = self.get_part(
+                    "{0}.{1}".format(self.__SUMM_PART_PFX, locale),
+                    must_exist=True,
+                )
+                if part is None:
+                    # Data not available for this
+                    # locale.
+                    continue
+                parts.append(part)
+
+        def merge_entry(src, dest):
+            for k, v in six.iteritems(src):
+                if k == "actions":
+                    dest.setdefault(k, [])
+                    dest[k] += v
+                elif k != "version":
+                    dest[k] = v
+
+        for ver, entries in base.entries_by_version(name, pubs=pubs):
+            nentries = []
+            for f, bentry in entries:
+                mdata = {}
+                merge_entry(bentry, mdata)
+                for part in parts:
+                    entry = part.get_entry(f)
+                    if entry is None:
+                        # Part doesn't have this FMRI,
+                        # so skip it.
+                        continue
+                    merge_entry(entry, mdata)
+                nentries.append((f, mdata))
+            yield ver, nentries
+
+    def entry_actions(
+        self,
+        info_needed,
+        excludes=EmptyI,
+        cb=None,
+        last=False,
+        locales=None,
+        ordered=False,
+        pubs=EmptyI,
+    ):
+        """A generator function that produces tuples of the format
+        ((pub, stem, version), entry, actions) as it iterates over
+        the contents of the catalog (where 'actions' is a generator
+        that returns the Actions corresponding to the requested
+        information).
+
+        If the catalog doesn't contain any action data for the package
+        entry, and manifest_cb was defined at Catalog creation time,
+        the action data will be lazy-loaded by the actions generator;
+        otherwise it will return an empty iterator.  This means that
+        the manifest_cb will be executed even for packages that don't
+        actually have any actions corresponding to info_needed.  For
+        example, if a package doesn't have any dependencies, the
+        manifest_cb will still be executed.  This was considered a
+        reasonable compromise as packages are generally expected to
+        have DEPENDENCY and SUMMARY information.
+
+        'excludes' is a list of variants which will be used to determine
+        what should be allowed by the actions generator in addition to
+        what is specified by 'info_needed'.
+
+        'cb' is an optional callback function that will be executed for
+        each package before its action data is retrieved. It must accept
+        two arguments: 'pkg' and 'entry'.  'pkg' is an FMRI object and
+        'entry' is the dictionary structure of the catalog entry for the
+        package.  If the callback returns False, then the entry will not
+        be included in the results.  This can significantly improve
+        performance by avoiding action data retrieval for results that
+        will not be used.
+
+        'info_needed' is a set of one or more catalog constants
+        indicating the types of catalog data that will be returned
+        in 'actions' in addition to the above:
+
+                DEPENDENCY
+                        Depend and set Actions for package obsoletion,
+                        renaming, variants.
+
+                SUMMARY
+                        Any remaining set Actions not listed above, such
+                        as pkg.summary, pkg.description, etc.
+
+        'last' is a boolean value that indicates only the last entry
+        for each package on a per-publisher basis should be returned.
+        As long as the catalog has been saved since the last modifying
+        operation, or finalize() has has been called, this will also be
+        the newest version of the package.
+
+        'locales' is an optional set of locale names for which Actions
+        should be returned.  The default is set(('C',)) if not provided.
+
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
+
+        'pfmri' is an optional FMRI to limit the returned results to.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        for r, entry in self.__entries(
+            cb=cb,
+            info_needed=info_needed,
+            locales=locales,
+            last_version=last,
+            ordered=ordered,
+            pubs=pubs,
+            tuples=True,
+        ):
+            try:
+                yield (
+                    r,
+                    entry,
+                    self.__gen_actions(r, entry["actions"], excludes),
+                )
+            except KeyError:
+                if self.__manifest_cb:
+                    pub, stem, ver = r
+                    f = fmri.PkgFmri(name=stem, publisher=pub, version=ver)
+                    yield (
+                        r,
+                        entry,
+                        self.__gen_lazy_actions(
+                            f, info_needed, locales, excludes
+                        ),
+                    )
+                else:
+                    yield r, entry, EmptyI
+
+    @property
+    def exists(self):
+        """A boolean value indicating whether the Catalog exists
+        on-disk."""
+
+        # If the Catalog attrs file exists on-disk,
+        # then the catalog does.
+        attrs = self._attrs
+        return attrs.exists
+
+    def finalize(self, pfmris=None, pubs=None):
+        """This function re-sorts the contents of the Catalog so that
+        version entries are in the correct order and sets the package
+        counts for the Catalog based on its current contents.
+
+        'pfmris' is an optional set of FMRIs that indicate what package
+        entries have been changed since this function was last called.
+        It is used to optimize the finalization process.
+
+        'pubs' is an optional set of publisher prefixes that indicate
+        what publisher has had package entries changed.  It is used
+        to optimize the finalization process.  This option has no effect
+        if 'pfmris' is also provided."""
+
+        return self.__finalize(pfmris=pfmris, pubs=pubs)
+
+    def fmris(self, last=False, objects=True, ordered=False, pubs=EmptyI):
+        """A generator function that produces FMRIs as it iterates
+        over the contents of the catalog.
+
+        'last' is a boolean value that indicates only the last FMRI
+        for each package on a per-publisher basis should be returned.
+        As long as the catalog has been saved since the last modifying
+        operation, or finalize() has has been called, this will also be
+        the newest version of the package.
+
+        'objects' is an optional boolean value indicating whether
+        FMRIs should be returned as FMRI objects or as strings.
+
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            # Catalog contains nothing.
+
+            # This construction is necessary to get python to
+            # return no results properly to callers expecting
+            # a generator function.
+            return iter(())
+        return base.fmris(
+            last=last, objects=objects, ordered=ordered, pubs=pubs
+        )
+
+    def fmris_by_version(self, name, pubs=EmptyI):
+        """A generator function that produces tuples of (version,
+        fmris), where fmris is a of the fmris related to the
+        version, for the given package name.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            # Catalog contains nothing.
+
+            # This construction is necessary to get python to
+            # return no results properly to callers expecting
+            # a generator function.
+            return iter(())
+        return base.fmris_by_version(name, pubs=pubs)
+
+    def get_entry(self, pfmri, info_needed=EmptyI, locales=None):
+        """Returns a dict containing the metadata for the specified
+        FMRI containing the requested information.  If the specified
+        FMRI does not exist in the catalog, a value of None will be
+        returned.
+
+        'metadata' always contains the following information at a
+         minimum:
+
+                BASE
+                        'metadata' will be populated with Manifest
+                        signature data, if available, using key-value
+                        pairs of the form 'signature-<name>': value.
+
+        'info_needed' is an optional list of one or more catalog
+        constants indicating the types of catalog data that will
+        be returned in 'metadata' in addition to the above:
+
+                DEPENDENCY
+                        'metadata' will contain depend and set Actions
+                        for package obsoletion, renaming, variants,
+                        and facets stored in a list under the
+                        key 'actions'.
+
+                SUMMARY
+                        'metadata' will contain any remaining Actions
+                        not listed above, such as pkg.summary,
+                        pkg.description, etc. in a list under the key
+                        'actions'.
+
+        'locales' is an optional set of locale names for which Actions
+        should be returned.  The default is set(('C',)) if not provided.
+        """
+
+        def merge_entry(src, dest):
+            for k, v in six.iteritems(src):
+                if k == "actions":
+                    dest.setdefault(k, [])
+                    dest[k] += v
+                elif k != "version":
+                    dest[k] = v
+
+        parts = []
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            return
+
+        if not locales:
+            locales = set(("C",))
+        else:
+            locales = set(locales)
+
+        # Always attempt to retrieve the BASE entry as FMRIs
+        # must be present in the BASE catalog part.
+        mdata = {}
+        bentry = base.get_entry(pfmri)
+        if bentry is None:
+            return
+        merge_entry(bentry, mdata)
+
+        if self.DEPENDENCY in info_needed:
+            part = self.get_part(self.__DEPS_PART, must_exist=True)
+            if part is not None:
+                parts.append(part)
+
+        if self.SUMMARY in info_needed:
+            for locale in locales:
+                part = self.get_part(
+                    "{0}.{1}".format(self.__SUMM_PART_PFX, locale),
+                    must_exist=True,
+                )
+                if part is None:
+                    # Data not available for this
+                    # locale.
+                    continue
+                parts.append(part)
+
+        for part in parts:
+            entry = part.get_entry(pfmri)
+            if entry is None:
+                # Part doesn't have this FMRI,
+                # so skip it.
+                continue
+            merge_entry(entry, mdata)
+        return mdata
+
+    def get_entry_actions(
+        self, pfmri, info_needed, excludes=EmptyI, locales=None
+    ):
+        """A generator function that produces Actions as it iterates
+        over the catalog entry of the specified FMRI corresponding to
+        the requested information).  If the catalog doesn't contain
+        any action data for the package entry, and manifest_cb was
+        defined at Catalog creation time, the action data will be
+        lazy-loaded by the actions generator; otherwise it will
+        return an empty iterator.
+
+        'excludes' is a list of variants which will be used to determine
+        what should be allowed by the actions generator in addition to
+        what is specified by 'info_needed'.  If not provided, only
+        'info_needed' will determine what actions are returned.
+
+        'info_needed' is a set of one or more catalog constants
+        indicating the types of catalog data that will be returned
+        in 'actions' in addition to the above:
+
+                DEPENDENCY
+                        Depend and set Actions for package obsoletion,
+                        renaming, variants.
+
+                SUMMARY
+                        Any remaining set Actions not listed above, such
+                        as pkg.summary, pkg.description, etc.
+
+        'locales' is an optional set of locale names for which Actions
+        should be returned.  The default is set(('C',)) if not provided.
+        """
+
+        assert info_needed
+        if not locales:
+            locales = set(("C",))
+        else:
+            locales = set(locales)
+
+        entry = self.get_entry(pfmri, info_needed=info_needed, locales=locales)
+        if entry is None:
+            raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+
+        try:
+            return self.__gen_actions(pfmri, entry["actions"], excludes)
+        except KeyError:
+            if self.__manifest_cb:
+                return self.__gen_lazy_actions(
+                    pfmri, info_needed, locales, excludes
+                )
+            else:
+                return EmptyI
+
+    def get_entry_all_variants(self, pfmri):
+        """A generator function that yields tuples of the format
+        (var_name, variants); where var_name is the name of the
+        variant and variants is a list of the variants for that
+        name."""
+
+        info_needed = [self.DEPENDENCY]
+        entry = self.get_entry(pfmri, info_needed=info_needed)
+        if entry is None:
+            raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+
+        try:
+            actions = self.__gen_actions(pfmri, entry["actions"])
+        except KeyError:
+            if self.__manifest_cb:
+                actions = self.__gen_lazy_actions(pfmri, info_needed)
+            else:
+                return
+
+        for a in actions:
+            if a.name != "set":
+                continue
+
+            attr_name = a.attrs["name"]
+            if not attr_name.startswith("variant"):
+                continue
+            yield attr_name, a.attrs["value"]
+
+    def get_entry_signatures(self, pfmri):
+        """A generator function that yields tuples of the form (sig,
+        value) where 'sig' is the name of the signature, and 'value' is
+        the raw catalog value for the signature.  Please note that the
+        data type of 'value' is dependent on the signature, so it may
+        be a string, list, dict, etc."""
+
+        entry = self.get_entry(pfmri)
+        if entry is None:
+            raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+        return (
+            (k.split("signature-")[1], v)
+            for k, v in six.iteritems(entry)
+            if k.startswith("signature-")
+        )
+
+    def get_entry_variants(self, pfmri, name):
+        """A generator function that returns the variants for the
+        specified variant name.  If no variants exist for the
+        specified name, None will be returned."""
+
+        for var_name, values in self.get_entry_all_variants(pfmri):
+            if var_name == name:
+                # A package can only have one set of values
+                # for a single variant name, so return it.
+                return values
+        return None
+
+    def gen_packages(
+        self,
+        collect_attrs=False,
+        matched=None,
+        patterns=EmptyI,
+        pubs=EmptyI,
+        unmatched=None,
+        return_fmris=False,
+    ):
+        """A generator function that produces tuples of the form:
+
+            (
+                (
+                    pub,    - (string) the publisher of the package
+                    stem,   - (string) the name of the package
+                    version - (string) the version of the package
+                ),
+                states,     - (list) states
+                attributes  - (dict) package attributes
+            )
+
+        Results are always sorted by stem, publisher, and then in
+        descending version order.
+
+        'collect_attrs' is an optional boolean that indicates whether
+        all package attributes should be collected and returned in the
+        fifth element of the return tuple.  If False, that element will
+        be an empty dictionary.
+
+        'matched' is an optional set to add matched patterns to.
+
+        'patterns' is an optional list of FMRI wildcard strings to
+        filter results by.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to.
+
+        'unmatched' is an optional set to add unmatched patterns to.
+
+        'return_fmris' is an optional boolean value that indicates that
+        an FMRI object should be returned in place of the (pub, stem,
+        ver) tuple that is normally returned."""
+
+        # Each pattern in patterns can be a partial or full FMRI, so
+        # extract the individual components for use in filtering.
+        newest = False
+        illegals = []
+        pat_tuples = {}
+        latest_pats = set()
+        seen = set()
+        npatterns = set()
+        for pat, error, pfmri, matcher in self.__parse_fmri_patterns(patterns):
+            if error:
+                illegals.append(error)
+                continue
+
+            # Duplicate patterns are ignored.
+            sfmri = str(pfmri)
+            if sfmri in seen:
+                # A different form of the same pattern
+                # was specified already; ignore this
+                # one (e.g. pkg:/network/ping,
+                # /network/ping).
+                continue
+
+            # Track used patterns.
+            seen.add(sfmri)
+            npatterns.add(pat)
+
+            if getattr(pfmri.version, "match_latest", None):
+                latest_pats.add(pat)
+            pat_tuples[pat] = (pfmri.tuple(), matcher)
+
+        patterns = npatterns
+        del npatterns, seen
+
+        if illegals:
+            raise api_errors.PackageMatchErrors(illegal=illegals)
+
+        # Keep track of listed stems for all other packages on a
+        # per-publisher basis.
+        nlist = collections.defaultdict(int)
+
+        # Track matching patterns.
+        matched_pats = set()
+        pkg_matching_pats = None
+
+        # Need dependency and summary actions.
+        cat_info = frozenset([self.DEPENDENCY, self.SUMMARY])
+
+        for t, entry, actions in self.entry_actions(
+            cat_info, ordered=True, pubs=pubs
+        ):
+            pub, stem, ver = t
+
+            omit_ver = False
+            omit_package = None
+
+            pkg_stem = "!".join((pub, stem))
+            if newest and pkg_stem in nlist:
+                # A newer version has already been listed, so
+                # any additional entries need to be marked for
+                # omission before continuing.
+                omit_package = True
+            else:
+                nlist[pkg_stem] += 1
+
+            if matched is not None or unmatched is not None:
+                pkg_matching_pats = set()
+            if not omit_package:
+                ever = None
+                for pat in patterns:
+                    (pat_pub, pat_stem, pat_ver), matcher = pat_tuples[pat]
+
+                    if pat_pub is not None and pub != pat_pub:
+                        # Publisher doesn't match.
+                        if omit_package is None:
+                            omit_package = True
+                        continue
+
+                    if matcher == fmri.exact_name_match:
+                        if pat_stem != stem:
+                            # Stem doesn't match.
+                            if omit_package is None:
+                                omit_package = True
+                            continue
+                    elif matcher == fmri.fmri_match:
+                        if not ("/" + stem).endswith("/" + pat_stem):
+                            # Stem doesn't match.
+                            if omit_package is None:
+                                omit_package = True
+                            continue
+                    elif matcher == fmri.glob_match:
+                        if not fnmatch.fnmatchcase(stem, pat_stem):
+                            # Stem doesn't match.
+                            if omit_package is None:
+                                omit_package = True
+                            continue
+
+                    if pat_ver is not None:
+                        if ever is None:
+                            # Avoid constructing a
+                            # version object more
+                            # than once for each
+                            # entry.
+                            ever = pkg.version.Version(ver)
+                        if not ever.is_successor(
+                            pat_ver, pkg.version.CONSTRAINT_AUTO
+                        ):
+                            if omit_package is None:
+                                omit_package = True
+                            omit_ver = True
+                            continue
+
+                    if pat in latest_pats and nlist[pkg_stem] > 1:
+                        # Package allowed by pattern,
+                        # but isn't the "latest"
+                        # version.
+                        if omit_package is None:
+                            omit_package = True
+                        omit_ver = True
+                        continue
+
+                    # If this entry matched at least one
+                    # pattern, then ensure it is returned.
+                    omit_package = False
+                    if matched is None and unmatched is None:
+                        # It's faster to stop as soon
+                        # as a match is found.
+                        break
+
+                    # If caller has requested other match
+                    # cases be returned, then all patterns
+                    # must be tested for every entry.  This
+                    # is slower, so only done if necessary.
+                    pkg_matching_pats.add(pat)
+
+            if omit_package:
+                # Package didn't match critera; skip it.
+                continue
+
+            # Collect attribute data if requested.
+            summ = None
+
+            omit_var = False
+            states = set()
+            if collect_attrs:
+                # use OrderedDict to get a deterministic output
+                attrs = collections.defaultdict(lambda: OrderedDict([]))
+            else:
+                attrs = EmptyDict
+
+            try:
+                for a in actions:
+                    if a.name != "set":
+                        continue
+
+                    atname = a.attrs["name"]
+                    atvalue = a.attrs["value"]
+                    if collect_attrs:
+                        atvlist = a.attrlist("value")
+                        # mods = frozenset(
+                        #   (k1, frozenset([k1_1, k1_2]))
+                        #   (k2, frozenset([k2_1, k2_2]))
+                        # )
+                        # will later be converted by the
+                        # caller into a dict like:
+                        # {
+                        #    k1: frozenset([k1_1, k1_2]),
+                        #    k2: frozenset([k2_1, k2_2])
+                        # }
+                        mods = frozenset(
+                            (k, frozenset(a.attrlist(k)))
+                            for k in six.iterkeys(a.attrs)
+                            if k not in ("name", "value")
+                        )
+                        if mods not in attrs[atname]:
+                            attrs[atname][mods] = atvlist
+                        else:
+                            attrs[atname][mods].extend(atvlist)
+
+                    if atname == "pkg.summary":
+                        summ = atvalue
+                        continue
+
+                    if atname == "description":
+                        if summ is not None:
+                            continue
+
+                        # Historical summary field.
+                        summ = atvalue
+                        if collect_attrs:
+                            if mods not in attrs["pkg.summary"]:
+                                attrs["pkg.summary"][mods] = atvlist
+                            else:
+                                attrs["pkg.summary"][mods].extend(atvlist)
+                        continue
+
+                    if atname == "pkg.renamed":
+                        if atvalue == "true":
+                            states.add(pkgdefs.PKG_STATE_RENAMED)
+                        continue
+                    if atname == "pkg.obsolete":
+                        if atvalue == "true":
+                            states.add(pkgdefs.PKG_STATE_OBSOLETE)
+                        continue
+                    if atname == "pkg.legacy":
+                        if atvalue == "true":
+                            states.add(pkgdefs.PKG_STATE_LEGACY)
+            except api_errors.InvalidPackageErrors:
+                # Ignore errors for packages that have invalid
+                # or unsupported metadata.
+                states.add(pkgdefs.PKG_STATE_UNSUPPORTED)
+
+            if omit_package:
+                # Package didn't match criteria; skip it.
+                if omit_ver and nlist[pkg_stem] == 1:
+                    del nlist[pkg_stem]
+                continue
+
+            if matched is not None or unmatched is not None:
+                # Only after all other filtering has been
+                # applied are the patterns that the package
+                # matched considered "matching".
+                matched_pats.update(pkg_matching_pats)
+
+            # Return the requested package data.
+            if return_fmris:
+                pfmri = fmri.PkgFmri(name=stem, publisher=pub, version=ver)
+                yield (pfmri, states, attrs)
+            else:
+                yield (t, states, attrs)
+
+        if matched is not None:
+            # Caller has requested that matched patterns be
+            # returned.
+            matched.update(matched_pats)
+        if unmatched is not None:
+            # Caller has requested that unmatched patterns be
+            # returned.
+            unmatched.update(set(pat_tuples.keys()) - matched_pats)
+
+    def get_matching_fmris(self, patterns):
+        """Given a user-specified list of FMRI pattern strings, return
+        a tuple of ('matching', 'references', 'unmatched'), where
+        matching is a dict of matching fmris, references is a dict of
+        the patterns indexed by matching FMRI, and unmatched is a set of
+        the patterns that did not match any FMRIs respectively:
+
+        {
+         pkgname: [fmri1, fmri2, ...],
+         pkgname: [fmri1, fmri2, ...],
+         ...
+        }
+
+        {
+         fmri1: [pat1, pat2, ...],
+         fmri2: [pat1, pat2, ...],
+         ...
+        }
+
+        set(['unmatched1', 'unmatchedN'])
+
+        'patterns' is the list of package patterns to match.
+
+        Constraint used is always AUTO as per expected UI behavior when
+        determining successor versions.
+
+        Note that patterns starting w/ pkg:/ require an exact match;
+        patterns containing '*' will using fnmatch rules; the default
+        trailing match rules are used for remaining patterns.
+
+        Exactly duplicated patterns are ignored.
+
+        Routine raises PackageMatchErrors if errors occur: it is
+        illegal to specify multiple different patterns that match the
+        same package name.  Only patterns that contain wildcards are
+        allowed to match multiple packages.
+        """
+
+        # problems we check for
+        illegals = []
+        unmatched = set()
+        multimatch = []
+        multispec = []
+        pat_data = []
+        wildcard_patterns = set()
+
+        # Each pattern in patterns can be a partial or full FMRI, so
+        # extract the individual components for use in filtering.
+        latest_pats = set()
+        seen = set()
+        npatterns = set()
+        for pat, error, pfmri, matcher in self.__parse_fmri_patterns(patterns):
+            if error:
+                illegals.append(error)
+                continue
+
+            # Duplicate patterns are ignored.
+            sfmri = str(pfmri)
+            if sfmri in seen:
+                # A different form of the same pattern
+                # was specified already; ignore this
+                # one (e.g. pkg:/network/ping,
+                # /network/ping).
+                continue
+
+            # Track used patterns.
+            seen.add(sfmri)
+            npatterns.add(pat)
+            if "*" in pfmri.pkg_name or "?" in pfmri.pkg_name:
+                wildcard_patterns.add(pat)
+
+            if getattr(pfmri.version, "match_latest", None):
+                latest_pats.add(pat)
+            pat_data.append((pat, matcher, pfmri))
+
+        patterns = npatterns
+        del npatterns, seen
+
+        if illegals:
+            raise api_errors.PackageMatchErrors(illegal=illegals)
+
+        # Create a dictionary of patterns, with each value being a
+        # dictionary of pkg names & fmris that match that pattern.
+        ret = dict(zip(patterns, [dict() for i in patterns]))
+
+        for name in self.names():
+            for pat, matcher, pfmri in pat_data:
+                pub = pfmri.publisher
+                version = pfmri.version
+                if not matcher(name, pfmri.pkg_name):
+                    continue  # name doesn't match
+                for ver, entries in self.entries_by_version(name):
+                    if version and not ver.is_successor(
+                        version, pkg.version.CONSTRAINT_AUTO
+                    ):
+                        continue  # version doesn't match
+                    for f, metadata in entries:
+                        fpub = f.publisher
+                        if pub and pub != fpub:
+                            # specified pubs
+                            # conflict
+                            continue
+                        ret[pat].setdefault(f.pkg_name, []).append(f)
+
+        # Discard all but the newest version of each match.
+        if latest_pats:
+            # Rebuild ret based on latest version of every package.
+            latest = {}
+            nret = {}
+            for p in patterns:
+                if p not in latest_pats or not ret[p]:
+                    nret[p] = ret[p]
+                    continue
+
+                nret[p] = {}
+                for pkg_name in ret[p]:
+                    nret[p].setdefault(pkg_name, [])
+                    for f in ret[p][pkg_name]:
+                        nver = latest.get(f.pkg_name, None)
+                        if nver > f.version:
+                            # Not the newest.
+                            continue
+                        if nver == f.version:
+                            # Allow for multiple
+                            # FMRIs of the same
+                            # latest version.
+                            nret[p][pkg_name].append(f)
+                            continue
+
+                        latest[f.pkg_name] = f.version
+                        nret[p][pkg_name] = [f]
+
+            # Assign new version of ret and discard latest list.
+            ret = nret
+            del latest
+
+        # Determine match failures.
+        matchdict = {}
+        for p in patterns:
+            l = len(ret[p])
+            if l == 0:  # no matches at all
+                unmatched.add(p)
+            elif l > 1 and p not in wildcard_patterns:
+                # multiple matches
+                multimatch.append(
+                    (p, [ret[p][n][0].get_pkg_stem() for n in ret[p]])
+                )
+            else:
+                # single match or wildcard
+                for k in ret[p].keys():
+                    # for each matching package name
+                    matchdict.setdefault(k, []).append(p)
+
+        if multimatch:
+            raise api_errors.PackageMatchErrors(multiple_matches=multimatch)
+
+        # Group the matching patterns by package name and allow multiple
+        # fmri matches.
+        proposed_dict = {}
+        for d in ret.values():
+            for k, l in six.iteritems(d):
+                proposed_dict.setdefault(k, []).extend(l)
+
+        # construct references so that we can know which pattern
+        # generated which fmris...
+        references = dict(
+            [
+                (f, p)
+                for p in ret.keys()
+                for flist in ret[p].values()
+                for f in flist
+            ]
+        )
+
+        return proposed_dict, references, unmatched
+
+    def get_package_counts_by_pub(self, pubs=EmptyI):
+        """Returns a generator of tuples of the form (pub,
+        package_count, package_version_count).  'pub' is the publisher
+        prefix, 'package_count' is the number of unique packages for the
+        publisher, and 'package_version_count' is the number of unique
+        package versions for the publisher.
+        """
+
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            # Catalog contains nothing.
+
+            # This construction is necessary to get python to
+            # return no results properly to callers expecting
+            # a generator function.
+            return iter(())
+        return base.get_package_counts_by_pub(pubs=pubs)
+
+    def get_part(self, name, must_exist=False):
+        """Returns the CatalogPart object for the named catalog part.
+
+        'must_exist' is an optional boolean value that indicates that
+        the catalog part must already exist in-memory or on-disk, if
+        not a value of None will be returned."""
+
+        # First, check if the part has already been cached, and if so,
+        # return it.
+        part = self.__parts.get(name, None)
+        if part is not None:
+            return part
+        elif not self.meta_root and must_exist:
+            return
+
+        # If the caller said the part must_exist, then it must already
+        # be part of the catalog attributes to be valid.
+        aparts = self._attrs.parts
+        if must_exist and name not in aparts:
+            return
+
+        # Next, since the part hasn't been cached, create an object
+        # for it and add it to catalog attributes.
+        part = CatalogPart(
+            name,
+            meta_root=self.meta_root,
+            ordered=not self.__batch_mode,
+            sign=self.__sign,
+        )
+        if must_exist and self.meta_root and not part.exists:
+            # This is a double-check for the client case where
+            # there is a part that is known to the catalog but
+            # that the client has purposefully not retrieved.
+            # (Think locale specific data.)
+            return
+
+        self.__parts[name] = part
+
+        if name not in aparts:
+            # Add a new entry to the catalog attributes for this new
+            # part since it didn't exist previously.
+            aparts[name] = {"last-modified": part.last_modified}
+        return part
+
+    def get_updates_needed(self, path):
+        """Returns a list of the catalog files needed to update
+        the existing catalog parts, based on the contents of the
+        catalog.attrs file in the directory indicated by 'path'.
+        A value of None will be returned if the catalog has
+        not been modified, while an empty list will be returned
+        if no catalog parts need to be updated, but the catalog
+        itself has changed."""
+
+        new_attrs = CatalogAttrs(meta_root=path)
+        if not new_attrs.exists:
+            # No updates needed (not even to attrs), so return None.
+            return None
+
+        old_attrs = self._attrs
+        if old_attrs.created != new_attrs.created:
+            # It's very likely that the catalog has been recreated
+            # or this is a completely different catalog than was
+            # expected.  In either case, an update isn't possible.
+            raise api_errors.BadCatalogUpdateIdentity(path)
+
+        if new_attrs.last_modified == old_attrs.last_modified:
+            # No updates needed (not even to attrs), so return None.
+            return None
+
+        # First, verify that all of the catalog parts the client has
+        # still exist.  If they no longer exist, the catalog is no
+        # longer valid and cannot be updated.
+        parts = {}
+        incremental = True
+        for name in old_attrs.parts:
+            if name not in new_attrs.parts:
+                raise api_errors.BadCatalogUpdateIdentity(path)
+
+            old_lm = old_attrs.parts[name]["last-modified"]
+            new_lm = new_attrs.parts[name]["last-modified"]
+
+            if new_lm == old_lm:
+                # Part hasn't changed.
+                continue
+            elif new_lm < old_lm:
+                raise api_errors.ObsoleteCatalogUpdate(path)
+
+            # The last component of the update name is the locale.
+            locale = name.split(".", 2)[2]
+
+            # Now check to see if an update log is still offered for
+            # the last time this catalog part was updated.  If it
+            # does not, then an incremental update cannot be safely
+            # performed since updates may be missing.
+            logdate = datetime_to_update_ts(old_lm)
+            logname = "update.{0}.{1}".format(logdate, locale)
+
+            if logname not in new_attrs.updates:
+                incremental = False
+
+            parts.setdefault(locale, set())
+            parts[locale].add(name)
+
+        # XXX in future, add current locale to this.  For now, just
+        # ensure that all of the locales of parts that were changed
+        # and exist on-disk are included.
+        locales = set(("C",))
+        locales.update(set(parts.keys()))
+
+        # Now determine if there are any new parts for this locale that
+        # this version of the API knows how to use that the client
+        # doesn't already have.
+        for name in new_attrs.parts:
+            if name in parts or name in old_attrs.parts:
+                continue
+
+            # The last component of the name is the locale.
+            locale = name.split(".", 2)[2]
+            if locale not in locales:
+                continue
+
+            # Currently, only these parts are used by the client,
+            # so only they need to be retrieved.
+            if (
+                name == self.__BASE_PART
+                or name == self.__DEPS_PART
+                or name.startswith(self.__SUMM_PART_PFX)
+            ):
+                incremental = False
+
+                # If a new part has been added for the current
+                # locale, then incremental updates can't be
+                # performed since updates for this locale can
+                # only be applied to parts that already exist.
+                parts.setdefault(locale, set())
+                parts[locale].add(name)
+
+        if not parts:
+            # No updates needed to catalog parts on-disk, but
+            # catalog has changed.
+            return []
+        elif not incremental:
+            # Since an incremental update cannot be performed,
+            # just return the updated parts for retrieval.
+            updates = set()
+            for locale in parts:
+                updates.update(parts[locale])
+            return updates
+
+        # Finally, determine the update logs needed based on the catalog
+        # parts that need updating on a per-locale basis.
+        updates = set()
+        for locale in parts:
+            # Determine the newest catalog part for a given locale,
+            # this will be used to determine which update logs are
+            # needed for an incremental update.
+            last_lm = None
+            for name in parts[locale]:
+                if name not in old_attrs.parts:
+                    continue
+
+                lm = old_attrs.parts[name]["last-modified"]
+                if not last_lm or lm > last_lm:
+                    last_lm = lm
+
+            for name, uattrs in six.iteritems(new_attrs.updates):
+                up_lm = uattrs["last-modified"]
+
+                # The last component of the update name is the
+                # locale.
+                up_locale = name.split(".", 2)[2]
+
+                if not up_locale == locale:
+                    # This update log doesn't apply to the
+                    # locale being evaluated for updates.
+                    continue
+
+                if up_lm <= last_lm:
+                    # Older or same as newest catalog part
+                    # for this locale; so skip.
+                    continue
+
+                # If this updatelog was changed after the
+                # newest catalog part for this locale, then
+                # it is needed to update one or more catalog
+                # parts for this locale.
+                updates.add(name)
+
+        # Ensure updates are in chronological ascending order.
+        return sorted(updates)
+
+    def names(self, pubs=EmptyI):
+        """Returns a set containing the names of all the packages in
+        the Catalog.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            # Catalog contains nothing.
+            return set()
+        return base.names(pubs=pubs)
+
+    @property
+    def package_count(self):
+        """The number of unique packages in the catalog."""
+        return self._attrs.package_count
+
+    @property
+    def package_version_count(self):
+        """The number of unique package versions in the catalog."""
+        return self._attrs.package_version_count
+
+    @property
+    def parts(self):
+        """A dict containing the list of CatalogParts that the catalog
+        is composed of along with information about each part."""
+
+        return self._attrs.parts
+
+    def pkg_names(self, pubs=EmptyI):
+        """A generator function that produces package tuples of the form
+        (pub, stem) as it iterates over the contents of the catalog.
+
+        'pubs' is an optional list that contains the prefixes of the
+        publishers to restrict the results to."""
+
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            # Catalog contains nothing.
+
+            # This construction is necessary to get python to
+            # return no results properly to callers expecting
+            # a generator function.
+            return iter(())
+        return base.pkg_names(pubs=pubs)
+
+    def publishers(self):
+        """Returns a set containing the prefixes of all the publishers
+        in the Catalog."""
+
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            # Catalog contains nothing.
+            return set()
+        return set(p for p in base.publishers())
+
+    def remove_package(self, pfmri):
+        """Remove a package and its metadata."""
+
+        assert not self.read_only
+
+        self.__lock_catalog()
+        try:
+            # The package has to be removed from every known part.
+            entries = {}
+
+            # Use the same operation time and date for all
+            # operations so that the last modification times
+            # of all catalog parts and update logs will be
+            # synchronized.
+            op_time = datetime.datetime.utcnow()
+
+            for name in self._attrs.parts:
+                part = self.get_part(name)
+                if part is None:
+                    continue
+
+                pkg_entry = part.get_entry(pfmri)
+                if pkg_entry is None:
+                    if name == self.__BASE_PART:
+                        # Entry should exist in at least
+                        # the base part.
+                        raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+                    # Skip; package's presence is optional
+                    # in other parts.
+                    continue
+
+                part.remove(pfmri, op_time=op_time)
+                if self.log_updates:
+                    entries[part.name] = pkg_entry
+
+            self.__log_update(
+                pfmri, CatalogUpdate.REMOVE, op_time, entries=entries
+            )
+        finally:
+            self.__unlock_catalog()
+
+    def save(self, fmt="utf8"):
+        """Finalize current state and save to file if possible."""
+
+        self.__lock_catalog()
+        try:
+            self.__save(fmt)
+        finally:
+            self.__unlock_catalog()
+
+    @property
+    def signatures(self):
+        """Returns a dict of the files the catalog is composed of along
+        with the last known signatures of each if they are available."""
+
+        attrs = self._attrs
+        sigs = {attrs.name: attrs.signatures}
+
+        for items in (attrs.parts, attrs.updates):
+            for name in items:
+                entry = sigs[name] = {}
+                for k in items[name]:
+                    try:
+                        sig = k.split("signature-")[1]
+                        entry[sig] = items[name][k]
+                    except IndexError:
+                        # Not a signature entry.
+                        continue
+        return sigs
+
+    def tuples(self, last=False, ordered=False, pubs=EmptyI):
+        """A generator function that produces FMRI tuples as it
+        iterates over the contents of the catalog.
+
+        'last' is a boolean value that indicates only the last FMRI
+        tuple for each package on a per-publisher basis should be
+        returned.  As long as the catalog has been saved since the
+        last modifying operation, or finalize() has has been called,
+        this will also be the newest version of the package.
+
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            # Catalog contains nothing.
+
+            # This construction is necessary to get python to
+            # return no results properly to callers expecting
+            # a generator function.
+            return iter(())
+        return base.tuples(last=last, ordered=ordered, pubs=pubs)
+
+    def tuple_entries(
+        self,
+        info_needed=EmptyI,
+        last=False,
+        locales=None,
+        ordered=False,
+        pubs=EmptyI,
+    ):
+        """A generator function that produces tuples of the format
+        ((pub, stem, version), entry, actions) as it iterates over
+        the contents of the catalog (where 'metadata' is a dict
+        containing the requested information).
+
+        'metadata' always contains the following information at a
+         minimum:
+
+                BASE
+                        'metadata' will be populated with Manifest
+                        signature data, if available, using key-value
+                        pairs of the form 'signature-<name>': value.
+
+        'info_needed' is an optional list of one or more catalog
+        constants indicating the types of catalog data that will
+        be returned in 'metadata' in addition to the above:
+
+                DEPENDENCY
+                        'metadata' will contain depend and set Actions
+                        for package obsoletion, renaming, variants,
+                        and facets stored in a list under the
+                        key 'actions'.
+
+                SUMMARY
+                        'metadata' will contain any remaining Actions
+                        not listed above, such as pkg.summary,
+                        pkg.description, etc. in a list under the key
+                        'actions'.
+
+        'last' is a boolean value that indicates only the last entry
+        for each package on a per-publisher basis should be returned.
+        As long as the catalog has been saved since the last modifying
+        operation, or finalize() has has been called, this will also be
+        the newest version of the package.
+
+        'locales' is an optional set of locale names for which Actions
+        should be returned.  The default is set(('C',)) if not provided.
+        Note that unlike actions(), catalog entries will not lazy-load
+        action data if it is missing from the catalog.
+
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to."""
+
+        return self.__entries(
+            info_needed=info_needed,
+            locales=locales,
+            last_version=last,
+            ordered=ordered,
+            pubs=pubs,
+            tuples=True,
+        )
+
+    @property
+    def updates(self):
+        """A dict containing the list of known updates for the catalog
+        along with information about each update."""
+
+        return self._attrs.updates
+
+    def update_entry(self, metadata, pfmri=None, pub=None, stem=None, ver=None):
+        """Updates the metadata stored in a package's BASE catalog
+        record for the specified package.  Cannot be used when read_only
+        or log_updates is enabled; should never be used with a Catalog
+        intended for incremental update usage.
+
+        'metadata' must be a dict of additional metadata to store with
+        the package's BASE record.
+
+        'pfmri' is the FMRI of the package to update the entry for.
+
+        'pub' is the publisher of the package.
+
+        'stem' is the stem of the package.
+
+        'ver' is the version string of the package.
+
+        'pfmri' or 'pub', 'stem', and 'ver' must be provided.
+        """
+
+        assert pfmri or (pub and stem and ver)
+        assert not self.log_updates and not self.read_only
+
+        base = self.get_part(self.__BASE_PART, must_exist=True)
+        if base is None:
+            if not pfmri:
+                pfmri = fmri.PkgFmri(name=stem, publisher=pub, version=ver)
+            raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+
+        # get_entry returns the actual catalog entry, so updating it
+        # simply requires reassignment.
+        entry = base.get_entry(pfmri=pfmri, pub=pub, stem=stem, ver=ver)
+        if entry is None:
+            if not pfmri:
+                pfmri = fmri.PkgFmri(name=stem, publisher=pub, version=ver)
+            raise api_errors.UnknownCatalogEntry(pfmri.get_fmri())
+        if metadata is None:
+            if "metadata" in entry:
+                del entry["metadata"]
+            return
+        entry["metadata"] = metadata
+
+        op_time = datetime.datetime.utcnow()
+        attrs = self._attrs
+        attrs.last_modified = op_time
+        attrs.parts[base.name] = {"last-modified": op_time}
+        base.last_modified = op_time
+
+    def validate(self, require_signatures=False):
+        """Verifies whether the signatures for the contents of the
+        catalog match the current signature data.  Raises the
+        exception named 'BadCatalogSignatures' on failure."""
+
+        self._attrs.validate(require_signatures=require_signatures)
+
+        def get_sigs(mdata):
+            sigs = {}
+            for key in mdata:
+                if not key.startswith("signature-"):
+                    continue
+                sig = key.split("signature-")[1]
+                sigs[sig] = mdata[key]
+            if not sigs:
+                # Allow validate() to perform its own fallback
+                # logic if signature data isn't available.
+                return None
+            return sigs
+
+        for name, mdata in six.iteritems(self._attrs.parts):
+            part = self.get_part(name, must_exist=True)
+            if part is None:
+                # Part does not exist; no validation needed.
+                continue
+            part.validate(
+                signatures=get_sigs(mdata),
+                require_signatures=require_signatures,
+            )
+
+        for name, mdata in six.iteritems(self._attrs.updates):
+            ulog = self.__get_update(name, cache=False, must_exist=True)
+            if ulog is None:
+                # Update does not exist; no validation needed.
+                continue
+            ulog.validate(
+                signatures=get_sigs(mdata),
+                require_signatures=require_signatures,
+            )
+
+    batch_mode = property(__get_batch_mode, __set_batch_mode)
+    last_modified = property(
+        __get_last_modified,
+        __set_last_modified,
+        doc="A UTC datetime object indicating the last time the catalog "
+        "was modified.",
+    )
+    meta_root = property(__get_meta_root, __set_meta_root)
+    sign = property(__get_sign, __set_sign)
+    version = property(__get_version, __set_version)
 
 
 # Methods used by external callers
 def verify(filename):
-        """Convert the catalog part named by filename into the correct
-        type of Catalog object and then call its validate method to ensure
-        that is contents are self-consistent."""
+    """Convert the catalog part named by filename into the correct
+    type of Catalog object and then call its validate method to ensure
+    that is contents are self-consistent."""
 
-        path, fn = os.path.split(filename)
-        catobj = None
+    path, fn = os.path.split(filename)
+    catobj = None
 
-        if fn.startswith("catalog"):
-                if fn.endswith("attrs"):
-                        catobj = CatalogAttrs(meta_root=path)
-                else:
-                        catobj = CatalogPart(fn, meta_root=path)
-        elif fn.startswith("update"):
-                catobj = CatalogUpdate(fn, meta_root=path)
+    if fn.startswith("catalog"):
+        if fn.endswith("attrs"):
+            catobj = CatalogAttrs(meta_root=path)
         else:
-                # Unrecognized.
-                raise api_errors.UnrecognizedCatalogPart(fn)
+            catobj = CatalogPart(fn, meta_root=path)
+    elif fn.startswith("update"):
+        catobj = CatalogUpdate(fn, meta_root=path)
+    else:
+        # Unrecognized.
+        raise api_errors.UnrecognizedCatalogPart(fn)
 
-        # With the else case above, this should never be None.
-        assert catobj
+    # With the else case above, this should never be None.
+    assert catobj
 
-        catobj.validate(require_signatures=True)
+    catobj.validate(require_signatures=True)
+
 
 # Methods used by Catalog classes.
 def datetime_to_ts(dt):
-        """Take datetime object dt, and convert it to a ts in ISO-8601
-        format. """
+    """Take datetime object dt, and convert it to a ts in ISO-8601
+    format."""
 
-        return dt.isoformat()
+    return dt.isoformat()
+
 
 def datetime_to_basic_ts(dt):
-        """Take datetime object dt, and convert it to a ts in ISO-8601
-        basic format. """
+    """Take datetime object dt, and convert it to a ts in ISO-8601
+    basic format."""
 
-        val = dt.isoformat()
-        val = val.replace("-", "")
-        val = val.replace(":", "")
+    val = dt.isoformat()
+    val = val.replace("-", "")
+    val = val.replace(":", "")
 
-        if not dt.tzname():
-                # Assume UTC.
-                val += "Z"
-        return val
+    if not dt.tzname():
+        # Assume UTC.
+        val += "Z"
+    return val
+
 
 def datetime_to_update_ts(dt):
-        """Take datetime object dt, and convert it to a ts in ISO-8601
-        basic partial format. """
+    """Take datetime object dt, and convert it to a ts in ISO-8601
+    basic partial format."""
 
-        val = dt.isoformat()
-        val = val.replace("-", "")
-        # Drop the minutes and seconds portion.
-        val = val.rsplit(":", 2)[0]
-        val = val.replace(":", "")
+    val = dt.isoformat()
+    val = val.replace("-", "")
+    # Drop the minutes and seconds portion.
+    val = val.rsplit(":", 2)[0]
+    val = val.replace(":", "")
 
-        if not dt.tzname():
-                # Assume UTC.
-                val += "Z"
-        return val
+    if not dt.tzname():
+        # Assume UTC.
+        val += "Z"
+    return val
+
 
 def now_to_basic_ts():
-        """Returns the current UTC time as timestamp in ISO-8601 basic
-        format."""
-        return datetime_to_basic_ts(datetime.datetime.utcnow())
+    """Returns the current UTC time as timestamp in ISO-8601 basic
+    format."""
+    return datetime_to_basic_ts(datetime.datetime.utcnow())
+
 
 def now_to_update_ts():
-        """Returns the current UTC time as timestamp in ISO-8601 basic
-        partial format."""
-        return datetime_to_update_ts(datetime.datetime.utcnow())
+    """Returns the current UTC time as timestamp in ISO-8601 basic
+    partial format."""
+    return datetime_to_update_ts(datetime.datetime.utcnow())
+
 
 def ts_to_datetime(ts):
-        """Take timestamp ts in ISO-8601 format, and convert it to a
-        datetime object."""
+    """Take timestamp ts in ISO-8601 format, and convert it to a
+    datetime object."""
 
-        year = int(ts[0:4])
-        month = int(ts[5:7])
-        day = int(ts[8:10])
-        hour = int(ts[11:13])
-        minutes = int(ts[14:16])
-        sec = int(ts[17:19])
-        # usec is not in the string if 0
-        try:
-                usec = int(ts[20:26])
-        except ValueError:
-                usec = 0
-        return datetime.datetime(year, month, day, hour, minutes, sec, usec)
+    year = int(ts[0:4])
+    month = int(ts[5:7])
+    day = int(ts[8:10])
+    hour = int(ts[11:13])
+    minutes = int(ts[14:16])
+    sec = int(ts[17:19])
+    # usec is not in the string if 0
+    try:
+        usec = int(ts[20:26])
+    except ValueError:
+        usec = 0
+    return datetime.datetime(year, month, day, hour, minutes, sec, usec)
+
 
 def basic_ts_to_datetime(ts):
-        """Take timestamp ts in ISO-8601 basic format, and convert it to a
-        datetime object."""
+    """Take timestamp ts in ISO-8601 basic format, and convert it to a
+    datetime object."""
 
-        year = int(ts[0:4])
-        month = int(ts[4:6])
-        day = int(ts[6:8])
-        hour = int(ts[9:11])
-        minutes = int(ts[11:13])
-        sec = int(ts[13:15])
-        # usec is not in the string if 0
-        try:
-                usec = int(ts[16:22])
-        except ValueError:
-                usec = 0
-        return datetime.datetime(year, month, day, hour, minutes, sec, usec)
+    year = int(ts[0:4])
+    month = int(ts[4:6])
+    day = int(ts[6:8])
+    hour = int(ts[9:11])
+    minutes = int(ts[11:13])
+    sec = int(ts[13:15])
+    # usec is not in the string if 0
+    try:
+        usec = int(ts[16:22])
+    except ValueError:
+        usec = 0
+    return datetime.datetime(year, month, day, hour, minutes, sec, usec)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/cfgfiles.py
+++ b/src/modules/cfgfiles.py
@@ -40,13 +40,20 @@ import time
 
 import pkg.lockfile as lockfile
 
+
 class CfgFile(object):
-    """ Solaris configuration file editor... make it easier to
-        modify Solaris line-oriented configuration files from actions """
+    """Solaris configuration file editor... make it easier to
+    modify Solaris line-oriented configuration files from actions"""
 
-    def __init__(self, filename, separator, column_names, keys,
-                 comment_match="#", continuation_lines=False):
-
+    def __init__(
+        self,
+        filename,
+        separator,
+        column_names,
+        keys,
+        comment_match="#",
+        continuation_lines=False,
+    ):
         self.filename = filename
         self.separator = separator
         self.continuation_lines = continuation_lines
@@ -58,7 +65,7 @@ class CfgFile(object):
         self.default_values = dict((e[2], e[1]) for e in l)
 
         self.comment_regexp = re.compile(comment_match)
-        self.max_lengths=dict((n, 8) for n in self.column_names)
+        self.max_lengths = dict((n, 8) for n in self.column_names)
 
         if isinstance(keys, str):
             self.keys = [keys]
@@ -67,11 +74,12 @@ class CfgFile(object):
 
         self.index = {}
 
-        assert(set(self.column_names) >= set(self.keys))
+        assert set(self.column_names) >= set(self.keys)
 
     def __str__(self):
         return "CfgFile({0}):{1}:{2}:{3}".format(
-            self.filename, self.keys, self.column_names, self.index)
+            self.filename, self.keys, self.column_names, self.index
+        )
 
     def getcolumnnames(self):
         return self.column_names
@@ -83,19 +91,18 @@ class CfgFile(object):
         return line.split(self.separator)
 
     def getfilelines(self):
-        """ given self, return list of lines to be printed.
-            default impl preserves orignal + insertion order"""
-        lines = [[self.index[l][2],self.index[l][0]] for l in self.index]
+        """given self, return list of lines to be printed.
+        default impl preserves orignal + insertion order"""
+        lines = [[self.index[l][2], self.index[l][0]] for l in self.index]
         lines.sort()
         return [l[1] for l in lines]
 
-
     def readfile(self):
         if os.path.exists(self.filename):
-            file = open(self.filename, 'rb')	
+            file = open(self.filename, "rb")
             lineno = 1
             for line in file:
-                linecnt = 1;
+                linecnt = 1
                 try:
                     line = line.decode("utf-8")
                 except UnicodeDecodeError:
@@ -108,14 +115,16 @@ class CfgFile(object):
 
                 line = line.rstrip("\n")
                 if self.iscommentline(line):
-                    self.index[lineno] = \
-                        (line, None, lineno)
+                    self.index[lineno] = (line, None, lineno)
                 else:
                     cols = self.splitline(line)
                     if len(cols) == len(self.column_names):
                         dic = dict(zip(self.column_names, cols))
-                        self.index[tuple(dic[k] for k in self.keys)] = \
-                            (line, dic, lineno)
+                        self.index[tuple(dic[k] for k in self.keys)] = (
+                            line,
+                            dic,
+                            lineno,
+                        )
                     else:
                         self.index[lineno] = (line, None, lineno)
                 lineno += linecnt
@@ -130,15 +139,17 @@ class CfgFile(object):
             return {}
 
     def getdefaultvalues(self):
-        """ returns dictionary of default string values - ignores
-        other types """
-        return dict((i, self.default_values[i])
-                    for i in self.default_values
-                    if isinstance(self.default_values[i], str))
+        """returns dictionary of default string values - ignores
+        other types"""
+        return dict(
+            (i, self.default_values[i])
+            for i in self.default_values
+            if isinstance(self.default_values[i], str)
+        )
 
     def updatevalue(self, template):
-        """ update existing record, using orig values if missing
-            in template"""
+        """update existing record, using orig values if missing
+        in template"""
         orig = self.index[tuple(template[k] for k in self.keys)].copy()
         for name in self.column_names:
             if name in template:
@@ -146,14 +157,15 @@ class CfgFile(object):
         self.setvalue(orig)
 
     def setvalue(self, template):
-        """ set value of record in file, replacing any previous def.
-            for any missing info, use defaults.  Will insert new value """
+        """set value of record in file, replacing any previous def.
+        for any missing info, use defaults.  Will insert new value"""
         # bring in any missing values as defaults if not None
         for field in self.column_names:
             if field not in template:
                 if self.default_values[field] is None:
                     raise RuntimeError(
-                        "Required attribute {0} is missing".format(field))
+                        "Required attribute {0} is missing".format(field)
+                    )
                 elif hasattr(self.default_values[field], "__call__"):
                     template[field] = self.default_values[field]()
                 else:
@@ -169,8 +181,11 @@ class CfgFile(object):
         else:
             lineno = 0
         line = self.valuetostr(template)
-        self.index[tuple(template[k] for k in self.keys)] = \
-            (line, template, lineno)
+        self.index[tuple(template[k] for k in self.keys)] = (
+            line,
+            template,
+            lineno,
+        )
         self.needswriting = True
 
     def removevalue(self, template):
@@ -178,14 +193,14 @@ class CfgFile(object):
         self.needswriting = True
 
     def valuetostr(self, template):
-        """ print out values in file format """
-        return("{0}".format(self.separator.join(
-            [
-                "{0}".format(template[key]) for key in self.column_names
-            ])))
+        """print out values in file format"""
+        return "{0}".format(
+            self.separator.join(
+                ["{0}".format(template[key]) for key in self.column_names]
+            )
+        )
 
     def writefile(self):
-
         if not self.needswriting:
             return
 
@@ -205,51 +220,61 @@ class CfgFile(object):
 
         os.rename(name, self.filename)
 
+
 class PasswordFile(CfgFile):
     """Manage the passwd and shadow together. Note that
-       insertion/deletion of +/- fields isn't supported"""
+    insertion/deletion of +/- fields isn't supported"""
+
     def __init__(self, path_prefix, lock=False):
-        self.password_file = \
-            CfgFile(os.path.join(path_prefix, "etc/passwd"),
-                    ":",
-                    {"username"   : (1, None),
-                     "password"   : (2, "x"),
-                     "uid"        : (3, None),
-                     "gid"        : (4, None),
-                     "gcos-field" : (5, "& User"),
-                     "home-dir"   : (6, "/"),
-                     "login-shell": (7, "")
-                     },
-                    "username", comment_match="[-+]")
+        self.password_file = CfgFile(
+            os.path.join(path_prefix, "etc/passwd"),
+            ":",
+            {
+                "username": (1, None),
+                "password": (2, "x"),
+                "uid": (3, None),
+                "gid": (4, None),
+                "gcos-field": (5, "& User"),
+                "home-dir": (6, "/"),
+                "login-shell": (7, ""),
+            },
+            "username",
+            comment_match="[-+]",
+        )
         days = datetime.timedelta(seconds=time.time()).days
-        self.shadow_file = \
-            CfgFile(os.path.join(path_prefix, "etc/shadow"),
-                    ":",
-                    {"username"   : (1, None),
-                     "password"   : (2, "*LK*"),
-                     "lastchg"    : (3, days),
-                     "min"        : (4, ""),
-                     "max"        : (5, ""),
-                     "warn"       : (6, ""),
-                     "inactive"   : (7, ""),
-                     "expire"     : (8, ""),
-                     "flag"       : (9, "")
-                     },
-                    "username", comment_match="[-+]")
+        self.shadow_file = CfgFile(
+            os.path.join(path_prefix, "etc/shadow"),
+            ":",
+            {
+                "username": (1, None),
+                "password": (2, "*LK*"),
+                "lastchg": (3, days),
+                "min": (4, ""),
+                "max": (5, ""),
+                "warn": (6, ""),
+                "inactive": (7, ""),
+                "expire": (8, ""),
+                "flag": (9, ""),
+            },
+            "username",
+            comment_match="[-+]",
+        )
         self.path_prefix = path_prefix
-        self.lockfile = lockfile.LockFile(os.path.join(self.path_prefix,
-            "etc/.pwd.lock"))
+        self.lockfile = lockfile.LockFile(
+            os.path.join(self.path_prefix, "etc/.pwd.lock")
+        )
         if lock:
             self.lock()
         self.readfile()
         self.password_file.default_values["uid"] = self.getnextuid()
 
     def __str__(self):
-        return "PasswordFile: [{0} {1}]".format(self.password_file,
-            self.shadow_file)
+        return "PasswordFile: [{0} {1}]".format(
+            self.password_file, self.shadow_file
+        )
 
     def getvalue(self, template):
-        """ merge dbs... do passwd file first to get right passwd value"""
+        """merge dbs... do passwd file first to get right passwd value"""
         c = self.password_file.getvalue(template).copy()
         c.update(self.shadow_file.getvalue(template))
         return c
@@ -257,7 +282,7 @@ class PasswordFile(CfgFile):
     def updatevalue(self, template):
         copy = template.copy()
         if "password" in copy:
-            copy["password"]=""
+            copy["password"] = ""
         self.password_file.updatevalue(copy)
         self.shadow_file.updatevalue(template)
 
@@ -265,7 +290,7 @@ class PasswordFile(CfgFile):
         # ignore attempts to set passwd for passwd file
         copy = template.copy()
         if "password" in copy:
-            copy["password"]="x"
+            copy["password"] = "x"
         self.password_file.setvalue(copy)
         self.shadow_file.setvalue(template)
 
@@ -275,7 +300,7 @@ class PasswordFile(CfgFile):
 
     def getnextuid(self):
         """returns next free system (<=99) uid"""
-        uids=[]
+        uids = []
         for t in six.itervalues(self.password_file.index):
             if t[1]:
                 uids.append(t[1]["uid"])
@@ -298,7 +323,7 @@ class PasswordFile(CfgFile):
         self.shadow_file.writefile()
 
     def getuser(self, username):
-        return self.getvalue({"username" : username})
+        return self.getvalue({"username": username})
 
     def getdefaultvalues(self):
         a = self.password_file.getdefaultvalues()
@@ -311,25 +336,32 @@ class PasswordFile(CfgFile):
     def unlock(self):
         self.lockfile.unlock()
 
+
 class GroupFile(CfgFile):
-    """ manage the group file"""
+    """manage the group file"""
+
     def __init__(self, image):
         self.__image = image
-        CfgFile.__init__(self, os.path.join(image.get_root(), "etc/group"),
-                         ":",
-                         {"groupname"  : (1, None),
-                          "password"   : (2, ""),
-                          "gid"        : (3, None),
-                          "user-list"  : (4, "")
-                          },
-                         "groupname", comment_match="[+-]")
+        CfgFile.__init__(
+            self,
+            os.path.join(image.get_root(), "etc/group"),
+            ":",
+            {
+                "groupname": (1, None),
+                "password": (2, ""),
+                "gid": (3, None),
+                "user-list": (4, ""),
+            },
+            "groupname",
+            comment_match="[+-]",
+        )
 
         self.readfile()
         self.default_values["gid"] = self.getnextgid()
 
     def getnextgid(self):
         """returns next free system (<=99) gid"""
-        gids=[]
+        gids = []
         for t in six.itervalues(self.index):
             if t[1]:
                 gids.append(t[1]["gid"])
@@ -339,7 +371,7 @@ class GroupFile(CfgFile):
         raise RuntimeError("No free system gids")
 
     def adduser(self, groupname, username):
-        """"add named user to group; does not check if user exists"""
+        """ "add named user to group; does not check if user exists"""
         group = self.getvalue({"groupname": groupname})
         # If the group isn't in the database, we'll add the user to the group,
         # but unless the group is being added in the same transaction, the group
@@ -348,33 +380,36 @@ class GroupFile(CfgFile):
             group = {
                 "groupname": groupname,
                 "gid": self.__image._groupsbyname.get(groupname, ""),
-                "user-list": ""
+                "user-list": "",
             }
-        users = set(group["user-list"].replace(","," ").split())
+        users = set(group["user-list"].replace(",", " ").split())
         users.add(username)
         group["user-list"] = ",".join(users)
         self.setvalue(group)
 
     def subuser(self, groupname, username):
-        """ remove named user from group """
+        """remove named user from group"""
         group = self.getvalue({"groupname": groupname})
         if not group:
             raise RuntimeError("subuser: No such group {0}".format(groupname))
-        users = set(group["user-list"].replace(","," ").split())
+        users = set(group["user-list"].replace(",", " ").split())
         if username not in users:
-            raise RuntimeError("User {0} not in group {1}".format(
-                username, groupname))
+            raise RuntimeError(
+                "User {0} not in group {1}".format(username, groupname)
+            )
         users.remove(username)
         group["user-list"] = ",".join(users)
         self.setvalue(group)
 
     def getgroups(self, username):
-        """ return list of additional groups user belongs to """
-        return sorted([
+        """return list of additional groups user belongs to"""
+        return sorted(
+            [
                 t[1]["groupname"]
                 for t in self.index.values()
                 if t[1] is not None and username in t[1]["user-list"].split(",")
-                ])
+            ]
+        )
 
     def setgroups(self, username, groups):
         current = self.getgroups(username)
@@ -390,31 +425,32 @@ class GroupFile(CfgFile):
         for g in self.getgroups(username):
             self.subuser(g, username)
 
+
 class FtpusersFile(CfgFile):
-    """ If a username is present in this file, it denies that user
+    """If a username is present in this file, it denies that user
     the ability to use ftp"""
 
     def __init__(self, path_prefix):
-
-        CfgFile.__init__(self, os.path.join(path_prefix, "etc/ftpd/ftpusers"),
-                    " ",
-                    {"username"   : (1, None)
-                     },
-                    "username")
+        CfgFile.__init__(
+            self,
+            os.path.join(path_prefix, "etc/ftpd/ftpusers"),
+            " ",
+            {"username": (1, None)},
+            "username",
+        )
         self.readfile()
 
     def getuser(self, username):
-        """ returns true if user is allowed to use FTP - ie is NOT in file"""
-        return not 'username' in self.getvalue({"username" : username})
-
+        """returns true if user is allowed to use FTP - ie is NOT in file"""
+        return not "username" in self.getvalue({"username": username})
 
     def adduser(self, username):
-        """ add specified user to file, removing ability to use ftp"""
-        self.setvalue({"username" : username})
+        """add specified user to file, removing ability to use ftp"""
+        self.setvalue({"username": username})
 
     def subuser(self, username):
-        """ remove specified user from file """
-        self.removevalue({"username" : username})
+        """remove specified user from file"""
+        self.removevalue({"username": username})
 
     def setuser(self, username, value):
         """Add or remove 'username' from the file to turn off or on the user's
@@ -428,32 +464,38 @@ class FtpusersFile(CfgFile):
         elif value and not self.getuser(username):
             self.subuser(username)
 
+
 class UserattrFile(CfgFile):
-    """ manage the userattr file """
+    """manage the userattr file"""
+
     def __init__(self, path_prefix):
-        CfgFile.__init__(self, os.path.join(path_prefix, "etc/user_attr"),
-                         ":",
-                         {"username"    : (1, None),
-                          "qualifier"   : (2, ""),
-                          "reserved1"   : (3, ""),
-                          "reserved2"   : (4, ""),
-                          "attributes"  : (5, "")
-                          },
-                         "username")
+        CfgFile.__init__(
+            self,
+            os.path.join(path_prefix, "etc/user_attr"),
+            ":",
+            {
+                "username": (1, None),
+                "qualifier": (2, ""),
+                "reserved1": (3, ""),
+                "reserved2": (4, ""),
+                "attributes": (5, ""),
+            },
+            "username",
+        )
         self.readfile()
 
     def iscommentline(self, line):
         return len(line) == 0 or self.comment_regexp.match(line)
 
     def splitline(self, line):
-        """ return tokenized line, with attribute column a dictionary
-            w/ lists for values"""
-        cols = re.split(r"(?<=[^\\]):", line) #match non-escaped :
+        """return tokenized line, with attribute column a dictionary
+        w/ lists for values"""
+        cols = re.split(r"(?<=[^\\]):", line)  # match non-escaped :
 
         if len(cols) != len(self.column_names):
             return cols
 
-        attributes=re.split(r"(?<=[^\\]);", cols[4]) # match non escaped ;
+        attributes = re.split(r"(?<=[^\\]);", cols[4])  # match non escaped ;
 
         d = {}
         for attr in attributes:
@@ -463,19 +505,22 @@ class UserattrFile(CfgFile):
         return cols
 
     def valuetostr(self, template):
-        """ print out string; replace attribute dictionary with proper
-        string and use base class to convert entire record to a string """
-        c = template.copy() # since we're mucking w/ this....
+        """print out string; replace attribute dictionary with proper
+        string and use base class to convert entire record to a string"""
+        c = template.copy()  # since we're mucking w/ this....
         attrdict = c["attributes"]
 
-        str = "{0}".format(";".join(
-            [
-                "{0}={1}".format(key, ",".join(attrdict[key]))
-                for key in attrdict
-                ]))
+        str = "{0}".format(
+            ";".join(
+                [
+                    "{0}={1}".format(key, ",".join(attrdict[key]))
+                    for key in attrdict
+                ]
+            )
+        )
         c["attributes"] = str
         return CfgFile.valuetostr(self, c)
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/choose.py
+++ b/src/modules/choose.py
@@ -8,22 +8,24 @@
 import fnmatch
 import re
 
+
 def choose(names, pat, case_sensitive):
-        """Return the subset of names that match pat. case_sensitive determines
-        whether the regexp is compiled to be case sensitive or not.
-        """
-        # Derived from fnmatch.filter
-        result = []
-        flag = 0
-        # Setting the flag to re.I makes the regexp match using case
-        # insensitive rules.
-        if not case_sensitive:
-                flag = re.I
-        match = re.compile(fnmatch.translate(pat), flag).match
-        for name in names:
-                if match(name):
-                        result.append(name)
-        return result
+    """Return the subset of names that match pat. case_sensitive determines
+    whether the regexp is compiled to be case sensitive or not.
+    """
+    # Derived from fnmatch.filter
+    result = []
+    flag = 0
+    # Setting the flag to re.I makes the regexp match using case
+    # insensitive rules.
+    if not case_sensitive:
+        flag = re.I
+    match = re.compile(fnmatch.translate(pat), flag).match
+    for name in names:
+        if match(name):
+            result.append(name)
+    return result
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/__init__.py
+++ b/src/modules/client/__init__.py
@@ -32,227 +32,245 @@ import sys
 
 __all__ = ["global_settings"]
 
-class _LogFilter(logging.Filter):
-        def __init__(self, max_level=logging.CRITICAL):
-                logging.Filter.__init__(self)
-                self.max_level = max_level
 
-        def filter(self, record):
-                return record.levelno <= self.max_level
+class _LogFilter(logging.Filter):
+    def __init__(self, max_level=logging.CRITICAL):
+        logging.Filter.__init__(self)
+        self.max_level = max_level
+
+    def filter(self, record):
+        return record.levelno <= self.max_level
 
 
 class _StreamHandler(logging.StreamHandler):
-        """Simple subclass to ignore exceptions raised during logging output."""
+    """Simple subclass to ignore exceptions raised during logging output."""
 
-        def handleError(self, record):
-                # Ignore exceptions raised during output to stdout/stderr.
-                return
+    def handleError(self, record):
+        # Ignore exceptions raised during output to stdout/stderr.
+        return
 
 
 class GlobalSettings(object):
-        """ This class defines settings which are global
-            to the client instance """
+    """This class defines settings which are global
+    to the client instance"""
 
-        def __init__(self):
-                object.__init__(self)
-                self.__info_log_handler = None
-                self.__error_log_handler = None
-                self.__verbose = False
+    def __init__(self):
+        object.__init__(self)
+        self.__info_log_handler = None
+        self.__error_log_handler = None
+        self.__verbose = False
 
-                #
-                # These properties allow the client to describe how it
-                # has been asked to behave with respect to output.  This
-                # allows subprocess invocations (e.g. for linked images) to
-                # discover from the global settings how they are expected
-                # to behave.
-                #
-                self.client_output_verbose = 0
-                self.client_output_quiet = False
-                self.client_output_parsable_version = None
-                self.client_no_network_cache = False
+        #
+        # These properties allow the client to describe how it
+        # has been asked to behave with respect to output.  This
+        # allows subprocess invocations (e.g. for linked images) to
+        # discover from the global settings how they are expected
+        # to behave.
+        #
+        self.client_output_verbose = 0
+        self.client_output_quiet = False
+        self.client_output_parsable_version = None
+        self.client_no_network_cache = False
 
-                # runid, used by the pkg.1 client and the linked image
-                # subsystem when when generating temporary files.
-                self.client_runid = os.getpid()
+        # runid, used by the pkg.1 client and the linked image
+        # subsystem when when generating temporary files.
+        self.client_runid = os.getpid()
 
-                # file descriptor used by ProgressTracker classes when running
-                # "pkg remote" to indicate progress back to the parent/client
-                # process.
-                self.client_output_progfd = None
+        # file descriptor used by ProgressTracker classes when running
+        # "pkg remote" to indicate progress back to the parent/client
+        # process.
+        self.client_output_progfd = None
 
-                # concurrency value used for linked image recursion
-                self.client_concurrency_set = False
-                self.client_concurrency_default = 1
-                self.client_concurrency = self.client_concurrency_default
-                try:
-                        self.client_concurrency = int(os.environ.get(
-                            "PKG_CONCURRENCY",
-                            self.client_concurrency_default))
-                        if "PKG_CONCURRENCY" in os.environ:
-                                self.client_concurrency_set = True
-                        # remove PKG_CONCURRENCY from the environment so child
-                        # processes don't inherit it.
-                        os.environ.pop("PKG_CONCURRENCY", None)
-                except ValueError:
-                        pass
+        # concurrency value used for linked image recursion
+        self.client_concurrency_set = False
+        self.client_concurrency_default = 1
+        self.client_concurrency = self.client_concurrency_default
+        try:
+            self.client_concurrency = int(
+                os.environ.get(
+                    "PKG_CONCURRENCY", self.client_concurrency_default
+                )
+            )
+            if "PKG_CONCURRENCY" in os.environ:
+                self.client_concurrency_set = True
+            # remove PKG_CONCURRENCY from the environment so child
+            # processes don't inherit it.
+            os.environ.pop("PKG_CONCURRENCY", None)
+        except ValueError:
+            pass
 
-                self.client_name = None
-                self.client_args = sys.argv[:]
-                # Default maximum number of redirects received before
-                # aborting a connection.
-                self.pkg_client_max_redirect_default = 5
-                # Default number of retries per-host
-                self.pkg_client_max_timeout_default = 4
-                # Default number of seconds to give up if not connected
-                self.pkg_client_connect_timeout_default = 60
-                # Default number of seconds beneath low-speed limit before
-                # giving up.
-                self.pkg_client_lowspeed_timeout_default = 30
-                # Minimum bytes/sec before client thinks about giving up
-                # on connection.
-                self.pkg_client_lowspeed_limit = 1024
-                # Maximum number of transient errors before we abort an
-                # endpoint.
-                self.pkg_client_max_consecutive_error_default = 4
+        self.client_name = None
+        self.client_args = sys.argv[:]
+        # Default maximum number of redirects received before
+        # aborting a connection.
+        self.pkg_client_max_redirect_default = 5
+        # Default number of retries per-host
+        self.pkg_client_max_timeout_default = 4
+        # Default number of seconds to give up if not connected
+        self.pkg_client_connect_timeout_default = 60
+        # Default number of seconds beneath low-speed limit before
+        # giving up.
+        self.pkg_client_lowspeed_timeout_default = 30
+        # Minimum bytes/sec before client thinks about giving up
+        # on connection.
+        self.pkg_client_lowspeed_limit = 1024
+        # Maximum number of transient errors before we abort an
+        # endpoint.
+        self.pkg_client_max_consecutive_error_default = 4
 
-                # The location within the image of the cache for pkg.sysrepo(8)
-                self.sysrepo_pub_cache_path = \
-                    "var/cache/pkg/sysrepo_pub_cache.dat"
+        # The location within the image of the cache for pkg.sysrepo(8)
+        self.sysrepo_pub_cache_path = "var/cache/pkg/sysrepo_pub_cache.dat"
 
-                try:
-                        # Maximum number of timeouts before client gives up.
-                        self.PKG_CLIENT_MAX_TIMEOUT = int(os.environ.get(
-                            "PKG_CLIENT_MAX_TIMEOUT",
-                            self.pkg_client_max_timeout_default))
-                except ValueError:
-                        self.PKG_CLIENT_MAX_TIMEOUT = \
-                            self.pkg_client_max_timeout_default
-                try:
-                        # Number of seconds trying to connect before client
-                        # aborts.
-                        self.PKG_CLIENT_CONNECT_TIMEOUT = int(os.environ.get(
-                            "PKG_CLIENT_CONNECT_TIMEOUT",
-                            self.pkg_client_connect_timeout_default))
-                except ValueError:
-                        self.PKG_CLIENT_CONNECT_TIMEOUT = \
-                            self.pkg_client_connect_timeout_default
-                try:
-                        # Number of seconds below lowspeed limit before
-                        # transaction is aborted.
-                        self.PKG_CLIENT_LOWSPEED_TIMEOUT = int(os.environ.get(
-                            "PKG_CLIENT_LOWSPEED_TIMEOUT",
-                            self.pkg_client_lowspeed_timeout_default))
-                except ValueError:
-                        self.PKG_CLIENT_LOWSPEED_TIMEOUT = \
-                            self.pkg_client_lowspeed_timeout_default
-                try:
-                        # Number of transient errors before transaction
-                        # is aborted.
-                        self.PKG_CLIENT_MAX_CONSECUTIVE_ERROR = int(
-                            os.environ.get("PKG_CLIENT_MAX_CONSECUTIVE_ERROR",
-                            self.pkg_client_max_consecutive_error_default))
-                except ValueError:
-                        self.PKG_CLIENT_MAX_CONSECUTIVE_ERROR = \
-                            self.pkg_client_max_consecutive_error_default
-                try:
-                        # Number of redirects before a connection is
-                        # aborted.
-                        self.PKG_CLIENT_MAX_REDIRECT = int(
-                            os.environ.get("PKG_CLIENT_MAX_REDIRECT",
-                            self.pkg_client_max_redirect_default))
-                except ValueError:
-                        self.PKG_CLIENT_MAX_REDIRECT = \
-                            self.pkg_client_max_redirect_default
-                self.reset_logging()
+        try:
+            # Maximum number of timeouts before client gives up.
+            self.PKG_CLIENT_MAX_TIMEOUT = int(
+                os.environ.get(
+                    "PKG_CLIENT_MAX_TIMEOUT",
+                    self.pkg_client_max_timeout_default,
+                )
+            )
+        except ValueError:
+            self.PKG_CLIENT_MAX_TIMEOUT = self.pkg_client_max_timeout_default
+        try:
+            # Number of seconds trying to connect before client
+            # aborts.
+            self.PKG_CLIENT_CONNECT_TIMEOUT = int(
+                os.environ.get(
+                    "PKG_CLIENT_CONNECT_TIMEOUT",
+                    self.pkg_client_connect_timeout_default,
+                )
+            )
+        except ValueError:
+            self.PKG_CLIENT_CONNECT_TIMEOUT = (
+                self.pkg_client_connect_timeout_default
+            )
+        try:
+            # Number of seconds below lowspeed limit before
+            # transaction is aborted.
+            self.PKG_CLIENT_LOWSPEED_TIMEOUT = int(
+                os.environ.get(
+                    "PKG_CLIENT_LOWSPEED_TIMEOUT",
+                    self.pkg_client_lowspeed_timeout_default,
+                )
+            )
+        except ValueError:
+            self.PKG_CLIENT_LOWSPEED_TIMEOUT = (
+                self.pkg_client_lowspeed_timeout_default
+            )
+        try:
+            # Number of transient errors before transaction
+            # is aborted.
+            self.PKG_CLIENT_MAX_CONSECUTIVE_ERROR = int(
+                os.environ.get(
+                    "PKG_CLIENT_MAX_CONSECUTIVE_ERROR",
+                    self.pkg_client_max_consecutive_error_default,
+                )
+            )
+        except ValueError:
+            self.PKG_CLIENT_MAX_CONSECUTIVE_ERROR = (
+                self.pkg_client_max_consecutive_error_default
+            )
+        try:
+            # Number of redirects before a connection is
+            # aborted.
+            self.PKG_CLIENT_MAX_REDIRECT = int(
+                os.environ.get(
+                    "PKG_CLIENT_MAX_REDIRECT",
+                    self.pkg_client_max_redirect_default,
+                )
+            )
+        except ValueError:
+            self.PKG_CLIENT_MAX_REDIRECT = self.pkg_client_max_redirect_default
+        self.reset_logging()
 
-        def __get_error_log_handler(self):
-                return self.__error_log_handler
+    def __get_error_log_handler(self):
+        return self.__error_log_handler
 
-        def __get_info_log_handler(self):
-                return self.__info_log_handler
+    def __get_info_log_handler(self):
+        return self.__info_log_handler
 
-        def __get_verbose(self):
-                return self.__verbose
+    def __get_verbose(self):
+        return self.__verbose
 
-        def __set_error_log_handler(self, val):
-                logger = logging.getLogger("pkg")
-                if self.__error_log_handler:
-                        logger.removeHandler(self.__error_log_handler)
-                self.__error_log_handler = val
-                if val:
-                        logger.addHandler(val)
+    def __set_error_log_handler(self, val):
+        logger = logging.getLogger("pkg")
+        if self.__error_log_handler:
+            logger.removeHandler(self.__error_log_handler)
+        self.__error_log_handler = val
+        if val:
+            logger.addHandler(val)
 
-        def __set_info_log_handler(self, val):
-                logger = logging.getLogger("pkg")
-                if self.__info_log_handler:
-                        logger.removeHandler(self.__info_log_handler)
-                self.__info_log_handler = val
-                if val:
-                        logger.addHandler(val)
+    def __set_info_log_handler(self, val):
+        logger = logging.getLogger("pkg")
+        if self.__info_log_handler:
+            logger.removeHandler(self.__info_log_handler)
+        self.__info_log_handler = val
+        if val:
+            logger.addHandler(val)
 
-        def __set_verbose(self, val):
-                if self.__info_log_handler:
-                        if val:
-                                level = logging.DEBUG
-                        else:
-                                level = logging.INFO
-                        self.__info_log_handler.setLevel(level)
-                self.__verbose = val
+    def __set_verbose(self, val):
+        if self.__info_log_handler:
+            if val:
+                level = logging.DEBUG
+            else:
+                level = logging.INFO
+            self.__info_log_handler.setLevel(level)
+        self.__verbose = val
 
-        @property
-        def logger(self):
-		# Method could be a function; pylint: disable=R0201
-                return logging.getLogger("pkg")
+    @property
+    def logger(self):
+        # Method could be a function; pylint: disable=R0201
+        return logging.getLogger("pkg")
 
-        def reset_logging(self):
-                """Resets client logging to its default state.  This will cause
-                all logging.INFO entries to go to sys.stdout, and all entries of
-                logging.WARNING or higher to go to sys.stderr."""
+    def reset_logging(self):
+        """Resets client logging to its default state.  This will cause
+        all logging.INFO entries to go to sys.stdout, and all entries of
+        logging.WARNING or higher to go to sys.stderr."""
 
-                logger = logging.getLogger("pkg")
-                logger.setLevel(logging.DEBUG)
+        logger = logging.getLogger("pkg")
+        logger.setLevel(logging.DEBUG)
 
-                # Don't pass messages that are rejected to the root logger.
-                logger.propagate = 0
+        # Don't pass messages that are rejected to the root logger.
+        logger.propagate = 0
 
-                # By default, log all informational messages, but not warnings
-                # and above to stdout.
-                info_h = _StreamHandler(sys.stdout)
+        # By default, log all informational messages, but not warnings
+        # and above to stdout.
+        info_h = _StreamHandler(sys.stdout)
 
-                # Minimum logging level for informational messages.
-                if self.verbose:
-                        info_h.setLevel(logging.DEBUG)
-                else:
-                        info_h.setLevel(logging.INFO)
+        # Minimum logging level for informational messages.
+        if self.verbose:
+            info_h.setLevel(logging.DEBUG)
+        else:
+            info_h.setLevel(logging.INFO)
 
-                log_fmt = logging.Formatter()
+        log_fmt = logging.Formatter()
 
-                # Enforce maximum logging level for informational messages.
-                info_f = _LogFilter(logging.INFO)
-                info_h.addFilter(info_f)
-                info_h.setFormatter(log_fmt)
-                logger.addHandler(info_h)
+        # Enforce maximum logging level for informational messages.
+        info_f = _LogFilter(logging.INFO)
+        info_h.addFilter(info_f)
+        info_h.setFormatter(log_fmt)
+        logger.addHandler(info_h)
 
-                # By default, log all warnings and above to stderr.
-                error_h = _StreamHandler(sys.stderr)
-                error_h.setFormatter(log_fmt)
-                error_h.setLevel(logging.WARNING)
-                logger.addHandler(error_h)
+        # By default, log all warnings and above to stderr.
+        error_h = _StreamHandler(sys.stderr)
+        error_h.setFormatter(log_fmt)
+        error_h.setLevel(logging.WARNING)
+        logger.addHandler(error_h)
 
-                # Stash the handles so they can be removed later.
-                self.info_log_handler = info_h
-                self.error_log_handler = error_h
+        # Stash the handles so they can be removed later.
+        self.info_log_handler = info_h
+        self.error_log_handler = error_h
 
-        error_log_handler = property(__get_error_log_handler,
-            __set_error_log_handler)
+    error_log_handler = property(
+        __get_error_log_handler, __set_error_log_handler
+    )
 
-        info_log_handler = property(__get_info_log_handler,
-            __set_info_log_handler)
+    info_log_handler = property(__get_info_log_handler, __set_info_log_handler)
 
-        verbose = property(__get_verbose, __set_verbose)
+    verbose = property(__get_verbose, __set_verbose)
 
 
 global_settings = GlobalSettings()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/actuator.py
+++ b/src/modules/client/actuator.py
@@ -36,394 +36,432 @@ import six
 
 
 class Actuator(object):
-        """Actuators are action attributes that cause side effects
-        on live images when those actions are updated, installed
-        or removed.  Since no side effects are caused when the
-        affected image isn't the current root image, the OS may
-        need to cause the equivalent effect during boot.
-        This is Solaris specific for now. """
-
-        # Each set of attributes listed below determines what attributes
-        # will be scanned for a given type of operation.  These sets must
-        # match the logic found in exec_pre_actuators() and
-        # exec_post_actuators() below or planning output may be incorrect.
-        __install_actuator_attrs = set([
-            "release-note",     # conditionally include this file
-                                # in release notes
-            "refresh_fmri",     # refresh this service on any change
-            "restart_fmri",     # restart this service on any change
-        ])
-
-        __update_actuator_attrs = set([
-            "reboot-needed",    # have to reboot to update this file
-            "release-note",     # conditionally include this file
-                                # in release notes
-            "refresh_fmri",     # refresh this service on any change
-            "restart_fmri",     # restart this service on any change
-            "suspend_fmri",     # suspend this service during update
-        ])
-
-        __removal_actuator_attrs = set([
-            "reboot-needed",    # have to reboot to update this file
-            "refresh_fmri",     # refresh this service on any change
-            "restart_fmri",     # restart this service on any change
-            "disable_fmri"      # disable this service prior to removal
-        ])
-
-        __state__desc = {
-                "install": {
-                    "disable_fmri": set(),
-                    "reboot-needed": set(),
-                    "refresh_fmri": set(),
-                    "release-note": [(pkg.actions.generic.NSG, pkg.fmri.PkgFmri)],
-                    "restart_fmri": set(),
-                    "suspend_fmri": set(),
-                },
-                "removal": {
-                    "disable_fmri": set(),
-                    "reboot-needed": set(),
-                    "refresh_fmri": set(),
-                    "release-note": [(pkg.actions.generic.NSG, pkg.fmri.PkgFmri)],
-                    "restart_fmri": set(),
-                    "suspend_fmri": set(),
-                },
-                "update": {
-                    "disable_fmri": set(),
-                    "reboot-needed": set(),
-                    "refresh_fmri": set(),
-                    "release-note": [(pkg.actions.generic.NSG, pkg.fmri.PkgFmri)],
-                    "restart_fmri": set(),
-                    "suspend_fmri": set(),
-                },
-        }
-
-        def __init__(self):
-                self.install = {}
-                self.removal = {}
-                self.update =  {}
-                self.suspend_fmris = None
-                self.tmp_suspend_fmris = None
-                self.do_nothing = True
-                #self.cmd_path = ""
-                self.sync_timeout = 0
-                self.act_timed_out = False
-                self.zone = None
-
-        @staticmethod
-        def getstate(obj, je_state=None):
-                """Returns the serialized state of this object in a format
-                that that can be easily stored using JSON, pickle, etc."""
-                return pkg.misc.json_encode(Actuator.__name__, obj.__dict__,
-                    Actuator.__state__desc, je_state=je_state)
-
-        @staticmethod
-        def setstate(obj, state, jd_state=None):
-                """Update the state of this object using previously serialized
-                state obtained via getstate()."""
-
-                # get the name of the object we're dealing with
-                name = type(obj).__name__
-
-                # decode serialized state into python objects
-                state = pkg.misc.json_decode(name, state,
-                    Actuator.__state__desc, jd_state=jd_state)
-
-                # bulk update
-                obj.__dict__.update(state)
-
-        @staticmethod
-        def fromstate(state, jd_state=None):
-                """Allocate a new object using previously serialized state
-                obtained via getstate()."""
-                rv = Actuator()
-                Actuator.setstate(rv, state, jd_state)
-                return rv
-
-        def set_timeout(self, timeout):
-                """ Set actuator timeout.
-                'timeout'       Actuator timeout in seconds. The following
-                                special values are allowed:
-                                  0: don't use synchronous actuators
-                                 -1: no timeout, wait until finished
-                """
-                self.sync_timeout = timeout
-
-        def set_zone(self, zname):
-                """Specify if actuators are supposed to be run within a zone.
-                If 'zname' is None, actuators are run in the global zone,
-                otherwise actuators are run in the zone 'zname'. The caller has
-                to make sure the zone exists and is running. If there are any
-                issues with calling an actuator in the zone, it will be
-                ignored."""
-
-                self.zone = zname
-
-        @property
-        def timed_out(self):
-                return self.act_timed_out
-
-        # Defining "boolness" of a class, Python 2 uses the special method
-        # called __nonzero__() while Python 3 uses __bool__(). For Python
-        # 2 and 3 compatibility, define __bool__() only, and let
-        # __nonzero__ = __bool__
-        def __bool__(self):
-                return bool(self.install) or bool(self.removal) or \
-                    bool(self.update)
-
-        __nonzero__ = __bool__
-
-        # scan_* functions take ActionPlan arguments (see imageplan.py)
-        def scan_install(self, ap):
-                self.__scan(self.install, ap.dst, ap.p.destination_fmri,
-                    self.__install_actuator_attrs)
-
-        def scan_removal(self, ap):
-                self.__scan(self.removal, ap.src, ap.p.origin_fmri,
-                    self.__removal_actuator_attrs)
-
-        def scan_update(self, ap):
-                if ap.src:
-                        self.__scan(self.update, ap.src, ap.p.destination_fmri,
-                            self.__update_actuator_attrs)
-                self.__scan(self.update, ap.dst, ap.p.destination_fmri,
-                    self.__update_actuator_attrs)
-
-        def __scan(self, dictionary, act, fmri, actuator_attrs):
-                attrs = act.attrs
-                for a in set(attrs.keys()) & actuator_attrs:
-                        if a != "release-note":
-                                values = attrs[a]
-                                if not isinstance(values, list):
-                                        values = [values]
-                                dictionary.setdefault(a, set()).update(values)
-                        else:
-                                if act.name == "file": # ignore for non-files
-                                        dictionary.setdefault(a, list()).append(
-                                            (act, fmri))
-
-        def get_list(self):
-                """Returns a list of actuator value pairs, suitable for printing"""
-                def check_val(dfmri):
-                        # For actuators which are a single, global function that
-                        # needs to get executed, simply print true.
-                        if hasattr(dfmri, "__call__") or isinstance(dfmri, list):
-                                return [ "true" ]
-                        else:
-                                return dfmri
-
-                merge = {}
-                for d in [self.removal, self.update, self.install]:
-                        for a in d.keys():
-                                for smf in check_val(d[a]):
-                                        merge.setdefault(a, set()).add(smf)
-
-                if self.reboot_needed():
-                        merge["reboot-needed"] = set(["true"])
-                else:
-                        merge["reboot-needed"] = set(["false"])
-                return [(fmri, smf)
-                        for fmri in merge
-                        for smf in merge[fmri]
-                        ]
-
-        def get_release_note_info(self):
-                """Returns a list of tuples of possible release notes"""
-                return self.update.get("release-note", []) + \
-                    self.install.get("release-note", [])
-
-        def get_services_list(self):
-                """Returns a list of services that would be restarted"""
-                return [(fmri, smf) for fmri, smf in self.get_list()
-                    if smf not in ["true", "false"]]
-
-        def __str__(self):
-            return "\n".join("  {0:>16}: {1:}".format(fmri, smf)
-                    for fmri, smf in self.get_list())
-
-        def reboot_advised(self):
-                """Returns True if action install execution may require a
-                reboot."""
-
-                return bool("true" in self.install.get("reboot-needed", []))
-
-        def reboot_needed(self):
-                """Returns True if action execution requires a new boot
-                environment."""
-
-                return bool("true" in self.update.get("reboot-needed", [])) or \
-                    bool("true" in self.removal.get("reboot-needed", []))
-
-        def __invoke(self, func, *args, **kwargs):
-                """Execute SMF command. Remember if command timed out."""
-
-                if self.zone:
-                        kwargs["zone"] = self.zone
-
-                try:
-                        func(*args, **kwargs)
-                except smf.NonzeroExitException as nze:
-                        if nze.return_code == smf.EXIT_TIMEOUT:
-                                self.act_timed_out = True
-                        elif " ".join(nze.output).startswith("zlogin:"):
-                                # Ignore zlogin errors; the worst which
-                                # can happen is that an actuator is not run
-                                # (disable is always run with -t).
-                                # Since we only test once if the zone is
-                                # runnning, this could happen if someone shuts
-                                # down the zone while we are in the process of
-                                # executing.
-                                pass
-                        else:
-                                raise
-
-        def exec_prep(self, image):
-                if not image.is_liveroot():
-#
-# XXX don't create the marker file as illumos doesn't support self-assembly
-# milestone
-#
-#                        # we're doing off-line pkg ops; we need
-#                        # to support self-assembly milestone
-#                        # so create the necessary marker file
-#
-#                        if image.type != IMG_USER:
-#                                path = os.path.join(image.root,
-#                                    ".SELF-ASSEMBLY-REQUIRED")
-#                                # create only if it doesn't exist
-#
-#                                if not os.path.exists(path):
-#                                        os.close(os.open(path,
-#                                            os.O_EXCL  |
-#                                            os.O_CREAT |
-#                                            os.O_WRONLY))
-                        if not DebugValues.get_value("smf_cmds_dir") and \
-                            not self.zone:
-                                return
-
-                self.do_nothing = False
-
-        def exec_pre_actuators(self, image):
-                """do pre execution actuator processing..."""
-
-                if self.do_nothing:
-                        return
-
-                suspend_fmris = self.update.get("suspend_fmri", set())
-                tmp_suspend_fmris = set()
-
-                disable_fmris = self.removal.get("disable_fmri", set())
-
-                suspend_fmris = smf.check_fmris("suspend_fmri", suspend_fmris,
-                    zone=self.zone)
-                disable_fmris = smf.check_fmris("disable_fmri", disable_fmris,
-                    zone=self.zone)
-                # eliminate services not loaded or not running
-                # remember those services enabled only temporarily
-
-                for fmri in suspend_fmris.copy():
-                        state = smf.get_state(fmri, zone=self.zone)
-                        if state <= smf.SMF_SVC_TMP_ENABLED:
-                                suspend_fmris.remove(fmri)
-                        if state == smf.SMF_SVC_TMP_ENABLED:
-                                tmp_suspend_fmris.add(fmri)
-
-                for fmri in disable_fmris.copy():
-                        if smf.is_disabled(fmri, zone=self.zone):
-                                disable_fmris.remove(fmri)
-
-                self.suspend_fmris = suspend_fmris
-                self.tmp_suspend_fmris = tmp_suspend_fmris
-
-                params = tuple(suspend_fmris | tmp_suspend_fmris)
-
-                if params:
-                        self.__invoke(smf.disable, params, temporary=True)
-
-                params = tuple(disable_fmris)
-
-                if params:
-                        self.__invoke(smf.disable, params)
-
-        def exec_fail_actuators(self, image):
-                """handle a failed install"""
-
-                if self.do_nothing:
-                        return
-
-                params = tuple(self.suspend_fmris |
-                    self.tmp_suspend_fmris)
-
-                if params:
-                        self.__invoke(smf.mark, "maintenance", params)
-
-        def exec_post_actuators(self, image):
-                """do post execution actuator processing"""
-
-                if self.do_nothing:
-                        return
-
-                # handle callables first
-
-                for act in six.itervalues(self.removal):
-                        if hasattr(act, "__call__"):
-                                act()
-
-                for act in six.itervalues(self.install):
-                        if hasattr(act, "__call__"):
-                                act()
-
-                for act in six.itervalues(self.update):
-                        if hasattr(act, "__call__"):
-                                act()
-
-
-                refresh_fmris = self.removal.get("refresh_fmri", set()) | \
-                    self.update.get("refresh_fmri", set()) | \
-                    self.install.get("refresh_fmri", set())
-
-                restart_fmris = self.removal.get("restart_fmri", set()) | \
-                    self.update.get("restart_fmri", set()) | \
-                    self.install.get("restart_fmri", set())
-
-                refresh_fmris = smf.check_fmris("refresh_fmri", refresh_fmris,
-                    zone=self.zone)
-                restart_fmris = smf.check_fmris("restart_fmri", restart_fmris,
-                    zone=self.zone)
-
-                # ignore services not present or not
-                # enabled
-
-                for fmri in refresh_fmris.copy():
-                        if smf.is_disabled(fmri, zone=self.zone):
-                                refresh_fmris.remove(fmri)
-
-                params = tuple(refresh_fmris)
-
-                if params:
-                        self.__invoke(smf.refresh, params, sync_timeout=self.sync_timeout)
-
-                for fmri in restart_fmris.copy():
-                        if smf.is_disabled(fmri, zone=self.zone):
-                                restart_fmris.remove(fmri)
-
-                params = tuple(restart_fmris)
-                if params:
-                        self.__invoke(smf.restart, params, sync_timeout=self.sync_timeout)
-
-                # reenable suspended services that were running
-                # be sure to not enable services that weren't running
-                # and temp. enable those services that were in that
-                # state.
-
-                params = tuple(self.suspend_fmris)
-                if params:
-                        self.__invoke(smf.enable, params, sync_timeout=self.sync_timeout)
-
-                params = tuple(self.tmp_suspend_fmris)
-                if params:
-                        self.__invoke(smf.enable, params, temporary=True,
-                            sync_timeout=self.sync_timeout)
+    """Actuators are action attributes that cause side effects
+    on live images when those actions are updated, installed
+    or removed.  Since no side effects are caused when the
+    affected image isn't the current root image, the OS may
+    need to cause the equivalent effect during boot.
+    This is Solaris specific for now."""
+
+    # Each set of attributes listed below determines what attributes
+    # will be scanned for a given type of operation.  These sets must
+    # match the logic found in exec_pre_actuators() and
+    # exec_post_actuators() below or planning output may be incorrect.
+    __install_actuator_attrs = set(
+        [
+            "release-note",  # conditionally include this file
+            # in release notes
+            "refresh_fmri",  # refresh this service on any change
+            "restart_fmri",  # restart this service on any change
+        ]
+    )
+
+    __update_actuator_attrs = set(
+        [
+            "reboot-needed",  # have to reboot to update this file
+            "release-note",  # conditionally include this file
+            # in release notes
+            "refresh_fmri",  # refresh this service on any change
+            "restart_fmri",  # restart this service on any change
+            "suspend_fmri",  # suspend this service during update
+        ]
+    )
+
+    __removal_actuator_attrs = set(
+        [
+            "reboot-needed",  # have to reboot to update this file
+            "refresh_fmri",  # refresh this service on any change
+            "restart_fmri",  # restart this service on any change
+            "disable_fmri",  # disable this service prior to removal
+        ]
+    )
+
+    __state__desc = {
+        "install": {
+            "disable_fmri": set(),
+            "reboot-needed": set(),
+            "refresh_fmri": set(),
+            "release-note": [(pkg.actions.generic.NSG, pkg.fmri.PkgFmri)],
+            "restart_fmri": set(),
+            "suspend_fmri": set(),
+        },
+        "removal": {
+            "disable_fmri": set(),
+            "reboot-needed": set(),
+            "refresh_fmri": set(),
+            "release-note": [(pkg.actions.generic.NSG, pkg.fmri.PkgFmri)],
+            "restart_fmri": set(),
+            "suspend_fmri": set(),
+        },
+        "update": {
+            "disable_fmri": set(),
+            "reboot-needed": set(),
+            "refresh_fmri": set(),
+            "release-note": [(pkg.actions.generic.NSG, pkg.fmri.PkgFmri)],
+            "restart_fmri": set(),
+            "suspend_fmri": set(),
+        },
+    }
+
+    def __init__(self):
+        self.install = {}
+        self.removal = {}
+        self.update = {}
+        self.suspend_fmris = None
+        self.tmp_suspend_fmris = None
+        self.do_nothing = True
+        # self.cmd_path = ""
+        self.sync_timeout = 0
+        self.act_timed_out = False
+        self.zone = None
+
+    @staticmethod
+    def getstate(obj, je_state=None):
+        """Returns the serialized state of this object in a format
+        that that can be easily stored using JSON, pickle, etc."""
+        return pkg.misc.json_encode(
+            Actuator.__name__,
+            obj.__dict__,
+            Actuator.__state__desc,
+            je_state=je_state,
+        )
+
+    @staticmethod
+    def setstate(obj, state, jd_state=None):
+        """Update the state of this object using previously serialized
+        state obtained via getstate()."""
+
+        # get the name of the object we're dealing with
+        name = type(obj).__name__
+
+        # decode serialized state into python objects
+        state = pkg.misc.json_decode(
+            name, state, Actuator.__state__desc, jd_state=jd_state
+        )
+
+        # bulk update
+        obj.__dict__.update(state)
+
+    @staticmethod
+    def fromstate(state, jd_state=None):
+        """Allocate a new object using previously serialized state
+        obtained via getstate()."""
+        rv = Actuator()
+        Actuator.setstate(rv, state, jd_state)
+        return rv
+
+    def set_timeout(self, timeout):
+        """Set actuator timeout.
+        'timeout'       Actuator timeout in seconds. The following
+                        special values are allowed:
+                          0: don't use synchronous actuators
+                         -1: no timeout, wait until finished
+        """
+        self.sync_timeout = timeout
+
+    def set_zone(self, zname):
+        """Specify if actuators are supposed to be run within a zone.
+        If 'zname' is None, actuators are run in the global zone,
+        otherwise actuators are run in the zone 'zname'. The caller has
+        to make sure the zone exists and is running. If there are any
+        issues with calling an actuator in the zone, it will be
+        ignored."""
+
+        self.zone = zname
+
+    @property
+    def timed_out(self):
+        return self.act_timed_out
+
+    # Defining "boolness" of a class, Python 2 uses the special method
+    # called __nonzero__() while Python 3 uses __bool__(). For Python
+    # 2 and 3 compatibility, define __bool__() only, and let
+    # __nonzero__ = __bool__
+    def __bool__(self):
+        return bool(self.install) or bool(self.removal) or bool(self.update)
+
+    __nonzero__ = __bool__
+
+    # scan_* functions take ActionPlan arguments (see imageplan.py)
+    def scan_install(self, ap):
+        self.__scan(
+            self.install,
+            ap.dst,
+            ap.p.destination_fmri,
+            self.__install_actuator_attrs,
+        )
+
+    def scan_removal(self, ap):
+        self.__scan(
+            self.removal,
+            ap.src,
+            ap.p.origin_fmri,
+            self.__removal_actuator_attrs,
+        )
+
+    def scan_update(self, ap):
+        if ap.src:
+            self.__scan(
+                self.update,
+                ap.src,
+                ap.p.destination_fmri,
+                self.__update_actuator_attrs,
+            )
+        self.__scan(
+            self.update,
+            ap.dst,
+            ap.p.destination_fmri,
+            self.__update_actuator_attrs,
+        )
+
+    def __scan(self, dictionary, act, fmri, actuator_attrs):
+        attrs = act.attrs
+        for a in set(attrs.keys()) & actuator_attrs:
+            if a != "release-note":
+                values = attrs[a]
+                if not isinstance(values, list):
+                    values = [values]
+                dictionary.setdefault(a, set()).update(values)
+            else:
+                if act.name == "file":  # ignore for non-files
+                    dictionary.setdefault(a, list()).append((act, fmri))
+
+    def get_list(self):
+        """Returns a list of actuator value pairs, suitable for printing"""
+
+        def check_val(dfmri):
+            # For actuators which are a single, global function that
+            # needs to get executed, simply print true.
+            if hasattr(dfmri, "__call__") or isinstance(dfmri, list):
+                return ["true"]
+            else:
+                return dfmri
+
+        merge = {}
+        for d in [self.removal, self.update, self.install]:
+            for a in d.keys():
+                for smf in check_val(d[a]):
+                    merge.setdefault(a, set()).add(smf)
+
+        if self.reboot_needed():
+            merge["reboot-needed"] = set(["true"])
+        else:
+            merge["reboot-needed"] = set(["false"])
+        return [(fmri, smf) for fmri in merge for smf in merge[fmri]]
+
+    def get_release_note_info(self):
+        """Returns a list of tuples of possible release notes"""
+        return self.update.get("release-note", []) + self.install.get(
+            "release-note", []
+        )
+
+    def get_services_list(self):
+        """Returns a list of services that would be restarted"""
+        return [
+            (fmri, smf)
+            for fmri, smf in self.get_list()
+            if smf not in ["true", "false"]
+        ]
+
+    def __str__(self):
+        return "\n".join(
+            "  {0:>16}: {1:}".format(fmri, smf) for fmri, smf in self.get_list()
+        )
+
+    def reboot_advised(self):
+        """Returns True if action install execution may require a
+        reboot."""
+
+        return bool("true" in self.install.get("reboot-needed", []))
+
+    def reboot_needed(self):
+        """Returns True if action execution requires a new boot
+        environment."""
+
+        return bool("true" in self.update.get("reboot-needed", [])) or bool(
+            "true" in self.removal.get("reboot-needed", [])
+        )
+
+    def __invoke(self, func, *args, **kwargs):
+        """Execute SMF command. Remember if command timed out."""
+
+        if self.zone:
+            kwargs["zone"] = self.zone
+
+        try:
+            func(*args, **kwargs)
+        except smf.NonzeroExitException as nze:
+            if nze.return_code == smf.EXIT_TIMEOUT:
+                self.act_timed_out = True
+            elif " ".join(nze.output).startswith("zlogin:"):
+                # Ignore zlogin errors; the worst which
+                # can happen is that an actuator is not run
+                # (disable is always run with -t).
+                # Since we only test once if the zone is
+                # runnning, this could happen if someone shuts
+                # down the zone while we are in the process of
+                # executing.
+                pass
+            else:
+                raise
+
+    def exec_prep(self, image):
+        if not image.is_liveroot():
+            #
+            # XXX don't create the marker file as illumos doesn't support self-assembly
+            # milestone
+            #
+            #                        # we're doing off-line pkg ops; we need
+            #                        # to support self-assembly milestone
+            #                        # so create the necessary marker file
+            #
+            #                        if image.type != IMG_USER:
+            #                                path = os.path.join(image.root,
+            #                                    ".SELF-ASSEMBLY-REQUIRED")
+            #                                # create only if it doesn't exist
+            #
+            #                                if not os.path.exists(path):
+            #                                        os.close(os.open(path,
+            #                                            os.O_EXCL  |
+            #                                            os.O_CREAT |
+            #                                            os.O_WRONLY))
+            if not DebugValues.get_value("smf_cmds_dir") and not self.zone:
+                return
+
+        self.do_nothing = False
+
+    def exec_pre_actuators(self, image):
+        """do pre execution actuator processing..."""
+
+        if self.do_nothing:
+            return
+
+        suspend_fmris = self.update.get("suspend_fmri", set())
+        tmp_suspend_fmris = set()
+
+        disable_fmris = self.removal.get("disable_fmri", set())
+
+        suspend_fmris = smf.check_fmris(
+            "suspend_fmri", suspend_fmris, zone=self.zone
+        )
+        disable_fmris = smf.check_fmris(
+            "disable_fmri", disable_fmris, zone=self.zone
+        )
+        # eliminate services not loaded or not running
+        # remember those services enabled only temporarily
+
+        for fmri in suspend_fmris.copy():
+            state = smf.get_state(fmri, zone=self.zone)
+            if state <= smf.SMF_SVC_TMP_ENABLED:
+                suspend_fmris.remove(fmri)
+            if state == smf.SMF_SVC_TMP_ENABLED:
+                tmp_suspend_fmris.add(fmri)
+
+        for fmri in disable_fmris.copy():
+            if smf.is_disabled(fmri, zone=self.zone):
+                disable_fmris.remove(fmri)
+
+        self.suspend_fmris = suspend_fmris
+        self.tmp_suspend_fmris = tmp_suspend_fmris
+
+        params = tuple(suspend_fmris | tmp_suspend_fmris)
+
+        if params:
+            self.__invoke(smf.disable, params, temporary=True)
+
+        params = tuple(disable_fmris)
+
+        if params:
+            self.__invoke(smf.disable, params)
+
+    def exec_fail_actuators(self, image):
+        """handle a failed install"""
+
+        if self.do_nothing:
+            return
+
+        params = tuple(self.suspend_fmris | self.tmp_suspend_fmris)
+
+        if params:
+            self.__invoke(smf.mark, "maintenance", params)
+
+    def exec_post_actuators(self, image):
+        """do post execution actuator processing"""
+
+        if self.do_nothing:
+            return
+
+        # handle callables first
+
+        for act in six.itervalues(self.removal):
+            if hasattr(act, "__call__"):
+                act()
+
+        for act in six.itervalues(self.install):
+            if hasattr(act, "__call__"):
+                act()
+
+        for act in six.itervalues(self.update):
+            if hasattr(act, "__call__"):
+                act()
+
+        refresh_fmris = (
+            self.removal.get("refresh_fmri", set())
+            | self.update.get("refresh_fmri", set())
+            | self.install.get("refresh_fmri", set())
+        )
+
+        restart_fmris = (
+            self.removal.get("restart_fmri", set())
+            | self.update.get("restart_fmri", set())
+            | self.install.get("restart_fmri", set())
+        )
+
+        refresh_fmris = smf.check_fmris(
+            "refresh_fmri", refresh_fmris, zone=self.zone
+        )
+        restart_fmris = smf.check_fmris(
+            "restart_fmri", restart_fmris, zone=self.zone
+        )
+
+        # ignore services not present or not
+        # enabled
+
+        for fmri in refresh_fmris.copy():
+            if smf.is_disabled(fmri, zone=self.zone):
+                refresh_fmris.remove(fmri)
+
+        params = tuple(refresh_fmris)
+
+        if params:
+            self.__invoke(smf.refresh, params, sync_timeout=self.sync_timeout)
+
+        for fmri in restart_fmris.copy():
+            if smf.is_disabled(fmri, zone=self.zone):
+                restart_fmris.remove(fmri)
+
+        params = tuple(restart_fmris)
+        if params:
+            self.__invoke(smf.restart, params, sync_timeout=self.sync_timeout)
+
+        # reenable suspended services that were running
+        # be sure to not enable services that weren't running
+        # and temp. enable those services that were in that
+        # state.
+
+        params = tuple(self.suspend_fmris)
+        if params:
+            self.__invoke(smf.enable, params, sync_timeout=self.sync_timeout)
+
+        params = tuple(self.tmp_suspend_fmris)
+        if params:
+            self.__invoke(
+                smf.enable,
+                params,
+                temporary=True,
+                sync_timeout=self.sync_timeout,
+            )
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/api.py
+++ b/src/modules/client/api.py
@@ -98,28 +98,33 @@ import pkg.portable as portable
 import pkg.search_errors as search_errors
 import pkg.version
 
-from pkg.api_common import (PackageInfo, LicenseInfo, PackageCategory,
-    _get_pkg_cat_data)
+from pkg.api_common import (
+    PackageInfo,
+    LicenseInfo,
+    PackageCategory,
+    _get_pkg_cat_data,
+)
 from pkg.client import global_settings
 from pkg.client.debugvalues import DebugValues
-from pkg.client.pkgdefs import * # pylint: disable=W0401
+from pkg.client.pkgdefs import *  # pylint: disable=W0401
 from pkg.smf import NonzeroExitException
 
 # we import PlanDescription here even though it isn't used so that consumers
 # of the api still have access to the class definition and are able to do
 # things like help(pkg.client.api.PlanDescription)
-from pkg.client.plandesc import PlanDescription # pylint: disable=W0611
+from pkg.client.plandesc import PlanDescription  # pylint: disable=W0611
 
 CURRENT_API_VERSION = 84
-COMPATIBLE_API_VERSIONS = frozenset([72, 73, 74, 75, 76, 77, 78, 79, 80, 81,
-    82, 83, CURRENT_API_VERSION])
+COMPATIBLE_API_VERSIONS = frozenset(
+    [72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, CURRENT_API_VERSION]
+)
 CURRENT_P5I_VERSION = 1
 
 # Image type constants.
-IMG_TYPE_NONE = imgtypes.IMG_NONE # No image.
-IMG_TYPE_ENTIRE = imgtypes.IMG_ENTIRE # Full image ('/').
+IMG_TYPE_NONE = imgtypes.IMG_NONE  # No image.
+IMG_TYPE_ENTIRE = imgtypes.IMG_ENTIRE  # Full image ('/').
 IMG_TYPE_PARTIAL = imgtypes.IMG_PARTIAL  # Not yet implemented.
-IMG_TYPE_USER = imgtypes.IMG_USER # Not '/'; some other location.
+IMG_TYPE_USER = imgtypes.IMG_USER  # Not '/'; some other location.
 
 # History result constants.
 RESULT_CANCELED = history.RESULT_CANCELED
@@ -143,6007 +148,6626 @@ AUTO_BE_NAME_TIME_PREFIX = "time:"
 # Globals.
 logger = global_settings.logger
 
+
 class _LockedGenerator(object):
-        """This is a private class and should not be used by API consumers.
+    """This is a private class and should not be used by API consumers.
 
-        This decorator class wraps API generator functions, managing the
-        activity and cancelation locks.  Due to implementation differences
-        in the decorator protocol, the decorator must be used with
-        parenthesis in order for this to function correctly.  Always
-        decorate functions @_LockedGenerator()."""
+    This decorator class wraps API generator functions, managing the
+    activity and cancelation locks.  Due to implementation differences
+    in the decorator protocol, the decorator must be used with
+    parenthesis in order for this to function correctly.  Always
+    decorate functions @_LockedGenerator()."""
 
-        def __init__(self, *d_args, **d_kwargs):
-                object.__init__(self)
+    def __init__(self, *d_args, **d_kwargs):
+        object.__init__(self)
 
-        def __call__(self, f):
-                def wrapper(*fargs, **f_kwargs):
-                        instance, fargs = fargs[0], fargs[1:]
-                        instance._acquire_activity_lock()
-                        instance._enable_cancel()
+    def __call__(self, f):
+        def wrapper(*fargs, **f_kwargs):
+            instance, fargs = fargs[0], fargs[1:]
+            instance._acquire_activity_lock()
+            instance._enable_cancel()
 
-                        clean_exit = True
-                        canceled = False
-                        try:
-                                for v in f(instance, *fargs, **f_kwargs):
-                                        yield v
-                        except GeneratorExit:
-                                return
-                        except apx.CanceledException:
-                                canceled = True
-                                raise
-                        except Exception:
-                                clean_exit = False
-                                raise
-                        finally:
-                                if canceled:
-                                        instance._cancel_done()
-                                elif clean_exit:
-                                        try:
-                                                instance._disable_cancel()
-                                        except apx.CanceledException:
-                                                instance._cancel_done()
-                                                instance._activity_lock.release()
-                                                raise
-                                else:
-                                        instance._cancel_cleanup_exception()
-                                instance._activity_lock.release()
+            clean_exit = True
+            canceled = False
+            try:
+                for v in f(instance, *fargs, **f_kwargs):
+                    yield v
+            except GeneratorExit:
+                return
+            except apx.CanceledException:
+                canceled = True
+                raise
+            except Exception:
+                clean_exit = False
+                raise
+            finally:
+                if canceled:
+                    instance._cancel_done()
+                elif clean_exit:
+                    try:
+                        instance._disable_cancel()
+                    except apx.CanceledException:
+                        instance._cancel_done()
+                        instance._activity_lock.release()
+                        raise
+                else:
+                    instance._cancel_cleanup_exception()
+                instance._activity_lock.release()
 
-                return wrapper
+        return wrapper
 
 
 class _LockedCancelable(object):
-        """This is a private class and should not be used by API consumers.
+    """This is a private class and should not be used by API consumers.
 
-        This decorator class wraps non-generator cancelable API functions,
-        managing the activity and cancelation locks.  Due to implementation
-        differences in the decorator protocol, the decorator must be used with
-        parenthesis in order for this to function correctly.  Always
-        decorate functions @_LockedCancelable()."""
+    This decorator class wraps non-generator cancelable API functions,
+    managing the activity and cancelation locks.  Due to implementation
+    differences in the decorator protocol, the decorator must be used with
+    parenthesis in order for this to function correctly.  Always
+    decorate functions @_LockedCancelable()."""
 
-        def __init__(self, *d_args, **d_kwargs):
-                object.__init__(self)
+    def __init__(self, *d_args, **d_kwargs):
+        object.__init__(self)
 
-        def __call__(self, f):
-                def wrapper(*fargs, **f_kwargs):
-                        instance, fargs = fargs[0], fargs[1:]
-                        instance._acquire_activity_lock()
-                        instance._enable_cancel()
+    def __call__(self, f):
+        def wrapper(*fargs, **f_kwargs):
+            instance, fargs = fargs[0], fargs[1:]
+            instance._acquire_activity_lock()
+            instance._enable_cancel()
 
-                        clean_exit = True
-                        canceled = False
-                        try:
-                                return f(instance, *fargs, **f_kwargs)
-                        except apx.CanceledException:
-                                canceled = True
-                                raise
-                        except Exception:
-                                clean_exit = False
-                                raise
-                        finally:
-                                instance._img.cleanup_downloads()
-                                try:
-                                        if int(os.environ.get("PKG_DUMP_STATS",
-                                            0)) > 0:
-                                                instance._img.transport.stats.dump()
-                                except ValueError:
-                                        # Don't generate stats if an invalid
-                                        # value is supplied.
-                                        pass
+            clean_exit = True
+            canceled = False
+            try:
+                return f(instance, *fargs, **f_kwargs)
+            except apx.CanceledException:
+                canceled = True
+                raise
+            except Exception:
+                clean_exit = False
+                raise
+            finally:
+                instance._img.cleanup_downloads()
+                try:
+                    if int(os.environ.get("PKG_DUMP_STATS", 0)) > 0:
+                        instance._img.transport.stats.dump()
+                except ValueError:
+                    # Don't generate stats if an invalid
+                    # value is supplied.
+                    pass
 
-                                if canceled:
-                                        instance._cancel_done()
-                                elif clean_exit:
-                                        try:
-                                                instance._disable_cancel()
-                                        except apx.CanceledException:
-                                                instance._cancel_done()
-                                                # if f() acquired the image
-                                                # lock, drop it
-                                                if instance._img.locked:
-                                                        instance._img.unlock()
-                                                instance._activity_lock.release()
-                                                raise
-                                else:
-                                        instance._cancel_cleanup_exception()
-                                # if f() acquired the image lock, drop it
-                                if instance._img.locked:
-                                        instance._img.unlock()
-                                instance._activity_lock.release()
+                if canceled:
+                    instance._cancel_done()
+                elif clean_exit:
+                    try:
+                        instance._disable_cancel()
+                    except apx.CanceledException:
+                        instance._cancel_done()
+                        # if f() acquired the image
+                        # lock, drop it
+                        if instance._img.locked:
+                            instance._img.unlock()
+                        instance._activity_lock.release()
+                        raise
+                else:
+                    instance._cancel_cleanup_exception()
+                # if f() acquired the image lock, drop it
+                if instance._img.locked:
+                    instance._img.unlock()
+                instance._activity_lock.release()
 
-                return wrapper
+        return wrapper
 
 
 class ImageInterface(object):
-        """This class presents an interface to images that clients may use.
-        There is a specific order of methods which must be used to install
-        or uninstall packages, or update an image.  First, a gen_plan_* method
-        must be called.  After that method completes successfully, describe may
-        be called, and prepare must be called.  Finally, execute_plan may be
-        called to implement the previous created plan.  The other methods
-        do not have an ordering imposed upon them, and may be used as
-        needed.  Cancel may only be invoked while a cancelable method is
-        running."""
-
-        FACET_ALL = 0
-        FACET_IMAGE = 1
-        FACET_INSTALLED = 2
-
-        FACET_SRC_SYSTEM = pkg.facet.Facets.FACET_SRC_SYSTEM
-        FACET_SRC_LOCAL = pkg.facet.Facets.FACET_SRC_LOCAL
-        FACET_SRC_PARENT = pkg.facet.Facets.FACET_SRC_PARENT
-
-        # Constants used to reference specific values that info can return.
-        INFO_FOUND = 0
-        INFO_MISSING = 1
-        INFO_ILLEGALS = 3
-
-        LIST_ALL = 0
-        LIST_INSTALLED = 1
-        LIST_INSTALLED_NEWEST = 2
-        LIST_NEWEST = 3
-        LIST_UPGRADABLE = 4
-        LIST_REMOVABLE = 5
-
-        MATCH_EXACT = 0
-        MATCH_FMRI = 1
-        MATCH_GLOB = 2
-
-        VARIANT_ALL = 0
-        VARIANT_ALL_POSSIBLE = 1
-        VARIANT_IMAGE = 2
-        VARIANT_IMAGE_POSSIBLE = 3
-        VARIANT_INSTALLED = 4
-        VARIANT_INSTALLED_POSSIBLE = 5
-
-        def __init__(self, img_path, version_id, progresstracker,
-            cancel_state_callable, pkg_client_name, exact_match=True,
-            cmdpath=None):
-                """Constructs an ImageInterface object.
-
-                'img_path' is the absolute path to an existing image or to a
-                path from which to start looking for an image.  To control this
-                behaviour use the 'exact_match' parameter.
-
-                'version_id' indicates the version of the api the client is
-                expecting to use.
-
-                'progresstracker' is the ProgressTracker object the client wants
-                the api to use for UI progress callbacks.
-
-                'cancel_state_callable' is an optional function reference that
-                will be called if the cancellable status of an operation
-                changes.
-
-                'pkg_client_name' is a string containing the name of the client,
-                such as "pkg".
-
-                'exact_match' is a boolean indicating whether the API should
-                attempt to find a usable image starting from the specified
-                directory, going up to the filesystem root until it finds one.
-                If set to True, an image must exist at the location indicated
-                by 'img_path'.
-                """
-
-                if version_id not in COMPATIBLE_API_VERSIONS:
-                        raise apx.VersionException(CURRENT_API_VERSION,
-                            version_id)
-
-                if sys.path[0].startswith("/dev/fd/"):
-                        #
-                        # Normally when the kernel forks off an interpreted
-                        # program, it executes the interpreter with the first
-                        # argument being the path to the interpreted program
-                        # we're executing.  But in the case of suid scripts
-                        # this presents a security problem because that path
-                        # could be updated after exec but before the
-                        # interpreter opens reads the program.  To avoid this
-                        # race, for suid script the kernel replaces the name
-                        # of the interpreted program with /dev/fd/###, and
-                        # opens the interpreted program such that it can be
-                        # read from the specified file descriptor device node.
-                        # So if we detect that path[0] (which should be then
-                        # interpreted program name) is a /dev/fd/ path, that
-                        # means we're being run as an suid script, which we
-                        # don't really want to support.  (Since this breaks
-                        # our subsequent code that attempt to determine the
-                        # name of the executable we are running as.)
-                        #
-                        raise apx.SuidUnsupportedError()
-
-                # The image's History object will use client_name from
-                # global_settings, but if the program forgot to set it,
-                # we'll go ahead and do so here.
-                if global_settings.client_name is None:
-                        global_settings.client_name = pkg_client_name
-
-                if cmdpath is None:
-                        cmdpath = misc.api_cmdpath()
-                self.cmdpath = cmdpath
-
-                # prevent brokeness in the test suite
-                if self.cmdpath and \
-                    "PKG_NO_RUNPY_CMDPATH" in os.environ and \
-                    self.cmdpath.endswith(os.sep + "run.py"):
-                        raise RuntimeError("""
-An ImageInterface object was allocated from within ipkg test suite and
-cmdpath was not explicitly overridden.  Please make sure to set
-explicitly set cmdpath when allocating an ImageInterface object, or
-override cmdpath when allocating an Image object by setting PKG_CMDPATH
-in the environment or by setting simulate_cmdpath in DebugValues.""")
-
-                if isinstance(img_path, six.string_types):
-                        # Store this for reset().
-                        self._img_path = img_path
-                        self._img = image.Image(img_path,
-                            progtrack=progresstracker,
-                            user_provided_dir=exact_match,
-                            cmdpath=self.cmdpath)
-
-                        # Store final image path.
-                        self._img_path = self._img.get_root()
-                elif isinstance(img_path, image.Image):
-                        # This is a temporary, special case for client.py
-                        # until the image api is complete.
-                        self._img = img_path
-                        self._img_path = img_path.get_root()
-                else:
-                        # API consumer passed an unknown type for img_path.
-                        raise TypeError(_("Unknown img_path type."))
-
-                self.__progresstracker = progresstracker
-                lin = None
-                if self._img.linked.ischild():
-                        lin = self._img.linked.child_name
-                self.__progresstracker.set_linked_name(lin)
-
-                self.__cancel_state_callable = cancel_state_callable
-                self.__plan_type = None
-                self.__api_op = None
-                self.__plan_desc = None
-                self.__planned_children = False
-                self.__prepared = False
-                self.__executed = False
-                self.__be_activate = True
-                self.__backup_be_name = None
-                self.__be_name = None
-                self.__can_be_canceled = False
-                self.__canceling = False
-                self._activity_lock = pkg.nrlock.NRLock()
-                self.__blocking_locks = False
-                self._img.blocking_locks = self.__blocking_locks
-                self.__cancel_lock = pkg.nrlock.NRLock()
-                self.__cancel_cv = threading.Condition(self.__cancel_lock)
-                self.__backup_be = None # create if needed
-                self.__new_be = None # create if needed
-                self.__alt_sources = {}
-
-        def __set_blocking_locks(self, value):
-                self._activity_lock.acquire()
-                self.__blocking_locks = value
-                self._img.blocking_locks = value
-                self._activity_lock.release()
-
-        def __set_img_alt_sources(self, repos):
-                """Private helper function to change image to use alternate
-                package sources if applicable."""
-
-                # When using alternate package sources with the image, the
-                # result is a composite of the package data already known
-                # by the image and the alternate sources.
-                if repos:
-                        self._img.set_alt_pkg_sources(
-                            self.__get_alt_pkg_data(repos))
-                else:
-                        self._img.set_alt_pkg_sources(None)
-
-        @_LockedCancelable()
-        def set_alt_repos(self, repos):
-                """Public function to specify alternate package sources."""
-                self.__set_img_alt_sources(repos)
-
-        blocking_locks = property(lambda self: self.__blocking_locks,
-            __set_blocking_locks, doc="A boolean value indicating whether "
-            "the API should wait until the image interface can be locked if "
-            "it is in use by another thread or process.  Clients should be "
-            "aware that there is no timeout mechanism in place if blocking is "
-            "enabled, and so should take steps to remain responsive to user "
-            "input or provide a way for users to cancel operations.")
-
-        @property
-        def excludes(self):
-                """The list of excludes for the image."""
-                return self._img.list_excludes()
-
-        @property
-        def img(self):
-                """Private; public access to this property will be removed at
-                a later date.  Do not use."""
-                return self._img
-
-        @property
-        def img_type(self):
-                """Returns the IMG_TYPE constant for the image's type."""
-                if not self._img:
-                        return None
-                return self._img.image_type(self._img.root)
-
-        @property
-        def is_liveroot(self):
-                """A boolean indicating whether the image to be modified is
-                for the live system root."""
-                return self._img.is_liveroot()
-
-        @property
-        def is_zone(self):
-                """A boolean value indicating whether the image is a zone."""
-                return self._img.is_zone()
-
-        @property
-        def is_active_liveroot_be(self):
-                """A boolean indicating whether the image to be modified is
-                the active BE for the system's root image."""
-
-                if not self._img.is_liveroot():
-                        return False
-
-                try:
-                        be_name, be_uuid = bootenv.BootEnv.get_be_name(
-                            self._img.root)
-                        return be_name == \
-                            bootenv.BootEnv.get_activated_be_name(bootnext=True)
-                except apx.BEException:
-                        # If boot environment logic isn't supported, return
-                        # False.  This is necessary for user images and for
-                        # the test suite.
-                        return False
-
-        @property
-        def img_plandir(self):
-                """A path to the image planning directory."""
-                plandir = self._img.plandir
-                misc.makedirs(plandir)
-                return plandir
-
-        @property
-        def last_modified(self):
-                """A datetime object representing when the image's metadata was
-                last updated."""
-
-                return self._img.get_last_modified()
-
-        def __set_progresstracker(self, value):
-                self._activity_lock.acquire()
-                self.__progresstracker = value
-
-                # tell the progress tracker about this image's name
-                lin = None
-                if self._img.linked.ischild():
-                        lin = self._img.linked.child_name
-                self.__progresstracker.set_linked_name(lin)
-
-                self._activity_lock.release()
-
-        progresstracker = property(lambda self: self.__progresstracker,
-            __set_progresstracker, doc="The current ProgressTracker object.  "
-            "This value should only be set when no other API calls are in "
-            "progress.")
-
-        @property
-        def mediators(self):
-                """A dictionary of the mediators and their configured version
-                and implementation of the form:
-
-                   {
-                       mediator-name: {
-                           "version": mediator-version-string,
-                           "version-source": (site|vendor|system|local),
-                           "implementation": mediator-implementation-string,
-                           "implementation-source": (site|vendor|system|local),
-                       }
-                   }
-
-                  'version' is an optional string that specifies the version
-                   (expressed as a dot-separated sequence of non-negative
-                   integers) of the mediator for use.
-
-                   'version-source' is a string describing the source of the
-                   selected version configuration.  It indicates how the
-                   version component of the mediation was selected.
-
-                   'implementation' is an optional string that specifies the
-                   implementation of the mediator for use in addition to or
-                   instead of 'version'.
-
-                   'implementation-source' is a string describing the source of
-                   the selected implementation configuration.  It indicates how
-                   the implementation component of the mediation was selected.
-                 """
-
-                ret = {}
-                for m, mvalues in six.iteritems(self._img.cfg.mediators):
-                        ret[m] = copy.copy(mvalues)
-                        if "version" in ret[m]:
-                                # Don't expose internal Version object to
-                                # external consumers.
-                                ret[m]["version"] = \
-                                    ret[m]["version"].get_short_version()
-                        if "implementation-version" in ret[m]:
-                                # Don't expose internal Version object to
-                                # external consumers.
-                                ret[m]["implementation-version"] = \
-                                    ret[m]["implementation-version"].get_short_version()
-                return ret
-
-        @property
-        def root(self):
-                """The absolute pathname of the filesystem root of the image.
-                This property is read-only."""
-                if not self._img:
-                        return None
-                return self._img.root
-
-        @staticmethod
-        def check_be_name(be_name):
-                bootenv.BootEnv.check_be_name(be_name)
-                return True
-
-        def __cert_verify(self, log_op_end=None):
-                """Verify validity of certificates.  Any apx.ExpiringCertificate
-                exceptions are caught here, a message is displayed, and
-                execution continues.
-
-                All other exceptions will be passed to the calling context.
-                The caller can also set log_op_end to a list of exceptions
-                that should result in a call to self.log_operation_end()
-                before the exception is passed on.
-                """
-
-                if log_op_end is None:
-                        log_op_end = []
-
-                # we always explicitly handle apx.ExpiringCertificate
-                assert apx.ExpiringCertificate not in log_op_end
-
-                try:
-                        self._img.check_cert_validity()
-                except apx.ExpiringCertificate as e:
-                        logger.warning(e)
-                except:
-                        exc_type, exc_value, exc_traceback = sys.exc_info()
-                        if exc_type in log_op_end:
-                                self.log_operation_end(error=exc_value)
-                        raise
-
-        def __refresh_publishers(self):
-                """Refresh publisher metadata; this should only be used by
-                functions in this module for implicit refresh cases."""
-
-                #
-                # Verify validity of certificates before possibly
-                # attempting network operations.
-                #
-                self.__cert_verify()
-                try:
-                        self._img.refresh_publishers(immediate=True,
-                            progtrack=self.__progresstracker)
-                except apx.ImageFormatUpdateNeeded:
-                        # If image format update is needed to perform refresh,
-                        # continue on and allow failure to happen later since
-                        # an implicit refresh failing for this reason isn't
-                        # important.  (This allows planning installs and updates
-                        # before the format of an image is updated.  Yes, this
-                        # means that if the refresh was needed to do that, then
-                        # this isn't useful, but this is as good as it gets.)
-                        logger.warning(_("Skipping publisher metadata refresh;"
-                            "image rooted at {0} must have its format updated "
-                            "before a refresh can occur.").format(self._img.root))
-
-        def _acquire_activity_lock(self):
-                """Private helper method to aqcuire activity lock."""
-
-                rc = self._activity_lock.acquire(
-                    blocking=self.__blocking_locks)
-                if not rc:
-                        raise apx.ImageLockedError()
-
-        def __plan_common_start(self, operation, noexecute, backup_be,
-            backup_be_name, new_be, be_name, be_activate):
-                """Start planning an operation:
-                    Acquire locks.
-                    Log the start of the operation.
-                    Check be_name."""
-
-                self._acquire_activity_lock()
-                try:
-                        self._enable_cancel()
-                        if self.__plan_type is not None:
-                                raise apx.PlanExistsException(
-                                    self.__plan_type)
-                        self._img.lock(allow_unprivileged=noexecute)
-                except OSError as e:
-                        self._cancel_cleanup_exception()
-                        self._activity_lock.release()
-                        if e.errno in (errno.ENOSPC, errno.EDQUOT):
-                                raise apx.ImageLockingFailedError(
-                                    self._img_path, e.strerror)
-                        raise
-                except:
-                        self._cancel_cleanup_exception()
-                        self._activity_lock.release()
-                        raise
-
-                assert self._activity_lock._is_owned()
-                self.log_operation_start(operation)
-                self.__backup_be = backup_be
-                self.__backup_be_name = backup_be_name
-                self.__new_be = new_be
-                self.__be_activate = be_activate
-                self.__be_name = be_name
-                for val in (self.__be_name, self.__backup_be_name):
-                        if val is not None:
-                                self.check_be_name(val)
-                                if not self._img.is_liveroot():
-                                        self._cancel_cleanup_exception()
-                                        self._activity_lock.release()
-                                        self._img.unlock()
-                                        raise apx.BENameGivenOnDeadBE(val)
-
-        def __plan_common_finish(self):
-                """Finish planning an operation."""
-
-                assert self._activity_lock._is_owned()
-                self._img.cleanup_downloads()
-                self._img.unlock()
-                try:
-                        if int(os.environ.get("PKG_DUMP_STATS", 0)) > 0:
-                                self._img.transport.stats.dump()
-                except ValueError:
-                        # Don't generate stats if an invalid value
-                        # is supplied.
-                        pass
-
-                self._activity_lock.release()
-
-        def __auto_be_name(self):
-                try:
-                        be_template = self._img.cfg.get_property(
-                            'property', imgcfg.AUTO_BE_NAME)
-                except:
-                        be_template = None
-
-                if not be_template or len(be_template) == 0:
-                        return
-
-                if be_template.startswith(AUTO_BE_NAME_TIME_PREFIX):
-                        try:
-                                be_template = time.strftime(
-                                    be_template[len(AUTO_BE_NAME_TIME_PREFIX):])
-                        except:
-                                return
-                else:
-                        release = date = None
-                        # Check to see if release/name is being updated
-                        for src, dest in self._img.imageplan.plan_desc:
-                                if (not dest or
-                                    dest.get_name() != 'release/name'):
-                                        continue
-                                # It is, extract attributes
-                                for a in self._img.imageplan.pd.update_actions:
-                                        if not isinstance(a.dst,
-                                            actions.attribute.AttributeAction):
-                                                continue
-                                        name = a.dst.attrs['name']
-                                        if name == 'ooce.release':
-                                                release = a.dst.attrs['value']
-                                        elif name == 'ooce.release.build':
-                                                date = a.dst.attrs['value']
-                                        if release and date:
-                                                break
-                                break
-
-                        if not release and not date:
-                                # No variables changed in this update
-                                return
-
-                        if '%r' in be_template and not release:
-                                return
-                        if '%d' in be_template and not date:
-                                return
-                        if '%D' in be_template and not date:
-                                return
-                        if release:
-                                be_template = be_template.replace('%r', release)
-                        if date:
-                                be_template = be_template.replace('%d', date)
-                                be_template = be_template.replace('%D',
-                                    date.replace('.', ''))
-
-                if not be_template or len(be_template) == 0:
-                        return
-
-                be = bootenv.BootEnv(self._img)
-                self.__be_name = be.get_new_be_name(new_bename=be_template)
-
-        def __set_be_creation(self):
-                """Figure out whether or not we'd create a new or backup boot
-                environment given inputs and plan.  Toss cookies if we need a
-                new be and can't have one."""
-
-                if not self._img.is_liveroot():
-                        self.__backup_be = False
-                        self.__new_be = False
-                        return
-
-                if self.__new_be is None:
-                        # If image policy requires a new BE or the plan requires
-                        # it, then create a new BE.
-                        self.__new_be = (self._img.cfg.get_policy_str(
-                            imgcfg.BE_POLICY) == "always-new" or
-                            self._img.imageplan.reboot_needed())
-                elif self.__new_be is False and \
-                    self._img.imageplan.reboot_needed():
-                        raise apx.ImageUpdateOnLiveImageException()
-
-                # If a new BE is required and no BE name has been provided
-                # on the command line, attempt to determine a BE name
-                # automatically.
-                if self.__new_be == True and self.__be_name == None:
-                        self.__auto_be_name()
-
-                if not self.__new_be and self.__backup_be is None:
-                        # Create a backup be if allowed by policy (note that the
-                        # 'default' policy is currently an alias for
-                        # 'create-backup') ...
-                        allow_backup = self._img.cfg.get_policy_str(
-                            imgcfg.BE_POLICY) in ("default",
-                                "create-backup")
-
-                        self.__backup_be = False
-                        if allow_backup:
-                                # ...when packages are being
-                                # updated...
-                                for src, dest in self._img.imageplan.plan_desc:
-                                        if src and dest:
-                                                self.__backup_be = True
-                                                break
-                        if allow_backup and not self.__backup_be:
-                                # ...or if new packages that have
-                                # reboot-needed=true are being
-                                # installed.
-                                self.__backup_be = \
-                                    self._img.imageplan.reboot_advised()
-
-        def abort(self, result=RESULT_FAILED_UNKNOWN):
-                """Indicate that execution was unexpectedly aborted and log
-                operation failure if possible."""
-                try:
-                        # This can raise if, for example, we're aborting
-                        # because we have a PipeError and we can no longer
-                        # write.  So suppress problems here.
-                        if self.__progresstracker:
-                                self.__progresstracker.flush()
-                except:
-                        pass
-
-                self._img.history.abort(result)
-
-        def avoid_pkgs(self, fmri_strings, unavoid=False):
-                """Avoid/Unavoid one or more packages.  It is an error to
-                avoid an installed package, or unavoid one that would
-                be installed."""
-
-                self._acquire_activity_lock()
-                try:
-                        if not unavoid:
-                                self._img.avoid_pkgs(fmri_strings,
-                                    progtrack=self.__progresstracker,
-                                    check_cancel=self.__check_cancel)
-                        else:
-                                self._img.unavoid_pkgs(fmri_strings,
-                                    progtrack=self.__progresstracker,
-                                    check_cancel=self.__check_cancel)
-                finally:
-                        self._activity_lock.release()
-                return True
-
-        def flag_pkgs(self, fmri_strings, flag, value):
-                if flag == 'manual':
-                        state = PackageInfo.MANUAL
-                else:
-                        raise apx.InvalidOptionErrors('Unknown flag')
-
-                pfmris = []
-                for pfmri, _, _, _, _ in self.get_pkg_list(
-                    pkg_list=self.LIST_INSTALLED, patterns=fmri_strings,
-                    raise_unmatched=True, return_fmris=True):
-                        pfmris.append(pfmri)
-
-                self._acquire_activity_lock()
-
-                try:
-                        self._img.flag_pkgs(pfmris=pfmris,
-                            state=state, value=value,
-                            progtrack=self.__progresstracker)
-                finally:
-                        self._activity_lock.release()
-                return True
-
-        def gen_available_mediators(self):
-                """A generator function that yields tuples of the form
-                   (mediator, mediations), where mediator is the name of the
-                   provided mediation and mediations is a list of dictionaries
-                   of possible mediations to set, provided by installed
-                   packages, of the form:
-
-                   {
-                       mediator-name: {
-                           "version": mediator-version-string,
-                           "version-source": (site|vendor|system|local),
-                           "implementation": mediator-implementation-string,
-                           "implementation-source": (site|vendor|system|local),
-                       }
-                   }
-
-                  'version' is an optional string that specifies the version
-                   (expressed as a dot-separated sequence of non-negative
-                   integers) of the mediator for use.
-
-                   'version-source' is a string describing how the version
-                   component of the mediation will be evaluated during
-                   mediation. (The priority.)
-
-                   'implementation' is an optional string that specifies the
-                   implementation of the mediator for use in addition to or
-                   instead of 'version'.
-
-                   'implementation-source' is a string describing how the
-                   implementation component of the mediation will be evaluated
-                   during mediation.  (The priority.)
-
-                The list of possible mediations returned for each mediator is
-                ordered by source in the sequence 'site', 'vendor', 'system',
-                and then by version and implementation.  It does not include
-                mediations that exist only in the image configuration.
-                """
-
-                ret = collections.defaultdict(set)
-                excludes = self._img.list_excludes()
-                for f in self._img.gen_installed_pkgs():
-                        mfst = self._img.get_manifest(f)
-                        for m, mediations in mfst.gen_mediators(
-                            excludes=excludes):
-                                ret[m].update(mediations)
-
-                for mediator in sorted(ret):
-                        for med_priority, med_ver, med_impl in sorted(
-                            ret[mediator], key=cmp_to_key(med.cmp_mediations)):
-                                val = {}
-                                if med_ver:
-                                        # Don't expose internal Version object
-                                        # to callers.
-                                        val["version"] = \
-                                            med_ver.get_short_version()
-                                if med_impl:
-                                        val["implementation"] = med_impl
-
-                                ret_priority = med_priority
-                                if not ret_priority:
-                                        # For consistency with the configured
-                                        # case, list source as this.
-                                        ret_priority = "system"
-                                # Always set both to be consistent
-                                # with @mediators.
-                                val["version-source"] = ret_priority
-                                val["implementation-source"] = \
-                                    ret_priority
-                                yield mediator, val
-
-        def get_avoid_list(self):
-                """Return list of tuples of (pkg stem, pkgs w/ group
-                dependencies on this) """
-                return [a for a in six.iteritems(self._img.get_avoid_dict())]
-
-        def gen_facets(self, facet_list, implicit=False, patterns=misc.EmptyI):
-                """A generator function that produces tuples of the form:
-
-                    (
-                        name,    - (string) facet name (e.g. facet.doc)
-                        value    - (boolean) current facet value
-                        src      - (string) source for the value
-                        masked   - (boolean) is the facet maksed by another
-                    )
-
-                Results are always sorted by facet name.
-
-                'facet_list' is one of the following constant values indicating
-                which facets should be returned based on how they were set:
-
-                        FACET_ALL
-                                Return all facets set in the image and all
-                                facets listed in installed packages.
-
-                        FACET_IMAGE
-                                Return only the facets set in the image.
-
-                        FACET_INSTALLED
-                                Return only the facets listed in installed
-                                packages.
-
-                'implicit' is a boolean indicating whether facets specified in
-                the 'patterns' parameter that are not explicitly set in the
-                image or found in a package should be included.  Ignored for
-                FACET_INSTALLED case.
-
-                'patterns' is an optional list of facet wildcard strings to
-                filter results by."""
-
-                facets = self._img.cfg.facets
-                if facet_list != self.FACET_INSTALLED:
-                        # Include all facets set in image.
-                        fimg = set(facets.keys())
-                else:
-                        # Don't include any set only in image.
-                        fimg = set()
-
-                # Get all facets found in packages and determine state.
-                fpkg = set()
-                excludes = self._img.list_excludes()
-                if facet_list != self.FACET_IMAGE:
-                        for f in self._img.gen_installed_pkgs():
-                                # The manifest must be loaded without
-                                # pre-applying excludes so that gen_facets() can
-                                # choose how to filter the actions.
-                                mfst = self._img.get_manifest(f,
-                                    ignore_excludes=True)
-                                for facet in mfst.gen_facets(excludes=excludes):
-                                        # Use Facets object to determine
-                                        # effective facet state.
-                                        fpkg.add(facet)
-
-                # If caller wants implicit values, include non-glob patterns
-                # (even if not found) in results unless only installed facets
-                # were requested.
-                iset = set()
-                if implicit and facet_list != self.FACET_INSTALLED:
-                        iset = set(
-                            p.startswith("facet.") and p or ("facet." + p)
-                            for p in patterns
-                            if "*" not in p and "?" not in p
-                        )
-                flist = sorted(fimg | fpkg | iset)
-
-                # Generate the results.
-                for name in misc.yield_matching("facet.", flist, patterns):
-                        # check if the facet is explicitly set.
-                        if name not in facets:
-                                # The image's Facets dictionary will return
-                                # the effective value for any facets not
-                                # explicitly set in the image (wildcards or
-                                # implicit). _match_src() will tell us how
-                                # that effective value was determined (via a
-                                # local or inherited wildcard facet, or via a
-                                # system default).
-                                src = facets._match_src(name)
-                                yield (name, facets[name], src, False)
-                                continue
-
-                        # This is an explicitly set facet.
-                        for value, src, masked in facets._src_values(name):
-                                yield (name, value, src, masked)
-
-        def gen_variants(self, variant_list, implicit=False,
-            patterns=misc.EmptyI):
-                """A generator function that produces tuples of the form:
-
-                    (
-                        name,    - (string) variant name (e.g. variant.arch)
-                        value    - (string) current variant value,
-                        possible - (list) list of possible variant values based
-                                   on installed packages; empty unless using
-                                   *_POSSIBLE variant_list.
-                    )
-
-                Results are always sorted by variant name.
-
-                'variant_list' is one of the following constant values indicating
-                which variants should be returned based on how they were set:
-
-                        VARIANT_ALL
-                                Return all variants set in the image and all
-                                variants listed in installed packages.
-
-                        VARIANT_ALL_POSSIBLE
-                                Return possible variant values (those found in
-                                any installed package) for all variants set in
-                                the image and all variants listed in installed
-                                packages.
-
-                        VARIANT_IMAGE
-                                Return only the variants set in the image.
-
-                        VARIANT_IMAGE_POSSIBLE
-                                Return possible variant values (those found in
-                                any installed package) for only the variants set
-                                in the image.
-
-                        VARIANT_INSTALLED
-                                Return only the variants listed in installed
-                                packages.
-
-                        VARIANT_INSTALLED_POSSIBLE
-                                Return possible variant values (those found in
-                                any installed package) for only the variants
-                                listed in installed packages.
-
-                'implicit' is a boolean indicating whether variants specified in
-                the 'patterns' parameter that are not explicitly set in the
-                image or found in a package should be included.  Ignored for
-                VARIANT_INSTALLED* cases.
-
-                'patterns' is an optional list of variant wildcard strings to
-                filter results by."""
-
-                variants = self._img.cfg.variants
-                if variant_list != self.VARIANT_INSTALLED and \
-                    variant_list != self.VARIANT_INSTALLED_POSSIBLE:
-                        # Include all variants set in image.
-                        vimg = set(variants.keys())
-                else:
-                        # Don't include any set only in image.
-                        vimg = set()
-
-                # Get all variants found in packages and determine state.
-                vpkg = {}
-                excludes = self._img.list_excludes()
-                vposs = collections.defaultdict(set)
-                if variant_list != self.VARIANT_IMAGE:
-                        # Only incur the overhead of reading through all
-                        # installed packages if not just listing variants set in
-                        # image or listing possible values for them.
-                        for f in self._img.gen_installed_pkgs():
-                                # The manifest must be loaded without
-                                # pre-applying excludes so that gen_variants()
-                                # can choose how to filter the actions.
-                                mfst = self._img.get_manifest(f,
-                                    ignore_excludes=True)
-                                for variant, vals in mfst.gen_variants(
-                                    excludes=excludes):
-                                        if variant not in vimg:
-                                                # Although rare, packages with
-                                                # unknown variants (those not
-                                                # set in the image) can be
-                                                # installed as long as content
-                                                # does not conflict.  For those
-                                                # variants, return None.  This
-                                                # is done without using get() as
-                                                # that would cause None to be
-                                                # returned for implicitly set
-                                                # variants (e.g. debug).
-                                                try:
-                                                        vpkg[variant] = \
-                                                            variants[variant]
-                                                except KeyError:
-                                                        vpkg[variant] = None
-
-                                        if (variant_list == \
-                                            self.VARIANT_ALL_POSSIBLE or
-                                            variant_list == \
-                                                self.VARIANT_IMAGE_POSSIBLE or
-                                            variant_list == \
-                                                self.VARIANT_INSTALLED_POSSIBLE):
-                                                # Build possible list of variant
-                                                # values.
-                                                vposs[variant].update(set(vals))
-
-                # If caller wants implicit values, include non-glob debug
-                # patterns (even if not found) in results unless only installed
-                # variants were requested.
-                iset = set()
-                if implicit and variant_list != self.VARIANT_INSTALLED and \
-                    variant_list != self.VARIANT_INSTALLED_POSSIBLE:
-                        # Normalize patterns.
-                        iset = set(
-                            p.startswith("variant.") and p or ("variant." + p)
-                            for p in patterns
-                            if "*" not in p and "?" not in p
-                        )
-                        # Only debug variants can have an implicit value.
-                        iset = set(
-                            p
-                            for p in iset
-                            if p.startswith("variant.debug.")
-                        )
-                vlist = sorted(vimg | set(vpkg.keys()) | iset)
-
-                # Generate the results.
-                for name in misc.yield_matching("variant.", vlist, patterns):
-                        try:
-                                yield (name, vpkg[name], sorted(vposs[name]))
-                        except KeyError:
-                                yield (name, variants[name],
-                                    sorted(vposs[name]))
-
-        def freeze_pkgs(self, fmri_strings, dry_run=False, comment=None,
-            unfreeze=False):
-                """Freeze/Unfreeze one or more packages."""
-
-                # Comment is only a valid parameter if a freeze is happening.
-                assert not comment or not unfreeze
-
-                self._acquire_activity_lock()
-                try:
-                        if unfreeze:
-                                return self._img.unfreeze_pkgs(fmri_strings,
-                                    progtrack=self.__progresstracker,
-                                    check_cancel=self.__check_cancel,
-                                    dry_run=dry_run)
-                        else:
-                                return self._img.freeze_pkgs(fmri_strings,
-                                    progtrack=self.__progresstracker,
-                                    check_cancel=self.__check_cancel,
-                                    dry_run=dry_run, comment=comment)
-                finally:
-                        self._activity_lock.release()
-
-        def get_frozen_list(self):
-                """Return list of tuples of (pkg fmri, reason package was
-                frozen, timestamp when package was frozen)."""
-
-                return self._img.get_frozen_list()
-
-        def cleanup_cached_content(self, verbose=False):
-                """Clean up any cached content."""
-
-                self._acquire_activity_lock()
-                try:
-                        return self._img.cleanup_cached_content(
-                            progtrack=self.__progresstracker, force=True,
-                            verbose=verbose)
-                finally:
-                        self._activity_lock.release()
-
-        def __plan_common_exception(self, log_op_end_all=False):
-                """Deal with exceptions that can occur while planning an
-                operation.  Any exceptions generated here are passed
-                onto the calling context.  By default all exceptions
-                will result in a call to self.log_operation_end() before
-                they are passed onto the calling context."""
-
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-
-                if exc_type == apx.PlanCreationException:
-                        self.__set_history_PlanCreationException(exc_value)
-                elif exc_type == apx.CanceledException:
-                        self._cancel_done()
-                elif exc_type == apx.ConflictingActionErrors:
-                        self.log_operation_end(error=str(exc_value),
-                            result=RESULT_CONFLICTING_ACTIONS)
-                elif exc_type in [
-                    apx.IpkgOutOfDateException,
-                    fmri.IllegalFmri]:
-                        self.log_operation_end(error=exc_value)
-                elif log_op_end_all:
-                        self.log_operation_end(error=exc_value)
-
-                if exc_type not in (apx.ImageLockedError,
-                    apx.ImageLockingFailedError):
-                        # Must be called before reset_unlock, and only if
-                        # the exception was not a locked error.
-                        self._img.unlock()
-
-                try:
-                        if int(os.environ.get("PKG_DUMP_STATS", 0)) > 0:
-                                self._img.transport.stats.dump()
-                except ValueError:
-                        # Don't generate stats if an invalid value
-                        # is supplied.
-                        pass
-
-                # In the case of duplicate actions, we want to save off the plan
-                # description for display to the client (if they requested it),
-                # as once the solver's done its job, there's interesting
-                # information in the plan.  We have to save it here and restore
-                # it later because __reset_unlock() torches it.
-                if exc_type == apx.ConflictingActionErrors:
-                        self._img.imageplan.set_be_options(self.__backup_be,
-                            self.__backup_be_name, self.__new_be,
-                            self.__be_activate, self.__be_name)
-                        plan_desc = self._img.imageplan.describe()
-
-                self.__reset_unlock()
-
-                if exc_type == apx.ConflictingActionErrors:
-                        self.__plan_desc = plan_desc
-
-                self._activity_lock.release()
-
-                # re-raise the original exception. (we have to explicitly
-                # restate the original exception since we may have cleared the
-                # current exception scope above.)
-                six.reraise(exc_type, exc_value, exc_traceback)
-
-        def solaris_image(self):
-                """Returns True if the current image is a solaris image, or an
-                image which contains the pkg(7) packaging system."""
-
-                # First check to see if the special package "release/name"
-                # exists and contains metadata saying this is Solaris.
-                results = self.__get_pkg_list(self.LIST_INSTALLED,
-                    patterns=["release/name"], return_fmris=True)
-                results = [e for e in results]
-                if results:
-                        pfmri, summary, categories, states, attrs = results[0]
-                        mfst = self._img.get_manifest(pfmri)
-                        osname = mfst.get("pkg.release.osname", None)
-                        if osname == "sunos":
-                                return True
-
-                # Otherwise, see if we can find package/pkg (or SUNWipkg) and
-                # system/core-os (or SUNWcs).
-                results = self.__get_pkg_list(self.LIST_INSTALLED,
-                    patterns=["/package/pkg", "SUNWipkg", "/system/core-os",
-                        "SUNWcs"])
-                installed = set(e[0][1] for e in results)
-                if ("SUNWcs" in installed or "system/core-os" in installed) and \
-                    ("SUNWipkg" in installed or "package/pkg" in installed):
-                        return True
-
-                return False
-
-        def __ipkg_require_latest(self, noexecute):
-                """Raises an IpkgOutOfDateException if the current image
-                contains the pkg(7) packaging system and a newer version
-                of the pkg(7) packaging system is installable."""
-
-                if not self.solaris_image():
-                        return
-
-                # Get old purpose in order to be able to restore it on return.
-                p = self.__progresstracker.get_purpose()
-
-                try:
-                        #
-                        # Let progress tracker know that subsequent callbacks
-                        # into it will all be in service of update checking.
-                        # Note that even though this might return, the
-                        # finally: will still reset the purpose.
-                        #
-                        self.__progresstracker.set_purpose(
-                            self.__progresstracker.PURPOSE_PKG_UPDATE_CHK)
-                        if self._img.ipkg_is_up_to_date(
-                            self.__check_cancel, noexecute,
-                            refresh_allowed=False,
-                            progtrack=self.__progresstracker):
-                                return
-                except apx.ImageNotFoundException:
-                        # Can't do anything in this
-                        # case; so proceed.
-                        return
-                finally:
-                        self.__progresstracker.set_purpose(p)
-
-                raise apx.IpkgOutOfDateException()
-
-        def __verify_args(self, args):
-                """Verifies arguments passed into the API.
-                It tests for correct data types of the input args, verifies that
-                passed in FMRIs are valid, checks if repository URIs are valid
-                and does some logical tests for the combination of arguments."""
-
-                arg_types = {
-                    # arg name              type                   nullable
-                    "_act_timeout":         (int,                  False),
-                    "_be_activate":         ('activate',           False),
-                    "_be_name":             (six.string_types,     True),
-                    "_backup_be":           (bool,                 True),
-                    "_backup_be_name":      (six.string_types,     True),
-                    "_ignore_missing":      (bool,                 False),
-                    "_ipkg_require_latest": (bool,                 False),
-                    "_li_erecurse":         (iter,                 True),
-                    "_li_ignore":           (iter,                 True),
-                    "_li_md_only":          (bool,                 False),
-                    "_li_parent_sync":      (bool,                 False),
-                    "_new_be":              (bool,                 True),
-                    "_noexecute":           (bool,                 False),
-                    "_pubcheck":            (bool,                 False),
-                    "_refresh_catalogs":    (bool,                 False),
-                    "_repos":               (iter,                 True),
-                    "_update_index":        (bool,                 False),
-                    "facets":               (dict,                 True),
-                    "mediators":            (iter,                 True),
-                    "pkgs_inst":            (iter,                 True),
-                    "pkgs_to_uninstall":    (iter,                 True),
-                    "pkgs_update":          (iter,                 True),
-                    "reject_list":          (iter,                 True),
-                    "variants":             (dict,                 True),
-                }
-
-                # merge kwargs into the main arg dict
-                if "kwargs" in args:
-                        for name, value in args["kwargs"].items():
-                                args[name] = value
-
-                # check arguments for proper type and nullability
-                for a in args:
-                        try:
-                                a_type, nullable = arg_types[a]
-                        except KeyError:
-                                # unknown argument passed, ignore
-                                continue
-
-                        assert nullable or args[a] is not None
-
-                        if args[a] is not None and a_type == iter:
-                                try:
-                                        iter(args[a])
-                                except TypeError:
-                                        raise AssertionError("{0} is not an "
-                                            "iterable".format(a))
-                        elif a_type == 'activate':
-                                assert isinstance(args[a], bool) or (
-                                    isinstance(args[a], str) and
-                                    args[a] == 'bootnext')
-                        else:
-                                assert (args[a] is None or
-                                    isinstance(args[a], a_type)), "{0} is " \
-                                    "type {1}; expected {2}".format(a, type(a),
-                                    a_type)
-
-                # check if passed FMRIs are valid
-                illegals = []
-                for i in ("pkgs_inst", "pkgs_update", "pkgs_to_uninstall",
-                    "reject_list"):
-                        try:
-                                fmris = args[i]
-                        except KeyError:
-                                continue
-                        if fmris is None:
-                                continue
-                        for pat, err, pfmri, matcher in \
-                            self.parse_fmri_patterns(fmris):
-                                if not err:
-                                        continue
-                                else:
-                                        illegals.append(fmris)
-
-                if illegals:
-                        raise apx.PlanCreationException(illegal=illegals)
-
-                # some logical checks
-                errors = []
-                if not args["_new_be"] and args["_be_name"]:
-                        errors.append(apx.InvalidOptionError(
-                            apx.InvalidOptionError.REQUIRED, ["_be_name",
-                            "_new_be"]))
-                if not args["_backup_be"] and args["_backup_be_name"]:
-                        errors.append(apx.InvalidOptionError(
-                            apx.InvalidOptionError.REQUIRED, ["_backup_be_name",
-                            "_backup_be"]))
-                if args["_backup_be"] and args["_new_be"]:
-                        errors.append(apx.InvalidOptionError(
-                            apx.InvalidOptionError.INCOMPAT, ["_backup_be",
-                            "_new_be"]))
-
-                if errors:
-                        raise apx.InvalidOptionErrors(errors)
-
-                # check if repo URIs are valid
-                try:
-                        repos = args["_repos"]
-                except KeyError:
-                        return
-
-                if not repos:
-                        return
-
-                illegals = []
-                for r in repos:
-                        valid = False
-                        if type(r) == publisher.RepositoryURI:
-                                # RepoURI objects pass right away
-                                continue
-
-                        if not misc.valid_pub_url(r):
-                                illegals.append(r)
-
-                if illegals:
-                        raise apx.UnsupportedRepositoryURI(illegals)
-
-        def __plan_op(self, _op, _act_timeout=0, _ad_kwargs=None,
-            _backup_be=None, _backup_be_name=None, _be_activate=True,
-            _be_name=None, _ipkg_require_latest=False, _li_ignore=None,
-            _li_erecurse=None, _li_md_only=False, _li_parent_sync=True,
-            _new_be=False, _noexecute=False, _pubcheck=True,
-            _refresh_catalogs=True, _repos=None, _update_index=True, **kwargs):
-                """Contructs a plan to change the package or linked image
-                state of an image.
-
-                We can raise PermissionsException, PlanCreationException,
-                InventoryException, or LinkedImageException.
-
-                Arguments prefixed with '_' are primarily used within this
-                function.  All other arguments must be specified via keyword
-                assignment and will be passed directly on to the image
-                interfaces being invoked."
-
-                '_op' is the API operation we will perform.
-
-                '_ad_kwargs' is only used dyring attach or detach and it
-                is a dictionary of arguments that will be passed to the
-                linked image attach/detach interfaces.
-
-                '_ipkg_require_latest' enables a check to verify that the
-                latest installable version of the pkg(7) packaging system is
-                installed before we proceed with the requested operation.
-
-                For all other '_' prefixed parameters, please refer to the
-                'gen_plan_*' functions which invoke this function for an
-                explanation of their usage and effects.
-
-                This function first yields the plan description for the global
-                zone, then either a series of dictionaries representing the
-                parsable output from operating on the child images or a series
-                of None values."""
-
-                # sanity checks
-                assert _op in api_op_values
-                assert _ad_kwargs is None or \
-                    _op in [API_OP_ATTACH, API_OP_DETACH]
-                assert _ad_kwargs != None or \
-                    _op not in [API_OP_ATTACH, API_OP_DETACH]
-                assert not _li_md_only or \
-                    _op in [API_OP_ATTACH, API_OP_DETACH, API_OP_SYNC]
-                assert not _li_md_only or _li_parent_sync
-
-                self.__verify_args(locals())
-
-                # make some perf optimizations
-                if _li_md_only:
-                        _refresh_catalogs = _update_index = False
-                if _op in [API_OP_DETACH, API_OP_SET_MEDIATOR, API_OP_FIX,
-                    API_OP_VERIFY, API_OP_DEHYDRATE, API_OP_REHYDRATE]:
-                        # these operations don't change fmris and don't need
-                        # to recurse, so disable a bunch of linked image
-                        # operations.
-                        _li_parent_sync = False
-                        _pubcheck = False
-                        _li_ignore = [] # ignore all children
-
-                # All the image interface functions that we invoke have some
-                # common arguments.  Set those up now.
-                args_common = {}
-                args_common["op"] = _op
-                args_common["progtrack"] = self.__progresstracker
-                args_common["check_cancel"] = self.__check_cancel
-                args_common["noexecute"] = _noexecute
-
-                # make sure there is no overlap between the common arguments
-                # supplied to all api interfaces and the arguments that the
-                # api arguments that caller passed to this function.
-                assert (set(args_common) & set(kwargs)) == set(), \
-                    "{0} & {1} != set()".format(str(set(args_common)),
-                    str(set(kwargs)))
-                kwargs.update(args_common)
-
-                try:
-                        # Lock the current image.
-                        self.__plan_common_start(_op, _noexecute, _backup_be,
-                            _backup_be_name, _new_be, _be_name, _be_activate)
-
-                except:
-                        raise
-
-                try:
-                        if _op == API_OP_ATTACH:
-                                self._img.linked.attach_parent(**_ad_kwargs)
-                        elif _op == API_OP_DETACH:
-                                self._img.linked.detach_parent(**_ad_kwargs)
-
-                        if _li_parent_sync:
-                                # refresh linked image data from parent image.
-                                self._img.linked.syncmd_from_parent()
-
-                        # initialize recursion state
-                        self._img.linked.api_recurse_init(
-                                li_ignore=_li_ignore, repos=_repos)
-
-                        if _pubcheck:
-                                # check that linked image pubs are in sync
-                                self.__linked_pubcheck(_op)
-
-                        if _refresh_catalogs:
-                                self.__refresh_publishers()
-
-                        if _ipkg_require_latest:
-                                # If this is an image update then make
-                                # sure the latest version of the ipkg
-                                # software is installed.
-                                self.__ipkg_require_latest(_noexecute)
-
-                        self.__set_img_alt_sources(_repos)
-
-                        if _li_md_only:
-                                self._img.make_noop_plan(**args_common)
-                        elif _op in [API_OP_ATTACH, API_OP_DETACH, API_OP_SYNC]:
-                                self._img.make_sync_plan(**kwargs)
-                        elif _op in [API_OP_CHANGE_FACET,
-                            API_OP_CHANGE_VARIANT]:
-                                self._img.make_change_varcets_plan(**kwargs)
-                        elif _op == API_OP_DEHYDRATE:
-                                self._img.make_dehydrate_plan(**kwargs)
-                        elif _op == API_OP_INSTALL or \
-                            _op == API_OP_EXACT_INSTALL:
-                                self._img.make_install_plan(**kwargs)
-                        elif _op in [API_OP_FIX, API_OP_VERIFY]:
-                                self._img.make_fix_plan(**kwargs)
-                        elif _op == API_OP_REHYDRATE:
-                                self._img.make_rehydrate_plan(**kwargs)
-                        elif _op == API_OP_REVERT:
-                                self._img.make_revert_plan(**kwargs)
-                        elif _op == API_OP_SET_MEDIATOR:
-                                self._img.make_set_mediators_plan(**kwargs)
-                        elif _op == API_OP_UNINSTALL:
-                                self._img.make_uninstall_plan(**kwargs)
-                        elif _op == API_OP_UPDATE:
-                                self._img.make_update_plan(**kwargs)
-                        else:
-                                raise RuntimeError(
-                                    "Unknown api op: {0}".format(_op))
-
-                        self.__api_op = _op
-
-                        if self._img.imageplan.nothingtodo():
-                                # no package changes mean no index changes
-                                _update_index = False
-
-                        self._disable_cancel()
-                        self.__set_be_creation()
-                        self._img.imageplan.set_be_options(
-                            self.__backup_be, self.__backup_be_name,
-                            self.__new_be, self.__be_activate, self.__be_name)
-                        self.__plan_desc = self._img.imageplan.describe()
-                        if not _noexecute:
-                                self.__plan_type = self.__plan_desc.plan_type
-
-                        if _act_timeout != 0:
-                                self.__plan_desc.set_actuator_timeout(
-                                    _act_timeout)
-
-                        # Yield to our caller so they can display our plan
-                        # before we recurse into child images.  Drop the
-                        # activity lock before yielding because otherwise the
-                        # caller can't do things like set the displayed
-                        # license state for pkg plans).
-                        self._activity_lock.release()
-                        yield self.__plan_desc
-                        self._activity_lock.acquire()
-
-                        # plan operation in child images.  This currently yields
-                        # either a dictionary representing the parsable output
-                        # from the child image operation, or None.  Eventually
-                        # these will yield plan descriptions objects instead.
-
-                        for p_dict in self._img.linked.api_recurse_plan(
-                            api_kwargs=kwargs, erecurse_list=_li_erecurse,
-                            refresh_catalogs=_refresh_catalogs,
-                            update_index=_update_index,
-                            progtrack=self.__progresstracker):
-                                yield p_dict
-
-                        self.__planned_children = True
-
-                except:
-                        if _op in [
-                            API_OP_UPDATE,
-                            API_OP_INSTALL,
-                            API_OP_REVERT,
-                            API_OP_SYNC]:
-                                self.__plan_common_exception(
-                                    log_op_end_all=True)
-                        else:
-                                self.__plan_common_exception()
-                        # NOTREACHED
-
-                stuff_to_do = not self.planned_nothingtodo()
-
-                if not stuff_to_do or _noexecute:
-                        self.log_operation_end(
-                            result=RESULT_NOTHING_TO_DO)
-
-                self._img.imageplan.update_index = _update_index
-                self.__plan_common_finish()
-
-                # Value 'DebugValues' is unsubscriptable;
-                # pylint: disable=E1136
-                if DebugValues["plandesc_validate"]:
-                        # save, load, and get a new json copy of the plan,
-                        # then compare that new copy against our current one.
-                        # this regressions tests the plan save/load code.
-                        pd_json1 = self.__plan_desc.getstate(self.__plan_desc,
-                            reset_volatiles=True)
-                        fobj = tempfile.TemporaryFile(mode="w+")
-                        json.dump(pd_json1, fobj)
-                        pd_new = plandesc.PlanDescription(_op)
-                        pd_new._load(fobj)
-                        pd_json2 = pd_new.getstate(pd_new, reset_volatiles=True)
-                        fobj.close()
-                        del fobj, pd_new
-                        pkg.misc.json_diff("PlanDescription", \
-                            pd_json1, pd_json2, pd_json1, pd_json2)
-                        del pd_json1, pd_json2
-
-        @_LockedCancelable()
-        def load_plan(self, plan, prepared=False):
-                """Load a previously generated PlanDescription."""
-
-                # Prevent loading a plan if one has been already.
-                if self.__plan_type is not None:
-                        raise apx.PlanExistsException(self.__plan_type)
-
-                # grab image lock.  we don't worry about dropping the image
-                # lock since __activity_lock will drop it for us us after we
-                # return (or if we generate an exception).
-                self._img.lock()
-
-                # load the plan
-                self.__plan_desc = plan
-                self.__plan_type = plan.plan_type
-                self.__planned_children = True
-                self.__prepared = prepared
-
-                # load BE related plan settings
-                self.__new_be = plan.new_be
-                self.__be_activate = plan.activate_be
-                self.__be_name = plan.be_name
-
-                # sanity check: verify the BE name
-                if self.__be_name is not None:
-                        self.check_be_name(self.__be_name)
-                        if not self._img.is_liveroot():
-                                raise apx.BENameGivenOnDeadBE(self.__be_name)
-
-                # sanity check: verify that all the fmris in the plan are in
-                # the known catalog
-                pkg_cat = self._img.get_catalog(self._img.IMG_CATALOG_KNOWN)
-                for pp in plan.pkg_plans:
-                        if pp.destination_fmri:
-                                assert pkg_cat.get_entry(pp.destination_fmri), \
-                                     "fmri part of plan, but currently " \
-                                     "unknown: {0}".format(pp.destination_fmri)
-
-                # allocate an image plan based on the supplied plan
-                self._img.imageplan = imageplan.ImagePlan(self._img, plan._op,
-                    self.__progresstracker, check_cancel=self.__check_cancel,
-                    pd=plan)
-
-                if prepared:
-                        self._img.imageplan.skip_preexecute()
-
-                # create a history entry
-                self.log_operation_start(plan.plan_type)
-
-        def __linked_pubcheck(self, api_op=None):
-                """Private interface to perform publisher check on this image
-                and its children."""
-
-                if api_op in [API_OP_DETACH, API_OP_SET_MEDIATOR]:
-                        # we don't need to do a pubcheck for detach or
-                        # changing mediators
-                        return
-
-                # check the current image
-                self._img.linked.pubcheck()
-
-                # check child images
-                self._img.linked.api_recurse_pubcheck(self.__progresstracker)
-
-        @_LockedCancelable()
-        def linked_publisher_check(self):
-                """If we're a child image, verify that the parent image's
-                publisher configuration is a subset of the child image's
-                publisher configuration.  If we have any children, recurse
-                into them and perform a publisher check."""
-
-                # grab image lock.  we don't worry about dropping the image
-                # lock since __activity_lock will drop it for us us after we
-                # return (or if we generate an exception).
-                self._img.lock(allow_unprivileged=True)
-
-                # get ready to recurse
-                self._img.linked.api_recurse_init()
-
-                # check that linked image pubs are in sync
-                self.__linked_pubcheck()
-
-        @_LockedCancelable()
-        def hotfix_origin_cleanup(self):
-
-                # grab image lock. Cleanup is handled by the decorator.
-                self._img.lock(allow_unprivileged=False)
-
-                # prepare for recursion
-                self._img.linked.api_recurse_init()
-
-                # clean up the image
-                self._img.hotfix_origin_cleanup()
-
-                # clean up children
-                self._img.linked.api_recurse_hfo_cleanup(self.__progresstracker)
-
-        def planned_nothingtodo(self, li_ignore_all=False):
-                """Once an operation has been planned check if there is
-                something todo.
-
-                Callers should pass all arguments by name assignment and
-                not by positional order.
-
-                'li_ignore_all' indicates if we should only report on work
-                todo in the parent image.  (i.e., if an operation was planned
-                and that operation only involves changes to children, and
-                li_ignore_all is true, then we'll report that there's nothing
-                todo."""
-
-                if not self._img.imageplan:
-                        # if theres no plan there nothing to do
-                        return True
-                if not self._img.imageplan.nothingtodo():
-                        return False
-                if not self._img.linked.nothingtodo():
-                        return False
-                if not li_ignore_all:
-                        assert self.__planned_children
-                        if not self._img.linked.recurse_nothingtodo():
-                                return False
-                return True
-
-        def plan_update(self, pkg_list, refresh_catalogs=True,
-            reject_list=misc.EmptyI, noexecute=False, update_index=True,
-            be_name=None, new_be=False, repos=None, be_activate=True):
-                """DEPRECATED.  use gen_plan_update()."""
-                for pd in self.gen_plan_update(
-                    pkgs_update=pkg_list, refresh_catalogs=refresh_catalogs,
-                    reject_list=reject_list, noexecute=noexecute,
-                    update_index=update_index, be_name=be_name, new_be=new_be,
-                    repos=repos, be_activate=be_activate):
-                        continue
-                return not self.planned_nothingtodo()
-
-        def plan_update_all(self, refresh_catalogs=True,
-            reject_list=misc.EmptyI, noexecute=False, force=False,
-            update_index=True, be_name=None, new_be=True, repos=None,
-            be_activate=True):
-                """DEPRECATED.  use gen_plan_update()."""
-                for pd in self.gen_plan_update(
-                    refresh_catalogs=refresh_catalogs, reject_list=reject_list,
-                    noexecute=noexecute, force=force,
-                    update_index=update_index, be_name=be_name, new_be=new_be,
-                    repos=repos, be_activate=be_activate):
-                        continue
-                return (not self.planned_nothingtodo(), self.solaris_image())
-
-        def gen_plan_update(self, pkgs_update=None, act_timeout=0,
-            backup_be=None, backup_be_name=None, be_activate=True, be_name=None,
-            force=False, ignore_missing=False, li_ignore=None,
-            li_parent_sync=True, li_erecurse=None, new_be=True, noexecute=False,
-            pubcheck=True, refresh_catalogs=True, reject_list=misc.EmptyI,
-            repos=None, update_index=True):
-
-                """This is a generator function that yields a PlanDescription
-                object.  If parsable_version is set, it also yields dictionaries
-                containing plan information for child images.
-
-                If pkgs_update is not set, constructs a plan to update all
-                packages on the system to the latest known versions.  Once an
-                operation has been planned, it may be executed by first
-                calling prepare(), and then execute_plan().  After execution
-                of a plan, or to abandon a plan, reset() should be called.
-
-                Callers should pass all arguments by name assignment and
-                not by positional order.
-
-                If 'pkgs_update' is set, constructs a plan to update the
-                packages provided in pkgs_update.
-
-                Once an operation has been planned, it may be executed by
-                first calling prepare(), and then execute_plan().
-
-                'force' indicates whether update should skip the package
-                system up to date check.
-
-                'ignore_missing' indicates whether update should ignore packages
-                which are not installed.
-
-                'pubcheck' indicates that we should skip the child image
-                publisher check before creating a plan for this image.  only
-                pkg.1 should use this parameter, other callers should never
-                specify it.
-
-                For all other parameters, refer to the 'gen_plan_install'
-                function for an explanation of their usage and effects."""
-
-                if pkgs_update or force:
-                        ipkg_require_latest = False
-                else:
-                        ipkg_require_latest = True
-
-                op = API_OP_UPDATE
-                return self.__plan_op(op,
-                    _act_timeout=act_timeout, _backup_be=backup_be,
-                    _backup_be_name=backup_be_name, _be_activate=be_activate,
-                    _be_name=be_name, _ipkg_require_latest=ipkg_require_latest,
-                    _li_ignore=li_ignore, _li_parent_sync=li_parent_sync,
-                    _li_erecurse=li_erecurse, _new_be=new_be,
-                    _noexecute=noexecute, _pubcheck=pubcheck,
-                    _refresh_catalogs=refresh_catalogs, _repos=repos,
-                    _update_index=update_index, ignore_missing=ignore_missing,
-                    pkgs_update=pkgs_update, reject_list=reject_list,
-                    )
-
-        def plan_install(self, pkg_list, refresh_catalogs=True,
-            noexecute=False, update_index=True, be_name=None,
-            reject_list=misc.EmptyI, new_be=False, repos=None,
-            be_activate=True):
-                """DEPRECATED.  use gen_plan_install()."""
-                for pd in self.gen_plan_install(
-                     pkgs_inst=pkg_list, refresh_catalogs=refresh_catalogs,
-                     noexecute=noexecute, update_index=update_index,
-                     be_name=be_name, reject_list=reject_list, new_be=new_be,
-                     repos=repos, be_activate=be_activate):
-                        continue
-                return not self.planned_nothingtodo()
-
-        def gen_plan_install(self, pkgs_inst, act_timeout=0, backup_be=None,
-            backup_be_name=None, be_activate=True, be_name=None,
-            li_erecurse=None, li_ignore=None, li_parent_sync=True, new_be=False,
-            noexecute=False, pubcheck=True, refresh_catalogs=True,
-            reject_list=misc.EmptyI, repos=None, update_index=True):
-                """This is a generator function that yields a PlanDescription
-                object.  If parsable_version is set, it also yields dictionaries
-                containing plan information for child images.
-
-                Constructs a plan to install the packages provided in
-                pkgs_inst.  Once an operation has been planned, it may be
-                executed by first calling prepare(), and then execute_plan().
-                After execution of a plan, or to abandon a plan, reset()
-                should be called.
-
-                Callers should pass all arguments by name assignment and
-                not by positional order.
-
-                'act_timeout' sets the timeout for synchronous actuators in
-                seconds, -1 is no timeout, 0 is for using asynchronous
-                actuators.
-
-                'backup_be' indicates whether a backup boot environment should
-                be created before the operation is executed.  If True, a backup
-                boot environment will be created.  If False, a backup boot
-                environment will not be created. If None and a new boot
-                environment is not created, and packages are being updated or
-                are being installed and tagged with reboot-needed, a backup
-                boot environment will be created.
-
-                'backup_be_name' is a string to use as the name of any backup
-                boot environment created during the operation.
-
-                'be_activate' is an optional boolean indicating whether any
-                new boot environment created for the operation should be set
-                as the active one on next boot if the operation is successful.
-
-                'be_name' is a string to use as the name of any new boot
-                environment created during the operation.
-
-                'li_erecurse' is either None or a list. If it's None (the
-                default), the planning operation will not explicitly recurse
-                into linked children to perform the requested operation. If this
-                is a list of linked image children names, the requested
-                operation will be performed in each of the specified
-                children.
-
-                'li_ignore' is either None or a list.  If it's None (the
-                default), the planning operation will attempt to keep all
-                linked children in sync.  If it's an empty list the planning
-                operation will ignore all children.  If this is a list of
-                linked image children names, those children will be ignored
-                during the planning operation.  If a child is ignored during
-                the planning phase it will also be skipped during the
-                preparation and execution phases.
-
-                'li_parent_sync' if the current image is a child image, this
-                flag controls whether the linked image parent metadata will be
-                automatically refreshed.
-
-                'new_be' indicates whether a new boot environment should be
-                created during the operation.  If True, a new boot environment
-                will be created.  If False, and a new boot environment is
-                needed, an ImageUpdateOnLiveImageException will be raised.
-                If None, a new boot environment will be created only if needed.
-
-                'noexecute' determines whether the resulting plan can be
-                executed and whether history will be recorded after
-                planning is finished.
-
-                'pkgs_inst' is a list of packages to install.
-
-                'refresh_catalogs' controls whether the catalogs will
-                automatically be refreshed.
-
-                'reject_list' is a list of patterns not to be permitted
-                in solution; installed packages matching these patterns
-                are removed.
-
-                'repos' is a list of URI strings or RepositoryURI objects that
-                represent the locations of additional sources of package data to
-                use during the planned operation.  All API functions called
-                while a plan is still active will use this package data.
-
-                'update_index' determines whether client search indexes
-                will be updated after operation completion during plan
-                execution."""
-
-                # certain parameters must be specified
-                assert pkgs_inst and type(pkgs_inst) == list
-
-                op = API_OP_INSTALL
-                return self.__plan_op(op, _act_timeout=act_timeout,
-                    _backup_be=backup_be, _backup_be_name=backup_be_name,
-                    _be_activate=be_activate, _be_name=be_name,
-                    _li_erecurse=li_erecurse, _li_ignore=li_ignore,
-                    _li_parent_sync=li_parent_sync, _new_be=new_be,
-                    _noexecute=noexecute, _pubcheck=pubcheck,
-                    _refresh_catalogs=refresh_catalogs, _repos=repos,
-                    _update_index=update_index, pkgs_inst=pkgs_inst,
-                    reject_list=reject_list, )
-
-        def gen_plan_exact_install(self, pkgs_inst, backup_be=None,
-            backup_be_name=None, be_activate=True, be_name=None, li_ignore=None,
-            li_parent_sync=True, new_be=False, noexecute=False,
-            refresh_catalogs=True, reject_list=misc.EmptyI, repos=None,
-            update_index=True):
-                """This is a generator function that yields a PlanDescription
-                object.  If parsable_version is set, it also yields dictionaries
-                containing plan information for child images.
-
-                Constructs a plan to install exactly the packages provided in
-                pkgs_inst.  Once an operation has been planned, it may be
-                executed by first calling prepare(), and then execute_plan().
-                After execution of a plan, or to abandon a plan, reset()
-                should be called.
-
-                Callers should pass all arguments by name assignment and
-                not by positional order.
-
-                'pkgs_inst' is a list of packages to install exactly.
-
-                For all other parameters, refer to 'gen_plan_install'
-                for an explanation of their usage and effects."""
-
-                # certain parameters must be specified
-                assert pkgs_inst and type(pkgs_inst) == list
-
-                op = API_OP_EXACT_INSTALL
-                return self.__plan_op(op,
-                    _backup_be=backup_be, _backup_be_name=backup_be_name,
-                    _be_activate=be_activate, _be_name=be_name,
-                    _li_ignore=li_ignore, _li_parent_sync=li_parent_sync,
-                    _new_be=new_be, _noexecute=noexecute,
-                    _refresh_catalogs=refresh_catalogs, _repos=repos,
-                    _update_index=update_index, pkgs_inst=pkgs_inst,
-                    reject_list=reject_list)
-
-        def gen_plan_sync(self, backup_be=None, backup_be_name=None,
-            be_activate=True, be_name=None, li_ignore=None, li_md_only=False,
-            li_parent_sync=True, li_pkg_updates=True, new_be=False,
-            noexecute=False, pubcheck=True, refresh_catalogs=True,
-            reject_list=misc.EmptyI, repos=None, update_index=True):
-                """This is a generator function that yields a PlanDescription
-                object.  If parsable_version is set, it also yields dictionaries
-                containing plan information for child images.
-
-                Constructs a plan to sync the current image with its
-                linked image constraints.  Once an operation has been planned,
-                it may be executed by first calling prepare(), and then
-                execute_plan().  After execution of a plan, or to abandon a
-                plan, reset() should be called.
-
-                Callers should pass all arguments by name assignment and
-                not by positional order.
-
-                'li_md_only' don't actually modify any packages in the current
-                images, only sync the linked image metadata from the parent
-                image.  If this options is True, 'li_parent_sync' must also be
-                True.
-
-                'li_pkg_updates' when planning a sync operation, allow updates
-                to packages other than the constraints package.  If this
-                option is False, planning a sync will fail if any packages
-                (other than the constraints package) need updating to bring
-                the image in sync with its parent.
-
-                For all other parameters, refer to 'gen_plan_install' and
-                'gen_plan_update' for an explanation of their usage and
-                effects."""
-
-                # we should only be invoked on a child image.
-                if not self.ischild():
-                        raise apx.LinkedImageException(
-                            self_not_child=self._img_path)
-
-                op = API_OP_SYNC
-                return self.__plan_op(op,
-                    _backup_be=backup_be, _backup_be_name=backup_be_name,
-                    _be_activate=be_activate, _be_name=be_name,
-                    _li_ignore=li_ignore, _li_md_only=li_md_only,
-                    _li_parent_sync=li_parent_sync, _new_be=new_be,
-                    _noexecute=noexecute, _pubcheck=pubcheck,
-                    _refresh_catalogs=refresh_catalogs,
-                    _repos=repos,
-                    _update_index=update_index,
-                    li_pkg_updates=li_pkg_updates, reject_list=reject_list)
-
-        def gen_plan_attach(self, lin, li_path, allow_relink=False,
-            backup_be=None, backup_be_name=None, be_activate=True, be_name=None,
-            force=False, li_ignore=None, li_md_only=False, li_pkg_updates=True,
-            li_props=None, new_be=False, noexecute=False, refresh_catalogs=True,
-            reject_list=misc.EmptyI, repos=None, update_index=True):
-                """This is a generator function that yields a PlanDescription
-                object.  If parsable_version is set, it also yields dictionaries
-                containing plan information for child images.
-
-                Attach a parent image and sync the packages in the current
-                image with the new parent.  Once an operation has been
-                planned, it may be executed by first calling prepare(), and
-                then execute_plan().  After execution of a plan, or to abandon
-                a plan, reset() should be called.
-
-                Callers should pass all arguments by name assignment and
-                not by positional order.
-
-                'lin' a LinkedImageName object that is a name for the current
-                image.
-
-                'li_path' a path to the parent image.
-
-                'allow_relink' allows re-linking of an image that is already a
-                linked image child.  If this option is True we'll overwrite
-                all existing linked image metadata.
-
-                'li_props' optional linked image properties to apply to the
-                child image.
-
-                For all other parameters, refer to the 'gen_plan_install' and
-                'gen_plan_sync' functions for an explanation of their usage
-                and effects."""
-
-                if li_props is None:
-                        li_props = dict()
-
-                op = API_OP_ATTACH
-                ad_kwargs = {
-                    "allow_relink": allow_relink,
-                    "force": force,
-                    "lin": lin,
-                    "path": li_path,
-                    "props": li_props,
-                }
-                return self.__plan_op(op,
-                    _backup_be=backup_be, _backup_be_name=backup_be_name,
-                    _be_activate=be_activate, _be_name=be_name,
-                    _li_ignore=li_ignore, _li_md_only=li_md_only,
-                    _new_be=new_be, _noexecute=noexecute,
-                    _refresh_catalogs=refresh_catalogs, _repos=repos,
-                    _update_index=update_index, _ad_kwargs=ad_kwargs,
-                    li_pkg_updates=li_pkg_updates, reject_list=reject_list)
-
-        def gen_plan_detach(self, backup_be=None,
-            backup_be_name=None, be_activate=True, be_name=None, force=False,
-            li_ignore=None, li_md_only=False, li_pkg_updates=True, new_be=False,
-            noexecute=False):
-                """This is a generator function that yields a PlanDescription
-                object.  If parsable_version is set, it also yields dictionaries
-                containing plan information for child images.
-
-                Detach from a parent image and remove any constraints
-                package from this image.  Once an operation has been planned,
-                it may be executed by first calling prepare(), and then
-                execute_plan().  After execution of a plan, or to abandon a
-                plan, reset() should be called.
-
-                Callers should pass all arguments by name assignment and
-                not by positional order.
-
-                For all other parameters, refer to the 'gen_plan_install' and
-                'gen_plan_sync' functions for an explanation of their usage
-                and effects."""
-
-                op = API_OP_DETACH
-                ad_kwargs = {
-                    "force": force
-                }
-                return self.__plan_op(op, _ad_kwargs=ad_kwargs,
-                    _backup_be=backup_be, _backup_be_name=backup_be_name,
-                    _be_activate=be_activate, _be_name=be_name,
-                    _li_ignore=li_ignore, _li_md_only=li_md_only,
-                    _new_be=new_be, _noexecute=noexecute,
-                    _refresh_catalogs=False, _update_index=False,
-                    li_pkg_updates=li_pkg_updates)
-
-        def plan_uninstall(self, pkg_list, noexecute=False, update_index=True,
-            be_name=None, new_be=False, be_activate=True):
-                """DEPRECATED.  use gen_plan_uninstall()."""
-                for pd in self.gen_plan_uninstall(pkgs_to_uninstall=pkg_list,
-                    noexecute=noexecute, update_index=update_index,
-                    be_name=be_name, new_be=new_be, be_activate=be_activate):
-                        continue
-                return not self.planned_nothingtodo()
-
-        def gen_plan_uninstall(self, pkgs_to_uninstall, act_timeout=0,
-            backup_be=None, backup_be_name=None, be_activate=True,
-            be_name=None, ignore_missing=False, li_ignore=None,
-            li_parent_sync=True, li_erecurse=None, new_be=False, noexecute=False,
-            pubcheck=True, update_index=True):
-                """This is a generator function that yields a PlanDescription
-                object.  If parsable_version is set, it also yields dictionaries
-                containing plan information for child images.
-
-                Constructs a plan to remove the packages provided in
-                pkgs_to_uninstall.  Once an operation has been planned, it may
-                be executed by first calling prepare(), and then
-                execute_plan().  After execution of a plan, or to abandon a
-                plan, reset() should be called.
-
-                Callers should pass all arguments by name assignment and
-                not by positional order.
-
-                'ignore_missing' indicates whether uninstall should ignore
-                packages which are not installed.
-
-                'pkgs_to_uninstall' is a list of packages to uninstall.
-
-                For all other parameters, refer to the 'gen_plan_install'
-                function for an explanation of their usage and effects."""
-
-                # certain parameters must be specified
-                assert pkgs_to_uninstall and type(pkgs_to_uninstall) == list
-
-                op = API_OP_UNINSTALL
-                return self.__plan_op(op, _act_timeout=act_timeout,
-                    _backup_be=backup_be, _backup_be_name=backup_be_name,
-                    _be_activate=be_activate, _be_name=be_name,
-                    _li_erecurse=li_erecurse, _li_ignore=li_ignore,
-                    _li_parent_sync=li_parent_sync, _new_be=new_be,
-                    _noexecute=noexecute, _pubcheck=pubcheck,
-                    _refresh_catalogs=False, _update_index=update_index,
-                    ignore_missing=ignore_missing,
-                    pkgs_to_uninstall=pkgs_to_uninstall)
-
-        def gen_plan_set_mediators(self, mediators, backup_be=None,
-            backup_be_name=None, be_activate=True, be_name=None, li_ignore=None,
-            li_parent_sync=True, new_be=None, noexecute=False,
-            update_index=True):
-                """This is a generator function that yields a PlanDescription
-                object.  If parsable_version is set, it also yields dictionaries
-                containing plan information for child images.
-
-                Creates a plan to change the version and implementation values
-                for mediators as specified in the provided dictionary.  Once an
-                operation has been planned, it may be executed by first calling
-                prepare(), and then execute_plan().  After execution of a plan,
-                or to abandon a plan, reset() should be called.
-
-                Callers should pass all arguments by name assignment and not by
-                positional order.
-
-                'mediators' is a dict of dicts of the mediators to set version
-                and implementation for.  If the dict for a given mediator-name
-                is empty, it will be interpreted as a request to revert the
-                specified mediator to the default, "optimal" mediation.  It
-                should be of the form:
-
-                   {
-                       mediator-name: {
-                           "implementation": mediator-implementation-string,
-                           "version": mediator-version-string
-                       }
-                   }
-
-                   'implementation' is an optional string that specifies the
-                   implementation of the mediator for use in addition to or
-                   instead of 'version'.
-
-                   'version' is an optional string that specifies the version
-                   (expressed as a dot-separated sequence of non-negative
-                   integers) of the mediator for use.
-
-                For all other parameters, refer to the 'gen_plan_install'
-                function for an explanation of their usage and effects."""
-
-                assert mediators
-                return self.__plan_op(API_OP_SET_MEDIATOR,
-                    _backup_be=backup_be, _backup_be_name=backup_be_name,
-                    _be_activate=be_activate, _be_name=be_name,
-                    _li_ignore=li_ignore, _li_parent_sync=li_parent_sync,
-                    mediators=mediators, _new_be=new_be, _noexecute=noexecute,
-                    _refresh_catalogs=False, _update_index=update_index)
-
-        def plan_change_varcets(self, variants=None, facets=None,
-            noexecute=False, be_name=None, new_be=None, repos=None,
-            be_activate=True):
-                """DEPRECATED.  use gen_plan_change_varcets()."""
-                for pd in self.gen_plan_change_varcets(
-                    variants=variants, facets=facets, noexecute=noexecute,
-                    be_name=be_name, new_be=new_be, repos=repos,
-                    be_activate=be_activate):
-                        continue
-                return not self.planned_nothingtodo()
-
-        def gen_plan_change_varcets(self, facets=None, variants=None,
-            act_timeout=0, backup_be=None, backup_be_name=None,
-            be_activate=True, be_name=None, li_erecurse=None, li_ignore=None,
-            li_parent_sync=True, new_be=None, noexecute=False, pubcheck=True,
-            refresh_catalogs=True, reject_list=misc.EmptyI, repos=None,
-            update_index=True):
-                """This is a generator function that yields a PlanDescription
-                object.  If parsable_version is set, it also yields dictionaries
-                containing plan information for child images.
-
-                Creates a plan to change the specified variants and/or
-                facets for the image.  Once an operation has been planned, it
-                may be executed by first calling prepare(), and then
-                execute_plan().  After execution of a plan, or to abandon a
-                plan, reset() should be called.
-
-                Callers should pass all arguments by name assignment and
-                not by positional order.
-
-                'facets' is a dict of the facets to change the values of.
-
-                'variants' is a dict of the variants to change the values of.
-
-                For all other parameters, refer to the 'gen_plan_install'
-                function for an explanation of their usage and effects."""
-
-                # An empty facets dictionary is allowed because that's how to
-                # unset all set facets.
-                if not variants and facets is None:
-                        raise ValueError("Nothing to do")
-
-                invalid_names = []
-                if variants:
-                        op = API_OP_CHANGE_VARIANT
-                        # Check whether '*' or '?' is in the input. Currently,
-                        # change-variant does not accept globbing. Also check
-                        # for whitespaces.
-                        for variant in variants:
-                                if "*" in variant or "?" in variant:
-                                        raise apx.UnsupportedVariantGlobbing()
-                                if not misc.valid_varcet_name(variant):
-                                        invalid_names.append(variant)
-                else:
-                        op = API_OP_CHANGE_FACET
-                        for facet in facets:
-                                # Explict check for not None so that we can fix
-                                # a broken system from the past by clearing
-                                # the facet. Neither True of False should be
-                                # allowed for this special facet.
-                                if facet == "facet.version-lock.*" and \
-                                    facets[facet] is not None:
-                                        raise apx.UnsupportedFacetChange(facet,
-                                            facets[facet])
-                                if not misc.valid_varcet_name(facet):
-                                        invalid_names.append(facet)
-                if invalid_names:
-                        raise apx.InvalidVarcetNames(invalid_names)
-
-                return self.__plan_op(op, _act_timeout=act_timeout,
-                    _backup_be=backup_be, _backup_be_name=backup_be_name,
-                    _be_activate=be_activate, _be_name=be_name,
-                    _li_erecurse=li_erecurse, _li_ignore=li_ignore,
-                    _li_parent_sync=li_parent_sync, _new_be=new_be,
-                    _noexecute=noexecute, _pubcheck=pubcheck,
-                    _refresh_catalogs=refresh_catalogs, _repos=repos,
-                    _update_index=update_index, facets=facets,
-                    variants=variants, reject_list=reject_list)
-
-        def plan_revert(self, args, tagged=False, noexecute=True, be_name=None,
-            new_be=None, be_activate=True):
-                """DEPRECATED.  use gen_plan_revert()."""
-                for pd in self.gen_plan_revert(
-                    args=args, tagged=tagged, noexecute=noexecute,
-                    be_name=be_name, new_be=new_be, be_activate=be_activate):
-                        continue
-                return not self.planned_nothingtodo()
-
-        def gen_plan_revert(self, args, backup_be=None, backup_be_name=None,
-            be_activate=True, be_name=None, new_be=None, noexecute=True,
-            tagged=False):
-                """This is a generator function that yields a PlanDescription
-                object.  If parsable_version is set, it also yields dictionaries
-                containing plan information for child images.
-
-                Plan to revert either files or all files tagged with
-                specified values.  Args contains either path names or tag
-                names to be reverted, tagged is True if args contains tags.
-                Once an operation has been planned, it may be executed by
-                first calling prepare(), and then execute_plan().  After
-                execution of a plan, or to abandon a plan, reset() should be
-                called.
-
-                For all other parameters, refer to the 'gen_plan_install'
-                function for an explanation of their usage and effects."""
-
-                op = API_OP_REVERT
-                return self.__plan_op(op, _be_activate=be_activate,
-                    _backup_be=backup_be, _backup_be_name=backup_be_name,
-                    _be_name=be_name, _li_ignore=[], _new_be=new_be,
-                    _noexecute=noexecute, _refresh_catalogs=False,
-                    _update_index=False, args=args, tagged=tagged)
-
-        def gen_plan_dehydrate(self, publishers=None, noexecute=True):
-                """This is a generator function that yields a PlanDescription
-                object.
-
-                Plan to remove non-editable files and hardlinks from an image.
-                Once an operation has been planned, it may be executed by
-                first calling prepare(), and then execute_plan().  After
-                execution of a plan, or to abandon a plan, reset() should be
-                called.
-
-                'publishers' is a list of publishers to dehydrate.
-
-                For all other parameters, refer to the 'gen_plan_install'
-                function for an explanation of their usage and effects."""
-
-                op = API_OP_DEHYDRATE
-                return self.__plan_op(op, _noexecute=noexecute,
-                    _refresh_catalogs=False, _update_index=False,
-                    publishers=publishers)
-
-        def gen_plan_rehydrate(self, publishers=None, noexecute=True):
-                """This is a generator function that yields a PlanDescription
-                object.
-
-                Plan to reinstall non-editable files and hardlinks to a dehydrated
-                image. Once an operation has been planned, it may be executed by
-                first calling prepare(), and then execute_plan().  After
-                execution of a plan, or to abandon a plan, reset() should be
-                called.
-
-                'publishers' is a list of publishers to dehydrate on.
-
-                For all other parameters, refer to the 'gen_plan_install'
-                function for an explanation of their usage and effects."""
-
-                op = API_OP_REHYDRATE
-                return self.__plan_op(op, _noexecute=noexecute,
-                    _refresh_catalogs=False, _update_index=False,
-                    publishers=publishers)
-
-        def gen_plan_verify(self, args, noexecute=True, unpackaged=False,
-            unpackaged_only=False, verify_paths=misc.EmptyI):
-                """This is a generator function that yields a PlanDescription
-                object.
-
-                Plan to repair anything that fails to verify. Once an operation
-                has been planned, it may be executed by first calling prepare(),
-                and then execute_plan().  After execution of a plan, or to
-                abandon a plan, reset() should be called.
-
-                For parameters, refer to the 'gen_plan_install'
-                function for an explanation of their usage and effects."""
-
-                op = API_OP_VERIFY
-                return self.__plan_op(op, args=args, _noexecute=noexecute,
-                    _refresh_catalogs=False, _update_index=False, _new_be=None,
-                    unpackaged=unpackaged, unpackaged_only=unpackaged_only,
-                    verify_paths=verify_paths)
-
-        def gen_plan_fix(self, args, backup_be=None, backup_be_name=None,
-            be_activate=True, be_name=None, new_be=None, noexecute=True,
-            unpackaged=False):
-                """This is a generator function that yields a PlanDescription
-                object.
-
-                Plan to repair anything that fails to verify. Once an operation
-                has been planned, it may be executed by first calling prepare(),
-                and then execute_plan().  After execution of a plan, or to
-                abandon a plan, reset() should be called.
-
-                For parameters, refer to the 'gen_plan_install'
-                function for an explanation of their usage and effects."""
-
-                op = API_OP_FIX
-                return self.__plan_op(op, args=args, _be_activate=be_activate,
-                    _backup_be=backup_be, _backup_be_name=backup_be_name,
-                    _be_name=be_name, _new_be=new_be, _noexecute=noexecute,
-                    _refresh_catalogs=False, _update_index=False,
-                    unpackaged=unpackaged)
-
-        def attach_linked_child(self, lin, li_path, li_props=None,
-            accept=False, allow_relink=False, force=False, li_md_only=False,
-            li_pkg_updates=True, noexecute=False,
-            refresh_catalogs=True, reject_list=misc.EmptyI,
-            show_licenses=False, update_index=True):
-                """Attach an image as a child to the current image (the
-                current image will become a parent image. This operation
-                results in attempting to sync the child image with the parent
-                image.
-
-                'lin' is the name of the child image
-
-                'li_path' is the path to the child image
-
-                'li_props' optional linked image properties to apply to the
-                child image.
-
-                'allow_relink' indicates whether we should allow linking of a
-                child image that is already linked (the child may already
-                be a child or a parent image).
-
-                'force' indicates whether we should allow linking of a child
-                image even if the specified linked image type doesn't support
-                attaching of children.
-
-                'li_md_only' indicates whether we should only update linked
-                image metadata and not actually try to sync the child image.
-
-                'li_pkg_updates' indicates whether we should disallow pkg
-                updates during the child image sync.
-
-                'noexecute' indicates if we should actually make any changes
-                rather or just simulate the operation.
-
-                'refresh_catalogs' controls whether the catalogs will
-                automatically be refreshed.
-
-                'reject_list' is a list of patterns not to be permitted
-                in solution; installed packages matching these patterns
-                are removed.
-
-                'update_index' determines whether client search indexes will
-                be updated in the child after the sync operation completes.
-
-                This function returns a tuple of the format (rv, err) where rv
-                is a pkg.client.pkgdefs return value and if an error was
-                encountered err is an exception object which describes the
-                error."""
-
-                return self._img.linked.attach_child(lin, li_path, li_props,
-                    accept=accept, allow_relink=allow_relink, force=force,
-                    li_md_only=li_md_only, li_pkg_updates=li_pkg_updates,
-                    noexecute=noexecute,
-                    progtrack=self.__progresstracker,
-                    refresh_catalogs=refresh_catalogs, reject_list=reject_list,
-                    show_licenses=show_licenses, update_index=update_index)
-
-        def detach_linked_children(self, li_list, force=False,
-            li_md_only=False, li_pkg_updates=True, noexecute=False):
-                """Detach one or more children from the current image. This
-                operation results in the removal of any constraint package
-                from the child images.
-
-                'li_list' a list of linked image name objects which specified
-                which children to operate on.  If the list is empty then we
-                operate on all children.
-
-                For all other parameters, refer to the 'attach_linked_child'
-                function for an explanation of their usage and effects.
-
-                This function returns a dictionary where the keys are linked
-                image name objects and the values are the result of the
-                specified operation on the associated child image.  The result
-                is a tuple of the format (rv, err) where rv is a
-                pkg.client.pkgdefs return value and if an error was
-                encountered err is an exception object which describes the
-                error."""
-
-                return self._img.linked.detach_children(li_list,
-                    force=force, li_md_only=li_md_only,
-                    li_pkg_updates=li_pkg_updates,
-                    noexecute=noexecute)
-
-        def detach_linked_rvdict2rv(self, rvdict):
-                """Convenience function that takes a dictionary returned from
-                an operations on multiple children and merges the results into
-                a single return code."""
-
-                return self._img.linked.detach_rvdict2rv(rvdict)
-
-        def sync_linked_children(self, li_list,
-            accept=False, li_md_only=False,
-            li_pkg_updates=True, noexecute=False,
-            refresh_catalogs=True, show_licenses=False, update_index=True):
-                """Sync one or more children of the current image.
-
-                For all other parameters, refer to the 'attach_linked_child'
-                and 'detach_linked_children' functions for an explanation of
-                their usage and effects.
-
-                For a description of the return value, refer to the
-                'detach_linked_children' function."""
-
-                rvdict = self._img.linked.sync_children(li_list,
-                    accept=accept, li_md_only=li_md_only,
-                    li_pkg_updates=li_pkg_updates, noexecute=noexecute,
-                    progtrack=self.__progresstracker,
-                    refresh_catalogs=refresh_catalogs,
-                    show_licenses=show_licenses, update_index=update_index)
-                return rvdict
-
-        def sync_linked_rvdict2rv(self, rvdict):
-                """Convenience function that takes a dictionary returned from
-                an operations on multiple children and merges the results into
-                a single return code."""
-
-                return self._img.linked.sync_rvdict2rv(rvdict)
-
-        def audit_linked_children(self, li_list):
-                """Audit one or more children of the current image to see if
-                they are in sync with this image.
-
-                For all parameters, refer to the 'detach_linked_children'
-                functions for an explanation of their usage and effects.
-
-                For a description of the return value, refer to the
-                'detach_linked_children' function."""
-
-                rvdict = self._img.linked.audit_children(li_list)
-                return rvdict
-
-        def audit_linked_rvdict2rv(self, rvdict):
-                """Convenience function that takes a dictionary returned from
-                an operations on multiple children and merges the results into
-                a single return code."""
-
-                return self._img.linked.audit_rvdict2rv(rvdict)
-
-        def audit_linked(self, li_parent_sync=True):
-                """If the current image is a child image, this function
-                audits the current image to see if it's in sync with it's
-                parent.
-
-                For a description of the return value, refer to the
-                'detach_linked_children' function."""
-
-                lin = self._img.linked.child_name
-                rvdict = {}
-
-                if li_parent_sync:
-                        # refresh linked image data from parent image.
-                        rvdict[lin] = self._img.linked.syncmd_from_parent(
-                            catch_exception=True)
-                        if rvdict[lin] is not None:
-                                return rvdict
-
-                rvdict[lin] = self._img.linked.audit_self()
-                return rvdict
-
-        def ischild(self):
-                """Indicates whether the current image is a child image."""
-                return self._img.linked.ischild()
-
-        def isparent(self, li_ignore=None):
-                """Indicates whether the current image is a parent image."""
-                return self._img.linked.isparent(li_ignore)
-
-        @staticmethod
-        def __utc_format(time_str, utc_now):
-                """Given a local time value string, formatted with
-                "%Y-%m-%dT%H:%M:%S, return a UTC representation of that value,
-                formatted with %Y%m%dT%H%M%SZ.  This raises a ValueError if the
-                time was incorrectly formatted.  If the time_str is "now", it
-                returns the value of utc_now"""
-
-                if time_str == "now":
-                        return utc_now
-
-                try:
-                        local_dt = datetime.datetime.strptime(time_str,
-                            "%Y-%m-%dT%H:%M:%S")
-                        secs = time.mktime(local_dt.timetuple())
-                        utc_dt = datetime.datetime.utcfromtimestamp(secs)
-                        return utc_dt.strftime("%Y%m%dT%H%M%SZ")
-                except ValueError as e:
-                        raise apx.HistoryRequestException(e)
-
-        def __get_history_paths(self, time_val, utc_now):
-                """Given a local timestamp, either as a discrete value, or a
-                range of values, formatted as '<timestamp>-<timestamp>', and a
-                path to find history xml files, return an array of paths that
-                match that timestamp.  utc_now is the current time expressed in
-                UTC"""
-
-                files = []
-                if len(time_val) > 20 or time_val.startswith("now-"):
-                        if time_val.startswith("now-"):
-                                start = utc_now
-                                finish = self.__utc_format(time_val[4:],
-                                    utc_now)
-                        else:
-                                # our ranges are 19 chars of timestamp, a '-',
-                                # and another timestamp
-                                start = self.__utc_format(time_val[:19],
-                                    utc_now)
-                                finish = self.__utc_format(time_val[20:],
-                                    utc_now)
-                        if start > finish:
-                                raise apx.HistoryRequestException(_("Start "
-                                    "time must be older than finish time: "
-                                    "{0}").format(time_val))
-                        files = self.__get_history_range(start, finish)
-                else:
-                        # there can be multiple event files per timestamp
-                        prefix = self.__utc_format(time_val, utc_now)
-                        files = glob.glob(os.path.join(self._img.history.path,
-                            "{0}*".format(prefix)))
-                if not files:
-                        raise apx.HistoryRequestException(_("No history "
-                            "entries found for {0}").format(time_val))
-                return files
-
-        def __get_history_range(self, start, finish):
-                """Given a start and finish date, formatted as UTC date strings
-                as per __utc_format(), return a list of history filenames that
-                fall within that date range.  A range of two equal dates is
-                the equivalent of just retrieving history for that single date
-                string."""
-
-                entries = []
-                all_entries = sorted(os.listdir(self._img.history.path))
-
-                for entry in all_entries:
-                        # our timestamps are always 16 character datestamps
-                        basename = os.path.basename(entry)[:16]
-                        if basename >= start:
-                                if basename > finish:
-                                        # we can stop looking now.
-                                        break
-                                entries.append(entry)
-                return entries
-
-        def gen_history(self, limit=None, times=misc.EmptyI):
-                """A generator function that returns History objects up to the
-                limit specified matching the times specified.
-
-                'limit' is an optional integer value specifying the maximum
-                number of entries to return.
-
-                'times' is a list of timestamp or timestamp range strings to
-                restrict the returned entries to."""
-
-                # Make entries a set to cope with multiple overlapping ranges or
-                # times.
-                entries = set()
-
-                utc_now = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
-                for time_val in times:
-                        # Ranges are 19 chars of timestamp, a '-', and
-                        # another timestamp.
-                        if len(time_val) > 20 or time_val.startswith("now-"):
-                                if time_val.startswith("now-"):
-                                        start = utc_now
-                                        finish = self.__utc_format(time_val[4:],
-                                            utc_now)
-                                else:
-                                        start = self.__utc_format(time_val[:19],
-                                            utc_now)
-                                        finish = self.__utc_format(
-                                            time_val[20:], utc_now)
-                                if start > finish:
-                                        raise apx.HistoryRequestException(
-                                            _("Start time must be older than "
-                                            "finish time: {0}").format(
-                                            time_val))
-                                files = self.__get_history_range(start, finish)
-                        else:
-                                # There can be multiple entries per timestamp.
-                                prefix = self.__utc_format(time_val, utc_now)
-                                files = glob.glob(os.path.join(
-                                    self._img.history.path, "{0}*".format(
-                                    prefix)))
-
-                        try:
-                                files = self.__get_history_paths(time_val,
-                                    utc_now)
-                                entries.update(files)
-                        except ValueError:
-                                raise apx.HistoryRequestException(_("Invalid "
-                                    "time format '{0}'.  Please use "
-                                    "%Y-%m-%dT%H:%M:%S or\n"
-                                    "%Y-%m-%dT%H:%M:%S-"
-                                    "%Y-%m-%dT%H:%M:%S").format(time_val))
-
-                if not times:
-                        try:
-                                entries = os.listdir(self._img.history.path)
-                        except EnvironmentError as e:
-                                if e.errno == errno.ENOENT:
-                                        # No history to list.
-                                        return
-                                raise apx._convert_error(e)
-
-                entries = sorted(entries)
-                if limit:
-                        limit *= -1
-                        entries = entries[limit:]
-
-                try:
-                        uuid_be_dic = bootenv.BootEnv.get_uuid_be_dic()
-                except apx.ApiException as e:
-                        uuid_be_dic = {}
-
-                for entry in entries:
-                        # Yield each history entry object as it is loaded.
-                        try:
-                                yield history.History(
-                                    root_dir=self._img.history.root_dir,
-                                    filename=entry, uuid_be_dic=uuid_be_dic)
-                        except apx.HistoryLoadException as e:
-                                if e.parse_failure:
-                                        # Ignore corrupt entries.
-                                        continue
-                                raise
-
-        def get_linked_name(self):
-                """If the current image is a child image, this function
-                returns a linked image name object which represents the name
-                of the current image."""
-                return self._img.linked.child_name
-
-        def get_linked_props(self, lin=None):
-                """Return a dictionary which represents the linked image
-                properties associated with a linked image.
-
-                'lin' is the name of the child image.  If lin is None then
-                the current image is assumed to be a linked image and it's
-                properties are returned."""
-
-                return self._img.linked.child_props(lin=lin)
-
-        def list_linked(self, li_ignore=None):
-                """Returns a list of linked images associated with the
-                current image.  This includes both child and parent images.
-
-                For all parameters, refer to the 'gen_plan_install' function
-                for an explanation of their usage and effects.
-
-                The returned value is a list of tuples where each tuple
-                contains (<li name>, <relationship>, <li path>)."""
-
-                return self._img.linked.list_related(li_ignore=li_ignore)
-
-        def parse_linked_name(self, li_name, allow_unknown=False):
-                """Given a string representing a linked image child name,
-                returns linked image name object representing the same name.
-
-                'allow_unknown' indicates whether the name must represent
-                actual children or simply be syntactically correct."""
-
-                return self._img.linked.parse_name(li_name, allow_unknown)
-
-        def parse_linked_name_list(self, li_name_list, allow_unknown=False):
-                """Given a list of strings representing linked image child
-                names, returns a list of linked image name objects
-                representing the same names.
-
-                For all other parameters, refer to the 'parse_linked_name'
-                function for an explanation of their usage and effects."""
-
-                return [
-                    self.parse_linked_name(li_name, allow_unknown)
-                    for li_name in li_name_list
-                ]
-
-        def describe(self):
-                """Returns None if no plan is ready yet, otherwise returns
-                a PlanDescription."""
-
-                return self.__plan_desc
-
-        def prepare(self):
-                """Takes care of things which must be done before the plan can
-                be executed.  This includes downloading the packages to disk and
-                preparing the indexes to be updated during execution.  Should
-                only be called once a gen_plan_*() method has been called.  If
-                a plan is abandoned after calling this method, reset() should
-                be called."""
-
-                self._acquire_activity_lock()
-                try:
-                        self._img.lock()
-                except:
-                        self._activity_lock.release()
-                        raise
-
-                try:
-                        if not self._img.imageplan:
-                                raise apx.PlanMissingException()
-
-                        if not self.__planned_children:
-                                # if we never planned children images then we
-                                # didn't finish planning.
-                                raise apx.PlanMissingException()
-
-                        if self.__prepared:
-                                raise apx.AlreadyPreparedException()
-
-                        self._enable_cancel()
-
-                        try:
-                                self._img.imageplan.preexecute()
-                        except search_errors.ProblematicPermissionsIndexException as e:
-                                raise apx.ProblematicPermissionsIndexException(e)
-                        except:
-                                raise
-
-                        self._disable_cancel()
-                        self.__prepared = True
-                except apx.CanceledException as e:
-                        self._cancel_done()
-                        if self._img.history.operation_name:
-                                # If an operation is in progress, log
-                                # the error and mark its end.
-                                self.log_operation_end(error=e)
-                        raise
-                except Exception as e:
-                        self._cancel_cleanup_exception()
-                        if self._img.history.operation_name:
-                                # If an operation is in progress, log
-                                # the error and mark its end.
-                                self.log_operation_end(error=e)
-                        raise
-                except:
-                        # Handle exceptions that are not subclasses of
-                        # Exception.
-                        self._cancel_cleanup_exception()
-                        if self._img.history.operation_name:
-                                # If an operation is in progress, log
-                                # the error and mark its end.
-                                exc_type, exc_value, exc_traceback = \
-                                    sys.exc_info()
-                                self.log_operation_end(error=exc_type)
-                        raise
-                finally:
-                        self._img.cleanup_downloads()
-                        self._img.unlock()
-                        try:
-                                if int(os.environ.get("PKG_DUMP_STATS", 0)) > 0:
-                                        self._img.transport.stats.dump()
-                        except ValueError:
-                                # Don't generate stats if an invalid value
-                                # is supplied.
-                                pass
-                        self._activity_lock.release()
-
-                self._img.linked.api_recurse_prepare(self.__progresstracker)
-
-        def execute_plan(self):
-                """Executes the plan. This is uncancelable once it begins.
-                Should only be called after the prepare method has been
-                called.  After plan execution, reset() should be called."""
-
-                self._acquire_activity_lock()
-                try:
-                        self._disable_cancel()
-                        self._img.lock()
-                except:
-                        self._activity_lock.release()
-                        raise
-
-                try:
-                        if not self._img.imageplan:
-                                raise apx.PlanMissingException()
-
-                        if not self.__prepared:
-                                raise apx.PrematureExecutionException()
-
-                        if self.__executed:
-                                raise apx.AlreadyExecutedException()
-
-                        try:
-                                be = bootenv.BootEnv(self._img,
-                                    self.__progresstracker)
-                        except RuntimeError:
-                                be = bootenv.BootEnvNull(self._img)
-                        self._img.bootenv = be
-
-                        if not self.__new_be and \
-                            self._img.imageplan.reboot_needed() and \
-                            self._img.is_liveroot():
-                                e = apx.RebootNeededOnLiveImageException()
-                                self.log_operation_end(error=e)
-                                raise e
-
-                        # Before proceeding, create a backup boot environment if
-                        # requested.
-                        if self.__backup_be:
-                                try:
-                                        be.create_backup_be(
-                                            be_name=self.__backup_be_name)
-                                except Exception as e:
-                                        self.log_operation_end(error=e)
-                                        raise
-                                except:
-                                        # Handle exceptions that are not
-                                        # subclasses of Exception.
-                                        exc_type, exc_value, exc_traceback = \
-                                            sys.exc_info()
-                                        self.log_operation_end(error=exc_type)
-                                        raise
-
-                        # After (possibly) creating backup be, determine if
-                        # operation should execute on a clone of current BE.
-                        if self.__new_be:
-                                try:
-                                        be.init_image_recovery(self._img,
-                                            self.__be_name)
-                                except Exception as e:
-                                        self.log_operation_end(error=e)
-                                        raise
-                                except:
-                                        # Handle exceptions that are not
-                                        # subclasses of Exception.
-                                        exc_type, exc_value, exc_traceback = \
-                                            sys.exc_info()
-                                        self.log_operation_end(error=exc_type)
-                                        raise
-                                # check if things gained underneath us
-                                if self._img.is_liveroot():
-                                        e = apx.UnableToCopyBE()
-                                        self.log_operation_end(error=e)
-                                        raise e
-
-                        raise_later = None
-
-                        # we're about to execute a plan so change our current
-                        # working directory to / so that we won't fail if we
-                        # try to remove our current working directory
-                        os.chdir(os.sep)
-
-                        try:
-                                try:
-                                        self._img.imageplan.execute()
-                                except apx.WrapIndexingException as e:
-                                        raise_later = e
-
-                                if not self._img.linked.nothingtodo():
-                                        self._img.linked.syncmd()
-                        except RuntimeError as e:
-                                if self.__new_be:
-                                        be.restore_image()
-                                else:
-                                        be.restore_install_uninstall()
-                                # Must be done after bootenv restore.
-                                self.log_operation_end(error=e)
-                                raise
-                        except search_errors.IndexLockedException as e:
-                                error = apx.IndexLockedException(e)
-                                self.log_operation_end(error=error)
-                                raise error
-                        except search_errors.ProblematicPermissionsIndexException as e:
-                                error = apx.ProblematicPermissionsIndexException(e)
-                                self.log_operation_end(error=error)
-                                raise error
-                        except search_errors.InconsistentIndexException as e:
-                                error = apx.CorruptedIndexException(e)
-                                self.log_operation_end(error=error)
-                                raise error
-                        except NonzeroExitException as e:
-                                # Won't happen during update
-                                be.restore_install_uninstall()
-                                error = apx.ActuatorException(e)
-                                self.log_operation_end(error=error)
-                                raise error
-                        except apx.InvalidMediatorTarget as e:
-                                # Mount a new BE but do not activate it in case the
-                                # missing mediator target will cause a broken system.
-                                # Allows the admin to take the appropriate action.
-                                if self.__new_be:
-                                        be.restore_image()
-                                self.log_operation_end(error=e)
-                                raise e
-                        except Exception as e:
-                                if self.__new_be:
-                                        be.restore_image()
-                                else:
-                                        be.restore_install_uninstall()
-                                # Must be done after bootenv restore.
-                                self.log_operation_end(error=e)
-                                raise
-                        except:
-                                # Handle exceptions that are not subclasses of
-                                # Exception.
-                                exc_type, exc_value, exc_traceback = \
-                                    sys.exc_info()
-
-                                if self.__new_be:
-                                        be.restore_image()
-                                else:
-                                        be.restore_install_uninstall()
-                                # Must be done after bootenv restore.
-                                self.log_operation_end(error=exc_type)
-                                raise
-
-                        self._img.linked.api_recurse_execute(
-                            self.__progresstracker)
-
-                        self.__finished_execution(be)
-                        if raise_later:
-                                raise raise_later
-
-                finally:
-                        self._img.cleanup_downloads()
-                        if self._img.locked:
-                                self._img.unlock()
-                        self._activity_lock.release()
-
-        def __finished_execution(self, be):
-                if self._img.imageplan.state != plandesc.EXECUTED_OK:
-                        if self.__new_be:
-                                be.restore_image()
-                        else:
-                                be.restore_install_uninstall()
-
-                        error = apx.ImageplanStateException(
-                            self._img.imageplan.state)
-                        # Must be done after bootenv restore.
-                        self.log_operation_end(error=error)
-                        raise error
-
-                if self._img.imageplan.boot_archive_needed() or \
-                    self.__new_be:
-                        be.update_boot_archive()
-
-                self._img.hotfix_origin_cleanup()
-
-                if self.__new_be:
-                        be.activate_image(set_active=self.__be_activate)
-                else:
-                        be.activate_install_uninstall()
-                self._img.cleanup_cached_content(
-                    progtrack=self.__progresstracker)
-                # If the end of the operation wasn't already logged
-                # by one of the previous operations, then log it as
-                # ending now.
-                if self._img.history.operation_name:
-                        self.log_operation_end(release_notes=
-                            self._img.imageplan.pd.release_notes_name)
-                self.__executed = True
-
-        def set_plan_license_status(self, pfmri, plicense, accepted=None,
-            displayed=None):
-                """Sets the license status for the given package FMRI and
-                license entry.
-
-                'accepted' is an optional parameter that can be one of three
-                values:
-                        None    leaves accepted status unchanged
-                        False   sets accepted status to False
-                        True    sets accepted status to True
-
-                'displayed' is an optional parameter that can be one of three
-                values:
-                        None    leaves displayed status unchanged
-                        False   sets displayed status to False
-                        True    sets displayed status to True"""
-
-                self._acquire_activity_lock()
-                try:
-                        try:
-                                self._disable_cancel()
-                        except apx.CanceledException:
-                                self._cancel_done()
-                                raise
-
-                        if not self._img.imageplan:
-                                raise apx.PlanMissingException()
-
-                        for pp in self.__plan_desc.pkg_plans:
-                                if pp.destination_fmri == pfmri:
-                                        pp.set_license_status(plicense,
-                                            accepted=accepted,
-                                            displayed=displayed)
-                                        break
-                finally:
-                        self._activity_lock.release()
-
-        def refresh(self, full_refresh=False, pubs=None, immediate=False,
-            ignore_unreachable=True):
-                """Refreshes the metadata (e.g. catalog) for one or more
-                publishers.
-
-                'full_refresh' is an optional boolean value indicating whether
-                a full retrieval of publisher metadata (e.g. catalogs) or only
-                an update to the existing metadata should be performed.  When
-                True, 'immediate' is also set to True.
-
-                'pubs' is a list of publisher prefixes or publisher objects
-                to refresh.  Passing an empty list or using the default value
-                implies all publishers.
-
-                'immediate' is an optional boolean value indicating whether
-                a refresh should occur now.  If False, a publisher's selected
-                repository will only be checked for updates if the update
-                interval period recorded in the image configuration has been
-                exceeded.
-
-                'ignore_unreachable' is an optional boolean value indicating
-                whether unreachable repositories should be ignored. If True,
-                errors contacting this repository are stored in the transport
-                but no exception is raised, allowing an operation to continue
-                if an unneeded repository is not online.
-
-                Currently returns an image object, allowing existing code to
-                work while the rest of the API is put into place."""
-
-                self._acquire_activity_lock()
-                try:
-                        self._disable_cancel()
-                        self._img.lock()
-                        try:
-                                self.__refresh(full_refresh=full_refresh,
-                                    pubs=pubs,
-                                    ignore_unreachable=ignore_unreachable,
-                                    immediate=immediate)
-                                return self._img
-                        finally:
-                                self._img.unlock()
-                                self._img.cleanup_downloads()
-                except apx.CanceledException:
-                        self._cancel_done()
-                        raise
-                finally:
-                        try:
-                                if int(os.environ.get("PKG_DUMP_STATS", 0)) > 0:
-                                        self._img.transport.stats.dump()
-                        except ValueError:
-                                # Don't generate stats if an invalid value
-                                # is supplied.
-                                pass
-                        self._activity_lock.release()
-
-        def __refresh(self, full_refresh=False, pubs=None, immediate=False,
-            ignore_unreachable=True):
-                """Private refresh method; caller responsible for locking and
-                cleanup."""
-
-                self._img.refresh_publishers(full_refresh=full_refresh,
-                    ignore_unreachable=ignore_unreachable,
-                    immediate=immediate, pubs=pubs,
-                    progtrack=self.__progresstracker)
-
-        def __licenses(self, pfmri, mfst, alt_pub=None):
-                """Private function. Returns the license info from the
-                manifest mfst."""
-                license_lst = []
-                for lic in mfst.gen_actions_by_type("license"):
-                        license_lst.append(LicenseInfo(pfmri, lic,
-                            img=self._img, alt_pub=alt_pub))
-                return license_lst
-
-        @_LockedCancelable()
-        def get_pkg_categories(self, installed=False, pubs=misc.EmptyI,
-            repos=None):
-                """Returns an ordered list of tuples of the form (scheme,
-                category) containing the names of all categories in use by
-                the last version of each unique package in the catalog on a
-                per-publisher basis.
-
-                'installed' is an optional boolean value indicating whether
-                only the categories used by currently installed packages
-                should be returned.  If False, the categories used by the
-                latest vesion of every known package will be returned
-                instead.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to.
-
-                'repos' is a list of URI strings or RepositoryURI objects that
-                represent the locations of package repositories to list packages
-                for.
-                """
-
-                if installed:
-                        excludes = misc.EmptyI
-                else:
-                        excludes = self._img.list_excludes()
-
-                if repos:
-                        ignored, ignored, known_cat, inst_cat = \
-                            self.__get_alt_pkg_data(repos)
-                        if installed:
-                                pkg_cat = inst_cat
-                        else:
-                                pkg_cat = known_cat
-                elif installed:
-                        pkg_cat = self._img.get_catalog(
-                            self._img.IMG_CATALOG_INSTALLED)
-                else:
-                        pkg_cat = self._img.get_catalog(
-                            self._img.IMG_CATALOG_KNOWN)
-                return sorted(pkg_cat.categories(excludes=excludes, pubs=pubs))
-
-        def __map_installed_newest(self, pubs, known_cat=None):
-                """Private function.  Maps incorporations and publisher
-                relationships for installed packages and returns them
-                as a tuple of (pub_ranks, inc_stems, inc_vers, inst_stems,
-                ren_stems, ren_inst_stems).
-                """
-
-                img_cat = self._img.get_catalog(
-                    self._img.IMG_CATALOG_INSTALLED)
-                cat_info = frozenset([img_cat.DEPENDENCY])
-
-                inst_stems = {}
-                ren_inst_stems = {}
-                ren_stems = {}
-
-                inc_stems = {}
-                inc_vers = {}
-
-                pub_ranks = self._img.get_publisher_ranks()
-
-                # The incorporation list should include all installed,
-                # incorporated packages from all publishers.
-                for t in img_cat.entry_actions(cat_info):
-                        (pub, stem, ver), entry, actions = t
-
-                        inst_stems[stem] = ver
-                        pkgr = False
-                        targets = set()
-                        try:
-                                for a in actions:
-                                        if a.name == "set" and \
-                                            a.attrs["name"] == "pkg.renamed":
-                                                pkgr = True
-                                                continue
-                                        elif a.name != "depend":
-                                                continue
-
-                                        if a.attrs["type"] == "require":
-                                                # Because the actions are not
-                                                # returned in a guaranteed
-                                                # order, the dependencies will
-                                                # have to be recorded for
-                                                # evaluation later.
-                                                targets.add(a.attrs["fmri"])
-                                        elif a.attrs["type"] == "incorporate":
-                                                # Record incorporated packages.
-                                                tgt = fmri.PkgFmri(
-                                                    a.attrs["fmri"])
-                                                tver = tgt.version
-                                                # incorporates without a version
-                                                # should be ignored.
-                                                if not tver:
-                                                        continue
-                                                over = inc_vers.get(
-                                                    tgt.pkg_name, None)
-
-                                                # In case this package has been
-                                                # incorporated more than once,
-                                                # use the newest version.
-                                                if over is not None and \
-                                                    over > tver:
-                                                        continue
-                                                inc_vers[tgt.pkg_name] = tver
-                        except apx.InvalidPackageErrors:
-                                # For mapping purposes, ignore unsupported
-                                # (and invalid) actions.  This is necessary so
-                                # that API consumers can discover new package
-                                # data that may be needed to perform an upgrade
-                                # so that the API can understand them.
-                                pass
-
-                        if pkgr:
-                                for f in targets:
-                                        tgt = fmri.PkgFmri(f)
-                                        ren_stems[tgt.pkg_name] = stem
-                                        ren_inst_stems.setdefault(stem,
-                                            set())
-                                        ren_inst_stems[stem].add(
-                                            tgt.pkg_name)
-
-                def check_stem(t, entry):
-                        pub, stem, ver = t
-                        if stem in inst_stems:
-                                iver = inst_stems[stem]
-                                if stem in ren_inst_stems or \
-                                    ver == iver:
-                                        # The package has been renamed
-                                        # or the entry is for the same
-                                        # version as that which is
-                                        # installed, so doesn't need
-                                        # to be checked.
-                                        return False
-                                # The package may have been renamed in
-                                # a newer version, so must be checked.
-                                return True
-                        elif stem in inc_vers:
-                                # Package is incorporated, but not
-                                # installed, so should be checked.
-                                return True
-
-                        tgt = ren_stems.get(stem, None)
-                        while tgt is not None:
-                                # This seems counter-intuitive, but
-                                # for performance and other reasons,
-                                # this stem should only be checked
-                                # for a rename if it is incorporated
-                                # or installed using a previous name.
-                                if tgt in inst_stems or \
-                                    tgt in inc_vers:
-                                        return True
-                                tgt = ren_stems.get(tgt, None)
-
-                        # Package should not be checked.
-                        return False
-
-                if not known_cat:
-                        known_cat = self._img.get_catalog(
-                            self._img.IMG_CATALOG_KNOWN)
-
-                # Find terminal rename entry for all known packages not
-                # rejected by check_stem().
-                for t, entry, actions in known_cat.entry_actions(cat_info,
-                    cb=check_stem, last=True):
-                        pkgr = False
-                        targets = set()
-                        try:
-                                for a in actions:
-                                        if a.name == "set" and \
-                                            a.attrs["name"] == "pkg.renamed":
-                                                pkgr = True
-                                                continue
-
-                                        if a.name != "depend":
-                                                continue
-
-                                        if a.attrs["type"] != "require":
-                                                continue
-
-                                        # Because the actions are not
-                                        # returned in a guaranteed
-                                        # order, the dependencies will
-                                        # have to be recorded for
-                                        # evaluation later.
-                                        targets.add(a.attrs["fmri"])
-                        except apx.InvalidPackageErrors:
-                                # For mapping purposes, ignore unsupported
-                                # (and invalid) actions.  This is necessary so
-                                # that API consumers can discover new package
-                                # data that may be needed to perform an upgrade
-                                # so that the API can understand them.
-                                pass
-
-                        if pkgr:
-                                pub, stem, ver = t
-                                for f in targets:
-                                        tgt = fmri.PkgFmri(f)
-                                        ren_stems[tgt.pkg_name] = stem
-
-                # Determine highest ranked publisher for package stems
-                # listed in installed incorporations.
-                def pub_key(item):
-                        return pub_ranks[item][0]
-
-                for p in sorted(pub_ranks, key=pub_key):
-                        if pubs and p not in pubs:
-                                continue
-                        for stem in known_cat.names(pubs=[p]):
-                                if stem in inc_vers:
-                                        inc_stems.setdefault(stem, p)
-
-                return (pub_ranks, inc_stems, inc_vers, inst_stems, ren_stems,
-                    ren_inst_stems)
-
-        def __get_temp_repo_pubs(self, repos):
-                """Private helper function to retrieve publisher information
-                from list of temporary repositories.  Caller is responsible
-                for locking."""
-
-                ret_pubs = []
-                for repo_uri in repos:
-                        if isinstance(repo_uri, six.string_types):
-                                repo = publisher.RepositoryURI(repo_uri)
-                        else:
-                                # Already a RepositoryURI.
-                                repo = repo_uri
-
-                        pubs = None
-                        try:
-                                pubs = self._img.transport.get_publisherdata(
-                                    repo, ccancel=self.__check_cancel)
-                        except apx.UnsupportedRepositoryOperation:
-                                raise apx.RepoPubConfigUnavailable(
-                                    location=str(repo))
-
-                        if not pubs:
-                                # Empty repository configuration.
-                                raise apx.RepoPubConfigUnavailable(
-                                    location=str(repo))
-
-                        for p in pubs:
-                                p.client_uuid = "transient"
-                                psrepo = p.repository
-                                if not psrepo:
-                                        # Repository configuration info wasn't
-                                        # provided, so assume origin is
-                                        # repo_uri.
-                                        p.repository = publisher.Repository(
-                                            origins=[repo_uri])
-                                elif not psrepo.origins:
-                                        # Repository configuration was provided,
-                                        # but without an origin.  Assume the
-                                        # repo_uri is the origin.
-                                        psrepo.add_origin(repo_uri)
-                                elif repo not in psrepo.origins:
-                                        # If the repo_uri used is not
-                                        # in the list of sources, then
-                                        # add it as the first origin.
-                                        psrepo.origins.insert(0, repo)
-                        ret_pubs.extend(pubs)
-
-                return sorted(ret_pubs)
-
-        def __get_alt_pkg_data(self, repos):
-                """Private helper function to retrieve composite known and
-                installed catalog and package repository map for temporary
-                set of package repositories.  Returns (pkg_pub_map, alt_pubs,
-                known_cat, inst_cat)."""
-
-                repos = set(repos)
-                eid = ",".join(sorted(map(str, repos)))
-                try:
-                        return self.__alt_sources[eid]
-                except KeyError:
-                        # Need to cache new set of alternate sources.
-                        pass
-
-                img_inst_cat = self._img.get_catalog(
-                    self._img.IMG_CATALOG_INSTALLED)
-                img_inst_base = img_inst_cat.get_part("catalog.base.C",
-                    must_exist=True)
-                op_time = datetime.datetime.utcnow()
-                pubs = self.__get_temp_repo_pubs(repos)
-                progtrack = self.__progresstracker
-
-                # Create temporary directories.
-                tmpdir = tempfile.mkdtemp()
-
-                pkg_repos = {}
-                pkg_pub_map = {}
-                # Too many nested blocks;
-                # pylint: disable=R0101
-                try:
-                        progtrack.refresh_start(len(pubs), full_refresh=False)
-                        failed = []
-                        pub_cats = []
-                        for pub in pubs:
-                                # Assign a temporary meta root to each
-                                # publisher.
-                                meta_root = os.path.join(tmpdir, str(id(pub)))
-                                misc.makedirs(meta_root)
-                                pub.meta_root = meta_root
-                                pub.transport = self._img.transport
-                                repo = pub.repository
-                                pkg_repos[id(repo)] = repo
-
-                                # Retrieve each publisher's catalog.
-                                progtrack.refresh_start_pub(pub)
-                                try:
-                                        pub.refresh()
-                                except apx.PermissionsException as e:
-                                        failed.append((pub, e))
-                                        # No point in continuing since no data
-                                        # can be written.
-                                        break
-                                except apx.ApiException as e:
-                                        failed.append((pub, e))
-                                        continue
-                                finally:
-                                        progtrack.refresh_end_pub(pub)
-                                pub_cats.append((
-                                    pub.prefix,
-                                    repo,
-                                    pub.catalog
-                                ))
-
-                        progtrack.refresh_done()
-
-                        if failed:
-                                total = len(pub_cats) + len(failed)
-                                e = apx.CatalogRefreshException(failed, total,
-                                    len(pub_cats))
-                                raise e
-
-                        # Determine upgradability.
-                        newest = {}
-                        for pfx, repo, cat in [(None, None, img_inst_cat)] + \
-                            pub_cats:
-                                if pfx:
-                                        pkg_list = cat.fmris(last=True,
-                                            pubs=[pfx])
-                                else:
-                                        pkg_list = cat.fmris(last=True)
-
-                                for f in pkg_list:
-                                        nver, snver = newest.get(f.pkg_name,
-                                            (None, None))
-                                        if f.version > nver:
-                                                newest[f.pkg_name] = (f.version,
-                                                    str(f.version))
-
-                        # Build list of installed packages.
-                        inst_stems = {}
-                        for t, entry in img_inst_cat.tuple_entries():
-                                states = entry["metadata"]["states"]
-                                if pkgdefs.PKG_STATE_INSTALLED not in states:
-                                        continue
-                                pub, stem, ver = t
-                                inst_stems.setdefault(pub, {})
-                                inst_stems[pub].setdefault(stem, {})
-                                inst_stems[pub][stem][ver] = False
-
-                        # Now create composite known and installed catalogs.
-                        compicat = pkg.catalog.Catalog(batch_mode=True,
-                            sign=False)
-                        compkcat = pkg.catalog.Catalog(batch_mode=True,
-                            sign=False)
-
-                        sparts = (
-                           (pfx, cat, repo, name, cat.get_part(name, must_exist=True))
-                           for pfx, repo, cat in pub_cats
-                           for name in cat.parts
-                        )
-
-                        excludes = self._img.list_excludes()
-                        proc_stems = {}
-                        for pfx, cat, repo, name, spart in sparts:
-                                # 'spart' is the source part.
-                                if spart is None:
-                                        # Client hasn't retrieved this part.
-                                        continue
-
-                                # New known part.
-                                nkpart = compkcat.get_part(name)
-                                nipart = compicat.get_part(name)
-                                base = name.startswith("catalog.base.")
-
-                                # Avoid accessor overhead since these will be
-                                # used for every entry.
-                                cat_ver = cat.version
-                                dp = cat.get_part("catalog.dependency.C",
-                                    must_exist=True)
-
-                                for t, sentry in spart.tuple_entries(pubs=[pfx]):
-                                        pub, stem, ver = t
-
-                                        pkg_pub_map.setdefault(pub, {})
-                                        pkg_pub_map[pub].setdefault(stem, {})
-                                        pkg_pub_map[pub][stem].setdefault(ver,
-                                            set())
-                                        pkg_pub_map[pub][stem][ver].add(
-                                            id(repo))
-
-                                        if pub in proc_stems and \
-                                            stem in proc_stems[pub] and \
-                                            ver in proc_stems[pub][stem]:
-                                                if id(cat) != proc_stems[pub][stem][ver]:
-                                                        # Already added from another
-                                                        # catalog.
-                                                        continue
-                                        else:
-                                                proc_stems.setdefault(pub, {})
-                                                proc_stems[pub].setdefault(stem,
-                                                    {})
-                                                proc_stems[pub][stem][ver] = \
-                                                    id(cat)
-
-                                        installed = False
-                                        if pub in inst_stems and \
-                                            stem in inst_stems[pub] and \
-                                            ver in inst_stems[pub][stem]:
-                                                installed = True
-                                                inst_stems[pub][stem][ver] = \
-                                                    True
-
-                                        # copy() is too slow here and catalog
-                                        # entries are shallow so this should be
-                                        # sufficient.
-                                        entry = dict(six.iteritems(sentry))
-                                        if not base:
-                                                # Nothing else to do except add
-                                                # the entry for non-base catalog
-                                                # parts.
-                                                nkpart.add(metadata=entry,
-                                                    op_time=op_time, pub=pub,
-                                                    stem=stem, ver=ver)
-                                                if installed:
-                                                        nipart.add(
-                                                            metadata=entry,
-                                                            op_time=op_time,
-                                                            pub=pub, stem=stem,
-                                                            ver=ver)
-                                                continue
-
-                                        # Only the base catalog part stores
-                                        # package state information and/or
-                                        # other metadata.
-                                        mdata = {}
-                                        if installed:
-                                                mdata = dict(
-                                                    img_inst_base.get_entry(
-                                                    pub=pub, stem=stem,
-                                                    ver=ver)["metadata"])
-
-                                        entry["metadata"] = mdata
-
-                                        states = [pkgdefs.PKG_STATE_KNOWN,
-                                            pkgdefs.PKG_STATE_ALT_SOURCE]
-                                        if cat_ver == 0:
-                                                states.append(
-                                                    pkgdefs.PKG_STATE_V0)
-                                        else:
-                                                # Assume V1 catalog source.
-                                                states.append(
-                                                    pkgdefs.PKG_STATE_V1)
-
-                                        if installed:
-                                                states.append(
-                                                    pkgdefs.PKG_STATE_INSTALLED)
-
-                                        nver, snver = newest.get(stem,
-                                            (None, None))
-                                        if snver is not None and ver != snver:
-                                                states.append(
-                                                    pkgdefs.PKG_STATE_UPGRADABLE)
-
-                                        # Determine if package is obsolete or
-                                        # has been renamed and mark with
-                                        # appropriate state.
-                                        dpent = None
-                                        if dp is not None:
-                                                dpent = dp.get_entry(pub=pub,
-                                                    stem=stem, ver=ver)
-                                        if dpent is not None:
-                                                for a in dpent["actions"]:
-                                                        # Constructing action
-                                                        # objects for every
-                                                        # action would be a lot
-                                                        # slower, so a simple
-                                                        # string match is done
-                                                        # first so that only
-                                                        # interesting actions
-                                                        # get constructed.
-                                                        if not a.startswith("set"):
-                                                                continue
-                                                        if not ("pkg.obsolete" in a or \
-                                                            "pkg.renamed" in a or \
-                                                            "pkg.legacy" in a):
-                                                                continue
-
-                                                        try:
-                                                                act = pkg.actions.fromstr(a)
-                                                        except pkg.actions.ActionError:
-                                                                # If the action can't be
-                                                                # parsed or is not yet
-                                                                # supported, continue.
-                                                                continue
-
-                                                        if act.attrs["value"].lower() != "true":
-                                                                continue
-
-                                                        if act.attrs["name"] == "pkg.obsolete":
-                                                                states.append(
-                                                                    pkgdefs.PKG_STATE_OBSOLETE)
-                                                        elif act.attrs["name"] == "pkg.renamed":
-                                                                if not act.include_this(
-                                                                    excludes, publisher=pub):
-                                                                        continue
-                                                                states.append(
-                                                                    pkgdefs.PKG_STATE_RENAMED)
-                                                        elif act.attrs["name"] == "pkg.legacy":
-                                                                states.append(
-                                                                    pkgdefs.PKG_STATE_LEGACY)
-
-                                        mdata["states"] = states
-
-                                        # Add base entries.
-                                        nkpart.add(metadata=entry,
-                                            op_time=op_time, pub=pub, stem=stem,
-                                            ver=ver)
-                                        if installed:
-                                                nipart.add(metadata=entry,
-                                                    op_time=op_time, pub=pub,
-                                                    stem=stem, ver=ver)
-
-                        pub_map = {}
-                        for pub in pubs:
-                                try:
-                                        opub = pub_map[pub.prefix]
-                                except KeyError:
-                                        nrepo = publisher.Repository()
-                                        opub = publisher.Publisher(pub.prefix,
-                                            catalog=compkcat, repository=nrepo)
-                                        pub_map[pub.prefix] = opub
-
-                        rid_map = {}
-                        for pub in pkg_pub_map:
-                                for stem in pkg_pub_map[pub]:
-                                        for ver in pkg_pub_map[pub][stem]:
-                                                rids = tuple(sorted(
-                                                    pkg_pub_map[pub][stem][ver]))
-
-                                                if rids not in rid_map:
-                                                        # Create a publisher and
-                                                        # repository for this
-                                                        # unique set of origins.
-                                                        origins = []
-                                                        list(map(origins.extend, [
-                                                           pkg_repos.get(rid).origins
-                                                           for rid in rids
-                                                        ]))
-                                                        npub = \
-                                                            copy.copy(pub_map[pub])
-                                                        nrepo = npub.repository
-                                                        nrepo.origins = origins
-                                                        assert npub.catalog == \
-                                                            compkcat
-                                                        rid_map[rids] = npub
-
-                                                pkg_pub_map[pub][stem][ver] = \
-                                                    rid_map[rids]
-
-                        # Now consolidate all origins for each publisher under
-                        # a single repository object for the caller.
-                        for pub in pubs:
-                                npub = pub_map[pub.prefix]
-                                nrepo = npub.repository
-                                for o in pub.repository.origins:
-                                        if not nrepo.has_origin(o):
-                                                nrepo.add_origin(o)
-                                assert npub.catalog == compkcat
-
-                        for compcat in (compicat, compkcat):
-                                compcat.batch_mode = False
-                                compcat.finalize()
-                                compcat.read_only = True
-
-                        # Cache these for future callers.
-                        self.__alt_sources[eid] = (pkg_pub_map,
-                            sorted(pub_map.values()), compkcat, compicat)
-                        return self.__alt_sources[eid]
-                finally:
-                        shutil.rmtree(tmpdir, ignore_errors=True)
-                        self._img.cleanup_downloads()
-
-        @_LockedGenerator()
-        def get_pkg_list(self, pkg_list, cats=None, collect_attrs=False,
-            patterns=misc.EmptyI, pubs=misc.EmptyI, raise_unmatched=False,
-            ranked=False, repos=None, return_fmris=False, variants=False):
-                """A generator function that produces tuples of the form:
-
-                    (
-                        (
-                            pub,    - (string) the publisher of the package
-                            stem,   - (string) the name of the package
-                            version - (string) the version of the package
-                        ),
-                        summary,    - (string) the package summary
-                        categories, - (list) string tuples of (scheme, category)
-                        states,     - (list) PackageInfo states
-                        attributes  - (dict) package attributes
-                    )
-
-                Results are always sorted by stem, publisher, and then in
-                descending version order.
-
-                'pkg_list' is one of the following constant values indicating
-                what base set of package data should be used for results:
-
-                        LIST_ALL
-                                All known packages.
-
-                        LIST_INSTALLED
-                                Installed packages.
-
-                        LIST_INSTALLED_NEWEST
-                                Installed packages and the newest
-                                versions of packages not installed.
-                                Renamed packages that are listed in
-                                an installed incorporation will be
-                                excluded unless they are installed.
-
-                        LIST_NEWEST
-                                The newest versions of all known packages
-                                that match the provided patterns and
-                                other criteria.
-
-                        LIST_UPGRADABLE
-                                Packages that are installed and upgradable.
-
-                        LIST_REMOVABLE
-                                Packages that have no dependants
-
-                'cats' is an optional list of package category tuples of the
-                form (scheme, cat) to restrict the results to.  If a package
-                is assigned to any of the given categories, it will be
-                returned.  A value of [] will return packages not assigned
-                to any package category.  A value of None indicates that no
-                package category filtering should be applied.
-
-                'collect_attrs' is an optional boolean that indicates whether
-                all package attributes should be collected and returned in the
-                fifth element of the return tuple.  If False, that element will
-                be an empty dictionary.
-
-                'patterns' is an optional list of FMRI wildcard strings to
-                filter results by.
-
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to.
-
-                'raise_unmatched' is an optional boolean value that indicates
-                whether an InventoryException should be raised if any patterns
-                (after applying all other filtering and returning all results)
-                didn't match any packages.
-
-                'ranked' is an optional boolean value that indicates whether
-                only the matching package versions from the highest-ranked
-                publisher should be returned.  This option is ignored for
-                patterns that explicitly specify the publisher to match.
-
-                'repos' is a list of URI strings or RepositoryURI objects that
-                represent the locations of package repositories to list packages
-                for.
-
-                'return_fmris' is an optional boolean value that indicates that
-                an FMRI object should be returned in place of the (pub, stem,
-                ver) tuple that is normally returned.
-
-                'variants' is an optional boolean value that indicates that
-                packages that are for arch or zone variants not applicable to
-                this image should be returned.
-
-                Please note that this function may invoke network operations
-                to retrieve the requested package information."""
-
-                return self.__get_pkg_list(pkg_list, cats=cats,
-                    collect_attrs=collect_attrs, patterns=patterns, pubs=pubs,
-                    raise_unmatched=raise_unmatched, ranked=ranked, repos=repos,
-                    return_fmris=return_fmris, variants=variants)
-
-
-        def __get_pkg_refcounts(self, pkg_cat, excludes, pubs):
-                pkg_ref = set()
-                pkg_optref = set()
-
-                cat_info = frozenset([pkg_cat.DEPENDENCY])
-
-                for pfmri, actions in pkg_cat.actions(cat_info,
-                    excludes=excludes, pubs=pubs):
-                        for a in actions:
-                                # Always keep packages with an install-hold
-                                if (a.name == 'set' and a.attrs['name'] ==
-                                    'pkg.depend.install-hold'):
-                                        pkg_ref.add(pfmri.pkg_name)
-                                        continue
-                                if a.name != 'depend': continue
-                                for f in a.attrlist('fmri'):
-                                        tgt = fmri.PkgFmri(f)
-                                        if a.attrs['type'] in [
-                                            'require',
-                                            'conditional'
-                                            ]:
-                                                pkg_ref.add(tgt.pkg_name)
-                                        if a.attrs['type'] == 'optional':
-                                                pkg_optref.add(tgt.pkg_name)
-                return pkg_ref, pkg_optref
-
-        def __get_pkg_list(self, pkg_list, cats=None, collect_attrs=False,
-            inst_cat=None, known_cat=None, patterns=misc.EmptyI,
-            pubs=misc.EmptyI, raise_unmatched=False, ranked=False, repos=None,
-            return_fmris=False, return_metadata=False, variants=False):
-                """This is the implementation of get_pkg_list.  The other
-                function is a wrapper that uses locking.  The separation was
-                necessary because of API functions that already perform locking
-                but need to use get_pkg_list().  This is a generator
-                function."""
-
-                installed = inst_newest = newest = upgradable = False
-                removable = False
-                if pkg_list == self.LIST_INSTALLED:
-                        installed = True
-                elif pkg_list == self.LIST_INSTALLED_NEWEST:
-                        inst_newest = True
-                elif pkg_list == self.LIST_NEWEST:
-                        newest = True
-                elif pkg_list == self.LIST_UPGRADABLE:
-                        upgradable = True
-                elif pkg_list == self.LIST_REMOVABLE:
-                        removable = True
-
-                # Each pattern in patterns can be a partial or full FMRI, so
-                # extract the individual components for use in filtering.
-                illegals = []
-                pat_tuples = {}
-                pat_versioned = False
-                latest_pats = set()
-                seen = set()
-                npatterns = set()
-                for pat, error, pfmri, matcher in self.parse_fmri_patterns(
-                    patterns):
-                        if error:
-                                illegals.append(error)
-                                continue
-
-                        # Duplicate patterns are ignored.
-                        sfmri = str(pfmri)
-                        if sfmri in seen:
-                                # A different form of the same pattern
-                                # was specified already; ignore this
-                                # one (e.g. pkg:/network/ping,
-                                # /network/ping).
-                                continue
-
-                        # Track used patterns.
-                        seen.add(sfmri)
-                        npatterns.add(pat)
-
-                        if "@" in pat:
-                                # Mark that a pattern contained version
-                                # information.  This is used for a listing
-                                # optimization later on.
-                                pat_versioned = True
-                        if getattr(pfmri.version, "match_latest", None):
-                                latest_pats.add(pat)
-                        pat_tuples[pat] = (pfmri.tuple(), matcher)
-
-                patterns = npatterns
-                del npatterns, seen
-
-                if illegals:
-                        raise apx.InventoryException(illegal=illegals)
-
-                if repos:
-                        ignored, ignored, known_cat, inst_cat = \
-                            self.__get_alt_pkg_data(repos)
-
-                # For LIST_INSTALLED_NEWEST, installed packages need to be
-                # determined and incorporation and publisher relationships
-                # mapped.
-                if inst_newest:
-                        pub_ranks, inc_stems, inc_vers, inst_stems, ren_stems, \
-                            ren_inst_stems = self.__map_installed_newest(
-                            pubs, known_cat=known_cat)
-                else:
-                        pub_ranks = inc_stems = inc_vers = inst_stems = \
-                            ren_stems = ren_inst_stems = misc.EmptyDict
-
-                if installed or upgradable or removable:
-                        if inst_cat:
-                                pkg_cat = inst_cat
-                        else:
-                                pkg_cat = self._img.get_catalog(
-                                    self._img.IMG_CATALOG_INSTALLED)
-
-                        # Don't need to perform variant filtering if only
-                        # listing installed packages.
-                        variants = True
-                elif known_cat:
-                        pkg_cat = known_cat
-                else:
-                        pkg_cat = self._img.get_catalog(
-                            self._img.IMG_CATALOG_KNOWN)
-
-                cat_info = frozenset([pkg_cat.DEPENDENCY, pkg_cat.SUMMARY])
-
-                # Keep track of when the newest version has been found for
-                # each incorporated stem.
-                slist = set()
-
-                # Keep track of listed stems for all other packages on a
-                # per-publisher basis.
-                nlist = collections.defaultdict(int)
-
-                def check_state(t, entry):
-                        states = entry["metadata"]["states"]
-                        pkgi = pkgdefs.PKG_STATE_INSTALLED in states
-                        pkgu = pkgdefs.PKG_STATE_UPGRADABLE in states
-                        pub, stem, ver = t
-
-                        if upgradable:
-                                # If package is marked upgradable, return it.
-                                return pkgu
-                        elif removable:
-                                return not stem in pkg_ref
-                        elif pkgi:
-                                # Nothing more to do here.
-                                return True
-                        elif stem in inst_stems:
-                                # Some other version of this package is
-                                # installed, so this one should not be
-                                # returned.
-                                return False
-
-                        # Attempt to determine if this package is installed
-                        # under a different name or constrained under a
-                        # different name.
-                        tgt = ren_stems.get(stem, None)
-                        while tgt is not None:
-                                if tgt in inc_vers:
-                                        # Package is incorporated under a
-                                        # different name, so allow this
-                                        # to fallthrough to the incoporation
-                                        # evaluation.
-                                        break
-                                elif tgt in inst_stems:
-                                        # Package is installed under a
-                                        # different name, so skip it.
-                                        return False
-                                tgt = ren_stems.get(tgt, None)
-
-                        # Attempt to find a suitable version to return.
-                        if stem in inc_vers:
-                                # For package stems that are incorporated, only
-                                # return the newest successor version  based on
-                                # publisher rank.
-                                if stem in slist:
-                                        # Newest version already returned.
-                                        return False
-
-                                if stem in inc_stems and \
-                                    pub != inc_stems[stem]:
-                                        # This entry is for a lower-ranked
-                                        # publisher.
-                                        return False
-
-                                # XXX version should not require build release.
-                                ever = pkg.version.Version(ver)
-
-                                # If the entry's version is a successor to
-                                # the incorporated version, then this is the
-                                # 'newest' version of this package since
-                                # entries are processed in descending version
-                                # order.
-                                iver = inc_vers[stem]
-                                if ever.is_successor(iver,
-                                    pkg.version.CONSTRAINT_AUTO):
-                                        slist.add(stem)
-                                        return True
-                                return False
-
-                        pkg_stem = "!".join((pub, stem))
-                        if pkg_stem in nlist:
-                                # A newer version has already been listed for
-                                # this stem and publisher.
-                                return False
-                        return True
-
-                filter_cb = None
-                if inst_newest or upgradable or removable:
-                        # Filtering needs to be applied.
-                        filter_cb = check_state
-
-                excludes = self._img.list_excludes()
-                img_variants = self._img.get_variants()
-
-                if removable:
-                        pkg_ref, pkg_optref = self.__get_pkg_refcounts(
-                            pkg_cat, excludes, pubs)
-
-                matched_pats = set()
-                pkg_matching_pats = None
-
-                # Retrieve only the newest package versions for LIST_NEWEST if
-                # none of the patterns have version information and variants are
-                # included.  (This cuts down on the number of entries that have
-                # to be filtered.)
-                use_last = newest and not pat_versioned and variants
-
-                if ranked:
-                        # If caller requested results to be ranked by publisher,
-                        # then the list of publishers to return must be passed
-                        # to entry_actions() in rank order.
-                        pub_ranks = self._img.get_publisher_ranks()
-                        if not pubs:
-                                # It's important that the list of possible
-                                # publishers is gleaned from the catalog
-                                # directly and not image configuration so
-                                # that temporary sources (archives, etc.)
-                                # work as expected.
-                                pubs = pkg_cat.publishers()
-                        for p in pubs:
-                                pub_ranks.setdefault(p, (99, (p, False, False)))
-
-                        def pub_key(a):
-                                return (pub_ranks[a], a)
-
-                        pubs = sorted(pubs, key=pub_key)
-
-                # Too many nested blocks;
-                # pylint: disable=R0101
-                ranked_stems = {}
-                for t, entry, actions in pkg_cat.entry_actions(cat_info,
-                    cb=filter_cb, excludes=excludes, last=use_last,
-                    ordered=True, pubs=pubs):
-                        pub, stem, ver = t
-
-                        omit_ver = False
-                        omit_package = None
-
-                        pkg_stem = "!".join((pub, stem))
-                        if newest and pkg_stem in nlist:
-                                # A newer version has already been listed, so
-                                # any additional entries need to be marked for
-                                # omission before continuing.
-                                omit_package = True
-                        elif ranked and not patterns and \
-                            ranked_stems.get(stem, pub) != pub:
-                                # A different version from a higher-ranked
-                                # publisher has been returned already, so skip
-                                # this one.  This can only be done safely at
-                                # this point if no patterns have been specified,
-                                # since publisher-specific patterns override
-                                # ranking behaviour.
-                                omit_package = True
-                        else:
-                                nlist[pkg_stem] += 1
-
-                        if raise_unmatched:
-                                pkg_matching_pats = set()
-                        if not omit_package:
-                                ever = None
-                                for pat in patterns:
-                                        (pat_pub, pat_stem, pat_ver), matcher = \
-                                            pat_tuples[pat]
-
-                                        if pat_pub is not None and \
-                                            pub != pat_pub:
-                                                # Publisher doesn't match.
-                                                if omit_package is None:
-                                                        omit_package = True
-                                                continue
-                                        elif ranked and not pat_pub and \
-                                            ranked_stems.get(stem, pub) != pub:
-                                                # A different version from a
-                                                # higher-ranked publisher has
-                                                # been returned already, so skip
-                                                # this one since no publisher
-                                                # was specified for the pattern.
-                                                if omit_package is None:
-                                                        omit_package = True
-                                                continue
-
-                                        if matcher == self.MATCH_EXACT:
-                                                if pat_stem != stem:
-                                                        # Stem doesn't match.
-                                                        if omit_package is None:
-                                                                omit_package = \
-                                                                    True
-                                                        continue
-                                        elif matcher == self.MATCH_FMRI:
-                                                if not ("/" + stem).endswith(
-                                                    "/" + pat_stem):
-                                                        # Stem doesn't match.
-                                                        if omit_package is None:
-                                                                omit_package = \
-                                                                    True
-                                                        continue
-                                        elif matcher == self.MATCH_GLOB:
-                                                if not fnmatch.fnmatchcase(stem,
-                                                    pat_stem):
-                                                        # Stem doesn't match.
-                                                        if omit_package is None:
-                                                                omit_package = \
-                                                                    True
-                                                        continue
-
-                                        if pat_ver is not None:
-                                                if ever is None:
-                                                        # Avoid constructing a
-                                                        # version object more
-                                                        # than once for each
-                                                        # entry.
-                                                        ever = pkg.version.Version(ver)
-                                                if not ever.is_successor(pat_ver,
-                                                    pkg.version.CONSTRAINT_AUTO):
-                                                        if omit_package is None:
-                                                                omit_package = \
-                                                                    True
-                                                        omit_ver = True
-                                                        continue
-
-                                        if pat in latest_pats and \
-                                            nlist[pkg_stem] > 1:
-                                                # Package allowed by pattern,
-                                                # but isn't the "latest"
-                                                # version.
-                                                if omit_package is None:
-                                                        omit_package = True
-                                                omit_ver = True
-                                                continue
-
-                                        # If this entry matched at least one
-                                        # pattern, then ensure it is returned.
-                                        omit_package = False
-                                        if not raise_unmatched:
-                                                # It's faster to stop as soon
-                                                # as a match is found.
-                                                break
-
-                                        # If caller has requested other match
-                                        # cases be raised as an exception, then
-                                        # all patterns must be tested for every
-                                        # entry.  This is slower, so only done
-                                        # if necessary.
-                                        pkg_matching_pats.add(pat)
-
-                        if omit_package:
-                                # Package didn't match critera; skip it.
-                                if (filter_cb is not None or (newest and
-                                    pat_versioned)) and omit_ver and \
-                                    nlist[pkg_stem] == 1:
-                                        # If omitting because of version, and
-                                        # no other versions have been returned
-                                        # yet for this stem, then discard
-                                        # tracking entry so that other
-                                        # versions will be listed.
-                                        del nlist[pkg_stem]
-                                        slist.discard(stem)
-                                continue
-
-                        # Perform image arch and zone variant filtering so
-                        # that only packages appropriate for this image are
-                        # returned, but only do this for packages that are
-                        # not installed.
-                        pcats = []
-                        pkgr = False
-                        unsupported = False
-                        summ = None
-                        targets = set()
-
-                        omit_var = False
-                        mdata = entry["metadata"]
-                        states = mdata["states"]
-                        pkgi = pkgdefs.PKG_STATE_INSTALLED in states
-                        ddm = lambda: collections.defaultdict(list)
-                        attrs = collections.defaultdict(ddm)
-                        try:
-                                for a in actions:
-                                        if a.name == "depend" and \
-                                            a.attrs["type"] == "require":
-                                                targets.add(a.attrs["fmri"])
-                                                continue
-                                        if a.name != "set":
-                                                continue
-
-                                        atname = a.attrs["name"]
-                                        atvalue = a.attrs["value"]
-                                        if collect_attrs:
-                                                atvlist = a.attrlist("value")
-
-                                                # XXX Need to describe this data
-                                                # structure sanely somewhere.
-                                                mods = tuple(
-                                                    (k, tuple(sorted(a.attrlist(k))))
-                                                    for k in sorted(six.iterkeys(a.attrs))
-                                                    if k not in ("name", "value")
-                                                )
-                                                attrs[atname][mods].extend(atvlist)
-
-                                        if atname == "pkg.summary":
-                                                summ = atvalue
-                                                continue
-
-                                        if atname == "description":
-                                                if summ is None:
-                                                        # Historical summary
-                                                        # field.
-                                                        summ = atvalue
-                                                        # pylint: disable=W0106
-                                                        collect_attrs and \
-                                                            attrs["pkg.summary"] \
-                                                            [mods]. \
-                                                            extend(atvlist)
-                                                continue
-
-                                        if atname == "info.classification":
-                                                pcats.extend(
-                                                    a.parse_category_info())
-
-                                        if pkgi:
-                                                # No filtering for installed
-                                                # packages.
-                                                continue
-
-                                        # Rename filtering should only be
-                                        # performed for incorporated packages
-                                        # at this point.
-                                        if atname == "pkg.renamed":
-                                                if stem in inc_vers:
-                                                        pkgr = True
-                                                continue
-
-                                        if variants or \
-                                            not atname.startswith("variant."):
-                                                # No variant filtering required.
-                                                continue
-
-                                        # For all variants explicitly set in the
-                                        # image, elide packages that are not for
-                                        # a matching variant value.
-                                        is_list = type(atvalue) == list
-                                        for vn, vv in six.iteritems(img_variants):
-                                                if vn == atname and \
-                                                    ((is_list and
-                                                    vv not in atvalue) or \
-                                                    (not is_list and
-                                                    vv != atvalue)):
-                                                        omit_package = True
-                                                        omit_var = True
-                                                        break
-                        except apx.InvalidPackageErrors:
-                                # Ignore errors for packages that have invalid
-                                # or unsupported metadata.  This is necessary so
-                                # that API consumers can discover new package
-                                # data that may be needed to perform an upgrade
-                                # so that the API can understand them.
-                                states = set(states)
-                                states.add(PackageInfo.UNSUPPORTED)
-                                unsupported = True
-
-                        if not pkgi and pkgr and stem in inc_vers:
-                                # If the package is not installed, but this is
-                                # the terminal version entry for the stem and
-                                # it is an incorporated package, then omit the
-                                # package if it has been installed or is
-                                # incorporated using one of the new names.
-                                for e in targets:
-                                        tgt = e
-                                        while tgt is not None:
-                                                if tgt in ren_inst_stems or \
-                                                    tgt in inc_vers:
-                                                        omit_package = True
-                                                        break
-                                                tgt = ren_stems.get(tgt, None)
-
-                        if omit_package:
-                                # Package didn't match criteria; skip it.
-                                if (filter_cb is not None or newest) and \
-                                    omit_var and nlist[pkg_stem] == 1:
-                                        # If omitting because of variant, and
-                                        # no other versions have been returned
-                                        # yet for this stem, then discard
-                                        # tracking entry so that other
-                                        # versions will be listed.
-                                        del nlist[pkg_stem]
-                                        slist.discard(stem)
-                                continue
-
-                        if cats is not None:
-                                if not cats:
-                                        if pcats:
-                                                # Only want packages with no
-                                                # categories.
-                                                continue
-                                elif not [sc for sc in cats if sc in pcats]:
-                                        # Package doesn't match specified
-                                        # category criteria.
-                                        continue
-
-                        if removable and stem in pkg_optref:
-                                states.append(pkgdefs.PKG_STATE_OPTIONAL)
-
-                        # Return the requested package data.
-                        if not unsupported:
-                                # Prevent modification of state data.
-                                states = frozenset(states)
-
-                        if raise_unmatched:
-                                # Only after all other filtering has been
-                                # applied are the patterns that the package
-                                # matched considered "matching".
-                                matched_pats.update(pkg_matching_pats)
-                        if ranked:
-                                # Only after all other filtering has been
-                                # applied is the stem considered to have been
-                                # a "ranked" match.
-                                ranked_stems.setdefault(stem, pub)
-
-                        if return_fmris:
-                                pfmri = fmri.PkgFmri(name=stem, publisher=pub,
-                                        version=ver)
-                                if return_metadata:
-                                        yield (pfmri, summ, pcats, states,
-                                            attrs, mdata)
-                                else:
-                                        yield (pfmri, summ, pcats, states,
-                                            attrs)
-                        else:
-                                if return_metadata:
-                                        yield (t, summ, pcats, states,
-                                            attrs, mdata)
-                                else:
-                                        yield (t, summ, pcats, states,
-                                            attrs)
-
-                if raise_unmatched:
-                        # Caller has requested that non-matching patterns or
-                        # patterns that match multiple packages cause an
-                        # exception to be raised.
-                        notfound = set(pat_tuples.keys()) - matched_pats
-                        if raise_unmatched and notfound:
-                                raise apx.InventoryException(notfound=notfound)
-
-        @_LockedCancelable()
-        def info(self, fmri_strings, local, info_needed, ranked=False,
-            repos=None):
-                """Gathers information about fmris.  fmri_strings is a list
-                of fmri_names for which information is desired.  local
-                determines whether to retrieve the information locally
-                (if possible).  It returns a dictionary of lists.  The keys
-                for the dictionary are the constants specified in the class
-                definition.  The values are lists of PackageInfo objects or
-                strings.
-
-                'ranked' is an optional boolean value that indicates whether
-                only the matching package versions from the highest-ranked
-                publisher should be returned.  This option is ignored for
-                patterns that explicitly specify the publisher to match.
-
-                'repos' is a list of URI strings or RepositoryURI objects that
-                represent the locations of packages to return information for.
-                """
-
-                bad_opts = info_needed - PackageInfo.ALL_OPTIONS
-                if bad_opts:
-                        raise apx.UnrecognizedOptionsToInfo(bad_opts)
-
-                self.log_operation_start("info")
-
-                # Common logic for image and temp repos case.
-                if local:
-                        ilist = self.LIST_INSTALLED
-                else:
-                        # Verify validity of certificates before attempting
-                        # network operations.
-                        self.__cert_verify(log_op_end=[apx.CertificateError])
-                        ilist = self.LIST_NEWEST
-
-                # The pkg_pub_map is only populated when temp repos are
-                # specified and maps packages to the repositories that
-                # contain them for manifest retrieval.
-                pkg_pub_map = None
-                known_cat = None
-                inst_cat = None
-                if repos:
-                        pkg_pub_map, ignored, known_cat, inst_cat = \
-                            self.__get_alt_pkg_data(repos)
-                        if local:
-                                pkg_cat = inst_cat
-                        else:
-                                pkg_cat = known_cat
-                elif local:
-                        pkg_cat = self._img.get_catalog(
-                            self._img.IMG_CATALOG_INSTALLED)
-                        if not fmri_strings and pkg_cat.package_count == 0:
-                                self.log_operation_end(
-                                    result=RESULT_NOTHING_TO_DO)
-                                raise apx.NoPackagesInstalledException()
-                else:
-                        pkg_cat = self._img.get_catalog(
-                            self._img.IMG_CATALOG_KNOWN)
-
-                excludes = self._img.list_excludes()
-
-                # Set of options that can use catalog data.
-                cat_opts = frozenset([PackageInfo.DESCRIPTION,
-                    PackageInfo.DEPENDENCIES])
-
-                # Set of options that require manifest retrieval.
-                act_opts = PackageInfo.ACTION_OPTIONS - \
-                    frozenset([PackageInfo.DEPENDENCIES])
-
-                collect_attrs = PackageInfo.ALL_ATTRIBUTES in info_needed
-
-                pis = []
-                rval = {
-                    self.INFO_FOUND: pis,
-                    self.INFO_MISSING: misc.EmptyI,
-                    self.INFO_ILLEGALS: misc.EmptyI,
-                }
-
-                try:
-                        for pfmri, summary, cats, states, attrs, mdata in \
-                            self.__get_pkg_list(
-                            ilist, collect_attrs=collect_attrs,
-                            inst_cat=inst_cat, known_cat=known_cat,
-                            patterns=fmri_strings, raise_unmatched=True,
-                            ranked=ranked, return_fmris=True,
-                            return_metadata=True, variants=True):
-                                release = build_release = branch = \
-                                    packaging_date = None
-
-                                pub, name, version = pfmri.tuple()
-                                alt_pub = None
-                                if pkg_pub_map:
-                                        alt_pub = \
-                                            pkg_pub_map[pub][name][str(version)]
-
-                                if PackageInfo.IDENTITY in info_needed:
-                                        release = version.release
-                                        build_release = version.build_release
-                                        branch = version.branch
-                                        packaging_date = \
-                                            version.get_timestamp().strftime(
-                                            "%c")
-                                else:
-                                        pub = name = version = None
-
-                                links = hardlinks = files = dirs = \
-                                    csize = size = licenses = cat_info = \
-                                    description = None
-
-                                if PackageInfo.CATEGORIES in info_needed:
-                                        cat_info = [
-                                            PackageCategory(scheme, cat)
-                                            for scheme, cat in cats
-                                        ]
-
-                                ret_cat_data = cat_opts & info_needed
-                                dependencies = None
-                                unsupported = False
-                                if ret_cat_data:
-                                        try:
-                                                ignored, description, ignored, \
-                                                    dependencies = \
-                                                    _get_pkg_cat_data(pkg_cat,
-                                                        ret_cat_data,
-                                                        excludes=excludes,
-                                                        pfmri=pfmri)
-                                        except apx.InvalidPackageErrors:
-                                                # If the information can't be
-                                                # retrieved because the manifest
-                                                # can't be parsed, mark it and
-                                                # continue.
-                                                unsupported = True
-
-                                if dependencies is None:
-                                        dependencies = misc.EmptyI
-
-                                mfst = None
-                                if not unsupported and \
-                                    (frozenset([PackageInfo.SIZE,
-                                    PackageInfo.LICENSES]) | act_opts) & \
-                                    info_needed:
-                                        try:
-                                                mfst = self._img.get_manifest(
-                                                    pfmri, alt_pub=alt_pub)
-                                        except apx.InvalidPackageErrors:
-                                                # If the information can't be
-                                                # retrieved because the manifest
-                                                # can't be parsed, mark it and
-                                                # continue.
-                                                unsupported = True
-
-                                if mfst is not None:
-                                        if PackageInfo.LICENSES in info_needed:
-                                                licenses = self.__licenses(pfmri,
-                                                    mfst, alt_pub=alt_pub)
-
-                                        if PackageInfo.SIZE in info_needed:
-                                                size, csize = mfst.get_size(
-                                                    excludes=excludes)
-
-                                        if act_opts & info_needed:
-                                                if PackageInfo.LINKS in info_needed:
-                                                        links = list(
-                                                            mfst.gen_key_attribute_value_by_type(
-                                                            "link", excludes))
-                                                if PackageInfo.HARDLINKS in info_needed:
-                                                        hardlinks = list(
-                                                            mfst.gen_key_attribute_value_by_type(
-                                                            "hardlink", excludes))
-                                                if PackageInfo.FILES in info_needed:
-                                                        files = list(
-                                                            mfst.gen_key_attribute_value_by_type(
-                                                            "file", excludes))
-                                                if PackageInfo.DIRS in info_needed:
-                                                        dirs = list(
-                                                            mfst.gen_key_attribute_value_by_type(
-                                                            "dir", excludes))
-                                elif PackageInfo.SIZE in info_needed:
-                                        size = csize = 0
-
-                                # Trim response set.
-                                last_install = None
-                                last_update = None
-                                if PackageInfo.STATE in info_needed:
-                                        if unsupported is True and \
-                                            PackageInfo.UNSUPPORTED not in states:
-                                                # Mark package as
-                                                # unsupported so that
-                                                # caller can decide
-                                                # what to do.
-                                                states = set(states)
-                                                states.add(
-                                                    PackageInfo.UNSUPPORTED)
-
-                                        if "last-update" in mdata:
-                                                last_update = catalog.basic_ts_to_datetime(
-                                                    mdata["last-update"]).strftime("%c")
-                                        if "last-install" in mdata:
-                                                last_install = catalog.basic_ts_to_datetime(
-                                                    mdata["last-install"]).strftime("%c")
-                                else:
-                                        states = misc.EmptyI
-
-                                if PackageInfo.CATEGORIES not in info_needed:
-                                        cats = None
-                                if PackageInfo.SUMMARY in info_needed:
-                                        if summary is None:
-                                                summary = ""
-                                else:
-                                        summary = None
-
-                                pis.append(PackageInfo(pkg_stem=name,
-                                    summary=summary, category_info_list=cat_info,
-                                    states=states, publisher=pub, version=release,
-                                    build_release=build_release, branch=branch,
-                                    packaging_date=packaging_date, size=size,
-                                    csize=csize, pfmri=pfmri, licenses=licenses,
-                                    links=links, hardlinks=hardlinks, files=files,
-                                    dirs=dirs, dependencies=dependencies,
-                                    description=description, attrs=attrs,
-                                    last_update=last_update,
-                                    last_install=last_install))
-                except apx.InventoryException as e:
-                        if e.illegal:
-                                self.log_operation_end(
-                                    result=RESULT_FAILED_BAD_REQUEST)
-                        rval[self.INFO_MISSING] = e.notfound
-                        rval[self.INFO_ILLEGALS] = e.illegal
-                else:
-                        if pis:
-                                self.log_operation_end()
-                        else:
-                                self.log_operation_end(
-                                    result=RESULT_NOTHING_TO_DO)
-                return rval
-
-        def can_be_canceled(self):
-                """Returns true if the API is in a cancelable state."""
-                return self.__can_be_canceled
-
-        def _disable_cancel(self):
-                """Sets_can_be_canceled to False in a way that prevents missed
-                wakeups.  This may raise CanceledException, if a
-                cancellation is pending."""
-
-                self.__cancel_lock.acquire()
-                if self.__canceling:
-                        self.__cancel_lock.release()
-                        self._img.transport.reset()
-                        raise apx.CanceledException()
-                else:
-                        self.__set_can_be_canceled(False)
-                self.__cancel_lock.release()
-
-        def _enable_cancel(self):
-                """Sets can_be_canceled to True while grabbing the cancel
-                locks.  The caller must still hold the activity lock while
-                calling this function."""
-
-                self.__cancel_lock.acquire()
-                self.__set_can_be_canceled(True)
-                self.__cancel_lock.release()
-
-        def __set_can_be_canceled(self, status):
-                """Private method. Handles the details of changing the
-                cancelable state."""
-                assert self.__cancel_lock._is_owned()
-
-                # If caller requests a change to current state there is
-                # nothing to do.
-                if self.__can_be_canceled == status:
-                        return
-
-                if status:
-                        # Callers must hold activity lock for operations
-                        # that they will make cancelable.
-                        assert self._activity_lock._is_owned()
-                        # In any situation where the caller holds the activity
-                        # lock and wants to set cancelable to true, a cancel
-                        # should not already be in progress.  This is because
-                        # it should not be possible to invoke cancel until
-                        # this routine has finished.  Assert that we're not
-                        # canceling.
-                        assert not self.__canceling
-
-                self.__can_be_canceled = status
-                if self.__cancel_state_callable:
-                        self.__cancel_state_callable(self.__can_be_canceled)
-
-        def reset(self):
-                """Resets the API back the initial state. Note:
-                this does not necessarily return the disk to its initial state
-                since the indexes or download cache may have been changed by
-                the prepare method."""
-                self._acquire_activity_lock()
-                self.__reset_unlock()
-                self._activity_lock.release()
-
-        def __reset_unlock(self):
-                """Private method. Provides a way to reset without taking the
-                activity lock. Should only be called by a thread which already
-                holds the activity lock."""
-
-                assert self._activity_lock._is_owned()
-
-                # This needs to be done first so that find_root can use it.
-                self.__progresstracker.reset()
-
-                # Ensure alternate sources are always cleared in an
-                # exception scenario.
-                self.__set_img_alt_sources(None)
-                self.__alt_sources = {}
-
-                self._img.cleanup_downloads()
-                # Cache transport statistics about problematic repo sources
-                repo_status = self._img.transport.repo_status
-                self._img.transport.shutdown()
-
-                # Recreate the image object using the path the api
-                # object was created with instead of the current path.
-                self._img = image.Image(self._img_path,
-                    progtrack=self.__progresstracker,
-                    user_provided_dir=True,
-                    cmdpath=self.cmdpath)
-                self._img.blocking_locks = self.__blocking_locks
-
-                self._img.transport.repo_status = repo_status
-
-                lin = None
-                if self._img.linked.ischild():
-                        lin = self._img.linked.child_name
-                self.__progresstracker.set_linked_name(lin)
-
-                self.__plan_desc = None
-                self.__planned_children = False
-                self.__plan_type = None
-                self.__prepared = False
-                self.__executed = False
-                self.__be_name = None
-
-                self._cancel_cleanup_exception()
-
-        def __check_cancel(self):
-                """Private method. Provides a callback method for internal
-                code to use to determine whether the current action has been
-                canceled."""
-                return self.__canceling
-
-        def _cancel_cleanup_exception(self):
-                """A private method that is called from exception handlers.
-                This is not needed if the method calls reset unlock,
-                which will call this method too.  This catches the case
-                where a caller might have called cancel and gone to sleep,
-                but the requested operation failed with an exception before
-                it could raise a CanceledException."""
-
-                self.__cancel_lock.acquire()
-                self.__set_can_be_canceled(False)
-                self.__canceling = False
-                # Wake up any threads that are waiting on this aborted
-                # operation.
-                self.__cancel_cv.notify_all()
-                self.__cancel_lock.release()
-
-        def _cancel_done(self):
-                """A private method that wakes any threads that have been
-                sleeping, waiting for a cancellation to finish."""
-
-                self.__cancel_lock.acquire()
-                if self.__canceling:
-                        self.__canceling = False
-                        self.__cancel_cv.notify_all()
-                self.__cancel_lock.release()
-
-        def cancel(self):
-                """Used for asynchronous cancelation. It returns the API
-                to the state it was in prior to the current method being
-                invoked.  Canceling during a plan phase returns the API to
-                its initial state. Canceling during prepare puts the API
-                into the state it was in just after planning had completed.
-                Plan execution cannot be canceled. A call to this method blocks
-                until the cancellation has happened. Note: this does not
-                necessarily return the disk to its initial state since the
-                indexes or download cache may have been changed by the
-                prepare method."""
-
-                self.__cancel_lock.acquire()
-
-                if not self.__can_be_canceled:
-                        self.__cancel_lock.release()
-                        return False
-
-                self.__set_can_be_canceled(False)
-                self.__canceling = True
-                # Wait until the cancelled operation wakes us up.
-                self.__cancel_cv.wait()
-                self.__cancel_lock.release()
-                return True
-
-        def clear_history(self):
-                """Discard history information about in-progress operations."""
-                self._img.history.clear()
-
-        def __set_history_PlanCreationException(self, e):
-                if e.unmatched_fmris or e.multiple_matches or \
-                    e.missing_matches or e.illegal:
-                        self.log_operation_end(error=e,
-                            result=RESULT_FAILED_BAD_REQUEST)
-                else:
-                        self.log_operation_end(error=e)
-
-        @_LockedGenerator()
-        def local_search(self, query_lst):
-                """local_search takes a list of Query objects and performs
-                each query against the installed packages of the image."""
-
-                l = query_p.QueryLexer()
-                l.build()
-                qp = query_p.QueryParser(l)
-                ssu = None
-                for i, q in enumerate(query_lst):
-                        try:
-                                query = qp.parse(q.text)
-                                query_rr = qp.parse(q.text)
-                                if query_rr.remove_root(self._img.root):
-                                        query.add_or(query_rr)
-                                if q.return_type == \
-                                    query_p.Query.RETURN_PACKAGES:
-                                        query.propagate_pkg_return()
-                        except query_p.BooleanQueryException as e:
-                                raise apx.BooleanQueryException(e)
-                        except query_p.ParseError as e:
-                                raise apx.ParseError(e)
-                        self._img.update_index_dir()
-                        assert self._img.index_dir
-                        try:
-                                query.set_info(num_to_return=q.num_to_return,
-                                    start_point=q.start_point,
-                                    index_dir=self._img.index_dir,
-                                    get_manifest_path=\
-                                        self._img.get_manifest_path,
-                                    gen_installed_pkg_names=\
-                                        self._img.gen_installed_pkg_names,
-                                    case_sensitive=q.case_sensitive)
-                                res = query.search(
-                                    self._img.gen_installed_pkgs,
-                                    self._img.get_manifest_path,
-                                    self._img.list_excludes())
-                        except search_errors.InconsistentIndexException as e:
-                                raise apx.InconsistentIndexException(e)
-                        # i is being inserted to track which query the results
-                        # are for.  None is being inserted since there is no
-                        # publisher being searched against.
-                        try:
-                                for r in res:
-                                        yield i, None, r
-                        except apx.SlowSearchUsed as e:
-                                ssu = e
-                if ssu:
-                        raise ssu
-
-        @staticmethod
-        def __parse_v_0(line, pub, v):
-                """This function parses the string returned by a version 0
-                search server and puts it into the expected format of
-                (query_number, publisher, (version, return_type, (results))).
-
-                "query_number" in the return value is fixed at 0 since search
-                v0 servers cannot accept multiple queries in a single HTTP
-                request."""
-
-                line = line.strip()
-                fields = line.split(None, 3)
-                return (0, pub, (v, Query.RETURN_ACTIONS, (fields[:4])))
-
-        @staticmethod
-        def __parse_v_1(line, pub, v):
-                """This function parses the string returned by a version 1
-                search server and puts it into the expected format of
-                (query_number, publisher, (version, return_type, (results)))
-                If it receives a line it can't parse, it raises a
-                ServerReturnError."""
-
-                fields = line.split(None, 2)
-                if len(fields) != 3:
-                        raise apx.ServerReturnError(line)
-                try:
-                        return_type = int(fields[1])
-                        query_num = int(fields[0])
-                except ValueError:
-                        raise apx.ServerReturnError(line)
-                if return_type == Query.RETURN_ACTIONS:
-                        subfields = fields[2].split(None, 2)
-                        pfmri = fmri.PkgFmri(subfields[0])
-                        return pfmri, (query_num, pub, (v, return_type,
-                            (pfmri, unquote(subfields[1]),
-                            subfields[2])))
-                elif return_type == Query.RETURN_PACKAGES:
-                        pfmri = fmri.PkgFmri(fields[2])
-                        return pfmri, (query_num, pub, (v, return_type, pfmri))
-                else:
-                        raise apx.ServerReturnError(line)
-
-        @_LockedGenerator()
-        def remote_search(self, query_str_and_args_lst, servers=None,
-            prune_versions=True):
-                """This function takes a list of Query objects, and optionally
-                a list of servers to search against.  It performs each query
-                against each server and yields the results in turn.  If no
-                servers are provided, the search is conducted against all
-                active servers known by the image.
-
-                The servers argument is a list of servers in two possible
-                forms: the old deprecated form of a publisher, in a
-                dictionary, or a Publisher object.
-
-                A call to this function returns a generator that holds
-                API locks.  Callers must either iterate through all of the
-                results, or call close() on the resulting object.  Otherwise
-                it is possible to get deadlocks or NRLock reentrance
-                exceptions."""
-
-                failed = []
-                invalid = []
-                unsupported = []
-
-                if not servers:
-                        servers = self._img.gen_publishers()
-
-                new_qs = []
-                l = query_p.QueryLexer()
-                l.build()
-                qp = query_p.QueryParser(l)
-                for q in query_str_and_args_lst:
-                        try:
-                                query = qp.parse(q.text)
-                                query_rr = qp.parse(q.text)
-                                if query_rr.remove_root(self._img.root):
-                                        query.add_or(query_rr)
-                                if q.return_type == \
-                                    query_p.Query.RETURN_PACKAGES:
-                                        query.propagate_pkg_return()
-                                new_qs.append(query_p.Query(str(query),
-                                    q.case_sensitive, q.return_type,
-                                    q.num_to_return, q.start_point))
-                        except query_p.BooleanQueryException as e:
-                                raise apx.BooleanQueryException(e)
-                        except query_p.ParseError as e:
-                                raise apx.ParseError(e)
-
-                query_str_and_args_lst = new_qs
-
-                incorp_info, inst_stems = self.get_incorp_info()
-
-                slist = []
-                for entry in servers:
-                        if isinstance(entry, dict):
-                                origin = entry["origin"]
-                                try:
-                                        pub = self._img.get_publisher(
-                                            origin=origin)
-                                        pub_uri = publisher.RepositoryURI(
-                                            origin)
-                                        repo = publisher.Repository(
-                                            origins=[pub_uri])
-                                except apx.UnknownPublisher:
-                                        pub = publisher.RepositoryURI(origin)
-                                        repo = publisher.Repository(
-                                            origins=[pub])
-                                slist.append((pub, repo, origin))
-                                continue
-
-                        # Must be a publisher object.
-                        osets = entry.get_origin_sets()
-                        if not osets:
-                                continue
-                        for repo in osets:
-                                slist.append((entry, repo, entry.prefix))
-
-                for pub, alt_repo, descriptive_name in slist:
-                        if self.__canceling:
-                                raise apx.CanceledException()
-
-                        try:
-                                res = self._img.transport.do_search(pub,
-                                    query_str_and_args_lst,
-                                    ccancel=self.__check_cancel,
-                                    alt_repo=alt_repo)
-                        except apx.CanceledException:
-                                raise
-                        except apx.NegativeSearchResult:
-                                continue
-                        except (apx.InvalidDepotResponseException,
-                            apx.TransportError) as e:
-                                # Alternate source failed portal test or can't
-                                # be contacted at all.
-                                failed.append((descriptive_name, e))
-                                continue
-                        except apx.UnsupportedSearchError as e:
-                                unsupported.append((descriptive_name, e))
-                                continue
-                        except apx.MalformedSearchRequest as e:
-                                ex = self._validate_search(
-                                    query_str_and_args_lst)
-                                if ex:
-                                        raise ex
-                                failed.append((descriptive_name, e))
-                                continue
-
-                        try:
-                                if not self.validate_response(res, 1):
-                                        invalid.append(descriptive_name)
-                                        continue
-                                for line in res:
-                                        pfmri, ret = self.__parse_v_1(line, pub,
-                                            1)
-                                        pstem = pfmri.pkg_name
-                                        pver = pfmri.version
-                                        # Skip this package if a newer version
-                                        # is already installed and version
-                                        # pruning is enabled.
-                                        if prune_versions and \
-                                            pstem in inst_stems and \
-                                            pver < inst_stems[pstem]:
-                                                continue
-                                        # Return this result if version pruning
-                                        # is disabled, the package is not
-                                        # incorporated, or the version of the
-                                        # package matches the incorporation.
-                                        if not prune_versions or \
-                                            pstem not in incorp_info or \
-                                            pfmri.version.is_successor(
-                                                incorp_info[pstem],
-                                                pkg.version.CONSTRAINT_AUTO):
-                                                yield ret
-
-                        except apx.CanceledException:
-                                raise
-                        except apx.TransportError as e:
-                                failed.append((descriptive_name, e))
-                                continue
-
-                if failed or invalid or unsupported:
-                        raise apx.ProblematicSearchServers(failed,
-                            invalid, unsupported)
-
-        def get_incorp_info(self):
-                """This function returns a mapping of package stems to the
-                version at which they are incorporated, if they are
-                incorporated, and the version at which they are installed, if
-                they are installed."""
-
-                # This maps fmris to the version at which they're incorporated.
-                inc_vers = {}
-                inst_stems = {}
-
-                img_cat = self._img.get_catalog(
-                    self._img.IMG_CATALOG_INSTALLED)
-                cat_info = frozenset([img_cat.DEPENDENCY])
-
-                # The incorporation list should include all installed,
-                # incorporated packages from all publishers.
-                for pfmri, actions in img_cat.actions(cat_info):
-                        inst_stems[pfmri.pkg_name] = pfmri.version
-                        for a in actions:
-                                if a.name != "depend" or \
-                                    a.attrs["type"] != "incorporate":
-                                        continue
-                                # Record incorporated packages.
-                                tgt = fmri.PkgFmri(a.attrs["fmri"])
-                                tver = tgt.version
-                                # incorporates without a version should be
-                                # ignored.
-                                if not tver:
-                                        continue
-                                over = inc_vers.get(
-                                    tgt.pkg_name, None)
-
-                                # In case this package has been
-                                # incorporated more than once,
-                                # use the newest version.
-                                if over > tver:
-                                        continue
-                                inc_vers[tgt.pkg_name] = tver
-                return inc_vers, inst_stems
-
-        @staticmethod
-        def __unconvert_return_type(v):
-                return v == query_p.Query.RETURN_ACTIONS
-
-        def _validate_search(self, query_str_lst):
-                """Called by remote search if server responds that the
-                request was invalid.  In this case, parse the query on
-                the client-side and determine what went wrong."""
-
-                for q in query_str_lst:
-                        l = query_p.QueryLexer()
-                        l.build()
-                        qp = query_p.QueryParser(l)
-                        try:
-                                query = qp.parse(q.text)
-                        except query_p.BooleanQueryException as e:
-                                return apx.BooleanQueryException(e)
-                        except query_p.ParseError as e:
-                                return apx.ParseError(e)
-
-                return None
-
-        def rebuild_search_index(self):
-                """Rebuilds the search indexes.  Removes all
-                existing indexes and replaces them from scratch rather than
-                performing the incremental update which is usually used.
-                This is useful for times when the index for the client has
-                been corrupted."""
-                self._img.update_index_dir()
-                self.log_operation_start("rebuild-index")
-                if not os.path.isdir(self._img.index_dir):
-                        self._img.mkdirs()
-                try:
-                        ind = indexer.Indexer(self._img, self._img.get_manifest,
-                            self._img.get_manifest_path,
-                            self.__progresstracker, self._img.list_excludes())
-                        ind.rebuild_index_from_scratch(
-                            self._img.gen_installed_pkgs())
-                except search_errors.ProblematicPermissionsIndexException as e:
-                        error = apx.ProblematicPermissionsIndexException(e)
-                        self.log_operation_end(error=error)
-                        raise error
-                else:
-                        self.log_operation_end()
-
-        def get_manifest(self, pfmri, all_variants=True, repos=None):
-                """Returns the Manifest object for the given package FMRI.
-
-                'all_variants' is an optional boolean value indicating whther
-                the manifest should include metadata for all variants and
-                facets.
-
-                'repos' is a list of URI strings or RepositoryURI objects that
-                represent the locations of additional sources of package data to
-                use during the planned operation.
-                """
-
-                alt_pub = None
-                if repos:
-                        pkg_pub_map, ignored, known_cat, inst_cat = \
-                            self.__get_alt_pkg_data(repos)
-                        alt_pub = pkg_pub_map.get(pfmri.publisher, {}).get(
-                            pfmri.pkg_name, {}).get(str(pfmri.version), None)
-                return self._img.get_manifest(pfmri,
-                    ignore_excludes=all_variants, alt_pub=alt_pub)
-
-        @staticmethod
-        def validate_response(res, v):
-                """This function is used to determine whether the first
-                line returned from a server is expected.  This ensures that
-                search is really communicating with a search-enabled server."""
-
-                try:
-                        s = next(res)
-                        return s == Query.VALIDATION_STRING[v]
-                except StopIteration:
-                        return False
-
-        def add_publisher(self, pub, refresh_allowed=True,
-            approved_cas=misc.EmptyI, revoked_cas=misc.EmptyI,
-            search_after=None, search_before=None, search_first=None,
-            unset_cas=misc.EmptyI):
-                """Add the provided publisher object to the image
-                configuration."""
-                try:
-                        self._img.add_publisher(pub,
-                            refresh_allowed=refresh_allowed,
-                            progtrack=self.__progresstracker,
-                            approved_cas=approved_cas, revoked_cas=revoked_cas,
-                            search_after=search_after,
-                            search_before=search_before,
-                            search_first=search_first,
-                            unset_cas=unset_cas)
-                finally:
-                        self._img.cleanup_downloads()
-
-        def get_highest_ranked_publisher(self):
-                """Returns the highest ranked publisher object for the image."""
-                return self._img.get_highest_ranked_publisher()
-
-        def get_publisher(self, prefix=None, alias=None, duplicate=False):
-                """Retrieves a publisher object matching the provided prefix
-                (name) or alias.
-
-                'duplicate' is an optional boolean value indicating whether
-                a copy of the publisher object should be returned instead
-                of the original.
-                """
-                pub = self._img.get_publisher(prefix=prefix, alias=alias)
-                if duplicate:
-                        # Never return the original so that changes to the
-                        # retrieved object are not reflected until
-                        # update_publisher is called.
-                        return copy.copy(pub)
-                return pub
-
-        @_LockedCancelable()
-        def get_publisherdata(self, pub=None, repo=None):
-                """Attempts to retrieve publisher configuration information from
-                the specified publisher's repository or the provided repository.
-                If successful, it will either return an empty list (in the case
-                that the repository supports the operation, but doesn't offer
-                configuration information) or a list of Publisher objects.
-                If this operation is not supported by the publisher or the
-                specified repository, an UnsupportedRepositoryOperation
-                exception will be raised.
-
-                'pub' is an optional Publisher object.
-
-                'repo' is an optional RepositoryURI object.
-
-                Either 'pub' or 'repo' must be provided."""
-
-                assert (pub or repo) and not (pub and repo)
-
-                # Transport accepts either type of object, but a distinction is
-                # made in the client API for clarity.
-                pub = max(pub, repo)
-
-                return self._img.transport.get_publisherdata(pub,
-                    ccancel=self.__check_cancel)
-
-        def get_publishers(self, duplicate=False):
-                """Returns a list of the publisher objects for the current
-                image.
-
-                'duplicate' is an optional boolean value indicating whether
-                copies of the publisher objects should be returned instead
-                of the originals.
-                """
-
-                res = self._img.get_sorted_publishers()
-                if duplicate:
-                        return [copy.copy(p) for p in res]
-                return res
-
-        def get_publisher_last_update_time(self, prefix=None, alias=None):
-                """Returns a datetime object representing the last time the
-                catalog for a publisher was modified or None."""
-
-                if alias:
-                        pub = self.get_publisher(alias=alias)
-                else:
-                        pub = self.get_publisher(prefix=prefix)
-
-                if pub.disabled:
-                        return None
-
-                dt = None
-                self._acquire_activity_lock()
-                try:
-                        self._enable_cancel()
-                        try:
-                                dt = pub.catalog.last_modified
-                        except:
-                                self.__reset_unlock()
-                                raise
-                        try:
-                                self._disable_cancel()
-                        except apx.CanceledException:
-                                self._cancel_done()
-                                raise
-                finally:
-                        self._activity_lock.release()
-                return dt
-
-        def has_publisher(self, prefix=None, alias=None):
-                """Returns a boolean value indicating whether a publisher using
-                the given prefix or alias exists."""
-                return self._img.has_publisher(prefix=prefix, alias=alias)
-
-        def remove_publisher(self, prefix=None, alias=None):
-                """Removes a publisher object matching the provided prefix
-                (name) or alias."""
-                self._img.remove_publisher(prefix=prefix, alias=alias,
-                    progtrack=self.__progresstracker)
-
-                self.__remove_unused_client_certificates()
-
-        def update_publisher(self, pub, refresh_allowed=True, search_after=None,
-            search_before=None, search_first=None):
-                """Replaces an existing publisher object with the provided one
-                using the _source_object_id identifier set during copy.
-
-                'refresh_allowed' is an optional boolean value indicating
-                whether a refresh of publisher metadata (such as its catalog)
-                should be performed if transport information is changed for a
-                repository, mirror, or origin.  If False, no attempt will be
-                made to retrieve publisher metadata."""
-
-                self._acquire_activity_lock()
-                try:
-                        self._disable_cancel()
-                        with self._img.locked_op("update-publisher"):
-                                return self.__update_publisher(pub,
-                                    refresh_allowed=refresh_allowed,
-                                    search_after=search_after,
-                                    search_before=search_before,
-                                    search_first=search_first)
-                except apx.CanceledException as e:
-                        self._cancel_done()
-                        raise
-                finally:
-                        self._img.cleanup_downloads()
-                        self._activity_lock.release()
-
-        def __update_publisher(self, pub, refresh_allowed=True,
-            search_after=None, search_before=None, search_first=None):
-                """Private publisher update method; caller responsible for
-                locking."""
-
-                assert (not search_after and not search_before) or \
-                    (not search_after and not search_first) or \
-                    (not search_before and not search_first)
-
-                # Before continuing, validate SSL information.
-                try:
-                        self._img.check_cert_validity(pubs=[pub])
-                except apx.ExpiringCertificate as e:
-                        logger.warning(str(e))
-
-                def origins_changed(oldr, newr):
-                        old_origins = set([
-                            (o.uri, o.ssl_cert,
-                                o.ssl_key, tuple(sorted(o.proxies)), o.disabled)
-                            for o in oldr.origins
-                        ])
-                        new_origins = set([
-                            (o.uri, o.ssl_cert,
-                                o.ssl_key, tuple(sorted(o.proxies)), o.disabled)
-                            for o in newr.origins
-                        ])
-                        return (new_origins - old_origins), \
-                            new_origins.symmetric_difference(old_origins)
-
-                def need_refresh(oldo, newo):
-                        if newo.disabled:
-                                # The publisher is disabled, so no refresh
-                                # should be performed.
-                                return False
-
-                        if oldo.disabled and not newo.disabled:
-                                # The publisher has been re-enabled, so
-                                # retrieve the catalog.
-                                return True
-
-                        oldr = oldo.repository
-                        newr = newo.repository
-                        if newr._source_object_id != id(oldr):
-                                # Selected repository has changed.
-                                return True
-                        # If any were added or removed, refresh.
-                        return len(origins_changed(oldr, newr)[1]) != 0
-
-                refresh_catalog = False
-                disable = False
-                orig_pub = None
-
-                # Configuration must be manipulated directly.
-                publishers = self._img.cfg.publishers
-
-                # First, attempt to match the updated publisher object to an
-                # existing one using the object id that was stored during
-                # copy().
-                for key, old in six.iteritems(publishers):
-                        if pub._source_object_id == id(old):
-                                # Store the new publisher's id and the old
-                                # publisher object so it can be restored if the
-                                # update operation fails.
-                                orig_pub = (id(pub), old)
-                                break
-
-                if not orig_pub:
-                        # If a matching publisher couldn't be found and
-                        # replaced, something is wrong (client api usage
-                        # error).
-                        raise apx.UnknownPublisher(pub)
-
-                # Next, be certain that the publisher's prefix and alias
-                # are not already in use by another publisher.
-                for key, old in six.iteritems(publishers):
-                        if pub._source_object_id == id(old):
-                                # Don't check the object we're replacing.
-                                continue
-
-                        if pub.prefix == old.prefix or \
-                            pub.prefix == old.alias or \
-                            pub.alias and (pub.alias == old.alias or
-                            pub.alias == old.prefix):
-                                raise apx.DuplicatePublisher(pub)
-
-                # Next, determine what needs updating and add the updated
-                # publisher.
-                for key, old in six.iteritems(publishers):
-                        if pub._source_object_id == id(old):
-                                old = orig_pub[-1]
-                                if need_refresh(old, pub):
-                                        refresh_catalog = True
-                                if not old.disabled and pub.disabled:
-                                        disable = True
-
-                                # Now remove the old publisher object using the
-                                # iterator key if the prefix has changed.
-                                if key != pub.prefix:
-                                        del publishers[key]
-
-                                # Prepare the new publisher object.
-                                pub.meta_root = \
-                                    self._img._get_publisher_meta_root(
-                                    pub.prefix)
-                                pub.transport = self._img.transport
-
-                                # Finally, add the new publisher object.
-                                publishers[pub.prefix] = pub
-                                break
-
-                def cleanup():
-                        # Attempting to unpack a non-sequence%s;
-                        # pylint: disable=W0633
-                        new_id, old_pub = orig_pub
-                        for new_pfx, new_pub in six.iteritems(publishers):
-                                if id(new_pub) == new_id:
-                                        publishers[old_pub.prefix] = old_pub
-                                        break
-
-                repo = pub.repository
-
-                validate = origins_changed(orig_pub[-1].repository,
-                    pub.repository)[0]
-
-                try:
-                        if disable or (not repo.origins and
-                            orig_pub[-1].repository.origins):
-                                # Remove the publisher's metadata (such as
-                                # catalogs, etc.).  This only needs to be done
-                                # in the event that a publisher is disabled or
-                                # has transitioned from having origins to not
-                                # having any at all; in any other case (the
-                                # origins changing, etc.), refresh() will do the
-                                # right thing.
-                                self._img.remove_publisher_metadata(pub)
-                        elif not pub.disabled and not refresh_catalog:
-                                refresh_catalog = pub.needs_refresh
-
-                        if refresh_catalog and refresh_allowed:
-                                # One of the publisher's repository origins may
-                                # have changed, so the publisher needs to be
-                                # revalidated.
-
-                                if validate:
-                                        self._img.transport.valid_publisher_test(
-                                            pub)
-
-                                # Validate all new origins against publisher
-                                # configuration.
-                                for uri, ssl_cert, ssl_key, proxies, disabled \
-                                    in validate:
-                                        repo = publisher.RepositoryURI(uri,
-                                            ssl_cert=ssl_cert, ssl_key=ssl_key,
-                                            proxies=proxies, disabled=disabled)
-                                        pub.validate_config(repo)
-
-                                self.__refresh(pubs=[pub], immediate=True,
-                                    ignore_unreachable=False)
-                        elif refresh_catalog:
-                                # Something has changed (such as a repository
-                                # origin) for the publisher, so a refresh should
-                                # occur, but isn't currently allowed.  As such,
-                                # clear the last_refreshed time so that the next
-                                # time the client checks to see if a refresh is
-                                # needed and is allowed, one will be performed.
-                                pub.last_refreshed = None
-                except Exception as e:
-                        # If any of the above fails, the original publisher
-                        # information needs to be restored so that state is
-                        # consistent.
-                        cleanup()
-                        raise
-                except:
-                        # If any of the above fails, the original publisher
-                        # information needs to be restored so that state is
-                        # consistent.
-                        cleanup()
-                        raise
-
-                if search_first:
-                        self._img.set_highest_ranked_publisher(
-                            prefix=pub.prefix)
-                elif search_before:
-                        self._img.pub_search_before(pub.prefix, search_before)
-                elif search_after:
-                        self._img.pub_search_after(pub.prefix, search_after)
-
-                # Successful; so save configuration.
-                self._img.save_config()
-
-                self.__remove_unused_client_certificates()
-
-        def __remove_unused_client_certificates(self):
-                """Remove unused client certificate files"""
-
-                # Get certificate files currently in use.
-                ssl_path = os.path.join(self._img.imgdir, "ssl")
-                current_file_list = set()
-                pubs = self._img.get_publishers()
-                for p in pubs:
-                        pub = pubs[p]
-                        for origin in pub.repository.origins:
-                                current_file_list.add(origin.ssl_key)
-                                current_file_list.add(origin.ssl_cert)
-
-                # Remove files found in ssl directory that
-                # are not in use by publishers.
-                for f in os.listdir(ssl_path):
-                        path = os.path.join(ssl_path, f)
-                        if path not in current_file_list:
-                                try:
-                                        portable.remove(path)
-                                except:
-                                        continue
-
-        def log_operation_end(self, error=None, result=None,
-            release_notes=None):
-                """Marks the end of an operation to be recorded in image
-                history.
-
-                'result' should be a pkg.client.history constant value
-                representing the outcome of an operation.  If not provided,
-                and 'error' is provided, the final result of the operation will
-                be based on the class of 'error' and 'error' will be recorded
-                for the current operation.  If 'result' and 'error' is not
-                provided, success is assumed."""
-                self._img.history.log_operation_end(error=error, result=result,
-                release_notes=release_notes)
-
-        def log_operation_error(self, error):
-                """Adds an error to the list of errors to be recorded in image
-                history for the current opreation."""
-                self._img.history.log_operation_error(error)
-
-        def log_operation_start(self, name):
-                """Marks the start of an operation to be recorded in image
-                history."""
-                # If an operation is going to be discarded, then don't take the
-                # performance hit of actually getting the BE info.
-                if name in history.DISCARDED_OPERATIONS:
-                        be_name, be_uuid = None, None
-                else:
-                        be_name, be_uuid = bootenv.BootEnv.get_be_name(
-                            self._img.root)
-                self._img.history.log_operation_start(name,
-                    be_name=be_name, be_uuid=be_uuid)
-
-        def parse_liname(self, name, unknown_ok=False):
-                """Parse a linked image name string and return a
-                LinkedImageName object.  If "unknown_ok" is true then
-                liname must correspond to an existing linked image.  If
-                "unknown_ok" is false and liname doesn't correspond to
-                an existing linked image then liname must be a
-                syntactically valid and fully qualified linked image
-                name."""
-
-                return self._img.linked.parse_name(name, unknown_ok=unknown_ok)
-
-        def parse_p5i(self, data=None, fileobj=None, location=None):
-                """Reads the pkg(7) publisher JSON formatted data at 'location'
-                or from the provided file-like object 'fileobj' and returns a
-                list of tuples of the format (publisher object, pkg_names).
-                pkg_names is a list of strings representing package names or
-                FMRIs.  If any pkg_names not specific to a publisher were
-                provided, the last tuple returned will be of the format (None,
-                pkg_names).
-
-                'data' is an optional string containing the p5i data.
-
-                'fileobj' is an optional file-like object that must support a
-                'read' method for retrieving data.
-
-                'location' is an optional string value that should either start
-                with a leading slash and be pathname of a file or a URI string.
-                If it is a URI string, supported protocol schemes are 'file',
-                'ftp', 'http', and 'https'.
-
-                'data' or 'fileobj' or 'location' must be provided."""
-
-                return p5i.parse(data=data, fileobj=fileobj, location=location)
-
-        def parse_fmri_patterns(self, patterns):
-                """A generator function that yields a list of tuples of the form
-                (pattern, error, fmri, matcher) based on the provided patterns,
-                where 'error' is any exception encountered while parsing the
-                pattern, 'fmri' is the resulting FMRI object, and 'matcher' is
-                one of the following constant values:
-
-                        MATCH_EXACT
-                                Indicates that the name portion of the pattern
-                                must match exactly and the version (if provided)
-                                must be considered a successor or equal to the
-                                target FMRI.
-
-                        MATCH_FMRI
-                                Indicates that the name portion of the pattern
-                                must be a proper subset and the version (if
-                                provided) must be considered a successor or
-                                equal to the target FMRI.
-
-                        MATCH_GLOB
-                                Indicates that the name portion of the pattern
-                                uses fnmatch rules for pattern matching (shell-
-                                style wildcards) and that the version can either
-                                match exactly, match partially, or contain
-                                wildcards.
-                """
-
-                for pat in patterns:
-                        error = None
-                        matcher = None
-                        npat = None
-                        try:
-                                parts = pat.split("@", 1)
-                                pat_stem = parts[0]
-                                pat_ver = None
-                                if len(parts) > 1:
-                                        pat_ver = parts[1]
-
-                                if "*" in pat_stem or "?" in pat_stem:
-                                        matcher = self.MATCH_GLOB
-                                elif pat_stem.startswith("pkg:/") or \
-                                    pat_stem.startswith("/"):
-                                        matcher = self.MATCH_EXACT
-                                else:
-                                        matcher = self.MATCH_FMRI
-
-                                if matcher == self.MATCH_GLOB:
-                                        npat = fmri.MatchingPkgFmri(pat_stem)
-                                else:
-                                        npat = fmri.PkgFmri(pat_stem)
-
-                                if not pat_ver:
-                                        # Do nothing.
-                                        pass
-                                elif "*" in pat_ver or "?" in pat_ver or \
-                                    pat_ver == "latest":
-                                        npat.version = \
-                                            pkg.version.MatchingVersion(pat_ver)
-                                else:
-                                        npat.version = \
-                                            pkg.version.Version(pat_ver)
-
-                        except (fmri.FmriError, pkg.version.VersionError) as e:
-                                # Whatever the error was, return it.
-                                error = e
-                        yield (pat, error, npat, matcher)
-
-        def purge_history(self):
-                """Deletes all client history."""
-                be_name, be_uuid = bootenv.BootEnv.get_be_name(self._img.root)
-                self._img.history.purge(be_name=be_name, be_uuid=be_uuid)
-
-        def update_format(self):
-                """Attempt to update the on-disk format of the image to the
-                newest version.  Returns a boolean indicating whether any action
-                was taken."""
-
-                self._acquire_activity_lock()
-                try:
-                        self._disable_cancel()
-                        self._img.allow_ondisk_upgrade = True
-                        return self._img.update_format(
-                            progtrack=self.__progresstracker)
-                except apx.CanceledException as e:
-                        self._cancel_done()
-                        raise
-                finally:
-                        self._activity_lock.release()
-
-        def write_p5i(self, fileobj, pkg_names=None, pubs=None):
-                """Writes the publisher, repository, and provided package names
-                to the provided file-like object 'fileobj' in JSON p5i format.
-
-                'fileobj' is only required to have a 'write' method that accepts
-                data to be written as a parameter.
-
-                'pkg_names' is a dict of lists, tuples, or sets indexed by
-                publisher prefix that contain package names, FMRI strings, or
-                package info objects.  A prefix of "" can be used for packages
-                that are not specific to a publisher.
-
-                'pubs' is an optional list of publisher prefixes or Publisher
-                objects.  If not provided, the information for all publishers
-                (excluding those disabled) will be output."""
-
-                if not pubs:
-                        plist = [
-                            p for p in self.get_publishers()
-                            if not p.disabled
-                        ]
-                else:
-                        plist = []
-                        for p in pubs:
-                                if not isinstance(p, publisher.Publisher):
-                                        plist.append(self._img.get_publisher(
-                                            prefix=p, alias=p))
-                                else:
-                                        plist.append(p)
-
-                # Transform PackageInfo object entries into PkgFmri entries
-                # before passing them to the p5i module.
-                new_pkg_names = {}
-                for pub in pkg_names:
-                        pkglist = []
-                        for p in pkg_names[pub]:
-                                if isinstance(p, PackageInfo):
-                                        pkglist.append(p.fmri)
-                                else:
-                                        pkglist.append(p)
-                        new_pkg_names[pub] = pkglist
-                p5i.write(fileobj, plist, pkg_names=new_pkg_names)
-
-        def write_syspub(self, path, prefixes, version):
-                """Write the syspub/version response to the provided path."""
-                if version != 0:
-                        raise apx.UnsupportedP5SVersion(version)
-
-                pubs = [
-                    p for p in self.get_publishers()
-                    if p.prefix in prefixes
-                ]
-                fd, fp = tempfile.mkstemp()
-                try:
-                        fh = os.fdopen(fd, "w")
-                        p5s.write(fh, pubs, self._img.cfg)
-                        fh.close()
-                        portable.rename(fp, path)
-                except:
-                        if os.path.exists(fp):
-                                portable.remove(fp)
-                        raise
-
-        def get_dehydrated_publishers(self):
-                """Return the list of dehydrated publishers' prefixes."""
-
-                return self._img.cfg.get_property("property", "dehydrated")
-
-
-class Query(query_p.Query):
-        """This class is the object used to pass queries into the api functions.
-        It encapsulates the possible options available for a query as well as
-        the text of the query itself."""
-
-        def __init__(self, text, case_sensitive, return_actions=True,
-            num_to_return=None, start_point=None):
-                if return_actions:
-                        return_type = query_p.Query.RETURN_ACTIONS
-                else:
-                        return_type = query_p.Query.RETURN_PACKAGES
-                try:
-                        query_p.Query.__init__(self, text, case_sensitive,
-                            return_type, num_to_return, start_point)
-                except query_p.QueryLengthExceeded as e:
-                        raise apx.ParseError(e)
-
-
-def get_default_image_root(orig_cwd=None):
-        """Returns a tuple of (root, exact_match) where 'root' is the absolute
-        path of the default image root based on current environment given the
-        client working directory and platform defaults, and 'exact_match' is a
-        boolean specifying how the default should be treated by ImageInterface.
-        Note that the root returned may not actually be the valid root of an
-        image; it is merely the default location a client should use when
-        initializing an ImageInterface (e.g. '/' is not a valid image on Solaris
-        10).
-
-        The ImageInterface object will use the root provided as a starting point
-        to find an image, searching upwards through each parent directory until
-        '/' is reached based on the value of exact_match.
-
-        'orig_cwd' should be the original current working directory at the time
-        of client startup.  This value is assumed to be valid if provided,
-        although permission and access errors will be gracefully handled.
-        """
-
-        # If an image location wasn't explicitly specified, check $PKG_IMAGE in
-        # the environment.
-        root = os.environ.get("PKG_IMAGE")
-        exact_match = True
-        if not root:
-                if os.environ.get("PKG_FIND_IMAGE") or \
-                    portable.osname != "sunos":
-                        # If no image location was found in the environment,
-                        # then see if user enabled finding image or if current
-                        # platform isn't Solaris.  If so, attempt to find the
-                        # image starting with the working directory.
-                        root = orig_cwd
-                        if root:
-                                exact_match = False
-                if not root:
-                        # If no image directory has been determined based on
-                        # request or environment, default to live root.
-                        root = misc.liveroot()
-        return root, exact_match
-
-
-def image_create(pkg_client_name, version_id, root, imgtype, is_zone,
-    cancel_state_callable=None, facets=misc.EmptyDict, force=False,
-    mirrors=misc.EmptyI, origins=misc.EmptyI, prefix=None, refresh_allowed=True,
-    repo_uri=None, ssl_cert=None, ssl_key=None, user_provided_dir=False,
-    progtrack=None, variants=misc.EmptyDict, props=misc.EmptyDict,
-    cmdpath=None):
-        """Creates an image at the specified location.
-
-        'pkg_client_name' is a string containing the name of the client,
-        such as "pkg".
+    """This class presents an interface to images that clients may use.
+    There is a specific order of methods which must be used to install
+    or uninstall packages, or update an image.  First, a gen_plan_* method
+    must be called.  After that method completes successfully, describe may
+    be called, and prepare must be called.  Finally, execute_plan may be
+    called to implement the previous created plan.  The other methods
+    do not have an ordering imposed upon them, and may be used as
+    needed.  Cancel may only be invoked while a cancelable method is
+    running."""
+
+    FACET_ALL = 0
+    FACET_IMAGE = 1
+    FACET_INSTALLED = 2
+
+    FACET_SRC_SYSTEM = pkg.facet.Facets.FACET_SRC_SYSTEM
+    FACET_SRC_LOCAL = pkg.facet.Facets.FACET_SRC_LOCAL
+    FACET_SRC_PARENT = pkg.facet.Facets.FACET_SRC_PARENT
+
+    # Constants used to reference specific values that info can return.
+    INFO_FOUND = 0
+    INFO_MISSING = 1
+    INFO_ILLEGALS = 3
+
+    LIST_ALL = 0
+    LIST_INSTALLED = 1
+    LIST_INSTALLED_NEWEST = 2
+    LIST_NEWEST = 3
+    LIST_UPGRADABLE = 4
+    LIST_REMOVABLE = 5
+
+    MATCH_EXACT = 0
+    MATCH_FMRI = 1
+    MATCH_GLOB = 2
+
+    VARIANT_ALL = 0
+    VARIANT_ALL_POSSIBLE = 1
+    VARIANT_IMAGE = 2
+    VARIANT_IMAGE_POSSIBLE = 3
+    VARIANT_INSTALLED = 4
+    VARIANT_INSTALLED_POSSIBLE = 5
+
+    def __init__(
+        self,
+        img_path,
+        version_id,
+        progresstracker,
+        cancel_state_callable,
+        pkg_client_name,
+        exact_match=True,
+        cmdpath=None,
+    ):
+        """Constructs an ImageInterface object.
+
+        'img_path' is the absolute path to an existing image or to a
+        path from which to start looking for an image.  To control this
+        behaviour use the 'exact_match' parameter.
 
         'version_id' indicates the version of the api the client is
         expecting to use.
 
-        'root' is the absolute path of the directory where the image will
-        be created.  If it does not exist, it will be created.
+        'progresstracker' is the ProgressTracker object the client wants
+        the api to use for UI progress callbacks.
 
-        'imgtype' is an IMG_TYPE constant representing the type of image
-        to create.
+        'cancel_state_callable' is an optional function reference that
+        will be called if the cancellable status of an operation
+        changes.
 
-        'is_zone' is a boolean value indicating whether the image being
-        created is for a zone.
+        'pkg_client_name' is a string containing the name of the client,
+        such as "pkg".
 
-        'cancel_state_callable' is an optional function reference that will
-        be called if the cancellable status of an operation changes.
-
-        'facets' is a dictionary of facet names and values to set during
-        the image creation process.
-
-        'force' is an optional boolean value indicating that if an image
-        already exists at the specified 'root' that it should be overwritten.
-
-        'mirrors' is an optional list of URI strings that should be added to
-        all publishers configured during image creation as mirrors.
-
-        'origins' is an optional list of URI strings that should be added to
-        all publishers configured during image creation as origins.
-
-        'prefix' is an optional publisher prefix to configure as a publisher
-        for the new image if origins is provided, or to restrict which publisher
-        will be configured if 'repo_uri' is provided.  If this prefix does not
-        match the publisher configuration retrieved from the repository, an
-        UnknownRepositoryPublishers exception will be raised.  If not provided,
-        'refresh_allowed' cannot be False.
-
-        'props' is an optional dictionary mapping image property names to values
-        to be set while creating the image.
-
-        'refresh_allowed' is an optional boolean value indicating whether
-        publisher configuration data and metadata can be retrieved during
-        image creation.  If False, 'repo_uri' cannot be specified and
-        a 'prefix' must be provided.
-
-        'repo_uri' is an optional URI string of a package repository to
-        retrieve publisher configuration information from.  If the target
-        repository supports this, all publishers found will be added to the
-        image and any origins or mirrors will be added to all of those
-        publishers.  If the target repository does not support this, and a
-        prefix was not specified, an UnsupportedRepositoryOperation exception
-        will be raised.  If the target repository supports the operation, but
-        does not provide complete configuration information, a
-        RepoPubConfigUnavailable exception will be raised.
-
-        'ssl_cert' is an optional pathname of an SSL Certificate file to
-        configure all publishers with and to use when retrieving publisher
-        configuration information.  If provided, 'ssl_key' must also be
-        provided.  The certificate file must be pem-encoded.
-
-        'ssl_key' is an optional pathname of an SSL Key file to configure all
-        publishers with and to use when retrieving publisher configuration
-        information.  If provided, 'ssl_cert' must also be provided.  The
-        key file must be pem-encoded.
-
-        'user_provided_dir' is an optional boolean value indicating that the
-        provided 'root' was user-supplied and that additional error handling
-        should be enforced.  This primarily affects cases where a relative
-        root has been provided or the root was based on the current working
-        directory.
-
-        'progtrack' is an optional ProgressTracker object.
-
-        'variants' is a dictionary of variant names and values to set during
-        the image creation process.
-
-        Callers must provide one of the following when calling this function:
-         * no 'prefix' and no 'origins'
-         * a 'prefix' and 'repo_uri' (origins and mirrors are optional)
-         * no 'prefix' and a 'repo_uri'  (origins and mirrors are optional)
-         * a 'prefix' and 'origins'
+        'exact_match' is a boolean indicating whether the API should
+        attempt to find a usable image starting from the specified
+        directory, going up to the filesystem root until it finds one.
+        If set to True, an image must exist at the location indicated
+        by 'img_path'.
         """
 
-        # Caller must provide a prefix and repository, or no prefix and a
-        # repository, or a prefix and origins, or no prefix and no origins.
-        assert (prefix and repo_uri) or (not prefix and repo_uri) or (prefix and
-            origins or (not prefix and not origins))
+        if version_id not in COMPATIBLE_API_VERSIONS:
+            raise apx.VersionException(CURRENT_API_VERSION, version_id)
 
-        # If prefix isn't provided and refresh isn't allowed, then auto-config
-        # cannot be done.
-        assert (prefix or refresh_allowed) or not repo_uri
+        if sys.path[0].startswith("/dev/fd/"):
+            #
+            # Normally when the kernel forks off an interpreted
+            # program, it executes the interpreter with the first
+            # argument being the path to the interpreted program
+            # we're executing.  But in the case of suid scripts
+            # this presents a security problem because that path
+            # could be updated after exec but before the
+            # interpreter opens reads the program.  To avoid this
+            # race, for suid script the kernel replaces the name
+            # of the interpreted program with /dev/fd/###, and
+            # opens the interpreted program such that it can be
+            # read from the specified file descriptor device node.
+            # So if we detect that path[0] (which should be then
+            # interpreted program name) is a /dev/fd/ path, that
+            # means we're being run as an suid script, which we
+            # don't really want to support.  (Since this breaks
+            # our subsequent code that attempt to determine the
+            # name of the executable we are running as.)
+            #
+            raise apx.SuidUnsupportedError()
 
-        destroy_root = False
+        # The image's History object will use client_name from
+        # global_settings, but if the program forgot to set it,
+        # we'll go ahead and do so here.
+        if global_settings.client_name is None:
+            global_settings.client_name = pkg_client_name
+
+        if cmdpath is None:
+            cmdpath = misc.api_cmdpath()
+        self.cmdpath = cmdpath
+
+        # prevent brokeness in the test suite
+        if (
+            self.cmdpath
+            and "PKG_NO_RUNPY_CMDPATH" in os.environ
+            and self.cmdpath.endswith(os.sep + "run.py")
+        ):
+            raise RuntimeError(
+                """
+An ImageInterface object was allocated from within ipkg test suite and
+cmdpath was not explicitly overridden.  Please make sure to set
+explicitly set cmdpath when allocating an ImageInterface object, or
+override cmdpath when allocating an Image object by setting PKG_CMDPATH
+in the environment or by setting simulate_cmdpath in DebugValues."""
+            )
+
+        if isinstance(img_path, six.string_types):
+            # Store this for reset().
+            self._img_path = img_path
+            self._img = image.Image(
+                img_path,
+                progtrack=progresstracker,
+                user_provided_dir=exact_match,
+                cmdpath=self.cmdpath,
+            )
+
+            # Store final image path.
+            self._img_path = self._img.get_root()
+        elif isinstance(img_path, image.Image):
+            # This is a temporary, special case for client.py
+            # until the image api is complete.
+            self._img = img_path
+            self._img_path = img_path.get_root()
+        else:
+            # API consumer passed an unknown type for img_path.
+            raise TypeError(_("Unknown img_path type."))
+
+        self.__progresstracker = progresstracker
+        lin = None
+        if self._img.linked.ischild():
+            lin = self._img.linked.child_name
+        self.__progresstracker.set_linked_name(lin)
+
+        self.__cancel_state_callable = cancel_state_callable
+        self.__plan_type = None
+        self.__api_op = None
+        self.__plan_desc = None
+        self.__planned_children = False
+        self.__prepared = False
+        self.__executed = False
+        self.__be_activate = True
+        self.__backup_be_name = None
+        self.__be_name = None
+        self.__can_be_canceled = False
+        self.__canceling = False
+        self._activity_lock = pkg.nrlock.NRLock()
+        self.__blocking_locks = False
+        self._img.blocking_locks = self.__blocking_locks
+        self.__cancel_lock = pkg.nrlock.NRLock()
+        self.__cancel_cv = threading.Condition(self.__cancel_lock)
+        self.__backup_be = None  # create if needed
+        self.__new_be = None  # create if needed
+        self.__alt_sources = {}
+
+    def __set_blocking_locks(self, value):
+        self._activity_lock.acquire()
+        self.__blocking_locks = value
+        self._img.blocking_locks = value
+        self._activity_lock.release()
+
+    def __set_img_alt_sources(self, repos):
+        """Private helper function to change image to use alternate
+        package sources if applicable."""
+
+        # When using alternate package sources with the image, the
+        # result is a composite of the package data already known
+        # by the image and the alternate sources.
+        if repos:
+            self._img.set_alt_pkg_sources(self.__get_alt_pkg_data(repos))
+        else:
+            self._img.set_alt_pkg_sources(None)
+
+    @_LockedCancelable()
+    def set_alt_repos(self, repos):
+        """Public function to specify alternate package sources."""
+        self.__set_img_alt_sources(repos)
+
+    blocking_locks = property(
+        lambda self: self.__blocking_locks,
+        __set_blocking_locks,
+        doc="A boolean value indicating whether "
+        "the API should wait until the image interface can be locked if "
+        "it is in use by another thread or process.  Clients should be "
+        "aware that there is no timeout mechanism in place if blocking is "
+        "enabled, and so should take steps to remain responsive to user "
+        "input or provide a way for users to cancel operations.",
+    )
+
+    @property
+    def excludes(self):
+        """The list of excludes for the image."""
+        return self._img.list_excludes()
+
+    @property
+    def img(self):
+        """Private; public access to this property will be removed at
+        a later date.  Do not use."""
+        return self._img
+
+    @property
+    def img_type(self):
+        """Returns the IMG_TYPE constant for the image's type."""
+        if not self._img:
+            return None
+        return self._img.image_type(self._img.root)
+
+    @property
+    def is_liveroot(self):
+        """A boolean indicating whether the image to be modified is
+        for the live system root."""
+        return self._img.is_liveroot()
+
+    @property
+    def is_zone(self):
+        """A boolean value indicating whether the image is a zone."""
+        return self._img.is_zone()
+
+    @property
+    def is_active_liveroot_be(self):
+        """A boolean indicating whether the image to be modified is
+        the active BE for the system's root image."""
+
+        if not self._img.is_liveroot():
+            return False
+
         try:
-                destroy_root = not os.path.exists(root)
-        except EnvironmentError as e:
-                if e.errno == errno.EACCES:
-                        raise apx.PermissionsException(
-                            e.filename)
-                raise
+            be_name, be_uuid = bootenv.BootEnv.get_be_name(self._img.root)
+            return be_name == bootenv.BootEnv.get_activated_be_name(
+                bootnext=True
+            )
+        except apx.BEException:
+            # If boot environment logic isn't supported, return
+            # False.  This is necessary for user images and for
+            # the test suite.
+            return False
 
-        # The image object must be created first since transport may be
-        # needed to retrieve publisher configuration information.
-        img = image.Image(root, force=force, imgtype=imgtype,
-            progtrack=progtrack, should_exist=False,
-            user_provided_dir=user_provided_dir, cmdpath=cmdpath,
-            props=props)
-        api_inst = ImageInterface(img, version_id,
-            progtrack, cancel_state_callable, pkg_client_name,
-            cmdpath=cmdpath)
+    @property
+    def img_plandir(self):
+        """A path to the image planning directory."""
+        plandir = self._img.plandir
+        misc.makedirs(plandir)
+        return plandir
 
-        pubs = []
+    @property
+    def last_modified(self):
+        """A datetime object representing when the image's metadata was
+        last updated."""
+
+        return self._img.get_last_modified()
+
+    def __set_progresstracker(self, value):
+        self._activity_lock.acquire()
+        self.__progresstracker = value
+
+        # tell the progress tracker about this image's name
+        lin = None
+        if self._img.linked.ischild():
+            lin = self._img.linked.child_name
+        self.__progresstracker.set_linked_name(lin)
+
+        self._activity_lock.release()
+
+    progresstracker = property(
+        lambda self: self.__progresstracker,
+        __set_progresstracker,
+        doc="The current ProgressTracker object.  "
+        "This value should only be set when no other API calls are in "
+        "progress.",
+    )
+
+    @property
+    def mediators(self):
+        """A dictionary of the mediators and their configured version
+        and implementation of the form:
+
+           {
+               mediator-name: {
+                   "version": mediator-version-string,
+                   "version-source": (site|vendor|system|local),
+                   "implementation": mediator-implementation-string,
+                   "implementation-source": (site|vendor|system|local),
+               }
+           }
+
+          'version' is an optional string that specifies the version
+           (expressed as a dot-separated sequence of non-negative
+           integers) of the mediator for use.
+
+           'version-source' is a string describing the source of the
+           selected version configuration.  It indicates how the
+           version component of the mediation was selected.
+
+           'implementation' is an optional string that specifies the
+           implementation of the mediator for use in addition to or
+           instead of 'version'.
+
+           'implementation-source' is a string describing the source of
+           the selected implementation configuration.  It indicates how
+           the implementation component of the mediation was selected.
+        """
+
+        ret = {}
+        for m, mvalues in six.iteritems(self._img.cfg.mediators):
+            ret[m] = copy.copy(mvalues)
+            if "version" in ret[m]:
+                # Don't expose internal Version object to
+                # external consumers.
+                ret[m]["version"] = ret[m]["version"].get_short_version()
+            if "implementation-version" in ret[m]:
+                # Don't expose internal Version object to
+                # external consumers.
+                ret[m]["implementation-version"] = ret[m][
+                    "implementation-version"
+                ].get_short_version()
+        return ret
+
+    @property
+    def root(self):
+        """The absolute pathname of the filesystem root of the image.
+        This property is read-only."""
+        if not self._img:
+            return None
+        return self._img.root
+
+    @staticmethod
+    def check_be_name(be_name):
+        bootenv.BootEnv.check_be_name(be_name)
+        return True
+
+    def __cert_verify(self, log_op_end=None):
+        """Verify validity of certificates.  Any apx.ExpiringCertificate
+        exceptions are caught here, a message is displayed, and
+        execution continues.
+
+        All other exceptions will be passed to the calling context.
+        The caller can also set log_op_end to a list of exceptions
+        that should result in a call to self.log_operation_end()
+        before the exception is passed on.
+        """
+
+        if log_op_end is None:
+            log_op_end = []
+
+        # we always explicitly handle apx.ExpiringCertificate
+        assert apx.ExpiringCertificate not in log_op_end
 
         try:
-                if repo_uri:
-                        # Assume auto configuration.
-                        if ssl_cert:
-                                try:
-                                        misc.validate_ssl_cert(
-                                            ssl_cert,
-                                            prefix=prefix,
-                                            uri=repo_uri)
-                                except apx.ExpiringCertificate as e:
-                                        logger.warning(e)
-
-                        repo = publisher.RepositoryURI(repo_uri,
-                            ssl_cert=ssl_cert, ssl_key=ssl_key)
-
-                        pubs = None
-                        try:
-                                pubs = api_inst.get_publisherdata(repo=repo)
-                        except apx.UnsupportedRepositoryOperation:
-                                if not prefix:
-                                        raise apx.RepoPubConfigUnavailable(
-                                            location=repo_uri)
-                                # For a v0 repo where a prefix was specified,
-                                # fallback to manual configuration.
-                                if not origins:
-                                        origins = [repo_uri]
-                                repo_uri = None
-
-                        if not prefix and not pubs:
-                                # Empty repository configuration.
-                                raise apx.RepoPubConfigUnavailable(
-                                    location=repo_uri)
-
-                        if repo_uri:
-                                for p in pubs:
-                                        psrepo = p.repository
-                                        if not psrepo:
-                                                # Repository configuration info
-                                                # was not provided, so assume
-                                                # origin is repo_uri.
-                                                p.repository = \
-                                                    publisher.Repository(
-                                                    origins=[repo_uri])
-                                        elif not psrepo.origins:
-                                                # Repository configuration was
-                                                # provided, but without an
-                                                # origin.  Assume the repo_uri
-                                                # is the origin.
-                                                psrepo.add_origin(repo_uri)
-                                        elif repo not in psrepo.origins:
-                                                # If the repo_uri used is not
-                                                # in the list of sources, then
-                                                # add it as the first origin.
-                                                psrepo.origins.insert(0, repo)
-
-                if prefix and not repo_uri:
-                        # Auto-configuration not possible or not requested.
-                        if ssl_cert:
-                                try:
-                                        misc.validate_ssl_cert(
-                                            ssl_cert,
-                                            prefix=prefix,
-                                            uri=origins[0])
-                                except apx.ExpiringCertificate as e:
-                                        logger.warning(e)
-
-                        repo = publisher.Repository()
-                        for o in origins:
-                                repo.add_origin(o) # pylint: disable=E1103
-                        for m in mirrors:
-                                repo.add_mirror(m) # pylint: disable=E1103
-                        pub = publisher.Publisher(prefix,
-                            repository=repo)
-                        pubs = [pub]
-
-                if prefix and prefix not in pubs:
-                        # If publisher prefix requested isn't found in the list
-                        # of publishers at this point, then configuration isn't
-                        # possible.
-                        known = [p.prefix for p in pubs]
-                        raise apx.UnknownRepositoryPublishers(
-                            known=known, unknown=[prefix], location=repo_uri)
-                elif prefix:
-                        # Filter out any publishers that weren't requested.
-                        pubs = [
-                            p for p in pubs
-                            if p.prefix == prefix
-                        ]
-
-                # Add additional origins and mirrors that weren't found in the
-                # publisher configuration if provided.
-                for p in pubs:
-                        pr = p.repository
-                        for o in origins:
-                                if not pr.has_origin(o):
-                                        pr.add_origin(o)
-                        for m in mirrors:
-                                if not pr.has_mirror(m):
-                                        pr.add_mirror(m)
-
-                # Set provided SSL Cert/Key for all configured publishers.
-                for p in pubs:
-                        repo = p.repository
-                        for o in repo.origins:
-                                if o.scheme not in publisher.SSL_SCHEMES:
-                                        continue
-                                o.ssl_cert = ssl_cert
-                                o.ssl_key = ssl_key
-                        for m in repo.mirrors:
-                                if m.scheme not in publisher.SSL_SCHEMES:
-                                        continue
-                                m.ssl_cert = ssl_cert
-                                m.ssl_key = ssl_key
-
-                img.create(pubs, facets=facets, is_zone=is_zone,
-                    progtrack=progtrack, refresh_allowed=refresh_allowed,
-                    variants=variants, props=props)
-        except EnvironmentError as e:
-                if e.errno == errno.EACCES:
-                        raise apx.PermissionsException(
-                            e.filename)
-                if e.errno == errno.EROFS:
-                        raise apx.ReadOnlyFileSystemException(
-                            e.filename)
-                raise
+            self._img.check_cert_validity()
+        except apx.ExpiringCertificate as e:
+            logger.warning(e)
         except:
-                # Ensure a defunct image isn't left behind.
-                img.destroy()
-                if destroy_root and \
-                    os.path.abspath(root) != "/" and \
-                    os.path.exists(root):
-                        # Root didn't exist before create and isn't '/',
-                        # so remove it.
-                        shutil.rmtree(root, True)
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            if exc_type in log_op_end:
+                self.log_operation_end(error=exc_value)
+            raise
+
+    def __refresh_publishers(self):
+        """Refresh publisher metadata; this should only be used by
+        functions in this module for implicit refresh cases."""
+
+        #
+        # Verify validity of certificates before possibly
+        # attempting network operations.
+        #
+        self.__cert_verify()
+        try:
+            self._img.refresh_publishers(
+                immediate=True, progtrack=self.__progresstracker
+            )
+        except apx.ImageFormatUpdateNeeded:
+            # If image format update is needed to perform refresh,
+            # continue on and allow failure to happen later since
+            # an implicit refresh failing for this reason isn't
+            # important.  (This allows planning installs and updates
+            # before the format of an image is updated.  Yes, this
+            # means that if the refresh was needed to do that, then
+            # this isn't useful, but this is as good as it gets.)
+            logger.warning(
+                _(
+                    "Skipping publisher metadata refresh;"
+                    "image rooted at {0} must have its format updated "
+                    "before a refresh can occur."
+                ).format(self._img.root)
+            )
+
+    def _acquire_activity_lock(self):
+        """Private helper method to aqcuire activity lock."""
+
+        rc = self._activity_lock.acquire(blocking=self.__blocking_locks)
+        if not rc:
+            raise apx.ImageLockedError()
+
+    def __plan_common_start(
+        self,
+        operation,
+        noexecute,
+        backup_be,
+        backup_be_name,
+        new_be,
+        be_name,
+        be_activate,
+    ):
+        """Start planning an operation:
+        Acquire locks.
+        Log the start of the operation.
+        Check be_name."""
+
+        self._acquire_activity_lock()
+        try:
+            self._enable_cancel()
+            if self.__plan_type is not None:
+                raise apx.PlanExistsException(self.__plan_type)
+            self._img.lock(allow_unprivileged=noexecute)
+        except OSError as e:
+            self._cancel_cleanup_exception()
+            self._activity_lock.release()
+            if e.errno in (errno.ENOSPC, errno.EDQUOT):
+                raise apx.ImageLockingFailedError(self._img_path, e.strerror)
+            raise
+        except:
+            self._cancel_cleanup_exception()
+            self._activity_lock.release()
+            raise
+
+        assert self._activity_lock._is_owned()
+        self.log_operation_start(operation)
+        self.__backup_be = backup_be
+        self.__backup_be_name = backup_be_name
+        self.__new_be = new_be
+        self.__be_activate = be_activate
+        self.__be_name = be_name
+        for val in (self.__be_name, self.__backup_be_name):
+            if val is not None:
+                self.check_be_name(val)
+                if not self._img.is_liveroot():
+                    self._cancel_cleanup_exception()
+                    self._activity_lock.release()
+                    self._img.unlock()
+                    raise apx.BENameGivenOnDeadBE(val)
+
+    def __plan_common_finish(self):
+        """Finish planning an operation."""
+
+        assert self._activity_lock._is_owned()
+        self._img.cleanup_downloads()
+        self._img.unlock()
+        try:
+            if int(os.environ.get("PKG_DUMP_STATS", 0)) > 0:
+                self._img.transport.stats.dump()
+        except ValueError:
+            # Don't generate stats if an invalid value
+            # is supplied.
+            pass
+
+        self._activity_lock.release()
+
+    def __auto_be_name(self):
+        try:
+            be_template = self._img.cfg.get_property(
+                "property", imgcfg.AUTO_BE_NAME
+            )
+        except:
+            be_template = None
+
+        if not be_template or len(be_template) == 0:
+            return
+
+        if be_template.startswith(AUTO_BE_NAME_TIME_PREFIX):
+            try:
+                be_template = time.strftime(
+                    be_template[len(AUTO_BE_NAME_TIME_PREFIX) :]
+                )
+            except:
+                return
+        else:
+            release = date = None
+            # Check to see if release/name is being updated
+            for src, dest in self._img.imageplan.plan_desc:
+                if not dest or dest.get_name() != "release/name":
+                    continue
+                # It is, extract attributes
+                for a in self._img.imageplan.pd.update_actions:
+                    if not isinstance(a.dst, actions.attribute.AttributeAction):
+                        continue
+                    name = a.dst.attrs["name"]
+                    if name == "ooce.release":
+                        release = a.dst.attrs["value"]
+                    elif name == "ooce.release.build":
+                        date = a.dst.attrs["value"]
+                    if release and date:
+                        break
+                break
+
+            if not release and not date:
+                # No variables changed in this update
+                return
+
+            if "%r" in be_template and not release:
+                return
+            if "%d" in be_template and not date:
+                return
+            if "%D" in be_template and not date:
+                return
+            if release:
+                be_template = be_template.replace("%r", release)
+            if date:
+                be_template = be_template.replace("%d", date)
+                be_template = be_template.replace("%D", date.replace(".", ""))
+
+        if not be_template or len(be_template) == 0:
+            return
+
+        be = bootenv.BootEnv(self._img)
+        self.__be_name = be.get_new_be_name(new_bename=be_template)
+
+    def __set_be_creation(self):
+        """Figure out whether or not we'd create a new or backup boot
+        environment given inputs and plan.  Toss cookies if we need a
+        new be and can't have one."""
+
+        if not self._img.is_liveroot():
+            self.__backup_be = False
+            self.__new_be = False
+            return
+
+        if self.__new_be is None:
+            # If image policy requires a new BE or the plan requires
+            # it, then create a new BE.
+            self.__new_be = (
+                self._img.cfg.get_policy_str(imgcfg.BE_POLICY) == "always-new"
+                or self._img.imageplan.reboot_needed()
+            )
+        elif self.__new_be is False and self._img.imageplan.reboot_needed():
+            raise apx.ImageUpdateOnLiveImageException()
+
+        # If a new BE is required and no BE name has been provided
+        # on the command line, attempt to determine a BE name
+        # automatically.
+        if self.__new_be == True and self.__be_name == None:
+            self.__auto_be_name()
+
+        if not self.__new_be and self.__backup_be is None:
+            # Create a backup be if allowed by policy (note that the
+            # 'default' policy is currently an alias for
+            # 'create-backup') ...
+            allow_backup = self._img.cfg.get_policy_str(imgcfg.BE_POLICY) in (
+                "default",
+                "create-backup",
+            )
+
+            self.__backup_be = False
+            if allow_backup:
+                # ...when packages are being
+                # updated...
+                for src, dest in self._img.imageplan.plan_desc:
+                    if src and dest:
+                        self.__backup_be = True
+                        break
+            if allow_backup and not self.__backup_be:
+                # ...or if new packages that have
+                # reboot-needed=true are being
+                # installed.
+                self.__backup_be = self._img.imageplan.reboot_advised()
+
+    def abort(self, result=RESULT_FAILED_UNKNOWN):
+        """Indicate that execution was unexpectedly aborted and log
+        operation failure if possible."""
+        try:
+            # This can raise if, for example, we're aborting
+            # because we have a PipeError and we can no longer
+            # write.  So suppress problems here.
+            if self.__progresstracker:
+                self.__progresstracker.flush()
+        except:
+            pass
+
+        self._img.history.abort(result)
+
+    def avoid_pkgs(self, fmri_strings, unavoid=False):
+        """Avoid/Unavoid one or more packages.  It is an error to
+        avoid an installed package, or unavoid one that would
+        be installed."""
+
+        self._acquire_activity_lock()
+        try:
+            if not unavoid:
+                self._img.avoid_pkgs(
+                    fmri_strings,
+                    progtrack=self.__progresstracker,
+                    check_cancel=self.__check_cancel,
+                )
+            else:
+                self._img.unavoid_pkgs(
+                    fmri_strings,
+                    progtrack=self.__progresstracker,
+                    check_cancel=self.__check_cancel,
+                )
+        finally:
+            self._activity_lock.release()
+        return True
+
+    def flag_pkgs(self, fmri_strings, flag, value):
+        if flag == "manual":
+            state = PackageInfo.MANUAL
+        else:
+            raise apx.InvalidOptionErrors("Unknown flag")
+
+        pfmris = []
+        for pfmri, _, _, _, _ in self.get_pkg_list(
+            pkg_list=self.LIST_INSTALLED,
+            patterns=fmri_strings,
+            raise_unmatched=True,
+            return_fmris=True,
+        ):
+            pfmris.append(pfmri)
+
+        self._acquire_activity_lock()
+
+        try:
+            self._img.flag_pkgs(
+                pfmris=pfmris,
+                state=state,
+                value=value,
+                progtrack=self.__progresstracker,
+            )
+        finally:
+            self._activity_lock.release()
+        return True
+
+    def gen_available_mediators(self):
+        """A generator function that yields tuples of the form
+           (mediator, mediations), where mediator is the name of the
+           provided mediation and mediations is a list of dictionaries
+           of possible mediations to set, provided by installed
+           packages, of the form:
+
+           {
+               mediator-name: {
+                   "version": mediator-version-string,
+                   "version-source": (site|vendor|system|local),
+                   "implementation": mediator-implementation-string,
+                   "implementation-source": (site|vendor|system|local),
+               }
+           }
+
+          'version' is an optional string that specifies the version
+           (expressed as a dot-separated sequence of non-negative
+           integers) of the mediator for use.
+
+           'version-source' is a string describing how the version
+           component of the mediation will be evaluated during
+           mediation. (The priority.)
+
+           'implementation' is an optional string that specifies the
+           implementation of the mediator for use in addition to or
+           instead of 'version'.
+
+           'implementation-source' is a string describing how the
+           implementation component of the mediation will be evaluated
+           during mediation.  (The priority.)
+
+        The list of possible mediations returned for each mediator is
+        ordered by source in the sequence 'site', 'vendor', 'system',
+        and then by version and implementation.  It does not include
+        mediations that exist only in the image configuration.
+        """
+
+        ret = collections.defaultdict(set)
+        excludes = self._img.list_excludes()
+        for f in self._img.gen_installed_pkgs():
+            mfst = self._img.get_manifest(f)
+            for m, mediations in mfst.gen_mediators(excludes=excludes):
+                ret[m].update(mediations)
+
+        for mediator in sorted(ret):
+            for med_priority, med_ver, med_impl in sorted(
+                ret[mediator], key=cmp_to_key(med.cmp_mediations)
+            ):
+                val = {}
+                if med_ver:
+                    # Don't expose internal Version object
+                    # to callers.
+                    val["version"] = med_ver.get_short_version()
+                if med_impl:
+                    val["implementation"] = med_impl
+
+                ret_priority = med_priority
+                if not ret_priority:
+                    # For consistency with the configured
+                    # case, list source as this.
+                    ret_priority = "system"
+                # Always set both to be consistent
+                # with @mediators.
+                val["version-source"] = ret_priority
+                val["implementation-source"] = ret_priority
+                yield mediator, val
+
+    def get_avoid_list(self):
+        """Return list of tuples of (pkg stem, pkgs w/ group
+        dependencies on this)"""
+        return [a for a in six.iteritems(self._img.get_avoid_dict())]
+
+    def gen_facets(self, facet_list, implicit=False, patterns=misc.EmptyI):
+        """A generator function that produces tuples of the form:
+
+            (
+                name,    - (string) facet name (e.g. facet.doc)
+                value    - (boolean) current facet value
+                src      - (string) source for the value
+                masked   - (boolean) is the facet maksed by another
+            )
+
+        Results are always sorted by facet name.
+
+        'facet_list' is one of the following constant values indicating
+        which facets should be returned based on how they were set:
+
+                FACET_ALL
+                        Return all facets set in the image and all
+                        facets listed in installed packages.
+
+                FACET_IMAGE
+                        Return only the facets set in the image.
+
+                FACET_INSTALLED
+                        Return only the facets listed in installed
+                        packages.
+
+        'implicit' is a boolean indicating whether facets specified in
+        the 'patterns' parameter that are not explicitly set in the
+        image or found in a package should be included.  Ignored for
+        FACET_INSTALLED case.
+
+        'patterns' is an optional list of facet wildcard strings to
+        filter results by."""
+
+        facets = self._img.cfg.facets
+        if facet_list != self.FACET_INSTALLED:
+            # Include all facets set in image.
+            fimg = set(facets.keys())
+        else:
+            # Don't include any set only in image.
+            fimg = set()
+
+        # Get all facets found in packages and determine state.
+        fpkg = set()
+        excludes = self._img.list_excludes()
+        if facet_list != self.FACET_IMAGE:
+            for f in self._img.gen_installed_pkgs():
+                # The manifest must be loaded without
+                # pre-applying excludes so that gen_facets() can
+                # choose how to filter the actions.
+                mfst = self._img.get_manifest(f, ignore_excludes=True)
+                for facet in mfst.gen_facets(excludes=excludes):
+                    # Use Facets object to determine
+                    # effective facet state.
+                    fpkg.add(facet)
+
+        # If caller wants implicit values, include non-glob patterns
+        # (even if not found) in results unless only installed facets
+        # were requested.
+        iset = set()
+        if implicit and facet_list != self.FACET_INSTALLED:
+            iset = set(
+                p.startswith("facet.") and p or ("facet." + p)
+                for p in patterns
+                if "*" not in p and "?" not in p
+            )
+        flist = sorted(fimg | fpkg | iset)
+
+        # Generate the results.
+        for name in misc.yield_matching("facet.", flist, patterns):
+            # check if the facet is explicitly set.
+            if name not in facets:
+                # The image's Facets dictionary will return
+                # the effective value for any facets not
+                # explicitly set in the image (wildcards or
+                # implicit). _match_src() will tell us how
+                # that effective value was determined (via a
+                # local or inherited wildcard facet, or via a
+                # system default).
+                src = facets._match_src(name)
+                yield (name, facets[name], src, False)
+                continue
+
+            # This is an explicitly set facet.
+            for value, src, masked in facets._src_values(name):
+                yield (name, value, src, masked)
+
+    def gen_variants(self, variant_list, implicit=False, patterns=misc.EmptyI):
+        """A generator function that produces tuples of the form:
+
+            (
+                name,    - (string) variant name (e.g. variant.arch)
+                value    - (string) current variant value,
+                possible - (list) list of possible variant values based
+                           on installed packages; empty unless using
+                           *_POSSIBLE variant_list.
+            )
+
+        Results are always sorted by variant name.
+
+        'variant_list' is one of the following constant values indicating
+        which variants should be returned based on how they were set:
+
+                VARIANT_ALL
+                        Return all variants set in the image and all
+                        variants listed in installed packages.
+
+                VARIANT_ALL_POSSIBLE
+                        Return possible variant values (those found in
+                        any installed package) for all variants set in
+                        the image and all variants listed in installed
+                        packages.
+
+                VARIANT_IMAGE
+                        Return only the variants set in the image.
+
+                VARIANT_IMAGE_POSSIBLE
+                        Return possible variant values (those found in
+                        any installed package) for only the variants set
+                        in the image.
+
+                VARIANT_INSTALLED
+                        Return only the variants listed in installed
+                        packages.
+
+                VARIANT_INSTALLED_POSSIBLE
+                        Return possible variant values (those found in
+                        any installed package) for only the variants
+                        listed in installed packages.
+
+        'implicit' is a boolean indicating whether variants specified in
+        the 'patterns' parameter that are not explicitly set in the
+        image or found in a package should be included.  Ignored for
+        VARIANT_INSTALLED* cases.
+
+        'patterns' is an optional list of variant wildcard strings to
+        filter results by."""
+
+        variants = self._img.cfg.variants
+        if (
+            variant_list != self.VARIANT_INSTALLED
+            and variant_list != self.VARIANT_INSTALLED_POSSIBLE
+        ):
+            # Include all variants set in image.
+            vimg = set(variants.keys())
+        else:
+            # Don't include any set only in image.
+            vimg = set()
+
+        # Get all variants found in packages and determine state.
+        vpkg = {}
+        excludes = self._img.list_excludes()
+        vposs = collections.defaultdict(set)
+        if variant_list != self.VARIANT_IMAGE:
+            # Only incur the overhead of reading through all
+            # installed packages if not just listing variants set in
+            # image or listing possible values for them.
+            for f in self._img.gen_installed_pkgs():
+                # The manifest must be loaded without
+                # pre-applying excludes so that gen_variants()
+                # can choose how to filter the actions.
+                mfst = self._img.get_manifest(f, ignore_excludes=True)
+                for variant, vals in mfst.gen_variants(excludes=excludes):
+                    if variant not in vimg:
+                        # Although rare, packages with
+                        # unknown variants (those not
+                        # set in the image) can be
+                        # installed as long as content
+                        # does not conflict.  For those
+                        # variants, return None.  This
+                        # is done without using get() as
+                        # that would cause None to be
+                        # returned for implicitly set
+                        # variants (e.g. debug).
+                        try:
+                            vpkg[variant] = variants[variant]
+                        except KeyError:
+                            vpkg[variant] = None
+
+                    if (
+                        variant_list == self.VARIANT_ALL_POSSIBLE
+                        or variant_list == self.VARIANT_IMAGE_POSSIBLE
+                        or variant_list == self.VARIANT_INSTALLED_POSSIBLE
+                    ):
+                        # Build possible list of variant
+                        # values.
+                        vposs[variant].update(set(vals))
+
+        # If caller wants implicit values, include non-glob debug
+        # patterns (even if not found) in results unless only installed
+        # variants were requested.
+        iset = set()
+        if (
+            implicit
+            and variant_list != self.VARIANT_INSTALLED
+            and variant_list != self.VARIANT_INSTALLED_POSSIBLE
+        ):
+            # Normalize patterns.
+            iset = set(
+                p.startswith("variant.") and p or ("variant." + p)
+                for p in patterns
+                if "*" not in p and "?" not in p
+            )
+            # Only debug variants can have an implicit value.
+            iset = set(p for p in iset if p.startswith("variant.debug."))
+        vlist = sorted(vimg | set(vpkg.keys()) | iset)
+
+        # Generate the results.
+        for name in misc.yield_matching("variant.", vlist, patterns):
+            try:
+                yield (name, vpkg[name], sorted(vposs[name]))
+            except KeyError:
+                yield (name, variants[name], sorted(vposs[name]))
+
+    def freeze_pkgs(
+        self, fmri_strings, dry_run=False, comment=None, unfreeze=False
+    ):
+        """Freeze/Unfreeze one or more packages."""
+
+        # Comment is only a valid parameter if a freeze is happening.
+        assert not comment or not unfreeze
+
+        self._acquire_activity_lock()
+        try:
+            if unfreeze:
+                return self._img.unfreeze_pkgs(
+                    fmri_strings,
+                    progtrack=self.__progresstracker,
+                    check_cancel=self.__check_cancel,
+                    dry_run=dry_run,
+                )
+            else:
+                return self._img.freeze_pkgs(
+                    fmri_strings,
+                    progtrack=self.__progresstracker,
+                    check_cancel=self.__check_cancel,
+                    dry_run=dry_run,
+                    comment=comment,
+                )
+        finally:
+            self._activity_lock.release()
+
+    def get_frozen_list(self):
+        """Return list of tuples of (pkg fmri, reason package was
+        frozen, timestamp when package was frozen)."""
+
+        return self._img.get_frozen_list()
+
+    def cleanup_cached_content(self, verbose=False):
+        """Clean up any cached content."""
+
+        self._acquire_activity_lock()
+        try:
+            return self._img.cleanup_cached_content(
+                progtrack=self.__progresstracker, force=True, verbose=verbose
+            )
+        finally:
+            self._activity_lock.release()
+
+    def __plan_common_exception(self, log_op_end_all=False):
+        """Deal with exceptions that can occur while planning an
+        operation.  Any exceptions generated here are passed
+        onto the calling context.  By default all exceptions
+        will result in a call to self.log_operation_end() before
+        they are passed onto the calling context."""
+
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+
+        if exc_type == apx.PlanCreationException:
+            self.__set_history_PlanCreationException(exc_value)
+        elif exc_type == apx.CanceledException:
+            self._cancel_done()
+        elif exc_type == apx.ConflictingActionErrors:
+            self.log_operation_end(
+                error=str(exc_value), result=RESULT_CONFLICTING_ACTIONS
+            )
+        elif exc_type in [apx.IpkgOutOfDateException, fmri.IllegalFmri]:
+            self.log_operation_end(error=exc_value)
+        elif log_op_end_all:
+            self.log_operation_end(error=exc_value)
+
+        if exc_type not in (apx.ImageLockedError, apx.ImageLockingFailedError):
+            # Must be called before reset_unlock, and only if
+            # the exception was not a locked error.
+            self._img.unlock()
+
+        try:
+            if int(os.environ.get("PKG_DUMP_STATS", 0)) > 0:
+                self._img.transport.stats.dump()
+        except ValueError:
+            # Don't generate stats if an invalid value
+            # is supplied.
+            pass
+
+        # In the case of duplicate actions, we want to save off the plan
+        # description for display to the client (if they requested it),
+        # as once the solver's done its job, there's interesting
+        # information in the plan.  We have to save it here and restore
+        # it later because __reset_unlock() torches it.
+        if exc_type == apx.ConflictingActionErrors:
+            self._img.imageplan.set_be_options(
+                self.__backup_be,
+                self.__backup_be_name,
+                self.__new_be,
+                self.__be_activate,
+                self.__be_name,
+            )
+            plan_desc = self._img.imageplan.describe()
+
+        self.__reset_unlock()
+
+        if exc_type == apx.ConflictingActionErrors:
+            self.__plan_desc = plan_desc
+
+        self._activity_lock.release()
+
+        # re-raise the original exception. (we have to explicitly
+        # restate the original exception since we may have cleared the
+        # current exception scope above.)
+        six.reraise(exc_type, exc_value, exc_traceback)
+
+    def solaris_image(self):
+        """Returns True if the current image is a solaris image, or an
+        image which contains the pkg(7) packaging system."""
+
+        # First check to see if the special package "release/name"
+        # exists and contains metadata saying this is Solaris.
+        results = self.__get_pkg_list(
+            self.LIST_INSTALLED, patterns=["release/name"], return_fmris=True
+        )
+        results = [e for e in results]
+        if results:
+            pfmri, summary, categories, states, attrs = results[0]
+            mfst = self._img.get_manifest(pfmri)
+            osname = mfst.get("pkg.release.osname", None)
+            if osname == "sunos":
+                return True
+
+        # Otherwise, see if we can find package/pkg (or SUNWipkg) and
+        # system/core-os (or SUNWcs).
+        results = self.__get_pkg_list(
+            self.LIST_INSTALLED,
+            patterns=["/package/pkg", "SUNWipkg", "/system/core-os", "SUNWcs"],
+        )
+        installed = set(e[0][1] for e in results)
+        if ("SUNWcs" in installed or "system/core-os" in installed) and (
+            "SUNWipkg" in installed or "package/pkg" in installed
+        ):
+            return True
+
+        return False
+
+    def __ipkg_require_latest(self, noexecute):
+        """Raises an IpkgOutOfDateException if the current image
+        contains the pkg(7) packaging system and a newer version
+        of the pkg(7) packaging system is installable."""
+
+        if not self.solaris_image():
+            return
+
+        # Get old purpose in order to be able to restore it on return.
+        p = self.__progresstracker.get_purpose()
+
+        try:
+            #
+            # Let progress tracker know that subsequent callbacks
+            # into it will all be in service of update checking.
+            # Note that even though this might return, the
+            # finally: will still reset the purpose.
+            #
+            self.__progresstracker.set_purpose(
+                self.__progresstracker.PURPOSE_PKG_UPDATE_CHK
+            )
+            if self._img.ipkg_is_up_to_date(
+                self.__check_cancel,
+                noexecute,
+                refresh_allowed=False,
+                progtrack=self.__progresstracker,
+            ):
+                return
+        except apx.ImageNotFoundException:
+            # Can't do anything in this
+            # case; so proceed.
+            return
+        finally:
+            self.__progresstracker.set_purpose(p)
+
+        raise apx.IpkgOutOfDateException()
+
+    def __verify_args(self, args):
+        """Verifies arguments passed into the API.
+        It tests for correct data types of the input args, verifies that
+        passed in FMRIs are valid, checks if repository URIs are valid
+        and does some logical tests for the combination of arguments."""
+
+        arg_types = {
+            # arg name              type                   nullable
+            "_act_timeout": (int, False),
+            "_be_activate": ("activate", False),
+            "_be_name": (six.string_types, True),
+            "_backup_be": (bool, True),
+            "_backup_be_name": (six.string_types, True),
+            "_ignore_missing": (bool, False),
+            "_ipkg_require_latest": (bool, False),
+            "_li_erecurse": (iter, True),
+            "_li_ignore": (iter, True),
+            "_li_md_only": (bool, False),
+            "_li_parent_sync": (bool, False),
+            "_new_be": (bool, True),
+            "_noexecute": (bool, False),
+            "_pubcheck": (bool, False),
+            "_refresh_catalogs": (bool, False),
+            "_repos": (iter, True),
+            "_update_index": (bool, False),
+            "facets": (dict, True),
+            "mediators": (iter, True),
+            "pkgs_inst": (iter, True),
+            "pkgs_to_uninstall": (iter, True),
+            "pkgs_update": (iter, True),
+            "reject_list": (iter, True),
+            "variants": (dict, True),
+        }
+
+        # merge kwargs into the main arg dict
+        if "kwargs" in args:
+            for name, value in args["kwargs"].items():
+                args[name] = value
+
+        # check arguments for proper type and nullability
+        for a in args:
+            try:
+                a_type, nullable = arg_types[a]
+            except KeyError:
+                # unknown argument passed, ignore
+                continue
+
+            assert nullable or args[a] is not None
+
+            if args[a] is not None and a_type == iter:
+                try:
+                    iter(args[a])
+                except TypeError:
+                    raise AssertionError("{0} is not an " "iterable".format(a))
+            elif a_type == "activate":
+                assert isinstance(args[a], bool) or (
+                    isinstance(args[a], str) and args[a] == "bootnext"
+                )
+            else:
+                assert args[a] is None or isinstance(
+                    args[a], a_type
+                ), "{0} is " "type {1}; expected {2}".format(a, type(a), a_type)
+
+        # check if passed FMRIs are valid
+        illegals = []
+        for i in (
+            "pkgs_inst",
+            "pkgs_update",
+            "pkgs_to_uninstall",
+            "reject_list",
+        ):
+            try:
+                fmris = args[i]
+            except KeyError:
+                continue
+            if fmris is None:
+                continue
+            for pat, err, pfmri, matcher in self.parse_fmri_patterns(fmris):
+                if not err:
+                    continue
+                else:
+                    illegals.append(fmris)
+
+        if illegals:
+            raise apx.PlanCreationException(illegal=illegals)
+
+        # some logical checks
+        errors = []
+        if not args["_new_be"] and args["_be_name"]:
+            errors.append(
+                apx.InvalidOptionError(
+                    apx.InvalidOptionError.REQUIRED, ["_be_name", "_new_be"]
+                )
+            )
+        if not args["_backup_be"] and args["_backup_be_name"]:
+            errors.append(
+                apx.InvalidOptionError(
+                    apx.InvalidOptionError.REQUIRED,
+                    ["_backup_be_name", "_backup_be"],
+                )
+            )
+        if args["_backup_be"] and args["_new_be"]:
+            errors.append(
+                apx.InvalidOptionError(
+                    apx.InvalidOptionError.INCOMPAT, ["_backup_be", "_new_be"]
+                )
+            )
+
+        if errors:
+            raise apx.InvalidOptionErrors(errors)
+
+        # check if repo URIs are valid
+        try:
+            repos = args["_repos"]
+        except KeyError:
+            return
+
+        if not repos:
+            return
+
+        illegals = []
+        for r in repos:
+            valid = False
+            if type(r) == publisher.RepositoryURI:
+                # RepoURI objects pass right away
+                continue
+
+            if not misc.valid_pub_url(r):
+                illegals.append(r)
+
+        if illegals:
+            raise apx.UnsupportedRepositoryURI(illegals)
+
+    def __plan_op(
+        self,
+        _op,
+        _act_timeout=0,
+        _ad_kwargs=None,
+        _backup_be=None,
+        _backup_be_name=None,
+        _be_activate=True,
+        _be_name=None,
+        _ipkg_require_latest=False,
+        _li_ignore=None,
+        _li_erecurse=None,
+        _li_md_only=False,
+        _li_parent_sync=True,
+        _new_be=False,
+        _noexecute=False,
+        _pubcheck=True,
+        _refresh_catalogs=True,
+        _repos=None,
+        _update_index=True,
+        **kwargs,
+    ):
+        """Contructs a plan to change the package or linked image
+        state of an image.
+
+        We can raise PermissionsException, PlanCreationException,
+        InventoryException, or LinkedImageException.
+
+        Arguments prefixed with '_' are primarily used within this
+        function.  All other arguments must be specified via keyword
+        assignment and will be passed directly on to the image
+        interfaces being invoked."
+
+        '_op' is the API operation we will perform.
+
+        '_ad_kwargs' is only used dyring attach or detach and it
+        is a dictionary of arguments that will be passed to the
+        linked image attach/detach interfaces.
+
+        '_ipkg_require_latest' enables a check to verify that the
+        latest installable version of the pkg(7) packaging system is
+        installed before we proceed with the requested operation.
+
+        For all other '_' prefixed parameters, please refer to the
+        'gen_plan_*' functions which invoke this function for an
+        explanation of their usage and effects.
+
+        This function first yields the plan description for the global
+        zone, then either a series of dictionaries representing the
+        parsable output from operating on the child images or a series
+        of None values."""
+
+        # sanity checks
+        assert _op in api_op_values
+        assert _ad_kwargs is None or _op in [API_OP_ATTACH, API_OP_DETACH]
+        assert _ad_kwargs != None or _op not in [API_OP_ATTACH, API_OP_DETACH]
+        assert not _li_md_only or _op in [
+            API_OP_ATTACH,
+            API_OP_DETACH,
+            API_OP_SYNC,
+        ]
+        assert not _li_md_only or _li_parent_sync
+
+        self.__verify_args(locals())
+
+        # make some perf optimizations
+        if _li_md_only:
+            _refresh_catalogs = _update_index = False
+        if _op in [
+            API_OP_DETACH,
+            API_OP_SET_MEDIATOR,
+            API_OP_FIX,
+            API_OP_VERIFY,
+            API_OP_DEHYDRATE,
+            API_OP_REHYDRATE,
+        ]:
+            # these operations don't change fmris and don't need
+            # to recurse, so disable a bunch of linked image
+            # operations.
+            _li_parent_sync = False
+            _pubcheck = False
+            _li_ignore = []  # ignore all children
+
+        # All the image interface functions that we invoke have some
+        # common arguments.  Set those up now.
+        args_common = {}
+        args_common["op"] = _op
+        args_common["progtrack"] = self.__progresstracker
+        args_common["check_cancel"] = self.__check_cancel
+        args_common["noexecute"] = _noexecute
+
+        # make sure there is no overlap between the common arguments
+        # supplied to all api interfaces and the arguments that the
+        # api arguments that caller passed to this function.
+        assert (
+            set(args_common) & set(kwargs)
+        ) == set(), "{0} & {1} != set()".format(
+            str(set(args_common)), str(set(kwargs))
+        )
+        kwargs.update(args_common)
+
+        try:
+            # Lock the current image.
+            self.__plan_common_start(
+                _op,
+                _noexecute,
+                _backup_be,
+                _backup_be_name,
+                _new_be,
+                _be_name,
+                _be_activate,
+            )
+
+        except:
+            raise
+
+        try:
+            if _op == API_OP_ATTACH:
+                self._img.linked.attach_parent(**_ad_kwargs)
+            elif _op == API_OP_DETACH:
+                self._img.linked.detach_parent(**_ad_kwargs)
+
+            if _li_parent_sync:
+                # refresh linked image data from parent image.
+                self._img.linked.syncmd_from_parent()
+
+            # initialize recursion state
+            self._img.linked.api_recurse_init(
+                li_ignore=_li_ignore, repos=_repos
+            )
+
+            if _pubcheck:
+                # check that linked image pubs are in sync
+                self.__linked_pubcheck(_op)
+
+            if _refresh_catalogs:
+                self.__refresh_publishers()
+
+            if _ipkg_require_latest:
+                # If this is an image update then make
+                # sure the latest version of the ipkg
+                # software is installed.
+                self.__ipkg_require_latest(_noexecute)
+
+            self.__set_img_alt_sources(_repos)
+
+            if _li_md_only:
+                self._img.make_noop_plan(**args_common)
+            elif _op in [API_OP_ATTACH, API_OP_DETACH, API_OP_SYNC]:
+                self._img.make_sync_plan(**kwargs)
+            elif _op in [API_OP_CHANGE_FACET, API_OP_CHANGE_VARIANT]:
+                self._img.make_change_varcets_plan(**kwargs)
+            elif _op == API_OP_DEHYDRATE:
+                self._img.make_dehydrate_plan(**kwargs)
+            elif _op == API_OP_INSTALL or _op == API_OP_EXACT_INSTALL:
+                self._img.make_install_plan(**kwargs)
+            elif _op in [API_OP_FIX, API_OP_VERIFY]:
+                self._img.make_fix_plan(**kwargs)
+            elif _op == API_OP_REHYDRATE:
+                self._img.make_rehydrate_plan(**kwargs)
+            elif _op == API_OP_REVERT:
+                self._img.make_revert_plan(**kwargs)
+            elif _op == API_OP_SET_MEDIATOR:
+                self._img.make_set_mediators_plan(**kwargs)
+            elif _op == API_OP_UNINSTALL:
+                self._img.make_uninstall_plan(**kwargs)
+            elif _op == API_OP_UPDATE:
+                self._img.make_update_plan(**kwargs)
+            else:
+                raise RuntimeError("Unknown api op: {0}".format(_op))
+
+            self.__api_op = _op
+
+            if self._img.imageplan.nothingtodo():
+                # no package changes mean no index changes
+                _update_index = False
+
+            self._disable_cancel()
+            self.__set_be_creation()
+            self._img.imageplan.set_be_options(
+                self.__backup_be,
+                self.__backup_be_name,
+                self.__new_be,
+                self.__be_activate,
+                self.__be_name,
+            )
+            self.__plan_desc = self._img.imageplan.describe()
+            if not _noexecute:
+                self.__plan_type = self.__plan_desc.plan_type
+
+            if _act_timeout != 0:
+                self.__plan_desc.set_actuator_timeout(_act_timeout)
+
+            # Yield to our caller so they can display our plan
+            # before we recurse into child images.  Drop the
+            # activity lock before yielding because otherwise the
+            # caller can't do things like set the displayed
+            # license state for pkg plans).
+            self._activity_lock.release()
+            yield self.__plan_desc
+            self._activity_lock.acquire()
+
+            # plan operation in child images.  This currently yields
+            # either a dictionary representing the parsable output
+            # from the child image operation, or None.  Eventually
+            # these will yield plan descriptions objects instead.
+
+            for p_dict in self._img.linked.api_recurse_plan(
+                api_kwargs=kwargs,
+                erecurse_list=_li_erecurse,
+                refresh_catalogs=_refresh_catalogs,
+                update_index=_update_index,
+                progtrack=self.__progresstracker,
+            ):
+                yield p_dict
+
+            self.__planned_children = True
+
+        except:
+            if _op in [
+                API_OP_UPDATE,
+                API_OP_INSTALL,
+                API_OP_REVERT,
+                API_OP_SYNC,
+            ]:
+                self.__plan_common_exception(log_op_end_all=True)
+            else:
+                self.__plan_common_exception()
+            # NOTREACHED
+
+        stuff_to_do = not self.planned_nothingtodo()
+
+        if not stuff_to_do or _noexecute:
+            self.log_operation_end(result=RESULT_NOTHING_TO_DO)
+
+        self._img.imageplan.update_index = _update_index
+        self.__plan_common_finish()
+
+        # Value 'DebugValues' is unsubscriptable;
+        # pylint: disable=E1136
+        if DebugValues["plandesc_validate"]:
+            # save, load, and get a new json copy of the plan,
+            # then compare that new copy against our current one.
+            # this regressions tests the plan save/load code.
+            pd_json1 = self.__plan_desc.getstate(
+                self.__plan_desc, reset_volatiles=True
+            )
+            fobj = tempfile.TemporaryFile(mode="w+")
+            json.dump(pd_json1, fobj)
+            pd_new = plandesc.PlanDescription(_op)
+            pd_new._load(fobj)
+            pd_json2 = pd_new.getstate(pd_new, reset_volatiles=True)
+            fobj.close()
+            del fobj, pd_new
+            pkg.misc.json_diff(
+                "PlanDescription", pd_json1, pd_json2, pd_json1, pd_json2
+            )
+            del pd_json1, pd_json2
+
+    @_LockedCancelable()
+    def load_plan(self, plan, prepared=False):
+        """Load a previously generated PlanDescription."""
+
+        # Prevent loading a plan if one has been already.
+        if self.__plan_type is not None:
+            raise apx.PlanExistsException(self.__plan_type)
+
+        # grab image lock.  we don't worry about dropping the image
+        # lock since __activity_lock will drop it for us us after we
+        # return (or if we generate an exception).
+        self._img.lock()
+
+        # load the plan
+        self.__plan_desc = plan
+        self.__plan_type = plan.plan_type
+        self.__planned_children = True
+        self.__prepared = prepared
+
+        # load BE related plan settings
+        self.__new_be = plan.new_be
+        self.__be_activate = plan.activate_be
+        self.__be_name = plan.be_name
+
+        # sanity check: verify the BE name
+        if self.__be_name is not None:
+            self.check_be_name(self.__be_name)
+            if not self._img.is_liveroot():
+                raise apx.BENameGivenOnDeadBE(self.__be_name)
+
+        # sanity check: verify that all the fmris in the plan are in
+        # the known catalog
+        pkg_cat = self._img.get_catalog(self._img.IMG_CATALOG_KNOWN)
+        for pp in plan.pkg_plans:
+            if pp.destination_fmri:
+                assert pkg_cat.get_entry(
+                    pp.destination_fmri
+                ), "fmri part of plan, but currently " "unknown: {0}".format(
+                    pp.destination_fmri
+                )
+
+        # allocate an image plan based on the supplied plan
+        self._img.imageplan = imageplan.ImagePlan(
+            self._img,
+            plan._op,
+            self.__progresstracker,
+            check_cancel=self.__check_cancel,
+            pd=plan,
+        )
+
+        if prepared:
+            self._img.imageplan.skip_preexecute()
+
+        # create a history entry
+        self.log_operation_start(plan.plan_type)
+
+    def __linked_pubcheck(self, api_op=None):
+        """Private interface to perform publisher check on this image
+        and its children."""
+
+        if api_op in [API_OP_DETACH, API_OP_SET_MEDIATOR]:
+            # we don't need to do a pubcheck for detach or
+            # changing mediators
+            return
+
+        # check the current image
+        self._img.linked.pubcheck()
+
+        # check child images
+        self._img.linked.api_recurse_pubcheck(self.__progresstracker)
+
+    @_LockedCancelable()
+    def linked_publisher_check(self):
+        """If we're a child image, verify that the parent image's
+        publisher configuration is a subset of the child image's
+        publisher configuration.  If we have any children, recurse
+        into them and perform a publisher check."""
+
+        # grab image lock.  we don't worry about dropping the image
+        # lock since __activity_lock will drop it for us us after we
+        # return (or if we generate an exception).
+        self._img.lock(allow_unprivileged=True)
+
+        # get ready to recurse
+        self._img.linked.api_recurse_init()
+
+        # check that linked image pubs are in sync
+        self.__linked_pubcheck()
+
+    @_LockedCancelable()
+    def hotfix_origin_cleanup(self):
+        # grab image lock. Cleanup is handled by the decorator.
+        self._img.lock(allow_unprivileged=False)
+
+        # prepare for recursion
+        self._img.linked.api_recurse_init()
+
+        # clean up the image
+        self._img.hotfix_origin_cleanup()
+
+        # clean up children
+        self._img.linked.api_recurse_hfo_cleanup(self.__progresstracker)
+
+    def planned_nothingtodo(self, li_ignore_all=False):
+        """Once an operation has been planned check if there is
+        something todo.
+
+        Callers should pass all arguments by name assignment and
+        not by positional order.
+
+        'li_ignore_all' indicates if we should only report on work
+        todo in the parent image.  (i.e., if an operation was planned
+        and that operation only involves changes to children, and
+        li_ignore_all is true, then we'll report that there's nothing
+        todo."""
+
+        if not self._img.imageplan:
+            # if theres no plan there nothing to do
+            return True
+        if not self._img.imageplan.nothingtodo():
+            return False
+        if not self._img.linked.nothingtodo():
+            return False
+        if not li_ignore_all:
+            assert self.__planned_children
+            if not self._img.linked.recurse_nothingtodo():
+                return False
+        return True
+
+    def plan_update(
+        self,
+        pkg_list,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        noexecute=False,
+        update_index=True,
+        be_name=None,
+        new_be=False,
+        repos=None,
+        be_activate=True,
+    ):
+        """DEPRECATED.  use gen_plan_update()."""
+        for pd in self.gen_plan_update(
+            pkgs_update=pkg_list,
+            refresh_catalogs=refresh_catalogs,
+            reject_list=reject_list,
+            noexecute=noexecute,
+            update_index=update_index,
+            be_name=be_name,
+            new_be=new_be,
+            repos=repos,
+            be_activate=be_activate,
+        ):
+            continue
+        return not self.planned_nothingtodo()
+
+    def plan_update_all(
+        self,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        noexecute=False,
+        force=False,
+        update_index=True,
+        be_name=None,
+        new_be=True,
+        repos=None,
+        be_activate=True,
+    ):
+        """DEPRECATED.  use gen_plan_update()."""
+        for pd in self.gen_plan_update(
+            refresh_catalogs=refresh_catalogs,
+            reject_list=reject_list,
+            noexecute=noexecute,
+            force=force,
+            update_index=update_index,
+            be_name=be_name,
+            new_be=new_be,
+            repos=repos,
+            be_activate=be_activate,
+        ):
+            continue
+        return (not self.planned_nothingtodo(), self.solaris_image())
+
+    def gen_plan_update(
+        self,
+        pkgs_update=None,
+        act_timeout=0,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        force=False,
+        ignore_missing=False,
+        li_ignore=None,
+        li_parent_sync=True,
+        li_erecurse=None,
+        new_be=True,
+        noexecute=False,
+        pubcheck=True,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        repos=None,
+        update_index=True,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.  If parsable_version is set, it also yields dictionaries
+        containing plan information for child images.
+
+        If pkgs_update is not set, constructs a plan to update all
+        packages on the system to the latest known versions.  Once an
+        operation has been planned, it may be executed by first
+        calling prepare(), and then execute_plan().  After execution
+        of a plan, or to abandon a plan, reset() should be called.
+
+        Callers should pass all arguments by name assignment and
+        not by positional order.
+
+        If 'pkgs_update' is set, constructs a plan to update the
+        packages provided in pkgs_update.
+
+        Once an operation has been planned, it may be executed by
+        first calling prepare(), and then execute_plan().
+
+        'force' indicates whether update should skip the package
+        system up to date check.
+
+        'ignore_missing' indicates whether update should ignore packages
+        which are not installed.
+
+        'pubcheck' indicates that we should skip the child image
+        publisher check before creating a plan for this image.  only
+        pkg.1 should use this parameter, other callers should never
+        specify it.
+
+        For all other parameters, refer to the 'gen_plan_install'
+        function for an explanation of their usage and effects."""
+
+        if pkgs_update or force:
+            ipkg_require_latest = False
+        else:
+            ipkg_require_latest = True
+
+        op = API_OP_UPDATE
+        return self.__plan_op(
+            op,
+            _act_timeout=act_timeout,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_activate=be_activate,
+            _be_name=be_name,
+            _ipkg_require_latest=ipkg_require_latest,
+            _li_ignore=li_ignore,
+            _li_parent_sync=li_parent_sync,
+            _li_erecurse=li_erecurse,
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _pubcheck=pubcheck,
+            _refresh_catalogs=refresh_catalogs,
+            _repos=repos,
+            _update_index=update_index,
+            ignore_missing=ignore_missing,
+            pkgs_update=pkgs_update,
+            reject_list=reject_list,
+        )
+
+    def plan_install(
+        self,
+        pkg_list,
+        refresh_catalogs=True,
+        noexecute=False,
+        update_index=True,
+        be_name=None,
+        reject_list=misc.EmptyI,
+        new_be=False,
+        repos=None,
+        be_activate=True,
+    ):
+        """DEPRECATED.  use gen_plan_install()."""
+        for pd in self.gen_plan_install(
+            pkgs_inst=pkg_list,
+            refresh_catalogs=refresh_catalogs,
+            noexecute=noexecute,
+            update_index=update_index,
+            be_name=be_name,
+            reject_list=reject_list,
+            new_be=new_be,
+            repos=repos,
+            be_activate=be_activate,
+        ):
+            continue
+        return not self.planned_nothingtodo()
+
+    def gen_plan_install(
+        self,
+        pkgs_inst,
+        act_timeout=0,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        li_erecurse=None,
+        li_ignore=None,
+        li_parent_sync=True,
+        new_be=False,
+        noexecute=False,
+        pubcheck=True,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        repos=None,
+        update_index=True,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.  If parsable_version is set, it also yields dictionaries
+        containing plan information for child images.
+
+        Constructs a plan to install the packages provided in
+        pkgs_inst.  Once an operation has been planned, it may be
+        executed by first calling prepare(), and then execute_plan().
+        After execution of a plan, or to abandon a plan, reset()
+        should be called.
+
+        Callers should pass all arguments by name assignment and
+        not by positional order.
+
+        'act_timeout' sets the timeout for synchronous actuators in
+        seconds, -1 is no timeout, 0 is for using asynchronous
+        actuators.
+
+        'backup_be' indicates whether a backup boot environment should
+        be created before the operation is executed.  If True, a backup
+        boot environment will be created.  If False, a backup boot
+        environment will not be created. If None and a new boot
+        environment is not created, and packages are being updated or
+        are being installed and tagged with reboot-needed, a backup
+        boot environment will be created.
+
+        'backup_be_name' is a string to use as the name of any backup
+        boot environment created during the operation.
+
+        'be_activate' is an optional boolean indicating whether any
+        new boot environment created for the operation should be set
+        as the active one on next boot if the operation is successful.
+
+        'be_name' is a string to use as the name of any new boot
+        environment created during the operation.
+
+        'li_erecurse' is either None or a list. If it's None (the
+        default), the planning operation will not explicitly recurse
+        into linked children to perform the requested operation. If this
+        is a list of linked image children names, the requested
+        operation will be performed in each of the specified
+        children.
+
+        'li_ignore' is either None or a list.  If it's None (the
+        default), the planning operation will attempt to keep all
+        linked children in sync.  If it's an empty list the planning
+        operation will ignore all children.  If this is a list of
+        linked image children names, those children will be ignored
+        during the planning operation.  If a child is ignored during
+        the planning phase it will also be skipped during the
+        preparation and execution phases.
+
+        'li_parent_sync' if the current image is a child image, this
+        flag controls whether the linked image parent metadata will be
+        automatically refreshed.
+
+        'new_be' indicates whether a new boot environment should be
+        created during the operation.  If True, a new boot environment
+        will be created.  If False, and a new boot environment is
+        needed, an ImageUpdateOnLiveImageException will be raised.
+        If None, a new boot environment will be created only if needed.
+
+        'noexecute' determines whether the resulting plan can be
+        executed and whether history will be recorded after
+        planning is finished.
+
+        'pkgs_inst' is a list of packages to install.
+
+        'refresh_catalogs' controls whether the catalogs will
+        automatically be refreshed.
+
+        'reject_list' is a list of patterns not to be permitted
+        in solution; installed packages matching these patterns
+        are removed.
+
+        'repos' is a list of URI strings or RepositoryURI objects that
+        represent the locations of additional sources of package data to
+        use during the planned operation.  All API functions called
+        while a plan is still active will use this package data.
+
+        'update_index' determines whether client search indexes
+        will be updated after operation completion during plan
+        execution."""
+
+        # certain parameters must be specified
+        assert pkgs_inst and type(pkgs_inst) == list
+
+        op = API_OP_INSTALL
+        return self.__plan_op(
+            op,
+            _act_timeout=act_timeout,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_activate=be_activate,
+            _be_name=be_name,
+            _li_erecurse=li_erecurse,
+            _li_ignore=li_ignore,
+            _li_parent_sync=li_parent_sync,
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _pubcheck=pubcheck,
+            _refresh_catalogs=refresh_catalogs,
+            _repos=repos,
+            _update_index=update_index,
+            pkgs_inst=pkgs_inst,
+            reject_list=reject_list,
+        )
+
+    def gen_plan_exact_install(
+        self,
+        pkgs_inst,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        li_ignore=None,
+        li_parent_sync=True,
+        new_be=False,
+        noexecute=False,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        repos=None,
+        update_index=True,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.  If parsable_version is set, it also yields dictionaries
+        containing plan information for child images.
+
+        Constructs a plan to install exactly the packages provided in
+        pkgs_inst.  Once an operation has been planned, it may be
+        executed by first calling prepare(), and then execute_plan().
+        After execution of a plan, or to abandon a plan, reset()
+        should be called.
+
+        Callers should pass all arguments by name assignment and
+        not by positional order.
+
+        'pkgs_inst' is a list of packages to install exactly.
+
+        For all other parameters, refer to 'gen_plan_install'
+        for an explanation of their usage and effects."""
+
+        # certain parameters must be specified
+        assert pkgs_inst and type(pkgs_inst) == list
+
+        op = API_OP_EXACT_INSTALL
+        return self.__plan_op(
+            op,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_activate=be_activate,
+            _be_name=be_name,
+            _li_ignore=li_ignore,
+            _li_parent_sync=li_parent_sync,
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _refresh_catalogs=refresh_catalogs,
+            _repos=repos,
+            _update_index=update_index,
+            pkgs_inst=pkgs_inst,
+            reject_list=reject_list,
+        )
+
+    def gen_plan_sync(
+        self,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        li_ignore=None,
+        li_md_only=False,
+        li_parent_sync=True,
+        li_pkg_updates=True,
+        new_be=False,
+        noexecute=False,
+        pubcheck=True,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        repos=None,
+        update_index=True,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.  If parsable_version is set, it also yields dictionaries
+        containing plan information for child images.
+
+        Constructs a plan to sync the current image with its
+        linked image constraints.  Once an operation has been planned,
+        it may be executed by first calling prepare(), and then
+        execute_plan().  After execution of a plan, or to abandon a
+        plan, reset() should be called.
+
+        Callers should pass all arguments by name assignment and
+        not by positional order.
+
+        'li_md_only' don't actually modify any packages in the current
+        images, only sync the linked image metadata from the parent
+        image.  If this options is True, 'li_parent_sync' must also be
+        True.
+
+        'li_pkg_updates' when planning a sync operation, allow updates
+        to packages other than the constraints package.  If this
+        option is False, planning a sync will fail if any packages
+        (other than the constraints package) need updating to bring
+        the image in sync with its parent.
+
+        For all other parameters, refer to 'gen_plan_install' and
+        'gen_plan_update' for an explanation of their usage and
+        effects."""
+
+        # we should only be invoked on a child image.
+        if not self.ischild():
+            raise apx.LinkedImageException(self_not_child=self._img_path)
+
+        op = API_OP_SYNC
+        return self.__plan_op(
+            op,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_activate=be_activate,
+            _be_name=be_name,
+            _li_ignore=li_ignore,
+            _li_md_only=li_md_only,
+            _li_parent_sync=li_parent_sync,
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _pubcheck=pubcheck,
+            _refresh_catalogs=refresh_catalogs,
+            _repos=repos,
+            _update_index=update_index,
+            li_pkg_updates=li_pkg_updates,
+            reject_list=reject_list,
+        )
+
+    def gen_plan_attach(
+        self,
+        lin,
+        li_path,
+        allow_relink=False,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        force=False,
+        li_ignore=None,
+        li_md_only=False,
+        li_pkg_updates=True,
+        li_props=None,
+        new_be=False,
+        noexecute=False,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        repos=None,
+        update_index=True,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.  If parsable_version is set, it also yields dictionaries
+        containing plan information for child images.
+
+        Attach a parent image and sync the packages in the current
+        image with the new parent.  Once an operation has been
+        planned, it may be executed by first calling prepare(), and
+        then execute_plan().  After execution of a plan, or to abandon
+        a plan, reset() should be called.
+
+        Callers should pass all arguments by name assignment and
+        not by positional order.
+
+        'lin' a LinkedImageName object that is a name for the current
+        image.
+
+        'li_path' a path to the parent image.
+
+        'allow_relink' allows re-linking of an image that is already a
+        linked image child.  If this option is True we'll overwrite
+        all existing linked image metadata.
+
+        'li_props' optional linked image properties to apply to the
+        child image.
+
+        For all other parameters, refer to the 'gen_plan_install' and
+        'gen_plan_sync' functions for an explanation of their usage
+        and effects."""
+
+        if li_props is None:
+            li_props = dict()
+
+        op = API_OP_ATTACH
+        ad_kwargs = {
+            "allow_relink": allow_relink,
+            "force": force,
+            "lin": lin,
+            "path": li_path,
+            "props": li_props,
+        }
+        return self.__plan_op(
+            op,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_activate=be_activate,
+            _be_name=be_name,
+            _li_ignore=li_ignore,
+            _li_md_only=li_md_only,
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _refresh_catalogs=refresh_catalogs,
+            _repos=repos,
+            _update_index=update_index,
+            _ad_kwargs=ad_kwargs,
+            li_pkg_updates=li_pkg_updates,
+            reject_list=reject_list,
+        )
+
+    def gen_plan_detach(
+        self,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        force=False,
+        li_ignore=None,
+        li_md_only=False,
+        li_pkg_updates=True,
+        new_be=False,
+        noexecute=False,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.  If parsable_version is set, it also yields dictionaries
+        containing plan information for child images.
+
+        Detach from a parent image and remove any constraints
+        package from this image.  Once an operation has been planned,
+        it may be executed by first calling prepare(), and then
+        execute_plan().  After execution of a plan, or to abandon a
+        plan, reset() should be called.
+
+        Callers should pass all arguments by name assignment and
+        not by positional order.
+
+        For all other parameters, refer to the 'gen_plan_install' and
+        'gen_plan_sync' functions for an explanation of their usage
+        and effects."""
+
+        op = API_OP_DETACH
+        ad_kwargs = {"force": force}
+        return self.__plan_op(
+            op,
+            _ad_kwargs=ad_kwargs,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_activate=be_activate,
+            _be_name=be_name,
+            _li_ignore=li_ignore,
+            _li_md_only=li_md_only,
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _refresh_catalogs=False,
+            _update_index=False,
+            li_pkg_updates=li_pkg_updates,
+        )
+
+    def plan_uninstall(
+        self,
+        pkg_list,
+        noexecute=False,
+        update_index=True,
+        be_name=None,
+        new_be=False,
+        be_activate=True,
+    ):
+        """DEPRECATED.  use gen_plan_uninstall()."""
+        for pd in self.gen_plan_uninstall(
+            pkgs_to_uninstall=pkg_list,
+            noexecute=noexecute,
+            update_index=update_index,
+            be_name=be_name,
+            new_be=new_be,
+            be_activate=be_activate,
+        ):
+            continue
+        return not self.planned_nothingtodo()
+
+    def gen_plan_uninstall(
+        self,
+        pkgs_to_uninstall,
+        act_timeout=0,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        ignore_missing=False,
+        li_ignore=None,
+        li_parent_sync=True,
+        li_erecurse=None,
+        new_be=False,
+        noexecute=False,
+        pubcheck=True,
+        update_index=True,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.  If parsable_version is set, it also yields dictionaries
+        containing plan information for child images.
+
+        Constructs a plan to remove the packages provided in
+        pkgs_to_uninstall.  Once an operation has been planned, it may
+        be executed by first calling prepare(), and then
+        execute_plan().  After execution of a plan, or to abandon a
+        plan, reset() should be called.
+
+        Callers should pass all arguments by name assignment and
+        not by positional order.
+
+        'ignore_missing' indicates whether uninstall should ignore
+        packages which are not installed.
+
+        'pkgs_to_uninstall' is a list of packages to uninstall.
+
+        For all other parameters, refer to the 'gen_plan_install'
+        function for an explanation of their usage and effects."""
+
+        # certain parameters must be specified
+        assert pkgs_to_uninstall and type(pkgs_to_uninstall) == list
+
+        op = API_OP_UNINSTALL
+        return self.__plan_op(
+            op,
+            _act_timeout=act_timeout,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_activate=be_activate,
+            _be_name=be_name,
+            _li_erecurse=li_erecurse,
+            _li_ignore=li_ignore,
+            _li_parent_sync=li_parent_sync,
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _pubcheck=pubcheck,
+            _refresh_catalogs=False,
+            _update_index=update_index,
+            ignore_missing=ignore_missing,
+            pkgs_to_uninstall=pkgs_to_uninstall,
+        )
+
+    def gen_plan_set_mediators(
+        self,
+        mediators,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        li_ignore=None,
+        li_parent_sync=True,
+        new_be=None,
+        noexecute=False,
+        update_index=True,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.  If parsable_version is set, it also yields dictionaries
+        containing plan information for child images.
+
+        Creates a plan to change the version and implementation values
+        for mediators as specified in the provided dictionary.  Once an
+        operation has been planned, it may be executed by first calling
+        prepare(), and then execute_plan().  After execution of a plan,
+        or to abandon a plan, reset() should be called.
+
+        Callers should pass all arguments by name assignment and not by
+        positional order.
+
+        'mediators' is a dict of dicts of the mediators to set version
+        and implementation for.  If the dict for a given mediator-name
+        is empty, it will be interpreted as a request to revert the
+        specified mediator to the default, "optimal" mediation.  It
+        should be of the form:
+
+           {
+               mediator-name: {
+                   "implementation": mediator-implementation-string,
+                   "version": mediator-version-string
+               }
+           }
+
+           'implementation' is an optional string that specifies the
+           implementation of the mediator for use in addition to or
+           instead of 'version'.
+
+           'version' is an optional string that specifies the version
+           (expressed as a dot-separated sequence of non-negative
+           integers) of the mediator for use.
+
+        For all other parameters, refer to the 'gen_plan_install'
+        function for an explanation of their usage and effects."""
+
+        assert mediators
+        return self.__plan_op(
+            API_OP_SET_MEDIATOR,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_activate=be_activate,
+            _be_name=be_name,
+            _li_ignore=li_ignore,
+            _li_parent_sync=li_parent_sync,
+            mediators=mediators,
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _refresh_catalogs=False,
+            _update_index=update_index,
+        )
+
+    def plan_change_varcets(
+        self,
+        variants=None,
+        facets=None,
+        noexecute=False,
+        be_name=None,
+        new_be=None,
+        repos=None,
+        be_activate=True,
+    ):
+        """DEPRECATED.  use gen_plan_change_varcets()."""
+        for pd in self.gen_plan_change_varcets(
+            variants=variants,
+            facets=facets,
+            noexecute=noexecute,
+            be_name=be_name,
+            new_be=new_be,
+            repos=repos,
+            be_activate=be_activate,
+        ):
+            continue
+        return not self.planned_nothingtodo()
+
+    def gen_plan_change_varcets(
+        self,
+        facets=None,
+        variants=None,
+        act_timeout=0,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        li_erecurse=None,
+        li_ignore=None,
+        li_parent_sync=True,
+        new_be=None,
+        noexecute=False,
+        pubcheck=True,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        repos=None,
+        update_index=True,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.  If parsable_version is set, it also yields dictionaries
+        containing plan information for child images.
+
+        Creates a plan to change the specified variants and/or
+        facets for the image.  Once an operation has been planned, it
+        may be executed by first calling prepare(), and then
+        execute_plan().  After execution of a plan, or to abandon a
+        plan, reset() should be called.
+
+        Callers should pass all arguments by name assignment and
+        not by positional order.
+
+        'facets' is a dict of the facets to change the values of.
+
+        'variants' is a dict of the variants to change the values of.
+
+        For all other parameters, refer to the 'gen_plan_install'
+        function for an explanation of their usage and effects."""
+
+        # An empty facets dictionary is allowed because that's how to
+        # unset all set facets.
+        if not variants and facets is None:
+            raise ValueError("Nothing to do")
+
+        invalid_names = []
+        if variants:
+            op = API_OP_CHANGE_VARIANT
+            # Check whether '*' or '?' is in the input. Currently,
+            # change-variant does not accept globbing. Also check
+            # for whitespaces.
+            for variant in variants:
+                if "*" in variant or "?" in variant:
+                    raise apx.UnsupportedVariantGlobbing()
+                if not misc.valid_varcet_name(variant):
+                    invalid_names.append(variant)
+        else:
+            op = API_OP_CHANGE_FACET
+            for facet in facets:
+                # Explict check for not None so that we can fix
+                # a broken system from the past by clearing
+                # the facet. Neither True of False should be
+                # allowed for this special facet.
+                if (
+                    facet == "facet.version-lock.*"
+                    and facets[facet] is not None
+                ):
+                    raise apx.UnsupportedFacetChange(facet, facets[facet])
+                if not misc.valid_varcet_name(facet):
+                    invalid_names.append(facet)
+        if invalid_names:
+            raise apx.InvalidVarcetNames(invalid_names)
+
+        return self.__plan_op(
+            op,
+            _act_timeout=act_timeout,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_activate=be_activate,
+            _be_name=be_name,
+            _li_erecurse=li_erecurse,
+            _li_ignore=li_ignore,
+            _li_parent_sync=li_parent_sync,
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _pubcheck=pubcheck,
+            _refresh_catalogs=refresh_catalogs,
+            _repos=repos,
+            _update_index=update_index,
+            facets=facets,
+            variants=variants,
+            reject_list=reject_list,
+        )
+
+    def plan_revert(
+        self,
+        args,
+        tagged=False,
+        noexecute=True,
+        be_name=None,
+        new_be=None,
+        be_activate=True,
+    ):
+        """DEPRECATED.  use gen_plan_revert()."""
+        for pd in self.gen_plan_revert(
+            args=args,
+            tagged=tagged,
+            noexecute=noexecute,
+            be_name=be_name,
+            new_be=new_be,
+            be_activate=be_activate,
+        ):
+            continue
+        return not self.planned_nothingtodo()
+
+    def gen_plan_revert(
+        self,
+        args,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        new_be=None,
+        noexecute=True,
+        tagged=False,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.  If parsable_version is set, it also yields dictionaries
+        containing plan information for child images.
+
+        Plan to revert either files or all files tagged with
+        specified values.  Args contains either path names or tag
+        names to be reverted, tagged is True if args contains tags.
+        Once an operation has been planned, it may be executed by
+        first calling prepare(), and then execute_plan().  After
+        execution of a plan, or to abandon a plan, reset() should be
+        called.
+
+        For all other parameters, refer to the 'gen_plan_install'
+        function for an explanation of their usage and effects."""
+
+        op = API_OP_REVERT
+        return self.__plan_op(
+            op,
+            _be_activate=be_activate,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_name=be_name,
+            _li_ignore=[],
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _refresh_catalogs=False,
+            _update_index=False,
+            args=args,
+            tagged=tagged,
+        )
+
+    def gen_plan_dehydrate(self, publishers=None, noexecute=True):
+        """This is a generator function that yields a PlanDescription
+        object.
+
+        Plan to remove non-editable files and hardlinks from an image.
+        Once an operation has been planned, it may be executed by
+        first calling prepare(), and then execute_plan().  After
+        execution of a plan, or to abandon a plan, reset() should be
+        called.
+
+        'publishers' is a list of publishers to dehydrate.
+
+        For all other parameters, refer to the 'gen_plan_install'
+        function for an explanation of their usage and effects."""
+
+        op = API_OP_DEHYDRATE
+        return self.__plan_op(
+            op,
+            _noexecute=noexecute,
+            _refresh_catalogs=False,
+            _update_index=False,
+            publishers=publishers,
+        )
+
+    def gen_plan_rehydrate(self, publishers=None, noexecute=True):
+        """This is a generator function that yields a PlanDescription
+        object.
+
+        Plan to reinstall non-editable files and hardlinks to a dehydrated
+        image. Once an operation has been planned, it may be executed by
+        first calling prepare(), and then execute_plan().  After
+        execution of a plan, or to abandon a plan, reset() should be
+        called.
+
+        'publishers' is a list of publishers to dehydrate on.
+
+        For all other parameters, refer to the 'gen_plan_install'
+        function for an explanation of their usage and effects."""
+
+        op = API_OP_REHYDRATE
+        return self.__plan_op(
+            op,
+            _noexecute=noexecute,
+            _refresh_catalogs=False,
+            _update_index=False,
+            publishers=publishers,
+        )
+
+    def gen_plan_verify(
+        self,
+        args,
+        noexecute=True,
+        unpackaged=False,
+        unpackaged_only=False,
+        verify_paths=misc.EmptyI,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.
+
+        Plan to repair anything that fails to verify. Once an operation
+        has been planned, it may be executed by first calling prepare(),
+        and then execute_plan().  After execution of a plan, or to
+        abandon a plan, reset() should be called.
+
+        For parameters, refer to the 'gen_plan_install'
+        function for an explanation of their usage and effects."""
+
+        op = API_OP_VERIFY
+        return self.__plan_op(
+            op,
+            args=args,
+            _noexecute=noexecute,
+            _refresh_catalogs=False,
+            _update_index=False,
+            _new_be=None,
+            unpackaged=unpackaged,
+            unpackaged_only=unpackaged_only,
+            verify_paths=verify_paths,
+        )
+
+    def gen_plan_fix(
+        self,
+        args,
+        backup_be=None,
+        backup_be_name=None,
+        be_activate=True,
+        be_name=None,
+        new_be=None,
+        noexecute=True,
+        unpackaged=False,
+    ):
+        """This is a generator function that yields a PlanDescription
+        object.
+
+        Plan to repair anything that fails to verify. Once an operation
+        has been planned, it may be executed by first calling prepare(),
+        and then execute_plan().  After execution of a plan, or to
+        abandon a plan, reset() should be called.
+
+        For parameters, refer to the 'gen_plan_install'
+        function for an explanation of their usage and effects."""
+
+        op = API_OP_FIX
+        return self.__plan_op(
+            op,
+            args=args,
+            _be_activate=be_activate,
+            _backup_be=backup_be,
+            _backup_be_name=backup_be_name,
+            _be_name=be_name,
+            _new_be=new_be,
+            _noexecute=noexecute,
+            _refresh_catalogs=False,
+            _update_index=False,
+            unpackaged=unpackaged,
+        )
+
+    def attach_linked_child(
+        self,
+        lin,
+        li_path,
+        li_props=None,
+        accept=False,
+        allow_relink=False,
+        force=False,
+        li_md_only=False,
+        li_pkg_updates=True,
+        noexecute=False,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        show_licenses=False,
+        update_index=True,
+    ):
+        """Attach an image as a child to the current image (the
+        current image will become a parent image. This operation
+        results in attempting to sync the child image with the parent
+        image.
+
+        'lin' is the name of the child image
+
+        'li_path' is the path to the child image
+
+        'li_props' optional linked image properties to apply to the
+        child image.
+
+        'allow_relink' indicates whether we should allow linking of a
+        child image that is already linked (the child may already
+        be a child or a parent image).
+
+        'force' indicates whether we should allow linking of a child
+        image even if the specified linked image type doesn't support
+        attaching of children.
+
+        'li_md_only' indicates whether we should only update linked
+        image metadata and not actually try to sync the child image.
+
+        'li_pkg_updates' indicates whether we should disallow pkg
+        updates during the child image sync.
+
+        'noexecute' indicates if we should actually make any changes
+        rather or just simulate the operation.
+
+        'refresh_catalogs' controls whether the catalogs will
+        automatically be refreshed.
+
+        'reject_list' is a list of patterns not to be permitted
+        in solution; installed packages matching these patterns
+        are removed.
+
+        'update_index' determines whether client search indexes will
+        be updated in the child after the sync operation completes.
+
+        This function returns a tuple of the format (rv, err) where rv
+        is a pkg.client.pkgdefs return value and if an error was
+        encountered err is an exception object which describes the
+        error."""
+
+        return self._img.linked.attach_child(
+            lin,
+            li_path,
+            li_props,
+            accept=accept,
+            allow_relink=allow_relink,
+            force=force,
+            li_md_only=li_md_only,
+            li_pkg_updates=li_pkg_updates,
+            noexecute=noexecute,
+            progtrack=self.__progresstracker,
+            refresh_catalogs=refresh_catalogs,
+            reject_list=reject_list,
+            show_licenses=show_licenses,
+            update_index=update_index,
+        )
+
+    def detach_linked_children(
+        self,
+        li_list,
+        force=False,
+        li_md_only=False,
+        li_pkg_updates=True,
+        noexecute=False,
+    ):
+        """Detach one or more children from the current image. This
+        operation results in the removal of any constraint package
+        from the child images.
+
+        'li_list' a list of linked image name objects which specified
+        which children to operate on.  If the list is empty then we
+        operate on all children.
+
+        For all other parameters, refer to the 'attach_linked_child'
+        function for an explanation of their usage and effects.
+
+        This function returns a dictionary where the keys are linked
+        image name objects and the values are the result of the
+        specified operation on the associated child image.  The result
+        is a tuple of the format (rv, err) where rv is a
+        pkg.client.pkgdefs return value and if an error was
+        encountered err is an exception object which describes the
+        error."""
+
+        return self._img.linked.detach_children(
+            li_list,
+            force=force,
+            li_md_only=li_md_only,
+            li_pkg_updates=li_pkg_updates,
+            noexecute=noexecute,
+        )
+
+    def detach_linked_rvdict2rv(self, rvdict):
+        """Convenience function that takes a dictionary returned from
+        an operations on multiple children and merges the results into
+        a single return code."""
+
+        return self._img.linked.detach_rvdict2rv(rvdict)
+
+    def sync_linked_children(
+        self,
+        li_list,
+        accept=False,
+        li_md_only=False,
+        li_pkg_updates=True,
+        noexecute=False,
+        refresh_catalogs=True,
+        show_licenses=False,
+        update_index=True,
+    ):
+        """Sync one or more children of the current image.
+
+        For all other parameters, refer to the 'attach_linked_child'
+        and 'detach_linked_children' functions for an explanation of
+        their usage and effects.
+
+        For a description of the return value, refer to the
+        'detach_linked_children' function."""
+
+        rvdict = self._img.linked.sync_children(
+            li_list,
+            accept=accept,
+            li_md_only=li_md_only,
+            li_pkg_updates=li_pkg_updates,
+            noexecute=noexecute,
+            progtrack=self.__progresstracker,
+            refresh_catalogs=refresh_catalogs,
+            show_licenses=show_licenses,
+            update_index=update_index,
+        )
+        return rvdict
+
+    def sync_linked_rvdict2rv(self, rvdict):
+        """Convenience function that takes a dictionary returned from
+        an operations on multiple children and merges the results into
+        a single return code."""
+
+        return self._img.linked.sync_rvdict2rv(rvdict)
+
+    def audit_linked_children(self, li_list):
+        """Audit one or more children of the current image to see if
+        they are in sync with this image.
+
+        For all parameters, refer to the 'detach_linked_children'
+        functions for an explanation of their usage and effects.
+
+        For a description of the return value, refer to the
+        'detach_linked_children' function."""
+
+        rvdict = self._img.linked.audit_children(li_list)
+        return rvdict
+
+    def audit_linked_rvdict2rv(self, rvdict):
+        """Convenience function that takes a dictionary returned from
+        an operations on multiple children and merges the results into
+        a single return code."""
+
+        return self._img.linked.audit_rvdict2rv(rvdict)
+
+    def audit_linked(self, li_parent_sync=True):
+        """If the current image is a child image, this function
+        audits the current image to see if it's in sync with it's
+        parent.
+
+        For a description of the return value, refer to the
+        'detach_linked_children' function."""
+
+        lin = self._img.linked.child_name
+        rvdict = {}
+
+        if li_parent_sync:
+            # refresh linked image data from parent image.
+            rvdict[lin] = self._img.linked.syncmd_from_parent(
+                catch_exception=True
+            )
+            if rvdict[lin] is not None:
+                return rvdict
+
+        rvdict[lin] = self._img.linked.audit_self()
+        return rvdict
+
+    def ischild(self):
+        """Indicates whether the current image is a child image."""
+        return self._img.linked.ischild()
+
+    def isparent(self, li_ignore=None):
+        """Indicates whether the current image is a parent image."""
+        return self._img.linked.isparent(li_ignore)
+
+    @staticmethod
+    def __utc_format(time_str, utc_now):
+        """Given a local time value string, formatted with
+        "%Y-%m-%dT%H:%M:%S, return a UTC representation of that value,
+        formatted with %Y%m%dT%H%M%SZ.  This raises a ValueError if the
+        time was incorrectly formatted.  If the time_str is "now", it
+        returns the value of utc_now"""
+
+        if time_str == "now":
+            return utc_now
+
+        try:
+            local_dt = datetime.datetime.strptime(time_str, "%Y-%m-%dT%H:%M:%S")
+            secs = time.mktime(local_dt.timetuple())
+            utc_dt = datetime.datetime.utcfromtimestamp(secs)
+            return utc_dt.strftime("%Y%m%dT%H%M%SZ")
+        except ValueError as e:
+            raise apx.HistoryRequestException(e)
+
+    def __get_history_paths(self, time_val, utc_now):
+        """Given a local timestamp, either as a discrete value, or a
+        range of values, formatted as '<timestamp>-<timestamp>', and a
+        path to find history xml files, return an array of paths that
+        match that timestamp.  utc_now is the current time expressed in
+        UTC"""
+
+        files = []
+        if len(time_val) > 20 or time_val.startswith("now-"):
+            if time_val.startswith("now-"):
+                start = utc_now
+                finish = self.__utc_format(time_val[4:], utc_now)
+            else:
+                # our ranges are 19 chars of timestamp, a '-',
+                # and another timestamp
+                start = self.__utc_format(time_val[:19], utc_now)
+                finish = self.__utc_format(time_val[20:], utc_now)
+            if start > finish:
+                raise apx.HistoryRequestException(
+                    _(
+                        "Start " "time must be older than finish time: " "{0}"
+                    ).format(time_val)
+                )
+            files = self.__get_history_range(start, finish)
+        else:
+            # there can be multiple event files per timestamp
+            prefix = self.__utc_format(time_val, utc_now)
+            files = glob.glob(
+                os.path.join(self._img.history.path, "{0}*".format(prefix))
+            )
+        if not files:
+            raise apx.HistoryRequestException(
+                _("No history " "entries found for {0}").format(time_val)
+            )
+        return files
+
+    def __get_history_range(self, start, finish):
+        """Given a start and finish date, formatted as UTC date strings
+        as per __utc_format(), return a list of history filenames that
+        fall within that date range.  A range of two equal dates is
+        the equivalent of just retrieving history for that single date
+        string."""
+
+        entries = []
+        all_entries = sorted(os.listdir(self._img.history.path))
+
+        for entry in all_entries:
+            # our timestamps are always 16 character datestamps
+            basename = os.path.basename(entry)[:16]
+            if basename >= start:
+                if basename > finish:
+                    # we can stop looking now.
+                    break
+                entries.append(entry)
+        return entries
+
+    def gen_history(self, limit=None, times=misc.EmptyI):
+        """A generator function that returns History objects up to the
+        limit specified matching the times specified.
+
+        'limit' is an optional integer value specifying the maximum
+        number of entries to return.
+
+        'times' is a list of timestamp or timestamp range strings to
+        restrict the returned entries to."""
+
+        # Make entries a set to cope with multiple overlapping ranges or
+        # times.
+        entries = set()
+
+        utc_now = datetime.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        for time_val in times:
+            # Ranges are 19 chars of timestamp, a '-', and
+            # another timestamp.
+            if len(time_val) > 20 or time_val.startswith("now-"):
+                if time_val.startswith("now-"):
+                    start = utc_now
+                    finish = self.__utc_format(time_val[4:], utc_now)
+                else:
+                    start = self.__utc_format(time_val[:19], utc_now)
+                    finish = self.__utc_format(time_val[20:], utc_now)
+                if start > finish:
+                    raise apx.HistoryRequestException(
+                        _(
+                            "Start time must be older than " "finish time: {0}"
+                        ).format(time_val)
+                    )
+                files = self.__get_history_range(start, finish)
+            else:
+                # There can be multiple entries per timestamp.
+                prefix = self.__utc_format(time_val, utc_now)
+                files = glob.glob(
+                    os.path.join(self._img.history.path, "{0}*".format(prefix))
+                )
+
+            try:
+                files = self.__get_history_paths(time_val, utc_now)
+                entries.update(files)
+            except ValueError:
+                raise apx.HistoryRequestException(
+                    _(
+                        "Invalid "
+                        "time format '{0}'.  Please use "
+                        "%Y-%m-%dT%H:%M:%S or\n"
+                        "%Y-%m-%dT%H:%M:%S-"
+                        "%Y-%m-%dT%H:%M:%S"
+                    ).format(time_val)
+                )
+
+        if not times:
+            try:
+                entries = os.listdir(self._img.history.path)
+            except EnvironmentError as e:
+                if e.errno == errno.ENOENT:
+                    # No history to list.
+                    return
+                raise apx._convert_error(e)
+
+        entries = sorted(entries)
+        if limit:
+            limit *= -1
+            entries = entries[limit:]
+
+        try:
+            uuid_be_dic = bootenv.BootEnv.get_uuid_be_dic()
+        except apx.ApiException as e:
+            uuid_be_dic = {}
+
+        for entry in entries:
+            # Yield each history entry object as it is loaded.
+            try:
+                yield history.History(
+                    root_dir=self._img.history.root_dir,
+                    filename=entry,
+                    uuid_be_dic=uuid_be_dic,
+                )
+            except apx.HistoryLoadException as e:
+                if e.parse_failure:
+                    # Ignore corrupt entries.
+                    continue
                 raise
 
-        img.cleanup_downloads()
+    def get_linked_name(self):
+        """If the current image is a child image, this function
+        returns a linked image name object which represents the name
+        of the current image."""
+        return self._img.linked.child_name
 
-        return api_inst
+    def get_linked_props(self, lin=None):
+        """Return a dictionary which represents the linked image
+        properties associated with a linked image.
+
+        'lin' is the name of the child image.  If lin is None then
+        the current image is assumed to be a linked image and it's
+        properties are returned."""
+
+        return self._img.linked.child_props(lin=lin)
+
+    def list_linked(self, li_ignore=None):
+        """Returns a list of linked images associated with the
+        current image.  This includes both child and parent images.
+
+        For all parameters, refer to the 'gen_plan_install' function
+        for an explanation of their usage and effects.
+
+        The returned value is a list of tuples where each tuple
+        contains (<li name>, <relationship>, <li path>)."""
+
+        return self._img.linked.list_related(li_ignore=li_ignore)
+
+    def parse_linked_name(self, li_name, allow_unknown=False):
+        """Given a string representing a linked image child name,
+        returns linked image name object representing the same name.
+
+        'allow_unknown' indicates whether the name must represent
+        actual children or simply be syntactically correct."""
+
+        return self._img.linked.parse_name(li_name, allow_unknown)
+
+    def parse_linked_name_list(self, li_name_list, allow_unknown=False):
+        """Given a list of strings representing linked image child
+        names, returns a list of linked image name objects
+        representing the same names.
+
+        For all other parameters, refer to the 'parse_linked_name'
+        function for an explanation of their usage and effects."""
+
+        return [
+            self.parse_linked_name(li_name, allow_unknown)
+            for li_name in li_name_list
+        ]
+
+    def describe(self):
+        """Returns None if no plan is ready yet, otherwise returns
+        a PlanDescription."""
+
+        return self.__plan_desc
+
+    def prepare(self):
+        """Takes care of things which must be done before the plan can
+        be executed.  This includes downloading the packages to disk and
+        preparing the indexes to be updated during execution.  Should
+        only be called once a gen_plan_*() method has been called.  If
+        a plan is abandoned after calling this method, reset() should
+        be called."""
+
+        self._acquire_activity_lock()
+        try:
+            self._img.lock()
+        except:
+            self._activity_lock.release()
+            raise
+
+        try:
+            if not self._img.imageplan:
+                raise apx.PlanMissingException()
+
+            if not self.__planned_children:
+                # if we never planned children images then we
+                # didn't finish planning.
+                raise apx.PlanMissingException()
+
+            if self.__prepared:
+                raise apx.AlreadyPreparedException()
+
+            self._enable_cancel()
+
+            try:
+                self._img.imageplan.preexecute()
+            except search_errors.ProblematicPermissionsIndexException as e:
+                raise apx.ProblematicPermissionsIndexException(e)
+            except:
+                raise
+
+            self._disable_cancel()
+            self.__prepared = True
+        except apx.CanceledException as e:
+            self._cancel_done()
+            if self._img.history.operation_name:
+                # If an operation is in progress, log
+                # the error and mark its end.
+                self.log_operation_end(error=e)
+            raise
+        except Exception as e:
+            self._cancel_cleanup_exception()
+            if self._img.history.operation_name:
+                # If an operation is in progress, log
+                # the error and mark its end.
+                self.log_operation_end(error=e)
+            raise
+        except:
+            # Handle exceptions that are not subclasses of
+            # Exception.
+            self._cancel_cleanup_exception()
+            if self._img.history.operation_name:
+                # If an operation is in progress, log
+                # the error and mark its end.
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                self.log_operation_end(error=exc_type)
+            raise
+        finally:
+            self._img.cleanup_downloads()
+            self._img.unlock()
+            try:
+                if int(os.environ.get("PKG_DUMP_STATS", 0)) > 0:
+                    self._img.transport.stats.dump()
+            except ValueError:
+                # Don't generate stats if an invalid value
+                # is supplied.
+                pass
+            self._activity_lock.release()
+
+        self._img.linked.api_recurse_prepare(self.__progresstracker)
+
+    def execute_plan(self):
+        """Executes the plan. This is uncancelable once it begins.
+        Should only be called after the prepare method has been
+        called.  After plan execution, reset() should be called."""
+
+        self._acquire_activity_lock()
+        try:
+            self._disable_cancel()
+            self._img.lock()
+        except:
+            self._activity_lock.release()
+            raise
+
+        try:
+            if not self._img.imageplan:
+                raise apx.PlanMissingException()
+
+            if not self.__prepared:
+                raise apx.PrematureExecutionException()
+
+            if self.__executed:
+                raise apx.AlreadyExecutedException()
+
+            try:
+                be = bootenv.BootEnv(self._img, self.__progresstracker)
+            except RuntimeError:
+                be = bootenv.BootEnvNull(self._img)
+            self._img.bootenv = be
+
+            if (
+                not self.__new_be
+                and self._img.imageplan.reboot_needed()
+                and self._img.is_liveroot()
+            ):
+                e = apx.RebootNeededOnLiveImageException()
+                self.log_operation_end(error=e)
+                raise e
+
+            # Before proceeding, create a backup boot environment if
+            # requested.
+            if self.__backup_be:
+                try:
+                    be.create_backup_be(be_name=self.__backup_be_name)
+                except Exception as e:
+                    self.log_operation_end(error=e)
+                    raise
+                except:
+                    # Handle exceptions that are not
+                    # subclasses of Exception.
+                    exc_type, exc_value, exc_traceback = sys.exc_info()
+                    self.log_operation_end(error=exc_type)
+                    raise
+
+            # After (possibly) creating backup be, determine if
+            # operation should execute on a clone of current BE.
+            if self.__new_be:
+                try:
+                    be.init_image_recovery(self._img, self.__be_name)
+                except Exception as e:
+                    self.log_operation_end(error=e)
+                    raise
+                except:
+                    # Handle exceptions that are not
+                    # subclasses of Exception.
+                    exc_type, exc_value, exc_traceback = sys.exc_info()
+                    self.log_operation_end(error=exc_type)
+                    raise
+                # check if things gained underneath us
+                if self._img.is_liveroot():
+                    e = apx.UnableToCopyBE()
+                    self.log_operation_end(error=e)
+                    raise e
+
+            raise_later = None
+
+            # we're about to execute a plan so change our current
+            # working directory to / so that we won't fail if we
+            # try to remove our current working directory
+            os.chdir(os.sep)
+
+            try:
+                try:
+                    self._img.imageplan.execute()
+                except apx.WrapIndexingException as e:
+                    raise_later = e
+
+                if not self._img.linked.nothingtodo():
+                    self._img.linked.syncmd()
+            except RuntimeError as e:
+                if self.__new_be:
+                    be.restore_image()
+                else:
+                    be.restore_install_uninstall()
+                # Must be done after bootenv restore.
+                self.log_operation_end(error=e)
+                raise
+            except search_errors.IndexLockedException as e:
+                error = apx.IndexLockedException(e)
+                self.log_operation_end(error=error)
+                raise error
+            except search_errors.ProblematicPermissionsIndexException as e:
+                error = apx.ProblematicPermissionsIndexException(e)
+                self.log_operation_end(error=error)
+                raise error
+            except search_errors.InconsistentIndexException as e:
+                error = apx.CorruptedIndexException(e)
+                self.log_operation_end(error=error)
+                raise error
+            except NonzeroExitException as e:
+                # Won't happen during update
+                be.restore_install_uninstall()
+                error = apx.ActuatorException(e)
+                self.log_operation_end(error=error)
+                raise error
+            except apx.InvalidMediatorTarget as e:
+                # Mount a new BE but do not activate it in case the
+                # missing mediator target will cause a broken system.
+                # Allows the admin to take the appropriate action.
+                if self.__new_be:
+                    be.restore_image()
+                self.log_operation_end(error=e)
+                raise e
+            except Exception as e:
+                if self.__new_be:
+                    be.restore_image()
+                else:
+                    be.restore_install_uninstall()
+                # Must be done after bootenv restore.
+                self.log_operation_end(error=e)
+                raise
+            except:
+                # Handle exceptions that are not subclasses of
+                # Exception.
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+
+                if self.__new_be:
+                    be.restore_image()
+                else:
+                    be.restore_install_uninstall()
+                # Must be done after bootenv restore.
+                self.log_operation_end(error=exc_type)
+                raise
+
+            self._img.linked.api_recurse_execute(self.__progresstracker)
+
+            self.__finished_execution(be)
+            if raise_later:
+                raise raise_later
+
+        finally:
+            self._img.cleanup_downloads()
+            if self._img.locked:
+                self._img.unlock()
+            self._activity_lock.release()
+
+    def __finished_execution(self, be):
+        if self._img.imageplan.state != plandesc.EXECUTED_OK:
+            if self.__new_be:
+                be.restore_image()
+            else:
+                be.restore_install_uninstall()
+
+            error = apx.ImageplanStateException(self._img.imageplan.state)
+            # Must be done after bootenv restore.
+            self.log_operation_end(error=error)
+            raise error
+
+        if self._img.imageplan.boot_archive_needed() or self.__new_be:
+            be.update_boot_archive()
+
+        self._img.hotfix_origin_cleanup()
+
+        if self.__new_be:
+            be.activate_image(set_active=self.__be_activate)
+        else:
+            be.activate_install_uninstall()
+        self._img.cleanup_cached_content(progtrack=self.__progresstracker)
+        # If the end of the operation wasn't already logged
+        # by one of the previous operations, then log it as
+        # ending now.
+        if self._img.history.operation_name:
+            self.log_operation_end(
+                release_notes=self._img.imageplan.pd.release_notes_name
+            )
+        self.__executed = True
+
+    def set_plan_license_status(
+        self, pfmri, plicense, accepted=None, displayed=None
+    ):
+        """Sets the license status for the given package FMRI and
+        license entry.
+
+        'accepted' is an optional parameter that can be one of three
+        values:
+                None    leaves accepted status unchanged
+                False   sets accepted status to False
+                True    sets accepted status to True
+
+        'displayed' is an optional parameter that can be one of three
+        values:
+                None    leaves displayed status unchanged
+                False   sets displayed status to False
+                True    sets displayed status to True"""
+
+        self._acquire_activity_lock()
+        try:
+            try:
+                self._disable_cancel()
+            except apx.CanceledException:
+                self._cancel_done()
+                raise
+
+            if not self._img.imageplan:
+                raise apx.PlanMissingException()
+
+            for pp in self.__plan_desc.pkg_plans:
+                if pp.destination_fmri == pfmri:
+                    pp.set_license_status(
+                        plicense, accepted=accepted, displayed=displayed
+                    )
+                    break
+        finally:
+            self._activity_lock.release()
+
+    def refresh(
+        self,
+        full_refresh=False,
+        pubs=None,
+        immediate=False,
+        ignore_unreachable=True,
+    ):
+        """Refreshes the metadata (e.g. catalog) for one or more
+        publishers.
+
+        'full_refresh' is an optional boolean value indicating whether
+        a full retrieval of publisher metadata (e.g. catalogs) or only
+        an update to the existing metadata should be performed.  When
+        True, 'immediate' is also set to True.
+
+        'pubs' is a list of publisher prefixes or publisher objects
+        to refresh.  Passing an empty list or using the default value
+        implies all publishers.
+
+        'immediate' is an optional boolean value indicating whether
+        a refresh should occur now.  If False, a publisher's selected
+        repository will only be checked for updates if the update
+        interval period recorded in the image configuration has been
+        exceeded.
+
+        'ignore_unreachable' is an optional boolean value indicating
+        whether unreachable repositories should be ignored. If True,
+        errors contacting this repository are stored in the transport
+        but no exception is raised, allowing an operation to continue
+        if an unneeded repository is not online.
+
+        Currently returns an image object, allowing existing code to
+        work while the rest of the API is put into place."""
+
+        self._acquire_activity_lock()
+        try:
+            self._disable_cancel()
+            self._img.lock()
+            try:
+                self.__refresh(
+                    full_refresh=full_refresh,
+                    pubs=pubs,
+                    ignore_unreachable=ignore_unreachable,
+                    immediate=immediate,
+                )
+                return self._img
+            finally:
+                self._img.unlock()
+                self._img.cleanup_downloads()
+        except apx.CanceledException:
+            self._cancel_done()
+            raise
+        finally:
+            try:
+                if int(os.environ.get("PKG_DUMP_STATS", 0)) > 0:
+                    self._img.transport.stats.dump()
+            except ValueError:
+                # Don't generate stats if an invalid value
+                # is supplied.
+                pass
+            self._activity_lock.release()
+
+    def __refresh(
+        self,
+        full_refresh=False,
+        pubs=None,
+        immediate=False,
+        ignore_unreachable=True,
+    ):
+        """Private refresh method; caller responsible for locking and
+        cleanup."""
+
+        self._img.refresh_publishers(
+            full_refresh=full_refresh,
+            ignore_unreachable=ignore_unreachable,
+            immediate=immediate,
+            pubs=pubs,
+            progtrack=self.__progresstracker,
+        )
+
+    def __licenses(self, pfmri, mfst, alt_pub=None):
+        """Private function. Returns the license info from the
+        manifest mfst."""
+        license_lst = []
+        for lic in mfst.gen_actions_by_type("license"):
+            license_lst.append(
+                LicenseInfo(pfmri, lic, img=self._img, alt_pub=alt_pub)
+            )
+        return license_lst
+
+    @_LockedCancelable()
+    def get_pkg_categories(self, installed=False, pubs=misc.EmptyI, repos=None):
+        """Returns an ordered list of tuples of the form (scheme,
+        category) containing the names of all categories in use by
+        the last version of each unique package in the catalog on a
+        per-publisher basis.
+
+        'installed' is an optional boolean value indicating whether
+        only the categories used by currently installed packages
+        should be returned.  If False, the categories used by the
+        latest vesion of every known package will be returned
+        instead.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to.
+
+        'repos' is a list of URI strings or RepositoryURI objects that
+        represent the locations of package repositories to list packages
+        for.
+        """
+
+        if installed:
+            excludes = misc.EmptyI
+        else:
+            excludes = self._img.list_excludes()
+
+        if repos:
+            ignored, ignored, known_cat, inst_cat = self.__get_alt_pkg_data(
+                repos
+            )
+            if installed:
+                pkg_cat = inst_cat
+            else:
+                pkg_cat = known_cat
+        elif installed:
+            pkg_cat = self._img.get_catalog(self._img.IMG_CATALOG_INSTALLED)
+        else:
+            pkg_cat = self._img.get_catalog(self._img.IMG_CATALOG_KNOWN)
+        return sorted(pkg_cat.categories(excludes=excludes, pubs=pubs))
+
+    def __map_installed_newest(self, pubs, known_cat=None):
+        """Private function.  Maps incorporations and publisher
+        relationships for installed packages and returns them
+        as a tuple of (pub_ranks, inc_stems, inc_vers, inst_stems,
+        ren_stems, ren_inst_stems).
+        """
+
+        img_cat = self._img.get_catalog(self._img.IMG_CATALOG_INSTALLED)
+        cat_info = frozenset([img_cat.DEPENDENCY])
+
+        inst_stems = {}
+        ren_inst_stems = {}
+        ren_stems = {}
+
+        inc_stems = {}
+        inc_vers = {}
+
+        pub_ranks = self._img.get_publisher_ranks()
+
+        # The incorporation list should include all installed,
+        # incorporated packages from all publishers.
+        for t in img_cat.entry_actions(cat_info):
+            (pub, stem, ver), entry, actions = t
+
+            inst_stems[stem] = ver
+            pkgr = False
+            targets = set()
+            try:
+                for a in actions:
+                    if a.name == "set" and a.attrs["name"] == "pkg.renamed":
+                        pkgr = True
+                        continue
+                    elif a.name != "depend":
+                        continue
+
+                    if a.attrs["type"] == "require":
+                        # Because the actions are not
+                        # returned in a guaranteed
+                        # order, the dependencies will
+                        # have to be recorded for
+                        # evaluation later.
+                        targets.add(a.attrs["fmri"])
+                    elif a.attrs["type"] == "incorporate":
+                        # Record incorporated packages.
+                        tgt = fmri.PkgFmri(a.attrs["fmri"])
+                        tver = tgt.version
+                        # incorporates without a version
+                        # should be ignored.
+                        if not tver:
+                            continue
+                        over = inc_vers.get(tgt.pkg_name, None)
+
+                        # In case this package has been
+                        # incorporated more than once,
+                        # use the newest version.
+                        if over is not None and over > tver:
+                            continue
+                        inc_vers[tgt.pkg_name] = tver
+            except apx.InvalidPackageErrors:
+                # For mapping purposes, ignore unsupported
+                # (and invalid) actions.  This is necessary so
+                # that API consumers can discover new package
+                # data that may be needed to perform an upgrade
+                # so that the API can understand them.
+                pass
+
+            if pkgr:
+                for f in targets:
+                    tgt = fmri.PkgFmri(f)
+                    ren_stems[tgt.pkg_name] = stem
+                    ren_inst_stems.setdefault(stem, set())
+                    ren_inst_stems[stem].add(tgt.pkg_name)
+
+        def check_stem(t, entry):
+            pub, stem, ver = t
+            if stem in inst_stems:
+                iver = inst_stems[stem]
+                if stem in ren_inst_stems or ver == iver:
+                    # The package has been renamed
+                    # or the entry is for the same
+                    # version as that which is
+                    # installed, so doesn't need
+                    # to be checked.
+                    return False
+                # The package may have been renamed in
+                # a newer version, so must be checked.
+                return True
+            elif stem in inc_vers:
+                # Package is incorporated, but not
+                # installed, so should be checked.
+                return True
+
+            tgt = ren_stems.get(stem, None)
+            while tgt is not None:
+                # This seems counter-intuitive, but
+                # for performance and other reasons,
+                # this stem should only be checked
+                # for a rename if it is incorporated
+                # or installed using a previous name.
+                if tgt in inst_stems or tgt in inc_vers:
+                    return True
+                tgt = ren_stems.get(tgt, None)
+
+            # Package should not be checked.
+            return False
+
+        if not known_cat:
+            known_cat = self._img.get_catalog(self._img.IMG_CATALOG_KNOWN)
+
+        # Find terminal rename entry for all known packages not
+        # rejected by check_stem().
+        for t, entry, actions in known_cat.entry_actions(
+            cat_info, cb=check_stem, last=True
+        ):
+            pkgr = False
+            targets = set()
+            try:
+                for a in actions:
+                    if a.name == "set" and a.attrs["name"] == "pkg.renamed":
+                        pkgr = True
+                        continue
+
+                    if a.name != "depend":
+                        continue
+
+                    if a.attrs["type"] != "require":
+                        continue
+
+                    # Because the actions are not
+                    # returned in a guaranteed
+                    # order, the dependencies will
+                    # have to be recorded for
+                    # evaluation later.
+                    targets.add(a.attrs["fmri"])
+            except apx.InvalidPackageErrors:
+                # For mapping purposes, ignore unsupported
+                # (and invalid) actions.  This is necessary so
+                # that API consumers can discover new package
+                # data that may be needed to perform an upgrade
+                # so that the API can understand them.
+                pass
+
+            if pkgr:
+                pub, stem, ver = t
+                for f in targets:
+                    tgt = fmri.PkgFmri(f)
+                    ren_stems[tgt.pkg_name] = stem
+
+        # Determine highest ranked publisher for package stems
+        # listed in installed incorporations.
+        def pub_key(item):
+            return pub_ranks[item][0]
+
+        for p in sorted(pub_ranks, key=pub_key):
+            if pubs and p not in pubs:
+                continue
+            for stem in known_cat.names(pubs=[p]):
+                if stem in inc_vers:
+                    inc_stems.setdefault(stem, p)
+
+        return (
+            pub_ranks,
+            inc_stems,
+            inc_vers,
+            inst_stems,
+            ren_stems,
+            ren_inst_stems,
+        )
+
+    def __get_temp_repo_pubs(self, repos):
+        """Private helper function to retrieve publisher information
+        from list of temporary repositories.  Caller is responsible
+        for locking."""
+
+        ret_pubs = []
+        for repo_uri in repos:
+            if isinstance(repo_uri, six.string_types):
+                repo = publisher.RepositoryURI(repo_uri)
+            else:
+                # Already a RepositoryURI.
+                repo = repo_uri
+
+            pubs = None
+            try:
+                pubs = self._img.transport.get_publisherdata(
+                    repo, ccancel=self.__check_cancel
+                )
+            except apx.UnsupportedRepositoryOperation:
+                raise apx.RepoPubConfigUnavailable(location=str(repo))
+
+            if not pubs:
+                # Empty repository configuration.
+                raise apx.RepoPubConfigUnavailable(location=str(repo))
+
+            for p in pubs:
+                p.client_uuid = "transient"
+                psrepo = p.repository
+                if not psrepo:
+                    # Repository configuration info wasn't
+                    # provided, so assume origin is
+                    # repo_uri.
+                    p.repository = publisher.Repository(origins=[repo_uri])
+                elif not psrepo.origins:
+                    # Repository configuration was provided,
+                    # but without an origin.  Assume the
+                    # repo_uri is the origin.
+                    psrepo.add_origin(repo_uri)
+                elif repo not in psrepo.origins:
+                    # If the repo_uri used is not
+                    # in the list of sources, then
+                    # add it as the first origin.
+                    psrepo.origins.insert(0, repo)
+            ret_pubs.extend(pubs)
+
+        return sorted(ret_pubs)
+
+    def __get_alt_pkg_data(self, repos):
+        """Private helper function to retrieve composite known and
+        installed catalog and package repository map for temporary
+        set of package repositories.  Returns (pkg_pub_map, alt_pubs,
+        known_cat, inst_cat)."""
+
+        repos = set(repos)
+        eid = ",".join(sorted(map(str, repos)))
+        try:
+            return self.__alt_sources[eid]
+        except KeyError:
+            # Need to cache new set of alternate sources.
+            pass
+
+        img_inst_cat = self._img.get_catalog(self._img.IMG_CATALOG_INSTALLED)
+        img_inst_base = img_inst_cat.get_part("catalog.base.C", must_exist=True)
+        op_time = datetime.datetime.utcnow()
+        pubs = self.__get_temp_repo_pubs(repos)
+        progtrack = self.__progresstracker
+
+        # Create temporary directories.
+        tmpdir = tempfile.mkdtemp()
+
+        pkg_repos = {}
+        pkg_pub_map = {}
+        # Too many nested blocks;
+        # pylint: disable=R0101
+        try:
+            progtrack.refresh_start(len(pubs), full_refresh=False)
+            failed = []
+            pub_cats = []
+            for pub in pubs:
+                # Assign a temporary meta root to each
+                # publisher.
+                meta_root = os.path.join(tmpdir, str(id(pub)))
+                misc.makedirs(meta_root)
+                pub.meta_root = meta_root
+                pub.transport = self._img.transport
+                repo = pub.repository
+                pkg_repos[id(repo)] = repo
+
+                # Retrieve each publisher's catalog.
+                progtrack.refresh_start_pub(pub)
+                try:
+                    pub.refresh()
+                except apx.PermissionsException as e:
+                    failed.append((pub, e))
+                    # No point in continuing since no data
+                    # can be written.
+                    break
+                except apx.ApiException as e:
+                    failed.append((pub, e))
+                    continue
+                finally:
+                    progtrack.refresh_end_pub(pub)
+                pub_cats.append((pub.prefix, repo, pub.catalog))
+
+            progtrack.refresh_done()
+
+            if failed:
+                total = len(pub_cats) + len(failed)
+                e = apx.CatalogRefreshException(failed, total, len(pub_cats))
+                raise e
+
+            # Determine upgradability.
+            newest = {}
+            for pfx, repo, cat in [(None, None, img_inst_cat)] + pub_cats:
+                if pfx:
+                    pkg_list = cat.fmris(last=True, pubs=[pfx])
+                else:
+                    pkg_list = cat.fmris(last=True)
+
+                for f in pkg_list:
+                    nver, snver = newest.get(f.pkg_name, (None, None))
+                    if f.version > nver:
+                        newest[f.pkg_name] = (f.version, str(f.version))
+
+            # Build list of installed packages.
+            inst_stems = {}
+            for t, entry in img_inst_cat.tuple_entries():
+                states = entry["metadata"]["states"]
+                if pkgdefs.PKG_STATE_INSTALLED not in states:
+                    continue
+                pub, stem, ver = t
+                inst_stems.setdefault(pub, {})
+                inst_stems[pub].setdefault(stem, {})
+                inst_stems[pub][stem][ver] = False
+
+            # Now create composite known and installed catalogs.
+            compicat = pkg.catalog.Catalog(batch_mode=True, sign=False)
+            compkcat = pkg.catalog.Catalog(batch_mode=True, sign=False)
+
+            sparts = (
+                (pfx, cat, repo, name, cat.get_part(name, must_exist=True))
+                for pfx, repo, cat in pub_cats
+                for name in cat.parts
+            )
+
+            excludes = self._img.list_excludes()
+            proc_stems = {}
+            for pfx, cat, repo, name, spart in sparts:
+                # 'spart' is the source part.
+                if spart is None:
+                    # Client hasn't retrieved this part.
+                    continue
+
+                # New known part.
+                nkpart = compkcat.get_part(name)
+                nipart = compicat.get_part(name)
+                base = name.startswith("catalog.base.")
+
+                # Avoid accessor overhead since these will be
+                # used for every entry.
+                cat_ver = cat.version
+                dp = cat.get_part("catalog.dependency.C", must_exist=True)
+
+                for t, sentry in spart.tuple_entries(pubs=[pfx]):
+                    pub, stem, ver = t
+
+                    pkg_pub_map.setdefault(pub, {})
+                    pkg_pub_map[pub].setdefault(stem, {})
+                    pkg_pub_map[pub][stem].setdefault(ver, set())
+                    pkg_pub_map[pub][stem][ver].add(id(repo))
+
+                    if (
+                        pub in proc_stems
+                        and stem in proc_stems[pub]
+                        and ver in proc_stems[pub][stem]
+                    ):
+                        if id(cat) != proc_stems[pub][stem][ver]:
+                            # Already added from another
+                            # catalog.
+                            continue
+                    else:
+                        proc_stems.setdefault(pub, {})
+                        proc_stems[pub].setdefault(stem, {})
+                        proc_stems[pub][stem][ver] = id(cat)
+
+                    installed = False
+                    if (
+                        pub in inst_stems
+                        and stem in inst_stems[pub]
+                        and ver in inst_stems[pub][stem]
+                    ):
+                        installed = True
+                        inst_stems[pub][stem][ver] = True
+
+                    # copy() is too slow here and catalog
+                    # entries are shallow so this should be
+                    # sufficient.
+                    entry = dict(six.iteritems(sentry))
+                    if not base:
+                        # Nothing else to do except add
+                        # the entry for non-base catalog
+                        # parts.
+                        nkpart.add(
+                            metadata=entry,
+                            op_time=op_time,
+                            pub=pub,
+                            stem=stem,
+                            ver=ver,
+                        )
+                        if installed:
+                            nipart.add(
+                                metadata=entry,
+                                op_time=op_time,
+                                pub=pub,
+                                stem=stem,
+                                ver=ver,
+                            )
+                        continue
+
+                    # Only the base catalog part stores
+                    # package state information and/or
+                    # other metadata.
+                    mdata = {}
+                    if installed:
+                        mdata = dict(
+                            img_inst_base.get_entry(
+                                pub=pub, stem=stem, ver=ver
+                            )["metadata"]
+                        )
+
+                    entry["metadata"] = mdata
+
+                    states = [
+                        pkgdefs.PKG_STATE_KNOWN,
+                        pkgdefs.PKG_STATE_ALT_SOURCE,
+                    ]
+                    if cat_ver == 0:
+                        states.append(pkgdefs.PKG_STATE_V0)
+                    else:
+                        # Assume V1 catalog source.
+                        states.append(pkgdefs.PKG_STATE_V1)
+
+                    if installed:
+                        states.append(pkgdefs.PKG_STATE_INSTALLED)
+
+                    nver, snver = newest.get(stem, (None, None))
+                    if snver is not None and ver != snver:
+                        states.append(pkgdefs.PKG_STATE_UPGRADABLE)
+
+                    # Determine if package is obsolete or
+                    # has been renamed and mark with
+                    # appropriate state.
+                    dpent = None
+                    if dp is not None:
+                        dpent = dp.get_entry(pub=pub, stem=stem, ver=ver)
+                    if dpent is not None:
+                        for a in dpent["actions"]:
+                            # Constructing action
+                            # objects for every
+                            # action would be a lot
+                            # slower, so a simple
+                            # string match is done
+                            # first so that only
+                            # interesting actions
+                            # get constructed.
+                            if not a.startswith("set"):
+                                continue
+                            if not (
+                                "pkg.obsolete" in a
+                                or "pkg.renamed" in a
+                                or "pkg.legacy" in a
+                            ):
+                                continue
+
+                            try:
+                                act = pkg.actions.fromstr(a)
+                            except pkg.actions.ActionError:
+                                # If the action can't be
+                                # parsed or is not yet
+                                # supported, continue.
+                                continue
+
+                            if act.attrs["value"].lower() != "true":
+                                continue
+
+                            if act.attrs["name"] == "pkg.obsolete":
+                                states.append(pkgdefs.PKG_STATE_OBSOLETE)
+                            elif act.attrs["name"] == "pkg.renamed":
+                                if not act.include_this(
+                                    excludes, publisher=pub
+                                ):
+                                    continue
+                                states.append(pkgdefs.PKG_STATE_RENAMED)
+                            elif act.attrs["name"] == "pkg.legacy":
+                                states.append(pkgdefs.PKG_STATE_LEGACY)
+
+                    mdata["states"] = states
+
+                    # Add base entries.
+                    nkpart.add(
+                        metadata=entry,
+                        op_time=op_time,
+                        pub=pub,
+                        stem=stem,
+                        ver=ver,
+                    )
+                    if installed:
+                        nipart.add(
+                            metadata=entry,
+                            op_time=op_time,
+                            pub=pub,
+                            stem=stem,
+                            ver=ver,
+                        )
+
+            pub_map = {}
+            for pub in pubs:
+                try:
+                    opub = pub_map[pub.prefix]
+                except KeyError:
+                    nrepo = publisher.Repository()
+                    opub = publisher.Publisher(
+                        pub.prefix, catalog=compkcat, repository=nrepo
+                    )
+                    pub_map[pub.prefix] = opub
+
+            rid_map = {}
+            for pub in pkg_pub_map:
+                for stem in pkg_pub_map[pub]:
+                    for ver in pkg_pub_map[pub][stem]:
+                        rids = tuple(sorted(pkg_pub_map[pub][stem][ver]))
+
+                        if rids not in rid_map:
+                            # Create a publisher and
+                            # repository for this
+                            # unique set of origins.
+                            origins = []
+                            list(
+                                map(
+                                    origins.extend,
+                                    [
+                                        pkg_repos.get(rid).origins
+                                        for rid in rids
+                                    ],
+                                )
+                            )
+                            npub = copy.copy(pub_map[pub])
+                            nrepo = npub.repository
+                            nrepo.origins = origins
+                            assert npub.catalog == compkcat
+                            rid_map[rids] = npub
+
+                        pkg_pub_map[pub][stem][ver] = rid_map[rids]
+
+            # Now consolidate all origins for each publisher under
+            # a single repository object for the caller.
+            for pub in pubs:
+                npub = pub_map[pub.prefix]
+                nrepo = npub.repository
+                for o in pub.repository.origins:
+                    if not nrepo.has_origin(o):
+                        nrepo.add_origin(o)
+                assert npub.catalog == compkcat
+
+            for compcat in (compicat, compkcat):
+                compcat.batch_mode = False
+                compcat.finalize()
+                compcat.read_only = True
+
+            # Cache these for future callers.
+            self.__alt_sources[eid] = (
+                pkg_pub_map,
+                sorted(pub_map.values()),
+                compkcat,
+                compicat,
+            )
+            return self.__alt_sources[eid]
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+            self._img.cleanup_downloads()
+
+    @_LockedGenerator()
+    def get_pkg_list(
+        self,
+        pkg_list,
+        cats=None,
+        collect_attrs=False,
+        patterns=misc.EmptyI,
+        pubs=misc.EmptyI,
+        raise_unmatched=False,
+        ranked=False,
+        repos=None,
+        return_fmris=False,
+        variants=False,
+    ):
+        """A generator function that produces tuples of the form:
+
+            (
+                (
+                    pub,    - (string) the publisher of the package
+                    stem,   - (string) the name of the package
+                    version - (string) the version of the package
+                ),
+                summary,    - (string) the package summary
+                categories, - (list) string tuples of (scheme, category)
+                states,     - (list) PackageInfo states
+                attributes  - (dict) package attributes
+            )
+
+        Results are always sorted by stem, publisher, and then in
+        descending version order.
+
+        'pkg_list' is one of the following constant values indicating
+        what base set of package data should be used for results:
+
+                LIST_ALL
+                        All known packages.
+
+                LIST_INSTALLED
+                        Installed packages.
+
+                LIST_INSTALLED_NEWEST
+                        Installed packages and the newest
+                        versions of packages not installed.
+                        Renamed packages that are listed in
+                        an installed incorporation will be
+                        excluded unless they are installed.
+
+                LIST_NEWEST
+                        The newest versions of all known packages
+                        that match the provided patterns and
+                        other criteria.
+
+                LIST_UPGRADABLE
+                        Packages that are installed and upgradable.
+
+                LIST_REMOVABLE
+                        Packages that have no dependants
+
+        'cats' is an optional list of package category tuples of the
+        form (scheme, cat) to restrict the results to.  If a package
+        is assigned to any of the given categories, it will be
+        returned.  A value of [] will return packages not assigned
+        to any package category.  A value of None indicates that no
+        package category filtering should be applied.
+
+        'collect_attrs' is an optional boolean that indicates whether
+        all package attributes should be collected and returned in the
+        fifth element of the return tuple.  If False, that element will
+        be an empty dictionary.
+
+        'patterns' is an optional list of FMRI wildcard strings to
+        filter results by.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to.
+
+        'raise_unmatched' is an optional boolean value that indicates
+        whether an InventoryException should be raised if any patterns
+        (after applying all other filtering and returning all results)
+        didn't match any packages.
+
+        'ranked' is an optional boolean value that indicates whether
+        only the matching package versions from the highest-ranked
+        publisher should be returned.  This option is ignored for
+        patterns that explicitly specify the publisher to match.
+
+        'repos' is a list of URI strings or RepositoryURI objects that
+        represent the locations of package repositories to list packages
+        for.
+
+        'return_fmris' is an optional boolean value that indicates that
+        an FMRI object should be returned in place of the (pub, stem,
+        ver) tuple that is normally returned.
+
+        'variants' is an optional boolean value that indicates that
+        packages that are for arch or zone variants not applicable to
+        this image should be returned.
+
+        Please note that this function may invoke network operations
+        to retrieve the requested package information."""
+
+        return self.__get_pkg_list(
+            pkg_list,
+            cats=cats,
+            collect_attrs=collect_attrs,
+            patterns=patterns,
+            pubs=pubs,
+            raise_unmatched=raise_unmatched,
+            ranked=ranked,
+            repos=repos,
+            return_fmris=return_fmris,
+            variants=variants,
+        )
+
+    def __get_pkg_refcounts(self, pkg_cat, excludes, pubs):
+        pkg_ref = set()
+        pkg_optref = set()
+
+        cat_info = frozenset([pkg_cat.DEPENDENCY])
+
+        for pfmri, actions in pkg_cat.actions(
+            cat_info, excludes=excludes, pubs=pubs
+        ):
+            for a in actions:
+                # Always keep packages with an install-hold
+                if (
+                    a.name == "set"
+                    and a.attrs["name"] == "pkg.depend.install-hold"
+                ):
+                    pkg_ref.add(pfmri.pkg_name)
+                    continue
+                if a.name != "depend":
+                    continue
+                for f in a.attrlist("fmri"):
+                    tgt = fmri.PkgFmri(f)
+                    if a.attrs["type"] in ["require", "conditional"]:
+                        pkg_ref.add(tgt.pkg_name)
+                    if a.attrs["type"] == "optional":
+                        pkg_optref.add(tgt.pkg_name)
+        return pkg_ref, pkg_optref
+
+    def __get_pkg_list(
+        self,
+        pkg_list,
+        cats=None,
+        collect_attrs=False,
+        inst_cat=None,
+        known_cat=None,
+        patterns=misc.EmptyI,
+        pubs=misc.EmptyI,
+        raise_unmatched=False,
+        ranked=False,
+        repos=None,
+        return_fmris=False,
+        return_metadata=False,
+        variants=False,
+    ):
+        """This is the implementation of get_pkg_list.  The other
+        function is a wrapper that uses locking.  The separation was
+        necessary because of API functions that already perform locking
+        but need to use get_pkg_list().  This is a generator
+        function."""
+
+        installed = inst_newest = newest = upgradable = False
+        removable = False
+        if pkg_list == self.LIST_INSTALLED:
+            installed = True
+        elif pkg_list == self.LIST_INSTALLED_NEWEST:
+            inst_newest = True
+        elif pkg_list == self.LIST_NEWEST:
+            newest = True
+        elif pkg_list == self.LIST_UPGRADABLE:
+            upgradable = True
+        elif pkg_list == self.LIST_REMOVABLE:
+            removable = True
+
+        # Each pattern in patterns can be a partial or full FMRI, so
+        # extract the individual components for use in filtering.
+        illegals = []
+        pat_tuples = {}
+        pat_versioned = False
+        latest_pats = set()
+        seen = set()
+        npatterns = set()
+        for pat, error, pfmri, matcher in self.parse_fmri_patterns(patterns):
+            if error:
+                illegals.append(error)
+                continue
+
+            # Duplicate patterns are ignored.
+            sfmri = str(pfmri)
+            if sfmri in seen:
+                # A different form of the same pattern
+                # was specified already; ignore this
+                # one (e.g. pkg:/network/ping,
+                # /network/ping).
+                continue
+
+            # Track used patterns.
+            seen.add(sfmri)
+            npatterns.add(pat)
+
+            if "@" in pat:
+                # Mark that a pattern contained version
+                # information.  This is used for a listing
+                # optimization later on.
+                pat_versioned = True
+            if getattr(pfmri.version, "match_latest", None):
+                latest_pats.add(pat)
+            pat_tuples[pat] = (pfmri.tuple(), matcher)
+
+        patterns = npatterns
+        del npatterns, seen
+
+        if illegals:
+            raise apx.InventoryException(illegal=illegals)
+
+        if repos:
+            ignored, ignored, known_cat, inst_cat = self.__get_alt_pkg_data(
+                repos
+            )
+
+        # For LIST_INSTALLED_NEWEST, installed packages need to be
+        # determined and incorporation and publisher relationships
+        # mapped.
+        if inst_newest:
+            (
+                pub_ranks,
+                inc_stems,
+                inc_vers,
+                inst_stems,
+                ren_stems,
+                ren_inst_stems,
+            ) = self.__map_installed_newest(pubs, known_cat=known_cat)
+        else:
+            pub_ranks = (
+                inc_stems
+            ) = (
+                inc_vers
+            ) = inst_stems = ren_stems = ren_inst_stems = misc.EmptyDict
+
+        if installed or upgradable or removable:
+            if inst_cat:
+                pkg_cat = inst_cat
+            else:
+                pkg_cat = self._img.get_catalog(self._img.IMG_CATALOG_INSTALLED)
+
+            # Don't need to perform variant filtering if only
+            # listing installed packages.
+            variants = True
+        elif known_cat:
+            pkg_cat = known_cat
+        else:
+            pkg_cat = self._img.get_catalog(self._img.IMG_CATALOG_KNOWN)
+
+        cat_info = frozenset([pkg_cat.DEPENDENCY, pkg_cat.SUMMARY])
+
+        # Keep track of when the newest version has been found for
+        # each incorporated stem.
+        slist = set()
+
+        # Keep track of listed stems for all other packages on a
+        # per-publisher basis.
+        nlist = collections.defaultdict(int)
+
+        def check_state(t, entry):
+            states = entry["metadata"]["states"]
+            pkgi = pkgdefs.PKG_STATE_INSTALLED in states
+            pkgu = pkgdefs.PKG_STATE_UPGRADABLE in states
+            pub, stem, ver = t
+
+            if upgradable:
+                # If package is marked upgradable, return it.
+                return pkgu
+            elif removable:
+                return not stem in pkg_ref
+            elif pkgi:
+                # Nothing more to do here.
+                return True
+            elif stem in inst_stems:
+                # Some other version of this package is
+                # installed, so this one should not be
+                # returned.
+                return False
+
+            # Attempt to determine if this package is installed
+            # under a different name or constrained under a
+            # different name.
+            tgt = ren_stems.get(stem, None)
+            while tgt is not None:
+                if tgt in inc_vers:
+                    # Package is incorporated under a
+                    # different name, so allow this
+                    # to fallthrough to the incoporation
+                    # evaluation.
+                    break
+                elif tgt in inst_stems:
+                    # Package is installed under a
+                    # different name, so skip it.
+                    return False
+                tgt = ren_stems.get(tgt, None)
+
+            # Attempt to find a suitable version to return.
+            if stem in inc_vers:
+                # For package stems that are incorporated, only
+                # return the newest successor version  based on
+                # publisher rank.
+                if stem in slist:
+                    # Newest version already returned.
+                    return False
+
+                if stem in inc_stems and pub != inc_stems[stem]:
+                    # This entry is for a lower-ranked
+                    # publisher.
+                    return False
+
+                # XXX version should not require build release.
+                ever = pkg.version.Version(ver)
+
+                # If the entry's version is a successor to
+                # the incorporated version, then this is the
+                # 'newest' version of this package since
+                # entries are processed in descending version
+                # order.
+                iver = inc_vers[stem]
+                if ever.is_successor(iver, pkg.version.CONSTRAINT_AUTO):
+                    slist.add(stem)
+                    return True
+                return False
+
+            pkg_stem = "!".join((pub, stem))
+            if pkg_stem in nlist:
+                # A newer version has already been listed for
+                # this stem and publisher.
+                return False
+            return True
+
+        filter_cb = None
+        if inst_newest or upgradable or removable:
+            # Filtering needs to be applied.
+            filter_cb = check_state
+
+        excludes = self._img.list_excludes()
+        img_variants = self._img.get_variants()
+
+        if removable:
+            pkg_ref, pkg_optref = self.__get_pkg_refcounts(
+                pkg_cat, excludes, pubs
+            )
+
+        matched_pats = set()
+        pkg_matching_pats = None
+
+        # Retrieve only the newest package versions for LIST_NEWEST if
+        # none of the patterns have version information and variants are
+        # included.  (This cuts down on the number of entries that have
+        # to be filtered.)
+        use_last = newest and not pat_versioned and variants
+
+        if ranked:
+            # If caller requested results to be ranked by publisher,
+            # then the list of publishers to return must be passed
+            # to entry_actions() in rank order.
+            pub_ranks = self._img.get_publisher_ranks()
+            if not pubs:
+                # It's important that the list of possible
+                # publishers is gleaned from the catalog
+                # directly and not image configuration so
+                # that temporary sources (archives, etc.)
+                # work as expected.
+                pubs = pkg_cat.publishers()
+            for p in pubs:
+                pub_ranks.setdefault(p, (99, (p, False, False)))
+
+            def pub_key(a):
+                return (pub_ranks[a], a)
+
+            pubs = sorted(pubs, key=pub_key)
+
+        # Too many nested blocks;
+        # pylint: disable=R0101
+        ranked_stems = {}
+        for t, entry, actions in pkg_cat.entry_actions(
+            cat_info,
+            cb=filter_cb,
+            excludes=excludes,
+            last=use_last,
+            ordered=True,
+            pubs=pubs,
+        ):
+            pub, stem, ver = t
+
+            omit_ver = False
+            omit_package = None
+
+            pkg_stem = "!".join((pub, stem))
+            if newest and pkg_stem in nlist:
+                # A newer version has already been listed, so
+                # any additional entries need to be marked for
+                # omission before continuing.
+                omit_package = True
+            elif ranked and not patterns and ranked_stems.get(stem, pub) != pub:
+                # A different version from a higher-ranked
+                # publisher has been returned already, so skip
+                # this one.  This can only be done safely at
+                # this point if no patterns have been specified,
+                # since publisher-specific patterns override
+                # ranking behaviour.
+                omit_package = True
+            else:
+                nlist[pkg_stem] += 1
+
+            if raise_unmatched:
+                pkg_matching_pats = set()
+            if not omit_package:
+                ever = None
+                for pat in patterns:
+                    (pat_pub, pat_stem, pat_ver), matcher = pat_tuples[pat]
+
+                    if pat_pub is not None and pub != pat_pub:
+                        # Publisher doesn't match.
+                        if omit_package is None:
+                            omit_package = True
+                        continue
+                    elif (
+                        ranked
+                        and not pat_pub
+                        and ranked_stems.get(stem, pub) != pub
+                    ):
+                        # A different version from a
+                        # higher-ranked publisher has
+                        # been returned already, so skip
+                        # this one since no publisher
+                        # was specified for the pattern.
+                        if omit_package is None:
+                            omit_package = True
+                        continue
+
+                    if matcher == self.MATCH_EXACT:
+                        if pat_stem != stem:
+                            # Stem doesn't match.
+                            if omit_package is None:
+                                omit_package = True
+                            continue
+                    elif matcher == self.MATCH_FMRI:
+                        if not ("/" + stem).endswith("/" + pat_stem):
+                            # Stem doesn't match.
+                            if omit_package is None:
+                                omit_package = True
+                            continue
+                    elif matcher == self.MATCH_GLOB:
+                        if not fnmatch.fnmatchcase(stem, pat_stem):
+                            # Stem doesn't match.
+                            if omit_package is None:
+                                omit_package = True
+                            continue
+
+                    if pat_ver is not None:
+                        if ever is None:
+                            # Avoid constructing a
+                            # version object more
+                            # than once for each
+                            # entry.
+                            ever = pkg.version.Version(ver)
+                        if not ever.is_successor(
+                            pat_ver, pkg.version.CONSTRAINT_AUTO
+                        ):
+                            if omit_package is None:
+                                omit_package = True
+                            omit_ver = True
+                            continue
+
+                    if pat in latest_pats and nlist[pkg_stem] > 1:
+                        # Package allowed by pattern,
+                        # but isn't the "latest"
+                        # version.
+                        if omit_package is None:
+                            omit_package = True
+                        omit_ver = True
+                        continue
+
+                    # If this entry matched at least one
+                    # pattern, then ensure it is returned.
+                    omit_package = False
+                    if not raise_unmatched:
+                        # It's faster to stop as soon
+                        # as a match is found.
+                        break
+
+                    # If caller has requested other match
+                    # cases be raised as an exception, then
+                    # all patterns must be tested for every
+                    # entry.  This is slower, so only done
+                    # if necessary.
+                    pkg_matching_pats.add(pat)
+
+            if omit_package:
+                # Package didn't match critera; skip it.
+                if (
+                    (filter_cb is not None or (newest and pat_versioned))
+                    and omit_ver
+                    and nlist[pkg_stem] == 1
+                ):
+                    # If omitting because of version, and
+                    # no other versions have been returned
+                    # yet for this stem, then discard
+                    # tracking entry so that other
+                    # versions will be listed.
+                    del nlist[pkg_stem]
+                    slist.discard(stem)
+                continue
+
+            # Perform image arch and zone variant filtering so
+            # that only packages appropriate for this image are
+            # returned, but only do this for packages that are
+            # not installed.
+            pcats = []
+            pkgr = False
+            unsupported = False
+            summ = None
+            targets = set()
+
+            omit_var = False
+            mdata = entry["metadata"]
+            states = mdata["states"]
+            pkgi = pkgdefs.PKG_STATE_INSTALLED in states
+            ddm = lambda: collections.defaultdict(list)
+            attrs = collections.defaultdict(ddm)
+            try:
+                for a in actions:
+                    if a.name == "depend" and a.attrs["type"] == "require":
+                        targets.add(a.attrs["fmri"])
+                        continue
+                    if a.name != "set":
+                        continue
+
+                    atname = a.attrs["name"]
+                    atvalue = a.attrs["value"]
+                    if collect_attrs:
+                        atvlist = a.attrlist("value")
+
+                        # XXX Need to describe this data
+                        # structure sanely somewhere.
+                        mods = tuple(
+                            (k, tuple(sorted(a.attrlist(k))))
+                            for k in sorted(six.iterkeys(a.attrs))
+                            if k not in ("name", "value")
+                        )
+                        attrs[atname][mods].extend(atvlist)
+
+                    if atname == "pkg.summary":
+                        summ = atvalue
+                        continue
+
+                    if atname == "description":
+                        if summ is None:
+                            # Historical summary
+                            # field.
+                            summ = atvalue
+                            # pylint: disable=W0106
+                            collect_attrs and attrs["pkg.summary"][mods].extend(
+                                atvlist
+                            )
+                        continue
+
+                    if atname == "info.classification":
+                        pcats.extend(a.parse_category_info())
+
+                    if pkgi:
+                        # No filtering for installed
+                        # packages.
+                        continue
+
+                    # Rename filtering should only be
+                    # performed for incorporated packages
+                    # at this point.
+                    if atname == "pkg.renamed":
+                        if stem in inc_vers:
+                            pkgr = True
+                        continue
+
+                    if variants or not atname.startswith("variant."):
+                        # No variant filtering required.
+                        continue
+
+                    # For all variants explicitly set in the
+                    # image, elide packages that are not for
+                    # a matching variant value.
+                    is_list = type(atvalue) == list
+                    for vn, vv in six.iteritems(img_variants):
+                        if vn == atname and (
+                            (is_list and vv not in atvalue)
+                            or (not is_list and vv != atvalue)
+                        ):
+                            omit_package = True
+                            omit_var = True
+                            break
+            except apx.InvalidPackageErrors:
+                # Ignore errors for packages that have invalid
+                # or unsupported metadata.  This is necessary so
+                # that API consumers can discover new package
+                # data that may be needed to perform an upgrade
+                # so that the API can understand them.
+                states = set(states)
+                states.add(PackageInfo.UNSUPPORTED)
+                unsupported = True
+
+            if not pkgi and pkgr and stem in inc_vers:
+                # If the package is not installed, but this is
+                # the terminal version entry for the stem and
+                # it is an incorporated package, then omit the
+                # package if it has been installed or is
+                # incorporated using one of the new names.
+                for e in targets:
+                    tgt = e
+                    while tgt is not None:
+                        if tgt in ren_inst_stems or tgt in inc_vers:
+                            omit_package = True
+                            break
+                        tgt = ren_stems.get(tgt, None)
+
+            if omit_package:
+                # Package didn't match criteria; skip it.
+                if (
+                    (filter_cb is not None or newest)
+                    and omit_var
+                    and nlist[pkg_stem] == 1
+                ):
+                    # If omitting because of variant, and
+                    # no other versions have been returned
+                    # yet for this stem, then discard
+                    # tracking entry so that other
+                    # versions will be listed.
+                    del nlist[pkg_stem]
+                    slist.discard(stem)
+                continue
+
+            if cats is not None:
+                if not cats:
+                    if pcats:
+                        # Only want packages with no
+                        # categories.
+                        continue
+                elif not [sc for sc in cats if sc in pcats]:
+                    # Package doesn't match specified
+                    # category criteria.
+                    continue
+
+            if removable and stem in pkg_optref:
+                states.append(pkgdefs.PKG_STATE_OPTIONAL)
+
+            # Return the requested package data.
+            if not unsupported:
+                # Prevent modification of state data.
+                states = frozenset(states)
+
+            if raise_unmatched:
+                # Only after all other filtering has been
+                # applied are the patterns that the package
+                # matched considered "matching".
+                matched_pats.update(pkg_matching_pats)
+            if ranked:
+                # Only after all other filtering has been
+                # applied is the stem considered to have been
+                # a "ranked" match.
+                ranked_stems.setdefault(stem, pub)
+
+            if return_fmris:
+                pfmri = fmri.PkgFmri(name=stem, publisher=pub, version=ver)
+                if return_metadata:
+                    yield (pfmri, summ, pcats, states, attrs, mdata)
+                else:
+                    yield (pfmri, summ, pcats, states, attrs)
+            else:
+                if return_metadata:
+                    yield (t, summ, pcats, states, attrs, mdata)
+                else:
+                    yield (t, summ, pcats, states, attrs)
+
+        if raise_unmatched:
+            # Caller has requested that non-matching patterns or
+            # patterns that match multiple packages cause an
+            # exception to be raised.
+            notfound = set(pat_tuples.keys()) - matched_pats
+            if raise_unmatched and notfound:
+                raise apx.InventoryException(notfound=notfound)
+
+    @_LockedCancelable()
+    def info(self, fmri_strings, local, info_needed, ranked=False, repos=None):
+        """Gathers information about fmris.  fmri_strings is a list
+        of fmri_names for which information is desired.  local
+        determines whether to retrieve the information locally
+        (if possible).  It returns a dictionary of lists.  The keys
+        for the dictionary are the constants specified in the class
+        definition.  The values are lists of PackageInfo objects or
+        strings.
+
+        'ranked' is an optional boolean value that indicates whether
+        only the matching package versions from the highest-ranked
+        publisher should be returned.  This option is ignored for
+        patterns that explicitly specify the publisher to match.
+
+        'repos' is a list of URI strings or RepositoryURI objects that
+        represent the locations of packages to return information for.
+        """
+
+        bad_opts = info_needed - PackageInfo.ALL_OPTIONS
+        if bad_opts:
+            raise apx.UnrecognizedOptionsToInfo(bad_opts)
+
+        self.log_operation_start("info")
+
+        # Common logic for image and temp repos case.
+        if local:
+            ilist = self.LIST_INSTALLED
+        else:
+            # Verify validity of certificates before attempting
+            # network operations.
+            self.__cert_verify(log_op_end=[apx.CertificateError])
+            ilist = self.LIST_NEWEST
+
+        # The pkg_pub_map is only populated when temp repos are
+        # specified and maps packages to the repositories that
+        # contain them for manifest retrieval.
+        pkg_pub_map = None
+        known_cat = None
+        inst_cat = None
+        if repos:
+            pkg_pub_map, ignored, known_cat, inst_cat = self.__get_alt_pkg_data(
+                repos
+            )
+            if local:
+                pkg_cat = inst_cat
+            else:
+                pkg_cat = known_cat
+        elif local:
+            pkg_cat = self._img.get_catalog(self._img.IMG_CATALOG_INSTALLED)
+            if not fmri_strings and pkg_cat.package_count == 0:
+                self.log_operation_end(result=RESULT_NOTHING_TO_DO)
+                raise apx.NoPackagesInstalledException()
+        else:
+            pkg_cat = self._img.get_catalog(self._img.IMG_CATALOG_KNOWN)
+
+        excludes = self._img.list_excludes()
+
+        # Set of options that can use catalog data.
+        cat_opts = frozenset(
+            [PackageInfo.DESCRIPTION, PackageInfo.DEPENDENCIES]
+        )
+
+        # Set of options that require manifest retrieval.
+        act_opts = PackageInfo.ACTION_OPTIONS - frozenset(
+            [PackageInfo.DEPENDENCIES]
+        )
+
+        collect_attrs = PackageInfo.ALL_ATTRIBUTES in info_needed
+
+        pis = []
+        rval = {
+            self.INFO_FOUND: pis,
+            self.INFO_MISSING: misc.EmptyI,
+            self.INFO_ILLEGALS: misc.EmptyI,
+        }
+
+        try:
+            for (
+                pfmri,
+                summary,
+                cats,
+                states,
+                attrs,
+                mdata,
+            ) in self.__get_pkg_list(
+                ilist,
+                collect_attrs=collect_attrs,
+                inst_cat=inst_cat,
+                known_cat=known_cat,
+                patterns=fmri_strings,
+                raise_unmatched=True,
+                ranked=ranked,
+                return_fmris=True,
+                return_metadata=True,
+                variants=True,
+            ):
+                release = build_release = branch = packaging_date = None
+
+                pub, name, version = pfmri.tuple()
+                alt_pub = None
+                if pkg_pub_map:
+                    alt_pub = pkg_pub_map[pub][name][str(version)]
+
+                if PackageInfo.IDENTITY in info_needed:
+                    release = version.release
+                    build_release = version.build_release
+                    branch = version.branch
+                    packaging_date = version.get_timestamp().strftime("%c")
+                else:
+                    pub = name = version = None
+
+                links = (
+                    hardlinks
+                ) = (
+                    files
+                ) = (
+                    dirs
+                ) = csize = size = licenses = cat_info = description = None
+
+                if PackageInfo.CATEGORIES in info_needed:
+                    cat_info = [
+                        PackageCategory(scheme, cat) for scheme, cat in cats
+                    ]
+
+                ret_cat_data = cat_opts & info_needed
+                dependencies = None
+                unsupported = False
+                if ret_cat_data:
+                    try:
+                        (
+                            ignored,
+                            description,
+                            ignored,
+                            dependencies,
+                        ) = _get_pkg_cat_data(
+                            pkg_cat,
+                            ret_cat_data,
+                            excludes=excludes,
+                            pfmri=pfmri,
+                        )
+                    except apx.InvalidPackageErrors:
+                        # If the information can't be
+                        # retrieved because the manifest
+                        # can't be parsed, mark it and
+                        # continue.
+                        unsupported = True
+
+                if dependencies is None:
+                    dependencies = misc.EmptyI
+
+                mfst = None
+                if (
+                    not unsupported
+                    and (
+                        frozenset([PackageInfo.SIZE, PackageInfo.LICENSES])
+                        | act_opts
+                    )
+                    & info_needed
+                ):
+                    try:
+                        mfst = self._img.get_manifest(pfmri, alt_pub=alt_pub)
+                    except apx.InvalidPackageErrors:
+                        # If the information can't be
+                        # retrieved because the manifest
+                        # can't be parsed, mark it and
+                        # continue.
+                        unsupported = True
+
+                if mfst is not None:
+                    if PackageInfo.LICENSES in info_needed:
+                        licenses = self.__licenses(pfmri, mfst, alt_pub=alt_pub)
+
+                    if PackageInfo.SIZE in info_needed:
+                        size, csize = mfst.get_size(excludes=excludes)
+
+                    if act_opts & info_needed:
+                        if PackageInfo.LINKS in info_needed:
+                            links = list(
+                                mfst.gen_key_attribute_value_by_type(
+                                    "link", excludes
+                                )
+                            )
+                        if PackageInfo.HARDLINKS in info_needed:
+                            hardlinks = list(
+                                mfst.gen_key_attribute_value_by_type(
+                                    "hardlink", excludes
+                                )
+                            )
+                        if PackageInfo.FILES in info_needed:
+                            files = list(
+                                mfst.gen_key_attribute_value_by_type(
+                                    "file", excludes
+                                )
+                            )
+                        if PackageInfo.DIRS in info_needed:
+                            dirs = list(
+                                mfst.gen_key_attribute_value_by_type(
+                                    "dir", excludes
+                                )
+                            )
+                elif PackageInfo.SIZE in info_needed:
+                    size = csize = 0
+
+                # Trim response set.
+                last_install = None
+                last_update = None
+                if PackageInfo.STATE in info_needed:
+                    if (
+                        unsupported is True
+                        and PackageInfo.UNSUPPORTED not in states
+                    ):
+                        # Mark package as
+                        # unsupported so that
+                        # caller can decide
+                        # what to do.
+                        states = set(states)
+                        states.add(PackageInfo.UNSUPPORTED)
+
+                    if "last-update" in mdata:
+                        last_update = catalog.basic_ts_to_datetime(
+                            mdata["last-update"]
+                        ).strftime("%c")
+                    if "last-install" in mdata:
+                        last_install = catalog.basic_ts_to_datetime(
+                            mdata["last-install"]
+                        ).strftime("%c")
+                else:
+                    states = misc.EmptyI
+
+                if PackageInfo.CATEGORIES not in info_needed:
+                    cats = None
+                if PackageInfo.SUMMARY in info_needed:
+                    if summary is None:
+                        summary = ""
+                else:
+                    summary = None
+
+                pis.append(
+                    PackageInfo(
+                        pkg_stem=name,
+                        summary=summary,
+                        category_info_list=cat_info,
+                        states=states,
+                        publisher=pub,
+                        version=release,
+                        build_release=build_release,
+                        branch=branch,
+                        packaging_date=packaging_date,
+                        size=size,
+                        csize=csize,
+                        pfmri=pfmri,
+                        licenses=licenses,
+                        links=links,
+                        hardlinks=hardlinks,
+                        files=files,
+                        dirs=dirs,
+                        dependencies=dependencies,
+                        description=description,
+                        attrs=attrs,
+                        last_update=last_update,
+                        last_install=last_install,
+                    )
+                )
+        except apx.InventoryException as e:
+            if e.illegal:
+                self.log_operation_end(result=RESULT_FAILED_BAD_REQUEST)
+            rval[self.INFO_MISSING] = e.notfound
+            rval[self.INFO_ILLEGALS] = e.illegal
+        else:
+            if pis:
+                self.log_operation_end()
+            else:
+                self.log_operation_end(result=RESULT_NOTHING_TO_DO)
+        return rval
+
+    def can_be_canceled(self):
+        """Returns true if the API is in a cancelable state."""
+        return self.__can_be_canceled
+
+    def _disable_cancel(self):
+        """Sets_can_be_canceled to False in a way that prevents missed
+        wakeups.  This may raise CanceledException, if a
+        cancellation is pending."""
+
+        self.__cancel_lock.acquire()
+        if self.__canceling:
+            self.__cancel_lock.release()
+            self._img.transport.reset()
+            raise apx.CanceledException()
+        else:
+            self.__set_can_be_canceled(False)
+        self.__cancel_lock.release()
+
+    def _enable_cancel(self):
+        """Sets can_be_canceled to True while grabbing the cancel
+        locks.  The caller must still hold the activity lock while
+        calling this function."""
+
+        self.__cancel_lock.acquire()
+        self.__set_can_be_canceled(True)
+        self.__cancel_lock.release()
+
+    def __set_can_be_canceled(self, status):
+        """Private method. Handles the details of changing the
+        cancelable state."""
+        assert self.__cancel_lock._is_owned()
+
+        # If caller requests a change to current state there is
+        # nothing to do.
+        if self.__can_be_canceled == status:
+            return
+
+        if status:
+            # Callers must hold activity lock for operations
+            # that they will make cancelable.
+            assert self._activity_lock._is_owned()
+            # In any situation where the caller holds the activity
+            # lock and wants to set cancelable to true, a cancel
+            # should not already be in progress.  This is because
+            # it should not be possible to invoke cancel until
+            # this routine has finished.  Assert that we're not
+            # canceling.
+            assert not self.__canceling
+
+        self.__can_be_canceled = status
+        if self.__cancel_state_callable:
+            self.__cancel_state_callable(self.__can_be_canceled)
+
+    def reset(self):
+        """Resets the API back the initial state. Note:
+        this does not necessarily return the disk to its initial state
+        since the indexes or download cache may have been changed by
+        the prepare method."""
+        self._acquire_activity_lock()
+        self.__reset_unlock()
+        self._activity_lock.release()
+
+    def __reset_unlock(self):
+        """Private method. Provides a way to reset without taking the
+        activity lock. Should only be called by a thread which already
+        holds the activity lock."""
+
+        assert self._activity_lock._is_owned()
+
+        # This needs to be done first so that find_root can use it.
+        self.__progresstracker.reset()
+
+        # Ensure alternate sources are always cleared in an
+        # exception scenario.
+        self.__set_img_alt_sources(None)
+        self.__alt_sources = {}
+
+        self._img.cleanup_downloads()
+        # Cache transport statistics about problematic repo sources
+        repo_status = self._img.transport.repo_status
+        self._img.transport.shutdown()
+
+        # Recreate the image object using the path the api
+        # object was created with instead of the current path.
+        self._img = image.Image(
+            self._img_path,
+            progtrack=self.__progresstracker,
+            user_provided_dir=True,
+            cmdpath=self.cmdpath,
+        )
+        self._img.blocking_locks = self.__blocking_locks
+
+        self._img.transport.repo_status = repo_status
+
+        lin = None
+        if self._img.linked.ischild():
+            lin = self._img.linked.child_name
+        self.__progresstracker.set_linked_name(lin)
+
+        self.__plan_desc = None
+        self.__planned_children = False
+        self.__plan_type = None
+        self.__prepared = False
+        self.__executed = False
+        self.__be_name = None
+
+        self._cancel_cleanup_exception()
+
+    def __check_cancel(self):
+        """Private method. Provides a callback method for internal
+        code to use to determine whether the current action has been
+        canceled."""
+        return self.__canceling
+
+    def _cancel_cleanup_exception(self):
+        """A private method that is called from exception handlers.
+        This is not needed if the method calls reset unlock,
+        which will call this method too.  This catches the case
+        where a caller might have called cancel and gone to sleep,
+        but the requested operation failed with an exception before
+        it could raise a CanceledException."""
+
+        self.__cancel_lock.acquire()
+        self.__set_can_be_canceled(False)
+        self.__canceling = False
+        # Wake up any threads that are waiting on this aborted
+        # operation.
+        self.__cancel_cv.notify_all()
+        self.__cancel_lock.release()
+
+    def _cancel_done(self):
+        """A private method that wakes any threads that have been
+        sleeping, waiting for a cancellation to finish."""
+
+        self.__cancel_lock.acquire()
+        if self.__canceling:
+            self.__canceling = False
+            self.__cancel_cv.notify_all()
+        self.__cancel_lock.release()
+
+    def cancel(self):
+        """Used for asynchronous cancelation. It returns the API
+        to the state it was in prior to the current method being
+        invoked.  Canceling during a plan phase returns the API to
+        its initial state. Canceling during prepare puts the API
+        into the state it was in just after planning had completed.
+        Plan execution cannot be canceled. A call to this method blocks
+        until the cancellation has happened. Note: this does not
+        necessarily return the disk to its initial state since the
+        indexes or download cache may have been changed by the
+        prepare method."""
+
+        self.__cancel_lock.acquire()
+
+        if not self.__can_be_canceled:
+            self.__cancel_lock.release()
+            return False
+
+        self.__set_can_be_canceled(False)
+        self.__canceling = True
+        # Wait until the cancelled operation wakes us up.
+        self.__cancel_cv.wait()
+        self.__cancel_lock.release()
+        return True
+
+    def clear_history(self):
+        """Discard history information about in-progress operations."""
+        self._img.history.clear()
+
+    def __set_history_PlanCreationException(self, e):
+        if (
+            e.unmatched_fmris
+            or e.multiple_matches
+            or e.missing_matches
+            or e.illegal
+        ):
+            self.log_operation_end(error=e, result=RESULT_FAILED_BAD_REQUEST)
+        else:
+            self.log_operation_end(error=e)
+
+    @_LockedGenerator()
+    def local_search(self, query_lst):
+        """local_search takes a list of Query objects and performs
+        each query against the installed packages of the image."""
+
+        l = query_p.QueryLexer()
+        l.build()
+        qp = query_p.QueryParser(l)
+        ssu = None
+        for i, q in enumerate(query_lst):
+            try:
+                query = qp.parse(q.text)
+                query_rr = qp.parse(q.text)
+                if query_rr.remove_root(self._img.root):
+                    query.add_or(query_rr)
+                if q.return_type == query_p.Query.RETURN_PACKAGES:
+                    query.propagate_pkg_return()
+            except query_p.BooleanQueryException as e:
+                raise apx.BooleanQueryException(e)
+            except query_p.ParseError as e:
+                raise apx.ParseError(e)
+            self._img.update_index_dir()
+            assert self._img.index_dir
+            try:
+                query.set_info(
+                    num_to_return=q.num_to_return,
+                    start_point=q.start_point,
+                    index_dir=self._img.index_dir,
+                    get_manifest_path=self._img.get_manifest_path,
+                    gen_installed_pkg_names=self._img.gen_installed_pkg_names,
+                    case_sensitive=q.case_sensitive,
+                )
+                res = query.search(
+                    self._img.gen_installed_pkgs,
+                    self._img.get_manifest_path,
+                    self._img.list_excludes(),
+                )
+            except search_errors.InconsistentIndexException as e:
+                raise apx.InconsistentIndexException(e)
+            # i is being inserted to track which query the results
+            # are for.  None is being inserted since there is no
+            # publisher being searched against.
+            try:
+                for r in res:
+                    yield i, None, r
+            except apx.SlowSearchUsed as e:
+                ssu = e
+        if ssu:
+            raise ssu
+
+    @staticmethod
+    def __parse_v_0(line, pub, v):
+        """This function parses the string returned by a version 0
+        search server and puts it into the expected format of
+        (query_number, publisher, (version, return_type, (results))).
+
+        "query_number" in the return value is fixed at 0 since search
+        v0 servers cannot accept multiple queries in a single HTTP
+        request."""
+
+        line = line.strip()
+        fields = line.split(None, 3)
+        return (0, pub, (v, Query.RETURN_ACTIONS, (fields[:4])))
+
+    @staticmethod
+    def __parse_v_1(line, pub, v):
+        """This function parses the string returned by a version 1
+        search server and puts it into the expected format of
+        (query_number, publisher, (version, return_type, (results)))
+        If it receives a line it can't parse, it raises a
+        ServerReturnError."""
+
+        fields = line.split(None, 2)
+        if len(fields) != 3:
+            raise apx.ServerReturnError(line)
+        try:
+            return_type = int(fields[1])
+            query_num = int(fields[0])
+        except ValueError:
+            raise apx.ServerReturnError(line)
+        if return_type == Query.RETURN_ACTIONS:
+            subfields = fields[2].split(None, 2)
+            pfmri = fmri.PkgFmri(subfields[0])
+            return pfmri, (
+                query_num,
+                pub,
+                (v, return_type, (pfmri, unquote(subfields[1]), subfields[2])),
+            )
+        elif return_type == Query.RETURN_PACKAGES:
+            pfmri = fmri.PkgFmri(fields[2])
+            return pfmri, (query_num, pub, (v, return_type, pfmri))
+        else:
+            raise apx.ServerReturnError(line)
+
+    @_LockedGenerator()
+    def remote_search(
+        self, query_str_and_args_lst, servers=None, prune_versions=True
+    ):
+        """This function takes a list of Query objects, and optionally
+        a list of servers to search against.  It performs each query
+        against each server and yields the results in turn.  If no
+        servers are provided, the search is conducted against all
+        active servers known by the image.
+
+        The servers argument is a list of servers in two possible
+        forms: the old deprecated form of a publisher, in a
+        dictionary, or a Publisher object.
+
+        A call to this function returns a generator that holds
+        API locks.  Callers must either iterate through all of the
+        results, or call close() on the resulting object.  Otherwise
+        it is possible to get deadlocks or NRLock reentrance
+        exceptions."""
+
+        failed = []
+        invalid = []
+        unsupported = []
+
+        if not servers:
+            servers = self._img.gen_publishers()
+
+        new_qs = []
+        l = query_p.QueryLexer()
+        l.build()
+        qp = query_p.QueryParser(l)
+        for q in query_str_and_args_lst:
+            try:
+                query = qp.parse(q.text)
+                query_rr = qp.parse(q.text)
+                if query_rr.remove_root(self._img.root):
+                    query.add_or(query_rr)
+                if q.return_type == query_p.Query.RETURN_PACKAGES:
+                    query.propagate_pkg_return()
+                new_qs.append(
+                    query_p.Query(
+                        str(query),
+                        q.case_sensitive,
+                        q.return_type,
+                        q.num_to_return,
+                        q.start_point,
+                    )
+                )
+            except query_p.BooleanQueryException as e:
+                raise apx.BooleanQueryException(e)
+            except query_p.ParseError as e:
+                raise apx.ParseError(e)
+
+        query_str_and_args_lst = new_qs
+
+        incorp_info, inst_stems = self.get_incorp_info()
+
+        slist = []
+        for entry in servers:
+            if isinstance(entry, dict):
+                origin = entry["origin"]
+                try:
+                    pub = self._img.get_publisher(origin=origin)
+                    pub_uri = publisher.RepositoryURI(origin)
+                    repo = publisher.Repository(origins=[pub_uri])
+                except apx.UnknownPublisher:
+                    pub = publisher.RepositoryURI(origin)
+                    repo = publisher.Repository(origins=[pub])
+                slist.append((pub, repo, origin))
+                continue
+
+            # Must be a publisher object.
+            osets = entry.get_origin_sets()
+            if not osets:
+                continue
+            for repo in osets:
+                slist.append((entry, repo, entry.prefix))
+
+        for pub, alt_repo, descriptive_name in slist:
+            if self.__canceling:
+                raise apx.CanceledException()
+
+            try:
+                res = self._img.transport.do_search(
+                    pub,
+                    query_str_and_args_lst,
+                    ccancel=self.__check_cancel,
+                    alt_repo=alt_repo,
+                )
+            except apx.CanceledException:
+                raise
+            except apx.NegativeSearchResult:
+                continue
+            except (apx.InvalidDepotResponseException, apx.TransportError) as e:
+                # Alternate source failed portal test or can't
+                # be contacted at all.
+                failed.append((descriptive_name, e))
+                continue
+            except apx.UnsupportedSearchError as e:
+                unsupported.append((descriptive_name, e))
+                continue
+            except apx.MalformedSearchRequest as e:
+                ex = self._validate_search(query_str_and_args_lst)
+                if ex:
+                    raise ex
+                failed.append((descriptive_name, e))
+                continue
+
+            try:
+                if not self.validate_response(res, 1):
+                    invalid.append(descriptive_name)
+                    continue
+                for line in res:
+                    pfmri, ret = self.__parse_v_1(line, pub, 1)
+                    pstem = pfmri.pkg_name
+                    pver = pfmri.version
+                    # Skip this package if a newer version
+                    # is already installed and version
+                    # pruning is enabled.
+                    if (
+                        prune_versions
+                        and pstem in inst_stems
+                        and pver < inst_stems[pstem]
+                    ):
+                        continue
+                    # Return this result if version pruning
+                    # is disabled, the package is not
+                    # incorporated, or the version of the
+                    # package matches the incorporation.
+                    if (
+                        not prune_versions
+                        or pstem not in incorp_info
+                        or pfmri.version.is_successor(
+                            incorp_info[pstem], pkg.version.CONSTRAINT_AUTO
+                        )
+                    ):
+                        yield ret
+
+            except apx.CanceledException:
+                raise
+            except apx.TransportError as e:
+                failed.append((descriptive_name, e))
+                continue
+
+        if failed or invalid or unsupported:
+            raise apx.ProblematicSearchServers(failed, invalid, unsupported)
+
+    def get_incorp_info(self):
+        """This function returns a mapping of package stems to the
+        version at which they are incorporated, if they are
+        incorporated, and the version at which they are installed, if
+        they are installed."""
+
+        # This maps fmris to the version at which they're incorporated.
+        inc_vers = {}
+        inst_stems = {}
+
+        img_cat = self._img.get_catalog(self._img.IMG_CATALOG_INSTALLED)
+        cat_info = frozenset([img_cat.DEPENDENCY])
+
+        # The incorporation list should include all installed,
+        # incorporated packages from all publishers.
+        for pfmri, actions in img_cat.actions(cat_info):
+            inst_stems[pfmri.pkg_name] = pfmri.version
+            for a in actions:
+                if a.name != "depend" or a.attrs["type"] != "incorporate":
+                    continue
+                # Record incorporated packages.
+                tgt = fmri.PkgFmri(a.attrs["fmri"])
+                tver = tgt.version
+                # incorporates without a version should be
+                # ignored.
+                if not tver:
+                    continue
+                over = inc_vers.get(tgt.pkg_name, None)
+
+                # In case this package has been
+                # incorporated more than once,
+                # use the newest version.
+                if over > tver:
+                    continue
+                inc_vers[tgt.pkg_name] = tver
+        return inc_vers, inst_stems
+
+    @staticmethod
+    def __unconvert_return_type(v):
+        return v == query_p.Query.RETURN_ACTIONS
+
+    def _validate_search(self, query_str_lst):
+        """Called by remote search if server responds that the
+        request was invalid.  In this case, parse the query on
+        the client-side and determine what went wrong."""
+
+        for q in query_str_lst:
+            l = query_p.QueryLexer()
+            l.build()
+            qp = query_p.QueryParser(l)
+            try:
+                query = qp.parse(q.text)
+            except query_p.BooleanQueryException as e:
+                return apx.BooleanQueryException(e)
+            except query_p.ParseError as e:
+                return apx.ParseError(e)
+
+        return None
+
+    def rebuild_search_index(self):
+        """Rebuilds the search indexes.  Removes all
+        existing indexes and replaces them from scratch rather than
+        performing the incremental update which is usually used.
+        This is useful for times when the index for the client has
+        been corrupted."""
+        self._img.update_index_dir()
+        self.log_operation_start("rebuild-index")
+        if not os.path.isdir(self._img.index_dir):
+            self._img.mkdirs()
+        try:
+            ind = indexer.Indexer(
+                self._img,
+                self._img.get_manifest,
+                self._img.get_manifest_path,
+                self.__progresstracker,
+                self._img.list_excludes(),
+            )
+            ind.rebuild_index_from_scratch(self._img.gen_installed_pkgs())
+        except search_errors.ProblematicPermissionsIndexException as e:
+            error = apx.ProblematicPermissionsIndexException(e)
+            self.log_operation_end(error=error)
+            raise error
+        else:
+            self.log_operation_end()
+
+    def get_manifest(self, pfmri, all_variants=True, repos=None):
+        """Returns the Manifest object for the given package FMRI.
+
+        'all_variants' is an optional boolean value indicating whther
+        the manifest should include metadata for all variants and
+        facets.
+
+        'repos' is a list of URI strings or RepositoryURI objects that
+        represent the locations of additional sources of package data to
+        use during the planned operation.
+        """
+
+        alt_pub = None
+        if repos:
+            pkg_pub_map, ignored, known_cat, inst_cat = self.__get_alt_pkg_data(
+                repos
+            )
+            alt_pub = (
+                pkg_pub_map.get(pfmri.publisher, {})
+                .get(pfmri.pkg_name, {})
+                .get(str(pfmri.version), None)
+            )
+        return self._img.get_manifest(
+            pfmri, ignore_excludes=all_variants, alt_pub=alt_pub
+        )
+
+    @staticmethod
+    def validate_response(res, v):
+        """This function is used to determine whether the first
+        line returned from a server is expected.  This ensures that
+        search is really communicating with a search-enabled server."""
+
+        try:
+            s = next(res)
+            return s == Query.VALIDATION_STRING[v]
+        except StopIteration:
+            return False
+
+    def add_publisher(
+        self,
+        pub,
+        refresh_allowed=True,
+        approved_cas=misc.EmptyI,
+        revoked_cas=misc.EmptyI,
+        search_after=None,
+        search_before=None,
+        search_first=None,
+        unset_cas=misc.EmptyI,
+    ):
+        """Add the provided publisher object to the image
+        configuration."""
+        try:
+            self._img.add_publisher(
+                pub,
+                refresh_allowed=refresh_allowed,
+                progtrack=self.__progresstracker,
+                approved_cas=approved_cas,
+                revoked_cas=revoked_cas,
+                search_after=search_after,
+                search_before=search_before,
+                search_first=search_first,
+                unset_cas=unset_cas,
+            )
+        finally:
+            self._img.cleanup_downloads()
+
+    def get_highest_ranked_publisher(self):
+        """Returns the highest ranked publisher object for the image."""
+        return self._img.get_highest_ranked_publisher()
+
+    def get_publisher(self, prefix=None, alias=None, duplicate=False):
+        """Retrieves a publisher object matching the provided prefix
+        (name) or alias.
+
+        'duplicate' is an optional boolean value indicating whether
+        a copy of the publisher object should be returned instead
+        of the original.
+        """
+        pub = self._img.get_publisher(prefix=prefix, alias=alias)
+        if duplicate:
+            # Never return the original so that changes to the
+            # retrieved object are not reflected until
+            # update_publisher is called.
+            return copy.copy(pub)
+        return pub
+
+    @_LockedCancelable()
+    def get_publisherdata(self, pub=None, repo=None):
+        """Attempts to retrieve publisher configuration information from
+        the specified publisher's repository or the provided repository.
+        If successful, it will either return an empty list (in the case
+        that the repository supports the operation, but doesn't offer
+        configuration information) or a list of Publisher objects.
+        If this operation is not supported by the publisher or the
+        specified repository, an UnsupportedRepositoryOperation
+        exception will be raised.
+
+        'pub' is an optional Publisher object.
+
+        'repo' is an optional RepositoryURI object.
+
+        Either 'pub' or 'repo' must be provided."""
+
+        assert (pub or repo) and not (pub and repo)
+
+        # Transport accepts either type of object, but a distinction is
+        # made in the client API for clarity.
+        pub = max(pub, repo)
+
+        return self._img.transport.get_publisherdata(
+            pub, ccancel=self.__check_cancel
+        )
+
+    def get_publishers(self, duplicate=False):
+        """Returns a list of the publisher objects for the current
+        image.
+
+        'duplicate' is an optional boolean value indicating whether
+        copies of the publisher objects should be returned instead
+        of the originals.
+        """
+
+        res = self._img.get_sorted_publishers()
+        if duplicate:
+            return [copy.copy(p) for p in res]
+        return res
+
+    def get_publisher_last_update_time(self, prefix=None, alias=None):
+        """Returns a datetime object representing the last time the
+        catalog for a publisher was modified or None."""
+
+        if alias:
+            pub = self.get_publisher(alias=alias)
+        else:
+            pub = self.get_publisher(prefix=prefix)
+
+        if pub.disabled:
+            return None
+
+        dt = None
+        self._acquire_activity_lock()
+        try:
+            self._enable_cancel()
+            try:
+                dt = pub.catalog.last_modified
+            except:
+                self.__reset_unlock()
+                raise
+            try:
+                self._disable_cancel()
+            except apx.CanceledException:
+                self._cancel_done()
+                raise
+        finally:
+            self._activity_lock.release()
+        return dt
+
+    def has_publisher(self, prefix=None, alias=None):
+        """Returns a boolean value indicating whether a publisher using
+        the given prefix or alias exists."""
+        return self._img.has_publisher(prefix=prefix, alias=alias)
+
+    def remove_publisher(self, prefix=None, alias=None):
+        """Removes a publisher object matching the provided prefix
+        (name) or alias."""
+        self._img.remove_publisher(
+            prefix=prefix, alias=alias, progtrack=self.__progresstracker
+        )
+
+        self.__remove_unused_client_certificates()
+
+    def update_publisher(
+        self,
+        pub,
+        refresh_allowed=True,
+        search_after=None,
+        search_before=None,
+        search_first=None,
+    ):
+        """Replaces an existing publisher object with the provided one
+        using the _source_object_id identifier set during copy.
+
+        'refresh_allowed' is an optional boolean value indicating
+        whether a refresh of publisher metadata (such as its catalog)
+        should be performed if transport information is changed for a
+        repository, mirror, or origin.  If False, no attempt will be
+        made to retrieve publisher metadata."""
+
+        self._acquire_activity_lock()
+        try:
+            self._disable_cancel()
+            with self._img.locked_op("update-publisher"):
+                return self.__update_publisher(
+                    pub,
+                    refresh_allowed=refresh_allowed,
+                    search_after=search_after,
+                    search_before=search_before,
+                    search_first=search_first,
+                )
+        except apx.CanceledException as e:
+            self._cancel_done()
+            raise
+        finally:
+            self._img.cleanup_downloads()
+            self._activity_lock.release()
+
+    def __update_publisher(
+        self,
+        pub,
+        refresh_allowed=True,
+        search_after=None,
+        search_before=None,
+        search_first=None,
+    ):
+        """Private publisher update method; caller responsible for
+        locking."""
+
+        assert (
+            (not search_after and not search_before)
+            or (not search_after and not search_first)
+            or (not search_before and not search_first)
+        )
+
+        # Before continuing, validate SSL information.
+        try:
+            self._img.check_cert_validity(pubs=[pub])
+        except apx.ExpiringCertificate as e:
+            logger.warning(str(e))
+
+        def origins_changed(oldr, newr):
+            old_origins = set(
+                [
+                    (
+                        o.uri,
+                        o.ssl_cert,
+                        o.ssl_key,
+                        tuple(sorted(o.proxies)),
+                        o.disabled,
+                    )
+                    for o in oldr.origins
+                ]
+            )
+            new_origins = set(
+                [
+                    (
+                        o.uri,
+                        o.ssl_cert,
+                        o.ssl_key,
+                        tuple(sorted(o.proxies)),
+                        o.disabled,
+                    )
+                    for o in newr.origins
+                ]
+            )
+            return (
+                new_origins - old_origins
+            ), new_origins.symmetric_difference(old_origins)
+
+        def need_refresh(oldo, newo):
+            if newo.disabled:
+                # The publisher is disabled, so no refresh
+                # should be performed.
+                return False
+
+            if oldo.disabled and not newo.disabled:
+                # The publisher has been re-enabled, so
+                # retrieve the catalog.
+                return True
+
+            oldr = oldo.repository
+            newr = newo.repository
+            if newr._source_object_id != id(oldr):
+                # Selected repository has changed.
+                return True
+            # If any were added or removed, refresh.
+            return len(origins_changed(oldr, newr)[1]) != 0
+
+        refresh_catalog = False
+        disable = False
+        orig_pub = None
+
+        # Configuration must be manipulated directly.
+        publishers = self._img.cfg.publishers
+
+        # First, attempt to match the updated publisher object to an
+        # existing one using the object id that was stored during
+        # copy().
+        for key, old in six.iteritems(publishers):
+            if pub._source_object_id == id(old):
+                # Store the new publisher's id and the old
+                # publisher object so it can be restored if the
+                # update operation fails.
+                orig_pub = (id(pub), old)
+                break
+
+        if not orig_pub:
+            # If a matching publisher couldn't be found and
+            # replaced, something is wrong (client api usage
+            # error).
+            raise apx.UnknownPublisher(pub)
+
+        # Next, be certain that the publisher's prefix and alias
+        # are not already in use by another publisher.
+        for key, old in six.iteritems(publishers):
+            if pub._source_object_id == id(old):
+                # Don't check the object we're replacing.
+                continue
+
+            if (
+                pub.prefix == old.prefix
+                or pub.prefix == old.alias
+                or pub.alias
+                and (pub.alias == old.alias or pub.alias == old.prefix)
+            ):
+                raise apx.DuplicatePublisher(pub)
+
+        # Next, determine what needs updating and add the updated
+        # publisher.
+        for key, old in six.iteritems(publishers):
+            if pub._source_object_id == id(old):
+                old = orig_pub[-1]
+                if need_refresh(old, pub):
+                    refresh_catalog = True
+                if not old.disabled and pub.disabled:
+                    disable = True
+
+                # Now remove the old publisher object using the
+                # iterator key if the prefix has changed.
+                if key != pub.prefix:
+                    del publishers[key]
+
+                # Prepare the new publisher object.
+                pub.meta_root = self._img._get_publisher_meta_root(pub.prefix)
+                pub.transport = self._img.transport
+
+                # Finally, add the new publisher object.
+                publishers[pub.prefix] = pub
+                break
+
+        def cleanup():
+            # Attempting to unpack a non-sequence%s;
+            # pylint: disable=W0633
+            new_id, old_pub = orig_pub
+            for new_pfx, new_pub in six.iteritems(publishers):
+                if id(new_pub) == new_id:
+                    publishers[old_pub.prefix] = old_pub
+                    break
+
+        repo = pub.repository
+
+        validate = origins_changed(orig_pub[-1].repository, pub.repository)[0]
+
+        try:
+            if disable or (
+                not repo.origins and orig_pub[-1].repository.origins
+            ):
+                # Remove the publisher's metadata (such as
+                # catalogs, etc.).  This only needs to be done
+                # in the event that a publisher is disabled or
+                # has transitioned from having origins to not
+                # having any at all; in any other case (the
+                # origins changing, etc.), refresh() will do the
+                # right thing.
+                self._img.remove_publisher_metadata(pub)
+            elif not pub.disabled and not refresh_catalog:
+                refresh_catalog = pub.needs_refresh
+
+            if refresh_catalog and refresh_allowed:
+                # One of the publisher's repository origins may
+                # have changed, so the publisher needs to be
+                # revalidated.
+
+                if validate:
+                    self._img.transport.valid_publisher_test(pub)
+
+                # Validate all new origins against publisher
+                # configuration.
+                for uri, ssl_cert, ssl_key, proxies, disabled in validate:
+                    repo = publisher.RepositoryURI(
+                        uri,
+                        ssl_cert=ssl_cert,
+                        ssl_key=ssl_key,
+                        proxies=proxies,
+                        disabled=disabled,
+                    )
+                    pub.validate_config(repo)
+
+                self.__refresh(
+                    pubs=[pub], immediate=True, ignore_unreachable=False
+                )
+            elif refresh_catalog:
+                # Something has changed (such as a repository
+                # origin) for the publisher, so a refresh should
+                # occur, but isn't currently allowed.  As such,
+                # clear the last_refreshed time so that the next
+                # time the client checks to see if a refresh is
+                # needed and is allowed, one will be performed.
+                pub.last_refreshed = None
+        except Exception as e:
+            # If any of the above fails, the original publisher
+            # information needs to be restored so that state is
+            # consistent.
+            cleanup()
+            raise
+        except:
+            # If any of the above fails, the original publisher
+            # information needs to be restored so that state is
+            # consistent.
+            cleanup()
+            raise
+
+        if search_first:
+            self._img.set_highest_ranked_publisher(prefix=pub.prefix)
+        elif search_before:
+            self._img.pub_search_before(pub.prefix, search_before)
+        elif search_after:
+            self._img.pub_search_after(pub.prefix, search_after)
+
+        # Successful; so save configuration.
+        self._img.save_config()
+
+        self.__remove_unused_client_certificates()
+
+    def __remove_unused_client_certificates(self):
+        """Remove unused client certificate files"""
+
+        # Get certificate files currently in use.
+        ssl_path = os.path.join(self._img.imgdir, "ssl")
+        current_file_list = set()
+        pubs = self._img.get_publishers()
+        for p in pubs:
+            pub = pubs[p]
+            for origin in pub.repository.origins:
+                current_file_list.add(origin.ssl_key)
+                current_file_list.add(origin.ssl_cert)
+
+        # Remove files found in ssl directory that
+        # are not in use by publishers.
+        for f in os.listdir(ssl_path):
+            path = os.path.join(ssl_path, f)
+            if path not in current_file_list:
+                try:
+                    portable.remove(path)
+                except:
+                    continue
+
+    def log_operation_end(self, error=None, result=None, release_notes=None):
+        """Marks the end of an operation to be recorded in image
+        history.
+
+        'result' should be a pkg.client.history constant value
+        representing the outcome of an operation.  If not provided,
+        and 'error' is provided, the final result of the operation will
+        be based on the class of 'error' and 'error' will be recorded
+        for the current operation.  If 'result' and 'error' is not
+        provided, success is assumed."""
+        self._img.history.log_operation_end(
+            error=error, result=result, release_notes=release_notes
+        )
+
+    def log_operation_error(self, error):
+        """Adds an error to the list of errors to be recorded in image
+        history for the current opreation."""
+        self._img.history.log_operation_error(error)
+
+    def log_operation_start(self, name):
+        """Marks the start of an operation to be recorded in image
+        history."""
+        # If an operation is going to be discarded, then don't take the
+        # performance hit of actually getting the BE info.
+        if name in history.DISCARDED_OPERATIONS:
+            be_name, be_uuid = None, None
+        else:
+            be_name, be_uuid = bootenv.BootEnv.get_be_name(self._img.root)
+        self._img.history.log_operation_start(
+            name, be_name=be_name, be_uuid=be_uuid
+        )
+
+    def parse_liname(self, name, unknown_ok=False):
+        """Parse a linked image name string and return a
+        LinkedImageName object.  If "unknown_ok" is true then
+        liname must correspond to an existing linked image.  If
+        "unknown_ok" is false and liname doesn't correspond to
+        an existing linked image then liname must be a
+        syntactically valid and fully qualified linked image
+        name."""
+
+        return self._img.linked.parse_name(name, unknown_ok=unknown_ok)
+
+    def parse_p5i(self, data=None, fileobj=None, location=None):
+        """Reads the pkg(7) publisher JSON formatted data at 'location'
+        or from the provided file-like object 'fileobj' and returns a
+        list of tuples of the format (publisher object, pkg_names).
+        pkg_names is a list of strings representing package names or
+        FMRIs.  If any pkg_names not specific to a publisher were
+        provided, the last tuple returned will be of the format (None,
+        pkg_names).
+
+        'data' is an optional string containing the p5i data.
+
+        'fileobj' is an optional file-like object that must support a
+        'read' method for retrieving data.
+
+        'location' is an optional string value that should either start
+        with a leading slash and be pathname of a file or a URI string.
+        If it is a URI string, supported protocol schemes are 'file',
+        'ftp', 'http', and 'https'.
+
+        'data' or 'fileobj' or 'location' must be provided."""
+
+        return p5i.parse(data=data, fileobj=fileobj, location=location)
+
+    def parse_fmri_patterns(self, patterns):
+        """A generator function that yields a list of tuples of the form
+        (pattern, error, fmri, matcher) based on the provided patterns,
+        where 'error' is any exception encountered while parsing the
+        pattern, 'fmri' is the resulting FMRI object, and 'matcher' is
+        one of the following constant values:
+
+                MATCH_EXACT
+                        Indicates that the name portion of the pattern
+                        must match exactly and the version (if provided)
+                        must be considered a successor or equal to the
+                        target FMRI.
+
+                MATCH_FMRI
+                        Indicates that the name portion of the pattern
+                        must be a proper subset and the version (if
+                        provided) must be considered a successor or
+                        equal to the target FMRI.
+
+                MATCH_GLOB
+                        Indicates that the name portion of the pattern
+                        uses fnmatch rules for pattern matching (shell-
+                        style wildcards) and that the version can either
+                        match exactly, match partially, or contain
+                        wildcards.
+        """
+
+        for pat in patterns:
+            error = None
+            matcher = None
+            npat = None
+            try:
+                parts = pat.split("@", 1)
+                pat_stem = parts[0]
+                pat_ver = None
+                if len(parts) > 1:
+                    pat_ver = parts[1]
+
+                if "*" in pat_stem or "?" in pat_stem:
+                    matcher = self.MATCH_GLOB
+                elif pat_stem.startswith("pkg:/") or pat_stem.startswith("/"):
+                    matcher = self.MATCH_EXACT
+                else:
+                    matcher = self.MATCH_FMRI
+
+                if matcher == self.MATCH_GLOB:
+                    npat = fmri.MatchingPkgFmri(pat_stem)
+                else:
+                    npat = fmri.PkgFmri(pat_stem)
+
+                if not pat_ver:
+                    # Do nothing.
+                    pass
+                elif "*" in pat_ver or "?" in pat_ver or pat_ver == "latest":
+                    npat.version = pkg.version.MatchingVersion(pat_ver)
+                else:
+                    npat.version = pkg.version.Version(pat_ver)
+
+            except (fmri.FmriError, pkg.version.VersionError) as e:
+                # Whatever the error was, return it.
+                error = e
+            yield (pat, error, npat, matcher)
+
+    def purge_history(self):
+        """Deletes all client history."""
+        be_name, be_uuid = bootenv.BootEnv.get_be_name(self._img.root)
+        self._img.history.purge(be_name=be_name, be_uuid=be_uuid)
+
+    def update_format(self):
+        """Attempt to update the on-disk format of the image to the
+        newest version.  Returns a boolean indicating whether any action
+        was taken."""
+
+        self._acquire_activity_lock()
+        try:
+            self._disable_cancel()
+            self._img.allow_ondisk_upgrade = True
+            return self._img.update_format(progtrack=self.__progresstracker)
+        except apx.CanceledException as e:
+            self._cancel_done()
+            raise
+        finally:
+            self._activity_lock.release()
+
+    def write_p5i(self, fileobj, pkg_names=None, pubs=None):
+        """Writes the publisher, repository, and provided package names
+        to the provided file-like object 'fileobj' in JSON p5i format.
+
+        'fileobj' is only required to have a 'write' method that accepts
+        data to be written as a parameter.
+
+        'pkg_names' is a dict of lists, tuples, or sets indexed by
+        publisher prefix that contain package names, FMRI strings, or
+        package info objects.  A prefix of "" can be used for packages
+        that are not specific to a publisher.
+
+        'pubs' is an optional list of publisher prefixes or Publisher
+        objects.  If not provided, the information for all publishers
+        (excluding those disabled) will be output."""
+
+        if not pubs:
+            plist = [p for p in self.get_publishers() if not p.disabled]
+        else:
+            plist = []
+            for p in pubs:
+                if not isinstance(p, publisher.Publisher):
+                    plist.append(self._img.get_publisher(prefix=p, alias=p))
+                else:
+                    plist.append(p)
+
+        # Transform PackageInfo object entries into PkgFmri entries
+        # before passing them to the p5i module.
+        new_pkg_names = {}
+        for pub in pkg_names:
+            pkglist = []
+            for p in pkg_names[pub]:
+                if isinstance(p, PackageInfo):
+                    pkglist.append(p.fmri)
+                else:
+                    pkglist.append(p)
+            new_pkg_names[pub] = pkglist
+        p5i.write(fileobj, plist, pkg_names=new_pkg_names)
+
+    def write_syspub(self, path, prefixes, version):
+        """Write the syspub/version response to the provided path."""
+        if version != 0:
+            raise apx.UnsupportedP5SVersion(version)
+
+        pubs = [p for p in self.get_publishers() if p.prefix in prefixes]
+        fd, fp = tempfile.mkstemp()
+        try:
+            fh = os.fdopen(fd, "w")
+            p5s.write(fh, pubs, self._img.cfg)
+            fh.close()
+            portable.rename(fp, path)
+        except:
+            if os.path.exists(fp):
+                portable.remove(fp)
+            raise
+
+    def get_dehydrated_publishers(self):
+        """Return the list of dehydrated publishers' prefixes."""
+
+        return self._img.cfg.get_property("property", "dehydrated")
+
+
+class Query(query_p.Query):
+    """This class is the object used to pass queries into the api functions.
+    It encapsulates the possible options available for a query as well as
+    the text of the query itself."""
+
+    def __init__(
+        self,
+        text,
+        case_sensitive,
+        return_actions=True,
+        num_to_return=None,
+        start_point=None,
+    ):
+        if return_actions:
+            return_type = query_p.Query.RETURN_ACTIONS
+        else:
+            return_type = query_p.Query.RETURN_PACKAGES
+        try:
+            query_p.Query.__init__(
+                self,
+                text,
+                case_sensitive,
+                return_type,
+                num_to_return,
+                start_point,
+            )
+        except query_p.QueryLengthExceeded as e:
+            raise apx.ParseError(e)
+
+
+def get_default_image_root(orig_cwd=None):
+    """Returns a tuple of (root, exact_match) where 'root' is the absolute
+    path of the default image root based on current environment given the
+    client working directory and platform defaults, and 'exact_match' is a
+    boolean specifying how the default should be treated by ImageInterface.
+    Note that the root returned may not actually be the valid root of an
+    image; it is merely the default location a client should use when
+    initializing an ImageInterface (e.g. '/' is not a valid image on Solaris
+    10).
+
+    The ImageInterface object will use the root provided as a starting point
+    to find an image, searching upwards through each parent directory until
+    '/' is reached based on the value of exact_match.
+
+    'orig_cwd' should be the original current working directory at the time
+    of client startup.  This value is assumed to be valid if provided,
+    although permission and access errors will be gracefully handled.
+    """
+
+    # If an image location wasn't explicitly specified, check $PKG_IMAGE in
+    # the environment.
+    root = os.environ.get("PKG_IMAGE")
+    exact_match = True
+    if not root:
+        if os.environ.get("PKG_FIND_IMAGE") or portable.osname != "sunos":
+            # If no image location was found in the environment,
+            # then see if user enabled finding image or if current
+            # platform isn't Solaris.  If so, attempt to find the
+            # image starting with the working directory.
+            root = orig_cwd
+            if root:
+                exact_match = False
+        if not root:
+            # If no image directory has been determined based on
+            # request or environment, default to live root.
+            root = misc.liveroot()
+    return root, exact_match
+
+
+def image_create(
+    pkg_client_name,
+    version_id,
+    root,
+    imgtype,
+    is_zone,
+    cancel_state_callable=None,
+    facets=misc.EmptyDict,
+    force=False,
+    mirrors=misc.EmptyI,
+    origins=misc.EmptyI,
+    prefix=None,
+    refresh_allowed=True,
+    repo_uri=None,
+    ssl_cert=None,
+    ssl_key=None,
+    user_provided_dir=False,
+    progtrack=None,
+    variants=misc.EmptyDict,
+    props=misc.EmptyDict,
+    cmdpath=None,
+):
+    """Creates an image at the specified location.
+
+    'pkg_client_name' is a string containing the name of the client,
+    such as "pkg".
+
+    'version_id' indicates the version of the api the client is
+    expecting to use.
+
+    'root' is the absolute path of the directory where the image will
+    be created.  If it does not exist, it will be created.
+
+    'imgtype' is an IMG_TYPE constant representing the type of image
+    to create.
+
+    'is_zone' is a boolean value indicating whether the image being
+    created is for a zone.
+
+    'cancel_state_callable' is an optional function reference that will
+    be called if the cancellable status of an operation changes.
+
+    'facets' is a dictionary of facet names and values to set during
+    the image creation process.
+
+    'force' is an optional boolean value indicating that if an image
+    already exists at the specified 'root' that it should be overwritten.
+
+    'mirrors' is an optional list of URI strings that should be added to
+    all publishers configured during image creation as mirrors.
+
+    'origins' is an optional list of URI strings that should be added to
+    all publishers configured during image creation as origins.
+
+    'prefix' is an optional publisher prefix to configure as a publisher
+    for the new image if origins is provided, or to restrict which publisher
+    will be configured if 'repo_uri' is provided.  If this prefix does not
+    match the publisher configuration retrieved from the repository, an
+    UnknownRepositoryPublishers exception will be raised.  If not provided,
+    'refresh_allowed' cannot be False.
+
+    'props' is an optional dictionary mapping image property names to values
+    to be set while creating the image.
+
+    'refresh_allowed' is an optional boolean value indicating whether
+    publisher configuration data and metadata can be retrieved during
+    image creation.  If False, 'repo_uri' cannot be specified and
+    a 'prefix' must be provided.
+
+    'repo_uri' is an optional URI string of a package repository to
+    retrieve publisher configuration information from.  If the target
+    repository supports this, all publishers found will be added to the
+    image and any origins or mirrors will be added to all of those
+    publishers.  If the target repository does not support this, and a
+    prefix was not specified, an UnsupportedRepositoryOperation exception
+    will be raised.  If the target repository supports the operation, but
+    does not provide complete configuration information, a
+    RepoPubConfigUnavailable exception will be raised.
+
+    'ssl_cert' is an optional pathname of an SSL Certificate file to
+    configure all publishers with and to use when retrieving publisher
+    configuration information.  If provided, 'ssl_key' must also be
+    provided.  The certificate file must be pem-encoded.
+
+    'ssl_key' is an optional pathname of an SSL Key file to configure all
+    publishers with and to use when retrieving publisher configuration
+    information.  If provided, 'ssl_cert' must also be provided.  The
+    key file must be pem-encoded.
+
+    'user_provided_dir' is an optional boolean value indicating that the
+    provided 'root' was user-supplied and that additional error handling
+    should be enforced.  This primarily affects cases where a relative
+    root has been provided or the root was based on the current working
+    directory.
+
+    'progtrack' is an optional ProgressTracker object.
+
+    'variants' is a dictionary of variant names and values to set during
+    the image creation process.
+
+    Callers must provide one of the following when calling this function:
+     * no 'prefix' and no 'origins'
+     * a 'prefix' and 'repo_uri' (origins and mirrors are optional)
+     * no 'prefix' and a 'repo_uri'  (origins and mirrors are optional)
+     * a 'prefix' and 'origins'
+    """
+
+    # Caller must provide a prefix and repository, or no prefix and a
+    # repository, or a prefix and origins, or no prefix and no origins.
+    assert (
+        (prefix and repo_uri)
+        or (not prefix and repo_uri)
+        or (prefix and origins or (not prefix and not origins))
+    )
+
+    # If prefix isn't provided and refresh isn't allowed, then auto-config
+    # cannot be done.
+    assert (prefix or refresh_allowed) or not repo_uri
+
+    destroy_root = False
+    try:
+        destroy_root = not os.path.exists(root)
+    except EnvironmentError as e:
+        if e.errno == errno.EACCES:
+            raise apx.PermissionsException(e.filename)
+        raise
+
+    # The image object must be created first since transport may be
+    # needed to retrieve publisher configuration information.
+    img = image.Image(
+        root,
+        force=force,
+        imgtype=imgtype,
+        progtrack=progtrack,
+        should_exist=False,
+        user_provided_dir=user_provided_dir,
+        cmdpath=cmdpath,
+        props=props,
+    )
+    api_inst = ImageInterface(
+        img,
+        version_id,
+        progtrack,
+        cancel_state_callable,
+        pkg_client_name,
+        cmdpath=cmdpath,
+    )
+
+    pubs = []
+
+    try:
+        if repo_uri:
+            # Assume auto configuration.
+            if ssl_cert:
+                try:
+                    misc.validate_ssl_cert(
+                        ssl_cert, prefix=prefix, uri=repo_uri
+                    )
+                except apx.ExpiringCertificate as e:
+                    logger.warning(e)
+
+            repo = publisher.RepositoryURI(
+                repo_uri, ssl_cert=ssl_cert, ssl_key=ssl_key
+            )
+
+            pubs = None
+            try:
+                pubs = api_inst.get_publisherdata(repo=repo)
+            except apx.UnsupportedRepositoryOperation:
+                if not prefix:
+                    raise apx.RepoPubConfigUnavailable(location=repo_uri)
+                # For a v0 repo where a prefix was specified,
+                # fallback to manual configuration.
+                if not origins:
+                    origins = [repo_uri]
+                repo_uri = None
+
+            if not prefix and not pubs:
+                # Empty repository configuration.
+                raise apx.RepoPubConfigUnavailable(location=repo_uri)
+
+            if repo_uri:
+                for p in pubs:
+                    psrepo = p.repository
+                    if not psrepo:
+                        # Repository configuration info
+                        # was not provided, so assume
+                        # origin is repo_uri.
+                        p.repository = publisher.Repository(origins=[repo_uri])
+                    elif not psrepo.origins:
+                        # Repository configuration was
+                        # provided, but without an
+                        # origin.  Assume the repo_uri
+                        # is the origin.
+                        psrepo.add_origin(repo_uri)
+                    elif repo not in psrepo.origins:
+                        # If the repo_uri used is not
+                        # in the list of sources, then
+                        # add it as the first origin.
+                        psrepo.origins.insert(0, repo)
+
+        if prefix and not repo_uri:
+            # Auto-configuration not possible or not requested.
+            if ssl_cert:
+                try:
+                    misc.validate_ssl_cert(
+                        ssl_cert, prefix=prefix, uri=origins[0]
+                    )
+                except apx.ExpiringCertificate as e:
+                    logger.warning(e)
+
+            repo = publisher.Repository()
+            for o in origins:
+                repo.add_origin(o)  # pylint: disable=E1103
+            for m in mirrors:
+                repo.add_mirror(m)  # pylint: disable=E1103
+            pub = publisher.Publisher(prefix, repository=repo)
+            pubs = [pub]
+
+        if prefix and prefix not in pubs:
+            # If publisher prefix requested isn't found in the list
+            # of publishers at this point, then configuration isn't
+            # possible.
+            known = [p.prefix for p in pubs]
+            raise apx.UnknownRepositoryPublishers(
+                known=known, unknown=[prefix], location=repo_uri
+            )
+        elif prefix:
+            # Filter out any publishers that weren't requested.
+            pubs = [p for p in pubs if p.prefix == prefix]
+
+        # Add additional origins and mirrors that weren't found in the
+        # publisher configuration if provided.
+        for p in pubs:
+            pr = p.repository
+            for o in origins:
+                if not pr.has_origin(o):
+                    pr.add_origin(o)
+            for m in mirrors:
+                if not pr.has_mirror(m):
+                    pr.add_mirror(m)
+
+        # Set provided SSL Cert/Key for all configured publishers.
+        for p in pubs:
+            repo = p.repository
+            for o in repo.origins:
+                if o.scheme not in publisher.SSL_SCHEMES:
+                    continue
+                o.ssl_cert = ssl_cert
+                o.ssl_key = ssl_key
+            for m in repo.mirrors:
+                if m.scheme not in publisher.SSL_SCHEMES:
+                    continue
+                m.ssl_cert = ssl_cert
+                m.ssl_key = ssl_key
+
+        img.create(
+            pubs,
+            facets=facets,
+            is_zone=is_zone,
+            progtrack=progtrack,
+            refresh_allowed=refresh_allowed,
+            variants=variants,
+            props=props,
+        )
+    except EnvironmentError as e:
+        if e.errno == errno.EACCES:
+            raise apx.PermissionsException(e.filename)
+        if e.errno == errno.EROFS:
+            raise apx.ReadOnlyFileSystemException(e.filename)
+        raise
+    except:
+        # Ensure a defunct image isn't left behind.
+        img.destroy()
+        if (
+            destroy_root
+            and os.path.abspath(root) != "/"
+            and os.path.exists(root)
+        ):
+            # Root didn't exist before create and isn't '/',
+            # so remove it.
+            shutil.rmtree(root, True)
+        raise
+
+    img.cleanup_downloads()
+
+    return api_inst
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/api_errors.py
+++ b/src/modules/client/api_errors.py
@@ -40,3216 +40,3608 @@ import pkg.client.pkgdefs as pkgdefs
 # dependency.
 EmptyI = tuple()
 
+
 class ApiException(Exception):
-        def __init__(self, *args):
-                Exception.__init__(self)
-                self.__verbose_info = []
+    def __init__(self, *args):
+        Exception.__init__(self)
+        self.__verbose_info = []
 
-        def add_verbose_info(self, info):
-                self.__verbose_info.extend(info)
+    def add_verbose_info(self, info):
+        self.__verbose_info.extend(info)
 
-        @property
-        def verbose_info(self):
-                return self.__verbose_info
+    @property
+    def verbose_info(self):
+        return self.__verbose_info
+
 
 class SuidUnsupportedError(ApiException):
-        def __str__(self):
-                return _("""
-The pkg client api module can not be invoked from an setuid executable.""")
+    def __str__(self):
+        return _(
+            """
+The pkg client api module can not be invoked from an setuid executable."""
+        )
 
 
 class HistoryException(ApiException):
-        """Private base exception class for all History exceptions."""
+    """Private base exception class for all History exceptions."""
 
-        def __init__(self, *args):
-                Exception.__init__(self, *args)
-                self.error = args[0]
+    def __init__(self, *args):
+        Exception.__init__(self, *args)
+        self.error = args[0]
 
-        def __str__(self):
-                return str(self.error)
+    def __str__(self):
+        return str(self.error)
 
 
 class HistoryLoadException(HistoryException):
-        """Used to indicate that an unexpected error occurred while loading
-        History operation information.
+    """Used to indicate that an unexpected error occurred while loading
+    History operation information.
 
-        The first argument should be an exception object related to the
-        error encountered.
-        """
-        def __init__(self, *args):
-                HistoryException.__init__(self, *args)
-                self.parse_failure = isinstance(self.error, expat.ExpatError)
+    The first argument should be an exception object related to the
+    error encountered.
+    """
+
+    def __init__(self, *args):
+        HistoryException.__init__(self, *args)
+        self.parse_failure = isinstance(self.error, expat.ExpatError)
 
 
 class HistoryRequestException(HistoryException):
-        """Used to indicate that invalid time / range values were provided to
-        history API functions."""
-        pass
+    """Used to indicate that invalid time / range values were provided to
+    history API functions."""
+
+    pass
 
 
 class HistoryStoreException(HistoryException):
-        """Used to indicate that an unexpected error occurred while storing
-        History operation information.
+    """Used to indicate that an unexpected error occurred while storing
+    History operation information.
 
-        The first argument should be an exception object related to the
-        error encountered.
-        """
-        pass
+    The first argument should be an exception object related to the
+    error encountered.
+    """
+
+    pass
 
 
 class HistoryPurgeException(HistoryException):
-        """Used to indicate that an unexpected error occurred while purging
-        History operation information.
+    """Used to indicate that an unexpected error occurred while purging
+    History operation information.
 
-        The first argument should be an exception object related to the
-        error encountered.
-        """
-        pass
+    The first argument should be an exception object related to the
+    error encountered.
+    """
+
+    pass
+
 
 class ImageLockedError(ApiException):
-        """Used to indicate that the image is currently locked by another thread
-        or process and cannot be modified."""
+    """Used to indicate that the image is currently locked by another thread
+    or process and cannot be modified."""
 
-        def __init__(self, hostname=None, pid=None, pid_name=None):
-                ApiException.__init__(self)
-                self.hostname = hostname
-                self.pid = pid
-                self.pid_name = pid_name
+    def __init__(self, hostname=None, pid=None, pid_name=None):
+        ApiException.__init__(self)
+        self.hostname = hostname
+        self.pid = pid
+        self.pid_name = pid_name
 
-        def __str__(self):
-                if self.pid is not None and self.pid_name is not None and \
-                    self.hostname is not None:
-                        return _("The image cannot be modified as it is "
-                            "currently in use by another package client: "
-                            "{pid_name} on {host}, pid {pid}.").format(
-                            pid_name=self.pid_name, pid=self.pid,
-                            host=self.hostname)
-                if self.pid is not None and self.pid_name is not None:
-                        return _("The image cannot be modified as it is "
-                            "currently in use by another package client: "
-                            "{pid_name} on an unknown host, pid {pid}.").format(
-                            pid_name=self.pid_name, pid=self.pid)
-                elif self.pid is not None:
-                        return _("The image cannot be modified as it is "
-                            "currently in use by another package client: "
-                            "pid {pid} on {host}.").format(
-                            pid=self.pid, host=self.hostname)
-                return _("The image cannot be modified as it is currently "
-                    "in use by another package client.")
+    def __str__(self):
+        if (
+            self.pid is not None
+            and self.pid_name is not None
+            and self.hostname is not None
+        ):
+            return _(
+                "The image cannot be modified as it is "
+                "currently in use by another package client: "
+                "{pid_name} on {host}, pid {pid}."
+            ).format(pid_name=self.pid_name, pid=self.pid, host=self.hostname)
+        if self.pid is not None and self.pid_name is not None:
+            return _(
+                "The image cannot be modified as it is "
+                "currently in use by another package client: "
+                "{pid_name} on an unknown host, pid {pid}."
+            ).format(pid_name=self.pid_name, pid=self.pid)
+        elif self.pid is not None:
+            return _(
+                "The image cannot be modified as it is "
+                "currently in use by another package client: "
+                "pid {pid} on {host}."
+            ).format(pid=self.pid, host=self.hostname)
+        return _(
+            "The image cannot be modified as it is currently "
+            "in use by another package client."
+        )
+
 
 class ImageLockingFailedError(ApiException):
-        """Used to indicate that the image could not be locked."""
+    """Used to indicate that the image could not be locked."""
 
-        def __init__(self, root_dir, err):
-                ApiException.__init__(self)
-                self.root_dir = root_dir
-                self.err = err
+    def __init__(self, root_dir, err):
+        ApiException.__init__(self)
+        self.root_dir = root_dir
+        self.err = err
 
-        def __str__(self):
-                return _("Failed to lock the image rooted at {0}: {1}").format(
-                    self.root_dir, self.err)
+    def __str__(self):
+        return _("Failed to lock the image rooted at {0}: {1}").format(
+            self.root_dir, self.err
+        )
+
 
 class ImageNotFoundException(ApiException):
-        """Used when an image was not found"""
-        def __init__(self, user_specified, user_dir, root_dir):
-                ApiException.__init__(self)
-                self.user_specified = user_specified
-                self.user_dir = user_dir
-                self.root_dir = root_dir
+    """Used when an image was not found"""
 
-        def __str__(self):
-                return _("No image rooted at '{0}'").format(self.user_dir)
+    def __init__(self, user_specified, user_dir, root_dir):
+        ApiException.__init__(self)
+        self.user_specified = user_specified
+        self.user_dir = user_dir
+        self.root_dir = root_dir
+
+    def __str__(self):
+        return _("No image rooted at '{0}'").format(self.user_dir)
+
 
 class ImageMissingKeyFile(ApiException):
-        """Used when an image does not contain all expected key files"""
-        def __init__(self, keyfile):
-                ApiException.__init__(self)
-                self.keyfile = keyfile
+    """Used when an image does not contain all expected key files"""
 
-        def __str__(self):
-                return _("Image is missing key file. "
-                    "Is everything mounted? '{0}'").format(self.keyfile)
+    def __init__(self, keyfile):
+        ApiException.__init__(self)
+        self.keyfile = keyfile
+
+    def __str__(self):
+        return _(
+            "Image is missing key file. " "Is everything mounted? '{0}'"
+        ).format(self.keyfile)
+
 
 class ImageFormatUpdateNeeded(ApiException):
-        """Used to indicate that an image cannot be used until its format is
-        updated."""
+    """Used to indicate that an image cannot be used until its format is
+    updated."""
 
-        def __init__(self, path):
-                ApiException.__init__(self)
-                self.path = path
+    def __init__(self, path):
+        ApiException.__init__(self)
+        self.path = path
 
-        def __str__(self):
-                return _("The image rooted at {0} is written in an older format "
-                    "and must be updated before the requested operation can be "
-                    "performed.").format(self.path)
+    def __str__(self):
+        return _(
+            "The image rooted at {0} is written in an older format "
+            "and must be updated before the requested operation can be "
+            "performed."
+        ).format(self.path)
+
 
 class ImageInsufficentSpace(ApiException):
-        """Used when insuffcient space exists for proposed operation"""
-        def __init__(self, needed, avail, use):
-                self.needed = needed
-                self.avail = avail
-                self.use = use
+    """Used when insuffcient space exists for proposed operation"""
 
-        def __str__(self):
-                from pkg.misc import bytes_to_str
-                return _("Insufficient disk space available ({avail}) "
-                    "for estimated need ({needed}) for {use}").format(
-                    avail=bytes_to_str(self.avail),
-                    needed=bytes_to_str(self.needed),
-                    use=self.use
-                   )
+    def __init__(self, needed, avail, use):
+        self.needed = needed
+        self.avail = avail
+        self.use = use
+
+    def __str__(self):
+        from pkg.misc import bytes_to_str
+
+        return _(
+            "Insufficient disk space available ({avail}) "
+            "for estimated need ({needed}) for {use}"
+        ).format(
+            avail=bytes_to_str(self.avail),
+            needed=bytes_to_str(self.needed),
+            use=self.use,
+        )
 
 
 class VersionException(ApiException):
-        def __init__(self, expected_version, received_version):
-                ApiException.__init__(self)
-                self.expected_version = expected_version
-                self.received_version = received_version
+    def __init__(self, expected_version, received_version):
+        ApiException.__init__(self)
+        self.expected_version = expected_version
+        self.received_version = received_version
 
 
 class PlanExistsException(ApiException):
-        def __init__(self, plan_type):
-                ApiException.__init__(self)
-                self.plan_type = plan_type
+    def __init__(self, plan_type):
+        ApiException.__init__(self)
+        self.plan_type = plan_type
 
 
 class PlanPrepareException(ApiException):
-        """Base exception class for plan preparation errors."""
-        pass
+    """Base exception class for plan preparation errors."""
+
+    pass
 
 
 class InvalidPackageErrors(ApiException):
-        """Used to indicate that the requested operation could not be completed
-        as one or more packages contained invalid metadata."""
+    """Used to indicate that the requested operation could not be completed
+    as one or more packages contained invalid metadata."""
 
-        def __init__(self, errors):
-                """'errors' should be a list of exceptions or strings
-                indicating what packages had errors and why."""
+    def __init__(self, errors):
+        """'errors' should be a list of exceptions or strings
+        indicating what packages had errors and why."""
 
-                ApiException.__init__(self)
-                self.errors = errors
+        ApiException.__init__(self)
+        self.errors = errors
 
-        def __str__(self):
-                return _("The requested operation cannot be completed due "
-                    "to invalid package metadata.  Details follow:\n\n"
-                    "{0}").format("\n".join(str(e) for e in self.errors))
+    def __str__(self):
+        return _(
+            "The requested operation cannot be completed due "
+            "to invalid package metadata.  Details follow:\n\n"
+            "{0}"
+        ).format("\n".join(str(e) for e in self.errors))
+
 
 class PlanExclusionError(ApiException):
-        """Used to indicate that the requested operation could not be executed
-        due to exclusions configured on the image."""
+    """Used to indicate that the requested operation could not be executed
+    due to exclusions configured on the image."""
 
-        def __init__(self, paths):
-                self.paths = paths
+    def __init__(self, paths):
+        self.paths = paths
 
-        def __str__(self):
-                return "{0}\n\n    {1}\n\n{2}".format(
-                    _("""\
+    def __str__(self):
+        return "{0}\n\n    {1}\n\n{2}".format(
+            _(
+                """\
 The files listed below match exclusions which are configured
-on this image and can therefore not be installed:"""),
-                    "\n    ".join(list(self.paths)),
-                    _("""\
+on this image and can therefore not be installed:"""
+            ),
+            "\n    ".join(list(self.paths)),
+            _(
+                """\
 See the 'exclude-patterns' and 'exclude-policy' image properties in pkg(1) for
-more information.""")
-                )
+more information."""
+            ),
+        )
+
 
 class LicenseAcceptanceError(ApiException):
-        """Used to indicate that license-related errors occurred during
-        plan evaluation or execution."""
+    """Used to indicate that license-related errors occurred during
+    plan evaluation or execution."""
 
-        def __init__(self, pfmri, src=None, dest=None, accepted=None,
-            displayed=None):
-                ApiException.__init__(self)
-                self.fmri = pfmri
-                self.src = src
-                self.dest = dest
-                self.accepted = accepted
-                self.displayed = displayed
+    def __init__(
+        self, pfmri, src=None, dest=None, accepted=None, displayed=None
+    ):
+        ApiException.__init__(self)
+        self.fmri = pfmri
+        self.src = src
+        self.dest = dest
+        self.accepted = accepted
+        self.displayed = displayed
 
 
 class PkgLicenseErrors(PlanPrepareException):
-        """Used to indicate that plan evaluation or execution failed due
-        to license-related errors for a package."""
+    """Used to indicate that plan evaluation or execution failed due
+    to license-related errors for a package."""
 
-        def __init__(self, errors):
-                """'errors' should be a list of LicenseAcceptanceError
-                exceptions."""
+    def __init__(self, errors):
+        """'errors' should be a list of LicenseAcceptanceError
+        exceptions."""
 
-                PlanPrepareException.__init__(self)
-                self.__errors = errors
+        PlanPrepareException.__init__(self)
+        self.__errors = errors
 
-        @property
-        def errors(self):
-                """A list of LicenseAcceptanceError exceptions."""
-                return self.__errors
+    @property
+    def errors(self):
+        """A list of LicenseAcceptanceError exceptions."""
+        return self.__errors
 
 
 class PlanLicenseErrors(PlanPrepareException):
-        """Used to indicate that image plan evaluation or execution failed due
-        to license-related errors."""
+    """Used to indicate that image plan evaluation or execution failed due
+    to license-related errors."""
 
-        def __init__(self, pp_errors):
-                """'errors' should be a list of PkgLicenseErrors exceptions."""
+    def __init__(self, pp_errors):
+        """'errors' should be a list of PkgLicenseErrors exceptions."""
 
-                PlanPrepareException.__init__(self)
-                self.__errors = pkgs = {}
-                for pp_err in pp_errors:
-                        for e in pp_err.errors:
-                                pkgs.setdefault(str(e.fmri), []).append(e)
+        PlanPrepareException.__init__(self)
+        self.__errors = pkgs = {}
+        for pp_err in pp_errors:
+            for e in pp_err.errors:
+                pkgs.setdefault(str(e.fmri), []).append(e)
 
-        @property
-        def errors(self):
-                """Returns a dictionary indexed by package FMRI string of
-                lists of LicenseAcceptanceError exceptions."""
+    @property
+    def errors(self):
+        """Returns a dictionary indexed by package FMRI string of
+        lists of LicenseAcceptanceError exceptions."""
 
-                return self.__errors
+        return self.__errors
 
-        def __str__(self):
-                """Returns a string representation of the license errors."""
+    def __str__(self):
+        """Returns a string representation of the license errors."""
 
-                output = ""
-                for sfmri in self.__errors:
-                        output += ("-" * 40) + "\n"
-                        output += _("Package: {0}\n\n").format(sfmri)
-                        for e in self.__errors[sfmri]:
-                                lic_name = e.dest.attrs["license"]
-                                output += _("License: {0}\n").format(lic_name)
-                                if e.dest.must_accept and not e.accepted:
-                                        output += _("  License requires "
-                                            "acceptance.")
-                                if e.dest.must_display and not e.displayed:
-                                        output += _("  License must be viewed.")
-                                output += "\n"
-                return output
+        output = ""
+        for sfmri in self.__errors:
+            output += ("-" * 40) + "\n"
+            output += _("Package: {0}\n\n").format(sfmri)
+            for e in self.__errors[sfmri]:
+                lic_name = e.dest.attrs["license"]
+                output += _("License: {0}\n").format(lic_name)
+                if e.dest.must_accept and not e.accepted:
+                    output += _("  License requires " "acceptance.")
+                if e.dest.must_display and not e.displayed:
+                    output += _("  License must be viewed.")
+                output += "\n"
+        return output
 
 
 class InvalidVarcetNames(PlanPrepareException):
-        """Used to indicate that image plan evaluation or execution failed due
-        to illegal characters in variant/facet names."""
+    """Used to indicate that image plan evaluation or execution failed due
+    to illegal characters in variant/facet names."""
 
-        def __init__(self, invalid_names):
-                PlanPrepareException.__init__(self)
-                self.names = invalid_names
+    def __init__(self, invalid_names):
+        PlanPrepareException.__init__(self)
+        self.names = invalid_names
 
-        def __str__(self):
-                return _(", ".join(self.names) + " are not valid variant/facet "
-                    "names; variant/facet names cannot contain whitespace.")
+    def __str__(self):
+        return _(
+            ", ".join(self.names) + " are not valid variant/facet "
+            "names; variant/facet names cannot contain whitespace."
+        )
 
 
 class ActuatorException(ApiException):
-        def __init__(self, e):
-                ApiException.__init__(self)
-                self.exception = e
+    def __init__(self, e):
+        ApiException.__init__(self)
+        self.exception = e
 
-        def __str__(self):
-                return str(self.exception)
+    def __str__(self):
+        return str(self.exception)
 
 
 class PrematureExecutionException(ApiException):
-        pass
+    pass
 
 
 class AlreadyPreparedException(PlanPrepareException):
-        pass
+    pass
 
 
 class AlreadyExecutedException(ApiException):
-        pass
+    pass
 
 
 class ImageplanStateException(ApiException):
-        def __init__(self, state):
-                ApiException.__init__(self)
-                self.state = state
+    def __init__(self, state):
+        ApiException.__init__(self)
+        self.state = state
 
 
 class InvalidPlanError(ApiException):
-        """Used to indicate that the image plan is no longer valid, likely as a
-        result of an image state change since the plan was created."""
+    """Used to indicate that the image plan is no longer valid, likely as a
+    result of an image state change since the plan was created."""
 
-        def __str__(self):
-                return _("The plan for the current operation is no longer "
-                    "valid.  The image has likely been modified by another "
-                    "process or client.  Please try the operation again.")
+    def __str__(self):
+        return _(
+            "The plan for the current operation is no longer "
+            "valid.  The image has likely been modified by another "
+            "process or client.  Please try the operation again."
+        )
 
 
 class ImagePkgStateError(ApiException):
+    def __init__(self, fmri, states):
+        ApiException.__init__(self)
+        self.fmri = fmri
+        self.states = states
 
-        def __init__(self, fmri, states):
-                ApiException.__init__(self)
-                self.fmri = fmri
-                self.states = states
-
-        def __str__(self):
-                return _("Invalid package state change attempted '{states}' "
-                    "for package '{fmri}'.").format(states=self.states,
-                    fmri=self.fmri)
+    def __str__(self):
+        return _(
+            "Invalid package state change attempted '{states}' "
+            "for package '{fmri}'."
+        ).format(states=self.states, fmri=self.fmri)
 
 
 class IpkgOutOfDateException(ApiException):
-        def __str__(self):
-                return _("pkg(7) out of date")
+    def __str__(self):
+        return _("pkg(7) out of date")
 
 
 class ImageUpdateOnLiveImageException(ApiException):
-        def __str__(self):
-                return _("Requested operation cannot be performed "
-                    "in live image.")
+    def __str__(self):
+        return _("Requested operation cannot be performed " "in live image.")
 
 
 class RebootNeededOnLiveImageException(ApiException):
-        def __str__(self):
-                return _("Requested operation cannot be performed "
-                    "in live image.")
+    def __str__(self):
+        return _("Requested operation cannot be performed " "in live image.")
 
 
 class CanceledException(ApiException):
-        pass
+    pass
+
 
 class PlanMissingException(ApiException):
-        pass
+    pass
+
 
 class NoPackagesInstalledException(ApiException):
-        pass
+    pass
+
 
 class PermissionsException(ApiException):
-        def __init__(self, path):
-                ApiException.__init__(self)
-                self.path = path
+    def __init__(self, path):
+        ApiException.__init__(self)
+        self.path = path
 
-        def __str__(self):
-                if self.path:
-                        return _("Could not operate on {0}\nbecause of "
-                            "insufficient permissions. Please try the "
-                            "command again as a privileged user.").format(
-                            self.path)
-                else:
-                        return _("""
+    def __str__(self):
+        if self.path:
+            return _(
+                "Could not operate on {0}\nbecause of "
+                "insufficient permissions. Please try the "
+                "command again as a privileged user."
+            ).format(self.path)
+        else:
+            return _(
+                """
 Could not complete the operation because of insufficient permissions.
 Please try the command again as a privileged user.
-""")
+"""
+            )
+
 
 class FileInUseException(PermissionsException):
-        def __init__(self, path):
-                PermissionsException.__init__(self, path)
-                assert path
+    def __init__(self, path):
+        PermissionsException.__init__(self, path)
+        assert path
 
-        def __str__(self):
-                return _("Could not operate on {0}\nbecause the file is "
-                    "in use. Please stop using the file and try the\n"
-                    "operation again.").format(self.path)
+    def __str__(self):
+        return _(
+            "Could not operate on {0}\nbecause the file is "
+            "in use. Please stop using the file and try the\n"
+            "operation again."
+        ).format(self.path)
 
 
 class UnprivilegedUserError(PermissionsException):
-        def __init__(self, path):
-                PermissionsException.__init__(self, path)
+    def __init__(self, path):
+        PermissionsException.__init__(self, path)
 
-        def __str__(self):
-                return _("Insufficient access to complete the requested "
-                    "operation.\nPlease try the operation again as a "
-                    "privileged user.")
+    def __str__(self):
+        return _(
+            "Insufficient access to complete the requested "
+            "operation.\nPlease try the operation again as a "
+            "privileged user."
+        )
 
 
 class ReadOnlyFileSystemException(PermissionsException):
-        """Used to indicate that the operation was attempted on a
-        read-only filesystem"""
+    """Used to indicate that the operation was attempted on a
+    read-only filesystem"""
 
-        def __init__(self, path):
-                ApiException.__init__(self)
-                self.path = path
+    def __init__(self, path):
+        ApiException.__init__(self)
+        self.path = path
 
-        def __str__(self):
-                if self.path:
-                        return _("Could not complete the operation on {0}: "
-                            "read-only filesystem.").format(self.path)
-                return _("Could not complete the operation: read-only "
-                        "filesystem.")
+    def __str__(self):
+        if self.path:
+            return _(
+                "Could not complete the operation on {0}: "
+                "read-only filesystem."
+            ).format(self.path)
+        return _("Could not complete the operation: read-only " "filesystem.")
 
 
 class InvalidLockException(ApiException):
-        def __init__(self, path):
-                ApiException.__init__(self)
-                self.path = path
+    def __init__(self, path):
+        ApiException.__init__(self)
+        self.path = path
 
-        def __str__(self):
-                return _("Unable to obtain or operate on lock at {0}.\n"
-                    "Please try the operation again as a privileged "
-                    "user.").format(self.path)
+    def __str__(self):
+        return _(
+            "Unable to obtain or operate on lock at {0}.\n"
+            "Please try the operation again as a privileged "
+            "user."
+        ).format(self.path)
 
 
 class PackageMatchErrors(ApiException):
-        """Used to indicate which patterns were not matched or illegal during
-        a package name matching operation."""
+    """Used to indicate which patterns were not matched or illegal during
+    a package name matching operation."""
 
-        def __init__(self, unmatched_fmris=EmptyI, multiple_matches=EmptyI,
-            illegal=EmptyI, multispec=EmptyI):
-                ApiException.__init__(self)
-                self.unmatched_fmris = unmatched_fmris
-                self.multiple_matches = multiple_matches
-                self.illegal = illegal
-                self.multispec = multispec
+    def __init__(
+        self,
+        unmatched_fmris=EmptyI,
+        multiple_matches=EmptyI,
+        illegal=EmptyI,
+        multispec=EmptyI,
+    ):
+        ApiException.__init__(self)
+        self.unmatched_fmris = unmatched_fmris
+        self.multiple_matches = multiple_matches
+        self.illegal = illegal
+        self.multispec = multispec
 
-        def __str__(self):
-                res = []
-                if self.unmatched_fmris:
-                        s = _("The following pattern(s) did not match any "
-                            "packages:")
+    def __str__(self):
+        res = []
+        if self.unmatched_fmris:
+            s = _("The following pattern(s) did not match any " "packages:")
 
-                        res += [s]
-                        res += ["\t{0}".format(p) for p in self.unmatched_fmris]
+            res += [s]
+            res += ["\t{0}".format(p) for p in self.unmatched_fmris]
 
-                if self.multiple_matches:
-                        s = _("'{0}' matches multiple packages")
-                        for p, lst in self.multiple_matches:
-                                res.append(s.format(p))
-                                for pfmri in lst:
-                                        res.append("\t{0}".format(pfmri))
+        if self.multiple_matches:
+            s = _("'{0}' matches multiple packages")
+            for p, lst in self.multiple_matches:
+                res.append(s.format(p))
+                for pfmri in lst:
+                    res.append("\t{0}".format(pfmri))
 
-                if self.illegal:
-                        s = _("'{0}' is an illegal FMRI")
-                        res += [ s.format(p) for p in self.illegal ]
+        if self.illegal:
+            s = _("'{0}' is an illegal FMRI")
+            res += [s.format(p) for p in self.illegal]
 
-                if self.multispec:
-                        s = _("The following different patterns specify the "
-                          "same package(s):")
-                        res += [s]
-                        for t in self.multispec:
-                                res += [
-                                    ", ".join([t[i] for i in range(1, len(t))])
-                                    + ": {0}".format(t[0])
-                                ]
+        if self.multispec:
+            s = _(
+                "The following different patterns specify the "
+                "same package(s):"
+            )
+            res += [s]
+            for t in self.multispec:
+                res += [
+                    ", ".join([t[i] for i in range(1, len(t))])
+                    + ": {0}".format(t[0])
+                ]
 
-                return "\n".join(res)
+        return "\n".join(res)
 
 
 class PlanExecutionError(InvalidPlanError):
-        """Used to indicate that the requested operation could not be executed
-        due to unexpected changes in image state after planning was completed.
-        """
+    """Used to indicate that the requested operation could not be executed
+    due to unexpected changes in image state after planning was completed.
+    """
 
-        def __init__(self, paths):
-                self.paths = paths
+    def __init__(self, paths):
+        self.paths = paths
 
-        def __str__(self):
-                return _("The files listed below were modified after operation "
-                    "planning was complete or were missing during plan "
-                    "execution; this may indicate an administrative issue or "
-                    "system configuration issue:\n{0}".format(
-                    "\n".join(list(self.paths))))
+    def __str__(self):
+        return _(
+            "The files listed below were modified after operation "
+            "planning was complete or were missing during plan "
+            "execution; this may indicate an administrative issue or "
+            "system configuration issue:\n{0}".format(
+                "\n".join(list(self.paths))
+            )
+        )
 
 
 class PlanCreationException(ApiException):
-        def __init__(self,
-            already_installed=EmptyI,
-            badarch=EmptyI,
-            illegal=EmptyI,
-            installed=EmptyI,
-            invalid_mediations=EmptyI,
-            linked_pub_error=EmptyI,
-            missing_dependency=EmptyI,
-            missing_matches=EmptyI,
-            multiple_matches=EmptyI,
-            multispec=EmptyI,
-            no_solution=False,
-            no_tmp_origins=False,
-            no_version=EmptyI,
-            not_avoided=EmptyI,
-            nofiles=EmptyI,
-            obsolete=EmptyI,
-            pkg_updates_required=EmptyI,
-            rejected_pats=EmptyI,
-            solver_errors=EmptyI,
-            no_repo_pubs=EmptyI,
-            unmatched_fmris=EmptyI,
-            would_install=EmptyI,
-            wrong_publishers=EmptyI,
-            wrong_variants=EmptyI):
+    def __init__(
+        self,
+        already_installed=EmptyI,
+        badarch=EmptyI,
+        illegal=EmptyI,
+        installed=EmptyI,
+        invalid_mediations=EmptyI,
+        linked_pub_error=EmptyI,
+        missing_dependency=EmptyI,
+        missing_matches=EmptyI,
+        multiple_matches=EmptyI,
+        multispec=EmptyI,
+        no_solution=False,
+        no_tmp_origins=False,
+        no_version=EmptyI,
+        not_avoided=EmptyI,
+        nofiles=EmptyI,
+        obsolete=EmptyI,
+        pkg_updates_required=EmptyI,
+        rejected_pats=EmptyI,
+        solver_errors=EmptyI,
+        no_repo_pubs=EmptyI,
+        unmatched_fmris=EmptyI,
+        would_install=EmptyI,
+        wrong_publishers=EmptyI,
+        wrong_variants=EmptyI,
+    ):
+        ApiException.__init__(self)
+        self.already_installed = already_installed
+        self.badarch = badarch
+        self.illegal = illegal
+        self.installed = installed
+        self.invalid_mediations = invalid_mediations
+        self.linked_pub_error = linked_pub_error
+        self.missing_dependency = missing_dependency
+        self.missing_matches = missing_matches
+        self.multiple_matches = multiple_matches
+        self.multispec = multispec
+        self.no_solution = no_solution
+        self.no_tmp_origins = no_tmp_origins
+        self.no_version = no_version
+        self.not_avoided = not_avoided
+        self.nofiles = nofiles
+        self.obsolete = obsolete
+        self.pkg_updates_required = pkg_updates_required
+        self.rejected_pats = rejected_pats
+        self.solver_errors = solver_errors
+        self.unmatched_fmris = unmatched_fmris
+        self.no_repo_pubs = no_repo_pubs
+        self.would_install = would_install
+        self.wrong_publishers = wrong_publishers
+        self.wrong_variants = wrong_variants
 
-                ApiException.__init__(self)
-                self.already_installed     = already_installed
-                self.badarch               = badarch
-                self.illegal               = illegal
-                self.installed             = installed
-                self.invalid_mediations    = invalid_mediations
-                self.linked_pub_error      = linked_pub_error
-                self.missing_dependency    = missing_dependency
-                self.missing_matches       = missing_matches
-                self.multiple_matches      = multiple_matches
-                self.multispec             = multispec
-                self.no_solution           = no_solution
-                self.no_tmp_origins        = no_tmp_origins
-                self.no_version            = no_version
-                self.not_avoided           = not_avoided
-                self.nofiles               = nofiles
-                self.obsolete              = obsolete
-                self.pkg_updates_required  = pkg_updates_required
-                self.rejected_pats         = rejected_pats
-                self.solver_errors         = solver_errors
-                self.unmatched_fmris       = unmatched_fmris
-                self.no_repo_pubs          = no_repo_pubs
-                self.would_install         = would_install
-                self.wrong_publishers      = wrong_publishers
-                self.wrong_variants        = wrong_variants
-
-        def __str__(self):
-                res = []
-                if self.unmatched_fmris:
-                        s = _("""\
+    def __str__(self):
+        res = []
+        if self.unmatched_fmris:
+            s = _(
+                """\
 The following pattern(s) did not match any allowable packages.  Try
 using a different matching pattern, or refreshing publisher information:
-""")
-                        res += [s]
-                        res += ["\t{0}".format(p) for p in self.unmatched_fmris]
+"""
+            )
+            res += [s]
+            res += ["\t{0}".format(p) for p in self.unmatched_fmris]
 
-                if self.rejected_pats:
-                        s = _("""\
+        if self.rejected_pats:
+            s = _(
+                """\
 The following pattern(s) only matched packages rejected by user request.  Try
 using a different matching pattern, or refreshing publisher information:
-""")
-                        res += [s]
-                        res += ["\t{0}".format(p) for p in self.rejected_pats]
+"""
+            )
+            res += [s]
+            res += ["\t{0}".format(p) for p in self.rejected_pats]
 
-                if self.wrong_variants:
-                        s = _("""\
+        if self.wrong_variants:
+            s = _(
+                """\
 The following pattern(s) only matched packages that are not available
-for the current image's architecture, zone type, and/or other variant:""")
-                        res += [s]
-                        res += ["\t{0}".format(p) for p in self.wrong_variants]
+for the current image's architecture, zone type, and/or other variant:"""
+            )
+            res += [s]
+            res += ["\t{0}".format(p) for p in self.wrong_variants]
 
-                if self.wrong_publishers:
-                        s = _("The following patterns only matched packages "
-                            "that are from publishers other than that which "
-                            "supplied the already installed version of this package")
-                        res += [s]
-                        res += ["\t{0}: {1}".format(p[0], ", ".join(p[1])) for p in self.wrong_publishers]
+        if self.wrong_publishers:
+            s = _(
+                "The following patterns only matched packages "
+                "that are from publishers other than that which "
+                "supplied the already installed version of this package"
+            )
+            res += [s]
+            res += [
+                "\t{0}: {1}".format(p[0], ", ".join(p[1]))
+                for p in self.wrong_publishers
+            ]
 
-                if self.multiple_matches:
-                        s = _("'{0}' matches multiple packages")
-                        for p, lst in self.multiple_matches:
-                                res.append(s.format(p))
-                                for pfmri in lst:
-                                        res.append("\t{0}".format(pfmri))
+        if self.multiple_matches:
+            s = _("'{0}' matches multiple packages")
+            for p, lst in self.multiple_matches:
+                res.append(s.format(p))
+                for pfmri in lst:
+                    res.append("\t{0}".format(pfmri))
 
-                if self.missing_matches:
-                        s = _("'{0}' matches no installed packages")
-                        res += [ s.format(p) for p in self.missing_matches ]
+        if self.missing_matches:
+            s = _("'{0}' matches no installed packages")
+            res += [s.format(p) for p in self.missing_matches]
 
-                if self.illegal:
-                        s = _("'{0}' is an illegal fmri")
-                        res += [ s.format(p) for p in self.illegal ]
+        if self.illegal:
+            s = _("'{0}' is an illegal fmri")
+            res += [s.format(p) for p in self.illegal]
 
-                if self.badarch:
-                        s = _("'{p}' supports the following architectures: "
-                            "{archs}")
-                        a = _("Image architecture is defined as: {0}")
-                        res += [ s.format(p=self.badarch[0],
-                            archs=", ".join(self.badarch[1]))]
-                        res += [ a.format(self.badarch[2])]
+        if self.badarch:
+            s = _("'{p}' supports the following architectures: " "{archs}")
+            a = _("Image architecture is defined as: {0}")
+            res += [
+                s.format(p=self.badarch[0], archs=", ".join(self.badarch[1]))
+            ]
+            res += [a.format(self.badarch[2])]
 
-                s = _("'{p}' depends on obsolete package '{op}'")
-                res += [ s.format(p=p, op=op) for p, op in self.obsolete ]
+        s = _("'{p}' depends on obsolete package '{op}'")
+        res += [s.format(p=p, op=op) for p, op in self.obsolete]
 
-                if self.installed:
-                        s = _("The proposed operation can not be performed for "
-                            "the following package(s) as they are already "
-                            "installed: ")
-                        res += [s]
-                        res += ["\t{0}".format(p) for p in self.installed]
+        if self.installed:
+            s = _(
+                "The proposed operation can not be performed for "
+                "the following package(s) as they are already "
+                "installed: "
+            )
+            res += [s]
+            res += ["\t{0}".format(p) for p in self.installed]
 
-                if self.invalid_mediations:
-                        s = _("The following mediations are not syntactically "
-                            "valid:")
-                        for m, entries in six.iteritems(self.invalid_mediations):
-                                for value, error in entries.values():
-                                        res.append(error)
+        if self.invalid_mediations:
+            s = _("The following mediations are not syntactically " "valid:")
+            for m, entries in six.iteritems(self.invalid_mediations):
+                for value, error in entries.values():
+                    res.append(error)
 
-                if self.multispec:
-                        s = _("The following patterns specify different "
-                            "versions of the same package(s):")
-                        res += [s]
-                        for t in self.multispec:
-                                res += [
-                                        ", ".join(
-                                        [t[i] for i in range(1, len(t))])
-                                        + ": {0}".format(t[0])
-                                        ]
-                if self.no_solution:
-                        res += [_("No solution was found to satisfy constraints")]
-                        if isinstance(self.no_solution, list):
-                                res.extend(self.no_solution)
+        if self.multispec:
+            s = _(
+                "The following patterns specify different "
+                "versions of the same package(s):"
+            )
+            res += [s]
+            for t in self.multispec:
+                res += [
+                    ", ".join([t[i] for i in range(1, len(t))])
+                    + ": {0}".format(t[0])
+                ]
+        if self.no_solution:
+            res += [_("No solution was found to satisfy constraints")]
+            if isinstance(self.no_solution, list):
+                res.extend(self.no_solution)
 
-                if self.pkg_updates_required:
-                        s = _("""\
+        if self.pkg_updates_required:
+            s = _(
+                """\
 Syncing this linked image would require the following package updates:
-""")
-                        res += [s]
-                        for (oldfmri, newfmri) in self.pkg_updates_required:
-                                res += ["{oldfmri} -> {newfmri}\n".format(
-                                    oldfmri=oldfmri, newfmri=newfmri)]
+"""
+            )
+            res += [s]
+            for oldfmri, newfmri in self.pkg_updates_required:
+                res += [
+                    "{oldfmri} -> {newfmri}\n".format(
+                        oldfmri=oldfmri, newfmri=newfmri
+                    )
+                ]
 
-                if self.no_version:
-                        res += self.no_version
+        if self.no_version:
+            res += self.no_version
 
-                if self.no_tmp_origins:
-                        s = _("""
+        if self.no_tmp_origins:
+            s = _(
+                """
 The proposed operation on this parent image can not be performed because
 temporary origins were specified and this image has children.  Please either
 retry the operation again without specifying any temporary origins, or if
 packages from additional origins are required, please configure those origins
-persistently.""")
-                        res = [s]
+persistently."""
+            )
+            res = [s]
 
-                if self.missing_dependency:
-                        res += [_("Package {pkg} is missing a dependency: "
-                            "{dep}").format(
-                            pkg=self.missing_dependency[0],
-                             dep=self.missing_dependency[1])]
-                if self.nofiles:
-                        res += [_("The following files are not packaged in this image:")]
-                        res += ["\t{0}".format(f) for f in self.nofiles]
+        if self.missing_dependency:
+            res += [
+                _("Package {pkg} is missing a dependency: " "{dep}").format(
+                    pkg=self.missing_dependency[0],
+                    dep=self.missing_dependency[1],
+                )
+            ]
+        if self.nofiles:
+            res += [_("The following files are not packaged in this image:")]
+            res += ["\t{0}".format(f) for f in self.nofiles]
 
-                if self.solver_errors:
-                        res += ["\n"]
-                        res += [_("Solver dependency errors:")]
-                        res.extend(self.solver_errors)
+        if self.solver_errors:
+            res += ["\n"]
+            res += [_("Solver dependency errors:")]
+            res.extend(self.solver_errors)
 
-                if self.already_installed:
-                        res += [_("The following packages are already "
-                            "installed in this image; use uninstall to "
-                            "avoid these:")]
-                        res += [ "\t{0}".format(s) for s in self.already_installed]
+        if self.already_installed:
+            res += [
+                _(
+                    "The following packages are already "
+                    "installed in this image; use uninstall to "
+                    "avoid these:"
+                )
+            ]
+            res += ["\t{0}".format(s) for s in self.already_installed]
 
-                if self.would_install:
-                        res += [_("The following packages are a target "
-                            "of group dependencies; use install to unavoid "
-                            "these:")]
-                        res += [ "\t{0}".format(s) for s in self.would_install]
+        if self.would_install:
+            res += [
+                _(
+                    "The following packages are a target "
+                    "of group dependencies; use install to unavoid "
+                    "these:"
+                )
+            ]
+            res += ["\t{0}".format(s) for s in self.would_install]
 
-                if self.not_avoided:
-                        res += [_("The following packages are not on the "
-                            "avoid list, so they\ncannot be removed from it.")]
-                        res += [ "\t{0}".format(s) for s in sorted(self.not_avoided)]
+        if self.not_avoided:
+            res += [
+                _(
+                    "The following packages are not on the "
+                    "avoid list, so they\ncannot be removed from it."
+                )
+            ]
+            res += ["\t{0}".format(s) for s in sorted(self.not_avoided)]
 
-                def __format_li_pubs(pubs, res):
-                        i = 0
-                        for pub, sticky in pubs:
-                                s = "    {0} {1:d}: {2}".format(_("PUBLISHER"),
-                                    i, pub)
-                                mod = []
-                                if not sticky:
-                                        mod.append(_("non-sticky"))
-                                if mod:
-                                        s += " ({0})".format(",".join(mod))
-                                res.append(s)
-                                i += 1
+        def __format_li_pubs(pubs, res):
+            i = 0
+            for pub, sticky in pubs:
+                s = "    {0} {1:d}: {2}".format(_("PUBLISHER"), i, pub)
+                mod = []
+                if not sticky:
+                    mod.append(_("non-sticky"))
+                if mod:
+                    s += " ({0})".format(",".join(mod))
+                res.append(s)
+                i += 1
 
-                if self.linked_pub_error:
-                        res = []
-                        (pubs, parent_pubs) = self.linked_pub_error
+        if self.linked_pub_error:
+            res = []
+            (pubs, parent_pubs) = self.linked_pub_error
 
-                        res.append(_("""
+            res.append(
+                _(
+                    """
 Invalid child image publisher configuration.  Child image publisher
 configuration must be a superset of the parent image publisher configuration.
 Please update the child publisher configuration to match the parent.  If the
 child image is a zone this can be done automatically by detaching and
 attaching the zone.
 
-The parent image has the following enabled publishers:"""))
-                        __format_li_pubs(parent_pubs, res)
-                        res.append(_("""
-The child image has the following enabled publishers:"""))
-                        __format_li_pubs(pubs, res)
+The parent image has the following enabled publishers:"""
+                )
+            )
+            __format_li_pubs(parent_pubs, res)
+            res.append(
+                _(
+                    """
+The child image has the following enabled publishers:"""
+                )
+            )
+            __format_li_pubs(pubs, res)
 
-                if self.no_repo_pubs:
-                        res += [_("The following publishers do not have any "
-                            "configured package repositories and cannot be "
-                            "used in package dehydration or rehydration "
-                            "operations:\n")]
-                        res += ["\t{0}".format(s) for s in sorted(
-                            self.no_repo_pubs)]
+        if self.no_repo_pubs:
+            res += [
+                _(
+                    "The following publishers do not have any "
+                    "configured package repositories and cannot be "
+                    "used in package dehydration or rehydration "
+                    "operations:\n"
+                )
+            ]
+            res += ["\t{0}".format(s) for s in sorted(self.no_repo_pubs)]
 
-                return "\n".join(res)
+        return "\n".join(res)
 
 
 class ConflictingActionError(ApiException):
-        """Used to indicate that the imageplan would result in one or more sets
-        of conflicting actions, meaning that more than one action would exist on
-        the system with the same key attribute value in the same namespace.
-        There are three categories, each with its own subclass:
+    """Used to indicate that the imageplan would result in one or more sets
+    of conflicting actions, meaning that more than one action would exist on
+    the system with the same key attribute value in the same namespace.
+    There are three categories, each with its own subclass:
 
-          - multiple files delivered to the same path or drivers, users, groups,
-            etc, delivered with the same key attribute;
+      - multiple files delivered to the same path or drivers, users, groups,
+        etc, delivered with the same key attribute;
 
-          - multiple objects delivered to the same path which aren't the same
-            type;
+      - multiple objects delivered to the same path which aren't the same
+        type;
 
-          - multiple directories, links, or hardlinks delivered to the same path
-            but with conflicting attributes.
-        """
+      - multiple directories, links, or hardlinks delivered to the same path
+        but with conflicting attributes.
+    """
 
-        def __init__(self, data):
-                self._data = data
+    def __init__(self, data):
+        self._data = data
+
 
 class ConflictingActionErrors(ApiException):
-        """A container for multiple ConflictingActionError exception objects
-        that can be raised as a single exception."""
+    """A container for multiple ConflictingActionError exception objects
+    that can be raised as a single exception."""
 
-        def __init__(self, errors):
-                self.__errors = errors
+    def __init__(self, errors):
+        self.__errors = errors
 
-        def __str__(self):
-                return "\n\n".join((str(err) for err in self.__errors))
+    def __str__(self):
+        return "\n\n".join((str(err) for err in self.__errors))
+
 
 class DuplicateActionError(ConflictingActionError):
-        """Multiple actions of the same type have been delivered with the same
-        key attribute (when not allowed)."""
+    """Multiple actions of the same type have been delivered with the same
+    key attribute (when not allowed)."""
 
-        def __str__(self):
-                pfmris = set((a[1] for a in self._data))
-                kv = self._data[0][0].attrs[self._data[0][0].key_attr]
-                action = self._data[0][0].name
-                if len(pfmris) > 1:
-                        s = _("The following packages all deliver {action} "
-                            "actions to {kv}:\n").format(**locals())
-                        for a, p in self._data:
-                                s += "\n  {0}".format(p)
-                        s += _("\n\nThese packages cannot be installed "
-                            "together. Any non-conflicting subset\nof "
-                            "the above packages can be installed.")
-                else:
-                        pfmri = pfmris.pop()
-                        s = _("The package {pfmri} delivers multiple copies "
-                            "of {action} {kv}").format(**locals())
-                        s += _("\nThis package must be corrected before it "
-                            "can be installed.")
+    def __str__(self):
+        pfmris = set((a[1] for a in self._data))
+        kv = self._data[0][0].attrs[self._data[0][0].key_attr]
+        action = self._data[0][0].name
+        if len(pfmris) > 1:
+            s = _(
+                "The following packages all deliver {action} "
+                "actions to {kv}:\n"
+            ).format(**locals())
+            for a, p in self._data:
+                s += "\n  {0}".format(p)
+            s += _(
+                "\n\nThese packages cannot be installed "
+                "together. Any non-conflicting subset\nof "
+                "the above packages can be installed."
+            )
+        else:
+            pfmri = pfmris.pop()
+            s = _(
+                "The package {pfmri} delivers multiple copies "
+                "of {action} {kv}"
+            ).format(**locals())
+            s += _(
+                "\nThis package must be corrected before it "
+                "can be installed."
+            )
 
-                return s
+        return s
+
 
 class InconsistentActionTypeError(ConflictingActionError):
-        """Multiple actions of different types have been delivered with the same
-        'path' attribute.  While this exception could represent other action
-        groups which share a single namespace, none such exist."""
+    """Multiple actions of different types have been delivered with the same
+    'path' attribute.  While this exception could represent other action
+    groups which share a single namespace, none such exist."""
 
-        def __str__(self):
-                ad = {}
-                pfmris = set()
-                kv = self._data[0][0].attrs[self._data[0][0].key_attr]
-                for a, p in self._data:
-                        ad.setdefault(a.name, []).append(p)
-                        pfmris.add(p)
+    def __str__(self):
+        ad = {}
+        pfmris = set()
+        kv = self._data[0][0].attrs[self._data[0][0].key_attr]
+        for a, p in self._data:
+            ad.setdefault(a.name, []).append(p)
+            pfmris.add(p)
 
-                if len(pfmris) > 1:
-                        s = _("The following packages deliver conflicting "
-                            "action types to {0}:\n").format(kv)
-                        for name, pl in six.iteritems(ad):
-                                s += "\n  {0}:".format(name)
-                                s += "".join("\n    {0}".format(p) for p in pl)
-                        s += _("\n\nThese packages cannot be installed "
-                            "together. Any non-conflicting subset\nof "
-                            "the above packages can be installed.")
-                else:
-                        pfmri = pfmris.pop()
-                        types = list_to_lang(list(ad.keys()))
-                        s = _("The package {pfmri} delivers conflicting "
-                            "action types ({types}) to {kv}").format(**locals())
-                        s += _("\nThis package must be corrected before it "
-                            "can be installed.")
-                return s
+        if len(pfmris) > 1:
+            s = _(
+                "The following packages deliver conflicting "
+                "action types to {0}:\n"
+            ).format(kv)
+            for name, pl in six.iteritems(ad):
+                s += "\n  {0}:".format(name)
+                s += "".join("\n    {0}".format(p) for p in pl)
+            s += _(
+                "\n\nThese packages cannot be installed "
+                "together. Any non-conflicting subset\nof "
+                "the above packages can be installed."
+            )
+        else:
+            pfmri = pfmris.pop()
+            types = list_to_lang(list(ad.keys()))
+            s = _(
+                "The package {pfmri} delivers conflicting "
+                "action types ({types}) to {kv}"
+            ).format(**locals())
+            s += _(
+                "\nThis package must be corrected before it "
+                "can be installed."
+            )
+        return s
+
 
 class InconsistentActionAttributeError(ConflictingActionError):
-        """Multiple actions of the same type representing the same object have
-        have been delivered, but with conflicting attributes, such as two
-        directories at /usr with groups 'root' and 'sys', or two 'root' users
-        with uids '0' and '7'."""
+    """Multiple actions of the same type representing the same object have
+    have been delivered, but with conflicting attributes, such as two
+    directories at /usr with groups 'root' and 'sys', or two 'root' users
+    with uids '0' and '7'."""
 
-        def __str__(self):
-                actions = self._data
-                keyattr = actions[0][0].attrs[actions[0][0].key_attr]
-                actname = actions[0][0].name
+    def __str__(self):
+        actions = self._data
+        keyattr = actions[0][0].attrs[actions[0][0].key_attr]
+        actname = actions[0][0].name
 
-                # Trim the action's attributes to only those required to be
-                # unique.
-                def ou(action):
-                        ua = dict(
-                            (k, v)
-                            for k, v in six.iteritems(action.attrs)
-                            if ((k in action.unique_attrs and
-                                not (k == "preserve" and "overlay" in action.attrs)) or
-                                ((action.name == "link" or action.name == "hardlink") and
-                                k.startswith("mediator")))
-                        )
-                        action.attrs = ua
-                        return action
+        # Trim the action's attributes to only those required to be
+        # unique.
+        def ou(action):
+            ua = dict(
+                (k, v)
+                for k, v in six.iteritems(action.attrs)
+                if (
+                    (
+                        k in action.unique_attrs
+                        and not (k == "preserve" and "overlay" in action.attrs)
+                    )
+                    or (
+                        (action.name == "link" or action.name == "hardlink")
+                        and k.startswith("mediator")
+                    )
+                )
+            )
+            action.attrs = ua
+            return action
 
-                d = {}
-                for a in actions:
-                        if a[0].attrs.get("implicit", "false") == "false":
-                                d.setdefault(str(ou(a[0])), set()).add(a[1])
-                l = sorted([
-                    (len(pkglist), action, pkglist)
-                    for action, pkglist in six.iteritems(d)
-                ])
+        d = {}
+        for a in actions:
+            if a[0].attrs.get("implicit", "false") == "false":
+                d.setdefault(str(ou(a[0])), set()).add(a[1])
+        l = sorted(
+            [
+                (len(pkglist), action, pkglist)
+                for action, pkglist in six.iteritems(d)
+            ]
+        )
 
-                s = _("The requested change to the system attempts to install "
-                    "multiple actions\nfor {a} '{k}' with conflicting "
-                    "attributes:\n\n").format(a=actname, k=keyattr)
-                allpkgs = set()
-                for num, action, pkglist in l:
-                        allpkgs.update(pkglist)
-                        if num <= 5:
-                                if num == 1:
-                                        t = _("    {n:d} package delivers '{a}':\n")
-                                else:
-                                        t = _("    {n:d} packages deliver '{a}':\n")
-                                s += t.format(n=num, a=action)
-                                for pkg in sorted(pkglist):
-                                        s += _("        {0}\n").format(pkg)
-                        else:
-                                t = _("    {n:d} packages deliver '{a}', including:\n")
-                                s += t.format(n=num, a=action)
-                                for pkg in sorted(pkglist)[:5]:
-                                        s += _("        {0}\n").format(pkg)
-
-                if len(allpkgs) == 1:
-                        s += _("\nThis package must be corrected before it "
-                            "can be installed.")
+        s = _(
+            "The requested change to the system attempts to install "
+            "multiple actions\nfor {a} '{k}' with conflicting "
+            "attributes:\n\n"
+        ).format(a=actname, k=keyattr)
+        allpkgs = set()
+        for num, action, pkglist in l:
+            allpkgs.update(pkglist)
+            if num <= 5:
+                if num == 1:
+                    t = _("    {n:d} package delivers '{a}':\n")
                 else:
-                        s += _("\n\nThese packages cannot be installed "
-                            "together. Any non-conflicting subset\nof "
-                            "the above packages can be installed.")
+                    t = _("    {n:d} packages deliver '{a}':\n")
+                s += t.format(n=num, a=action)
+                for pkg in sorted(pkglist):
+                    s += _("        {0}\n").format(pkg)
+            else:
+                t = _("    {n:d} packages deliver '{a}', including:\n")
+                s += t.format(n=num, a=action)
+                for pkg in sorted(pkglist)[:5]:
+                    s += _("        {0}\n").format(pkg)
 
-                return s
+        if len(allpkgs) == 1:
+            s += _(
+                "\nThis package must be corrected before it "
+                "can be installed."
+            )
+        else:
+            s += _(
+                "\n\nThese packages cannot be installed "
+                "together. Any non-conflicting subset\nof "
+                "the above packages can be installed."
+            )
+
+        return s
 
 
 class ImageBoundaryError(ApiException):
-        """Used to indicate that a file is delivered to image dir"""
+    """Used to indicate that a file is delivered to image dir"""
 
-        GENERIC    = "generic"     # generic image boundary violation
-        OUTSIDE_BE = "outside_be"  # deliver items outside boot environment
-        RESERVED   = "reserved"    # deliver items to reserved dirs
+    GENERIC = "generic"  # generic image boundary violation
+    OUTSIDE_BE = "outside_be"  # deliver items outside boot environment
+    RESERVED = "reserved"  # deliver items to reserved dirs
 
-        def __init__(self, fmri, actions=None):
-                """fmri is the package fmri
-                actions should be a dictionary of which key is the
-                error type and value is a list of actions"""
+    def __init__(self, fmri, actions=None):
+        """fmri is the package fmri
+        actions should be a dictionary of which key is the
+        error type and value is a list of actions"""
 
-                ApiException.__init__(self)
-                self.fmri = fmri
-                generic = _("The following items are outside the boundaries "
-                    "of the target image:\n\n")
-                outside_be = _("The following items are delivered outside "
-                    "the target boot environment:\n\n")
-                reserved = _("The following items are delivered to "
-                    "reserved directories:\n\n")
+        ApiException.__init__(self)
+        self.fmri = fmri
+        generic = _(
+            "The following items are outside the boundaries "
+            "of the target image:\n\n"
+        )
+        outside_be = _(
+            "The following items are delivered outside "
+            "the target boot environment:\n\n"
+        )
+        reserved = _(
+            "The following items are delivered to " "reserved directories:\n\n"
+        )
 
-                self.message = {
-                    self.GENERIC: generic,
-                    self.OUTSIDE_BE: outside_be,
-                    self.RESERVED: reserved
-                }
+        self.message = {
+            self.GENERIC: generic,
+            self.OUTSIDE_BE: outside_be,
+            self.RESERVED: reserved,
+        }
 
-                if actions:
-                        self.actions = actions
+        if actions:
+            self.actions = actions
+        else:
+            self.actions = {}
+
+    def append_error(self, action, err_type=GENERIC):
+        """This function is used to append errors in the error
+        dictionary"""
+
+        if action:
+            self.actions.setdefault(err_type, []).append(action)
+
+    def isEmpty(self):
+        """Return whether error dictionary is empty"""
+
+        return len(self.actions) == 0
+
+    def __str__(self):
+        error_list = [self.GENERIC, self.OUTSIDE_BE, self.RESERVED]
+        s = ""
+        for err_type in error_list:
+            if not err_type in self.actions:
+                continue
+            if self.actions[err_type]:
+                if err_type == self.GENERIC:
+                    s += (
+                        "The package {0} delivers items"
+                        " outside the boundaries of"
+                        " the target image and can not be"
+                        " installed.\n\n"
+                    ).format(self.fmri)
+                elif err_type == self.OUTSIDE_BE:
+                    s += (
+                        "The package {0} delivers items"
+                        " outside the target boot"
+                        " environment and can not be"
+                        " installed.\n\n"
+                    ).format(self.fmri)
                 else:
-                        self.actions = {}
-
-        def append_error(self, action, err_type=GENERIC):
-                """This function is used to append errors in the error
-                dictionary"""
-
-                if action:
-                        self.actions.setdefault(err_type, []).append(action)
-
-        def isEmpty(self):
-                """Return whether error dictionary is empty"""
-
-                return len(self.actions) == 0
-
-        def __str__(self):
-                error_list = [self.GENERIC, self.OUTSIDE_BE, self.RESERVED]
-                s = ""
-                for err_type in error_list:
-                        if not err_type in self.actions:
-                                continue
-                        if self.actions[err_type]:
-                                if err_type == self.GENERIC:
-                                        s += ("The package {0} delivers items"
-                                            " outside the boundaries of"
-                                            " the target image and can not be"
-                                            " installed.\n\n").format(self.fmri)
-                                elif err_type == self.OUTSIDE_BE:
-                                        s += ("The package {0} delivers items"
-                                            " outside the target boot"
-                                            " environment and can not be"
-                                            " installed.\n\n").format(self.fmri)
-                                else:
-                                        s += ("The package {0} delivers items"
-                                            " to reserved directories and can"
-                                            " not be installed.\n\n").format(self.fmri) 
-                                s += self.message[err_type]
-                        for action in self.actions[err_type]:
-                                s += ("      {0} {1}\n").format(
-                                    action.name, action.attrs["path"])
-                return s
+                    s += (
+                        "The package {0} delivers items"
+                        " to reserved directories and can"
+                        " not be installed.\n\n"
+                    ).format(self.fmri)
+                s += self.message[err_type]
+            for action in self.actions[err_type]:
+                s += ("      {0} {1}\n").format(
+                    action.name, action.attrs["path"]
+                )
+        return s
 
 
 class ImageBoundaryErrors(ApiException):
-        """A container for multiple ImageBoundaryError exception objects
-        that can be raised as a single exception."""
+    """A container for multiple ImageBoundaryError exception objects
+    that can be raised as a single exception."""
 
-        def __init__(self, errors):
-                ApiException.__init__(self)
-                self.__errors = errors
+    def __init__(self, errors):
+        ApiException.__init__(self)
+        self.__errors = errors
 
-                generic = _("The following packages deliver items outside "
-                    "the boundaries of the target image and can not be "
-                    "installed:\n\n")
-                outside_be = _("The following packages deliver items outside "
-                    "the target boot environment and can not be "
-                    "installed:\n\n")
-                reserved = _("The following packages deliver items to reserved "
-                    "directories and can not be installed:\n\n")
+        generic = _(
+            "The following packages deliver items outside "
+            "the boundaries of the target image and can not be "
+            "installed:\n\n"
+        )
+        outside_be = _(
+            "The following packages deliver items outside "
+            "the target boot environment and can not be "
+            "installed:\n\n"
+        )
+        reserved = _(
+            "The following packages deliver items to reserved "
+            "directories and can not be installed:\n\n"
+        )
 
-                self.message = {
-                    ImageBoundaryError.GENERIC: generic,
-                    ImageBoundaryError.OUTSIDE_BE: outside_be,
-                    ImageBoundaryError.RESERVED: reserved
-                }
+        self.message = {
+            ImageBoundaryError.GENERIC: generic,
+            ImageBoundaryError.OUTSIDE_BE: outside_be,
+            ImageBoundaryError.RESERVED: reserved,
+        }
 
-        def __str__(self):
-                if len(self.__errors) <= 1:
-                        return "\n".join([str(err) for err in self.__errors])
+    def __str__(self):
+        if len(self.__errors) <= 1:
+            return "\n".join([str(err) for err in self.__errors])
 
-                s = ""
-                for err_type in self.message:
-                        cur_errs = []
-                        for err in self.__errors:
-                                # If err does not contain this error type
-                                # we just ignore this.
-                                if not err_type in err.actions or \
-                                    not err.actions[err_type]:
-                                            continue
-                                cur_errs.append(err)
+        s = ""
+        for err_type in self.message:
+            cur_errs = []
+            for err in self.__errors:
+                # If err does not contain this error type
+                # we just ignore this.
+                if not err_type in err.actions or not err.actions[err_type]:
+                    continue
+                cur_errs.append(err)
 
-                        if not cur_errs:
-                                continue
+            if not cur_errs:
+                continue
 
-                        if len(cur_errs) == 1:
-                                s += str(cur_errs[0]) + "\n"
-                                continue
+            if len(cur_errs) == 1:
+                s += str(cur_errs[0]) + "\n"
+                continue
 
-                        s += self.message[err_type]
-                        for err in cur_errs:
-                                s += ("    {0}\n").format(err.fmri)
-                                for action in err.actions[err_type]:
-                                        s += ("      {0} {1}\n").format(
-                                            action.name, action.attrs["path"])
-                                s += "\n"
-                return s
+            s += self.message[err_type]
+            for err in cur_errs:
+                s += ("    {0}\n").format(err.fmri)
+                for action in err.actions[err_type]:
+                    s += ("      {0} {1}\n").format(
+                        action.name, action.attrs["path"]
+                    )
+                s += "\n"
+        return s
 
 
 def list_to_lang(l):
-        """Takes a list of items and puts them into a string, with commas in
-        between items, and an "and" between the last two items.  Special cases
-        for lists of two or fewer items, and uses the Oxford comma."""
+    """Takes a list of items and puts them into a string, with commas in
+    between items, and an "and" between the last two items.  Special cases
+    for lists of two or fewer items, and uses the Oxford comma."""
 
-        if not l:
-                return ""
-        if len(l) == 1:
-                return l[0]
-        if len(l) == 2:
-                # Used for a two-element list
-                return _("{penultimate} and {ultimate}").format(
-                    penultimate=l[0],
-                    ultimate=l[1]
-               )
-        # In order to properly i18n this construct, we create two templates:
-        # one for each element save the last, and one that tacks on the last
-        # element.
-        # 'elementtemplate' is for each element through the penultimate
-        elementtemplate = _("{0}, ")
-        # 'listtemplate' concatenates the concatenation of non-ultimate elements
-        # and the ultimate element.
-        listtemplate = _("{list}and {tail}")
-        return listtemplate.format(
-            list="".join(elementtemplate.format(i) for i in l[:-1]),
-            tail=l[-1]
-       )
+    if not l:
+        return ""
+    if len(l) == 1:
+        return l[0]
+    if len(l) == 2:
+        # Used for a two-element list
+        return _("{penultimate} and {ultimate}").format(
+            penultimate=l[0], ultimate=l[1]
+        )
+    # In order to properly i18n this construct, we create two templates:
+    # one for each element save the last, and one that tacks on the last
+    # element.
+    # 'elementtemplate' is for each element through the penultimate
+    elementtemplate = _("{0}, ")
+    # 'listtemplate' concatenates the concatenation of non-ultimate elements
+    # and the ultimate element.
+    listtemplate = _("{list}and {tail}")
+    return listtemplate.format(
+        list="".join(elementtemplate.format(i) for i in l[:-1]), tail=l[-1]
+    )
+
 
 class ActionExecutionError(ApiException):
-        """Used to indicate that action execution (such as install, remove,
-        etc.) failed even though the action is valid.
+    """Used to indicate that action execution (such as install, remove,
+    etc.) failed even though the action is valid.
 
-        In particular, this exception indicates that something went wrong in the
-        application (or unapplication) of the action to the system, and is most
-        likely not an error in the pkg(7) code."""
+    In particular, this exception indicates that something went wrong in the
+    application (or unapplication) of the action to the system, and is most
+    likely not an error in the pkg(7) code."""
 
-        def __init__(self, action, details=None, error=None, fmri=None,
-            use_errno=None):
-                """'action' is the object for the action that failed during the
-                requested operation.
+    def __init__(
+        self, action, details=None, error=None, fmri=None, use_errno=None
+    ):
+        """'action' is the object for the action that failed during the
+        requested operation.
 
-                'details' is an optional message explaining what operation
-                failed, why it failed, and why it cannot continue.  It should
-                also include a suggestion as to how to resolve the situation
-                if possible.
+        'details' is an optional message explaining what operation
+        failed, why it failed, and why it cannot continue.  It should
+        also include a suggestion as to how to resolve the situation
+        if possible.
 
-                'error' is an optional exception object that may have been
-                raised when the operation failed.
+        'error' is an optional exception object that may have been
+        raised when the operation failed.
 
-                'fmri' is an optional package FMRI indicating what package
-                was being operated on at the time the error occurred.
+        'fmri' is an optional package FMRI indicating what package
+        was being operated on at the time the error occurred.
 
-                'use_errno' is an optional boolean value indicating whether
-                the strerror() text of the exception should be used.  If
-                'details' is provided, the default value is False, otherwise
-                True."""
+        'use_errno' is an optional boolean value indicating whether
+        the strerror() text of the exception should be used.  If
+        'details' is provided, the default value is False, otherwise
+        True."""
 
-                assert (details or error)
-                self.action = action
-                self.details = details
-                self.error = error
-                self.fmri = fmri
-                if use_errno == None:
-                        # If details were provided, don't use errno unless
-                        # explicitly requested.
-                        use_errno = not details
-                self.use_errno = use_errno
+        assert details or error
+        self.action = action
+        self.details = details
+        self.error = error
+        self.fmri = fmri
+        if use_errno == None:
+            # If details were provided, don't use errno unless
+            # explicitly requested.
+            use_errno = not details
+        self.use_errno = use_errno
 
-        @property
-        def errno(self):
-                if self.error and hasattr(self.error, "errno"):
-                        return self.error.errno
-                return None
+    @property
+    def errno(self):
+        if self.error and hasattr(self.error, "errno"):
+            return self.error.errno
+        return None
 
-        def __str__(self):
-                errno = ""
-                if self.use_errno and self.errno is not None:
-                        errno = "[errno {0:d}: {1}]".format(self.errno,
-                            os.strerror(self.errno))
+    def __str__(self):
+        errno = ""
+        if self.use_errno and self.errno is not None:
+            errno = "[errno {0:d}: {1}]".format(
+                self.errno, os.strerror(self.errno)
+            )
 
-                details = self.details or ""
+        details = self.details or ""
 
-                # Fall back on the wrapped exception if we don't have anything
-                # useful.
-                if not errno and not details:
-                        return str(self.error)
+        # Fall back on the wrapped exception if we don't have anything
+        # useful.
+        if not errno and not details:
+            return str(self.error)
 
-                if errno and details:
-                        details = "{0}: {1}".format(errno, details)
+        if errno and details:
+            details = "{0}: {1}".format(errno, details)
 
-                if details and not self.fmri:
-                        details = _("Requested operation failed for action "
-                            "{action}:\n{details}").format(
-                            action=self.action,
-                            details=details)
-                elif details:
-                        details = _("Requested operation failed for package "
-                            "{fmri}:\n{details}").format(fmri=self.fmri,
-                            details=details)
+        if details and not self.fmri:
+            details = _(
+                "Requested operation failed for action " "{action}:\n{details}"
+            ).format(action=self.action, details=details)
+        elif details:
+            details = _(
+                "Requested operation failed for package " "{fmri}:\n{details}"
+            ).format(fmri=self.fmri, details=details)
 
-                # If we only have one of the two, no need for the colon.
-                return "{0}{1}".format(errno, details)
+        # If we only have one of the two, no need for the colon.
+        return "{0}{1}".format(errno, details)
 
 
 class CatalogOriginRefreshException(ApiException):
-        def __init__(self, failed, total, errmessage=None):
-                ApiException.__init__(self)
-                self.failed = failed
-                self.total = total
-                self.errmessage = errmessage
+    def __init__(self, failed, total, errmessage=None):
+        ApiException.__init__(self)
+        self.failed = failed
+        self.total = total
+        self.errmessage = errmessage
 
 
 class CatalogRefreshException(ApiException):
-        def __init__(self, failed, total, succeeded, errmessage=None):
-                ApiException.__init__(self)
-                self.failed = failed
-                self.total = total
-                self.succeeded = succeeded
-                self.errmessage = errmessage
+    def __init__(self, failed, total, succeeded, errmessage=None):
+        ApiException.__init__(self)
+        self.failed = failed
+        self.total = total
+        self.succeeded = succeeded
+        self.errmessage = errmessage
 
 
 class CatalogError(ApiException):
-        """Base exception class for all catalog exceptions."""
+    """Base exception class for all catalog exceptions."""
 
-        def __init__(self, *args, **kwargs):
-                ApiException.__init__(self)
-                if args:
-                        self.data = args[0]
-                else:
-                        self.data = None
-                self._args = kwargs
+    def __init__(self, *args, **kwargs):
+        ApiException.__init__(self)
+        if args:
+            self.data = args[0]
+        else:
+            self.data = None
+        self._args = kwargs
 
-        def __str__(self):
-                return str(self.data)
+    def __str__(self):
+        return str(self.data)
 
 
 class AnarchicalCatalogFMRI(CatalogError):
-        """Used to indicate that the specified FMRI is not valid for catalog
-        operations because it is missing publisher information."""
+    """Used to indicate that the specified FMRI is not valid for catalog
+    operations because it is missing publisher information."""
 
-        def __str__(self):
-                return _("The FMRI '{0}' does not contain publisher information "
-                    "and cannot be used for catalog operations.").format(
-                    self.data)
+    def __str__(self):
+        return _(
+            "The FMRI '{0}' does not contain publisher information "
+            "and cannot be used for catalog operations."
+        ).format(self.data)
 
 
 class BadCatalogMetaRoot(CatalogError):
-        """Used to indicate an operation on the catalog's meta_root failed
-        because the meta_root is invalid."""
+    """Used to indicate an operation on the catalog's meta_root failed
+    because the meta_root is invalid."""
 
-        def __str__(self):
-                return _("Catalog meta_root '{root}' is invalid; unable "
-                    "to complete operation: '{op}'.").format(root=self.data,
-                    op=self._args.get("operation", None))
+    def __str__(self):
+        return _(
+            "Catalog meta_root '{root}' is invalid; unable "
+            "to complete operation: '{op}'."
+        ).format(root=self.data, op=self._args.get("operation", None))
 
 
 class BadCatalogPermissions(CatalogError):
-        """Used to indicate the server catalog files do not have the expected
-        permissions."""
+    """Used to indicate the server catalog files do not have the expected
+    permissions."""
 
-        def __init__(self, files):
-                """files should contain a list object with each entry consisting
-                of a tuple of filename, expected_mode, received_mode."""
-                if not files:
-                        files = []
-                CatalogError.__init__(self, files)
+    def __init__(self, files):
+        """files should contain a list object with each entry consisting
+        of a tuple of filename, expected_mode, received_mode."""
+        if not files:
+            files = []
+        CatalogError.__init__(self, files)
 
-        def __str__(self):
-                msg = _("The following catalog files have incorrect "
-                    "permissions:\n")
-                for f in self.data:
-                        fname, emode, fmode = f
-                        msg += _("\t{fname}: expected mode: {emode}, found "
-                            "mode: {fmode}\n").format(fname=fname,
-                            emode=emode, fmode=fmode)
-                return msg
+    def __str__(self):
+        msg = _("The following catalog files have incorrect " "permissions:\n")
+        for f in self.data:
+            fname, emode, fmode = f
+            msg += _(
+                "\t{fname}: expected mode: {emode}, found " "mode: {fmode}\n"
+            ).format(fname=fname, emode=emode, fmode=fmode)
+        return msg
 
 
 class BadCatalogSignatures(CatalogError):
-        """Used to indicate that the Catalog signatures are not valid."""
+    """Used to indicate that the Catalog signatures are not valid."""
 
-        def __str__(self):
-                return _("The signature data for the '{0}' catalog file is not "
-                    "valid.").format(self.data)
+    def __str__(self):
+        return _(
+            "The signature data for the '{0}' catalog file is not " "valid."
+        ).format(self.data)
 
 
 class BadCatalogUpdateIdentity(CatalogError):
-        """Used to indicate that the requested catalog updates could not be
-        applied as the new catalog data is significantly different such that
-        the old catalog cannot be updated to match it."""
+    """Used to indicate that the requested catalog updates could not be
+    applied as the new catalog data is significantly different such that
+    the old catalog cannot be updated to match it."""
 
-        def __str__(self):
-                return _("Unable to determine the updates needed for  "
-                    "the current catalog using the provided catalog "
-                    "update data in '{0}'.").format(self.data)
+    def __str__(self):
+        return _(
+            "Unable to determine the updates needed for  "
+            "the current catalog using the provided catalog "
+            "update data in '{0}'."
+        ).format(self.data)
 
 
 class DuplicateCatalogEntry(CatalogError):
-        """Used to indicate that the specified catalog operation could not be
-        performed since it would result in a duplicate catalog entry."""
+    """Used to indicate that the specified catalog operation could not be
+    performed since it would result in a duplicate catalog entry."""
 
-        def __str__(self):
-                return _("Unable to perform '{op}' operation for catalog "
-                    "{name}; completion would result in a duplicate entry "
-                    "for package '{fmri}'.").format(op=self._args.get(
-                    "operation", None), name=self._args.get("catalog_name",
-                    None), fmri=self.data)
+    def __str__(self):
+        return _(
+            "Unable to perform '{op}' operation for catalog "
+            "{name}; completion would result in a duplicate entry "
+            "for package '{fmri}'."
+        ).format(
+            op=self._args.get("operation", None),
+            name=self._args.get("catalog_name", None),
+            fmri=self.data,
+        )
 
 
 class CatalogUpdateRequirements(CatalogError):
-        """Used to indicate that an update request for the catalog could not
-        be performed because update requirements were not satisfied."""
+    """Used to indicate that an update request for the catalog could not
+    be performed because update requirements were not satisfied."""
 
-        def __str__(self):
-                return _("Catalog updates can only be applied to an on-disk "
-                    "catalog.")
+    def __str__(self):
+        return _(
+            "Catalog updates can only be applied to an on-disk " "catalog."
+        )
 
 
 class InvalidCatalogFile(CatalogError):
-        """Used to indicate a Catalog file could not be loaded."""
+    """Used to indicate a Catalog file could not be loaded."""
 
-        def __str__(self):
-                return _("Catalog file '{0}' is invalid.\nUse 'pkgrepo rebuild' "
-                    "to create a new package catalog.").format(self.data)
+    def __str__(self):
+        return _(
+            "Catalog file '{0}' is invalid.\nUse 'pkgrepo rebuild' "
+            "to create a new package catalog."
+        ).format(self.data)
 
 
 class MismatchedCatalog(CatalogError):
-        """Used to indicate that a Catalog's attributes and parts do not
-        match.  This is likely the result of an attributes file being
-        retrieved which doesn't match the parts that were retrieved such
-        as in a misconfigured or stale cache case."""
+    """Used to indicate that a Catalog's attributes and parts do not
+    match.  This is likely the result of an attributes file being
+    retrieved which doesn't match the parts that were retrieved such
+    as in a misconfigured or stale cache case."""
 
-        def __str__(self):
-                return _("The content of the catalog for publisher '{0}' "
-                    "doesn't match the catalog's attributes.  This is "
-                    "likely the result of a mix of older and newer "
-                    "catalog files being provided for the publisher.").format(
-                    self.data)
+    def __str__(self):
+        return _(
+            "The content of the catalog for publisher '{0}' "
+            "doesn't match the catalog's attributes.  This is "
+            "likely the result of a mix of older and newer "
+            "catalog files being provided for the publisher."
+        ).format(self.data)
 
 
 class ObsoleteCatalogUpdate(CatalogError):
-        """Used to indicate that the specified catalog updates are for an older
-        version of the catalog and cannot be applied."""
+    """Used to indicate that the specified catalog updates are for an older
+    version of the catalog and cannot be applied."""
 
-        def __str__(self):
-                return _("Unable to determine the updates needed for the "
-                    "catalog using the provided catalog update data in '{0}'. "
-                    "The specified catalog updates are for an older version "
-                    "of the catalog and cannot be used.").format(self.data)
+    def __str__(self):
+        return _(
+            "Unable to determine the updates needed for the "
+            "catalog using the provided catalog update data in '{0}'. "
+            "The specified catalog updates are for an older version "
+            "of the catalog and cannot be used."
+        ).format(self.data)
 
 
 class UnknownCatalogEntry(CatalogError):
-        """Used to indicate that an entry for the specified package FMRI or
-        pattern could not be found in the catalog."""
+    """Used to indicate that an entry for the specified package FMRI or
+    pattern could not be found in the catalog."""
 
-        def __str__(self):
-                return _("'{0}' could not be found in the catalog.").format(
-                    self.data)
+    def __str__(self):
+        return _("'{0}' could not be found in the catalog.").format(self.data)
 
 
 class UnknownUpdateType(CatalogError):
-        """Used to indicate that the specified CatalogUpdate operation is
-        unknown."""
+    """Used to indicate that the specified CatalogUpdate operation is
+    unknown."""
 
-        def __str__(self):
-                return _("Unknown catalog update type '{0}'").format(self.data)
+    def __str__(self):
+        return _("Unknown catalog update type '{0}'").format(self.data)
 
 
 class UnrecognizedCatalogPart(CatalogError):
-        """Raised when the catalog finds a CatalogPart that is unrecognized
-        or invalid."""
+    """Raised when the catalog finds a CatalogPart that is unrecognized
+    or invalid."""
 
-        def __str__(self):
-                return _("Unrecognized, unknown, or invalid CatalogPart '{0}'").format(
-                    self.data)
+    def __str__(self):
+        return _("Unrecognized, unknown, or invalid CatalogPart '{0}'").format(
+            self.data
+        )
 
 
 class InventoryException(ApiException):
-        """Used to indicate that some of the specified patterns to a catalog
-        matching function did not match any catalog entries, or were invalid
-        patterns."""
+    """Used to indicate that some of the specified patterns to a catalog
+    matching function did not match any catalog entries, or were invalid
+    patterns."""
 
-        def __init__(self, illegal=EmptyI, matcher=EmptyI, notfound=EmptyI,
-            publisher=EmptyI, version=EmptyI):
-                ApiException.__init__(self)
-                self.illegal = illegal
-                self.matcher = matcher
-                self.notfound = set(notfound)
-                self.publisher = publisher
-                self.version = version
+    def __init__(
+        self,
+        illegal=EmptyI,
+        matcher=EmptyI,
+        notfound=EmptyI,
+        publisher=EmptyI,
+        version=EmptyI,
+    ):
+        ApiException.__init__(self)
+        self.illegal = illegal
+        self.matcher = matcher
+        self.notfound = set(notfound)
+        self.publisher = publisher
+        self.version = version
 
-                self.notfound.update(matcher)
-                self.notfound.update(publisher)
-                self.notfound.update(version)
-                self.notfound = sorted(list(self.notfound))
+        self.notfound.update(matcher)
+        self.notfound.update(publisher)
+        self.notfound.update(version)
+        self.notfound = sorted(list(self.notfound))
 
-                assert self.illegal or self.notfound
+        assert self.illegal or self.notfound
 
-        def __str__(self):
-                outstr = ""
-                for x in self.illegal:
-                        # Illegal FMRIs have their own __str__ method
-                        outstr += "{0}\n".format(x)
+    def __str__(self):
+        outstr = ""
+        for x in self.illegal:
+            # Illegal FMRIs have their own __str__ method
+            outstr += "{0}\n".format(x)
 
-                if self.matcher or self.publisher or self.version:
-                        outstr += _("No matching package could be found for "
-                            "the following FMRIs in any of the catalogs for "
-                            "the current publishers:\n")
+        if self.matcher or self.publisher or self.version:
+            outstr += _(
+                "No matching package could be found for "
+                "the following FMRIs in any of the catalogs for "
+                "the current publishers:\n"
+            )
 
-                        for x in self.matcher:
-                                outstr += \
-                                    _("{0} (pattern did not match)\n").format(x)
-                        for x in self.publisher:
-                                outstr += _("{0} (publisher did not "
-                                    "match)\n").format(x)
-                        for x in self.version:
-                                outstr += \
-                                    _("{0} (version did not match)\n").format(x)
-                return outstr
+            for x in self.matcher:
+                outstr += _("{0} (pattern did not match)\n").format(x)
+            for x in self.publisher:
+                outstr += _("{0} (publisher did not " "match)\n").format(x)
+            for x in self.version:
+                outstr += _("{0} (version did not match)\n").format(x)
+        return outstr
 
 
 # SearchExceptions
 
+
 class SearchException(ApiException):
-        """Based class used for all search-related api exceptions."""
-        pass
+    """Based class used for all search-related api exceptions."""
+
+    pass
 
 
 class MalformedSearchRequest(SearchException):
-        """Raised when the server cannot understand the format of the
-        search request."""
+    """Raised when the server cannot understand the format of the
+    search request."""
 
-        def __init__(self, url):
-                SearchException.__init__(self)
-                self.url = url
+    def __init__(self, url):
+        SearchException.__init__(self)
+        self.url = url
 
-        def __str__(self):
-                return str(self.url)
+    def __str__(self):
+        return str(self.url)
 
 
 class NegativeSearchResult(SearchException):
-        """Returned when the search cannot find any matches."""
+    """Returned when the search cannot find any matches."""
 
-        def __init__(self, url):
-                SearchException.__init__(self)
-                self.url = url
+    def __init__(self, url):
+        SearchException.__init__(self)
+        self.url = url
 
-        def __str__(self):
-                return _("The search at url {0} returned no results.").format(
-                    self.url)
+    def __str__(self):
+        return _("The search at url {0} returned no results.").format(self.url)
 
 
 class ProblematicSearchServers(SearchException):
-        """This class wraps exceptions which could appear while trying to
-        do a search request."""
+    """This class wraps exceptions which could appear while trying to
+    do a search request."""
 
-        def __init__(self, failed=EmptyI, invalid=EmptyI, unsupported=EmptyI):
-                SearchException.__init__(self)
-                self.failed_servers = failed
-                self.invalid_servers  = invalid
-                self.unsupported_servers = unsupported
+    def __init__(self, failed=EmptyI, invalid=EmptyI, unsupported=EmptyI):
+        SearchException.__init__(self)
+        self.failed_servers = failed
+        self.invalid_servers = invalid
+        self.unsupported_servers = unsupported
 
-        def __str__(self):
-                s = _("Some repositories failed to respond appropriately:\n")
-                for pub, err in self.failed_servers:
-                        s += _("{o}:\n{msg}\n").format(
-                            o=pub, msg=err)
-                for pub in self.invalid_servers:
-                        s += _("{0} did not return a valid "
-                            "response.\n".format(pub))
-                if len(self.unsupported_servers) > 0:
-                        s += _("Some repositories don't support requested "
-                            "search operation:\n")
-                for pub, err in self.unsupported_servers:
-                        s += _("{o}:\n{msg}\n").format(
-                            o=pub, msg=err)
+    def __str__(self):
+        s = _("Some repositories failed to respond appropriately:\n")
+        for pub, err in self.failed_servers:
+            s += _("{o}:\n{msg}\n").format(o=pub, msg=err)
+        for pub in self.invalid_servers:
+            s += _("{0} did not return a valid " "response.\n".format(pub))
+        if len(self.unsupported_servers) > 0:
+            s += _(
+                "Some repositories don't support requested "
+                "search operation:\n"
+            )
+        for pub, err in self.unsupported_servers:
+            s += _("{o}:\n{msg}\n").format(o=pub, msg=err)
 
-                return s
+        return s
 
 
 class SlowSearchUsed(SearchException):
-        """This exception is thrown when a local search is performed without
-        an index.  It's raised after all results have been yielded."""
+    """This exception is thrown when a local search is performed without
+    an index.  It's raised after all results have been yielded."""
 
-        def __str__(self):
-                return _("Search performance is degraded.\n"
-                    "Run 'pkg rebuild-index' to improve search speed.")
+    def __str__(self):
+        return _(
+            "Search performance is degraded.\n"
+            "Run 'pkg rebuild-index' to improve search speed."
+        )
 
 
 @total_ordering
 class UnsupportedSearchError(SearchException):
-        """Returned when a search protocol is not supported by the
-        remote server."""
+    """Returned when a search protocol is not supported by the
+    remote server."""
 
-        def __init__(self, url=None, proto=None):
-                SearchException.__init__(self)
-                self.url = url
-                self.proto = proto
+    def __init__(self, url=None, proto=None):
+        SearchException.__init__(self)
+        self.url = url
+        self.proto = proto
 
-        def __str__(self):
-                s = _("Search repository does not support the requested "
-                    "protocol:")
-                if self.url:
-                        s += "\nRepository URL: {0}".format(self.url)
-                if self.proto:
-                        s += "\nRequested operation: {0}".format(self.proto)
-                return s
+    def __str__(self):
+        s = _("Search repository does not support the requested " "protocol:")
+        if self.url:
+            s += "\nRepository URL: {0}".format(self.url)
+        if self.proto:
+            s += "\nRequested operation: {0}".format(self.proto)
+        return s
 
-        def __eq__(self, other):
-                if not isinstance(other, UnsupportedSearchError):
-                        return False
-                return self.url == other.url and \
-                    self.proto == other.proto
+    def __eq__(self, other):
+        if not isinstance(other, UnsupportedSearchError):
+            return False
+        return self.url == other.url and self.proto == other.proto
 
-        def __le__(self, other):
-                if not isinstance(other, UnsupportedSearchError):
-                        return True
-                if self.url < other.url:
-                        return True
-                if self.url != other.url:
-                        return False
-                return self.proto < other.proto
+    def __le__(self, other):
+        if not isinstance(other, UnsupportedSearchError):
+            return True
+        if self.url < other.url:
+            return True
+        if self.url != other.url:
+            return False
+        return self.proto < other.proto
 
-        def __hash__(self):
-                return hash((self.url, self.proto))
+    def __hash__(self):
+        return hash((self.url, self.proto))
 
 
 # IndexingExceptions.
 
-class IndexingException(SearchException):
-        """ The base class for all exceptions that can occur while indexing. """
 
-        def __init__(self, private_exception):
-                SearchException.__init__(self)
-                self.cause = private_exception.cause
+class IndexingException(SearchException):
+    """The base class for all exceptions that can occur while indexing."""
+
+    def __init__(self, private_exception):
+        SearchException.__init__(self)
+        self.cause = private_exception.cause
 
 
 class CorruptedIndexException(IndexingException):
-        """This is used when the index is not in a correct state."""
-        def __str__(self):
-                return _("The search index appears corrupted.")
+    """This is used when the index is not in a correct state."""
+
+    def __str__(self):
+        return _("The search index appears corrupted.")
 
 
 class InconsistentIndexException(IndexingException):
-        """This is used when the existing index is found to have inconsistent
-        versions."""
-        def __init__(self, e):
-                IndexingException.__init__(self, e)
-                self.exception = e
+    """This is used when the existing index is found to have inconsistent
+    versions."""
 
-        def __str__(self):
-                return str(self.exception)
+    def __init__(self, e):
+        IndexingException.__init__(self, e)
+        self.exception = e
+
+    def __str__(self):
+        return str(self.exception)
 
 
 class IndexLockedException(IndexingException):
-        """This is used when an attempt to modify an index locked by another
-        process or thread is made."""
+    """This is used when an attempt to modify an index locked by another
+    process or thread is made."""
 
-        def __init__(self, e):
-                IndexingException.__init__(self, e)
-                self.exception = e
+    def __init__(self, e):
+        IndexingException.__init__(self, e)
+        self.exception = e
 
-        def __str__(self):
-                return str(self.exception)
+    def __str__(self):
+        return str(self.exception)
 
 
 class ProblematicPermissionsIndexException(IndexingException):
-        """ This is used when the indexer is unable to create, move, or remove
-        files or directories it should be able to. """
-        def __str__(self):
-                return "Could not remove or create " \
-                    "{0} because of incorrect " \
-                    "permissions. Please correct this issue then " \
-                    "rebuild the index.".format(self.cause)
+    """This is used when the indexer is unable to create, move, or remove
+    files or directories it should be able to."""
+
+    def __str__(self):
+        return (
+            "Could not remove or create "
+            "{0} because of incorrect "
+            "permissions. Please correct this issue then "
+            "rebuild the index.".format(self.cause)
+        )
+
 
 class WrapIndexingException(ApiException):
-        """This exception is used to wrap an indexing exception during install,
-        uninstall, or update so that a more appropriate error message can be
-        displayed to the user."""
+    """This exception is used to wrap an indexing exception during install,
+    uninstall, or update so that a more appropriate error message can be
+    displayed to the user."""
 
-        def __init__(self, e, tb, stack):
-                ApiException.__init__(self)
-                self.wrapped = e
-                self.tb = tb
-                self.stack = stack
+    def __init__(self, e, tb, stack):
+        ApiException.__init__(self)
+        self.wrapped = e
+        self.tb = tb
+        self.stack = stack
 
-        def __str__(self):
-                tmp = self.tb.split("\n")
-                res = tmp[:1] + [s.rstrip("\n") for s in self.stack] + tmp[1:]
-                return "\n".join(res)
+    def __str__(self):
+        tmp = self.tb.split("\n")
+        res = tmp[:1] + [s.rstrip("\n") for s in self.stack] + tmp[1:]
+        return "\n".join(res)
 
 
 class WrapSuccessfulIndexingException(WrapIndexingException):
-        """This exception is used to wrap an indexing exception during install,
-        uninstall, or update which was recovered from by performing a full
-        reindex."""
-        pass
+    """This exception is used to wrap an indexing exception during install,
+    uninstall, or update which was recovered from by performing a full
+    reindex."""
+
+    pass
 
 
 # Query Parsing Exceptions
 class BooleanQueryException(ApiException):
-        """This exception is used when the children of a boolean operation
-        have different return types.  The command 'pkg search foo AND <bar>'
-        is the simplest example of this."""
+    """This exception is used when the children of a boolean operation
+    have different return types.  The command 'pkg search foo AND <bar>'
+    is the simplest example of this."""
 
-        def __init__(self, e):
-                ApiException.__init__(self)
-                self.e = e
+    def __init__(self, e):
+        ApiException.__init__(self)
+        self.e = e
 
-        def __str__(self):
-                return str(self.e)
+    def __str__(self):
+        return str(self.e)
 
 
 class ParseError(ApiException):
-        def __init__(self, e):
-                ApiException.__init__(self)
-                self.e = e
+    def __init__(self, e):
+        ApiException.__init__(self)
+        self.e = e
 
-        def __str__(self):
-                return str(self.e)
+    def __str__(self):
+        return str(self.e)
 
 
 class NonLeafPackageException(ApiException):
-        """Removal of a package which satisfies dependencies has been attempted.
+    """Removal of a package which satisfies dependencies has been attempted.
 
-        The first argument to the constructor is the FMRI which we tried to
-        remove, and is available as the "fmri" member of the exception.  The
-        second argument is the list of dependent packages that prevent the
-        removal of the package, and is available as the "dependents" member.
-        """
+    The first argument to the constructor is the FMRI which we tried to
+    remove, and is available as the "fmri" member of the exception.  The
+    second argument is the list of dependent packages that prevent the
+    removal of the package, and is available as the "dependents" member.
+    """
 
-        def __init__(self, *args):
-                ApiException.__init__(self, *args)
+    def __init__(self, *args):
+        ApiException.__init__(self, *args)
 
-                self.fmri = args[0]
-                self.dependents = args[1]
+        self.fmri = args[0]
+        self.dependents = args[1]
 
-        def __str__(self):
-                s = _("Unable to remove '{0}' due to the following packages "
-                    "that depend on it:\n").format(self.fmri.get_short_fmri(
-                        anarchy=True, include_scheme=False))
-                skey = operator.attrgetter('pkg_name')
-                s += "\n".join(
-                    "  {0}".format(f.get_short_fmri(anarchy=True,
-                        include_scheme=False))
-                    for f in sorted(self.dependents, key=skey)
-                )
-                return s
+    def __str__(self):
+        s = _(
+            "Unable to remove '{0}' due to the following packages "
+            "that depend on it:\n"
+        ).format(self.fmri.get_short_fmri(anarchy=True, include_scheme=False))
+        skey = operator.attrgetter("pkg_name")
+        s += "\n".join(
+            "  {0}".format(f.get_short_fmri(anarchy=True, include_scheme=False))
+            for f in sorted(self.dependents, key=skey)
+        )
+        return s
 
 
 def _str_autofix(self):
-
-        if getattr(self, "_autofix_pkgs", []):
-                s = _("\nThis is happening because the following "
-                    "packages needed to be repaired as\npart of this "
-                    "operation:\n\n    ")
-                s += "\n    ".join(str(f) for f in self._autofix_pkgs)
-                s += _("\n\nYou will need to reestablish your access to the "
-                        "repository or remove the\npackages in the list above.")
-                return s
-        return ""
+    if getattr(self, "_autofix_pkgs", []):
+        s = _(
+            "\nThis is happening because the following "
+            "packages needed to be repaired as\npart of this "
+            "operation:\n\n    "
+        )
+        s += "\n    ".join(str(f) for f in self._autofix_pkgs)
+        s += _(
+            "\n\nYou will need to reestablish your access to the "
+            "repository or remove the\npackages in the list above."
+        )
+        return s
+    return ""
 
 
 class InvalidDepotResponseException(ApiException):
-        """Raised when the depot doesn't have versions of operations
-        that the client needs to operate successfully."""
-        def __init__(self, url, data):
-                ApiException.__init__(self)
-                self.url = url
-                self.data = data
+    """Raised when the depot doesn't have versions of operations
+    that the client needs to operate successfully."""
 
-        def __str__(self):
-                s = _("Unable to contact valid package repository")
-                if self.url:
-                        s += _(": {0}").format(self.url)
-                if self.data:
-                        s += ("\nEncountered the following error(s):\n{0}").format(
-                            self.data)
+    def __init__(self, url, data):
+        ApiException.__init__(self)
+        self.url = url
+        self.data = data
 
-                s += _str_autofix(self)
+    def __str__(self):
+        s = _("Unable to contact valid package repository")
+        if self.url:
+            s += _(": {0}").format(self.url)
+        if self.data:
+            s += ("\nEncountered the following error(s):\n{0}").format(
+                self.data
+            )
 
-                return s
+        s += _str_autofix(self)
+
+        return s
 
 
 class DataError(ApiException):
-        """Base exception class used for all data related errors."""
+    """Base exception class used for all data related errors."""
 
-        def __init__(self, *args, **kwargs):
-                ApiException.__init__(self, *args)
-                if args:
-                        self.data = args[0]
-                else:
-                        self.data = None
-                self._args = kwargs
+    def __init__(self, *args, **kwargs):
+        ApiException.__init__(self, *args)
+        if args:
+            self.data = args[0]
+        else:
+            self.data = None
+        self._args = kwargs
 
 
 class InvalidP5IFile(DataError):
-        """Used to indicate that the specified location does not contain a
-        valid p5i-formatted file."""
+    """Used to indicate that the specified location does not contain a
+    valid p5i-formatted file."""
 
-        def __str__(self):
-                if self.data:
-                        return _("The provided p5i data is in an unrecognized "
-                            "format or does not contain valid publisher "
-                            "information: {0}").format(self.data)
-                return _("The provided p5i data is in an unrecognized format "
-                    "or does not contain valid publisher information.")
+    def __str__(self):
+        if self.data:
+            return _(
+                "The provided p5i data is in an unrecognized "
+                "format or does not contain valid publisher "
+                "information: {0}"
+            ).format(self.data)
+        return _(
+            "The provided p5i data is in an unrecognized format "
+            "or does not contain valid publisher information."
+        )
 
 
 class InvalidP5SFile(DataError):
-        """Used to indicate that the specified location does not contain a
-        valid p5i-formatted file."""
+    """Used to indicate that the specified location does not contain a
+    valid p5i-formatted file."""
 
-        def __str__(self):
-                if self.data:
-                        return _("The provided p5s data is in an unrecognized "
-                            "format or does not contain valid publisher "
-                            "information: {0}").format(self.data)
-                return _("The provided p5s data is in an unrecognized format "
-                    "or does not contain valid publisher information.")
+    def __str__(self):
+        if self.data:
+            return _(
+                "The provided p5s data is in an unrecognized "
+                "format or does not contain valid publisher "
+                "information: {0}"
+            ).format(self.data)
+        return _(
+            "The provided p5s data is in an unrecognized format "
+            "or does not contain valid publisher information."
+        )
 
 
 class UnsupportedP5IFile(DataError):
-        """Used to indicate that an attempt to read an unsupported version
-        of pkg(7) info file was attempted."""
+    """Used to indicate that an attempt to read an unsupported version
+    of pkg(7) info file was attempted."""
 
-        def __str__(self):
-                return _("Unsupported pkg(7) publisher information data "
-                    "format.")
+    def __str__(self):
+        return _("Unsupported pkg(7) publisher information data " "format.")
 
 
 class UnsupportedP5SFile(DataError):
-        """Used to indicate that an attempt to read an unsupported version
-        of pkg(7) info file was attempted."""
+    """Used to indicate that an attempt to read an unsupported version
+    of pkg(7) info file was attempted."""
 
-        def __str__(self):
-                return _("Unsupported pkg(7) publisher and image information "
-                    "data format.")
+    def __str__(self):
+        return _(
+            "Unsupported pkg(7) publisher and image information " "data format."
+        )
 
 
 class UnsupportedP5SVersion(ApiException):
-        """Used to indicate that an attempt to read an unsupported version
-        of pkg(7) info file was attempted."""
+    """Used to indicate that an attempt to read an unsupported version
+    of pkg(7) info file was attempted."""
 
-        def __init__(self, v):
-                self.version = v
+    def __init__(self, v):
+        self.version = v
 
-        def __str__(self):
-                return _("{0} is not a supported version for creating a "
-                    "syspub response.").format(self.version)
+    def __str__(self):
+        return _(
+            "{0} is not a supported version for creating a " "syspub response."
+        ).format(self.version)
 
 
 class TransportError(ApiException):
-        """Abstract exception class for all transport exceptions.
-        Specific transport exceptions should be implemented in the
-        transport code.  Callers wishing to catch transport exceptions
-        should use this class.  Subclasses must implement all methods
-        defined here that raise NotImplementedError."""
+    """Abstract exception class for all transport exceptions.
+    Specific transport exceptions should be implemented in the
+    transport code.  Callers wishing to catch transport exceptions
+    should use this class.  Subclasses must implement all methods
+    defined here that raise NotImplementedError."""
 
-        def __str__(self):
-                raise NotImplementedError()
+    def __str__(self):
+        raise NotImplementedError()
 
-        def _str_autofix(self):
-                return _str_autofix(self)
+    def _str_autofix(self):
+        return _str_autofix(self)
 
 
 class RetrievalError(ApiException):
-        """Used to indicate that a a requested resource could not be
-        retrieved."""
+    """Used to indicate that a a requested resource could not be
+    retrieved."""
 
-        def __init__(self, data, location=None):
-                ApiException.__init__(self)
-                self.data = data
-                self.location = location
+    def __init__(self, data, location=None):
+        ApiException.__init__(self)
+        self.data = data
+        self.location = location
 
-        def __str__(self):
-                if self.location:
-                        return _("Error encountered while retrieving data from "
-                            "'{location}':\n{data}").format(
-                            location=self.location, data=self.data)
-                return _("Error encountered while retrieving data from: {0}").format(
-                    self.data)
+    def __str__(self):
+        if self.location:
+            return _(
+                "Error encountered while retrieving data from "
+                "'{location}':\n{data}"
+            ).format(location=self.location, data=self.data)
+        return _("Error encountered while retrieving data from: {0}").format(
+            self.data
+        )
 
 
 class InvalidResourceLocation(ApiException):
-        """Used to indicate that an invalid transport location was provided."""
+    """Used to indicate that an invalid transport location was provided."""
 
-        def __init__(self, data):
-                ApiException.__init__(self)
-                self.data = data
+    def __init__(self, data):
+        ApiException.__init__(self)
+        self.data = data
 
-        def __str__(self):
-                return _("'{0}' is not a valid location.").format(self.data)
+    def __str__(self):
+        return _("'{0}' is not a valid location.").format(self.data)
+
 
 class BEException(ApiException):
-        def __init__(self):
-                ApiException.__init__(self)
+    def __init__(self):
+        ApiException.__init__(self)
+
 
 class InvalidBENameException(BEException):
-        def __init__(self, be_name):
-                BEException.__init__(self)
-                self.be_name = be_name
+    def __init__(self, be_name):
+        BEException.__init__(self)
+        self.be_name = be_name
 
-        def __str__(self):
-                return _("'{0}' is not a valid boot environment name.").format(
-                    self.be_name)
+    def __str__(self):
+        return _("'{0}' is not a valid boot environment name.").format(
+            self.be_name
+        )
+
 
 class DuplicateBEName(BEException):
-        """Used to indicate that there is an existing boot environment
-        with this name"""
+    """Used to indicate that there is an existing boot environment
+    with this name"""
 
-        def __init__(self, be_name):
-                BEException.__init__(self)
-                self.be_name = be_name
+    def __init__(self, be_name):
+        BEException.__init__(self)
+        self.be_name = be_name
 
-        def __str__(self):
-                return _("The boot environment '{0}' already exists.").format(
-                    self.be_name)
+    def __str__(self):
+        return _("The boot environment '{0}' already exists.").format(
+            self.be_name
+        )
+
 
 class BENamingNotSupported(BEException):
-        def __init__(self, be_name):
-                BEException.__init__(self)
-                self.be_name = be_name
+    def __init__(self, be_name):
+        BEException.__init__(self)
+        self.be_name = be_name
 
-        def __str__(self):
-                return _("""\
+    def __str__(self):
+        return _(
+            """\
 Boot environment naming during package install is not supported on this
-version of OpenSolaris. Please update without the --be-name option.""")
+version of OpenSolaris. Please update without the --be-name option."""
+        )
+
 
 class UnableToCopyBE(BEException):
-        def __str__(self):
-                return _("Unable to clone the current boot environment.")
+    def __str__(self):
+        return _("Unable to clone the current boot environment.")
+
 
 class UnableToRenameBE(BEException):
-        def __init__(self, orig, dest):
-                BEException.__init__(self)
-                self.original_name = orig
-                self.destination_name = dest
+    def __init__(self, orig, dest):
+        BEException.__init__(self)
+        self.original_name = orig
+        self.destination_name = dest
 
-        def __str__(self):
-                d = {
-                    "orig": self.original_name,
-                    "dest": self.destination_name
-                }
-                return _("""\
+    def __str__(self):
+        d = {"orig": self.original_name, "dest": self.destination_name}
+        return _(
+            """\
 A problem occurred while attempting to rename the boot environment
-currently named {orig} to {dest}.""").format(**d)
+currently named {orig} to {dest}."""
+        ).format(**d)
+
 
 class UnableToMountBE(BEException):
-        def __init__(self, be_name, be_dir):
-                BEException.__init__(self)
-                self.name = be_name
-                self.mountpoint = be_dir
+    def __init__(self, be_name, be_dir):
+        BEException.__init__(self)
+        self.name = be_name
+        self.mountpoint = be_dir
 
-        def __str__(self):
-                return _("Unable to mount {name} at {mt}").format(
-                    name=self.name, mt=self.mountpoint)
+    def __str__(self):
+        return _("Unable to mount {name} at {mt}").format(
+            name=self.name, mt=self.mountpoint
+        )
+
 
 class BENameGivenOnDeadBE(BEException):
-        def __init__(self, be_name):
-                BEException.__init__(self)
-                self.name = be_name
+    def __init__(self, be_name):
+        BEException.__init__(self)
+        self.name = be_name
 
-        def __str__(self):
-                return _("""\
+    def __str__(self):
+        return _(
+            """\
 Naming a boot environment when operating on a non-live image is
-not allowed.""")
+not allowed."""
+        )
 
 
 class UnrecognizedOptionsToInfo(ApiException):
-        def __init__(self, opts):
-                ApiException.__init__(self)
-                self._opts = opts
+    def __init__(self, opts):
+        ApiException.__init__(self)
+        self._opts = opts
 
-        def __str__(self):
-                s = _("Info does not recognize the following options:")
-                for o in self._opts:
-                        s += _(" '") + str(o) + _("'")
-                return s
+    def __str__(self):
+        s = _("Info does not recognize the following options:")
+        for o in self._opts:
+            s += _(" '") + str(o) + _("'")
+        return s
+
 
 class IncorrectIndexFileHash(ApiException):
-        """This is used when the index hash value doesn't match the hash of the
-        packages installed in the image."""
-        pass
+    """This is used when the index hash value doesn't match the hash of the
+    packages installed in the image."""
+
+    pass
 
 
 class PublisherError(ApiException):
-        """Base exception class for all publisher exceptions."""
+    """Base exception class for all publisher exceptions."""
 
-        def __init__(self, *args, **kwargs):
-                ApiException.__init__(self, *args)
-                if args:
-                        self.data = args[0]
-                else:
-                        self.data = None
-                self._args = kwargs
+    def __init__(self, *args, **kwargs):
+        ApiException.__init__(self, *args)
+        if args:
+            self.data = args[0]
+        else:
+            self.data = None
+        self._args = kwargs
 
-        def __str__(self):
-                return str(self.data)
+    def __str__(self):
+        return str(self.data)
 
 
 class BadPublisherMetaRoot(PublisherError):
-        """Used to indicate an operation on the publisher's meta_root failed
-        because the meta_root is invalid."""
+    """Used to indicate an operation on the publisher's meta_root failed
+    because the meta_root is invalid."""
 
-        def __str__(self):
-                return _("Publisher meta_root '{root}' is invalid; unable "
-                    "to complete operation: '{op}'.").format(root=self.data,
-                    op=self._args.get("operation", None))
+    def __str__(self):
+        return _(
+            "Publisher meta_root '{root}' is invalid; unable "
+            "to complete operation: '{op}'."
+        ).format(root=self.data, op=self._args.get("operation", None))
 
 
 class BadPublisherAlias(PublisherError):
-        """Used to indicate that a publisher alias is not valid."""
+    """Used to indicate that a publisher alias is not valid."""
 
-        def __str__(self):
-                return _("'{0}' is not a valid publisher alias.").format(
-                    self.data)
+    def __str__(self):
+        return _("'{0}' is not a valid publisher alias.").format(self.data)
 
 
 class BadPublisherPrefix(PublisherError):
-        """Used to indicate that a publisher name is not valid."""
+    """Used to indicate that a publisher name is not valid."""
 
-        def __str__(self):
-                return _("'{0}' is not a valid publisher name.").format(
-                    self.data)
+    def __str__(self):
+        return _("'{0}' is not a valid publisher name.").format(self.data)
 
 
 class ReservedPublisherPrefix(PublisherError):
-        """Used to indicate that a publisher name is not valid."""
+    """Used to indicate that a publisher name is not valid."""
 
-        def __str__(self):
-                fmri = self._args["fmri"]
-                return _("'{pkg_pub}' is a reserved publisher and does not "
-                    "contain the requested package: pkg:/{pkg_name}").format(
-                    pkg_pub=fmri.publisher, pkg_name=fmri.pkg_name)
+    def __str__(self):
+        fmri = self._args["fmri"]
+        return _(
+            "'{pkg_pub}' is a reserved publisher and does not "
+            "contain the requested package: pkg:/{pkg_name}"
+        ).format(pkg_pub=fmri.publisher, pkg_name=fmri.pkg_name)
 
 
 class BadRepositoryAttributeValue(PublisherError):
-        """Used to indicate that the specified repository attribute value is
-        invalid."""
+    """Used to indicate that the specified repository attribute value is
+    invalid."""
 
-        def __str__(self):
-                return _("'{value}' is not a valid value for repository "
-                    "attribute '{attribute}'.").format(
-                    value=self._args["value"], attribute=self.data)
+    def __str__(self):
+        return _(
+            "'{value}' is not a valid value for repository "
+            "attribute '{attribute}'."
+        ).format(value=self._args["value"], attribute=self.data)
 
 
 class BadRepositoryCollectionType(PublisherError):
-        """Used to indicate that the specified repository collection type is
-        invalid."""
+    """Used to indicate that the specified repository collection type is
+    invalid."""
 
-        def __init__(self, *args, **kwargs):
-                PublisherError.__init__(self, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        PublisherError.__init__(self, *args, **kwargs)
 
-        def __str__(self):
-                return _("'{0}' is not a valid repository collection type.").format(
-                    self.data)
+    def __str__(self):
+        return _("'{0}' is not a valid repository collection type.").format(
+            self.data
+        )
 
 
 class BadRepositoryURI(PublisherError):
-        """Used to indicate that a repository URI is not syntactically valid."""
+    """Used to indicate that a repository URI is not syntactically valid."""
 
-        def __str__(self):
-                return _("'{0}' is not a valid URI.").format(self.data)
+    def __str__(self):
+        return _("'{0}' is not a valid URI.").format(self.data)
 
 
 class BadRepositoryURIPriority(PublisherError):
-        """Used to indicate that the priority specified for a repository URI is
-        not valid."""
+    """Used to indicate that the priority specified for a repository URI is
+    not valid."""
 
-        def __str__(self):
-                return _("'{0}' is not a valid URI priority; integer value "
-                    "expected.").format(self.data)
+    def __str__(self):
+        return _(
+            "'{0}' is not a valid URI priority; integer value " "expected."
+        ).format(self.data)
 
 
 class BadRepositoryURISortPolicy(PublisherError):
-        """Used to indicate that the specified repository URI sort policy is
-        invalid."""
+    """Used to indicate that the specified repository URI sort policy is
+    invalid."""
 
-        def __init__(self, *args, **kwargs):
-                PublisherError.__init__(self, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        PublisherError.__init__(self, *args, **kwargs)
 
-        def __str__(self):
-                return _("'{0}' is not a valid repository URI sort policy.").format(
-                    self.data)
+    def __str__(self):
+        return _("'{0}' is not a valid repository URI sort policy.").format(
+            self.data
+        )
 
 
 class DisabledPublisher(PublisherError):
-        """Used to indicate that an attempt to use a disabled publisher occurred
-        during an operation."""
+    """Used to indicate that an attempt to use a disabled publisher occurred
+    during an operation."""
 
-        def __str__(self):
-                return _("Publisher '{0}' is disabled and cannot be used for "
-                    "packaging operations.").format(self.data)
+    def __str__(self):
+        return _(
+            "Publisher '{0}' is disabled and cannot be used for "
+            "packaging operations."
+        ).format(self.data)
 
 
 class DuplicatePublisher(PublisherError):
-        """Used to indicate that a publisher with the same name or alias already
-        exists for an image."""
+    """Used to indicate that a publisher with the same name or alias already
+    exists for an image."""
 
-        def __str__(self):
-                return _("A publisher with the same name or alias as '{0}' "
-                    "already exists.").format(self.data)
+    def __str__(self):
+        return _(
+            "A publisher with the same name or alias as '{0}' "
+            "already exists."
+        ).format(self.data)
 
 
 class DuplicateRepository(PublisherError):
-        """Used to indicate that a repository with the same origin uris
-        already exists for a publisher."""
+    """Used to indicate that a repository with the same origin uris
+    already exists for a publisher."""
 
-        def __str__(self):
-                return _("A repository with the same name or origin URIs "
-                   "already exists for publisher '{0}'.").format(self.data)
+    def __str__(self):
+        return _(
+            "A repository with the same name or origin URIs "
+            "already exists for publisher '{0}'."
+        ).format(self.data)
 
 
 class DuplicateRepositoryMirror(PublisherError):
-        """Used to indicate that a repository URI is already in use by another
-        repository mirror."""
+    """Used to indicate that a repository URI is already in use by another
+    repository mirror."""
 
-        def __str__(self):
-                return _("Mirror '{0}' already exists for the specified "
-                    "publisher.").format(self.data)
+    def __str__(self):
+        return _(
+            "Mirror '{0}' already exists for the specified " "publisher."
+        ).format(self.data)
 
 
 class DuplicateSyspubMirror(PublisherError):
-        """Used to indicate that a repository URI is already in use by the
-        system publisher."""
+    """Used to indicate that a repository URI is already in use by the
+    system publisher."""
 
-        def __str__(self):
-                return _("Mirror '{0}' is already accessible through the "
-                    "system repository.").format(self.data)
+    def __str__(self):
+        return _(
+            "Mirror '{0}' is already accessible through the "
+            "system repository."
+        ).format(self.data)
 
 
 class DuplicateRepositoryOrigin(PublisherError):
-        """Used to indicate that a repository URI is already in use by another
-        repository origin."""
+    """Used to indicate that a repository URI is already in use by another
+    repository origin."""
 
-        def __str__(self):
-                return _("Origin '{0}' already exists for the specified "
-                    "publisher.").format(self.data)
+    def __str__(self):
+        return _(
+            "Origin '{0}' already exists for the specified " "publisher."
+        ).format(self.data)
 
 
 class DuplicateSyspubOrigin(PublisherError):
-        """Used to indicate that a repository URI is already in use by the
-        system publisher."""
+    """Used to indicate that a repository URI is already in use by the
+    system publisher."""
 
-        def __str__(self):
-                return _("Origin '{0}' is already accessible through the "
-                    "system repository.").format(self.data)
+    def __str__(self):
+        return _(
+            "Origin '{0}' is already accessible through the "
+            "system repository."
+        ).format(self.data)
 
 
 class RemoveSyspubOrigin(PublisherError):
-        """Used to indicate that a system publisher origin may not be
-        removed."""
+    """Used to indicate that a system publisher origin may not be
+    removed."""
 
-        def __str__(self):
-                return _("Unable to remove origin '{0}' since it is provided "
-                    "by the system repository.").format(self.data)
+    def __str__(self):
+        return _(
+            "Unable to remove origin '{0}' since it is provided "
+            "by the system repository."
+        ).format(self.data)
+
 
 class RemoveSyspubMirror(PublisherError):
-        """Used to indicate that a system publisher mirror may not be
-        removed."""
+    """Used to indicate that a system publisher mirror may not be
+    removed."""
 
-        def __str__(self):
-                return _("Unable to remove mirror '{0}' since it is provided "
-                    "by the system repository.").format(self.data)
+    def __str__(self):
+        return _(
+            "Unable to remove mirror '{0}' since it is provided "
+            "by the system repository."
+        ).format(self.data)
 
 
 class NoPublisherRepositories(TransportError):
-        """Used to indicate that a Publisher has no repository information
-        configured and so transport operations cannot be performed."""
+    """Used to indicate that a Publisher has no repository information
+    configured and so transport operations cannot be performed."""
 
-        def __init__(self, prefix):
-                TransportError.__init__(self)
-                self.publisher = prefix
+    def __init__(self, prefix):
+        TransportError.__init__(self)
+        self.publisher = prefix
 
-        def __str__(self):
-                return _("""
+    def __str__(self):
+        return _(
+            """
 The requested operation requires that one or more package repositories are
 configured for publisher '{0}'.
 
 Use 'pkg set-publisher' to add new package repositories or restore previously
-configured package repositories for publisher '{0}'.""").format(self.publisher)
+configured package repositories for publisher '{0}'."""
+        ).format(self.publisher)
 
 
 class MoveRelativeToSelf(PublisherError):
-        """Used to indicate an attempt to search a repo before or after itself"""
+    """Used to indicate an attempt to search a repo before or after itself"""
 
-        def __str__(self):
-                return _("Cannot search a repository before or after itself")
+    def __str__(self):
+        return _("Cannot search a repository before or after itself")
 
 
 class MoveRelativeToUnknown(PublisherError):
-        """Used to indicate an attempt to order a publisher relative to an
-        unknown publisher."""
+    """Used to indicate an attempt to order a publisher relative to an
+    unknown publisher."""
 
-        def __init__(self, unknown_pub):
-                self.__unknown_pub = unknown_pub
+    def __init__(self, unknown_pub):
+        self.__unknown_pub = unknown_pub
 
-        def __str__(self):
-                return _("{0} is an unknown publisher; no other publishers can "
-                    "be ordered relative to it.").format(self.__unknown_pub)
+    def __str__(self):
+        return _(
+            "{0} is an unknown publisher; no other publishers can "
+            "be ordered relative to it."
+        ).format(self.__unknown_pub)
 
 
 class SelectedRepositoryRemoval(PublisherError):
-        """Used to indicate that an attempt to remove the selected repository
-        for a publisher was made."""
+    """Used to indicate that an attempt to remove the selected repository
+    for a publisher was made."""
 
-        def __str__(self):
-                return _("Cannot remove the selected repository for a "
-                    "publisher.")
+    def __str__(self):
+        return _("Cannot remove the selected repository for a " "publisher.")
 
 
 class UnknownLegalURI(PublisherError):
-        """Used to indicate that no matching legal URI could be found using the
-        provided criteria."""
+    """Used to indicate that no matching legal URI could be found using the
+    provided criteria."""
 
-        def __str__(self):
-                return _("Unknown legal URI '{0}'.").format(self.data)
+    def __str__(self):
+        return _("Unknown legal URI '{0}'.").format(self.data)
 
 
 class UnknownPublisher(PublisherError):
-        """Used to indicate that no matching publisher could be found using the
-        provided criteria."""
+    """Used to indicate that no matching publisher could be found using the
+    provided criteria."""
 
-        def __str__(self):
-                return _("Unknown publisher '{0}'.").format(self.data)
+    def __str__(self):
+        return _("Unknown publisher '{0}'.").format(self.data)
 
 
 class UnknownRepositoryPublishers(PublisherError):
-        """Used to indicate that one or more publisher prefixes are unknown by
-        the specified repository."""
+    """Used to indicate that one or more publisher prefixes are unknown by
+    the specified repository."""
 
-        def __init__(self, known=EmptyI, unknown=EmptyI, location=None,
-            origins=EmptyI):
-                ApiException.__init__(self)
-                self.known = known
-                self.location = location
-                self.origins = origins
-                self.unknown = unknown
+    def __init__(
+        self, known=EmptyI, unknown=EmptyI, location=None, origins=EmptyI
+    ):
+        ApiException.__init__(self)
+        self.known = known
+        self.location = location
+        self.origins = origins
+        self.unknown = unknown
 
-        def __str__(self):
-                if self.location:
-                        return _("The repository at {location} does not "
-                            "contain package data for {unknown}; only "
-                            "{known}.\n\nThis is either because the "
-                            "repository location is not valid, or because the "
-                            "provided publisher does not match those known by "
-                            "the repository.").format(
-                            unknown=", ".join(self.unknown),
-                            location=self.location,
-                            known=", ".join(self.known))
-                if self.origins:
-                        return _("One or more of the repository origin(s) "
-                            "listed below contains package data for "
-                            "{known}; not {unknown}:\n\n{origins}\n\n"
-                            "This is either because one of the repository "
-                            "origins is not valid for this publisher, or "
-                            "because the list of known publishers retrieved "
-                            "from the repository origin does not match the "
-                            "client.").format(unknown=", ".join(self.unknown),
-                            known=", ".join(self.known),
-                            origins="\n".join(str(o) for o in self.origins))
-                return _("The specified publisher repository does not "
-                    "contain any package data for {unknown}; only "
-                    "{known}.").format(unknown=", ".join(self.unknown),
-                    known=", ".join(self.known))
+    def __str__(self):
+        if self.location:
+            return _(
+                "The repository at {location} does not "
+                "contain package data for {unknown}; only "
+                "{known}.\n\nThis is either because the "
+                "repository location is not valid, or because the "
+                "provided publisher does not match those known by "
+                "the repository."
+            ).format(
+                unknown=", ".join(self.unknown),
+                location=self.location,
+                known=", ".join(self.known),
+            )
+        if self.origins:
+            return _(
+                "One or more of the repository origin(s) "
+                "listed below contains package data for "
+                "{known}; not {unknown}:\n\n{origins}\n\n"
+                "This is either because one of the repository "
+                "origins is not valid for this publisher, or "
+                "because the list of known publishers retrieved "
+                "from the repository origin does not match the "
+                "client."
+            ).format(
+                unknown=", ".join(self.unknown),
+                known=", ".join(self.known),
+                origins="\n".join(str(o) for o in self.origins),
+            )
+        return _(
+            "The specified publisher repository does not "
+            "contain any package data for {unknown}; only "
+            "{known}."
+        ).format(unknown=", ".join(self.unknown), known=", ".join(self.known))
 
 
 class UnknownRelatedURI(PublisherError):
-        """Used to indicate that no matching related URI could be found using
-        the provided criteria."""
+    """Used to indicate that no matching related URI could be found using
+    the provided criteria."""
 
-        def __str__(self):
-                return _("Unknown related URI '{0}'.").format(self.data)
+    def __str__(self):
+        return _("Unknown related URI '{0}'.").format(self.data)
 
 
 class UnknownRepository(PublisherError):
-        """Used to indicate that no matching repository could be found using the
-        provided criteria."""
+    """Used to indicate that no matching repository could be found using the
+    provided criteria."""
 
-        def __str__(self):
-                return _("Unknown repository '{0}'.").format(self.data)
+    def __str__(self):
+        return _("Unknown repository '{0}'.").format(self.data)
 
 
 class UnknownRepositoryMirror(PublisherError):
-        """Used to indicate that a repository URI could not be found in the
-        list of repository mirrors."""
+    """Used to indicate that a repository URI could not be found in the
+    list of repository mirrors."""
 
-        def __str__(self):
-                return _("Unknown repository mirror '{0}'.").format(self.data)
+    def __str__(self):
+        return _("Unknown repository mirror '{0}'.").format(self.data)
+
 
 class UnsupportedRepositoryOperation(TransportError):
-        """The publisher has no active repositories that support the
-        requested operation."""
+    """The publisher has no active repositories that support the
+    requested operation."""
 
-        def __init__(self, pub, operation):
-                ApiException.__init__(self)
-                self.data = None
-                self.kwargs = None
-                self.pub = pub
-                self.op = operation
+    def __init__(self, pub, operation):
+        ApiException.__init__(self)
+        self.data = None
+        self.kwargs = None
+        self.pub = pub
+        self.op = operation
 
-        def __str__(self):
-                return _("Publisher '{pub}' has no repositories that support "
-                    "the '{op}' operation.").format(**self.__dict__)
+    def __str__(self):
+        return _(
+            "Publisher '{pub}' has no repositories that support "
+            "the '{op}' operation."
+        ).format(**self.__dict__)
 
 
 class RepoPubConfigUnavailable(PublisherError):
-        """Used to indicate that the specified repository does not provide
-        publisher configuration information."""
+    """Used to indicate that the specified repository does not provide
+    publisher configuration information."""
 
-        def __init__(self, location=None, pub=None):
-                ApiException.__init__(self)
-                self.location = location
-                self.pub = pub
+    def __init__(self, location=None, pub=None):
+        ApiException.__init__(self)
+        self.location = location
+        self.pub = pub
 
-        def __str__(self):
-                if not self.location and not self.pub:
-                        return _("The specified package repository does not "
-                            "provide publisher configuration information.")
-                if self.location:
-                        return _("The package repository at {0} does not "
-                            "provide publisher configuration information or "
-                            "the information provided is incomplete.").format(
-                            self.location)
-                return _("One of the package repository origins for {0} does "
-                    "not provide publisher configuration information or the "
-                    "information provided is incomplete.").format(self.pub)
+    def __str__(self):
+        if not self.location and not self.pub:
+            return _(
+                "The specified package repository does not "
+                "provide publisher configuration information."
+            )
+        if self.location:
+            return _(
+                "The package repository at {0} does not "
+                "provide publisher configuration information or "
+                "the information provided is incomplete."
+            ).format(self.location)
+        return _(
+            "One of the package repository origins for {0} does "
+            "not provide publisher configuration information or the "
+            "information provided is incomplete."
+        ).format(self.pub)
 
 
 class UnknownRepositoryOrigin(PublisherError):
-        """Used to indicate that a repository URI could not be found in the
-        list of repository origins."""
+    """Used to indicate that a repository URI could not be found in the
+    list of repository origins."""
 
-        def __str__(self):
-                return _("Unknown repository origin '{0}'").format(self.data)
+    def __str__(self):
+        return _("Unknown repository origin '{0}'").format(self.data)
 
 
 class UnsupportedRepositoryURI(PublisherError):
-        """Used to indicate that the specified repository URI uses an
-        unsupported scheme."""
+    """Used to indicate that the specified repository URI uses an
+    unsupported scheme."""
 
-        def __init__(self, uris=[]):
-                if isinstance(uris, six.string_types):
-                        uris = [uris]
+    def __init__(self, uris=[]):
+        if isinstance(uris, six.string_types):
+            uris = [uris]
 
-                assert isinstance(uris, (list, tuple, set))
+        assert isinstance(uris, (list, tuple, set))
 
-                self.uris = uris
+        self.uris = uris
 
-        def __str__(self):
-                illegals = []
+    def __str__(self):
+        illegals = []
 
-                for u in self.uris:
-                        assert isinstance(u, six.string_types)
-                        scheme = urlsplit(u,
-                            allow_fragments=0)[0]
-                        illegals.append((u, scheme))
+        for u in self.uris:
+            assert isinstance(u, six.string_types)
+            scheme = urlsplit(u, allow_fragments=0)[0]
+            illegals.append((u, scheme))
 
-                if len(illegals) > 1:
-                        msg = _("The follwing URIs use unsupported "
-                            "schemes.  Supported schemes are "
-                            "file://, http://, and https://.")
-                        for i, s in illegals:
-                                msg += _("\n  {uri} (scheme: "
-                                    "{scheme})").format(uri=i, scheme=s)
-                        return msg
-                elif len(illegals) == 1:
-                        i, s = illegals[0]
-                        return _("The URI '{uri}' uses the unsupported "
-                            "scheme '{scheme}'.  Supported schemes are "
-                            "file://, http://, and https://.").format(
-                            uri=i, scheme=s)
-                return _("The specified URI uses an unsupported scheme."
-                    "  Supported schemes are: file://, http://, and "
-                    "https://.")
+        if len(illegals) > 1:
+            msg = _(
+                "The follwing URIs use unsupported "
+                "schemes.  Supported schemes are "
+                "file://, http://, and https://."
+            )
+            for i, s in illegals:
+                msg += _("\n  {uri} (scheme: " "{scheme})").format(
+                    uri=i, scheme=s
+                )
+            return msg
+        elif len(illegals) == 1:
+            i, s = illegals[0]
+            return _(
+                "The URI '{uri}' uses the unsupported "
+                "scheme '{scheme}'.  Supported schemes are "
+                "file://, http://, and https://."
+            ).format(uri=i, scheme=s)
+        return _(
+            "The specified URI uses an unsupported scheme."
+            "  Supported schemes are: file://, http://, and "
+            "https://."
+        )
 
 
 class UnsupportedRepositoryURIAttribute(PublisherError):
-        """Used to indicate that the specified repository URI attribute is not
-        supported for the URI's scheme."""
+    """Used to indicate that the specified repository URI attribute is not
+    supported for the URI's scheme."""
 
-        def __str__(self):
-                return _("'{attr}' is not supported for '{scheme}'.").format(
-                    attr=self.data, scheme=self._args["scheme"])
+    def __str__(self):
+        return _("'{attr}' is not supported for '{scheme}'.").format(
+            attr=self.data, scheme=self._args["scheme"]
+        )
 
 
 class UnsupportedProxyURI(PublisherError):
-        """Used to indicate that the specified proxy URI is unsupported."""
+    """Used to indicate that the specified proxy URI is unsupported."""
 
-        def __str__(self):
-                if self.data:
-                        scheme = urlsplit(self.data,
-                            allow_fragments=0)[0]
-                        return _("The proxy URI '{uri}' uses the unsupported "
-                            "scheme '{scheme}'. Currently the only supported "
-                            "scheme is http://.").format(
-                            uri=self.data, scheme=scheme)
-                return _("The specified proxy URI uses an unsupported scheme."
-                    " Currently the only supported scheme is: http://.")
+    def __str__(self):
+        if self.data:
+            scheme = urlsplit(self.data, allow_fragments=0)[0]
+            return _(
+                "The proxy URI '{uri}' uses the unsupported "
+                "scheme '{scheme}'. Currently the only supported "
+                "scheme is http://."
+            ).format(uri=self.data, scheme=scheme)
+        return _(
+            "The specified proxy URI uses an unsupported scheme."
+            " Currently the only supported scheme is: http://."
+        )
+
 
 class BadProxyURI(PublisherError):
-        """Used to indicate that a proxy URI is not syntactically valid."""
+    """Used to indicate that a proxy URI is not syntactically valid."""
 
-        def __str__(self):
-                return _("'{0}' is not a valid URI.").format(self.data)
+    def __str__(self):
+        return _("'{0}' is not a valid URI.").format(self.data)
 
 
 class UnknownSysrepoConfiguration(ApiException):
-        """Used when a pkg client needs to communicate with the system
-        repository but can't find the configuration for it."""
+    """Used when a pkg client needs to communicate with the system
+    repository but can't find the configuration for it."""
 
-        def __str__(self):
-                return _("""\
+    def __str__(self):
+        return _(
+            """\
 pkg is configured to use the system repository (via the use-system-repo
 property) but it could not get the host and port from
 svc:/application/pkg/zones-proxy-client nor svc:/application/pkg/system-repository, and
 the PKG_SYSREPO_URL environment variable was not set.  Please try enabling one
 of those services or setting the PKG_SYSREPO_URL environment variable.
-""")
+"""
+        )
 
 
 class ModifyingSyspubException(ApiException):
-        """This exception is raised when a user attempts to modify a system
-        publisher."""
+    """This exception is raised when a user attempts to modify a system
+    publisher."""
 
-        def __init__(self, s):
-                self.s = s
+    def __init__(self, s):
+        self.s = s
 
-        def __str__(self):
-                return self.s
+    def __str__(self):
+        return self.s
 
 
 class SigningException(ApiException):
-        """The base class for exceptions related to manifest signing."""
+    """The base class for exceptions related to manifest signing."""
 
-        def __init__(self, pfmri=None, sig=None):
-                self.pfmri = pfmri
-                self.sig = sig
+    def __init__(self, pfmri=None, sig=None):
+        self.pfmri = pfmri
+        self.sig = sig
 
-        # This string method is used by subclasses to fill in the details
-        # about the package and signature involved.
-        def __str__(self):
-                if self.pfmri:
-                        if self.sig:
-                                return _("The relevant signature action is "
-                                    "found in {pfmri} and has a hash of "
-                                    "{hsh}").format(
-                                    pfmri=self.pfmri, hsh=self.sig.hash)
-                        return _("The package involved is {0}").format(
-                            self.pfmri)
-                if self.sig:
-                        return _("The relevant signature action's value "
-                            "attribute is {0}").format(self.sig.attrs["value"])
-                return ""
+    # This string method is used by subclasses to fill in the details
+    # about the package and signature involved.
+    def __str__(self):
+        if self.pfmri:
+            if self.sig:
+                return _(
+                    "The relevant signature action is "
+                    "found in {pfmri} and has a hash of "
+                    "{hsh}"
+                ).format(pfmri=self.pfmri, hsh=self.sig.hash)
+            return _("The package involved is {0}").format(self.pfmri)
+        if self.sig:
+            return _(
+                "The relevant signature action's value " "attribute is {0}"
+            ).format(self.sig.attrs["value"])
+        return ""
 
 
 class BadFileFormat(SigningException):
-        """Exception used when a key, certificate or CRL file is not in a
-        recognized format."""
+    """Exception used when a key, certificate or CRL file is not in a
+    recognized format."""
 
-        def __init__(self, txt):
-                self.txt = txt
+    def __init__(self, txt):
+        self.txt = txt
 
-        def __str__(self):
-                return self.txt
+    def __str__(self):
+        return self.txt
 
 
 class UnsupportedSignatureVersion(SigningException):
-        """Exception used when a signature reports a version which this version
-        of pkg(7) doesn't support."""
+    """Exception used when a signature reports a version which this version
+    of pkg(7) doesn't support."""
 
-        def __init__(self, version, *args, **kwargs):
-                SigningException.__init__(self, *args, **kwargs)
-                self.version = version
+    def __init__(self, version, *args, **kwargs):
+        SigningException.__init__(self, *args, **kwargs)
+        self.version = version
 
-        def __str__(self):
-                return _("The signature action {act} was made using a "
-                    "version ({ver}) this version of pkg(7) doesn't "
-                    "understand.").format(act=self.sig, ver=self.version)
+    def __str__(self):
+        return _(
+            "The signature action {act} was made using a "
+            "version ({ver}) this version of pkg(7) doesn't "
+            "understand."
+        ).format(act=self.sig, ver=self.version)
 
 
 class CertificateException(SigningException):
-        """Base class for exceptions encountered while establishing the chain
-        of trust."""
+    """Base class for exceptions encountered while establishing the chain
+    of trust."""
 
-        def __init__(self, cert, pfmri=None):
-                SigningException.__init__(self, pfmri)
-                self.cert = cert
+    def __init__(self, cert, pfmri=None):
+        SigningException.__init__(self, pfmri)
+        self.cert = cert
 
 
 class ModifiedCertificateException(CertificateException):
-        """Exception used when a certificate does not match its expected hash
-        value."""
+    """Exception used when a certificate does not match its expected hash
+    value."""
 
-        def __init__(self, cert, path, pfmri=None):
-                CertificateException.__init__(self, cert, pfmri)
-                self.path = path
+    def __init__(self, cert, path, pfmri=None):
+        CertificateException.__init__(self, cert, pfmri)
+        self.path = path
 
-        def __str__(self):
-                return _("Certificate {0} has been modified on disk. Its hash "
-                    "value is not what was expected.").format(self.path)
+    def __str__(self):
+        return _(
+            "Certificate {0} has been modified on disk. Its hash "
+            "value is not what was expected."
+        ).format(self.path)
 
 
 class UntrustedSelfSignedCert(CertificateException):
-        """Exception used when a chain of trust is rooted in an untrusted
-        self-signed certificate."""
+    """Exception used when a chain of trust is rooted in an untrusted
+    self-signed certificate."""
 
-        def __str__(self):
-                return _("The signing certificate chain is rooted in a " + \
-                    "certificate not present in the trust-anchor-directory.\n" + \
-                    "See the image properties section of pkg(1).\n") + \
-                    "Certificate  Subject:" + \
-                    self.cert.subject.rfc4514_string() + "\n" + \
-                    CertificateException.__str__(self)
+    def __str__(self):
+        return (
+            _(
+                "The signing certificate chain is rooted in a "
+                + "certificate not present in the trust-anchor-directory.\n"
+                + "See the image properties section of pkg(1).\n"
+            )
+            + "Certificate  Subject:"
+            + self.cert.subject.rfc4514_string()
+            + "\n"
+            + CertificateException.__str__(self)
+        )
 
 
 class BrokenChain(CertificateException):
-        """Exception used when a chain of trust can not be established between
-        the leaf certificate and a trust anchor."""
+    """Exception used when a chain of trust can not be established between
+    the leaf certificate and a trust anchor."""
 
-        def __init__(self, cert, cert_exceptions, *args, **kwargs):
-                CertificateException.__init__(self, cert, *args, **kwargs)
-                self.ext_exs = cert_exceptions
+    def __init__(self, cert, cert_exceptions, *args, **kwargs):
+        CertificateException.__init__(self, cert, *args, **kwargs)
+        self.ext_exs = cert_exceptions
 
-        def __str__(self):
-                s = ""
-                if self.ext_exs:
-                        s = _("The following problems were encountered:\n") + \
-                        "\n".join([str(e) for e in self.ext_exs])
-                return _("The certificate which issued this "
-                    "certificate: {subj} could not be found. The issuer "
-                    "is: {issuer}\n").format(subj="/".join("{0}={1}".format(
-                    sub.oid._name, sub.value) for sub in self.cert.subject),
-                    issuer="/".join("{0}={1}".format(i.oid._name, i.value)
-                    for i in self.cert.issuer)) + s + "\n" + \
-                    CertificateException.__str__(self)
+    def __str__(self):
+        s = ""
+        if self.ext_exs:
+            s = _("The following problems were encountered:\n") + "\n".join(
+                [str(e) for e in self.ext_exs]
+            )
+        return (
+            _(
+                "The certificate which issued this "
+                "certificate: {subj} could not be found. The issuer "
+                "is: {issuer}\n"
+            ).format(
+                subj="/".join(
+                    "{0}={1}".format(sub.oid._name, sub.value)
+                    for sub in self.cert.subject
+                ),
+                issuer="/".join(
+                    "{0}={1}".format(i.oid._name, i.value)
+                    for i in self.cert.issuer
+                ),
+            )
+            + s
+            + "\n"
+            + CertificateException.__str__(self)
+        )
 
 
 class RevokedCertificate(CertificateException):
-        """Exception used when a chain of trust contains a revoked certificate.
-        """
+    """Exception used when a chain of trust contains a revoked certificate."""
 
-        def __init__(self, cert, reason, *args, **kwargs):
-                CertificateException.__init__(self, cert, *args, **kwargs)
-                self.reason = reason
+    def __init__(self, cert, reason, *args, **kwargs):
+        CertificateException.__init__(self, cert, *args, **kwargs)
+        self.reason = reason
 
-        def __str__(self):
-                return _("This certificate was revoked:{cert} for this "
-                    "reason:\n{reason}\n").format(cert="/".join("{0}={1}".format(
-                    s.oid._name, s.value) for s in self.cert.subject),
-                    reason=self.reason) + CertificateException.__str__(self)
+    def __str__(self):
+        return _(
+            "This certificate was revoked:{cert} for this "
+            "reason:\n{reason}\n"
+        ).format(
+            cert="/".join(
+                "{0}={1}".format(s.oid._name, s.value)
+                for s in self.cert.subject
+            ),
+            reason=self.reason,
+        ) + CertificateException.__str__(
+            self
+        )
 
 
 class UnverifiedSignature(SigningException):
-        """Exception used when a signature could not be verified by the
-        expected certificate."""
+    """Exception used when a signature could not be verified by the
+    expected certificate."""
 
-        def __init__(self, sig, reason, pfmri=None):
-                SigningException.__init__(self, pfmri)
-                self.sig = sig
-                self.reason = reason
+    def __init__(self, sig, reason, pfmri=None):
+        SigningException.__init__(self, pfmri)
+        self.sig = sig
+        self.reason = reason
 
-        def __str__(self):
-                if self.pfmri:
-                        return _("A signature in {pfmri} could not be "
-                            "verified for "
-                            "this reason:\n{reason}\nThe signature's hash is "
-                            "{hash}").format(pfmri=self.pfmri,
-                            reason=self.reason,
-                            hash=self.sig.hash)
-                return _("The signature with this signature value:\n"
-                    "{sigval}\n could not be verified for this reason:\n"
-                    "{reason}\n").format(reason=self.reason,
-                    sigval=self.sig.attrs["value"])
+    def __str__(self):
+        if self.pfmri:
+            return _(
+                "A signature in {pfmri} could not be "
+                "verified for "
+                "this reason:\n{reason}\nThe signature's hash is "
+                "{hash}"
+            ).format(pfmri=self.pfmri, reason=self.reason, hash=self.sig.hash)
+        return _(
+            "The signature with this signature value:\n"
+            "{sigval}\n could not be verified for this reason:\n"
+            "{reason}\n"
+        ).format(reason=self.reason, sigval=self.sig.attrs["value"])
 
 
 class RequiredSignaturePolicyException(SigningException):
-        """Exception used when signatures were required but none were found."""
+    """Exception used when signatures were required but none were found."""
 
-        def __init__(self, pub, pfmri=None):
-                SigningException.__init__(self, pfmri)
-                self.pub = pub
+    def __init__(self, pub, pfmri=None):
+        SigningException.__init__(self, pfmri)
+        self.pub = pub
 
-        def __str__(self):
-                pub_str = self.pub.prefix
-                if self.pfmri:
-                        return _("The policy for {pub_str} requires "
-                            "signatures to be present but no signature was "
-                            "found in {fmri_str}.").format(
-                            pub_str=pub_str, fmri_str=self.pfmri)
-                return _("The policy for {pub_str} requires signatures to be "
-                    "present but no signature was found.").format(
-                    pub_str=pub_str)
+    def __str__(self):
+        pub_str = self.pub.prefix
+        if self.pfmri:
+            return _(
+                "The policy for {pub_str} requires "
+                "signatures to be present but no signature was "
+                "found in {fmri_str}."
+            ).format(pub_str=pub_str, fmri_str=self.pfmri)
+        return _(
+            "The policy for {pub_str} requires signatures to be "
+            "present but no signature was found."
+        ).format(pub_str=pub_str)
 
 
 class MissingRequiredNamesException(SigningException):
-        """Exception used when a signature policy required names to be seen
-        which weren't seen."""
+    """Exception used when a signature policy required names to be seen
+    which weren't seen."""
 
-        def __init__(self, pub, missing_names, pfmri=None):
-                SigningException.__init__(self, pfmri)
-                self.pub = pub
-                self.missing_names = missing_names
+    def __init__(self, pub, missing_names, pfmri=None):
+        SigningException.__init__(self, pfmri)
+        self.pub = pub
+        self.missing_names = missing_names
 
-        def __str__(self):
-                pub_str = self.pub.prefix
-                if self.pfmri:
-                        return _("The policy for {pub_str} requires certain "
-                            "CNs to be seen in a chain of trust. The following "
-                            "required names couldn't be found for this "
-                            "package:{fmri_str}.\n{missing}").format(
-                            pub_str=pub_str, fmri_str=self.pfmri,
-                            missing="\n".join(self.missing_names))
-                return _("The policy for {pub_str} requires certain CNs to "
-                    "be seen in a chain of trust. The following required names "
-                    "couldn't be found.\n{missing}").format(pub_str=pub_str,
-                    missing="\n".join(self.missing_names))
+    def __str__(self):
+        pub_str = self.pub.prefix
+        if self.pfmri:
+            return _(
+                "The policy for {pub_str} requires certain "
+                "CNs to be seen in a chain of trust. The following "
+                "required names couldn't be found for this "
+                "package:{fmri_str}.\n{missing}"
+            ).format(
+                pub_str=pub_str,
+                fmri_str=self.pfmri,
+                missing="\n".join(self.missing_names),
+            )
+        return _(
+            "The policy for {pub_str} requires certain CNs to "
+            "be seen in a chain of trust. The following required names "
+            "couldn't be found.\n{missing}"
+        ).format(pub_str=pub_str, missing="\n".join(self.missing_names))
+
 
 class UnsupportedCriticalExtension(SigningException):
-        """Exception used when a certificate in the chain of trust uses a
-        critical extension pkg doesn't understand."""
+    """Exception used when a certificate in the chain of trust uses a
+    critical extension pkg doesn't understand."""
 
-        def __init__(self, cert, ext):
-                SigningException.__init__(self)
-                self.cert = cert
-                self.ext = ext
+    def __init__(self, cert, ext):
+        SigningException.__init__(self)
+        self.cert = cert
+        self.ext = ext
 
-        def __str__(self):
-                return _("The certificate whose subject is {cert} could not "
-                    "be verified because it uses an unsupported critical "
-                    "extension.\nExtension name: {name}\nExtension "
-                    "value: {val}").format(cert="/".join("{0}={1}".format(
-                    s.oid._name, s.value) for s in self.cert.subject),
-                    name=self.ext.oid._name, val=self.ext.value)
+    def __str__(self):
+        return _(
+            "The certificate whose subject is {cert} could not "
+            "be verified because it uses an unsupported critical "
+            "extension.\nExtension name: {name}\nExtension "
+            "value: {val}"
+        ).format(
+            cert="/".join(
+                "{0}={1}".format(s.oid._name, s.value)
+                for s in self.cert.subject
+            ),
+            name=self.ext.oid._name,
+            val=self.ext.value,
+        )
+
 
 class UnsupportedExtensionValue(SigningException):
-        """Exception used when a certificate in the chain of trust has an
-        extension with a value pkg doesn't understand."""
+    """Exception used when a certificate in the chain of trust has an
+    extension with a value pkg doesn't understand."""
 
-        def __init__(self, cert, ext, val, bad_val=None):
-                SigningException.__init__(self)
-                self.cert = cert
-                self.ext = ext
-                self.val = val
-                self.bad_val = bad_val
+    def __init__(self, cert, ext, val, bad_val=None):
+        SigningException.__init__(self)
+        self.cert = cert
+        self.ext = ext
+        self.val = val
+        self.bad_val = bad_val
 
-        def __str__(self):
-                s = _("The certificate whose subject is {cert} could not be "
-                    "verified because it has an extension with a value that "
-                    "pkg(7) does not understand."
-                    "\nExtension name: {name}\nExtension value: {val}").format(
-                    cert="/".join("{0}={1}".format(
-                    s.oid._name, s.value) for s in self.cert.subject),
-                    name=self.ext.oid._name, val=self.val)
-                if self.bad_val:
-                        s += _("\nProblematic value: {0}").format(self.bad_val)
-                return s
+    def __str__(self):
+        s = _(
+            "The certificate whose subject is {cert} could not be "
+            "verified because it has an extension with a value that "
+            "pkg(7) does not understand."
+            "\nExtension name: {name}\nExtension value: {val}"
+        ).format(
+            cert="/".join(
+                "{0}={1}".format(s.oid._name, s.value)
+                for s in self.cert.subject
+            ),
+            name=self.ext.oid._name,
+            val=self.val,
+        )
+        if self.bad_val:
+            s += _("\nProblematic value: {0}").format(self.bad_val)
+        return s
+
 
 class InvalidCertificateExtensions(SigningException):
-        """Exception used when a certificate in the chain of trust has
-        invalid extensions."""
+    """Exception used when a certificate in the chain of trust has
+    invalid extensions."""
 
-        def __init__(self, cert, error):
-                SigningException.__init__(self)
-                self.cert = cert
-                self.error = error
+    def __init__(self, cert, error):
+        SigningException.__init__(self)
+        self.cert = cert
+        self.error = error
 
-        def __str__(self):
-                s = _("The certificate whose subject is {cert} could not be "
-                    "verified because it has invalid extensions:\n{error}"
-                    ).format(cert="/".join("{0}={1}".format(
-                    s.oid._name, s.value) for s in self.cert.subject),
-                    error=self.error)
-                return s
+    def __str__(self):
+        s = _(
+            "The certificate whose subject is {cert} could not be "
+            "verified because it has invalid extensions:\n{error}"
+        ).format(
+            cert="/".join(
+                "{0}={1}".format(s.oid._name, s.value)
+                for s in self.cert.subject
+            ),
+            error=self.error,
+        )
+        return s
+
 
 class InappropriateCertificateUse(SigningException):
-        """Exception used when a certificate in the chain of trust has been used
-        inappropriately.  An example would be a certificate which was only
-        supposed to be used to sign code being used to sign other certificates.
-        """
+    """Exception used when a certificate in the chain of trust has been used
+    inappropriately.  An example would be a certificate which was only
+    supposed to be used to sign code being used to sign other certificates.
+    """
 
-        def __init__(self, cert, ext, use, val):
-                SigningException.__init__(self)
-                self.cert = cert
-                self.ext = ext
-                self.use = use
-                self.val = val
+    def __init__(self, cert, ext, use, val):
+        SigningException.__init__(self)
+        self.cert = cert
+        self.ext = ext
+        self.use = use
+        self.val = val
 
-        def __str__(self):
-                return _("The certificate whose subject is {cert} could not "
-                    "be verified because it has been used inappropriately.  "
-                    "The way it is used means that the value for extension "
-                    "{name} must include '{use}' but the value was "
-                    "'{val}'.").format(cert="/".join("{0}={1}".format(
-                    s.oid._name, s.value) for s in self.cert.subject),
-                    use=self.use, name=self.ext.oid._name,
-                    val=self.val)
+    def __str__(self):
+        return _(
+            "The certificate whose subject is {cert} could not "
+            "be verified because it has been used inappropriately.  "
+            "The way it is used means that the value for extension "
+            "{name} must include '{use}' but the value was "
+            "'{val}'."
+        ).format(
+            cert="/".join(
+                "{0}={1}".format(s.oid._name, s.value)
+                for s in self.cert.subject
+            ),
+            use=self.use,
+            name=self.ext.oid._name,
+            val=self.val,
+        )
+
 
 class PathlenTooShort(InappropriateCertificateUse):
-        """Exception used when a certificate in the chain of trust has been used
-        inappropriately.  An example would be a certificate which was only
-        supposed to be used to sign code being used to sign other certificates.
-        """
+    """Exception used when a certificate in the chain of trust has been used
+    inappropriately.  An example would be a certificate which was only
+    supposed to be used to sign code being used to sign other certificates.
+    """
 
-        def __init__(self, cert, actual_length, cert_length):
-                SigningException.__init__(self)
-                self.cert = cert
-                self.al = actual_length
-                self.cl = cert_length
+    def __init__(self, cert, actual_length, cert_length):
+        SigningException.__init__(self)
+        self.cert = cert
+        self.al = actual_length
+        self.cl = cert_length
 
-        def __str__(self):
-                return _("The certificate whose subject is {cert} could not "
-                    "be verified because it has been used inappropriately.  "
-                    "There can only be {cl} certificates between this "
-                    "certificate and the leaf certificate.  There are {al} "
-                    "certificates between this certificate and the leaf in "
-                    "this chain.").format(
-                        cert="/".join("{0}={1}".format(
-                        s.oid._name, s.value) for s in self.cert.subject),
-                        al=self.al,
-                        cl=self.cl
-                   )
+    def __str__(self):
+        return _(
+            "The certificate whose subject is {cert} could not "
+            "be verified because it has been used inappropriately.  "
+            "There can only be {cl} certificates between this "
+            "certificate and the leaf certificate.  There are {al} "
+            "certificates between this certificate and the leaf in "
+            "this chain."
+        ).format(
+            cert="/".join(
+                "{0}={1}".format(s.oid._name, s.value)
+                for s in self.cert.subject
+            ),
+            al=self.al,
+            cl=self.cl,
+        )
 
 
 class AlmostIdentical(ApiException):
-        """Exception used when a package already has a signature action which is
-        nearly identical to the one being added but differs on some
-        attributes."""
+    """Exception used when a package already has a signature action which is
+    nearly identical to the one being added but differs on some
+    attributes."""
 
-        def __init__(self, hsh, algorithm, version, pkg=None):
-                self.hsh = hsh
-                self.algorithm = algorithm
-                self.version = version
-                self.pkg = pkg
+    def __init__(self, hsh, algorithm, version, pkg=None):
+        self.hsh = hsh
+        self.algorithm = algorithm
+        self.version = version
+        self.pkg = pkg
 
-        def __str__(self):
-                s = _("The signature to be added to the package has the same "
-                    "hash ({hash}), algorithm ({algorithm}), and "
-                    "version ({version}) as an existing signature, but "
-                    "doesn't match the signature exactly.  For this signature "
-                    "to be added, the existing signature must be removed.").format(
-                        hash=self.hsh,
-                        algorithm=self.algorithm,
-                        version=self.version
-                   )
-                if self.pkg:
-                        s += _("The package being signed was {pkg}").format(
-                            pkg=self.pkg)
-                return s
+    def __str__(self):
+        s = _(
+            "The signature to be added to the package has the same "
+            "hash ({hash}), algorithm ({algorithm}), and "
+            "version ({version}) as an existing signature, but "
+            "doesn't match the signature exactly.  For this signature "
+            "to be added, the existing signature must be removed."
+        ).format(hash=self.hsh, algorithm=self.algorithm, version=self.version)
+        if self.pkg:
+            s += _("The package being signed was {pkg}").format(pkg=self.pkg)
+        return s
 
 
 class DuplicateSignaturesAlreadyExist(ApiException):
-        """Exception used when a package already has a signature action which is
-        nearly identical to the one being added but differs on some
-        attributes."""
+    """Exception used when a package already has a signature action which is
+    nearly identical to the one being added but differs on some
+    attributes."""
 
-        def __init__(self, pfmri):
-                self.pfmri = pfmri
+    def __init__(self, pfmri):
+        self.pfmri = pfmri
 
-        def __str__(self):
-                return _("{0} could not be signed because it already has two "
-                    "copies of this signature in it.  One of those signature "
-                    "actions must be removed before the package is given to "
-                    "users.").format(self.pfmri)
+    def __str__(self):
+        return _(
+            "{0} could not be signed because it already has two "
+            "copies of this signature in it.  One of those signature "
+            "actions must be removed before the package is given to "
+            "users."
+        ).format(self.pfmri)
 
 
 class InvalidPropertyValue(ApiException):
-        """Exception used when a property was set to an invalid value."""
+    """Exception used when a property was set to an invalid value."""
 
-        def __init__(self, s):
-                ApiException.__init__(self)
-                self.str = s
+    def __init__(self, s):
+        ApiException.__init__(self)
+        self.str = s
 
-        def __str__(self):
-                return self.str
+    def __str__(self):
+        return self.str
 
 
 class CertificateError(ApiException):
-        """Base exception class for all certificate exceptions."""
+    """Base exception class for all certificate exceptions."""
 
-        def __init__(self, *args, **kwargs):
-                ApiException.__init__(self, *args)
-                if args:
-                        self.data = args[0]
-                else:
-                        self.data = None
-                self._args = kwargs
+    def __init__(self, *args, **kwargs):
+        ApiException.__init__(self, *args)
+        if args:
+            self.data = args[0]
+        else:
+            self.data = None
+        self._args = kwargs
 
-        def __str__(self):
-                return str(self.data)
+    def __str__(self):
+        return str(self.data)
 
 
 class ExpiredCertificate(CertificateError):
-        """Used to indicate that a certificate has expired."""
+    """Used to indicate that a certificate has expired."""
 
-        def __init__(self, *args, **kwargs):
-                CertificateError.__init__(self, *args, **kwargs)
-                self.publisher = self._args.get("publisher", None)
-                self.uri = self._args.get("uri", None)
+    def __init__(self, *args, **kwargs):
+        CertificateError.__init__(self, *args, **kwargs)
+        self.publisher = self._args.get("publisher", None)
+        self.uri = self._args.get("uri", None)
 
-        def __str__(self):
-                if self.publisher:
-                        if self.uri:
-                                return _("Certificate '{cert}' for publisher "
-                                    "'{pub}' needed to access '{uri}', "
-                                    "has expired.  Please install a valid "
-                                    "certificate.").format(cert=self.data,
-                                    pub=self.publisher, uri=self.uri)
-                        return _("Certificate '{cert}' for publisher "
-                            "'{pub}', has expired.  Please install a valid "
-                            "certificate.").format(cert=self.data,
-                            pub=self.publisher)
-                if self.uri:
-                        return _("Certificate '{cert}', needed to access "
-                            "'{uri}', has expired.  Please install a valid "
-                            "certificate.").format(cert=self.data,
-                            uri=self.uri)
-                return _("Certificate '{0}' has expired.  Please install a "
-                    "valid certificate.").format(self.data)
+    def __str__(self):
+        if self.publisher:
+            if self.uri:
+                return _(
+                    "Certificate '{cert}' for publisher "
+                    "'{pub}' needed to access '{uri}', "
+                    "has expired.  Please install a valid "
+                    "certificate."
+                ).format(cert=self.data, pub=self.publisher, uri=self.uri)
+            return _(
+                "Certificate '{cert}' for publisher "
+                "'{pub}', has expired.  Please install a valid "
+                "certificate."
+            ).format(cert=self.data, pub=self.publisher)
+        if self.uri:
+            return _(
+                "Certificate '{cert}', needed to access "
+                "'{uri}', has expired.  Please install a valid "
+                "certificate."
+            ).format(cert=self.data, uri=self.uri)
+        return _(
+            "Certificate '{0}' has expired.  Please install a "
+            "valid certificate."
+        ).format(self.data)
 
 
 class ExpiredCertificates(CertificateError):
-        """Used to collect ExpiredCertficate exceptions."""
+    """Used to collect ExpiredCertficate exceptions."""
 
-        def __init__(self, errors):
+    def __init__(self, errors):
+        self.errors = []
 
-                self.errors = []
+        assert isinstance(errors, (list, tuple, set, ExpiredCertificate))
 
-                assert (isinstance(errors, (list, tuple,
-                    set, ExpiredCertificate)))
+        if isinstance(errors, ExpiredCertificate):
+            self.errors.append(errors)
+        else:
+            self.errors = errors
 
-                if isinstance(errors, ExpiredCertificate):
-                        self.errors.append(errors)
-                else:
-                        self.errors = errors
+    def __str__(self):
+        pdict = dict()
+        for e in self.errors:
+            if e.publisher in pdict:
+                pdict[e.publisher].append(e.uri)
+            else:
+                pdict[e.publisher] = [e.uri]
 
-        def __str__(self):
-                pdict = dict()
-                for e in self.errors:
-                        if e.publisher in pdict:
-                                pdict[e.publisher].append(e.uri)
-                        else:
-                                pdict[e.publisher] = [e.uri]
-
-                msg = ""
-                for pub, uris in pdict.items():
-                        msg += "\n{0}:".format(_("Publisher"))
-                        msg += " {0}".format(pub)
-                        for uri in uris:
-                                msg += "\n  {0}:\n".format(_("Origin URI"))
-                                msg += "    {0}\n".format(uri)
-                                msg += "  {0}:\n".format(_("Certificate"))
-                                msg += "    {0}\n".format(uri.ssl_cert)
-                                msg += "  {0}:\n".format(_("Key"))
-                                msg += "    {0}\n".format(uri.ssl_key)
-                return _("One or more client key and certificate files have "
-                    "expired. Please\nupdate the configuration for the "
-                    "publishers or origins listed below:\n {0}").format(msg)
+        msg = ""
+        for pub, uris in pdict.items():
+            msg += "\n{0}:".format(_("Publisher"))
+            msg += " {0}".format(pub)
+            for uri in uris:
+                msg += "\n  {0}:\n".format(_("Origin URI"))
+                msg += "    {0}\n".format(uri)
+                msg += "  {0}:\n".format(_("Certificate"))
+                msg += "    {0}\n".format(uri.ssl_cert)
+                msg += "  {0}:\n".format(_("Key"))
+                msg += "    {0}\n".format(uri.ssl_key)
+        return _(
+            "One or more client key and certificate files have "
+            "expired. Please\nupdate the configuration for the "
+            "publishers or origins listed below:\n {0}"
+        ).format(msg)
 
 
 class ExpiringCertificate(CertificateError):
-        """Used to indicate that a certificate has expired."""
+    """Used to indicate that a certificate has expired."""
 
-        def __str__(self):
-                publisher = self._args.get("publisher", None)
-                uri = self._args.get("uri", None)
-                days = self._args.get("days", 0)
-                if publisher:
-                        if uri:
-                                return _("Certificate '{cert}' for publisher "
-                                    "'{pub}', needed to access '{uri}', "
-                                    "will expire in '{days}' days.").format(
-                                    cert=self.data, pub=publisher,
-                                    uri=uri, days=days)
-                        return _("Certificate '{cert}' for publisher "
-                            "'{pub}' will expire in '{days}' days.").format(
-                            cert=self.data, pub=publisher, days=days)
-                if uri:
-                        return _("Certificate '{cert}', needed to access "
-                            "'{uri}', will expire in '{days}' days.").format(
-                            cert=self.data, uri=uri, days=days)
-                return _("Certificate '{cert}' will expire in "
-                    "'{days}' days.").format(cert=self.data, days=days)
+    def __str__(self):
+        publisher = self._args.get("publisher", None)
+        uri = self._args.get("uri", None)
+        days = self._args.get("days", 0)
+        if publisher:
+            if uri:
+                return _(
+                    "Certificate '{cert}' for publisher "
+                    "'{pub}', needed to access '{uri}', "
+                    "will expire in '{days}' days."
+                ).format(cert=self.data, pub=publisher, uri=uri, days=days)
+            return _(
+                "Certificate '{cert}' for publisher "
+                "'{pub}' will expire in '{days}' days."
+            ).format(cert=self.data, pub=publisher, days=days)
+        if uri:
+            return _(
+                "Certificate '{cert}', needed to access "
+                "'{uri}', will expire in '{days}' days."
+            ).format(cert=self.data, uri=uri, days=days)
+        return _(
+            "Certificate '{cert}' will expire in " "'{days}' days."
+        ).format(cert=self.data, days=days)
 
 
 class InvalidCertificate(CertificateError):
-        """Used to indicate that a certificate is invalid."""
+    """Used to indicate that a certificate is invalid."""
 
-        def __str__(self):
-                publisher = self._args.get("publisher", None)
-                uri = self._args.get("uri", None)
-                if publisher:
-                        if uri:
-                                return _("Certificate '{cert}' for publisher "
-                                    "'{pub}', needed to access '{uri}', is "
-                                    "invalid.").format(cert=self.data,
-                                    pub=publisher, uri=uri)
-                        return _("Certificate '{cert}' for publisher "
-                            "'{pub}' is invalid.").format(cert=self.data,
-                            pub=publisher)
-                if uri:
-                        return _("Certificate '{cert}' needed to access "
-                            "'{uri}' is invalid.").format(cert=self.data,
-                            uri=uri)
-                return _("Invalid certificate '{0}'.").format(self.data)
+    def __str__(self):
+        publisher = self._args.get("publisher", None)
+        uri = self._args.get("uri", None)
+        if publisher:
+            if uri:
+                return _(
+                    "Certificate '{cert}' for publisher "
+                    "'{pub}', needed to access '{uri}', is "
+                    "invalid."
+                ).format(cert=self.data, pub=publisher, uri=uri)
+            return _(
+                "Certificate '{cert}' for publisher " "'{pub}' is invalid."
+            ).format(cert=self.data, pub=publisher)
+        if uri:
+            return _(
+                "Certificate '{cert}' needed to access " "'{uri}' is invalid."
+            ).format(cert=self.data, uri=uri)
+        return _("Invalid certificate '{0}'.").format(self.data)
 
 
 class NoSuchKey(CertificateError):
-        """Used to indicate that a key could not be found."""
+    """Used to indicate that a key could not be found."""
 
-        def __str__(self):
-                publisher = self._args.get("publisher", None)
-                uri = self._args.get("uri", None)
-                if publisher:
-                        if uri:
-                                return _("Unable to locate key '{key}' for "
-                                    "publisher '{pub}' needed to access "
-                                    "'{uri}'.").format(key=self.data,
-                                    pub=publisher, uri=uri)
-                        return _("Unable to locate key '{key}' for publisher "
-                            "'{pub}'.").format(key=self.data, pub=publisher
-                           )
-                if uri:
-                        return _("Unable to locate key '{key}' needed to "
-                            "access '{uri}'.").format(key=self.data,
-                            uri=uri)
-                return _("Unable to locate key '{0}'.").format(self.data)
+    def __str__(self):
+        publisher = self._args.get("publisher", None)
+        uri = self._args.get("uri", None)
+        if publisher:
+            if uri:
+                return _(
+                    "Unable to locate key '{key}' for "
+                    "publisher '{pub}' needed to access "
+                    "'{uri}'."
+                ).format(key=self.data, pub=publisher, uri=uri)
+            return _(
+                "Unable to locate key '{key}' for publisher " "'{pub}'."
+            ).format(key=self.data, pub=publisher)
+        if uri:
+            return _(
+                "Unable to locate key '{key}' needed to " "access '{uri}'."
+            ).format(key=self.data, uri=uri)
+        return _("Unable to locate key '{0}'.").format(self.data)
 
 
 class NoSuchCertificate(CertificateError):
-        """Used to indicate that a certificate could not be found."""
+    """Used to indicate that a certificate could not be found."""
 
-        def __str__(self):
-                publisher = self._args.get("publisher", None)
-                uri = self._args.get("uri", None)
-                if publisher:
-                        if uri:
-                                return _("Unable to locate certificate "
-                                    "'{cert}' for publisher '{pub}' needed "
-                                    "to access '{uri}'.").format(
-                                    cert=self.data, pub=publisher,
-                                    uri=uri)
-                        return _("Unable to locate certificate '{cert}' for "
-                            "publisher '{pub}'.").format(cert=self.data,
-                            pub=publisher)
-                if uri:
-                        return _("Unable to locate certificate '{cert}' "
-                            "needed to access '{uri}'.").format(
-                            cert=self.data, uri=uri)
-                return _("Unable to locate certificate '{0}'.").format(
-                    self.data)
+    def __str__(self):
+        publisher = self._args.get("publisher", None)
+        uri = self._args.get("uri", None)
+        if publisher:
+            if uri:
+                return _(
+                    "Unable to locate certificate "
+                    "'{cert}' for publisher '{pub}' needed "
+                    "to access '{uri}'."
+                ).format(cert=self.data, pub=publisher, uri=uri)
+            return _(
+                "Unable to locate certificate '{cert}' for "
+                "publisher '{pub}'."
+            ).format(cert=self.data, pub=publisher)
+        if uri:
+            return _(
+                "Unable to locate certificate '{cert}' "
+                "needed to access '{uri}'."
+            ).format(cert=self.data, uri=uri)
+        return _("Unable to locate certificate '{0}'.").format(self.data)
 
 
 class NotYetValidCertificate(CertificateError):
-        """Used to indicate that a certificate is not yet valid (future
-        effective date)."""
+    """Used to indicate that a certificate is not yet valid (future
+    effective date)."""
 
-        def __str__(self):
-                publisher = self._args.get("publisher", None)
-                uri = self._args.get("uri", None)
-                if publisher:
-                        if uri:
-                                return _("Certificate '{cert}' for publisher "
-                                    "'{pub}', needed to access '{uri}', "
-                                    "has a future effective date.").format(
-                                    cert=self.data, pub=publisher,
-                                    uri=uri)
-                        return _("Certificate '{cert}' for publisher "
-                            "'{pub}' has a future effective date.").format(
-                            cert=self.data, pub=publisher)
-                if uri:
-                        return _("Certificate '{cert}' needed to access "
-                            "'{uri}' has a future effective date.").format(
-                            cert=self.data, uri=uri)
-                return _("Certificate '{0}' has a future effective date.").format(
-                    self.data)
+    def __str__(self):
+        publisher = self._args.get("publisher", None)
+        uri = self._args.get("uri", None)
+        if publisher:
+            if uri:
+                return _(
+                    "Certificate '{cert}' for publisher "
+                    "'{pub}', needed to access '{uri}', "
+                    "has a future effective date."
+                ).format(cert=self.data, pub=publisher, uri=uri)
+            return _(
+                "Certificate '{cert}' for publisher "
+                "'{pub}' has a future effective date."
+            ).format(cert=self.data, pub=publisher)
+        if uri:
+            return _(
+                "Certificate '{cert}' needed to access "
+                "'{uri}' has a future effective date."
+            ).format(cert=self.data, uri=uri)
+        return _("Certificate '{0}' has a future effective date.").format(
+            self.data
+        )
 
 
 class ServerReturnError(ApiException):
-        """This exception is used when the server returns a line which the
-        client cannot parse correctly."""
+    """This exception is used when the server returns a line which the
+    client cannot parse correctly."""
 
-        def __init__(self, line):
-                ApiException.__init__(self)
-                self.line = line
+    def __init__(self, line):
+        ApiException.__init__(self)
+        self.line = line
 
-        def __str__(self):
-                return _("Gave a bad response:{0}").format(self.line)
+    def __str__(self):
+        return _("Gave a bad response:{0}").format(self.line)
 
 
 class MissingFileArgumentException(ApiException):
-        """This exception is used when a file was given as an argument but
-        no such file could be found."""
-        def __init__(self, path):
-                ApiException.__init__(self)
-                self.path = path
+    """This exception is used when a file was given as an argument but
+    no such file could be found."""
 
-        def __str__(self):
-                return _("Could not find {0}").format(self.path)
+    def __init__(self, path):
+        ApiException.__init__(self)
+        self.path = path
+
+    def __str__(self):
+        return _("Could not find {0}").format(self.path)
 
 
 class ManifestError(ApiException):
-        """Base exception class for all manifest exceptions."""
+    """Base exception class for all manifest exceptions."""
 
-        def __init__(self, *args, **kwargs):
-                ApiException.__init__(self, *args, **kwargs)
-                if args:
-                        self.data = args[0]
-                else:
-                        self.data = None
-                self._args = kwargs
+    def __init__(self, *args, **kwargs):
+        ApiException.__init__(self, *args, **kwargs)
+        if args:
+            self.data = args[0]
+        else:
+            self.data = None
+        self._args = kwargs
 
-        def __str__(self):
-                return str(self.data)
+    def __str__(self):
+        return str(self.data)
 
 
 class BadManifestSignatures(ManifestError):
-        """Used to indicate that the Manifest signatures are not valid."""
+    """Used to indicate that the Manifest signatures are not valid."""
 
-        def __str__(self):
-                if self.data:
-                        return _("The signature data for the manifest of the "
-                            "'{0}' package is not valid.").format(self.data)
-                return _("The signature data for the manifest is not valid.")
+    def __str__(self):
+        if self.data:
+            return _(
+                "The signature data for the manifest of the "
+                "'{0}' package is not valid."
+            ).format(self.data)
+        return _("The signature data for the manifest is not valid.")
 
 
 class UnknownErrors(ApiException):
-        """Used to indicate that one or more exceptions were encountered.
-        This is intended for use with where multiple exceptions for multiple
-        files are encountered and the errors have been condensed into a
-        single exception and re-raised.  One example case would be rmtree()
-        with shutil.Error."""
+    """Used to indicate that one or more exceptions were encountered.
+    This is intended for use with where multiple exceptions for multiple
+    files are encountered and the errors have been condensed into a
+    single exception and re-raised.  One example case would be rmtree()
+    with shutil.Error."""
 
-        def __init__(self, msg):
-                ApiException.__init__(self)
-                self.__msg = msg
+    def __init__(self, msg):
+        ApiException.__init__(self)
+        self.__msg = msg
 
-        def __str__(self):
-                return self.__msg
+    def __str__(self):
+        return self.__msg
 
 
 # Image creation exceptions
 class ImageCreationException(ApiException):
-        def __init__(self, path):
-                ApiException.__init__(self)
-                self.path = path
+    def __init__(self, path):
+        ApiException.__init__(self)
+        self.path = path
 
-        def __str__(self):
-                raise NotImplementedError()
+    def __str__(self):
+        raise NotImplementedError()
 
 
 class ImageAlreadyExists(ImageCreationException):
-        def __str__(self):
-                return _("there is already an image at: {0}.\nTo override, use "
-                    "the -f (force) option.").format(self.path)
+    def __str__(self):
+        return _(
+            "there is already an image at: {0}.\nTo override, use "
+            "the -f (force) option."
+        ).format(self.path)
 
 
 class ImageCfgEmptyError(ApiException):
-        """Used to indicate that the image configuration is invalid."""
+    """Used to indicate that the image configuration is invalid."""
 
-        def __str__(self):
-                return _("The configuration data for the image rooted at "
-                    "{0} is empty or missing.").format(self.data)
+    def __str__(self):
+        return _(
+            "The configuration data for the image rooted at "
+            "{0} is empty or missing."
+        ).format(self.data)
 
 
 class UnsupportedImageError(ApiException):
-        """Used to indicate that the image at a specific location is in a format
-        not supported by this version of the pkg(7) API."""
+    """Used to indicate that the image at a specific location is in a format
+    not supported by this version of the pkg(7) API."""
 
-        def __init__(self, path):
-                ApiException.__init__(self)
-                self.path = path
+    def __init__(self, path):
+        ApiException.__init__(self)
+        self.path = path
 
-        def __str__(self):
-                return _("The image rooted at {0} is invalid or is not "
-                    "supported by this version of the packaging system.").format(
-                    self.path)
+    def __str__(self):
+        return _(
+            "The image rooted at {0} is invalid or is not "
+            "supported by this version of the packaging system."
+        ).format(self.path)
 
 
 class CreatingImageInNonEmptyDir(ImageCreationException):
-        def __str__(self):
-                return _("the specified image path is not empty: {0}.\nTo "
-                    "override, use the -f (force) option.").format(self.path)
+    def __str__(self):
+        return _(
+            "the specified image path is not empty: {0}.\nTo "
+            "override, use the -f (force) option."
+        ).format(self.path)
 
 
 def _convert_error(e, ignored_errors=EmptyI):
-        """Converts the provided exception into an ApiException equivalent if
-        possible.  Returns a new exception object if converted or the original
-        if not.
+    """Converts the provided exception into an ApiException equivalent if
+    possible.  Returns a new exception object if converted or the original
+    if not.
 
-        'ignored_errors' is an optional list of errno values for which None
-        should be returned.
-        """
+    'ignored_errors' is an optional list of errno values for which None
+    should be returned.
+    """
 
-        if not hasattr(e, "errno"):
-                return e
-        if e.errno in ignored_errors:
-                return None
-        if e.errno in (errno.EACCES, errno.EPERM):
-                return PermissionsException(e.filename)
-        if e.errno == errno.EROFS:
-                return ReadOnlyFileSystemException(e.filename)
+    if not hasattr(e, "errno"):
         return e
+    if e.errno in ignored_errors:
+        return None
+    if e.errno in (errno.EACCES, errno.EPERM):
+        return PermissionsException(e.filename)
+    if e.errno == errno.EROFS:
+        return ReadOnlyFileSystemException(e.filename)
+    return e
+
 
 class LinkedImageException(ApiException):
+    def __init__(
+        self,
+        bundle=None,
+        lin=None,
+        exitrv=None,
+        attach_bad_prop=None,
+        attach_bad_prop_value=None,
+        attach_child_notsup=None,
+        attach_parent_notsup=None,
+        attach_root_as_child=None,
+        attach_with_curpath=None,
+        child_bad_img=None,
+        child_diverged=None,
+        child_dup=None,
+        child_not_in_altroot=None,
+        child_not_nested=None,
+        child_op_failed=None,
+        child_path_notabs=None,
+        child_unknown=None,
+        cmd_failed=None,
+        cmd_output_invalid=None,
+        detach_child_notsup=None,
+        detach_from_parent=None,
+        detach_parent_notsup=None,
+        img_linked=None,
+        intermediate_image=None,
+        lin_malformed=None,
+        link_to_self=None,
+        parent_bad_img=None,
+        parent_bad_notabs=None,
+        parent_bad_path=None,
+        parent_nested=None,
+        parent_not_in_altroot=None,
+        pkg_op_failed=None,
+        self_linked=None,
+        self_not_child=None,
+        unparsable_output=None,
+    ):
+        from pkg.misc import force_str
 
-        def __init__(self, bundle=None, lin=None, exitrv=None,
-            attach_bad_prop=None,
-            attach_bad_prop_value=None,
-            attach_child_notsup=None,
-            attach_parent_notsup=None,
-            attach_root_as_child=None,
-            attach_with_curpath=None,
-            child_bad_img=None,
-            child_diverged=None,
-            child_dup=None,
-            child_not_in_altroot=None,
-            child_not_nested=None,
-            child_op_failed=None,
-            child_path_notabs=None,
-            child_unknown=None,
-            cmd_failed=None,
-            cmd_output_invalid=None,
-            detach_child_notsup=None,
-            detach_from_parent=None,
-            detach_parent_notsup=None,
-            img_linked=None,
-            intermediate_image=None,
-            lin_malformed=None,
-            link_to_self=None,
-            parent_bad_img=None,
-            parent_bad_notabs=None,
-            parent_bad_path=None,
-            parent_nested=None,
-            parent_not_in_altroot=None,
-            pkg_op_failed=None,
-            self_linked=None,
-            self_not_child=None,
-            unparsable_output=None):
+        self.attach_bad_prop = attach_bad_prop
+        self.attach_bad_prop_value = attach_bad_prop_value
+        self.attach_child_notsup = attach_child_notsup
+        self.attach_parent_notsup = attach_parent_notsup
+        self.attach_root_as_child = attach_root_as_child
+        self.attach_with_curpath = attach_with_curpath
+        self.child_bad_img = child_bad_img
+        self.child_diverged = child_diverged
+        self.child_dup = child_dup
+        self.child_not_in_altroot = child_not_in_altroot
+        self.child_not_nested = child_not_nested
+        self.child_op_failed = child_op_failed
+        self.child_path_notabs = child_path_notabs
+        self.child_unknown = child_unknown
+        self.cmd_failed = cmd_failed
+        self.cmd_output_invalid = cmd_output_invalid
+        self.detach_child_notsup = detach_child_notsup
+        self.detach_from_parent = detach_from_parent
+        self.detach_parent_notsup = detach_parent_notsup
+        self.img_linked = img_linked
+        self.intermediate_image = intermediate_image
+        self.lin_malformed = lin_malformed
+        self.link_to_self = link_to_self
+        self.parent_bad_img = parent_bad_img
+        self.parent_bad_notabs = parent_bad_notabs
+        self.parent_bad_path = parent_bad_path
+        self.parent_nested = parent_nested
+        self.parent_not_in_altroot = parent_not_in_altroot
+        self.pkg_op_failed = pkg_op_failed
+        self.self_linked = self_linked
+        self.self_not_child = self_not_child
+        self.unparsable_output = unparsable_output
 
-                from pkg.misc import force_str
+        # first deal with an error bundle
+        if bundle:
+            assert type(bundle) in [tuple, list, set]
+            for e in bundle:
+                assert isinstance(e, LinkedImageException)
 
-                self.attach_bad_prop = attach_bad_prop
-                self.attach_bad_prop_value = attach_bad_prop_value
-                self.attach_child_notsup = attach_child_notsup
-                self.attach_parent_notsup = attach_parent_notsup
-                self.attach_root_as_child = attach_root_as_child
-                self.attach_with_curpath = attach_with_curpath
-                self.child_bad_img = child_bad_img
-                self.child_diverged = child_diverged
-                self.child_dup = child_dup
-                self.child_not_in_altroot = child_not_in_altroot
-                self.child_not_nested = child_not_nested
-                self.child_op_failed = child_op_failed
-                self.child_path_notabs = child_path_notabs
-                self.child_unknown = child_unknown
-                self.cmd_failed = cmd_failed
-                self.cmd_output_invalid = cmd_output_invalid
-                self.detach_child_notsup = detach_child_notsup
-                self.detach_from_parent = detach_from_parent
-                self.detach_parent_notsup = detach_parent_notsup
-                self.img_linked = img_linked
-                self.intermediate_image = intermediate_image
-                self.lin_malformed = lin_malformed
-                self.link_to_self = link_to_self
-                self.parent_bad_img = parent_bad_img
-                self.parent_bad_notabs = parent_bad_notabs
-                self.parent_bad_path = parent_bad_path
-                self.parent_nested = parent_nested
-                self.parent_not_in_altroot = parent_not_in_altroot
-                self.pkg_op_failed = pkg_op_failed
-                self.self_linked = self_linked
-                self.self_not_child = self_not_child
-                self.unparsable_output = unparsable_output
+            # set default error return value
+            if exitrv == None:
+                exitrv = pkgdefs.EXIT_OOPS
 
-                # first deal with an error bundle
-                if bundle:
-                        assert type(bundle) in [tuple, list, set]
-                        for e in bundle:
-                                assert isinstance(e, LinkedImageException)
+            self.lix_err = None
+            self.lix_bundle = bundle
+            self.lix_exitrv = exitrv
+            return
 
-                        # set default error return value
-                        if exitrv == None:
-                                exitrv = pkgdefs.EXIT_OOPS
+        err = None
 
-                        self.lix_err = None
-                        self.lix_bundle = bundle
-                        self.lix_exitrv = exitrv
-                        return
+        if attach_bad_prop is not None:
+            err = _("Invalid linked image attach property: {0}").format(
+                attach_bad_prop
+            )
 
-                err = None
+        if attach_bad_prop_value is not None:
+            assert type(attach_bad_prop_value) in [tuple, list]
+            assert len(attach_bad_prop_value) == 2
+            err = _(
+                "Invalid linked image attach property " "value: {0}"
+            ).format("=".join(attach_bad_prop_value))
 
-                if attach_bad_prop is not None:
-                        err = _("Invalid linked image attach property: {0}").format(
-                            attach_bad_prop)
+        if attach_child_notsup is not None:
+            err = _(
+                "Linked image type does not support child " "attach: {0}"
+            ).format(attach_child_notsup)
 
-                if attach_bad_prop_value is not None:
-                        assert type(attach_bad_prop_value) in [tuple, list]
-                        assert len(attach_bad_prop_value) == 2
-                        err =  _("Invalid linked image attach property "
-                            "value: {0}").format(
-                            "=".join(attach_bad_prop_value))
+        if attach_parent_notsup is not None:
+            err = _(
+                "Linked image type does not support parent " "attach: {0}"
+            ).format(attach_parent_notsup)
 
-                if attach_child_notsup is not None:
-                        err = _("Linked image type does not support child "
-                            "attach: {0}").format(attach_child_notsup)
+        if attach_root_as_child is not None:
+            err = _(
+                "Cannot attach root image as child: {0}".format(
+                    attach_root_as_child
+                )
+            )
 
-                if attach_parent_notsup is not None:
-                        err = _("Linked image type does not support parent "
-                            "attach: {0}").format(attach_parent_notsup)
+        if attach_with_curpath is not None:
+            path, curpath = attach_with_curpath
+            err = _(
+                "Cannot link images when an image is not at "
+                "its default location.  The image currently "
+                "located at:\n  {curpath}\n"
+                "is normally located at:\n  {path}\n"
+            ).format(
+                path=path,
+                curpath=curpath,
+            )
 
-                if attach_root_as_child is not None:
-                        err = _("Cannot attach root image as child: {0}".format(
-                            attach_root_as_child))
+        if child_bad_img is not None:
+            if exitrv == None:
+                exitrv = pkgdefs.EXIT_EACCESS
+            if lin:
+                err = _(
+                    "Can't initialize child image " "({lin}) at path: {path}"
+                ).format(lin=lin, path=child_bad_img)
+            else:
+                err = _("Can't initialize child image " "at path: {0}").format(
+                    child_bad_img
+                )
 
-                if attach_with_curpath is not None:
-                        path, curpath = attach_with_curpath
-                        err = _("Cannot link images when an image is not at "
-                            "its default location.  The image currently "
-                            "located at:\n  {curpath}\n"
-                            "is normally located at:\n  {path}\n").format(
-                                path=path,
-                                curpath=curpath,
-                           )
+        if child_diverged is not None:
+            if exitrv == None:
+                exitrv = pkgdefs.EXIT_DIVERGED
+            err = _("Linked image is diverged: {0}").format(child_diverged)
 
-                if child_bad_img is not None:
-                        if exitrv == None:
-                                exitrv = pkgdefs.EXIT_EACCESS
-                        if lin:
-                                err = _("Can't initialize child image "
-                                    "({lin}) at path: {path}").format(
-                                        lin=lin,
-                                        path=child_bad_img
-                                   )
-                        else:
-                                err = _("Can't initialize child image "
-                                    "at path: {0}").format(child_bad_img)
+        if child_dup is not None:
+            err = _(
+                "A linked child image with this name " "already exists: {0}"
+            ).format(child_dup)
 
-                if child_diverged is not None:
-                        if exitrv == None:
-                                exitrv = pkgdefs.EXIT_DIVERGED
-                        err = _("Linked image is diverged: {0}").format(
-                            child_diverged)
+        if child_not_in_altroot is not None:
+            path, altroot = child_not_in_altroot
+            err = _(
+                "Child image '{path}' is not located "
+                "within the parent's altroot '{altroot}'"
+            ).format(path=path, altroot=altroot)
 
-                if child_dup is not None:
-                        err = _("A linked child image with this name "
-                            "already exists: {0}").format(child_dup)
+        if child_not_nested is not None:
+            cpath, ppath = child_not_nested
+            err = _(
+                "Child image '{cpath}' is not nested "
+                "within the parent image '{ppath}'"
+            ).format(
+                cpath=cpath,
+                ppath=ppath,
+            )
 
-                if child_not_in_altroot is not None:
-                        path, altroot = child_not_in_altroot
-                        err = _("Child image '{path}' is not located "
-                           "within the parent's altroot '{altroot}'").format(
-                                path=path,
-                                altroot=altroot
-                           )
+        if child_op_failed is not None:
+            op, cpath, e = child_op_failed
+            if exitrv == None:
+                exitrv = pkgdefs.EXIT_EACCESS
+            if lin:
+                err = _(
+                    "Failed '{op}' for child image "
+                    "({lin}) at path: {path}: "
+                    "{strerror}"
+                ).format(
+                    op=op,
+                    lin=lin,
+                    path=cpath,
+                    strerror=e,
+                )
+            else:
+                err = _(
+                    "Failed '{op}' for child image "
+                    "at path: {path}: {strerror}"
+                ).format(
+                    op=op,
+                    path=cpath,
+                    strerror=e,
+                )
 
-                if child_not_nested is not None:
-                        cpath, ppath = child_not_nested
-                        err = _("Child image '{cpath}' is not nested "
-                            "within the parent image '{ppath}'").format(
-                                cpath=cpath,
-                                ppath=ppath,
-                           )
+        if child_path_notabs is not None:
+            err = _("Child path not absolute: {0}").format(child_path_notabs)
 
-                if child_op_failed is not None:
-                        op, cpath, e = child_op_failed
-                        if exitrv == None:
-                                exitrv = pkgdefs.EXIT_EACCESS
-                        if lin:
-                                err = _("Failed '{op}' for child image "
-                                    "({lin}) at path: {path}: "
-                                    "{strerror}").format(
-                                        op=op,
-                                        lin=lin,
-                                        path=cpath,
-                                        strerror=e,
-                                   )
-                        else:
-                                err = _("Failed '{op}' for child image "
-                                    "at path: {path}: {strerror}").format(
-                                        op=op,
-                                        path=cpath,
-                                        strerror=e,
-                                   )
+        if child_unknown is not None:
+            err = _("Unknown child linked image: {0}").format(child_unknown)
 
-                if child_path_notabs is not None:
-                        err = _("Child path not absolute: {0}").format(
-                            child_path_notabs)
+        if cmd_failed is not None:
+            (rv, cmd, errout) = cmd_failed
+            err = _(
+                "The following subprocess returned an "
+                "unexpected exit code of {rv:d}:\n    {cmd}"
+            ).format(rv=rv, cmd=cmd)
+            if errout:
+                err += _(
+                    "\nAnd generated the following error "
+                    "message:\n{errout}".format(errout=force_str(errout))
+                )
 
-                if child_unknown is not None:
-                        err = _("Unknown child linked image: {0}").format(
-                            child_unknown)
+        if cmd_output_invalid is not None:
+            (cmd, output) = cmd_output_invalid
+            err = _(
+                "The following subprocess:\n"
+                "    {cmd}\n"
+                "Generated the following unexpected output:\n"
+                "{output}\n".format(cmd=" ".join(cmd), output="\n".join(output))
+            )
 
-                if cmd_failed is not None:
-                        (rv, cmd, errout) = cmd_failed
-                        err = _("The following subprocess returned an "
-                            "unexpected exit code of {rv:d}:\n    {cmd}").format(
-                            rv=rv, cmd=cmd)
-                        if errout:
-                                err += _("\nAnd generated the following error "
-                                    "message:\n{errout}".format(
-                                    errout=force_str(errout)))
+        if detach_child_notsup is not None:
+            err = _(
+                "Linked image type does not support " "child detach: {0}"
+            ).format(detach_child_notsup)
 
-                if cmd_output_invalid is not None:
-                        (cmd, output) = cmd_output_invalid
-                        err = _(
-                            "The following subprocess:\n"
-                            "    {cmd}\n"
-                            "Generated the following unexpected output:\n"
-                            "{output}\n".format(
-                            cmd=" ".join(cmd), output="\n".join(output)))
+        if detach_from_parent is not None:
+            if exitrv == None:
+                exitrv = pkgdefs.EXIT_PARENTOP
+            err = _(
+                "Parent linked to child, can not detach " "child: {0}"
+            ).format(detach_from_parent)
 
-                if detach_child_notsup is not None:
-                        err = _("Linked image type does not support "
-                            "child detach: {0}").format(detach_child_notsup)
+        if detach_parent_notsup is not None:
+            err = _(
+                "Linked image type does not support " "parent detach: {0}"
+            ).format(detach_parent_notsup)
 
-                if detach_from_parent is not None:
-                        if exitrv == None:
-                                exitrv = pkgdefs.EXIT_PARENTOP
-                        err =  _("Parent linked to child, can not detach "
-                            "child: {0}").format(detach_from_parent)
+        if img_linked is not None:
+            err = _("Image already a linked child: {0}").format(img_linked)
 
-                if detach_parent_notsup is not None:
-                        err = _("Linked image type does not support "
-                            "parent detach: {0}").format(detach_parent_notsup)
+        if intermediate_image is not None:
+            ppath, cpath, ipath = intermediate_image
+            err = _(
+                "Intermediate image '{ipath}' found between "
+                "child '{cpath}' and "
+                "parent '{ppath}'"
+            ).format(
+                ppath=ppath,
+                cpath=cpath,
+                ipath=ipath,
+            )
 
-                if img_linked is not None:
-                        err = _("Image already a linked child: {0}").format(
-                            img_linked)
+        if lin_malformed is not None:
+            err = _(
+                "Invalid linked image name '{0}'. "
+                "Linked image names have the following format "
+                "'<linked_image plugin>:<linked_image name>'"
+            ).format(lin_malformed)
 
-                if intermediate_image is not None:
-                        ppath, cpath, ipath = intermediate_image
-                        err = _(
-                            "Intermediate image '{ipath}' found between "
-                            "child '{cpath}' and "
-                            "parent '{ppath}'").format(
-                                ppath=ppath,
-                                cpath=cpath,
-                                ipath=ipath,
-                           )
+        if link_to_self is not None:
+            err = _("Can't link image to itself: {0}")
 
-                if lin_malformed is not None:
-                        err = _("Invalid linked image name '{0}'. "
-                            "Linked image names have the following format "
-                            "'<linked_image plugin>:<linked_image name>'").format(
-                            lin_malformed)
+        if parent_bad_img is not None:
+            if exitrv == None:
+                exitrv = pkgdefs.EXIT_EACCESS
+            err = _("Can't initialize parent image at path: {0}").format(
+                parent_bad_img
+            )
 
-                if link_to_self is not None:
-                        err = _("Can't link image to itself: {0}")
+        if parent_bad_notabs is not None:
+            err = _("Parent path not absolute: {0}").format(parent_bad_notabs)
 
-                if parent_bad_img is not None:
-                        if exitrv == None:
-                                exitrv = pkgdefs.EXIT_EACCESS
-                        err = _("Can't initialize parent image at path: {0}").format(
-                            parent_bad_img)
+        if parent_bad_path is not None:
+            if exitrv == None:
+                exitrv = pkgdefs.EXIT_EACCESS
+            err = _("Can't access parent image at path: {0}").format(
+                parent_bad_path
+            )
 
-                if parent_bad_notabs is not None:
-                        err = _("Parent path not absolute: {0}").format(
-                            parent_bad_notabs)
+        if parent_nested is not None:
+            ppath, cpath = parent_nested
+            err = _(
+                "A parent image '{ppath}' can not be nested "
+                "within a child image '{cpath}'"
+            ).format(
+                ppath=ppath,
+                cpath=cpath,
+            )
 
-                if parent_bad_path is not None:
-                        if exitrv == None:
-                                exitrv = pkgdefs.EXIT_EACCESS
-                        err = _("Can't access parent image at path: {0}").format(
-                            parent_bad_path)
+        if parent_not_in_altroot is not None:
+            path, altroot = parent_not_in_altroot
+            err = _(
+                "Parent image '{path}' is not located "
+                "within the child's altroot '{altroot}'"
+            ).format(path=path, altroot=altroot)
 
-                if parent_nested is not None:
-                        ppath, cpath = parent_nested
-                        err = _("A parent image '{ppath}' can not be nested "
-                            "within a child image '{cpath}'").format(
-                                ppath=ppath,
-                                cpath=cpath,
-                           )
+        if pkg_op_failed is not None:
+            assert lin
+            (op, exitrv, errout, e) = pkg_op_failed
+            assert op is not None
 
-                if parent_not_in_altroot is not None:
-                        path, altroot = parent_not_in_altroot
-                        err = _("Parent image '{path}' is not located "
-                            "within the child's altroot '{altroot}'").format(
-                                path=path,
-                                altroot=altroot
-                           )
-
-                if pkg_op_failed is not None:
-                        assert lin
-                        (op, exitrv, errout, e) = pkg_op_failed
-                        assert op is not None
-
-                        if e is None:
-                                err = _("""
+            if e is None:
+                err = _(
+                    """
 A '{op}' operation failed for child '{lin}' with an unexpected
 return value of {exitrv:d} and generated the following output:
 {errout}
 
 """
-                                ).format(
-                                    lin=lin,
-                                    op=op,
-                                    exitrv=exitrv,
-                                    errout=force_str(errout),
-                               )
-                        else:
-                                err = _("""
+                ).format(
+                    lin=lin,
+                    op=op,
+                    exitrv=exitrv,
+                    errout=force_str(errout),
+                )
+            else:
+                err = _(
+                    """
 A '{op}' operation failed for child '{lin}' with an unexpected
 exception:
 {e}
@@ -3258,26 +3650,29 @@ The child generated the following output:
 {errout}
 
 """
-                                ).format(
-                                    lin=lin,
-                                    op=op,
-                                    errout=force_str(errout),
-                                    e=e,
-                               )
+                ).format(
+                    lin=lin,
+                    op=op,
+                    errout=force_str(errout),
+                    e=e,
+                )
 
-                if self_linked is not None:
-                        err = _("Current image already a linked child: {0}").format(
-                            self_linked)
+        if self_linked is not None:
+            err = _("Current image already a linked child: {0}").format(
+                self_linked
+            )
 
-                if self_not_child is not None:
-                        if exitrv == None:
-                                exitrv = pkgdefs.EXIT_NOPARENT
-                        err = _("Current image is not a linked child: {0}").format(
-                            self_not_child)
+        if self_not_child is not None:
+            if exitrv == None:
+                exitrv = pkgdefs.EXIT_NOPARENT
+            err = _("Current image is not a linked child: {0}").format(
+                self_not_child
+            )
 
-                if unparsable_output is not None:
-                        (op, errout, e) = unparsable_output
-                        err = _("""
+        if unparsable_output is not None:
+            (op, errout, e) = unparsable_output
+            err = _(
+                """
 A '{op}' operation for child '{lin}' generated non-json output.
 The json parser failed with the following error:
 {e}
@@ -3286,279 +3681,318 @@ The child generated the following output:
 {errout}
 
 """
-                                ).format(
-                                    lin=lin,
-                                    op=op,
-                                    e=e,
-                                    errout=force_str(errout),
-                               )
+            ).format(
+                lin=lin,
+                op=op,
+                e=e,
+                errout=force_str(errout),
+            )
 
-                # set default error return value
-                if exitrv == None:
-                        exitrv = pkgdefs.EXIT_OOPS
+        # set default error return value
+        if exitrv == None:
+            exitrv = pkgdefs.EXIT_OOPS
 
-                self.lix_err = err
-                self.lix_bundle = None
-                self.lix_exitrv = exitrv
+        self.lix_err = err
+        self.lix_bundle = None
+        self.lix_exitrv = exitrv
 
-        def __str__(self):
-                assert self.lix_err or self.lix_bundle
-                assert not (self.lix_err and self.lix_bundle), \
-                   "self.lix_err = {0}, self.lix_bundle = {1}".format(
-                   str(self.lix_err), str(self.lix_bundle))
+    def __str__(self):
+        assert self.lix_err or self.lix_bundle
+        assert not (
+            self.lix_err and self.lix_bundle
+        ), "self.lix_err = {0}, self.lix_bundle = {1}".format(
+            str(self.lix_err), str(self.lix_bundle)
+        )
 
-                # single error
-                if self.lix_err:
-                        return self.lix_err
+        # single error
+        if self.lix_err:
+            return self.lix_err
 
-                # concatenate multiple errors
-                bundle_str = []
-                for e in self.lix_bundle:
-                        bundle_str.append(str(e))
-                return "\n".join(bundle_str)
+        # concatenate multiple errors
+        bundle_str = []
+        for e in self.lix_bundle:
+            bundle_str.append(str(e))
+        return "\n".join(bundle_str)
 
 
 class FreezePkgsException(ApiException):
-        """Used if an argument to pkg freeze isn't valid."""
+    """Used if an argument to pkg freeze isn't valid."""
 
-        def __init__(self, multiversions=None, unmatched_wildcards=None,
-            version_mismatch=None, versionless_uninstalled=None):
-                ApiException.__init__(self)
-                self.multiversions = multiversions
-                self.unmatched_wildcards = unmatched_wildcards
-                self.version_mismatch = version_mismatch
-                self.versionless_uninstalled = versionless_uninstalled
+    def __init__(
+        self,
+        multiversions=None,
+        unmatched_wildcards=None,
+        version_mismatch=None,
+        versionless_uninstalled=None,
+    ):
+        ApiException.__init__(self)
+        self.multiversions = multiversions
+        self.unmatched_wildcards = unmatched_wildcards
+        self.version_mismatch = version_mismatch
+        self.versionless_uninstalled = versionless_uninstalled
 
-        def __str__(self):
-                res = []
-                if self.multiversions:
-                        s = _("""\
+    def __str__(self):
+        res = []
+        if self.multiversions:
+            s = _(
+                """\
 The following packages were frozen at two different versions by
 the patterns provided.  The package stem and the versions it was frozen at are
-provided:""")
-                        res += [s]
-                        res += ["\t{0}\t{1}".format(stem, " ".join([
-                            str(v) for v in sorted(versions)]))
-                            for stem, versions in sorted(self.multiversions)]
+provided:"""
+            )
+            res += [s]
+            res += [
+                "\t{0}\t{1}".format(
+                    stem, " ".join([str(v) for v in sorted(versions)])
+                )
+                for stem, versions in sorted(self.multiversions)
+            ]
 
-                if self.unmatched_wildcards:
-                        s = _("""\
+        if self.unmatched_wildcards:
+            s = _(
+                """\
 The following patterns contained wildcards but matched no
-installed packages.""")
-                        res += [s]
-                        res += ["\t{0}".format(pat) for pat in sorted(
-                            self.unmatched_wildcards)]
+installed packages."""
+            )
+            res += [s]
+            res += [
+                "\t{0}".format(pat) for pat in sorted(self.unmatched_wildcards)
+            ]
 
-                if self.version_mismatch:
-                        s = _("""\
+        if self.version_mismatch:
+            s = _(
+                """\
 The following patterns attempted to freeze the listed packages
-at a version different from the version at which the packages are installed.""")
-                        res += [s]
-                        for pat in sorted(self.version_mismatch):
-                                res += ["\t{0}".format(pat)]
-                                if len(self.version_mismatch[pat]) > 1:
-                                        res += [
-                                            "\t\t{0}".format(stem)
-                                            for stem
-                                            in sorted(self.version_mismatch[pat])
-                                        ]
+at a version different from the version at which the packages are installed."""
+            )
+            res += [s]
+            for pat in sorted(self.version_mismatch):
+                res += ["\t{0}".format(pat)]
+                if len(self.version_mismatch[pat]) > 1:
+                    res += [
+                        "\t\t{0}".format(stem)
+                        for stem in sorted(self.version_mismatch[pat])
+                    ]
 
-                if self.versionless_uninstalled:
-                        s = _("""\
+        if self.versionless_uninstalled:
+            s = _(
+                """\
 The following patterns don't match installed packages and
 contain no version information.  Uninstalled packages can only be frozen by
-providing a version at which to freeze them.""")
-                        res += [s]
-                        res += ["\t{0}".format(p) for p in sorted(
-                            self.versionless_uninstalled)]
-                return "\n".join(res)
+providing a version at which to freeze them."""
+            )
+            res += [s]
+            res += [
+                "\t{0}".format(p) for p in sorted(self.versionless_uninstalled)
+            ]
+        return "\n".join(res)
+
 
 class InvalidFreezeFile(ApiException):
-        """Used to indicate the freeze state file could not be loaded."""
+    """Used to indicate the freeze state file could not be loaded."""
 
-        def __str__(self):
-                return _("The freeze state file '{0}' is invalid.").format(
-                    self.data)
+    def __str__(self):
+        return _("The freeze state file '{0}' is invalid.").format(self.data)
+
 
 class UnknownFreezeFileVersion(ApiException):
-        """Used when the version on the freeze state file isn't the version
-        that's expected."""
+    """Used when the version on the freeze state file isn't the version
+    that's expected."""
 
-        def __init__(self, found_ver, expected_ver, location):
-                self.found = found_ver
-                self.expected = expected_ver
-                self.loc = location
+    def __init__(self, found_ver, expected_ver, location):
+        self.found = found_ver
+        self.expected = expected_ver
+        self.loc = location
 
-        def __str__(self):
-                return _("The freeze state file '{loc}' was expected to have "
-                    "a version of {exp}, but its version was {found}").format(
-                    exp=self.expected,
-                    found=self.found,
-                    loc=self.loc,
-               )
+    def __str__(self):
+        return _(
+            "The freeze state file '{loc}' was expected to have "
+            "a version of {exp}, but its version was {found}"
+        ).format(
+            exp=self.expected,
+            found=self.found,
+            loc=self.loc,
+        )
+
 
 class InvalidOptionError(ApiException):
-        """Used to indicate an issue with verifying options passed to a certain
-        operation."""
+    """Used to indicate an issue with verifying options passed to a certain
+    operation."""
 
-        GENERIC      = "generic"      # generic option violation
-        OPT_REPEAT   = "opt_repeat"   # option repetition is not allowed
-        ARG_REPEAT   = "arg_repeat"   # argument repetition is not allowed
-        ARG_INVALID  = "arg_invalid"  # argument is invalid
-        INCOMPAT     = "incompat"     # option 'a' can not be specified with option 'b'
-        REQUIRED     = "required"     # option 'a' requires option 'b'
-        REQUIRED_ANY = "required_any" # option 'a' requires option 'b', 'c' or more
-        XOR          = "xor"          # either option 'a' or option 'b' must be specified
+    GENERIC = "generic"  # generic option violation
+    OPT_REPEAT = "opt_repeat"  # option repetition is not allowed
+    ARG_REPEAT = "arg_repeat"  # argument repetition is not allowed
+    ARG_INVALID = "arg_invalid"  # argument is invalid
+    INCOMPAT = "incompat"  # option 'a' can not be specified with option 'b'
+    REQUIRED = "required"  # option 'a' requires option 'b'
+    REQUIRED_ANY = "required_any"  # option 'a' requires option 'b', 'c' or more
+    XOR = "xor"  # either option 'a' or option 'b' must be specified
 
-        def __init__(self, err_type=GENERIC, options=[], msg=None,
-            valid_args=[]):
+    def __init__(self, err_type=GENERIC, options=[], msg=None, valid_args=[]):
+        self.err_type = err_type
+        self.options = options
+        self.msg = msg
+        self.valid_args = valid_args
 
-                self.err_type = err_type
-                self.options = options
-                self.msg = msg
-                self.valid_args = valid_args
+    def __str__(self):
+        # In case the user provided a custom message we just take it and
+        # append the according options.
+        if self.msg is not None:
+            if self.options:
+                self.msg += ": "
+                self.msg += " ".join(self.options)
+            return self.msg
 
-        def __str__(self):
+        if self.err_type == self.OPT_REPEAT:
+            assert len(self.options) == 1
+            return _("Option '{option}' may not be repeated.").format(
+                option=self.options[0]
+            )
+        elif self.err_type == self.ARG_REPEAT:
+            assert len(self.options) == 2
+            return _(
+                "Argument '{op1}' for option '{op2}' may " "not be repeated."
+            ).format(op1=self.options[0], op2=self.options[1])
+        elif self.err_type == self.ARG_INVALID:
+            assert len(self.options) == 2
+            s = _("Argument '{op1}' for option '{op2}' is " "invalid.").format(
+                op1=self.options[0], op2=self.options[1]
+            )
+            if self.valid_args:
+                s += _("\nSupported: {0}").format(
+                    ", ".join([str(va) for va in self.valid_args])
+                )
+            return s
+        elif self.err_type == self.INCOMPAT:
+            assert len(self.options) == 2
+            return _(
+                "The '{op1}' and '{op2}' options may " "not be combined."
+            ).format(op1=self.options[0], op2=self.options[1])
+        elif self.err_type == self.REQUIRED:
+            assert len(self.options) == 2
+            return _("'{op1}' may only be used with " "'{op2}'.").format(
+                op1=self.options[0], op2=self.options[1]
+            )
+        elif self.err_type == self.REQUIRED_ANY:
+            assert len(self.options) > 2
+            return _(
+                "'{op1}' may only be used with " "'{op2}' or {op3}."
+            ).format(
+                op1=self.options[0],
+                op2=", ".join(self.options[1:-1]),
+                op3=self.options[-1],
+            )
+        elif self.err_type == self.XOR:
+            assert len(self.options) == 2
+            return _("Either '{op1}' or '{op2}' must be " "specified").format(
+                op1=self.options[0], op2=self.options[1]
+            )
+        else:
+            return _("invalid option(s): ") + " ".join(self.options)
 
-                # In case the user provided a custom message we just take it and
-                # append the according options.
-                if self.msg is not None:
-                        if self.options:
-                                self.msg += ": "
-                                self.msg += " ".join(self.options)
-                        return self.msg
-
-                if self.err_type == self.OPT_REPEAT:
-                        assert len(self.options) == 1
-                        return _("Option '{option}' may not be repeated.").format(
-                            option=self.options[0])
-                elif self.err_type == self.ARG_REPEAT:
-                        assert len(self.options) == 2
-                        return _("Argument '{op1}' for option '{op2}' may "
-                            "not be repeated.").format(op1=self.options[0],
-                            op2=self.options[1])
-                elif self.err_type == self.ARG_INVALID:
-                        assert len(self.options) == 2
-                        s = _("Argument '{op1}' for option '{op2}' is "
-                            "invalid.").format(op1=self.options[0],
-                            op2=self.options[1])
-                        if self.valid_args:
-                                s += _("\nSupported: {0}").format(", ".join(
-                                    [str(va) for va in self.valid_args]))
-                        return s
-                elif self.err_type == self.INCOMPAT:
-                        assert len(self.options) == 2
-                        return _("The '{op1}' and '{op2}' options may "
-                            "not be combined.").format(op1=self.options[0],
-                            op2=self.options[1])
-                elif self.err_type == self.REQUIRED:
-                        assert len(self.options) == 2
-                        return _("'{op1}' may only be used with "
-                            "'{op2}'.").format(op1=self.options[0],
-                            op2=self.options[1])
-                elif self.err_type == self.REQUIRED_ANY:
-                        assert len(self.options) > 2
-                        return _("'{op1}' may only be used with "
-                            "'{op2}' or {op3}.").format(op1=self.options[0],
-                            op2=", ".join(self.options[1:-1]),
-                            op3=self.options[-1])
-                elif self.err_type == self.XOR:
-                        assert len(self.options) == 2
-                        return _("Either '{op1}' or '{op2}' must be "
-                            "specified").format(op1=self.options[0],
-                            op2=self.options[1])
-                else:
-                        return _("invalid option(s): ") + " ".join(self.options)
 
 class InvalidOptionErrors(ApiException):
+    def __init__(self, errors):
+        self.errors = []
 
-        def __init__(self, errors):
+        assert (
+            isinstance(errors, list)
+            or isinstance(errors, tuple)
+            or isinstance(errors, set)
+            or isinstance(errors, InvalidOptionError)
+        )
 
-                self.errors = []
+        if isinstance(errors, InvalidOptionError):
+            self.errors.append(errors)
+        else:
+            self.errors = errors
 
-                assert (isinstance(errors, list) or isinstance(errors, tuple) or
-                    isinstance(errors, set) or
-                    isinstance(errors, InvalidOptionError))
+    def __str__(self):
+        msgs = []
+        for e in self.errors:
+            msgs.append(str(e))
+        return "\n".join(msgs)
 
-                if isinstance(errors, InvalidOptionError):
-                        self.errors.append(errors)
-                else:
-                        self.errors = errors
-
-        def __str__(self):
-                msgs = []
-                for e in self.errors:
-                        msgs.append(str(e))
-                return "\n".join(msgs)
 
 class UnexpectedLinkError(ApiException):
-        """Used to indicate that an image state file has been replaced
-        with a symlink."""
+    """Used to indicate that an image state file has been replaced
+    with a symlink."""
 
-        def __init__(self, path, filename, errno):
-                self.path = path
-                self.filename = filename
-                self.errno = errno
+    def __init__(self, path, filename, errno):
+        self.path = path
+        self.filename = filename
+        self.errno = errno
 
-        def __str__(self):
-                return _("Cannot update file: '{file}' at path "
-                    "'{path}', contains a symlink. "
-                    "[Error '{errno:d}': '{error}']").format(
-                    error=os.strerror(self.errno),
-                    errno=self.errno,
-                    path=self.path,
-                    file=self.filename,
-               )
+    def __str__(self):
+        return _(
+            "Cannot update file: '{file}' at path "
+            "'{path}', contains a symlink. "
+            "[Error '{errno:d}': '{error}']"
+        ).format(
+            error=os.strerror(self.errno),
+            errno=self.errno,
+            path=self.path,
+            file=self.filename,
+        )
 
 
 class InvalidConfigFile(ApiException):
-        """Used to indicate that a configuration file is invalid
-        or broken"""
+    """Used to indicate that a configuration file is invalid
+    or broken"""
 
-        def __init__(self, path):
-                self.path = path
+    def __init__(self, path):
+        self.path = path
 
-        def __str__(self):
-                return _("Cannot parse configuration file "
-                    "{path}'.").format(path=self.path)
+    def __str__(self):
+        return _("Cannot parse configuration file " "{path}'.").format(
+            path=self.path
+        )
 
 
 class PkgUnicodeDecodeError(UnicodeDecodeError):
-        def __init__(self, obj, *args):
-                self.obj = obj
-                UnicodeDecodeError.__init__(self, *args)
+    def __init__(self, obj, *args):
+        self.obj = obj
+        UnicodeDecodeError.__init__(self, *args)
 
-        def __str__(self):
-                s = UnicodeDecodeError.__str__(self)
-                return "{0}. You passed in {1!r} {2}".format(s, self.obj,
-                    type(self.obj))
+    def __str__(self):
+        s = UnicodeDecodeError.__str__(self)
+        return "{0}. You passed in {1!r} {2}".format(
+            s, self.obj, type(self.obj)
+        )
+
 
 class UnsupportedVariantGlobbing(ApiException):
-        """Used to indicate that globbing for variant is not supported."""
+    """Used to indicate that globbing for variant is not supported."""
 
-        def __str__(self):
-                return _("Globbing is not supported for variants.")
+    def __str__(self):
+        return _("Globbing is not supported for variants.")
+
 
 class UnsupportedFacetChange(ApiException):
-        """Used to indicate an unsupported facet change."""
+    """Used to indicate an unsupported facet change."""
 
-        def __init__(self, facet, value=None):
-            self.facet = facet
-            self.value = value
+    def __init__(self, facet, value=None):
+        self.facet = facet
+        self.value = value
 
-        def __str__(self):
-                return _("Changing '{facet}' to '{value}' is not supported.".
-                         format(facet=self.facet, value=self.value))
+    def __str__(self):
+        return _(
+            "Changing '{facet}' to '{value}' is not supported.".format(
+                facet=self.facet, value=self.value
+            )
+        )
+
 
 class InvalidMediatorTarget(ApiException):
-        """ Used to indicate if the target of a mediated link is missing,
-            which could lead to a broken system on a reboot."""
+    """Used to indicate if the target of a mediated link is missing,
+    which could lead to a broken system on a reboot."""
 
-        def __init__(self, medmsg):
-            self.medmsg = medmsg
+    def __init__(self, medmsg):
+        self.medmsg = medmsg
 
-        def __str__(self):
-            return self.medmsg
+    def __str__(self):
+        return self.medmsg
+
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/bootenv.py
+++ b/src/modules/client/bootenv.py
@@ -29,6 +29,7 @@ import shutil
 import tempfile
 
 from pkg.client import global_settings
+
 logger = global_settings.logger
 
 import pkg.client.api_errors as api_errors
@@ -39,833 +40,875 @@ import pkg.pkgsubprocess as subprocess
 # Since pkg(1) may be installed without libbe installed
 # check for libbe and import it if it exists.
 try:
-        import libbe_py as be
+    import libbe_py as be
 except ImportError:
-        # All recovery actions are disabled when libbe can't be
-        # imported.
-        pass
+    # All recovery actions are disabled when libbe can't be
+    # imported.
+    pass
+
 
 class BootEnv(object):
 
-        """A BootEnv object is an object containing the logic for managing the
-        recovery of image-modifying operations such as install, uninstall, and
-        update.
+    """A BootEnv object is an object containing the logic for managing the
+    recovery of image-modifying operations such as install, uninstall, and
+    update.
 
-        Recovery is only enabled for ZFS filesystems. Any operation attempted on
-        UFS will not be handled by BootEnv.
+    Recovery is only enabled for ZFS filesystems. Any operation attempted on
+    UFS will not be handled by BootEnv.
 
-        This class makes use of usr/lib/python*/vendor-packages/libbe.py as the
-        python wrapper for interfacing with libbe.  Both libraries are delivered
-        by the install/beadm package.  This package is not required for pkg(1)
-        to operate successfully.  It is soft required, meaning if it exists the
-        bootenv class will attempt to provide recovery support."""
+    This class makes use of usr/lib/python*/vendor-packages/libbe.py as the
+    python wrapper for interfacing with libbe.  Both libraries are delivered
+    by the install/beadm package.  This package is not required for pkg(1)
+    to operate successfully.  It is soft required, meaning if it exists the
+    bootenv class will attempt to provide recovery support."""
 
-        def __init__(self, img, progress_tracker=None):
-                self.be_name = None
-                self.dataset = None
-                self.be_name_clone = None
-                self.be_name_clone_uuid = None
-                self.clone_dir = None
-                self.img = img
-                self.is_live_BE = False
-                self.is_valid = False
-                self.snapshot_name = None
-                self.progress_tracker = progress_tracker
+    def __init__(self, img, progress_tracker=None):
+        self.be_name = None
+        self.dataset = None
+        self.be_name_clone = None
+        self.be_name_clone_uuid = None
+        self.clone_dir = None
+        self.img = img
+        self.is_live_BE = False
+        self.is_valid = False
+        self.snapshot_name = None
+        self.progress_tracker = progress_tracker
 
-                # record current location of image root so we can remember
-                # original source BE if we clone existing image
-                self.root = self.img.get_root()
-                rc = 0
+        # record current location of image root so we can remember
+        # original source BE if we clone existing image
+        self.root = self.img.get_root()
+        rc = 0
 
-                assert self.root != None
+        assert self.root != None
 
-                # Need to find the name of the BE we're operating on in order
-                # to create a snapshot and/or a clone of the BE.
-                self.beList = self.get_be_list(raise_error=True)
+        # Need to find the name of the BE we're operating on in order
+        # to create a snapshot and/or a clone of the BE.
+        self.beList = self.get_be_list(raise_error=True)
 
-                for i, beVals in enumerate(self.beList):
-                        # pkg(1) expects a directory as the target of an
-                        # operation. BootEnv needs to determine if this target
-                        # directory maps to a BE. If a bogus directory is
-                        # provided to pkg(1) via -R, then pkg(1) just updates
-                        # '/' which also causes BootEnv to manage '/' as well.
-                        # This should be fixed before this class is ever
-                        # instantiated.
+        for i, beVals in enumerate(self.beList):
+            # pkg(1) expects a directory as the target of an
+            # operation. BootEnv needs to determine if this target
+            # directory maps to a BE. If a bogus directory is
+            # provided to pkg(1) via -R, then pkg(1) just updates
+            # '/' which also causes BootEnv to manage '/' as well.
+            # This should be fixed before this class is ever
+            # instantiated.
 
-                        be_name = beVals.get("orig_be_name")
+            be_name = beVals.get("orig_be_name")
 
-                        # If we're not looking at a boot env entry or an
-                        # entry that is not mounted then continue.
-                        if not be_name or not beVals.get("mounted"):
-                                continue
+            # If we're not looking at a boot env entry or an
+            # entry that is not mounted then continue.
+            if not be_name or not beVals.get("mounted"):
+                continue
 
-                        # Check if we're operating on the live BE.
-                        # If so it must also be active. If we are not
-                        # operating on the live BE, then verify
-                        # that the mountpoint of the BE matches
-                        # the -R argument passed in by the user.
-                        if self.root == '/':
-                                if not beVals.get("active"):
-                                        continue
-                                else:
-                                        self.is_live_BE = True
-                        else:
-                                if beVals.get("mountpoint") != self.root:
-                                        continue
+            # Check if we're operating on the live BE.
+            # If so it must also be active. If we are not
+            # operating on the live BE, then verify
+            # that the mountpoint of the BE matches
+            # the -R argument passed in by the user.
+            if self.root == "/":
+                if not beVals.get("active"):
+                    continue
+                else:
+                    self.is_live_BE = True
+            else:
+                if beVals.get("mountpoint") != self.root:
+                    continue
 
-                        # Set the needed BE components so snapshots
-                        # and clones can be managed.
-                        self.be_name = be_name
+            # Set the needed BE components so snapshots
+            # and clones can be managed.
+            self.be_name = be_name
 
-                        self.dataset = beVals.get("dataset")
+            self.dataset = beVals.get("dataset")
 
-                        # Let libbe provide the snapshot name
-                        err, snapshot_name = be.beCreateSnapshot(self.be_name)
-                        self.clone_dir = tempfile.mkdtemp()
+            # Let libbe provide the snapshot name
+            err, snapshot_name = be.beCreateSnapshot(self.be_name)
+            self.clone_dir = tempfile.mkdtemp()
 
-                        # Check first field for failure.
-                        # 2nd field is the returned snapshot name
-                        if err == 0:
-                                self.snapshot_name = snapshot_name
-                                # we require BootEnv to be initialised within
-                                # the context of a history operation, i.e.
-                                # after img.history.operation_name has been set.
-                                img.history.operation_snapshot = snapshot_name
-                        else:
-                                logger.error(_("pkg: unable to create an auto "
-                                    "snapshot. pkg recovery is disabled."))
-                                raise RuntimeError("recoveryDisabled")
-                        self.is_valid = True
+            # Check first field for failure.
+            # 2nd field is the returned snapshot name
+            if err == 0:
+                self.snapshot_name = snapshot_name
+                # we require BootEnv to be initialised within
+                # the context of a history operation, i.e.
+                # after img.history.operation_name has been set.
+                img.history.operation_snapshot = snapshot_name
+            else:
+                logger.error(
+                    _(
+                        "pkg: unable to create an auto "
+                        "snapshot. pkg recovery is disabled."
+                    )
+                )
+                raise RuntimeError("recoveryDisabled")
+            self.is_valid = True
+            break
+
+        else:
+            # We will get here if we don't find find any BE's. e.g
+            # if were are on UFS.
+            raise RuntimeError("recoveryDisabled")
+
+    def get_new_be_name(self, new_bename=None, suffix=None):
+        """Create a new boot environment name."""
+
+        if new_bename == None:
+            new_bename = self.be_name
+        if suffix:
+            new_bename += suffix
+
+        base, sep, rev = new_bename.rpartition("-")
+        if sep and rev.isdigit():
+            maxrev = int(rev)
+        else:
+            # new_bename does not include a numerical suffix
+            # so start with the bare name
+            base = new_bename
+            maxrev = 0
+
+        # List all BEs, cycle through the names and find the
+        # one with the same basename as new_bename which has the
+        # highest revision. This revision will be the starting
+        # point for building the new BE name so that gaps in the
+        # numbering are not filled.
+
+        for d in self.beList:
+            oben = d.get("orig_be_name", None)
+            if not oben:
+                continue
+            nbase, sep, nrev = oben.rpartition("-")
+            if not sep or nbase != base or not nrev.isdigit():
+                continue
+            maxrev = max(int(nrev), maxrev)
+
+        good = False
+        num = maxrev
+        while not good:
+            if num > 0:
+                new_bename = "-".join((base, str(num)))
+            else:
+                new_bename = base
+            for d in self.beList:
+                oben = d.get("orig_be_name", None)
+                if not oben:
+                    continue
+                if oben == new_bename:
+                    # Already exists
+                    break
+            else:
+                good = True
+
+            num += 1
+
+        return new_bename
+
+    def __store_image_state(self):
+        """Internal function used to preserve current image information
+        and history state to be restored later with __reset_image_state
+        if needed."""
+
+        # Preserve the current history information and state so that if
+        # boot environment operations fail, they can be written to the
+        # original image root, etc.
+        self.img.history.create_snapshot()
+
+    def __reset_image_state(self, failure=False):
+        """Internal function intended to be used to reset the image
+        state, if needed, after the failure or success of boot
+        environment operations."""
+
+        if not self.img:
+            # Nothing to restore.
+            return
+
+        if self.root != self.img.root:
+            if failure:
+                # Since the image root changed and the operation
+                # was not successful, restore the original
+                # history and state information so that it can
+                # be recorded in the original image root.  This
+                # needs to be done before the image root is
+                # reset since it might fail.
+                self.img.history.restore_snapshot()
+
+            self.img.history.discard_snapshot()
+
+            # After the completion of an operation that has changed
+            # the image root, it needs to be reset back to its
+            # original value so that the client will read and write
+            # information using the correct location (this is
+            # especially important for bootenv operations).
+            self.img.find_root(self.root)
+        else:
+            self.img.history.discard_snapshot()
+
+    def exists(self):
+        """Return true if this object represents a valid BE."""
+
+        return self.is_valid
+
+    @staticmethod
+    def libbe_exists():
+        return True
+
+    @staticmethod
+    def check_verify():
+        return hasattr(be, "beVerifyBEName")
+
+    @staticmethod
+    def split_be_entry(bee):
+        name = bee.get("orig_be_name")
+        return (
+            name,
+            bee.get("active"),
+            bee.get("active_boot"),
+            bee.get("space_used"),
+            bee.get("date"),
+        )
+
+    @staticmethod
+    def copy_be(src_be_name, dst_be_name):
+        ret, be_name_clone, not_used = be.beCopy(dst_be_name, src_be_name)
+        if ret != 0:
+            raise api_errors.UnableToCopyBE()
+
+    @staticmethod
+    def rename_be(orig_name, new_name):
+        return be.beRename(orig_name, new_name)
+
+    @staticmethod
+    def destroy_be(be_name):
+        return be.beDestroy(be_name, 1, True)
+
+    @staticmethod
+    def cleanup_be(be_name):
+        be_list = BootEnv.get_be_list()
+        for elem in be_list:
+            if "orig_be_name" in elem and be_name == elem["orig_be_name"]:
+                # Force unmount the be and destroy it.
+                # Ignore errors.
+                try:
+                    if elem.get("mounted"):
+                        BootEnv.unmount_be(be_name, force=True)
+                        shutil.rmtree(
+                            elem.get("mountpoint"), ignore_errors=True
+                        )
+                    BootEnv.destroy_be(be_name)
+                except Exception as e:
+                    pass
+                break
+
+    @staticmethod
+    def mount_be(be_name, mntpt, include_bpool=False):
+        return be.beMount(be_name, mntpt)
+
+    @staticmethod
+    def unmount_be(be_name, force=False):
+        return be.beUnmount(be_name, force=force)
+
+    @staticmethod
+    def set_default_be(be_name):
+        return be.beActivate(be_name)
+
+    @staticmethod
+    def check_be_name(be_name):
+        try:
+            if be_name is None:
+                return
+
+            if be.beVerifyBEName(be_name) != 0:
+                raise api_errors.InvalidBENameException(be_name)
+
+            beList = BootEnv.get_be_list()
+
+            # If there is already a BE with the same name as
+            # be_name, then raise an exception.
+            if be_name in (be.get("orig_be_name") for be in beList):
+                raise api_errors.DuplicateBEName(be_name)
+        except AttributeError:
+            raise api_errors.BENamingNotSupported(be_name)
+
+    @staticmethod
+    def get_be_list(raise_error=False):
+        # This check enables the test suite to run much more quickly.
+        # It is necessary because pkg5unittest (eventually) imports this
+        # module before the environment is sanitized.
+        if "PKG_NO_LIVE_ROOT" in os.environ:
+            return BootEnvNull.get_be_list()
+
+        rc, beList = be.beList(nosnaps=True)
+        if not beList or rc != 0:
+            if raise_error:
+                # Happens e.g. in zones (for now) or live CD
+                # environment.
+                raise RuntimeError("nobootenvironments")
+            beList = []
+
+        return beList
+
+    @staticmethod
+    def get_be_names():
+        """Return a list of BE names."""
+        return [
+            be["orig_be_name"]
+            for be in BootEnv.get_be_list()
+            if "orig_be_name" in be
+        ]
+
+    @staticmethod
+    def get_be_name(path):
+        """Looks for the name of the boot environment corresponding to
+        an image root, returning name and uuid"""
+        beList = BootEnv.get_be_list()
+
+        for be in beList:
+            be_name = be.get("orig_be_name")
+            be_uuid = be.get("uuid_str")
+
+            if not be_name or not be.get("mounted"):
+                continue
+
+            # Check if we're operating on the live BE.
+            # If so it must also be active. If we are not
+            # operating on the live BE, then verify
+            # that the mountpoint of the BE matches
+            # the path argument passed in by the user.
+            if path == "/":
+                if be.get("active"):
+                    return be_name, be_uuid
+            else:
+                if be.get("mountpoint") == path:
+                    return be_name, be_uuid
+        return None, None
+
+    @staticmethod
+    def get_uuid_be_dic():
+        """Return a dictionary of all boot environment names on the
+        system, keyed by uuid"""
+        beList = BootEnv.get_be_list()
+        uuid_bes = {}
+        for be in beList:
+            uuid_bes[be.get("uuid_str")] = be.get("orig_be_name")
+        return uuid_bes
+
+    @staticmethod
+    def get_activated_be_name(bootnext=False):
+        """Gets the name of the currently activated boot environment.
+        If 'bootnext' is true, then also consider temporary (bootnext)
+        activations"""
+        try:
+            beList = BootEnv.get_be_list()
+            name = None
+
+            for be in beList:
+                # don't look at active but unbootable BEs.
+                # (happens in zones when we have ZBEs
+                # associated with other global zone BEs.)
+                if be.get("active_unbootable", False):
+                    continue
+                if not be.get("global_active", True):
+                    continue
+                if bootnext and be.get("active_nextboot", False):
+                    return be.get("orig_be_name")
+                if be.get("active_boot"):
+                    name = be.get("orig_be_name")
+                    if not bootnext:
                         break
+            return name
+        except AttributeError:
+            raise api_errors.BENamingNotSupported(be_name)
 
+    @staticmethod
+    def get_active_be_name():
+        try:
+            beList = BootEnv.get_be_list()
+
+            for be in beList:
+                if be.get("active"):
+                    return be.get("orig_be_name")
+        except AttributeError:
+            raise api_errors.BENamingNotSupported(be_name)
+
+    def create_backup_be(self, be_name=None):
+        """Create a backup BE if the BE being modified is the live one.
+
+        'be_name' is an optional string indicating the name to use
+        for the new backup BE."""
+
+        self.check_be_name(be_name)
+
+        if self.is_live_BE:
+            # Create a clone of the live BE, but do not mount or
+            # activate it.  Do nothing with the returned snapshot
+            # name that is taken of the clone during beCopy.
+            ret, be_name_clone, not_used = be.beCopy()
+            if ret != 0:
+                raise api_errors.UnableToCopyBE()
+
+            if not be_name:
+                be_name = self.get_new_be_name(suffix="-backup-1")
+            ret = be.beRename(be_name_clone, be_name)
+            if ret != 0:
+                raise api_errors.UnableToRenameBE(be_name_clone, be_name)
+        elif be_name is not None:
+            raise api_errors.BENameGivenOnDeadBE(be_name)
+
+    def init_image_recovery(self, img, be_name=None):
+        """Initialize for an update.
+        If a be_name is given, validate it.
+        If we're operating on a live BE then clone the
+        live BE and operate on the clone.
+        If we're operating on a non-live BE we use
+        the already created snapshot"""
+
+        self.img = img
+
+        if self.is_live_BE:
+            # Create a clone of the live BE and mount it.
+            self.destroy_snapshot()
+
+            self.check_be_name(be_name)
+
+            # Do nothing with the returned snapshot name
+            # that is taken of the clone during beCopy.
+            ret, self.be_name_clone, not_used = be.beCopy()
+            if ret != 0:
+                raise api_errors.UnableToCopyBE()
+            if be_name:
+                ret = be.beRename(self.be_name_clone, be_name)
+                if ret == 0:
+                    self.be_name_clone = be_name
                 else:
-                        # We will get here if we don't find find any BE's. e.g
-                        # if were are on UFS.
-                        raise RuntimeError("recoveryDisabled")
+                    raise api_errors.UnableToRenameBE(
+                        self.be_name_clone, be_name
+                    )
+            if be.beMount(self.be_name_clone, self.clone_dir) != 0:
+                raise api_errors.UnableToMountBE(
+                    self.be_name_clone, self.clone_dir
+                )
 
-        def get_new_be_name(self, new_bename=None, suffix=None):
-                """Create a new boot environment name."""
+            # record the UUID of this cloned boot environment
+            not_used, self.be_name_clone_uuid = BootEnv.get_be_name(
+                self.clone_dir
+            )
 
-                if new_bename == None:
-                        new_bename = self.be_name
-                if suffix:
-                        new_bename += suffix
+            # Set the image to our new mounted BE.
+            img.find_root(self.clone_dir, exact_match=True)
+        elif be_name is not None:
+            raise api_errors.BENameGivenOnDeadBE(be_name)
 
-                base, sep, rev = new_bename.rpartition("-")
-                if sep and rev.isdigit():
-                        maxrev = int(rev)
+    def update_boot_archive(self):
+        """Rebuild the boot archive in the current image.
+        Just report errors; failure of pkg command is not needed,
+        and bootadm problems should be rare."""
+        cmd = ["/sbin/bootadm", "update-archive", "-R", self.img.get_root()]
+
+        try:
+            ret = subprocess.call(
+                cmd, stdout=open(os.devnull), stderr=subprocess.STDOUT
+            )
+        except OSError as e:
+            logger.error(
+                _(
+                    "pkg: A system error {e} was " "caught executing {cmd}"
+                ).format(e=e, cmd=" ".join(cmd))
+            )
+            return
+
+        if ret:
+            logger.error(
+                _(
+                    "pkg: '{cmd}' failed. \nwith " "a return code of {ret:d}."
+                ).format(cmd=" ".join(cmd), ret=ret)
+            )
+
+    def activate_image(self, set_active=True):
+        """Activate a clone of the BE being operated on.
+                If were operating on a non-live BE then
+                destroy the snapshot.
+
+        'set_active' is an optional argument indicating whether the new
+        BE (if created) should be set as the active one on next boot.
+        If 'set_active' is set to the string 'bootnext' then the
+        a temporary one-time activation will be performed.
+        """
+
+        def activate_live_be():
+            if set_active:
+                if set_active == "bootnext":
+                    ret = be.beActivate(self.be_name_clone, temporary=1)
                 else:
-                        # new_bename does not include a numerical suffix
-                        # so start with the bare name
-                        base = new_bename
-                        maxrev = 0
-
-                # List all BEs, cycle through the names and find the
-                # one with the same basename as new_bename which has the
-                # highest revision. This revision will be the starting
-                # point for building the new BE name so that gaps in the
-                # numbering are not filled.
-
-                for d in self.beList:
-                        oben = d.get("orig_be_name", None)
-                        if not oben:
-                                continue
-                        nbase, sep, nrev = oben.rpartition("-")
-                        if (not sep or nbase != base or
-                            not nrev.isdigit()):
-                                continue
-                        maxrev = max(int(nrev), maxrev)
-
-                good = False
-                num = maxrev
-                while not good:
-                        if num > 0:
-                                new_bename = "-".join((base, str(num)))
-                        else:
-                                new_bename = base
-                        for d in self.beList:
-                                oben = d.get("orig_be_name", None)
-                                if not oben:
-                                        continue
-                                if oben == new_bename:
-                                        # Already exists
-                                        break
-                        else:
-                                good = True
-
-                        num += 1
-
-                return new_bename
-
-        def __store_image_state(self):
-                """Internal function used to preserve current image information
-                and history state to be restored later with __reset_image_state
-                if needed."""
-
-                # Preserve the current history information and state so that if
-                # boot environment operations fail, they can be written to the
-                # original image root, etc.
-                self.img.history.create_snapshot()
-
-        def __reset_image_state(self, failure=False):
-                """Internal function intended to be used to reset the image
-                state, if needed, after the failure or success of boot
-                environment operations."""
-
-                if not self.img:
-                        # Nothing to restore.
-                        return
-
-                if self.root != self.img.root:
-                        if failure:
-                                # Since the image root changed and the operation
-                                # was not successful, restore the original
-                                # history and state information so that it can
-                                # be recorded in the original image root.  This
-                                # needs to be done before the image root is
-                                # reset since it might fail.
-                                self.img.history.restore_snapshot()
-
-                        self.img.history.discard_snapshot()
-
-                        # After the completion of an operation that has changed
-                        # the image root, it needs to be reset back to its
-                        # original value so that the client will read and write
-                        # information using the correct location (this is
-                        # especially important for bootenv operations).
-                        self.img.find_root(self.root)
-                else:
-                        self.img.history.discard_snapshot()
-
-        def exists(self):
-
-                """Return true if this object represents a valid BE."""
-
-                return self.is_valid
-
-        @staticmethod
-        def libbe_exists():
-                return True
-
-        @staticmethod
-        def check_verify():
-                return hasattr(be, "beVerifyBEName")
-
-        @staticmethod
-        def split_be_entry(bee):
-                name = bee.get("orig_be_name")
-                return (name, bee.get("active"), bee.get("active_boot"),
-                    bee.get("space_used"), bee.get("date"))
-
-        @staticmethod
-        def copy_be(src_be_name, dst_be_name):
-                ret, be_name_clone, not_used = be.beCopy(
-                    dst_be_name, src_be_name)
+                    ret = be.beActivate(self.be_name_clone)
                 if ret != 0:
-                        raise api_errors.UnableToCopyBE()
+                    logger.error(
+                        _("pkg: unable to activate " "{0}").format(
+                            self.be_name_clone
+                        )
+                    )
+                    return
 
-        @staticmethod
-        def rename_be(orig_name, new_name):
-                return be.beRename(orig_name, new_name)
+            # Consider the last operation a success, and log it as
+            # ending here so that it will be recorded in the new
+            # image's history.
+            self.img.history.operation_new_be = self.be_name_clone
+            self.img.history.operation_new_be_uuid = self.be_name_clone_uuid
+            self.img.history.log_operation_end(
+                release_notes=self.img.imageplan.pd.release_notes_name
+            )
 
-        @staticmethod
-        def destroy_be(be_name):
-                return be.beDestroy(be_name, 1, True)
+            if be.beUnmount(self.be_name_clone) != 0:
+                logger.error(
+                    _(
+                        "unable to unmount BE " "{be_name} mounted at {be_path}"
+                    ).format(be_name=self.be_name_clone, be_path=self.clone_dir)
+                )
+                return
 
-        @staticmethod
-        def cleanup_be(be_name):
-                be_list = BootEnv.get_be_list()
-                for elem in be_list:
-                        if "orig_be_name" in elem and be_name == \
-                            elem["orig_be_name"]:
-                                # Force unmount the be and destroy it.
-                                # Ignore errors.
-                                try:
-                                        if elem.get("mounted"):
-                                                BootEnv.unmount_be(
-                                                    be_name, force=True)
-                                                shutil.rmtree(elem.get(
-                                                    "mountpoint"),
-                                                    ignore_errors=True)
-                                        BootEnv.destroy_be(
-                                            be_name)
-                                except Exception as e:
-                                            pass
-                                break
+            os.rmdir(self.clone_dir)
 
-        @staticmethod
-        def mount_be(be_name, mntpt, include_bpool=False):
-                return be.beMount(be_name, mntpt)
-
-        @staticmethod
-        def unmount_be(be_name, force=False):
-                return be.beUnmount(be_name, force=force)
-
-        @staticmethod
-        def set_default_be(be_name):
-                return be.beActivate(be_name)
-
-        @staticmethod
-        def check_be_name(be_name):
-                try:
-                        if be_name is None:
-                                return
-
-                        if be.beVerifyBEName(be_name) != 0:
-                                raise api_errors.InvalidBENameException(be_name)
-
-                        beList = BootEnv.get_be_list()
-
-                        # If there is already a BE with the same name as
-                        # be_name, then raise an exception.
-                        if be_name in (be.get("orig_be_name") for be in beList):
-                                raise api_errors.DuplicateBEName(be_name)
-                except AttributeError:
-                        raise api_errors.BENamingNotSupported(be_name)
-
-        @staticmethod
-        def get_be_list(raise_error=False):
-                # This check enables the test suite to run much more quickly.
-                # It is necessary because pkg5unittest (eventually) imports this
-                # module before the environment is sanitized.
-                if "PKG_NO_LIVE_ROOT" in os.environ:
-                        return BootEnvNull.get_be_list()
-
-                rc, beList = be.beList(nosnaps=True)
-                if not beList or rc != 0:
-                        if raise_error:
-                                # Happens e.g. in zones (for now) or live CD
-                                # environment.
-                                raise RuntimeError("nobootenvironments")
-                        beList = []
-
-                return beList
-
-        @staticmethod
-        def get_be_names():
-                """Return a list of BE names."""
-                return [
-                    be['orig_be_name'] for be in BootEnv.get_be_list()
-                        if 'orig_be_name' in be
-                ]
-
-        @staticmethod
-        def get_be_name(path):
-                """Looks for the name of the boot environment corresponding to
-                an image root, returning name and uuid """
-                beList = BootEnv.get_be_list()
-
-                for be in beList:
-                        be_name = be.get("orig_be_name")
-                        be_uuid = be.get("uuid_str")
-
-                        if not be_name or not be.get("mounted"):
-                                continue
-
-                        # Check if we're operating on the live BE.
-                        # If so it must also be active. If we are not
-                        # operating on the live BE, then verify
-                        # that the mountpoint of the BE matches
-                        # the path argument passed in by the user.
-                        if path == '/':
-                                if be.get("active"):
-                                        return be_name, be_uuid
-                        else:
-                                if be.get("mountpoint") == path:
-                                        return be_name, be_uuid
-                return None, None
-
-        @staticmethod
-        def get_uuid_be_dic():
-                """Return a dictionary of all boot environment names on the
-                system, keyed by uuid"""
-                beList = BootEnv.get_be_list()
-                uuid_bes = {}
-                for be in beList:
-                        uuid_bes[be.get("uuid_str")] = be.get("orig_be_name")
-                return uuid_bes
-
-        @staticmethod
-        def get_activated_be_name(bootnext=False):
-                """Gets the name of the currently activated boot environment.
-                If 'bootnext' is true, then also consider temporary (bootnext)
-                activations """
-                try:
-                        beList = BootEnv.get_be_list()
-                        name = None
-
-                        for be in beList:
-                                # don't look at active but unbootable BEs.
-                                # (happens in zones when we have ZBEs
-                                # associated with other global zone BEs.)
-                                if be.get("active_unbootable", False):
-                                        continue
-                                if not be.get("global_active", True):
-                                        continue
-                                if (bootnext and
-                                    be.get("active_nextboot", False)):
-                                        return be.get("orig_be_name")
-                                if be.get("active_boot"):
-                                        name = be.get("orig_be_name")
-                                        if not bootnext:
-                                                break
-                        return name
-                except AttributeError:
-                        raise api_errors.BENamingNotSupported(be_name)
-
-        @staticmethod
-        def get_active_be_name():
-                try:
-                        beList = BootEnv.get_be_list()
-
-                        for be in beList:
-                                if be.get("active"):
-                                        return be.get("orig_be_name")
-                except AttributeError:
-                        raise api_errors.BENamingNotSupported(be_name)
-
-        def create_backup_be(self, be_name=None):
-                """Create a backup BE if the BE being modified is the live one.
-
-                'be_name' is an optional string indicating the name to use
-                for the new backup BE."""
-
-                self.check_be_name(be_name)
-
-                if self.is_live_BE:
-                        # Create a clone of the live BE, but do not mount or
-                        # activate it.  Do nothing with the returned snapshot
-                        # name that is taken of the clone during beCopy.
-                        ret, be_name_clone, not_used = be.beCopy()
-                        if ret != 0:
-                                raise api_errors.UnableToCopyBE()
-
-                        if not be_name:
-                                be_name = self.get_new_be_name(
-                                    suffix="-backup-1")
-                        ret = be.beRename(be_name_clone, be_name)
-                        if ret != 0:
-                                raise api_errors.UnableToRenameBE(
-                                    be_name_clone, be_name)
-                elif be_name is not None:
-                        raise api_errors.BENameGivenOnDeadBE(be_name)
-
-        def init_image_recovery(self, img, be_name=None):
-
-                """Initialize for an update.
-                        If a be_name is given, validate it.
-                        If we're operating on a live BE then clone the
-                        live BE and operate on the clone.
-                        If we're operating on a non-live BE we use
-                        the already created snapshot"""
-
-                self.img = img
-
-                if self.is_live_BE:
-                        # Create a clone of the live BE and mount it.
-                        self.destroy_snapshot()
-
-                        self.check_be_name(be_name)
-
-                        # Do nothing with the returned snapshot name
-                        # that is taken of the clone during beCopy.
-                        ret, self.be_name_clone, not_used = be.beCopy()
-                        if ret != 0:
-                                raise api_errors.UnableToCopyBE()
-                        if be_name:
-                                ret = be.beRename(self.be_name_clone, be_name)
-                                if ret == 0:
-                                        self.be_name_clone = be_name
-                                else:
-                                        raise api_errors.UnableToRenameBE(
-                                            self.be_name_clone, be_name)
-                        if be.beMount(self.be_name_clone, self.clone_dir) != 0:
-                                raise api_errors.UnableToMountBE(
-                                    self.be_name_clone, self.clone_dir)
-
-                        # record the UUID of this cloned boot environment
-                        not_used, self.be_name_clone_uuid = \
-                            BootEnv.get_be_name(self.clone_dir)
-
-                        # Set the image to our new mounted BE.
-                        img.find_root(self.clone_dir, exact_match=True)
-                elif be_name is not None:
-                        raise api_errors.BENameGivenOnDeadBE(be_name)
-
-        def update_boot_archive(self):
-                """Rebuild the boot archive in the current image.
-                Just report errors; failure of pkg command is not needed,
-                and bootadm problems should be rare."""
-                cmd = [
-                    "/sbin/bootadm", "update-archive", "-R",
-                    self.img.get_root()
-                    ]
-
-                try:
-                        ret = subprocess.call(cmd,
-                            stdout = open(os.devnull), stderr=subprocess.STDOUT)
-                except OSError as e:
-                        logger.error(_("pkg: A system error {e} was "
-                            "caught executing {cmd}").format(e=e,
-                            cmd=" ".join(cmd)))
-                        return
-
-                if ret:
-                        logger.error(_("pkg: '{cmd}' failed. \nwith "
-                            "a return code of {ret:d}.").format(
-                            cmd=" ".join(cmd), ret=ret))
-
-        def activate_image(self, set_active=True):
-                """Activate a clone of the BE being operated on.
-                        If were operating on a non-live BE then
-                        destroy the snapshot.
-
-                'set_active' is an optional argument indicating whether the new
-                BE (if created) should be set as the active one on next boot.
-                If 'set_active' is set to the string 'bootnext' then the
-                a temporary one-time activation will be performed.
-                """
-
-                def activate_live_be():
-                        if set_active:
-                                if set_active == "bootnext":
-                                        ret = be.beActivate(self.be_name_clone,
-                                            temporary=1)
-                                else:
-                                        ret = be.beActivate(self.be_name_clone)
-                                if ret != 0:
-                                        logger.error(
-                                            _("pkg: unable to activate "
-                                            "{0}").format(self.be_name_clone))
-                                        return
-
-                        # Consider the last operation a success, and log it as
-                        # ending here so that it will be recorded in the new
-                        # image's history.
-                        self.img.history.operation_new_be = self.be_name_clone
-                        self.img.history.operation_new_be_uuid = self.be_name_clone_uuid
-                        self.img.history.log_operation_end(release_notes=
-			    self.img.imageplan.pd.release_notes_name)
-
-                        if be.beUnmount(self.be_name_clone) != 0:
-                                logger.error(_("unable to unmount BE "
-                                    "{be_name} mounted at {be_path}").format(
-                                    be_name=self.be_name_clone,
-                                    be_path=self.clone_dir))
-                                return
-
-                        os.rmdir(self.clone_dir)
-
-                        if set_active:
-                                logger.info(_("""
+            if set_active:
+                logger.info(
+                    _(
+                        """
 A clone of {be_name} exists and has been updated and activated.
 On the next boot the Boot Environment {be_name_clone} will be
 mounted on '/'.  Reboot when ready to switch to this updated BE.
 
 *** Reboot required ***
 New BE: {be_name_clone}
-""").format(**self.__dict__))
-                        else:
-                                logger.info(_("""
+"""
+                    ).format(**self.__dict__)
+                )
+            else:
+                logger.info(
+                    _(
+                        """
 A clone of {be_name} exists and has been updated.  To set the
 new BE as the active one on next boot, execute the following
 command as a privileged user and reboot when ready to switch to
 the updated BE:
 
 beadm activate {be_name_clone}
-""").format(**self.__dict__))
+"""
+                    ).format(**self.__dict__)
+                )
 
-                def activate_be():
-                        # Delete the snapshot that was taken before we
-                        # updated the image and the boot archive.
-                        logger.info(_("{0} has been updated "
-                            "successfully").format(self.be_name))
+        def activate_be():
+            # Delete the snapshot that was taken before we
+            # updated the image and the boot archive.
+            logger.info(
+                _("{0} has been updated " "successfully").format(self.be_name)
+            )
 
-                        os.rmdir(self.clone_dir)
-                        self.destroy_snapshot()
-                        self.img.history.operation_snapshot = None
+            os.rmdir(self.clone_dir)
+            self.destroy_snapshot()
+            self.img.history.operation_snapshot = None
 
-                self.__store_image_state()
+        self.__store_image_state()
 
-                # Ensure cache is flushed before activating and unmounting BE.
-                self.img.cleanup_cached_content(progtrack=self.progress_tracker)
+        # Ensure cache is flushed before activating and unmounting BE.
+        self.img.cleanup_cached_content(progtrack=self.progress_tracker)
 
+        relock = False
+        if self.img.locked:
+            # This is necessary since the lock will
+            # prevent the boot environment from being
+            # unmounted during activation.  Normally,
+            # locking for the image is handled
+            # automatically.
+            relock = True
+            self.img.unlock()
+
+        caught_exception = None
+
+        try:
+            if self.is_live_BE:
+                activate_live_be()
+            else:
+                activate_be()
+        except Exception as e:
+            caught_exception = e
+            if relock:
+                # Re-lock be image.
                 relock = False
-                if self.img.locked:
-                        # This is necessary since the lock will
-                        # prevent the boot environment from being
-                        # unmounted during activation.  Normally,
-                        # locking for the image is handled
-                        # automatically.
-                        relock = True
-                        self.img.unlock()
+                self.img.lock()
 
-                caught_exception = None
+        self.__reset_image_state(failure=caught_exception)
+        if relock:
+            # Activation was successful so the be image was
+            # unmounted and the parent image must be re-locked.
+            self.img.lock()
 
-                try:
-                        if self.is_live_BE:
-                                activate_live_be()
-                        else:
-                                activate_be()
-                except Exception as e:
-                        caught_exception = e
-                        if relock:
-                                # Re-lock be image.
-                                relock = False
-                                self.img.lock()
+        if caught_exception:
+            self.img.history.log_operation_error(error=e)
+            raise caught_exception
 
-                self.__reset_image_state(failure=caught_exception)
-                if relock:
-                        # Activation was successful so the be image was
-                        # unmounted and the parent image must be re-locked.
-                        self.img.lock()
+    def restore_image(self):
+        """Restore a failed update attempt."""
 
-                if caught_exception:
-                        self.img.history.log_operation_error(error=e)
-                        raise caught_exception
+        # flush() is necessary here so that the warnings get printed
+        # on a new line.
+        if self.progress_tracker:
+            self.progress_tracker.flush()
 
-        def restore_image(self):
-                """Restore a failed update attempt."""
+        self.__reset_image_state(failure=True)
 
-                # flush() is necessary here so that the warnings get printed
-                # on a new line.
-                if self.progress_tracker:
-                        self.progress_tracker.flush()
+        # Leave the clone around for debugging purposes if we're
+        # operating on the live BE.
+        if self.is_live_BE:
+            logger.error(
+                _(
+                    "The running system has not been "
+                    "modified. Modifications were only made to a clone "
+                    "({0}) of the running system. This clone is "
+                    "mounted at {1} should you wish to inspect "
+                    "it."
+                ).format(self.be_name_clone, self.clone_dir)
+            )
 
-                self.__reset_image_state(failure=True)
-
-                # Leave the clone around for debugging purposes if we're
-                # operating on the live BE.
-                if self.is_live_BE:
-                        logger.error(_("The running system has not been "
-                            "modified. Modifications were only made to a clone "
-                            "({0}) of the running system. This clone is "
-                            "mounted at {1} should you wish to inspect "
-                            "it.").format(
-                            self.be_name_clone, self.clone_dir))
-
-                else:
-                        # Rollback and destroy the snapshot.
-                        try:
-                                if be.beRollback(self.be_name,
-                                    self.snapshot_name) != 0:
-                                        logger.error(_("pkg: unable to "
-                                            "rollback BE {0} and restore "
-                                            "image").format(self.be_name))
-
-                                self.destroy_snapshot()
-                                os.rmdir(self.clone_dir)
-                        except Exception as e:
-                                self.img.history.log_operation_error(error=e)
-                                raise e
-
-                        logger.error(_("{bename} failed to be updated. No "
-                            "changes have been made to {bename}.").format(
-                            bename=self.be_name))
-
-        def destroy_snapshot(self):
-
-                """Destroy a snapshot of the BE being operated on.
-                        Note that this will destroy the last created
-                        snapshot and does not support destroying
-                        multiple snapshots. Create another instance of
-                        BootEnv to manage multiple snapshots."""
-
-                if be.beDestroySnapshot(self.be_name, self.snapshot_name) != 0:
-                        logger.error(_("pkg: unable to destroy snapshot "
-                            "{0}").format(self.snapshot_name))
-
-        def restore_install_uninstall(self):
-
-                """Restore a failed install or uninstall attempt.
-                        Clone the snapshot, mount the BE and
-                        notify user of its existence. Rollback
-                        if not operating on a live BE"""
-
-                # flush() is necessary here so that the warnings get printed
-                # on a new line.
-                if self.progress_tracker:
-                        self.progress_tracker.flush()
-
-                if self.is_live_BE:
-                        # Create a new BE based on the previously taken
-                        # snapshot.
-
-                        ret, self.be_name_clone, not_used = \
-                            be.beCopy(None, self.be_name, self.snapshot_name)
-                        if ret != 0:
-                                # If the above beCopy() failed we will try it
-                                # without expecting the BE clone name to be
-                                # returned by libbe. We do this in case an old
-                                # version of libbe is on a system with
-                                # a new version of pkg.
-                                self.be_name_clone = self.be_name + "_" + \
-                                    self.snapshot_name
-
-                                ret, not_used, not_used2 = \
-                                    be.beCopy(self.be_name_clone, \
-                                    self.be_name, self.snapshot_name)
-                                if ret != 0:
-                                        logger.error(_("pkg: unable to create "
-                                            "BE {0}").format(
-                                            self.be_name_clone))
-                                        return
-
-                        if be.beMount(self.be_name_clone, self.clone_dir) != 0:
-                                logger.error(_("pkg: unable to mount BE "
-                                    "{name} on {clone_dir}").format(
-                                    name=self.be_name_clone,
-                                    clone_dir=self.clone_dir))
-                                return
-
-                        logger.error(_("The Boot Environment {name} failed "
-                            "to be updated. A snapshot was taken before the "
-                            "failed attempt and is mounted here {clone_dir}. "
-                            "Use 'beadm unmount {clone_name}' and then "
-                            "'beadm activate {clone_name}' if you wish to "
-                            "boot to this BE.").format(name=self.be_name,
-                            clone_dir=self.clone_dir,
-                            clone_name=self.be_name_clone))
-                else:
-                        if be.beRollback(self.be_name, self.snapshot_name) != 0:
-                                logger.error("pkg: unable to rollback BE "
-                                    "{0}".format(self.be_name))
-
-                        self.destroy_snapshot()
-
-                        logger.error(_("The Boot Environment {bename} failed "
-                            "to be updated. A snapshot was taken before the "
-                            "failed attempt and has been restored so no "
-                            "changes have been made to {bename}.").format(
-                            bename=self.be_name))
-
-        def activate_install_uninstall(self):
-                """Activate an install/uninstall attempt. Which just means
-                        destroy the snapshot for the live and non-live case."""
+        else:
+            # Rollback and destroy the snapshot.
+            try:
+                if be.beRollback(self.be_name, self.snapshot_name) != 0:
+                    logger.error(
+                        _(
+                            "pkg: unable to "
+                            "rollback BE {0} and restore "
+                            "image"
+                        ).format(self.be_name)
+                    )
 
                 self.destroy_snapshot()
+                os.rmdir(self.clone_dir)
+            except Exception as e:
+                self.img.history.log_operation_error(error=e)
+                raise e
+
+            logger.error(
+                _(
+                    "{bename} failed to be updated. No "
+                    "changes have been made to {bename}."
+                ).format(bename=self.be_name)
+            )
+
+    def destroy_snapshot(self):
+        """Destroy a snapshot of the BE being operated on.
+        Note that this will destroy the last created
+        snapshot and does not support destroying
+        multiple snapshots. Create another instance of
+        BootEnv to manage multiple snapshots."""
+
+        if be.beDestroySnapshot(self.be_name, self.snapshot_name) != 0:
+            logger.error(
+                _("pkg: unable to destroy snapshot " "{0}").format(
+                    self.snapshot_name
+                )
+            )
+
+    def restore_install_uninstall(self):
+        """Restore a failed install or uninstall attempt.
+        Clone the snapshot, mount the BE and
+        notify user of its existence. Rollback
+        if not operating on a live BE"""
+
+        # flush() is necessary here so that the warnings get printed
+        # on a new line.
+        if self.progress_tracker:
+            self.progress_tracker.flush()
+
+        if self.is_live_BE:
+            # Create a new BE based on the previously taken
+            # snapshot.
+
+            ret, self.be_name_clone, not_used = be.beCopy(
+                None, self.be_name, self.snapshot_name
+            )
+            if ret != 0:
+                # If the above beCopy() failed we will try it
+                # without expecting the BE clone name to be
+                # returned by libbe. We do this in case an old
+                # version of libbe is on a system with
+                # a new version of pkg.
+                self.be_name_clone = self.be_name + "_" + self.snapshot_name
+
+                ret, not_used, not_used2 = be.beCopy(
+                    self.be_name_clone, self.be_name, self.snapshot_name
+                )
+                if ret != 0:
+                    logger.error(
+                        _("pkg: unable to create " "BE {0}").format(
+                            self.be_name_clone
+                        )
+                    )
+                    return
+
+            if be.beMount(self.be_name_clone, self.clone_dir) != 0:
+                logger.error(
+                    _(
+                        "pkg: unable to mount BE " "{name} on {clone_dir}"
+                    ).format(name=self.be_name_clone, clone_dir=self.clone_dir)
+                )
+                return
+
+            logger.error(
+                _(
+                    "The Boot Environment {name} failed "
+                    "to be updated. A snapshot was taken before the "
+                    "failed attempt and is mounted here {clone_dir}. "
+                    "Use 'beadm unmount {clone_name}' and then "
+                    "'beadm activate {clone_name}' if you wish to "
+                    "boot to this BE."
+                ).format(
+                    name=self.be_name,
+                    clone_dir=self.clone_dir,
+                    clone_name=self.be_name_clone,
+                )
+            )
+        else:
+            if be.beRollback(self.be_name, self.snapshot_name) != 0:
+                logger.error(
+                    "pkg: unable to rollback BE " "{0}".format(self.be_name)
+                )
+
+            self.destroy_snapshot()
+
+            logger.error(
+                _(
+                    "The Boot Environment {bename} failed "
+                    "to be updated. A snapshot was taken before the "
+                    "failed attempt and has been restored so no "
+                    "changes have been made to {bename}."
+                ).format(bename=self.be_name)
+            )
+
+    def activate_install_uninstall(self):
+        """Activate an install/uninstall attempt. Which just means
+        destroy the snapshot for the live and non-live case."""
+
+        self.destroy_snapshot()
 
 
 class BootEnvNull(object):
 
-        """BootEnvNull is a class that gets used when libbe doesn't exist."""
+    """BootEnvNull is a class that gets used when libbe doesn't exist."""
 
-        def __init__(self, img, progress_tracker=None):
-                pass
+    def __init__(self, img, progress_tracker=None):
+        pass
 
-        @staticmethod
-        def update_boot_archive():
-                pass
+    @staticmethod
+    def update_boot_archive():
+        pass
 
-        @staticmethod
-        def exists():
-                return False
+    @staticmethod
+    def exists():
+        return False
 
-        @staticmethod
-        def libbe_exists():
-                return False
+    @staticmethod
+    def libbe_exists():
+        return False
 
-        @staticmethod
-        def check_verify():
-                return False
+    @staticmethod
+    def check_verify():
+        return False
 
-        @staticmethod
-        def split_be_entry(bee):
-                return None
+    @staticmethod
+    def split_be_entry(bee):
+        return None
 
-        @staticmethod
-        def copy_be(src_be_name, dst_be_name):
-                pass
+    @staticmethod
+    def copy_be(src_be_name, dst_be_name):
+        pass
 
-        @staticmethod
-        def rename_be(orig_name, new_name):
-                pass
+    @staticmethod
+    def rename_be(orig_name, new_name):
+        pass
 
-        @staticmethod
-        def destroy_be(be_name):
-                pass
+    @staticmethod
+    def destroy_be(be_name):
+        pass
 
-        @staticmethod
-        def cleanup_be(be_name):
-                pass
+    @staticmethod
+    def cleanup_be(be_name):
+        pass
 
-        @staticmethod
-        def mount_be(be_name, mntpt, include_bpool=False):
-                return None
+    @staticmethod
+    def mount_be(be_name, mntpt, include_bpool=False):
+        return None
 
-        @staticmethod
-        def unmount_be(be_name, force=False):
-                return None
+    @staticmethod
+    def unmount_be(be_name, force=False):
+        return None
 
-        @staticmethod
-        def set_default_be(be_name):
-                pass
+    @staticmethod
+    def set_default_be(be_name):
+        pass
 
-        @staticmethod
-        def check_be_name(be_name):
-                if be_name:
-                        raise api_errors.BENamingNotSupported(be_name)
+    @staticmethod
+    def check_be_name(be_name):
+        if be_name:
+            raise api_errors.BENamingNotSupported(be_name)
 
-        @staticmethod
-        def get_be_list():
-                return []
+    @staticmethod
+    def get_be_list():
+        return []
 
-        @staticmethod
-        def get_be_names():
-                return []
+    @staticmethod
+    def get_be_names():
+        return []
 
-        @staticmethod
-        def get_be_name(path):
-                return None, None
+    @staticmethod
+    def get_be_name(path):
+        return None, None
 
-        @staticmethod
-        def get_uuid_be_dic():
-                return misc.EmptyDict
+    @staticmethod
+    def get_uuid_be_dic():
+        return misc.EmptyDict
 
-        @staticmethod
-        def get_activated_be_name(bootnext=False):
-                pass
+    @staticmethod
+    def get_activated_be_name(bootnext=False):
+        pass
 
-        @staticmethod
-        def get_active_be_name():
-                pass
+    @staticmethod
+    def get_active_be_name():
+        pass
 
-        @staticmethod
-        def get_new_be_name(new_bename=None, suffix=None):
-                pass
+    @staticmethod
+    def get_new_be_name(new_bename=None, suffix=None):
+        pass
 
-        @staticmethod
-        def create_backup_be(be_name=None):
-                if be_name is not None:
-                        raise api_errors.BENameGivenOnDeadBE(be_name)
+    @staticmethod
+    def create_backup_be(be_name=None):
+        if be_name is not None:
+            raise api_errors.BENameGivenOnDeadBE(be_name)
 
-        @staticmethod
-        def init_image_recovery(img, be_name=None):
-                if be_name is not None:
-                        raise api_errors.BENameGivenOnDeadBE(be_name)
+    @staticmethod
+    def init_image_recovery(img, be_name=None):
+        if be_name is not None:
+            raise api_errors.BENameGivenOnDeadBE(be_name)
 
-        @staticmethod
-        def activate_image():
-                pass
+    @staticmethod
+    def activate_image():
+        pass
 
-        @staticmethod
-        def restore_image():
-                pass
+    @staticmethod
+    def restore_image():
+        pass
 
-        @staticmethod
-        def destroy_snapshot():
-                pass
+    @staticmethod
+    def destroy_snapshot():
+        pass
 
-        @staticmethod
-        def restore_install_uninstall():
-                pass
+    @staticmethod
+    def restore_install_uninstall():
+        pass
 
-        @staticmethod
-        def activate_install_uninstall():
-                pass
+    @staticmethod
+    def activate_install_uninstall():
+        pass
+
 
 if "be" not in locals():
-        BootEnv = BootEnvNull
+    BootEnv = BootEnvNull
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/client_api.py
+++ b/src/modules/client/client_api.py
@@ -61,12 +61,22 @@ import pkg.portable as portable
 import pkg.version as version
 
 from pkg.client import global_settings
-from pkg.client.api import (IMG_TYPE_ENTIRE, IMG_TYPE_PARTIAL,
-    IMG_TYPE_USER, RESULT_CANCELED, RESULT_FAILED_BAD_REQUEST,
-    RESULT_FAILED_CONFIGURATION, RESULT_FAILED_CONSTRAINED,
-    RESULT_FAILED_LOCKED, RESULT_FAILED_STORAGE, RESULT_NOTHING_TO_DO,
-    RESULT_SUCCEEDED, RESULT_FAILED_TRANSPORT, RESULT_FAILED_UNKNOWN,
-    RESULT_FAILED_OUTOFMEMORY)
+from pkg.client.api import (
+    IMG_TYPE_ENTIRE,
+    IMG_TYPE_PARTIAL,
+    IMG_TYPE_USER,
+    RESULT_CANCELED,
+    RESULT_FAILED_BAD_REQUEST,
+    RESULT_FAILED_CONFIGURATION,
+    RESULT_FAILED_CONSTRAINED,
+    RESULT_FAILED_LOCKED,
+    RESULT_FAILED_STORAGE,
+    RESULT_NOTHING_TO_DO,
+    RESULT_SUCCEEDED,
+    RESULT_FAILED_TRANSPORT,
+    RESULT_FAILED_UNKNOWN,
+    RESULT_FAILED_OUTOFMEMORY,
+)
 from pkg.client.debugvalues import DebugValues
 from pkg.client.pkgdefs import *
 from pkg.misc import EmptyI, msg, emsg, PipeError
@@ -79,1096 +89,1282 @@ PROG_DELAY = 5.0
 
 
 def _strify(input):
-        """Convert unicode string into byte string in Python 2 and convert
-        bytes string into unicode string in Python 3. This will be used by json
-        loads function."""
+    """Convert unicode string into byte string in Python 2 and convert
+    bytes string into unicode string in Python 3. This will be used by json
+    loads function."""
 
-        if isinstance(input, dict):
-                return dict([(_strify(key), _strify(value)) for key, value in
-                    six.iteritems(input)])
-        elif isinstance(input, list):
-                return [_strify(element) for element in input]
-        elif isinstance(input, (six.string_types, bytes)):
-                return misc.force_str(input, "utf-8")
-        else:
-                return input
+    if isinstance(input, dict):
+        return dict(
+            [
+                (_strify(key), _strify(value))
+                for key, value in six.iteritems(input)
+            ]
+        )
+    elif isinstance(input, list):
+        return [_strify(element) for element in input]
+    elif isinstance(input, (six.string_types, bytes)):
+        return misc.force_str(input, "utf-8")
+    else:
+        return input
+
 
 def _get_pkg_input_schema(subcommand, opts_mapping=misc.EmptyDict):
-        """Get the input schema for pkg subcommand."""
+    """Get the input schema for pkg subcommand."""
 
-        # Return None if the subcommand is not defined.
-        if subcommand not in cmds:
-                return None
+    # Return None if the subcommand is not defined.
+    if subcommand not in cmds:
+        return None
 
-        props = {}
-        data_schema = __get_pkg_input_schema(subcommand,
-            opts_mapping=opts_mapping)
-        props.update(data_schema)
-        schema = __construct_json_schema("{0} input schema".format(subcommand),
-            properties=props)
-        return schema
+    props = {}
+    data_schema = __get_pkg_input_schema(subcommand, opts_mapping=opts_mapping)
+    props.update(data_schema)
+    schema = __construct_json_schema(
+        "{0} input schema".format(subcommand), properties=props
+    )
+    return schema
+
 
 def _get_pkg_output_schema(subcommand):
-        """Get the output schema for pkg subcommand."""
+    """Get the output schema for pkg subcommand."""
 
-        # Return None if the subcommand is not defined.
-        if subcommand not in cmds:
-                return None
+    # Return None if the subcommand is not defined.
+    if subcommand not in cmds:
+        return None
 
-        props = {"status": {"type": "number"},
-            "errors": {"type": "array",
-                "items": __default_error_json_schema()
-                }
-            }
-        required = ["status"]
-        data_schema = cmds[subcommand][1]()
-        if data_schema:
-                props["data"] = data_schema
-        schema = __construct_json_schema("{0} output schema".format(
-            subcommand), properties=props, required=required)
-        return schema
+    props = {
+        "status": {"type": "number"},
+        "errors": {"type": "array", "items": __default_error_json_schema()},
+    }
+    required = ["status"]
+    data_schema = cmds[subcommand][1]()
+    if data_schema:
+        props["data"] = data_schema
+    schema = __construct_json_schema(
+        "{0} output schema".format(subcommand),
+        properties=props,
+        required=required,
+    )
+    return schema
+
 
 def __get_pkg_input_schema(pkg_op, opts_mapping=misc.EmptyDict):
-        properties = {}
-        opts = options.pkg_op_opts[pkg_op]
-        if opts is not None:
-                for entry in opts:
-                        if type(entry) != tuple:
-                                continue
-                        if len(entry) == 4:
-                                opt, dummy_default, dummy_valid_args, \
-                                    schema = entry
+    properties = {}
+    opts = options.pkg_op_opts[pkg_op]
+    if opts is not None:
+        for entry in opts:
+            if type(entry) != tuple:
+                continue
+            if len(entry) == 4:
+                opt, dummy_default, dummy_valid_args, schema = entry
 
-                                if opt in opts_mapping:
-                                        optn = opts_mapping[opt]
-                                        if optn:
-                                                properties[optn] = schema
-                                        else:
-                                                properties[opt] = schema
-                                else:
-                                        properties[opt] = schema
+                if opt in opts_mapping:
+                    optn = opts_mapping[opt]
+                    if optn:
+                        properties[optn] = schema
+                    else:
+                        properties[opt] = schema
+                else:
+                    properties[opt] = schema
 
-        arg_name = "pargs_json"
-        input_schema = \
-            {arg_name: {
-                "type": "array",
-                "items": {
-                    "type": "string"
-                    }
-                },
-                "opts_json": {"type": "object",
-                    "properties": properties
-                },
-            }
-        return input_schema
+    arg_name = "pargs_json"
+    input_schema = {
+        arg_name: {"type": "array", "items": {"type": "string"}},
+        "opts_json": {"type": "object", "properties": properties},
+    }
+    return input_schema
+
 
 def __pkg_list_output_schema():
-        data_schema = {"type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "pub": {"type": "string"},
-                    "pkg": {"type": "string"},
-                    "version": {"type": "string"},
-                    "summary": {"type": "string"},
-                    "states": {"type": "array",
-                        "items": {"type": "string"}}
-                    }
-                }
-            }
-        return data_schema
-
-def __get_plan_props():
-        msg_payload_item = {
+    data_schema = {
+        "type": "array",
+        "items": {
             "type": "object",
             "properties": {
-                "msg_time": {"type": ["null", "string"]},
-                "msg_level": {"type": ["null", "string"]},
-                "msg_type": {"type": ["null", "string"]},
-                "msg_text": {"type": ["null", "string"]}
-            }
-        }
-        plan_props = {"type": "object",
-            "properties": {
-                "image-name": {"type": ["null", "string"]},
-                "affect-services": {
-                  "type": "array",
-                  "items": {}
-                },
-                "licenses": {
-                  "type": "array",
-                  "items": [
+                "pub": {"type": "string"},
+                "pkg": {"type": "string"},
+                "version": {"type": "string"},
+                "summary": {"type": "string"},
+                "states": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+    }
+    return data_schema
+
+
+def __get_plan_props():
+    msg_payload_item = {
+        "type": "object",
+        "properties": {
+            "msg_time": {"type": ["null", "string"]},
+            "msg_level": {"type": ["null", "string"]},
+            "msg_type": {"type": ["null", "string"]},
+            "msg_text": {"type": ["null", "string"]},
+        },
+    }
+    plan_props = {
+        "type": "object",
+        "properties": {
+            "image-name": {"type": ["null", "string"]},
+            "affect-services": {"type": "array", "items": {}},
+            "licenses": {
+                "type": "array",
+                "items": [
                     {
-                      "type": "array",
-                      "items": [
-                        {"type": ["null", "string"]},
-                        {},
-                        {
-                          "type": "array",
-                          "items": [
+                        "type": "array",
+                        "items": [
                             {"type": ["null", "string"]},
-                            {"type": ["null", "string"]},
-                            {"type": ["null", "string"]},
-                            {"type": ["null", "boolean"]},
-                            {"type": ["null", "boolean"]}
-                          ]}]
+                            {},
+                            {
+                                "type": "array",
+                                "items": [
+                                    {"type": ["null", "string"]},
+                                    {"type": ["null", "string"]},
+                                    {"type": ["null", "string"]},
+                                    {"type": ["null", "boolean"]},
+                                    {"type": ["null", "boolean"]},
+                                ],
+                            },
+                        ],
                     },
-                    {"type": "array",
-                      "items": [
-                        {"type": ["null", "string"]},
-                        {},
-                        {"type": "array",
-                          "items": [
+                    {
+                        "type": "array",
+                        "items": [
                             {"type": ["null", "string"]},
-                            {"type": ["null", "string"]},
-                            {"type": ["null", "string"]},
-                            {"type": ["null", "boolean"]},
-                            {"type": ["null", "boolean"]}
-                          ]}]}]
-                },
-                "child-images": {
-                  "type": "array",
-                  "items": {}
-                },
-                "change-mediators": {
-                  "type": "array",
-                  "items": {}
-                },
-                "change-facets": {
-                  "type": "array",
-                  "items": {}
-                },
-                "remove-packages": {
-                  "type": "array",
-                  "items": {}
-                },
-                "be-name": {
-                  "type": ["null", "string"],
-                },
-                "space-available": {
-                  "type": ["null", "number"],
-                },
-                "boot-archive-rebuild": {
-                  "type": ["null", "boolean"],
-                },
-                "version": {
-                  "type": ["null", "number"],
-                },
-                "create-new-be": {
-                  "type": ["null", "boolean"],
-                },
-                "change-packages": {
-                  "type": "array",
-                  "items": {}
-                },
-                "space-required": {
-                  "type": ["null", "number"],
-                },
-                "change-variants": {
-                  "type": "array",
-                  "items": {}
-                },
-                "affect-packages": {
-                  "type": "array",
-                  "items": {}
-                },
-                "change-editables": {
-                  "type": "array",
-                  "items": {}
-                },
-                "create-backup-be": {
-                  "type": ["null", "boolean"],
-                },
-                "release-notes": {
-                  "type": "array",
-                  "items": {}
-                },
-                "add-packages": {
-                  "type": "array",
-                  "items": {
-                    "type": ["null", "string"]
-                  },
-                },
-                "backup-be-name": {
-                  "type": ["null", "string"]
-                },
-                "activate-be": {
-                  "type": ["null", "boolean"],
-                },
-                # Because item id is non-deterministic, only properties that
-                # can be determined are listed here.
-                "item-messages": {"type": "object",
-                    "properties": {
-                        "unpackaged": {"type": "object",
-                            "properties": {
-                                "errors": {"type": "array",
-                                                "items": msg_payload_item},
-                                "warnings": {"type": "array",
-                                                     "items": msg_payload_item}
-                            }
-                        }
+                            {},
+                            {
+                                "type": "array",
+                                "items": [
+                                    {"type": ["null", "string"]},
+                                    {"type": ["null", "string"]},
+                                    {"type": ["null", "string"]},
+                                    {"type": ["null", "boolean"]},
+                                    {"type": ["null", "boolean"]},
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            "child-images": {"type": "array", "items": {}},
+            "change-mediators": {"type": "array", "items": {}},
+            "change-facets": {"type": "array", "items": {}},
+            "remove-packages": {"type": "array", "items": {}},
+            "be-name": {
+                "type": ["null", "string"],
+            },
+            "space-available": {
+                "type": ["null", "number"],
+            },
+            "boot-archive-rebuild": {
+                "type": ["null", "boolean"],
+            },
+            "version": {
+                "type": ["null", "number"],
+            },
+            "create-new-be": {
+                "type": ["null", "boolean"],
+            },
+            "change-packages": {"type": "array", "items": {}},
+            "space-required": {
+                "type": ["null", "number"],
+            },
+            "change-variants": {"type": "array", "items": {}},
+            "affect-packages": {"type": "array", "items": {}},
+            "change-editables": {"type": "array", "items": {}},
+            "create-backup-be": {
+                "type": ["null", "boolean"],
+            },
+            "release-notes": {"type": "array", "items": {}},
+            "add-packages": {
+                "type": "array",
+                "items": {"type": ["null", "string"]},
+            },
+            "backup-be-name": {"type": ["null", "string"]},
+            "activate-be": {
+                "type": ["null", "boolean"],
+            },
+            # Because item id is non-deterministic, only properties that
+            # can be determined are listed here.
+            "item-messages": {
+                "type": "object",
+                "properties": {
+                    "unpackaged": {
+                        "type": "object",
+                        "properties": {
+                            "errors": {
+                                "type": "array",
+                                "items": msg_payload_item,
+                            },
+                            "warnings": {
+                                "type": "array",
+                                "items": msg_payload_item,
+                            },
+                        },
                     }
-                }
-              }
-            }
-        return plan_props
+                },
+            },
+        },
+    }
+    return plan_props
+
 
 def __pkg_exact_install_output_schema():
-        data_schema = {"type": "object",
-            "properties": {
-                "plan": __get_plan_props(),
-                "release_notes_url": {"type": ["null", "string"]}
-                }
-            }
-        return data_schema
+    data_schema = {
+        "type": "object",
+        "properties": {
+            "plan": __get_plan_props(),
+            "release_notes_url": {"type": ["null", "string"]},
+        },
+    }
+    return data_schema
+
 
 def __pkg_install_output_schema():
-        data_schema = {"type": "object",
-            "properties": {
-                "plan": __get_plan_props(),
-                "release_notes_url": {"type": ["null", "string"]}
-                }
-            }
-        return data_schema
+    data_schema = {
+        "type": "object",
+        "properties": {
+            "plan": __get_plan_props(),
+            "release_notes_url": {"type": ["null", "string"]},
+        },
+    }
+    return data_schema
+
 
 def __pkg_update_output_schema():
-        data_schema = {"type": "object",
-            "properties": {
-                "plan": __get_plan_props(),
-                "release_notes_url": {"type": ["null", "string"]}
-                }
-            }
-        return data_schema
+    data_schema = {
+        "type": "object",
+        "properties": {
+            "plan": __get_plan_props(),
+            "release_notes_url": {"type": ["null", "string"]},
+        },
+    }
+    return data_schema
+
 
 def __pkg_uninstall_output_schema():
-        data_schema = {"type": "object",
-            "properties": {
-                "plan": __get_plan_props(),
-                }
-            }
-        return data_schema
+    data_schema = {
+        "type": "object",
+        "properties": {
+            "plan": __get_plan_props(),
+        },
+    }
+    return data_schema
+
 
 def __pkg_publisher_set_output_schema():
-        data_schema = {"type": "object",
-            "properties": {
-                "header": {"type": "string"},
-                "added": {"type": "array", "items": {"type": "string"}},
-                "updated": {"type": "array", "items": {"type": "string"}}
-                }
-            }
-        return data_schema
+    data_schema = {
+        "type": "object",
+        "properties": {
+            "header": {"type": "string"},
+            "added": {"type": "array", "items": {"type": "string"}},
+            "updated": {"type": "array", "items": {"type": "string"}},
+        },
+    }
+    return data_schema
+
 
 def __pkg_publisher_unset_output_schema():
-        return {}
+    return {}
+
 
 def __pkg_publisher_output_schema():
-        data_schema = {"type": "object",
-            "properties": {
-                "header": {"type": "array", "items": {"type": "string"}},
-                "publishers": {"type": "array", "items": {"type": "array",
-                    "items": {"type": ["null", "string"]}}},
-                "publisher_details": {"type": "array",
-                    "items": {"type": "object", "properties": {
+    data_schema = {
+        "type": "object",
+        "properties": {
+            "header": {"type": "array", "items": {"type": "string"}},
+            "publishers": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {"type": ["null", "string"]},
+                },
+            },
+            "publisher_details": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
                         "Publisher": {"type": ["null", "string"]},
                         "Alias": {"type": ["null", "string"]},
                         "Client UUID": {"type": ["null", "string"]},
                         "Catalog Updated": {"type": ["null", "string"]},
                         "Enabled": {"type": ["null", "string"]},
                         "Properties": {"type": "object"},
-                        "origins": {"type": "array",
-                            "items": {"type": "object"}},
-                        "mirrors": {"type": "array",
-                            "items": {"type": "object"}},
+                        "origins": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                        },
+                        "mirrors": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                        },
                         "Approved CAs": {"type": "array"},
                         "Revoked CAs": {"type": "array"},
-                    }}}
-                }
-            }
-        return data_schema
+                    },
+                },
+            },
+        },
+    }
+    return data_schema
+
 
 def __pkg_info_output_schema():
-        data_schema = {"type": "object",
-            "properties": {
-                "licenses": {"type": "array", "items": {"type": "array",
-                    "items": {"type": ["null", "string"]}}},
-                "package_attrs": {"type": "array",
-                    "items": {"type": "array", "items": {"type": "array",
-                    "items": [{"type": ["null", "string"]}, {"type": "array",
-                    "items": {"type": ["null", "string"]}}]}}}
-            }
-        }
-        return data_schema
+    data_schema = {
+        "type": "object",
+        "properties": {
+            "licenses": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {"type": ["null", "string"]},
+                },
+            },
+            "package_attrs": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": [
+                            {"type": ["null", "string"]},
+                            {
+                                "type": "array",
+                                "items": {"type": ["null", "string"]},
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    }
+    return data_schema
+
 
 def __pkg_verify_output_schema():
-        data_schema = {"type": "object",
-            "properties": {
-                "plan": __get_plan_props(),
-                }
-            }
-        return data_schema
+    data_schema = {
+        "type": "object",
+        "properties": {
+            "plan": __get_plan_props(),
+        },
+    }
+    return data_schema
+
 
 def __pkg_fix_output_schema():
-        data_schema = {"type": "object",
-            "properties": {
-                "plan": __get_plan_props(),
-                }
-            }
-        return data_schema
+    data_schema = {
+        "type": "object",
+        "properties": {
+            "plan": __get_plan_props(),
+        },
+    }
+    return data_schema
+
 
 def _format_update_error(e, errors_json=None):
-        # This message is displayed to the user whenever an
-        # ImageFormatUpdateNeeded exception is encountered.
-        if errors_json:
-                error = {"reason": str(e), "errtype": "format_update"}
-                errors_json.append(error)
+    # This message is displayed to the user whenever an
+    # ImageFormatUpdateNeeded exception is encountered.
+    if errors_json:
+        error = {"reason": str(e), "errtype": "format_update"}
+        errors_json.append(error)
+
 
 def _error_json(text, cmd=None, errors_json=None, errorType=None):
-        """Prepare an error message for json output. """
+    """Prepare an error message for json output."""
 
-        if not isinstance(text, six.string_types):
-                # Assume it's an object that can be stringified.
-                text = str(text)
+    if not isinstance(text, six.string_types):
+        # Assume it's an object that can be stringified.
+        text = str(text)
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        if cmd:
-                text_nows = "{0}: {1}".format(cmd, text_nows)
-                pkg_cmd = "pkg "
-        else:
-                pkg_cmd = "pkg: "
+    if cmd:
+        text_nows = "{0}: {1}".format(cmd, text_nows)
+        pkg_cmd = "pkg "
+    else:
+        pkg_cmd = "pkg: "
 
-        if errors_json is not None:
-                error = {}
-                if errorType:
-                        error["errtype"] = errorType
-                error["reason"] = ws + pkg_cmd + text_nows
-                errors_json.append(error)
+    if errors_json is not None:
+        error = {}
+        if errorType:
+            error["errtype"] = errorType
+        error["reason"] = ws + pkg_cmd + text_nows
+        errors_json.append(error)
+
 
 def _collect_proxy_config_errors(errors_json=None):
-        """If the user has configured http_proxy or https_proxy in the
-        environment, collect the values. Some transport errors are
-        not debuggable without this information handy."""
+    """If the user has configured http_proxy or https_proxy in the
+    environment, collect the values. Some transport errors are
+    not debuggable without this information handy."""
 
-        http_proxy = os.environ.get("http_proxy", None)
-        https_proxy = os.environ.get("https_proxy", None)
+    http_proxy = os.environ.get("http_proxy", None)
+    https_proxy = os.environ.get("https_proxy", None)
 
-        if not http_proxy and not https_proxy:
-                return
+    if not http_proxy and not https_proxy:
+        return
 
-        err = "\nThe following proxy configuration is set in the " \
-            "environment:\n"
-        if http_proxy:
-                err += "http_proxy: {0}\n".format(http_proxy)
-        if https_proxy:
-                err += "https_proxy: {0}\n".format(https_proxy)
-        if errors_json:
-                errors_json.append({"reason": err})
+    err = "\nThe following proxy configuration is set in the " "environment:\n"
+    if http_proxy:
+        err += "http_proxy: {0}\n".format(http_proxy)
+    if https_proxy:
+        err += "https_proxy: {0}\n".format(https_proxy)
+    if errors_json:
+        errors_json.append({"reason": err})
+
 
 def _get_fmri_args(api_inst, pargs, cmd=None, errors_json=None):
-        """ Convenience routine to check that input args are valid fmris. """
+    """Convenience routine to check that input args are valid fmris."""
 
-        res = []
-        errors = []
-        for pat, err, pfmri, matcher in api_inst.parse_fmri_patterns(pargs):
-                if not err:
-                        res.append((pat, err, pfmri, matcher))
-                        continue
-                if isinstance(err, version.VersionError):
-                        # For version errors, include the pattern so
-                        # that the user understands why it failed.
-                        errors.append("Illegal FMRI '{0}': {1}".format(pat,
-                            err))
-                else:
-                        # Including the pattern is redundant for other
-                        # exceptions.
-                        errors.append(err)
-        if errors:
-                _error_json("\n".join(str(e) for e in errors),
-                    cmd=cmd, errors_json=errors_json)
-        return len(errors) == 0, res
+    res = []
+    errors = []
+    for pat, err, pfmri, matcher in api_inst.parse_fmri_patterns(pargs):
+        if not err:
+            res.append((pat, err, pfmri, matcher))
+            continue
+        if isinstance(err, version.VersionError):
+            # For version errors, include the pattern so
+            # that the user understands why it failed.
+            errors.append("Illegal FMRI '{0}': {1}".format(pat, err))
+        else:
+            # Including the pattern is redundant for other
+            # exceptions.
+            errors.append(err)
+    if errors:
+        _error_json(
+            "\n".join(str(e) for e in errors), cmd=cmd, errors_json=errors_json
+        )
+    return len(errors) == 0, res
+
 
 def __default_error_json_schema():
-        """Get the default error json schema."""
+    """Get the default error json schema."""
 
-        error_schema = {
-            "type": "object",
-            "properties": {
-                "errtype": {"type": "string",
-                    "enum": ["format_update", "catalog_refresh",
-                    "catalog_refresh_failed", "inventory",
-                    "inventory_extra", "plan_license", "publisher_set",
-                    "unsupported_repo_op", "cert_info", "info_not_found",
-                    "info_no_licenses"]},
-                "reason": {"type": "string"},
-                "info": {"type": "string"}
-                }
-            }
-        return error_schema
+    error_schema = {
+        "type": "object",
+        "properties": {
+            "errtype": {
+                "type": "string",
+                "enum": [
+                    "format_update",
+                    "catalog_refresh",
+                    "catalog_refresh_failed",
+                    "inventory",
+                    "inventory_extra",
+                    "plan_license",
+                    "publisher_set",
+                    "unsupported_repo_op",
+                    "cert_info",
+                    "info_not_found",
+                    "info_no_licenses",
+                ],
+            },
+            "reason": {"type": "string"},
+            "info": {"type": "string"},
+        },
+    }
+    return error_schema
 
-def __construct_json_schema(title, description=None, stype="object",
-    properties=None, required=None, additional_prop=False):
-        """Construct  json schema."""
 
-        json_schema = {"$schema": "http://json-schema.org/draft-04/schema#",
-            "title": title,
-            "type": stype,
-            }
-        if description:
-                json_schema["description"] = description
-        if properties:
-                json_schema["properties"] = properties
-        if required:
-                json_schema["required"] = required
-        json_schema["additionalProperties"] = additional_prop
-        return json_schema
+def __construct_json_schema(
+    title,
+    description=None,
+    stype="object",
+    properties=None,
+    required=None,
+    additional_prop=False,
+):
+    """Construct  json schema."""
+
+    json_schema = {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "title": title,
+        "type": stype,
+    }
+    if description:
+        json_schema["description"] = description
+    if properties:
+        json_schema["properties"] = properties
+    if required:
+        json_schema["required"] = required
+    json_schema["additionalProperties"] = additional_prop
+    return json_schema
+
 
 def __prepare_json(status, op=None, schema=None, data=None, errors=None):
-        """Prepare json structure for returning."""
+    """Prepare json structure for returning."""
 
-        ret_json = {"status": status}
+    ret_json = {"status": status}
 
-        if errors:
-                if not isinstance(errors, list):
-                        ret_json["errors"] = [errors]
-                else:
-                        ret_json["errors"] = errors
-        if data:
-                ret_json["data"] = data
-        if op:
-                op_schema = _get_pkg_output_schema(op)
-                try:
-                        json.validate(ret_json, op_schema)
-                except json.ValidationError as e:
-                        newret_json = {"status": EXIT_OOPS,
-                            "errors": [{"reason": str(e)}]}
-                        return newret_json
-        if schema:
-                ret_json["schema"] = schema
+    if errors:
+        if not isinstance(errors, list):
+            ret_json["errors"] = [errors]
+        else:
+            ret_json["errors"] = errors
+    if data:
+        ret_json["data"] = data
+    if op:
+        op_schema = _get_pkg_output_schema(op)
+        try:
+            json.validate(ret_json, op_schema)
+        except json.ValidationError as e:
+            newret_json = {"status": EXIT_OOPS, "errors": [{"reason": str(e)}]}
+            return newret_json
+    if schema:
+        ret_json["schema"] = schema
 
-        return ret_json
+    return ret_json
+
 
 def _collect_catalog_failures(cre, ignore_perms_failure=False, errors=None):
-        total = cre.total
-        succeeded = cre.succeeded
-        partial = 0
-        refresh_errstr = ""
+    total = cre.total
+    succeeded = cre.succeeded
+    partial = 0
+    refresh_errstr = ""
 
-        for pub, err in cre.failed:
-                if isinstance(err, api_errors.CatalogOriginRefreshException):
-                        if len(err.failed) < err.total:
-                                partial += 1
+    for pub, err in cre.failed:
+        if isinstance(err, api_errors.CatalogOriginRefreshException):
+            if len(err.failed) < err.total:
+                partial += 1
 
-                        refresh_errstr += _("\n{0}/{1} repositories for "
-                            "publisher '{2}' could not be refreshed.\n").format(
-                            len(err.failed), err.total, pub)
-                        for o, e in err.failed:
-                                refresh_errstr += "\n"
-                                refresh_errstr += str(e)
-                        refresh_errstr += "\n"
-                else:
-                        refresh_errstr += "\n\n" + str(err)
+            refresh_errstr += _(
+                "\n{0}/{1} repositories for "
+                "publisher '{2}' could not be refreshed.\n"
+            ).format(len(err.failed), err.total, pub)
+            for o, e in err.failed:
+                refresh_errstr += "\n"
+                refresh_errstr += str(e)
+            refresh_errstr += "\n"
+        else:
+            refresh_errstr += "\n\n" + str(err)
 
+    partial_str = ":"
+    if partial:
+        partial_str = _(" ({0} partial):").format(str(partial))
 
-        partial_str = ":"
-        if partial:
-                partial_str = _(" ({0} partial):").format(str(partial))
+    txt = _(
+        "pkg: {succeeded}/{total} catalogs successfully " "updated{partial}"
+    ).format(succeeded=succeeded, total=total, partial=partial_str)
 
-        txt = _("pkg: {succeeded}/{total} catalogs successfully "
-            "updated{partial}").format(succeeded=succeeded, total=total,
-            partial=partial_str)
+    if errors is not None:
+        if cre.failed:
+            error = {"reason": txt, "errtype": "catalog_refresh"}
+        else:
+            error = {"info": txt, "errtype": "catalog_refresh"}
+        errors.append(error)
 
+    for pub, err in cre.failed:
+        if ignore_perms_failure and not isinstance(
+            err, api_errors.PermissionsException
+        ):
+            # If any errors other than a permissions exception are
+            # found, then don't ignore them.
+            ignore_perms_failure = False
+            break
+
+    if cre.failed and ignore_perms_failure:
+        # Consider those that failed to have succeeded and add them
+        # to the actual successful total.
+        return succeeded + partial + len(cre.failed)
+
+    if errors is not None:
+        error = {"reason": str(refresh_errstr), "errtype": "catalog_refresh"}
+        errors.append(error)
+
+    if cre.errmessage:
         if errors is not None:
-                if cre.failed:
-                        error = {"reason": txt, "errtype": "catalog_refresh"}
-                else:
-                        error = {"info": txt, "errtype": "catalog_refresh"}
-                errors.append(error)
+            error = {
+                "reason": str(cre.errmessage),
+                "errtype": "catalog_refresh",
+            }
+            errors.append(error)
 
-        for pub, err in cre.failed:
-                if ignore_perms_failure and \
-                    not isinstance(err, api_errors.PermissionsException):
-                        # If any errors other than a permissions exception are
-                        # found, then don't ignore them.
-                        ignore_perms_failure = False
-                        break
-
-        if cre.failed and ignore_perms_failure:
-                # Consider those that failed to have succeeded and add them
-                # to the actual successful total.
-                return succeeded + partial + len(cre.failed)
+    return succeeded + partial
 
 
-        if errors is not None:
-                error = {"reason": str(refresh_errstr),
-                    "errtype": "catalog_refresh"}
-                errors.append(error)
+def _list_inventory(
+    op,
+    api_inst,
+    pargs,
+    li_parent_sync,
+    list_all,
+    list_installed_newest,
+    list_newest,
+    list_upgradable,
+    origins,
+    quiet,
+    refresh_catalogs,
+    **other_opts,
+):
+    """List packages."""
 
-        if cre.errmessage:
-                if errors is not None:
-                        error = {"reason": str(cre.errmessage),
-                            "errtype": "catalog_refresh"}
-                        errors.append(error)
+    api_inst.progresstracker.set_purpose(
+        api_inst.progresstracker.PURPOSE_LISTING
+    )
 
-        return succeeded + partial
+    variants = False
+    pkg_list = api.ImageInterface.LIST_INSTALLED
+    if list_all:
+        variants = True
+        pkg_list = api.ImageInterface.LIST_ALL
+    elif list_installed_newest:
+        pkg_list = api.ImageInterface.LIST_INSTALLED_NEWEST
+    elif list_newest:
+        pkg_list = api.ImageInterface.LIST_NEWEST
+    elif list_upgradable:
+        pkg_list = api.ImageInterface.LIST_UPGRADABLE
+    elif "list_removable" in other_opts and other_opts["list_removable"]:
+        pkg_list = api.ImageInterface.LIST_REMOVABLE
 
-def _list_inventory(op, api_inst, pargs,
-    li_parent_sync, list_all, list_installed_newest, list_newest,
-    list_upgradable, origins, quiet, refresh_catalogs, **other_opts):
-        """List packages."""
+    # Each pattern in pats can be a partial or full FMRI, so
+    # extract the individual components.  These patterns are
+    # transformed here so that partial failure can be detected
+    # when more than one pattern is provided.
+    errors_json = []
+    rval, res = _get_fmri_args(api_inst, pargs, cmd=op, errors_json=errors_json)
+    if not rval:
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
 
-        api_inst.progresstracker.set_purpose(
-            api_inst.progresstracker.PURPOSE_LISTING)
-
-        variants = False
-        pkg_list = api.ImageInterface.LIST_INSTALLED
-        if list_all:
-                variants = True
-                pkg_list = api.ImageInterface.LIST_ALL
-        elif list_installed_newest:
-                pkg_list = api.ImageInterface.LIST_INSTALLED_NEWEST
-        elif list_newest:
-                pkg_list = api.ImageInterface.LIST_NEWEST
-        elif list_upgradable:
-                pkg_list = api.ImageInterface.LIST_UPGRADABLE
-        elif 'list_removable' in other_opts and other_opts['list_removable']:
-                pkg_list = api.ImageInterface.LIST_REMOVABLE
-
-        # Each pattern in pats can be a partial or full FMRI, so
-        # extract the individual components.  These patterns are
-        # transformed here so that partial failure can be detected
-        # when more than one pattern is provided.
-        errors_json = []
-        rval, res = _get_fmri_args(api_inst, pargs, cmd=op,
-            errors_json=errors_json)
-        if not rval:
+    api_inst.log_operation_start(op)
+    if (
+        pkg_list not in [api_inst.LIST_INSTALLED, api_inst.LIST_REMOVABLE]
+        and refresh_catalogs
+    ):
+        # If the user requested packages other than those
+        # installed, ensure that a refresh is performed if
+        # needed since the catalog may be out of date or
+        # invalid as a result of publisher information
+        # changing (such as an origin uri, etc.).
+        try:
+            api_inst.refresh(ignore_unreachable=False)
+        except api_errors.PermissionsException:
+            # Ignore permission exceptions with the
+            # assumption that an unprivileged user is
+            # executing this command and that the
+            # refresh doesn't matter.
+            pass
+        except api_errors.CatalogRefreshException as e:
+            succeeded = _collect_catalog_failures(
+                e, ignore_perms_failure=True, errors=errors_json
+            )
+            if succeeded != e.total:
+                # If total number of publishers does
+                # not match 'successful' number
+                # refreshed, abort.
                 return __prepare_json(EXIT_OOPS, errors=errors_json)
 
-        api_inst.log_operation_start(op)
-        if (pkg_list not in [api_inst.LIST_INSTALLED, api_inst.LIST_REMOVABLE]
-            and refresh_catalogs):
-                # If the user requested packages other than those
-                # installed, ensure that a refresh is performed if
-                # needed since the catalog may be out of date or
-                # invalid as a result of publisher information
-                # changing (such as an origin uri, etc.).
-                try:
-                        api_inst.refresh(ignore_unreachable=False)
-                except api_errors.PermissionsException:
-                        # Ignore permission exceptions with the
-                        # assumption that an unprivileged user is
-                        # executing this command and that the
-                        # refresh doesn't matter.
-                        pass
-                except api_errors.CatalogRefreshException as e:
-                        succeeded = _collect_catalog_failures(e,
-                            ignore_perms_failure=True, errors=errors_json)
-                        if succeeded != e.total:
-                                # If total number of publishers does
-                                # not match 'successful' number
-                                # refreshed, abort.
-                                return __prepare_json(EXIT_OOPS,
-                                    errors=errors_json)
+        except:
+            # Ignore the above error and just use what
+            # already exists.
+            pass
 
-                except:
-                        # Ignore the above error and just use what
-                        # already exists.
-                        pass
+    state_map = [
+        [(api.PackageInfo.INSTALLED, "installed")],
+        [(api.PackageInfo.FROZEN, "frozen")],
+        [(api.PackageInfo.OPTIONAL, "optional")],
+        [(api.PackageInfo.MANUAL, "manual")],
+        [
+            (api.PackageInfo.OBSOLETE, "obsolete"),
+            (api.PackageInfo.LEGACY, "legacy"),
+            (api.PackageInfo.RENAMED, "renamed"),
+        ],
+    ]
 
-        state_map = [
-            [(api.PackageInfo.INSTALLED, "installed")],
-            [(api.PackageInfo.FROZEN, "frozen")],
-            [(api.PackageInfo.OPTIONAL, "optional")],
-            [(api.PackageInfo.MANUAL, "manual")],
-            [
-                (api.PackageInfo.OBSOLETE, "obsolete"),
-                (api.PackageInfo.LEGACY, "legacy"),
-                (api.PackageInfo.RENAMED, "renamed")
-            ],
-        ]
+    # Now get the matching list of packages and display it.
+    found = False
 
-        # Now get the matching list of packages and display it.
-        found = False
+    data = []
+    try:
+        res = api_inst.get_pkg_list(
+            pkg_list,
+            patterns=pargs,
+            raise_unmatched=True,
+            repos=origins,
+            variants=variants,
+        )
+        for pt, summ, cats, states, attrs in res:
+            found = True
+            entry = {}
+            pub, stem, ver = pt
+            entry["pub"] = pub
+            entry["pkg"] = stem
+            entry["version"] = ver
+            entry["summary"] = summ
 
-        data = []
-        try:
-                res = api_inst.get_pkg_list(pkg_list, patterns=pargs,
-                    raise_unmatched=True, repos=origins, variants=variants)
-                for pt, summ, cats, states, attrs in res:
-                        found = True
-                        entry = {}
-                        pub, stem, ver = pt
-                        entry["pub"] = pub
-                        entry["pkg"] = stem
-                        entry["version"] = ver
-                        entry["summary"] = summ
-
-                        stateslist = []
-                        for sentry in state_map:
-                                for s, v in sentry:
-                                        if s in states:
-                                                stateslist.append(v)
-                                                break
-                        entry["states"] = stateslist
-                        data.append(entry)
-                if not found and not pargs:
-                        if pkg_list == api_inst.LIST_INSTALLED:
-                                if not quiet:
-                                        err = {"reason":
-                                            _("no packages installed")}
-                                        errors_json.append(err)
-                                api_inst.log_operation_end(
-                                    result=RESULT_NOTHING_TO_DO)
-                        elif pkg_list == api_inst.LIST_INSTALLED_NEWEST:
-                                if not quiet:
-                                        err = {"reason": _("no packages "
-                                            "installed or available for "
-                                            "installation")}
-                                        errors_json.append(err)
-                                api_inst.log_operation_end(
-                                    result=RESULT_NOTHING_TO_DO)
-                        elif pkg_list == api_inst.LIST_UPGRADABLE:
-                                if not quiet:
-                                        img = api_inst._img
-                                        cat = img.get_catalog(
-                                            img.IMG_CATALOG_INSTALLED)
-                                        if cat.package_count > 0:
-                                                err = {"reason":
-                                                    _("no packages have "
-                                                    "newer versions "
-                                                    "available")}
-                                        else:
-                                                err = {"reason":
-                                                    _("no packages are "
-                                                    "installed")}
-                                        errors_json.append(err)
-                                api_inst.log_operation_end(
-                                    result=RESULT_NOTHING_TO_DO)
-                        elif pkg_list == api_inst.LIST_REMOVABLE:
-                                if not quiet:
-                                        err = {"reason":
-                                            _("no installed packages "
-                                            "are removable")}
-                                        errors_json.append(err)
-                                api_inst.log_operation_end(
-                                    result=RESULT_NOTHING_TO_DO)
-                        else:
-                                api_inst.log_operation_end(
-                                    result=RESULT_NOTHING_TO_DO)
-                        return __prepare_json(EXIT_OOPS,
-                            errors=errors_json)
-
-                api_inst.log_operation_end()
-                return __prepare_json(EXIT_OK, data=data,
-                    errors=errors_json)
-        except (api_errors.InvalidPackageErrors,
-            api_errors.ActionExecutionError,
-            api_errors.PermissionsException) as e:
-                _error_json(e, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, data=data,
-                    errors=errors_json)
-        except api_errors.CatalogRefreshException as e:
-                _collect_catalog_failures(e, errors=errors_json)
-                return __prepare_json(EXIT_OOPS, data=data,
-                    errors=errors_json)
-        except api_errors.InventoryException as e:
-                if e.illegal:
-                        for i in e.illegal:
-                                _error_json(i, errors_json=errors_json)
-                        api_inst.log_operation_end(
-                            result=RESULT_FAILED_BAD_REQUEST)
-                        return __prepare_json(EXIT_OOPS, data=data,
-                            errors=errors_json)
-
-                if quiet:
-                        # Collect nothing.
-                        pass
-                elif pkg_list == api.ImageInterface.LIST_ALL or \
-                    pkg_list == api.ImageInterface.LIST_NEWEST:
-                        _error_json(_("no known packages matching:\n  {0}"
-                            ).format("\n  ".join(e.notfound)), cmd=op,
-                            errors_json=errors_json,
-                            errorType="inventory")
-                elif pkg_list == api.ImageInterface.LIST_INSTALLED_NEWEST:
-                        _error_json(_("no packages matching the following "
-                            "patterns are allowed by installed "
-                            "incorporations, or image variants that are known "
-                            "or installed\n  {0}").format(
-                            "\n  ".join(e.notfound)), cmd=op,
-                            errors_json=errors_json,
-                            errorType="inventory_extra")
-                elif pkg_list == api.ImageInterface.LIST_UPGRADABLE:
-                        # Creating a list of packages that are uptodate
-                        # and that are not installed on the system.
-                        no_updates = []
-                        not_installed = []
-                        try:
-                                for entry in api_inst.get_pkg_list(
-                                    api.ImageInterface.LIST_INSTALLED,
-                                    patterns=e.notfound, raise_unmatched=True):
-                                        pub, stem, ver = entry[0]
-                                        no_updates.append(stem)
-                        except api_errors.InventoryException as exc:
-                                not_installed = exc.notfound
-
-                        err_str = ""
-                        if not_installed:
-                                err_str = _("no packages matching the "
-                                    "following patterns are installed:\n  {0}"
-                                    ).format("\n  ".join(not_installed))
-
-                        if no_updates:
-                                err_str = err_str + _("no updates are "
-                                    "available for the following packages:\n  "
-                                    "{0}").format("\n  ".join(no_updates))
-                        if err_str:
-                                _error_json(err_str, cmd=op,
-                                    errors_json=errors_json,
-                                    errorType="inventory")
-                else:
-                        _error_json(_("no packages matching the following "
-                            "patterns are installed:\n  {0}").format(
-                            "\n  ".join(e.notfound)), cmd=op,
-                            errors_json=errors_json,
-                            errorType="inventory")
-
-                if found and e.notfound:
-                        # Only some patterns matched.
-                        api_inst.log_operation_end()
-                        return __prepare_json(EXIT_PARTIAL, data=data,
-                            errors=errors_json)
+            stateslist = []
+            for sentry in state_map:
+                for s, v in sentry:
+                    if s in states:
+                        stateslist.append(v)
+                        break
+            entry["states"] = stateslist
+            data.append(entry)
+        if not found and not pargs:
+            if pkg_list == api_inst.LIST_INSTALLED:
+                if not quiet:
+                    err = {"reason": _("no packages installed")}
+                    errors_json.append(err)
                 api_inst.log_operation_end(result=RESULT_NOTHING_TO_DO)
-                return __prepare_json(EXIT_OOPS, data=data, errors=errors_json)
+            elif pkg_list == api_inst.LIST_INSTALLED_NEWEST:
+                if not quiet:
+                    err = {
+                        "reason": _(
+                            "no packages "
+                            "installed or available for "
+                            "installation"
+                        )
+                    }
+                    errors_json.append(err)
+                api_inst.log_operation_end(result=RESULT_NOTHING_TO_DO)
+            elif pkg_list == api_inst.LIST_UPGRADABLE:
+                if not quiet:
+                    img = api_inst._img
+                    cat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
+                    if cat.package_count > 0:
+                        err = {
+                            "reason": _(
+                                "no packages have "
+                                "newer versions "
+                                "available"
+                            )
+                        }
+                    else:
+                        err = {"reason": _("no packages are " "installed")}
+                    errors_json.append(err)
+                api_inst.log_operation_end(result=RESULT_NOTHING_TO_DO)
+            elif pkg_list == api_inst.LIST_REMOVABLE:
+                if not quiet:
+                    err = {
+                        "reason": _("no installed packages " "are removable")
+                    }
+                    errors_json.append(err)
+                api_inst.log_operation_end(result=RESULT_NOTHING_TO_DO)
+            else:
+                api_inst.log_operation_end(result=RESULT_NOTHING_TO_DO)
+            return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+        api_inst.log_operation_end()
+        return __prepare_json(EXIT_OK, data=data, errors=errors_json)
+    except (
+        api_errors.InvalidPackageErrors,
+        api_errors.ActionExecutionError,
+        api_errors.PermissionsException,
+    ) as e:
+        _error_json(e, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, data=data, errors=errors_json)
+    except api_errors.CatalogRefreshException as e:
+        _collect_catalog_failures(e, errors=errors_json)
+        return __prepare_json(EXIT_OOPS, data=data, errors=errors_json)
+    except api_errors.InventoryException as e:
+        if e.illegal:
+            for i in e.illegal:
+                _error_json(i, errors_json=errors_json)
+            api_inst.log_operation_end(result=RESULT_FAILED_BAD_REQUEST)
+            return __prepare_json(EXIT_OOPS, data=data, errors=errors_json)
+
+        if quiet:
+            # Collect nothing.
+            pass
+        elif (
+            pkg_list == api.ImageInterface.LIST_ALL
+            or pkg_list == api.ImageInterface.LIST_NEWEST
+        ):
+            _error_json(
+                _("no known packages matching:\n  {0}").format(
+                    "\n  ".join(e.notfound)
+                ),
+                cmd=op,
+                errors_json=errors_json,
+                errorType="inventory",
+            )
+        elif pkg_list == api.ImageInterface.LIST_INSTALLED_NEWEST:
+            _error_json(
+                _(
+                    "no packages matching the following "
+                    "patterns are allowed by installed "
+                    "incorporations, or image variants that are known "
+                    "or installed\n  {0}"
+                ).format("\n  ".join(e.notfound)),
+                cmd=op,
+                errors_json=errors_json,
+                errorType="inventory_extra",
+            )
+        elif pkg_list == api.ImageInterface.LIST_UPGRADABLE:
+            # Creating a list of packages that are uptodate
+            # and that are not installed on the system.
+            no_updates = []
+            not_installed = []
+            try:
+                for entry in api_inst.get_pkg_list(
+                    api.ImageInterface.LIST_INSTALLED,
+                    patterns=e.notfound,
+                    raise_unmatched=True,
+                ):
+                    pub, stem, ver = entry[0]
+                    no_updates.append(stem)
+            except api_errors.InventoryException as exc:
+                not_installed = exc.notfound
+
+            err_str = ""
+            if not_installed:
+                err_str = _(
+                    "no packages matching the "
+                    "following patterns are installed:\n  {0}"
+                ).format("\n  ".join(not_installed))
+
+            if no_updates:
+                err_str = err_str + _(
+                    "no updates are "
+                    "available for the following packages:\n  "
+                    "{0}"
+                ).format("\n  ".join(no_updates))
+            if err_str:
+                _error_json(
+                    err_str,
+                    cmd=op,
+                    errors_json=errors_json,
+                    errorType="inventory",
+                )
+        else:
+            _error_json(
+                _(
+                    "no packages matching the following "
+                    "patterns are installed:\n  {0}"
+                ).format("\n  ".join(e.notfound)),
+                cmd=op,
+                errors_json=errors_json,
+                errorType="inventory",
+            )
+
+        if found and e.notfound:
+            # Only some patterns matched.
+            api_inst.log_operation_end()
+            return __prepare_json(EXIT_PARTIAL, data=data, errors=errors_json)
+        api_inst.log_operation_end(result=RESULT_NOTHING_TO_DO)
+        return __prepare_json(EXIT_OOPS, data=data, errors=errors_json)
+
 
 def _get_tracker(prog_delay=PROG_DELAY, prog_tracker=None):
-        if prog_tracker:
-                return prog_tracker
-        elif global_settings.client_output_parsable_version is not None:
-                progresstracker = progress.NullProgressTracker()
-        elif global_settings.client_output_quiet:
-                progresstracker = progress.QuietProgressTracker()
-        elif global_settings.client_output_progfd:
-                # This logic handles linked images: for linked children
-                # we elide the progress output.
-                output_file = os.fdopen(global_settings.client_output_progfd,
-                    "w")
-                child_tracker = progress.LinkedChildProgressTracker(
-                    output_file=output_file)
-                dot_tracker = progress.DotProgressTracker(
-                    term_delay=prog_delay, output_file=output_file)
-                progresstracker = progress.MultiProgressTracker(
-                    [child_tracker, dot_tracker])
-        else:
-                try:
-                        progresstracker = progress.FancyUNIXProgressTracker(
-                            term_delay=prog_delay)
-                except progress.ProgressTrackerException:
-                        progresstracker = progress.CommandLineProgressTracker(
-                            term_delay=prog_delay)
-        return progresstracker
+    if prog_tracker:
+        return prog_tracker
+    elif global_settings.client_output_parsable_version is not None:
+        progresstracker = progress.NullProgressTracker()
+    elif global_settings.client_output_quiet:
+        progresstracker = progress.QuietProgressTracker()
+    elif global_settings.client_output_progfd:
+        # This logic handles linked images: for linked children
+        # we elide the progress output.
+        output_file = os.fdopen(global_settings.client_output_progfd, "w")
+        child_tracker = progress.LinkedChildProgressTracker(
+            output_file=output_file
+        )
+        dot_tracker = progress.DotProgressTracker(
+            term_delay=prog_delay, output_file=output_file
+        )
+        progresstracker = progress.MultiProgressTracker(
+            [child_tracker, dot_tracker]
+        )
+    else:
+        try:
+            progresstracker = progress.FancyUNIXProgressTracker(
+                term_delay=prog_delay
+            )
+        except progress.ProgressTrackerException:
+            progresstracker = progress.CommandLineProgressTracker(
+                term_delay=prog_delay
+            )
+    return progresstracker
+
 
 def _accept_plan_licenses(api_inst):
-        """Helper function that marks all licenses for the current plan as
-        accepted if they require acceptance."""
+    """Helper function that marks all licenses for the current plan as
+    accepted if they require acceptance."""
 
-        plan = api_inst.describe()
-        for pfmri, src, dest, accepted, displayed in plan.get_licenses():
-                if not dest.must_accept:
-                        continue
-                api_inst.set_plan_license_status(pfmri, dest.license,
-                    accepted=True)
+    plan = api_inst.describe()
+    for pfmri, src, dest, accepted, displayed in plan.get_licenses():
+        if not dest.must_accept:
+            continue
+        api_inst.set_plan_license_status(pfmri, dest.license, accepted=True)
 
-display_plan_options = ["basic", "fmris", "variants/facets", "services",
-    "actions", "boot-archive"]
 
-def __api_alloc(pkg_image, orig_cwd, prog_delay=PROG_DELAY, prog_tracker=None,
-    errors_json=None):
-        """Allocate API instance."""
+display_plan_options = [
+    "basic",
+    "fmris",
+    "variants/facets",
+    "services",
+    "actions",
+    "boot-archive",
+]
 
-        provided_image_dir = True
-        pkg_image_used = False
 
-        if pkg_image:
-                imgdir = pkg_image
+def __api_alloc(
+    pkg_image,
+    orig_cwd,
+    prog_delay=PROG_DELAY,
+    prog_tracker=None,
+    errors_json=None,
+):
+    """Allocate API instance."""
 
-        if "imgdir" not in locals():
-                imgdir, provided_image_dir = api.get_default_image_root(
-                    orig_cwd=orig_cwd)
-                if os.environ.get("PKG_IMAGE"):
-                        # It's assumed that this has been checked by the above
-                        # function call and hasn't been removed from the
-                        # environment.
-                        pkg_image_used = True
+    provided_image_dir = True
+    pkg_image_used = False
 
-        if not imgdir:
-                if errors_json:
-                        err = {"reason": "Could not find image. Set the "
-                            "pkg_image property to the\nlocation of an image."}
-                        errors_json.append(err)
-                return
+    if pkg_image:
+        imgdir = pkg_image
 
-        progresstracker = _get_tracker(prog_delay=prog_delay,
-            prog_tracker=prog_tracker)
-        try:
-                return api.ImageInterface(imgdir, CLIENT_API_VERSION,
-                    progresstracker, None, PKG_CLIENT_NAME,
-                    exact_match=provided_image_dir)
-        except api_errors.ImageNotFoundException as e:
-                if e.user_specified:
-                        if pkg_image_used:
-                                _error_json(_("No image rooted at '{0}' "
-                                    "(set by $PKG_IMAGE)").format(e.user_dir),
-                                    errors_json=errors_json)
-                        else:
-                                _error_json(_("No image rooted at '{0}'")
-                                   .format(e.user_dir), errors_json=errors_json)
-                else:
-                        _error_json(_("No image found."),
-                            errors_json=errors_json)
-                return
-        except api_errors.PermissionsException as e:
-                _error_json(e, errors_json=errors_json)
-                return
-        except api_errors.ImageFormatUpdateNeeded as e:
-                _format_update_error(e, errors_json=errors_json)
-                return
+    if "imgdir" not in locals():
+        imgdir, provided_image_dir = api.get_default_image_root(
+            orig_cwd=orig_cwd
+        )
+        if os.environ.get("PKG_IMAGE"):
+            # It's assumed that this has been checked by the above
+            # function call and hasn't been removed from the
+            # environment.
+            pkg_image_used = True
+
+    if not imgdir:
+        if errors_json:
+            err = {
+                "reason": "Could not find image. Set the "
+                "pkg_image property to the\nlocation of an image."
+            }
+            errors_json.append(err)
+        return
+
+    progresstracker = _get_tracker(
+        prog_delay=prog_delay, prog_tracker=prog_tracker
+    )
+    try:
+        return api.ImageInterface(
+            imgdir,
+            CLIENT_API_VERSION,
+            progresstracker,
+            None,
+            PKG_CLIENT_NAME,
+            exact_match=provided_image_dir,
+        )
+    except api_errors.ImageNotFoundException as e:
+        if e.user_specified:
+            if pkg_image_used:
+                _error_json(
+                    _("No image rooted at '{0}' " "(set by $PKG_IMAGE)").format(
+                        e.user_dir
+                    ),
+                    errors_json=errors_json,
+                )
+            else:
+                _error_json(
+                    _("No image rooted at '{0}'").format(e.user_dir),
+                    errors_json=errors_json,
+                )
+        else:
+            _error_json(_("No image found."), errors_json=errors_json)
+        return
+    except api_errors.PermissionsException as e:
+        _error_json(e, errors_json=errors_json)
+        return
+    except api_errors.ImageFormatUpdateNeeded as e:
+        _format_update_error(e, errors_json=errors_json)
+        return
+
 
 def __api_prepare_plan(operation, api_inst):
-        # Exceptions which happen here are printed in the above level, with
-        # or without some extra decoration done here.
-        # XXX would be nice to kick the progress tracker.
-        errors_json =[]
-        try:
-                api_inst.prepare()
-        except (api_errors.PermissionsException, api_errors.UnknownErrors) as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                _error_json("\n" + str(e), errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.TransportError as e:
-                raise e
-        except api_errors.PlanLicenseErrors as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                _error_json(_("\nThe following packages require their "
-                    "licenses to be accepted before they can be installed "
-                    "or updated:\n {0}").format(str(e)),
-                    errors_json=errors_json, errorType="plan_license")
-                return __prepare_json(EXIT_LICENSE, errors=errors_json)
-        except api_errors.InvalidPlanError as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                _error_json("\n" + str(e), errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.ImageFormatUpdateNeeded as e:
-                _format_update_error(e, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.ImageInsufficentSpace as e:
-                _error_json(str(e), errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.LinkedImageException as e:
-                _error_json(str(e), errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except KeyboardInterrupt:
-                raise
-        except Exception as e:
-                _error_json(_("\nAn unexpected error happened while preparing "
-                    "for {op}: {err}").format(op=operation, err=str(e)))
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        return __prepare_json(EXIT_OK)
+    # Exceptions which happen here are printed in the above level, with
+    # or without some extra decoration done here.
+    # XXX would be nice to kick the progress tracker.
+    errors_json = []
+    try:
+        api_inst.prepare()
+    except (api_errors.PermissionsException, api_errors.UnknownErrors) as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        _error_json("\n" + str(e), errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.TransportError as e:
+        raise e
+    except api_errors.PlanLicenseErrors as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        _error_json(
+            _(
+                "\nThe following packages require their "
+                "licenses to be accepted before they can be installed "
+                "or updated:\n {0}"
+            ).format(str(e)),
+            errors_json=errors_json,
+            errorType="plan_license",
+        )
+        return __prepare_json(EXIT_LICENSE, errors=errors_json)
+    except api_errors.InvalidPlanError as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        _error_json("\n" + str(e), errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.ImageFormatUpdateNeeded as e:
+        _format_update_error(e, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.ImageInsufficentSpace as e:
+        _error_json(str(e), errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.LinkedImageException as e:
+        _error_json(str(e), errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except KeyboardInterrupt:
+        raise
+    except Exception as e:
+        _error_json(
+            _(
+                "\nAn unexpected error happened while preparing "
+                "for {op}: {err}"
+            ).format(op=operation, err=str(e))
+        )
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    return __prepare_json(EXIT_OK)
+
 
 def __api_execute_plan(operation, api_inst):
-        rval = None
-        errors_json = []
+    rval = None
+    errors_json = []
+    try:
+        api_inst.execute_plan()
+        pd = api_inst.describe()
+        if pd.actuator_timed_out:
+            rval = __prepare_json(EXIT_ACTUATOR)
+        else:
+            rval = __prepare_json(EXIT_OK)
+    except RuntimeError as e:
+        _error_json(
+            _("{operation} failed: {err}").format(operation=operation, err=e),
+            errors_json=errors_json,
+        )
+        rval = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except (
+        api_errors.InvalidPlanError,
+        api_errors.ActionExecutionError,
+        api_errors.InvalidPackageErrors,
+        api_errors.PlanExclusionError,
+    ) as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        _error_json("\n" + str(e), errors_json=errors_json)
+        rval = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.LinkedImageException as e:
+        _error_json(
+            _(
+                "{operation} failed (linked image exception(s))" ":\n{err}"
+            ).format(operation=operation, err=e),
+            errors_json=errors_json,
+        )
+        rval = __prepare_json(e.lix_exitrv, errors=errors_json)
+    except api_errors.ImageUpdateOnLiveImageException:
+        _error_json(
+            _("{0} cannot be done on live image").format(operation),
+            errors_json=errors_json,
+        )
+        rval = __prepare_json(EXIT_NOTLIVE, errors=errors_json)
+    except api_errors.RebootNeededOnLiveImageException:
+        _error_json(
+            _(
+                'Requested "{0}" operation would affect files '
+                "that cannot be modified in live image.\n"
+                "Please retry this operation on an alternate boot "
+                "environment."
+            ).format(operation),
+            errors_json=errors_json,
+        )
+        rval = __prepare_json(EXIT_NOTLIVE, errors=errors_json)
+    except api_errors.CorruptedIndexException as e:
+        _error_json(
+            "The search index appears corrupted.  Please "
+            "rebuild the index with 'pkg rebuild-index'.",
+            errors_json=errors_json,
+        )
+        rval = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.ProblematicPermissionsIndexException as e:
+        _error_json(str(e), errors_json=errors_json)
+        _error_json(
+            _(
+                "\n(Failure to consistently execute pkg commands "
+                "as a privileged user is often a source of this problem.)"
+            ),
+            errors_json=errors_json,
+        )
+        rval = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except (api_errors.PermissionsException, api_errors.UnknownErrors) as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        _error_json("\n" + str(e), errors_json=errors_json)
+        rval = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.ImageFormatUpdateNeeded as e:
+        _format_update_error(e, errors_json=errors_json)
+        rval = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.BEException as e:
+        _error_json(e, errors_json=errors_json)
+        rval = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.WrapSuccessfulIndexingException:
+        raise
+    except api_errors.ImageInsufficentSpace as e:
+        _error_json(str(e), errors_json=errors_json)
+        rval = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.InvalidMediatorTarget as e:
+        _error_json(str(e), errors_json=errors_json)
+        # An invalid target means the operation completed but
+        # the user needs to consider the state of any image so
+        # return a EXIT_PARTIAL.
+        rval = __prepare_json(EXIT_PARTIAL, errors=errors_json)
+    except Exception as e:
+        _error_json(
+            _(
+                "An unexpected error happened during " "{operation}: {err}"
+            ).format(operation=operation, err=e),
+            errors_json=errors_json,
+        )
+        rval = __prepare_json(EXIT_OOPS, errors=errors_json)
+    finally:
+        exc_type = exc_value = exc_tb = None
+        if rval is None:
+            # Store original exception so that the real cause of
+            # failure can be raised if this fails.
+            exc_type, exc_value, exc_tb = sys.exc_info()
+
         try:
-                api_inst.execute_plan()
-                pd = api_inst.describe()
-                if pd.actuator_timed_out:
-                        rval = __prepare_json(EXIT_ACTUATOR)
-                else:
-                        rval = __prepare_json(EXIT_OK)
-        except RuntimeError as e:
-                _error_json(_("{operation} failed: {err}").format(
-                    operation=operation, err=e), errors_json=errors_json)
-                rval = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except (api_errors.InvalidPlanError,
-            api_errors.ActionExecutionError,
-            api_errors.InvalidPackageErrors,
-            api_errors.PlanExclusionError) as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                _error_json("\n" + str(e), errors_json=errors_json)
-                rval = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except (api_errors.LinkedImageException) as e:
-                _error_json(_("{operation} failed (linked image exception(s))"
-                    ":\n{err}").format(operation=operation, err=e),
-                    errors_json=errors_json)
-                rval = __prepare_json(e.lix_exitrv, errors=errors_json)
-        except api_errors.ImageUpdateOnLiveImageException:
-                _error_json(_("{0} cannot be done on live image").format(
-                    operation), errors_json=errors_json)
-                rval = __prepare_json(EXIT_NOTLIVE, errors=errors_json)
-        except api_errors.RebootNeededOnLiveImageException:
-                _error_json(_("Requested \"{0}\" operation would affect files "
-                    "that cannot be modified in live image.\n"
-                    "Please retry this operation on an alternate boot "
-                    "environment.").format(operation), errors_json=errors_json)
-                rval = __prepare_json(EXIT_NOTLIVE, errors=errors_json)
-        except api_errors.CorruptedIndexException as e:
-                _error_json("The search index appears corrupted.  Please "
-                    "rebuild the index with 'pkg rebuild-index'.",
-                    errors_json=errors_json)
-                rval = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.ProblematicPermissionsIndexException as e:
-                _error_json(str(e), errors_json=errors_json)
-                _error_json(_("\n(Failure to consistently execute pkg commands "
-                    "as a privileged user is often a source of this problem.)"),
-                    errors_json=errors_json)
-                rval = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except (api_errors.PermissionsException, api_errors.UnknownErrors) as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                _error_json("\n" + str(e), errors_json=errors_json)
-                rval = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.ImageFormatUpdateNeeded as e:
-                _format_update_error(e, errors_json=errors_json)
-                rval = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.BEException as e:
-                _error_json(e, errors_json=errors_json)
-                rval = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.WrapSuccessfulIndexingException:
+            salvaged = api_inst.describe().salvaged
+            newbe = api_inst.describe().new_be
+            stat = None
+            if rval:
+                stat = rval["status"]
+            if salvaged and (stat == EXIT_OK or not newbe):
+                # Only show salvaged file list if populated
+                # and operation was successful, or if operation
+                # failed and a new BE was not created for
+                # the operation.
+                err = _(
+                    "\nThe following "
+                    "unexpected or editable files and "
+                    "directories were\n"
+                    "salvaged while executing the requested "
+                    "package operation; they\nhave been moved "
+                    "to the displayed location in the image:\n"
+                )
+                for opath, spath in salvaged:
+                    err += "  {0} -> {1}\n".format(opath, spath)
+                errors_json.append({"info": err})
+        except Exception:
+            if rval is not None:
+                # Only raise exception encountered here if the
+                # exception previously raised was suppressed.
                 raise
-        except api_errors.ImageInsufficentSpace as e:
-                _error_json(str(e), errors_json=errors_json)
-                rval = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.InvalidMediatorTarget as e:
-                _error_json(str(e), errors_json=errors_json)
-                # An invalid target means the operation completed but
-                # the user needs to consider the state of any image so
-                # return a EXIT_PARTIAL.
-                rval = __prepare_json(EXIT_PARTIAL, errors=errors_json)
-        except Exception as e:
-                _error_json(_("An unexpected error happened during "
-                    "{operation}: {err}").format(
-                    operation=operation, err=e), errors_json=errors_json)
-                rval = __prepare_json(EXIT_OOPS, errors=errors_json)
-        finally:
-                exc_type = exc_value = exc_tb = None
-                if rval is None:
-                        # Store original exception so that the real cause of
-                        # failure can be raised if this fails.
-                        exc_type, exc_value, exc_tb = sys.exc_info()
 
-                try:
-                        salvaged = api_inst.describe().salvaged
-                        newbe = api_inst.describe().new_be
-                        stat = None
-                        if rval:
-                                stat = rval["status"]
-                        if salvaged and (stat == EXIT_OK or not newbe):
-                                # Only show salvaged file list if populated
-                                # and operation was successful, or if operation
-                                # failed and a new BE was not created for
-                                # the operation.
-                                err = _("\nThe following "
-                                    "unexpected or editable files and "
-                                    "directories were\n"
-                                    "salvaged while executing the requested "
-                                    "package operation; they\nhave been moved "
-                                    "to the displayed location in the image:\n")
-                                for opath, spath in salvaged:
-                                        err += "  {0} -> {1}\n".format(opath,
-                                            spath)
-                                errors_json.append({"info": err})
-                except Exception:
-                        if rval is not None:
-                                # Only raise exception encountered here if the
-                                # exception previously raised was suppressed.
-                                raise
+        if exc_value or exc_tb:
+            if six.PY2:
+                six.reraise(exc_value, None, exc_tb)
+            else:
+                raise exc_value
 
-                if exc_value or exc_tb:
-                        if six.PY2:
-                                six.reraise(exc_value, None, exc_tb)
-                        else:
-                                raise exc_value
+    return rval
 
-        return rval
 
-def __api_plan_exception(op, noexecute, verbose, api_inst, errors_json=[],
-    display_plan_cb=None):
-        e_type, e, e_traceback = sys.exc_info()
+def __api_plan_exception(
+    op, noexecute, verbose, api_inst, errors_json=[], display_plan_cb=None
+):
+    e_type, e, e_traceback = sys.exc_info()
 
-        if e_type == api_errors.ImageNotFoundException:
-                _error_json(_("No image rooted at '{0}'").format(e.user_dir),
-                    cmd=op, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        if e_type == api_errors.ImageLockingFailedError:
-                _error_json(_(e), cmd=op, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        if e_type == api_errors.InventoryException:
-                _error_json("\n" + _("{operation} failed (inventory exception):\n"
-                    "{err}").format(operation=op, err=e),
-                    errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        if isinstance(e, api_errors.LinkedImageException):
-                _error_json(_("{operation} failed (linked image exception(s)):\n"
-                    "{err}").format(operation=op, err=e),
-                    errors_json=errors_json)
-                return __prepare_json(e.lix_exitrv, errors=errors_json)
-        if e_type == api_errors.IpkgOutOfDateException:
-                error ={"info": _("""\
+    if e_type == api_errors.ImageNotFoundException:
+        _error_json(
+            _("No image rooted at '{0}'").format(e.user_dir),
+            cmd=op,
+            errors_json=errors_json,
+        )
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    if e_type == api_errors.ImageLockingFailedError:
+        _error_json(_(e), cmd=op, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    if e_type == api_errors.InventoryException:
+        _error_json(
+            "\n"
+            + _("{operation} failed (inventory exception):\n" "{err}").format(
+                operation=op, err=e
+            ),
+            errors_json=errors_json,
+        )
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    if isinstance(e, api_errors.LinkedImageException):
+        _error_json(
+            _(
+                "{operation} failed (linked image exception(s)):\n" "{err}"
+            ).format(operation=op, err=e),
+            errors_json=errors_json,
+        )
+        return __prepare_json(e.lix_exitrv, errors=errors_json)
+    if e_type == api_errors.IpkgOutOfDateException:
+        error = {
+            "info": _(
+                """\
 WARNING: pkg(7) appears to be out of date, and should be updated before
 running {op}.  Please update pkg(7) by executing 'pkg install
 pkg:/package/pkg' as a privileged user and then retry the {op}."""
-                    ).format(**locals())}
-                errors_json.append(error)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        if e_type == api_errors.CatalogRefreshException:
-                _collect_catalog_failures(e, errors=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        if e_type == api_errors.ConflictingActionErrors or \
-            e_type == api_errors.ImageBoundaryErrors:
-                if verbose and display_plan_cb:
-                        display_plan_cb(api_inst, verbose=verbose,
-                            noexecute=noexecute, plan_only=True)
-                _error_json("\n" + str(e), cmd=op, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        if e_type == api_errors.ImageFormatUpdateNeeded:
-                _format_update_error(e, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
+            ).format(**locals())
+        }
+        errors_json.append(error)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    if e_type == api_errors.CatalogRefreshException:
+        _collect_catalog_failures(e, errors=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    if (
+        e_type == api_errors.ConflictingActionErrors
+        or e_type == api_errors.ImageBoundaryErrors
+    ):
+        if verbose and display_plan_cb:
+            display_plan_cb(
+                api_inst, verbose=verbose, noexecute=noexecute, plan_only=True
+            )
+        _error_json("\n" + str(e), cmd=op, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    if e_type == api_errors.ImageFormatUpdateNeeded:
+        _format_update_error(e, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
 
-        if e_type == api_errors.ImageUpdateOnLiveImageException:
-                _error_json("\n" + _("The proposed operation cannot be "
-                    "performed on a live image."), cmd=op,
-                    errors_json=errors_json)
-                return __prepare_json(EXIT_NOTLIVE, errors=errors_json)
+    if e_type == api_errors.ImageUpdateOnLiveImageException:
+        _error_json(
+            "\n"
+            + _(
+                "The proposed operation cannot be " "performed on a live image."
+            ),
+            cmd=op,
+            errors_json=errors_json,
+        )
+        return __prepare_json(EXIT_NOTLIVE, errors=errors_json)
 
-        if issubclass(e_type, api_errors.BEException):
-                _error_json("\n" + str(e), cmd=op, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
+    if issubclass(e_type, api_errors.BEException):
+        _error_json("\n" + str(e), cmd=op, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
 
-        if e_type == api_errors.PlanCreationException:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                txt = str(e)
-                if e.multiple_matches:
-                        txt += "\n\n" + _("Please provide one of the package "
-                            "FMRIs listed above to the install command.")
-                _error_json("\n" + txt, cmd=op, errors_json=errors_json)
-                if verbose:
-                        err_txt = "\n".join(e.verbose_info)
-                        if err_txt:
-                                errors_json.append({"reason": err_txt})
-                if e.invalid_mediations:
-                        # Bad user input for mediation.
-                        return __prepare_json(EXIT_BADOPT, errors=errors_json)
-                if e.no_solution:
-                        return __prepare_json(EXIT_CONSTRAINED, errors=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
+    if e_type == api_errors.PlanCreationException:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        txt = str(e)
+        if e.multiple_matches:
+            txt += "\n\n" + _(
+                "Please provide one of the package "
+                "FMRIs listed above to the install command."
+            )
+        _error_json("\n" + txt, cmd=op, errors_json=errors_json)
+        if verbose:
+            err_txt = "\n".join(e.verbose_info)
+            if err_txt:
+                errors_json.append({"reason": err_txt})
+        if e.invalid_mediations:
+            # Bad user input for mediation.
+            return __prepare_json(EXIT_BADOPT, errors=errors_json)
+        if e.no_solution:
+            return __prepare_json(EXIT_CONSTRAINED, errors=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
 
-        if isinstance(e, (api_errors.CertificateError,
+    if isinstance(
+        e,
+        (
+            api_errors.CertificateError,
             api_errors.UnknownErrors,
             api_errors.PermissionsException,
             api_errors.InvalidPropertyValue,
@@ -1183,2202 +1379,2788 @@ pkg:/package/pkg' as a privileged user and then retry the {op}."""
             api_errors.ActionExecutionError,
             api_errors.InvalidPackageErrors,
             api_errors.ImageBoundaryErrors,
-            api_errors.InvalidVarcetNames)):
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                _error_json("\n" + str(e), cmd=op, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
+            api_errors.InvalidVarcetNames,
+        ),
+    ):
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        _error_json("\n" + str(e), cmd=op, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
 
-        # if we didn't deal with the exception above, pass it on.
-        raise
-        # NOTREACHED
+    # if we didn't deal with the exception above, pass it on.
+    raise
+    # NOTREACHED
 
-def __api_plan(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
-    _omit_headers=False, _origins=None, _parsable_version=None, _quiet=False,
-    _quiet_plan=False, _review_release_notes=False, _show_licenses=False,
-    _stage=API_STAGE_DEFAULT, _verbose=0, display_plan_cb=None, logger=None,
-    _unpackaged=False, _unpackaged_only=False, _verify_paths=EmptyI, **kwargs):
 
-        # All the api interface functions that we invoke have some
-        # common arguments.  Set those up now.
-        if _op not in (PKG_OP_REVERT, PKG_OP_FIX, PKG_OP_VERIFY,
-            PKG_OP_DEHYDRATE, PKG_OP_REHYDRATE):
-                kwargs["li_ignore"] = _li_ignore
-        if _op == PKG_OP_VERIFY:
-                kwargs["unpackaged"] = _unpackaged
-                kwargs["unpackaged_only"] = _unpackaged_only
-                kwargs["verify_paths"] = _verify_paths
-        elif _op == PKG_OP_FIX:
-                kwargs["unpackaged"] = _unpackaged
+def __api_plan(
+    _op,
+    _api_inst,
+    _accept=False,
+    _li_ignore=None,
+    _noexecute=False,
+    _omit_headers=False,
+    _origins=None,
+    _parsable_version=None,
+    _quiet=False,
+    _quiet_plan=False,
+    _review_release_notes=False,
+    _show_licenses=False,
+    _stage=API_STAGE_DEFAULT,
+    _verbose=0,
+    display_plan_cb=None,
+    logger=None,
+    _unpackaged=False,
+    _unpackaged_only=False,
+    _verify_paths=EmptyI,
+    **kwargs,
+):
+    # All the api interface functions that we invoke have some
+    # common arguments.  Set those up now.
+    if _op not in (
+        PKG_OP_REVERT,
+        PKG_OP_FIX,
+        PKG_OP_VERIFY,
+        PKG_OP_DEHYDRATE,
+        PKG_OP_REHYDRATE,
+    ):
+        kwargs["li_ignore"] = _li_ignore
+    if _op == PKG_OP_VERIFY:
+        kwargs["unpackaged"] = _unpackaged
+        kwargs["unpackaged_only"] = _unpackaged_only
+        kwargs["verify_paths"] = _verify_paths
+    elif _op == PKG_OP_FIX:
+        kwargs["unpackaged"] = _unpackaged
 
-        kwargs["noexecute"] = _noexecute
-        if _origins:
-                kwargs["repos"] = _origins
-        if _stage != API_STAGE_DEFAULT:
-                kwargs["pubcheck"] = False
+    kwargs["noexecute"] = _noexecute
+    if _origins:
+        kwargs["repos"] = _origins
+    if _stage != API_STAGE_DEFAULT:
+        kwargs["pubcheck"] = False
 
-        # display plan debugging information
-        if _verbose > 2:
-                DebugValues.set_value("plan", "True")
+    # display plan debugging information
+    if _verbose > 2:
+        DebugValues.set_value("plan", "True")
 
-        # plan the requested operation
-        stuff_to_do = None
+    # plan the requested operation
+    stuff_to_do = None
 
-        if _op == PKG_OP_ATTACH:
-                api_plan_func = _api_inst.gen_plan_attach
-        elif _op in [PKG_OP_CHANGE_FACET, PKG_OP_CHANGE_VARIANT]:
-                api_plan_func = _api_inst.gen_plan_change_varcets
-        elif _op == PKG_OP_DEHYDRATE:
-                api_plan_func = _api_inst.gen_plan_dehydrate
-        elif _op == PKG_OP_DETACH:
-                api_plan_func = _api_inst.gen_plan_detach
-        elif _op == PKG_OP_EXACT_INSTALL:
-                api_plan_func = _api_inst.gen_plan_exact_install
-        elif _op == PKG_OP_FIX:
-                api_plan_func = _api_inst.gen_plan_fix
-        elif _op == PKG_OP_INSTALL:
-                api_plan_func = _api_inst.gen_plan_install
-        elif _op == PKG_OP_REHYDRATE:
-                api_plan_func = _api_inst.gen_plan_rehydrate
-        elif _op == PKG_OP_REVERT:
-                api_plan_func = _api_inst.gen_plan_revert
-        elif _op == PKG_OP_SYNC:
-                api_plan_func = _api_inst.gen_plan_sync
-        elif _op == PKG_OP_UNINSTALL:
-                api_plan_func = _api_inst.gen_plan_uninstall
-        elif _op == PKG_OP_UPDATE:
-                api_plan_func = _api_inst.gen_plan_update
-        elif _op == PKG_OP_VERIFY:
-                api_plan_func = _api_inst.gen_plan_verify
-        else:
-                raise RuntimeError("__api_plan() invalid op: {0}".format(_op))
+    if _op == PKG_OP_ATTACH:
+        api_plan_func = _api_inst.gen_plan_attach
+    elif _op in [PKG_OP_CHANGE_FACET, PKG_OP_CHANGE_VARIANT]:
+        api_plan_func = _api_inst.gen_plan_change_varcets
+    elif _op == PKG_OP_DEHYDRATE:
+        api_plan_func = _api_inst.gen_plan_dehydrate
+    elif _op == PKG_OP_DETACH:
+        api_plan_func = _api_inst.gen_plan_detach
+    elif _op == PKG_OP_EXACT_INSTALL:
+        api_plan_func = _api_inst.gen_plan_exact_install
+    elif _op == PKG_OP_FIX:
+        api_plan_func = _api_inst.gen_plan_fix
+    elif _op == PKG_OP_INSTALL:
+        api_plan_func = _api_inst.gen_plan_install
+    elif _op == PKG_OP_REHYDRATE:
+        api_plan_func = _api_inst.gen_plan_rehydrate
+    elif _op == PKG_OP_REVERT:
+        api_plan_func = _api_inst.gen_plan_revert
+    elif _op == PKG_OP_SYNC:
+        api_plan_func = _api_inst.gen_plan_sync
+    elif _op == PKG_OP_UNINSTALL:
+        api_plan_func = _api_inst.gen_plan_uninstall
+    elif _op == PKG_OP_UPDATE:
+        api_plan_func = _api_inst.gen_plan_update
+    elif _op == PKG_OP_VERIFY:
+        api_plan_func = _api_inst.gen_plan_verify
+    else:
+        raise RuntimeError("__api_plan() invalid op: {0}".format(_op))
 
-        errors_json = []
-        planned_self = False
-        child_plans = []
-        try:
-                for pd in api_plan_func(**kwargs):
-                        if planned_self:
-                                # we don't display anything for child images
-                                # since they currently do their own display
-                                # work (unless parsable output is requested).
-                                child_plans.append(pd)
-                                continue
+    errors_json = []
+    planned_self = False
+    child_plans = []
+    try:
+        for pd in api_plan_func(**kwargs):
+            if planned_self:
+                # we don't display anything for child images
+                # since they currently do their own display
+                # work (unless parsable output is requested).
+                child_plans.append(pd)
+                continue
 
-                        # the first plan description is always for ourself.
-                        planned_self = True
-                        pkg_timer.record("planning", logger=logger)
+            # the first plan description is always for ourself.
+            planned_self = True
+            pkg_timer.record("planning", logger=logger)
 
-                        # if we're in parsable mode don't display anything
-                        # until after we finish planning for all children
-                        if _parsable_version is None and display_plan_cb:
-                                display_plan_cb(_api_inst, [], _noexecute,
-                                    _omit_headers, _op, _parsable_version,
-                                    _quiet, _quiet_plan, _show_licenses,
-                                    _stage, _verbose, _unpackaged,
-                                    _unpackaged_only)
+            # if we're in parsable mode don't display anything
+            # until after we finish planning for all children
+            if _parsable_version is None and display_plan_cb:
+                display_plan_cb(
+                    _api_inst,
+                    [],
+                    _noexecute,
+                    _omit_headers,
+                    _op,
+                    _parsable_version,
+                    _quiet,
+                    _quiet_plan,
+                    _show_licenses,
+                    _stage,
+                    _verbose,
+                    _unpackaged,
+                    _unpackaged_only,
+                )
 
-                        # if requested accept licenses for child images.  we
-                        # have to do this before recursing into children.
-                        if _accept:
-                                _accept_plan_licenses(_api_inst)
-        except:
-                ret = __api_plan_exception(_op, _noexecute, _verbose,
-                    _api_inst, errors_json=errors_json,
-                    display_plan_cb=display_plan_cb)
-                if ret["status"] != EXIT_OK:
-                        pkg_timer.record("planning", logger=logger)
-                        return ret
-
-        if not planned_self:
-                # if we got an exception we didn't do planning for children
-                pkg_timer.record("planning", logger=logger)
-
-        elif _api_inst.isparent(_li_ignore):
-                # if we didn't get an exception and we're a parent image then
-                # we should have done planning for child images.
-                pkg_timer.record("planning children", logger=logger)
-
-        # if we didn't display our own plan (due to an exception), or if we're
-        # in parsable mode, then display our plan now.
-        parsable_plan = None
-        if not planned_self or _parsable_version is not None:
-                try:
-                        if display_plan_cb:
-                                display_plan_cb(_api_inst, child_plans,
-                                    _noexecute, _omit_headers, _op,
-                                    _parsable_version, _quiet, _quiet_plan,
-                                    _show_licenses, _stage, _verbose,
-                                    _unpackaged, _unpackaged_only)
-                        else:
-                                plan = _api_inst.describe()
-                                parsable_plan =plan.get_parsable_plan(
-                                    _parsable_version, child_plans,
-                                    api_inst=_api_inst)
-                                # Convert to json.
-                                parsable_plan = json.loads(json.dumps(
-                                    parsable_plan))
-                except api_errors.ApiException as e:
-                        _error_json(e, cmd=_op, errors_json=errors_json)
-                        return __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        # if we didn't accept licenses (due to an exception) then do that now.
-        if not planned_self and _accept:
+            # if requested accept licenses for child images.  we
+            # have to do this before recursing into children.
+            if _accept:
                 _accept_plan_licenses(_api_inst)
+    except:
+        ret = __api_plan_exception(
+            _op,
+            _noexecute,
+            _verbose,
+            _api_inst,
+            errors_json=errors_json,
+            display_plan_cb=display_plan_cb,
+        )
+        if ret["status"] != EXIT_OK:
+            pkg_timer.record("planning", logger=logger)
+            return ret
 
-        data = {}
-        if parsable_plan:
-                data["plan"] = parsable_plan
+    if not planned_self:
+        # if we got an exception we didn't do planning for children
+        pkg_timer.record("planning", logger=logger)
 
-        return __prepare_json(EXIT_OK, data=data)
+    elif _api_inst.isparent(_li_ignore):
+        # if we didn't get an exception and we're a parent image then
+        # we should have done planning for child images.
+        pkg_timer.record("planning children", logger=logger)
+
+    # if we didn't display our own plan (due to an exception), or if we're
+    # in parsable mode, then display our plan now.
+    parsable_plan = None
+    if not planned_self or _parsable_version is not None:
+        try:
+            if display_plan_cb:
+                display_plan_cb(
+                    _api_inst,
+                    child_plans,
+                    _noexecute,
+                    _omit_headers,
+                    _op,
+                    _parsable_version,
+                    _quiet,
+                    _quiet_plan,
+                    _show_licenses,
+                    _stage,
+                    _verbose,
+                    _unpackaged,
+                    _unpackaged_only,
+                )
+            else:
+                plan = _api_inst.describe()
+                parsable_plan = plan.get_parsable_plan(
+                    _parsable_version, child_plans, api_inst=_api_inst
+                )
+                # Convert to json.
+                parsable_plan = json.loads(json.dumps(parsable_plan))
+        except api_errors.ApiException as e:
+            _error_json(e, cmd=_op, errors_json=errors_json)
+            return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    # if we didn't accept licenses (due to an exception) then do that now.
+    if not planned_self and _accept:
+        _accept_plan_licenses(_api_inst)
+
+    data = {}
+    if parsable_plan:
+        data["plan"] = parsable_plan
+
+    return __prepare_json(EXIT_OK, data=data)
+
 
 def __api_plan_file(api_inst):
-        """Return the path to the PlanDescription save file."""
+    """Return the path to the PlanDescription save file."""
 
-        plandir = api_inst.img_plandir
-        return os.path.join(plandir, "plandesc")
+    plandir = api_inst.img_plandir
+    return os.path.join(plandir, "plandesc")
+
 
 def __api_plan_save(api_inst, logger=None):
-        """Save an image plan to a file."""
+    """Save an image plan to a file."""
 
-        # get a pointer to the plan
-        plan = api_inst.describe()
+    # get a pointer to the plan
+    plan = api_inst.describe()
 
-        # save the PlanDescription to a file
-        path = __api_plan_file(api_inst)
-        oflags = os.O_CREAT | os.O_TRUNC | os.O_WRONLY
-        try:
-                fd = os.open(path, oflags, 0o644)
-                with os.fdopen(fd, "w") as fobj:
-                        plan._save(fobj)
+    # save the PlanDescription to a file
+    path = __api_plan_file(api_inst)
+    oflags = os.O_CREAT | os.O_TRUNC | os.O_WRONLY
+    try:
+        fd = os.open(path, oflags, 0o644)
+        with os.fdopen(fd, "w") as fobj:
+            plan._save(fobj)
 
-                # cleanup any old style imageplan save files
-                for f in os.listdir(api_inst.img_plandir):
-                        path = os.path.join(api_inst.img_plandir, f)
-                        if re.search(r"^actions\.[0-9]+\.json$", f):
-                                os.unlink(path)
-                        if re.search(r"^pkgs\.[0-9]+\.json$", f):
-                                os.unlink(path)
-        except OSError as e:
-                raise api_errors._convert_error(e)
+        # cleanup any old style imageplan save files
+        for f in os.listdir(api_inst.img_plandir):
+            path = os.path.join(api_inst.img_plandir, f)
+            if re.search(r"^actions\.[0-9]+\.json$", f):
+                os.unlink(path)
+            if re.search(r"^pkgs\.[0-9]+\.json$", f):
+                os.unlink(path)
+    except OSError as e:
+        raise api_errors._convert_error(e)
 
-        pkg_timer.record("saving plan", logger=logger)
+    pkg_timer.record("saving plan", logger=logger)
+
 
 def __api_plan_load(api_inst, stage, origins, logger=None):
-        """Loan an image plan from a file."""
+    """Loan an image plan from a file."""
 
-        # load an existing plan
-        path = __api_plan_file(api_inst)
-        plan = api.PlanDescription()
-        try:
-                with open(path) as fobj:
-                        plan._load(fobj)
-        except OSError as e:
-                raise api_errors._convert_error(e)
+    # load an existing plan
+    path = __api_plan_file(api_inst)
+    plan = api.PlanDescription()
+    try:
+        with open(path) as fobj:
+            plan._load(fobj)
+    except OSError as e:
+        raise api_errors._convert_error(e)
 
-        pkg_timer.record("loading plan", logger=logger)
+    pkg_timer.record("loading plan", logger=logger)
 
-        api_inst.reset()
-        api_inst.set_alt_repos(origins)
-        api_inst.load_plan(plan, prepared=(stage == API_STAGE_EXECUTE))
-        pkg_timer.record("re-initializing plan", logger=logger)
+    api_inst.reset()
+    api_inst.set_alt_repos(origins)
+    api_inst.load_plan(plan, prepared=(stage == API_STAGE_EXECUTE))
+    pkg_timer.record("re-initializing plan", logger=logger)
 
-        if stage == API_STAGE_EXECUTE:
-                __api_plan_delete(api_inst)
+    if stage == API_STAGE_EXECUTE:
+        __api_plan_delete(api_inst)
+
 
 def __api_plan_delete(api_inst):
-        """Delete an image plan file."""
+    """Delete an image plan file."""
 
-        path = __api_plan_file(api_inst)
-        try:
-                os.unlink(path)
-        except OSError as e:
-                raise api_errors._convert_error(e)
+    path = __api_plan_file(api_inst)
+    try:
+        os.unlink(path)
+    except OSError as e:
+        raise api_errors._convert_error(e)
+
 
 def __verify_exit_status(api_inst):
-        """Determine verify exit status."""
+    """Determine verify exit status."""
 
-        plan = api_inst.describe()
-        for item_id, parent_id, msg_time, msg_level, msg_type, msg_text in \
-            plan.gen_item_messages():
-                if msg_level == MSG_ERROR:
-                        return EXIT_OOPS
-        return EXIT_OK
+    plan = api_inst.describe()
+    for (
+        item_id,
+        parent_id,
+        msg_time,
+        msg_level,
+        msg_type,
+        msg_text,
+    ) in plan.gen_item_messages():
+        if msg_level == MSG_ERROR:
+            return EXIT_OOPS
+    return EXIT_OK
 
-def __api_op(_op, _api_inst, _accept=False, _li_ignore=None, _noexecute=False,
-    _origins=None, _parsable_version=None, _quiet=False, _quiet_plan=False,
-    _review_release_notes=False, _show_licenses=False,
-    _stage=API_STAGE_DEFAULT, _verbose=0,
-    _unpackaged=False, _unpackaged_only=False, _verify_paths=EmptyI,
-    display_plan_cb=None, logger=None,
-    **kwargs):
-        """Do something that involves the api.
 
-        Arguments prefixed with '_' are primarily used within this
-        function.  All other arguments must be specified via keyword
-        assignment and will be passed directly on to the api
-        interfaces being invoked."""
+def __api_op(
+    _op,
+    _api_inst,
+    _accept=False,
+    _li_ignore=None,
+    _noexecute=False,
+    _origins=None,
+    _parsable_version=None,
+    _quiet=False,
+    _quiet_plan=False,
+    _review_release_notes=False,
+    _show_licenses=False,
+    _stage=API_STAGE_DEFAULT,
+    _verbose=0,
+    _unpackaged=False,
+    _unpackaged_only=False,
+    _verify_paths=EmptyI,
+    display_plan_cb=None,
+    logger=None,
+    **kwargs,
+):
+    """Do something that involves the api.
 
-        data = {}
-        if _stage in [API_STAGE_DEFAULT, API_STAGE_PLAN]:
-                # create a new plan
-                ret = __api_plan(_op=_op, _api_inst=_api_inst,
-                    _accept=_accept, _li_ignore=_li_ignore,
-                    _noexecute=_noexecute, _origins=_origins,
-                    _parsable_version=_parsable_version, _quiet=_quiet,
-                    _review_release_notes=_review_release_notes,
-                    _show_licenses=_show_licenses, _stage=_stage,
-                    _verbose=_verbose, _quiet_plan=_quiet_plan,
-                    _unpackaged=_unpackaged, _unpackaged_only=_unpackaged_only,
-                    _verify_paths=_verify_paths, display_plan_cb=display_plan_cb,
-                    logger=logger, **kwargs)
+    Arguments prefixed with '_' are primarily used within this
+    function.  All other arguments must be specified via keyword
+    assignment and will be passed directly on to the api
+    interfaces being invoked."""
 
-                if "_failures" in _api_inst._img.transport.repo_status:
-                        ret.setdefault("data", {}).update(
-                            {"repo_status":
-                            _api_inst._img.transport.repo_status})
+    data = {}
+    if _stage in [API_STAGE_DEFAULT, API_STAGE_PLAN]:
+        # create a new plan
+        ret = __api_plan(
+            _op=_op,
+            _api_inst=_api_inst,
+            _accept=_accept,
+            _li_ignore=_li_ignore,
+            _noexecute=_noexecute,
+            _origins=_origins,
+            _parsable_version=_parsable_version,
+            _quiet=_quiet,
+            _review_release_notes=_review_release_notes,
+            _show_licenses=_show_licenses,
+            _stage=_stage,
+            _verbose=_verbose,
+            _quiet_plan=_quiet_plan,
+            _unpackaged=_unpackaged,
+            _unpackaged_only=_unpackaged_only,
+            _verify_paths=_verify_paths,
+            display_plan_cb=display_plan_cb,
+            logger=logger,
+            **kwargs,
+        )
 
-                if ret["status"] != EXIT_OK:
-                        return ret
-                if "data" in ret:
-                        data.update(ret["data"])
+        if "_failures" in _api_inst._img.transport.repo_status:
+            ret.setdefault("data", {}).update(
+                {"repo_status": _api_inst._img.transport.repo_status}
+            )
 
-                if not _noexecute and _stage == API_STAGE_PLAN:
-                        # We always save the plan, even if it is a noop.  We
-                        # do this because we want to be able to verify that we
-                        # can load and execute a noop plan.  (This mimics
-                        # normal api behavior which doesn't prevent an api
-                        # consumer from creating a noop plan and then
-                        # preparing and executing it.)
-                        __api_plan_save(_api_inst, logger=logger)
-                # for pkg verify or fix.
-                if _op in [PKG_OP_FIX, PKG_OP_VERIFY] and _noexecute and \
-                    _quiet_plan:
-                        exit_code = __verify_exit_status(_api_inst)
-                        return __prepare_json(exit_code, data=data)
-                if _api_inst.planned_nothingtodo():
-                        return __prepare_json(EXIT_NOP, data=data)
-                if _noexecute or _stage == API_STAGE_PLAN:
-                        return __prepare_json(EXIT_OK, data=data)
+        if ret["status"] != EXIT_OK:
+            return ret
+        if "data" in ret:
+            data.update(ret["data"])
+
+        if not _noexecute and _stage == API_STAGE_PLAN:
+            # We always save the plan, even if it is a noop.  We
+            # do this because we want to be able to verify that we
+            # can load and execute a noop plan.  (This mimics
+            # normal api behavior which doesn't prevent an api
+            # consumer from creating a noop plan and then
+            # preparing and executing it.)
+            __api_plan_save(_api_inst, logger=logger)
+        # for pkg verify or fix.
+        if _op in [PKG_OP_FIX, PKG_OP_VERIFY] and _noexecute and _quiet_plan:
+            exit_code = __verify_exit_status(_api_inst)
+            return __prepare_json(exit_code, data=data)
+        if _api_inst.planned_nothingtodo():
+            return __prepare_json(EXIT_NOP, data=data)
+        if _noexecute or _stage == API_STAGE_PLAN:
+            return __prepare_json(EXIT_OK, data=data)
+    else:
+        assert _stage in [API_STAGE_PREPARE, API_STAGE_EXECUTE]
+        __api_plan_load(_api_inst, _stage, _origins, logger=logger)
+
+    # Exceptions which happen here are printed in the above level,
+    # with or without some extra decoration done here.
+    if _stage in [API_STAGE_DEFAULT, API_STAGE_PREPARE]:
+        ret = __api_prepare_plan(_op, _api_inst)
+        pkg_timer.record("preparing", logger=logger)
+
+        if ret["status"] != EXIT_OK:
+            return ret
+        if _stage == API_STAGE_PREPARE:
+            return __prepare_json(EXIT_OK, data=data)
+
+    ret = __api_execute_plan(_op, _api_inst)
+    pkg_timer.record("executing", logger=logger)
+
+    if (
+        _review_release_notes
+        and ret["status"] == EXIT_OK
+        and _stage == API_STAGE_DEFAULT
+        and _api_inst.solaris_image()
+    ):
+        data["release_notes_url"] = misc.get_release_notes_url()
+        ret = __prepare_json(EXIT_OK, data=data)
+    elif ret["status"] == EXIT_OK and data:
+        ret = __prepare_json(EXIT_OK, data=data)
+
+    return ret
+
+
+def _exact_install(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    li_ignore,
+    li_parent_sync,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    update_index,
+    verbose,
+    display_plan_cb=None,
+    logger=None,
+):
+    errors_json = []
+    if not pargs:
+        error = {"reason": _("at least one package name required")}
+        errors_json.append(error)
+        return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
+
+    rval, res = _get_fmri_args(api_inst, pargs, cmd=op, errors_json=errors_json)
+    if not rval:
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    xrval, xres = _get_fmri_args(
+        api_inst, reject_pats, cmd=op, errors_json=errors_json
+    )
+    if not xrval:
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    return __api_op(
+        op,
+        api_inst,
+        _accept=accept,
+        _li_ignore=li_ignore,
+        _noexecute=noexecute,
+        _origins=origins,
+        _quiet=quiet,
+        _show_licenses=show_licenses,
+        _verbose=verbose,
+        backup_be=backup_be,
+        backup_be_name=backup_be_name,
+        be_activate=be_activate,
+        be_name=be_name,
+        li_parent_sync=li_parent_sync,
+        new_be=new_be,
+        _parsable_version=parsable_version,
+        pkgs_inst=pargs,
+        refresh_catalogs=refresh_catalogs,
+        reject_list=reject_pats,
+        update_index=update_index,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
+
+
+def _install(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    act_timeout,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    li_ignore,
+    li_erecurse,
+    li_parent_sync,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    stage,
+    update_index,
+    verbose,
+    display_plan_cb=None,
+    logger=None,
+):
+    """Attempt to take package specified to INSTALLED state.  The operands
+    are interpreted as glob patterns."""
+
+    errors_json = []
+    if not pargs:
+        error = {"reason": _("at least one package name required")}
+        errors_json.append(error)
+        return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
+
+    rval, res = _get_fmri_args(api_inst, pargs, cmd=op, errors_json=errors_json)
+    if not rval:
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    xrval, xres = _get_fmri_args(
+        api_inst, reject_pats, cmd=op, errors_json=errors_json
+    )
+    if not xrval:
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    return __api_op(
+        op,
+        api_inst,
+        _accept=accept,
+        _li_ignore=li_ignore,
+        _noexecute=noexecute,
+        _origins=origins,
+        _parsable_version=parsable_version,
+        _quiet=quiet,
+        _show_licenses=show_licenses,
+        _stage=stage,
+        _verbose=verbose,
+        act_timeout=act_timeout,
+        backup_be=backup_be,
+        backup_be_name=backup_be_name,
+        be_activate=be_activate,
+        be_name=be_name,
+        li_erecurse=li_erecurse,
+        li_parent_sync=li_parent_sync,
+        new_be=new_be,
+        pkgs_inst=pargs,
+        refresh_catalogs=refresh_catalogs,
+        reject_list=reject_pats,
+        update_index=update_index,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
+
+
+def _update(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    act_timeout,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    force,
+    ignore_missing,
+    li_ignore,
+    li_erecurse,
+    li_parent_sync,
+    new_be,
+    noexecute,
+    origins,
+    parsable_version,
+    quiet,
+    refresh_catalogs,
+    reject_pats,
+    show_licenses,
+    stage,
+    update_index,
+    verbose,
+    display_plan_cb=None,
+    logger=None,
+):
+    """Attempt to take all installed packages specified to latest
+    version."""
+
+    errors_json = []
+    rval, res = _get_fmri_args(api_inst, pargs, cmd=op, errors_json=errors_json)
+    if not rval:
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    xrval, xres = _get_fmri_args(
+        api_inst, reject_pats, cmd=op, errors_json=errors_json
+    )
+    if not xrval:
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    if res:
+        # If there are specific installed packages to update,
+        # then take only those packages to the latest version
+        # allowed by the patterns specified.  (The versions
+        # specified can be older than what is installed.)
+        pkgs_update = pargs
+        review_release_notes = False
+    else:
+        # If no packages were specified, attempt to update all
+        # installed packages.
+        pkgs_update = None
+        review_release_notes = True
+
+    return __api_op(
+        op,
+        api_inst,
+        _accept=accept,
+        _li_ignore=li_ignore,
+        _noexecute=noexecute,
+        _origins=origins,
+        _parsable_version=parsable_version,
+        _quiet=quiet,
+        _review_release_notes=review_release_notes,
+        _show_licenses=show_licenses,
+        _stage=stage,
+        _verbose=verbose,
+        act_timeout=act_timeout,
+        backup_be=backup_be,
+        backup_be_name=backup_be_name,
+        be_activate=be_activate,
+        be_name=be_name,
+        force=force,
+        ignore_missing=ignore_missing,
+        li_erecurse=li_erecurse,
+        li_parent_sync=li_parent_sync,
+        new_be=new_be,
+        pkgs_update=pkgs_update,
+        refresh_catalogs=refresh_catalogs,
+        reject_list=reject_pats,
+        update_index=update_index,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
+
+
+def _uninstall(
+    op,
+    api_inst,
+    pargs,
+    act_timeout,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    ignore_missing,
+    li_ignore,
+    li_erecurse,
+    li_parent_sync,
+    new_be,
+    noexecute,
+    parsable_version,
+    quiet,
+    stage,
+    update_index,
+    verbose,
+    display_plan_cb=None,
+    logger=None,
+):
+    """Attempt to take package specified to DELETED state."""
+
+    errors_json = []
+    if not pargs:
+        error = {"reason": _("at least one package name required")}
+        errors_json.append(error)
+        return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
+
+    rval, res = _get_fmri_args(api_inst, pargs, cmd=op, errors_json=errors_json)
+    if not rval:
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    return __api_op(
+        op,
+        api_inst,
+        _li_ignore=li_ignore,
+        _noexecute=noexecute,
+        _parsable_version=parsable_version,
+        _quiet=quiet,
+        _stage=stage,
+        _verbose=verbose,
+        act_timeout=act_timeout,
+        backup_be=backup_be,
+        backup_be_name=backup_be_name,
+        be_activate=be_activate,
+        be_name=be_name,
+        ignore_missing=ignore_missing,
+        li_erecurse=li_erecurse,
+        li_parent_sync=li_parent_sync,
+        new_be=new_be,
+        pkgs_to_uninstall=pargs,
+        update_index=update_index,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
+
+
+def _publisher_set(
+    op,
+    api_inst,
+    pargs,
+    ssl_key,
+    ssl_cert,
+    origin_uri,
+    reset_uuid,
+    add_mirrors,
+    remove_mirrors,
+    add_origins,
+    remove_origins,
+    enable_origins,
+    disable_origins,
+    refresh_allowed,
+    disable,
+    sticky,
+    search_before,
+    search_after,
+    search_first,
+    approved_ca_certs,
+    revoked_ca_certs,
+    unset_ca_certs,
+    set_props,
+    add_prop_values,
+    remove_prop_values,
+    unset_props,
+    repo_uri,
+    proxy_uri,
+    verbose=None,
+    li_erecurse=None,
+):
+    """Function to set publisher."""
+
+    name = None
+    errors_json = []
+    if len(pargs) == 0 and not repo_uri:
+        errors_json.append({"reason": _("requires a publisher name")})
+        return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
+    elif len(pargs) > 1:
+        errors_json.append(
+            {"reason": _("only one publisher name may " "be specified")}
+        )
+        return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
+    elif pargs:
+        name = pargs[0]
+
+    # Get sanitized SSL Cert/Key input values.
+    ssl_cert, ssl_key = _get_ssl_cert_key(
+        api_inst.root, api_inst.is_zone, ssl_cert, ssl_key
+    )
+
+    if not repo_uri:
+        # Normal case.
+        ret_json = _set_pub_error_wrap(
+            _add_update_pub,
+            name,
+            [],
+            api_inst,
+            name,
+            disable=disable,
+            sticky=sticky,
+            origin_uri=origin_uri,
+            add_mirrors=add_mirrors,
+            remove_mirrors=remove_mirrors,
+            add_origins=add_origins,
+            remove_origins=remove_origins,
+            enable_origins=enable_origins,
+            disable_origins=disable_origins,
+            ssl_cert=ssl_cert,
+            ssl_key=ssl_key,
+            search_before=search_before,
+            search_after=search_after,
+            search_first=search_first,
+            reset_uuid=reset_uuid,
+            refresh_allowed=refresh_allowed,
+            set_props=set_props,
+            add_prop_values=add_prop_values,
+            remove_prop_values=remove_prop_values,
+            unset_props=unset_props,
+            approved_cas=approved_ca_certs,
+            revoked_cas=revoked_ca_certs,
+            unset_cas=unset_ca_certs,
+            proxy_uri=proxy_uri,
+        )
+
+        if "errors" in ret_json:
+            for err in ret_json["errors"]:
+                errors_json.append(err)
+        return __prepare_json(ret_json["status"], errors=errors_json)
+
+    # Automatic configuration via -p case.
+    def get_pubs():
+        if proxy_uri:
+            proxies = [publisher.ProxyURI(proxy_uri)]
         else:
-                assert _stage in [API_STAGE_PREPARE, API_STAGE_EXECUTE]
-                __api_plan_load(_api_inst, _stage, _origins, logger=logger)
+            proxies = []
+        repo = publisher.RepositoryURI(
+            repo_uri, ssl_cert=ssl_cert, ssl_key=ssl_key, proxies=proxies
+        )
+        return __prepare_json(
+            EXIT_OK, data=api_inst.get_publisherdata(repo=repo)
+        )
 
-        # Exceptions which happen here are printed in the above level,
-        # with or without some extra decoration done here.
-        if _stage in [API_STAGE_DEFAULT, API_STAGE_PREPARE]:
-                ret = __api_prepare_plan(_op, _api_inst)
-                pkg_timer.record("preparing", logger=logger)
-
-                if ret["status"] != EXIT_OK:
-                        return ret
-                if _stage == API_STAGE_PREPARE:
-                        return __prepare_json(EXIT_OK, data=data)
-
-        ret = __api_execute_plan(_op, _api_inst)
-        pkg_timer.record("executing", logger=logger)
-
-        if _review_release_notes and ret["status"] == EXIT_OK and \
-            _stage == API_STAGE_DEFAULT and _api_inst.solaris_image():
-                data["release_notes_url"] = misc.get_release_notes_url()
-                ret = __prepare_json(EXIT_OK, data=data)
-        elif ret["status"] == EXIT_OK and data:
-                ret = __prepare_json(EXIT_OK, data=data)
-
-        return ret
-
-def _exact_install(op, api_inst, pargs,
-    accept, backup_be, backup_be_name, be_activate, be_name, li_ignore,
-    li_parent_sync, new_be, noexecute, origins, parsable_version, quiet,
-    refresh_catalogs, reject_pats, show_licenses, update_index, verbose,
-    display_plan_cb=None, logger=None):
-        errors_json = []
-        if not pargs:
-                error = {"reason": _("at least one package name required")}
-                errors_json.append(error)
-                return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
-
-        rval, res = _get_fmri_args(api_inst, pargs, cmd=op,
-            errors_json=errors_json)
-        if not rval:
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        xrval, xres = _get_fmri_args(api_inst, reject_pats, cmd=op,
-                    errors_json=errors_json)
-        if not xrval:
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        return __api_op(op, api_inst, _accept=accept, _li_ignore=li_ignore,
-            _noexecute=noexecute, _origins=origins, _quiet=quiet,
-            _show_licenses=show_licenses, _verbose=verbose,
-            backup_be=backup_be, backup_be_name=backup_be_name,
-            be_activate=be_activate, be_name=be_name,
-            li_parent_sync=li_parent_sync, new_be=new_be,
-            _parsable_version=parsable_version, pkgs_inst=pargs,
-            refresh_catalogs=refresh_catalogs, reject_list=reject_pats,
-            update_index=update_index, display_plan_cb=display_plan_cb,
-            logger=logger)
-
-def _install(op, api_inst, pargs, accept, act_timeout, backup_be,
-    backup_be_name, be_activate, be_name, li_ignore, li_erecurse,
-    li_parent_sync, new_be, noexecute, origins, parsable_version, quiet,
-    refresh_catalogs, reject_pats, show_licenses, stage, update_index,
-    verbose, display_plan_cb=None, logger=None):
-        """Attempt to take package specified to INSTALLED state.  The operands
-        are interpreted as glob patterns."""
-
-        errors_json = []
-        if not pargs:
-                error = {"reason": _("at least one package name required")}
-                errors_json.append(error)
-                return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
-
-        rval, res = _get_fmri_args(api_inst, pargs, cmd=op,
-            errors_json=errors_json)
-        if not rval:
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        xrval, xres = _get_fmri_args(api_inst, reject_pats, cmd=op,
-                    errors_json=errors_json)
-        if not xrval:
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        return __api_op(op, api_inst, _accept=accept, _li_ignore=li_ignore,
-            _noexecute=noexecute, _origins=origins,
-            _parsable_version=parsable_version, _quiet=quiet,
-            _show_licenses=show_licenses, _stage=stage, _verbose=verbose,
-            act_timeout=act_timeout, backup_be=backup_be,
-            backup_be_name=backup_be_name, be_activate=be_activate,
-            be_name=be_name, li_erecurse=li_erecurse,
-            li_parent_sync=li_parent_sync, new_be=new_be, pkgs_inst=pargs,
-            refresh_catalogs=refresh_catalogs, reject_list=reject_pats,
-            update_index=update_index, display_plan_cb=display_plan_cb,
-            logger=logger)
-
-def _update(op, api_inst, pargs, accept, act_timeout, backup_be, backup_be_name,
-    be_activate, be_name, force, ignore_missing, li_ignore, li_erecurse,
-    li_parent_sync, new_be, noexecute, origins, parsable_version, quiet,
-    refresh_catalogs, reject_pats, show_licenses, stage, update_index, verbose,
-    display_plan_cb=None, logger=None):
-        """Attempt to take all installed packages specified to latest
-        version."""
-
-        errors_json = []
-        rval, res = _get_fmri_args(api_inst, pargs, cmd=op,
-            errors_json=errors_json)
-        if not rval:
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        xrval, xres = _get_fmri_args(api_inst, reject_pats, cmd=op,
-                errors_json=errors_json)
-        if not xrval:
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        if res:
-                # If there are specific installed packages to update,
-                # then take only those packages to the latest version
-                # allowed by the patterns specified.  (The versions
-                # specified can be older than what is installed.)
-                pkgs_update = pargs
-                review_release_notes = False
-        else:
-                # If no packages were specified, attempt to update all
-                # installed packages.
-                pkgs_update = None
-                review_release_notes = True
-
-        return __api_op(op, api_inst, _accept=accept, _li_ignore=li_ignore,
-            _noexecute=noexecute, _origins=origins,
-            _parsable_version=parsable_version, _quiet=quiet,
-            _review_release_notes=review_release_notes,
-            _show_licenses=show_licenses, _stage=stage, _verbose=verbose,
-            act_timeout=act_timeout, backup_be=backup_be,
-            backup_be_name=backup_be_name, be_activate=be_activate,
-            be_name=be_name, force=force, ignore_missing=ignore_missing,
-            li_erecurse=li_erecurse, li_parent_sync=li_parent_sync,
-            new_be=new_be, pkgs_update=pkgs_update,
-            refresh_catalogs=refresh_catalogs, reject_list=reject_pats,
-            update_index=update_index, display_plan_cb=display_plan_cb,
-            logger=logger)
-
-def _uninstall(op, api_inst, pargs,
-    act_timeout, backup_be, backup_be_name, be_activate, be_name,
-    ignore_missing, li_ignore, li_erecurse, li_parent_sync, new_be, noexecute,
-    parsable_version, quiet, stage, update_index, verbose,
-    display_plan_cb=None, logger=None):
-        """Attempt to take package specified to DELETED state."""
-
-        errors_json = []
-        if not pargs:
-                error = {"reason": _("at least one package name required")}
-                errors_json.append(error)
-                return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
-
-        rval, res = _get_fmri_args(api_inst, pargs, cmd=op,
-            errors_json=errors_json)
-        if not rval:
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        return __api_op(op, api_inst, _li_ignore=li_ignore,
-            _noexecute=noexecute, _parsable_version=parsable_version,
-            _quiet=quiet, _stage=stage, _verbose=verbose,
-            act_timeout=act_timeout, backup_be=backup_be,
-            backup_be_name=backup_be_name, be_activate=be_activate,
-            be_name=be_name, ignore_missing=ignore_missing,
-            li_erecurse=li_erecurse, li_parent_sync=li_parent_sync,
-            new_be=new_be, pkgs_to_uninstall=pargs, update_index=update_index,
-            display_plan_cb=display_plan_cb, logger=logger)
-
-def _publisher_set(op, api_inst, pargs, ssl_key, ssl_cert, origin_uri,
-    reset_uuid, add_mirrors, remove_mirrors, add_origins, remove_origins,
-    enable_origins, disable_origins, refresh_allowed, disable, sticky,
-    search_before, search_after, search_first, approved_ca_certs,
-    revoked_ca_certs, unset_ca_certs, set_props, add_prop_values,
-    remove_prop_values, unset_props, repo_uri, proxy_uri,
-    verbose=None, li_erecurse=None):
-        """Function to set publisher."""
-
-        name = None
-        errors_json = []
-        if len(pargs) == 0 and not repo_uri:
-                errors_json.append({"reason": _("requires a publisher name")})
-                return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
-        elif len(pargs) > 1:
-                errors_json.append({"reason": _("only one publisher name may "
-                    "be specified")})
-                return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
-        elif pargs:
-                name = pargs[0]
-
-        # Get sanitized SSL Cert/Key input values.
-        ssl_cert, ssl_key = _get_ssl_cert_key(api_inst.root, api_inst.is_zone,
-            ssl_cert, ssl_key)
-
-        if not repo_uri:
-                # Normal case.
-                ret_json = _set_pub_error_wrap(_add_update_pub, name, [],
-                    api_inst, name, disable=disable, sticky=sticky,
-                    origin_uri=origin_uri, add_mirrors=add_mirrors,
-                    remove_mirrors=remove_mirrors, add_origins=add_origins,
-                    remove_origins=remove_origins,
-                    enable_origins=enable_origins,
-                    disable_origins=disable_origins, ssl_cert=ssl_cert,
-                    ssl_key=ssl_key, search_before=search_before,
-                    search_after=search_after, search_first=search_first,
-                    reset_uuid=reset_uuid, refresh_allowed=refresh_allowed,
-                    set_props=set_props, add_prop_values=add_prop_values,
-                    remove_prop_values=remove_prop_values,
-                    unset_props=unset_props, approved_cas=approved_ca_certs,
-                    revoked_cas=revoked_ca_certs, unset_cas=unset_ca_certs,
-                    proxy_uri=proxy_uri)
-
-                if "errors" in ret_json:
-                        for err in ret_json["errors"]:
-                                errors_json.append(err)
-                return __prepare_json(ret_json["status"], errors=errors_json)
-
-        # Automatic configuration via -p case.
-        def get_pubs():
-                if proxy_uri:
-                        proxies = [publisher.ProxyURI(proxy_uri)]
-                else:
-                        proxies = []
-                repo = publisher.RepositoryURI(repo_uri,
-                    ssl_cert=ssl_cert, ssl_key=ssl_key, proxies=proxies)
-                return __prepare_json(EXIT_OK, data=api_inst.get_publisherdata(
-                    repo=repo))
-
-        ret_json = None
-        try:
-                ret_json = _set_pub_error_wrap(get_pubs, name,
-                    [api_errors.UnsupportedRepositoryOperation])
-        except api_errors.UnsupportedRepositoryOperation as e:
-                # Fail if the operation can't be done automatically.
-                _error_json(str(e), cmd=op, errors_json=errors_json,
-                    errorType="unsupported_repo_op")
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        else:
-                if ret_json["status"] != EXIT_OK and "errors" in ret_json:
-                        for err in ret_json["errors"]:
-                                _error_json(err["reason"], cmd=op,
-                                    errors_json=errors_json)
-                        return __prepare_json(ret_json["status"],
-                            errors=errors_json)
-        # For the automatic publisher configuration case, update or add
-        # publishers based on whether they exist and if they match any
-        # specified publisher prefix.
-        if "data" not in ret_json:
-                _error_json(_("""
+    ret_json = None
+    try:
+        ret_json = _set_pub_error_wrap(
+            get_pubs, name, [api_errors.UnsupportedRepositoryOperation]
+        )
+    except api_errors.UnsupportedRepositoryOperation as e:
+        # Fail if the operation can't be done automatically.
+        _error_json(
+            str(e),
+            cmd=op,
+            errors_json=errors_json,
+            errorType="unsupported_repo_op",
+        )
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    else:
+        if ret_json["status"] != EXIT_OK and "errors" in ret_json:
+            for err in ret_json["errors"]:
+                _error_json(err["reason"], cmd=op, errors_json=errors_json)
+            return __prepare_json(ret_json["status"], errors=errors_json)
+    # For the automatic publisher configuration case, update or add
+    # publishers based on whether they exist and if they match any
+    # specified publisher prefix.
+    if "data" not in ret_json:
+        _error_json(
+            _(
+                """
 The specified repository did not contain any publisher configuration
 information.  This is likely the result of a repository configuration
 error.  Please contact the repository administrator for further
-assistance."""), errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
+assistance."""
+            ),
+            errors_json=errors_json,
+        )
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
 
-        pubs = ret_json["data"]
-        if name and name not in pubs:
-                known = [p.prefix for p in pubs]
-                unknown = [name]
-                e = api_errors.UnknownRepositoryPublishers(known=known,
-                    unknown=unknown, location=repo_uri)
-                _error_json(str(e), errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
+    pubs = ret_json["data"]
+    if name and name not in pubs:
+        known = [p.prefix for p in pubs]
+        unknown = [name]
+        e = api_errors.UnknownRepositoryPublishers(
+            known=known, unknown=unknown, location=repo_uri
+        )
+        _error_json(str(e), errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
 
-        added = []
-        updated = []
-        failed = []
+    added = []
+    updated = []
+    failed = []
 
-        for src_pub in sorted(pubs):
-                prefix = src_pub.prefix
-                if name and prefix != name:
-                        # User didn't request this one.
-                        continue
+    for src_pub in sorted(pubs):
+        prefix = src_pub.prefix
+        if name and prefix != name:
+            # User didn't request this one.
+            continue
 
-                src_repo = src_pub.repository
-                if not api_inst.has_publisher(prefix=prefix):
-                        add_origins = []
-                        if not src_repo or not src_repo.origins:
-                                # If the repository publisher configuration
-                                # didn't include configuration information
-                                # for the publisher's repositories, assume
-                                # that the origin for the new publisher
-                                # matches the URI provided.
-                                add_origins.append(repo_uri)
+        src_repo = src_pub.repository
+        if not api_inst.has_publisher(prefix=prefix):
+            add_origins = []
+            if not src_repo or not src_repo.origins:
+                # If the repository publisher configuration
+                # didn't include configuration information
+                # for the publisher's repositories, assume
+                # that the origin for the new publisher
+                # matches the URI provided.
+                add_origins.append(repo_uri)
 
-                        # Any -p origins/mirrors returned from get_pubs() should
-                        # use the proxy we declared, if any.
-                        if proxy_uri and src_repo:
-                                proxies = [publisher.ProxyURI(proxy_uri)]
-                                for repo_uri in src_repo.origins:
-                                        repo_uri.proxies = proxies
-                                for repo_uri in src_repo.mirrors:
-                                        repo_uri.proxies = proxies
+            # Any -p origins/mirrors returned from get_pubs() should
+            # use the proxy we declared, if any.
+            if proxy_uri and src_repo:
+                proxies = [publisher.ProxyURI(proxy_uri)]
+                for repo_uri in src_repo.origins:
+                    repo_uri.proxies = proxies
+                for repo_uri in src_repo.mirrors:
+                    repo_uri.proxies = proxies
 
-                        ret_json = _set_pub_error_wrap(_add_update_pub, name,
-                            [], api_inst, prefix, pub=src_pub,
-                            add_origins=add_origins, ssl_cert=ssl_cert,
-                            ssl_key=ssl_key, sticky=sticky,
-                            search_after=search_after,
-                            search_before=search_before,
-                            search_first=search_first,
-                            set_props=set_props,
-                            add_prop_values=add_prop_values,
-                            remove_prop_values=remove_prop_values,
-                            unset_props=unset_props, proxy_uri=proxy_uri)
-                        if ret_json["status"] == EXIT_OK:
-                                added.append(prefix)
+            ret_json = _set_pub_error_wrap(
+                _add_update_pub,
+                name,
+                [],
+                api_inst,
+                prefix,
+                pub=src_pub,
+                add_origins=add_origins,
+                ssl_cert=ssl_cert,
+                ssl_key=ssl_key,
+                sticky=sticky,
+                search_after=search_after,
+                search_before=search_before,
+                search_first=search_first,
+                set_props=set_props,
+                add_prop_values=add_prop_values,
+                remove_prop_values=remove_prop_values,
+                unset_props=unset_props,
+                proxy_uri=proxy_uri,
+            )
+            if ret_json["status"] == EXIT_OK:
+                added.append(prefix)
 
-                        # When multiple publishers result from a single -p
-                        # operation, this ensures that the new publishers are
-                        # ordered correctly.
-                        search_first = False
-                        search_after = prefix
-                        search_before = None
-                else:
-                        add_origins = []
-                        add_mirrors = []
-                        dest_pub = api_inst.get_publisher(prefix=prefix,
-                            duplicate=True)
-                        dest_repo = dest_pub.repository
-                        if dest_repo.origins and \
-                            not dest_repo.has_origin(repo_uri):
-                                add_origins = [repo_uri]
+            # When multiple publishers result from a single -p
+            # operation, this ensures that the new publishers are
+            # ordered correctly.
+            search_first = False
+            search_after = prefix
+            search_before = None
+        else:
+            add_origins = []
+            add_mirrors = []
+            dest_pub = api_inst.get_publisher(prefix=prefix, duplicate=True)
+            dest_repo = dest_pub.repository
+            if dest_repo.origins and not dest_repo.has_origin(repo_uri):
+                add_origins = [repo_uri]
 
-                        if not src_repo and not add_origins:
-                                # The repository doesn't have to provide origin
-                                # information for publishers.  If it doesn't,
-                                # the origin of every publisher returned is
-                                # assumed to match the URI that the user
-                                # provided.  Since this is an update case,
-                                # nothing special needs to be done.
-                                if not dest_repo.origins:
-                                        add_origins = [repo_uri]
-                        elif src_repo:
-                                # Avoid duplicates by adding only those mirrors
-                                # or origins not already known.
-                                add_mirrors = [
-                                    u.uri
-                                    for u in src_repo.mirrors
-                                    if u.uri not in dest_repo.mirrors
-                                ]
-                                add_origins = [
-                                    u.uri
-                                    for u in src_repo.origins
-                                    if u.uri not in dest_repo.origins
-                                ]
+            if not src_repo and not add_origins:
+                # The repository doesn't have to provide origin
+                # information for publishers.  If it doesn't,
+                # the origin of every publisher returned is
+                # assumed to match the URI that the user
+                # provided.  Since this is an update case,
+                # nothing special needs to be done.
+                if not dest_repo.origins:
+                    add_origins = [repo_uri]
+            elif src_repo:
+                # Avoid duplicates by adding only those mirrors
+                # or origins not already known.
+                add_mirrors = [
+                    u.uri
+                    for u in src_repo.mirrors
+                    if u.uri not in dest_repo.mirrors
+                ]
+                add_origins = [
+                    u.uri
+                    for u in src_repo.origins
+                    if u.uri not in dest_repo.origins
+                ]
 
-                                # Special bits to update; for these, take the
-                                # new value as-is (don't attempt to merge).
-                                for prop in ("collection_type", "description",
-                                    "legal_uris", "name", "refresh_seconds",
-                                    "registration_uri", "related_uris"):
-                                        src_val = getattr(src_repo, prop)
-                                        if src_val is not None:
-                                                setattr(dest_repo, prop,
-                                                    src_val)
+                # Special bits to update; for these, take the
+                # new value as-is (don't attempt to merge).
+                for prop in (
+                    "collection_type",
+                    "description",
+                    "legal_uris",
+                    "name",
+                    "refresh_seconds",
+                    "registration_uri",
+                    "related_uris",
+                ):
+                    src_val = getattr(src_repo, prop)
+                    if src_val is not None:
+                        setattr(dest_repo, prop, src_val)
 
-                        # If an alias doesn't already exist, update it too.
-                        if src_pub.alias and not dest_pub.alias:
-                                dest_pub.alias = src_pub.alias
+            # If an alias doesn't already exist, update it too.
+            if src_pub.alias and not dest_pub.alias:
+                dest_pub.alias = src_pub.alias
 
-                        ret_json = _set_pub_error_wrap(_add_update_pub, name,
-                            [], api_inst, prefix, pub=dest_pub,
-                            add_mirrors=add_mirrors, add_origins=add_origins,
-                            set_props=set_props,
-                            add_prop_values=add_prop_values,
-                            remove_prop_values=remove_prop_values,
-                            unset_props=unset_props, proxy_uri=proxy_uri)
+            ret_json = _set_pub_error_wrap(
+                _add_update_pub,
+                name,
+                [],
+                api_inst,
+                prefix,
+                pub=dest_pub,
+                add_mirrors=add_mirrors,
+                add_origins=add_origins,
+                set_props=set_props,
+                add_prop_values=add_prop_values,
+                remove_prop_values=remove_prop_values,
+                unset_props=unset_props,
+                proxy_uri=proxy_uri,
+            )
 
-                        if ret_json["status"] == EXIT_OK:
-                                updated.append(prefix)
+            if ret_json["status"] == EXIT_OK:
+                updated.append(prefix)
 
-                if ret_json["status"] != EXIT_OK:
-                        for err in ret_json["errors"]:
-                                failed.append((prefix, err["reason"]))
-                        continue
+        if ret_json["status"] != EXIT_OK:
+            for err in ret_json["errors"]:
+                failed.append((prefix, err["reason"]))
+            continue
 
-        first = True
-        for pub, rmsg in failed:
-                if first:
-                        first = False
-                        _error_json("failed to add or update one or more "
-                            "publishers", cmd=op, errors_json=errors_json,
-                             errorType="publisher_set")
-                errors_json.append({"reason": "  {0}:\n{1}".format(pub, rmsg),
-                    "errtype": "publisher_set"})
+    first = True
+    for pub, rmsg in failed:
+        if first:
+            first = False
+            _error_json(
+                "failed to add or update one or more " "publishers",
+                cmd=op,
+                errors_json=errors_json,
+                errorType="publisher_set",
+            )
+        errors_json.append(
+            {
+                "reason": "  {0}:\n{1}".format(pub, rmsg),
+                "errtype": "publisher_set",
+            }
+        )
 
-        data = {}
-        if added or updated:
-                if first:
-                        data["header"] = "pkg set-publisher:"
-                if added:
-                        data["added"] = added
-                if updated:
-                        data["updated"] = updated
+    data = {}
+    if added or updated:
+        if first:
+            data["header"] = "pkg set-publisher:"
+        if added:
+            data["added"] = added
+        if updated:
+            data["updated"] = updated
 
-        if failed:
-                if len(failed) != len(pubs):
-                        # Not all publishers retrieved could be added or
-                        # updated.
-                        return __prepare_json(EXIT_PARTIAL, data=data,
-                            errors=errors_json)
-                return __prepare_json(EXIT_OOPS, data=data, errors=errors_json)
+    if failed:
+        if len(failed) != len(pubs):
+            # Not all publishers retrieved could be added or
+            # updated.
+            return __prepare_json(EXIT_PARTIAL, data=data, errors=errors_json)
+        return __prepare_json(EXIT_OOPS, data=data, errors=errors_json)
 
-        # Now that the configuration was successful, attempt to refresh the
-        # catalog data for all of the configured publishers.  If the refresh
-        # had been allowed earlier while configuring each publisher, then this
-        # wouldn't be necessary and some possibly invalid configuration could
-        # have been eliminated sooner.  However, that would be much slower as
-        # each refresh requires a client image state rebuild.
-        ret_json = __refresh(api_inst, added + updated)
-        ret_json["data"] = data
-        return ret_json
+    # Now that the configuration was successful, attempt to refresh the
+    # catalog data for all of the configured publishers.  If the refresh
+    # had been allowed earlier while configuring each publisher, then this
+    # wouldn't be necessary and some possibly invalid configuration could
+    # have been eliminated sooner.  However, that would be much slower as
+    # each refresh requires a client image state rebuild.
+    ret_json = __refresh(api_inst, added + updated)
+    ret_json["data"] = data
+    return ret_json
+
 
 def _publisher_unset(op, api_inst, pargs):
-        """Function to unset publishers."""
+    """Function to unset publishers."""
 
-        errors_json = []
-        if not pargs:
-                errors_json.append({"reason": _("at least one publisher must "
-                    "be specified")})
-                return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
+    errors_json = []
+    if not pargs:
+        errors_json.append(
+            {"reason": _("at least one publisher must " "be specified")}
+        )
+        return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
 
-        errors = []
-        goal = len(pargs)
-        progtrack = api_inst.progresstracker
-        progtrack.job_start(progtrack.JOB_PKG_CACHE, goal=goal)
-        for name in pargs:
-                try:
-                        api_inst.remove_publisher(prefix=name, alias=name)
-                except api_errors.ImageFormatUpdateNeeded as e:
-                        _format_update_error(e, errors_json)
-                        return __prepare_json(EXIT_OOPS, errors=errors_json)
-                except (api_errors.PermissionsException,
-                    api_errors.PublisherError,
-                    api_errors.ModifyingSyspubException) as e:
-                        errors.append((name, e))
-                finally:
-                        progtrack.job_add_progress(progtrack.JOB_PKG_CACHE)
+    errors = []
+    goal = len(pargs)
+    progtrack = api_inst.progresstracker
+    progtrack.job_start(progtrack.JOB_PKG_CACHE, goal=goal)
+    for name in pargs:
+        try:
+            api_inst.remove_publisher(prefix=name, alias=name)
+        except api_errors.ImageFormatUpdateNeeded as e:
+            _format_update_error(e, errors_json)
+            return __prepare_json(EXIT_OOPS, errors=errors_json)
+        except (
+            api_errors.PermissionsException,
+            api_errors.PublisherError,
+            api_errors.ModifyingSyspubException,
+        ) as e:
+            errors.append((name, e))
+        finally:
+            progtrack.job_add_progress(progtrack.JOB_PKG_CACHE)
 
-        progtrack.job_done(progtrack.JOB_PKG_CACHE)
-        retcode = EXIT_OK
-        errors_json = []
-        if errors:
-                if len(errors) == len(pargs):
-                        # If the operation failed for every provided publisher
-                        # prefix or alias, complete failure occurred.
-                        retcode = EXIT_OOPS
+    progtrack.job_done(progtrack.JOB_PKG_CACHE)
+    retcode = EXIT_OK
+    errors_json = []
+    if errors:
+        if len(errors) == len(pargs):
+            # If the operation failed for every provided publisher
+            # prefix or alias, complete failure occurred.
+            retcode = EXIT_OOPS
+        else:
+            # If the operation failed for only some of the provided
+            # publisher prefixes or aliases, then partial failure
+            # occurred.
+            retcode = EXIT_PARTIAL
+
+        txt = ""
+        for name, err in errors:
+            txt += "\n"
+            txt += _("Removal failed for '{pub}': {msg}").format(
+                pub=name, msg=err
+            )
+            txt += "\n"
+        _error_json(txt, cmd=op, errors_json=errors_json)
+
+    return __prepare_json(retcode, errors=errors_json)
+
+
+def _publisher_list(
+    op,
+    api_inst,
+    pargs,
+    omit_headers,
+    preferred_only,
+    inc_disabled,
+    output_format,
+):
+    """pkg publishers. Note: publisher_a is a left-over parameter."""
+
+    errors_json = []
+    field_data = {
+        "publisher": [("default", "tsv"), _("PUBLISHER"), ""],
+        "attrs": [("default"), "", ""],
+        "type": [("default", "tsv"), _("TYPE"), ""],
+        "status": [("default", "tsv"), _("STATUS"), ""],
+        "repo_loc": [("default"), _("LOCATION"), ""],
+        "uri": [("tsv"), _("URI"), ""],
+        "sticky": [("tsv"), _("STICKY"), ""],
+        "enabled": [("tsv"), _("ENABLED"), ""],
+        "syspub": [("tsv"), _("SYSPUB"), ""],
+        "proxy": [("tsv"), _("PROXY"), ""],
+        "proxied": [("default"), _("P"), ""],
+    }
+
+    desired_field_order = (
+        _("PUBLISHER"),
+        "",
+        _("STICKY"),
+        _("SYSPUB"),
+        _("ENABLED"),
+        _("TYPE"),
+        _("STATUS"),
+        _("P"),
+        _("LOCATION"),
+    )
+
+    # Custom key function for preserving field ordering
+    def key_fields(item):
+        return desired_field_order.index(get_header(item))
+
+    # Functions for manipulating field_data records
+    def filter_default(record):
+        return "default" in record[0]
+
+    def filter_tsv(record):
+        return "tsv" in record[0]
+
+    def get_header(record):
+        return record[1]
+
+    def get_value(record):
+        return record[2]
+
+    def set_value(record, value):
+        record[2] = value
+
+    api_inst.progresstracker.set_purpose(
+        api_inst.progresstracker.PURPOSE_LISTING
+    )
+
+    cert_cache = {}
+
+    def get_cert_info(ssl_cert):
+        if not ssl_cert:
+            return None
+        if ssl_cert not in cert_cache:
+            c = cert_cache[ssl_cert] = {}
+            errors = c["errors"] = []
+            times = c["info"] = {
+                "effective": "",
+                "expiration": "",
+            }
+
+            try:
+                cert = misc.validate_ssl_cert(ssl_cert)
+            except (
+                EnvironmentError,
+                api_errors.CertificateError,
+                api_errors.PermissionsException,
+            ) as e:
+                # If the cert information can't be retrieved,
+                # add the errors to a list and continue on.
+                errors.append(e)
+                c["valid"] = False
+            else:
+                nb = cert.get_notBefore()
+                # strptime's first argument must be str
+                t = time.strptime(misc.force_str(nb), "%Y%m%d%H%M%SZ")
+                nb = datetime.datetime.utcfromtimestamp(calendar.timegm(t))
+                times["effective"] = nb.strftime("%c")
+
+                na = cert.get_notAfter()
+                t = time.strptime(misc.force_str(na), "%Y%m%d%H%M%SZ")
+                na = datetime.datetime.utcfromtimestamp(calendar.timegm(t))
+                times["expiration"] = na.strftime("%c")
+                c["valid"] = True
+
+        return cert_cache[ssl_cert]
+
+    retcode = EXIT_OK
+    data = {}
+    if len(pargs) == 0:
+        if preferred_only:
+            pref_pub = api_inst.get_highest_ranked_publisher()
+            if api_inst.has_publisher(pref_pub):
+                pubs = [pref_pub]
+            else:
+                # Only publisher known is from an installed
+                # package and is not configured in the image.
+                pubs = []
+        else:
+            pubs = [
+                p
+                for p in api_inst.get_publishers()
+                if inc_disabled or not p.disabled
+            ]
+        # Create a formatting string for the default output
+        # format
+        if output_format == "default":
+            filter_func = filter_default
+
+        # Create a formatting string for the tsv output
+        # format
+        if output_format == "tsv":
+            filter_func = filter_tsv
+            desired_field_order = (
+                _("PUBLISHER"),
+                "",
+                _("STICKY"),
+                _("SYSPUB"),
+                _("ENABLED"),
+                _("TYPE"),
+                _("STATUS"),
+                _("URI"),
+                _("PROXY"),
+            )
+
+        # Extract our list of headers from the field_data
+        # dictionary Make sure they are extracted in the
+        # desired order by using our custom key function.
+        hdrs = list(
+            map(
+                get_header,
+                sorted(
+                    filter(filter_func, list(field_data.values())),
+                    key=key_fields,
+                ),
+            )
+        )
+
+        if not omit_headers:
+            data["headers"] = hdrs
+        data["publishers"] = []
+        for p in pubs:
+            # Store all our publisher related data in
+            # field_data ready for output
+
+            set_value(field_data["publisher"], p.prefix)
+            # Setup the synthetic attrs field if the
+            # format is default.
+            if output_format == "default":
+                pstatus = ""
+
+                if not p.sticky:
+                    pstatus_list = [_("non-sticky")]
                 else:
-                        # If the operation failed for only some of the provided
-                        # publisher prefixes or aliases, then partial failure
-                        # occurred.
-                        retcode = EXIT_PARTIAL
+                    pstatus_list = []
 
-                txt = ""
-                for name, err in errors:
-                        txt += "\n"
-                        txt += _("Removal failed for '{pub}': {msg}").format(
-                            pub=name, msg=err)
-                        txt += "\n"
-                _error_json(txt, cmd=op, errors_json=errors_json)
+                if p.disabled:
+                    pstatus_list.append(_("disabled"))
+                if p.sys_pub:
+                    pstatus_list.append(_("syspub"))
+                if pstatus_list:
+                    pstatus = "({0})".format(", ".join(pstatus_list))
+                set_value(field_data["attrs"], pstatus)
 
-        return __prepare_json(retcode, errors=errors_json)
+            if p.sticky:
+                set_value(field_data["sticky"], _("true"))
+            else:
+                set_value(field_data["sticky"], _("false"))
+            if not p.disabled:
+                set_value(field_data["enabled"], _("true"))
+            else:
+                set_value(field_data["enabled"], _("false"))
+            if p.sys_pub:
+                set_value(field_data["syspub"], _("true"))
+            else:
+                set_value(field_data["syspub"], _("false"))
 
-def _publisher_list(op, api_inst, pargs, omit_headers, preferred_only,
-    inc_disabled, output_format):
-        """pkg publishers. Note: publisher_a is a left-over parameter."""
+            # Only show the selected repository's information in
+            # summary view.
+            if p.repository:
+                origins = p.repository.origins
+                mirrors = p.repository.mirrors
+            else:
+                origins = mirrors = []
 
-        errors_json = []
-        field_data = {
-            "publisher" : [("default", "tsv"), _("PUBLISHER"), ""],
-            "attrs" : [("default"), "", ""],
-            "type" : [("default", "tsv"), _("TYPE"), ""],
-            "status" : [("default", "tsv"), _("STATUS"), ""],
-            "repo_loc" : [("default"), _("LOCATION"), ""],
-            "uri": [("tsv"), _("URI"), ""],
-            "sticky" : [("tsv"), _("STICKY"), ""],
-            "enabled" : [("tsv"), _("ENABLED"), ""],
-            "syspub" : [("tsv"), _("SYSPUB"), ""],
-            "proxy"  : [("tsv"), _("PROXY"), ""],
-            "proxied" : [("default"), _("P"), ""]
+            set_value(field_data["repo_loc"], "")
+            set_value(field_data["proxied"], "")
+            # Update field_data for each origin and output
+            # a publisher record in our desired format.
+            for uri in sorted(origins):
+                # XXX get the real origin status
+                set_value(field_data["type"], _("origin"))
+                set_value(field_data["proxy"], "-")
+                set_value(field_data["proxied"], "F")
+
+                set_value(field_data["uri"], uri)
+                if uri.disabled:
+                    set_value(field_data["enabled"], _("false"))
+                    set_value(field_data["status"], _("disabled"))
+                else:
+                    set_value(field_data["enabled"], _("true"))
+                    set_value(field_data["status"], _("online"))
+
+                if uri.proxies:
+                    set_value(field_data["proxied"], _("T"))
+                    set_value(
+                        field_data["proxy"],
+                        ", ".join([proxy.uri for proxy in uri.proxies]),
+                    )
+                if uri.system:
+                    set_value(field_data["repo_loc"], SYSREPO_HIDDEN_URI)
+                else:
+                    set_value(field_data["repo_loc"], uri)
+
+                values = map(
+                    get_value,
+                    sorted(
+                        filter(filter_func, field_data.values()), key=key_fields
+                    ),
+                )
+                entry = []
+                for e in values:
+                    if isinstance(e, six.string_types):
+                        entry.append(e)
+                    else:
+                        entry.append(str(e))
+                data["publishers"].append(entry)
+            # Update field_data for each mirror and output
+            # a publisher record in our desired format.
+            for uri in mirrors:
+                # XXX get the real mirror status
+                set_value(field_data["type"], _("mirror"))
+                # We do not currently deal with mirrors. So
+                # they are always online.
+                set_value(field_data["status"], _("online"))
+                set_value(field_data["proxy"], "-")
+                set_value(field_data["proxied"], _("F"))
+
+                set_value(field_data["uri"], uri)
+
+                if uri.proxies:
+                    set_value(field_data["proxied"], _("T"))
+                    set_value(
+                        field_data["proxy"],
+                        ", ".join([p.uri for p in uri.proxies]),
+                    )
+                if uri.system:
+                    set_value(field_data["repo_loc"], SYSREPO_HIDDEN_URI)
+                else:
+                    set_value(field_data["repo_loc"], uri)
+
+                values = map(
+                    get_value,
+                    sorted(
+                        filter(filter_func, field_data.values()), key=key_fields
+                    ),
+                )
+                entry = []
+                for e in values:
+                    if isinstance(e, six.string_types):
+                        entry.append(e)
+                    else:
+                        entry.append(str(e))
+                data["publishers"].append(entry)
+
+            if not origins and not mirrors:
+                set_value(field_data["type"], "")
+                set_value(field_data["status"], "")
+                set_value(field_data["uri"], "")
+                set_value(field_data["proxy"], "")
+                values = map(
+                    get_value,
+                    sorted(
+                        filter(filter_func, field_data.values()), key=key_fields
+                    ),
+                )
+                entry = []
+                for e in values:
+                    if isinstance(e, six.string_types):
+                        entry.append(e)
+                    else:
+                        entry.append(str(e))
+                data["publishers"].append(entry)
+    else:
+
+        def collect_ssl_info(uri, uri_data):
+            retcode = EXIT_OK
+            c = get_cert_info(uri.ssl_cert)
+            uri_data["SSL Key"] = str(uri.ssl_key)
+            uri_data["SSL Cert"] = str(uri.ssl_cert)
+
+            if not c:
+                return retcode
+
+            if c["errors"]:
+                retcode = EXIT_OOPS
+
+            for e in c["errors"]:
+                errors_json.append(
+                    {"reason": "\n" + str(e) + "\n", "errtype": "cert_info"}
+                )
+
+            if c["valid"]:
+                uri_data["Cert. Effective Date"] = str(c["info"]["effective"])
+                uri_data["Cert. Expiration Date"] = str(c["info"]["expiration"])
+            return retcode
+
+        def collect_repository(r, pub_data):
+            retcode = 0
+            origins_data = []
+            for uri in r.origins:
+                origin_data = {"Origin URI": str(uri)}
+                if uri.disabled:
+                    origin_data["Status"] = _("Disabled")
+                else:
+                    origin_data["Status"] = _("Online")
+                if uri.proxies:
+                    origin_data["Proxy"] = [str(p.uri) for p in uri.proxies]
+                rval = collect_ssl_info(uri, origin_data)
+                if rval == 1:
+                    retcode = EXIT_PARTIAL
+                origins_data.append(origin_data)
+
+            mirrors_data = []
+            for uri in r.mirrors:
+                mirror_data = {"Mirror URI": str(uri)}
+                mirror_data["Status"] = _("Online")
+                if uri.proxies:
+                    mirror_data["Proxy"] = [str(p.uri) for p in uri.proxies]
+                rval = collect_ssl_info(uri, mirror_data)
+                if rval == 1:
+                    retcode = EXIT_PARTIAL
+                mirrors_data.append(mirror_data)
+            if origins_data:
+                pub_data["origins"] = origins_data
+            if mirrors_data:
+                pub_data["mirrors"] = mirrors_data
+            return retcode
+
+        def collect_signing_certs(p, pub_data):
+            if p.approved_ca_certs:
+                pub_data["Approved CAs"] = [
+                    str(cert) for cert in p.approved_ca_certs
+                ]
+            if p.revoked_ca_certs:
+                pub_data["Revoked CAs"] = [
+                    str(cert) for cert in p.revoked_ca_certs
+                ]
+
+        for name in pargs:
+            # detailed print
+            pub = api_inst.get_publisher(prefix=name, alias=name)
+            dt = api_inst.get_publisher_last_update_time(pub.prefix)
+            if dt:
+                dt = dt.strftime("%c")
+
+            pub_data = {}
+            pub_data["Publisher"] = pub.prefix
+            pub_data["Alias"] = pub.alias
+
+            rval = collect_repository(pub.repository, pub_data)
+            if rval != 0:
+                # There was an error in displaying some
+                # of the information about a repository.
+                # However, continue on.
+                retcode = rval
+
+            pub_data["Client UUID"] = pub.client_uuid
+            pub_data["Catalog Updated"] = dt
+            collect_signing_certs(pub, pub_data)
+            if pub.disabled:
+                pub_data["enabled"] = "No"
+            else:
+                pub_data["enabled"] = "Yes"
+            if pub.sticky:
+                pub_data["sticky"] = "Yes"
+            else:
+                pub_data["sticky"] = "No"
+            if pub.sys_pub:
+                pub_data["sys_pub"] = "Yes"
+            else:
+                pub_data["sys_pub"] = "No"
+            if pub.properties:
+                pub_data["Properties"] = {}
+                for k, v in six.iteritems(pub.properties):
+                    pub_data["Properties"][k] = v
+            data.setdefault("publisher_details", []).append(pub_data)
+    return __prepare_json(retcode, data=data, errors=errors_json, op=op)
+
+
+def _info(
+    op,
+    api_inst,
+    pargs,
+    display_license,
+    info_local,
+    info_remote,
+    origins,
+    quiet,
+):
+    """Display information about a package or packages."""
+
+    errors_json = []
+    data = {}
+    if info_remote and not pargs:
+        error = {
+            "reason": _("must request remote info for specific " "packages")
+        }
+        errors_json.append(error)
+        return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
+
+    err = EXIT_OK
+    # Reset the progress tracker here, because we may have to switch to a
+    # different tracker due to the options parse.
+    api_inst.progresstracker = _get_tracker()
+
+    api_inst.progresstracker.set_purpose(
+        api_inst.progresstracker.PURPOSE_LISTING
+    )
+
+    info_needed = api.PackageInfo.ALL_OPTIONS
+    if not display_license:
+        info_needed = api.PackageInfo.ALL_OPTIONS - frozenset(
+            [api.PackageInfo.LICENSES]
+        )
+    info_needed -= api.PackageInfo.ACTION_OPTIONS
+    info_needed |= frozenset([api.PackageInfo.DEPENDENCIES])
+
+    try:
+        ret = api_inst.info(
+            pargs, info_local, info_needed, ranked=info_remote, repos=origins
+        )
+    except api_errors.ImageFormatUpdateNeeded as e:
+        _format_update_error(e, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.NoPackagesInstalledException:
+        _error_json(_("no packages installed"), errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.ApiException as e:
+        _error_json(e, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    pis = ret[api.ImageInterface.INFO_FOUND]
+    notfound = ret[api.ImageInterface.INFO_MISSING]
+    illegals = ret[api.ImageInterface.INFO_ILLEGALS]
+
+    if illegals:
+        # No other results will be returned if illegal patterns were
+        # specified.
+        for i in illegals:
+            errors_json.append({"reason": str(i)})
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    no_licenses = []
+    for i, pi in enumerate(pis):
+        if display_license:
+            if not pi.licenses:
+                no_licenses.append(pi.fmri)
+            elif not quiet:
+                lics = []
+                for lic in pi.licenses:
+                    lics.append(str(lic))
+                data.setdefault("licenses", []).append([pi.pkg_stem, lics])
+            continue
+
+        if quiet:
+            continue
+
+        state = ""
+        if api.PackageInfo.INSTALLED in pi.states:
+            state = _("Installed")
+        elif api.PackageInfo.UNSUPPORTED in pi.states:
+            state = _("Unsupported")
+        else:
+            state = _("Not installed")
+
+        states = []
+        lparen = False
+        if api.PackageInfo.OBSOLETE in pi.states:
+            states.append(_("Obsolete"))
+        elif api.PackageInfo.RENAMED in pi.states:
+            states.append(_("Renamed"))
+        elif api.PackageInfo.LEGACY in pi.states:
+            states.append(_("Legacy"))
+        if api.PackageInfo.FROZEN in pi.states:
+            states.append(_("Frozen"))
+        if api.PackageInfo.MANUAL in pi.states:
+            states.append(_("Manually installed"))
+        if len(states):
+            state += " ({})".format(", ".join(states))
+
+        attr_list = []
+        seen = {}
+
+        def __append_attr_lists(label, values):
+            """Given arguments label and values, either extend
+            the existing list value or add new one to
+            attr_list"""
+
+            if not isinstance(values, list):
+                values = [values]
+            if label in seen:
+                seen[label].extend(values)
+            else:
+                attr_list.append([label, values])
+                seen[label] = values
+
+        __append_attr_lists(_("Name"), pi.pkg_stem)
+        __append_attr_lists(_("Summary"), pi.summary)
+        if pi.description:
+            __append_attr_lists(_("Description"), pi.description)
+        if pi.category_info_list:
+            category_info = []
+            verbose = len(pi.category_info_list) > 1
+            category_info.append(pi.category_info_list[0].__str__(verbose))
+            if len(pi.category_info_list) > 1:
+                for ci in pi.category_info_list[1:]:
+                    category_info.append(ci.__str__(verbose))
+            __append_attr_lists(_("Category"), category_info)
+
+        __append_attr_lists(_("State"), state)
+
+        # Renamed packages have dependencies, but the dependencies
+        # may not apply to this image's variants so won't be
+        # returned.
+        if api.PackageInfo.RENAMED in pi.states:
+            __append_attr_lists(_("Renamed to"), pi.dependencies)
+
+        # XXX even more info on the publisher would be nice?
+        __append_attr_lists(_("Publisher"), pi.publisher)
+        hum_ver = pi.get_attr_values("pkg.human-version")
+        if hum_ver and hum_ver[0] != str(pi.version):
+            __append_attr_lists(
+                _("Version"), "{0} ({1})".format(pi.version, hum_ver[0])
+            )
+        else:
+            __append_attr_lists(_("Version"), str(pi.version))
+
+        __append_attr_lists(_("Branch"), str(pi.branch))
+        __append_attr_lists(_("Packaging Date"), pi.packaging_date)
+        if pi.last_install:
+            __append_attr_lists(_("Last Install Time"), pi.last_install)
+        if pi.last_update:
+            __append_attr_lists(_("Last Update Time"), pi.last_update)
+        __append_attr_lists(_("Size"), misc.bytes_to_str(pi.size))
+        __append_attr_lists(_("FMRI"), pi.fmri.get_fmri(include_build=False))
+        # XXX add license/copyright info here?
+
+        addl_attr_list = {
+            "info.keyword": _("Additional Keywords"),
+            "info.upstream": _("Project Contact"),
+            "info.maintainer": _("Project Maintainer"),
+            "info.maintainer-url": _("Project Maintainer URL"),
+            "pkg.detailed-url": _("Project URL"),
+            "info.upstream-url": _("Project URL"),
+            "info.repository-changeset": _("Repository Changeset"),
+            "info.repository-url": _("Source URL"),
+            "info.source-url": _("Source URL"),
         }
 
-        desired_field_order = (_("PUBLISHER"), "", _("STICKY"),
-                               _("SYSPUB"), _("ENABLED"), _("TYPE"),
-                               _("STATUS"), _("P"), _("LOCATION"))
+        for key in addl_attr_list:
+            if key in pi.attrs:
+                __append_attr_lists(
+                    addl_attr_list[key], pi.get_attr_values(key)
+                )
 
-        # Custom key function for preserving field ordering
-        def key_fields(item):
-                return desired_field_order.index(get_header(item))
+        for key in pi.attrs:
+            if key.startswith("info.source-url."):
+                __append_attr_lists(
+                    addl_attr_list[key[:15]], pi.get_attr_values(key)
+                )
 
-        # Functions for manipulating field_data records
-        def filter_default(record):
-                return "default" in record[0]
-
-        def filter_tsv(record):
-                return "tsv" in record[0]
-
-        def get_header(record):
-                return record[1]
-
-        def get_value(record):
-                return record[2]
-
-        def set_value(record, value):
-                record[2] = value
-
-        api_inst.progresstracker.set_purpose(
-            api_inst.progresstracker.PURPOSE_LISTING)
-
-        cert_cache = {}
-        def get_cert_info(ssl_cert):
-                if not ssl_cert:
-                        return None
-                if ssl_cert not in cert_cache:
-                        c = cert_cache[ssl_cert] = {}
-                        errors = c["errors"] = []
-                        times = c["info"] = {
-                            "effective": "",
-                            "expiration": "",
-                        }
-
-                        try:
-                                cert = misc.validate_ssl_cert(ssl_cert)
-                        except (EnvironmentError,
-                            api_errors.CertificateError,
-                            api_errors.PermissionsException) as e:
-                                # If the cert information can't be retrieved,
-                                # add the errors to a list and continue on.
-                                errors.append(e)
-                                c["valid"] = False
-                        else:
-                                nb = cert.get_notBefore()
-                                # strptime's first argument must be str
-                                t = time.strptime(misc.force_str(nb),
-                                    "%Y%m%d%H%M%SZ")
-                                nb = datetime.datetime.utcfromtimestamp(
-                                    calendar.timegm(t))
-                                times["effective"] = nb.strftime("%c")
-
-                                na = cert.get_notAfter()
-                                t = time.strptime(misc.force_str(na),
-                                    "%Y%m%d%H%M%SZ")
-                                na = datetime.datetime.utcfromtimestamp(
-                                    calendar.timegm(t))
-                                times["expiration"] = na.strftime("%c")
-                                c["valid"] = True
-
-                return cert_cache[ssl_cert]
-
-        retcode = EXIT_OK
-        data = {}
-        if len(pargs) == 0:
-                if preferred_only:
-                        pref_pub = api_inst.get_highest_ranked_publisher()
-                        if api_inst.has_publisher(pref_pub):
-                                pubs = [pref_pub]
-                        else:
-                                # Only publisher known is from an installed
-                                # package and is not configured in the image.
-                                pubs = []
-                else:
-                        pubs = [
-                            p for p in api_inst.get_publishers()
-                            if inc_disabled or not p.disabled
-                        ]
-                # Create a formatting string for the default output
-                # format
-                if output_format == "default":
-                        filter_func = filter_default
-
-                # Create a formatting string for the tsv output
-                # format
-                if output_format == "tsv":
-                        filter_func = filter_tsv
-                        desired_field_order = (_("PUBLISHER"), "", _("STICKY"),
-                               _("SYSPUB"), _("ENABLED"), _("TYPE"),
-                               _("STATUS"), _("URI"), _("PROXY"))
-
-                # Extract our list of headers from the field_data
-                # dictionary Make sure they are extracted in the
-                # desired order by using our custom key function.
-                hdrs = list(map(get_header, sorted(filter(filter_func,
-                    list(field_data.values())), key=key_fields)))
-
-                if not omit_headers:
-                        data["headers"] = hdrs
-                data["publishers"] = []
-                for p in pubs:
-                        # Store all our publisher related data in
-                        # field_data ready for output
-
-                        set_value(field_data["publisher"], p.prefix)
-                        # Setup the synthetic attrs field if the
-                        # format is default.
-                        if output_format == "default":
-                                pstatus = ""
-
-                                if not p.sticky:
-                                        pstatus_list = [_("non-sticky")]
-                                else:
-                                        pstatus_list = []
-
-                                if p.disabled:
-                                        pstatus_list.append(_("disabled"))
-                                if p.sys_pub:
-                                        pstatus_list.append(_("syspub"))
-                                if pstatus_list:
-                                        pstatus = "({0})".format(
-                                            ", ".join(pstatus_list))
-                                set_value(field_data["attrs"], pstatus)
-
-                        if p.sticky:
-                                set_value(field_data["sticky"], _("true"))
-                        else:
-                                set_value(field_data["sticky"], _("false"))
-                        if not p.disabled:
-                                set_value(field_data["enabled"], _("true"))
-                        else:
-                                set_value(field_data["enabled"], _("false"))
-                        if p.sys_pub:
-                                set_value(field_data["syspub"], _("true"))
-                        else:
-                                set_value(field_data["syspub"], _("false"))
-
-                        # Only show the selected repository's information in
-                        # summary view.
-                        if p.repository:
-                                origins = p.repository.origins
-                                mirrors = p.repository.mirrors
-                        else:
-                                origins = mirrors = []
-
-                        set_value(field_data["repo_loc"], "")
-                        set_value(field_data["proxied"], "")
-                        # Update field_data for each origin and output
-                        # a publisher record in our desired format.
-                        for uri in sorted(origins):
-                                # XXX get the real origin status
-                                set_value(field_data["type"], _("origin"))
-                                set_value(field_data["proxy"], "-")
-                                set_value(field_data["proxied"], "F")
-
-                                set_value(field_data["uri"], uri)
-                                if uri.disabled:
-                                        set_value(field_data["enabled"],
-                                            _("false"))
-                                        set_value(field_data["status"],
-                                            _("disabled"))
-                                else:
-                                        set_value(field_data["enabled"],
-                                            _("true"))
-                                        set_value(field_data["status"],
-                                            _("online"))
-
-                                if uri.proxies:
-                                        set_value(field_data["proxied"], _("T"))
-                                        set_value(field_data["proxy"],
-                                            ", ".join(
-                                            [proxy.uri
-                                            for proxy in uri.proxies]))
-                                if uri.system:
-                                        set_value(field_data["repo_loc"],
-                                            SYSREPO_HIDDEN_URI)
-                                else:
-                                        set_value(field_data["repo_loc"], uri)
-
-                                values = map(get_value,
-                                    sorted(filter(filter_func,
-                                    field_data.values()), key=key_fields)
-                                )
-                                entry = []
-                                for e in values:
-                                        if isinstance(e, six.string_types):
-                                                entry.append(e)
-                                        else:
-                                                entry.append(str(e))
-                                data["publishers"].append(entry)
-                        # Update field_data for each mirror and output
-                        # a publisher record in our desired format.
-                        for uri in mirrors:
-                                # XXX get the real mirror status
-                                set_value(field_data["type"], _("mirror"))
-                                # We do not currently deal with mirrors. So
-                                # they are always online.
-                                set_value(field_data["status"], _("online"))
-                                set_value(field_data["proxy"], "-")
-                                set_value(field_data["proxied"], _("F"))
-
-                                set_value(field_data["uri"], uri)
-
-                                if uri.proxies:
-                                        set_value(field_data["proxied"],
-                                            _("T"))
-                                        set_value(field_data["proxy"],
-                                            ", ".join(
-                                            [p.uri for p in uri.proxies]))
-                                if uri.system:
-                                        set_value(field_data["repo_loc"],
-                                            SYSREPO_HIDDEN_URI)
-                                else:
-                                        set_value(field_data["repo_loc"], uri)
-
-                                values = map(get_value,
-                                    sorted(filter(filter_func,
-                                    field_data.values()), key=key_fields)
-                                )
-                                entry = []
-                                for e in values:
-                                        if isinstance(e, six.string_types):
-                                                entry.append(e)
-                                        else:
-                                                entry.append(str(e))
-                                data["publishers"].append(entry)
-
-                        if not origins and not mirrors:
-                                set_value(field_data["type"], "")
-                                set_value(field_data["status"], "")
-                                set_value(field_data["uri"], "")
-                                set_value(field_data["proxy"], "")
-                                values = map(get_value,
-                                    sorted(filter(filter_func,
-                                    field_data.values()), key=key_fields)
-                                )
-                                entry = []
-                                for e in values:
-                                        if isinstance(e, six.string_types):
-                                                entry.append(e)
-                                        else:
-                                                entry.append(str(e))
-                                data["publishers"].append(entry)
+        if "package_attrs" not in data:
+            data["package_attrs"] = [attr_list]
         else:
-                def collect_ssl_info(uri, uri_data):
-                        retcode = EXIT_OK
-                        c = get_cert_info(uri.ssl_cert)
-                        uri_data["SSL Key"] = str(uri.ssl_key)
-                        uri_data["SSL Cert"] = str(uri.ssl_cert)
+            data["package_attrs"].append(attr_list)
 
-                        if not c:
-                                return retcode
-
-                        if c["errors"]:
-                                retcode = EXIT_OOPS
-
-                        for e in c["errors"]:
-                                errors_json.append({"reason":
-                                    "\n" + str(e) + "\n", "errtype": "cert_info"})
-
-                        if c["valid"]:
-                                uri_data["Cert. Effective Date"] = \
-                                    str(c["info"]["effective"])
-                                uri_data["Cert. Expiration Date"] = \
-                                    str(c["info"]["expiration"])
-                        return retcode
-
-                def collect_repository(r, pub_data):
-                        retcode = 0
-                        origins_data = []
-                        for uri in r.origins:
-                                origin_data = {"Origin URI": str(uri)}
-                                if uri.disabled:
-                                        origin_data["Status"] = _("Disabled")
-                                else:
-                                        origin_data["Status"] = _("Online")
-                                if uri.proxies:
-                                        origin_data["Proxy"] = \
-                                            [str(p.uri) for p in uri.proxies]
-                                rval = collect_ssl_info(uri, origin_data)
-                                if rval == 1:
-                                        retcode = EXIT_PARTIAL
-                                origins_data.append(origin_data)
-
-                        mirrors_data = []
-                        for uri in r.mirrors:
-                                mirror_data = {"Mirror URI": str(uri)}
-                                mirror_data["Status"] = _("Online")
-                                if uri.proxies:
-                                        mirror_data["Proxy"] = \
-                                            [str(p.uri) for p in uri.proxies]
-                                rval = collect_ssl_info(uri, mirror_data)
-                                if rval == 1:
-                                        retcode = EXIT_PARTIAL
-                                mirrors_data.append(mirror_data)
-                        if origins_data:
-                                pub_data["origins"] = origins_data
-                        if mirrors_data:
-                                pub_data["mirrors"] = mirrors_data
-                        return retcode
-
-                def collect_signing_certs(p, pub_data):
-                        if p.approved_ca_certs:
-                                pub_data["Approved CAs"] = [str(cert) for
-                                    cert in p.approved_ca_certs]
-                        if p.revoked_ca_certs:
-                                pub_data["Revoked CAs"] = [str(cert) for
-                                    cert in p.revoked_ca_certs]
-
-                for name in pargs:
-                        # detailed print
-                        pub = api_inst.get_publisher(prefix=name, alias=name)
-                        dt = api_inst.get_publisher_last_update_time(pub.prefix)
-                        if dt:
-                                dt = dt.strftime("%c")
-
-                        pub_data = {}
-                        pub_data["Publisher"] = pub.prefix
-                        pub_data["Alias"] = pub.alias
-
-                        rval = collect_repository(pub.repository, pub_data)
-                        if rval != 0:
-                                # There was an error in displaying some
-                                # of the information about a repository.
-                                # However, continue on.
-                                retcode = rval
-
-                        pub_data["Client UUID"] = pub.client_uuid
-                        pub_data["Catalog Updated"] = dt
-                        collect_signing_certs(pub, pub_data)
-                        if pub.disabled:
-                                pub_data["enabled"] = "No"
-                        else:
-                                pub_data["enabled"] = "Yes"
-                        if pub.sticky:
-                                pub_data["sticky"] = "Yes"
-                        else:
-                                pub_data["sticky"] = "No"
-                        if pub.sys_pub:
-                                pub_data["sys_pub"] = "Yes"
-                        else:
-                                pub_data["sys_pub"] = "No"
-                        if pub.properties:
-                                pub_data["Properties"] = {}
-                                for k, v in six.iteritems(pub.properties):
-                                        pub_data["Properties"][k] = v
-                        data.setdefault("publisher_details", []).append(
-                            pub_data)
-        return __prepare_json(retcode, data=data, errors=errors_json, op=op)
-
-def _info(op, api_inst, pargs, display_license, info_local, info_remote,
-    origins, quiet):
-        """Display information about a package or packages.
-        """
-
-        errors_json = []
-        data = {}
-        if info_remote and not pargs:
-                error = {"reason": _("must request remote info for specific "
-                    "packages")}
-                errors_json.append(error)
-                return __prepare_json(EXIT_BADOPT, errors=errors_json, op=op)
-
-        err = EXIT_OK
-        # Reset the progress tracker here, because we may have to switch to a
-        # different tracker due to the options parse.
-        api_inst.progresstracker = _get_tracker()
-
-        api_inst.progresstracker.set_purpose(
-            api_inst.progresstracker.PURPOSE_LISTING)
-
-        info_needed = api.PackageInfo.ALL_OPTIONS
-        if not display_license:
-                info_needed = api.PackageInfo.ALL_OPTIONS - \
-                    frozenset([api.PackageInfo.LICENSES])
-        info_needed -= api.PackageInfo.ACTION_OPTIONS
-        info_needed |= frozenset([api.PackageInfo.DEPENDENCIES])
-
-        try:
-                ret = api_inst.info(pargs, info_local, info_needed,
-                    ranked=info_remote, repos=origins)
-        except api_errors.ImageFormatUpdateNeeded as e:
-                _format_update_error(e, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.NoPackagesInstalledException:
-                _error_json(_("no packages installed"), errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.ApiException as e:
-                _error_json(e, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        pis = ret[api.ImageInterface.INFO_FOUND]
-        notfound = ret[api.ImageInterface.INFO_MISSING]
-        illegals = ret[api.ImageInterface.INFO_ILLEGALS]
-
-        if illegals:
-                # No other results will be returned if illegal patterns were
-                # specified.
-                for i in illegals:
-                        errors_json.append({"reason": str(i)})
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        no_licenses = []
-        for i, pi in enumerate(pis):
-                if display_license:
-                        if not pi.licenses:
-                                no_licenses.append(pi.fmri)
-                        elif not quiet:
-                                lics = []
-                                for lic in pi.licenses:
-                                        lics.append(str(lic))
-                                data.setdefault("licenses", []).append(
-                                    [pi.pkg_stem, lics])
-                        continue
-
-                if quiet:
-                        continue
-
-                state = ""
-                if api.PackageInfo.INSTALLED in pi.states:
-                        state = _("Installed")
-                elif api.PackageInfo.UNSUPPORTED in pi.states:
-                        state = _("Unsupported")
-                else:
-                        state = _("Not installed")
-
-                states = []
-                lparen = False
-                if api.PackageInfo.OBSOLETE in pi.states:
-                        states.append(_("Obsolete"))
-                elif api.PackageInfo.RENAMED in pi.states:
-                        states.append(_("Renamed"))
-                elif api.PackageInfo.LEGACY in pi.states:
-                        states.append(_("Legacy"))
-                if api.PackageInfo.FROZEN in pi.states:
-                        states.append(_("Frozen"))
-                if api.PackageInfo.MANUAL in pi.states:
-                        states.append(_("Manually installed"))
-                if len(states):
-                        state += ' ({})'.format(', '.join(states))
-
-                attr_list = []
-                seen = {}
-
-                def __append_attr_lists(label, values):
-                        """Given arguments label and values, either extend
-                        the existing list value or add new one to
-                        attr_list"""
-
-                        if not isinstance(values, list):
-                                values = [values]
-                        if label in seen:
-                                seen[label].extend(values)
-                        else:
-                                attr_list.append([label, values])
-                                seen[label] = values
-
-                __append_attr_lists(_("Name"), pi.pkg_stem)
-                __append_attr_lists(_("Summary"), pi.summary)
-                if pi.description:
-                        __append_attr_lists(_("Description"), pi.description)
-                if pi.category_info_list:
-                        category_info = []
-                        verbose = len(pi.category_info_list) > 1
-                        category_info.append \
-                            (pi.category_info_list[0].__str__(verbose))
-                        if len(pi.category_info_list) > 1:
-                                for ci in pi.category_info_list[1:]:
-                                        category_info.append \
-                                            (ci.__str__(verbose))
-                        __append_attr_lists(_("Category"), category_info)
-
-                __append_attr_lists(_("State"), state)
-
-                # Renamed packages have dependencies, but the dependencies
-                # may not apply to this image's variants so won't be
-                # returned.
-                if api.PackageInfo.RENAMED in pi.states:
-                        __append_attr_lists(_("Renamed to"), pi.dependencies)
-
-                # XXX even more info on the publisher would be nice?
-                __append_attr_lists(_("Publisher"), pi.publisher)
-                hum_ver = pi.get_attr_values("pkg.human-version")
-                if hum_ver and hum_ver[0] != str(pi.version):
-                        __append_attr_lists(_("Version"), "{0} ({1})".format(
-                            pi.version, hum_ver[0]))
-                else:
-                        __append_attr_lists(_("Version"), str(pi.version))
-
-                __append_attr_lists(_("Branch"), str(pi.branch))
-                __append_attr_lists(_("Packaging Date"), pi.packaging_date)
-                if pi.last_install:
-                        __append_attr_lists(_("Last Install Time"),
-                            pi.last_install)
-                if pi.last_update:
-                        __append_attr_lists(_("Last Update Time"),
-                            pi.last_update)
-                __append_attr_lists(_("Size"), misc.bytes_to_str(pi.size))
-                __append_attr_lists(_("FMRI"),
-                    pi.fmri.get_fmri(include_build=False))
-                # XXX add license/copyright info here?
-
-                addl_attr_list = {
-                    "info.keyword": _("Additional Keywords"),
-                    "info.upstream": _("Project Contact"),
-                    "info.maintainer": _("Project Maintainer"),
-                    "info.maintainer-url": _("Project Maintainer URL"),
-                    "pkg.detailed-url": _("Project URL"),
-                    "info.upstream-url": _("Project URL"),
-                    "info.repository-changeset": _("Repository Changeset"),
-                    "info.repository-url": _("Source URL"),
-                    "info.source-url": _("Source URL")
-                }
-
-                for key in addl_attr_list:
-                        if key in pi.attrs:
-                                __append_attr_lists(addl_attr_list[key],
-                                    pi.get_attr_values(key))
-
-                for key in pi.attrs:
-                        if key.startswith('info.source-url.'):
-                                __append_attr_lists(addl_attr_list[key[:15]],
-                                    pi.get_attr_values(key))
-
-                if "package_attrs" not in data:
-                        data["package_attrs"] = [attr_list]
-                else:
-                        data["package_attrs"].append(attr_list)
-
-        if notfound:
-                err_txt = ""
-                if pis:
-                        err = EXIT_PARTIAL
-                        if not quiet:
-                                err_txt += "\n"
-                else:
-                        err = EXIT_OOPS
-                if not quiet:
-                        if info_local:
-                                err_txt += _("""\
+    if notfound:
+        err_txt = ""
+        if pis:
+            err = EXIT_PARTIAL
+            if not quiet:
+                err_txt += "\n"
+        else:
+            err = EXIT_OOPS
+        if not quiet:
+            if info_local:
+                err_txt += _(
+                    """\
 pkg: info: no packages matching the following patterns you specified are
-installed on the system.  Try querying remotely instead:\n""")
-                        elif info_remote:
-                                err_txt += _("""\
+installed on the system.  Try querying remotely instead:\n"""
+                )
+            elif info_remote:
+                err_txt += _(
+                    """\
 pkg: info: no packages matching the following patterns you specified were
 found in the catalog.  Try relaxing the patterns, refreshing, and/or
-examining the catalogs:\n""")
-                        err_txt += "\n"
-                        for p in notfound:
-                                err_txt += "        {0}".format(p)
-                        errors_json.append({"reason": err_txt,
-                            "errtype": "info_not_found"})
+examining the catalogs:\n"""
+                )
+            err_txt += "\n"
+            for p in notfound:
+                err_txt += "        {0}".format(p)
+            errors_json.append({"reason": err_txt, "errtype": "info_not_found"})
 
-        if no_licenses:
-                err_txt = ""
-                if len(no_licenses) == len(pis):
-                        err = EXIT_OOPS
-                else:
-                        err = EXIT_PARTIAL
+    if no_licenses:
+        err_txt = ""
+        if len(no_licenses) == len(pis):
+            err = EXIT_OOPS
+        else:
+            err = EXIT_PARTIAL
 
-                if not quiet:
-                        err_txt += _("no license information could be found "
-                            "for the following packages:\n")
-                        for pfmri in no_licenses:
-                                err_txt += "\t{0}\n".format(pfmri)
-                        _error_json(err_txt, errors_json=errors_json,
-                            errorType="info_no_licenses")
+        if not quiet:
+            err_txt += _(
+                "no license information could be found "
+                "for the following packages:\n"
+            )
+            for pfmri in no_licenses:
+                err_txt += "\t{0}\n".format(pfmri)
+            _error_json(
+                err_txt, errors_json=errors_json, errorType="info_no_licenses"
+            )
 
-        return __prepare_json(err, errors=errors_json, data=data)
+    return __prepare_json(err, errors=errors_json, data=data)
 
-def _verify(op, api_inst, pargs, omit_headers, parsable_version, quiet, verbose,
-    unpackaged, unpackaged_only, verify_paths, display_plan_cb=None, logger=None):
-        """Determine if installed packages match manifests."""
 
-        errors_json = []
-        if pargs and unpackaged_only:
-                error = {"reason": _("can not report only unpackaged contents "
-                    "with package arguments.")}
-                errors_json.append(error)
-                return __prepare_json(EXIT_BADOPT, errors=errors_json)
+def _verify(
+    op,
+    api_inst,
+    pargs,
+    omit_headers,
+    parsable_version,
+    quiet,
+    verbose,
+    unpackaged,
+    unpackaged_only,
+    verify_paths,
+    display_plan_cb=None,
+    logger=None,
+):
+    """Determine if installed packages match manifests."""
 
-        return __api_op(op, api_inst, args=pargs, _noexecute=True,
-            _omit_headers=omit_headers, _quiet=quiet, _quiet_plan=True,
-            _verbose=verbose, _parsable_version=parsable_version,
-            _unpackaged=unpackaged, _unpackaged_only=unpackaged_only,
-            _verify_paths=verify_paths, display_plan_cb=display_plan_cb,
-            logger=logger)
+    errors_json = []
+    if pargs and unpackaged_only:
+        error = {
+            "reason": _(
+                "can not report only unpackaged contents "
+                "with package arguments."
+            )
+        }
+        errors_json.append(error)
+        return __prepare_json(EXIT_BADOPT, errors=errors_json)
 
-def _fix(op, api_inst, pargs, accept, backup_be, backup_be_name, be_activate,
-    be_name, new_be, noexecute, omit_headers, parsable_version, quiet,
-    show_licenses, verbose, unpackaged, display_plan_cb=None, logger=None):
-        """Fix packaging errors found in the image."""
+    return __api_op(
+        op,
+        api_inst,
+        args=pargs,
+        _noexecute=True,
+        _omit_headers=omit_headers,
+        _quiet=quiet,
+        _quiet_plan=True,
+        _verbose=verbose,
+        _parsable_version=parsable_version,
+        _unpackaged=unpackaged,
+        _unpackaged_only=unpackaged_only,
+        _verify_paths=verify_paths,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
 
-        return __api_op(op, api_inst, args=pargs, _accept=accept,
-            _noexecute=noexecute, _omit_headers=omit_headers, _quiet=quiet,
-            _show_licenses=show_licenses, _verbose=verbose, backup_be=backup_be,
-            backup_be_name=backup_be_name, be_activate=be_activate,
-            be_name=be_name, new_be=new_be, _parsable_version=parsable_version,
-            _unpackaged=unpackaged, display_plan_cb=display_plan_cb,
-            logger=logger)
+
+def _fix(
+    op,
+    api_inst,
+    pargs,
+    accept,
+    backup_be,
+    backup_be_name,
+    be_activate,
+    be_name,
+    new_be,
+    noexecute,
+    omit_headers,
+    parsable_version,
+    quiet,
+    show_licenses,
+    verbose,
+    unpackaged,
+    display_plan_cb=None,
+    logger=None,
+):
+    """Fix packaging errors found in the image."""
+
+    return __api_op(
+        op,
+        api_inst,
+        args=pargs,
+        _accept=accept,
+        _noexecute=noexecute,
+        _omit_headers=omit_headers,
+        _quiet=quiet,
+        _show_licenses=show_licenses,
+        _verbose=verbose,
+        backup_be=backup_be,
+        backup_be_name=backup_be_name,
+        be_activate=be_activate,
+        be_name=be_name,
+        new_be=new_be,
+        _parsable_version=parsable_version,
+        _unpackaged=unpackaged,
+        display_plan_cb=display_plan_cb,
+        logger=logger,
+    )
+
 
 def __refresh(api_inst, pubs, full_refresh=False):
-        """Private helper method for refreshing publisher data."""
+    """Private helper method for refreshing publisher data."""
 
-        errors_json = []
-        try:
-                # The user explicitly requested this refresh, so set the
-                # refresh to occur immediately.
-                api_inst.refresh(full_refresh=full_refresh,
-                    immediate=True, pubs=pubs)
-        except api_errors.ImageFormatUpdateNeeded as e:
-                _format_update_error(e, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.PublisherError as e:
-                _error_json(e, errors_json=errors_json)
-                _error_json(_("'pkg publisher' will show a list of publishers."
-                    ), errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except (api_errors.UnknownErrors, api_errors.PermissionsException) as e:
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                _error_json("\n" + str(e), errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.CatalogRefreshException as e:
-                if _collect_catalog_failures(e, errors=errors_json) == 0:
-                        return __prepare_json(EXIT_OOPS, errors=errors_json)
-                return __prepare_json(EXIT_PARTIAL, errors=errors_json)
-        return __prepare_json(EXIT_OK)
+    errors_json = []
+    try:
+        # The user explicitly requested this refresh, so set the
+        # refresh to occur immediately.
+        api_inst.refresh(full_refresh=full_refresh, immediate=True, pubs=pubs)
+    except api_errors.ImageFormatUpdateNeeded as e:
+        _format_update_error(e, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.PublisherError as e:
+        _error_json(e, errors_json=errors_json)
+        _error_json(
+            _("'pkg publisher' will show a list of publishers."),
+            errors_json=errors_json,
+        )
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except (api_errors.UnknownErrors, api_errors.PermissionsException) as e:
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        _error_json("\n" + str(e), errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.CatalogRefreshException as e:
+        if _collect_catalog_failures(e, errors=errors_json) == 0:
+            return __prepare_json(EXIT_OOPS, errors=errors_json)
+        return __prepare_json(EXIT_PARTIAL, errors=errors_json)
+    return __prepare_json(EXIT_OK)
+
 
 def _get_ssl_cert_key(root, is_zone, ssl_cert, ssl_key):
-        if ssl_cert is not None or ssl_key is not None:
-                # In the case of zones, the ssl cert given is assumed to
-                # be relative to the root of the image, not truly absolute.
-                orig_cwd = _get_orig_cwd()
-                if is_zone:
-                        if ssl_cert is not None:
-                                ssl_cert = os.path.abspath(
-                                    root + os.sep + ssl_cert)
-                        if ssl_key is not None:
-                                ssl_key = os.path.abspath(
-                                    root + os.sep + ssl_key)
-                elif orig_cwd:
-                        if ssl_cert and not os.path.isabs(ssl_cert):
-                                ssl_cert = os.path.normpath(os.path.join(
-                                    orig_cwd, ssl_cert))
-                        if ssl_key and not os.path.isabs(ssl_key):
-                                ssl_key = os.path.normpath(os.path.join(
-                                    orig_cwd, ssl_key))
-        return ssl_cert, ssl_key
+    if ssl_cert is not None or ssl_key is not None:
+        # In the case of zones, the ssl cert given is assumed to
+        # be relative to the root of the image, not truly absolute.
+        orig_cwd = _get_orig_cwd()
+        if is_zone:
+            if ssl_cert is not None:
+                ssl_cert = os.path.abspath(root + os.sep + ssl_cert)
+            if ssl_key is not None:
+                ssl_key = os.path.abspath(root + os.sep + ssl_key)
+        elif orig_cwd:
+            if ssl_cert and not os.path.isabs(ssl_cert):
+                ssl_cert = os.path.normpath(os.path.join(orig_cwd, ssl_cert))
+            if ssl_key and not os.path.isabs(ssl_key):
+                ssl_key = os.path.normpath(os.path.join(orig_cwd, ssl_key))
+    return ssl_cert, ssl_key
+
 
 def _set_pub_error_wrap(func, pfx, raise_errors, *args, **kwargs):
-        """Helper function to wrap set-publisher private methods.  Returns
-        a tuple of (return value, message).  Callers should check the return
-        value for errors."""
+    """Helper function to wrap set-publisher private methods.  Returns
+    a tuple of (return value, message).  Callers should check the return
+    value for errors."""
 
-        errors_json = []
-        try:
-                return func(*args, **kwargs)
-        except api_errors.CatalogRefreshException as e:
-                for entry in raise_errors:
-                        if isinstance(e, entry):
-                                raise
-                succeeded = _collect_catalog_failures(e,
-                    ignore_perms_failure=True, errors=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
+    errors_json = []
+    try:
+        return func(*args, **kwargs)
+    except api_errors.CatalogRefreshException as e:
+        for entry in raise_errors:
+            if isinstance(e, entry):
+                raise
+        succeeded = _collect_catalog_failures(
+            e, ignore_perms_failure=True, errors=errors_json
+        )
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
 
-        except api_errors.InvalidDepotResponseException as e:
-                for entry in raise_errors:
-                        if isinstance(e, entry):
-                                raise
-                if pfx:
-                        errors_json.append({"reason": _("The origin URIs for "
-                            "'{pubname}' do not appear to point to a valid "
-                            "pkg repository.\nPlease verify the repository's "
-                            "location and the client's network configuration."
-                            "\nAdditional details:\n\n{details}").format(
-                            pubname=pfx, details=str(e))})
-                        return __prepare_json(EXIT_OOPS, errors=errors_json)
-                errors_json.append({"reason": _("The specified URI does "
+    except api_errors.InvalidDepotResponseException as e:
+        for entry in raise_errors:
+            if isinstance(e, entry):
+                raise
+        if pfx:
+            errors_json.append(
+                {
+                    "reason": _(
+                        "The origin URIs for "
+                        "'{pubname}' do not appear to point to a valid "
+                        "pkg repository.\nPlease verify the repository's "
+                        "location and the client's network configuration."
+                        "\nAdditional details:\n\n{details}"
+                    ).format(pubname=pfx, details=str(e))
+                }
+            )
+            return __prepare_json(EXIT_OOPS, errors=errors_json)
+        errors_json.append(
+            {
+                "reason": _(
+                    "The specified URI does "
                     "not appear to point to a valid pkg repository.\nPlease "
                     "check the URI and the client's network configuration."
-                    "\nAdditional details:\n\n{0}").format(str(e))})
+                    "\nAdditional details:\n\n{0}"
+                ).format(str(e))
+            }
+        )
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.ImageFormatUpdateNeeded as e:
+        for entry in raise_errors:
+            if isinstance(e, entry):
+                raise
+        _format_update_error(e, errors_json=errors_json)
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.ApiException as e:
+        for entry in raise_errors:
+            if isinstance(e, entry):
+                raise
+        # Prepend a newline because otherwise the exception will
+        # be printed on the same line as the spinner.
+        errors_json.append({"reason": ("\n" + str(e))})
+        return __prepare_json(EXIT_OOPS, errors=errors_json)
+
+
+def _add_update_pub(
+    api_inst,
+    prefix,
+    pub=None,
+    disable=None,
+    sticky=None,
+    origin_uri=None,
+    add_mirrors=EmptyI,
+    remove_mirrors=EmptyI,
+    add_origins=EmptyI,
+    remove_origins=EmptyI,
+    enable_origins=EmptyI,
+    disable_origins=EmptyI,
+    ssl_cert=None,
+    ssl_key=None,
+    search_before=None,
+    search_after=None,
+    search_first=False,
+    reset_uuid=None,
+    refresh_allowed=False,
+    set_props=EmptyI,
+    add_prop_values=EmptyI,
+    remove_prop_values=EmptyI,
+    unset_props=EmptyI,
+    approved_cas=EmptyI,
+    revoked_cas=EmptyI,
+    unset_cas=EmptyI,
+    proxy_uri=None,
+):
+    repo = None
+    new_pub = False
+    errors_json = []
+    if not pub:
+        try:
+            pub = api_inst.get_publisher(
+                prefix=prefix, alias=prefix, duplicate=True
+            )
+            if reset_uuid:
+                pub.reset_client_uuid()
+            repo = pub.repository
+        except api_errors.UnknownPublisher as e:
+            if (
+                not origin_uri
+                and not add_origins
+                and (
+                    remove_origins
+                    or remove_mirrors
+                    or remove_prop_values
+                    or add_mirrors
+                    or enable_origins
+                    or disable_origins
+                )
+            ):
+                errors_json.append({"reason": str(e)})
                 return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.ImageFormatUpdateNeeded as e:
-                for entry in raise_errors:
-                        if isinstance(e, entry):
-                                raise
-                _format_update_error(e, errors_json=errors_json)
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.ApiException as e:
-                for entry in raise_errors:
-                        if isinstance(e, entry):
-                                raise
-                # Prepend a newline because otherwise the exception will
-                # be printed on the same line as the spinner.
-                errors_json.append({"reason": ("\n" + str(e))})
-                return __prepare_json(EXIT_OOPS, errors=errors_json)
 
-def _add_update_pub(api_inst, prefix, pub=None, disable=None, sticky=None,
-    origin_uri=None, add_mirrors=EmptyI, remove_mirrors=EmptyI,
-    add_origins=EmptyI, remove_origins=EmptyI, enable_origins=EmptyI,
-    disable_origins=EmptyI, ssl_cert=None, ssl_key=None,
-    search_before=None, search_after=None, search_first=False,
-    reset_uuid=None, refresh_allowed=False,
-    set_props=EmptyI, add_prop_values=EmptyI,
-    remove_prop_values=EmptyI, unset_props=EmptyI, approved_cas=EmptyI,
-    revoked_cas=EmptyI, unset_cas=EmptyI, proxy_uri=None):
+            # No pre-existing, so create a new one.
+            repo = publisher.Repository()
+            pub = publisher.Publisher(prefix, repository=repo)
+            new_pub = True
+    elif not api_inst.has_publisher(prefix=pub.prefix):
+        new_pub = True
 
-        repo = None
-        new_pub = False
-        errors_json = []
-        if not pub:
-                try:
-                        pub = api_inst.get_publisher(prefix=prefix,
-                            alias=prefix, duplicate=True)
-                        if reset_uuid:
-                                pub.reset_client_uuid()
-                        repo = pub.repository
-                except api_errors.UnknownPublisher as e:
-                        if not origin_uri and not add_origins and \
-                            (remove_origins or remove_mirrors or
-                            remove_prop_values or add_mirrors or
-                            enable_origins or disable_origins):
-                                errors_json.append({"reason": str(e)})
-                                return __prepare_json(EXIT_OOPS,
-                                    errors=errors_json)
-
-                        # No pre-existing, so create a new one.
-                        repo = publisher.Repository()
-                        pub = publisher.Publisher(prefix, repository=repo)
-                        new_pub = True
-        elif not api_inst.has_publisher(prefix=pub.prefix):
-                new_pub = True
-
+    if not repo:
+        repo = pub.repository
         if not repo:
-                repo = pub.repository
-                if not repo:
-                        # Could be a new publisher from auto-configuration
-                        # case where no origin was provided in repository
-                        # configuration.
-                        repo = publisher.Repository()
-                        pub.repository = repo
+            # Could be a new publisher from auto-configuration
+            # case where no origin was provided in repository
+            # configuration.
+            repo = publisher.Repository()
+            pub.repository = repo
 
-        if sticky is not None:
-                # Set stickiness only if provided
-                pub.sticky = sticky
+    if sticky is not None:
+        # Set stickiness only if provided
+        pub.sticky = sticky
 
-        if proxy_uri:
-                # we only support a single proxy for now.
-                proxies = [publisher.ProxyURI(proxy_uri)]
+    if proxy_uri:
+        # we only support a single proxy for now.
+        proxies = [publisher.ProxyURI(proxy_uri)]
+    else:
+        proxies = []
+
+    if origin_uri:
+        # For compatibility with old -O behaviour, treat -O as a wipe
+        # of existing origins and add the new one.
+
+        origin_uri = misc.parse_uri(origin_uri, cwd=_get_orig_cwd())
+
+        # Only use existing cert information if the new URI uses
+        # https for transport.
+        if (
+            repo.origins
+            and not (ssl_cert or ssl_key)
+            and any(
+                origin_uri.startswith(scheme + ":")
+                for scheme in publisher.SSL_SCHEMES
+            )
+        ):
+            for uri in repo.origins:
+                if ssl_cert is None:
+                    ssl_cert = uri.ssl_cert
+                if ssl_key is None:
+                    ssl_key = uri.ssl_key
+                break
+
+        repo.reset_origins()
+        o = publisher.RepositoryURI(origin_uri, proxies=proxies)
+        repo.add_origin(o)
+
+        # XXX once image configuration supports storing this
+        # information at the uri level, ssl info should be set
+        # here.
+
+    for entry in (
+        ("mirror", add_mirrors, remove_mirrors),
+        ("origin", add_origins, remove_origins),
+    ):
+        etype, add, remove = entry
+        # XXX once image configuration supports storing this
+        # information at the uri level, ssl info should be set
+        # here.
+        if "*" in remove:
+            getattr(repo, "reset_{0}s".format(etype))()
         else:
-                proxies = []
+            for u in remove:
+                getattr(repo, "remove_{0}".format(etype))(u)
 
-        if origin_uri:
-                # For compatibility with old -O behaviour, treat -O as a wipe
-                # of existing origins and add the new one.
+        for u in add:
+            uri = publisher.RepositoryURI(u, proxies=proxies)
+            try:
+                getattr(repo, "add_{0}".format(etype))(uri)
+            except (
+                api_errors.DuplicateSyspubOrigin,
+                api_errors.DuplicateRepositoryOrigin,
+            ):
+                # If this exception occurs, we know the
+                # origin already exists. Then if it is
+                # combined with --enable or --disable,
+                # we turn it into an update task for the
+                # origin. Otherwise, raise the exception
+                # again.
+                if not (disable_origins or enable_origins):
+                    raise
 
-                origin_uri = misc.parse_uri(origin_uri, cwd=_get_orig_cwd())
-
-                # Only use existing cert information if the new URI uses
-                # https for transport.
-                if repo.origins and not (ssl_cert or ssl_key) and \
-                    any(origin_uri.startswith(scheme + ":")
-                        for scheme in publisher.SSL_SCHEMES):
-
-                        for uri in repo.origins:
-                                if ssl_cert is None:
-                                        ssl_cert = uri.ssl_cert
-                                if ssl_key is None:
-                                        ssl_key = uri.ssl_key
-                                break
-
-                repo.reset_origins()
-                o = publisher.RepositoryURI(origin_uri, proxies=proxies)
-                repo.add_origin(o)
-
-                # XXX once image configuration supports storing this
-                # information at the uri level, ssl info should be set
-                # here.
-
-        for entry in (("mirror", add_mirrors, remove_mirrors), ("origin",
-            add_origins, remove_origins)):
-                etype, add, remove = entry
-                # XXX once image configuration supports storing this
-                # information at the uri level, ssl info should be set
-                # here.
-                if "*" in remove:
-                        getattr(repo, "reset_{0}s".format(etype))()
-                else:
-                        for u in remove:
-                                getattr(repo, "remove_{0}".format(etype))(u)
-
-                for u in add:
-                        uri = publisher.RepositoryURI(u, proxies=proxies)
-                        try:
-                                getattr(repo, "add_{0}".format(etype)
-                                    )(uri)
-                        except (api_errors.DuplicateSyspubOrigin,
-                            api_errors.DuplicateRepositoryOrigin):
-                                # If this exception occurs, we know the
-                                # origin already exists. Then if it is
-                                # combined with --enable or --disable,
-                                # we turn it into an update task for the
-                                # origin. Otherwise, raise the exception
-                                # again.
-                                if not (disable_origins or enable_origins):
-                                        raise
-
-        if disable is not None:
-                # Set disabled property only if provided.
-                # If "*" in enable or disable origins list or disable without
-                # enable or disable origins specified, then it is a publisher
-                # level disable.
-                if not (enable_origins or disable_origins):
-                        pub.disabled = disable
-                else:
-                        if disable_origins:
-                                if "*" in disable_origins:
-                                        for o in repo.origins:
-                                                o.disabled = True
-                                else:
-                                        for diso in disable_origins:
-                                                ori = repo.get_origin(diso)
-                                                ori.disabled = True
-                        if enable_origins:
-                                if "*" in enable_origins:
-                                        for o in repo.origins:
-                                                o.disabled = False
-                                else:
-                                        for eno in enable_origins:
-                                                ori = repo.get_origin(eno)
-                                                ori.disabled = False
-
-        # None is checked for here so that a client can unset a ssl_cert or
-        # ssl_key by using -k "" or -c "".
-        if ssl_cert is not None or ssl_key is not None:
-                # Assume the user wanted to update the ssl_cert or ssl_key
-                # information for *all* of the currently selected
-                # repository's origins and mirrors that use SSL schemes.
-                found_ssl = False
-                for uri in repo.origins:
-                        if uri.scheme not in publisher.SSL_SCHEMES:
-                                continue
-                        found_ssl = True
-                        if ssl_cert is not None:
-                                uri.ssl_cert = ssl_cert
-                        if ssl_key is not None:
-                                uri.ssl_key = ssl_key
-                for uri in repo.mirrors:
-                        if uri.scheme not in publisher.SSL_SCHEMES:
-                                continue
-                        found_ssl = True
-                        if ssl_cert is not None:
-                                uri.ssl_cert = ssl_cert
-                        if ssl_key is not None:
-                                uri.ssl_key = ssl_key
-
-                if (ssl_cert or ssl_key) and not found_ssl:
-                        # None of the origins or mirrors for the publisher
-                        # use SSL schemes so the cert and key information
-                        # won't be retained.
-                        errors_json.append({"reason": _("Publisher '{0}' does "
-                            "not have any SSL-based origins or mirrors."
-                            ).format(prefix)})
-                        return __prepare_json(EXIT_BADOPT, errors=errors_json)
-
-        if set_props or add_prop_values or remove_prop_values or unset_props:
-                pub.update_props(set_props=set_props,
-                    add_prop_values=add_prop_values,
-                    remove_prop_values=remove_prop_values,
-                    unset_props=unset_props)
-
-        if new_pub:
-                api_inst.add_publisher(pub,
-                    refresh_allowed=refresh_allowed, approved_cas=approved_cas,
-                    revoked_cas=revoked_cas, unset_cas=unset_cas,
-                    search_after=search_after, search_before=search_before,
-                    search_first=search_first)
+    if disable is not None:
+        # Set disabled property only if provided.
+        # If "*" in enable or disable origins list or disable without
+        # enable or disable origins specified, then it is a publisher
+        # level disable.
+        if not (enable_origins or disable_origins):
+            pub.disabled = disable
         else:
-                for ca in approved_cas:
-                        try:
-                                ca = os.path.normpath(
-                                    os.path.join(_get_orig_cwd(), ca))
-                                with open(ca, "rb") as fh:
-                                        s = fh.read()
-                        except EnvironmentError as e:
-                                if e.errno == errno.ENOENT:
-                                        raise api_errors.MissingFileArgumentException(
-                                            ca)
-                                elif e.errno == errno.EACCES:
-                                        raise api_errors.PermissionsException(
-                                            ca)
-                                raise
-                        pub.approve_ca_cert(s)
+            if disable_origins:
+                if "*" in disable_origins:
+                    for o in repo.origins:
+                        o.disabled = True
+                else:
+                    for diso in disable_origins:
+                        ori = repo.get_origin(diso)
+                        ori.disabled = True
+            if enable_origins:
+                if "*" in enable_origins:
+                    for o in repo.origins:
+                        o.disabled = False
+                else:
+                    for eno in enable_origins:
+                        ori = repo.get_origin(eno)
+                        ori.disabled = False
 
-                for hsh in revoked_cas:
-                        pub.revoke_ca_cert(hsh)
+    # None is checked for here so that a client can unset a ssl_cert or
+    # ssl_key by using -k "" or -c "".
+    if ssl_cert is not None or ssl_key is not None:
+        # Assume the user wanted to update the ssl_cert or ssl_key
+        # information for *all* of the currently selected
+        # repository's origins and mirrors that use SSL schemes.
+        found_ssl = False
+        for uri in repo.origins:
+            if uri.scheme not in publisher.SSL_SCHEMES:
+                continue
+            found_ssl = True
+            if ssl_cert is not None:
+                uri.ssl_cert = ssl_cert
+            if ssl_key is not None:
+                uri.ssl_key = ssl_key
+        for uri in repo.mirrors:
+            if uri.scheme not in publisher.SSL_SCHEMES:
+                continue
+            found_ssl = True
+            if ssl_cert is not None:
+                uri.ssl_cert = ssl_cert
+            if ssl_key is not None:
+                uri.ssl_key = ssl_key
 
-                for hsh in unset_cas:
-                        pub.unset_ca_cert(hsh)
+        if (ssl_cert or ssl_key) and not found_ssl:
+            # None of the origins or mirrors for the publisher
+            # use SSL schemes so the cert and key information
+            # won't be retained.
+            errors_json.append(
+                {
+                    "reason": _(
+                        "Publisher '{0}' does "
+                        "not have any SSL-based origins or mirrors."
+                    ).format(prefix)
+                }
+            )
+            return __prepare_json(EXIT_BADOPT, errors=errors_json)
 
-                api_inst.update_publisher(pub,
-                    refresh_allowed=refresh_allowed, search_after=search_after,
-                    search_before=search_before, search_first=search_first)
+    if set_props or add_prop_values or remove_prop_values or unset_props:
+        pub.update_props(
+            set_props=set_props,
+            add_prop_values=add_prop_values,
+            remove_prop_values=remove_prop_values,
+            unset_props=unset_props,
+        )
 
-        return __prepare_json(EXIT_OK)
+    if new_pub:
+        api_inst.add_publisher(
+            pub,
+            refresh_allowed=refresh_allowed,
+            approved_cas=approved_cas,
+            revoked_cas=revoked_cas,
+            unset_cas=unset_cas,
+            search_after=search_after,
+            search_before=search_before,
+            search_first=search_first,
+        )
+    else:
+        for ca in approved_cas:
+            try:
+                ca = os.path.normpath(os.path.join(_get_orig_cwd(), ca))
+                with open(ca, "rb") as fh:
+                    s = fh.read()
+            except EnvironmentError as e:
+                if e.errno == errno.ENOENT:
+                    raise api_errors.MissingFileArgumentException(ca)
+                elif e.errno == errno.EACCES:
+                    raise api_errors.PermissionsException(ca)
+                raise
+            pub.approve_ca_cert(s)
+
+        for hsh in revoked_cas:
+            pub.revoke_ca_cert(hsh)
+
+        for hsh in unset_cas:
+            pub.unset_ca_cert(hsh)
+
+        api_inst.update_publisher(
+            pub,
+            refresh_allowed=refresh_allowed,
+            search_after=search_after,
+            search_before=search_before,
+            search_first=search_first,
+        )
+
+    return __prepare_json(EXIT_OK)
+
 
 def _get_orig_cwd():
-        """Get the original current working directory."""
+    """Get the original current working directory."""
+    try:
+        orig_cwd = os.getcwd()
+    except OSError as e:
         try:
-                orig_cwd = os.getcwd()
-        except OSError as e:
-                try:
-                        orig_cwd = os.environ["PWD"]
-                        if not orig_cwd or orig_cwd[0] != "/":
-                                orig_cwd = None
-                except KeyError:
-                        orig_cwd = None
-        return orig_cwd
+            orig_cwd = os.environ["PWD"]
+            if not orig_cwd or orig_cwd[0] != "/":
+                orig_cwd = None
+        except KeyError:
+            orig_cwd = None
+    return orig_cwd
 
-def __pkg(subcommand, pargs_json, opts_json, pkg_image=None,
-    prog_delay=PROG_DELAY, prog_tracker=None, opts_mapping=misc.EmptyDict,
-    api_inst=None):
-        """Private function to invoke pkg subcommands."""
 
-        errors_json = []
-        if subcommand is None:
-                err = {"reason": "Sub-command cannot be none type."}
+def __pkg(
+    subcommand,
+    pargs_json,
+    opts_json,
+    pkg_image=None,
+    prog_delay=PROG_DELAY,
+    prog_tracker=None,
+    opts_mapping=misc.EmptyDict,
+    api_inst=None,
+):
+    """Private function to invoke pkg subcommands."""
+
+    errors_json = []
+    if subcommand is None:
+        err = {"reason": "Sub-command cannot be none type."}
+        errors_json.append(err)
+        return None, __prepare_json(EXIT_OOPS, errors=errors_json)
+    if subcommand not in cmds:
+        err = {"reason": "Unknown sub-command: {0}.".format(subcommand)}
+        errors_json.append(err)
+        return None, __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    arg_name = "pargs_json"
+    try:
+        if pargs_json is None:
+            pargs = []
+        # Pargs_json is already a list, use it.
+        elif isinstance(pargs_json, list):
+            pargs = pargs_json
+        else:
+            pargs = json.loads(pargs_json)
+        if not isinstance(pargs, list):
+            if not isinstance(pargs, six.string_types):
+                err = {"reason": "{0} is invalid.".format(arg_name)}
                 errors_json.append(err)
                 return None, __prepare_json(EXIT_OOPS, errors=errors_json)
-        if subcommand not in cmds:
-                err = {"reason": "Unknown sub-command: {0}.".format(
-                    subcommand)}
-                errors_json.append(err)
-                return None, __prepare_json(EXIT_OOPS, errors=errors_json)
+            misc.force_str(pargs)
+            pargs = [pargs]
+        else:
+            for idx in range(len(pargs)):
+                misc.force_str(pargs[idx])
+    except Exception as e:
+        err = {"reason": "{0} is invalid.".format(arg_name)}
+        errors_json.append(err)
+        return None, __prepare_json(EXIT_OOPS, errors=errors_json)
 
-        arg_name = "pargs_json"
+    try:
+        if opts_json is None:
+            opts = {}
+        # If opts_json is already a dict, use it.
+        elif isinstance(opts_json, dict):
+            opts = opts_json
+        else:
+            opts = json.loads(opts_json, object_hook=_strify)
+        if not isinstance(opts, dict):
+            err = {"reason": "opts_json is invalid."}
+            errors_json.append(err)
+            return None, __prepare_json(EXIT_OOPS, errors=errors_json)
+    except:
+        err = {"reason": "opts_json is invalid."}
+        errors_json.append(err)
+        return None, __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    try:
+        # Validate JSON input with JSON schema.
+        input_schema = _get_pkg_input_schema(
+            subcommand, opts_mapping=opts_mapping
+        )
+        json.validate({arg_name: pargs, "opts_json": opts}, input_schema)
+    except json.ValidationError as e:
+        return None, __prepare_json(EXIT_BADOPT, errors=[{"reason": str(e)}])
+
+    orig_cwd = _get_orig_cwd()
+
+    # Get ImageInterface and image object.
+    if not api_inst:
+        api_inst = __api_alloc(
+            pkg_image,
+            orig_cwd,
+            prog_delay=prog_delay,
+            prog_tracker=prog_tracker,
+            errors_json=errors_json,
+        )
+    if api_inst is None:
+        return None, __prepare_json(EXIT_OOPS, errors=errors_json)
+
+    func = cmds[subcommand][0]
+    # Get the available options for the requested operation to create the
+    # getopt parsing strings.
+    valid_opts = options.get_pkg_opts(subcommand, add_table=cmd_opts)
+    pargs_limit = None
+    if len(cmds[subcommand]) > 2:
+        pargs_limit = cmds[subcommand][2]
+
+    if not valid_opts:
+        # if there are no options for an op, it has its own processing.
         try:
-                if pargs_json is None:
-                        pargs = []
-                # Pargs_json is already a list, use it.
-                elif isinstance(pargs_json, list):
-                        pargs = pargs_json
+            if subcommand in ["unset-publisher"]:
+                return api_inst, func(subcommand, api_inst, pargs, **opts)
+            else:
+                return api_inst, func(api_inst, pargs, **opts)
+        except getopt.GetoptError as e:
+            err = {"reason": str(e)}
+            return api_inst, __prepare_json(EXIT_OOPS, errors=err)
+    try:
+        opt_dict = misc.opts_parse(
+            subcommand, [], valid_opts, opts_mapping, use_cli_opts=False, **opts
+        )
+        if pargs_limit is not None and len(pargs) > pargs_limit:
+            err = {
+                "reason": _("illegal argument -- {0}").format(
+                    pargs[pargs_limit]
+                )
+            }
+            return api_inst, __prepare_json(EXIT_OOPS, errors=err)
+        opts = options.opts_assemble(
+            subcommand, api_inst, opt_dict, add_table=cmd_opts, cwd=orig_cwd
+        )
+    except api_errors.InvalidOptionError as e:
+        # We can't use the string representation of the exception since
+        # it references internal option names. We substitute the RAD
+        # options and create a new exception to make sure the messages
+        # are correct.
+
+        # Convert the internal options to RAD options. We make sure that
+        # when there is a short and a long version for the same option
+        # we print both to avoid confusion.
+        def get_cli_opt(option):
+            try:
+                option_name = None
+                if option in opts_mapping:
+                    option_name = opts_mapping[option]
+
+                if option_name:
+                    return option_name
                 else:
-                        pargs = json.loads(pargs_json)
-                if not isinstance(pargs, list):
-                        if not isinstance(pargs, six.string_types):
-                                err = {"reason": "{0} is invalid.".format(
-                                    arg_name)}
-                                errors_json.append(err)
-                                return None, __prepare_json(EXIT_OOPS,
-                                    errors=errors_json)
-                        misc.force_str(pargs)
-                        pargs = [pargs]
-                else:
-                        for idx in range(len(pargs)):
-                                misc.force_str(pargs[idx])
-        except Exception as e:
-                err = {"reason": "{0} is invalid.".format(
-                    arg_name)}
-                errors_json.append(err)
-                return None, __prepare_json(EXIT_OOPS, errors=errors_json)
+                    return option
+            except KeyError:
+                # ignore if we can't find a match
+                # (happens for repeated arguments or invalid
+                # arguments)
+                return option
+            except TypeError:
+                # ignore if we can't find a match
+                # (happens for an invalid arguments list)
+                return option
 
+        cli_opts = []
+        opt_def = []
+
+        for o in e.options:
+            cli_opts.append(get_cli_opt(o))
+
+            # collect the default value (see comment below)
+            opt_def.append(
+                options.get_pkg_opts_defaults(subcommand, o, add_table=cmd_opts)
+            )
+
+        # Prepare for headache:
+        # If we have an option 'b' which is set to True by default it
+        # will be toggled to False if the users specifies the according
+        # option on the CLI.
+        # If we now have an option 'a' which requires option 'b' to be
+        # set, we can't say "'a' requires 'b'" because the user can only
+        # specify 'not b'. So the correct message would be:
+        # "'a' is incompatible with 'not b'".
+        # We can get there by just changing the type of the exception
+        # for all cases where the default value of one of the options is
+        # True.
+        if e.err_type == api_errors.InvalidOptionError.REQUIRED:
+            if len(opt_def) == 2 and (opt_def[0] or opt_def[1]):
+                e.err_type = api_errors.InvalidOptionError.INCOMPAT
+
+        # This new exception will have the CLI options, so can be passed
+        # directly to usage().
+        new_e = api_errors.InvalidOptionError(
+            err_type=e.err_type, options=cli_opts, msg=e.msg
+        )
+        err = {"reason": str(new_e)}
+        return api_inst, __prepare_json(EXIT_BADOPT, errors=err)
+    return api_inst, func(op=subcommand, api_inst=api_inst, pargs=pargs, **opts)
+
+
+def __handle_errors_json(
+    func,
+    non_wrap_print=True,
+    subcommand=None,
+    pargs_json=None,
+    opts_json=None,
+    pkg_image=None,
+    prog_delay=PROG_DELAY,
+    prog_tracker=None,
+    opts_mapping=misc.EmptyDict,
+    api_inst=None,
+    reset_api=False,
+):
+    """Error handling for pkg subcommands."""
+
+    traceback_str = misc.get_traceback_message()
+    errors_json = []
+
+    _api_inst = None
+    try:
+        # Out of memory errors can be raised as EnvironmentErrors with
+        # an errno of ENOMEM, so in order to handle those exceptions
+        # with other errnos, we nest this try block and have the outer
+        # one handle the other instances.
         try:
-                if opts_json is None:
-                        opts = {}
-                # If opts_json is already a dict, use it.
-                elif isinstance(opts_json, dict):
-                        opts = opts_json
-                else:
-                        opts = json.loads(opts_json, object_hook=_strify)
-                if not isinstance(opts, dict):
-                        err = {"reason": "opts_json is invalid."}
-                        errors_json.append(err)
-                        return None, __prepare_json(EXIT_OOPS,
-                            errors=errors_json)
-        except:
-                err = {"reason": "opts_json is invalid."}
-                errors_json.append(err)
-                return None, __prepare_json(EXIT_OOPS, errors=errors_json)
+            if non_wrap_print:
+                _api_inst, ret_json = func(
+                    subcommand,
+                    pargs_json,
+                    opts_json,
+                    pkg_image=pkg_image,
+                    prog_delay=prog_delay,
+                    prog_tracker=prog_tracker,
+                    opts_mapping=opts_mapping,
+                    api_inst=api_inst,
+                )
+            else:
+                func()
+        except (MemoryError, EnvironmentError) as __e:
+            if isinstance(__e, EnvironmentError) and __e.errno != errno.ENOMEM:
+                raise
+            if _api_inst:
+                _api_inst.abort(result=RESULT_FAILED_OUTOFMEMORY)
+            _error_json(misc.out_of_memory(), errors_json=errors_json)
+            ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except SystemExit as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
+        raise __e
+    except (PipeError, KeyboardInterrupt):
+        if _api_inst:
+            _api_inst.abort(result=RESULT_CANCELED)
+        # We don't want to display any messages here to prevent
+        # possible further broken pipe (EPIPE) errors.
+        ret_json = __prepare_json(EXIT_OOPS)
+    except api_errors.LinkedImageException as __e:
+        _error_json(
+            _("Linked image exception(s):\n{0}").format(str(__e)),
+            errors_json=errors_json,
+        )
+        ret_json = __prepare_json(__e.lix_exitrv, errors=errors_json)
+    except api_errors.CertificateError as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_CONFIGURATION)
+        _error_json(__e, errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.PublisherError as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_BAD_REQUEST)
+        _error_json(__e, errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.ImageLockedError as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_LOCKED)
+        _error_json(__e, errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_LOCKED, errors=errors_json)
+    except api_errors.TransportError as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_TRANSPORT)
 
-        try:
-                # Validate JSON input with JSON schema.
-                input_schema = _get_pkg_input_schema(subcommand,
-                    opts_mapping=opts_mapping)
-                json.validate({arg_name: pargs, "opts_json": opts},
-                    input_schema)
-        except json.ValidationError as e:
-                return None, __prepare_json(EXIT_BADOPT,
-                    errors=[{"reason": str(e)}])
-
-        orig_cwd = _get_orig_cwd()
-
-        # Get ImageInterface and image object.
-        if not api_inst:
-                api_inst = __api_alloc(pkg_image, orig_cwd,
-                    prog_delay=prog_delay, prog_tracker=prog_tracker,
-                    errors_json=errors_json)
-        if api_inst is None:
-                return None, __prepare_json(EXIT_OOPS, errors=errors_json)
-
-        func = cmds[subcommand][0]
-        # Get the available options for the requested operation to create the
-        # getopt parsing strings.
-        valid_opts = options.get_pkg_opts(subcommand, add_table=cmd_opts)
-        pargs_limit = None
-        if len(cmds[subcommand]) > 2:
-                pargs_limit = cmds[subcommand][2]
-
-        if not valid_opts:
-                # if there are no options for an op, it has its own processing.
-                try:
-                        if subcommand in ["unset-publisher"]:
-                                return api_inst, func(subcommand, api_inst, pargs,
-                                    **opts)
-                        else:
-                                return api_inst, func(api_inst, pargs, **opts)
-                except getopt.GetoptError as e:
-                        err = {"reason": str(e)}
-                        return api_inst, __prepare_json(EXIT_OOPS, errors=err)
-        try:
-                opt_dict = misc.opts_parse(subcommand, [],
-                    valid_opts, opts_mapping, use_cli_opts=False, **opts)
-                if pargs_limit is not None and len(pargs) > pargs_limit:
-                        err = {"reason": _("illegal argument -- {0}").format(
-                            pargs[pargs_limit])}
-                        return api_inst, __prepare_json(EXIT_OOPS, errors=err)
-                opts = options.opts_assemble(subcommand, api_inst, opt_dict,
-                        add_table=cmd_opts, cwd=orig_cwd)
-        except api_errors.InvalidOptionError as e:
-                # We can't use the string representation of the exception since
-                # it references internal option names. We substitute the RAD
-                # options and create a new exception to make sure the messages
-                # are correct.
-
-                # Convert the internal options to RAD options. We make sure that
-                # when there is a short and a long version for the same option
-                # we print both to avoid confusion.
-                def get_cli_opt(option):
-                        try:
-                                option_name = None
-                                if option in opts_mapping:
-                                        option_name = opts_mapping[option]
-
-                                if option_name:
-                                        return option_name
-                                else:
-                                        return option
-                        except KeyError:
-                                # ignore if we can't find a match
-                                # (happens for repeated arguments or invalid
-                                # arguments)
-                                return option
-                        except TypeError:
-                                # ignore if we can't find a match
-                                # (happens for an invalid arguments list)
-                                return option
-                cli_opts = []
-                opt_def = []
-
-                for o in e.options:
-                        cli_opts.append(get_cli_opt(o))
-
-                        # collect the default value (see comment below)
-                        opt_def.append(options.get_pkg_opts_defaults(subcommand,
-                            o, add_table=cmd_opts))
-
-                # Prepare for headache:
-                # If we have an option 'b' which is set to True by default it
-                # will be toggled to False if the users specifies the according
-                # option on the CLI.
-                # If we now have an option 'a' which requires option 'b' to be
-                # set, we can't say "'a' requires 'b'" because the user can only
-                # specify 'not b'. So the correct message would be:
-                # "'a' is incompatible with 'not b'".
-                # We can get there by just changing the type of the exception
-                # for all cases where the default value of one of the options is
-                # True.
-                if e.err_type == api_errors.InvalidOptionError.REQUIRED:
-                        if len(opt_def) == 2 and (opt_def[0] or opt_def[1]):
-                                e.err_type = \
-                                    api_errors.InvalidOptionError.INCOMPAT
-
-                # This new exception will have the CLI options, so can be passed
-                # directly to usage().
-                new_e = api_errors.InvalidOptionError(err_type=e.err_type,
-                    options=cli_opts, msg=e.msg)
-                err = {"reason": str(new_e)}
-                return api_inst, __prepare_json(EXIT_BADOPT, errors=err)
-        return api_inst, func(op=subcommand, api_inst=api_inst,
-            pargs=pargs, **opts)
-
-def __handle_errors_json(func, non_wrap_print=True, subcommand=None,
-    pargs_json=None, opts_json=None, pkg_image=None,
-    prog_delay=PROG_DELAY, prog_tracker=None, opts_mapping=misc.EmptyDict,
-    api_inst=None, reset_api=False):
-        """Error handling for pkg subcommands."""
-
-        traceback_str = misc.get_traceback_message()
-        errors_json = []
-
-        _api_inst = None
-        try:
-                # Out of memory errors can be raised as EnvironmentErrors with
-                # an errno of ENOMEM, so in order to handle those exceptions
-                # with other errnos, we nest this try block and have the outer
-                # one handle the other instances.
-                try:
-                        if non_wrap_print:
-                                _api_inst, ret_json = func(subcommand, pargs_json,
-                                    opts_json, pkg_image=pkg_image,
-                                    prog_delay=prog_delay,
-                                    prog_tracker=prog_tracker,
-                                    opts_mapping=opts_mapping,
-                                    api_inst=api_inst)
-                        else:
-                                func()
-                except (MemoryError, EnvironmentError) as __e:
-                        if isinstance(__e, EnvironmentError) and \
-                            __e.errno != errno.ENOMEM:
-                                raise
-                        if _api_inst:
-                                _api_inst.abort(
-                                    result=RESULT_FAILED_OUTOFMEMORY)
-                        _error_json(misc.out_of_memory(),
-                            errors_json=errors_json)
-                        ret_json = __prepare_json(EXIT_OOPS,
-                            errors=errors_json)
-        except SystemExit as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
-                raise __e
-        except (PipeError, KeyboardInterrupt):
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_CANCELED)
-                # We don't want to display any messages here to prevent
-                # possible further broken pipe (EPIPE) errors.
-                ret_json = __prepare_json(EXIT_OOPS)
-        except api_errors.LinkedImageException as __e:
-                _error_json(_("Linked image exception(s):\n{0}").format(
-                      str(__e)), errors_json=errors_json)
-                ret_json = __prepare_json(__e.lix_exitrv, errors=errors_json)
-        except api_errors.CertificateError as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_CONFIGURATION)
-                _error_json(__e, errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.PublisherError as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_BAD_REQUEST)
-                _error_json(__e, errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.ImageLockedError as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_LOCKED)
-                _error_json(__e, errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_LOCKED, errors=errors_json)
-        except api_errors.TransportError as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_TRANSPORT)
-
-                errors_json.append({"reason": _("Errors were encountered "
+        errors_json.append(
+            {
+                "reason": _(
+                    "Errors were encountered "
                     "while attempting to retrieve package or file data "
-                    "for the requested operation.")})
-                errors_json.append({"reason": _("Details follow:\n\n{0}"
-                    ).format(__e)})
-                _collect_proxy_config_errors(errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.InvalidCatalogFile as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_STORAGE)
-                errors_json.append({"reason": _("An error was encountered "
+                    "for the requested operation."
+                )
+            }
+        )
+        errors_json.append({"reason": _("Details follow:\n\n{0}").format(__e)})
+        _collect_proxy_config_errors(errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.InvalidCatalogFile as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_STORAGE)
+        errors_json.append(
+            {
+                "reason": _(
+                    "An error was encountered "
                     "while attempting to read image state information to "
                     "perform the requested operation. Details follow:\n\n{0}"
-                    ).format(__e)})
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.InvalidDepotResponseException as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_TRANSPORT)
-                errors_json.append({"reason": _("\nUnable to contact a valid "
+                ).format(__e)
+            }
+        )
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.InvalidDepotResponseException as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_TRANSPORT)
+        errors_json.append(
+            {
+                "reason": _(
+                    "\nUnable to contact a valid "
                     "package repository. This may be due to a problem with "
                     "the repository, network misconfiguration, or an "
                     "incorrect pkg client configuration.  Please verify the "
                     "client's network configuration and repository's location."
-                    "\nAdditional details:\n\n{0}").format(__e)})
-                _collect_proxy_config_errors(errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.HistoryLoadException as __e:
-                # Since a history related error occurred, discard all
-                # information about the current operation(s) in progress.
-                if _api_inst:
-                        _api_inst.clear_history()
-                _error_json(_("An error was encountered while attempting to "
-                    "load history information\nabout past client operations."),
-                    errors_json=errors_json)
-                _error_json(__e, errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.HistoryStoreException as __e:
-                # Since a history related error occurred, discard all
-                # information about the current operation(s) in progress.
-                if _api_inst:
-                        _api_inst.clear_history()
-                _error_json({"reason": _("An error was encountered while "
+                    "\nAdditional details:\n\n{0}"
+                ).format(__e)
+            }
+        )
+        _collect_proxy_config_errors(errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.HistoryLoadException as __e:
+        # Since a history related error occurred, discard all
+        # information about the current operation(s) in progress.
+        if _api_inst:
+            _api_inst.clear_history()
+        _error_json(
+            _(
+                "An error was encountered while attempting to "
+                "load history information\nabout past client operations."
+            ),
+            errors_json=errors_json,
+        )
+        _error_json(__e, errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.HistoryStoreException as __e:
+        # Since a history related error occurred, discard all
+        # information about the current operation(s) in progress.
+        if _api_inst:
+            _api_inst.clear_history()
+        _error_json(
+            {
+                "reason": _(
+                    "An error was encountered while "
                     "attempting to store information about the\ncurrent "
                     "operation in client history. Details follow:\n\n{0}"
-                    ).format(__e)}, errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.HistoryPurgeException as __e:
-                # Since a history related error occurred, discard all
-                # information about the current operation(s) in progress.
-                if _api_inst:
-                        _api_inst.clear_history()
-                errors_json.append({"reason": _("An error was encountered "
+                ).format(__e)
+            },
+            errors_json=errors_json,
+        )
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.HistoryPurgeException as __e:
+        # Since a history related error occurred, discard all
+        # information about the current operation(s) in progress.
+        if _api_inst:
+            _api_inst.clear_history()
+        errors_json.append(
+            {
+                "reason": _(
+                    "An error was encountered "
                     "while attempting to purge client history. "
-                    "Details follow:\n\n{0}").format(__e)})
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.VersionException as __e:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
-                _error_json(_("The pkg command appears out of sync with the "
-                    "libraries provided\nby pkg:/package/pkg. The client "
-                    "version is {client} while the library\nAPI version is "
-                    "{api}.").format(client=__e.received_version,
-                    api=__e.expected_version), errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.WrapSuccessfulIndexingException as __e:
-                ret_json = __prepare_json(EXIT_OK)
-        except api_errors.WrapIndexingException as __e:
-                def _wrapper():
-                        raise __e.wrapped
-                ret_json = __handle_errors_json(_wrapper, non_wrap_print=False)
+                    "Details follow:\n\n{0}"
+                ).format(__e)
+            }
+        )
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.VersionException as __e:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
+        _error_json(
+            _(
+                "The pkg command appears out of sync with the "
+                "libraries provided\nby pkg:/package/pkg. The client "
+                "version is {client} while the library\nAPI version is "
+                "{api}."
+            ).format(client=__e.received_version, api=__e.expected_version),
+            errors_json=errors_json,
+        )
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.WrapSuccessfulIndexingException as __e:
+        ret_json = __prepare_json(EXIT_OK)
+    except api_errors.WrapIndexingException as __e:
 
-                s = ""
-                if ret_json["status"] == 99:
-                        s += _("\n{err}{stacktrace}").format(
-                        err=__e, stacktrace=traceback_str)
+        def _wrapper():
+            raise __e.wrapped
 
-                s += _("\n\nDespite the error while indexing, the operation "
-                    "has completed successfuly.")
-                _error_json(s, errors_json=errors_json)
-                if "errors" in ret_json:
-                        ret_json["errors"].extend(errors_json)
-                else:
-                        ret_json["errors"] = errors_json
-        except api_errors.ReadOnlyFileSystemException as __e:
-                _error_json("The file system is read only.",
-                    errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.UnexpectedLinkError as __e:
-                _error_json(str(__e), errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.UnrecognizedCatalogPart as __e:
-                _error_json(str(__e), errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except api_errors.InvalidConfigFile as __e:
-                _error_json(str(__e), errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except (api_errors.PkgUnicodeDecodeError, UnicodeEncodeError) as __e:
-                _error_json(str(__e), errors_json=errors_json)
-                ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
-        except:
-                if _api_inst:
-                        _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
-                if non_wrap_print:
-                        traceback.print_exc()
-                        _error_json(traceback.format_exc()+"\n"+traceback_str,
-                            errors_json=errors_json)
-                ret_json = __prepare_json(99, errors=errors_json)
+        ret_json = __handle_errors_json(_wrapper, non_wrap_print=False)
 
-        if reset_api:
-                try:
-                        if _api_inst:
-                                _api_inst.reset()
-                except:
-                        # If any errors occur during reset, we will discard
-                        # this api_inst.
-                        _api_inst = None
+        s = ""
+        if ret_json["status"] == 99:
+            s += _("\n{err}{stacktrace}").format(
+                err=__e, stacktrace=traceback_str
+            )
 
-        return _api_inst, ret_json
-
-def _pkg_invoke(subcommand=None, pargs_json=None, opts_json=None, pkg_image=None,
-    prog_delay=PROG_DELAY, prog_tracker=None, opts_mapping=misc.EmptyDict,
-    api_inst=None, reset_api=False, return_api=False):
-        """pkg subcommands invocation. Output will be in JSON format.
-        subcommand: a string type pkg subcommand.
-
-        pargs_json: a JSON blob containing a list of pargs.
-
-        opts_json: a JSON blob containing a dictionary of pkg
-        subcommand options.
-
-        pkg_image: a string type alternate image path.
-
-        prog_delay: long progress event delay in sec.
-
-        prog_tracker: progress tracker object.
-
-        alternate_pargs_name: by default, 'pargs_json' will be the name in
-            input JSON schema. This option allows consumer to change the
-            pargs_json into an alternate name.
-        """
-
-        _api_inst, ret_json = __handle_errors_json(__pkg,
-            subcommand=subcommand, pargs_json=pargs_json,
-            opts_json=opts_json, pkg_image=pkg_image,
-            prog_delay=prog_delay, prog_tracker=prog_tracker,
-            opts_mapping=opts_mapping, api_inst=api_inst, reset_api=reset_api)
-        if return_api:
-                return _api_inst, ret_json
+        s += _(
+            "\n\nDespite the error while indexing, the operation "
+            "has completed successfuly."
+        )
+        _error_json(s, errors_json=errors_json)
+        if "errors" in ret_json:
+            ret_json["errors"].extend(errors_json)
         else:
-                return ret_json
+            ret_json["errors"] = errors_json
+    except api_errors.ReadOnlyFileSystemException as __e:
+        _error_json("The file system is read only.", errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.UnexpectedLinkError as __e:
+        _error_json(str(__e), errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.UnrecognizedCatalogPart as __e:
+        _error_json(str(__e), errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except api_errors.InvalidConfigFile as __e:
+        _error_json(str(__e), errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except (api_errors.PkgUnicodeDecodeError, UnicodeEncodeError) as __e:
+        _error_json(str(__e), errors_json=errors_json)
+        ret_json = __prepare_json(EXIT_OOPS, errors=errors_json)
+    except:
+        if _api_inst:
+            _api_inst.abort(result=RESULT_FAILED_UNKNOWN)
+        if non_wrap_print:
+            traceback.print_exc()
+            _error_json(
+                traceback.format_exc() + "\n" + traceback_str,
+                errors_json=errors_json,
+            )
+        ret_json = __prepare_json(99, errors=errors_json)
+
+    if reset_api:
+        try:
+            if _api_inst:
+                _api_inst.reset()
+        except:
+            # If any errors occur during reset, we will discard
+            # this api_inst.
+            _api_inst = None
+
+    return _api_inst, ret_json
+
+
+def _pkg_invoke(
+    subcommand=None,
+    pargs_json=None,
+    opts_json=None,
+    pkg_image=None,
+    prog_delay=PROG_DELAY,
+    prog_tracker=None,
+    opts_mapping=misc.EmptyDict,
+    api_inst=None,
+    reset_api=False,
+    return_api=False,
+):
+    """pkg subcommands invocation. Output will be in JSON format.
+    subcommand: a string type pkg subcommand.
+
+    pargs_json: a JSON blob containing a list of pargs.
+
+    opts_json: a JSON blob containing a dictionary of pkg
+    subcommand options.
+
+    pkg_image: a string type alternate image path.
+
+    prog_delay: long progress event delay in sec.
+
+    prog_tracker: progress tracker object.
+
+    alternate_pargs_name: by default, 'pargs_json' will be the name in
+        input JSON schema. This option allows consumer to change the
+        pargs_json into an alternate name.
+    """
+
+    _api_inst, ret_json = __handle_errors_json(
+        __pkg,
+        subcommand=subcommand,
+        pargs_json=pargs_json,
+        opts_json=opts_json,
+        pkg_image=pkg_image,
+        prog_delay=prog_delay,
+        prog_tracker=prog_tracker,
+        opts_mapping=opts_mapping,
+        api_inst=api_inst,
+        reset_api=reset_api,
+    )
+    if return_api:
+        return _api_inst, ret_json
+    else:
+        return ret_json
+
 
 class ClientInterface(object):
-        """Class to provide a general interface to various clients."""
+    """Class to provide a general interface to various clients."""
 
-        def __init__(self, pkg_image=None, prog_delay=PROG_DELAY,
-            prog_tracker=None, opts_mapping=misc.EmptyDict):
-                self.api_inst = None
-                self.pkg_image = pkg_image
-                self.prog_delay = prog_delay
-                self.prog_tracker = prog_tracker
-                self.opts_mapping = opts_mapping
+    def __init__(
+        self,
+        pkg_image=None,
+        prog_delay=PROG_DELAY,
+        prog_tracker=None,
+        opts_mapping=misc.EmptyDict,
+    ):
+        self.api_inst = None
+        self.pkg_image = pkg_image
+        self.prog_delay = prog_delay
+        self.prog_tracker = prog_tracker
+        self.opts_mapping = opts_mapping
 
-        def __cmd_invoke(self, cmd, pargs_json=None, opts_json=None):
-                """Helper function for command invocation."""
+    def __cmd_invoke(self, cmd, pargs_json=None, opts_json=None):
+        """Helper function for command invocation."""
 
-                # We will always reset api instance on exception.
-                _api_inst, ret_json = _pkg_invoke(cmd, pargs_json=pargs_json,
-                    opts_json=opts_json, pkg_image=self.pkg_image,
-                    prog_delay=self.prog_delay, prog_tracker=self.prog_tracker,
-                    opts_mapping=self.opts_mapping, api_inst=self.api_inst,
-                    reset_api=True, return_api=True)
-                self.api_inst = _api_inst
-                return ret_json
+        # We will always reset api instance on exception.
+        _api_inst, ret_json = _pkg_invoke(
+            cmd,
+            pargs_json=pargs_json,
+            opts_json=opts_json,
+            pkg_image=self.pkg_image,
+            prog_delay=self.prog_delay,
+            prog_tracker=self.prog_tracker,
+            opts_mapping=self.opts_mapping,
+            api_inst=self.api_inst,
+            reset_api=True,
+            return_api=True,
+        )
+        self.api_inst = _api_inst
+        return ret_json
 
-        def list_inventory(self, pargs_json=None, opts_json=None):
-                """Invoke pkg list subcommand."""
+    def list_inventory(self, pargs_json=None, opts_json=None):
+        """Invoke pkg list subcommand."""
 
-                return self.__cmd_invoke("list", pargs_json=pargs_json,
-                    opts_json=opts_json)
+        return self.__cmd_invoke(
+            "list", pargs_json=pargs_json, opts_json=opts_json
+        )
 
-        def info(self, pargs_json=None, opts_json=None):
-                """Invoke pkg info subcommand."""
+    def info(self, pargs_json=None, opts_json=None):
+        """Invoke pkg info subcommand."""
 
-                return self.__cmd_invoke("info", pargs_json=pargs_json,
-                    opts_json=opts_json)
+        return self.__cmd_invoke(
+            "info", pargs_json=pargs_json, opts_json=opts_json
+        )
 
-        def exact_install(self, pargs_json=None, opts_json=None):
-                """Invoke pkg exact-install subcommand."""
+    def exact_install(self, pargs_json=None, opts_json=None):
+        """Invoke pkg exact-install subcommand."""
 
-                return self.__cmd_invoke("exact-install",
-                    pargs_json=pargs_json, opts_json=opts_json)
+        return self.__cmd_invoke(
+            "exact-install", pargs_json=pargs_json, opts_json=opts_json
+        )
 
-        def install(self, pargs_json=None, opts_json=None):
-                """Invoke pkg install subcommand."""
+    def install(self, pargs_json=None, opts_json=None):
+        """Invoke pkg install subcommand."""
 
-                return self.__cmd_invoke("install", pargs_json=pargs_json,
-                    opts_json=opts_json)
+        return self.__cmd_invoke(
+            "install", pargs_json=pargs_json, opts_json=opts_json
+        )
 
-        def update(self, pargs_json=None, opts_json=None):
-                """Invoke pkg update subcommand."""
+    def update(self, pargs_json=None, opts_json=None):
+        """Invoke pkg update subcommand."""
 
-                return self.__cmd_invoke("update", pargs_json=pargs_json,
-                    opts_json=opts_json)
+        return self.__cmd_invoke(
+            "update", pargs_json=pargs_json, opts_json=opts_json
+        )
 
-        def uninstall(self, pargs_json=None, opts_json=None):
-                """Invoke pkg uninstall subcommand."""
+    def uninstall(self, pargs_json=None, opts_json=None):
+        """Invoke pkg uninstall subcommand."""
 
-                return self.__cmd_invoke("uninstall", pargs_json=pargs_json,
-                    opts_json=opts_json)
+        return self.__cmd_invoke(
+            "uninstall", pargs_json=pargs_json, opts_json=opts_json
+        )
 
-        def publisher_set(self, pargs_json=None, opts_json=None):
-                """Invoke pkg set-publisher subcommand."""
+    def publisher_set(self, pargs_json=None, opts_json=None):
+        """Invoke pkg set-publisher subcommand."""
 
-                return self.__cmd_invoke("set-publisher",
-                    pargs_json=pargs_json, opts_json=opts_json)
+        return self.__cmd_invoke(
+            "set-publisher", pargs_json=pargs_json, opts_json=opts_json
+        )
 
-        def publisher_unset(self, pargs_json=None):
-                """Invoke pkg unset-publisher subcommand."""
+    def publisher_unset(self, pargs_json=None):
+        """Invoke pkg unset-publisher subcommand."""
 
-                return self.__cmd_invoke("unset-publisher",
-                    pargs_json=pargs_json)
+        return self.__cmd_invoke("unset-publisher", pargs_json=pargs_json)
 
-        def publisher_list(self, pargs_json=None, opts_json=None):
-                """Invoke pkg publisher subcommand."""
+    def publisher_list(self, pargs_json=None, opts_json=None):
+        """Invoke pkg publisher subcommand."""
 
-                return self._cmd_invoke("publisher", pargs_json=pargs_json,
-                    opts_json=opts_json)
+        return self._cmd_invoke(
+            "publisher", pargs_json=pargs_json, opts_json=opts_json
+        )
 
-        def verify(self, pargs_json=None, opts_json=None):
-                """Invoke pkg verify subcommand."""
+    def verify(self, pargs_json=None, opts_json=None):
+        """Invoke pkg verify subcommand."""
 
-                return self._cmd_invoke("verify", pargs_json=pargs_json,
-                    opts_json=opts_json)
+        return self._cmd_invoke(
+            "verify", pargs_json=pargs_json, opts_json=opts_json
+        )
 
-        def fix(self, pargs_json=None, opts_json=None):
-                """Invoke pkg fix subcommand."""
+    def fix(self, pargs_json=None, opts_json=None):
+        """Invoke pkg fix subcommand."""
 
-                return self._cmd_invoke("fix", pargs_json=pargs_json,
-                    opts_json=opts_json)
+        return self._cmd_invoke(
+            "fix", pargs_json=pargs_json, opts_json=opts_json
+        )
 
-        def get_pkg_input_schema(self, subcommand):
-                """Get input schema for a specific subcommand."""
+    def get_pkg_input_schema(self, subcommand):
+        """Get input schema for a specific subcommand."""
 
-                return _get_pkg_input_schema(subcommand,
-                    opts_mapping=self.opts_mapping)
+        return _get_pkg_input_schema(subcommand, opts_mapping=self.opts_mapping)
 
-        def get_pkg_output_schema(self, subcommand):
-                """Get output schema for a specific subcommand."""
+    def get_pkg_output_schema(self, subcommand):
+        """Get output schema for a specific subcommand."""
 
-                return _get_pkg_output_schema(subcommand)
+        return _get_pkg_output_schema(subcommand)
 
 
 cmds = {
-    "exact-install"   : [_exact_install, __pkg_exact_install_output_schema],
-    "fix"             : [_fix, __pkg_fix_output_schema],
-    "list"            : [_list_inventory, __pkg_list_output_schema],
-    "install"         : [_install, __pkg_install_output_schema],
-    "update"          : [_update, __pkg_update_output_schema],
-    "uninstall"       : [_uninstall, __pkg_uninstall_output_schema],
-    "set-publisher"   : [_publisher_set,
-                          __pkg_publisher_set_output_schema],
-    "unset-publisher" : [_publisher_unset,
-                          __pkg_publisher_unset_output_schema],
-    "publisher"       : [_publisher_list, __pkg_publisher_output_schema],
-    "info"            : [_info, __pkg_info_output_schema],
-    "verify"          : [_verify, __pkg_verify_output_schema]
+    "exact-install": [_exact_install, __pkg_exact_install_output_schema],
+    "fix": [_fix, __pkg_fix_output_schema],
+    "list": [_list_inventory, __pkg_list_output_schema],
+    "install": [_install, __pkg_install_output_schema],
+    "update": [_update, __pkg_update_output_schema],
+    "uninstall": [_uninstall, __pkg_uninstall_output_schema],
+    "set-publisher": [_publisher_set, __pkg_publisher_set_output_schema],
+    "unset-publisher": [_publisher_unset, __pkg_publisher_unset_output_schema],
+    "publisher": [_publisher_list, __pkg_publisher_output_schema],
+    "info": [_info, __pkg_info_output_schema],
+    "verify": [_verify, __pkg_verify_output_schema],
 }
 
 # Addendum table for option extensions.
 cmd_opts = {}
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/debugvalues.py
+++ b/src/modules/client/debugvalues.py
@@ -26,38 +26,38 @@
 
 import six
 
+
 class Singleton(type):
-        """Set __metaclass__ to Singleton to create a singleton.
-        See http://en.wikipedia.org/wiki/Singleton_pattern """
+    """Set __metaclass__ to Singleton to create a singleton.
+    See http://en.wikipedia.org/wiki/Singleton_pattern"""
 
-        def __init__(self, name, bases, dictionary):
-                super(Singleton, self).__init__(name, bases, dictionary)
-                self.instance = None
+    def __init__(self, name, bases, dictionary):
+        super(Singleton, self).__init__(name, bases, dictionary)
+        self.instance = None
 
-        def __call__(self, *args, **kw):
-                if self.instance is None:
-                        self.instance = super(Singleton, self).__call__(*args,
-                            **kw)
+    def __call__(self, *args, **kw):
+        if self.instance is None:
+            self.instance = super(Singleton, self).__call__(*args, **kw)
 
-                return self.instance
+        return self.instance
 
 
 class DebugValues(six.with_metaclass(Singleton, dict)):
-        """Singleton dict that returns None if unknown value
-        is referenced"""
+    """Singleton dict that returns None if unknown value
+    is referenced"""
 
-        def __getitem__(self, item):
-                """ returns None if not set """
-                return self.get(item, None)
+    def __getitem__(self, item):
+        """returns None if not set"""
+        return self.get(item, None)
 
-        def get_value(self, key):
-                return self[key]
+    def get_value(self, key):
+        return self[key]
 
-        def set_value(self, key, value):
-                self[key] = value
+    def set_value(self, key, value):
+        self[key] = value
 
 
-DebugValues=DebugValues()
+DebugValues = DebugValues()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/firmware.py
+++ b/src/modules/client/firmware.py
@@ -36,98 +36,133 @@ from pkg.actions.generic import quote_attr_value
 
 
 class Firmware(object):
-        def __init__(self):
-            self.__firmware = {} # cache of things we've checked already
+    def __init__(self):
+        self.__firmware = {}  # cache of things we've checked already
 
-        def check_firmware(self, dep_action, firmware_name):
-                """Check firmware dependency.
-                returns ((true, false, none (internal error)),
-                error text)"""
+    def check_firmware(self, dep_action, firmware_name):
+        """Check firmware dependency.
+        returns ((true, false, none (internal error)),
+        error text)"""
 
-                firmware_dir = "/usr/lib/fwenum"
-                # leverage smf test infrastructure
-                cmds_dir = DebugValues["smf_cmds_dir"]
-                if DebugValues["firmware-dependency-bypass"]:
-                        return (True, None)
-                if cmds_dir: # we're testing;
-                        firmware_dir = cmds_dir
+        firmware_dir = "/usr/lib/fwenum"
+        # leverage smf test infrastructure
+        cmds_dir = DebugValues["smf_cmds_dir"]
+        if DebugValues["firmware-dependency-bypass"]:
+            return (True, None)
+        if cmds_dir:  # we're testing;
+            firmware_dir = cmds_dir
 
-                args = [os.path.join(firmware_dir, firmware_name[len("feature/firmware/"):])]
-                args.extend([
-                    "{0}={1}".format(k, quote_attr_value(v))
-                    for k,v in sorted(six.iteritems(dep_action.attrs))
-                    if k not in ["type", "root-image", "fmri"]
-                ])
+        args = [
+            os.path.join(
+                firmware_dir, firmware_name[len("feature/firmware/") :]
+            )
+        ]
+        args.extend(
+            [
+                "{0}={1}".format(k, quote_attr_value(v))
+                for k, v in sorted(six.iteritems(dep_action.attrs))
+                if k not in ["type", "root-image", "fmri"]
+            ]
+        )
 
-                key = str(args)
+        key = str(args)
 
-                # use a cache since each check may be expensive and each
-                # pkg version may have the same dependency.
-                # ignore non-solaris systems here
+        # use a cache since each check may be expensive and each
+        # pkg version may have the same dependency.
+        # ignore non-solaris systems here
 
-                if portable.osname != "sunos" and key not in self.firmware:
-                    self.__firmware[key] = (True, None)
+        if portable.osname != "sunos" and key not in self.firmware:
+            self.__firmware[key] = (True, None)
 
-                if key not in self.__firmware:
-                        try:
-                                proc = subprocess.Popen(args, stdout=subprocess.PIPE,
-                                    stderr=subprocess.STDOUT)
-                                # output from proc is bytes
-                                buf = [misc.force_str(l) for l in
-                                    proc.stdout.readlines()]
-                                ret = proc.wait()
-                                # if there was output, something went wrong.
-                                # Since generic errors are often exit(1),
-                                # map this to an internal error.
-                                if ret == 1 and len(buf) > 0:
-                                        ret = 255
-                                if ret == 0:
-                                        ans = (True, None)
-                                elif 0 < ret <= 239:
-                                        ans = (False, (_("There are {0} instances"
-                                            " of downrev firmware for the '{1}' "
-                                            " devices present on this system. "
-                                            "Update each to version {2} or better."
-                                            ).format(ret, args[1],
-                                            dep_action.attrs.get("minimum-version",
-                                            _("UNSPECIFIED")))))
-                                elif ret == 240:
-                                        ans = (False, (_("There are 240 or more "
-                                            "instances of downrev firmware for the"
-                                            "'{0}' devices present on this system. "
-                                            "Update each to version {1} or better."
-                                            ).format(args[1],
-                                            dep_action.attrs.get("minimum-version",
-                                            _("UNSPECIFIED")))))
-                                elif ret < 0:
-                                        ans = (None,
-                                            (_("Firmware dependency error: {0} "
-                                            " exited due to signal {1}").format(
-                                            " ".join(args), misc.signame(-ret))))
-                                else:
-                                        ans = (None,
-                                            (_("Firmware dependency error: General "
-                                            "internal error {0} running '{1}': '{2}'"
-                                            ).format(str(ret), " ".join(args),
-                                            "\n".join(buf))))
+        if key not in self.__firmware:
+            try:
+                proc = subprocess.Popen(
+                    args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+                )
+                # output from proc is bytes
+                buf = [misc.force_str(l) for l in proc.stdout.readlines()]
+                ret = proc.wait()
+                # if there was output, something went wrong.
+                # Since generic errors are often exit(1),
+                # map this to an internal error.
+                if ret == 1 and len(buf) > 0:
+                    ret = 255
+                if ret == 0:
+                    ans = (True, None)
+                elif 0 < ret <= 239:
+                    ans = (
+                        False,
+                        (
+                            _(
+                                "There are {0} instances"
+                                " of downrev firmware for the '{1}' "
+                                " devices present on this system. "
+                                "Update each to version {2} or better."
+                            ).format(
+                                ret,
+                                args[1],
+                                dep_action.attrs.get(
+                                    "minimum-version", _("UNSPECIFIED")
+                                ),
+                            )
+                        ),
+                    )
+                elif ret == 240:
+                    ans = (
+                        False,
+                        (
+                            _(
+                                "There are 240 or more "
+                                "instances of downrev firmware for the"
+                                "'{0}' devices present on this system. "
+                                "Update each to version {1} or better."
+                            ).format(
+                                args[1],
+                                dep_action.attrs.get(
+                                    "minimum-version", _("UNSPECIFIED")
+                                ),
+                            )
+                        ),
+                    )
+                elif ret < 0:
+                    ans = (
+                        None,
+                        (
+                            _(
+                                "Firmware dependency error: {0} "
+                                " exited due to signal {1}"
+                            ).format(" ".join(args), misc.signame(-ret))
+                        ),
+                    )
+                else:
+                    ans = (
+                        None,
+                        (
+                            _(
+                                "Firmware dependency error: General "
+                                "internal error {0} running '{1}': '{2}'"
+                            ).format(str(ret), " ".join(args), "\n".join(buf))
+                        ),
+                    )
 
-                        except OSError as e:
-                                # we have no enumerator installed.  This can
-                                # occur if this driver is being installed
-                                # for the first time or, more likely, we
-                                # just added enumerators & a firmware dependency
-                                # for the first time.  For now, drive on and
-                                # ignore this to permit the addition of such
-                                # dependencies concurrently with their
-                                # enumerarators.
-                                # ans = (None, (_("Firmware dependency error:"
-                                # " Cannot exec {0}: {1}").format(" ".join(args)
-                                # , str(e))))
-                                ans = (True, 0)
+            except OSError as e:
+                # we have no enumerator installed.  This can
+                # occur if this driver is being installed
+                # for the first time or, more likely, we
+                # just added enumerators & a firmware dependency
+                # for the first time.  For now, drive on and
+                # ignore this to permit the addition of such
+                # dependencies concurrently with their
+                # enumerarators.
+                # ans = (None, (_("Firmware dependency error:"
+                # " Cannot exec {0}: {1}").format(" ".join(args)
+                # , str(e))))
+                ans = (True, 0)
 
-                        self.__firmware[key] = ans
+            self.__firmware[key] = ans
 
-                return self.__firmware[key]
+        return self.__firmware[key]
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/history.py
+++ b/src/modules/client/history.py
@@ -105,41 +105,66 @@ error_results = {
     MemoryError: RESULT_FAILED_OUTOFMEMORY,
 }
 
+
 class _HistoryOperation(object):
-        """A _HistoryOperation object is a representation of data about an
-        operation that a pkg(7) client has performed.  This class is private
-        and not intended for use by classes other than History.
+    """A _HistoryOperation object is a representation of data about an
+    operation that a pkg(7) client has performed.  This class is private
+    and not intended for use by classes other than History.
 
-        This class provides an abstraction layer between the stack of
-        operations that History manages should these values need to be
-        manipulated as they are set or retrieved.
-        """
+    This class provides an abstraction layer between the stack of
+    operations that History manages should these values need to be
+    manipulated as they are set or retrieved.
+    """
 
-        result_l10n = {}    # Static variable for dictionary
+    result_l10n = {}  # Static variable for dictionary
 
-        def __copy__(self):
-                h = _HistoryOperation()
-                for attr in ("name", "start_time", "end_time", "start_state",
-                    "end_state", "username", "userid", "be", "be_exists",
-                    "be_uuid", "current_be", "current_new_be", "new_be",
-                    "new_be_exists", "new_be_uuid", "result", "release_notes",
-                    "snapshot"):
-                        setattr(h, attr, getattr(self, attr))
-                h.errors = [copy.copy(e) for e in self.errors]
-                return h
+    def __copy__(self):
+        h = _HistoryOperation()
+        for attr in (
+            "name",
+            "start_time",
+            "end_time",
+            "start_state",
+            "end_state",
+            "username",
+            "userid",
+            "be",
+            "be_exists",
+            "be_uuid",
+            "current_be",
+            "current_new_be",
+            "new_be",
+            "new_be_exists",
+            "new_be_uuid",
+            "result",
+            "release_notes",
+            "snapshot",
+        ):
+            setattr(h, attr, getattr(self, attr))
+        h.errors = [copy.copy(e) for e in self.errors]
+        return h
 
-        def __setattr__(self, name, value):
-                if name not in ("result", "errors", "be", "be_uuid",
-                    "current_be", "current_new_be", "new_be", "new_be_exists",
-                    "new_be_uuid", "snapshot"):
-                        # Force all other attribute values to be a string
-                        # to avoid issues with minidom.
-                        value = str(value)
+    def __setattr__(self, name, value):
+        if name not in (
+            "result",
+            "errors",
+            "be",
+            "be_uuid",
+            "current_be",
+            "current_new_be",
+            "new_be",
+            "new_be_exists",
+            "new_be_uuid",
+            "snapshot",
+        ):
+            # Force all other attribute values to be a string
+            # to avoid issues with minidom.
+            value = str(value)
 
-                return object.__setattr__(self, name, value)
+        return object.__setattr__(self, name, value)
 
-        def __str__(self):
-                return """\
+    def __str__(self):
+        return """\
 Operation Name: {0}
 Operation Result: {1}
 Operation Start Time: {2}
@@ -159,757 +184,774 @@ Operation Snapshot: {14}
 Operation Release Notes: {15}
 Operation Errors:
 {16}
-""".format(self.name, self.result, self.start_time, self.end_time,
-    self.start_state, self.end_state, self.username, self.userid,
-    self.be, self.current_be, self.be_uuid, self.new_be, self.current_new_be,
-    self.new_be_uuid, self.snapshot, self.release_notes, self.errors)
+""".format(
+            self.name,
+            self.result,
+            self.start_time,
+            self.end_time,
+            self.start_state,
+            self.end_state,
+            self.username,
+            self.userid,
+            self.be,
+            self.current_be,
+            self.be_uuid,
+            self.new_be,
+            self.current_new_be,
+            self.new_be_uuid,
+            self.snapshot,
+            self.release_notes,
+            self.errors,
+        )
 
-        # All "time" values should be in UTC, using ISO 8601 as the format.
-        # Name of the operation performed (e.g. install, update, etc.).
-        name = None
-        # When the operation started.
-        start_time = None
-        # When the operation ended.
-        end_time = None
-        # The starting state of the operation (e.g. image plan pre-evaluation).
-        start_state = None
-        # The ending state of the operation (e.g. image plan post-evaluation).
-        end_state = None
-        # Errors encountered during an operation.
-        errors = None
-        # username of the user that performed the operation.
-        username = None
-        # id of the user that performed the operation.
-        userid = None
-        # The boot environment on which the user performed the operation
-        be = None
-        # The current name of the boot environment.
-        current_be = None
-        # The uuid of the BE on which the user performed the operation
-        be_uuid = None
-        # The new boot environment that was created as a result of the operation
-        new_be = None
-        # The current name of the new boot environment.
-        current_new_be = None
-        # The uuid of the boot environment that was created as a result of the
-        # operation
-        new_be_uuid = None
-        # The name of the file containing the release notes, or None.
-        release_notes = None
+    # All "time" values should be in UTC, using ISO 8601 as the format.
+    # Name of the operation performed (e.g. install, update, etc.).
+    name = None
+    # When the operation started.
+    start_time = None
+    # When the operation ended.
+    end_time = None
+    # The starting state of the operation (e.g. image plan pre-evaluation).
+    start_state = None
+    # The ending state of the operation (e.g. image plan post-evaluation).
+    end_state = None
+    # Errors encountered during an operation.
+    errors = None
+    # username of the user that performed the operation.
+    username = None
+    # id of the user that performed the operation.
+    userid = None
+    # The boot environment on which the user performed the operation
+    be = None
+    # The current name of the boot environment.
+    current_be = None
+    # The uuid of the BE on which the user performed the operation
+    be_uuid = None
+    # The new boot environment that was created as a result of the operation
+    new_be = None
+    # The current name of the new boot environment.
+    current_new_be = None
+    # The uuid of the boot environment that was created as a result of the
+    # operation
+    new_be_uuid = None
+    # The name of the file containing the release notes, or None.
+    release_notes = None
 
-        # The snapshot that was created while running this operation
-        # set to None if no snapshot was taken, or destroyed after successful
-        # completion
-        snapshot = None
+    # The snapshot that was created while running this operation
+    # set to None if no snapshot was taken, or destroyed after successful
+    # completion
+    snapshot = None
 
-        # The result of the operation (must be a list indicating (outcome,
-        # reason)).
-        result = None
+    # The result of the operation (must be a list indicating (outcome,
+    # reason)).
+    result = None
 
-        def __init__(self):
-                self.errors = []
+    def __init__(self):
+        self.errors = []
 
-        @property
-        def result_text(self):
-                """Returns a tuple containing the translated text for the
-                operation result of the form (outcome, reason)."""
+    @property
+    def result_text(self):
+        """Returns a tuple containing the translated text for the
+        operation result of the form (outcome, reason)."""
 
-                if not _HistoryOperation.result_l10n:
-                        # since we store english text in our XML files, we
-                        # need a way for clients obtain a translated version
-                        # of these messages.
-                        _HistoryOperation.result_l10n = {
-                            "Canceled": _("Canceled"),
-                            "Failed": _("Failed"),
-                            "Ignored": _("Ignored"),
-                            "Nothing to do": _("Nothing to do"),
-                            "Succeeded": _("Succeeded"),
-                            "Bad Request": _("Bad Request"),
-                            "Configuration": _("Configuration"),
-                            "Constrained": _("Constrained"),
-                            "Locked": _("Locked"),
-                            "Search": _("Search"),
-                            "Storage": _("Storage"),
-                            "Transport": _("Transport"),
-                            "Actuator": _("Actuator"),
-                            "Out of Memory": _("Out of Memory"),
-                            "Conflicting Actions": _("Conflicting Actions"),
-                            "Unknown": _("Unknown"),
-                            "None": _("None")
-                        }
+        if not _HistoryOperation.result_l10n:
+            # since we store english text in our XML files, we
+            # need a way for clients obtain a translated version
+            # of these messages.
+            _HistoryOperation.result_l10n = {
+                "Canceled": _("Canceled"),
+                "Failed": _("Failed"),
+                "Ignored": _("Ignored"),
+                "Nothing to do": _("Nothing to do"),
+                "Succeeded": _("Succeeded"),
+                "Bad Request": _("Bad Request"),
+                "Configuration": _("Configuration"),
+                "Constrained": _("Constrained"),
+                "Locked": _("Locked"),
+                "Search": _("Search"),
+                "Storage": _("Storage"),
+                "Transport": _("Transport"),
+                "Actuator": _("Actuator"),
+                "Out of Memory": _("Out of Memory"),
+                "Conflicting Actions": _("Conflicting Actions"),
+                "Unknown": _("Unknown"),
+                "None": _("None"),
+            }
 
-                if not self.start_time or not self.result:
-                        return ("", "")
-                return (_HistoryOperation.result_l10n[self.result[0]],
-                    _HistoryOperation.result_l10n[self.result[1]])
+        if not self.start_time or not self.result:
+            return ("", "")
+        return (
+            _HistoryOperation.result_l10n[self.result[0]],
+            _HistoryOperation.result_l10n[self.result[1]],
+        )
 
 
 class History(object):
-        """A History object is a representation of data about a pkg(7) client
-        and about operations that the client is executing or has executed.  It
-        uses the _HistoryOperation class to represent the data about an
-        operation.
+    """A History object is a representation of data about a pkg(7) client
+    and about operations that the client is executing or has executed.  It
+    uses the _HistoryOperation class to represent the data about an
+    operation.
+    """
+
+    # The directory where the history directory can be found (or
+    # created if it doesn't exist).
+    root_dir = None
+    # The name of the client (e.g. pkg, etc.)
+    client_name = None
+    # The version of the client (e.g. 093ca22da67c).
+    client_version = None
+    # How the client was invoked (e.g. 'pkg install -n foo').
+    client_args = None
+
+    # A stack where operation data will actually be stored.
+    __operations = []
+
+    # A private property used by preserve() and restore() to store snapshots
+    # of history and operation state information.
+    __snapshot = None
+
+    # These attributes exist to fake access to the operations stack.
+    operation_name = None
+    operation_username = None
+    operation_userid = None
+    operation_current_be = None
+    operation_be = None
+    operation_be_uuid = None
+    operation_current_new_be = None
+    operation_new_be = None
+    operation_new_be_uuid = None
+    operation_start_time = None
+    operation_end_time = None
+    operation_start_state = None
+    operation_end_state = None
+    operation_snapshot = None
+    operation_errors = None
+    operation_result = None
+    operation_release_notes = None
+
+    def __copy__(self):
+        h = History()
+        for attr in ("root_dir", "client_name", "client_version"):
+            setattr(h, attr, getattr(self, attr))
+        object.__setattr__(
+            self, "client_args", [copy.copy(a) for a in self.client_args]
+        )
+        # A deepcopy has to be performed here since this a list of dicts
+        # and not just History operation objects.
+        h.__operations = [copy.deepcopy(o) for o in self.__operations]
+        return h
+
+    def __getattribute__(self, name):
+        if name == "client_args":
+            return object.__getattribute__(self, name)[:]
+
+        if not name.startswith("operation_"):
+            return object.__getattribute__(self, name)
+
+        ops = object.__getattribute__(self, "_History__operations")
+        if not ops:
+            return None
+
+        return getattr(ops[-1]["operation"], name[len("operation_") :])
+
+    def __setattr__(self, name, value):
+        if name == "client_args":
+            raise AttributeError(
+                "'history' object attribute '{0}' " "is read-only.".format(name)
+            )
+
+        if not name.startswith("operation_"):
+            return object.__setattr__(self, name, value)
+
+        ops = object.__getattribute__(self, "_History__operations")
+        if name == "operation_name":
+            if not ops:
+                ops = []
+                object.__setattr__(self, "_History__operations", ops)
+
+            ops.append({"pathname": None, "operation": _HistoryOperation()})
+        elif not ops:
+            raise AttributeError(
+                "'history' object attribute '{0}' "
+                "cannot be set before 'operation_name'.".format(name)
+            )
+
+        op = ops[-1]["operation"]
+        setattr(op, name[len("operation_") :], value)
+
+        # Access to the class attributes is done through object instead
+        # of just referencing self to avoid any of the special logic in
+        # place interfering with logic here.
+        if name == "operation_name":
+            # Before a new operation starts, clear exception state
+            # for the current one so that when this one ends, the
+            # last operation's exception won't be recorded to this
+            # one.  If the error hasn't been recorded by now, it
+            # doesn't matter anyway, so should be safe to clear.
+            # sys.exc_clear() isn't supported in Python 3, and
+            # couldn't find a replacement.
+            try:
+                sys.exc_clear()
+            except:
+                pass
+
+            # Mark the operation as having started and record
+            # other, relevant information.
+            op.start_time = misc.time_to_timestamp(None)
+            try:
+                op.username = portable.get_username()
+            except KeyError:
+                op.username = "unknown"
+            op.userid = portable.get_userid()
+
+            ca = None
+            if sys.argv[0]:
+                ca = [sys.argv[0]]
+            else:
+                # Fallback for clients that provide no value.
+                ca = [self.client_name]
+
+            ca.extend(sys.argv[1:])
+            object.__setattr__(self, "client_args", ca)
+            object.__setattr__(self, "client_version", pkg.VERSION)
+
+        elif name == "operation_result":
+            # Record when the operation ended.
+            op.end_time = misc.time_to_timestamp(None)
+
+            # Some operations shouldn't be saved -- they're merely
+            # included in the stack for completeness or to support
+            # client functionality.
+            if (
+                op.name not in DISCARDED_OPERATIONS
+                and value != RESULT_NOTHING_TO_DO
+            ):
+                # Write current history and last operation to a
+                # file.
+                self.__save()
+
+            # Discard it now that it is no longer needed.
+            del ops[-1]
+
+    def __init__(self, root_dir=".", filename=None, uuid_be_dic=None):
+        """'root_dir' should be the path of the directory where the
+        history directory can be found (or created if it doesn't
+        exist).  'filename' should be the name of an XML file
+        containing serialized history information to load.
+        'uuid_be_dic', if supplied, should be a dictionary of BE uuid
+        information, as produced by
+        pkg.client.bootenv.BootEnv.get_uuid_be_dic(), otherwise that
+        method is called each time a History object is created.
+        """
+        # Since this is a read-only attribute normally, we have to
+        # bypass our setattr override by calling object.
+        object.__setattr__(self, "client_args", [])
+
+        # Initialize client_name to what the client thinks it is.  This
+        # will be overridden if we load history entries off disk.
+        self.client_name = pkg.client.global_settings.client_name
+
+        self.root_dir = root_dir
+        if filename:
+            self.__load(filename, uuid_be_dic=uuid_be_dic)
+
+    def __str__(self):
+        ops = self.__operations
+        return "\n".join([str(op["operation"]) for op in ops])
+
+    @property
+    def path(self):
+        """The directory where history files will be written to or
+        read from.
+        """
+        return os.path.join(self.root_dir, "history")
+
+    @property
+    def pathname(self):
+        """Returns the pathname that the history information was read
+        from or will attempted to be written to.  Returns None if no
+        operation has started yet or if no operation has been loaded.
+        """
+        if not self.operation_start_time:
+            return None
+
+        ops = self.__operations
+        pathname = ops[-1]["pathname"]
+        if not pathname:
+            return os.path.join(
+                self.path, "{0}-01.xml".format(ops[-1]["operation"].start_time)
+            )
+        return pathname
+
+    @property
+    def notes(self):
+        """Generates the lines of release notes for this operation.
+        If no release notes are present, no output occurs."""
+
+        if not self.operation_release_notes:
+            return
+        try:
+            rpath = os.path.join(
+                self.root_dir, "notes", self.operation_release_notes
+            )
+            for a in open(rpath, "r"):
+                yield a.rstrip()
+
+        except Exception as e:
+            raise apx.HistoryLoadException(e)
+
+    def clear(self):
+        """Discards all information related to the current history
+        object.
+        """
+        self.client_name = None
+        self.client_version = None
+        object.__setattr__(self, "client_args", [])
+        self.__operations = []
+
+    def __load_client_data(self, node):
+        """Internal function to load the client data from the given XML
+        'node' object.
+        """
+        self.client_name = node.getAttribute("name")
+        self.client_version = node.getAttribute("version")
+        try:
+            args = node.getElementsByTagName("args")[0]
+        except IndexError:
+            # There might not be any.
+            pass
+        else:
+            ca = object.__getattribute__(self, "client_args")
+            for cnode in args.getElementsByTagName("arg"):
+                try:
+                    ca.append(cnode.childNodes[0].wholeText)
+                except (AttributeError, IndexError):
+                    # There may be no childNodes, or
+                    # wholeText may not be defined.
+                    pass
+
+    @staticmethod
+    def __load_operation_data(node, uuid_be_dic):
+        """Internal function to load the operation data from the given
+        XML 'node' object and return a _HistoryOperation object.
+        """
+        op = _HistoryOperation()
+        op.name = node.getAttribute("name")
+        op.start_time = node.getAttribute("start_time")
+        op.end_time = node.getAttribute("end_time")
+        op.username = node.getAttribute("username")
+        op.userid = node.getAttribute("userid")
+        op.result = node.getAttribute("result").split(", ")
+
+        if len(op.result) == 1:
+            op.result.append("None")
+
+        # older clients simply wrote "Nothing to do" instead of
+        # "Ignored, Nothing to do", so work around that
+        if op.result[0] == "Nothing to do":
+            op.result = RESULT_NOTHING_TO_DO
+
+        if node.hasAttribute("be_uuid"):
+            op.be_uuid = node.getAttribute("be_uuid")
+        if node.hasAttribute("new_be_uuid"):
+            op.new_be_uuid = node.getAttribute("new_be_uuid")
+        if node.hasAttribute("be"):
+            op.be = node.getAttribute("be")
+            if op.be_uuid:
+                op.current_be = uuid_be_dic.get(op.be_uuid, op.be)
+        if node.hasAttribute("new_be"):
+            op.new_be = node.getAttribute("new_be")
+            if op.new_be_uuid:
+                op.current_new_be = uuid_be_dic.get(op.new_be_uuid, op.new_be)
+        if node.hasAttribute("release-notes"):
+            op.release_notes = node.getAttribute("release-notes")
+
+        def get_node_values(parent_name, child_name=None):
+            try:
+                parent = node.getElementsByTagName(parent_name)[0]
+                if child_name:
+                    cnodes = parent.getElementsByTagName(child_name)
+                    return [cnode.childNodes[0].wholeText for cnode in cnodes]
+                return parent.childNodes[0].wholeText
+            except (AttributeError, IndexError):
+                # Assume no values are present for the node.
+                pass
+            if child_name:
+                return []
+            return
+
+        op.start_state = get_node_values("start_state")
+        op.end_state = get_node_values("end_state")
+        op.errors.extend(get_node_values("errors", child_name="error"))
+
+        return op
+
+    def __load(self, filename, uuid_be_dic=None):
+        """Loads the history from a file located in self.path/history/
+        {filename}.  The file should contain a serialized history
+        object in XML format.
         """
 
-        # The directory where the history directory can be found (or
-        # created if it doesn't exist).
-        root_dir = None
-        # The name of the client (e.g. pkg, etc.)
-        client_name = None
-        # The version of the client (e.g. 093ca22da67c).
-        client_version = None
-        # How the client was invoked (e.g. 'pkg install -n foo').
-        client_args = None
-
-        # A stack where operation data will actually be stored.
-        __operations = []
-
-        # A private property used by preserve() and restore() to store snapshots
-        # of history and operation state information.
-        __snapshot = None
-
-        # These attributes exist to fake access to the operations stack.
-        operation_name = None
-        operation_username = None
-        operation_userid = None
-        operation_current_be = None
-        operation_be = None
-        operation_be_uuid = None
-        operation_current_new_be = None
-        operation_new_be = None
-        operation_new_be_uuid = None
-        operation_start_time = None
-        operation_end_time = None
-        operation_start_state = None
-        operation_end_state = None
-        operation_snapshot = None
-        operation_errors = None
-        operation_result = None
-        operation_release_notes = None
-
-        def __copy__(self):
-                h = History()
-                for attr in ("root_dir", "client_name", "client_version"):
-                        setattr(h, attr, getattr(self, attr))
-                object.__setattr__(self, "client_args",
-                    [copy.copy(a) for a in self.client_args])
-                # A deepcopy has to be performed here since this a list of dicts
-                # and not just History operation objects.
-                h.__operations = [copy.deepcopy(o) for o in self.__operations]
-                return h
-
-        def __getattribute__(self, name):
-                if name == "client_args":
-                        return object.__getattribute__(self, name)[:]
-
-                if not name.startswith("operation_"):
-                        return object.__getattribute__(self, name)
-
-                ops = object.__getattribute__(self, "_History__operations")
-                if not ops:
-                        return None
-
-                return getattr(ops[-1]["operation"], name[len("operation_"):])
-
-        def __setattr__(self, name, value):
-                if name == "client_args":
-                        raise AttributeError("'history' object attribute '{0}' "
-                            "is read-only.".format(name))
-
-                if not name.startswith("operation_"):
-                        return object.__setattr__(self, name, value)
-
-                ops = object.__getattribute__(self, "_History__operations")
-                if name == "operation_name":
-                        if not ops:
-                                ops = []
-                                object.__setattr__(self,
-                                    "_History__operations", ops)
-
-                        ops.append({
-                            "pathname": None,
-                            "operation": _HistoryOperation()
-                        })
-                elif not ops:
-                        raise AttributeError("'history' object attribute '{0}' "
-                            "cannot be set before 'operation_name'.".format(
-                            name))
-
-                op = ops[-1]["operation"]
-                setattr(op, name[len("operation_"):], value)
-
-                # Access to the class attributes is done through object instead
-                # of just referencing self to avoid any of the special logic in
-                # place interfering with logic here.
-                if name == "operation_name":
-                        # Before a new operation starts, clear exception state
-                        # for the current one so that when this one ends, the
-                        # last operation's exception won't be recorded to this
-                        # one.  If the error hasn't been recorded by now, it
-                        # doesn't matter anyway, so should be safe to clear.
-                        # sys.exc_clear() isn't supported in Python 3, and
-                        # couldn't find a replacement.
-                        try:
-                                sys.exc_clear()
-                        except:
-                                pass
-
-                        # Mark the operation as having started and record
-                        # other, relevant information.
-                        op.start_time = misc.time_to_timestamp(None)
-                        try:
-                                op.username = portable.get_username()
-                        except KeyError:
-                                op.username = "unknown"
-                        op.userid = portable.get_userid()
-
-                        ca = None
-                        if sys.argv[0]:
-                                ca = [sys.argv[0]]
-                        else:
-                                # Fallback for clients that provide no value.
-                                ca = [self.client_name]
-
-                        ca.extend(sys.argv[1:])
-                        object.__setattr__(self, "client_args", ca)
-                        object.__setattr__(self, "client_version", pkg.VERSION)
-
-                elif name == "operation_result":
-                        # Record when the operation ended.
-                        op.end_time = misc.time_to_timestamp(None)
-
-                        # Some operations shouldn't be saved -- they're merely
-                        # included in the stack for completeness or to support
-                        # client functionality.
-                        if op.name not in DISCARDED_OPERATIONS and \
-                            value != RESULT_NOTHING_TO_DO:
-                                # Write current history and last operation to a
-                                # file.
-                                self.__save()
-
-                        # Discard it now that it is no longer needed.
-                        del ops[-1]
-
-        def __init__(self, root_dir=".", filename=None, uuid_be_dic=None):
-                """'root_dir' should be the path of the directory where the
-                history directory can be found (or created if it doesn't
-                exist).  'filename' should be the name of an XML file
-                containing serialized history information to load.
-                'uuid_be_dic', if supplied, should be a dictionary of BE uuid
-                information, as produced by
-                pkg.client.bootenv.BootEnv.get_uuid_be_dic(), otherwise that
-                method is called each time a History object is created.
-                """
-                # Since this is a read-only attribute normally, we have to
-                # bypass our setattr override by calling object.
-                object.__setattr__(self, "client_args", [])
-
-                # Initialize client_name to what the client thinks it is.  This
-                # will be overridden if we load history entries off disk.
-                self.client_name = pkg.client.global_settings.client_name
-
-                self.root_dir = root_dir
-                if filename:
-                        self.__load(filename, uuid_be_dic=uuid_be_dic)
-
-        def __str__(self):
-                ops = self.__operations
-                return "\n".join([str(op["operation"]) for op in ops])
-
-        @property
-        def path(self):
-                """The directory where history files will be written to or
-                read from.
-                """
-                return os.path.join(self.root_dir, "history")
-
-        @property
-        def pathname(self):
-                """Returns the pathname that the history information was read
-                from or will attempted to be written to.  Returns None if no
-                operation has started yet or if no operation has been loaded.
-                """
-                if not self.operation_start_time:
-                        return None
-
-                ops = self.__operations
-                pathname = ops[-1]["pathname"]
-                if not pathname:
-                        return os.path.join(self.path,
-                            "{0}-01.xml".format(ops[-1]["operation"].start_time))
-                return pathname
-
-        @property
-        def notes(self):
-                """Generates the lines of release notes for this operation.
-                If no release notes are present, no output occurs."""
-
-                if not self.operation_release_notes:
-                        return
-                try:
-                        rpath = os.path.join(self.root_dir,
-                            "notes", 
-                            self.operation_release_notes)
-                        for a in open(rpath, "r"):
-                                yield a.rstrip()
-
-                except Exception as e:
-                        raise apx.HistoryLoadException(e)
-
-        def clear(self):
-                """Discards all information related to the current history
-                object.
-                """
-                self.client_name = None
-                self.client_version = None
-                object.__setattr__(self, "client_args", [])
-                self.__operations = []
-
-        def __load_client_data(self, node):
-                """Internal function to load the client data from the given XML
-                'node' object.
-                """
-                self.client_name = node.getAttribute("name")
-                self.client_version = node.getAttribute("version")
-                try:
-                        args = node.getElementsByTagName("args")[0]
-                except IndexError:
-                        # There might not be any.
-                        pass
-                else:
-                        ca = object.__getattribute__(self, "client_args")
-                        for cnode in args.getElementsByTagName("arg"):
-                                try:
-                                        ca.append(cnode.childNodes[0].wholeText)
-                                except (AttributeError, IndexError):
-                                        # There may be no childNodes, or
-                                        # wholeText may not be defined.
-                                        pass
-
-        @staticmethod
-        def __load_operation_data(node, uuid_be_dic):
-                """Internal function to load the operation data from the given
-                XML 'node' object and return a _HistoryOperation object.
-                """
-                op = _HistoryOperation()
-                op.name = node.getAttribute("name")
-                op.start_time = node.getAttribute("start_time")
-                op.end_time = node.getAttribute("end_time")
-                op.username = node.getAttribute("username")
-                op.userid = node.getAttribute("userid")
-                op.result = node.getAttribute("result").split(", ")
-
-                if len(op.result) == 1:
-                        op.result.append("None")
-
-                # older clients simply wrote "Nothing to do" instead of
-                # "Ignored, Nothing to do", so work around that
-                if op.result[0] == "Nothing to do":
-                        op.result = RESULT_NOTHING_TO_DO
-
-                if node.hasAttribute("be_uuid"):
-                        op.be_uuid = node.getAttribute("be_uuid")
-                if node.hasAttribute("new_be_uuid"):
-                        op.new_be_uuid = node.getAttribute("new_be_uuid")
-                if node.hasAttribute("be"):
-                        op.be = node.getAttribute("be")
-                        if op.be_uuid:
-                                op.current_be = uuid_be_dic.get(op.be_uuid,
-                                    op.be)
-                if node.hasAttribute("new_be"):
-                        op.new_be = node.getAttribute("new_be")
-                        if op.new_be_uuid:
-                                op.current_new_be = uuid_be_dic.get(
-                                    op.new_be_uuid, op.new_be)
-                if node.hasAttribute("release-notes"):
-                        op.release_notes = node.getAttribute("release-notes")
-
-                def get_node_values(parent_name, child_name=None):
-                        try:
-                                parent = node.getElementsByTagName(parent_name)[0]
-                                if child_name:
-                                        cnodes = parent.getElementsByTagName(
-                                            child_name)
-                                        return [
-                                            cnode.childNodes[0].wholeText
-                                            for cnode in cnodes
-                                        ]
-                                return parent.childNodes[0].wholeText
-                        except (AttributeError, IndexError):
-                                # Assume no values are present for the node.
-                                pass
-                        if child_name:
-                                return []
-                        return
-
-                op.start_state = get_node_values("start_state")
-                op.end_state = get_node_values("end_state")
-                op.errors.extend(get_node_values("errors", child_name="error"))
-
-                return op
-
-        def __load(self, filename, uuid_be_dic=None):
-                """Loads the history from a file located in self.path/history/
-                {filename}.  The file should contain a serialized history
-                object in XML format.
-                """
-
-                # Ensure all previous information is discarded.
-                self.clear()
-
-                try:
-                        if not uuid_be_dic:
-                                uuid_be_dic = bootenv.BootEnv.get_uuid_be_dic()
-                except apx.ApiException as e:
-                        uuid_be_dic = {}
-
-                try:
-                        pathname = os.path.join(self.path, filename)
-                        d = xmini.parse(pathname)
-                        root = d.documentElement
-                        for cnode in root.childNodes:
-                                if cnode.nodeName == "client":
-                                        self.__load_client_data(cnode)
-                                elif cnode.nodeName == "operation":
-                                        # Operations load differently due to
-                                        # the stack.
-                                        self.__operations.append({
-                                            "pathname": pathname,
-                                            "operation":
-                                                self.__load_operation_data(
-                                                cnode, uuid_be_dic)
-                                            })
-                except KeyboardInterrupt:
-                        raise
-                except Exception as e:
-                        raise apx.HistoryLoadException(e)
-
-        def __serialize_client_data(self, d):
-                """Internal function used to serialize current client data
-                using the supplied 'd' (xml.dom.minidom) object.
-                """
-
-                assert self.client_name is not None
-                assert self.client_version is not None
-
-                root = d.documentElement
-                client = d.createElement("client")
-                client.setAttribute("name", self.client_name)
-                client.setAttribute("version", self.client_version)
-                root.appendChild(client)
-
-                if self.client_args:
-                        args = d.createElement("args")
-                        client.appendChild(args)
-                        for entry in self.client_args:
-                                arg = d.createElement("arg")
-                                args.appendChild(arg)
-                                arg.appendChild(
-                                    d.createCDATASection(str(entry)))
-
-        def __serialize_operation_data(self, d):
-                """Internal function used to serialize current operation data
-                using the supplied 'd' (xml.dom.minidom) object.
-                """
-
-                if self.operation_userid is None:
-                        raise apx.HistoryStoreException("Unable to determine "
-                            "the id of the user that performed the current "
-                            "operation; unable to store history information.")
-                elif self.operation_username is None:
-                        raise apx.HistoryStoreException("Unable to determine "
-                            "the username of the user that performed the "
-                            "current operation; unable to store history "
-                            "information.")
-
-                root = d.documentElement
-                op = d.createElement("operation")
-                op.setAttribute("name", self.operation_name)
-                # Must explictly convert values to a string due to minidom bug
-                # that causes a fatal whenever using types other than str.
-                op.setAttribute("username", str(self.operation_username))
-                op.setAttribute("userid", str(self.operation_userid))
-                op.setAttribute("result", ", ".join(self.operation_result))
-                op.setAttribute("start_time", self.operation_start_time)
-                op.setAttribute("end_time", self.operation_end_time)
-
-                if self.operation_be:
-                        op.setAttribute("be", self.operation_be)
-                if self.operation_be_uuid:
-                        op.setAttribute("be_uuid", self.operation_be_uuid)
-                if self.operation_new_be:
-                        op.setAttribute("new_be", self.operation_new_be)
-                if self.operation_new_be_uuid:
-                        op.setAttribute("new_be_uuid",
-                            self.operation_new_be_uuid)
-                if self.operation_snapshot:
-                        op.setAttribute("snapshot", self.operation_snapshot)
-                if self.operation_release_notes:
-                        op.setAttribute("release-notes", self.operation_release_notes)
-
-                root.appendChild(op)
-
-                if self.operation_start_state:
-                        state = d.createElement("start_state")
-                        op.appendChild(state)
-                        state.appendChild(d.createCDATASection(
-                            str(self.operation_start_state)))
-
-                if self.operation_end_state:
-                        state = d.createElement("end_state")
-                        op.appendChild(state)
-                        state.appendChild(d.createCDATASection(
-                            str(self.operation_end_state)))
-
-                if self.operation_errors:
-                        errors = d.createElement("errors")
-                        op.appendChild(errors)
-
-                        for entry in self.operation_errors:
-                                error = d.createElement("error")
-                                errors.appendChild(error)
-                                error.appendChild(
-                                    d.createCDATASection(str(entry)))
-
-        def __save(self):
-                """Serializes the current history information and writes it to
-                a file in self.path/{operation_start_time}-{sequence}.xml.
-                """
-                d = xmini.Document()
-                d.appendChild(d.createElement("history"))
-                self.__serialize_client_data(d)
-                self.__serialize_operation_data(d)
-
-                if not os.path.exists(self.path):
-                        try:
-                                # Only the right-most directory should be
-                                # created.  Assume that if the parent structure
-                                # does not exist, it shouldn't be created.
-                                os.mkdir(self.path, misc.PKG_DIR_MODE)
-                        except EnvironmentError as e:
-                                if e.errno not in (errno.EROFS, errno.EACCES,
-                                    errno.ENOENT):
-                                        # Ignore read-only file system and
-                                        # access errors as it isn't critical
-                                        # to the image that this data is
-                                        # written.
-                                        raise apx.HistoryStoreException(e)
-                                # Return, since without the directory, the rest
-                                # of this will fail.
-                                return
-                        except KeyboardInterrupt:
-                                raise
-                        except Exception as e:
-                                raise apx.HistoryStoreException(e)
-
-                # Repeatedly attempt to write the history (only if it's because
-                # the file already exists).  This is necessary due to multiple
-                # operations possibly occuring within the same second (but not
-                # microsecond).
-                pathname = self.pathname
-                for i in range(1, 100):
-                        try:
-                                f = os.fdopen(os.open(pathname,
-                                    os.O_CREAT|os.O_EXCL|os.O_WRONLY,
-                                    misc.PKG_FILE_MODE), "w")
-                                d.writexml(f,
-                                    encoding=sys.getdefaultencoding())
-                                f.close()
-                                return
-                        except EnvironmentError as e:
-                                if e.errno == errno.EEXIST:
-                                        name, ext = os.path.splitext(
-                                            os.path.basename(pathname))
-                                        name = name.split("-", 1)[0]
-                                        # Pick the next name in our sequence
-                                        # and try again.
-                                        pathname = os.path.join(self.path,
-                                            "{0}-{1:>02d}{2}".format(name,
-                                            i + 1, ext))
-                                        continue
-                                elif e.errno not in (errno.EROFS,
-                                    errno.EACCES):
-                                        # Ignore read-only file system and
-                                        # access errors as it isn't critical
-                                        # to the image that this data is
-                                        # written.
-                                        raise apx.HistoryStoreException(e)
-                                # For all other failures, return, and avoid any
-                                # further attempts.
-                                return
-                        except KeyboardInterrupt:
-                                raise
-                        except Exception as e:
-                                raise apx.HistoryStoreException(e)
-
-        def purge(self, be_name=None, be_uuid=None):
-                """Removes all history information by deleting the directory
-                indicated by the value self.path and then creates a new history
-                entry to record that this purge occurred.
-                """
-                self.operation_name = "purge-history"
-                self.operation_be = be_name
-                self.operation_be_uuid = be_uuid
-
-                try:
-                        shutil.rmtree(self.path)
-                except KeyboardInterrupt:
-                        raise
-                except EnvironmentError as e:
-                        if e.errno in (errno.ENOENT, errno.ESRCH):
-                                # History already purged; record as successful.
-                                self.operation_result = RESULT_SUCCEEDED
-                                return
-                        raise apx.HistoryPurgeException(e)
-                except Exception as e:
-                        raise apx.HistoryPurgeException(e)
-                else:
-                        self.operation_result = RESULT_SUCCEEDED
-
-        def abort(self, result):
-                """Intended to be used by the client during top-level error
-                handling to indicate that an unrecoverable error occurred
-                during the current operation(s).  This allows History to end
-                all of the current operations properly and handle any possible
-                errors that might be encountered in History itself.
-                """
-                try:
-                        # Ensure that all operations in the current stack are
-                        # ended properly.
-                        while self.operation_name:
-                                self.operation_result = result
-                except apx.HistoryStoreException:
-                        # Ignore storage errors as it's likely that whatever
-                        # caused the client to abort() also caused the storage
-                        # of the history information to fail.
-                        return
-
-        def log_operation_start(self, name, be_name=None, be_uuid=None):
-                """Marks the start of an operation to be recorded in image
-                history."""
-                self.operation_name = name
-                self.operation_be = be_name
-                self.operation_be_uuid = be_uuid
-
-        def log_operation_end(self, error=None, result=None, release_notes=None):
-                """Marks the end of an operation to be recorded in image
-                history.
-
-                'result' should be a pkg.client.history constant value
-                representing the outcome of an operation.  If not provided,
-                and 'error' is provided, the final result of the operation will
-                be based on the class of 'error' and 'error' will be recorded
-                for the current operation.  If 'result' and 'error' is not
-                provided, success is assumed."""
+        # Ensure all previous information is discarded.
+        self.clear()
+
+        try:
+            if not uuid_be_dic:
+                uuid_be_dic = bootenv.BootEnv.get_uuid_be_dic()
+        except apx.ApiException as e:
+            uuid_be_dic = {}
+
+        try:
+            pathname = os.path.join(self.path, filename)
+            d = xmini.parse(pathname)
+            root = d.documentElement
+            for cnode in root.childNodes:
+                if cnode.nodeName == "client":
+                    self.__load_client_data(cnode)
+                elif cnode.nodeName == "operation":
+                    # Operations load differently due to
+                    # the stack.
+                    self.__operations.append(
+                        {
+                            "pathname": pathname,
+                            "operation": self.__load_operation_data(
+                                cnode, uuid_be_dic
+                            ),
+                        }
+                    )
+        except KeyboardInterrupt:
+            raise
+        except Exception as e:
+            raise apx.HistoryLoadException(e)
+
+    def __serialize_client_data(self, d):
+        """Internal function used to serialize current client data
+        using the supplied 'd' (xml.dom.minidom) object.
+        """
+
+        assert self.client_name is not None
+        assert self.client_version is not None
+
+        root = d.documentElement
+        client = d.createElement("client")
+        client.setAttribute("name", self.client_name)
+        client.setAttribute("version", self.client_version)
+        root.appendChild(client)
+
+        if self.client_args:
+            args = d.createElement("args")
+            client.appendChild(args)
+            for entry in self.client_args:
+                arg = d.createElement("arg")
+                args.appendChild(arg)
+                arg.appendChild(d.createCDATASection(str(entry)))
+
+    def __serialize_operation_data(self, d):
+        """Internal function used to serialize current operation data
+        using the supplied 'd' (xml.dom.minidom) object.
+        """
+
+        if self.operation_userid is None:
+            raise apx.HistoryStoreException(
+                "Unable to determine "
+                "the id of the user that performed the current "
+                "operation; unable to store history information."
+            )
+        elif self.operation_username is None:
+            raise apx.HistoryStoreException(
+                "Unable to determine "
+                "the username of the user that performed the "
+                "current operation; unable to store history "
+                "information."
+            )
+
+        root = d.documentElement
+        op = d.createElement("operation")
+        op.setAttribute("name", self.operation_name)
+        # Must explictly convert values to a string due to minidom bug
+        # that causes a fatal whenever using types other than str.
+        op.setAttribute("username", str(self.operation_username))
+        op.setAttribute("userid", str(self.operation_userid))
+        op.setAttribute("result", ", ".join(self.operation_result))
+        op.setAttribute("start_time", self.operation_start_time)
+        op.setAttribute("end_time", self.operation_end_time)
+
+        if self.operation_be:
+            op.setAttribute("be", self.operation_be)
+        if self.operation_be_uuid:
+            op.setAttribute("be_uuid", self.operation_be_uuid)
+        if self.operation_new_be:
+            op.setAttribute("new_be", self.operation_new_be)
+        if self.operation_new_be_uuid:
+            op.setAttribute("new_be_uuid", self.operation_new_be_uuid)
+        if self.operation_snapshot:
+            op.setAttribute("snapshot", self.operation_snapshot)
+        if self.operation_release_notes:
+            op.setAttribute("release-notes", self.operation_release_notes)
+
+        root.appendChild(op)
+
+        if self.operation_start_state:
+            state = d.createElement("start_state")
+            op.appendChild(state)
+            state.appendChild(
+                d.createCDATASection(str(self.operation_start_state))
+            )
+
+        if self.operation_end_state:
+            state = d.createElement("end_state")
+            op.appendChild(state)
+            state.appendChild(
+                d.createCDATASection(str(self.operation_end_state))
+            )
+
+        if self.operation_errors:
+            errors = d.createElement("errors")
+            op.appendChild(errors)
+
+            for entry in self.operation_errors:
+                error = d.createElement("error")
+                errors.appendChild(error)
+                error.appendChild(d.createCDATASection(str(entry)))
+
+    def __save(self):
+        """Serializes the current history information and writes it to
+        a file in self.path/{operation_start_time}-{sequence}.xml.
+        """
+        d = xmini.Document()
+        d.appendChild(d.createElement("history"))
+        self.__serialize_client_data(d)
+        self.__serialize_operation_data(d)
+
+        if not os.path.exists(self.path):
+            try:
+                # Only the right-most directory should be
+                # created.  Assume that if the parent structure
+                # does not exist, it shouldn't be created.
+                os.mkdir(self.path, misc.PKG_DIR_MODE)
+            except EnvironmentError as e:
+                if e.errno not in (errno.EROFS, errno.EACCES, errno.ENOENT):
+                    # Ignore read-only file system and
+                    # access errors as it isn't critical
+                    # to the image that this data is
+                    # written.
+                    raise apx.HistoryStoreException(e)
+                # Return, since without the directory, the rest
+                # of this will fail.
+                return
+            except KeyboardInterrupt:
+                raise
+            except Exception as e:
+                raise apx.HistoryStoreException(e)
+
+        # Repeatedly attempt to write the history (only if it's because
+        # the file already exists).  This is necessary due to multiple
+        # operations possibly occuring within the same second (but not
+        # microsecond).
+        pathname = self.pathname
+        for i in range(1, 100):
+            try:
+                f = os.fdopen(
+                    os.open(
+                        pathname,
+                        os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                        misc.PKG_FILE_MODE,
+                    ),
+                    "w",
+                )
+                d.writexml(f, encoding=sys.getdefaultencoding())
+                f.close()
+                return
+            except EnvironmentError as e:
+                if e.errno == errno.EEXIST:
+                    name, ext = os.path.splitext(os.path.basename(pathname))
+                    name = name.split("-", 1)[0]
+                    # Pick the next name in our sequence
+                    # and try again.
+                    pathname = os.path.join(
+                        self.path, "{0}-{1:>02d}{2}".format(name, i + 1, ext)
+                    )
+                    continue
+                elif e.errno not in (errno.EROFS, errno.EACCES):
+                    # Ignore read-only file system and
+                    # access errors as it isn't critical
+                    # to the image that this data is
+                    # written.
+                    raise apx.HistoryStoreException(e)
+                # For all other failures, return, and avoid any
+                # further attempts.
+                return
+            except KeyboardInterrupt:
+                raise
+            except Exception as e:
+                raise apx.HistoryStoreException(e)
+
+    def purge(self, be_name=None, be_uuid=None):
+        """Removes all history information by deleting the directory
+        indicated by the value self.path and then creates a new history
+        entry to record that this purge occurred.
+        """
+        self.operation_name = "purge-history"
+        self.operation_be = be_name
+        self.operation_be_uuid = be_uuid
+
+        try:
+            shutil.rmtree(self.path)
+        except KeyboardInterrupt:
+            raise
+        except EnvironmentError as e:
+            if e.errno in (errno.ENOENT, errno.ESRCH):
+                # History already purged; record as successful.
+                self.operation_result = RESULT_SUCCEEDED
+                return
+            raise apx.HistoryPurgeException(e)
+        except Exception as e:
+            raise apx.HistoryPurgeException(e)
+        else:
+            self.operation_result = RESULT_SUCCEEDED
+
+    def abort(self, result):
+        """Intended to be used by the client during top-level error
+        handling to indicate that an unrecoverable error occurred
+        during the current operation(s).  This allows History to end
+        all of the current operations properly and handle any possible
+        errors that might be encountered in History itself.
+        """
+        try:
+            # Ensure that all operations in the current stack are
+            # ended properly.
+            while self.operation_name:
+                self.operation_result = result
+        except apx.HistoryStoreException:
+            # Ignore storage errors as it's likely that whatever
+            # caused the client to abort() also caused the storage
+            # of the history information to fail.
+            return
+
+    def log_operation_start(self, name, be_name=None, be_uuid=None):
+        """Marks the start of an operation to be recorded in image
+        history."""
+        self.operation_name = name
+        self.operation_be = be_name
+        self.operation_be_uuid = be_uuid
+
+    def log_operation_end(self, error=None, result=None, release_notes=None):
+        """Marks the end of an operation to be recorded in image
+        history.
+
+        'result' should be a pkg.client.history constant value
+        representing the outcome of an operation.  If not provided,
+        and 'error' is provided, the final result of the operation will
+        be based on the class of 'error' and 'error' will be recorded
+        for the current operation.  If 'result' and 'error' is not
+        provided, success is assumed."""
+
+        if error:
+            self.log_operation_error(error)
+            self.operation_new_be = None
+            self.operation_new_be_uuid = None
+
+        if error and not result:
+            try:
+                # Attempt get an exact error match first.
+                result = error_results[error.__class__]
+            except (AttributeError, KeyError):
+                # Failing an exact match, determine if this
+                # error is a subclass of an existing one.
+                for entry, val in six.iteritems(error_results):
+                    if isinstance(error, entry):
+                        result = val
+                        break
+            if not result:
+                # If a result could still not be determined,
+                # assume unknown failure case.
+                result = RESULT_FAILED_UNKNOWN
+        elif not result:
+            # Assume success if no error and no result.
+            result = RESULT_SUCCEEDED
+        if release_notes:
+            self.operation_release_notes = release_notes
+        self.operation_result = result
+
+    def log_operation_error(self, error):
+        """Adds an error to the list of errors to be recorded in image
+        history for the current operation."""
+
+        if self.operation_name:
+            out_stack = None
+            out_err = None
+            use_current_stack = True
+            if isinstance(error, Exception):
+                # Attempt to get the exception's stack trace
+                # from the stack.  If the exception on the stack
+                # isn't the same object as the one being logged,
+                # then we have to use the current stack (which
+                # is somewhat less useful) instead of being able
+                # to find the code location of the original
+                # error.
+                type, val, tb = sys.exc_info()
+                if error == val:
+                    output = traceback.format_exc()
+                    use_current_stack = False
+
+            if isinstance(error, six.string_types):
+                output = error
+            elif use_current_stack:
+                # Assume the current stack is more useful if
+                # the error doesn't inherit from Exception or
+                # we can't use the last exception's stack.
+                out_stack = "".join(traceback.format_stack())
 
                 if error:
-                        self.log_operation_error(error)
-                        self.operation_new_be = None
-                        self.operation_new_be_uuid = None
+                    # This may result in the text
+                    # of the error itself being written
+                    # twice, but that is necessary in case
+                    # it is not contained within the
+                    # output of format_exc().
+                    out_err = str(error)
+                    if not out_err or out_err == "None":
+                        out_err = error.__class__.__name__
 
-                if error and not result:
-                        try:
-                                # Attempt get an exact error match first.
-                                result = error_results[error.__class__]
-                        except (AttributeError, KeyError):
-                                # Failing an exact match, determine if this
-                                # error is a subclass of an existing one.
-                                for entry, val in six.iteritems(error_results):
-                                        if isinstance(error, entry):
-                                                result = val
-                                                break
-                        if not result:
-                                # If a result could still not be determined,
-                                # assume unknown failure case.
-                                result = RESULT_FAILED_UNKNOWN
-                elif not result:
-                        # Assume success if no error and no result.
-                        result = RESULT_SUCCEEDED
-                if release_notes:
-                        self.operation_release_notes = release_notes
-                self.operation_result = result
+                output = "".join(
+                    [item for item in [out_stack, out_err] if item]
+                )
 
-        def log_operation_error(self, error):
-                """Adds an error to the list of errors to be recorded in image
-                history for the current operation."""
+            self.operation_errors.append(output.strip())
 
-                if self.operation_name:
-                        out_stack = None
-                        out_err = None
-                        use_current_stack = True
-                        if isinstance(error, Exception):
-                                # Attempt to get the exception's stack trace
-                                # from the stack.  If the exception on the stack
-                                # isn't the same object as the one being logged,
-                                # then we have to use the current stack (which
-                                # is somewhat less useful) instead of being able
-                                # to find the code location of the original
-                                # error.
-                                type, val, tb = sys.exc_info()
-                                if error == val:
-                                        output = traceback.format_exc()
-                                        use_current_stack = False
+    def create_snapshot(self):
+        """Stores a snapshot of the current history and operation state
+        information in memory so that it can be restored in the event of
+        client failure (such as inability to store history information
+        or the failure of a boot environment operation).  Each call to
+        this function will overwrite the previous snapshot."""
 
-                        if isinstance(error, six.string_types):
-                                output = error
-                        elif use_current_stack:
-                                # Assume the current stack is more useful if
-                                # the error doesn't inherit from Exception or
-                                # we can't use the last exception's stack.
-                                out_stack = "".join(traceback.format_stack())
+        attrs = self.__snapshot = {}
+        for attr in ("root_dir", "client_name", "client_version"):
+            attrs[attr] = getattr(self, attr)
+        attrs["client_args"] = [copy.copy(a) for a in self.client_args]
+        # A deepcopy has to be performed here since this a list of dicts
+        # and not just History operation objects.
+        attrs["__operations"] = [copy.deepcopy(o) for o in self.__operations]
 
-                                if error:
-                                        # This may result in the text
-                                        # of the error itself being written
-                                        # twice, but that is necessary in case
-                                        # it is not contained within the
-                                        # output of format_exc().
-                                        out_err = str(error)
-                                        if not out_err or out_err == "None":
-                                                out_err = \
-                                                    error.__class__.__name__
+    def discard_snapshot(self):
+        """Discards the current history and operation state information
+        snapshot."""
+        self.__snapshot = None
 
-                                output = "".join([
-                                    item for item in [out_stack, out_err]
-                                    if item
-                                ])
+    def restore_snapshot(self):
+        """Restores the last snapshot taken of history and operation
+        state information completely discarding the existing history and
+        operation state information.  If nothing exists to restore, this
+        this function will silently return."""
 
-                        self.operation_errors.append(output.strip())
+        if not self.__snapshot:
+            return
 
-        def create_snapshot(self):
-                """Stores a snapshot of the current history and operation state
-                information in memory so that it can be restored in the event of
-                client failure (such as inability to store history information
-                or the failure of a boot environment operation).  Each call to
-                this function will overwrite the previous snapshot."""
+        for name, val in six.iteritems(self.__snapshot):
+            if not name.startswith("__"):
+                object.__setattr__(self, name, val)
+        self.__operations = self.__snapshot["__operations"]
 
-                attrs = self.__snapshot = {}
-                for attr in ("root_dir", "client_name", "client_version"):
-                        attrs[attr] = getattr(self, attr)
-                attrs["client_args"] = [copy.copy(a) for a in self.client_args]
-                # A deepcopy has to be performed here since this a list of dicts
-                # and not just History operation objects.
-                attrs["__operations"] = \
-                    [copy.deepcopy(o) for o in self.__operations]
-
-        def discard_snapshot(self):
-                """Discards the current history and operation state information
-                snapshot."""
-                self.__snapshot = None
-
-        def restore_snapshot(self):
-                """Restores the last snapshot taken of history and operation
-                state information completely discarding the existing history and
-                operation state information.  If nothing exists to restore, this
-                this function will silently return."""
-
-                if not self.__snapshot:
-                        return
-
-                for name, val in six.iteritems(self.__snapshot):
-                        if not name.startswith("__"):
-                                object.__setattr__(self, name, val)
-                self.__operations = self.__snapshot["__operations"]
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/image.py
+++ b/src/modules/client/image.py
@@ -49,35 +49,36 @@ from six.moves.urllib.parse import quote, unquote
 
 import pkg.actions
 import pkg.catalog
-import pkg.client.api_errors            as apx
-import pkg.client.bootenv               as bootenv
-import pkg.client.history               as history
-import pkg.client.imageconfig           as imageconfig
-import pkg.client.imageplan             as imageplan
-import pkg.client.linkedimage           as li
-import pkg.client.pkgdefs               as pkgdefs
-import pkg.client.pkgplan               as pkgplan
-import pkg.client.plandesc              as plandesc
-import pkg.client.progress              as progress
-import pkg.client.publisher             as publisher
-import pkg.client.sigpolicy             as sigpolicy
-import pkg.client.transport.transport   as transport
-import pkg.config                       as cfg
-import pkg.file_layout.layout           as fl
+import pkg.client.api_errors as apx
+import pkg.client.bootenv as bootenv
+import pkg.client.history as history
+import pkg.client.imageconfig as imageconfig
+import pkg.client.imageplan as imageplan
+import pkg.client.linkedimage as li
+import pkg.client.pkgdefs as pkgdefs
+import pkg.client.pkgplan as pkgplan
+import pkg.client.plandesc as plandesc
+import pkg.client.progress as progress
+import pkg.client.publisher as publisher
+import pkg.client.sigpolicy as sigpolicy
+import pkg.client.transport.transport as transport
+import pkg.config as cfg
+import pkg.file_layout.layout as fl
 import pkg.fmri
-import pkg.json                         as json
-import pkg.lockfile                     as lockfile
-import pkg.manifest                     as manifest
-import pkg.mediator                     as med
-import pkg.misc                         as misc
+import pkg.json as json
+import pkg.lockfile as lockfile
+import pkg.manifest as manifest
+import pkg.mediator as med
+import pkg.misc as misc
 import pkg.nrlock
-import pkg.pkgsubprocess                as subprocess
-import pkg.portable                     as portable
+import pkg.pkgsubprocess as subprocess
+import pkg.portable as portable
 import pkg.server.catalog
-import pkg.smf                          as smf
+import pkg.smf as smf
 import pkg.version
 
 from pkg.client import global_settings
+
 logger = global_settings.logger
 
 from pkg.client.debugvalues import DebugValues
@@ -90,5031 +91,5264 @@ img_root_prefix = "var/pkg"
 
 IMG_PUB_DIR = "publisher"
 
+
 class Image(object):
-        """An Image object is a directory tree containing the laid-down contents
-        of a self-consistent graph of Packages.
+    """An Image object is a directory tree containing the laid-down contents
+    of a self-consistent graph of Packages.
 
-        An Image has a root path.
+    An Image has a root path.
 
-        An Image of type IMG_ENTIRE does not have a parent Image.  Other Image
-        types must have a parent Image.  The external state of the parent Image
-        must be accessible from the Image's context, or duplicated within the
-        Image (IMG_PARTIAL for zones, for instance).
+    An Image of type IMG_ENTIRE does not have a parent Image.  Other Image
+    types must have a parent Image.  The external state of the parent Image
+    must be accessible from the Image's context, or duplicated within the
+    Image (IMG_PARTIAL for zones, for instance).
 
-        The parent of a user Image can be a partial Image.  The parent of a
-        partial Image must be an entire Image.
+    The parent of a user Image can be a partial Image.  The parent of a
+    partial Image must be an entire Image.
 
-        An Image of type IMG_USER stores its external state at self.root +
-        ".org.opensolaris,pkg".
+    An Image of type IMG_USER stores its external state at self.root +
+    ".org.opensolaris,pkg".
 
-        An Image of type IMG_ENTIRE or IMG_PARTIAL stores its external state at
-        self.root + "/var/pkg".
+    An Image of type IMG_ENTIRE or IMG_PARTIAL stores its external state at
+    self.root + "/var/pkg".
 
-        An Image needs to be able to have a different repository set than the
-        system's root Image.
+    An Image needs to be able to have a different repository set than the
+    system's root Image.
 
-        For image format details, see section 5.3 of doc/on-disk-format.txt
-        in the pkg(7) gate.
-        """
+    For image format details, see section 5.3 of doc/on-disk-format.txt
+    in the pkg(7) gate.
+    """
 
-        # Class constants
-        CURRENT_VERSION = 4
-        IMG_CATALOG_KNOWN = "known"
-        IMG_CATALOG_INSTALLED = "installed"
+    # Class constants
+    CURRENT_VERSION = 4
+    IMG_CATALOG_KNOWN = "known"
+    IMG_CATALOG_INSTALLED = "installed"
 
-        __STATE_UPDATING_FILE = "state_updating"
+    __STATE_UPDATING_FILE = "state_updating"
 
-        def __init__(self, root, user_provided_dir=False, progtrack=None,
-            should_exist=True, imgtype=None, force=False,
-            augment_ta_from_parent_image=True, allow_ondisk_upgrade=None,
-            props=misc.EmptyDict, cmdpath=None):
+    def __init__(
+        self,
+        root,
+        user_provided_dir=False,
+        progtrack=None,
+        should_exist=True,
+        imgtype=None,
+        force=False,
+        augment_ta_from_parent_image=True,
+        allow_ondisk_upgrade=None,
+        props=misc.EmptyDict,
+        cmdpath=None,
+    ):
+        if should_exist:
+            assert imgtype is None
+            assert not force
+        else:
+            assert imgtype is not None
 
-                if should_exist:
-                        assert(imgtype is None)
-                        assert(not force)
-                else:
-                        assert(imgtype is not None)
+        # Alternate package sources.
+        self.__alt_pkg_pub_map = None
+        self.__alt_pubs = None
+        self.__alt_known_cat = None
+        self.__alt_pkg_sources_loaded = False
 
-                # Alternate package sources.
-                self.__alt_pkg_pub_map = None
-                self.__alt_pubs = None
-                self.__alt_known_cat = None
-                self.__alt_pkg_sources_loaded = False
+        # Determine identity of client executable if appropriate.
+        if cmdpath == None:
+            cmdpath = misc.api_cmdpath()
+        self.cmdpath = cmdpath
 
-                # Determine identity of client executable if appropriate.
-                if cmdpath == None:
-                        cmdpath = misc.api_cmdpath()
-                self.cmdpath = cmdpath
+        if self.cmdpath != None:
+            self.__cmddir = os.path.dirname(cmdpath)
 
-                if self.cmdpath != None:
-                        self.__cmddir = os.path.dirname(cmdpath)
-
-                # prevent brokeness in the test suite
-                if self.cmdpath and \
-                    "PKG_NO_RUNPY_CMDPATH" in os.environ and \
-                    self.cmdpath.endswith(os.sep + "run.py"):
-                        raise RuntimeError("""
+        # prevent brokeness in the test suite
+        if (
+            self.cmdpath
+            and "PKG_NO_RUNPY_CMDPATH" in os.environ
+            and self.cmdpath.endswith(os.sep + "run.py")
+        ):
+            raise RuntimeError(
+                """
 An Image object was allocated from within ipkg test suite and
 cmdpath was not explicitly overridden.  Please make sure to
 explicitly set cmdpath when allocating an Image object, or
 override cmdpath when allocating an Image object by setting PKG_CMDPATH
-in the environment or by setting simulate_cmdpath in DebugValues.""")
+in the environment or by setting simulate_cmdpath in DebugValues."""
+            )
 
-                self.linked = None
+        self.linked = None
 
-                # Indicates whether automatic image format upgrades of the
-                # on-disk format are allowed.
-                self.allow_ondisk_upgrade = allow_ondisk_upgrade
-                self.__upgraded = False
+        # Indicates whether automatic image format upgrades of the
+        # on-disk format are allowed.
+        self.allow_ondisk_upgrade = allow_ondisk_upgrade
+        self.__upgraded = False
 
-                # Must happen after upgraded assignment.
-                self.__init_catalogs()
+        # Must happen after upgraded assignment.
+        self.__init_catalogs()
 
-                self.__imgdir = None
-                self.__root = root
+        self.__imgdir = None
+        self.__root = root
 
-                self.blocking_locks = False
-                self.cfg = None
-                self.history = history.History()
-                self.imageplan = None
-                self.img_prefix = None
-                self.index_dir = None
-                self.plandir = None
-                self.version = -1
+        self.blocking_locks = False
+        self.cfg = None
+        self.history = history.History()
+        self.imageplan = None
+        self.img_prefix = None
+        self.index_dir = None
+        self.plandir = None
+        self.version = -1
 
-                # Can have multiple read cache dirs...
-                self.__read_cache_dirs = []
+        # Can have multiple read cache dirs...
+        self.__read_cache_dirs = []
 
-                # ...but only one global write cache dir and incoming write dir.
-                self.__write_cache_dir = None
-                self.__user_cache_dir = None
-                self._incoming_cache_dir = None
+        # ...but only one global write cache dir and incoming write dir.
+        self.__write_cache_dir = None
+        self.__user_cache_dir = None
+        self._incoming_cache_dir = None
 
-                # Set if write_cache is actually a tree like /var/pkg/publisher
-                # instead of a flat cache.
-                self.__write_cache_root = None
+        # Set if write_cache is actually a tree like /var/pkg/publisher
+        # instead of a flat cache.
+        self.__write_cache_root = None
 
-                self.__lock = pkg.nrlock.NRLock()
-                self.__lockfile = None
-                self.__sig_policy = None
-                self.__trust_anchors = None
-                self.__bad_trust_anchors = []
+        self.__lock = pkg.nrlock.NRLock()
+        self.__lockfile = None
+        self.__sig_policy = None
+        self.__trust_anchors = None
+        self.__bad_trust_anchors = []
 
-                # cache for presence of boot-archive
-                self.__boot_archive = None
+        # cache for presence of boot-archive
+        self.__boot_archive = None
 
-                # When users and groups are added before their database files
-                # have been installed, the actions store them temporarily in the
-                # image, in these members.
-                self._users = set()
-                self._groups = set()
-                self._usersbyname = {}
-                self._groupsbyname = {}
+        # When users and groups are added before their database files
+        # have been installed, the actions store them temporarily in the
+        # image, in these members.
+        self._users = set()
+        self._groups = set()
+        self._usersbyname = {}
+        self._groupsbyname = {}
 
-                # Set of pkg stems being avoided per configuration.
-                self.__avoid_set = None
-                self.__avoid_set_altered = False
+        # Set of pkg stems being avoided per configuration.
+        self.__avoid_set = None
+        self.__avoid_set_altered = False
 
-                # Set of pkg stems being avoided by solver due to dependency
-                # constraints (not administrative action).
-                self.__implicit_avoid_set = None
+        # Set of pkg stems being avoided by solver due to dependency
+        # constraints (not administrative action).
+        self.__implicit_avoid_set = None
 
-                # set of pkg stems subject to group
-                # dependency but removed because obsolete
-                self.__group_obsolete = None
+        # set of pkg stems subject to group
+        # dependency but removed because obsolete
+        self.__group_obsolete = None
 
-                # The action dictionary that's returned by __load_actdict.
-                self.__actdict = None
-                self.__actdict_timestamp = None
+        # The action dictionary that's returned by __load_actdict.
+        self.__actdict = None
+        self.__actdict_timestamp = None
 
-                self.__property_overrides = { "property": props }
+        self.__property_overrides = {"property": props}
 
-                # Transport operations for this image
-                self.transport = transport.Transport(
-                    transport.ImageTransportCfg(self))
+        # Transport operations for this image
+        self.transport = transport.Transport(transport.ImageTransportCfg(self))
 
-                self.linked = li.LinkedImage(self)
+        self.linked = li.LinkedImage(self)
 
-                if should_exist:
-                        self.find_root(self.root, user_provided_dir,
-                            progtrack)
-                else:
-                        if not force and self.image_type(self.root) != None:
-                                raise apx.ImageAlreadyExists(self.root)
-                        if not force and os.path.exists(self.root):
-                                # ignore .zfs snapdir if it's present
-                                snapdir = os.path.join(self.root, ".zfs")
-                                listdir = set(os.listdir(self.root))
-                                if os.path.isdir(snapdir):
-                                        listdir -= set([".zfs"])
-                                if len(listdir) > 0:
-                                        raise apx.CreatingImageInNonEmptyDir(
-                                            self.root)
-                        self.__set_dirs(root=self.root, imgtype=imgtype,
-                            progtrack=progtrack, purge=True)
+        if should_exist:
+            self.find_root(self.root, user_provided_dir, progtrack)
+        else:
+            if not force and self.image_type(self.root) != None:
+                raise apx.ImageAlreadyExists(self.root)
+            if not force and os.path.exists(self.root):
+                # ignore .zfs snapdir if it's present
+                snapdir = os.path.join(self.root, ".zfs")
+                listdir = set(os.listdir(self.root))
+                if os.path.isdir(snapdir):
+                    listdir -= set([".zfs"])
+                if len(listdir) > 0:
+                    raise apx.CreatingImageInNonEmptyDir(self.root)
+            self.__set_dirs(
+                root=self.root, imgtype=imgtype, progtrack=progtrack, purge=True
+            )
 
-                # right now we don't explicitly set dir/file modes everywhere;
-                # set umask to proper value to prevent problems w/ overly
-                # locked down umask.
-                os.umask(0o022)
+        # right now we don't explicitly set dir/file modes everywhere;
+        # set umask to proper value to prevent problems w/ overly
+        # locked down umask.
+        os.umask(0o022)
 
-                self.augment_ta_from_parent_image = augment_ta_from_parent_image
+        self.augment_ta_from_parent_image = augment_ta_from_parent_image
 
-        def __catalog_loaded(self, name):
-                """Returns a boolean value indicating whether the named catalog
-                has already been loaded.  This is intended to be used as an
-                optimization function to determine which catalog to request."""
+    def __catalog_loaded(self, name):
+        """Returns a boolean value indicating whether the named catalog
+        has already been loaded.  This is intended to be used as an
+        optimization function to determine which catalog to request."""
 
-                return name in self.__catalogs
+        return name in self.__catalogs
 
-        def __init_catalogs(self):
-                """Initializes default catalog state.  Actual data is provided
-                on demand via get_catalog()"""
+    def __init_catalogs(self):
+        """Initializes default catalog state.  Actual data is provided
+        on demand via get_catalog()"""
 
-                if self.__upgraded and self.version < 3:
-                        # Ignore request; transformed catalog data only exists
-                        # in memory and can't be reloaded from disk.
-                        return
+        if self.__upgraded and self.version < 3:
+            # Ignore request; transformed catalog data only exists
+            # in memory and can't be reloaded from disk.
+            return
 
-                # This is used to cache image catalogs.
-                self.__catalogs = {}
-                self.__alt_pkg_sources_loaded = False
+        # This is used to cache image catalogs.
+        self.__catalogs = {}
+        self.__alt_pkg_sources_loaded = False
 
-        @staticmethod
-        def alloc(*args, **kwargs):
-                return Image(*args, **kwargs)
+    @staticmethod
+    def alloc(*args, **kwargs):
+        return Image(*args, **kwargs)
 
-        @property
-        def imgdir(self):
-                """The absolute path of the image's metadata."""
-                return self.__imgdir
+    @property
+    def imgdir(self):
+        """The absolute path of the image's metadata."""
+        return self.__imgdir
 
-        @property
-        def locked(self):
-                """A boolean value indicating whether the image is currently
-                locked."""
+    @property
+    def locked(self):
+        """A boolean value indicating whether the image is currently
+        locked."""
 
-                return self.__lock and self.__lock.locked
+        return self.__lock and self.__lock.locked
 
-        @property
-        def root(self):
-                """The absolute path of the image's location."""
-                return self.__root
+    @property
+    def root(self):
+        """The absolute path of the image's location."""
+        return self.__root
 
-        @property
-        def signature_policy(self):
-                """The current signature policy for this image."""
+    @property
+    def signature_policy(self):
+        """The current signature policy for this image."""
 
-                if self.__sig_policy is not None:
-                        return self.__sig_policy
-                txt = self.cfg.get_policy_str(imageconfig.SIGNATURE_POLICY)
-                names = self.cfg.get_property("property",
-                    "signature-required-names")
-                self.__sig_policy = sigpolicy.Policy.policy_factory(txt, names)
-                return self.__sig_policy
+        if self.__sig_policy is not None:
+            return self.__sig_policy
+        txt = self.cfg.get_policy_str(imageconfig.SIGNATURE_POLICY)
+        names = self.cfg.get_property("property", "signature-required-names")
+        self.__sig_policy = sigpolicy.Policy.policy_factory(txt, names)
+        return self.__sig_policy
 
-        @property
-        def trust_anchors(self):
-                """A dictionary mapping subject hashes for certificates this
-                image trusts to those certs.  The image trusts the trust anchors
-                in its trust_anchor_dir and those in the image from which the
-                client was run."""
+    @property
+    def trust_anchors(self):
+        """A dictionary mapping subject hashes for certificates this
+        image trusts to those certs.  The image trusts the trust anchors
+        in its trust_anchor_dir and those in the image from which the
+        client was run."""
 
-                if self.__trust_anchors is not None:
-                        return self.__trust_anchors
+        if self.__trust_anchors is not None:
+            return self.__trust_anchors
 
-                user_set_ta_loc = True
-                rel_dir = self.get_property("trust-anchor-directory")
-                if rel_dir[0] == "/":
-                        rel_dir = rel_dir[1:]
-                trust_anchor_loc = os.path.join(self.root, rel_dir)
-                loc_is_dir = os.path.isdir(trust_anchor_loc)
-                pkg_trust_anchors = {}
-                if self.__cmddir and self.augment_ta_from_parent_image:
-                        pkg_trust_anchors = Image(self.__cmddir,
-                            augment_ta_from_parent_image=False,
-                            cmdpath=self.cmdpath).trust_anchors
-                if not loc_is_dir and os.path.exists(trust_anchor_loc):
-                        raise apx.InvalidPropertyValue(_("The trust "
-                            "anchors for the image were expected to be found "
-                            "in {0}, but that is not a directory.  Please set "
-                            "the image property 'trust-anchor-directory' to "
-                            "the correct path.").format(trust_anchor_loc))
-                self.__trust_anchors = {}
-                if loc_is_dir:
-                        for fn in os.listdir(trust_anchor_loc):
-                                pth = os.path.join(trust_anchor_loc, fn)
-                                if os.path.islink(pth):
-                                        continue
-                                try:
-                                        with open(pth, "rb") as f:
-                                                raw = f.read()
-                                        trusted_ca = \
-                                            x509.load_pem_x509_certificate(
-                                            raw, default_backend())
-                                except (ValueError, IOError) as e:
-                                        self.__bad_trust_anchors.append(
-                                            (pth, str(e)))
-                                else:
-                                        # We store certificates internally by
-                                        # the SHA-1 hash of its subject.
-                                        s = hashlib.sha1(misc.force_bytes(
-                                            trusted_ca.subject)).hexdigest()
-                                        self.__trust_anchors.setdefault(s, [])
-                                        self.__trust_anchors[s].append(
-                                            trusted_ca)
-                for s in pkg_trust_anchors:
-                        if s not in self.__trust_anchors:
-                                self.__trust_anchors[s] = pkg_trust_anchors[s]
-                return self.__trust_anchors
-
-        @property
-        def bad_trust_anchors(self):
-                """A list of strings decribing errors encountered while parsing
-                trust anchors."""
-
-                return [_("{path} is expected to be a certificate but could "
-                    "not be parsed.  The error encountered "
-                    "was:\n\t{err}").format(path=p, err=e)
-                    for p, e in self.__bad_trust_anchors
-                ]
-
-        @property
-        def write_cache_path(self):
-                """The path to the filesystem that holds the write cache--used
-                to compute whether sufficent space is available for
-                downloads."""
-
-                return self.__user_cache_dir or \
-                    os.path.join(self.imgdir, IMG_PUB_DIR)
-
-        @contextmanager
-        def locked_op(self, op, allow_unprivileged=False, new_history_op=True):
-                """Helper method for executing an image-modifying operation
-                that needs locking.  It automatically handles calling
-                log_operation_start and log_operation_end by default.  Locking
-                behaviour is controlled by the blocking_locks image property.
-
-                'allow_unprivileged' is an optional boolean value indicating
-                that permissions-related exceptions should be ignored when
-                attempting to obtain the lock as the related operation will
-                still work correctly even though the image cannot (presumably)
-                be modified.
-
-                'new_history_op' indicates whether we should handle history
-                operations.
-                """
-
-                error = None
-                self.lock(allow_unprivileged=allow_unprivileged)
+        user_set_ta_loc = True
+        rel_dir = self.get_property("trust-anchor-directory")
+        if rel_dir[0] == "/":
+            rel_dir = rel_dir[1:]
+        trust_anchor_loc = os.path.join(self.root, rel_dir)
+        loc_is_dir = os.path.isdir(trust_anchor_loc)
+        pkg_trust_anchors = {}
+        if self.__cmddir and self.augment_ta_from_parent_image:
+            pkg_trust_anchors = Image(
+                self.__cmddir,
+                augment_ta_from_parent_image=False,
+                cmdpath=self.cmdpath,
+            ).trust_anchors
+        if not loc_is_dir and os.path.exists(trust_anchor_loc):
+            raise apx.InvalidPropertyValue(
+                _(
+                    "The trust "
+                    "anchors for the image were expected to be found "
+                    "in {0}, but that is not a directory.  Please set "
+                    "the image property 'trust-anchor-directory' to "
+                    "the correct path."
+                ).format(trust_anchor_loc)
+            )
+        self.__trust_anchors = {}
+        if loc_is_dir:
+            for fn in os.listdir(trust_anchor_loc):
+                pth = os.path.join(trust_anchor_loc, fn)
+                if os.path.islink(pth):
+                    continue
                 try:
-                        be_name, be_uuid = \
-                            bootenv.BootEnv.get_be_name(self.root)
-                        if new_history_op:
-                                self.history.log_operation_start(op,
-                                    be_name=be_name, be_uuid=be_uuid)
-                        yield
-                except apx.ImageLockedError as e:
-                        # Don't unlock the image if the call failed to
-                        # get the lock.
-                        error = e
-                        raise
-                except Exception as e:
-                        error = e
-                        self.unlock()
-                        raise
+                    with open(pth, "rb") as f:
+                        raw = f.read()
+                    trusted_ca = x509.load_pem_x509_certificate(
+                        raw, default_backend()
+                    )
+                except (ValueError, IOError) as e:
+                    self.__bad_trust_anchors.append((pth, str(e)))
                 else:
-                        self.unlock()
-                finally:
-                        if new_history_op:
-                                self.history.log_operation_end(error=error)
-
-        def lock(self, allow_unprivileged=False):
-                """Locks the image in preparation for an image-modifying
-                operation.  Raises an ImageLockedError exception on failure.
-                Locking behaviour is controlled by the blocking_locks image
-                property.
-
-                'allow_unprivileged' is an optional boolean value indicating
-                that permissions-related exceptions should be ignored when
-                attempting to obtain the lock as the related operation will
-                still work correctly even though the image cannot (presumably)
-                be modified.
-                """
-
-                blocking = self.blocking_locks
-
-                # First, attempt to obtain a thread lock.
-                if not self.__lock.acquire(blocking=blocking):
-                        raise apx.ImageLockedError()
-
-                try:
-                        # Attempt to obtain a file lock.
-                        self.__lockfile.lock(blocking=blocking)
-                except EnvironmentError as e:
-                        exc = None
-                        if e.errno == errno.ENOENT:
-                                return
-                        if e.errno == errno.EACCES:
-                                exc = apx.UnprivilegedUserError(e.filename)
-                        elif e.errno == errno.EROFS:
-                                exc = apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        elif e.errno in (errno.ENOSPC, errno.EDQUOT):
-                                # Failed due to space constraint
-                                raise e
-                        else:
-                                self.__lock.release()
-                                raise
-
-                        if exc and not allow_unprivileged:
-                                self.__lock.release()
-                                raise exc
-                except:
-                        # If process lock fails, ensure thread lock is released.
-                        self.__lock.release()
-                        raise
-
-        def unlock(self):
-                """Unlocks the image."""
-
-                try:
-                        if self.__lockfile:
-                                self.__lockfile.unlock()
-                finally:
-                        self.__lock.release()
-
-        def image_type(self, d):
-                """Returns the type of image at directory: d; or None"""
-                rv = None
-
-                def is_image(sub_d, prefix):
-                        # First check for new image configuration file.
-                        if os.path.isfile(os.path.join(sub_d, prefix,
-                            "pkg5.image")):
-                                # Regardless of directory structure, assume
-                                # this is an image for now.
-                                return True
-
-                        if not os.path.isfile(os.path.join(sub_d, prefix,
-                            "cfg_cache")):
-                                # For older formats, if configuration is
-                                # missing, this can't be an image.
-                                return False
-
-                        # Configuration exists, but for older formats,
-                        # all of these directories have to exist.
-                        for n in ("state", "pkg"):
-                                if not os.path.isdir(os.path.join(sub_d, prefix,
-                                    n)):
-                                        return False
-
-                        return True
-
-                if os.path.isdir(os.path.join(d, img_user_prefix)) and \
-                    is_image(d, img_user_prefix):
-                        rv = IMG_USER
-                elif os.path.isdir(os.path.join(d, img_root_prefix)) and \
-                    is_image(d, img_root_prefix):
-                        rv = IMG_ENTIRE
-                return rv
-
-        def find_root(self, d, exact_match=False, progtrack=None):
-                # Ascend from the given directory d to find first
-                # encountered image.  If exact_match is true, if the
-                # image found doesn't match startd, raise an
-                # ImageNotFoundException.
-
-                startd = d
-                # eliminate problem if relative path such as "." is passed in
-                d = os.path.realpath(d)
-
-                while True:
-                        imgtype = self.image_type(d)
-                        if imgtype in (IMG_USER, IMG_ENTIRE):
-                                if exact_match and \
-                                    os.path.realpath(startd) != \
-                                    os.path.realpath(d):
-                                        raise apx.ImageNotFoundException(
-                                            exact_match, startd, d)
-                                self.__set_dirs(imgtype=imgtype, root=d,
-                                    startd=startd, progtrack=progtrack)
-                                return
-
-                        # XXX follow symlinks or not?
-                        oldpath = d
-                        d = os.path.normpath(os.path.join(d, os.path.pardir))
-
-                        # Make sure we are making progress and aren't in an
-                        # infinite loop.
-                        #
-                        # (XXX - Need to deal with symlinks here too)
-                        if d == oldpath:
-                                raise apx.ImageNotFoundException(
-                                    exact_match, startd, d)
-
-        def __load_config(self):
-                """Load this image's cached configuration from the default
-                location.  This function should not be called anywhere other
-                than __set_dirs()."""
-
-                # XXX Incomplete with respect to doc/image.txt description of
-                # configuration.
-
-                if self.root == None:
-                        raise RuntimeError("self.root must be set")
-
-                version = None
-                if self.version > -1:
-                        if self.version >= 3:
-                                # Configuration version is currently 3
-                                # for all v3 images and newer.
-                                version = 3
-                        else:
-                                version = self.version
-
-                self.cfg = imageconfig.ImageConfig(self.__cfgpathname,
-                    self.root, version=version,
-                    overrides=self.__property_overrides)
-
-                if self.__upgraded:
-                        self.cfg = imageconfig.BlendedConfig(self.cfg,
-                            self.get_catalog(self.IMG_CATALOG_INSTALLED).\
-                                get_package_counts_by_pub(),
-                            self.imgdir, self.transport,
-                            self.cfg.get_policy("use-system-repo"))
-
-                if self.cfg.version == imageconfig.CURRENT_VERSION:
-                        for keyf in self.get_property(imageconfig.KEY_FILES):
-                                if not os.path.exists(
-                                    self.root + os.path.sep + keyf):
-                                        raise apx.ImageMissingKeyFile(keyf)
-
-                self.__load_publisher_ssl()
-
-        def __store_publisher_ssl(self):
-                """Normalizes publisher SSL configuration data, storing any
-                certificate files as needed in the image's SSL directory.  This
-                logic is performed here in the image instead of ImageConfig as
-                it relies on special knowledge of the image structure."""
-
-                ssl_dir = os.path.join(self.imgdir, "ssl")
-
-                def store_ssl_file(src):
-                        try:
-                                if not src or not os.path.exists(src):
-                                        # If SSL file doesn't exist (for
-                                        # whatever reason), then don't update
-                                        # configuration.  (Let the failure
-                                        # happen later during an operation
-                                        # that requires the file.)
-                                        return
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-
-                        # Ensure ssl_dir exists; makedirs handles any errors.
-                        misc.makedirs(ssl_dir)
-
-                        try:
-                                # Destination name is based on digest of file.
-                                # In order for this image to interoperate with
-                                # older and newer clients, we must use sha-1
-                                # here.
-                                dest = os.path.join(ssl_dir,
-                                    misc.get_data_digest(src,
-                                        hash_func=hashlib.sha1)[0])
-                                if src != dest:
-                                        portable.copyfile(src, dest)
-
-                                # Ensure file can be read by unprivileged users.
-                                os.chmod(dest, misc.PKG_FILE_MODE)
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-                        return dest
-
-                for pub in self.cfg.publishers.values():
-                        # self.cfg.publishers is used because gen_publishers
-                        # includes temporary publishers and this is only for
-                        # configured ones.
-                        repo = pub.repository
-                        if not repo:
-                                continue
-
-                        # Store and normalize ssl_cert and ssl_key.
-                        for u in repo.origins + repo.mirrors:
-                                for prop in ("ssl_cert", "ssl_key"):
-                                        pval = getattr(u, prop)
-                                        if pval:
-                                                pval = store_ssl_file(pval)
-                                        if not pval:
-                                                continue
-                                        # Store path as absolute to image root,
-                                        # it will be corrected on load to match
-                                        # actual image location if needed.
-                                        setattr(u, prop,
-                                            os.path.splitdrive(self.root)[0] +
-                                            os.path.sep +
-                                            misc.relpath(pval, start=self.root))
-
-        def __load_publisher_ssl(self):
-                """Should be called every time image configuration is loaded;
-                ensure ssl_cert and ssl_key properties of publisher repository
-                URI objects match current image location."""
-
-                ssl_dir = os.path.join(self.imgdir, "ssl")
-
-                for pub in self.cfg.publishers.values():
-                        # self.cfg.publishers is used because gen_publishers
-                        # includes temporary publishers and this is only for
-                        # configured ones.
-                        repo = pub.repository
-                        if not repo:
-                                continue
-
-                        for u in repo.origins + repo.mirrors:
-                                for prop in ("ssl_cert", "ssl_key"):
-                                        pval = getattr(u, prop)
-                                        if not pval:
-                                                continue
-                                        if not os.path.join(self.img_prefix,
-                                            "ssl") in os.path.dirname(pval):
-                                                continue
-                                        # If special image directory is part
-                                        # of path, then assume path should be
-                                        # rewritten to match current image
-                                        # location.
-                                        setattr(u, prop, os.path.join(ssl_dir,
-                                           os.path.basename(pval)))
-
-        def update_last_modified(self):
-                """Update $imgdir/modified timestamp for image; should be
-                called after any image modification has completed.  This
-                provides a public interface for programs that want to monitor
-                the image for modifications via event ports, etc."""
-
-                # This is usually /var/pkg/modified.
-                fname = os.path.join(self.imgdir, "modified")
-                try:
-                        with os.fdopen(
-                            os.open(fname, os.O_CREAT|os.O_NOFOLLOW,
-                                misc.PKG_FILE_MODE)) as f:
-                                os.utime(fname, None)
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-
-        def save_config(self):
-                # First, create the image directories if they haven't been, so
-                # the configuration file can be written.
-                self.mkdirs()
-                self.__store_publisher_ssl()
-                self.cfg.write()
-                self.update_last_modified()
-                self.__load_publisher_ssl()
-
-                # Remove the old the pkg.sysrepo(8) cache, if present.
-                cache_path = os.path.join(self.root,
-                    global_settings.sysrepo_pub_cache_path)
-                try:
-                        portable.remove(cache_path)
-                except EnvironmentError as e:
-                        if e.errno != errno.ENOENT:
-                                raise apx._convert_error(e)
-
-                if self.is_liveroot() and \
-                    smf.get_state(
-                        "svc:/application/pkg/system-repository:default") in \
-                    (smf.SMF_SVC_TMP_ENABLED, smf.SMF_SVC_ENABLED):
-                        smf.refresh([
-                            "svc:/application/pkg/system-repository:default"])
-
-                # This ensures all old transport configuration is thrown away.
-                self.transport = transport.Transport(
-                    transport.ImageTransportCfg(self))
-
-        def hotfix_origin_cleanup(self):
-                """Remove any temporary hot-fix source origins"""
-
-                changed = False
-
-                for pub in self.cfg.publishers.values():
-                        if not pub.repository:
-                                continue
-
-                        for o in pub.repository.origins:
-                                if relib.search('/pkg_hfa_.*p5p/$', o.uri):
-                                        pub.repository.remove_origin(o)
-                                        changed = True
-
-                if changed:
-                        self.save_config()
-
-        def mkdirs(self, root=None, version=None):
-                """Create any missing parts of the image's directory structure.
-
-                'root' is an optional path to a directory to create the new
-                image structure in.  If not provided, the current image
-                directory is the default.
-
-                'version' is an optional integer value indicating the version
-                of the structure to create.  If not provided, the current image
-                version is the default.
-                """
-
-                if not root:
-                        root = self.imgdir
-                if not version:
-                        version = self.version
-
-                if version == self.CURRENT_VERSION:
-                        img_dirs = ["cache/index", "cache/publisher",
-                            "cache/tmp", "gui_cache", "history", "license",
-                            "lost+found", "publisher", "ssl", "state/installed",
-                            "state/known"]
-                else:
-                        img_dirs = ["download", "file", "gui_cache", "history",
-                            "index", "lost+found", "pkg", "publisher",
-                            "state/installed", "state/known", "tmp"]
-
-                for sd in img_dirs:
-                        try:
-                                misc.makedirs(os.path.join(root, sd))
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-
-        def __set_dirs(self, imgtype, root, startd=None, progtrack=None,
-            purge=False):
-                # Ensure upgraded status is reset.
-                self.__upgraded = False
-
-                if not self.__allow_liveroot() and root == misc.liveroot():
-                        if startd == None:
-                                startd = root
-                        raise RuntimeError(
-                            "Live root image access is disabled but was \
-                            attempted.\nliveroot: {0}\nimage path: {1}".format(
-                            misc.liveroot(), startd))
-
-                self.__root = root
-                self.type = imgtype
-                if self.type == IMG_USER:
-                        self.img_prefix = img_user_prefix
-                else:
-                        self.img_prefix = img_root_prefix
-
-                # Use a new Transport object every time location is changed.
-                self.transport = transport.Transport(
-                    transport.ImageTransportCfg(self))
-
-                # cleanup specified path
-                if os.path.isdir(root):
-                        try:
-                                cwd = os.getcwd()
-                        except Exception as e:
-                                # If current directory can't be obtained for any
-                                # reason, ignore the error.
-                                cwd = None
-
-                        try:
-                                os.chdir(root)
-                                self.__root = os.getcwd()
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-                        finally:
-                                if cwd:
-                                        os.chdir(cwd)
-
-                # If current image is locked, then it should be unlocked
-                # and then relocked after the imgdir is changed.  This
-                # ensures that alternate BE scenarios work.
-                relock = self.imgdir and self.locked
-                if relock:
-                        self.unlock()
-
-                # Must set imgdir first.
-                self.__imgdir = os.path.join(self.root, self.img_prefix)
-
-                # Force a reset of version.
-                self.version = -1
-
-                # Assume version 4+ configuration location.
-                self.__cfgpathname = os.path.join(self.imgdir, "pkg5.image")
-
-                # In the case of initial image creation, purge is specified
-                # to ensure that when an image is created over an existing
-                # one, any old data is removed first.
-                if purge and os.path.exists(self.imgdir):
-                        for entry in os.listdir(self.imgdir):
-                                if entry == "ssl":
-                                        # Preserve certs and keys directory
-                                        # as a special exception.
-                                        continue
-                                epath = os.path.join(self.imgdir, entry)
-                                try:
-                                        if os.path.isdir(epath):
-                                                shutil.rmtree(epath)
-                                        else:
-                                                portable.remove(epath)
-                                except EnvironmentError as e:
-                                        raise apx._convert_error(e)
-                elif not purge:
-                        # Determine if the version 4 configuration file exists.
-                        if not os.path.exists(self.__cfgpathname):
-                                self.__cfgpathname = os.path.join(self.imgdir,
-                                    "cfg_cache")
-
-                # Load the image configuration.
-                self.__load_config()
-
-                if not purge:
-                        try:
-                                self.version = int(self.cfg.get_property("image",
-                                    "version"))
-                        except (cfg.PropertyConfigError, ValueError):
-                                # If version couldn't be read from
-                                # configuration, then allow fallback
-                                # path below to set things right.
-                                self.version = -1
-
-                if self.version <= 0:
-                        # If version doesn't exist, attempt to determine version
-                        # based on structure.
-                        pub_root = os.path.join(self.imgdir, IMG_PUB_DIR)
-                        if purge:
-                                # This is a new image.
-                                self.version = self.CURRENT_VERSION
-                        elif os.path.exists(pub_root):
-                                cache_root = os.path.join(self.imgdir, "cache")
-                                if os.path.exists(cache_root):
-                                        # The image must be corrupted, as the
-                                        # version should have been loaded from
-                                        # configuration.  For now, raise an
-                                        # exception.  In the future, this
-                                        # behaviour should probably be optional
-                                        # so that pkg fix or pkg verify can
-                                        # still use the image.
-                                        raise apx.UnsupportedImageError(
-                                            self.root)
-                                else:
-                                        # Assume version 3 image.
-                                        self.version = 3
-
-                                # Reload image configuration again now that
-                                # version has been determined so that property
-                                # definitions match.
-                                self.__load_config()
-                        elif os.path.exists(os.path.join(self.imgdir,
-                            "catalog")):
-                                self.version = 2
-
-                                # Reload image configuration again now that
-                                # version has been determined so that property
-                                # definitions match.
-                                self.__load_config()
-                        else:
-                                # Format is too old or invalid.
-                                raise apx.UnsupportedImageError(self.root)
-
-                if self.version > self.CURRENT_VERSION or self.version < 2:
-                        # Image is too new or too old.
-                        raise apx.UnsupportedImageError(self.root)
-
-                # Ensure image version matches determined one; this must
-                # be set *after* the version checks above.
-                self.cfg.set_property("image", "version", self.version)
-
-                # Remaining dirs may now be set.
-                if self.version == self.CURRENT_VERSION:
-                        self.__tmpdir = os.path.join(self.imgdir, "cache",
-                            "tmp")
-                else:
-                        self.__tmpdir = os.path.join(self.imgdir, "tmp")
-                self._statedir = os.path.join(self.imgdir, "state")
-                self.plandir = os.path.join(self.__tmpdir, "plan")
-                self.update_index_dir()
-
-                self.history.root_dir = self.imgdir
-                self.__lockfile = lockfile.LockFile(os.path.join(self.imgdir,
-                    "lock"), set_lockstr=lockfile.client_lock_set_str,
-                    get_lockstr=lockfile.client_lock_get_str,
-                    failure_exc=apx.ImageLockedError,
-                    provide_mutex=False)
-
-                if relock:
-                        self.lock()
-
-                # Setup cache directories.
-                self.__read_cache_dirs = []
-                self._incoming_cache_dir = None
-                self.__user_cache_dir = None
-                self.__write_cache_dir = None
-                self.__write_cache_root = None
-                # The user specified cache is used as an additional place to
-                # read cache data from, but as the only place to store new
-                # cache data.
-                if "PKG_CACHEROOT" in os.environ:
-                        # If set, cache is structured like /var/pkg/publisher.
-                        # get_cachedirs() will build paths for each publisher's
-                        # cache using this directory.
-                        self.__user_cache_dir = os.path.normpath(
-                            os.environ["PKG_CACHEROOT"])
-                        self.__write_cache_root = self.__user_cache_dir
-                elif "PKG_CACHEDIR" in os.environ:
-                        # If set, cache is a flat structure that is used for
-                        # all publishers.
-                        self.__user_cache_dir = os.path.normpath(
-                            os.environ["PKG_CACHEDIR"])
-                        self.__write_cache_dir = self.__user_cache_dir
-                        # Since the cache structure is flat, add it to the
-                        # list of global read caches.
-                        self.__read_cache_dirs.append(self.__user_cache_dir)
-                if self.__user_cache_dir:
-                        self._incoming_cache_dir = os.path.join(
-                            self.__user_cache_dir,
-                            "incoming-{0:d}".format(os.getpid()))
-
-                if self.version < 4:
-                        self.__action_cache_dir = self.temporary_dir()
-                else:
-                        self.__action_cache_dir = os.path.join(self.imgdir,
-                            "cache")
-
-                if self.version < 4:
-                        if not self.__user_cache_dir:
-                                self.__write_cache_dir = os.path.join(
-                                    self.imgdir, "download")
-                                self._incoming_cache_dir = os.path.join(
-                                    self.__write_cache_dir,
-                                    "incoming-{0:d}".format(os.getpid()))
-                        self.__read_cache_dirs.append(os.path.normpath(
-                            os.path.join(self.imgdir, "download")))
-                elif not self._incoming_cache_dir:
-                        # Only a global incoming cache exists for newer images.
-                        self._incoming_cache_dir = os.path.join(self.imgdir,
-                            "cache", "incoming-{0:d}".format(os.getpid()))
-
-                # Test if we have the permissions to create the cache
-                # incoming directory in this hierarchy.  If not, we'll need to
-                # move it somewhere else.
-                try:
-                        os.makedirs(self._incoming_cache_dir)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES or e.errno == errno.EROFS:
-                                self.__write_cache_dir = tempfile.mkdtemp(
-                                    prefix="download-{0:d}-".format(
-                                    os.getpid()))
-                                self._incoming_cache_dir = os.path.normpath(
-                                    os.path.join(self.__write_cache_dir,
-                                    "incoming-{0:d}".format(os.getpid())))
-                                self.__read_cache_dirs.append(
-                                    self.__write_cache_dir)
-                                # There's no image cleanup hook, so we'll just
-                                # remove this directory on process exit.
-                                atexit.register(shutil.rmtree,
-                                    self.__write_cache_dir, ignore_errors=True)
-                else:
-                        os.rmdir(self._incoming_cache_dir)
-
-                # Forcibly discard image catalogs so they can be re-loaded
-                # from the new location if they are already loaded.  This
-                # also prevents scribbling on image state information in
-                # the wrong location.
-                self.__init_catalogs()
-
-                # Upgrade the image's format if needed.
-                self.update_format(allow_unprivileged=True,
-                    progtrack=progtrack)
-
-                # If we haven't loaded the system publisher configuration, do
-                # that now.
-                if isinstance(self.cfg, imageconfig.ImageConfig):
-                        self.cfg = imageconfig.BlendedConfig(self.cfg,
-                            self.get_catalog(self.IMG_CATALOG_INSTALLED).\
-                                get_package_counts_by_pub(),
-                            self.imgdir, self.transport,
-                            self.cfg.get_policy("use-system-repo"))
-
-                # Check to see if any system publishers have been changed.
-                # If so they need to be refreshed, so clear last_refreshed.
-                for p in self.cfg.modified_pubs:
-                        p.meta_root = self._get_publisher_meta_root(p.prefix)
-                        p.last_refreshed = None
-
-                # Check to see if any system publishers have been
-                # removed.  If they have, remove their metadata and
-                # rebuild the catalogs.
-                changed = False
-                for p in self.cfg.removed_pubs:
-                        p.meta_root = self._get_publisher_meta_root(p.prefix)
-                        try:
-                                self.remove_publisher_metadata(p, rebuild=False)
-                                changed = True
-                        except apx.PermissionsException:
-                                pass
-                if changed:
-                        self.__rebuild_image_catalogs()
-
-                # we delay writing out any new system repository configuration
-                # until we've updated on on-disk catalog state.  (otherwise we
-                # could lose track of syspub publishers changes and either
-                # return stale catalog information, or not do refreshes when
-                # we need to.)
-                self.cfg.write_sys_cfg()
-
-                self.__load_publisher_ssl()
-                if purge:
-                        # Configuration shouldn't be written again unless this
-                        # is an image creation operation (hence the purge).
-                        self.save_config()
-
-                # Let the linked image subsystem know that root is moving
-                self.linked._init_root()
-
-                # load image avoid pkg set
-                self.__avoid_set_load()
-
-        def update_format(self, allow_unprivileged=False, progtrack=None):
-                """Transform the existing image structure and its data to
-                the newest format.  Callers are responsible for locking.
-
-                'allow_unprivileged' is an optional boolean indicating
-                whether a fallback to an in-memory only upgrade should
-                be performed if a PermissionsException is encountered
-                during the operation.
-
-                'progtrack' is an optional ProgressTracker object.
-                """
-
-                if self.version == self.CURRENT_VERSION:
-                        # Already upgraded.
-                        self.__upgraded = True
-
-                        # If pre-upgrade data still exists; fire off a
-                        # process to dump it so execution can continue.
-                        orig_root = self.imgdir + ".old"
-                        nullf = open(os.devnull, "w")
-                        if os.path.exists(orig_root):
-                                # Ensure all output is discarded; it really
-                                # doesn't matter if this succeeds.
-                                cmdargs = ["/usr/bin/rm", "-rf", orig_root]
-                                subprocess.Popen(cmdargs, stdout=nullf,
-                                    stderr=nullf)
-                        nullf.close()
-                        return False
-
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-
-                # Not technically 'caching', but close enough ...
-                progtrack.cache_catalogs_start()
-
-                # Upgrade catalog data if needed.
-                self.__upgrade_catalogs()
-
-                # Data conversion finished.
-                self.__upgraded = True
-
-                # Determine if on-disk portion of the upgrade is allowed.
-                if self.allow_ondisk_upgrade == False:
-                        return True
-
-                if self.allow_ondisk_upgrade is None and self.type != IMG_USER:
-                        if not self.is_liveroot() and not self.is_zone():
-                                # By default, don't update image format if it
-                                # is not the live root, and is not for a zone.
-                                self.allow_ondisk_upgrade = False
-                                return True
-
-                # The logic to perform the on-disk upgrade is in its own
-                # function so that it can easily be wrapped with locking logic.
-                with self.locked_op("update-format",
-                    allow_unprivileged=allow_unprivileged):
-                        self.__upgrade_image_format(progtrack,
-                            allow_unprivileged=allow_unprivileged)
-
-                progtrack.cache_catalogs_done()
-                return True
-
-        def __upgrade_catalogs(self):
-                """Private helper function for update_format."""
-
-                if self.version >= 3:
-                        # Nothing to do.
-                        return
-
-                def installed_file_publisher(filepath):
-                        """Find the pkg's installed file named by filepath.
-                        Return the publisher that installed this package."""
-
-                        f = open(filepath)
-                        try:
-                                flines = f.readlines()
-                                version, pub = flines
-                                version = version.strip()
-                                pub = pub.strip()
-                                f.close()
-                        except ValueError:
-                                # If ValueError occurs, the installed file is of
-                                # a previous format.  For upgrades to work, it's
-                                # necessary to assume that the package was
-                                # installed from the highest ranked publisher.
-                                # Here, the publisher is setup to record that.
-                                if flines:
-                                        pub = flines[0]
-                                        pub = pub.strip()
-                                        newpub = "{0}_{1}".format(
-                                            pkg.fmri.PREF_PUB_PFX, pub)
-                                else:
-                                        newpub = "{0}_{1}".format(
-                                            pkg.fmri.PREF_PUB_PFX,
-                                            self.get_highest_ranked_publisher())
-                                pub = newpub
-                        assert pub
-                        return pub
-
-                # First, load the old package state information.
-                installed_state_dir = "{0}/state/installed".format(self.imgdir)
-
-                # If the state directory structure has already been created,
-                # loading information from it is fast.  The directory is
-                # populated with files, named by their (url-encoded) FMRI,
-                # which point to the "installed" file in the corresponding
-                # directory under /var/pkg.
-                installed = {}
-                def add_installed_entry(f):
-                        path = "{0}/pkg/{1}/installed".format(
-                            self.imgdir, f.get_dir_path())
-                        pub = installed_file_publisher(path)
-                        f.set_publisher(pub)
-                        installed[f.pkg_name] = f
-
-                for pl in os.listdir(installed_state_dir):
-                        fmristr = "{0}".format(unquote(pl))
-                        f = pkg.fmri.PkgFmri(fmristr)
-                        add_installed_entry(f)
-
-                # Create the new image catalogs.
-                kcat = pkg.catalog.Catalog(batch_mode=True,
-                    manifest_cb=self._manifest_cb, sign=False)
-                icat = pkg.catalog.Catalog(batch_mode=True,
-                    manifest_cb=self._manifest_cb, sign=False)
-
-                # XXX For backwards compatibility, 'upgradability' of packages
-                # is calculated and stored based on whether a given pkg stem
-                # matches the newest version in the catalog.  This is quite
-                # expensive (due to overhead), but at least the cost is
-                # consolidated here.  This comparison is also cross-publisher,
-                # as it used to be.
-                newest = {}
-                old_pub_cats = []
-                for pub in self.gen_publishers():
-                        try:
-                                old_cat = pkg.server.catalog.ServerCatalog(
-                                    pub.meta_root, read_only=True,
-                                    publisher=pub.prefix)
-
-                                old_pub_cats.append((pub, old_cat))
-                                for f in old_cat.fmris():
-                                        nver = newest.get(f.pkg_name, None)
-                                        newest[f.pkg_name] = max(nver,
-                                            f.version)
-
-                        except EnvironmentError as e:
-                                # If a catalog file is just missing, ignore it.
-                                # If there's a worse error, make sure the user
-                                # knows about it.
-                                if e.errno != errno.ENOENT:
-                                        raise
-
-                # Next, load the existing catalog data and convert it.
-                pub_cats = []
-                for pub, old_cat in old_pub_cats:
-                        new_cat = pub.catalog
-                        new_cat.batch_mode = True
-                        new_cat.sign = False
-                        if new_cat.exists:
-                                new_cat.destroy()
-
-                        # First convert the old publisher catalog to
-                        # the new format.
-                        for f in old_cat.fmris():
-                                new_cat.add_package(f)
-
-                                # Now populate the image catalogs.
-                                states = [pkgdefs.PKG_STATE_KNOWN,
-                                    pkgdefs.PKG_STATE_V0]
-                                mdata = { "states": states }
-                                if f.version != newest[f.pkg_name]:
-                                        states.append(
-                                            pkgdefs.PKG_STATE_UPGRADABLE)
-
-                                inst_fmri = installed.get(f.pkg_name, None)
-                                if inst_fmri and \
-                                    inst_fmri.version == f.version and \
-                                    pkg.fmri.is_same_publisher(f.publisher,
-                                    inst_fmri.publisher):
-                                        states.append(
-                                            pkgdefs.PKG_STATE_INSTALLED)
-                                        if inst_fmri.preferred_publisher():
-                                                # Strip the PREF_PUB_PFX.
-                                                inst_fmri.set_publisher(
-                                                    inst_fmri.get_publisher())
-                                        icat.add_package(f, metadata=mdata)
-                                        del installed[f.pkg_name]
-                                kcat.add_package(f, metadata=mdata)
-
-                        # Normally, the Catalog's attributes are automatically
-                        # populated as a result of catalog operations.  But in
-                        # this case, the new Catalog's attributes should match
-                        # those of the old catalog.
-                        old_lm = old_cat.last_modified()
-                        if old_lm:
-                                # Can be None for empty v0 catalogs.
-                                old_lm = pkg.catalog.ts_to_datetime(old_lm)
-                        new_cat.last_modified = old_lm
-                        new_cat.version = 0
-
-                        # Add to the list of catalogs to save.
-                        new_cat.batch_mode = False
-                        pub_cats.append(new_cat)
-
-                # Discard the old catalog objects.
-                old_pub_cats = None
-
-                for f in installed.values():
-                        # Any remaining FMRIs need to be added to all of the
-                        # image catalogs.
-                        states = [pkgdefs.PKG_STATE_INSTALLED,
-                            pkgdefs.PKG_STATE_V0]
-                        mdata = { "states": states }
-                        # This package may be installed from a publisher that
-                        # is no longer known or has been disabled.
-                        if f.pkg_name in newest and \
-                            f.version != newest[f.pkg_name]:
-                                states.append(pkgdefs.PKG_STATE_UPGRADABLE)
-
-                        if f.preferred_publisher():
-                                # Strip the PREF_PUB_PFX.
-                                f.set_publisher(f.get_publisher())
-
-                        icat.add_package(f, metadata=mdata)
-                        kcat.add_package(f, metadata=mdata)
-
-                for cat in pub_cats + [kcat, icat]:
-                        cat.finalize()
-
-                # Cache converted catalogs so that operations can function as
-                # expected if the on-disk format of the catalogs isn't upgraded.
-                self.__catalogs[self.IMG_CATALOG_KNOWN] = kcat
-                self.__catalogs[self.IMG_CATALOG_INSTALLED] = icat
-
-        def __upgrade_image_format(self, progtrack, allow_unprivileged=False):
-                """Private helper function for update_format."""
-
-                try:
-                        # Ensure Image directory structure is valid.
-                        self.mkdirs()
-                except apx.PermissionsException as e:
-                        if not allow_unprivileged:
-                                raise
-                        # An unprivileged user is attempting to use the
-                        # new client with an old image.  Since none of
-                        # the changes can be saved, warn the user and
-                        # then return.
-                        #
-                        # Raising an exception here would be a decidedly
-                        # bad thing as it would disrupt find_root, etc.
-                        return
-
-                # This has to be done after the permissions check above.
-                # First, create a new temporary root to store the converted
-                # image metadata.
-                tmp_root = self.imgdir + ".new"
-                try:
-                        shutil.rmtree(tmp_root)
-                except EnvironmentError as e:
-                        if e.errno in (errno.EROFS, errno.EPERM) and \
-                            allow_unprivileged:
-                                # Bail.
-                                return
-                        if e.errno != errno.ENOENT:
-                                raise apx._convert_error(e)
-
-                try:
-                        self.mkdirs(root=tmp_root, version=self.CURRENT_VERSION)
-                except apx.PermissionsException as e:
-                        # Same handling needed as above; but not after this.
-                        if not allow_unprivileged:
-                                raise
-                        return
-
-                def linktree(src_root, dest_root):
-                        if not os.path.exists(src_root):
-                                # Nothing to do.
-                                return
-
-                        for entry in os.listdir(src_root):
-                                src = os.path.join(src_root, entry)
-                                dest = os.path.join(dest_root, entry)
-                                if os.path.isdir(src):
-                                        # Recurse into directory to link
-                                        # its contents.
-                                        misc.makedirs(dest)
-                                        linktree(src, dest)
-                                        continue
-                                # Link source file into target dest.
-                                assert os.path.isfile(src)
-                                try:
-                                        os.link(src, dest)
-                                except EnvironmentError as e:
-                                        raise apx._convert_error(e)
-
-                # Next, link history data into place.
-                linktree(self.history.path, os.path.join(tmp_root,
-                    "history"))
-
-                # Next, link index data into place.
-                linktree(self.index_dir, os.path.join(tmp_root,
-                    "cache", "index"))
-
-                # Next, link ssl data into place.
-                linktree(os.path.join(self.imgdir, "ssl"),
-                    os.path.join(tmp_root, "ssl"))
-
-                # Next, write state data into place.
-                if self.version < 3:
-                        # Image state and publisher metadata
-                        tmp_state_root = os.path.join(tmp_root, "state")
-
-                        # Update image catalog locations.
-                        kcat = self.get_catalog(self.IMG_CATALOG_KNOWN)
-                        icat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-                        kcat.meta_root = os.path.join(tmp_state_root,
-                            self.IMG_CATALOG_KNOWN)
-                        icat.meta_root = os.path.join(tmp_state_root,
-                            self.IMG_CATALOG_INSTALLED)
-
-                        # Assume that since mkdirs succeeded that the remaining
-                        # data can be saved and the image structure can be
-                        # upgraded.  But first, attempt to save the image
-                        # catalogs.
-                        for cat in icat, kcat:
-                                misc.makedirs(cat.meta_root)
-                                cat.save()
-                else:
-                        # For version 3 and newer images, just link existing
-                        # state information into place.
-                        linktree(self._statedir, os.path.join(tmp_root,
-                            "state"))
-
-                # Reset each publisher's meta_root and ensure its complete
-                # directory structure is intact.  Then either link in or
-                # write out the metadata for each publisher.
-                for pub in self.gen_publishers():
-                        old_root = pub.meta_root
-                        old_cat_root = pub.catalog_root
-                        old_cert_root = pub.cert_root
-                        pub.meta_root = os.path.join(tmp_root,
-                            IMG_PUB_DIR, pub.prefix)
-                        pub.create_meta_root()
-
-                        if self.version < 3:
-                                # Should be loaded in memory and transformed
-                                # already, so just need to be written out.
-                                pub.catalog.save()
-                                continue
-
-                        # Now link any catalog or cert files from the old root
-                        # into the new root.
-                        linktree(old_cat_root, pub.catalog_root)
-                        linktree(old_cert_root, pub.cert_root)
-
-                        # Finally, create a directory for the publisher's
-                        # manifests to live in.
-                        misc.makedirs(os.path.join(pub.meta_root, "pkg"))
-
-                # Next, link licenses and manifests of installed packages into
-                # new image dir.
-                for pfmri in self.gen_installed_pkgs():
-                        # Link licenses.
-                        mdir = self.get_manifest_dir(pfmri)
-                        for entry in os.listdir(mdir):
-                                if not entry.startswith("license."):
-                                        continue
-                                src = os.path.join(mdir, entry)
-                                if os.path.isdir(src):
-                                        # Ignore broken licenses.
-                                        continue
-
-                                # For conversion, ensure destination link uses
-                                # encoded license name to match how new image
-                                # format stores licenses.
-                                dest = os.path.join(tmp_root, "license",
-                                    pfmri.get_dir_path(stemonly=True),
-                                    quote(entry, ""))
-                                misc.makedirs(os.path.dirname(dest))
-                                try:
-                                        os.link(src, dest)
-                                except EnvironmentError as e:
-                                        raise apx._convert_error(e)
-
-                        # Link manifest.
-                        src = self.get_manifest_path(pfmri)
-                        dest = os.path.join(tmp_root, "publisher",
-                            pfmri.publisher, "pkg", pfmri.get_dir_path())
-                        misc.makedirs(os.path.dirname(dest))
-                        try:
-                                os.link(src, dest)
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-
-                # Next, copy the old configuration into the new location using
-                # the new name.  The configuration is copied instead of being
-                # linked so that any changes to configuration as a result of
-                # the upgrade won't be written into the old image directory.
-                src = os.path.join(self.imgdir, "disabled_auth")
-                if os.path.exists(src):
-                        dest = os.path.join(tmp_root, "disabled_auth")
-                        portable.copyfile(src, dest)
-
-                src = self.cfg.target
-                dest = os.path.join(tmp_root, "pkg5.image")
-                try:
-                        portable.copyfile(src, dest)
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-
-                # Update the new configuration's version information and then
-                # write it out again.
-                newcfg = imageconfig.ImageConfig(dest, tmp_root,
-                    version=3, overrides={ "image": {
-                    "version": self.CURRENT_VERSION } })
-                newcfg._version = 3
-                newcfg.write()
-
-                # Now reload configuration and write again to configuration data
-                # reflects updated version information.
-                newcfg.reset()
-                newcfg.write()
-
-                # Finally, rename the old package metadata directory, then
-                # rename the new one into place, and then reinitialize.  The
-                # old data will be dumped during initialization.
-                orig_root = self.imgdir + ".old"
-                try:
-                        portable.rename(self.imgdir, orig_root)
-                        portable.rename(tmp_root, self.imgdir)
-
-                        # /var/pkg/repo is renamed into place instead of being
-                        # linked piece-by-piece for performance reasons.
-                        # Crawling the entire tree structure of a repository is
-                        # far slower than simply renaming the top level
-                        # directory (since it often has thousands or millions
-                        # of objects).
-                        old_repo = os.path.join(orig_root, "repo")
-                        if os.path.exists(old_repo):
-                                new_repo = os.path.join(tmp_root, "repo")
-                                portable.rename(old_repo, new_repo)
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-                self.find_root(self.root, exact_match=True, progtrack=progtrack)
-
-        def create(self, pubs, facets=EmptyDict, is_zone=False,  progtrack=None,
-            props=EmptyDict, refresh_allowed=True, variants=EmptyDict):
-                """Creates a new image with the given attributes if it does not
-                exist; should not be used with an existing image.
-
-                'is_zone' is a boolean indicating whether the image is a zone.
-
-                'pubs' is a list of Publisher objects to configure the image
-                with.
-
-                'refresh_allowed' is an optional boolean indicating that
-                network operations (such as publisher data retrieval) are
-                allowed.
-
-                'progtrack' is an optional ProgressTracker object.
-
-                'props' is an option dictionary mapping image property names to
-                values.
-
-                'variants' is an optional dictionary of variant names and
-                values.
-
-                'facets' is an optional dictionary of facet names and values.
-                """
-
-                for p in pubs:
-                        p.meta_root = self._get_publisher_meta_root(p.prefix)
-                        p.transport = self.transport
-
-                # Override any initial configuration information.
-                self.set_properties(props)
-
-                # Start the operation.
-                self.history.log_operation_start("image-create")
-
-                # Determine and add the default variants for the image.
-                if is_zone:
-                        self.cfg.variants["variant.opensolaris.zone"] = \
-                            "nonglobal"
-                else:
-                        self.cfg.variants["variant.opensolaris.zone"] = \
-                            "global"
-
-                self.cfg.variants["variant.arch"] = \
-                    variants.get("variant.arch", platform.processor())
-
-                # After setting up the default variants, add any overrides or
-                # additional variants or facets specified.
-                self.cfg.variants.update(variants)
-                self.cfg.facets.update(facets)
-
-                # Now everything is ready for publisher configuration.
-                # Since multiple publishers are allowed, they are all
-                # added at once without any publisher data retrieval.
-                # A single retrieval is then performed afterwards, if
-                # allowed, to minimize the amount of work the client
-                # needs to perform.
-                for p in pubs:
-                        self.add_publisher(p, refresh_allowed=False,
-                            progtrack=progtrack)
-
-                if refresh_allowed:
-                        self.refresh_publishers(progtrack=progtrack,
-                            full_refresh=True, ignore_unreachable=False)
-                else:
-                        # initialize empty catalogs on disk
-                        self.__rebuild_image_catalogs(progtrack=progtrack)
-
-                self.cfg.set_property("property", "publisher-search-order",
-                    [p.prefix for p in pubs])
-
-                # Ensure publisher search order is written.
-                self.save_config()
-
-                self.history.log_operation_end()
-
-        @staticmethod
-        def __allow_liveroot():
-                """Check if we're allowed to access the current live root
-                image."""
-
-                # if we're simulating a live root then allow access to it
-                if DebugValues.get_value("simulate_live_root") or \
-                    "PKG_LIVE_ROOT" in os.environ:
-                        return True
-
-                # check if the user disabled access to the live root
-                if DebugValues.get_value("simulate_no_live_root"):
-                        return False
-                if "PKG_NO_LIVE_ROOT" in os.environ:
-                        return False
-
-                # by default allow access to the live root
-                return True
-
-        def is_liveroot(self):
-                return bool(self.root == misc.liveroot())
-
-        def is_zone(self):
-                return self.cfg.variants["variant.opensolaris.zone"] == \
-                    "nonglobal"
-
-        def get_arch(self):
-                return self.cfg.variants["variant.arch"]
-
-        def has_boot_archive(self):
-                """Returns True if a boot_archive is present in this image"""
-                if self.__boot_archive is not None:
-                        return self.__boot_archive
-
-                for p in ["platform/i86pc/amd64/boot_archive",
-                          "platform/i86pc/boot_archive",
-                          "platform/sun4u/boot_archive",
-                          "platform/sun4v/boot_archive"]:
-                        if os.path.isfile(os.path.join(self.root, p)):
-                                self.__boot_archive = True
-                                break
-                else:
-                        self.__boot_archive = False
-                return self.__boot_archive
-
-        def get_ramdisk_filelist(self):
-                """return the filelist... add the filelist so we rebuild
-                boot archive if it changes... append trailing / to
-                directories that are really there"""
-
-                p = "boot/solaris/filelist.ramdisk"
-                f = os.path.join(self.root, p)
-
-                def addslash(path):
-                        if os.path.isdir(os.path.join(self.root, path)):
-                                return path + "/"
-                        return path
-
-                if not os.path.isfile(f):
-                        return []
-
-                return [ addslash(l.strip()) for l in open(f) ] + [p]
-
-        def get_cachedirs(self):
-                """Returns a list of tuples of the form (dir, readonly, pub,
-                layout) where 'dir' is the absolute path of the cache directory,
-                'readonly' is a boolean indicating whether the cache can
-                be written to, 'pub' is the prefix of the publisher that
-                the cache directory should be used for, and 'layout' is a
-                FileManager object used to access file content in the cache.
-                If 'pub' is None, the cache directory is intended for all
-                publishers.  If 'layout' is None, file content layout can
-                vary.
-                """
-
-                file_layout = None
-                if self.version >= 4:
-                        # Assume cache directories are in V1 Layout if image
-                        # format is v4+.
-                        file_layout = fl.V1Layout()
-
-                # Get all readonly cache directories.
-                cdirs = [
-                    (cdir, True, None, file_layout)
-                    for cdir in self.__read_cache_dirs
-                ]
-
-                # Get global write cache directory.
-                if self.__write_cache_dir:
-                        cdirs.append((self.__write_cache_dir, False, None,
-                            file_layout))
-
-                # For images newer than version 3, file data can be stored
-                # in the publisher's file root.
-                if self.version == self.CURRENT_VERSION:
-                        for pub in self.gen_publishers(inc_disabled=True):
-                                froot = os.path.join(pub.meta_root, "file")
-                                readonly = False
-                                if self.__write_cache_dir or \
-                                    self.__write_cache_root:
-                                        readonly = True
-                                cdirs.append((froot, readonly, pub.prefix,
-                                    file_layout))
-
-                                if self.__write_cache_root:
-                                        # Cache is a tree structure like
-                                        # /var/pkg/publisher.
-                                        froot = os.path.join(
-                                            self.__write_cache_root, pub.prefix,
-                                            "file")
-                                        cdirs.append((froot, False, pub.prefix,
-                                            file_layout))
-
-                return cdirs
-
-        def get_root(self):
-                return self.root
-
-        def get_last_modified(self, string=False):
-                """Return the UTC time of the image's last state change or
-                None if unknown.  By default the time is returned via datetime
-                object.  If 'string' is true and a time is available, then the
-                time is returned as a string (instead of as a datetime
-                object)."""
-
-                # Always get last_modified time from known catalog.  It's
-                # retrieved from the catalog itself since that is accurate
-                # down to the micrsecond (as opposed to the filesystem which
-                # has an OS-specific resolution).
-                rv = self.__get_catalog(self.IMG_CATALOG_KNOWN).last_modified
-                if rv is None or not string:
-                        return rv
-                return rv.strftime("%Y-%m-%dT%H:%M:%S.%f")
-
-        def gen_publishers(self, inc_disabled=False):
-                if not self.cfg:
-                        raise apx.ImageCfgEmptyError(self.root)
-
-                alt_pubs = {}
-                if self.__alt_pkg_pub_map:
-                        alt_src_pubs = dict(
-                            (p.prefix, p)
-                            for p in self.__alt_pubs
-                        )
-
-                        for pfx in self.__alt_known_cat.publishers():
-                                # Include alternate package source publishers
-                                # in result, and temporarily enable any
-                                # disabled publishers that already exist in
-                                # the image configuration.
-                                try:
-                                        img_pub = self.cfg.publishers[pfx]
-
-                                        if not img_pub.disabled:
-                                                # No override needed.
-                                                continue
-                                        new_pub = copy.copy(img_pub)
-                                        new_pub.disabled = False
-
-                                        # Discard origins and mirrors to prevent
-                                        # their accidental use.
-                                        repo = new_pub.repository
-                                        repo.reset_origins()
-                                        repo.reset_mirrors()
-                                except KeyError:
-                                        new_pub = alt_src_pubs[pfx]
-
-                                alt_pubs[pfx] = new_pub
-
-                publishers = [
-                    alt_pubs.get(p.prefix, p)
-                    for p in self.cfg.publishers.values()
-                ]
-                publishers.extend((
-                    p for p in alt_pubs.values()
-                    if p not in publishers
-                ))
-
-                for pub in publishers:
-                        # Prepare publishers for transport usage; this must be
-                        # done each time so that information reflects current
-                        # image state.  This is done whether or not the
-                        # publisher is returned so that in-memory state is
-                        # always current.
-                        pub.meta_root = self._get_publisher_meta_root(
-                            pub.prefix)
-                        pub.transport = self.transport
-                        if inc_disabled or not pub.disabled:
-                                yield pub
-
-        def get_publisher_ranks(self):
-                """Return dictionary of configured + enabled publishers and
-                unconfigured publishers which still have packages installed.
-
-                Each entry contains a tuple of search order index starting at
-                0, and a boolean indicating whether or not this publisher is
-                "sticky", and a boolean indicating whether or not the
-                publisher is enabled"""
-
-                pubs = self.get_sorted_publishers(inc_disabled=False)
-                ret = dict([
-                    (pubs[i].prefix, (i, pubs[i].sticky, True))
-                    for i in range(0, len(pubs))
-                ])
-
-                # Add any publishers for pkgs that are installed,
-                # but have been deleted. These publishers are implicitly
-                # not-sticky and disabled.
-                for pub in self.get_installed_pubs():
-                        i = len(ret)
-                        ret.setdefault(pub, (i, False, False))
-                return ret
-
-        def get_highest_ranked_publisher(self):
-                """Return the highest ranked publisher."""
-
-                pubs = self.cfg.get_property("property",
-                    "publisher-search-order")
-                if pubs:
-                        return self.get_publisher(prefix=pubs[0])
-                for p in self.gen_publishers():
-                        return p
-                for p in self.get_installed_pubs():
-                        return publisher.Publisher(p)
-                return None
-
-        def check_cert_validity(self, pubs=EmptyI):
-                """Validate the certificates of the specified publishers.
-
-                Raise an exception if any of the certificates has expired or
-                is close to expiring."""
-
-                if not pubs:
-                        pubs = self.gen_publishers()
-
-                errors = []
-                for p in pubs:
-                        r = p.repository
-                        for uri in r.origins:
-                                if uri.ssl_cert:
-                                        try:
-                                                misc.validate_ssl_cert(
-                                                    uri.ssl_cert,
-                                                    prefix=p.prefix,
-                                                    uri=uri)
-                                        except apx.ExpiredCertificate as e:
-                                                errors.append(e)
-
-                                if uri.ssl_key:
-                                        try:
-                                                if not os.path.exists(
-                                                    uri.ssl_key):
-                                                        raise apx.NoSuchKey(
-                                                            uri.ssl_key,
-                                                            publisher=p,
-                                                            uri=uri)
-                                        except EnvironmentError as e:
-                                                raise apx._convert_error(e)
-
-                if errors:
-                        raise apx.ExpiredCertificates(errors)
-
-        def has_publisher(self, prefix=None, alias=None):
-                """Returns a boolean value indicating whether a publisher
-                exists in the image configuration that matches the given
-                prefix or alias."""
-                for pub in self.gen_publishers(inc_disabled=True):
-                        if prefix == pub.prefix or (alias and
-                            alias == pub.alias):
-                                return True
-                return False
-
-        def remove_publisher(self, prefix=None, alias=None, progtrack=None):
-                """Removes the publisher with the matching identity from the
-                image."""
-
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-
-                with self.locked_op("remove-publisher"):
-                        pub = self.get_publisher(prefix=prefix,
-                            alias=alias)
-
-                        self.cfg.remove_publisher(pub.prefix)
-                        self.remove_publisher_metadata(pub, progtrack=progtrack)
-                        self.save_config()
-
-        def get_publishers(self, inc_disabled=True):
-                """Return a dictionary of configured publishers.  This doesn't
-                include unconfigured publishers which still have packages
-                installed."""
-
-                return dict(
-                    (p.prefix, p)
-                    for p in self.gen_publishers(inc_disabled=inc_disabled)
+                    # We store certificates internally by
+                    # the SHA-1 hash of its subject.
+                    s = hashlib.sha1(
+                        misc.force_bytes(trusted_ca.subject)
+                    ).hexdigest()
+                    self.__trust_anchors.setdefault(s, [])
+                    self.__trust_anchors[s].append(trusted_ca)
+        for s in pkg_trust_anchors:
+            if s not in self.__trust_anchors:
+                self.__trust_anchors[s] = pkg_trust_anchors[s]
+        return self.__trust_anchors
+
+    @property
+    def bad_trust_anchors(self):
+        """A list of strings decribing errors encountered while parsing
+        trust anchors."""
+
+        return [
+            _(
+                "{path} is expected to be a certificate but could "
+                "not be parsed.  The error encountered "
+                "was:\n\t{err}"
+            ).format(path=p, err=e)
+            for p, e in self.__bad_trust_anchors
+        ]
+
+    @property
+    def write_cache_path(self):
+        """The path to the filesystem that holds the write cache--used
+        to compute whether sufficent space is available for
+        downloads."""
+
+        return self.__user_cache_dir or os.path.join(self.imgdir, IMG_PUB_DIR)
+
+    @contextmanager
+    def locked_op(self, op, allow_unprivileged=False, new_history_op=True):
+        """Helper method for executing an image-modifying operation
+        that needs locking.  It automatically handles calling
+        log_operation_start and log_operation_end by default.  Locking
+        behaviour is controlled by the blocking_locks image property.
+
+        'allow_unprivileged' is an optional boolean value indicating
+        that permissions-related exceptions should be ignored when
+        attempting to obtain the lock as the related operation will
+        still work correctly even though the image cannot (presumably)
+        be modified.
+
+        'new_history_op' indicates whether we should handle history
+        operations.
+        """
+
+        error = None
+        self.lock(allow_unprivileged=allow_unprivileged)
+        try:
+            be_name, be_uuid = bootenv.BootEnv.get_be_name(self.root)
+            if new_history_op:
+                self.history.log_operation_start(
+                    op, be_name=be_name, be_uuid=be_uuid
                 )
-
-        def get_sorted_publishers(self, inc_disabled=True):
-                """Return a list of configured publishers sorted by rank.
-                This doesn't include unconfigured publishers which still have
-                packages installed."""
-
-                d = self.get_publishers(inc_disabled=inc_disabled)
-                names = self.cfg.get_property("property",
-                    "publisher-search-order")
-
-                #
-                # If someone has been editing the config file we may have
-                # unranked publishers.  Also, as publisher come and go via the
-                # sysrepo we can end up with configured but unranked
-                # publishers.  In either case just sort unranked publishers
-                # alphabetically.
-                #
-                unranked = set(d) - set(names)
-                ret = [
-                    d[n]
-                    for n in names
-                    if n in d
-                ] + [
-                    d[n]
-                    for n in sorted(unranked)
-                ]
-                return ret
-
-        def get_publisher(self, prefix=None, alias=None, origin=None):
-                for pub in self.gen_publishers(inc_disabled=True):
-                        if prefix and prefix == pub.prefix:
-                                return pub
-                        elif alias and alias == pub.alias:
-                                return pub
-                        elif origin and pub.repository and \
-                            pub.repository.has_origin(origin):
-                                return pub
-
-                if prefix is None and alias is None and origin is None:
-                        raise apx.UnknownPublisher(None)
-
-                raise apx.UnknownPublisher(max(i for i in
-                    [prefix, alias, origin] if i is not None))
-
-        def pub_search_before(self, being_moved, staying_put):
-                """Moves publisher "being_moved" to before "staying_put"
-                in search order.
-
-                The caller is responsible for locking the image."""
-
-                self.cfg.change_publisher_search_order(being_moved, staying_put,
-                    after=False)
-
-        def pub_search_after(self, being_moved, staying_put):
-                """Moves publisher "being_moved" to after "staying_put"
-                in search order.
-
-                The caller is responsible for locking the image."""
-
-                self.cfg.change_publisher_search_order(being_moved, staying_put,
-                    after=True)
-
-        def __apply_alt_pkg_sources(self, img_kcat):
-                pkg_pub_map = self.__alt_pkg_pub_map
-                if not pkg_pub_map or self.__alt_pkg_sources_loaded:
-                        # No alternate sources to merge.
-                        return
-
-                # Temporarily merge the package metadata in the alternate
-                # known package catalog for packages not listed in the
-                # image's known catalog.
-                def merge_check(alt_kcat, pfmri, new_entry):
-                        states = new_entry["metadata"]["states"]
-                        if pkgdefs.PKG_STATE_INSTALLED in states:
-                                # Not interesting; already installed.
-                                return False, None
-                        img_entry = img_kcat.get_entry(pfmri=pfmri)
-                        if not img_entry is None:
-                                # Already in image known catalog.
-                                return False, None
-                        return True, new_entry
-
-                img_kcat.append(self.__alt_known_cat, cb=merge_check)
-                img_kcat.finalize()
-
-                self.__alt_pkg_sources_loaded = True
-                self.transport.cfg.pkg_pub_map = self.__alt_pkg_pub_map
-                self.transport.cfg.alt_pubs = self.__alt_pubs
-                self.transport.cfg.reset_caches()
-
-        def __cleanup_alt_pkg_certs(self):
-                """Private helper function to cleanup package certificate
-                information after use of temporary package data."""
-
-                if not self.__alt_pubs:
-                        return
-
-                # Cleanup publisher cert information; any certs not retrieved
-                # retrieved during temporary publisher use need to be expunged
-                # from the image configuration.
-                for pub in self.__alt_pubs:
-                        try:
-                                ipub = self.cfg.publishers[pub.prefix]
-                        except KeyError:
-                                # Nothing to do.
-                                continue
-
-        def set_alt_pkg_sources(self, alt_sources):
-                """Specifies an alternate source of package metadata to be
-                temporarily merged with image state so that it can be used
-                as part of packaging operations."""
-
-                if not alt_sources:
-                        self.__init_catalogs()
-                        self.__alt_pkg_pub_map = None
-                        self.__alt_pubs = None
-                        self.__alt_known_cat = None
-                        self.__alt_pkg_sources_loaded = False
-                        self.transport.cfg.pkg_pub_map = None
-                        self.transport.cfg.alt_pubs = None
-                        self.transport.cfg.reset_caches()
-                        return
-                elif self.__alt_pkg_sources_loaded:
-                        # Ensure existing alternate package source data
-                        # is not part of temporary image state.
-                        self.__init_catalogs()
-
-                pkg_pub_map, alt_pubs, alt_kcat, ignored = alt_sources
-                self.__alt_pkg_pub_map = pkg_pub_map
-                self.__alt_pubs = alt_pubs
-                self.__alt_known_cat = alt_kcat
-
-        def set_highest_ranked_publisher(self, prefix=None, alias=None,
-            pub=None):
-                """Sets the preferred publisher for packaging operations.
-
-                'prefix' is an optional string value specifying the name of
-                a publisher; ignored if 'pub' is provided.
-
-                'alias' is an optional string value specifying the alias of
-                a publisher; ignored if 'pub' is provided.
-
-                'pub' is an optional Publisher object identifying the
-                publisher to set as the preferred publisher.
-
-                One of the above parameters must be provided.
-
-                The caller is responsible for locking the image."""
-
-                if not pub:
-                        pub = self.get_publisher(prefix=prefix, alias=alias)
-                if not self.cfg.allowed_to_move(pub):
-                        raise apx.ModifyingSyspubException(_("Publisher '{0}' "
-                            "is a system publisher and cannot be "
-                            "moved.").format(pub))
-
-                pubs = self.get_sorted_publishers()
-                relative = None
-                for p in pubs:
-                        # If we've gotten to the publisher we want to make
-                        # highest ranked, then there's nothing to do because
-                        # it's already as high as it can be.
-                        if p == pub:
-                                return
-                        if self.cfg.allowed_to_move(p):
-                                relative = p
-                                break
-                assert relative, "Expected {0} to already be part of the " + \
-                    "search order:{1}".format(relative, ranks)
-                self.cfg.change_publisher_search_order(pub.prefix,
-                    relative.prefix, after=False)
-
-        def set_property(self, prop_name, prop_value):
-                with self.locked_op("set-property"):
-                        self.cfg.set_property("property", prop_name,
-                            prop_value)
-                        self.save_config()
-
-        def set_properties(self, properties):
-                properties = { "property": properties }
-                with self.locked_op("set-property"):
-                        self.cfg.set_properties(properties)
-                        self.save_config()
-
-        def get_property(self, prop_name):
-                return self.cfg.get_property("property", prop_name)
-
-        def has_property(self, prop_name):
-                try:
-                        self.cfg.get_property("property", prop_name)
-                        return True
-                except cfg.ConfigError:
-                        return False
-
-        def delete_property(self, prop_name):
-                with self.locked_op("unset-property"):
-                        self.cfg.remove_property("property", prop_name)
-                        self.save_config()
-
-        def add_property_value(self, prop_name, prop_value):
-                with self.locked_op("add-property-value"):
-                        self.cfg.add_property_value("property", prop_name,
-                            prop_value)
-                        self.save_config()
-
-        def remove_property_value(self, prop_name, prop_value):
-                with self.locked_op("remove-property-value"):
-                        self.cfg.remove_property_value("property", prop_name,
-                            prop_value)
-                        self.save_config()
-
-        def destroy(self):
-                """Destroys the image; image object should not be used
-                afterwards."""
-
-                if not self.imgdir or not os.path.exists(self.imgdir):
-                        return
-
-                if os.path.abspath(self.imgdir) == "/":
-                        # Paranoia.
-                        return
-
-                try:
-                        shutil.rmtree(self.imgdir)
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-
-        def properties(self):
-                if not self.cfg:
-                        raise apx.ImageCfgEmptyError(self.root)
-                return list(self.cfg.get_index()["property"].keys())
-
-        def add_publisher(self, pub, refresh_allowed=True, progtrack=None,
-            approved_cas=EmptyI, revoked_cas=EmptyI, search_after=None,
-            search_before=None, search_first=None, unset_cas=EmptyI):
-                """Adds the provided publisher object to the image
-                configuration.
-
-                'refresh_allowed' is an optional, boolean value indicating
-                whether the publisher's metadata should be retrieved when adding
-                it to the image's configuration.
-
-                'progtrack' is an optional ProgressTracker object."""
-
-                with self.locked_op("add-publisher"):
-                        return self.__add_publisher(pub,
-                            refresh_allowed=refresh_allowed,
-                            progtrack=progtrack, approved_cas=EmptyI,
-                            revoked_cas=EmptyI, search_after=search_after,
-                            search_before=search_before,
-                            search_first=search_first, unset_cas=EmptyI)
-
-        def __update_publisher_catalogs(self, pub, progtrack=None,
-            refresh_allowed=True):
-                # Ensure that if the publisher's meta directory already
-                # exists for some reason that the data within is not
-                # used.
-                self.remove_publisher_metadata(pub, progtrack=progtrack,
-                    rebuild=False)
-
-                repo = pub.repository
-                if refresh_allowed and repo.origins:
-                        try:
-                                # First, verify that the publisher has a
-                                # valid pkg(7) repository.
-                                self.transport.valid_publisher_test(pub)
-                                pub.validate_config()
-                                self.refresh_publishers(pubs=[pub],
-                                    progtrack=progtrack,
-                                    ignore_unreachable=False)
-                        except Exception as e:
-                                # Remove the newly added publisher since
-                                # it is invalid or the retrieval failed.
-                                if not pub.sys_pub:
-                                        self.cfg.remove_publisher(pub.prefix)
-                                raise
-                        except:
-                                # Remove the newly added publisher since
-                                # the retrieval failed.
-                                if not pub.sys_pub:
-                                        self.cfg.remove_publisher(pub.prefix)
-                                raise
-
-        def __add_publisher(self, pub, refresh_allowed=True, progtrack=None,
-            approved_cas=EmptyI, revoked_cas=EmptyI, search_after=None,
-            search_before=None, search_first=None, unset_cas=EmptyI):
-                """Private version of add_publisher(); caller is responsible
-                for locking."""
-
-                assert (not search_after and not search_before) or \
-                    (not search_after and not search_first) or \
-                    (not search_before and not search_first)
-
-                if self.version < self.CURRENT_VERSION:
-                        raise apx.ImageFormatUpdateNeeded(self.root)
-
-                for p in self.cfg.publishers.values():
-                        if pub.prefix == p.prefix or \
-                            pub.prefix == p.alias or \
-                            pub.alias and (pub.alias == p.alias or
-                            pub.alias == p.prefix):
-                                raise apx.DuplicatePublisher(pub)
-
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-
-                # Must assign this first before performing operations.
-                pub.meta_root = self._get_publisher_meta_root(
-                    pub.prefix)
-                pub.transport = self.transport
-
-                # Before continuing, validate SSL information.
-                try:
-                        self.check_cert_validity(pubs=[pub])
-                except apx.ExpiringCertificate as e:
-                        logger.error(str(e))
-
-                self.cfg.publishers[pub.prefix] = pub
-
-                self.__update_publisher_catalogs(pub, progtrack=progtrack,
-                    refresh_allowed=refresh_allowed)
-
-                for ca in approved_cas:
-                        try:
-                                ca = os.path.abspath(ca)
-                                fh = open(ca, "r")
-                                s = fh.read()
-                                fh.close()
-                        except EnvironmentError as e:
-                                if e.errno == errno.ENOENT:
-                                        raise apx.MissingFileArgumentException(
-                                            ca)
-                                raise apx._convert_error(e)
-                        pub.approve_ca_cert(s, manual=True)
-
-                for hsh in revoked_cas:
-                        pub.revoke_ca_cert(hsh)
-
-                for hsh in unset_cas:
-                        pub.unset_ca_cert(hsh)
-
-                if search_first:
-                        self.set_highest_ranked_publisher(prefix=pub.prefix)
-                elif search_before:
-                        self.pub_search_before(pub.prefix, search_before)
-                elif search_after:
-                        self.pub_search_after(pub.prefix, search_after)
-
-                # Only after success should the configuration be saved.
-                self.save_config()
-
-        def __process_verify(self, act, path, path_only, fmri, excludes,
-            vardrate_excludes, progresstracker, verifypaths=None,
-            overlaypaths=None, **kwargs):
-                errors = []
-                warnings = []
-                info = []
-                if act.include_this(excludes, publisher=fmri.publisher):
-                        if not path_only:
-                                errors, warnings, info = act.verify(
-                                    self, pfmri=fmri, **kwargs)
-                        elif path in verifypaths or path in overlaypaths:
-                                if path in verifypaths:
-                                        progresstracker.plan_add_progress(
-                                            progresstracker.PLAN_PKG_VERIFY)
-
-                                errors, warnings, info = act.verify(
-                                    self, pfmri=fmri, **kwargs)
-                                # It's safe to immediately discard this
-                                # match as only one action can deliver a
-                                # path with overlay=allow and only one with
-                                # overlay=true.
-                                overlaypaths.discard(path)
-                                if act.attrs.get("overlay") == "allow":
-                                        overlaypaths.add(path)
-                                verifypaths.discard(path)
-                elif act.include_this(vardrate_excludes,
-                    publisher=fmri.publisher) and not act.refcountable:
-                        # Verify that file that is faceted out does not
-                        # exist. Exclude actions which may be delivered
-                        # from multiple packages.
-                        if path is not None and os.path.exists(os.path.join(
-                            self.root, path)):
-                                errors.append(_("File should not exist"))
-                else:
-                        # Action that is not applicable to image variant
-                        # or has been dehydrated.
-                        return None, None, None, True
-                return errors, warnings, info, False
-
-        def verify(self, fmri, progresstracker, verifypaths=None,
-            overlaypaths=None, single_act=None, **kwargs):
-                """Generator that returns a tuple of the form (action, errors,
-                warnings, info) if there are any error, warning, or other
-                messages about an action contained within the specified
-                package.  Where the returned messages are lists of strings
-                indicating fatal problems, potential issues (that can be
-                ignored), or extra information to be displayed respectively.
-
-                'fmri' is the fmri of the package to verify.
-
-                'progresstracker' is a ProgressTracker object.
-
-                'verifypaths' is the set of paths to verify.
-
-                'overlaypaths' is the set of overlaying path to verify.
-
-                'single_act' is the only action of the specified fmri to
-                 verify.
-
-                'kwargs' is a dict of additional keyword arguments to be passed
-                to each action verification routine."""
-
-                path_only = bool(verifypaths or overlaypaths)
-                # pkg verify only looks at actions that have not been dehydrated.
-                excludes = self.list_excludes()
-                vardrate_excludes = [self.cfg.variants.allow_action]
-                dehydrate = self.cfg.get_property("property", "dehydrated")
-                if dehydrate:
-                        func = self.get_dehydrated_exclude_func(dehydrate)
-                        excludes.append(func)
-                        vardrate_excludes.append(func)
-
-                # If single_act is set, only that action will be processed.
-                if single_act:
-                        overlay = None
-                        if single_act.attrs.get("overlay") == "allow":
-                                overlay = "overlaid"
-                        elif single_act.attrs.get("overlay") == "true":
-                                overlay = "overlaying"
-                        progresstracker.plan_add_progress(
-                            progresstracker.PLAN_PKG_VERIFY, nitems=0)
-                        path = single_act.attrs.get("path")
-                        errors, warnings, info, ignore = \
-                            self.__process_verify(single_act,
-                                path, path_only, fmri,
-                                excludes, vardrate_excludes,
-                                progresstracker, verifypaths=verifypaths,
-                                overlaypaths=overlaypaths, **kwargs)
-                        if (errors or warnings or info) and not ignore:
-                                yield single_act, errors, \
-                                    warnings, info, overlay
-                        return
-
-                try:
-                        pub = self.get_publisher(prefix=fmri.publisher)
-                except apx.UnknownPublisher:
-                        # Since user removed publisher, assume this is the same
-                        # as if they had set signature-policy ignore for the
-                        # publisher.
-                        sig_pol = None
-                else:
-                        sig_pol = self.signature_policy.combine(
-                            pub.signature_policy)
-
-                if not path_only:
-                        progresstracker.plan_add_progress(
-                            progresstracker.PLAN_PKG_VERIFY)
-
-                manf = self.get_manifest(fmri, ignore_excludes=True)
-                sigs = list(manf.gen_actions_by_type("signature",
-                    excludes=self.list_excludes()))
-                if sig_pol and (sigs or sig_pol.name != "ignore"):
-                        # Only perform signature verification logic if there are
-                        # signatures or if signature-policy is not 'ignore'.
-                        try:
-                                # Signature verification must be done using all
-                                # the actions from the manifest, not just the
-                                # ones for this image's variants.
-                                sig_pol.process_signatures(sigs,
-                                    manf.gen_actions(), pub, self.trust_anchors,
-                                    self.cfg.get_policy(
-                                        "check-certificate-revocation"))
-                        except apx.SigningException as e:
-                                e.pfmri = fmri
-                                yield e.sig, [e], [], [], None
-                        except apx.InvalidResourceLocation as e:
-                                yield None, [e], [], [], None
-
-                def mediation_allowed(act):
-                        """Helper function to determine if the mediation
-                        delivered by a link is allowed.  If it is, then
-                        the link should be verified.  (Yes, this does mean
-                        that the non-existence of links is not verified.)
-                        """
-
-                        mediator = act.attrs.get("mediator")
-                        if not mediator or mediator not in self.cfg.mediators:
-                                # Link isn't mediated or mediation is unknown.
-                                return True
-
-                        cfg_med_version = self.cfg.mediators[mediator].get(
-                            "version")
-                        cfg_med_impl = self.cfg.mediators[mediator].get(
-                            "implementation")
-
-                        med_version = act.attrs.get("mediator-version")
-                        if med_version:
-                                med_version = pkg.version.Version(
-                                    med_version)
-                        med_impl = act.attrs.get("mediator-implementation")
-
-                        return med_version == cfg_med_version and \
-                            med.mediator_impl_matches(med_impl, cfg_med_impl)
-
-                for act in manf.gen_actions():
-                        path = act.attrs.get("path")
-                        # Defer verification on actions with 'overlay'
-                        # attribute = 'allow'.
-                        if not path_only:
-                                if act.attrs.get("overlay") == "true":
-                                        yield act, [], [], [], "overlaying"
-                                        continue
-                                elif act.attrs.get("overlay"):
-                                        yield act, [], [], [], "overlaid"
-                                        continue
-
-
-                        progresstracker.plan_add_progress(
-                            progresstracker.PLAN_PKG_VERIFY, nitems=0)
-
-                        if (act.name == "link" or
-                            act.name == "hardlink") and \
-                            not mediation_allowed(act):
-                                # Link doesn't match configured
-                                # mediation, so shouldn't be verified.
-                                continue
-
-                        errors, warnings, info, ignore = self.__process_verify(
-                            act, path, path_only, fmri, excludes,
-                            vardrate_excludes, progresstracker,
-                            verifypaths=verifypaths, overlaypaths=overlaypaths,
-                            **kwargs)
-                        if (errors or warnings or info) and not ignore:
-                                yield act, errors, warnings, info, None
-
-        def image_config_update(self, new_variants, new_facets, new_mediators):
-                """update variants in image config"""
-
-                if new_variants is not None:
-                        self.cfg.variants.update(new_variants)
-                if new_facets is not None:
-                        self.cfg.facets = new_facets
-                if new_mediators is not None:
-                        self.cfg.mediators = new_mediators
-                self.save_config()
-
-        def __verify_manifest(self, fmri, mfstpath, alt_pub=None):
-                """Verify a manifest.  The caller must supply the FMRI
-                for the package in 'fmri', as well as the path to the
-                manifest file that will be verified."""
-
-                try:
-                        return self.transport._verify_manifest(fmri,
-                            mfstpath=mfstpath, pub=alt_pub)
-                except InvalidContentException:
-                        return False
-
-        def has_manifest(self, pfmri, alt_pub=None):
-                """Check to see if the manifest for pfmri is present on disk and
-                has the correct hash."""
-
-                pth = self.get_manifest_path(pfmri)
-                on_disk = os.path.exists(pth)
-
-                if not on_disk or \
-                    self.is_pkg_installed(pfmri) or \
-                    self.__verify_manifest(fmri=pfmri, mfstpath=pth, alt_pub=alt_pub):
-                        return on_disk
+            yield
+        except apx.ImageLockedError as e:
+            # Don't unlock the image if the call failed to
+            # get the lock.
+            error = e
+            raise
+        except Exception as e:
+            error = e
+            self.unlock()
+            raise
+        else:
+            self.unlock()
+        finally:
+            if new_history_op:
+                self.history.log_operation_end(error=error)
+
+    def lock(self, allow_unprivileged=False):
+        """Locks the image in preparation for an image-modifying
+        operation.  Raises an ImageLockedError exception on failure.
+        Locking behaviour is controlled by the blocking_locks image
+        property.
+
+        'allow_unprivileged' is an optional boolean value indicating
+        that permissions-related exceptions should be ignored when
+        attempting to obtain the lock as the related operation will
+        still work correctly even though the image cannot (presumably)
+        be modified.
+        """
+
+        blocking = self.blocking_locks
+
+        # First, attempt to obtain a thread lock.
+        if not self.__lock.acquire(blocking=blocking):
+            raise apx.ImageLockedError()
+
+        try:
+            # Attempt to obtain a file lock.
+            self.__lockfile.lock(blocking=blocking)
+        except EnvironmentError as e:
+            exc = None
+            if e.errno == errno.ENOENT:
+                return
+            if e.errno == errno.EACCES:
+                exc = apx.UnprivilegedUserError(e.filename)
+            elif e.errno == errno.EROFS:
+                exc = apx.ReadOnlyFileSystemException(e.filename)
+            elif e.errno in (errno.ENOSPC, errno.EDQUOT):
+                # Failed due to space constraint
+                raise e
+            else:
+                self.__lock.release()
+                raise
+
+            if exc and not allow_unprivileged:
+                self.__lock.release()
+                raise exc
+        except:
+            # If process lock fails, ensure thread lock is released.
+            self.__lock.release()
+            raise
+
+    def unlock(self):
+        """Unlocks the image."""
+
+        try:
+            if self.__lockfile:
+                self.__lockfile.unlock()
+        finally:
+            self.__lock.release()
+
+    def image_type(self, d):
+        """Returns the type of image at directory: d; or None"""
+        rv = None
+
+        def is_image(sub_d, prefix):
+            # First check for new image configuration file.
+            if os.path.isfile(os.path.join(sub_d, prefix, "pkg5.image")):
+                # Regardless of directory structure, assume
+                # this is an image for now.
+                return True
+
+            if not os.path.isfile(os.path.join(sub_d, prefix, "cfg_cache")):
+                # For older formats, if configuration is
+                # missing, this can't be an image.
                 return False
 
-        def get_license_dir(self, pfmri):
-                """Return path to package license directory."""
-                if self.version == self.CURRENT_VERSION:
-                        # Newer image format stores license files per-stem,
-                        # instead of per-stem and version, so that transitions
-                        # between package versions don't require redelivery
-                        # of license files.
-                        return os.path.join(self.imgdir, "license",
-                            pfmri.get_dir_path(stemonly=True))
-                # Older image formats store license files in the manifest cache
-                # directory.
-                return self.get_manifest_dir(pfmri)
+            # Configuration exists, but for older formats,
+            # all of these directories have to exist.
+            for n in ("state", "pkg"):
+                if not os.path.isdir(os.path.join(sub_d, prefix, n)):
+                    return False
 
-        def __get_installed_pkg_publisher(self, pfmri):
-                """Returns the publisher for the FMRI of an installed package
-                or None if the package is not installed.
-                """
-                for f in self.gen_installed_pkgs():
-                        if f.pkg_name == pfmri.pkg_name:
-                                return f.publisher
-                return None
+            return True
 
-        def get_manifest_dir(self, pfmri):
-                """Return path to on-disk manifest cache directory."""
-                if not pfmri.publisher:
-                        # Needed for consumers such as search that don't provide
-                        # publisher information.
-                        pfmri = pfmri.copy()
-                        pfmri.publisher = self.__get_installed_pkg_publisher(
-                            pfmri)
-                assert pfmri.publisher
-                if self.version == self.CURRENT_VERSION:
-                        root = self._get_publisher_cache_root(pfmri.publisher)
-                else:
-                        root = self.imgdir
-                return os.path.join(root, "pkg", pfmri.get_dir_path())
+        if os.path.isdir(os.path.join(d, img_user_prefix)) and is_image(
+            d, img_user_prefix
+        ):
+            rv = IMG_USER
+        elif os.path.isdir(os.path.join(d, img_root_prefix)) and is_image(
+            d, img_root_prefix
+        ):
+            rv = IMG_ENTIRE
+        return rv
 
-        def get_manifest_path(self, pfmri):
-                """Return path to on-disk manifest file."""
-                if not pfmri.publisher:
-                        # Needed for consumers such as search that don't provide
-                        # publisher information.
-                        pfmri = pfmri.copy()
-                        pfmri.publisher = self.__get_installed_pkg_publisher(
-                            pfmri)
-                assert pfmri.publisher
-                if self.version == self.CURRENT_VERSION:
-                        root = os.path.join(self._get_publisher_meta_root(
-                            pfmri.publisher))
-                        return os.path.join(root, "pkg", pfmri.get_dir_path())
-                return os.path.join(self.get_manifest_dir(pfmri),
-                    "manifest")
+    def find_root(self, d, exact_match=False, progtrack=None):
+        # Ascend from the given directory d to find first
+        # encountered image.  If exact_match is true, if the
+        # image found doesn't match startd, raise an
+        # ImageNotFoundException.
 
-        def __get_manifest(self, fmri, excludes=EmptyI, intent=None,
-            alt_pub=None):
-                """Find on-disk manifest and create in-memory Manifest
-                object.... grab from server if needed"""
+        startd = d
+        # eliminate problem if relative path such as "." is passed in
+        d = os.path.realpath(d)
 
-                try:
-                        if not self.has_manifest(fmri, alt_pub=alt_pub):
-                                raise KeyError
-                        ret = manifest.FactoredManifest(fmri,
-                            self.get_manifest_dir(fmri),
-                            excludes=excludes,
-                            pathname=self.get_manifest_path(fmri))
-
-                        # if we have a intent string, let depot
-                        # know for what we're using the cached manifest
-                        if intent:
-                                alt_repo = None
-                                if alt_pub:
-                                        alt_repo = alt_pub.repository
-                                try:
-                                        self.transport.touch_manifest(fmri,
-                                            intent, alt_repo=alt_repo)
-                                except (apx.UnknownPublisher,
-                                    apx.TransportError):
-                                        # It's not fatal if we can't find
-                                        # or reach the publisher.
-                                        pass
-                except KeyError:
-                        ret = self.transport.get_manifest(fmri, excludes,
-                            intent, pub=alt_pub)
-                return ret
-
-        def get_manifest(self, fmri, ignore_excludes=False, intent=None,
-            alt_pub=None):
-                """return manifest; uses cached version if available.
-                ignore_excludes controls whether manifest contains actions
-                for all variants
-
-                If 'ignore_excludes' is set to True, then all actions in the
-                manifest are included, regardless of variant or facet tags.  If
-                set to False, then the variants and facets currently set in the
-                image will be applied, potentially filtering out some of the
-                actions."""
-
-                # Normally elide other arch variants, facets
-
-                if ignore_excludes:
-                        excludes = EmptyI
-                else:
-                        excludes = [self.cfg.variants.allow_action,
-                            self.cfg.facets.allow_action]
-
-                try:
-                        m = self.__get_manifest(fmri, excludes=excludes,
-                            intent=intent, alt_pub=alt_pub)
-                except apx.ActionExecutionError as e:
-                        raise
-                except pkg.actions.ActionError as e:
-                        raise apx.InvalidPackageErrors([e])
-
-                return m
-
-        def __catalog_save(self, cats, pfmris, progtrack):
-
-                # Temporarily redirect the catalogs to a different location,
-                # so that if the save is interrupted, the image won't be left
-                # with invalid state, and then save them.
-                tmp_state_root = self.temporary_dir()
-
-                try:
-                        for cat, name in cats:
-                                cpath = os.path.join(tmp_state_root, name)
-
-                                # Must copy the old catalog data to the new
-                                # destination as only changed files will be
-                                # written.
-                                progtrack.job_add_progress(
-                                    progtrack.JOB_IMAGE_STATE)
-                                misc.copytree(cat.meta_root, cpath)
-                                progtrack.job_add_progress(
-                                    progtrack.JOB_IMAGE_STATE)
-                                cat.meta_root = cpath
-                                cat.finalize(pfmris=pfmris)
-                                progtrack.job_add_progress(
-                                    progtrack.JOB_IMAGE_STATE)
-                                cat.save()
-                                progtrack.job_add_progress(
-                                    progtrack.JOB_IMAGE_STATE)
-
-                        del cat, name
-                        self.__init_catalogs()
-                        progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
-
-                        # copy any other state files from current state
-                        # dir into new state dir.
-                        for p in os.listdir(self._statedir):
-                                progtrack.job_add_progress(
-                                            progtrack.JOB_IMAGE_STATE)
-                                fp = os.path.join(self._statedir, p)
-                                if os.path.isfile(fp):
-                                        portable.copyfile(fp,
-                                            os.path.join(tmp_state_root, p))
-
-                        # Next, preserve the old installed state dir, rename the
-                        # new one into place, and then remove the old one.
-                        orig_state_root = self.salvage(self._statedir,
-                            full_path=True)
-                        portable.rename(tmp_state_root, self._statedir)
-
-                        progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
-                        shutil.rmtree(orig_state_root, True)
-
-                        progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
-                except EnvironmentError as e:
-                        # shutil.Error can contains a tuple of lists of errors.
-                        # Some of the error entries may be a tuple others will
-                        # be a string due to poor error handling in shutil.
-                        if isinstance(e, shutil.Error) and \
-                            type(e.args[0]) == list:
-                                msg = ""
-                                for elist in e.args:
-                                        for entry in elist:
-                                                if type(entry) == tuple:
-                                                        msg += "{0}\n".format(
-                                                            entry[-1])
-                                                else:
-                                                        msg += "{0}\n".format(
-                                                            entry)
-                                raise apx.UnknownErrors(msg)
-                        raise apx._convert_error(e)
-                finally:
-                        # Regardless of success, the following must happen.
-                        self.__init_catalogs()
-                        if os.path.exists(tmp_state_root):
-                                shutil.rmtree(tmp_state_root, True)
-
-        def update_pkg_installed_state(self, pkg_pairs, progtrack, origin):
-                """Sets the recorded installed state of each package pair in
-                'pkg_pairs'.  'pkg_pair' should be an iterable of tuples of
-                the format (added, removed) where 'removed' is the FMRI of the
-                package that was uninstalled, and 'added' is the package
-                installed for the operation.  These pairs are representative of
-                the destination and origin package for each part of the
-                operation."""
-
-                if self.version < self.CURRENT_VERSION:
-                        raise apx.ImageFormatUpdateNeeded(self.root)
-
-                kcat = self.get_catalog(self.IMG_CATALOG_KNOWN)
-                icat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-
-                added = set()
-                removed = set()
-                manual = set()
-                updated = {}
-                for add_pkg, rem_pkg in pkg_pairs:
-                        if add_pkg == rem_pkg:
-                                continue
-                        if add_pkg:
-                                added.add(add_pkg)
-                                if add_pkg in origin:
-                                        manual.add(add_pkg)
-                        if rem_pkg:
-                                removed.add(rem_pkg)
-                        if add_pkg and rem_pkg:
-                                updated[add_pkg] = \
-                                    dict(kcat.get_entry(rem_pkg).get(
-                                    "metadata", {}))
-
-                combo = added.union(removed)
-
-                # If PKG_AUTOINSTALL is set in the environment, don't mark
-                # the installed packages as 'manually installed'. This is
-                # used by Kayak when creating the initial ZFS send stream.
-                if "PKG_AUTOINSTALL" in os.environ:
-                        manual = set()
-
-                progtrack.job_start(progtrack.JOB_STATE_DB)
-                # 'Updating package state database'
-                for pfmri in combo:
-                        progtrack.job_add_progress(progtrack.JOB_STATE_DB)
-                        entry = kcat.get_entry(pfmri)
-                        mdata = entry.get("metadata", {})
-                        states = set(mdata.get("states", set()))
-                        if pfmri in removed:
-                                icat.remove_package(pfmri)
-                                states.discard(pkgdefs.PKG_STATE_INSTALLED)
-                                states.discard(pkgdefs.PKG_STATE_MANUAL)
-                                mdata.pop("last-install", None)
-                                mdata.pop("last-update", None)
-
-                        if pfmri in added:
-                                states.add(pkgdefs.PKG_STATE_INSTALLED)
-                                if pfmri in manual:
-                                        states.add(pkgdefs.PKG_STATE_MANUAL)
-                                cur_time = pkg.catalog.now_to_basic_ts()
-                                if pfmri in updated:
-                                        last_install = updated[pfmri].get(
-                                            "last-install")
-                                        if last_install:
-                                                mdata["last-install"] = \
-                                                    last_install
-                                                mdata["last-update"] = \
-                                                    cur_time
-                                        else:
-                                                mdata["last-install"] = \
-                                                    cur_time
-                                        ostates = set(updated[pfmri]
-                                            .get("states", set()))
-                                        if pkgdefs.PKG_STATE_MANUAL in ostates:
-                                                states.add(
-                                                    pkgdefs.PKG_STATE_MANUAL)
-                                else:
-                                        mdata["last-install"] = cur_time
-                                if pkgdefs.PKG_STATE_ALT_SOURCE in states:
-                                        states.discard(
-                                            pkgdefs.PKG_STATE_UPGRADABLE)
-                                        states.discard(
-                                            pkgdefs.PKG_STATE_ALT_SOURCE)
-                                        states.discard(
-                                            pkgdefs.PKG_STATE_KNOWN)
-                        elif pkgdefs.PKG_STATE_KNOWN not in states:
-                                # This entry is no longer available and has no
-                                # meaningful state information, so should be
-                                # discarded.
-                                kcat.remove_package(pfmri)
-                                progtrack.job_add_progress(
-                                    progtrack.JOB_STATE_DB)
-                                continue
-
-                        if (pkgdefs.PKG_STATE_INSTALLED in states and
-                            pkgdefs.PKG_STATE_UNINSTALLED in states) or (
-                            pkgdefs.PKG_STATE_KNOWN in states and
-                            pkgdefs.PKG_STATE_UNKNOWN in states):
-                                raise apx.ImagePkgStateError(pfmri,
-                                    states)
-
-                        # Catalog format only supports lists.
-                        mdata["states"] = list(states)
-
-                        # Now record the package state.
-                        kcat.update_entry(mdata, pfmri=pfmri)
-
-                        # If the package is being marked as installed,
-                        # then  it shouldn't already exist in the
-                        # installed catalog and should be added.
-                        if pfmri in added:
-                                icat.append(kcat, pfmri=pfmri)
-
-                        entry = mdata = states = None
-                        progtrack.job_add_progress(progtrack.JOB_STATE_DB)
-                progtrack.job_done(progtrack.JOB_STATE_DB)
-
-                # Discard entries for alternate source packages that weren't
-                # installed as part of the operation.
-                if self.__alt_pkg_pub_map:
-                        for pfmri in self.__alt_known_cat.fmris():
-                                if pfmri in added:
-                                        # Nothing to do.
-                                        continue
-
-                                entry = kcat.get_entry(pfmri)
-                                if not entry:
-                                        # The only reason that the entry should
-                                        # not exist in the 'known' part is
-                                        # because it was removed during the
-                                        # operation.
-                                        assert pfmri in removed
-                                        continue
-
-                                states = entry.get("metadata", {}).get("states",
-                                    EmptyI)
-                                if pkgdefs.PKG_STATE_ALT_SOURCE in states:
-                                        kcat.remove_package(pfmri)
-
-                        # Now add the publishers of packages that were installed
-                        # from temporary sources that did not previously exist
-                        # to the image's configuration.  (But without any
-                        # origins, sticky, and enabled.)
-                        cfgpubs = set(self.cfg.publishers.keys())
-                        instpubs = set(f.publisher for f in added)
-                        altpubs = self.__alt_known_cat.publishers()
-
-                        # List of publishers that need to be added is the
-                        # intersection of installed and alternate minus
-                        # the already configured.
-                        newpubs = (instpubs & altpubs) - cfgpubs
-                        # Sort the set to get a deterministic output.
-                        for pfx in sorted(newpubs):
-                                npub = publisher.Publisher(pfx,
-                                    repository=publisher.Repository())
-                                self.__add_publisher(npub,
-                                    refresh_allowed=False)
-
-                        # Ensure image configuration reflects new information.
-                        self.__cleanup_alt_pkg_certs()
-                        self.save_config()
-
-                # Remove manifests of packages that were removed from the
-                # system.  Some packages may have only had facets or
-                # variants changed, so don't remove those.
-
-                # 'Updating package cache'
-                progtrack.job_start(progtrack.JOB_PKG_CACHE, goal=len(removed))
-                for pfmri in removed:
-                        mcdir = self.get_manifest_dir(pfmri)
-                        manifest.FactoredManifest.clear_cache(mcdir)
-
-                        # Remove package cache directory if possible; we don't
-                        # care if it fails.
-                        try:
-                                os.rmdir(os.path.dirname(mcdir))
-                        except:
-                                pass
-
-                        mpath = self.get_manifest_path(pfmri)
-                        try:
-                                portable.remove(mpath)
-                        except EnvironmentError as e:
-                                if e.errno != errno.ENOENT:
-                                        raise apx._convert_error(e)
-
-                        # Remove package manifest directory if possible; we
-                        # don't care if it fails.
-                        try:
-                                os.rmdir(os.path.dirname(mpath))
-                        except:
-                                pass
-                        progtrack.job_add_progress(progtrack.JOB_PKG_CACHE)
-                progtrack.job_done(progtrack.JOB_PKG_CACHE)
-
-                progtrack.job_start(progtrack.JOB_IMAGE_STATE)
-
-                self.__catalog_save(
-                    [(kcat, self.IMG_CATALOG_KNOWN),
-                     (icat, self.IMG_CATALOG_INSTALLED)],
-                    added, progtrack)
-
-                progtrack.job_done(progtrack.JOB_IMAGE_STATE)
-
-        def get_catalog(self, name):
-                """Returns the requested image catalog.
-
-                'name' must be one of the following image constants:
-                    IMG_CATALOG_KNOWN
-                        The known catalog contains all of packages that are
-                        installed or available from a publisher's repository.
-
-                    IMG_CATALOG_INSTALLED
-                        The installed catalog is a subset of the 'known'
-                        catalog that only contains installed packages."""
-
-                if not self.imgdir:
-                        raise RuntimeError("self.imgdir must be set")
-
-                cat = self.__catalogs.get(name)
-                if not cat:
-                        cat = self.__get_catalog(name)
-                        self.__catalogs[name] = cat
-
-                if name == self.IMG_CATALOG_KNOWN:
-                        # Apply alternate package source data every time that
-                        # the known catalog is requested.
-                        self.__apply_alt_pkg_sources(cat)
-
-                return cat
-
-        def _manifest_cb(self, cat, f):
-                # Only allow lazy-load for packages from non-v1 sources.
-                # Assume entries for other sources have all data
-                # required in catalog.  This prevents manifest retrieval
-                # for packages that don't have any related action data
-                # in the catalog because they don't have any related
-                # action data in their manifest.
-                entry = cat.get_entry(f)
-                states = entry["metadata"]["states"]
-                if pkgdefs.PKG_STATE_V1 not in states:
-                        return self.get_manifest(f, ignore_excludes=True)
+        while True:
+            imgtype = self.image_type(d)
+            if imgtype in (IMG_USER, IMG_ENTIRE):
+                if exact_match and os.path.realpath(startd) != os.path.realpath(
+                    d
+                ):
+                    raise apx.ImageNotFoundException(exact_match, startd, d)
+                self.__set_dirs(
+                    imgtype=imgtype, root=d, startd=startd, progtrack=progtrack
+                )
                 return
 
-        def __get_catalog(self, name):
-                """Private method to retrieve catalog; this bypasses the
-                normal automatic caching (unless the image hasn't been
-                upgraded yet)."""
+            # XXX follow symlinks or not?
+            oldpath = d
+            d = os.path.normpath(os.path.join(d, os.path.pardir))
 
-                if self.__upgraded and self.version < 3:
-                        # Assume the catalog is already cached in this case
-                        # and can't be reloaded from disk as it doesn't exist
-                        # on disk yet.
-                        return self.__catalogs[name]
+            # Make sure we are making progress and aren't in an
+            # infinite loop.
+            #
+            # (XXX - Need to deal with symlinks here too)
+            if d == oldpath:
+                raise apx.ImageNotFoundException(exact_match, startd, d)
 
-                croot = os.path.join(self._statedir, name)
+    def __load_config(self):
+        """Load this image's cached configuration from the default
+        location.  This function should not be called anywhere other
+        than __set_dirs()."""
+
+        # XXX Incomplete with respect to doc/image.txt description of
+        # configuration.
+
+        if self.root == None:
+            raise RuntimeError("self.root must be set")
+
+        version = None
+        if self.version > -1:
+            if self.version >= 3:
+                # Configuration version is currently 3
+                # for all v3 images and newer.
+                version = 3
+            else:
+                version = self.version
+
+        self.cfg = imageconfig.ImageConfig(
+            self.__cfgpathname,
+            self.root,
+            version=version,
+            overrides=self.__property_overrides,
+        )
+
+        if self.__upgraded:
+            self.cfg = imageconfig.BlendedConfig(
+                self.cfg,
+                self.get_catalog(
+                    self.IMG_CATALOG_INSTALLED
+                ).get_package_counts_by_pub(),
+                self.imgdir,
+                self.transport,
+                self.cfg.get_policy("use-system-repo"),
+            )
+
+        if self.cfg.version == imageconfig.CURRENT_VERSION:
+            for keyf in self.get_property(imageconfig.KEY_FILES):
+                if not os.path.exists(self.root + os.path.sep + keyf):
+                    raise apx.ImageMissingKeyFile(keyf)
+
+        self.__load_publisher_ssl()
+
+    def __store_publisher_ssl(self):
+        """Normalizes publisher SSL configuration data, storing any
+        certificate files as needed in the image's SSL directory.  This
+        logic is performed here in the image instead of ImageConfig as
+        it relies on special knowledge of the image structure."""
+
+        ssl_dir = os.path.join(self.imgdir, "ssl")
+
+        def store_ssl_file(src):
+            try:
+                if not src or not os.path.exists(src):
+                    # If SSL file doesn't exist (for
+                    # whatever reason), then don't update
+                    # configuration.  (Let the failure
+                    # happen later during an operation
+                    # that requires the file.)
+                    return
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+
+            # Ensure ssl_dir exists; makedirs handles any errors.
+            misc.makedirs(ssl_dir)
+
+            try:
+                # Destination name is based on digest of file.
+                # In order for this image to interoperate with
+                # older and newer clients, we must use sha-1
+                # here.
+                dest = os.path.join(
+                    ssl_dir,
+                    misc.get_data_digest(src, hash_func=hashlib.sha1)[0],
+                )
+                if src != dest:
+                    portable.copyfile(src, dest)
+
+                # Ensure file can be read by unprivileged users.
+                os.chmod(dest, misc.PKG_FILE_MODE)
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+            return dest
+
+        for pub in self.cfg.publishers.values():
+            # self.cfg.publishers is used because gen_publishers
+            # includes temporary publishers and this is only for
+            # configured ones.
+            repo = pub.repository
+            if not repo:
+                continue
+
+            # Store and normalize ssl_cert and ssl_key.
+            for u in repo.origins + repo.mirrors:
+                for prop in ("ssl_cert", "ssl_key"):
+                    pval = getattr(u, prop)
+                    if pval:
+                        pval = store_ssl_file(pval)
+                    if not pval:
+                        continue
+                    # Store path as absolute to image root,
+                    # it will be corrected on load to match
+                    # actual image location if needed.
+                    setattr(
+                        u,
+                        prop,
+                        os.path.splitdrive(self.root)[0]
+                        + os.path.sep
+                        + misc.relpath(pval, start=self.root),
+                    )
+
+    def __load_publisher_ssl(self):
+        """Should be called every time image configuration is loaded;
+        ensure ssl_cert and ssl_key properties of publisher repository
+        URI objects match current image location."""
+
+        ssl_dir = os.path.join(self.imgdir, "ssl")
+
+        for pub in self.cfg.publishers.values():
+            # self.cfg.publishers is used because gen_publishers
+            # includes temporary publishers and this is only for
+            # configured ones.
+            repo = pub.repository
+            if not repo:
+                continue
+
+            for u in repo.origins + repo.mirrors:
+                for prop in ("ssl_cert", "ssl_key"):
+                    pval = getattr(u, prop)
+                    if not pval:
+                        continue
+                    if not os.path.join(
+                        self.img_prefix, "ssl"
+                    ) in os.path.dirname(pval):
+                        continue
+                    # If special image directory is part
+                    # of path, then assume path should be
+                    # rewritten to match current image
+                    # location.
+                    setattr(
+                        u, prop, os.path.join(ssl_dir, os.path.basename(pval))
+                    )
+
+    def update_last_modified(self):
+        """Update $imgdir/modified timestamp for image; should be
+        called after any image modification has completed.  This
+        provides a public interface for programs that want to monitor
+        the image for modifications via event ports, etc."""
+
+        # This is usually /var/pkg/modified.
+        fname = os.path.join(self.imgdir, "modified")
+        try:
+            with os.fdopen(
+                os.open(fname, os.O_CREAT | os.O_NOFOLLOW, misc.PKG_FILE_MODE)
+            ) as f:
+                os.utime(fname, None)
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+
+    def save_config(self):
+        # First, create the image directories if they haven't been, so
+        # the configuration file can be written.
+        self.mkdirs()
+        self.__store_publisher_ssl()
+        self.cfg.write()
+        self.update_last_modified()
+        self.__load_publisher_ssl()
+
+        # Remove the old the pkg.sysrepo(8) cache, if present.
+        cache_path = os.path.join(
+            self.root, global_settings.sysrepo_pub_cache_path
+        )
+        try:
+            portable.remove(cache_path)
+        except EnvironmentError as e:
+            if e.errno != errno.ENOENT:
+                raise apx._convert_error(e)
+
+        if self.is_liveroot() and smf.get_state(
+            "svc:/application/pkg/system-repository:default"
+        ) in (smf.SMF_SVC_TMP_ENABLED, smf.SMF_SVC_ENABLED):
+            smf.refresh(["svc:/application/pkg/system-repository:default"])
+
+        # This ensures all old transport configuration is thrown away.
+        self.transport = transport.Transport(transport.ImageTransportCfg(self))
+
+    def hotfix_origin_cleanup(self):
+        """Remove any temporary hot-fix source origins"""
+
+        changed = False
+
+        for pub in self.cfg.publishers.values():
+            if not pub.repository:
+                continue
+
+            for o in pub.repository.origins:
+                if relib.search("/pkg_hfa_.*p5p/$", o.uri):
+                    pub.repository.remove_origin(o)
+                    changed = True
+
+        if changed:
+            self.save_config()
+
+    def mkdirs(self, root=None, version=None):
+        """Create any missing parts of the image's directory structure.
+
+        'root' is an optional path to a directory to create the new
+        image structure in.  If not provided, the current image
+        directory is the default.
+
+        'version' is an optional integer value indicating the version
+        of the structure to create.  If not provided, the current image
+        version is the default.
+        """
+
+        if not root:
+            root = self.imgdir
+        if not version:
+            version = self.version
+
+        if version == self.CURRENT_VERSION:
+            img_dirs = [
+                "cache/index",
+                "cache/publisher",
+                "cache/tmp",
+                "gui_cache",
+                "history",
+                "license",
+                "lost+found",
+                "publisher",
+                "ssl",
+                "state/installed",
+                "state/known",
+            ]
+        else:
+            img_dirs = [
+                "download",
+                "file",
+                "gui_cache",
+                "history",
+                "index",
+                "lost+found",
+                "pkg",
+                "publisher",
+                "state/installed",
+                "state/known",
+                "tmp",
+            ]
+
+        for sd in img_dirs:
+            try:
+                misc.makedirs(os.path.join(root, sd))
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+
+    def __set_dirs(
+        self, imgtype, root, startd=None, progtrack=None, purge=False
+    ):
+        # Ensure upgraded status is reset.
+        self.__upgraded = False
+
+        if not self.__allow_liveroot() and root == misc.liveroot():
+            if startd == None:
+                startd = root
+            raise RuntimeError(
+                "Live root image access is disabled but was \
+                            attempted.\nliveroot: {0}\nimage path: {1}".format(
+                    misc.liveroot(), startd
+                )
+            )
+
+        self.__root = root
+        self.type = imgtype
+        if self.type == IMG_USER:
+            self.img_prefix = img_user_prefix
+        else:
+            self.img_prefix = img_root_prefix
+
+        # Use a new Transport object every time location is changed.
+        self.transport = transport.Transport(transport.ImageTransportCfg(self))
+
+        # cleanup specified path
+        if os.path.isdir(root):
+            try:
+                cwd = os.getcwd()
+            except Exception as e:
+                # If current directory can't be obtained for any
+                # reason, ignore the error.
+                cwd = None
+
+            try:
+                os.chdir(root)
+                self.__root = os.getcwd()
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+            finally:
+                if cwd:
+                    os.chdir(cwd)
+
+        # If current image is locked, then it should be unlocked
+        # and then relocked after the imgdir is changed.  This
+        # ensures that alternate BE scenarios work.
+        relock = self.imgdir and self.locked
+        if relock:
+            self.unlock()
+
+        # Must set imgdir first.
+        self.__imgdir = os.path.join(self.root, self.img_prefix)
+
+        # Force a reset of version.
+        self.version = -1
+
+        # Assume version 4+ configuration location.
+        self.__cfgpathname = os.path.join(self.imgdir, "pkg5.image")
+
+        # In the case of initial image creation, purge is specified
+        # to ensure that when an image is created over an existing
+        # one, any old data is removed first.
+        if purge and os.path.exists(self.imgdir):
+            for entry in os.listdir(self.imgdir):
+                if entry == "ssl":
+                    # Preserve certs and keys directory
+                    # as a special exception.
+                    continue
+                epath = os.path.join(self.imgdir, entry)
                 try:
-                        os.makedirs(croot)
+                    if os.path.isdir(epath):
+                        shutil.rmtree(epath)
+                    else:
+                        portable.remove(epath)
                 except EnvironmentError as e:
-                        if e.errno in (errno.EACCES, errno.EROFS):
-                                # Allow operations to work for
-                                # unprivileged users.
-                                croot = None
-                        elif e.errno != errno.EEXIST:
-                                raise
+                    raise apx._convert_error(e)
+        elif not purge:
+            # Determine if the version 4 configuration file exists.
+            if not os.path.exists(self.__cfgpathname):
+                self.__cfgpathname = os.path.join(self.imgdir, "cfg_cache")
 
-                # batch_mode is set to True here as any operations that modify
-                # the catalogs (add or remove entries) are only done during an
-                # image upgrade or metadata refresh.  In both cases, the catalog
-                # is resorted and finalized so this is always safe to use.
-                cat = pkg.catalog.Catalog(batch_mode=True,
-                    manifest_cb=self._manifest_cb, meta_root=croot, sign=False)
-                return cat
+        # Load the image configuration.
+        self.__load_config()
 
-        def __remove_catalogs(self):
-                """Removes all image catalogs and their directories."""
+        if not purge:
+            try:
+                self.version = int(self.cfg.get_property("image", "version"))
+            except (cfg.PropertyConfigError, ValueError):
+                # If version couldn't be read from
+                # configuration, then allow fallback
+                # path below to set things right.
+                self.version = -1
 
-                self.__init_catalogs()
-                for name in (self.IMG_CATALOG_KNOWN,
-                    self.IMG_CATALOG_INSTALLED):
-                        shutil.rmtree(os.path.join(self._statedir, name))
+        if self.version <= 0:
+            # If version doesn't exist, attempt to determine version
+            # based on structure.
+            pub_root = os.path.join(self.imgdir, IMG_PUB_DIR)
+            if purge:
+                # This is a new image.
+                self.version = self.CURRENT_VERSION
+            elif os.path.exists(pub_root):
+                cache_root = os.path.join(self.imgdir, "cache")
+                if os.path.exists(cache_root):
+                    # The image must be corrupted, as the
+                    # version should have been loaded from
+                    # configuration.  For now, raise an
+                    # exception.  In the future, this
+                    # behaviour should probably be optional
+                    # so that pkg fix or pkg verify can
+                    # still use the image.
+                    raise apx.UnsupportedImageError(self.root)
+                else:
+                    # Assume version 3 image.
+                    self.version = 3
 
-        def get_version_installed(self, pfmri):
-                """Returns an fmri of the installed package matching the
-                package stem of the given fmri or None if no match is found."""
+                # Reload image configuration again now that
+                # version has been determined so that property
+                # definitions match.
+                self.__load_config()
+            elif os.path.exists(os.path.join(self.imgdir, "catalog")):
+                self.version = 2
 
-                cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-                for ver, fmris in cat.fmris_by_version(pfmri.pkg_name):
-                        return fmris[0]
-                return None
+                # Reload image configuration again now that
+                # version has been determined so that property
+                # definitions match.
+                self.__load_config()
+            else:
+                # Format is too old or invalid.
+                raise apx.UnsupportedImageError(self.root)
 
-        def get_pkg_repo(self, pfmri):
-                """Returns the repository object containing the origins that
-                should be used to retrieve the specified package or None if
-                it can be retrieved from all sources or is not a known package.
-                """
+        if self.version > self.CURRENT_VERSION or self.version < 2:
+            # Image is too new or too old.
+            raise apx.UnsupportedImageError(self.root)
 
-                assert pfmri.publisher
-                cat = self.get_catalog(self.IMG_CATALOG_KNOWN)
-                entry = cat.get_entry(pfmri)
-                if entry is None:
-                        # Package not known.
-                        return
+        # Ensure image version matches determined one; this must
+        # be set *after* the version checks above.
+        self.cfg.set_property("image", "version", self.version)
 
+        # Remaining dirs may now be set.
+        if self.version == self.CURRENT_VERSION:
+            self.__tmpdir = os.path.join(self.imgdir, "cache", "tmp")
+        else:
+            self.__tmpdir = os.path.join(self.imgdir, "tmp")
+        self._statedir = os.path.join(self.imgdir, "state")
+        self.plandir = os.path.join(self.__tmpdir, "plan")
+        self.update_index_dir()
+
+        self.history.root_dir = self.imgdir
+        self.__lockfile = lockfile.LockFile(
+            os.path.join(self.imgdir, "lock"),
+            set_lockstr=lockfile.client_lock_set_str,
+            get_lockstr=lockfile.client_lock_get_str,
+            failure_exc=apx.ImageLockedError,
+            provide_mutex=False,
+        )
+
+        if relock:
+            self.lock()
+
+        # Setup cache directories.
+        self.__read_cache_dirs = []
+        self._incoming_cache_dir = None
+        self.__user_cache_dir = None
+        self.__write_cache_dir = None
+        self.__write_cache_root = None
+        # The user specified cache is used as an additional place to
+        # read cache data from, but as the only place to store new
+        # cache data.
+        if "PKG_CACHEROOT" in os.environ:
+            # If set, cache is structured like /var/pkg/publisher.
+            # get_cachedirs() will build paths for each publisher's
+            # cache using this directory.
+            self.__user_cache_dir = os.path.normpath(
+                os.environ["PKG_CACHEROOT"]
+            )
+            self.__write_cache_root = self.__user_cache_dir
+        elif "PKG_CACHEDIR" in os.environ:
+            # If set, cache is a flat structure that is used for
+            # all publishers.
+            self.__user_cache_dir = os.path.normpath(os.environ["PKG_CACHEDIR"])
+            self.__write_cache_dir = self.__user_cache_dir
+            # Since the cache structure is flat, add it to the
+            # list of global read caches.
+            self.__read_cache_dirs.append(self.__user_cache_dir)
+        if self.__user_cache_dir:
+            self._incoming_cache_dir = os.path.join(
+                self.__user_cache_dir, "incoming-{0:d}".format(os.getpid())
+            )
+
+        if self.version < 4:
+            self.__action_cache_dir = self.temporary_dir()
+        else:
+            self.__action_cache_dir = os.path.join(self.imgdir, "cache")
+
+        if self.version < 4:
+            if not self.__user_cache_dir:
+                self.__write_cache_dir = os.path.join(self.imgdir, "download")
+                self._incoming_cache_dir = os.path.join(
+                    self.__write_cache_dir, "incoming-{0:d}".format(os.getpid())
+                )
+            self.__read_cache_dirs.append(
+                os.path.normpath(os.path.join(self.imgdir, "download"))
+            )
+        elif not self._incoming_cache_dir:
+            # Only a global incoming cache exists for newer images.
+            self._incoming_cache_dir = os.path.join(
+                self.imgdir, "cache", "incoming-{0:d}".format(os.getpid())
+            )
+
+        # Test if we have the permissions to create the cache
+        # incoming directory in this hierarchy.  If not, we'll need to
+        # move it somewhere else.
+        try:
+            os.makedirs(self._incoming_cache_dir)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES or e.errno == errno.EROFS:
+                self.__write_cache_dir = tempfile.mkdtemp(
+                    prefix="download-{0:d}-".format(os.getpid())
+                )
+                self._incoming_cache_dir = os.path.normpath(
+                    os.path.join(
+                        self.__write_cache_dir,
+                        "incoming-{0:d}".format(os.getpid()),
+                    )
+                )
+                self.__read_cache_dirs.append(self.__write_cache_dir)
+                # There's no image cleanup hook, so we'll just
+                # remove this directory on process exit.
+                atexit.register(
+                    shutil.rmtree, self.__write_cache_dir, ignore_errors=True
+                )
+        else:
+            os.rmdir(self._incoming_cache_dir)
+
+        # Forcibly discard image catalogs so they can be re-loaded
+        # from the new location if they are already loaded.  This
+        # also prevents scribbling on image state information in
+        # the wrong location.
+        self.__init_catalogs()
+
+        # Upgrade the image's format if needed.
+        self.update_format(allow_unprivileged=True, progtrack=progtrack)
+
+        # If we haven't loaded the system publisher configuration, do
+        # that now.
+        if isinstance(self.cfg, imageconfig.ImageConfig):
+            self.cfg = imageconfig.BlendedConfig(
+                self.cfg,
+                self.get_catalog(
+                    self.IMG_CATALOG_INSTALLED
+                ).get_package_counts_by_pub(),
+                self.imgdir,
+                self.transport,
+                self.cfg.get_policy("use-system-repo"),
+            )
+
+        # Check to see if any system publishers have been changed.
+        # If so they need to be refreshed, so clear last_refreshed.
+        for p in self.cfg.modified_pubs:
+            p.meta_root = self._get_publisher_meta_root(p.prefix)
+            p.last_refreshed = None
+
+        # Check to see if any system publishers have been
+        # removed.  If they have, remove their metadata and
+        # rebuild the catalogs.
+        changed = False
+        for p in self.cfg.removed_pubs:
+            p.meta_root = self._get_publisher_meta_root(p.prefix)
+            try:
+                self.remove_publisher_metadata(p, rebuild=False)
+                changed = True
+            except apx.PermissionsException:
+                pass
+        if changed:
+            self.__rebuild_image_catalogs()
+
+        # we delay writing out any new system repository configuration
+        # until we've updated on on-disk catalog state.  (otherwise we
+        # could lose track of syspub publishers changes and either
+        # return stale catalog information, or not do refreshes when
+        # we need to.)
+        self.cfg.write_sys_cfg()
+
+        self.__load_publisher_ssl()
+        if purge:
+            # Configuration shouldn't be written again unless this
+            # is an image creation operation (hence the purge).
+            self.save_config()
+
+        # Let the linked image subsystem know that root is moving
+        self.linked._init_root()
+
+        # load image avoid pkg set
+        self.__avoid_set_load()
+
+    def update_format(self, allow_unprivileged=False, progtrack=None):
+        """Transform the existing image structure and its data to
+        the newest format.  Callers are responsible for locking.
+
+        'allow_unprivileged' is an optional boolean indicating
+        whether a fallback to an in-memory only upgrade should
+        be performed if a PermissionsException is encountered
+        during the operation.
+
+        'progtrack' is an optional ProgressTracker object.
+        """
+
+        if self.version == self.CURRENT_VERSION:
+            # Already upgraded.
+            self.__upgraded = True
+
+            # If pre-upgrade data still exists; fire off a
+            # process to dump it so execution can continue.
+            orig_root = self.imgdir + ".old"
+            nullf = open(os.devnull, "w")
+            if os.path.exists(orig_root):
+                # Ensure all output is discarded; it really
+                # doesn't matter if this succeeds.
+                cmdargs = ["/usr/bin/rm", "-rf", orig_root]
+                subprocess.Popen(cmdargs, stdout=nullf, stderr=nullf)
+            nullf.close()
+            return False
+
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        # Not technically 'caching', but close enough ...
+        progtrack.cache_catalogs_start()
+
+        # Upgrade catalog data if needed.
+        self.__upgrade_catalogs()
+
+        # Data conversion finished.
+        self.__upgraded = True
+
+        # Determine if on-disk portion of the upgrade is allowed.
+        if self.allow_ondisk_upgrade == False:
+            return True
+
+        if self.allow_ondisk_upgrade is None and self.type != IMG_USER:
+            if not self.is_liveroot() and not self.is_zone():
+                # By default, don't update image format if it
+                # is not the live root, and is not for a zone.
+                self.allow_ondisk_upgrade = False
+                return True
+
+        # The logic to perform the on-disk upgrade is in its own
+        # function so that it can easily be wrapped with locking logic.
+        with self.locked_op(
+            "update-format", allow_unprivileged=allow_unprivileged
+        ):
+            self.__upgrade_image_format(
+                progtrack, allow_unprivileged=allow_unprivileged
+            )
+
+        progtrack.cache_catalogs_done()
+        return True
+
+    def __upgrade_catalogs(self):
+        """Private helper function for update_format."""
+
+        if self.version >= 3:
+            # Nothing to do.
+            return
+
+        def installed_file_publisher(filepath):
+            """Find the pkg's installed file named by filepath.
+            Return the publisher that installed this package."""
+
+            f = open(filepath)
+            try:
+                flines = f.readlines()
+                version, pub = flines
+                version = version.strip()
+                pub = pub.strip()
+                f.close()
+            except ValueError:
+                # If ValueError occurs, the installed file is of
+                # a previous format.  For upgrades to work, it's
+                # necessary to assume that the package was
+                # installed from the highest ranked publisher.
+                # Here, the publisher is setup to record that.
+                if flines:
+                    pub = flines[0]
+                    pub = pub.strip()
+                    newpub = "{0}_{1}".format(pkg.fmri.PREF_PUB_PFX, pub)
+                else:
+                    newpub = "{0}_{1}".format(
+                        pkg.fmri.PREF_PUB_PFX,
+                        self.get_highest_ranked_publisher(),
+                    )
+                pub = newpub
+            assert pub
+            return pub
+
+        # First, load the old package state information.
+        installed_state_dir = "{0}/state/installed".format(self.imgdir)
+
+        # If the state directory structure has already been created,
+        # loading information from it is fast.  The directory is
+        # populated with files, named by their (url-encoded) FMRI,
+        # which point to the "installed" file in the corresponding
+        # directory under /var/pkg.
+        installed = {}
+
+        def add_installed_entry(f):
+            path = "{0}/pkg/{1}/installed".format(self.imgdir, f.get_dir_path())
+            pub = installed_file_publisher(path)
+            f.set_publisher(pub)
+            installed[f.pkg_name] = f
+
+        for pl in os.listdir(installed_state_dir):
+            fmristr = "{0}".format(unquote(pl))
+            f = pkg.fmri.PkgFmri(fmristr)
+            add_installed_entry(f)
+
+        # Create the new image catalogs.
+        kcat = pkg.catalog.Catalog(
+            batch_mode=True, manifest_cb=self._manifest_cb, sign=False
+        )
+        icat = pkg.catalog.Catalog(
+            batch_mode=True, manifest_cb=self._manifest_cb, sign=False
+        )
+
+        # XXX For backwards compatibility, 'upgradability' of packages
+        # is calculated and stored based on whether a given pkg stem
+        # matches the newest version in the catalog.  This is quite
+        # expensive (due to overhead), but at least the cost is
+        # consolidated here.  This comparison is also cross-publisher,
+        # as it used to be.
+        newest = {}
+        old_pub_cats = []
+        for pub in self.gen_publishers():
+            try:
+                old_cat = pkg.server.catalog.ServerCatalog(
+                    pub.meta_root, read_only=True, publisher=pub.prefix
+                )
+
+                old_pub_cats.append((pub, old_cat))
+                for f in old_cat.fmris():
+                    nver = newest.get(f.pkg_name, None)
+                    newest[f.pkg_name] = max(nver, f.version)
+
+            except EnvironmentError as e:
+                # If a catalog file is just missing, ignore it.
+                # If there's a worse error, make sure the user
+                # knows about it.
+                if e.errno != errno.ENOENT:
+                    raise
+
+        # Next, load the existing catalog data and convert it.
+        pub_cats = []
+        for pub, old_cat in old_pub_cats:
+            new_cat = pub.catalog
+            new_cat.batch_mode = True
+            new_cat.sign = False
+            if new_cat.exists:
+                new_cat.destroy()
+
+            # First convert the old publisher catalog to
+            # the new format.
+            for f in old_cat.fmris():
+                new_cat.add_package(f)
+
+                # Now populate the image catalogs.
+                states = [pkgdefs.PKG_STATE_KNOWN, pkgdefs.PKG_STATE_V0]
+                mdata = {"states": states}
+                if f.version != newest[f.pkg_name]:
+                    states.append(pkgdefs.PKG_STATE_UPGRADABLE)
+
+                inst_fmri = installed.get(f.pkg_name, None)
+                if (
+                    inst_fmri
+                    and inst_fmri.version == f.version
+                    and pkg.fmri.is_same_publisher(
+                        f.publisher, inst_fmri.publisher
+                    )
+                ):
+                    states.append(pkgdefs.PKG_STATE_INSTALLED)
+                    if inst_fmri.preferred_publisher():
+                        # Strip the PREF_PUB_PFX.
+                        inst_fmri.set_publisher(inst_fmri.get_publisher())
+                    icat.add_package(f, metadata=mdata)
+                    del installed[f.pkg_name]
+                kcat.add_package(f, metadata=mdata)
+
+            # Normally, the Catalog's attributes are automatically
+            # populated as a result of catalog operations.  But in
+            # this case, the new Catalog's attributes should match
+            # those of the old catalog.
+            old_lm = old_cat.last_modified()
+            if old_lm:
+                # Can be None for empty v0 catalogs.
+                old_lm = pkg.catalog.ts_to_datetime(old_lm)
+            new_cat.last_modified = old_lm
+            new_cat.version = 0
+
+            # Add to the list of catalogs to save.
+            new_cat.batch_mode = False
+            pub_cats.append(new_cat)
+
+        # Discard the old catalog objects.
+        old_pub_cats = None
+
+        for f in installed.values():
+            # Any remaining FMRIs need to be added to all of the
+            # image catalogs.
+            states = [pkgdefs.PKG_STATE_INSTALLED, pkgdefs.PKG_STATE_V0]
+            mdata = {"states": states}
+            # This package may be installed from a publisher that
+            # is no longer known or has been disabled.
+            if f.pkg_name in newest and f.version != newest[f.pkg_name]:
+                states.append(pkgdefs.PKG_STATE_UPGRADABLE)
+
+            if f.preferred_publisher():
+                # Strip the PREF_PUB_PFX.
+                f.set_publisher(f.get_publisher())
+
+            icat.add_package(f, metadata=mdata)
+            kcat.add_package(f, metadata=mdata)
+
+        for cat in pub_cats + [kcat, icat]:
+            cat.finalize()
+
+        # Cache converted catalogs so that operations can function as
+        # expected if the on-disk format of the catalogs isn't upgraded.
+        self.__catalogs[self.IMG_CATALOG_KNOWN] = kcat
+        self.__catalogs[self.IMG_CATALOG_INSTALLED] = icat
+
+    def __upgrade_image_format(self, progtrack, allow_unprivileged=False):
+        """Private helper function for update_format."""
+
+        try:
+            # Ensure Image directory structure is valid.
+            self.mkdirs()
+        except apx.PermissionsException as e:
+            if not allow_unprivileged:
+                raise
+            # An unprivileged user is attempting to use the
+            # new client with an old image.  Since none of
+            # the changes can be saved, warn the user and
+            # then return.
+            #
+            # Raising an exception here would be a decidedly
+            # bad thing as it would disrupt find_root, etc.
+            return
+
+        # This has to be done after the permissions check above.
+        # First, create a new temporary root to store the converted
+        # image metadata.
+        tmp_root = self.imgdir + ".new"
+        try:
+            shutil.rmtree(tmp_root)
+        except EnvironmentError as e:
+            if e.errno in (errno.EROFS, errno.EPERM) and allow_unprivileged:
+                # Bail.
+                return
+            if e.errno != errno.ENOENT:
+                raise apx._convert_error(e)
+
+        try:
+            self.mkdirs(root=tmp_root, version=self.CURRENT_VERSION)
+        except apx.PermissionsException as e:
+            # Same handling needed as above; but not after this.
+            if not allow_unprivileged:
+                raise
+            return
+
+        def linktree(src_root, dest_root):
+            if not os.path.exists(src_root):
+                # Nothing to do.
+                return
+
+            for entry in os.listdir(src_root):
+                src = os.path.join(src_root, entry)
+                dest = os.path.join(dest_root, entry)
+                if os.path.isdir(src):
+                    # Recurse into directory to link
+                    # its contents.
+                    misc.makedirs(dest)
+                    linktree(src, dest)
+                    continue
+                # Link source file into target dest.
+                assert os.path.isfile(src)
                 try:
-                        slist = entry["metadata"]["sources"]
+                    os.link(src, dest)
+                except EnvironmentError as e:
+                    raise apx._convert_error(e)
+
+        # Next, link history data into place.
+        linktree(self.history.path, os.path.join(tmp_root, "history"))
+
+        # Next, link index data into place.
+        linktree(self.index_dir, os.path.join(tmp_root, "cache", "index"))
+
+        # Next, link ssl data into place.
+        linktree(
+            os.path.join(self.imgdir, "ssl"), os.path.join(tmp_root, "ssl")
+        )
+
+        # Next, write state data into place.
+        if self.version < 3:
+            # Image state and publisher metadata
+            tmp_state_root = os.path.join(tmp_root, "state")
+
+            # Update image catalog locations.
+            kcat = self.get_catalog(self.IMG_CATALOG_KNOWN)
+            icat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+            kcat.meta_root = os.path.join(
+                tmp_state_root, self.IMG_CATALOG_KNOWN
+            )
+            icat.meta_root = os.path.join(
+                tmp_state_root, self.IMG_CATALOG_INSTALLED
+            )
+
+            # Assume that since mkdirs succeeded that the remaining
+            # data can be saved and the image structure can be
+            # upgraded.  But first, attempt to save the image
+            # catalogs.
+            for cat in icat, kcat:
+                misc.makedirs(cat.meta_root)
+                cat.save()
+        else:
+            # For version 3 and newer images, just link existing
+            # state information into place.
+            linktree(self._statedir, os.path.join(tmp_root, "state"))
+
+        # Reset each publisher's meta_root and ensure its complete
+        # directory structure is intact.  Then either link in or
+        # write out the metadata for each publisher.
+        for pub in self.gen_publishers():
+            old_root = pub.meta_root
+            old_cat_root = pub.catalog_root
+            old_cert_root = pub.cert_root
+            pub.meta_root = os.path.join(tmp_root, IMG_PUB_DIR, pub.prefix)
+            pub.create_meta_root()
+
+            if self.version < 3:
+                # Should be loaded in memory and transformed
+                # already, so just need to be written out.
+                pub.catalog.save()
+                continue
+
+            # Now link any catalog or cert files from the old root
+            # into the new root.
+            linktree(old_cat_root, pub.catalog_root)
+            linktree(old_cert_root, pub.cert_root)
+
+            # Finally, create a directory for the publisher's
+            # manifests to live in.
+            misc.makedirs(os.path.join(pub.meta_root, "pkg"))
+
+        # Next, link licenses and manifests of installed packages into
+        # new image dir.
+        for pfmri in self.gen_installed_pkgs():
+            # Link licenses.
+            mdir = self.get_manifest_dir(pfmri)
+            for entry in os.listdir(mdir):
+                if not entry.startswith("license."):
+                    continue
+                src = os.path.join(mdir, entry)
+                if os.path.isdir(src):
+                    # Ignore broken licenses.
+                    continue
+
+                # For conversion, ensure destination link uses
+                # encoded license name to match how new image
+                # format stores licenses.
+                dest = os.path.join(
+                    tmp_root,
+                    "license",
+                    pfmri.get_dir_path(stemonly=True),
+                    quote(entry, ""),
+                )
+                misc.makedirs(os.path.dirname(dest))
+                try:
+                    os.link(src, dest)
+                except EnvironmentError as e:
+                    raise apx._convert_error(e)
+
+            # Link manifest.
+            src = self.get_manifest_path(pfmri)
+            dest = os.path.join(
+                tmp_root,
+                "publisher",
+                pfmri.publisher,
+                "pkg",
+                pfmri.get_dir_path(),
+            )
+            misc.makedirs(os.path.dirname(dest))
+            try:
+                os.link(src, dest)
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+
+        # Next, copy the old configuration into the new location using
+        # the new name.  The configuration is copied instead of being
+        # linked so that any changes to configuration as a result of
+        # the upgrade won't be written into the old image directory.
+        src = os.path.join(self.imgdir, "disabled_auth")
+        if os.path.exists(src):
+            dest = os.path.join(tmp_root, "disabled_auth")
+            portable.copyfile(src, dest)
+
+        src = self.cfg.target
+        dest = os.path.join(tmp_root, "pkg5.image")
+        try:
+            portable.copyfile(src, dest)
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+
+        # Update the new configuration's version information and then
+        # write it out again.
+        newcfg = imageconfig.ImageConfig(
+            dest,
+            tmp_root,
+            version=3,
+            overrides={"image": {"version": self.CURRENT_VERSION}},
+        )
+        newcfg._version = 3
+        newcfg.write()
+
+        # Now reload configuration and write again to configuration data
+        # reflects updated version information.
+        newcfg.reset()
+        newcfg.write()
+
+        # Finally, rename the old package metadata directory, then
+        # rename the new one into place, and then reinitialize.  The
+        # old data will be dumped during initialization.
+        orig_root = self.imgdir + ".old"
+        try:
+            portable.rename(self.imgdir, orig_root)
+            portable.rename(tmp_root, self.imgdir)
+
+            # /var/pkg/repo is renamed into place instead of being
+            # linked piece-by-piece for performance reasons.
+            # Crawling the entire tree structure of a repository is
+            # far slower than simply renaming the top level
+            # directory (since it often has thousands or millions
+            # of objects).
+            old_repo = os.path.join(orig_root, "repo")
+            if os.path.exists(old_repo):
+                new_repo = os.path.join(tmp_root, "repo")
+                portable.rename(old_repo, new_repo)
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+        self.find_root(self.root, exact_match=True, progtrack=progtrack)
+
+    def create(
+        self,
+        pubs,
+        facets=EmptyDict,
+        is_zone=False,
+        progtrack=None,
+        props=EmptyDict,
+        refresh_allowed=True,
+        variants=EmptyDict,
+    ):
+        """Creates a new image with the given attributes if it does not
+        exist; should not be used with an existing image.
+
+        'is_zone' is a boolean indicating whether the image is a zone.
+
+        'pubs' is a list of Publisher objects to configure the image
+        with.
+
+        'refresh_allowed' is an optional boolean indicating that
+        network operations (such as publisher data retrieval) are
+        allowed.
+
+        'progtrack' is an optional ProgressTracker object.
+
+        'props' is an option dictionary mapping image property names to
+        values.
+
+        'variants' is an optional dictionary of variant names and
+        values.
+
+        'facets' is an optional dictionary of facet names and values.
+        """
+
+        for p in pubs:
+            p.meta_root = self._get_publisher_meta_root(p.prefix)
+            p.transport = self.transport
+
+        # Override any initial configuration information.
+        self.set_properties(props)
+
+        # Start the operation.
+        self.history.log_operation_start("image-create")
+
+        # Determine and add the default variants for the image.
+        if is_zone:
+            self.cfg.variants["variant.opensolaris.zone"] = "nonglobal"
+        else:
+            self.cfg.variants["variant.opensolaris.zone"] = "global"
+
+        self.cfg.variants["variant.arch"] = variants.get(
+            "variant.arch", platform.processor()
+        )
+
+        # After setting up the default variants, add any overrides or
+        # additional variants or facets specified.
+        self.cfg.variants.update(variants)
+        self.cfg.facets.update(facets)
+
+        # Now everything is ready for publisher configuration.
+        # Since multiple publishers are allowed, they are all
+        # added at once without any publisher data retrieval.
+        # A single retrieval is then performed afterwards, if
+        # allowed, to minimize the amount of work the client
+        # needs to perform.
+        for p in pubs:
+            self.add_publisher(p, refresh_allowed=False, progtrack=progtrack)
+
+        if refresh_allowed:
+            self.refresh_publishers(
+                progtrack=progtrack, full_refresh=True, ignore_unreachable=False
+            )
+        else:
+            # initialize empty catalogs on disk
+            self.__rebuild_image_catalogs(progtrack=progtrack)
+
+        self.cfg.set_property(
+            "property", "publisher-search-order", [p.prefix for p in pubs]
+        )
+
+        # Ensure publisher search order is written.
+        self.save_config()
+
+        self.history.log_operation_end()
+
+    @staticmethod
+    def __allow_liveroot():
+        """Check if we're allowed to access the current live root
+        image."""
+
+        # if we're simulating a live root then allow access to it
+        if (
+            DebugValues.get_value("simulate_live_root")
+            or "PKG_LIVE_ROOT" in os.environ
+        ):
+            return True
+
+        # check if the user disabled access to the live root
+        if DebugValues.get_value("simulate_no_live_root"):
+            return False
+        if "PKG_NO_LIVE_ROOT" in os.environ:
+            return False
+
+        # by default allow access to the live root
+        return True
+
+    def is_liveroot(self):
+        return bool(self.root == misc.liveroot())
+
+    def is_zone(self):
+        return self.cfg.variants["variant.opensolaris.zone"] == "nonglobal"
+
+    def get_arch(self):
+        return self.cfg.variants["variant.arch"]
+
+    def has_boot_archive(self):
+        """Returns True if a boot_archive is present in this image"""
+        if self.__boot_archive is not None:
+            return self.__boot_archive
+
+        for p in [
+            "platform/i86pc/amd64/boot_archive",
+            "platform/i86pc/boot_archive",
+            "platform/sun4u/boot_archive",
+            "platform/sun4v/boot_archive",
+        ]:
+            if os.path.isfile(os.path.join(self.root, p)):
+                self.__boot_archive = True
+                break
+        else:
+            self.__boot_archive = False
+        return self.__boot_archive
+
+    def get_ramdisk_filelist(self):
+        """return the filelist... add the filelist so we rebuild
+        boot archive if it changes... append trailing / to
+        directories that are really there"""
+
+        p = "boot/solaris/filelist.ramdisk"
+        f = os.path.join(self.root, p)
+
+        def addslash(path):
+            if os.path.isdir(os.path.join(self.root, path)):
+                return path + "/"
+            return path
+
+        if not os.path.isfile(f):
+            return []
+
+        return [addslash(l.strip()) for l in open(f)] + [p]
+
+    def get_cachedirs(self):
+        """Returns a list of tuples of the form (dir, readonly, pub,
+        layout) where 'dir' is the absolute path of the cache directory,
+        'readonly' is a boolean indicating whether the cache can
+        be written to, 'pub' is the prefix of the publisher that
+        the cache directory should be used for, and 'layout' is a
+        FileManager object used to access file content in the cache.
+        If 'pub' is None, the cache directory is intended for all
+        publishers.  If 'layout' is None, file content layout can
+        vary.
+        """
+
+        file_layout = None
+        if self.version >= 4:
+            # Assume cache directories are in V1 Layout if image
+            # format is v4+.
+            file_layout = fl.V1Layout()
+
+        # Get all readonly cache directories.
+        cdirs = [
+            (cdir, True, None, file_layout) for cdir in self.__read_cache_dirs
+        ]
+
+        # Get global write cache directory.
+        if self.__write_cache_dir:
+            cdirs.append((self.__write_cache_dir, False, None, file_layout))
+
+        # For images newer than version 3, file data can be stored
+        # in the publisher's file root.
+        if self.version == self.CURRENT_VERSION:
+            for pub in self.gen_publishers(inc_disabled=True):
+                froot = os.path.join(pub.meta_root, "file")
+                readonly = False
+                if self.__write_cache_dir or self.__write_cache_root:
+                    readonly = True
+                cdirs.append((froot, readonly, pub.prefix, file_layout))
+
+                if self.__write_cache_root:
+                    # Cache is a tree structure like
+                    # /var/pkg/publisher.
+                    froot = os.path.join(
+                        self.__write_cache_root, pub.prefix, "file"
+                    )
+                    cdirs.append((froot, False, pub.prefix, file_layout))
+
+        return cdirs
+
+    def get_root(self):
+        return self.root
+
+    def get_last_modified(self, string=False):
+        """Return the UTC time of the image's last state change or
+        None if unknown.  By default the time is returned via datetime
+        object.  If 'string' is true and a time is available, then the
+        time is returned as a string (instead of as a datetime
+        object)."""
+
+        # Always get last_modified time from known catalog.  It's
+        # retrieved from the catalog itself since that is accurate
+        # down to the micrsecond (as opposed to the filesystem which
+        # has an OS-specific resolution).
+        rv = self.__get_catalog(self.IMG_CATALOG_KNOWN).last_modified
+        if rv is None or not string:
+            return rv
+        return rv.strftime("%Y-%m-%dT%H:%M:%S.%f")
+
+    def gen_publishers(self, inc_disabled=False):
+        if not self.cfg:
+            raise apx.ImageCfgEmptyError(self.root)
+
+        alt_pubs = {}
+        if self.__alt_pkg_pub_map:
+            alt_src_pubs = dict((p.prefix, p) for p in self.__alt_pubs)
+
+            for pfx in self.__alt_known_cat.publishers():
+                # Include alternate package source publishers
+                # in result, and temporarily enable any
+                # disabled publishers that already exist in
+                # the image configuration.
+                try:
+                    img_pub = self.cfg.publishers[pfx]
+
+                    if not img_pub.disabled:
+                        # No override needed.
+                        continue
+                    new_pub = copy.copy(img_pub)
+                    new_pub.disabled = False
+
+                    # Discard origins and mirrors to prevent
+                    # their accidental use.
+                    repo = new_pub.repository
+                    repo.reset_origins()
+                    repo.reset_mirrors()
                 except KeyError:
-                        # Can be retrieved from any source.
-                        return
-                else:
-                        if not slist:
-                                # Can be retrieved from any source.
-                                return
+                    new_pub = alt_src_pubs[pfx]
 
-                pub = self.get_publisher(prefix=pfmri.publisher)
-                repo = copy.copy(pub.repository)
-                norigins = [
-                    o for o in repo.origins
-                    if o.uri in slist
-                ]
+                alt_pubs[pfx] = new_pub
 
-                if not norigins:
-                        # Known sources don't match configured; return so that
-                        # caller can fallback to default behaviour.
-                        return
+        publishers = [
+            alt_pubs.get(p.prefix, p) for p in self.cfg.publishers.values()
+        ]
+        publishers.extend((p for p in alt_pubs.values() if p not in publishers))
 
-                repo.origins = norigins
-                return repo
+        for pub in publishers:
+            # Prepare publishers for transport usage; this must be
+            # done each time so that information reflects current
+            # image state.  This is done whether or not the
+            # publisher is returned so that in-memory state is
+            # always current.
+            pub.meta_root = self._get_publisher_meta_root(pub.prefix)
+            pub.transport = self.transport
+            if inc_disabled or not pub.disabled:
+                yield pub
 
-        def get_pkg_state(self, pfmri):
-                """Returns the list of states a package is in for this image."""
+    def get_publisher_ranks(self):
+        """Return dictionary of configured + enabled publishers and
+        unconfigured publishers which still have packages installed.
 
-                cat = self.get_catalog(self.IMG_CATALOG_KNOWN)
-                entry = cat.get_entry(pfmri)
-                if entry is None:
-                        return []
-                return entry["metadata"]["states"]
+        Each entry contains a tuple of search order index starting at
+        0, and a boolean indicating whether or not this publisher is
+        "sticky", and a boolean indicating whether or not the
+        publisher is enabled"""
 
-        def is_pkg_installed(self, pfmri):
-                """Returns a boolean value indicating whether the specified
-                package is installed."""
+        pubs = self.get_sorted_publishers(inc_disabled=False)
+        ret = dict(
+            [
+                (pubs[i].prefix, (i, pubs[i].sticky, True))
+                for i in range(0, len(pubs))
+            ]
+        )
 
-                # Avoid loading the installed catalog if the known catalog
-                # is already loaded.  This is safe since the installed
-                # catalog is a subset of the known, and a specific entry
-                # is being retrieved.
-                if not self.__catalog_loaded(self.IMG_CATALOG_KNOWN):
-                        cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-                else:
-                        cat = self.get_catalog(self.IMG_CATALOG_KNOWN)
+        # Add any publishers for pkgs that are installed,
+        # but have been deleted. These publishers are implicitly
+        # not-sticky and disabled.
+        for pub in self.get_installed_pubs():
+            i = len(ret)
+            ret.setdefault(pub, (i, False, False))
+        return ret
 
-                entry = cat.get_entry(pfmri)
-                if entry is None:
-                        return False
-                states = entry["metadata"]["states"]
-                return pkgdefs.PKG_STATE_INSTALLED in states
+    def get_highest_ranked_publisher(self):
+        """Return the highest ranked publisher."""
 
-        def list_excludes(self, new_variants=None, new_facets=None):
-                """Generate a list of callables that each return True if an
-                action is to be included in the image using the currently
-                defined variants & facets for the image, or an updated set if
-                new_variants or new_facets are specified."""
+        pubs = self.cfg.get_property("property", "publisher-search-order")
+        if pubs:
+            return self.get_publisher(prefix=pubs[0])
+        for p in self.gen_publishers():
+            return p
+        for p in self.get_installed_pubs():
+            return publisher.Publisher(p)
+        return None
 
-                if new_variants:
-                        new_vars = self.cfg.variants.copy()
-                        new_vars.update(new_variants)
-                        var_call = new_vars.allow_action
-                else:
-                        var_call = self.cfg.variants.allow_action
-                if new_facets is not None:
-                        fac_call = new_facets.allow_action
-                else:
-                        fac_call = self.cfg.facets.allow_action
+    def check_cert_validity(self, pubs=EmptyI):
+        """Validate the certificates of the specified publishers.
 
-                return [var_call, fac_call]
+        Raise an exception if any of the certificates has expired or
+        is close to expiring."""
 
-        def get_variants(self):
-                """ return a copy of the current image variants"""
-                return self.cfg.variants.copy()
+        if not pubs:
+            pubs = self.gen_publishers()
 
-        def get_facets(self):
-                """ Return a copy of the current image facets"""
-                return self.cfg.facets.copy()
+        errors = []
+        for p in pubs:
+            r = p.repository
+            for uri in r.origins:
+                if uri.ssl_cert:
+                    try:
+                        misc.validate_ssl_cert(
+                            uri.ssl_cert, prefix=p.prefix, uri=uri
+                        )
+                    except apx.ExpiredCertificate as e:
+                        errors.append(e)
 
-        def __state_updating_pathname(self):
-                """Return the path to a flag file indicating that the image
-                catalog is being updated."""
-                return os.path.join(self._statedir, self.__STATE_UPDATING_FILE)
+                if uri.ssl_key:
+                    try:
+                        if not os.path.exists(uri.ssl_key):
+                            raise apx.NoSuchKey(
+                                uri.ssl_key, publisher=p, uri=uri
+                            )
+                    except EnvironmentError as e:
+                        raise apx._convert_error(e)
 
-        def __start_state_update(self):
-                """Called when we start updating the image catalog.  Normally
-                returns False, but will return True if a previous update was
-                interrupted."""
+        if errors:
+            raise apx.ExpiredCertificates(errors)
 
-                # get the path to the image catalog update flag file
-                pathname = self.__state_updating_pathname()
+    def has_publisher(self, prefix=None, alias=None):
+        """Returns a boolean value indicating whether a publisher
+        exists in the image configuration that matches the given
+        prefix or alias."""
+        for pub in self.gen_publishers(inc_disabled=True):
+            if prefix == pub.prefix or (alias and alias == pub.alias):
+                return True
+        return False
 
-                # if the flag file exists a previous update was interrupted so
-                # return 1
-                if os.path.exists(pathname):
-                        return True
+    def remove_publisher(self, prefix=None, alias=None, progtrack=None):
+        """Removes the publisher with the matching identity from the
+        image."""
 
-                # create the flag file and return 0
-                file_mode = misc.PKG_FILE_MODE
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        with self.locked_op("remove-publisher"):
+            pub = self.get_publisher(prefix=prefix, alias=alias)
+
+            self.cfg.remove_publisher(pub.prefix)
+            self.remove_publisher_metadata(pub, progtrack=progtrack)
+            self.save_config()
+
+    def get_publishers(self, inc_disabled=True):
+        """Return a dictionary of configured publishers.  This doesn't
+        include unconfigured publishers which still have packages
+        installed."""
+
+        return dict(
+            (p.prefix, p)
+            for p in self.gen_publishers(inc_disabled=inc_disabled)
+        )
+
+    def get_sorted_publishers(self, inc_disabled=True):
+        """Return a list of configured publishers sorted by rank.
+        This doesn't include unconfigured publishers which still have
+        packages installed."""
+
+        d = self.get_publishers(inc_disabled=inc_disabled)
+        names = self.cfg.get_property("property", "publisher-search-order")
+
+        #
+        # If someone has been editing the config file we may have
+        # unranked publishers.  Also, as publisher come and go via the
+        # sysrepo we can end up with configured but unranked
+        # publishers.  In either case just sort unranked publishers
+        # alphabetically.
+        #
+        unranked = set(d) - set(names)
+        ret = [d[n] for n in names if n in d] + [d[n] for n in sorted(unranked)]
+        return ret
+
+    def get_publisher(self, prefix=None, alias=None, origin=None):
+        for pub in self.gen_publishers(inc_disabled=True):
+            if prefix and prefix == pub.prefix:
+                return pub
+            elif alias and alias == pub.alias:
+                return pub
+            elif (
+                origin and pub.repository and pub.repository.has_origin(origin)
+            ):
+                return pub
+
+        if prefix is None and alias is None and origin is None:
+            raise apx.UnknownPublisher(None)
+
+        raise apx.UnknownPublisher(
+            max(i for i in [prefix, alias, origin] if i is not None)
+        )
+
+    def pub_search_before(self, being_moved, staying_put):
+        """Moves publisher "being_moved" to before "staying_put"
+        in search order.
+
+        The caller is responsible for locking the image."""
+
+        self.cfg.change_publisher_search_order(
+            being_moved, staying_put, after=False
+        )
+
+    def pub_search_after(self, being_moved, staying_put):
+        """Moves publisher "being_moved" to after "staying_put"
+        in search order.
+
+        The caller is responsible for locking the image."""
+
+        self.cfg.change_publisher_search_order(
+            being_moved, staying_put, after=True
+        )
+
+    def __apply_alt_pkg_sources(self, img_kcat):
+        pkg_pub_map = self.__alt_pkg_pub_map
+        if not pkg_pub_map or self.__alt_pkg_sources_loaded:
+            # No alternate sources to merge.
+            return
+
+        # Temporarily merge the package metadata in the alternate
+        # known package catalog for packages not listed in the
+        # image's known catalog.
+        def merge_check(alt_kcat, pfmri, new_entry):
+            states = new_entry["metadata"]["states"]
+            if pkgdefs.PKG_STATE_INSTALLED in states:
+                # Not interesting; already installed.
+                return False, None
+            img_entry = img_kcat.get_entry(pfmri=pfmri)
+            if not img_entry is None:
+                # Already in image known catalog.
+                return False, None
+            return True, new_entry
+
+        img_kcat.append(self.__alt_known_cat, cb=merge_check)
+        img_kcat.finalize()
+
+        self.__alt_pkg_sources_loaded = True
+        self.transport.cfg.pkg_pub_map = self.__alt_pkg_pub_map
+        self.transport.cfg.alt_pubs = self.__alt_pubs
+        self.transport.cfg.reset_caches()
+
+    def __cleanup_alt_pkg_certs(self):
+        """Private helper function to cleanup package certificate
+        information after use of temporary package data."""
+
+        if not self.__alt_pubs:
+            return
+
+        # Cleanup publisher cert information; any certs not retrieved
+        # retrieved during temporary publisher use need to be expunged
+        # from the image configuration.
+        for pub in self.__alt_pubs:
+            try:
+                ipub = self.cfg.publishers[pub.prefix]
+            except KeyError:
+                # Nothing to do.
+                continue
+
+    def set_alt_pkg_sources(self, alt_sources):
+        """Specifies an alternate source of package metadata to be
+        temporarily merged with image state so that it can be used
+        as part of packaging operations."""
+
+        if not alt_sources:
+            self.__init_catalogs()
+            self.__alt_pkg_pub_map = None
+            self.__alt_pubs = None
+            self.__alt_known_cat = None
+            self.__alt_pkg_sources_loaded = False
+            self.transport.cfg.pkg_pub_map = None
+            self.transport.cfg.alt_pubs = None
+            self.transport.cfg.reset_caches()
+            return
+        elif self.__alt_pkg_sources_loaded:
+            # Ensure existing alternate package source data
+            # is not part of temporary image state.
+            self.__init_catalogs()
+
+        pkg_pub_map, alt_pubs, alt_kcat, ignored = alt_sources
+        self.__alt_pkg_pub_map = pkg_pub_map
+        self.__alt_pubs = alt_pubs
+        self.__alt_known_cat = alt_kcat
+
+    def set_highest_ranked_publisher(self, prefix=None, alias=None, pub=None):
+        """Sets the preferred publisher for packaging operations.
+
+        'prefix' is an optional string value specifying the name of
+        a publisher; ignored if 'pub' is provided.
+
+        'alias' is an optional string value specifying the alias of
+        a publisher; ignored if 'pub' is provided.
+
+        'pub' is an optional Publisher object identifying the
+        publisher to set as the preferred publisher.
+
+        One of the above parameters must be provided.
+
+        The caller is responsible for locking the image."""
+
+        if not pub:
+            pub = self.get_publisher(prefix=prefix, alias=alias)
+        if not self.cfg.allowed_to_move(pub):
+            raise apx.ModifyingSyspubException(
+                _(
+                    "Publisher '{0}' "
+                    "is a system publisher and cannot be "
+                    "moved."
+                ).format(pub)
+            )
+
+        pubs = self.get_sorted_publishers()
+        relative = None
+        for p in pubs:
+            # If we've gotten to the publisher we want to make
+            # highest ranked, then there's nothing to do because
+            # it's already as high as it can be.
+            if p == pub:
+                return
+            if self.cfg.allowed_to_move(p):
+                relative = p
+                break
+        assert relative, (
+            "Expected {0} to already be part of the "
+            + "search order:{1}".format(relative, ranks)
+        )
+        self.cfg.change_publisher_search_order(
+            pub.prefix, relative.prefix, after=False
+        )
+
+    def set_property(self, prop_name, prop_value):
+        with self.locked_op("set-property"):
+            self.cfg.set_property("property", prop_name, prop_value)
+            self.save_config()
+
+    def set_properties(self, properties):
+        properties = {"property": properties}
+        with self.locked_op("set-property"):
+            self.cfg.set_properties(properties)
+            self.save_config()
+
+    def get_property(self, prop_name):
+        return self.cfg.get_property("property", prop_name)
+
+    def has_property(self, prop_name):
+        try:
+            self.cfg.get_property("property", prop_name)
+            return True
+        except cfg.ConfigError:
+            return False
+
+    def delete_property(self, prop_name):
+        with self.locked_op("unset-property"):
+            self.cfg.remove_property("property", prop_name)
+            self.save_config()
+
+    def add_property_value(self, prop_name, prop_value):
+        with self.locked_op("add-property-value"):
+            self.cfg.add_property_value("property", prop_name, prop_value)
+            self.save_config()
+
+    def remove_property_value(self, prop_name, prop_value):
+        with self.locked_op("remove-property-value"):
+            self.cfg.remove_property_value("property", prop_name, prop_value)
+            self.save_config()
+
+    def destroy(self):
+        """Destroys the image; image object should not be used
+        afterwards."""
+
+        if not self.imgdir or not os.path.exists(self.imgdir):
+            return
+
+        if os.path.abspath(self.imgdir) == "/":
+            # Paranoia.
+            return
+
+        try:
+            shutil.rmtree(self.imgdir)
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+
+    def properties(self):
+        if not self.cfg:
+            raise apx.ImageCfgEmptyError(self.root)
+        return list(self.cfg.get_index()["property"].keys())
+
+    def add_publisher(
+        self,
+        pub,
+        refresh_allowed=True,
+        progtrack=None,
+        approved_cas=EmptyI,
+        revoked_cas=EmptyI,
+        search_after=None,
+        search_before=None,
+        search_first=None,
+        unset_cas=EmptyI,
+    ):
+        """Adds the provided publisher object to the image
+        configuration.
+
+        'refresh_allowed' is an optional, boolean value indicating
+        whether the publisher's metadata should be retrieved when adding
+        it to the image's configuration.
+
+        'progtrack' is an optional ProgressTracker object."""
+
+        with self.locked_op("add-publisher"):
+            return self.__add_publisher(
+                pub,
+                refresh_allowed=refresh_allowed,
+                progtrack=progtrack,
+                approved_cas=EmptyI,
+                revoked_cas=EmptyI,
+                search_after=search_after,
+                search_before=search_before,
+                search_first=search_first,
+                unset_cas=EmptyI,
+            )
+
+    def __update_publisher_catalogs(
+        self, pub, progtrack=None, refresh_allowed=True
+    ):
+        # Ensure that if the publisher's meta directory already
+        # exists for some reason that the data within is not
+        # used.
+        self.remove_publisher_metadata(pub, progtrack=progtrack, rebuild=False)
+
+        repo = pub.repository
+        if refresh_allowed and repo.origins:
+            try:
+                # First, verify that the publisher has a
+                # valid pkg(7) repository.
+                self.transport.valid_publisher_test(pub)
+                pub.validate_config()
+                self.refresh_publishers(
+                    pubs=[pub], progtrack=progtrack, ignore_unreachable=False
+                )
+            except Exception as e:
+                # Remove the newly added publisher since
+                # it is invalid or the retrieval failed.
+                if not pub.sys_pub:
+                    self.cfg.remove_publisher(pub.prefix)
+                raise
+            except:
+                # Remove the newly added publisher since
+                # the retrieval failed.
+                if not pub.sys_pub:
+                    self.cfg.remove_publisher(pub.prefix)
+                raise
+
+    def __add_publisher(
+        self,
+        pub,
+        refresh_allowed=True,
+        progtrack=None,
+        approved_cas=EmptyI,
+        revoked_cas=EmptyI,
+        search_after=None,
+        search_before=None,
+        search_first=None,
+        unset_cas=EmptyI,
+    ):
+        """Private version of add_publisher(); caller is responsible
+        for locking."""
+
+        assert (
+            (not search_after and not search_before)
+            or (not search_after and not search_first)
+            or (not search_before and not search_first)
+        )
+
+        if self.version < self.CURRENT_VERSION:
+            raise apx.ImageFormatUpdateNeeded(self.root)
+
+        for p in self.cfg.publishers.values():
+            if (
+                pub.prefix == p.prefix
+                or pub.prefix == p.alias
+                or pub.alias
+                and (pub.alias == p.alias or pub.alias == p.prefix)
+            ):
+                raise apx.DuplicatePublisher(pub)
+
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        # Must assign this first before performing operations.
+        pub.meta_root = self._get_publisher_meta_root(pub.prefix)
+        pub.transport = self.transport
+
+        # Before continuing, validate SSL information.
+        try:
+            self.check_cert_validity(pubs=[pub])
+        except apx.ExpiringCertificate as e:
+            logger.error(str(e))
+
+        self.cfg.publishers[pub.prefix] = pub
+
+        self.__update_publisher_catalogs(
+            pub, progtrack=progtrack, refresh_allowed=refresh_allowed
+        )
+
+        for ca in approved_cas:
+            try:
+                ca = os.path.abspath(ca)
+                fh = open(ca, "r")
+                s = fh.read()
+                fh.close()
+            except EnvironmentError as e:
+                if e.errno == errno.ENOENT:
+                    raise apx.MissingFileArgumentException(ca)
+                raise apx._convert_error(e)
+            pub.approve_ca_cert(s, manual=True)
+
+        for hsh in revoked_cas:
+            pub.revoke_ca_cert(hsh)
+
+        for hsh in unset_cas:
+            pub.unset_ca_cert(hsh)
+
+        if search_first:
+            self.set_highest_ranked_publisher(prefix=pub.prefix)
+        elif search_before:
+            self.pub_search_before(pub.prefix, search_before)
+        elif search_after:
+            self.pub_search_after(pub.prefix, search_after)
+
+        # Only after success should the configuration be saved.
+        self.save_config()
+
+    def __process_verify(
+        self,
+        act,
+        path,
+        path_only,
+        fmri,
+        excludes,
+        vardrate_excludes,
+        progresstracker,
+        verifypaths=None,
+        overlaypaths=None,
+        **kwargs,
+    ):
+        errors = []
+        warnings = []
+        info = []
+        if act.include_this(excludes, publisher=fmri.publisher):
+            if not path_only:
+                errors, warnings, info = act.verify(self, pfmri=fmri, **kwargs)
+            elif path in verifypaths or path in overlaypaths:
+                if path in verifypaths:
+                    progresstracker.plan_add_progress(
+                        progresstracker.PLAN_PKG_VERIFY
+                    )
+
+                errors, warnings, info = act.verify(self, pfmri=fmri, **kwargs)
+                # It's safe to immediately discard this
+                # match as only one action can deliver a
+                # path with overlay=allow and only one with
+                # overlay=true.
+                overlaypaths.discard(path)
+                if act.attrs.get("overlay") == "allow":
+                    overlaypaths.add(path)
+                verifypaths.discard(path)
+        elif (
+            act.include_this(vardrate_excludes, publisher=fmri.publisher)
+            and not act.refcountable
+        ):
+            # Verify that file that is faceted out does not
+            # exist. Exclude actions which may be delivered
+            # from multiple packages.
+            if path is not None and os.path.exists(
+                os.path.join(self.root, path)
+            ):
+                errors.append(_("File should not exist"))
+        else:
+            # Action that is not applicable to image variant
+            # or has been dehydrated.
+            return None, None, None, True
+        return errors, warnings, info, False
+
+    def verify(
+        self,
+        fmri,
+        progresstracker,
+        verifypaths=None,
+        overlaypaths=None,
+        single_act=None,
+        **kwargs,
+    ):
+        """Generator that returns a tuple of the form (action, errors,
+        warnings, info) if there are any error, warning, or other
+        messages about an action contained within the specified
+        package.  Where the returned messages are lists of strings
+        indicating fatal problems, potential issues (that can be
+        ignored), or extra information to be displayed respectively.
+
+        'fmri' is the fmri of the package to verify.
+
+        'progresstracker' is a ProgressTracker object.
+
+        'verifypaths' is the set of paths to verify.
+
+        'overlaypaths' is the set of overlaying path to verify.
+
+        'single_act' is the only action of the specified fmri to
+         verify.
+
+        'kwargs' is a dict of additional keyword arguments to be passed
+        to each action verification routine."""
+
+        path_only = bool(verifypaths or overlaypaths)
+        # pkg verify only looks at actions that have not been dehydrated.
+        excludes = self.list_excludes()
+        vardrate_excludes = [self.cfg.variants.allow_action]
+        dehydrate = self.cfg.get_property("property", "dehydrated")
+        if dehydrate:
+            func = self.get_dehydrated_exclude_func(dehydrate)
+            excludes.append(func)
+            vardrate_excludes.append(func)
+
+        # If single_act is set, only that action will be processed.
+        if single_act:
+            overlay = None
+            if single_act.attrs.get("overlay") == "allow":
+                overlay = "overlaid"
+            elif single_act.attrs.get("overlay") == "true":
+                overlay = "overlaying"
+            progresstracker.plan_add_progress(
+                progresstracker.PLAN_PKG_VERIFY, nitems=0
+            )
+            path = single_act.attrs.get("path")
+            errors, warnings, info, ignore = self.__process_verify(
+                single_act,
+                path,
+                path_only,
+                fmri,
+                excludes,
+                vardrate_excludes,
+                progresstracker,
+                verifypaths=verifypaths,
+                overlaypaths=overlaypaths,
+                **kwargs,
+            )
+            if (errors or warnings or info) and not ignore:
+                yield single_act, errors, warnings, info, overlay
+            return
+
+        try:
+            pub = self.get_publisher(prefix=fmri.publisher)
+        except apx.UnknownPublisher:
+            # Since user removed publisher, assume this is the same
+            # as if they had set signature-policy ignore for the
+            # publisher.
+            sig_pol = None
+        else:
+            sig_pol = self.signature_policy.combine(pub.signature_policy)
+
+        if not path_only:
+            progresstracker.plan_add_progress(progresstracker.PLAN_PKG_VERIFY)
+
+        manf = self.get_manifest(fmri, ignore_excludes=True)
+        sigs = list(
+            manf.gen_actions_by_type("signature", excludes=self.list_excludes())
+        )
+        if sig_pol and (sigs or sig_pol.name != "ignore"):
+            # Only perform signature verification logic if there are
+            # signatures or if signature-policy is not 'ignore'.
+            try:
+                # Signature verification must be done using all
+                # the actions from the manifest, not just the
+                # ones for this image's variants.
+                sig_pol.process_signatures(
+                    sigs,
+                    manf.gen_actions(),
+                    pub,
+                    self.trust_anchors,
+                    self.cfg.get_policy("check-certificate-revocation"),
+                )
+            except apx.SigningException as e:
+                e.pfmri = fmri
+                yield e.sig, [e], [], [], None
+            except apx.InvalidResourceLocation as e:
+                yield None, [e], [], [], None
+
+        def mediation_allowed(act):
+            """Helper function to determine if the mediation
+            delivered by a link is allowed.  If it is, then
+            the link should be verified.  (Yes, this does mean
+            that the non-existence of links is not verified.)
+            """
+
+            mediator = act.attrs.get("mediator")
+            if not mediator or mediator not in self.cfg.mediators:
+                # Link isn't mediated or mediation is unknown.
+                return True
+
+            cfg_med_version = self.cfg.mediators[mediator].get("version")
+            cfg_med_impl = self.cfg.mediators[mediator].get("implementation")
+
+            med_version = act.attrs.get("mediator-version")
+            if med_version:
+                med_version = pkg.version.Version(med_version)
+            med_impl = act.attrs.get("mediator-implementation")
+
+            return med_version == cfg_med_version and med.mediator_impl_matches(
+                med_impl, cfg_med_impl
+            )
+
+        for act in manf.gen_actions():
+            path = act.attrs.get("path")
+            # Defer verification on actions with 'overlay'
+            # attribute = 'allow'.
+            if not path_only:
+                if act.attrs.get("overlay") == "true":
+                    yield act, [], [], [], "overlaying"
+                    continue
+                elif act.attrs.get("overlay"):
+                    yield act, [], [], [], "overlaid"
+                    continue
+
+            progresstracker.plan_add_progress(
+                progresstracker.PLAN_PKG_VERIFY, nitems=0
+            )
+
+            if (
+                act.name == "link" or act.name == "hardlink"
+            ) and not mediation_allowed(act):
+                # Link doesn't match configured
+                # mediation, so shouldn't be verified.
+                continue
+
+            errors, warnings, info, ignore = self.__process_verify(
+                act,
+                path,
+                path_only,
+                fmri,
+                excludes,
+                vardrate_excludes,
+                progresstracker,
+                verifypaths=verifypaths,
+                overlaypaths=overlaypaths,
+                **kwargs,
+            )
+            if (errors or warnings or info) and not ignore:
+                yield act, errors, warnings, info, None
+
+    def image_config_update(self, new_variants, new_facets, new_mediators):
+        """update variants in image config"""
+
+        if new_variants is not None:
+            self.cfg.variants.update(new_variants)
+        if new_facets is not None:
+            self.cfg.facets = new_facets
+        if new_mediators is not None:
+            self.cfg.mediators = new_mediators
+        self.save_config()
+
+    def __verify_manifest(self, fmri, mfstpath, alt_pub=None):
+        """Verify a manifest.  The caller must supply the FMRI
+        for the package in 'fmri', as well as the path to the
+        manifest file that will be verified."""
+
+        try:
+            return self.transport._verify_manifest(
+                fmri, mfstpath=mfstpath, pub=alt_pub
+            )
+        except InvalidContentException:
+            return False
+
+    def has_manifest(self, pfmri, alt_pub=None):
+        """Check to see if the manifest for pfmri is present on disk and
+        has the correct hash."""
+
+        pth = self.get_manifest_path(pfmri)
+        on_disk = os.path.exists(pth)
+
+        if (
+            not on_disk
+            or self.is_pkg_installed(pfmri)
+            or self.__verify_manifest(fmri=pfmri, mfstpath=pth, alt_pub=alt_pub)
+        ):
+            return on_disk
+        return False
+
+    def get_license_dir(self, pfmri):
+        """Return path to package license directory."""
+        if self.version == self.CURRENT_VERSION:
+            # Newer image format stores license files per-stem,
+            # instead of per-stem and version, so that transitions
+            # between package versions don't require redelivery
+            # of license files.
+            return os.path.join(
+                self.imgdir, "license", pfmri.get_dir_path(stemonly=True)
+            )
+        # Older image formats store license files in the manifest cache
+        # directory.
+        return self.get_manifest_dir(pfmri)
+
+    def __get_installed_pkg_publisher(self, pfmri):
+        """Returns the publisher for the FMRI of an installed package
+        or None if the package is not installed.
+        """
+        for f in self.gen_installed_pkgs():
+            if f.pkg_name == pfmri.pkg_name:
+                return f.publisher
+        return None
+
+    def get_manifest_dir(self, pfmri):
+        """Return path to on-disk manifest cache directory."""
+        if not pfmri.publisher:
+            # Needed for consumers such as search that don't provide
+            # publisher information.
+            pfmri = pfmri.copy()
+            pfmri.publisher = self.__get_installed_pkg_publisher(pfmri)
+        assert pfmri.publisher
+        if self.version == self.CURRENT_VERSION:
+            root = self._get_publisher_cache_root(pfmri.publisher)
+        else:
+            root = self.imgdir
+        return os.path.join(root, "pkg", pfmri.get_dir_path())
+
+    def get_manifest_path(self, pfmri):
+        """Return path to on-disk manifest file."""
+        if not pfmri.publisher:
+            # Needed for consumers such as search that don't provide
+            # publisher information.
+            pfmri = pfmri.copy()
+            pfmri.publisher = self.__get_installed_pkg_publisher(pfmri)
+        assert pfmri.publisher
+        if self.version == self.CURRENT_VERSION:
+            root = os.path.join(self._get_publisher_meta_root(pfmri.publisher))
+            return os.path.join(root, "pkg", pfmri.get_dir_path())
+        return os.path.join(self.get_manifest_dir(pfmri), "manifest")
+
+    def __get_manifest(self, fmri, excludes=EmptyI, intent=None, alt_pub=None):
+        """Find on-disk manifest and create in-memory Manifest
+        object.... grab from server if needed"""
+
+        try:
+            if not self.has_manifest(fmri, alt_pub=alt_pub):
+                raise KeyError
+            ret = manifest.FactoredManifest(
+                fmri,
+                self.get_manifest_dir(fmri),
+                excludes=excludes,
+                pathname=self.get_manifest_path(fmri),
+            )
+
+            # if we have a intent string, let depot
+            # know for what we're using the cached manifest
+            if intent:
+                alt_repo = None
+                if alt_pub:
+                    alt_repo = alt_pub.repository
                 try:
-                        with open(pathname, "w"):
-                                os.chmod(pathname, file_mode)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
+                    self.transport.touch_manifest(
+                        fmri, intent, alt_repo=alt_repo
+                    )
+                except (apx.UnknownPublisher, apx.TransportError):
+                    # It's not fatal if we can't find
+                    # or reach the publisher.
+                    pass
+        except KeyError:
+            ret = self.transport.get_manifest(
+                fmri, excludes, intent, pub=alt_pub
+            )
+        return ret
+
+    def get_manifest(
+        self, fmri, ignore_excludes=False, intent=None, alt_pub=None
+    ):
+        """return manifest; uses cached version if available.
+        ignore_excludes controls whether manifest contains actions
+        for all variants
+
+        If 'ignore_excludes' is set to True, then all actions in the
+        manifest are included, regardless of variant or facet tags.  If
+        set to False, then the variants and facets currently set in the
+        image will be applied, potentially filtering out some of the
+        actions."""
+
+        # Normally elide other arch variants, facets
+
+        if ignore_excludes:
+            excludes = EmptyI
+        else:
+            excludes = [
+                self.cfg.variants.allow_action,
+                self.cfg.facets.allow_action,
+            ]
+
+        try:
+            m = self.__get_manifest(
+                fmri, excludes=excludes, intent=intent, alt_pub=alt_pub
+            )
+        except apx.ActionExecutionError as e:
+            raise
+        except pkg.actions.ActionError as e:
+            raise apx.InvalidPackageErrors([e])
+
+        return m
+
+    def __catalog_save(self, cats, pfmris, progtrack):
+        # Temporarily redirect the catalogs to a different location,
+        # so that if the save is interrupted, the image won't be left
+        # with invalid state, and then save them.
+        tmp_state_root = self.temporary_dir()
+
+        try:
+            for cat, name in cats:
+                cpath = os.path.join(tmp_state_root, name)
+
+                # Must copy the old catalog data to the new
+                # destination as only changed files will be
+                # written.
+                progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
+                misc.copytree(cat.meta_root, cpath)
+                progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
+                cat.meta_root = cpath
+                cat.finalize(pfmris=pfmris)
+                progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
+                cat.save()
+                progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
+
+            del cat, name
+            self.__init_catalogs()
+            progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
+
+            # copy any other state files from current state
+            # dir into new state dir.
+            for p in os.listdir(self._statedir):
+                progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
+                fp = os.path.join(self._statedir, p)
+                if os.path.isfile(fp):
+                    portable.copyfile(fp, os.path.join(tmp_state_root, p))
+
+            # Next, preserve the old installed state dir, rename the
+            # new one into place, and then remove the old one.
+            orig_state_root = self.salvage(self._statedir, full_path=True)
+            portable.rename(tmp_state_root, self._statedir)
+
+            progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
+            shutil.rmtree(orig_state_root, True)
+
+            progtrack.job_add_progress(progtrack.JOB_IMAGE_STATE)
+        except EnvironmentError as e:
+            # shutil.Error can contains a tuple of lists of errors.
+            # Some of the error entries may be a tuple others will
+            # be a string due to poor error handling in shutil.
+            if isinstance(e, shutil.Error) and type(e.args[0]) == list:
+                msg = ""
+                for elist in e.args:
+                    for entry in elist:
+                        if type(entry) == tuple:
+                            msg += "{0}\n".format(entry[-1])
+                        else:
+                            msg += "{0}\n".format(entry)
+                raise apx.UnknownErrors(msg)
+            raise apx._convert_error(e)
+        finally:
+            # Regardless of success, the following must happen.
+            self.__init_catalogs()
+            if os.path.exists(tmp_state_root):
+                shutil.rmtree(tmp_state_root, True)
+
+    def update_pkg_installed_state(self, pkg_pairs, progtrack, origin):
+        """Sets the recorded installed state of each package pair in
+        'pkg_pairs'.  'pkg_pair' should be an iterable of tuples of
+        the format (added, removed) where 'removed' is the FMRI of the
+        package that was uninstalled, and 'added' is the package
+        installed for the operation.  These pairs are representative of
+        the destination and origin package for each part of the
+        operation."""
+
+        if self.version < self.CURRENT_VERSION:
+            raise apx.ImageFormatUpdateNeeded(self.root)
+
+        kcat = self.get_catalog(self.IMG_CATALOG_KNOWN)
+        icat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+
+        added = set()
+        removed = set()
+        manual = set()
+        updated = {}
+        for add_pkg, rem_pkg in pkg_pairs:
+            if add_pkg == rem_pkg:
+                continue
+            if add_pkg:
+                added.add(add_pkg)
+                if add_pkg in origin:
+                    manual.add(add_pkg)
+            if rem_pkg:
+                removed.add(rem_pkg)
+            if add_pkg and rem_pkg:
+                updated[add_pkg] = dict(
+                    kcat.get_entry(rem_pkg).get("metadata", {})
+                )
+
+        combo = added.union(removed)
+
+        # If PKG_AUTOINSTALL is set in the environment, don't mark
+        # the installed packages as 'manually installed'. This is
+        # used by Kayak when creating the initial ZFS send stream.
+        if "PKG_AUTOINSTALL" in os.environ:
+            manual = set()
+
+        progtrack.job_start(progtrack.JOB_STATE_DB)
+        # 'Updating package state database'
+        for pfmri in combo:
+            progtrack.job_add_progress(progtrack.JOB_STATE_DB)
+            entry = kcat.get_entry(pfmri)
+            mdata = entry.get("metadata", {})
+            states = set(mdata.get("states", set()))
+            if pfmri in removed:
+                icat.remove_package(pfmri)
+                states.discard(pkgdefs.PKG_STATE_INSTALLED)
+                states.discard(pkgdefs.PKG_STATE_MANUAL)
+                mdata.pop("last-install", None)
+                mdata.pop("last-update", None)
+
+            if pfmri in added:
+                states.add(pkgdefs.PKG_STATE_INSTALLED)
+                if pfmri in manual:
+                    states.add(pkgdefs.PKG_STATE_MANUAL)
+                cur_time = pkg.catalog.now_to_basic_ts()
+                if pfmri in updated:
+                    last_install = updated[pfmri].get("last-install")
+                    if last_install:
+                        mdata["last-install"] = last_install
+                        mdata["last-update"] = cur_time
+                    else:
+                        mdata["last-install"] = cur_time
+                    ostates = set(updated[pfmri].get("states", set()))
+                    if pkgdefs.PKG_STATE_MANUAL in ostates:
+                        states.add(pkgdefs.PKG_STATE_MANUAL)
+                else:
+                    mdata["last-install"] = cur_time
+                if pkgdefs.PKG_STATE_ALT_SOURCE in states:
+                    states.discard(pkgdefs.PKG_STATE_UPGRADABLE)
+                    states.discard(pkgdefs.PKG_STATE_ALT_SOURCE)
+                    states.discard(pkgdefs.PKG_STATE_KNOWN)
+            elif pkgdefs.PKG_STATE_KNOWN not in states:
+                # This entry is no longer available and has no
+                # meaningful state information, so should be
+                # discarded.
+                kcat.remove_package(pfmri)
+                progtrack.job_add_progress(progtrack.JOB_STATE_DB)
+                continue
+
+            if (
+                pkgdefs.PKG_STATE_INSTALLED in states
+                and pkgdefs.PKG_STATE_UNINSTALLED in states
+            ) or (
+                pkgdefs.PKG_STATE_KNOWN in states
+                and pkgdefs.PKG_STATE_UNKNOWN in states
+            ):
+                raise apx.ImagePkgStateError(pfmri, states)
+
+            # Catalog format only supports lists.
+            mdata["states"] = list(states)
+
+            # Now record the package state.
+            kcat.update_entry(mdata, pfmri=pfmri)
+
+            # If the package is being marked as installed,
+            # then  it shouldn't already exist in the
+            # installed catalog and should be added.
+            if pfmri in added:
+                icat.append(kcat, pfmri=pfmri)
+
+            entry = mdata = states = None
+            progtrack.job_add_progress(progtrack.JOB_STATE_DB)
+        progtrack.job_done(progtrack.JOB_STATE_DB)
+
+        # Discard entries for alternate source packages that weren't
+        # installed as part of the operation.
+        if self.__alt_pkg_pub_map:
+            for pfmri in self.__alt_known_cat.fmris():
+                if pfmri in added:
+                    # Nothing to do.
+                    continue
+
+                entry = kcat.get_entry(pfmri)
+                if not entry:
+                    # The only reason that the entry should
+                    # not exist in the 'known' part is
+                    # because it was removed during the
+                    # operation.
+                    assert pfmri in removed
+                    continue
+
+                states = entry.get("metadata", {}).get("states", EmptyI)
+                if pkgdefs.PKG_STATE_ALT_SOURCE in states:
+                    kcat.remove_package(pfmri)
+
+            # Now add the publishers of packages that were installed
+            # from temporary sources that did not previously exist
+            # to the image's configuration.  (But without any
+            # origins, sticky, and enabled.)
+            cfgpubs = set(self.cfg.publishers.keys())
+            instpubs = set(f.publisher for f in added)
+            altpubs = self.__alt_known_cat.publishers()
+
+            # List of publishers that need to be added is the
+            # intersection of installed and alternate minus
+            # the already configured.
+            newpubs = (instpubs & altpubs) - cfgpubs
+            # Sort the set to get a deterministic output.
+            for pfx in sorted(newpubs):
+                npub = publisher.Publisher(
+                    pfx, repository=publisher.Repository()
+                )
+                self.__add_publisher(npub, refresh_allowed=False)
+
+            # Ensure image configuration reflects new information.
+            self.__cleanup_alt_pkg_certs()
+            self.save_config()
+
+        # Remove manifests of packages that were removed from the
+        # system.  Some packages may have only had facets or
+        # variants changed, so don't remove those.
+
+        # 'Updating package cache'
+        progtrack.job_start(progtrack.JOB_PKG_CACHE, goal=len(removed))
+        for pfmri in removed:
+            mcdir = self.get_manifest_dir(pfmri)
+            manifest.FactoredManifest.clear_cache(mcdir)
+
+            # Remove package cache directory if possible; we don't
+            # care if it fails.
+            try:
+                os.rmdir(os.path.dirname(mcdir))
+            except:
+                pass
+
+            mpath = self.get_manifest_path(pfmri)
+            try:
+                portable.remove(mpath)
+            except EnvironmentError as e:
+                if e.errno != errno.ENOENT:
+                    raise apx._convert_error(e)
+
+            # Remove package manifest directory if possible; we
+            # don't care if it fails.
+            try:
+                os.rmdir(os.path.dirname(mpath))
+            except:
+                pass
+            progtrack.job_add_progress(progtrack.JOB_PKG_CACHE)
+        progtrack.job_done(progtrack.JOB_PKG_CACHE)
+
+        progtrack.job_start(progtrack.JOB_IMAGE_STATE)
+
+        self.__catalog_save(
+            [
+                (kcat, self.IMG_CATALOG_KNOWN),
+                (icat, self.IMG_CATALOG_INSTALLED),
+            ],
+            added,
+            progtrack,
+        )
+
+        progtrack.job_done(progtrack.JOB_IMAGE_STATE)
+
+    def get_catalog(self, name):
+        """Returns the requested image catalog.
+
+        'name' must be one of the following image constants:
+            IMG_CATALOG_KNOWN
+                The known catalog contains all of packages that are
+                installed or available from a publisher's repository.
+
+            IMG_CATALOG_INSTALLED
+                The installed catalog is a subset of the 'known'
+                catalog that only contains installed packages."""
+
+        if not self.imgdir:
+            raise RuntimeError("self.imgdir must be set")
+
+        cat = self.__catalogs.get(name)
+        if not cat:
+            cat = self.__get_catalog(name)
+            self.__catalogs[name] = cat
+
+        if name == self.IMG_CATALOG_KNOWN:
+            # Apply alternate package source data every time that
+            # the known catalog is requested.
+            self.__apply_alt_pkg_sources(cat)
+
+        return cat
+
+    def _manifest_cb(self, cat, f):
+        # Only allow lazy-load for packages from non-v1 sources.
+        # Assume entries for other sources have all data
+        # required in catalog.  This prevents manifest retrieval
+        # for packages that don't have any related action data
+        # in the catalog because they don't have any related
+        # action data in their manifest.
+        entry = cat.get_entry(f)
+        states = entry["metadata"]["states"]
+        if pkgdefs.PKG_STATE_V1 not in states:
+            return self.get_manifest(f, ignore_excludes=True)
+        return
+
+    def __get_catalog(self, name):
+        """Private method to retrieve catalog; this bypasses the
+        normal automatic caching (unless the image hasn't been
+        upgraded yet)."""
+
+        if self.__upgraded and self.version < 3:
+            # Assume the catalog is already cached in this case
+            # and can't be reloaded from disk as it doesn't exist
+            # on disk yet.
+            return self.__catalogs[name]
+
+        croot = os.path.join(self._statedir, name)
+        try:
+            os.makedirs(croot)
+        except EnvironmentError as e:
+            if e.errno in (errno.EACCES, errno.EROFS):
+                # Allow operations to work for
+                # unprivileged users.
+                croot = None
+            elif e.errno != errno.EEXIST:
+                raise
+
+        # batch_mode is set to True here as any operations that modify
+        # the catalogs (add or remove entries) are only done during an
+        # image upgrade or metadata refresh.  In both cases, the catalog
+        # is resorted and finalized so this is always safe to use.
+        cat = pkg.catalog.Catalog(
+            batch_mode=True,
+            manifest_cb=self._manifest_cb,
+            meta_root=croot,
+            sign=False,
+        )
+        return cat
+
+    def __remove_catalogs(self):
+        """Removes all image catalogs and their directories."""
+
+        self.__init_catalogs()
+        for name in (self.IMG_CATALOG_KNOWN, self.IMG_CATALOG_INSTALLED):
+            shutil.rmtree(os.path.join(self._statedir, name))
+
+    def get_version_installed(self, pfmri):
+        """Returns an fmri of the installed package matching the
+        package stem of the given fmri or None if no match is found."""
+
+        cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+        for ver, fmris in cat.fmris_by_version(pfmri.pkg_name):
+            return fmris[0]
+        return None
+
+    def get_pkg_repo(self, pfmri):
+        """Returns the repository object containing the origins that
+        should be used to retrieve the specified package or None if
+        it can be retrieved from all sources or is not a known package.
+        """
+
+        assert pfmri.publisher
+        cat = self.get_catalog(self.IMG_CATALOG_KNOWN)
+        entry = cat.get_entry(pfmri)
+        if entry is None:
+            # Package not known.
+            return
+
+        try:
+            slist = entry["metadata"]["sources"]
+        except KeyError:
+            # Can be retrieved from any source.
+            return
+        else:
+            if not slist:
+                # Can be retrieved from any source.
+                return
+
+        pub = self.get_publisher(prefix=pfmri.publisher)
+        repo = copy.copy(pub.repository)
+        norigins = [o for o in repo.origins if o.uri in slist]
+
+        if not norigins:
+            # Known sources don't match configured; return so that
+            # caller can fallback to default behaviour.
+            return
+
+        repo.origins = norigins
+        return repo
+
+    def get_pkg_state(self, pfmri):
+        """Returns the list of states a package is in for this image."""
+
+        cat = self.get_catalog(self.IMG_CATALOG_KNOWN)
+        entry = cat.get_entry(pfmri)
+        if entry is None:
+            return []
+        return entry["metadata"]["states"]
+
+    def is_pkg_installed(self, pfmri):
+        """Returns a boolean value indicating whether the specified
+        package is installed."""
+
+        # Avoid loading the installed catalog if the known catalog
+        # is already loaded.  This is safe since the installed
+        # catalog is a subset of the known, and a specific entry
+        # is being retrieved.
+        if not self.__catalog_loaded(self.IMG_CATALOG_KNOWN):
+            cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+        else:
+            cat = self.get_catalog(self.IMG_CATALOG_KNOWN)
+
+        entry = cat.get_entry(pfmri)
+        if entry is None:
+            return False
+        states = entry["metadata"]["states"]
+        return pkgdefs.PKG_STATE_INSTALLED in states
+
+    def list_excludes(self, new_variants=None, new_facets=None):
+        """Generate a list of callables that each return True if an
+        action is to be included in the image using the currently
+        defined variants & facets for the image, or an updated set if
+        new_variants or new_facets are specified."""
+
+        if new_variants:
+            new_vars = self.cfg.variants.copy()
+            new_vars.update(new_variants)
+            var_call = new_vars.allow_action
+        else:
+            var_call = self.cfg.variants.allow_action
+        if new_facets is not None:
+            fac_call = new_facets.allow_action
+        else:
+            fac_call = self.cfg.facets.allow_action
+
+        return [var_call, fac_call]
+
+    def get_variants(self):
+        """return a copy of the current image variants"""
+        return self.cfg.variants.copy()
+
+    def get_facets(self):
+        """Return a copy of the current image facets"""
+        return self.cfg.facets.copy()
+
+    def __state_updating_pathname(self):
+        """Return the path to a flag file indicating that the image
+        catalog is being updated."""
+        return os.path.join(self._statedir, self.__STATE_UPDATING_FILE)
+
+    def __start_state_update(self):
+        """Called when we start updating the image catalog.  Normally
+        returns False, but will return True if a previous update was
+        interrupted."""
+
+        # get the path to the image catalog update flag file
+        pathname = self.__state_updating_pathname()
+
+        # if the flag file exists a previous update was interrupted so
+        # return 1
+        if os.path.exists(pathname):
+            return True
+
+        # create the flag file and return 0
+        file_mode = misc.PKG_FILE_MODE
+        try:
+            with open(pathname, "w"):
+                os.chmod(pathname, file_mode)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
+        return False
+
+    def __end_state_update(self):
+        """Called when we're done updating the image catalog."""
+
+        # get the path to the image catalog update flag file
+        pathname = self.__state_updating_pathname()
+
+        # delete the flag file.
+        try:
+            portable.remove(pathname)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
+
+    def __rebuild_image_catalogs(self, progtrack=None):
+        """Rebuilds the image catalogs based on the available publisher
+        catalogs."""
+
+        if self.version < 3:
+            raise apx.ImageFormatUpdateNeeded(self.root)
+
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        progtrack.cache_catalogs_start()
+
+        publist = list(self.gen_publishers())
+
+        be_name, be_uuid = bootenv.BootEnv.get_be_name(self.root)
+        self.history.log_operation_start(
+            "rebuild-image-catalogs", be_name=be_name, be_uuid=be_uuid
+        )
+
+        # Mark all operations as occurring at this time.
+        op_time = datetime.datetime.utcnow()
+
+        # The image catalogs need to be updated, but this is a bit
+        # tricky as previously known packages must remain known even
+        # if PKG_STATE_KNOWN is no longer true if any other state
+        # information is present.  This is to allow freezing, etc. of
+        # package states on a permanent basis even if the package is
+        # no longer available from a publisher repository.  However,
+        # this is only True of installed packages.
+        old_icat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+
+        # batch_mode is set to True here since without it, catalog
+        # population time is almost doubled (since the catalog is
+        # re-sorted and stats are generated for every operation).
+        # In addition, the new catalog is first created in a new
+        # temporary directory so that it can be moved into place
+        # at the very end of this process (to minimize the chance
+        # that failure or interruption will cause the image to be
+        # left in an inconsistent state).
+        tmp_state_root = self.temporary_dir()
+
+        # Copy any regular files placed in the state directory
+        for p in os.listdir(self._statedir):
+            if p == self.__STATE_UPDATING_FILE:
+                # don't copy the state updating file
+                continue
+            fp = os.path.join(self._statedir, p)
+            if os.path.isfile(fp):
+                portable.copyfile(fp, os.path.join(tmp_state_root, p))
+
+        kcat = pkg.catalog.Catalog(
+            batch_mode=True,
+            meta_root=os.path.join(tmp_state_root, self.IMG_CATALOG_KNOWN),
+            sign=False,
+        )
+
+        # XXX if any of the below fails for any reason, the old 'known'
+        # catalog needs to be re-loaded so the client is in a consistent
+        # state.
+
+        # All enabled publisher catalogs must be processed.
+        pub_cats = [(pub.prefix, pub.catalog) for pub in publist]
+
+        # XXX For backwards compatibility, 'upgradability' of packages
+        # is calculated and stored based on whether a given pkg stem
+        # matches the newest version in the catalog.  This is quite
+        # expensive (due to overhead), but at least the cost is
+        # consolidated here.  This comparison is also cross-publisher,
+        # as it used to be.  In the future, it could likely be improved
+        # by usage of the SAT solver.
+        newest = {}
+        for pfx, cat in [(None, old_icat)] + pub_cats:
+            for f in cat.fmris(last=True, pubs=pfx and [pfx] or EmptyI):
+                nver, snver = newest.get(f.pkg_name, (None, None))
+                if f.version > nver:
+                    newest[f.pkg_name] = (f.version, str(f.version))
+
+        # Next, copy all of the entries for the catalog parts that
+        # currently exist into the image 'known' catalog.
+
+        # Iterator for source parts.
+        sparts = (
+            (pfx, cat, name, cat.get_part(name, must_exist=True))
+            for pfx, cat in pub_cats
+            for name in cat.parts
+        )
+
+        # Build list of installed packages based on actual state
+        # information just in case there is a state issue from an
+        # older client.
+        # Also stash away any old metadata, in particular we want
+        # the last-install and last-update times but maybe other
+        # metadata will be useful in the future.
+        inst_stems = {}
+        for t, entry in old_icat.tuple_entries():
+            states = entry["metadata"]["states"]
+            if pkgdefs.PKG_STATE_INSTALLED not in states:
+                continue
+            pub, stem, ver = t
+            inst_stems.setdefault(pub, {})
+            inst_stems[pub].setdefault(stem, {})
+            inst_stems[pub][stem][ver] = {
+                "installed": False,
+                "metadata": entry["metadata"],
+            }
+
+        # Create the new installed catalog in a temporary location.
+        icat = pkg.catalog.Catalog(
+            batch_mode=True,
+            meta_root=os.path.join(tmp_state_root, self.IMG_CATALOG_INSTALLED),
+            sign=False,
+        )
+
+        excludes = self.list_excludes()
+
+        frozen_pkgs = dict(
+            [(p[0].pkg_name, p[0]) for p in self.get_frozen_list()]
+        )
+        for pfx, cat, name, spart in sparts:
+            # 'spart' is the source part.
+            if spart is None:
+                # Client hasn't retrieved this part.
+                continue
+
+            # New known part.
+            nkpart = kcat.get_part(name)
+            nipart = icat.get_part(name)
+            base = name.startswith("catalog.base.")
+
+            # Avoid accessor overhead since these will be
+            # used for every entry.
+            cat_ver = cat.version
+            dp = cat.get_part("catalog.dependency.C", must_exist=True)
+
+            for t, sentry in spart.tuple_entries(pubs=[pfx]):
+                pub, stem, ver = t
+
+                installed = False
+                if (
+                    pub in inst_stems
+                    and stem in inst_stems[pub]
+                    and ver in inst_stems[pub][stem]
+                ):
+                    installed = True
+                    inst_stems[pub][stem][ver]["installed"] = True
+
+                # copy() is too slow here and catalog entries
+                # are shallow so this should be sufficient.
+                entry = dict(six.iteritems(sentry))
+                if not base:
+                    # Nothing else to do except add the
+                    # entry for non-base catalog parts.
+                    nkpart.add(
+                        metadata=entry,
+                        op_time=op_time,
+                        pub=pub,
+                        stem=stem,
+                        ver=ver,
+                    )
+                    if installed:
+                        nipart.add(
+                            metadata=entry,
+                            op_time=op_time,
+                            pub=pub,
+                            stem=stem,
+                            ver=ver,
+                        )
+                    continue
+
+                # Only the base catalog part stores package
+                # state information and/or other metadata.
+                mdata = entry.setdefault("metadata", {})
+                states = mdata.setdefault("states", [])
+                states.append(pkgdefs.PKG_STATE_KNOWN)
+
+                if cat_ver == 0:
+                    states.append(pkgdefs.PKG_STATE_V0)
+                elif pkgdefs.PKG_STATE_V0 not in states:
+                    # Assume V1 catalog source.
+                    states.append(pkgdefs.PKG_STATE_V1)
+
+                if installed:
+                    states.append(pkgdefs.PKG_STATE_INSTALLED)
+                    # Preserve the dates of install/update
+                    # if present in the old metadata
+                    md = inst_stems[pub][stem][ver]["metadata"]
+                    for key in ["last-install", "last-update"]:
+                        if key in md:
+                            entry["metadata"][key] = md[key]
+                    # Preserve the manual installation
+                    # flag, if present in the old metadata
+                    ostates = set(md.get("states", set()))
+                    if pkgdefs.PKG_STATE_MANUAL in ostates:
+                        states.append(pkgdefs.PKG_STATE_MANUAL)
+
+                nver, snver = newest.get(stem, (None, None))
+                if snver is not None and ver != snver:
+                    states.append(pkgdefs.PKG_STATE_UPGRADABLE)
+
+                # Check if the package is frozen.
+                if stem in frozen_pkgs:
+                    f_ver = frozen_pkgs[stem].version
+                    if f_ver == ver or pkg.version.Version(ver).is_successor(
+                        f_ver, constraint=pkg.version.CONSTRAINT_AUTO
+                    ):
+                        states.append(pkgdefs.PKG_STATE_FROZEN)
+
+                # Determine if package is obsolete or has been
+                # renamed and mark with appropriate state.
+                dpent = None
+                if dp is not None:
+                    dpent = dp.get_entry(pub=pub, stem=stem, ver=ver)
+                if dpent is not None:
+                    for a in dpent["actions"]:
+                        # Constructing action objects
+                        # for every action would be a
+                        # lot slower, so a simple string
+                        # match is done first so that
+                        # only interesting actions get
+                        # constructed.
+                        if not a.startswith("set"):
+                            continue
+                        if not (
+                            "pkg.obsolete" in a
+                            or "pkg.renamed" in a
+                            or "pkg.legacy" in a
+                        ):
+                            continue
+
+                        try:
+                            act = pkg.actions.fromstr(a)
+                        except pkg.actions.ActionError:
+                            # If the action can't be
+                            # parsed or is not yet
+                            # supported, continue.
+                            continue
+
+                        if act.attrs["value"].lower() != "true":
+                            continue
+
+                        if act.attrs["name"] == "pkg.obsolete":
+                            states.append(pkgdefs.PKG_STATE_OBSOLETE)
+                        elif act.attrs["name"] == "pkg.renamed":
+                            if not act.include_this(excludes, publisher=pub):
+                                continue
+                            states.append(pkgdefs.PKG_STATE_RENAMED)
+                        elif act.attrs["name"] == "pkg.legacy":
+                            states.append(pkgdefs.PKG_STATE_LEGACY)
+
+                mdata["states"] = states
+
+                # Add base entries.
+                nkpart.add(
+                    metadata=entry, op_time=op_time, pub=pub, stem=stem, ver=ver
+                )
+                if installed:
+                    nipart.add(
+                        metadata=entry,
+                        op_time=op_time,
+                        pub=pub,
+                        stem=stem,
+                        ver=ver,
+                    )
+
+        # Now add installed packages to list of known packages using
+        # previous state information.  While doing so, track any
+        # new entries as the versions for the stem of the entry will
+        # need to be passed to finalize() for sorting.
+        final_fmris = []
+        for name in old_icat.parts:
+            # Old installed part.
+            ipart = old_icat.get_part(name, must_exist=True)
+
+            # New known part.
+            nkpart = kcat.get_part(name)
+
+            # New installed part.
+            nipart = icat.get_part(name)
+
+            base = name.startswith("catalog.base.")
+
+            mdata = None
+            for t, entry in ipart.tuple_entries():
+                pub, stem, ver = t
+
+                if (
+                    pub not in inst_stems
+                    or stem not in inst_stems[pub]
+                    or ver not in inst_stems[pub][stem]
+                    or inst_stems[pub][stem][ver]["installed"]
+                ):
+                    # Entry is no longer valid or is already
+                    # known.
+                    continue
+
+                if base:
+                    mdata = entry["metadata"]
+                    states = set(mdata["states"])
+                    states.discard(pkgdefs.PKG_STATE_KNOWN)
+
+                    nver, snver = newest.get(stem, (None, None))
+                    if not nver or (snver is not None and ver == snver):
+                        states.discard(pkgdefs.PKG_STATE_UPGRADABLE)
+                    elif snver is not None:
+                        states.add(pkgdefs.PKG_STATE_UPGRADABLE)
+                    # Check if the package is frozen.
+                    if stem in frozen_pkgs:
+                        f_ver = frozen_pkgs[stem].version
+                        if f_ver == ver or pkg.version.Version(
+                            ver
+                        ).is_successor(
+                            f_ver, constraint=pkg.version.CONSTRAINT_AUTO
+                        ):
+                            states.add(pkgdefs.PKG_STATE_FROZEN)
+                    else:
+                        states.discard(pkgdefs.PKG_STATE_FROZEN)
+
+                    mdata["states"] = list(states)
+
+                # Add entries.
+                nkpart.add(
+                    metadata=entry, op_time=op_time, pub=pub, stem=stem, ver=ver
+                )
+                nipart.add(
+                    metadata=entry, op_time=op_time, pub=pub, stem=stem, ver=ver
+                )
+                final_fmris.append(
+                    pkg.fmri.PkgFmri(name=stem, publisher=pub, version=ver)
+                )
+
+        # Save the new catalogs.
+        for cat in kcat, icat:
+            misc.makedirs(cat.meta_root)
+            cat.finalize(pfmris=final_fmris)
+            cat.save()
+
+        # Next, preserve the old installed state dir, rename the
+        # new one into place, and then remove the old one.
+        orig_state_root = self.salvage(self._statedir, full_path=True)
+        portable.rename(tmp_state_root, self._statedir)
+        shutil.rmtree(orig_state_root, True)
+
+        # Ensure in-memory catalogs get reloaded.
+        self.__init_catalogs()
+
+        self.update_last_modified()
+        progtrack.cache_catalogs_done()
+        self.history.log_operation_end()
+
+    def refresh_publishers(
+        self,
+        full_refresh=False,
+        immediate=False,
+        pubs=None,
+        progtrack=None,
+        ignore_unreachable=True,
+    ):
+        """Refreshes the metadata (e.g. catalog) for one or more
+        publishers.  Callers are responsible for locking the image.
+
+        'full_refresh' is an optional boolean value indicating whether
+        a full retrieval of publisher metadata (e.g. catalogs) or only
+        an update to the existing metadata should be performed.  When
+        True, 'immediate' is also set to True.
+
+        'immediate' is an optional boolean value indicating whether the
+        a refresh should occur now.  If False, a publisher's selected
+        repository will only be checked for updates if the update
+        interval period recorded in the image configuration has been
+        exceeded.
+
+        'pubs' is a list of publisher prefixes or publisher objects
+        to refresh.  Passing an empty list or using the default value
+        implies all publishers.
+
+        'ignore_unreachable' is an optional boolean value indicating
+        whether unreachable repositories should be ignored. If True,
+        errors contacting this repository are stored in the transport
+        but no exception is raised, allowing an operation to continue
+        if an unneeded repository is not online."""
+
+        if self.version < 3:
+            raise apx.ImageFormatUpdateNeeded(self.root)
+
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        be_name, be_uuid = bootenv.BootEnv.get_be_name(self.root)
+        self.history.log_operation_start(
+            "refresh-publishers", be_name=be_name, be_uuid=be_uuid
+        )
+
+        pubs_to_refresh = []
+
+        if not pubs:
+            # Omit disabled publishers.
+            pubs = [p for p in self.gen_publishers()]
+
+        if not pubs:
+            self.__rebuild_image_catalogs(progtrack=progtrack)
+            return
+
+        for pub in pubs:
+            p = pub
+            if not isinstance(p, publisher.Publisher):
+                p = self.get_publisher(prefix=p)
+            if p.disabled:
+                e = apx.DisabledPublisher(p)
+                self.history.log_operation_end(error=e)
+                raise e
+            pubs_to_refresh.append(p)
+
+        if not pubs_to_refresh:
+            self.history.log_operation_end(result=history.RESULT_NOTHING_TO_DO)
+            return
+
+        # Verify validity of certificates before attempting network
+        # operations.
+        try:
+            self.check_cert_validity(pubs=pubs_to_refresh)
+        except apx.ExpiringCertificate as e:
+            logger.error(str(e))
+
+        try:
+            # Ensure Image directory structure is valid.
+            self.mkdirs()
+        except Exception as e:
+            self.history.log_operation_end(error=e)
+            raise
+
+        progtrack.refresh_start(len(pubs_to_refresh), full_refresh=full_refresh)
+
+        failed = []
+        total = 0
+        succeeded = set()
+        updated = self.__start_state_update()
+        for pub in pubs_to_refresh:
+            total += 1
+            progtrack.refresh_start_pub(pub)
+            try:
+                changed, e = pub.refresh(
+                    full_refresh=full_refresh,
+                    immediate=immediate,
+                    progtrack=progtrack,
+                )
+                if changed:
+                    updated = True
+
+                if not ignore_unreachable and e:
+                    failed.append((pub, e))
+                    continue
+
+            except apx.PermissionsException as e:
+                failed.append((pub, e))
+                # No point in continuing since no data can
+                # be written.
+                break
+            except apx.ApiException as e:
+                failed.append((pub, e))
+                continue
+            finally:
+                progtrack.refresh_end_pub(pub)
+            succeeded.add(pub.prefix)
+
+        progtrack.refresh_done()
+
+        if updated:
+            self.__rebuild_image_catalogs(progtrack=progtrack)
+            # Ensure any configuration or metadata changes made
+            # during refresh are reflected in on-disk state.
+            self.save_config()
+        else:
+            self.__end_state_update()
+
+        if failed:
+            e = apx.CatalogRefreshException(failed, total, len(succeeded))
+            self.history.log_operation_end(error=e)
+            raise e
+
+        if not updated:
+            self.history.log_operation_end(result=history.RESULT_NOTHING_TO_DO)
+            return
+        self.history.log_operation_end()
+
+    def _get_publisher_meta_dir(self):
+        if self.version >= 3:
+            return IMG_PUB_DIR
+        return "catalog"
+
+    def _get_publisher_cache_root(self, prefix):
+        return os.path.join(self.imgdir, "cache", "publisher", prefix)
+
+    def _get_publisher_meta_root(self, prefix):
+        return os.path.join(self.imgdir, self._get_publisher_meta_dir(), prefix)
+
+    def remove_publisher_metadata(self, pub, progtrack=None, rebuild=True):
+        """Removes the metadata for the specified publisher object,
+        except data for installed packages.
+
+        'pub' is the object of the publisher to remove the data for.
+
+        'progtrack' is an optional ProgressTracker object.
+
+        'rebuild' is an optional boolean specifying whether image
+        catalogs should be rebuilt after removing the publisher's
+        metadata.
+        """
+
+        if self.version < 4:
+            # Older images don't require fine-grained deletion.
+            pub.remove_meta_root()
+            if rebuild:
+                self.__rebuild_image_catalogs(progtrack=progtrack)
+            return
+
+        # Build a list of paths that shouldn't be removed because they
+        # belong to installed packages.
+        excluded = [
+            self.get_manifest_path(f)
+            for f in self.gen_installed_pkgs()
+            if f.publisher == pub.prefix
+        ]
+
+        if not excluded:
+            pub.remove_meta_root()
+        else:
+            try:
+                # Discard all publisher metadata except
+                # package manifests as a first pass.
+                for entry in os.listdir(pub.meta_root):
+                    if entry == "pkg":
+                        continue
+
+                    target = os.path.join(pub.meta_root, entry)
+                    if os.path.isdir(target):
+                        shutil.rmtree(target, ignore_errors=True)
+                    else:
+                        portable.remove(target)
+
+                # Build the list of directories that can't be
+                # removed.
+                exdirs = [os.path.dirname(e) for e in excluded]
+
+                # Now try to discard only package manifests
+                # that aren't for installed packages.
+                mroot = os.path.join(pub.meta_root, "pkg")
+                for pdir in os.listdir(mroot):
+                    proot = os.path.join(mroot, pdir)
+                    if proot not in exdirs:
+                        # This removes all manifest data
+                        # for a given package stem.
+                        shutil.rmtree(proot, ignore_errors=True)
+                        continue
+
+                    # Remove only manifest data for packages
+                    # that are not installed.
+                    for mname in os.listdir(proot):
+                        mpath = os.path.join(proot, mname)
+                        if mpath not in excluded:
+                            portable.remove(mpath)
+
+                # Finally, dump any cache data for this
+                # publisher if possible.
+                shutil.rmtree(
+                    self._get_publisher_cache_root(pub.prefix),
+                    ignore_errors=True,
+                )
+            except EnvironmentError as e:
+                if e.errno != errno.ENOENT:
+                    raise apx._convert_error(e)
+
+        if rebuild:
+            self.__rebuild_image_catalogs(progtrack=progtrack)
+
+    def gen_installed_pkg_names(self, anarchy=True):
+        """A generator function that produces FMRI strings as it
+        iterates over the list of installed packages.  This is
+        faster than gen_installed_pkgs when only the FMRI string
+        is needed."""
+
+        cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+        for f in cat.fmris(objects=False):
+            if anarchy:
+                # Catalog entries always have publisher prefix.
+                yield "pkg:/{0}".format(f[6:].split("/", 1)[-1])
+                continue
+            yield f
+
+    def gen_installed_pkgs(self, pubs=EmptyI, ordered=False):
+        """Return an iteration through the installed packages."""
+
+        cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+        for f in cat.fmris(pubs=pubs, ordered=ordered):
+            yield f
+
+    def count_installed_pkgs(self, pubs=EmptyI):
+        """Return the number of installed packages."""
+        cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+        assert cat.package_count == cat.package_version_count
+        return sum(
+            pkg_count
+            for (pub, pkg_count, _ignored) in cat.get_package_counts_by_pub(
+                pubs=pubs
+            )
+        )
+
+    def gen_tracked_stems(self):
+        """Return an iteration through all the tracked pkg stems
+        in the set of currently installed packages.  Return value
+        is group pkg fmri, stem"""
+        cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+        excludes = self.list_excludes()
+
+        for f in cat.fmris():
+            for a in cat.get_entry_actions(
+                f, [pkg.catalog.Catalog.DEPENDENCY], excludes=excludes
+            ):
+                if a.name == "depend" and a.attrs["type"] == "group":
+                    yield (f, self.strtofmri(a.attrs["fmri"]).pkg_name)
+
+    def _create_fast_lookups(self, progtrack=None):
+        """Create an on-disk database mapping action name and key
+        attribute value to the action string comprising the unique
+        attributes of the action, for all installed actions.  This is
+        done with a file mapping the tuple to an offset into a second
+        file, where those actions are kept.  Once the offsets are loaded
+        into memory, it is simple to seek into the second file to the
+        given offset and read until you hit an action that doesn't
+        match."""
+
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        self.__actdict = None
+        self.__actdict_timestamp = None
+        stripped_path = os.path.join(
+            self.__action_cache_dir, "actions.stripped"
+        )
+        offsets_path = os.path.join(self.__action_cache_dir, "actions.offsets")
+        conflicting_keys_path = os.path.join(
+            self.__action_cache_dir, "keys.conflicting"
+        )
+
+        excludes = self.list_excludes()
+        heap = []
+
+        # nsd is the "name-space dictionary."  It maps action name
+        # spaces (see action.generic for more information) to
+        # dictionaries which map keys to pairs which contain an action
+        # with that key and the pfmri of the package which delivered the
+        # action.
+        nsd = {}
+
+        from heapq import heappush, heappop
+
+        progtrack.job_start(progtrack.JOB_FAST_LOOKUP)
+
+        for pfmri in self.gen_installed_pkgs():
+            progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
+            m = self.get_manifest(pfmri, ignore_excludes=True)
+            for act in m.gen_actions(excludes=excludes):
+                if not act.globally_identical:
+                    continue
+                act.strip()
+                heappush(heap, (act.name, act.attrs[act.key_attr], pfmri, act))
+                nsd.setdefault(act.namespace_group, {})
+                nsd[act.namespace_group].setdefault(act.attrs[act.key_attr], [])
+                nsd[act.namespace_group][act.attrs[act.key_attr]].append(
+                    (act, pfmri)
+                )
+
+        progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
+
+        # If we can't write the temporary files, then there's no point
+        # in producing actdict because it depends on a synchronized
+        # stripped actions file.
+        try:
+            actdict = {}
+            sf, sp = self.temporary_file(close=False)
+            of, op = self.temporary_file(close=False)
+            bf, bp = self.temporary_file(close=False)
+
+            sf = os.fdopen(sf, "w")
+            of = os.fdopen(of, "w")
+            bf = os.fdopen(bf, "w")
+
+            # We need to make sure the files are coordinated.
+            timestamp = int(time.time())
+            sf.write("VERSION 1\n{0}\n".format(timestamp))
+            of.write("VERSION 2\n{0}\n".format(timestamp))
+            # The conflicting keys file doesn't need a timestamp
+            # because it's not coordinated with the stripped or
+            # offsets files and the result of loading it isn't
+            # reused by this class.
+            bf.write("VERSION 1\n")
+
+            cnt, offset_update_bytes = 0, 0
+            last_name, last_key, last_offset = None, None, sf.tell()
+            while heap:
+                # This is a tight loop, so try to avoid burning
+                # CPU calling into the progress tracker
+                # excessively.
+                if len(heap) % 100 == 0:
+                    progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
+                item = heappop(heap)
+                fmri, act = item[2:]
+                key = act.attrs[act.key_attr]
+                if act.name != last_name or key != last_key:
+                    if last_name is None:
+                        assert last_key is None
+                        cnt += 1
+                        last_name = act.name
+                        last_key = key
+                    else:
+                        assert cnt > 0
+                        of.write(
+                            "{0} {1} {2} {3}\n".format(
+                                last_name, last_offset, cnt, last_key
+                            )
+                        )
+                        actdict[(last_name, last_key)] = last_offset, cnt
+                        last_name, last_key = act.name, key
+                        last_offset += offset_update_bytes
+                        offset_update_bytes = 0
+                        cnt = 1
+                else:
+                    cnt += 1
+                sf_line = f"{fmri} {act}\n"
+                sf.write(sf_line)
+                offset_update_bytes += len(sf_line.encode("utf-8"))
+            if last_name is not None:
+                assert last_key is not None
+                assert last_offset is not None
+                assert cnt > 0
+                of.write(
+                    "{0} {1} {2} {3}\n".format(
+                        last_name, last_offset, cnt, last_key
+                    )
+                )
+                actdict[(last_name, last_key)] = last_offset, cnt
+
+            progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
+
+            bad_keys = imageplan.ImagePlan._check_actions(nsd)
+            for k in sorted(bad_keys):
+                bf.write("{0}\n".format(k))
+
+            progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
+            sf.close()
+            of.close()
+            bf.close()
+            os.chmod(sp, misc.PKG_FILE_MODE)
+            os.chmod(op, misc.PKG_FILE_MODE)
+            os.chmod(bp, misc.PKG_FILE_MODE)
+        except BaseException as e:
+            try:
+                os.unlink(sp)
+                os.unlink(op)
+                os.unlink(bp)
+            except:
+                pass
+            raise
+
+        progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
+
+        # Finally, rename the temporary files into their final place.
+        # If we have any problems, do our best to remove them, and we'll
+        # try to recreate them on the read-side.
+        try:
+            if not os.path.exists(self.__action_cache_dir):
+                os.makedirs(self.__action_cache_dir)
+            portable.rename(sp, stripped_path)
+            portable.rename(op, offsets_path)
+            portable.rename(bp, conflicting_keys_path)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES or e.errno == errno.EROFS:
+                self.__action_cache_dir = self.temporary_dir()
+                stripped_path = os.path.join(
+                    self.__action_cache_dir, "actions.stripped"
+                )
+                offsets_path = os.path.join(
+                    self.__action_cache_dir, "actions.offsets"
+                )
+                conflicting_keys_path = os.path.join(
+                    self.__action_cache_dir, "keys.conflicting"
+                )
+                portable.rename(sp, stripped_path)
+                portable.rename(op, offsets_path)
+                portable.rename(bp, conflicting_keys_path)
+            else:
+                exc_info = sys.exc_info()
+                try:
+                    os.unlink(stripped_path)
+                    os.unlink(offsets_path)
+                    os.unlink(conflicting_keys_path)
+                except:
+                    pass
+                six.reraise(exc_info[0], exc_info[1], exc_info[2])
+
+        progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
+        progtrack.job_done(progtrack.JOB_FAST_LOOKUP)
+        return actdict, timestamp
+
+    def _remove_fast_lookups(self):
+        """Remove on-disk database created by _create_fast_lookups.
+        Should be called before updating image state to prevent the
+        client from seeing stale state if _create_fast_lookups is
+        interrupted."""
+
+        for fname in (
+            "actions.stripped",
+            "actions.offsets",
+            "keys.conflicting",
+        ):
+            try:
+                portable.remove(os.path.join(self.__action_cache_dir, fname))
+            except EnvironmentError as e:
+                if e.errno == errno.ENOENT:
+                    continue
+                raise apx._convert_error(e)
+
+    def _load_actdict(self, progtrack):
+        """Read the file of offsets created in _create_fast_lookups()
+        and return the dictionary mapping action name and key value to
+        offset."""
+
+        try:
+            of = open(
+                os.path.join(self.__action_cache_dir, "actions.offsets"), "r"
+            )
+        except IOError as e:
+            if e.errno != errno.ENOENT:
+                raise
+            actdict, otimestamp = self._create_fast_lookups()
+            assert actdict is not None
+            self.__actdict = actdict
+            self.__actdict_timestamp = otimestamp
+            return actdict
+
+        # Make sure the files are paired, and try to create them if not.
+        oversion = of.readline().rstrip()
+        otimestamp = of.readline().rstrip()
+
+        # The original action.offsets file existed and had the same
+        # timestamp as the stored actdict, so that actdict can be
+        # reused.
+        if self.__actdict and otimestamp == self.__actdict_timestamp:
+            return self.__actdict
+
+        sversion, stimestamp = self._get_stripped_actions_file(internal=True)
+
+        # If we recognize neither file's version or their timestamps
+        # don't match, then we blow them away and try again.
+        if (
+            oversion != "VERSION 2"
+            or sversion != "VERSION 1"
+            or stimestamp != otimestamp
+        ):
+            of.close()
+            actdict, otimestamp = self._create_fast_lookups()
+            assert actdict is not None
+            self.__actdict = actdict
+            self.__actdict_timestamp = otimestamp
+            return actdict
+
+        # At this point, the original actions.offsets file existed, no
+        # actdict was saved in the image, the versions matched what was
+        # expected, and the timestamps of the actions.offsets and
+        # actions.stripped files matched, so the actions.offsets file is
+        # parsed to generate actdict.
+        actdict = {}
+
+        for line in of:
+            actname, offset, cnt, key_attr = line.rstrip().split(None, 3)
+            off = int(offset)
+            actdict[(actname, key_attr)] = (off, int(cnt))
+
+            # This is a tight loop, so try to avoid burning
+            # CPU calling into the progress tracker excessively.
+            # Since we are already using the offset, we use that
+            # to damp calls back into the progress tracker.
+            if off % 500 == 0:
+                progtrack.plan_add_progress(progtrack.PLAN_ACTION_CONFLICT)
+
+        of.close()
+        self.__actdict = actdict
+        self.__actdict_timestamp = otimestamp
+        return actdict
+
+    def _get_stripped_actions_file(self, internal=False):
+        """Open the actions file described in _create_fast_lookups() and
+        return the corresponding file object."""
+
+        sf = open(
+            os.path.join(self.__action_cache_dir, "actions.stripped"), "r"
+        )
+        sversion = sf.readline().rstrip()
+        stimestamp = sf.readline().rstrip()
+        if internal:
+            sf.close()
+            return sversion, stimestamp
+
+        return sf
+
+    def _load_conflicting_keys(self):
+        """Load the list of keys which have conflicting actions in the
+        existing image.  If no such list exists, then return None."""
+
+        pth = os.path.join(self.__action_cache_dir, "keys.conflicting")
+        try:
+            with open(pth, "r") as fh:
+                version = fh.readline().rstrip()
+                if version != "VERSION 1":
+                    return None
+                return set(l.rstrip() for l in fh)
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                return None
+            raise
+
+    def gen_installed_actions_bytype(self, atype, implicit_dirs=False):
+        """Iterates through the installed actions of type 'atype'.  If
+        'implicit_dirs' is True and 'atype' is 'dir', then include
+        directories only implicitly defined by other filesystem
+        actions."""
+
+        if implicit_dirs and atype != "dir":
+            implicit_dirs = False
+
+        excludes = self.list_excludes()
+
+        for pfmri in self.gen_installed_pkgs():
+            m = self.get_manifest(pfmri)
+            dirs = set()
+            for act in m.gen_actions_by_type(atype, excludes=excludes):
+                if implicit_dirs:
+                    dirs.add(act.attrs["path"])
+                yield act, pfmri
+            if implicit_dirs:
+                da = pkg.actions.directory.DirectoryAction
+                for d in m.get_directories(excludes):
+                    if d not in dirs:
+                        yield da(path=d, implicit="true"), pfmri
+
+    def get_installed_pubs(self):
+        """Returns a set containing the prefixes of all publishers with
+        installed packages."""
+
+        cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+        return cat.publishers()
+
+    def strtofmri(self, myfmri):
+        return pkg.fmri.PkgFmri(myfmri)
+
+    def strtomatchingfmri(self, myfmri):
+        return pkg.fmri.MatchingPkgFmri(myfmri)
+
+    def get_user_by_name(self, name):
+        uid = self._usersbyname.get(name, None)
+        if uid is not None:
+            return uid
+        return portable.get_user_by_name(name, self.root, self.type != IMG_USER)
+
+    def get_name_by_uid(self, uid, returnuid=False):
+        # XXX What to do about IMG_PARTIAL?
+        try:
+            return portable.get_name_by_uid(
+                uid, self.root, self.type != IMG_USER
+            )
+        except KeyError:
+            if returnuid:
+                return uid
+            else:
+                raise
+
+    def get_group_by_name(self, name):
+        gid = self._groupsbyname.get(name, None)
+        if gid is not None:
+            return gid
+        return portable.get_group_by_name(
+            name, self.root, self.type != IMG_USER
+        )
+
+    def get_name_by_gid(self, gid, returngid=False):
+        try:
+            return portable.get_name_by_gid(
+                gid, self.root, self.type != IMG_USER
+            )
+        except KeyError:
+            if returngid:
+                return gid
+            else:
+                raise
+
+    def get_usernames_by_gid(self, gid):
+        return portable.get_usernames_by_gid(gid, self.root)
+
+    def update_index_dir(self, postfix="index"):
+        """Since the index directory will not reliably be updated when
+        the image root is, this should be called prior to using the
+        index directory.
+        """
+        if self.version == self.CURRENT_VERSION:
+            self.index_dir = os.path.join(self.imgdir, "cache", postfix)
+        else:
+            self.index_dir = os.path.join(self.imgdir, postfix)
+
+    def cleanup_downloads(self):
+        """Clean up any downloads that were in progress but that
+        did not successfully finish."""
+
+        shutil.rmtree(self._incoming_cache_dir, True)
+
+    def cleanup_cached_content(
+        self, progtrack=None, force=False, verbose=False
+    ):
+        """Delete the directory that stores all of our cached
+        downloaded content.  This may take a while for a large
+        directory hierarchy.  Don't clean up caches if the
+        user overrode the underlying setting using PKG_CACHEDIR or
+        PKG_CACHEROOT."""
+
+        if not force and not self.cfg.get_policy(
+            imageconfig.FLUSH_CONTENT_CACHE
+        ):
+            return
+
+        cdirs = []
+        for path, readonly, pub, layout in self.get_cachedirs():
+            if verbose:
+                print("Checking cache directory {} ({})".format(path, pub))
+            if readonly or (
+                self.__user_cache_dir and path.startswith(self.__user_cache_dir)
+            ):
+                continue
+            cdirs.append(path)
+
+        if not cdirs:
+            return
+
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        # 'Updating package cache'
+        progtrack.job_start(progtrack.JOB_PKG_CACHE, goal=len(cdirs))
+        for path in cdirs:
+            shutil.rmtree(path, True)
+            progtrack.job_add_progress(progtrack.JOB_PKG_CACHE)
+        progtrack.job_done(progtrack.JOB_PKG_CACHE)
+
+    def salvage(self, path, full_path=False):
+        """Called when unexpected file or directory is found during
+        package operations; returns the path of the salvage
+        directory where the item was stored. Can be called with
+        either image-relative or absolute (current) path to file/dir
+        to be salvaged.  If full_path is False (the default), remove
+        the current mountpoint of the image from the returned
+        directory path"""
+
+        # This ensures that if the path is already rooted in the image,
+        # that it will be stored in lost+found (due to os.path.join
+        # behaviour with absolute path components).
+        if path.startswith(self.root):
+            path = path.replace(self.root, "", 1)
+
+        if os.path.isabs(path):
+            # If for some reason the path wasn't rooted in the
+            # image, but it is an absolute one, then strip the
+            # absolute part so that it will be stored in lost+found
+            # (due to os.path.join behaviour with absolute path
+            # components).
+            path = os.path.splitdrive(path)[-1].lstrip(os.path.sep)
+
+        sdir = os.path.normpath(
+            os.path.join(
+                self.imgdir,
+                "lost+found",
+                path + "-" + time.strftime("%Y%m%dT%H%M%SZ"),
+            )
+        )
+
+        parent = os.path.dirname(sdir)
+        if not os.path.exists(parent):
+            misc.makedirs(parent)
+
+        orig = os.path.normpath(os.path.join(self.root, path))
+
+        misc.move(orig, sdir)
+        # remove current mountpoint from sdir
+        if not full_path:
+            sdir.replace(self.root, "", 1)
+        return sdir
+
+    def recover(self, local_spath, full_dest_path, dest_path, old_path):
+        """Called when recovering directory contents to implement
+        "salvage-from" directive... full_dest_path must exist.
+        dest_path is the image-relative location where we salvage to,
+        old_path is original image-relative directory that delivered
+        the files we're now recovering.
+
+        When recovering directories where the salvage-from string is
+        a substring of the previously packaged directory, attempt
+        to restore as much of the old directory structure as possible
+        by comparing the salvage-from value with the previously
+        packaged directory.
+
+        For example, say we had user-content in /var/user/myuser/.ssh,
+        but have stopped delivering that dir, replacing it with a new
+        directory /var/.migrate/user which specifies
+        salvage-from=var/user.
+
+        The intent of the package author, was to have the
+        /var/.migrate/user directory get the unpackaged 'myuser/.ssh'
+        directory created as part of the salvaging operation, giving
+        them /var/.migrate/user/myuser/.ssh
+        and not to just end up with
+        /var/.migrate/user/<contents of .ssh dir from myuser>
+        """
+
+        source_path = os.path.normpath(os.path.join(self.root, local_spath))
+        if dest_path != old_path and old_path.startswith(
+            dest_path + os.path.sep
+        ):
+            # this is here so that when salvaging the contents
+            # of a previously packaged directory, we attempt to
+            # restore as much of the old directory structure as
+            # possible.
+            spath = os.path.relpath(old_path, dest_path)
+            full_dest_path = os.path.join(full_dest_path, spath)
+            try:
+                os.makedirs(full_dest_path)
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise e
+
+        for file_name in os.listdir(source_path):
+            misc.move(os.path.join(source_path, file_name), full_dest_path)
+
+    def temporary_dir(self):
+        """Create a temp directory under the image directory for various
+        purposes.  If the process is unable to create a directory in the
+        image's temporary directory, a replacement location is found."""
+
+        try:
+            misc.makedirs(self.__tmpdir)
+        except (apx.PermissionsException, apx.ReadOnlyFileSystemException):
+            self.__tmpdir = tempfile.mkdtemp(prefix="pkg5tmp-")
+            atexit.register(shutil.rmtree, self.__tmpdir, ignore_errors=True)
+            return self.temporary_dir()
+
+        try:
+            rval = tempfile.mkdtemp(dir=self.__tmpdir)
+
+            # Force standard mode.
+            os.chmod(rval, misc.PKG_DIR_MODE)
+            return rval
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES or e.errno == errno.EROFS:
+                self.__tmpdir = tempfile.mkdtemp(prefix="pkg5tmp-")
+                atexit.register(
+                    shutil.rmtree, self.__tmpdir, ignore_errors=True
+                )
+                return self.temporary_dir()
+            raise apx._convert_error(e)
+
+    def temporary_file(self, close=True):
+        """Create a temporary file under the image directory for various
+        purposes.  If 'close' is True, close the file descriptor;
+        otherwise leave it open.  If the process is unable to create a
+        file in the image's temporary directory, a replacement is
+        found."""
+
+        try:
+            misc.makedirs(self.__tmpdir)
+        except (apx.PermissionsException, apx.ReadOnlyFileSystemException):
+            self.__tmpdir = tempfile.mkdtemp(prefix="pkg5tmp-")
+            atexit.register(shutil.rmtree, self.__tmpdir, ignore_errors=True)
+            return self.temporary_file(close=close)
+
+        try:
+            fd, name = tempfile.mkstemp(dir=self.__tmpdir)
+            if close:
+                os.close(fd)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES or e.errno == errno.EROFS:
+                self.__tmpdir = tempfile.mkdtemp(prefix="pkg5tmp-")
+                atexit.register(
+                    shutil.rmtree, self.__tmpdir, ignore_errors=True
+                )
+                return self.temporary_file(close=close)
+            raise apx._convert_error(e)
+
+        if close:
+            return name
+        else:
+            return fd, name
+
+    def __filter_install_matches(self, matches):
+        """Attempts to eliminate redundant matches found during
+        packaging operations:
+
+            * First, stems of installed packages for publishers that
+              are now unknown (no longer present in the image
+              configuration) are dropped.
+
+            * Second, if multiple matches are still present, stems of
+              of installed packages, that are not presently in the
+              corresponding publisher's catalog, are dropped.
+
+            * Finally, if multiple matches are still present, all
+              stems except for those in state PKG_STATE_INSTALLED are
+              dropped.
+
+        Returns a list of the filtered matches, along with a dict of
+        their unique names."""
+
+        olist = []
+        onames = set()
+
+        # First eliminate any duplicate matches that are for unknown
+        # publishers (publishers which have been removed from the image
+        # configuration).
+        publist = set(p.prefix for p in self.get_publishers().values())
+        for m, st in matches:
+            if m.publisher in publist:
+                onames.add(m.get_pkg_stem())
+                olist.append((m, st))
+
+        # Next, if there are still multiple matches, eliminate matches
+        # belonging to publishers that no longer have the FMRI in their
+        # catalog.
+        found_state = False
+        if len(onames) > 1:
+            mlist = []
+            mnames = set()
+            for m, st in olist:
+                if not st["in_catalog"]:
+                    continue
+                if st["state"] == pkgdefs.PKG_STATE_INSTALLED:
+                    found_state = True
+                mnames.add(m.get_pkg_stem())
+                mlist.append((m, st))
+            olist = mlist
+            onames = mnames
+
+        # Finally, if there are still multiple matches, and a known
+        # stem is installed, then eliminate any stems that do not
+        # have an installed version.
+        if found_state and len(onames) > 1:
+            mlist = []
+            mnames = set()
+            for m, st in olist:
+                if st["state"] == pkgdefs.PKG_STATE_INSTALLED:
+                    mnames.add(m.get_pkg_stem())
+                    mlist.append((m, st))
+            olist = mlist
+            onames = mnames
+
+        return olist, onames
+
+    def flag_pkgs(self, pfmris, state, value, progtrack):
+        """Sets/unsets a state flag for packages installed in
+        the image."""
+
+        if self.version < self.CURRENT_VERSION:
+            raise apx.ImageFormatUpdateNeeded(self.root)
+
+        # Only the 'manual' flag can be set or unset via this
+        # method.
+        if state not in [pkgdefs.PKG_STATE_MANUAL]:
+            raise apx.ImagePkgStateError(pfmri, state)
+
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        with self.locked_op("state"):
+            icat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
+            kcat = self.get_catalog(self.IMG_CATALOG_KNOWN)
+
+            progtrack.job_start(progtrack.JOB_STATE_DB)
+
+            changed = set()
+
+            for pfmri in pfmris:
+                entry = kcat.get_entry(pfmri)
+                mdata = entry.get("metadata", {})
+                states = set(mdata.get("states", set()))
+
+                if pkgdefs.PKG_STATE_INSTALLED not in states:
+                    raise apx.ImagePkgStateError(pfmri, states)
+
+                progtrack.job_add_progress(progtrack.JOB_STATE_DB)
+
+                if value and state not in states:
+                    states.add(state)
+                    changed.add(pfmri)
+                elif not value and state in states:
+                    states.discard(state)
+                    changed.add(pfmri)
+                else:
+                    continue
+
+                # Catalog format only supports lists.
+                mdata["states"] = list(states)
+
+                # Now record the package state.
+                kcat.update_entry(mdata, pfmri=pfmri)
+                icat.update_entry(mdata, pfmri=pfmri)
+
+            progtrack.job_done(progtrack.JOB_STATE_DB)
+
+            if len(changed):
+                progtrack.job_start(progtrack.JOB_IMAGE_STATE)
+                self.__catalog_save(
+                    [
+                        (kcat, self.IMG_CATALOG_KNOWN),
+                        (icat, self.IMG_CATALOG_INSTALLED),
+                    ],
+                    changed,
+                    progtrack,
+                )
+                progtrack.job_done(progtrack.JOB_IMAGE_STATE)
+
+            print(
+                "{} package{} updated.".format(
+                    len(changed), "s" if len(changed) != 1 else ""
+                )
+            )
+
+    def avoid_pkgs(self, pat_list, progtrack, check_cancel):
+        """Avoid the specified packages... use pattern matching on
+        names; ignore versions."""
+
+        with self.locked_op("avoid"):
+            ip = imageplan.ImagePlan
+            self._avoid_set_save(
+                self.avoid_set_get()
+                | set(ip.match_user_stems(self, pat_list, ip.MATCH_UNINSTALLED))
+            )
+
+    def unavoid_pkgs(self, pat_list, progtrack, check_cancel):
+        """Unavoid the specified packages... use pattern matching on
+        names; ignore versions."""
+
+        with self.locked_op("unavoid"):
+            ip = imageplan.ImagePlan
+            unavoid_set = set(ip.match_user_stems(self, pat_list, ip.MATCH_ALL))
+            current_set = self.avoid_set_get()
+            not_avoided = unavoid_set - current_set
+            if not_avoided:
+                raise apx.PlanCreationException(not_avoided=not_avoided)
+
+            # Don't allow unavoid if removal of the package from the
+            # avoid list would require the package to be installed
+            # as this would invalidate current image state.  If the
+            # package is already installed though, it doesn't really
+            # matter if it's a target of an avoid or not.
+            installed_set = set([f.pkg_name for f in self.gen_installed_pkgs()])
+
+            would_install = [
+                a
+                for f, a in self.gen_tracked_stems()
+                if a in unavoid_set and a not in installed_set
+            ]
+
+            if would_install:
+                raise apx.PlanCreationException(would_install=would_install)
+
+            self._avoid_set_save(current_set - unavoid_set)
+
+    def get_avoid_dict(self):
+        """return dict of lists (avoided stem, pkgs w/ group
+        dependencies on this pkg)"""
+        ret = dict((a, list()) for a in self.avoid_set_get())
+        for fmri, group in self.gen_tracked_stems():
+            if group in ret:
+                ret[group].append(fmri.pkg_name)
+        return ret
+
+    def freeze_pkgs(self, pat_list, progtrack, check_cancel, dry_run, comment):
+        """Freeze the specified packages... use pattern matching on
+        names.
+
+        The 'pat_list' parameter contains the list of patterns of
+        packages to freeze.
+
+        The 'progtrack' parameter contains the progress tracker for this
+        operation.
+
+        The 'check_cancel' parameter contains a function to call to
+        check if the operation has been canceled.
+
+        The 'dry_run' parameter controls whether packages are actually
+        frozen.
+
+        The 'comment' parameter contains the comment, if any, which will
+        be associated with the packages that are frozen.
+        """
+
+        def __make_publisherless_fmri(pat):
+            p = pkg.fmri.MatchingPkgFmri(pat)
+            p.publisher = None
+            return p
+
+        def __calc_frozen():
+            stems_and_pats = imageplan.ImagePlan.freeze_pkgs_match(
+                self, pat_list
+            )
+            return dict(
+                [
+                    (s, __make_publisherless_fmri(p))
+                    for s, p in six.iteritems(stems_and_pats)
+                ]
+            )
+
+        if dry_run:
+            return list(__calc_frozen().values())
+        with self.locked_op("freeze"):
+            stems_and_pats = __calc_frozen()
+            # Get existing dictionary of frozen packages.
+            d = self.__freeze_dict_load()
+            # Update the dictionary with the new freezes and
+            # comment.
+            timestamp = calendar.timegm(time.gmtime())
+            d.update(
+                [
+                    (s, (str(p), comment, timestamp))
+                    for s, p in six.iteritems(stems_and_pats)
+                ]
+            )
+            self._freeze_dict_save(d)
+            return list(stems_and_pats.values())
+
+    def unfreeze_pkgs(self, pat_list, progtrack, check_cancel, dry_run):
+        """Unfreeze the specified packages... use pattern matching on
+        names; ignore versions.
+
+        The 'pat_list' parameter contains the list of patterns of
+        packages to freeze.
+
+        The 'progtrack' parameter contains the progress tracker for this
+        operation.
+
+        The 'check_cancel' parameter contains a function to call to
+        check if the operation has been canceled.
+
+        The 'dry_run' parameter controls whether packages are actually
+        frozen."""
+
+        def __calc_unfrozen():
+            # Get existing dictionary of frozen packages.
+            d = self.__freeze_dict_load()
+            # Match the user's patterns against the frozen packages
+            # and return the stems which matched, and the dictionary
+            # of the currently frozen packages.
+            ip = imageplan.ImagePlan
+            return (
+                set(
+                    ip.match_user_stems(
+                        self,
+                        pat_list,
+                        ip.MATCH_ALL,
+                        raise_unmatched=False,
+                        universe=[(None, k) for k in d.keys()],
+                    )
+                ),
+                d,
+            )
+
+        if dry_run:
+            return __calc_unfrozen()[0]
+        with self.locked_op("freeze"):
+            unfrozen_set, d = __calc_unfrozen()
+            # Remove the specified packages from the frozen set.
+            for n in unfrozen_set:
+                d.pop(n, None)
+            self._freeze_dict_save(d)
+            return unfrozen_set
+
+    def __call_imageplan_evaluate(self, ip):
+        # A plan can be requested without actually performing an
+        # operation on the image.
+        if self.history.operation_name:
+            self.history.operation_start_state = ip.get_plan()
+
+        try:
+            ip.evaluate()
+        except apx.ConflictingActionErrors:
+            # Image plan evaluation can fail because of duplicate
+            # action discovery, but we still want to be able to
+            # display and log the solved FMRI changes.
+            self.imageplan = ip
+            if self.history.operation_name:
+                self.history.operation_end_state = (
+                    "Unevaluated: merged plan had errors\n"
+                    + ip.get_plan(full=False)
+                )
+            raise
+
+        self.imageplan = ip
+
+        if self.history.operation_name:
+            self.history.operation_end_state = ip.get_plan(full=False)
+
+    def __make_plan_common(
+        self,
+        _op,
+        _progtrack,
+        _check_cancel,
+        _noexecute,
+        _ip_noop=False,
+        **kwargs,
+    ):
+        """Private helper function to perform base plan creation and
+        cleanup.
+        """
+
+        if DebugValues.get_value("simulate-plan-hang"):
+            # If pkg5.hang file is present in image dir, then
+            # sleep after loading configuration until file is
+            # gone.  This is used by the test suite for signal
+            # handling testing, etc.
+            hang_file = os.path.join(self.imgdir, "pkg5.hang")
+            with open(hang_file, "w") as f:
+                f.write(str(os.getpid()))
+
+            while os.path.exists(hang_file):
+                time.sleep(1)
+
+        # Allow garbage collection of previous plan.
+        self.imageplan = None
+
+        ip = imageplan.ImagePlan(
+            self, _op, _progtrack, _check_cancel, noexecute=_noexecute
+        )
+
+        # Always start with most current (on-disk) state information.
+        self.__init_catalogs()
+
+        try:
+            try:
+                if _ip_noop:
+                    ip.plan_noop(**kwargs)
+                elif _op in [
+                    pkgdefs.API_OP_ATTACH,
+                    pkgdefs.API_OP_DETACH,
+                    pkgdefs.API_OP_SYNC,
+                ]:
+                    ip.plan_sync(**kwargs)
+                elif _op in [
+                    pkgdefs.API_OP_CHANGE_FACET,
+                    pkgdefs.API_OP_CHANGE_VARIANT,
+                ]:
+                    ip.plan_change_varcets(**kwargs)
+                elif _op == pkgdefs.API_OP_DEHYDRATE:
+                    ip.plan_dehydrate(**kwargs)
+                elif _op == pkgdefs.API_OP_INSTALL:
+                    ip.plan_install(**kwargs)
+                elif _op == pkgdefs.API_OP_EXACT_INSTALL:
+                    ip.plan_exact_install(**kwargs)
+                elif _op in [pkgdefs.API_OP_FIX, pkgdefs.API_OP_VERIFY]:
+                    ip.plan_fix(**kwargs)
+                elif _op == pkgdefs.API_OP_REHYDRATE:
+                    ip.plan_rehydrate(**kwargs)
+                elif _op == pkgdefs.API_OP_REVERT:
+                    ip.plan_revert(**kwargs)
+                elif _op == pkgdefs.API_OP_SET_MEDIATOR:
+                    ip.plan_set_mediators(**kwargs)
+                elif _op == pkgdefs.API_OP_UNINSTALL:
+                    ip.plan_uninstall(**kwargs)
+                elif _op == pkgdefs.API_OP_UPDATE:
+                    ip.plan_update(**kwargs)
+                else:
+                    raise RuntimeError("Unknown api op: {0}".format(_op))
+
+            except apx.ActionExecutionError as e:
+                raise
+            except pkg.actions.ActionError as e:
+                raise apx.InvalidPackageErrors([e])
+            except apx.ApiException:
+                raise
+            try:
+                self.__call_imageplan_evaluate(ip)
+            except apx.ActionExecutionError as e:
+                raise
+            except pkg.actions.ActionError as e:
+                raise apx.InvalidPackageErrors([e])
+        finally:
+            self.__cleanup_alt_pkg_certs()
+
+    def make_install_plan(
+        self,
+        op,
+        progtrack,
+        check_cancel,
+        noexecute,
+        pkgs_inst=None,
+        reject_list=misc.EmptyI,
+    ):
+        """Take a list of packages, specified in pkgs_inst, and attempt
+        to assemble an appropriate image plan.  This is a helper
+        routine for some common operations in the client.
+        """
+
+        progtrack.plan_all_start()
+
+        self.__make_plan_common(
+            op,
+            progtrack,
+            check_cancel,
+            noexecute,
+            pkgs_inst=pkgs_inst,
+            reject_list=reject_list,
+        )
+
+        progtrack.plan_all_done()
+
+    def make_change_varcets_plan(
+        self,
+        op,
+        progtrack,
+        check_cancel,
+        noexecute,
+        facets=None,
+        reject_list=misc.EmptyI,
+        variants=None,
+    ):
+        """Take a list of variants and/or facets and attempt to
+        assemble an image plan which changes them.  This is a helper
+        routine for some common operations in the client."""
+
+        progtrack.plan_all_start()
+        # compute dict of changing variants
+        if variants:
+            new = set(six.iteritems(variants))
+            cur = set(six.iteritems(self.cfg.variants))
+            variants = dict(new - cur)
+        elif facets:
+            new_facets = self.get_facets()
+            for f in facets:
+                if facets[f] is None:
+                    new_facets.pop(f, None)
+                else:
+                    new_facets[f] = facets[f]
+            facets = new_facets
+
+        self.__make_plan_common(
+            op,
+            progtrack,
+            check_cancel,
+            noexecute,
+            new_variants=variants,
+            new_facets=facets,
+            reject_list=reject_list,
+        )
+
+        progtrack.plan_all_done()
+
+    def make_set_mediators_plan(
+        self, op, progtrack, check_cancel, noexecute, mediators
+    ):
+        """Take a dictionary of mediators and attempt to assemble an
+        appropriate image plan to set or revert them based on the
+        provided version and implementation values.  This is a helper
+        routine for some common operations in the client.
+        """
+
+        progtrack.plan_all_start()
+
+        # Compute dict of changing mediators.
+        new_mediators = copy.deepcopy(mediators)
+        old_mediators = self.cfg.mediators
+        invalid_mediations = collections.defaultdict(dict)
+        for m in new_mediators.keys():
+            new_values = new_mediators[m]
+            if not new_values:
+                if m not in old_mediators:
+                    # Nothing to revert.
+                    del new_mediators[m]
+                    continue
+
+                # Revert mediator to defaults.
+                new_mediators[m] = {}
+                continue
+
+            # Validate mediator, provided version, implementation,
+            # and source.
+            valid, error = med.valid_mediator(m)
+            if not valid:
+                invalid_mediations[m]["mediator"] = (m, error)
+
+            med_version = new_values.get("version")
+            if med_version:
+                valid, error = med.valid_mediator_version(med_version)
+                if valid:
+                    new_mediators[m]["version"] = pkg.version.Version(
+                        med_version
+                    )
+                else:
+                    invalid_mediations[m]["version"] = (med_version, error)
+
+            med_impl = new_values.get("implementation")
+            if med_impl:
+                valid, error = med.valid_mediator_implementation(
+                    med_impl, allow_empty_version=True
+                )
+                if not valid:
+                    invalid_mediations[m]["version"] = (med_impl, error)
+
+        if invalid_mediations:
+            raise apx.PlanCreationException(
+                invalid_mediations=invalid_mediations
+            )
+
+        self.__make_plan_common(
+            op, progtrack, check_cancel, noexecute, new_mediators=new_mediators
+        )
+
+        progtrack.plan_all_done()
+
+    def make_sync_plan(
+        self,
+        op,
+        progtrack,
+        check_cancel,
+        noexecute,
+        li_pkg_updates=True,
+        reject_list=misc.EmptyI,
+    ):
+        """Attempt to create an appropriate image plan to bring an
+        image in sync with it's linked image constraints.  This is a
+        helper routine for some common operations in the client."""
+
+        progtrack.plan_all_start()
+
+        self.__make_plan_common(
+            op,
+            progtrack,
+            check_cancel,
+            noexecute,
+            reject_list=reject_list,
+            li_pkg_updates=li_pkg_updates,
+        )
+
+        progtrack.plan_all_done()
+
+    def make_uninstall_plan(
+        self,
+        op,
+        progtrack,
+        check_cancel,
+        ignore_missing,
+        noexecute,
+        pkgs_to_uninstall,
+    ):
+        """Create uninstall plan to remove the specified packages."""
+
+        progtrack.plan_all_start()
+
+        self.__make_plan_common(
+            op,
+            progtrack,
+            check_cancel,
+            noexecute,
+            ignore_missing=ignore_missing,
+            pkgs_to_uninstall=pkgs_to_uninstall,
+        )
+
+        progtrack.plan_all_done()
+
+    def make_update_plan(
+        self,
+        op,
+        progtrack,
+        check_cancel,
+        noexecute,
+        ignore_missing=False,
+        pkgs_update=None,
+        reject_list=misc.EmptyI,
+    ):
+        """Create a plan to update all packages or the specific ones as
+        far as possible.  This is a helper routine for some common
+        operations in the client.
+        """
+
+        progtrack.plan_all_start()
+        self.__make_plan_common(
+            op,
+            progtrack,
+            check_cancel,
+            noexecute,
+            ignore_missing=ignore_missing,
+            pkgs_update=pkgs_update,
+            reject_list=reject_list,
+        )
+        progtrack.plan_all_done()
+
+    def make_revert_plan(
+        self, op, progtrack, check_cancel, noexecute, args, tagged
+    ):
+        """Revert the specified files, or all files tagged as specified
+        in args to their manifest definitions.
+        """
+
+        progtrack.plan_all_start()
+        self.__make_plan_common(
+            op, progtrack, check_cancel, noexecute, args=args, tagged=tagged
+        )
+        progtrack.plan_all_done()
+
+    def make_dehydrate_plan(
+        self, op, progtrack, check_cancel, noexecute, publishers
+    ):
+        """Remove non-editable files and hardlinks from an image."""
+
+        progtrack.plan_all_start()
+        self.__make_plan_common(
+            op, progtrack, check_cancel, noexecute, publishers=publishers
+        )
+        progtrack.plan_all_done()
+
+    def make_rehydrate_plan(
+        self, op, progtrack, check_cancel, noexecute, publishers
+    ):
+        """Reinstall non-editable files and hardlinks to an dehydrated
+        image."""
+
+        progtrack.plan_all_start()
+        self.__make_plan_common(
+            op, progtrack, check_cancel, noexecute, publishers=publishers
+        )
+        progtrack.plan_all_done()
+
+    def make_fix_plan(
+        self,
+        op,
+        progtrack,
+        check_cancel,
+        noexecute,
+        args,
+        unpackaged=False,
+        unpackaged_only=False,
+        verify_paths=EmptyI,
+    ):
+        """Create an image plan to fix the image. Note: verify shares
+        the same routine."""
+
+        progtrack.plan_all_start()
+        self.__make_plan_common(
+            op,
+            progtrack,
+            check_cancel,
+            noexecute,
+            args=args,
+            unpackaged=unpackaged,
+            unpackaged_only=unpackaged_only,
+            verify_paths=verify_paths,
+        )
+        progtrack.plan_all_done()
+
+    def make_noop_plan(self, op, progtrack, check_cancel, noexecute):
+        """Create an image plan that doesn't update the image in any
+        way."""
+
+        progtrack.plan_all_start()
+        self.__make_plan_common(
+            op, progtrack, check_cancel, noexecute, _ip_noop=True
+        )
+        progtrack.plan_all_done()
+
+    def ipkg_is_up_to_date(
+        self, check_cancel, noexecute, refresh_allowed=True, progtrack=None
+    ):
+        """Test whether the packaging system is updated to the latest
+        version known to be available for this image."""
+
+        #
+        # This routine makes the distinction between the "target image",
+        # which will be altered, and the "running image", which is
+        # to say whatever image appears to contain the version of the
+        # pkg command we're running.
+        #
+
+        #
+        # There are two relevant cases here:
+        #     1) Packaging code and image we're updating are the same
+        #        image.  (i.e. 'pkg update')
+        #
+        #     2) Packaging code's image and the image we're updating are
+        #        different (i.e. 'pkg update -R')
+        #
+        # In general, we care about getting the user to run the
+        # most recent packaging code available for their build.  So,
+        # if we're not in the liveroot case, we create a new image
+        # which represents "/" on the system.
+        #
+
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        img = self
+
+        if self.__cmddir and not img.is_liveroot():
+            #
+            # Find the path to ourselves, and use that
+            # as a way to locate the image we're in.  It's
+            # not perfect-- we could be in a developer's
+            # workspace, for example.
+            #
+            newimg = Image(
+                self.__cmddir,
+                allow_ondisk_upgrade=False,
+                progtrack=progtrack,
+                cmdpath=self.cmdpath,
+            )
+            useimg = True
+            if refresh_allowed:
+                # If refreshing publisher metadata is allowed,
+                # then perform a refresh so that a new packaging
+                # system package can be discovered.
+                newimg.lock(allow_unprivileged=True)
+                try:
+                    newimg.refresh_publishers(progtrack=progtrack)
+                except (apx.ImageFormatUpdateNeeded, apx.PermissionsException):
+                    # Can't use the image to perform an
+                    # update check and it would be wrong
+                    # to prevent the operation from
+                    # continuing in these cases.
+                    useimg = False
+                except apx.CatalogRefreshException as cre:
+                    cre.errmessage = _("pkg(7) update check failed.")
+                    raise
+                finally:
+                    newimg.unlock()
+
+            if useimg:
+                img = newimg
+
+        pfmri = img.get_version_installed(img.strtofmri("package/pkg"))
+        if not pfmri or not pkgdefs.PKG_STATE_UPGRADABLE in img.get_pkg_state(
+            pfmri
+        ):
+            # If no version of the package system is installed or a
+            # newer version isn't available, then the client is
+            # "up-to-date".
+            return True
+
+        inc_fmri = img.get_version_installed(
+            img.strtofmri("consolidation/ips/ips-incorporation")
+        )
+        if inc_fmri:
+            # If the ips-incorporation is installed (it should be
+            # since package/pkg depends on it), then we can
+            # bypass the solver and plan evaluation if none of the
+            # newer versions are allowed by the incorporation.
+
+            # Find the version at which package/pkg is incorporated.
+            cat = img.get_catalog(img.IMG_CATALOG_KNOWN)
+            inc_ver = None
+            for act in cat.get_entry_actions(
+                inc_fmri, [cat.DEPENDENCY], excludes=img.list_excludes()
+            ):
+                if (
+                    act.name == "depend"
+                    and act.attrs["type"] == "incorporate"
+                    and act.attrs["fmri"].startswith("package/pkg")
+                ):
+                    inc_ver = img.strtofmri(act.attrs["fmri"]).version
+                    break
+
+            if inc_ver:
+                for ver, fmris in cat.fmris_by_version("package/pkg"):
+                    if ver != pfmri.version and ver.is_successor(
+                        inc_ver, pkg.version.CONSTRAINT_AUTO
+                    ):
+                        break
+                else:
+                    # No version is newer than installed and
+                    # satisfied incorporation constraint.
+                    return True
+
+        # XXX call to progress tracker that the package is being
+        # refreshed
+        img.make_install_plan(
+            pkgdefs.API_OP_INSTALL,
+            progtrack,
+            check_cancel,
+            noexecute,
+            pkgs_inst=["pkg:/package/pkg"],
+        )
+
+        return img.imageplan.nothingtodo()
+
+    # avoid set implementation uses json to store a set of pkg_stems
+    # being avoided (explicitly or implicitly), and a set of tracked stems
+    # that are obsolete.
+    #
+    # format is (version, dict((pkg stem, "avoid", "implicit-avoid" or
+    # "obsolete"))
+
+    __AVOID_SET_VERSION = 1
+
+    def avoid_set_get(self, implicit=False):
+        """Return copy of avoid set"""
+        if implicit:
+            return self.__implicit_avoid_set.copy()
+        return self.__avoid_set.copy()
+
+    def obsolete_set_get(self):
+        """Return copy of tracked obsolete pkgs"""
+        return self.__group_obsolete.copy()
+
+    def __avoid_set_load(self):
+        """Load avoid set fron image state directory"""
+        state_file = os.path.join(self._statedir, "avoid_set")
+        self.__avoid_set = set()
+        self.__implicit_avoid_set = set()
+        self.__group_obsolete = set()
+        if os.path.isfile(state_file):
+            try:
+                with open(state_file) as f:
+                    version, d = json.load(f)
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+            except ValueError as e:
+                salvaged_path = self.salvage(state_file, full_path=True)
+                logger.warning(
+                    "Corrupted avoid list - salvaging"
+                    " file {state_file} in {salvaged_path}".format(
+                        state_file=state_file, salvaged_path=salvaged_path
+                    )
+                )
+                return
+            assert version == self.__AVOID_SET_VERSION
+            for stem in d:
+                if d[stem] == "avoid":
+                    self.__avoid_set.add(stem)
+                elif d[stem] == "implicit-avoid":
+                    self.__implicit_avoid_set.add(stem)
+                elif d[stem] == "obsolete":
+                    self.__group_obsolete.add(stem)
+                else:
+                    logger.warning("Corrupted avoid list - ignoring")
+                    self.__avoid_set = set()
+                    self.__implicit_avoid_set = set()
+                    self.__group_obsolete = set()
+                    self.__avoid_set_altered = True
+        else:
+            self.__avoid_set_altered = True
+
+    def _avoid_set_save(self, new_set=None, implicit_avoid=None, obsolete=None):
+        """Store avoid set to image state directory"""
+        if new_set is not None:
+            self.__avoid_set_altered = True
+            self.__avoid_set = new_set
+
+        if implicit_avoid is not None:
+            self.__avoid_set_altered = True
+            self.__implicit_avoid_set = implicit_avoid
+
+        if obsolete is not None:
+            self.__group_obsolete = obsolete
+            self.__avoid_set_altered = True
+
+        if not self.__avoid_set_altered:
+            return
+
+        state_file = os.path.join(self._statedir, "avoid_set")
+        tmp_file = os.path.join(self._statedir, "avoid_set.new")
+        tf = open(tmp_file, "w")
+
+        d = dict((a, "avoid") for a in self.__avoid_set)
+        d.update((a, "implicit-avoid") for a in self.__implicit_avoid_set)
+        d.update((a, "obsolete") for a in self.__group_obsolete)
+
+        try:
+            json.dump((self.__AVOID_SET_VERSION, d), tf)
+            tf.close()
+            portable.rename(tmp_file, state_file)
+        except Exception as e:
+            logger.warning("Cannot save avoid list: {0}".format(str(e)))
+            return
+
+        self.update_last_modified()
+
+        self.__avoid_set_altered = False
+
+    # frozen dict implementation uses json to store a dictionary of
+    # pkg_stems that are frozen, the versions at which they're frozen, and
+    # the reason, if given, why the package was frozen.
+    #
+    # format is (version, dict((pkg stem, (fmri, comment, timestamp))))
+
+    __FROZEN_DICT_VERSION = 1
+
+    def get_frozen_list(self):
+        """Return a list of tuples containing the fmri that was frozen,
+        and the reason it was frozen."""
+
+        return [
+            (pkg.fmri.MatchingPkgFmri(v[0]), v[1], v[2])
+            for v in self.__freeze_dict_load().values()
+        ]
+
+    def __freeze_dict_load(self):
+        """Load the dictionary containing the current state of frozen
+        packages."""
+
+        state_file = os.path.join(self._statedir, "frozen_dict")
+        if os.path.isfile(state_file):
+            try:
+                with open(state_file) as f:
+                    version, d = json.load(f)
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+            except ValueError as e:
+                raise apx.InvalidFreezeFile(state_file)
+            if version != self.__FROZEN_DICT_VERSION:
+                raise apx.UnknownFreezeFileVersion(
+                    version, self.__FROZEN_DICT_VERSION, state_file
+                )
+            return d
+        return {}
+
+    def _freeze_dict_save(self, new_dict):
+        """Save the dictionary of frozen packages."""
+
+        # Save the dictionary to disk.
+        state_file = os.path.join(self._statedir, "frozen_dict")
+        tmp_file = os.path.join(self._statedir, "frozen_dict.new")
+
+        try:
+            with open(tmp_file, "w") as tf:
+                json.dump((self.__FROZEN_DICT_VERSION, new_dict), tf)
+            portable.rename(tmp_file, state_file)
+            self.update_last_modified()
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+        self.__rebuild_image_catalogs()
+
+    @staticmethod
+    def get_dehydrated_exclude_func(dehydrated_pubs):
+        """A boolean function that will be added to the pkg(7) exclude
+        mechanism to determine if an action is allowed to be installed
+        based on whether its publisher is going to be dehydrated or has
+        been currently dehydrated."""
+
+        # A closure is used so that the list of dehydrated publishers
+        # can be accessed.
+        def __allow_action_dehydrate(act, publisher):
+            if publisher not in dehydrated_pubs:
+                # Allow actions from publishers that are not
+                # dehydrated.
+                return True
+
+            aname = act.name
+            if aname == "file":
+                attrs = act.attrs
+                if attrs.get("dehydrate") == "false":
+                    return True
+                if "preserve" in attrs or "overlay" in attrs:
+                    return True
+                return False
+            elif aname == "hardlink":
                 return False
 
-        def __end_state_update(self):
-                """Called when we're done updating the image catalog."""
+            return True
 
-                # get the path to the image catalog update flag file
-                pathname = self.__state_updating_pathname()
+        return __allow_action_dehydrate
 
-                # delete the flag file.
-                try:
-                        portable.remove(pathname)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
-
-        def __rebuild_image_catalogs(self, progtrack=None):
-                """Rebuilds the image catalogs based on the available publisher
-                catalogs."""
-
-                if self.version < 3:
-                        raise apx.ImageFormatUpdateNeeded(self.root)
-
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-
-                progtrack.cache_catalogs_start()
-
-                publist = list(self.gen_publishers())
-
-                be_name, be_uuid = bootenv.BootEnv.get_be_name(self.root)
-                self.history.log_operation_start("rebuild-image-catalogs",
-                    be_name=be_name, be_uuid=be_uuid)
-
-                # Mark all operations as occurring at this time.
-                op_time = datetime.datetime.utcnow()
-
-                # The image catalogs need to be updated, but this is a bit
-                # tricky as previously known packages must remain known even
-                # if PKG_STATE_KNOWN is no longer true if any other state
-                # information is present.  This is to allow freezing, etc. of
-                # package states on a permanent basis even if the package is
-                # no longer available from a publisher repository.  However,
-                # this is only True of installed packages.
-                old_icat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-
-                # batch_mode is set to True here since without it, catalog
-                # population time is almost doubled (since the catalog is
-                # re-sorted and stats are generated for every operation).
-                # In addition, the new catalog is first created in a new
-                # temporary directory so that it can be moved into place
-                # at the very end of this process (to minimize the chance
-                # that failure or interruption will cause the image to be
-                # left in an inconsistent state).
-                tmp_state_root = self.temporary_dir()
-
-                # Copy any regular files placed in the state directory
-                for p in os.listdir(self._statedir):
-                        if p == self.__STATE_UPDATING_FILE:
-                                # don't copy the state updating file
-                                continue
-                        fp = os.path.join(self._statedir, p)
-                        if os.path.isfile(fp):
-                                portable.copyfile(fp, os.path.join(tmp_state_root, p))
-
-                kcat = pkg.catalog.Catalog(batch_mode=True,
-                    meta_root=os.path.join(tmp_state_root,
-                    self.IMG_CATALOG_KNOWN), sign=False)
-
-                # XXX if any of the below fails for any reason, the old 'known'
-                # catalog needs to be re-loaded so the client is in a consistent
-                # state.
-
-                # All enabled publisher catalogs must be processed.
-                pub_cats = [(pub.prefix, pub.catalog) for pub in publist]
-
-                # XXX For backwards compatibility, 'upgradability' of packages
-                # is calculated and stored based on whether a given pkg stem
-                # matches the newest version in the catalog.  This is quite
-                # expensive (due to overhead), but at least the cost is
-                # consolidated here.  This comparison is also cross-publisher,
-                # as it used to be.  In the future, it could likely be improved
-                # by usage of the SAT solver.
-                newest = {}
-                for pfx, cat in [(None, old_icat)] + pub_cats:
-                        for f in cat.fmris(last=True,
-                            pubs=pfx and [pfx] or EmptyI):
-                                nver, snver = newest.get(f.pkg_name, (None,
-                                    None))
-                                if f.version > nver:
-                                        newest[f.pkg_name] = (f.version,
-                                            str(f.version))
-
-                # Next, copy all of the entries for the catalog parts that
-                # currently exist into the image 'known' catalog.
-
-                # Iterator for source parts.
-                sparts = (
-                   (pfx, cat, name, cat.get_part(name, must_exist=True))
-                   for pfx, cat in pub_cats
-                   for name in cat.parts
-                )
-
-                # Build list of installed packages based on actual state
-                # information just in case there is a state issue from an
-                # older client.
-                # Also stash away any old metadata, in particular we want
-                # the last-install and last-update times but maybe other
-                # metadata will be useful in the future.
-                inst_stems = {}
-                for t, entry in old_icat.tuple_entries():
-                        states = entry["metadata"]["states"]
-                        if pkgdefs.PKG_STATE_INSTALLED not in states:
-                                continue
-                        pub, stem, ver = t
-                        inst_stems.setdefault(pub, {})
-                        inst_stems[pub].setdefault(stem, {})
-                        inst_stems[pub][stem][ver] = { "installed": False,
-                            "metadata" : entry["metadata"] }
-
-                # Create the new installed catalog in a temporary location.
-                icat = pkg.catalog.Catalog(batch_mode=True,
-                    meta_root=os.path.join(tmp_state_root,
-                    self.IMG_CATALOG_INSTALLED), sign=False)
-
-                excludes = self.list_excludes()
-
-                frozen_pkgs = dict([
-                    (p[0].pkg_name, p[0]) for p in self.get_frozen_list()
-                ])
-                for pfx, cat, name, spart in sparts:
-                        # 'spart' is the source part.
-                        if spart is None:
-                                # Client hasn't retrieved this part.
-                                continue
-
-                        # New known part.
-                        nkpart = kcat.get_part(name)
-                        nipart = icat.get_part(name)
-                        base = name.startswith("catalog.base.")
-
-                        # Avoid accessor overhead since these will be
-                        # used for every entry.
-                        cat_ver = cat.version
-                        dp = cat.get_part("catalog.dependency.C",
-                            must_exist=True)
-
-                        for t, sentry in spart.tuple_entries(pubs=[pfx]):
-                                pub, stem, ver = t
-
-                                installed = False
-                                if pub in inst_stems and \
-                                    stem in inst_stems[pub] and \
-                                    ver in inst_stems[pub][stem]:
-                                        installed = True
-                                        inst_stems[pub][stem][ver]["installed"] = True
-
-                                # copy() is too slow here and catalog entries
-                                # are shallow so this should be sufficient.
-                                entry = dict(six.iteritems(sentry))
-                                if not base:
-                                        # Nothing else to do except add the
-                                        # entry for non-base catalog parts.
-                                        nkpart.add(metadata=entry,
-                                            op_time=op_time, pub=pub, stem=stem,
-                                            ver=ver)
-                                        if installed:
-                                                nipart.add(metadata=entry,
-                                                    op_time=op_time, pub=pub,
-                                                    stem=stem, ver=ver)
-                                        continue
-
-                                # Only the base catalog part stores package
-                                # state information and/or other metadata.
-                                mdata = entry.setdefault("metadata", {})
-                                states = mdata.setdefault("states", [])
-                                states.append(pkgdefs.PKG_STATE_KNOWN)
-
-                                if cat_ver == 0:
-                                        states.append(pkgdefs.PKG_STATE_V0)
-                                elif pkgdefs.PKG_STATE_V0 not in states:
-                                        # Assume V1 catalog source.
-                                        states.append(pkgdefs.PKG_STATE_V1)
-
-                                if installed:
-                                        states.append(
-                                            pkgdefs.PKG_STATE_INSTALLED)
-                                        # Preserve the dates of install/update
-                                        # if present in the old metadata
-                                        md = inst_stems[pub][stem][ver]["metadata"]
-                                        for key in ["last-install", "last-update"]:
-                                            if key in md:
-                                                entry["metadata"][key] = md[key]
-                                        # Preserve the manual installation
-                                        # flag, if present in the old metadata
-                                        ostates = set(md.get("states", set()))
-                                        if pkgdefs.PKG_STATE_MANUAL in ostates:
-                                                states.append(
-                                                    pkgdefs.PKG_STATE_MANUAL)
-
-                                nver, snver = newest.get(stem, (None, None))
-                                if snver is not None and ver != snver:
-                                        states.append(
-                                            pkgdefs.PKG_STATE_UPGRADABLE)
-
-                                # Check if the package is frozen.
-                                if stem in frozen_pkgs:
-                                        f_ver = frozen_pkgs[stem].version
-                                        if f_ver == ver or \
-                                            pkg.version.Version(ver
-                                            ).is_successor(f_ver,
-                                            constraint=
-                                            pkg.version.CONSTRAINT_AUTO):
-                                                states.append(
-                                                    pkgdefs.PKG_STATE_FROZEN)
-
-                                # Determine if package is obsolete or has been
-                                # renamed and mark with appropriate state.
-                                dpent = None
-                                if dp is not None:
-                                        dpent = dp.get_entry(pub=pub, stem=stem,
-                                            ver=ver)
-                                if dpent is not None:
-                                        for a in dpent["actions"]:
-                                                # Constructing action objects
-                                                # for every action would be a
-                                                # lot slower, so a simple string
-                                                # match is done first so that
-                                                # only interesting actions get
-                                                # constructed.
-                                                if not a.startswith("set"):
-                                                        continue
-                                                if not ("pkg.obsolete" in a or \
-                                                    "pkg.renamed" in a or \
-                                                    "pkg.legacy" in a):
-                                                        continue
-
-                                                try:
-                                                        act = pkg.actions.fromstr(a)
-                                                except pkg.actions.ActionError:
-                                                        # If the action can't be
-                                                        # parsed or is not yet
-                                                        # supported, continue.
-                                                        continue
-
-                                                if act.attrs["value"].lower() != "true":
-                                                        continue
-
-                                                if act.attrs["name"] == "pkg.obsolete":
-                                                        states.append(
-                                                            pkgdefs.PKG_STATE_OBSOLETE)
-                                                elif act.attrs["name"] == "pkg.renamed":
-                                                        if not act.include_this(
-                                                            excludes, publisher=pub):
-                                                                continue
-                                                        states.append(
-                                                            pkgdefs.PKG_STATE_RENAMED)
-                                                elif act.attrs["name"] == "pkg.legacy":
-                                                        states.append(
-                                                            pkgdefs.PKG_STATE_LEGACY)
-
-                                mdata["states"] = states
-
-                                # Add base entries.
-                                nkpart.add(metadata=entry, op_time=op_time,
-                                    pub=pub, stem=stem, ver=ver)
-                                if installed:
-                                        nipart.add(metadata=entry,
-                                            op_time=op_time, pub=pub, stem=stem,
-                                            ver=ver)
-
-                # Now add installed packages to list of known packages using
-                # previous state information.  While doing so, track any
-                # new entries as the versions for the stem of the entry will
-                # need to be passed to finalize() for sorting.
-                final_fmris = []
-                for name in old_icat.parts:
-                        # Old installed part.
-                        ipart = old_icat.get_part(name, must_exist=True)
-
-                        # New known part.
-                        nkpart = kcat.get_part(name)
-
-                        # New installed part.
-                        nipart = icat.get_part(name)
-
-                        base = name.startswith("catalog.base.")
-
-                        mdata = None
-                        for t, entry in ipart.tuple_entries():
-                                pub, stem, ver = t
-
-                                if pub not in inst_stems or \
-                                    stem not in inst_stems[pub] or \
-                                    ver not in inst_stems[pub][stem] or \
-                                    inst_stems[pub][stem][ver]["installed"]:
-                                        # Entry is no longer valid or is already
-                                        # known.
-                                        continue
-
-                                if base:
-                                        mdata = entry["metadata"]
-                                        states = set(mdata["states"])
-                                        states.discard(pkgdefs.PKG_STATE_KNOWN)
-
-                                        nver, snver = newest.get(stem, (None,
-                                            None))
-                                        if not nver or \
-                                            (snver is not None and ver == snver):
-                                                states.discard(
-                                                    pkgdefs.PKG_STATE_UPGRADABLE)
-                                        elif snver is not None:
-                                                states.add(
-                                                    pkgdefs.PKG_STATE_UPGRADABLE)
-                                        # Check if the package is frozen.
-                                        if stem in frozen_pkgs:
-                                                f_ver = frozen_pkgs[stem].version
-                                                if f_ver == ver or \
-                                                    pkg.version.Version(ver
-                                                    ).is_successor(f_ver,
-                                                    constraint=
-                                                    pkg.version.CONSTRAINT_AUTO):
-                                                        states.add(
-                                                            pkgdefs.PKG_STATE_FROZEN)
-                                        else:
-                                                states.discard(
-                                                    pkgdefs.PKG_STATE_FROZEN)
-
-                                        mdata["states"] = list(states)
-
-                                # Add entries.
-                                nkpart.add(metadata=entry, op_time=op_time,
-                                    pub=pub, stem=stem, ver=ver)
-                                nipart.add(metadata=entry, op_time=op_time,
-                                    pub=pub, stem=stem, ver=ver)
-                                final_fmris.append(pkg.fmri.PkgFmri(name=stem,
-                                    publisher=pub, version=ver))
-
-                # Save the new catalogs.
-                for cat in kcat, icat:
-                        misc.makedirs(cat.meta_root)
-                        cat.finalize(pfmris=final_fmris)
-                        cat.save()
-
-                # Next, preserve the old installed state dir, rename the
-                # new one into place, and then remove the old one.
-                orig_state_root = self.salvage(self._statedir, full_path=True)
-                portable.rename(tmp_state_root, self._statedir)
-                shutil.rmtree(orig_state_root, True)
-
-                # Ensure in-memory catalogs get reloaded.
-                self.__init_catalogs()
-
-                self.update_last_modified()
-                progtrack.cache_catalogs_done()
-                self.history.log_operation_end()
-
-        def refresh_publishers(self, full_refresh=False, immediate=False,
-            pubs=None, progtrack=None, ignore_unreachable=True):
-                """Refreshes the metadata (e.g. catalog) for one or more
-                publishers.  Callers are responsible for locking the image.
-
-                'full_refresh' is an optional boolean value indicating whether
-                a full retrieval of publisher metadata (e.g. catalogs) or only
-                an update to the existing metadata should be performed.  When
-                True, 'immediate' is also set to True.
-
-                'immediate' is an optional boolean value indicating whether the
-                a refresh should occur now.  If False, a publisher's selected
-                repository will only be checked for updates if the update
-                interval period recorded in the image configuration has been
-                exceeded.
-
-                'pubs' is a list of publisher prefixes or publisher objects
-                to refresh.  Passing an empty list or using the default value
-                implies all publishers.
-
-                'ignore_unreachable' is an optional boolean value indicating
-                whether unreachable repositories should be ignored. If True,
-                errors contacting this repository are stored in the transport
-                but no exception is raised, allowing an operation to continue
-                if an unneeded repository is not online."""
-
-                if self.version < 3:
-                        raise apx.ImageFormatUpdateNeeded(self.root)
-
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-
-                be_name, be_uuid = bootenv.BootEnv.get_be_name(self.root)
-                self.history.log_operation_start("refresh-publishers",
-                    be_name=be_name, be_uuid=be_uuid)
-
-                pubs_to_refresh = []
-
-                if not pubs:
-                        # Omit disabled publishers.
-                        pubs = [p for p in self.gen_publishers()]
-
-                if not pubs:
-                        self.__rebuild_image_catalogs(progtrack=progtrack)
-                        return
-
-                for pub in pubs:
-                        p = pub
-                        if not isinstance(p, publisher.Publisher):
-                                p = self.get_publisher(prefix=p)
-                        if p.disabled:
-                                e = apx.DisabledPublisher(p)
-                                self.history.log_operation_end(error=e)
-                                raise e
-                        pubs_to_refresh.append(p)
-
-                if not pubs_to_refresh:
-                        self.history.log_operation_end(
-                            result=history.RESULT_NOTHING_TO_DO)
-                        return
-
-                # Verify validity of certificates before attempting network
-                # operations.
-                try:
-                        self.check_cert_validity(pubs=pubs_to_refresh)
-                except apx.ExpiringCertificate as e:
-                        logger.error(str(e))
-
-                try:
-                        # Ensure Image directory structure is valid.
-                        self.mkdirs()
-                except Exception as e:
-                        self.history.log_operation_end(error=e)
-                        raise
-
-                progtrack.refresh_start(len(pubs_to_refresh),
-                    full_refresh=full_refresh)
-
-                failed = []
-                total = 0
-                succeeded = set()
-                updated = self.__start_state_update()
-                for pub in pubs_to_refresh:
-                        total += 1
-                        progtrack.refresh_start_pub(pub)
-                        try:
-                                changed, e = pub.refresh(
-                                    full_refresh=full_refresh,
-                                    immediate=immediate, progtrack=progtrack)
-                                if changed:
-                                        updated = True
-
-                                if not ignore_unreachable and e:
-                                        failed.append((pub, e))
-                                        continue
-
-                        except apx.PermissionsException as e:
-                                failed.append((pub, e))
-                                # No point in continuing since no data can
-                                # be written.
-                                break
-                        except apx.ApiException as e:
-                                failed.append((pub, e))
-                                continue
-                        finally:
-                                progtrack.refresh_end_pub(pub)
-                        succeeded.add(pub.prefix)
-
-                progtrack.refresh_done()
-
-                if updated:
-                        self.__rebuild_image_catalogs(progtrack=progtrack)
-                        # Ensure any configuration or metadata changes made
-                        # during refresh are reflected in on-disk state.
-                        self.save_config()
-                else:
-                        self.__end_state_update()
-
-                if failed:
-                        e = apx.CatalogRefreshException(failed, total,
-                            len(succeeded))
-                        self.history.log_operation_end(error=e)
-                        raise e
-
-                if not updated:
-                        self.history.log_operation_end(
-                            result=history.RESULT_NOTHING_TO_DO)
-                        return
-                self.history.log_operation_end()
-
-        def _get_publisher_meta_dir(self):
-                if self.version >= 3:
-                        return IMG_PUB_DIR
-                return "catalog"
-
-        def _get_publisher_cache_root(self, prefix):
-                return os.path.join(self.imgdir, "cache", "publisher", prefix)
-
-        def _get_publisher_meta_root(self, prefix):
-                return os.path.join(self.imgdir, self._get_publisher_meta_dir(),
-                    prefix)
-
-        def remove_publisher_metadata(self, pub, progtrack=None, rebuild=True):
-                """Removes the metadata for the specified publisher object,
-                except data for installed packages.
-
-                'pub' is the object of the publisher to remove the data for.
-
-                'progtrack' is an optional ProgressTracker object.
-
-                'rebuild' is an optional boolean specifying whether image
-                catalogs should be rebuilt after removing the publisher's
-                metadata.
-                """
-
-                if self.version < 4:
-                        # Older images don't require fine-grained deletion.
-                        pub.remove_meta_root()
-                        if rebuild:
-                                self.__rebuild_image_catalogs(
-                                    progtrack=progtrack)
-                        return
-
-                # Build a list of paths that shouldn't be removed because they
-                # belong to installed packages.
-                excluded = [
-                    self.get_manifest_path(f)
-                    for f in self.gen_installed_pkgs()
-                    if f.publisher == pub.prefix
-                ]
-
-                if not excluded:
-                        pub.remove_meta_root()
-                else:
-                        try:
-                                # Discard all publisher metadata except
-                                # package manifests as a first pass.
-                                for entry in os.listdir(pub.meta_root):
-                                        if entry == "pkg":
-                                                continue
-
-                                        target = os.path.join(pub.meta_root,
-                                            entry)
-                                        if os.path.isdir(target):
-                                                shutil.rmtree(target,
-                                                    ignore_errors=True)
-                                        else:
-                                                portable.remove(target)
-
-                                # Build the list of directories that can't be
-                                # removed.
-                                exdirs = [os.path.dirname(e) for e in excluded]
-
-                                # Now try to discard only package manifests
-                                # that aren't for installed packages.
-                                mroot = os.path.join(pub.meta_root, "pkg")
-                                for pdir in os.listdir(mroot):
-                                        proot = os.path.join(mroot, pdir)
-                                        if proot not in exdirs:
-                                                # This removes all manifest data
-                                                # for a given package stem.
-                                                shutil.rmtree(proot,
-                                                    ignore_errors=True)
-                                                continue
-
-                                        # Remove only manifest data for packages
-                                        # that are not installed.
-                                        for mname in os.listdir(proot):
-                                                mpath = os.path.join(proot,
-                                                    mname)
-                                                if mpath not in excluded:
-                                                        portable.remove(mpath)
-
-                                # Finally, dump any cache data for this
-                                # publisher if possible.
-                                shutil.rmtree(self._get_publisher_cache_root(
-                                    pub.prefix), ignore_errors=True)
-                        except EnvironmentError as e:
-                                if e.errno != errno.ENOENT:
-                                        raise apx._convert_error(e)
-
-                if rebuild:
-                        self.__rebuild_image_catalogs(progtrack=progtrack)
-
-        def gen_installed_pkg_names(self, anarchy=True):
-                """A generator function that produces FMRI strings as it
-                iterates over the list of installed packages.  This is
-                faster than gen_installed_pkgs when only the FMRI string
-                is needed."""
-
-                cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-                for f in cat.fmris(objects=False):
-                        if anarchy:
-                                # Catalog entries always have publisher prefix.
-                                yield "pkg:/{0}".format(f[6:].split("/", 1)[-1])
-                                continue
-                        yield f
-
-        def gen_installed_pkgs(self, pubs=EmptyI, ordered=False):
-                """Return an iteration through the installed packages."""
-
-                cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-                for f in cat.fmris(pubs=pubs, ordered=ordered):
-                        yield f
-
-        def count_installed_pkgs(self, pubs=EmptyI):
-                """Return the number of installed packages."""
-                cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-                assert cat.package_count == cat.package_version_count
-                return sum(
-                    pkg_count
-                    for (pub, pkg_count, _ignored) in
-                        cat.get_package_counts_by_pub(pubs=pubs)
-                )
-
-        def gen_tracked_stems(self):
-                """Return an iteration through all the tracked pkg stems
-                in the set of currently installed packages.  Return value
-                is group pkg fmri, stem"""
-                cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-                excludes = self.list_excludes()
-
-                for f in cat.fmris():
-                        for a in cat.get_entry_actions(f,
-                            [pkg.catalog.Catalog.DEPENDENCY], excludes=excludes):
-                                if a.name == "depend" and a.attrs["type"] == "group":
-                                        yield (f, self.strtofmri(
-                                            a.attrs["fmri"]).pkg_name)
-
-        def _create_fast_lookups(self, progtrack=None):
-                """Create an on-disk database mapping action name and key
-                attribute value to the action string comprising the unique
-                attributes of the action, for all installed actions.  This is
-                done with a file mapping the tuple to an offset into a second
-                file, where those actions are kept.  Once the offsets are loaded
-                into memory, it is simple to seek into the second file to the
-                given offset and read until you hit an action that doesn't
-                match."""
-
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-
-                self.__actdict = None
-                self.__actdict_timestamp = None
-                stripped_path = os.path.join(self.__action_cache_dir,
-                    "actions.stripped")
-                offsets_path = os.path.join(self.__action_cache_dir,
-                    "actions.offsets")
-                conflicting_keys_path = os.path.join(self.__action_cache_dir,
-                    "keys.conflicting")
-
-                excludes = self.list_excludes()
-                heap = []
-
-                # nsd is the "name-space dictionary."  It maps action name
-                # spaces (see action.generic for more information) to
-                # dictionaries which map keys to pairs which contain an action
-                # with that key and the pfmri of the package which delivered the
-                # action.
-                nsd = {}
-
-                from heapq import heappush, heappop
-
-                progtrack.job_start(progtrack.JOB_FAST_LOOKUP)
-
-                for pfmri in self.gen_installed_pkgs():
-                        progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
-                        m = self.get_manifest(pfmri, ignore_excludes=True)
-                        for act in m.gen_actions(excludes=excludes):
-                                if not act.globally_identical:
-                                        continue
-                                act.strip()
-                                heappush(heap, (act.name,
-                                    act.attrs[act.key_attr], pfmri, act))
-                                nsd.setdefault(act.namespace_group, {})
-                                nsd[act.namespace_group].setdefault(
-                                    act.attrs[act.key_attr], [])
-                                nsd[act.namespace_group][
-                                    act.attrs[act.key_attr]].append((
-                                    act, pfmri))
-
-                progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
-
-                # If we can't write the temporary files, then there's no point
-                # in producing actdict because it depends on a synchronized
-                # stripped actions file.
-                try:
-                        actdict = {}
-                        sf, sp = self.temporary_file(close=False)
-                        of, op = self.temporary_file(close=False)
-                        bf, bp = self.temporary_file(close=False)
-
-                        sf = os.fdopen(sf, "w")
-                        of = os.fdopen(of, "w")
-                        bf = os.fdopen(bf, "w")
-
-                        # We need to make sure the files are coordinated.
-                        timestamp = int(time.time())
-                        sf.write("VERSION 1\n{0}\n".format(timestamp))
-                        of.write("VERSION 2\n{0}\n".format(timestamp))
-                        # The conflicting keys file doesn't need a timestamp
-                        # because it's not coordinated with the stripped or
-                        # offsets files and the result of loading it isn't
-                        # reused by this class.
-                        bf.write("VERSION 1\n")
-
-                        cnt, offset_update_bytes = 0, 0
-                        last_name, last_key, last_offset = None, None, sf.tell()
-                        while heap:
-                                # This is a tight loop, so try to avoid burning
-                                # CPU calling into the progress tracker
-                                # excessively.
-                                if len(heap) % 100 == 0:
-                                        progtrack.job_add_progress(
-                                            progtrack.JOB_FAST_LOOKUP)
-                                item = heappop(heap)
-                                fmri, act = item[2:]
-                                key = act.attrs[act.key_attr]
-                                if act.name != last_name or key != last_key:
-                                        if last_name is None:
-                                                assert last_key is None
-                                                cnt += 1
-                                                last_name = act.name
-                                                last_key = key
-                                        else:
-                                                assert cnt > 0
-                                                of.write("{0} {1} {2} {3}\n".format(
-                                                    last_name, last_offset,
-                                                    cnt, last_key))
-                                                actdict[(last_name, last_key)] = last_offset, cnt
-                                                last_name, last_key = act.name, key
-                                                last_offset += offset_update_bytes
-                                                offset_update_bytes = 0
-                                                cnt = 1
-                                else:
-                                        cnt += 1
-                                sf_line = f"{fmri} {act}\n"
-                                sf.write(sf_line)
-                                offset_update_bytes += len(sf_line.encode('utf-8'))
-                        if last_name is not None:
-                                assert last_key is not None
-                                assert last_offset is not None
-                                assert cnt > 0
-                                of.write("{0} {1} {2} {3}\n".format(
-                                    last_name, last_offset, cnt, last_key))
-                                actdict[(last_name, last_key)] = \
-                                    last_offset, cnt
-
-                        progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
-
-                        bad_keys = imageplan.ImagePlan._check_actions(nsd)
-                        for k in sorted(bad_keys):
-                                bf.write("{0}\n".format(k))
-
-                        progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
-                        sf.close()
-                        of.close()
-                        bf.close()
-                        os.chmod(sp, misc.PKG_FILE_MODE)
-                        os.chmod(op, misc.PKG_FILE_MODE)
-                        os.chmod(bp, misc.PKG_FILE_MODE)
-                except BaseException as e:
-                        try:
-                                os.unlink(sp)
-                                os.unlink(op)
-                                os.unlink(bp)
-                        except:
-                                pass
-                        raise
-
-                progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
-
-                # Finally, rename the temporary files into their final place.
-                # If we have any problems, do our best to remove them, and we'll
-                # try to recreate them on the read-side.
-                try:
-                        if not os.path.exists(self.__action_cache_dir):
-                                os.makedirs(self.__action_cache_dir)
-                        portable.rename(sp, stripped_path)
-                        portable.rename(op, offsets_path)
-                        portable.rename(bp, conflicting_keys_path)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES or e.errno == errno.EROFS:
-                                self.__action_cache_dir = self.temporary_dir()
-                                stripped_path = os.path.join(
-                                    self.__action_cache_dir, "actions.stripped")
-                                offsets_path = os.path.join(
-                                    self.__action_cache_dir, "actions.offsets")
-                                conflicting_keys_path = os.path.join(
-                                    self.__action_cache_dir, "keys.conflicting")
-                                portable.rename(sp, stripped_path)
-                                portable.rename(op, offsets_path)
-                                portable.rename(bp, conflicting_keys_path)
-                        else:
-                                exc_info = sys.exc_info()
-                                try:
-                                        os.unlink(stripped_path)
-                                        os.unlink(offsets_path)
-                                        os.unlink(conflicting_keys_path)
-                                except:
-                                        pass
-                                six.reraise(exc_info[0], exc_info[1], exc_info[2])
-
-                progtrack.job_add_progress(progtrack.JOB_FAST_LOOKUP)
-                progtrack.job_done(progtrack.JOB_FAST_LOOKUP)
-                return actdict, timestamp
-
-        def _remove_fast_lookups(self):
-                """Remove on-disk database created by _create_fast_lookups.
-                Should be called before updating image state to prevent the
-                client from seeing stale state if _create_fast_lookups is
-                interrupted."""
-
-                for fname in ("actions.stripped", "actions.offsets",
-                    "keys.conflicting"):
-                        try:
-                                portable.remove(os.path.join(
-                                    self.__action_cache_dir, fname))
-                        except EnvironmentError as e:
-                                if e.errno == errno.ENOENT:
-                                        continue
-                                raise apx._convert_error(e)
-
-        def _load_actdict(self, progtrack):
-                """Read the file of offsets created in _create_fast_lookups()
-                and return the dictionary mapping action name and key value to
-                offset."""
-
-                try:
-                        of = open(os.path.join(self.__action_cache_dir,
-                            "actions.offsets"), "r")
-                except IOError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
-                        actdict, otimestamp = self._create_fast_lookups()
-                        assert actdict is not None
-                        self.__actdict = actdict
-                        self.__actdict_timestamp = otimestamp
-                        return actdict
-
-                # Make sure the files are paired, and try to create them if not.
-                oversion = of.readline().rstrip()
-                otimestamp = of.readline().rstrip()
-
-                # The original action.offsets file existed and had the same
-                # timestamp as the stored actdict, so that actdict can be
-                # reused.
-                if self.__actdict and otimestamp == self.__actdict_timestamp:
-                        return self.__actdict
-
-                sversion, stimestamp = self._get_stripped_actions_file(
-                    internal=True)
-
-                # If we recognize neither file's version or their timestamps
-                # don't match, then we blow them away and try again.
-                if oversion != "VERSION 2" or sversion != "VERSION 1" or \
-                    stimestamp != otimestamp:
-                        of.close()
-                        actdict, otimestamp = self._create_fast_lookups()
-                        assert actdict is not None
-                        self.__actdict = actdict
-                        self.__actdict_timestamp = otimestamp
-                        return actdict
-
-                # At this point, the original actions.offsets file existed, no
-                # actdict was saved in the image, the versions matched what was
-                # expected, and the timestamps of the actions.offsets and
-                # actions.stripped files matched, so the actions.offsets file is
-                # parsed to generate actdict.
-                actdict = {}
-
-                for line in of:
-                        actname, offset, cnt, key_attr = \
-                            line.rstrip().split(None, 3)
-                        off = int(offset)
-                        actdict[(actname, key_attr)] = (off, int(cnt))
-
-                        # This is a tight loop, so try to avoid burning
-                        # CPU calling into the progress tracker excessively.
-                        # Since we are already using the offset, we use that
-                        # to damp calls back into the progress tracker.
-                        if off % 500 == 0:
-                                progtrack.plan_add_progress(
-                                    progtrack.PLAN_ACTION_CONFLICT)
-
-                of.close()
-                self.__actdict = actdict
-                self.__actdict_timestamp = otimestamp
-                return actdict
-
-        def _get_stripped_actions_file(self, internal=False):
-                """Open the actions file described in _create_fast_lookups() and
-                return the corresponding file object."""
-
-                sf = open(os.path.join(self.__action_cache_dir,
-                    "actions.stripped"), "r")
-                sversion = sf.readline().rstrip()
-                stimestamp = sf.readline().rstrip()
-                if internal:
-                        sf.close()
-                        return sversion, stimestamp
-
-                return sf
-
-        def _load_conflicting_keys(self):
-                """Load the list of keys which have conflicting actions in the
-                existing image.  If no such list exists, then return None."""
-
-                pth = os.path.join(self.__action_cache_dir, "keys.conflicting")
-                try:
-                        with open(pth, "r") as fh:
-                                version = fh.readline().rstrip()
-                                if version != "VERSION 1":
-                                        return None
-                                return set(l.rstrip() for l in fh)
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                return None
-                        raise
-
-        def gen_installed_actions_bytype(self, atype, implicit_dirs=False):
-                """Iterates through the installed actions of type 'atype'.  If
-                'implicit_dirs' is True and 'atype' is 'dir', then include
-                directories only implicitly defined by other filesystem
-                actions."""
-
-                if implicit_dirs and atype != "dir":
-                        implicit_dirs = False
-
-                excludes = self.list_excludes()
-
-                for pfmri in self.gen_installed_pkgs():
-                        m = self.get_manifest(pfmri)
-                        dirs = set()
-                        for act in m.gen_actions_by_type(atype,
-                            excludes=excludes):
-                                if implicit_dirs:
-                                        dirs.add(act.attrs["path"])
-                                yield act, pfmri
-                        if implicit_dirs:
-                                da = pkg.actions.directory.DirectoryAction
-                                for d in m.get_directories(excludes):
-                                        if d not in dirs:
-                                                yield da(path=d, implicit="true"), pfmri
-
-        def get_installed_pubs(self):
-                """Returns a set containing the prefixes of all publishers with
-                installed packages."""
-
-                cat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-                return cat.publishers()
-
-        def strtofmri(self, myfmri):
-                return pkg.fmri.PkgFmri(myfmri)
-
-        def strtomatchingfmri(self, myfmri):
-                return pkg.fmri.MatchingPkgFmri(myfmri)
-
-        def get_user_by_name(self, name):
-                uid = self._usersbyname.get(name, None)
-                if uid is not None:
-                        return uid
-                return portable.get_user_by_name(name, self.root,
-                    self.type != IMG_USER)
-
-        def get_name_by_uid(self, uid, returnuid = False):
-                # XXX What to do about IMG_PARTIAL?
-                try:
-                        return portable.get_name_by_uid(uid, self.root,
-                            self.type != IMG_USER)
-                except KeyError:
-                        if returnuid:
-                                return uid
-                        else:
-                                raise
-
-        def get_group_by_name(self, name):
-                gid = self._groupsbyname.get(name, None)
-                if gid is not None:
-                        return gid
-                return portable.get_group_by_name(name, self.root,
-                    self.type != IMG_USER)
-
-        def get_name_by_gid(self, gid, returngid = False):
-                try:
-                        return portable.get_name_by_gid(gid, self.root,
-                            self.type != IMG_USER)
-                except KeyError:
-                        if returngid:
-                                return gid
-                        else:
-                                raise
-
-        def get_usernames_by_gid(self, gid):
-                return portable.get_usernames_by_gid(gid, self.root)
-
-        def update_index_dir(self, postfix="index"):
-                """Since the index directory will not reliably be updated when
-                the image root is, this should be called prior to using the
-                index directory.
-                """
-                if self.version == self.CURRENT_VERSION:
-                        self.index_dir = os.path.join(self.imgdir, "cache",
-                            postfix)
-                else:
-                        self.index_dir = os.path.join(self.imgdir, postfix)
-
-        def cleanup_downloads(self):
-                """Clean up any downloads that were in progress but that
-                did not successfully finish."""
-
-                shutil.rmtree(self._incoming_cache_dir, True)
-
-        def cleanup_cached_content(self, progtrack=None, force=False,
-            verbose=False):
-                """Delete the directory that stores all of our cached
-                downloaded content.  This may take a while for a large
-                directory hierarchy.  Don't clean up caches if the
-                user overrode the underlying setting using PKG_CACHEDIR or
-                PKG_CACHEROOT. """
-
-                if (not force and
-                    not self.cfg.get_policy(imageconfig.FLUSH_CONTENT_CACHE)):
-                        return
-
-                cdirs = []
-                for path, readonly, pub, layout in self.get_cachedirs():
-                        if verbose:
-                                print('Checking cache directory {} ({})'
-                                    .format(path, pub))
-                        if readonly or (self.__user_cache_dir and
-                            path.startswith(self.__user_cache_dir)):
-                                continue
-                        cdirs.append(path)
-
-                if not cdirs:
-                        return
-
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-
-                # 'Updating package cache'
-                progtrack.job_start(progtrack.JOB_PKG_CACHE, goal=len(cdirs))
-                for path in cdirs:
-                        shutil.rmtree(path, True)
-                        progtrack.job_add_progress(progtrack.JOB_PKG_CACHE)
-                progtrack.job_done(progtrack.JOB_PKG_CACHE)
-
-        def salvage(self, path, full_path=False):
-                """Called when unexpected file or directory is found during
-                package operations; returns the path of the salvage
-                directory where the item was stored. Can be called with
-                either image-relative or absolute (current) path to file/dir
-                to be salvaged.  If full_path is False (the default), remove
-                the current mountpoint of the image from the returned
-                directory path"""
-
-                # This ensures that if the path is already rooted in the image,
-                # that it will be stored in lost+found (due to os.path.join
-                # behaviour with absolute path components).
-                if path.startswith(self.root):
-                        path = path.replace(self.root, "", 1)
-
-                if os.path.isabs(path):
-                        # If for some reason the path wasn't rooted in the
-                        # image, but it is an absolute one, then strip the
-                        # absolute part so that it will be stored in lost+found
-                        # (due to os.path.join behaviour with absolute path
-                        # components).
-                        path = os.path.splitdrive(path)[-1].lstrip(os.path.sep)
-
-                sdir = os.path.normpath(
-                    os.path.join(self.imgdir, "lost+found",
-                    path + "-" + time.strftime("%Y%m%dT%H%M%SZ")))
-
-                parent = os.path.dirname(sdir)
-                if not os.path.exists(parent):
-                        misc.makedirs(parent)
-
-                orig = os.path.normpath(os.path.join(self.root, path))
-
-                misc.move(orig, sdir)
-                # remove current mountpoint from sdir
-                if not full_path:
-                        sdir.replace(self.root, "", 1)
-                return sdir
-
-        def recover(self, local_spath, full_dest_path, dest_path, old_path):
-                """Called when recovering directory contents to implement
-                "salvage-from" directive... full_dest_path must exist.
-                dest_path is the image-relative location where we salvage to,
-                old_path is original image-relative directory that delivered
-                the files we're now recovering.
-
-                When recovering directories where the salvage-from string is
-                a substring of the previously packaged directory, attempt
-                to restore as much of the old directory structure as possible
-                by comparing the salvage-from value with the previously
-                packaged directory.
-
-                For example, say we had user-content in /var/user/myuser/.ssh,
-                but have stopped delivering that dir, replacing it with a new
-                directory /var/.migrate/user which specifies
-                salvage-from=var/user.
-
-                The intent of the package author, was to have the
-                /var/.migrate/user directory get the unpackaged 'myuser/.ssh'
-                directory created as part of the salvaging operation, giving
-                them /var/.migrate/user/myuser/.ssh
-                and not to just end up with
-                /var/.migrate/user/<contents of .ssh dir from myuser>
-                """
-
-                source_path = os.path.normpath(
-                    os.path.join(self.root, local_spath))
-                if dest_path != old_path and old_path.startswith(
-                    dest_path + os.path.sep):
-                        # this is here so that when salvaging the contents
-                        # of a previously packaged directory, we attempt to
-                        # restore as much of the old directory structure as
-                        # possible.
-                        spath = os.path.relpath(old_path, dest_path)
-                        full_dest_path = os.path.join(full_dest_path, spath)
-                        try:
-                                os.makedirs(full_dest_path)
-                        except OSError as e:
-                                if e.errno != errno.EEXIST:
-                                        raise e
-
-                for file_name in os.listdir(source_path):
-                        misc.move(os.path.join(source_path, file_name),
-                            full_dest_path)
-
-        def temporary_dir(self):
-                """Create a temp directory under the image directory for various
-                purposes.  If the process is unable to create a directory in the
-                image's temporary directory, a replacement location is found."""
-
-                try:
-                        misc.makedirs(self.__tmpdir)
-                except (apx.PermissionsException,
-                    apx.ReadOnlyFileSystemException):
-                        self.__tmpdir = tempfile.mkdtemp(prefix="pkg5tmp-")
-                        atexit.register(shutil.rmtree,
-                            self.__tmpdir, ignore_errors=True)
-                        return self.temporary_dir()
-
-                try:
-                        rval = tempfile.mkdtemp(dir=self.__tmpdir)
-
-                        # Force standard mode.
-                        os.chmod(rval, misc.PKG_DIR_MODE)
-                        return rval
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES or e.errno == errno.EROFS:
-                                self.__tmpdir = tempfile.mkdtemp(prefix="pkg5tmp-")
-                                atexit.register(shutil.rmtree,
-                                    self.__tmpdir, ignore_errors=True)
-                                return self.temporary_dir()
-                        raise apx._convert_error(e)
-
-        def temporary_file(self, close=True):
-                """Create a temporary file under the image directory for various
-                purposes.  If 'close' is True, close the file descriptor;
-                otherwise leave it open.  If the process is unable to create a
-                file in the image's temporary directory, a replacement is
-                found."""
-
-                try:
-                        misc.makedirs(self.__tmpdir)
-                except (apx.PermissionsException,
-                    apx.ReadOnlyFileSystemException):
-                        self.__tmpdir = tempfile.mkdtemp(prefix="pkg5tmp-")
-                        atexit.register(shutil.rmtree,
-                            self.__tmpdir, ignore_errors=True)
-                        return self.temporary_file(close=close)
-
-                try:
-                        fd, name = tempfile.mkstemp(dir=self.__tmpdir)
-                        if close:
-                                os.close(fd)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES or e.errno == errno.EROFS:
-                                self.__tmpdir = tempfile.mkdtemp(prefix="pkg5tmp-")
-                                atexit.register(shutil.rmtree,
-                                    self.__tmpdir, ignore_errors=True)
-                                return self.temporary_file(close=close)
-                        raise apx._convert_error(e)
-
-                if close:
-                        return name
-                else:
-                        return fd, name
-
-        def __filter_install_matches(self, matches):
-                """Attempts to eliminate redundant matches found during
-                packaging operations:
-
-                    * First, stems of installed packages for publishers that
-                      are now unknown (no longer present in the image
-                      configuration) are dropped.
-
-                    * Second, if multiple matches are still present, stems of
-                      of installed packages, that are not presently in the
-                      corresponding publisher's catalog, are dropped.
-
-                    * Finally, if multiple matches are still present, all
-                      stems except for those in state PKG_STATE_INSTALLED are
-                      dropped.
-
-                Returns a list of the filtered matches, along with a dict of
-                their unique names."""
-
-                olist = []
-                onames = set()
-
-                # First eliminate any duplicate matches that are for unknown
-                # publishers (publishers which have been removed from the image
-                # configuration).
-                publist = set(p.prefix for p in self.get_publishers().values())
-                for m, st in matches:
-                        if m.publisher in publist:
-                                onames.add(m.get_pkg_stem())
-                                olist.append((m, st))
-
-                # Next, if there are still multiple matches, eliminate matches
-                # belonging to publishers that no longer have the FMRI in their
-                # catalog.
-                found_state = False
-                if len(onames) > 1:
-                        mlist = []
-                        mnames = set()
-                        for m, st in olist:
-                                if not st["in_catalog"]:
-                                        continue
-                                if st["state"] == pkgdefs.PKG_STATE_INSTALLED:
-                                        found_state = True
-                                mnames.add(m.get_pkg_stem())
-                                mlist.append((m, st))
-                        olist = mlist
-                        onames = mnames
-
-                # Finally, if there are still multiple matches, and a known
-                # stem is installed, then eliminate any stems that do not
-                # have an installed version.
-                if found_state and len(onames) > 1:
-                        mlist = []
-                        mnames = set()
-                        for m, st in olist:
-                                if st["state"] == pkgdefs.PKG_STATE_INSTALLED:
-                                        mnames.add(m.get_pkg_stem())
-                                        mlist.append((m, st))
-                        olist = mlist
-                        onames = mnames
-
-                return olist, onames
-
-        def flag_pkgs(self, pfmris, state, value, progtrack):
-                """Sets/unsets a state flag for packages installed in
-                   the image."""
-
-                if self.version < self.CURRENT_VERSION:
-                        raise apx.ImageFormatUpdateNeeded(self.root)
-
-                # Only the 'manual' flag can be set or unset via this
-                # method.
-                if state not in [pkgdefs.PKG_STATE_MANUAL]:
-                        raise apx.ImagePkgStateError(pfmri, state)
-
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-
-                with self.locked_op("state"):
-
-                        icat = self.get_catalog(self.IMG_CATALOG_INSTALLED)
-                        kcat = self.get_catalog(self.IMG_CATALOG_KNOWN)
-
-                        progtrack.job_start(progtrack.JOB_STATE_DB)
-
-                        changed = set()
-
-                        for pfmri in pfmris:
-
-                                entry = kcat.get_entry(pfmri)
-                                mdata = entry.get("metadata", {})
-                                states = set(mdata.get("states", set()))
-
-                                if pkgdefs.PKG_STATE_INSTALLED not in states:
-                                        raise apx.ImagePkgStateError(pfmri,
-                                            states)
-
-                                progtrack.job_add_progress(
-                                    progtrack.JOB_STATE_DB)
-
-                                if value and state not in states:
-                                        states.add(state)
-                                        changed.add(pfmri)
-                                elif not value and state in states:
-                                        states.discard(state)
-                                        changed.add(pfmri)
-                                else:
-                                        continue
-
-                                # Catalog format only supports lists.
-                                mdata["states"] = list(states)
-
-                                # Now record the package state.
-                                kcat.update_entry(mdata, pfmri=pfmri)
-                                icat.update_entry(mdata, pfmri=pfmri)
-
-                        progtrack.job_done(progtrack.JOB_STATE_DB)
-
-                        if len(changed):
-                                progtrack.job_start(progtrack.JOB_IMAGE_STATE)
-                                self.__catalog_save([
-                                    (kcat, self.IMG_CATALOG_KNOWN),
-                                    (icat, self.IMG_CATALOG_INSTALLED)
-                                    ], changed, progtrack)
-                                progtrack.job_done(progtrack.JOB_IMAGE_STATE)
-
-                        print('{} package{} updated.'.format(
-                            len(changed), "s" if len(changed) != 1 else ""))
-
-        def avoid_pkgs(self, pat_list, progtrack, check_cancel):
-                """Avoid the specified packages... use pattern matching on
-                names; ignore versions."""
-
-                with self.locked_op("avoid"):
-                        ip = imageplan.ImagePlan
-                        self._avoid_set_save(self.avoid_set_get() |
-                            set(ip.match_user_stems(self, pat_list,
-                            ip.MATCH_UNINSTALLED)))
-
-        def unavoid_pkgs(self, pat_list, progtrack, check_cancel):
-                """Unavoid the specified packages... use pattern matching on
-                names; ignore versions."""
-
-                with self.locked_op("unavoid"):
-                        ip = imageplan.ImagePlan
-                        unavoid_set = set(ip.match_user_stems(self, pat_list,
-                            ip.MATCH_ALL))
-                        current_set = self.avoid_set_get()
-                        not_avoided = unavoid_set - current_set
-                        if not_avoided:
-                                raise apx.PlanCreationException(not_avoided=not_avoided)
-
-                        # Don't allow unavoid if removal of the package from the
-                        # avoid list would require the package to be installed
-                        # as this would invalidate current image state.  If the
-                        # package is already installed though, it doesn't really
-                        # matter if it's a target of an avoid or not.
-                        installed_set = set([
-                            f.pkg_name
-                            for f in self.gen_installed_pkgs()
-                        ])
-
-                        would_install = [
-                            a
-                            for f, a in self.gen_tracked_stems()
-                            if a in unavoid_set and a not in installed_set
-                        ]
-
-                        if would_install:
-                                raise apx.PlanCreationException(would_install=would_install)
-
-                        self._avoid_set_save(current_set - unavoid_set)
-
-        def get_avoid_dict(self):
-                """ return dict of lists (avoided stem, pkgs w/ group
-                dependencies on this pkg)"""
-                ret = dict((a, list()) for a in self.avoid_set_get())
-                for fmri, group in self.gen_tracked_stems():
-                        if group in ret:
-                                ret[group].append(fmri.pkg_name)
-                return ret
-
-        def freeze_pkgs(self, pat_list, progtrack, check_cancel, dry_run,
-            comment):
-                """Freeze the specified packages... use pattern matching on
-                names.
-
-                The 'pat_list' parameter contains the list of patterns of
-                packages to freeze.
-
-                The 'progtrack' parameter contains the progress tracker for this
-                operation.
-
-                The 'check_cancel' parameter contains a function to call to
-                check if the operation has been canceled.
-
-                The 'dry_run' parameter controls whether packages are actually
-                frozen.
-
-                The 'comment' parameter contains the comment, if any, which will
-                be associated with the packages that are frozen.
-                """
-
-                def __make_publisherless_fmri(pat):
-                        p = pkg.fmri.MatchingPkgFmri(pat)
-                        p.publisher = None
-                        return p
-
-                def __calc_frozen():
-                        stems_and_pats = imageplan.ImagePlan.freeze_pkgs_match(
-                            self, pat_list)
-                        return dict([(s, __make_publisherless_fmri(p))
-                            for s, p in six.iteritems(stems_and_pats)])
-                if dry_run:
-                        return list(__calc_frozen().values())
-                with self.locked_op("freeze"):
-                        stems_and_pats = __calc_frozen()
-                        # Get existing dictionary of frozen packages.
-                        d = self.__freeze_dict_load()
-                        # Update the dictionary with the new freezes and
-                        # comment.
-                        timestamp = calendar.timegm(time.gmtime())
-                        d.update([(s, (str(p), comment, timestamp))
-                            for s, p in six.iteritems(stems_and_pats)])
-                        self._freeze_dict_save(d)
-                        return list(stems_and_pats.values())
-
-        def unfreeze_pkgs(self, pat_list, progtrack, check_cancel, dry_run):
-                """Unfreeze the specified packages... use pattern matching on
-                names; ignore versions.
-
-                The 'pat_list' parameter contains the list of patterns of
-                packages to freeze.
-
-                The 'progtrack' parameter contains the progress tracker for this
-                operation.
-
-                The 'check_cancel' parameter contains a function to call to
-                check if the operation has been canceled.
-
-                The 'dry_run' parameter controls whether packages are actually
-                frozen."""
-
-                def __calc_unfrozen():
-                        # Get existing dictionary of frozen packages.
-                        d = self.__freeze_dict_load()
-                        # Match the user's patterns against the frozen packages
-                        # and return the stems which matched, and the dictionary
-                        # of the currently frozen packages.
-                        ip = imageplan.ImagePlan
-                        return set(ip.match_user_stems(self, pat_list,
-                            ip.MATCH_ALL, raise_unmatched=False,
-                            universe=[(None, k) for k in d.keys()])), d
-
-                if dry_run:
-                        return __calc_unfrozen()[0]
-                with self.locked_op("freeze"):
-                        unfrozen_set, d = __calc_unfrozen()
-                        # Remove the specified packages from the frozen set.
-                        for n in unfrozen_set:
-                                d.pop(n, None)
-                        self._freeze_dict_save(d)
-                        return unfrozen_set
-
-        def __call_imageplan_evaluate(self, ip):
-                # A plan can be requested without actually performing an
-                # operation on the image.
-                if self.history.operation_name:
-                        self.history.operation_start_state = ip.get_plan()
-
-                try:
-                        ip.evaluate()
-                except apx.ConflictingActionErrors:
-                        # Image plan evaluation can fail because of duplicate
-                        # action discovery, but we still want to be able to
-                        # display and log the solved FMRI changes.
-                        self.imageplan = ip
-                        if self.history.operation_name:
-                                self.history.operation_end_state = \
-                                    "Unevaluated: merged plan had errors\n" + \
-                                    ip.get_plan(full=False)
-                        raise
-
-                self.imageplan = ip
-
-                if self.history.operation_name:
-                        self.history.operation_end_state = \
-                            ip.get_plan(full=False)
-
-        def __make_plan_common(self, _op, _progtrack, _check_cancel,
-            _noexecute, _ip_noop=False, **kwargs):
-                """Private helper function to perform base plan creation and
-                cleanup.
-                """
-
-                if DebugValues.get_value("simulate-plan-hang"):
-                        # If pkg5.hang file is present in image dir, then
-                        # sleep after loading configuration until file is
-                        # gone.  This is used by the test suite for signal
-                        # handling testing, etc.
-                        hang_file = os.path.join(self.imgdir, "pkg5.hang")
-                        with open(hang_file, "w") as f:
-                                f.write(str(os.getpid()))
-
-                        while os.path.exists(hang_file):
-                                time.sleep(1)
-
-                # Allow garbage collection of previous plan.
-                self.imageplan = None
-
-                ip = imageplan.ImagePlan(self, _op, _progtrack, _check_cancel,
-                    noexecute=_noexecute)
-
-                # Always start with most current (on-disk) state information.
-                self.__init_catalogs()
-
-                try:
-                        try:
-                                if _ip_noop:
-                                        ip.plan_noop(**kwargs)
-                                elif _op in [
-                                    pkgdefs.API_OP_ATTACH,
-                                    pkgdefs.API_OP_DETACH,
-                                    pkgdefs.API_OP_SYNC]:
-                                        ip.plan_sync(**kwargs)
-                                elif _op in [
-                                    pkgdefs.API_OP_CHANGE_FACET,
-                                    pkgdefs.API_OP_CHANGE_VARIANT]:
-                                        ip.plan_change_varcets(**kwargs)
-                                elif _op == pkgdefs.API_OP_DEHYDRATE:
-                                        ip.plan_dehydrate(**kwargs)
-                                elif _op == pkgdefs.API_OP_INSTALL:
-                                        ip.plan_install(**kwargs)
-                                elif _op ==pkgdefs.API_OP_EXACT_INSTALL:
-                                        ip.plan_exact_install(**kwargs)
-                                elif _op in [pkgdefs.API_OP_FIX,
-                                    pkgdefs.API_OP_VERIFY]:
-                                        ip.plan_fix(**kwargs)
-                                elif _op == pkgdefs.API_OP_REHYDRATE:
-                                        ip.plan_rehydrate(**kwargs)
-                                elif _op == pkgdefs.API_OP_REVERT:
-                                        ip.plan_revert(**kwargs)
-                                elif _op == pkgdefs.API_OP_SET_MEDIATOR:
-                                        ip.plan_set_mediators(**kwargs)
-                                elif _op == pkgdefs.API_OP_UNINSTALL:
-                                        ip.plan_uninstall(**kwargs)
-                                elif _op == pkgdefs.API_OP_UPDATE:
-                                        ip.plan_update(**kwargs)
-                                else:
-                                        raise RuntimeError(
-                                            "Unknown api op: {0}".format(_op))
-
-                        except apx.ActionExecutionError as e:
-                                raise
-                        except pkg.actions.ActionError as e:
-                                raise apx.InvalidPackageErrors([e])
-                        except apx.ApiException:
-                                raise
-                        try:
-                                self.__call_imageplan_evaluate(ip)
-                        except apx.ActionExecutionError as e:
-                                raise
-                        except pkg.actions.ActionError as e:
-                                raise apx.InvalidPackageErrors([e])
-                finally:
-                        self.__cleanup_alt_pkg_certs()
-
-        def make_install_plan(self, op, progtrack, check_cancel,
-            noexecute, pkgs_inst=None, reject_list=misc.EmptyI):
-                """Take a list of packages, specified in pkgs_inst, and attempt
-                to assemble an appropriate image plan.  This is a helper
-                routine for some common operations in the client.
-                """
-
-                progtrack.plan_all_start()
-
-                self.__make_plan_common(op, progtrack, check_cancel,
-                    noexecute, pkgs_inst=pkgs_inst,
-                    reject_list=reject_list)
-
-                progtrack.plan_all_done()
-
-        def make_change_varcets_plan(self, op, progtrack, check_cancel,
-            noexecute, facets=None, reject_list=misc.EmptyI,
-            variants=None):
-                """Take a list of variants and/or facets and attempt to
-                assemble an image plan which changes them.  This is a helper
-                routine for some common operations in the client."""
-
-                progtrack.plan_all_start()
-                # compute dict of changing variants
-                if variants:
-                        new = set(six.iteritems(variants))
-                        cur = set(six.iteritems(self.cfg.variants))
-                        variants = dict(new - cur)
-                elif facets:
-                        new_facets = self.get_facets()
-                        for f in facets:
-                                if facets[f] is None:
-                                        new_facets.pop(f, None)
-                                else:
-                                        new_facets[f] = facets[f]
-                        facets = new_facets
-
-                self.__make_plan_common(op, progtrack, check_cancel,
-                    noexecute, new_variants=variants, new_facets=facets,
-                    reject_list=reject_list)
-
-                progtrack.plan_all_done()
-
-        def make_set_mediators_plan(self, op, progtrack, check_cancel,
-            noexecute, mediators):
-                """Take a dictionary of mediators and attempt to assemble an
-                appropriate image plan to set or revert them based on the
-                provided version and implementation values.  This is a helper
-                routine for some common operations in the client.
-                """
-
-                progtrack.plan_all_start()
-
-                # Compute dict of changing mediators.
-                new_mediators = copy.deepcopy(mediators)
-                old_mediators = self.cfg.mediators
-                invalid_mediations = collections.defaultdict(dict)
-                for m in new_mediators.keys():
-                        new_values = new_mediators[m]
-                        if not new_values:
-                                if m not in old_mediators:
-                                        # Nothing to revert.
-                                        del new_mediators[m]
-                                        continue
-
-                                # Revert mediator to defaults.
-                                new_mediators[m] = {}
-                                continue
-
-                        # Validate mediator, provided version, implementation,
-                        # and source.
-                        valid, error = med.valid_mediator(m)
-                        if not valid:
-                                invalid_mediations[m]["mediator"] = (m, error)
-
-                        med_version = new_values.get("version")
-                        if med_version:
-                                valid, error = med.valid_mediator_version(
-                                    med_version)
-                                if valid:
-                                         new_mediators[m]["version"] = \
-                                            pkg.version.Version(med_version)
-                                else:
-                                        invalid_mediations[m]["version"] = \
-                                            (med_version, error)
-
-                        med_impl = new_values.get("implementation")
-                        if med_impl:
-                                valid, error = med.valid_mediator_implementation(
-                                    med_impl, allow_empty_version=True)
-                                if not valid:
-                                        invalid_mediations[m]["version"] = \
-                                            (med_impl, error)
-
-                if invalid_mediations:
-                        raise apx.PlanCreationException(
-                            invalid_mediations=invalid_mediations)
-
-                self.__make_plan_common(op, progtrack, check_cancel,
-                    noexecute, new_mediators=new_mediators)
-
-                progtrack.plan_all_done()
-
-        def make_sync_plan(self, op, progtrack, check_cancel,
-            noexecute, li_pkg_updates=True, reject_list=misc.EmptyI):
-                """Attempt to create an appropriate image plan to bring an
-                image in sync with it's linked image constraints.  This is a
-                helper routine for some common operations in the client."""
-
-                progtrack.plan_all_start()
-
-                self.__make_plan_common(op, progtrack, check_cancel,
-                    noexecute, reject_list=reject_list,
-                    li_pkg_updates=li_pkg_updates)
-
-                progtrack.plan_all_done()
-
-        def make_uninstall_plan(self, op, progtrack, check_cancel,
-            ignore_missing, noexecute, pkgs_to_uninstall):
-                """Create uninstall plan to remove the specified packages."""
-
-                progtrack.plan_all_start()
-
-                self.__make_plan_common(op, progtrack, check_cancel,
-                    noexecute, ignore_missing=ignore_missing,
-                    pkgs_to_uninstall=pkgs_to_uninstall)
-
-                progtrack.plan_all_done()
-
-        def make_update_plan(self, op, progtrack, check_cancel,
-            noexecute, ignore_missing=False, pkgs_update=None,
-            reject_list=misc.EmptyI):
-                """Create a plan to update all packages or the specific ones as
-                far as possible.  This is a helper routine for some common
-                operations in the client.
-                """
-
-                progtrack.plan_all_start()
-                self.__make_plan_common(op, progtrack, check_cancel,
-                    noexecute, ignore_missing=ignore_missing,
-                    pkgs_update=pkgs_update, reject_list=reject_list)
-                progtrack.plan_all_done()
-
-        def make_revert_plan(self, op, progtrack, check_cancel,
-            noexecute, args, tagged):
-                """Revert the specified files, or all files tagged as specified
-                in args to their manifest definitions.
-                """
-
-                progtrack.plan_all_start()
-                self.__make_plan_common(op, progtrack, check_cancel,
-                    noexecute, args=args, tagged=tagged)
-                progtrack.plan_all_done()
-
-        def make_dehydrate_plan(self, op, progtrack, check_cancel, noexecute,
-                publishers):
-                """Remove non-editable files and hardlinks from an image."""
-
-                progtrack.plan_all_start()
-                self.__make_plan_common(op, progtrack, check_cancel,
-                    noexecute, publishers=publishers)
-                progtrack.plan_all_done()
-
-        def make_rehydrate_plan(self, op, progtrack, check_cancel, noexecute,
-                publishers):
-                """Reinstall non-editable files and hardlinks to an dehydrated
-                image."""
-
-                progtrack.plan_all_start()
-                self.__make_plan_common(op, progtrack, check_cancel,
-                    noexecute, publishers=publishers)
-                progtrack.plan_all_done()
-
-        def make_fix_plan(self, op, progtrack, check_cancel, noexecute, args,
-            unpackaged=False, unpackaged_only=False, verify_paths=EmptyI):
-                """Create an image plan to fix the image. Note: verify shares
-                the same routine."""
-
-                progtrack.plan_all_start()
-                self.__make_plan_common(op, progtrack, check_cancel, noexecute,
-                    args=args, unpackaged=unpackaged,
-                    unpackaged_only=unpackaged_only, verify_paths=verify_paths)
-                progtrack.plan_all_done()
-
-        def make_noop_plan(self, op, progtrack, check_cancel,
-            noexecute):
-                """Create an image plan that doesn't update the image in any
-                way."""
-
-                progtrack.plan_all_start()
-                self.__make_plan_common(op, progtrack, check_cancel,
-                    noexecute, _ip_noop=True)
-                progtrack.plan_all_done()
-
-        def ipkg_is_up_to_date(self, check_cancel, noexecute,
-            refresh_allowed=True, progtrack=None):
-                """Test whether the packaging system is updated to the latest
-                version known to be available for this image."""
-
-                #
-                # This routine makes the distinction between the "target image",
-                # which will be altered, and the "running image", which is
-                # to say whatever image appears to contain the version of the
-                # pkg command we're running.
-                #
-
-                #
-                # There are two relevant cases here:
-                #     1) Packaging code and image we're updating are the same
-                #        image.  (i.e. 'pkg update')
-                #
-                #     2) Packaging code's image and the image we're updating are
-                #        different (i.e. 'pkg update -R')
-                #
-                # In general, we care about getting the user to run the
-                # most recent packaging code available for their build.  So,
-                # if we're not in the liveroot case, we create a new image
-                # which represents "/" on the system.
-                #
-
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-
-                img = self
-
-                if self.__cmddir and not img.is_liveroot():
-                        #
-                        # Find the path to ourselves, and use that
-                        # as a way to locate the image we're in.  It's
-                        # not perfect-- we could be in a developer's
-                        # workspace, for example.
-                        #
-                        newimg = Image(self.__cmddir,
-                            allow_ondisk_upgrade=False, progtrack=progtrack,
-                            cmdpath=self.cmdpath)
-                        useimg = True
-                        if refresh_allowed:
-                                # If refreshing publisher metadata is allowed,
-                                # then perform a refresh so that a new packaging
-                                # system package can be discovered.
-                                newimg.lock(allow_unprivileged=True)
-                                try:
-                                        newimg.refresh_publishers(
-                                            progtrack=progtrack)
-                                except (apx.ImageFormatUpdateNeeded,
-                                    apx.PermissionsException):
-                                        # Can't use the image to perform an
-                                        # update check and it would be wrong
-                                        # to prevent the operation from
-                                        # continuing in these cases.
-                                        useimg = False
-                                except apx.CatalogRefreshException as cre:
-                                        cre.errmessage = \
-                                            _("pkg(7) update check failed.")
-                                        raise
-                                finally:
-                                        newimg.unlock()
-
-                        if useimg:
-                                img = newimg
-
-                pfmri = img.get_version_installed(img.strtofmri("package/pkg"))
-                if not pfmri or \
-                    not pkgdefs.PKG_STATE_UPGRADABLE in img.get_pkg_state(pfmri):
-                        # If no version of the package system is installed or a
-                        # newer version isn't available, then the client is
-                        # "up-to-date".
-                        return True
-
-                inc_fmri = img.get_version_installed(img.strtofmri(
-                    "consolidation/ips/ips-incorporation"))
-                if inc_fmri:
-                        # If the ips-incorporation is installed (it should be
-                        # since package/pkg depends on it), then we can
-                        # bypass the solver and plan evaluation if none of the
-                        # newer versions are allowed by the incorporation.
-
-                        # Find the version at which package/pkg is incorporated.
-                        cat = img.get_catalog(img.IMG_CATALOG_KNOWN)
-                        inc_ver = None
-                        for act in cat.get_entry_actions(inc_fmri, [cat.DEPENDENCY],
-                            excludes=img.list_excludes()):
-                                if act.name == "depend" and \
-                                    act.attrs["type"] == "incorporate" and \
-                                    act.attrs["fmri"].startswith("package/pkg"):
-                                        inc_ver = img.strtofmri(
-                                            act.attrs["fmri"]).version
-                                        break
-
-                        if inc_ver:
-                                for ver, fmris in cat.fmris_by_version(
-                                    "package/pkg"):
-                                        if ver != pfmri.version and \
-                                            ver.is_successor(inc_ver,
-                                                pkg.version.CONSTRAINT_AUTO):
-                                                break
-                                else:
-                                        # No version is newer than installed and
-                                        # satisfied incorporation constraint.
-                                        return True
-
-                # XXX call to progress tracker that the package is being
-                # refreshed
-                img.make_install_plan(pkgdefs.API_OP_INSTALL, progtrack,
-                    check_cancel, noexecute, pkgs_inst=["pkg:/package/pkg"])
-
-                return img.imageplan.nothingtodo()
-
-        # avoid set implementation uses json to store a set of pkg_stems
-        # being avoided (explicitly or implicitly), and a set of tracked stems
-        # that are obsolete.
-        #
-        # format is (version, dict((pkg stem, "avoid", "implicit-avoid" or
-        # "obsolete"))
-
-        __AVOID_SET_VERSION = 1
-
-        def avoid_set_get(self, implicit=False):
-                """Return copy of avoid set"""
-                if implicit:
-                        return self.__implicit_avoid_set.copy()
-                return self.__avoid_set.copy()
-
-        def obsolete_set_get(self):
-                """Return copy of tracked obsolete pkgs"""
-                return self.__group_obsolete.copy()
-
-        def __avoid_set_load(self):
-                """Load avoid set fron image state directory"""
-                state_file = os.path.join(self._statedir, "avoid_set")
-                self.__avoid_set = set()
-                self.__implicit_avoid_set = set()
-                self.__group_obsolete = set()
-                if os.path.isfile(state_file):
-                        try:
-                                 with open(state_file) as f:
-                                        version, d = json.load(f)
-                        except EnvironmentError as e:
-                                 raise apx._convert_error(e)
-                        except ValueError as e:
-                                 salvaged_path = self.salvage(state_file,
-                                     full_path=True)
-                                 logger.warning("Corrupted avoid list - salvaging"
-                                     " file {state_file} in {salvaged_path}"
-                                     .format(state_file=state_file,
-                                     salvaged_path=salvaged_path))
-                                 return
-                        assert version == self.__AVOID_SET_VERSION
-                        for stem in d:
-                                if d[stem] == "avoid":
-                                        self.__avoid_set.add(stem)
-                                elif d[stem] == "implicit-avoid":
-                                        self.__implicit_avoid_set.add(stem)
-                                elif d[stem] == "obsolete":
-                                        self.__group_obsolete.add(stem)
-                                else:
-                                        logger.warning("Corrupted avoid list - ignoring")
-                                        self.__avoid_set = set()
-                                        self.__implicit_avoid_set = set()
-                                        self.__group_obsolete = set()
-                                        self.__avoid_set_altered = True
-                else:
-                        self.__avoid_set_altered = True
-
-        def _avoid_set_save(self, new_set=None, implicit_avoid=None,
-            obsolete=None):
-                """Store avoid set to image state directory"""
-                if new_set is not None:
-                        self.__avoid_set_altered = True
-                        self.__avoid_set = new_set
-
-                if implicit_avoid is not None:
-                        self.__avoid_set_altered = True
-                        self.__implicit_avoid_set = implicit_avoid
-
-                if obsolete is not None:
-                        self.__group_obsolete = obsolete
-                        self.__avoid_set_altered = True
-
-                if not self.__avoid_set_altered:
-                        return
-
-
-                state_file = os.path.join(self._statedir, "avoid_set")
-                tmp_file   = os.path.join(self._statedir, "avoid_set.new")
-                tf = open(tmp_file, "w")
-
-                d = dict((a, "avoid") for a in self.__avoid_set)
-                d.update(
-                    (a, "implicit-avoid")
-                    for a in self.__implicit_avoid_set
-                )
-                d.update((a, "obsolete") for a in self.__group_obsolete)
-
-                try:
-                        json.dump((self.__AVOID_SET_VERSION, d), tf)
-                        tf.close()
-                        portable.rename(tmp_file, state_file)
-                except Exception as e:
-                        logger.warning("Cannot save avoid list: {0}".format(
-                            str(e)))
-                        return
-
-                self.update_last_modified()
-
-                self.__avoid_set_altered = False
-
-        # frozen dict implementation uses json to store a dictionary of
-        # pkg_stems that are frozen, the versions at which they're frozen, and
-        # the reason, if given, why the package was frozen.
-        #
-        # format is (version, dict((pkg stem, (fmri, comment, timestamp))))
-
-        __FROZEN_DICT_VERSION = 1
-
-        def get_frozen_list(self):
-                """Return a list of tuples containing the fmri that was frozen,
-                and the reason it was frozen."""
-
-                return [
-                    (pkg.fmri.MatchingPkgFmri(v[0]), v[1], v[2])
-                    for v in self.__freeze_dict_load().values()
-                ]
-
-        def __freeze_dict_load(self):
-                """Load the dictionary containing the current state of frozen
-                packages."""
-
-                state_file = os.path.join(self._statedir, "frozen_dict")
-                if os.path.isfile(state_file):
-                        try:
-                                with open(state_file) as f:
-                                        version, d = json.load(f)
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-                        except ValueError as e:
-                                raise apx.InvalidFreezeFile(state_file)
-                        if version != self.__FROZEN_DICT_VERSION:
-                                raise apx.UnknownFreezeFileVersion(
-                                    version, self.__FROZEN_DICT_VERSION,
-                                    state_file)
-                        return d
-                return {}
-
-        def _freeze_dict_save(self, new_dict):
-                """Save the dictionary of frozen packages."""
-
-                # Save the dictionary to disk.
-                state_file = os.path.join(self._statedir, "frozen_dict")
-                tmp_file   = os.path.join(self._statedir, "frozen_dict.new")
-
-                try:
-                        with open(tmp_file, "w") as tf:
-                                json.dump(
-                                    (self.__FROZEN_DICT_VERSION, new_dict), tf)
-                        portable.rename(tmp_file, state_file)
-                        self.update_last_modified()
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-                self.__rebuild_image_catalogs()
-
-        @staticmethod
-        def get_dehydrated_exclude_func(dehydrated_pubs):
-                """A boolean function that will be added to the pkg(7) exclude
-                mechanism to determine if an action is allowed to be installed
-                based on whether its publisher is going to be dehydrated or has
-                been currently dehydrated."""
-
-                # A closure is used so that the list of dehydrated publishers
-                # can be accessed.
-                def __allow_action_dehydrate(act, publisher):
-                        if publisher not in dehydrated_pubs:
-                                # Allow actions from publishers that are not
-                                # dehydrated.
-                                return True
-
-                        aname = act.name
-                        if aname == "file":
-                                attrs = act.attrs
-                                if attrs.get("dehydrate") == "false":
-                                        return True
-                                if "preserve" in attrs or "overlay" in attrs:
-                                        return True
-                                return False
-                        elif aname == "hardlink":
-                                return False
-
-                        return True
-
-                return __allow_action_dehydrate
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/imageconfig.py
+++ b/src/modules/client/imageconfig.py
@@ -47,11 +47,13 @@ import pkg.smf as smf
 import pkg.variant as variant
 
 from pkg.client import global_settings
+
 logger = global_settings.logger
 
 from pkg.misc import DictProperty, SIGNATURE_POLICY
 from pkg.client.debugvalues import DebugValues
 from pkg.client.transport.exception import TransportFailures
+
 # The default_policies dictionary defines the policies that are supported by
 # pkg(7) and their default values. Calls to the ImageConfig.get_policy method
 # should use the constants defined here.
@@ -86,18 +88,18 @@ default_policies = {
 }
 
 default_policy_map = {
-    BE_POLICY: { "default": "create-backup" },
-    CONTENT_UPDATE_POLICY: { "default": "always" },
+    BE_POLICY: {"default": "create-backup"},
+    CONTENT_UPDATE_POLICY: {"default": "always"},
 }
 
 CA_PATH = "ca-path"
 # Default CA_PATH is /etc/ssl/certs
 default_properties = {
-        CA_PATH: os.path.join(os.path.sep, "etc", "ssl", "certs"),
-        # Path default is intentionally relative for this case.
-        "trust-anchor-directory": os.path.join("etc", "ssl", "pkg"),
-        DEFAULT_CONCURRENCY: 1,
-        AUTO_BE_NAME: "omnios-r%r",
+    CA_PATH: os.path.join(os.path.sep, "etc", "ssl", "certs"),
+    # Path default is intentionally relative for this case.
+    "trust-anchor-directory": os.path.join("etc", "ssl", "pkg"),
+    DEFAULT_CONCURRENCY: 1,
+    AUTO_BE_NAME: "omnios-r%r",
 }
 
 # Assume the repository metadata should be checked no more than once every
@@ -110,140 +112,213 @@ DA_FILE = "disabled_auth"
 
 # Token used for default values.
 DEF_TOKEN = "DEFAULT"
-_val_map_none = { "None": None }
+_val_map_none = {"None": None}
 
 CURRENT_VERSION = 3
 
-class ImageConfig(cfg.FileConfig):
-        """An ImageConfig object is a collection of configuration information:
-        URLs, publishers, properties, etc. that allow an Image to operate."""
 
-        # This dictionary defines the set of default properties and property
-        # groups for an image configuration indexed by version.
-        __defs = {
-            2: [
-                cfg.PropertySection("filter", properties=[]),
-                cfg.PropertySection("image", properties=[
+class ImageConfig(cfg.FileConfig):
+    """An ImageConfig object is a collection of configuration information:
+    URLs, publishers, properties, etc. that allow an Image to operate."""
+
+    # This dictionary defines the set of default properties and property
+    # groups for an image configuration indexed by version.
+    __defs = {
+        2: [
+            cfg.PropertySection("filter", properties=[]),
+            cfg.PropertySection(
+                "image",
+                properties=[
                     cfg.PropInt("version"),
-                ]),
-                cfg.PropertySection("property", properties=[
+                ],
+            ),
+            cfg.PropertySection(
+                "property",
+                properties=[
                     cfg.PropList("publisher-search-order"),
                     cfg.PropPublisher("preferred-authority"),
                     cfg.PropBool("display-coprights", default=True),
                     cfg.PropBool("require-optional", default=False),
                     cfg.PropBool("pursue-latest", default=True),
-                    cfg.PropBool(FLUSH_CONTENT_CACHE,
-                        default=default_policies[FLUSH_CONTENT_CACHE]),
-                    cfg.PropBool(SEND_UUID,
-                        default=default_policies[SEND_UUID]),
-                ]),
-                cfg.PropertySection("variant", properties=[]),
-                cfg.PropertySectionTemplate("^authority_.*", properties=[
+                    cfg.PropBool(
+                        FLUSH_CONTENT_CACHE,
+                        default=default_policies[FLUSH_CONTENT_CACHE],
+                    ),
+                    cfg.PropBool(
+                        SEND_UUID, default=default_policies[SEND_UUID]
+                    ),
+                ],
+            ),
+            cfg.PropertySection("variant", properties=[]),
+            cfg.PropertySectionTemplate(
+                "^authority_.*",
+                properties=[
                     # Base publisher information.
                     cfg.PropPublisher("alias", value_map=_val_map_none),
                     cfg.PropPublisher("prefix", value_map=_val_map_none),
                     cfg.PropBool("disabled"),
                     cfg.PropUUID("uuid", value_map=_val_map_none),
                     # Publisher transport information.
-                    cfg.PropPubURIList("mirrors",
-                        value_map=_val_map_none),
+                    cfg.PropPubURIList("mirrors", value_map=_val_map_none),
                     cfg.PropPubURI("origin", value_map=_val_map_none),
                     cfg.Property("ssl_cert", value_map=_val_map_none),
                     cfg.Property("ssl_key", value_map=_val_map_none),
                     # Publisher repository metadata.
-                    cfg.PropDefined("repo.collection_type", ["core",
-                        "supplemental"], default="core",
-                        value_map=_val_map_none),
-                    cfg.PropDefined("repo.description",
-                        value_map=_val_map_none),
+                    cfg.PropDefined(
+                        "repo.collection_type",
+                        ["core", "supplemental"],
+                        default="core",
+                        value_map=_val_map_none,
+                    ),
+                    cfg.PropDefined(
+                        "repo.description", value_map=_val_map_none
+                    ),
                     cfg.PropList("repo.legal_uris", value_map=_val_map_none),
-                    cfg.PropDefined("repo.name", default="package repository",
-                        value_map=_val_map_none),
+                    cfg.PropDefined(
+                        "repo.name",
+                        default="package repository",
+                        value_map=_val_map_none,
+                    ),
                     # Must be a string so "" can be stored.
-                    cfg.Property("repo.refresh_seconds",
+                    cfg.Property(
+                        "repo.refresh_seconds",
                         default=str(REPO_REFRESH_SECONDS_DEFAULT),
-                        value_map=_val_map_none),
+                        value_map=_val_map_none,
+                    ),
                     cfg.PropBool("repo.registered", value_map=_val_map_none),
-                    cfg.Property("repo.registration_uri",
-                        value_map=_val_map_none),
-                    cfg.PropList("repo.related_uris",
-                        value_map=_val_map_none),
+                    cfg.Property(
+                        "repo.registration_uri", value_map=_val_map_none
+                    ),
+                    cfg.PropList("repo.related_uris", value_map=_val_map_none),
                     cfg.Property("repo.sort_policy", value_map=_val_map_none),
-                ]),
-            ],
-            3: [
-                cfg.PropertySection("image", properties=[
+                ],
+            ),
+        ],
+        3: [
+            cfg.PropertySection(
+                "image",
+                properties=[
                     cfg.PropInt("version"),
-                ]),
-                # The preferred-authority property should be removed from
-                # version 4 of image config.
-                cfg.PropertySection("property", properties=[
+                ],
+            ),
+            # The preferred-authority property should be removed from
+            # version 4 of image config.
+            cfg.PropertySection(
+                "property",
+                properties=[
                     cfg.PropPublisher("preferred-authority"),
                     cfg.PropList("publisher-search-order"),
-                    cfg.PropDefined(BE_POLICY, allowed=["default",
-                        "always-new", "create-backup", "when-required"],
-                        default=default_policies[BE_POLICY]),
-                    cfg.PropDefined(CONTENT_UPDATE_POLICY, allowed=["default",
-                        "always", "when-required"],
-                        default=default_policies[CONTENT_UPDATE_POLICY]),
-                    cfg.PropBool(FLUSH_CONTENT_CACHE,
-                        default=default_policies[FLUSH_CONTENT_CACHE]),
-                    cfg.PropBool(MIRROR_DISCOVERY,
-                        default=default_policies[MIRROR_DISCOVERY]),
-                    cfg.PropBool(SEND_UUID,
-                        default=default_policies[SEND_UUID]),
-                    cfg.PropDefined(SIGNATURE_POLICY,
+                    cfg.PropDefined(
+                        BE_POLICY,
+                        allowed=[
+                            "default",
+                            "always-new",
+                            "create-backup",
+                            "when-required",
+                        ],
+                        default=default_policies[BE_POLICY],
+                    ),
+                    cfg.PropDefined(
+                        CONTENT_UPDATE_POLICY,
+                        allowed=["default", "always", "when-required"],
+                        default=default_policies[CONTENT_UPDATE_POLICY],
+                    ),
+                    cfg.PropBool(
+                        FLUSH_CONTENT_CACHE,
+                        default=default_policies[FLUSH_CONTENT_CACHE],
+                    ),
+                    cfg.PropBool(
+                        MIRROR_DISCOVERY,
+                        default=default_policies[MIRROR_DISCOVERY],
+                    ),
+                    cfg.PropBool(
+                        SEND_UUID, default=default_policies[SEND_UUID]
+                    ),
+                    cfg.PropDefined(
+                        SIGNATURE_POLICY,
                         allowed=list(sigpolicy.Policy.policies()) + [DEF_TOKEN],
-                        default=DEF_TOKEN),
-                    cfg.PropBool(USE_SYSTEM_REPO,
-                        default=default_policies[USE_SYSTEM_REPO]),
-                    cfg.Property(CA_PATH,
-                        default=default_properties[CA_PATH]),
-                    cfg.Property("trust-anchor-directory",
-                        default=DEF_TOKEN),
+                        default=DEF_TOKEN,
+                    ),
+                    cfg.PropBool(
+                        USE_SYSTEM_REPO,
+                        default=default_policies[USE_SYSTEM_REPO],
+                    ),
+                    cfg.Property(CA_PATH, default=default_properties[CA_PATH]),
+                    cfg.Property("trust-anchor-directory", default=DEF_TOKEN),
                     cfg.PropList("signature-required-names"),
-                    cfg.Property(CHECK_CERTIFICATE_REVOCATION,
-                        default=default_policies[
-                            CHECK_CERTIFICATE_REVOCATION]),
+                    cfg.Property(
+                        CHECK_CERTIFICATE_REVOCATION,
+                        default=default_policies[CHECK_CERTIFICATE_REVOCATION],
+                    ),
                     cfg.PropList("dehydrated"),
                     cfg.PropList(EXCLUDE_PATTERNS),
-                    cfg.PropDefined(EXCLUDE_POLICY,
+                    cfg.PropDefined(
+                        EXCLUDE_POLICY,
                         allowed=["ignore", "warn", "reject"],
-                        default=default_policies[EXCLUDE_POLICY]),
+                        default=default_policies[EXCLUDE_POLICY],
+                    ),
                     cfg.PropList(KEY_FILES),
-                    cfg.PropBool(DEFAULT_RECURSE,
-                        default=default_policies[DEFAULT_RECURSE]),
-                    cfg.PropInt(DEFAULT_CONCURRENCY,
+                    cfg.PropBool(
+                        DEFAULT_RECURSE,
+                        default=default_policies[DEFAULT_RECURSE],
+                    ),
+                    cfg.PropInt(
+                        DEFAULT_CONCURRENCY,
                         minimum=0,
-                        default=default_properties[DEFAULT_CONCURRENCY]),
-                    cfg.Property(AUTO_BE_NAME,
+                        default=default_properties[DEFAULT_CONCURRENCY],
+                    ),
+                    cfg.Property(
+                        AUTO_BE_NAME,
                         default=default_properties[AUTO_BE_NAME],
-                        value_map=_val_map_none),
-                    cfg.PropBool(TEMP_BE_ACTIVATION,
-                        default=default_policies[TEMP_BE_ACTIVATION]),
-                ]),
-                cfg.PropertySection("facet", properties=[
+                        value_map=_val_map_none,
+                    ),
+                    cfg.PropBool(
+                        TEMP_BE_ACTIVATION,
+                        default=default_policies[TEMP_BE_ACTIVATION],
+                    ),
+                ],
+            ),
+            cfg.PropertySection(
+                "facet",
+                properties=[
                     cfg.PropertyTemplate(r"^facet\..*", prop_type=cfg.PropBool),
-                ]),
-                cfg.PropertySection("inherited_facet", properties=[
+                ],
+            ),
+            cfg.PropertySection(
+                "inherited_facet",
+                properties=[
                     cfg.PropertyTemplate(r"^facet\..*", prop_type=cfg.PropBool),
-                ]),
-                cfg.PropertySection("mediators", properties=[
+                ],
+            ),
+            cfg.PropertySection(
+                "mediators",
+                properties=[
                     cfg.PropertyTemplate(r"^[A-Za-z0-9\-]+\.implementation$"),
-                    cfg.PropertyTemplate(r"^[A-Za-z0-9\-]+\.implementation-version$",
-                        prop_type=cfg.PropVersion),
-                    cfg.PropertyTemplate(r"^[A-Za-z0-9\-]+\.implementation-source$",
-                        prop_type=cfg.PropDefined, allowed=["site", "vendor",
-                        "local", "system"], default="local"),
-                    cfg.PropertyTemplate(r"^[A-Za-z0-9\-]+\.version$",
-                        prop_type=cfg.PropVersion),
-                    cfg.PropertyTemplate(r"^[A-Za-z0-9\-]+\.version-source$",
-                        prop_type=cfg.PropDefined, allowed=["site", "vendor",
-                        "local", "system"], default="local"),
-                ]),
-                cfg.PropertySection("variant", properties=[]),
-
-                cfg.PropertySectionTemplate("^authority_.*", properties=[
+                    cfg.PropertyTemplate(
+                        r"^[A-Za-z0-9\-]+\.implementation-version$",
+                        prop_type=cfg.PropVersion,
+                    ),
+                    cfg.PropertyTemplate(
+                        r"^[A-Za-z0-9\-]+\.implementation-source$",
+                        prop_type=cfg.PropDefined,
+                        allowed=["site", "vendor", "local", "system"],
+                        default="local",
+                    ),
+                    cfg.PropertyTemplate(
+                        r"^[A-Za-z0-9\-]+\.version$", prop_type=cfg.PropVersion
+                    ),
+                    cfg.PropertyTemplate(
+                        r"^[A-Za-z0-9\-]+\.version-source$",
+                        prop_type=cfg.PropDefined,
+                        allowed=["site", "vendor", "local", "system"],
+                        default="local",
+                    ),
+                ],
+            ),
+            cfg.PropertySection("variant", properties=[]),
+            cfg.PropertySectionTemplate(
+                "^authority_.*",
+                properties=[
                     # Base publisher information.
                     cfg.PropPublisher("alias", value_map=_val_map_none),
                     cfg.PropPublisher("prefix", value_map=_val_map_none),
@@ -252,1401 +327,1483 @@ class ImageConfig(cfg.FileConfig):
                     cfg.PropUUID("uuid", value_map=_val_map_none),
                     cfg.Property("last_uuid", value_map=_val_map_none),
                     # Publisher transport information.
-                    cfg.PropPubURIList("mirrors",
-                        value_map=_val_map_none),
+                    cfg.PropPubURIList("mirrors", value_map=_val_map_none),
                     # extended information about mirrors
-                    cfg.PropPubURIDictionaryList("mirror_info",
-                        value_map=_val_map_none),
+                    cfg.PropPubURIDictionaryList(
+                        "mirror_info", value_map=_val_map_none
+                    ),
                     cfg.PropPubURI("origin", value_map=_val_map_none),
-                    cfg.PropPubURIList("origins",
-                        value_map=_val_map_none),
+                    cfg.PropPubURIList("origins", value_map=_val_map_none),
                     # extended information about origins
-                    cfg.PropPubURIDictionaryList("origin_info",
-                        value_map=_val_map_none),
+                    cfg.PropPubURIDictionaryList(
+                        "origin_info", value_map=_val_map_none
+                    ),
                     # when keys/certs can be set per-origin/mirror, these
                     # should move into origin_info/mirror_info
                     cfg.Property("ssl_cert", value_map=_val_map_none),
                     cfg.Property("ssl_key", value_map=_val_map_none),
                     # Publisher signing information.
-                    cfg.PropDefined("property.{0}".format(SIGNATURE_POLICY),
+                    cfg.PropDefined(
+                        "property.{0}".format(SIGNATURE_POLICY),
                         allowed=list(sigpolicy.Policy.policies()) + [DEF_TOKEN],
-                        default=DEF_TOKEN),
+                        default=DEF_TOKEN,
+                    ),
                     cfg.PropList("property.signature-required-names"),
                     cfg.PropList("intermediate_certs"),
                     cfg.PropList("approved_ca_certs"),
                     cfg.PropList("revoked_ca_certs"),
                     cfg.PropList("signing_ca_certs"),
                     # Publisher repository metadata.
-                    cfg.PropDefined("repo.collection_type", ["core",
-                        "supplemental"], default="core",
-                        value_map=_val_map_none),
-                    cfg.PropDefined("repo.description",
-                        value_map=_val_map_none),
+                    cfg.PropDefined(
+                        "repo.collection_type",
+                        ["core", "supplemental"],
+                        default="core",
+                        value_map=_val_map_none,
+                    ),
+                    cfg.PropDefined(
+                        "repo.description", value_map=_val_map_none
+                    ),
                     cfg.PropList("repo.legal_uris", value_map=_val_map_none),
-                    cfg.PropDefined("repo.name", default="package repository",
-                        value_map=_val_map_none),
+                    cfg.PropDefined(
+                        "repo.name",
+                        default="package repository",
+                        value_map=_val_map_none,
+                    ),
                     # Must be a string so "" can be stored.
-                    cfg.Property("repo.refresh_seconds",
+                    cfg.Property(
+                        "repo.refresh_seconds",
                         default=str(REPO_REFRESH_SECONDS_DEFAULT),
-                        value_map=_val_map_none),
+                        value_map=_val_map_none,
+                    ),
                     cfg.PropBool("repo.registered", value_map=_val_map_none),
-                    cfg.Property("repo.registration_uri",
-                        value_map=_val_map_none),
-                    cfg.PropList("repo.related_uris",
-                        value_map=_val_map_none),
+                    cfg.Property(
+                        "repo.registration_uri", value_map=_val_map_none
+                    ),
+                    cfg.PropList("repo.related_uris", value_map=_val_map_none),
                     cfg.Property("repo.sort_policy", value_map=_val_map_none),
-                ]),
-                cfg.PropertySectionTemplate("^linked_.*", properties=[
+                ],
+            ),
+            cfg.PropertySectionTemplate(
+                "^linked_.*",
+                properties=[
                     cfg.Property(li.PROP_NAME, value_map=_val_map_none),
                     cfg.Property(li.PROP_PATH, value_map=_val_map_none),
                     cfg.PropBool(li.PROP_RECURSE, default=True),
-                ]),
-            ],
-        }
+                ],
+            ),
+        ],
+    }
 
-        def __init__(self, cfgpathname, imgroot, overrides=misc.EmptyDict,
-            version=None, sysrepo_proxy=False):
-                """
-                'write_sysrepo_proxy' is a boolean, set to 'True' if this
-                ImageConfig should write the special publisher.SYSREPO_PROXY
-                token to the backing FileConfig in place of any actual proxies
-                used at runtime."""
-                self.__imgroot = imgroot
-                self.__publishers = {}
-                self.__validate = False
-                self.facets = facet.Facets()
-                self.mediators = {}
-                self.variants = variant.Variants()
-                self.linked_children = {}
-                self.write_sysrepo_proxy = sysrepo_proxy
-                cfg.FileConfig.__init__(self, cfgpathname,
-                    definitions=self.__defs, overrides=overrides,
-                    version=version)
+    def __init__(
+        self,
+        cfgpathname,
+        imgroot,
+        overrides=misc.EmptyDict,
+        version=None,
+        sysrepo_proxy=False,
+    ):
+        """
+        'write_sysrepo_proxy' is a boolean, set to 'True' if this
+        ImageConfig should write the special publisher.SYSREPO_PROXY
+        token to the backing FileConfig in place of any actual proxies
+        used at runtime."""
+        self.__imgroot = imgroot
+        self.__publishers = {}
+        self.__validate = False
+        self.facets = facet.Facets()
+        self.mediators = {}
+        self.variants = variant.Variants()
+        self.linked_children = {}
+        self.write_sysrepo_proxy = sysrepo_proxy
+        cfg.FileConfig.__init__(
+            self,
+            cfgpathname,
+            definitions=self.__defs,
+            overrides=overrides,
+            version=version,
+        )
 
-        def __str__(self):
-                return "{0}\n{1}".format(self.__publishers, self.__defs)
+    def __str__(self):
+        return "{0}\n{1}".format(self.__publishers, self.__defs)
 
-        def remove_publisher(self, prefix):
-                """External functional interface - use property interface"""
-                del self.publishers[prefix]
+    def remove_publisher(self, prefix):
+        """External functional interface - use property interface"""
+        del self.publishers[prefix]
 
-        def change_publisher_search_order(self, being_moved, staying_put,
-            after):
-                """Change the publisher search order by moving the publisher
-                'being_moved' relative to the publisher 'staying put.'  The
-                boolean 'after' determins whether 'being_moved' is placed before
-                or after 'staying_put'."""
+    def change_publisher_search_order(self, being_moved, staying_put, after):
+        """Change the publisher search order by moving the publisher
+        'being_moved' relative to the publisher 'staying put.'  The
+        boolean 'after' determins whether 'being_moved' is placed before
+        or after 'staying_put'."""
 
-                so = self.get_property("property", "publisher-search-order")
-                so.remove(being_moved)
+        so = self.get_property("property", "publisher-search-order")
+        so.remove(being_moved)
+        try:
+            ind = so.index(staying_put)
+        except ValueError:
+            raise apx.MoveRelativeToUnknown(staying_put)
+        if after:
+            so.insert(ind + 1, being_moved)
+        else:
+            so.insert(ind, being_moved)
+        self.set_property("property", "publisher-search-order", so)
+
+    def __get_publisher(self, prefix):
+        """Accessor method for publishers dictionary"""
+        return self.__publishers[prefix]
+
+    def __set_publisher(self, prefix, pubobj):
+        """Accessor method to keep search order correct on insert"""
+        pval = self.get_property("property", "publisher-search-order")
+        if prefix not in pval:
+            self.add_property_value(
+                "property", "publisher-search-order", prefix
+            )
+        self.__publishers[prefix] = pubobj
+
+    def __del_publisher(self, prefix):
+        """Accessor method for publishers"""
+        pval = self.get_property("property", "publisher-search-order")
+        if prefix in pval:
+            self.remove_property_value(
+                "property", "publisher-search-order", prefix
+            )
+        try:
+            self.remove_section("authority_{0}".format(prefix))
+        except cfg.UnknownSectionError:
+            pass
+        del self.__publishers[prefix]
+
+    def __publisher_iter(self):
+        return self.__publishers.__iter__()
+
+    def __publisher_iteritems(self):
+        """Support iteritems on publishers"""
+        return six.iteritems(self.__publishers)
+
+    def __publisher_keys(self):
+        """Support keys() on publishers"""
+        return list(self.__publishers.keys())
+
+    def __publisher_values(self):
+        """Support values() on publishers"""
+        return list(self.__publishers.values())
+
+    def get_policy(self, policy):
+        """Return a boolean value for the named policy.  Returns
+        the default value for the policy if the named policy is
+        not defined in the image configuration.
+        """
+        return str(self.get_policy_str(policy)).lower() in ("true", "yes")
+
+    def get_policy_str(self, policy):
+        """Return the string value for the named policy.  Returns
+        the default value for the policy if the named policy is
+        not defined in the image configuration.
+        """
+        assert policy in default_policies
+
+        prop = self.get_property("property", policy)
+
+        # If requested policy has a default mapping in
+        # default_policy_map, we substitute the correct value if it's
+        # still set to 'default'.
+        if policy in default_policy_map and prop == default_policies[policy]:
+            return default_policy_map[policy][default_policies[policy]]
+
+        return prop
+
+    def get_property(self, section, name):
+        """Returns the value of the property object matching the given
+        section and name.  Raises UnknownPropertyError if it does not
+        exist.
+        """
+        rval = cfg.FileConfig.get_property(self, section, name)
+        if name in default_policies and rval == DEF_TOKEN:
+            return default_policies[name]
+        if name in default_properties and rval == DEF_TOKEN:
+            return default_properties[name]
+        return rval
+
+    def reset(self, overrides=misc.EmptyDict):
+        """Discards current configuration state and returns the
+        configuration object to its initial state.
+
+        'overrides' is an optional dictionary of property values indexed
+        by section name and property name.  If provided, it will be used
+        to override any default values initially assigned during reset.
+        """
+
+        # Set __validate to be False so that the order the properties
+        # are set here doesn't matter.
+        self.__validate = False
+
+        # Allow parent class to populate property data first.
+        cfg.FileConfig.reset(self, overrides=overrides)
+
+        #
+        # Now transform property data as needed and populate image
+        # configuration data structures.
+        #
+
+        # Must load variants first, since in the case of zones, the
+        # variant can impact the processing of publishers.  (Notably,
+        # how ssl cert and key paths are interpreted.)
+        idx = self.get_index()
+        self.variants.update(idx.get("variant", {}))
+        # Variants and facets are encoded so they can contain
+        # '/' characters.
+        for k, v in six.iteritems(idx.get("variant", {})):
+            # convert variant name from unicode to a string
+            self.variants[str(unquote(k))] = v
+        for k, v in six.iteritems(idx.get("facet", {})):
+            # convert facet name from unicode to a string
+            self.facets[str(unquote(k))] = v
+        for k, v in six.iteritems(idx.get("inherited_facet", {})):
+            # convert facet name from unicode to a string
+            self.facets._set_inherited(str(unquote(k)), v)
+
+        # Ensure architecture and zone variants are defined.
+        if "variant.arch" not in self.variants:
+            self.variants["variant.arch"] = platform.processor()
+        if "variant.opensolaris.zone" not in self.variants:
+            self.variants["variant.opensolaris.zone"] = "global"
+        # Ensure imagetype variant is defined
+        if "variant.opensolaris.imagetype" not in self.variants:
+            self.variants["variant.opensolaris.imagetype"] = "full"
+
+        # load linked image child properties
+        for s, v in six.iteritems(idx):
+            if not re.match("linked_.*", s):
+                continue
+            linked_props = self.read_linked(s, v)
+            if linked_props:
+                lin = linked_props[li.PROP_NAME]
+                assert lin not in self.linked_children
+                self.linked_children[lin] = linked_props
+
+        # Merge disabled publisher file with configuration; the DA_FILE
+        # is used for compatibility with older clients.
+        dafile = os.path.join(os.path.dirname(self.target), DA_FILE)
+        if os.path.exists(dafile):
+            # Merge disabled publisher configuration data.
+            disabled_cfg = cfg.FileConfig(
+                dafile, definitions=self.__defs, version=self.version
+            )
+            for s in disabled_cfg.get_sections():
+                if s.name.startswith("authority_"):
+                    self.add_section(s)
+
+            # Get updated configuration index.
+            idx = self.get_index()
+
+        # Sort the index so that the prefixes are added to the list
+        # "publisher-search-order" in alphabetic order.
+        for s, v in collections.OrderedDict(sorted(six.iteritems(idx))).items():
+            if re.match("authority_.*", s):
+                k, a = self.read_publisher(s, v)
+                # this will call __set_publisher and add the
+                # prefix to "publisher-search-order".
+                self.publishers[k] = a
+
+        # Move any properties found in policy section (from older
+        # images) to the property section.
+        for k, v in six.iteritems(idx.get("policy", {})):
+            self.set_property("property", k, v)
+            self.remove_property("policy", k)
+
+        # Setup defaults for properties that have no value.
+        if not self.get_property("property", CA_PATH):
+            self.set_property("property", CA_PATH, default_properties[CA_PATH])
+
+        pso = self.get_property("property", "publisher-search-order")
+        # Ensure that all configured publishers are present in
+        # search order (add them in alpha order to the end).
+        # Also ensure that all publishers in search order that
+        # are not known are removed.
+        known_pubs = set(self.__publishers.keys())
+        sorted_pubs = set(pso)
+        new_pubs = known_pubs - sorted_pubs
+        old_pubs = sorted_pubs - known_pubs
+        for pub in old_pubs:
+            pso.remove(pub)
+        pso.extend(sorted(new_pubs))
+        self.set_property("property", "publisher-search-order", pso)
+
+        # Load mediator data.
+        for entry, value in six.iteritems(idx.get("mediators", {})):
+            mname, mtype = entry.rsplit(".", 1)
+            # convert mediator name+type from unicode to a string
+            mname = str(mname)
+            mtype = str(mtype)
+            self.mediators.setdefault(mname, {})[mtype] = value
+
+        # Now re-enable validation and validate the properties.
+        self.__validate = True
+        self.__validate_properties()
+
+        # Finally, attempt to write configuration again to ensure
+        # changes are reflected on-disk -- but only if the version
+        # matches most current.
+        if self.version == CURRENT_VERSION:
+            self.write(ignore_unprivileged=True)
+
+    def set_property(self, section, name, value):
+        """Sets the value of the property object matching the given
+        section and name.  If the section or property does not already
+        exist, it will be added.  Raises InvalidPropertyValueError if
+        the value is not valid for the given property."""
+
+        cfg.FileConfig.set_property(self, section, name, value)
+
+        if self.__validate:
+            self.__validate_properties()
+
+    def set_properties(self, properties):
+        """Sets the values of the property objects matching those found
+        in the provided dictionary.  If any section or property does not
+        already exist, it will be added.  An InvalidPropertyValueError
+        will be raised if the value is not valid for the given
+        properties.
+
+        'properties' should be a dictionary of dictionaries indexed by
+        section and then by property name.  As an example:
+
+            {
+                'section': {
+                    'property': value
+                }
+            }
+        """
+
+        # Validation must be delayed until after all properties are set,
+        # in case some properties are interdependent for validation.
+        self.__validate = False
+        try:
+            cfg.FileConfig.set_properties(self, properties)
+        finally:
+            # Ensure validation is re-enabled even if an exception
+            # is raised.
+            self.__validate = True
+
+        self.__validate_properties()
+
+    def write(self, ignore_unprivileged=False):
+        """Write the image configuration."""
+
+        # The variant, facet, and mediator sections must be removed so
+        # the private copies can be transferred to the configuration
+        # object.
+        try:
+            self.remove_section("variant")
+        except cfg.UnknownSectionError:
+            pass
+        for f in self.variants:
+            self.set_property("variant", quote(f, ""), self.variants[f])
+
+        try:
+            self.remove_section("facet")
+        except cfg.UnknownSectionError:
+            pass
+        # save local facets
+        for f in self.facets.local:
+            self.set_property("facet", quote(f, ""), self.facets.local[f])
+
+        try:
+            self.remove_section("inherited_facet")
+        except cfg.UnknownSectionError:
+            pass
+        # save inherited facets
+        for f in self.facets.inherited:
+            self.set_property(
+                "inherited_facet", quote(f, ""), self.facets.inherited[f]
+            )
+
+        try:
+            self.remove_section("mediators")
+        except cfg.UnknownSectionError:
+            pass
+        for mname, mvalues in six.iteritems(self.mediators):
+            for mtype, mvalue in six.iteritems(mvalues):
+                # name.implementation[-(source|version)]
+                # name.version[-source]
+                pname = mname + "." + mtype
+                self.set_property("mediators", pname, mvalue)
+
+        # remove all linked image child configuration
+        idx = self.get_index()
+        for s, v in six.iteritems(idx):
+            if not re.match("linked_.*", s):
+                continue
+            self.remove_section(s)
+
+        # add sections for any known linked children
+        for lin in sorted(self.linked_children):
+            linked_props = self.linked_children[lin]
+            s = "linked_{0}".format(str(lin))
+            for k in [li.PROP_NAME, li.PROP_PATH, li.PROP_RECURSE]:
+                self.set_property(s, k, str(linked_props[k]))
+
+        # Transfer current publisher information to configuration.
+        for prefix in self.__publishers:
+            pub = self.__publishers[prefix]
+            section = "authority_{0}".format(pub.prefix)
+
+            for prop in (
+                "alias",
+                "prefix",
+                "approved_ca_certs",
+                "revoked_ca_certs",
+                "disabled",
+                "sticky",
+            ):
+                self.set_property(section, prop, getattr(pub, prop))
+
+            # Force removal of origin property when writing.  It
+            # should only exist when configuration is loaded if
+            # the client is using an older image.
+            try:
+                self.remove_property(section, "origin")
+            except cfg.UnknownPropertyError:
+                # Already gone.
+                pass
+
+            # Store SSL Cert and Key data.
+            repo = pub.repository
+            p = ""
+            for o in repo.origins:
+                if o.ssl_key:
+                    p = str(o.ssl_key)
+                    break
+            self.set_property(section, "ssl_key", p)
+
+            p = ""
+            for o in repo.origins:
+                if o.ssl_cert:
+                    p = str(o.ssl_cert)
+                    break
+            self.set_property(section, "ssl_cert", p)
+
+            # Store per-origin/mirror information.  For now, this
+            # information is limited to the proxy used for each URI.
+            for repouri_list, prop_name in [
+                (repo.origins, "origin_info"),
+                (repo.mirrors, "mirror_info"),
+            ]:
+                plist = []
+                for r in repouri_list:
+                    # Convert boolean value into string for
+                    # json.
+                    r_disabled = "false"
+                    if r.disabled:
+                        r_disabled = "true"
+                    if not r.proxies:
+                        plist.append(
+                            {"uri": r.uri, "proxy": "", "disabled": r_disabled}
+                        )
+                        continue
+                    for p in r.proxies:
+                        # sys_cfg proxy values should
+                        # always be '<sysrepo>' so that
+                        # if the system-repository port
+                        # is changed, that gets picked
+                        # up in the image.  See
+                        # read_publisher(..) and
+                        # BlendedConfig.__merge_publishers
+                        if self.write_sysrepo_proxy:
+                            puri = publisher.SYSREPO_PROXY
+                        elif not p:
+                            # we do not want None
+                            # stringified to 'None'
+                            puri = ""
+                        else:
+                            puri = p.uri
+                        plist.append(
+                            {
+                                "uri": r.uri,
+                                "proxy": puri,
+                                "disabled": r_disabled,
+                            }
+                        )
+
+                self.set_property(section, prop_name, str(plist))
+
+            # Store publisher UUID.
+            self.set_property(section, "uuid", pub.client_uuid)
+            self.set_property(section, "last_uuid", pub.client_uuid_time)
+
+            # Write repository origins and mirrors, ensuring the
+            # list contains unique values.  We must check for
+            # uniqueness manually, rather than using a set()
+            # to properly preserve the order in which origins and
+            # mirrors are set.
+            for prop in ("origins", "mirrors"):
+                pval = [str(v) for v in getattr(repo, prop)]
+                values = set()
+                unique_pval = []
+                for item in pval:
+                    if item not in values:
+                        values.add(item)
+                        unique_pval.append(item)
+
+                self.set_property(section, prop, unique_pval)
+
+            for prop in (
+                "collection_type",
+                "description",
+                "legal_uris",
+                "name",
+                "refresh_seconds",
+                "registered",
+                "registration_uri",
+                "related_uris",
+                "sort_policy",
+            ):
+                pval = getattr(repo, prop)
+                if isinstance(pval, list):
+                    # Stringify lists of objects; this
+                    # assumes the underlying objects
+                    # can be stringified properly.
+                    pval = [str(v) for v in pval]
+
+                cfg_key = "repo.{0}".format(prop)
+                if prop == "registration_uri":
+                    # Must be stringified.
+                    pval = str(pval)
+                self.set_property(section, cfg_key, pval)
+
+            secobj = self.get_section(section)
+            for pname in secobj.get_index():
+                if (
+                    pname.startswith("property.")
+                    and pname[len("property.") :] not in pub.properties
+                ):
+                    # Ensure properties not currently set
+                    # for the publisher are removed from
+                    # the existing configuration.
+                    secobj.remove_property(pname)
+
+            for key, val in pub.properties.iteritems():
+                if val == DEF_TOKEN:
+                    continue
+                self.set_property(section, "property.{0}".format(key), val)
+
+        # Write configuration only if configuration directory exists;
+        # this is to prevent failure during the early stages of image
+        # creation.
+        if os.path.exists(os.path.dirname(self.target)):
+            # Discard old disabled publisher configuration if it
+            # exists.
+            da_path = os.path.join(os.path.dirname(self.target), DA_FILE)
+            try:
+                portable.remove(da_path)
+            except EnvironmentError as e:
+                # Don't care if the file is already gone.
+                if e.errno != errno.ENOENT:
+                    exc = apx._convert_error(e)
+                    if (
+                        not isinstance(exc, apx.PermissionsException)
+                        or not ignore_unprivileged
+                    ):
+                        raise exc
+
+            # Ensure properties with the special value of DEF_TOKEN
+            # are never written so that if the default value is
+            # changed later, clients will automatically get that
+            # value instead of the previous one.
+            default = []
+            for name in list(default_properties.keys()) + list(
+                default_policies.keys()
+            ):
+                # The actual class method must be called here as
+                # ImageConfig's set_property can return the
+                # value that maps to 'DEFAULT' instead.
+                secobj = self.get_section("property")
                 try:
-                        ind = so.index(staying_put)
-                except ValueError:
-                        raise apx.MoveRelativeToUnknown(staying_put)
-                if after:
-                        so.insert(ind + 1, being_moved)
+                    propobj = secobj.get_property(name)
+                except cfg.UnknownPropertyError:
+                    # Property was removed, so skip it.
+                    continue
+
+                if propobj.value == DEF_TOKEN:
+                    default.append(name)
+                    secobj.remove_property(name)
+
+            try:
+                cfg.FileConfig.write(self)
+            except apx.PermissionsException:
+                if not ignore_unprivileged:
+                    raise
+            finally:
+                # Merge default props back into configuration.
+                for name in default:
+                    self.set_property("property", name, DEF_TOKEN)
+
+    def read_linked(self, s, sidx):
+        """Read linked image properties associated with a child image.
+        Zone linked images do not store their properties here in the
+        image config.
+
+        If we encounter an error while parsing property data, then
+        instead of throwing an error/exception which the user would
+        have no way of fixing, we simply return and ignore the child.
+        The child data will be removed from the config file the next
+        time it gets re-written, and if the user want the child back
+        they'll have to re-attach it."""
+
+        linked_props = dict()
+
+        # Check for known properties
+        for k in [li.PROP_NAME, li.PROP_PATH, li.PROP_RECURSE]:
+            if k not in sidx:
+                # we're missing a property
+                return None
+            linked_props[k] = sidx[k]
+
+        # all children saved in the config file are pushed based
+        linked_props[li.PROP_MODEL] = li.PV_MODEL_PUSH
+
+        # make sure the name is valid
+        try:
+            lin = li.LinkedImageName(linked_props[li.PROP_NAME])
+        except apx.MalformedLinkedImageName:
+            # invalid child image name
+            return None
+        linked_props[li.PROP_NAME] = lin
+
+        # check if this image is already defined
+        if lin in self.linked_children:
+            # duplicate child linked image data, first copy wins
+            return None
+
+        return linked_props
+
+    def read_publisher(self, sname, sec_idx):
+        # sname is the section of the config file.
+        # publisher block has alias, prefix, origin, and mirrors
+
+        # Add 'origin' to list of origins if it doesn't exist already.
+        origins = sec_idx.get("origins", [])
+        origin = sec_idx.get("origin", None)
+        if origin and origin not in origins:
+            origins.append(origin)
+
+        mirrors = sec_idx.get("mirrors", [])
+
+        # [origin|mirror]_info dictionaries map URIs to a list of dicts
+        # containing property values for that URI.  (we allow a single
+        # origin to have several dictionaries with different properties)
+        # As we go, we crosscheck against the lists of known
+        # origins/mirrors.
+        #
+        # For now, the only property tracked on a per-origin/mirror
+        # basis is which proxy (if any) is used to access it. In the
+        # future, we may wish to store additional information per-URI,
+        # eg.
+        # {"proxy": "<uri>", "ssl_key": "<key>", "ssl_cert": "<cert>"}
+        #
+        # Storing multiple dictionaries, means we could store several
+        # proxies or key/value pairs per URI if necessary.  This list
+        # of dictionaries is intentionally flat, so that the underlying
+        # configuration file is easily human-readable.
+        #
+        origin_info = {}
+        mirror_info = {}
+        for repouri_info, prop, orig in [
+            (origin_info, "origin_info", origins),
+            (mirror_info, "mirror_info", mirrors),
+        ]:
+            # get the list of dictionaries from the cfg
+            plist = sec_idx.get(prop, [])
+            if not plist:
+                continue
+            for uri_info in plist:
+                uri = uri_info["uri"]
+                proxy = uri_info.get("proxy")
+                disabled = uri_info.get("disabled", False)
+                # Convert a "" proxy value to None
+                if proxy == "":
+                    proxy = None
+
+                # if the uri isn't in either 'origins' or
+                # 'mirrors', then we've likely deleted it
+                # using an older pkg(7) client format.  We
+                # must ignore this entry.
+                if uri not in orig:
+                    continue
+
+                repouri_info.setdefault(uri, []).append(
+                    {"uri": uri, "proxy": proxy, "disabled": disabled}
+                )
+
+        props = {}
+        for k, v in six.iteritems(sec_idx):
+            if not k.startswith("property."):
+                continue
+            prop_name = k[len("property.") :]
+            if v == DEF_TOKEN:
+                # Discard publisher properties with the
+                # DEF_TOKEN value; allow the publisher class to
+                # handle these.
+                self.remove_property(sname, k)
+                continue
+            props[prop_name] = v
+
+        # Load repository data.
+        repo_data = {}
+        for key, val in six.iteritems(sec_idx):
+            if key.startswith("repo."):
+                pname = key[len("repo.") :]
+                repo_data[pname] = val
+
+        # Normalize/sanitize repository data.
+        for attr in ("collection_type", "sort_policy"):
+            if not repo_data[attr]:
+                # Assume default value for attr.
+                del repo_data[attr]
+
+        if repo_data["refresh_seconds"] == "":
+            repo_data["refresh_seconds"] = str(REPO_REFRESH_SECONDS_DEFAULT)
+
+        prefix = sec_idx["prefix"]
+        ssl_key = sec_idx["ssl_key"]
+        ssl_cert = sec_idx["ssl_cert"]
+
+        r = publisher.Repository(**repo_data)
+
+        # Set per-origin/mirror URI properties
+        for uri_list, info_map, repo_add_func in [
+            (origins, origin_info, r.add_origin),
+            (mirrors, mirror_info, r.add_mirror),
+        ]:
+            for uri in uri_list:
+                # If we didn't gather property information for
+                # this origin/mirror, assume a single
+                # origin/mirror with no proxy.
+                plist = info_map.get(uri, [{}])
+                proxies = []
+                disabled = False
+                for uri_info in plist:
+                    proxy = uri_info.get("proxy")
+                    if uri_info.get("disabled") == "true":
+                        disabled = True
+                    if proxy:
+                        if proxy == publisher.SYSREPO_PROXY:
+                            p = publisher.ProxyURI(None, system=True)
+                        else:
+                            p = publisher.ProxyURI(proxy)
+                        proxies.append(p)
+
+                if not any(
+                    uri.startswith(scheme + ":")
+                    for scheme in publisher.SSL_SCHEMES
+                ):
+                    repouri = publisher.RepositoryURI(
+                        uri, proxies=proxies, disabled=disabled
+                    )
                 else:
-                        so.insert(ind, being_moved)
-                self.set_property("property", "publisher-search-order", so)
-
-        def __get_publisher(self, prefix):
-                """Accessor method for publishers dictionary"""
-                return self.__publishers[prefix]
-
-        def __set_publisher(self, prefix, pubobj):
-                """Accessor method to keep search order correct on insert"""
-                pval = self.get_property("property", "publisher-search-order")
-                if prefix not in pval:
-                        self.add_property_value("property",
-                            "publisher-search-order", prefix)
-                self.__publishers[prefix] = pubobj
-
-        def __del_publisher(self, prefix):
-                """Accessor method for publishers"""
-                pval = self.get_property("property", "publisher-search-order")
-                if prefix in pval:
-                        self.remove_property_value("property",
-                            "publisher-search-order", prefix)
-                try:
-                        self.remove_section("authority_{0}".format(prefix))
-                except cfg.UnknownSectionError:
-                        pass
-                del self.__publishers[prefix]
-
-        def __publisher_iter(self):
-                return self.__publishers.__iter__()
-
-        def __publisher_iteritems(self):
-                """Support iteritems on publishers"""
-                return six.iteritems(self.__publishers)
-
-        def __publisher_keys(self):
-                """Support keys() on publishers"""
-                return list(self.__publishers.keys())
-
-        def __publisher_values(self):
-                """Support values() on publishers"""
-                return list(self.__publishers.values())
-
-        def get_policy(self, policy):
-                """Return a boolean value for the named policy.  Returns
-                the default value for the policy if the named policy is
-                not defined in the image configuration.
-                """
-                return str(self.get_policy_str(policy)).lower() in ("true",
-                    "yes")
-
-        def get_policy_str(self, policy):
-                """Return the string value for the named policy.  Returns
-                the default value for the policy if the named policy is
-                not defined in the image configuration.
-                """
-                assert policy in default_policies
-
-                prop = self.get_property("property", policy)
-
-                # If requested policy has a default mapping in
-                # default_policy_map, we substitute the correct value if it's
-                # still set to 'default'.
-                if policy in default_policy_map and \
-                    prop == default_policies[policy]:
-                        return default_policy_map[policy] \
-                            [default_policies[policy]]
-
-                return prop
-
-        def get_property(self, section, name):
-                """Returns the value of the property object matching the given
-                section and name.  Raises UnknownPropertyError if it does not
-                exist.
-                """
-                rval = cfg.FileConfig.get_property(self, section, name)
-                if name in default_policies and rval == DEF_TOKEN:
-                        return default_policies[name]
-                if name in default_properties and rval == DEF_TOKEN:
-                        return default_properties[name]
-                return rval
-
-        def reset(self, overrides=misc.EmptyDict):
-                """Discards current configuration state and returns the
-                configuration object to its initial state.
-
-                'overrides' is an optional dictionary of property values indexed
-                by section name and property name.  If provided, it will be used
-                to override any default values initially assigned during reset.
-                """
-
-                # Set __validate to be False so that the order the properties
-                # are set here doesn't matter.
-                self.__validate = False
-
-                # Allow parent class to populate property data first.
-                cfg.FileConfig.reset(self, overrides=overrides)
-
-                #
-                # Now transform property data as needed and populate image
-                # configuration data structures.
-                #
-
-                # Must load variants first, since in the case of zones, the
-                # variant can impact the processing of publishers.  (Notably,
-                # how ssl cert and key paths are interpreted.)
-                idx = self.get_index()
-                self.variants.update(idx.get("variant", {}))
-                # Variants and facets are encoded so they can contain
-                # '/' characters.
-                for k, v in six.iteritems(idx.get("variant", {})):
-                        # convert variant name from unicode to a string
-                        self.variants[str(unquote(k))] = v
-                for k, v in six.iteritems(idx.get("facet", {})):
-                        # convert facet name from unicode to a string
-                        self.facets[str(unquote(k))] = v
-                for k, v in six.iteritems(idx.get("inherited_facet", {})):
-                        # convert facet name from unicode to a string
-                        self.facets._set_inherited(str(unquote(k)), v)
-
-                # Ensure architecture and zone variants are defined.
-                if "variant.arch" not in self.variants:
-                        self.variants["variant.arch"] = platform.processor()
-                if "variant.opensolaris.zone" not in self.variants:
-                        self.variants["variant.opensolaris.zone"] = "global"
-                # Ensure imagetype variant is defined
-                if "variant.opensolaris.imagetype" not in self.variants:
-                        self.variants["variant.opensolaris.imagetype"] = "full"
-
-                # load linked image child properties
-                for s, v in six.iteritems(idx):
-                        if not re.match("linked_.*", s):
-                                continue
-                        linked_props = self.read_linked(s, v)
-                        if linked_props:
-                                lin = linked_props[li.PROP_NAME]
-                                assert lin not in self.linked_children
-                                self.linked_children[lin] = linked_props
-
-                # Merge disabled publisher file with configuration; the DA_FILE
-                # is used for compatibility with older clients.
-                dafile = os.path.join(os.path.dirname(self.target), DA_FILE)
-                if os.path.exists(dafile):
-                        # Merge disabled publisher configuration data.
-                        disabled_cfg = cfg.FileConfig(dafile,
-                            definitions=self.__defs, version=self.version)
-                        for s in disabled_cfg.get_sections():
-                                if s.name.startswith("authority_"):
-                                        self.add_section(s)
-
-                        # Get updated configuration index.
-                        idx = self.get_index()
-
-                # Sort the index so that the prefixes are added to the list
-                # "publisher-search-order" in alphabetic order.
-                for s, v in collections.OrderedDict(
-                    sorted(six.iteritems(idx))).items():
-                        if re.match("authority_.*", s):
-                                k, a = self.read_publisher(s, v)
-                                # this will call __set_publisher and add the
-                                # prefix to "publisher-search-order".
-                                self.publishers[k] = a
-
-                # Move any properties found in policy section (from older
-                # images) to the property section.
-                for k, v in six.iteritems(idx.get("policy", {})):
-                        self.set_property("property", k, v)
-                        self.remove_property("policy", k)
-
-                # Setup defaults for properties that have no value.
-                if not self.get_property("property", CA_PATH):
-                        self.set_property("property", CA_PATH,
-                            default_properties[CA_PATH])
-
-                pso = self.get_property("property", "publisher-search-order")
-                # Ensure that all configured publishers are present in
-                # search order (add them in alpha order to the end).
-                # Also ensure that all publishers in search order that
-                # are not known are removed.
-                known_pubs = set(self.__publishers.keys())
-                sorted_pubs = set(pso)
-                new_pubs = known_pubs - sorted_pubs
-                old_pubs = sorted_pubs - known_pubs
-                for pub in old_pubs:
-                        pso.remove(pub)
-                pso.extend(sorted(new_pubs))
-                self.set_property("property", "publisher-search-order", pso)
-
-                # Load mediator data.
-                for entry, value in six.iteritems(idx.get("mediators", {})):
-                        mname, mtype = entry.rsplit(".", 1)
-                        # convert mediator name+type from unicode to a string
-                        mname = str(mname)
-                        mtype = str(mtype)
-                        self.mediators.setdefault(mname, {})[mtype] = value
-
-                # Now re-enable validation and validate the properties.
-                self.__validate = True
-                self.__validate_properties()
-
-                # Finally, attempt to write configuration again to ensure
-                # changes are reflected on-disk -- but only if the version
-                # matches most current.
-                if self.version == CURRENT_VERSION:
-                        self.write(ignore_unprivileged=True)
-
-        def set_property(self, section, name, value):
-                """Sets the value of the property object matching the given
-                section and name.  If the section or property does not already
-                exist, it will be added.  Raises InvalidPropertyValueError if
-                the value is not valid for the given property."""
-
-                cfg.FileConfig.set_property(self, section, name, value)
-
-                if self.__validate:
-                        self.__validate_properties()
-
-        def set_properties(self, properties):
-                """Sets the values of the property objects matching those found
-                in the provided dictionary.  If any section or property does not
-                already exist, it will be added.  An InvalidPropertyValueError
-                will be raised if the value is not valid for the given
-                properties.
-
-                'properties' should be a dictionary of dictionaries indexed by
-                section and then by property name.  As an example:
-
-                    {
-                        'section': {
-                            'property': value
-                        }
-                    }
-                """
-
-                # Validation must be delayed until after all properties are set,
-                # in case some properties are interdependent for validation.
-                self.__validate = False
-                try:
-                        cfg.FileConfig.set_properties(self, properties)
-                finally:
-                        # Ensure validation is re-enabled even if an exception
-                        # is raised.
-                        self.__validate = True
-
-                self.__validate_properties()
-
-        def write(self, ignore_unprivileged=False):
-                """Write the image configuration."""
-
-                # The variant, facet, and mediator sections must be removed so
-                # the private copies can be transferred to the configuration
-                # object.
-                try:
-                        self.remove_section("variant")
-                except cfg.UnknownSectionError:
-                        pass
-                for f in self.variants:
-                        self.set_property("variant",
-                            quote(f, ""), self.variants[f])
-
-                try:
-                        self.remove_section("facet")
-                except cfg.UnknownSectionError:
-                        pass
-                # save local facets
-                for f in self.facets.local:
-                        self.set_property("facet",
-                            quote(f, ""), self.facets.local[f])
-
-                try:
-                        self.remove_section("inherited_facet")
-                except cfg.UnknownSectionError:
-                        pass
-                # save inherited facets
-                for f in self.facets.inherited:
-                        self.set_property("inherited_facet",
-                            quote(f, ""), self.facets.inherited[f])
-
-                try:
-                        self.remove_section("mediators")
-                except cfg.UnknownSectionError:
-                        pass
-                for mname, mvalues in six.iteritems(self.mediators):
-                        for mtype, mvalue in six.iteritems(mvalues):
-                                # name.implementation[-(source|version)]
-                                # name.version[-source]
-                                pname = mname + "." + mtype
-                                self.set_property("mediators", pname, mvalue)
-
-                # remove all linked image child configuration
-                idx = self.get_index()
-                for s, v in six.iteritems(idx):
-                        if not re.match("linked_.*", s):
-                                continue
-                        self.remove_section(s)
-
-                # add sections for any known linked children
-                for lin in sorted(self.linked_children):
-                        linked_props = self.linked_children[lin]
-                        s = "linked_{0}".format(str(lin))
-                        for k in [li.PROP_NAME, li.PROP_PATH, li.PROP_RECURSE]:
-                                self.set_property(s, k, str(linked_props[k]))
-
-
-                # Transfer current publisher information to configuration.
-                for prefix in self.__publishers:
-                        pub = self.__publishers[prefix]
-                        section = "authority_{0}".format(pub.prefix)
-
-                        for prop in ("alias", "prefix", "approved_ca_certs",
-                            "revoked_ca_certs", "disabled", "sticky"):
-                                self.set_property(section, prop,
-                                    getattr(pub, prop))
-
-                        # Force removal of origin property when writing.  It
-                        # should only exist when configuration is loaded if
-                        # the client is using an older image.
-                        try:
-                                self.remove_property(section, "origin")
-                        except cfg.UnknownPropertyError:
-                                # Already gone.
-                                pass
-
-                        # Store SSL Cert and Key data.
-                        repo = pub.repository
-                        p = ""
-                        for o in repo.origins:
-                                if o.ssl_key:
-                                        p = str(o.ssl_key)
-                                        break
-                        self.set_property(section, "ssl_key", p)
-
-                        p = ""
-                        for o in repo.origins:
-                                if o.ssl_cert:
-                                        p = str(o.ssl_cert)
-                                        break
-                        self.set_property(section, "ssl_cert", p)
-
-                        # Store per-origin/mirror information.  For now, this
-                        # information is limited to the proxy used for each URI.
-                        for repouri_list, prop_name in [
-                            (repo.origins, "origin_info"),
-                            (repo.mirrors, "mirror_info")]:
-                                plist = []
-                                for r in repouri_list:
-                                        # Convert boolean value into string for
-                                        # json.
-                                        r_disabled = "false"
-                                        if r.disabled:
-                                                r_disabled = "true"
-                                        if not r.proxies:
-                                                plist.append(
-                                                        {"uri": r.uri,
-                                                        "proxy": "",
-                                                        "disabled": r_disabled})
-                                                continue
-                                        for p in r.proxies:
-                                                # sys_cfg proxy values should
-                                                # always be '<sysrepo>' so that
-                                                # if the system-repository port
-                                                # is changed, that gets picked
-                                                # up in the image.  See
-                                                # read_publisher(..) and
-                                                # BlendedConfig.__merge_publishers
-                                                if self.write_sysrepo_proxy:
-                                                        puri = publisher.SYSREPO_PROXY
-                                                elif not p:
-                                                        # we do not want None
-                                                        # stringified to 'None'
-                                                        puri = ""
-                                                else:
-                                                        puri = p.uri
-                                                plist.append(
-                                                    {"uri": r.uri,
-                                                    "proxy": puri,
-                                                    "disabled": r_disabled})
-
-                                self.set_property(section, prop_name,
-                                    str(plist))
-
-                        # Store publisher UUID.
-                        self.set_property(section, "uuid", pub.client_uuid)
-                        self.set_property(section, "last_uuid",
-                            pub.client_uuid_time)
-
-                        # Write repository origins and mirrors, ensuring the
-                        # list contains unique values.  We must check for
-                        # uniqueness manually, rather than using a set()
-                        # to properly preserve the order in which origins and
-                        # mirrors are set.
-                        for prop in ("origins", "mirrors"):
-                                pval = [str(v) for v in
-                                    getattr(repo, prop)]
-                                values = set()
-                                unique_pval = []
-                                for item in pval:
-                                        if item not in values:
-                                                values.add(item)
-                                                unique_pval.append(item)
-
-                                self.set_property(section, prop, unique_pval)
-
-                        for prop in ("collection_type",
-                            "description", "legal_uris", "name",
-                            "refresh_seconds", "registered", "registration_uri",
-                            "related_uris", "sort_policy"):
-                                pval = getattr(repo, prop)
-                                if isinstance(pval, list):
-                                        # Stringify lists of objects; this
-                                        # assumes the underlying objects
-                                        # can be stringified properly.
-                                        pval = [str(v) for v in pval]
-
-                                cfg_key = "repo.{0}".format(prop)
-                                if prop == "registration_uri":
-                                        # Must be stringified.
-                                        pval = str(pval)
-                                self.set_property(section, cfg_key, pval)
-
-                        secobj = self.get_section(section)
-                        for pname in secobj.get_index():
-                                if pname.startswith("property.") and \
-                                    pname[len("property."):] not in pub.properties:
-                                        # Ensure properties not currently set
-                                        # for the publisher are removed from
-                                        # the existing configuration.
-                                        secobj.remove_property(pname)
-
-                        for key, val in pub.properties.iteritems():
-                                if val == DEF_TOKEN:
-                                        continue
-                                self.set_property(section,
-                                    "property.{0}".format(key), val)
-
-                # Write configuration only if configuration directory exists;
-                # this is to prevent failure during the early stages of image
-                # creation.
-                if os.path.exists(os.path.dirname(self.target)):
-                        # Discard old disabled publisher configuration if it
-                        # exists.
-                        da_path = os.path.join(os.path.dirname(self.target),
-                            DA_FILE)
-                        try:
-                                portable.remove(da_path)
-                        except EnvironmentError as e:
-                                # Don't care if the file is already gone.
-                                if e.errno != errno.ENOENT:
-                                        exc = apx._convert_error(e)
-                                        if not isinstance(exc, apx.PermissionsException) or \
-                                            not ignore_unprivileged:
-                                                raise exc
-
-                        # Ensure properties with the special value of DEF_TOKEN
-                        # are never written so that if the default value is
-                        # changed later, clients will automatically get that
-                        # value instead of the previous one.
-                        default = []
-                        for name in (list(default_properties.keys()) +
-                            list(default_policies.keys())):
-                                # The actual class method must be called here as
-                                # ImageConfig's set_property can return the
-                                # value that maps to 'DEFAULT' instead.
-                                secobj = self.get_section("property")
-                                try:
-                                        propobj = secobj.get_property(name)
-                                except cfg.UnknownPropertyError:
-                                        # Property was removed, so skip it.
-                                        continue
-
-                                if propobj.value == DEF_TOKEN:
-                                        default.append(name)
-                                        secobj.remove_property(name)
-
-                        try:
-                                cfg.FileConfig.write(self)
-                        except apx.PermissionsException:
-                                if not ignore_unprivileged:
-                                        raise
-                        finally:
-                                # Merge default props back into configuration.
-                                for name in default:
-                                        self.set_property("property", name,
-                                            DEF_TOKEN)
-
-        def read_linked(self, s, sidx):
-                """Read linked image properties associated with a child image.
-                Zone linked images do not store their properties here in the
-                image config.
-
-                If we encounter an error while parsing property data, then
-                instead of throwing an error/exception which the user would
-                have no way of fixing, we simply return and ignore the child.
-                The child data will be removed from the config file the next
-                time it gets re-written, and if the user want the child back
-                they'll have to re-attach it."""
-
-                linked_props = dict()
-
-                # Check for known properties
-                for k in [li.PROP_NAME, li.PROP_PATH, li.PROP_RECURSE]:
-                        if k not in sidx:
-                                # we're missing a property
-                                return None
-                        linked_props[k] = sidx[k]
-
-                # all children saved in the config file are pushed based
-                linked_props[li.PROP_MODEL] = li.PV_MODEL_PUSH
-
-                # make sure the name is valid
-                try:
-                        lin = li.LinkedImageName(linked_props[li.PROP_NAME])
-                except apx.MalformedLinkedImageName:
-                        # invalid child image name
-                        return None
-                linked_props[li.PROP_NAME] = lin
-
-                # check if this image is already defined
-                if lin in self.linked_children:
-                        # duplicate child linked image data, first copy wins
-                        return None
-
-                return linked_props
-
-        def read_publisher(self, sname, sec_idx):
-                # sname is the section of the config file.
-                # publisher block has alias, prefix, origin, and mirrors
-
-                # Add 'origin' to list of origins if it doesn't exist already.
-                origins = sec_idx.get("origins", [])
-                origin = sec_idx.get("origin", None)
-                if origin and origin not in origins:
-                        origins.append(origin)
-
-                mirrors = sec_idx.get("mirrors", [])
-
-                # [origin|mirror]_info dictionaries map URIs to a list of dicts
-                # containing property values for that URI.  (we allow a single
-                # origin to have several dictionaries with different properties)
-                # As we go, we crosscheck against the lists of known
-                # origins/mirrors.
-                #
-                # For now, the only property tracked on a per-origin/mirror
-                # basis is which proxy (if any) is used to access it. In the
-                # future, we may wish to store additional information per-URI,
-                # eg.
-                # {"proxy": "<uri>", "ssl_key": "<key>", "ssl_cert": "<cert>"}
-                #
-                # Storing multiple dictionaries, means we could store several
-                # proxies or key/value pairs per URI if necessary.  This list
-                # of dictionaries is intentionally flat, so that the underlying
-                # configuration file is easily human-readable.
-                #
-                origin_info = {}
-                mirror_info = {}
-                for repouri_info, prop, orig in [
-                    (origin_info, "origin_info", origins),
-                    (mirror_info, "mirror_info", mirrors)]:
-                        # get the list of dictionaries from the cfg
-                        plist = sec_idx.get(prop, [])
-                        if not plist:
-                                continue
-                        for uri_info in plist:
-                                uri = uri_info["uri"]
-                                proxy = uri_info.get("proxy")
-                                disabled = uri_info.get("disabled", False)
-                                # Convert a "" proxy value to None
-                                if proxy == "":
-                                        proxy = None
-
-                                # if the uri isn't in either 'origins' or
-                                # 'mirrors', then we've likely deleted it
-                                # using an older pkg(7) client format.  We
-                                # must ignore this entry.
-                                if uri not in orig:
-                                        continue
-
-                                repouri_info.setdefault(uri, []).append(
-                                    {"uri": uri, "proxy": proxy,
-                                    "disabled": disabled})
-
-                props = {}
-                for k, v in six.iteritems(sec_idx):
-                        if not k.startswith("property."):
-                                continue
-                        prop_name = k[len("property."):]
-                        if v == DEF_TOKEN:
-                                # Discard publisher properties with the
-                                # DEF_TOKEN value; allow the publisher class to
-                                # handle these.
-                                self.remove_property(sname, k)
-                                continue
-                        props[prop_name] = v
-
-                # Load repository data.
-                repo_data = {}
-                for key, val in six.iteritems(sec_idx):
-                        if key.startswith("repo."):
-                                pname = key[len("repo."):]
-                                repo_data[pname] = val
-
-                # Normalize/sanitize repository data.
-                for attr in ("collection_type", "sort_policy"):
-                        if not repo_data[attr]:
-                                # Assume default value for attr.
-                                del repo_data[attr]
-
-                if repo_data["refresh_seconds"] == "":
-                        repo_data["refresh_seconds"] = \
-                            str(REPO_REFRESH_SECONDS_DEFAULT)
-
-                prefix = sec_idx["prefix"]
-                ssl_key = sec_idx["ssl_key"]
-                ssl_cert = sec_idx["ssl_cert"]
-
-                r = publisher.Repository(**repo_data)
-
-                # Set per-origin/mirror URI properties
-                for (uri_list, info_map, repo_add_func) in [
-                    (origins, origin_info, r.add_origin),
-                    (mirrors, mirror_info, r.add_mirror)]:
-                        for uri in uri_list:
-                                # If we didn't gather property information for
-                                # this origin/mirror, assume a single
-                                # origin/mirror with no proxy.
-                                plist = info_map.get(uri, [{}])
-                                proxies = []
-                                disabled = False
-                                for uri_info in plist:
-                                        proxy = uri_info.get("proxy")
-                                        if uri_info.get("disabled") == "true":
-                                                disabled = True
-                                        if proxy:
-                                                if proxy == \
-                                                    publisher.SYSREPO_PROXY:
-                                                        p =  publisher.ProxyURI(
-                                                            None, system=True)
-                                                else:
-                                                        p = publisher.ProxyURI(
-                                                            proxy)
-                                                proxies.append(p)
-
-                                if not any(uri.startswith(scheme + ":") for
-                                    scheme in publisher.SSL_SCHEMES):
-                                        repouri = publisher.RepositoryURI(uri,
-                                            proxies=proxies, disabled=disabled)
-                                else:
-                                        repouri = publisher.RepositoryURI(uri,
-                                            ssl_cert=ssl_cert, ssl_key=ssl_key,
-                                            proxies=proxies, disabled=disabled)
-                                repo_add_func(repouri)
-
-                pub = publisher.Publisher(prefix, alias=sec_idx["alias"],
-                    client_uuid=sec_idx["uuid"],
-                    client_uuid_time=sec_idx["last_uuid"],
-                    disabled=sec_idx["disabled"],
-                    repository=r, sticky=sec_idx.get("sticky", True),
-                    props=props,
-                    revoked_ca_certs=sec_idx.get("revoked_ca_certs", []),
-                    approved_ca_certs=sec_idx.get("approved_ca_certs", []))
-
-                if pub.client_uuid != sec_idx["uuid"]:
-                        # Publisher has generated new uuid; ensure configuration
-                        # matches.
-                        self.set_property(sname, "uuid", pub.client_uuid)
-                        self.set_property(sname, "last_uuid",
-                            pub.client_uuid_time)
-
-                return prefix, pub
-
-        def __validate_properties(self):
-                """Check that properties are consistent with each other."""
-
-                try:
-                        polval = self.get_property("property", SIGNATURE_POLICY)
-                except cfg.PropertyConfigError:
-                        # If it hasn't been set yet, there's nothing to
-                        # validate.
-                        return
-
-                if polval == "require-names":
-                        signames = self.get_property("property",
-                            "signature-required-names")
-                        if not signames:
-                                raise apx.InvalidPropertyValue(_(
-                                    "At least one name must be provided for "
-                                    "the signature-required-names policy."))
-
-        def __publisher_getdefault(self, name, value):
-                """Support getdefault() on properties"""
-                return self.__publishers.get(name, value)
-
-        # properties so we can enforce rules
-        publishers = DictProperty(__get_publisher, __set_publisher,
-            __del_publisher, __publisher_iteritems, __publisher_keys,
-            __publisher_values, __publisher_iter,
-            doc="A dict mapping publisher prefixes to publisher objects",
-            fgetdefault=__publisher_getdefault, )
+                    repouri = publisher.RepositoryURI(
+                        uri,
+                        ssl_cert=ssl_cert,
+                        ssl_key=ssl_key,
+                        proxies=proxies,
+                        disabled=disabled,
+                    )
+                repo_add_func(repouri)
+
+        pub = publisher.Publisher(
+            prefix,
+            alias=sec_idx["alias"],
+            client_uuid=sec_idx["uuid"],
+            client_uuid_time=sec_idx["last_uuid"],
+            disabled=sec_idx["disabled"],
+            repository=r,
+            sticky=sec_idx.get("sticky", True),
+            props=props,
+            revoked_ca_certs=sec_idx.get("revoked_ca_certs", []),
+            approved_ca_certs=sec_idx.get("approved_ca_certs", []),
+        )
+
+        if pub.client_uuid != sec_idx["uuid"]:
+            # Publisher has generated new uuid; ensure configuration
+            # matches.
+            self.set_property(sname, "uuid", pub.client_uuid)
+            self.set_property(sname, "last_uuid", pub.client_uuid_time)
+
+        return prefix, pub
+
+    def __validate_properties(self):
+        """Check that properties are consistent with each other."""
+
+        try:
+            polval = self.get_property("property", SIGNATURE_POLICY)
+        except cfg.PropertyConfigError:
+            # If it hasn't been set yet, there's nothing to
+            # validate.
+            return
+
+        if polval == "require-names":
+            signames = self.get_property("property", "signature-required-names")
+            if not signames:
+                raise apx.InvalidPropertyValue(
+                    _(
+                        "At least one name must be provided for "
+                        "the signature-required-names policy."
+                    )
+                )
+
+    def __publisher_getdefault(self, name, value):
+        """Support getdefault() on properties"""
+        return self.__publishers.get(name, value)
+
+    # properties so we can enforce rules
+    publishers = DictProperty(
+        __get_publisher,
+        __set_publisher,
+        __del_publisher,
+        __publisher_iteritems,
+        __publisher_keys,
+        __publisher_values,
+        __publisher_iter,
+        doc="A dict mapping publisher prefixes to publisher objects",
+        fgetdefault=__publisher_getdefault,
+    )
 
 
 class NullSystemPublisher(object):
-        """Dummy system publisher object for use when an image doesn't use a
-        system publisher."""
+    """Dummy system publisher object for use when an image doesn't use a
+    system publisher."""
 
-        # property.proxied-urls is here for backwards compatibility, it is no
-        # longer used by pkg(7)
-        __supported_props = ("publisher-search-order", "property.proxied-urls",
-            SIGNATURE_POLICY, "signature-required-names")
+    # property.proxied-urls is here for backwards compatibility, it is no
+    # longer used by pkg(7)
+    __supported_props = (
+        "publisher-search-order",
+        "property.proxied-urls",
+        SIGNATURE_POLICY,
+        "signature-required-names",
+    )
 
-        def __init__(self):
-                self.publishers = {}
-                self.__props = dict([(p, []) for p in self.__supported_props])
-                self.__props[SIGNATURE_POLICY] = \
-                    default_policies[SIGNATURE_POLICY]
+    def __init__(self):
+        self.publishers = {}
+        self.__props = dict([(p, []) for p in self.__supported_props])
+        self.__props[SIGNATURE_POLICY] = default_policies[SIGNATURE_POLICY]
 
-        def write(self):
-                return
+    def write(self):
+        return
 
-        def get_property(self, section, name):
-                """Return the value of the property if the NullSystemPublisher
-                has any knowledge of it."""
+    def get_property(self, section, name):
+        """Return the value of the property if the NullSystemPublisher
+        has any knowledge of it."""
 
-                if section == "property" and \
-                    name in self.__supported_props:
-                        return self.__props[name]
-                raise NotImplementedError()
+        if section == "property" and name in self.__supported_props:
+            return self.__props[name]
+        raise NotImplementedError()
 
-        def set_property(self, section, name, value):
-                if section == "property" and name in self.__supported_props:
-                        self.__props[name] = value
-                        self.__validate_properties()
-                        return
-                raise NotImplementedError()
+    def set_property(self, section, name, value):
+        if section == "property" and name in self.__supported_props:
+            self.__props[name] = value
+            self.__validate_properties()
+            return
+        raise NotImplementedError()
 
-        def __validate_properties(self):
-                """Check that properties are consistent with each other."""
+    def __validate_properties(self):
+        """Check that properties are consistent with each other."""
 
-                try:
-                        polval = self.get_property("property", SIGNATURE_POLICY)
-                except cfg.PropertyConfigError:
-                        # If it hasn't been set yet, there's nothing to
-                        # validate.
-                        return
+        try:
+            polval = self.get_property("property", SIGNATURE_POLICY)
+        except cfg.PropertyConfigError:
+            # If it hasn't been set yet, there's nothing to
+            # validate.
+            return
 
-                if polval == "require-names":
-                        signames = self.get_property("property",
-                            "signature-required-names")
-                        if not signames:
-                                raise apx.InvalidPropertyValue(_(
-                                    "At least one name must be provided for "
-                                    "the signature-required-names policy."))
+        if polval == "require-names":
+            signames = self.get_property("property", "signature-required-names")
+            if not signames:
+                raise apx.InvalidPropertyValue(
+                    _(
+                        "At least one name must be provided for "
+                        "the signature-required-names policy."
+                    )
+                )
 
-        def set_properties(self, properties):
-                """Set multiple properties at one time."""
+    def set_properties(self, properties):
+        """Set multiple properties at one time."""
 
-                if list(properties.keys()) != ["property"]:
-                        raise NotImplementedError
-                props = properties["property"]
-                if not all(k in self.__supported_props for k in props):
-                        raise NotImplementedError()
-                self.__props.update(props)
-                self.__validate_properties()
+        if list(properties.keys()) != ["property"]:
+            raise NotImplementedError
+        props = properties["property"]
+        if not all(k in self.__supported_props for k in props):
+            raise NotImplementedError()
+        self.__props.update(props)
+        self.__validate_properties()
 
 
 class BlendedConfig(object):
-        """Class which handles combining the system repository configuration
-        with the image configuration."""
-
-        def __init__(self, img_cfg, pkg_counts, imgdir, transport,
-            use_system_pub):
-                """The 'img_cfg' parameter is the ImageConfig object for the
-                image.
-
-                The 'pkg_counts' parameter is a list of tuples which contains
-                the number of packages each publisher has installed.
-
-                The 'imgdir' parameter is the directory the current image
-                resides in.
-
-                The 'transport' object is the image's transport.
-
-                The 'use_system_pub' parameter is a boolean which indicates
-                whether the system publisher should be used."""
-
-                self.img_cfg = img_cfg
-                self.__pkg_counts = pkg_counts
-
-                self.__proxy_url = None
-
-                syscfg_path = os.path.join(imgdir, "pkg5.syspub")
-                # load the existing system repo config
-                if os.path.exists(syscfg_path):
-                        old_sysconfig = ImageConfig(syscfg_path, None)
-                else:
-                        old_sysconfig = NullSystemPublisher()
-
-                # A tuple of properties whose value should be taken from the
-                # system repository configuration and not the image
-                # configuration.
-                self.__system_override_properties = (SIGNATURE_POLICY,
-                    "signature-required-names")
-
-                self.__write_sys_cfg = True
-                if use_system_pub:
-                        # get new syspub data from sysdepot
-                        try:
-                                self.__proxy_url = os.environ["PKG_SYSREPO_URL"]
-                                if not self.__proxy_url.startswith("http://"):
-                                        self.__proxy_url = "http://" + \
-                                            self.__proxy_url
-                        except KeyError:
-                                try:
-                                        host = smf.get_prop(
-                                            "application/pkg/zones-proxy-client",
-                                            "config/listen_host")
-                                        port = smf.get_prop(
-                                            "application/pkg/zones-proxy-client",
-                                            "config/listen_port")
-                                except smf.NonzeroExitException as e:
-                                        # If we can't get information out of
-                                        # smf, try using pkg/sysrepo.
-                                        try:
-                                                host = smf.get_prop(
-                                                    "application/pkg/system-repository:default",
-                                                    "config/host")
-                                                host = "localhost"
-                                                port = smf.get_prop(
-                                                    "application/pkg/system-repository:default",
-                                                    "config/port")
-                                        except smf.NonzeroExitException as e:
-                                                raise apx.UnknownSysrepoConfiguration()
-                                self.__proxy_url = "http://{0}:{1}".format(host, port)
-                        # We use system=True so that we don't try to retrieve
-                        # runtime $http_proxy environment variables in
-                        # pkg.client.publisher.TransportRepoURI.__get_runtime_proxy(..)
-                        # See also how 'system' is handled in
-                        # pkg.client.transport.engine.CurlTransportEngine.__setup_handle(..)
-                        # pkg.client.transport.repo.get_syspub_info(..)
-                        sysdepot_uri = publisher.RepositoryURI(self.__proxy_url,
-                            system=True)
-                        assert sysdepot_uri.get_host()
-                        try:
-                                pubs, props = transport.get_syspub_data(
-                                    sysdepot_uri)
-                        except TransportFailures:
-                                self.sys_cfg = old_sysconfig
-                                self.__write_sys_cfg = False
-                        else:
-                                try:
-                                        try:
-                                                # Try to remove any previous
-                                                # system repository
-                                                # configuration.
-                                                portable.remove(syscfg_path)
-                                        except OSError as e:
-                                                if e.errno == errno.ENOENT:
-                                                        # Check to see whether
-                                                        # we'll be able to write
-                                                        # the configuration
-                                                        # later.
-                                                        with open(syscfg_path,
-                                                            "wb") as fh:
-                                                                fh.close()
-                                                        self.sys_cfg = \
-                                                            ImageConfig(
-                                                            syscfg_path, None)
-                                                else:
-                                                        raise
-                                except OSError as e:
-                                        if e.errno in \
-                                            (errno.EACCES, errno.EROFS):
-                                                # A permissions error means that
-                                                # either we couldn't remove the
-                                                # existing configuration or
-                                                # create a new configuration in
-                                                # that place.  In that case, use
-                                                # an in-memory only version of
-                                                # the ImageConfig.
-                                                self.sys_cfg = \
-                                                    NullSystemPublisher()
-                                                self.__write_sys_cfg = False
-                                        else:
-                                                raise
-                                else:
-                                        # The previous configuration was
-                                        # successfully removed, so use that
-                                        # location for the new ImageConfig.
-                                        self.sys_cfg = \
-                                            ImageConfig(syscfg_path, None,
-                                                sysrepo_proxy=True)
-                                for p in pubs:
-                                        assert not p.disabled, "System " \
-                                            "publisher {0} was unexpectedly " \
-                                            "marked disabled in system " \
-                                            "configuration.".format(p.prefix)
-                                        self.sys_cfg.publishers[p.prefix] = p
-
-                                self.sys_cfg.set_property("property",
-                                    "publisher-search-order",
-                                    props["publisher-search-order"])
-                                # A dictionary is used to change both of these
-                                # properties at once since setting the
-                                # signature-policy to require-names without
-                                # having any require-names set will cause
-                                # property validation to fail.
-                                d = {}
-                                if SIGNATURE_POLICY in props:
-                                        d.setdefault("property", {})[
-                                            SIGNATURE_POLICY] = props[
-                                            SIGNATURE_POLICY]
-                                if "signature-required-names" in props:
-                                        d.setdefault("property", {})[
-                                            "signature-required-names"] = props[
-                                            "signature-required-names"]
-                                if d:
-                                        self.sys_cfg.set_properties(d)
-                else:
-                        self.sys_cfg = NullSystemPublisher()
-                        self.__system_override_properties = ()
-
-                self.__publishers, self.added_pubs, self.removed_pubs, \
-                    self.modified_pubs = \
-                        self.__merge_publishers(self.img_cfg, self.sys_cfg,
-                            pkg_counts, old_sysconfig, self.__proxy_url)
-
-        @staticmethod
-        def __merge_publishers(img_cfg, sys_cfg, pkg_counts, old_sysconfig,
-            proxy_url):
-                """This function merges an old publisher configuration from the
-                system repository with the new publisher configuration from the
-                system repository.  It returns a tuple containing a dictionary
-                mapping prefix to publisher, the publisher objects for the newly
-                added system publishers, and the publisher objects for the
-                system publishers which were removed.
-
-                The 'img_cfg' parameter is the ImageConfig object for the
-                image.
-
-                The 'sys_cfg' parameter is the ImageConfig object containing the
-                publisher configuration from the system repository.
-
-                The 'pkg_counts' parameter is a list of tuples which contains
-                the number of packages each publisher has installed.
-
-                The 'old_sysconfig' parameter is ImageConfig object containing
-                the previous publisher configuration from the system repository.
-
-                The 'proxy_url' parameter is the url for the system repository.
-                """
-
-                pubs_with_installed_pkgs = set()
-                for prefix, cnt, ver_cnt in pkg_counts:
-                        if cnt > 0:
-                                pubs_with_installed_pkgs.add(prefix)
-
-                # keep track of old system publishers which are becoming
-                # disabled image publishers (because they have packages
-                # installed).
-                disabled_pubs = set()
-
-                # Merge in previously existing system publishers which have
-                # installed packages.
-                for prefix in old_sysconfig.get_property("property",
-                    "publisher-search-order"):
-                        if prefix in sys_cfg.publishers or \
-                            prefix in img_cfg.publishers or \
-                            prefix not in pubs_with_installed_pkgs:
-                                continue
-
-                        # only report this publisher as disabled if it wasn't
-                        # previously reported and saved as disabled.
-                        if not old_sysconfig.publishers[prefix].disabled:
-                                disabled_pubs |= set([prefix])
-
-                        sys_cfg.publishers[prefix] = \
-                            old_sysconfig.publishers[prefix]
-                        sys_cfg.publishers[prefix].disabled = True
-
-                        # if a syspub publisher is no longer available then
-                        # remove all the origin and mirror information
-                        # associated with that publisher.
-                        sys_cfg.publishers[prefix].repository.origins = []
-                        sys_cfg.publishers[prefix].repository.mirrors = []
-
-                # check if any system publisher have had origin changes.
-                modified_pubs = set()
-                for prefix in set(old_sysconfig.publishers) & \
-                    set(sys_cfg.publishers):
-                        pold = old_sysconfig.publishers[prefix]
-                        pnew = sys_cfg.publishers[prefix]
-                        if list(map(str, pold.repository.origins)) != \
-                            list(map(str, pnew.repository.origins)):
-                                modified_pubs |= set([prefix])
-
-                if proxy_url:
-                        # We must replace the temporary "system" proxy with the
-                        # real URL of the system-repository.
-                        system_proxy = publisher.ProxyURI(None, system=True)
-                        real_system_proxy = publisher.ProxyURI(proxy_url)
-                        for p in sys_cfg.publishers.values():
-                                for o in p.repository.origins:
-                                        o.system = True
-                                        try:
-                                                i = o.proxies.index(system_proxy)
-                                                o.proxies[i] = real_system_proxy
-                                        except ValueError:
-                                                pass
-
-                                for m in p.repository.mirrors:
-                                        m.system = True
-                                        try:
-                                                i = m.proxies.index(system_proxy)
-                                                m.proxies[i] = real_system_proxy
-                                        except ValueError:
-                                                pass
-                                p.sys_pub = True
-
-                # Create a dictionary mapping publisher prefix to publisher
-                # object while merging user configured origins into system
-                # publishers.
-                res = {}
-                for p in sys_cfg.publishers:
-                        res[p] = sys_cfg.publishers[p]
-                for p in img_cfg.publishers.values():
-                        assert isinstance(p, publisher.Publisher)
-                        if p.prefix in res:
-                                repo = p.repository
-                                srepo = res[p.prefix].repository
-                                # We do not allow duplicate URIs for either
-                                # origins or mirrors, so must check whether the
-                                # system publisher already provides
-                                # a path to each user-configured origin/mirror.
-                                # If so, we do not add the user-configured
-                                # origin or mirror.
-                                for o in repo.origins:
-                                        if not srepo.has_origin(o):
-                                                srepo.add_origin(o)
-                                for m in repo.mirrors:
-                                        if not srepo.has_mirror(m):
-                                                srepo.add_mirror(m)
-                        else:
-                                res[p.prefix] = p
-
-                new_pubs = set(sys_cfg.publishers.keys())
-                old_pubs = set(old_sysconfig.publishers.keys())
-
-                # Find the system publishers which appeared or vanished.  This
-                # is needed so that the catalog information can be rebuilt.
-                added_pubs = new_pubs - old_pubs
-                removed_pubs = old_pubs - new_pubs
-
-                added_pubs = [res[p] for p in added_pubs]
-                removed_pubs = [
-                    old_sysconfig.publishers[p]
-                    for p in removed_pubs | disabled_pubs
-                ]
-                modified_pubs = [
-                    old_sysconfig.publishers[p]
-                    for p in modified_pubs
-                ]
-                return (res, added_pubs, removed_pubs, modified_pubs)
-
-        def write_sys_cfg(self):
-                # Write out the new system publisher configuration.
-                if self.__write_sys_cfg:
-                        self.sys_cfg.write()
-
-        def write(self):
-                """Update the image configuration to reflect any changes made,
-                then write it."""
-
-                for p in self.__publishers.values():
-
-                        if not p.sys_pub:
-                                self.img_cfg.publishers[p.prefix] = p
-                                continue
-
-                        # If we had previous user-configuration for this
-                        # publisher, only store non-system publisher changes
-                        repo = p.repository
-                        sticky = p.sticky
-                        user_origins = [o for o in repo.origins if not o.system]
-                        system_origins = [o for o in repo.origins if o.system]
-                        user_mirrors = [o for o in repo.mirrors if not o.system]
-                        system_mirrors = [o for o in repo.mirrors if o.system]
-                        old_origins = []
-                        old_mirrors = []
-
-                        # look for any previously set configuration
-                        if p.prefix in self.img_cfg.publishers:
-                                old_pub = self.img_cfg.publishers[p.prefix]
-                                old_origins = old_pub.repository.origins
-                                old_mirrors = old_pub.repository.mirrors
-                                sticky = old_pub.sticky
-
-                                # Preserve any origins configured in the image,
-                                # but masked by the same origin also provided
-                                # by the system-repository.
-                                user_origins = user_origins + \
-                                    [o for o in old_origins
-                                    if o in system_origins]
-                                user_mirrors = user_mirrors + \
-                                    [o for o in old_mirrors
-                                    if o in system_mirrors]
-
-                        # no user changes, so nothing new to write
-                        if set(user_origins) == set(old_origins) and \
-                            set(user_mirrors) == set(old_mirrors):
-                                continue
-
-                        # store a publisher with this configuration
-                        user_pub = publisher.Publisher(prefix=p.prefix,
-                            sticky=sticky)
-                        user_pub.repository = publisher.Repository()
-                        user_pub.repository.origins = user_origins
-                        user_pub.repository.mirrors = user_mirrors
-                        self.img_cfg.publishers[p.prefix] = user_pub
-
-                # Write out the image configuration.
-                self.img_cfg.write()
-
-        def allowed_to_move(self, pub):
-                """Return whether a publisher is allowed to move in the search
-                order."""
-
-                return not self.__is_sys_pub(pub)
-
-        def add_property_value(self, *args, **kwargs):
-                return self.img_cfg.add_property_value(*args, **kwargs)
-
-        def remove_property_value(self, *args, **kwargs):
-                return self.img_cfg.remove_property_value(*args, **kwargs)
-
-        def get_index(self):
-                return self.img_cfg.get_index()
-
-        def get_policy(self, *args, **kwargs):
-                return self.img_cfg.get_policy(*args, **kwargs)
-
-        def get_policy_str(self, *args, **kwargs):
-                return self.img_cfg.get_policy_str(*args, **kwargs)
-
-        def get_property(self, section, name):
-                # If the property being retrieved is the publisher search order,
-                # it's necessary to merge the information from the image
-                # configuration and the system configuration.
-                if section == "property" and name == "publisher-search-order":
-                        res = self.sys_cfg.get_property(section, name)
-                        enabled_sys_pubs = [
-                            p for p in res
-                            if not self.sys_cfg.publishers[p].disabled
-                        ]
-                        img_pubs = [
-                            s for s in self.img_cfg.get_property(section, name)
-                            if s not in enabled_sys_pubs
-                        ]
-                        disabled_sys_pubs = [
-                            p for p in res
-                            if self.sys_cfg.publishers[p].disabled and \
-                                p not in img_pubs
-                        ]
-                        return enabled_sys_pubs + img_pubs + disabled_sys_pubs
-                if section == "property" and name in \
-                    self.__system_override_properties:
-                        return self.sys_cfg.get_property(section, name)
-                return self.img_cfg.get_property(section, name)
-
-        def remove_property(self, *args, **kwargs):
-                return self.img_cfg.remove_property(*args, **kwargs)
-
-        def set_property(self, *args, **kwargs):
-                return self.img_cfg.set_property(*args, **kwargs)
-
-        def set_properties(self, *args, **kwargs):
-                return self.img_cfg.set_properties(*args, **kwargs)
-
-        @property
-        def target(self):
-                return self.img_cfg.target
-
-        @property
-        def variants(self):
-                return self.img_cfg.variants
-
-        def __get_mediators(self):
-                return self.img_cfg.mediators
-
-        def __set_mediators(self, mediators):
-                self.img_cfg.mediators = mediators
-
-        mediators = property(__get_mediators, __set_mediators)
-
-        def __get_facets(self):
-                return self.img_cfg.facets
-
-        def __set_facets(self, facets):
-                self.img_cfg.facets = facets
-
-        facets = property(__get_facets, __set_facets)
-
-        def __get_linked_children(self):
-                return self.img_cfg.linked_children
-
-        def __set_linked_children(self, linked_children):
-                self.img_cfg.linked_children = linked_children
-
-        linked_children = property(__get_linked_children,
-            __set_linked_children)
-
-        def __is_sys_pub(self, prefix):
-                """Return whether the publisher with the prefix 'prefix' is a
-                system publisher."""
-
-                return prefix in self.sys_cfg.publishers
-
-        def remove_publisher(self, prefix):
+    """Class which handles combining the system repository configuration
+    with the image configuration."""
+
+    def __init__(self, img_cfg, pkg_counts, imgdir, transport, use_system_pub):
+        """The 'img_cfg' parameter is the ImageConfig object for the
+        image.
+
+        The 'pkg_counts' parameter is a list of tuples which contains
+        the number of packages each publisher has installed.
+
+        The 'imgdir' parameter is the directory the current image
+        resides in.
+
+        The 'transport' object is the image's transport.
+
+        The 'use_system_pub' parameter is a boolean which indicates
+        whether the system publisher should be used."""
+
+        self.img_cfg = img_cfg
+        self.__pkg_counts = pkg_counts
+
+        self.__proxy_url = None
+
+        syscfg_path = os.path.join(imgdir, "pkg5.syspub")
+        # load the existing system repo config
+        if os.path.exists(syscfg_path):
+            old_sysconfig = ImageConfig(syscfg_path, None)
+        else:
+            old_sysconfig = NullSystemPublisher()
+
+        # A tuple of properties whose value should be taken from the
+        # system repository configuration and not the image
+        # configuration.
+        self.__system_override_properties = (
+            SIGNATURE_POLICY,
+            "signature-required-names",
+        )
+
+        self.__write_sys_cfg = True
+        if use_system_pub:
+            # get new syspub data from sysdepot
+            try:
+                self.__proxy_url = os.environ["PKG_SYSREPO_URL"]
+                if not self.__proxy_url.startswith("http://"):
+                    self.__proxy_url = "http://" + self.__proxy_url
+            except KeyError:
                 try:
-                        del self.publishers[prefix]
-                except KeyError:
+                    host = smf.get_prop(
+                        "application/pkg/zones-proxy-client",
+                        "config/listen_host",
+                    )
+                    port = smf.get_prop(
+                        "application/pkg/zones-proxy-client",
+                        "config/listen_port",
+                    )
+                except smf.NonzeroExitException as e:
+                    # If we can't get information out of
+                    # smf, try using pkg/sysrepo.
+                    try:
+                        host = smf.get_prop(
+                            "application/pkg/system-repository:default",
+                            "config/host",
+                        )
+                        host = "localhost"
+                        port = smf.get_prop(
+                            "application/pkg/system-repository:default",
+                            "config/port",
+                        )
+                    except smf.NonzeroExitException as e:
+                        raise apx.UnknownSysrepoConfiguration()
+                self.__proxy_url = "http://{0}:{1}".format(host, port)
+            # We use system=True so that we don't try to retrieve
+            # runtime $http_proxy environment variables in
+            # pkg.client.publisher.TransportRepoURI.__get_runtime_proxy(..)
+            # See also how 'system' is handled in
+            # pkg.client.transport.engine.CurlTransportEngine.__setup_handle(..)
+            # pkg.client.transport.repo.get_syspub_info(..)
+            sysdepot_uri = publisher.RepositoryURI(
+                self.__proxy_url, system=True
+            )
+            assert sysdepot_uri.get_host()
+            try:
+                pubs, props = transport.get_syspub_data(sysdepot_uri)
+            except TransportFailures:
+                self.sys_cfg = old_sysconfig
+                self.__write_sys_cfg = False
+            else:
+                try:
+                    try:
+                        # Try to remove any previous
+                        # system repository
+                        # configuration.
+                        portable.remove(syscfg_path)
+                    except OSError as e:
+                        if e.errno == errno.ENOENT:
+                            # Check to see whether
+                            # we'll be able to write
+                            # the configuration
+                            # later.
+                            with open(syscfg_path, "wb") as fh:
+                                fh.close()
+                            self.sys_cfg = ImageConfig(syscfg_path, None)
+                        else:
+                            raise
+                except OSError as e:
+                    if e.errno in (errno.EACCES, errno.EROFS):
+                        # A permissions error means that
+                        # either we couldn't remove the
+                        # existing configuration or
+                        # create a new configuration in
+                        # that place.  In that case, use
+                        # an in-memory only version of
+                        # the ImageConfig.
+                        self.sys_cfg = NullSystemPublisher()
+                        self.__write_sys_cfg = False
+                    else:
+                        raise
+                else:
+                    # The previous configuration was
+                    # successfully removed, so use that
+                    # location for the new ImageConfig.
+                    self.sys_cfg = ImageConfig(
+                        syscfg_path, None, sysrepo_proxy=True
+                    )
+                for p in pubs:
+                    assert not p.disabled, (
+                        "System "
+                        "publisher {0} was unexpectedly "
+                        "marked disabled in system "
+                        "configuration.".format(p.prefix)
+                    )
+                    self.sys_cfg.publishers[p.prefix] = p
+
+                self.sys_cfg.set_property(
+                    "property",
+                    "publisher-search-order",
+                    props["publisher-search-order"],
+                )
+                # A dictionary is used to change both of these
+                # properties at once since setting the
+                # signature-policy to require-names without
+                # having any require-names set will cause
+                # property validation to fail.
+                d = {}
+                if SIGNATURE_POLICY in props:
+                    d.setdefault("property", {})[SIGNATURE_POLICY] = props[
+                        SIGNATURE_POLICY
+                    ]
+                if "signature-required-names" in props:
+                    d.setdefault("property", {})[
+                        "signature-required-names"
+                    ] = props["signature-required-names"]
+                if d:
+                    self.sys_cfg.set_properties(d)
+        else:
+            self.sys_cfg = NullSystemPublisher()
+            self.__system_override_properties = ()
+
+        (
+            self.__publishers,
+            self.added_pubs,
+            self.removed_pubs,
+            self.modified_pubs,
+        ) = self.__merge_publishers(
+            self.img_cfg,
+            self.sys_cfg,
+            pkg_counts,
+            old_sysconfig,
+            self.__proxy_url,
+        )
+
+    @staticmethod
+    def __merge_publishers(
+        img_cfg, sys_cfg, pkg_counts, old_sysconfig, proxy_url
+    ):
+        """This function merges an old publisher configuration from the
+        system repository with the new publisher configuration from the
+        system repository.  It returns a tuple containing a dictionary
+        mapping prefix to publisher, the publisher objects for the newly
+        added system publishers, and the publisher objects for the
+        system publishers which were removed.
+
+        The 'img_cfg' parameter is the ImageConfig object for the
+        image.
+
+        The 'sys_cfg' parameter is the ImageConfig object containing the
+        publisher configuration from the system repository.
+
+        The 'pkg_counts' parameter is a list of tuples which contains
+        the number of packages each publisher has installed.
+
+        The 'old_sysconfig' parameter is ImageConfig object containing
+        the previous publisher configuration from the system repository.
+
+        The 'proxy_url' parameter is the url for the system repository.
+        """
+
+        pubs_with_installed_pkgs = set()
+        for prefix, cnt, ver_cnt in pkg_counts:
+            if cnt > 0:
+                pubs_with_installed_pkgs.add(prefix)
+
+        # keep track of old system publishers which are becoming
+        # disabled image publishers (because they have packages
+        # installed).
+        disabled_pubs = set()
+
+        # Merge in previously existing system publishers which have
+        # installed packages.
+        for prefix in old_sysconfig.get_property(
+            "property", "publisher-search-order"
+        ):
+            if (
+                prefix in sys_cfg.publishers
+                or prefix in img_cfg.publishers
+                or prefix not in pubs_with_installed_pkgs
+            ):
+                continue
+
+            # only report this publisher as disabled if it wasn't
+            # previously reported and saved as disabled.
+            if not old_sysconfig.publishers[prefix].disabled:
+                disabled_pubs |= set([prefix])
+
+            sys_cfg.publishers[prefix] = old_sysconfig.publishers[prefix]
+            sys_cfg.publishers[prefix].disabled = True
+
+            # if a syspub publisher is no longer available then
+            # remove all the origin and mirror information
+            # associated with that publisher.
+            sys_cfg.publishers[prefix].repository.origins = []
+            sys_cfg.publishers[prefix].repository.mirrors = []
+
+        # check if any system publisher have had origin changes.
+        modified_pubs = set()
+        for prefix in set(old_sysconfig.publishers) & set(sys_cfg.publishers):
+            pold = old_sysconfig.publishers[prefix]
+            pnew = sys_cfg.publishers[prefix]
+            if list(map(str, pold.repository.origins)) != list(
+                map(str, pnew.repository.origins)
+            ):
+                modified_pubs |= set([prefix])
+
+        if proxy_url:
+            # We must replace the temporary "system" proxy with the
+            # real URL of the system-repository.
+            system_proxy = publisher.ProxyURI(None, system=True)
+            real_system_proxy = publisher.ProxyURI(proxy_url)
+            for p in sys_cfg.publishers.values():
+                for o in p.repository.origins:
+                    o.system = True
+                    try:
+                        i = o.proxies.index(system_proxy)
+                        o.proxies[i] = real_system_proxy
+                    except ValueError:
                         pass
 
-        def change_publisher_search_order(self, being_moved, staying_put,
-            after):
-                """Change the publisher search order by moving the publisher
-                'being_moved' relative to the publisher 'staying put.'  The
-                boolean 'after' determines whether 'being_moved' is placed before
-                or after 'staying_put'."""
+                for m in p.repository.mirrors:
+                    m.system = True
+                    try:
+                        i = m.proxies.index(system_proxy)
+                        m.proxies[i] = real_system_proxy
+                    except ValueError:
+                        pass
+                p.sys_pub = True
 
-                if being_moved == staying_put:
-                        raise apx.MoveRelativeToSelf()
+        # Create a dictionary mapping publisher prefix to publisher
+        # object while merging user configured origins into system
+        # publishers.
+        res = {}
+        for p in sys_cfg.publishers:
+            res[p] = sys_cfg.publishers[p]
+        for p in img_cfg.publishers.values():
+            assert isinstance(p, publisher.Publisher)
+            if p.prefix in res:
+                repo = p.repository
+                srepo = res[p.prefix].repository
+                # We do not allow duplicate URIs for either
+                # origins or mirrors, so must check whether the
+                # system publisher already provides
+                # a path to each user-configured origin/mirror.
+                # If so, we do not add the user-configured
+                # origin or mirror.
+                for o in repo.origins:
+                    if not srepo.has_origin(o):
+                        srepo.add_origin(o)
+                for m in repo.mirrors:
+                    if not srepo.has_mirror(m):
+                        srepo.add_mirror(m)
+            else:
+                res[p.prefix] = p
 
-                if self.__is_sys_pub(being_moved):
-                        raise apx.ModifyingSyspubException(_("Publisher '{0}' "
-                            "is a system publisher and cannot be moved.").format(
-                            being_moved))
-                if self.__is_sys_pub(staying_put):
-                        raise apx.ModifyingSyspubException(_("Publisher '{0}' "
-                            "is a system publisher and other publishers cannot "
-                            "be moved relative to it.").format(staying_put))
-                self.img_cfg.change_publisher_search_order(being_moved,
-                    staying_put, after)
+        new_pubs = set(sys_cfg.publishers.keys())
+        old_pubs = set(old_sysconfig.publishers.keys())
 
-        def reset(self, overrides=misc.EmptyDict):
-                """Discards current configuration state and returns the
-                configuration object to its initial state.
+        # Find the system publishers which appeared or vanished.  This
+        # is needed so that the catalog information can be rebuilt.
+        added_pubs = new_pubs - old_pubs
+        removed_pubs = old_pubs - new_pubs
 
-                'overrides' is an optional dictionary of property values indexed
-                by section name and property name.  If provided, it will be used
-                to override any default values initially assigned during reset.
-                """
+        added_pubs = [res[p] for p in added_pubs]
+        removed_pubs = [
+            old_sysconfig.publishers[p] for p in removed_pubs | disabled_pubs
+        ]
+        modified_pubs = [old_sysconfig.publishers[p] for p in modified_pubs]
+        return (res, added_pubs, removed_pubs, modified_pubs)
 
-                self.img_cfg.reset(overrides)
-                self.sys_cfg.reset()
-                old_sysconfig = ImageConfig(os.path.join(imgdir, "pkg5.syspub"),
-                    None)
-                self.__publishers, self.added_pubs, self.removed_pubs, \
-                    self.modified_pubs = \
-                        self.__merge_publishers(self.img_cfg,
-                            self.sys_cfg, self.__pkg_counts, old_sysconfig)
+    def write_sys_cfg(self):
+        # Write out the new system publisher configuration.
+        if self.__write_sys_cfg:
+            self.sys_cfg.write()
 
-        def __get_publisher(self, prefix):
-                """Accessor method for publishers dictionary"""
-                return self.__publishers[prefix]
+    def write(self):
+        """Update the image configuration to reflect any changes made,
+        then write it."""
 
-        def __set_publisher(self, prefix, pubobj):
-                """Accessor method to keep search order correct on insert"""
-                pval = self.get_property("property", "publisher-search-order")
-                if prefix not in pval:
-                        self.add_property_value("property",
-                            "publisher-search-order", prefix)
-                self.__publishers[prefix] = pubobj
+        for p in self.__publishers.values():
+            if not p.sys_pub:
+                self.img_cfg.publishers[p.prefix] = p
+                continue
 
-        def __del_publisher(self, prefix):
-                """Accessor method for publishers"""
-                if self.__is_sys_pub(prefix):
-                        raise apx.ModifyingSyspubException(_("{0} is a system "
-                            "publisher and cannot be unset.").format(prefix))
+            # If we had previous user-configuration for this
+            # publisher, only store non-system publisher changes
+            repo = p.repository
+            sticky = p.sticky
+            user_origins = [o for o in repo.origins if not o.system]
+            system_origins = [o for o in repo.origins if o.system]
+            user_mirrors = [o for o in repo.mirrors if not o.system]
+            system_mirrors = [o for o in repo.mirrors if o.system]
+            old_origins = []
+            old_mirrors = []
 
-                del self.img_cfg.publishers[prefix]
-                del self.__publishers[prefix]
+            # look for any previously set configuration
+            if p.prefix in self.img_cfg.publishers:
+                old_pub = self.img_cfg.publishers[p.prefix]
+                old_origins = old_pub.repository.origins
+                old_mirrors = old_pub.repository.mirrors
+                sticky = old_pub.sticky
 
-        def __publisher_iter(self):
-                return self.__publishers.__iter__()
+                # Preserve any origins configured in the image,
+                # but masked by the same origin also provided
+                # by the system-repository.
+                user_origins = user_origins + [
+                    o for o in old_origins if o in system_origins
+                ]
+                user_mirrors = user_mirrors + [
+                    o for o in old_mirrors if o in system_mirrors
+                ]
 
-        def __publisher_iteritems(self):
-                """Support iteritems on publishers"""
-                return six.iteritems(self.__publishers)
+            # no user changes, so nothing new to write
+            if set(user_origins) == set(old_origins) and set(
+                user_mirrors
+            ) == set(old_mirrors):
+                continue
 
-        def __publisher_keys(self):
-                """Support keys() on publishers"""
-                return list(self.__publishers.keys())
+            # store a publisher with this configuration
+            user_pub = publisher.Publisher(prefix=p.prefix, sticky=sticky)
+            user_pub.repository = publisher.Repository()
+            user_pub.repository.origins = user_origins
+            user_pub.repository.mirrors = user_mirrors
+            self.img_cfg.publishers[p.prefix] = user_pub
 
-        def __publisher_values(self):
-                """Support values() on publishers"""
-                return list(self.__publishers.values())
+        # Write out the image configuration.
+        self.img_cfg.write()
 
-        # properties so we can enforce rules and manage two potentially
-        # overlapping sets of publishers
-        publishers = DictProperty(__get_publisher, __set_publisher,
-            __del_publisher, __publisher_iteritems, __publisher_keys,
-            __publisher_values, __publisher_iter,
-            doc="A dict mapping publisher prefixes to publisher objects")
+    def allowed_to_move(self, pub):
+        """Return whether a publisher is allowed to move in the search
+        order."""
+
+        return not self.__is_sys_pub(pub)
+
+    def add_property_value(self, *args, **kwargs):
+        return self.img_cfg.add_property_value(*args, **kwargs)
+
+    def remove_property_value(self, *args, **kwargs):
+        return self.img_cfg.remove_property_value(*args, **kwargs)
+
+    def get_index(self):
+        return self.img_cfg.get_index()
+
+    def get_policy(self, *args, **kwargs):
+        return self.img_cfg.get_policy(*args, **kwargs)
+
+    def get_policy_str(self, *args, **kwargs):
+        return self.img_cfg.get_policy_str(*args, **kwargs)
+
+    def get_property(self, section, name):
+        # If the property being retrieved is the publisher search order,
+        # it's necessary to merge the information from the image
+        # configuration and the system configuration.
+        if section == "property" and name == "publisher-search-order":
+            res = self.sys_cfg.get_property(section, name)
+            enabled_sys_pubs = [
+                p for p in res if not self.sys_cfg.publishers[p].disabled
+            ]
+            img_pubs = [
+                s
+                for s in self.img_cfg.get_property(section, name)
+                if s not in enabled_sys_pubs
+            ]
+            disabled_sys_pubs = [
+                p
+                for p in res
+                if self.sys_cfg.publishers[p].disabled and p not in img_pubs
+            ]
+            return enabled_sys_pubs + img_pubs + disabled_sys_pubs
+        if section == "property" and name in self.__system_override_properties:
+            return self.sys_cfg.get_property(section, name)
+        return self.img_cfg.get_property(section, name)
+
+    def remove_property(self, *args, **kwargs):
+        return self.img_cfg.remove_property(*args, **kwargs)
+
+    def set_property(self, *args, **kwargs):
+        return self.img_cfg.set_property(*args, **kwargs)
+
+    def set_properties(self, *args, **kwargs):
+        return self.img_cfg.set_properties(*args, **kwargs)
+
+    @property
+    def target(self):
+        return self.img_cfg.target
+
+    @property
+    def variants(self):
+        return self.img_cfg.variants
+
+    def __get_mediators(self):
+        return self.img_cfg.mediators
+
+    def __set_mediators(self, mediators):
+        self.img_cfg.mediators = mediators
+
+    mediators = property(__get_mediators, __set_mediators)
+
+    def __get_facets(self):
+        return self.img_cfg.facets
+
+    def __set_facets(self, facets):
+        self.img_cfg.facets = facets
+
+    facets = property(__get_facets, __set_facets)
+
+    def __get_linked_children(self):
+        return self.img_cfg.linked_children
+
+    def __set_linked_children(self, linked_children):
+        self.img_cfg.linked_children = linked_children
+
+    linked_children = property(__get_linked_children, __set_linked_children)
+
+    def __is_sys_pub(self, prefix):
+        """Return whether the publisher with the prefix 'prefix' is a
+        system publisher."""
+
+        return prefix in self.sys_cfg.publishers
+
+    def remove_publisher(self, prefix):
+        try:
+            del self.publishers[prefix]
+        except KeyError:
+            pass
+
+    def change_publisher_search_order(self, being_moved, staying_put, after):
+        """Change the publisher search order by moving the publisher
+        'being_moved' relative to the publisher 'staying put.'  The
+        boolean 'after' determines whether 'being_moved' is placed before
+        or after 'staying_put'."""
+
+        if being_moved == staying_put:
+            raise apx.MoveRelativeToSelf()
+
+        if self.__is_sys_pub(being_moved):
+            raise apx.ModifyingSyspubException(
+                _(
+                    "Publisher '{0}' "
+                    "is a system publisher and cannot be moved."
+                ).format(being_moved)
+            )
+        if self.__is_sys_pub(staying_put):
+            raise apx.ModifyingSyspubException(
+                _(
+                    "Publisher '{0}' "
+                    "is a system publisher and other publishers cannot "
+                    "be moved relative to it."
+                ).format(staying_put)
+            )
+        self.img_cfg.change_publisher_search_order(
+            being_moved, staying_put, after
+        )
+
+    def reset(self, overrides=misc.EmptyDict):
+        """Discards current configuration state and returns the
+        configuration object to its initial state.
+
+        'overrides' is an optional dictionary of property values indexed
+        by section name and property name.  If provided, it will be used
+        to override any default values initially assigned during reset.
+        """
+
+        self.img_cfg.reset(overrides)
+        self.sys_cfg.reset()
+        old_sysconfig = ImageConfig(os.path.join(imgdir, "pkg5.syspub"), None)
+        (
+            self.__publishers,
+            self.added_pubs,
+            self.removed_pubs,
+            self.modified_pubs,
+        ) = self.__merge_publishers(
+            self.img_cfg, self.sys_cfg, self.__pkg_counts, old_sysconfig
+        )
+
+    def __get_publisher(self, prefix):
+        """Accessor method for publishers dictionary"""
+        return self.__publishers[prefix]
+
+    def __set_publisher(self, prefix, pubobj):
+        """Accessor method to keep search order correct on insert"""
+        pval = self.get_property("property", "publisher-search-order")
+        if prefix not in pval:
+            self.add_property_value(
+                "property", "publisher-search-order", prefix
+            )
+        self.__publishers[prefix] = pubobj
+
+    def __del_publisher(self, prefix):
+        """Accessor method for publishers"""
+        if self.__is_sys_pub(prefix):
+            raise apx.ModifyingSyspubException(
+                _("{0} is a system " "publisher and cannot be unset.").format(
+                    prefix
+                )
+            )
+
+        del self.img_cfg.publishers[prefix]
+        del self.__publishers[prefix]
+
+    def __publisher_iter(self):
+        return self.__publishers.__iter__()
+
+    def __publisher_iteritems(self):
+        """Support iteritems on publishers"""
+        return six.iteritems(self.__publishers)
+
+    def __publisher_keys(self):
+        """Support keys() on publishers"""
+        return list(self.__publishers.keys())
+
+    def __publisher_values(self):
+        """Support values() on publishers"""
+        return list(self.__publishers.values())
+
+    # properties so we can enforce rules and manage two potentially
+    # overlapping sets of publishers
+    publishers = DictProperty(
+        __get_publisher,
+        __set_publisher,
+        __del_publisher,
+        __publisher_iteritems,
+        __publisher_keys,
+        __publisher_values,
+        __publisher_iter,
+        doc="A dict mapping publisher prefixes to publisher objects",
+    )
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/imageplan.py
+++ b/src/modules/client/imageplan.py
@@ -48,6 +48,7 @@ import re as relib
 from functools import cmp_to_key, reduce
 
 from pkg.client import global_settings
+
 logger = global_settings.logger
 
 import pkg.actions
@@ -74,6488 +75,6886 @@ import pkg.version
 from pkg.client.debugvalues import DebugValues
 from pkg.client.plandesc import _ActionPlan
 from pkg.mediator import mediator_impl_matches
-from pkg.client.pkgdefs import (PKG_OP_DEHYDRATE, PKG_OP_REHYDRATE, MSG_ERROR,
-    MSG_WARNING, MSG_INFO, MSG_GENERAL, MSG_UNPACKAGED, PKG_OP_VERIFY)
+from pkg.client.pkgdefs import (
+    PKG_OP_DEHYDRATE,
+    PKG_OP_REHYDRATE,
+    MSG_ERROR,
+    MSG_WARNING,
+    MSG_INFO,
+    MSG_GENERAL,
+    MSG_UNPACKAGED,
+    PKG_OP_VERIFY,
+)
 
 
 def _reorder_hardlinks(hardlinks):
-        """Re-order the list of hardlinks to handle hard links whose
-        target is another hard link."""
+    """Re-order the list of hardlinks to handle hard links whose
+    target is another hard link."""
 
-        reordered = []
+    reordered = []
 
-        # Capture the paths for all given hardlinks.
-        paths = [hardlink.dst.attrs["path"] for hardlink in hardlinks]
+    # Capture the paths for all given hardlinks.
+    paths = [hardlink.dst.attrs["path"] for hardlink in hardlinks]
 
-        def add_targets(path, hardlinks, reordered):
-                """Find those hardlinks whose target is path."""
+    def add_targets(path, hardlinks, reordered):
+        """Find those hardlinks whose target is path."""
 
-                srcs = [l for l in hardlinks
-                    if l.dst.get_target_path() == path]
-                for hardlink in srcs:
-                        hardlinks.remove(hardlink)
-                        reordered.append(hardlink)
-                        # ... process hardlinks whose dst is _this_ hardlink.
-                        add_targets(hardlink.dst.attrs["path"], hardlinks,
-                            reordered)
+        srcs = [l for l in hardlinks if l.dst.get_target_path() == path]
+        for hardlink in srcs:
+            hardlinks.remove(hardlink)
+            reordered.append(hardlink)
+            # ... process hardlinks whose dst is _this_ hardlink.
+            add_targets(hardlink.dst.attrs["path"], hardlinks, reordered)
 
-        # Find hardlinks whose dst is _not_ another hardlink.
-        unchained = [l for l in hardlinks
-            if l.dst.get_target_path() not in paths]
-        for hardlink in unchained:
-                hardlinks.remove(hardlink)
-                reordered.append(hardlink)
-                # ... process hardlinks whose target is _this_ hardlink.
-                add_targets(hardlink.dst.attrs["path"], hardlinks,
-                    reordered)
+    # Find hardlinks whose dst is _not_ another hardlink.
+    unchained = [l for l in hardlinks if l.dst.get_target_path() not in paths]
+    for hardlink in unchained:
+        hardlinks.remove(hardlink)
+        reordered.append(hardlink)
+        # ... process hardlinks whose target is _this_ hardlink.
+        add_targets(hardlink.dst.attrs["path"], hardlinks, reordered)
 
-        # Append remaining hardlinks (likely circular or otherwise broken).
-        reordered.extend(hardlinks)
+    # Append remaining hardlinks (likely circular or otherwise broken).
+    reordered.extend(hardlinks)
 
-        return reordered
+    return reordered
 
 
 class ImagePlan(object):
-        """ImagePlan object contains the plan for changing the image...
-        there are separate routines for planning the various types of
-        image modifying operations; evaluation (comparing manifests
-        and building lists of removal, install and update actions
-        and their execution is all common code"""
-
-        MATCH_ALL           = 0
-        MATCH_INST_VERSIONS = 1
-        MATCH_INST_STEMS    = 2
-        MATCH_UNINSTALLED   = 3
-
-        def __init__(self, image, op, progtrack, check_cancel, noexecute=False,
-            pd=None):
-
-                self.image = image
-                self.__progtrack = progtrack
-                self.__check_cancel = check_cancel
-                self.__noexecute = noexecute
-
-                # The set of processed target object directories known to be
-                # valid (those that are not symlinks and thus are valid for
-                # use during installation).  This is used by the pkg.actions
-                # classes during install() operations.
-                self.valid_directories = set()
-
-                # A place to keep info about saved_files; needed by file action.
-                self.saved_files = {}
-
-                self.__target_install_count = 0
-                self.__target_update_count  = 0
-                self.__target_removal_count = 0
-
-                self.__directories = None # implement ref counting
-                self.__symlinks = None    # for dirs and links and
-                self.__hardlinks = None   # hardlinks
-                self.__exclude_re = None
-                self.__licenses = None
-                self.__legacy = None
-                self.__cached_actions = {}
-                self.__fixups = {}
-                self.operations_pubs = None # pubs being operated in hydrate
-
-                self.invalid_meds = defaultdict(set) # targetless mediated links
-                self.__old_excludes = image.list_excludes()
-                self.__new_excludes = self.__old_excludes
-
-                self.__preexecuted_indexing_error = None
-                self.__match_inst = {} # dict of fmri -> pattern
-                self.__match_rm = {} # dict of fmri -> pattern
-                self.__match_update = {} # dict of fmri -> pattern
-
-                self.__pkg_actuators = set()
-                self._retrieved = set()
-
-                self.pd = None
-                if pd is None:
-                        pd = plandesc.PlanDescription(op)
-                assert(pd._op == op)
-                self.__setup_plan(pd)
-
-        def __str__(self):
-
-                if self.pd.state == plandesc.UNEVALUATED:
-                        s = "UNEVALUATED:\n"
-                        return s
-
-                s = "{0}\n".format(self.pd._solver_summary)
-
-                if self.pd.state < plandesc.EVALUATED_PKGS:
-                        return s
-
-                s += "Package version changes:\n"
-
-                for oldfmri, newfmri in self.pd._fmri_changes:
-                        s += "{0} -> {1}\n".format(oldfmri, newfmri)
-
-                if self.pd._actuators:
-                        s = s + "\nActuators:\n{0}\n".format(self.pd._actuators)
-
-                if self.__old_excludes != self.__new_excludes:
-                        s += "\nVariants/Facet changes:\n {0}".format(
-                            "\n".join(self.pd.get_varcets()))
-
-                if self.pd._mediators_change:
-                        s = s + "\nMediator changes:\n {0}".format(
-                            "\n".join(self.pd.get_mediators()))
-
-                return s
-
-        def __setup_plan(self, plan):
-                assert plan.state in [
-                    plandesc.UNEVALUATED, plandesc.EVALUATED_PKGS,
-                    plandesc.EVALUATED_OK]
-
-                self.pd = plan
-                self.__update_avail_space()
-
-                # make sure we init this even if we don't call solver
-                self.pd._new_avoid_obs = (self.image.avoid_set_get(),
-                    self.image.avoid_set_get(implicit=True),
-                    self.image.obsolete_set_get())
-
-                if self.pd.state == plandesc.UNEVALUATED:
-                        self.image.linked.init_plan(plan)
-                        return
-
-                # figure out excludes
-                self.__new_excludes = self.image.list_excludes(
-                    self.pd._new_variants, self.pd._new_facets)
-
-                # tell the linked image subsystem about this plan
-                self.image.linked.setup_plan(plan)
-
-                for pp in self.pd.pkg_plans:
-                        pp.image = self.image
-                        if pp.origin_fmri and pp.destination_fmri:
-                                self.__target_update_count += 1
-                        elif pp.destination_fmri:
-                                self.__target_install_count += 1
-                        elif pp.origin_fmri:
-                                self.__target_removal_count += 1
-
-        def skip_preexecute(self):
-                assert self.pd.state in \
-                    [plandesc.PREEXECUTED_OK, plandesc.EVALUATED_OK], \
-                    "{0} not in [{1}, {2}]".format(self.pd.state,
-                    plandesc.PREEXECUTED_OK, plandesc.EVALUATED_OK)
-
-                if self.pd.state == plandesc.PREEXECUTED_OK:
-                        # can't skip preexecute since we already preexecuted it
-                        return
-
-                if self.image.version != self.image.CURRENT_VERSION:
-                        # Prevent plan execution if image format isn't current.
-                        raise api_errors.ImageFormatUpdateNeeded(
-                            self.image.root)
-
-                if self.image.transport:
-                        self.image.transport.shutdown()
-
-                self.pd.state = plandesc.PREEXECUTED_OK
-
-        @property
-        def state(self):
-                return self.pd.state
-
-        @property
-        def planned_op(self):
-                """Returns a constant value indicating the type of operation
-                planned."""
-
-                return self.pd._op
-
-        @property
-        def plan_desc(self):
-                """Get the proposed fmri changes."""
-                return self.pd._fmri_changes
-
-        def describe(self):
-                """Return a pointer to the plan description."""
-                return self.pd
-
-        @property
-        def bytes_added(self):
-                """get the (approx) number of bytes added"""
-                return self.pd._bytes_added
-        @property
-        def cbytes_added(self):
-                """get the (approx) number of bytes needed in download cache"""
-                return self.pd._cbytes_added
-
-        @property
-        def bytes_avail(self):
-                """get the (approx) number of bytes space available"""
-                return self.pd._bytes_avail
-        @property
-        def cbytes_avail(self):
-                """get the (approx) number of download space available"""
-                return self.pd._cbytes_avail
-
-        def __finish_plan(self, pdstate, fmri_changes=None):
-                """Private helper function that must be called at the end of
-                every planning operation to ensure final plan state is set and
-                any general post-plan work is performed."""
-
-                pd = self.pd
-                pd.state = pdstate
-                if not fmri_changes is None:
-                        pd._fmri_changes = fmri_changes
-
-        def __vector_2_fmri_changes(self, installed_dict, vector,
-            li_pkg_updates=True, new_variants=None, new_facets=None,
-            fmri_changes=None):
-                """Given an installed set of packages, and a proposed vector
-                of package changes determine what, if any, changes should be
-                made to the image.  This takes into account different
-                behaviors during operations like variant changes, and updates
-                where the only packages being updated are linked image
-                constraints, etc."""
-
-                fmri_updates = []
-                if fmri_changes is not None:
-                        affected = [f[0] for f in fmri_changes]
-                else:
-                        affected = None
-
-                for a, b in ImagePlan.__dicts2fmrichanges(installed_dict,
-                    ImagePlan.__fmris2dict(vector)):
-                        if a != b:
-                                fmri_updates.append((a, b))
-                                continue
-
-                        if (new_facets is not None or new_variants):
-                                if affected is None or a in affected:
-                                        # If affected list of packages has not
-                                        # been predetermined for package fmris
-                                        # that are unchanged, or if the fmri
-                                        # exists in the list of affected
-                                        # packages, add it to the list.
-                                        fmri_updates.append((a, a))
-
-                # cache li_pkg_updates in the plan description for later
-                # evaluation
-                self.pd._li_pkg_updates = li_pkg_updates
-
-                return fmri_updates
-
-        def __plan_op(self):
-                """Private helper method used to mark the start of a planned
-                operation."""
-
-                self.pd._image_lm = self.image.get_last_modified(string=True)
-
-        def __merge_inherited_facets(self, new_facets=None):
-                """Merge any new facets settings with (possibly changing)
-                inherited facets."""
-
-                if new_facets is not None:
-                        # make sure we don't accidentally update the caller
-                        # supplied facets.
-                        new_facets = pkg.facet.Facets(new_facets)
-
-                        # we don't allow callers to specify inherited facets
-                        # (they can only come from parent images.)
-                        new_facets._clear_inherited()
-
-                # get the existing image facets.
-                old_facets = self.image.cfg.facets
-
-                if new_facets is None:
-                        # the user did not request any facet changes, but we
-                        # still need to see if inherited facets are changing.
-                        # so set new_facets to the existing facet set with
-                        # inherited facets removed.
-                        new_facets = pkg.facet.Facets(old_facets)
-                        new_facets._clear_inherited()
-
-                # get the latest inherited facets and merge them into the user
-                # specified facets.
-                new_facets.update(self.image.linked.inherited_facets())
-
-                if new_facets == old_facets:
-                        # there are no caller specified or inherited facet
-                        # changes.
-                        return (None, False, False)
-
-                facet_change = bool(old_facets._cmp_values(new_facets)) or \
-                    bool(old_facets._cmp_priority(new_facets))
-                masked_facet_change = bool(not facet_change) and \
-                    bool(old_facets._cmp_all_values(new_facets))
-
-                # Something better be changing.  But if visible facets are
-                # changing we don't report masked facet changes.
-                assert facet_change != masked_facet_change
-
-                return (new_facets, facet_change, masked_facet_change)
-
-        def __evaluate_excludes(self, new_variants=None, new_facets=None,
-            dehydrate=None, rehydrate=None):
-                """Private helper function used to determine new facet and
-                variant state for image."""
-
-                # merge caller supplied and inherited facets
-                new_facets, facet_change, masked_facet_change = \
-                    self.__merge_inherited_facets(new_facets)
-
-                # if we're changing variants or facets, save that to the plan.
-                if new_variants or facet_change or masked_facet_change:
-                        self.pd._varcets_change = True
-                        if new_variants:
-                                # This particular data are passed as unicode
-                                # instead of bytes in the child image due to the
-                                # jsonrpclib update, so we use force_str here to
-                                # reduce the pain in comparing json data type.
-                                self.pd._new_variants = {}
-                                for k, v in new_variants.items():
-                                        self.pd._new_variants[misc.force_str(k)] = \
-                                            misc.force_str(v)
-                        else:
-                                self.pd._new_variants = new_variants
-                        self.pd._old_facets   = self.image.cfg.facets
-                        self.pd._new_facets   = new_facets
-                        self.pd._facet_change = facet_change
-                        self.pd._masked_facet_change = masked_facet_change
-
-                self.__new_excludes = self.image.list_excludes(new_variants,
-                    new_facets)
-
-                # Previously dehydrated publishers.
-                old_dehydrated = set(self.image.cfg.get_property("property",
-                    "dehydrated"))
-
-                # We only want to exclude all actions in the old image that
-                # belong to an already dehydrated publisher.
-                if old_dehydrated:
-                        self.__old_excludes.append(
-                            self.image.get_dehydrated_exclude_func(
-                            old_dehydrated))
-
-                # Publishers to rehydrate
-                if rehydrate is None:
-                        rehydrate = set()
-                rehydrate = set(rehydrate)
-
-                # Publishers to dehydrate
-                if dehydrate is None:
-                        dehydrate = set()
-                dehydrate = set(dehydrate) | (old_dehydrated - rehydrate)
-
-                self.operations_pubs = sorted(dehydrate)
-                # Only allows actions in new image that cannot be dehydrated
-                # or that are in the dehydrate list and not in the rehydrate
-                # list.
-                if dehydrate:
-                        self.__new_excludes.append(
-                            self.image.get_dehydrated_exclude_func(dehydrate))
-
-                return (new_variants, new_facets, facet_change,
-                    masked_facet_change)
-
-        def __run_solver(self, solver_cb, retry_wo_parent_deps=True):
-                """Run the solver, and if it fails, optionally retry the
-                operation once while relaxing installed parent
-                dependencies."""
-
-                # have the solver try to satisfy parent dependencies.
-                ignore_inst_parent_deps = False
-
-                # In some error cases, significant recursion may be required,
-                # and the default (1000) is not enough.  In testing, this was
-                # found to be sufficient for the solver's needs.
-                prlimit = sys.getrecursionlimit()
-                if prlimit < 3000:
-                        sys.setrecursionlimit(3000)
-
-                try:
-                        return solver_cb(ignore_inst_parent_deps)
-                except api_errors.PlanCreationException as e:
-                        # if we're currently in sync don't retry the
-                        # operation
-                        if self.image.linked.insync(latest_md=False):
-                                raise e
-                        # if PKG_REQUIRE_SYNC is set in the
-                        # environment we require an in-sync image.
-                        if "PKG_REQUIRE_SYNC" in os.environ:
-                                raise e
-                        # caller doesn't want us to retry
-                        if not retry_wo_parent_deps:
-                                raise e
-                        # we're an out-of-sync child image so retry
-                        # this operation while ignoring parent
-                        # dependencies for any installed packages.  we
-                        # do this so that users can manipulate out of
-                        # sync images in an attempt to bring them back
-                        # in sync.  since we don't ignore parent
-                        # dependencies for uninstalled packages, the
-                        # user won't be able to take the image further
-                        # out of sync.
-                        ignore_inst_parent_deps = True
-                        return solver_cb(ignore_inst_parent_deps)
-                finally:
-                        # restore original recursion limit
-                        sys.setrecursionlimit(prlimit)
-
-        def __add_actuator(self, trigger_fmri, trigger_op, exec_op, values,
-            solver_inst, installed_dict):
-                """Add a single actuator to the solver 'solver_inst' and update
-                the plan. 'trigger_fmri' is pkg which triggered the operation
-                and is only used in the plan. 'trigger_op' is the name of the
-                operation which triggered the change, 'exec_op' is the name of
-                the operation which should be performed.
-                'values' contains the fmris of the pkgs which should get
-                changed."""
-
-                if not isinstance(values, list):
-                        values = [values]
-
-                pub_ranks = self.image.get_publisher_ranks()
-
-                matched_vals, unmatched = self.__match_user_fmris(
-                    self.image, values, self.MATCH_INST_STEMS,
-                    pub_ranks=pub_ranks, installed_pkgs=installed_dict,
-                    raise_not_installed=False,
-                    default_matcher=pkg.fmri.exact_name_match)
-
-                triggered_fmris = set()
-                for m in matched_vals.values():
-                        triggered_fmris |= set(m)
-
-                # Removals are done by stem so we have to make sure we only add
-                # removal FMRIs for versions which are actually installed. If
-                # the actuator specifies a version which is not installed, treat
-                # as nop.
-                # For updates, we have to remove versions which are already in
-                # the image because we don't want them in the proposed list for
-                # the solver. Otherwise we might trim on the installed version
-                # which prevents us from downgrading.
-                for t in triggered_fmris.copy():
-                        if (exec_op == pkgdefs.PKG_OP_UNINSTALL and
-                            t not in installed_dict.values()) or \
-                            (exec_op != pkgdefs.PKG_OP_UNINSTALL
-                            and t in installed_dict.values()):
-                                triggered_fmris.remove(t)
-                                continue
-                        self.__pkg_actuators.add((trigger_fmri, t.pkg_name,
-                            trigger_op, exec_op))
-
-                solver_inst.add_triggered_op(trigger_op, exec_op,
-                    triggered_fmris)
-
-
-        def __decode_pkg_actuator_attrs(self, action, op):
-                """Read and decode pkg actuator data from action 'action'."""
-
-                # we ignore any non-supported operations
-                supported_exec_ops = [pkgdefs.PKG_OP_UPDATE,
-                    pkgdefs.PKG_OP_UNINSTALL]
-
-                if not action.attrs["name"].startswith("pkg.additional-"):
-                        return
-
-                # e.g.: set name=pkg.additional-update-on-uninstall value=...
-                try:
-                        trigger_op = action.attrs["name"].split("-")[3]
-                        exec_op = action.attrs["name"].split("-")[1]
-                except KeyError:
-                        # Ignore invalid pkg actuators.
-                        return
-
-                if trigger_op != op or exec_op not in supported_exec_ops:
-                        # Ignore unsupported pkg actuators.
-                        return
-
-                for f in action.attrlist("value"):
-                        # Ignore values which are not valid FMRIs, we don't
-                        # support globbing here.
-                        try:
-                                pkg.fmri.PkgFmri(f)
-                        except pkg.fmri.IllegalFmri:
-                                continue
-                        yield (exec_op, f)
-
-        def __set_pkg_actuators(self, patterns, op, solver_inst):
-                """Check the manifests for the pkgs specified by 'patterns' and
-                add them to the solver instance specified by 'solver_inst'. 'op'
-                defines the trigger operation which called this function."""
-
-                trigger_entries = {}
-
-                ignore = DebugValues["ignore-pkg-actuators"]
-                if ignore and ignore.lower() == "true":
-                        return
-
-                # build installed dict
-                installed_dict = ImagePlan.__fmris2dict(
-                    self.image.gen_installed_pkgs())
-                pub_ranks = self.image.get_publisher_ranks()
-
-                # Match only on installed stems. This makes sure no new pkgs
-                # will get installed when an update is specified.  Note that
-                # this allows trailing matches (i.e. 'ambiguous') matches that
-                # may result in failure as the list of patterns are assumed to
-                # be from user input.
-                matched_vals, unmatched = self.__match_user_fmris(
-                    self.image, patterns, self.MATCH_INST_VERSIONS,
-                    pub_ranks=pub_ranks, installed_pkgs=installed_dict,
-                    raise_not_installed=False)
-
-                pfmris = set()
-                for m in matched_vals:
-                        pfmris |= set(matched_vals[m])
-
-                for f in pfmris:
-                        if not isinstance(f, pkg.fmri.PkgFmri):
-                                f = pkg.fmri.PkgFmri(f)
-                        for a in self.image.get_catalog(
-                            self.image.IMG_CATALOG_INSTALLED).get_entry_actions(
-                            f, [pkg.catalog.Catalog.SUMMARY]):
-                                for exec_op, efmri in \
-                                    self.__decode_pkg_actuator_attrs(a, op):
-                                        self.__add_actuator(f, op,
-                                            exec_op, efmri, solver_inst,
-                                            installed_dict)
-
-        def __add_pkg_actuators_to_pd(self, user_pkgs):
-                """ Add pkg actuators to PlanDescription. Skip any changes which
-                would have been triggered by an actuator but were also requested
-                explicitly by the user to avoid confusion. """
-
-                for (tf, p, t, e) in self.__pkg_actuators:
-                        for (before, after) in self.pd._fmri_changes:
-                                if (before and before.pkg_name == p or
-                                    after and after.pkg_name == p) and \
-                                    p not in user_pkgs:
-                                        self.pd.add_pkg_actuator(tf.pkg_name, e,
-                                            p)
-
-        def __plan_install_solver(self, li_pkg_updates=True, li_sync_op=False,
-            new_facets=None, new_variants=None, pkgs_inst=None,
-            reject_list=misc.EmptyI, fmri_changes=None, exact_install=False):
-                """Use the solver to determine the fmri changes needed to
-                install the specified pkgs, sync the specified image, and/or
-                change facets/variants within the current image."""
-
-                # evaluate what varcet changes are required
-                new_variants, new_facets, \
-                    facet_change, masked_facet_change = \
-                    self.__evaluate_excludes(new_variants, new_facets)
-
-                # check if we need to uninstall any packages.
-                uninstall = self.__any_reject_matches(reject_list)
-
-                # check if anything is actually changing.
-                if not (li_sync_op or pkgs_inst or uninstall or
-                    new_variants or facet_change or fmri_changes is not None):
-                        # the solver is not necessary.
-                        self.pd._fmri_changes = []
-                        return
-
-                # get ranking of publishers
-                pub_ranks = self.image.get_publisher_ranks()
-
-                # build installed dict
-                installed_dict = ImagePlan.__fmris2dict(
-                    self.image.gen_installed_pkgs())
-
-                if reject_list:
-                        reject_set = self.match_user_stems(self.image,
-                            reject_list, self.MATCH_ALL)
-                else:
-                        reject_set = set()
-
-                if pkgs_inst:
-                        inst_dict, references = self.__match_user_fmris(
-                            self.image, pkgs_inst, self.MATCH_ALL,
-                            pub_ranks=pub_ranks, installed_pkgs=installed_dict,
-                            reject_set=reject_set)
-                        self.__match_inst = references
-                else:
-                        inst_dict = {}
-
-                if new_variants:
-                        variants = new_variants
-                else:
-                        variants = self.image.get_variants()
-
-                installed_dict_tmp = {}
-                # If exact_install is on, clear the installed_dict.
-                if exact_install:
-                        installed_dict_tmp = installed_dict.copy()
-                        installed_dict = {}
-
-                def solver_cb(ignore_inst_parent_deps):
-                        avoid_set = self.image.avoid_set_get()
-                        frozen_list = self.image.get_frozen_list()
-                        # If exact_install is on, ignore avoid_set and
-                        # frozen_list.
-                        if exact_install:
-                                avoid_set = set()
-                                frozen_list = []
-
-                        # instantiate solver
-                        solver = pkg_solver.PkgSolver(
-                            self.image.get_catalog(
-                                self.image.IMG_CATALOG_KNOWN),
-                            installed_dict,
-                            pub_ranks,
-                            variants,
-                            avoid_set,
-                            self.image.linked.parent_fmris(),
-                            self.__progtrack)
-
-                        if reject_list:
-                                # use reject_list, not reject_set, to preserve
-                                # input intent (e.g. 'pkg:/', '/' prefixes).
-                                self.__set_pkg_actuators(reject_list,
-                                    pkgdefs.PKG_OP_UNINSTALL, solver)
-
-                        # run solver
-                        new_vector, new_avoid_obs = \
-                            solver.solve_install(
-                                frozen_list,
-                                inst_dict,
-                                new_variants=new_variants,
-                                excludes=self.__new_excludes,
-                                reject_set=reject_set,
-                                trim_proposed_installed=False,
-                                relax_all=li_sync_op,
-                                ignore_inst_parent_deps=\
-                                    ignore_inst_parent_deps,
-                                exact_install=exact_install,
-                                installed_dict_tmp=installed_dict_tmp)
-
-                        return solver, new_vector, new_avoid_obs
-
-                # We can't retry this operation while ignoring parent
-                # dependencies if we're doing a linked image sync.
-                retry_wo_parent_deps = not li_sync_op
-
-                # Solve; will raise exceptions if no solution is found.
-                solver, new_vector, self.pd._new_avoid_obs = \
-                    self.__run_solver(solver_cb, \
-                        retry_wo_parent_deps=retry_wo_parent_deps)
-
-                # Restore the installed_dict for checking fmri changes.
-                if exact_install:
-                        installed_dict = installed_dict_tmp.copy()
-
-                self.pd._fmri_changes = self.__vector_2_fmri_changes(
-                    installed_dict, new_vector,
-                    li_pkg_updates=li_pkg_updates,
-                    new_variants=new_variants, new_facets=new_facets,
-                    fmri_changes=fmri_changes)
-
-                self.__add_pkg_actuators_to_pd(reject_set)
-
-                self.pd._solver_summary = str(solver)
-                if DebugValues["plan"]:
-                        self.pd._solver_errors = solver.get_trim_errors()
-
-        def __plan_install(self, li_pkg_updates=True, li_sync_op=False,
-            new_facets=None, new_variants=None, pkgs_inst=None,
-            reject_list=misc.EmptyI):
-                """Determine the fmri changes needed to install the specified
-                pkgs, sync the image, and/or change facets/variants within the
-                current image."""
-
-                self.__plan_op()
-                self.__plan_install_solver(
-                    li_pkg_updates=li_pkg_updates,
-                    li_sync_op=li_sync_op,
-                    new_facets=new_facets,
-                    new_variants=new_variants,
-                    pkgs_inst=pkgs_inst,
-                    reject_list=reject_list)
-                self.__finish_plan(plandesc.EVALUATED_PKGS)
-
-        def __plan_exact_install(self, li_pkg_updates=True, li_sync_op=False,
-            new_facets=None, new_variants=None, pkgs_inst=None,
-            reject_list=misc.EmptyI):
-                """Determine the fmri changes needed to install exactly the
-                specified pkgs, sync the image, and/or change facets/variants
-                within the current image."""
-
-                self.__plan_op()
-                self.__plan_install_solver(
-                    li_pkg_updates=li_pkg_updates,
-                    li_sync_op=li_sync_op,
-                    new_facets=new_facets,
-                    new_variants=new_variants,
-                    pkgs_inst=pkgs_inst,
-                    reject_list=reject_list,
-                    exact_install=True)
-                self.__finish_plan(plandesc.EVALUATED_PKGS)
-
-        def set_be_options(self, backup_be, backup_be_name, new_be,
-            be_activate, be_name):
-                self.pd._backup_be = backup_be
-                self.pd._backup_be_name = backup_be_name
-                self.pd._new_be = new_be
-                self.pd._be_activate = be_activate
-                self.pd._be_name = be_name
-
-        def __set_update_index(self, value):
-                self.pd._update_index = value
-
-        def __get_update_index(self):
-                return self.pd._update_index
-
-        update_index = property(__get_update_index, __set_update_index)
-
-        def plan_install(self, pkgs_inst=None, reject_list=misc.EmptyI):
-                """Determine the fmri changes needed to install the specified
-                pkgs"""
-
-                self.__plan_install(pkgs_inst=pkgs_inst,
-                     reject_list=reject_list)
-
-        def plan_exact_install(self, pkgs_inst=None, reject_list=misc.EmptyI):
-                """Determine the fmri changes needed to install exactly the
-                specified pkgs"""
-
-                self.__plan_exact_install(pkgs_inst=pkgs_inst,
-                     reject_list=reject_list)
-
-        def __get_attr_fmri_changes(self, get_mattrs):
-                # Attempt to optimize package planning by determining which
-                # packages are actually affected by changing attributes (e.g.,
-                # facets, variants).  This also provides an accurate list of
-                # affected packages as a side effect (normally, all installed
-                # packages are seen as changed).  This assumes that facets and
-                # variants are not both changing at the same time.
-                use_solver = False
-                cat = self.image.get_catalog(
-                    self.image.IMG_CATALOG_INSTALLED)
-                cat_info = frozenset([cat.DEPENDENCY])
-
-                fmri_changes = []
-                pt = self.__progtrack
-                rem_pkgs = self.image.count_installed_pkgs()
-
-                pt.plan_start(pt.PLAN_PKGPLAN, goal=rem_pkgs)
-                for f in self.image.gen_installed_pkgs():
-                        m = self.image.get_manifest(f,
-                            ignore_excludes=True)
-
-                        # Get the list of attributes involved in this operation
-                        # that the package uses and that have changed.
-                        use_solver, mattrs = get_mattrs(m, use_solver)
-                        if not mattrs:
-                                # Changed attributes unused.
-                                pt.plan_add_progress(pt.PLAN_PKGPLAN)
-                                rem_pkgs -= 1
-                                continue
-
-                        # Changed attributes are used in this package.
-                        fmri_changes.append((f, f))
-
-                        # If any dependency actions are tagged with one
-                        # of the changed attributes, assume the solver
-                        # must be used.
-                        for act in cat.get_entry_actions(f, cat_info):
-                                for attr in mattrs:
-                                        if use_solver:
-                                                break
-                                        if (act.name == "depend" and
-                                            attr in act.attrs):
-                                                use_solver = True
-                                                break
-                                if use_solver:
-                                        break
-
-                        rem_pkgs -= 1
-                        pt.plan_add_progress(pt.PLAN_PKGPLAN)
-
-                pt.plan_done(pt.PLAN_PKGPLAN)
-                pt.plan_all_done()
-
-                return use_solver, fmri_changes
-
-        def __facet_change_fastpath(self):
-                """The following optimizations only work correctly if only
-                facets are changing (not variants, uninstalls, etc)."""
-
-                old_facets = self.pd._old_facets
-                new_facets = self.pd._new_facets
-
-                # List of changed facets are those that have a new value,
-                # and those that have been removed.
-                changed_facets = [
-                        f
-                        for f in new_facets
-                        if f not in old_facets or \
-                            old_facets[f] != new_facets[f]
-                ]
-                changed_facets.extend(
-                        f
-                        for f in old_facets
-                        if f not in new_facets
+    """ImagePlan object contains the plan for changing the image...
+    there are separate routines for planning the various types of
+    image modifying operations; evaluation (comparing manifests
+    and building lists of removal, install and update actions
+    and their execution is all common code"""
+
+    MATCH_ALL = 0
+    MATCH_INST_VERSIONS = 1
+    MATCH_INST_STEMS = 2
+    MATCH_UNINSTALLED = 3
+
+    def __init__(
+        self, image, op, progtrack, check_cancel, noexecute=False, pd=None
+    ):
+        self.image = image
+        self.__progtrack = progtrack
+        self.__check_cancel = check_cancel
+        self.__noexecute = noexecute
+
+        # The set of processed target object directories known to be
+        # valid (those that are not symlinks and thus are valid for
+        # use during installation).  This is used by the pkg.actions
+        # classes during install() operations.
+        self.valid_directories = set()
+
+        # A place to keep info about saved_files; needed by file action.
+        self.saved_files = {}
+
+        self.__target_install_count = 0
+        self.__target_update_count = 0
+        self.__target_removal_count = 0
+
+        self.__directories = None  # implement ref counting
+        self.__symlinks = None  # for dirs and links and
+        self.__hardlinks = None  # hardlinks
+        self.__exclude_re = None
+        self.__licenses = None
+        self.__legacy = None
+        self.__cached_actions = {}
+        self.__fixups = {}
+        self.operations_pubs = None  # pubs being operated in hydrate
+
+        self.invalid_meds = defaultdict(set)  # targetless mediated links
+        self.__old_excludes = image.list_excludes()
+        self.__new_excludes = self.__old_excludes
+
+        self.__preexecuted_indexing_error = None
+        self.__match_inst = {}  # dict of fmri -> pattern
+        self.__match_rm = {}  # dict of fmri -> pattern
+        self.__match_update = {}  # dict of fmri -> pattern
+
+        self.__pkg_actuators = set()
+        self._retrieved = set()
+
+        self.pd = None
+        if pd is None:
+            pd = plandesc.PlanDescription(op)
+        assert pd._op == op
+        self.__setup_plan(pd)
+
+    def __str__(self):
+        if self.pd.state == plandesc.UNEVALUATED:
+            s = "UNEVALUATED:\n"
+            return s
+
+        s = "{0}\n".format(self.pd._solver_summary)
+
+        if self.pd.state < plandesc.EVALUATED_PKGS:
+            return s
+
+        s += "Package version changes:\n"
+
+        for oldfmri, newfmri in self.pd._fmri_changes:
+            s += "{0} -> {1}\n".format(oldfmri, newfmri)
+
+        if self.pd._actuators:
+            s = s + "\nActuators:\n{0}\n".format(self.pd._actuators)
+
+        if self.__old_excludes != self.__new_excludes:
+            s += "\nVariants/Facet changes:\n {0}".format(
+                "\n".join(self.pd.get_varcets())
+            )
+
+        if self.pd._mediators_change:
+            s = s + "\nMediator changes:\n {0}".format(
+                "\n".join(self.pd.get_mediators())
+            )
+
+        return s
+
+    def __setup_plan(self, plan):
+        assert plan.state in [
+            plandesc.UNEVALUATED,
+            plandesc.EVALUATED_PKGS,
+            plandesc.EVALUATED_OK,
+        ]
+
+        self.pd = plan
+        self.__update_avail_space()
+
+        # make sure we init this even if we don't call solver
+        self.pd._new_avoid_obs = (
+            self.image.avoid_set_get(),
+            self.image.avoid_set_get(implicit=True),
+            self.image.obsolete_set_get(),
+        )
+
+        if self.pd.state == plandesc.UNEVALUATED:
+            self.image.linked.init_plan(plan)
+            return
+
+        # figure out excludes
+        self.__new_excludes = self.image.list_excludes(
+            self.pd._new_variants, self.pd._new_facets
+        )
+
+        # tell the linked image subsystem about this plan
+        self.image.linked.setup_plan(plan)
+
+        for pp in self.pd.pkg_plans:
+            pp.image = self.image
+            if pp.origin_fmri and pp.destination_fmri:
+                self.__target_update_count += 1
+            elif pp.destination_fmri:
+                self.__target_install_count += 1
+            elif pp.origin_fmri:
+                self.__target_removal_count += 1
+
+    def skip_preexecute(self):
+        assert self.pd.state in [
+            plandesc.PREEXECUTED_OK,
+            plandesc.EVALUATED_OK,
+        ], "{0} not in [{1}, {2}]".format(
+            self.pd.state, plandesc.PREEXECUTED_OK, plandesc.EVALUATED_OK
+        )
+
+        if self.pd.state == plandesc.PREEXECUTED_OK:
+            # can't skip preexecute since we already preexecuted it
+            return
+
+        if self.image.version != self.image.CURRENT_VERSION:
+            # Prevent plan execution if image format isn't current.
+            raise api_errors.ImageFormatUpdateNeeded(self.image.root)
+
+        if self.image.transport:
+            self.image.transport.shutdown()
+
+        self.pd.state = plandesc.PREEXECUTED_OK
+
+    @property
+    def state(self):
+        return self.pd.state
+
+    @property
+    def planned_op(self):
+        """Returns a constant value indicating the type of operation
+        planned."""
+
+        return self.pd._op
+
+    @property
+    def plan_desc(self):
+        """Get the proposed fmri changes."""
+        return self.pd._fmri_changes
+
+    def describe(self):
+        """Return a pointer to the plan description."""
+        return self.pd
+
+    @property
+    def bytes_added(self):
+        """get the (approx) number of bytes added"""
+        return self.pd._bytes_added
+
+    @property
+    def cbytes_added(self):
+        """get the (approx) number of bytes needed in download cache"""
+        return self.pd._cbytes_added
+
+    @property
+    def bytes_avail(self):
+        """get the (approx) number of bytes space available"""
+        return self.pd._bytes_avail
+
+    @property
+    def cbytes_avail(self):
+        """get the (approx) number of download space available"""
+        return self.pd._cbytes_avail
+
+    def __finish_plan(self, pdstate, fmri_changes=None):
+        """Private helper function that must be called at the end of
+        every planning operation to ensure final plan state is set and
+        any general post-plan work is performed."""
+
+        pd = self.pd
+        pd.state = pdstate
+        if not fmri_changes is None:
+            pd._fmri_changes = fmri_changes
+
+    def __vector_2_fmri_changes(
+        self,
+        installed_dict,
+        vector,
+        li_pkg_updates=True,
+        new_variants=None,
+        new_facets=None,
+        fmri_changes=None,
+    ):
+        """Given an installed set of packages, and a proposed vector
+        of package changes determine what, if any, changes should be
+        made to the image.  This takes into account different
+        behaviors during operations like variant changes, and updates
+        where the only packages being updated are linked image
+        constraints, etc."""
+
+        fmri_updates = []
+        if fmri_changes is not None:
+            affected = [f[0] for f in fmri_changes]
+        else:
+            affected = None
+
+        for a, b in ImagePlan.__dicts2fmrichanges(
+            installed_dict, ImagePlan.__fmris2dict(vector)
+        ):
+            if a != b:
+                fmri_updates.append((a, b))
+                continue
+
+            if new_facets is not None or new_variants:
+                if affected is None or a in affected:
+                    # If affected list of packages has not
+                    # been predetermined for package fmris
+                    # that are unchanged, or if the fmri
+                    # exists in the list of affected
+                    # packages, add it to the list.
+                    fmri_updates.append((a, a))
+
+        # cache li_pkg_updates in the plan description for later
+        # evaluation
+        self.pd._li_pkg_updates = li_pkg_updates
+
+        return fmri_updates
+
+    def __plan_op(self):
+        """Private helper method used to mark the start of a planned
+        operation."""
+
+        self.pd._image_lm = self.image.get_last_modified(string=True)
+
+    def __merge_inherited_facets(self, new_facets=None):
+        """Merge any new facets settings with (possibly changing)
+        inherited facets."""
+
+        if new_facets is not None:
+            # make sure we don't accidentally update the caller
+            # supplied facets.
+            new_facets = pkg.facet.Facets(new_facets)
+
+            # we don't allow callers to specify inherited facets
+            # (they can only come from parent images.)
+            new_facets._clear_inherited()
+
+        # get the existing image facets.
+        old_facets = self.image.cfg.facets
+
+        if new_facets is None:
+            # the user did not request any facet changes, but we
+            # still need to see if inherited facets are changing.
+            # so set new_facets to the existing facet set with
+            # inherited facets removed.
+            new_facets = pkg.facet.Facets(old_facets)
+            new_facets._clear_inherited()
+
+        # get the latest inherited facets and merge them into the user
+        # specified facets.
+        new_facets.update(self.image.linked.inherited_facets())
+
+        if new_facets == old_facets:
+            # there are no caller specified or inherited facet
+            # changes.
+            return (None, False, False)
+
+        facet_change = bool(old_facets._cmp_values(new_facets)) or bool(
+            old_facets._cmp_priority(new_facets)
+        )
+        masked_facet_change = bool(not facet_change) and bool(
+            old_facets._cmp_all_values(new_facets)
+        )
+
+        # Something better be changing.  But if visible facets are
+        # changing we don't report masked facet changes.
+        assert facet_change != masked_facet_change
+
+        return (new_facets, facet_change, masked_facet_change)
+
+    def __evaluate_excludes(
+        self, new_variants=None, new_facets=None, dehydrate=None, rehydrate=None
+    ):
+        """Private helper function used to determine new facet and
+        variant state for image."""
+
+        # merge caller supplied and inherited facets
+        (
+            new_facets,
+            facet_change,
+            masked_facet_change,
+        ) = self.__merge_inherited_facets(new_facets)
+
+        # if we're changing variants or facets, save that to the plan.
+        if new_variants or facet_change or masked_facet_change:
+            self.pd._varcets_change = True
+            if new_variants:
+                # This particular data are passed as unicode
+                # instead of bytes in the child image due to the
+                # jsonrpclib update, so we use force_str here to
+                # reduce the pain in comparing json data type.
+                self.pd._new_variants = {}
+                for k, v in new_variants.items():
+                    self.pd._new_variants[misc.force_str(k)] = misc.force_str(v)
+            else:
+                self.pd._new_variants = new_variants
+            self.pd._old_facets = self.image.cfg.facets
+            self.pd._new_facets = new_facets
+            self.pd._facet_change = facet_change
+            self.pd._masked_facet_change = masked_facet_change
+
+        self.__new_excludes = self.image.list_excludes(new_variants, new_facets)
+
+        # Previously dehydrated publishers.
+        old_dehydrated = set(
+            self.image.cfg.get_property("property", "dehydrated")
+        )
+
+        # We only want to exclude all actions in the old image that
+        # belong to an already dehydrated publisher.
+        if old_dehydrated:
+            self.__old_excludes.append(
+                self.image.get_dehydrated_exclude_func(old_dehydrated)
+            )
+
+        # Publishers to rehydrate
+        if rehydrate is None:
+            rehydrate = set()
+        rehydrate = set(rehydrate)
+
+        # Publishers to dehydrate
+        if dehydrate is None:
+            dehydrate = set()
+        dehydrate = set(dehydrate) | (old_dehydrated - rehydrate)
+
+        self.operations_pubs = sorted(dehydrate)
+        # Only allows actions in new image that cannot be dehydrated
+        # or that are in the dehydrate list and not in the rehydrate
+        # list.
+        if dehydrate:
+            self.__new_excludes.append(
+                self.image.get_dehydrated_exclude_func(dehydrate)
+            )
+
+        return (new_variants, new_facets, facet_change, masked_facet_change)
+
+    def __run_solver(self, solver_cb, retry_wo_parent_deps=True):
+        """Run the solver, and if it fails, optionally retry the
+        operation once while relaxing installed parent
+        dependencies."""
+
+        # have the solver try to satisfy parent dependencies.
+        ignore_inst_parent_deps = False
+
+        # In some error cases, significant recursion may be required,
+        # and the default (1000) is not enough.  In testing, this was
+        # found to be sufficient for the solver's needs.
+        prlimit = sys.getrecursionlimit()
+        if prlimit < 3000:
+            sys.setrecursionlimit(3000)
+
+        try:
+            return solver_cb(ignore_inst_parent_deps)
+        except api_errors.PlanCreationException as e:
+            # if we're currently in sync don't retry the
+            # operation
+            if self.image.linked.insync(latest_md=False):
+                raise e
+            # if PKG_REQUIRE_SYNC is set in the
+            # environment we require an in-sync image.
+            if "PKG_REQUIRE_SYNC" in os.environ:
+                raise e
+            # caller doesn't want us to retry
+            if not retry_wo_parent_deps:
+                raise e
+            # we're an out-of-sync child image so retry
+            # this operation while ignoring parent
+            # dependencies for any installed packages.  we
+            # do this so that users can manipulate out of
+            # sync images in an attempt to bring them back
+            # in sync.  since we don't ignore parent
+            # dependencies for uninstalled packages, the
+            # user won't be able to take the image further
+            # out of sync.
+            ignore_inst_parent_deps = True
+            return solver_cb(ignore_inst_parent_deps)
+        finally:
+            # restore original recursion limit
+            sys.setrecursionlimit(prlimit)
+
+    def __add_actuator(
+        self,
+        trigger_fmri,
+        trigger_op,
+        exec_op,
+        values,
+        solver_inst,
+        installed_dict,
+    ):
+        """Add a single actuator to the solver 'solver_inst' and update
+        the plan. 'trigger_fmri' is pkg which triggered the operation
+        and is only used in the plan. 'trigger_op' is the name of the
+        operation which triggered the change, 'exec_op' is the name of
+        the operation which should be performed.
+        'values' contains the fmris of the pkgs which should get
+        changed."""
+
+        if not isinstance(values, list):
+            values = [values]
+
+        pub_ranks = self.image.get_publisher_ranks()
+
+        matched_vals, unmatched = self.__match_user_fmris(
+            self.image,
+            values,
+            self.MATCH_INST_STEMS,
+            pub_ranks=pub_ranks,
+            installed_pkgs=installed_dict,
+            raise_not_installed=False,
+            default_matcher=pkg.fmri.exact_name_match,
+        )
+
+        triggered_fmris = set()
+        for m in matched_vals.values():
+            triggered_fmris |= set(m)
+
+        # Removals are done by stem so we have to make sure we only add
+        # removal FMRIs for versions which are actually installed. If
+        # the actuator specifies a version which is not installed, treat
+        # as nop.
+        # For updates, we have to remove versions which are already in
+        # the image because we don't want them in the proposed list for
+        # the solver. Otherwise we might trim on the installed version
+        # which prevents us from downgrading.
+        for t in triggered_fmris.copy():
+            if (
+                exec_op == pkgdefs.PKG_OP_UNINSTALL
+                and t not in installed_dict.values()
+            ) or (
+                exec_op != pkgdefs.PKG_OP_UNINSTALL
+                and t in installed_dict.values()
+            ):
+                triggered_fmris.remove(t)
+                continue
+            self.__pkg_actuators.add(
+                (trigger_fmri, t.pkg_name, trigger_op, exec_op)
+            )
+
+        solver_inst.add_triggered_op(trigger_op, exec_op, triggered_fmris)
+
+    def __decode_pkg_actuator_attrs(self, action, op):
+        """Read and decode pkg actuator data from action 'action'."""
+
+        # we ignore any non-supported operations
+        supported_exec_ops = [pkgdefs.PKG_OP_UPDATE, pkgdefs.PKG_OP_UNINSTALL]
+
+        if not action.attrs["name"].startswith("pkg.additional-"):
+            return
+
+        # e.g.: set name=pkg.additional-update-on-uninstall value=...
+        try:
+            trigger_op = action.attrs["name"].split("-")[3]
+            exec_op = action.attrs["name"].split("-")[1]
+        except KeyError:
+            # Ignore invalid pkg actuators.
+            return
+
+        if trigger_op != op or exec_op not in supported_exec_ops:
+            # Ignore unsupported pkg actuators.
+            return
+
+        for f in action.attrlist("value"):
+            # Ignore values which are not valid FMRIs, we don't
+            # support globbing here.
+            try:
+                pkg.fmri.PkgFmri(f)
+            except pkg.fmri.IllegalFmri:
+                continue
+            yield (exec_op, f)
+
+    def __set_pkg_actuators(self, patterns, op, solver_inst):
+        """Check the manifests for the pkgs specified by 'patterns' and
+        add them to the solver instance specified by 'solver_inst'. 'op'
+        defines the trigger operation which called this function."""
+
+        trigger_entries = {}
+
+        ignore = DebugValues["ignore-pkg-actuators"]
+        if ignore and ignore.lower() == "true":
+            return
+
+        # build installed dict
+        installed_dict = ImagePlan.__fmris2dict(self.image.gen_installed_pkgs())
+        pub_ranks = self.image.get_publisher_ranks()
+
+        # Match only on installed stems. This makes sure no new pkgs
+        # will get installed when an update is specified.  Note that
+        # this allows trailing matches (i.e. 'ambiguous') matches that
+        # may result in failure as the list of patterns are assumed to
+        # be from user input.
+        matched_vals, unmatched = self.__match_user_fmris(
+            self.image,
+            patterns,
+            self.MATCH_INST_VERSIONS,
+            pub_ranks=pub_ranks,
+            installed_pkgs=installed_dict,
+            raise_not_installed=False,
+        )
+
+        pfmris = set()
+        for m in matched_vals:
+            pfmris |= set(matched_vals[m])
+
+        for f in pfmris:
+            if not isinstance(f, pkg.fmri.PkgFmri):
+                f = pkg.fmri.PkgFmri(f)
+            for a in self.image.get_catalog(
+                self.image.IMG_CATALOG_INSTALLED
+            ).get_entry_actions(f, [pkg.catalog.Catalog.SUMMARY]):
+                for exec_op, efmri in self.__decode_pkg_actuator_attrs(a, op):
+                    self.__add_actuator(
+                        f, op, exec_op, efmri, solver_inst, installed_dict
+                    )
+
+    def __add_pkg_actuators_to_pd(self, user_pkgs):
+        """Add pkg actuators to PlanDescription. Skip any changes which
+        would have been triggered by an actuator but were also requested
+        explicitly by the user to avoid confusion."""
+
+        for tf, p, t, e in self.__pkg_actuators:
+            for before, after in self.pd._fmri_changes:
+                if (
+                    before
+                    and before.pkg_name == p
+                    or after
+                    and after.pkg_name == p
+                ) and p not in user_pkgs:
+                    self.pd.add_pkg_actuator(tf.pkg_name, e, p)
+
+    def __plan_install_solver(
+        self,
+        li_pkg_updates=True,
+        li_sync_op=False,
+        new_facets=None,
+        new_variants=None,
+        pkgs_inst=None,
+        reject_list=misc.EmptyI,
+        fmri_changes=None,
+        exact_install=False,
+    ):
+        """Use the solver to determine the fmri changes needed to
+        install the specified pkgs, sync the specified image, and/or
+        change facets/variants within the current image."""
+
+        # evaluate what varcet changes are required
+        (
+            new_variants,
+            new_facets,
+            facet_change,
+            masked_facet_change,
+        ) = self.__evaluate_excludes(new_variants, new_facets)
+
+        # check if we need to uninstall any packages.
+        uninstall = self.__any_reject_matches(reject_list)
+
+        # check if anything is actually changing.
+        if not (
+            li_sync_op
+            or pkgs_inst
+            or uninstall
+            or new_variants
+            or facet_change
+            or fmri_changes is not None
+        ):
+            # the solver is not necessary.
+            self.pd._fmri_changes = []
+            return
+
+        # get ranking of publishers
+        pub_ranks = self.image.get_publisher_ranks()
+
+        # build installed dict
+        installed_dict = ImagePlan.__fmris2dict(self.image.gen_installed_pkgs())
+
+        if reject_list:
+            reject_set = self.match_user_stems(
+                self.image, reject_list, self.MATCH_ALL
+            )
+        else:
+            reject_set = set()
+
+        if pkgs_inst:
+            inst_dict, references = self.__match_user_fmris(
+                self.image,
+                pkgs_inst,
+                self.MATCH_ALL,
+                pub_ranks=pub_ranks,
+                installed_pkgs=installed_dict,
+                reject_set=reject_set,
+            )
+            self.__match_inst = references
+        else:
+            inst_dict = {}
+
+        if new_variants:
+            variants = new_variants
+        else:
+            variants = self.image.get_variants()
+
+        installed_dict_tmp = {}
+        # If exact_install is on, clear the installed_dict.
+        if exact_install:
+            installed_dict_tmp = installed_dict.copy()
+            installed_dict = {}
+
+        def solver_cb(ignore_inst_parent_deps):
+            avoid_set = self.image.avoid_set_get()
+            frozen_list = self.image.get_frozen_list()
+            # If exact_install is on, ignore avoid_set and
+            # frozen_list.
+            if exact_install:
+                avoid_set = set()
+                frozen_list = []
+
+            # instantiate solver
+            solver = pkg_solver.PkgSolver(
+                self.image.get_catalog(self.image.IMG_CATALOG_KNOWN),
+                installed_dict,
+                pub_ranks,
+                variants,
+                avoid_set,
+                self.image.linked.parent_fmris(),
+                self.__progtrack,
+            )
+
+            if reject_list:
+                # use reject_list, not reject_set, to preserve
+                # input intent (e.g. 'pkg:/', '/' prefixes).
+                self.__set_pkg_actuators(
+                    reject_list, pkgdefs.PKG_OP_UNINSTALL, solver
                 )
 
-                def get_fattrs(m, use_solver):
-                        # Get the list of facets involved in this
-                        # operation that the package uses.  To
-                        # accurately determine which packages are
-                        # actually being changed, we must compare the
-                        # old effective value for each facet that is
-                        # changing with its new effective value.
-                        return use_solver, list(
-                            f
-                            for f in m.gen_facets(
-                                excludes=self.__new_excludes,
-                                patterns=changed_facets)
-                            if new_facets[f] != old_facets[f]
-                        )
+            # run solver
+            new_vector, new_avoid_obs = solver.solve_install(
+                frozen_list,
+                inst_dict,
+                new_variants=new_variants,
+                excludes=self.__new_excludes,
+                reject_set=reject_set,
+                trim_proposed_installed=False,
+                relax_all=li_sync_op,
+                ignore_inst_parent_deps=ignore_inst_parent_deps,
+                exact_install=exact_install,
+                installed_dict_tmp=installed_dict_tmp,
+            )
 
-                return self.__get_attr_fmri_changes(get_fattrs)
+            return solver, new_vector, new_avoid_obs
 
-        def __variant_change_fastpath(self):
-                """The following optimizations only work correctly if only
-                variants are changing (not facets, uninstalls, etc)."""
+        # We can't retry this operation while ignoring parent
+        # dependencies if we're doing a linked image sync.
+        retry_wo_parent_deps = not li_sync_op
 
-                nvariants = self.pd._new_variants
+        # Solve; will raise exceptions if no solution is found.
+        solver, new_vector, self.pd._new_avoid_obs = self.__run_solver(
+            solver_cb, retry_wo_parent_deps=retry_wo_parent_deps
+        )
 
-                def get_vattrs(m, use_solver):
-                        # Get the list of variants involved in this
-                        # operation that the package uses.
-                        mvars = []
-                        for (variant, pvals) in m.gen_variants(
-                            excludes=self.__new_excludes,
-                            patterns=nvariants
-                        ):
-                                if nvariants[variant] not in pvals:
-                                        # If the new value for the
-                                        # variant is unsupported by this
-                                        # package, then the solver
-                                        # should be triggered so the
-                                        # package can be removed.
-                                        use_solver = True
-                                mvars.append(variant)
-                        return use_solver, mvars
+        # Restore the installed_dict for checking fmri changes.
+        if exact_install:
+            installed_dict = installed_dict_tmp.copy()
 
-                return self.__get_attr_fmri_changes(get_vattrs)
+        self.pd._fmri_changes = self.__vector_2_fmri_changes(
+            installed_dict,
+            new_vector,
+            li_pkg_updates=li_pkg_updates,
+            new_variants=new_variants,
+            new_facets=new_facets,
+            fmri_changes=fmri_changes,
+        )
 
-        def __get_publishers_with_repos(self, publishers=misc.EmptyI):
-                """Return publishers that have repositories configured.
+        self.__add_pkg_actuators_to_pd(reject_set)
 
-                'publishers' is an optional list of publisher prefixes to
-                limit the returned results to.
+        self.pd._solver_summary = str(solver)
+        if DebugValues["plan"]:
+            self.pd._solver_errors = solver.get_trim_errors()
 
-                A PlanCreationException will be raised if any of the publishers
-                specified do not exist, if any of the specified publishers have
-                no configured repositories, or if all known publishers have
-                no configured repositories."""
+    def __plan_install(
+        self,
+        li_pkg_updates=True,
+        li_sync_op=False,
+        new_facets=None,
+        new_variants=None,
+        pkgs_inst=None,
+        reject_list=misc.EmptyI,
+    ):
+        """Determine the fmri changes needed to install the specified
+        pkgs, sync the image, and/or change facets/variants within the
+        current image."""
 
-                all_pubs = [ p.prefix for p in self.image.gen_publishers() ]
-                if not publishers:
-                        if all_pubs:
-                                publishers = all_pubs
-                        else:
-                                return misc.EmptyI
+        self.__plan_op()
+        self.__plan_install_solver(
+            li_pkg_updates=li_pkg_updates,
+            li_sync_op=li_sync_op,
+            new_facets=new_facets,
+            new_variants=new_variants,
+            pkgs_inst=pkgs_inst,
+            reject_list=reject_list,
+        )
+        self.__finish_plan(plandesc.EVALUATED_PKGS)
 
-                configured_pubs = [
-                    pub.prefix
-                    for pub in self.image.gen_publishers()
-                    if pub.prefix in publishers and \
-                        (pub.repository and pub.repository.origins)
-                ]
+    def __plan_exact_install(
+        self,
+        li_pkg_updates=True,
+        li_sync_op=False,
+        new_facets=None,
+        new_variants=None,
+        pkgs_inst=None,
+        reject_list=misc.EmptyI,
+    ):
+        """Determine the fmri changes needed to install exactly the
+        specified pkgs, sync the image, and/or change facets/variants
+        within the current image."""
 
-                unconfigured_pubs = set(publishers) - set(configured_pubs)
-                if unconfigured_pubs:
-                        raise api_errors.PlanCreationException(
-                            no_repo_pubs=unconfigured_pubs)
+        self.__plan_op()
+        self.__plan_install_solver(
+            li_pkg_updates=li_pkg_updates,
+            li_sync_op=li_sync_op,
+            new_facets=new_facets,
+            new_variants=new_variants,
+            pkgs_inst=pkgs_inst,
+            reject_list=reject_list,
+            exact_install=True,
+        )
+        self.__finish_plan(plandesc.EVALUATED_PKGS)
 
-                return configured_pubs
+    def set_be_options(
+        self, backup_be, backup_be_name, new_be, be_activate, be_name
+    ):
+        self.pd._backup_be = backup_be
+        self.pd._backup_be_name = backup_be_name
+        self.pd._new_be = new_be
+        self.pd._be_activate = be_activate
+        self.pd._be_name = be_name
 
-        def __plan_common_hydration(self, publishers, dehydrate=False):
-                self.__plan_op()
+    def __set_update_index(self, value):
+        self.pd._update_index = value
 
-                # get publishers to dehydrate or rehydrate
-                pubs = self.__get_publishers_with_repos(publishers=publishers)
+    def __get_update_index(self):
+        return self.pd._update_index
 
-                if not pubs:
-                        # Nothing to do.
-                        self.__finish_plan(plandesc.EVALUATED_PKGS)
-                        return
+    update_index = property(__get_update_index, __set_update_index)
 
-                # List of packages that will be modified.
-                fmri_changes = [
-                    (f, f)
-                    for f in self.image.gen_installed_pkgs(pubs=pubs)
-                ]
+    def plan_install(self, pkgs_inst=None, reject_list=misc.EmptyI):
+        """Determine the fmri changes needed to install the specified
+        pkgs"""
 
-                # Evaluate current facets / variants.
-                if dehydrate:
-                        self.__evaluate_excludes(dehydrate=pubs)
-                else:
-                        self.__evaluate_excludes(rehydrate=pubs)
+        self.__plan_install(pkgs_inst=pkgs_inst, reject_list=reject_list)
 
-                # If solver isn't involved, assume the list of packages
-                # has been determined.
-                assert fmri_changes is not None
-                self.__finish_plan(plandesc.EVALUATED_PKGS,
-                    fmri_changes=fmri_changes)
+    def plan_exact_install(self, pkgs_inst=None, reject_list=misc.EmptyI):
+        """Determine the fmri changes needed to install exactly the
+        specified pkgs"""
 
-        def plan_dehydrate(self, publishers=None):
-                """Dehydrate packages for given publishers.  If no publishers
-                are specified, packages for all publishers with configured
-                repositories will be dehydrated."""
+        self.__plan_exact_install(pkgs_inst=pkgs_inst, reject_list=reject_list)
 
-                self.__plan_common_hydration(publishers, dehydrate=True)
+    def __get_attr_fmri_changes(self, get_mattrs):
+        # Attempt to optimize package planning by determining which
+        # packages are actually affected by changing attributes (e.g.,
+        # facets, variants).  This also provides an accurate list of
+        # affected packages as a side effect (normally, all installed
+        # packages are seen as changed).  This assumes that facets and
+        # variants are not both changing at the same time.
+        use_solver = False
+        cat = self.image.get_catalog(self.image.IMG_CATALOG_INSTALLED)
+        cat_info = frozenset([cat.DEPENDENCY])
 
-        def plan_rehydrate(self, publishers=None):
-                """Rehydrate packages for given publishers.  If no publishers
-                are specified, packages for all dehydrated publishers with
-                configured repositories will be rehydrated."""
+        fmri_changes = []
+        pt = self.__progtrack
+        rem_pkgs = self.image.count_installed_pkgs()
 
-                self.__plan_common_hydration(publishers)
+        pt.plan_start(pt.PLAN_PKGPLAN, goal=rem_pkgs)
+        for f in self.image.gen_installed_pkgs():
+            m = self.image.get_manifest(f, ignore_excludes=True)
 
-        def plan_change_varcets(self, new_facets=None, new_variants=None,
-            reject_list=misc.EmptyI):
-                """Determine the fmri changes needed to change the specified
-                facets/variants."""
+            # Get the list of attributes involved in this operation
+            # that the package uses and that have changed.
+            use_solver, mattrs = get_mattrs(m, use_solver)
+            if not mattrs:
+                # Changed attributes unused.
+                pt.plan_add_progress(pt.PLAN_PKGPLAN)
+                rem_pkgs -= 1
+                continue
 
-                self.__plan_op()
+            # Changed attributes are used in this package.
+            fmri_changes.append((f, f))
 
-                # assume none of our optimizations will work.
-                fmri_changes = None
-
-                # convenience function to invoke the solver.
-                def plan_install_solver():
-                        self.__plan_install_solver(
-                            new_facets=new_facets,
-                            new_variants=new_variants,
-                            reject_list=reject_list,
-                            fmri_changes=fmri_changes)
-                        self.__finish_plan(plandesc.EVALUATED_PKGS)
-
-                # evaluate what varcet changes are required
-                new_variants, new_facets, \
-                    facet_change, masked_facet_change = \
-                    self.__evaluate_excludes(new_variants, new_facets)
-
-                # uninstalling packages requires the solver.
-                uninstall = self.__any_reject_matches(reject_list)
-                if uninstall:
-                        plan_install_solver()
-                        return
-
-                # All operations (including varcet changes) need to try and
-                # keep linked images in sync.  Linked image audits are fast,
-                # so do one now and if we're not in sync we need to invoke the
-                # solver.
-                if not self.image.linked.insync():
-                        plan_install_solver()
-                        return
-
-                # if facets and variants are changing at the same time, then
-                # we need to invoke the solver.
-                if new_variants and facet_change:
-                        plan_install_solver()
-                        return
-
-                # By default, we assume the solver must be used.  If any of the
-                # optimizations below can be applied, they'll determine whether
-                # the solver can be used.
-                use_solver = True
-
-                # the following facet optimization only works if we're not
-                # changing variants at the same time.
-                if facet_change:
-                        assert not new_variants
-                        use_solver, fmri_changes = \
-                            self.__facet_change_fastpath()
-
-                # the following variant optimization only works if we're not
-                # changing facets at the same time.
-                if new_variants:
-                        assert not facet_change
-                        use_solver, fmri_changes = \
-                            self.__variant_change_fastpath()
-
+            # If any dependency actions are tagged with one
+            # of the changed attributes, assume the solver
+            # must be used.
+            for act in cat.get_entry_actions(f, cat_info):
+                for attr in mattrs:
+                    if use_solver:
+                        break
+                    if act.name == "depend" and attr in act.attrs:
+                        use_solver = True
+                        break
                 if use_solver:
-                        plan_install_solver()
-                        return
-
-                # If solver isn't involved, assume the list of packages
-                # has been determined.
-                assert fmri_changes is not None
-                self.__finish_plan(plandesc.EVALUATED_PKGS,
-                    fmri_changes=fmri_changes)
-
-
-        def plan_set_mediators(self, new_mediators):
-                """Determine the changes needed to set the specified mediators.
-
-                'new_mediators' is a dict of dicts of the mediators to set
-                version and implementation for.  It should be of the form:
-
-                   {
-                       mediator-name: {
-                           "implementation": mediator-implementation-string,
-                           "version": mediator-version-string
-                       }
-                   }
-
-                   'implementation' is an optional string that specifies the
-                   implementation of the mediator for use in addition to or
-                   instead of 'version'.  A value of None will be interpreted
-                   as requesting a reset of implementation to its optimal
-                   default.
-
-                   'version' is an optional string that specifies the version
-                   (expressed as a dot-separated sequence of non-negative
-                   integers) of the mediator for use.  A value of None will be
-                   interpreted as requesting a reset of version to its optimal
-                   default.
-                """
-
-                self.__plan_op()
-                self.__evaluate_excludes()
-
-                self.pd._mediators_change = True
-                self.pd._new_mediators = new_mediators
-                cfg_mediators = self.image.cfg.mediators
-
-                pt = self.__progtrack
-
-                pt.plan_start(pt.PLAN_MEDIATION_CHG)
-                # keys() is used since entries are deleted during iteration.
-                update_mediators = {}
-                for m in list(self.pd._new_mediators.keys()):
-                        pt.plan_add_progress(pt.PLAN_MEDIATION_CHG)
-                        for k in ("implementation", "version"):
-                                if k in self.pd._new_mediators[m]:
-                                        if self.pd._new_mediators[m][k] is not None:
-                                                # Any mediators being set this
-                                                # way are forced to be marked as
-                                                # being set by local administrator.
-                                                self.pd._new_mediators[m]["{0}-source".format(k)] = \
-                                                    "local"
-                                                continue
-
-                                        # Explicit reset requested.
-                                        del self.pd._new_mediators[m][k]
-                                        self.pd._new_mediators[m].pop(
-                                            "{0}-source".format(k), None)
-                                        if k == "implementation":
-                                                self.pd._new_mediators[m].pop(
-                                                    "implementation-version",
-                                                    None)
-                                        continue
-
-                                if m not in cfg_mediators:
-                                        # Nothing to do if not previously
-                                        # configured.
-                                        continue
-
-                                # If the mediator was configured by the local
-                                # administrator, merge existing configuration.
-                                # This is necessary since callers are only
-                                # required to specify the components they want
-                                # to change.
-                                med_source = cfg_mediators[m].get("{0}-source".format(k))
-                                if med_source != "local":
-                                        continue
-
-                                self.pd._new_mediators[m][k] = \
-                                    cfg_mediators[m].get(k)
-                                self.pd._new_mediators[m]["{0}-source".format(k)] = "local"
-
-                                if k == "implementation" and \
-                                    "implementation-version" in cfg_mediators[m]:
-                                        self.pd._new_mediators[m]["implementation-version"] = \
-                                            cfg_mediators[m].get("implementation-version")
-
-                        if m not in cfg_mediators:
-                                # mediation changed.
-                                continue
-
-                        # Determine if the only thing changing for mediations is
-                        # whether configuration source is changing.  If so,
-                        # optimize planning by not loading any package data.
-                        for k in ("implementation", "version"):
-                                if self.pd._new_mediators[m].get(k) != \
-                                    cfg_mediators[m].get(k):
-                                        break
-                        else:
-                                if (self.pd._new_mediators[m].get("version-source") != \
-                                    cfg_mediators[m].get("version-source")) or \
-                                    (self.pd._new_mediators[m].get("implementation-source") != \
-                                    cfg_mediators[m].get("implementation-source")):
-                                        update_mediators[m] = \
-                                            self.pd._new_mediators[m]
-                                del self.pd._new_mediators[m]
-
-                if self.pd._new_mediators:
-                        # Some mediations are changing, so merge the update only
-                        # ones back in.
-                        self.pd._new_mediators.update(update_mediators)
-
-                        # Determine which packages will be affected.
-                        for f in self.image.gen_installed_pkgs():
-                                pt.plan_add_progress(pt.PLAN_MEDIATION_CHG)
-                                m = self.image.get_manifest(f,
-                                    ignore_excludes=True)
-                                mediated = []
-                                for act in m.gen_actions_by_types(("hardlink",
-                                    "link"), excludes=self.__new_excludes):
-                                        try:
-                                                mediator = act.attrs["mediator"]
-                                        except KeyError:
-                                                continue
-                                        if mediator in new_mediators:
-                                                mediated.append(act)
-
-                                if mediated:
-                                        pp = pkgplan.PkgPlan(self.image)
-                                        pp.propose_repair(f, m, mediated,
-                                            misc.EmptyI)
-                                        pp.evaluate(self.__new_excludes,
-                                            self.__new_excludes,
-                                            can_exclude=True)
-                                        self.pd.pkg_plans.append(pp)
-                else:
-                        # Only the source property is being updated for
-                        # these mediators, so no packages needed loading.
-                        self.pd._new_mediators = update_mediators
-
-                pt.plan_done(pt.PLAN_MEDIATION_CHG)
-                self.__finish_plan(plandesc.EVALUATED_PKGS)
-
-        def __any_reject_matches(self, reject_list):
-                """Check if any reject patterns match installed packages (in
-                which case a packaging operation should attempt to uninstall
-                those packages)."""
-
-                # return true if any packages in reject list
-                # match any installed packages
-                return bool(reject_list) and \
-                    bool(self.match_user_stems(self.image, reject_list,
-                        self.MATCH_INST_VERSIONS, raise_not_installed=False))
-
-        def plan_sync(self, li_pkg_updates=True, reject_list=misc.EmptyI):
-                """Determine the fmri changes needed to sync the image."""
-
-                self.__plan_op()
-
-                # check if we need to uninstall any packages.
-                uninstall = self.__any_reject_matches(reject_list)
-
-                # check if inherited facets are changing
-                new_facets = self.__evaluate_excludes()[1]
-
-                # audits are fast, so do an audit to check if we're in sync.
-                insync = self.image.linked.insync()
-
-                # if we're not trying to uninstall packages, and inherited
-                # facets are not changing, and we're already in sync, then
-                # don't bother invoking the solver.
-                if not uninstall and not new_facets is not None and insync:
-                        # we don't need to do anything
-                        self.__finish_plan(plandesc.EVALUATED_PKGS,
-                            fmri_changes=[])
-                        return
-
-                self.__plan_install(li_pkg_updates=li_pkg_updates,
-                    li_sync_op=True, reject_list=reject_list)
-
-        def plan_uninstall(self, pkgs_to_uninstall, ignore_missing=False):
-                self.__plan_op()
-                proposed_dict, self.__match_rm = self.__match_user_fmris(
-                    self.image, pkgs_to_uninstall, self.MATCH_INST_VERSIONS,
-                    raise_not_installed=not ignore_missing)
-
-                # merge patterns together
-                proposed_removals = set([
-                    f
-                    for each in proposed_dict.values()
-                    for f in each
-                ])
-
-                # check if inherited facets are changing
-                new_facets = self.__evaluate_excludes()[1]
-
-                # build installed dict
-                installed_dict = ImagePlan.__fmris2dict(
-                    self.image.gen_installed_pkgs())
-
-                def solver_cb(ignore_inst_parent_deps):
-                        # instantiate solver
-                        solver = pkg_solver.PkgSolver(
-                            self.image.get_catalog(
-                                self.image.IMG_CATALOG_KNOWN),
-                            installed_dict,
-                            self.image.get_publisher_ranks(),
-                            self.image.get_variants(),
-                            self.image.avoid_set_get(),
-                            self.image.linked.parent_fmris(),
-                            self.__progtrack)
-
-                        # check for triggered ops
-                        self.__set_pkg_actuators(pkgs_to_uninstall,
-                            pkgdefs.PKG_OP_UNINSTALL, solver)
-
-                        # run solver
-                        new_vector, new_avoid_obs = \
-                            solver.solve_uninstall(
-                                self.image.get_frozen_list(),
-                                proposed_removals,
-                                self.__new_excludes,
-                                ignore_inst_parent_deps=\
-                                    ignore_inst_parent_deps)
-
-                        return solver, new_vector, new_avoid_obs
-
-                # Solve; will raise exceptions if no solution is found.
-                solver, new_vector, self.pd._new_avoid_obs = \
-                    self.__run_solver(solver_cb)
-
-                self.pd._fmri_changes = self.__vector_2_fmri_changes(
-                    installed_dict, new_vector,
-                    new_facets=new_facets)
-
-                self.__add_pkg_actuators_to_pd(
-                    [x.pkg_name for x in proposed_removals])
-
-                self.pd._solver_summary = str(solver)
-                if DebugValues["plan"]:
-                        self.pd._solver_errors = solver.get_trim_errors()
-
-                self.__finish_plan(plandesc.EVALUATED_PKGS)
-
-        def __plan_update_solver(self, pkgs_update=None,
-            ignore_missing=False, reject_list=misc.EmptyI):
-                """Use the solver to determine the fmri changes needed to
-                update the specified pkgs or all packages if none were
-                specified."""
-
-                # check if inherited facets are changing
-                new_facets = self.__evaluate_excludes()[1]
-
-                # get ranking of publishers
-                pub_ranks = self.image.get_publisher_ranks()
-
-                # build installed dict
-                installed_dict = ImagePlan.__fmris2dict(
-                    self.image.gen_installed_pkgs())
-
-                # If specific packages or patterns were provided, then
-                # determine the proposed set to pass to the solver.
-                if reject_list:
-                        reject_set = self.match_user_stems(self.image,
-                            reject_list, self.MATCH_ALL)
-                else:
-                        reject_set = set()
-
-                if pkgs_update:
-                        update_dict, references = self.__match_user_fmris(
-                            self.image, pkgs_update, self.MATCH_INST_STEMS,
-                            pub_ranks=pub_ranks, installed_pkgs=installed_dict,
-                            raise_not_installed=not ignore_missing,
-                            reject_set=reject_set)
-                        self.__match_update = references
-
-                def solver_cb(ignore_inst_parent_deps):
-                        # instantiate solver
-                        solver = pkg_solver.PkgSolver(
-                            self.image.get_catalog(
-                                self.image.IMG_CATALOG_KNOWN),
-                            installed_dict,
-                            pub_ranks,
-                            self.image.get_variants(),
-                            self.image.avoid_set_get(),
-                            self.image.linked.parent_fmris(),
-                            self.__progtrack)
-
-                        if reject_list:
-                                # use reject_list, not reject_set, to preserve
-                                # input intent (e.g. 'pkg:/', '/' prefixes).
-                                self.__set_pkg_actuators(reject_list,
-                                    pkgdefs.PKG_OP_UNINSTALL, solver)
-
-                        # run solver
-                        if pkgs_update:
-                                new_vector, new_avoid_obs = \
-                                    solver.solve_install(
-                                        self.image.get_frozen_list(),
-                                        update_dict,
-                                        excludes=self.__new_excludes,
-                                        reject_set=reject_set,
-                                        trim_proposed_installed=False,
-                                        ignore_inst_parent_deps=\
-                                            ignore_inst_parent_deps)
-                        else:
-                                # Updating all installed packages requires a
-                                # different solution path.
-                                new_vector, new_avoid_obs = \
-                                    solver.solve_update_all(
-                                        self.image.get_frozen_list(),
-                                        excludes=self.__new_excludes,
-                                        reject_set=reject_set)
-
-                        return solver, new_vector, new_avoid_obs
-
-                # We can't retry this operation while ignoring parent
-                # dependencies if we're doing a unconstrained update.
-                retry_wo_parent_deps = bool(pkgs_update)
-
-                # Solve; will raise exceptions if no solution is found.
-                solver, new_vector, self.pd._new_avoid_obs = \
-                    self.__run_solver(solver_cb, \
-                        retry_wo_parent_deps=retry_wo_parent_deps)
-
-                self.pd._fmri_changes = self.__vector_2_fmri_changes(
-                    installed_dict, new_vector,
-                    new_facets=new_facets)
-
-                self.__add_pkg_actuators_to_pd(reject_set)
-
-                self.pd._solver_summary = str(solver)
-                if DebugValues["plan"]:
-                        self.pd._solver_errors = solver.get_trim_errors()
-
-        def plan_update(self, pkgs_update=None,
-            ignore_missing=False, reject_list=misc.EmptyI):
-                """Determine the fmri changes needed to update the specified
-                pkgs or all packages if none were specified."""
-
-                self.__plan_op()
-                self.__plan_update_solver(
-                    ignore_missing=ignore_missing,
-                    pkgs_update=pkgs_update,
-                    reject_list=reject_list)
-                self.__finish_plan(plandesc.EVALUATED_PKGS)
-
-        def plan_revert(self, args, tagged):
-                """Plan reverting the specified files or files tagged as
-                specified.  We create the pkgplans here rather than in
-                evaluate; by keeping the list of changed_fmris empty we
-                skip most of the processing in evaluate.
-                We also process revert tags on directories here"""
-
-                self.__plan_op()
-                self.__evaluate_excludes()
-
-                revert_dict = defaultdict(list)
-                revert_dirs = defaultdict(list)
-
-                pt = self.__progtrack
-                pt.plan_all_start()
-
-                # since the fmri list stays empty, we can set this;
-                # we need this set so we can build directories and
-                # actions lists as we're doing checking with installed
-                # actions earlier here.
-                self.pd.state = plandesc.EVALUATED_PKGS
-
-                # We could have a specific 'revert' tracker item, but
-                # "package planning" seems as good a term as any.
-                pt.plan_start(pt.PLAN_PKGPLAN,
-                    goal=self.image.count_installed_pkgs())
-                if tagged:
-                        # look through all the files on the system; any files
-                        # tagged w/ revert-tag set to any of the values on
-                        # the command line need to be checked and reverted if
-                        # they differ from the manifests.  Note we don't care
-                        # if the file is editable or not.
-
-                        # look through directories to see if any have our
-                        # revert-tag set; we then need to check the value
-                        # to find any unpackaged files that need deletion.
-                        tag_set = set(args)
-                        for f in self.image.gen_installed_pkgs():
-                                pt.plan_add_progress(pt.PLAN_PKGPLAN)
-                                m = self.image.get_manifest(f,
-                                    ignore_excludes=True)
-                                for act in m.gen_actions_by_type("file",
-                                    excludes=self.__new_excludes):
-                                        if "revert-tag" in act.attrs and \
-                                            (set(act.attrlist("revert-tag")) &
-                                             tag_set):
-                                                revert_dict[(f, m)].append(act)
-
-                                for act in m.gen_actions_by_type("dir",
-                                    excludes=self.__new_excludes):
-                                        if "revert-tag" not in act.attrs:
-                                                continue
-                                        for a in act.attrlist("revert-tag"):
-                                                tag_parts = a.split("=", 2)
-                                                if tag_parts[0] not in tag_set or \
-                                                    len(tag_parts) != 2:
-                                                        continue
-                                                revert_dirs[(f, m)].append(
-                                                    self.__gen_matching_acts(
-                                                    act.attrs["path"],
-                                                    tag_parts[1]))
-                else:
-                        # look through all the packages, looking for our files
-                        # we could use search for this.  We don't support reverting
-                        # directories by ad-hoc means.
-
-                        revertpaths = set([a.lstrip(os.path.sep) for a in args])
-                        overlaypaths = set()
-                        for f in self.image.gen_installed_pkgs():
-                                pt.plan_add_progress(pt.PLAN_PKGPLAN)
-                                m = self.image.get_manifest(f,
-                                    ignore_excludes=True)
-                                for act in m.gen_actions_by_type("file",
-                                    excludes=self.__new_excludes):
-                                        path = act.attrs["path"]
-                                        if path in revertpaths or \
-                                            path in overlaypaths:
-                                                revert_dict[(f, m)].append(act)
-                                                if act.attrs.get("overlay") == \
-                                                    "allow":
-                                                        # Action allows overlay,
-                                                        # all matching actions
-                                                        # must be collected.
-                                                        # The imageplan will
-                                                        # automatically handle
-                                                        # the overlaid action
-                                                        # if an overlaying
-                                                        # action is present.
-                                                        overlaypaths.add(path)
-                                                revertpaths.discard(path)
-
-                        revertpaths.difference_update(overlaypaths)
-                        if revertpaths:
-                                pt.plan_done(pt.PLAN_PKGPLAN)
-                                pt.plan_all_done()
-                                raise api_errors.PlanCreationException(
-                                    nofiles=list(revertpaths))
-
-                for f, m in revert_dict.keys():
-                        # build list of actions that will need to be reverted
-                        # no sense in replacing files that are original already
-                        needs_change = []
-                        pt.plan_add_progress(pt.PLAN_PKGPLAN, nitems=0)
-                        for act in revert_dict[(f, m)]:
-                                # delete preserve and preserve-version
-                                # attributes to both find and enable
-                                # replacement of modified editable files.
-                                # Note: preserve=abandon should be skipped
-                                # because, by definition, these files should
-                                # not be restored (they have been abandoned)
-                                if act.attrs.get("preserve") == "abandon":
-                                        continue
-
-                                act.attrs.pop("preserve", None)
-                                act.attrs.pop("preserve-version", None)
-                                act.verify(self.image, forever=True)
-                                if act.replace_required == True:
-                                        needs_change.append(act)
-
-                        revert_dict[(f, m)] = needs_change
-
-                for f, m in revert_dirs:
-                        needs_delete = []
-                        for unchecked, checked in revert_dirs[(f, m)]:
-                                # just add these...
-                                needs_delete.extend(checked)
-                                # look for these
-                                for un in unchecked:
-                                        path = un.attrs["path"]
-                                        if path not in self.get_actions("file") \
-                                            and path not in self.get_actions("hardlink") \
-                                            and path not in self.get_actions("link"):
-                                                needs_delete.append(un)
-                        revert_dirs[(f, m)] = needs_delete
-
-                # build the pkg plans, making sure to propose only one repair
-                # per fmri
-                for f, m in set(list(revert_dirs.keys()) + list(revert_dict.keys())):
-                        needs_delete = revert_dirs[(f, m)]
-                        needs_change = revert_dict[(f, m)]
-                        if not needs_delete and not needs_change:
-                                continue
-
-                        pp = pkgplan.PkgPlan(self.image)
-                        pp.propose_repair(f, m, needs_change, needs_delete)
-                        pp.evaluate(self.__new_excludes, self.__new_excludes,
-                            can_exclude=True)
-                        self.pd.pkg_plans.append(pp)
-
+                    break
+
+            rem_pkgs -= 1
+            pt.plan_add_progress(pt.PLAN_PKGPLAN)
+
+        pt.plan_done(pt.PLAN_PKGPLAN)
+        pt.plan_all_done()
+
+        return use_solver, fmri_changes
+
+    def __facet_change_fastpath(self):
+        """The following optimizations only work correctly if only
+        facets are changing (not variants, uninstalls, etc)."""
+
+        old_facets = self.pd._old_facets
+        new_facets = self.pd._new_facets
+
+        # List of changed facets are those that have a new value,
+        # and those that have been removed.
+        changed_facets = [
+            f
+            for f in new_facets
+            if f not in old_facets or old_facets[f] != new_facets[f]
+        ]
+        changed_facets.extend(f for f in old_facets if f not in new_facets)
+
+        def get_fattrs(m, use_solver):
+            # Get the list of facets involved in this
+            # operation that the package uses.  To
+            # accurately determine which packages are
+            # actually being changed, we must compare the
+            # old effective value for each facet that is
+            # changing with its new effective value.
+            return use_solver, list(
+                f
+                for f in m.gen_facets(
+                    excludes=self.__new_excludes, patterns=changed_facets
+                )
+                if new_facets[f] != old_facets[f]
+            )
+
+        return self.__get_attr_fmri_changes(get_fattrs)
+
+    def __variant_change_fastpath(self):
+        """The following optimizations only work correctly if only
+        variants are changing (not facets, uninstalls, etc)."""
+
+        nvariants = self.pd._new_variants
+
+        def get_vattrs(m, use_solver):
+            # Get the list of variants involved in this
+            # operation that the package uses.
+            mvars = []
+            for variant, pvals in m.gen_variants(
+                excludes=self.__new_excludes, patterns=nvariants
+            ):
+                if nvariants[variant] not in pvals:
+                    # If the new value for the
+                    # variant is unsupported by this
+                    # package, then the solver
+                    # should be triggered so the
+                    # package can be removed.
+                    use_solver = True
+                mvars.append(variant)
+            return use_solver, mvars
+
+        return self.__get_attr_fmri_changes(get_vattrs)
+
+    def __get_publishers_with_repos(self, publishers=misc.EmptyI):
+        """Return publishers that have repositories configured.
+
+        'publishers' is an optional list of publisher prefixes to
+        limit the returned results to.
+
+        A PlanCreationException will be raised if any of the publishers
+        specified do not exist, if any of the specified publishers have
+        no configured repositories, or if all known publishers have
+        no configured repositories."""
+
+        all_pubs = [p.prefix for p in self.image.gen_publishers()]
+        if not publishers:
+            if all_pubs:
+                publishers = all_pubs
+            else:
+                return misc.EmptyI
+
+        configured_pubs = [
+            pub.prefix
+            for pub in self.image.gen_publishers()
+            if pub.prefix in publishers
+            and (pub.repository and pub.repository.origins)
+        ]
+
+        unconfigured_pubs = set(publishers) - set(configured_pubs)
+        if unconfigured_pubs:
+            raise api_errors.PlanCreationException(
+                no_repo_pubs=unconfigured_pubs
+            )
+
+        return configured_pubs
+
+    def __plan_common_hydration(self, publishers, dehydrate=False):
+        self.__plan_op()
+
+        # get publishers to dehydrate or rehydrate
+        pubs = self.__get_publishers_with_repos(publishers=publishers)
+
+        if not pubs:
+            # Nothing to do.
+            self.__finish_plan(plandesc.EVALUATED_PKGS)
+            return
+
+        # List of packages that will be modified.
+        fmri_changes = [
+            (f, f) for f in self.image.gen_installed_pkgs(pubs=pubs)
+        ]
+
+        # Evaluate current facets / variants.
+        if dehydrate:
+            self.__evaluate_excludes(dehydrate=pubs)
+        else:
+            self.__evaluate_excludes(rehydrate=pubs)
+
+        # If solver isn't involved, assume the list of packages
+        # has been determined.
+        assert fmri_changes is not None
+        self.__finish_plan(plandesc.EVALUATED_PKGS, fmri_changes=fmri_changes)
+
+    def plan_dehydrate(self, publishers=None):
+        """Dehydrate packages for given publishers.  If no publishers
+        are specified, packages for all publishers with configured
+        repositories will be dehydrated."""
+
+        self.__plan_common_hydration(publishers, dehydrate=True)
+
+    def plan_rehydrate(self, publishers=None):
+        """Rehydrate packages for given publishers.  If no publishers
+        are specified, packages for all dehydrated publishers with
+        configured repositories will be rehydrated."""
+
+        self.__plan_common_hydration(publishers)
+
+    def plan_change_varcets(
+        self, new_facets=None, new_variants=None, reject_list=misc.EmptyI
+    ):
+        """Determine the fmri changes needed to change the specified
+        facets/variants."""
+
+        self.__plan_op()
+
+        # assume none of our optimizations will work.
+        fmri_changes = None
+
+        # convenience function to invoke the solver.
+        def plan_install_solver():
+            self.__plan_install_solver(
+                new_facets=new_facets,
+                new_variants=new_variants,
+                reject_list=reject_list,
+                fmri_changes=fmri_changes,
+            )
+            self.__finish_plan(plandesc.EVALUATED_PKGS)
+
+        # evaluate what varcet changes are required
+        (
+            new_variants,
+            new_facets,
+            facet_change,
+            masked_facet_change,
+        ) = self.__evaluate_excludes(new_variants, new_facets)
+
+        # uninstalling packages requires the solver.
+        uninstall = self.__any_reject_matches(reject_list)
+        if uninstall:
+            plan_install_solver()
+            return
+
+        # All operations (including varcet changes) need to try and
+        # keep linked images in sync.  Linked image audits are fast,
+        # so do one now and if we're not in sync we need to invoke the
+        # solver.
+        if not self.image.linked.insync():
+            plan_install_solver()
+            return
+
+        # if facets and variants are changing at the same time, then
+        # we need to invoke the solver.
+        if new_variants and facet_change:
+            plan_install_solver()
+            return
+
+        # By default, we assume the solver must be used.  If any of the
+        # optimizations below can be applied, they'll determine whether
+        # the solver can be used.
+        use_solver = True
+
+        # the following facet optimization only works if we're not
+        # changing variants at the same time.
+        if facet_change:
+            assert not new_variants
+            use_solver, fmri_changes = self.__facet_change_fastpath()
+
+        # the following variant optimization only works if we're not
+        # changing facets at the same time.
+        if new_variants:
+            assert not facet_change
+            use_solver, fmri_changes = self.__variant_change_fastpath()
+
+        if use_solver:
+            plan_install_solver()
+            return
+
+        # If solver isn't involved, assume the list of packages
+        # has been determined.
+        assert fmri_changes is not None
+        self.__finish_plan(plandesc.EVALUATED_PKGS, fmri_changes=fmri_changes)
+
+    def plan_set_mediators(self, new_mediators):
+        """Determine the changes needed to set the specified mediators.
+
+        'new_mediators' is a dict of dicts of the mediators to set
+        version and implementation for.  It should be of the form:
+
+           {
+               mediator-name: {
+                   "implementation": mediator-implementation-string,
+                   "version": mediator-version-string
+               }
+           }
+
+           'implementation' is an optional string that specifies the
+           implementation of the mediator for use in addition to or
+           instead of 'version'.  A value of None will be interpreted
+           as requesting a reset of implementation to its optimal
+           default.
+
+           'version' is an optional string that specifies the version
+           (expressed as a dot-separated sequence of non-negative
+           integers) of the mediator for use.  A value of None will be
+           interpreted as requesting a reset of version to its optimal
+           default.
+        """
+
+        self.__plan_op()
+        self.__evaluate_excludes()
+
+        self.pd._mediators_change = True
+        self.pd._new_mediators = new_mediators
+        cfg_mediators = self.image.cfg.mediators
+
+        pt = self.__progtrack
+
+        pt.plan_start(pt.PLAN_MEDIATION_CHG)
+        # keys() is used since entries are deleted during iteration.
+        update_mediators = {}
+        for m in list(self.pd._new_mediators.keys()):
+            pt.plan_add_progress(pt.PLAN_MEDIATION_CHG)
+            for k in ("implementation", "version"):
+                if k in self.pd._new_mediators[m]:
+                    if self.pd._new_mediators[m][k] is not None:
+                        # Any mediators being set this
+                        # way are forced to be marked as
+                        # being set by local administrator.
+                        self.pd._new_mediators[m][
+                            "{0}-source".format(k)
+                        ] = "local"
+                        continue
+
+                    # Explicit reset requested.
+                    del self.pd._new_mediators[m][k]
+                    self.pd._new_mediators[m].pop("{0}-source".format(k), None)
+                    if k == "implementation":
+                        self.pd._new_mediators[m].pop(
+                            "implementation-version", None
+                        )
+                    continue
+
+                if m not in cfg_mediators:
+                    # Nothing to do if not previously
+                    # configured.
+                    continue
+
+                # If the mediator was configured by the local
+                # administrator, merge existing configuration.
+                # This is necessary since callers are only
+                # required to specify the components they want
+                # to change.
+                med_source = cfg_mediators[m].get("{0}-source".format(k))
+                if med_source != "local":
+                    continue
+
+                self.pd._new_mediators[m][k] = cfg_mediators[m].get(k)
+                self.pd._new_mediators[m]["{0}-source".format(k)] = "local"
+
+                if (
+                    k == "implementation"
+                    and "implementation-version" in cfg_mediators[m]
+                ):
+                    self.pd._new_mediators[m][
+                        "implementation-version"
+                    ] = cfg_mediators[m].get("implementation-version")
+
+            if m not in cfg_mediators:
+                # mediation changed.
+                continue
+
+            # Determine if the only thing changing for mediations is
+            # whether configuration source is changing.  If so,
+            # optimize planning by not loading any package data.
+            for k in ("implementation", "version"):
+                if self.pd._new_mediators[m].get(k) != cfg_mediators[m].get(k):
+                    break
+            else:
+                if (
+                    self.pd._new_mediators[m].get("version-source")
+                    != cfg_mediators[m].get("version-source")
+                ) or (
+                    self.pd._new_mediators[m].get("implementation-source")
+                    != cfg_mediators[m].get("implementation-source")
+                ):
+                    update_mediators[m] = self.pd._new_mediators[m]
+                del self.pd._new_mediators[m]
+
+        if self.pd._new_mediators:
+            # Some mediations are changing, so merge the update only
+            # ones back in.
+            self.pd._new_mediators.update(update_mediators)
+
+            # Determine which packages will be affected.
+            for f in self.image.gen_installed_pkgs():
+                pt.plan_add_progress(pt.PLAN_MEDIATION_CHG)
+                m = self.image.get_manifest(f, ignore_excludes=True)
+                mediated = []
+                for act in m.gen_actions_by_types(
+                    ("hardlink", "link"), excludes=self.__new_excludes
+                ):
+                    try:
+                        mediator = act.attrs["mediator"]
+                    except KeyError:
+                        continue
+                    if mediator in new_mediators:
+                        mediated.append(act)
+
+                if mediated:
+                    pp = pkgplan.PkgPlan(self.image)
+                    pp.propose_repair(f, m, mediated, misc.EmptyI)
+                    pp.evaluate(
+                        self.__new_excludes,
+                        self.__new_excludes,
+                        can_exclude=True,
+                    )
+                    self.pd.pkg_plans.append(pp)
+        else:
+            # Only the source property is being updated for
+            # these mediators, so no packages needed loading.
+            self.pd._new_mediators = update_mediators
+
+        pt.plan_done(pt.PLAN_MEDIATION_CHG)
+        self.__finish_plan(plandesc.EVALUATED_PKGS)
+
+    def __any_reject_matches(self, reject_list):
+        """Check if any reject patterns match installed packages (in
+        which case a packaging operation should attempt to uninstall
+        those packages)."""
+
+        # return true if any packages in reject list
+        # match any installed packages
+        return bool(reject_list) and bool(
+            self.match_user_stems(
+                self.image,
+                reject_list,
+                self.MATCH_INST_VERSIONS,
+                raise_not_installed=False,
+            )
+        )
+
+    def plan_sync(self, li_pkg_updates=True, reject_list=misc.EmptyI):
+        """Determine the fmri changes needed to sync the image."""
+
+        self.__plan_op()
+
+        # check if we need to uninstall any packages.
+        uninstall = self.__any_reject_matches(reject_list)
+
+        # check if inherited facets are changing
+        new_facets = self.__evaluate_excludes()[1]
+
+        # audits are fast, so do an audit to check if we're in sync.
+        insync = self.image.linked.insync()
+
+        # if we're not trying to uninstall packages, and inherited
+        # facets are not changing, and we're already in sync, then
+        # don't bother invoking the solver.
+        if not uninstall and not new_facets is not None and insync:
+            # we don't need to do anything
+            self.__finish_plan(plandesc.EVALUATED_PKGS, fmri_changes=[])
+            return
+
+        self.__plan_install(
+            li_pkg_updates=li_pkg_updates,
+            li_sync_op=True,
+            reject_list=reject_list,
+        )
+
+    def plan_uninstall(self, pkgs_to_uninstall, ignore_missing=False):
+        self.__plan_op()
+        proposed_dict, self.__match_rm = self.__match_user_fmris(
+            self.image,
+            pkgs_to_uninstall,
+            self.MATCH_INST_VERSIONS,
+            raise_not_installed=not ignore_missing,
+        )
+
+        # merge patterns together
+        proposed_removals = set(
+            [f for each in proposed_dict.values() for f in each]
+        )
+
+        # check if inherited facets are changing
+        new_facets = self.__evaluate_excludes()[1]
+
+        # build installed dict
+        installed_dict = ImagePlan.__fmris2dict(self.image.gen_installed_pkgs())
+
+        def solver_cb(ignore_inst_parent_deps):
+            # instantiate solver
+            solver = pkg_solver.PkgSolver(
+                self.image.get_catalog(self.image.IMG_CATALOG_KNOWN),
+                installed_dict,
+                self.image.get_publisher_ranks(),
+                self.image.get_variants(),
+                self.image.avoid_set_get(),
+                self.image.linked.parent_fmris(),
+                self.__progtrack,
+            )
+
+            # check for triggered ops
+            self.__set_pkg_actuators(
+                pkgs_to_uninstall, pkgdefs.PKG_OP_UNINSTALL, solver
+            )
+
+            # run solver
+            new_vector, new_avoid_obs = solver.solve_uninstall(
+                self.image.get_frozen_list(),
+                proposed_removals,
+                self.__new_excludes,
+                ignore_inst_parent_deps=ignore_inst_parent_deps,
+            )
+
+            return solver, new_vector, new_avoid_obs
+
+        # Solve; will raise exceptions if no solution is found.
+        solver, new_vector, self.pd._new_avoid_obs = self.__run_solver(
+            solver_cb
+        )
+
+        self.pd._fmri_changes = self.__vector_2_fmri_changes(
+            installed_dict, new_vector, new_facets=new_facets
+        )
+
+        self.__add_pkg_actuators_to_pd([x.pkg_name for x in proposed_removals])
+
+        self.pd._solver_summary = str(solver)
+        if DebugValues["plan"]:
+            self.pd._solver_errors = solver.get_trim_errors()
+
+        self.__finish_plan(plandesc.EVALUATED_PKGS)
+
+    def __plan_update_solver(
+        self, pkgs_update=None, ignore_missing=False, reject_list=misc.EmptyI
+    ):
+        """Use the solver to determine the fmri changes needed to
+        update the specified pkgs or all packages if none were
+        specified."""
+
+        # check if inherited facets are changing
+        new_facets = self.__evaluate_excludes()[1]
+
+        # get ranking of publishers
+        pub_ranks = self.image.get_publisher_ranks()
+
+        # build installed dict
+        installed_dict = ImagePlan.__fmris2dict(self.image.gen_installed_pkgs())
+
+        # If specific packages or patterns were provided, then
+        # determine the proposed set to pass to the solver.
+        if reject_list:
+            reject_set = self.match_user_stems(
+                self.image, reject_list, self.MATCH_ALL
+            )
+        else:
+            reject_set = set()
+
+        if pkgs_update:
+            update_dict, references = self.__match_user_fmris(
+                self.image,
+                pkgs_update,
+                self.MATCH_INST_STEMS,
+                pub_ranks=pub_ranks,
+                installed_pkgs=installed_dict,
+                raise_not_installed=not ignore_missing,
+                reject_set=reject_set,
+            )
+            self.__match_update = references
+
+        def solver_cb(ignore_inst_parent_deps):
+            # instantiate solver
+            solver = pkg_solver.PkgSolver(
+                self.image.get_catalog(self.image.IMG_CATALOG_KNOWN),
+                installed_dict,
+                pub_ranks,
+                self.image.get_variants(),
+                self.image.avoid_set_get(),
+                self.image.linked.parent_fmris(),
+                self.__progtrack,
+            )
+
+            if reject_list:
+                # use reject_list, not reject_set, to preserve
+                # input intent (e.g. 'pkg:/', '/' prefixes).
+                self.__set_pkg_actuators(
+                    reject_list, pkgdefs.PKG_OP_UNINSTALL, solver
+                )
+
+            # run solver
+            if pkgs_update:
+                new_vector, new_avoid_obs = solver.solve_install(
+                    self.image.get_frozen_list(),
+                    update_dict,
+                    excludes=self.__new_excludes,
+                    reject_set=reject_set,
+                    trim_proposed_installed=False,
+                    ignore_inst_parent_deps=ignore_inst_parent_deps,
+                )
+            else:
+                # Updating all installed packages requires a
+                # different solution path.
+                new_vector, new_avoid_obs = solver.solve_update_all(
+                    self.image.get_frozen_list(),
+                    excludes=self.__new_excludes,
+                    reject_set=reject_set,
+                )
+
+            return solver, new_vector, new_avoid_obs
+
+        # We can't retry this operation while ignoring parent
+        # dependencies if we're doing a unconstrained update.
+        retry_wo_parent_deps = bool(pkgs_update)
+
+        # Solve; will raise exceptions if no solution is found.
+        solver, new_vector, self.pd._new_avoid_obs = self.__run_solver(
+            solver_cb, retry_wo_parent_deps=retry_wo_parent_deps
+        )
+
+        self.pd._fmri_changes = self.__vector_2_fmri_changes(
+            installed_dict, new_vector, new_facets=new_facets
+        )
+
+        self.__add_pkg_actuators_to_pd(reject_set)
+
+        self.pd._solver_summary = str(solver)
+        if DebugValues["plan"]:
+            self.pd._solver_errors = solver.get_trim_errors()
+
+    def plan_update(
+        self, pkgs_update=None, ignore_missing=False, reject_list=misc.EmptyI
+    ):
+        """Determine the fmri changes needed to update the specified
+        pkgs or all packages if none were specified."""
+
+        self.__plan_op()
+        self.__plan_update_solver(
+            ignore_missing=ignore_missing,
+            pkgs_update=pkgs_update,
+            reject_list=reject_list,
+        )
+        self.__finish_plan(plandesc.EVALUATED_PKGS)
+
+    def plan_revert(self, args, tagged):
+        """Plan reverting the specified files or files tagged as
+        specified.  We create the pkgplans here rather than in
+        evaluate; by keeping the list of changed_fmris empty we
+        skip most of the processing in evaluate.
+        We also process revert tags on directories here"""
+
+        self.__plan_op()
+        self.__evaluate_excludes()
+
+        revert_dict = defaultdict(list)
+        revert_dirs = defaultdict(list)
+
+        pt = self.__progtrack
+        pt.plan_all_start()
+
+        # since the fmri list stays empty, we can set this;
+        # we need this set so we can build directories and
+        # actions lists as we're doing checking with installed
+        # actions earlier here.
+        self.pd.state = plandesc.EVALUATED_PKGS
+
+        # We could have a specific 'revert' tracker item, but
+        # "package planning" seems as good a term as any.
+        pt.plan_start(pt.PLAN_PKGPLAN, goal=self.image.count_installed_pkgs())
+        if tagged:
+            # look through all the files on the system; any files
+            # tagged w/ revert-tag set to any of the values on
+            # the command line need to be checked and reverted if
+            # they differ from the manifests.  Note we don't care
+            # if the file is editable or not.
+
+            # look through directories to see if any have our
+            # revert-tag set; we then need to check the value
+            # to find any unpackaged files that need deletion.
+            tag_set = set(args)
+            for f in self.image.gen_installed_pkgs():
+                pt.plan_add_progress(pt.PLAN_PKGPLAN)
+                m = self.image.get_manifest(f, ignore_excludes=True)
+                for act in m.gen_actions_by_type(
+                    "file", excludes=self.__new_excludes
+                ):
+                    if "revert-tag" in act.attrs and (
+                        set(act.attrlist("revert-tag")) & tag_set
+                    ):
+                        revert_dict[(f, m)].append(act)
+
+                for act in m.gen_actions_by_type(
+                    "dir", excludes=self.__new_excludes
+                ):
+                    if "revert-tag" not in act.attrs:
+                        continue
+                    for a in act.attrlist("revert-tag"):
+                        tag_parts = a.split("=", 2)
+                        if tag_parts[0] not in tag_set or len(tag_parts) != 2:
+                            continue
+                        revert_dirs[(f, m)].append(
+                            self.__gen_matching_acts(
+                                act.attrs["path"], tag_parts[1]
+                            )
+                        )
+        else:
+            # look through all the packages, looking for our files
+            # we could use search for this.  We don't support reverting
+            # directories by ad-hoc means.
+
+            revertpaths = set([a.lstrip(os.path.sep) for a in args])
+            overlaypaths = set()
+            for f in self.image.gen_installed_pkgs():
+                pt.plan_add_progress(pt.PLAN_PKGPLAN)
+                m = self.image.get_manifest(f, ignore_excludes=True)
+                for act in m.gen_actions_by_type(
+                    "file", excludes=self.__new_excludes
+                ):
+                    path = act.attrs["path"]
+                    if path in revertpaths or path in overlaypaths:
+                        revert_dict[(f, m)].append(act)
+                        if act.attrs.get("overlay") == "allow":
+                            # Action allows overlay,
+                            # all matching actions
+                            # must be collected.
+                            # The imageplan will
+                            # automatically handle
+                            # the overlaid action
+                            # if an overlaying
+                            # action is present.
+                            overlaypaths.add(path)
+                        revertpaths.discard(path)
+
+            revertpaths.difference_update(overlaypaths)
+            if revertpaths:
                 pt.plan_done(pt.PLAN_PKGPLAN)
                 pt.plan_all_done()
-                self.__finish_plan(plandesc.EVALUATED_PKGS, fmri_changes=[])
+                raise api_errors.PlanCreationException(
+                    nofiles=list(revertpaths)
+                )
 
-        def __gen_matching_acts(self, path, pattern):
-                # return two lists of actions that match pattern at path
-                # include (recursively) directories only if they are not
-                # implicitly or explicitly packaged.  First list may
-                # contain packaged objects, second does not.
+        for f, m in revert_dict.keys():
+            # build list of actions that will need to be reverted
+            # no sense in replacing files that are original already
+            needs_change = []
+            pt.plan_add_progress(pt.PLAN_PKGPLAN, nitems=0)
+            for act in revert_dict[(f, m)]:
+                # delete preserve and preserve-version
+                # attributes to both find and enable
+                # replacement of modified editable files.
+                # Note: preserve=abandon should be skipped
+                # because, by definition, these files should
+                # not be restored (they have been abandoned)
+                if act.attrs.get("preserve") == "abandon":
+                    continue
 
-                if path == os.path.sep: # not doing root
-                        return [], []
+                act.attrs.pop("preserve", None)
+                act.attrs.pop("preserve-version", None)
+                act.verify(self.image, forever=True)
+                if act.replace_required == True:
+                    needs_change.append(act)
 
-                dir_loc  = os.path.join(self.image.root, path)
+            revert_dict[(f, m)] = needs_change
 
-                # If this is a mount point, disable this; too easy
-                # to break things.  This means this doesn't work
-                # on /var and /tmp - that's ok.
+        for f, m in revert_dirs:
+            needs_delete = []
+            for unchecked, checked in revert_dirs[(f, m)]:
+                # just add these...
+                needs_delete.extend(checked)
+                # look for these
+                for un in unchecked:
+                    path = un.attrs["path"]
+                    if (
+                        path not in self.get_actions("file")
+                        and path not in self.get_actions("hardlink")
+                        and path not in self.get_actions("link")
+                    ):
+                        needs_delete.append(un)
+            revert_dirs[(f, m)] = needs_delete
 
+        # build the pkg plans, making sure to propose only one repair
+        # per fmri
+        for f, m in set(list(revert_dirs.keys()) + list(revert_dict.keys())):
+            needs_delete = revert_dirs[(f, m)]
+            needs_change = revert_dict[(f, m)]
+            if not needs_delete and not needs_change:
+                continue
+
+            pp = pkgplan.PkgPlan(self.image)
+            pp.propose_repair(f, m, needs_change, needs_delete)
+            pp.evaluate(
+                self.__new_excludes, self.__new_excludes, can_exclude=True
+            )
+            self.pd.pkg_plans.append(pp)
+
+        pt.plan_done(pt.PLAN_PKGPLAN)
+        pt.plan_all_done()
+        self.__finish_plan(plandesc.EVALUATED_PKGS, fmri_changes=[])
+
+    def __gen_matching_acts(self, path, pattern):
+        # return two lists of actions that match pattern at path
+        # include (recursively) directories only if they are not
+        # implicitly or explicitly packaged.  First list may
+        # contain packaged objects, second does not.
+
+        if path == os.path.sep:  # not doing root
+            return [], []
+
+        dir_loc = os.path.join(self.image.root, path)
+
+        # If this is a mount point, disable this; too easy
+        # to break things.  This means this doesn't work
+        # on /var and /tmp - that's ok.
+
+        try:
+            # if dir is missing, nothing to delete :)
+            my_dev = os.stat(dir_loc).st_dev
+        except OSError:
+            return [], []
+
+        # disallow mount points for safety's sake.
+        if my_dev != os.stat(os.path.dirname(dir_loc)).st_dev:
+            return [], []
+
+        # Any explicit or implicitly packaged directories are
+        # ignored; checking all directory entries is cheap.
+        paths = [
+            os.path.join(dir_loc, a)
+            for a in fnmatch.filter(os.listdir(dir_loc), pattern)
+            if os.path.join(path, a) not in self.__get_directories()
+        ]
+
+        # now we have list of items to be removed.  We know that
+        # any directories are not packaged, so expand those here
+        # and generate actions
+        unchecked = []
+        checked = []
+
+        for path in paths:
+            if os.path.isdir(path) and not os.path.islink(path):
+                # we have a directory that needs expanding;
+                # add it in and then walk the contents
+                checked.append(self.__gen_del_act(path))
+                for dirpath, dirnames, filenames in os.walk(path):
+                    # crossed mountpoints - don't go here.
+                    if os.stat(dirpath).st_dev != my_dev:
+                        continue
+                    for name in dirnames + filenames:
+                        checked.append(
+                            self.__gen_del_act(os.path.join(dirpath, name))
+                        )
+            else:
+                unchecked.append(self.__gen_del_act(path))
+        return unchecked, checked
+
+    def __gen_del_act(self, path):
+        # With fully qualified path, return action suitable for
+        # deletion from image. Don't bother getting owner
+        # and group right; we're just going to blow it up anyway.
+
+        rootdir = self.image.root
+        pubpath = pkg.misc.relpath(path, rootdir)
+        pstat = os.lstat(path)
+        mode = oct(stat.S_IMODE(pstat.st_mode))
+        if stat.S_ISLNK(pstat.st_mode):
+            return pkg.actions.link.LinkAction(
+                None, target=os.readlink(path), path=pubpath
+            )
+        elif stat.S_ISDIR(pstat.st_mode):
+            return pkg.actions.directory.DirectoryAction(
+                None, mode=mode, owner="root", group="bin", path=pubpath
+            )
+        else:  # treat everything else as a file
+            return pkg.actions.file.FileAction(
+                None, mode=mode, owner="root", group="bin", path=pubpath
+            )
+
+    def __get_overlaying(self, img, act, pfmri):
+        """Given an action with attribute overlay=allow, if there is an
+        overlaying action installed in the image, return the overlaying
+        package's FMRI and the action."""
+
+        for f in img.gen_installed_pkgs():
+            if f == pfmri:
+                # Not interested in ourselves.
+                continue
+            m = img.get_manifest(f)
+            matching = list(
+                m.gen_actions_by_types(
+                    [act.name], {"path": [act.attrs["path"]]}
+                )
+            )
+            if matching:
+                # Only one action can overlay another, so we
+                # know we've found a match at this point.
+                return f, matching[0]
+        return None, None
+
+    def __process_verify_result(
+        self,
+        act,
+        pfmri,
+        pt,
+        verifypaths=None,
+        overlaypaths=None,
+        ovlying_fmri=None,
+        ovlying_act=None,
+        skip_ovlying=False,
+        ovly_entries=None,
+    ):
+        """Process delayed actions."""
+        if not ovlying_act and not skip_ovlying:
+            # Find the overlaying fmri/action.
+            ovlying_fmri, ovlying_act = self.__get_overlaying(
+                self.image, act, pfmri
+            )
+        # If overlaying action is found, we use the overlaying action
+        # for verification.
+        if ovlying_act:
+            # Update overlaying entries with the newly found
+            # overlaying action.
+            if ovly_entries:
+                ovlying_path = ovlying_act.attrs.get("path")
+                if ovlying_path in ovly_entries:
+                    ovly_entries[ovlying_path].append(
+                        (ovlying_fmri, ovlying_act, "overlaying")
+                    )
+            for (
+                oing_act,
+                errors,
+                warnings,
+                pinfo,
+                is_overlaid,
+            ) in self.image.verify(
+                pfmri,
+                pt,
+                verifypaths=verifypaths,
+                overlaypaths=overlaypaths,
+                single_act=ovlying_act,
+                verbose=True,
+                forever=True,
+            ):
+                return oing_act, errors, warnings, pinfo, ovlying_fmri
+        else:
+            for (
+                olaid_act,
+                errors,
+                warnings,
+                pinfo,
+                is_overlaid,
+            ) in self.image.verify(
+                pfmri,
+                pt,
+                verifypaths=verifypaths,
+                overlaypaths=overlaypaths,
+                single_act=act,
+                verbose=True,
+                forever=True,
+            ):
+                return olaid_act, errors, warnings, pinfo, None
+        return act, [], [], [], None
+
+    def __is_active_liveroot_be(self, img):
+        """Check if an image is in an active live be."""
+
+        if not img.is_liveroot():
+            return False, None
+
+        try:
+            be_name, be_uuid = bootenv.BootEnv.get_be_name(img.root)
+            return True, be_name
+        except api_errors.BEException:
+            # If boot environment logic isn't supported, return
+            # False.  This is necessary for user images and for
+            # the test suite.
+            return False, None
+
+    def __alt_image_root_with_new_be(self, dup_be_name, orig_img_root):
+        img_root = orig_img_root
+        mntpoint = None
+        if not dup_be_name:
+            dup_be_name = "duplicate_livebe_for_verify"
+        isalbe, src_be_name = self.__is_active_liveroot_be(self.image)
+        if not isalbe:
+            return img_root, mntpoint
+
+        try:
+            bootenv.BootEnv.cleanup_be(dup_be_name)
+            temp_root = misc.config_temp_root()
+            mntpoint = tempfile.mkdtemp(
+                dir=temp_root, prefix="pkg-verify" + "-"
+            )
+            bootenv.BootEnv.copy_be(src_be_name, dup_be_name)
+            bootenv.BootEnv.mount_be(dup_be_name, mntpoint)
+            img_root = mntpoint
+        except Exception as e:
+            did_create = dup_be_name in bootenv.BootEnv.get_be_names()
+            warn = _(
+                "Cannot create or mount a copy of current be. "
+                "Reporting unpackaged content aganist current live "
+                "image."
+            )
+            fallback = False
+            timestamp = misc.time_to_timestamp(time.time())
+            if did_create:
                 try:
-                        # if dir is missing, nothing to delete :)
-                        my_dev = os.stat(dir_loc).st_dev
-                except OSError:
-                        return [], []
-
-                # disallow mount points for safety's sake.
-                if my_dev != os.stat(os.path.dirname(dir_loc)).st_dev:
-                        return [], []
-
-                # Any explicit or implicitly packaged directories are
-                # ignored; checking all directory entries is cheap.
-                paths = [
-                    os.path.join(dir_loc, a)
-                    for a in fnmatch.filter(os.listdir(dir_loc), pattern)
-                    if os.path.join(path, a) not in self.__get_directories()
-                ]
-
-                # now we have list of items to be removed.  We know that
-                # any directories are not packaged, so expand those here
-                # and generate actions
-                unchecked = []
-                checked = []
-
-                for path in paths:
-                        if os.path.isdir(path) and not os.path.islink(path):
-                                # we have a directory that needs expanding;
-                                # add it in and then walk the contents
-                                checked.append(self.__gen_del_act(path))
-                                for dirpath, dirnames, filenames in os.walk(path):
-                                        # crossed mountpoints - don't go here.
-                                        if os.stat(dirpath).st_dev != my_dev:
-                                                continue
-                                        for name in dirnames + filenames:
-                                                checked.append(
-                                                    self.__gen_del_act(
-                                                    os.path.join(dirpath, name)))
-                        else:
-                                unchecked.append(self.__gen_del_act(path))
-                return unchecked, checked
-
-        def __gen_del_act(self, path):
-                # With fully qualified path, return action suitable for
-                # deletion from image. Don't bother getting owner
-                # and group right; we're just going to blow it up anyway.
-
-                rootdir = self.image.root
-                pubpath = pkg.misc.relpath(path, rootdir)
-                pstat = os.lstat(path)
-                mode = oct(stat.S_IMODE(pstat.st_mode))
-                if stat.S_ISLNK(pstat.st_mode):
-                        return pkg.actions.link.LinkAction(None,
-                            target=os.readlink(path), path=pubpath)
-                elif stat.S_ISDIR(pstat.st_mode):
-                        return pkg.actions.directory.DirectoryAction(None,
-                            mode=mode, owner="root",
-                            group="bin", path=pubpath)
-                else: # treat everything else as a file
-                        return pkg.actions.file.FileAction(None,
-                            mode=mode, owner="root",
-                            group="bin", path=pubpath)
-
-        def __get_overlaying(self, img, act, pfmri):
-                """Given an action with attribute overlay=allow, if there is an
-                overlaying action installed in the image, return the overlaying
-                package's FMRI and the action."""
-
-                for f in img.gen_installed_pkgs():
-                        if f == pfmri:
-                                # Not interested in ourselves.
-                                continue
-                        m = img.get_manifest(f)
-                        matching = list(m.gen_actions_by_types([act.name],
-                            {"path": [act.attrs["path"]]}))
-                        if matching:
-                                # Only one action can overlay another, so we
-                                # know we've found a match at this point.
-                                return f, matching[0]
-                return None, None
-
-        def __process_verify_result(self, act, pfmri, pt,
-            verifypaths=None, overlaypaths=None, ovlying_fmri=None,
-            ovlying_act=None, skip_ovlying=False, ovly_entries=None):
-                """Process delayed actions."""
-                if not ovlying_act and not skip_ovlying:
-                        # Find the overlaying fmri/action.
-                        ovlying_fmri, ovlying_act = self.__get_overlaying(
-                            self.image, act, pfmri)
-                # If overlaying action is found, we use the overlaying action
-                # for verification.
-                if ovlying_act:
-                        # Update overlaying entries with the newly found
-                        # overlaying action.
-                        if ovly_entries:
-                                ovlying_path = ovlying_act.attrs.get("path")
-                                if ovlying_path in ovly_entries:
-                                        ovly_entries[ovlying_path].append(
-                                            (ovlying_fmri, ovlying_act,
-                                            "overlaying"))
-                        for oing_act, errors, warnings, pinfo, is_overlaid in \
-                            self.image.verify(pfmri, pt,
-                            verifypaths=verifypaths, overlaypaths=overlaypaths,
-                            single_act=ovlying_act, verbose=True,
-                            forever=True):
-                                return oing_act, errors, warnings, pinfo, \
-                                    ovlying_fmri
-                else:
-                        for olaid_act, errors, warnings, pinfo, is_overlaid \
-                            in self.image.verify(pfmri, pt,
-                            verifypaths=verifypaths, overlaypaths=overlaypaths,
-                            single_act=act, verbose=True, forever=True):
-                                return olaid_act, errors, warnings, pinfo, \
-                                    None
-                return act, [], [], [], None
-
-        def __is_active_liveroot_be(self, img):
-                """Check if an image is in an active live be."""
-
-                if not img.is_liveroot():
-                        return False, None
-
-                try:
-                        be_name, be_uuid = bootenv.BootEnv.get_be_name(
-                            img.root)
-                        return True, be_name
-                except api_errors.BEException:
-                        # If boot environment logic isn't supported, return
-                        # False.  This is necessary for user images and for
-                        # the test suite.
-                        return False, None
-
-        def __alt_image_root_with_new_be(self, dup_be_name, orig_img_root):
-                img_root = orig_img_root
-                mntpoint = None
-                if not dup_be_name:
-                        dup_be_name = "duplicate_livebe_for_verify"
-                isalbe, src_be_name = self.__is_active_liveroot_be(self.image)
-                if not isalbe:
-                        return img_root, mntpoint
-
-                try:
-                        bootenv.BootEnv.cleanup_be(dup_be_name)
-                        temp_root = misc.config_temp_root()
-                        mntpoint = tempfile.mkdtemp(dir=temp_root,
-                            prefix="pkg-verify" + "-")
-                        bootenv.BootEnv.copy_be(src_be_name, dup_be_name)
+                    if img_root != mntpoint:
                         bootenv.BootEnv.mount_be(dup_be_name, mntpoint)
                         img_root = mntpoint
                 except Exception as e:
-                        did_create = dup_be_name in \
-                            bootenv.BootEnv.get_be_names()
-                        warn = _("Cannot create or mount a copy of current be. "
-                            "Reporting unpackaged content aganist current live "
-                            "image.")
-                        fallback = False
-                        timestamp = misc.time_to_timestamp(time.time())
-                        if did_create:
-                                try:
-                                        if img_root != mntpoint:
-                                                bootenv.BootEnv.mount_be(
-                                                    dup_be_name, mntpoint)
-                                                img_root = mntpoint
-                                except Exception as e:
-                                        # Cannot mount be, fallback.
-                                        fallback = True
-                        else:
-                                # Cannot create be, fallback.
-                                fallback = True
+                    # Cannot mount be, fallback.
+                    fallback = True
+            else:
+                # Cannot create be, fallback.
+                fallback = True
 
-                        if fallback:
-                                shutil.rmtree(mntpoint, ignore_errors=True)
-                                self.pd.add_item_message("warnings", timestamp,
-                                    MSG_WARNING, warn, msg_type=MSG_UNPACKAGED,
-                                    parent="unpackaged")
-                return img_root, mntpoint
+            if fallback:
+                shutil.rmtree(mntpoint, ignore_errors=True)
+                self.pd.add_item_message(
+                    "warnings",
+                    timestamp,
+                    MSG_WARNING,
+                    warn,
+                    msg_type=MSG_UNPACKAGED,
+                    parent="unpackaged",
+                )
+        return img_root, mntpoint
 
-        def __process_unpackaged(self, proposed_fmris, pt=None,
-            dup_be_name="duplicate_livebe_for_verify"):
-                allentries = {}
-                img_root = self.image.get_root()
+    def __process_unpackaged(
+        self, proposed_fmris, pt=None, dup_be_name="duplicate_livebe_for_verify"
+    ):
+        allentries = {}
+        img_root = self.image.get_root()
 
-                for fmri in proposed_fmris:
-                        m = self.image.get_manifest(fmri)
-                        for act in m.gen_actions():
-                                if act.name in ["link", "hardlink", "dir",
-                                    "file"]:
-                                        install_path = os.path.normpath(
-                                            os.path.join(img_root,
-                                            act.attrs["path"]))
-                                        allentries[install_path] = act.name
-                        # Process possible implicit directories.
-                        for d in m.get_directories(()):
-                                install_path = os.path.normpath(
-                                    os.path.join(img_root, d))
-                                if install_path not in allentries:
-                                        allentries[install_path] = "dir"
-                        if pt:
-                                pt.plan_add_progress(pt.PLAN_PKG_VERIFY)
+        for fmri in proposed_fmris:
+            m = self.image.get_manifest(fmri)
+            for act in m.gen_actions():
+                if act.name in ["link", "hardlink", "dir", "file"]:
+                    install_path = os.path.normpath(
+                        os.path.join(img_root, act.attrs["path"])
+                    )
+                    allentries[install_path] = act.name
+            # Process possible implicit directories.
+            for d in m.get_directories(()):
+                install_path = os.path.normpath(os.path.join(img_root, d))
+                if install_path not in allentries:
+                    allentries[install_path] = "dir"
+            if pt:
+                pt.plan_add_progress(pt.PLAN_PKG_VERIFY)
 
-                def handle_walk_error(oserror_inst):
-                        timestamp = misc.time_to_timestamp(time.time())
-                        self.pd.add_item_message("errors", timestamp,
-                            MSG_ERROR, str(oserror_inst),
-                            msg_type=MSG_UNPACKAGED, parent="unpackaged")
+        def handle_walk_error(oserror_inst):
+            timestamp = misc.time_to_timestamp(time.time())
+            self.pd.add_item_message(
+                "errors",
+                timestamp,
+                MSG_ERROR,
+                str(oserror_inst),
+                msg_type=MSG_UNPACKAGED,
+                parent="unpackaged",
+            )
 
-                orig_img_root = img_root
-                img_root, mntpoint = self.__alt_image_root_with_new_be(
-                    dup_be_name, orig_img_root)
+        orig_img_root = img_root
+        img_root, mntpoint = self.__alt_image_root_with_new_be(
+            dup_be_name, orig_img_root
+        )
 
-                # Walk through file system structure.
-                for root, dirs, files in os.walk(img_root,
-                    onerror=handle_walk_error):
-                        newdirs = []
-                        # Since we possibly changed the img_root into the
-                        # mounted be root, we need to change it back for look
-                        # up.
-                        orig_root = os.path.normpath(os.path.join(
-                            orig_img_root, os.path.relpath(root, img_root)))
-                        for d in sorted(dirs):
-                                timestamp = misc.time_to_timestamp(time.time())
-                                path = os.path.normpath(os.path.join(
-                                    orig_root, d))
-                                # Since the mntpoint is created solely for
-                                # verify purpose, ignore it.
-                                if mntpoint and path == mntpoint:
-                                        continue
-                                if path not in allentries or allentries[path] \
-                                    not in ["dir", "link"]:
-                                        self.pd.add_item_message(
-                                            _("dir: {0}").format(path),
-                                            timestamp,
-                                            MSG_INFO,
-                                            _("Unpackaged directory"),
-                                            msg_type=MSG_UNPACKAGED,
-                                            parent="unpackaged")
-                                else:
-                                        newdirs.append(d)
-                        dirs[:] = newdirs
-
-                        for f in sorted(files):
-                                timestamp = misc.time_to_timestamp(time.time())
-                                path = os.path.normpath(os.path.join(
-                                    orig_root, f))
-                                if path not in allentries or allentries[path] \
-                                    not in ["file", "link", "hardlink"]:
-                                        self.pd.add_item_message(
-                                            _("file: {0}").format(path),
-                                            timestamp, MSG_INFO,
-                                            _("Unpackaged file"),
-                                            msg_type=MSG_UNPACKAGED,
-                                            parent="unpackaged")
-
-        def __process_msgs(self, entries, pfmri, msg_level, result, needs_fix,
-            repairs):
-                """Generate plan message for verify result."""
-
+        # Walk through file system structure.
+        for root, dirs, files in os.walk(img_root, onerror=handle_walk_error):
+            newdirs = []
+            # Since we possibly changed the img_root into the
+            # mounted be root, we need to change it back for look
+            # up.
+            orig_root = os.path.normpath(
+                os.path.join(orig_img_root, os.path.relpath(root, img_root))
+            )
+            for d in sorted(dirs):
                 timestamp = misc.time_to_timestamp(time.time())
-                ffmri = str(pfmri)
-                self.pd.add_item_message(ffmri, timestamp,
-                    msg_level, _("{pkg_name:70} {result:>7}").format(
-                    pkg_name=pfmri.get_pkg_stem(),
-                    result=result))
+                path = os.path.normpath(os.path.join(orig_root, d))
+                # Since the mntpoint is created solely for
+                # verify purpose, ignore it.
+                if mntpoint and path == mntpoint:
+                    continue
+                if path not in allentries or allentries[path] not in [
+                    "dir",
+                    "link",
+                ]:
+                    self.pd.add_item_message(
+                        _("dir: {0}").format(path),
+                        timestamp,
+                        MSG_INFO,
+                        _("Unpackaged directory"),
+                        msg_type=MSG_UNPACKAGED,
+                        parent="unpackaged",
+                    )
+                else:
+                    newdirs.append(d)
+            dirs[:] = newdirs
+
+            for f in sorted(files):
                 timestamp = misc.time_to_timestamp(time.time())
+                path = os.path.normpath(os.path.join(orig_root, f))
+                if path not in allentries or allentries[path] not in [
+                    "file",
+                    "link",
+                    "hardlink",
+                ]:
+                    self.pd.add_item_message(
+                        _("file: {0}").format(path),
+                        timestamp,
+                        MSG_INFO,
+                        _("Unpackaged file"),
+                        msg_type=MSG_UNPACKAGED,
+                        parent="unpackaged",
+                    )
 
-                for act, errors, warnings, info, oing_fmri in entries:
-                        if act:
-                                item_id = act.distinguished_name()
-                                if oing_fmri:
-                                    item_id += ' (from {0})'.format(
-                                        oing_fmri.get_pkg_stem(anarchy=True))
-                                parent = ffmri
-                        else:
-                                item_id = ffmri
-                                parent = None
-                        for x in errors:
-                                self.pd.add_item_message(item_id,
-                                    timestamp, MSG_ERROR,
-                                    _("ERROR: {0}").format(x),
-                                    parent=parent)
-                        for x in warnings:
-                                self.pd.add_item_message(item_id,
-                                    timestamp, MSG_WARNING,
-                                    _("WARNING: {0}").format(x),
-                                    parent=parent)
-                        for x in info:
-                                self.pd.add_item_message(item_id,
-                                    timestamp, MSG_INFO,
-                                    _("{0}").format(x),
-                                    parent=parent)
+    def __process_msgs(
+        self, entries, pfmri, msg_level, result, needs_fix, repairs
+    ):
+        """Generate plan message for verify result."""
 
-                if needs_fix:
-                    # Eliminate policy-based entries with no repair
-                    # action.
-                    for x in needs_fix:
-                        if x[0] in repairs:
-                            if x[1] is not None:
-                                repairs[x[0]].append(
-                                    x[1])
-                        else:
-                            if x[1] is None:
-                                repairs[x[0]] = []
-                            else:
-                                repairs[x[0]] = [x[1]]
+        timestamp = misc.time_to_timestamp(time.time())
+        ffmri = str(pfmri)
+        self.pd.add_item_message(
+            ffmri,
+            timestamp,
+            msg_level,
+            _("{pkg_name:70} {result:>7}").format(
+                pkg_name=pfmri.get_pkg_stem(), result=result
+            ),
+        )
+        timestamp = misc.time_to_timestamp(time.time())
 
-        def __get_overlaying_act_from_cache(self, path, overlay_entries):
-                """Get overlaying action from overlay_entries cache."""
-
-                for e in overlay_entries[path]:
-                        if e[2] == 'overlaying':
-                                return e[0], e[1]
-                return None, None
-
-        def __add_to_processed(self, oing_fmri, overlay, def_pkgs, pfmri, act,
-            errors, warnings, pinfo):
-                """Add newly processed actions results into cache."""
-
-                # If found overlaying package.
+        for act, errors, warnings, info, oing_fmri in entries:
+            if act:
+                item_id = act.distinguished_name()
                 if oing_fmri:
-                        # If the action is an overlaid one, attach the
-                        # overlaying fmri for msg print.
-                        if overlay == "overlaid":
-                            def_pkgs[
-                                pfmri].append((act, errors, warnings, pinfo,
-                                oing_fmri))
-                        # The overlaying action is itself.
-                        else:
-                            def_pkgs[
-                                pfmri].append((act, errors, warnings, pinfo,
-                                None))
-                else:
-                        def_pkgs[
-                            pfmri].append((act, errors, warnings, pinfo,
-                            None))
-
-        def __process_per_overlay_action(self, args, pfmri, entry,
-            def_pkgs, verifypaths, overlaypaths, overlay_entries, pt):
-                """Process per overlay action."""
-
-                act = entry[0]
-                overlay = entry[1]
-                path = act.attrs.get("path")
-                # Try the overlay_entries cache first.
-                oing_fmri, oing_act = \
-                    self.__get_overlaying_act_from_cache(
-                        path, overlay_entries)
-                # If found, process it directly.
-                if oing_act:
-                    act, errors, warnings, pinfo, \
-                    oing_fmri = \
-                        self.__process_verify_result(
-                            act, pfmri, pt,
-                            verifypaths=verifypaths,
-                            overlaypaths=overlaypaths,
-                            ovlying_fmri=oing_fmri,
-                            ovlying_act=oing_act)
-                elif args:
-                        # Not all fmris were processed, we need to find the
-                        # overlaying action.
-                        #
-                        # Also need to collect newly found overlaying
-                        # actions into overlay_entries if any.
-                        act, errors, warnings, pinfo, oing_fmri = \
-                            self.__process_verify_result(
-                            act, pfmri, pt,
-                            verifypaths=verifypaths,
-                            overlaypaths=overlaypaths,
-                            ovly_entries=overlay_entries)
-                else:
-                        # All fmris were processed, if the cache didn't contain
-                        # the action, that means no overlaying action.
-                        #
-                        # We need to skip overlaying action finding, since we
-                        # already know no overlaying action in the cache.
-                        act, errors, warnings, pinfo, oing_fmri = \
-                            self.__process_verify_result(
-                            act, pfmri, pt,
-                            verifypaths=verifypaths,
-                            overlaypaths=overlaypaths,
-                            skip_ovlying=True)
-                self.__add_to_processed(oing_fmri, overlay, def_pkgs, pfmri,
-                    act, errors, warnings, pinfo)
-
-        def __check_attr_mismatch_between_actions(self, overlaid, overlaying):
-                """Check attribute mismatch between overlaying and overlaid
-                 actions."""
-
-                overlaid_act = overlaid[1]
-                overlaying_act = overlaying[1]
-                o_attr_overlaid = overlaid_act.attrs.get("overlay-attributes")
-                o_attr_overlaying = overlaying_act.attrs.get(
-                    "overlay-attributes")
-                owner_overlaid = overlaid_act.attrs["owner"]
-                owner_overlaying = overlaying_act.attrs["owner"]
-                mode_overlaid = overlaid_act.attrs["mode"]
-                mode_overlaying = overlaying_act.attrs["mode"]
-                group_overlaid = overlaid_act.attrs["group"]
-                group_overlaying = overlaying_act.attrs["group"]
-
-                msgs = []
-                if owner_overlaid != owner_overlaying:
-                        msgs.append(_("owner: {0} does not match overlaid "
-                            "package owner: {1}").format(owner_overlaying,
-                            owner_overlaid))
-                if mode_overlaid != mode_overlaying:
-                        msgs.append(_("mode: {0} does not match overlaid "
-                            "package mode: {1}").format(mode_overlaying,
-                            mode_overlaid))
-                if group_overlaid != group_overlaying:
-                        msgs.append(_("group: {0} does not match overlaid "
-                            "package group: {1}").format(group_overlaying,
-                            group_overlaid))
-                if not msgs:
-                        return
-
-                item_id = str(overlaying[0])
-                act_id = overlaid_act.distinguished_name()
-                msg_level = MSG_INFO
-                result = "OK"
-
-                if o_attr_overlaid == "deny" or o_attr_overlaying == "deny":
-                        msg_level = MSG_ERROR
-
-                # Check if there is already an FMRI-level message;
-                # update it or add a new one if necessary.
-                item_msgs = self.pd.get_parsable_item_messages()
-                added_msgs = None
-                if item_id in item_msgs and "messages" in item_msgs[item_id]:
-                        added_msgs = item_msgs[item_id]["messages"]
-                add_msg = False
-                if added_msgs:
-                        if (added_msgs[0]["msg_level"] == MSG_INFO and
-                            msg_level == MSG_ERROR):
-                                # Empty the current message list.
-                                added_msgs[:] = []
-                                add_msg = True
-                else:
-                        add_msg = True
-
-                timestamp = misc.time_to_timestamp(time.time())
-                if add_msg:
-                        self.pd.add_item_message(item_id, timestamp, msg_level,
-                            _("{pkg_name:70} {result:>7}").format(
-                            pkg_name=overlaying[0].get_pkg_stem(),
-                            result=result))
-                self.pd.add_item_message(act_id, timestamp, msg_level,
-                    _("Overlaid package: {0}").format(
-                    overlaid[0].get_pkg_stem()), parent=item_id)
-
-                for msg in msgs:
-                        if msg_level == MSG_ERROR:
-                                imsg = _("ERROR: {0}").format(msg)
-                        else:
-                                imsg = msg
-                        self.pd.add_item_message(act_id, timestamp, msg_level,
-                            imsg, parent=item_id)
-
-        def __verify_fmris(self, repairs, args, proposed_fmris, pt, verifypaths,
-            overlaypaths):
-                """Verify FRMIs."""
-
-                path_only = bool(verifypaths or overlaypaths)
-                overlay_entries = {}
-                def_pkgs = {}  # deferred packages
-                def_acts = {}  # deferred actions
-                for pfmri in proposed_fmris:
-                        entries = []
-                        needs_fix = []
-                        result = "OK"
-                        failed = False
-                        msg_level = MSG_INFO
-
-                        # Since every entry returned by verify might not be
-                        # something needing repair, the relevant information
-                        # for each package must be accumulated first to find
-                        # an overall success/failure result and then the
-                        # related messages output for it.
-                        verify_path_count = len(verifypaths)
-                        overlay_path_count = len(overlaypaths)
-                        for act, errors, warnings, pinfo, overlay in \
-                            self.image.verify(pfmri, pt,
-                            verifypaths=verifypaths,
-                            overlaypaths=overlaypaths, verbose=True,
-                            forever=True):
-                                if not path_only and overlay:
-                                        path = act.attrs.get("path")
-                                        if path not in overlay_entries:
-                                            overlay_entries[path] = []
-                                        overlay_entries[path].append(
-                                            (pfmri, act, overlay))
-
-                                        if pfmri not in def_acts:
-                                            def_acts[pfmri] = []
-                                        def_acts[pfmri].append((act, overlay))
-                                else:
-                                        entries.append((act, errors, warnings,
-                                            pinfo, None))
-                                # Try to determine the package's status and
-                                # message type. This is subject to change if
-                                # the package contains overlay actions.
-                                if errors:
-                                        failed = True
-                                        result = "ERROR"
-                                        msg_level = MSG_ERROR
-                                        # Some errors are based on policy (e.g.
-                                        # signature policy) and not a specific
-                                        # action, so act may be None.
-                                        needs_fix.append((pfmri, act))
-                                elif not failed and warnings:
-                                        result = "WARNING"
-                                        msg_level = MSG_WARNING
-
-                        # Defer final processing of package if verification was
-                        # deferred for any of its actions.
-                        if pfmri in def_acts:
-                                def_pkgs[pfmri] = entries
-                                continue
-
-                        if (path_only and verify_path_count == len(verifypaths)
-                            and overlay_path_count == len(overlaypaths)):
-                                # When verifying paths, omit packages without any
-                                # matches from output.
-                                continue
-                        self.__process_msgs(entries, pfmri, msg_level, result,
-                            needs_fix, repairs)
-                        if path_only and not overlaypaths and not verifypaths:
-                                return
-
-                # No need to proceed for path only case.
-                if path_only:
-                        return
-
-                # Process deferred actions.
-                for pfmri, entries in def_acts.items():
-                        for entry in entries:
-                                self.__process_per_overlay_action(args, pfmri,
-                                    entry, def_pkgs, verifypaths,
-                                    overlaypaths, overlay_entries, pt)
-
-                # Generate messages for all processed packages with overlay
-                # actions.
-                for pfmri, entries in def_pkgs.items():
-                        failed = False
-                        result = "OK"
-                        msg_level = MSG_INFO
-                        needs_fix = []
-                        for act, errors, warnings, pinfo, oing_fmri in entries:
-                                # Try to determine the package's status and
-                                # message type.
-                                if errors:
-                                        failed = True
-                                        result = "ERROR"
-                                        msg_level = MSG_ERROR
-                                        if oing_fmri:
-                                                # Only append overlaying action
-                                                # if not all packages are
-                                                # verified. Otherwise, the
-                                                # overlaying action will be
-                                                # append later.
-                                                if args:
-                                                        needs_fix.append((
-                                                            oing_fmri, act))
-                                        else:
-                                                needs_fix.append((pfmri, act))
-                                elif not failed and warnings:
-                                        result = "WARNING"
-                                        msg_level = MSG_WARNING
-
-                        self.__process_msgs(entries, pfmri, msg_level, result,
-                            needs_fix, repairs)
-
-                # Generate overlay-specific messages.
-                for path, entries in overlay_entries.items():
-                        overlaid = None
-                        overlaying = None
-                        for e in entries:
-                                if e[2] == "overlaid":
-                                        overlaid = e
-                                elif e[2] == "overlaying":
-                                        overlaying = e
-                        if overlaid and overlaying:
-                                self.__check_attr_mismatch_between_actions(
-                                    overlaid, overlaying)
-
-        def plan_fix(self, args, unpackaged=False, unpackaged_only=False,
-                verify_paths=misc.EmptyI):
-                """Determine the changes needed to fix the image."""
-
-                self.__plan_op()
-                self.__evaluate_excludes()
-
-                pt = self.__progtrack
-                pt.plan_all_start()
-
-                if args:
-                        proposed_dict, self.__match_rm = self.__match_user_fmris(
-                            self.image, args, self.MATCH_INST_VERSIONS)
-
-                        # merge patterns together
-                        proposed_fixes = sorted(set([
-                            f
-                            for each in proposed_dict.values()
-                            for f in each
-                        ]))
-                else:
-                        # No FMRIs specified, verify all packages
-                        proposed_fixes = list(self.image.gen_installed_pkgs(
-                            ordered=True))
-
-                repairs = {}
-                overlaypaths = set()
-                verifypaths = set(a.lstrip(os.path.sep) for a in verify_paths)
-
-                if not verify_paths:
-                        pt.plan_start(pt.PLAN_PKG_VERIFY, goal=len(proposed_fixes))
-
-                        # Verify unpackaged contents.
-                        if unpackaged or unpackaged_only:
-                                dup_be_name = "duplicate_livebe_for_verify"
-                                try:
-                                        self.__process_unpackaged(
-                                            proposed_fixes, pt=pt,
-                                            dup_be_name=dup_be_name)
-                                finally:
-                                        # Clean up the BE used for verify.
-                                        bootenv.BootEnv.cleanup_be(dup_be_name)
-                                pt.plan_done(pt.PLAN_PKG_VERIFY)
-                                if unpackaged_only:
-                                        self.__finish_plan(plandesc.EVALUATED_PKGS)
-                                        return
-                                # Otherwise we reset the goals for packaged
-                                # contents.
-                                pt.plan_start(pt.PLAN_PKG_VERIFY, goal=len(
-                                    proposed_fixes))
-                        self.__verify_fmris(repairs, args, proposed_fixes, pt,
-                            verifypaths, overlaypaths)
-                else:
-                        pt.plan_start(pt.PLAN_PKG_VERIFY, goal=len(verifypaths))
-
-                        self.__verify_fmris(repairs, args, proposed_fixes, pt,
-                            verifypaths, overlaypaths)
-
-                        timestamp = misc.time_to_timestamp(time.time())
-                        for path_not_found in verifypaths:
-                                pt.plan_add_progress(pt.PLAN_PKG_VERIFY)
-                                self.pd.add_item_message("path not found",
-                                    timestamp, MSG_WARNING,
-                                    _("{path} is not found in the image").format(
-                                        path=path_not_found))
-
-                        if args and overlaypaths:
-                                # Only perform verification for the rest of packages
-                                # if FMRIs are provided and there are actions with
-                                # overlay=allow found in those FMRIs. In the second
-                                # pass, only look for actions with overlay=true.
-                                pfixes = set(proposed_fixes)
-                                path_fmri = [
-                                    f
-                                    for f in self.image.gen_installed_pkgs(
-                                        ordered=True)
-                                        if f not in pfixes
-                                ]
-                                self.__verify_fmris(repairs, args, path_fmri, pt,
-                                    set(), overlaypaths)
-
-                pt.plan_done(pt.PLAN_PKG_VERIFY)
-                # If no repairs, finish the plan.
-                if not repairs:
-                        self.__finish_plan(plandesc.EVALUATED_PKGS)
-                        return
-
-                # Repair anything we failed to verify.
-                pt.plan_start(pt.PLAN_PKG_FIX, goal=len(repairs))
-                for fmri, actions in repairs.items():
-                        pt.plan_add_progress(pt.PLAN_PKG_FIX)
-                        # Need to get all variants otherwise evaluating the
-                        # pkgplan will fail in signature verification.
-                        m = self.image.get_manifest(fmri, ignore_excludes=True)
-                        pp = pkgplan.PkgPlan(self.image)
-                        pp.propose_repair(fmri, m, actions, [])
-                        pp.evaluate(self.__old_excludes, self.__new_excludes)
-                        self.pd.pkg_plans.append(pp)
-
-                pt.plan_done(pt.PLAN_PKG_FIX)
-                pt.plan_all_done()
-                self.__finish_plan(plandesc.EVALUATED_PKGS)
-
-        def plan_noop(self):
-                """Create a plan that doesn't change the package contents of
-                the current image."""
-                self.__plan_op()
-                self.pd._fmri_changes = []
-                self.pd.state = plandesc.EVALUATED_PKGS
-
-        @staticmethod
-        def __fmris2dict(fmri_list):
-                return  dict([
-                    (f.pkg_name, f)
-                    for f in fmri_list
-                ])
-
-        @staticmethod
-        def __dicts2fmrichanges(olddict, newdict):
-                return [
-                    (olddict.get(k, None), newdict.get(k, None))
-                    for k in set(list(olddict.keys()) + list(newdict.keys()))
-                ]
-
-        def reboot_advised(self):
-                """Check if evaluated imageplan suggests a reboot"""
-                assert self.state >= plandesc.MERGED_OK
-                return self.pd._actuators.reboot_advised()
-
-        def reboot_needed(self):
-                """Check if evaluated imageplan requires a reboot"""
-                assert self.pd.state >= plandesc.MERGED_OK
-                return self.pd._actuators.reboot_needed()
-
-        def boot_archive_needed(self):
-                """True if boot archive needs to be rebuilt"""
-                assert self.pd.state >= plandesc.MERGED_OK
-                return self.pd._need_boot_archive
-
-        def get_solver_errors(self):
-                """Returns a list of strings for all FMRIs evaluated by the
-                solver explaining why they were rejected.  (All packages
-                found in solver's trim database.)"""
-                return self.pd.get_solver_errors()
-
-        def get_plan(self, full=True):
-                if full:
-                        return str(self)
-
-                output = ""
-                for t in self.pd._fmri_changes:
-                        output += "{0} -> {1}\n".format(*t)
-                return output
-
-        def gen_new_installed_pkgs(self):
-                """Generates all the fmris which will be in the new image."""
-                assert self.pd.state >= plandesc.EVALUATED_PKGS
-                fmri_set = set(self.image.gen_installed_pkgs())
-
-                for p in self.pd.pkg_plans:
-                        p.update_pkg_set(fmri_set)
-
-                for pfmri in fmri_set:
-                        yield pfmri
-
-        def __gen_only_new_installed_info(self):
-                """Generates fmri-manifest pairs for all packages which are
-                being installed (or fixed, etc.)."""
-                assert self.pd.state >= plandesc.EVALUATED_PKGS
-
-                for p in self.pd.pkg_plans:
-                        if p.destination_fmri:
-                                assert p.destination_manifest
-                                yield p.destination_fmri, p.destination_manifest
-
-        def __gen_outgoing_info(self):
-                """Generates fmri-manifest pairs for all the packages which are
-                being removed."""
-                assert self.pd.state >= plandesc.EVALUATED_PKGS
-
-                for p in self.pd.pkg_plans:
-                        if p.origin_fmri and \
-                            p.origin_fmri != p.destination_fmri:
-                                assert p.origin_manifest
-                                yield p.origin_fmri, p.origin_manifest
-
-        def gen_new_installed_actions_bytype(self, atype, implicit_dirs=False):
-                """Generates actions of type 'atype' from the packages in the
-                future image."""
-
-                return self.__gen_star_actions_bytype(atype,
-                    self.gen_new_installed_pkgs, implicit_dirs=implicit_dirs)
-
-        def gen_only_new_installed_actions_bytype(self, atype,
-            implicit_dirs=False, excludes=misc.EmptyI):
-                """Generates actions of type 'atype' from packages being
-                installed."""
-
-                return self.__gen_star_actions_bytype_from_extant_manifests(
-                    atype, self.__gen_only_new_installed_info, excludes,
-                    implicit_dirs=implicit_dirs)
-
-        def gen_outgoing_actions_bytype(self, atype,
-            implicit_dirs=False, excludes=misc.EmptyI):
-                """Generates actions of type 'atype' from packages being
-                removed (not necessarily actions being removed)."""
-
-                return self.__gen_star_actions_bytype_from_extant_manifests(
-                    atype, self.__gen_outgoing_info, excludes,
-                    implicit_dirs=implicit_dirs)
-
-        def __gen_star_actions_bytype(self, atype, generator, implicit_dirs=False):
-                """Generate installed actions of type 'atype' from the package
-                fmris emitted by 'generator'.  If 'implicit_dirs' is True, then
-                when 'atype' is 'dir', directories only implicitly delivered
-                in the image will be emitted as well."""
-
-                assert self.pd.state >= plandesc.EVALUATED_PKGS
-
-                # Don't bother accounting for implicit directories if we're not
-                # looking for them.
-                if implicit_dirs:
-                        if atype != "dir":
-                                implicit_dirs = False
-                        else:
-                                da = pkg.actions.directory.DirectoryAction
-
-                for pfmri in generator():
-                        m = self.image.get_manifest(pfmri, ignore_excludes=True)
-                        if implicit_dirs:
-                                dirs = set() # Keep track of explicit dirs
-                        for act in m.gen_actions_by_type(atype,
-                            excludes=self.__new_excludes):
-                                if implicit_dirs:
-                                        dirs.add(act.attrs["path"])
-                                yield act, pfmri
-                        if implicit_dirs:
-                                for d in m.get_directories(self.__new_excludes):
-                                        if d not in dirs:
-                                                yield da(path=d, implicit="true"), pfmri
-
-        def __gen_star_actions_bytype_from_extant_manifests(self, atype,
-            generator, excludes, implicit_dirs=False):
-                """Generate installed actions of type 'atype' from the package
-                manifests emitted by 'generator'.  'excludes' is a list of
-                variants and facets which should be excluded from the actions
-                generated.  If 'implicit_dirs' is True, then when 'atype' is
-                'dir', directories only implicitly delivered in the image will
-                be emitted as well."""
-
-                assert self.pd.state >= plandesc.EVALUATED_PKGS
-
-                # Don't bother accounting for implicit directories if we're not
-                # looking for them.
-                if implicit_dirs:
-                        if atype != "dir":
-                                implicit_dirs = False
-                        else:
-                                da = pkg.actions.directory.DirectoryAction
-
-                for pfmri, m in generator():
-                        if implicit_dirs:
-                                dirs = set() # Keep track of explicit dirs
-                        for act in m.gen_actions_by_type(atype,
-                            excludes=excludes):
-                                if implicit_dirs:
-                                        dirs.add(act.attrs["path"])
-                                yield act, pfmri
-
-                        if implicit_dirs:
-                                for d in m.get_directories(excludes):
-                                        if d not in dirs:
-                                                yield da(path=d,
-                                                    implicit="true"), pfmri
-
-        def __get_directories(self):
-                """ return set of all directories in target image """
-                # always consider var and the image directory fixed in image...
-                if self.__directories == None:
-                        # It's faster to build a large set and make a small
-                        # update to it than to do the reverse.
-                        dirs = set((
-                            os.path.normpath(d[0].attrs["path"])
-                            for d in self.gen_new_installed_actions_bytype("dir",
-                                implicit_dirs=True)
-                        ))
-                        dirs.update([
-                            self.image.imgdir.rstrip("/"),
-                            "var",
-                            "var/sadm",
-                            "var/sadm/install"
-                        ])
-                        self.__directories = dirs
-                return self.__directories
-
-        def __get_symlinks(self):
-                """ return a set of all symlinks in target image"""
-                if self.__symlinks == None:
-                        self.__symlinks = set((
-                            a.attrs["path"]
-                            for a, pfmri in self.gen_new_installed_actions_bytype("link")
-                        ))
-                return self.__symlinks
-
-        def __get_hardlinks(self):
-                """ return a set of all hardlinks in target image"""
-                if self.__hardlinks == None:
-                        self.__hardlinks = set((
-                            a.attrs["path"]
-                            for a, pfmri in self.gen_new_installed_actions_bytype("hardlink")
-                        ))
-                return self.__hardlinks
-
-        def __get_licenses(self):
-                """ return a set of all licenses in target image"""
-                if self.__licenses == None:
-                        self.__licenses = set((
-                            a.attrs["license"]
-                            for a, pfmri in self.gen_new_installed_actions_bytype("license")
-                        ))
-                return self.__licenses
-
-        def __get_legacy(self):
-                """ return a set of all legacy actions in target image"""
-                if self.__legacy == None:
-                        self.__legacy = set((
-                            a.attrs["pkg"]
-                            for a, pfmri in self.gen_new_installed_actions_bytype("legacy")
-                        ))
-                return self.__legacy
-
-        @staticmethod
-        def __check_inconsistent_types(actions, oactions):
-                """Check whether multiple action types within a namespace group
-                deliver to a given name in that space."""
-
-                ntypes = set((a[0].name for a in actions))
-                otypes = set((a[0].name for a in oactions))
-
-                # We end up with nothing at this path, or start and end with one
-                # of the same type, or we just add one type to an empty path.
-                if len(ntypes) == 0 or (len(ntypes) == 1 and len(otypes) <= 1):
-                        return None
-
-                # We have fewer types, so actions are getting removed.
-                if len(ntypes) < len(otypes):
-                        # If we still end up in a broken state, signal the
-                        # caller that we should move forward, but not remove
-                        # anything at this path.  Note that the type on the
-                        # filesystem may not match any of the remaining types.
-                        if len(ntypes) > 1:
-                                return "nothing", None
-
-                        assert len(ntypes) == 1
-
-                        # If we end up in a sane state, signal the caller that
-                        # we should make sure the right contents are in place.
-                        # This implies that the actions remove() method should
-                        # handle when the action isn't present.
-                        if actions[0][0].name != "dir":
-                                return "fixup", actions[0]
-
-                        # If we end up with a directory, then we need to be
-                        # careful to choose a non-implicit directory as the
-                        # fixup action.
-                        for a in actions:
-                                if "implicit" not in a[0].attrs:
-                                        return "fixup", a
-                        else:
-                                # If we only have implicit directories left,
-                                # make up the rest of the attributes.
-                                a[0].attrs.update({"mode": "0755", "owner":
-                                    "root", "group": "root"})
-                                return "fixup", a
-
-                # If the broken packages remain unchanged across the plan, then
-                # we can ignore it.  We just check that the packages haven't
-                # changed.
-                sort_key = operator.itemgetter(1)
-                actions = sorted(actions, key=sort_key)
-                oactions = sorted(oactions, key=sort_key)
-                if ntypes == otypes and \
-                    all(o[1] == n[1] for o, n in zip(oactions, actions)):
-                        return "nothing", None
-
-                return "error", actions
-
-        @staticmethod
-        def __check_duplicate_actions(actions, oactions):
-                """Check whether we deliver more than one action with a given
-                key attribute value if only a single action of that type and
-                value may be delivered."""
-
-                # We end up with no actions or start with one or none and end
-                # with exactly one.
-                if len(actions) == 0 or (len(oactions) <= len(actions) == 1):
-                        if (len(oactions) > 1 and
-                            any(a[0].attrs.get("overlay") == "true"
-                                for a in oactions)):
-                                # If more than one action is being removed and
-                                # one of them is an overlay, then suppress
-                                # removal of the overlaid actions (if any) to
-                                # ensure preserve rules of overlay action apply.
-                                return "overlay", None
-                        return None
-
-                # Removing actions.
-                if len(actions) < len(oactions):
-                        # If any of the new actions is an overlay, suppress
-                        # the removal of the overlaid action.
-                        if any(a[0].attrs.get("overlay") == "true"
-                            for a in actions):
-                                return "overlay", None
-
-                        # If we still end up in a broken state, signal the
-                        # caller that we should move forward, but not remove
-                        # any actions.
-                        if len(actions) > 1 or \
-                            any("preserve" in a[0].attrs for a in actions):
-                                return "nothing", None
-
-                        # If we end up in a sane state, signal the caller that
-                        # we should make sure the right contents are in place.
-                        # This implies that the action's remove() method should
-                        # handle when the action isn't present.
-                        return "fixup", actions[0]
-
-                # If the broken paths remain unchanged across the plan, then we
-                # can ignore it.  We have to resort to stringifying the actions
-                # in order to sort them since the usual sort is much lighter
-                # weight.
-                oactions.sort(key=lambda x: str(x[0]))
-                actions.sort(key=lambda x: str(x[0]))
-                if len(oactions) == len(actions) and \
-                    all(o[0] == n[0] for o, n, in zip(oactions, actions)):
-                        return "nothing", None
-
-                # For file actions, delivery of two actions to a single point is
-                # permitted if:
-                #   * there are only two actions in conflict
-                #   * one action has 'preserve' set and 'overlay=allow'
-                #   * the other action has 'overlay=true'
-                if len(actions) == 2:
-                        overlayable = overlay = None
-                        for act, ignored in actions:
-                                if (act.name == "file" and
-                                    act.attrs.get("overlay") == "allow" and
-                                    "preserve" in act.attrs):
-                                        overlayable = act
-                                elif (act.name == "file" and
-                                    act.attrs.get("overlay") == "true"):
-                                        overlay = act
-                        if overlayable and overlay:
-                                # Found both an overlayable action and the
-                                # action that overlays it.
-                                ignore = ["preserve"]
-                                # If neither overlay nor overlayable action
-                                # has "deny" set in "overlay-attributes"
-                                if ("deny" not in overlay.attrlist(
-                                    "overlay-attributes") and "deny" not in
-                                    overlayable.attrlist(
-                                    "overlay-attributes")):
-                                        ignore.extend(["owner", "group",
-                                            "mode", "sysattr"])
-                                # Need to verify mismatched attributes between
-                                # overlaying action and overlaid action in
-                                # testsuite.
-                                elif DebugValues[
-                                    "broken-conflicting-action-handling"]:
-                                        ignore.extend(["owner", "group",
-                                            "mode", "sysattr"])
-                                errors = ImagePlan.__find_inconsistent_attrs(
-                                    actions, ignore=ignore)
-                                if errors:
-                                        # overlay is not permitted if unique
-                                        # attributes (except 'preserve') are
-                                        # inconsistent
-                                        return ("error", actions,
-                                            api_errors.InconsistentActionAttributeError)
-                                return "overlay", None
-
-                return "error", actions
-
-        @staticmethod
-        def __find_inconsistent_attrs(actions, ignore=misc.EmptyI):
-                """Find all the problem Action pairs.
-
-                'ignore' is an optional list of attributes to ignore when
-                checking for inconsistent attributes.  By default, all
-                attributes listed in the 'unique_attrs' property of an
-                Action are checked.
-                """
-
-                # We iterate over all pairs of actions to see if any conflict
-                # with the rest.  If two actions are "safe" together, then we
-                # can ignore one of them for the rest of the run, since we can
-                # compare the rest of the actions against just one copy of
-                # essentially identical actions.
-                seen = set()
-                problems = []
-                for a1, a2 in itertools.combinations(actions, 2):
-                        # Implicit directories don't contribute to problems.
-                        if a1[0].name == "dir" and "implicit" in a1[0].attrs:
-                                continue
-
-                        if a2 in seen:
-                                continue
-
-                        # Find the attributes which are different between the
-                        # two actions, and if there are none, skip the action.
-                        # We have to treat "implicit" specially for implicit
-                        # directories because none of the attributes except for
-                        # "path" will exist.
-                        diffs = a1[0].differences(a2[0])
-                        if not diffs or "implicit" in diffs:
-                                seen.add(a2)
-                                continue
-
-                        # If none of the different attributes is one that must
-                        # be identical, then we can skip this action.
-                        if not any(
-                            d for d in diffs
-                            if (d in a1[0].unique_attrs and
-                                d not in ignore)):
-                                seen.add(a2)
-                                continue
-
-                        if ((a1[0].name == "link" or a1[0].name == "hardlink") and
-                           (a1[0].attrs.get("mediator") == a2[0].attrs.get("mediator")) and
-                           (a1[0].attrs.get("mediator-version") != a2[0].attrs.get("mediator-version") or
-                            a1[0].attrs.get("mediator-implementation") != a2[0].attrs.get("mediator-implementation"))):
-                                # If two links share the same mediator and have
-                                # different mediator versions and/or
-                                # implementations, then permit them to collide.
-                                # The imageplan will select which ones to remove
-                                # and install based on the mediator configuration
-                                # in the image.
-                                seen.add(a2)
-                                continue
-
-                        problems.append((a1, a2))
-
-                return problems
-
-        @staticmethod
-        def __check_inconsistent_attrs(actions, oactions):
-                """Check whether we have non-identical actions delivering to the
-                same point in their namespace."""
-
-                nproblems = ImagePlan.__find_inconsistent_attrs(actions)
-                oproblems = ImagePlan.__find_inconsistent_attrs(oactions)
-
-                # If we end up with more problems than we started with, we
-                # should error out.  If we end up with the same number as
-                # before, then we simply leave things alone.  And if we end up
-                # with fewer, then we try to clean up.
-                if len(nproblems) > len(oproblems):
-                        return "error", actions
-                elif not nproblems and not oproblems:
-                        return
-                elif len(nproblems) == len(oproblems):
-                        return "nothing", None
-                else:
-                        if actions[0][0].name != "dir":
-                                return "fixup", actions[0]
-
-                        # Find a non-implicit directory action to use
-                        for a in actions:
-                                if "implicit" not in a[0].attrs:
-                                        return "fixup", a
-                        else:
-                                return "nothing", None
-
-        def __propose_fixup(self, inst_action, rem_action, pfmri):
-                """Add to the current plan a pseudo repair plan to fix up
-                correctable conflicts."""
-
-                pp, install, remove = self.__fixups.get(pfmri,
-                    (None, None, None))
-                if pp is None:
-                        pp = pkgplan.PkgPlan(self.image)
-                        if inst_action:
-                                install = [inst_action]
-                                remove = []
-                        else:
-                                install = []
-                                remove = [rem_action]
-                        self.__fixups[pfmri] = pp, install, remove
-                elif inst_action:
-                        install.append(inst_action)
-                else:
-                        remove.append(rem_action)
-
-        def __evaluate_fixups(self):
-                nfm = manifest.NullFactoredManifest
-                for pfmri, (pp, install, remove) in self.__fixups.items():
-                        pp.propose_repair(pfmri, nfm, install, remove,
-                            autofix=True)
-                        pp.evaluate(self.__old_excludes, self.__new_excludes)
-                        self.pd.pkg_plans.append(pp)
-
-                        # Repairs end up going into the package plan's update
-                        # and remove lists, so _ActionPlans needed to be
-                        # appended for each action in this fixup pkgplan to
-                        # the list of related actions.
-                        for action in install:
-                                if 'path' in action.attrs and \
-                                    self.__check_excluded(action.attrs['path']):
-                                        continue
-                                self.pd.update_actions.append(
-                                    _ActionPlan(pp, None, action))
-                        for action in remove:
-                                if 'path' in action.attrs and \
-                                    self.__check_excluded(action.attrs['path']):
-                                        continue
-                                self.pd.removal_actions.append(
-                                    _ActionPlan(pp, action, None))
-
-                # Don't process this particular set of fixups again.
-                self.__fixups = {}
-
-        def __process_conflicts(self, key, func, actions, oactions, errclass, errs):
-                """The conflicting action checking functions all need to be
-                dealt with in a similar fashion, so we do that work in one
-                place."""
-
-                ret = func(actions, oactions)
-                if ret is None:
-                        return False
-
-                if len(ret) == 3:
-                        # Allow checking functions to override default errclass.
-                        msg, actions, errclass = ret
-                else:
-                        msg, actions = ret
-
-                if not isinstance(msg, six.string_types):
-                        return False
-
-                if msg == "nothing":
-                        for i, ap in enumerate(self.pd.removal_actions):
-                                if ap and ap.src.attrs.get(ap.src.key_attr,
-                                    None) == key:
-                                        self.pd.removal_actions[i] = None
-                elif msg == "overlay":
-                        pp_needs_trimming = {}
-                        moved = set()
-                        # Suppress install and update of overlaid file.
-                        for al in (self.pd.install_actions,
-                            self.pd.update_actions):
-                                for i, ap in enumerate(al):
-                                        if not ap:
-                                                # Action has been removed.
-                                                continue
-
-                                        attrs = ap.dst.attrs
-                                        if attrs.get(ap.dst.key_attr) != key:
-                                                if ("preserve" in attrs and
-                                                    "original_name" in attrs):
-                                                        # Possible move to a
-                                                        # different location for
-                                                        # editable file.
-                                                        # Overlay attribute is
-                                                        # not checked in case it
-                                                        # was dropped as part of
-                                                        # move.
-                                                        moved.add(
-                                                            attrs["original_name"])
-                                                continue
-
-                                        if attrs.get("overlay") != "allow":
-                                                    # Only care about overlaid
-                                                    # actions.
-                                                    continue
-
-                                        # Remove conflicting, overlaid actions
-                                        # from plan.
-                                        al[i] = None
-                                        pp_needs_trimming.setdefault(id(ap.p),
-                                            { "plan": ap.p, "trim": [] })
-                                        pp_needs_trimming[id(ap.p)]["trim"].append(
-                                            id(ap.dst))
-                                        break
-
-                        # Suppress removal of overlaid file.
-                        al = self.pd.removal_actions
-                        for i, ap in enumerate(al):
-                                if not ap:
-                                        continue
-
-                                attrs = ap.src.attrs
-                                if not attrs.get(ap.src.key_attr) == key:
-                                        continue
-
-                                if attrs.get("overlay") != "allow":
-                                        # Only interested in overlaid actions.
-                                        continue
-
-                                orig_name = attrs.get("original_name",
-                                    "{0}:{1}".format(ap.p.origin_fmri.get_name(),
-                                        attrs["path"]))
-                                if orig_name in moved:
-                                        # File has moved locations; removal will
-                                        # be executed, but file will be saved
-                                        # for the move skipping unlink.
-                                        ap.src.attrs["save_file"] = \
-                                            [orig_name, "false"]
-                                        break
-
-                                al[i] = None
-                                pp_needs_trimming.setdefault(id(ap.p),
-                                    { "plan": ap.p, "trim": [] })
-                                pp_needs_trimming[id(ap.p)]["trim"].append(
-                                    id(ap.src))
-                                break
-
-                        for entry in pp_needs_trimming.values():
-                                p = entry["plan"]
-                                trim = entry["trim"]
-                                # Can't modify the p.actions tuple, so modify
-                                # the added member in-place.
-                                for prop in ("added", "changed", "removed"):
-                                        pval = getattr(p.actions, prop)
-                                        pval[:] = [
-                                            a
-                                            for a in pval
-                                            if id(a[1]) not in trim
-                                        ]
-                elif msg == "fixup":
-                        self.__propose_fixup(actions[0], None, actions[1])
-                elif msg == "error":
-                        errs.append(errclass(actions))
-                else:
-                        assert False, "{0}() returned something other than " \
-                            "'nothing', 'overlay', 'error', or 'fixup': '{1}'".format(
-                            func.__name__, msg)
-
-                return True
-
-        def __seed(self, gen_func, action_classes, excludes):
-                """Build a mapping from action keys to action, pfmri tuples for
-                a set of action types.
-
-                The 'gen_func' is a function which takes an action type and
-                'implicit_dirs' and returns action-pfmri pairs.
-
-                The 'action_classes' parameter is a list of action types."""
-
-                d = {}
-                for klass in action_classes:
-                        self.__progtrack.plan_add_progress(
-                            self.__progtrack.PLAN_ACTION_CONFLICT)
-                        for a, pfmri in \
-                            gen_func(klass.name, implicit_dirs=True,
-                            excludes=excludes):
-                                d.setdefault(a.attrs[klass.key_attr],
-                                    []).append((a, pfmri))
-                return d
-
-        @staticmethod
-        def __act_dup_check(tgt, key, actstr, fmristr):
-                """Check for duplicate actions/fmri tuples in 'tgt', which is
-                indexed by 'key'."""
-
-                #
-                # When checking for duplicate actions we have to account for
-                # the fact that actions which are part of a package plan are
-                # not stripped.  But the actions we're iterating over here are
-                # coming from the stripped action cache, so they have had
-                # assorted attributes removed (like variants, facets, etc.) So
-                # to check for duplicates we have to make sure to strip the
-                # actions we're comparing against.  Of course we can't just
-                # strip the actions which are part of a package plan because
-                # we could be removing data critical to the execution of that
-                # action like original_name, etc.  So before we strip an
-                # action we have to make a copy of it.
-                #
-                # If we're dealing with a directory action and an "implicit"
-                # attribute exists, we need to preserve it.  We assume it's a
-                # synthetic attribute that indicates that the action was
-                # created implicitly (and hence won't conflict with an
-                # explicit directory action defining the same directory).
-                # Note that we've assumed that no one will ever add an
-                # explicit "implicit" attribute to a directory action.
-                #
-                preserve = {"dir": ["implicit"]}
-                if key not in tgt:
-                        return False
-                for act, pfmri in tgt[key]:
-                        # check the fmri first since that's easy
-                        if fmristr != str(pfmri):
-                                continue
-                        act = pkg.actions.fromstr(str(act))
-                        act.strip(preserve=preserve)
-                        if actstr == str(act):
-                                return True
-                return False
-
-        def __update_act(self, keys, tgt, skip_dups, offset_dict,
-            action_classes, sf, skip_fmris, fmri_dict):
-                """Update 'tgt' with action/fmri pairs from the stripped
-                action cache that are associated with the specified action
-                'keys'.
-
-                The 'skip_dups' parameter indicates if we should avoid adding
-                duplicate action/pfmri pairs into 'tgt'.
-
-                The 'offset_dict' parameter contains a mapping from key to
-                offsets into the actions.stripped file and the number of lines
-                to read.
-
-                The 'action_classes' parameter contains the list of action types
-                where one action can conflict with another action.
-
-                The 'sf' parameter is the actions.stripped file from which we
-                read the actual actions indicated by the offset dictionary
-                'offset_dict.'
-
-                The 'skip_fmris' parameter contains a set of strings
-                representing the packages which we should not process actions
-                for.
-
-                The 'fmri_dict' parameter is a cache of previously built PkgFmri
-                objects which is used so the same string isn't translated into
-                the same PkgFmri object multiple times."""
-
-                for key in keys:
-                        offsets = []
-                        for klass in action_classes:
-                                offset = offset_dict.get((klass.name, key),
-                                    None)
-                                if offset is not None:
-                                        offsets.append(offset)
-
-                        for offset, cnt in offsets:
-                                sf.seek(offset)
-                                pns = None
-                                i = 0
-                                while 1:
-                                        # sf is reading in binary mode
-                                        line = misc.force_str(sf.readline())
-                                        i += 1
-                                        if i > cnt:
-                                                break
-                                        line = line.rstrip()
-                                        if line == "":
-                                                break
-                                        fmristr, actstr = line.split(None, 1)
-                                        if fmristr in skip_fmris:
-                                                continue
-                                        act = pkg.actions.fromstr(actstr)
-                                        if act.attrs[act.key_attr] != key:
-                                                raise api_errors.InvalidPackageErrors([
-                                                    "{} has invalid manifest "
-                                                    "line:".format(
-                                                    fmristr),
-                                                    "    '{}'".format(actstr),
-                                                    "    '{}' vs. '{}'".format(
-                                                        act.attrs[act.key_attr],
-                                                        key
-                                                    )
-                                                    ])
-                                        assert pns is None or \
-                                            act.namespace_group == pns
-                                        pns = act.namespace_group
-
-                                        try:
-                                                pfmri = fmri_dict[fmristr]
-                                        except KeyError:
-                                                pfmri = pkg.fmri.PkgFmri(
-                                                    fmristr)
-                                                fmri_dict[fmristr] = pfmri
-                                        if skip_dups and self.__act_dup_check(
-                                            tgt, key, actstr, fmristr):
-                                                continue
-                                        tgt.setdefault(key, []).append(
-                                            (act, pfmri))
-
-        def __fast_check(self, new, old, ns):
-                """Check whether actions being added and removed are
-                sufficiently similar that further conflict checking on those
-                actions isn't needed.
-
-                The 'new' parameter is a dictionary mapping keys to the incoming
-                actions with that as a key.  The incoming actions are actions
-                delivered by packages which are being installed or updated to.
-
-                The 'old' parameter is a dictionary mapping keys to the outgoing
-                actions with that as a key.  The outgoing actions are actions
-                delivered by packages which are being removed or updated from.
-
-                The 'ns' parameter is the action namespace for the actions in
-                'new' and 'old'."""
-
-                # .keys() is being used because we're removing keys from the
-                # dictionary as we go.
-                for key in list(new.keys()):
-                        actions = new[key]
-                        assert len(actions) > 0
-                        oactions = old.get(key, [])
-                        # If new actions are being installed, then we need to do
-                        # the full conflict checking.
-                        if not oactions:
-                                continue
-
-                        unmatched_old_actions = set(range(0, len(oactions)))
-
-                        # If the action isn't refcountable and there's more than
-                        # one action, that's an error so we let
-                        # __check_conflicts handle it.
-                        entry = actions[0][0]
-                        if not entry.refcountable and \
-                            entry.globally_identical and \
-                            len(actions) > 1:
-                                continue
-
-                        # Check that each incoming action has a match in the
-                        # outgoing actions.
-                        next_key = False
-                        for act, pfmri in actions:
-                                matched = False
-                                aname = act.name
-                                aattrs = act.attrs
-                                # Compare this action with each outgoing action.
-                                for i, (oact, opfmri) in enumerate(oactions):
-                                        if aname != oact.name:
-                                                continue
-                                        # Check whether all attributes which
-                                        # need to be unique are identical for
-                                        # these two actions.
-                                        oattrs = oact.attrs
-                                        if all((
-                                            aattrs.get(a) == oattrs.get(a)
-                                            for a in act.unique_attrs
-                                        )):
-                                                matched = True
-                                                break
-
-                                # If this action didn't have a match in the old
-                                # action, then this key needs full conflict
-                                # checking so move on to the next key.
-                                if not matched:
-                                        next_key = True
-                                        break
-                                unmatched_old_actions.discard(i)
-                        if next_key:
-                                continue
-
-                        # Check that each outgoing action has a match in the
-                        # incoming actions.
-                        for i, (oact, opfmri) in enumerate(oactions):
-                                if i not in unmatched_old_actions:
-                                        continue
-                                matched = False
-                                for act, pfmri in actions:
-                                        if act.name != oact.name:
-                                                continue
-                                        if all((
-                                            act.attrs.get(a) ==
-                                                oact.attrs.get(a)
-                                            for a in act.unique_attrs
-                                        )):
-                                                matched = True
-                                                break
-                                if not matched:
-                                        next_key = True
-                                        break
-                                unmatched_old_actions.discard(i)
-                        if next_key or unmatched_old_actions:
-                                continue
-                        # We know that each incoming action matches at least one
-                        # outgoing action and each outgoing action matches at
-                        # least one incoming action, so no further conflict
-                        # checking is needed.
-                        del new[key]
-                        del old[key]
-
-                # .keys() is being used because we're removing keys from the
-                # dictionary as we go.
-                for key in list(old.keys()):
-                        # If actions that aren't in conflict are being removed,
-                        # then nothing more needs to be done.
-                        if key not in new:
-                                del old[key]
-
-        def __check_conflicts(self, new, old, action_classes, ns,
-            errs):
-                """Check all the newly installed actions for conflicts with
-                existing actions."""
-
-                for key, actions in six.iteritems(new):
-                        oactions = old.get(key, [])
-
-                        self.__progtrack.plan_add_progress(
-                            self.__progtrack.PLAN_ACTION_CONFLICT)
-
-                        if len(actions) == 1 and len(oactions) < 2:
-                                continue
-
-                        # Actions delivering to the same point in a
-                        # namespace group's namespace should have the
-                        # same type.
-                        if type(ns) != int:
-                                if self.__process_conflicts(key,
-                                    self.__check_inconsistent_types,
-                                    actions, oactions,
-                                    api_errors.InconsistentActionTypeError,
-                                    errs):
-                                        continue
-
-                        # By virtue of the above check, all actions at
-                        # this point in this namespace are the same.
-                        assert(len(set(a[0].name for a in actions)) <= 1)
-                        assert(len(set(a[0].name for a in oactions)) <= 1)
-
-                        # Multiple non-refcountable actions delivered to
-                        # the same name is an error.
-                        entry = actions[0][0]
-                        if not entry.refcountable and entry.globally_identical:
-                                if self.__process_conflicts(key,
-                                    self.__check_duplicate_actions,
-                                    actions, oactions,
-                                    api_errors.DuplicateActionError,
-                                    errs):
-                                        continue
-
-                        # Multiple refcountable but globally unique
-                        # actions delivered to the same name must be
-                        # identical.
-                        elif entry.globally_identical:
-                                if self.__process_conflicts(key,
-                                    self.__check_inconsistent_attrs,
-                                    actions, oactions,
-                                    api_errors.InconsistentActionAttributeError,
-                                    errs):
-                                        continue
-
-                # Ensure that overlay and preserve file semantics are handled
-                # as expected when conflicts only exist in packages that are
-                # being removed.
-                for key, oactions in six.iteritems(old):
-                        self.__progtrack.plan_add_progress(
-                            self.__progtrack.PLAN_ACTION_CONFLICT)
-
-                        if len(oactions) < 2:
-                                continue
-
-                        if key in new:
-                                # Already processed.
-                                continue
-
-                        if any(a[0].name != "file" for a in oactions):
-                                continue
-
-                        entry = oactions[0][0]
-                        if not entry.refcountable and entry.globally_identical:
-                                if self.__process_conflicts(key,
-                                    self.__check_duplicate_actions,
-                                    [], oactions,
-                                    api_errors.DuplicateActionError,
-                                    errs):
-                                        continue
-
-        @staticmethod
-        def _check_actions(nsd):
-                """Return the keys in the namespace dictionary ('nsd') which
-                map to actions that conflict with each other."""
-
-                def noop(*args):
-                        return None
-
-                bad_keys = set()
-                for ns, key_dict in six.iteritems(nsd):
-                        if type(ns) != int:
-                                type_func = ImagePlan.__check_inconsistent_types
-                        else:
-                                type_func = noop
-                        for key, actions in six.iteritems(key_dict):
-                                if len(actions) == 1:
-                                        continue
-                                if type_func(actions, []) is not None:
-                                        bad_keys.add(key)
-                                        continue
-                                if not actions[0][0].refcountable and \
-                                    actions[0][0].globally_identical:
-                                        if ImagePlan.__check_duplicate_actions(
-                                            actions, []) is not None:
-                                                bad_keys.add(key)
-                                                continue
-                                elif actions[0][0].globally_identical and \
-                                    ImagePlan.__check_inconsistent_attrs(
-                                    actions, []) is not None:
-                                        bad_keys.add(key)
-                                        continue
-                return bad_keys
-
-        def __clear_pkg_plans(self):
-                """Now that we're done reading the manifests, we can clear them
-                from the pkgplans."""
-
-                for p in self.pd.pkg_plans:
-                        p.clear_dest_manifest()
-                        p.clear_origin_manifest()
-
-        def __find_all_conflicts(self):
-                """Find all instances of conflicting actions.
-
-                There are three categories of conflicting actions.  The first
-                involves the notion of a 'namespace group': a set of action
-                classes which install into the same namespace.  The only example
-                of this is the set of filesystem actions: file, dir, link, and
-                hardlink.  If more than one action delivers to a given pathname,
-                all of those actions need to be of the same type.
-
-                The second category involves actions which cannot be delivered
-                multiple times to the same point in their namespace.  For
-                example, files must be delivered exactly once, as must users,
-                but directories or symlinks can be delivered multiple times, and
-                we refcount them.
-
-                The third category involves actions which may be delivered
-                multiple times, but all of those actions must be identical in
-                their core attributes.
-                """
-
-                 # We need to be able to create broken images from the testsuite.
-                if DebugValues["broken-conflicting-action-handling"]:
-                        self.__clear_pkg_plans()
-                        return
-
-                errs = []
-
-                pt = self.__progtrack
-                pt.plan_start(pt.PLAN_ACTION_CONFLICT)
-
-                # Using strings instead of PkgFmri objects in sets allows for
-                # much faster performance.
-                new_fmris = set((str(s) for s in self.gen_new_installed_pkgs()))
-
-                # If we're removing all packages, there won't be any conflicts.
-                if not new_fmris:
-                        pt.plan_done(pt.PLAN_ACTION_CONFLICT)
-                        self.__clear_pkg_plans()
-                        return
-
-                # figure out which installed packages are being removed by
-                # this operation
-                old_fmris = set((
-                    str(s) for s in self.image.gen_installed_pkgs()
-                ))
-                gone_fmris = old_fmris - new_fmris
-
-                # figure out which new packages are being touched by this
-                # operation.
-                changing_fmris = set([
-                        str(p.destination_fmri)
-                        for p in self.pd.pkg_plans
-                        if p.destination_fmri
-                ])
-
-                # Group action types by namespace groups
-                kf = operator.attrgetter("namespace_group")
-                # Unequal types are not comparable in Python 3, therefore
-                # convert them to the same type 'int' first.
-                def key(a):
-                        kf = a.namespace_group
-                        if kf is None:
-                            return -1
-                        elif kf == "path":
-                            return 20
-                        return kf
-                types = sorted(six.itervalues(pkg.actions.types), key=key)
-
-                namespace_dict = dict(
-                    (ns, list(action_classes))
-                    for ns, action_classes in itertools.groupby(types, kf)
+                    item_id += " (from {0})".format(
+                        oing_fmri.get_pkg_stem(anarchy=True)
+                    )
+                parent = ffmri
+            else:
+                item_id = ffmri
+                parent = None
+            for x in errors:
+                self.pd.add_item_message(
+                    item_id,
+                    timestamp,
+                    MSG_ERROR,
+                    _("ERROR: {0}").format(x),
+                    parent=parent,
+                )
+            for x in warnings:
+                self.pd.add_item_message(
+                    item_id,
+                    timestamp,
+                    MSG_WARNING,
+                    _("WARNING: {0}").format(x),
+                    parent=parent,
+                )
+            for x in info:
+                self.pd.add_item_message(
+                    item_id,
+                    timestamp,
+                    MSG_INFO,
+                    _("{0}").format(x),
+                    parent=parent,
                 )
 
-                pt.plan_add_progress(pt.PLAN_ACTION_CONFLICT)
-                # Load information about the actions currently on the system.
-                offset_dict = self.image._load_actdict(self.__progtrack)
-                sf = self.image._get_stripped_actions_file()
-
-                conflict_clean_image = \
-                    self.image._load_conflicting_keys() == set()
-
-                fmri_dict = weakref.WeakValueDictionary()
-                # Iterate over action types in namespace groups first; our first
-                # check should be for action type consistency.
-                for ns, action_classes in six.iteritems(namespace_dict):
-                        pt.plan_add_progress(pt.PLAN_ACTION_CONFLICT)
-                        # There's no sense in checking actions which have no
-                        # limits
-                        if all(not c.globally_identical
-                            for c in action_classes):
-                                continue
-
-                        # The 'new' dict contains information about the system
-                        # as it will be.  We start by accumulating actions from
-                        # the manifests of the packages being installed.
-                        new = self.__seed(
-                            self.gen_only_new_installed_actions_bytype,
-                            action_classes, self.__new_excludes)
-
-                        # The 'old' dict contains information about the system
-                        # as it is now.  We start by accumulating actions from
-                        # the manifests of the packages being removed.
-                        old = self.__seed(self.gen_outgoing_actions_bytype,
-                            action_classes, self.__old_excludes)
-
-                        if conflict_clean_image:
-                                self.__fast_check(new, old, ns)
-
-                        with contextlib.closing(mmap.mmap(sf.fileno(), 0,
-                            access=mmap.ACCESS_READ)) as msf:
-                                # Skip file header.
-                                msf.readline()
-                                msf.readline()
-
-                                # Update 'old' with all actions from the action
-                                # cache which could conflict with the new
-                                # actions being installed, or with actions
-                                # already installed, but not getting removed.
-                                keys = set(itertools.chain(six.iterkeys(new),
-                                    six.iterkeys(old)))
-                                self.__update_act(keys, old, False,
-                                    offset_dict, action_classes, msf,
-                                    gone_fmris, fmri_dict)
-
-                                # Now update 'new' with all actions from the
-                                # action cache which are staying on the system,
-                                # and could conflict with the actions being
-                                # installed.
-                                keys = set(six.iterkeys(old))
-                                self.__update_act(keys, new, True,
-                                    offset_dict, action_classes, msf,
-                                    gone_fmris | changing_fmris, fmri_dict)
-
-                        self.__check_conflicts(new, old, action_classes, ns,
-                            errs)
-
-                del fmri_dict
-                self.__clear_pkg_plans()
-                sf.close()
-                self.__evaluate_fixups()
-                pt.plan_done(pt.PLAN_ACTION_CONFLICT)
-
-                if errs:
-                        raise api_errors.ConflictingActionErrors(errs)
-
-        @staticmethod
-        def default_keyfunc(name, act):
-                """This is the default function used by get_actions when
-                the caller provides no key."""
-
-                attr_name = pkg.actions.types[name].key_attr
-                return act.attrs[attr_name]
-
-        @staticmethod
-        def hardlink_keyfunc(name, act):
-                """Keyfunc used in evaluate when calling get_actions
-                for hardlinks."""
-
-                return act.get_target_path()
-
-        def get_actions(self, name, key=None):
-                """Return a dictionary of actions of the type given by 'name'
-                describing the target image.  If 'key' is given and not None,
-                the dictionary's key will be the name of the action type's key
-                attribute.  Otherwise, it's a callable taking an action as an
-                argument which returns the key.  This dictionary is cached for
-                quick future lookups."""
-                if key is None:
-                        key = self.default_keyfunc
-
-                if (name, key) in self.__cached_actions:
-                        return self.__cached_actions[(name, key)]
-
-                d = {}
-                for act, pfmri in self.gen_new_installed_actions_bytype(name):
-                        t = key(name, act)
-                        d.setdefault(t, []).append(act)
-                self.__cached_actions[(name, key)] = d
-                return self.__cached_actions[(name, key)]
-
-        def __get_manifest(self, pfmri, intent, ignore_excludes=False):
-                """Return manifest for pfmri"""
-                if pfmri:
-                        return self.image.get_manifest(pfmri,
-                            ignore_excludes=ignore_excludes or
-                            self.pd._varcets_change,
-                            intent=intent)
+        if needs_fix:
+            # Eliminate policy-based entries with no repair
+            # action.
+            for x in needs_fix:
+                if x[0] in repairs:
+                    if x[1] is not None:
+                        repairs[x[0]].append(x[1])
                 else:
-                        return manifest.NullFactoredManifest
+                    if x[1] is None:
+                        repairs[x[0]] = []
+                    else:
+                        repairs[x[0]] = [x[1]]
 
-        def __create_intent(self, old_fmri, new_fmri, enabled_publishers):
-                """Return intent strings (or None).  Given a pair
-                of fmris describing a package operation, this
-                routine returns intent strings to be passed to
-                originating publisher describing manifest
-                operations.  We never send publisher info to
-                prevent cross-publisher leakage of info."""
+    def __get_overlaying_act_from_cache(self, path, overlay_entries):
+        """Get overlaying action from overlay_entries cache."""
 
-                if self.__noexecute:
-                        return None, None
+        for e in overlay_entries[path]:
+            if e[2] == "overlaying":
+                return e[0], e[1]
+        return None, None
 
-                __match_intent = dict()
-                __match_intent.update(self.__match_inst)
-                __match_intent.update(self.__match_rm)
-                __match_intent.update(self.__match_update)
+    def __add_to_processed(
+        self, oing_fmri, overlay, def_pkgs, pfmri, act, errors, warnings, pinfo
+    ):
+        """Add newly processed actions results into cache."""
 
-                if new_fmri:
-                        reference = __match_intent.get(new_fmri, None)
-                        # don't leak prev. version info across publishers
-                        if old_fmri:
-                                if old_fmri.get_publisher() != \
-                                    new_fmri.get_publisher():
-                                        old_fmri = "unknown"
-                                else:
-                                        old_fmri = \
-                                            old_fmri.get_fmri(anarchy=True)
-                        # don't send pub
-                        new_fmri = new_fmri.get_fmri(anarchy=True)
+        # If found overlaying package.
+        if oing_fmri:
+            # If the action is an overlaid one, attach the
+            # overlaying fmri for msg print.
+            if overlay == "overlaid":
+                def_pkgs[pfmri].append(
+                    (act, errors, warnings, pinfo, oing_fmri)
+                )
+            # The overlaying action is itself.
+            else:
+                def_pkgs[pfmri].append((act, errors, warnings, pinfo, None))
+        else:
+            def_pkgs[pfmri].append((act, errors, warnings, pinfo, None))
+
+    def __process_per_overlay_action(
+        self,
+        args,
+        pfmri,
+        entry,
+        def_pkgs,
+        verifypaths,
+        overlaypaths,
+        overlay_entries,
+        pt,
+    ):
+        """Process per overlay action."""
+
+        act = entry[0]
+        overlay = entry[1]
+        path = act.attrs.get("path")
+        # Try the overlay_entries cache first.
+        oing_fmri, oing_act = self.__get_overlaying_act_from_cache(
+            path, overlay_entries
+        )
+        # If found, process it directly.
+        if oing_act:
+            (
+                act,
+                errors,
+                warnings,
+                pinfo,
+                oing_fmri,
+            ) = self.__process_verify_result(
+                act,
+                pfmri,
+                pt,
+                verifypaths=verifypaths,
+                overlaypaths=overlaypaths,
+                ovlying_fmri=oing_fmri,
+                ovlying_act=oing_act,
+            )
+        elif args:
+            # Not all fmris were processed, we need to find the
+            # overlaying action.
+            #
+            # Also need to collect newly found overlaying
+            # actions into overlay_entries if any.
+            (
+                act,
+                errors,
+                warnings,
+                pinfo,
+                oing_fmri,
+            ) = self.__process_verify_result(
+                act,
+                pfmri,
+                pt,
+                verifypaths=verifypaths,
+                overlaypaths=overlaypaths,
+                ovly_entries=overlay_entries,
+            )
+        else:
+            # All fmris were processed, if the cache didn't contain
+            # the action, that means no overlaying action.
+            #
+            # We need to skip overlaying action finding, since we
+            # already know no overlaying action in the cache.
+            (
+                act,
+                errors,
+                warnings,
+                pinfo,
+                oing_fmri,
+            ) = self.__process_verify_result(
+                act,
+                pfmri,
+                pt,
+                verifypaths=verifypaths,
+                overlaypaths=overlaypaths,
+                skip_ovlying=True,
+            )
+        self.__add_to_processed(
+            oing_fmri, overlay, def_pkgs, pfmri, act, errors, warnings, pinfo
+        )
+
+    def __check_attr_mismatch_between_actions(self, overlaid, overlaying):
+        """Check attribute mismatch between overlaying and overlaid
+        actions."""
+
+        overlaid_act = overlaid[1]
+        overlaying_act = overlaying[1]
+        o_attr_overlaid = overlaid_act.attrs.get("overlay-attributes")
+        o_attr_overlaying = overlaying_act.attrs.get("overlay-attributes")
+        owner_overlaid = overlaid_act.attrs["owner"]
+        owner_overlaying = overlaying_act.attrs["owner"]
+        mode_overlaid = overlaid_act.attrs["mode"]
+        mode_overlaying = overlaying_act.attrs["mode"]
+        group_overlaid = overlaid_act.attrs["group"]
+        group_overlaying = overlaying_act.attrs["group"]
+
+        msgs = []
+        if owner_overlaid != owner_overlaying:
+            msgs.append(
+                _(
+                    "owner: {0} does not match overlaid " "package owner: {1}"
+                ).format(owner_overlaying, owner_overlaid)
+            )
+        if mode_overlaid != mode_overlaying:
+            msgs.append(
+                _(
+                    "mode: {0} does not match overlaid " "package mode: {1}"
+                ).format(mode_overlaying, mode_overlaid)
+            )
+        if group_overlaid != group_overlaying:
+            msgs.append(
+                _(
+                    "group: {0} does not match overlaid " "package group: {1}"
+                ).format(group_overlaying, group_overlaid)
+            )
+        if not msgs:
+            return
+
+        item_id = str(overlaying[0])
+        act_id = overlaid_act.distinguished_name()
+        msg_level = MSG_INFO
+        result = "OK"
+
+        if o_attr_overlaid == "deny" or o_attr_overlaying == "deny":
+            msg_level = MSG_ERROR
+
+        # Check if there is already an FMRI-level message;
+        # update it or add a new one if necessary.
+        item_msgs = self.pd.get_parsable_item_messages()
+        added_msgs = None
+        if item_id in item_msgs and "messages" in item_msgs[item_id]:
+            added_msgs = item_msgs[item_id]["messages"]
+        add_msg = False
+        if added_msgs:
+            if (
+                added_msgs[0]["msg_level"] == MSG_INFO
+                and msg_level == MSG_ERROR
+            ):
+                # Empty the current message list.
+                added_msgs[:] = []
+                add_msg = True
+        else:
+            add_msg = True
+
+        timestamp = misc.time_to_timestamp(time.time())
+        if add_msg:
+            self.pd.add_item_message(
+                item_id,
+                timestamp,
+                msg_level,
+                _("{pkg_name:70} {result:>7}").format(
+                    pkg_name=overlaying[0].get_pkg_stem(), result=result
+                ),
+            )
+        self.pd.add_item_message(
+            act_id,
+            timestamp,
+            msg_level,
+            _("Overlaid package: {0}").format(overlaid[0].get_pkg_stem()),
+            parent=item_id,
+        )
+
+        for msg in msgs:
+            if msg_level == MSG_ERROR:
+                imsg = _("ERROR: {0}").format(msg)
+            else:
+                imsg = msg
+            self.pd.add_item_message(
+                act_id, timestamp, msg_level, imsg, parent=item_id
+            )
+
+    def __verify_fmris(
+        self, repairs, args, proposed_fmris, pt, verifypaths, overlaypaths
+    ):
+        """Verify FRMIs."""
+
+        path_only = bool(verifypaths or overlaypaths)
+        overlay_entries = {}
+        def_pkgs = {}  # deferred packages
+        def_acts = {}  # deferred actions
+        for pfmri in proposed_fmris:
+            entries = []
+            needs_fix = []
+            result = "OK"
+            failed = False
+            msg_level = MSG_INFO
+
+            # Since every entry returned by verify might not be
+            # something needing repair, the relevant information
+            # for each package must be accumulated first to find
+            # an overall success/failure result and then the
+            # related messages output for it.
+            verify_path_count = len(verifypaths)
+            overlay_path_count = len(overlaypaths)
+            for act, errors, warnings, pinfo, overlay in self.image.verify(
+                pfmri,
+                pt,
+                verifypaths=verifypaths,
+                overlaypaths=overlaypaths,
+                verbose=True,
+                forever=True,
+            ):
+                if not path_only and overlay:
+                    path = act.attrs.get("path")
+                    if path not in overlay_entries:
+                        overlay_entries[path] = []
+                    overlay_entries[path].append((pfmri, act, overlay))
+
+                    if pfmri not in def_acts:
+                        def_acts[pfmri] = []
+                    def_acts[pfmri].append((act, overlay))
                 else:
-                        reference = __match_intent.get(old_fmri, None)
-                        # don't try to send intent info to disabled publisher
-                        if old_fmri.get_publisher() in enabled_publishers:
-                                # don't send pub
-                                old_fmri = old_fmri.get_fmri(anarchy=True)
-                        else:
-                                old_fmri = None
+                    entries.append((act, errors, warnings, pinfo, None))
+                # Try to determine the package's status and
+                # message type. This is subject to change if
+                # the package contains overlay actions.
+                if errors:
+                    failed = True
+                    result = "ERROR"
+                    msg_level = MSG_ERROR
+                    # Some errors are based on policy (e.g.
+                    # signature policy) and not a specific
+                    # action, so act may be None.
+                    needs_fix.append((pfmri, act))
+                elif not failed and warnings:
+                    result = "WARNING"
+                    msg_level = MSG_WARNING
 
-                info = {
-                    "operation": self.pd._op,
-                    "old_fmri" : old_fmri,
-                    "new_fmri" : new_fmri,
-                    "reference": reference
-                }
+            # Defer final processing of package if verification was
+            # deferred for any of its actions.
+            if pfmri in def_acts:
+                def_pkgs[pfmri] = entries
+                continue
 
-                s = "({0})".format(";".join([
-                    "{0}={1}".format(key, info[key]) for key in info
-                    if info[key] is not None
-                ]))
+            if (
+                path_only
+                and verify_path_count == len(verifypaths)
+                and overlay_path_count == len(overlaypaths)
+            ):
+                # When verifying paths, omit packages without any
+                # matches from output.
+                continue
+            self.__process_msgs(
+                entries, pfmri, msg_level, result, needs_fix, repairs
+            )
+            if path_only and not overlaypaths and not verifypaths:
+                return
 
-                if new_fmri:
-                        return None, s    # only report new on upgrade
-                elif old_fmri:
-                        return s, None    # uninstall w/ enabled pub
-                else:
-                        return None, None # uninstall w/ disabled pub
+        # No need to proceed for path only case.
+        if path_only:
+            return
 
-        def add_actuator(self, phase, name, value):
-                """Add an actuator to the plan.
+        # Process deferred actions.
+        for pfmri, entries in def_acts.items():
+            for entry in entries:
+                self.__process_per_overlay_action(
+                    args,
+                    pfmri,
+                    entry,
+                    def_pkgs,
+                    verifypaths,
+                    overlaypaths,
+                    overlay_entries,
+                    pt,
+                )
 
-                The actuator name ('reboot-needed', 'restart_fmri', etc.) is
-                given in 'name', and the fmri string or callable is given in
-                'value'.  The 'phase' parameter must be one of 'install',
-                'remove', or 'update'.
-                """
+        # Generate messages for all processed packages with overlay
+        # actions.
+        for pfmri, entries in def_pkgs.items():
+            failed = False
+            result = "OK"
+            msg_level = MSG_INFO
+            needs_fix = []
+            for act, errors, warnings, pinfo, oing_fmri in entries:
+                # Try to determine the package's status and
+                # message type.
+                if errors:
+                    failed = True
+                    result = "ERROR"
+                    msg_level = MSG_ERROR
+                    if oing_fmri:
+                        # Only append overlaying action
+                        # if not all packages are
+                        # verified. Otherwise, the
+                        # overlaying action will be
+                        # append later.
+                        if args:
+                            needs_fix.append((oing_fmri, act))
+                    else:
+                        needs_fix.append((pfmri, act))
+                elif not failed and warnings:
+                    result = "WARNING"
+                    msg_level = MSG_WARNING
 
-                if phase == "install":
-                        d = self.pd._actuators.install
-                elif phase == "remove":
-                        d = self.pd._actuators.removal
-                elif phase == "update":
-                        d = self.pd._actuators.update
+            self.__process_msgs(
+                entries, pfmri, msg_level, result, needs_fix, repairs
+            )
 
-                if hasattr(value, "__call__"):
-                        d[name] = value
-                else:
-                        d.setdefault(name, []).append(value)
+        # Generate overlay-specific messages.
+        for path, entries in overlay_entries.items():
+            overlaid = None
+            overlaying = None
+            for e in entries:
+                if e[2] == "overlaid":
+                    overlaid = e
+                elif e[2] == "overlaying":
+                    overlaying = e
+            if overlaid and overlaying:
+                self.__check_attr_mismatch_between_actions(overlaid, overlaying)
 
-        def __evaluate_pkg_preserved_files(self):
-                """Private helper function that determines which preserved files
-                have changed in ImagePlan and how."""
+    def plan_fix(
+        self,
+        args,
+        unpackaged=False,
+        unpackaged_only=False,
+        verify_paths=misc.EmptyI,
+    ):
+        """Determine the changes needed to fix the image."""
 
-                assert self.state >= plandesc.MERGED_OK
+        self.__plan_op()
+        self.__evaluate_excludes()
 
-                pd = self.pd
+        pt = self.__progtrack
+        pt.plan_all_start()
 
-                # Track movement of preserved ("editable") files for plan
-                # summary and cache management.
-                moved = []
-                removed = []
-                installed = []
-                updated = []
+        if args:
+            proposed_dict, self.__match_rm = self.__match_user_fmris(
+                self.image, args, self.MATCH_INST_VERSIONS
+            )
 
-                # __merge_actions() adds the 'save_file' attribute to src
-                # actions that are being moved somewhere else and to dest
-                # actions that will be restored from a src action.  This only
-                # happens when at least one of the files involved has a
-                # 'preserve' attribute, so it's safe to treat either as a
-                # 'preserved' ("editable") file.
+            # merge patterns together
+            proposed_fixes = sorted(
+                set([f for each in proposed_dict.values() for f in each])
+            )
+        else:
+            # No FMRIs specified, verify all packages
+            proposed_fixes = list(self.image.gen_installed_pkgs(ordered=True))
 
-                # The removal_actions are processed first since we'll determine
-                # how to transform them while processing the install and update
-                # actions based on the destination file state.
-                for ap in pd.removal_actions:
-                        src = ap.src
-                        if src.name != "file":
-                                continue
-                        if not ("preserve" in src.attrs or
-                            "save_file" in src.attrs or
-                            "overlay" in src.attrs):
-                                # Removed action has to be a preserved file or a
-                                # source of a restore.
-                                continue
-                        if "elfhash" in src.attrs:
-                                # Ignore erroneously tagged files.
-                                continue
+        repairs = {}
+        overlaypaths = set()
+        verifypaths = set(a.lstrip(os.path.sep) for a in verify_paths)
 
-                        if src.attrs.get("preserve") in ("abandon",
-                            "install-only"):
-                                # these files are never removed.
-                                continue
+        if not verify_paths:
+            pt.plan_start(pt.PLAN_PKG_VERIFY, goal=len(proposed_fixes))
 
-                        entry = [src.attrs["path"]]
-                        save_file = src.attrs.get("save_file")
-                        if save_file:
-                                entry.append(save_file[0])
-                                entry.append(src)
-                        removed.append(entry)
-
-                for ap in itertools.chain(pd.install_actions,
-                    pd.update_actions):
-                        orig = ap.src
-                        dest = ap.dst
-                        if dest.name != "file":
-                                continue
-
-                        dpres_type = dest.attrs.get("preserve")
-                        if not ((orig and ("preserve" in orig.attrs or
-                            "save_file" in orig.attrs or
-                            "overlay" in orig.attrs)) or
-                            (dpres_type or
-                            "save_file" in dest.attrs or
-                            "overlay" in dest.attrs)):
-                                # At least one of the actions has to be a
-                                # preserved file or a target of a restore.
-                                continue
-                        if "elfhash" in dest.attrs:
-                                # Ignore erroneously tagged files.
-                                continue
-
-                        tpath = dest.attrs["path"]
-                        entry = [tpath]
-                        save_file = dest.attrs.get("save_file")
-                        if save_file:
-                                tcache_name = save_file[0]
-                                for (ridx, rentry) in enumerate(removed):
-                                        if len(rentry) == 1:
-                                                continue
-
-                                        rpath, rcache_name, rorig = rentry
-                                        if rcache_name == tcache_name:
-                                                # If the cache name for this new
-                                                # file matches one of those for
-                                                # a removed file, the removed
-                                                # file will be renamed to this
-                                                # action's path before the
-                                                # action is processed.
-                                                del removed[ridx]
-                                                save_file = rpath
-                                                orig = rorig
-                                                break
-                                else:
-                                        save_file = None
-
-                        if not orig and dpres_type == "install-only":
-                                # For install-only, we can rely on
-                                # _check_preserve.
-                                try:
-                                        if not dest._check_preserve(orig, ap.p):
-                                                installed.append(entry)
-                                except EnvironmentError as e:
-                                        if e.errno != errno.EACCES:
-                                                raise
-                                continue
-                        elif not orig:
-                                # We can't rely on _check_preserve for this case
-                                # as there's no existing on-disk file at the
-                                # destination path yet.
-                                if (dpres_type != "legacy" and
-                                    dpres_type != "abandon"):
-                                        # 'abandon' actions are never delivered;
-                                        # 'legacy' actions are only delivered if
-                                        # we're updating something already
-                                        # installed or moving an existing file.
-                                        installed.append(entry)
-                                continue
-                        elif orig.name != "file":
-                                # File is being replaced with another object
-                                # type.
-                                updated.append(entry)
-                                continue
-
-                        # The order of these checks is significant in
-                        # determining how a preserved file changed!
-                        #
-                        # First, check for on-disk content changes.
-                        opath = orig.get_installed_path(self.image.get_root())
-                        try:
-                                pres_type = dest._check_preserve(orig, ap.p,
-                                    orig_path=opath)
-                        except EnvironmentError as e:
-                                if e.errno == errno.EACCES:
-                                        continue
-                                else:
-                                        raise
-
-                        final_path = dest.get_installed_path(
-                            self.image.get_root())
-
-                        # If a removed action is going to be restored to
-                        # complete the operation, show the removed action path
-                        # as the source for the move omitting the steps
-                        # in-between.  For example:
-                        #  moved: testme -> newme
-                        #  moved: newme -> newme.legacy
-                        #  installed: newme
-                        # ...becomes:
-                        #  moved: testme -> newme.legacy
-                        #  installed: newme
-                        if save_file:
-                                mpath = save_file
-                        else:
-                                mpath = tpath
-
-                        if pres_type == "abandon":
-                                # newly-tagged preserve=abandon files never
-                                # delivered.
-                                continue
-                        elif pres_type == "renameold":
-                                moved.append([mpath, tpath + ".old"])
-                                installed.append(entry)
-                                continue
-                        elif pres_type == "renameold.update":
-                                moved.append([mpath, tpath + ".update"])
-                                installed.append(entry)
-                                continue
-                        elif pres_type == "legacy":
-                                if orig.attrs.get("preserve") == "legacy":
-                                        updated.append(entry)
-                                        continue
-                                # Move only happens on preserve transition and
-                                # only if original already exists.
-                                if os.path.isfile(opath):
-                                        moved.append([mpath, tpath + ".legacy"])
-                                installed.append(entry)
-                                continue
-                        elif pres_type == True and save_file:
-                                # If the source and destination path are the
-                                # same, the content won't be updated.
-                                if mpath != tpath:
-                                        # New content ignored in favour of old.
-                                        moved.append([mpath, tpath])
-                                continue
-
-                        # Next, if on-disk file will be preserved and some other
-                        # unique_attr is changing (such as mode, etc.) mark the
-                        # file as "updated".
-                        if (pres_type == True and
-                            ImagePlan.__find_inconsistent_attrs(
-                                ((orig,), (dest,)),
-                                ignore=("path", "preserve"))):
-
-                                # For 'install-only', we can only update for
-                                # inconsistent attributes if the file already
-                                # exists.
-                                if (dpres_type != "install-only" or
-                                    os.path.isfile(final_path)):
-                                        updated.append(entry)
-                                continue
-
-                        # For remaining cases, what happens is based on the
-                        # result of _check_preserve().
-                        if pres_type == "renamenew":
-                                if save_file:
-                                        moved.append([mpath, tpath])
-                                # Delivered content changed.
-                                installed.append([tpath + ".new"])
-                        elif pres_type is None:
-                                # Delivered content or unique_attrs changed.
-                                updated.append(entry)
-                        elif pres_type == False:
-                                if save_file:
-                                        moved.append([mpath, tpath])
-                                        continue
-
-                                if not os.path.isfile(final_path):
-                                        # File is missing or of wrong type.
-                                        installed.append(entry)
-                                        continue
-
-                                # If a file is moving between packages, it will
-                                # appear as an update, but may not have not have
-                                # different content or unique_attrs.  Check to
-                                # see if it does.
-                                if ImagePlan.__find_inconsistent_attrs(
-                                    ((orig,), (dest,)),
-                                    ignore=("path", "preserve")):
-                                        # Different unique_attrs.
-                                        updated.append(entry)
-                                        continue
-
-                                attr, shash, ohash, hfunc = \
-                                    digest.get_common_preferred_hash(dest, orig)
-                                if shash != ohash:
-                                        # Delivered content changed.
-                                        updated.append(entry)
-                                        continue
-
-                # Pre-sort results for consumers.
-                installed.sort()
-                moved.sort()
-                removed.sort()
-                updated.sort()
-
-                self.pd._preserved = {
-                    "installed": installed,
-                    "moved": moved,
-                    "removed": removed,
-                    "updated": updated,
-                }
-
-        def __evaluate_pkg_downloads(self):
-                """Private helper function that determines package data to be
-                downloaded and updates the plan accordingly."""
-
-                assert self.state >= plandesc.MERGED_OK
-
-                pd = self.pd
-
-                for p in pd.pkg_plans:
-                        cpbytes, pbytes = p.get_bytes_added()
-                        if p.destination_fmri:
-                                mpath = self.image.get_manifest_path(
-                                    p.destination_fmri)
-                                try:
-                                        # Manifest data is essentially stored
-                                        # three times (original, cache, catalog).
-                                        # For now, include this in cbytes_added
-                                        # since that's closest to where the
-                                        # download cache is stored.
-                                        pd._cbytes_added += \
-                                            os.stat(mpath).st_size * 3
-                                except EnvironmentError as e:
-                                        raise api_errors._convert_error(e)
-                        pd._cbytes_added += cpbytes
-                        pd._bytes_added += pbytes
-
-                # Include state directory in cbytes_added for now since it's
-                # closest to where the download cache is stored.  (Twice the
-                # amount is used because image state update involves using
-                # a complete copy of existing state.)
-                pd._cbytes_added += misc.get_dir_size(self.image._statedir) * 2
-
-                # Our slop factor is 25%; overestimating is safer than under-
-                # estimating.  This attempts to approximate how much overhead
-                # the filesystem will impose on the operation.  Empirical
-                # testing suggests that overhead can vary wildly depending on
-                # average file size, fragmentation, zfs metadata overhead, etc.
-                # For an install of a package such as solaris-small-server into
-                # an image, a 12% difference between actual size and installed
-                # size was found, so this seems safe enough.  (And helps account
-                # for any bootarchives, fs overhead, etc.)
-                pd._cbytes_added *= 1.25
-                pd._bytes_added *= 1.25
-
-                # XXX For now, include cbytes_added in bytes_added total; in the
-                # future, this should only happen if they share the same
-                # filesystem.
-                pd._bytes_added += pd._cbytes_added
-                self.__update_avail_space()
-
-                # Verify that there is enough space for the change.
-                if self.pd._bytes_added > self.pd._bytes_avail:
-                        # During a dry run log a warning and continue to run the
-                        # solver to produce any further warnings/errors.
-                        if self.__noexecute:
-                                msg = api_errors.ImageInsufficentSpace(
-                                          self.pd._bytes_added,
-                                          self.pd._bytes_avail,
-                                          _("Root filesystem"))
-                                timestamp = misc.time_to_timestamp(time.time())
-                                self.pd.add_item_message("warning",
-                                    timestamp, MSG_WARNING, _(msg))
-                        else:
-                                raise api_errors.ImageInsufficentSpace(
-                                    self.pd._bytes_added,
-                                    self.pd._bytes_avail,
-                                    _("Root filesystem"))
-
-
-        def evaluate(self):
-                """Given already determined fmri changes,
-                build pkg plans and figure out exact impact of
-                proposed changes"""
-
-                assert self.pd.state == plandesc.EVALUATED_PKGS, self
-
-                if self.pd._image_lm != \
-                    self.image.get_last_modified(string=True):
-                        # State has been modified since plan was created; this
-                        # plan is no longer valid.
-                        raise api_errors.InvalidPlanError()
-
-                self.__evaluate_pkg_plans()
-                self.__merge_actions()
-                self.__compile_release_notes()
-
-                if not self.pd._li_pkg_updates and self.pd.pkg_plans:
-                        # oops.  the caller requested no package updates and
-                        # we couldn't satisfy that request.
-                        fmri_updates = [
-                                (p.origin_fmri, p.destination_fmri)
-                                for p in self.pd.pkg_plans
-                        ]
-                        raise api_errors.PlanCreationException(
-                            pkg_updates_required=fmri_updates)
-
-                # Check for files which have been elided due to image
-                # exclusions, and honour the image's exclusion policy.
-                ix_policy = self.image.get_property(
-                    imageconfig.EXCLUDE_POLICY)
-                if self.pd.elided_actions and ix_policy != 'ignore':
-                    elided = []
-                    for (o, n) in self.pd.get_elided_actions():
-                        if o is None:
-                            elided.extend(n.attrlist('path'))
-                    if ix_policy == 'warn':
-                        timestamp = misc.time_to_timestamp(time.time())
-                        self.pd.add_item_message(
-                            "warning", timestamp, MSG_WARNING,
-                            self.__make_excl_msg(elided))
-                    elif ix_policy == 'reject':
-                        raise api_errors.PlanExclusionError(paths=elided)
-
-                # These must be done after action merging.
-                self.__evaluate_pkg_preserved_files()
-                self.__evaluate_pkg_downloads()
-                # If there are invalid mediators then message about it
-                # for the no execute (-n) or zones case. If an update
-                # in the global zone an exception will be raised later.
-                if self.invalid_meds:
-                        if self.__noexecute or self.image.is_zone():
-                                medmsg = self.__make_med_msg()
-                                timestamp = misc.time_to_timestamp(time.time())
-                                self.pd.add_item_message("warning", timestamp,
-                                                         MSG_WARNING, medmsg)
-
-        def __update_avail_space(self):
-                """Update amount of available space on FS"""
-
-                self.pd._cbytes_avail = misc.spaceavail(
-                    self.image.write_cache_path)
-
-                self.pd._bytes_avail = misc.spaceavail(self.image.root)
-                # if we don't have a full image yet
-                if self.pd._cbytes_avail < 0:
-                        self.pd._cbytes_avail = self.pd._bytes_avail
-
-        def __include_note(self, installed_dict, act, containing_fmri):
-                """Decide if a release note should be shown/included.  If
-                feature/pkg/self is fmri, fmri is containing package;
-                if version is then 0, this is note is displayed on initial
-                install only.  Otherwise, if version earlier than specified
-                fmri is present in code, display release note."""
-
-                for fmristr in act.attrlist("release-note"):
-                        try:
-                                pfmri = pkg.fmri.PkgFmri(fmristr)
-                        except pkg.fmri.FmriError:
-                                continue # skip malformed fmris
-                        # any special handling here?
-                        if pfmri.pkg_name == "feature/pkg/self":
-                                if str(pfmri.version) == "0,5.11" \
-                                    and containing_fmri.pkg_name \
-                                    not in installed_dict:
-                                        return True
-                                else:
-                                        pfmri.pkg_name = \
-                                            containing_fmri.pkg_name
-                        if pfmri.pkg_name not in installed_dict:
-                                continue
-                        installed_fmri = installed_dict[pfmri.pkg_name]
-                        # if neither is successor they are equal
-                        if pfmri.is_successor(installed_fmri):
-                                return True
-                return False
-
-        def __get_note_text(self, act, pfmri):
-                """Retrieve text for release note from repo
-
-                If there are UTF-8 encoding errors in the text replace them
-                so that we still have a note to show rather than failing
-                the entire operation.  The copy saved on disk is left as is."""
+            # Verify unpackaged contents.
+            if unpackaged or unpackaged_only:
+                dup_be_name = "duplicate_livebe_for_verify"
                 try:
-                        pub = self.image.get_publisher(pfmri.publisher)
-                        hash_attr, hash_val, hash_func = \
-                            digest.get_least_preferred_hash(act)
-                        return self.image.transport.get_content(pub, hash_val,
-                            fmri=pfmri, hash_func=hash_func, errors="replace")
+                    self.__process_unpackaged(
+                        proposed_fixes, pt=pt, dup_be_name=dup_be_name
+                    )
                 finally:
-                        self.image.cleanup_downloads()
+                    # Clean up the BE used for verify.
+                    bootenv.BootEnv.cleanup_be(dup_be_name)
+                pt.plan_done(pt.PLAN_PKG_VERIFY)
+                if unpackaged_only:
+                    self.__finish_plan(plandesc.EVALUATED_PKGS)
+                    return
+                # Otherwise we reset the goals for packaged
+                # contents.
+                pt.plan_start(pt.PLAN_PKG_VERIFY, goal=len(proposed_fixes))
+            self.__verify_fmris(
+                repairs, args, proposed_fixes, pt, verifypaths, overlaypaths
+            )
+        else:
+            pt.plan_start(pt.PLAN_PKG_VERIFY, goal=len(verifypaths))
 
-        def __compile_release_notes(self):
-                """Figure out what release notes need to be displayed"""
-                release_notes = self.pd._actuators.get_release_note_info()
-                must_display = False
-                notes = []
+            self.__verify_fmris(
+                repairs, args, proposed_fixes, pt, verifypaths, overlaypaths
+            )
 
-                if release_notes:
-                        installed_dict = ImagePlan.__fmris2dict(
-                            self.image.gen_installed_pkgs())
-                        for act, pfmri in release_notes:
-                                if self.__include_note(installed_dict, act,
-                                    pfmri):
-                                        if act.attrs.get("must-display",
-                                            "false") == "true":
-                                                must_display = True
-                                        for l in self.__get_note_text(
-                                            act, pfmri).splitlines():
-                                                notes.append(misc.decode(l))
+            timestamp = misc.time_to_timestamp(time.time())
+            for path_not_found in verifypaths:
+                pt.plan_add_progress(pt.PLAN_PKG_VERIFY)
+                self.pd.add_item_message(
+                    "path not found",
+                    timestamp,
+                    MSG_WARNING,
+                    _("{path} is not found in the image").format(
+                        path=path_not_found
+                    ),
+                )
 
-                        self.pd.release_notes = (must_display, notes)
+            if args and overlaypaths:
+                # Only perform verification for the rest of packages
+                # if FMRIs are provided and there are actions with
+                # overlay=allow found in those FMRIs. In the second
+                # pass, only look for actions with overlay=true.
+                pfixes = set(proposed_fixes)
+                path_fmri = [
+                    f
+                    for f in self.image.gen_installed_pkgs(ordered=True)
+                    if f not in pfixes
+                ]
+                self.__verify_fmris(
+                    repairs, args, path_fmri, pt, set(), overlaypaths
+                )
 
-        def __save_release_notes(self):
-                """Save a copy of the release notes and store the file name"""
-                if self.pd.release_notes[1]:
-                        # create a file in imgdir/notes
-                        dpath = os.path.join(self.image.imgdir, "notes")
-                        misc.makedirs(dpath)
-                        fd, path = tempfile.mkstemp(suffix=".txt",
-                            dir=dpath, prefix="release-notes-")
-                        tmpfile = os.fdopen(fd, "w")
-                        for note in self.pd.release_notes[1]:
-                                note = misc.force_str(note)
-                                print(note, file=tmpfile)
-                        # make file world readable
-                        os.chmod(path, 0o644)
-                        tmpfile.close()
-                        self.pd.release_notes_name = os.path.basename(path)
+        pt.plan_done(pt.PLAN_PKG_VERIFY)
+        # If no repairs, finish the plan.
+        if not repairs:
+            self.__finish_plan(plandesc.EVALUATED_PKGS)
+            return
 
-        def __evaluate_pkg_plans(self):
-                """Internal helper function that does the work of converting
-                fmri changes into pkg plans."""
+        # Repair anything we failed to verify.
+        pt.plan_start(pt.PLAN_PKG_FIX, goal=len(repairs))
+        for fmri, actions in repairs.items():
+            pt.plan_add_progress(pt.PLAN_PKG_FIX)
+            # Need to get all variants otherwise evaluating the
+            # pkgplan will fail in signature verification.
+            m = self.image.get_manifest(fmri, ignore_excludes=True)
+            pp = pkgplan.PkgPlan(self.image)
+            pp.propose_repair(fmri, m, actions, [])
+            pp.evaluate(self.__old_excludes, self.__new_excludes)
+            self.pd.pkg_plans.append(pp)
 
-                pt = self.__progtrack
-                # prefetch manifests
-                prefetch_mfsts = [] # manifest, intents to be prefetched
-                eval_list = []     # oldfmri, oldintent, newfmri, newintent
-                                   # prefetched intents omitted
-                enabled_publishers = set([
-                                a.prefix
-                                for a in self.image.gen_publishers()
-                                ])
+        pt.plan_done(pt.PLAN_PKG_FIX)
+        pt.plan_all_done()
+        self.__finish_plan(plandesc.EVALUATED_PKGS)
 
-                #
-                # XXX this could be improved, or perhaps the "do we have it?"
-                # logic could be moved into prefetch_manifests, and
-                # PLAN_FIND_MFST could go away?  This can be slow.
-                #
-                pt.plan_start(pt.PLAN_FIND_MFST)
-                for oldfmri, newfmri in self.pd._fmri_changes:
-                        pt.plan_add_progress(pt.PLAN_FIND_MFST)
-                        old_in, new_in = self.__create_intent(oldfmri, newfmri,
-                            enabled_publishers)
-                        if oldfmri:
-                                if not self.image.has_manifest(oldfmri):
-                                        prefetch_mfsts.append((oldfmri, old_in))
-                                        old_in = None # so we don't send it twice
-                        if newfmri:
-                                if not self.image.has_manifest(newfmri):
-                                        prefetch_mfsts.append((newfmri, new_in))
-                                        new_in = None
-                        eval_list.append((oldfmri, old_in, newfmri, new_in))
-                        old_in = new_in = None
-                pt.plan_done(pt.PLAN_FIND_MFST)
+    def plan_noop(self):
+        """Create a plan that doesn't change the package contents of
+        the current image."""
+        self.__plan_op()
+        self.pd._fmri_changes = []
+        self.pd.state = plandesc.EVALUATED_PKGS
 
-                # No longer needed.
-                del enabled_publishers
-                self.__match_rm = {}
-                self.__match_update = {}
+    @staticmethod
+    def __fmris2dict(fmri_list):
+        return dict([(f.pkg_name, f) for f in fmri_list])
 
-                self.image.transport.prefetch_manifests(prefetch_mfsts,
-                    ccancel=self.__check_cancel, progtrack=self.__progtrack)
+    @staticmethod
+    def __dicts2fmrichanges(olddict, newdict):
+        return [
+            (olddict.get(k, None), newdict.get(k, None))
+            for k in set(list(olddict.keys()) + list(newdict.keys()))
+        ]
 
-                # No longer needed.
-                del prefetch_mfsts
+    def reboot_advised(self):
+        """Check if evaluated imageplan suggests a reboot"""
+        assert self.state >= plandesc.MERGED_OK
+        return self.pd._actuators.reboot_advised()
 
-                max_items = len(eval_list)
-                pt.plan_start(pt.PLAN_PKGPLAN, goal=max_items)
-                same_excludes = self.__old_excludes == self.__new_excludes
+    def reboot_needed(self):
+        """Check if evaluated imageplan requires a reboot"""
+        assert self.pd.state >= plandesc.MERGED_OK
+        return self.pd._actuators.reboot_needed()
 
-                for oldfmri, old_in, newfmri, new_in in eval_list:
-                        pp = pkgplan.PkgPlan(self.image)
+    def boot_archive_needed(self):
+        """True if boot archive needs to be rebuilt"""
+        assert self.pd.state >= plandesc.MERGED_OK
+        return self.pd._need_boot_archive
 
-                        if oldfmri == newfmri:
-                                # When creating intent, we always prefer to send
-                                # the new intent over old intent (see
-                                # __create_intent), so it's not necessary to
-                                # touch the old manifest in this situation.
-                                m = self.__get_manifest(newfmri, new_in,
-                                    ignore_excludes=True)
-                                pp.propose(
-                                    oldfmri, m,
-                                    newfmri, m)
-                                can_exclude = same_excludes
-                        else:
-                                pp.propose(
-                                    oldfmri,
-                                    self.__get_manifest(oldfmri, old_in),
-                                    newfmri,
-                                    self.__get_manifest(newfmri, new_in,
-                                    ignore_excludes=True))
-                                can_exclude = True
+    def get_solver_errors(self):
+        """Returns a list of strings for all FMRIs evaluated by the
+        solver explaining why they were rejected.  (All packages
+        found in solver's trim database.)"""
+        return self.pd.get_solver_errors()
 
-                        pp.evaluate(self.__old_excludes, self.__new_excludes,
-                            can_exclude=can_exclude)
+    def get_plan(self, full=True):
+        if full:
+            return str(self)
 
-                        self.pd.pkg_plans.append(pp)
-                        pt.plan_add_progress(pt.PLAN_PKGPLAN, nitems=1)
-                        pp = None
+        output = ""
+        for t in self.pd._fmri_changes:
+            output += "{0} -> {1}\n".format(*t)
+        return output
 
-                # No longer needed.
-                del eval_list
-                pt.plan_done(pt.PLAN_PKGPLAN)
+    def gen_new_installed_pkgs(self):
+        """Generates all the fmris which will be in the new image."""
+        assert self.pd.state >= plandesc.EVALUATED_PKGS
+        fmri_set = set(self.image.gen_installed_pkgs())
 
-        def __mediate_links(self, mediated_removed_paths):
-                """Mediate links in the plan--this requires first determining the
-                possible mediation for each mediator.  This is done solely based
-                on the metadata of the links that are still or will be installed.
-                Returns a dictionary of the proposed mediations."""
+        for p in self.pd.pkg_plans:
+            p.update_pkg_set(fmri_set)
 
-                #
-                # If we're not changing mediators, and we're not changing
-                # variants or facets (which could affect mediators), and we're
-                # not changing any packages (which could affect mediators),
-                # then mediators can't be changing so there's nothing to do
-                # here.
-                #
-                if not self.pd._mediators_change and \
-                    not self.pd._varcets_change and \
-                    not self.pd._fmri_changes:
-                        # return the currently configured mediators
-                        return defaultdict(set, self.pd._cfg_mediators)
+        for pfmri in fmri_set:
+            yield pfmri
 
-                prop_mediators = defaultdict(set)
-                mediated_installed_paths = defaultdict(set)
-                for a, pfmri in itertools.chain(
-                    self.gen_new_installed_actions_bytype("link"),
-                    self.gen_new_installed_actions_bytype("hardlink")):
-                        mediator = a.attrs.get("mediator")
-                        if not mediator:
-                                # Link is not mediated.
-                                continue
-                        med_ver = a.attrs.get("mediator-version")
-                        if med_ver:
-                                med_ver = pkg.version.Version(med_ver)
-                        med_impl = a.attrs.get("mediator-implementation")
-                        if not (med_ver or med_impl):
-                                # Link mediation is incomplete.
-                                continue
-                        med_priority = a.attrs.get("mediator-priority")
-                        prop_mediators[mediator].add((med_priority, med_ver,
-                            med_impl))
-                        mediated_installed_paths[a.attrs["path"]].add((a, pfmri,
-                            mediator, med_ver, med_impl))
+    def __gen_only_new_installed_info(self):
+        """Generates fmri-manifest pairs for all packages which are
+        being installed (or fixed, etc.)."""
+        assert self.pd.state >= plandesc.EVALUATED_PKGS
 
-                # Now select only the "best" mediation for each mediator;
-                # items() is used here as the dictionary is altered during
-                # iteration.
-                cfg_mediators = self.pd._cfg_mediators
-                changed_mediators = set()
-                for mediator, values in prop_mediators.items():
-                        med_ver_source = med_impl_source = med_priority = \
-                            med_ver = med_impl = med_impl_ver = None
+        for p in self.pd.pkg_plans:
+            if p.destination_fmri:
+                assert p.destination_manifest
+                yield p.destination_fmri, p.destination_manifest
 
-                        mediation = self.pd._new_mediators.get(mediator)
-                        cfg_mediation = cfg_mediators.get(mediator)
-                        if mediation:
-                                med_ver = mediation.get("version")
-                                med_ver_source = mediation.get("version-source")
-                                med_impl = mediation.get("implementation")
-                                med_impl_source = mediation.get(
-                                    "implementation-source")
-                        elif mediation is None and cfg_mediation:
-                                # If a reset of mediation was not requested,
-                                # use previously configured mediation as the
-                                # default.
-                                med_ver = cfg_mediation.get("version")
-                                med_ver_source = cfg_mediation.get(
-                                    "version-source")
-                                med_impl = cfg_mediation.get("implementation")
-                                med_impl_source = cfg_mediation.get(
-                                    "implementation-source")
+    def __gen_outgoing_info(self):
+        """Generates fmri-manifest pairs for all the packages which are
+        being removed."""
+        assert self.pd.state >= plandesc.EVALUATED_PKGS
 
-                        # Pick first "optimal" version and/or implementation.
-                        for opt_priority, opt_ver, opt_impl in sorted(values,
-                            key=cmp_to_key(med.cmp_mediations)):
-                                if med_ver_source == "local":
-                                        if opt_ver != med_ver:
-                                                # This mediation not allowed
-                                                # by local configuration.
-                                                continue
-                                if med_impl_source == "local":
-                                        if not mediator_impl_matches(opt_impl,
-                                            med_impl):
-                                                # This mediation not allowed
-                                                # by local configuration.
-                                                continue
+        for p in self.pd.pkg_plans:
+            if p.origin_fmri and p.origin_fmri != p.destination_fmri:
+                assert p.origin_manifest
+                yield p.origin_fmri, p.origin_manifest
 
-                                med_source = opt_priority
-                                if not med_source:
-                                        # 'source' is equivalent to priority,
-                                        # but if no priority was specified,
-                                        # treat this as 'system' to indicate
-                                        # the mediation component was arbitrarily
-                                        # selected.
-                                        med_source = "system"
+    def gen_new_installed_actions_bytype(self, atype, implicit_dirs=False):
+        """Generates actions of type 'atype' from the packages in the
+        future image."""
 
-                                if med_ver_source != "local":
-                                        med_ver = opt_ver
-                                        med_ver_source = med_source
-                                if med_impl_source != "local":
-                                        med_impl = opt_impl
-                                        med_impl_source = med_source
-                                elif med_impl and "@" not in med_impl:
-                                        # In the event a versionless
-                                        # implementation is set by the
-                                        # administrator, the version component
-                                        # has to be stored separately for display
-                                        # purposes.
-                                        impl_ver = \
-                                            med.parse_mediator_implementation(
-                                            opt_impl)[1]
-                                        if impl_ver:
-                                                med_impl_ver = impl_ver
-                                break
+        return self.__gen_star_actions_bytype(
+            atype, self.gen_new_installed_pkgs, implicit_dirs=implicit_dirs
+        )
 
-                        if cfg_mediation and \
-                             (med_ver != cfg_mediation.get("version") or
-                             not mediator_impl_matches(med_impl,
-                                 cfg_mediation.get("implementation"))):
-                                # If mediation has changed for a mediator, then
-                                # all links for already installed packages will
-                                # have to be removed if they are for the old
-                                # mediation or repaired (installed) if they are
-                                # for the new mediation.
-                                changed_mediators.add(mediator)
+    def gen_only_new_installed_actions_bytype(
+        self, atype, implicit_dirs=False, excludes=misc.EmptyI
+    ):
+        """Generates actions of type 'atype' from packages being
+        installed."""
 
-                        prop_mediators[mediator] = {}
-                        if med_ver:
-                                prop_mediators[mediator]["version"] = med_ver
-                        if med_ver_source:
-                                prop_mediators[mediator]["version-source"] = \
-                                    med_ver_source
-                        if med_impl:
-                                prop_mediators[mediator]["implementation"] = \
-                                    med_impl
-                        if med_impl_ver:
-                                prop_mediators[mediator]["implementation-version"] = \
-                                    med_impl_ver
-                        if med_impl_source:
-                                prop_mediators[mediator]["implementation-source"] = \
-                                    med_impl_source
+        return self.__gen_star_actions_bytype_from_extant_manifests(
+            atype,
+            self.__gen_only_new_installed_info,
+            excludes,
+            implicit_dirs=implicit_dirs,
+        )
 
-                # Determine which install and update actions should not be
-                # executed based on configured and proposed mediations.  Also
-                # transform any install or update actions belonging to a
-                # changing mediation into removals.
+    def gen_outgoing_actions_bytype(
+        self, atype, implicit_dirs=False, excludes=misc.EmptyI
+    ):
+        """Generates actions of type 'atype' from packages being
+        removed (not necessarily actions being removed)."""
 
-                # This keeps track of which pkgplans need to be trimmed.
-                act_removals = {}
+        return self.__gen_star_actions_bytype_from_extant_manifests(
+            atype,
+            self.__gen_outgoing_info,
+            excludes,
+            implicit_dirs=implicit_dirs,
+        )
 
-                # This keeps track of which mediated paths are being delivered
-                # and which need removal.
-                act_mediated_paths = { "installed": {}, "removed": {} }
+    def __gen_star_actions_bytype(self, atype, generator, implicit_dirs=False):
+        """Generate installed actions of type 'atype' from the package
+        fmris emitted by 'generator'.  If 'implicit_dirs' is True, then
+        when 'atype' is 'dir', directories only implicitly delivered
+        in the image will be emitted as well."""
 
-                for al, ptype in ((self.pd.install_actions, "added"),
-                    (self.pd.update_actions, "changed")):
-                        for i, ap in enumerate(al):
-                                if not ap or not (ap.dst.name == "link" or
-                                    ap.dst.name == "hardlink"):
-                                        continue
+        assert self.pd.state >= plandesc.EVALUATED_PKGS
 
-                                mediator = ap.dst.attrs.get("mediator")
-                                if not mediator:
-                                        # Link is not mediated.
-                                        continue
+        # Don't bother accounting for implicit directories if we're not
+        # looking for them.
+        if implicit_dirs:
+            if atype != "dir":
+                implicit_dirs = False
+            else:
+                da = pkg.actions.directory.DirectoryAction
 
-                                med_ver = ap.dst.attrs.get("mediator-version")
-                                if med_ver:
-                                        med_ver = pkg.version.Version(med_ver)
-                                med_impl = ap.dst.attrs.get(
-                                    "mediator-implementation")
+        for pfmri in generator():
+            m = self.image.get_manifest(pfmri, ignore_excludes=True)
+            if implicit_dirs:
+                dirs = set()  # Keep track of explicit dirs
+            for act in m.gen_actions_by_type(
+                atype, excludes=self.__new_excludes
+            ):
+                if implicit_dirs:
+                    dirs.add(act.attrs["path"])
+                yield act, pfmri
+            if implicit_dirs:
+                for d in m.get_directories(self.__new_excludes):
+                    if d not in dirs:
+                        yield da(path=d, implicit="true"), pfmri
 
-                                prop_med_ver = prop_mediators[mediator].get(
-                                    "version")
-                                prop_med_impl = prop_mediators[mediator].get(
-                                    "implementation")
+    def __gen_star_actions_bytype_from_extant_manifests(
+        self, atype, generator, excludes, implicit_dirs=False
+    ):
+        """Generate installed actions of type 'atype' from the package
+        manifests emitted by 'generator'.  'excludes' is a list of
+        variants and facets which should be excluded from the actions
+        generated.  If 'implicit_dirs' is True, then when 'atype' is
+        'dir', directories only implicitly delivered in the image will
+        be emitted as well."""
 
-                                if med_ver == prop_med_ver and \
-                                    mediator_impl_matches(med_impl,
-                                        prop_med_impl):
-                                        # Action should be delivered.
-                                        act_mediated_paths["installed"][ap.dst.attrs["path"]] = \
-                                            None
-                                        mediated_installed_paths.pop(
-                                            ap.dst.attrs["path"], None)
-                                        continue
+        assert self.pd.state >= plandesc.EVALUATED_PKGS
 
-                                # Ensure action is not delivered.
-                                al[i] = None
+        # Don't bother accounting for implicit directories if we're not
+        # looking for them.
+        if implicit_dirs:
+            if atype != "dir":
+                implicit_dirs = False
+            else:
+                da = pkg.actions.directory.DirectoryAction
 
-                                act_removals.setdefault(id(ap.p),
-                                    { "plan": ap.p, "added": [], "changed": [] })
-                                act_removals[id(ap.p)][ptype].append(id(ap.dst))
+        for pfmri, m in generator():
+            if implicit_dirs:
+                dirs = set()  # Keep track of explicit dirs
+            for act in m.gen_actions_by_type(atype, excludes=excludes):
+                if implicit_dirs:
+                    dirs.add(act.attrs["path"])
+                yield act, pfmri
 
-                                cfg_med_ver = cfg_mediators.get(mediator,
-                                    misc.EmptyDict).get("version")
-                                cfg_med_impl = cfg_mediators.get(mediator,
-                                    misc.EmptyDict).get("implementation")
+            if implicit_dirs:
+                for d in m.get_directories(excludes):
+                    if d not in dirs:
+                        yield da(path=d, implicit="true"), pfmri
 
-                                if (mediator in cfg_mediators and
-                                    mediator in prop_mediators and
-                                    (med_ver == cfg_med_ver and
-                                    mediator_impl_matches(med_impl,
-                                        cfg_med_impl))):
-                                        # Install / update actions should only be
-                                        # transformed into removals if they match
-                                        # the previous configuration and are not
-                                        # allowed by the proposed mediation.
-                                        act_mediated_paths["removed"].setdefault(
-                                            ap.dst.attrs["path"], []).append(ap)
+    def __get_directories(self):
+        """return set of all directories in target image"""
+        # always consider var and the image directory fixed in image...
+        if self.__directories == None:
+            # It's faster to build a large set and make a small
+            # update to it than to do the reverse.
+            dirs = set(
+                (
+                    os.path.normpath(d[0].attrs["path"])
+                    for d in self.gen_new_installed_actions_bytype(
+                        "dir", implicit_dirs=True
+                    )
+                )
+            )
+            dirs.update(
+                [
+                    self.image.imgdir.rstrip("/"),
+                    "var",
+                    "var/sadm",
+                    "var/sadm/install",
+                ]
+            )
+            self.__directories = dirs
+        return self.__directories
 
-                # As an optimization, only remove rejected, mediated paths if
-                # another link is not being delivered to the same path.
-                for ap in (
-                    ap
-                    for path in act_mediated_paths["removed"]
-                    for ap in act_mediated_paths["removed"][path]
-                    if path not in act_mediated_paths["installed"]
+    def __get_symlinks(self):
+        """return a set of all symlinks in target image"""
+        if self.__symlinks == None:
+            self.__symlinks = set(
+                (
+                    a.attrs["path"]
+                    for a, pfmri in self.gen_new_installed_actions_bytype(
+                        "link"
+                    )
+                )
+            )
+        return self.__symlinks
+
+    def __get_hardlinks(self):
+        """return a set of all hardlinks in target image"""
+        if self.__hardlinks == None:
+            self.__hardlinks = set(
+                (
+                    a.attrs["path"]
+                    for a, pfmri in self.gen_new_installed_actions_bytype(
+                        "hardlink"
+                    )
+                )
+            )
+        return self.__hardlinks
+
+    def __get_licenses(self):
+        """return a set of all licenses in target image"""
+        if self.__licenses == None:
+            self.__licenses = set(
+                (
+                    a.attrs["license"]
+                    for a, pfmri in self.gen_new_installed_actions_bytype(
+                        "license"
+                    )
+                )
+            )
+        return self.__licenses
+
+    def __get_legacy(self):
+        """return a set of all legacy actions in target image"""
+        if self.__legacy == None:
+            self.__legacy = set(
+                (
+                    a.attrs["pkg"]
+                    for a, pfmri in self.gen_new_installed_actions_bytype(
+                        "legacy"
+                    )
+                )
+            )
+        return self.__legacy
+
+    @staticmethod
+    def __check_inconsistent_types(actions, oactions):
+        """Check whether multiple action types within a namespace group
+        deliver to a given name in that space."""
+
+        ntypes = set((a[0].name for a in actions))
+        otypes = set((a[0].name for a in oactions))
+
+        # We end up with nothing at this path, or start and end with one
+        # of the same type, or we just add one type to an empty path.
+        if len(ntypes) == 0 or (len(ntypes) == 1 and len(otypes) <= 1):
+            return None
+
+        # We have fewer types, so actions are getting removed.
+        if len(ntypes) < len(otypes):
+            # If we still end up in a broken state, signal the
+            # caller that we should move forward, but not remove
+            # anything at this path.  Note that the type on the
+            # filesystem may not match any of the remaining types.
+            if len(ntypes) > 1:
+                return "nothing", None
+
+            assert len(ntypes) == 1
+
+            # If we end up in a sane state, signal the caller that
+            # we should make sure the right contents are in place.
+            # This implies that the actions remove() method should
+            # handle when the action isn't present.
+            if actions[0][0].name != "dir":
+                return "fixup", actions[0]
+
+            # If we end up with a directory, then we need to be
+            # careful to choose a non-implicit directory as the
+            # fixup action.
+            for a in actions:
+                if "implicit" not in a[0].attrs:
+                    return "fixup", a
+            else:
+                # If we only have implicit directories left,
+                # make up the rest of the attributes.
+                a[0].attrs.update(
+                    {"mode": "0755", "owner": "root", "group": "root"}
+                )
+                return "fixup", a
+
+        # If the broken packages remain unchanged across the plan, then
+        # we can ignore it.  We just check that the packages haven't
+        # changed.
+        sort_key = operator.itemgetter(1)
+        actions = sorted(actions, key=sort_key)
+        oactions = sorted(oactions, key=sort_key)
+        if ntypes == otypes and all(
+            o[1] == n[1] for o, n in zip(oactions, actions)
+        ):
+            return "nothing", None
+
+        return "error", actions
+
+    @staticmethod
+    def __check_duplicate_actions(actions, oactions):
+        """Check whether we deliver more than one action with a given
+        key attribute value if only a single action of that type and
+        value may be delivered."""
+
+        # We end up with no actions or start with one or none and end
+        # with exactly one.
+        if len(actions) == 0 or (len(oactions) <= len(actions) == 1):
+            if len(oactions) > 1 and any(
+                a[0].attrs.get("overlay") == "true" for a in oactions
+            ):
+                # If more than one action is being removed and
+                # one of them is an overlay, then suppress
+                # removal of the overlaid actions (if any) to
+                # ensure preserve rules of overlay action apply.
+                return "overlay", None
+            return None
+
+        # Removing actions.
+        if len(actions) < len(oactions):
+            # If any of the new actions is an overlay, suppress
+            # the removal of the overlaid action.
+            if any(a[0].attrs.get("overlay") == "true" for a in actions):
+                return "overlay", None
+
+            # If we still end up in a broken state, signal the
+            # caller that we should move forward, but not remove
+            # any actions.
+            if len(actions) > 1 or any(
+                "preserve" in a[0].attrs for a in actions
+            ):
+                return "nothing", None
+
+            # If we end up in a sane state, signal the caller that
+            # we should make sure the right contents are in place.
+            # This implies that the action's remove() method should
+            # handle when the action isn't present.
+            return "fixup", actions[0]
+
+        # If the broken paths remain unchanged across the plan, then we
+        # can ignore it.  We have to resort to stringifying the actions
+        # in order to sort them since the usual sort is much lighter
+        # weight.
+        oactions.sort(key=lambda x: str(x[0]))
+        actions.sort(key=lambda x: str(x[0]))
+        if len(oactions) == len(actions) and all(
+            o[0] == n[0] for o, n, in zip(oactions, actions)
+        ):
+            return "nothing", None
+
+        # For file actions, delivery of two actions to a single point is
+        # permitted if:
+        #   * there are only two actions in conflict
+        #   * one action has 'preserve' set and 'overlay=allow'
+        #   * the other action has 'overlay=true'
+        if len(actions) == 2:
+            overlayable = overlay = None
+            for act, ignored in actions:
+                if (
+                    act.name == "file"
+                    and act.attrs.get("overlay") == "allow"
+                    and "preserve" in act.attrs
                 ):
-                        ap.p.actions.removed.append((ap.dst,
-                            None))
-                        self.pd.removal_actions.append(_ActionPlan(
-                            ap.p, ap.dst, None))
-                act_mediated_paths = None
+                    overlayable = act
+                elif act.name == "file" and act.attrs.get("overlay") == "true":
+                    overlay = act
+            if overlayable and overlay:
+                # Found both an overlayable action and the
+                # action that overlays it.
+                ignore = ["preserve"]
+                # If neither overlay nor overlayable action
+                # has "deny" set in "overlay-attributes"
+                if "deny" not in overlay.attrlist(
+                    "overlay-attributes"
+                ) and "deny" not in overlayable.attrlist("overlay-attributes"):
+                    ignore.extend(["owner", "group", "mode", "sysattr"])
+                # Need to verify mismatched attributes between
+                # overlaying action and overlaid action in
+                # testsuite.
+                elif DebugValues["broken-conflicting-action-handling"]:
+                    ignore.extend(["owner", "group", "mode", "sysattr"])
+                errors = ImagePlan.__find_inconsistent_attrs(
+                    actions, ignore=ignore
+                )
+                if errors:
+                    # overlay is not permitted if unique
+                    # attributes (except 'preserve') are
+                    # inconsistent
+                    return (
+                        "error",
+                        actions,
+                        api_errors.InconsistentActionAttributeError,
+                    )
+                return "overlay", None
 
-                for a, pfmri, mediator, med_ver, med_impl in (
-                    med_link
-                    for entry in mediated_installed_paths.values()
-                    for med_link in entry):
-                        if mediator not in changed_mediators:
-                                # Action doesn't need repairing.
-                                continue
+        return "error", actions
 
-                        new_med_ver = prop_mediators[mediator].get("version")
-                        new_med_impl = prop_mediators[mediator].get(
-                            "implementation")
+    @staticmethod
+    def __find_inconsistent_attrs(actions, ignore=misc.EmptyI):
+        """Find all the problem Action pairs.
 
-                        if med_ver == new_med_ver and \
-                            mediator_impl_matches(med_impl, new_med_impl):
-                                # Action needs to be repaired (installed) since
-                                # mediation now applies.
-                                self.__propose_fixup(a, None, pfmri)
-                                continue
+        'ignore' is an optional list of attributes to ignore when
+        checking for inconsistent attributes.  By default, all
+        attributes listed in the 'unique_attrs' property of an
+        Action are checked.
+        """
 
-                        if mediator not in cfg_mediators:
-                                # Nothing to do.
-                                continue
+        # We iterate over all pairs of actions to see if any conflict
+        # with the rest.  If two actions are "safe" together, then we
+        # can ignore one of them for the rest of the run, since we can
+        # compare the rest of the actions against just one copy of
+        # essentially identical actions.
+        seen = set()
+        problems = []
+        for a1, a2 in itertools.combinations(actions, 2):
+            # Implicit directories don't contribute to problems.
+            if a1[0].name == "dir" and "implicit" in a1[0].attrs:
+                continue
 
-                        cfg_med_ver = cfg_mediators[mediator].get("version")
-                        cfg_med_impl = cfg_mediators[mediator].get(
-                            "implementation")
-                        if a.attrs["path"] not in mediated_removed_paths and \
-                            med_ver == cfg_med_ver and \
-                            mediator_impl_matches(med_impl, cfg_med_impl):
-                                # Action needs to be removed since mediation no
-                                # longer applies and is not already set for
-                                # removal.
-                                self.__propose_fixup(None, a, pfmri)
+            if a2 in seen:
+                continue
 
-                # Now trim pkgplans and elide empty entries from list of actions
-                # to execute.
-                for entry in act_removals.values():
-                        p = entry["plan"]
-                        for prop in ("added", "changed"):
-                                trim = entry[prop]
-                                # Can't modify the p.actions tuple directly, so
-                                # modify the members in place.
-                                pval = getattr(p.actions, prop)
-                                pval[:] = [
-                                    a
-                                    for a in pval
-                                    if id(a[1]) not in trim
-                                ]
+            # Find the attributes which are different between the
+            # two actions, and if there are none, skip the action.
+            # We have to treat "implicit" specially for implicit
+            # directories because none of the attributes except for
+            # "path" will exist.
+            diffs = a1[0].differences(a2[0])
+            if not diffs or "implicit" in diffs:
+                seen.add(a2)
+                continue
 
-                return prop_mediators
+            # If none of the different attributes is one that must
+            # be identical, then we can skip this action.
+            if not any(
+                d
+                for d in diffs
+                if (d in a1[0].unique_attrs and d not in ignore)
+            ):
+                seen.add(a2)
+                continue
 
-        def __full_target_path(self, linkpath):
-                """ Resolves a link target to a relative pathname
-                    of the image being modified. """
+            if (
+                (a1[0].name == "link" or a1[0].name == "hardlink")
+                and (a1[0].attrs.get("mediator") == a2[0].attrs.get("mediator"))
+                and (
+                    a1[0].attrs.get("mediator-version")
+                    != a2[0].attrs.get("mediator-version")
+                    or a1[0].attrs.get("mediator-implementation")
+                    != a2[0].attrs.get("mediator-implementation")
+                )
+            ):
+                # If two links share the same mediator and have
+                # different mediator versions and/or
+                # implementations, then permit them to collide.
+                # The imageplan will select which ones to remove
+                # and install based on the mediator configuration
+                # in the image.
+                seen.add(a2)
+                continue
 
-                rootpath = os.path.join(self.image.root, linkpath)
-                reallinkpath = os.path.normpath(rootpath)
+            problems.append((a1, a2))
 
-                targetname = os.path.realpath(reallinkpath)
-                # Should only trigger if there is something wrong with the
-                # associated package manifest.
-                assert(targetname.startswith(self.image.root))
-                # Chop the image.root off as a relative path to match
-                # the package manifests is required.
-                res = targetname[len(self.image.root):]
-                # Zones will have an extra '/' at the start of the pathname,
-                # so remove it.
-                if res.startswith("/"):
-                        return res[1:]
-                return res
+        return problems
 
-        def __make_med_msg(self):
-                """ Helper function to create the message string for poorly
-                    configured mediators. """
-                fmt_str = "  {0:24} {1}\n"
-                res = _("The following mediated link targets do not exist, "
-                        "please reset the links via pkg set-mediator:\n")
-                res = res + fmt_str.format(_("MEDIATOR"), _("REMOVED PATH(S)"))
-                for med in self.invalid_meds:
-                        res = res + fmt_str.format(med,
-                                                   ", ".join(
-                                                   self.invalid_meds[med]))
-                return res
+    @staticmethod
+    def __check_inconsistent_attrs(actions, oactions):
+        """Check whether we have non-identical actions delivering to the
+        same point in their namespace."""
 
-        def __make_excl_msg(self, elided: list[str]) -> str:
-                """ Helper function to create the message string for excluded
-                    actions. """
+        nproblems = ImagePlan.__find_inconsistent_attrs(actions)
+        oproblems = ImagePlan.__find_inconsistent_attrs(oactions)
 
-                return _("""\
+        # If we end up with more problems than we started with, we
+        # should error out.  If we end up with the same number as
+        # before, then we simply leave things alone.  And if we end up
+        # with fewer, then we try to clean up.
+        if len(nproblems) > len(oproblems):
+            return "error", actions
+        elif not nproblems and not oproblems:
+            return
+        elif len(nproblems) == len(oproblems):
+            return "nothing", None
+        else:
+            if actions[0][0].name != "dir":
+                return "fixup", actions[0]
+
+            # Find a non-implicit directory action to use
+            for a in actions:
+                if "implicit" not in a[0].attrs:
+                    return "fixup", a
+            else:
+                return "nothing", None
+
+    def __propose_fixup(self, inst_action, rem_action, pfmri):
+        """Add to the current plan a pseudo repair plan to fix up
+        correctable conflicts."""
+
+        pp, install, remove = self.__fixups.get(pfmri, (None, None, None))
+        if pp is None:
+            pp = pkgplan.PkgPlan(self.image)
+            if inst_action:
+                install = [inst_action]
+                remove = []
+            else:
+                install = []
+                remove = [rem_action]
+            self.__fixups[pfmri] = pp, install, remove
+        elif inst_action:
+            install.append(inst_action)
+        else:
+            remove.append(rem_action)
+
+    def __evaluate_fixups(self):
+        nfm = manifest.NullFactoredManifest
+        for pfmri, (pp, install, remove) in self.__fixups.items():
+            pp.propose_repair(pfmri, nfm, install, remove, autofix=True)
+            pp.evaluate(self.__old_excludes, self.__new_excludes)
+            self.pd.pkg_plans.append(pp)
+
+            # Repairs end up going into the package plan's update
+            # and remove lists, so _ActionPlans needed to be
+            # appended for each action in this fixup pkgplan to
+            # the list of related actions.
+            for action in install:
+                if "path" in action.attrs and self.__check_excluded(
+                    action.attrs["path"]
+                ):
+                    continue
+                self.pd.update_actions.append(_ActionPlan(pp, None, action))
+            for action in remove:
+                if "path" in action.attrs and self.__check_excluded(
+                    action.attrs["path"]
+                ):
+                    continue
+                self.pd.removal_actions.append(_ActionPlan(pp, action, None))
+
+        # Don't process this particular set of fixups again.
+        self.__fixups = {}
+
+    def __process_conflicts(self, key, func, actions, oactions, errclass, errs):
+        """The conflicting action checking functions all need to be
+        dealt with in a similar fashion, so we do that work in one
+        place."""
+
+        ret = func(actions, oactions)
+        if ret is None:
+            return False
+
+        if len(ret) == 3:
+            # Allow checking functions to override default errclass.
+            msg, actions, errclass = ret
+        else:
+            msg, actions = ret
+
+        if not isinstance(msg, six.string_types):
+            return False
+
+        if msg == "nothing":
+            for i, ap in enumerate(self.pd.removal_actions):
+                if ap and ap.src.attrs.get(ap.src.key_attr, None) == key:
+                    self.pd.removal_actions[i] = None
+        elif msg == "overlay":
+            pp_needs_trimming = {}
+            moved = set()
+            # Suppress install and update of overlaid file.
+            for al in (self.pd.install_actions, self.pd.update_actions):
+                for i, ap in enumerate(al):
+                    if not ap:
+                        # Action has been removed.
+                        continue
+
+                    attrs = ap.dst.attrs
+                    if attrs.get(ap.dst.key_attr) != key:
+                        if "preserve" in attrs and "original_name" in attrs:
+                            # Possible move to a
+                            # different location for
+                            # editable file.
+                            # Overlay attribute is
+                            # not checked in case it
+                            # was dropped as part of
+                            # move.
+                            moved.add(attrs["original_name"])
+                        continue
+
+                    if attrs.get("overlay") != "allow":
+                        # Only care about overlaid
+                        # actions.
+                        continue
+
+                    # Remove conflicting, overlaid actions
+                    # from plan.
+                    al[i] = None
+                    pp_needs_trimming.setdefault(
+                        id(ap.p), {"plan": ap.p, "trim": []}
+                    )
+                    pp_needs_trimming[id(ap.p)]["trim"].append(id(ap.dst))
+                    break
+
+            # Suppress removal of overlaid file.
+            al = self.pd.removal_actions
+            for i, ap in enumerate(al):
+                if not ap:
+                    continue
+
+                attrs = ap.src.attrs
+                if not attrs.get(ap.src.key_attr) == key:
+                    continue
+
+                if attrs.get("overlay") != "allow":
+                    # Only interested in overlaid actions.
+                    continue
+
+                orig_name = attrs.get(
+                    "original_name",
+                    "{0}:{1}".format(
+                        ap.p.origin_fmri.get_name(), attrs["path"]
+                    ),
+                )
+                if orig_name in moved:
+                    # File has moved locations; removal will
+                    # be executed, but file will be saved
+                    # for the move skipping unlink.
+                    ap.src.attrs["save_file"] = [orig_name, "false"]
+                    break
+
+                al[i] = None
+                pp_needs_trimming.setdefault(
+                    id(ap.p), {"plan": ap.p, "trim": []}
+                )
+                pp_needs_trimming[id(ap.p)]["trim"].append(id(ap.src))
+                break
+
+            for entry in pp_needs_trimming.values():
+                p = entry["plan"]
+                trim = entry["trim"]
+                # Can't modify the p.actions tuple, so modify
+                # the added member in-place.
+                for prop in ("added", "changed", "removed"):
+                    pval = getattr(p.actions, prop)
+                    pval[:] = [a for a in pval if id(a[1]) not in trim]
+        elif msg == "fixup":
+            self.__propose_fixup(actions[0], None, actions[1])
+        elif msg == "error":
+            errs.append(errclass(actions))
+        else:
+            assert False, (
+                "{0}() returned something other than "
+                "'nothing', 'overlay', 'error', or 'fixup': '{1}'".format(
+                    func.__name__, msg
+                )
+            )
+
+        return True
+
+    def __seed(self, gen_func, action_classes, excludes):
+        """Build a mapping from action keys to action, pfmri tuples for
+        a set of action types.
+
+        The 'gen_func' is a function which takes an action type and
+        'implicit_dirs' and returns action-pfmri pairs.
+
+        The 'action_classes' parameter is a list of action types."""
+
+        d = {}
+        for klass in action_classes:
+            self.__progtrack.plan_add_progress(
+                self.__progtrack.PLAN_ACTION_CONFLICT
+            )
+            for a, pfmri in gen_func(
+                klass.name, implicit_dirs=True, excludes=excludes
+            ):
+                d.setdefault(a.attrs[klass.key_attr], []).append((a, pfmri))
+        return d
+
+    @staticmethod
+    def __act_dup_check(tgt, key, actstr, fmristr):
+        """Check for duplicate actions/fmri tuples in 'tgt', which is
+        indexed by 'key'."""
+
+        #
+        # When checking for duplicate actions we have to account for
+        # the fact that actions which are part of a package plan are
+        # not stripped.  But the actions we're iterating over here are
+        # coming from the stripped action cache, so they have had
+        # assorted attributes removed (like variants, facets, etc.) So
+        # to check for duplicates we have to make sure to strip the
+        # actions we're comparing against.  Of course we can't just
+        # strip the actions which are part of a package plan because
+        # we could be removing data critical to the execution of that
+        # action like original_name, etc.  So before we strip an
+        # action we have to make a copy of it.
+        #
+        # If we're dealing with a directory action and an "implicit"
+        # attribute exists, we need to preserve it.  We assume it's a
+        # synthetic attribute that indicates that the action was
+        # created implicitly (and hence won't conflict with an
+        # explicit directory action defining the same directory).
+        # Note that we've assumed that no one will ever add an
+        # explicit "implicit" attribute to a directory action.
+        #
+        preserve = {"dir": ["implicit"]}
+        if key not in tgt:
+            return False
+        for act, pfmri in tgt[key]:
+            # check the fmri first since that's easy
+            if fmristr != str(pfmri):
+                continue
+            act = pkg.actions.fromstr(str(act))
+            act.strip(preserve=preserve)
+            if actstr == str(act):
+                return True
+        return False
+
+    def __update_act(
+        self,
+        keys,
+        tgt,
+        skip_dups,
+        offset_dict,
+        action_classes,
+        sf,
+        skip_fmris,
+        fmri_dict,
+    ):
+        """Update 'tgt' with action/fmri pairs from the stripped
+        action cache that are associated with the specified action
+        'keys'.
+
+        The 'skip_dups' parameter indicates if we should avoid adding
+        duplicate action/pfmri pairs into 'tgt'.
+
+        The 'offset_dict' parameter contains a mapping from key to
+        offsets into the actions.stripped file and the number of lines
+        to read.
+
+        The 'action_classes' parameter contains the list of action types
+        where one action can conflict with another action.
+
+        The 'sf' parameter is the actions.stripped file from which we
+        read the actual actions indicated by the offset dictionary
+        'offset_dict.'
+
+        The 'skip_fmris' parameter contains a set of strings
+        representing the packages which we should not process actions
+        for.
+
+        The 'fmri_dict' parameter is a cache of previously built PkgFmri
+        objects which is used so the same string isn't translated into
+        the same PkgFmri object multiple times."""
+
+        for key in keys:
+            offsets = []
+            for klass in action_classes:
+                offset = offset_dict.get((klass.name, key), None)
+                if offset is not None:
+                    offsets.append(offset)
+
+            for offset, cnt in offsets:
+                sf.seek(offset)
+                pns = None
+                i = 0
+                while 1:
+                    # sf is reading in binary mode
+                    line = misc.force_str(sf.readline())
+                    i += 1
+                    if i > cnt:
+                        break
+                    line = line.rstrip()
+                    if line == "":
+                        break
+                    fmristr, actstr = line.split(None, 1)
+                    if fmristr in skip_fmris:
+                        continue
+                    act = pkg.actions.fromstr(actstr)
+                    if act.attrs[act.key_attr] != key:
+                        raise api_errors.InvalidPackageErrors(
+                            [
+                                "{} has invalid manifest "
+                                "line:".format(fmristr),
+                                "    '{}'".format(actstr),
+                                "    '{}' vs. '{}'".format(
+                                    act.attrs[act.key_attr], key
+                                ),
+                            ]
+                        )
+                    assert pns is None or act.namespace_group == pns
+                    pns = act.namespace_group
+
+                    try:
+                        pfmri = fmri_dict[fmristr]
+                    except KeyError:
+                        pfmri = pkg.fmri.PkgFmri(fmristr)
+                        fmri_dict[fmristr] = pfmri
+                    if skip_dups and self.__act_dup_check(
+                        tgt, key, actstr, fmristr
+                    ):
+                        continue
+                    tgt.setdefault(key, []).append((act, pfmri))
+
+    def __fast_check(self, new, old, ns):
+        """Check whether actions being added and removed are
+        sufficiently similar that further conflict checking on those
+        actions isn't needed.
+
+        The 'new' parameter is a dictionary mapping keys to the incoming
+        actions with that as a key.  The incoming actions are actions
+        delivered by packages which are being installed or updated to.
+
+        The 'old' parameter is a dictionary mapping keys to the outgoing
+        actions with that as a key.  The outgoing actions are actions
+        delivered by packages which are being removed or updated from.
+
+        The 'ns' parameter is the action namespace for the actions in
+        'new' and 'old'."""
+
+        # .keys() is being used because we're removing keys from the
+        # dictionary as we go.
+        for key in list(new.keys()):
+            actions = new[key]
+            assert len(actions) > 0
+            oactions = old.get(key, [])
+            # If new actions are being installed, then we need to do
+            # the full conflict checking.
+            if not oactions:
+                continue
+
+            unmatched_old_actions = set(range(0, len(oactions)))
+
+            # If the action isn't refcountable and there's more than
+            # one action, that's an error so we let
+            # __check_conflicts handle it.
+            entry = actions[0][0]
+            if (
+                not entry.refcountable
+                and entry.globally_identical
+                and len(actions) > 1
+            ):
+                continue
+
+            # Check that each incoming action has a match in the
+            # outgoing actions.
+            next_key = False
+            for act, pfmri in actions:
+                matched = False
+                aname = act.name
+                aattrs = act.attrs
+                # Compare this action with each outgoing action.
+                for i, (oact, opfmri) in enumerate(oactions):
+                    if aname != oact.name:
+                        continue
+                    # Check whether all attributes which
+                    # need to be unique are identical for
+                    # these two actions.
+                    oattrs = oact.attrs
+                    if all(
+                        (
+                            aattrs.get(a) == oattrs.get(a)
+                            for a in act.unique_attrs
+                        )
+                    ):
+                        matched = True
+                        break
+
+                # If this action didn't have a match in the old
+                # action, then this key needs full conflict
+                # checking so move on to the next key.
+                if not matched:
+                    next_key = True
+                    break
+                unmatched_old_actions.discard(i)
+            if next_key:
+                continue
+
+            # Check that each outgoing action has a match in the
+            # incoming actions.
+            for i, (oact, opfmri) in enumerate(oactions):
+                if i not in unmatched_old_actions:
+                    continue
+                matched = False
+                for act, pfmri in actions:
+                    if act.name != oact.name:
+                        continue
+                    if all(
+                        (
+                            act.attrs.get(a) == oact.attrs.get(a)
+                            for a in act.unique_attrs
+                        )
+                    ):
+                        matched = True
+                        break
+                if not matched:
+                    next_key = True
+                    break
+                unmatched_old_actions.discard(i)
+            if next_key or unmatched_old_actions:
+                continue
+            # We know that each incoming action matches at least one
+            # outgoing action and each outgoing action matches at
+            # least one incoming action, so no further conflict
+            # checking is needed.
+            del new[key]
+            del old[key]
+
+        # .keys() is being used because we're removing keys from the
+        # dictionary as we go.
+        for key in list(old.keys()):
+            # If actions that aren't in conflict are being removed,
+            # then nothing more needs to be done.
+            if key not in new:
+                del old[key]
+
+    def __check_conflicts(self, new, old, action_classes, ns, errs):
+        """Check all the newly installed actions for conflicts with
+        existing actions."""
+
+        for key, actions in six.iteritems(new):
+            oactions = old.get(key, [])
+
+            self.__progtrack.plan_add_progress(
+                self.__progtrack.PLAN_ACTION_CONFLICT
+            )
+
+            if len(actions) == 1 and len(oactions) < 2:
+                continue
+
+            # Actions delivering to the same point in a
+            # namespace group's namespace should have the
+            # same type.
+            if type(ns) != int:
+                if self.__process_conflicts(
+                    key,
+                    self.__check_inconsistent_types,
+                    actions,
+                    oactions,
+                    api_errors.InconsistentActionTypeError,
+                    errs,
+                ):
+                    continue
+
+            # By virtue of the above check, all actions at
+            # this point in this namespace are the same.
+            assert len(set(a[0].name for a in actions)) <= 1
+            assert len(set(a[0].name for a in oactions)) <= 1
+
+            # Multiple non-refcountable actions delivered to
+            # the same name is an error.
+            entry = actions[0][0]
+            if not entry.refcountable and entry.globally_identical:
+                if self.__process_conflicts(
+                    key,
+                    self.__check_duplicate_actions,
+                    actions,
+                    oactions,
+                    api_errors.DuplicateActionError,
+                    errs,
+                ):
+                    continue
+
+            # Multiple refcountable but globally unique
+            # actions delivered to the same name must be
+            # identical.
+            elif entry.globally_identical:
+                if self.__process_conflicts(
+                    key,
+                    self.__check_inconsistent_attrs,
+                    actions,
+                    oactions,
+                    api_errors.InconsistentActionAttributeError,
+                    errs,
+                ):
+                    continue
+
+        # Ensure that overlay and preserve file semantics are handled
+        # as expected when conflicts only exist in packages that are
+        # being removed.
+        for key, oactions in six.iteritems(old):
+            self.__progtrack.plan_add_progress(
+                self.__progtrack.PLAN_ACTION_CONFLICT
+            )
+
+            if len(oactions) < 2:
+                continue
+
+            if key in new:
+                # Already processed.
+                continue
+
+            if any(a[0].name != "file" for a in oactions):
+                continue
+
+            entry = oactions[0][0]
+            if not entry.refcountable and entry.globally_identical:
+                if self.__process_conflicts(
+                    key,
+                    self.__check_duplicate_actions,
+                    [],
+                    oactions,
+                    api_errors.DuplicateActionError,
+                    errs,
+                ):
+                    continue
+
+    @staticmethod
+    def _check_actions(nsd):
+        """Return the keys in the namespace dictionary ('nsd') which
+        map to actions that conflict with each other."""
+
+        def noop(*args):
+            return None
+
+        bad_keys = set()
+        for ns, key_dict in six.iteritems(nsd):
+            if type(ns) != int:
+                type_func = ImagePlan.__check_inconsistent_types
+            else:
+                type_func = noop
+            for key, actions in six.iteritems(key_dict):
+                if len(actions) == 1:
+                    continue
+                if type_func(actions, []) is not None:
+                    bad_keys.add(key)
+                    continue
+                if (
+                    not actions[0][0].refcountable
+                    and actions[0][0].globally_identical
+                ):
+                    if (
+                        ImagePlan.__check_duplicate_actions(actions, [])
+                        is not None
+                    ):
+                        bad_keys.add(key)
+                        continue
+                elif (
+                    actions[0][0].globally_identical
+                    and ImagePlan.__check_inconsistent_attrs(actions, [])
+                    is not None
+                ):
+                    bad_keys.add(key)
+                    continue
+        return bad_keys
+
+    def __clear_pkg_plans(self):
+        """Now that we're done reading the manifests, we can clear them
+        from the pkgplans."""
+
+        for p in self.pd.pkg_plans:
+            p.clear_dest_manifest()
+            p.clear_origin_manifest()
+
+    def __find_all_conflicts(self):
+        """Find all instances of conflicting actions.
+
+        There are three categories of conflicting actions.  The first
+        involves the notion of a 'namespace group': a set of action
+        classes which install into the same namespace.  The only example
+        of this is the set of filesystem actions: file, dir, link, and
+        hardlink.  If more than one action delivers to a given pathname,
+        all of those actions need to be of the same type.
+
+        The second category involves actions which cannot be delivered
+        multiple times to the same point in their namespace.  For
+        example, files must be delivered exactly once, as must users,
+        but directories or symlinks can be delivered multiple times, and
+        we refcount them.
+
+        The third category involves actions which may be delivered
+        multiple times, but all of those actions must be identical in
+        their core attributes.
+        """
+
+        # We need to be able to create broken images from the testsuite.
+        if DebugValues["broken-conflicting-action-handling"]:
+            self.__clear_pkg_plans()
+            return
+
+        errs = []
+
+        pt = self.__progtrack
+        pt.plan_start(pt.PLAN_ACTION_CONFLICT)
+
+        # Using strings instead of PkgFmri objects in sets allows for
+        # much faster performance.
+        new_fmris = set((str(s) for s in self.gen_new_installed_pkgs()))
+
+        # If we're removing all packages, there won't be any conflicts.
+        if not new_fmris:
+            pt.plan_done(pt.PLAN_ACTION_CONFLICT)
+            self.__clear_pkg_plans()
+            return
+
+        # figure out which installed packages are being removed by
+        # this operation
+        old_fmris = set((str(s) for s in self.image.gen_installed_pkgs()))
+        gone_fmris = old_fmris - new_fmris
+
+        # figure out which new packages are being touched by this
+        # operation.
+        changing_fmris = set(
+            [
+                str(p.destination_fmri)
+                for p in self.pd.pkg_plans
+                if p.destination_fmri
+            ]
+        )
+
+        # Group action types by namespace groups
+        kf = operator.attrgetter("namespace_group")
+
+        # Unequal types are not comparable in Python 3, therefore
+        # convert them to the same type 'int' first.
+        def key(a):
+            kf = a.namespace_group
+            if kf is None:
+                return -1
+            elif kf == "path":
+                return 20
+            return kf
+
+        types = sorted(six.itervalues(pkg.actions.types), key=key)
+
+        namespace_dict = dict(
+            (ns, list(action_classes))
+            for ns, action_classes in itertools.groupby(types, kf)
+        )
+
+        pt.plan_add_progress(pt.PLAN_ACTION_CONFLICT)
+        # Load information about the actions currently on the system.
+        offset_dict = self.image._load_actdict(self.__progtrack)
+        sf = self.image._get_stripped_actions_file()
+
+        conflict_clean_image = self.image._load_conflicting_keys() == set()
+
+        fmri_dict = weakref.WeakValueDictionary()
+        # Iterate over action types in namespace groups first; our first
+        # check should be for action type consistency.
+        for ns, action_classes in six.iteritems(namespace_dict):
+            pt.plan_add_progress(pt.PLAN_ACTION_CONFLICT)
+            # There's no sense in checking actions which have no
+            # limits
+            if all(not c.globally_identical for c in action_classes):
+                continue
+
+            # The 'new' dict contains information about the system
+            # as it will be.  We start by accumulating actions from
+            # the manifests of the packages being installed.
+            new = self.__seed(
+                self.gen_only_new_installed_actions_bytype,
+                action_classes,
+                self.__new_excludes,
+            )
+
+            # The 'old' dict contains information about the system
+            # as it is now.  We start by accumulating actions from
+            # the manifests of the packages being removed.
+            old = self.__seed(
+                self.gen_outgoing_actions_bytype,
+                action_classes,
+                self.__old_excludes,
+            )
+
+            if conflict_clean_image:
+                self.__fast_check(new, old, ns)
+
+            with contextlib.closing(
+                mmap.mmap(sf.fileno(), 0, access=mmap.ACCESS_READ)
+            ) as msf:
+                # Skip file header.
+                msf.readline()
+                msf.readline()
+
+                # Update 'old' with all actions from the action
+                # cache which could conflict with the new
+                # actions being installed, or with actions
+                # already installed, but not getting removed.
+                keys = set(
+                    itertools.chain(six.iterkeys(new), six.iterkeys(old))
+                )
+                self.__update_act(
+                    keys,
+                    old,
+                    False,
+                    offset_dict,
+                    action_classes,
+                    msf,
+                    gone_fmris,
+                    fmri_dict,
+                )
+
+                # Now update 'new' with all actions from the
+                # action cache which are staying on the system,
+                # and could conflict with the actions being
+                # installed.
+                keys = set(six.iterkeys(old))
+                self.__update_act(
+                    keys,
+                    new,
+                    True,
+                    offset_dict,
+                    action_classes,
+                    msf,
+                    gone_fmris | changing_fmris,
+                    fmri_dict,
+                )
+
+            self.__check_conflicts(new, old, action_classes, ns, errs)
+
+        del fmri_dict
+        self.__clear_pkg_plans()
+        sf.close()
+        self.__evaluate_fixups()
+        pt.plan_done(pt.PLAN_ACTION_CONFLICT)
+
+        if errs:
+            raise api_errors.ConflictingActionErrors(errs)
+
+    @staticmethod
+    def default_keyfunc(name, act):
+        """This is the default function used by get_actions when
+        the caller provides no key."""
+
+        attr_name = pkg.actions.types[name].key_attr
+        return act.attrs[attr_name]
+
+    @staticmethod
+    def hardlink_keyfunc(name, act):
+        """Keyfunc used in evaluate when calling get_actions
+        for hardlinks."""
+
+        return act.get_target_path()
+
+    def get_actions(self, name, key=None):
+        """Return a dictionary of actions of the type given by 'name'
+        describing the target image.  If 'key' is given and not None,
+        the dictionary's key will be the name of the action type's key
+        attribute.  Otherwise, it's a callable taking an action as an
+        argument which returns the key.  This dictionary is cached for
+        quick future lookups."""
+        if key is None:
+            key = self.default_keyfunc
+
+        if (name, key) in self.__cached_actions:
+            return self.__cached_actions[(name, key)]
+
+        d = {}
+        for act, pfmri in self.gen_new_installed_actions_bytype(name):
+            t = key(name, act)
+            d.setdefault(t, []).append(act)
+        self.__cached_actions[(name, key)] = d
+        return self.__cached_actions[(name, key)]
+
+    def __get_manifest(self, pfmri, intent, ignore_excludes=False):
+        """Return manifest for pfmri"""
+        if pfmri:
+            return self.image.get_manifest(
+                pfmri,
+                ignore_excludes=ignore_excludes or self.pd._varcets_change,
+                intent=intent,
+            )
+        else:
+            return manifest.NullFactoredManifest
+
+    def __create_intent(self, old_fmri, new_fmri, enabled_publishers):
+        """Return intent strings (or None).  Given a pair
+        of fmris describing a package operation, this
+        routine returns intent strings to be passed to
+        originating publisher describing manifest
+        operations.  We never send publisher info to
+        prevent cross-publisher leakage of info."""
+
+        if self.__noexecute:
+            return None, None
+
+        __match_intent = dict()
+        __match_intent.update(self.__match_inst)
+        __match_intent.update(self.__match_rm)
+        __match_intent.update(self.__match_update)
+
+        if new_fmri:
+            reference = __match_intent.get(new_fmri, None)
+            # don't leak prev. version info across publishers
+            if old_fmri:
+                if old_fmri.get_publisher() != new_fmri.get_publisher():
+                    old_fmri = "unknown"
+                else:
+                    old_fmri = old_fmri.get_fmri(anarchy=True)
+            # don't send pub
+            new_fmri = new_fmri.get_fmri(anarchy=True)
+        else:
+            reference = __match_intent.get(old_fmri, None)
+            # don't try to send intent info to disabled publisher
+            if old_fmri.get_publisher() in enabled_publishers:
+                # don't send pub
+                old_fmri = old_fmri.get_fmri(anarchy=True)
+            else:
+                old_fmri = None
+
+        info = {
+            "operation": self.pd._op,
+            "old_fmri": old_fmri,
+            "new_fmri": new_fmri,
+            "reference": reference,
+        }
+
+        s = "({0})".format(
+            ";".join(
+                [
+                    "{0}={1}".format(key, info[key])
+                    for key in info
+                    if info[key] is not None
+                ]
+            )
+        )
+
+        if new_fmri:
+            return None, s  # only report new on upgrade
+        elif old_fmri:
+            return s, None  # uninstall w/ enabled pub
+        else:
+            return None, None  # uninstall w/ disabled pub
+
+    def add_actuator(self, phase, name, value):
+        """Add an actuator to the plan.
+
+        The actuator name ('reboot-needed', 'restart_fmri', etc.) is
+        given in 'name', and the fmri string or callable is given in
+        'value'.  The 'phase' parameter must be one of 'install',
+        'remove', or 'update'.
+        """
+
+        if phase == "install":
+            d = self.pd._actuators.install
+        elif phase == "remove":
+            d = self.pd._actuators.removal
+        elif phase == "update":
+            d = self.pd._actuators.update
+
+        if hasattr(value, "__call__"):
+            d[name] = value
+        else:
+            d.setdefault(name, []).append(value)
+
+    def __evaluate_pkg_preserved_files(self):
+        """Private helper function that determines which preserved files
+        have changed in ImagePlan and how."""
+
+        assert self.state >= plandesc.MERGED_OK
+
+        pd = self.pd
+
+        # Track movement of preserved ("editable") files for plan
+        # summary and cache management.
+        moved = []
+        removed = []
+        installed = []
+        updated = []
+
+        # __merge_actions() adds the 'save_file' attribute to src
+        # actions that are being moved somewhere else and to dest
+        # actions that will be restored from a src action.  This only
+        # happens when at least one of the files involved has a
+        # 'preserve' attribute, so it's safe to treat either as a
+        # 'preserved' ("editable") file.
+
+        # The removal_actions are processed first since we'll determine
+        # how to transform them while processing the install and update
+        # actions based on the destination file state.
+        for ap in pd.removal_actions:
+            src = ap.src
+            if src.name != "file":
+                continue
+            if not (
+                "preserve" in src.attrs
+                or "save_file" in src.attrs
+                or "overlay" in src.attrs
+            ):
+                # Removed action has to be a preserved file or a
+                # source of a restore.
+                continue
+            if "elfhash" in src.attrs:
+                # Ignore erroneously tagged files.
+                continue
+
+            if src.attrs.get("preserve") in ("abandon", "install-only"):
+                # these files are never removed.
+                continue
+
+            entry = [src.attrs["path"]]
+            save_file = src.attrs.get("save_file")
+            if save_file:
+                entry.append(save_file[0])
+                entry.append(src)
+            removed.append(entry)
+
+        for ap in itertools.chain(pd.install_actions, pd.update_actions):
+            orig = ap.src
+            dest = ap.dst
+            if dest.name != "file":
+                continue
+
+            dpres_type = dest.attrs.get("preserve")
+            if not (
+                (
+                    orig
+                    and (
+                        "preserve" in orig.attrs
+                        or "save_file" in orig.attrs
+                        or "overlay" in orig.attrs
+                    )
+                )
+                or (
+                    dpres_type
+                    or "save_file" in dest.attrs
+                    or "overlay" in dest.attrs
+                )
+            ):
+                # At least one of the actions has to be a
+                # preserved file or a target of a restore.
+                continue
+            if "elfhash" in dest.attrs:
+                # Ignore erroneously tagged files.
+                continue
+
+            tpath = dest.attrs["path"]
+            entry = [tpath]
+            save_file = dest.attrs.get("save_file")
+            if save_file:
+                tcache_name = save_file[0]
+                for ridx, rentry in enumerate(removed):
+                    if len(rentry) == 1:
+                        continue
+
+                    rpath, rcache_name, rorig = rentry
+                    if rcache_name == tcache_name:
+                        # If the cache name for this new
+                        # file matches one of those for
+                        # a removed file, the removed
+                        # file will be renamed to this
+                        # action's path before the
+                        # action is processed.
+                        del removed[ridx]
+                        save_file = rpath
+                        orig = rorig
+                        break
+                else:
+                    save_file = None
+
+            if not orig and dpres_type == "install-only":
+                # For install-only, we can rely on
+                # _check_preserve.
+                try:
+                    if not dest._check_preserve(orig, ap.p):
+                        installed.append(entry)
+                except EnvironmentError as e:
+                    if e.errno != errno.EACCES:
+                        raise
+                continue
+            elif not orig:
+                # We can't rely on _check_preserve for this case
+                # as there's no existing on-disk file at the
+                # destination path yet.
+                if dpres_type != "legacy" and dpres_type != "abandon":
+                    # 'abandon' actions are never delivered;
+                    # 'legacy' actions are only delivered if
+                    # we're updating something already
+                    # installed or moving an existing file.
+                    installed.append(entry)
+                continue
+            elif orig.name != "file":
+                # File is being replaced with another object
+                # type.
+                updated.append(entry)
+                continue
+
+            # The order of these checks is significant in
+            # determining how a preserved file changed!
+            #
+            # First, check for on-disk content changes.
+            opath = orig.get_installed_path(self.image.get_root())
+            try:
+                pres_type = dest._check_preserve(orig, ap.p, orig_path=opath)
+            except EnvironmentError as e:
+                if e.errno == errno.EACCES:
+                    continue
+                else:
+                    raise
+
+            final_path = dest.get_installed_path(self.image.get_root())
+
+            # If a removed action is going to be restored to
+            # complete the operation, show the removed action path
+            # as the source for the move omitting the steps
+            # in-between.  For example:
+            #  moved: testme -> newme
+            #  moved: newme -> newme.legacy
+            #  installed: newme
+            # ...becomes:
+            #  moved: testme -> newme.legacy
+            #  installed: newme
+            if save_file:
+                mpath = save_file
+            else:
+                mpath = tpath
+
+            if pres_type == "abandon":
+                # newly-tagged preserve=abandon files never
+                # delivered.
+                continue
+            elif pres_type == "renameold":
+                moved.append([mpath, tpath + ".old"])
+                installed.append(entry)
+                continue
+            elif pres_type == "renameold.update":
+                moved.append([mpath, tpath + ".update"])
+                installed.append(entry)
+                continue
+            elif pres_type == "legacy":
+                if orig.attrs.get("preserve") == "legacy":
+                    updated.append(entry)
+                    continue
+                # Move only happens on preserve transition and
+                # only if original already exists.
+                if os.path.isfile(opath):
+                    moved.append([mpath, tpath + ".legacy"])
+                installed.append(entry)
+                continue
+            elif pres_type == True and save_file:
+                # If the source and destination path are the
+                # same, the content won't be updated.
+                if mpath != tpath:
+                    # New content ignored in favour of old.
+                    moved.append([mpath, tpath])
+                continue
+
+            # Next, if on-disk file will be preserved and some other
+            # unique_attr is changing (such as mode, etc.) mark the
+            # file as "updated".
+            if pres_type == True and ImagePlan.__find_inconsistent_attrs(
+                ((orig,), (dest,)), ignore=("path", "preserve")
+            ):
+                # For 'install-only', we can only update for
+                # inconsistent attributes if the file already
+                # exists.
+                if dpres_type != "install-only" or os.path.isfile(final_path):
+                    updated.append(entry)
+                continue
+
+            # For remaining cases, what happens is based on the
+            # result of _check_preserve().
+            if pres_type == "renamenew":
+                if save_file:
+                    moved.append([mpath, tpath])
+                # Delivered content changed.
+                installed.append([tpath + ".new"])
+            elif pres_type is None:
+                # Delivered content or unique_attrs changed.
+                updated.append(entry)
+            elif pres_type == False:
+                if save_file:
+                    moved.append([mpath, tpath])
+                    continue
+
+                if not os.path.isfile(final_path):
+                    # File is missing or of wrong type.
+                    installed.append(entry)
+                    continue
+
+                # If a file is moving between packages, it will
+                # appear as an update, but may not have not have
+                # different content or unique_attrs.  Check to
+                # see if it does.
+                if ImagePlan.__find_inconsistent_attrs(
+                    ((orig,), (dest,)), ignore=("path", "preserve")
+                ):
+                    # Different unique_attrs.
+                    updated.append(entry)
+                    continue
+
+                attr, shash, ohash, hfunc = digest.get_common_preferred_hash(
+                    dest, orig
+                )
+                if shash != ohash:
+                    # Delivered content changed.
+                    updated.append(entry)
+                    continue
+
+        # Pre-sort results for consumers.
+        installed.sort()
+        moved.sort()
+        removed.sort()
+        updated.sort()
+
+        self.pd._preserved = {
+            "installed": installed,
+            "moved": moved,
+            "removed": removed,
+            "updated": updated,
+        }
+
+    def __evaluate_pkg_downloads(self):
+        """Private helper function that determines package data to be
+        downloaded and updates the plan accordingly."""
+
+        assert self.state >= plandesc.MERGED_OK
+
+        pd = self.pd
+
+        for p in pd.pkg_plans:
+            cpbytes, pbytes = p.get_bytes_added()
+            if p.destination_fmri:
+                mpath = self.image.get_manifest_path(p.destination_fmri)
+                try:
+                    # Manifest data is essentially stored
+                    # three times (original, cache, catalog).
+                    # For now, include this in cbytes_added
+                    # since that's closest to where the
+                    # download cache is stored.
+                    pd._cbytes_added += os.stat(mpath).st_size * 3
+                except EnvironmentError as e:
+                    raise api_errors._convert_error(e)
+            pd._cbytes_added += cpbytes
+            pd._bytes_added += pbytes
+
+        # Include state directory in cbytes_added for now since it's
+        # closest to where the download cache is stored.  (Twice the
+        # amount is used because image state update involves using
+        # a complete copy of existing state.)
+        pd._cbytes_added += misc.get_dir_size(self.image._statedir) * 2
+
+        # Our slop factor is 25%; overestimating is safer than under-
+        # estimating.  This attempts to approximate how much overhead
+        # the filesystem will impose on the operation.  Empirical
+        # testing suggests that overhead can vary wildly depending on
+        # average file size, fragmentation, zfs metadata overhead, etc.
+        # For an install of a package such as solaris-small-server into
+        # an image, a 12% difference between actual size and installed
+        # size was found, so this seems safe enough.  (And helps account
+        # for any bootarchives, fs overhead, etc.)
+        pd._cbytes_added *= 1.25
+        pd._bytes_added *= 1.25
+
+        # XXX For now, include cbytes_added in bytes_added total; in the
+        # future, this should only happen if they share the same
+        # filesystem.
+        pd._bytes_added += pd._cbytes_added
+        self.__update_avail_space()
+
+        # Verify that there is enough space for the change.
+        if self.pd._bytes_added > self.pd._bytes_avail:
+            # During a dry run log a warning and continue to run the
+            # solver to produce any further warnings/errors.
+            if self.__noexecute:
+                msg = api_errors.ImageInsufficentSpace(
+                    self.pd._bytes_added,
+                    self.pd._bytes_avail,
+                    _("Root filesystem"),
+                )
+                timestamp = misc.time_to_timestamp(time.time())
+                self.pd.add_item_message(
+                    "warning", timestamp, MSG_WARNING, _(msg)
+                )
+            else:
+                raise api_errors.ImageInsufficentSpace(
+                    self.pd._bytes_added,
+                    self.pd._bytes_avail,
+                    _("Root filesystem"),
+                )
+
+    def evaluate(self):
+        """Given already determined fmri changes,
+        build pkg plans and figure out exact impact of
+        proposed changes"""
+
+        assert self.pd.state == plandesc.EVALUATED_PKGS, self
+
+        if self.pd._image_lm != self.image.get_last_modified(string=True):
+            # State has been modified since plan was created; this
+            # plan is no longer valid.
+            raise api_errors.InvalidPlanError()
+
+        self.__evaluate_pkg_plans()
+        self.__merge_actions()
+        self.__compile_release_notes()
+
+        if not self.pd._li_pkg_updates and self.pd.pkg_plans:
+            # oops.  the caller requested no package updates and
+            # we couldn't satisfy that request.
+            fmri_updates = [
+                (p.origin_fmri, p.destination_fmri) for p in self.pd.pkg_plans
+            ]
+            raise api_errors.PlanCreationException(
+                pkg_updates_required=fmri_updates
+            )
+
+        # Check for files which have been elided due to image
+        # exclusions, and honour the image's exclusion policy.
+        ix_policy = self.image.get_property(imageconfig.EXCLUDE_POLICY)
+        if self.pd.elided_actions and ix_policy != "ignore":
+            elided = []
+            for o, n in self.pd.get_elided_actions():
+                if o is None:
+                    elided.extend(n.attrlist("path"))
+            if ix_policy == "warn":
+                timestamp = misc.time_to_timestamp(time.time())
+                self.pd.add_item_message(
+                    "warning",
+                    timestamp,
+                    MSG_WARNING,
+                    self.__make_excl_msg(elided),
+                )
+            elif ix_policy == "reject":
+                raise api_errors.PlanExclusionError(paths=elided)
+
+        # These must be done after action merging.
+        self.__evaluate_pkg_preserved_files()
+        self.__evaluate_pkg_downloads()
+        # If there are invalid mediators then message about it
+        # for the no execute (-n) or zones case. If an update
+        # in the global zone an exception will be raised later.
+        if self.invalid_meds:
+            if self.__noexecute or self.image.is_zone():
+                medmsg = self.__make_med_msg()
+                timestamp = misc.time_to_timestamp(time.time())
+                self.pd.add_item_message(
+                    "warning", timestamp, MSG_WARNING, medmsg
+                )
+
+    def __update_avail_space(self):
+        """Update amount of available space on FS"""
+
+        self.pd._cbytes_avail = misc.spaceavail(self.image.write_cache_path)
+
+        self.pd._bytes_avail = misc.spaceavail(self.image.root)
+        # if we don't have a full image yet
+        if self.pd._cbytes_avail < 0:
+            self.pd._cbytes_avail = self.pd._bytes_avail
+
+    def __include_note(self, installed_dict, act, containing_fmri):
+        """Decide if a release note should be shown/included.  If
+        feature/pkg/self is fmri, fmri is containing package;
+        if version is then 0, this is note is displayed on initial
+        install only.  Otherwise, if version earlier than specified
+        fmri is present in code, display release note."""
+
+        for fmristr in act.attrlist("release-note"):
+            try:
+                pfmri = pkg.fmri.PkgFmri(fmristr)
+            except pkg.fmri.FmriError:
+                continue  # skip malformed fmris
+            # any special handling here?
+            if pfmri.pkg_name == "feature/pkg/self":
+                if (
+                    str(pfmri.version) == "0,5.11"
+                    and containing_fmri.pkg_name not in installed_dict
+                ):
+                    return True
+                else:
+                    pfmri.pkg_name = containing_fmri.pkg_name
+            if pfmri.pkg_name not in installed_dict:
+                continue
+            installed_fmri = installed_dict[pfmri.pkg_name]
+            # if neither is successor they are equal
+            if pfmri.is_successor(installed_fmri):
+                return True
+        return False
+
+    def __get_note_text(self, act, pfmri):
+        """Retrieve text for release note from repo
+
+        If there are UTF-8 encoding errors in the text replace them
+        so that we still have a note to show rather than failing
+        the entire operation.  The copy saved on disk is left as is."""
+        try:
+            pub = self.image.get_publisher(pfmri.publisher)
+            hash_attr, hash_val, hash_func = digest.get_least_preferred_hash(
+                act
+            )
+            return self.image.transport.get_content(
+                pub, hash_val, fmri=pfmri, hash_func=hash_func, errors="replace"
+            )
+        finally:
+            self.image.cleanup_downloads()
+
+    def __compile_release_notes(self):
+        """Figure out what release notes need to be displayed"""
+        release_notes = self.pd._actuators.get_release_note_info()
+        must_display = False
+        notes = []
+
+        if release_notes:
+            installed_dict = ImagePlan.__fmris2dict(
+                self.image.gen_installed_pkgs()
+            )
+            for act, pfmri in release_notes:
+                if self.__include_note(installed_dict, act, pfmri):
+                    if act.attrs.get("must-display", "false") == "true":
+                        must_display = True
+                    for l in self.__get_note_text(act, pfmri).splitlines():
+                        notes.append(misc.decode(l))
+
+            self.pd.release_notes = (must_display, notes)
+
+    def __save_release_notes(self):
+        """Save a copy of the release notes and store the file name"""
+        if self.pd.release_notes[1]:
+            # create a file in imgdir/notes
+            dpath = os.path.join(self.image.imgdir, "notes")
+            misc.makedirs(dpath)
+            fd, path = tempfile.mkstemp(
+                suffix=".txt", dir=dpath, prefix="release-notes-"
+            )
+            tmpfile = os.fdopen(fd, "w")
+            for note in self.pd.release_notes[1]:
+                note = misc.force_str(note)
+                print(note, file=tmpfile)
+            # make file world readable
+            os.chmod(path, 0o644)
+            tmpfile.close()
+            self.pd.release_notes_name = os.path.basename(path)
+
+    def __evaluate_pkg_plans(self):
+        """Internal helper function that does the work of converting
+        fmri changes into pkg plans."""
+
+        pt = self.__progtrack
+        # prefetch manifests
+        prefetch_mfsts = []  # manifest, intents to be prefetched
+        eval_list = []  # oldfmri, oldintent, newfmri, newintent
+        # prefetched intents omitted
+        enabled_publishers = set(
+            [a.prefix for a in self.image.gen_publishers()]
+        )
+
+        #
+        # XXX this could be improved, or perhaps the "do we have it?"
+        # logic could be moved into prefetch_manifests, and
+        # PLAN_FIND_MFST could go away?  This can be slow.
+        #
+        pt.plan_start(pt.PLAN_FIND_MFST)
+        for oldfmri, newfmri in self.pd._fmri_changes:
+            pt.plan_add_progress(pt.PLAN_FIND_MFST)
+            old_in, new_in = self.__create_intent(
+                oldfmri, newfmri, enabled_publishers
+            )
+            if oldfmri:
+                if not self.image.has_manifest(oldfmri):
+                    prefetch_mfsts.append((oldfmri, old_in))
+                    old_in = None  # so we don't send it twice
+            if newfmri:
+                if not self.image.has_manifest(newfmri):
+                    prefetch_mfsts.append((newfmri, new_in))
+                    new_in = None
+            eval_list.append((oldfmri, old_in, newfmri, new_in))
+            old_in = new_in = None
+        pt.plan_done(pt.PLAN_FIND_MFST)
+
+        # No longer needed.
+        del enabled_publishers
+        self.__match_rm = {}
+        self.__match_update = {}
+
+        self.image.transport.prefetch_manifests(
+            prefetch_mfsts,
+            ccancel=self.__check_cancel,
+            progtrack=self.__progtrack,
+        )
+
+        # No longer needed.
+        del prefetch_mfsts
+
+        max_items = len(eval_list)
+        pt.plan_start(pt.PLAN_PKGPLAN, goal=max_items)
+        same_excludes = self.__old_excludes == self.__new_excludes
+
+        for oldfmri, old_in, newfmri, new_in in eval_list:
+            pp = pkgplan.PkgPlan(self.image)
+
+            if oldfmri == newfmri:
+                # When creating intent, we always prefer to send
+                # the new intent over old intent (see
+                # __create_intent), so it's not necessary to
+                # touch the old manifest in this situation.
+                m = self.__get_manifest(newfmri, new_in, ignore_excludes=True)
+                pp.propose(oldfmri, m, newfmri, m)
+                can_exclude = same_excludes
+            else:
+                pp.propose(
+                    oldfmri,
+                    self.__get_manifest(oldfmri, old_in),
+                    newfmri,
+                    self.__get_manifest(newfmri, new_in, ignore_excludes=True),
+                )
+                can_exclude = True
+
+            pp.evaluate(
+                self.__old_excludes,
+                self.__new_excludes,
+                can_exclude=can_exclude,
+            )
+
+            self.pd.pkg_plans.append(pp)
+            pt.plan_add_progress(pt.PLAN_PKGPLAN, nitems=1)
+            pp = None
+
+        # No longer needed.
+        del eval_list
+        pt.plan_done(pt.PLAN_PKGPLAN)
+
+    def __mediate_links(self, mediated_removed_paths):
+        """Mediate links in the plan--this requires first determining the
+        possible mediation for each mediator.  This is done solely based
+        on the metadata of the links that are still or will be installed.
+        Returns a dictionary of the proposed mediations."""
+
+        #
+        # If we're not changing mediators, and we're not changing
+        # variants or facets (which could affect mediators), and we're
+        # not changing any packages (which could affect mediators),
+        # then mediators can't be changing so there's nothing to do
+        # here.
+        #
+        if (
+            not self.pd._mediators_change
+            and not self.pd._varcets_change
+            and not self.pd._fmri_changes
+        ):
+            # return the currently configured mediators
+            return defaultdict(set, self.pd._cfg_mediators)
+
+        prop_mediators = defaultdict(set)
+        mediated_installed_paths = defaultdict(set)
+        for a, pfmri in itertools.chain(
+            self.gen_new_installed_actions_bytype("link"),
+            self.gen_new_installed_actions_bytype("hardlink"),
+        ):
+            mediator = a.attrs.get("mediator")
+            if not mediator:
+                # Link is not mediated.
+                continue
+            med_ver = a.attrs.get("mediator-version")
+            if med_ver:
+                med_ver = pkg.version.Version(med_ver)
+            med_impl = a.attrs.get("mediator-implementation")
+            if not (med_ver or med_impl):
+                # Link mediation is incomplete.
+                continue
+            med_priority = a.attrs.get("mediator-priority")
+            prop_mediators[mediator].add((med_priority, med_ver, med_impl))
+            mediated_installed_paths[a.attrs["path"]].add(
+                (a, pfmri, mediator, med_ver, med_impl)
+            )
+
+        # Now select only the "best" mediation for each mediator;
+        # items() is used here as the dictionary is altered during
+        # iteration.
+        cfg_mediators = self.pd._cfg_mediators
+        changed_mediators = set()
+        for mediator, values in prop_mediators.items():
+            med_ver_source = (
+                med_impl_source
+            ) = med_priority = med_ver = med_impl = med_impl_ver = None
+
+            mediation = self.pd._new_mediators.get(mediator)
+            cfg_mediation = cfg_mediators.get(mediator)
+            if mediation:
+                med_ver = mediation.get("version")
+                med_ver_source = mediation.get("version-source")
+                med_impl = mediation.get("implementation")
+                med_impl_source = mediation.get("implementation-source")
+            elif mediation is None and cfg_mediation:
+                # If a reset of mediation was not requested,
+                # use previously configured mediation as the
+                # default.
+                med_ver = cfg_mediation.get("version")
+                med_ver_source = cfg_mediation.get("version-source")
+                med_impl = cfg_mediation.get("implementation")
+                med_impl_source = cfg_mediation.get("implementation-source")
+
+            # Pick first "optimal" version and/or implementation.
+            for opt_priority, opt_ver, opt_impl in sorted(
+                values, key=cmp_to_key(med.cmp_mediations)
+            ):
+                if med_ver_source == "local":
+                    if opt_ver != med_ver:
+                        # This mediation not allowed
+                        # by local configuration.
+                        continue
+                if med_impl_source == "local":
+                    if not mediator_impl_matches(opt_impl, med_impl):
+                        # This mediation not allowed
+                        # by local configuration.
+                        continue
+
+                med_source = opt_priority
+                if not med_source:
+                    # 'source' is equivalent to priority,
+                    # but if no priority was specified,
+                    # treat this as 'system' to indicate
+                    # the mediation component was arbitrarily
+                    # selected.
+                    med_source = "system"
+
+                if med_ver_source != "local":
+                    med_ver = opt_ver
+                    med_ver_source = med_source
+                if med_impl_source != "local":
+                    med_impl = opt_impl
+                    med_impl_source = med_source
+                elif med_impl and "@" not in med_impl:
+                    # In the event a versionless
+                    # implementation is set by the
+                    # administrator, the version component
+                    # has to be stored separately for display
+                    # purposes.
+                    impl_ver = med.parse_mediator_implementation(opt_impl)[1]
+                    if impl_ver:
+                        med_impl_ver = impl_ver
+                break
+
+            if cfg_mediation and (
+                med_ver != cfg_mediation.get("version")
+                or not mediator_impl_matches(
+                    med_impl, cfg_mediation.get("implementation")
+                )
+            ):
+                # If mediation has changed for a mediator, then
+                # all links for already installed packages will
+                # have to be removed if they are for the old
+                # mediation or repaired (installed) if they are
+                # for the new mediation.
+                changed_mediators.add(mediator)
+
+            prop_mediators[mediator] = {}
+            if med_ver:
+                prop_mediators[mediator]["version"] = med_ver
+            if med_ver_source:
+                prop_mediators[mediator]["version-source"] = med_ver_source
+            if med_impl:
+                prop_mediators[mediator]["implementation"] = med_impl
+            if med_impl_ver:
+                prop_mediators[mediator][
+                    "implementation-version"
+                ] = med_impl_ver
+            if med_impl_source:
+                prop_mediators[mediator][
+                    "implementation-source"
+                ] = med_impl_source
+
+        # Determine which install and update actions should not be
+        # executed based on configured and proposed mediations.  Also
+        # transform any install or update actions belonging to a
+        # changing mediation into removals.
+
+        # This keeps track of which pkgplans need to be trimmed.
+        act_removals = {}
+
+        # This keeps track of which mediated paths are being delivered
+        # and which need removal.
+        act_mediated_paths = {"installed": {}, "removed": {}}
+
+        for al, ptype in (
+            (self.pd.install_actions, "added"),
+            (self.pd.update_actions, "changed"),
+        ):
+            for i, ap in enumerate(al):
+                if not ap or not (
+                    ap.dst.name == "link" or ap.dst.name == "hardlink"
+                ):
+                    continue
+
+                mediator = ap.dst.attrs.get("mediator")
+                if not mediator:
+                    # Link is not mediated.
+                    continue
+
+                med_ver = ap.dst.attrs.get("mediator-version")
+                if med_ver:
+                    med_ver = pkg.version.Version(med_ver)
+                med_impl = ap.dst.attrs.get("mediator-implementation")
+
+                prop_med_ver = prop_mediators[mediator].get("version")
+                prop_med_impl = prop_mediators[mediator].get("implementation")
+
+                if med_ver == prop_med_ver and mediator_impl_matches(
+                    med_impl, prop_med_impl
+                ):
+                    # Action should be delivered.
+                    act_mediated_paths["installed"][ap.dst.attrs["path"]] = None
+                    mediated_installed_paths.pop(ap.dst.attrs["path"], None)
+                    continue
+
+                # Ensure action is not delivered.
+                al[i] = None
+
+                act_removals.setdefault(
+                    id(ap.p), {"plan": ap.p, "added": [], "changed": []}
+                )
+                act_removals[id(ap.p)][ptype].append(id(ap.dst))
+
+                cfg_med_ver = cfg_mediators.get(mediator, misc.EmptyDict).get(
+                    "version"
+                )
+                cfg_med_impl = cfg_mediators.get(mediator, misc.EmptyDict).get(
+                    "implementation"
+                )
+
+                if (
+                    mediator in cfg_mediators
+                    and mediator in prop_mediators
+                    and (
+                        med_ver == cfg_med_ver
+                        and mediator_impl_matches(med_impl, cfg_med_impl)
+                    )
+                ):
+                    # Install / update actions should only be
+                    # transformed into removals if they match
+                    # the previous configuration and are not
+                    # allowed by the proposed mediation.
+                    act_mediated_paths["removed"].setdefault(
+                        ap.dst.attrs["path"], []
+                    ).append(ap)
+
+        # As an optimization, only remove rejected, mediated paths if
+        # another link is not being delivered to the same path.
+        for ap in (
+            ap
+            for path in act_mediated_paths["removed"]
+            for ap in act_mediated_paths["removed"][path]
+            if path not in act_mediated_paths["installed"]
+        ):
+            ap.p.actions.removed.append((ap.dst, None))
+            self.pd.removal_actions.append(_ActionPlan(ap.p, ap.dst, None))
+        act_mediated_paths = None
+
+        for a, pfmri, mediator, med_ver, med_impl in (
+            med_link
+            for entry in mediated_installed_paths.values()
+            for med_link in entry
+        ):
+            if mediator not in changed_mediators:
+                # Action doesn't need repairing.
+                continue
+
+            new_med_ver = prop_mediators[mediator].get("version")
+            new_med_impl = prop_mediators[mediator].get("implementation")
+
+            if med_ver == new_med_ver and mediator_impl_matches(
+                med_impl, new_med_impl
+            ):
+                # Action needs to be repaired (installed) since
+                # mediation now applies.
+                self.__propose_fixup(a, None, pfmri)
+                continue
+
+            if mediator not in cfg_mediators:
+                # Nothing to do.
+                continue
+
+            cfg_med_ver = cfg_mediators[mediator].get("version")
+            cfg_med_impl = cfg_mediators[mediator].get("implementation")
+            if (
+                a.attrs["path"] not in mediated_removed_paths
+                and med_ver == cfg_med_ver
+                and mediator_impl_matches(med_impl, cfg_med_impl)
+            ):
+                # Action needs to be removed since mediation no
+                # longer applies and is not already set for
+                # removal.
+                self.__propose_fixup(None, a, pfmri)
+
+        # Now trim pkgplans and elide empty entries from list of actions
+        # to execute.
+        for entry in act_removals.values():
+            p = entry["plan"]
+            for prop in ("added", "changed"):
+                trim = entry[prop]
+                # Can't modify the p.actions tuple directly, so
+                # modify the members in place.
+                pval = getattr(p.actions, prop)
+                pval[:] = [a for a in pval if id(a[1]) not in trim]
+
+        return prop_mediators
+
+    def __full_target_path(self, linkpath):
+        """Resolves a link target to a relative pathname
+        of the image being modified."""
+
+        rootpath = os.path.join(self.image.root, linkpath)
+        reallinkpath = os.path.normpath(rootpath)
+
+        targetname = os.path.realpath(reallinkpath)
+        # Should only trigger if there is something wrong with the
+        # associated package manifest.
+        assert targetname.startswith(self.image.root)
+        # Chop the image.root off as a relative path to match
+        # the package manifests is required.
+        res = targetname[len(self.image.root) :]
+        # Zones will have an extra '/' at the start of the pathname,
+        # so remove it.
+        if res.startswith("/"):
+            return res[1:]
+        return res
+
+    def __make_med_msg(self):
+        """Helper function to create the message string for poorly
+        configured mediators."""
+        fmt_str = "  {0:24} {1}\n"
+        res = _(
+            "The following mediated link targets do not exist, "
+            "please reset the links via pkg set-mediator:\n"
+        )
+        res = res + fmt_str.format(_("MEDIATOR"), _("REMOVED PATH(S)"))
+        for med in self.invalid_meds:
+            res = res + fmt_str.format(med, ", ".join(self.invalid_meds[med]))
+        return res
+
+    def __make_excl_msg(self, elided: list[str]) -> str:
+        """Helper function to create the message string for excluded
+        actions."""
+
+        return (
+            _(
+                """\
 *****************************************************************************
 WARNING: The following actions have not been installed as this is a partial
-image (there are configured exclusions):""") + \
-                        "\n\n    " + "\n    ".join(elided) + """
+image (there are configured exclusions):"""
+            )
+            + "\n\n    "
+            + "\n    ".join(elided)
+            + """
 *****************************************************************************
 """
+        )
 
+    def __is_target_removed(self, filepath):
+        """Check to see if the named filepath is being removed in
+        the plan."""
+        removed = self.pd.find_removal(filepath)
+        return removed
 
-        def __is_target_removed(self, filepath):
-                """ Check to see if the named filepath is being removed in
-                    the plan."""
-                removed = self.pd.find_removal(filepath)
-                return removed
+    def __finalize_mediation(self, prop_mediators, mediated_del_path_target):
+        """Merge requested and previously configured mediators that are
+        being set but don't affect the plan and update proposed image
+        configuration."""
 
-        def __finalize_mediation(self, prop_mediators, mediated_del_path_target):
-                """Merge requested and previously configured mediators that are
-                being set but don't affect the plan and update proposed image
-                configuration."""
+        cfg_mediators = self.pd._cfg_mediators
+        for m in self.pd._new_mediators:
+            prop_mediators.setdefault(m, self.pd._new_mediators[m])
+        for m in cfg_mediators:
+            mediation = cfg_mediators[m]
+            # Check to see if the proposed mediator has removed
+            # targets, if so then upon an update there will be
+            # invalid mediated links so add the target to the
+            # invalid list, otherwise it is okay so nothing to
+            # do.
+            if m in prop_mediators:
+                if m in mediated_del_path_target:
+                    for target in mediated_del_path_target[m]:
+                        if self.__is_target_removed(target):
+                            self.invalid_meds[m].add(target)
+                continue
 
-                cfg_mediators = self.pd._cfg_mediators
-                for m in self.pd._new_mediators:
-                        prop_mediators.setdefault(m, self.pd._new_mediators[m])
-                for m in cfg_mediators:
+            new_mediation = mediation.copy()
+            if mediation.get("version-source") != "local":
+                new_mediation.pop("version", None)
+                del new_mediation["version-source"]
+            if mediation.get("implementation-source") != "local":
+                new_mediation.pop("implementation", None)
+                new_mediation.pop("implementation-version", None)
+                del new_mediation["implementation-source"]
 
-                        mediation = cfg_mediators[m]
-                        # Check to see if the proposed mediator has removed
-                        # targets, if so then upon an update there will be
-                        # invalid mediated links so add the target to the
-                        # invalid list, otherwise it is okay so nothing to
-                        # do.
-                        if m in prop_mediators:
-                                if m in mediated_del_path_target:
-                                     for target in mediated_del_path_target[m]:
-                                         if self.__is_target_removed(target):
-                                               self.invalid_meds[m].add(target)
-                                continue
+            if new_mediation:
+                # Only preserve the portion of configured
+                # mediations provided by the image administrator.
+                prop_mediators[m] = new_mediation
 
-                        new_mediation = mediation.copy()
-                        if mediation.get("version-source") != "local":
-                                new_mediation.pop("version", None)
-                                del new_mediation["version-source"]
-                        if mediation.get("implementation-source") != "local":
-                                new_mediation.pop("implementation", None)
-                                new_mediation.pop("implementation-version", None)
-                                del new_mediation["implementation-source"]
+        for m, new_mediation in six.iteritems(prop_mediators):
+            # If after processing all mediation data, a source wasn't
+            # marked for a particular component, mark it as being
+            # sourced from 'system'.
+            if (
+                "implementation-source" in new_mediation
+                and "version-source" not in new_mediation
+            ):
+                new_mediation["version-source"] = "system"
+            elif (
+                "version-source" in new_mediation
+                and "implementation-source" not in new_mediation
+            ):
+                new_mediation["implementation-source"] = "system"
 
-                        if new_mediation:
-                                # Only preserve the portion of configured
-                                # mediations provided by the image administrator.
-                                prop_mediators[m] = new_mediation
+        # The proposed mediators become the new mediators (this accounts
+        # for mediation selection done as part of a packaging operation
+        # instead of being explicitly requested).
 
-                for m, new_mediation in six.iteritems(prop_mediators):
-                        # If after processing all mediation data, a source wasn't
-                        # marked for a particular component, mark it as being
-                        # sourced from 'system'.
-                        if "implementation-source" in new_mediation and \
-                            "version-source" not in new_mediation:
-                                new_mediation["version-source"] = "system"
-                        elif "version-source" in new_mediation and \
-                            "implementation-source" not in new_mediation:
-                                new_mediation["implementation-source"] = "system"
+        # Initially assume mediation is changing.
+        self.pd._mediators_change = True
 
-                # The proposed mediators become the new mediators (this accounts
-                # for mediation selection done as part of a packaging operation
-                # instead of being explicitly requested).
+        for m in list(prop_mediators.keys()):
+            if m not in cfg_mediators:
+                if prop_mediators[m]:
+                    # Fully-defined mediation not in previous
+                    # configuration; mediation has changed.
+                    break
 
-                # Initially assume mediation is changing.
-                self.pd._mediators_change = True
+                # No change in mediation; elide it.
+                del prop_mediators[m]
+                continue
 
-                for m in list(prop_mediators.keys()):
-                        if m not in cfg_mediators:
-                                if prop_mediators[m]:
-                                        # Fully-defined mediation not in previous
-                                        # configuration; mediation has changed.
-                                        break
+            mediation = cfg_mediators[m]
+            if any(
+                k
+                for k in set(
+                    list(prop_mediators[m].keys()) + list(mediation.keys())
+                )
+                if prop_mediators[m].get(k) != mediation.get(k)
+            ):
+                # Mediation has changed.
+                break
+        else:
+            for m in cfg_mediators:
+                if m not in prop_mediators:
+                    # Mediation has been removed from
+                    # configuration.
+                    break
+            else:
+                self.pd._mediators_change = False
 
-                                # No change in mediation; elide it.
-                                del prop_mediators[m]
-                                continue
+        self.pd._new_mediators = prop_mediators
+        # Link mediation is complete.
 
-                        mediation = cfg_mediators[m]
-                        if any(
-                            k
-                            for k in set(list(prop_mediators[m].keys()) +
-                                list(mediation.keys()))
-                            if prop_mediators[m].get(k) != mediation.get(k)):
-                                # Mediation has changed.
-                                break
-                else:
-                        for m in cfg_mediators:
-                                if m not in prop_mediators:
-                                        # Mediation has been removed from
-                                        # configuration.
-                                        break
-                        else:
-                                self.pd._mediators_change = False
+    def __check_reserved(self, action):
+        """Check whether files are delivered to var/pkg or
+        .org.opensolaris.pkg"""
 
-                self.pd._new_mediators = prop_mediators
-                # Link mediation is complete.
+        if not "path" in action.attrs:
+            return True
 
-        def __check_reserved(self, action):
-                """Check whether files are delivered to var/pkg or
-                .org.opensolaris.pkg"""
+        dirs = [
+            "cache",
+            "gui_cache",
+            "history",
+            "license",
+            "linked",
+            "lost+found",
+            "publisher",
+            "ssl",
+            "state",
+        ]
 
-                if not "path" in action.attrs:
-                        return True
+        # Also check whether files are delivered to other
+        # reserved directories besides var/pkg
+        if portable.osname == "sunos":
+            reserved_dirs = ["var/tmp", "var/share", "tmp", "system/volatile"]
+        else:
+            reserved_dirs = []
 
-                dirs = ["cache", "gui_cache", "history", "license",
-                    "linked", "lost+found", "publisher", "ssl", "state"
-                ]
+        files = ["pkg5.image", "lock"]
+        path = action.get_installed_path(self.image.root)
+        dir_path = path + "/"
 
-                # Also check whether files are delivered to other
-                # reserved directories besides var/pkg
-                if portable.osname == "sunos":
-                        reserved_dirs = ["var/tmp", "var/share", "tmp", "system/volatile"]
-                else:
-                        reserved_dirs = []
+        for d in dirs:
+            dir_p = os.path.join(self.image.imgdir, d) + "/"
+            if dir_path.startswith(dir_p):
+                return False
 
-                files = ["pkg5.image", "lock"]
-                path = action.get_installed_path(self.image.root)
-                dir_path = path + "/"
+        for d in reserved_dirs:
+            dir_p = os.path.join(self.image.root, d) + "/"
+            # can package these directories but not deliver anything to them
+            if dir_path.startswith(dir_p) and dir_path != dir_p:
+                return False
 
-                for d in dirs:
-                        dir_p = os.path.join(self.image.imgdir, d) + "/"
-                        if dir_path.startswith(dir_p):
-                                return False
+        for f in files:
+            fname = os.path.join(self.image.imgdir, f)
+            if path == fname:
+                return False
+        return True
 
-                for d in reserved_dirs:
-                        dir_p = os.path.join(self.image.root, d) + "/"
-                        # can package these directories but not deliver anything to them
-                        if dir_path.startswith(dir_p) and dir_path != dir_p:
-                                return False
-
-                for f in files:
-                        fname = os.path.join(self.image.imgdir, f)
-                        if path == fname:
-                                return False
-                return True
-
-        def __check_excluded(self, path):
-                if self.__exclude_re is None:
-                        img_exclude = self.image.get_property(
-                            imageconfig.EXCLUDE_PATTERNS)
-                        if len(img_exclude):
-                                exclude_regex = "^(?:" + (
-                                    "|".join(img_exclude)) + ")"
-                                if DebugValues["exclude"]:
-                                        print("Exclude Regex:", exclude_regex)
-                                self.__exclude_re = relib.compile(exclude_regex)
-                        else:
-                                self.__exclude_re = ''
-
-                if self.__exclude_re == '': return False
-                if (self.image.root != '/' and
-                    path.startswith(self.image.root[1:])):
-                        path = path[len(self.image.root):]
+    def __check_excluded(self, path):
+        if self.__exclude_re is None:
+            img_exclude = self.image.get_property(imageconfig.EXCLUDE_PATTERNS)
+            if len(img_exclude):
+                exclude_regex = "^(?:" + ("|".join(img_exclude)) + ")"
                 if DebugValues["exclude"]:
-                        print("Checking exclude:", path)
-                return self.__exclude_re.search(path)
+                    print("Exclude Regex:", exclude_regex)
+                self.__exclude_re = relib.compile(exclude_regex)
+            else:
+                self.__exclude_re = ""
 
-        def __merge_actions(self):
-                """Given a set of fmri changes and their associated pkg plan,
-                merge all the resultant actions for the packages being
-                updated."""
+        if self.__exclude_re == "":
+            return False
+        if self.image.root != "/" and path.startswith(self.image.root[1:]):
+            path = path[len(self.image.root) :]
+        if DebugValues["exclude"]:
+            print("Checking exclude:", path)
+        return self.__exclude_re.search(path)
 
-                pt = self.__progtrack
-                if self.pd._new_mediators is None:
-                        self.pd._new_mediators = {}
+    def __merge_actions(self):
+        """Given a set of fmri changes and their associated pkg plan,
+        merge all the resultant actions for the packages being
+        updated."""
 
-                if self.image.has_boot_archive():
-                        ramdisk_prefixes = tuple(
-                            self.image.get_ramdisk_filelist())
-                        if not ramdisk_prefixes:
-                                self.pd._need_boot_archive = False
+        pt = self.__progtrack
+        if self.pd._new_mediators is None:
+            self.pd._new_mediators = {}
+
+        if self.image.has_boot_archive():
+            ramdisk_prefixes = tuple(self.image.get_ramdisk_filelist())
+            if not ramdisk_prefixes:
+                self.pd._need_boot_archive = False
+        else:
+            self.pd._need_boot_archive = False
+
+        # now combine all actions together to create a synthetic
+        # single step upgrade operation, and handle editable
+        # files moving from package to package.  See theory
+        # comment in execute, below.
+
+        for pp in self.pd.pkg_plans:
+            if pp.origin_fmri and pp.destination_fmri:
+                self.__target_update_count += 1
+            elif pp.destination_fmri:
+                self.__target_install_count += 1
+            elif pp.origin_fmri:
+                self.__target_removal_count += 1
+
+        # we now have a workable set of pkgplans to add/upgrade/remove
+        # now combine all actions together to create a synthetic single
+        # step upgrade operation, and handle editable files moving from
+        # package to package.  See theory comment in execute, below.
+        self.pd.removal_actions = []
+
+        pt.plan_start(pt.PLAN_ACTION_MERGE)
+        # cache the current image mediators within the plan
+        cfg_mediators = self.pd._cfg_mediators = self.image.cfg.mediators
+
+        mediated_removed_paths = set()
+        mediated_del_path_target = defaultdict(set)
+        for p in self.pd.pkg_plans:
+            pt.plan_add_progress(pt.PLAN_ACTION_MERGE)
+            for src, dest in p.gen_removal_actions():
+                if DebugValues["actions"]:
+                    print("Removal: " + str(src))
+                if src.name == "user":
+                    self.pd.removed_users[src.attrs["username"]] = p.origin_fmri
+                elif src.name == "group":
+                    self.pd.removed_groups[
+                        src.attrs["groupname"]
+                    ] = p.origin_fmri
+
+                self.pd.removal_actions.append(_ActionPlan(p, src, dest))
+                if (
+                    not (src.name == "link" or src.name == "hardlink")
+                    or "mediator" not in src.attrs
+                ):
+                    continue
+
+                # Keep track of which mediated paths have been
+                # removed from the system so that which paths
+                # need to be repaired can be determined.
+                mediator = src.attrs["mediator"]
+                src_version = src.attrs.get("mediator-version")
+                src_impl = src.attrs.get("mediator-implementation")
+
+                mediation = cfg_mediators.get(mediator)
+                if not mediation:
+                    # Shouldn't happen, but if it does,
+                    # drive on.
+                    continue
+
+                cfg_version = mediation.get("version")
+                if cfg_version:
+                    # For comparison, version must be a
+                    # string.
+                    cfg_version = cfg_version.get_short_version()
+
+                cfg_version_source = mediation.get("version-source")
+                cfg_impl = mediation.get("implementation")
+                cfg_impl_source = mediation.get("implementation-source")
+
+                if src_version == cfg_version and mediator_impl_matches(
+                    src_impl, cfg_impl
+                ):
+                    mediated_removed_paths.add(src.attrs["path"])
+                    # Need the target to be a full path
+                    # so it can be found in the plan.
+                    if (
+                        cfg_version_source == "local"
+                        or cfg_impl_source == "local"
+                    ):
+                        binpath = src.attrs["path"]
+                        target = self.__full_target_path(binpath)
+                        mediated_del_path_target[mediator].add(target)
+
+        self.pd.update_actions = []
+        self.pd._rm_aliases = {}
+        for p in self.pd.pkg_plans:
+            pt.plan_add_progress(pt.PLAN_ACTION_MERGE)
+            for src, dest in p.gen_update_actions():
+                if DebugValues["actions"]:
+                    print("Update:" + str(src))
+                    print("       " + str(dest))
+                if dest.name == "user":
+                    self.pd.added_users[
+                        dest.attrs["username"]
+                    ] = p.destination_fmri
+                elif dest.name == "group":
+                    self.pd.added_groups[
+                        dest.attrs["groupname"]
+                    ] = p.destination_fmri
+                elif dest.name == "driver" and src:
+                    rm = set(src.attrlist("alias")) - set(
+                        dest.attrlist("alias")
+                    )
+                    if rm:
+                        self.pd._rm_aliases.setdefault(
+                            dest.attrs["name"], set()
+                        ).update(rm)
+                self.pd.update_actions.append(_ActionPlan(p, src, dest))
+
+        self.pd.install_actions = []
+        errs = []
+        for p in self.pd.pkg_plans:
+            pfmri = None
+            if p.destination_fmri:
+                pfmri = p.destination_fmri.get_fmri()
+            err_actions = api_errors.ImageBoundaryError(pfmri)
+            pt.plan_add_progress(pt.PLAN_ACTION_MERGE)
+            for src, dest in p.gen_install_actions():
+                if DebugValues["actions"]:
+                    print("Install: " + str(dest))
+                if dest.name == "user":
+                    self.pd.added_users[
+                        dest.attrs["username"]
+                    ] = p.destination_fmri
+                elif dest.name == "group":
+                    self.pd.added_groups[
+                        dest.attrs["groupname"]
+                    ] = p.destination_fmri
+                # Check whether files are delivered in reserved
+                # locations.
+                if not self.__check_reserved(dest):
+                    err_actions.append_error(
+                        action=dest,
+                        err_type=api_errors.ImageBoundaryError.RESERVED,
+                    )
+                self.pd.install_actions.append(_ActionPlan(p, src, dest))
+            if not err_actions.isEmpty():
+                errs.append(err_actions)
+
+        if errs:
+            raise api_errors.ImageBoundaryErrors(errs)
+
+        # In case a removed user or group was added back...
+        for entry in self.pd.added_groups.keys():
+            if entry in self.pd.removed_groups:
+                del self.pd.removed_groups[entry]
+        for entry in self.pd.added_users.keys():
+            if entry in self.pd.removed_users:
+                del self.pd.removed_users[entry]
+
+        self.pd.state = plandesc.MERGED_OK
+        pt.plan_done(pt.PLAN_ACTION_MERGE)
+
+        if not self.nothingtodo():
+            self.__find_all_conflicts()
+
+        pt.plan_start(pt.PLAN_ACTION_CONSOLIDATE)
+        ConsolidationEntry = namedtuple("ConsolidationEntry", "idx id")
+
+        # cons_named maps original_name tags to the index into
+        # removal_actions so we can retrieve them later.  cons_generic
+        # maps the (action.name, action.key-attribute-value) tuple to
+        # the same thing.  The reason for both is that cons_named allows
+        # us to deal with files which change their path as well as their
+        # package, while cons_generic doesn't require the "receiving"
+        # package to have marked the file in any special way, plus
+        # obviously it handles all actions even if they don't have
+        # paths.
+        cons_named = {}
+        cons_generic = {}
+
+        def hashify(v):
+            """handle key values that may be lists"""
+            if isinstance(v, list):
+                return frozenset(v)
+            else:
+                return v
+
+        for i, ap in enumerate(self.pd.removal_actions):
+            if ap is None:
+                continue
+            pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
+
+            # If the action type needs to be reference-counted, make
+            # sure it doesn't get removed if another instance
+            # remains in the target image.
+            remove = True
+            if (
+                ap.src.name == "dir"
+                and os.path.normpath(ap.src.attrs["path"])
+                in self.__get_directories()
+            ):
+                remove = False
+            elif ap.src.name == "link" or ap.src.name == "hardlink":
+                lpath = os.path.normpath(ap.src.attrs["path"])
+                if ap.src.name == "link":
+                    inst_links = self.__get_symlinks()
                 else:
-                        self.pd._need_boot_archive = False
+                    inst_links = self.__get_hardlinks()
+                if self.__check_excluded(lpath):
+                    if DebugValues["exclude"]:
+                        print("!Removal:", lpath)
+                    self.pd.elided_actions.append(ap)
+                    remove = False
+                elif lpath in inst_links:
+                    # Another link delivers to the same
+                    # location, so assume it can't be
+                    # safely removed initially.
+                    remove = False
 
-                # now combine all actions together to create a synthetic
-                # single step upgrade operation, and handle editable
-                # files moving from package to package.  See theory
-                # comment in execute, below.
+                    # If link is mediated, and the mediator
+                    # doesn't match the new mediation
+                    # criteria, it is safe to remove.
+                    mediator = ap.src.attrs.get("mediator")
+                    if mediator in self.pd._new_mediators:
+                        src_version = ap.src.attrs.get("mediator-version")
+                        src_impl = ap.src.attrs.get("mediator-implementation")
+                        dest_version = self.pd._new_mediators[mediator].get(
+                            "version"
+                        )
+                        if dest_version:
+                            # Requested version needs
+                            # to be a string for
+                            # comparison.
+                            dest_version = dest_version.get_short_version()
+                        dest_impl = self.pd._new_mediators[mediator].get(
+                            "implementation"
+                        )
+                        if (
+                            dest_version is not None
+                            and src_version != dest_version
+                        ):
+                            remove = True
+                        if dest_impl is not None and not mediator_impl_matches(
+                            src_impl, dest_impl
+                        ):
+                            remove = True
 
-                for pp in self.pd.pkg_plans:
-                        if pp.origin_fmri and pp.destination_fmri:
-                                self.__target_update_count += 1
-                        elif pp.destination_fmri:
-                                self.__target_install_count += 1
-                        elif pp.origin_fmri:
-                                self.__target_removal_count += 1
+            elif (
+                ap.src.name == "license"
+                and ap.src.attrs["license"] in self.__get_licenses()
+            ):
+                remove = False
+            elif (
+                ap.src.name == "legacy"
+                and ap.src.attrs["pkg"] in self.__get_legacy()
+            ):
+                remove = False
+            elif "path" in ap.src.attrs and self.__check_excluded(
+                ap.src.attrs["path"]
+            ):
+                if DebugValues["exclude"]:
+                    print("!Remove", ap.src.attrs["path"])
+                self.pd.elided_actions.append(ap)
+                remove = False
 
-                # we now have a workable set of pkgplans to add/upgrade/remove
-                # now combine all actions together to create a synthetic single
-                # step upgrade operation, and handle editable files moving from
-                # package to package.  See theory comment in execute, below.
+            if not remove:
+                self.pd.removal_actions[i] = None
+                if "mediator" in ap.src.attrs:
+                    mediated_removed_paths.discard(ap.src.attrs["path"])
+                continue
+
+            # store names of files being removed under own name
+            # or original name if specified
+            if ap.src.globally_identical:
+                attrs = ap.src.attrs
+                # Store the index into removal_actions and the
+                # id of the action object in that slot.
+                re = ConsolidationEntry(i, id(ap.src))
+                cons_generic[
+                    (ap.src.name, hashify(attrs[ap.src.key_attr]))
+                ] = re
+                if ap.src.name == "file":
+                    fname = attrs.get(
+                        "original_name",
+                        "{0}:{1}".format(
+                            ap.p.origin_fmri.get_name(), attrs["path"]
+                        ),
+                    )
+                    cons_named[fname] = re
+                    fname = None
+                attrs = re = None
+
+            self.pd._actuators.scan_removal(ap)
+            if self.pd._need_boot_archive is None:
+                if self.pd._op != PKG_OP_DEHYDRATE and ap.src.attrs.get(
+                    "path", ""
+                ).startswith(ramdisk_prefixes):
+                    self.pd._need_boot_archive = True
+
+        # reduce memory consumption
+        self.__directories = None
+        self.__symlinks = None
+        self.__hardlinks = None
+        self.__licenses = None
+        self.__legacy = None
+
+        pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
+
+        # Construct a mapping from the install actions in a pkgplan to
+        # the position they have in the plan's list.  This allows us to
+        # remove them efficiently later, if they've been consolidated.
+        #
+        # NOTE: This means that the action ordering in the package plans
+        # must remain fixed, at least for the duration of the imageplan
+        # evaluation.
+        plan_pos = {}
+        for p in self.pd.pkg_plans:
+            for i, a in enumerate(p.gen_install_actions()):
+                plan_pos[id(a[1])] = i
+
+        # This keeps track of which pkgplans have had install actions
+        # consolidated away.
+        pp_needs_trimming = set()
+
+        # This maps destination actions to the pkgplans they're
+        # associated with, which allows us to create the newly
+        # discovered update _ActionPlans.
+        dest_pkgplans = {}
+
+        new_updates = []
+        for i, ap in enumerate(self.pd.install_actions):
+            if ap is None:
+                continue
+            pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
+
+            if "path" in ap.dst.attrs and self.__check_excluded(
+                ap.dst.attrs["path"]
+            ):
+                if DebugValues["exclude"]:
+                    print("!Install", ap.dst.attrs["path"])
+                self.pd.elided_actions.append(ap)
+                pp_needs_trimming.add(ap.p)
+                ap.p.actions.added[plan_pos[id(ap.dst)]] = None
+                self.pd.install_actions[i] = None
+
+            # In order to handle editable files that move their path
+            # or change pkgs, for all new files with original_name
+            # attribute, make sure file isn't being removed by
+            # checking removal list.  If it is, tag removal to save
+            # file, and install to recover cached version... caching
+            # is needed if directories are removed or don't exist
+            # yet.
+            if (
+                ap.dst.name == "file"
+                and "original_name" in ap.dst.attrs
+                and ap.dst.attrs["original_name"] in cons_named
+            ):
+                cache_name = ap.dst.attrs["original_name"]
+                index = cons_named[cache_name].idx
+                ra = self.pd.removal_actions[index].src
+                assert id(ra) == cons_named[cache_name].id
+                # If the paths match, don't remove and add;
+                # convert to update.
+                if ap.dst.attrs["path"] == ra.attrs["path"]:
+                    new_updates.append((ra, ap.dst))
+                    # If we delete items here, the indices
+                    # in cons_named will be bogus, so mark
+                    # them for later deletion.
+                    self.pd.removal_actions[index] = None
+                    self.pd.install_actions[i] = None
+                    # No need to handle it in cons_generic
+                    # anymore
+                    del cons_generic[("file", ra.attrs["path"])]
+                    dest_pkgplans[id(ap.dst)] = ap.p
+                else:
+                    # The 'true' indicates the file should
+                    # be removed from source.  The removal
+                    # action is changed using setdefault so
+                    # that any overlay rules applied during
+                    # conflict checking remain intact.
+                    ra.attrs.setdefault("save_file", [cache_name, "true"])
+                    ap.dst.attrs["save_file"] = [cache_name, "true"]
+
+                cache_name = index = ra = None
+
+            # Similarly, try to prevent files (and other actions)
+            # from unnecessarily being deleted and re-created if
+            # they're simply moving between packages, but only if
+            # they keep their paths (or key-attribute values).
+            keyval = hashify(ap.dst.attrs.get(ap.dst.key_attr, None))
+            if (ap.dst.name, keyval) in cons_generic:
+                nkv = ap.dst.name, keyval
+                index = cons_generic[nkv].idx
+                ra = self.pd.removal_actions[index].src
+                assert id(ra) == cons_generic[nkv].id
+                if keyval == ra.attrs[ra.key_attr]:
+                    new_updates.append((ra, ap.dst))
+                    self.pd.removal_actions[index] = None
+                    self.pd.install_actions[i] = None
+                    dest_pkgplans[id(ap.dst)] = ap.p
+                    # Add the action to the pkgplan's update
+                    # list and mark it for removal from the
+                    # install list.
+                    ap.p.actions.changed.append((ra, ap.dst))
+                    ap.p.actions.added[plan_pos[id(ap.dst)]] = None
+                    pp_needs_trimming.add(ap.p)
+                nkv = index = ra = None
+
+            self.pd._actuators.scan_install(ap)
+            if self.pd._need_boot_archive is None:
+                if ap.dst.attrs.get("path", "").startswith(ramdisk_prefixes):
+                    self.pd._need_boot_archive = True
+
+        del ConsolidationEntry, cons_generic, cons_named, plan_pos
+
+        # Remove from the pkgplans the install actions which have been
+        # consolidated away.
+        for p in pp_needs_trimming:
+            # Can't modify the p.actions tuple, so modify the added
+            # member in-place.
+            p.actions.added[:] = [a for a in p.actions.added if a is not None]
+        del pp_needs_trimming
+
+        pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
+
+        # We want to cull out actions where they've not changed at all,
+        # leaving only the changed ones to put into
+        # self.pd.update_actions.
+        nu_src = manifest.Manifest()
+        nu_src.set_content(
+            content=(a[0] for a in new_updates), excludes=self.__old_excludes
+        )
+        nu_dst = manifest.Manifest()
+        pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
+        nu_dst.set_content(
+            content=(a[1] for a in new_updates), excludes=self.__new_excludes
+        )
+        del new_updates
+        pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
+        nu_add, nu_chg, nu_rem = nu_dst.difference(
+            nu_src, self.__old_excludes, self.__new_excludes
+        )
+        pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
+        # All the differences should be updates
+        assert not nu_add
+        assert not nu_rem
+        del nu_src, nu_dst
+
+        # Extend update_actions with the new tuples.  The package plan
+        # is the one associated with the action getting installed.
+        self.pd.update_actions.extend(
+            [
+                _ActionPlan(dest_pkgplans[id(dst)], src, dst)
+                for src, dst in nu_chg
+            ]
+        )
+
+        del dest_pkgplans, nu_chg
+
+        # Cull any update actions that are excluded by the exclusion
+        # patterns configured in the image.
+        for i, ap in enumerate(self.pd.update_actions):
+            if ap is None:
+                continue
+            path = None
+            if (
+                ap.src
+                and "path" in ap.src.attrs
+                and self.__check_excluded(ap.src.attrs["path"])
+            ):
+                path = ap.src.attrs["path"]
+            elif (
+                ap.dst
+                and "path" in ap.dst.attrs
+                and self.__check_excluded(ap.dst.attrs["path"])
+            ):
+                path = ap.dst.attrs["path"]
+
+            if path:
+                if DebugValues["exclude"]:
+                    print("!Update", path)
+                self.pd.elided_actions.append(ap)
+                self.pd.update_actions[i] = None
+
+        pt.plan_done(pt.PLAN_ACTION_CONSOLIDATE)
+        pt.plan_start(pt.PLAN_ACTION_MEDIATION)
+        pt.plan_add_progress(pt.PLAN_ACTION_MEDIATION)
+
+        # Mediate and repair links affected by the plan.
+        prop_mediators = self.__mediate_links(mediated_removed_paths)
+
+        pt.plan_add_progress(pt.PLAN_ACTION_MEDIATION)
+        for prop in ("removal_actions", "install_actions", "update_actions"):
+            pval = getattr(self.pd, prop)
+            pval[:] = [a for a in pval if a is not None]
+
+        pt.plan_add_progress(pt.PLAN_ACTION_MEDIATION)
+
+        # Add any necessary repairs to plan.
+        self.__evaluate_fixups()
+
+        pt.plan_add_progress(pt.PLAN_ACTION_MEDIATION)
+
+        # Finalize link mediation.
+        self.__finalize_mediation(prop_mediators, mediated_del_path_target)
+
+        pt.plan_done(pt.PLAN_ACTION_MEDIATION)
+
+        if DebugValues["actions"]:
+            print("--- Final actions ---")
+            for prop in (
+                "removal_actions",
+                "install_actions",
+                "update_actions",
+            ):
+                key = prop.split("_")[0]
+                for a in getattr(self.pd, prop):
+                    print("{0} {1}".format(key, str(a)))
+
+        pt.plan_start(pt.PLAN_ACTION_FINALIZE)
+
+        # Go over update actions
+        l_refresh = []
+        l_actions = {}
+        if self.pd.update_actions:
+            # iterating over actions is slow, so don't do it
+            # unless we have to.
+            l_actions = self.get_actions("hardlink", self.hardlink_keyfunc)
+        for a in self.pd.update_actions:
+            # For any files being updated that are the target of
+            # _any_ hardlink actions, append the hardlink actions
+            # to the update list so that they are not broken.
+            # Since we reference count hardlinks, update each one
+            # only once.
+            if a[2].name == "file":
+                path = a[2].attrs["path"]
+                if path in l_actions:
+                    unique_links = dict(
+                        (l.attrs["path"], l) for l in l_actions[path]
+                    )
+                    l_refresh.extend(
+                        [_ActionPlan(a[0], l, l) for l in unique_links.values()]
+                    )
+                path = None
+
+            # scan both old and new actions
+            # repairs may result in update action w/o orig action
+            self.pd._actuators.scan_update(a)
+            if self.pd._need_boot_archive is None:
+                if a[2].attrs.get("path", "").startswith(ramdisk_prefixes):
+                    self.pd._need_boot_archive = True
+
+        self.pd.update_actions.extend(l_refresh)
+
+        # sort actions to match needed processing order
+        remsort = operator.itemgetter(1)
+        addsort = operator.itemgetter(2)
+        self.pd.removal_actions.sort(key=remsort, reverse=True)
+        self.pd.update_actions.sort(key=addsort)
+        self.pd.install_actions.sort(key=addsort)
+
+        # find the first and last hardlink in the install_actions
+        fhl = lhl = -1
+        for i, ap in enumerate(self.pd.install_actions):
+            if ap.dst.name == "hardlink":
+                if fhl == -1:
+                    fhl = i
+                lhl = i
+            elif fhl != -1:
+                break
+
+        # now reorder the hardlinks to respect inter-dependencies
+        if fhl != -1:
+            hardlinks = self.pd.install_actions[fhl : lhl + 1]
+            hardlinks = _reorder_hardlinks(hardlinks)
+            self.pd.install_actions[fhl : lhl + 1] = hardlinks
+
+        # cleanup pkg_plan objects which don't actually contain any
+        # changes and add any new ones to list of changes
+        for p in list(self.pd.pkg_plans):
+            if (
+                p.origin_fmri != p.destination_fmri
+                or p.actions.removed
+                or p.actions.changed
+                or p.actions.added
+            ):
+                pair = (p.origin_fmri, p.destination_fmri)
+                if pair not in self.pd._fmri_changes:
+                    self.pd._fmri_changes.append(pair)
+                continue
+            self.pd.pkg_plans.remove(p)
+            fmri = p.origin_fmri
+            if (fmri, fmri) in self.pd._fmri_changes:
+                self.pd._fmri_changes.remove((fmri, fmri))
+            del p
+
+        #
+        # Sort the package plans by fmri to create predictability (and
+        # some sense of order) in the download output; this is not
+        # a perfect sort of this, but we only really care for things
+        # we fetch over the wire.
+        #
+        def key_func(a):
+            if a.destination_fmri:
+                return a.destination_fmri
+            return ""
+
+        self.pd.pkg_plans.sort(key=key_func)
+
+        pt.plan_done(pt.PLAN_ACTION_FINALIZE)
+
+        if self.pd._need_boot_archive is None:
+            self.pd._need_boot_archive = False
+
+        self.pd.state = plandesc.EVALUATED_OK
+
+    def nothingtodo(self):
+        """Test whether this image plan contains any work to do"""
+
+        if self.pd.state in [plandesc.EVALUATED_PKGS, plandesc.MERGED_OK]:
+            return not (
+                self.pd._fmri_changes
+                or self.pd._new_variants
+                or (self.pd._new_facets is not None)
+                or self.pd._mediators_change
+                or self.pd.pkg_plans
+            )
+        elif self.pd.state >= plandesc.EVALUATED_OK:
+            return not (
+                self.pd.pkg_plans
+                or self.pd._new_variants
+                or (self.pd._new_facets is not None)
+                or self.pd._mediators_change
+            )
+        assert 0, "Shouldn't call nothingtodo() for state = {0:d}".format(
+            self.pd.state
+        )
+
+    def preexecute(self):
+        """Invoke the evaluated image plan
+        preexecute, execute and postexecute
+        execute actions need to be sorted across packages
+        """
+
+        assert self.pd.state == plandesc.EVALUATED_OK
+
+        if self.pd._image_lm != self.image.get_last_modified(string=True):
+            # State has been modified since plan was created; this
+            # plan is no longer valid.
+            self.pd.state = plandesc.PREEXECUTED_ERROR
+            raise api_errors.InvalidPlanError()
+
+        if self.nothingtodo():
+            self.pd.state = plandesc.PREEXECUTED_OK
+            return
+
+        if self.image.version != self.image.CURRENT_VERSION:
+            # Prevent plan execution if image format isn't current.
+            raise api_errors.ImageFormatUpdateNeeded(self.image.root)
+
+        if DebugValues["plandesc_validate"]:
+            # get a json copy of the plan description so that
+            # later we can verify that it wasn't updated during
+            # the pre-execution stage.
+            pd_json1 = self.pd.getstate(self.pd, reset_volatiles=True)
+
+        # Checks the index to make sure it exists and is
+        # consistent. If it's inconsistent an exception is thrown.
+        # If it's totally absent, it will index the existing packages
+        # so that the incremental update that follows at the end of
+        # the function will work correctly. It also repairs the index
+        # for this BE so the user can boot into this BE and have a
+        # correct index.
+        if self.update_index:
+            ind = None
+            try:
+                self.image.update_index_dir()
+                ind = indexer.Indexer(
+                    self.image,
+                    self.image.get_manifest,
+                    self.image.get_manifest_path,
+                    progtrack=self.__progtrack,
+                    excludes=self.__old_excludes,
+                )
+                if ind.check_index_existence():
+                    try:
+                        ind.check_index_has_exactly_fmris(
+                            self.image.gen_installed_pkg_names()
+                        )
+                    except se.IncorrectIndexFileHash as e:
+                        self.__preexecuted_indexing_error = (
+                            api_errors.WrapSuccessfulIndexingException(
+                                e,
+                                traceback.format_exc(),
+                                traceback.format_stack(),
+                            )
+                        )
+                        ind.rebuild_index_from_scratch(
+                            self.image.gen_installed_pkgs()
+                        )
+            except se.IndexingException as e:
+                # If there's a problem indexing, we want to
+                # attempt to finish the installation anyway. If
+                # there's a problem updating the index on the
+                # new image, that error needs to be
+                # communicated to the user.
+                self.__preexecuted_indexing_error = (
+                    api_errors.WrapSuccessfulIndexingException(
+                        e, traceback.format_exc(), traceback.format_stack()
+                    )
+                )
+
+            # No longer needed.
+            del ind
+
+        # check if we're going to have enough room
+        # stat fs again just in case someone else is using space...
+        self.__update_avail_space()
+        if self.pd._cbytes_added > self.pd._cbytes_avail:
+            raise api_errors.ImageInsufficentSpace(
+                self.pd._cbytes_added,
+                self.pd._cbytes_avail,
+                _("Download cache"),
+            )
+        if self.pd._bytes_added > self.pd._bytes_avail:
+            raise api_errors.ImageInsufficentSpace(
+                self.pd._bytes_added, self.pd._bytes_avail, _("Root filesystem")
+            )
+
+        # Remove history about manifest/catalog transactions.  This
+        # helps the stats engine by only considering the performance of
+        # bulk downloads.
+        self.image.transport.stats.reset()
+
+        #
+        # Calculate size of data retrieval and pass it to progress
+        # tracker.
+        #
+        npkgs = nfiles = nbytes = 0
+        for p in self.pd.pkg_plans:
+            nf, nb = p.get_xferstats()
+            nbytes += nb
+            nfiles += nf
+
+            # It's not perfectly accurate but we count a download
+            # even if the package will do zero data transfer.  This
+            # makes the pkg stats consistent between download and
+            # install.
+            npkgs += 1
+        self.__progtrack.download_set_goal(npkgs, nfiles, nbytes)
+
+        lic_errors = []
+        try:
+            # Check for license acceptance issues first to avoid
+            # wasted time in the download phase and so failure
+            # can occur early.
+            for p in self.pd.pkg_plans:
+                try:
+                    p.preexecute()
+                except api_errors.PkgLicenseErrors as e:
+                    # Accumulate all license errors.
+                    lic_errors.append(e)
+                except EnvironmentError as e:
+                    if e.errno == errno.EACCES:
+                        raise api_errors.PermissionsException(e.filename)
+                    if e.errno == errno.EROFS:
+                        raise api_errors.ReadOnlyFileSystemException(e.filename)
+                    raise
+
+            if lic_errors:
+                raise api_errors.PlanLicenseErrors(lic_errors)
+
+            try:
+                for p in self.pd.pkg_plans:
+                    p.download(self.__progtrack, self.__check_cancel)
+            except EnvironmentError as e:
+                if e.errno == errno.EACCES:
+                    raise api_errors.PermissionsException(e.filename)
+                if e.errno == errno.EROFS:
+                    raise api_errors.ReadOnlyFileSystemException(e.filename)
+                raise
+            except (
+                api_errors.InvalidDepotResponseException,
+                api_errors.TransportError,
+            ) as e:
+                if p and p._autofix_pkgs:
+                    e._autofix_pkgs = p._autofix_pkgs
+                raise
+
+            self.image.transport.shutdown()
+            self.__progtrack.download_done()
+        except:
+            self.pd.state = plandesc.PREEXECUTED_ERROR
+            raise
+
+        self.pd.state = plandesc.PREEXECUTED_OK
+
+        if DebugValues["plandesc_validate"]:
+            # verify that preexecution did not update the plan
+            pd_json2 = self.pd.getstate(self.pd, reset_volatiles=True)
+            pkg.misc.json_diff(
+                "PlanDescription", pd_json1, pd_json2, pd_json1, pd_json2
+            )
+            del pd_json1, pd_json2
+
+    def execute(self):
+        """Invoke the evaluated image plan
+        preexecute, execute and postexecute
+        execute actions need to be sorted across packages
+        """
+        assert self.pd.state == plandesc.PREEXECUTED_OK
+
+        if self.pd._image_lm != self.image.get_last_modified(string=True):
+            # State has been modified since plan was created; this
+            # plan is no longer valid.
+            self.pd.state = plandesc.EXECUTED_ERROR
+            raise api_errors.InvalidPlanError()
+
+        # load data from previously downloaded actions
+        try:
+            for p in self.pd.pkg_plans:
+                p.cacheload()
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(e.filename)
+            raise
+
+        # check for available space
+        self.__update_avail_space()
+        if (
+            self.pd._bytes_added - self.pd._cbytes_added
+        ) > self.pd._bytes_avail:
+            raise api_errors.ImageInsufficentSpace(
+                self.pd._bytes_added - self.pd._cbytes_added,
+                self.pd._bytes_avail,
+                _("Root filesystem"),
+            )
+
+        #
+        # what determines execution order?
+        #
+        # The following constraints are key in understanding imageplan
+        # execution:
+        #
+        # 1) All non-directory actions (files, users, hardlinks,
+        # symbolic links, etc.) must appear in only a single installed
+        # package.
+        #
+        # 2) All installed packages must be consistent in their view of
+        # action types; if /usr/openwin is a directory in one package,
+        # it must be a directory in all packages, never a symbolic link;
+        # this includes implicitly defined directories.
+        #
+        # A key goal in IPS is to be able to undergo an arbitrary
+        # transformation in package contents in a single step.  Packages
+        # must be able to exchange files, convert directories to
+        # symbolic links, etc.; so long as the start and end states meet
+        # the above two constraints IPS must be able to transition
+        # between the states directly.  This leads to the following:
+        #
+        # 1) All actions must be ordered across packages; packages
+        # cannot be updated one at a time.
+        #
+        #    This is readily apparent when one considers two packages
+        #    exchanging files in their new versions; in each case the
+        #    package now owning the file must be installed last, but it
+        #    is not possible for each package to be installed before the
+        #    other.  Clearly, all the removals must be done first,
+        #    followed by the installs and updates.
+        #
+        # 2) Installs of new actions must precede updates of existing
+        # ones.
+        #
+        #    In order to accommodate changes of file ownership of
+        #    existing files to a newly created user, it is necessary
+        #    for the installation of that user to precede the update of
+        #    files to reflect their new ownership.
+        #
+        #    The exception to this rule is driver actions.  Aliases of
+        #    existing drivers which are going to be removed must be
+        #    removed before any new drivers are installed or updated.
+        #    This prevents an error if an alias is moving from one
+        #    driver to another.
+
+        if self.nothingtodo():
+            self.pd.state = plandesc.EXECUTED_OK
+            return
+
+        pt = self.__progtrack
+        pt.set_major_phase(pt.PHASE_EXECUTE)
+
+        # It's necessary to do this check here because the state of the
+        # image before the current operation is performed is desired.
+        empty_image = self.__is_image_empty()
+
+        if not empty_image:
+            # Before proceeding, remove fast lookups database so
+            # that if _create_fast_lookups is interrupted later the
+            # client isn't left with invalid state.
+            self.image._remove_fast_lookups()
+
+        if not self.image.is_liveroot():
+            # Check if the child is a running zone. If so run the
+            # actuator in the zone.
+
+            # Linked Image code uses trailing slashes, Image code
+            # does not. So we make sure that our path comparisons
+            # are always on tha same page.
+            root = os.path.normpath(self.image.root)
+
+            rzones = zone.list_running_zones()
+            for z, path in six.iteritems(rzones):
+                if os.path.normpath(path) == root:
+                    self.pd._actuators.set_zone(z)
+                    # there should be only on zone per path
+                    break
+
+        self.pd._actuators.exec_prep(self.image)
+
+        self.pd._actuators.exec_pre_actuators(self.image)
+
+        # List of tuples of (src, dest) used to track each pkgplan so
+        # that it can be discarded after execution.
+        executed_pp = []
+        try:
+            try:
+                pt.actions_set_goal(
+                    pt.ACTION_REMOVE, len(self.pd.removal_actions)
+                )
+                pt.actions_set_goal(
+                    pt.ACTION_INSTALL, len(self.pd.install_actions)
+                )
+                pt.actions_set_goal(
+                    pt.ACTION_UPDATE, len(self.pd.update_actions)
+                )
+
+                # execute removals
+                for p, src, dest in self.pd.removal_actions:
+                    p.execute_removal(src, dest)
+                    pt.actions_add_progress(pt.ACTION_REMOVE)
+                pt.actions_done(pt.ACTION_REMOVE)
+
+                # Update driver alias database to reflect the
+                # aliases drivers have lost in the new image.
+                # This prevents two drivers from ever attempting
+                # to have the same alias at the same time.
+                for name, aliases in six.iteritems(self.pd._rm_aliases):
+                    driver.DriverAction.remove_aliases(
+                        name, aliases, self.image
+                    )
+
+                # Done with removals; discard them so memory can
+                # be re-used.
                 self.pd.removal_actions = []
 
-                pt.plan_start(pt.PLAN_ACTION_MERGE)
-                # cache the current image mediators within the plan
-                cfg_mediators = self.pd._cfg_mediators = \
-                    self.image.cfg.mediators
+                # execute installs; if action throws a retry
+                # exception try it again afterwards.
+                retries = []
+                for p, src, dest in self.pd.install_actions:
+                    try:
+                        p.execute_install(src, dest)
+                        pt.actions_add_progress(pt.ACTION_INSTALL)
+                    except pkg.actions.ActionRetry:
+                        retries.append((p, src, dest))
+                for p, src, dest in retries:
+                    p.execute_retry(src, dest)
+                    pt.actions_add_progress(pt.ACTION_INSTALL)
+                retries = []
+                pt.actions_done(pt.ACTION_INSTALL)
 
-                mediated_removed_paths = set()
-                mediated_del_path_target = defaultdict(set)
-                for p in self.pd.pkg_plans:
-                        pt.plan_add_progress(pt.PLAN_ACTION_MERGE)
-                        for src, dest in p.gen_removal_actions():
-                                if DebugValues["actions"]:
-                                        print("Removal: " + str(src))
-                                if src.name == "user":
-                                        self.pd.removed_users[src.attrs[
-                                            "username"]] = p.origin_fmri
-                                elif src.name == "group":
-                                        self.pd.removed_groups[src.attrs[
-                                            "groupname"]] = p.origin_fmri
-
-                                self.pd.removal_actions.append(
-                                    _ActionPlan(p, src, dest))
-                                if (not (src.name == "link" or
-                                    src.name == "hardlink") or
-                                    "mediator" not in src.attrs):
-                                        continue
-
-                                # Keep track of which mediated paths have been
-                                # removed from the system so that which paths
-                                # need to be repaired can be determined.
-                                mediator = src.attrs["mediator"]
-                                src_version = src.attrs.get(
-                                    "mediator-version")
-                                src_impl = src.attrs.get(
-                                    "mediator-implementation")
-
-                                mediation = cfg_mediators.get(mediator)
-                                if not mediation:
-                                        # Shouldn't happen, but if it does,
-                                        # drive on.
-                                        continue
-
-                                cfg_version = mediation.get("version")
-                                if cfg_version:
-                                        # For comparison, version must be a
-                                        # string.
-                                        cfg_version = \
-                                            cfg_version.get_short_version()
-
-                                cfg_version_source = mediation.get("version-source")
-                                cfg_impl = mediation.get("implementation")
-                                cfg_impl_source = mediation.get("implementation-source")
-
-                                if src_version == cfg_version and \
-                                    mediator_impl_matches(src_impl, cfg_impl):
-                                        mediated_removed_paths.add(
-                                            src.attrs["path"])
-                                        # Need the target to be a full path
-                                        # so it can be found in the plan.
-                                        if cfg_version_source == "local" or \
-                                             cfg_impl_source == "local":
-                                                 binpath = src.attrs["path"]
-                                                 target = self.__full_target_path(binpath)
-                                                 mediated_del_path_target[mediator].add(target)
-
-                self.pd.update_actions = []
-                self.pd._rm_aliases = {}
-                for p in self.pd.pkg_plans:
-                        pt.plan_add_progress(pt.PLAN_ACTION_MERGE)
-                        for src, dest in p.gen_update_actions():
-                                if DebugValues["actions"]:
-                                        print("Update:" + str(src))
-                                        print("       " + str(dest))
-                                if dest.name == "user":
-                                        self.pd.added_users[dest.attrs[
-                                            "username"]] = p.destination_fmri
-                                elif dest.name == "group":
-                                        self.pd.added_groups[dest.attrs[
-                                            "groupname"]] = p.destination_fmri
-                                elif dest.name == "driver" and src:
-                                        rm = \
-                                            set(src.attrlist("alias")) - \
-                                            set(dest.attrlist("alias"))
-                                        if rm:
-                                                self.pd._rm_aliases.setdefault(
-                                                    dest.attrs["name"],
-                                                    set()).update(rm)
-                                self.pd.update_actions.append(
-                                    _ActionPlan(p, src, dest))
-
+                # Done with installs, so discard them so memory
+                # can be re-used.
                 self.pd.install_actions = []
-                errs = []
-                for p in self.pd.pkg_plans:
-                        pfmri = None
-                        if p.destination_fmri:
-                                pfmri = p.destination_fmri.get_fmri()
-                        err_actions = api_errors.ImageBoundaryError(pfmri)
-                        pt.plan_add_progress(pt.PLAN_ACTION_MERGE)
-                        for src, dest in p.gen_install_actions():
-                                if DebugValues["actions"]:
-                                        print("Install: " + str(dest))
-                                if dest.name == "user":
-                                        self.pd.added_users[dest.attrs[
-                                            "username"]] = p.destination_fmri
-                                elif dest.name == "group":
-                                        self.pd.added_groups[dest.attrs[
-                                            "groupname"]] = p.destination_fmri
-                                # Check whether files are delivered in reserved
-                                # locations.
-                                if not self.__check_reserved(dest):
-                                        err_actions.append_error(
-                                            action=dest,
-                                            err_type=api_errors.\
-                                            ImageBoundaryError.RESERVED)
-                                self.pd.install_actions.append(
-                                    _ActionPlan(p, src, dest))
-                        if not err_actions.isEmpty():
-                                errs.append(err_actions)
 
-                if errs:
-                        raise api_errors.ImageBoundaryErrors(errs)
-
-                # In case a removed user or group was added back...
-                for entry in self.pd.added_groups.keys():
-                        if entry in self.pd.removed_groups:
-                                del self.pd.removed_groups[entry]
-                for entry in self.pd.added_users.keys():
-                        if entry in self.pd.removed_users:
-                                del self.pd.removed_users[entry]
-
-                self.pd.state = plandesc.MERGED_OK
-                pt.plan_done(pt.PLAN_ACTION_MERGE)
-
-                if not self.nothingtodo():
-                        self.__find_all_conflicts()
-
-                pt.plan_start(pt.PLAN_ACTION_CONSOLIDATE)
-                ConsolidationEntry = namedtuple("ConsolidationEntry", "idx id")
-
-                # cons_named maps original_name tags to the index into
-                # removal_actions so we can retrieve them later.  cons_generic
-                # maps the (action.name, action.key-attribute-value) tuple to
-                # the same thing.  The reason for both is that cons_named allows
-                # us to deal with files which change their path as well as their
-                # package, while cons_generic doesn't require the "receiving"
-                # package to have marked the file in any special way, plus
-                # obviously it handles all actions even if they don't have
-                # paths.
-                cons_named = {}
-                cons_generic = {}
-
-                def hashify(v):
-                        """handle key values that may be lists"""
-                        if isinstance(v, list):
-                                return frozenset(v)
-                        else:
-                                return v
-
-                for i, ap in enumerate(self.pd.removal_actions):
-                        if ap is None:
-                                continue
-                        pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
-
-                        # If the action type needs to be reference-counted, make
-                        # sure it doesn't get removed if another instance
-                        # remains in the target image.
-                        remove = True
-                        if ap.src.name == "dir" and \
-                            os.path.normpath(ap.src.attrs["path"]) in \
-                            self.__get_directories():
-                                remove = False
-                        elif ap.src.name == "link" or ap.src.name == "hardlink":
-                                lpath = os.path.normpath(ap.src.attrs["path"])
-                                if ap.src.name == "link":
-                                        inst_links = self.__get_symlinks()
-                                else:
-                                        inst_links = self.__get_hardlinks()
-                                if self.__check_excluded(lpath):
-                                        if DebugValues["exclude"]:
-                                                print("!Removal:", lpath)
-                                        self.pd.elided_actions.append(ap)
-                                        remove = False
-                                elif lpath in inst_links:
-                                        # Another link delivers to the same
-                                        # location, so assume it can't be
-                                        # safely removed initially.
-                                        remove = False
-
-                                        # If link is mediated, and the mediator
-                                        # doesn't match the new mediation
-                                        # criteria, it is safe to remove.
-                                        mediator = ap.src.attrs.get("mediator")
-                                        if mediator in self.pd._new_mediators:
-                                                src_version = ap.src.attrs.get(
-                                                    "mediator-version")
-                                                src_impl = ap.src.attrs.get(
-                                                    "mediator-implementation")
-                                                dest_version = \
-                                                    self.pd._new_mediators[mediator].get(
-                                                        "version")
-                                                if dest_version:
-                                                        # Requested version needs
-                                                        # to be a string for
-                                                        # comparison.
-                                                        dest_version = \
-                                                            dest_version.get_short_version()
-                                                dest_impl = \
-                                                    self.pd._new_mediators[mediator].get(
-                                                        "implementation")
-                                                if dest_version is not None and \
-                                                    src_version != dest_version:
-                                                        remove = True
-                                                if dest_impl is not None and \
-                                                    not mediator_impl_matches(
-                                                        src_impl, dest_impl):
-                                                        remove = True
-
-                        elif ap.src.name == "license" and \
-                            ap.src.attrs["license"] in self.__get_licenses():
-                                remove = False
-                        elif ap.src.name == "legacy" and \
-                            ap.src.attrs["pkg"] in self.__get_legacy():
-                                remove = False
-                        elif "path" in ap.src.attrs and \
-                            self.__check_excluded(ap.src.attrs["path"]):
-                                if DebugValues["exclude"]:
-                                        print("!Remove", ap.src.attrs["path"])
-                                self.pd.elided_actions.append(ap)
-                                remove = False
-
-                        if not remove:
-                                self.pd.removal_actions[i] = None
-                                if "mediator" in ap.src.attrs:
-                                        mediated_removed_paths.discard(
-                                            ap.src.attrs["path"])
-                                continue
-
-                        # store names of files being removed under own name
-                        # or original name if specified
-                        if ap.src.globally_identical:
-                                attrs = ap.src.attrs
-                                # Store the index into removal_actions and the
-                                # id of the action object in that slot.
-                                re = ConsolidationEntry(i, id(ap.src))
-                                cons_generic[(ap.src.name,
-                                    hashify(attrs[ap.src.key_attr]))] = re
-                                if ap.src.name == "file":
-                                        fname = attrs.get("original_name",
-                                            "{0}:{1}".format(
-                                            ap.p.origin_fmri.get_name(),
-                                            attrs["path"]))
-                                        cons_named[fname] = re
-                                        fname = None
-                                attrs = re = None
-
-                        self.pd._actuators.scan_removal(ap)
-                        if self.pd._need_boot_archive is None:
-                                if self.pd._op != PKG_OP_DEHYDRATE and \
-                                    ap.src.attrs.get("path", "").startswith(
-                                    ramdisk_prefixes):
-                                        self.pd._need_boot_archive = True
-
-                # reduce memory consumption
-                self.__directories = None
-                self.__symlinks = None
-                self.__hardlinks = None
-                self.__licenses = None
-                self.__legacy = None
-
-                pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
-
-                # Construct a mapping from the install actions in a pkgplan to
-                # the position they have in the plan's list.  This allows us to
-                # remove them efficiently later, if they've been consolidated.
-                #
-                # NOTE: This means that the action ordering in the package plans
-                # must remain fixed, at least for the duration of the imageplan
-                # evaluation.
-                plan_pos = {}
-                for p in self.pd.pkg_plans:
-                        for i, a in enumerate(p.gen_install_actions()):
-                                plan_pos[id(a[1])] = i
-
-                # This keeps track of which pkgplans have had install actions
-                # consolidated away.
-                pp_needs_trimming = set()
-
-                # This maps destination actions to the pkgplans they're
-                # associated with, which allows us to create the newly
-                # discovered update _ActionPlans.
-                dest_pkgplans = {}
-
-                new_updates = []
-                for i, ap in enumerate(self.pd.install_actions):
-                        if ap is None:
-                                continue
-                        pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
-
-                        if "path" in ap.dst.attrs and \
-                            self.__check_excluded(ap.dst.attrs["path"]):
-                                if DebugValues["exclude"]:
-                                        print("!Install", ap.dst.attrs["path"])
-                                self.pd.elided_actions.append(ap)
-                                pp_needs_trimming.add(ap.p)
-                                ap.p.actions.added[plan_pos[id(ap.dst)]] = None
-                                self.pd.install_actions[i] = None
-
-                        # In order to handle editable files that move their path
-                        # or change pkgs, for all new files with original_name
-                        # attribute, make sure file isn't being removed by
-                        # checking removal list.  If it is, tag removal to save
-                        # file, and install to recover cached version... caching
-                        # is needed if directories are removed or don't exist
-                        # yet.
-                        if (ap.dst.name == "file" and
-                            "original_name" in ap.dst.attrs and
-                            ap.dst.attrs["original_name"] in cons_named):
-                                cache_name = ap.dst.attrs["original_name"]
-                                index = cons_named[cache_name].idx
-                                ra = self.pd.removal_actions[index].src
-                                assert(id(ra) == cons_named[cache_name].id)
-                                # If the paths match, don't remove and add;
-                                # convert to update.
-                                if ap.dst.attrs["path"] == ra.attrs["path"]:
-                                        new_updates.append((ra, ap.dst))
-                                        # If we delete items here, the indices
-                                        # in cons_named will be bogus, so mark
-                                        # them for later deletion.
-                                        self.pd.removal_actions[index] = None
-                                        self.pd.install_actions[i] = None
-                                        # No need to handle it in cons_generic
-                                        # anymore
-                                        del cons_generic[("file", ra.attrs["path"])]
-                                        dest_pkgplans[id(ap.dst)] = ap.p
-                                else:
-                                        # The 'true' indicates the file should
-                                        # be removed from source.  The removal
-                                        # action is changed using setdefault so
-                                        # that any overlay rules applied during
-                                        # conflict checking remain intact.
-                                        ra.attrs.setdefault("save_file",
-                                            [cache_name, "true"])
-                                        ap.dst.attrs["save_file"] = [cache_name,
-                                            "true"]
-
-                                cache_name = index = ra = None
-
-                        # Similarly, try to prevent files (and other actions)
-                        # from unnecessarily being deleted and re-created if
-                        # they're simply moving between packages, but only if
-                        # they keep their paths (or key-attribute values).
-                        keyval = hashify(ap.dst.attrs.get(ap.dst.key_attr, None))
-                        if (ap.dst.name, keyval) in cons_generic:
-                                nkv = ap.dst.name, keyval
-                                index = cons_generic[nkv].idx
-                                ra = self.pd.removal_actions[index].src
-                                assert(id(ra) == cons_generic[nkv].id)
-                                if keyval == ra.attrs[ra.key_attr]:
-                                        new_updates.append((ra, ap.dst))
-                                        self.pd.removal_actions[index] = None
-                                        self.pd.install_actions[i] = None
-                                        dest_pkgplans[id(ap.dst)] = ap.p
-                                        # Add the action to the pkgplan's update
-                                        # list and mark it for removal from the
-                                        # install list.
-                                        ap.p.actions.changed.append((ra, ap.dst))
-                                        ap.p.actions.added[plan_pos[id(ap.dst)]] = None
-                                        pp_needs_trimming.add(ap.p)
-                                nkv = index = ra = None
-
-                        self.pd._actuators.scan_install(ap)
-                        if self.pd._need_boot_archive is None:
-                                if ap.dst.attrs.get("path", "").startswith(
-                                    ramdisk_prefixes):
-                                        self.pd._need_boot_archive = True
-
-                del ConsolidationEntry, cons_generic, cons_named, plan_pos
-
-                # Remove from the pkgplans the install actions which have been
-                # consolidated away.
-                for p in pp_needs_trimming:
-                        # Can't modify the p.actions tuple, so modify the added
-                        # member in-place.
-                        p.actions.added[:] = [
-                            a
-                            for a in p.actions.added
-                            if a is not None
-                        ]
-                del pp_needs_trimming
-
-                pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
-
-                # We want to cull out actions where they've not changed at all,
-                # leaving only the changed ones to put into
-                # self.pd.update_actions.
-                nu_src = manifest.Manifest()
-                nu_src.set_content(content=(a[0] for a in new_updates),
-                    excludes=self.__old_excludes)
-                nu_dst = manifest.Manifest()
-                pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
-                nu_dst.set_content(content=(a[1] for a in new_updates),
-                    excludes=self.__new_excludes)
-                del new_updates
-                pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
-                nu_add, nu_chg, nu_rem = nu_dst.difference(nu_src,
-                    self.__old_excludes, self.__new_excludes)
-                pt.plan_add_progress(pt.PLAN_ACTION_CONSOLIDATE)
-                # All the differences should be updates
-                assert not nu_add
-                assert not nu_rem
-                del nu_src, nu_dst
-
-                # Extend update_actions with the new tuples.  The package plan
-                # is the one associated with the action getting installed.
-                self.pd.update_actions.extend([
-                    _ActionPlan(dest_pkgplans[id(dst)], src, dst)
-                    for src, dst in nu_chg
-                ])
-
-                del dest_pkgplans, nu_chg
-
-                # Cull any update actions that are excluded by the exclusion
-                # patterns configured in the image.
-                for i, ap in enumerate(self.pd.update_actions):
-                        if ap is None:
-                                continue
-                        path = None
-                        if (ap.src and "path" in ap.src.attrs and
-                            self.__check_excluded(
-                            ap.src.attrs["path"])):
-                                path = ap.src.attrs["path"]
-                        elif (ap.dst and "path" in ap.dst.attrs and
-                            self.__check_excluded(
-                            ap.dst.attrs["path"])):
-                                path = ap.dst.attrs["path"]
-
-                        if path:
-                                if DebugValues["exclude"]:
-                                        print("!Update", path)
-                                self.pd.elided_actions.append(ap)
-                                self.pd.update_actions[i] = None
-
-                pt.plan_done(pt.PLAN_ACTION_CONSOLIDATE)
-                pt.plan_start(pt.PLAN_ACTION_MEDIATION)
-                pt.plan_add_progress(pt.PLAN_ACTION_MEDIATION)
-
-                # Mediate and repair links affected by the plan.
-                prop_mediators = self.__mediate_links(mediated_removed_paths)
-
-                pt.plan_add_progress(pt.PLAN_ACTION_MEDIATION)
-                for prop in ("removal_actions", "install_actions",
-                    "update_actions"):
-                        pval = getattr(self.pd, prop)
-                        pval[:] = [
-                            a
-                            for a in pval
-                            if a is not None
-                        ]
-
-                pt.plan_add_progress(pt.PLAN_ACTION_MEDIATION)
-
-                # Add any necessary repairs to plan.
-                self.__evaluate_fixups()
-
-                pt.plan_add_progress(pt.PLAN_ACTION_MEDIATION)
-
-                # Finalize link mediation.
-                self.__finalize_mediation(prop_mediators, mediated_del_path_target)
-
-                pt.plan_done(pt.PLAN_ACTION_MEDIATION)
-
-                if DebugValues["actions"]:
-                        print("--- Final actions ---")
-                        for prop in ("removal_actions", "install_actions",
-                            "update_actions"):
-                                key = prop.split("_")[0]
-                                for a in getattr(self.pd, prop):
-                                        print("{0} {1}".format(key, str(a)))
-
-                pt.plan_start(pt.PLAN_ACTION_FINALIZE)
-
-                # Go over update actions
-                l_refresh = []
-                l_actions = {}
-                if self.pd.update_actions:
-                        # iterating over actions is slow, so don't do it
-                        # unless we have to.
-                        l_actions = self.get_actions("hardlink",
-                            self.hardlink_keyfunc)
-                for a in self.pd.update_actions:
-                        # For any files being updated that are the target of
-                        # _any_ hardlink actions, append the hardlink actions
-                        # to the update list so that they are not broken.
-                        # Since we reference count hardlinks, update each one
-                        # only once.
-                        if a[2].name == "file":
-                                path = a[2].attrs["path"]
-                                if path in l_actions:
-                                        unique_links = dict((l.attrs["path"], l)
-                                            for l in l_actions[path])
-                                        l_refresh.extend([
-                                            _ActionPlan(a[0], l, l)
-                                            for l in unique_links.values()
-                                        ])
-                                path = None
-
-                        # scan both old and new actions
-                        # repairs may result in update action w/o orig action
-                        self.pd._actuators.scan_update(a)
-                        if self.pd._need_boot_archive is None:
-                                if a[2].attrs.get("path", "").startswith(
-                                    ramdisk_prefixes):
-                                        self.pd._need_boot_archive = True
-
-                self.pd.update_actions.extend(l_refresh)
-
-                # sort actions to match needed processing order
-                remsort = operator.itemgetter(1)
-                addsort = operator.itemgetter(2)
-                self.pd.removal_actions.sort(key=remsort, reverse=True)
-                self.pd.update_actions.sort(key=addsort)
-                self.pd.install_actions.sort(key=addsort)
-
-                # find the first and last hardlink in the install_actions
-                fhl = lhl = -1
-                for i, ap in enumerate(self.pd.install_actions):
-                        if ap.dst.name == "hardlink":
-                                if fhl == -1:
-                                        fhl = i
-                                lhl = i
-                        elif fhl != -1:
-                                break
-
-                # now reorder the hardlinks to respect inter-dependencies
-                if fhl != -1:
-                        hardlinks = self.pd.install_actions[fhl:lhl + 1]
-                        hardlinks = _reorder_hardlinks(hardlinks)
-                        self.pd.install_actions[fhl:lhl + 1] = hardlinks
-
-                # cleanup pkg_plan objects which don't actually contain any
-                # changes and add any new ones to list of changes
-                for p in list(self.pd.pkg_plans):
-                        if p.origin_fmri != p.destination_fmri or \
-                            p.actions.removed or p.actions.changed or \
-                            p.actions.added:
-                                pair = (p.origin_fmri, p.destination_fmri)
-                                if pair not in self.pd._fmri_changes:
-                                        self.pd._fmri_changes.append(pair)
-                                continue
-                        self.pd.pkg_plans.remove(p)
-                        fmri = p.origin_fmri
-                        if (fmri, fmri) in self.pd._fmri_changes:
-                                self.pd._fmri_changes.remove(
-                                    (fmri, fmri))
-                        del p
-
-                #
-                # Sort the package plans by fmri to create predictability (and
-                # some sense of order) in the download output; this is not
-                # a perfect sort of this, but we only really care for things
-                # we fetch over the wire.
-                #
-                def key_func(a):
-                        if a.destination_fmri:
-                                return a.destination_fmri
-                        return ""
-
-                self.pd.pkg_plans.sort(key=key_func)
-
-                pt.plan_done(pt.PLAN_ACTION_FINALIZE)
-
-                if self.pd._need_boot_archive is None:
-                        self.pd._need_boot_archive = False
-
-                self.pd.state = plandesc.EVALUATED_OK
-
-        def nothingtodo(self):
-                """Test whether this image plan contains any work to do """
-
-                if self.pd.state in [plandesc.EVALUATED_PKGS,
-                    plandesc.MERGED_OK]:
-                        return not (self.pd._fmri_changes or
-                            self.pd._new_variants or
-                            (self.pd._new_facets is not None) or
-                            self.pd._mediators_change or
-                            self.pd.pkg_plans)
-                elif self.pd.state >= plandesc.EVALUATED_OK:
-                        return not (self.pd.pkg_plans or
-                            self.pd._new_variants or
-                            (self.pd._new_facets is not None) or
-                            self.pd._mediators_change)
-                assert 0, "Shouldn't call nothingtodo() for state = {0:d}".format(
-                    self.pd.state)
-
-        def preexecute(self):
-                """Invoke the evaluated image plan
-                preexecute, execute and postexecute
-                execute actions need to be sorted across packages
-                """
-
-                assert self.pd.state == plandesc.EVALUATED_OK
-
-                if self.pd._image_lm != \
-                    self.image.get_last_modified(string=True):
-                        # State has been modified since plan was created; this
-                        # plan is no longer valid.
-                        self.pd.state = plandesc.PREEXECUTED_ERROR
-                        raise api_errors.InvalidPlanError()
-
-                if self.nothingtodo():
-                        self.pd.state = plandesc.PREEXECUTED_OK
-                        return
-
-                if self.image.version != self.image.CURRENT_VERSION:
-                        # Prevent plan execution if image format isn't current.
-                        raise api_errors.ImageFormatUpdateNeeded(
-                            self.image.root)
-
-                if DebugValues["plandesc_validate"]:
-                        # get a json copy of the plan description so that
-                        # later we can verify that it wasn't updated during
-                        # the pre-execution stage.
-                        pd_json1 = self.pd.getstate(self.pd,
-                            reset_volatiles=True)
-
-                # Checks the index to make sure it exists and is
-                # consistent. If it's inconsistent an exception is thrown.
-                # If it's totally absent, it will index the existing packages
-                # so that the incremental update that follows at the end of
-                # the function will work correctly. It also repairs the index
-                # for this BE so the user can boot into this BE and have a
-                # correct index.
-                if self.update_index:
-                        ind = None
-                        try:
-                                self.image.update_index_dir()
-                                ind = indexer.Indexer(self.image,
-                                    self.image.get_manifest,
-                                    self.image.get_manifest_path,
-                                    progtrack=self.__progtrack,
-                                    excludes=self.__old_excludes)
-                                if ind.check_index_existence():
-                                        try:
-                                                ind.check_index_has_exactly_fmris(
-                                                        self.image.gen_installed_pkg_names())
-                                        except se.IncorrectIndexFileHash as e:
-                                                self.__preexecuted_indexing_error = \
-                                                    api_errors.WrapSuccessfulIndexingException(
-                                                        e,
-                                                        traceback.format_exc(),
-                                                        traceback.format_stack()
-                                                        )
-                                                ind.rebuild_index_from_scratch(
-                                                        self.image.\
-                                                            gen_installed_pkgs()
-                                                        )
-                        except se.IndexingException as e:
-                                # If there's a problem indexing, we want to
-                                # attempt to finish the installation anyway. If
-                                # there's a problem updating the index on the
-                                # new image, that error needs to be
-                                # communicated to the user.
-                                self.__preexecuted_indexing_error = \
-                                    api_errors.WrapSuccessfulIndexingException(
-                                        e, traceback.format_exc(),
-                                        traceback.format_stack())
-
-                        # No longer needed.
-                        del ind
-
-                # check if we're going to have enough room
-                # stat fs again just in case someone else is using space...
-                self.__update_avail_space()
-                if self.pd._cbytes_added > self.pd._cbytes_avail:
-                        raise api_errors.ImageInsufficentSpace(
-                            self.pd._cbytes_added,
-                            self.pd._cbytes_avail,
-                            _("Download cache"))
-                if self.pd._bytes_added > self.pd._bytes_avail:
-                        raise api_errors.ImageInsufficentSpace(
-                            self.pd._bytes_added,
-                            self.pd._bytes_avail,
-                            _("Root filesystem"))
-
-                # Remove history about manifest/catalog transactions.  This
-                # helps the stats engine by only considering the performance of
-                # bulk downloads.
-                self.image.transport.stats.reset()
-
-                #
-                # Calculate size of data retrieval and pass it to progress
-                # tracker.
-                #
-                npkgs = nfiles = nbytes = 0
-                for p in self.pd.pkg_plans:
-                        nf, nb = p.get_xferstats()
-                        nbytes += nb
-                        nfiles += nf
-
-                        # It's not perfectly accurate but we count a download
-                        # even if the package will do zero data transfer.  This
-                        # makes the pkg stats consistent between download and
-                        # install.
-                        npkgs += 1
-                self.__progtrack.download_set_goal(npkgs, nfiles, nbytes)
-
-                lic_errors = []
-                try:
-                        # Check for license acceptance issues first to avoid
-                        # wasted time in the download phase and so failure
-                        # can occur early.
-                        for p in self.pd.pkg_plans:
-                                try:
-                                        p.preexecute()
-                                except api_errors.PkgLicenseErrors as e:
-                                        # Accumulate all license errors.
-                                        lic_errors.append(e)
-                                except EnvironmentError as e:
-                                        if e.errno == errno.EACCES:
-                                                raise api_errors.PermissionsException(
-                                                    e.filename)
-                                        if e.errno == errno.EROFS:
-                                                raise api_errors.ReadOnlyFileSystemException(
-                                                    e.filename)
-                                        raise
-
-                        if lic_errors:
-                                raise api_errors.PlanLicenseErrors(lic_errors)
-
-                        try:
-                                for p in self.pd.pkg_plans:
-                                        p.download(self.__progtrack,
-                                            self.__check_cancel)
-                        except EnvironmentError as e:
-                                if e.errno == errno.EACCES:
-                                        raise api_errors.PermissionsException(
-                                            e.filename)
-                                if e.errno == errno.EROFS:
-                                        raise api_errors.ReadOnlyFileSystemException(
-                                            e.filename)
-                                raise
-                        except (api_errors.InvalidDepotResponseException,
-                            api_errors.TransportError) as e:
-                                if p and p._autofix_pkgs:
-                                        e._autofix_pkgs = p._autofix_pkgs
-                                raise
-
-                        self.image.transport.shutdown()
-                        self.__progtrack.download_done()
-                except:
-                        self.pd.state = plandesc.PREEXECUTED_ERROR
-                        raise
-
-                self.pd.state = plandesc.PREEXECUTED_OK
-
-                if DebugValues["plandesc_validate"]:
-                        # verify that preexecution did not update the plan
-                        pd_json2 = self.pd.getstate(self.pd,
-                            reset_volatiles=True)
-                        pkg.misc.json_diff("PlanDescription",
-                            pd_json1, pd_json2, pd_json1, pd_json2)
-                        del pd_json1, pd_json2
-
-        def execute(self):
-                """Invoke the evaluated image plan
-                preexecute, execute and postexecute
-                execute actions need to be sorted across packages
-                """
-                assert self.pd.state == plandesc.PREEXECUTED_OK
-
-                if self.pd._image_lm != \
-                    self.image.get_last_modified(string=True):
-                        # State has been modified since plan was created; this
-                        # plan is no longer valid.
-                        self.pd.state = plandesc.EXECUTED_ERROR
-                        raise api_errors.InvalidPlanError()
-
-                # load data from previously downloaded actions
-                try:
-                        for p in self.pd.pkg_plans:
-                                p.cacheload()
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    e.filename)
-                        raise
-
-                # check for available space
-                self.__update_avail_space()
-                if (self.pd._bytes_added - self.pd._cbytes_added) > self.pd._bytes_avail:
-                        raise api_errors.ImageInsufficentSpace(
-                            self.pd._bytes_added - self.pd._cbytes_added,
-                            self.pd._bytes_avail,
-                            _("Root filesystem"))
-
-                #
-                # what determines execution order?
-                #
-                # The following constraints are key in understanding imageplan
-                # execution:
-                #
-                # 1) All non-directory actions (files, users, hardlinks,
-                # symbolic links, etc.) must appear in only a single installed
-                # package.
-                #
-                # 2) All installed packages must be consistent in their view of
-                # action types; if /usr/openwin is a directory in one package,
-                # it must be a directory in all packages, never a symbolic link;
-                # this includes implicitly defined directories.
-                #
-                # A key goal in IPS is to be able to undergo an arbitrary
-                # transformation in package contents in a single step.  Packages
-                # must be able to exchange files, convert directories to
-                # symbolic links, etc.; so long as the start and end states meet
-                # the above two constraints IPS must be able to transition
-                # between the states directly.  This leads to the following:
-                #
-                # 1) All actions must be ordered across packages; packages
-                # cannot be updated one at a time.
-                #
-                #    This is readily apparent when one considers two packages
-                #    exchanging files in their new versions; in each case the
-                #    package now owning the file must be installed last, but it
-                #    is not possible for each package to be installed before the
-                #    other.  Clearly, all the removals must be done first,
-                #    followed by the installs and updates.
-                #
-                # 2) Installs of new actions must precede updates of existing
-                # ones.
-                #
-                #    In order to accommodate changes of file ownership of
-                #    existing files to a newly created user, it is necessary
-                #    for the installation of that user to precede the update of
-                #    files to reflect their new ownership.
-                #
-                #    The exception to this rule is driver actions.  Aliases of
-                #    existing drivers which are going to be removed must be
-                #    removed before any new drivers are installed or updated.
-                #    This prevents an error if an alias is moving from one
-                #    driver to another.
-
-                if self.nothingtodo():
-                        self.pd.state = plandesc.EXECUTED_OK
-                        return
-
-                pt = self.__progtrack
-                pt.set_major_phase(pt.PHASE_EXECUTE)
-
-                # It's necessary to do this check here because the state of the
-                # image before the current operation is performed is desired.
-                empty_image = self.__is_image_empty()
-
-                if not empty_image:
-                        # Before proceeding, remove fast lookups database so
-                        # that if _create_fast_lookups is interrupted later the
-                        # client isn't left with invalid state.
-                        self.image._remove_fast_lookups()
-
-                if not self.image.is_liveroot():
-                        # Check if the child is a running zone. If so run the
-                        # actuator in the zone.
-
-                        # Linked Image code uses trailing slashes, Image code
-                        # does not. So we make sure that our path comparisons
-                        # are always on tha same page.
-                        root = os.path.normpath(self.image.root)
-
-                        rzones = zone.list_running_zones()
-                        for z, path in six.iteritems(rzones):
-                                if os.path.normpath(path) == root:
-                                        self.pd._actuators.set_zone(z)
-                                        # there should be only on zone per path
-                                        break
-
-                self.pd._actuators.exec_prep(self.image)
-
-                self.pd._actuators.exec_pre_actuators(self.image)
-
-                # List of tuples of (src, dest) used to track each pkgplan so
-                # that it can be discarded after execution.
-                executed_pp = []
-                try:
-                        try:
-                                pt.actions_set_goal(pt.ACTION_REMOVE,
-                                    len(self.pd.removal_actions))
-                                pt.actions_set_goal(pt.ACTION_INSTALL,
-                                    len(self.pd.install_actions))
-                                pt.actions_set_goal(pt.ACTION_UPDATE,
-                                    len(self.pd.update_actions))
-
-                                # execute removals
-                                for p, src, dest in self.pd.removal_actions:
-                                        p.execute_removal(src, dest)
-                                        pt.actions_add_progress(
-                                            pt.ACTION_REMOVE)
-                                pt.actions_done(pt.ACTION_REMOVE)
-
-                                # Update driver alias database to reflect the
-                                # aliases drivers have lost in the new image.
-                                # This prevents two drivers from ever attempting
-                                # to have the same alias at the same time.
-                                for name, aliases in \
-                                    six.iteritems(self.pd._rm_aliases):
-                                        driver.DriverAction.remove_aliases(name,
-                                            aliases, self.image)
-
-                                # Done with removals; discard them so memory can
-                                # be re-used.
-                                self.pd.removal_actions = []
-
-                                # execute installs; if action throws a retry
-                                # exception try it again afterwards.
-                                retries = []
-                                for p, src, dest in self.pd.install_actions:
-                                        try:
-                                                p.execute_install(src, dest)
-                                                pt.actions_add_progress(
-                                                    pt.ACTION_INSTALL)
-                                        except pkg.actions.ActionRetry:
-                                                retries.append((p, src, dest))
-                                for p, src, dest in retries:
-                                        p.execute_retry(src, dest)
-                                        pt.actions_add_progress(
-                                            pt.ACTION_INSTALL)
-                                retries = []
-                                pt.actions_done(pt.ACTION_INSTALL)
-
-                                # Done with installs, so discard them so memory
-                                # can be re-used.
-                                self.pd.install_actions = []
-
-                                # execute updates; in some cases there may be
-                                # a retryable exception, so capture those and
-                                # retry after running through all the
-                                # actions(which might address the reason for
-                                # the retryable exception).
-                                # An example is a user action that depends
-                                # upon a file existing (ie ftpusers).
-                                retries = []
-                                for p, src, dest in self.pd.update_actions:
-                                        try:
-                                            p.execute_update(src, dest)
-                                            pt.actions_add_progress(
-                                                pt.ACTION_UPDATE)
-                                        except pkg.actions.ActionRetry:
-                                            retries.append((p, src, dest))
-
-                                for p, src, dest in retries:
-                                    p.execute_retry(src, dest)
-                                    pt.actions_add_progress(pt.ACTION_UPDATE)
-                                retries = []
-
-                                pt.actions_done(pt.ACTION_UPDATE)
-                                pt.actions_all_done()
-                                pt.set_major_phase(pt.PHASE_FINALIZE)
-
-                                # Done with updates, so discard them so memory
-                                # can be re-used.
-                                self.pd.update_actions = []
-
-                                # handle any postexecute operations
-                                while self.pd.pkg_plans:
-                                        # postexecute in reverse, but pkg_plans
-                                        # aren't ordered, so does it matter?
-                                        # This allows the pkgplan objects to be
-                                        # discarded as they're executed which
-                                        # allows memory to be-reused sooner.
-                                        p = self.pd.pkg_plans.pop()
-                                        p.postexecute()
-                                        executed_pp.append((p.destination_fmri,
-                                            p.origin_fmri))
-                                        p = None
-
-                                # save package state
-                                self.image.update_pkg_installed_state(
-                                    executed_pp, self.__progtrack,
-                                    self.__match_inst.keys())
-                                # no longer needed
-                                self.__match_inst = {}
-
-                                # write out variant changes to the image config
-                                if self.pd._varcets_change or \
-                                    self.pd._mediators_change:
-                                        self.image.image_config_update(
-                                            self.pd._new_variants,
-                                            self.pd._new_facets,
-                                            self.pd._new_mediators)
-                                # write out any changes
-                                self.image._avoid_set_save(
-                                    *self.pd._new_avoid_obs)
-                                # An essential step to set the property
-                                # "dehydrated" if dehydrate/rehydrate succeeds.
-                                if self.pd._op in (PKG_OP_DEHYDRATE,
-                                    PKG_OP_REHYDRATE):
-                                        self.image.cfg.set_property("property",
-                                            "dehydrated", self.operations_pubs)
-                                        self.image.save_config()
-                                else:
-                                        # Mark image as modified if not calling
-                                        # save_config (which will do it for us).
-                                        self.image.update_last_modified()
-
-                        except EnvironmentError as e:
-                                if e.errno == errno.EACCES or \
-                                    e.errno == errno.EPERM:
-                                        raise api_errors.PermissionsException(
-                                            e.filename)
-                                elif e.errno == errno.EROFS:
-                                        raise api_errors.ReadOnlyFileSystemException(
-                                            e.filename)
-                                elif e.errno == errno.ELOOP:
-                                        act = pkg.actions.unknown.UnknownAction()
-                                        raise api_errors.ActionExecutionError(
-                                            act, _("A link targeting itself or "
-                                            "part of a link loop was found at "
-                                            "'{0}'; a file or directory was "
-                                            "expected.  Please remove the link "
-                                            "and try again.").format(
-                                            e.filename))
-                                raise
-                except pkg.actions.ActionError:
-                        exc_type, exc_value, exc_tb = sys.exc_info()
-                        self.pd.state = plandesc.EXECUTED_ERROR
-                        try:
-                                self.pd._actuators.exec_fail_actuators(
-                                    self.image)
-                        except:
-                                # Ensure the real cause of failure is raised.
-                                pass
-                        if six.PY2:
-                                six.reraise(api_errors.InvalidPackageErrors([
-                                    exc_value]), None, exc_tb)
-                        else:
-                                # six.reraise requires the first argument
-                                # callable if the second argument is None.
-                                # Also the traceback is automatically attached,
-                                # in Python 3, so we can simply raise it.
-                                raise api_errors.InvalidPackageErrors([
-                                    exc_value])
-                except:
-                        exc_type, exc_value, exc_tb = sys.exc_info()
-                        self.pd.state = plandesc.EXECUTED_ERROR
-                        try:
-                                self.pd._actuators.exec_fail_actuators(
-                                    self.image)
-                        finally:
-                                # This ensures that the original exception and
-                                # traceback are used if exec_fail_actuators
-                                # fails.
-                                if six.PY2:
-                                        six.reraise(exc_value, None, exc_tb)
-                                else:
-                                        raise exc_value
-
+                # execute updates; in some cases there may be
+                # a retryable exception, so capture those and
+                # retry after running through all the
+                # actions(which might address the reason for
+                # the retryable exception).
+                # An example is a user action that depends
+                # upon a file existing (ie ftpusers).
+                retries = []
+                for p, src, dest in self.pd.update_actions:
+                    try:
+                        p.execute_update(src, dest)
+                        pt.actions_add_progress(pt.ACTION_UPDATE)
+                    except pkg.actions.ActionRetry:
+                        retries.append((p, src, dest))
+
+                for p, src, dest in retries:
+                    p.execute_retry(src, dest)
+                    pt.actions_add_progress(pt.ACTION_UPDATE)
+                retries = []
+
+                pt.actions_done(pt.ACTION_UPDATE)
+                pt.actions_all_done()
+                pt.set_major_phase(pt.PHASE_FINALIZE)
+
+                # Done with updates, so discard them so memory
+                # can be re-used.
+                self.pd.update_actions = []
+
+                # handle any postexecute operations
+                while self.pd.pkg_plans:
+                    # postexecute in reverse, but pkg_plans
+                    # aren't ordered, so does it matter?
+                    # This allows the pkgplan objects to be
+                    # discarded as they're executed which
+                    # allows memory to be-reused sooner.
+                    p = self.pd.pkg_plans.pop()
+                    p.postexecute()
+                    executed_pp.append((p.destination_fmri, p.origin_fmri))
+                    p = None
+
+                # save package state
+                self.image.update_pkg_installed_state(
+                    executed_pp, self.__progtrack, self.__match_inst.keys()
+                )
+                # no longer needed
+                self.__match_inst = {}
+
+                # write out variant changes to the image config
+                if self.pd._varcets_change or self.pd._mediators_change:
+                    self.image.image_config_update(
+                        self.pd._new_variants,
+                        self.pd._new_facets,
+                        self.pd._new_mediators,
+                    )
+                # write out any changes
+                self.image._avoid_set_save(*self.pd._new_avoid_obs)
+                # An essential step to set the property
+                # "dehydrated" if dehydrate/rehydrate succeeds.
+                if self.pd._op in (PKG_OP_DEHYDRATE, PKG_OP_REHYDRATE):
+                    self.image.cfg.set_property(
+                        "property", "dehydrated", self.operations_pubs
+                    )
+                    self.image.save_config()
                 else:
-                        self.pd._actuators.exec_post_actuators(self.image)
+                    # Mark image as modified if not calling
+                    # save_config (which will do it for us).
+                    self.image.update_last_modified()
 
-                self.image._create_fast_lookups(progtrack=self.__progtrack)
-                self.__save_release_notes()
+            except EnvironmentError as e:
+                if e.errno == errno.EACCES or e.errno == errno.EPERM:
+                    raise api_errors.PermissionsException(e.filename)
+                elif e.errno == errno.EROFS:
+                    raise api_errors.ReadOnlyFileSystemException(e.filename)
+                elif e.errno == errno.ELOOP:
+                    act = pkg.actions.unknown.UnknownAction()
+                    raise api_errors.ActionExecutionError(
+                        act,
+                        _(
+                            "A link targeting itself or "
+                            "part of a link loop was found at "
+                            "'{0}'; a file or directory was "
+                            "expected.  Please remove the link "
+                            "and try again."
+                        ).format(e.filename),
+                    )
+                raise
+        except pkg.actions.ActionError:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            self.pd.state = plandesc.EXECUTED_ERROR
+            try:
+                self.pd._actuators.exec_fail_actuators(self.image)
+            except:
+                # Ensure the real cause of failure is raised.
+                pass
+            if six.PY2:
+                six.reraise(
+                    api_errors.InvalidPackageErrors([exc_value]), None, exc_tb
+                )
+            else:
+                # six.reraise requires the first argument
+                # callable if the second argument is None.
+                # Also the traceback is automatically attached,
+                # in Python 3, so we can simply raise it.
+                raise api_errors.InvalidPackageErrors([exc_value])
+        except:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            self.pd.state = plandesc.EXECUTED_ERROR
+            try:
+                self.pd._actuators.exec_fail_actuators(self.image)
+            finally:
+                # This ensures that the original exception and
+                # traceback are used if exec_fail_actuators
+                # fails.
+                if six.PY2:
+                    six.reraise(exc_value, None, exc_tb)
+                else:
+                    raise exc_value
 
-                # success
-                self.pd.state = plandesc.EXECUTED_OK
-                self.pd._executed_ok()
+        else:
+            self.pd._actuators.exec_post_actuators(self.image)
 
-                # reduce memory consumption
-                self.saved_files = {}
-                self.valid_directories = set()
-                self.__cached_actions = {}
+        self.image._create_fast_lookups(progtrack=self.__progtrack)
+        self.__save_release_notes()
 
-                # Clear out the primordial user and group caches.
-                self.image._users = set()
-                self.image._groups = set()
-                self.image._usersbyname = {}
-                self.image._groupsbyname = {}
+        # success
+        self.pd.state = plandesc.EXECUTED_OK
+        self.pd._executed_ok()
 
-                # Perform the incremental update to the search indexes
-                # for all changed packages
-                if self.update_index:
-                        self.image.update_index_dir()
-                        ind = indexer.Indexer(self.image,
-                            self.image.get_manifest,
-                            self.image.get_manifest_path,
-                            progtrack=self.__progtrack,
-                            excludes=self.__new_excludes)
-                        try:
-                                if empty_image:
-                                        ind.setup()
-                                if empty_image or ind.check_index_existence():
-                                        ind.client_update_index(([],
-                                            executed_pp), self.image)
-                        except KeyboardInterrupt:
-                                raise
-                        except se.ProblematicPermissionsIndexException:
-                                # ProblematicPermissionsIndexException
-                                # is included here as there's little
-                                # chance that trying again will fix this
-                                # problem.
-                                raise api_errors.WrapIndexingException(e,
-                                    traceback.format_exc(),
-                                    traceback.format_stack())
-                        except Exception as e:
-                                # It's important to delete and rebuild
-                                # from scratch rather than using the
-                                # existing indexer because otherwise the
-                                # state will become confused.
-                                del ind
-                                # XXX Once we have a framework for
-                                # emitting a message to the user in this
-                                # spot in the code, we should tell them
-                                # something has gone wrong so that we
-                                # continue to get feedback to allow
-                                # us to debug the code.
-                                try:
-                                        ind = indexer.Indexer(self.image,
-                                            self.image.get_manifest,
-                                            self.image.get_manifest_path,
-                                            progtrack=self.__progtrack,
-                                            excludes=self.__new_excludes)
-                                        ind.rebuild_index_from_scratch(
-                                            self.image.gen_installed_pkgs())
-                                except Exception as e:
-                                        raise api_errors.WrapIndexingException(
-                                            e, traceback.format_exc(),
-                                            traceback.format_stack())
-                                raise \
-                                    api_errors.WrapSuccessfulIndexingException(
-                                        e, traceback.format_exc(),
-                                        traceback.format_stack())
-                        if self.__preexecuted_indexing_error is not None:
-                                raise self.__preexecuted_indexing_error
+        # reduce memory consumption
+        self.saved_files = {}
+        self.valid_directories = set()
+        self.__cached_actions = {}
 
-                # As the very last thing, check if there are any broken
-                # mediators.
-                if self.invalid_meds and not self.image.is_zone():
-                        medmsg = self.__make_med_msg()
-                        raise api_errors.InvalidMediatorTarget(medmsg)
+        # Clear out the primordial user and group caches.
+        self.image._users = set()
+        self.image._groups = set()
+        self.image._usersbyname = {}
+        self.image._groupsbyname = {}
 
-
-        def __is_image_empty(self):
+        # Perform the incremental update to the search indexes
+        # for all changed packages
+        if self.update_index:
+            self.image.update_index_dir()
+            ind = indexer.Indexer(
+                self.image,
+                self.image.get_manifest,
+                self.image.get_manifest_path,
+                progtrack=self.__progtrack,
+                excludes=self.__new_excludes,
+            )
+            try:
+                if empty_image:
+                    ind.setup()
+                if empty_image or ind.check_index_existence():
+                    ind.client_update_index(([], executed_pp), self.image)
+            except KeyboardInterrupt:
+                raise
+            except se.ProblematicPermissionsIndexException:
+                # ProblematicPermissionsIndexException
+                # is included here as there's little
+                # chance that trying again will fix this
+                # problem.
+                raise api_errors.WrapIndexingException(
+                    e, traceback.format_exc(), traceback.format_stack()
+                )
+            except Exception as e:
+                # It's important to delete and rebuild
+                # from scratch rather than using the
+                # existing indexer because otherwise the
+                # state will become confused.
+                del ind
+                # XXX Once we have a framework for
+                # emitting a message to the user in this
+                # spot in the code, we should tell them
+                # something has gone wrong so that we
+                # continue to get feedback to allow
+                # us to debug the code.
                 try:
-                        next(self.image.gen_installed_pkg_names())
-                        return False
-                except StopIteration:
-                        return True
+                    ind = indexer.Indexer(
+                        self.image,
+                        self.image.get_manifest,
+                        self.image.get_manifest_path,
+                        progtrack=self.__progtrack,
+                        excludes=self.__new_excludes,
+                    )
+                    ind.rebuild_index_from_scratch(
+                        self.image.gen_installed_pkgs()
+                    )
+                except Exception as e:
+                    raise api_errors.WrapIndexingException(
+                        e, traceback.format_exc(), traceback.format_stack()
+                    )
+                raise api_errors.WrapSuccessfulIndexingException(
+                    e, traceback.format_exc(), traceback.format_stack()
+                )
+            if self.__preexecuted_indexing_error is not None:
+                raise self.__preexecuted_indexing_error
 
-        @staticmethod
-        def match_user_stems(image, patterns, match_type, raise_unmatched=True,
-            raise_not_installed=True, return_matchdict=False, universe=None):
-                """Given a user specified list of patterns, return a set
-                of matching package stems.  Any versions specified are
-                ignored.
+        # As the very last thing, check if there are any broken
+        # mediators.
+        if self.invalid_meds and not self.image.is_zone():
+            medmsg = self.__make_med_msg()
+            raise api_errors.InvalidMediatorTarget(medmsg)
 
-                'match_type' indicates how matching should be restricted.  The
-                possible values are:
+    def __is_image_empty(self):
+        try:
+            next(self.image.gen_installed_pkg_names())
+            return False
+        except StopIteration:
+            return True
 
-                    MATCH_ALL
-                        Matching is performed using all known package stems.
+    @staticmethod
+    def match_user_stems(
+        image,
+        patterns,
+        match_type,
+        raise_unmatched=True,
+        raise_not_installed=True,
+        return_matchdict=False,
+        universe=None,
+    ):
+        """Given a user specified list of patterns, return a set
+        of matching package stems.  Any versions specified are
+        ignored.
 
-                    MATCH_INST_VERSIONS
-                        Matching is performed using only installed package
-                        stems.
+        'match_type' indicates how matching should be restricted.  The
+        possible values are:
 
-                    MATCH_UNINSTALLED
-                        Matching is performed using uninstalled packages;
-                        it is an error for a pattern to match an installed
-                        package.
+            MATCH_ALL
+                Matching is performed using all known package stems.
 
-                Note that patterns starting w/ pkg:/ require an exact match;
-                patterns containing '*' will using fnmatch rules; the default
-                trailing match rules are used for remaining patterns.
+            MATCH_INST_VERSIONS
+                Matching is performed using only installed package
+                stems.
 
-                Exactly duplicated patterns are ignored.
+            MATCH_UNINSTALLED
+                Matching is performed using uninstalled packages;
+                it is an error for a pattern to match an installed
+                package.
 
-                Routine raises PlanCreationException if errors occur: it is
-                illegal to specify multiple different patterns that match the
-                same pkg name.  Only patterns that contain wildcards are allowed
-                to match multiple packages.
+        Note that patterns starting w/ pkg:/ require an exact match;
+        patterns containing '*' will using fnmatch rules; the default
+        trailing match rules are used for remaining patterns.
 
-                'raise_unmatched' determines whether an exception will be
-                raised if any patterns didn't match any packages.
+        Exactly duplicated patterns are ignored.
 
-                'raise_not_installed' determines whether an exception will be
-                raised if any pattern matches a package that's not installed.
+        Routine raises PlanCreationException if errors occur: it is
+        illegal to specify multiple different patterns that match the
+        same pkg name.  Only patterns that contain wildcards are allowed
+        to match multiple packages.
 
-                'return_matchdict' determines whether the dictionary containing
-                which patterns matched which stems or the list of stems is
-                returned.
+        'raise_unmatched' determines whether an exception will be
+        raised if any patterns didn't match any packages.
 
-                'universe' contains a list of tuples of publishers and package
-                names against which the patterns should be matched.
-                """
-                # avoid checking everywhere
-                if not patterns:
-                        return set()
+        'raise_not_installed' determines whether an exception will be
+        raised if any pattern matches a package that's not installed.
 
-                illegals      = []
-                nonmatch      = []
-                multimatch    = []
-                not_installed = []
-                multispec     = []
-                already_installed = []
+        'return_matchdict' determines whether the dictionary containing
+        which patterns matched which stems or the list of stems is
+        returned.
 
-                matchers = []
-                fmris    = []
-                pubs     = []
+        'universe' contains a list of tuples of publishers and package
+        names against which the patterns should be matched.
+        """
+        # avoid checking everywhere
+        if not patterns:
+            return set()
 
-                wildcard_patterns = set()
+        illegals = []
+        nonmatch = []
+        multimatch = []
+        not_installed = []
+        multispec = []
+        already_installed = []
 
-                # ignore dups
-                patterns = list(set(patterns))
+        matchers = []
+        fmris = []
+        pubs = []
 
-                # figure out which kind of matching rules to employ
-                seen = set()
-                npatterns = []
-                for pat in patterns:
-                        try:
-                                parts = pat.split("@", 1)
-                                pat_stem = parts[0]
+        wildcard_patterns = set()
 
-                                if "*" in pat_stem or "?" in pat_stem:
-                                        matcher = pkg.fmri.glob_match
-                                        wildcard_patterns.add(pat)
-                                elif pat_stem.startswith("pkg:/") or \
-                                    pat_stem.startswith("/"):
-                                        matcher = pkg.fmri.exact_name_match
-                                else:
-                                        matcher = pkg.fmri.fmri_match
+        # ignore dups
+        patterns = list(set(patterns))
 
-                                if matcher == pkg.fmri.glob_match:
-                                        fmri = pkg.fmri.MatchingPkgFmri(
-                                            pat_stem)
-                                else:
-                                        fmri = pkg.fmri.PkgFmri(pat_stem)
+        # figure out which kind of matching rules to employ
+        seen = set()
+        npatterns = []
+        for pat in patterns:
+            try:
+                parts = pat.split("@", 1)
+                pat_stem = parts[0]
 
-                                sfmri = str(fmri)
-                                if sfmri in seen:
-                                        # A different form of the same pattern
-                                        # was specified already; ignore this
-                                        # one (e.g. pkg:/network/ping,
-                                        # /network/ping).
-                                        wildcard_patterns.discard(pat)
-                                        continue
-
-                                seen.add(sfmri)
-                                npatterns.append(pat)
-                                matchers.append(matcher)
-                                pubs.append(fmri.publisher)
-                                fmris.append(fmri)
-                        except pkg.fmri.FmriError as e:
-                                illegals.append(e)
-                patterns = npatterns
-                del npatterns, seen
-
-                # Create a dictionary of patterns, with each value being a
-                # set of pkg names that match that pattern.
-                ret = dict(zip(patterns, [set() for i in patterns]))
-
-                if universe is not None:
-                        assert match_type == ImagePlan.MATCH_ALL
-                        pkg_names = universe
+                if "*" in pat_stem or "?" in pat_stem:
+                    matcher = pkg.fmri.glob_match
+                    wildcard_patterns.add(pat)
+                elif pat_stem.startswith("pkg:/") or pat_stem.startswith("/"):
+                    matcher = pkg.fmri.exact_name_match
                 else:
-                        if match_type != ImagePlan.MATCH_INST_VERSIONS:
-                                cat = image.get_catalog(image.IMG_CATALOG_KNOWN)
-                        else:
-                                cat = image.get_catalog(
-                                    image.IMG_CATALOG_INSTALLED)
-                        pkg_names = cat.pkg_names()
+                    matcher = pkg.fmri.fmri_match
 
-                # construct matches for each pattern
-                for pkg_pub, name in pkg_names:
-                        for pat, matcher, fmri, pub in \
-                            zip(patterns, matchers, fmris, pubs):
-                                if pub and pkg_pub != pub:
-                                        continue
-                                if matcher(name, fmri.pkg_name):
-                                        ret[pat].add(name)
-
-                matchdict = {}
-                for p in patterns:
-                        l = len(ret[p])
-                        if l == 0: # no matches at all
-                                nonmatch.append(p)
-                        elif l > 1 and p not in wildcard_patterns:
-                                # multiple matches
-                                multimatch.append((p, list(ret[p])))
-                        else:
-                                # single match or wildcard
-                                for k in ret[p]:
-                                        # for each matching package name
-                                        matchdict.setdefault(k, []).append(p)
-
-                for name in matchdict:
-                        if len(matchdict[name]) > 1:
-                                # different pats, same pkg
-                                multispec.append(tuple([name] +
-                                    matchdict[name]))
-
-                if match_type == ImagePlan.MATCH_INST_VERSIONS:
-                        not_installed, nonmatch = nonmatch, not_installed
-                elif match_type == ImagePlan.MATCH_UNINSTALLED:
-                        already_installed = [
-                            name
-                            for name in image.get_catalog(
-                            image.IMG_CATALOG_INSTALLED).names()
-                            if name in matchdict
-                        ]
-                if illegals or (raise_unmatched and nonmatch) or multimatch \
-                    or (not_installed and raise_not_installed) or multispec \
-                    or already_installed:
-                        raise api_errors.PlanCreationException(
-                            already_installed=already_installed,
-                            illegal=illegals,
-                            missing_matches=not_installed,
-                            multiple_matches=multimatch,
-                            multispec=multispec,
-                            unmatched_fmris=nonmatch)
-
-                if return_matchdict:
-                        return matchdict
-                return set(matchdict.keys())
-
-        @staticmethod
-        def __match_user_fmris(image, patterns, match_type,
-            pub_ranks=misc.EmptyDict, installed_pkgs=misc.EmptyDict,
-            raise_not_installed=True, reject_set=misc.EmptyI,
-            default_matcher=None):
-                """Given a user-specified list of patterns, return a dictionary
-                of matching fmris:
-
-                {pkgname: [fmri1, fmri2, ...]
-                 pkgname: [fmri1, fmri2, ...],
-                 ...
-                }
-
-                Constraint used is always AUTO as per expected UI behavior.
-
-                'match_type' indicates how matching should be restricted.  The
-                possible values are:
-
-                    MATCH_ALL
-                        Matching is performed using all known package stems
-                        and versions.  In this case, 'installed_pkgs' must also
-                        be provided.
-
-                    MATCH_INST_VERSIONS
-                        Matching is performed using only installed package
-                        stems and versions.
-
-                    MATCH_INST_STEMS
-                        Matching is performed using all known package versions
-                        for stems matching installed packages.  In this case,
-                        'installed_pkgs' must also be provided.
-
-
-                Note that patterns starting w/ pkg:/ require an exact match;
-                patterns containing '*' will using fnmatch rules; the default
-                trailing match rules are used for remaining patterns unless
-                'default_matcher' is specified.
-
-                'default_matcher' is an optional pkg.fmri.match_* method to
-                determine which matching rules should be applied to patterns
-                that do not use wildcards or start with 'pkg:/' or '/'.
-
-                Exactly duplicated patterns are ignored.
-
-                Routine raises PlanCreationException if errors occur: it is
-                illegal to specify multiple different patterns that match the
-                same pkg name unless exactly one of those patterns contained no
-                wildcards.  Only patterns that contain wildcards are allowed to
-                match multiple packages.
-
-                FMRI lists are trimmed by publisher, either by pattern
-                specification, installed version or publisher ranking (in that
-                order) when match_type is not MATCH_INST_VERSIONS.
-
-                'raise_not_installed' determines whether an exception will be
-                raised if any pattern matches a package that's not installed.
-
-                'reject_set' is a set() containing the stems of packages that
-                should be excluded from matches.
-                """
-
-                # problems we check for
-                illegals      = []
-                nonmatch      = []
-                multimatch    = []
-                not_installed = []
-                multispec     = []
-                exclpats      = []
-                wrongpub      = []
-                wrongvar      = set()
-
-                matchers = []
-                fmris    = []
-                pubs     = []
-                versions = []
-
-                wildcard_patterns = set()
-
-                renamed_fmris = defaultdict(set)
-                obsolete_fmris = []
-
-                # ignore dups
-                patterns = list(set(patterns))
-
-                installed_pubs = misc.EmptyDict
-                if match_type in [ImagePlan.MATCH_INST_STEMS,
-                    ImagePlan.MATCH_ALL]:
-                        # build installed publisher dictionary
-                        installed_pubs = dict((
-                            (f.pkg_name, f.get_publisher())
-                            for f in installed_pkgs.values()
-                        ))
-
-                # figure out which kind of matching rules to employ
-                latest_pats = set()
-                seen = set()
-                npatterns = []
-                for pat in patterns:
-                        try:
-                                parts = pat.split("@", 1)
-                                pat_stem = parts[0]
-                                pat_ver = None
-                                if len(parts) > 1:
-                                        pat_ver = parts[1]
-
-                                if "*" in pat_stem or "?" in pat_stem:
-                                        matcher = pkg.fmri.glob_match
-                                        wildcard_patterns.add(pat)
-                                elif pat_stem.startswith("pkg:/") or \
-                                    pat_stem.startswith("/"):
-                                        matcher = pkg.fmri.exact_name_match
-                                elif default_matcher:
-                                        matcher = default_matcher
-                                else:
-                                        matcher = pkg.fmri.fmri_match
-
-                                if matcher == pkg.fmri.glob_match:
-                                        fmri = pkg.fmri.MatchingPkgFmri(
-                                            pat_stem)
-                                else:
-                                        fmri = pkg.fmri.PkgFmri(
-                                            pat_stem)
-
-                                if not pat_ver:
-                                        # Do nothing.
-                                        pass
-                                elif "*" in pat_ver or "?" in pat_ver or \
-                                    pat_ver == "latest":
-                                        fmri.version = \
-                                            pkg.version.MatchingVersion(pat_ver)
-                                else:
-                                        fmri.version = \
-                                            pkg.version.Version(pat_ver)
-
-                                sfmri = str(fmri)
-                                if sfmri in seen:
-                                        # A different form of the same pattern
-                                        # was specified already; ignore this
-                                        # one (e.g. pkg:/network/ping,
-                                        # /network/ping).
-                                        wildcard_patterns.discard(pat)
-                                        continue
-
-                                seen.add(sfmri)
-                                npatterns.append(pat)
-                                if pat_ver and \
-                                    getattr(fmri.version, "match_latest", None):
-                                        latest_pats.add(pat)
-
-                                matchers.append(matcher)
-                                pubs.append(fmri.publisher)
-                                versions.append(fmri.version)
-                                fmris.append(fmri)
-
-                        except (pkg.fmri.FmriError,
-                            pkg.version.VersionError) as e:
-                                # illegals should be a list of fmri patterns so that
-                                # PackageMatchErrors can construct correct error message.
-                                illegals.append(pat)
-                patterns = npatterns
-                del npatterns, seen
-
-                # Create a dictionary of patterns, with each value being a
-                # dictionary of pkg names & fmris that match that pattern.
-                ret = dict(zip(patterns, [dict() for i in patterns]))
-
-                # Track patterns rejected due to user request (--reject).
-                rejected_pats = set()
-
-                # Track patterns rejected due to variants.
-                rejected_vars = set()
-
-                # keep track of publishers we reject due to implict selection
-                # of installed publisher to produce better error message.
-                rejected_pubs = {}
-
-                if match_type != ImagePlan.MATCH_INST_VERSIONS:
-                        cat = image.get_catalog(image.IMG_CATALOG_KNOWN)
-                        info_needed = [pkg.catalog.Catalog.DEPENDENCY]
+                if matcher == pkg.fmri.glob_match:
+                    fmri = pkg.fmri.MatchingPkgFmri(pat_stem)
                 else:
-                        cat = image.get_catalog(image.IMG_CATALOG_INSTALLED)
-                        info_needed = []
+                    fmri = pkg.fmri.PkgFmri(pat_stem)
 
-                variants = image.get_variants()
-                for name in cat.names():
-                        for pat, matcher, fmri, version, pub in \
-                            zip(patterns, matchers, fmris, versions, pubs):
-                                if not matcher(name, fmri.pkg_name):
-                                        continue # name doesn't match
-                                for ver, entries in cat.entries_by_version(name,
-                                    info_needed=info_needed):
-                                        if version and not ver.is_successor(version,
-                                            pkg.version.CONSTRAINT_AUTO):
-                                                continue # version doesn't match
-                                        for f, metadata in entries:
-                                                fpub = f.publisher
-                                                if pub and pub != fpub:
-                                                        continue # specified pubs conflict
-                                                elif match_type == ImagePlan.MATCH_INST_STEMS and \
-                                                    f.pkg_name not in installed_pkgs:
-                                                        # Matched stem is not
-                                                        # in list of installed
-                                                        # stems.
-                                                        continue
-                                                elif f.pkg_name in reject_set:
-                                                        # Pattern is excluded.
-                                                        rejected_pats.add(pat)
-                                                        continue
+                sfmri = str(fmri)
+                if sfmri in seen:
+                    # A different form of the same pattern
+                    # was specified already; ignore this
+                    # one (e.g. pkg:/network/ping,
+                    # /network/ping).
+                    wildcard_patterns.discard(pat)
+                    continue
 
-                                                states = metadata["metadata"]["states"]
-                                                ren_deps = []
-                                                omit_package = False
-                                                # Check for renamed packages and
-                                                # that the package matches the
-                                                # image's variants.
-                                                for astr in metadata.get("actions",
-                                                    misc.EmptyI):
-                                                        try:
-                                                                a = pkg.actions.fromstr(
-                                                                    astr)
-                                                        except pkg.actions.ActionError:
-                                                                # Unsupported or
-                                                                # invalid package;
-                                                                # drive on and
-                                                                # filter as much as
-                                                                # possible.  The
-                                                                # solver will reject
-                                                                # this package later.
-                                                                continue
+                seen.add(sfmri)
+                npatterns.append(pat)
+                matchers.append(matcher)
+                pubs.append(fmri.publisher)
+                fmris.append(fmri)
+            except pkg.fmri.FmriError as e:
+                illegals.append(e)
+        patterns = npatterns
+        del npatterns, seen
 
-                                                        if pkgdefs.PKG_STATE_RENAMED in states and \
-                                                            a.name == "depend" and \
-                                                            a.attrs["type"] == "require":
-                                                                ren_deps.append(pkg.fmri.PkgFmri(
-                                                                    a.attrs["fmri"]))
-                                                                continue
-                                                        elif a.name != "set":
-                                                                continue
+        # Create a dictionary of patterns, with each value being a
+        # set of pkg names that match that pattern.
+        ret = dict(zip(patterns, [set() for i in patterns]))
 
-                                                        atname = a.attrs["name"]
-                                                        if not atname.startswith("variant."):
-                                                                continue
+        if universe is not None:
+            assert match_type == ImagePlan.MATCH_ALL
+            pkg_names = universe
+        else:
+            if match_type != ImagePlan.MATCH_INST_VERSIONS:
+                cat = image.get_catalog(image.IMG_CATALOG_KNOWN)
+            else:
+                cat = image.get_catalog(image.IMG_CATALOG_INSTALLED)
+            pkg_names = cat.pkg_names()
 
-                                                        # For all variants set
-                                                        # in the image, elide
-                                                        # packages that are not
-                                                        # for a matching variant
-                                                        # value.
-                                                        atvalue = a.attrs["value"]
-                                                        is_list = type(atvalue) == list
-                                                        for vn, vv in six.iteritems(variants):
-                                                                if vn == atname and \
-                                                                    ((is_list and
-                                                                    vv not in atvalue) or \
-                                                                    (not is_list and
-                                                                    vv != atvalue)):
-                                                                        omit_package = True
-                                                                        break
+        # construct matches for each pattern
+        for pkg_pub, name in pkg_names:
+            for pat, matcher, fmri, pub in zip(patterns, matchers, fmris, pubs):
+                if pub and pkg_pub != pub:
+                    continue
+                if matcher(name, fmri.pkg_name):
+                    ret[pat].add(name)
 
-                                                if omit_package:
-                                                        # Package skipped due to
-                                                        # variant.
-                                                        rejected_vars.add(pat)
-                                                        continue
+        matchdict = {}
+        for p in patterns:
+            l = len(ret[p])
+            if l == 0:  # no matches at all
+                nonmatch.append(p)
+            elif l > 1 and p not in wildcard_patterns:
+                # multiple matches
+                multimatch.append((p, list(ret[p])))
+            else:
+                # single match or wildcard
+                for k in ret[p]:
+                    # for each matching package name
+                    matchdict.setdefault(k, []).append(p)
 
-                                                ret[pat].setdefault(f.pkg_name,
-                                                    []).append(f)
+        for name in matchdict:
+            if len(matchdict[name]) > 1:
+                # different pats, same pkg
+                multispec.append(tuple([name] + matchdict[name]))
 
-                                                if not pub and match_type != ImagePlan.MATCH_INST_VERSIONS and \
-                                                    name in installed_pubs and \
-                                                    pub_ranks[installed_pubs[name]][1] \
-                                                    == True and installed_pubs[name] != \
-                                                    fpub:
-                                                        # Fmri publisher
-                                                        # filtering is handled
-                                                        # later.
-                                                        rejected_pubs.setdefault(pat,
-                                                            set()).add(fpub)
+        if match_type == ImagePlan.MATCH_INST_VERSIONS:
+            not_installed, nonmatch = nonmatch, not_installed
+        elif match_type == ImagePlan.MATCH_UNINSTALLED:
+            already_installed = [
+                name
+                for name in image.get_catalog(
+                    image.IMG_CATALOG_INSTALLED
+                ).names()
+                if name in matchdict
+            ]
+        if (
+            illegals
+            or (raise_unmatched and nonmatch)
+            or multimatch
+            or (not_installed and raise_not_installed)
+            or multispec
+            or already_installed
+        ):
+            raise api_errors.PlanCreationException(
+                already_installed=already_installed,
+                illegal=illegals,
+                missing_matches=not_installed,
+                multiple_matches=multimatch,
+                multispec=multispec,
+                unmatched_fmris=nonmatch,
+            )
 
-                                                states = metadata["metadata"]["states"]
-                                                if pkgdefs.PKG_STATE_OBSOLETE in states:
-                                                        obsolete_fmris.append(f)
-                                                if pkgdefs.PKG_STATE_RENAMED in states:
-                                                        renamed_fmris[f] = ren_deps
+        if return_matchdict:
+            return matchdict
+        return set(matchdict.keys())
 
-                # remove multiple matches if all versions are obsolete
-                for p in patterns:
-                        if len(ret[p]) > 1 and p not in wildcard_patterns:
-                                # create dictionary of obsolete status vs
-                                # pkg_name
-                                obsolete = dict([
-                                    (pkg_name, reduce(operator.or_,
-                                    [f in obsolete_fmris for f in ret[p][pkg_name]]))
-                                    for pkg_name in ret[p]
-                                ])
-                                # remove all obsolete match if non-obsolete
-                                # match also exists
-                                if set([True, False]) == set(obsolete.values()):
-                                        for pkg_name in obsolete:
-                                                if obsolete[pkg_name]:
-                                                        del ret[p][pkg_name]
+    @staticmethod
+    def __match_user_fmris(
+        image,
+        patterns,
+        match_type,
+        pub_ranks=misc.EmptyDict,
+        installed_pkgs=misc.EmptyDict,
+        raise_not_installed=True,
+        reject_set=misc.EmptyI,
+        default_matcher=None,
+    ):
+        """Given a user-specified list of patterns, return a dictionary
+        of matching fmris:
 
-                # remove newer multiple match if renamed version exists
-                for p in patterns:
-                        if len(ret[p]) > 1 and p not in wildcard_patterns:
-                                renamed_matches = [
-                                    pfmri
-                                    for pkg_name in ret[p]
-                                    for pfmri in ret[p][pkg_name]
-                                    if pfmri in renamed_fmris
-                                    ]
-                                targets = set([
-                                    pf.pkg_name
-                                    for f in renamed_matches
-                                    for pf in renamed_fmris[f]
-                                ])
+        {pkgname: [fmri1, fmri2, ...]
+         pkgname: [fmri1, fmri2, ...],
+         ...
+        }
 
-                                for pkg_name in list(ret[p].keys()):
-                                        if pkg_name in targets:
-                                                del ret[p][pkg_name]
+        Constraint used is always AUTO as per expected UI behavior.
 
-                # Determine match failures.
-                # matchdict maps package stems to input patterns.
-                matchdict = {}
-                for p in patterns:
-                        l = len(ret[p])
-                        if l == 0: # no matches at all
-                                if p in rejected_vars:
-                                        wrongvar.add(p)
-                                elif p in rejected_pats:
-                                        exclpats.append(p)
-                                else:
-                                        nonmatch.append(p)
-                        elif l > 1 and p not in wildcard_patterns:
-                                # multiple matches
-                                multimatch.append((p, set([
-                                    f.get_pkg_stem()
-                                    for n in ret[p]
-                                    for f in ret[p][n]
-                                ])))
-                        else:
-                                # single match or wildcard
-                                for k, pfmris in six.iteritems(ret[p]):
-                                        # for each matching package name
-                                        matchdict.setdefault(k, []).append(
-                                            (p, pfmris))
+        'match_type' indicates how matching should be restricted.  The
+        possible values are:
 
-                proposed_dict = {}
-                for name, lst in six.iteritems(matchdict):
-                        nwc_ps = [
-                            (p, set(pfmris))
-                            for p, pfmris in lst
-                            if p not in wildcard_patterns
-                        ]
-                        pub_named = False
-                        # If there are any non-wildcarded patterns that match
-                        # this package name, prefer the fmris they selected over
-                        # any the wildcarded patterns selected.
-                        if nwc_ps:
-                                rel_ps = nwc_ps
-                                # Remove the wildcarded patterns that match this
-                                # package from the result dictionary.
-                                for p, pfmris in lst:
-                                        if p not in wildcard_patterns:
-                                                if p.startswith("pkg://") or \
-                                                    p.startswith("//"):
-                                                        pub_named = True
-                                                        break
-                        else:
-                                tmp_ps = [
-                                    (p, set(pfmris))
-                                    for p, pfmris in lst
-                                    if p in wildcard_patterns
-                                ]
-                                # If wildcarded package names then compare
-                                # patterns to see if any specify a particular
-                                # publisher.  If they do, prefer the package
-                                # from that publisher.
-                                rel_ps = [
-                                    (p, set(pfmris))
-                                    for p, pfmris in tmp_ps
-                                    if p.startswith("pkg://") or
-                                    p.startswith("//")
-                                ]
-                                if rel_ps:
-                                        pub_named = True
-                                else:
-                                        rel_ps = tmp_ps
+            MATCH_ALL
+                Matching is performed using all known package stems
+                and versions.  In this case, 'installed_pkgs' must also
+                be provided.
 
-                        # Find the intersection of versions which matched all
-                        # the relevant patterns.
-                        common_pfmris = rel_ps[0][1]
-                        for p, vs in rel_ps[1:]:
-                                common_pfmris &= vs
-                        # If none of the patterns specified a particular
-                        # publisher and the package in question is installed
-                        # from a sticky publisher, then remove all pfmris which
-                        # have a different publisher.
-                        inst_pub = installed_pubs.get(name)
-                        stripped_by_publisher = False
-                        if not pub_named and common_pfmris and \
-                            match_type != ImagePlan.MATCH_INST_VERSIONS and \
-                            inst_pub and pub_ranks[inst_pub][1] == True:
-                                common_pfmris = set(
-                                    p for p in common_pfmris
-                                    if p.publisher == inst_pub
+            MATCH_INST_VERSIONS
+                Matching is performed using only installed package
+                stems and versions.
+
+            MATCH_INST_STEMS
+                Matching is performed using all known package versions
+                for stems matching installed packages.  In this case,
+                'installed_pkgs' must also be provided.
+
+
+        Note that patterns starting w/ pkg:/ require an exact match;
+        patterns containing '*' will using fnmatch rules; the default
+        trailing match rules are used for remaining patterns unless
+        'default_matcher' is specified.
+
+        'default_matcher' is an optional pkg.fmri.match_* method to
+        determine which matching rules should be applied to patterns
+        that do not use wildcards or start with 'pkg:/' or '/'.
+
+        Exactly duplicated patterns are ignored.
+
+        Routine raises PlanCreationException if errors occur: it is
+        illegal to specify multiple different patterns that match the
+        same pkg name unless exactly one of those patterns contained no
+        wildcards.  Only patterns that contain wildcards are allowed to
+        match multiple packages.
+
+        FMRI lists are trimmed by publisher, either by pattern
+        specification, installed version or publisher ranking (in that
+        order) when match_type is not MATCH_INST_VERSIONS.
+
+        'raise_not_installed' determines whether an exception will be
+        raised if any pattern matches a package that's not installed.
+
+        'reject_set' is a set() containing the stems of packages that
+        should be excluded from matches.
+        """
+
+        # problems we check for
+        illegals = []
+        nonmatch = []
+        multimatch = []
+        not_installed = []
+        multispec = []
+        exclpats = []
+        wrongpub = []
+        wrongvar = set()
+
+        matchers = []
+        fmris = []
+        pubs = []
+        versions = []
+
+        wildcard_patterns = set()
+
+        renamed_fmris = defaultdict(set)
+        obsolete_fmris = []
+
+        # ignore dups
+        patterns = list(set(patterns))
+
+        installed_pubs = misc.EmptyDict
+        if match_type in [ImagePlan.MATCH_INST_STEMS, ImagePlan.MATCH_ALL]:
+            # build installed publisher dictionary
+            installed_pubs = dict(
+                (
+                    (f.pkg_name, f.get_publisher())
+                    for f in installed_pkgs.values()
+                )
+            )
+
+        # figure out which kind of matching rules to employ
+        latest_pats = set()
+        seen = set()
+        npatterns = []
+        for pat in patterns:
+            try:
+                parts = pat.split("@", 1)
+                pat_stem = parts[0]
+                pat_ver = None
+                if len(parts) > 1:
+                    pat_ver = parts[1]
+
+                if "*" in pat_stem or "?" in pat_stem:
+                    matcher = pkg.fmri.glob_match
+                    wildcard_patterns.add(pat)
+                elif pat_stem.startswith("pkg:/") or pat_stem.startswith("/"):
+                    matcher = pkg.fmri.exact_name_match
+                elif default_matcher:
+                    matcher = default_matcher
+                else:
+                    matcher = pkg.fmri.fmri_match
+
+                if matcher == pkg.fmri.glob_match:
+                    fmri = pkg.fmri.MatchingPkgFmri(pat_stem)
+                else:
+                    fmri = pkg.fmri.PkgFmri(pat_stem)
+
+                if not pat_ver:
+                    # Do nothing.
+                    pass
+                elif "*" in pat_ver or "?" in pat_ver or pat_ver == "latest":
+                    fmri.version = pkg.version.MatchingVersion(pat_ver)
+                else:
+                    fmri.version = pkg.version.Version(pat_ver)
+
+                sfmri = str(fmri)
+                if sfmri in seen:
+                    # A different form of the same pattern
+                    # was specified already; ignore this
+                    # one (e.g. pkg:/network/ping,
+                    # /network/ping).
+                    wildcard_patterns.discard(pat)
+                    continue
+
+                seen.add(sfmri)
+                npatterns.append(pat)
+                if pat_ver and getattr(fmri.version, "match_latest", None):
+                    latest_pats.add(pat)
+
+                matchers.append(matcher)
+                pubs.append(fmri.publisher)
+                versions.append(fmri.version)
+                fmris.append(fmri)
+
+            except (pkg.fmri.FmriError, pkg.version.VersionError) as e:
+                # illegals should be a list of fmri patterns so that
+                # PackageMatchErrors can construct correct error message.
+                illegals.append(pat)
+        patterns = npatterns
+        del npatterns, seen
+
+        # Create a dictionary of patterns, with each value being a
+        # dictionary of pkg names & fmris that match that pattern.
+        ret = dict(zip(patterns, [dict() for i in patterns]))
+
+        # Track patterns rejected due to user request (--reject).
+        rejected_pats = set()
+
+        # Track patterns rejected due to variants.
+        rejected_vars = set()
+
+        # keep track of publishers we reject due to implict selection
+        # of installed publisher to produce better error message.
+        rejected_pubs = {}
+
+        if match_type != ImagePlan.MATCH_INST_VERSIONS:
+            cat = image.get_catalog(image.IMG_CATALOG_KNOWN)
+            info_needed = [pkg.catalog.Catalog.DEPENDENCY]
+        else:
+            cat = image.get_catalog(image.IMG_CATALOG_INSTALLED)
+            info_needed = []
+
+        variants = image.get_variants()
+        for name in cat.names():
+            for pat, matcher, fmri, version, pub in zip(
+                patterns, matchers, fmris, versions, pubs
+            ):
+                if not matcher(name, fmri.pkg_name):
+                    continue  # name doesn't match
+                for ver, entries in cat.entries_by_version(
+                    name, info_needed=info_needed
+                ):
+                    if version and not ver.is_successor(
+                        version, pkg.version.CONSTRAINT_AUTO
+                    ):
+                        continue  # version doesn't match
+                    for f, metadata in entries:
+                        fpub = f.publisher
+                        if pub and pub != fpub:
+                            continue  # specified pubs conflict
+                        elif (
+                            match_type == ImagePlan.MATCH_INST_STEMS
+                            and f.pkg_name not in installed_pkgs
+                        ):
+                            # Matched stem is not
+                            # in list of installed
+                            # stems.
+                            continue
+                        elif f.pkg_name in reject_set:
+                            # Pattern is excluded.
+                            rejected_pats.add(pat)
+                            continue
+
+                        states = metadata["metadata"]["states"]
+                        ren_deps = []
+                        omit_package = False
+                        # Check for renamed packages and
+                        # that the package matches the
+                        # image's variants.
+                        for astr in metadata.get("actions", misc.EmptyI):
+                            try:
+                                a = pkg.actions.fromstr(astr)
+                            except pkg.actions.ActionError:
+                                # Unsupported or
+                                # invalid package;
+                                # drive on and
+                                # filter as much as
+                                # possible.  The
+                                # solver will reject
+                                # this package later.
+                                continue
+
+                            if (
+                                pkgdefs.PKG_STATE_RENAMED in states
+                                and a.name == "depend"
+                                and a.attrs["type"] == "require"
+                            ):
+                                ren_deps.append(
+                                    pkg.fmri.PkgFmri(a.attrs["fmri"])
                                 )
-                                stripped_by_publisher = True
-                        if common_pfmris:
-                                # The solver depends on these being in sorted
-                                # order.
-                                proposed_dict[name] = sorted(common_pfmris)
-                        elif stripped_by_publisher:
-                                for p, vs in rel_ps:
-                                        wrongpub.append((p, rejected_pubs[p]))
-                        else:
-                                multispec.append(tuple([name] +
-                                    [p for p, vs in rel_ps]))
+                                continue
+                            elif a.name != "set":
+                                continue
 
-                if match_type != ImagePlan.MATCH_ALL:
-                        not_installed, nonmatch = nonmatch, not_installed
+                            atname = a.attrs["name"]
+                            if not atname.startswith("variant."):
+                                continue
 
-                if illegals or nonmatch or multimatch or \
-                    (not_installed and raise_not_installed) or multispec or \
-                    wrongpub or wrongvar or exclpats:
-                        if not raise_not_installed:
-                                not_installed = []
-                        raise api_errors.PlanCreationException(
-                            unmatched_fmris=nonmatch,
-                            multiple_matches=multimatch, illegal=illegals,
-                            missing_matches=not_installed, multispec=multispec,
-                            wrong_publishers=wrongpub, wrong_variants=wrongvar,
-                            rejected_pats=exclpats)
+                            # For all variants set
+                            # in the image, elide
+                            # packages that are not
+                            # for a matching variant
+                            # value.
+                            atvalue = a.attrs["value"]
+                            is_list = type(atvalue) == list
+                            for vn, vv in six.iteritems(variants):
+                                if vn == atname and (
+                                    (is_list and vv not in atvalue)
+                                    or (not is_list and vv != atvalue)
+                                ):
+                                    omit_package = True
+                                    break
 
-                # eliminate lower ranked publishers
-                if match_type != ImagePlan.MATCH_INST_VERSIONS:
-                        # no point for installed pkgs....
-                        for pkg_name in proposed_dict:
-                                pubs_found = set([
-                                    f.publisher
-                                    for f in proposed_dict[pkg_name]
-                                ])
-                                # 1000 is hack for installed but unconfigured
-                                # publishers
-                                best_pub = sorted([
-                                    (pub_ranks.get(p, (1000, True))[0], p)
-                                    for p in pubs_found
-                                ])[0][1]
+                        if omit_package:
+                            # Package skipped due to
+                            # variant.
+                            rejected_vars.add(pat)
+                            continue
 
-                                # Include any installed FMRIs that were allowed
-                                # by all of the previous filtering, even if they
-                                # aren't from the "best" available publisher, to
-                                # account for the scenario where the installed
-                                # version is the newest or best version for the
-                                # plan solution.  While doing so, also eliminate
-                                # any exact duplicate FMRIs from publishers
-                                # other than the installed publisher to prevent
-                                # thrashing in the solver due to many equiv.
-                                # solutions and unexpected changes in package
-                                # publishers that weren't explicitly requested.
-                                inst_f = installed_pkgs.get(f.pkg_name, None)
-                                inst_v = None
-                                if inst_f not in proposed_dict[pkg_name]:
-                                        # Should only apply if it's part of the
-                                        # proposed set.
-                                        inst_f = None
-                                else:
-                                        inst_v = inst_f.version
+                        ret[pat].setdefault(f.pkg_name, []).append(f)
 
-                                proposed_dict[pkg_name] = [
-                                    f for f in proposed_dict[pkg_name]
-                                    if f == inst_f or \
-                                        (f.publisher == best_pub and
-                                        f.version != inst_v)
-                                ]
+                        if (
+                            not pub
+                            and match_type != ImagePlan.MATCH_INST_VERSIONS
+                            and name in installed_pubs
+                            and pub_ranks[installed_pubs[name]][1] == True
+                            and installed_pubs[name] != fpub
+                        ):
+                            # Fmri publisher
+                            # filtering is handled
+                            # later.
+                            rejected_pubs.setdefault(pat, set()).add(fpub)
 
-                # construct references so that we can know which pattern
-                # generated which fmris...
-                references = dict([
+                        states = metadata["metadata"]["states"]
+                        if pkgdefs.PKG_STATE_OBSOLETE in states:
+                            obsolete_fmris.append(f)
+                        if pkgdefs.PKG_STATE_RENAMED in states:
+                            renamed_fmris[f] = ren_deps
+
+        # remove multiple matches if all versions are obsolete
+        for p in patterns:
+            if len(ret[p]) > 1 and p not in wildcard_patterns:
+                # create dictionary of obsolete status vs
+                # pkg_name
+                obsolete = dict(
+                    [
+                        (
+                            pkg_name,
+                            reduce(
+                                operator.or_,
+                                [f in obsolete_fmris for f in ret[p][pkg_name]],
+                            ),
+                        )
+                        for pkg_name in ret[p]
+                    ]
+                )
+                # remove all obsolete match if non-obsolete
+                # match also exists
+                if set([True, False]) == set(obsolete.values()):
+                    for pkg_name in obsolete:
+                        if obsolete[pkg_name]:
+                            del ret[p][pkg_name]
+
+        # remove newer multiple match if renamed version exists
+        for p in patterns:
+            if len(ret[p]) > 1 and p not in wildcard_patterns:
+                renamed_matches = [
+                    pfmri
+                    for pkg_name in ret[p]
+                    for pfmri in ret[p][pkg_name]
+                    if pfmri in renamed_fmris
+                ]
+                targets = set(
+                    [
+                        pf.pkg_name
+                        for f in renamed_matches
+                        for pf in renamed_fmris[f]
+                    ]
+                )
+
+                for pkg_name in list(ret[p].keys()):
+                    if pkg_name in targets:
+                        del ret[p][pkg_name]
+
+        # Determine match failures.
+        # matchdict maps package stems to input patterns.
+        matchdict = {}
+        for p in patterns:
+            l = len(ret[p])
+            if l == 0:  # no matches at all
+                if p in rejected_vars:
+                    wrongvar.add(p)
+                elif p in rejected_pats:
+                    exclpats.append(p)
+                else:
+                    nonmatch.append(p)
+            elif l > 1 and p not in wildcard_patterns:
+                # multiple matches
+                multimatch.append(
+                    (
+                        p,
+                        set(
+                            [
+                                f.get_pkg_stem()
+                                for n in ret[p]
+                                for f in ret[p][n]
+                            ]
+                        ),
+                    )
+                )
+            else:
+                # single match or wildcard
+                for k, pfmris in six.iteritems(ret[p]):
+                    # for each matching package name
+                    matchdict.setdefault(k, []).append((p, pfmris))
+
+        proposed_dict = {}
+        for name, lst in six.iteritems(matchdict):
+            nwc_ps = [
+                (p, set(pfmris))
+                for p, pfmris in lst
+                if p not in wildcard_patterns
+            ]
+            pub_named = False
+            # If there are any non-wildcarded patterns that match
+            # this package name, prefer the fmris they selected over
+            # any the wildcarded patterns selected.
+            if nwc_ps:
+                rel_ps = nwc_ps
+                # Remove the wildcarded patterns that match this
+                # package from the result dictionary.
+                for p, pfmris in lst:
+                    if p not in wildcard_patterns:
+                        if p.startswith("pkg://") or p.startswith("//"):
+                            pub_named = True
+                            break
+            else:
+                tmp_ps = [
+                    (p, set(pfmris))
+                    for p, pfmris in lst
+                    if p in wildcard_patterns
+                ]
+                # If wildcarded package names then compare
+                # patterns to see if any specify a particular
+                # publisher.  If they do, prefer the package
+                # from that publisher.
+                rel_ps = [
+                    (p, set(pfmris))
+                    for p, pfmris in tmp_ps
+                    if p.startswith("pkg://") or p.startswith("//")
+                ]
+                if rel_ps:
+                    pub_named = True
+                else:
+                    rel_ps = tmp_ps
+
+            # Find the intersection of versions which matched all
+            # the relevant patterns.
+            common_pfmris = rel_ps[0][1]
+            for p, vs in rel_ps[1:]:
+                common_pfmris &= vs
+            # If none of the patterns specified a particular
+            # publisher and the package in question is installed
+            # from a sticky publisher, then remove all pfmris which
+            # have a different publisher.
+            inst_pub = installed_pubs.get(name)
+            stripped_by_publisher = False
+            if (
+                not pub_named
+                and common_pfmris
+                and match_type != ImagePlan.MATCH_INST_VERSIONS
+                and inst_pub
+                and pub_ranks[inst_pub][1] == True
+            ):
+                common_pfmris = set(
+                    p for p in common_pfmris if p.publisher == inst_pub
+                )
+                stripped_by_publisher = True
+            if common_pfmris:
+                # The solver depends on these being in sorted
+                # order.
+                proposed_dict[name] = sorted(common_pfmris)
+            elif stripped_by_publisher:
+                for p, vs in rel_ps:
+                    wrongpub.append((p, rejected_pubs[p]))
+            else:
+                multispec.append(tuple([name] + [p for p, vs in rel_ps]))
+
+        if match_type != ImagePlan.MATCH_ALL:
+            not_installed, nonmatch = nonmatch, not_installed
+
+        if (
+            illegals
+            or nonmatch
+            or multimatch
+            or (not_installed and raise_not_installed)
+            or multispec
+            or wrongpub
+            or wrongvar
+            or exclpats
+        ):
+            if not raise_not_installed:
+                not_installed = []
+            raise api_errors.PlanCreationException(
+                unmatched_fmris=nonmatch,
+                multiple_matches=multimatch,
+                illegal=illegals,
+                missing_matches=not_installed,
+                multispec=multispec,
+                wrong_publishers=wrongpub,
+                wrong_variants=wrongvar,
+                rejected_pats=exclpats,
+            )
+
+        # eliminate lower ranked publishers
+        if match_type != ImagePlan.MATCH_INST_VERSIONS:
+            # no point for installed pkgs....
+            for pkg_name in proposed_dict:
+                pubs_found = set([f.publisher for f in proposed_dict[pkg_name]])
+                # 1000 is hack for installed but unconfigured
+                # publishers
+                best_pub = sorted(
+                    [(pub_ranks.get(p, (1000, True))[0], p) for p in pubs_found]
+                )[0][1]
+
+                # Include any installed FMRIs that were allowed
+                # by all of the previous filtering, even if they
+                # aren't from the "best" available publisher, to
+                # account for the scenario where the installed
+                # version is the newest or best version for the
+                # plan solution.  While doing so, also eliminate
+                # any exact duplicate FMRIs from publishers
+                # other than the installed publisher to prevent
+                # thrashing in the solver due to many equiv.
+                # solutions and unexpected changes in package
+                # publishers that weren't explicitly requested.
+                inst_f = installed_pkgs.get(f.pkg_name, None)
+                inst_v = None
+                if inst_f not in proposed_dict[pkg_name]:
+                    # Should only apply if it's part of the
+                    # proposed set.
+                    inst_f = None
+                else:
+                    inst_v = inst_f.version
+
+                proposed_dict[pkg_name] = [
+                    f
+                    for f in proposed_dict[pkg_name]
+                    if f == inst_f
+                    or (f.publisher == best_pub and f.version != inst_v)
+                ]
+
+        # construct references so that we can know which pattern
+        # generated which fmris...
+        references = dict(
+            [
+                (f, p)
+                for p in ret.keys()
+                for flist in ret[p].values()
+                for f in flist
+                if f in proposed_dict[f.pkg_name]
+            ]
+        )
+
+        # Discard all but the newest version of each match.
+        if latest_pats:
+            # Rebuild proposed_dict based on latest version of every
+            # package.
+            sort_key = operator.attrgetter("version")
+            for pname, flist in six.iteritems(proposed_dict):
+                # Must sort on version; sorting by FMRI would
+                # sort by publisher, then by version which is
+                # not desirable.
+                platest = sorted(flist, key=sort_key)[-1]
+                if references[platest] not in latest_pats:
+                    # Nothing to do.
+                    continue
+
+                # Filter out all versions except the latest for
+                # each matching package.  Allow for multiple
+                # FMRIs of the same latest version.  (There
+                # might be more than one publisher with the
+                # same version.)
+                proposed_dict[pname] = [
+                    f for f in flist if f.version == platest.version
+                ]
+
+            # Construct references again to match final state
+            # of proposed_dict.
+            references = dict(
+                [
                     (f, p)
                     for p in ret.keys()
                     for flist in ret[p].values()
                     for f in flist
                     if f in proposed_dict[f.pkg_name]
-                ])
+                ]
+            )
 
-                # Discard all but the newest version of each match.
-                if latest_pats:
-                        # Rebuild proposed_dict based on latest version of every
-                        # package.
-                        sort_key = operator.attrgetter("version")
-                        for pname, flist in six.iteritems(proposed_dict):
-                                # Must sort on version; sorting by FMRI would
-                                # sort by publisher, then by version which is
-                                # not desirable.
-                                platest = sorted(flist, key=sort_key)[-1]
-                                if references[platest] not in latest_pats:
-                                        # Nothing to do.
-                                        continue
+        return proposed_dict, references
 
-                                # Filter out all versions except the latest for
-                                # each matching package.  Allow for multiple
-                                # FMRIs of the same latest version.  (There
-                                # might be more than one publisher with the
-                                # same version.)
-                                proposed_dict[pname] = [
-                                    f for f in flist
-                                    if f.version == platest.version
-                                ]
+    @staticmethod
+    def freeze_pkgs_match(image, pats):
+        """Find the packages which match the given patterns and thus
+        should be frozen."""
 
-                        # Construct references again to match final state
-                        # of proposed_dict.
-                        references = dict([
-                            (f, p)
-                            for p in ret.keys()
-                            for flist in ret[p].values()
-                            for f in flist
-                            if f in proposed_dict[f.pkg_name]
-                        ])
+        pats = set(pats)
+        freezes = set()
+        pub_ranks = image.get_publisher_ranks()
+        installed_version_mismatches = {}
+        versionless_uninstalled = set()
+        multiversions = []
 
-                return proposed_dict, references
+        # Find the installed packages that match the provided patterns.
+        inst_dict, references = ImagePlan.__match_user_fmris(
+            image,
+            pats,
+            ImagePlan.MATCH_INST_VERSIONS,
+            pub_ranks=pub_ranks,
+            raise_not_installed=False,
+        )
 
-        @staticmethod
-        def freeze_pkgs_match(image, pats):
-                """Find the packages which match the given patterns and thus
-                should be frozen."""
+        # Find the installed package stems that match the provided
+        # patterns.
+        installed_stems_dict = ImagePlan.match_user_stems(
+            image,
+            pats,
+            ImagePlan.MATCH_INST_VERSIONS,
+            raise_unmatched=False,
+            raise_not_installed=False,
+            return_matchdict=True,
+        )
 
-                pats = set(pats)
-                freezes = set()
-                pub_ranks = image.get_publisher_ranks()
-                installed_version_mismatches = {}
-                versionless_uninstalled = set()
-                multiversions = []
+        stems_of_fmri_matches = set(inst_dict.keys())
+        stems_of_stems_matches = set(installed_stems_dict.keys())
 
-                # Find the installed packages that match the provided patterns.
-                inst_dict, references = ImagePlan.__match_user_fmris(image,
-                    pats, ImagePlan.MATCH_INST_VERSIONS, pub_ranks=pub_ranks,
-                    raise_not_installed=False)
+        assert stems_of_fmri_matches.issubset(stems_of_stems_matches)
 
-                # Find the installed package stems that match the provided
-                # patterns.
-                installed_stems_dict = ImagePlan.match_user_stems(image, pats,
-                    ImagePlan.MATCH_INST_VERSIONS, raise_unmatched=False,
-                    raise_not_installed=False, return_matchdict=True)
+        # For each package stem which matched a pattern only when
+        # versions were ignored ...
+        for stem in stems_of_stems_matches - stems_of_fmri_matches:
+            # If more than one pattern matched this stem, then
+            # match_user_stems should've raised an exception.
+            assert len(installed_stems_dict[stem]) == 1
+            bad_pat = installed_stems_dict[stem][0]
+            installed_version_mismatches.setdefault(bad_pat, []).append(stem)
+            # If this pattern is bad, then we don't care about it
+            # anymore.
+            pats.discard(bad_pat)
 
-                stems_of_fmri_matches = set(inst_dict.keys())
-                stems_of_stems_matches = set(installed_stems_dict.keys())
+        # For each fmri, pattern where the pattern matched the fmri
+        # including the version ...
+        for full_fmri, pat in six.iteritems(references):
+            parts = pat.split("@", 1)
+            # If the pattern doesn't include a version, then add the
+            # version the package is installed at to the list of
+            # things to freeze.  If it does include a version, then
+            # just freeze using the version from the pattern, and
+            # the name from the matching fmri.
+            if len(parts) < 2 or parts[1] == "":
+                freezes.add(
+                    full_fmri.get_fmri(anarchy=True, include_scheme=False)
+                )
+            else:
+                freezes.add(full_fmri.pkg_name + "@" + parts[1])
+            # We're done with this pattern now.
+            pats.discard(pat)
 
-                assert stems_of_fmri_matches.issubset(stems_of_stems_matches)
+        # Any wildcarded patterns remaining matched no installed
+        # packages and so are invalid arguments to freeze.
+        unmatched_wildcards = set(
+            [pat for pat in pats if "*" in pat or "?" in pat]
+        )
+        pats -= unmatched_wildcards
 
-                # For each package stem which matched a pattern only when
-                # versions were ignored ...
-                for stem in stems_of_stems_matches - stems_of_fmri_matches:
-                        # If more than one pattern matched this stem, then
-                        # match_user_stems should've raised an exception.
-                        assert len(installed_stems_dict[stem]) == 1
-                        bad_pat = installed_stems_dict[stem][0]
-                        installed_version_mismatches.setdefault(
-                            bad_pat, []).append(stem)
-                        # If this pattern is bad, then we don't care about it
-                        # anymore.
-                        pats.discard(bad_pat)
+        # Now check the remaining pats to ensure they have a version
+        # component.  If they don't, then they can't be used to freeze
+        # uninstalled packages.
+        for pat in pats:
+            parts = pat.split("@", 1)
+            if len(parts) < 2 or parts[1] == "":
+                versionless_uninstalled.add(pat)
+        pats -= versionless_uninstalled
+        freezes |= pats
 
-                # For each fmri, pattern where the pattern matched the fmri
-                # including the version ...
-                for full_fmri, pat in six.iteritems(references):
-                        parts = pat.split("@", 1)
-                        # If the pattern doesn't include a version, then add the
-                        # version the package is installed at to the list of
-                        # things to freeze.  If it does include a version, then
-                        # just freeze using the version from the pattern, and
-                        # the name from the matching fmri.
-                        if len(parts) < 2 or parts[1] == "":
-                                freezes.add(full_fmri.get_fmri(anarchy=True,
-                                    include_scheme=False))
-                        else:
-                                freezes.add(full_fmri.pkg_name + "@" + parts[1])
-                        # We're done with this pattern now.
-                        pats.discard(pat)
+        stems = {}
+        for p in freezes:
+            stems.setdefault(
+                pkg.fmri.PkgFmri(p).get_pkg_stem(
+                    anarchy=True, include_scheme=False
+                ),
+                set(),
+            ).add(p)
+        # Check whether one stem has been frozen at non-identical
+        # versions.
+        for k, v in six.iteritems(stems):
+            if len(v) > 1:
+                multiversions.append((k, v))
+            else:
+                stems[k] = v.pop()
 
-                # Any wildcarded patterns remaining matched no installed
-                # packages and so are invalid arguments to freeze.
-                unmatched_wildcards = set([
-                    pat for pat in pats if "*" in pat or "?" in pat
-                ])
-                pats -= unmatched_wildcards
+        if (
+            versionless_uninstalled
+            or unmatched_wildcards
+            or installed_version_mismatches
+            or multiversions
+        ):
+            raise api_errors.FreezePkgsException(
+                multiversions=multiversions,
+                unmatched_wildcards=unmatched_wildcards,
+                version_mismatch=installed_version_mismatches,
+                versionless_uninstalled=versionless_uninstalled,
+            )
+        return stems
 
-                # Now check the remaining pats to ensure they have a version
-                # component.  If they don't, then they can't be used to freeze
-                # uninstalled packages.
-                for pat in pats:
-                        parts = pat.split("@", 1)
-                        if len(parts) < 2 or parts[1] == "":
-                                versionless_uninstalled.add(pat)
-                pats -= versionless_uninstalled
-                freezes |= pats
-
-                stems = {}
-                for p in freezes:
-                        stems.setdefault(pkg.fmri.PkgFmri(p).get_pkg_stem(
-                            anarchy=True, include_scheme=False), set()).add(p)
-                # Check whether one stem has been frozen at non-identical
-                # versions.
-                for k, v in six.iteritems(stems):
-                        if len(v) > 1:
-                                multiversions.append((k, v))
-                        else:
-                                stems[k] = v.pop()
-
-                if versionless_uninstalled or unmatched_wildcards or \
-                    installed_version_mismatches or multiversions:
-                        raise api_errors.FreezePkgsException(
-                            multiversions=multiversions,
-                            unmatched_wildcards=unmatched_wildcards,
-                            version_mismatch=installed_version_mismatches,
-                            versionless_uninstalled=versionless_uninstalled)
-                return stems
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/imagetypes.py
+++ b/src/modules/client/imagetypes.py
@@ -32,9 +32,9 @@ img_type_names = {
     IMG_NONE: "none",
     IMG_ENTIRE: "full",
     IMG_PARTIAL: "partial",
-    IMG_USER: "user"
+    IMG_USER: "user",
 }
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/indexer.py
+++ b/src/modules/client/indexer.py
@@ -34,39 +34,55 @@ import pkg.indexer as indexer
 import pkg.search_storage as ss
 from pkg.misc import EmptyI
 
+
 class Indexer(indexer.Indexer):
-        def __init__(self, image, get_manf_func, get_manifest_path,
-            progtrack=None, excludes=EmptyI):
-                indexer.Indexer.__init__(self, image.index_dir, get_manf_func,
-                    get_manifest_path, progtrack, excludes)
-                self.image = image
-                self._data_dict['full_fmri_hash'] = \
-                    ss.IndexStoreSetHash('full_fmri_list.hash')
-                self._data_full_fmri_hash = self._data_dict['full_fmri_hash']
+    def __init__(
+        self,
+        image,
+        get_manf_func,
+        get_manifest_path,
+        progtrack=None,
+        excludes=EmptyI,
+    ):
+        indexer.Indexer.__init__(
+            self,
+            image.index_dir,
+            get_manf_func,
+            get_manifest_path,
+            progtrack,
+            excludes,
+        )
+        self.image = image
+        self._data_dict["full_fmri_hash"] = ss.IndexStoreSetHash(
+            "full_fmri_list.hash"
+        )
+        self._data_full_fmri_hash = self._data_dict["full_fmri_hash"]
 
-        def _write_assistant_dicts(self, out_dir):
-                """Gives the full_fmri hash object the data it needs before
-                the superclass is called to write out the dictionaries.
-                """
-                self._data_full_fmri_hash.set_hash(
-                    self._data_full_fmri.get_set())
-                indexer.Indexer._write_assistant_dicts(self, out_dir)
+    def _write_assistant_dicts(self, out_dir):
+        """Gives the full_fmri hash object the data it needs before
+        the superclass is called to write out the dictionaries.
+        """
+        self._data_full_fmri_hash.set_hash(self._data_full_fmri.get_set())
+        indexer.Indexer._write_assistant_dicts(self, out_dir)
 
-        def check_index_has_exactly_fmris(self, fmri_names):
-                """Checks to see if the fmris given are the ones indexed.
-                """
-                try:
-                        res = \
-                            ss.consistent_open(self._data_dict.values(),
-                                self._index_dir, self._file_timeout_secs)
-                        if res is not None and \
-                            not self._data_full_fmri_hash.check_against_file(
-                            fmri_names):
-                                res = None
-                finally:
-                        for d in self._data_dict.values():
-                                d.close_file_handle()
-                return res is not None
+    def check_index_has_exactly_fmris(self, fmri_names):
+        """Checks to see if the fmris given are the ones indexed."""
+        try:
+            res = ss.consistent_open(
+                self._data_dict.values(),
+                self._index_dir,
+                self._file_timeout_secs,
+            )
+            if (
+                res is not None
+                and not self._data_full_fmri_hash.check_against_file(fmri_names)
+            ):
+                res = None
+        finally:
+            for d in self._data_dict.values():
+                d.close_file_handle()
+        return res is not None
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/linkedimage/__init__.py
+++ b/src/modules/client/linkedimage/__init__.py
@@ -36,10 +36,10 @@ modules are supported below.
 import inspect
 
 # import linked image common code
-from pkg.client.linkedimage.common import * # pylint: disable=W0401, W0622
+from pkg.client.linkedimage.common import *  # pylint: disable=W0401, W0622
 
 # names of linked image plugins
-p_types = [ "zone", "system" ]
+p_types = ["zone", "system"]
 
 # map of plugin names to their associated LinkedImagePlugin derived class
 p_classes = {}
@@ -52,29 +52,33 @@ _modname = _module = _nvlist = _classes = _i = None
 
 # initialize p_classes and p_classes_child
 for _modname in p_types:
-        _module = __import__("{0}.{1}".format(__name__, _modname),
-            globals(), locals(), [_modname])
+    _module = __import__(
+        "{0}.{1}".format(__name__, _modname), globals(), locals(), [_modname]
+    )
 
-        # Find all the classes actually defined in this module.
-        _nvlist = inspect.getmembers(_module, inspect.isclass)
-        _classes = [
-            _i[1]
-            for _i in _nvlist
-            if _i[1].__module__ == ("{0}.{1}".format(__name__, _modname))
-        ]
+    # Find all the classes actually defined in this module.
+    _nvlist = inspect.getmembers(_module, inspect.isclass)
+    _classes = [
+        _i[1]
+        for _i in _nvlist
+        if _i[1].__module__ == ("{0}.{1}".format(__name__, _modname))
+    ]
 
-        for _i in _classes:
-                if LinkedImagePlugin in inspect.getmro(_i):
-                        p_classes[_modname] = _i
-                elif LinkedImageChildPlugin in inspect.getmro(_i):
-                        p_classes_child[_modname] = _i
-                else:
-                        raise RuntimeError("""
+    for _i in _classes:
+        if LinkedImagePlugin in inspect.getmro(_i):
+            p_classes[_modname] = _i
+        elif LinkedImageChildPlugin in inspect.getmro(_i):
+            p_classes_child[_modname] = _i
+        else:
+            raise RuntimeError(
+                """
 Invalid linked image plugin class '{0}' for plugin '{1}'""".format(
-                             _i.__name__, _modname))
+                    _i.__name__, _modname
+                )
+            )
 
 # Clean up temporary variables
 del _modname, _module, _nvlist, _classes, _i
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/linkedimage/common.py
+++ b/src/modules/client/linkedimage/common.py
@@ -80,35 +80,39 @@ logger = global_settings.logger
 
 # linked image relationship types (returned by LinkedImage.list_related())
 REL_PARENT = "parent"
-REL_SELF   = "self"
-REL_CHILD  = "child"
+REL_SELF = "self"
+REL_CHILD = "child"
 
 # linked image properties
 PROP_CURRENT_PARENT_PATH = "li-current-parent"
-PROP_CURRENT_PATH        = "li-current-path"
-PROP_MODEL               = "li-model"
-PROP_NAME                = "li-name"
-PROP_PARENT_PATH         = "li-parent"
-PROP_PATH                = "li-path"
-PROP_PATH_TRANSFORM      = "li-path-transform"
-PROP_RECURSE             = "li-recurse"
-prop_values         = frozenset([
-    PROP_CURRENT_PARENT_PATH,
-    PROP_CURRENT_PATH,
-    PROP_MODEL,
-    PROP_NAME,
-    PROP_PARENT_PATH,
-    PROP_PATH,
-    PROP_PATH_TRANSFORM,
-    PROP_RECURSE,
-])
+PROP_CURRENT_PATH = "li-current-path"
+PROP_MODEL = "li-model"
+PROP_NAME = "li-name"
+PROP_PARENT_PATH = "li-parent"
+PROP_PATH = "li-path"
+PROP_PATH_TRANSFORM = "li-path-transform"
+PROP_RECURSE = "li-recurse"
+prop_values = frozenset(
+    [
+        PROP_CURRENT_PARENT_PATH,
+        PROP_CURRENT_PATH,
+        PROP_MODEL,
+        PROP_NAME,
+        PROP_PARENT_PATH,
+        PROP_PATH,
+        PROP_PATH_TRANSFORM,
+        PROP_RECURSE,
+    ]
+)
 
 # properties that never get saved
-temporal_props = frozenset([
-    PROP_CURRENT_PARENT_PATH,
-    PROP_CURRENT_PATH,
-    PROP_PATH_TRANSFORM,
-])
+temporal_props = frozenset(
+    [
+        PROP_CURRENT_PARENT_PATH,
+        PROP_CURRENT_PATH,
+        PROP_PATH_TRANSFORM,
+    ]
+)
 
 # special linked image name values (PROP_NAME)
 PV_NAME_NONE = "-"
@@ -116,17 +120,19 @@ PV_NAME_NONE = "-"
 # linked image model values (PROP_MODEL)
 PV_MODEL_PUSH = "push"
 PV_MODEL_PULL = "pull"
-model_values = frozenset([
-    PV_MODEL_PUSH,
-    PV_MODEL_PULL,
-])
+model_values = frozenset(
+    [
+        PV_MODEL_PUSH,
+        PV_MODEL_PULL,
+    ]
+)
 
 # files which contain linked image data
-__DATA_DIR     = "linked"
-PATH_PFACETS    = os.path.join(__DATA_DIR, "linked_pfacets")
-PATH_PPKGS     = os.path.join(__DATA_DIR, "linked_ppkgs")
-PATH_PROP      = os.path.join(__DATA_DIR, "linked_prop")
-PATH_PUBS      = os.path.join(__DATA_DIR, "linked_ppubs")
+__DATA_DIR = "linked"
+PATH_PFACETS = os.path.join(__DATA_DIR, "linked_pfacets")
+PATH_PPKGS = os.path.join(__DATA_DIR, "linked_ppkgs")
+PATH_PROP = os.path.join(__DATA_DIR, "linked_prop")
+PATH_PUBS = os.path.join(__DATA_DIR, "linked_ppubs")
 
 #
 # we define PATH_TRANSFORM_NONE as a tuple instead of just None because this
@@ -136,3788 +142,3943 @@ PATH_TRANSFORM_NONE = ("/", "/")
 
 LI_RVTuple = collections.namedtuple("LI_RVTuple", "rvt_rv rvt_e rvt_p_dict")
 
+
 def _li_rvtuple_check(rvtuple):
-        """Sanity check a linked image operation return value tuple.
-        The format of said tuple is:
-                process return code
-                LinkedImageException exception (optional)
-                json dictionary containing planned image changes
-        """
+    """Sanity check a linked image operation return value tuple.
+    The format of said tuple is:
+            process return code
+            LinkedImageException exception (optional)
+            json dictionary containing planned image changes
+    """
 
-        # make sure we're using the LI_RVTuple class
-        assert type(rvtuple) == LI_RVTuple
+    # make sure we're using the LI_RVTuple class
+    assert type(rvtuple) == LI_RVTuple
 
-        # decode the tuple
-        rv, e, p_dict = rvtuple
+    # decode the tuple
+    rv, e, p_dict = rvtuple
 
-        # rv must be an integer
-        assert type(rv) == int
-        # any exception returned must be a LinkedImageException
-        assert e is None or type(e) == apx.LinkedImageException
-        # if specified, p_dict must be a dictionary
-        assert p_dict is None or type(p_dict) is dict
-        # some child return codes should never be associated with an exception
-        assert rv not in [pkgdefs.EXIT_OK, pkgdefs.EXIT_NOP] or e is None
-        # a p_dict can only be returned if the child returned EXIT_OK
-        assert rv == pkgdefs.EXIT_OK or p_dict is None
+    # rv must be an integer
+    assert type(rv) == int
+    # any exception returned must be a LinkedImageException
+    assert e is None or type(e) == apx.LinkedImageException
+    # if specified, p_dict must be a dictionary
+    assert p_dict is None or type(p_dict) is dict
+    # some child return codes should never be associated with an exception
+    assert rv not in [pkgdefs.EXIT_OK, pkgdefs.EXIT_NOP] or e is None
+    # a p_dict can only be returned if the child returned EXIT_OK
+    assert rv == pkgdefs.EXIT_OK or p_dict is None
 
-        # return the value that was passed in
-        return rvtuple
+    # return the value that was passed in
+    return rvtuple
+
 
 def _li_rvdict_check(rvdict):
-        """Given a linked image return value dictionary, sanity check all the
-        entries."""
+    """Given a linked image return value dictionary, sanity check all the
+    entries."""
 
-        assert type(rvdict) == dict
-        for k, v in six.iteritems(rvdict):
-                assert type(k) == LinkedImageName, \
-                    ("Unexpected rvdict key: ", k)
-                _li_rvtuple_check(v)
+    assert type(rvdict) == dict
+    for k, v in six.iteritems(rvdict):
+        assert type(k) == LinkedImageName, ("Unexpected rvdict key: ", k)
+        _li_rvtuple_check(v)
 
-        # return the value that was passed in
-        return rvdict
+    # return the value that was passed in
+    return rvdict
+
 
 def _li_rvdict_exceptions(rvdict):
-        """Given a linked image return value dictionary, return a list of any
-        exceptions that were encountered while processing children."""
+    """Given a linked image return value dictionary, return a list of any
+    exceptions that were encountered while processing children."""
 
-        # sanity check rvdict
-        _li_rvdict_check(rvdict)
+    # sanity check rvdict
+    _li_rvdict_check(rvdict)
 
-        # get a list of exceptions
-        return [
-            rvtuple.rvt_e
-            for rvtuple in rvdict.values()
-            if rvtuple.rvt_e is not None
-        ]
+    # get a list of exceptions
+    return [
+        rvtuple.rvt_e
+        for rvtuple in rvdict.values()
+        if rvtuple.rvt_e is not None
+    ]
+
 
 def _li_rvdict_raise_exceptions(rvdict):
-        """If an exception was encountered while operating on a linked
-        child then raise that exception.  If multiple exceptions were
-        encountered while operating on multiple children, then bundle
-        those exceptions together and raise them."""
+    """If an exception was encountered while operating on a linked
+    child then raise that exception.  If multiple exceptions were
+    encountered while operating on multiple children, then bundle
+    those exceptions together and raise them."""
 
-        # get a list of exceptions
-        exceptions = _li_rvdict_exceptions(rvdict)
+    # get a list of exceptions
+    exceptions = _li_rvdict_exceptions(rvdict)
 
-        if len(exceptions) == 1:
-                # one exception encountered
-                raise exceptions[0]
+    if len(exceptions) == 1:
+        # one exception encountered
+        raise exceptions[0]
 
-        if exceptions:
-                # multiple exceptions encountered
-                raise apx.LinkedImageException(bundle=exceptions)
+    if exceptions:
+        # multiple exceptions encountered
+        raise apx.LinkedImageException(bundle=exceptions)
+
 
 class LinkedImagePlugin(object):
-        """This class is a template that all linked image plugins should
-        inherit from.  Linked image plugins derived from this class are
-        designed to manage linked aspects of the current image (vs managing
-        linked aspects of a specific child of the current image).
+    """This class is a template that all linked image plugins should
+    inherit from.  Linked image plugins derived from this class are
+    designed to manage linked aspects of the current image (vs managing
+    linked aspects of a specific child of the current image).
 
-        All the interfaces exported by this class and its descendants are
-        private to the linked image subsystem and should not be called
-        directly by any other subsystem."""
+    All the interfaces exported by this class and its descendants are
+    private to the linked image subsystem and should not be called
+    directly by any other subsystem."""
 
-        # functionality flags
-        support_attach = False
-        support_detach = False
+    # functionality flags
+    support_attach = False
+    support_detach = False
 
-        # Unused argument; pylint: disable=W0613
-        def __init__(self, pname, linked):
-                """Initialize a linked image plugin.
+    # Unused argument; pylint: disable=W0613
+    def __init__(self, pname, linked):
+        """Initialize a linked image plugin.
 
-                'pname' is the name of the plugin class derived from this
-                base class.
+        'pname' is the name of the plugin class derived from this
+        base class.
 
-                'linked' is the LinkedImage object initializing this plugin.
-                """
+        'linked' is the LinkedImage object initializing this plugin.
+        """
 
-                return
+        return
 
-        def init_root(self, root):
-                """Called when the path to the image that we're operating on
-                is changing.  This normally occurs when we clone an image
-                after we've planned and prepared to do an operation."""
+    def init_root(self, root):
+        """Called when the path to the image that we're operating on
+        is changing.  This normally occurs when we clone an image
+        after we've planned and prepared to do an operation."""
 
-                # return value: None
-                raise NotImplementedError
+        # return value: None
+        raise NotImplementedError
 
-        def guess_path_transform(self, ignore_errors=False):
-                """If the linked image plugin is able to detect that we're
-                operating on an image in an alternate root then return an
-                transform that can be used to translate between the original
-                image path and the current one."""
+    def guess_path_transform(self, ignore_errors=False):
+        """If the linked image plugin is able to detect that we're
+        operating on an image in an alternate root then return an
+        transform that can be used to translate between the original
+        image path and the current one."""
 
-                # return value: string or None
-                raise NotImplementedError
+        # return value: string or None
+        raise NotImplementedError
 
-        def get_child_list(self, nocache=False, ignore_errors=False):
-                """Return a list of the child images and paths associated with
-                the current image.  The paths that are returned should be
-                absolute paths to the original child image locations."""
+    def get_child_list(self, nocache=False, ignore_errors=False):
+        """Return a list of the child images and paths associated with
+        the current image.  The paths that are returned should be
+        absolute paths to the original child image locations."""
 
-                # return value: list
-                raise NotImplementedError
+        # return value: list
+        raise NotImplementedError
 
-        def get_child_props(self, lin):
-                """Get the linked image properties associated with the
-                specified child image."""
+    def get_child_props(self, lin):
+        """Get the linked image properties associated with the
+        specified child image."""
 
-                # return value: dict
-                raise NotImplementedError
+        # return value: dict
+        raise NotImplementedError
 
-        def attach_child_inmemory(self, props, allow_relink):
-                """Attach the specified child image. This operation should
-                only affect in-memory state of the current image. It should
-                not update any persistent on-disk linked image state or access
-                the child image in any way. This routine should assume that
-                the linked image properties have already been validated."""
+    def attach_child_inmemory(self, props, allow_relink):
+        """Attach the specified child image. This operation should
+        only affect in-memory state of the current image. It should
+        not update any persistent on-disk linked image state or access
+        the child image in any way. This routine should assume that
+        the linked image properties have already been validated."""
 
-                # return value: None
-                raise NotImplementedError
+        # return value: None
+        raise NotImplementedError
 
-        def detach_child_inmemory(self, lin):
-                """Detach the specified child image. This operation should
-                only affect in-memory state of the current image. It should
-                not update any persistent on-disk linked image state or access
-                the child image in any way."""
+    def detach_child_inmemory(self, lin):
+        """Detach the specified child image. This operation should
+        only affect in-memory state of the current image. It should
+        not update any persistent on-disk linked image state or access
+        the child image in any way."""
 
-                # return value: None
-                raise NotImplementedError
+        # return value: None
+        raise NotImplementedError
 
-        def sync_children_todisk(self):
-                """Sync out the in-memory linked image state of this image to
-                disk."""
+    def sync_children_todisk(self):
+        """Sync out the in-memory linked image state of this image to
+        disk."""
 
-                # return value: LI_RVTuple()
-                raise NotImplementedError
+        # return value: LI_RVTuple()
+        raise NotImplementedError
 
 
 class LinkedImageChildPlugin(object):
-        """This class is a template that all linked image child plugins should
-        inherit from.  Linked image child plugins derived from this class are
-        designed to manage linked aspects of children of the current image.
-        (vs managing linked aspects of the current image itself).
+    """This class is a template that all linked image child plugins should
+    inherit from.  Linked image child plugins derived from this class are
+    designed to manage linked aspects of children of the current image.
+    (vs managing linked aspects of the current image itself).
 
-        All the interfaces exported by this class and its descendants are
-        private to the linked image subsystem and should not be called
-        directly by any other subsystem."""
+    All the interfaces exported by this class and its descendants are
+    private to the linked image subsystem and should not be called
+    directly by any other subsystem."""
 
-        def __init__(self, lic): # Unused argument; pylint: disable=W0613
-                """Initialize a linked image child plugin.
+    def __init__(self, lic):  # Unused argument; pylint: disable=W0613
+        """Initialize a linked image child plugin.
 
-                'lic' is the LinkedImageChild object initializing this plugin.
-                """
+        'lic' is the LinkedImageChild object initializing this plugin.
+        """
 
-                return
+        return
 
-        def munge_props(self, props):
-                """Called before a parent image saves linked image properties
-                into a child image.  Gives the linked image child plugin a
-                chance to update the properties that will be saved within the
-                child image."""
+    def munge_props(self, props):
+        """Called before a parent image saves linked image properties
+        into a child image.  Gives the linked image child plugin a
+        chance to update the properties that will be saved within the
+        child image."""
 
-                # return value: None
-                raise NotImplementedError
+        # return value: None
+        raise NotImplementedError
 
 
 class LinkedImageName(object):
-        """A class for naming child linked images.  Linked image names are
-        used for all child images (and only child images), and they encode two
-        pieces of information.  The name of the plugin used to manage the
-        image and a linked image name.  Linked image names have the following
-        format "<linked_image_plugin>:<linked_image_name>"""
+    """A class for naming child linked images.  Linked image names are
+    used for all child images (and only child images), and they encode two
+    pieces of information.  The name of the plugin used to manage the
+    image and a linked image name.  Linked image names have the following
+    format "<linked_image_plugin>:<linked_image_name>"""
 
-        def __init__(self, name):
-                assert type(name) == str
+    def __init__(self, name):
+        assert type(name) == str
 
-                self.lin_type = self.lin_name = None
+        self.lin_type = self.lin_name = None
 
-                try:
-                        self.lin_type, self.lin_name = name.split(":")
-                except ValueError:
-                        raise apx.LinkedImageException(lin_malformed=name)
+        try:
+            self.lin_type, self.lin_name = name.split(":")
+        except ValueError:
+            raise apx.LinkedImageException(lin_malformed=name)
 
-                if len(self.lin_type) == 0 or len(self.lin_name) == 0 :
-                        raise apx.LinkedImageException(lin_malformed=name)
+        if len(self.lin_type) == 0 or len(self.lin_name) == 0:
+            raise apx.LinkedImageException(lin_malformed=name)
 
-                if self.lin_type not in pkg.client.linkedimage.p_types:
-                        raise apx.LinkedImageException(lin_malformed=name)
+        if self.lin_type not in pkg.client.linkedimage.p_types:
+            raise apx.LinkedImageException(lin_malformed=name)
 
-        @staticmethod
-        def getstate(obj, je_state=None):
-                """Returns the serialized state of this object in a format
-                that that can be easily stored using JSON, pickle, etc."""
-                # Unused argument; pylint: disable=W0613
-                return str(obj)
+    @staticmethod
+    def getstate(obj, je_state=None):
+        """Returns the serialized state of this object in a format
+        that that can be easily stored using JSON, pickle, etc."""
+        # Unused argument; pylint: disable=W0613
+        return str(obj)
 
-        @staticmethod
-        def fromstate(state, jd_state=None):
-                """Allocate a new object using previously serialized state
-                obtained via getstate()."""
-                # Unused argument; pylint: disable=W0613
-                return LinkedImageName(state)
+    @staticmethod
+    def fromstate(state, jd_state=None):
+        """Allocate a new object using previously serialized state
+        obtained via getstate()."""
+        # Unused argument; pylint: disable=W0613
+        return LinkedImageName(state)
 
-        def __str__(self):
-                return "{0}:{1}".format(self.lin_type, self.lin_name)
+    def __str__(self):
+        return "{0}:{1}".format(self.lin_type, self.lin_name)
 
-        def __len__(self):
-                return len(self.__str__())
+    def __len__(self):
+        return len(self.__str__())
 
-        def __lt__(self, other):
-                assert type(self) == LinkedImageName
-                if not other:
-                        return False
-                if other == PV_NAME_NONE:
-                        return False
-                assert type(other) == LinkedImageName
-                if self.lin_type < other.lin_type:
-                        return True
-                if self.lin_type != other.lin_type:
-                        return False
-                return self.lin_name < other.lin_name
+    def __lt__(self, other):
+        assert type(self) == LinkedImageName
+        if not other:
+            return False
+        if other == PV_NAME_NONE:
+            return False
+        assert type(other) == LinkedImageName
+        if self.lin_type < other.lin_type:
+            return True
+        if self.lin_type != other.lin_type:
+            return False
+        return self.lin_name < other.lin_name
 
-        def __gt__(self, other):
-                assert type(self) == LinkedImageName
-                if not other:
-                        return True
-                if other == PV_NAME_NONE:
-                        return True
-                assert type(other) == LinkedImageName
-                if self.lin_type > other.lin_type:
-                        return True
-                if self.lin_type != other.lin_type:
-                        return False
-                return self.lin_name > other.lin_name
+    def __gt__(self, other):
+        assert type(self) == LinkedImageName
+        if not other:
+            return True
+        if other == PV_NAME_NONE:
+            return True
+        assert type(other) == LinkedImageName
+        if self.lin_type > other.lin_type:
+            return True
+        if self.lin_type != other.lin_type:
+            return False
+        return self.lin_name > other.lin_name
 
-        def __le__(self, other):
-                return not self > other
+    def __le__(self, other):
+        return not self > other
 
-        def __ge__(self, other):
-                return not self < other
+    def __ge__(self, other):
+        return not self < other
 
-        def __hash__(self):
-                return hash(str(self))
+    def __hash__(self):
+        return hash(str(self))
 
-        def __eq__(self, other):
-                if not isinstance(other, LinkedImageName):
-                        return False
+    def __eq__(self, other):
+        if not isinstance(other, LinkedImageName):
+            return False
 
-                return str(self) == str(other)
+        return str(self) == str(other)
 
-        def __ne__(self, other):
-                return not self.__eq__(other)
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
 
 class LinkedImage(object):
-        """A LinkedImage object is used to manage the linked image aspects of
-        an image.  This image could be a child image, a parent image, or both
-        a parent and child.  This object allows for access to linked image
-        properties and also provides routines that allow operations to be
-        performed on child images."""
+    """A LinkedImage object is used to manage the linked image aspects of
+    an image.  This image could be a child image, a parent image, or both
+    a parent and child.  This object allows for access to linked image
+    properties and also provides routines that allow operations to be
+    performed on child images."""
 
-        # Properties that a parent image with push children should save locally.
-        __parent_props = frozenset([
-            PROP_PATH
-        ])
+    # Properties that a parent image with push children should save locally.
+    __parent_props = frozenset([PROP_PATH])
 
-        # Properties that a pull child image should save locally.
-        __pull_child_props = frozenset([
+    # Properties that a pull child image should save locally.
+    __pull_child_props = frozenset(
+        [
             PROP_NAME,
             PROP_PATH,
             PROP_MODEL,
             PROP_PARENT_PATH,
-        ])
+        ]
+    )
 
-        # Properties that a parent image with push children should save in
-        # those children.
-        __push_child_props = frozenset([
+    # Properties that a parent image with push children should save in
+    # those children.
+    __push_child_props = frozenset(
+        [
             PROP_NAME,
             PROP_PATH,
             PROP_MODEL,
             PROP_RECURSE,
-        ])
-
-        # make sure there is no invalid overlap
-        assert not (temporal_props & (
-            __parent_props |
-            __pull_child_props |
-            __push_child_props))
-
-        def __init__(self, img):
-                """Initialize a new LinkedImage object."""
-
-                # globals
-                self.__img = img
-
-                # variables reset by self.__update_props()
-                self.__props = dict()
-                self.__ppkgs = frozenset()
-                self.__ppubs = None
-                self.__pfacets = pkg.facet.Facets()
-                self.__pimg = None
-
-                # variables reset by self.__recursion_init()
-                self.__lic_ignore = None
-                self.__lic_dict = {}
-
-                # variables reset by self._init_root()
-                self.__root = None
-                self.__path_ppkgs = None
-                self.__path_prop = None
-                self.__path_ppubs = None
-                self.__path_pfacets = None
-                self.__img_insync = True
-
-                # initialize with no properties
-                self.__update_props()
-
-                # initialize linked image plugin objects
-                self.__plugins = dict()
-                for p in pkg.client.linkedimage.p_types:
-                        self.__plugins[p] = \
-                            pkg.client.linkedimage.p_classes[p](p, self)
-
-                # if the image has a path setup, we can load data from it.
-                if self.__img.imgdir:
-                        self._init_root()
-
-        @property
-        def image(self):
-                """Get a pointer to the image object associated with this
-                linked image object."""
-                return self.__img
-
-        def _init_root(self):
-                """Called during object initialization and by
-                image.py`__set_root() to let us know when we're changing the
-                root location of the image.  (The only time we change the root
-                path is when changes BEs during operations which clone BEs.
-                So when this happens most our metadata shouldn't actually
-                change."""
-
-                assert self.__img.root, \
-                    "root = {0}".format(str(self.__img.root))
-                assert self.__img.imgdir, \
-                    "imgdir = {0}".format(str(self.__img.imgdir))
-
-                # Check if this is our first time accessing the current image
-                # or if we're just re-initializing ourselves.
-                first_pass = self.__root is None
-
-                # figure out the new root image path
-                root = self.__img.root.rstrip(os.sep) + os.sep
-
-                # initialize paths for linked image data files
-                self.__root = root
-                imgdir = self.__img.imgdir.rstrip(os.sep) + os.sep
-                self.__path_ppkgs = os.path.join(imgdir, PATH_PPKGS)
-                self.__path_prop = os.path.join(imgdir, PATH_PROP)
-                self.__path_ppubs = os.path.join(imgdir, PATH_PUBS)
-                self.__path_pfacets = os.path.join(imgdir, PATH_PFACETS)
-
-                # if this isn't a reset, then load data from the image
-                if first_pass:
-                        # the first time around we load non-temporary data (if
-                        # there is any) so that we can audit ourselves and see
-                        # if we're in currently in sync.
-                        self.__load(tmp=False)
-                        if self.ischild():
-                                self.__img_insync = self.__insync()
-
-                        # now re-load all the data taking into account any
-                        # temporary new data associated with an in-progress
-                        # operation.
-                        self.__load()
-
-                # if we're not linked we're done
-                if not self.__props:
-                        return
-
-                # if this is a reset, update temporal properties
-                if not first_pass:
-                        self.__set_current_path(self.__props, update=True)
-
-                # Tell linked image plugins about the updated paths
-                # Unused variable 'plugin'; pylint: disable=W0612
-                for plugin, lip in six.iteritems(self.__plugins):
-                # pylint: enable=W0612
-                        lip.init_root(root)
-
-                # Tell linked image children about the updated paths
-                for lic in six.itervalues(self.__lic_dict):
-                        lic.child_init_root()
-
-        def __update_props(self, props=None):
-                """Internal helper routine used when we want to update any
-                linked image properties.  This routine sanity check the
-                new properties, updates them, and resets any cached state
-                that is affected by property values."""
-
-                if props is None:
-                        props = dict()
-                elif props:
-                        self.__verify_props(props)
-
-                        # all temporal properties must exist
-                        for p in temporal_props:
-                                # PROP_CURRENT_PARENT_PATH can only be set if
-                                # we have PROP_PARENT_PATH.
-                                if p is PROP_CURRENT_PARENT_PATH and \
-                                    PROP_PARENT_PATH not in props:
-                                        continue
-                                assert p in props, \
-                                    "'{0}' not in {1}".format(p, set(props))
-
-                # update state
-                self.__props = props
-                self.__ppkgs = frozenset()
-                self.__ppubs = None
-                self.__pfacets = pkg.facet.Facets()
-                self.__pimg = None
-
-        def __verify_props(self, props):
-                """Perform internal consistency checks for a set of linked
-                image properties.  Don't update any state."""
-
-                props_set = set(props)
-
-                # if we're not a child image ourselves, then we're done
-                if (props_set - temporal_props) == self.__parent_props:
-                        return props
-
-                # make sure PROP_MODEL was specified
-                if PROP_NAME not in props:
-                        _rterr(path=self.__root,
-                            missing_props=[PROP_NAME])
-
-                # validate the linked image name
-                try:
-                        lin = LinkedImageName(str(props[PROP_NAME]))
-                except apx.LinkedImageException:
-                        _rterr(path=self.__root,
-                            bad_prop=(PROP_NAME, props[PROP_NAME]))
-
-                if lin.lin_type not in self.__plugins:
-                        _rterr(path=self.__root, lin=lin,
-                            bad_lin_type=lin.lin_type)
-
-                # make sure PROP_MODEL was specified
-                if PROP_MODEL not in props:
-                        _rterr(path=self.__root, lin=lin,
-                            missing_props=[PROP_MODEL])
-
-                model = props[PROP_MODEL]
-                if model not in model_values:
-                        _rterr(path=self.__root, lin=lin,
-                            bad_prop=(PROP_MODEL, model))
-
-                if model == PV_MODEL_PUSH:
-                        missing = self.__push_child_props - props_set
-                        if missing:
-                                _rterr(path=self.__root, lin=lin,
-                                    missing_props=missing)
-
-                if model == PV_MODEL_PULL:
-                        missing = self.__pull_child_props - props_set
-                        if missing:
-                                _rterr(path=self.__root, lin=lin,
-                                    missing_props=missing)
-
-        @staticmethod
-        def set_path_transform(props, path_transform,
-            path=None, current_path=None, update=False):
-                """Given a new path_transform, update path properties."""
-
-                if update:
-                        assert (set(props) & temporal_props), \
-                            "no temporal properties are set: {0}".format(props)
-                else:
-                        assert not (set(props) & temporal_props), \
-                            "temporal properties already set: {0}".format(props)
-
-                # Either 'path' or 'current_path' must be specified.
-                assert path is None or current_path is None
-                assert path is not None or current_path is not None
-
-                if path is not None:
-                        current_path = path_transform_apply(path,
-                            path_transform)
-
-                elif current_path is not None:
-                        path = path_transform_revert(current_path,
-                            path_transform)
-
-                props[PROP_PATH] = path
-                props[PROP_CURRENT_PATH] = current_path
-                props[PROP_PATH_TRANSFORM] = path_transform
-                parent_path = props.get(PROP_PARENT_PATH)
-                if not parent_path:
-                        return
-
-                if not path_transform_applicable(parent_path, path_transform):
-                        props[PROP_CURRENT_PARENT_PATH] = parent_path
-                        return
-
-                props[PROP_CURRENT_PARENT_PATH] = path_transform_apply(
-                    parent_path, path_transform)
-
-        def __set_current_path(self, props, update=False):
-                """Given a set of linked image properties, the image paths
-                stored within those properties may not match the actual image
-                paths if we're executing within an alternate root environment.
-                To deal with this situation we create temporal in-memory
-                properties that represent the current path to the image, and a
-                transform that allows us to translate between the current path
-                and the original path."""
-
-                current_path = self.__root
-                path_transform = compute_path_transform(props[PROP_PATH],
-                    current_path)
-
-                self.set_path_transform(props, path_transform,
-                    current_path=current_path, update=update)
-
-        def __guess_path_transform(self, ignore_errors=False):
-                """If we're initializing parent linked image properties for
-                the first time (or if those properties somehow got deleted)
-                then we need to know if the parent image that we're currently
-                operating on is located within an alternate root.  One way to
-                do this is to ask our linked image plugins if they can
-                determine this (the zones linked image plugin usually can
-                if the image is a global zone)."""
-
-                # ask each plugin if we're operating in an alternate root
-                p_transforms = []
-                for plugin, lip in six.iteritems(self.__plugins):
-                        p_transform = lip.guess_path_transform(
-                            ignore_errors=ignore_errors)
-                        if p_transform is not PATH_TRANSFORM_NONE:
-                                p_transforms.append((plugin, p_transform))
-
-                if not p_transforms:
-                        # no transform suggested by plugins
-                        return PATH_TRANSFORM_NONE
-
-                # check for conflicting transforms
-                transforms = list(set([
-                        p_transform
-                        # Unused variable; pylint: disable=W0612
-                        for pname, p_transform in p_transforms
-                        # pylint: enable=W0612
-                ]))
-
-                if len(transforms) == 1:
-                        # we have a transform from our plugins
-                        return transforms[0]
-
-                # we have conflicting transforms, time to die
-                _rterr(li=self, multiple_transforms=p_transforms)
-
-        def __fabricate_parent_props(self, ignore_errors=False):
-                """Fabricate the minimum set of properties required for a
-                parent image."""
-
-                # ask our plugins if we're operating with alternate image paths
-                path_transform = self.__guess_path_transform(
-                    ignore_errors=ignore_errors)
-
-                props = dict()
-                self.set_path_transform(props, path_transform,
-                    current_path=self.__root)
-                return props
-
-        def __load_ondisk_props(self, tmp=True):
-                """Load linked image properties from disk and return them to
-                the caller.  We sanity check the properties, but we don't
-                update any internal linked image state.
-
-                'tmp' determines if we should read/write to the official
-                linked image metadata files, or if we should access temporary
-                versions (which have ".<runid>" appended to them."""
-
-                path = self.__path_prop
-                path_tmp = "{0}.{1:d}".format(self.__path_prop,
-                    global_settings.client_runid)
-
-                # read the linked image properties from disk
-                if tmp and path_exists(path_tmp):
-                        path = path_tmp
-                        props = load_data(path)
-                elif path_exists(path):
-                        props = load_data(path)
-                else:
-                        return None
-
-                # make sure there are no saved temporal properties
-                assert not set(props) & temporal_props
-
-                if PROP_NAME in props:
-                        # convert PROP_NAME into a linked image name obj
-                        name = props[PROP_NAME]
-                        try:
-                                lin = LinkedImageName(name)
-                                props[PROP_NAME] = lin
-                        except apx.LinkedImageException:
-                                _rterr(path=self.__root,
-                                    bad_prop=(PROP_NAME, name))
-
-                # sanity check our properties
-                self.__verify_props(props)
-                return props
-
-        def __load_ondisk_pfacets(self, tmp=True):
-                """Load linked image inherited facets from disk.
-                Don't update any internal state.
-
-                'tmp' determines if we should read/write to the official
-                linked image metadata files, or if we should access temporary
-                versions (which have ".<runid>" appended to them."""
-
-                pfacets = misc.EmptyDict
-                path = "{0}.{1:d}".format(self.__path_pfacets,
-                    global_settings.client_runid)
-                if tmp and path_exists(path):
-                        pfacets = load_data(path)
-                else:
-                        path = self.__path_pfacets
-                        pfacets = load_data(path, missing_ok=True)
-
-                if pfacets is None:
-                        return None
-
-                rv = pkg.facet.Facets()
-                for k, v in six.iteritems(pfacets):
-                        # W0212 Access to a protected member
-                        # pylint: disable=W0212
-                        rv._set_inherited(k, v)
-                return rv
-
-        def __load_ondisk_ppkgs(self, tmp=True):
-                """Load linked image parent packages from disk.
-                Don't update any internal state.
-
-                'tmp' determines if we should read/write to the official
-                linked image metadata files, or if we should access temporary
-                versions (which have ".<runid>" appended to them."""
-
-                fmri_strs = None
-                path = "{0}.{1:d}".format(self.__path_ppkgs,
-                    global_settings.client_runid)
-                if tmp and path_exists(path):
-                        fmri_strs = load_data(path)
-                else:
-                        path = self.__path_ppkgs
-                        fmri_strs = load_data(path, missing_ok=True)
-
-                if fmri_strs is None:
-                        return None
-
-                return frozenset([
-                    pkg.fmri.PkgFmri(str(s))
-                    for s in fmri_strs
-                ])
-
-        def __load_ondisk_ppubs(self, tmp=True):
-                """Load linked image parent publishers from disk.
-                Don't update any internal state.
-
-                'tmp' determines if we should read/write to the official
-                linked image metadata files, or if we should access temporary
-                versions (which have ".<runid>" appended to them."""
-
-                ppubs = None
-                path = "{0}.{1:d}".format(self.__path_ppubs,
-                    global_settings.client_runid)
-                if tmp and path_exists(path):
-                        ppubs = load_data(path)
-                else:
-                        path = self.__path_ppubs
-                        ppubs = load_data(path, missing_ok=True)
-
-                return ppubs
-
-        def __load(self, tmp=True):
-                """Load linked image properties and constraints from disk.
-                Update the linked image internal state with the loaded data."""
-
-                #
-                # Normally, if we're a parent image we'll have linked image
-                # properties stored on disk.  So load those now.
-                #
-                # If no properties are loaded, we may still be a parent image
-                # that is just missing it's metadata.  (oops.)  We attempt to
-                # detect this situation by invoking __isparent(), which will
-                # ask each child if there are any children.  This is a best
-                # effort attempt, so when we do this we ignore any plugin
-                # runtime errors since we really want Image object
-                # initialization to succeed.  If we don't have any linked
-                # image metadata, and we're having runtime errors querying for
-                # children, then we'll allow initialization here, but any
-                # subsequent operation that tries to access children will fail
-                # and the caller will have to specify that they want to ignore
-                # all children to allow the operation to succeed.
-                #
-                props = self.__load_ondisk_props(tmp=tmp)
-                if not props and not self.__isparent(ignore_errors=True):
-                        # we're not linked
-                        return
-
-                if not props:
-                        #
-                        # Oops.  We're a parent image with no properties
-                        # stored on disk.  Rather than throwing an exception
-                        # try to fabricate up some props with reasonably
-                        # guessed values which the user can subsequently
-                        # change and/or fix.
-                        #
-                        props = self.__fabricate_parent_props(
-                            ignore_errors=True)
-                else:
-                        self.__set_current_path(props)
-
-                self.__update_props(props)
-
-                if not self.ischild():
-                        return
-
-                # load parent packages. if parent package data is missing just
-                # continue along and hope for the best.
-                ppkgs = self.__load_ondisk_ppkgs(tmp=tmp)
-                if ppkgs is not None:
-                        self.__ppkgs = ppkgs
-
-                # load inherited facets. if inherited facet data is missing
-                # just continue along and hope for the best.
-                pfacets = self.__load_ondisk_pfacets(tmp=tmp)
-                if pfacets is not None:
-                        self.__pfacets = pfacets
-
-                # load parent publisher data. if publisher data is missing
-                # continue along and we'll just skip the publisher checks,
-                # it's better than failing and preventing any image updates.
-                self.__ppubs = self.__load_ondisk_ppubs(tmp=tmp)
-
-        @staticmethod
-        def __validate_prop_recurse(v):
-                """Verify property value for PROP_RECURSE."""
-                if v in [True, False]:
-                        return True
-                if type(v) == str and v.lower() in ["true", "false"]:
-                        return True
-                return False
-
-        def __validate_attach_props(self, model, props):
-                """Validate user supplied linked image attach properties.
-                Don't update any internal state."""
-
-                # make sure that only attach time options have been
-                # specified, and that they have allowed values.
-                validate_props = {
-                        PROP_RECURSE: self.__validate_prop_recurse
-                }
-
-                if model == PV_MODEL_PUSH:
-                        allowed_props = self.__push_child_props
-                else:
-                        assert model == PV_MODEL_PULL
-                        allowed_props = self.__pull_child_props
-
-                errs = []
-
-                # check each property the user specified.
-                for k, v in six.iteritems(props):
-
-                        # did the user specify an allowable property?
-                        if k not in validate_props:
-                                errs.append(apx.LinkedImageException(
-                                    attach_bad_prop=k))
-                                continue
-
-                        # did the user specify a valid property value?
-                        if not validate_props[k](v):
-                                errs.append(apx.LinkedImageException(
-                                    attach_bad_prop_value=(k, v)))
-                                continue
-
-                        # is this property valid for this type of image?
-                        if k not in allowed_props:
-                                errs.append(apx.LinkedImageException(
-                                    attach_bad_prop=k))
-                                continue
-
-                if len(errs) == 1:
-                        raise errs[0]
-                if errs:
-                        raise apx.LinkedImageException(bundle=errs)
-
-        def __init_pimg(self, path):
-                """Initialize an Image object which can be used to access a
-                parent image."""
-
-                try:
-                        os.stat(path)
-                except OSError:
-                        raise apx.LinkedImageException(parent_bad_path=path)
-
-                try:
-                        pimg = self.__img.alloc(
-                            root=path,
-                            user_provided_dir=True,
-                            cmdpath=self.__img.cmdpath)
-                except apx.ImageNotFoundException:
-                        raise apx.LinkedImageException(parent_bad_img=path)
-
-                return pimg
-
-        def nothingtodo(self):
-                """If our in-memory linked image state matches the on-disk
-                linked image state then there's nothing to do.  If the state
-                differs then there is stuff to do since the new state needs
-                to be saved to disk."""
-
-                # check if we're not a linked image.
-                if not self.isparent() and not self.ischild():
-                        # if any linked image metadata files exist they need
-                        # to be deleted.
-                        paths = [
-                            self.__path_pfacets,
-                            self.__path_ppkgs,
-                            self.__path_ppubs,
-                            self.__path_prop,
-                        ]
-                        for path in paths:
-                                if path_exists(path):
-                                        return False
-                        return True
-
-                # compare in-memory and on-disk properties
-                li_ondisk_props = self.__load_ondisk_props(tmp=False)
-                if li_ondisk_props is None:
-                        li_ondisk_props = dict()
-                li_inmemory_props = rm_dict_ent(self.__props,
-                    temporal_props)
-                if li_ondisk_props != li_inmemory_props:
-                        return False
-
-                # linked image metadata files with inherited data
-                paths = [
-                    self.__path_pfacets,
-                    self.__path_ppkgs,
-                    self.__path_ppubs,
+        ]
+    )
+
+    # make sure there is no invalid overlap
+    assert not (
+        temporal_props
+        & (__parent_props | __pull_child_props | __push_child_props)
+    )
+
+    def __init__(self, img):
+        """Initialize a new LinkedImage object."""
+
+        # globals
+        self.__img = img
+
+        # variables reset by self.__update_props()
+        self.__props = dict()
+        self.__ppkgs = frozenset()
+        self.__ppubs = None
+        self.__pfacets = pkg.facet.Facets()
+        self.__pimg = None
+
+        # variables reset by self.__recursion_init()
+        self.__lic_ignore = None
+        self.__lic_dict = {}
+
+        # variables reset by self._init_root()
+        self.__root = None
+        self.__path_ppkgs = None
+        self.__path_prop = None
+        self.__path_ppubs = None
+        self.__path_pfacets = None
+        self.__img_insync = True
+
+        # initialize with no properties
+        self.__update_props()
+
+        # initialize linked image plugin objects
+        self.__plugins = dict()
+        for p in pkg.client.linkedimage.p_types:
+            self.__plugins[p] = pkg.client.linkedimage.p_classes[p](p, self)
+
+        # if the image has a path setup, we can load data from it.
+        if self.__img.imgdir:
+            self._init_root()
+
+    @property
+    def image(self):
+        """Get a pointer to the image object associated with this
+        linked image object."""
+        return self.__img
+
+    def _init_root(self):
+        """Called during object initialization and by
+        image.py`__set_root() to let us know when we're changing the
+        root location of the image.  (The only time we change the root
+        path is when changes BEs during operations which clone BEs.
+        So when this happens most our metadata shouldn't actually
+        change."""
+
+        assert self.__img.root, "root = {0}".format(str(self.__img.root))
+        assert self.__img.imgdir, "imgdir = {0}".format(str(self.__img.imgdir))
+
+        # Check if this is our first time accessing the current image
+        # or if we're just re-initializing ourselves.
+        first_pass = self.__root is None
+
+        # figure out the new root image path
+        root = self.__img.root.rstrip(os.sep) + os.sep
+
+        # initialize paths for linked image data files
+        self.__root = root
+        imgdir = self.__img.imgdir.rstrip(os.sep) + os.sep
+        self.__path_ppkgs = os.path.join(imgdir, PATH_PPKGS)
+        self.__path_prop = os.path.join(imgdir, PATH_PROP)
+        self.__path_ppubs = os.path.join(imgdir, PATH_PUBS)
+        self.__path_pfacets = os.path.join(imgdir, PATH_PFACETS)
+
+        # if this isn't a reset, then load data from the image
+        if first_pass:
+            # the first time around we load non-temporary data (if
+            # there is any) so that we can audit ourselves and see
+            # if we're in currently in sync.
+            self.__load(tmp=False)
+            if self.ischild():
+                self.__img_insync = self.__insync()
+
+            # now re-load all the data taking into account any
+            # temporary new data associated with an in-progress
+            # operation.
+            self.__load()
+
+        # if we're not linked we're done
+        if not self.__props:
+            return
+
+        # if this is a reset, update temporal properties
+        if not first_pass:
+            self.__set_current_path(self.__props, update=True)
+
+        # Tell linked image plugins about the updated paths
+        # Unused variable 'plugin'; pylint: disable=W0612
+        for plugin, lip in six.iteritems(self.__plugins):
+            # pylint: enable=W0612
+            lip.init_root(root)
+
+        # Tell linked image children about the updated paths
+        for lic in six.itervalues(self.__lic_dict):
+            lic.child_init_root()
+
+    def __update_props(self, props=None):
+        """Internal helper routine used when we want to update any
+        linked image properties.  This routine sanity check the
+        new properties, updates them, and resets any cached state
+        that is affected by property values."""
+
+        if props is None:
+            props = dict()
+        elif props:
+            self.__verify_props(props)
+
+            # all temporal properties must exist
+            for p in temporal_props:
+                # PROP_CURRENT_PARENT_PATH can only be set if
+                # we have PROP_PARENT_PATH.
+                if (
+                    p is PROP_CURRENT_PARENT_PATH
+                    and PROP_PARENT_PATH not in props
+                ):
+                    continue
+                assert p in props, "'{0}' not in {1}".format(p, set(props))
+
+        # update state
+        self.__props = props
+        self.__ppkgs = frozenset()
+        self.__ppubs = None
+        self.__pfacets = pkg.facet.Facets()
+        self.__pimg = None
+
+    def __verify_props(self, props):
+        """Perform internal consistency checks for a set of linked
+        image properties.  Don't update any state."""
+
+        props_set = set(props)
+
+        # if we're not a child image ourselves, then we're done
+        if (props_set - temporal_props) == self.__parent_props:
+            return props
+
+        # make sure PROP_MODEL was specified
+        if PROP_NAME not in props:
+            _rterr(path=self.__root, missing_props=[PROP_NAME])
+
+        # validate the linked image name
+        try:
+            lin = LinkedImageName(str(props[PROP_NAME]))
+        except apx.LinkedImageException:
+            _rterr(path=self.__root, bad_prop=(PROP_NAME, props[PROP_NAME]))
+
+        if lin.lin_type not in self.__plugins:
+            _rterr(path=self.__root, lin=lin, bad_lin_type=lin.lin_type)
+
+        # make sure PROP_MODEL was specified
+        if PROP_MODEL not in props:
+            _rterr(path=self.__root, lin=lin, missing_props=[PROP_MODEL])
+
+        model = props[PROP_MODEL]
+        if model not in model_values:
+            _rterr(path=self.__root, lin=lin, bad_prop=(PROP_MODEL, model))
+
+        if model == PV_MODEL_PUSH:
+            missing = self.__push_child_props - props_set
+            if missing:
+                _rterr(path=self.__root, lin=lin, missing_props=missing)
+
+        if model == PV_MODEL_PULL:
+            missing = self.__pull_child_props - props_set
+            if missing:
+                _rterr(path=self.__root, lin=lin, missing_props=missing)
+
+    @staticmethod
+    def set_path_transform(
+        props, path_transform, path=None, current_path=None, update=False
+    ):
+        """Given a new path_transform, update path properties."""
+
+        if update:
+            assert (
+                set(props) & temporal_props
+            ), "no temporal properties are set: {0}".format(props)
+        else:
+            assert not (
+                set(props) & temporal_props
+            ), "temporal properties already set: {0}".format(props)
+
+        # Either 'path' or 'current_path' must be specified.
+        assert path is None or current_path is None
+        assert path is not None or current_path is not None
+
+        if path is not None:
+            current_path = path_transform_apply(path, path_transform)
+
+        elif current_path is not None:
+            path = path_transform_revert(current_path, path_transform)
+
+        props[PROP_PATH] = path
+        props[PROP_CURRENT_PATH] = current_path
+        props[PROP_PATH_TRANSFORM] = path_transform
+        parent_path = props.get(PROP_PARENT_PATH)
+        if not parent_path:
+            return
+
+        if not path_transform_applicable(parent_path, path_transform):
+            props[PROP_CURRENT_PARENT_PATH] = parent_path
+            return
+
+        props[PROP_CURRENT_PARENT_PATH] = path_transform_apply(
+            parent_path, path_transform
+        )
+
+    def __set_current_path(self, props, update=False):
+        """Given a set of linked image properties, the image paths
+        stored within those properties may not match the actual image
+        paths if we're executing within an alternate root environment.
+        To deal with this situation we create temporal in-memory
+        properties that represent the current path to the image, and a
+        transform that allows us to translate between the current path
+        and the original path."""
+
+        current_path = self.__root
+        path_transform = compute_path_transform(props[PROP_PATH], current_path)
+
+        self.set_path_transform(
+            props, path_transform, current_path=current_path, update=update
+        )
+
+    def __guess_path_transform(self, ignore_errors=False):
+        """If we're initializing parent linked image properties for
+        the first time (or if those properties somehow got deleted)
+        then we need to know if the parent image that we're currently
+        operating on is located within an alternate root.  One way to
+        do this is to ask our linked image plugins if they can
+        determine this (the zones linked image plugin usually can
+        if the image is a global zone)."""
+
+        # ask each plugin if we're operating in an alternate root
+        p_transforms = []
+        for plugin, lip in six.iteritems(self.__plugins):
+            p_transform = lip.guess_path_transform(ignore_errors=ignore_errors)
+            if p_transform is not PATH_TRANSFORM_NONE:
+                p_transforms.append((plugin, p_transform))
+
+        if not p_transforms:
+            # no transform suggested by plugins
+            return PATH_TRANSFORM_NONE
+
+        # check for conflicting transforms
+        transforms = list(
+            set(
+                [
+                    p_transform
+                    # Unused variable; pylint: disable=W0612
+                    for pname, p_transform in p_transforms
+                    # pylint: enable=W0612
                 ]
-
-                # check if we're just a parent image.
-                if not self.ischild():
-                        # parent images only have properties.  if any linked
-                        # image metadata files that contain inherited
-                        # information exist they need to be deleted.
-                        for path in paths:
-                                if path_exists(path):
-                                        return False
-                        return True
-
-                # if we're missing any metadata files then there's work todo
-                for path in paths:
-                        if not path_exists(path):
-                                return False
-
-                # compare in-memory and on-disk inherited facets
-                li_ondisk_pfacets = self.__load_ondisk_pfacets(tmp=False)
-                if self.__pfacets != li_ondisk_pfacets:
-                        return False
-
-                # compare in-memory and on-disk parent packages
-                li_ondisk_ppkgs = self.__load_ondisk_ppkgs(tmp=False)
-                if self.__ppkgs != li_ondisk_ppkgs:
-                        return False
-
-                # compare in-memory and on-disk parent publishers
-                li_ondisk_ppubs = self.__load_ondisk_ppubs(tmp=False)
-                if self.__ppubs != li_ondisk_ppubs:
-                        return False
-
-                return True
-
-        def pubcheck(self):
-                """If we're a child image's, verify that the parent image
-                publisher configuration is a subset of the child images
-                publisher configuration.  This means that all publishers
-                configured within the parent image must also be configured
-                within the child image with the same:
-
-                        - publisher rank
-                        - sticky and disabled settings
-
-                The child image may have additional publishers configured but
-                they must all be lower ranked than the parent's publishers.
-                """
-
-                # if we're not a child image then bail
-                if not self.ischild():
-                        return
-
-                # if we're using the sysrepo then don't bother
-                if self.__img.cfg.get_policy("use-system-repo"):
-                        return
-
-                pubs = get_pubs(self.__img)
-                ppubs = self.__ppubs
-
-                if ppubs is None:
-                        # parent publisher data is missing, press on and hope
-                        # for the best.
-                        return
-
-                # child image needs at least as many publishers as the parent
-                if len(pubs) < len(ppubs):
-                        raise apx.PlanCreationException(
-                            linked_pub_error=(pubs, ppubs))
-
-                # check rank, sticky, and disabled settings
-                for (p, pp) in zip(pubs, ppubs):
-                        if p == pp:
-                                continue
-                        raise apx.PlanCreationException(
-                            linked_pub_error=(pubs, ppubs))
-
-        def __syncmd_from_parent(self):
-                """Update linked image constraint, publisher data, and
-                state from our parent image."""
-
-                if not self.ischild():
-                        # we're not a child image, nothing to do
-                        return
-
-                if self.__props[PROP_MODEL] == PV_MODEL_PUSH:
-                        # parent pushes data to us, nothing to do
-                        return
-
-                # initialize the parent image
-                if not self.__pimg:
-                        path = self.parent_path()
-                        self.__pimg = self.__init_pimg(path)
-
-                # get metadata from our parent image
-                self.__ppubs = get_pubs(self.__pimg)
-                self.__ppkgs = get_packages(self.__pimg)
-                self.__pfacets = get_inheritable_facets(self.__pimg)
-
-        def syncmd_from_parent(self, catch_exception=False):
-                """Update linked image constraint, publisher data, and state
-                from our parent image.  If catch_exception is true catch any
-                linked image exceptions and pack them up in a linked image
-                return value tuple."""
-
-                try:
-                        self.__syncmd_from_parent()
-                except apx.LinkedImageException as e:
-                        if not catch_exception:
-                                raise e
-                        return LI_RVTuple(e.lix_exitrv, e, None)
-                return
-
-        def syncmd(self):
-                """Write in-memory linked image state to disk."""
-
-                # create a list of metadata file paths
-                paths = [
-                    self.__path_pfacets,
-                    self.__path_ppkgs,
-                    self.__path_ppubs,
-                    self.__path_prop,
-                ]
-
-                # cleanup any temporary files
-                for path in paths:
-                        path = "{0}.{1:d}".format(path,
-                            global_settings.client_runid)
-                        path_unlink(path, noent_ok=True)
-
-                if not self.ischild() and not self.isparent():
-                        # we're no longer linked; delete metadata
-                        for path in paths:
-                                path_unlink(path, noent_ok=True)
-                        return
-
-                # save our properties, but first remove any temporal properties
-                props = rm_dict_ent(self.__props, temporal_props)
-                save_data(self.__path_prop, props)
-
-                if not self.ischild():
-                        # if we're not a child we don't have parent data
-                        path_unlink(self.__path_pfacets, noent_ok=True)
-                        path_unlink(self.__path_ppkgs, noent_ok=True)
-                        path_unlink(self.__path_ppubs, noent_ok=True)
-                        return
-
-                # we're a child so save our latest constraints
-                save_data(self.__path_pfacets, self.__pfacets)
-                save_data(self.__path_ppkgs, self.__ppkgs)
-                save_data(self.__path_ppubs, self.__ppubs)
-
-        @property
-        def child_name(self):
-                """If the current image is a child image, this function
-                returns a linked image name object which represents the name
-                of the current image."""
-
-                if not self.ischild():
-                        raise self.__apx_not_child()
-                return self.__props[PROP_NAME]
-
-        def ischild(self):
-                """Indicates whether the current image is a child image."""
-
-                return PROP_NAME in self.__props
-
-        def __isparent(self, ignore_errors=False):
-                """Indicates whether the current image is a parent image.
-
-                'ignore_plugin_errors' ignore plugin runtime errors when
-                trying to determine if we're a parent image.
-                """
-
-                return len(self.__list_children(
-                    ignore_errors=ignore_errors)) > 0
-
-        def isparent(self, li_ignore=None):
-                """Indicates whether the current image is a parent image."""
-
-                return len(self.__list_children(li_ignore=li_ignore)) > 0
-
-        def islinked(self):
-                """Indicates wether the current image is already linked."""
-                return self.ischild() or self.isparent()
-
-        def get_path_transform(self):
-                """Return the current path transform property."""
-
-                return self.__props.get(
-                    PROP_PATH_TRANSFORM, PATH_TRANSFORM_NONE)
-
-        def inaltroot(self):
-                """Check if we're accessing a linked image at an alternate
-                location/path."""
-
-                return self.get_path_transform() != PATH_TRANSFORM_NONE
-
-        def path(self):
-                """Report our current image path."""
-
-                assert self.islinked()
-                return self.__props[PROP_PATH]
-
-        def current_path(self):
-                """Report our current image path."""
-
-                assert self.islinked()
-                return self.__props[PROP_CURRENT_PATH]
-
-        def parent_path(self):
-                """If we know where our parent should be, report it's expected
-                location."""
-
-                if PROP_PARENT_PATH not in self.__props:
-                        return None
-
-                path = self.__props[PROP_CURRENT_PARENT_PATH]
-                assert path[-1] == "/"
-                return path
-
-        def child_props(self, lin=None):
-                """Return a dictionary which represents the linked image
-                properties associated with a linked image.
-
-                'lin' is the name of the child image.  If lin is None then
-                the current image is assumed to be a linked image and it's
-                properties are returned.
-
-                Always returns a copy of the properties in case the caller
-                tries to update them."""
-
-                if lin is None:
-                        # If we're not linked we'll return an empty
-                        # dictionary.  That's ok.
-                        return self.__props.copy()
-
-                # make sure the specified child exists
-                self.__verify_child_name(lin, raise_except=True)
-
-                # make a copy of the props in case they are updated
-                lip = self.__plugins[lin.lin_type]
-                props = lip.get_child_props(lin).copy()
-
-                # add temporal properties
-                self.set_path_transform(props, self.get_path_transform(),
-                    path=props[PROP_PATH])
-                return props
-
-        def __apx_not_child(self):
-                """Raise an exception because the current image is not a child
-                image."""
-
-                return apx.LinkedImageException(self_not_child=self.__root)
-
-        def __verify_child_name(self, lin, raise_except=False):
-                """Check if a specific child image exists."""
-
-                assert type(lin) == LinkedImageName, \
-                    "{0} == LinkedImageName".format(type(lin))
-
-                for i in self.__list_children():
-                        if i[0] == lin:
-                                return True
-
-                if raise_except:
-                        raise apx.LinkedImageException(child_unknown=lin)
-                return False
-
-        def verify_names(self, lin_list):
-                """Given a list of linked image name objects, make sure all
-                the children exist."""
-
-                assert isinstance(lin_list, list), \
-                    "type(lin_list) == {0}, str(lin_list) == {1}".format(
-                    type(lin_list), str(lin_list))
-
-                for lin in lin_list:
-                        self.__verify_child_name(lin, raise_except=True)
-
-        def inherited_facets(self):
-                """Facets inherited from our parent image."""
-                return self.__pfacets
-
-        def parent_fmris(self):
-                """A set of the fmris installed in our parent image."""
-
-                if not self.ischild():
-                        # We return None since frozenset() would indicate
-                        # that there are no packages installed in the parent
-                        # image.
-                        return None
-
-                return self.__ppkgs
-
-        def parse_name(self, name, allow_unknown=False):
-                """Given a string representing a linked image child name,
-                returns linked image name object representing the same name.
-
-                'allow_unknown' indicates whether the name must represent
-                actual children or simply be syntactically correct."""
-
-                assert type(name) == str
-
+            )
+        )
+
+        if len(transforms) == 1:
+            # we have a transform from our plugins
+            return transforms[0]
+
+        # we have conflicting transforms, time to die
+        _rterr(li=self, multiple_transforms=p_transforms)
+
+    def __fabricate_parent_props(self, ignore_errors=False):
+        """Fabricate the minimum set of properties required for a
+        parent image."""
+
+        # ask our plugins if we're operating with alternate image paths
+        path_transform = self.__guess_path_transform(
+            ignore_errors=ignore_errors
+        )
+
+        props = dict()
+        self.set_path_transform(props, path_transform, current_path=self.__root)
+        return props
+
+    def __load_ondisk_props(self, tmp=True):
+        """Load linked image properties from disk and return them to
+        the caller.  We sanity check the properties, but we don't
+        update any internal linked image state.
+
+        'tmp' determines if we should read/write to the official
+        linked image metadata files, or if we should access temporary
+        versions (which have ".<runid>" appended to them."""
+
+        path = self.__path_prop
+        path_tmp = "{0}.{1:d}".format(
+            self.__path_prop, global_settings.client_runid
+        )
+
+        # read the linked image properties from disk
+        if tmp and path_exists(path_tmp):
+            path = path_tmp
+            props = load_data(path)
+        elif path_exists(path):
+            props = load_data(path)
+        else:
+            return None
+
+        # make sure there are no saved temporal properties
+        assert not set(props) & temporal_props
+
+        if PROP_NAME in props:
+            # convert PROP_NAME into a linked image name obj
+            name = props[PROP_NAME]
+            try:
                 lin = LinkedImageName(name)
-                if not allow_unknown:
-                        self.__verify_child_name(lin, raise_except=True)
-                return lin
-
-        def __list_children(self, li_ignore=None, ignore_errors=False):
-                """Returns a list of linked child images associated with the
-                current image.
-
-                'li_ignore' see list_related() for a description.
-
-                The returned value is a list of tuples where each tuple
-                contains (<li name>, <li path>)."""
-
-                if li_ignore == []:
-                        # ignore all children
-                        return []
-
-                li_children = []
-                for p in pkg.client.linkedimage.p_types:
-                        for lin, path in self.__plugins[p].get_child_list(
-                            ignore_errors=ignore_errors):
-                                assert lin.lin_type == p
-                                path = path_transform_apply(path,
-                                    self.get_path_transform())
-                                li_children.append([lin, path])
-
-                # sort by linked image name
-                li_children = sorted(li_children, key=operator.itemgetter(0))
-
-                if li_ignore is None:
-                        # don't ignore any children
-                        return li_children
-
-                li_all = set([lin for lin, path in li_children])
-                errs = [
-                    apx.LinkedImageException(child_unknown=lin)
-                    for lin in (set(li_ignore) - li_all)
-                ]
-                if len(errs) == 1:
-                        raise errs[0]
-                if errs:
-                        raise apx.LinkedImageException(bundle=errs)
-
-                return [
-                    (lin, path)
-                    for lin, path in li_children
-                    if lin not in li_ignore
-                ]
-
-        def list_related(self, li_ignore=None):
-                """Returns a list of linked images associated with the
-                current image.  This includes both child and parent images.
-
-                'li_ignore' is either None or a list.  If it's None (the
-                default), all children will be listed.  If it's an empty list
-                no children will be listed.  Otherwise, any children listed
-                in li_ignore will be ommited from the results.
-
-                The returned value is a list of tuples where each tuple
-                contains (<li name>, <relationship>, <li path>)."""
-
-                li_children = self.__list_children(li_ignore=li_ignore)
-                li_list = [
-                    (lin, REL_CHILD, path)
-                    for lin, path in li_children
-                ]
-
-                if not li_list and not self.ischild():
-                        # we're not linked
-                        return []
-
-                # we're linked so append ourself to the list
-                lin = PV_NAME_NONE
-                if self.ischild():
-                        lin = self.child_name
-
-                path = self.current_path()
-                li_self = (lin, REL_SELF, path)
-                li_list.append(li_self)
-
-                # if we have a path to our parent then append that as well.
-                path = self.parent_path()
-                if path is not None:
-                        li_parent = (PV_NAME_NONE, REL_PARENT, path)
-                        li_list.append(li_parent)
-
-                # sort by linked image name
-                li_list = sorted(li_list, key=operator.itemgetter(0))
-
-                return li_list
-
-        def attach_parent(self, lin, path, props, allow_relink=False,
-            force=False):
-                """We only update in-memory state; nothing is written to
-                disk, to sync linked image state to disk call syncmd."""
-
-                assert type(lin) == LinkedImageName
-                assert type(path) == str
-                assert props is None or type(props) == dict, \
-                    "type(props) == {0}".format(type(props))
-                if props is None:
-                        props = dict()
-
-                lip = self.__plugins[lin.lin_type]
-
-                if self.ischild() and not allow_relink:
-                        raise apx.LinkedImageException(self_linked=self.__root)
-
-                if not lip.support_attach and not force:
-                        raise apx.LinkedImageException(
-                            attach_parent_notsup=lin.lin_type)
-
-                # Path must be an absolute path.
-                if not os.path.isabs(path):
-                        raise apx.LinkedImageException(parent_bad_notabs=path)
-
-                # we don't bother to cleanup the path to the parent image here
-                # because when we allocate an Image object for the parent
-                # image, it will do that work for us.
-                pimg = self.__init_pimg(path)
-
-                # get the cleaned up parent image path.
-                path = pimg.root
-
-                # Make sure our parent image is at it's default path.  (We
-                # don't allow attaching new images if an image is located at
-                # an alternate path.)
-                if pimg.linked.inaltroot():
-                        raise apx.LinkedImageException(attach_with_curpath=(
-                            pimg.linked.path(), pimg.current_path()))
-
-                self.__validate_attach_props(PV_MODEL_PULL, props)
-                self.__validate_attach_img_paths(path, self.__root)
-
-                # make a copy of the properties and update them
-                props = props.copy()
                 props[PROP_NAME] = lin
-                props[PROP_MODEL] = PV_MODEL_PULL
+            except apx.LinkedImageException:
+                _rterr(path=self.__root, bad_prop=(PROP_NAME, name))
 
-                # If we're in an alternate root, the parent must also be within
-                # that alternate root.
-                path_transform = self.get_path_transform()
-                if not path_transform_applied(path, path_transform):
-                        raise apx.LinkedImageException(
-                            parent_not_in_altroot=(path, path_transform[1]))
+        # sanity check our properties
+        self.__verify_props(props)
+        return props
 
-                # Set path related properties.  We use self.__root in place of
-                # current_path() since we may not actually be linked yet.
-                props[PROP_PARENT_PATH] = path.rstrip(os.sep) + os.sep
-                self.set_path_transform(props, path_transform,
-                    current_path=self.__root)
+    def __load_ondisk_pfacets(self, tmp=True):
+        """Load linked image inherited facets from disk.
+        Don't update any internal state.
 
-                for k, v in six.iteritems(lip.attach_props_def):
-                        if k not in self.__pull_child_props:
-                                # this prop doesn't apply to pull images
-                                continue
-                        if k not in props:
-                                props[k] = v
+        'tmp' determines if we should read/write to the official
+        linked image metadata files, or if we should access temporary
+        versions (which have ".<runid>" appended to them."""
 
-                self.__update_props(props)
-                self.__pimg = pimg
+        pfacets = misc.EmptyDict
+        path = "{0}.{1:d}".format(
+            self.__path_pfacets, global_settings.client_runid
+        )
+        if tmp and path_exists(path):
+            pfacets = load_data(path)
+        else:
+            path = self.__path_pfacets
+            pfacets = load_data(path, missing_ok=True)
 
-        def detach_parent(self, force=False):
-                """We only update in memory state; nothing is written to
-                disk, to sync linked image state to disk call syncmd."""
+        if pfacets is None:
+            return None
 
-                lin = self.child_name
-                lip = self.__plugins[lin.lin_type]
-                if not force:
-                        if self.__props[PROP_MODEL] == PV_MODEL_PUSH:
-                                raise apx.LinkedImageException(
-                                    detach_from_parent=self.__root)
+        rv = pkg.facet.Facets()
+        for k, v in six.iteritems(pfacets):
+            # W0212 Access to a protected member
+            # pylint: disable=W0212
+            rv._set_inherited(k, v)
+        return rv
 
-                        if not lip.support_detach:
-                                raise apx.LinkedImageException(
-                                    detach_parent_notsup=lin.lin_type)
+    def __load_ondisk_ppkgs(self, tmp=True):
+        """Load linked image parent packages from disk.
+        Don't update any internal state.
 
-                # Generate a new set of linked image properties.  If we have
-                # no children then we don't need any more properties.
-                props = None
+        'tmp' determines if we should read/write to the official
+        linked image metadata files, or if we should access temporary
+        versions (which have ".<runid>" appended to them."""
 
-                # If we have children we'll need to keep some properties.
-                if self.isparent():
-                        strip = prop_values - \
-                            (self.__parent_props | temporal_props)
-                        props = rm_dict_ent(self.__props, strip)
+        fmri_strs = None
+        path = "{0}.{1:d}".format(
+            self.__path_ppkgs, global_settings.client_runid
+        )
+        if tmp and path_exists(path):
+            fmri_strs = load_data(path)
+        else:
+            path = self.__path_ppkgs
+            fmri_strs = load_data(path, missing_ok=True)
 
-                # Update our linked image properties.
-                self.__update_props(props)
+        if fmri_strs is None:
+            return None
 
-        def __insync(self):
-                """Determine if an image is in sync with its constraints."""
+        return frozenset([pkg.fmri.PkgFmri(str(s)) for s in fmri_strs])
 
-                assert self.ischild()
+    def __load_ondisk_ppubs(self, tmp=True):
+        """Load linked image parent publishers from disk.
+        Don't update any internal state.
 
-                cat = self.__img.get_catalog(self.__img.IMG_CATALOG_INSTALLED)
-                excludes = self.__img.list_excludes()
+        'tmp' determines if we should read/write to the official
+        linked image metadata files, or if we should access temporary
+        versions (which have ".<runid>" appended to them."""
 
-                sync_fmris = []
-                for fmri in cat.fmris():
-                        # get parent dependencies from the catalog
-                        for f in itertools.chain.from_iterable(
-                            a.attrlist("fmri")
-                            for a in cat.get_entry_actions(fmri,
-                                [pkg.catalog.Catalog.DEPENDENCY],
-                                excludes=excludes)
-                            if a.name == "depend" and
-                                a.attrs["type"] == "parent"
-                        ):
-                                if f == pkg.actions.depend.DEPEND_SELF:
-                                        sync_fmris.append((fmri, fmri))
-                                else:
-                                        sync_fmris.append((fmri,
-                                            pkg.fmri.PkgFmri(f)))
+        ppubs = None
+        path = "{0}.{1:d}".format(
+            self.__path_ppubs, global_settings.client_runid
+        )
+        if tmp and path_exists(path):
+            ppubs = load_data(path)
+        else:
+            path = self.__path_ppubs
+            ppubs = load_data(path, missing_ok=True)
 
-                if not sync_fmris:
-                        # No packages to sync
-                        return True
+        return ppubs
 
-                # create a dictionary of packages installed in the parent
-                ppkgs_dict = dict([
-                        (fmri.pkg_name, fmri)
-                        for fmri in self.parent_fmris()
-                ])
+    def __load(self, tmp=True):
+        """Load linked image properties and constraints from disk.
+        Update the linked image internal state with the loaded data."""
 
-                for (pkg_fmri, fmri) in sync_fmris:
-                        if fmri.pkg_name not in ppkgs_dict:
-                                return False
-                        # This intentionally mirrors the logic in
-                        # __trim_nonmatching_parents1 in pkg_solver.py.
-                        pf = ppkgs_dict[fmri.pkg_name]
-                        if pf.version == fmri.version:
-                                # parent dependency is satisfied, which applies
-                                # to both DEPEND_SELF and other cases
-                                continue
-                        elif (pkg_fmri != fmri and
-                            pf.version.is_successor(fmri.version,
-                                pkg.version.CONSTRAINT_NONE)):
-                                # *not* DEPEND_SELF; parent dependency is
-                                # satisfied
-                                continue
-                        return False
+        #
+        # Normally, if we're a parent image we'll have linked image
+        # properties stored on disk.  So load those now.
+        #
+        # If no properties are loaded, we may still be a parent image
+        # that is just missing it's metadata.  (oops.)  We attempt to
+        # detect this situation by invoking __isparent(), which will
+        # ask each child if there are any children.  This is a best
+        # effort attempt, so when we do this we ignore any plugin
+        # runtime errors since we really want Image object
+        # initialization to succeed.  If we don't have any linked
+        # image metadata, and we're having runtime errors querying for
+        # children, then we'll allow initialization here, but any
+        # subsequent operation that tries to access children will fail
+        # and the caller will have to specify that they want to ignore
+        # all children to allow the operation to succeed.
+        #
+        props = self.__load_ondisk_props(tmp=tmp)
+        if not props and not self.__isparent(ignore_errors=True):
+            # we're not linked
+            return
+
+        if not props:
+            #
+            # Oops.  We're a parent image with no properties
+            # stored on disk.  Rather than throwing an exception
+            # try to fabricate up some props with reasonably
+            # guessed values which the user can subsequently
+            # change and/or fix.
+            #
+            props = self.__fabricate_parent_props(ignore_errors=True)
+        else:
+            self.__set_current_path(props)
+
+        self.__update_props(props)
+
+        if not self.ischild():
+            return
+
+        # load parent packages. if parent package data is missing just
+        # continue along and hope for the best.
+        ppkgs = self.__load_ondisk_ppkgs(tmp=tmp)
+        if ppkgs is not None:
+            self.__ppkgs = ppkgs
+
+        # load inherited facets. if inherited facet data is missing
+        # just continue along and hope for the best.
+        pfacets = self.__load_ondisk_pfacets(tmp=tmp)
+        if pfacets is not None:
+            self.__pfacets = pfacets
+
+        # load parent publisher data. if publisher data is missing
+        # continue along and we'll just skip the publisher checks,
+        # it's better than failing and preventing any image updates.
+        self.__ppubs = self.__load_ondisk_ppubs(tmp=tmp)
+
+    @staticmethod
+    def __validate_prop_recurse(v):
+        """Verify property value for PROP_RECURSE."""
+        if v in [True, False]:
+            return True
+        if type(v) == str and v.lower() in ["true", "false"]:
+            return True
+        return False
+
+    def __validate_attach_props(self, model, props):
+        """Validate user supplied linked image attach properties.
+        Don't update any internal state."""
+
+        # make sure that only attach time options have been
+        # specified, and that they have allowed values.
+        validate_props = {PROP_RECURSE: self.__validate_prop_recurse}
+
+        if model == PV_MODEL_PUSH:
+            allowed_props = self.__push_child_props
+        else:
+            assert model == PV_MODEL_PULL
+            allowed_props = self.__pull_child_props
+
+        errs = []
+
+        # check each property the user specified.
+        for k, v in six.iteritems(props):
+            # did the user specify an allowable property?
+            if k not in validate_props:
+                errs.append(apx.LinkedImageException(attach_bad_prop=k))
+                continue
+
+            # did the user specify a valid property value?
+            if not validate_props[k](v):
+                errs.append(
+                    apx.LinkedImageException(attach_bad_prop_value=(k, v))
+                )
+                continue
+
+            # is this property valid for this type of image?
+            if k not in allowed_props:
+                errs.append(apx.LinkedImageException(attach_bad_prop=k))
+                continue
+
+        if len(errs) == 1:
+            raise errs[0]
+        if errs:
+            raise apx.LinkedImageException(bundle=errs)
+
+    def __init_pimg(self, path):
+        """Initialize an Image object which can be used to access a
+        parent image."""
+
+        try:
+            os.stat(path)
+        except OSError:
+            raise apx.LinkedImageException(parent_bad_path=path)
+
+        try:
+            pimg = self.__img.alloc(
+                root=path, user_provided_dir=True, cmdpath=self.__img.cmdpath
+            )
+        except apx.ImageNotFoundException:
+            raise apx.LinkedImageException(parent_bad_img=path)
+
+        return pimg
+
+    def nothingtodo(self):
+        """If our in-memory linked image state matches the on-disk
+        linked image state then there's nothing to do.  If the state
+        differs then there is stuff to do since the new state needs
+        to be saved to disk."""
+
+        # check if we're not a linked image.
+        if not self.isparent() and not self.ischild():
+            # if any linked image metadata files exist they need
+            # to be deleted.
+            paths = [
+                self.__path_pfacets,
+                self.__path_ppkgs,
+                self.__path_ppubs,
+                self.__path_prop,
+            ]
+            for path in paths:
+                if path_exists(path):
+                    return False
+            return True
+
+        # compare in-memory and on-disk properties
+        li_ondisk_props = self.__load_ondisk_props(tmp=False)
+        if li_ondisk_props is None:
+            li_ondisk_props = dict()
+        li_inmemory_props = rm_dict_ent(self.__props, temporal_props)
+        if li_ondisk_props != li_inmemory_props:
+            return False
+
+        # linked image metadata files with inherited data
+        paths = [
+            self.__path_pfacets,
+            self.__path_ppkgs,
+            self.__path_ppubs,
+        ]
+
+        # check if we're just a parent image.
+        if not self.ischild():
+            # parent images only have properties.  if any linked
+            # image metadata files that contain inherited
+            # information exist they need to be deleted.
+            for path in paths:
+                if path_exists(path):
+                    return False
+            return True
+
+        # if we're missing any metadata files then there's work todo
+        for path in paths:
+            if not path_exists(path):
+                return False
+
+        # compare in-memory and on-disk inherited facets
+        li_ondisk_pfacets = self.__load_ondisk_pfacets(tmp=False)
+        if self.__pfacets != li_ondisk_pfacets:
+            return False
+
+        # compare in-memory and on-disk parent packages
+        li_ondisk_ppkgs = self.__load_ondisk_ppkgs(tmp=False)
+        if self.__ppkgs != li_ondisk_ppkgs:
+            return False
+
+        # compare in-memory and on-disk parent publishers
+        li_ondisk_ppubs = self.__load_ondisk_ppubs(tmp=False)
+        if self.__ppubs != li_ondisk_ppubs:
+            return False
+
+        return True
+
+    def pubcheck(self):
+        """If we're a child image's, verify that the parent image
+        publisher configuration is a subset of the child images
+        publisher configuration.  This means that all publishers
+        configured within the parent image must also be configured
+        within the child image with the same:
+
+                - publisher rank
+                - sticky and disabled settings
+
+        The child image may have additional publishers configured but
+        they must all be lower ranked than the parent's publishers.
+        """
+
+        # if we're not a child image then bail
+        if not self.ischild():
+            return
+
+        # if we're using the sysrepo then don't bother
+        if self.__img.cfg.get_policy("use-system-repo"):
+            return
+
+        pubs = get_pubs(self.__img)
+        ppubs = self.__ppubs
+
+        if ppubs is None:
+            # parent publisher data is missing, press on and hope
+            # for the best.
+            return
+
+        # child image needs at least as many publishers as the parent
+        if len(pubs) < len(ppubs):
+            raise apx.PlanCreationException(linked_pub_error=(pubs, ppubs))
+
+        # check rank, sticky, and disabled settings
+        for p, pp in zip(pubs, ppubs):
+            if p == pp:
+                continue
+            raise apx.PlanCreationException(linked_pub_error=(pubs, ppubs))
+
+    def __syncmd_from_parent(self):
+        """Update linked image constraint, publisher data, and
+        state from our parent image."""
+
+        if not self.ischild():
+            # we're not a child image, nothing to do
+            return
+
+        if self.__props[PROP_MODEL] == PV_MODEL_PUSH:
+            # parent pushes data to us, nothing to do
+            return
+
+        # initialize the parent image
+        if not self.__pimg:
+            path = self.parent_path()
+            self.__pimg = self.__init_pimg(path)
+
+        # get metadata from our parent image
+        self.__ppubs = get_pubs(self.__pimg)
+        self.__ppkgs = get_packages(self.__pimg)
+        self.__pfacets = get_inheritable_facets(self.__pimg)
+
+    def syncmd_from_parent(self, catch_exception=False):
+        """Update linked image constraint, publisher data, and state
+        from our parent image.  If catch_exception is true catch any
+        linked image exceptions and pack them up in a linked image
+        return value tuple."""
+
+        try:
+            self.__syncmd_from_parent()
+        except apx.LinkedImageException as e:
+            if not catch_exception:
+                raise e
+            return LI_RVTuple(e.lix_exitrv, e, None)
+        return
+
+    def syncmd(self):
+        """Write in-memory linked image state to disk."""
+
+        # create a list of metadata file paths
+        paths = [
+            self.__path_pfacets,
+            self.__path_ppkgs,
+            self.__path_ppubs,
+            self.__path_prop,
+        ]
+
+        # cleanup any temporary files
+        for path in paths:
+            path = "{0}.{1:d}".format(path, global_settings.client_runid)
+            path_unlink(path, noent_ok=True)
+
+        if not self.ischild() and not self.isparent():
+            # we're no longer linked; delete metadata
+            for path in paths:
+                path_unlink(path, noent_ok=True)
+            return
+
+        # save our properties, but first remove any temporal properties
+        props = rm_dict_ent(self.__props, temporal_props)
+        save_data(self.__path_prop, props)
+
+        if not self.ischild():
+            # if we're not a child we don't have parent data
+            path_unlink(self.__path_pfacets, noent_ok=True)
+            path_unlink(self.__path_ppkgs, noent_ok=True)
+            path_unlink(self.__path_ppubs, noent_ok=True)
+            return
+
+        # we're a child so save our latest constraints
+        save_data(self.__path_pfacets, self.__pfacets)
+        save_data(self.__path_ppkgs, self.__ppkgs)
+        save_data(self.__path_ppubs, self.__ppubs)
+
+    @property
+    def child_name(self):
+        """If the current image is a child image, this function
+        returns a linked image name object which represents the name
+        of the current image."""
+
+        if not self.ischild():
+            raise self.__apx_not_child()
+        return self.__props[PROP_NAME]
+
+    def ischild(self):
+        """Indicates whether the current image is a child image."""
+
+        return PROP_NAME in self.__props
+
+    def __isparent(self, ignore_errors=False):
+        """Indicates whether the current image is a parent image.
+
+        'ignore_plugin_errors' ignore plugin runtime errors when
+        trying to determine if we're a parent image.
+        """
+
+        return len(self.__list_children(ignore_errors=ignore_errors)) > 0
+
+    def isparent(self, li_ignore=None):
+        """Indicates whether the current image is a parent image."""
+
+        return len(self.__list_children(li_ignore=li_ignore)) > 0
+
+    def islinked(self):
+        """Indicates wether the current image is already linked."""
+        return self.ischild() or self.isparent()
+
+    def get_path_transform(self):
+        """Return the current path transform property."""
+
+        return self.__props.get(PROP_PATH_TRANSFORM, PATH_TRANSFORM_NONE)
+
+    def inaltroot(self):
+        """Check if we're accessing a linked image at an alternate
+        location/path."""
+
+        return self.get_path_transform() != PATH_TRANSFORM_NONE
+
+    def path(self):
+        """Report our current image path."""
+
+        assert self.islinked()
+        return self.__props[PROP_PATH]
+
+    def current_path(self):
+        """Report our current image path."""
+
+        assert self.islinked()
+        return self.__props[PROP_CURRENT_PATH]
+
+    def parent_path(self):
+        """If we know where our parent should be, report it's expected
+        location."""
+
+        if PROP_PARENT_PATH not in self.__props:
+            return None
+
+        path = self.__props[PROP_CURRENT_PARENT_PATH]
+        assert path[-1] == "/"
+        return path
+
+    def child_props(self, lin=None):
+        """Return a dictionary which represents the linked image
+        properties associated with a linked image.
+
+        'lin' is the name of the child image.  If lin is None then
+        the current image is assumed to be a linked image and it's
+        properties are returned.
+
+        Always returns a copy of the properties in case the caller
+        tries to update them."""
+
+        if lin is None:
+            # If we're not linked we'll return an empty
+            # dictionary.  That's ok.
+            return self.__props.copy()
+
+        # make sure the specified child exists
+        self.__verify_child_name(lin, raise_except=True)
+
+        # make a copy of the props in case they are updated
+        lip = self.__plugins[lin.lin_type]
+        props = lip.get_child_props(lin).copy()
+
+        # add temporal properties
+        self.set_path_transform(
+            props, self.get_path_transform(), path=props[PROP_PATH]
+        )
+        return props
+
+    def __apx_not_child(self):
+        """Raise an exception because the current image is not a child
+        image."""
+
+        return apx.LinkedImageException(self_not_child=self.__root)
+
+    def __verify_child_name(self, lin, raise_except=False):
+        """Check if a specific child image exists."""
+
+        assert type(lin) == LinkedImageName, "{0} == LinkedImageName".format(
+            type(lin)
+        )
+
+        for i in self.__list_children():
+            if i[0] == lin:
                 return True
 
-        def audit_self(self, latest_md=True):
-                """If the current image is a child image, this function
-                audits the current image to see if it's in sync with its
-                parent."""
+        if raise_except:
+            raise apx.LinkedImageException(child_unknown=lin)
+        return False
 
-                if not self.ischild():
-                        e = self.__apx_not_child()
-                        return LI_RVTuple(pkgdefs.EXIT_OOPS, e, None)
+    def verify_names(self, lin_list):
+        """Given a list of linked image name objects, make sure all
+        the children exist."""
 
-                if not latest_md:
-                        # we don't use the latest linked image metadata.
-                        # instead return cached insync value which was
-                        # computed using the initial linked image metadata
-                        # that we loaded from disk.
-                        if not self.__img_insync:
-                                e = apx.LinkedImageException(
-                                    child_diverged=self.child_name)
-                                return LI_RVTuple(pkgdefs.EXIT_DIVERGED, e,
-                                    None)
-                        return LI_RVTuple(pkgdefs.EXIT_OK, None, None)
+        assert isinstance(
+            lin_list, list
+        ), "type(lin_list) == {0}, str(lin_list) == {1}".format(
+            type(lin_list), str(lin_list)
+        )
 
-                if not self.__insync():
-                        e = apx.LinkedImageException(
-                            child_diverged=self.child_name)
-                        return LI_RVTuple(pkgdefs.EXIT_DIVERGED, e, None)
+        for lin in lin_list:
+            self.__verify_child_name(lin, raise_except=True)
 
-                return LI_RVTuple(pkgdefs.EXIT_OK, None, None)
+    def inherited_facets(self):
+        """Facets inherited from our parent image."""
+        return self.__pfacets
 
-        def insync(self, latest_md=True):
-                """A convenience wrapper for audit_self().  Note that we
-                consider non-child images as always in sync and ignore
-                any runtime errors."""
+    def parent_fmris(self):
+        """A set of the fmris installed in our parent image."""
 
-                rv = self.image.linked.audit_self(latest_md=latest_md)[0]
-                if rv == pkgdefs.EXIT_DIVERGED:
-                        return False
-                return True
+        if not self.ischild():
+            # We return None since frozenset() would indicate
+            # that there are no packages installed in the parent
+            # image.
+            return None
 
-        @staticmethod
-        def __rvdict2rv(rvdict, rv_map=None):
-                """Internal helper function that takes a dictionary returned
-                from an operations on multiple children and merges the results
-                into a single return code."""
+        return self.__ppkgs
 
-                _li_rvdict_check(rvdict)
-                if type(rv_map) != type(None):
-                        assert type(rv_map) == list
-                        for (rv_set, rv) in rv_map:
-                                assert type(rv_set) == set
-                                assert type(rv) == int
+    def parse_name(self, name, allow_unknown=False):
+        """Given a string representing a linked image child name,
+        returns linked image name object representing the same name.
 
-                if not rvdict:
-                        return LI_RVTuple(pkgdefs.EXIT_OK, None, None)
+        'allow_unknown' indicates whether the name must represent
+        actual children or simply be syntactically correct."""
 
-                if not rv_map:
-                        rv_map = [(set([pkgdefs.EXIT_OK]), pkgdefs.EXIT_OK)]
+        assert type(name) == str
 
-                p_dicts = [
-                    rvtuple.rvt_p_dict
-                    for rvtuple in six.itervalues(rvdict)
-                    if rvtuple.rvt_p_dict is not None
-                ]
+        lin = LinkedImageName(name)
+        if not allow_unknown:
+            self.__verify_child_name(lin, raise_except=True)
+        return lin
 
-                rv_mapped = set()
-                rv_seen = set([
-                    rvtuple.rvt_rv
-                    for rvtuple in six.itervalues(rvdict)
-                ])
-                for (rv_map_set, rv_map_rv) in rv_map:
-                        if rv_seen == rv_map_set:
-                                return LI_RVTuple(rv_map_rv, None, p_dicts)
-                        # keep track of all the return values that are mapped
-                        rv_mapped |= rv_map_set
+    def __list_children(self, li_ignore=None, ignore_errors=False):
+        """Returns a list of linked child images associated with the
+        current image.
 
-                # the mappings better have included pkgdefs.EXIT_OK
-                assert pkgdefs.EXIT_OK in rv_mapped
+        'li_ignore' see list_related() for a description.
 
-                # if we had errors for unmapped return values, bundle them up
-                errs = [
-                        rvtuple.rvt_e
-                        for rvtuple in six.itervalues(rvdict)
-                        if rvtuple.rvt_e and rvtuple.rvt_rv not in rv_mapped
-                ]
-                if len(errs) == 1:
-                        err = errs[0]
-                elif errs:
-                        err = apx.LinkedImageException(bundle=errs)
+        The returned value is a list of tuples where each tuple
+        contains (<li name>, <li path>)."""
+
+        if li_ignore == []:
+            # ignore all children
+            return []
+
+        li_children = []
+        for p in pkg.client.linkedimage.p_types:
+            for lin, path in self.__plugins[p].get_child_list(
+                ignore_errors=ignore_errors
+            ):
+                assert lin.lin_type == p
+                path = path_transform_apply(path, self.get_path_transform())
+                li_children.append([lin, path])
+
+        # sort by linked image name
+        li_children = sorted(li_children, key=operator.itemgetter(0))
+
+        if li_ignore is None:
+            # don't ignore any children
+            return li_children
+
+        li_all = set([lin for lin, path in li_children])
+        errs = [
+            apx.LinkedImageException(child_unknown=lin)
+            for lin in (set(li_ignore) - li_all)
+        ]
+        if len(errs) == 1:
+            raise errs[0]
+        if errs:
+            raise apx.LinkedImageException(bundle=errs)
+
+        return [
+            (lin, path) for lin, path in li_children if lin not in li_ignore
+        ]
+
+    def list_related(self, li_ignore=None):
+        """Returns a list of linked images associated with the
+        current image.  This includes both child and parent images.
+
+        'li_ignore' is either None or a list.  If it's None (the
+        default), all children will be listed.  If it's an empty list
+        no children will be listed.  Otherwise, any children listed
+        in li_ignore will be ommited from the results.
+
+        The returned value is a list of tuples where each tuple
+        contains (<li name>, <relationship>, <li path>)."""
+
+        li_children = self.__list_children(li_ignore=li_ignore)
+        li_list = [(lin, REL_CHILD, path) for lin, path in li_children]
+
+        if not li_list and not self.ischild():
+            # we're not linked
+            return []
+
+        # we're linked so append ourself to the list
+        lin = PV_NAME_NONE
+        if self.ischild():
+            lin = self.child_name
+
+        path = self.current_path()
+        li_self = (lin, REL_SELF, path)
+        li_list.append(li_self)
+
+        # if we have a path to our parent then append that as well.
+        path = self.parent_path()
+        if path is not None:
+            li_parent = (PV_NAME_NONE, REL_PARENT, path)
+            li_list.append(li_parent)
+
+        # sort by linked image name
+        li_list = sorted(li_list, key=operator.itemgetter(0))
+
+        return li_list
+
+    def attach_parent(self, lin, path, props, allow_relink=False, force=False):
+        """We only update in-memory state; nothing is written to
+        disk, to sync linked image state to disk call syncmd."""
+
+        assert type(lin) == LinkedImageName
+        assert type(path) == str
+        assert (
+            props is None or type(props) == dict
+        ), "type(props) == {0}".format(type(props))
+        if props is None:
+            props = dict()
+
+        lip = self.__plugins[lin.lin_type]
+
+        if self.ischild() and not allow_relink:
+            raise apx.LinkedImageException(self_linked=self.__root)
+
+        if not lip.support_attach and not force:
+            raise apx.LinkedImageException(attach_parent_notsup=lin.lin_type)
+
+        # Path must be an absolute path.
+        if not os.path.isabs(path):
+            raise apx.LinkedImageException(parent_bad_notabs=path)
+
+        # we don't bother to cleanup the path to the parent image here
+        # because when we allocate an Image object for the parent
+        # image, it will do that work for us.
+        pimg = self.__init_pimg(path)
+
+        # get the cleaned up parent image path.
+        path = pimg.root
+
+        # Make sure our parent image is at it's default path.  (We
+        # don't allow attaching new images if an image is located at
+        # an alternate path.)
+        if pimg.linked.inaltroot():
+            raise apx.LinkedImageException(
+                attach_with_curpath=(pimg.linked.path(), pimg.current_path())
+            )
+
+        self.__validate_attach_props(PV_MODEL_PULL, props)
+        self.__validate_attach_img_paths(path, self.__root)
+
+        # make a copy of the properties and update them
+        props = props.copy()
+        props[PROP_NAME] = lin
+        props[PROP_MODEL] = PV_MODEL_PULL
+
+        # If we're in an alternate root, the parent must also be within
+        # that alternate root.
+        path_transform = self.get_path_transform()
+        if not path_transform_applied(path, path_transform):
+            raise apx.LinkedImageException(
+                parent_not_in_altroot=(path, path_transform[1])
+            )
+
+        # Set path related properties.  We use self.__root in place of
+        # current_path() since we may not actually be linked yet.
+        props[PROP_PARENT_PATH] = path.rstrip(os.sep) + os.sep
+        self.set_path_transform(props, path_transform, current_path=self.__root)
+
+        for k, v in six.iteritems(lip.attach_props_def):
+            if k not in self.__pull_child_props:
+                # this prop doesn't apply to pull images
+                continue
+            if k not in props:
+                props[k] = v
+
+        self.__update_props(props)
+        self.__pimg = pimg
+
+    def detach_parent(self, force=False):
+        """We only update in memory state; nothing is written to
+        disk, to sync linked image state to disk call syncmd."""
+
+        lin = self.child_name
+        lip = self.__plugins[lin.lin_type]
+        if not force:
+            if self.__props[PROP_MODEL] == PV_MODEL_PUSH:
+                raise apx.LinkedImageException(detach_from_parent=self.__root)
+
+            if not lip.support_detach:
+                raise apx.LinkedImageException(
+                    detach_parent_notsup=lin.lin_type
+                )
+
+        # Generate a new set of linked image properties.  If we have
+        # no children then we don't need any more properties.
+        props = None
+
+        # If we have children we'll need to keep some properties.
+        if self.isparent():
+            strip = prop_values - (self.__parent_props | temporal_props)
+            props = rm_dict_ent(self.__props, strip)
+
+        # Update our linked image properties.
+        self.__update_props(props)
+
+    def __insync(self):
+        """Determine if an image is in sync with its constraints."""
+
+        assert self.ischild()
+
+        cat = self.__img.get_catalog(self.__img.IMG_CATALOG_INSTALLED)
+        excludes = self.__img.list_excludes()
+
+        sync_fmris = []
+        for fmri in cat.fmris():
+            # get parent dependencies from the catalog
+            for f in itertools.chain.from_iterable(
+                a.attrlist("fmri")
+                for a in cat.get_entry_actions(
+                    fmri, [pkg.catalog.Catalog.DEPENDENCY], excludes=excludes
+                )
+                if a.name == "depend" and a.attrs["type"] == "parent"
+            ):
+                if f == pkg.actions.depend.DEPEND_SELF:
+                    sync_fmris.append((fmri, fmri))
                 else:
-                        err = None
+                    sync_fmris.append((fmri, pkg.fmri.PkgFmri(f)))
 
-                if len(rv_seen) == 1:
-                        # we have one consistent return value
-                        return LI_RVTuple(list(rv_seen)[0], err, p_dicts)
+        if not sync_fmris:
+            # No packages to sync
+            return True
 
-                return LI_RVTuple(pkgdefs.EXIT_PARTIAL, err, p_dicts)
+        # create a dictionary of packages installed in the parent
+        ppkgs_dict = dict(
+            [(fmri.pkg_name, fmri) for fmri in self.parent_fmris()]
+        )
 
-        def audit_rvdict2rv(self, rvdict):
-                """Convenience function that takes a dictionary returned from
-                an operations on multiple children and merges the results into
-                a single return code."""
+        for pkg_fmri, fmri in sync_fmris:
+            if fmri.pkg_name not in ppkgs_dict:
+                return False
+            # This intentionally mirrors the logic in
+            # __trim_nonmatching_parents1 in pkg_solver.py.
+            pf = ppkgs_dict[fmri.pkg_name]
+            if pf.version == fmri.version:
+                # parent dependency is satisfied, which applies
+                # to both DEPEND_SELF and other cases
+                continue
+            elif pkg_fmri != fmri and pf.version.is_successor(
+                fmri.version, pkg.version.CONSTRAINT_NONE
+            ):
+                # *not* DEPEND_SELF; parent dependency is
+                # satisfied
+                continue
+            return False
+        return True
 
-                rv_map = [
-                    (set([pkgdefs.EXIT_OK]), pkgdefs.EXIT_OK),
-                    (set([pkgdefs.EXIT_DIVERGED]), pkgdefs.EXIT_DIVERGED),
-                    (set([pkgdefs.EXIT_OK, pkgdefs.EXIT_DIVERGED]),
-                        pkgdefs.EXIT_DIVERGED),
-                ]
-                return self.__rvdict2rv(rvdict, rv_map)
+    def audit_self(self, latest_md=True):
+        """If the current image is a child image, this function
+        audits the current image to see if it's in sync with its
+        parent."""
 
-        def sync_rvdict2rv(self, rvdict):
-                """Convenience function that takes a dictionary returned from
-                an operations on multiple children and merges the results into
-                a single return code."""
+        if not self.ischild():
+            e = self.__apx_not_child()
+            return LI_RVTuple(pkgdefs.EXIT_OOPS, e, None)
 
-                rv_map = [
-                    (set([pkgdefs.EXIT_OK]), pkgdefs.EXIT_OK),
-                    (set([pkgdefs.EXIT_OK, pkgdefs.EXIT_NOP]), pkgdefs.EXIT_OK),
-                    (set([pkgdefs.EXIT_NOP]), pkgdefs.EXIT_NOP),
-                ]
-                return self.__rvdict2rv(rvdict, rv_map)
+        if not latest_md:
+            # we don't use the latest linked image metadata.
+            # instead return cached insync value which was
+            # computed using the initial linked image metadata
+            # that we loaded from disk.
+            if not self.__img_insync:
+                e = apx.LinkedImageException(child_diverged=self.child_name)
+                return LI_RVTuple(pkgdefs.EXIT_DIVERGED, e, None)
+            return LI_RVTuple(pkgdefs.EXIT_OK, None, None)
 
-        def detach_rvdict2rv(self, rvdict):
-                """Convenience function that takes a dictionary returned from
-                an operations on multiple children and merges the results into
-                a single return code."""
+        if not self.__insync():
+            e = apx.LinkedImageException(child_diverged=self.child_name)
+            return LI_RVTuple(pkgdefs.EXIT_DIVERGED, e, None)
 
-                return self.__rvdict2rv(rvdict)
+        return LI_RVTuple(pkgdefs.EXIT_OK, None, None)
 
-        def __validate_child_attach(self, lin, path, props,
-            allow_relink=False):
-                """Sanity check the parameters associated with a child image
-                that we are trying to attach."""
+    def insync(self, latest_md=True):
+        """A convenience wrapper for audit_self().  Note that we
+        consider non-child images as always in sync and ignore
+        any runtime errors."""
 
-                assert type(lin) == LinkedImageName
-                assert type(props) == dict
-                assert type(path) == str
+        rv = self.image.linked.audit_self(latest_md=latest_md)[0]
+        if rv == pkgdefs.EXIT_DIVERGED:
+            return False
+        return True
 
-                # check the name to make sure it doesn't already exist
-                if self.__verify_child_name(lin) and not allow_relink:
-                        raise apx.LinkedImageException(child_dup=lin)
+    @staticmethod
+    def __rvdict2rv(rvdict, rv_map=None):
+        """Internal helper function that takes a dictionary returned
+        from an operations on multiple children and merges the results
+        into a single return code."""
 
-                self.__validate_attach_props(PV_MODEL_PUSH, props)
+        _li_rvdict_check(rvdict)
+        if type(rv_map) != type(None):
+            assert type(rv_map) == list
+            for rv_set, rv in rv_map:
+                assert type(rv_set) == set
+                assert type(rv) == int
 
-                # Path must be an absolute path.
-                if not os.path.isabs(path):
-                        raise apx.LinkedImageException(child_path_notabs=path)
+        if not rvdict:
+            return LI_RVTuple(pkgdefs.EXIT_OK, None, None)
 
-                # If we're in an alternate root, the child must also be within
-                # that alternate root
-                path_transform = self.__props[PROP_PATH_TRANSFORM]
-                if not path_transform_applied(path, path_transform):
-                        raise apx.LinkedImageException(
-                            child_not_in_altroot=(path, path_transform[1]))
+        if not rv_map:
+            rv_map = [(set([pkgdefs.EXIT_OK]), pkgdefs.EXIT_OK)]
 
-                # path must be an image
+        p_dicts = [
+            rvtuple.rvt_p_dict
+            for rvtuple in six.itervalues(rvdict)
+            if rvtuple.rvt_p_dict is not None
+        ]
+
+        rv_mapped = set()
+        rv_seen = set([rvtuple.rvt_rv for rvtuple in six.itervalues(rvdict)])
+        for rv_map_set, rv_map_rv in rv_map:
+            if rv_seen == rv_map_set:
+                return LI_RVTuple(rv_map_rv, None, p_dicts)
+            # keep track of all the return values that are mapped
+            rv_mapped |= rv_map_set
+
+        # the mappings better have included pkgdefs.EXIT_OK
+        assert pkgdefs.EXIT_OK in rv_mapped
+
+        # if we had errors for unmapped return values, bundle them up
+        errs = [
+            rvtuple.rvt_e
+            for rvtuple in six.itervalues(rvdict)
+            if rvtuple.rvt_e and rvtuple.rvt_rv not in rv_mapped
+        ]
+        if len(errs) == 1:
+            err = errs[0]
+        elif errs:
+            err = apx.LinkedImageException(bundle=errs)
+        else:
+            err = None
+
+        if len(rv_seen) == 1:
+            # we have one consistent return value
+            return LI_RVTuple(list(rv_seen)[0], err, p_dicts)
+
+        return LI_RVTuple(pkgdefs.EXIT_PARTIAL, err, p_dicts)
+
+    def audit_rvdict2rv(self, rvdict):
+        """Convenience function that takes a dictionary returned from
+        an operations on multiple children and merges the results into
+        a single return code."""
+
+        rv_map = [
+            (set([pkgdefs.EXIT_OK]), pkgdefs.EXIT_OK),
+            (set([pkgdefs.EXIT_DIVERGED]), pkgdefs.EXIT_DIVERGED),
+            (
+                set([pkgdefs.EXIT_OK, pkgdefs.EXIT_DIVERGED]),
+                pkgdefs.EXIT_DIVERGED,
+            ),
+        ]
+        return self.__rvdict2rv(rvdict, rv_map)
+
+    def sync_rvdict2rv(self, rvdict):
+        """Convenience function that takes a dictionary returned from
+        an operations on multiple children and merges the results into
+        a single return code."""
+
+        rv_map = [
+            (set([pkgdefs.EXIT_OK]), pkgdefs.EXIT_OK),
+            (set([pkgdefs.EXIT_OK, pkgdefs.EXIT_NOP]), pkgdefs.EXIT_OK),
+            (set([pkgdefs.EXIT_NOP]), pkgdefs.EXIT_NOP),
+        ]
+        return self.__rvdict2rv(rvdict, rv_map)
+
+    def detach_rvdict2rv(self, rvdict):
+        """Convenience function that takes a dictionary returned from
+        an operations on multiple children and merges the results into
+        a single return code."""
+
+        return self.__rvdict2rv(rvdict)
+
+    def __validate_child_attach(self, lin, path, props, allow_relink=False):
+        """Sanity check the parameters associated with a child image
+        that we are trying to attach."""
+
+        assert type(lin) == LinkedImageName
+        assert type(props) == dict
+        assert type(path) == str
+
+        # check the name to make sure it doesn't already exist
+        if self.__verify_child_name(lin) and not allow_relink:
+            raise apx.LinkedImageException(child_dup=lin)
+
+        self.__validate_attach_props(PV_MODEL_PUSH, props)
+
+        # Path must be an absolute path.
+        if not os.path.isabs(path):
+            raise apx.LinkedImageException(child_path_notabs=path)
+
+        # If we're in an alternate root, the child must also be within
+        # that alternate root
+        path_transform = self.__props[PROP_PATH_TRANSFORM]
+        if not path_transform_applied(path, path_transform):
+            raise apx.LinkedImageException(
+                child_not_in_altroot=(path, path_transform[1])
+            )
+
+        # path must be an image
+        try:
+            img_prefix = ar.ar_img_prefix(path)
+        except OSError as e:
+            raise apx.LinkedImageException(
+                lin=lin, child_op_failed=("find", path, e)
+            )
+        if not img_prefix:
+            raise apx.LinkedImageException(child_bad_img=path)
+
+        # Does the parent image (ourselves) reside in clonable BE?
+        # Unused variable 'be_uuid'; pylint: disable=W0612
+        (be_name, be_uuid) = bootenv.BootEnv.get_be_name(self.__root)
+        # pylint: enable=W0612
+        img_is_clonable = bool(be_name)
+
+        # If the parent image is clonable then the new child image
+        # must be nested within the parents filesystem namespace.
+        path = path.rstrip(os.sep) + os.sep
+        p_root = self.__root.rstrip(os.sep) + os.sep
+        if img_is_clonable and not path.startswith(p_root):
+            raise apx.LinkedImageException(child_not_nested=(path, p_root))
+
+        # Child image should not already be linked
+        img_li_data_props = os.path.join(img_prefix, PATH_PROP)
+        try:
+            exists = ar.ar_exists(path, img_li_data_props)
+        except OSError as e:
+            # W0212 Access to a protected member
+            # pylint: disable=W0212
+            raise apx._convert_error(e)
+        if exists and not allow_relink:
+            raise apx.LinkedImageException(img_linked=path)
+
+        self.__validate_attach_img_paths(p_root, path)
+
+    def __validate_attach_img_paths(self, ppath, cpath):
+        """Make sure there are no additional images in between the
+        parent and the child. For example, this prevents linking of
+        images if one of the images is nested within another unrelated
+        image. This is done by looking at all the parent directories
+        for both the parent and the child image until we reach a
+        common ancestor."""
+
+        # Make sure each path has a trailing '/'.
+        ppath = ppath.rstrip(os.sep) + os.sep
+        cpath = cpath.rstrip(os.sep) + os.sep
+
+        # Make sure we're not linking to ourselves.
+        if ppath == cpath:
+            raise apx.LinkedImageException(link_to_self=ppath)
+
+        # The parent image can't be nested nested within child.
+        if ppath.startswith(cpath):
+            raise apx.LinkedImageException(parent_nested=(ppath, cpath))
+
+        # Make sure we're not linking the root image as a child.
+        if cpath == misc.liveroot():
+            raise apx.LinkedImageException(attach_root_as_child=cpath)
+
+        # Make sure our current image is at it's default path.  (We
+        # don't allow attaching new images if an image is located at
+        # an alternate path.)
+        if self.inaltroot():
+            raise apx.LinkedImageException(
+                attach_with_curpath=(self.path(), self.current_path())
+            )
+
+        def abort_if_imgdir(d):
+            """Raise an exception if directory 'd' contains an
+            image."""
+            try:
+                tmp = ar.ar_img_prefix(d)
+            except OSError as e:
+                # W0212 Access to a protected member
+                # pylint: disable=W0212
+                raise apx._convert_error(e)
+            if tmp:
+                raise apx.LinkedImageException(
+                    intermediate_image=(ppath, cpath, d)
+                )
+
+        # Find the common parent directory of the both parent and the
+        # child image.
+        dir_common = os.sep
+        pdirs = ppath.split(os.sep)[1:-1]
+        cdirs = cpath.split(os.sep)[1:-1]
+        for pdir, cdir in zip(pdirs, cdirs):
+            if pdir != cdir:
+                break
+            dir_common = os.path.join(dir_common, pdir)
+        dir_common = dir_common.rstrip(os.sep) + os.sep
+
+        # Test the common parent.
+        if ppath != dir_common and cpath != dir_common:
+            abort_if_imgdir(dir_common)
+
+        # First check the parent directories of the child.
+        d = os.path.dirname(cpath.rstrip(os.sep)) + os.sep
+        while len(d) > len(dir_common):
+            abort_if_imgdir(d)
+            d = os.path.dirname(d.rstrip(os.sep))
+            if d != os.sep:
+                d += os.sep
+
+        # Then check the parent directories of the parent.
+        d = os.path.dirname(ppath.rstrip(os.sep)) + os.sep
+        while len(d) > len(dir_common):
+            abort_if_imgdir(d)
+            d = os.path.dirname(d.rstrip(os.sep))
+            if d != os.sep:
+                d += os.sep
+
+    def attach_child(
+        self,
+        lin,
+        path,
+        props,
+        accept=False,
+        allow_relink=False,
+        force=False,
+        li_md_only=False,
+        li_pkg_updates=True,
+        noexecute=False,
+        progtrack=None,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        show_licenses=False,
+        update_index=True,
+    ):
+        """Attach an image as a child to the current image (the
+        current image will become a parent image. This operation
+        results in attempting to sync the child image with the parent
+        image.
+
+        For descriptions of parameters please see the descriptions in
+        api.py`gen_plan_*"""
+
+        assert type(lin) == LinkedImageName
+        assert type(path) == str
+        assert (
+            props is None or type(props) == dict
+        ), "type(props) == {0}".format(type(props))
+        if props is None:
+            props = dict()
+
+        lip = self.__plugins[lin.lin_type]
+        if not lip.support_attach and not force:
+            e = apx.LinkedImageException(attach_child_notsup=lin.lin_type)
+            return LI_RVTuple(e.lix_exitrv, e, None)
+
+        # Path must be an absolute path.
+        if not os.path.isabs(path):
+            e = apx.LinkedImageException(child_path_notabs=path)
+            return LI_RVTuple(e.lix_exitrv, e, None)
+
+        # cleanup specified path
+        cwd = os.getcwd()
+        try:
+            os.chdir(path)
+        except OSError as e:
+            e = apx.LinkedImageException(
+                lin=lin, child_op_failed=("access", path, e)
+            )
+            return LI_RVTuple(e.lix_exitrv, e, None)
+        path = os.getcwd()
+        os.chdir(cwd)
+
+        # if the current image isn't linked yet then we need to
+        # generate some linked image properties for ourselves
+        if PROP_PATH not in self.__props:
+            p_props = self.__fabricate_parent_props()
+            self.__update_props(p_props)
+
+        # sanity check the input
+        try:
+            self.__validate_child_attach(
+                lin, path, props, allow_relink=allow_relink
+            )
+        except apx.LinkedImageException as e:
+            return LI_RVTuple(e.lix_exitrv, e, None)
+
+        # make a copy of the options and start updating them
+        child_props = props.copy()
+        child_props[PROP_NAME] = lin
+        child_props[PROP_MODEL] = PV_MODEL_PUSH
+
+        # set path related properties
+        self.set_path_transform(
+            child_props, self.get_path_transform(), current_path=path
+        )
+
+        # fill in any missing defaults options
+        for k, v in six.iteritems(lip.attach_props_def):
+            if k not in child_props:
+                child_props[k] = v
+
+        # attach the child in memory
+        lip.attach_child_inmemory(child_props, allow_relink)
+
+        if noexecute and li_md_only:
+            # we've validated parameters, nothing else to do
+            return LI_RVTuple(pkgdefs.EXIT_OK, None, None)
+
+        # update the child
+        try:
+            lic = LinkedImageChild(self, lin)
+        except apx.LinkedImageException as e:
+            return LI_RVTuple(e.lix_exitrv, e, None)
+
+        rvdict = {}
+        list(
+            self.__children_op(
+                _pkg_op=pkgdefs.PKG_OP_SYNC,
+                _lic_list=[lic],
+                _rvdict=rvdict,
+                _progtrack=progtrack,
+                _failfast=False,
+                _expect_plan=True,
+                _syncmd_tmp=True,
+                accept=accept,
+                li_md_only=li_md_only,
+                li_pkg_updates=li_pkg_updates,
+                noexecute=noexecute,
+                refresh_catalogs=refresh_catalogs,
+                reject_list=reject_list,
+                show_licenses=show_licenses,
+                update_index=update_index,
+            )
+        )
+
+        rvtuple = rvdict[lin]
+
+        if noexecute or rvtuple.rvt_rv not in [
+            pkgdefs.EXIT_OK,
+            pkgdefs.EXIT_NOP,
+        ]:
+            return rvtuple
+
+        # commit child image property updates
+        rvtuple2 = lip.sync_children_todisk()
+        _li_rvtuple_check(rvtuple2)
+        if rvtuple2.rvt_e:
+            return rvtuple2
+
+        # save parent image properties
+        self.syncmd()
+
+        # The recursive child operation may have returned NOP, but
+        # since we always update our own image metadata, we always
+        # return OK.
+        if rvtuple.rvt_rv == pkgdefs.EXIT_NOP:
+            return LI_RVTuple(pkgdefs.EXIT_OK, None, None)
+        return rvtuple
+
+    def audit_children(self, lin_list):
+        """Audit one or more children of the current image to see if
+        they are in sync with this image."""
+
+        if lin_list == []:
+            lin_list = None
+
+        lic_dict, rvdict = self.__children_init(
+            lin_list=lin_list, failfast=False
+        )
+
+        list(
+            self.__children_op(
+                _pkg_op=pkgdefs.PKG_OP_AUDIT_LINKED,
+                _lic_list=list(lic_dict.values()),
+                _rvdict=rvdict,
+                _progtrack=progress.QuietProgressTracker(),
+                _failfast=False,
+            )
+        )
+        return rvdict
+
+    def sync_children(
+        self,
+        lin_list,
+        accept=False,
+        li_md_only=False,
+        li_pkg_updates=True,
+        progtrack=None,
+        noexecute=False,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        show_licenses=False,
+        update_index=True,
+    ):
+        """Sync one or more children of the current image."""
+
+        if progtrack is None:
+            progtrack = progress.NullProgressTracker()
+
+        if lin_list == []:
+            lin_list = None
+
+        lic_dict = self.__children_init(lin_list=lin_list)
+
+        _syncmd_tmp = True
+        if not noexecute and li_md_only:
+            _syncmd_tmp = False
+
+        rvdict = {}
+        list(
+            self.__children_op(
+                _pkg_op=pkgdefs.PKG_OP_SYNC,
+                _lic_list=list(lic_dict.values()),
+                _rvdict=rvdict,
+                _progtrack=progtrack,
+                _failfast=False,
+                _expect_plan=True,
+                _syncmd_tmp=_syncmd_tmp,
+                accept=accept,
+                li_md_only=li_md_only,
+                li_pkg_updates=li_pkg_updates,
+                noexecute=noexecute,
+                refresh_catalogs=refresh_catalogs,
+                reject_list=reject_list,
+                show_licenses=show_licenses,
+                update_index=update_index,
+            )
+        )
+        return rvdict
+
+    def detach_children(
+        self,
+        lin_list,
+        force=False,
+        noexecute=False,
+        li_md_only=False,
+        li_pkg_updates=True,
+    ):
+        """Detach one or more children from the current image. This
+        operation results in the removal of any constraint package
+        from the child images."""
+
+        if lin_list == []:
+            lin_list = None
+
+        lic_dict, rvdict = self.__children_init(
+            lin_list=lin_list, failfast=False
+        )
+
+        # check if we support detach for these children.  we don't use
+        # iteritems() when walking lic_dict because we might modify
+        # lic_dict.
+        for lin in lic_dict:
+            lip = self.__plugins[lin.lin_type]
+            if lip.support_detach or force:
+                continue
+
+            # we can't detach this type of image.
+            e = apx.LinkedImageException(detach_child_notsup=lin.lin_type)
+            rvdict[lin] = LI_RVTuple(e.lix_exitrv, e, None)
+            _li_rvtuple_check(rvdict[lin])
+            del lic_dict[lin]
+
+        # do the detach
+        list(
+            self.__children_op(
+                _pkg_op=pkgdefs.PKG_OP_DETACH,
+                _lic_list=list(lic_dict.values()),
+                _rvdict=rvdict,
+                _progtrack=progress.NullProgressTracker(),
+                _failfast=False,
+                li_md_only=li_md_only,
+                li_pkg_updates=li_pkg_updates,
+                noexecute=noexecute,
+            )
+        )
+
+        # if any of the children successfully detached, then we want
+        # to discard our metadata for that child.
+        for lin, rvtuple in six.iteritems(rvdict):
+            # if the detach failed leave metadata in parent
+            if rvtuple.rvt_e and not force:
+                continue
+
+            # detach the child in memory
+            lip = self.__plugins[lin.lin_type]
+            lip.detach_child_inmemory(lin)
+
+            if noexecute:
+                continue
+
+            # commit child image property updates
+            rvtuple2 = lip.sync_children_todisk()
+            _li_rvtuple_check(rvtuple2)
+
+            # don't overwrite previous errors
+            if rvtuple2.rvt_e and rvtuple.rvt_e is None:
+                rvdict[lin] = rvtuple2
+
+        if not (self.ischild() or self.isparent()):
+            # we're not linked anymore, so delete all our linked
+            # properties.
+            self.__update_props()
+            self.syncmd()
+
+        return rvdict
+
+    def __children_op(
+        self,
+        _pkg_op,
+        _lic_list,
+        _rvdict,
+        _progtrack,
+        _failfast,
+        _expect_plan=False,
+        _ignore_syncmd_nop=True,
+        _syncmd_tmp=False,
+        _pd=None,
+        **kwargs,
+    ):
+        """Wrapper for __children_op_vec() to stay compatible with old
+        callers which only support one operation for all linked images.
+
+        '_pkg_op' is the pkg.1 operation that we're going to perform
+
+        '_lic_list' is a list of linked image child objects to perform
+        the operation on.
+
+        '_ignore_syncmd_nop' a boolean that indicates if we should
+        always recurse into a child even if the linked image meta data
+        isn't changing.
+
+        See __children_op_vec() for an explanation of the remaining
+        options."""
+
+        for p_dict in self.__children_op_vec(
+            _lic_op_vectors=[(_pkg_op, _lic_list, kwargs, _ignore_syncmd_nop)],
+            _rvdict=_rvdict,
+            _progtrack=_progtrack,
+            _failfast=_failfast,
+            _expect_plan=_expect_plan,
+            _syncmd_tmp=_syncmd_tmp,
+            _pd=_pd,
+            stage=pkgdefs.API_STAGE_DEFAULT,
+        ):
+            yield p_dict
+
+    def __children_op_vec(
+        self,
+        _lic_op_vectors,
+        _rvdict,
+        _progtrack,
+        _failfast,
+        _expect_plan=False,
+        _syncmd_tmp=False,
+        _pd=None,
+        stage=pkgdefs.API_STAGE_DEFAULT,
+    ):
+        """An iterator function which performs a linked image
+        operation on multiple children in parallel.
+
+        '_lic_op_vectors' is a list of tuples containing the operation
+        to perform, the list of linked images the operation is to be
+        performed on, the kwargs for this operation and if the metadata
+        sync nop should be ignored in the following form:
+                [(pkg_op, lin_list, kwargs, ignore_syncmd_nop), ...]
+
+        '_rvdict' is a dictionary, indexed by linked image name, which
+        contains rvtuples of the result of the operation for each
+        child.
+
+        '_prograck' is a ProgressTracker pointer.
+
+        '_failfast' is a boolean.  If True and we encounter a failure
+        operating on a child then we raise an exception immediately.
+        If False then we'll attempt to perform the operation on all
+        children and rvdict will contain a LI_RVTuple result for all
+        children.
+
+        '_expect_plan' is a boolean that indicates if we expect this
+        operation to generate an image plan.
+
+        '_syncmd_tmp' a boolean that indicates if we should write
+        linked image metadata in a temporary location in child images,
+        or just overwrite any existing data.
+
+        '_pd' a PlanDescription pointer."""
+
+        lic_all = reduce(operator.add, [i[1] for i in _lic_op_vectors], [])
+        lic_num = len(lic_all)
+
+        # make sure we don't have any duplicate LICs or duplicate LINs
+        assert lic_num == len(set(lic_all))
+        assert lic_num == len(set([i.child_name for i in lic_all]))
+
+        # At the moment the PT doesn't seem to really use the operation
+        # type for display reasons. It only uses it to treat pubcheck
+        # differently. Therefore it should be sufficient to skip the
+        # operation type in case we have different operations going on
+        # at the same time.
+        # Additionally, if the operation is the same for all children
+        # we can use some optimizations.
+        concurrency = global_settings.client_concurrency
+        if len(_lic_op_vectors) == 1:
+            pkg_op = _lic_op_vectors[0][0]
+
+            if pkg_op in [
+                pkgdefs.PKG_OP_AUDIT_LINKED,
+                pkgdefs.PKG_OP_PUBCHECK,
+                pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+            ]:
+                # These operations are cheap so ideally we'd
+                # like to use full parallelism.  But if the user
+                # specified a concurrency limit we should
+                # respect that.
+                if not global_settings.client_concurrency_set:
+                    # No limit was specified, use full
+                    # concurrency.
+                    concurrency = -1
+        else:
+            pkg_op = "<various>"
+
+        if lic_num:
+            _progtrack.li_recurse_start(pkg_op, lic_num)
+
+        # If we have a plan for the current image that means linked
+        # image metadata is probably changing so we always save it to
+        # a temporary file (and we don't overwrite the existing
+        # metadata until after we execute the plan).
+        if _pd is not None:
+            _syncmd_tmp = True
+
+        lic_setup = []
+        for pkg_op, lic_list, kwargs, ignore_syncmd_nop in _lic_op_vectors:
+            if stage != pkgdefs.API_STAGE_DEFAULT:
+                kwargs = kwargs.copy()
+                kwargs["stage"] = stage
+
+            # get parent metadata common to all child images
+            _pmd = None
+            if pkg_op != pkgdefs.PKG_OP_DETACH:
+                ppubs = get_pubs(self.__img)
+                ppkgs = get_packages(self.__img, pd=_pd)
+                pfacets = get_inheritable_facets(self.__img, pd=_pd)
+                _pmd = (ppubs, ppkgs, pfacets)
+
+            # setup operation for each child
+            for lic in lic_list:
                 try:
-                        img_prefix = ar.ar_img_prefix(path)
-                except OSError as e:
-                        raise apx.LinkedImageException(lin=lin,
-                            child_op_failed=("find", path, e))
-                if not img_prefix:
-                        raise apx.LinkedImageException(child_bad_img=path)
-
-                # Does the parent image (ourselves) reside in clonable BE?
-                # Unused variable 'be_uuid'; pylint: disable=W0612
-                (be_name, be_uuid) = bootenv.BootEnv.get_be_name(self.__root)
-                # pylint: enable=W0612
-                img_is_clonable = bool(be_name)
-
-                # If the parent image is clonable then the new child image
-                # must be nested within the parents filesystem namespace.
-                path = path.rstrip(os.sep) + os.sep
-                p_root = self.__root.rstrip(os.sep) + os.sep
-                if img_is_clonable and not path.startswith(p_root):
-                        raise apx.LinkedImageException(
-                            child_not_nested=(path, p_root))
-
-                # Child image should not already be linked
-                img_li_data_props = os.path.join(img_prefix, PATH_PROP)
-                try:
-                        exists = ar.ar_exists(path, img_li_data_props)
-                except OSError as e:
-                        # W0212 Access to a protected member
-                        # pylint: disable=W0212
-                        raise apx._convert_error(e)
-                if exists and not allow_relink:
-                        raise apx.LinkedImageException(img_linked=path)
-
-                self.__validate_attach_img_paths(p_root, path)
-
-        def __validate_attach_img_paths(self, ppath, cpath):
-                """Make sure there are no additional images in between the
-                parent and the child. For example, this prevents linking of
-                images if one of the images is nested within another unrelated
-                image. This is done by looking at all the parent directories
-                for both the parent and the child image until we reach a
-                common ancestor."""
-
-                # Make sure each path has a trailing '/'.
-                ppath = ppath.rstrip(os.sep) + os.sep
-                cpath = cpath.rstrip(os.sep) + os.sep
-
-                # Make sure we're not linking to ourselves.
-                if ppath == cpath:
-                        raise apx.LinkedImageException(link_to_self=ppath)
-
-                # The parent image can't be nested nested within child.
-                if ppath.startswith(cpath):
-                        raise apx.LinkedImageException(
-                                parent_nested=(ppath, cpath))
-
-                # Make sure we're not linking the root image as a child.
-                if cpath == misc.liveroot():
-                        raise apx.LinkedImageException(
-                            attach_root_as_child=cpath)
-
-                # Make sure our current image is at it's default path.  (We
-                # don't allow attaching new images if an image is located at
-                # an alternate path.)
-                if self.inaltroot():
-                        raise apx.LinkedImageException(attach_with_curpath=(
-                            self.path(), self.current_path()))
-
-                def abort_if_imgdir(d):
-                        """Raise an exception if directory 'd' contains an
-                        image."""
-                        try:
-                                tmp = ar.ar_img_prefix(d)
-                        except OSError as e:
-                                # W0212 Access to a protected member
-                                # pylint: disable=W0212
-                                raise apx._convert_error(e)
-                        if tmp:
-                                raise apx.LinkedImageException(
-                                    intermediate_image=(ppath, cpath, d))
-
-                # Find the common parent directory of the both parent and the
-                # child image.
-                dir_common = os.sep
-                pdirs = ppath.split(os.sep)[1:-1]
-                cdirs = cpath.split(os.sep)[1:-1]
-                for pdir, cdir in zip(pdirs, cdirs):
-                        if pdir != cdir:
-                                break
-                        dir_common = os.path.join(dir_common, pdir)
-                dir_common = dir_common.rstrip(os.sep) + os.sep
-
-                # Test the common parent.
-                if ppath != dir_common and cpath != dir_common:
-                        abort_if_imgdir(dir_common)
-
-                # First check the parent directories of the child.
-                d = os.path.dirname(cpath.rstrip(os.sep)) + os.sep
-                while len(d) > len(dir_common):
-                        abort_if_imgdir(d)
-                        d = os.path.dirname(d.rstrip(os.sep))
-                        if d != os.sep:
-                                d += os.sep
-
-                # Then check the parent directories of the parent.
-                d = os.path.dirname(ppath.rstrip(os.sep)) + os.sep
-                while len(d) > len(dir_common):
-                        abort_if_imgdir(d)
-                        d = os.path.dirname(d.rstrip(os.sep))
-                        if d != os.sep:
-                                d += os.sep
-
-        def attach_child(self, lin, path, props,
-            accept=False, allow_relink=False, force=False, li_md_only=False,
-            li_pkg_updates=True, noexecute=False,
-            progtrack=None, refresh_catalogs=True, reject_list=misc.EmptyI,
-            show_licenses=False, update_index=True):
-                """Attach an image as a child to the current image (the
-                current image will become a parent image. This operation
-                results in attempting to sync the child image with the parent
-                image.
-
-                For descriptions of parameters please see the descriptions in
-                api.py`gen_plan_*"""
-
-                assert type(lin) == LinkedImageName
-                assert type(path) == str
-                assert props is None or type(props) == dict, \
-                    "type(props) == {0}".format(type(props))
-                if props is None:
-                        props = dict()
-
-                lip = self.__plugins[lin.lin_type]
-                if not lip.support_attach and not force:
-                        e = apx.LinkedImageException(
-                            attach_child_notsup=lin.lin_type)
-                        return LI_RVTuple(e.lix_exitrv, e, None)
-
-                # Path must be an absolute path.
-                if not os.path.isabs(path):
-                        e = apx.LinkedImageException(child_path_notabs=path)
-                        return LI_RVTuple(e.lix_exitrv, e, None)
-
-                # cleanup specified path
-                cwd = os.getcwd()
-                try:
-                        os.chdir(path)
-                except OSError as e:
-                        e = apx.LinkedImageException(lin=lin,
-                            child_op_failed=("access", path, e))
-                        return LI_RVTuple(e.lix_exitrv, e, None)
-                path = os.getcwd()
-                os.chdir(cwd)
-
-                # if the current image isn't linked yet then we need to
-                # generate some linked image properties for ourselves
-                if PROP_PATH not in self.__props:
-                        p_props = self.__fabricate_parent_props()
-                        self.__update_props(p_props)
-
-                # sanity check the input
-                try:
-                        self.__validate_child_attach(lin, path, props,
-                            allow_relink=allow_relink)
+                    lic.child_op_setup(
+                        pkg_op,
+                        _pmd,
+                        _progtrack,
+                        ignore_syncmd_nop,
+                        _syncmd_tmp,
+                        **kwargs,
+                    )
+                    lic_setup.append(lic)
                 except apx.LinkedImageException as e:
-                        return LI_RVTuple(e.lix_exitrv, e, None)
-
-                # make a copy of the options and start updating them
-                child_props = props.copy()
-                child_props[PROP_NAME] = lin
-                child_props[PROP_MODEL] = PV_MODEL_PUSH
-
-                # set path related properties
-                self.set_path_transform(child_props,
-                    self.get_path_transform(), current_path=path)
-
-                # fill in any missing defaults options
-                for k, v in six.iteritems(lip.attach_props_def):
-                        if k not in child_props:
-                                child_props[k] = v
-
-                # attach the child in memory
-                lip.attach_child_inmemory(child_props, allow_relink)
-
-                if noexecute and li_md_only:
-                        # we've validated parameters, nothing else to do
-                        return LI_RVTuple(pkgdefs.EXIT_OK, None, None)
-
-                # update the child
-                try:
-                        lic = LinkedImageChild(self, lin)
-                except apx.LinkedImageException as e:
-                        return LI_RVTuple(e.lix_exitrv, e, None)
-
-                rvdict = {}
-                list(self.__children_op(
-                    _pkg_op=pkgdefs.PKG_OP_SYNC,
-                    _lic_list=[lic],
-                    _rvdict=rvdict,
-                    _progtrack=progtrack,
-                    _failfast=False,
-                    _expect_plan=True,
-                    _syncmd_tmp=True,
-                    accept=accept,
-                    li_md_only=li_md_only,
-                    li_pkg_updates=li_pkg_updates,
-                    noexecute=noexecute,
-                    refresh_catalogs=refresh_catalogs,
-                    reject_list=reject_list,
-                    show_licenses=show_licenses,
-                    update_index=update_index))
-
-                rvtuple = rvdict[lin]
-
-                if noexecute or rvtuple.rvt_rv not in [
-                    pkgdefs.EXIT_OK, pkgdefs.EXIT_NOP ]:
-                        return rvtuple
-
-                # commit child image property updates
-                rvtuple2 = lip.sync_children_todisk()
-                _li_rvtuple_check(rvtuple2)
-                if rvtuple2.rvt_e:
-                        return rvtuple2
-
-                # save parent image properties
-                self.syncmd()
-
-                # The recursive child operation may have returned NOP, but
-                # since we always update our own image metadata, we always
-                # return OK.
-                if rvtuple.rvt_rv == pkgdefs.EXIT_NOP:
-                        return LI_RVTuple(pkgdefs.EXIT_OK, None, None)
-                return rvtuple
-
-        def audit_children(self, lin_list):
-                """Audit one or more children of the current image to see if
-                they are in sync with this image."""
-
-                if lin_list == []:
-                        lin_list = None
-
-                lic_dict, rvdict = self.__children_init(lin_list=lin_list,
-                    failfast=False)
-
-                list(self.__children_op(
-                    _pkg_op=pkgdefs.PKG_OP_AUDIT_LINKED,
-                    _lic_list=list(lic_dict.values()),
-                    _rvdict=rvdict,
-                    _progtrack=progress.QuietProgressTracker(),
-                    _failfast=False))
-                return rvdict
-
-        def sync_children(self, lin_list, accept=False,
-            li_md_only=False, li_pkg_updates=True, progtrack=None,
-            noexecute=False, refresh_catalogs=True, reject_list=misc.EmptyI,
-            show_licenses=False, update_index=True):
-                """Sync one or more children of the current image."""
-
-                if progtrack is None:
-                        progtrack = progress.NullProgressTracker()
-
-                if lin_list == []:
-                        lin_list = None
-
-                lic_dict = self.__children_init(lin_list=lin_list)
-
-                _syncmd_tmp = True
-                if not noexecute and li_md_only:
-                        _syncmd_tmp = False
-
-                rvdict = {}
-                list(self.__children_op(
-                    _pkg_op=pkgdefs.PKG_OP_SYNC,
-                    _lic_list=list(lic_dict.values()),
-                    _rvdict=rvdict,
-                    _progtrack=progtrack,
-                    _failfast=False,
-                    _expect_plan=True,
-                    _syncmd_tmp=_syncmd_tmp,
-                    accept=accept,
-                    li_md_only=li_md_only,
-                    li_pkg_updates=li_pkg_updates,
-                    noexecute=noexecute,
-                    refresh_catalogs=refresh_catalogs,
-                    reject_list=reject_list,
-                    show_licenses=show_licenses,
-                    update_index=update_index))
-                return rvdict
-
-        def detach_children(self, lin_list, force=False, noexecute=False,
-            li_md_only=False, li_pkg_updates=True):
-                """Detach one or more children from the current image. This
-                operation results in the removal of any constraint package
-                from the child images."""
-
-                if lin_list == []:
-                        lin_list = None
-
-                lic_dict, rvdict = self.__children_init(lin_list=lin_list,
-                    failfast=False)
-
-                # check if we support detach for these children.  we don't use
-                # iteritems() when walking lic_dict because we might modify
-                # lic_dict.
-                for lin in lic_dict:
-                        lip = self.__plugins[lin.lin_type]
-                        if lip.support_detach or force:
-                                continue
-
-                        # we can't detach this type of image.
-                        e = apx.LinkedImageException(
-                                detach_child_notsup=lin.lin_type)
-                        rvdict[lin] = LI_RVTuple(e.lix_exitrv, e, None)
-                        _li_rvtuple_check(rvdict[lin])
-                        del lic_dict[lin]
-
-                # do the detach
-                list(self.__children_op(
-                    _pkg_op=pkgdefs.PKG_OP_DETACH,
-                    _lic_list=list(lic_dict.values()),
-                    _rvdict=rvdict,
-                    _progtrack=progress.NullProgressTracker(),
-                    _failfast=False,
-                    li_md_only=li_md_only,
-                    li_pkg_updates=li_pkg_updates,
-                    noexecute=noexecute))
-
-                # if any of the children successfully detached, then we want
-                # to discard our metadata for that child.
-                for lin, rvtuple in six.iteritems(rvdict):
-
-                        # if the detach failed leave metadata in parent
-                        if rvtuple.rvt_e and not force:
-                                continue
-
-                        # detach the child in memory
-                        lip = self.__plugins[lin.lin_type]
-                        lip.detach_child_inmemory(lin)
-
-                        if noexecute:
-                                continue
-
-                        # commit child image property updates
-                        rvtuple2 = lip.sync_children_todisk()
-                        _li_rvtuple_check(rvtuple2)
-
-                        # don't overwrite previous errors
-                        if rvtuple2.rvt_e and rvtuple.rvt_e is None:
-                                rvdict[lin] = rvtuple2
-
-                if not (self.ischild() or self.isparent()):
-                        # we're not linked anymore, so delete all our linked
-                        # properties.
-                        self.__update_props()
-                        self.syncmd()
-
-                return rvdict
-
-        def __children_op(self, _pkg_op, _lic_list, _rvdict, _progtrack,
-            _failfast, _expect_plan=False, _ignore_syncmd_nop=True,
-            _syncmd_tmp=False, _pd=None, **kwargs):
-                """Wrapper for __children_op_vec() to stay compatible with old
-                callers which only support one operation for all linked images.
-
-                '_pkg_op' is the pkg.1 operation that we're going to perform
-
-                '_lic_list' is a list of linked image child objects to perform
-                the operation on.
-
-                '_ignore_syncmd_nop' a boolean that indicates if we should
-                always recurse into a child even if the linked image meta data
-                isn't changing.
-
-                See __children_op_vec() for an explanation of the remaining
-                options."""
-
-                for p_dict in self.__children_op_vec(
-                    _lic_op_vectors=[(_pkg_op, _lic_list, kwargs,
-                        _ignore_syncmd_nop)],
-                    _rvdict=_rvdict,
-                    _progtrack=_progtrack,
-                    _failfast=_failfast,
-                    _expect_plan=_expect_plan,
-                    _syncmd_tmp=_syncmd_tmp,
-                    _pd=_pd,
-                    stage=pkgdefs.API_STAGE_DEFAULT
-                    ):
-                        yield p_dict
-
-        def __children_op_vec(self, _lic_op_vectors, _rvdict, _progtrack,
-            _failfast, _expect_plan=False, _syncmd_tmp=False, _pd=None,
-            stage=pkgdefs.API_STAGE_DEFAULT):
-                """An iterator function which performs a linked image
-                operation on multiple children in parallel.
-
-                '_lic_op_vectors' is a list of tuples containing the operation
-                to perform, the list of linked images the operation is to be
-                performed on, the kwargs for this operation and if the metadata
-                sync nop should be ignored in the following form:
-                        [(pkg_op, lin_list, kwargs, ignore_syncmd_nop), ...]
-
-                '_rvdict' is a dictionary, indexed by linked image name, which
-                contains rvtuples of the result of the operation for each
-                child.
-
-                '_prograck' is a ProgressTracker pointer.
-
-                '_failfast' is a boolean.  If True and we encounter a failure
-                operating on a child then we raise an exception immediately.
-                If False then we'll attempt to perform the operation on all
-                children and rvdict will contain a LI_RVTuple result for all
-                children.
-
-                '_expect_plan' is a boolean that indicates if we expect this
-                operation to generate an image plan.
-
-                '_syncmd_tmp' a boolean that indicates if we should write
-                linked image metadata in a temporary location in child images,
-                or just overwrite any existing data.
-
-                '_pd' a PlanDescription pointer."""
-
-
-                lic_all = reduce(operator.add,
-                    [i[1] for i in _lic_op_vectors], [])
-                lic_num = len(lic_all)
-
-                # make sure we don't have any duplicate LICs or duplicate LINs
-                assert lic_num == len(set(lic_all))
-                assert lic_num == len(set([i.child_name for i in lic_all]))
-
-                # At the moment the PT doesn't seem to really use the operation
-                # type for display reasons. It only uses it to treat pubcheck
-                # differently. Therefore it should be sufficient to skip the
-                # operation type in case we have different operations going on
-                # at the same time.
-                # Additionally, if the operation is the same for all children
-                # we can use some optimizations.
-                concurrency = global_settings.client_concurrency
-                if len(_lic_op_vectors) == 1:
-                        pkg_op = _lic_op_vectors[0][0]
-
-                        if pkg_op in [ pkgdefs.PKG_OP_AUDIT_LINKED,
-                            pkgdefs.PKG_OP_PUBCHECK,
-                            pkgdefs.PKG_OP_HOTFIX_CLEANUP ]:
-                                # These operations are cheap so ideally we'd
-                                # like to use full parallelism.  But if the user
-                                # specified a concurrency limit we should
-                                # respect that.
-                                if not global_settings.client_concurrency_set:
-                                        # No limit was specified, use full
-                                        # concurrency.
-                                        concurrency = -1
-                else:
-                        pkg_op = "<various>"
-
-                if lic_num:
-                        _progtrack.li_recurse_start(pkg_op, lic_num)
-
-                # If we have a plan for the current image that means linked
-                # image metadata is probably changing so we always save it to
-                # a temporary file (and we don't overwrite the existing
-                # metadata until after we execute the plan).
-                if _pd is not None:
-                        _syncmd_tmp = True
-
-                lic_setup = []
-                for pkg_op, lic_list, kwargs, ignore_syncmd_nop in \
-                    _lic_op_vectors:
-
-                        if stage != pkgdefs.API_STAGE_DEFAULT:
-                                kwargs = kwargs.copy()
-                                kwargs["stage"] = stage
-
-                        # get parent metadata common to all child images
-                        _pmd = None
-                        if pkg_op != pkgdefs.PKG_OP_DETACH:
-                                ppubs = get_pubs(self.__img)
-                                ppkgs = get_packages(self.__img, pd=_pd)
-                                pfacets = get_inheritable_facets(self.__img,
-                                    pd=_pd)
-                                _pmd = (ppubs, ppkgs, pfacets)
-
-                        # setup operation for each child
-                        for lic in lic_list:
-                                try:
-                                        lic.child_op_setup(pkg_op, _pmd,
-                                            _progtrack, ignore_syncmd_nop,
-                                            _syncmd_tmp, **kwargs)
-                                        lic_setup.append(lic)
-                                except apx.LinkedImageException as e:
-                                        _rvdict[lic.child_name] = \
-                                            LI_RVTuple(e.lix_exitrv, e, None)
-
-                # if _failfast is true, then throw an exception if we failed
-                # to setup any of the children.  if _failfast is false we'll
-                # continue to perform the operation on any children that
-                # successfully initialized and we'll report setup errors along
-                # with the final results for all children.
-                if _failfast and _li_rvdict_exceptions(_rvdict):
-                        # before we raise an exception we need to cleanup any
-                        # children that we setup.
-                        for lic in lic_setup:
-                                lic.child_op_abort()
-                        # raise an exception
-                        _li_rvdict_raise_exceptions(_rvdict)
-
-                def __child_op_finish(lic, lic_list, _rvdict,
-                    _progtrack, _failfast, _expect_plan):
-                        """An iterator function invoked when a child has
-                        finished an operation.
-
-                        'lic' is the child that has finished execution.
-
-                        'lic_list' a list of children to remove 'lic' from.
-
-                        See __children_op() for an explanation of the other
-                        parameters."""
-
-                        assert lic.child_op_is_done()
-
-                        lic_list.remove(lic)
-
-                        rvtuple, stdout, stderr = lic.child_op_rv(_expect_plan)
-                        _li_rvtuple_check(rvtuple)
-                        _rvdict[lic.child_name] = rvtuple
-
-                        # check if we should raise an exception
-                        if _failfast and _li_rvdict_exceptions(_rvdict):
-
-                                # we're going to raise an exception.  abort
-                                # the remaining children.
-                                for lic in lic_list:
-                                        lic.child_op_abort()
-
-                                # raise an exception
-                                _li_rvdict_raise_exceptions(_rvdict)
-
-                        if rvtuple.rvt_rv in [ pkgdefs.EXIT_OK,
-                            pkgdefs.EXIT_NOP ]:
-
-                                # only display child output if there was no
-                                # error (otherwise the exception includes the
-                                # output so we'll display it twice.)
-                                _progtrack.li_recurse_output(lic.child_name,
-                                    stdout, stderr)
-
-                        # check if we should yield a plan.
-                        if _expect_plan and rvtuple.rvt_rv == pkgdefs.EXIT_OK:
-                                yield rvtuple.rvt_p_dict
-
-                # check if we did everything we needed to do during child
-                # setup.  (this can happen if we're just doing an implicit
-                # syncmd during setup we discover the linked image metadata
-                # isn't changing.)  we iterate over a copy of lic_setup to
-                # allow __child_op_finish() to remove elements from lic_setup
-                # while we're walking through it.
-                for lic in copy.copy(lic_setup):
-                        if not lic.child_op_is_done():
-                                continue
-                        for p_dict in __child_op_finish(lic, lic_setup,
-                            _rvdict, _progtrack, _failfast,
-                            _expect_plan):
-                                yield p_dict
-
-                # keep track of currently running children
-                lic_running = []
-
-                # keep going as long as there are children to process
+                    _rvdict[lic.child_name] = LI_RVTuple(e.lix_exitrv, e, None)
+
+        # if _failfast is true, then throw an exception if we failed
+        # to setup any of the children.  if _failfast is false we'll
+        # continue to perform the operation on any children that
+        # successfully initialized and we'll report setup errors along
+        # with the final results for all children.
+        if _failfast and _li_rvdict_exceptions(_rvdict):
+            # before we raise an exception we need to cleanup any
+            # children that we setup.
+            for lic in lic_setup:
+                lic.child_op_abort()
+            # raise an exception
+            _li_rvdict_raise_exceptions(_rvdict)
+
+        def __child_op_finish(
+            lic, lic_list, _rvdict, _progtrack, _failfast, _expect_plan
+        ):
+            """An iterator function invoked when a child has
+            finished an operation.
+
+            'lic' is the child that has finished execution.
+
+            'lic_list' a list of children to remove 'lic' from.
+
+            See __children_op() for an explanation of the other
+            parameters."""
+
+            assert lic.child_op_is_done()
+
+            lic_list.remove(lic)
+
+            rvtuple, stdout, stderr = lic.child_op_rv(_expect_plan)
+            _li_rvtuple_check(rvtuple)
+            _rvdict[lic.child_name] = rvtuple
+
+            # check if we should raise an exception
+            if _failfast and _li_rvdict_exceptions(_rvdict):
+                # we're going to raise an exception.  abort
+                # the remaining children.
+                for lic in lic_list:
+                    lic.child_op_abort()
+
+                # raise an exception
+                _li_rvdict_raise_exceptions(_rvdict)
+
+            if rvtuple.rvt_rv in [pkgdefs.EXIT_OK, pkgdefs.EXIT_NOP]:
+                # only display child output if there was no
+                # error (otherwise the exception includes the
+                # output so we'll display it twice.)
+                _progtrack.li_recurse_output(lic.child_name, stdout, stderr)
+
+            # check if we should yield a plan.
+            if _expect_plan and rvtuple.rvt_rv == pkgdefs.EXIT_OK:
+                yield rvtuple.rvt_p_dict
+
+        # check if we did everything we needed to do during child
+        # setup.  (this can happen if we're just doing an implicit
+        # syncmd during setup we discover the linked image metadata
+        # isn't changing.)  we iterate over a copy of lic_setup to
+        # allow __child_op_finish() to remove elements from lic_setup
+        # while we're walking through it.
+        for lic in copy.copy(lic_setup):
+            if not lic.child_op_is_done():
+                continue
+            for p_dict in __child_op_finish(
+                lic, lic_setup, _rvdict, _progtrack, _failfast, _expect_plan
+            ):
+                yield p_dict
+
+        # keep track of currently running children
+        lic_running = []
+
+        # keep going as long as there are children to process
+        progtrack_update = False
+        while len(lic_setup) or len(lic_running):
+            while lic_setup and (
+                concurrency > len(lic_running) or concurrency <= 0
+            ):
+                # start processing on a child
+                progtrack_update = True
+                lic = lic_setup.pop()
+                lic_running.append(lic)
+                lic.child_op_start()
+
+            if progtrack_update:
+                # display progress on children
                 progtrack_update = False
-                while len(lic_setup) or len(lic_running):
-
-                        while lic_setup and (
-                            concurrency > len(lic_running) or
-                            concurrency <= 0):
-                                # start processing on a child
-                                progtrack_update = True
-                                lic = lic_setup.pop()
-                                lic_running.append(lic)
-                                lic.child_op_start()
-
-                        if progtrack_update:
-                                # display progress on children
-                                progtrack_update = False
-                                done = lic_num - len(lic_setup) - \
-                                    len(lic_running)
-                                lin_running = sorted([
-                                    lic.child_name for lic in lic_running])
-                                _progtrack.li_recurse_status(lin_running,
-                                    done)
-
-                        # poll on all the linked image children and see which
-                        # ones have pending output.
-                        fd_hash = dict([
-                            (lic.fileno(), lic)
-                            for lic in lic_running
-                        ])
-                        p = select.poll()
-                        for fd in fd_hash.keys():
-                                p.register(fd, select.POLLIN)
-                        events = p.poll()
-                        lic_list = [ fd_hash[event[0]] for event in events ]
-
-                        for lic in lic_list:
-                                _progtrack.li_recurse_progress(lic.child_name)
-                                if not lic.child_op_is_done():
-                                        continue
-                                # a child finished processing
-                                progtrack_update = True
-                                for p_dict in __child_op_finish(lic,
-                                    lic_running, _rvdict, _progtrack,
-                                    _failfast, _expect_plan):
-                                        yield p_dict
-
-                _li_rvdict_check(_rvdict)
-                if lic_num:
-                        _progtrack.li_recurse_end()
-
-        def __children_init(self, lin_list=None, li_ignore=None, failfast=True):
-                """Initialize LinkedImageChild objects for children specified
-                in 'lin_list'.  If 'lin_list' is not specified, then
-                initialize objects for all children (excluding any being
-                ignored via 'li_ignore')."""
-
-                # you can't specify children to operate on and children to be
-                # ignored at the same time
-                assert lin_list is None or li_ignore is None
-
-                # if no children we listed, build a list of children
-                if lin_list is None:
-                        lin_list = [
-                            i[0]
-                            for i in self.__list_children(li_ignore)
-                        ]
-                else:
-                        self.verify_names(lin_list)
-
-                rvdict = {}
-                lic_dict = {}
-                for lin in lin_list:
-                        try:
-                                lic = LinkedImageChild(self, lin)
-                                lic_dict[lin] = lic
-                        except apx.LinkedImageException as e:
-                                rvdict[lin] = LI_RVTuple(e.lix_exitrv, e, None)
-
-                if failfast:
-                        _li_rvdict_raise_exceptions(rvdict)
-                        return lic_dict
-
-                return (lic_dict, rvdict)
-
-        def __recursion_init(self, li_ignore):
-                """Initialize child objects used during recursive packaging
-                operations."""
-
-                self.__lic_ignore = li_ignore
-                self.__lic_dict = self.__children_init(li_ignore=li_ignore)
-
-        def api_recurse_init(self, li_ignore=None, repos=None):
-                """Initialize planning state.  If we're a child image we save
-                our current state (which may reflect a planned state that we
-                have not committed to disk) into the plan.  We also initialize
-                all our children to prepare to recurse into them."""
-
-                if PROP_RECURSE in self.__props and \
-                    not self.__props[PROP_RECURSE]:
-                        # we don't want to recurse
-                        self.__recursion_init(li_ignore=[])
-                        return
-
-                # Initialize children
-                self.__recursion_init(li_ignore)
-
-                if not self.__lic_dict:
-                        # we don't need to recurse
-                        return
-
-                # if we have any children we don't support operations using
-                # temporary repositories.
-                if repos:
-                        raise apx.PlanCreationException(no_tmp_origins=True)
-
-        def api_recurse_pubcheck(self, progtrack):
-                """Do a recursive publisher check"""
-
-                # get a list of of children to recurse into.
-                lic_list = list(self.__lic_dict.values())
-
-                # do a publisher check on all of them
-                rvdict = {}
-                list(self.__children_op(
-                    _pkg_op=pkgdefs.PKG_OP_PUBCHECK,
-                    _lic_list=lic_list,
-                    _rvdict=rvdict,
-                    _progtrack=progtrack,
-                    _failfast=False))
-
-                # raise an exception if one or more children failed the
-                # publisher check.
-                _li_rvdict_raise_exceptions(rvdict)
-
-        def api_recurse_hfo_cleanup(self, progtrack):
-                """Do a recursive hot-fix origin cleanup"""
-
-                # get a list of of children to recurse into.
-                lic_list = list(self.__lic_dict.values())
-
-                rvdict = {}
-                list(self.__children_op(
-                    _pkg_op=pkgdefs.PKG_OP_HOTFIX_CLEANUP,
-                    _lic_list=lic_list,
-                    _rvdict=rvdict,
-                    _progtrack=progtrack,
-                    _failfast=False))
-
-                # raise an exception if one or more children failed
-                _li_rvdict_raise_exceptions(rvdict)
-
-        def __api_recurse(self, stage, progtrack):
-                """This is an iterator function.  It recurses into linked
-                image children to perform the specified operation.
-                """
-
-                # get a pointer to the current image plan
-                pd = self.__img.imageplan.pd
-
-                # get a list of of children to recurse into.
-                lic_list = list(self.__lic_dict.values())
-
-                # sanity check stage
-                assert stage in [pkgdefs.API_STAGE_PLAN,
-                    pkgdefs.API_STAGE_PREPARE, pkgdefs.API_STAGE_EXECUTE]
-
-                # if we're ignoring all children then we can't be recursing
-                assert pd.children_ignored != [] or lic_list == []
-
-                # sanity check the plan description state
-                if stage == pkgdefs.API_STAGE_PLAN:
-                        # the state should be uninitialized
-                        assert pd.children_planned == []
-                        assert pd.children_nop == []
-                else:
-                        # if we ignored all children, we better not have
-                        # recursed into any children.
-                        assert pd.children_ignored != [] or \
-                            pd.children_planned == pd.children_nop == []
-
-                        # there shouldn't be any overlap between sets of
-                        # children in the plan
-                        assert not (set(pd.children_planned) &
-                            set(pd.children_nop))
-                        if pd.children_ignored:
-                                assert not (set(pd.children_ignored) &
-                                    set(pd.children_planned))
-                                assert not (set(pd.children_ignored) &
-                                    set(pd.children_nop))
-
-                        # make sure set of child handles matches the set of
-                        # previously planned children.
-                        assert set(self.__lic_dict) == set(pd.children_planned)
-
-                # if we're in the planning stage, we should pass the current
-                # image plan onto the child and also expect an image plan from
-                # the child.
-                expect_plan = False
-                if stage == pkgdefs.API_STAGE_PLAN:
-                        expect_plan = True
-
-                # Assemble list of LICs from LINs in pd.child_op_vectors and
-                # create new lic_op_vectors to pass to __children_op_vec().
-                lic_op_vectors = []
-                for op, lin_list, kwargs, ignore_syncmd_nop in \
-                    pd.child_op_vectors:
-                        assert "stage" not in kwargs
-                        lic_list = []
-                        for l in lin_list:
-                                try:
-                                        lic_list.append(self.__lic_dict[l])
-                                except KeyError:
-                                        # For the prepare and execute phase we
-                                        # remove children for which there is
-                                        # nothing to do from self.__lic_dict.
-                                        # So ignore those we can't find.
-                                        pass
-                        lic_op_vectors.append((op, lic_list, kwargs,
-                            ignore_syncmd_nop))
-
-                rvdict = {}
-                for p_dict in self.__children_op_vec(
-                    _lic_op_vectors=lic_op_vectors,
-                    _rvdict=rvdict,
-                    _progtrack=progtrack,
-                    _failfast=True,
-                    _expect_plan=expect_plan,
-                    stage=stage,
-                    _pd=pd):
-                        yield p_dict
-
-                assert not _li_rvdict_exceptions(rvdict)
-
-                for lin in rvdict:
-                        # check for children that don't need any updates
-                        if rvdict[lin].rvt_rv == pkgdefs.EXIT_NOP:
-                                assert lin not in pd.children_nop
-                                pd.children_nop.append(lin)
-                                del self.__lic_dict[lin]
-
-                        # record the children that are done planning
-                        if stage == pkgdefs.API_STAGE_PLAN and \
-                            rvdict[lin].rvt_rv == pkgdefs.EXIT_OK:
-                                assert lin not in pd.children_planned
-                                pd.children_planned.append(lin)
-
-        @staticmethod
-        def __recursion_ops(api_op):
-                """Determine what pkg command to use when recursing into child
-                images."""
-
-                #
-                # given the api operation being performed on the current
-                # image, figure out what api operation should be performed on
-                # child images.
-                #
-                # the recursion policy which hard coded here is that if we do
-                # an pkg update in the parent image without any packages
-                # specified (ie, we want to update everything) then when we
-                # recurse we'll also do an update of everything.  but if we're
-                # doing any other operation like install, uninstall, an update
-                # of specific packages, etc, then when we recurse we'll do a
-                # sync in the child.
-                #
-
-
-                # To improve performance we assume the child is already in sync,
-                # so if its linked image metadata isn't changing then the child
-                # won't need any updates so there will be no need to recurse
-                # into it.
-                ignore_syncmd_nop = False
-                pkg_op_erecurse = None
-
-                if api_op == pkgdefs.API_OP_SYNC:
-                        pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
-                        # If we are doing an explicit sync, we do have to make
-                        # sure we actually recurse into the child and sync
-                        # metadata.
-                        ignore_syncmd_nop = True
-                elif api_op == pkgdefs.API_OP_INSTALL:
-                        pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
-                        pkg_op_erecurse = pkgdefs.PKG_OP_INSTALL
-                elif api_op == pkgdefs.API_OP_CHANGE_FACET:
-                        pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
-                        pkg_op_erecurse = pkgdefs.PKG_OP_CHANGE_FACET
-                elif api_op == pkgdefs.API_OP_CHANGE_VARIANT:
-                        pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
-                        pkg_op_erecurse = pkgdefs.PKG_OP_CHANGE_VARIANT
-                if api_op == pkgdefs.API_OP_UPDATE:
-                        pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
-                        pkg_op_erecurse = pkgdefs.PKG_OP_UPDATE
-                elif api_op == pkgdefs.API_OP_UNINSTALL:
-                        pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
-                        pkg_op_erecurse = pkgdefs.PKG_OP_UNINSTALL
-                else:
-                        pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
-
-                return pkg_op_irecurse, pkg_op_erecurse, ignore_syncmd_nop
-
-        @staticmethod
-        def __recursion_args(op, refresh_catalogs, update_index, api_kwargs):
-                """Determine what pkg command arguments to use when recursing
-                into child images."""
-
-                kwargs = {}
-                kwargs["noexecute"] = api_kwargs["noexecute"]
-                kwargs["refresh_catalogs"] = refresh_catalogs
-                kwargs["show_licenses"] = False
-                kwargs["update_index"] = update_index
-
-                #
-                # when we recurse we always accept all new licenses (for now).
-                #
-                # ultimately (when start yielding back plan descriptions for
-                # children) in addition to accepting licenses on the plan for
-                # the current image the api client will also have to
-                # explicitly accept licenses for all child images.  but until
-                # that happens we'll just assume that the parent image license
-                # space is a superset of the child image license space (and
-                # since the api consumer must accept licenses in the parent
-                # before we'll do anything, we'll assume licenses in the child
-                # are accepted as well).
-                #
-                kwargs["accept"] = True
-
-                if "li_pkg_updates" in api_kwargs:
-                        # option specific to: attach, set-property-linked, sync
-                        kwargs["li_pkg_updates"] = api_kwargs["li_pkg_updates"]
-
-                if op == pkgdefs.PKG_OP_INSTALL:
-                        assert "pkgs_inst" in api_kwargs
-                        # option specific to: install
-                        kwargs["pkgs_inst"] = api_kwargs["pkgs_inst"]
-                        kwargs["reject_list"] = api_kwargs["reject_list"]
-                elif op == pkgdefs.PKG_OP_CHANGE_VARIANT:
-                        assert "variants" in api_kwargs
-                        # option specific to: change-variant
-                        kwargs["variants"] = api_kwargs["variants"]
-                        kwargs["facets"] = None
-                        kwargs["reject_list"] = api_kwargs["reject_list"]
-                elif op == pkgdefs.PKG_OP_CHANGE_FACET:
-                        assert "facets" in api_kwargs
-                        # option specific to: change-facet
-                        kwargs["facets"] = api_kwargs["facets"]
-                        kwargs["variants"] = None
-                        kwargs["reject_list"] = api_kwargs["reject_list"]
-                elif op == pkgdefs.PKG_OP_UNINSTALL:
-                        assert "pkgs_to_uninstall" in api_kwargs
-                        # option specific to: uninstall
-                        kwargs["pkgs_to_uninstall"] = \
-                            api_kwargs["pkgs_to_uninstall"]
-                        del kwargs["show_licenses"]
-                        del kwargs["refresh_catalogs"]
-                        del kwargs["accept"]
-                elif op == pkgdefs.PKG_OP_UPDATE:
-                        # skip ipkg up to date check for child images
-                        kwargs["force"] = True
-                        kwargs["pkgs_update"] = api_kwargs["pkgs_update"]
-                        kwargs["reject_list"] = api_kwargs["reject_list"]
-
-                return kwargs
-
-        def api_recurse_plan(self, api_kwargs, erecurse_list, refresh_catalogs,
-            update_index, progtrack):
-                """Plan child image updates."""
-
-                pd = self.__img.imageplan.pd
-                api_op = pd.plan_type
-
-                pd.child_op_vectors = []
-
-                # Get LinkedImageNames of all children
-                lin_list = list(self.__lic_dict.keys())
-
-                pkg_op_irecurse, pkg_op_erecurse, ignore_syncmd_nop = \
-                    self.__recursion_ops(api_op)
-
-                # Prepare op vector for explicit recurse operations
-                if erecurse_list:
-                        assert pkg_op_erecurse
-                        # remove recurse children from sync list
-                        lin_list = list(set(lin_list) - set(erecurse_list))
-
-                        erecurse_kwargs = self.__recursion_args(pkg_op_erecurse,
-                            refresh_catalogs, update_index, api_kwargs)
-                        pd.child_op_vectors.append((pkg_op_erecurse,
-                            list(erecurse_list), erecurse_kwargs, True))
-
-                # Prepare op vector for implicit recurse operations
-                irecurse_kwargs = self.__recursion_args(pkg_op_irecurse,
-                    refresh_catalogs, update_index, api_kwargs)
-
-                pd.child_op_vectors.append((pkg_op_irecurse, lin_list,
-                    irecurse_kwargs, ignore_syncmd_nop))
-
-                pd.children_ignored = self.__lic_ignore
-
-                # recurse into children
-                for p_dict in self.__api_recurse(pkgdefs.API_STAGE_PLAN,
-                    progtrack):
-                        yield p_dict
-
-        def api_recurse_prepare(self, progtrack):
-                """Prepare child image updates."""
-                progtrack.set_major_phase(progtrack.PHASE_DOWNLOAD)
-                list(self.__api_recurse(pkgdefs.API_STAGE_PREPARE, progtrack))
-
-        def api_recurse_execute(self, progtrack):
-                """Execute child image updates."""
-                progtrack.set_major_phase(progtrack.PHASE_FINALIZE)
-                list(self.__api_recurse(pkgdefs.API_STAGE_EXECUTE, progtrack))
-
-        def init_plan(self, pd):
-                """Initialize our state in the PlanDescription."""
-
-                # if we're a child, save our parent package state into the
-                # plan description
-                pd.li_props = rm_dict_ent(self.__props.copy(), temporal_props)
-                pd.li_ppkgs = self.__ppkgs
-                pd.li_ppubs = self.__ppubs
-                pd.li_pfacets = self.__pfacets
-
-        def setup_plan(self, pd):
-                """Reload a previously created plan."""
-
-                # make a copy of the linked image properties
-                props = pd.li_props.copy()
-
-                # generate temporal properties
-                if props:
-                        self.__set_current_path(props)
-
-                # load linked image state from the plan
-                self.__update_props(props)
-                self.__ppubs = pd.li_ppubs
-                self.__ppkgs = pd.li_ppkgs
-                self.__pfacets = pd.li_pfacets
-
-                # now initialize our recursion state, this involves allocating
-                # handles to operate on children.  we don't need handles for
-                # children that were either ignored during planning, or which
-                # return EXIT_NOP after planning (since these children don't
-                # need any updates).
-                li_ignore = copy.copy(pd.children_ignored)
-
-                # merge the children that returned nop into li_ignore (since
-                # we don't need to recurse into them).  if li_ignore is [],
-                # then we ignored all children during planning
-                if li_ignore != [] and pd.children_nop:
-                        if li_ignore is None:
-                                # no children were ignored during planning
-                                li_ignore = []
-                        li_ignore += pd.children_nop
-
-                # Initialize children
-                self.__recursion_init(li_ignore=li_ignore)
-
-        def recurse_nothingtodo(self):
-                """Return True if there is no planned work to do on child
-                image."""
-
-                for lic in six.itervalues(self.__lic_dict):
-                        if lic.child_name not in \
-                            self.__img.imageplan.pd.children_nop:
-                                return False
-                return True
+                done = lic_num - len(lic_setup) - len(lic_running)
+                lin_running = sorted([lic.child_name for lic in lic_running])
+                _progtrack.li_recurse_status(lin_running, done)
+
+            # poll on all the linked image children and see which
+            # ones have pending output.
+            fd_hash = dict([(lic.fileno(), lic) for lic in lic_running])
+            p = select.poll()
+            for fd in fd_hash.keys():
+                p.register(fd, select.POLLIN)
+            events = p.poll()
+            lic_list = [fd_hash[event[0]] for event in events]
+
+            for lic in lic_list:
+                _progtrack.li_recurse_progress(lic.child_name)
+                if not lic.child_op_is_done():
+                    continue
+                # a child finished processing
+                progtrack_update = True
+                for p_dict in __child_op_finish(
+                    lic,
+                    lic_running,
+                    _rvdict,
+                    _progtrack,
+                    _failfast,
+                    _expect_plan,
+                ):
+                    yield p_dict
+
+        _li_rvdict_check(_rvdict)
+        if lic_num:
+            _progtrack.li_recurse_end()
+
+    def __children_init(self, lin_list=None, li_ignore=None, failfast=True):
+        """Initialize LinkedImageChild objects for children specified
+        in 'lin_list'.  If 'lin_list' is not specified, then
+        initialize objects for all children (excluding any being
+        ignored via 'li_ignore')."""
+
+        # you can't specify children to operate on and children to be
+        # ignored at the same time
+        assert lin_list is None or li_ignore is None
+
+        # if no children we listed, build a list of children
+        if lin_list is None:
+            lin_list = [i[0] for i in self.__list_children(li_ignore)]
+        else:
+            self.verify_names(lin_list)
+
+        rvdict = {}
+        lic_dict = {}
+        for lin in lin_list:
+            try:
+                lic = LinkedImageChild(self, lin)
+                lic_dict[lin] = lic
+            except apx.LinkedImageException as e:
+                rvdict[lin] = LI_RVTuple(e.lix_exitrv, e, None)
+
+        if failfast:
+            _li_rvdict_raise_exceptions(rvdict)
+            return lic_dict
+
+        return (lic_dict, rvdict)
+
+    def __recursion_init(self, li_ignore):
+        """Initialize child objects used during recursive packaging
+        operations."""
+
+        self.__lic_ignore = li_ignore
+        self.__lic_dict = self.__children_init(li_ignore=li_ignore)
+
+    def api_recurse_init(self, li_ignore=None, repos=None):
+        """Initialize planning state.  If we're a child image we save
+        our current state (which may reflect a planned state that we
+        have not committed to disk) into the plan.  We also initialize
+        all our children to prepare to recurse into them."""
+
+        if PROP_RECURSE in self.__props and not self.__props[PROP_RECURSE]:
+            # we don't want to recurse
+            self.__recursion_init(li_ignore=[])
+            return
+
+        # Initialize children
+        self.__recursion_init(li_ignore)
+
+        if not self.__lic_dict:
+            # we don't need to recurse
+            return
+
+        # if we have any children we don't support operations using
+        # temporary repositories.
+        if repos:
+            raise apx.PlanCreationException(no_tmp_origins=True)
+
+    def api_recurse_pubcheck(self, progtrack):
+        """Do a recursive publisher check"""
+
+        # get a list of of children to recurse into.
+        lic_list = list(self.__lic_dict.values())
+
+        # do a publisher check on all of them
+        rvdict = {}
+        list(
+            self.__children_op(
+                _pkg_op=pkgdefs.PKG_OP_PUBCHECK,
+                _lic_list=lic_list,
+                _rvdict=rvdict,
+                _progtrack=progtrack,
+                _failfast=False,
+            )
+        )
+
+        # raise an exception if one or more children failed the
+        # publisher check.
+        _li_rvdict_raise_exceptions(rvdict)
+
+    def api_recurse_hfo_cleanup(self, progtrack):
+        """Do a recursive hot-fix origin cleanup"""
+
+        # get a list of of children to recurse into.
+        lic_list = list(self.__lic_dict.values())
+
+        rvdict = {}
+        list(
+            self.__children_op(
+                _pkg_op=pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+                _lic_list=lic_list,
+                _rvdict=rvdict,
+                _progtrack=progtrack,
+                _failfast=False,
+            )
+        )
+
+        # raise an exception if one or more children failed
+        _li_rvdict_raise_exceptions(rvdict)
+
+    def __api_recurse(self, stage, progtrack):
+        """This is an iterator function.  It recurses into linked
+        image children to perform the specified operation.
+        """
+
+        # get a pointer to the current image plan
+        pd = self.__img.imageplan.pd
+
+        # get a list of of children to recurse into.
+        lic_list = list(self.__lic_dict.values())
+
+        # sanity check stage
+        assert stage in [
+            pkgdefs.API_STAGE_PLAN,
+            pkgdefs.API_STAGE_PREPARE,
+            pkgdefs.API_STAGE_EXECUTE,
+        ]
+
+        # if we're ignoring all children then we can't be recursing
+        assert pd.children_ignored != [] or lic_list == []
+
+        # sanity check the plan description state
+        if stage == pkgdefs.API_STAGE_PLAN:
+            # the state should be uninitialized
+            assert pd.children_planned == []
+            assert pd.children_nop == []
+        else:
+            # if we ignored all children, we better not have
+            # recursed into any children.
+            assert (
+                pd.children_ignored != []
+                or pd.children_planned == pd.children_nop == []
+            )
+
+            # there shouldn't be any overlap between sets of
+            # children in the plan
+            assert not (set(pd.children_planned) & set(pd.children_nop))
+            if pd.children_ignored:
+                assert not (set(pd.children_ignored) & set(pd.children_planned))
+                assert not (set(pd.children_ignored) & set(pd.children_nop))
+
+            # make sure set of child handles matches the set of
+            # previously planned children.
+            assert set(self.__lic_dict) == set(pd.children_planned)
+
+        # if we're in the planning stage, we should pass the current
+        # image plan onto the child and also expect an image plan from
+        # the child.
+        expect_plan = False
+        if stage == pkgdefs.API_STAGE_PLAN:
+            expect_plan = True
+
+        # Assemble list of LICs from LINs in pd.child_op_vectors and
+        # create new lic_op_vectors to pass to __children_op_vec().
+        lic_op_vectors = []
+        for op, lin_list, kwargs, ignore_syncmd_nop in pd.child_op_vectors:
+            assert "stage" not in kwargs
+            lic_list = []
+            for l in lin_list:
+                try:
+                    lic_list.append(self.__lic_dict[l])
+                except KeyError:
+                    # For the prepare and execute phase we
+                    # remove children for which there is
+                    # nothing to do from self.__lic_dict.
+                    # So ignore those we can't find.
+                    pass
+            lic_op_vectors.append((op, lic_list, kwargs, ignore_syncmd_nop))
+
+        rvdict = {}
+        for p_dict in self.__children_op_vec(
+            _lic_op_vectors=lic_op_vectors,
+            _rvdict=rvdict,
+            _progtrack=progtrack,
+            _failfast=True,
+            _expect_plan=expect_plan,
+            stage=stage,
+            _pd=pd,
+        ):
+            yield p_dict
+
+        assert not _li_rvdict_exceptions(rvdict)
+
+        for lin in rvdict:
+            # check for children that don't need any updates
+            if rvdict[lin].rvt_rv == pkgdefs.EXIT_NOP:
+                assert lin not in pd.children_nop
+                pd.children_nop.append(lin)
+                del self.__lic_dict[lin]
+
+            # record the children that are done planning
+            if (
+                stage == pkgdefs.API_STAGE_PLAN
+                and rvdict[lin].rvt_rv == pkgdefs.EXIT_OK
+            ):
+                assert lin not in pd.children_planned
+                pd.children_planned.append(lin)
+
+    @staticmethod
+    def __recursion_ops(api_op):
+        """Determine what pkg command to use when recursing into child
+        images."""
+
+        #
+        # given the api operation being performed on the current
+        # image, figure out what api operation should be performed on
+        # child images.
+        #
+        # the recursion policy which hard coded here is that if we do
+        # an pkg update in the parent image without any packages
+        # specified (ie, we want to update everything) then when we
+        # recurse we'll also do an update of everything.  but if we're
+        # doing any other operation like install, uninstall, an update
+        # of specific packages, etc, then when we recurse we'll do a
+        # sync in the child.
+        #
+
+        # To improve performance we assume the child is already in sync,
+        # so if its linked image metadata isn't changing then the child
+        # won't need any updates so there will be no need to recurse
+        # into it.
+        ignore_syncmd_nop = False
+        pkg_op_erecurse = None
+
+        if api_op == pkgdefs.API_OP_SYNC:
+            pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
+            # If we are doing an explicit sync, we do have to make
+            # sure we actually recurse into the child and sync
+            # metadata.
+            ignore_syncmd_nop = True
+        elif api_op == pkgdefs.API_OP_INSTALL:
+            pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
+            pkg_op_erecurse = pkgdefs.PKG_OP_INSTALL
+        elif api_op == pkgdefs.API_OP_CHANGE_FACET:
+            pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
+            pkg_op_erecurse = pkgdefs.PKG_OP_CHANGE_FACET
+        elif api_op == pkgdefs.API_OP_CHANGE_VARIANT:
+            pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
+            pkg_op_erecurse = pkgdefs.PKG_OP_CHANGE_VARIANT
+        if api_op == pkgdefs.API_OP_UPDATE:
+            pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
+            pkg_op_erecurse = pkgdefs.PKG_OP_UPDATE
+        elif api_op == pkgdefs.API_OP_UNINSTALL:
+            pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
+            pkg_op_erecurse = pkgdefs.PKG_OP_UNINSTALL
+        else:
+            pkg_op_irecurse = pkgdefs.PKG_OP_SYNC
+
+        return pkg_op_irecurse, pkg_op_erecurse, ignore_syncmd_nop
+
+    @staticmethod
+    def __recursion_args(op, refresh_catalogs, update_index, api_kwargs):
+        """Determine what pkg command arguments to use when recursing
+        into child images."""
+
+        kwargs = {}
+        kwargs["noexecute"] = api_kwargs["noexecute"]
+        kwargs["refresh_catalogs"] = refresh_catalogs
+        kwargs["show_licenses"] = False
+        kwargs["update_index"] = update_index
+
+        #
+        # when we recurse we always accept all new licenses (for now).
+        #
+        # ultimately (when start yielding back plan descriptions for
+        # children) in addition to accepting licenses on the plan for
+        # the current image the api client will also have to
+        # explicitly accept licenses for all child images.  but until
+        # that happens we'll just assume that the parent image license
+        # space is a superset of the child image license space (and
+        # since the api consumer must accept licenses in the parent
+        # before we'll do anything, we'll assume licenses in the child
+        # are accepted as well).
+        #
+        kwargs["accept"] = True
+
+        if "li_pkg_updates" in api_kwargs:
+            # option specific to: attach, set-property-linked, sync
+            kwargs["li_pkg_updates"] = api_kwargs["li_pkg_updates"]
+
+        if op == pkgdefs.PKG_OP_INSTALL:
+            assert "pkgs_inst" in api_kwargs
+            # option specific to: install
+            kwargs["pkgs_inst"] = api_kwargs["pkgs_inst"]
+            kwargs["reject_list"] = api_kwargs["reject_list"]
+        elif op == pkgdefs.PKG_OP_CHANGE_VARIANT:
+            assert "variants" in api_kwargs
+            # option specific to: change-variant
+            kwargs["variants"] = api_kwargs["variants"]
+            kwargs["facets"] = None
+            kwargs["reject_list"] = api_kwargs["reject_list"]
+        elif op == pkgdefs.PKG_OP_CHANGE_FACET:
+            assert "facets" in api_kwargs
+            # option specific to: change-facet
+            kwargs["facets"] = api_kwargs["facets"]
+            kwargs["variants"] = None
+            kwargs["reject_list"] = api_kwargs["reject_list"]
+        elif op == pkgdefs.PKG_OP_UNINSTALL:
+            assert "pkgs_to_uninstall" in api_kwargs
+            # option specific to: uninstall
+            kwargs["pkgs_to_uninstall"] = api_kwargs["pkgs_to_uninstall"]
+            del kwargs["show_licenses"]
+            del kwargs["refresh_catalogs"]
+            del kwargs["accept"]
+        elif op == pkgdefs.PKG_OP_UPDATE:
+            # skip ipkg up to date check for child images
+            kwargs["force"] = True
+            kwargs["pkgs_update"] = api_kwargs["pkgs_update"]
+            kwargs["reject_list"] = api_kwargs["reject_list"]
+
+        return kwargs
+
+    def api_recurse_plan(
+        self,
+        api_kwargs,
+        erecurse_list,
+        refresh_catalogs,
+        update_index,
+        progtrack,
+    ):
+        """Plan child image updates."""
+
+        pd = self.__img.imageplan.pd
+        api_op = pd.plan_type
+
+        pd.child_op_vectors = []
+
+        # Get LinkedImageNames of all children
+        lin_list = list(self.__lic_dict.keys())
+
+        (
+            pkg_op_irecurse,
+            pkg_op_erecurse,
+            ignore_syncmd_nop,
+        ) = self.__recursion_ops(api_op)
+
+        # Prepare op vector for explicit recurse operations
+        if erecurse_list:
+            assert pkg_op_erecurse
+            # remove recurse children from sync list
+            lin_list = list(set(lin_list) - set(erecurse_list))
+
+            erecurse_kwargs = self.__recursion_args(
+                pkg_op_erecurse, refresh_catalogs, update_index, api_kwargs
+            )
+            pd.child_op_vectors.append(
+                (pkg_op_erecurse, list(erecurse_list), erecurse_kwargs, True)
+            )
+
+        # Prepare op vector for implicit recurse operations
+        irecurse_kwargs = self.__recursion_args(
+            pkg_op_irecurse, refresh_catalogs, update_index, api_kwargs
+        )
+
+        pd.child_op_vectors.append(
+            (pkg_op_irecurse, lin_list, irecurse_kwargs, ignore_syncmd_nop)
+        )
+
+        pd.children_ignored = self.__lic_ignore
+
+        # recurse into children
+        for p_dict in self.__api_recurse(pkgdefs.API_STAGE_PLAN, progtrack):
+            yield p_dict
+
+    def api_recurse_prepare(self, progtrack):
+        """Prepare child image updates."""
+        progtrack.set_major_phase(progtrack.PHASE_DOWNLOAD)
+        list(self.__api_recurse(pkgdefs.API_STAGE_PREPARE, progtrack))
+
+    def api_recurse_execute(self, progtrack):
+        """Execute child image updates."""
+        progtrack.set_major_phase(progtrack.PHASE_FINALIZE)
+        list(self.__api_recurse(pkgdefs.API_STAGE_EXECUTE, progtrack))
+
+    def init_plan(self, pd):
+        """Initialize our state in the PlanDescription."""
+
+        # if we're a child, save our parent package state into the
+        # plan description
+        pd.li_props = rm_dict_ent(self.__props.copy(), temporal_props)
+        pd.li_ppkgs = self.__ppkgs
+        pd.li_ppubs = self.__ppubs
+        pd.li_pfacets = self.__pfacets
+
+    def setup_plan(self, pd):
+        """Reload a previously created plan."""
+
+        # make a copy of the linked image properties
+        props = pd.li_props.copy()
+
+        # generate temporal properties
+        if props:
+            self.__set_current_path(props)
+
+        # load linked image state from the plan
+        self.__update_props(props)
+        self.__ppubs = pd.li_ppubs
+        self.__ppkgs = pd.li_ppkgs
+        self.__pfacets = pd.li_pfacets
+
+        # now initialize our recursion state, this involves allocating
+        # handles to operate on children.  we don't need handles for
+        # children that were either ignored during planning, or which
+        # return EXIT_NOP after planning (since these children don't
+        # need any updates).
+        li_ignore = copy.copy(pd.children_ignored)
+
+        # merge the children that returned nop into li_ignore (since
+        # we don't need to recurse into them).  if li_ignore is [],
+        # then we ignored all children during planning
+        if li_ignore != [] and pd.children_nop:
+            if li_ignore is None:
+                # no children were ignored during planning
+                li_ignore = []
+            li_ignore += pd.children_nop
+
+        # Initialize children
+        self.__recursion_init(li_ignore=li_ignore)
+
+    def recurse_nothingtodo(self):
+        """Return True if there is no planned work to do on child
+        image."""
+
+        for lic in six.itervalues(self.__lic_dict):
+            if lic.child_name not in self.__img.imageplan.pd.children_nop:
+                return False
+        return True
 
 
 class LinkedImageChild(object):
-        """A LinkedImageChild object is used when a parent image wants to
-        access a child image.  These accesses may include things like:
-        saving/pushing linked image metadata into a child image, syncing or
-        auditing a child image, or recursing into a child image to keep it in
-        sync with planned changes in the parent image."""
-
-        def __init__(self, li, lin):
-                assert isinstance(li, LinkedImage), \
-                    "isinstance({0}, LinkedImage)".format(type(li))
-                assert isinstance(lin, LinkedImageName), \
-                    "isinstance({0}, LinkedImageName)".format(type(lin))
-
-                # globals
-                self.__linked = li
-                self.__img = li.image
-
-                # cache properties.
-                self.__props = self.__linked.child_props(lin)
-                assert self.__props[PROP_NAME] == lin
-
-                try:
-                        imgdir = ar.ar_img_prefix(self.child_path)
-                except OSError as e:
-                        raise apx.LinkedImageException(lin=lin,
-                            child_op_failed=("find", self.child_path, e))
-
-                if not imgdir:
-                        raise apx.LinkedImageException(
-                            lin=lin, child_bad_img=self.child_path)
-
-                # initialize paths for linked image data files
-                self.__path_ppkgs = os.path.join(imgdir, PATH_PPKGS)
-                self.__path_prop = os.path.join(imgdir, PATH_PROP)
-                self.__path_ppubs = os.path.join(imgdir, PATH_PUBS)
-                self.__path_pfacets = os.path.join(imgdir, PATH_PFACETS)
-
-                # initialize a linked image child plugin
-                self.__plugin = \
-                    pkg.client.linkedimage.p_classes_child[lin.lin_type](self)
-
-                self.__pkg_remote = pkg.client.pkgremote.PkgRemote()
-                self.__child_op_rvtuple = None
-                self.__child_op = None
-
-        @property
-        def child_name(self):
-                """Get the name associated with a child image."""
-                return self.__props[PROP_NAME]
-
-        @property
-        def child_path(self):
-                """Get the path associated with a child image."""
-
-                if self.__linked.inaltroot():
-                        return self.__props[PROP_CURRENT_PATH]
-                return self.__props[PROP_PATH]
-
-        @property
-        def child_pimage(self):
-                """Get a pointer to the parent image object associated with
-                this child."""
-                return self.__img
-
-        def __push_data(self, root, path, data, tmp, test):
-                """Write data to a child image."""
-
-                try:
-                        # first save our data to a temporary file
-                        path_tmp = "{0}.{1}".format(path,
-                            global_settings.client_runid)
-                        save_data(path_tmp, data, root=root,
-                            catch_exception=False)
-
-                        # Check if the data is changing.  To do this
-                        # comparison we load the serialized on-disk json data
-                        # into memory because there are no guarantees about
-                        # data ordering during serialization.  When loading
-                        # the data we don't bother decoding it into objects.
-                        updated = True
-                        old_data = load_data(path, missing_ok=True,
-                            root=root, decode=False,
-                            catch_exception=False)
-                        if old_data is not None:
-                                new_data = load_data(path_tmp,
-                                    root=root, decode=False,
-                                    catch_exception=False)
-                                # We regard every combination of the same
-                                # elements in a list being the same data, for
-                                # example, ["a", "b"] equals ["b", "a"], so we
-                                # need to sort the list first before comparison
-                                # because ["a", "b"] != ["b", "a"] in Python.
-                                if isinstance(old_data, list) and \
-                                     isinstance(new_data, list):
-                                        old_data = sorted(old_data)
-                                        new_data = sorted(new_data)
-                                if old_data == new_data:
-                                        updated = False
-
-
-                        # If we're not actually updating any data, or if we
-                        # were just doing a test to see if the data has
-                        # changed, then delete the temporary data file.
-                        if not updated or test:
-                                ar.ar_unlink(root, path_tmp)
-                                return updated
-
-                        if not tmp:
-                                ar.ar_rename(root, path_tmp, path)
-
-                except OSError as e:
-                        raise apx.LinkedImageException(lin=self.child_name,
-                            child_op_failed=("metadata update",
-                            self.child_path, e))
-
-                return True
-
-        def __push_ppkgs(self, ppkgs, tmp=False, test=False):
-                """Sync linked image parent constraint data to a child image.
-
-                'tmp' determines if we should read/write to the official
-                linked image metadata files, or if we should access temporary
-                versions (which have ".<runid>" appended to them."""
-
-                # save the planned parent packages
-                return self.__push_data(self.child_path, self.__path_ppkgs,
-                    ppkgs, tmp, test)
-
-        def __push_pfacets(self, pfacets, tmp=False, test=False):
-                """Sync linked image parent facet data to a child image.
-
-                'tmp' determines if we should read/write to the official
-                linked image metadata files, or if we should access temporary
-                versions (which have ".<runid>" appended to them."""
-
-                # save the planned parent facets
-                return self.__push_data(self.child_path, self.__path_pfacets,
-                    pfacets, tmp, test)
-
-
-        def __push_props(self, tmp=False, test=False):
-                """Sync linked image properties data to a child image.
-
-                'tmp' determines if we should read/write to the official
-                linked image metadata files, or if we should access temporary
-                versions (which have ".<runid>" appended to them."""
-
-                # make a copy of the props we want to push
-                props = self.__props.copy()
-                assert PROP_PARENT_PATH not in props
-
-                self.__plugin.munge_props(props)
-
-                # delete temporal properties
-                props = rm_dict_ent(props, temporal_props)
-                return self.__push_data(self.child_path, self.__path_prop,
-                    props, tmp, test)
-
-        def __push_ppubs(self, ppubs, tmp=False, test=False):
-                """Sync linked image parent publisher data to a child image.
-
-                'tmp' determines if we should read/write to the official
-                linked image metadata files, or if we should access temporary
-                versions (which have ".<runid>" appended to them."""
-
-                return self.__push_data(self.child_path, self.__path_ppubs,
-                    ppubs, tmp, test)
-
-        def __syncmd(self, pmd, tmp=False, test=False):
-                """Sync linked image data to a child image.
-
-                'tmp' determines if we should read/write to the official
-                linked image metadata files, or if we should access temporary
-                versions (which have ".<runid>" appended to them."""
-
-                # unpack parent metadata tuple
-                ppubs, ppkgs, pfacets = pmd
-
-                ppkgs_updated = self.__push_ppkgs(ppkgs, tmp, test)
-                props_updated = self.__push_props(tmp, test)
-                pubs_updated = self.__push_ppubs(ppubs, tmp, test)
-                pfacets_updated = self.__push_pfacets(pfacets, tmp, test)
-
-                return (props_updated or ppkgs_updated or pubs_updated or
-                    pfacets_updated)
-
-        def __child_op_setup_syncmd(self, pmd, ignore_syncmd_nop=True,
-            tmp=False, test=False, stage=pkgdefs.API_STAGE_DEFAULT):
-                """Prepare to perform an operation on a child image by syncing
-                the latest linked image data to that image.  As part of this
-                operation, if we discover that the meta data hasn't changed we
-                may report back that there is nothing to do (EXIT_NOP).
-
-                'pmd' is a tuple that contains parent metadata that we will
-                sync to the child image.  Note this is not all the metadata
-                that we will sync, just the set which is common to all
-                children.
-
-                'ignore_syncmd_nop' a boolean that indicates if we should
-                always recurse into a child even if the linked image meta data
-                isn't changing.
-
-                'tmp' a boolean that indicates if we should save the child
-                image meta data into temporary files (instead of overwriting
-                the persistent meta data files).
-
-                'test' a boolean that indicates we shouldn't save any child
-                image meta data, instead we should just test to see if the
-                meta data is changing.
-
-                'stage' indicates which stage of execution we should be
-                performing on a child image."""
-
-                # we don't update metadata during all stages of operation
-                if stage not in [
-                    pkgdefs.API_STAGE_DEFAULT, pkgdefs.API_STAGE_PLAN]:
-                        return True
-
-                try:
-                        updated = self.__syncmd(pmd, tmp=tmp, test=test)
-                except apx.LinkedImageException as e:
-                        self.__child_op_rvtuple = \
-                            LI_RVTuple(e.lix_exitrv, e, None)
-                        return False
-
-                if ignore_syncmd_nop:
-                        # we successfully updated the metadata
-                        return True
-
-                # if the metadata changed then report success
-                if updated:
-                        return True
-
-                # the metadata didn't change, so this operation is a NOP
-                self.__child_op_rvtuple = \
-                    LI_RVTuple(pkgdefs.EXIT_NOP, None, None)
-                return False
-
-        def __child_setup_sync(self, _pmd, _progtrack, _ignore_syncmd_nop,
-            _syncmd_tmp,
-            accept=False,
-            li_md_only=False,
-            li_pkg_updates=True,
-            noexecute=False,
-            refresh_catalogs=True,
-            reject_list=misc.EmptyI,
-            show_licenses=False,
-            stage=pkgdefs.API_STAGE_DEFAULT,
-            update_index=True):
-                """Prepare to sync a child image.  This involves updating the
-                linked image metadata in the child and then possibly recursing
-                into the child to actually update packages.
-
-                For descriptions of parameters please see the descriptions in
-                api.py`gen_plan_*"""
-
-                if li_md_only:
-                        #
-                        # we're not going to recurse into the child image,
-                        # we're just going to update its metadata.
-                        #
-                        # we don't support updating packages in the parent
-                        # during attach metadata only sync.
-                        #
-                        if not self.__child_op_setup_syncmd(_pmd,
-                            ignore_syncmd_nop=False,
-                            test=noexecute, stage=stage):
-                                # the update failed
-                                return
-                        self.__child_op_rvtuple = \
-                            LI_RVTuple(pkgdefs.EXIT_OK, None, None)
-                        return
-
-                #
-                # first sync the metadata
-                #
-                # if we're doing this sync as part of an attach, then
-                # temporarily sync the metadata since we don't know yet if the
-                # attach will succeed.  if the attach doesn't succeed this
-                # means we don't have to delete any metadata.  if the attach
-                # succeeds the child will make the temporary metadata
-                # permanent as part of the commit.
-                #
-                # we don't support updating packages in the parent
-                # during attach.
-                #
-                if not self.__child_op_setup_syncmd(_pmd,
-                    ignore_syncmd_nop=_ignore_syncmd_nop,
-                    tmp=_syncmd_tmp, stage=stage):
-                        # the update failed or the metadata didn't change
-                        return
-
-                self.__pkg_remote.setup(self.child_path,
-                    pkgdefs.PKG_OP_SYNC,
-                    accept=accept,
-                    backup_be=None,
-                    backup_be_name=None,
-                    be_activate=True,
-                    be_name=None,
-                    li_ignore=None,
-                    li_md_only=li_md_only,
-                    li_parent_sync=True,
-                    li_pkg_updates=li_pkg_updates,
-                    li_target_all=False,
-                    li_target_list=[],
-                    new_be=None,
-                    noexecute=noexecute,
-                    origins=[],
-                    parsable_version=\
-                        global_settings.client_output_parsable_version,
-                    quiet=global_settings.client_output_quiet,
-                    refresh_catalogs=refresh_catalogs,
-                    reject_pats=reject_list,
-                    show_licenses=show_licenses,
-                    stage=stage,
-                    update_index=update_index,
-                    verbose=global_settings.client_output_verbose)
-
-        def __child_setup_update(self, _pmd, _progtrack, _syncmd_tmp,
-            accept, force, noexecute, pkgs_update, refresh_catalogs,
-            reject_list, show_licenses, stage, update_index):
-                """Prepare to update a child image."""
-
-                # first sync the metadata
-                if not self.__child_op_setup_syncmd(_pmd,
-                    ignore_syncmd_nop=True,
-                    tmp=_syncmd_tmp, stage=stage):
-                        # the update failed or the metadata didn't change
-                        return
-
-                # We need to make sure we don't pass None as pargs in
-                # client.py`update()
-                if pkgs_update is None:
-                        pkgs_update = []
-
-                self.__pkg_remote.setup(self.child_path,
-                    pkgdefs.PKG_OP_UPDATE,
-                    act_timeout=0,
-                    accept=accept,
-                    backup_be=None,
-                    backup_be_name=None,
-                    be_activate=True,
-                    be_name=None,
-                    force=force,
-                    ignore_missing=True,
-                    li_erecurse=None,
-                    li_ignore=None,
-                    li_parent_sync=True,
-                    new_be=None,
-                    noexecute=noexecute,
-                    origins=[],
-                    pargs=pkgs_update,
-                    parsable_version=\
-                        global_settings.client_output_parsable_version,
-                    quiet=global_settings.client_output_quiet,
-                    refresh_catalogs=refresh_catalogs,
-                    reject_pats=reject_list,
-                    show_licenses=show_licenses,
-                    stage=stage,
-                    update_index=update_index,
-                    verbose=global_settings.client_output_verbose)
-
-        def __child_setup_install(self, _pmd, _progtrack, _syncmd_tmp,
-            accept, noexecute, pkgs_inst, refresh_catalogs, reject_list,
-            show_licenses, stage, update_index):
-                """Prepare to install a pkg in a child image."""
-
-                # first sync the metadata
-                if not self.__child_op_setup_syncmd(_pmd,
-                    ignore_syncmd_nop=True,
-                    tmp=_syncmd_tmp, stage=stage):
-                        # the update failed or the metadata didn't change
-                        return
-
-                self.__pkg_remote.setup(self.child_path,
-                    pkgdefs.PKG_OP_INSTALL,
-                    accept=accept,
-                    act_timeout=0,
-                    backup_be=None,
-                    backup_be_name=None,
-                    be_activate=True,
-                    be_name=None,
-                    li_erecurse=None,
-                    li_ignore=None,
-                    li_parent_sync=True,
-                    new_be=None,
-                    noexecute=noexecute,
-                    origins=[],
-                    pargs=pkgs_inst,
-                    parsable_version=\
-                        global_settings.client_output_parsable_version,
-                    quiet=global_settings.client_output_quiet,
-                    refresh_catalogs=refresh_catalogs,
-                    reject_pats=reject_list,
-                    show_licenses=show_licenses,
-                    stage=stage,
-                    update_index=update_index,
-                    verbose=global_settings.client_output_verbose)
-
-        def __child_setup_uninstall(self, _pmd, _progtrack, _syncmd_tmp,
-            noexecute, pkgs_to_uninstall, stage, update_index):
-                """Prepare to install a pkg in a child image."""
-
-                # first sync the metadata
-                if not self.__child_op_setup_syncmd(_pmd,
-                    ignore_syncmd_nop=True,
-                    tmp=_syncmd_tmp, stage=stage):
-                        # the update failed or the metadata didn't change
-                        return
-
-                self.__pkg_remote.setup(self.child_path,
-                    pkgdefs.PKG_OP_UNINSTALL,
-                    act_timeout=0,
-                    backup_be=None,
-                    backup_be_name=None,
-                    be_activate=True,
-                    be_name=None,
-                    li_erecurse=None,
-                    li_ignore=None,
-                    li_parent_sync=True,
-                    new_be=None,
-                    noexecute=noexecute,
-                    pargs=pkgs_to_uninstall,
-                    parsable_version=\
-                        global_settings.client_output_parsable_version,
-                    quiet=global_settings.client_output_quiet,
-                    stage=stage,
-                    update_index=update_index,
-                    ignore_missing=True,
-                    verbose=global_settings.client_output_verbose)
-
-        def __child_setup_change_varcets(self, _pmd, _progtrack, _syncmd_tmp,
-            accept, facets, noexecute, refresh_catalogs, reject_list,
-            show_licenses, stage, update_index, variants):
-                """Prepare to install a pkg in a child image."""
-
-                # first sync the metadata
-                if not self.__child_op_setup_syncmd(_pmd,
-                    ignore_syncmd_nop=True,
-                    tmp=_syncmd_tmp, stage=stage):
-                        # the update failed or the metadata didn't change
-                        return
-
-                assert not (variants and facets)
-                if variants:
-                        op = pkgdefs.PKG_OP_CHANGE_VARIANT
-                        varcet_dict = variants
-                else:
-                        op = pkgdefs.PKG_OP_CHANGE_FACET
-                        varcet_dict = facets
-
-                # need to transform varcets back to string list
-                varcets = [ "{0}={1}".format(a, b) for (a, b) in
-                    varcet_dict.items()]
-
-                self.__pkg_remote.setup(self.child_path,
-                    op,
-                    accept=accept,
-                    act_timeout=0,
-                    backup_be=None,
-                    backup_be_name=None,
-                    be_activate=True,
-                    be_name=None,
-                    li_erecurse=None,
-                    li_ignore=None,
-                    li_parent_sync=True,
-                    new_be=None,
-                    noexecute=noexecute,
-                    origins=[],
-                    pargs=varcets,
-                    parsable_version=\
-                        global_settings.client_output_parsable_version,
-                    quiet=global_settings.client_output_quiet,
-                    refresh_catalogs=refresh_catalogs,
-                    reject_pats=reject_list,
-                    show_licenses=show_licenses,
-                    stage=stage,
-                    update_index=update_index,
-                    verbose=global_settings.client_output_verbose)
-
-        def __child_setup_detach(self, _progtrack, li_md_only=False,
-            li_pkg_updates=True, noexecute=False):
-                """Prepare to detach a child image."""
-
-                self.__pkg_remote.setup(self.child_path,
-                    pkgdefs.PKG_OP_DETACH,
-                    force=True,
-                    li_md_only=li_md_only,
-                    li_pkg_updates=li_pkg_updates,
-                    li_target_all=False,
-                    li_target_list=[],
-                    noexecute=noexecute,
-                    quiet=global_settings.client_output_quiet,
-                    verbose=global_settings.client_output_verbose)
-
-        def __child_setup_pubcheck(self, _pmd):
-                """Prepare to a check if a child's publishers are in sync."""
-
-                # first sync the metadata
-                # a pubcheck should never update persistent meta data
-                if not self.__child_op_setup_syncmd(_pmd, tmp=True):
-                        # the update failed
-                        return
-
-                # setup recursion into the child image
-                self.__pkg_remote.setup(self.child_path,
-                    pkgdefs.PKG_OP_PUBCHECK)
-
-        def __child_setup_hfo_cleanup(self, _pmd):
-                """Prepare to a clean up any stale hotfix origins."""
-
-                # set up recursion into the child image
-                self.__pkg_remote.setup(self.child_path,
-                    pkgdefs.PKG_OP_HOTFIX_CLEANUP)
-
-        def __child_setup_audit(self, _pmd):
-                """Prepare to a child image to see if it's in sync with its
-                constraints."""
-
-                # first sync the metadata
-                if not self.__child_op_setup_syncmd(_pmd, tmp=True):
-                        # the update failed
-                        return
-
-                # setup recursion into the child image
-                self.__pkg_remote.setup(self.child_path,
-                    pkgdefs.PKG_OP_AUDIT_LINKED,
-                    li_parent_sync=True,
-                    li_target_all=False,
-                    li_target_list=[],
-                    omit_headers=True,
-                    quiet=True)
-
-        def child_op_abort(self):
-                """Public interface to abort an operation on a child image."""
-
-                self.__pkg_remote.abort()
-                self.__child_op_rvtuple = None
-                self.__child_op = None
-
-        def child_op_setup(self, _pkg_op, _pmd, _progtrack, _ignore_syncmd_nop,
-            _syncmd_tmp, **kwargs):
-                """Public interface to setup an operation that we'd like to
-                perform on a child image."""
-
-                assert self.__child_op_rvtuple is None
-                assert self.__child_op is None
-
-                self.__child_op = _pkg_op
-
-                if _pkg_op == pkgdefs.PKG_OP_AUDIT_LINKED:
-                        self.__child_setup_audit(_pmd, **kwargs)
-                elif _pkg_op == pkgdefs.PKG_OP_DETACH:
-                        self.__child_setup_detach(_progtrack, **kwargs)
-                elif _pkg_op == pkgdefs.PKG_OP_PUBCHECK:
-                        self.__child_setup_pubcheck(_pmd, **kwargs)
-                elif _pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
-                        self.__child_setup_hfo_cleanup(_pmd, **kwargs)
-                elif _pkg_op == pkgdefs.PKG_OP_SYNC:
-                        self.__child_setup_sync(_pmd, _progtrack,
-                            _ignore_syncmd_nop, _syncmd_tmp, **kwargs)
-                elif _pkg_op == pkgdefs.PKG_OP_UPDATE:
-                        self.__child_setup_update(_pmd, _progtrack,
-                            _syncmd_tmp, **kwargs)
-                elif _pkg_op == pkgdefs.PKG_OP_INSTALL:
-                        self.__child_setup_install(_pmd, _progtrack,
-                            _syncmd_tmp, **kwargs)
-                elif _pkg_op == pkgdefs.PKG_OP_UNINSTALL:
-                        self.__child_setup_uninstall(_pmd, _progtrack,
-                            _syncmd_tmp, **kwargs)
-                elif _pkg_op == pkgdefs.PKG_OP_CHANGE_FACET or \
-                    _pkg_op == pkgdefs.PKG_OP_CHANGE_VARIANT:
-                        self.__child_setup_change_varcets(_pmd, _progtrack,
-                            _syncmd_tmp, **kwargs)
-                else:
-                        raise RuntimeError(
-                            "Unsupported package client op: {0}".format(
-                            _pkg_op))
-
-        def child_op_start(self):
-                """Public interface to start an operation on a child image."""
-
-                # if we have a return value this operation is done
-                if self.__child_op_rvtuple is not None:
-                        return True
-
-                self.__pkg_remote.start()
-
-        def child_op_is_done(self):
-                """Public interface to query if an operation on a child image
-                is done."""
-
-                # if we have a return value this operation is done
-                if self.__child_op_rvtuple is not None:
-                        return True
-
-                # make sure there is some data from the child
-                return self.__pkg_remote.is_done()
-
-        def child_op_rv(self, expect_plan):
-                """Public interface to get the result of an operation on a
-                child image.
-
-                'expect_plan' boolean indicating if the child is performing a
-                planning operation.  this is needed because if we're running
-                in parsable output mode then the child will emit a parsable
-                json version of the plan on stdout, and we'll verify it by
-                running it through the json parser.
-                """
-
-                # The child op is now done, so we reset __child_op to make sure
-                # we don't accidentally reuse the LIC without properly setting
-                # it up again. However, we still need the op type in this
-                # function so we make a copy.
-                pkg_op = self.__child_op
-                self.__child_op = None
-
-                # if we have a return value this operation is done
-                if self.__child_op_rvtuple is not None:
-                        rvtuple = self.__child_op_rvtuple
-                        self.__child_op_rvtuple = None
-                        return (rvtuple, None, None)
-
-                # make sure we're not going to block
-                assert self.__pkg_remote.is_done()
-
-                (rv, e, stdout, stderr) = self.__pkg_remote.result()
-                if e is not None:
-                        rv = pkgdefs.EXIT_OOPS
-
-                # if we got an exception, or a return value other than OK or
-                # NOP, then return an exception.
-                if e is not None or \
-                    rv not in [pkgdefs.EXIT_OK, pkgdefs.EXIT_NOP]:
-                        e = apx.LinkedImageException(
-                            lin=self.child_name, exitrv=rv,
-                            pkg_op_failed=(pkg_op, rv, stdout + stderr, e))
-                        rvtuple = LI_RVTuple(rv, e, None)
-                        return (rvtuple, stdout, stderr)
-
-                # check for NOP.
-                if rv == pkgdefs.EXIT_NOP:
-                        assert e is None
-                        rvtuple = LI_RVTuple(rv, None, None)
-                        return (rvtuple, stdout, stderr)
-
-                if global_settings.client_output_parsable_version is None or \
-                    not expect_plan:
-                        rvtuple = LI_RVTuple(rv, None, None)
-                        return (rvtuple, stdout, stderr)
-
-                # If a plan was created and we're in parsable output mode then
-                # parse the plan that should have been displayed to stdout.
-                p_dict = None
-                try:
-                        p_dict = json.loads(stdout)
-                except ValueError as e:
-                        # JSON raises a subclass of ValueError when it
-                        # can't parse a string.
-
-                        e = apx.LinkedImageException(
-                            lin=self.child_name,
-                            unparsable_output=(pkg_op, stdout + stderr, e))
-                        rvtuple = LI_RVTuple(rv, e, None)
-                        return (rvtuple, stdout, stderr)
-
-                p_dict["image-name"] = str(self.child_name)
-                rvtuple = LI_RVTuple(rv, None, p_dict)
-                return (rvtuple, stdout, stderr)
-
-        def fileno(self):
-                """Return the progress pipe associated with the PkgRemote
-                instance that is operating on a child image."""
-                return self.__pkg_remote.fileno()
-
-        def child_init_root(self):
-                """Our image path is being updated, so figure out our new
-                child image paths.  This interface only gets invoked when:
-
-                - We're doing a packaging operation on a parent image and
-                  we've just cloned that parent to create a new BE that we're
-                  going to update.  This clone also cloned all the children
-                  and so now we need to update our paths to point to the newly
-                  created children.
-
-                - We tried to update a cloned image (as described above) and
-                  our update failed, hence we're changing paths back to the
-                  original images that were the source of the clone."""
-
-                # PROP_PARENT_PATH better not be present because
-                # LinkedImageChild objects are only used with push child
-                # images.
-                assert PROP_PARENT_PATH not in self.__props
-
-                # Remove any path transform and reapply.
-                self.__props = rm_dict_ent(self.__props, temporal_props)
-                self.__linked.set_path_transform(self.__props,
-                    self.__linked.get_path_transform(),
-                    path=self.__props[PROP_PATH])
+    """A LinkedImageChild object is used when a parent image wants to
+    access a child image.  These accesses may include things like:
+    saving/pushing linked image metadata into a child image, syncing or
+    auditing a child image, or recursing into a child image to keep it in
+    sync with planned changes in the parent image."""
+
+    def __init__(self, li, lin):
+        assert isinstance(
+            li, LinkedImage
+        ), "isinstance({0}, LinkedImage)".format(type(li))
+        assert isinstance(
+            lin, LinkedImageName
+        ), "isinstance({0}, LinkedImageName)".format(type(lin))
+
+        # globals
+        self.__linked = li
+        self.__img = li.image
+
+        # cache properties.
+        self.__props = self.__linked.child_props(lin)
+        assert self.__props[PROP_NAME] == lin
+
+        try:
+            imgdir = ar.ar_img_prefix(self.child_path)
+        except OSError as e:
+            raise apx.LinkedImageException(
+                lin=lin, child_op_failed=("find", self.child_path, e)
+            )
+
+        if not imgdir:
+            raise apx.LinkedImageException(
+                lin=lin, child_bad_img=self.child_path
+            )
+
+        # initialize paths for linked image data files
+        self.__path_ppkgs = os.path.join(imgdir, PATH_PPKGS)
+        self.__path_prop = os.path.join(imgdir, PATH_PROP)
+        self.__path_ppubs = os.path.join(imgdir, PATH_PUBS)
+        self.__path_pfacets = os.path.join(imgdir, PATH_PFACETS)
+
+        # initialize a linked image child plugin
+        self.__plugin = pkg.client.linkedimage.p_classes_child[lin.lin_type](
+            self
+        )
+
+        self.__pkg_remote = pkg.client.pkgremote.PkgRemote()
+        self.__child_op_rvtuple = None
+        self.__child_op = None
+
+    @property
+    def child_name(self):
+        """Get the name associated with a child image."""
+        return self.__props[PROP_NAME]
+
+    @property
+    def child_path(self):
+        """Get the path associated with a child image."""
+
+        if self.__linked.inaltroot():
+            return self.__props[PROP_CURRENT_PATH]
+        return self.__props[PROP_PATH]
+
+    @property
+    def child_pimage(self):
+        """Get a pointer to the parent image object associated with
+        this child."""
+        return self.__img
+
+    def __push_data(self, root, path, data, tmp, test):
+        """Write data to a child image."""
+
+        try:
+            # first save our data to a temporary file
+            path_tmp = "{0}.{1}".format(path, global_settings.client_runid)
+            save_data(path_tmp, data, root=root, catch_exception=False)
+
+            # Check if the data is changing.  To do this
+            # comparison we load the serialized on-disk json data
+            # into memory because there are no guarantees about
+            # data ordering during serialization.  When loading
+            # the data we don't bother decoding it into objects.
+            updated = True
+            old_data = load_data(
+                path,
+                missing_ok=True,
+                root=root,
+                decode=False,
+                catch_exception=False,
+            )
+            if old_data is not None:
+                new_data = load_data(
+                    path_tmp, root=root, decode=False, catch_exception=False
+                )
+                # We regard every combination of the same
+                # elements in a list being the same data, for
+                # example, ["a", "b"] equals ["b", "a"], so we
+                # need to sort the list first before comparison
+                # because ["a", "b"] != ["b", "a"] in Python.
+                if isinstance(old_data, list) and isinstance(new_data, list):
+                    old_data = sorted(old_data)
+                    new_data = sorted(new_data)
+                if old_data == new_data:
+                    updated = False
+
+            # If we're not actually updating any data, or if we
+            # were just doing a test to see if the data has
+            # changed, then delete the temporary data file.
+            if not updated or test:
+                ar.ar_unlink(root, path_tmp)
+                return updated
+
+            if not tmp:
+                ar.ar_rename(root, path_tmp, path)
+
+        except OSError as e:
+            raise apx.LinkedImageException(
+                lin=self.child_name,
+                child_op_failed=("metadata update", self.child_path, e),
+            )
+
+        return True
+
+    def __push_ppkgs(self, ppkgs, tmp=False, test=False):
+        """Sync linked image parent constraint data to a child image.
+
+        'tmp' determines if we should read/write to the official
+        linked image metadata files, or if we should access temporary
+        versions (which have ".<runid>" appended to them."""
+
+        # save the planned parent packages
+        return self.__push_data(
+            self.child_path, self.__path_ppkgs, ppkgs, tmp, test
+        )
+
+    def __push_pfacets(self, pfacets, tmp=False, test=False):
+        """Sync linked image parent facet data to a child image.
+
+        'tmp' determines if we should read/write to the official
+        linked image metadata files, or if we should access temporary
+        versions (which have ".<runid>" appended to them."""
+
+        # save the planned parent facets
+        return self.__push_data(
+            self.child_path, self.__path_pfacets, pfacets, tmp, test
+        )
+
+    def __push_props(self, tmp=False, test=False):
+        """Sync linked image properties data to a child image.
+
+        'tmp' determines if we should read/write to the official
+        linked image metadata files, or if we should access temporary
+        versions (which have ".<runid>" appended to them."""
+
+        # make a copy of the props we want to push
+        props = self.__props.copy()
+        assert PROP_PARENT_PATH not in props
+
+        self.__plugin.munge_props(props)
+
+        # delete temporal properties
+        props = rm_dict_ent(props, temporal_props)
+        return self.__push_data(
+            self.child_path, self.__path_prop, props, tmp, test
+        )
+
+    def __push_ppubs(self, ppubs, tmp=False, test=False):
+        """Sync linked image parent publisher data to a child image.
+
+        'tmp' determines if we should read/write to the official
+        linked image metadata files, or if we should access temporary
+        versions (which have ".<runid>" appended to them."""
+
+        return self.__push_data(
+            self.child_path, self.__path_ppubs, ppubs, tmp, test
+        )
+
+    def __syncmd(self, pmd, tmp=False, test=False):
+        """Sync linked image data to a child image.
+
+        'tmp' determines if we should read/write to the official
+        linked image metadata files, or if we should access temporary
+        versions (which have ".<runid>" appended to them."""
+
+        # unpack parent metadata tuple
+        ppubs, ppkgs, pfacets = pmd
+
+        ppkgs_updated = self.__push_ppkgs(ppkgs, tmp, test)
+        props_updated = self.__push_props(tmp, test)
+        pubs_updated = self.__push_ppubs(ppubs, tmp, test)
+        pfacets_updated = self.__push_pfacets(pfacets, tmp, test)
+
+        return props_updated or ppkgs_updated or pubs_updated or pfacets_updated
+
+    def __child_op_setup_syncmd(
+        self,
+        pmd,
+        ignore_syncmd_nop=True,
+        tmp=False,
+        test=False,
+        stage=pkgdefs.API_STAGE_DEFAULT,
+    ):
+        """Prepare to perform an operation on a child image by syncing
+        the latest linked image data to that image.  As part of this
+        operation, if we discover that the meta data hasn't changed we
+        may report back that there is nothing to do (EXIT_NOP).
+
+        'pmd' is a tuple that contains parent metadata that we will
+        sync to the child image.  Note this is not all the metadata
+        that we will sync, just the set which is common to all
+        children.
+
+        'ignore_syncmd_nop' a boolean that indicates if we should
+        always recurse into a child even if the linked image meta data
+        isn't changing.
+
+        'tmp' a boolean that indicates if we should save the child
+        image meta data into temporary files (instead of overwriting
+        the persistent meta data files).
+
+        'test' a boolean that indicates we shouldn't save any child
+        image meta data, instead we should just test to see if the
+        meta data is changing.
+
+        'stage' indicates which stage of execution we should be
+        performing on a child image."""
+
+        # we don't update metadata during all stages of operation
+        if stage not in [pkgdefs.API_STAGE_DEFAULT, pkgdefs.API_STAGE_PLAN]:
+            return True
+
+        try:
+            updated = self.__syncmd(pmd, tmp=tmp, test=test)
+        except apx.LinkedImageException as e:
+            self.__child_op_rvtuple = LI_RVTuple(e.lix_exitrv, e, None)
+            return False
+
+        if ignore_syncmd_nop:
+            # we successfully updated the metadata
+            return True
+
+        # if the metadata changed then report success
+        if updated:
+            return True
+
+        # the metadata didn't change, so this operation is a NOP
+        self.__child_op_rvtuple = LI_RVTuple(pkgdefs.EXIT_NOP, None, None)
+        return False
+
+    def __child_setup_sync(
+        self,
+        _pmd,
+        _progtrack,
+        _ignore_syncmd_nop,
+        _syncmd_tmp,
+        accept=False,
+        li_md_only=False,
+        li_pkg_updates=True,
+        noexecute=False,
+        refresh_catalogs=True,
+        reject_list=misc.EmptyI,
+        show_licenses=False,
+        stage=pkgdefs.API_STAGE_DEFAULT,
+        update_index=True,
+    ):
+        """Prepare to sync a child image.  This involves updating the
+        linked image metadata in the child and then possibly recursing
+        into the child to actually update packages.
+
+        For descriptions of parameters please see the descriptions in
+        api.py`gen_plan_*"""
+
+        if li_md_only:
+            #
+            # we're not going to recurse into the child image,
+            # we're just going to update its metadata.
+            #
+            # we don't support updating packages in the parent
+            # during attach metadata only sync.
+            #
+            if not self.__child_op_setup_syncmd(
+                _pmd, ignore_syncmd_nop=False, test=noexecute, stage=stage
+            ):
+                # the update failed
+                return
+            self.__child_op_rvtuple = LI_RVTuple(pkgdefs.EXIT_OK, None, None)
+            return
+
+        #
+        # first sync the metadata
+        #
+        # if we're doing this sync as part of an attach, then
+        # temporarily sync the metadata since we don't know yet if the
+        # attach will succeed.  if the attach doesn't succeed this
+        # means we don't have to delete any metadata.  if the attach
+        # succeeds the child will make the temporary metadata
+        # permanent as part of the commit.
+        #
+        # we don't support updating packages in the parent
+        # during attach.
+        #
+        if not self.__child_op_setup_syncmd(
+            _pmd,
+            ignore_syncmd_nop=_ignore_syncmd_nop,
+            tmp=_syncmd_tmp,
+            stage=stage,
+        ):
+            # the update failed or the metadata didn't change
+            return
+
+        self.__pkg_remote.setup(
+            self.child_path,
+            pkgdefs.PKG_OP_SYNC,
+            accept=accept,
+            backup_be=None,
+            backup_be_name=None,
+            be_activate=True,
+            be_name=None,
+            li_ignore=None,
+            li_md_only=li_md_only,
+            li_parent_sync=True,
+            li_pkg_updates=li_pkg_updates,
+            li_target_all=False,
+            li_target_list=[],
+            new_be=None,
+            noexecute=noexecute,
+            origins=[],
+            parsable_version=global_settings.client_output_parsable_version,
+            quiet=global_settings.client_output_quiet,
+            refresh_catalogs=refresh_catalogs,
+            reject_pats=reject_list,
+            show_licenses=show_licenses,
+            stage=stage,
+            update_index=update_index,
+            verbose=global_settings.client_output_verbose,
+        )
+
+    def __child_setup_update(
+        self,
+        _pmd,
+        _progtrack,
+        _syncmd_tmp,
+        accept,
+        force,
+        noexecute,
+        pkgs_update,
+        refresh_catalogs,
+        reject_list,
+        show_licenses,
+        stage,
+        update_index,
+    ):
+        """Prepare to update a child image."""
+
+        # first sync the metadata
+        if not self.__child_op_setup_syncmd(
+            _pmd, ignore_syncmd_nop=True, tmp=_syncmd_tmp, stage=stage
+        ):
+            # the update failed or the metadata didn't change
+            return
+
+        # We need to make sure we don't pass None as pargs in
+        # client.py`update()
+        if pkgs_update is None:
+            pkgs_update = []
+
+        self.__pkg_remote.setup(
+            self.child_path,
+            pkgdefs.PKG_OP_UPDATE,
+            act_timeout=0,
+            accept=accept,
+            backup_be=None,
+            backup_be_name=None,
+            be_activate=True,
+            be_name=None,
+            force=force,
+            ignore_missing=True,
+            li_erecurse=None,
+            li_ignore=None,
+            li_parent_sync=True,
+            new_be=None,
+            noexecute=noexecute,
+            origins=[],
+            pargs=pkgs_update,
+            parsable_version=global_settings.client_output_parsable_version,
+            quiet=global_settings.client_output_quiet,
+            refresh_catalogs=refresh_catalogs,
+            reject_pats=reject_list,
+            show_licenses=show_licenses,
+            stage=stage,
+            update_index=update_index,
+            verbose=global_settings.client_output_verbose,
+        )
+
+    def __child_setup_install(
+        self,
+        _pmd,
+        _progtrack,
+        _syncmd_tmp,
+        accept,
+        noexecute,
+        pkgs_inst,
+        refresh_catalogs,
+        reject_list,
+        show_licenses,
+        stage,
+        update_index,
+    ):
+        """Prepare to install a pkg in a child image."""
+
+        # first sync the metadata
+        if not self.__child_op_setup_syncmd(
+            _pmd, ignore_syncmd_nop=True, tmp=_syncmd_tmp, stage=stage
+        ):
+            # the update failed or the metadata didn't change
+            return
+
+        self.__pkg_remote.setup(
+            self.child_path,
+            pkgdefs.PKG_OP_INSTALL,
+            accept=accept,
+            act_timeout=0,
+            backup_be=None,
+            backup_be_name=None,
+            be_activate=True,
+            be_name=None,
+            li_erecurse=None,
+            li_ignore=None,
+            li_parent_sync=True,
+            new_be=None,
+            noexecute=noexecute,
+            origins=[],
+            pargs=pkgs_inst,
+            parsable_version=global_settings.client_output_parsable_version,
+            quiet=global_settings.client_output_quiet,
+            refresh_catalogs=refresh_catalogs,
+            reject_pats=reject_list,
+            show_licenses=show_licenses,
+            stage=stage,
+            update_index=update_index,
+            verbose=global_settings.client_output_verbose,
+        )
+
+    def __child_setup_uninstall(
+        self,
+        _pmd,
+        _progtrack,
+        _syncmd_tmp,
+        noexecute,
+        pkgs_to_uninstall,
+        stage,
+        update_index,
+    ):
+        """Prepare to install a pkg in a child image."""
+
+        # first sync the metadata
+        if not self.__child_op_setup_syncmd(
+            _pmd, ignore_syncmd_nop=True, tmp=_syncmd_tmp, stage=stage
+        ):
+            # the update failed or the metadata didn't change
+            return
+
+        self.__pkg_remote.setup(
+            self.child_path,
+            pkgdefs.PKG_OP_UNINSTALL,
+            act_timeout=0,
+            backup_be=None,
+            backup_be_name=None,
+            be_activate=True,
+            be_name=None,
+            li_erecurse=None,
+            li_ignore=None,
+            li_parent_sync=True,
+            new_be=None,
+            noexecute=noexecute,
+            pargs=pkgs_to_uninstall,
+            parsable_version=global_settings.client_output_parsable_version,
+            quiet=global_settings.client_output_quiet,
+            stage=stage,
+            update_index=update_index,
+            ignore_missing=True,
+            verbose=global_settings.client_output_verbose,
+        )
+
+    def __child_setup_change_varcets(
+        self,
+        _pmd,
+        _progtrack,
+        _syncmd_tmp,
+        accept,
+        facets,
+        noexecute,
+        refresh_catalogs,
+        reject_list,
+        show_licenses,
+        stage,
+        update_index,
+        variants,
+    ):
+        """Prepare to install a pkg in a child image."""
+
+        # first sync the metadata
+        if not self.__child_op_setup_syncmd(
+            _pmd, ignore_syncmd_nop=True, tmp=_syncmd_tmp, stage=stage
+        ):
+            # the update failed or the metadata didn't change
+            return
+
+        assert not (variants and facets)
+        if variants:
+            op = pkgdefs.PKG_OP_CHANGE_VARIANT
+            varcet_dict = variants
+        else:
+            op = pkgdefs.PKG_OP_CHANGE_FACET
+            varcet_dict = facets
+
+        # need to transform varcets back to string list
+        varcets = ["{0}={1}".format(a, b) for (a, b) in varcet_dict.items()]
+
+        self.__pkg_remote.setup(
+            self.child_path,
+            op,
+            accept=accept,
+            act_timeout=0,
+            backup_be=None,
+            backup_be_name=None,
+            be_activate=True,
+            be_name=None,
+            li_erecurse=None,
+            li_ignore=None,
+            li_parent_sync=True,
+            new_be=None,
+            noexecute=noexecute,
+            origins=[],
+            pargs=varcets,
+            parsable_version=global_settings.client_output_parsable_version,
+            quiet=global_settings.client_output_quiet,
+            refresh_catalogs=refresh_catalogs,
+            reject_pats=reject_list,
+            show_licenses=show_licenses,
+            stage=stage,
+            update_index=update_index,
+            verbose=global_settings.client_output_verbose,
+        )
+
+    def __child_setup_detach(
+        self, _progtrack, li_md_only=False, li_pkg_updates=True, noexecute=False
+    ):
+        """Prepare to detach a child image."""
+
+        self.__pkg_remote.setup(
+            self.child_path,
+            pkgdefs.PKG_OP_DETACH,
+            force=True,
+            li_md_only=li_md_only,
+            li_pkg_updates=li_pkg_updates,
+            li_target_all=False,
+            li_target_list=[],
+            noexecute=noexecute,
+            quiet=global_settings.client_output_quiet,
+            verbose=global_settings.client_output_verbose,
+        )
+
+    def __child_setup_pubcheck(self, _pmd):
+        """Prepare to a check if a child's publishers are in sync."""
+
+        # first sync the metadata
+        # a pubcheck should never update persistent meta data
+        if not self.__child_op_setup_syncmd(_pmd, tmp=True):
+            # the update failed
+            return
+
+        # setup recursion into the child image
+        self.__pkg_remote.setup(self.child_path, pkgdefs.PKG_OP_PUBCHECK)
+
+    def __child_setup_hfo_cleanup(self, _pmd):
+        """Prepare to a clean up any stale hotfix origins."""
+
+        # set up recursion into the child image
+        self.__pkg_remote.setup(self.child_path, pkgdefs.PKG_OP_HOTFIX_CLEANUP)
+
+    def __child_setup_audit(self, _pmd):
+        """Prepare to a child image to see if it's in sync with its
+        constraints."""
+
+        # first sync the metadata
+        if not self.__child_op_setup_syncmd(_pmd, tmp=True):
+            # the update failed
+            return
+
+        # setup recursion into the child image
+        self.__pkg_remote.setup(
+            self.child_path,
+            pkgdefs.PKG_OP_AUDIT_LINKED,
+            li_parent_sync=True,
+            li_target_all=False,
+            li_target_list=[],
+            omit_headers=True,
+            quiet=True,
+        )
+
+    def child_op_abort(self):
+        """Public interface to abort an operation on a child image."""
+
+        self.__pkg_remote.abort()
+        self.__child_op_rvtuple = None
+        self.__child_op = None
+
+    def child_op_setup(
+        self,
+        _pkg_op,
+        _pmd,
+        _progtrack,
+        _ignore_syncmd_nop,
+        _syncmd_tmp,
+        **kwargs,
+    ):
+        """Public interface to setup an operation that we'd like to
+        perform on a child image."""
+
+        assert self.__child_op_rvtuple is None
+        assert self.__child_op is None
+
+        self.__child_op = _pkg_op
+
+        if _pkg_op == pkgdefs.PKG_OP_AUDIT_LINKED:
+            self.__child_setup_audit(_pmd, **kwargs)
+        elif _pkg_op == pkgdefs.PKG_OP_DETACH:
+            self.__child_setup_detach(_progtrack, **kwargs)
+        elif _pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+            self.__child_setup_pubcheck(_pmd, **kwargs)
+        elif _pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
+            self.__child_setup_hfo_cleanup(_pmd, **kwargs)
+        elif _pkg_op == pkgdefs.PKG_OP_SYNC:
+            self.__child_setup_sync(
+                _pmd, _progtrack, _ignore_syncmd_nop, _syncmd_tmp, **kwargs
+            )
+        elif _pkg_op == pkgdefs.PKG_OP_UPDATE:
+            self.__child_setup_update(_pmd, _progtrack, _syncmd_tmp, **kwargs)
+        elif _pkg_op == pkgdefs.PKG_OP_INSTALL:
+            self.__child_setup_install(_pmd, _progtrack, _syncmd_tmp, **kwargs)
+        elif _pkg_op == pkgdefs.PKG_OP_UNINSTALL:
+            self.__child_setup_uninstall(
+                _pmd, _progtrack, _syncmd_tmp, **kwargs
+            )
+        elif (
+            _pkg_op == pkgdefs.PKG_OP_CHANGE_FACET
+            or _pkg_op == pkgdefs.PKG_OP_CHANGE_VARIANT
+        ):
+            self.__child_setup_change_varcets(
+                _pmd, _progtrack, _syncmd_tmp, **kwargs
+            )
+        else:
+            raise RuntimeError(
+                "Unsupported package client op: {0}".format(_pkg_op)
+            )
+
+    def child_op_start(self):
+        """Public interface to start an operation on a child image."""
+
+        # if we have a return value this operation is done
+        if self.__child_op_rvtuple is not None:
+            return True
+
+        self.__pkg_remote.start()
+
+    def child_op_is_done(self):
+        """Public interface to query if an operation on a child image
+        is done."""
+
+        # if we have a return value this operation is done
+        if self.__child_op_rvtuple is not None:
+            return True
+
+        # make sure there is some data from the child
+        return self.__pkg_remote.is_done()
+
+    def child_op_rv(self, expect_plan):
+        """Public interface to get the result of an operation on a
+        child image.
+
+        'expect_plan' boolean indicating if the child is performing a
+        planning operation.  this is needed because if we're running
+        in parsable output mode then the child will emit a parsable
+        json version of the plan on stdout, and we'll verify it by
+        running it through the json parser.
+        """
+
+        # The child op is now done, so we reset __child_op to make sure
+        # we don't accidentally reuse the LIC without properly setting
+        # it up again. However, we still need the op type in this
+        # function so we make a copy.
+        pkg_op = self.__child_op
+        self.__child_op = None
+
+        # if we have a return value this operation is done
+        if self.__child_op_rvtuple is not None:
+            rvtuple = self.__child_op_rvtuple
+            self.__child_op_rvtuple = None
+            return (rvtuple, None, None)
+
+        # make sure we're not going to block
+        assert self.__pkg_remote.is_done()
+
+        (rv, e, stdout, stderr) = self.__pkg_remote.result()
+        if e is not None:
+            rv = pkgdefs.EXIT_OOPS
+
+        # if we got an exception, or a return value other than OK or
+        # NOP, then return an exception.
+        if e is not None or rv not in [pkgdefs.EXIT_OK, pkgdefs.EXIT_NOP]:
+            e = apx.LinkedImageException(
+                lin=self.child_name,
+                exitrv=rv,
+                pkg_op_failed=(pkg_op, rv, stdout + stderr, e),
+            )
+            rvtuple = LI_RVTuple(rv, e, None)
+            return (rvtuple, stdout, stderr)
+
+        # check for NOP.
+        if rv == pkgdefs.EXIT_NOP:
+            assert e is None
+            rvtuple = LI_RVTuple(rv, None, None)
+            return (rvtuple, stdout, stderr)
+
+        if (
+            global_settings.client_output_parsable_version is None
+            or not expect_plan
+        ):
+            rvtuple = LI_RVTuple(rv, None, None)
+            return (rvtuple, stdout, stderr)
+
+        # If a plan was created and we're in parsable output mode then
+        # parse the plan that should have been displayed to stdout.
+        p_dict = None
+        try:
+            p_dict = json.loads(stdout)
+        except ValueError as e:
+            # JSON raises a subclass of ValueError when it
+            # can't parse a string.
+
+            e = apx.LinkedImageException(
+                lin=self.child_name,
+                unparsable_output=(pkg_op, stdout + stderr, e),
+            )
+            rvtuple = LI_RVTuple(rv, e, None)
+            return (rvtuple, stdout, stderr)
+
+        p_dict["image-name"] = str(self.child_name)
+        rvtuple = LI_RVTuple(rv, None, p_dict)
+        return (rvtuple, stdout, stderr)
+
+    def fileno(self):
+        """Return the progress pipe associated with the PkgRemote
+        instance that is operating on a child image."""
+        return self.__pkg_remote.fileno()
+
+    def child_init_root(self):
+        """Our image path is being updated, so figure out our new
+        child image paths.  This interface only gets invoked when:
+
+        - We're doing a packaging operation on a parent image and
+          we've just cloned that parent to create a new BE that we're
+          going to update.  This clone also cloned all the children
+          and so now we need to update our paths to point to the newly
+          created children.
+
+        - We tried to update a cloned image (as described above) and
+          our update failed, hence we're changing paths back to the
+          original images that were the source of the clone."""
+
+        # PROP_PARENT_PATH better not be present because
+        # LinkedImageChild objects are only used with push child
+        # images.
+        assert PROP_PARENT_PATH not in self.__props
+
+        # Remove any path transform and reapply.
+        self.__props = rm_dict_ent(self.__props, temporal_props)
+        self.__linked.set_path_transform(
+            self.__props,
+            self.__linked.get_path_transform(),
+            path=self.__props[PROP_PATH],
+        )
 
 
 # ---------------------------------------------------------------------------
 # Interfaces to obtain linked image metadata from an image
 #
 def get_pubs(img):
-        """Return publisher information for the specified image.
+    """Return publisher information for the specified image.
 
-        Publisher information is returned in a sorted list of lists
-        of the format:
-                <publisher name>, <sticky>
+    Publisher information is returned in a sorted list of lists
+    of the format:
+            <publisher name>, <sticky>
 
-        Where:
-                <publisher name> is a string
-                <sticky> is a boolean
+    Where:
+            <publisher name> is a string
+            <sticky> is a boolean
 
-        The tuples are sorted by publisher rank.
-        """
+    The tuples are sorted by publisher rank.
+    """
 
-        return [
-            [str(p), p.sticky]
-            for p in img.get_sorted_publishers(inc_disabled=False)
-            if not p.nochild
-        ]
+    return [
+        [str(p), p.sticky]
+        for p in img.get_sorted_publishers(inc_disabled=False)
+        if not p.nochild
+    ]
+
 
 def get_packages(img, pd=None):
-        """Figure out the current (or planned) list of packages in img."""
+    """Figure out the current (or planned) list of packages in img."""
 
-        ppkgs = set(img.get_catalog(img.IMG_CATALOG_INSTALLED).fmris())
+    ppkgs = set(img.get_catalog(img.IMG_CATALOG_INSTALLED).fmris())
 
-        # if there's an image plan the we need to update the installed
-        # packages based on that plan.
-        if pd is not None:
-                for src, dst in pd.plan_desc:
-                        if src == dst:
-                                continue
-                        if src:
-                                assert src in ppkgs
-                                ppkgs -= set([src])
-                        if dst:
-                                assert dst not in ppkgs
-                                ppkgs |= set([dst])
+    # if there's an image plan the we need to update the installed
+    # packages based on that plan.
+    if pd is not None:
+        for src, dst in pd.plan_desc:
+            if src == dst:
+                continue
+            if src:
+                assert src in ppkgs
+                ppkgs -= set([src])
+            if dst:
+                assert dst not in ppkgs
+                ppkgs |= set([dst])
 
-        # paranoia
-        return frozenset(ppkgs)
+    # paranoia
+    return frozenset(ppkgs)
+
 
 def get_inheritable_facets(img, pd=None):
-        """Get Facets from an image that a child should inherit.
+    """Get Facets from an image that a child should inherit.
 
-        We only want to sync facets which affect packages that have parent
-        dependencies on themselves.  In practice this essentially limits us to
-        "facet.version-lock.*" facets."""
+    We only want to sync facets which affect packages that have parent
+    dependencies on themselves.  In practice this essentially limits us to
+    "facet.version-lock.*" facets."""
 
-        # get installed (or planned) parent packages and facets
-        ppkgs = get_packages(img, pd=pd)
-        facets = img.cfg.facets
-        if pd is not None and pd.new_facets is not None:
-                facets = pd.new_facets
+    # get installed (or planned) parent packages and facets
+    ppkgs = get_packages(img, pd=pd)
+    facets = img.cfg.facets
+    if pd is not None and pd.new_facets is not None:
+        facets = pd.new_facets
 
-        # create a packages dictionary indexed by package stem.
-        ppkgs_dict = dict([
-                (pfmri.pkg_name, pfmri)
-                for pfmri in ppkgs
-        ])
+    # create a packages dictionary indexed by package stem.
+    ppkgs_dict = dict([(pfmri.pkg_name, pfmri) for pfmri in ppkgs])
 
-        #
-        # For performance reasons see if we can limit ourselves to using the
-        # installed catalog.  If this is a non-image modifying operation then
-        # the installed catalog should be sufficient.  If this is an image
-        # modifying operation that is installing new packages, then we'll need
-        # to use the known catalog (which should already have been initialized
-        # and used during the image planning operation) to lookup information
-        # about the packages being installed.
-        #
-        cat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
-        if not ppkgs <= frozenset(cat.fmris()):
-                cat = img.get_catalog(img.IMG_CATALOG_KNOWN)
+    #
+    # For performance reasons see if we can limit ourselves to using the
+    # installed catalog.  If this is a non-image modifying operation then
+    # the installed catalog should be sufficient.  If this is an image
+    # modifying operation that is installing new packages, then we'll need
+    # to use the known catalog (which should already have been initialized
+    # and used during the image planning operation) to lookup information
+    # about the packages being installed.
+    #
+    cat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
+    if not ppkgs <= frozenset(cat.fmris()):
+        cat = img.get_catalog(img.IMG_CATALOG_KNOWN)
 
-        #
-        # iterate through all installed (or planned) package incorporation
-        # dependency actions and find those that are affected by image facets.
-        #
-        # we don't check for package-wide facets here because they don't do
-        # anything.  (ie, facets defined via "set" actions in a package have
-        # no effect on other actions within that package.)
-        #
-        faceted_deps = dict()
-        for pfmri in ppkgs:
-                for act in cat.get_entry_actions(pfmri, [cat.DEPENDENCY]):
-                        # we're only interested in incorporate dependencies
-                        if act.name != "depend" or \
-                            act.attrs["type"] != "incorporate":
-                                continue
+    #
+    # iterate through all installed (or planned) package incorporation
+    # dependency actions and find those that are affected by image facets.
+    #
+    # we don't check for package-wide facets here because they don't do
+    # anything.  (ie, facets defined via "set" actions in a package have
+    # no effect on other actions within that package.)
+    #
+    faceted_deps = dict()
+    for pfmri in ppkgs:
+        for act in cat.get_entry_actions(pfmri, [cat.DEPENDENCY]):
+            # we're only interested in incorporate dependencies
+            if act.name != "depend" or act.attrs["type"] != "incorporate":
+                continue
 
-                        # check if any image facets affect this dependency
-                        # W0212 Access to a protected member
-                        # pylint: disable=W0212
-                        matching_facets = facets._action_match(act)
-                        # pylint: enable=W0212
-                        if not matching_facets:
-                                continue
+            # check if any image facets affect this dependency
+            # W0212 Access to a protected member
+            # pylint: disable=W0212
+            matching_facets = facets._action_match(act)
+            # pylint: enable=W0212
+            if not matching_facets:
+                continue
 
-                        # if all the matching facets are true we don't care
-                        # about the match.
-                        if set([i[1] for i in matching_facets]) == set([True]):
-                                continue
+            # if all the matching facets are true we don't care
+            # about the match.
+            if set([i[1] for i in matching_facets]) == set([True]):
+                continue
 
-                        # save this set of facets.
-                        faceted_deps[act] = matching_facets
+            # save this set of facets.
+            faceted_deps[act] = matching_facets
 
-        #
-        # For each faceted incorporation dependency, check if it affects a
-        # package that has parent dependencies on itself.  This is really a
-        # best effort in that we don't follow package renames or obsoletions,
-        # etc.
-        #
-        # To limit the number of packages we inspect, we'll try to match the
-        # incorporation dependency fmri targets packages by stem to packages
-        # which are installed (or planned) within the parent image.  This
-        # allows us to quickly get a fully qualified fmri and check against a
-        # package for which we have already downloaded a manifest.
-        #
-        # If we can't match the dependency fmri package stem against packages
-        # installed (or planned) in the parent image, we don't bother
-        # searching for allowable packages in the catalog, because even if we
-        # found them in the catalog and they did have a parent dependency,
-        # they'd all still be uninstallable in any children because there
-        # would be no way to satisfy the parent dependency.  (as we already
-        # stated the package is not installed in the parent.)
-        #
-        faceted_linked_deps = dict()
-        for act in faceted_deps:
-                for fmri in act.attrlist("fmri"):
-                        pfmri = pkg.fmri.PkgFmri(fmri)
-                        pfmri = ppkgs_dict.get(pfmri.pkg_name, None)
-                        if pfmri is None:
-                                continue
+    #
+    # For each faceted incorporation dependency, check if it affects a
+    # package that has parent dependencies on itself.  This is really a
+    # best effort in that we don't follow package renames or obsoletions,
+    # etc.
+    #
+    # To limit the number of packages we inspect, we'll try to match the
+    # incorporation dependency fmri targets packages by stem to packages
+    # which are installed (or planned) within the parent image.  This
+    # allows us to quickly get a fully qualified fmri and check against a
+    # package for which we have already downloaded a manifest.
+    #
+    # If we can't match the dependency fmri package stem against packages
+    # installed (or planned) in the parent image, we don't bother
+    # searching for allowable packages in the catalog, because even if we
+    # found them in the catalog and they did have a parent dependency,
+    # they'd all still be uninstallable in any children because there
+    # would be no way to satisfy the parent dependency.  (as we already
+    # stated the package is not installed in the parent.)
+    #
+    faceted_linked_deps = dict()
+    for act in faceted_deps:
+        for fmri in act.attrlist("fmri"):
+            pfmri = pkg.fmri.PkgFmri(fmri)
+            pfmri = ppkgs_dict.get(pfmri.pkg_name, None)
+            if pfmri is None:
+                continue
 
-                        # check if this package has a dependency on itself in
-                        # its parent image.
-                        for act2 in cat.get_entry_actions(pfmri,
-                            [cat.DEPENDENCY]):
-                                if act2.name != "depend" or \
-                                    act2.attrs["type"] != "parent":
-                                        continue
-                                if pkg.actions.depend.DEPEND_SELF not in \
-                                    act2.attrlist("fmri"):
-                                        continue
-                                faceted_linked_deps[act] = faceted_deps[act]
-                                break
-        del faceted_deps
+            # check if this package has a dependency on itself in
+            # its parent image.
+            for act2 in cat.get_entry_actions(pfmri, [cat.DEPENDENCY]):
+                if act2.name != "depend" or act2.attrs["type"] != "parent":
+                    continue
+                if pkg.actions.depend.DEPEND_SELF not in act2.attrlist("fmri"):
+                    continue
+                faceted_linked_deps[act] = faceted_deps[act]
+                break
+    del faceted_deps
 
-        #
-        # Create a set of all facets which affect incorporation dependencies
-        # on synced packages.
-        #
-        # Note that we can't limit ourselves to only passing on facets that
-        # affect dependencies which have been disabled.  Doing this could lead
-        # to incorrect results because facets allow for pattern matching.  So
-        # for example say we had the following dependencies on synced
-        # packages:
-        #
-        #    depend type=incorporation fmri=some_synced_pkg1 facet.123456=true
-        #    depend type=incorporation fmri=some_synced_pkg2 facet.456789=true
-        #
-        # and the following image facets:
-        #
-        #    facet.123456 = True
-        #    facet.*456* = False
-        #
-        # if we only passed through facets which affected disabled packages
-        # we'd just pass through "facet.*456*", but this would result in
-        # disabling both dependencies above, not just the second dependency.
-        #
-        pfacets = pkg.facet.Facets()
-        for facets in faceted_linked_deps.values():
-                for k, v in facets:
-                        # W0212 Access to a protected member
-                        # pylint: disable=W0212
-                        pfacets._set_inherited(k, v)
+    #
+    # Create a set of all facets which affect incorporation dependencies
+    # on synced packages.
+    #
+    # Note that we can't limit ourselves to only passing on facets that
+    # affect dependencies which have been disabled.  Doing this could lead
+    # to incorrect results because facets allow for pattern matching.  So
+    # for example say we had the following dependencies on synced
+    # packages:
+    #
+    #    depend type=incorporation fmri=some_synced_pkg1 facet.123456=true
+    #    depend type=incorporation fmri=some_synced_pkg2 facet.456789=true
+    #
+    # and the following image facets:
+    #
+    #    facet.123456 = True
+    #    facet.*456* = False
+    #
+    # if we only passed through facets which affected disabled packages
+    # we'd just pass through "facet.*456*", but this would result in
+    # disabling both dependencies above, not just the second dependency.
+    #
+    pfacets = pkg.facet.Facets()
+    for facets in faceted_linked_deps.values():
+        for k, v in facets:
+            # W0212 Access to a protected member
+            # pylint: disable=W0212
+            pfacets._set_inherited(k, v)
 
-        return pfacets
+    return pfacets
+
 
 # ---------------------------------------------------------------------------
 # Utility Functions
 #
 def save_data(path, data, root="/", catch_exception=True):
-        """Save JSON encoded linked image metadata to a file."""
+    """Save JSON encoded linked image metadata to a file."""
 
-        def PkgEncode(obj):
-                """Required routine that overrides the default base
-                class version.  This routine must serialize 'obj' when
-                attempting to save 'obj' json format."""
+    def PkgEncode(obj):
+        """Required routine that overrides the default base
+        class version.  This routine must serialize 'obj' when
+        attempting to save 'obj' json format."""
 
-                if isinstance(obj, (pkg.fmri.PkgFmri,
-                    pkg.client.linkedimage.common.LinkedImageName)):
-                        return str(obj)
+        if isinstance(
+            obj,
+            (pkg.fmri.PkgFmri, pkg.client.linkedimage.common.LinkedImageName),
+        ):
+            return str(obj)
 
-                if isinstance(obj, pkgplan.PkgPlan):
-                        return obj.getstate()
+        if isinstance(obj, pkgplan.PkgPlan):
+            return obj.getstate()
 
-                if isinstance(obj, (set, frozenset)):
-                        return list(obj)
+        if isinstance(obj, (set, frozenset)):
+            return list(obj)
 
-        # make sure the directory we're about to save data into exists.
-        path_dir = os.path.dirname(path)
-        pathtmp = "{0}.{1:d}.tmp".format(path, os.getpid())
+    # make sure the directory we're about to save data into exists.
+    path_dir = os.path.dirname(path)
+    pathtmp = "{0}.{1:d}.tmp".format(path, os.getpid())
 
-        try:
-                if not ar.ar_exists(root, path_dir):
-                        ar.ar_mkdir(root, path_dir, misc.PKG_DIR_MODE,
-                            exists_is_ok=True) # parallel zone create race
+    try:
+        if not ar.ar_exists(root, path_dir):
+            ar.ar_mkdir(
+                root, path_dir, misc.PKG_DIR_MODE, exists_is_ok=True
+            )  # parallel zone create race
 
-                # write the output to a temporary file
-                fd = ar.ar_open(root, pathtmp, os.O_WRONLY,
-                    mode=0o644, create=True, truncate=True)
-                fobj = os.fdopen(fd, "w")
-                json.dump(data, fobj, default=PkgEncode)
-                fobj.close()
+        # write the output to a temporary file
+        fd = ar.ar_open(
+            root, pathtmp, os.O_WRONLY, mode=0o644, create=True, truncate=True
+        )
+        fobj = os.fdopen(fd, "w")
+        json.dump(data, fobj, default=PkgEncode)
+        fobj.close()
 
-                # atomically create the desired file
-                ar.ar_rename(root, pathtmp, path)
-        except OSError as e:
-                # W0212 Access to a protected member
-                # pylint: disable=W0212
-                if catch_exception:
-                        raise apx._convert_error(e)
-                raise e
+        # atomically create the desired file
+        ar.ar_rename(root, pathtmp, path)
+    except OSError as e:
+        # W0212 Access to a protected member
+        # pylint: disable=W0212
+        if catch_exception:
+            raise apx._convert_error(e)
+        raise e
 
-def load_data(path, missing_ok=False, root="/", decode=True,
-    catch_exception=False):
-        """Load JSON encoded linked image metadata from a file."""
 
-        object_hook = None
-        if decode:
-                object_hook = pkg.client.linkedimage.PkgDecoder
+def load_data(
+    path, missing_ok=False, root="/", decode=True, catch_exception=False
+):
+    """Load JSON encoded linked image metadata from a file."""
 
-        try:
-                if missing_ok and not path_exists(path, root=root):
-                        return None
+    object_hook = None
+    if decode:
+        object_hook = pkg.client.linkedimage.PkgDecoder
 
-                fd = ar.ar_open(root, path, os.O_RDONLY)
-                fobj = os.fdopen(fd, "r")
-                data = json.load(fobj, object_hook=object_hook)
-                fobj.close()
-        except OSError as e:
-                # W0212 Access to a protected member
-                # pylint: disable=W0212
-                if catch_exception:
-                        raise apx._convert_error(e)
-                raise apx._convert_error(e)
-        return data
+    try:
+        if missing_ok and not path_exists(path, root=root):
+            return None
+
+        fd = ar.ar_open(root, path, os.O_RDONLY)
+        fobj = os.fdopen(fd, "r")
+        data = json.load(fobj, object_hook=object_hook)
+        fobj.close()
+    except OSError as e:
+        # W0212 Access to a protected member
+        # pylint: disable=W0212
+        if catch_exception:
+            raise apx._convert_error(e)
+        raise apx._convert_error(e)
+    return data
+
 
 def PkgDecoder(dct):
-        """Utility class used when json decoding linked image metadata."""
-        # Replace unicode keys/values with strings
-        rvdct = {}
-        for k, v in six.iteritems(dct):
+    """Utility class used when json decoding linked image metadata."""
+    # Replace unicode keys/values with strings
+    rvdct = {}
+    for k, v in six.iteritems(dct):
+        k = misc.force_str(k)
+        v = misc.force_str(v)
 
-                k = misc.force_str(k)
-                v = misc.force_str(v)
+        # convert boolean strings values back into booleans
+        if type(v) == str:
+            if v.lower() == "true":
+                v = True
+            elif v.lower() == "false":
+                v = False
 
-                # convert boolean strings values back into booleans
-                if type(v) == str:
-                        if v.lower() == "true":
-                                v = True
-                        elif v.lower() == "false":
-                                v = False
+        rvdct[k] = v
+    return rvdct
 
-                rvdct[k] = v
-        return rvdct
 
 def rm_dict_ent(d, keys):
-        """Remove a set of keys from a dictionary."""
-        return dict([
-                (k, v)
-                for k, v in six.iteritems(d)
-                if k not in keys
-        ])
+    """Remove a set of keys from a dictionary."""
+    return dict([(k, v) for k, v in six.iteritems(d) if k not in keys])
 
-def _rterr(li=None, lic=None, lin=None, path=None, err=None,
+
+def _rterr(
+    li=None,
+    lic=None,
+    lin=None,
+    path=None,
+    err=None,
     bad_cp=None,
     bad_iup=None,
     bad_lin_type=None,
     bad_prop=None,
     missing_props=None,
     multiple_transforms=None,
-    saved_temporal_props=None):
-        """Oops.  We hit a runtime error.  Die with a nice informative
-        message.  Note that runtime errors should never happen and usually
-        indicate bugs (or possibly corrupted linked image metadata), so they
-        are not localized (just like asserts are not localized)."""
+    saved_temporal_props=None,
+):
+    """Oops.  We hit a runtime error.  Die with a nice informative
+    message.  Note that runtime errors should never happen and usually
+    indicate bugs (or possibly corrupted linked image metadata), so they
+    are not localized (just like asserts are not localized)."""
 
-        assert not (li and lic)
-        assert not ((lin or path) and li)
-        assert not ((lin or path) and lic)
-        assert path is None or type(path) == str
+    assert not (li and lic)
+    assert not ((lin or path) and li)
+    assert not ((lin or path) and lic)
+    assert path is None or type(path) == str
 
-        if bad_cp:
-                assert err is None
-                err = "Invalid linked content policy: {0}".format(bad_cp)
-        elif bad_iup:
-                assert err is None
-                err = "Invalid linked image update policy: {0}".format(bad_iup)
-        elif bad_lin_type:
-                assert err is None
-                err = "Invalid linked image type: {0}".format(bad_lin_type)
-        elif bad_prop:
-                assert err is None
-                err = "Invalid linked property value: {0}={1}".format(*bad_prop)
-        elif missing_props:
-                assert err is None
-                err = "Missing required linked properties: {0}".format(
-                    ", ".join(missing_props))
-        elif multiple_transforms:
-                assert err is None
-                err = "Multiple plugins reported different path transforms:"
-                for plugin, transform in multiple_transforms:
-                        err += "\n\t{0} = {1} -> {2}".format(plugin,
-                            transform[0], transform[1])
-        elif saved_temporal_props:
-                assert err is None
-                err = "Found saved temporal linked properties: {0}".format(
-                    ", ".join(saved_temporal_props))
-        else:
-                assert err != None
+    if bad_cp:
+        assert err is None
+        err = "Invalid linked content policy: {0}".format(bad_cp)
+    elif bad_iup:
+        assert err is None
+        err = "Invalid linked image update policy: {0}".format(bad_iup)
+    elif bad_lin_type:
+        assert err is None
+        err = "Invalid linked image type: {0}".format(bad_lin_type)
+    elif bad_prop:
+        assert err is None
+        err = "Invalid linked property value: {0}={1}".format(*bad_prop)
+    elif missing_props:
+        assert err is None
+        err = "Missing required linked properties: {0}".format(
+            ", ".join(missing_props)
+        )
+    elif multiple_transforms:
+        assert err is None
+        err = "Multiple plugins reported different path transforms:"
+        for plugin, transform in multiple_transforms:
+            err += "\n\t{0} = {1} -> {2}".format(
+                plugin, transform[0], transform[1]
+            )
+    elif saved_temporal_props:
+        assert err is None
+        err = "Found saved temporal linked properties: {0}".format(
+            ", ".join(saved_temporal_props)
+        )
+    else:
+        assert err != None
 
-        if li:
-                if li.ischild():
-                        lin = li.child_name
-                path = li.image.root
+    if li:
+        if li.ischild():
+            lin = li.child_name
+        path = li.image.root
 
-        if lic:
-                lin = lic.child_name
-                path = lic.child_path
+    if lic:
+        lin = lic.child_name
+        path = lic.child_path
 
-        err_prefix = "Linked image error: "
-        if lin:
-                err_prefix = "Linked image ({0}) error: ".format(str(lin))
+    err_prefix = "Linked image error: "
+    if lin:
+        err_prefix = "Linked image ({0}) error: ".format(str(lin))
 
-        err_suffix = ""
-        if path and lin:
-                err_suffix = "\nLinked image ({0}) path: {1}".format(str(lin),
-                    path)
-        elif path:
-                err_suffix = "\nLinked image path: {0}".format(path)
+    err_suffix = ""
+    if path and lin:
+        err_suffix = "\nLinked image ({0}) path: {1}".format(str(lin), path)
+    elif path:
+        err_suffix = "\nLinked image path: {0}".format(path)
 
-        raise RuntimeError(
-            "{0}: {1}{2}".format(err_prefix, err, err_suffix))
+    raise RuntimeError("{0}: {1}{2}".format(err_prefix, err, err_suffix))
+
 
 # ---------------------------------------------------------------------------
 # Functions for accessing files in the current root
 #
 def path_exists(path, root="/"):
-        """Simple wrapper for accessing files in the current root."""
+    """Simple wrapper for accessing files in the current root."""
 
-        try:
-                return ar.ar_exists(root, path)
-        except OSError as e:
-                # W0212 Access to a protected member
-                # pylint: disable=W0212
-                raise apx._convert_error(e)
+    try:
+        return ar.ar_exists(root, path)
+    except OSError as e:
+        # W0212 Access to a protected member
+        # pylint: disable=W0212
+        raise apx._convert_error(e)
+
 
 def path_isdir(path):
-        """Simple wrapper for accessing files in the current root."""
+    """Simple wrapper for accessing files in the current root."""
 
-        try:
-                return ar.ar_isdir("/", path)
-        except OSError as e:
-                # W0212 Access to a protected member
-                # pylint: disable=W0212
-                raise apx._convert_error(e)
+    try:
+        return ar.ar_isdir("/", path)
+    except OSError as e:
+        # W0212 Access to a protected member
+        # pylint: disable=W0212
+        raise apx._convert_error(e)
+
 
 def path_mkdir(path, mode):
-        """Simple wrapper for accessing files in the current root."""
+    """Simple wrapper for accessing files in the current root."""
 
-        try:
-                return ar.ar_mkdir("/", path, mode)
-        except OSError as e:
-                # W0212 Access to a protected member
-                # pylint: disable=W0212
-                raise apx._convert_error(e)
+    try:
+        return ar.ar_mkdir("/", path, mode)
+    except OSError as e:
+        # W0212 Access to a protected member
+        # pylint: disable=W0212
+        raise apx._convert_error(e)
+
 
 def path_unlink(path, noent_ok=False):
-        """Simple wrapper for accessing files in the current root."""
+    """Simple wrapper for accessing files in the current root."""
 
-        try:
-                return ar.ar_unlink("/", path, noent_ok=noent_ok)
-        except OSError as e:
-                # W0212 Access to a protected member
-                # pylint: disable=W0212
-                raise apx._convert_error(e)
+    try:
+        return ar.ar_unlink("/", path, noent_ok=noent_ok)
+    except OSError as e:
+        # W0212 Access to a protected member
+        # pylint: disable=W0212
+        raise apx._convert_error(e)
+
 
 # ---------------------------------------------------------------------------
 # Functions for managing images which may be in alternate roots
 #
 
+
 def path_transform_applicable(path, path_transform):
-        """Check if 'path_transform' can be applied to 'path'."""
+    """Check if 'path_transform' can be applied to 'path'."""
 
-        # Make sure path has a leading and trailing os.sep.
-        assert os.path.isabs(path), "path is not absolute: {0}".format(path)
-        path = path.rstrip(os.sep) + os.sep
+    # Make sure path has a leading and trailing os.sep.
+    assert os.path.isabs(path), "path is not absolute: {0}".format(path)
+    path = path.rstrip(os.sep) + os.sep
 
-        # If there is no transform, then any any translation is valid.
-        if path_transform == PATH_TRANSFORM_NONE:
-                return True
+    # If there is no transform, then any any translation is valid.
+    if path_transform == PATH_TRANSFORM_NONE:
+        return True
 
-        # check for nested or equal paths
-        if path.startswith(path_transform[0]):
-                return True
-        return False
+    # check for nested or equal paths
+    if path.startswith(path_transform[0]):
+        return True
+    return False
+
 
 def path_transform_applied(path, path_transform):
-        """Check if 'path_transform' has been applied to 'path'."""
+    """Check if 'path_transform' has been applied to 'path'."""
 
-        # Make sure path has a leading and trailing os.sep.
-        assert os.path.isabs(path), "path is not absolute: {0}".format(path)
-        path = path.rstrip(os.sep) + os.sep
+    # Make sure path has a leading and trailing os.sep.
+    assert os.path.isabs(path), "path is not absolute: {0}".format(path)
+    path = path.rstrip(os.sep) + os.sep
 
-        # Reverse the transform.
-        path_transform = (path_transform[1], path_transform[0])
-        return path_transform_applicable(path, path_transform)
+    # Reverse the transform.
+    path_transform = (path_transform[1], path_transform[0])
+    return path_transform_applicable(path, path_transform)
+
 
 def path_transform_apply(path, path_transform):
-        """Apply the 'path_transform' to 'path'."""
+    """Apply the 'path_transform' to 'path'."""
 
-        # Make sure path has a leading and trailing os.sep.
-        assert os.path.isabs(path), "path is not absolute: {0}".format(path)
-        path = path.rstrip(os.sep) + os.sep
+    # Make sure path has a leading and trailing os.sep.
+    assert os.path.isabs(path), "path is not absolute: {0}".format(path)
+    path = path.rstrip(os.sep) + os.sep
 
-        if path_transform == PATH_TRANSFORM_NONE:
-                return path
+    if path_transform == PATH_TRANSFORM_NONE:
+        return path
 
-        oroot, nroot = path_transform
-        assert path_transform_applicable(path, path_transform)
-        return os.path.join(nroot, path[len(oroot):])
+    oroot, nroot = path_transform
+    assert path_transform_applicable(path, path_transform)
+    return os.path.join(nroot, path[len(oroot) :])
+
 
 def path_transform_revert(path, path_transform):
-        """Unapply the 'path_transform' from 'path'."""
+    """Unapply the 'path_transform' from 'path'."""
 
-        # Reverse the transform.
-        path_transform = (path_transform[1], path_transform[0])
-        return path_transform_apply(path, path_transform)
+    # Reverse the transform.
+    path_transform = (path_transform[1], path_transform[0])
+    return path_transform_apply(path, path_transform)
+
 
 def compute_path_transform(opath, npath):
-        """Given an two paths create a transform that can be used to translate
-        between them."""
+    """Given an two paths create a transform that can be used to translate
+    between them."""
 
-        # Make sure all paths have a leading and trailing os.sep.
-        assert os.path.isabs(opath), "opath is not absolute: {0}".format(opath)
-        assert os.path.isabs(npath), "npath is not absolute: {0}".format(npath)
-        opath = opath.rstrip(os.sep) + os.sep
-        npath = npath.rstrip(os.sep) + os.sep
+    # Make sure all paths have a leading and trailing os.sep.
+    assert os.path.isabs(opath), "opath is not absolute: {0}".format(opath)
+    assert os.path.isabs(npath), "npath is not absolute: {0}".format(npath)
+    opath = opath.rstrip(os.sep) + os.sep
+    npath = npath.rstrip(os.sep) + os.sep
 
-        # Remove the longest common path suffix.  Do this by reversing the
-        # path strings, finding the longest common prefix, removing the common
-        # prefix, and reversing the paths strings again.  Make sure there is a
-        # trailing os.sep.
-        i = 0
-        opath_rev = opath[::-1]
-        npath_rev = npath[::-1]
-        for i in range(min(len(opath_rev), len(npath_rev))):
-                if opath_rev[i] != npath_rev[i]:
-                        break
-        oroot = opath_rev[i:][::-1].rstrip(os.sep) + os.sep
-        nroot = npath_rev[i:][::-1].rstrip(os.sep) + os.sep
+    # Remove the longest common path suffix.  Do this by reversing the
+    # path strings, finding the longest common prefix, removing the common
+    # prefix, and reversing the paths strings again.  Make sure there is a
+    # trailing os.sep.
+    i = 0
+    opath_rev = opath[::-1]
+    npath_rev = npath[::-1]
+    for i in range(min(len(opath_rev), len(npath_rev))):
+        if opath_rev[i] != npath_rev[i]:
+            break
+    oroot = opath_rev[i:][::-1].rstrip(os.sep) + os.sep
+    nroot = npath_rev[i:][::-1].rstrip(os.sep) + os.sep
 
-        # Old root and new root should start and end with a '/'.
-        assert oroot[0] == nroot[0] == '/'
-        assert oroot[-1] == nroot[-1] == '/'
+    # Old root and new root should start and end with a '/'.
+    assert oroot[0] == nroot[0] == "/"
+    assert oroot[-1] == nroot[-1] == "/"
 
-        # Return the altroot transform tuple.
-        if oroot == nroot:
-                return PATH_TRANSFORM_NONE
-        return (oroot, nroot)
+    # Return the altroot transform tuple.
+    if oroot == nroot:
+        return PATH_TRANSFORM_NONE
+    return (oroot, nroot)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/linkedimage/system.py
+++ b/src/modules/client/linkedimage/system.py
@@ -34,110 +34,109 @@ stored within a parent images pkg5.image configuration file.
 import pkg.client.pkgdefs as pkgdefs
 
 # import linked image common code
-from . import common as li # Relative import; pylint: disable=W0403
+from . import common as li  # Relative import; pylint: disable=W0403
 
 
 class LinkedImageSystemPlugin(li.LinkedImagePlugin):
+    """See parent class for docstring."""
+
+    # specify what functionality we support
+    support_attach = True
+    support_detach = True
+
+    # default attach property values
+    attach_props_def = {li.PROP_RECURSE: True}
+
+    def __init__(self, pname, linked):
+        """See parent class for docstring."""
+        li.LinkedImagePlugin.__init__(self, pname, linked)
+
+        # globals
+        self.__img = linked.image
+        self.__pname = pname
+        self.__linked = linked
+
+    def init_root(self, root):
+        """See parent class for docstring."""
+        # nothing to do
+        return
+
+    def guess_path_transform(self, ignore_errors=False):
+        """See parent class for docstring."""
+        # nothing to do
+        return li.PATH_TRANSFORM_NONE
+
+    def get_child_list(self, nocache=False, ignore_errors=False):
         """See parent class for docstring."""
 
-        # specify what functionality we support
-        support_attach = True
-        support_detach = True
+        if not self.__img.cfg:
+            # this may be a new image that hasn't actually been
+            # created yet
+            return []
 
-        # default attach property values
-        attach_props_def = {
-            li.PROP_RECURSE:        True
-        }
+        rv = []
+        for lin in self.__img.cfg.linked_children:
+            path = self.get_child_props(lin)[li.PROP_PATH]
+            rv.append([lin, path])
 
-        def __init__(self, pname, linked):
-                """See parent class for docstring."""
-                li.LinkedImagePlugin.__init__(self, pname, linked)
+        for lin, path in rv:
+            assert lin.lin_type == self.__pname
 
-                # globals
-                self.__img = linked.image
-                self.__pname = pname
-                self.__linked = linked
+        return rv
 
-        def init_root(self, root):
-                """See parent class for docstring."""
-                # nothing to do
-                return
+    def get_child_props(self, lin):
+        """See parent class for docstring."""
 
-        def guess_path_transform(self, ignore_errors=False):
-                """See parent class for docstring."""
-                # nothing to do
-                return li.PATH_TRANSFORM_NONE
+        # return a copy of the properties
+        return self.__img.cfg.linked_children[lin].copy()
 
-        def get_child_list(self, nocache=False, ignore_errors=False):
-                """See parent class for docstring."""
+    def attach_child_inmemory(self, props, allow_relink):
+        """See parent class for docstring."""
 
-                if not self.__img.cfg:
-                        # this may be a new image that hasn't actually been
-                        # created yet
-                        return []
+        # make sure this child doesn't already exist
+        lin_list = [i[0] for i in self.get_child_list()]
+        lin = props[li.PROP_NAME]
+        assert lin not in lin_list or allow_relink
 
-                rv = []
-                for lin in self.__img.cfg.linked_children:
-                        path = self.get_child_props(lin)[li.PROP_PATH]
-                        rv.append([lin, path])
+        # make a copy of the properties
+        props = props.copy()
 
-                for lin, path in rv:
-                        assert lin.lin_type == self.__pname
+        # delete temporal properties
+        props = li.rm_dict_ent(props, li.temporal_props)
 
-                return rv
+        self.__img.cfg.linked_children[lin] = props
 
-        def get_child_props(self, lin):
-                """See parent class for docstring."""
+    def detach_child_inmemory(self, lin):
+        """See parent class for docstring."""
 
-                # return a copy of the properties
-                return self.__img.cfg.linked_children[lin].copy()
+        # make sure this child exists
+        assert lin in [i[0] for i in self.get_child_list()]
 
-        def attach_child_inmemory(self, props, allow_relink):
-                """See parent class for docstring."""
+        # Delete this linked image
+        del self.__img.cfg.linked_children[lin]
 
-                # make sure this child doesn't already exist
-                lin_list = [i[0] for i in self.get_child_list()]
-                lin = props[li.PROP_NAME]
-                assert lin not in lin_list or allow_relink
+    def sync_children_todisk(self):
+        """See parent class for docstring."""
 
-                # make a copy of the properties
-                props = props.copy()
+        self.__img.cfg.write()
 
-                # delete temporal properties
-                props = li.rm_dict_ent(props, li.temporal_props)
-
-                self.__img.cfg.linked_children[lin] = props
-
-        def detach_child_inmemory(self, lin):
-                """See parent class for docstring."""
-
-                # make sure this child exists
-                assert lin in [i[0] for i in self.get_child_list()]
-
-                # Delete this linked image
-                del self.__img.cfg.linked_children[lin]
-
-        def sync_children_todisk(self):
-                """See parent class for docstring."""
-
-                self.__img.cfg.write()
-
-                return li.LI_RVTuple(pkgdefs.EXIT_OK, None, None)
+        return li.LI_RVTuple(pkgdefs.EXIT_OK, None, None)
 
 
 class LinkedImageSystemChildPlugin(li.LinkedImageChildPlugin):
+    """See parent class for docstring."""
+
+    def __init__(self, lic):
         """See parent class for docstring."""
+        li.LinkedImageChildPlugin.__init__(self, lic)
 
-        def __init__(self, lic):
-                """See parent class for docstring."""
-                li.LinkedImageChildPlugin.__init__(self, lic)
+        # globals
+        self.__linked = lic.child_pimage.linked
 
-                # globals
-                self.__linked = lic.child_pimage.linked
+    def munge_props(self, props):
+        """See parent class for docstring."""
+        pass
 
-        def munge_props(self, props):
-                """See parent class for docstring."""
-                pass
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/linkedimage/zone.py
+++ b/src/modules/client/linkedimage/zone.py
@@ -46,23 +46,23 @@ import pkg.pkgsubprocess
 from pkg.client.debugvalues import DebugValues
 
 # import linked image common code
-from . import common as li # Relative import; pylint: disable=W0403
+from . import common as li  # Relative import; pylint: disable=W0403
 
 # W0511 XXX / FIXME Comments; pylint: disable=W0511
 # XXX: should be defined by libzonecfg python wrapper
 # pylint: enable=W0511
 
-ZONE_GLOBAL                  = "global"
+ZONE_GLOBAL = "global"
 
-ZONE_STATE_STR_CONFIGURED    = "configured"
-ZONE_STATE_STR_INCOMPLETE    = "incomplete"
-ZONE_STATE_STR_UNAVAILABLE   = "unavailable"
-ZONE_STATE_STR_INSTALLED     = "installed"
-ZONE_STATE_STR_READY         = "ready"
-ZONE_STATE_STR_MOUNTED       = "mounted"
-ZONE_STATE_STR_RUNNING       = "running"
+ZONE_STATE_STR_CONFIGURED = "configured"
+ZONE_STATE_STR_INCOMPLETE = "incomplete"
+ZONE_STATE_STR_UNAVAILABLE = "unavailable"
+ZONE_STATE_STR_INSTALLED = "installed"
+ZONE_STATE_STR_READY = "ready"
+ZONE_STATE_STR_MOUNTED = "mounted"
+ZONE_STATE_STR_RUNNING = "running"
 ZONE_STATE_STR_SHUTTING_DOWN = "shutting_down"
-ZONE_STATE_STR_DOWN          = "down"
+ZONE_STATE_STR_DOWN = "down"
 
 zone_installed_states = [
     ZONE_STATE_STR_INSTALLED,
@@ -70,7 +70,7 @@ zone_installed_states = [
     ZONE_STATE_STR_MOUNTED,
     ZONE_STATE_STR_RUNNING,
     ZONE_STATE_STR_SHUTTING_DOWN,
-    ZONE_STATE_STR_DOWN
+    ZONE_STATE_STR_DOWN,
 ]
 
 
@@ -118,433 +118,436 @@ zone_installed_states = [
 
 
 class LinkedImageZonePlugin(li.LinkedImagePlugin):
+    """See parent class for docstring."""
+
+    # default attach property values
+    attach_props_def = {li.PROP_RECURSE: False}
+
+    __zone_pkgs = frozenset(
+        [frozenset(["system/zones"]), frozenset(["SUNWzoner", "SUNWzoneu"])]
+    )
+
+    def __init__(self, pname, linked):
         """See parent class for docstring."""
+        li.LinkedImagePlugin.__init__(self, pname, linked)
 
-        # default attach property values
-        attach_props_def = {
-            li.PROP_RECURSE:        False
-        }
+        # globals
+        self.__pname = pname
+        self.__linked = linked
+        self.__img = linked.image
+        self.__in_gz_cached = None
 
-        __zone_pkgs = frozenset([
-            frozenset(["system/zones"]),
-            frozenset(["SUNWzoner", "SUNWzoneu"])
-        ])
+        # keep track of our freshly attach children
+        self.__children = dict()
 
-        def __init__(self, pname, linked):
-                """See parent class for docstring."""
-                li.LinkedImagePlugin.__init__(self, pname, linked)
+        # cache zoneadm output
+        self.__zoneadm_list_cache = None
 
-                # globals
-                self.__pname = pname
-                self.__linked = linked
-                self.__img = linked.image
-                self.__in_gz_cached = None
+    def __in_gz(self, ignore_errors=False):
+        """Check if we're executing in the global zone.  Note that
+        this doesn't tell us anything about the image we're
+        manipulating, just the environment that we're running in."""
 
-                # keep track of our freshly attach children
-                self.__children = dict()
+        if self.__in_gz_cached != None:
+            return self.__in_gz_cached
 
-                # cache zoneadm output
-                self.__zoneadm_list_cache = None
-
-        def __in_gz(self, ignore_errors=False):
-                """Check if we're executing in the global zone.  Note that
-                this doesn't tell us anything about the image we're
-                manipulating, just the environment that we're running in."""
-
-                if self.__in_gz_cached != None:
-                        return self.__in_gz_cached
-
-                # check if we're running in the gz
-                try:
-                        self.__in_gz_cached = (_zonename() == ZONE_GLOBAL)
-                except OSError as e:
-                        # W0212 Access to a protected member
-                        # pylint: disable=W0212
-                        if ignore_errors:
-                                # default to being in the global zone
-                                return True
-                        raise apx._convert_error(e)
-                except apx.LinkedImageException as e:
-                        if ignore_errors:
-                                # default to being in the global zone
-                                return True
-                        raise e
-
-                return self.__in_gz_cached
-
-        def __zones_supported(self):
-                """Check to see if zones are supported in the current image.
-                i.e. can the current image have zone children."""
-
-                # pylint: disable=E1120
-                if DebugValues.get_value("zones_supported"):
-                        return True
-                # pylint: enable=E1120
-
-                # first check if the image variant is global
-                variant = "variant.opensolaris.zone"
-                value = self.__img.cfg.variants[variant]
-                if value != "global":
-                        return False
-
-                #
-                # sanity check the path to to /etc/zones.  below we check for
-                # the zones packages, and any image that has the zones
-                # packages installed should have a /etc/zones file (since
-                # those packages deliver this file) but it's possible that the
-                # image was corrupted and the user now wants to be able to run
-                # pkg commands to fix it.  if the path doesn't exist then we
-                # don't have any zones so just report that zones are
-                # unsupported (since zoneadm may fail to run anyway).
-                #
-                path = self.__img.root
-                if not os.path.isdir(os.path.join(path, "etc")):
-                        return False
-                if not os.path.isdir(os.path.join(path, "etc/zones")):
-                        return False
-
-                # get a set of installed packages
-                cati = self.__img.get_catalog(self.__img.IMG_CATALOG_INSTALLED)
-                pkgs_inst = frozenset([
-                        stem
-                        # Unused variable 'pub'; pylint: disable=W0612
-                        for pub, stem in cati.pkg_names()
-                        # pylint: enable=W0612
-                ])
-
-                # check if the zones packages are installed
-                for pkgs in self.__zone_pkgs:
-                        if (pkgs & pkgs_inst) == pkgs:
-                                return True
-
-                return False
-
-        def __list_zones_cached(self, nocache=False, ignore_errors=False):
-                """List the zones associated with the current image.  Since
-                this involves forking and running zone commands, cache the
-                results."""
-
-                # if nocache is set then delete any cached children
-                if nocache:
-                        self.__zoneadm_list_cache = None
-
-                # try to return the cached children
-                if self.__zoneadm_list_cache != None:
-                        assert type(self.__zoneadm_list_cache) == list
-                        return self.__zoneadm_list_cache
-
-                # see if the target image supports zones
-                if not self.__zones_supported():
-                        self.__zoneadm_list_cache = []
-                        return self.__list_zones_cached()
-
-                # zones are only visible when running in the global zone
-                if not self.__in_gz(ignore_errors=ignore_errors):
-                        self.__zoneadm_list_cache = []
-                        return self.__list_zones_cached()
-
-                # find zones
-                try:
-                        zdict = _list_zones(self.__img.root,
-                            self.__linked.get_path_transform())
-                except OSError as e:
-                        # W0212 Access to a protected member
-                        # pylint: disable=W0212
-                        if ignore_errors:
-                                # don't cache the result
-                                return []
-                        raise apx._convert_error(e)
-                except apx.LinkedImageException as e:
-                        if ignore_errors:
-                                # don't cache the result
-                                return []
-                        raise e
-
-                # convert zone names into into LinkedImageName objects
-                zlist = []
-                # state is unused
-                # pylint: disable=W0612
-                for zone, (path, state) in six.iteritems(zdict):
-                        lin = li.LinkedImageName("{0}:{1}".format(self.__pname,
-                            zone))
-                        zlist.append([lin, path])
-
-                self.__zoneadm_list_cache = zlist
-                return self.__list_zones_cached()
-
-        def init_root(self, root):
-                """See parent class for docstring."""
-                # nuke any cached children
-                self.__zoneadm_list_cache = None
-
-        def guess_path_transform(self, ignore_errors=False):
-                """See parent class for docstring."""
-
-                zlist = self.__list_zones_cached(nocache=True,
-                    ignore_errors=ignore_errors)
-                if not zlist:
-                        return li.PATH_TRANSFORM_NONE
-
-                # only global zones can have zone children, and global zones
-                # always execute with "/" as their root.  so if the current
-                # image path is not "/", then assume we're in an alternate
-                # root.
-                root = self.__img.root.rstrip(os.sep) + os.sep
-                return (os.sep, root)
-
-        def get_child_list(self, nocache=False, ignore_errors=False):
-                """See parent class for docstring."""
-
-                inmemory = []
-                # find any newly attached zone images
-                for lin in self.__children:
-                        path = self.__children[lin][li.PROP_PATH]
-                        inmemory.append([lin, path])
-
-                ondisk = []
-                for (lin, path) in self.__list_zones_cached(nocache,
-                    ignore_errors=ignore_errors):
-                        if lin in [i[0] for i in inmemory]:
-                                # we re-attached a zone in memory.
-                                continue
-                        ondisk.append([lin, path])
-
-                rv = []
-                rv.extend(ondisk)
-                rv.extend(inmemory)
-
-                for lin, path in rv:
-                        assert lin.lin_type == self.__pname
-
-                return rv
-
-        def get_child_props(self, lin):
-                """See parent class for docstring."""
-
-                if lin in self.__children:
-                        return self.__children[lin]
-
-                props = dict()
-                props[li.PROP_NAME] = lin
-                for i_lin, i_path in self.get_child_list():
-                        if lin == i_lin:
-                                props[li.PROP_PATH] = i_path
-                                break
-                assert li.PROP_PATH in props
-
-                props[li.PROP_MODEL] = li.PV_MODEL_PUSH
-                for k, v in six.iteritems(self.attach_props_def):
-                        if k not in props:
-                                props[k] = v
-
-                return props
-
-        def attach_child_inmemory(self, props, allow_relink):
-                """See parent class for docstring."""
-
-                # make sure this child doesn't already exist
-                lin = props[li.PROP_NAME]
-                lin_list = [i[0] for i in self.get_child_list()]
-                assert lin not in lin_list or allow_relink
-
-                # cache properties (sans any temporarl ones)
-                self.__children[lin] = li.rm_dict_ent(props, li.temporal_props)
-
-        def detach_child_inmemory(self, lin):
-                """See parent class for docstring."""
-
-                # make sure this child exists
-                assert lin in [i[0] for i in self.get_child_list()]
-
-                # Delete this linked image
-                del self.__children[lin]
-
-        def sync_children_todisk(self):
-                """See parent class for docstring."""
-
-                # nothing to do
-                return li.LI_RVTuple(pkgdefs.EXIT_OK, None, None)
-
-
-class LinkedImageZoneChildPlugin(li.LinkedImageChildPlugin):
-        """See parent class for docstring."""
-
-        def __init__(self, lic):
-                """See parent class for docstring."""
-                li.LinkedImageChildPlugin.__init__(self, lic)
-
-        def munge_props(self, props):
-                """See parent class for docstring."""
-
-                #
-                # For zones we always update the pushed child image path to
-                # be '/' (Since any linked children of the zone will be
-                # relative to that zone's root).
-                #
-                props[li.PROP_PATH] = "/"
-
-
-def _zonename():
-        """Get the zonname of the current system."""
-
-        cmd = DebugValues.get_value("bin_zonename") # pylint: disable=E1120
-        if cmd is not None:
-                cmd = [cmd]
-        else:
-                cmd = ["/bin/zonename"]
-
-        # if the command doesn't exist then bail.
-        if not li.path_exists(cmd[0]):
-                return
-
-        # open a temporary file in text mode for compatible string handling
-        fout = tempfile.TemporaryFile(mode="w+")
-        ferrout = tempfile.TemporaryFile(mode="w+")
-        p = pkg.pkgsubprocess.Popen(cmd, stdout=fout, stderr=ferrout)
-        p.wait()
-        if p.returncode != 0:
-                cmd = " ".join(cmd)
-                ferrout.seek(0)
-                errout = "".join(ferrout.readlines())
-                ferrout.close()
-                raise apx.LinkedImageException(
-                    cmd_failed=(p.returncode, cmd, errout))
-
-        # parse the command output
-        fout.seek(0)
-        lines = fout.readlines()
-        if lines:
-                zonename = lines[0].rstrip()
-                fout.close()
-                return zonename
-
-        # If /bin/zonename does not return the expected output,
-        # we raise an exception of LinkedImageException, which
-        # is handled by _in_gz().
-        cmd = " ".join(cmd)
-        raise apx.LinkedImageException(
-                cmd_output_invalid=(cmd, lines))
-
-
-def _zoneadm_list_parse(line, cmd, output):
-        """Parse zoneadm list -p output.  It's possible for zonepath to
-        contain a ":".  If it does it will be escaped to be "\\:".  (But note
-        that if the zonepath contains a "\" it will not be escaped, which
-        is argubaly a bug.)"""
-
-        # zoneadm list output should never contain a NUL char, so
-        # temporarily replace any escaped colons with a NUL, split the string
-        # on any remaining colons, and then switch any NULs back to colons.
-        tmp_char = "\0"
-        fields = [
-                field.replace(tmp_char, ":")
-                for field in line.replace(r"\:", tmp_char).split(":")
-        ]
-
+        # check if we're running in the gz
         try:
-                # Unused variable; pylint: disable=W0612
-                z_id, z_name, z_state, z_path, z_uuid, z_brand, z_iptype = \
-                    fields[:7]
+            self.__in_gz_cached = _zonename() == ZONE_GLOBAL
+        except OSError as e:
+            # W0212 Access to a protected member
+            # pylint: disable=W0212
+            if ignore_errors:
+                # default to being in the global zone
+                return True
+            raise apx._convert_error(e)
+        except apx.LinkedImageException as e:
+            if ignore_errors:
+                # default to being in the global zone
+                return True
+            raise e
+
+        return self.__in_gz_cached
+
+    def __zones_supported(self):
+        """Check to see if zones are supported in the current image.
+        i.e. can the current image have zone children."""
+
+        # pylint: disable=E1120
+        if DebugValues.get_value("zones_supported"):
+            return True
+        # pylint: enable=E1120
+
+        # first check if the image variant is global
+        variant = "variant.opensolaris.zone"
+        value = self.__img.cfg.variants[variant]
+        if value != "global":
+            return False
+
+        #
+        # sanity check the path to to /etc/zones.  below we check for
+        # the zones packages, and any image that has the zones
+        # packages installed should have a /etc/zones file (since
+        # those packages deliver this file) but it's possible that the
+        # image was corrupted and the user now wants to be able to run
+        # pkg commands to fix it.  if the path doesn't exist then we
+        # don't have any zones so just report that zones are
+        # unsupported (since zoneadm may fail to run anyway).
+        #
+        path = self.__img.root
+        if not os.path.isdir(os.path.join(path, "etc")):
+            return False
+        if not os.path.isdir(os.path.join(path, "etc/zones")):
+            return False
+
+        # get a set of installed packages
+        cati = self.__img.get_catalog(self.__img.IMG_CATALOG_INSTALLED)
+        pkgs_inst = frozenset(
+            [
+                stem
+                # Unused variable 'pub'; pylint: disable=W0612
+                for pub, stem in cati.pkg_names()
                 # pylint: enable=W0612
-        except ValueError:
-                raise apx.LinkedImageException(
-                    cmd_output_invalid=(cmd, output))
+            ]
+        )
 
-        return z_name, z_state, z_path, z_brand
+        # check if the zones packages are installed
+        for pkgs in self.__zone_pkgs:
+            if (pkgs & pkgs_inst) == pkgs:
+                return True
 
-def _list_zones(root, path_transform):
-        """Get the zones associated with the image located at 'root'.  We
-        return a dictionary where the keys are zone names and the values are
-        tuples containing zone root path and current state. The global zone is
-        excluded from the results. Solaris10 branded zones are excluded from the
+        return False
+
+    def __list_zones_cached(self, nocache=False, ignore_errors=False):
+        """List the zones associated with the current image.  Since
+        this involves forking and running zone commands, cache the
         results."""
 
-        rv = dict()
-        cmd = DebugValues.get_value("bin_zoneadm") # pylint: disable=E1120
-        if cmd is not None:
-                cmd = [cmd]
-        else:
-                cmd = ["/usr/sbin/zoneadm"]
+        # if nocache is set then delete any cached children
+        if nocache:
+            self.__zoneadm_list_cache = None
 
-        # if the command doesn't exist then bail.
-        if not li.path_exists(cmd[0]):
-                return rv
+        # try to return the cached children
+        if self.__zoneadm_list_cache != None:
+            assert type(self.__zoneadm_list_cache) == list
+            return self.__zoneadm_list_cache
 
-        # make sure "root" has a trailing '/'
-        root = root.rstrip(os.sep) + os.sep
+        # see if the target image supports zones
+        if not self.__zones_supported():
+            self.__zoneadm_list_cache = []
+            return self.__list_zones_cached()
 
-        # create the zoneadm command line
-        cmd.extend(["-R", str(root), "list", "-cp"])
+        # zones are only visible when running in the global zone
+        if not self.__in_gz(ignore_errors=ignore_errors):
+            self.__zoneadm_list_cache = []
+            return self.__list_zones_cached()
 
-        # execute zoneadm and save its output to a file
-        # open a temporary file in text mode for compatible string handling
-        fout = tempfile.TemporaryFile(mode="w+")
-        ferrout = tempfile.TemporaryFile(mode="w+")
-        p = pkg.pkgsubprocess.Popen(cmd, stdout=fout, stderr=ferrout)
-        p.wait()
-        if p.returncode != 0:
-                cmd = " ".join(cmd)
-                ferrout.seek(0)
-                errout = "".join(ferrout.readlines())
-                ferrout.close()
-                raise apx.LinkedImageException(
-                    cmd_failed=(p.returncode, cmd, errout))
+        # find zones
+        try:
+            zdict = _list_zones(
+                self.__img.root, self.__linked.get_path_transform()
+            )
+        except OSError as e:
+            # W0212 Access to a protected member
+            # pylint: disable=W0212
+            if ignore_errors:
+                # don't cache the result
+                return []
+            raise apx._convert_error(e)
+        except apx.LinkedImageException as e:
+            if ignore_errors:
+                # don't cache the result
+                return []
+            raise e
 
-        # parse the command output
-        fout.seek(0)
-        output = fout.readlines()
-        fout.close()
-        for l in output:
-                l = l.rstrip()
+        # convert zone names into into LinkedImageName objects
+        zlist = []
+        # state is unused
+        # pylint: disable=W0612
+        for zone, (path, state) in six.iteritems(zdict):
+            lin = li.LinkedImageName("{0}:{1}".format(self.__pname, zone))
+            zlist.append([lin, path])
 
-                z_name, z_state, z_path, z_brand = \
-                    _zoneadm_list_parse(l, cmd, output)
+        self.__zoneadm_list_cache = zlist
+        return self.__list_zones_cached()
 
-                # skip brands that we don't care about
-                # W0511 XXX / FIXME Comments; pylint: disable=W0511
-                # XXX: don't hard code brand names, use a brand attribute
-                # pylint: enable=W0511
-                if z_brand not in [
-                    "lipkg", "solaris", "sn1", "labeled", "sparse", "pkgsrc"]:
-                        continue
+    def init_root(self, root):
+        """See parent class for docstring."""
+        # nuke any cached children
+        self.__zoneadm_list_cache = None
 
-                # we don't care about the global zone.
-                if z_name == "global":
-                        continue
+    def guess_path_transform(self, ignore_errors=False):
+        """See parent class for docstring."""
 
-                # append "/root" to zonepath
-                z_rootpath = os.path.join(z_path, "root")
-                assert z_rootpath.startswith(root), \
-                    "zone path '{0}' doesn't begin with '{1}".format(
-                    z_rootpath, root)
+        zlist = self.__list_zones_cached(
+            nocache=True, ignore_errors=ignore_errors
+        )
+        if not zlist:
+            return li.PATH_TRANSFORM_NONE
 
-                # If there is a current path transform in effect then revert
-                # the path reported by zoneadm to the original zone path.
-                if li.path_transform_applied(z_rootpath, path_transform):
-                        z_rootpath = li.path_transform_revert(z_rootpath,
-                            path_transform)
+        # only global zones can have zone children, and global zones
+        # always execute with "/" as their root.  so if the current
+        # image path is not "/", then assume we're in an alternate
+        # root.
+        root = self.__img.root.rstrip(os.sep) + os.sep
+        return (os.sep, root)
 
-                # we only care about zones that have been installed
-                if z_state not in zone_installed_states:
-                        continue
+    def get_child_list(self, nocache=False, ignore_errors=False):
+        """See parent class for docstring."""
 
-                rv[z_name] = (z_rootpath, z_state)
+        inmemory = []
+        # find any newly attached zone images
+        for lin in self.__children:
+            path = self.__children[lin][li.PROP_PATH]
+            inmemory.append([lin, path])
+
+        ondisk = []
+        for lin, path in self.__list_zones_cached(
+            nocache, ignore_errors=ignore_errors
+        ):
+            if lin in [i[0] for i in inmemory]:
+                # we re-attached a zone in memory.
+                continue
+            ondisk.append([lin, path])
+
+        rv = []
+        rv.extend(ondisk)
+        rv.extend(inmemory)
+
+        for lin, path in rv:
+            assert lin.lin_type == self.__pname
 
         return rv
 
+    def get_child_props(self, lin):
+        """See parent class for docstring."""
+
+        if lin in self.__children:
+            return self.__children[lin]
+
+        props = dict()
+        props[li.PROP_NAME] = lin
+        for i_lin, i_path in self.get_child_list():
+            if lin == i_lin:
+                props[li.PROP_PATH] = i_path
+                break
+        assert li.PROP_PATH in props
+
+        props[li.PROP_MODEL] = li.PV_MODEL_PUSH
+        for k, v in six.iteritems(self.attach_props_def):
+            if k not in props:
+                props[k] = v
+
+        return props
+
+    def attach_child_inmemory(self, props, allow_relink):
+        """See parent class for docstring."""
+
+        # make sure this child doesn't already exist
+        lin = props[li.PROP_NAME]
+        lin_list = [i[0] for i in self.get_child_list()]
+        assert lin not in lin_list or allow_relink
+
+        # cache properties (sans any temporarl ones)
+        self.__children[lin] = li.rm_dict_ent(props, li.temporal_props)
+
+    def detach_child_inmemory(self, lin):
+        """See parent class for docstring."""
+
+        # make sure this child exists
+        assert lin in [i[0] for i in self.get_child_list()]
+
+        # Delete this linked image
+        del self.__children[lin]
+
+    def sync_children_todisk(self):
+        """See parent class for docstring."""
+
+        # nothing to do
+        return li.LI_RVTuple(pkgdefs.EXIT_OK, None, None)
+
+
+class LinkedImageZoneChildPlugin(li.LinkedImageChildPlugin):
+    """See parent class for docstring."""
+
+    def __init__(self, lic):
+        """See parent class for docstring."""
+        li.LinkedImageChildPlugin.__init__(self, lic)
+
+    def munge_props(self, props):
+        """See parent class for docstring."""
+
+        #
+        # For zones we always update the pushed child image path to
+        # be '/' (Since any linked children of the zone will be
+        # relative to that zone's root).
+        #
+        props[li.PROP_PATH] = "/"
+
+
+def _zonename():
+    """Get the zonname of the current system."""
+
+    cmd = DebugValues.get_value("bin_zonename")  # pylint: disable=E1120
+    if cmd is not None:
+        cmd = [cmd]
+    else:
+        cmd = ["/bin/zonename"]
+
+    # if the command doesn't exist then bail.
+    if not li.path_exists(cmd[0]):
+        return
+
+    # open a temporary file in text mode for compatible string handling
+    fout = tempfile.TemporaryFile(mode="w+")
+    ferrout = tempfile.TemporaryFile(mode="w+")
+    p = pkg.pkgsubprocess.Popen(cmd, stdout=fout, stderr=ferrout)
+    p.wait()
+    if p.returncode != 0:
+        cmd = " ".join(cmd)
+        ferrout.seek(0)
+        errout = "".join(ferrout.readlines())
+        ferrout.close()
+        raise apx.LinkedImageException(cmd_failed=(p.returncode, cmd, errout))
+
+    # parse the command output
+    fout.seek(0)
+    lines = fout.readlines()
+    if lines:
+        zonename = lines[0].rstrip()
+        fout.close()
+        return zonename
+
+    # If /bin/zonename does not return the expected output,
+    # we raise an exception of LinkedImageException, which
+    # is handled by _in_gz().
+    cmd = " ".join(cmd)
+    raise apx.LinkedImageException(cmd_output_invalid=(cmd, lines))
+
+
+def _zoneadm_list_parse(line, cmd, output):
+    """Parse zoneadm list -p output.  It's possible for zonepath to
+    contain a ":".  If it does it will be escaped to be "\\:".  (But note
+    that if the zonepath contains a "\" it will not be escaped, which
+    is argubaly a bug.)"""
+
+    # zoneadm list output should never contain a NUL char, so
+    # temporarily replace any escaped colons with a NUL, split the string
+    # on any remaining colons, and then switch any NULs back to colons.
+    tmp_char = "\0"
+    fields = [
+        field.replace(tmp_char, ":")
+        for field in line.replace(r"\:", tmp_char).split(":")
+    ]
+
+    try:
+        # Unused variable; pylint: disable=W0612
+        z_id, z_name, z_state, z_path, z_uuid, z_brand, z_iptype = fields[:7]
+        # pylint: enable=W0612
+    except ValueError:
+        raise apx.LinkedImageException(cmd_output_invalid=(cmd, output))
+
+    return z_name, z_state, z_path, z_brand
+
+
+def _list_zones(root, path_transform):
+    """Get the zones associated with the image located at 'root'.  We
+    return a dictionary where the keys are zone names and the values are
+    tuples containing zone root path and current state. The global zone is
+    excluded from the results. Solaris10 branded zones are excluded from the
+    results."""
+
+    rv = dict()
+    cmd = DebugValues.get_value("bin_zoneadm")  # pylint: disable=E1120
+    if cmd is not None:
+        cmd = [cmd]
+    else:
+        cmd = ["/usr/sbin/zoneadm"]
+
+    # if the command doesn't exist then bail.
+    if not li.path_exists(cmd[0]):
+        return rv
+
+    # make sure "root" has a trailing '/'
+    root = root.rstrip(os.sep) + os.sep
+
+    # create the zoneadm command line
+    cmd.extend(["-R", str(root), "list", "-cp"])
+
+    # execute zoneadm and save its output to a file
+    # open a temporary file in text mode for compatible string handling
+    fout = tempfile.TemporaryFile(mode="w+")
+    ferrout = tempfile.TemporaryFile(mode="w+")
+    p = pkg.pkgsubprocess.Popen(cmd, stdout=fout, stderr=ferrout)
+    p.wait()
+    if p.returncode != 0:
+        cmd = " ".join(cmd)
+        ferrout.seek(0)
+        errout = "".join(ferrout.readlines())
+        ferrout.close()
+        raise apx.LinkedImageException(cmd_failed=(p.returncode, cmd, errout))
+
+    # parse the command output
+    fout.seek(0)
+    output = fout.readlines()
+    fout.close()
+    for l in output:
+        l = l.rstrip()
+
+        z_name, z_state, z_path, z_brand = _zoneadm_list_parse(l, cmd, output)
+
+        # skip brands that we don't care about
+        # W0511 XXX / FIXME Comments; pylint: disable=W0511
+        # XXX: don't hard code brand names, use a brand attribute
+        # pylint: enable=W0511
+        if z_brand not in [
+            "lipkg",
+            "solaris",
+            "sn1",
+            "labeled",
+            "sparse",
+            "pkgsrc",
+        ]:
+            continue
+
+        # we don't care about the global zone.
+        if z_name == "global":
+            continue
+
+        # append "/root" to zonepath
+        z_rootpath = os.path.join(z_path, "root")
+        assert z_rootpath.startswith(
+            root
+        ), "zone path '{0}' doesn't begin with '{1}".format(z_rootpath, root)
+
+        # If there is a current path transform in effect then revert
+        # the path reported by zoneadm to the original zone path.
+        if li.path_transform_applied(z_rootpath, path_transform):
+            z_rootpath = li.path_transform_revert(z_rootpath, path_transform)
+
+        # we only care about zones that have been installed
+        if z_state not in zone_installed_states:
+            continue
+
+        rv[z_name] = (z_rootpath, z_state)
+
+    return rv
+
+
 def list_running_zones():
-        """Return dictionary with currently running zones of the system in the
-        following form:
-                { zone_name : zone_path, ... }
-        """
+    """Return dictionary with currently running zones of the system in the
+    following form:
+            { zone_name : zone_path, ... }
+    """
 
-        zdict = _list_zones("/", li.PATH_TRANSFORM_NONE)
-        rzdict = {}
-        for z_name, (z_path, z_state) in six.iteritems(zdict):
-                if z_state == ZONE_STATE_STR_RUNNING:
-                        rzdict[z_name] = z_path
+    zdict = _list_zones("/", li.PATH_TRANSFORM_NONE)
+    rzdict = {}
+    for z_name, (z_path, z_state) in six.iteritems(zdict):
+        if z_state == ZONE_STATE_STR_RUNNING:
+            rzdict[z_name] = z_path
 
-        return rzdict
+    return rzdict
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/options.py
+++ b/src/modules/client/options.py
@@ -31,10 +31,15 @@ import pkg.misc as misc
 
 from pkg.client.api_errors import InvalidOptionError, LinkedImageException
 from pkg.client import global_settings
-from pkg.client.imageconfig import DEFAULT_RECURSE, DEFAULT_CONCURRENCY, \
-    TEMP_BE_ACTIVATION
+from pkg.client.imageconfig import (
+    DEFAULT_RECURSE,
+    DEFAULT_CONCURRENCY,
+    TEMP_BE_ACTIVATION,
+)
 
 _orig_cwd = None
+
+# fmt: off
 
 # List of available options for common option processing.
 ACCEPT                = "accept"
@@ -135,777 +140,879 @@ DISPLAY_LICENSE       = "display_license"
 INFO_LOCAL            = "info_local"
 INFO_REMOTE           = "info_remote"
 
+# fmt: on
+
+
 def opts_table_cb_info(op, api_inst, opts, opts_new):
-        opts_new[ORIGINS] = set()
-        for e in opts[ORIGINS]:
-                opts_new[ORIGINS].add(misc.parse_uri(e,
-                    cwd=_orig_cwd))
-        if opts[ORIGINS]:
-                opts_new[INFO_REMOTE] = True
-        if opts[QUIET]:
-                global_settings.client_output_quiet = True
-        if not opts_new[INFO_LOCAL] and not opts_new[INFO_REMOTE]:
-                opts_new[INFO_LOCAL] = True
-        elif opts_new[INFO_LOCAL] and opts_new[INFO_REMOTE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [INFO_LOCAL, INFO_REMOTE])
+    opts_new[ORIGINS] = set()
+    for e in opts[ORIGINS]:
+        opts_new[ORIGINS].add(misc.parse_uri(e, cwd=_orig_cwd))
+    if opts[ORIGINS]:
+        opts_new[INFO_REMOTE] = True
+    if opts[QUIET]:
+        global_settings.client_output_quiet = True
+    if not opts_new[INFO_LOCAL] and not opts_new[INFO_REMOTE]:
+        opts_new[INFO_LOCAL] = True
+    elif opts_new[INFO_LOCAL] and opts_new[INFO_REMOTE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [INFO_LOCAL, INFO_REMOTE]
+        )
+
 
 def __parse_set_props(args):
-        """"Parse set property options that were specified on the command
-        line into a dictionary.  Make sure duplicate properties were not
-        specified."""
+    """ "Parse set property options that were specified on the command
+    line into a dictionary.  Make sure duplicate properties were not
+    specified."""
 
-        set_props = dict()
-        for pv in args:
-                try:
-                        p, v = pv.split("=", 1)
-                except ValueError:
-                        raise InvalidOptionError(msg=_("properties to be set "
-                            "must be of the form '<name>=<value>'. This is "
-                            "what was given: {0}").format(pv))
+    set_props = dict()
+    for pv in args:
+        try:
+            p, v = pv.split("=", 1)
+        except ValueError:
+            raise InvalidOptionError(
+                msg=_(
+                    "properties to be set "
+                    "must be of the form '<name>=<value>'. This is "
+                    "what was given: {0}"
+                ).format(pv)
+            )
 
-                if p in set_props:
-                        raise InvalidOptionError(msg=_("a property may only "
-                            "be set once in a command. {0} was set twice"
-                            ).format(p))
-                set_props[p] = v
+        if p in set_props:
+            raise InvalidOptionError(
+                msg=_(
+                    "a property may only "
+                    "be set once in a command. {0} was set twice"
+                ).format(p)
+            )
+        set_props[p] = v
 
-        return set_props
+    return set_props
+
 
 def __parse_prop_values(args, add=True):
-        """"Parse add or remove property values options that were specified
-        on the command line into a dictionary.  Make sure duplicate properties
-        were not specified."""
+    """ "Parse add or remove property values options that were specified
+    on the command line into a dictionary.  Make sure duplicate properties
+    were not specified."""
 
-        props_values = dict()
-        if add:
-                add_txt = "added"
-        else:
-                add_txt = "removed"
+    props_values = dict()
+    if add:
+        add_txt = "added"
+    else:
+        add_txt = "removed"
 
-        for pv in args:
-                try:
-                        p, v = pv.split("=", 1)
-                except ValueError:
-                        raise InvalidOptionError(msg=_("property values to be "
-                            "{add} must be of the form '<name>=<value>'. "
-                            "This is what was given: {key}").format(
-                            add=add_txt, key=pv))
+    for pv in args:
+        try:
+            p, v = pv.split("=", 1)
+        except ValueError:
+            raise InvalidOptionError(
+                msg=_(
+                    "property values to be "
+                    "{add} must be of the form '<name>=<value>'. "
+                    "This is what was given: {key}"
+                ).format(add=add_txt, key=pv)
+            )
 
-                props_values.setdefault(p, [])
-                props_values[p].append(v)
+        props_values.setdefault(p, [])
+        props_values[p].append(v)
 
-        return props_values
+    return props_values
+
 
 def opts_table_cb_output_format(op, api_inst, opts, opts_new):
-        if opts[OUTPUT_FORMAT] == None:
-                opts_new[OUTPUT_FORMAT] = "default"
+    if opts[OUTPUT_FORMAT] == None:
+        opts_new[OUTPUT_FORMAT] = "default"
 
-        if (QUIET in opts and opts[QUIET] and
-            opts_new[OUTPUT_FORMAT] != 'default'):
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [QUIET, OUTPUT_FORMAT])
+    if QUIET in opts and opts[QUIET] and opts_new[OUTPUT_FORMAT] != "default":
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [QUIET, OUTPUT_FORMAT]
+        )
+
 
 def opts_table_cb_pub_props(op, api_inst, opts, opts_new):
-        opts_new[SET_PROPS] = __parse_set_props(opts[SET_PROPS])
-        opts_new[ADD_PROP_VALUES] = __parse_prop_values(opts[ADD_PROP_VALUES])
-        opts_new[REMOVE_PROP_VALUES] = __parse_prop_values(
-            opts[REMOVE_PROP_VALUES], add=False)
-        opts_new[UNSET_PROPS] = set(opts[UNSET_PROPS])
+    opts_new[SET_PROPS] = __parse_set_props(opts[SET_PROPS])
+    opts_new[ADD_PROP_VALUES] = __parse_prop_values(opts[ADD_PROP_VALUES])
+    opts_new[REMOVE_PROP_VALUES] = __parse_prop_values(
+        opts[REMOVE_PROP_VALUES], add=False
+    )
+    opts_new[UNSET_PROPS] = set(opts[UNSET_PROPS])
+
 
 def opts_table_cb_pub_search(op, api_inst, opts, opts_new):
-        if opts[SEARCH_BEFORE] and opts[SEARCH_AFTER]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [SEARCH_BEFORE, SEARCH_AFTER])
+    if opts[SEARCH_BEFORE] and opts[SEARCH_AFTER]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [SEARCH_BEFORE, SEARCH_AFTER]
+        )
 
-        if opts[SEARCH_BEFORE] and opts[SEARCH_FIRST]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [SEARCH_BEFORE, SEARCH_FIRST])
+    if opts[SEARCH_BEFORE] and opts[SEARCH_FIRST]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [SEARCH_BEFORE, SEARCH_FIRST]
+        )
 
-        if opts[SEARCH_AFTER] and opts[SEARCH_FIRST]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [SEARCH_AFTER, SEARCH_FIRST])
+    if opts[SEARCH_AFTER] and opts[SEARCH_FIRST]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [SEARCH_AFTER, SEARCH_FIRST]
+        )
+
 
 def opts_table_cb_pub_opts(op, api_inst, opts, opts_new):
-        del opts_new[PUB_DISABLE]
-        del opts_new[PUB_ENABLE]
-        del opts_new[PUB_STICKY]
-        del opts_new[PUB_NON_STICKY]
+    del opts_new[PUB_DISABLE]
+    del opts_new[PUB_ENABLE]
+    del opts_new[PUB_STICKY]
+    del opts_new[PUB_NON_STICKY]
 
-        if opts[PUB_DISABLE] and opts[PUB_ENABLE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [PUB_DISABLE, PUB_ENABLE])
+    if opts[PUB_DISABLE] and opts[PUB_ENABLE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [PUB_DISABLE, PUB_ENABLE]
+        )
 
-        if opts[PUB_STICKY] and opts[PUB_NON_STICKY]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [PUB_STICKY, PUB_NON_STICKY])
+    if opts[PUB_STICKY] and opts[PUB_NON_STICKY]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [PUB_STICKY, PUB_NON_STICKY]
+        )
 
-        opts_new[PUB_DISABLE] = None
-        if opts[PUB_DISABLE]:
-                opts_new[PUB_DISABLE] = True
+    opts_new[PUB_DISABLE] = None
+    if opts[PUB_DISABLE]:
+        opts_new[PUB_DISABLE] = True
 
-        if opts[PUB_ENABLE]:
-                opts_new[PUB_DISABLE] = False
+    if opts[PUB_ENABLE]:
+        opts_new[PUB_DISABLE] = False
 
-        opts_new[PUB_STICKY] = None
-        if opts[PUB_STICKY]:
-                opts_new[PUB_STICKY] = True
+    opts_new[PUB_STICKY] = None
+    if opts[PUB_STICKY]:
+        opts_new[PUB_STICKY] = True
 
-        if opts[PUB_NON_STICKY]:
-                opts_new[PUB_STICKY] = False
+    if opts[PUB_NON_STICKY]:
+        opts_new[PUB_STICKY] = False
 
-        if opts[ORIGIN_URI] and opts[ADD_ORIGINS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [ORIGIN_URI, ADD_ORIGINS])
+    if opts[ORIGIN_URI] and opts[ADD_ORIGINS]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [ORIGIN_URI, ADD_ORIGINS]
+        )
 
-        if opts[ORIGIN_URI] and opts[REMOVE_ORIGINS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [ORIGIN_URI, REMOVE_ORIGINS])
+    if opts[ORIGIN_URI] and opts[REMOVE_ORIGINS]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [ORIGIN_URI, REMOVE_ORIGINS]
+        )
 
-        if opts[REPO_URI] and opts[ADD_ORIGINS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [REPO_URI, ADD_ORIGINS])
-        if opts[REPO_URI] and opts[ADD_MIRRORS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [REPO_URI, ADD_MIRRORS])
-        if opts[REPO_URI] and opts[REMOVE_ORIGINS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [REPO_URI, REMOVE_ORIGINS])
-        if opts[REPO_URI] and opts[REMOVE_MIRRORS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [REPO_URI, REMOVE_MIRRORS])
-        if opts[REPO_URI] and opts[PUB_DISABLE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [REPO_URI, PUB_DISABLE])
-        if opts[REPO_URI] and opts[PUB_ENABLE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [REPO_URI, PUB_ENABLE])
-        if opts[REPO_URI] and not opts[REFRESH_ALLOWED]:
-                raise InvalidOptionError(InvalidOptionError.REQUIRED,
-                    [REPO_URI, REFRESH_ALLOWED])
-        if opts[REPO_URI] and opts[RESET_UUID]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [REPO_URI, RESET_UUID])
+    if opts[REPO_URI] and opts[ADD_ORIGINS]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [REPO_URI, ADD_ORIGINS]
+        )
+    if opts[REPO_URI] and opts[ADD_MIRRORS]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [REPO_URI, ADD_MIRRORS]
+        )
+    if opts[REPO_URI] and opts[REMOVE_ORIGINS]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [REPO_URI, REMOVE_ORIGINS]
+        )
+    if opts[REPO_URI] and opts[REMOVE_MIRRORS]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [REPO_URI, REMOVE_MIRRORS]
+        )
+    if opts[REPO_URI] and opts[PUB_DISABLE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [REPO_URI, PUB_DISABLE]
+        )
+    if opts[REPO_URI] and opts[PUB_ENABLE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [REPO_URI, PUB_ENABLE]
+        )
+    if opts[REPO_URI] and not opts[REFRESH_ALLOWED]:
+        raise InvalidOptionError(
+            InvalidOptionError.REQUIRED, [REPO_URI, REFRESH_ALLOWED]
+        )
+    if opts[REPO_URI] and opts[RESET_UUID]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [REPO_URI, RESET_UUID]
+        )
 
-        if opts[PROXY_URI] and not (opts[ADD_ORIGINS] or opts[ADD_MIRRORS]
-            or opts[REPO_URI] or opts[REMOVE_ORIGINS] or opts[REMOVE_MIRRORS]):
-                raise InvalidOptionError(InvalidOptionError.REQUIRED_ANY,
-                    [PROXY_URI, ADD_ORIGINS, ADD_MIRRORS, REMOVE_ORIGINS,
-                    REMOVE_MIRRORS, REPO_URI])
+    if opts[PROXY_URI] and not (
+        opts[ADD_ORIGINS]
+        or opts[ADD_MIRRORS]
+        or opts[REPO_URI]
+        or opts[REMOVE_ORIGINS]
+        or opts[REMOVE_MIRRORS]
+    ):
+        raise InvalidOptionError(
+            InvalidOptionError.REQUIRED_ANY,
+            [
+                PROXY_URI,
+                ADD_ORIGINS,
+                ADD_MIRRORS,
+                REMOVE_ORIGINS,
+                REMOVE_MIRRORS,
+                REPO_URI,
+            ],
+        )
 
-        opts_new[ADD_ORIGINS] = set()
-        opts_new[REMOVE_ORIGINS] = set()
-        opts_new[ADD_MIRRORS] = set()
-        opts_new[REMOVE_MIRRORS] = set()
-        opts_new[ENABLE_ORIGINS] = set()
-        opts_new[DISABLE_ORIGINS] = set()
-        for e in opts[ADD_ORIGINS]:
-                if e == "*":
-                        if not (opts[PUB_DISABLE] or opts[PUB_ENABLE]):
-                                raise InvalidOptionError(InvalidOptionError.XOR,
-                                    [PUB_ENABLE, PUB_DISABLE])
-                        # Allow wildcard to support an easy, scriptable
-                        # way of enabling all existing entries.
-                        if opts[PUB_DISABLE]:
-                                opts_new[DISABLE_ORIGINS].add("*")
-                        if opts[PUB_ENABLE]:
-                                opts_new[ENABLE_ORIGINS].add("*")
-                else:
-                        opts_new[ADD_ORIGINS].add(misc.parse_uri(e,
-                            cwd=_orig_cwd))
+    opts_new[ADD_ORIGINS] = set()
+    opts_new[REMOVE_ORIGINS] = set()
+    opts_new[ADD_MIRRORS] = set()
+    opts_new[REMOVE_MIRRORS] = set()
+    opts_new[ENABLE_ORIGINS] = set()
+    opts_new[DISABLE_ORIGINS] = set()
+    for e in opts[ADD_ORIGINS]:
+        if e == "*":
+            if not (opts[PUB_DISABLE] or opts[PUB_ENABLE]):
+                raise InvalidOptionError(
+                    InvalidOptionError.XOR, [PUB_ENABLE, PUB_DISABLE]
+                )
+            # Allow wildcard to support an easy, scriptable
+            # way of enabling all existing entries.
+            if opts[PUB_DISABLE]:
+                opts_new[DISABLE_ORIGINS].add("*")
+            if opts[PUB_ENABLE]:
+                opts_new[ENABLE_ORIGINS].add("*")
+        else:
+            opts_new[ADD_ORIGINS].add(misc.parse_uri(e, cwd=_orig_cwd))
 
-        # If enable/disable is specified and "*" is not present, then assign
-        # origins collected to be added into disable/enable set as well.
-        if opts[PUB_DISABLE]:
-                if "*" not in opts_new[DISABLE_ORIGINS]:
-                        opts_new[DISABLE_ORIGINS] = opts_new[ADD_ORIGINS]
+    # If enable/disable is specified and "*" is not present, then assign
+    # origins collected to be added into disable/enable set as well.
+    if opts[PUB_DISABLE]:
+        if "*" not in opts_new[DISABLE_ORIGINS]:
+            opts_new[DISABLE_ORIGINS] = opts_new[ADD_ORIGINS]
 
-        if opts[PUB_ENABLE]:
-                if "*" not in opts_new[ENABLE_ORIGINS]:
-                        opts_new[ENABLE_ORIGINS] = opts_new[ADD_ORIGINS]
+    if opts[PUB_ENABLE]:
+        if "*" not in opts_new[ENABLE_ORIGINS]:
+            opts_new[ENABLE_ORIGINS] = opts_new[ADD_ORIGINS]
 
-        for e in opts[REMOVE_ORIGINS]:
-                if e == "*":
-                        # Allow wildcard to support an easy, scriptable
-                        # way of removing all existing entries.
-                        opts_new[REMOVE_ORIGINS].add("*")
-                else:
-                        opts_new[REMOVE_ORIGINS].add(misc.parse_uri(e,
-                            cwd=_orig_cwd))
+    for e in opts[REMOVE_ORIGINS]:
+        if e == "*":
+            # Allow wildcard to support an easy, scriptable
+            # way of removing all existing entries.
+            opts_new[REMOVE_ORIGINS].add("*")
+        else:
+            opts_new[REMOVE_ORIGINS].add(misc.parse_uri(e, cwd=_orig_cwd))
 
-        for e in opts[ADD_MIRRORS]:
-                opts_new[ADD_MIRRORS].add(misc.parse_uri(e, cwd=_orig_cwd))
-        for e in opts[REMOVE_MIRRORS]:
-                if e == "*":
-                        # Allow wildcard to support an easy, scriptable
-                        # way of removing all existing entries.
-                        opts_new[REMOVE_MIRRORS].add("*")
-                else:
-                        opts_new[REMOVE_MIRRORS].add(misc.parse_uri(e,
-                            cwd=_orig_cwd))
+    for e in opts[ADD_MIRRORS]:
+        opts_new[ADD_MIRRORS].add(misc.parse_uri(e, cwd=_orig_cwd))
+    for e in opts[REMOVE_MIRRORS]:
+        if e == "*":
+            # Allow wildcard to support an easy, scriptable
+            # way of removing all existing entries.
+            opts_new[REMOVE_MIRRORS].add("*")
+        else:
+            opts_new[REMOVE_MIRRORS].add(misc.parse_uri(e, cwd=_orig_cwd))
 
-        if opts[REPO_URI]:
-                opts_new[REPO_URI] = misc.parse_uri(opts[REPO_URI],
-                    cwd=_orig_cwd)
+    if opts[REPO_URI]:
+        opts_new[REPO_URI] = misc.parse_uri(opts[REPO_URI], cwd=_orig_cwd)
+
 
 def opts_table_cb_beopts(op, api_inst, opts, opts_new):
+    # synthesize require_new_be and deny_new_be into new_be
+    del opts_new[REQUIRE_NEW_BE]
+    del opts_new[DENY_NEW_BE]
+    opts_new[NEW_BE] = None
 
-        # synthesize require_new_be and deny_new_be into new_be
-        del opts_new[REQUIRE_NEW_BE]
-        del opts_new[DENY_NEW_BE]
-        opts_new[NEW_BE] = None
+    if (opts[BE_NAME] or opts[REQUIRE_NEW_BE]) and opts[DENY_NEW_BE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [REQUIRE_NEW_BE, DENY_NEW_BE]
+        )
 
-        if (opts[BE_NAME] or opts[REQUIRE_NEW_BE]) and opts[DENY_NEW_BE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [REQUIRE_NEW_BE, DENY_NEW_BE])
+    # update BE_ACTIVATE based on BE_TEMP_ACTIVATE
+    if opts[BE_TEMP_ACTIVATE] and not opts[BE_ACTIVATE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [BE_ACTIVATE, BE_TEMP_ACTIVATE]
+        )
+    if opts[BE_ACTIVATE] and (
+        opts[BE_TEMP_ACTIVATE] or api_inst.img.get_property(TEMP_BE_ACTIVATION)
+    ):
+        opts_new[BE_ACTIVATE] = "bootnext"
+    del opts_new[BE_TEMP_ACTIVATE]
 
-        # update BE_ACTIVATE based on BE_TEMP_ACTIVATE
-        if opts[BE_TEMP_ACTIVATE] and not opts[BE_ACTIVATE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [BE_ACTIVATE, BE_TEMP_ACTIVATE])
-        if opts[BE_ACTIVATE] and (opts[BE_TEMP_ACTIVATE] or
-            api_inst.img.get_property(TEMP_BE_ACTIVATION)):
-                opts_new[BE_ACTIVATE] = 'bootnext'
-        del opts_new[BE_TEMP_ACTIVATE]
+    # create a new key called BACKUP_BE in the options array
+    if opts[REQUIRE_NEW_BE] or opts[BE_NAME]:
+        opts_new[NEW_BE] = True
+    if opts[DENY_NEW_BE]:
+        opts_new[NEW_BE] = False
 
-        # create a new key called BACKUP_BE in the options array
-        if opts[REQUIRE_NEW_BE] or opts[BE_NAME]:
-                opts_new[NEW_BE] = True
-        if opts[DENY_NEW_BE]:
-                opts_new[NEW_BE] = False
+    # synthesize require_backup_be and no_backup_be into backup_be
+    del opts_new[REQUIRE_BACKUP_BE]
+    del opts_new[NO_BACKUP_BE]
+    opts_new[BACKUP_BE] = None
 
-        # synthesize require_backup_be and no_backup_be into backup_be
-        del opts_new[REQUIRE_BACKUP_BE]
-        del opts_new[NO_BACKUP_BE]
-        opts_new[BACKUP_BE] = None
+    if (opts[REQUIRE_BACKUP_BE] or opts[BACKUP_BE_NAME]) and opts[NO_BACKUP_BE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [REQUIRE_BACKUP_BE, NO_BACKUP_BE]
+        )
 
-        if (opts[REQUIRE_BACKUP_BE] or opts[BACKUP_BE_NAME]) and \
-            opts[NO_BACKUP_BE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [REQUIRE_BACKUP_BE, NO_BACKUP_BE])
+    if (opts[REQUIRE_BACKUP_BE] or opts[BACKUP_BE_NAME]) and (
+        opts[REQUIRE_NEW_BE] or opts[BE_NAME]
+    ):
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [REQUIRE_BACKUP_BE, REQUIRE_NEW_BE]
+        )
 
-        if (opts[REQUIRE_BACKUP_BE] or opts[BACKUP_BE_NAME]) and \
-            (opts[REQUIRE_NEW_BE] or opts[BE_NAME]):
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [REQUIRE_BACKUP_BE, REQUIRE_NEW_BE])
+    # create a new key called BACKUP_BE in the options array
+    if opts[REQUIRE_BACKUP_BE] or opts[BACKUP_BE_NAME]:
+        opts_new[BACKUP_BE] = True
+    if opts[NO_BACKUP_BE]:
+        opts_new[BACKUP_BE] = False
 
-        # create a new key called BACKUP_BE in the options array
-        if opts[REQUIRE_BACKUP_BE] or opts[BACKUP_BE_NAME]:
-                opts_new[BACKUP_BE] = True
-        if opts[NO_BACKUP_BE]:
-                opts_new[BACKUP_BE] = False
 
 def opts_table_cb_li_ignore(op, api_inst, opts, opts_new):
+    # synthesize li_ignore_all and li_ignore_list into li_ignore
+    del opts_new[LI_IGNORE_ALL]
+    del opts_new[LI_IGNORE_LIST]
+    opts_new[LI_IGNORE] = None
 
-        # synthesize li_ignore_all and li_ignore_list into li_ignore
-        del opts_new[LI_IGNORE_ALL]
-        del opts_new[LI_IGNORE_LIST]
-        opts_new[LI_IGNORE] = None
+    # check if there's nothing to ignore
+    if not opts[LI_IGNORE_ALL] and not opts[LI_IGNORE_LIST]:
+        return
 
-        # check if there's nothing to ignore
-        if not opts[LI_IGNORE_ALL] and not opts[LI_IGNORE_LIST]:
-                return
+    if opts[LI_IGNORE_ALL]:
+        # can't ignore all and specific images
+        if opts[LI_IGNORE_LIST]:
+            raise InvalidOptionError(
+                InvalidOptionError.INCOMPAT, [LI_IGNORE_ALL, LI_IGNORE_LIST]
+            )
 
-        if opts[LI_IGNORE_ALL]:
-
-                # can't ignore all and specific images
-                if opts[LI_IGNORE_LIST]:
-                        raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                            [LI_IGNORE_ALL, LI_IGNORE_LIST])
-
-                # can't ignore all and target anything.
-                if LI_TARGET_ALL in opts and opts[LI_TARGET_ALL]:
-                        raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                            [LI_IGNORE_ALL, LI_TARGET_ALL])
-                if LI_TARGET_LIST in opts and opts[LI_TARGET_LIST]:
-                        raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                            [LI_IGNORE_ALL, LI_TARGET_LIST])
-                if LI_NAME in opts and opts[LI_NAME]:
-                        raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                            [LI_IGNORE_ALL, LI_NAME])
-                opts_new[LI_IGNORE] = []
-                return
-
-        assert opts[LI_IGNORE_LIST]
-
-        # it doesn't make sense to specify images to ignore if the
-        # user is already specifying images to operate on.
+        # can't ignore all and target anything.
         if LI_TARGET_ALL in opts and opts[LI_TARGET_ALL]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [LI_IGNORE_LIST, LI_TARGET_ALL])
+            raise InvalidOptionError(
+                InvalidOptionError.INCOMPAT, [LI_IGNORE_ALL, LI_TARGET_ALL]
+            )
         if LI_TARGET_LIST in opts and opts[LI_TARGET_LIST]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [LI_IGNORE_LIST, LI_TARGET_LIST])
+            raise InvalidOptionError(
+                InvalidOptionError.INCOMPAT, [LI_IGNORE_ALL, LI_TARGET_LIST]
+            )
         if LI_NAME in opts and opts[LI_NAME]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [LI_IGNORE_LIST, LI_NAME])
+            raise InvalidOptionError(
+                InvalidOptionError.INCOMPAT, [LI_IGNORE_ALL, LI_NAME]
+            )
+        opts_new[LI_IGNORE] = []
+        return
 
-        li_ignore = []
-        for li_name in opts[LI_IGNORE_LIST]:
-                # check for repeats
-                if li_name in li_ignore:
-                        raise InvalidOptionError(
-                            InvalidOptionError.ARG_REPEAT, [li_name,
-                            LI_IGNORE_LIST])
-                # add to ignore list
-                li_ignore.append(li_name)
+    assert opts[LI_IGNORE_LIST]
 
-        opts_new[LI_IGNORE] = api_inst.parse_linked_name_list(li_ignore)
+    # it doesn't make sense to specify images to ignore if the
+    # user is already specifying images to operate on.
+    if LI_TARGET_ALL in opts and opts[LI_TARGET_ALL]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [LI_IGNORE_LIST, LI_TARGET_ALL]
+        )
+    if LI_TARGET_LIST in opts and opts[LI_TARGET_LIST]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [LI_IGNORE_LIST, LI_TARGET_LIST]
+        )
+    if LI_NAME in opts and opts[LI_NAME]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [LI_IGNORE_LIST, LI_NAME]
+        )
+
+    li_ignore = []
+    for li_name in opts[LI_IGNORE_LIST]:
+        # check for repeats
+        if li_name in li_ignore:
+            raise InvalidOptionError(
+                InvalidOptionError.ARG_REPEAT, [li_name, LI_IGNORE_LIST]
+            )
+        # add to ignore list
+        li_ignore.append(li_name)
+
+    opts_new[LI_IGNORE] = api_inst.parse_linked_name_list(li_ignore)
+
 
 def opts_table_cb_li_no_psync(op, api_inst, opts, opts_new):
-        # if a target child linked image was specified, the no-parent-sync
-        # option doesn't make sense since we know that both the parent and
-        # child image are accessible
+    # if a target child linked image was specified, the no-parent-sync
+    # option doesn't make sense since we know that both the parent and
+    # child image are accessible
 
-        if LI_TARGET_ALL not in opts:
-                # we don't accept linked image target options
-                assert LI_TARGET_LIST not in opts
-                return
+    if LI_TARGET_ALL not in opts:
+        # we don't accept linked image target options
+        assert LI_TARGET_LIST not in opts
+        return
 
-        if opts[LI_TARGET_ALL] and not opts[LI_PARENT_SYNC]:
-                raise InvalidOptionError(InvalidOptionError.REQUIRED,
-                    [LI_TARGET_ALL, LI_PARENT_SYNC])
+    if opts[LI_TARGET_ALL] and not opts[LI_PARENT_SYNC]:
+        raise InvalidOptionError(
+            InvalidOptionError.REQUIRED, [LI_TARGET_ALL, LI_PARENT_SYNC]
+        )
 
-        if opts[LI_TARGET_LIST] and not opts[LI_PARENT_SYNC]:
-                raise InvalidOptionError(InvalidOptionError.REQUIRED,
-                    [LI_TARGET_LIST, LI_PARENT_SYNC])
+    if opts[LI_TARGET_LIST] and not opts[LI_PARENT_SYNC]:
+        raise InvalidOptionError(
+            InvalidOptionError.REQUIRED, [LI_TARGET_LIST, LI_PARENT_SYNC]
+        )
+
 
 def opts_table_cb_unpackaged(op, api_inst, opts, opts_new):
-        # Check whether unpackaged and unpackaged_only options are used
-        # together.
+    # Check whether unpackaged and unpackaged_only options are used
+    # together.
 
-        if opts[UNPACKAGED] and opts[UNPACKAGED_ONLY]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [UNPACKAGED, UNPACKAGED_ONLY])
+    if opts[UNPACKAGED] and opts[UNPACKAGED_ONLY]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [UNPACKAGED, UNPACKAGED_ONLY]
+        )
+
 
 def opts_table_cb_path_no_unpackaged(op, api_inst, opts, opts_new):
-        # Check whether path options is used with either unpackaged
-        # or unpackaged_only options.
+    # Check whether path options is used with either unpackaged
+    # or unpackaged_only options.
 
-        if opts[VERIFY_PATHS] and opts[UNPACKAGED]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [VERIFY_PATHS, UNPACKAGED])
+    if opts[VERIFY_PATHS] and opts[UNPACKAGED]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [VERIFY_PATHS, UNPACKAGED]
+        )
 
-        if opts[VERIFY_PATHS] and opts[UNPACKAGED_ONLY]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [VERIFY_PATHS, UNPACKAGED_ONLY])
+    if opts[VERIFY_PATHS] and opts[UNPACKAGED_ONLY]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [VERIFY_PATHS, UNPACKAGED_ONLY]
+        )
+
 
 def __parse_linked_props(args):
-        """"Parse linked image property options that were specified on the
-        command line into a dictionary.  Make sure duplicate properties were
-        not specified."""
+    """ "Parse linked image property options that were specified on the
+    command line into a dictionary.  Make sure duplicate properties were
+    not specified."""
 
-        linked_props = dict()
-        for pv in args:
-                try:
-                        p, v = pv.split("=", 1)
-                except ValueError:
-                        raise InvalidOptionError(msg=_("linked image "
-                            "property arguments must be of the form "
-                            "'<name>=<value>'."))
+    linked_props = dict()
+    for pv in args:
+        try:
+            p, v = pv.split("=", 1)
+        except ValueError:
+            raise InvalidOptionError(
+                msg=_(
+                    "linked image "
+                    "property arguments must be of the form "
+                    "'<name>=<value>'."
+                )
+            )
 
-                if p not in li.prop_values:
-                        raise InvalidOptionError(msg=_("invalid linked "
-                        "image property: '{0}'.").format(p))
+        if p not in li.prop_values:
+            raise InvalidOptionError(
+                msg=_("invalid linked " "image property: '{0}'.").format(p)
+            )
 
-                if p in linked_props:
-                        raise InvalidOptionError(msg=_("linked image "
-                            "property specified multiple times: "
-                            "'{0}'.").format(p))
+        if p in linked_props:
+            raise InvalidOptionError(
+                msg=_(
+                    "linked image "
+                    "property specified multiple times: "
+                    "'{0}'."
+                ).format(p)
+            )
 
-                linked_props[p] = v
+        linked_props[p] = v
 
-        return linked_props
+    return linked_props
+
 
 def opts_table_cb_li_props(op, api_inst, opts, opts_new):
-        """convert linked image prop list into a dictionary"""
+    """convert linked image prop list into a dictionary"""
 
-        opts_new[LI_PROPS] = __parse_linked_props(opts[LI_PROPS])
+    opts_new[LI_PROPS] = __parse_linked_props(opts[LI_PROPS])
+
 
 def opts_table_cb_li_target(op, api_inst, opts, opts_new):
-        # figure out which option the user specified
-        if opts[LI_TARGET_ALL] and opts[LI_TARGET_LIST]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [LI_TARGET_ALL, LI_TARGET_LIST])
-        elif opts[LI_TARGET_ALL]:
-                arg1 = LI_TARGET_ALL
-        elif opts[LI_TARGET_LIST]:
-                arg1 = LI_TARGET_LIST
-        else:
-                return
+    # figure out which option the user specified
+    if opts[LI_TARGET_ALL] and opts[LI_TARGET_LIST]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [LI_TARGET_ALL, LI_TARGET_LIST]
+        )
+    elif opts[LI_TARGET_ALL]:
+        arg1 = LI_TARGET_ALL
+    elif opts[LI_TARGET_LIST]:
+        arg1 = LI_TARGET_LIST
+    else:
+        return
 
-        if BE_ACTIVATE in opts and not opts[BE_ACTIVATE]:
-                raise InvalidOptionError(InvalidOptionError.REQUIRED,
-                    [arg1, BE_ACTIVATE])
-        if BE_NAME in opts and opts[BE_NAME]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, BE_NAME])
-        if DENY_NEW_BE in opts and opts[DENY_NEW_BE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, DENY_NEW_BE])
-        if REQUIRE_NEW_BE in opts and opts[REQUIRE_NEW_BE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, REQUIRE_NEW_BE])
-        if REJECT_PATS in opts and opts[REJECT_PATS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, REJECT_PATS])
-        if ORIGINS in opts and opts[ORIGINS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, ORIGINS])
+    if BE_ACTIVATE in opts and not opts[BE_ACTIVATE]:
+        raise InvalidOptionError(
+            InvalidOptionError.REQUIRED, [arg1, BE_ACTIVATE]
+        )
+    if BE_NAME in opts and opts[BE_NAME]:
+        raise InvalidOptionError(InvalidOptionError.INCOMPAT, [arg1, BE_NAME])
+    if DENY_NEW_BE in opts and opts[DENY_NEW_BE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [arg1, DENY_NEW_BE]
+        )
+    if REQUIRE_NEW_BE in opts and opts[REQUIRE_NEW_BE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [arg1, REQUIRE_NEW_BE]
+        )
+    if REJECT_PATS in opts and opts[REJECT_PATS]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [arg1, REJECT_PATS]
+        )
+    if ORIGINS in opts and opts[ORIGINS]:
+        raise InvalidOptionError(InvalidOptionError.INCOMPAT, [arg1, ORIGINS])
 
-        # validate linked image name
-        li_target_list = []
-        for li_name in opts[LI_TARGET_LIST]:
-                # check for repeats
-                if li_name in li_target_list:
-                        raise InvalidOptionError(
-                            InvalidOptionError.ARG_REPEAT, [li_name,
-                            LI_TARGET_LIST])
-                # add to ignore list
-                li_target_list.append(li_name)
+    # validate linked image name
+    li_target_list = []
+    for li_name in opts[LI_TARGET_LIST]:
+        # check for repeats
+        if li_name in li_target_list:
+            raise InvalidOptionError(
+                InvalidOptionError.ARG_REPEAT, [li_name, LI_TARGET_LIST]
+            )
+        # add to ignore list
+        li_target_list.append(li_name)
 
-        opts_new[LI_TARGET_LIST] = \
-            api_inst.parse_linked_name_list(li_target_list)
+    opts_new[LI_TARGET_LIST] = api_inst.parse_linked_name_list(li_target_list)
+
 
 def opts_table_cb_li_target1(op, api_inst, opts, opts_new):
-        # figure out which option the user specified
-        if opts[LI_NAME]:
-                arg1 = LI_NAME
-        else:
-                return
+    # figure out which option the user specified
+    if opts[LI_NAME]:
+        arg1 = LI_NAME
+    else:
+        return
 
-        if BE_ACTIVATE in opts and not opts[BE_ACTIVATE]:
-                raise InvalidOptionError(InvalidOptionError.REQUIRED,
-                    [arg1, BE_ACTIVATE])
-        if BE_NAME in opts and opts[BE_NAME]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, BE_NAME])
-        if DENY_NEW_BE in opts and opts[DENY_NEW_BE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, DENY_NEW_BE])
-        if REQUIRE_NEW_BE in opts and opts[REQUIRE_NEW_BE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, REQUIRE_NEW_BE])
-        if REJECT_PATS in opts and opts[REJECT_PATS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, REJECT_PATS])
-        if ORIGINS in opts and opts[ORIGINS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, ORIGINS])
+    if BE_ACTIVATE in opts and not opts[BE_ACTIVATE]:
+        raise InvalidOptionError(
+            InvalidOptionError.REQUIRED, [arg1, BE_ACTIVATE]
+        )
+    if BE_NAME in opts and opts[BE_NAME]:
+        raise InvalidOptionError(InvalidOptionError.INCOMPAT, [arg1, BE_NAME])
+    if DENY_NEW_BE in opts and opts[DENY_NEW_BE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [arg1, DENY_NEW_BE]
+        )
+    if REQUIRE_NEW_BE in opts and opts[REQUIRE_NEW_BE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [arg1, REQUIRE_NEW_BE]
+        )
+    if REJECT_PATS in opts and opts[REJECT_PATS]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [arg1, REJECT_PATS]
+        )
+    if ORIGINS in opts and opts[ORIGINS]:
+        raise InvalidOptionError(InvalidOptionError.INCOMPAT, [arg1, ORIGINS])
+
 
 def opts_table_cb_li_recurse(op, api_inst, opts, opts_new):
+    # Just LI_ERECURSE is preserved in the final options and that is
+    # set to the list of child images selected for recursion.
+    del opts_new[LI_ERECURSE_INCL]
+    del opts_new[LI_ERECURSE_EXCL]
+    del opts_new[LI_ERECURSE_ALL]
+    del opts_new[LI_ERECURSE_NONE]
 
-        # Just LI_ERECURSE is preserved in the final options and that is
-        # set to the list of child images selected for recursion.
-        del opts_new[LI_ERECURSE_INCL]
-        del opts_new[LI_ERECURSE_EXCL]
-        del opts_new[LI_ERECURSE_ALL]
-        del opts_new[LI_ERECURSE_NONE]
+    if (
+        op
+        in [
+            pkgdefs.PKG_OP_APPLY_HOT_FIX,
+            pkgdefs.PKG_OP_CHANGE_FACET,
+            pkgdefs.PKG_OP_CHANGE_VARIANT,
+            pkgdefs.PKG_OP_SET_MEDIATOR,
+            pkgdefs.PKG_OP_SET_PUBLISHER,
+            pkgdefs.PKG_OP_UPDATE,
+        ]
+        and api_inst.img.get_property(DEFAULT_RECURSE)
+        and not opts[LI_ERECURSE_NONE]
+    ):
+        opts[LI_ERECURSE_ALL] = True
 
-        if (op in [
-                pkgdefs.PKG_OP_APPLY_HOT_FIX,
-                pkgdefs.PKG_OP_CHANGE_FACET,
-                pkgdefs.PKG_OP_CHANGE_VARIANT,
-                pkgdefs.PKG_OP_SET_MEDIATOR,
-                pkgdefs.PKG_OP_SET_PUBLISHER,
-                pkgdefs.PKG_OP_UPDATE,
-            ]
-            and api_inst.img.get_property(DEFAULT_RECURSE)
-            and not opts[LI_ERECURSE_NONE]):
-                opts[LI_ERECURSE_ALL] = True
+    if opts[LI_ERECURSE_EXCL] and not opts[LI_ERECURSE_ALL]:
+        raise InvalidOptionError(
+            InvalidOptionError.REQUIRED, [LI_ERECURSE_EXCL, LI_ERECURSE_ALL]
+        )
 
-        if opts[LI_ERECURSE_EXCL] and not opts[LI_ERECURSE_ALL]:
-                raise InvalidOptionError(InvalidOptionError.REQUIRED,
-                    [LI_ERECURSE_EXCL, LI_ERECURSE_ALL])
+    if opts[LI_ERECURSE_INCL] and not opts[LI_ERECURSE_ALL]:
+        raise InvalidOptionError(
+            InvalidOptionError.REQUIRED, [LI_ERECURSE_INCL, LI_ERECURSE_ALL]
+        )
 
-        if opts[LI_ERECURSE_INCL] and not opts[LI_ERECURSE_ALL]:
-                raise InvalidOptionError(InvalidOptionError.REQUIRED,
-                    [LI_ERECURSE_INCL, LI_ERECURSE_ALL])
+    if opts[LI_ERECURSE_INCL] and opts[LI_ERECURSE_EXCL]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [LI_ERECURSE_INCL, LI_ERECURSE_EXCL]
+        )
 
-        if opts[LI_ERECURSE_INCL] and opts[LI_ERECURSE_EXCL]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [LI_ERECURSE_INCL, LI_ERECURSE_EXCL])
+    if not opts[LI_ERECURSE_ALL]:
+        opts_new[LI_ERECURSE] = None
+        return
 
-        if not opts[LI_ERECURSE_ALL]:
-                opts_new[LI_ERECURSE] = None
-                return
+    # Go through all children and check if they are in the recurse list.
+    li_child_targets = []
+    li_child_list = set(
+        [lin for lin, rel, path in api_inst.list_linked() if rel == "child"]
+    )
 
-        # Go through all children and check if they are in the recurse list.
-        li_child_targets = []
-        li_child_list = set([
-                lin
-                for lin, rel, path in api_inst.list_linked()
-                if rel == "child"
-        ])
+    def parse_lin(ulin):
+        lin = None
+        try:
+            lin = api_inst.parse_linked_name(ulin, allow_unknown=True)
+        except LinkedImageException as e:
+            try:
+                lin = api_inst.parse_linked_name(
+                    "zone:{0}".format(ulin), allow_unknown=True
+                )
+            except LinkedImageException as e:
+                pass
+        if lin is None or lin not in li_child_list:
+            raise InvalidOptionError(
+                msg=_("invalid linked image or zone name " "'{0}'.").format(
+                    ulin
+                )
+            )
 
-        def parse_lin(ulin):
-                lin = None
-                try:
-                        lin = api_inst.parse_linked_name(ulin,
-                            allow_unknown=True)
-                except LinkedImageException as e:
-                        try:
-                                lin = api_inst.parse_linked_name(
-                                    "zone:{0}".format(ulin), allow_unknown=True)
-                        except LinkedImageException as e:
-                                pass
-                if lin is None or lin not in li_child_list:
-                        raise InvalidOptionError(msg=
-                            _("invalid linked image or zone name "
-                            "'{0}'.").format(ulin))
+        return lin
 
-                return lin
+    if opts[LI_ERECURSE_INCL]:
+        # include list specified
+        for ulin in opts[LI_ERECURSE_INCL]:
+            li_child_targets.append(parse_lin(ulin))
+        opts_new[LI_ERECURSE] = li_child_targets
+    else:
+        # exclude list specified
+        for ulin in opts[LI_ERECURSE_EXCL]:
+            li_child_list.remove(parse_lin(ulin))
+        opts_new[LI_ERECURSE] = li_child_list
 
-        if opts[LI_ERECURSE_INCL]:
-                # include list specified
-                for ulin in opts[LI_ERECURSE_INCL]:
-                        li_child_targets.append(parse_lin(ulin))
-                opts_new[LI_ERECURSE] = li_child_targets
-        else:
-                # exclude list specified
-                for ulin in opts[LI_ERECURSE_EXCL]:
-                        li_child_list.remove(parse_lin(ulin))
-                opts_new[LI_ERECURSE] = li_child_list
+    # If we use image recursion we need to make sure uninstall and update
+    # ignore non-existing packages in the parent image.
+    if opts_new[LI_ERECURSE] and IGNORE_MISSING in opts:
+        opts_new[IGNORE_MISSING] = True
 
-        # If we use image recursion we need to make sure uninstall and update
-        # ignore non-existing packages in the parent image.
-        if opts_new[LI_ERECURSE] and IGNORE_MISSING in opts:
-                opts_new[IGNORE_MISSING] = True
 
 def opts_table_cb_no_headers_vs_quiet(op, api_inst, opts, opts_new):
-        # check if we accept the -q option
-        if QUIET not in opts:
-                return
+    # check if we accept the -q option
+    if QUIET not in opts:
+        return
 
-        # -q implies -H
-        if opts[QUIET]:
-                opts_new[OMIT_HEADERS] = True
+    # -q implies -H
+    if opts[QUIET]:
+        opts_new[OMIT_HEADERS] = True
+
 
 def opts_table_cb_q(op, api_inst, opts, opts_new):
-        # Be careful not to overwrite global_settings.client_output_quiet
-        # because it might be set "True" from elsewhere, e.g. in
-        # opts_table_cb_parsable.
-        if opts[QUIET] is True:
-                global_settings.client_output_quiet = True
+    # Be careful not to overwrite global_settings.client_output_quiet
+    # because it might be set "True" from elsewhere, e.g. in
+    # opts_table_cb_parsable.
+    if opts[QUIET] is True:
+        global_settings.client_output_quiet = True
+
 
 def opts_table_cb_v(op, api_inst, opts, opts_new):
-        global_settings.client_output_verbose = opts[VERBOSE]
+    global_settings.client_output_verbose = opts[VERBOSE]
+
 
 def opts_table_cb_nqv(op, api_inst, opts, opts_new):
-        if opts[VERBOSE] and opts[QUIET]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [VERBOSE, QUIET])
+    if opts[VERBOSE] and opts[QUIET]:
+        raise InvalidOptionError(InvalidOptionError.INCOMPAT, [VERBOSE, QUIET])
+
 
 def opts_table_cb_publishers(op, api_inst, opts, opts_new):
-        publishers = set()
-        for p in opts[PUBLISHERS]:
-                publishers.add(p)
-        opts_new[PUBLISHERS] = publishers
+    publishers = set()
+    for p in opts[PUBLISHERS]:
+        publishers.add(p)
+    opts_new[PUBLISHERS] = publishers
+
 
 def opts_table_cb_parsable(op, api_inst, opts, opts_new):
-        if opts[PARSABLE_VERSION] is not None and opts.get(VERBOSE, False):
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [VERBOSE, PARSABLE_VERSION])
-        if opts[PARSABLE_VERSION] is not None and opts.get(OMIT_HEADERS,
-            False):
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [OMIT_HEADERS, PARSABLE_VERSION])
-        if opts[PARSABLE_VERSION] is not None:
-                try:
-                        opts_new[PARSABLE_VERSION] = int(
-                            opts[PARSABLE_VERSION])
-                except ValueError:
-                        raise InvalidOptionError(
-                            options=[PARSABLE_VERSION],
-                            msg=_("integer argument expected"))
+    if opts[PARSABLE_VERSION] is not None and opts.get(VERBOSE, False):
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [VERBOSE, PARSABLE_VERSION]
+        )
+    if opts[PARSABLE_VERSION] is not None and opts.get(OMIT_HEADERS, False):
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [OMIT_HEADERS, PARSABLE_VERSION]
+        )
+    if opts[PARSABLE_VERSION] is not None:
+        try:
+            opts_new[PARSABLE_VERSION] = int(opts[PARSABLE_VERSION])
+        except ValueError:
+            raise InvalidOptionError(
+                options=[PARSABLE_VERSION], msg=_("integer argument expected")
+            )
 
-                global_settings.client_output_parsable_version = \
-                    opts_new[PARSABLE_VERSION]
-                opts_new[QUIET] = True
-                global_settings.client_output_quiet = True
+        global_settings.client_output_parsable_version = opts_new[
+            PARSABLE_VERSION
+        ]
+        opts_new[QUIET] = True
+        global_settings.client_output_quiet = True
+
 
 def opts_table_cb_origins(op, api_inst, opts, opts_new):
-        origins = set()
-        for o in opts[ORIGINS]:
-                origins.add(misc.parse_uri(o, cwd=_orig_cwd))
-        opts_new[ORIGINS] = origins
+    origins = set()
+    for o in opts[ORIGINS]:
+        origins.add(misc.parse_uri(o, cwd=_orig_cwd))
+    opts_new[ORIGINS] = origins
+
 
 def opts_table_cb_stage(op, api_inst, opts, opts_new):
-        if opts[STAGE] == None:
-                opts_new[STAGE] = pkgdefs.API_STAGE_DEFAULT
-                return
+    if opts[STAGE] == None:
+        opts_new[STAGE] = pkgdefs.API_STAGE_DEFAULT
+        return
 
-        if opts_new[STAGE] not in pkgdefs.api_stage_values:
-                raise InvalidOptionError(msg=_("invalid operation stage: "
-                    "'{0}'").format(opts[STAGE]))
+    if opts_new[STAGE] not in pkgdefs.api_stage_values:
+        raise InvalidOptionError(
+            msg=_("invalid operation stage: " "'{0}'").format(opts[STAGE])
+        )
+
 
 def opts_cb_li_attach(op, api_inst, opts, opts_new):
-        if opts[ATTACH_PARENT] and opts[ATTACH_CHILD]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [ATTACH_PARENT, ATTACH_CHILD])
+    if opts[ATTACH_PARENT] and opts[ATTACH_CHILD]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [ATTACH_PARENT, ATTACH_CHILD]
+        )
 
-        if not opts[ATTACH_PARENT] and not opts[ATTACH_CHILD]:
-                raise InvalidOptionError(InvalidOptionError.XOR,
-                    [ATTACH_PARENT, ATTACH_CHILD])
+    if not opts[ATTACH_PARENT] and not opts[ATTACH_CHILD]:
+        raise InvalidOptionError(
+            InvalidOptionError.XOR, [ATTACH_PARENT, ATTACH_CHILD]
+        )
 
-        if opts[ATTACH_CHILD]:
-                # if we're attaching a new child then that doesn't affect
-                # any other children, so ignoring them doesn't make sense.
-                if opts[LI_IGNORE_ALL]:
-                        raise InvalidOptionError(
-                            InvalidOptionError.INCOMPAT,
-                            [ATTACH_CHILD, LI_IGNORE_ALL])
-                if opts[LI_IGNORE_LIST]:
-                        raise InvalidOptionError(
-                            InvalidOptionError.INCOMPAT,
-                            [ATTACH_CHILD, LI_IGNORE_LIST])
+    if opts[ATTACH_CHILD]:
+        # if we're attaching a new child then that doesn't affect
+        # any other children, so ignoring them doesn't make sense.
+        if opts[LI_IGNORE_ALL]:
+            raise InvalidOptionError(
+                InvalidOptionError.INCOMPAT, [ATTACH_CHILD, LI_IGNORE_ALL]
+            )
+        if opts[LI_IGNORE_LIST]:
+            raise InvalidOptionError(
+                InvalidOptionError.INCOMPAT, [ATTACH_CHILD, LI_IGNORE_LIST]
+            )
+
 
 def opts_table_cb_md_only(op, api_inst, opts, opts_new):
-        # if the user didn't specify linked-md-only we're done
-        if not opts[LI_MD_ONLY]:
-                return
+    # if the user didn't specify linked-md-only we're done
+    if not opts[LI_MD_ONLY]:
+        return
 
-        # li_md_only implies no li_pkg_updates
-        if LI_PKG_UPDATES in opts:
-                opts_new[LI_PKG_UPDATES] = False
+    # li_md_only implies no li_pkg_updates
+    if LI_PKG_UPDATES in opts:
+        opts_new[LI_PKG_UPDATES] = False
 
-        #
-        # if li_md_only is false that means we're not updating any packages
-        # within the current image so there are a ton of options that no
-        # longer apply to the current operation, and hence are incompatible
-        # with li_md_only.
-        #
-        arg1 = LI_MD_ONLY
-        if BE_NAME in opts and opts[BE_NAME]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, BE_NAME])
-        if DENY_NEW_BE in opts and opts[DENY_NEW_BE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, DENY_NEW_BE])
-        if REQUIRE_NEW_BE in opts and opts[REQUIRE_NEW_BE]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, REQUIRE_NEW_BE])
-        if LI_PARENT_SYNC in opts and not opts[LI_PARENT_SYNC]:
-                raise InvalidOptionError(InvalidOptionError.REQUIRED,
-                    [arg1, LI_PARENT_SYNC])
-        if REJECT_PATS in opts and opts[REJECT_PATS]:
-                raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                    [arg1, REJECT_PATS])
+    #
+    # if li_md_only is false that means we're not updating any packages
+    # within the current image so there are a ton of options that no
+    # longer apply to the current operation, and hence are incompatible
+    # with li_md_only.
+    #
+    arg1 = LI_MD_ONLY
+    if BE_NAME in opts and opts[BE_NAME]:
+        raise InvalidOptionError(InvalidOptionError.INCOMPAT, [arg1, BE_NAME])
+    if DENY_NEW_BE in opts and opts[DENY_NEW_BE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [arg1, DENY_NEW_BE]
+        )
+    if REQUIRE_NEW_BE in opts and opts[REQUIRE_NEW_BE]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [arg1, REQUIRE_NEW_BE]
+        )
+    if LI_PARENT_SYNC in opts and not opts[LI_PARENT_SYNC]:
+        raise InvalidOptionError(
+            InvalidOptionError.REQUIRED, [arg1, LI_PARENT_SYNC]
+        )
+    if REJECT_PATS in opts and opts[REJECT_PATS]:
+        raise InvalidOptionError(
+            InvalidOptionError.INCOMPAT, [arg1, REJECT_PATS]
+        )
+
 
 list_incompat_options = [
-    [ ORIGINS, LIST_UPGRADABLE ],
-    [ ORIGINS, LIST_REMOVABLE ],
-
-    [ LIST_INSTALLED_NEWEST, LIST_NEWEST ],
-    [ LIST_INSTALLED_NEWEST, LIST_UPGRADABLE],
-    [ LIST_INSTALLED_NEWEST, LIST_REMOVABLE],
-
-    [ LIST_UPGRADABLE, LIST_REMOVABLE],
-    [ LIST_MANUAL, LIST_NOT_MANUAL],
-
-    [ LIST_INSTALLABLE, LIST_MANUAL ],
-    [ LIST_INSTALLABLE, LIST_NOT_MANUAL ],
-    [ LIST_INSTALLABLE, LIST_REMOVABLE ],
-    [ LIST_INSTALLABLE, LIST_UPGRADABLE ],
-
-    [ SUMMARY, VERBOSE],
-    [ QUIET, VERBOSE],
+    [ORIGINS, LIST_UPGRADABLE],
+    [ORIGINS, LIST_REMOVABLE],
+    [LIST_INSTALLED_NEWEST, LIST_NEWEST],
+    [LIST_INSTALLED_NEWEST, LIST_UPGRADABLE],
+    [LIST_INSTALLED_NEWEST, LIST_REMOVABLE],
+    [LIST_UPGRADABLE, LIST_REMOVABLE],
+    [LIST_MANUAL, LIST_NOT_MANUAL],
+    [LIST_INSTALLABLE, LIST_MANUAL],
+    [LIST_INSTALLABLE, LIST_NOT_MANUAL],
+    [LIST_INSTALLABLE, LIST_REMOVABLE],
+    [LIST_INSTALLABLE, LIST_UPGRADABLE],
+    [SUMMARY, VERBOSE],
+    [QUIET, VERBOSE],
 ]
 
+
 def opts_cb_list(op, api_inst, opts, opts_new):
+    if opts_new[LIST_ALL_REMOVABLE]:
+        opts_new[LIST_REMOVABLE] = True
 
-        if opts_new[LIST_ALL_REMOVABLE]:
-                opts_new[LIST_REMOVABLE] = True
+    for a, b in list_incompat_options:
+        if opts_new[a] and opts_new[b]:
+            raise InvalidOptionError(InvalidOptionError.INCOMPAT, [a, b])
 
-        for (a, b) in list_incompat_options:
-                if opts_new[a] and opts_new[b]:
-                        raise InvalidOptionError(InvalidOptionError.INCOMPAT,
-                            [a, b])
+    if opts_new[ORIGINS] and not opts_new[LIST_NEWEST]:
+        # Use of -g implies -a unless -n is provided.
+        opts_new[LIST_INSTALLED_NEWEST] = True
 
-        if opts_new[ORIGINS] and not opts_new[LIST_NEWEST]:
-                # Use of -g implies -a unless -n is provided.
-                opts_new[LIST_INSTALLED_NEWEST] = True
+    if opts_new[LIST_ALL] and not opts_new[LIST_INSTALLED_NEWEST]:
+        raise InvalidOptionError(
+            InvalidOptionError.REQUIRED, [LIST_ALL, LIST_INSTALLED_NEWEST]
+        )
 
-        if opts_new[LIST_ALL] and not opts_new[LIST_INSTALLED_NEWEST]:
-                raise InvalidOptionError(InvalidOptionError.REQUIRED,
-                    [LIST_ALL, LIST_INSTALLED_NEWEST])
+    if opts_new[LIST_INSTALLABLE] and not opts_new[LIST_INSTALLED_NEWEST]:
+        # Use of -i implies -n unless -a is provided.
+        opts_new[LIST_NEWEST] = True
 
-        if opts_new[LIST_INSTALLABLE] and not opts_new[LIST_INSTALLED_NEWEST]:
-                # Use of -i implies -n unless -a is provided.
-                opts_new[LIST_NEWEST] = True
 
 def opts_cb_int(k, api_inst, opts, opts_new, minimum=None):
+    if k not in opts or opts[k] == None:
+        err = _("missing required parameter")
+        raise InvalidOptionError(msg=err, options=[k])
 
-        if k not in opts or opts[k] == None:
-                err = _("missing required parameter")
-                raise InvalidOptionError(msg=err, options=[k])
+    # get the original argument value
+    v = opts[k]
 
-        # get the original argument value
-        v = opts[k]
+    # make sure it is an integer
+    try:
+        v = int(v)
+    except (ValueError, TypeError):
+        # not a valid integer
+        err = _("value '{0}' invalid").format(v)
+        raise InvalidOptionError(msg=err, options=[k])
 
-        # make sure it is an integer
-        try:
-                v = int(v)
-        except (ValueError, TypeError):
-                # not a valid integer
-                err = _("value '{0}' invalid").format(v)
-                raise InvalidOptionError(msg=err, options=[k])
+    # check the minimum bounds
+    if minimum is not None and v < minimum:
+        err = _("value must be >= {0:d}").format(minimum)
+        raise InvalidOptionError(msg=err, options=[k])
 
-        # check the minimum bounds
-        if minimum is not None and v < minimum:
-                err = _("value must be >= {0:d}").format(minimum)
-                raise InvalidOptionError(msg=err, options=[k])
+    # update the new options array to make the value an integer
+    opts_new[k] = v
 
-        # update the new options array to make the value an integer
-        opts_new[k] = v
 
 def opts_cb_fd(k, api_inst, opts, opts_new):
-        opts_cb_int(k, api_inst, opts, opts_new, minimum=0)
+    opts_cb_int(k, api_inst, opts, opts_new, minimum=0)
 
-        err = _("value '{0}' invalid").format(opts_new[k])
-        try:
-                os.fstat(opts_new[k])
-        except OSError:
-                # not a valid file descriptor
-                raise InvalidOptionError(msg=err, options=[k])
+    err = _("value '{0}' invalid").format(opts_new[k])
+    try:
+        os.fstat(opts_new[k])
+    except OSError:
+        # not a valid file descriptor
+        raise InvalidOptionError(msg=err, options=[k])
+
 
 def opts_table_cb_concurrency(op, api_inst, opts, opts_new):
-        if opts[CONCURRENCY] is None:
-                # If the concurrency has been set by an environment variable
-                # then client_concurrency_set will be true. Don't override with
-                # the image default in this case.
-                if not global_settings.client_concurrency_set:
-                        opts[CONCURRENCY] = api_inst.img.get_property(
-                            DEFAULT_CONCURRENCY)
-                else:
-                        # remove concurrency from parameters dict
-                        del opts_new[CONCURRENCY]
-                        return
+    if opts[CONCURRENCY] is None:
+        # If the concurrency has been set by an environment variable
+        # then client_concurrency_set will be true. Don't override with
+        # the image default in this case.
+        if not global_settings.client_concurrency_set:
+            opts[CONCURRENCY] = api_inst.img.get_property(DEFAULT_CONCURRENCY)
+        else:
+            # remove concurrency from parameters dict
+            del opts_new[CONCURRENCY]
+            return
 
-        # make sure we have an integer
-        opts_cb_int(CONCURRENCY, api_inst, opts, opts_new)
+    # make sure we have an integer
+    opts_cb_int(CONCURRENCY, api_inst, opts, opts_new)
 
-        # update global concurrency setting
-        global_settings.client_concurrency = opts_new[CONCURRENCY]
-        global_settings.client_concurrency_set = True
+    # update global concurrency setting
+    global_settings.client_concurrency = opts_new[CONCURRENCY]
+    global_settings.client_concurrency_set = True
 
-        # remove concurrency from parameters dict
-        del opts_new[CONCURRENCY]
+    # remove concurrency from parameters dict
+    del opts_new[CONCURRENCY]
+
 
 def opts_table_cb_actuators(op, api_inst, opts, opts_new):
+    del opts_new[ACT_TIMEOUT]
+    del opts_new[SYNC_ACT]
 
-        del opts_new[ACT_TIMEOUT]
-        del opts_new[SYNC_ACT]
+    if opts[ACT_TIMEOUT]:
+        # make sure we have an integer
+        opts_cb_int(ACT_TIMEOUT, api_inst, opts, opts_new)
+    elif opts[SYNC_ACT]:
+        # -1 is no timeout
+        opts_new[ACT_TIMEOUT] = -1
+    else:
+        # 0 is no sync actuators are used (timeout=0)
+        opts_new[ACT_TIMEOUT] = 0
 
-        if opts[ACT_TIMEOUT]:
-                # make sure we have an integer
-                opts_cb_int(ACT_TIMEOUT, api_inst, opts, opts_new)
-        elif opts[SYNC_ACT]:
-                # -1 is no timeout
-                opts_new[ACT_TIMEOUT] = -1
-        else:
-                # 0 is no sync actuators are used (timeout=0)
-                opts_new[ACT_TIMEOUT] = 0
 
 #
 # options common to multiple pkg(1) operations.  The format for specifying
@@ -920,6 +1027,8 @@ def opts_table_cb_actuators(op, api_inst, opts, opts_new):
 #       and it is optional.
 #       {}: json schema.
 #
+
+# fmt: off
 
 opts_table_info = [
     opts_table_cb_info,
@@ -1378,7 +1487,6 @@ opts_publisher = \
     []
 
 pkg_op_opts = {
-
     pkgdefs.PKG_OP_ATTACH         : opts_attach_linked,
     pkgdefs.PKG_OP_AUDIT_LINKED   : opts_audit_linked,
     pkgdefs.PKG_OP_CHANGE_FACET   : opts_install,
@@ -1409,130 +1517,133 @@ pkg_op_opts = {
     pkgdefs.PKG_OP_VERIFY         : opts_verify
 }
 
+# fmt: on
+
+
 def get_pkg_opts(op, add_table=None):
-        """Get the available options for a particular operation specified by
-        'op'. If the client uses custom pkg_op_opts tables they can be specified
-        by 'add_table'."""
+    """Get the available options for a particular operation specified by
+    'op'. If the client uses custom pkg_op_opts tables they can be specified
+    by 'add_table'."""
 
-        popts = pkg_op_opts.copy()
-        if add_table is not None:
-                popts.update(add_table)
+    popts = pkg_op_opts.copy()
+    if add_table is not None:
+        popts.update(add_table)
 
-        try:
-                opts = popts[op]
-        except KeyError:
-                opts = None
-        return opts
+    try:
+        opts = popts[op]
+    except KeyError:
+        opts = None
+    return opts
+
 
 def get_pkg_opts_defaults(op, opt, add_table=None):
-        """ Get the default value for a certain option 'opt' of a certain
-        operation 'op'. This is useful for clients which toggle boolean options.
-        """
-        popts = get_pkg_opts(op, add_table)
+    """Get the default value for a certain option 'opt' of a certain
+    operation 'op'. This is useful for clients which toggle boolean options.
+    """
+    popts = get_pkg_opts(op, add_table)
 
-        for o in popts:
-                if type(o) != tuple:
-                        continue
-                if len(o) == 2:
-                        opt_name, default = o
-                elif len(o) == 3:
-                        opt_name, default, dummy_valid_args = o
-                elif len(o) == 4:
-                        opt_name, default, dummy_valid_args, dummy_schema = o
-                if opt_name == opt:
-                        return default
+    for o in popts:
+        if type(o) != tuple:
+            continue
+        if len(o) == 2:
+            opt_name, default = o
+        elif len(o) == 3:
+            opt_name, default, dummy_valid_args = o
+        elif len(o) == 4:
+            opt_name, default, dummy_valid_args, dummy_schema = o
+        if opt_name == opt:
+            return default
+
 
 def opts_assemble(op, api_inst, opts, add_table=None, cwd=None):
-        """Assembly of the options for a specific operation. Options are read in
-        from a dict (see explanation below) and sanity tested.
+    """Assembly of the options for a specific operation. Options are read in
+    from a dict (see explanation below) and sanity tested.
 
-        This is the common interface to supply options to the functions of the
-        API.
+    This is the common interface to supply options to the functions of the
+    API.
 
-        'op' is the operation for which the options need to be assembled and
-        verified. The currently supported operations are listed in
-        pkgdefs.pkg_op_values.
+    'op' is the operation for which the options need to be assembled and
+    verified. The currently supported operations are listed in
+    pkgdefs.pkg_op_values.
 
-        'api_inst' is a reference to the API instance, required for some of the
-        verification steps.
+    'api_inst' is a reference to the API instance, required for some of the
+    verification steps.
 
-        'opts' is the raw options table to be processed. It needs to be a dict
-        in the format: { option_name: argument, ... }
-        """
+    'opts' is the raw options table to be processed. It needs to be a dict
+    in the format: { option_name: argument, ... }
+    """
 
-        global _orig_cwd
+    global _orig_cwd
 
-        if cwd is not None:
-                _orig_cwd = cwd
-        else:
-                _orig_cwd = None
+    if cwd is not None:
+        _orig_cwd = cwd
+    else:
+        _orig_cwd = None
 
-        popts = get_pkg_opts(op, add_table)
+    popts = get_pkg_opts(op, add_table)
 
-        rv = {}
-        callbacks = []
+    rv = {}
+    callbacks = []
 
-        for o in popts:
-                if type(o) != tuple:
-                        callbacks.append(o)
-                        continue
-                valid_args = []
-                # If no valid argument list specified.
-                if len(o) == 2:
-                        avail_opt, default = o
-                elif len(o) == 3:
-                        avail_opt, default, valid_args = o
-                elif len(o) == 4:
-                        avail_opt, default, valid_args, schema = o
-                # for options not given we substitue the default value
-                if avail_opt not in opts:
-                        rv[avail_opt] = default
-                        continue
+    for o in popts:
+        if type(o) != tuple:
+            callbacks.append(o)
+            continue
+        valid_args = []
+        # If no valid argument list specified.
+        if len(o) == 2:
+            avail_opt, default = o
+        elif len(o) == 3:
+            avail_opt, default, valid_args = o
+        elif len(o) == 4:
+            avail_opt, default, valid_args, schema = o
+        # for options not given we substitue the default value
+        if avail_opt not in opts:
+            rv[avail_opt] = default
+            continue
 
-                if type(default) == int:
-                        assert type(opts[avail_opt]) == int, opts[avail_opt]
-                elif type(default) == list:
-                        assert type(opts[avail_opt]) == list, opts[avail_opt]
-                elif type(default) == bool:
-                        assert type(opts[avail_opt]) == bool, opts[avail_opt]
+        if type(default) == int:
+            assert type(opts[avail_opt]) == int, opts[avail_opt]
+        elif type(default) == list:
+            assert type(opts[avail_opt]) == list, opts[avail_opt]
+        elif type(default) == bool:
+            assert type(opts[avail_opt]) == bool, opts[avail_opt]
 
-                if valid_args:
-                        assert type(default) == list or default is None, \
-                            default
-                        raise_error = False
-                        if type(opts[avail_opt]) == list:
-                                if not set(opts[avail_opt]).issubset(
-                                    set(valid_args)):
-                                        raise_error = True
-                        else:
-                                # If the any of valid_args is integer, we first
-                                # try to convert the argument value into
-                                # integer. This is for CLI mode where arguments
-                                # are strings.
-                                if any(type(va) == int for va in valid_args):
-                                        try:
-                                                opts[avail_opt] = int(
-                                                    opts[avail_opt])
-                                        except Exception:
-                                                pass
-                                if opts[avail_opt] not in valid_args:
-                                        raise_error = True
-                        if raise_error:
-                                raise InvalidOptionError(
-                                    InvalidOptionError.ARG_INVALID,
-                                    [opts[avail_opt], avail_opt],
-                                    valid_args=valid_args)
+        if valid_args:
+            assert type(default) == list or default is None, default
+            raise_error = False
+            if type(opts[avail_opt]) == list:
+                if not set(opts[avail_opt]).issubset(set(valid_args)):
+                    raise_error = True
+            else:
+                # If the any of valid_args is integer, we first
+                # try to convert the argument value into
+                # integer. This is for CLI mode where arguments
+                # are strings.
+                if any(type(va) == int for va in valid_args):
+                    try:
+                        opts[avail_opt] = int(opts[avail_opt])
+                    except Exception:
+                        pass
+                if opts[avail_opt] not in valid_args:
+                    raise_error = True
+            if raise_error:
+                raise InvalidOptionError(
+                    InvalidOptionError.ARG_INVALID,
+                    [opts[avail_opt], avail_opt],
+                    valid_args=valid_args,
+                )
 
-                rv[avail_opt] = opts[avail_opt]
+        rv[avail_opt] = opts[avail_opt]
 
-        rv_updated = rv.copy()
+    rv_updated = rv.copy()
 
-        # run the option verification callbacks
-        for cb in callbacks:
-                cb(op, api_inst, rv, rv_updated)
+    # run the option verification callbacks
+    for cb in callbacks:
+        cb(op, api_inst, rv, rv_updated)
 
-        return rv_updated
+    return rv_updated
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/pkg_solver.py
+++ b/src/modules/client/pkg_solver.py
@@ -32,10 +32,12 @@ import operator
 import time
 
 from collections import defaultdict
+
 # Redefining built-in; pylint: disable=W0622
 from functools import reduce
 
 import six
+
 # Imports from package six are not grouped: pylint: disable=C0412
 from six.moves import range
 from itertools import chain
@@ -55,9 +57,9 @@ from pkg.client.firmware import Firmware
 from pkg.client.pkgdefs import PKG_OP_UNINSTALL, PKG_OP_UPDATE
 from pkg.misc import EmptyI, EmptyDict, N_
 
-SOLVER_INIT    = "Initialized"
-SOLVER_OXY     = "Not possible"
-SOLVER_FAIL    = "Failed"
+SOLVER_INIT = "Initialized"
+SOLVER_OXY = "Not possible"
+SOLVER_FAIL = "Failed"
 SOLVER_SUCCESS = "Succeeded"
 
 #
@@ -66,3462 +68,3765 @@ SOLVER_SUCCESS = "Succeeded"
 # instead, they indicate the 'type' of trim applied. Values below must be
 # unique, but can be changed at any time.
 #
-_TRIM_DEP_MISSING = 0              # no matching pkg version found for dep
-_TRIM_DEP_OBSOLETE = 1             # all versions allowed by dep are obsolete
-_TRIM_DEP_TRIMMED = 2              # all versions allowed by dep already trimmed
-_TRIM_FIRMWARE = 3                 # firmware version requirement
-_TRIM_FREEZE = 4                   # pkg not allowed by freeze
-_TRIM_INSTALLED_EXCLUDE = 5        # pkg excludes installed pkg
-_TRIM_INSTALLED_INC = 6            # not allowed by installed pkg incorporation
-_TRIM_INSTALLED_NEWER = 7          # newer version installed already
-_TRIM_INSTALLED_ORIGIN = 8         # installed version in image too old
-_TRIM_INSTALLED_ROOT_ORIGIN = 9    # installed version in root image too old
-_TRIM_PARENT_MISSING = 10          # parent image must have this pkg too
-_TRIM_PARENT_NEWER = 11            # parent image has newer version
-_TRIM_PARENT_OLDER = 12            # parent image has older version
-_TRIM_PARENT_PUB = 13              # parent image has different publisher
-_TRIM_PROPOSED_INC = 14            # not allowed by requested pkg incorporation
-_TRIM_PROPOSED_PUB = 15            # didn't match requested publisher
-_TRIM_PROPOSED_VER = 16            # didn't match requested version
-_TRIM_PUB_RANK = 17                # pkg from higher or lower ranked publisher
-_TRIM_PUB_STICKY = 18              # pkg publisher != installed pkg publisher
-_TRIM_REJECT = 19                  # --reject
-_TRIM_UNSUPPORTED = 20             # invalid or unsupported actions
-_TRIM_VARIANT = 21                 # unsupported variant (e.g. i386 on sparc)
-_TRIM_EXPLICIT_INSTALL = 22        # pkg.depend.explicit-install is true.
-_TRIM_SYNCED_INC = 23              # incorporation must be in sync with parent
-_TRIM_MAX = 24                     # number of trim constants
+_TRIM_DEP_MISSING = 0  # no matching pkg version found for dep
+_TRIM_DEP_OBSOLETE = 1  # all versions allowed by dep are obsolete
+_TRIM_DEP_TRIMMED = 2  # all versions allowed by dep already trimmed
+_TRIM_FIRMWARE = 3  # firmware version requirement
+_TRIM_FREEZE = 4  # pkg not allowed by freeze
+_TRIM_INSTALLED_EXCLUDE = 5  # pkg excludes installed pkg
+_TRIM_INSTALLED_INC = 6  # not allowed by installed pkg incorporation
+_TRIM_INSTALLED_NEWER = 7  # newer version installed already
+_TRIM_INSTALLED_ORIGIN = 8  # installed version in image too old
+_TRIM_INSTALLED_ROOT_ORIGIN = 9  # installed version in root image too old
+_TRIM_PARENT_MISSING = 10  # parent image must have this pkg too
+_TRIM_PARENT_NEWER = 11  # parent image has newer version
+_TRIM_PARENT_OLDER = 12  # parent image has older version
+_TRIM_PARENT_PUB = 13  # parent image has different publisher
+_TRIM_PROPOSED_INC = 14  # not allowed by requested pkg incorporation
+_TRIM_PROPOSED_PUB = 15  # didn't match requested publisher
+_TRIM_PROPOSED_VER = 16  # didn't match requested version
+_TRIM_PUB_RANK = 17  # pkg from higher or lower ranked publisher
+_TRIM_PUB_STICKY = 18  # pkg publisher != installed pkg publisher
+_TRIM_REJECT = 19  # --reject
+_TRIM_UNSUPPORTED = 20  # invalid or unsupported actions
+_TRIM_VARIANT = 21  # unsupported variant (e.g. i386 on sparc)
+_TRIM_EXPLICIT_INSTALL = 22  # pkg.depend.explicit-install is true.
+_TRIM_SYNCED_INC = 23  # incorporation must be in sync with parent
+_TRIM_MAX = 24  # number of trim constants
 
 
 class DependencyException(Exception):
-        """local exception used to pass failure to match
-        dependencies in packages out of nested evaluation"""
+    """local exception used to pass failure to match
+    dependencies in packages out of nested evaluation"""
 
-        def __init__(self, reason_id, reason, fmris=EmptyI):
-                Exception.__init__(self)
-                self.__fmris = fmris
-                self.__reason_id = reason_id
-                self.__reason = reason
+    def __init__(self, reason_id, reason, fmris=EmptyI):
+        Exception.__init__(self)
+        self.__fmris = fmris
+        self.__reason_id = reason_id
+        self.__reason = reason
 
-        @property
-        def fmris(self):
-                """The FMRIs related to the exception."""
-                return self.__fmris
+    @property
+    def fmris(self):
+        """The FMRIs related to the exception."""
+        return self.__fmris
 
-        @property
-        def reason_id(self):
-                """A constant indicating why the related FMRIs were rejected."""
-                return self.__reason_id
+    @property
+    def reason_id(self):
+        """A constant indicating why the related FMRIs were rejected."""
+        return self.__reason_id
 
-        @property
-        def reason(self):
-                """A string describing why the related FMRIs were rejected."""
-                return self.__reason
+    @property
+    def reason(self):
+        """A string describing why the related FMRIs were rejected."""
+        return self.__reason
 
 
 class PkgSolver(object):
-        """Provides a SAT-based solution solver to determine which packages
-        should be installed, updated, or removed to perform a requested
-        operation."""
+    """Provides a SAT-based solution solver to determine which packages
+    should be installed, updated, or removed to perform a requested
+    operation."""
 
-        def __init__(self, cat, installed_dict, pub_ranks, variants, avoids,
-            parent_pkgs, progtrack):
-                """Create a PkgSolver instance; catalog should contain all
-                known pkgs, installed fmris should be a dict of fmris indexed
-                by name that define pkgs current installed in the image.
-                Pub_ranks dict contains (rank, stickiness, enabled) for each
-                publisher.  variants are the current image variants; avoids is
-                the set of pkg stems being avoided in the image due to
-                administrator action (e.g. --reject, uninstall)."""
+    def __init__(
+        self,
+        cat,
+        installed_dict,
+        pub_ranks,
+        variants,
+        avoids,
+        parent_pkgs,
+        progtrack,
+    ):
+        """Create a PkgSolver instance; catalog should contain all
+        known pkgs, installed fmris should be a dict of fmris indexed
+        by name that define pkgs current installed in the image.
+        Pub_ranks dict contains (rank, stickiness, enabled) for each
+        publisher.  variants are the current image variants; avoids is
+        the set of pkg stems being avoided in the image due to
+        administrator action (e.g. --reject, uninstall)."""
 
-                # Value 'DebugValues' is unsubscriptable;
-                # pylint: disable=E1136
-                # check if we're allowed to use the solver
-                if DebugValues["no_solver"]:
-                        raise RuntimeError("no_solver set, but solver invoked")
+        # Value 'DebugValues' is unsubscriptable;
+        # pylint: disable=E1136
+        # check if we're allowed to use the solver
+        if DebugValues["no_solver"]:
+            raise RuntimeError("no_solver set, but solver invoked")
 
-                self.__catalog = cat
-                self.__known_incs = set()       # stems with incorporate deps
-                self.__publisher = {}           # indexed by stem
-                self.__possible_dict = defaultdict(list) # indexed by stem
-                self.__pub_ranks = pub_ranks    # rank indexed by pub
-                self.__depend_ts = False        # flag used to indicate whether
-                                                # any dependencies with
-                                                # timestamps were seen; used in
-                                                # error output generation
-                self.__trim_dict = defaultdict(set) # fmris trimmed from
-                                                # consideration
+        self.__catalog = cat
+        self.__known_incs = set()  # stems with incorporate deps
+        self.__publisher = {}  # indexed by stem
+        self.__possible_dict = defaultdict(list)  # indexed by stem
+        self.__pub_ranks = pub_ranks  # rank indexed by pub
+        self.__depend_ts = False  # flag used to indicate whether
+        # any dependencies with
+        # timestamps were seen; used in
+        # error output generation
+        self.__trim_dict = defaultdict(set)  # fmris trimmed from
+        # consideration
 
-                self.__installed_dict = installed_dict.copy() # indexed by stem
-                self.__installed_pkgs = frozenset(self.__installed_dict)
-                self.__installed_fmris = frozenset(
-                    self.__installed_dict.values())
+        self.__installed_dict = installed_dict.copy()  # indexed by stem
+        self.__installed_pkgs = frozenset(self.__installed_dict)
+        self.__installed_fmris = frozenset(self.__installed_dict.values())
 
-                self.__pub_trim = {}            # pkg names already
-                                                # trimmed by pub.
-                self.__removal_fmris = set()    # installed fmris we're
-                                                # going to remove
+        self.__pub_trim = {}  # pkg names already
+        # trimmed by pub.
+        self.__removal_fmris = set()  # installed fmris we're
+        # going to remove
 
-                self.__req_pkg_names = set()    # package names that must be
-                                                # present in solution by spec.
-                for f in self.__installed_fmris: # record only sticky pubs
-                        pub = f.publisher
-                        if self.__pub_ranks[pub][1]:
-                                self.__publisher[f.pkg_name] = pub
+        self.__req_pkg_names = set()  # package names that must be
+        # present in solution by spec.
+        for f in self.__installed_fmris:  # record only sticky pubs
+            pub = f.publisher
+            if self.__pub_ranks[pub][1]:
+                self.__publisher[f.pkg_name] = pub
 
-                self.__id2fmri = {}             # map ids -> fmris
-                self.__fmri2id = {}             # and reverse
+        self.__id2fmri = {}  # map ids -> fmris
+        self.__fmri2id = {}  # and reverse
 
-                self.__solver = pkg.solver.msat_solver()
+        self.__solver = pkg.solver.msat_solver()
 
-                self.__progtrack = progtrack    # progress tracker
-                self.__progitem = None          # progress tracker plan item
+        self.__progtrack = progtrack  # progress tracker
+        self.__progitem = None  # progress tracker plan item
 
-                self.__addclause_failure = False
+        self.__addclause_failure = False
 
-                self.__variant_dict = {}        # fmris -> variant cache
-                self.__variants = variants      # variants supported by image
+        self.__variant_dict = {}  # fmris -> variant cache
+        self.__variants = variants  # variants supported by image
 
-                self.__cache = {}
-                self.__actcache = {}
-                self.__trimdone = False         # indicate we're finished
-                                                # trimming
-                self.__fmri_state = {}          # cache of obsolete, renamed
-                                                # bits so we can print something
-                                                # reasonable
-                self.__state = SOLVER_INIT
-                self.__iterations = 0
-                self.__clauses     = 0
-                self.__variables   = 0
-                self.__subphasename = None
-                self.__timings = []
-                self.__start_time = 0
-                self.__inc_list = []
-                self.__dependents = None
-                # set of fmris installed in root image; used for origin
-                # dependencies
-                self.__root_fmris = None
-                # set of stems avoided by admin (e.g. --reject, uninstall)
-                self.__avoid_set = avoids.copy()
-                # set of stems avoided by solver due to dependency constraints
-                # (e.g. all fmris that satisfy group dependency trimmed); this
-                # intentionally starts empty for every new solver invocation and
-                # is only stored in image configuration for diagnostic purposes.
-                self.__implicit_avoid_set = set()
-                # set of obsolete stems
-                self.__obs_set = None
-                # set of stems we're rejecting
-                self.__reject_set = set()
-                # pkgs that have parent deps
-                self.__linked_pkgs = set()
+        self.__cache = {}
+        self.__actcache = {}
+        self.__trimdone = False  # indicate we're finished
+        # trimming
+        self.__fmri_state = {}  # cache of obsolete, renamed
+        # bits so we can print something
+        # reasonable
+        self.__state = SOLVER_INIT
+        self.__iterations = 0
+        self.__clauses = 0
+        self.__variables = 0
+        self.__subphasename = None
+        self.__timings = []
+        self.__start_time = 0
+        self.__inc_list = []
+        self.__dependents = None
+        # set of fmris installed in root image; used for origin
+        # dependencies
+        self.__root_fmris = None
+        # set of stems avoided by admin (e.g. --reject, uninstall)
+        self.__avoid_set = avoids.copy()
+        # set of stems avoided by solver due to dependency constraints
+        # (e.g. all fmris that satisfy group dependency trimmed); this
+        # intentionally starts empty for every new solver invocation and
+        # is only stored in image configuration for diagnostic purposes.
+        self.__implicit_avoid_set = set()
+        # set of obsolete stems
+        self.__obs_set = None
+        # set of stems we're rejecting
+        self.__reject_set = set()
+        # pkgs that have parent deps
+        self.__linked_pkgs = set()
 
-                # Internal cache of created fmri objects.  Used so that the same
-                # PkgFmri doesn't need to be created more than once.  This isn't
-                # a weakref dictionary because in two of the four places where
-                # PkgFmri's are created, the name is extracted and the PkgFmri
-                # object is immediately discarded.
-                self.__fmridict = {}
+        # Internal cache of created fmri objects.  Used so that the same
+        # PkgFmri doesn't need to be created more than once.  This isn't
+        # a weakref dictionary because in two of the four places where
+        # PkgFmri's are created, the name is extracted and the PkgFmri
+        # object is immediately discarded.
+        self.__fmridict = {}
 
-                # Packages with explicit install action set to true.
-                self.__expl_install_dict = {}
+        # Packages with explicit install action set to true.
+        self.__expl_install_dict = {}
 
-                assert isinstance(parent_pkgs, (type(None), frozenset))
-                self.__parent_pkgs = parent_pkgs
-                self.__parent_dict = dict()
-                if self.__parent_pkgs != None:
-                        self.__parent_dict = dict([
-                            (f.pkg_name, f)
-                            for f in self.__parent_pkgs
-                        ])
+        assert isinstance(parent_pkgs, (type(None), frozenset))
+        self.__parent_pkgs = parent_pkgs
+        self.__parent_dict = dict()
+        if self.__parent_pkgs != None:
+            self.__parent_dict = dict(
+                [(f.pkg_name, f) for f in self.__parent_pkgs]
+            )
 
-                # cache of firmware dependencies
-                self.__firmware = Firmware()
+        # cache of firmware dependencies
+        self.__firmware = Firmware()
 
-                self.__triggered_ops = {
-                    PKG_OP_UNINSTALL : {
-                        PKG_OP_UPDATE    : set(),
-                        PKG_OP_UNINSTALL : set(),
-                    },
-                }
+        self.__triggered_ops = {
+            PKG_OP_UNINSTALL: {
+                PKG_OP_UPDATE: set(),
+                PKG_OP_UNINSTALL: set(),
+            },
+        }
 
-                self.__allowed_downgrades = set()  # allowed downrev FMRIs
-                self.__dg_incorp_cache = {}        # cache for downgradable
-                                                   # incorp deps
+        self.__allowed_downgrades = set()  # allowed downrev FMRIs
+        self.__dg_incorp_cache = {}  # cache for downgradable
+        # incorp deps
 
-        def __str__(self):
-                s = "Solver: ["
-                if self.__state in [SOLVER_FAIL, SOLVER_SUCCESS]:
-                        s += (" Variables: {0:d} Clauses: {1:d} Iterations: "
-                            "{2:d}").format(self.__variables, self.__clauses,
-                                self.__iterations)
-                s += " State: {0}]".format(self.__state)
+    def __str__(self):
+        s = "Solver: ["
+        if self.__state in [SOLVER_FAIL, SOLVER_SUCCESS]:
+            s += (
+                " Variables: {0:d} Clauses: {1:d} Iterations: " "{2:d}"
+            ).format(self.__variables, self.__clauses, self.__iterations)
+        s += " State: {0}]".format(self.__state)
 
-                s += "\nTimings: ["
-                s += ", ".join([
-                    "{0}: {1: 6.3f}".format(*a)
-                    for a in self.__timings
-                ])
-                s += "]"
+        s += "\nTimings: ["
+        s += ", ".join(["{0}: {1: 6.3f}".format(*a) for a in self.__timings])
+        s += "]"
 
-                if self.__inc_list:
-                        incs = "\n\t".join([str(a) for a in self.__inc_list])
-                else:
-                        incs = "None"
+        if self.__inc_list:
+            incs = "\n\t".join([str(a) for a in self.__inc_list])
+        else:
+            incs = "None"
 
-                s += "\nMaintained incorporations: {0}\n".format(incs)
+        s += "\nMaintained incorporations: {0}\n".format(incs)
 
-                return s
+        return s
 
-        def __cleanup(self, rval):
-                """Discards all solver information except for that needed to
-                show failure information or to stringify the solver object.
-                This allows early garbage collection to take place, and should
-                be performed after a solution is successfully returned."""
+    def __cleanup(self, rval):
+        """Discards all solver information except for that needed to
+        show failure information or to stringify the solver object.
+        This allows early garbage collection to take place, and should
+        be performed after a solution is successfully returned."""
 
-                self.__catalog = None
-                self.__installed_dict = {}
-                self.__installed_pkgs = frozenset()
-                self.__installed_fmris = frozenset()
-                self.__publisher = {}
-                self.__possible_dict = {}
-                self.__pub_ranks = None
-                self.__pub_trim = {}
-                self.__removal_fmris = set()
-                self.__id2fmri = None
-                self.__fmri2id = None
-                self.__solver = None
-                self.__progtrack = None
-                self.__addclause_failure = False
-                self.__variant_dict = None
-                self.__variants = None
-                self.__cache = None
-                self.__actcache = None
-                self.__trimdone = None
-                self.__fmri_state = None
-                self.__start_time = None
-                self.__dependents = None
-                self.__fmridict = {}
-                self.__firmware = None
-                self.__allowed_downgrades = None
-                self.__dg_incorp_cache = None
-                self.__linked_pkgs = set()
+        self.__catalog = None
+        self.__installed_dict = {}
+        self.__installed_pkgs = frozenset()
+        self.__installed_fmris = frozenset()
+        self.__publisher = {}
+        self.__possible_dict = {}
+        self.__pub_ranks = None
+        self.__pub_trim = {}
+        self.__removal_fmris = set()
+        self.__id2fmri = None
+        self.__fmri2id = None
+        self.__solver = None
+        self.__progtrack = None
+        self.__addclause_failure = False
+        self.__variant_dict = None
+        self.__variants = None
+        self.__cache = None
+        self.__actcache = None
+        self.__trimdone = None
+        self.__fmri_state = None
+        self.__start_time = None
+        self.__dependents = None
+        self.__fmridict = {}
+        self.__firmware = None
+        self.__allowed_downgrades = None
+        self.__dg_incorp_cache = None
+        self.__linked_pkgs = set()
 
-                # Value 'DebugValues' is unsubscriptable;
-                # pylint: disable=E1136
-                if DebugValues["plan"]:
-                        # Remaining data must be kept.
-                        return rval
+        # Value 'DebugValues' is unsubscriptable;
+        # pylint: disable=E1136
+        if DebugValues["plan"]:
+            # Remaining data must be kept.
+            return rval
 
-                self.__trim_dict = None
-                return rval
+        self.__trim_dict = None
+        return rval
 
-        def __progress(self):
-                """Bump progress tracker to indicate processing is active."""
-                assert self.__progitem
-                self.__progtrack.plan_add_progress(self.__progitem)
+    def __progress(self):
+        """Bump progress tracker to indicate processing is active."""
+        assert self.__progitem
+        self.__progtrack.plan_add_progress(self.__progitem)
 
-        def __start_subphase(self, subphase=None, reset=False):
-                """Add timing records and tickle progress tracker.  Ends
-                previous subphase if ongoing."""
-                if reset:
-                        self.__timings = []
-                if self.__subphasename is not None:
-                        self.__end_subphase()
-                self.__start_time = time.time()
-                self.__subphasename = "phase {0:d}".format(subphase)
-                self.__progress()
+    def __start_subphase(self, subphase=None, reset=False):
+        """Add timing records and tickle progress tracker.  Ends
+        previous subphase if ongoing."""
+        if reset:
+            self.__timings = []
+        if self.__subphasename is not None:
+            self.__end_subphase()
+        self.__start_time = time.time()
+        self.__subphasename = "phase {0:d}".format(subphase)
+        self.__progress()
 
-        def __end_subphase(self):
-                """Mark the end of a solver subphase, recording time taken."""
-                now = time.time()
-                self.__timings.append((self.__subphasename,
-                    now - self.__start_time))
-                self.__start_time = None
-                self.__subphasename = None
+    def __end_subphase(self):
+        """Mark the end of a solver subphase, recording time taken."""
+        now = time.time()
+        self.__timings.append((self.__subphasename, now - self.__start_time))
+        self.__start_time = None
+        self.__subphasename = None
 
-        def __trim_frozen(self, existing_freezes):
-                """Trim any packages we cannot update due to freezes."""
-                for f, r, _t in existing_freezes:
-                        if r:
-                                reason = (N_("This version is excluded by a "
-                                    "freeze on {0} at version {1}.  The "
-                                    "reason for the freeze is: {2}"),
-                                    (f.pkg_name, f.version.get_version(
-                                        include_build=False), r))
-                        else:
-                                reason = (N_("This version is excluded by a "
-                                    "freeze on {0} at version {1}."),
-                                    (f.pkg_name, f.version.get_version(
-                                        include_build=False)))
-                        self.__trim(self.__comb_auto_fmris(f, dotrim=False)[1],
-                            _TRIM_FREEZE, reason)
-
-        def __raise_solution_error(self, no_version=EmptyI, no_solution=EmptyI):
-                """Raise a plan exception due to solution errors."""
-
-                solver_errors = None
-                # Value 'DebugValues' is unsubscriptable;
-                # pylint: disable=E1136
-                if DebugValues["plan"]:
-                        solver_errors = self.get_trim_errors()
-                raise api_errors.PlanCreationException(no_solution=no_solution,
-                    no_version=no_version, solver_errors=solver_errors)
-
-        def __trim_proposed(self, proposed_dict):
-                """Remove any versions from proposed_dict that are in trim_dict
-                and raise an exception if no matching version of a proposed
-                package can be installed at this point."""
-
-                if proposed_dict is None:
-                        # Nothing to do.
-                        return
-
-                # Used to de-dup errors.
-                already_seen = set()
-
-                ret = []
-                for name in proposed_dict:
-                        tv = self.__dotrim(proposed_dict[name])
-                        if tv:
-                                proposed_dict[name] = tv
-                                continue
-
-                        ret.extend([_("No matching version of {0} can be "
-                            "installed:").format(name)])
-                        ret.extend(self.__fmri_list_errors(proposed_dict[name],
-                            already_seen=already_seen))
-                        # continue processing and accumulate all errors
-                if ret:
-                        self.__raise_solution_error(no_version=ret)
-
-        def __set_removed_and_required_packages(self, rejected, proposed=None):
-                """Sets the list of package to be removed from the image, the
-                list of packages to reject, the list of packages to avoid
-                during the operation, and the list of packages that must not be
-                removed from the image.
-
-                'rejected' is a set of package stems to reject.
-
-                'proposed' is an optional set of FMRI objects representing
-                packages to install or update.
-
-                Upon return:
-                  * self.__removal_fmris will contain the list of FMRIs to be
-                    removed from the image due to user request or due to past
-                    bugs that caused wrong variant to be installed by mistake.
-
-                  * self.__reject_set will contain the list of packages to avoid
-                    or that were rejected by user request as appropriate."""
-
-                if proposed is None:
-                        proposed = set()
-                else:
-                        # remove packages to be installed from avoid sets
-                        self.__avoid_set -= proposed
-                        self.__implicit_avoid_set -= proposed
-
-                self.__removal_fmris |= set([
-                    self.__installed_dict[name]
-                    for name in rejected
-                    if name in self.__installed_dict
-                ] + [
-                    f
-                    for f in self.__installed_fmris
-                    if not self.__trim_nonmatching_variants(f)
-                ])
-
-                self.__reject_set = rejected
-
-                # trim fmris that user explicitly disallowed
-                for name in rejected:
-                        self.__trim(self.__get_catalog_fmris(name),
-                            _TRIM_REJECT,
-                            N_("This version rejected by user request"))
-
-                self.__req_pkg_names = (self.__installed_pkgs |
-                    proposed) - rejected
-                self.__req_pkg_names -= set(
-                    f.pkg_name
-                    for f in self.__removal_fmris
+    def __trim_frozen(self, existing_freezes):
+        """Trim any packages we cannot update due to freezes."""
+        for f, r, _t in existing_freezes:
+            if r:
+                reason = (
+                    N_(
+                        "This version is excluded by a "
+                        "freeze on {0} at version {1}.  The "
+                        "reason for the freeze is: {2}"
+                    ),
+                    (f.pkg_name, f.version.get_version(include_build=False), r),
                 )
-
-        def __set_proposed_required(self, proposed_dict, excludes):
-                """Add the common set of conditional, group, and require
-                dependencies of proposed packages to the list of package stems
-                known to be a required part of the solution.  This will improve
-                error messaging if no solution is found."""
-
-                if proposed_dict is None:
-                        return
-
-                req_dep_names = set()
-                for name in proposed_dict:
-                        # Find intersection of the set of conditional, group,
-                        # and require dependencies for all proposed versions of
-                        # the proposed package.  The result is the set of
-                        # package stems we know will be required to be part of
-                        # the solution.
-                        comm_deps = None
-                        propvers = set(self.__dotrim(proposed_dict[name]))
-                        for f in propvers:
-                                prop_deps = set(
-                                    dname for (dtype, dname) in (
-                                        (da.attrs["type"],
-                                            pkg.fmri.extract_pkg_name(
-                                                da.attrs["fmri"]))
-                                        for da in self.__get_dependency_actions(
-                                            f, excludes)
-                                        if da.attrs["type"] == "conditional" or
-                                            da.attrs["type"] == "group" or
-                                            da.attrs["type"] == "require"
-                                    )
-                                    if dtype != "group" or
-                                        (dname not in self.__avoid_set and
-                                         dname not in self.__reject_set)
-                                )
-
-                                if comm_deps is None:
-                                        comm_deps = prop_deps
-                                else:
-                                        comm_deps &= prop_deps
-
-                        if comm_deps:
-                                req_dep_names |= comm_deps
-
-                self.__req_pkg_names = frozenset(req_dep_names |
-                    self.__req_pkg_names)
-
-        def __update_possible_closure(self, possible, excludes,
-            full_trim=False, filter_explicit=True, proposed_dict=None):
-                """Update the provided possible set of fmris with the transitive
-                closure of dependencies that can be satisfied, trimming those
-                packages that cannot be installed.
-
-                'possible' is a set of FMRI objects representing all possible
-                versions of packages to consider for the operation.
-
-                'full_trim' is an optional boolean indicating whether a full
-                trim of the dependency graph should be performed.  This is NOT
-                required for the solver to find a solution.  Trimming is only
-                needed to reduce the size of clauses and to provide error
-                messages.  This requires multiple passes to determine if the
-                transitive closure of dependencies can be satisfied.  This is
-                not required for correctness (and it greatly increases runtime).
-                However, it does greatly improve error messaging for some error
-                cases.
-
-                'filter_explicit' is an optional boolean indicating whether
-                packages with pkg.depend.explicit-install set to true will be
-                filtered out.
-
-                'proposed_dict' contains user specified FMRI objects indexed by
-                pkg_name that should be installed or updated within an image.
-
-                An example of a case where full_trim will be useful (dueling
-                incorporations):
-
-                Installed:
-                  entire
-                    incorporates java-7-incorporation
-                Proposed:
-                  osnet-incorporation
-                    incorporates system/resource-mgmt/dynamic-resource-pools
-                  system/resource-mgmt/dynamic-resource-pools
-                    requires new version of java not allowed by installed
-                      java-7-incorporation"""
-
-                first = True
-                while True:
-                        tsize = len(self.__trim_dict)
-                        res = self.__generate_dependency_closure(
-                            possible, excludes=excludes, full_trim=full_trim,
-                            filter_explicit=filter_explicit,
-                            proposed_dict=proposed_dict)
-                        if first:
-                                # The first pass will return the transitive
-                                # closure of all dependencies; subsequent passes
-                                # are only done for trimming, so need to update
-                                # the possible set only on first pass.
-                                possible.update(res)
-                                first = False
-
-                        nsize = len(self.__trim_dict)
-                        if not full_trim or nsize == tsize:
-                                # Nothing more to trim.
-                                break
-
-                # Remove trimmed items from possible_set.
-                possible.difference_update(six.iterkeys(self.__trim_dict))
-
-        def __enforce_unique_packages(self, excludes):
-                """Constrain the solver solution so that only one version of
-                each package can be installed and generate dependency clauses
-                for possible packages."""
-
-                # Generate clauses for only one version of each package, and
-                # for dependencies for each package.  Do so for all possible
-                # fmris.
-                for name in self.__possible_dict:
-                        self.__progress()
-                        # Ensure only one version of a package is installed
-                        self.__addclauses(self.__gen_highlander_clauses(
-                            self.__possible_dict[name]))
-                        # generate dependency clauses for each pkg
-                        for fmri in self.__possible_dict[name]:
-                                for da in self.__get_dependency_actions(fmri,
-                                    excludes=excludes):
-                                        self.__addclauses(
-                                            self.__gen_dependency_clauses(fmri,
-                                            da))
-
-        def __generate_operation_clauses(self, proposed=None,
-            proposed_dict=None):
-                """Generate initial solver clauses for the proposed packages (if
-                any) and installed packages.
-
-                'proposed' is a set of FMRI objects representing packages to
-                install or update.
-
-                'proposed_dict' contains user specified FMRI objects indexed by
-                pkg_name that should be installed or updated within an image."""
-
-                assert ((proposed is None and proposed_dict is None) or
-                    (proposed is not None and proposed_dict is not None))
-
-                if proposed is None:
-                        proposed = set()
-                if proposed_dict is None:
-                        proposed_dict = EmptyDict
-
-                # Generate clauses for proposed and installed pkgs note that we
-                # create clauses that require one of the proposed pkgs to work;
-                # this allows the possible_set to always contain the existing
-                # pkgs.
-                for name in proposed_dict:
-                        self.__progress()
-                        self.__addclauses(
-                            self.__gen_one_of_these_clauses(
-                                set(proposed_dict[name]) &
-                                set(self.__possible_dict[name])))
-
-                for name in (self.__installed_pkgs - proposed -
-                    self.__reject_set - self.__avoid_set):
-                        self.__progress()
-
-                        if (self.__installed_dict[name] in
-                            self.__removal_fmris):
-                                # we're uninstalling this package
-                                continue
-
-                        if name in self.__possible_dict:
-                                self.__addclauses(
-                                    self.__gen_one_of_these_clauses(
-                                        self.__possible_dict[name]))
-
-        def __begin_solve(self):
-                """Prepares solver for solution creation returning a
-                ProgressTracker object to be used for the operation."""
-
-                # Once solution has been returned or failure has occurred, a new
-                # solver must be used.
-                assert self.__state == SOLVER_INIT
-                self.__state = SOLVER_OXY
-
-                pt = self.__progtrack
-                # Check to see if we were invoked by solve_uninstall, in
-                # which case we don't want to restart what we've already
-                # started.
-                if self.__progitem is None:
-                        self.__progitem = pt.PLAN_SOLVE_SETUP
-                        pt.plan_start(pt.PLAN_SOLVE_SETUP)
-                self.__start_subphase(1, reset=True)
-
-                return pt
-
-        def __end_solve(self, solution, excludes):
-                """Returns the solution result to the caller after completing
-                all necessary solution cleanup."""
-
-                pt = self.__progtrack
-                self.__end_subphase()  # end the last subphase.
-                pt.plan_done(pt.PLAN_SOLVE_SOLVER)
-                return self.__cleanup((self.__elide_possible_renames(solution,
-                    excludes), (self.__avoid_set, self.__implicit_avoid_set,
-                        self.__obs_set)))
-
-        def __assert_installed_allowed(self, excludes, proposed=None):
-                """Raises a PlanCreationException if the proposed operation
-                would require the removal of installed packages that are not
-                marked for removal by the proposed operation."""
-
-                if proposed is None:
-                        proposed = set()
-
-                uninstall_fmris = []
-                for name in (self.__installed_pkgs - proposed -
-                    self.__reject_set - self.__avoid_set):
-                        self.__progress()
-
-                        if (self.__installed_dict[name] in
-                            self.__removal_fmris):
-                                # we're uninstalling this package
-                                continue
-
-                        if name in self.__possible_dict:
-                                continue
-
-                        # no version of this package is allowed
-                        uninstall_fmris.append(self.__installed_dict[name])
-
-                # Used to de-dup errors.
-                already_seen = set()
-                ret = []
-                msg = N_("Package '{0}' must be uninstalled or upgraded "
-                    "if the requested operation is to be performed.")
-
-                # First check for solver failures caused by missing parent
-                # dependencies.  We do this because missing parent dependency
-                # failures cause other cascading failures, so it's better to
-                # just emit these failures first, have the user fix them, and
-                # have them re-run the operation, so then we can provide more
-                # concise error output about other problems.
-                for fmri in uninstall_fmris:
-                        # Unused variable; pylint: disable=W0612
-                        for reason_id, reason_t, fmris in \
-                            self.__trim_dict.get(fmri, EmptyI):
-                                if reason_id == _TRIM_PARENT_MISSING:
-                                        break
-                        else:
-                                continue
-                        res = self.__fmri_list_errors([fmri],
-                            already_seen=already_seen)
-                        assert res
-                        ret.extend([msg.format(fmri.pkg_name)])
-                        ret.extend(res)
-
-                if ret:
-                        self.__raise_solution_error(no_version=ret)
-
-                for fmri in uninstall_fmris:
-                        flist = [fmri]
-                        if fmri in self.__linked_pkgs:
-                                depend_self = any(
-                                    da
-                                    for da in self.__get_dependency_actions(
-                                        fmri, excludes)
-                                    if da.attrs["type"] == "parent" and
-                                    pkg.actions.depend.DEPEND_SELF in
-                                        da.attrlist("fmri")
-                                )
-
-                                if depend_self:
-                                        pf = self.__parent_dict.get(
-                                            fmri.pkg_name)
-                                        if pf and pf != fmri:
-                                                # include parent's version of
-                                                # parent-constrained packages in
-                                                # error messaging for clarity if
-                                                # different
-                                                flist.append(pf)
-
-                        res = self.__fmri_list_errors(flist,
-                            already_seen=already_seen)
-
-                        # If no errors returned, that implies that all of the
-                        # reasons the FMRI was rejected aren't interesting.
-                        if res:
-                                ret.extend([msg.format(fmri.pkg_name)])
-                                ret.extend(res)
-
-                if ret:
-                        self.__raise_solution_error(no_version=ret)
-
-        def __assert_trim_errors(self, possible_set, excludes, proposed=None,
-            proposed_dict=None):
-                """Raises a PlanCreationException if any further trims would
-                prevent the installation or update of proposed or
-                installed/required packages.
-
-                'proposed' is an optional set of FMRI objects representing
-                packages to install or update.
-
-                'proposed_dict' contains user specified FMRIs indexed by
-                pkg_name that should be installed within an image.
-
-                'possible_set' is the set of FMRIs potentially allowed for use
-                in the proposed operation."""
-
-                # make sure all package trims appear
-                self.__trimdone = False
-
-                # Ensure required dependencies of proposed packages are flagged
-                # to improve error messaging when parsing the transitive
-                # closure of all dependencies.
-                self.__set_proposed_required(proposed_dict, excludes)
-
-                # First, perform a full trim of the package version space; this
-                # is normally skipped for performance reasons as it's not
-                # required for correctness.
-                self.__update_possible_closure(possible_set, excludes,
-                    full_trim=True, filter_explicit=False,
-                    proposed_dict=proposed_dict)
-
-                # Now try re-asserting that proposed (if any) and installed
-                # packages are allowed after the trimming; these calls will
-                # raise an exception if all the proposed or any of the
-                # installed/required packages are trimmed.
-                self.__set_proposed_required(proposed_dict, excludes)
-                self.__trim_proposed(proposed_dict)
-                self.__assign_possible(possible_set)
-                self.__assert_installed_allowed(excludes, proposed=proposed)
-
-        def __raise_install_error(self, exp, inc_list, proposed_dict,
-            possible_set, excludes):
-                """Private logic for solve_install() to process a
-                PlanCreationException and re-raise as appropriate.
-
-                'exp' is the related exception object raised by the solver when
-                no solution was found.
-
-                'inc_list' is a list of package FMRIs representing installed
-                incorporations that are being maintained.
-
-                'proposed_dict' contains user specified FMRIs indexed by
-                pkg_name that should be installed within an image.
-
-                'possible_set' is the set of FMRIs potentially allowed for use
-                in the proposed operation.
-                """
-
-                # Before making a guess, apply extra trimming to see if we can
-                # reject the operation based on changing packages.
-                self.__assert_trim_errors(possible_set, excludes,
-                    proposed_dict=proposed_dict)
-
-                # Despite all of the trimming done, we still don't know why the
-                # solver couldn't find a solution, so make a best effort guess
-                # at the reason why.
-                info = []
-                incs = []
-
-                incs.append("")
-                if inc_list:
-                        incs.append("maintained incorporations:")
-                        skey = operator.attrgetter('pkg_name')
-                        for il in sorted(inc_list, key=skey):
-                                incs.append("  {0}".format(il.get_short_fmri()))
-                else:
-                        incs.append("maintained incorporations: None")
-                incs.append("")
-
-                ms = self.__generate_dependency_errors([
-                    b for a in proposed_dict.values()
-                    for b in a
-                ], excludes=excludes)
-                if ms:
-                        info.append("")
-                        info.append(_("Plan Creation: dependency error(s) in "
-                            "proposed packages:"))
-                        info.append("")
-                        for s in ms:
-                                info.append("  {0}".format(s))
-
-                ms = self.__check_installed()
-                if ms:
-                        info.append("")
-                        info.append(_("Plan Creation: Errors in installed "
-                            "packages due to proposed changes:"))
-                        info.append("")
-                        for s in ms:
-                                info.append("  {0}".format(s))
-
-                if not info: # both error detection methods insufficent.
-                        info.append(_("Plan Creation: Package solver is "
-                            "unable to compute solution."))
-                        info.append(_("Dependency analysis is unable to "
-                            "determine exact cause."))
-                        info.append(_("Try running with -vv to "
-                            "obtain more detailed error messages."))
-                exp.no_solution = incs + info
-
-                # Value 'DebugValues' is unsubscriptable;
-                # pylint: disable=E1136
-                if DebugValues["plan"]:
-                        exp.solver_errors = self.get_trim_errors()
-                raise exp
-
-        def add_triggered_op(self, trigger_op, exec_op, fmris):
-                """Add the set of FMRIs in 'fmris' to the internal dict of
-                pkg-actuators. 'trigger_op' is the operation which triggered
-                the pkg change, 'exec_op' is the operation which is supposed to
-                be executed."""
-
-                assert trigger_op in self.__triggered_ops, "{0} is " \
-                    "not a valid trigger op for pkg actuators".format(
-                    trigger_op)
-                assert exec_op in self.__triggered_ops[trigger_op], "{0} is " \
-                    "not a valid execution op for pkg actuators".format(exec_op)
-                assert isinstance(fmris, set)
-
-                self.__triggered_ops[trigger_op][exec_op] |= fmris
-
-        def solve_install(self, existing_freezes, proposed_dict,
-            new_variants=None, excludes=EmptyI,
-            reject_set=frozenset(), trim_proposed_installed=True,
-            relax_all=False, ignore_inst_parent_deps=False,
-            exact_install=False, installed_dict_tmp=EmptyDict):
-                """Logic to install packages, change variants, and/or change
-                facets.
-
-                Returns FMRIs to be installed / upgraded in system and a new
-                set of packages to be avoided.
-
-                'existing_freezes' is a list of incorp. style FMRIs that
-                constrain package motion.
-
-                'proposed_dict' contains user specified FMRIs indexed by
-                pkg_name that should be installed within an image.
-
-                'new_variants' a dictionary containing variants which are
-                being updated.  (It should not contain existing variants which
-                are not changing.)
-
-                'reject_set' contains user specified package names that should
-                not be present within the final image.  (These packages may or
-                may not be currently installed.)
-
-                'trim_proposed_installed' is a boolean indicating whether the
-                solver should elide versions of proposed packages older than
-                those installed from the set of possible solutions.  If False,
-                package downgrades are allowed, but only for installed
-                packages matching those in the proposed_dict.
-
-                'relax_all' indicates if the solver should relax all install
-                holds, or only install holds specified by proposed packages.
-
-                'ignore_inst_parent_deps' indicates if the solver should
-                ignore parent dependencies for installed packages.  This
-                allows us to modify images with unsatisfied parent
-                dependencies (i.e., out-of-sync images).  Any packaging
-                operation which needs to guarantee that we have an in-sync
-                image (for example, sync-linked operations, or any recursive
-                packaging operations) should NOT enable this behavior.
-
-                'exact_install' is a flag to indicate whether we treat the
-                current image as an empty one. Any previously installed
-                packages that are not either specified in proposed_dict or
-                are a dependency (require, origin and parent dependencies)
-                of those packages will be removed.
-
-                'installed_dict_tmp' a dictionary containing the current
-                installed FMRIs indexed by pkg_name. Used when exact_install
-                is on."""
-
-                pt = self.__begin_solve()
-
-                # reject_set is a frozenset(), need to make copy to modify
-                r_set = set(reject_set)
-                for f in self.__triggered_ops[PKG_OP_UNINSTALL][PKG_OP_UPDATE]:
-                        if f.pkg_name in proposed_dict:
-                                proposed_dict[f.pkg_name].append(f)
-                        else:
-                                proposed_dict[f.pkg_name] = [f]
-                for f in \
-                    self.__triggered_ops[PKG_OP_UNINSTALL][PKG_OP_UNINSTALL]:
-                        r_set.add(f.pkg_name)
-                # re-freeze reject set
-                reject_set = frozenset(r_set)
-
-                proposed_pkgs = set(proposed_dict)
-
-                if new_variants:
-                        self.__variants = new_variants
-
-                        #
-                        # Entire packages can be tagged with variants thereby
-                        # making those packages uninstallable in certain
-                        # images.  So if we're changing variants such that
-                        # some currently installed packages are becoming
-                        # uninstallable add them to the removal package set.
-                        #
-                        for f in self.__installed_fmris:
-                                d = self.__get_variant_dict(f)
-                                for k in new_variants:
-                                        if k in d and \
-                                            new_variants[k] not in d[k]:
-                                                self.__removal_fmris |= set([f])
-
-                # proposed_dict already contains publisher selection logic,
-                # so prevent any further trimming of named packages based
-                # on publisher if they are installed.
-                for name in proposed_dict:
-                        if name in self.__installed_dict:
-                                self.__mark_pub_trimmed(name)
-                        else:
-                                self.__publisher[name] = \
-                                    proposed_dict[name][0].publisher
-
-                # Determine which packages are to be removed, rejected, and
-                # avoided and also determine which ones must not be removed
-                # during the operation.
-                self.__set_removed_and_required_packages(rejected=reject_set,
-                    proposed=proposed_pkgs)
-                self.__progress()
-
-                # find list of incorps we don't let change as a side effect of
-                # other changes; exclude any specified on command line if the
-                # proposed version is already installed and is not being removed
-                # translate proposed_dict into a set
-                if relax_all:
-                        relax_pkgs = self.__installed_pkgs
-                else:
-                        relax_pkgs = set(
-                            name
-                            for name in proposed_pkgs
-                            if not any(
-                                f for f in proposed_dict[name]
-                                if len(proposed_dict[name]) == 1 and
-                                    f in (self.__installed_fmris -
-                                        self.__removal_fmris)
-                            )
-                        )
-                        relax_pkgs |= \
-                            self.__installed_unsatisfied_parent_deps(excludes,
-                                ignore_inst_parent_deps)
-
-                inc_list, con_lists = self.__get_installed_unbound_inc_list(
-                    relax_pkgs, excludes=excludes)
-                self.__inc_list = inc_list
-
-                self.__start_subphase(2)
-                # generate set of possible fmris
-                #
-                # ensure existing pkgs stay installed; explicitly add in
-                # installed fmris in case publisher change has occurred and
-                # some pkgs aren't part of new publisher
-                possible_set = set()
-                self.__allowed_downgrades = set()
-                for f in self.__installed_fmris - self.__removal_fmris:
-                        possible_set |= self.__comb_newer_fmris(f)[0] | set([f])
-
-                # Add the proposed fmris, populate self.__expl_install_dict and
-                # check for allowed downgrades.
-                self.__expl_install_dict = defaultdict(list)
-                for name, flist in proposed_dict.items():
-                        possible_set.update(flist)
-                        for f in flist:
-                                self.__progress()
-                                self.__allowed_downgrades |= \
-                                    self.__allow_incorp_downgrades(f,
-                                    excludes=excludes)
-                                if self.__is_explicit_install(f):
-                                        self.__expl_install_dict[name].append(f)
-
-                # For linked image sync we have to analyze all pkgs of the
-                # possible_set because no proposed pkgs will be given. However,
-                # that takes more time so only do this for syncs. The relax_all
-                # flag is an indicator of a sync operation.
-                if not proposed_dict.values() and relax_all:
-                        for f in possible_set:
-                                self.__progress()
-                                self.__allowed_downgrades |= \
-                                    self.__allow_incorp_downgrades(f,
-                                    excludes=excludes, relax_all=True)
-
-                possible_set |= self.__allowed_downgrades
-
-                self.__start_subphase(3)
-                # If requested, trim any proposed fmris older than those of
-                # corresponding installed packages.
-                candidate_fmris = self.__installed_fmris - \
-                    self.__removal_fmris
-
-                for f in candidate_fmris:
-                        self.__progress()
-                        if not trim_proposed_installed and \
-                            f.pkg_name in proposed_dict:
-                                # Don't trim versions if newest version in
-                                # proposed dict is older than installed
-                                # version.
-                                verlist = proposed_dict[f.pkg_name]
-                                if verlist[-1].version < f.version:
-                                        # Assume downgrade is intentional.
-                                        continue
-                        valid_trigger = False
-                        for tf in self.__triggered_ops[
-                            PKG_OP_UNINSTALL][PKG_OP_UPDATE]:
-                                if tf.pkg_name == f.pkg_name:
-                                        self.__trim_older(tf)
-                                        valid_trigger = True
-                        if valid_trigger:
-                                continue
-
-                        self.__trim_older(f)
-
-                # trim fmris we excluded via proposed_fmris
-                for name in proposed_dict:
-                        self.__progress()
-                        self.__trim(set(self.__get_catalog_fmris(name)) -
-                            set(proposed_dict[name]),
-                            _TRIM_PROPOSED_VER,
-                            N_("This version excluded by specified "
-                                "installation version"))
-                        # trim packages excluded by incorps in proposed.
-                        self.__trim_recursive_incorps(proposed_dict[name],
-                            excludes, _TRIM_PROPOSED_INC)
-
-                # Trim packages with unsatisfied parent dependencies.  For any
-                # remaining allowable linked packages check if they are in
-                # relax_pkgs.  (Which means that either a version of them was
-                # requested explicitly on the command line or a version of them
-                # is installed which has unsatisfied parent dependencies and
-                # needs to be upgraded.)  In that case add the allowable
-                # packages to possible_linked so we can call
-                # __trim_recursive_incorps() on them to trim out more packages
-                # that may be disallowed due to synced incorporations.
-                if self.__is_child():
-                        possible_linked = defaultdict(set)
-                        for f in possible_set.copy():
-                                self.__progress()
-                                if not self.__trim_nonmatching_parents(f,
-                                    excludes, ignore_inst_parent_deps):
-                                        possible_set.remove(f)
-                                        continue
-                                if (f in self.__linked_pkgs and
-                                    f.pkg_name in relax_pkgs):
-                                        possible_linked[f.pkg_name].add(f)
-                        for name in possible_linked:
-                                # calling __trim_recursive_incorps can be
-                                # expensive so don't call it for versions except
-                                # the one currently installed in the parent if
-                                # it has been proposed.
-                                if name in proposed_dict:
-                                        pf = self.__parent_dict.get(name)
-                                        possible_linked[name] -= \
-                                            set(proposed_dict[name]) - \
-                                            set([pf])
-                                if not possible_linked[name]:
-                                        continue
-                                self.__progress()
-                                self.__trim_recursive_incorps(
-                                    list(possible_linked[name]),
-                                    excludes, _TRIM_SYNCED_INC)
-                        del possible_linked
-
-                self.__start_subphase(4)
-                # now trim pkgs we cannot update due to maintained
-                # incorporations
-                for i, flist in zip(inc_list, con_lists):
-                        reason = (N_("This version is excluded by installed "
-                            "incorporation {0}"), (i.get_short_fmri(
-                                anarchy=True, include_scheme=False),))
-                        self.__trim(self.__comb_auto_fmris(i)[1],
-                            _TRIM_INSTALLED_INC, reason)
-                        for f in flist:
-                                # dotrim=False here as we only want to trim
-                                # packages that don't satisfy the incorporation.
-                                self.__trim(self.__comb_auto_fmris(f,
-                                    dotrim=False)[1], _TRIM_INSTALLED_INC,
-                                    reason)
-
-                self.__start_subphase(5)
-                # now trim any pkgs we cannot update due to freezes
-                self.__trim_frozen(existing_freezes)
-
-                self.__start_subphase(6)
-                # elide any proposed versions that don't match variants (arch
-                # usually)
-                for name in proposed_dict:
-                        for fmri in proposed_dict[name]:
-                                self.__trim_nonmatching_variants(fmri)
-
-                self.__start_subphase(7)
-                # remove any versions from proposed_dict that are in trim_dict
-                try:
-                        self.__trim_proposed(proposed_dict)
-                except api_errors.PlanCreationException as exp:
-                        # One or more proposed packages have been rejected.
-                        self.__raise_install_error(exp, inc_list, proposed_dict,
-                            set(), excludes)
-
-                self.__start_subphase(8)
-
-                # Ensure required dependencies of proposed packages are flagged
-                # to improve error messaging when parsing the transitive
-                # closure of all dependencies.
-                self.__set_proposed_required(proposed_dict, excludes)
-
-                # Update the set of possible fmris with the transitive closure
-                # of all dependencies.
-                self.__update_possible_closure(possible_set, excludes,
-                    proposed_dict=proposed_dict)
-
-                self.__start_subphase(9)
-                # trim any non-matching variants, origins or parents
-                for f in possible_set:
-                        self.__progress()
-                        if not self.__trim_nonmatching_parents(f, excludes,
-                            ignore_inst_parent_deps):
-                                continue
-                        if not self.__trim_nonmatching_variants(f):
-                                continue
-                        self.__trim_nonmatching_origins(f, excludes,
-                            exact_install=exact_install,
-                            installed_dict_tmp=installed_dict_tmp)
-
-                self.__start_subphase(10)
-                # remove all trimmed fmris from consideration
-                possible_set.difference_update(six.iterkeys(self.__trim_dict))
-                # remove any versions from proposed_dict that are in trim_dict
-                # as trim dict has been updated w/ missing dependencies
-                try:
-                        self.__trim_proposed(proposed_dict)
-                except api_errors.PlanCreationException as exp:
-                        # One or more proposed packages have been rejected.
-                        self.__raise_install_error(exp, inc_list, proposed_dict,
-                            possible_set, excludes)
-
-                self.__start_subphase(11)
-                #
-                # Generate ids, possible_dict for clause generation.  Prepare
-                # the solver for invocation.
-                #
-                self.__assign_fmri_ids(possible_set)
-
-                # Constrain the solution so that only one version of each
-                # package can be installed.
-                self.__enforce_unique_packages(excludes)
-
-                self.__start_subphase(12)
-                # Add proposed and installed packages to solver.
-                self.__generate_operation_clauses(proposed=proposed_pkgs,
-                    proposed_dict=proposed_dict)
-                try:
-                        self.__assert_installed_allowed(excludes,
-                            proposed=proposed_pkgs)
-                except api_errors.PlanCreationException as exp:
-                        # One or more installed packages can't be retained or
-                        # upgraded.
-                        self.__raise_install_error(exp, inc_list, proposed_dict,
-                            possible_set, excludes)
-
-                pt.plan_done(pt.PLAN_SOLVE_SETUP)
-
-                self.__progitem = pt.PLAN_SOLVE_SOLVER
-                pt.plan_start(pt.PLAN_SOLVE_SOLVER)
-                self.__start_subphase(13)
-                # save a solver instance so we can come back here
-                # this is where errors happen...
-                saved_solver = self.__save_solver()
-                try:
-                        saved_solution = self.__solve()
-                except api_errors.PlanCreationException as exp:
-                        # no solution can be found.
-                        self.__raise_install_error(exp, inc_list, proposed_dict,
-                            possible_set, excludes)
-
-                self.__start_subphase(14)
-                # we have a solution that works... attempt to
-                # reduce collateral damage to other packages
-                # while still keeping command line pkgs at their
-                # optimum level
-
-                self.__restore_solver(saved_solver)
-
-                # fix the fmris that were specified on the cmd line
-                # at their optimum (newest) level along with the
-                # new dependencies, but try and avoid upgrading
-                # already installed pkgs or adding un-needed new pkgs.
-
-                for fmri in saved_solution:
-                        if fmri.pkg_name in proposed_dict:
-                                self.__addclauses(
-                                    self.__gen_one_of_these_clauses([fmri]))
-
-                self.__start_subphase(15)
-                # save context
-                saved_solver = self.__save_solver()
-
-                saved_solution = self.__solve(older=True)
-
-                self.__start_subphase(16)
-                # Now we have the oldest possible original fmris
-                # but we may have some that are not original
-                # Since we want to move as far forward as possible
-                # when we have to move a package, fix the originals
-                # and drive forward again w/ the remainder
-                self.__restore_solver(saved_solver)
-
-                for fmri in saved_solution & self.__installed_fmris:
-                        self.__addclauses(
-                            self.__gen_one_of_these_clauses([fmri]))
-
-                solution = self.__solve()
-                self.__progress()
-                solution = self.__update_solution_set(solution, excludes)
-
-                return self.__end_solve(solution, excludes)
-
-        def solve_update_all(self, existing_freezes, excludes=EmptyI,
-            reject_set=frozenset()):
-                """Logic to update all packages within an image to the latest
-                versions possible.
-
-                Returns FMRIs to be installed / upgraded in system and a new
-                set of packages to be avoided.
-
-                'existing_freezes' is a list of incorp. style FMRIs that
-                constrain pkg motion
-
-                'reject_set' contains user specified FMRIs that should not be
-                present within the final image.  (These packages may or may
-                not be currently installed.)
-                """
-
-                pt = self.__begin_solve()
-
-                # Determine which packages are to be removed, rejected, and
-                # avoided and also determine which ones must not be removed
-                # during the operation.
-                self.__set_removed_and_required_packages(rejected=reject_set)
-                self.__progress()
-
-                if self.__is_child():
-                        synced_parent_pkgs = \
-                            self.__installed_unsatisfied_parent_deps(excludes,
-                                False)
-                else:
-                        synced_parent_pkgs = frozenset()
-
-                self.__start_subphase(2)
-                # generate set of possible fmris
-                possible_set = set()
-                for f in self.__installed_fmris - self.__removal_fmris:
-                        self.__progress()
-                        matching = self.__comb_newer_fmris(f)[0]
-                        if not matching:            # disabled publisher...
-                                matching = set([f]) # staying put is an option
-                        possible_set |= matching
-
-                self.__allowed_downgrades = set()
-                for f in possible_set:
-                        self.__allowed_downgrades |= \
-                            self.__allow_incorp_downgrades(f, excludes=excludes,
-                                relax_all=True)
-                possible_set |= self.__allowed_downgrades
-
-                # trim fmris we cannot install because they're older
-                for f in self.__installed_fmris:
-                        self.__progress()
-                        self.__trim_older(f)
-
-                # now trim any pkgs we cannot update due to freezes
-                self.__trim_frozen(existing_freezes)
-
-                # Trim packages with unsatisfied parent dependencies.  Then
-                # for packages with satisfied parent dependenices (which will
-                # include incorporations), call __trim_recursive_incorps() to
-                # trim out more packages that are disallowed due to the synced
-                # incorporations.
-                if self.__is_child():
-                        possible_linked = defaultdict(set)
-                        for f in possible_set.copy():
-                                self.__progress()
-                                if not self.__trim_nonmatching_parents(f,
-                                    excludes):
-                                        possible_set.remove(f)
-                                        continue
-                                if (f in self.__linked_pkgs and
-                                    f.pkg_name not in synced_parent_pkgs):
-                                        possible_linked[f.pkg_name].add(f)
-                        for name in possible_linked:
-                                self.__progress()
-                                self.__trim_recursive_incorps(
-                                    list(possible_linked[name]), excludes,
-                                    _TRIM_SYNCED_INC)
-                        del possible_linked
-
-                self.__start_subphase(3)
-                # Update the set of possible FMRIs with the transitive closure
-                # of all dependencies.
-                self.__update_possible_closure(possible_set, excludes)
-
-                # trim any non-matching origins or parents
-                for f in possible_set:
-                        if self.__trim_nonmatching_parents(f, excludes):
-                                if self.__trim_nonmatching_variants(f):
-                                        self.__trim_nonmatching_origins(f,
-                                            excludes)
-
-                self.__start_subphase(4)
-
-                # remove all trimmed fmris from consideration
-                possible_set.difference_update(six.iterkeys(self.__trim_dict))
-
-                #
-                # Generate ids, possible_dict for clause generation.  Prepare
-                # the solver for invocation.
-                #
-                self.__assign_fmri_ids(possible_set)
-
-                # Constrain the solution so that only one version of each
-                # package can be installed.
-                self.__enforce_unique_packages(excludes)
-
-                self.__start_subphase(5)
-                # Add installed packages to solver.
-                self.__generate_operation_clauses()
-                try:
-                        self.__assert_installed_allowed(excludes)
-                except api_errors.PlanCreationException:
-                        # Attempt a full trim to see if we can raise a sensible
-                        # error.  If not, re-raise.
-                        self.__assert_trim_errors(possible_set, excludes)
-                        raise
-
-                pt.plan_done(pt.PLAN_SOLVE_SETUP)
-
-                self.__progitem = pt.PLAN_SOLVE_SOLVER
-                pt.plan_start(pt.PLAN_SOLVE_SOLVER)
-                self.__start_subphase(6)
-                try:
-                        solution = self.__solve()
-                except api_errors.PlanCreationException:
-                        # No solution can be found; attempt a full trim to see
-                        # if we can raise a sensible error.  If not, re-raise.
-                        self.__assert_trim_errors(possible_set, excludes)
-                        raise
-
-                self.__update_solution_set(solution, excludes)
-
-                for f in solution.copy():
-                        if self.__fmri_is_obsolete(f):
-                                solution.remove(f)
-
-                # If solution doesn't match installed set of packages, then an
-                # upgrade solution was found (heuristic):
-                if solution != self.__installed_fmris:
-                        return self.__end_solve(solution, excludes)
-
-                incorps = self.__get_installed_upgradeable_incorps(
-                    excludes)
-                if not incorps or self.__is_child():
-                        # If there are no installed, upgradeable incorporations,
-                        # then assume that no updates were available.  Also if
-                        # we're a linked image child we may not be able to
-                        # update to the latest available incorporations due to
-                        # parent constraints, so don't generate an error.
-                        return self.__end_solve(solution, excludes)
-
-                # Before making a guess, apply extra trimming to see if we can
-                # reject the operation based on changing packages.
-                self.__assert_trim_errors(possible_set, excludes)
-
-                # Despite all of the trimming done, we still don't know why the
-                # solver couldn't find a solution, so make a best-effort guess
-                # at the reason why.
-                skey = operator.attrgetter('pkg_name')
-                info = []
-                info.append(_("No solution found to update to latest available "
-                    "versions."))
-                info.append(_("This may indicate an overly constrained set of "
-                    "packages are installed."))
-                info.append(" ")
-                info.append(_("latest incorporations:"))
-                info.append(" ")
-                info.extend((
-                    "  {0}".format(f)
-                    for f in sorted(incorps, key=skey)
-                ))
-                info.append(" ")
-
-                ms = self.__generate_dependency_errors(incorps,
-                    excludes=excludes)
-                ms.extend(self.__check_installed())
-
-                if ms:
-                        info.append(_("The following indicates why the system "
-                            "cannot update to the latest version:"))
-                        info.append(" ")
-                        for s in ms:
-                                info.append("  {0}".format(s))
-                else:
-                        info.append(_("Dependency analysis is unable to "
-                            "determine the cause."))
-                        info.append(_("Try running with -vv to "
-                            "obtain more detailed error messages."))
-
-                self.__raise_solution_error(no_solution=info)
-
-        def solve_uninstall(self, existing_freezes, uninstall_list, excludes,
-            ignore_inst_parent_deps=False):
-                """Compute changes needed for uninstall"""
-
-                self.__begin_solve()
-
-                # generate list of installed pkgs w/ possible renames removed to
-                # forestall failing removal due to presence of unneeded renamed
-                # pkg
-                orig_installed_set = self.__installed_fmris
-                renamed_set = orig_installed_set - \
-                    self.__elide_possible_renames(orig_installed_set, excludes)
-
-                proposed_removals = set(uninstall_list) | renamed_set | \
-                    self.__triggered_ops[PKG_OP_UNINSTALL][PKG_OP_UNINSTALL]
-
-                # find pkgs which are going to be installed/updated
-                triggered_set = set()
-                for f in self.__triggered_ops[PKG_OP_UNINSTALL][PKG_OP_UPDATE]:
-                        triggered_set.add(f)
-
-                # check for dependents
-                for pfmri in proposed_removals:
-                        self.__progress()
-                        dependents = self.__get_dependents(pfmri, excludes) - \
-                            proposed_removals
-
-                        # Check if any of the dependents are going to be updated
-                        # to a different version which might not have the same
-                        # dependency constraints. If so, remove from dependents
-                        # list.
-
-                        # Example:
-                        # A@1 depends on B
-                        # A@2 does not depend on B
-                        #
-                        # A@1 is currently installed, B is requested for removal
-                        # -> not allowed
-                        # pkg actuator updates A to 2
-                        # -> now removal of B is allowed
-                        candidates = dict(
-                             (tf, f)
-                             for f in dependents
-                             for tf in triggered_set
-                             if f.pkg_name == tf.pkg_name
-                        )
-
-                        for tf in candidates:
-                                remove = True
-                                for da in self.__get_dependency_actions(tf,
-                                    excludes):
-                                        if da.attrs["type"] != "require":
-                                                continue
-                                        pkg_name = pkg.fmri.PkgFmri(
-                                            da.attrs["fmri"]).pkg_name
-                                        if pkg_name == pfmri.pkg_name:
-                                                remove = False
-                                                break
-                                if remove:
-                                        dependents.remove(candidates[tf])
-
-                        if dependents:
-                                raise api_errors.NonLeafPackageException(pfmri,
-                                    dependents)
-
-                reject_set = set(f.pkg_name for f in proposed_removals)
-
-                # Run it through the solver; with more complex dependencies
-                # we're going to be out of luck without it.
-                self.__state = SOLVER_INIT # reset to initial state
-                return self.solve_install(existing_freezes, {},
-                    excludes=excludes, reject_set=reject_set,
-                    ignore_inst_parent_deps=ignore_inst_parent_deps)
-
-        def __update_solution_set(self, solution, excludes):
-                """Update avoid sets w/ any missing packages (due to reject).
-                Remove obsolete packages from solution.  Keep track of which
-                obsolete packages have group dependencies so verify of group
-                packages w/ obsolete members works."""
-
-                solution_stems = set(f.pkg_name for f in solution)
-                tracked_stems = set()
-                for fmri in solution:
-                        for a in self.__get_dependency_actions(fmri,
-                            excludes=excludes, trim_invalid=False):
-                                if (a.attrs["type"] != "group" and
-                                    a.attrs["type"] != "group-any"):
-                                        continue
-
-                                for t in a.attrlist("fmri"):
-                                        try:
-                                                tmp = self.__fmridict[t]
-                                        except KeyError:
-                                                tmp = pkg.fmri.PkgFmri(t)
-                                                self.__fmridict[t] = tmp
-                                        tracked_stems.add(tmp.pkg_name)
-
-                avoided = (tracked_stems - solution_stems)
-                # Add stems omitted by solution and explicitly rejected.
-                self.__avoid_set |= avoided & self.__reject_set
-
-                ret = solution.copy()
-                obs = set()
-
-                for f in solution:
-                        if self.__fmri_is_obsolete(f):
-                                ret.remove(f)
-                                obs.add(f.pkg_name)
-
-                self.__obs_set = obs & tracked_stems
-
-                # Add stems omitted by solution but not explicitly rejected, not
-                # previously avoided, and not avoided due to obsoletion.
-                self.__implicit_avoid_set |= avoided - self.__avoid_set - \
-                    self.__obs_set
-
-                return ret
-
-        def __save_solver(self):
-                """Duplicate current current solver state and return it."""
-                return (self.__addclause_failure,
-                    pkg.solver.msat_solver(self.__solver))
-
-        def __restore_solver(self, solver):
-                """Set the current solver state to the previously saved one"""
-                self.__addclause_failure, self.__solver = solver
-                self.__iterations = 0
-
-        def __solve(self, older=False, max_iterations=2000):
-                """Perform iterative solution; try for newest pkgs unless
-                older=True"""
-                solution_vector = []
-                self.__state = SOLVER_FAIL
-                eliminated = set()
-                while not self.__addclause_failure and self.__solver.solve([]):
-                        self.__progress()
-                        self.__iterations += 1
-
-                        if self.__iterations > max_iterations:
-                                break
-
-                        solution_vector = self.__get_solution_vector()
-                        if not solution_vector:
-                                break
-
-                        # prevent the selection of any older pkgs except for
-                        # those that are part of the set of allowed downgrades;
-                        for fid in solution_vector:
-                                pfmri = self.__getfmri(fid)
-                                matching, remaining = \
-                                    self.__comb_newer_fmris(pfmri)
-                                if not older:
-                                        # without subtraction of allowed
-                                        # downgrades, an initial solution will
-                                        # exclude any solutions containing
-                                        # earlier versions of downgradeable
-                                        # packages
-                                        remove = remaining - \
-                                            self.__allowed_downgrades
-                                else:
-                                        remove = matching - set([pfmri]) - \
-                                            eliminated
-                                for f in remove:
-                                        self.__addclauses([[-self.__getid(f)]])
-
-
-                        # prevent the selection of this exact combo;
-                        # permit [] solution
-                        self.__addclauses([[-i for i in solution_vector]])
-
-                if not self.__iterations:
-                        self.__raise_solution_error(no_solution=True)
-
-                self.__state = SOLVER_SUCCESS
-
-                solution = set([self.__getfmri(i) for i in solution_vector])
-
-                return solution
-
-        def __get_solution_vector(self):
-                """Return solution vector from solver"""
-                return frozenset([
-                    (i + 1) for i in range(self.__solver.get_variables())
-                    if self.__solver.dereference(i)
-                ])
-
-        def __assign_possible(self, possible_set):
-                """Assign __possible_dict of possible package FMRIs by pkg stem
-                and mark trimming complete."""
-
-                # generate dictionary of possible pkgs fmris by pkg stem
-                self.__possible_dict.clear()
-
-                for f in possible_set:
-                        self.__possible_dict[f.pkg_name].append(f)
-                for name in self.__possible_dict:
-                        self.__possible_dict[name].sort()
-                self.__trimdone = True
-
-        def __assign_fmri_ids(self, possible_set):
-                """ give a set of possible fmris, assign ids"""
-
-                self.__assign_possible(possible_set)
-
-                # assign clause numbers (ids) to possible pkgs
-                pkgid = 1
-                for name in sorted(six.iterkeys(self.__possible_dict)):
-                        for fmri in reversed(self.__possible_dict[name]):
-                                self.__id2fmri[pkgid] = fmri
-                                self.__fmri2id[fmri] = pkgid
-                                pkgid += 1
-
-                self.__variables = pkgid - 1
-
-        def __getid(self, fmri):
-                """Translate fmri to variable number (id)"""
-                return self.__fmri2id[fmri]
-
-        def __getfmri(self, fid):
-                """Translate variable number (id) to fmris"""
-                return self.__id2fmri[fid]
-
-        def __get_fmris_by_version(self, pkg_name):
-                """Cache for catalog entries; helps performance"""
-                if pkg_name not in self.__cache:
-                        self.__cache[pkg_name] = [
-                            t
-                            for t in self.__catalog.fmris_by_version(pkg_name)
-                        ]
-                return self.__cache[pkg_name]
-
-        def __get_catalog_fmris(self, pkg_name):
-                """ return the list of fmris in catalog for this pkg name"""
-                if pkg_name not in self.__pub_trim:
-                        self.__filter_publishers(pkg_name)
-
-                if self.__trimdone:
-                        return self.__possible_dict.get(pkg_name, [])
-
-                return [
-                    f
-                    for tp in self.__get_fmris_by_version(pkg_name)
-                    for f in tp[1]
-                ]
-
-        def __comb_newer_fmris(self, fmri, dotrim=True, obsolete_ok=True):
-                """Returns tuple of set of fmris that are matched within
-                CONSTRAINT.NONE of specified version and set of remaining
-                fmris."""
-
-                return self.__comb_common(fmri, dotrim,
-                    version.CONSTRAINT_NONE, obsolete_ok)
-
-        def __comb_common(self, fmri, dotrim, constraint, obsolete_ok):
-                """Underlying impl. of other comb routines"""
-
-                self.__progress()
-
-                tp = (fmri, dotrim, constraint, obsolete_ok) # cache index
-                # determine if the data is cacheable or cached:
-                if (not self.__trimdone and dotrim) or tp not in self.__cache:
-                        # use frozensets so callers don't inadvertently update
-                        # these sets (which may be cached).
-                        all_fmris = set(self.__get_catalog_fmris(fmri.pkg_name))
-                        matching = frozenset([
-                            f
-                            for f in all_fmris
-                            if not dotrim or not self.__trim_dict.get(f)
-                            if not fmri.version or
-                                fmri.version == f.version or
-                                f.version.is_successor(fmri.version,
-                                    constraint=constraint)
-                            if obsolete_ok or not self.__fmri_is_obsolete(f)
-                        ])
-                        remaining = frozenset(all_fmris - matching)
-
-                        # if we haven't finished trimming, don't cache this
-                        if not self.__trimdone:
-                                return matching, remaining
-                        # cache the result
-                        self.__cache[tp] = (matching, remaining)
-
-                return self.__cache[tp]
-
-        def __comb_older_fmris(self, fmri, dotrim=True, obsolete_ok=True):
-                """Returns tuple of set of fmris that are older than
-                specified version and set of remaining fmris."""
-                newer, older = self.__comb_newer_fmris(fmri, dotrim=False,
-                    obsolete_ok=obsolete_ok)
-                if not dotrim:
-                        return older, newer
-
-                # we're going to return the older packages, so we need
-                # to make sure that any trimmed packages are removed
-                # from the matching set and added to the non-matching
-                # ones.
-                trimmed_older = set([
-                    f
-                    for f in older
-                    if self.__trim_dict.get(f)
-                ])
-                return older - trimmed_older, newer | trimmed_older
-
-        def __comb_auto_fmris(self, fmri, dotrim=True, obsolete_ok=True):
-                """Returns tuple of set of fmris that are match within
-                CONSTRAINT.AUTO of specified version and set of remaining
-                fmris."""
-                return self.__comb_common(fmri, dotrim, version.CONSTRAINT_AUTO,
-                    obsolete_ok)
-
-        def __fmri_loadstate(self, fmri, excludes):
-                """load fmri state (obsolete == True, renamed == True)"""
-
-                try:
-                        relevant = dict([
-                                (a.attrs["name"], a.attrs["value"])
-                                for a in self.__catalog.get_entry_actions(fmri,
-                                [catalog.Catalog.DEPENDENCY], excludes=excludes)
-                                if a.name == "set" and \
-                                    a.attrs["name"] in ["pkg.renamed",
-                                    "pkg.obsolete"]
-                                ])
-                except api_errors.InvalidPackageErrors:
-                        # Trim package entries that have unparseable action data
-                        # so that they can be filtered out later.
-                        self.__fmri_state[fmri] = ("false", "false")
-                        self.__trim_unsupported(fmri)
-                        return
-
-                self.__fmri_state[fmri] = (
-                    relevant.get("pkg.obsolete", "false").lower() == "true",
-                    relevant.get("pkg.renamed", "false").lower() == "true")
-
-        def __fmri_is_obsolete(self, fmri, excludes=EmptyI):
-                """check to see if fmri is obsolete"""
-                if fmri not in self.__fmri_state:
-                        self.__fmri_loadstate(fmri, excludes)
-                return self.__fmri_state[fmri][0]
-
-        def __fmri_is_renamed(self, fmri, excludes=EmptyI):
-                """check to see if fmri is renamed"""
-                if fmri not in self.__fmri_state:
-                        self.__fmri_loadstate(fmri, excludes)
-                return self.__fmri_state[fmri][1]
-
-        def __get_actions(self, fmri, name, excludes=EmptyI,
-            trim_invalid=True):
-                """Return list of actions of type 'name' for this 'fmri' in
-                Catalog.DEPENDENCY section."""
-
-                try:
-                        return self.__actcache[(fmri, name)]
-                except KeyError:
-                        pass
-
-                try:
-                        acts = [
-                            a
-                            for a in self.__catalog.get_entry_actions(fmri,
-                            [catalog.Catalog.DEPENDENCY], excludes=excludes)
-                            if a.name == name
-                        ]
-
-                        if name == "depend":
-                                for a in acts:
-                                        if a.attrs["type"] in dep_types:
-                                                continue
-                                        raise api_errors.InvalidPackageErrors([
-                                            "Unknown dependency type {0}".
-                                            format(a.attrs["type"])])
-
-                        self.__actcache[(fmri, name)] = acts
-                        return acts
-                except api_errors.InvalidPackageErrors:
-                        if not trim_invalid:
-                                raise
-
-                        # Trim package entries that have unparseable action
-                        # data so that they can be filtered out later.
-                        self.__fmri_state[fmri] = ("false", "false")
-                        self.__trim_unsupported(fmri)
-                        return []
-
-        def __get_dependency_actions(self, fmri, excludes=EmptyI,
-            trim_invalid=True):
-                """Return list of all dependency actions for this fmri."""
-
-                return self.__get_actions(fmri, "depend",
-                    excludes=excludes, trim_invalid=trim_invalid)
-
-        def __get_set_actions(self, fmri, excludes=EmptyI,
-            trim_invalid=True):
-                """Return list of all set actions for this fmri in
-                Catalog.DEPENDENCY section."""
-
-                return self.__get_actions(fmri, "set",
-                    excludes=excludes, trim_invalid=trim_invalid)
-
-        def __get_variant_dict(self, fmri):
-                """Return dictionary of variants suppported by fmri"""
-                try:
-                        if fmri not in self.__variant_dict:
-                                self.__variant_dict[fmri] = dict(
-                                    self.__catalog.get_entry_all_variants(fmri))
-                except api_errors.InvalidPackageErrors:
-                        # Trim package entries that have unparseable action data
-                        # so that they can be filtered out later.
-                        self.__variant_dict[fmri] = {}
-                        self.__trim_unsupported(fmri)
-                return self.__variant_dict[fmri]
-
-        def __is_explicit_install(self, fmri):
-                """check if given fmri has explicit install actions."""
-
-                for sa in self.__get_set_actions(fmri):
-                        if sa.attrs["name"] == "pkg.depend.explicit-install" \
-                            and sa.attrs["value"].lower() == "true":
-                                return True
-                return False
-
-        def __filter_explicit_install(self, fmri, excludes):
-                """Check packages which have 'pkg.depend.explicit-install'
-                action set to true, and prepare to filter."""
-
-                will_filter = True
-                # Filter out fmris with 'pkg.depend.explicit-install' set to
-                # true and not explicitly proposed, already installed in the
-                # current image, or is parent-constrained and is installed in
-                # the parent image.
-                if self.__is_explicit_install(fmri):
-                        pkg_name = fmri.pkg_name
-                        if pkg_name in self.__expl_install_dict and \
-                            fmri in self.__expl_install_dict[pkg_name]:
-                                will_filter = False
-                        elif pkg_name in self.__installed_dict:
-                                will_filter = False
-                        elif pkg_name in self.__parent_dict:
-                                # If this is a linked package that is
-                                # constrained to be the same version as parent,
-                                # and the parent has it installed, ignore
-                                # pkg.depend.explicit-install so that IDR
-                                # versions of packages can be used
-                                # automatically.
-                                will_filter = not any(
-                                    da
-                                    for da in self.__get_dependency_actions(
-                                        fmri, excludes)
-                                    if da.attrs["type"] == "parent" and
-                                        pkg.actions.depend.DEPEND_SELF in
-                                            da.attrlist("fmri")
-                                )
-                else:
-                        will_filter = False
-                return will_filter
-
-        def __generate_dependency_closure(self, fmri_set, excludes=EmptyI,
-            dotrim=True, full_trim=False, filter_explicit=True,
-            proposed_dict=None):
-                """return set of all fmris the set of specified fmris could
-                depend on; while trimming those packages that cannot be
-                installed"""
-
-                # Use a copy of the set provided by the caller to prevent
-                # unexpected modification!
-                needs_processing = set(fmri_set)
-                already_processed = set()
-
-                while needs_processing:
-                        self.__progress()
-                        fmri = needs_processing.pop()
-                        already_processed.add(fmri)
-                        # Trim filtered packages.
-                        if filter_explicit and \
-                            self.__filter_explicit_install(fmri, excludes):
-                                reason = (N_("Uninstalled fmri {0} can "
-                                    "only be installed if explicitly "
-                                    "requested"), (fmri,))
-                                self.__trim((fmri,), _TRIM_EXPLICIT_INSTALL,
-                                    reason)
-                                continue
-
-                        needs_processing |= (self.__generate_dependencies(fmri,
-                            excludes, dotrim, full_trim,
-                            proposed_dict=proposed_dict) - already_processed)
-                return already_processed
-
-        def __generate_dependencies(self, fmri, excludes=EmptyI, dotrim=True,
-            full_trim=False, proposed_dict=None):
-                """return set of direct (possible) dependencies of this pkg;
-                trim those packages whose dependencies cannot be satisfied"""
-                try:
-                        return set([
-                             f
-                             for da in self.__get_dependency_actions(fmri,
-                                 excludes)
-                             # check most common ones first; what is checked
-                             # here is a matter of optimization / messaging, not
-                             # correctness.
-                             if da.attrs["type"] == "require" or
-                                 da.attrs["type"] == "group" or
-                                 da.attrs["type"] == "conditional" or
-                                 da.attrs["type"] == "require-any" or
-                                 da.attrs["type"] == "group-any" or
-                                 (full_trim and (
-                                     da.attrs["type"] == "incorporate" or
-                                     da.attrs["type"] == "optional" or
-                                     da.attrs["type"] == "exclude"))
-                             for f in self.__parse_dependency(da, fmri,
-                                 dotrim, check_req=True,
-                                 proposed_dict=proposed_dict)[1]
-                        ])
-
-                except DependencyException as e:
-                        self.__trim((fmri,), e.reason_id, e.reason,
-                            fmri_adds=e.fmris)
-                        return set([])
-
-        def __elide_possible_renames(self, fmris, excludes=EmptyI):
-                """Return fmri list (which must be self-complete) with all
-                renamed fmris that have no other fmris depending on them
-                removed"""
-
-                # figure out which have been renamed
-                renamed_fmris = set([
-                    pfmri
-                    for pfmri in fmris
-                    if self.__fmri_is_renamed(pfmri, excludes)
-                ])
-
-                # return if nothing has been renamed
-                if not renamed_fmris:
-                        return set(fmris)
-
-                fmris_by_name = dict(
-                    (pfmri.pkg_name, pfmri)
-                    for pfmri in fmris
+            else:
+                reason = (
+                    N_(
+                        "This version is excluded by a "
+                        "freeze on {0} at version {1}."
+                    ),
+                    (f.pkg_name, f.version.get_version(include_build=False)),
                 )
+            self.__trim(
+                self.__comb_auto_fmris(f, dotrim=False)[1], _TRIM_FREEZE, reason
+            )
 
-                # figure out which renamed fmris have dependencies; compute
-                # transitively so we can handle multiple renames
+    def __raise_solution_error(self, no_version=EmptyI, no_solution=EmptyI):
+        """Raise a plan exception due to solution errors."""
 
-                needs_processing = set(fmris) - renamed_fmris
-                already_processed = set()
+        solver_errors = None
+        # Value 'DebugValues' is unsubscriptable;
+        # pylint: disable=E1136
+        if DebugValues["plan"]:
+            solver_errors = self.get_trim_errors()
+        raise api_errors.PlanCreationException(
+            no_solution=no_solution,
+            no_version=no_version,
+            solver_errors=solver_errors,
+        )
 
-                while needs_processing:
-                        pfmri = needs_processing.pop()
-                        already_processed.add(pfmri)
-                        for da in self.__get_dependency_actions(
-                            pfmri, excludes):
-                                if da.attrs["type"] not in \
-                                    ("incorporate", "optional", "origin"):
-                                        for f in da.attrlist("fmri"):
-                                                try:
-                                                        tmp = self.__fmridict[f]
-                                                except KeyError:
-                                                        tmp = \
-                                                            pkg.fmri.PkgFmri(f)
-                                                        self.__fmridict[f] = tmp
-                                                name = tmp.pkg_name
-                                                if name not in fmris_by_name:
-                                                        continue
-                                                new_fmri = fmris_by_name[name]
-                                                # since new_fmri will not be
-                                                # treated as renamed, make sure
-                                                # we check any dependencies it
-                                                # has
-                                                if new_fmri not in \
-                                                    already_processed:
-                                                        needs_processing.add(
-                                                            new_fmri)
-                                                renamed_fmris.discard(new_fmri)
-                return set(fmris) - renamed_fmris
+    def __trim_proposed(self, proposed_dict):
+        """Remove any versions from proposed_dict that are in trim_dict
+        and raise an exception if no matching version of a proposed
+        package can be installed at this point."""
 
+        if proposed_dict is None:
+            # Nothing to do.
+            return
 
-        def __get_dependents(self, pfmri, excludes=EmptyI):
-                """return set of installed fmris that have require dependencies
-                on specified installed fmri"""
-                if self.__dependents is None:
-                        self.__dependents = {}
-                        for f in self.__installed_fmris:
-                                for da in self.__get_dependency_actions(f,
-                                    excludes):
-                                        if da.attrs["type"] != "require":
-                                                continue
-                                        pkg_name = pkg.fmri.PkgFmri(
-                                            da.attrs["fmri"]).pkg_name
-                                        self.__dependents.setdefault(
-                                            self.__installed_dict[pkg_name],
-                                            set()).add(f)
-                return self.__dependents.get(pfmri, set())
+        # Used to de-dup errors.
+        already_seen = set()
 
-        def __trim_recursive_incorps(self, fmri_list, excludes, reason_id):
-                """trim packages affected by incorporations"""
-                processed = set()
+        ret = []
+        for name in proposed_dict:
+            tv = self.__dotrim(proposed_dict[name])
+            if tv:
+                proposed_dict[name] = tv
+                continue
 
-                work = [fmri_list]
-
-                if reason_id == _TRIM_PROPOSED_INC:
-                        reason = N_(
-                            "Excluded by proposed incorporation '{0}'")
-                elif reason_id == _TRIM_SYNCED_INC:
-                        reason = N_(
-                            "Excluded by synced parent incorporation '{0}'")
-                else:
-                        raise AssertionError(
-                            "Invalid reason_id value: {0}".format(reason_id))
-
-                while work:
-                        fmris = work.pop()
-                        enc_pkg_name = fmris[0].get_name()
-                        # If the package is not installed then any dependenices
-                        # it has are irrelevant.
-                        if enc_pkg_name not in self.__installed_dict:
-                                continue
-                        processed.add(frozenset(fmris))
-                        d = self.__combine_incorps(fmris, excludes)
-                        for name in d:
-                                self.__trim(d[name][1], reason_id,
-                                    (reason, (fmris[0].pkg_name,)))
-                                to_do = d[name][0]
-                                if to_do and frozenset(to_do) not in processed:
-                                        work.append(list(to_do))
-
-        def __combine_incorps(self, fmri_list, excludes):
-                """Given a list of fmris, one of which must be present, produce
-                a dictionary indexed by package name, which contains a tuple
-                of two sets (matching fmris, nonmatching)"""
-
-                dict_list = [
-                    self.__get_incorp_nonmatch_dict(f, excludes)
-                    for f in fmri_list
+            ret.extend(
+                [
+                    _("No matching version of {0} can be " "installed:").format(
+                        name
+                    )
                 ]
-                # The following ignores constraints that appear in only some of
-                # the versions.  This also handles obsoletions & renames.
-                all_keys = reduce(set.intersection,
-                    (set(d.keys()) for d in dict_list))
-
-                return dict(
-                    (k,
-                     (reduce(set.union,
-                         (d.get(k, (set(), set()))[0]
-                          for d in dict_list)),
-                      reduce(set.intersection,
-                         (d.get(k, (set(), set()))[1]
-                          for d in dict_list))))
-                    for k in all_keys
+            )
+            ret.extend(
+                self.__fmri_list_errors(
+                    proposed_dict[name], already_seen=already_seen
                 )
+            )
+            # continue processing and accumulate all errors
+        if ret:
+            self.__raise_solution_error(no_version=ret)
 
+    def __set_removed_and_required_packages(self, rejected, proposed=None):
+        """Sets the list of package to be removed from the image, the
+        list of packages to reject, the list of packages to avoid
+        during the operation, and the list of packages that must not be
+        removed from the image.
 
-        def __get_incorp_nonmatch_dict(self, fmri, excludes):
-                """Given a fmri with incorporation dependencies, produce a
-                dictionary containing (matching, non matching fmris),
-                indexed by pkg name.  Note that some fmris may be
-                incorporated more than once at different levels of
-                specificity"""
-                ret = dict()
-                for da in self.__get_dependency_actions(fmri,
-                    excludes=excludes):
-                        if da.attrs["type"] != "incorporate":
-                                continue
-                        nm, m, _c, _d, _r, f = self.__parse_dependency(da, fmri,
-                            dotrim=False)
-                        # Collect all incorp. dependencies affecting
-                        # a package in a list.  Note that it is
-                        # possible for both matching and non-matching
-                        # sets to be NULL, and we'll need at least
-                        # one item in the list for reduce to work.
-                        ret.setdefault(f.pkg_name, (list(), list()))
-                        ret[f.pkg_name][0].append(set(m))
-                        ret[f.pkg_name][1].append(set(nm))
+        'rejected' is a set of package stems to reject.
 
-                # For each of the packages constrained, combine multiple
-                # incorporation dependencies.  Matches are intersected,
-                # non-matches form a union.
-                for pkg_name in ret:
-                        ret[pkg_name] = (
-                            reduce(set.intersection, ret[pkg_name][0]),
-                            reduce(set.union, ret[pkg_name][1]))
-                return ret
+        'proposed' is an optional set of FMRI objects representing
+        packages to install or update.
 
-        def __parse_group_dependency(self, dotrim, obsolete_ok, fmris):
-                """Returns (matching, nonmatching) fmris for given list of group
-                dependencies."""
+        Upon return:
+          * self.__removal_fmris will contain the list of FMRIs to be
+            removed from the image due to user request or due to past
+            bugs that caused wrong variant to be installed by mistake.
 
-                matching = []
-                nonmatching = []
-                for f in fmris:
-                        # remove version explicitly; don't
-                        # modify cached fmri
-                        if f.version is not None:
-                                fmri = f.copy()
-                                fmri.version = None
-                        else:
-                                fmri = f
+          * self.__reject_set will contain the list of packages to avoid
+            or that were rejected by user request as appropriate."""
 
-                        m, nm = self.__comb_newer_fmris(fmri,
-                            dotrim, obsolete_ok=obsolete_ok)
-                        matching.extend(m)
-                        nonmatching.extend(nm)
+        if proposed is None:
+            proposed = set()
+        else:
+            # remove packages to be installed from avoid sets
+            self.__avoid_set -= proposed
+            self.__implicit_avoid_set -= proposed
 
-                return frozenset(matching), frozenset(nonmatching)
+        self.__removal_fmris |= set(
+            [
+                self.__installed_dict[name]
+                for name in rejected
+                if name in self.__installed_dict
+            ]
+            + [
+                f
+                for f in self.__installed_fmris
+                if not self.__trim_nonmatching_variants(f)
+            ]
+        )
 
-        def __parse_dependency(self, dependency_action, source,
-            dotrim=True, check_req=False, proposed_dict=None):
-                """Return tuple of (disallowed fmri list, allowed fmri list,
-                conditional_list, dependency_type, required)"""
+        self.__reject_set = rejected
 
-                dtype = dependency_action.attrs["type"]
-                fmris = []
-                for fmristr in dependency_action.attrlist("fmri"):
-                        try:
-                                fmri = self.__fmridict[fmristr]
-                        except KeyError:
-                                fmri = pkg.fmri.PkgFmri(fmristr)
-                                self.__fmridict[fmristr] = fmri
+        # trim fmris that user explicitly disallowed
+        for name in rejected:
+            self.__trim(
+                self.__get_catalog_fmris(name),
+                _TRIM_REJECT,
+                N_("This version rejected by user request"),
+            )
 
-                        if not self.__depend_ts:
-                                fver = fmri.version
-                                if fver and fver.timestr:
-                                        # Include timestamp in all error
-                                        # output for dependencies.
-                                        self.__depend_ts = True
+        self.__req_pkg_names = (self.__installed_pkgs | proposed) - rejected
+        self.__req_pkg_names -= set(f.pkg_name for f in self.__removal_fmris)
 
-                        fmris.append(fmri)
+    def __set_proposed_required(self, proposed_dict, excludes):
+        """Add the common set of conditional, group, and require
+        dependencies of proposed packages to the list of package stems
+        known to be a required part of the solution.  This will improve
+        error messaging if no solution is found."""
 
-                fmri = fmris[0]
+        if proposed_dict is None:
+            return
 
-                # true if match is required for containing pkg
-                required = True
-                # if this dependency has conditional fmris
-                conditional = None
-                # true if obsolete pkgs satisfy this dependency
-                obsolete_ok = False
-
-                if dtype == "require":
-                        matching, nonmatching = \
-                            self.__comb_newer_fmris(fmri, dotrim,
-                                obsolete_ok=obsolete_ok)
-
-                elif dtype == "optional":
-                        obsolete_ok = True
-                        matching, nonmatching = \
-                            self.__comb_newer_fmris(fmri, dotrim,
-                            obsolete_ok=obsolete_ok)
-                        if fmri.pkg_name not in self.__req_pkg_names:
-                                required = False
-
-                elif dtype == "exclude":
-                        obsolete_ok = True
-                        matching, nonmatching = \
-                            self.__comb_older_fmris(fmri, dotrim,
-                            obsolete_ok=obsolete_ok)
-                        if fmri.pkg_name not in self.__req_pkg_names:
-                                required = False
-
-                elif dtype == "incorporate":
-                        obsolete_ok = True
-                        matching, nonmatching = \
-                            self.__comb_auto_fmris(fmri, dotrim,
-                            obsolete_ok=obsolete_ok)
-                        if fmri.pkg_name not in self.__req_pkg_names:
-                                required = False
-                        # Track packages that deliver incorporate deps.
-                        self.__known_incs.add(source.pkg_name)
-
-                elif dtype == "conditional":
-                        cond_fmri = pkg.fmri.PkgFmri(
-                            dependency_action.attrs["predicate"])
-                        conditional, nonmatching = self.__comb_newer_fmris(
-                            cond_fmri, dotrim, obsolete_ok=obsolete_ok)
-
-                        # Required is only really helpful for solver error
-                        # messaging.  The only time we know that this dependency
-                        # is required is when the predicate package must be part
-                        # of the solution.
-                        if cond_fmri.pkg_name not in self.__req_pkg_names:
-                                required = False
-
-                        proposed = (
-                            proposed_dict[cond_fmri.pkg_name]
-                            if proposed_dict and
-                            cond_fmri.pkg_name in proposed_dict
-                            else []
+        req_dep_names = set()
+        for name in proposed_dict:
+            # Find intersection of the set of conditional, group,
+            # and require dependencies for all proposed versions of
+            # the proposed package.  The result is the set of
+            # package stems we know will be required to be part of
+            # the solution.
+            comm_deps = None
+            propvers = set(self.__dotrim(proposed_dict[name]))
+            for f in propvers:
+                prop_deps = set(
+                    dname
+                    for (dtype, dname) in (
+                        (
+                            da.attrs["type"],
+                            pkg.fmri.extract_pkg_name(da.attrs["fmri"]),
                         )
-
-                        # If the predicate is not installed and not in the
-                        # proposed set, then the dependant package is not
-                        # required.
-                        installed = False
-                        for f in conditional:
-                                if (f in proposed or
-                                    f in self.__installed_fmris -
-                                    self.__removal_fmris):
-                                        installed = True
-                        if not installed:
-                                required = False
-
-                        matching, nonmatching = \
-                            self.__comb_newer_fmris(fmri, dotrim,
-                            obsolete_ok=obsolete_ok)
-
-                elif dtype == "require-any":
-                        matching = []
-                        nonmatching = []
-                        for f in fmris:
-                                m, nm = self.__comb_newer_fmris(f, dotrim,
-                                    obsolete_ok=obsolete_ok)
-                                matching.extend(m)
-                                nonmatching.extend(nm)
-
-                        matching = set(matching)
-                        nonmatching = set(nonmatching)
-
-                elif dtype == "parent":
-                        # Parent dependency fmris must exist outside of the
-                        # current image, so we don't report any new matching
-                        # or nonmatching requirements for the solver.
-                        matching = nonmatching = frozenset()
-                        required = False
-
-                elif dtype == "origin":
-                        matching, nonmatching = \
-                            self.__comb_newer_fmris(fmri, dotrim=False,
-                            obsolete_ok=obsolete_ok)
-                        required = False
-
-                elif dtype == "group" or dtype == "group-any":
-                        obsolete_ok = True
-                        # Determine potential fmris for matching.
-                        potential = [
-                            fmri
-                            for fmri in fmris
-                            if not (fmri.pkg_name in self.__avoid_set or
-                                fmri.pkg_name in self.__reject_set)
-                        ]
-                        required = len(potential) > 0
-
-                        # Determine matching fmris.
-                        matching = nonmatching = frozenset()
-                        if required:
-                                matching, nonmatching = \
-                                    self.__parse_group_dependency(dotrim,
-                                        obsolete_ok, potential)
-                                if not matching and not nonmatching:
-                                        # No possible stems at all? Ignore
-                                        # dependency.
-                                        required = False
-
-                        # If more than one stem matched, prefer stems for which
-                        # no obsoletion exists.
-                        mstems = frozenset(f.pkg_name for f in matching)
-                        if required and len(mstems) > 1:
-                                ostems = set()
-                                ofmris = set()
-                                for f in matching:
-                                        if self.__fmri_is_obsolete(f):
-                                                ostems.add(f.pkg_name)
-                                                ofmris.add(f)
-
-                                # If not all matching stems had an obsolete
-                                # version, remove the obsolete fmris from
-                                # consideration.  This makes the assumption that
-                                # at least one of the remaining, non-obsolete
-                                # stems will be installable.  If that is not
-                                # true, the solver may not find anything to do,
-                                # or may not find a solution if the system is
-                                # overly constrained.  This is believed
-                                # unlikely, so seems a reasonable compromise.
-                                # In that scenario, a client can move forward by
-                                # using --reject to remove the related group
-                                # dependencies.
-                                if mstems - ostems:
-                                        matching -= ofmris
-                                        nonmatching |= ofmris
-
-                else: # only way this happens is if new type is incomplete
-                        raise api_errors.InvalidPackageErrors([
-                            "Unknown dependency type {0}".format(dtype)])
-
-                # check if we're throwing exceptions and we didn't find any
-                # matches on a required package
-                if not check_req or matching or not required:
-                        return (nonmatching, matching, conditional, dtype,
-                            required, fmri)
-                elif dotrim and source in self.__inc_list and \
-                     dtype == "incorporate":
-                        # This is an incorporation package that will not be
-                        # removed, so if dependencies can't be satisfied, try
-                        # again with dotrim=False to ignore rejections due to
-                        # proposed packages.
-                        return self.__parse_dependency(dependency_action,
-                            source, dotrim=False, check_req=check_req,
-                            proposed_dict=proposed_dict)
-
-                # Neither build or publisher is interesting for dependencies.
-                fstr = fmri.get_fmri(anarchy=True, include_build=False,
-                    include_scheme=False)
-
-                # we're going to toss an exception
-                if dtype == "exclude":
-                        # If we reach this point, we know that a required
-                        # package (already installed or proposed) was excluded.
-                        matching, nonmatching = self.__comb_older_fmris(
-                            fmri, dotrim=False, obsolete_ok=False)
-
-                        # Determine if excluded package is already installed.
-                        installed = False
-                        for f in nonmatching:
-                                if f in self.__installed_fmris:
-                                        installed = True
-                                        break
-
-                        if not matching and installed:
-                                # The exclude dependency doesn't allow the
-                                # version of the package that is already
-                                # installed.
-                                raise DependencyException(
-                                    _TRIM_INSTALLED_EXCLUDE,
-                                    (N_("Package contains 'exclude' dependency "
-                                        "{0} on installed package"), (fstr,)))
-                        elif not matching and not installed:
-                                # The exclude dependency doesn't allow any
-                                # version of the package that is proposed.
-                                raise DependencyException(
-                                    _TRIM_INSTALLED_EXCLUDE,
-                                    (N_("Package contains 'exclude' dependency "
-                                        "{0} on proposed package"), (fstr,)))
-                        else:
-                                # All versions of the package allowed by the
-                                # exclude dependency were trimmed by other
-                                # dependencies.  If changed, update _fmri_errors
-                                # _TRIM_DEP_TRIMMED.
-                                raise DependencyException(
-                                    _TRIM_DEP_TRIMMED,
-                                    (N_("No version allowed by 'exclude' "
-                                        "dependency {0} could be installed"),
-                                        (fstr,)), matching)
-                        # not reached
-                elif dtype == "incorporate":
-                        matching, nonmatching = \
-                            self.__comb_auto_fmris(fmri, dotrim=False,
-                            obsolete_ok=obsolete_ok)
-
-                # check if allowing obsolete packages helps
-
-                elif not obsolete_ok:
-                        # see if allowing obsolete pkgs gets us some matches
-                        if len(fmris) == 1:
-                                matching, nonmatching = \
-                                    self.__comb_newer_fmris(fmri, dotrim,
-                                    obsolete_ok=True)
-                        else:
-                                matching = []
-                                nonmatching = []
-                                for f in fmris:
-                                        m, nm = self.__comb_newer_fmris(f,
-                                            dotrim, obsolete_ok=True)
-                                        matching.extend(m)
-                                        nonmatching.extend(nm)
-                        if matching:
-                                if len(fmris) == 1:
-                                        raise DependencyException(
-                                            _TRIM_DEP_OBSOLETE,
-                                            (N_("All acceptable versions of "
-                                                "'{0}' dependency on {1} are "
-                                                "obsolete"), (dtype, fstr)))
-                                else:
-                                        sfmris = frozenset([
-                                            fmri.get_fmri(anarchy=True,
-                                                include_build=False,
-                                                include_scheme=False)
-                                            for f in fmris
-                                        ])
-                                        raise DependencyException(
-                                            _TRIM_DEP_OBSOLETE,
-                                            (N_("All acceptable versions of "
-                                                "'{0}' dependencies on {1} are "
-                                                "obsolete"), (dtype, sfmris)))
-                        # something else is wrong
-                        matching, nonmatching = self.__comb_newer_fmris(fmri,
-                            dotrim=False, obsolete_ok=obsolete_ok)
-                else:
-                        # try w/o trimming anything
-                        matching, nonmatching = self.__comb_newer_fmris(fmri,
-                            dotrim=False, obsolete_ok=obsolete_ok)
-
-                if not matching:
-                        raise DependencyException(_TRIM_DEP_MISSING,
-                            (N_("No version for '{0}' dependency on {1} can "
-                                "be found"), (dtype, fstr)))
-
-                # If this is a dependency of a proposed package for which only
-                # one version is possible, then mark all other versions as
-                # rejected by this package.  This ensures that other proposed
-                # packages will be included in error messaging if their
-                # dependencies can only be satisfied if this one is not
-                # proposed.
-                if dotrim and nonmatching and proposed_dict and \
-                    proposed_dict.get(source.pkg_name, []) == [source]:
-                        nm = self.__parse_dependency(dependency_action, source,
-                            dotrim=False, check_req=check_req,
-                            proposed_dict=proposed_dict)[0]
-                        self.__trim(nm, _TRIM_DEP_TRIMMED,
-                            (N_("Rejected by '{0}' dependency in proposed "
-                                "package '{1}'"), (dtype, source.pkg_name)),
-                            fmri_adds=[source])
-
-                # If changed, update _fmri_errors _TRIM_DEP_TRIMMED.
-                raise DependencyException(_TRIM_DEP_TRIMMED,
-                    (N_("No version matching '{0}' dependency {1} can be "
-                        "installed"), (dtype, fstr)), matching)
-
-        def __installed_unsatisfied_parent_deps(self, excludes,
-            ignore_inst_parent_deps):
-                """If we're a child image then we need to relax packages
-                that are dependent upon themselves in the parent image.  This
-                is necessary to keep those packages in sync."""
-
-                relax_pkgs = set()
-
-                # check if we're a child image.
-                if not self.__is_child():
-                        return relax_pkgs
-
-                # if we're ignoring parent dependencies there is no reason to
-                # relax install-holds in packages constrained by those
-                # dependencies.
-                if ignore_inst_parent_deps:
-                        return relax_pkgs
-
-                for f in self.__installed_fmris:
-                        for da in self.__get_dependency_actions(f, excludes):
-                                if da.attrs["type"] != "parent":
-                                        continue
-                                self.__linked_pkgs.add(f)
-
-                                if (pkg.actions.depend.DEPEND_SELF
-                                    not in da.attrlist("fmri")):
-                                        continue
-
-                                # We intentionally do not rely on 'insync' state
-                                # as a change in facets/variants may result in
-                                # changed parent constraints.
-                                pf = self.__parent_dict.get(f.pkg_name)
-                                if pf != f:
-                                        # We only need to relax packages that
-                                        # don't match the parent.
-                                        relax_pkgs.add(f.pkg_name)
-                                        break
-
-                return relax_pkgs
-
-        def __generate_dependency_errors(self, fmri_list, excludes=EmptyI):
-                """ Returns a list of strings describing why fmris cannot
-                be installed, or returns an empty list if installation
-                is possible. """
-                ret = []
-
-                needs_processing = set(fmri_list)
-                already_processed = set()
-                already_seen = set()
-
-                while needs_processing:
-                        fmri = needs_processing.pop()
-                        errors, newfmris = self.__do_error_work(fmri,
-                            excludes, already_seen)
-                        ret.extend(errors)
-                        already_processed.add(fmri)
-                        needs_processing |= newfmris - already_processed
-                return ret
-
-        def get_trim_errors(self):
-                """Returns a list of strings for all FMRIs evaluated by the
-                solver explaining why they were rejected.  (All packages
-                found in solver's trim database.)"""
-
-                # At a minimum, a solve_*() method must have been called first.
-                assert self.__state != SOLVER_INIT
-                # Value 'DebugValues' is unsubscriptable;
-                # pylint: disable=E1136
-                assert DebugValues["plan"]
-
-                return self.__fmri_list_errors(six.iterkeys(self.__trim_dict),
-                    already_seen=set(), verbose=True)
-
-        def __check_installed(self):
-                """Generate list of strings describing why currently
-                installed packages cannot be installed, or empty list"""
-
-                # Used to de-dup errors.
-                already_seen = set()
-
-                ret = []
-                for f in self.__installed_fmris - self.__removal_fmris:
-                        matching = self.__comb_newer_fmris(f, dotrim=True,
-                            obsolete_ok=True)[0]
-                        if matching:
-                                continue
-                        # no matches when disallowed packages are excluded
-                        matching = self.__comb_newer_fmris(f, dotrim=False,
-                            obsolete_ok=True)[0]
-
-                        ret.append(_("No suitable version of installed package "
-                            "{0} found").format(f.pkg_name))
-                        ret.extend(self.__fmri_list_errors(matching,
-                            already_seen=already_seen))
-
-                return ret
-
-        def __fmri_list_errors(self, fmri_list, indent="", already_seen=None,
-            omit=None, verbose=False):
-                """Given a list of FMRIs, return indented strings indicating why
-                they were rejected."""
-                ret = []
-
-                if omit is None:
-                        omit = set()
-
-                fmri_reasons = []
-                skey = operator.attrgetter('pkg_name')
-                for f in sorted(fmri_list, key=skey):
-                        res = self.__fmri_errors(f, indent,
-                            already_seen=already_seen, omit=omit,
-                            verbose=verbose)
-                        # If None was returned, that implies that all of the
-                        # reasons the FMRI was rejected aren't interesting.
-                        if res is not None:
-                                fmri_reasons.append(res)
-
-                last_run = []
-                def collapse_fmris():
-                        """Collapse a range of FMRIs into format:
-
-                           first_fmri
-                             to
-                           last_fmri
-
-                           ...based on verbose state."""
-
-                        if last_run:
-                                indent = last_run.pop(0)
-                                if verbose or len(last_run) <= 1:
-                                        ret.extend(last_run)
-                                elif (not self.__depend_ts and
-                                    ret[-1].endswith(last_run[-1].strip())):
-                                        # If timestamps are not being displayed
-                                        # and the last FMRI is the same as the
-                                        # first in the range then we only need
-                                        # to show the first.
-                                        pass
-                                else:
-                                        ret.append(indent + "  " + _("to"))
-                                        ret.append(last_run[-1])
-                        last_run[::] = []
-
-                last_reason = None
-                for fmri_id, reason in fmri_reasons:
-                        if reason == last_reason:
-                                indent = " " * len(fmri_id[0])
-                                if not last_run:
-                                        last_run.append(indent)
-                                last_run.append(indent + fmri_id[1])
-                                continue
-                        else: # ends run
-                                collapse_fmris()
-                                if last_reason:
-                                        ret.extend(last_reason)
-                                ret.append(fmri_id[0] + fmri_id[1])
-                                last_reason = reason
-                if last_reason:
-                        collapse_fmris()
-                        ret.extend(last_reason)
-                return ret
-
-        def __fmri_errors(self, fmri, indent="", already_seen=None,
-            omit=None, verbose=False):
-                """return a list of strings w/ indents why this fmri is not
-                suitable"""
-
-                if already_seen is None:
-                        already_seen = set()
-                if omit is None:
-                        omit = set()
-
-                fmri_id = [_("{0}  Reject:  ").format(indent)]
-                if not verbose and not self.__depend_ts:
-                        # Exclude build and timestamp for brevity.
-                        fmri_id.append(fmri.get_short_fmri())
-                else:
-                        # Include timestamp for clarity if any dependency
-                        # included a timestamp; exclude build for brevity.
-                        fmri_id.append(fmri.get_fmri(include_build=False))
-
-                tag = _("Reason:")
-
-                if fmri in already_seen:
-                        if fmri in omit:
-                                return
-
-                        # note to translators: 'indent' will be a series of
-                        # whitespaces.
-                        reason = _("{indent}  {tag}  [already rejected; see "
-                            "above]").format(indent=indent, tag=tag)
-                        return fmri_id, [reason]
-
-                already_seen.add(fmri)
-
-                if not verbose:
-                        # By default, omit packages from errors that were only
-                        # rejected due to a newer version being installed, or
-                        # because they didn't match user-specified input.  It's
-                        # tempting to omit _TRIM_REJECT here as well, but that
-                        # leads to some very mysterious errors for
-                        # administrators if the only reason an operation failed
-                        # is because a required dependency was rejected.
-                        for reason_id, reason_t, fmris in \
-                            self.__trim_dict.get(fmri, EmptyI):
-                                if reason_id not in (_TRIM_INSTALLED_NEWER,
-                                    _TRIM_PROPOSED_PUB, _TRIM_PROPOSED_VER):
-                                        break
-                        else:
-                                omit.add(fmri)
-                                return
-
-                ms = []
-                for reason_id, reason_t, fmris in sorted(
-                    self.__trim_dict.get(fmri, EmptyI)):
-
-                        if not verbose:
-                                if reason_id in (_TRIM_INSTALLED_NEWER,
-                                    _TRIM_PROPOSED_PUB, _TRIM_PROPOSED_VER):
-                                        continue
-
-                        if isinstance(reason_t, tuple):
-                                reason = _(reason_t[0]).format(*reason_t[1])
-                        else:
-                                reason = _(reason_t)
-
-                        ms.append("{0}  {1}  {2}".format(indent, tag, reason))
-
-                        if reason in already_seen:
-                                # If we've already explained why something was
-                                # rejected before, skip it.
-                                continue
-
-                        # Use the reason text and not the id, as the text is
-                        # specific to a particular rejection.
-                        already_seen.add(reason)
-
-                        # By default, don't include error output for
-                        # dependencies on incorporation packages that don't
-                        # specify a version since any version-specific
-                        # dependencies will have caused a rejection elsewhere.
-                        if (not verbose and
-                            reason_id == _TRIM_DEP_TRIMMED and
-                            len(reason_t[1]) == 2):
-                                dtype, fstr = reason_t[1]
-                                if dtype == "require" and "@" not in fstr:
-                                        # Assumes fstr does not include
-                                        # publisher or scheme.
-                                        if fstr in self.__known_incs:
-                                                continue
-
-                        # Add the reasons why each package version that
-                        # satisfied a dependency was rejected.
-                        res = self.__fmri_list_errors([
-                                f
-                                for f in sorted(fmris)
-                                if f not in already_seen
-                                if verbose or f not in omit
-                            ],
-                            indent + "  ",
-                            already_seen=already_seen,
-                            omit=omit,
-                            verbose=verbose
-                        )
-
-                        if res:
-                                ms.append(indent + "    " + ("-" * 40))
-                                ms.extend(res)
-                                ms.append(indent + "    " + ("-" * 40))
-
-                return fmri_id, ms
-
-        def __do_error_work(self, fmri, excludes, already_seen):
-                """Private helper function used by __generate_dependency_errors
-                to determine why packages were rejected."""
-
-                needs_processing = set()
-
-                if self.__trim_dict.get(fmri):
-                        return self.__fmri_list_errors([fmri],
-                            already_seen=already_seen), needs_processing
-
-                for a in self.__get_dependency_actions(fmri, excludes):
-                        try:
-                                matching = self.__parse_dependency(a, fmri,
-                                    check_req=True)[1]
-                        except DependencyException as e:
-                                self.__trim((fmri,), e.reason_id, e.reason,
-                                    fmri_adds=e.fmris)
-                                s = _("No suitable version of required package "
-                                    "{0} found:").format(fmri.pkg_name)
-                                return ([s] + self.__fmri_list_errors([fmri],
-                                    already_seen=already_seen),
-                                    set())
-                        needs_processing |= matching
-                return [], needs_processing
-
-        # clause generation routines
-        def __gen_dependency_clauses(self, fmri, da, dotrim=True):
-                """Return clauses to implement this dependency"""
-                nm, m, cond, dtype, _req, _depf = self.__parse_dependency(da,
-                    fmri, dotrim)
-
-                if dtype == "require" or dtype == "require-any":
-                        return self.__gen_require_clauses(fmri, m)
-                elif dtype == "group" or dtype == "group-any":
-                        if not m:
-                                return [] # no clauses needed; pkg avoided
-                        else:
-                                return self.__gen_require_clauses(fmri, m)
-                elif dtype == "conditional":
-                        return self.__gen_require_conditional_clauses(fmri, m,
-                            cond)
-                elif dtype in ["origin", "parent"]:
-                        # handled by trimming proposed set, not by solver
-                        return []
-                else:
-                        return self.__gen_negation_clauses(fmri, nm)
-
-        def __gen_highlander_clauses(self, fmri_list):
-                """Return a list of clauses that specifies only one or zero
-                of the fmris in fmri_list may be installed.  This prevents
-                multiple versions of the same package being installed
-                at once"""
-
-                # pair wise negation
-                # if a has 4 versions, we need
-                # [
-                #  [-a.1, -a.2],
-                #  [-a.1, -a.3],
-                #  [-a.1, -a.4],
-                #  [-a.2, -a.3],
-                #  [-a.2, -a.4],
-                #  [-a.3, -a.4]
-                # ]
-                # n*(n-1)/2 algorithms suck
-
-                if len(fmri_list) == 1: # avoid generation of singletons
-                        return []
-
-                id_list = [ -self.__getid(fmri) for fmri in fmri_list]
-                l = len(id_list)
-
-                return [
-                    [id_list[i], id_list[j]]
-                    for i in range(l-1)
-                    for j in range(i+1, l)
-                ]
-
-        def __gen_require_clauses(self, fmri, matching_fmri_list):
-                """generate clause for require dependency: if fmri is
-                installed, one of fmri_list is required"""
-                # if a.1 requires b.2, b.3 or b.4:
-                # !a.1 | b.2 | b.3 | b.4
-
-                return [
-                    [-self.__getid(fmri)] +
-                    [self.__getid(fmri) for fmri in matching_fmri_list]
-                ]
-
-        def __gen_require_conditional_clauses(self, fmri, matching_fmri_list,
-            conditional_fmri_list):
-                """Generate clauses for conditional dependency: if
-                fmri is installed and one of conditional_fmri_list is installed,
-                one of fmri list is required"""
-                # if a.1 requires c.2, c.3, c.4 if b.2 or newer is installed:
-                # !a.1 | !b.2 | c.2 | c.3 | c.4
-                # !a.1 | !b.3 | c.2 | c.3 | c.4
-                mlist = [self.__getid(f) for f in matching_fmri_list]
-
-                return [
-                    [-self.__getid(fmri)] + [-self.__getid(c)] + mlist
-                    for c in conditional_fmri_list
-                ]
-
-        def __gen_negation_clauses(self, fmri, non_matching_fmri_list):
-                """ generate clauses for optional, incorporate and
-                exclude dependencies to exclude non-acceptable versions"""
-                # if present, fmri must match ok list
-                # if a.1 optionally requires b.3:
-                # [
-                #   [!a.1 | !b.1],
-                #   [!a.1 | !b.2]
-                # ]
-                fmri_id = self.__getid(fmri)
-                return [
-                    [-fmri_id, -self.__getid(f)]
-                    for f in non_matching_fmri_list
-                ]
-
-        def __gen_one_of_these_clauses(self, fmri_list):
-                """generate clauses such that at least one of the fmri_list
-                members gets installed"""
-                # If a has four versions,
-                # a.1|a.2|a.3|a.4
-                # plus highlander clauses
-                assert fmri_list, "Empty list of which one is required"
-                return [[self.__getid(fmri) for fmri in fmri_list]]
-
-        def __addclauses(self, clauses):
-                """add list of clause lists to solver"""
-
-                for c in clauses:
-                        try:
-                                if not self.__solver.add_clause(c):
-                                        self.__addclause_failure = True
-                                self.__clauses += 1
-                        except TypeError:
-                                raise TypeError(_("List of integers, not {0}, "
-                                    "expected").format(c))
-
-        def __get_child_holds(self, install_holds, pkg_cons, inc_set):
-                """Returns the list of installed packages that are incorporated
-                by packages, delivering an install-hold, and that do not have an
-                install-hold but incorporate packages.
-
-                'install_holds' is a dict of installed package stems indicating
-                the pkg.depend.install-hold delivered by the package that are
-                not being removed.
-
-                'pkg_cons' is a dict of installed package fmris and the
-                incorporate constraints they deliver.
-
-                'inc_set' is a list of packages that incorporate other packages
-                and deliver install-hold actions.  It acts as the starting point
-                where we fan out to find "child" packages that incorporate other
-                packages."""
-
-                unprocessed = set(inc_set)
-                processed = set()
-                proc_cons = set()
-                incorps = set()
-
-                while unprocessed:
-                        self.__progress()
-                        ifmri = unprocessed.pop()
-                        processed.add(ifmri)
-
-                        if ifmri in self.__removal_fmris:
-                                # This package will be removed, so
-                                # nothing to do.
-                                continue
-
-                        cons = pkg_cons.get(ifmri, [])
-                        if cons and ifmri.pkg_name not in install_holds:
-                                # If this package incorporates other
-                                # packages and does not deliver an
-                                # install-hold, then consider it a
-                                # 'child' hold.
-                                incorps.add(ifmri)
-
-                        # Find all incorporation constraints that result
-                        # in only one possible match.  If there is only
-                        # one possible match for an incorporation
-                        # constraint then that package will not be
-                        # upgraded and should be checked for
-                        # incorporation constraints.
-                        for con in cons:
-                                if (con.pkg_name in install_holds or
-                                    con in proc_cons):
-                                        # Already handled.
-                                        continue
-                                matching = list(
-                                    self.__comb_auto_fmris(con)[0])
-                                if len(matching) == 1:
-                                        if matching[0] not in processed:
-                                                unprocessed.add(matching[0])
-                                else:
-                                        # Track which constraints have
-                                        # already been processed
-                                        # seperately from which
-                                        # package FMRIs have been
-                                        # processed to avoid (unlikely)
-                                        # collision.
-                                        proc_cons.add(con)
-
-                return incorps
-
-        def __get_installed_upgradeable_incorps(self, excludes=EmptyI):
-                """Return the latest version of installed upgradeable
-                incorporations w/ install holds"""
-
-                installed_incs = []
-                for f in self.__installed_fmris - self.__removal_fmris:
-                        for d in self.__catalog.get_entry_actions(f,
-                            [catalog.Catalog.DEPENDENCY], excludes=excludes):
-                                if (d.name == "set" and d.attrs["name"] ==
-                                    "pkg.depend.install-hold"):
-                                        installed_incs.append(f)
-
-                ret = []
-                for f in installed_incs:
-                        matching = self.__comb_newer_fmris(f, dotrim=False)[0]
-                        latest = sorted(matching, reverse=True)[0]
-                        if latest != f:
-                                ret.append(latest)
-                return ret
-
-        def __get_installed_unbound_inc_list(self, proposed_pkgs,
-            excludes=EmptyI):
-                """Return the list of incorporations that are to not to change
-                during this install operation, and the lists of fmris they
-                constrain."""
-
-                incorps = set()
-                versioned_dependents = set()
-                pkg_cons = {}
-                install_holds = {}
-
-                # Determine installed packages that contain incorporation
-                # dependencies, those packages that are depended on by explict
-                # version, and those that have pkg.depend.install-hold values.
-                for f in self.__installed_fmris - self.__removal_fmris:
-                        for d in self.__catalog.get_entry_actions(f,
-                            [catalog.Catalog.DEPENDENCY],
-                            excludes=excludes):
-                                if d.name == "depend":
-                                        fmris = []
-                                        for fl in d.attrlist("fmri"):
-                                                try:
-                                                        tmp = self.__fmridict[
-                                                            fl]
-                                                except KeyError:
-                                                        tmp = pkg.fmri.PkgFmri(
-                                                            fl)
-                                                        self.__fmridict[fl] = \
-                                                            tmp
-                                                fmris.append(tmp)
-                                        if d.attrs["type"] == "incorporate":
-                                                incorps.add(f.pkg_name)
-                                                pkg_cons.setdefault(f,
-                                                    []).append(fmris[0])
-                                        versioned_dependents.update(
-                                            fmri.pkg_name
-                                            for fmri in fmris
-                                            if fmri.version is not None
-                                        )
-                                elif (d.name == "set" and d.attrs["name"] ==
-                                    "pkg.depend.install-hold"):
-                                        install_holds[f.pkg_name] = \
-                                            d.attrs["value"]
-
-                # find install holds that appear on command line and are thus
-                # relaxed
-                relaxed_holds = set([
-                    install_holds[name]
-                    for name in proposed_pkgs
-                    if name in install_holds
-                ])
-
-                # add any other install holds that are relaxed because they have
-                # values that start w/ the relaxed ones...
-                relaxed_holds |= set([
-                    hold
-                    for hold in six.itervalues(install_holds)
-                    if [ r for r in relaxed_holds if hold.startswith(r + ".") ]
-                ])
-
-                # Expand the list of install holds to include packages that are
-                # incorporated by packages delivering an install-hold and that
-                # do not have an install-hold, but incorporate packages.
-                child_holds = self.__get_child_holds(install_holds, pkg_cons,
-                    set(inc for inc in pkg_cons
-                        if inc.pkg_name in install_holds and
-                        install_holds[inc.pkg_name] not in relaxed_holds
+                        for da in self.__get_dependency_actions(f, excludes)
+                        if da.attrs["type"] == "conditional"
+                        or da.attrs["type"] == "group"
+                        or da.attrs["type"] == "require"
+                    )
+                    if dtype != "group"
+                    or (
+                        dname not in self.__avoid_set
+                        and dname not in self.__reject_set
                     )
                 )
 
-                for child_hold in child_holds:
-                        assert child_hold.pkg_name not in install_holds
-                        install_holds[child_hold.pkg_name] = child_hold.pkg_name
-
-                # versioned_dependents contains all the packages that are
-                # depended on w/ a explicit version.  We now modify this list so
-                # that it does not contain any packages w/ install_holds, unless
-                # those holds were relaxed.
-                versioned_dependents -= set([
-                    pkg_name
-                    for pkg_name, hold_value in six.iteritems(install_holds)
-                    if hold_value not in relaxed_holds
-                ])
-                # Build the list of fmris that 1) contain incorp. dependencies
-                # 2) are not in the set of versioned_dependents and 3) do not
-                # explicitly appear on the install command line.
-                installed_dict = self.__installed_dict
-                ret = [
-                    installed_dict[pkg_name]
-                    for pkg_name in incorps - versioned_dependents
-                    if pkg_name not in proposed_pkgs
-                    if installed_dict[pkg_name] not in self.__removal_fmris
-                ]
-                # For each incorporation above that will not change, return a
-                # list of the fmris that incorporation constrains
-                con_lists = [
-                    [ i for i in pkg_cons[inc] ]
-                    for inc in ret
-                ]
-
-                return ret, con_lists
-
-        def __mark_pub_trimmed(self, pkg_name):
-                """Record that a given package stem has been trimmed based on
-                publisher."""
-
-                self.__pub_trim[pkg_name] = True
-
-        def __filter_publishers(self, pkg_name):
-                """Given a list of fmris for various versions of
-                a package from various publishers, trim those
-                that are not suitable"""
-
-                if pkg_name in self.__pub_trim: # already done
-                        return
-                self.__mark_pub_trimmed(pkg_name)
-
-                fmri_list = self.__get_catalog_fmris(pkg_name)
-
-                if pkg_name in self.__publisher:
-                        acceptable_pubs = [self.__publisher[pkg_name]]
-                        if pkg_name in self.__installed_dict:
-                                reason_id = _TRIM_PUB_STICKY
-                                reason = (N_("Currently installed package "
-                                    "'{0}' is from sticky publisher '{1}'."),
-                                    (pkg_name, self.__publisher[pkg_name]))
-                        else:
-                                reason_id = _TRIM_PROPOSED_PUB
-                                reason = N_("Package is from publisher other "
-                                    "than specified one.")
+                if comm_deps is None:
+                    comm_deps = prop_deps
                 else:
-                        # order by pub_rank; choose highest possible tier for
-                        # pkgs; guard against unconfigured publishers in known
-                        # catalog
-                        pubs_found = set((f.publisher for f in fmri_list))
-                        ranked = sorted([
-                            (self.__pub_ranks[p][0], p)
-                            for p in pubs_found
-                            if self.__pub_ranks.get(p, (0, False, False))[2]
-                        ])
-                        acceptable_pubs = [
-                            r[1]
-                            for r in ranked
-                            if r[0] == ranked[0][0]
-                        ]
-                        reason_id = _TRIM_PUB_RANK
-                        if acceptable_pubs:
-                                reason = (N_("Higher ranked publisher {0} was "
-                                    "selected"), (acceptable_pubs[0],))
-                        else:
-                                reason = N_("Package publisher is ranked lower "
-                                    "in search order")
+                    comm_deps &= prop_deps
 
-                # allow installed packages to co-exist to meet dependency reqs.
-                # in case new publisher not proper superset of original.  avoid
-                # multiple publishers w/ the exact same fmri to prevent
-                # thrashing in the solver due to many equiv. solutions.
-                inst_f = self.__installed_dict.get(pkg_name)
-                self.__trim([
-                    f
-                    for f in fmri_list
-                    if (f.publisher not in acceptable_pubs and
-                            (not inst_f or f != inst_f)) or
-                        (inst_f and f.publisher != inst_f.publisher and
-                            f.version == inst_f.version)
-                ], reason_id, reason)
+            if comm_deps:
+                req_dep_names |= comm_deps
 
-        # routines to manage the trim dictionary
-        # trim dictionary contains the reasons an fmri was rejected for
-        # consideration reason is a tuple of a string w/ format chars and args,
-        # or just a string.  fmri_adds are any fmris that caused the rejection
+        self.__req_pkg_names = frozenset(req_dep_names | self.__req_pkg_names)
 
-        def __trim(self, fmri_list, reason_id, reason, fmri_adds=EmptyI):
-                """Remove specified fmri(s) from consideration for specified
-                reason."""
+    def __update_possible_closure(
+        self,
+        possible,
+        excludes,
+        full_trim=False,
+        filter_explicit=True,
+        proposed_dict=None,
+    ):
+        """Update the provided possible set of fmris with the transitive
+        closure of dependencies that can be satisfied, trimming those
+        packages that cannot be installed.
 
-                self.__progress()
-                assert reason_id in range(_TRIM_MAX)
+        'possible' is a set of FMRI objects representing all possible
+        versions of packages to consider for the operation.
 
-                # XXX - determine whether this block is still necessary
-                # - was introduced in 51ff33eef0f3fdaf9954afeeabedd3f842008b50
-                # and subsequently moved.
+        'full_trim' is an optional boolean indicating whether a full
+        trim of the dependency graph should be performed.  This is NOT
+        required for the solver to find a solution.  Trimming is only
+        needed to reduce the size of clauses and to provide error
+        messages.  This requires multiple passes to determine if the
+        transitive closure of dependencies can be satisfied.  This is
+        not required for correctness (and it greatly increases runtime).
+        However, it does greatly improve error messaging for some error
+        cases.
 
-                # There's ugly issue when we receive reason having set of fmris
-                # with require-any dependencies, which differentiate only by
-                # timestamp. In this case add operation fails. The workaround
-                # is to add only the first dependency to the trim dictionary.
-                #if (type(reason[1]) is tuple and len(reason[1])>1 and
-                #    type(reason[1][1]) is list and len(reason[1][1])>=1):
-                #        reason=(reason[0],(reason[1][0],reason[1][1][0]))
+        'filter_explicit' is an optional boolean indicating whether
+        packages with pkg.depend.explicit-install set to true will be
+        filtered out.
 
-                tup = (reason_id, reason, frozenset(fmri_adds))
+        'proposed_dict' contains user specified FMRI objects indexed by
+        pkg_name that should be installed or updated within an image.
 
-                for fmri in fmri_list:
-                        self.__trim_dict[fmri].add(tup)
+        An example of a case where full_trim will be useful (dueling
+        incorporations):
 
-        def __trim_older(self, fmri):
-                """Trim any fmris older than this one"""
-                reason = (N_("Newer version {0} is already installed"), (fmri,))
-                self.__trim(self.__comb_newer_fmris(fmri, dotrim=False)[1] -
-                    self.__allowed_downgrades, _TRIM_INSTALLED_NEWER, reason)
+        Installed:
+          entire
+            incorporates java-7-incorporation
+        Proposed:
+          osnet-incorporation
+            incorporates system/resource-mgmt/dynamic-resource-pools
+          system/resource-mgmt/dynamic-resource-pools
+            requires new version of java not allowed by installed
+              java-7-incorporation"""
 
-        def __trim_nonmatching_variants(self, fmri):
-                """Trim packages that don't support image architecture or other
-                image variant."""
+        first = True
+        while True:
+            tsize = len(self.__trim_dict)
+            res = self.__generate_dependency_closure(
+                possible,
+                excludes=excludes,
+                full_trim=full_trim,
+                filter_explicit=filter_explicit,
+                proposed_dict=proposed_dict,
+            )
+            if first:
+                # The first pass will return the transitive
+                # closure of all dependencies; subsequent passes
+                # are only done for trimming, so need to update
+                # the possible set only on first pass.
+                possible.update(res)
+                first = False
 
-                vd = self.__get_variant_dict(fmri)
-                reason = ""
+            nsize = len(self.__trim_dict)
+            if not full_trim or nsize == tsize:
+                # Nothing more to trim.
+                break
 
-                for v in self.__variants.keys():
-                        if v in vd and self.__variants[v] not in vd[v]:
-                                if vd == "variant.arch":
-                                        reason = N_("Package doesn't support "
-                                            "image architecture")
-                                else:
-                                        reason = (N_("Package supports image "
-                                            "variant {0}={1} but doesn't "
-                                            "support this image's {0}={2}"),
-                                            (v, str(vd[v]),
-                                            str(self.__variants[v])))
+        # Remove trimmed items from possible_set.
+        possible.difference_update(six.iterkeys(self.__trim_dict))
 
-                                self.__trim((fmri,), _TRIM_VARIANT, reason)
-                return reason == ""
+    def __enforce_unique_packages(self, excludes):
+        """Constrain the solver solution so that only one version of
+        each package can be installed and generate dependency clauses
+        for possible packages."""
 
-        def __trim_nonmatching_parents1(self, pkg_fmri, fmri):
-                """Private helper function for __trim_nonmatching_parents that
-                trims any pkg_fmri that matches a parent dependency and that is
-                not installed in the parent image, that is from a different
-                publisher than the parent image, or that is a different version
-                than the parent image."""
+        # Generate clauses for only one version of each package, and
+        # for dependencies for each package.  Do so for all possible
+        # fmris.
+        for name in self.__possible_dict:
+            self.__progress()
+            # Ensure only one version of a package is installed
+            self.__addclauses(
+                self.__gen_highlander_clauses(self.__possible_dict[name])
+            )
+            # generate dependency clauses for each pkg
+            for fmri in self.__possible_dict[name]:
+                for da in self.__get_dependency_actions(
+                    fmri, excludes=excludes
+                ):
+                    self.__addclauses(self.__gen_dependency_clauses(fmri, da))
 
-                if fmri in self.__parent_pkgs:
-                        # exact fmri installed in parent
-                        return True
+    def __generate_operation_clauses(self, proposed=None, proposed_dict=None):
+        """Generate initial solver clauses for the proposed packages (if
+        any) and installed packages.
 
-                if fmri.pkg_name not in self.__parent_dict:
-                        # package is not installed in parent
-                        if self.__is_zone():
-                                reason = (N_("Package {0} is not installed in "
-                                    "global zone."), (fmri.pkg_name,))
-                        else:
-                                reason = (N_("Package {0} is not installed in "
-                                    "parent image."), (fmri.pkg_name,))
-                        self.__trim((pkg_fmri,), _TRIM_PARENT_MISSING, reason)
-                        return False
+        'proposed' is a set of FMRI objects representing packages to
+        install or update.
 
-                pf = self.__parent_dict[fmri.pkg_name]
-                if fmri.publisher and fmri.publisher != pf.publisher:
-                        # package is from a different publisher in the parent
-                        if self.__is_zone():
-                                reason = (N_("Package in global zone is from "
-                                    "a different publisher: {0}"), (pf,))
-                        else:
-                                reason = (N_("Package in parent is from a "
-                                    "different publisher: {0}"), (pf,))
-                        self.__trim((pkg_fmri,), _TRIM_PARENT_PUB, reason)
-                        return False
+        'proposed_dict' contains user specified FMRI objects indexed by
+        pkg_name that should be installed or updated within an image."""
 
-                if pf.version == fmri.version:
-                        # parent dependency is satisfied, which applies to both
-                        # DEPEND_SELF and other cases
-                        return True
-                elif (pkg_fmri != fmri and
-                    pf.version.is_successor(fmri.version,
-                        version.CONSTRAINT_NONE)):
-                        # *not* DEPEND_SELF; parent dependency is satisfied
-                        return True
+        assert (proposed is None and proposed_dict is None) or (
+            proposed is not None and proposed_dict is not None
+        )
 
-                # version mismatch
-                if pf.version.is_successor(fmri.version,
-                    version.CONSTRAINT_NONE):
-                        reason_id = _TRIM_PARENT_NEWER
-                        if self.__is_zone():
-                                reason = (N_("Global zone has a "
-                                    "newer version: {0}"), (pf,))
-                        else:
-                                reason = (N_("Parent image has a "
-                                    "newer version: {0}"), (pf,))
-                else:
-                        reason_id = _TRIM_PARENT_OLDER
-                        if self.__is_zone():
-                                reason = (N_("Global zone has an older "
-                                    "version of package: {0}"), (pf,))
-                        else:
-                                reason = (N_("Parent image has an older "
-                                    "version of package: {0}"), (pf,))
+        if proposed is None:
+            proposed = set()
+        if proposed_dict is None:
+            proposed_dict = EmptyDict
 
-                self.__trim((pkg_fmri,), reason_id, reason)
-                return False
+        # Generate clauses for proposed and installed pkgs note that we
+        # create clauses that require one of the proposed pkgs to work;
+        # this allows the possible_set to always contain the existing
+        # pkgs.
+        for name in proposed_dict:
+            self.__progress()
+            self.__addclauses(
+                self.__gen_one_of_these_clauses(
+                    set(proposed_dict[name]) & set(self.__possible_dict[name])
+                )
+            )
 
-        def __trim_nonmatching_parents(self, pkg_fmri, excludes,
-            ignore_inst_parent_deps=False):
-                """Trim any pkg_fmri that contains a parent dependency that
-                is not satisfied by the parent image."""
+        for name in (
+            self.__installed_pkgs
+            - proposed
+            - self.__reject_set
+            - self.__avoid_set
+        ):
+            self.__progress()
 
-                # the fmri for the package should include a publisher
-                assert pkg_fmri.publisher
+            if self.__installed_dict[name] in self.__removal_fmris:
+                # we're uninstalling this package
+                continue
 
-                # if we're not a child then ignore "parent" dependencies.
-                if not self.__is_child():
-                        return True
+            if name in self.__possible_dict:
+                self.__addclauses(
+                    self.__gen_one_of_these_clauses(self.__possible_dict[name])
+                )
 
-                # check if we're ignoring parent dependencies for installed
-                # packages.
-                if ignore_inst_parent_deps and \
-                    pkg_fmri in self.__installed_fmris:
-                        return True
+    def __begin_solve(self):
+        """Prepares solver for solution creation returning a
+        ProgressTracker object to be used for the operation."""
 
-                # Find all the fmris that we depend on in our parent.
-                # Use a set() to eliminate any dups.
-                pkg_deps = set([
-                    pkg.fmri.PkgFmri(f)
-                    for da in self.__get_dependency_actions(pkg_fmri, excludes)
+        # Once solution has been returned or failure has occurred, a new
+        # solver must be used.
+        assert self.__state == SOLVER_INIT
+        self.__state = SOLVER_OXY
+
+        pt = self.__progtrack
+        # Check to see if we were invoked by solve_uninstall, in
+        # which case we don't want to restart what we've already
+        # started.
+        if self.__progitem is None:
+            self.__progitem = pt.PLAN_SOLVE_SETUP
+            pt.plan_start(pt.PLAN_SOLVE_SETUP)
+        self.__start_subphase(1, reset=True)
+
+        return pt
+
+    def __end_solve(self, solution, excludes):
+        """Returns the solution result to the caller after completing
+        all necessary solution cleanup."""
+
+        pt = self.__progtrack
+        self.__end_subphase()  # end the last subphase.
+        pt.plan_done(pt.PLAN_SOLVE_SOLVER)
+        return self.__cleanup(
+            (
+                self.__elide_possible_renames(solution, excludes),
+                (self.__avoid_set, self.__implicit_avoid_set, self.__obs_set),
+            )
+        )
+
+    def __assert_installed_allowed(self, excludes, proposed=None):
+        """Raises a PlanCreationException if the proposed operation
+        would require the removal of installed packages that are not
+        marked for removal by the proposed operation."""
+
+        if proposed is None:
+            proposed = set()
+
+        uninstall_fmris = []
+        for name in (
+            self.__installed_pkgs
+            - proposed
+            - self.__reject_set
+            - self.__avoid_set
+        ):
+            self.__progress()
+
+            if self.__installed_dict[name] in self.__removal_fmris:
+                # we're uninstalling this package
+                continue
+
+            if name in self.__possible_dict:
+                continue
+
+            # no version of this package is allowed
+            uninstall_fmris.append(self.__installed_dict[name])
+
+        # Used to de-dup errors.
+        already_seen = set()
+        ret = []
+        msg = N_(
+            "Package '{0}' must be uninstalled or upgraded "
+            "if the requested operation is to be performed."
+        )
+
+        # First check for solver failures caused by missing parent
+        # dependencies.  We do this because missing parent dependency
+        # failures cause other cascading failures, so it's better to
+        # just emit these failures first, have the user fix them, and
+        # have them re-run the operation, so then we can provide more
+        # concise error output about other problems.
+        for fmri in uninstall_fmris:
+            # Unused variable; pylint: disable=W0612
+            for reason_id, reason_t, fmris in self.__trim_dict.get(
+                fmri, EmptyI
+            ):
+                if reason_id == _TRIM_PARENT_MISSING:
+                    break
+            else:
+                continue
+            res = self.__fmri_list_errors([fmri], already_seen=already_seen)
+            assert res
+            ret.extend([msg.format(fmri.pkg_name)])
+            ret.extend(res)
+
+        if ret:
+            self.__raise_solution_error(no_version=ret)
+
+        for fmri in uninstall_fmris:
+            flist = [fmri]
+            if fmri in self.__linked_pkgs:
+                depend_self = any(
+                    da
+                    for da in self.__get_dependency_actions(fmri, excludes)
                     if da.attrs["type"] == "parent"
-                    for f in da.attrlist("fmri")
-                ])
+                    and pkg.actions.depend.DEPEND_SELF in da.attrlist("fmri")
+                )
 
-                if not pkg_deps:
-                        # no parent dependencies.
-                        return True
-                self.__linked_pkgs.add(pkg_fmri)
+                if depend_self:
+                    pf = self.__parent_dict.get(fmri.pkg_name)
+                    if pf and pf != fmri:
+                        # include parent's version of
+                        # parent-constrained packages in
+                        # error messaging for clarity if
+                        # different
+                        flist.append(pf)
 
-                allowed = True
-                for f in pkg_deps:
-                        fmri = f
-                        if f.pkg_name == pkg.actions.depend.DEPEND_SELF:
-                                # check if this package depends on itself.
-                                fmri = pkg_fmri
-                        if not self.__trim_nonmatching_parents1(pkg_fmri, fmri):
-                                allowed = False
-                return allowed
+            res = self.__fmri_list_errors(flist, already_seen=already_seen)
 
-        def __trim_nonmatching_origins(self, fmri, excludes,
-            exact_install=False, installed_dict_tmp=EmptyDict):
-                """Trim any fmri that contains a origin dependency that is
-                not satisfied by the current image or root-image"""
+            # If no errors returned, that implies that all of the
+            # reasons the FMRI was rejected aren't interesting.
+            if res:
+                ret.extend([msg.format(fmri.pkg_name)])
+                ret.extend(res)
 
-                for da in self.__get_dependency_actions(fmri, excludes):
-                        if da.attrs["type"] != "origin":
-                                continue
+        if ret:
+            self.__raise_solution_error(no_version=ret)
 
-                        req_fmri = pkg.fmri.PkgFmri(da.attrs["fmri"])
+    def __assert_trim_errors(
+        self, possible_set, excludes, proposed=None, proposed_dict=None
+    ):
+        """Raises a PlanCreationException if any further trims would
+        prevent the installation or update of proposed or
+        installed/required packages.
 
-                        if da.attrs.get("root-image", "").lower() == "true":
-                                if req_fmri.pkg_name.startswith(
-                                    "feature/firmware/"):
-                                        # this is a firmware dependency
-                                        fw_ok, reason = \
-                                            self.__firmware.check_firmware(da,
-                                            req_fmri.pkg_name)
-                                        if not fw_ok:
-                                                self.__trim((fmri,),
-                                                    _TRIM_FIRMWARE, reason)
-                                                return False
-                                        continue
+        'proposed' is an optional set of FMRI objects representing
+        packages to install or update.
 
-                                if self.__root_fmris is None:
-                                        img = pkg.client.image.Image(
-                                            misc.liveroot(),
-                                            allow_ondisk_upgrade=False,
-                                            user_provided_dir=True,
-                                            should_exist=True)
-                                        self.__root_fmris = dict([
-                                            (f.pkg_name, f)
-                                            for f in img.gen_installed_pkgs()
-                                        ])
+        'proposed_dict' contains user specified FMRIs indexed by
+        pkg_name that should be installed within an image.
 
-                                installed = self.__root_fmris.get(
-                                    req_fmri.pkg_name)
-                                reason_id = _TRIM_INSTALLED_ROOT_ORIGIN
-                                reason = (N_("Installed version in root image "
-                                    "is too old for origin " "dependency {0}"),
-                                    (req_fmri,))
-                        else:
-                                # Always use the full installed dict for origin
-                                # dependency.
-                                if exact_install:
-                                        installed = installed_dict_tmp.get(
-                                            req_fmri.pkg_name)
-                                else:
-                                        installed = self.__installed_dict.get(
-                                            req_fmri.pkg_name)
-                                reason_id = _TRIM_INSTALLED_ORIGIN
-                                reason = (N_("Installed version in image "
-                                    "being upgraded is too old for origin "
-                                    "dependency {0}"), (req_fmri,))
+        'possible_set' is the set of FMRIs potentially allowed for use
+        in the proposed operation."""
 
-                        # assumption is that for root-image, publishers align;
-                        # otherwise these sorts of cross-environment
-                        # dependencies don't work well
+        # make sure all package trims appear
+        self.__trimdone = False
 
-                        if (not installed or not req_fmri.version or
-                            req_fmri.version == installed.version or
-                            installed.version.is_successor(req_fmri.version,
-                                version.CONSTRAINT_NONE)):
-                                continue
+        # Ensure required dependencies of proposed packages are flagged
+        # to improve error messaging when parsing the transitive
+        # closure of all dependencies.
+        self.__set_proposed_required(proposed_dict, excludes)
 
-                        self.__trim((fmri,), reason_id, reason)
+        # First, perform a full trim of the package version space; this
+        # is normally skipped for performance reasons as it's not
+        # required for correctness.
+        self.__update_possible_closure(
+            possible_set,
+            excludes,
+            full_trim=True,
+            filter_explicit=False,
+            proposed_dict=proposed_dict,
+        )
 
-                        return False
-                return True
+        # Now try re-asserting that proposed (if any) and installed
+        # packages are allowed after the trimming; these calls will
+        # raise an exception if all the proposed or any of the
+        # installed/required packages are trimmed.
+        self.__set_proposed_required(proposed_dict, excludes)
+        self.__trim_proposed(proposed_dict)
+        self.__assign_possible(possible_set)
+        self.__assert_installed_allowed(excludes, proposed=proposed)
 
-        def __trim_unsupported(self, fmri):
-                """Indicate given package FMRI is unsupported."""
-                self.__trim((fmri,), _TRIM_UNSUPPORTED,
-                    N_("Package contains invalid or unsupported actions"))
+    def __raise_install_error(
+        self, exp, inc_list, proposed_dict, possible_set, excludes
+    ):
+        """Private logic for solve_install() to process a
+        PlanCreationException and re-raise as appropriate.
 
-        def __get_older_incorp_pkgs(self, fmri, install_holds, excludes=EmptyI,
-            relax_all=False, depth=0):
-                """Get all incorporated pkgs for the given 'fmri' whose versions
-                are older than what is currently installed in the image."""
+        'exp' is the related exception object raised by the solver when
+        no solution was found.
 
-                candidates = set()
-                if fmri in self.__dg_incorp_cache:
-                        candidates |= self.__dg_incorp_cache[fmri]
-                        return candidates
+        'inc_list' is a list of package FMRIs representing installed
+        incorporations that are being maintained.
 
-                if depth > 10:
-                        # Safeguard against circular dependencies.
-                        # If it happens, just end the recursion tree.
-                        return candidates
+        'proposed_dict' contains user specified FMRIs indexed by
+        pkg_name that should be installed within an image.
 
-                self.__dg_incorp_cache[fmri] = set()
-                self.__progress()
+        'possible_set' is the set of FMRIs potentially allowed for use
+        in the proposed operation.
+        """
 
-                # Get all matching incorporated packages for this fmri; this is
-                # a list of sets, where each set represents all of the fmris
-                # matching the incorporate dependency for a single package stem.
-                # 
-                # Only add potential FMRIs to the list of allowed downgrades if
-                # the currently installed version is not allowed by the related
-                # incorporate dependency.  This prevents two undesirable
-                # behaviours:
-                #
-                # - downgrades when a package is no longer incorporated in
-                #   a newer version of an incorporating package and an older
-                #   version is otherwise allowed
-                # - upgrades of packages that are no longer incorporated
-                #   in a newer version of an incorporating package and a newer
-                #   version is otherwise allowed
-                for matchdg, nonmatchdg in six.itervalues(self.__get_incorp_nonmatch_dict(fmri,
-                    excludes)):
-                        match = next(iter(matchdg), None)
-                        if (not match or
-                            match.pkg_name not in self.__installed_dict):
-                                continue
+        # Before making a guess, apply extra trimming to see if we can
+        # reject the operation based on changing packages.
+        self.__assert_trim_errors(
+            possible_set, excludes, proposed_dict=proposed_dict
+        )
 
-                        inst_fmri = self.__installed_dict[match.pkg_name]
-                        if inst_fmri in matchdg:
-                                continue
+        # Despite all of the trimming done, we still don't know why the
+        # solver couldn't find a solution, so make a best effort guess
+        # at the reason why.
+        info = []
+        incs = []
 
-                        inst_ver = inst_fmri.version
-                        for df in matchdg:
-                                if df.version == inst_ver:
-                                        # If installed version is not changing,
-                                        # there is no need to check for
-                                        # downgraded incorporate deps.
-                                        continue
+        incs.append("")
+        if inc_list:
+            incs.append("maintained incorporations:")
+            skey = operator.attrgetter("pkg_name")
+            for il in sorted(inc_list, key=skey):
+                incs.append("  {0}".format(il.get_short_fmri()))
+        else:
+            incs.append("maintained incorporations: None")
+        incs.append("")
 
-                                is_successor = df.version.is_successor(inst_ver,
-                                    None)
-                                if relax_all and is_successor:
-                                        # If all install-holds are relaxed, and
-                                        # this package is being upgraded, it is
-                                        # not a downgrade candidate and there is
-                                        # no need to recursively check for
-                                        # downgraded incorporate deps here as
-                                        # will be checked directly later in
-                                        # solve_update_all.
-                                        continue
+        ms = self.__generate_dependency_errors(
+            [b for a in proposed_dict.values() for b in a], excludes=excludes
+        )
+        if ms:
+            info.append("")
+            info.append(
+                _("Plan Creation: dependency error(s) in " "proposed packages:")
+            )
+            info.append("")
+            for s in ms:
+                info.append("  {0}".format(s))
 
-                                # Do not allow implicit publisher switches.
-                                if df.publisher != fmri.publisher:
-                                        continue
+        ms = self.__check_installed()
+        if ms:
+            info.append("")
+            info.append(
+                _(
+                    "Plan Creation: Errors in installed "
+                    "packages due to proposed changes:"
+                )
+            )
+            info.append("")
+            for s in ms:
+                info.append("  {0}".format(s))
 
-                                # Do not allow pkgs marked for removal.
-                                if fmri in self.__removal_fmris:
-                                        continue
+        if not info:  # both error detection methods insufficent.
+            info.append(
+                _(
+                    "Plan Creation: Package solver is "
+                    "unable to compute solution."
+                )
+            )
+            info.append(
+                _("Dependency analysis is unable to " "determine exact cause.")
+            )
+            info.append(
+                _(
+                    "Try running with -vv to "
+                    "obtain more detailed error messages."
+                )
+            )
+        exp.no_solution = incs + info
 
-                                # Do not allow pkgs with install-holds but filter out
-                                # child holds
-                                install_hold = False
-                                for ha in [
-                                    sa
-                                    for sa in self.__get_actions(df, "set")
-                                    if sa.attrs["name"] ==
-                                        "pkg.depend.install-hold"
-                                ]:
-                                        install_hold = True
-                                        for h in install_holds:
-                                                if ha.attrs["value"].startswith(
-                                                    h):
-                                                        # This is a child hold
-                                                        # of an incorporating
-                                                        # pkg, ignore.
-                                                        install_hold = False
-                                                        break
-                                        if not install_hold:
-                                                break
-                                if install_hold:
-                                        continue
+        # Value 'DebugValues' is unsubscriptable;
+        # pylint: disable=E1136
+        if DebugValues["plan"]:
+            exp.solver_errors = self.get_trim_errors()
+        raise exp
 
-                                if not is_successor:
-                                        self.__dg_incorp_cache[fmri].add(df)
-                                        candidates.add(df)
+    def add_triggered_op(self, trigger_op, exec_op, fmris):
+        """Add the set of FMRIs in 'fmris' to the internal dict of
+        pkg-actuators. 'trigger_op' is the operation which triggered
+        the pkg change, 'exec_op' is the operation which is supposed to
+        be executed."""
 
-                                if not relax_all:
-                                        # If all install-holds are not relaxed,
-                                        # then we need to check if pkg has
-                                        # incorporate deps of its own since not
-                                        # every package is being checked
-                                        # individually.
-                                        candidates |= \
-                                            self.__get_older_incorp_pkgs(df,
-                                                install_holds,
-                                                excludes=excludes,
-                                                relax_all=relax_all,
-                                                depth=depth + 1)
+        assert (
+            trigger_op in self.__triggered_ops
+        ), "{0} is " "not a valid trigger op for pkg actuators".format(
+            trigger_op
+        )
+        assert (
+            exec_op in self.__triggered_ops[trigger_op]
+        ), "{0} is " "not a valid execution op for pkg actuators".format(
+            exec_op
+        )
+        assert isinstance(fmris, set)
 
-                return candidates
+        self.__triggered_ops[trigger_op][exec_op] |= fmris
 
-        def __allow_incorp_downgrades(self, fmri, excludes=EmptyI,
-            relax_all=False):
-                """Find packages which have lower versions than installed but
-                are incorporated by a package in the proposed list."""
+    def solve_install(
+        self,
+        existing_freezes,
+        proposed_dict,
+        new_variants=None,
+        excludes=EmptyI,
+        reject_set=frozenset(),
+        trim_proposed_installed=True,
+        relax_all=False,
+        ignore_inst_parent_deps=False,
+        exact_install=False,
+        installed_dict_tmp=EmptyDict,
+    ):
+        """Logic to install packages, change variants, and/or change
+        facets.
 
-                install_holds = set([
-                    sa.attrs["value"]
-                    for sa in self.__get_actions(fmri, "set")
-                    if sa.attrs["name"] == "pkg.depend.install-hold"
-                ])
+        Returns FMRIs to be installed / upgraded in system and a new
+        set of packages to be avoided.
 
-                # Get all pkgs which are incorporated by 'fmri',
-                # including nested incorps.
-                candidates = self.__get_older_incorp_pkgs(fmri, install_holds,
-                    excludes=excludes, relax_all=relax_all)
+        'existing_freezes' is a list of incorp. style FMRIs that
+        constrain package motion.
 
-                return candidates
+        'proposed_dict' contains user specified FMRIs indexed by
+        pkg_name that should be installed within an image.
 
-        def __dotrim(self, fmri_list):
-                """Return fmri_list trimmed of any fmris in self.__trim_dict"""
+        'new_variants' a dictionary containing variants which are
+        being updated.  (It should not contain existing variants which
+        are not changing.)
 
-                return [
+        'reject_set' contains user specified package names that should
+        not be present within the final image.  (These packages may or
+        may not be currently installed.)
+
+        'trim_proposed_installed' is a boolean indicating whether the
+        solver should elide versions of proposed packages older than
+        those installed from the set of possible solutions.  If False,
+        package downgrades are allowed, but only for installed
+        packages matching those in the proposed_dict.
+
+        'relax_all' indicates if the solver should relax all install
+        holds, or only install holds specified by proposed packages.
+
+        'ignore_inst_parent_deps' indicates if the solver should
+        ignore parent dependencies for installed packages.  This
+        allows us to modify images with unsatisfied parent
+        dependencies (i.e., out-of-sync images).  Any packaging
+        operation which needs to guarantee that we have an in-sync
+        image (for example, sync-linked operations, or any recursive
+        packaging operations) should NOT enable this behavior.
+
+        'exact_install' is a flag to indicate whether we treat the
+        current image as an empty one. Any previously installed
+        packages that are not either specified in proposed_dict or
+        are a dependency (require, origin and parent dependencies)
+        of those packages will be removed.
+
+        'installed_dict_tmp' a dictionary containing the current
+        installed FMRIs indexed by pkg_name. Used when exact_install
+        is on."""
+
+        pt = self.__begin_solve()
+
+        # reject_set is a frozenset(), need to make copy to modify
+        r_set = set(reject_set)
+        for f in self.__triggered_ops[PKG_OP_UNINSTALL][PKG_OP_UPDATE]:
+            if f.pkg_name in proposed_dict:
+                proposed_dict[f.pkg_name].append(f)
+            else:
+                proposed_dict[f.pkg_name] = [f]
+        for f in self.__triggered_ops[PKG_OP_UNINSTALL][PKG_OP_UNINSTALL]:
+            r_set.add(f.pkg_name)
+        # re-freeze reject set
+        reject_set = frozenset(r_set)
+
+        proposed_pkgs = set(proposed_dict)
+
+        if new_variants:
+            self.__variants = new_variants
+
+            #
+            # Entire packages can be tagged with variants thereby
+            # making those packages uninstallable in certain
+            # images.  So if we're changing variants such that
+            # some currently installed packages are becoming
+            # uninstallable add them to the removal package set.
+            #
+            for f in self.__installed_fmris:
+                d = self.__get_variant_dict(f)
+                for k in new_variants:
+                    if k in d and new_variants[k] not in d[k]:
+                        self.__removal_fmris |= set([f])
+
+        # proposed_dict already contains publisher selection logic,
+        # so prevent any further trimming of named packages based
+        # on publisher if they are installed.
+        for name in proposed_dict:
+            if name in self.__installed_dict:
+                self.__mark_pub_trimmed(name)
+            else:
+                self.__publisher[name] = proposed_dict[name][0].publisher
+
+        # Determine which packages are to be removed, rejected, and
+        # avoided and also determine which ones must not be removed
+        # during the operation.
+        self.__set_removed_and_required_packages(
+            rejected=reject_set, proposed=proposed_pkgs
+        )
+        self.__progress()
+
+        # find list of incorps we don't let change as a side effect of
+        # other changes; exclude any specified on command line if the
+        # proposed version is already installed and is not being removed
+        # translate proposed_dict into a set
+        if relax_all:
+            relax_pkgs = self.__installed_pkgs
+        else:
+            relax_pkgs = set(
+                name
+                for name in proposed_pkgs
+                if not any(
                     f
-                    for f in fmri_list
-                    if not self.__trim_dict.get(f)
-                ]
+                    for f in proposed_dict[name]
+                    if len(proposed_dict[name]) == 1
+                    and f in (self.__installed_fmris - self.__removal_fmris)
+                )
+            )
+            relax_pkgs |= self.__installed_unsatisfied_parent_deps(
+                excludes, ignore_inst_parent_deps
+            )
 
-        def __is_child(self):
-                """Return True if this image is a linked image child."""
-                return self.__parent_pkgs is not None
+        inc_list, con_lists = self.__get_installed_unbound_inc_list(
+            relax_pkgs, excludes=excludes
+        )
+        self.__inc_list = inc_list
 
-        def __is_zone(self):
-                """Return True if image is a nonglobal zone"""
-                if 'variant.opensolaris.zone' in self.__variants:
-                        return self.__variants['variant.opensolaris.zone'] == \
-                            'nonglobal'
+        self.__start_subphase(2)
+        # generate set of possible fmris
+        #
+        # ensure existing pkgs stay installed; explicitly add in
+        # installed fmris in case publisher change has occurred and
+        # some pkgs aren't part of new publisher
+        possible_set = set()
+        self.__allowed_downgrades = set()
+        for f in self.__installed_fmris - self.__removal_fmris:
+            possible_set |= self.__comb_newer_fmris(f)[0] | set([f])
+
+        # Add the proposed fmris, populate self.__expl_install_dict and
+        # check for allowed downgrades.
+        self.__expl_install_dict = defaultdict(list)
+        for name, flist in proposed_dict.items():
+            possible_set.update(flist)
+            for f in flist:
+                self.__progress()
+                self.__allowed_downgrades |= self.__allow_incorp_downgrades(
+                    f, excludes=excludes
+                )
+                if self.__is_explicit_install(f):
+                    self.__expl_install_dict[name].append(f)
+
+        # For linked image sync we have to analyze all pkgs of the
+        # possible_set because no proposed pkgs will be given. However,
+        # that takes more time so only do this for syncs. The relax_all
+        # flag is an indicator of a sync operation.
+        if not proposed_dict.values() and relax_all:
+            for f in possible_set:
+                self.__progress()
+                self.__allowed_downgrades |= self.__allow_incorp_downgrades(
+                    f, excludes=excludes, relax_all=True
+                )
+
+        possible_set |= self.__allowed_downgrades
+
+        self.__start_subphase(3)
+        # If requested, trim any proposed fmris older than those of
+        # corresponding installed packages.
+        candidate_fmris = self.__installed_fmris - self.__removal_fmris
+
+        for f in candidate_fmris:
+            self.__progress()
+            if not trim_proposed_installed and f.pkg_name in proposed_dict:
+                # Don't trim versions if newest version in
+                # proposed dict is older than installed
+                # version.
+                verlist = proposed_dict[f.pkg_name]
+                if verlist[-1].version < f.version:
+                    # Assume downgrade is intentional.
+                    continue
+            valid_trigger = False
+            for tf in self.__triggered_ops[PKG_OP_UNINSTALL][PKG_OP_UPDATE]:
+                if tf.pkg_name == f.pkg_name:
+                    self.__trim_older(tf)
+                    valid_trigger = True
+            if valid_trigger:
+                continue
+
+            self.__trim_older(f)
+
+        # trim fmris we excluded via proposed_fmris
+        for name in proposed_dict:
+            self.__progress()
+            self.__trim(
+                set(self.__get_catalog_fmris(name)) - set(proposed_dict[name]),
+                _TRIM_PROPOSED_VER,
+                N_(
+                    "This version excluded by specified " "installation version"
+                ),
+            )
+            # trim packages excluded by incorps in proposed.
+            self.__trim_recursive_incorps(
+                proposed_dict[name], excludes, _TRIM_PROPOSED_INC
+            )
+
+        # Trim packages with unsatisfied parent dependencies.  For any
+        # remaining allowable linked packages check if they are in
+        # relax_pkgs.  (Which means that either a version of them was
+        # requested explicitly on the command line or a version of them
+        # is installed which has unsatisfied parent dependencies and
+        # needs to be upgraded.)  In that case add the allowable
+        # packages to possible_linked so we can call
+        # __trim_recursive_incorps() on them to trim out more packages
+        # that may be disallowed due to synced incorporations.
+        if self.__is_child():
+            possible_linked = defaultdict(set)
+            for f in possible_set.copy():
+                self.__progress()
+                if not self.__trim_nonmatching_parents(
+                    f, excludes, ignore_inst_parent_deps
+                ):
+                    possible_set.remove(f)
+                    continue
+                if f in self.__linked_pkgs and f.pkg_name in relax_pkgs:
+                    possible_linked[f.pkg_name].add(f)
+            for name in possible_linked:
+                # calling __trim_recursive_incorps can be
+                # expensive so don't call it for versions except
+                # the one currently installed in the parent if
+                # it has been proposed.
+                if name in proposed_dict:
+                    pf = self.__parent_dict.get(name)
+                    possible_linked[name] -= set(proposed_dict[name]) - set(
+                        [pf]
+                    )
+                if not possible_linked[name]:
+                    continue
+                self.__progress()
+                self.__trim_recursive_incorps(
+                    list(possible_linked[name]), excludes, _TRIM_SYNCED_INC
+                )
+            del possible_linked
+
+        self.__start_subphase(4)
+        # now trim pkgs we cannot update due to maintained
+        # incorporations
+        for i, flist in zip(inc_list, con_lists):
+            reason = (
+                N_(
+                    "This version is excluded by installed " "incorporation {0}"
+                ),
+                (i.get_short_fmri(anarchy=True, include_scheme=False),),
+            )
+            self.__trim(
+                self.__comb_auto_fmris(i)[1], _TRIM_INSTALLED_INC, reason
+            )
+            for f in flist:
+                # dotrim=False here as we only want to trim
+                # packages that don't satisfy the incorporation.
+                self.__trim(
+                    self.__comb_auto_fmris(f, dotrim=False)[1],
+                    _TRIM_INSTALLED_INC,
+                    reason,
+                )
+
+        self.__start_subphase(5)
+        # now trim any pkgs we cannot update due to freezes
+        self.__trim_frozen(existing_freezes)
+
+        self.__start_subphase(6)
+        # elide any proposed versions that don't match variants (arch
+        # usually)
+        for name in proposed_dict:
+            for fmri in proposed_dict[name]:
+                self.__trim_nonmatching_variants(fmri)
+
+        self.__start_subphase(7)
+        # remove any versions from proposed_dict that are in trim_dict
+        try:
+            self.__trim_proposed(proposed_dict)
+        except api_errors.PlanCreationException as exp:
+            # One or more proposed packages have been rejected.
+            self.__raise_install_error(
+                exp, inc_list, proposed_dict, set(), excludes
+            )
+
+        self.__start_subphase(8)
+
+        # Ensure required dependencies of proposed packages are flagged
+        # to improve error messaging when parsing the transitive
+        # closure of all dependencies.
+        self.__set_proposed_required(proposed_dict, excludes)
+
+        # Update the set of possible fmris with the transitive closure
+        # of all dependencies.
+        self.__update_possible_closure(
+            possible_set, excludes, proposed_dict=proposed_dict
+        )
+
+        self.__start_subphase(9)
+        # trim any non-matching variants, origins or parents
+        for f in possible_set:
+            self.__progress()
+            if not self.__trim_nonmatching_parents(
+                f, excludes, ignore_inst_parent_deps
+            ):
+                continue
+            if not self.__trim_nonmatching_variants(f):
+                continue
+            self.__trim_nonmatching_origins(
+                f,
+                excludes,
+                exact_install=exact_install,
+                installed_dict_tmp=installed_dict_tmp,
+            )
+
+        self.__start_subphase(10)
+        # remove all trimmed fmris from consideration
+        possible_set.difference_update(six.iterkeys(self.__trim_dict))
+        # remove any versions from proposed_dict that are in trim_dict
+        # as trim dict has been updated w/ missing dependencies
+        try:
+            self.__trim_proposed(proposed_dict)
+        except api_errors.PlanCreationException as exp:
+            # One or more proposed packages have been rejected.
+            self.__raise_install_error(
+                exp, inc_list, proposed_dict, possible_set, excludes
+            )
+
+        self.__start_subphase(11)
+        #
+        # Generate ids, possible_dict for clause generation.  Prepare
+        # the solver for invocation.
+        #
+        self.__assign_fmri_ids(possible_set)
+
+        # Constrain the solution so that only one version of each
+        # package can be installed.
+        self.__enforce_unique_packages(excludes)
+
+        self.__start_subphase(12)
+        # Add proposed and installed packages to solver.
+        self.__generate_operation_clauses(
+            proposed=proposed_pkgs, proposed_dict=proposed_dict
+        )
+        try:
+            self.__assert_installed_allowed(excludes, proposed=proposed_pkgs)
+        except api_errors.PlanCreationException as exp:
+            # One or more installed packages can't be retained or
+            # upgraded.
+            self.__raise_install_error(
+                exp, inc_list, proposed_dict, possible_set, excludes
+            )
+
+        pt.plan_done(pt.PLAN_SOLVE_SETUP)
+
+        self.__progitem = pt.PLAN_SOLVE_SOLVER
+        pt.plan_start(pt.PLAN_SOLVE_SOLVER)
+        self.__start_subphase(13)
+        # save a solver instance so we can come back here
+        # this is where errors happen...
+        saved_solver = self.__save_solver()
+        try:
+            saved_solution = self.__solve()
+        except api_errors.PlanCreationException as exp:
+            # no solution can be found.
+            self.__raise_install_error(
+                exp, inc_list, proposed_dict, possible_set, excludes
+            )
+
+        self.__start_subphase(14)
+        # we have a solution that works... attempt to
+        # reduce collateral damage to other packages
+        # while still keeping command line pkgs at their
+        # optimum level
+
+        self.__restore_solver(saved_solver)
+
+        # fix the fmris that were specified on the cmd line
+        # at their optimum (newest) level along with the
+        # new dependencies, but try and avoid upgrading
+        # already installed pkgs or adding un-needed new pkgs.
+
+        for fmri in saved_solution:
+            if fmri.pkg_name in proposed_dict:
+                self.__addclauses(self.__gen_one_of_these_clauses([fmri]))
+
+        self.__start_subphase(15)
+        # save context
+        saved_solver = self.__save_solver()
+
+        saved_solution = self.__solve(older=True)
+
+        self.__start_subphase(16)
+        # Now we have the oldest possible original fmris
+        # but we may have some that are not original
+        # Since we want to move as far forward as possible
+        # when we have to move a package, fix the originals
+        # and drive forward again w/ the remainder
+        self.__restore_solver(saved_solver)
+
+        for fmri in saved_solution & self.__installed_fmris:
+            self.__addclauses(self.__gen_one_of_these_clauses([fmri]))
+
+        solution = self.__solve()
+        self.__progress()
+        solution = self.__update_solution_set(solution, excludes)
+
+        return self.__end_solve(solution, excludes)
+
+    def solve_update_all(
+        self, existing_freezes, excludes=EmptyI, reject_set=frozenset()
+    ):
+        """Logic to update all packages within an image to the latest
+        versions possible.
+
+        Returns FMRIs to be installed / upgraded in system and a new
+        set of packages to be avoided.
+
+        'existing_freezes' is a list of incorp. style FMRIs that
+        constrain pkg motion
+
+        'reject_set' contains user specified FMRIs that should not be
+        present within the final image.  (These packages may or may
+        not be currently installed.)
+        """
+
+        pt = self.__begin_solve()
+
+        # Determine which packages are to be removed, rejected, and
+        # avoided and also determine which ones must not be removed
+        # during the operation.
+        self.__set_removed_and_required_packages(rejected=reject_set)
+        self.__progress()
+
+        if self.__is_child():
+            synced_parent_pkgs = self.__installed_unsatisfied_parent_deps(
+                excludes, False
+            )
+        else:
+            synced_parent_pkgs = frozenset()
+
+        self.__start_subphase(2)
+        # generate set of possible fmris
+        possible_set = set()
+        for f in self.__installed_fmris - self.__removal_fmris:
+            self.__progress()
+            matching = self.__comb_newer_fmris(f)[0]
+            if not matching:  # disabled publisher...
+                matching = set([f])  # staying put is an option
+            possible_set |= matching
+
+        self.__allowed_downgrades = set()
+        for f in possible_set:
+            self.__allowed_downgrades |= self.__allow_incorp_downgrades(
+                f, excludes=excludes, relax_all=True
+            )
+        possible_set |= self.__allowed_downgrades
+
+        # trim fmris we cannot install because they're older
+        for f in self.__installed_fmris:
+            self.__progress()
+            self.__trim_older(f)
+
+        # now trim any pkgs we cannot update due to freezes
+        self.__trim_frozen(existing_freezes)
+
+        # Trim packages with unsatisfied parent dependencies.  Then
+        # for packages with satisfied parent dependenices (which will
+        # include incorporations), call __trim_recursive_incorps() to
+        # trim out more packages that are disallowed due to the synced
+        # incorporations.
+        if self.__is_child():
+            possible_linked = defaultdict(set)
+            for f in possible_set.copy():
+                self.__progress()
+                if not self.__trim_nonmatching_parents(f, excludes):
+                    possible_set.remove(f)
+                    continue
+                if (
+                    f in self.__linked_pkgs
+                    and f.pkg_name not in synced_parent_pkgs
+                ):
+                    possible_linked[f.pkg_name].add(f)
+            for name in possible_linked:
+                self.__progress()
+                self.__trim_recursive_incorps(
+                    list(possible_linked[name]), excludes, _TRIM_SYNCED_INC
+                )
+            del possible_linked
+
+        self.__start_subphase(3)
+        # Update the set of possible FMRIs with the transitive closure
+        # of all dependencies.
+        self.__update_possible_closure(possible_set, excludes)
+
+        # trim any non-matching origins or parents
+        for f in possible_set:
+            if self.__trim_nonmatching_parents(f, excludes):
+                if self.__trim_nonmatching_variants(f):
+                    self.__trim_nonmatching_origins(f, excludes)
+
+        self.__start_subphase(4)
+
+        # remove all trimmed fmris from consideration
+        possible_set.difference_update(six.iterkeys(self.__trim_dict))
+
+        #
+        # Generate ids, possible_dict for clause generation.  Prepare
+        # the solver for invocation.
+        #
+        self.__assign_fmri_ids(possible_set)
+
+        # Constrain the solution so that only one version of each
+        # package can be installed.
+        self.__enforce_unique_packages(excludes)
+
+        self.__start_subphase(5)
+        # Add installed packages to solver.
+        self.__generate_operation_clauses()
+        try:
+            self.__assert_installed_allowed(excludes)
+        except api_errors.PlanCreationException:
+            # Attempt a full trim to see if we can raise a sensible
+            # error.  If not, re-raise.
+            self.__assert_trim_errors(possible_set, excludes)
+            raise
+
+        pt.plan_done(pt.PLAN_SOLVE_SETUP)
+
+        self.__progitem = pt.PLAN_SOLVE_SOLVER
+        pt.plan_start(pt.PLAN_SOLVE_SOLVER)
+        self.__start_subphase(6)
+        try:
+            solution = self.__solve()
+        except api_errors.PlanCreationException:
+            # No solution can be found; attempt a full trim to see
+            # if we can raise a sensible error.  If not, re-raise.
+            self.__assert_trim_errors(possible_set, excludes)
+            raise
+
+        self.__update_solution_set(solution, excludes)
+
+        for f in solution.copy():
+            if self.__fmri_is_obsolete(f):
+                solution.remove(f)
+
+        # If solution doesn't match installed set of packages, then an
+        # upgrade solution was found (heuristic):
+        if solution != self.__installed_fmris:
+            return self.__end_solve(solution, excludes)
+
+        incorps = self.__get_installed_upgradeable_incorps(excludes)
+        if not incorps or self.__is_child():
+            # If there are no installed, upgradeable incorporations,
+            # then assume that no updates were available.  Also if
+            # we're a linked image child we may not be able to
+            # update to the latest available incorporations due to
+            # parent constraints, so don't generate an error.
+            return self.__end_solve(solution, excludes)
+
+        # Before making a guess, apply extra trimming to see if we can
+        # reject the operation based on changing packages.
+        self.__assert_trim_errors(possible_set, excludes)
+
+        # Despite all of the trimming done, we still don't know why the
+        # solver couldn't find a solution, so make a best-effort guess
+        # at the reason why.
+        skey = operator.attrgetter("pkg_name")
+        info = []
+        info.append(
+            _("No solution found to update to latest available " "versions.")
+        )
+        info.append(
+            _(
+                "This may indicate an overly constrained set of "
+                "packages are installed."
+            )
+        )
+        info.append(" ")
+        info.append(_("latest incorporations:"))
+        info.append(" ")
+        info.extend(("  {0}".format(f) for f in sorted(incorps, key=skey)))
+        info.append(" ")
+
+        ms = self.__generate_dependency_errors(incorps, excludes=excludes)
+        ms.extend(self.__check_installed())
+
+        if ms:
+            info.append(
+                _(
+                    "The following indicates why the system "
+                    "cannot update to the latest version:"
+                )
+            )
+            info.append(" ")
+            for s in ms:
+                info.append("  {0}".format(s))
+        else:
+            info.append(
+                _("Dependency analysis is unable to " "determine the cause.")
+            )
+            info.append(
+                _(
+                    "Try running with -vv to "
+                    "obtain more detailed error messages."
+                )
+            )
+
+        self.__raise_solution_error(no_solution=info)
+
+    def solve_uninstall(
+        self,
+        existing_freezes,
+        uninstall_list,
+        excludes,
+        ignore_inst_parent_deps=False,
+    ):
+        """Compute changes needed for uninstall"""
+
+        self.__begin_solve()
+
+        # generate list of installed pkgs w/ possible renames removed to
+        # forestall failing removal due to presence of unneeded renamed
+        # pkg
+        orig_installed_set = self.__installed_fmris
+        renamed_set = orig_installed_set - self.__elide_possible_renames(
+            orig_installed_set, excludes
+        )
+
+        proposed_removals = (
+            set(uninstall_list)
+            | renamed_set
+            | self.__triggered_ops[PKG_OP_UNINSTALL][PKG_OP_UNINSTALL]
+        )
+
+        # find pkgs which are going to be installed/updated
+        triggered_set = set()
+        for f in self.__triggered_ops[PKG_OP_UNINSTALL][PKG_OP_UPDATE]:
+            triggered_set.add(f)
+
+        # check for dependents
+        for pfmri in proposed_removals:
+            self.__progress()
+            dependents = (
+                self.__get_dependents(pfmri, excludes) - proposed_removals
+            )
+
+            # Check if any of the dependents are going to be updated
+            # to a different version which might not have the same
+            # dependency constraints. If so, remove from dependents
+            # list.
+
+            # Example:
+            # A@1 depends on B
+            # A@2 does not depend on B
+            #
+            # A@1 is currently installed, B is requested for removal
+            # -> not allowed
+            # pkg actuator updates A to 2
+            # -> now removal of B is allowed
+            candidates = dict(
+                (tf, f)
+                for f in dependents
+                for tf in triggered_set
+                if f.pkg_name == tf.pkg_name
+            )
+
+            for tf in candidates:
+                remove = True
+                for da in self.__get_dependency_actions(tf, excludes):
+                    if da.attrs["type"] != "require":
+                        continue
+                    pkg_name = pkg.fmri.PkgFmri(da.attrs["fmri"]).pkg_name
+                    if pkg_name == pfmri.pkg_name:
+                        remove = False
+                        break
+                if remove:
+                    dependents.remove(candidates[tf])
+
+            if dependents:
+                raise api_errors.NonLeafPackageException(pfmri, dependents)
+
+        reject_set = set(f.pkg_name for f in proposed_removals)
+
+        # Run it through the solver; with more complex dependencies
+        # we're going to be out of luck without it.
+        self.__state = SOLVER_INIT  # reset to initial state
+        return self.solve_install(
+            existing_freezes,
+            {},
+            excludes=excludes,
+            reject_set=reject_set,
+            ignore_inst_parent_deps=ignore_inst_parent_deps,
+        )
+
+    def __update_solution_set(self, solution, excludes):
+        """Update avoid sets w/ any missing packages (due to reject).
+        Remove obsolete packages from solution.  Keep track of which
+        obsolete packages have group dependencies so verify of group
+        packages w/ obsolete members works."""
+
+        solution_stems = set(f.pkg_name for f in solution)
+        tracked_stems = set()
+        for fmri in solution:
+            for a in self.__get_dependency_actions(
+                fmri, excludes=excludes, trim_invalid=False
+            ):
+                if (
+                    a.attrs["type"] != "group"
+                    and a.attrs["type"] != "group-any"
+                ):
+                    continue
+
+                for t in a.attrlist("fmri"):
+                    try:
+                        tmp = self.__fmridict[t]
+                    except KeyError:
+                        tmp = pkg.fmri.PkgFmri(t)
+                        self.__fmridict[t] = tmp
+                    tracked_stems.add(tmp.pkg_name)
+
+        avoided = tracked_stems - solution_stems
+        # Add stems omitted by solution and explicitly rejected.
+        self.__avoid_set |= avoided & self.__reject_set
+
+        ret = solution.copy()
+        obs = set()
+
+        for f in solution:
+            if self.__fmri_is_obsolete(f):
+                ret.remove(f)
+                obs.add(f.pkg_name)
+
+        self.__obs_set = obs & tracked_stems
+
+        # Add stems omitted by solution but not explicitly rejected, not
+        # previously avoided, and not avoided due to obsoletion.
+        self.__implicit_avoid_set |= avoided - self.__avoid_set - self.__obs_set
+
+        return ret
+
+    def __save_solver(self):
+        """Duplicate current current solver state and return it."""
+        return (self.__addclause_failure, pkg.solver.msat_solver(self.__solver))
+
+    def __restore_solver(self, solver):
+        """Set the current solver state to the previously saved one"""
+        self.__addclause_failure, self.__solver = solver
+        self.__iterations = 0
+
+    def __solve(self, older=False, max_iterations=2000):
+        """Perform iterative solution; try for newest pkgs unless
+        older=True"""
+        solution_vector = []
+        self.__state = SOLVER_FAIL
+        eliminated = set()
+        while not self.__addclause_failure and self.__solver.solve([]):
+            self.__progress()
+            self.__iterations += 1
+
+            if self.__iterations > max_iterations:
+                break
+
+            solution_vector = self.__get_solution_vector()
+            if not solution_vector:
+                break
+
+            # prevent the selection of any older pkgs except for
+            # those that are part of the set of allowed downgrades;
+            for fid in solution_vector:
+                pfmri = self.__getfmri(fid)
+                matching, remaining = self.__comb_newer_fmris(pfmri)
+                if not older:
+                    # without subtraction of allowed
+                    # downgrades, an initial solution will
+                    # exclude any solutions containing
+                    # earlier versions of downgradeable
+                    # packages
+                    remove = remaining - self.__allowed_downgrades
                 else:
+                    remove = matching - set([pfmri]) - eliminated
+                for f in remove:
+                    self.__addclauses([[-self.__getid(f)]])
+
+            # prevent the selection of this exact combo;
+            # permit [] solution
+            self.__addclauses([[-i for i in solution_vector]])
+
+        if not self.__iterations:
+            self.__raise_solution_error(no_solution=True)
+
+        self.__state = SOLVER_SUCCESS
+
+        solution = set([self.__getfmri(i) for i in solution_vector])
+
+        return solution
+
+    def __get_solution_vector(self):
+        """Return solution vector from solver"""
+        return frozenset(
+            [
+                (i + 1)
+                for i in range(self.__solver.get_variables())
+                if self.__solver.dereference(i)
+            ]
+        )
+
+    def __assign_possible(self, possible_set):
+        """Assign __possible_dict of possible package FMRIs by pkg stem
+        and mark trimming complete."""
+
+        # generate dictionary of possible pkgs fmris by pkg stem
+        self.__possible_dict.clear()
+
+        for f in possible_set:
+            self.__possible_dict[f.pkg_name].append(f)
+        for name in self.__possible_dict:
+            self.__possible_dict[name].sort()
+        self.__trimdone = True
+
+    def __assign_fmri_ids(self, possible_set):
+        """give a set of possible fmris, assign ids"""
+
+        self.__assign_possible(possible_set)
+
+        # assign clause numbers (ids) to possible pkgs
+        pkgid = 1
+        for name in sorted(six.iterkeys(self.__possible_dict)):
+            for fmri in reversed(self.__possible_dict[name]):
+                self.__id2fmri[pkgid] = fmri
+                self.__fmri2id[fmri] = pkgid
+                pkgid += 1
+
+        self.__variables = pkgid - 1
+
+    def __getid(self, fmri):
+        """Translate fmri to variable number (id)"""
+        return self.__fmri2id[fmri]
+
+    def __getfmri(self, fid):
+        """Translate variable number (id) to fmris"""
+        return self.__id2fmri[fid]
+
+    def __get_fmris_by_version(self, pkg_name):
+        """Cache for catalog entries; helps performance"""
+        if pkg_name not in self.__cache:
+            self.__cache[pkg_name] = [
+                t for t in self.__catalog.fmris_by_version(pkg_name)
+            ]
+        return self.__cache[pkg_name]
+
+    def __get_catalog_fmris(self, pkg_name):
+        """return the list of fmris in catalog for this pkg name"""
+        if pkg_name not in self.__pub_trim:
+            self.__filter_publishers(pkg_name)
+
+        if self.__trimdone:
+            return self.__possible_dict.get(pkg_name, [])
+
+        return [
+            f for tp in self.__get_fmris_by_version(pkg_name) for f in tp[1]
+        ]
+
+    def __comb_newer_fmris(self, fmri, dotrim=True, obsolete_ok=True):
+        """Returns tuple of set of fmris that are matched within
+        CONSTRAINT.NONE of specified version and set of remaining
+        fmris."""
+
+        return self.__comb_common(
+            fmri, dotrim, version.CONSTRAINT_NONE, obsolete_ok
+        )
+
+    def __comb_common(self, fmri, dotrim, constraint, obsolete_ok):
+        """Underlying impl. of other comb routines"""
+
+        self.__progress()
+
+        tp = (fmri, dotrim, constraint, obsolete_ok)  # cache index
+        # determine if the data is cacheable or cached:
+        if (not self.__trimdone and dotrim) or tp not in self.__cache:
+            # use frozensets so callers don't inadvertently update
+            # these sets (which may be cached).
+            all_fmris = set(self.__get_catalog_fmris(fmri.pkg_name))
+            matching = frozenset(
+                [
+                    f
+                    for f in all_fmris
+                    if not dotrim or not self.__trim_dict.get(f)
+                    if not fmri.version
+                    or fmri.version == f.version
+                    or f.version.is_successor(
+                        fmri.version, constraint=constraint
+                    )
+                    if obsolete_ok or not self.__fmri_is_obsolete(f)
+                ]
+            )
+            remaining = frozenset(all_fmris - matching)
+
+            # if we haven't finished trimming, don't cache this
+            if not self.__trimdone:
+                return matching, remaining
+            # cache the result
+            self.__cache[tp] = (matching, remaining)
+
+        return self.__cache[tp]
+
+    def __comb_older_fmris(self, fmri, dotrim=True, obsolete_ok=True):
+        """Returns tuple of set of fmris that are older than
+        specified version and set of remaining fmris."""
+        newer, older = self.__comb_newer_fmris(
+            fmri, dotrim=False, obsolete_ok=obsolete_ok
+        )
+        if not dotrim:
+            return older, newer
+
+        # we're going to return the older packages, so we need
+        # to make sure that any trimmed packages are removed
+        # from the matching set and added to the non-matching
+        # ones.
+        trimmed_older = set([f for f in older if self.__trim_dict.get(f)])
+        return older - trimmed_older, newer | trimmed_older
+
+    def __comb_auto_fmris(self, fmri, dotrim=True, obsolete_ok=True):
+        """Returns tuple of set of fmris that are match within
+        CONSTRAINT.AUTO of specified version and set of remaining
+        fmris."""
+        return self.__comb_common(
+            fmri, dotrim, version.CONSTRAINT_AUTO, obsolete_ok
+        )
+
+    def __fmri_loadstate(self, fmri, excludes):
+        """load fmri state (obsolete == True, renamed == True)"""
+
+        try:
+            relevant = dict(
+                [
+                    (a.attrs["name"], a.attrs["value"])
+                    for a in self.__catalog.get_entry_actions(
+                        fmri, [catalog.Catalog.DEPENDENCY], excludes=excludes
+                    )
+                    if a.name == "set"
+                    and a.attrs["name"] in ["pkg.renamed", "pkg.obsolete"]
+                ]
+            )
+        except api_errors.InvalidPackageErrors:
+            # Trim package entries that have unparseable action data
+            # so that they can be filtered out later.
+            self.__fmri_state[fmri] = ("false", "false")
+            self.__trim_unsupported(fmri)
+            return
+
+        self.__fmri_state[fmri] = (
+            relevant.get("pkg.obsolete", "false").lower() == "true",
+            relevant.get("pkg.renamed", "false").lower() == "true",
+        )
+
+    def __fmri_is_obsolete(self, fmri, excludes=EmptyI):
+        """check to see if fmri is obsolete"""
+        if fmri not in self.__fmri_state:
+            self.__fmri_loadstate(fmri, excludes)
+        return self.__fmri_state[fmri][0]
+
+    def __fmri_is_renamed(self, fmri, excludes=EmptyI):
+        """check to see if fmri is renamed"""
+        if fmri not in self.__fmri_state:
+            self.__fmri_loadstate(fmri, excludes)
+        return self.__fmri_state[fmri][1]
+
+    def __get_actions(self, fmri, name, excludes=EmptyI, trim_invalid=True):
+        """Return list of actions of type 'name' for this 'fmri' in
+        Catalog.DEPENDENCY section."""
+
+        try:
+            return self.__actcache[(fmri, name)]
+        except KeyError:
+            pass
+
+        try:
+            acts = [
+                a
+                for a in self.__catalog.get_entry_actions(
+                    fmri, [catalog.Catalog.DEPENDENCY], excludes=excludes
+                )
+                if a.name == name
+            ]
+
+            if name == "depend":
+                for a in acts:
+                    if a.attrs["type"] in dep_types:
+                        continue
+                    raise api_errors.InvalidPackageErrors(
+                        ["Unknown dependency type {0}".format(a.attrs["type"])]
+                    )
+
+            self.__actcache[(fmri, name)] = acts
+            return acts
+        except api_errors.InvalidPackageErrors:
+            if not trim_invalid:
+                raise
+
+            # Trim package entries that have unparseable action
+            # data so that they can be filtered out later.
+            self.__fmri_state[fmri] = ("false", "false")
+            self.__trim_unsupported(fmri)
+            return []
+
+    def __get_dependency_actions(
+        self, fmri, excludes=EmptyI, trim_invalid=True
+    ):
+        """Return list of all dependency actions for this fmri."""
+
+        return self.__get_actions(
+            fmri, "depend", excludes=excludes, trim_invalid=trim_invalid
+        )
+
+    def __get_set_actions(self, fmri, excludes=EmptyI, trim_invalid=True):
+        """Return list of all set actions for this fmri in
+        Catalog.DEPENDENCY section."""
+
+        return self.__get_actions(
+            fmri, "set", excludes=excludes, trim_invalid=trim_invalid
+        )
+
+    def __get_variant_dict(self, fmri):
+        """Return dictionary of variants suppported by fmri"""
+        try:
+            if fmri not in self.__variant_dict:
+                self.__variant_dict[fmri] = dict(
+                    self.__catalog.get_entry_all_variants(fmri)
+                )
+        except api_errors.InvalidPackageErrors:
+            # Trim package entries that have unparseable action data
+            # so that they can be filtered out later.
+            self.__variant_dict[fmri] = {}
+            self.__trim_unsupported(fmri)
+        return self.__variant_dict[fmri]
+
+    def __is_explicit_install(self, fmri):
+        """check if given fmri has explicit install actions."""
+
+        for sa in self.__get_set_actions(fmri):
+            if (
+                sa.attrs["name"] == "pkg.depend.explicit-install"
+                and sa.attrs["value"].lower() == "true"
+            ):
+                return True
+        return False
+
+    def __filter_explicit_install(self, fmri, excludes):
+        """Check packages which have 'pkg.depend.explicit-install'
+        action set to true, and prepare to filter."""
+
+        will_filter = True
+        # Filter out fmris with 'pkg.depend.explicit-install' set to
+        # true and not explicitly proposed, already installed in the
+        # current image, or is parent-constrained and is installed in
+        # the parent image.
+        if self.__is_explicit_install(fmri):
+            pkg_name = fmri.pkg_name
+            if (
+                pkg_name in self.__expl_install_dict
+                and fmri in self.__expl_install_dict[pkg_name]
+            ):
+                will_filter = False
+            elif pkg_name in self.__installed_dict:
+                will_filter = False
+            elif pkg_name in self.__parent_dict:
+                # If this is a linked package that is
+                # constrained to be the same version as parent,
+                # and the parent has it installed, ignore
+                # pkg.depend.explicit-install so that IDR
+                # versions of packages can be used
+                # automatically.
+                will_filter = not any(
+                    da
+                    for da in self.__get_dependency_actions(fmri, excludes)
+                    if da.attrs["type"] == "parent"
+                    and pkg.actions.depend.DEPEND_SELF in da.attrlist("fmri")
+                )
+        else:
+            will_filter = False
+        return will_filter
+
+    def __generate_dependency_closure(
+        self,
+        fmri_set,
+        excludes=EmptyI,
+        dotrim=True,
+        full_trim=False,
+        filter_explicit=True,
+        proposed_dict=None,
+    ):
+        """return set of all fmris the set of specified fmris could
+        depend on; while trimming those packages that cannot be
+        installed"""
+
+        # Use a copy of the set provided by the caller to prevent
+        # unexpected modification!
+        needs_processing = set(fmri_set)
+        already_processed = set()
+
+        while needs_processing:
+            self.__progress()
+            fmri = needs_processing.pop()
+            already_processed.add(fmri)
+            # Trim filtered packages.
+            if filter_explicit and self.__filter_explicit_install(
+                fmri, excludes
+            ):
+                reason = (
+                    N_(
+                        "Uninstalled fmri {0} can "
+                        "only be installed if explicitly "
+                        "requested"
+                    ),
+                    (fmri,),
+                )
+                self.__trim((fmri,), _TRIM_EXPLICIT_INSTALL, reason)
+                continue
+
+            needs_processing |= (
+                self.__generate_dependencies(
+                    fmri,
+                    excludes,
+                    dotrim,
+                    full_trim,
+                    proposed_dict=proposed_dict,
+                )
+                - already_processed
+            )
+        return already_processed
+
+    def __generate_dependencies(
+        self,
+        fmri,
+        excludes=EmptyI,
+        dotrim=True,
+        full_trim=False,
+        proposed_dict=None,
+    ):
+        """return set of direct (possible) dependencies of this pkg;
+        trim those packages whose dependencies cannot be satisfied"""
+        try:
+            return set(
+                [
+                    f
+                    for da in self.__get_dependency_actions(fmri, excludes)
+                    # check most common ones first; what is checked
+                    # here is a matter of optimization / messaging, not
+                    # correctness.
+                    if da.attrs["type"] == "require"
+                    or da.attrs["type"] == "group"
+                    or da.attrs["type"] == "conditional"
+                    or da.attrs["type"] == "require-any"
+                    or da.attrs["type"] == "group-any"
+                    or (
+                        full_trim
+                        and (
+                            da.attrs["type"] == "incorporate"
+                            or da.attrs["type"] == "optional"
+                            or da.attrs["type"] == "exclude"
+                        )
+                    )
+                    for f in self.__parse_dependency(
+                        da,
+                        fmri,
+                        dotrim,
+                        check_req=True,
+                        proposed_dict=proposed_dict,
+                    )[1]
+                ]
+            )
+
+        except DependencyException as e:
+            self.__trim((fmri,), e.reason_id, e.reason, fmri_adds=e.fmris)
+            return set([])
+
+    def __elide_possible_renames(self, fmris, excludes=EmptyI):
+        """Return fmri list (which must be self-complete) with all
+        renamed fmris that have no other fmris depending on them
+        removed"""
+
+        # figure out which have been renamed
+        renamed_fmris = set(
+            [
+                pfmri
+                for pfmri in fmris
+                if self.__fmri_is_renamed(pfmri, excludes)
+            ]
+        )
+
+        # return if nothing has been renamed
+        if not renamed_fmris:
+            return set(fmris)
+
+        fmris_by_name = dict((pfmri.pkg_name, pfmri) for pfmri in fmris)
+
+        # figure out which renamed fmris have dependencies; compute
+        # transitively so we can handle multiple renames
+
+        needs_processing = set(fmris) - renamed_fmris
+        already_processed = set()
+
+        while needs_processing:
+            pfmri = needs_processing.pop()
+            already_processed.add(pfmri)
+            for da in self.__get_dependency_actions(pfmri, excludes):
+                if da.attrs["type"] not in (
+                    "incorporate",
+                    "optional",
+                    "origin",
+                ):
+                    for f in da.attrlist("fmri"):
+                        try:
+                            tmp = self.__fmridict[f]
+                        except KeyError:
+                            tmp = pkg.fmri.PkgFmri(f)
+                            self.__fmridict[f] = tmp
+                        name = tmp.pkg_name
+                        if name not in fmris_by_name:
+                            continue
+                        new_fmri = fmris_by_name[name]
+                        # since new_fmri will not be
+                        # treated as renamed, make sure
+                        # we check any dependencies it
+                        # has
+                        if new_fmri not in already_processed:
+                            needs_processing.add(new_fmri)
+                        renamed_fmris.discard(new_fmri)
+        return set(fmris) - renamed_fmris
+
+    def __get_dependents(self, pfmri, excludes=EmptyI):
+        """return set of installed fmris that have require dependencies
+        on specified installed fmri"""
+        if self.__dependents is None:
+            self.__dependents = {}
+            for f in self.__installed_fmris:
+                for da in self.__get_dependency_actions(f, excludes):
+                    if da.attrs["type"] != "require":
+                        continue
+                    pkg_name = pkg.fmri.PkgFmri(da.attrs["fmri"]).pkg_name
+                    self.__dependents.setdefault(
+                        self.__installed_dict[pkg_name], set()
+                    ).add(f)
+        return self.__dependents.get(pfmri, set())
+
+    def __trim_recursive_incorps(self, fmri_list, excludes, reason_id):
+        """trim packages affected by incorporations"""
+        processed = set()
+
+        work = [fmri_list]
+
+        if reason_id == _TRIM_PROPOSED_INC:
+            reason = N_("Excluded by proposed incorporation '{0}'")
+        elif reason_id == _TRIM_SYNCED_INC:
+            reason = N_("Excluded by synced parent incorporation '{0}'")
+        else:
+            raise AssertionError(
+                "Invalid reason_id value: {0}".format(reason_id)
+            )
+
+        while work:
+            fmris = work.pop()
+            enc_pkg_name = fmris[0].get_name()
+            # If the package is not installed then any dependenices
+            # it has are irrelevant.
+            if enc_pkg_name not in self.__installed_dict:
+                continue
+            processed.add(frozenset(fmris))
+            d = self.__combine_incorps(fmris, excludes)
+            for name in d:
+                self.__trim(
+                    d[name][1], reason_id, (reason, (fmris[0].pkg_name,))
+                )
+                to_do = d[name][0]
+                if to_do and frozenset(to_do) not in processed:
+                    work.append(list(to_do))
+
+    def __combine_incorps(self, fmri_list, excludes):
+        """Given a list of fmris, one of which must be present, produce
+        a dictionary indexed by package name, which contains a tuple
+        of two sets (matching fmris, nonmatching)"""
+
+        dict_list = [
+            self.__get_incorp_nonmatch_dict(f, excludes) for f in fmri_list
+        ]
+        # The following ignores constraints that appear in only some of
+        # the versions.  This also handles obsoletions & renames.
+        all_keys = reduce(set.intersection, (set(d.keys()) for d in dict_list))
+
+        return dict(
+            (
+                k,
+                (
+                    reduce(
+                        set.union,
+                        (d.get(k, (set(), set()))[0] for d in dict_list),
+                    ),
+                    reduce(
+                        set.intersection,
+                        (d.get(k, (set(), set()))[1] for d in dict_list),
+                    ),
+                ),
+            )
+            for k in all_keys
+        )
+
+    def __get_incorp_nonmatch_dict(self, fmri, excludes):
+        """Given a fmri with incorporation dependencies, produce a
+        dictionary containing (matching, non matching fmris),
+        indexed by pkg name.  Note that some fmris may be
+        incorporated more than once at different levels of
+        specificity"""
+        ret = dict()
+        for da in self.__get_dependency_actions(fmri, excludes=excludes):
+            if da.attrs["type"] != "incorporate":
+                continue
+            nm, m, _c, _d, _r, f = self.__parse_dependency(
+                da, fmri, dotrim=False
+            )
+            # Collect all incorp. dependencies affecting
+            # a package in a list.  Note that it is
+            # possible for both matching and non-matching
+            # sets to be NULL, and we'll need at least
+            # one item in the list for reduce to work.
+            ret.setdefault(f.pkg_name, (list(), list()))
+            ret[f.pkg_name][0].append(set(m))
+            ret[f.pkg_name][1].append(set(nm))
+
+        # For each of the packages constrained, combine multiple
+        # incorporation dependencies.  Matches are intersected,
+        # non-matches form a union.
+        for pkg_name in ret:
+            ret[pkg_name] = (
+                reduce(set.intersection, ret[pkg_name][0]),
+                reduce(set.union, ret[pkg_name][1]),
+            )
+        return ret
+
+    def __parse_group_dependency(self, dotrim, obsolete_ok, fmris):
+        """Returns (matching, nonmatching) fmris for given list of group
+        dependencies."""
+
+        matching = []
+        nonmatching = []
+        for f in fmris:
+            # remove version explicitly; don't
+            # modify cached fmri
+            if f.version is not None:
+                fmri = f.copy()
+                fmri.version = None
+            else:
+                fmri = f
+
+            m, nm = self.__comb_newer_fmris(
+                fmri, dotrim, obsolete_ok=obsolete_ok
+            )
+            matching.extend(m)
+            nonmatching.extend(nm)
+
+        return frozenset(matching), frozenset(nonmatching)
+
+    def __parse_dependency(
+        self,
+        dependency_action,
+        source,
+        dotrim=True,
+        check_req=False,
+        proposed_dict=None,
+    ):
+        """Return tuple of (disallowed fmri list, allowed fmri list,
+        conditional_list, dependency_type, required)"""
+
+        dtype = dependency_action.attrs["type"]
+        fmris = []
+        for fmristr in dependency_action.attrlist("fmri"):
+            try:
+                fmri = self.__fmridict[fmristr]
+            except KeyError:
+                fmri = pkg.fmri.PkgFmri(fmristr)
+                self.__fmridict[fmristr] = fmri
+
+            if not self.__depend_ts:
+                fver = fmri.version
+                if fver and fver.timestr:
+                    # Include timestamp in all error
+                    # output for dependencies.
+                    self.__depend_ts = True
+
+            fmris.append(fmri)
+
+        fmri = fmris[0]
+
+        # true if match is required for containing pkg
+        required = True
+        # if this dependency has conditional fmris
+        conditional = None
+        # true if obsolete pkgs satisfy this dependency
+        obsolete_ok = False
+
+        if dtype == "require":
+            matching, nonmatching = self.__comb_newer_fmris(
+                fmri, dotrim, obsolete_ok=obsolete_ok
+            )
+
+        elif dtype == "optional":
+            obsolete_ok = True
+            matching, nonmatching = self.__comb_newer_fmris(
+                fmri, dotrim, obsolete_ok=obsolete_ok
+            )
+            if fmri.pkg_name not in self.__req_pkg_names:
+                required = False
+
+        elif dtype == "exclude":
+            obsolete_ok = True
+            matching, nonmatching = self.__comb_older_fmris(
+                fmri, dotrim, obsolete_ok=obsolete_ok
+            )
+            if fmri.pkg_name not in self.__req_pkg_names:
+                required = False
+
+        elif dtype == "incorporate":
+            obsolete_ok = True
+            matching, nonmatching = self.__comb_auto_fmris(
+                fmri, dotrim, obsolete_ok=obsolete_ok
+            )
+            if fmri.pkg_name not in self.__req_pkg_names:
+                required = False
+            # Track packages that deliver incorporate deps.
+            self.__known_incs.add(source.pkg_name)
+
+        elif dtype == "conditional":
+            cond_fmri = pkg.fmri.PkgFmri(dependency_action.attrs["predicate"])
+            conditional, nonmatching = self.__comb_newer_fmris(
+                cond_fmri, dotrim, obsolete_ok=obsolete_ok
+            )
+
+            # Required is only really helpful for solver error
+            # messaging.  The only time we know that this dependency
+            # is required is when the predicate package must be part
+            # of the solution.
+            if cond_fmri.pkg_name not in self.__req_pkg_names:
+                required = False
+
+            proposed = (
+                proposed_dict[cond_fmri.pkg_name]
+                if proposed_dict and cond_fmri.pkg_name in proposed_dict
+                else []
+            )
+
+            # If the predicate is not installed and not in the
+            # proposed set, then the dependant package is not
+            # required.
+            installed = False
+            for f in conditional:
+                if (
+                    f in proposed
+                    or f in self.__installed_fmris - self.__removal_fmris
+                ):
+                    installed = True
+            if not installed:
+                required = False
+
+            matching, nonmatching = self.__comb_newer_fmris(
+                fmri, dotrim, obsolete_ok=obsolete_ok
+            )
+
+        elif dtype == "require-any":
+            matching = []
+            nonmatching = []
+            for f in fmris:
+                m, nm = self.__comb_newer_fmris(
+                    f, dotrim, obsolete_ok=obsolete_ok
+                )
+                matching.extend(m)
+                nonmatching.extend(nm)
+
+            matching = set(matching)
+            nonmatching = set(nonmatching)
+
+        elif dtype == "parent":
+            # Parent dependency fmris must exist outside of the
+            # current image, so we don't report any new matching
+            # or nonmatching requirements for the solver.
+            matching = nonmatching = frozenset()
+            required = False
+
+        elif dtype == "origin":
+            matching, nonmatching = self.__comb_newer_fmris(
+                fmri, dotrim=False, obsolete_ok=obsolete_ok
+            )
+            required = False
+
+        elif dtype == "group" or dtype == "group-any":
+            obsolete_ok = True
+            # Determine potential fmris for matching.
+            potential = [
+                fmri
+                for fmri in fmris
+                if not (
+                    fmri.pkg_name in self.__avoid_set
+                    or fmri.pkg_name in self.__reject_set
+                )
+            ]
+            required = len(potential) > 0
+
+            # Determine matching fmris.
+            matching = nonmatching = frozenset()
+            if required:
+                matching, nonmatching = self.__parse_group_dependency(
+                    dotrim, obsolete_ok, potential
+                )
+                if not matching and not nonmatching:
+                    # No possible stems at all? Ignore
+                    # dependency.
+                    required = False
+
+            # If more than one stem matched, prefer stems for which
+            # no obsoletion exists.
+            mstems = frozenset(f.pkg_name for f in matching)
+            if required and len(mstems) > 1:
+                ostems = set()
+                ofmris = set()
+                for f in matching:
+                    if self.__fmri_is_obsolete(f):
+                        ostems.add(f.pkg_name)
+                        ofmris.add(f)
+
+                # If not all matching stems had an obsolete
+                # version, remove the obsolete fmris from
+                # consideration.  This makes the assumption that
+                # at least one of the remaining, non-obsolete
+                # stems will be installable.  If that is not
+                # true, the solver may not find anything to do,
+                # or may not find a solution if the system is
+                # overly constrained.  This is believed
+                # unlikely, so seems a reasonable compromise.
+                # In that scenario, a client can move forward by
+                # using --reject to remove the related group
+                # dependencies.
+                if mstems - ostems:
+                    matching -= ofmris
+                    nonmatching |= ofmris
+
+        else:  # only way this happens is if new type is incomplete
+            raise api_errors.InvalidPackageErrors(
+                ["Unknown dependency type {0}".format(dtype)]
+            )
+
+        # check if we're throwing exceptions and we didn't find any
+        # matches on a required package
+        if not check_req or matching or not required:
+            return (nonmatching, matching, conditional, dtype, required, fmri)
+        elif dotrim and source in self.__inc_list and dtype == "incorporate":
+            # This is an incorporation package that will not be
+            # removed, so if dependencies can't be satisfied, try
+            # again with dotrim=False to ignore rejections due to
+            # proposed packages.
+            return self.__parse_dependency(
+                dependency_action,
+                source,
+                dotrim=False,
+                check_req=check_req,
+                proposed_dict=proposed_dict,
+            )
+
+        # Neither build or publisher is interesting for dependencies.
+        fstr = fmri.get_fmri(
+            anarchy=True, include_build=False, include_scheme=False
+        )
+
+        # we're going to toss an exception
+        if dtype == "exclude":
+            # If we reach this point, we know that a required
+            # package (already installed or proposed) was excluded.
+            matching, nonmatching = self.__comb_older_fmris(
+                fmri, dotrim=False, obsolete_ok=False
+            )
+
+            # Determine if excluded package is already installed.
+            installed = False
+            for f in nonmatching:
+                if f in self.__installed_fmris:
+                    installed = True
+                    break
+
+            if not matching and installed:
+                # The exclude dependency doesn't allow the
+                # version of the package that is already
+                # installed.
+                raise DependencyException(
+                    _TRIM_INSTALLED_EXCLUDE,
+                    (
+                        N_(
+                            "Package contains 'exclude' dependency "
+                            "{0} on installed package"
+                        ),
+                        (fstr,),
+                    ),
+                )
+            elif not matching and not installed:
+                # The exclude dependency doesn't allow any
+                # version of the package that is proposed.
+                raise DependencyException(
+                    _TRIM_INSTALLED_EXCLUDE,
+                    (
+                        N_(
+                            "Package contains 'exclude' dependency "
+                            "{0} on proposed package"
+                        ),
+                        (fstr,),
+                    ),
+                )
+            else:
+                # All versions of the package allowed by the
+                # exclude dependency were trimmed by other
+                # dependencies.  If changed, update _fmri_errors
+                # _TRIM_DEP_TRIMMED.
+                raise DependencyException(
+                    _TRIM_DEP_TRIMMED,
+                    (
+                        N_(
+                            "No version allowed by 'exclude' "
+                            "dependency {0} could be installed"
+                        ),
+                        (fstr,),
+                    ),
+                    matching,
+                )
+            # not reached
+        elif dtype == "incorporate":
+            matching, nonmatching = self.__comb_auto_fmris(
+                fmri, dotrim=False, obsolete_ok=obsolete_ok
+            )
+
+        # check if allowing obsolete packages helps
+
+        elif not obsolete_ok:
+            # see if allowing obsolete pkgs gets us some matches
+            if len(fmris) == 1:
+                matching, nonmatching = self.__comb_newer_fmris(
+                    fmri, dotrim, obsolete_ok=True
+                )
+            else:
+                matching = []
+                nonmatching = []
+                for f in fmris:
+                    m, nm = self.__comb_newer_fmris(f, dotrim, obsolete_ok=True)
+                    matching.extend(m)
+                    nonmatching.extend(nm)
+            if matching:
+                if len(fmris) == 1:
+                    raise DependencyException(
+                        _TRIM_DEP_OBSOLETE,
+                        (
+                            N_(
+                                "All acceptable versions of "
+                                "'{0}' dependency on {1} are "
+                                "obsolete"
+                            ),
+                            (dtype, fstr),
+                        ),
+                    )
+                else:
+                    sfmris = frozenset(
+                        [
+                            fmri.get_fmri(
+                                anarchy=True,
+                                include_build=False,
+                                include_scheme=False,
+                            )
+                            for f in fmris
+                        ]
+                    )
+                    raise DependencyException(
+                        _TRIM_DEP_OBSOLETE,
+                        (
+                            N_(
+                                "All acceptable versions of "
+                                "'{0}' dependencies on {1} are "
+                                "obsolete"
+                            ),
+                            (dtype, sfmris),
+                        ),
+                    )
+            # something else is wrong
+            matching, nonmatching = self.__comb_newer_fmris(
+                fmri, dotrim=False, obsolete_ok=obsolete_ok
+            )
+        else:
+            # try w/o trimming anything
+            matching, nonmatching = self.__comb_newer_fmris(
+                fmri, dotrim=False, obsolete_ok=obsolete_ok
+            )
+
+        if not matching:
+            raise DependencyException(
+                _TRIM_DEP_MISSING,
+                (
+                    N_(
+                        "No version for '{0}' dependency on {1} can " "be found"
+                    ),
+                    (dtype, fstr),
+                ),
+            )
+
+        # If this is a dependency of a proposed package for which only
+        # one version is possible, then mark all other versions as
+        # rejected by this package.  This ensures that other proposed
+        # packages will be included in error messaging if their
+        # dependencies can only be satisfied if this one is not
+        # proposed.
+        if (
+            dotrim
+            and nonmatching
+            and proposed_dict
+            and proposed_dict.get(source.pkg_name, []) == [source]
+        ):
+            nm = self.__parse_dependency(
+                dependency_action,
+                source,
+                dotrim=False,
+                check_req=check_req,
+                proposed_dict=proposed_dict,
+            )[0]
+            self.__trim(
+                nm,
+                _TRIM_DEP_TRIMMED,
+                (
+                    N_(
+                        "Rejected by '{0}' dependency in proposed "
+                        "package '{1}'"
+                    ),
+                    (dtype, source.pkg_name),
+                ),
+                fmri_adds=[source],
+            )
+
+        # If changed, update _fmri_errors _TRIM_DEP_TRIMMED.
+        raise DependencyException(
+            _TRIM_DEP_TRIMMED,
+            (
+                N_(
+                    "No version matching '{0}' dependency {1} can be "
+                    "installed"
+                ),
+                (dtype, fstr),
+            ),
+            matching,
+        )
+
+    def __installed_unsatisfied_parent_deps(
+        self, excludes, ignore_inst_parent_deps
+    ):
+        """If we're a child image then we need to relax packages
+        that are dependent upon themselves in the parent image.  This
+        is necessary to keep those packages in sync."""
+
+        relax_pkgs = set()
+
+        # check if we're a child image.
+        if not self.__is_child():
+            return relax_pkgs
+
+        # if we're ignoring parent dependencies there is no reason to
+        # relax install-holds in packages constrained by those
+        # dependencies.
+        if ignore_inst_parent_deps:
+            return relax_pkgs
+
+        for f in self.__installed_fmris:
+            for da in self.__get_dependency_actions(f, excludes):
+                if da.attrs["type"] != "parent":
+                    continue
+                self.__linked_pkgs.add(f)
+
+                if pkg.actions.depend.DEPEND_SELF not in da.attrlist("fmri"):
+                    continue
+
+                # We intentionally do not rely on 'insync' state
+                # as a change in facets/variants may result in
+                # changed parent constraints.
+                pf = self.__parent_dict.get(f.pkg_name)
+                if pf != f:
+                    # We only need to relax packages that
+                    # don't match the parent.
+                    relax_pkgs.add(f.pkg_name)
+                    break
+
+        return relax_pkgs
+
+    def __generate_dependency_errors(self, fmri_list, excludes=EmptyI):
+        """Returns a list of strings describing why fmris cannot
+        be installed, or returns an empty list if installation
+        is possible."""
+        ret = []
+
+        needs_processing = set(fmri_list)
+        already_processed = set()
+        already_seen = set()
+
+        while needs_processing:
+            fmri = needs_processing.pop()
+            errors, newfmris = self.__do_error_work(
+                fmri, excludes, already_seen
+            )
+            ret.extend(errors)
+            already_processed.add(fmri)
+            needs_processing |= newfmris - already_processed
+        return ret
+
+    def get_trim_errors(self):
+        """Returns a list of strings for all FMRIs evaluated by the
+        solver explaining why they were rejected.  (All packages
+        found in solver's trim database.)"""
+
+        # At a minimum, a solve_*() method must have been called first.
+        assert self.__state != SOLVER_INIT
+        # Value 'DebugValues' is unsubscriptable;
+        # pylint: disable=E1136
+        assert DebugValues["plan"]
+
+        return self.__fmri_list_errors(
+            six.iterkeys(self.__trim_dict), already_seen=set(), verbose=True
+        )
+
+    def __check_installed(self):
+        """Generate list of strings describing why currently
+        installed packages cannot be installed, or empty list"""
+
+        # Used to de-dup errors.
+        already_seen = set()
+
+        ret = []
+        for f in self.__installed_fmris - self.__removal_fmris:
+            matching = self.__comb_newer_fmris(
+                f, dotrim=True, obsolete_ok=True
+            )[0]
+            if matching:
+                continue
+            # no matches when disallowed packages are excluded
+            matching = self.__comb_newer_fmris(
+                f, dotrim=False, obsolete_ok=True
+            )[0]
+
+            ret.append(
+                _(
+                    "No suitable version of installed package " "{0} found"
+                ).format(f.pkg_name)
+            )
+            ret.extend(
+                self.__fmri_list_errors(matching, already_seen=already_seen)
+            )
+
+        return ret
+
+    def __fmri_list_errors(
+        self, fmri_list, indent="", already_seen=None, omit=None, verbose=False
+    ):
+        """Given a list of FMRIs, return indented strings indicating why
+        they were rejected."""
+        ret = []
+
+        if omit is None:
+            omit = set()
+
+        fmri_reasons = []
+        skey = operator.attrgetter("pkg_name")
+        for f in sorted(fmri_list, key=skey):
+            res = self.__fmri_errors(
+                f, indent, already_seen=already_seen, omit=omit, verbose=verbose
+            )
+            # If None was returned, that implies that all of the
+            # reasons the FMRI was rejected aren't interesting.
+            if res is not None:
+                fmri_reasons.append(res)
+
+        last_run = []
+
+        def collapse_fmris():
+            """Collapse a range of FMRIs into format:
+
+            first_fmri
+              to
+            last_fmri
+
+            ...based on verbose state."""
+
+            if last_run:
+                indent = last_run.pop(0)
+                if verbose or len(last_run) <= 1:
+                    ret.extend(last_run)
+                elif not self.__depend_ts and ret[-1].endswith(
+                    last_run[-1].strip()
+                ):
+                    # If timestamps are not being displayed
+                    # and the last FMRI is the same as the
+                    # first in the range then we only need
+                    # to show the first.
+                    pass
+                else:
+                    ret.append(indent + "  " + _("to"))
+                    ret.append(last_run[-1])
+            last_run[::] = []
+
+        last_reason = None
+        for fmri_id, reason in fmri_reasons:
+            if reason == last_reason:
+                indent = " " * len(fmri_id[0])
+                if not last_run:
+                    last_run.append(indent)
+                last_run.append(indent + fmri_id[1])
+                continue
+            else:  # ends run
+                collapse_fmris()
+                if last_reason:
+                    ret.extend(last_reason)
+                ret.append(fmri_id[0] + fmri_id[1])
+                last_reason = reason
+        if last_reason:
+            collapse_fmris()
+            ret.extend(last_reason)
+        return ret
+
+    def __fmri_errors(
+        self, fmri, indent="", already_seen=None, omit=None, verbose=False
+    ):
+        """return a list of strings w/ indents why this fmri is not
+        suitable"""
+
+        if already_seen is None:
+            already_seen = set()
+        if omit is None:
+            omit = set()
+
+        fmri_id = [_("{0}  Reject:  ").format(indent)]
+        if not verbose and not self.__depend_ts:
+            # Exclude build and timestamp for brevity.
+            fmri_id.append(fmri.get_short_fmri())
+        else:
+            # Include timestamp for clarity if any dependency
+            # included a timestamp; exclude build for brevity.
+            fmri_id.append(fmri.get_fmri(include_build=False))
+
+        tag = _("Reason:")
+
+        if fmri in already_seen:
+            if fmri in omit:
+                return
+
+            # note to translators: 'indent' will be a series of
+            # whitespaces.
+            reason = _(
+                "{indent}  {tag}  [already rejected; see " "above]"
+            ).format(indent=indent, tag=tag)
+            return fmri_id, [reason]
+
+        already_seen.add(fmri)
+
+        if not verbose:
+            # By default, omit packages from errors that were only
+            # rejected due to a newer version being installed, or
+            # because they didn't match user-specified input.  It's
+            # tempting to omit _TRIM_REJECT here as well, but that
+            # leads to some very mysterious errors for
+            # administrators if the only reason an operation failed
+            # is because a required dependency was rejected.
+            for reason_id, reason_t, fmris in self.__trim_dict.get(
+                fmri, EmptyI
+            ):
+                if reason_id not in (
+                    _TRIM_INSTALLED_NEWER,
+                    _TRIM_PROPOSED_PUB,
+                    _TRIM_PROPOSED_VER,
+                ):
+                    break
+            else:
+                omit.add(fmri)
+                return
+
+        ms = []
+        for reason_id, reason_t, fmris in sorted(
+            self.__trim_dict.get(fmri, EmptyI)
+        ):
+            if not verbose:
+                if reason_id in (
+                    _TRIM_INSTALLED_NEWER,
+                    _TRIM_PROPOSED_PUB,
+                    _TRIM_PROPOSED_VER,
+                ):
+                    continue
+
+            if isinstance(reason_t, tuple):
+                reason = _(reason_t[0]).format(*reason_t[1])
+            else:
+                reason = _(reason_t)
+
+            ms.append("{0}  {1}  {2}".format(indent, tag, reason))
+
+            if reason in already_seen:
+                # If we've already explained why something was
+                # rejected before, skip it.
+                continue
+
+            # Use the reason text and not the id, as the text is
+            # specific to a particular rejection.
+            already_seen.add(reason)
+
+            # By default, don't include error output for
+            # dependencies on incorporation packages that don't
+            # specify a version since any version-specific
+            # dependencies will have caused a rejection elsewhere.
+            if (
+                not verbose
+                and reason_id == _TRIM_DEP_TRIMMED
+                and len(reason_t[1]) == 2
+            ):
+                dtype, fstr = reason_t[1]
+                if dtype == "require" and "@" not in fstr:
+                    # Assumes fstr does not include
+                    # publisher or scheme.
+                    if fstr in self.__known_incs:
+                        continue
+
+            # Add the reasons why each package version that
+            # satisfied a dependency was rejected.
+            res = self.__fmri_list_errors(
+                [
+                    f
+                    for f in sorted(fmris)
+                    if f not in already_seen
+                    if verbose or f not in omit
+                ],
+                indent + "  ",
+                already_seen=already_seen,
+                omit=omit,
+                verbose=verbose,
+            )
+
+            if res:
+                ms.append(indent + "    " + ("-" * 40))
+                ms.extend(res)
+                ms.append(indent + "    " + ("-" * 40))
+
+        return fmri_id, ms
+
+    def __do_error_work(self, fmri, excludes, already_seen):
+        """Private helper function used by __generate_dependency_errors
+        to determine why packages were rejected."""
+
+        needs_processing = set()
+
+        if self.__trim_dict.get(fmri):
+            return (
+                self.__fmri_list_errors([fmri], already_seen=already_seen),
+                needs_processing,
+            )
+
+        for a in self.__get_dependency_actions(fmri, excludes):
+            try:
+                matching = self.__parse_dependency(a, fmri, check_req=True)[1]
+            except DependencyException as e:
+                self.__trim((fmri,), e.reason_id, e.reason, fmri_adds=e.fmris)
+                s = _(
+                    "No suitable version of required package " "{0} found:"
+                ).format(fmri.pkg_name)
+                return (
+                    [s]
+                    + self.__fmri_list_errors(
+                        [fmri], already_seen=already_seen
+                    ),
+                    set(),
+                )
+            needs_processing |= matching
+        return [], needs_processing
+
+    # clause generation routines
+    def __gen_dependency_clauses(self, fmri, da, dotrim=True):
+        """Return clauses to implement this dependency"""
+        nm, m, cond, dtype, _req, _depf = self.__parse_dependency(
+            da, fmri, dotrim
+        )
+
+        if dtype == "require" or dtype == "require-any":
+            return self.__gen_require_clauses(fmri, m)
+        elif dtype == "group" or dtype == "group-any":
+            if not m:
+                return []  # no clauses needed; pkg avoided
+            else:
+                return self.__gen_require_clauses(fmri, m)
+        elif dtype == "conditional":
+            return self.__gen_require_conditional_clauses(fmri, m, cond)
+        elif dtype in ["origin", "parent"]:
+            # handled by trimming proposed set, not by solver
+            return []
+        else:
+            return self.__gen_negation_clauses(fmri, nm)
+
+    def __gen_highlander_clauses(self, fmri_list):
+        """Return a list of clauses that specifies only one or zero
+        of the fmris in fmri_list may be installed.  This prevents
+        multiple versions of the same package being installed
+        at once"""
+
+        # pair wise negation
+        # if a has 4 versions, we need
+        # [
+        #  [-a.1, -a.2],
+        #  [-a.1, -a.3],
+        #  [-a.1, -a.4],
+        #  [-a.2, -a.3],
+        #  [-a.2, -a.4],
+        #  [-a.3, -a.4]
+        # ]
+        # n*(n-1)/2 algorithms suck
+
+        if len(fmri_list) == 1:  # avoid generation of singletons
+            return []
+
+        id_list = [-self.__getid(fmri) for fmri in fmri_list]
+        l = len(id_list)
+
+        return [
+            [id_list[i], id_list[j]]
+            for i in range(l - 1)
+            for j in range(i + 1, l)
+        ]
+
+    def __gen_require_clauses(self, fmri, matching_fmri_list):
+        """generate clause for require dependency: if fmri is
+        installed, one of fmri_list is required"""
+        # if a.1 requires b.2, b.3 or b.4:
+        # !a.1 | b.2 | b.3 | b.4
+
+        return [
+            [-self.__getid(fmri)]
+            + [self.__getid(fmri) for fmri in matching_fmri_list]
+        ]
+
+    def __gen_require_conditional_clauses(
+        self, fmri, matching_fmri_list, conditional_fmri_list
+    ):
+        """Generate clauses for conditional dependency: if
+        fmri is installed and one of conditional_fmri_list is installed,
+        one of fmri list is required"""
+        # if a.1 requires c.2, c.3, c.4 if b.2 or newer is installed:
+        # !a.1 | !b.2 | c.2 | c.3 | c.4
+        # !a.1 | !b.3 | c.2 | c.3 | c.4
+        mlist = [self.__getid(f) for f in matching_fmri_list]
+
+        return [
+            [-self.__getid(fmri)] + [-self.__getid(c)] + mlist
+            for c in conditional_fmri_list
+        ]
+
+    def __gen_negation_clauses(self, fmri, non_matching_fmri_list):
+        """generate clauses for optional, incorporate and
+        exclude dependencies to exclude non-acceptable versions"""
+        # if present, fmri must match ok list
+        # if a.1 optionally requires b.3:
+        # [
+        #   [!a.1 | !b.1],
+        #   [!a.1 | !b.2]
+        # ]
+        fmri_id = self.__getid(fmri)
+        return [[-fmri_id, -self.__getid(f)] for f in non_matching_fmri_list]
+
+    def __gen_one_of_these_clauses(self, fmri_list):
+        """generate clauses such that at least one of the fmri_list
+        members gets installed"""
+        # If a has four versions,
+        # a.1|a.2|a.3|a.4
+        # plus highlander clauses
+        assert fmri_list, "Empty list of which one is required"
+        return [[self.__getid(fmri) for fmri in fmri_list]]
+
+    def __addclauses(self, clauses):
+        """add list of clause lists to solver"""
+
+        for c in clauses:
+            try:
+                if not self.__solver.add_clause(c):
+                    self.__addclause_failure = True
+                self.__clauses += 1
+            except TypeError:
+                raise TypeError(
+                    _("List of integers, not {0}, " "expected").format(c)
+                )
+
+    def __get_child_holds(self, install_holds, pkg_cons, inc_set):
+        """Returns the list of installed packages that are incorporated
+        by packages, delivering an install-hold, and that do not have an
+        install-hold but incorporate packages.
+
+        'install_holds' is a dict of installed package stems indicating
+        the pkg.depend.install-hold delivered by the package that are
+        not being removed.
+
+        'pkg_cons' is a dict of installed package fmris and the
+        incorporate constraints they deliver.
+
+        'inc_set' is a list of packages that incorporate other packages
+        and deliver install-hold actions.  It acts as the starting point
+        where we fan out to find "child" packages that incorporate other
+        packages."""
+
+        unprocessed = set(inc_set)
+        processed = set()
+        proc_cons = set()
+        incorps = set()
+
+        while unprocessed:
+            self.__progress()
+            ifmri = unprocessed.pop()
+            processed.add(ifmri)
+
+            if ifmri in self.__removal_fmris:
+                # This package will be removed, so
+                # nothing to do.
+                continue
+
+            cons = pkg_cons.get(ifmri, [])
+            if cons and ifmri.pkg_name not in install_holds:
+                # If this package incorporates other
+                # packages and does not deliver an
+                # install-hold, then consider it a
+                # 'child' hold.
+                incorps.add(ifmri)
+
+            # Find all incorporation constraints that result
+            # in only one possible match.  If there is only
+            # one possible match for an incorporation
+            # constraint then that package will not be
+            # upgraded and should be checked for
+            # incorporation constraints.
+            for con in cons:
+                if con.pkg_name in install_holds or con in proc_cons:
+                    # Already handled.
+                    continue
+                matching = list(self.__comb_auto_fmris(con)[0])
+                if len(matching) == 1:
+                    if matching[0] not in processed:
+                        unprocessed.add(matching[0])
+                else:
+                    # Track which constraints have
+                    # already been processed
+                    # seperately from which
+                    # package FMRIs have been
+                    # processed to avoid (unlikely)
+                    # collision.
+                    proc_cons.add(con)
+
+        return incorps
+
+    def __get_installed_upgradeable_incorps(self, excludes=EmptyI):
+        """Return the latest version of installed upgradeable
+        incorporations w/ install holds"""
+
+        installed_incs = []
+        for f in self.__installed_fmris - self.__removal_fmris:
+            for d in self.__catalog.get_entry_actions(
+                f, [catalog.Catalog.DEPENDENCY], excludes=excludes
+            ):
+                if (
+                    d.name == "set"
+                    and d.attrs["name"] == "pkg.depend.install-hold"
+                ):
+                    installed_incs.append(f)
+
+        ret = []
+        for f in installed_incs:
+            matching = self.__comb_newer_fmris(f, dotrim=False)[0]
+            latest = sorted(matching, reverse=True)[0]
+            if latest != f:
+                ret.append(latest)
+        return ret
+
+    def __get_installed_unbound_inc_list(self, proposed_pkgs, excludes=EmptyI):
+        """Return the list of incorporations that are to not to change
+        during this install operation, and the lists of fmris they
+        constrain."""
+
+        incorps = set()
+        versioned_dependents = set()
+        pkg_cons = {}
+        install_holds = {}
+
+        # Determine installed packages that contain incorporation
+        # dependencies, those packages that are depended on by explict
+        # version, and those that have pkg.depend.install-hold values.
+        for f in self.__installed_fmris - self.__removal_fmris:
+            for d in self.__catalog.get_entry_actions(
+                f, [catalog.Catalog.DEPENDENCY], excludes=excludes
+            ):
+                if d.name == "depend":
+                    fmris = []
+                    for fl in d.attrlist("fmri"):
+                        try:
+                            tmp = self.__fmridict[fl]
+                        except KeyError:
+                            tmp = pkg.fmri.PkgFmri(fl)
+                            self.__fmridict[fl] = tmp
+                        fmris.append(tmp)
+                    if d.attrs["type"] == "incorporate":
+                        incorps.add(f.pkg_name)
+                        pkg_cons.setdefault(f, []).append(fmris[0])
+                    versioned_dependents.update(
+                        fmri.pkg_name
+                        for fmri in fmris
+                        if fmri.version is not None
+                    )
+                elif (
+                    d.name == "set"
+                    and d.attrs["name"] == "pkg.depend.install-hold"
+                ):
+                    install_holds[f.pkg_name] = d.attrs["value"]
+
+        # find install holds that appear on command line and are thus
+        # relaxed
+        relaxed_holds = set(
+            [
+                install_holds[name]
+                for name in proposed_pkgs
+                if name in install_holds
+            ]
+        )
+
+        # add any other install holds that are relaxed because they have
+        # values that start w/ the relaxed ones...
+        relaxed_holds |= set(
+            [
+                hold
+                for hold in six.itervalues(install_holds)
+                if [r for r in relaxed_holds if hold.startswith(r + ".")]
+            ]
+        )
+
+        # Expand the list of install holds to include packages that are
+        # incorporated by packages delivering an install-hold and that
+        # do not have an install-hold, but incorporate packages.
+        child_holds = self.__get_child_holds(
+            install_holds,
+            pkg_cons,
+            set(
+                inc
+                for inc in pkg_cons
+                if inc.pkg_name in install_holds
+                and install_holds[inc.pkg_name] not in relaxed_holds
+            ),
+        )
+
+        for child_hold in child_holds:
+            assert child_hold.pkg_name not in install_holds
+            install_holds[child_hold.pkg_name] = child_hold.pkg_name
+
+        # versioned_dependents contains all the packages that are
+        # depended on w/ a explicit version.  We now modify this list so
+        # that it does not contain any packages w/ install_holds, unless
+        # those holds were relaxed.
+        versioned_dependents -= set(
+            [
+                pkg_name
+                for pkg_name, hold_value in six.iteritems(install_holds)
+                if hold_value not in relaxed_holds
+            ]
+        )
+        # Build the list of fmris that 1) contain incorp. dependencies
+        # 2) are not in the set of versioned_dependents and 3) do not
+        # explicitly appear on the install command line.
+        installed_dict = self.__installed_dict
+        ret = [
+            installed_dict[pkg_name]
+            for pkg_name in incorps - versioned_dependents
+            if pkg_name not in proposed_pkgs
+            if installed_dict[pkg_name] not in self.__removal_fmris
+        ]
+        # For each incorporation above that will not change, return a
+        # list of the fmris that incorporation constrains
+        con_lists = [[i for i in pkg_cons[inc]] for inc in ret]
+
+        return ret, con_lists
+
+    def __mark_pub_trimmed(self, pkg_name):
+        """Record that a given package stem has been trimmed based on
+        publisher."""
+
+        self.__pub_trim[pkg_name] = True
+
+    def __filter_publishers(self, pkg_name):
+        """Given a list of fmris for various versions of
+        a package from various publishers, trim those
+        that are not suitable"""
+
+        if pkg_name in self.__pub_trim:  # already done
+            return
+        self.__mark_pub_trimmed(pkg_name)
+
+        fmri_list = self.__get_catalog_fmris(pkg_name)
+
+        if pkg_name in self.__publisher:
+            acceptable_pubs = [self.__publisher[pkg_name]]
+            if pkg_name in self.__installed_dict:
+                reason_id = _TRIM_PUB_STICKY
+                reason = (
+                    N_(
+                        "Currently installed package "
+                        "'{0}' is from sticky publisher '{1}'."
+                    ),
+                    (pkg_name, self.__publisher[pkg_name]),
+                )
+            else:
+                reason_id = _TRIM_PROPOSED_PUB
+                reason = N_(
+                    "Package is from publisher other " "than specified one."
+                )
+        else:
+            # order by pub_rank; choose highest possible tier for
+            # pkgs; guard against unconfigured publishers in known
+            # catalog
+            pubs_found = set((f.publisher for f in fmri_list))
+            ranked = sorted(
+                [
+                    (self.__pub_ranks[p][0], p)
+                    for p in pubs_found
+                    if self.__pub_ranks.get(p, (0, False, False))[2]
+                ]
+            )
+            acceptable_pubs = [r[1] for r in ranked if r[0] == ranked[0][0]]
+            reason_id = _TRIM_PUB_RANK
+            if acceptable_pubs:
+                reason = (
+                    N_("Higher ranked publisher {0} was " "selected"),
+                    (acceptable_pubs[0],),
+                )
+            else:
+                reason = N_(
+                    "Package publisher is ranked lower " "in search order"
+                )
+
+        # allow installed packages to co-exist to meet dependency reqs.
+        # in case new publisher not proper superset of original.  avoid
+        # multiple publishers w/ the exact same fmri to prevent
+        # thrashing in the solver due to many equiv. solutions.
+        inst_f = self.__installed_dict.get(pkg_name)
+        self.__trim(
+            [
+                f
+                for f in fmri_list
+                if (
+                    f.publisher not in acceptable_pubs
+                    and (not inst_f or f != inst_f)
+                )
+                or (
+                    inst_f
+                    and f.publisher != inst_f.publisher
+                    and f.version == inst_f.version
+                )
+            ],
+            reason_id,
+            reason,
+        )
+
+    # routines to manage the trim dictionary
+    # trim dictionary contains the reasons an fmri was rejected for
+    # consideration reason is a tuple of a string w/ format chars and args,
+    # or just a string.  fmri_adds are any fmris that caused the rejection
+
+    def __trim(self, fmri_list, reason_id, reason, fmri_adds=EmptyI):
+        """Remove specified fmri(s) from consideration for specified
+        reason."""
+
+        self.__progress()
+        assert reason_id in range(_TRIM_MAX)
+
+        # XXX - determine whether this block is still necessary
+        # - was introduced in 51ff33eef0f3fdaf9954afeeabedd3f842008b50
+        # and subsequently moved.
+
+        # There's ugly issue when we receive reason having set of fmris
+        # with require-any dependencies, which differentiate only by
+        # timestamp. In this case add operation fails. The workaround
+        # is to add only the first dependency to the trim dictionary.
+        # if (type(reason[1]) is tuple and len(reason[1])>1 and
+        #    type(reason[1][1]) is list and len(reason[1][1])>=1):
+        #        reason=(reason[0],(reason[1][0],reason[1][1][0]))
+
+        tup = (reason_id, reason, frozenset(fmri_adds))
+
+        for fmri in fmri_list:
+            self.__trim_dict[fmri].add(tup)
+
+    def __trim_older(self, fmri):
+        """Trim any fmris older than this one"""
+        reason = (N_("Newer version {0} is already installed"), (fmri,))
+        self.__trim(
+            self.__comb_newer_fmris(fmri, dotrim=False)[1]
+            - self.__allowed_downgrades,
+            _TRIM_INSTALLED_NEWER,
+            reason,
+        )
+
+    def __trim_nonmatching_variants(self, fmri):
+        """Trim packages that don't support image architecture or other
+        image variant."""
+
+        vd = self.__get_variant_dict(fmri)
+        reason = ""
+
+        for v in self.__variants.keys():
+            if v in vd and self.__variants[v] not in vd[v]:
+                if vd == "variant.arch":
+                    reason = N_("Package doesn't support " "image architecture")
+                else:
+                    reason = (
+                        N_(
+                            "Package supports image "
+                            "variant {0}={1} but doesn't "
+                            "support this image's {0}={2}"
+                        ),
+                        (v, str(vd[v]), str(self.__variants[v])),
+                    )
+
+                self.__trim((fmri,), _TRIM_VARIANT, reason)
+        return reason == ""
+
+    def __trim_nonmatching_parents1(self, pkg_fmri, fmri):
+        """Private helper function for __trim_nonmatching_parents that
+        trims any pkg_fmri that matches a parent dependency and that is
+        not installed in the parent image, that is from a different
+        publisher than the parent image, or that is a different version
+        than the parent image."""
+
+        if fmri in self.__parent_pkgs:
+            # exact fmri installed in parent
+            return True
+
+        if fmri.pkg_name not in self.__parent_dict:
+            # package is not installed in parent
+            if self.__is_zone():
+                reason = (
+                    N_("Package {0} is not installed in " "global zone."),
+                    (fmri.pkg_name,),
+                )
+            else:
+                reason = (
+                    N_("Package {0} is not installed in " "parent image."),
+                    (fmri.pkg_name,),
+                )
+            self.__trim((pkg_fmri,), _TRIM_PARENT_MISSING, reason)
+            return False
+
+        pf = self.__parent_dict[fmri.pkg_name]
+        if fmri.publisher and fmri.publisher != pf.publisher:
+            # package is from a different publisher in the parent
+            if self.__is_zone():
+                reason = (
+                    N_(
+                        "Package in global zone is from "
+                        "a different publisher: {0}"
+                    ),
+                    (pf,),
+                )
+            else:
+                reason = (
+                    N_(
+                        "Package in parent is from a "
+                        "different publisher: {0}"
+                    ),
+                    (pf,),
+                )
+            self.__trim((pkg_fmri,), _TRIM_PARENT_PUB, reason)
+            return False
+
+        if pf.version == fmri.version:
+            # parent dependency is satisfied, which applies to both
+            # DEPEND_SELF and other cases
+            return True
+        elif pkg_fmri != fmri and pf.version.is_successor(
+            fmri.version, version.CONSTRAINT_NONE
+        ):
+            # *not* DEPEND_SELF; parent dependency is satisfied
+            return True
+
+        # version mismatch
+        if pf.version.is_successor(fmri.version, version.CONSTRAINT_NONE):
+            reason_id = _TRIM_PARENT_NEWER
+            if self.__is_zone():
+                reason = (N_("Global zone has a " "newer version: {0}"), (pf,))
+            else:
+                reason = (N_("Parent image has a " "newer version: {0}"), (pf,))
+        else:
+            reason_id = _TRIM_PARENT_OLDER
+            if self.__is_zone():
+                reason = (
+                    N_("Global zone has an older " "version of package: {0}"),
+                    (pf,),
+                )
+            else:
+                reason = (
+                    N_("Parent image has an older " "version of package: {0}"),
+                    (pf,),
+                )
+
+        self.__trim((pkg_fmri,), reason_id, reason)
+        return False
+
+    def __trim_nonmatching_parents(
+        self, pkg_fmri, excludes, ignore_inst_parent_deps=False
+    ):
+        """Trim any pkg_fmri that contains a parent dependency that
+        is not satisfied by the parent image."""
+
+        # the fmri for the package should include a publisher
+        assert pkg_fmri.publisher
+
+        # if we're not a child then ignore "parent" dependencies.
+        if not self.__is_child():
+            return True
+
+        # check if we're ignoring parent dependencies for installed
+        # packages.
+        if ignore_inst_parent_deps and pkg_fmri in self.__installed_fmris:
+            return True
+
+        # Find all the fmris that we depend on in our parent.
+        # Use a set() to eliminate any dups.
+        pkg_deps = set(
+            [
+                pkg.fmri.PkgFmri(f)
+                for da in self.__get_dependency_actions(pkg_fmri, excludes)
+                if da.attrs["type"] == "parent"
+                for f in da.attrlist("fmri")
+            ]
+        )
+
+        if not pkg_deps:
+            # no parent dependencies.
+            return True
+        self.__linked_pkgs.add(pkg_fmri)
+
+        allowed = True
+        for f in pkg_deps:
+            fmri = f
+            if f.pkg_name == pkg.actions.depend.DEPEND_SELF:
+                # check if this package depends on itself.
+                fmri = pkg_fmri
+            if not self.__trim_nonmatching_parents1(pkg_fmri, fmri):
+                allowed = False
+        return allowed
+
+    def __trim_nonmatching_origins(
+        self, fmri, excludes, exact_install=False, installed_dict_tmp=EmptyDict
+    ):
+        """Trim any fmri that contains a origin dependency that is
+        not satisfied by the current image or root-image"""
+
+        for da in self.__get_dependency_actions(fmri, excludes):
+            if da.attrs["type"] != "origin":
+                continue
+
+            req_fmri = pkg.fmri.PkgFmri(da.attrs["fmri"])
+
+            if da.attrs.get("root-image", "").lower() == "true":
+                if req_fmri.pkg_name.startswith("feature/firmware/"):
+                    # this is a firmware dependency
+                    fw_ok, reason = self.__firmware.check_firmware(
+                        da, req_fmri.pkg_name
+                    )
+                    if not fw_ok:
+                        self.__trim((fmri,), _TRIM_FIRMWARE, reason)
                         return False
+                    continue
+
+                if self.__root_fmris is None:
+                    img = pkg.client.image.Image(
+                        misc.liveroot(),
+                        allow_ondisk_upgrade=False,
+                        user_provided_dir=True,
+                        should_exist=True,
+                    )
+                    self.__root_fmris = dict(
+                        [(f.pkg_name, f) for f in img.gen_installed_pkgs()]
+                    )
+
+                installed = self.__root_fmris.get(req_fmri.pkg_name)
+                reason_id = _TRIM_INSTALLED_ROOT_ORIGIN
+                reason = (
+                    N_(
+                        "Installed version in root image "
+                        "is too old for origin "
+                        "dependency {0}"
+                    ),
+                    (req_fmri,),
+                )
+            else:
+                # Always use the full installed dict for origin
+                # dependency.
+                if exact_install:
+                    installed = installed_dict_tmp.get(req_fmri.pkg_name)
+                else:
+                    installed = self.__installed_dict.get(req_fmri.pkg_name)
+                reason_id = _TRIM_INSTALLED_ORIGIN
+                reason = (
+                    N_(
+                        "Installed version in image "
+                        "being upgraded is too old for origin "
+                        "dependency {0}"
+                    ),
+                    (req_fmri,),
+                )
+
+            # assumption is that for root-image, publishers align;
+            # otherwise these sorts of cross-environment
+            # dependencies don't work well
+
+            if (
+                not installed
+                or not req_fmri.version
+                or req_fmri.version == installed.version
+                or installed.version.is_successor(
+                    req_fmri.version, version.CONSTRAINT_NONE
+                )
+            ):
+                continue
+
+            self.__trim((fmri,), reason_id, reason)
+
+            return False
+        return True
+
+    def __trim_unsupported(self, fmri):
+        """Indicate given package FMRI is unsupported."""
+        self.__trim(
+            (fmri,),
+            _TRIM_UNSUPPORTED,
+            N_("Package contains invalid or unsupported actions"),
+        )
+
+    def __get_older_incorp_pkgs(
+        self, fmri, install_holds, excludes=EmptyI, relax_all=False, depth=0
+    ):
+        """Get all incorporated pkgs for the given 'fmri' whose versions
+        are older than what is currently installed in the image."""
+
+        candidates = set()
+        if fmri in self.__dg_incorp_cache:
+            candidates |= self.__dg_incorp_cache[fmri]
+            return candidates
+
+        if depth > 10:
+            # Safeguard against circular dependencies.
+            # If it happens, just end the recursion tree.
+            return candidates
+
+        self.__dg_incorp_cache[fmri] = set()
+        self.__progress()
+
+        # Get all matching incorporated packages for this fmri; this is
+        # a list of sets, where each set represents all of the fmris
+        # matching the incorporate dependency for a single package stem.
+        #
+        # Only add potential FMRIs to the list of allowed downgrades if
+        # the currently installed version is not allowed by the related
+        # incorporate dependency.  This prevents two undesirable
+        # behaviours:
+        #
+        # - downgrades when a package is no longer incorporated in
+        #   a newer version of an incorporating package and an older
+        #   version is otherwise allowed
+        # - upgrades of packages that are no longer incorporated
+        #   in a newer version of an incorporating package and a newer
+        #   version is otherwise allowed
+        for matchdg, nonmatchdg in six.itervalues(
+            self.__get_incorp_nonmatch_dict(fmri, excludes)
+        ):
+            match = next(iter(matchdg), None)
+            if not match or match.pkg_name not in self.__installed_dict:
+                continue
+
+            inst_fmri = self.__installed_dict[match.pkg_name]
+            if inst_fmri in matchdg:
+                continue
+
+            inst_ver = inst_fmri.version
+            for df in matchdg:
+                if df.version == inst_ver:
+                    # If installed version is not changing,
+                    # there is no need to check for
+                    # downgraded incorporate deps.
+                    continue
+
+                is_successor = df.version.is_successor(inst_ver, None)
+                if relax_all and is_successor:
+                    # If all install-holds are relaxed, and
+                    # this package is being upgraded, it is
+                    # not a downgrade candidate and there is
+                    # no need to recursively check for
+                    # downgraded incorporate deps here as
+                    # will be checked directly later in
+                    # solve_update_all.
+                    continue
+
+                # Do not allow implicit publisher switches.
+                if df.publisher != fmri.publisher:
+                    continue
+
+                # Do not allow pkgs marked for removal.
+                if fmri in self.__removal_fmris:
+                    continue
+
+                # Do not allow pkgs with install-holds but filter out
+                # child holds
+                install_hold = False
+                for ha in [
+                    sa
+                    for sa in self.__get_actions(df, "set")
+                    if sa.attrs["name"] == "pkg.depend.install-hold"
+                ]:
+                    install_hold = True
+                    for h in install_holds:
+                        if ha.attrs["value"].startswith(h):
+                            # This is a child hold
+                            # of an incorporating
+                            # pkg, ignore.
+                            install_hold = False
+                            break
+                    if not install_hold:
+                        break
+                if install_hold:
+                    continue
+
+                if not is_successor:
+                    self.__dg_incorp_cache[fmri].add(df)
+                    candidates.add(df)
+
+                if not relax_all:
+                    # If all install-holds are not relaxed,
+                    # then we need to check if pkg has
+                    # incorporate deps of its own since not
+                    # every package is being checked
+                    # individually.
+                    candidates |= self.__get_older_incorp_pkgs(
+                        df,
+                        install_holds,
+                        excludes=excludes,
+                        relax_all=relax_all,
+                        depth=depth + 1,
+                    )
+
+        return candidates
+
+    def __allow_incorp_downgrades(self, fmri, excludes=EmptyI, relax_all=False):
+        """Find packages which have lower versions than installed but
+        are incorporated by a package in the proposed list."""
+
+        install_holds = set(
+            [
+                sa.attrs["value"]
+                for sa in self.__get_actions(fmri, "set")
+                if sa.attrs["name"] == "pkg.depend.install-hold"
+            ]
+        )
+
+        # Get all pkgs which are incorporated by 'fmri',
+        # including nested incorps.
+        candidates = self.__get_older_incorp_pkgs(
+            fmri, install_holds, excludes=excludes, relax_all=relax_all
+        )
+
+        return candidates
+
+    def __dotrim(self, fmri_list):
+        """Return fmri_list trimmed of any fmris in self.__trim_dict"""
+
+        return [f for f in fmri_list if not self.__trim_dict.get(f)]
+
+    def __is_child(self):
+        """Return True if this image is a linked image child."""
+        return self.__parent_pkgs is not None
+
+    def __is_zone(self):
+        """Return True if image is a nonglobal zone"""
+        if "variant.opensolaris.zone" in self.__variants:
+            return self.__variants["variant.opensolaris.zone"] == "nonglobal"
+        else:
+            return False
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/pkgdefs.py
+++ b/src/modules/client/pkgdefs.py
@@ -30,130 +30,136 @@ Definitions for values used by the pkg(1) client.
 """
 
 # pkg exit codes
-EXIT_OK        =  0 # Command succeeded.
-EXIT_OOPS      =  1 # An error occurred.
-EXIT_BADOPT    =  2 # Invalid command line options were specified.
-EXIT_PARTIAL   =  3 # Multiple ops were requested, but not all succeeded.
-EXIT_NOP       =  4 # No changes were made - nothing to do.
-EXIT_NOTLIVE   =  5 # The requested op cannot be performed on a live image.
-EXIT_LICENSE   =  6 # License acceptance required for requested op.
-EXIT_LOCKED    =  7 # Image is currently locked by another process
-EXIT_ACTUATOR  =  8 # Actuator timed out
-EXIT_CONSTRAINED = 9 # Overly constrained
+EXIT_OK = 0  # Command succeeded.
+EXIT_OOPS = 1  # An error occurred.
+EXIT_BADOPT = 2  # Invalid command line options were specified.
+EXIT_PARTIAL = 3  # Multiple ops were requested, but not all succeeded.
+EXIT_NOP = 4  # No changes were made - nothing to do.
+EXIT_NOTLIVE = 5  # The requested op cannot be performed on a live image.
+EXIT_LICENSE = 6  # License acceptance required for requested op.
+EXIT_LOCKED = 7  # Image is currently locked by another process
+EXIT_ACTUATOR = 8  # Actuator timed out
+EXIT_CONSTRAINED = 9  # Overly constrained
 
 # private pkg exit codes
-EXIT_EACCESS   = 51 # Can't access requested image
-EXIT_DIVERGED  = 52 # Image is not in sync with its constraints
-EXIT_NOPARENT  = 53 # Image is not linked to a parent image
-EXIT_PARENTOP  = 54 # Linked operation must be done from parent
+EXIT_EACCESS = 51  # Can't access requested image
+EXIT_DIVERGED = 52  # Image is not in sync with its constraints
+EXIT_NOPARENT = 53  # Image is not linked to a parent image
+EXIT_PARENTOP = 54  # Linked operation must be done from parent
 
 # package operations
-PKG_OP_ATTACH          = "attach-linked"
-PKG_OP_AUDIT_LINKED    = "audit-linked"
-PKG_OP_CHANGE_FACET    = "change-facet"
-PKG_OP_CHANGE_VARIANT  = "change-variant"
-PKG_OP_DEHYDRATE       = "dehydrate"
-PKG_OP_DETACH          = "detach-linked"
-PKG_OP_EXACT_INSTALL   = "exact-install"
-PKG_OP_FIX             = "fix"
-PKG_OP_FLAG            = "flag"
-PKG_OP_INFO            = "info"
-PKG_OP_INSTALL         = "install"
-PKG_OP_LIST            = "list"
-PKG_OP_LIST_LINKED     = "list-linked"
-PKG_OP_PROP_LINKED     = "property-linked"
-PKG_OP_PUBCHECK        = "pubcheck-linked"
-PKG_OP_PUBLISHER_LIST  = "publisher"
-PKG_OP_REHYDRATE       = "rehydrate"
-PKG_OP_REVERT          = "revert"
-PKG_OP_SET_MEDIATOR    = "set-mediator"
-PKG_OP_SET_PUBLISHER   = "set-publisher"
+PKG_OP_ATTACH = "attach-linked"
+PKG_OP_AUDIT_LINKED = "audit-linked"
+PKG_OP_CHANGE_FACET = "change-facet"
+PKG_OP_CHANGE_VARIANT = "change-variant"
+PKG_OP_DEHYDRATE = "dehydrate"
+PKG_OP_DETACH = "detach-linked"
+PKG_OP_EXACT_INSTALL = "exact-install"
+PKG_OP_FIX = "fix"
+PKG_OP_FLAG = "flag"
+PKG_OP_INFO = "info"
+PKG_OP_INSTALL = "install"
+PKG_OP_LIST = "list"
+PKG_OP_LIST_LINKED = "list-linked"
+PKG_OP_PROP_LINKED = "property-linked"
+PKG_OP_PUBCHECK = "pubcheck-linked"
+PKG_OP_PUBLISHER_LIST = "publisher"
+PKG_OP_REHYDRATE = "rehydrate"
+PKG_OP_REVERT = "revert"
+PKG_OP_SET_MEDIATOR = "set-mediator"
+PKG_OP_SET_PUBLISHER = "set-publisher"
 PKG_OP_SET_PROP_LINKED = "set-property-linked"
-PKG_OP_SYNC            = "sync-linked"
-PKG_OP_UNINSTALL       = "uninstall"
+PKG_OP_SYNC = "sync-linked"
+PKG_OP_UNINSTALL = "uninstall"
 PKG_OP_UNSET_PUBLISHER = "unset-publisher"
-PKG_OP_UPDATE          = "update"
-PKG_OP_APPLY_HOT_FIX   = "apply-hot-fix"
-PKG_OP_AUTOREMOVE      = "autoremove"
-PKG_OP_HOTFIX_CLEANUP  = "clean-up-hot-fix"
-PKG_OP_VERIFY          = "verify"
-pkg_op_values          = frozenset([
-    PKG_OP_ATTACH,
-    PKG_OP_AUDIT_LINKED,
-    PKG_OP_CHANGE_FACET,
-    PKG_OP_CHANGE_VARIANT,
-    PKG_OP_DEHYDRATE,
-    PKG_OP_DETACH,
-    PKG_OP_EXACT_INSTALL,
-    PKG_OP_FIX,
-    PKG_OP_FLAG,
-    PKG_OP_INFO,
-    PKG_OP_INSTALL,
-    PKG_OP_LIST,
-    PKG_OP_LIST_LINKED,
-    PKG_OP_PROP_LINKED,
-    PKG_OP_PUBCHECK,
-    PKG_OP_PUBLISHER_LIST,
-    PKG_OP_REVERT,
-    PKG_OP_REHYDRATE,
-    PKG_OP_SET_MEDIATOR,
-    PKG_OP_SET_PUBLISHER,
-    PKG_OP_SET_PROP_LINKED,
-    PKG_OP_SYNC,
-    PKG_OP_UNINSTALL,
-    PKG_OP_UNSET_PUBLISHER,
-    PKG_OP_UPDATE,
-    PKG_OP_APPLY_HOT_FIX,
-    PKG_OP_AUTOREMOVE,
-    PKG_OP_HOTFIX_CLEANUP,
-    PKG_OP_VERIFY,
-])
+PKG_OP_UPDATE = "update"
+PKG_OP_APPLY_HOT_FIX = "apply-hot-fix"
+PKG_OP_AUTOREMOVE = "autoremove"
+PKG_OP_HOTFIX_CLEANUP = "clean-up-hot-fix"
+PKG_OP_VERIFY = "verify"
+pkg_op_values = frozenset(
+    [
+        PKG_OP_ATTACH,
+        PKG_OP_AUDIT_LINKED,
+        PKG_OP_CHANGE_FACET,
+        PKG_OP_CHANGE_VARIANT,
+        PKG_OP_DEHYDRATE,
+        PKG_OP_DETACH,
+        PKG_OP_EXACT_INSTALL,
+        PKG_OP_FIX,
+        PKG_OP_FLAG,
+        PKG_OP_INFO,
+        PKG_OP_INSTALL,
+        PKG_OP_LIST,
+        PKG_OP_LIST_LINKED,
+        PKG_OP_PROP_LINKED,
+        PKG_OP_PUBCHECK,
+        PKG_OP_PUBLISHER_LIST,
+        PKG_OP_REVERT,
+        PKG_OP_REHYDRATE,
+        PKG_OP_SET_MEDIATOR,
+        PKG_OP_SET_PUBLISHER,
+        PKG_OP_SET_PROP_LINKED,
+        PKG_OP_SYNC,
+        PKG_OP_UNINSTALL,
+        PKG_OP_UNSET_PUBLISHER,
+        PKG_OP_UPDATE,
+        PKG_OP_APPLY_HOT_FIX,
+        PKG_OP_AUTOREMOVE,
+        PKG_OP_HOTFIX_CLEANUP,
+        PKG_OP_VERIFY,
+    ]
+)
 
-API_OP_ATTACH         = "attach-linked"
-API_OP_CHANGE_FACET   = "change-facet"
+API_OP_ATTACH = "attach-linked"
+API_OP_CHANGE_FACET = "change-facet"
 API_OP_CHANGE_VARIANT = "change-variant"
-API_OP_DEHYDRATE      = "dehydrate"
-API_OP_DETACH         = "detach-linked"
-API_OP_EXACT_INSTALL  = "exact-install"
-API_OP_FIX            = "fix"
-API_OP_INSTALL        = "install"
-API_OP_REHYDRATE      = "rehydrate"
-API_OP_REPAIR         = "repair"
-API_OP_REVERT         = "revert"
-API_OP_SET_MEDIATOR   = "set-mediator"
-API_OP_SYNC           = "sync-linked"
-API_OP_UNINSTALL      = "uninstall"
-API_OP_UPDATE         = "update"
-API_OP_VERIFY         = "verify"
-api_op_values         = frozenset([
-    API_OP_ATTACH,
-    API_OP_CHANGE_FACET,
-    API_OP_CHANGE_VARIANT,
-    API_OP_DETACH,
-    API_OP_DEHYDRATE,
-    API_OP_EXACT_INSTALL,
-    API_OP_FIX,
-    API_OP_INSTALL,
-    API_OP_REHYDRATE,
-    API_OP_REPAIR,
-    API_OP_REVERT,
-    API_OP_SET_MEDIATOR,
-    API_OP_SYNC,
-    API_OP_UNINSTALL,
-    API_OP_UPDATE,
-    API_OP_VERIFY
-])
+API_OP_DEHYDRATE = "dehydrate"
+API_OP_DETACH = "detach-linked"
+API_OP_EXACT_INSTALL = "exact-install"
+API_OP_FIX = "fix"
+API_OP_INSTALL = "install"
+API_OP_REHYDRATE = "rehydrate"
+API_OP_REPAIR = "repair"
+API_OP_REVERT = "revert"
+API_OP_SET_MEDIATOR = "set-mediator"
+API_OP_SYNC = "sync-linked"
+API_OP_UNINSTALL = "uninstall"
+API_OP_UPDATE = "update"
+API_OP_VERIFY = "verify"
+api_op_values = frozenset(
+    [
+        API_OP_ATTACH,
+        API_OP_CHANGE_FACET,
+        API_OP_CHANGE_VARIANT,
+        API_OP_DETACH,
+        API_OP_DEHYDRATE,
+        API_OP_EXACT_INSTALL,
+        API_OP_FIX,
+        API_OP_INSTALL,
+        API_OP_REHYDRATE,
+        API_OP_REPAIR,
+        API_OP_REVERT,
+        API_OP_SET_MEDIATOR,
+        API_OP_SYNC,
+        API_OP_UNINSTALL,
+        API_OP_UPDATE,
+        API_OP_VERIFY,
+    ]
+)
 
-API_STAGE_DEFAULT  = "default"
-API_STAGE_PLAN     = "plan"
-API_STAGE_PREPARE  = "prepare"
-API_STAGE_EXECUTE  = "execute"
-api_stage_values  = frozenset([
-    API_STAGE_DEFAULT,
-    API_STAGE_PLAN,
-    API_STAGE_PREPARE,
-    API_STAGE_EXECUTE,
-])
+API_STAGE_DEFAULT = "default"
+API_STAGE_PLAN = "plan"
+API_STAGE_PREPARE = "prepare"
+API_STAGE_EXECUTE = "execute"
+api_stage_values = frozenset(
+    [
+        API_STAGE_DEFAULT,
+        API_STAGE_PLAN,
+        API_STAGE_PREPARE,
+        API_STAGE_EXECUTE,
+    ]
+)
 
 #
 # Please note that the values of these PKG_STATE constants should not
@@ -190,8 +196,8 @@ PKG_STATE_RENAMED = 9
 
 # These states are used to indicate why a package was rejected and
 # is not available for packaging operations.
-PKG_STATE_UNSUPPORTED = 10      # Package contains invalid or
-                                # unsupported metadata.
+PKG_STATE_UNSUPPORTED = 10  # Package contains invalid or
+# unsupported metadata.
 
 # This state indicates that this package is frozen.
 PKG_STATE_FROZEN = 11
@@ -223,4 +229,4 @@ MSG_GENERAL = "general"
 MSG_UNPACKAGED = "unpackaged"
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/pkgplan.py
+++ b/src/modules/client/pkgplan.py
@@ -47,678 +47,714 @@ from pkg.misc import expanddirs, get_pkg_otw_size, EmptyI
 
 logger = global_settings.logger
 
+
 class PkgPlan(object):
-        """A package plan takes two package FMRIs and an Image, and produces the
-        set of actions required to take the Image from the origin FMRI to the
-        destination FMRI.
+    """A package plan takes two package FMRIs and an Image, and produces the
+    set of actions required to take the Image from the origin FMRI to the
+    destination FMRI.
 
-        If the destination FMRI is None, the package is removed.
-        """
+    If the destination FMRI is None, the package is removed.
+    """
 
-        __slots__ = [
+    __slots__ = [
+        "__destination_mfst",
+        "_executed",
+        "_license_status",
+        "__origin_mfst",
+        "__repair_actions",
+        "__salvage_actions",
+        "__xferfiles",
+        "__xfersize",
+        "_autofix_pkgs",
+        "_hash",
+        "actions",
+        "destination_fmri",
+        "image",
+        "origin_fmri",
+        "pkg_summary",
+    ]
+
+    #
+    # we don't serialize __xferfiles or __xfersize since those should be
+    # recalculated after after a plan is loaded (since the contents of the
+    # download cache may have changed).
+    #
+    # we don't serialize __origin_mfst, __destination_mfst, or
+    # __repair_actions since we only support serializing pkgplans which
+    # have had their actions evaluated and merged, and when action
+    # evaluation is complete these fields are cleared.
+    #
+    # we don't serialize our image object pointer.  that has to be reset
+    # after this object is reloaded.
+    #
+    __state__noserialize = frozenset(
+        [
             "__destination_mfst",
-            "_executed",
-            "_license_status",
             "__origin_mfst",
             "__repair_actions",
             "__salvage_actions",
             "__xferfiles",
             "__xfersize",
-            "_autofix_pkgs",
-            "_hash",
-            "actions",
-            "destination_fmri",
             "image",
-            "origin_fmri",
-            "pkg_summary",
         ]
+    )
 
-        #
-        # we don't serialize __xferfiles or __xfersize since those should be
-        # recalculated after after a plan is loaded (since the contents of the
-        # download cache may have changed).
-        #
-        # we don't serialize __origin_mfst, __destination_mfst, or
-        # __repair_actions since we only support serializing pkgplans which
-        # have had their actions evaluated and merged, and when action
-        # evaluation is complete these fields are cleared.
-        #
-        # we don't serialize our image object pointer.  that has to be reset
-        # after this object is reloaded.
-        #
-        __state__noserialize = frozenset([
-                "__destination_mfst",
-                "__origin_mfst",
-                "__repair_actions",
-                "__salvage_actions",
-                "__xferfiles",
-                "__xfersize",
-                "image",
-        ])
+    # make sure all __state__noserialize values are valid
+    assert (__state__noserialize - set(__slots__)) == set()
 
-        # make sure all __state__noserialize values are valid
-        assert (__state__noserialize - set(__slots__)) == set()
+    # figure out which state we are saving.
+    __state__serialize = set(__slots__) - __state__noserialize
 
-        # figure out which state we are saving.
-        __state__serialize = set(__slots__) - __state__noserialize
-
-        # describe our state and the types of all objects
-        __state__desc = {
-            "_autofix_pkgs": [ pkg.fmri.PkgFmri ],
-            "_license_status": {
-                six.string_types[0]: {
-                    "src": pkg.actions.generic.NSG,
-                    "dest": pkg.actions.generic.NSG,
-                },
+    # describe our state and the types of all objects
+    __state__desc = {
+        "_autofix_pkgs": [pkg.fmri.PkgFmri],
+        "_license_status": {
+            six.string_types[0]: {
+                "src": pkg.actions.generic.NSG,
+                "dest": pkg.actions.generic.NSG,
             },
-            "actions": pkg.manifest.ManifestDifference,
-            "destination_fmri": pkg.fmri.PkgFmri,
-            "origin_fmri": pkg.fmri.PkgFmri,
+        },
+        "actions": pkg.manifest.ManifestDifference,
+        "destination_fmri": pkg.fmri.PkgFmri,
+        "origin_fmri": pkg.fmri.PkgFmri,
+    }
+
+    __state__commonize = frozenset(
+        [
+            pkg.fmri.PkgFmri,
+        ]
+    )
+
+    def __init__(self, image=None):
+        self.destination_fmri = None
+        self.__destination_mfst = manifest.NullFactoredManifest
+
+        self.origin_fmri = None
+        self.__origin_mfst = manifest.NullFactoredManifest
+
+        self.actions = manifest.ManifestDifference([], [], [])
+        self.image = image
+        self.pkg_summary = None
+
+        self._executed = False
+        self._license_status = {}
+        self.__repair_actions = {}
+        self.__salvage_actions = {}
+        self.__xferfiles = -1
+        self.__xfersize = -1
+        self._autofix_pkgs = []
+        self._hash = None
+
+    @staticmethod
+    def getstate(obj, je_state=None):
+        """Returns the serialized state of this object in a format
+        that that can be easily stored using JSON, pickle, etc."""
+
+        # validate unserialized state
+        # (see comments above __state__noserialize)
+        assert obj.__origin_mfst == manifest.NullFactoredManifest
+        assert obj.__destination_mfst == manifest.NullFactoredManifest
+        assert obj.__repair_actions == {}
+
+        # we use __slots__, so create a state dictionary
+        state = {}
+        for k in obj.__state__serialize:
+            state[k] = getattr(obj, k)
+
+        return pkg.misc.json_encode(
+            PkgPlan.__name__,
+            state,
+            PkgPlan.__state__desc,
+            commonize=PkgPlan.__state__commonize,
+            je_state=je_state,
+        )
+
+    @staticmethod
+    def setstate(obj, state, jd_state=None):
+        """Update the state of this object using previously serialized
+        state obtained via getstate()."""
+
+        # get the name of the object we're dealing with
+        name = type(obj).__name__
+
+        # decode serialized state into python objects
+        state = pkg.misc.json_decode(
+            name,
+            state,
+            PkgPlan.__state__desc,
+            commonize=PkgPlan.__state__commonize,
+            jd_state=jd_state,
+        )
+
+        # we use __slots__, so directly update attributes
+        for k in state:
+            setattr(obj, k, state[k])
+
+        # update unserialized state
+        # (see comments above __state__noserialize)
+        obj.__origin_mfst = manifest.NullFactoredManifest
+        obj.__destination_mfst = manifest.NullFactoredManifest
+        obj.__repair_actions = {}
+        obj.__xferfiles = -1
+        obj.__xfersize = -1
+        obj.image = None
+
+    @staticmethod
+    def fromstate(state, jd_state=None):
+        """Allocate a new object using previously serialized state
+        obtained via getstate()."""
+        rv = PkgPlan()
+        PkgPlan.setstate(rv, state, jd_state)
+        return rv
+
+    def __str__(self):
+        s = "{0} -> {1}\n".format(self.origin_fmri, self.destination_fmri)
+        for src, dest in itertools.chain(*self.actions):
+            s += "  {0} -> {1}\n".format(src, dest)
+        return s
+
+    def __add_license(self, src, dest):
+        """Adds a license status entry for the given src and dest
+        license actions.
+
+        'src' should be None or the source action for a license.
+
+        'dest' must be the destination action for a license."""
+
+        self._license_status[dest.attrs["license"]] = {
+            "src": src,
+            "dest": dest,
+            "accepted": False,
+            "displayed": False,
         }
 
-        __state__commonize = frozenset([
-            pkg.fmri.PkgFmri,
-        ])
+    def propose(self, of, om, df, dm):
+        """Propose origin and dest fmri, manifest"""
+        self.origin_fmri = of
+        self.__origin_mfst = om
+        self.destination_fmri = df
+        self.__destination_mfst = dm
 
-        def __init__(self, image=None):
-                self.destination_fmri = None
-                self.__destination_mfst = manifest.NullFactoredManifest
+    def __get_orig_act(self, dest):
+        """Generate the on-disk state (attributes) of the action
+        that fail verification."""
 
-                self.origin_fmri = None
-                self.__origin_mfst = manifest.NullFactoredManifest
+        if not dest.has_payload or "path" not in dest.attrs:
+            return
 
-                self.actions = manifest.ManifestDifference([], [], [])
-                self.image = image
-                self.pkg_summary = None
+        path = os.path.join(self.image.root, dest.attrs["path"])
+        try:
+            pstat = os.lstat(path)
+        except Exception:
+            # If file to repair isn't on-disk, treat as install
+            return
 
-                self._executed = False
-                self._license_status = {}
-                self.__repair_actions = {}
-                self.__salvage_actions = {}
-                self.__xferfiles = -1
-                self.__xfersize = -1
-                self._autofix_pkgs = []
-                self._hash = None
+        act = pkg.actions.fromstr(str(dest))
+        act.attrs["mode"] = oct(stat.S_IMODE(pstat.st_mode))
+        try:
+            owner = pwd.getpwuid(pstat.st_uid).pw_name
+            group = grp.getgrgid(pstat.st_gid).gr_name
+        except KeyError:
+            # If associated user / group can't be determined, treat
+            # as install. This is not optimal for repairs, but
+            # ensures proper ownership of file is set.
+            return
+        act.attrs["owner"] = owner
+        act.attrs["group"] = group
 
-        @staticmethod
-        def getstate(obj, je_state=None):
-                """Returns the serialized state of this object in a format
-                that that can be easily stored using JSON, pickle, etc."""
+        # No need to generate hash of on-disk content as verify
+        # short-circuits hash comparison by setting replace_required
+        # flag on action.  The same is true for preserved files which
+        # will automatically handle content replacement if needed based
+        # on the result of _check_preserve.
+        return act
 
-                # validate unserialized state
-                # (see comments above __state__noserialize)
-                assert obj.__origin_mfst == manifest.NullFactoredManifest
-                assert obj.__destination_mfst == manifest.NullFactoredManifest
-                assert obj.__repair_actions == {}
+    def propose_repair(self, fmri, mfst, install, remove, autofix=False):
+        self.propose(fmri, mfst, fmri, mfst)
+        # self.origin_fmri = None
+        # I'd like a cleaner solution than this; we need to actually
+        # construct a list of actions as things currently are rather
+        # than just re-applying the current set of actions.
+        #
+        # Create a list of (src, dst) pairs for the actions to send to
+        # execute_repair.
 
-                # we use __slots__, so create a state dictionary
-                state = {}
-                for k in obj.__state__serialize:
-                        state[k] = getattr(obj, k)
+        if autofix:
+            # If an uninstall causes a fixup to happen, we can't
+            # generate an on-disk state action because the result
+            # of needsdata is different between propose and execute.
+            # Therefore, we explicitly assign None to src for actions
+            # to be installed.
+            self.__repair_actions = {
+                # src is none for repairs
+                "install": [(None, x) for x in install],
+                # dest is none for removals.
+                "remove": [(x, None) for x in remove],
+            }
+            self._autofix_pkgs.append(fmri)
+        else:
+            self.__repair_actions = {
+                # src can be None or an action representing on-disk state
+                "install": [(self.__get_orig_act(x), x) for x in install],
+                "remove": [(x, None) for x in remove],
+            }
 
-                return pkg.misc.json_encode(PkgPlan.__name__, state,
-                    PkgPlan.__state__desc,
-                    commonize=PkgPlan.__state__commonize, je_state=je_state)
+    def get_actions(self):
+        raise NotImplementedError()
 
-        @staticmethod
-        def setstate(obj, state, jd_state=None):
-                """Update the state of this object using previously serialized
-                state obtained via getstate()."""
+    def get_nactions(self):
+        return (
+            len(self.actions.added)
+            + len(self.actions.changed)
+            + len(self.actions.removed)
+        )
 
-                # get the name of the object we're dealing with
-                name = type(obj).__name__
+    def update_pkg_set(self, fmri_set):
+        """updates a set of installed fmris to reflect
+        proposed new state"""
 
-                # decode serialized state into python objects
-                state = pkg.misc.json_decode(name, state,
-                    PkgPlan.__state__desc,
-                    commonize=PkgPlan.__state__commonize,
-                    jd_state=jd_state)
+        if self.origin_fmri:
+            fmri_set.discard(self.origin_fmri)
 
-                # we use __slots__, so directly update attributes
-                for k in state:
-                        setattr(obj, k, state[k])
+        if self.destination_fmri:
+            fmri_set.add(self.destination_fmri)
 
-                # update unserialized state
-                # (see comments above __state__noserialize)
-                obj.__origin_mfst = manifest.NullFactoredManifest
-                obj.__destination_mfst = manifest.NullFactoredManifest
-                obj.__repair_actions = {}
-                obj.__xferfiles = -1
-                obj.__xfersize = -1
-                obj.image = None
+    def evaluate(
+        self, old_excludes=EmptyI, new_excludes=EmptyI, can_exclude=False
+    ):
+        """Determine the actions required to transition the package."""
 
-        @staticmethod
-        def fromstate(state, jd_state=None):
-                """Allocate a new object using previously serialized state
-                obtained via getstate()."""
-                rv = PkgPlan()
-                PkgPlan.setstate(rv, state, jd_state)
-                return rv
+        # If new actions are being installed, check the destination
+        # manifest for signatures.
+        if self.destination_fmri is not None:
+            try:
+                dest_pub = self.image.get_publisher(
+                    prefix=self.destination_fmri.publisher
+                )
+            except apx.UnknownPublisher:
+                # Since user removed publisher, assume this is
+                # the same as if they had set signature-policy
+                # ignore for the publisher.
+                sig_pol = None
+            else:
+                sig_pol = self.image.signature_policy.combine(
+                    dest_pub.signature_policy
+                )
 
-        def __str__(self):
-                s = "{0} -> {1}\n".format(self.origin_fmri,
-                    self.destination_fmri)
-                for src, dest in itertools.chain(*self.actions):
-                        s += "  {0} -> {1}\n".format(src, dest)
-                return s
+            if self.destination_fmri in self._autofix_pkgs:
+                # Repaired packages use a manifest synthesized
+                # from the installed one; so retrieve the
+                # installed one for our signature checks.
+                sigman = self.image.get_manifest(
+                    self.destination_fmri, ignore_excludes=True
+                )
+            else:
+                sigman = self.__destination_mfst
 
-        def __add_license(self, src, dest):
-                """Adds a license status entry for the given src and dest
-                license actions.
+            sigs = list(
+                sigman.gen_actions_by_type("signature", excludes=new_excludes)
+            )
+            if sig_pol and (sigs or sig_pol.name != "ignore"):
+                # Only perform signature verification logic if
+                # there are signatures or if signature-policy
+                # is not 'ignore'.
 
-                'src' should be None or the source action for a license.
-
-                'dest' must be the destination action for a license."""
-
-                self._license_status[dest.attrs["license"]] = {
-                    "src": src,
-                    "dest": dest,
-                    "accepted": False,
-                    "displayed": False,
-                }
-
-        def propose(self, of, om, df, dm):
-                """Propose origin and dest fmri, manifest"""
-                self.origin_fmri = of
-                self.__origin_mfst = om
-                self.destination_fmri = df
-                self.__destination_mfst = dm
-
-        def __get_orig_act(self, dest):
-                """Generate the on-disk state (attributes) of the action
-                that fail verification."""
-
-                if not dest.has_payload or "path" not in dest.attrs:
-                        return
-
-                path = os.path.join(self.image.root, dest.attrs["path"])
                 try:
-                        pstat = os.lstat(path)
-                except Exception:
-                        # If file to repair isn't on-disk, treat as install
-                        return
-
-                act = pkg.actions.fromstr(str(dest))
-                act.attrs["mode"] = oct(stat.S_IMODE(pstat.st_mode))
-                try:
-                        owner = pwd.getpwuid(pstat.st_uid).pw_name
-                        group = grp.getgrgid(pstat.st_gid).gr_name
-                except KeyError:
-                        # If associated user / group can't be determined, treat
-                        # as install. This is not optimal for repairs, but
-                        # ensures proper ownership of file is set.
-                        return
-                act.attrs["owner"] = owner
-                act.attrs["group"] = group
-
-                # No need to generate hash of on-disk content as verify
-                # short-circuits hash comparison by setting replace_required
-                # flag on action.  The same is true for preserved files which
-                # will automatically handle content replacement if needed based
-                # on the result of _check_preserve.
-                return act
-
-        def propose_repair(self, fmri, mfst, install, remove, autofix=False):
-                self.propose(fmri, mfst, fmri, mfst)
-                # self.origin_fmri = None
-                # I'd like a cleaner solution than this; we need to actually
-                # construct a list of actions as things currently are rather
-                # than just re-applying the current set of actions.
-                #
-                # Create a list of (src, dst) pairs for the actions to send to
-                # execute_repair.
-
-                if autofix:
-                        # If an uninstall causes a fixup to happen, we can't
-                        # generate an on-disk state action because the result
-                        # of needsdata is different between propose and execute.
-                        # Therefore, we explicitly assign None to src for actions
-                        # to be installed.
-                        self.__repair_actions = {
-                            # src is none for repairs
-                            "install": [(None, x) for x in install],
-                            # dest is none for removals.
-                            "remove": [(x, None) for x in remove],
-                        }
-                        self._autofix_pkgs.append(fmri)
-                else:
-                        self.__repair_actions = {
-                            # src can be None or an action representing on-disk state
-                            "install": [(self.__get_orig_act(x), x) for x in install],
-                            "remove": [(x, None) for x in remove],
-                        }
-
-        def get_actions(self):
-                raise NotImplementedError()
-
-        def get_nactions(self):
-                return len(self.actions.added) + len(self.actions.changed) + \
-                    len(self.actions.removed)
-
-        def update_pkg_set(self, fmri_set):
-                """ updates a set of installed fmris to reflect
-                proposed new state"""
-
-                if self.origin_fmri:
-                        fmri_set.discard(self.origin_fmri)
-
-                if self.destination_fmri:
-                        fmri_set.add(self.destination_fmri)
-
-        def evaluate(self, old_excludes=EmptyI, new_excludes=EmptyI,
-            can_exclude=False):
-                """Determine the actions required to transition the package."""
-
-                # If new actions are being installed, check the destination
-                # manifest for signatures.
-                if self.destination_fmri is not None:
-                        try:
-                                dest_pub = self.image.get_publisher(
-                                    prefix=self.destination_fmri.publisher)
-                        except apx.UnknownPublisher:
-                                # Since user removed publisher, assume this is
-                                # the same as if they had set signature-policy
-                                # ignore for the publisher.
-                                sig_pol = None
-                        else:
-                                sig_pol = self.image.signature_policy.combine(
-                                    dest_pub.signature_policy)
-
-                        if self.destination_fmri in self._autofix_pkgs:
-                                # Repaired packages use a manifest synthesized
-                                # from the installed one; so retrieve the
-                                # installed one for our signature checks.
-                                sigman = self.image.get_manifest(
-                                    self.destination_fmri,
-                                    ignore_excludes=True)
-                        else:
-                                sigman = self.__destination_mfst
-
-                        sigs = list(sigman.gen_actions_by_type("signature",
-                            excludes=new_excludes))
-                        if sig_pol and (sigs or sig_pol.name != "ignore"):
-                                # Only perform signature verification logic if
-                                # there are signatures or if signature-policy
-                                # is not 'ignore'.
-
-                                try:
-                                        sig_pol.process_signatures(sigs,
-                                            sigman.gen_actions(),
-                                            dest_pub, self.image.trust_anchors,
-                                            self.image.cfg.get_policy(
-                                                "check-certificate-revocation"))
-                                except apx.SigningException as e:
-                                        e.pfmri = self.destination_fmri
-                                        if isinstance(e, apx.BrokenChain):
-                                                e.ext_exs.extend(
-                                                    self.image.bad_trust_anchors
-                                                    )
-                                        raise
-                if can_exclude:
-                        if self.__destination_mfst is not None:
-                                self.__destination_mfst.exclude_content(
-                                    new_excludes)
-                        if self.__origin_mfst is not None and \
-                            self.__destination_mfst != self.__origin_mfst:
-                                self.__origin_mfst.exclude_content(old_excludes)
-                        old_excludes = EmptyI
-                        new_excludes = EmptyI
-
-                self.actions = self.__destination_mfst.difference(
-                    self.__origin_mfst, old_excludes, new_excludes,
-                    pkgplan=self)
-
-                # figure out how many implicit directories disappear in this
-                # transition and add directory remove actions.  These won't
-                # do anything unless no pkgs reference that directory in
-                # new state....
-
-                # Retrieving origin_dirs first and then checking it for any
-                # entries allows avoiding an unnecessary expanddirs for the
-                # destination manifest when it isn't needed.
-                origin_dirs = expanddirs(self.__origin_mfst.get_directories(
-                    old_excludes))
-
-                # Manifest.get_directories() returns implicit directories, which
-                # means that this computation ends up re-adding all the explicit
-                # directories getting removed to the removed list.  This is
-                # ugly, but safe.
-                if origin_dirs:
-                        absent_dirs = origin_dirs - \
-                            expanddirs(self.__destination_mfst.get_directories(
-                            new_excludes))
-
-                        for a in absent_dirs:
-                                self.actions.removed.append(
-                                    (directory.DirectoryAction(path=a,
-                                    implicit="True"), None))
-
-                # Stash information needed by legacy actions.
-                self.pkg_summary = \
-                    self.__destination_mfst.get("pkg.summary",
-                    self.__destination_mfst.get("description", "none provided"))
-
-                # Add any install repair actions to the update list
-                self.actions.changed.extend(self.__repair_actions.get("install",
-                    EmptyI))
-                self.actions.removed.extend(self.__repair_actions.get("remove",
-                    EmptyI))
-
-                # No longer needed.
-                self.__repair_actions = {}
-
-                for src, dest in itertools.chain(self.gen_update_actions(),
-                    self.gen_install_actions()):
-                        if dest.name == "license":
-                                self.__add_license(src, dest)
-                                if not src:
-                                        # Initial installs require acceptance.
-                                        continue
-                                src_ma = src.attrs.get("must-accept", False)
-                                dest_ma = dest.attrs.get("must-accept", False)
-                                if (dest_ma and src_ma) and \
-                                    src.hash == dest.hash:
-                                        # If src action required acceptance,
-                                        # then license was already accepted
-                                        # before, and if the hashes are the
-                                        # same for the license payload, then
-                                        # it doesn't need to be accepted again.
-                                        self.set_license_status(
-                                            dest.attrs["license"],
-                                            accepted=True)
-
-                        # Keep a cache of dir actions with salvage-from attrs.
-                        # Since directories are installed in top-down order,
-                        # we need this list to make sure we salvage contents
-                        # as accurately as possible. For example, where:
-                        #
-                        #  /var/user gets salvaged to /var/.migrate/user
-                        #  and
-                        #  /var/user/myuser/.ssh to /var/.migrate/user/myuser/.ssh
-                        #
-                        # We must ensure that we don't try to salvage
-                        # var/user/myuser/.ssh when installing
-                        # /var/.migrate/user,
-                        # but instead wait till /var/.migrate/user/myuser/.ssh
-                        # is being installed, otherwise that content will
-                        # the salvaged to the wrong place.
-                        if (dest.name == "dir" and
-                            "salvage-from" in dest.attrs):
-                                for p in dest.attrlist("salvage-from"):
-                                        self.__salvage_actions[p] = dest
-
-        def get_licenses(self):
-                """A generator function that yields tuples of the form (license,
-                entry).  Where 'entry' is a dict containing the license status
-                information."""
-
-                for lic, entry in six.iteritems(self._license_status):
-                        yield lic, entry
-
-        def set_license_status(self, plicense, accepted=None, displayed=None):
-                """Sets the license status for the given license entry.
-
-                'plicense' should be the value of the license attribute for the
-                destination license action.
-
-                'accepted' is an optional parameter that can be one of three
-                values:
-                        None    leaves accepted status unchanged
-                        False   sets accepted status to False
-                        True    sets accepted status to True
-
-                'displayed' is an optional parameter that can be one of three
-                values:
-                        None    leaves displayed status unchanged
-                        False   sets displayed status to False
-                        True    sets displayed status to True"""
-
-                entry = self._license_status[plicense]
-                if accepted is not None:
-                        entry["accepted"] = accepted
-                if displayed is not None:
-                        entry["displayed"] = displayed
-
-        def get_xferstats(self):
-                if self.__xfersize != -1:
-                        return (self.__xferfiles, self.__xfersize)
-
-                self.__xfersize = 0
-                self.__xferfiles = 0
-                for src, dest in itertools.chain(*self.actions):
-                        if dest and dest.needsdata(src, self):
-                                self.__xfersize += get_pkg_otw_size(dest)
-                                self.__xferfiles += 1
-                                if dest.name == "signature":
-                                        self.__xfersize += \
-                                            dest.get_action_chain_csize()
-                                        self.__xferfiles += \
-                                            len(dest.attrs.get("chain",
-                                                "").split())
-
-                return (self.__xferfiles, self.__xfersize)
-
-        def get_bytes_added(self):
-                """Return tuple of compressed bytes possibly downloaded
-                and number of bytes laid down; ignore removals
-                because they're usually pinned by snapshots"""
-                def sum_dest_size(a, b):
-                        if b[1]:
-                                return (a[0] + int(b[1].attrs.get("pkg.csize" ,0)),
-                                    a[1] + int(b[1].attrs.get("pkg.size", 0)))
-                        return (a[0], a[1])
-
-                return reduce(sum_dest_size, itertools.chain(*self.actions),
-                    (0, 0))
-
-        def get_xferfmri(self):
-                if self.destination_fmri:
-                        return self.destination_fmri
-                if self.origin_fmri:
-                        return self.origin_fmri
-                return None
-
-        def preexecute(self):
-                """Perform actions required prior to installation or removal of
-                a package.
-
-                This method executes each action's preremove() or preinstall()
-                methods, as well as any package-wide steps that need to be taken
-                at such a time.
-                """
-
-                # Determine if license acceptance requirements have been met as
-                # early as possible.
-                errors = []
-                for lic, entry in self.get_licenses():
-                        dest = entry["dest"]
-                        if (dest.must_accept and not entry["accepted"]) or \
-                            (dest.must_display and not entry["displayed"]):
-                                errors.append(apx.LicenseAcceptanceError(
-                                    self.destination_fmri, **entry))
-
-                if errors:
-                        raise apx.PkgLicenseErrors(errors)
-
-                for src, dest in itertools.chain(*self.actions):
-                        if dest:
-                                dest.preinstall(self, src)
-                        else:
-                                src.preremove(self)
-
-        def download(self, progtrack, check_cancel):
-                """Download data for any actions that need it."""
-                progtrack.download_start_pkg(self.get_xferfmri())
-                mfile = self.image.transport.multi_file(self.destination_fmri,
-                    progtrack, check_cancel)
-
-                if mfile is None:
-                        progtrack.download_end_pkg(self.get_xferfmri())
-                        return
-
-                for src, dest in itertools.chain(*self.actions):
-                        if dest and dest.needsdata(src, self):
-                                mfile.add_action(dest)
-
-                mfile.wait_files()
-                progtrack.download_end_pkg(self.get_xferfmri())
-
-        def cacheload(self):
-                """Load previously downloaded data for actions that need it."""
-
-                fmri = self.destination_fmri
-                for src, dest in itertools.chain(*self.actions):
-                        if not dest or not dest.needsdata(src, self):
-                                continue
-                        dest.data = self.image.transport.action_cached(fmri,
-                            dest)
-
-        def gen_install_actions(self):
-                for src, dest in self.actions.added:
-                        yield src, dest
-
-        def gen_removal_actions(self):
-                for src, dest in self.actions.removed:
-                        yield src, dest
-
-        def gen_update_actions(self):
-                for src, dest in self.actions.changed:
-                        yield src, dest
-
-        def execute_install(self, src, dest):
-                """ perform action for installation of package"""
-                if DebugValues["actions"]:
-                        print("execute_install: {} -> {}".format(src, dest))
-                self._executed = True
-                try:
-                        dest.install(self, src)
-                except (pkg.actions.ActionError, EnvironmentError):
-                        # Don't log these as they're expected, and should be
-                        # handled by the caller.
-                        raise
-                except Exception as e:
-                        logger.error("Action install failed for '{0}' ({1}):\n  "
-                            "{2}: {3}".format(dest.attrs.get(dest.key_attr,
-                            id(dest)), self.destination_fmri.get_pkg_stem(),
-                            e.__class__.__name__, e))
-                        raise
-
-        def execute_update(self, src, dest):
-                """ handle action updates"""
-                if DebugValues["actions"]:
-                        print("execute_update: {} -> {}".format(src, dest))
-                self._executed = True
-                try:
-                        dest.install(self, src)
-                except (pkg.actions.ActionError, EnvironmentError):
-                        # Don't log these as they're expected, and should be
-                        # handled by the caller.
-                        raise
-                except Exception as e:
-                        logger.error("Action upgrade failed for '{0}' ({1}):\n "
-                            "{2}: {3}".format(dest.attrs.get(dest.key_attr,
-                            id(dest)), self.destination_fmri.get_pkg_stem(),
-                            e.__class__.__name__, e))
-                        raise
-
-        def execute_removal(self, src, dest):
-                """ handle action removals"""
-                if DebugValues["actions"]:
-                        print("execute_removal: {}".format(src))
-                self._executed = True
-                try:
-                        src.remove(self)
-                except (pkg.actions.ActionError, EnvironmentError):
-                        # Don't log these as they're expected, and should be
-                        # handled by the caller.
-                        raise
-                except Exception as e:
-                        logger.error("Action removal failed for '{0}' ({1}):\n "
-                            "{2}: {3}".format(src.attrs.get(src.key_attr,
-                            id(src)), self.origin_fmri.get_pkg_stem(),
-                            e.__class__.__name__, e))
-                        raise
-
-        def execute_retry(self, src, dest):
-                """handle a retry operation"""
-                dest.retry(self, dest)
-
-        def postexecute(self):
-                """Perform actions required after install or remove of a pkg.
-
-                This method executes each action's postremove() or postinstall()
-                methods, as well as any package-wide steps that need to be taken
-                at such a time.
-                """
-                # record that package states are consistent
-                for src, dest in itertools.chain(*self.actions):
-                        if dest:
-                                dest.postinstall(self, src)
-                        else:
-                                src.postremove(self)
-
-        def salvage(self, path):
-                """Used to save unexpected files or directories found during
-                plan execution.  Salvaged items are tracked in the imageplan.
-                """
-
-                assert self._executed
-                spath = self.image.salvage(path)
-                # get just the file path that was salvaged
-                fpath = path.replace(
-                    os.path.normpath(self.image.get_root()), "", 1)
-                if fpath.startswith(os.path.sep):
-                        fpath = fpath[1:]
-                self.image.imageplan.pd._salvaged.append((fpath, spath))
-
-        def salvage_from(self, local_path, full_destination):
-                """move unpackaged contents to specified destination"""
-                # remove leading / if present
-                if local_path.startswith(os.path.sep):
-                        local_path = local_path[1:]
-
-                # The salvaged locations known to us are a list of tuples of
-                # the form (old dir, lost+found salvage dir) and stored in
-                # self.image.imageplan.pd._salvaged[:]
-
-                #
-                # Check if this salvage-from is also the best match for other
-                # possibly previously packaged subdirs of this directory.
-                # E.g. if we stop delivering /var/user/evsuser/.ssh, then the
-                # action that specifies 'salvage-from=var/user' ought to deal
-                # with its files.
-                #
-                # On the other hand, if we package another directory, with
-                # 'salvage-from=/var/user/evsuser', then that should be used
-                # to salvage the .ssh content, not the action that salvages
-                # from /var/user.
-                #
-                for fpath, spath in self.image.imageplan.pd._salvaged[:]:
-                        if fpath.startswith(local_path):
-                                for other_salvage in self.__salvage_actions:
-                                   if fpath.startswith(other_salvage) and \
-                                       len(other_salvage) > len(local_path):
-                                            continue
-
-                                self.image.imageplan.pd._salvaged.remove(
-                                    (fpath, spath))
-                                self.image.recover(
-                                    spath, full_destination,
-                                    local_path, fpath)
-
-        @property
-        def destination_manifest(self):
-                return self.__destination_mfst
-
-        def clear_dest_manifest(self):
-                self.__destination_mfst = manifest.NullFactoredManifest
-
-        @property
-        def origin_manifest(self):
-                return self.__origin_mfst
-
-        def clear_origin_manifest(self):
-                self.__origin_mfst = manifest.NullFactoredManifest
+                    sig_pol.process_signatures(
+                        sigs,
+                        sigman.gen_actions(),
+                        dest_pub,
+                        self.image.trust_anchors,
+                        self.image.cfg.get_policy(
+                            "check-certificate-revocation"
+                        ),
+                    )
+                except apx.SigningException as e:
+                    e.pfmri = self.destination_fmri
+                    if isinstance(e, apx.BrokenChain):
+                        e.ext_exs.extend(self.image.bad_trust_anchors)
+                    raise
+        if can_exclude:
+            if self.__destination_mfst is not None:
+                self.__destination_mfst.exclude_content(new_excludes)
+            if (
+                self.__origin_mfst is not None
+                and self.__destination_mfst != self.__origin_mfst
+            ):
+                self.__origin_mfst.exclude_content(old_excludes)
+            old_excludes = EmptyI
+            new_excludes = EmptyI
+
+        self.actions = self.__destination_mfst.difference(
+            self.__origin_mfst, old_excludes, new_excludes, pkgplan=self
+        )
+
+        # figure out how many implicit directories disappear in this
+        # transition and add directory remove actions.  These won't
+        # do anything unless no pkgs reference that directory in
+        # new state....
+
+        # Retrieving origin_dirs first and then checking it for any
+        # entries allows avoiding an unnecessary expanddirs for the
+        # destination manifest when it isn't needed.
+        origin_dirs = expanddirs(
+            self.__origin_mfst.get_directories(old_excludes)
+        )
+
+        # Manifest.get_directories() returns implicit directories, which
+        # means that this computation ends up re-adding all the explicit
+        # directories getting removed to the removed list.  This is
+        # ugly, but safe.
+        if origin_dirs:
+            absent_dirs = origin_dirs - expanddirs(
+                self.__destination_mfst.get_directories(new_excludes)
+            )
+
+            for a in absent_dirs:
+                self.actions.removed.append(
+                    (directory.DirectoryAction(path=a, implicit="True"), None)
+                )
+
+        # Stash information needed by legacy actions.
+        self.pkg_summary = self.__destination_mfst.get(
+            "pkg.summary",
+            self.__destination_mfst.get("description", "none provided"),
+        )
+
+        # Add any install repair actions to the update list
+        self.actions.changed.extend(
+            self.__repair_actions.get("install", EmptyI)
+        )
+        self.actions.removed.extend(self.__repair_actions.get("remove", EmptyI))
+
+        # No longer needed.
+        self.__repair_actions = {}
+
+        for src, dest in itertools.chain(
+            self.gen_update_actions(), self.gen_install_actions()
+        ):
+            if dest.name == "license":
+                self.__add_license(src, dest)
+                if not src:
+                    # Initial installs require acceptance.
+                    continue
+                src_ma = src.attrs.get("must-accept", False)
+                dest_ma = dest.attrs.get("must-accept", False)
+                if (dest_ma and src_ma) and src.hash == dest.hash:
+                    # If src action required acceptance,
+                    # then license was already accepted
+                    # before, and if the hashes are the
+                    # same for the license payload, then
+                    # it doesn't need to be accepted again.
+                    self.set_license_status(
+                        dest.attrs["license"], accepted=True
+                    )
+
+            # Keep a cache of dir actions with salvage-from attrs.
+            # Since directories are installed in top-down order,
+            # we need this list to make sure we salvage contents
+            # as accurately as possible. For example, where:
+            #
+            #  /var/user gets salvaged to /var/.migrate/user
+            #  and
+            #  /var/user/myuser/.ssh to /var/.migrate/user/myuser/.ssh
+            #
+            # We must ensure that we don't try to salvage
+            # var/user/myuser/.ssh when installing
+            # /var/.migrate/user,
+            # but instead wait till /var/.migrate/user/myuser/.ssh
+            # is being installed, otherwise that content will
+            # the salvaged to the wrong place.
+            if dest.name == "dir" and "salvage-from" in dest.attrs:
+                for p in dest.attrlist("salvage-from"):
+                    self.__salvage_actions[p] = dest
+
+    def get_licenses(self):
+        """A generator function that yields tuples of the form (license,
+        entry).  Where 'entry' is a dict containing the license status
+        information."""
+
+        for lic, entry in six.iteritems(self._license_status):
+            yield lic, entry
+
+    def set_license_status(self, plicense, accepted=None, displayed=None):
+        """Sets the license status for the given license entry.
+
+        'plicense' should be the value of the license attribute for the
+        destination license action.
+
+        'accepted' is an optional parameter that can be one of three
+        values:
+                None    leaves accepted status unchanged
+                False   sets accepted status to False
+                True    sets accepted status to True
+
+        'displayed' is an optional parameter that can be one of three
+        values:
+                None    leaves displayed status unchanged
+                False   sets displayed status to False
+                True    sets displayed status to True"""
+
+        entry = self._license_status[plicense]
+        if accepted is not None:
+            entry["accepted"] = accepted
+        if displayed is not None:
+            entry["displayed"] = displayed
+
+    def get_xferstats(self):
+        if self.__xfersize != -1:
+            return (self.__xferfiles, self.__xfersize)
+
+        self.__xfersize = 0
+        self.__xferfiles = 0
+        for src, dest in itertools.chain(*self.actions):
+            if dest and dest.needsdata(src, self):
+                self.__xfersize += get_pkg_otw_size(dest)
+                self.__xferfiles += 1
+                if dest.name == "signature":
+                    self.__xfersize += dest.get_action_chain_csize()
+                    self.__xferfiles += len(dest.attrs.get("chain", "").split())
+
+        return (self.__xferfiles, self.__xfersize)
+
+    def get_bytes_added(self):
+        """Return tuple of compressed bytes possibly downloaded
+        and number of bytes laid down; ignore removals
+        because they're usually pinned by snapshots"""
+
+        def sum_dest_size(a, b):
+            if b[1]:
+                return (
+                    a[0] + int(b[1].attrs.get("pkg.csize", 0)),
+                    a[1] + int(b[1].attrs.get("pkg.size", 0)),
+                )
+            return (a[0], a[1])
+
+        return reduce(sum_dest_size, itertools.chain(*self.actions), (0, 0))
+
+    def get_xferfmri(self):
+        if self.destination_fmri:
+            return self.destination_fmri
+        if self.origin_fmri:
+            return self.origin_fmri
+        return None
+
+    def preexecute(self):
+        """Perform actions required prior to installation or removal of
+        a package.
+
+        This method executes each action's preremove() or preinstall()
+        methods, as well as any package-wide steps that need to be taken
+        at such a time.
+        """
+
+        # Determine if license acceptance requirements have been met as
+        # early as possible.
+        errors = []
+        for lic, entry in self.get_licenses():
+            dest = entry["dest"]
+            if (dest.must_accept and not entry["accepted"]) or (
+                dest.must_display and not entry["displayed"]
+            ):
+                errors.append(
+                    apx.LicenseAcceptanceError(self.destination_fmri, **entry)
+                )
+
+        if errors:
+            raise apx.PkgLicenseErrors(errors)
+
+        for src, dest in itertools.chain(*self.actions):
+            if dest:
+                dest.preinstall(self, src)
+            else:
+                src.preremove(self)
+
+    def download(self, progtrack, check_cancel):
+        """Download data for any actions that need it."""
+        progtrack.download_start_pkg(self.get_xferfmri())
+        mfile = self.image.transport.multi_file(
+            self.destination_fmri, progtrack, check_cancel
+        )
+
+        if mfile is None:
+            progtrack.download_end_pkg(self.get_xferfmri())
+            return
+
+        for src, dest in itertools.chain(*self.actions):
+            if dest and dest.needsdata(src, self):
+                mfile.add_action(dest)
+
+        mfile.wait_files()
+        progtrack.download_end_pkg(self.get_xferfmri())
+
+    def cacheload(self):
+        """Load previously downloaded data for actions that need it."""
+
+        fmri = self.destination_fmri
+        for src, dest in itertools.chain(*self.actions):
+            if not dest or not dest.needsdata(src, self):
+                continue
+            dest.data = self.image.transport.action_cached(fmri, dest)
+
+    def gen_install_actions(self):
+        for src, dest in self.actions.added:
+            yield src, dest
+
+    def gen_removal_actions(self):
+        for src, dest in self.actions.removed:
+            yield src, dest
+
+    def gen_update_actions(self):
+        for src, dest in self.actions.changed:
+            yield src, dest
+
+    def execute_install(self, src, dest):
+        """perform action for installation of package"""
+        if DebugValues["actions"]:
+            print("execute_install: {} -> {}".format(src, dest))
+        self._executed = True
+        try:
+            dest.install(self, src)
+        except (pkg.actions.ActionError, EnvironmentError):
+            # Don't log these as they're expected, and should be
+            # handled by the caller.
+            raise
+        except Exception as e:
+            logger.error(
+                "Action install failed for '{0}' ({1}):\n  "
+                "{2}: {3}".format(
+                    dest.attrs.get(dest.key_attr, id(dest)),
+                    self.destination_fmri.get_pkg_stem(),
+                    e.__class__.__name__,
+                    e,
+                )
+            )
+            raise
+
+    def execute_update(self, src, dest):
+        """handle action updates"""
+        if DebugValues["actions"]:
+            print("execute_update: {} -> {}".format(src, dest))
+        self._executed = True
+        try:
+            dest.install(self, src)
+        except (pkg.actions.ActionError, EnvironmentError):
+            # Don't log these as they're expected, and should be
+            # handled by the caller.
+            raise
+        except Exception as e:
+            logger.error(
+                "Action upgrade failed for '{0}' ({1}):\n "
+                "{2}: {3}".format(
+                    dest.attrs.get(dest.key_attr, id(dest)),
+                    self.destination_fmri.get_pkg_stem(),
+                    e.__class__.__name__,
+                    e,
+                )
+            )
+            raise
+
+    def execute_removal(self, src, dest):
+        """handle action removals"""
+        if DebugValues["actions"]:
+            print("execute_removal: {}".format(src))
+        self._executed = True
+        try:
+            src.remove(self)
+        except (pkg.actions.ActionError, EnvironmentError):
+            # Don't log these as they're expected, and should be
+            # handled by the caller.
+            raise
+        except Exception as e:
+            logger.error(
+                "Action removal failed for '{0}' ({1}):\n "
+                "{2}: {3}".format(
+                    src.attrs.get(src.key_attr, id(src)),
+                    self.origin_fmri.get_pkg_stem(),
+                    e.__class__.__name__,
+                    e,
+                )
+            )
+            raise
+
+    def execute_retry(self, src, dest):
+        """handle a retry operation"""
+        dest.retry(self, dest)
+
+    def postexecute(self):
+        """Perform actions required after install or remove of a pkg.
+
+        This method executes each action's postremove() or postinstall()
+        methods, as well as any package-wide steps that need to be taken
+        at such a time.
+        """
+        # record that package states are consistent
+        for src, dest in itertools.chain(*self.actions):
+            if dest:
+                dest.postinstall(self, src)
+            else:
+                src.postremove(self)
+
+    def salvage(self, path):
+        """Used to save unexpected files or directories found during
+        plan execution.  Salvaged items are tracked in the imageplan.
+        """
+
+        assert self._executed
+        spath = self.image.salvage(path)
+        # get just the file path that was salvaged
+        fpath = path.replace(os.path.normpath(self.image.get_root()), "", 1)
+        if fpath.startswith(os.path.sep):
+            fpath = fpath[1:]
+        self.image.imageplan.pd._salvaged.append((fpath, spath))
+
+    def salvage_from(self, local_path, full_destination):
+        """move unpackaged contents to specified destination"""
+        # remove leading / if present
+        if local_path.startswith(os.path.sep):
+            local_path = local_path[1:]
+
+        # The salvaged locations known to us are a list of tuples of
+        # the form (old dir, lost+found salvage dir) and stored in
+        # self.image.imageplan.pd._salvaged[:]
+
+        #
+        # Check if this salvage-from is also the best match for other
+        # possibly previously packaged subdirs of this directory.
+        # E.g. if we stop delivering /var/user/evsuser/.ssh, then the
+        # action that specifies 'salvage-from=var/user' ought to deal
+        # with its files.
+        #
+        # On the other hand, if we package another directory, with
+        # 'salvage-from=/var/user/evsuser', then that should be used
+        # to salvage the .ssh content, not the action that salvages
+        # from /var/user.
+        #
+        for fpath, spath in self.image.imageplan.pd._salvaged[:]:
+            if fpath.startswith(local_path):
+                for other_salvage in self.__salvage_actions:
+                    if fpath.startswith(other_salvage) and len(
+                        other_salvage
+                    ) > len(local_path):
+                        continue
+
+                self.image.imageplan.pd._salvaged.remove((fpath, spath))
+                self.image.recover(spath, full_destination, local_path, fpath)
+
+    @property
+    def destination_manifest(self):
+        return self.__destination_mfst
+
+    def clear_dest_manifest(self):
+        self.__destination_mfst = manifest.NullFactoredManifest
+
+    @property
+    def origin_manifest(self):
+        return self.__origin_mfst
+
+    def clear_origin_manifest(self):
+        self.__origin_mfst = manifest.NullFactoredManifest
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/pkgremote.py
+++ b/src/modules/client/pkgremote.py
@@ -52,495 +52,511 @@ from pkg.client.debugvalues import DebugValues
 # debugging aids
 # DebugValues is a singleton; pylint: disable=E1120
 pkgremote_debug = (
-    DebugValues.get_value("pkgremote_debug") is not None or
-    os.environ.get("PKG_PKGREMOTE_DEBUG", None) is not None)
+    DebugValues.get_value("pkgremote_debug") is not None
+    or os.environ.get("PKG_PKGREMOTE_DEBUG", None) is not None
+)
+
 
 class PkgRemote(object):
-        """This class is used to perform packaging operation on an image.  It
-        utilizes the "remote" subcommand within the pkg.1 client to manipulate
-        images.  Communication between this class and the "pkg remote" process
-        is done via RPC.  This class essentially implements an RPC client and
-        the "pkg remote" process is an RPC server."""
-
-        # variables to keep track of our RPC client call state.
-        __IDLE     = "call-idle"
-        __SETUP    = "call-setup"
-        __STARTED  = "call-started"
-
-        def __init__(self):
-                # initialize RPC server process state
-                self.__rpc_server_proc = None
-                self.__rpc_server_fstdout = None
-                self.__rpc_server_fstderr = None
-                self.__rpc_server_prog_pipe_fobj = None
-
-                # initialize RPC client process state
-                self.__rpc_client = None
-                self.__rpc_client_prog_pipe_fobj = None
-
-                # initialize RPC client call state
-                self.__state = self.__IDLE
-                self.__pkg_op = None
-                self.__kwargs = None
-                self.__async_rpc_caller = None
-                self.__async_rpc_waiter = None
-                self.__result = None
-
-                # sanity check the idle state by re-initializing it
-                self.__set_state_idle()
-
-        def __debug_msg(self, msg, t1=False, t2=False):
-                """Log debugging messages."""
-
-                if not pkgremote_debug:
-                        return
-
-                if t1:
-                        prefix = "PkgRemote({0}) client thread 1: ".format(
-                            id(self))
-                elif t2:
-                        prefix = "PkgRemote({0}) client thread 2: ".format(
-                            id(self))
-                else:
-                        prefix = "PkgRemote({0}) client: ".format(id(self))
-
-                # it's not an enforcement but a coding style
-                # logging-format-interpolation; pylint: disable=W1202
-                global_settings.logger.info("{0}{1}".format(prefix, msg))
-
-        def __rpc_server_fork(self, img_path,
-            server_cmd_pipe, server_prog_pipe_fobj):
-                """Fork off a "pkg remote" server process.
-
-                'img_path' is the path to the image to manipulate.
-
-                'server_cmd_pipe' is the server side of the command pipe which
-                the server will use to receive RPC requests.
-
-                'server_prog_pipe_fobj' is the server side of the progress
-                pipe which the server will write to to indicate progress."""
-
-                pkg_cmd = pkg.misc.api_pkgcmd() + [
-                    "-R", img_path,
-                    "--runid={0}".format(global_settings.client_runid),
-                    "remote",
-                    "--ctlfd={0}".format(server_cmd_pipe),
-                    "--progfd={0}".format(server_prog_pipe_fobj.fileno()),
-                ]
-
-                self.__debug_msg("RPC server cmd: {0}".format(
-                    " ".join(pkg_cmd)))
-
-                # create temporary files to log standard output and error from
-                # the RPC server.
-                fstdout = tempfile.TemporaryFile()
-                fstderr = tempfile.TemporaryFile()
-
-                try:
-                        # Under Python 3.4, os.pipe() returns non-inheritable
-                        # file descriptors. On UNIX, subprocess makes file
-                        # descriptors of the pass_fds parameter inheritable.
-                        # Since our pkgsubprocess use posix_pspawn* and doesn't
-                        # have an interface for pass_fds, we reuse the Python
-                        # module subprocess here.
-                        # unexpected-keyword-arg 'pass_fds';
-                        # pylint: disable=E1123
-                        # Redefinition of p type
-                        if six.PY2:
-                                p = pkg.pkgsubprocess.Popen(pkg_cmd,
-                                    stdout=fstdout, stderr=fstderr)
-                        else:
-                                p = subprocess.Popen(pkg_cmd,
-                                    stdout=fstdout, stderr=fstderr,
-                                    pass_fds=(server_cmd_pipe,
-                                    server_prog_pipe_fobj.fileno()))
-
-                except OSError as e:
-                        # Access to protected member; pylint: disable=W0212
-                        raise apx._convert_error(e)
-
-                # initalization successful, update RPC server state
-                self.__rpc_server_proc = p
-                self.__rpc_server_fstdout = fstdout
-                self.__rpc_server_fstderr = fstderr
-                self.__rpc_server_prog_pipe_fobj = server_prog_pipe_fobj
-
-        def __rpc_server_setup(self, img_path):
-                """Start a new RPC Server process.
-
-                'img_path' is the path to the image to manipulate."""
-
-                # create a pipe for communication between the client and server
-                client_cmd_pipe, server_cmd_pipe = os.pipe()
-                # create a pipe that the server server can use to indicate
-                # progress to the client.  wrap the pipe fds in python file
-                # objects so that they gets closed automatically when those
-                # objects are dereferenced.
-                client_prog_pipe, server_prog_pipe = os.pipe()
-                client_prog_pipe_fobj = os.fdopen(client_prog_pipe, "r")
-                server_prog_pipe_fobj = os.fdopen(server_prog_pipe, "w")
-
-                # initialize the client side of the RPC server
-                rpc_client = pkg.pipeutils.PipedServerProxy(client_cmd_pipe)
-
-                # fork off the server
-                self.__rpc_server_fork(img_path,
-                    server_cmd_pipe, server_prog_pipe_fobj)
-
-                # close our reference to server end of the pipe.  (the server
-                # should have already closed its reference to the client end
-                # of the pipe.)
-                os.close(server_cmd_pipe)
-
-                # initalization successful, update RPC client state
-                self.__rpc_client = rpc_client
-                self.__rpc_client_prog_pipe_fobj = client_prog_pipe_fobj
-
-        def __rpc_server_fini(self):
-                """Close connection to a RPC Server process."""
-
-                # destroying the RPC client object closes our connection to
-                # the server, which should cause the server to exit.
-                self.__rpc_client = None
-
-                # if we have a server, kill it and wait for it to exit
-                if self.__rpc_server_proc:
-                        self.__rpc_server_proc.terminate()
-                        self.__rpc_server_proc.wait()
-
-                # clear server state (which closes the rpc pipe file
-                # descriptors)
-                self.__rpc_server_proc = None
-                self.__rpc_server_fstdout = None
-                self.__rpc_server_fstderr = None
-
-                # wait for any client RPC threads to exit
-                if self.__async_rpc_caller:
-                        self.__async_rpc_caller.join()
-                if self.__async_rpc_waiter:
-                        self.__async_rpc_waiter.join()
-
-                # close the progress pipe
-                self.__rpc_server_prog_pipe_fobj = None
-                self.__rpc_client_prog_pipe_fobj = None
-
-        def fileno(self):
-                """Return the progress pipe for the server process.  We use
-                this to monitor progress in the RPC server"""
-
-                return self.__rpc_client_prog_pipe_fobj.fileno()
-
-        def __rpc_client_prog_pipe_drain(self):
-                """Drain the client progress pipe."""
-
-                progfd = self.__rpc_client_prog_pipe_fobj.fileno()
-                p = select.poll()
-                p.register(progfd, select.POLLIN)
-                while p.poll(0):
-                        os.read(progfd, 10240)
-
-        def __state_verify(self, state=None):
-                """Sanity check our internal call state.
-
-                'state' is an optional parameter that indicates which state
-                we should be in now.  (without this parameter we just verify
-                that the current state, whatever it is, is self
-                consistent.)"""
-
-                if state is not None:
-                        assert self.__state == state, \
-                            "{0} == {1}".format(self.__state, state)
-                else:
-                        state = self.__state
-
-                if state == self.__IDLE:
-                        assert self.__pkg_op is None, \
-                            "{0} is None".format(self.__pkg_op)
-                        assert self.__kwargs is None, \
-                            "{0} is None".format(self.__kwargs)
-                        assert self.__async_rpc_caller is None, \
-                            "{0} is None".format(self.__async_rpc_caller)
-                        assert self.__async_rpc_waiter is None, \
-                            "{0} is None".format(self.__async_rpc_waiter)
-                        assert self.__result is None, \
-                            "{0} is None".format(self.__result)
-
-                elif state == self.__SETUP:
-                        assert self.__pkg_op is not None, \
-                            "{0} is not None".format(self.__pkg_op)
-                        assert self.__kwargs is not None, \
-                            "{0} is not None".format(self.__kwargs)
-                        assert self.__async_rpc_caller is None, \
-                            "{0} is None".format(self.__async_rpc_caller)
-                        assert self.__async_rpc_waiter is None, \
-                            "{0} is None".format(self.__async_rpc_waiter)
-                        assert self.__result is None, \
-                            "{0} is None".format(self.__result)
-
-                elif state == self.__STARTED:
-                        assert self.__pkg_op is not None, \
-                            "{0} is not None".format(self.__pkg_op)
-                        assert self.__kwargs is not None, \
-                            "{0} is not None".format(self.__kwargs)
-                        assert self.__async_rpc_caller is not None, \
-                            "{0} is not None".format(self.__async_rpc_caller)
-                        assert self.__async_rpc_waiter is not None, \
-                            "{0} is not None".format(self.__async_rpc_waiter)
-                        assert self.__result is None, \
-                            "{0} is None".format(self.__result)
-
-        def __set_state_idle(self):
-                """Enter the __IDLE state.  This clears all RPC call
-                state."""
-
-                # verify the current state
-                self.__state_verify()
-
-                # setup the new state
-                self.__state = self.__IDLE
-                self.__pkg_op = None
-                self.__kwargs = None
-                self.__async_rpc_caller = None
-                self.__async_rpc_waiter = None
-                self.__result = None
-                self.__debug_msg("set call state: {0}".format(self.__state))
-
-                # verify the new state
-                self.__state_verify()
-
-        def __set_state_setup(self, pkg_op, kwargs):
-                """Enter the __SETUP state.  This indicates that we're
-                all ready to make a call into the RPC server.
-
-                'pkg_op' is the packaging operation we're going to do via RPC
-
-                'kwargs' is the argument dict for the RPC operation.
-
-                't' is the RPC client thread that will call into the RPC
-                server."""
-
-                # verify the current state
-                self.__state_verify(state=self.__IDLE)
-
-                # setup the new state
-                self.__state = self.__SETUP
-                self.__pkg_op = pkg_op
-                self.__kwargs = kwargs
-                self.__debug_msg("set call state: {0}, pkg op: {1}".format(
-                    self.__state, pkg_op))
-
-                # verify the new state
-                self.__state_verify()
-
-        def __set_state_started(self, async_rpc_caller, async_rpc_waiter):
-                """Enter the __SETUP state.  This indicates that we've
-                started a call to the RPC server and we're now waiting for
-                that call to return."""
-
-                # verify the current state
-                self.__state_verify(state=self.__SETUP)
-
-                # setup the new state
-                self.__state = self.__STARTED
-                self.__async_rpc_caller = async_rpc_caller
-                self.__async_rpc_waiter = async_rpc_waiter
-                self.__debug_msg("set call state: {0}".format(self.__state))
-
-                # verify the new state
-                self.__state_verify()
-
-        def __rpc_async_caller(self, fstdout, fstderr, rpc_client,
-            pkg_op, **kwargs):
-                """RPC thread callback.  This routine is invoked in its own
-                thread (so the caller doesn't have to block) and it makes a
-                blocking call to the RPC server.
-
-                'kwargs' is the argument dict for the RPC operation."""
-
-                self.__debug_msg("starting pkg op: {0}; args: {1}".format(
-                    pkg_op, kwargs), t1=True)
-
-                # make the RPC call
-                rv = e = None
-                rpc_method = getattr(rpc_client, pkg_op)
-                try:
-                        # Catch "Exception"; pylint: disable=W0703
-                        rv = rpc_method(**kwargs)
-                except Exception as ex:
-                        # due to python 3 scoping rules
-                        e = ex
-                        self.__debug_msg("caught exception\n{0}".format(
-                            traceback.format_exc()), t1=True)
-                else:
-                        self.__debug_msg("returned: {0}".format(rv), t1=True)
-                # ensure that the decoding is performed using the user's locale
-                # because messages from the called program will be using it.
-                encoding = locale.getpreferredencoding(do_setlocale=False)
-
-                # get output generated by the RPC server.  the server
-                # truncates its output file after each operation, so we always
-                # read output from the beginning of the file.
-                fstdout.seek(0)
-                stdout = (b"".join(fstdout.readlines())).decode(encoding)
-                fstderr.seek(0)
-                stderr = (b"".join(fstderr.readlines())).decode(encoding)
-
-                self.__debug_msg("exiting", t1=True)
-                return (rv, e, stdout, stderr)
-
-        def __rpc_async_waiter(self, async_call, prog_pipe):
-                """RPC waiter thread.  This thread waits on the RPC thread
-                and signals its completion by writing a byte to the progress
-                pipe.
-
-                The RPC call thread can't do this for itself because that
-                results in a race (the RPC thread could block after writing
-                this byte but before actually exiting, and then the client
-                would read the byte, see that the RPC thread is not done, and
-                block while trying to read another byte which would never show
-                up).  This thread solves this problem without using any shared
-                state."""
-
-                self.__debug_msg("starting", t2=True)
-                async_call.join()
-                try:
-                        os.write(prog_pipe.fileno(), b".")
-                except (IOError, OSError):
-                        pass
-                self.__debug_msg("exiting", t2=True)
-
-        def __rpc_client_setup(self, pkg_op, **kwargs):
-                """Prepare to perform a RPC operation.
-
-                'pkg_op' is the packaging operation we're going to do via RPC
-
-                'kwargs' is the argument dict for the RPC operation."""
-
-                self.__set_state_setup(pkg_op, kwargs)
-
-                # drain the progress pipe
-                self.__rpc_client_prog_pipe_drain()
-
-        def setup(self, img_path, pkg_op, **kwargs):
-                """Public interface to setup a remote packaging operation.
-
-                'img_path' is the path to the image to manipulate.
-
-                'pkg_op' is the packaging operation we're going to do via RPC
-
-                'kwargs' is the argument dict for the RPC operation."""
-
-                self.__debug_msg("setup()")
-                self.__rpc_server_setup(img_path)
-                self.__rpc_client_setup(pkg_op, **kwargs)
-
-        def start(self):
-                """Public interface to start a remote packaging operation."""
-
-                self.__debug_msg("start()")
-                self.__state_verify(self.__SETUP)
-
-                async_rpc_caller = pkg.misc.AsyncCall()
-                async_rpc_caller.start(
-                     self.__rpc_async_caller,
-                     self.__rpc_server_fstdout,
-                     self.__rpc_server_fstderr,
-                     self.__rpc_client,
-                     self.__pkg_op,
-                     **self.__kwargs)
-
-                async_rpc_waiter = pkg.misc.AsyncCall()
-                async_rpc_waiter.start(
-                    self.__rpc_async_waiter,
-                    async_rpc_caller,
-                    self.__rpc_server_prog_pipe_fobj)
-
-                self.__set_state_started(async_rpc_caller, async_rpc_waiter)
-
-        def is_done(self):
-                """Public interface to query if a remote packaging operation
-                is done."""
-
-                self.__debug_msg("is_done()")
-                assert self.__state in [self.__SETUP, self.__STARTED]
-
-                # drain the progress pipe.
-                self.__rpc_client_prog_pipe_drain()
-
-                if self.__state == self.__SETUP:
-                        rv = False
-                else:
-                        # see if the client is done
-                        rv = self.__async_rpc_caller.is_done()
-
-                return rv
-
-        def result(self):
-                """Public interface to get the result of a remote packaging
-                operation.  If the operation is not yet completed, this
-                interface will block until it finishes.  The return value is a
-                tuple which contains:
-
-                'rv' is the return value of the RPC operation
-
-                'e' is any exception generated by the RPC operation
-
-                'stdout' is the standard output generated by the RPC server
-                during the RPC operation.
-
-                'stderr' is the standard output generated by the RPC server
-                during the RPC operation."""
-
-                self.__debug_msg("result()")
-                self.__state_verify(self.__STARTED)
-
-                rvtuple = e = None
-                try:
-                        rvtuple = self.__async_rpc_caller.result()
-                except pkg.misc.AsyncCallException as ex:
-                        # due to python 3 scoping rules
-                        e = ex
-
-                # assume we didn't get any results
-                rv = pkgdefs.EXIT_OOPS
-                stdout = stderr = ""
-
-                # unpack our results if we got any
-                if e is None:
-                        # unpack our results.
-                        # our results can contain an embedded exception.
-                        # Attempting to unpack a non-sequence%s;
-                        # pylint: disable=W0633
-                        rv, e, stdout, stderr = rvtuple
-
-                # make sure the return value is an int
-                if type(rv) != int:
-                        rv = pkgdefs.EXIT_OOPS
-
-                # if we got any errors, make sure we return OOPS
-                if e is not None:
-                        rv = pkgdefs.EXIT_OOPS
-
-                # shutdown the RPC server
-                self.__rpc_server_fini()
-
-                # pack up our results and enter the done state
-                self.__set_state_idle()
-
-                return (rv, e, stdout, stderr)
-
-        def abort(self):
-                """Public interface to abort an in-progress RPC operation."""
-
-                assert self.__state in [self.__SETUP, self.__STARTED]
-
-                self.__debug_msg("call abort requested")
-
-                # shutdown the RPC server
-                self.__rpc_server_fini()
-
-                # enter the idle state
-                self.__set_state_idle()
+    """This class is used to perform packaging operation on an image.  It
+    utilizes the "remote" subcommand within the pkg.1 client to manipulate
+    images.  Communication between this class and the "pkg remote" process
+    is done via RPC.  This class essentially implements an RPC client and
+    the "pkg remote" process is an RPC server."""
+
+    # variables to keep track of our RPC client call state.
+    __IDLE = "call-idle"
+    __SETUP = "call-setup"
+    __STARTED = "call-started"
+
+    def __init__(self):
+        # initialize RPC server process state
+        self.__rpc_server_proc = None
+        self.__rpc_server_fstdout = None
+        self.__rpc_server_fstderr = None
+        self.__rpc_server_prog_pipe_fobj = None
+
+        # initialize RPC client process state
+        self.__rpc_client = None
+        self.__rpc_client_prog_pipe_fobj = None
+
+        # initialize RPC client call state
+        self.__state = self.__IDLE
+        self.__pkg_op = None
+        self.__kwargs = None
+        self.__async_rpc_caller = None
+        self.__async_rpc_waiter = None
+        self.__result = None
+
+        # sanity check the idle state by re-initializing it
+        self.__set_state_idle()
+
+    def __debug_msg(self, msg, t1=False, t2=False):
+        """Log debugging messages."""
+
+        if not pkgremote_debug:
+            return
+
+        if t1:
+            prefix = "PkgRemote({0}) client thread 1: ".format(id(self))
+        elif t2:
+            prefix = "PkgRemote({0}) client thread 2: ".format(id(self))
+        else:
+            prefix = "PkgRemote({0}) client: ".format(id(self))
+
+        # it's not an enforcement but a coding style
+        # logging-format-interpolation; pylint: disable=W1202
+        global_settings.logger.info("{0}{1}".format(prefix, msg))
+
+    def __rpc_server_fork(
+        self, img_path, server_cmd_pipe, server_prog_pipe_fobj
+    ):
+        """Fork off a "pkg remote" server process.
+
+        'img_path' is the path to the image to manipulate.
+
+        'server_cmd_pipe' is the server side of the command pipe which
+        the server will use to receive RPC requests.
+
+        'server_prog_pipe_fobj' is the server side of the progress
+        pipe which the server will write to to indicate progress."""
+
+        pkg_cmd = pkg.misc.api_pkgcmd() + [
+            "-R",
+            img_path,
+            "--runid={0}".format(global_settings.client_runid),
+            "remote",
+            "--ctlfd={0}".format(server_cmd_pipe),
+            "--progfd={0}".format(server_prog_pipe_fobj.fileno()),
+        ]
+
+        self.__debug_msg("RPC server cmd: {0}".format(" ".join(pkg_cmd)))
+
+        # create temporary files to log standard output and error from
+        # the RPC server.
+        fstdout = tempfile.TemporaryFile()
+        fstderr = tempfile.TemporaryFile()
+
+        try:
+            # Under Python 3.4, os.pipe() returns non-inheritable
+            # file descriptors. On UNIX, subprocess makes file
+            # descriptors of the pass_fds parameter inheritable.
+            # Since our pkgsubprocess use posix_pspawn* and doesn't
+            # have an interface for pass_fds, we reuse the Python
+            # module subprocess here.
+            # unexpected-keyword-arg 'pass_fds';
+            # pylint: disable=E1123
+            # Redefinition of p type
+            if six.PY2:
+                p = pkg.pkgsubprocess.Popen(
+                    pkg_cmd, stdout=fstdout, stderr=fstderr
+                )
+            else:
+                p = subprocess.Popen(
+                    pkg_cmd,
+                    stdout=fstdout,
+                    stderr=fstderr,
+                    pass_fds=(server_cmd_pipe, server_prog_pipe_fobj.fileno()),
+                )
+
+        except OSError as e:
+            # Access to protected member; pylint: disable=W0212
+            raise apx._convert_error(e)
+
+        # initalization successful, update RPC server state
+        self.__rpc_server_proc = p
+        self.__rpc_server_fstdout = fstdout
+        self.__rpc_server_fstderr = fstderr
+        self.__rpc_server_prog_pipe_fobj = server_prog_pipe_fobj
+
+    def __rpc_server_setup(self, img_path):
+        """Start a new RPC Server process.
+
+        'img_path' is the path to the image to manipulate."""
+
+        # create a pipe for communication between the client and server
+        client_cmd_pipe, server_cmd_pipe = os.pipe()
+        # create a pipe that the server server can use to indicate
+        # progress to the client.  wrap the pipe fds in python file
+        # objects so that they gets closed automatically when those
+        # objects are dereferenced.
+        client_prog_pipe, server_prog_pipe = os.pipe()
+        client_prog_pipe_fobj = os.fdopen(client_prog_pipe, "r")
+        server_prog_pipe_fobj = os.fdopen(server_prog_pipe, "w")
+
+        # initialize the client side of the RPC server
+        rpc_client = pkg.pipeutils.PipedServerProxy(client_cmd_pipe)
+
+        # fork off the server
+        self.__rpc_server_fork(img_path, server_cmd_pipe, server_prog_pipe_fobj)
+
+        # close our reference to server end of the pipe.  (the server
+        # should have already closed its reference to the client end
+        # of the pipe.)
+        os.close(server_cmd_pipe)
+
+        # initalization successful, update RPC client state
+        self.__rpc_client = rpc_client
+        self.__rpc_client_prog_pipe_fobj = client_prog_pipe_fobj
+
+    def __rpc_server_fini(self):
+        """Close connection to a RPC Server process."""
+
+        # destroying the RPC client object closes our connection to
+        # the server, which should cause the server to exit.
+        self.__rpc_client = None
+
+        # if we have a server, kill it and wait for it to exit
+        if self.__rpc_server_proc:
+            self.__rpc_server_proc.terminate()
+            self.__rpc_server_proc.wait()
+
+        # clear server state (which closes the rpc pipe file
+        # descriptors)
+        self.__rpc_server_proc = None
+        self.__rpc_server_fstdout = None
+        self.__rpc_server_fstderr = None
+
+        # wait for any client RPC threads to exit
+        if self.__async_rpc_caller:
+            self.__async_rpc_caller.join()
+        if self.__async_rpc_waiter:
+            self.__async_rpc_waiter.join()
+
+        # close the progress pipe
+        self.__rpc_server_prog_pipe_fobj = None
+        self.__rpc_client_prog_pipe_fobj = None
+
+    def fileno(self):
+        """Return the progress pipe for the server process.  We use
+        this to monitor progress in the RPC server"""
+
+        return self.__rpc_client_prog_pipe_fobj.fileno()
+
+    def __rpc_client_prog_pipe_drain(self):
+        """Drain the client progress pipe."""
+
+        progfd = self.__rpc_client_prog_pipe_fobj.fileno()
+        p = select.poll()
+        p.register(progfd, select.POLLIN)
+        while p.poll(0):
+            os.read(progfd, 10240)
+
+    def __state_verify(self, state=None):
+        """Sanity check our internal call state.
+
+        'state' is an optional parameter that indicates which state
+        we should be in now.  (without this parameter we just verify
+        that the current state, whatever it is, is self
+        consistent.)"""
+
+        if state is not None:
+            assert self.__state == state, "{0} == {1}".format(
+                self.__state, state
+            )
+        else:
+            state = self.__state
+
+        if state == self.__IDLE:
+            assert self.__pkg_op is None, "{0} is None".format(self.__pkg_op)
+            assert self.__kwargs is None, "{0} is None".format(self.__kwargs)
+            assert self.__async_rpc_caller is None, "{0} is None".format(
+                self.__async_rpc_caller
+            )
+            assert self.__async_rpc_waiter is None, "{0} is None".format(
+                self.__async_rpc_waiter
+            )
+            assert self.__result is None, "{0} is None".format(self.__result)
+
+        elif state == self.__SETUP:
+            assert self.__pkg_op is not None, "{0} is not None".format(
+                self.__pkg_op
+            )
+            assert self.__kwargs is not None, "{0} is not None".format(
+                self.__kwargs
+            )
+            assert self.__async_rpc_caller is None, "{0} is None".format(
+                self.__async_rpc_caller
+            )
+            assert self.__async_rpc_waiter is None, "{0} is None".format(
+                self.__async_rpc_waiter
+            )
+            assert self.__result is None, "{0} is None".format(self.__result)
+
+        elif state == self.__STARTED:
+            assert self.__pkg_op is not None, "{0} is not None".format(
+                self.__pkg_op
+            )
+            assert self.__kwargs is not None, "{0} is not None".format(
+                self.__kwargs
+            )
+            assert (
+                self.__async_rpc_caller is not None
+            ), "{0} is not None".format(self.__async_rpc_caller)
+            assert (
+                self.__async_rpc_waiter is not None
+            ), "{0} is not None".format(self.__async_rpc_waiter)
+            assert self.__result is None, "{0} is None".format(self.__result)
+
+    def __set_state_idle(self):
+        """Enter the __IDLE state.  This clears all RPC call
+        state."""
+
+        # verify the current state
+        self.__state_verify()
+
+        # setup the new state
+        self.__state = self.__IDLE
+        self.__pkg_op = None
+        self.__kwargs = None
+        self.__async_rpc_caller = None
+        self.__async_rpc_waiter = None
+        self.__result = None
+        self.__debug_msg("set call state: {0}".format(self.__state))
+
+        # verify the new state
+        self.__state_verify()
+
+    def __set_state_setup(self, pkg_op, kwargs):
+        """Enter the __SETUP state.  This indicates that we're
+        all ready to make a call into the RPC server.
+
+        'pkg_op' is the packaging operation we're going to do via RPC
+
+        'kwargs' is the argument dict for the RPC operation.
+
+        't' is the RPC client thread that will call into the RPC
+        server."""
+
+        # verify the current state
+        self.__state_verify(state=self.__IDLE)
+
+        # setup the new state
+        self.__state = self.__SETUP
+        self.__pkg_op = pkg_op
+        self.__kwargs = kwargs
+        self.__debug_msg(
+            "set call state: {0}, pkg op: {1}".format(self.__state, pkg_op)
+        )
+
+        # verify the new state
+        self.__state_verify()
+
+    def __set_state_started(self, async_rpc_caller, async_rpc_waiter):
+        """Enter the __SETUP state.  This indicates that we've
+        started a call to the RPC server and we're now waiting for
+        that call to return."""
+
+        # verify the current state
+        self.__state_verify(state=self.__SETUP)
+
+        # setup the new state
+        self.__state = self.__STARTED
+        self.__async_rpc_caller = async_rpc_caller
+        self.__async_rpc_waiter = async_rpc_waiter
+        self.__debug_msg("set call state: {0}".format(self.__state))
+
+        # verify the new state
+        self.__state_verify()
+
+    def __rpc_async_caller(
+        self, fstdout, fstderr, rpc_client, pkg_op, **kwargs
+    ):
+        """RPC thread callback.  This routine is invoked in its own
+        thread (so the caller doesn't have to block) and it makes a
+        blocking call to the RPC server.
+
+        'kwargs' is the argument dict for the RPC operation."""
+
+        self.__debug_msg(
+            "starting pkg op: {0}; args: {1}".format(pkg_op, kwargs), t1=True
+        )
+
+        # make the RPC call
+        rv = e = None
+        rpc_method = getattr(rpc_client, pkg_op)
+        try:
+            # Catch "Exception"; pylint: disable=W0703
+            rv = rpc_method(**kwargs)
+        except Exception as ex:
+            # due to python 3 scoping rules
+            e = ex
+            self.__debug_msg(
+                "caught exception\n{0}".format(traceback.format_exc()), t1=True
+            )
+        else:
+            self.__debug_msg("returned: {0}".format(rv), t1=True)
+        # ensure that the decoding is performed using the user's locale
+        # because messages from the called program will be using it.
+        encoding = locale.getpreferredencoding(do_setlocale=False)
+
+        # get output generated by the RPC server.  the server
+        # truncates its output file after each operation, so we always
+        # read output from the beginning of the file.
+        fstdout.seek(0)
+        stdout = (b"".join(fstdout.readlines())).decode(encoding)
+        fstderr.seek(0)
+        stderr = (b"".join(fstderr.readlines())).decode(encoding)
+
+        self.__debug_msg("exiting", t1=True)
+        return (rv, e, stdout, stderr)
+
+    def __rpc_async_waiter(self, async_call, prog_pipe):
+        """RPC waiter thread.  This thread waits on the RPC thread
+        and signals its completion by writing a byte to the progress
+        pipe.
+
+        The RPC call thread can't do this for itself because that
+        results in a race (the RPC thread could block after writing
+        this byte but before actually exiting, and then the client
+        would read the byte, see that the RPC thread is not done, and
+        block while trying to read another byte which would never show
+        up).  This thread solves this problem without using any shared
+        state."""
+
+        self.__debug_msg("starting", t2=True)
+        async_call.join()
+        try:
+            os.write(prog_pipe.fileno(), b".")
+        except (IOError, OSError):
+            pass
+        self.__debug_msg("exiting", t2=True)
+
+    def __rpc_client_setup(self, pkg_op, **kwargs):
+        """Prepare to perform a RPC operation.
+
+        'pkg_op' is the packaging operation we're going to do via RPC
+
+        'kwargs' is the argument dict for the RPC operation."""
+
+        self.__set_state_setup(pkg_op, kwargs)
+
+        # drain the progress pipe
+        self.__rpc_client_prog_pipe_drain()
+
+    def setup(self, img_path, pkg_op, **kwargs):
+        """Public interface to setup a remote packaging operation.
+
+        'img_path' is the path to the image to manipulate.
+
+        'pkg_op' is the packaging operation we're going to do via RPC
+
+        'kwargs' is the argument dict for the RPC operation."""
+
+        self.__debug_msg("setup()")
+        self.__rpc_server_setup(img_path)
+        self.__rpc_client_setup(pkg_op, **kwargs)
+
+    def start(self):
+        """Public interface to start a remote packaging operation."""
+
+        self.__debug_msg("start()")
+        self.__state_verify(self.__SETUP)
+
+        async_rpc_caller = pkg.misc.AsyncCall()
+        async_rpc_caller.start(
+            self.__rpc_async_caller,
+            self.__rpc_server_fstdout,
+            self.__rpc_server_fstderr,
+            self.__rpc_client,
+            self.__pkg_op,
+            **self.__kwargs,
+        )
+
+        async_rpc_waiter = pkg.misc.AsyncCall()
+        async_rpc_waiter.start(
+            self.__rpc_async_waiter,
+            async_rpc_caller,
+            self.__rpc_server_prog_pipe_fobj,
+        )
+
+        self.__set_state_started(async_rpc_caller, async_rpc_waiter)
+
+    def is_done(self):
+        """Public interface to query if a remote packaging operation
+        is done."""
+
+        self.__debug_msg("is_done()")
+        assert self.__state in [self.__SETUP, self.__STARTED]
+
+        # drain the progress pipe.
+        self.__rpc_client_prog_pipe_drain()
+
+        if self.__state == self.__SETUP:
+            rv = False
+        else:
+            # see if the client is done
+            rv = self.__async_rpc_caller.is_done()
+
+        return rv
+
+    def result(self):
+        """Public interface to get the result of a remote packaging
+        operation.  If the operation is not yet completed, this
+        interface will block until it finishes.  The return value is a
+        tuple which contains:
+
+        'rv' is the return value of the RPC operation
+
+        'e' is any exception generated by the RPC operation
+
+        'stdout' is the standard output generated by the RPC server
+        during the RPC operation.
+
+        'stderr' is the standard output generated by the RPC server
+        during the RPC operation."""
+
+        self.__debug_msg("result()")
+        self.__state_verify(self.__STARTED)
+
+        rvtuple = e = None
+        try:
+            rvtuple = self.__async_rpc_caller.result()
+        except pkg.misc.AsyncCallException as ex:
+            # due to python 3 scoping rules
+            e = ex
+
+        # assume we didn't get any results
+        rv = pkgdefs.EXIT_OOPS
+        stdout = stderr = ""
+
+        # unpack our results if we got any
+        if e is None:
+            # unpack our results.
+            # our results can contain an embedded exception.
+            # Attempting to unpack a non-sequence%s;
+            # pylint: disable=W0633
+            rv, e, stdout, stderr = rvtuple
+
+        # make sure the return value is an int
+        if type(rv) != int:
+            rv = pkgdefs.EXIT_OOPS
+
+        # if we got any errors, make sure we return OOPS
+        if e is not None:
+            rv = pkgdefs.EXIT_OOPS
+
+        # shutdown the RPC server
+        self.__rpc_server_fini()
+
+        # pack up our results and enter the done state
+        self.__set_state_idle()
+
+        return (rv, e, stdout, stderr)
+
+    def abort(self):
+        """Public interface to abort an in-progress RPC operation."""
+
+        assert self.__state in [self.__SETUP, self.__STARTED]
+
+        self.__debug_msg("call abort requested")
+
+        # shutdown the RPC server
+        self.__rpc_server_fini()
+
+        # enter the idle state
+        self.__set_state_idle()
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/plandesc.py
+++ b/src/modules/client/plandesc.py
@@ -55,1058 +55,1102 @@ import pkg.json as json
 import pkg.misc
 import pkg.version
 
-from pkg.api_common import (PackageInfo, LicenseInfo)
+from pkg.api_common import PackageInfo, LicenseInfo
 from pkg.client.pkgdefs import MSG_GENERAL
 
-UNEVALUATED       = 0 # nothing done yet
-EVALUATED_PKGS    = 1 # established fmri changes
-MERGED_OK         = 2 # created single merged plan
-EVALUATED_OK      = 3 # ready to execute
-PREEXECUTED_OK    = 4 # finished w/ preexecute
-PREEXECUTED_ERROR = 5 # whoops
-EXECUTED_OK       = 6 # finished execution
-EXECUTED_ERROR    = 7 # failed
+UNEVALUATED = 0  # nothing done yet
+EVALUATED_PKGS = 1  # established fmri changes
+MERGED_OK = 2  # created single merged plan
+EVALUATED_OK = 3  # ready to execute
+PREEXECUTED_OK = 4  # finished w/ preexecute
+PREEXECUTED_ERROR = 5  # whoops
+EXECUTED_OK = 6  # finished execution
+EXECUTED_ERROR = 7  # failed
 
-OP_STAGE_PLAN     = 0
-OP_STAGE_PREP     = 1
-OP_STAGE_EXEC     = 2
-OP_STAGE_PRINTED  = 3 # The message has been consumed by a client
+OP_STAGE_PLAN = 0
+OP_STAGE_PREP = 1
+OP_STAGE_EXEC = 2
+OP_STAGE_PRINTED = 3  # The message has been consumed by a client
+
 
 class _ActionPlan(collections.namedtuple("_ActionPlan", "p src dst")):
-        """A named tuple used to keep track of all the actions that will be
-        executed during an image-modifying procecure."""
-        # Class has no __init__ method; pylint: disable=W0232
-        # Use __slots__ on an old style class; pylint: disable=E1001
+    """A named tuple used to keep track of all the actions that will be
+    executed during an image-modifying procecure."""
 
-        __slots__ = []
+    # Class has no __init__ method; pylint: disable=W0232
+    # Use __slots__ on an old style class; pylint: disable=E1001
 
-        __state__desc = tuple([
+    __slots__ = []
+
+    __state__desc = tuple(
+        [
             pkg.client.pkgplan.PkgPlan,
             pkg.actions.generic.NSG,
             pkg.actions.generic.NSG,
-        ])
+        ]
+    )
 
-        @staticmethod
-        def getstate(obj, je_state=None):
-                """Returns the serialized state of this object in a format
-                that that can be easily stored using JSON, pickle, etc."""
-                return pkg.misc.json_encode(_ActionPlan.__name__, tuple(obj),
-                    _ActionPlan.__state__desc, je_state=je_state)
+    @staticmethod
+    def getstate(obj, je_state=None):
+        """Returns the serialized state of this object in a format
+        that that can be easily stored using JSON, pickle, etc."""
+        return pkg.misc.json_encode(
+            _ActionPlan.__name__,
+            tuple(obj),
+            _ActionPlan.__state__desc,
+            je_state=je_state,
+        )
 
-        @staticmethod
-        def fromstate(state, jd_state=None):
-                """Allocate a new object using previously serialized state
-                obtained via getstate()."""
-                # Access to protected member; pylint: disable=W0212
+    @staticmethod
+    def fromstate(state, jd_state=None):
+        """Allocate a new object using previously serialized state
+        obtained via getstate()."""
+        # Access to protected member; pylint: disable=W0212
 
-                # get the name of the object we're dealing with
-                name = _ActionPlan.__name__
+        # get the name of the object we're dealing with
+        name = _ActionPlan.__name__
 
-                # decode serialized state into python objects
-                state = pkg.misc.json_decode(name, state,
-                    _ActionPlan.__state__desc, jd_state=jd_state)
+        # decode serialized state into python objects
+        state = pkg.misc.json_decode(
+            name, state, _ActionPlan.__state__desc, jd_state=jd_state
+        )
 
-                return _ActionPlan(*state)
+        return _ActionPlan(*state)
 
 
 class PlanDescription(object):
-        """A class which describes the changes the plan will make."""
+    """A class which describes the changes the plan will make."""
 
-        __state__desc = {
-            "_actuators": pkg.client.actuator.Actuator,
-            "_cfg_mediators": {
+    __state__desc = {
+        "_actuators": pkg.client.actuator.Actuator,
+        "_cfg_mediators": {
+            str: {
+                "version": pkg.version.Version,
+                "implementation-version": pkg.version.Version,
+            }
+        },
+        "_fmri_changes": [(pkg.fmri.PkgFmri, pkg.fmri.PkgFmri)],
+        # avoid, implicit-avoid, obsolete
+        "_new_avoid_obs": (set(), set(), set()),
+        "_new_mediators": collections.defaultdict(
+            set,
+            {
                 str: {
                     "version": pkg.version.Version,
                     "implementation-version": pkg.version.Version,
                 }
             },
-            "_fmri_changes": [ ( pkg.fmri.PkgFmri, pkg.fmri.PkgFmri ) ],
-            # avoid, implicit-avoid, obsolete
-            "_new_avoid_obs": ( set(), set(), set() ),
-            "_new_mediators": collections.defaultdict(set, {
-                str: {
-                    "version": pkg.version.Version,
-                    "implementation-version": pkg.version.Version,
-                }
-            }),
-            "_old_facets": pkg.facet.Facets,
-            "_new_facets": pkg.facet.Facets,
-            "_rm_aliases": { str: set() },
-            "_preserved": {
-                "moved": [[str, str]],
-                "removed": [[str]],
-                "installed": [[str]],
-                "updated": [[str]],
-            },
-            # Messaging looks like:
-            # {"item_id": {"sub_item_id": [], "messages": []}}
-            "_item_msgs": collections.defaultdict(dict),
-            "_pkg_actuators": { str: { str: [ str ] } },
-            "added_groups": { str: pkg.fmri.PkgFmri },
-            "added_users": { str: pkg.fmri.PkgFmri },
-            "child_op_vectors": [ ( str, [ li.LinkedImageName ], {}, bool ) ],
-            "children_ignored": [ li.LinkedImageName ],
-            "children_nop": [ li.LinkedImageName ],
-            "children_planned": [ li.LinkedImageName ],
-            "install_actions": [ _ActionPlan ],
-            "elided_actions": [ _ActionPlan ],
-            "li_pfacets": pkg.facet.Facets,
-            "li_ppkgs": frozenset([ pkg.fmri.PkgFmri ]),
-            "li_props": { li.PROP_NAME: li.LinkedImageName },
-            "pkg_plans": [ pkg.client.pkgplan.PkgPlan ],
-            "release_notes": (bool, []),
-            "removal_actions": [ _ActionPlan ],
-            "removed_groups": { str: pkg.fmri.PkgFmri },
-            "removed_users": { str: pkg.fmri.PkgFmri },
-            "update_actions": [ _ActionPlan ],
-        }
+        ),
+        "_old_facets": pkg.facet.Facets,
+        "_new_facets": pkg.facet.Facets,
+        "_rm_aliases": {str: set()},
+        "_preserved": {
+            "moved": [[str, str]],
+            "removed": [[str]],
+            "installed": [[str]],
+            "updated": [[str]],
+        },
+        # Messaging looks like:
+        # {"item_id": {"sub_item_id": [], "messages": []}}
+        "_item_msgs": collections.defaultdict(dict),
+        "_pkg_actuators": {str: {str: [str]}},
+        "added_groups": {str: pkg.fmri.PkgFmri},
+        "added_users": {str: pkg.fmri.PkgFmri},
+        "child_op_vectors": [(str, [li.LinkedImageName], {}, bool)],
+        "children_ignored": [li.LinkedImageName],
+        "children_nop": [li.LinkedImageName],
+        "children_planned": [li.LinkedImageName],
+        "install_actions": [_ActionPlan],
+        "elided_actions": [_ActionPlan],
+        "li_pfacets": pkg.facet.Facets,
+        "li_ppkgs": frozenset([pkg.fmri.PkgFmri]),
+        "li_props": {li.PROP_NAME: li.LinkedImageName},
+        "pkg_plans": [pkg.client.pkgplan.PkgPlan],
+        "release_notes": (bool, []),
+        "removal_actions": [_ActionPlan],
+        "removed_groups": {str: pkg.fmri.PkgFmri},
+        "removed_users": {str: pkg.fmri.PkgFmri},
+        "update_actions": [_ActionPlan],
+    }
 
-        __state__commonize = frozenset([
+    __state__commonize = frozenset(
+        [
             pkg.actions.generic.NSG,
             pkg.client.pkgplan.PkgPlan,
             pkg.fmri.PkgFmri,
-        ])
+        ]
+    )
 
-        def __init__(self, op=None):
-                self.state = UNEVALUATED
-                self._op = op
+    def __init__(self, op=None):
+        self.state = UNEVALUATED
+        self._op = op
 
-                #
-                # Properties set when state >= EVALUATED_PKGS
-                #
-                self._image_lm = None
-                self._cfg_mediators = {}
-                self._varcets_change = False
-                self._new_variants = None
-                self._old_facets = None
-                self._new_facets = None
-                self._facet_change = False
-                self._masked_facet_change = False
-                self._new_mediators = collections.defaultdict(set)
-                self._mediators_change = False
-                self._new_avoid_obs = (set(), set(), set())
-                self._fmri_changes = [] # install  (None, fmri)
-                                        # remove   (oldfmri, None)
-                                        # update   (oldfmri, newfmri|oldfmri)
-                self._preserved = {
-                    "moved": [],
-                    "removed": [],
-                    "installed": [],
-                    "updated": [],
-                }
-                self._solver_summary = []
-                self._solver_errors = None
-                self.li_attach = False
-                self.li_ppkgs = frozenset()
-                self.li_ppubs = None
-                self.li_props = {}
-                self._li_pkg_updates = True
-                self._item_msgs = collections.defaultdict(dict)
+        #
+        # Properties set when state >= EVALUATED_PKGS
+        #
+        self._image_lm = None
+        self._cfg_mediators = {}
+        self._varcets_change = False
+        self._new_variants = None
+        self._old_facets = None
+        self._new_facets = None
+        self._facet_change = False
+        self._masked_facet_change = False
+        self._new_mediators = collections.defaultdict(set)
+        self._mediators_change = False
+        self._new_avoid_obs = (set(), set(), set())
+        self._fmri_changes = []  # install  (None, fmri)
+        # remove   (oldfmri, None)
+        # update   (oldfmri, newfmri|oldfmri)
+        self._preserved = {
+            "moved": [],
+            "removed": [],
+            "installed": [],
+            "updated": [],
+        }
+        self._solver_summary = []
+        self._solver_errors = None
+        self.li_attach = False
+        self.li_ppkgs = frozenset()
+        self.li_ppubs = None
+        self.li_props = {}
+        self._li_pkg_updates = True
+        self._item_msgs = collections.defaultdict(dict)
 
-                #
-                # Properties set when state >= EVALUATED_OK
-                #
-                # raw actions
-                self.pkg_plans = []
-                # merged actions
-                self.removal_actions = []
-                self.update_actions = []
-                self.install_actions = []
-                self.elided_actions = []
-                # smf and other actuators (driver actions get added during
-                # execution stage).
-                self._actuators = pkg.client.actuator.Actuator()
-                # Used to track users and groups that are part of operation.
-                self.added_groups = {}
-                self.added_users = {}
-                self.removed_groups = {}
-                self.removed_users = {}
-                # release notes that are part of this operation
-                self.release_notes = (False, [])
-                # plan properties
-                self._cbytes_added = 0 # size of compressed files
-                self._bytes_added = 0  # size of files added
-                self._need_boot_archive = None
-                # child properties
-                self.child_op_vectors = []
-                self.children_ignored = None
-                self.children_planned = []
-                self.children_nop = []
-                # driver aliases to remove
-                self._rm_aliases = {}
+        #
+        # Properties set when state >= EVALUATED_OK
+        #
+        # raw actions
+        self.pkg_plans = []
+        # merged actions
+        self.removal_actions = []
+        self.update_actions = []
+        self.install_actions = []
+        self.elided_actions = []
+        # smf and other actuators (driver actions get added during
+        # execution stage).
+        self._actuators = pkg.client.actuator.Actuator()
+        # Used to track users and groups that are part of operation.
+        self.added_groups = {}
+        self.added_users = {}
+        self.removed_groups = {}
+        self.removed_users = {}
+        # release notes that are part of this operation
+        self.release_notes = (False, [])
+        # plan properties
+        self._cbytes_added = 0  # size of compressed files
+        self._bytes_added = 0  # size of files added
+        self._need_boot_archive = None
+        # child properties
+        self.child_op_vectors = []
+        self.children_ignored = None
+        self.children_planned = []
+        self.children_nop = []
+        # driver aliases to remove
+        self._rm_aliases = {}
 
-                #
-                # Properties set when state >= EXECUTED_OK
-                #
-                self._salvaged = []
-                self.release_notes_name = None
+        #
+        # Properties set when state >= EXECUTED_OK
+        #
+        self._salvaged = []
+        self.release_notes_name = None
 
-                #
-                # Set by imageplan.set_be_options()
-                #
-                self._backup_be = None
-                self._backup_be_name = None
-                self._new_be = None
-                self._be_name = None
-                self._be_activate = False
+        #
+        # Set by imageplan.set_be_options()
+        #
+        self._backup_be = None
+        self._backup_be_name = None
+        self._new_be = None
+        self._be_name = None
+        self._be_activate = False
 
-                # Accessed via imageplan.update_index
-                self._update_index = True
+        # Accessed via imageplan.update_index
+        self._update_index = True
 
-                # stats about the current image
-                self._cbytes_avail = 0  # avail space for downloads
-                self._bytes_avail = 0   # avail space for fs
+        # stats about the current image
+        self._cbytes_avail = 0  # avail space for downloads
+        self._bytes_avail = 0  # avail space for fs
 
-                self._act_timed_out = False
+        self._act_timed_out = False
 
-                # Pkg actuators
-                self._pkg_actuators = {}
+        # Pkg actuators
+        self._pkg_actuators = {}
 
-        @staticmethod
-        def getstate(obj, je_state=None, reset_volatiles=False):
-                """Returns the serialized state of this object in a format
-                that that can be easily stored using JSON, pickle, etc."""
-                # Access to protected member; pylint: disable=W0212
+    @staticmethod
+    def getstate(obj, je_state=None, reset_volatiles=False):
+        """Returns the serialized state of this object in a format
+        that that can be easily stored using JSON, pickle, etc."""
+        # Access to protected member; pylint: disable=W0212
 
-                if reset_volatiles:
-                        # backup and clear volatiles
-                        _bytes_avail = obj._bytes_avail
-                        _cbytes_avail = obj._cbytes_avail
-                        obj._bytes_avail = obj._cbytes_avail = 0
+        if reset_volatiles:
+            # backup and clear volatiles
+            _bytes_avail = obj._bytes_avail
+            _cbytes_avail = obj._cbytes_avail
+            obj._bytes_avail = obj._cbytes_avail = 0
 
-                name = PlanDescription.__name__
-                state = pkg.misc.json_encode(name, obj.__dict__,
-                    PlanDescription.__state__desc,
-                    commonize=PlanDescription.__state__commonize,
-                    je_state=je_state)
+        name = PlanDescription.__name__
+        state = pkg.misc.json_encode(
+            name,
+            obj.__dict__,
+            PlanDescription.__state__desc,
+            commonize=PlanDescription.__state__commonize,
+            je_state=je_state,
+        )
 
-                # add a state version encoding identifier
-                state[name] = 0
+        # add a state version encoding identifier
+        state[name] = 0
 
-                if reset_volatiles:
-                        obj._bytes_avail = obj._bytes_avail
-                        obj._cbytes_avail = obj._cbytes_avail
+        if reset_volatiles:
+            obj._bytes_avail = obj._bytes_avail
+            obj._cbytes_avail = obj._cbytes_avail
 
-                return state
+        return state
 
-        @staticmethod
-        def setstate(obj, state, jd_state=None):
-                """Update the state of this object using previously serialized
-                state obtained via getstate()."""
-                # Access to protected member; pylint: disable=W0212
+    @staticmethod
+    def setstate(obj, state, jd_state=None):
+        """Update the state of this object using previously serialized
+        state obtained via getstate()."""
+        # Access to protected member; pylint: disable=W0212
 
-                # get the name of the object we're dealing with
-                name = PlanDescription.__name__
+        # get the name of the object we're dealing with
+        name = PlanDescription.__name__
 
-                # version check and delete the encoding identifier
-                assert state[name] == 0
-                del state[name]
+        # version check and delete the encoding identifier
+        assert state[name] == 0
+        del state[name]
 
-                # decode serialized state into python objects
-                state = pkg.misc.json_decode(name, state,
-                    PlanDescription.__state__desc,
-                    commonize=PlanDescription.__state__commonize,
-                    jd_state=jd_state)
+        # decode serialized state into python objects
+        state = pkg.misc.json_decode(
+            name,
+            state,
+            PlanDescription.__state__desc,
+            commonize=PlanDescription.__state__commonize,
+            jd_state=jd_state,
+        )
 
-                # bulk update
-                obj.__dict__.update(state)
+        # bulk update
+        obj.__dict__.update(state)
 
-                # clear volatiles
-                obj._cbytes_avail = 0
-                obj._bytes_avail = 0
+        # clear volatiles
+        obj._cbytes_avail = 0
+        obj._bytes_avail = 0
 
-        @staticmethod
-        def fromstate(state, jd_state=None):
-                """Allocate a new object using previously serialized state
-                obtained via getstate()."""
-                rv = PlanDescription()
-                PlanDescription.setstate(rv, state, jd_state)
-                return rv
+    @staticmethod
+    def fromstate(state, jd_state=None):
+        """Allocate a new object using previously serialized state
+        obtained via getstate()."""
+        rv = PlanDescription()
+        PlanDescription.setstate(rv, state, jd_state)
+        return rv
 
-        def _save(self, fobj, reset_volatiles=False):
-                """Save a json encoded representation of this plan
-                description objects into the specified file object."""
+    def _save(self, fobj, reset_volatiles=False):
+        """Save a json encoded representation of this plan
+        description objects into the specified file object."""
 
-                state = PlanDescription.getstate(self,
-                    reset_volatiles=reset_volatiles)
-                try:
-                        fobj.truncate()
-                        json.dump(state, fobj)
-                        fobj.flush()
-                except OSError as e:
-                        # Access to protected member; pylint: disable=W0212
-                        raise apx._convert_error(e)
+        state = PlanDescription.getstate(self, reset_volatiles=reset_volatiles)
+        try:
+            fobj.truncate()
+            json.dump(state, fobj)
+            fobj.flush()
+        except OSError as e:
+            # Access to protected member; pylint: disable=W0212
+            raise apx._convert_error(e)
 
-                del state
+        del state
 
-        def _load(self, fobj):
-                """Load a json encoded representation of a plan description
-                from the specified file object."""
+    def _load(self, fobj):
+        """Load a json encoded representation of a plan description
+        from the specified file object."""
 
-                assert self.state == UNEVALUATED
+        assert self.state == UNEVALUATED
 
-                try:
-                        fobj.seek(0)
-                        state = json.load(fobj, object_hook=pkg.misc.json_hook)
-                except OSError as e:
-                        # Access to protected member; pylint: disable=W0212
-                        raise apx._convert_error(e)
+        try:
+            fobj.seek(0)
+            state = json.load(fobj, object_hook=pkg.misc.json_hook)
+        except OSError as e:
+            # Access to protected member; pylint: disable=W0212
+            raise apx._convert_error(e)
 
-                PlanDescription.setstate(self, state)
-                del state
+        PlanDescription.setstate(self, state)
+        del state
 
-        def _executed_ok(self):
-                """A private interface used after a plan is successfully
-                invoked to free up memory."""
+    def _executed_ok(self):
+        """A private interface used after a plan is successfully
+        invoked to free up memory."""
 
-                # reduce memory consumption
-                self._fmri_changes = []
-                self._preserved = {}
-                # We have to save the timed_out state.
-                self._act_timed_out = self._actuators.timed_out
-                self._actuators = pkg.client.actuator.Actuator()
-                self.added_groups = {}
-                self.added_users = {}
-                self.removed_groups = {}
-                self.removed_users = {}
+        # reduce memory consumption
+        self._fmri_changes = []
+        self._preserved = {}
+        # We have to save the timed_out state.
+        self._act_timed_out = self._actuators.timed_out
+        self._actuators = pkg.client.actuator.Actuator()
+        self.added_groups = {}
+        self.added_users = {}
+        self.removed_groups = {}
+        self.removed_users = {}
 
-        @property
-        def executed(self):
-                """A boolean indicating if we attempted to execute this
-                plan."""
-                return self.state in [EXECUTED_OK, EXECUTED_ERROR]
+    @property
+    def executed(self):
+        """A boolean indicating if we attempted to execute this
+        plan."""
+        return self.state in [EXECUTED_OK, EXECUTED_ERROR]
 
-        @property
-        def services(self):
-                """Returns a list of string tuples describing affected services
-                (action, SMF FMRI)."""
-                return sorted(
-                    ((str(a), str(smf_fmri))
-                    for a, smf_fmri in self._actuators.get_services_list()),
-                        key=operator.itemgetter(0, 1)
+    @property
+    def services(self):
+        """Returns a list of string tuples describing affected services
+        (action, SMF FMRI)."""
+        return sorted(
+            (
+                (str(a), str(smf_fmri))
+                for a, smf_fmri in self._actuators.get_services_list()
+            ),
+            key=operator.itemgetter(0, 1),
+        )
+
+    @property
+    def mediators(self):
+        """Returns a list of three-tuples containing information about
+        the mediators.  The first element in the tuple is the name of
+        the mediator.  The second element is a tuple containing the
+        original version and source and the new version and source of
+        the mediator.  The third element is a tuple containing the
+        original implementation and source and new implementation and
+        source."""
+
+        ret = []
+
+        if not self._mediators_change or (
+            not self._cfg_mediators and not self._new_mediators
+        ):
+            return ret
+
+        def get_mediation(mediators, m):
+            # Missing docstring; pylint: disable=C0111
+            mimpl = mver = mimpl_source = mver_source = None
+            if m in mediators:
+                mimpl = mediators[m].get("implementation")
+                mimpl_ver = mediators[m].get("implementation-version")
+                if mimpl_ver:
+                    mimpl_ver = mimpl_ver.get_short_version()
+                if mimpl and mimpl_ver:
+                    mimpl += "(@{0})".format(mimpl_ver)
+                mimpl_source = mediators[m].get("implementation-source")
+
+                mver = mediators[m].get("version")
+                if mver:
+                    mver = mver.get_short_version()
+                mver_source = mediators[m].get("version-source")
+            return mimpl, mver, mimpl_source, mver_source
+
+        for m in sorted(set(self._new_mediators) | set(self._cfg_mediators)):
+            (
+                orig_impl,
+                orig_ver,
+                orig_impl_source,
+                orig_ver_source,
+            ) = get_mediation(self._cfg_mediators, m)
+            new_impl, new_ver, new_impl_source, new_ver_source = get_mediation(
+                self._new_mediators, m
+            )
+
+            if (
+                orig_ver == new_ver
+                and orig_ver_source == new_ver_source
+                and orig_impl == new_impl
+                and orig_impl_source == new_impl_source
+            ):
+                # Mediation not changed.
+                continue
+
+            out = (
+                m,
+                ((orig_ver, orig_ver_source), (new_ver, new_ver_source)),
+                ((orig_impl, orig_impl_source), (new_impl, new_impl_source)),
+            )
+
+            ret.append(out)
+
+        return ret
+
+    def find_removal(self, filename):
+        """Has the named file been tagged for removal ?"""
+
+        for ap in self.removal_actions:
+            if ap.src.name == "file" and ap.src.attrs["path"] == filename:
+                return True
+
+        return False
+
+    def get_mediators(self):
+        """Returns list of strings describing mediator changes."""
+
+        ret = []
+        for m, ver, impl in sorted(self.mediators):
+            ((orig_ver, orig_ver_source), (new_ver, new_ver_source)) = ver
+            ((orig_impl, orig_impl_source), (new_impl, new_impl_source)) = impl
+            out = "mediator {0}:\n".format(m)
+            if orig_ver and new_ver:
+                out += (
+                    "           version: {0} ({1} default)"
+                    " -> {2} ({3} default)\n".format(
+                        orig_ver, orig_ver_source, new_ver, new_ver_source
+                    )
+                )
+            elif orig_ver:
+                out += (
+                    "           version: {0} ({1} default)"
+                    " -> None\n".format(orig_ver, orig_ver_source)
+                )
+            elif new_ver:
+                out += (
+                    "           version: None -> "
+                    "{0} ({1} default)\n".format(new_ver, new_ver_source)
                 )
 
-        @property
-        def mediators(self):
-                """Returns a list of three-tuples containing information about
-                the mediators.  The first element in the tuple is the name of
-                the mediator.  The second element is a tuple containing the
-                original version and source and the new version and source of
-                the mediator.  The third element is a tuple containing the
-                original implementation and source and new implementation and
-                source."""
+            if orig_impl and new_impl:
+                out += (
+                    "    implementation: {0} ({1} default)"
+                    " -> {2} ({3} default)\n".format(
+                        orig_impl, orig_impl_source, new_impl, new_impl_source
+                    )
+                )
+            elif orig_impl:
+                out += (
+                    "    implementation: {0} ({1} default)"
+                    " -> None\n".format(orig_impl, orig_impl_source)
+                )
+            elif new_impl:
+                out += (
+                    "    implementation: None -> "
+                    "{0} ({1} default)\n".format(new_impl, new_impl_source)
+                )
+            ret.append(out)
+        return ret
 
-                ret = []
+    @property
+    def plan_desc(self):
+        """Get the proposed fmri changes."""
+        return self._fmri_changes
 
-                if not self._mediators_change or \
-                    (not self._cfg_mediators and not self._new_mediators):
-                        return ret
+    @property
+    def salvaged(self):
+        """A list of tuples of items that were salvaged during plan
+        execution.  Each tuple is of the form (original_path,
+        salvage_path).  Where 'original_path' is the path of the item
+        before it was salvaged, and 'salvage_path' is where the item was
+        moved to.  This property is only valid after plan execution
+        has completed."""
+        return self._salvaged
 
-                def get_mediation(mediators, m):
-                        # Missing docstring; pylint: disable=C0111
-                        mimpl = mver = mimpl_source = \
-                            mver_source = None
-                        if m in mediators:
-                                mimpl = mediators[m].get(
-                                    "implementation")
-                                mimpl_ver = mediators[m].get(
-                                    "implementation-version")
-                                if mimpl_ver:
-                                        mimpl_ver = \
-                                            mimpl_ver.get_short_version()
-                                if mimpl and mimpl_ver:
-                                        mimpl += "(@{0})".format(mimpl_ver)
-                                mimpl_source = mediators[m].get(
-                                    "implementation-source")
+    @property
+    def varcets(self):
+        """Returns a tuple of two lists containing the facet and
+        variant changes in this plan.
 
-                                mver = mediators[m].get("version")
-                                if mver:
-                                        mver = mver.get_short_version()
-                                mver_source = mediators[m].get(
-                                    "version-source")
-                        return mimpl, mver, mimpl_source, mver_source
+        The variant list contains tuples with the following format:
 
-                for m in sorted(set(self._new_mediators) |
-                    set(self._cfg_mediators)):
-                        orig_impl, orig_ver, orig_impl_source, \
-                            orig_ver_source = get_mediation(
-                                self._cfg_mediators, m)
-                        new_impl, new_ver, new_impl_source, new_ver_source = \
-                            get_mediation(self._new_mediators, m)
+            (<variant>, <new-value>)
 
-                        if orig_ver == new_ver and \
-                            orig_ver_source == new_ver_source and \
-                            orig_impl == new_impl and \
-                            orig_impl_source == new_impl_source:
-                                # Mediation not changed.
-                                continue
+        The facet list contains tuples with the following format:
 
-                        out = (m,
-                            ((orig_ver, orig_ver_source),
-                            (new_ver, new_ver_source)),
-                            ((orig_impl, orig_impl_source),
-                            (new_impl, new_impl_source)))
+            (<facet>, <new-value>, <old-value>, <source>,
+                <new-masked>, <old-masked>)
 
-                        ret.append(out)
+        """
 
-                return ret
+        vs = []
+        if self._new_variants:
+            vs = list(self._new_variants.items())
 
-        def find_removal(self, filename):
-                """ Has the named file been tagged for removal ?"""
+        # sort results by variant name
+        vs.sort(key=lambda x: x[0])
 
-                for ap in self.removal_actions:
-                        if ap.src.name == "file" and ap.src.attrs["path"] == filename:
-                               return True
+        fs = []
+        if self._new_facets is None:
+            return (vs, fs)
 
-                return False
+        # create new dictionaries that index facets by name and
+        # source:
+        #    dict[(<facet, src>)] = (<value>, <masked>)
+        old_facets = dict(
+            [
+                ((f, src), (v, masked))
+                # not-an-iterable self._old_facets;
+                # pylint: disable=E1133
+                for f in self._old_facets
+                # W0212 Access to a protected member
+                # pylint: disable=W0212
+                for v, src, masked in self._old_facets._src_values(f)
+            ]
+        )
+        new_facets = dict(
+            [
+                ((f, src), (v, masked))
+                # not-an-iterable self._new_facets;
+                # pylint: disable=E1133
+                for f in self._new_facets
+                # W0212 Access to a protected member
+                # pylint: disable=W0212
+                for v, src, masked in self._new_facets._src_values(f)
+            ]
+        )
 
-        def get_mediators(self):
-                """Returns list of strings describing mediator changes."""
+        # check for removed facets
+        for f, src in set(old_facets) - set(new_facets):
+            v, masked = old_facets[f, src]
+            fs.append((f, None, v, src, masked, False))
 
-                ret = []
-                for m, ver, impl in sorted(self.mediators):
-                        ((orig_ver, orig_ver_source),
-                            (new_ver, new_ver_source)) = ver
-                        ((orig_impl, orig_impl_source),
-                            (new_impl, new_impl_source)) = impl
-                        out = "mediator {0}:\n".format(m)
-                        if orig_ver and new_ver:
-                                out += "           version: {0} ({1} default)" \
-                                    " -> {2} ({3} default)\n".format(orig_ver,
-                                    orig_ver_source, new_ver, new_ver_source)
-                        elif orig_ver:
-                                out += "           version: {0} ({1} default)" \
-                                    " -> None\n".format(orig_ver,
-                                    orig_ver_source)
-                        elif new_ver:
-                                out += "           version: None -> " \
-                                    "{0} ({1} default)\n".format(new_ver,
-                                    new_ver_source)
+        # check for added facets
+        for f, src in set(new_facets) - set(old_facets):
+            v, masked = new_facets[f, src]
+            fs.append((f, v, None, src, False, masked))
 
-                        if orig_impl and new_impl:
-                                out += "    implementation: {0} ({1} default)" \
-                                    " -> {2} ({3} default)\n".format(orig_impl,
-                                    orig_impl_source, new_impl, new_impl_source)
-                        elif orig_impl:
-                                out += "    implementation: {0} ({1} default)" \
-                                    " -> None\n".format(orig_impl,
-                                    orig_impl_source)
-                        elif new_impl:
-                                out += "    implementation: None -> " \
-                                    "{0} ({1} default)\n".format(new_impl,
-                                    new_impl_source)
-                        ret.append(out)
-                return ret
+        # check for changing facets
+        for f, src in set(old_facets) & set(new_facets):
+            if old_facets[f, src] == new_facets[f, src]:
+                continue
+            v_old, m_old = old_facets[f, src]
+            v_new, m_new = new_facets[f, src]
+            fs.append((f, v_new, v_old, src, m_old, m_new))
 
-        @property
-        def plan_desc(self):
-                """Get the proposed fmri changes."""
-                return self._fmri_changes
+        # sort results by facet name
+        fs.sort(key=lambda x: x[0])
 
-        @property
-        def salvaged(self):
-                """A list of tuples of items that were salvaged during plan
-                execution.  Each tuple is of the form (original_path,
-                salvage_path).  Where 'original_path' is the path of the item
-                before it was salvaged, and 'salvage_path' is where the item was
-                moved to.  This property is only valid after plan execution
-                has completed."""
-                return self._salvaged
+        return (vs, fs)
 
-        @property
-        def varcets(self):
-                """Returns a tuple of two lists containing the facet and
-                variant changes in this plan.
+    def get_varcets(self):
+        """Returns a formatted list of strings representing the
+        variant/facet changes in this plan"""
+        vs, fs = self.varcets
+        rv = ["variant {0}: {1}".format(name[8:], val) for (name, val) in vs]
+        masked_str = _(" (masked)")
+        for name, v_new, v_old, src, m_old, m_new in fs:
+            m_old = m_old and masked_str or ""
+            m_new = m_new and masked_str or ""
+            msg = "  facet {0} ({1}): {2}{3} -> {4}{5}".format(
+                name[6:], src, v_old, m_old, v_new, m_new
+            )
+            rv.append(msg)
+        return rv
 
-                The variant list contains tuples with the following format:
+    def get_changes(self):
+        """A generator function that yields tuples of PackageInfo
+        objects of the form (src_pi, dest_pi).
 
-                    (<variant>, <new-value>)
+        If 'src_pi' is None, then 'dest_pi' is the package being
+        installed.
 
-                The facet list contains tuples with the following format:
+        If 'src_pi' is not None, and 'dest_pi' is None, 'src_pi'
+        is the package being removed.
 
-                    (<facet>, <new-value>, <old-value>, <source>,
-                        <new-masked>, <old-masked>)
+        If 'src_pi' is not None, and 'dest_pi' is not None,
+        then 'src_pi' is the original version of the package,
+        and 'dest_pi' is the new version of the package it is
+        being upgraded to."""
 
-                """
+        key = operator.attrgetter("origin_fmri", "destination_fmri")
+        for pp in sorted(self.pkg_plans, key=key):
+            sfmri = pp.origin_fmri
+            dfmri = pp.destination_fmri
+            if sfmri == dfmri:
+                sinfo = dinfo = PackageInfo.build_from_fmri(sfmri)
+            else:
+                sinfo = PackageInfo.build_from_fmri(sfmri)
+                dinfo = PackageInfo.build_from_fmri(dfmri)
+            yield (sinfo, dinfo)
 
-                vs = []
-                if self._new_variants:
-                        vs = list(self._new_variants.items())
+    def get_editable_changes(self):
+        """This function returns a tuple of generators that yield tuples
+        of the form (src, dest) of the preserved ("editable") files that
+        will be installed, moved, removed, or updated.  The returned
+        list of generators is (moved, removed, installed, updated)."""
 
-                # sort results by variant name
-                vs.sort(key=lambda x: x[0])
+        return (
+            (entry for entry in self._preserved["moved"]),
+            ((entry[0], None) for entry in self._preserved["removed"]),
+            ((None, entry[0]) for entry in self._preserved["installed"]),
+            ((entry[0], entry[0]) for entry in self._preserved["updated"]),
+        )
 
-                fs = []
-                if self._new_facets is None:
-                        return (vs, fs)
+    def get_actions(self):
+        """A generator function that yields action change descriptions
+        in the order they will be performed."""
 
-                # create new dictionaries that index facets by name and
-                # source:
-                #    dict[(<facet, src>)] = (<value>, <masked>)
-                old_facets = dict([
-                    ((f, src), (v, masked))
-                    # not-an-iterable self._old_facets;
-                    # pylint: disable=E1133
-                    for f in self._old_facets
-                    # W0212 Access to a protected member
-                    # pylint: disable=W0212
-                    for v, src, masked in self._old_facets._src_values(f)
-                ])
-                new_facets = dict([
-                    ((f, src), (v, masked))
-                    # not-an-iterable self._new_facets;
-                    # pylint: disable=E1133
-                    for f in self._new_facets
-                    # W0212 Access to a protected member
-                    # pylint: disable=W0212
-                    for v, src, masked in self._new_facets._src_values(f)
-                ])
+        # Unused variable '%s'; pylint: disable=W0612
+        for pplan, o_act, d_act in itertools.chain(
+            self.removal_actions, self.update_actions, self.install_actions
+        ):
+            # pylint: enable=W0612
+            yield "{0} -> {1}".format(o_act, d_act)
 
-                # check for removed facets
-                for f, src in set(old_facets) - set(new_facets):
-                        v, masked = old_facets[f, src]
-                        fs.append((f, None, v, src, masked, False))
+    def get_elided_actions(self) -> Iterator[tuple[object, object]]:
+        for pplan, o_act, d_act in self.elided_actions:
+            yield (o_act, d_act)
 
-                # check for added facets
-                for f, src in set(new_facets) - set(old_facets):
-                        v, masked = new_facets[f, src]
-                        fs.append((f, v, None, src, False, masked))
+    def has_release_notes(self):
+        """True if there are release notes for this plan"""
+        return bool(self.release_notes[1])
 
-                # check for changing facets
-                for f, src in set(old_facets) & set(new_facets):
-                        if old_facets[f, src] == new_facets[f, src]:
-                                continue
-                        v_old, m_old = old_facets[f, src]
-                        v_new, m_new = new_facets[f, src]
-                        fs.append((f, v_new, v_old, src, m_old, m_new))
+    def must_display_notes(self):
+        """True if the release notes must be displayed"""
+        return self.release_notes[0]
 
-                # sort results by facet name
-                fs.sort(key=lambda x: x[0])
+    def get_release_notes(self):
+        """A generator that returns the release notes for this plan"""
+        for notes in self.release_notes[1]:
+            yield notes
 
-                return (vs, fs)
+    def get_licenses(self, pfmri=None):
+        """A generator function that yields information about the
+        licenses related to the current plan in tuples of the form
+        (dest_fmri, src, dest, accepted, displayed) for the given
+        package FMRI or all packages in the plan.  This is only
+        available for licenses that are being installed or updated.
 
-        def get_varcets(self):
-                """Returns a formatted list of strings representing the
-                variant/facet changes in this plan"""
-                vs, fs = self.varcets
-                rv = [
-                    "variant {0}: {1}".format(name[8:], val)
-                    for (name, val) in vs
-                ]
-                masked_str = _(" (masked)")
-                for name, v_new, v_old, src, m_old, m_new in fs:
-                        m_old = m_old and masked_str or ""
-                        m_new = m_new and masked_str or ""
-                        msg = "  facet {0} ({1}): {2}{3} -> {4}{5}".format(
-                            name[6:], src, v_old, m_old, v_new, m_new)
-                        rv.append(msg)
-                return rv
+        'dest_fmri' is the FMRI of the package being installed.
 
-        def get_changes(self):
-                """A generator function that yields tuples of PackageInfo
-                objects of the form (src_pi, dest_pi).
+        'src' is a LicenseInfo object if the license of the related
+        package is being updated; otherwise it is None.
 
-                If 'src_pi' is None, then 'dest_pi' is the package being
-                installed.
+        'dest' is the LicenseInfo object for the license that is being
+        installed.
 
-                If 'src_pi' is not None, and 'dest_pi' is None, 'src_pi'
-                is the package being removed.
+        'accepted' is a boolean value indicating that the license has
+        been marked as accepted for the current plan.
 
-                If 'src_pi' is not None, and 'dest_pi' is not None,
-                then 'src_pi' is the original version of the package,
-                and 'dest_pi' is the new version of the package it is
-                being upgraded to."""
+        'displayed' is a boolean value indicating that the license has
+        been marked as displayed for the current plan."""
 
-                key = operator.attrgetter("origin_fmri", "destination_fmri")
-                for pp in sorted(self.pkg_plans, key=key):
-                        sfmri = pp.origin_fmri
-                        dfmri = pp.destination_fmri
-                        if sfmri == dfmri:
-                                sinfo = dinfo = PackageInfo.build_from_fmri(
-                                    sfmri)
-                        else:
-                                sinfo = PackageInfo.build_from_fmri(sfmri)
-                                dinfo = PackageInfo.build_from_fmri(dfmri)
-                        yield (sinfo, dinfo)
+        for pp in self.pkg_plans:
+            dfmri = pp.destination_fmri
+            if pfmri and dfmri != pfmri:
+                continue
 
-        def get_editable_changes(self):
-                """This function returns a tuple of generators that yield tuples
-                of the form (src, dest) of the preserved ("editable") files that
-                will be installed, moved, removed, or updated.  The returned
-                list of generators is (moved, removed, installed, updated)."""
+            # Unused variable; pylint: disable=W0612
+            for lid, entry in pp.get_licenses():
+                src = entry["src"]
+                src_li = None
+                if src:
+                    src_li = LicenseInfo(pp.origin_fmri, src, img=pp.image)
 
-                return (
-                    (entry for entry in self._preserved["moved"]),
-                    ((entry[0], None) for entry in self._preserved["removed"]),
-                    ((None, entry[0])
-                        for entry in self._preserved["installed"]),
-                    ((entry[0], entry[0])
-                        for entry in self._preserved["updated"]),
+                dest = entry["dest"]
+                dest_li = None
+                if dest:
+                    dest_li = LicenseInfo(
+                        pp.destination_fmri, dest, img=pp.image
+                    )
+
+                yield (
+                    pp.destination_fmri,
+                    src_li,
+                    dest_li,
+                    entry["accepted"],
+                    entry["displayed"],
                 )
 
-        def get_actions(self):
-                """A generator function that yields action change descriptions
-                in the order they will be performed."""
+            if pfmri:
+                break
 
-                # Unused variable '%s'; pylint: disable=W0612
-                for pplan, o_act, d_act in itertools.chain(
-                    self.removal_actions,
-                    self.update_actions,
-                    self.install_actions):
-                # pylint: enable=W0612
-                        yield "{0} -> {1}".format(o_act, d_act)
+    def get_solver_errors(self):
+        """Returns a list of strings for all FMRIs evaluated by the
+        solver explaining why they were rejected.  (All packages
+        found in solver's trim database.)  Only available if
+        DebugValues["plan"] was set when the plan was created.
+        """
 
-        def get_elided_actions(self) -> Iterator[tuple[object, object]]:
-                for pplan, o_act, d_act in self.elided_actions:
-                        yield (o_act, d_act)
+        assert self.state >= EVALUATED_PKGS, "{0} >= {1}".format(
+            self.state, EVALUATED_PKGS
+        )
 
-        def has_release_notes(self):
-                """True if there are release notes for this plan"""
-                return bool(self.release_notes[1])
+        # in case this operation doesn't use solver
+        if self._solver_errors is None:
+            return []
 
-        def must_display_notes(self):
-                """True if the release notes must be displayed"""
-                return self.release_notes[0]
+        return self._solver_errors
 
-        def get_release_notes(self):
-                """A generator that returns the release notes for this plan"""
-                for notes in self.release_notes[1]:
-                        yield notes
+    def get_parsable_plan(
+        self, parsable_version, child_images=None, api_inst=None
+    ):
+        """Display the parsable version of the plan."""
 
-        def get_licenses(self, pfmri=None):
-                """A generator function that yields information about the
-                licenses related to the current plan in tuples of the form
-                (dest_fmri, src, dest, accepted, displayed) for the given
-                package FMRI or all packages in the plan.  This is only
-                available for licenses that are being installed or updated.
+        assert parsable_version == 0, "parsable_version was {0!r}".format(
+            parsable_version
+        )
+        # Set the default values.
+        added_fmris = []
+        removed_fmris = []
+        changed_fmris = []
+        affected_fmris = []
+        backup_be_created = False
+        new_be_created = False
+        backup_be_name = None
+        be_name = None
+        boot_archive_rebuilt = False
+        be_activated = True
+        space_available = None
+        space_required = None
+        facets_changed = []
+        variants_changed = []
+        services_affected = []
+        mediators_changed = []
+        editables_changed = []
+        licenses = []
 
-                'dest_fmri' is the FMRI of the package being installed.
+        if child_images is None:
+            child_images = []
+        release_notes = []
+        if self:
+            for rem, add in self.get_changes():
+                assert rem is not None or add is not None
+                if rem is not None and add is not None:
+                    # Lists of lists are used here becuase
+                    # json will convert lists of tuples
+                    # into lists of lists anyway.
+                    if rem.fmri == add.fmri:
+                        affected_fmris.append(str(rem))
+                    else:
+                        changed_fmris.append([str(rem), str(add)])
+                elif rem is not None:
+                    removed_fmris.append(str(rem))
+                else:
+                    added_fmris.append(str(add))
+            variants_changed, facets_changed = self.varcets
+            backup_be_created = self.backup_be
+            new_be_created = self.new_be
+            backup_be_name = self.backup_be_name
+            be_name = self.be_name
+            boot_archive_rebuilt = self.update_boot_archive
+            be_activated = self.activate_be
+            space_available = self.bytes_avail
+            space_required = self.bytes_added
+            services_affected = self.services
+            mediators_changed = self.mediators
 
-                'src' is a LicenseInfo object if the license of the related
-                package is being updated; otherwise it is None.
+            emoved, eremoved, einstalled, eupdated = self.get_editable_changes()
 
-                'dest' is the LicenseInfo object for the license that is being
-                installed.
+            # Lists of lists are used here to ensure a consistent
+            # ordering and because tuples will be converted to
+            # lists anyway; a dictionary would be more logical for
+            # the top level entries, but would make testing more
+            # difficult and this is a small, known set anyway.
+            emoved = [[e for e in entry] for entry in emoved]
+            eremoved = [src for (src, dest) in eremoved]
+            einstalled = [dest for (src, dest) in einstalled]
+            eupdated = [dest for (src, dest) in eupdated]
+            if emoved:
+                editables_changed.append(["moved", emoved])
+            if eremoved:
+                editables_changed.append(["removed", eremoved])
+            if einstalled:
+                editables_changed.append(["installed", einstalled])
+            if eupdated:
+                editables_changed.append(["updated", eupdated])
 
-                'accepted' is a boolean value indicating that the license has
-                been marked as accepted for the current plan.
+            for n in self.get_release_notes():
+                release_notes.append(n)
 
-                'displayed' is a boolean value indicating that the license has
-                been marked as displayed for the current plan."""
+            for (
+                dfmri,
+                src_li,
+                dest_li,
+                dummy_acc,
+                dummy_disp,
+            ) in self.get_licenses():
+                src_tup = ()
+                if src_li:
+                    src_tup = (
+                        str(src_li.fmri),
+                        src_li.license,
+                        src_li.get_text(),
+                        src_li.must_accept,
+                        src_li.must_display,
+                    )
+                dest_tup = ()
+                if dest_li:
+                    dest_tup = (
+                        str(dest_li.fmri),
+                        dest_li.license,
+                        dest_li.get_text(),
+                        dest_li.must_accept,
+                        dest_li.must_display,
+                    )
+                licenses.append((str(dfmri), src_tup, dest_tup))
 
-                for pp in self.pkg_plans:
-                        dfmri = pp.destination_fmri
-                        if pfmri and dfmri != pfmri:
-                                continue
+                # If api_inst is set, mark licenses as
+                # displayed.
+                if api_inst:
+                    api_inst.set_plan_license_status(
+                        dfmri, dest_li.license, displayed=True
+                    )
 
-                        # Unused variable; pylint: disable=W0612
-                        for lid, entry in pp.get_licenses():
-                                src = entry["src"]
-                                src_li = None
-                                if src:
-                                        src_li = LicenseInfo(pp.origin_fmri,
-                                            src, img=pp.image)
+        # The image name for the parent image is always None.  If this
+        # image is a child image, then the image name will be set when
+        # the parent image processes this dictionary.
+        ret = {
+            "activate-be": be_activated,
+            "add-packages": sorted(added_fmris),
+            "affect-packages": sorted(affected_fmris),
+            "affect-services": sorted(services_affected),
+            "backup-be-name": backup_be_name,
+            "be-name": be_name,
+            "boot-archive-rebuild": boot_archive_rebuilt,
+            "change-facets": sorted(facets_changed),
+            "change-editables": editables_changed,
+            "change-mediators": sorted(mediators_changed),
+            "change-packages": sorted(changed_fmris),
+            "change-variants": sorted(variants_changed),
+            "child-images": child_images,
+            "create-backup-be": backup_be_created,
+            "create-new-be": new_be_created,
+            "image-name": None,
+            "item-messages": self.get_parsable_item_messages(),
+            "licenses": sorted(licenses, key=lambda x: (x[0], x[1], x[2])),
+            "release-notes": release_notes,
+            "remove-packages": sorted(removed_fmris),
+            "space-available": space_available,
+            "space-required": space_required,
+            "version": parsable_version,
+        }
+        return ret
 
-                                dest = entry["dest"]
-                                dest_li = None
-                                if dest:
-                                        dest_li = LicenseInfo(
-                                            pp.destination_fmri, dest,
-                                            img=pp.image)
+    def get_parsable_item_messages(self):
+        """Return parsable item messages."""
+        return self._item_msgs
 
-                                yield (pp.destination_fmri, src_li, dest_li,
-                                    entry["accepted"], entry["displayed"])
+    def add_item_message(
+        self,
+        item_id,
+        msg_time,
+        msg_level,
+        msg_text,
+        msg_type=MSG_GENERAL,
+        parent=None,
+    ):
+        """Add a new message with its time, type and text for an
+        item."""
+        if parent:
+            item_key = parent
+            sub_item = item_id
+        else:
+            item_key = item_id
+            sub_item = "messages"
+        if self.state >= PREEXECUTED_OK:
+            msg_stage = OP_STAGE_EXEC
+        elif self.state >= EVALUATED_OK:
+            msg_stage = OP_STAGE_PREP
+        else:
+            msg_stage = OP_STAGE_PLAN
+        # First level messaging looks like:
+        # {"item_id": {"messages": [msg_payload ...]}}
+        # Second level messaging looks like:
+        # {"item_id": {"sub_item_id": [msg_payload ...]}}.
+        msg_payload = {
+            "msg_time": msg_time,
+            "msg_level": msg_level,
+            "msg_type": msg_type,
+            "msg_text": msg_text,
+            "msg_stage": msg_stage,
+        }
+        self._item_msgs[item_key].setdefault(sub_item, []).append(msg_payload)
 
-                        if pfmri:
-                                break
+    def extend_item_messages(self, item_id, messages, parent=None):
+        """Add new messages to an item."""
+        if parent:
+            item_key = parent
+            sub_item = item_id
+        else:
+            item_key = item_id
+            sub_item = "messages"
+        self._item_msgs[item_key].setdefault(sub_item, []).extend(messages)
 
-        def get_solver_errors(self):
-                """Returns a list of strings for all FMRIs evaluated by the
-                solver explaining why they were rejected.  (All packages
-                found in solver's trim database.)  Only available if
-                DebugValues["plan"] was set when the plan was created.
-                """
+    @staticmethod
+    def __msg_dict2list(msg):
+        """Convert a message dictionary to a list."""
+        return [
+            msg["msg_time"],
+            msg["msg_level"],
+            msg["msg_type"],
+            msg["msg_text"],
+        ]
 
-                assert self.state >= EVALUATED_PKGS, \
-                        "{0} >= {1}".format(self.state, EVALUATED_PKGS)
+    def __gen_ordered_msg(self, stages):
+        """Generate ordered messages."""
+        ordered_list = []
+        for item_id in self._item_msgs:
+            # To make the first level messages come
+            # relatively earlier.
+            if "messages" in self._item_msgs[item_id]:
+                for msg in self._item_msgs[item_id]["messages"]:
+                    if stages is not None and msg["msg_stage"] not in stages:
+                        continue
+                    ordered_list.append(
+                        [item_id, None] + PlanDescription.__msg_dict2list(msg)
+                    )
+                    msg["msg_stage"] = OP_STAGE_PRINTED
+            for si, si_list in six.iteritems(self._item_msgs[item_id]):
+                if si == "messages":
+                    continue
+                for msg in si_list:
+                    if stages is not None and msg["msg_stage"] not in stages:
+                        continue
+                    ordered_list.append(
+                        [si, item_id] + PlanDescription.__msg_dict2list(msg)
+                    )
+                    msg["msg_stage"] = OP_STAGE_PRINTED
+        for entry in sorted(ordered_list, key=operator.itemgetter(2)):
+            yield entry
 
-                # in case this operation doesn't use solver
-                if self._solver_errors is None:
-                        return []
+    def __gen_unordered_msg(self, stages):
+        """Generate unordered messages."""
+        for item_id in self._item_msgs:
+            for si, si_list in six.iteritems(self._item_msgs[item_id]):
+                if si == "messages":
+                    iid = item_id
+                    pid = None
+                else:
+                    iid = si
+                    pid = item_id
+                for mp in si_list:
+                    if stages is not None and mp["msg_stage"] not in stages:
+                        continue
+                    mp["msg_stage"] = OP_STAGE_PRINTED
+                    yield ([iid, pid] + PlanDescription.__msg_dict2list(mp))
 
-                return self._solver_errors
+    def gen_item_messages(self, ordered=False, stages=None):
+        """Return all item messages.
 
-        def get_parsable_plan(self, parsable_version, child_images=None,
-            api_inst=None):
-                """Display the parsable version of the plan."""
+        'ordered' is an optional boolean value that indicates that
+        item messages will be sorted by msg_time. If False, item
+        messages will be in an arbitrary order.
 
-                assert parsable_version == 0, \
-                    "parsable_version was {0!r}".format(parsable_version)
-                # Set the default values.
-                added_fmris = []
-                removed_fmris = []
-                changed_fmris = []
-                affected_fmris = []
-                backup_be_created = False
-                new_be_created = False
-                backup_be_name = None
-                be_name = None
-                boot_archive_rebuilt = False
-                be_activated = True
-                space_available = None
-                space_required = None
-                facets_changed = []
-                variants_changed = []
-                services_affected = []
-                mediators_changed = []
-                editables_changed = []
-                licenses = []
+        'stages' is an optional list or set of the stages of messages
+        to return."""
 
-                if child_images is None:
-                        child_images = []
-                release_notes = []
-                if self:
-                        for rem, add in self.get_changes():
-                                assert rem is not None or add is not None
-                                if rem is not None and add is not None:
-                                        # Lists of lists are used here becuase
-                                        # json will convert lists of tuples
-                                        # into lists of lists anyway.
-                                        if rem.fmri == add.fmri:
-                                                affected_fmris.append(str(rem))
-                                        else:
-                                                changed_fmris.append(
-                                                    [str(rem), str(add)])
-                                elif rem is not None:
-                                        removed_fmris.append(str(rem))
-                                else:
-                                        added_fmris.append(str(add))
-                        variants_changed, facets_changed = self.varcets
-                        backup_be_created = self.backup_be
-                        new_be_created = self.new_be
-                        backup_be_name = self.backup_be_name
-                        be_name = self.be_name
-                        boot_archive_rebuilt = self.update_boot_archive
-                        be_activated = self.activate_be
-                        space_available = self.bytes_avail
-                        space_required = self.bytes_added
-                        services_affected = self.services
-                        mediators_changed = self.mediators
+        if ordered:
+            return self.__gen_ordered_msg(stages)
+        else:
+            return self.__gen_unordered_msg(stages)
 
-                        emoved, eremoved, einstalled, eupdated = \
-                            self.get_editable_changes()
+    def set_actuator_timeout(self, timeout):
+        """Set timeout for synchronous actuators."""
+        assert type(timeout) == int, "Actuator timeout must be an " "integer."
+        self._actuators.set_timeout(timeout)
 
-                        # Lists of lists are used here to ensure a consistent
-                        # ordering and because tuples will be converted to
-                        # lists anyway; a dictionary would be more logical for
-                        # the top level entries, but would make testing more
-                        # difficult and this is a small, known set anyway.
-                        emoved = [[e for e in entry] for entry in emoved]
-                        eremoved = [src for (src, dest) in eremoved]
-                        einstalled = [dest for (src, dest) in einstalled]
-                        eupdated = [dest for (src, dest) in eupdated]
-                        if emoved:
-                                editables_changed.append(["moved", emoved])
-                        if eremoved:
-                                editables_changed.append(["removed", eremoved])
-                        if einstalled:
-                                editables_changed.append(["installed",
-                                    einstalled])
-                        if eupdated:
-                                editables_changed.append(["updated", eupdated])
-
-                        for n in self.get_release_notes():
-                                release_notes.append(n)
-
-                        for dfmri, src_li, dest_li, dummy_acc, dummy_disp in \
-                            self.get_licenses():
-                                src_tup = ()
-                                if src_li:
-                                        src_tup = (str(src_li.fmri),
-                                            src_li.license, src_li.get_text(),
-                                            src_li.must_accept,
-                                            src_li.must_display)
-                                dest_tup = ()
-                                if dest_li:
-                                        dest_tup = (str(dest_li.fmri),
-                                            dest_li.license, dest_li.get_text(),
-                                            dest_li.must_accept,
-                                            dest_li.must_display)
-                                licenses.append(
-                                    (str(dfmri), src_tup, dest_tup))
-
-                                # If api_inst is set, mark licenses as
-                                # displayed.
-                                if api_inst:
-                                        api_inst.set_plan_license_status(dfmri,
-                                            dest_li.license, displayed=True)
-
-                # The image name for the parent image is always None.  If this
-                # image is a child image, then the image name will be set when
-                # the parent image processes this dictionary.
-                ret = {
-                    "activate-be": be_activated,
-                    "add-packages": sorted(added_fmris),
-                    "affect-packages": sorted(affected_fmris),
-                    "affect-services": sorted(services_affected),
-                    "backup-be-name": backup_be_name,
-                    "be-name": be_name,
-                    "boot-archive-rebuild": boot_archive_rebuilt,
-                    "change-facets": sorted(facets_changed),
-                    "change-editables": editables_changed,
-                    "change-mediators": sorted(mediators_changed),
-                    "change-packages": sorted(changed_fmris),
-                    "change-variants": sorted(variants_changed),
-                    "child-images": child_images,
-                    "create-backup-be": backup_be_created,
-                    "create-new-be": new_be_created,
-                    "image-name": None,
-                    "item-messages": self.get_parsable_item_messages(),
-                    "licenses": sorted(licenses,
-                        key=lambda x: (x[0], x[1], x[2])),
-                    "release-notes": release_notes,
-                    "remove-packages": sorted(removed_fmris),
-                    "space-available": space_available,
-                    "space-required": space_required,
-                    "version": parsable_version
+    def add_pkg_actuator(self, trigger_pkg, exec_op, cpkg):
+        """Add a pkg actuator to the plan. The internal dictionary looks
+        like this:
+                {  trigger_pkg: {
+                                  exec_op : [ changed pkg, ... ],
+                                  ...
+                                },
+                  ...
                 }
-                return ret
+        """
 
-        def get_parsable_item_messages(self):
-                """Return parsable item messages."""
-                return self._item_msgs
+        if trigger_pkg in self._pkg_actuators:
+            if exec_op in self._pkg_actuators[trigger_pkg]:
+                self._pkg_actuators[trigger_pkg][exec_op].append(cpkg)
+                self._pkg_actuators[trigger_pkg][exec_op].sort()
+            else:
+                self._pkg_actuators[trigger_pkg][exec_op] = [cpkg]
+        else:
+            self._pkg_actuators[trigger_pkg] = {exec_op: [cpkg]}
 
-        def add_item_message(self, item_id, msg_time, msg_level, msg_text,
-            msg_type=MSG_GENERAL, parent=None):
-                """Add a new message with its time, type and text for an
-                item."""
-                if parent:
-                        item_key = parent
-                        sub_item = item_id
-                else:
-                        item_key = item_id
-                        sub_item = "messages"
-                if self.state >= PREEXECUTED_OK:
-                        msg_stage = OP_STAGE_EXEC
-                elif self.state >= EVALUATED_OK:
-                        msg_stage = OP_STAGE_PREP
-                else:
-                        msg_stage = OP_STAGE_PLAN
-                # First level messaging looks like:
-                # {"item_id": {"messages": [msg_payload ...]}}
-                # Second level messaging looks like:
-                # {"item_id": {"sub_item_id": [msg_payload ...]}}.
-                msg_payload = {"msg_time": msg_time,
-                               "msg_level": msg_level,
-                               "msg_type": msg_type,
-                               "msg_text": msg_text,
-                               "msg_stage": msg_stage}
-                self._item_msgs[item_key].setdefault(sub_item,
-                    []).append(msg_payload)
+    def gen_pkg_actuators(self):
+        """Pkg actuators which got triggered by operation."""
+        for trigger_pkg in sorted(self._pkg_actuators):
+            yield (trigger_pkg, self._pkg_actuators[trigger_pkg])
 
-        def extend_item_messages(self, item_id, messages, parent=None):
-                """Add new messages to an item."""
-                if parent:
-                        item_key = parent
-                        sub_item = item_id
-                else:
-                        item_key = item_id
-                        sub_item = "messages"
-                self._item_msgs[item_key].setdefault(sub_item, []).extend(
-                    messages)
+    @property
+    def actuator_timed_out(self):
+        """Indicates that a synchronous actuator timed out."""
+        return self._act_timed_out
 
-        @staticmethod
-        def __msg_dict2list(msg):
-                """Convert a message dictionary to a list."""
-                return [msg["msg_time"], msg["msg_level"], msg["msg_type"],
-                    msg["msg_text"]]
+    @property
+    def plan_type(self):
+        """Return the type of plan that was created (ex:
+        API_OP_UPDATE)."""
+        return self._op
 
-        def __gen_ordered_msg(self, stages):
-                """Generate ordered messages."""
-                ordered_list = []
-                for item_id in self._item_msgs:
-                        # To make the first level messages come
-                        # relatively earlier.
-                        if "messages" in self._item_msgs[item_id]:
-                                for msg in self._item_msgs[item_id]["messages"]:
-                                        if (stages is not None and
-                                            msg["msg_stage"] not in stages):
-                                                continue
-                                        ordered_list.append([item_id, None] + \
-                                            PlanDescription. \
-                                                    __msg_dict2list(msg))
-                                        msg["msg_stage"] = OP_STAGE_PRINTED
-                        for si, si_list in six.iteritems(
-                            self._item_msgs[item_id]):
-                                if si == "messages":
-                                        continue
-                                for msg in si_list:
-                                        if (stages is not None and
-                                            msg["msg_stage"] not in stages):
-                                                continue
-                                        ordered_list.append([si, item_id] + \
-                                            PlanDescription. \
-                                                    __msg_dict2list(msg))
-                                        msg["msg_stage"] = OP_STAGE_PRINTED
-                for entry in sorted(ordered_list, key=operator.itemgetter(2)):
-                        yield entry
+    @property
+    def update_index(self):
+        """Boolean indicating if indexes will be updated as part of an
+        image-modifying operation."""
+        return self._update_index
 
-        def __gen_unordered_msg(self, stages):
-                """Generate unordered messages."""
-                for item_id in self._item_msgs:
-                        for si, si_list in six.iteritems(
-                            self._item_msgs[item_id]):
-                                if si == "messages":
-                                        iid = item_id
-                                        pid = None
-                                else:
-                                        iid = si
-                                        pid = item_id
-                                for mp in si_list:
-                                        if (stages is not None and
-                                            mp["msg_stage"] not in stages):
-                                                continue
-                                        mp["msg_stage"] = OP_STAGE_PRINTED
-                                        yield([iid, pid] + \
-                                            PlanDescription.__msg_dict2list(mp))
+    @property
+    def backup_be(self):
+        """Either None, True, or False.  If None then executing this
+        plan may create a backup BE.  If False, then executing this
+        plan will not create a backup BE.  If True, then executing
+        this plan will create a backup BE."""
+        return self._backup_be
 
-        def gen_item_messages(self, ordered=False, stages=None):
-                """Return all item messages.
+    @property
+    def be_name(self):
+        """The name of a new BE that will be created if this plan is
+        executed."""
+        return self._be_name
 
-                'ordered' is an optional boolean value that indicates that
-                item messages will be sorted by msg_time. If False, item
-                messages will be in an arbitrary order.
+    @property
+    def backup_be_name(self):
+        """The name of a new backup BE that will be created if this
+        plan is executed."""
+        return self._backup_be_name
 
-                'stages' is an optional list or set of the stages of messages
-                to return."""
+    @property
+    def activate_be(self):
+        """A boolean value indicating whether any new boot environment
+        will be set active on next boot."""
+        return self._be_activate
 
-                if ordered:
-                        return self.__gen_ordered_msg(stages)
-                else:
-                        return self.__gen_unordered_msg(stages)
+    @property
+    def reboot_needed(self):
+        """A boolean value indicating that execution of the plan will
+        require a restart of the system to take effect if the target
+        image is an existing boot environment."""
+        return self._actuators.reboot_needed()
 
-        def set_actuator_timeout(self, timeout):
-                """Set timeout for synchronous actuators."""
-                assert type(timeout) == int, "Actuator timeout must be an "\
-                    "integer."
-                self._actuators.set_timeout(timeout)
+    @property
+    def new_be(self):
+        """A boolean value indicating that execution of the plan will
+        take place in a clone of the current live environment"""
+        return self._new_be
 
-        def add_pkg_actuator(self, trigger_pkg, exec_op, cpkg):
-                """Add a pkg actuator to the plan. The internal dictionary looks
-                like this:
-                        {  trigger_pkg: {
-                                          exec_op : [ changed pkg, ... ],
-                                          ...
-                                        },
-                          ...
-                        }
-                """
+    @property
+    def update_boot_archive(self):
+        """A boolean value indicating whether or not the boot archive
+        will be rebuilt"""
+        return self._need_boot_archive
 
-                if trigger_pkg in self._pkg_actuators:
-                        if exec_op in self._pkg_actuators[trigger_pkg]:
-                                self._pkg_actuators[trigger_pkg][
-                                    exec_op].append(cpkg)
-                                self._pkg_actuators[trigger_pkg][exec_op].sort()
-                        else:
-                                self._pkg_actuators[trigger_pkg][exec_op] = \
-                                    [cpkg]
-                else:
-                        self._pkg_actuators[trigger_pkg] = {exec_op: [cpkg]}
+    @property
+    def bytes_added(self):
+        """Estimated number of bytes added"""
+        return self._bytes_added
 
-        def gen_pkg_actuators(self):
-                """Pkg actuators which got triggered by operation."""
-                for trigger_pkg in sorted(self._pkg_actuators):
-                        yield (trigger_pkg, self._pkg_actuators[trigger_pkg])
+    @property
+    def cbytes_added(self):
+        """Estimated number of download cache bytes added"""
+        return self._cbytes_added
 
-        @property
-        def actuator_timed_out(self):
-                """Indicates that a synchronous actuator timed out."""
-                return self._act_timed_out
+    @property
+    def bytes_avail(self):
+        """Estimated number of bytes available in image /"""
+        return self._bytes_avail
 
-        @property
-        def plan_type(self):
-                """Return the type of plan that was created (ex:
-                API_OP_UPDATE)."""
-                return self._op
+    @property
+    def cbytes_avail(self):
+        """Estimated number of bytes available in download cache"""
+        return self._cbytes_avail
 
-        @property
-        def update_index(self):
-                """Boolean indicating if indexes will be updated as part of an
-                image-modifying operation."""
-                return self._update_index
+    @property
+    def new_facets(self):
+        """If facets are changing, this is the new set of facets being
+        applied."""
+        if self._new_facets is None:
+            return None
+        return pkg.facet.Facets(self._new_facets)
 
-        @property
-        def backup_be(self):
-                """Either None, True, or False.  If None then executing this
-                plan may create a backup BE.  If False, then executing this
-                plan will not create a backup BE.  If True, then executing
-                this plan will create a backup BE."""
-                return self._backup_be
-
-        @property
-        def be_name(self):
-                """The name of a new BE that will be created if this plan is
-                executed."""
-                return self._be_name
-
-        @property
-        def backup_be_name(self):
-                """The name of a new backup BE that will be created if this
-                plan is executed."""
-                return self._backup_be_name
-
-        @property
-        def activate_be(self):
-                """A boolean value indicating whether any new boot environment
-                will be set active on next boot."""
-                return self._be_activate
-
-        @property
-        def reboot_needed(self):
-                """A boolean value indicating that execution of the plan will
-                require a restart of the system to take effect if the target
-                image is an existing boot environment."""
-                return self._actuators.reboot_needed()
-
-        @property
-        def new_be(self):
-                """A boolean value indicating that execution of the plan will
-                take place in a clone of the current live environment"""
-                return self._new_be
-
-        @property
-        def update_boot_archive(self):
-                """A boolean value indicating whether or not the boot archive
-                will be rebuilt"""
-                return self._need_boot_archive
-
-        @property
-        def bytes_added(self):
-                """Estimated number of bytes added"""
-                return self._bytes_added
-
-        @property
-        def cbytes_added(self):
-                """Estimated number of download cache bytes added"""
-                return self._cbytes_added
-
-        @property
-        def bytes_avail(self):
-                """Estimated number of bytes available in image /"""
-                return self._bytes_avail
-
-        @property
-        def cbytes_avail(self):
-                """Estimated number of bytes available in download cache"""
-                return self._cbytes_avail
-
-        @property
-        def new_facets(self):
-                """If facets are changing, this is the new set of facets being
-                applied."""
-                if self._new_facets is None:
-                        return None
-                return pkg.facet.Facets(self._new_facets)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/printengine.py
+++ b/src/modules/client/printengine.py
@@ -43,309 +43,313 @@ from pkg.misc import PipeError, force_str
 
 
 class PrintEngineException(Exception):
-        """Exception indicating the failure to create PrintEngine."""
-        def __str__(self):
-                return "PrintEngineException: {0}".format(" ".join(self.args))
+    """Exception indicating the failure to create PrintEngine."""
+
+    def __str__(self):
+        return "PrintEngineException: {0}".format(" ".join(self.args))
+
 
 class PrintEngine(six.with_metaclass(ABCMeta, object)):
-        """Abstract class defining what a PrintEngine must know how to do."""
+    """Abstract class defining what a PrintEngine must know how to do."""
 
-        def __init__(self):
-                pass
+    def __init__(self):
+        pass
 
-        @abstractmethod
-        def isslow(self):
-                """Returns true if out_file is 'slow' (<=9600 baud)."""
-                pass
+    @abstractmethod
+    def isslow(self):
+        """Returns true if out_file is 'slow' (<=9600 baud)."""
+        pass
 
-        @abstractmethod
-        def cprint(self, *args, **kwargs):
-                """Core print routine.  Must act basically like py3k's print
-                routine.  For some printengines, additional behaviors can be
-                indicated via keyword args."""
-                pass
+    @abstractmethod
+    def cprint(self, *args, **kwargs):
+        """Core print routine.  Must act basically like py3k's print
+        routine.  For some printengines, additional behaviors can be
+        indicated via keyword args."""
+        pass
 
-        @abstractmethod
-        def flush(self):
-                """Make the terminal or line ready for output by another
-                subsystem.  This commonly might entail issuing a newline."""
-                pass
+    @abstractmethod
+    def flush(self):
+        """Make the terminal or line ready for output by another
+        subsystem.  This commonly might entail issuing a newline."""
+        pass
 
 
 class POSIXPrintEngine(PrintEngine):
-        """This is an engine for printing output to the end user which has been
-        tweaked for IPS's printing needs."""
+    """This is an engine for printing output to the end user which has been
+    tweaked for IPS's printing needs."""
 
-        def __init__(self, out_file, ttymode):
-                """Create a printengine.
+    def __init__(self, out_file, ttymode):
+        """Create a printengine.
 
-                out_file -- the file object to print to
-                ttymode  -- Boolean indicating need for tty support.  Throws
-                            PrintEngineException if out_file can't support.
-                """
-                PrintEngine.__init__(self)
+        out_file -- the file object to print to
+        ttymode  -- Boolean indicating need for tty support.  Throws
+                    PrintEngineException if out_file can't support.
+        """
+        PrintEngine.__init__(self)
 
-                self._out_file = out_file
-                self.__nchars_printed = 0
-                self.__needs_nl = 0
-                self.__cr = None
-                self.__ttymode = ttymode
+        self._out_file = out_file
+        self.__nchars_printed = 0
+        self.__needs_nl = 0
+        self.__cr = None
+        self.__ttymode = ttymode
 
-                if not self.__ttymode:
-                        return
+        if not self.__ttymode:
+            return
 
-                self.__putp_re = re.compile(r"\$<[0-9]+>")
-                self.__el = None
-                if not self._out_file.isatty():
-                        raise PrintEngineException("Not a TTY")
+        self.__putp_re = re.compile(r"\$<[0-9]+>")
+        self.__el = None
+        if not self._out_file.isatty():
+            raise PrintEngineException("Not a TTY")
 
-                try:
-                        curses.setupterm(None, self._out_file.fileno())
-                        self.__cr = curses.tigetstr("cr")
-                        self.__el = curses.tigetstr("el")
-                except curses.error:
-                        raise PrintEngineException("Unknown terminal "
-                            "'{0}'".format(os.environ.get("TERM", "")))
+        try:
+            curses.setupterm(None, self._out_file.fileno())
+            self.__cr = curses.tigetstr("cr")
+            self.__el = curses.tigetstr("el")
+        except curses.error:
+            raise PrintEngineException(
+                "Unknown terminal " "'{0}'".format(os.environ.get("TERM", ""))
+            )
 
-        def putp(self, string):
-                """This routine loosely emulates python's curses.putp, but
-                works on whatever our output file is, instead just stdout"""
+    def putp(self, string):
+        """This routine loosely emulates python's curses.putp, but
+        works on whatever our output file is, instead just stdout"""
 
-                assert self.__ttymode
+        assert self.__ttymode
 
-                # Hardware terminals are pretty much gone now; we choose
-                # to drop delays specified in termcap (delays are in the
-                # form: $<[0-9]+>).
-                self._out_file.write(self.__putp_re.sub("", force_str(string)))
+        # Hardware terminals are pretty much gone now; we choose
+        # to drop delays specified in termcap (delays are in the
+        # form: $<[0-9]+>).
+        self._out_file.write(self.__putp_re.sub("", force_str(string)))
 
-        def isslow(self):
-                """Returns true if out_file is 'slow' (<=9600 baud)."""
-                b = termios.B38400   # assume it's fast if we can't tell.
-                try:
-                        b = termios.tcgetattr(self._out_file)[5]
-                except termios.error:
-                        pass
-                return b <= termios.B9600
+    def isslow(self):
+        """Returns true if out_file is 'slow' (<=9600 baud)."""
+        b = termios.B38400  # assume it's fast if we can't tell.
+        try:
+            b = termios.tcgetattr(self._out_file)[5]
+        except termios.error:
+            pass
+        return b <= termios.B9600
 
-        def erase(self):
-                """Send sequence to erase the current line to _out_file."""
-                if self.__el:
-                        self.putp(self.__cr)
-                        self.putp(self.__el)
-                        self.putp(self.__cr)
-                else:
-                        # fallback mode if we have no el; overwrite with
-                        # spaces.
-                        self.putp(self.__cr)
-                        self._out_file.write(self.__nchars_printed * ' ')
-                        self.putp(self.__cr)
+    def erase(self):
+        """Send sequence to erase the current line to _out_file."""
+        if self.__el:
+            self.putp(self.__cr)
+            self.putp(self.__el)
+            self.putp(self.__cr)
+        else:
+            # fallback mode if we have no el; overwrite with
+            # spaces.
+            self.putp(self.__cr)
+            self._out_file.write(self.__nchars_printed * " ")
+            self.putp(self.__cr)
 
-        def cprint(self, *args, **kwargs):
-                """Core print routine.  Acts largely like py3k's print command,
-                (supports 'sep' and 'end' kwargs) with an extension:
+    def cprint(self, *args, **kwargs):
+        """Core print routine.  Acts largely like py3k's print command,
+        (supports 'sep' and 'end' kwargs) with an extension:
 
-                erase=true: Erase any content on the present line, intended for
-                use in overwriting."""
+        erase=true: Erase any content on the present line, intended for
+        use in overwriting."""
 
-                sep = kwargs.get("sep", ' ')
-                outmsg = sep.join(args) + kwargs.get("end", '\n')
+        sep = kwargs.get("sep", " ")
+        outmsg = sep.join(args) + kwargs.get("end", "\n")
 
-                if kwargs.get("erase"):
-                        assert self.__ttymode
-                        self.erase()
-                        # account for the erase setting the number of chars
-                        # printed back to 0.
-                        self.__nchars_printed = 0
+        if kwargs.get("erase"):
+            assert self.__ttymode
+            self.erase()
+            # account for the erase setting the number of chars
+            # printed back to 0.
+            self.__nchars_printed = 0
 
-                #
-                # Setting __needs_nl is how _cprint works together with
-                # the flush entrypoint.  If we're partially through
-                # writing a line (which we know by inspecting the
-                # line and the "end" value), then we know that if we
-                # get flush()'d by a consumer, we need to issue an
-                # additional newline.
-                #
-                if outmsg != "" and not outmsg.endswith("\n"):
-                        self.__needs_nl = True
+        #
+        # Setting __needs_nl is how _cprint works together with
+        # the flush entrypoint.  If we're partially through
+        # writing a line (which we know by inspecting the
+        # line and the "end" value), then we know that if we
+        # get flush()'d by a consumer, we need to issue an
+        # additional newline.
+        #
+        if outmsg != "" and not outmsg.endswith("\n"):
+            self.__needs_nl = True
 
-                # find the rightmost newline in the msg
-                npos = outmsg.rfind("\n")
-                if npos == -1:
-                        self.__nchars_printed += len(outmsg)
-                else:
-                        # there was an nl or cr, so only the portion
-                        # after that counts.
-                        self.__nchars_printed = len(outmsg) - (npos + 1)
+        # find the rightmost newline in the msg
+        npos = outmsg.rfind("\n")
+        if npos == -1:
+            self.__nchars_printed += len(outmsg)
+        else:
+            # there was an nl or cr, so only the portion
+            # after that counts.
+            self.__nchars_printed = len(outmsg) - (npos + 1)
 
-                try:
-                        self._out_file.write(outmsg)
-                        self._out_file.flush()
-                        #
-                        # if indeed we printed a newline at the end, we know
-                        # that an additional newline is definitely not needed on
-                        # flush.
-                        #
-                        if outmsg.endswith("\n"):
-                                self.__needs_nl = False
-                except IOError as e:
-                        if e.errno == errno.EPIPE:
-                                raise PipeError(e)
-                        raise
+        try:
+            self._out_file.write(outmsg)
+            self._out_file.flush()
+            #
+            # if indeed we printed a newline at the end, we know
+            # that an additional newline is definitely not needed on
+            # flush.
+            #
+            if outmsg.endswith("\n"):
+                self.__needs_nl = False
+        except IOError as e:
+            if e.errno == errno.EPIPE:
+                raise PipeError(e)
+            raise
 
-        def flush(self):
-                """If we're in the middle of writing a line, this tries to
-                write a newline in order to allow clean output after flush()."""
-                try:
-                        if self.__needs_nl:
-                                self._out_file.write("\n")
-                                self.__needs_nl = False
-                        self._out_file.flush()
-                except IOError:
-                        # we consider this to be harmless.
-                        pass
+    def flush(self):
+        """If we're in the middle of writing a line, this tries to
+        write a newline in order to allow clean output after flush()."""
+        try:
+            if self.__needs_nl:
+                self._out_file.write("\n")
+                self.__needs_nl = False
+            self._out_file.flush()
+        except IOError:
+            # we consider this to be harmless.
+            pass
 
 
 class LoggingPrintEngine(PrintEngine):
-        """This class adapts a printengine such that it issues its output to a
-        python logger from the logging module.  Note that This class is used by
-        the AI (install) engine.
+    """This class adapts a printengine such that it issues its output to a
+    python logger from the logging module.  Note that This class is used by
+    the AI (install) engine.
 
-        The basic trick here is to use a StringIO in place of an actual file.
-        We then have the POSIX print engine issue its I/O to the StringIO, then
-        splitlines() the buffer and see if there are any complete lines that we
-        can output.  If so, each complete line is issued to the logger, and any
-        remainder is put back into the StringIO for subsequent display."""
+    The basic trick here is to use a StringIO in place of an actual file.
+    We then have the POSIX print engine issue its I/O to the StringIO, then
+    splitlines() the buffer and see if there are any complete lines that we
+    can output.  If so, each complete line is issued to the logger, and any
+    remainder is put back into the StringIO for subsequent display."""
 
-        def __init__(self, logger, loglevel):
-                PrintEngine.__init__(self)
-                self._logger = logger
-                self._loglevel = loglevel
-                self._stringio = six.StringIO()
-                self._pxpe = POSIXPrintEngine(self._stringio, False)
+    def __init__(self, logger, loglevel):
+        PrintEngine.__init__(self)
+        self._logger = logger
+        self._loglevel = loglevel
+        self._stringio = six.StringIO()
+        self._pxpe = POSIXPrintEngine(self._stringio, False)
 
-        def isslow(self):
-                """Returns true if out_file is 'slow' (<=9600 baud)."""
-                return False
+    def isslow(self):
+        """Returns true if out_file is 'slow' (<=9600 baud)."""
+        return False
 
-        def cprint(self, *args, **kwargs):
-                """Accumulates output into a buffer, emitting messages to
-                the _logger when full lines are available."""
-                self._pxpe.cprint(*args, **kwargs)
+    def cprint(self, *args, **kwargs):
+        """Accumulates output into a buffer, emitting messages to
+        the _logger when full lines are available."""
+        self._pxpe.cprint(*args, **kwargs)
 
-                lines = self._stringio.getvalue().splitlines(True)
-                line = ""
-                for line in lines:
-                        if line.endswith("\n"):
-                                # write out, stripping the newline
-                                self._logger.log(self._loglevel, line[:-1])
-                self._stringio.seek(0)
-                self._stringio.truncate(0)
-                # anything left without a newline?   Put it back.
-                if not line.endswith("\n"):
-                        self._stringio.write(line)
+        lines = self._stringio.getvalue().splitlines(True)
+        line = ""
+        for line in lines:
+            if line.endswith("\n"):
+                # write out, stripping the newline
+                self._logger.log(self._loglevel, line[:-1])
+        self._stringio.seek(0)
+        self._stringio.truncate(0)
+        # anything left without a newline?   Put it back.
+        if not line.endswith("\n"):
+            self._stringio.write(line)
 
-        def flush(self):
-                """Log any partial line we've got left."""
-                val = self._stringio.getvalue()
-                if val:
-                        # should only ever have a partial line
-                        assert not "\n" in val
-                        self._logger.log(self._loglevel, val)
-                self._stringio.seek(0)
-                self._stringio.truncate(0)
+    def flush(self):
+        """Log any partial line we've got left."""
+        val = self._stringio.getvalue()
+        if val:
+            # should only ever have a partial line
+            assert not "\n" in val
+            self._logger.log(self._loglevel, val)
+        self._stringio.seek(0)
+        self._stringio.truncate(0)
 
 
 def test_logging_printengine(output_file):
-        """Test driver for logging print engine.  This is maintained as a
-        standalone function in order to support the 'runprintengine' test
-        utility in $SRC/tests/interactive/runprintengine.py. It is also
-        called by the test suite."""
+    """Test driver for logging print engine.  This is maintained as a
+    standalone function in order to support the 'runprintengine' test
+    utility in $SRC/tests/interactive/runprintengine.py. It is also
+    called by the test suite."""
 
-        logger = logging.getLogger('test')
-        ch = logging.StreamHandler(output_file)
-        logger.addHandler(ch)
+    logger = logging.getLogger("test")
+    ch = logging.StreamHandler(output_file)
+    logger.addHandler(ch)
 
-        pe = LoggingPrintEngine(logger, logging.WARNING)
-        pe.cprint("Testing logging print engine. ", end='')
-        pe.cprint("Did you see this? ", end='')
-        pe.cprint("And this?")
-        pe.cprint("If the previous three sentences are on the same line, "
-            "it's working.")
-        pe.cprint("You need to see one more line after this one.")
-        pe.cprint("This should be the last line, printed by flushing", end='')
-        # just test that it works
-        pe.isslow()
-        pe.flush()
+    pe = LoggingPrintEngine(logger, logging.WARNING)
+    pe.cprint("Testing logging print engine. ", end="")
+    pe.cprint("Did you see this? ", end="")
+    pe.cprint("And this?")
+    pe.cprint(
+        "If the previous three sentences are on the same line, " "it's working."
+    )
+    pe.cprint("You need to see one more line after this one.")
+    pe.cprint("This should be the last line, printed by flushing", end="")
+    # just test that it works
+    pe.isslow()
+    pe.flush()
 
 
 def test_posix_printengine(output_file, ttymode):
-        """Test driver for POSIX print engine.  This is maintained as a
-        standalone function in order to support the 'runprintengine' test
-        utility in $SRC/tests/interactive/runprintengine.py; it is also
-        called by the test suite."""
+    """Test driver for POSIX print engine.  This is maintained as a
+    standalone function in order to support the 'runprintengine' test
+    utility in $SRC/tests/interactive/runprintengine.py; it is also
+    called by the test suite."""
 
-        pe = POSIXPrintEngine(output_file, ttymode=ttymode)
+    pe = POSIXPrintEngine(output_file, ttymode=ttymode)
 
-        standout = ""
-        sgr0 = ""
-        if ttymode:
-                # We assume that setupterm() has been called already.
-                standout = curses.tigetstr("smso") or ""
-                sgr0 = curses.tigetstr("sgr0") or ""
-
-        pe.cprint("Testing POSIX print engine; ttymode is {0}\n".format(
-            ttymode))
-
-        # If we're not in ttymode, then the testing is simple.
-        if not ttymode:
-                pe.cprint("testing  1  2  3")
-                pe.cprint("testing flush (2)")
-                pe.flush()
-                return
-
-        # We assume setupterm() has been called.
+    standout = ""
+    sgr0 = ""
+    if ttymode:
+        # We assume that setupterm() has been called already.
         standout = curses.tigetstr("smso") or ""
         sgr0 = curses.tigetstr("sgr0") or ""
-        pe.cprint("Now we'll print something and then erase it;")
-        pe.cprint("you should see a blank line below this line.")
-        pe.cprint("IF YOU CAN SEE THIS, THE TEST HAS FAILED", end='')
-        pe.cprint("", erase=True)
 
-        pe.cprint("You should see an X swishing back and forth; from")
-        pe.cprint("left to right it should be inverse.")
-        # Unused variable 'y'; pylint: disable=W0612
-        for y in range(0, 2):
-                for x in range(0, 30, 1):
-                        pe.cprint(" " * x, erase=True, end='')
-                        pe.putp(standout)
-                        pe.cprint("X", end='')
-                        pe.putp(sgr0)
-                        time.sleep(0.050)
-                for x in range(30, -1, -1):
-                        pe.cprint(" " * x + "X", erase=True, end='')
-                        time.sleep(0.050)
-        pe.cprint("", erase=True)
+    pe.cprint("Testing POSIX print engine; ttymode is {0}\n".format(ttymode))
+
+    # If we're not in ttymode, then the testing is simple.
+    if not ttymode:
         pe.cprint("testing  1  2  3")
-        pe.cprint("testing XX XX XX", end="")
-        time.sleep(0.500)
-        pe.cprint("testing  4  5  6\ntesting XX XX XX", erase=True, end="")
-        time.sleep(0.500)
-        pe.cprint("testing YY YY", end="", erase=True)
-        time.sleep(0.500)
-        pe.cprint("testing  7  8  9\ntesting 10 11 12", erase=True)
-        time.sleep(0.500)
-        pe.cprint("testing ZZ ZZ ZZ ZZ ZZ", end="")
-        time.sleep(0.500)
-        pe.cprint("testing 13 14 15", erase=True)
-
-        pe.cprint("testing flush...", end='')
-        pe.flush()
-        pe.cprint("This should be on the next line.")
         pe.cprint("testing flush (2)")
         pe.flush()
-        pe.cprint("This should be on the next line (with no nl's intervening).")
-        # just test that it works
-        pe.isslow()
+        return
+
+    # We assume setupterm() has been called.
+    standout = curses.tigetstr("smso") or ""
+    sgr0 = curses.tigetstr("sgr0") or ""
+    pe.cprint("Now we'll print something and then erase it;")
+    pe.cprint("you should see a blank line below this line.")
+    pe.cprint("IF YOU CAN SEE THIS, THE TEST HAS FAILED", end="")
+    pe.cprint("", erase=True)
+
+    pe.cprint("You should see an X swishing back and forth; from")
+    pe.cprint("left to right it should be inverse.")
+    # Unused variable 'y'; pylint: disable=W0612
+    for y in range(0, 2):
+        for x in range(0, 30, 1):
+            pe.cprint(" " * x, erase=True, end="")
+            pe.putp(standout)
+            pe.cprint("X", end="")
+            pe.putp(sgr0)
+            time.sleep(0.050)
+        for x in range(30, -1, -1):
+            pe.cprint(" " * x + "X", erase=True, end="")
+            time.sleep(0.050)
+    pe.cprint("", erase=True)
+    pe.cprint("testing  1  2  3")
+    pe.cprint("testing XX XX XX", end="")
+    time.sleep(0.500)
+    pe.cprint("testing  4  5  6\ntesting XX XX XX", erase=True, end="")
+    time.sleep(0.500)
+    pe.cprint("testing YY YY", end="", erase=True)
+    time.sleep(0.500)
+    pe.cprint("testing  7  8  9\ntesting 10 11 12", erase=True)
+    time.sleep(0.500)
+    pe.cprint("testing ZZ ZZ ZZ ZZ ZZ", end="")
+    time.sleep(0.500)
+    pe.cprint("testing 13 14 15", erase=True)
+
+    pe.cprint("testing flush...", end="")
+    pe.flush()
+    pe.cprint("This should be on the next line.")
+    pe.cprint("testing flush (2)")
+    pe.flush()
+    pe.cprint("This should be on the next line (with no nl's intervening).")
+    # just test that it works
+    pe.isslow()
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/progress.py
+++ b/src/modules/client/progress.py
@@ -53,480 +53,500 @@ import pkg.misc as misc
 
 from pkg.client import global_settings
 from pkg.client import printengine
+
 logger = global_settings.logger
 
+
 class ProgressTrackerException(Exception):
-        """Thrown if a ProgressTracker determines that it can't be instantiated.
-        For example, the tracker which depends on a UNIX style terminal should
-        throw this exception if it can't find a valid terminal."""
-        def __str__(self):
-                return "ProgressTrackerException: {0}".format(
-                    " ".join(self.args))
+    """Thrown if a ProgressTracker determines that it can't be instantiated.
+    For example, the tracker which depends on a UNIX style terminal should
+    throw this exception if it can't find a valid terminal."""
+
+    def __str__(self):
+        return "ProgressTrackerException: {0}".format(" ".join(self.args))
 
 
-def format_pair(format1, v1, v2, scale=None, targetwidth=None,
-    format2=None):
-        """Format a pair of numbers 'v1' and 'v2' representing a fraction, such
-        as v1=3 v2=200, such that for all anticipated values of v1 (0 through
-        v2) , the result is a fixed width pair separated by '/':
+def format_pair(format1, v1, v2, scale=None, targetwidth=None, format2=None):
+    """Format a pair of numbers 'v1' and 'v2' representing a fraction, such
+    as v1=3 v2=200, such that for all anticipated values of v1 (0 through
+    v2) , the result is a fixed width pair separated by '/':
 
-            format_pair("{0:d}", 3, 200)               --> "  3/200"
+        format_pair("{0:d}", 3, 200)               --> "  3/200"
 
-        'format1' is the preferred number format.  In the event that targetwidth
-        is specified and the width of (format1.format(v2) > targetwidth), then
-        'format2' is used instead:
+    'format1' is the preferred number format.  In the event that targetwidth
+    is specified and the width of (format1.format(v2) > targetwidth), then
+    'format2' is used instead:
 
-            format_pair("{0:.1f}", 20.322, 1000.23,
-                targetwidth=5, format2="{0:d}")             --> "  20/1000"
+        format_pair("{0:.1f}", 20.322, 1000.23,
+            targetwidth=5, format2="{0:d}")             --> "  20/1000"
 
-        This provides a mechanism for downshifting the accuracy of an output
-        to preserve column width.
+    This provides a mechanism for downshifting the accuracy of an output
+    to preserve column width.
 
-        Inputs are scaled (divided by 'scale') if scale is specified."""
+    Inputs are scaled (divided by 'scale') if scale is specified."""
 
-        if scale:
-                v1 /= float(scale)
-                v2 /= float(scale)
-        realformat = format1
-        v2format = realformat.format(v2)
-        v2len = len(v2format)
-        if format2 and targetwidth and v2len > targetwidth:
-                # see if format2 is shorter.
-                # convert type 'float' to 'int'.
-                if "d" in format2:
-                        v2format = format2.format(int(v2))
-                else:
-                        v2format = format2.format(v2)
-                v2len1 = len(v2format)
-                if v2len1 < v2len:
-                        realformat = format2
-                        v2len = v2len1
-
-        formatcolon = realformat.find(":")
-        v1format = realformat[0:formatcolon + 1] + str(v2len) + \
-            realformat[formatcolon + 1:]
-        if "d" in v1format:
-                return (v1format.format(int(v1))) + "/" + v2format
+    if scale:
+        v1 /= float(scale)
+        v2 /= float(scale)
+    realformat = format1
+    v2format = realformat.format(v2)
+    v2len = len(v2format)
+    if format2 and targetwidth and v2len > targetwidth:
+        # see if format2 is shorter.
+        # convert type 'float' to 'int'.
+        if "d" in format2:
+            v2format = format2.format(int(v2))
         else:
-                return (v1format.format(v1)) + "/" + v2format
+            v2format = format2.format(v2)
+        v2len1 = len(v2format)
+        if v2len1 < v2len:
+            realformat = format2
+            v2len = v2len1
+
+    formatcolon = realformat.find(":")
+    v1format = (
+        realformat[0 : formatcolon + 1]
+        + str(v2len)
+        + realformat[formatcolon + 1 :]
+    )
+    if "d" in v1format:
+        return (v1format.format(int(v1))) + "/" + v2format
+    else:
+        return (v1format.format(v1)) + "/" + v2format
 
 
 class SpeedEstimator(object):
-        """This class implements a rudimentary download speed estimator.
-        newdata() is used to indicate download progress; curl calls
-        us back pretty frequently so that's not a terrible way to
-        go.  Download progress records are kept on a deque, and are
-        expired after self.interval seconds have elapsed.  Speed estimates
-        are smoothed so that things don't bounce around too fast.
+    """This class implements a rudimentary download speed estimator.
+    newdata() is used to indicate download progress; curl calls
+    us back pretty frequently so that's not a terrible way to
+    go.  Download progress records are kept on a deque, and are
+    expired after self.interval seconds have elapsed.  Speed estimates
+    are smoothed so that things don't bounce around too fast.
 
-        The class also implements some heuristics designed to prevent
-        handing out crappy estimates early in the download."""
+    The class also implements some heuristics designed to prevent
+    handing out crappy estimates early in the download."""
 
-        # INTERVAL describes the interval, in seconds, which is used to
-        # compute the download speed.
-        INTERVAL = 10.0
-        # This is the decay rate (or how much we mix in the historical
-        # notion of speed into the current notion).
-        SMOOTHING = 0.98
+    # INTERVAL describes the interval, in seconds, which is used to
+    # compute the download speed.
+    INTERVAL = 10.0
+    # This is the decay rate (or how much we mix in the historical
+    # notion of speed into the current notion).
+    SMOOTHING = 0.98
 
-        def __init__(self, goalbytes):
+    def __init__(self, goalbytes):
+        # Ok to modify this during operation.
+        self.goalbytes = goalbytes
+        self.__deque = deque()
+        self.__intervalbytes = 0
+        self.__curtotal = 0
+        self.__last_smooth_speed = None
+        self.__instartup = True
+        self.__noestimate = True
+        self.__starttime = None
+        self.__donetime = None
 
-                # Ok to modify this during operation.
-                self.goalbytes = goalbytes
-                self.__deque = deque()
-                self.__intervalbytes = 0
-                self.__curtotal = 0
-                self.__last_smooth_speed = None
-                self.__instartup = True
-                self.__noestimate = True
-                self.__starttime = None
-                self.__donetime = None
+    @staticmethod
+    def format_speed(speed):
+        if speed is None:
+            return None
 
-        @staticmethod
-        def format_speed(speed):
-                if speed is None:
-                        return None
+        #
+        # A little hack to keep things tidy: if the length of
+        # the speedstr > 5, we whack off the floating point
+        # portion.
+        #
+        speedstr = misc.bytes_to_str(speed, "{num:>.1f}{shortunit}")
+        if speed < 1024 or len(speedstr) > 5:
+            speedstr = misc.bytes_to_str(speed, "{num:d}{shortunit}")
+        speedstr += "/s"
+        return speedstr
 
-                #
-                # A little hack to keep things tidy: if the length of
-                # the speedstr > 5, we whack off the floating point
-                # portion.
-                #
-                speedstr = misc.bytes_to_str(speed, "{num:>.1f}{shortunit}")
-                if speed < 1024 or len(speedstr) > 5:
-                        speedstr = misc.bytes_to_str(speed,
-                            "{num:d}{shortunit}")
-                speedstr += "/s"
-                return speedstr
+    def newdata(self, nbytes, timestamp=None):
+        """Add new data as it becomes available; timestamp can be
+        overridden, although this is primarily designed for testing."""
 
-        def newdata(self, nbytes, timestamp=None):
-                """Add new data as it becomes available; timestamp can be
-                overridden, although this is primarily designed for testing."""
+        # must be started before adding data (sorry)
+        assert self.__starttime
 
-                # must be started before adding data (sorry)
-                assert self.__starttime
+        #
+        # Step 1: Insert latest datum
+        #
+        curtime = timestamp if timestamp else time.time()
+        self.__curtotal += nbytes
+        self.__deque.append((curtime, nbytes))
+        self.__intervalbytes += nbytes
 
-                #
-                # Step 1: Insert latest datum
-                #
-                curtime = timestamp if timestamp else time.time()
-                self.__curtotal += nbytes
-                self.__deque.append((curtime, nbytes))
-                self.__intervalbytes += nbytes
+        #
+        # Step 2: Expunge old data
+        #
+        while len(self.__deque) > 0:
+            (ts, val) = self.__deque[0]
+            if ts < curtime - self.INTERVAL:
+                self.__intervalbytes -= val
+                self.__deque.popleft()
+            else:
+                break
 
-                #
-                # Step 2: Expunge old data
-                #
-                while len(self.__deque) > 0:
-                        (ts, val) = self.__deque[0]
-                        if ts < curtime - self.INTERVAL:
-                                self.__intervalbytes -= val
-                                self.__deque.popleft()
-                        else:
-                                break
+        #
+        # Step 3: Recompute the estimate
+        #
+        # compute time delta between front and back of deque
+        timelapse = self.__deque[-1][0] - self.__deque[0][0]
 
-                #
-                # Step 3: Recompute the estimate
-                #
-                # compute time delta between front and back of deque
-                timelapse = self.__deque[-1][0] - self.__deque[0][0]
+        if len(self.__deque) <= 1 or timelapse == 0.0:
+            # can't operate yet
+            self.__noestimate = True
+            return
 
-                if len(self.__deque) <= 1 or timelapse == 0.0:
-                        # can't operate yet
-                        self.__noestimate = True
-                        return
+        #
+        # 'ratiocomplete' is just the percentage done.  It is
+        # used to disable 'startup mode' if the d/l completes
+        # very rapidly.  We'll always start giving the user an
+        # estimate once ratiocomplete >= 50%.
+        # pylint is picky about this message:
+        # old-division; pylint: disable=W1619
+        ratiocomplete = (
+            0.0 if self.goalbytes == 0 else self.__curtotal / self.goalbytes
+        )
 
-                #
-                # 'ratiocomplete' is just the percentage done.  It is
-                # used to disable 'startup mode' if the d/l completes
-                # very rapidly.  We'll always start giving the user an
-                # estimate once ratiocomplete >= 50%.
-                # pylint is picky about this message:
-                # old-division; pylint: disable=W1619
-                ratiocomplete = 0.0 if self.goalbytes == 0 else \
-                    self.__curtotal / self.goalbytes
+        #
+        # Keep track of whether we're in the warmup phase.  This
+        # is used to deny estimates to callers until we feel good
+        # about them.  This is very heuristic; it's a higher bar than
+        # we use below for disabling the estimate, basically because
+        # we want to open with a solid estimate.
+        #
+        if (
+            self.__instartup
+            and len(self.__deque) > 50
+            and timelapse > (self.INTERVAL / 5.0)
+        ):
+            self.__instartup = False
 
-                #
-                # Keep track of whether we're in the warmup phase.  This
-                # is used to deny estimates to callers until we feel good
-                # about them.  This is very heuristic; it's a higher bar than
-                # we use below for disabling the estimate, basically because
-                # we want to open with a solid estimate.
-                #
-                if self.__instartup and len(self.__deque) > 50 and \
-                    timelapse > (self.INTERVAL / 5.0):
-                        self.__instartup = False
+        #
+        # Even if we haven't accomplished the above requirements,
+        # exit startup mode when we're 1/3 done or more.
+        #
+        if self.__instartup and ratiocomplete > 0.33:
+            self.__instartup = False
 
-                #
-                # Even if we haven't accomplished the above requirements,
-                # exit startup mode when we're 1/3 done or more.
-                #
-                if self.__instartup and ratiocomplete > 0.33:
-                        self.__instartup = False
+        #
+        # Take a look at the deque length as well as how much an
+        # interval's worth of data we have. If it is quite short,
+        # maybe the download has stalled out, or perhaps the user
+        # used ctrl-z and then resumed; disable the estimate until we
+        # build up more data.
+        #
+        self.__noestimate = bool(
+            len(self.__deque) < 10 or timelapse < (self.INTERVAL / 20.0)
+        )
 
-                #
-                # Take a look at the deque length as well as how much an
-                # interval's worth of data we have. If it is quite short,
-                # maybe the download has stalled out, or perhaps the user
-                # used ctrl-z and then resumed; disable the estimate until we
-                # build up more data.
-                #
-                self.__noestimate = bool(len(self.__deque) < 10 or
-                    timelapse < (self.INTERVAL / 20.0))
+        curspeed = self.__intervalbytes / timelapse
 
-                curspeed = self.__intervalbytes / timelapse
+        if self.__last_smooth_speed is None:
+            self.__last_smooth_speed = curspeed
+        else:
+            self.__last_smooth_speed = int(
+                (self.SMOOTHING * self.__last_smooth_speed)
+                + ((1.0 - self.SMOOTHING) * curspeed)
+            )
 
-                if self.__last_smooth_speed is None:
-                        self.__last_smooth_speed = curspeed
-                else:
-                        self.__last_smooth_speed = \
-                            int((self.SMOOTHING * self.__last_smooth_speed) + \
-                            ((1.0 - self.SMOOTHING) * curspeed))
+    def start(self, timestamp=None):
+        assert not self.__starttime
+        self.__starttime = timestamp if timestamp else time.time()
 
-        def start(self, timestamp=None):
-                assert not self.__starttime
-                self.__starttime = timestamp if timestamp else time.time()
+    def done(self, timestamp=None):
+        assert not self.__donetime
+        self.__donetime = timestamp if timestamp else time.time()
 
-        def done(self, timestamp=None):
-                assert not self.__donetime
-                self.__donetime = timestamp if timestamp else time.time()
+    def get_speed_estimate(self):
+        if (
+            self.__noestimate
+            or self.__instartup
+            or not self.__last_smooth_speed
+        ):
+            return None
+        return int(self.__last_smooth_speed)
 
-        def get_speed_estimate(self):
-                if self.__noestimate or self.__instartup or \
-                    not self.__last_smooth_speed:
-                        return None
-                return int(self.__last_smooth_speed)
+    def get_final_speed(self):
+        if self.__donetime is None:
+            return None
+        try:
+            # pylint is picky about this message:
+            # old-division; pylint: disable=W1619
+            return self.goalbytes / self.elapsed()
+        except ZeroDivisionError:
+            return None
 
-        def get_final_speed(self):
-                if self.__donetime is None:
-                        return None
-                try:
-                        # pylint is picky about this message:
-                        # old-division; pylint: disable=W1619
-                        return self.goalbytes / self.elapsed()
-                except ZeroDivisionError:
-                        return None
+    def elapsed(self):
+        return (
+            None
+            if self.__donetime is None
+            else self.__donetime - self.__starttime
+        )
 
-        def elapsed(self):
-                return None if self.__donetime is None else \
-                    self.__donetime - self.__starttime
-
-        def __str__(self):
-                s = "<SpeedEstimator: "
-                d = self.__dict__.copy()
-                d.pop("_SpeedEstimator__deque")
-                s += str(d)
-                s += " __deque=["
-                for x, (timestamp, nbytes) in enumerate(self.__deque):
-                        if x % 3 == 0:
-                                s += "\n    "
-                        s += "(t={0:>.3f}, b={1:5d}), ".format(
-                            timestamp - self.__starttime, nbytes)
-                s += "]>"
-                return s
+    def __str__(self):
+        s = "<SpeedEstimator: "
+        d = self.__dict__.copy()
+        d.pop("_SpeedEstimator__deque")
+        s += str(d)
+        s += " __deque=["
+        for x, (timestamp, nbytes) in enumerate(self.__deque):
+            if x % 3 == 0:
+                s += "\n    "
+            s += "(t={0:>.3f}, b={1:5d}), ".format(
+                timestamp - self.__starttime, nbytes
+            )
+        s += "]>"
+        return s
 
 
 class PrintTimer(object):
-        """This helper class is used to implement damping of excessive
-        printing by progress trackers.
+    """This helper class is used to implement damping of excessive
+    printing by progress trackers.
 
-        'print_value': This is a handy 'clicker' attribute which can be
-        read to get a monotonically increasing count of the number of times
-        time_to_print() has returned True.  Can be used to key a spinner,
-        e.g.:
-                print("{0}".format(pt.print_value.format(len(__spinner_chars))))
-        """
+    'print_value': This is a handy 'clicker' attribute which can be
+    read to get a monotonically increasing count of the number of times
+    time_to_print() has returned True.  Can be used to key a spinner,
+    e.g.:
+            print("{0}".format(pt.print_value.format(len(__spinner_chars))))
+    """
 
-        def __init__(self, delay):
-                self.print_value = 0
-                self.__delay = delay
-                self.__last_print_time = 0
+    def __init__(self, delay):
+        self.print_value = 0
+        self.__delay = delay
+        self.__last_print_time = 0
 
-        def reset(self):
-                self.__last_print_time = 0
+    def reset(self):
+        self.__last_print_time = 0
 
-        def reset_now(self):
-                self.__last_print_time = time.time()
+    def reset_now(self):
+        self.__last_print_time = time.time()
 
-        #
-        # See if it has been more than __delay time since the last time we
-        # indicated that it was time to print.  If this returns true, the
-        # caller should go ahead and print; this will not return true again
-        # until the 'delay' period has elapsed again.
-        #
-        def time_to_print(self):
-                tt = time.time()
-                if (tt - self.__last_print_time) < self.__delay:
-                        return False
-                self.__last_print_time = tt
-                self.print_value += 1
-                return True
+    #
+    # See if it has been more than __delay time since the last time we
+    # indicated that it was time to print.  If this returns true, the
+    # caller should go ahead and print; this will not return true again
+    # until the 'delay' period has elapsed again.
+    #
+    def time_to_print(self):
+        tt = time.time()
+        if (tt - self.__last_print_time) < self.__delay:
+            return False
+        self.__last_print_time = tt
+        self.print_value += 1
+        return True
 
 
 class OutSpec(object):
-        """OutSpec is used by the progress tracker frontend to convey
-        contextual information to backend routines about the output
-        being requested.  'first' means "this is the first output
-        for this group of items" (so perhaps print a header).
-        'last' similarly means "this is the last output for this
-        group of items."  Additional strings can be passed via
-        the 'changed' list, denoting other events of significance."""
+    """OutSpec is used by the progress tracker frontend to convey
+    contextual information to backend routines about the output
+    being requested.  'first' means "this is the first output
+    for this group of items" (so perhaps print a header).
+    'last' similarly means "this is the last output for this
+    group of items."  Additional strings can be passed via
+    the 'changed' list, denoting other events of significance."""
 
-        def __init__(self, first=False, last=False, changed=None):
-                self.first = first
-                self.last = last
-                self.changed = [] if changed is None else changed
+    def __init__(self, first=False, last=False, changed=None):
+        self.first = first
+        self.last = last
+        self.changed = [] if changed is None else changed
 
-        def __str__(self):
-                s = "<outspec:"
-                s += " +first" if self.first else ""
-                s += " +last" if self.last else ""
-                if self.changed:
-                        for chg in self.changed:
-                                s += " +'{0}'".format(str(chg))
-                s += ">"
-                return s
+    def __str__(self):
+        s = "<outspec:"
+        s += " +first" if self.first else ""
+        s += " +last" if self.last else ""
+        if self.changed:
+            for chg in self.changed:
+                s += " +'{0}'".format(str(chg))
+        s += ">"
+        return s
 
-        # Defining "boolness" of a class, Python 2 uses the special method
-        # called __nonzero__() while Python 3 uses __bool__(). For Python
-        # 2 and 3 compatibility, define __bool__() only, and let
-        # __nonzero__ = __bool__
-        def __bool__(self):
-                return bool(self.first) or bool(self.last) or bool(self.changed)
+    # Defining "boolness" of a class, Python 2 uses the special method
+    # called __nonzero__() while Python 3 uses __bool__(). For Python
+    # 2 and 3 compatibility, define __bool__() only, and let
+    # __nonzero__ = __bool__
+    def __bool__(self):
+        return bool(self.first) or bool(self.last) or bool(self.changed)
 
-        __nonzero__ = __bool__
+    __nonzero__ = __bool__
+
 
 class TrackerItem(object):
-        """This class describes an item of interest in tracking progress
-        against some "bucket" of work (for example, searching a filesystem for
-        some item).
+    """This class describes an item of interest in tracking progress
+    against some "bucket" of work (for example, searching a filesystem for
+    some item).
 
-        This provides a way to wrap together begin and end times of the
-        operation, the operation's name, and 'curinfo'-- some additional
-        tidbit of information (such as the current directory being scanned)."""
+    This provides a way to wrap together begin and end times of the
+    operation, the operation's name, and 'curinfo'-- some additional
+    tidbit of information (such as the current directory being scanned)."""
 
-        def __init__(self, name):
-                self.starttime = -1 # signal setattr that we're in __init__.
-                self.name = name
-                self.endtime = None
-                self.items = 0
-                #
-                # Used by clients to track if this item has been printed yet.
-                # The object itself does not care about the value of this
-                # attribute but will clear it on reset()
-                #
-                self.printed = False
+    def __init__(self, name):
+        self.starttime = -1  # signal setattr that we're in __init__.
+        self.name = name
+        self.endtime = None
+        self.items = 0
+        #
+        # Used by clients to track if this item has been printed yet.
+        # The object itself does not care about the value of this
+        # attribute but will clear it on reset()
+        #
+        self.printed = False
 
-                #
-                # This attribute allows us to hang some client data
-                # off of this object; use this to store some information
-                # about the thing we're currently working on.
-                #
-                self.curinfo = None
-                self.starttime = None # done constructing
+        #
+        # This attribute allows us to hang some client data
+        # off of this object; use this to store some information
+        # about the thing we're currently working on.
+        #
+        self.curinfo = None
+        self.starttime = None  # done constructing
 
-        def reset(self):
-                # This is a kludge but I can't find a better way to do this
-                # and keep pylint's "definied outside of __init__" rule (W0201)
-                # happy, without either repeating all of this code twice, or
-                # disabling the rule file-wide.  Both of which seem even worse.
-                self.__init__(self.name)
+    def reset(self):
+        # This is a kludge but I can't find a better way to do this
+        # and keep pylint's "definied outside of __init__" rule (W0201)
+        # happy, without either repeating all of this code twice, or
+        # disabling the rule file-wide.  Both of which seem even worse.
+        self.__init__(self.name)
 
-        def __setattr__(self, attrname, value):
-                #
-                # Start 'starttime' when 'items' is first set (even to zero)
-                # Note that starttime is initially set to -1 to avoid starting
-                # the timer during __init__().
-                #
-                # Special behavior only for 'items' and only when not resetting
-                if attrname != "items" or self.starttime == -1:
-                        self.__dict__[attrname] = value
-                        return
+    def __setattr__(self, attrname, value):
+        #
+        # Start 'starttime' when 'items' is first set (even to zero)
+        # Note that starttime is initially set to -1 to avoid starting
+        # the timer during __init__().
+        #
+        # Special behavior only for 'items' and only when not resetting
+        if attrname != "items" or self.starttime == -1:
+            self.__dict__[attrname] = value
+            return
 
-                if self.starttime is None:
-                        assert not getattr(self, "endtime", None), \
-                            "can't set items after explicit done(). " \
-                            "Tried to set {0}={1} (is {2})".format(
-                            attrname, value, self.__dict__[attrname])
-                        self.starttime = time.time()
-                self.__dict__[attrname] = value
+        if self.starttime is None:
+            assert not getattr(self, "endtime", None), (
+                "can't set items after explicit done(). "
+                "Tried to set {0}={1} (is {2})".format(
+                    attrname, value, self.__dict__[attrname]
+                )
+            )
+            self.starttime = time.time()
+        self.__dict__[attrname] = value
 
-        def start(self):
-                assert self.endtime is None
-                if not self.starttime:
-                        self.starttime = time.time()
+    def start(self):
+        assert self.endtime is None
+        if not self.starttime:
+            self.starttime = time.time()
 
-        def done(self):
-                self.endtime = time.time()
+    def done(self):
+        self.endtime = time.time()
 
-        def elapsed(self):
-                if not self.starttime:
-                        return 0.0
-                endtime = self.endtime
-                if endtime is None:
-                        endtime = time.time()
-                return endtime - self.starttime
+    def elapsed(self):
+        if not self.starttime:
+            return 0.0
+        endtime = self.endtime
+        if endtime is None:
+            endtime = time.time()
+        return endtime - self.starttime
 
-        def __str__(self):
-                info = ""
-                if self.curinfo:
-                        info = " ({0})".format(str(self.curinfo))
-                return "<{0}: {1}{2}>".format(self.name, self.items, info)
+    def __str__(self):
+        info = ""
+        if self.curinfo:
+            info = " ({0})".format(str(self.curinfo))
+        return "<{0}: {1}{2}>".format(self.name, self.items, info)
 
 
 class GoalTrackerItem(TrackerItem):
-        """This class extends TrackerItem to include the notion of progress
-        towards some goal which is known in advance of beginning the operation
-        (such as downloading 37 packages).  In addition to the features of
-        TrackerItem, this class provides helpful routines for conversion to
-        printable strings of the form "  3/100"."""
+    """This class extends TrackerItem to include the notion of progress
+    towards some goal which is known in advance of beginning the operation
+    (such as downloading 37 packages).  In addition to the features of
+    TrackerItem, this class provides helpful routines for conversion to
+    printable strings of the form "  3/100"."""
 
-        def __init__(self, name):
-                TrackerItem.__init__(self, name)
-                self.goalitems = None
+    def __init__(self, name):
+        TrackerItem.__init__(self, name)
+        self.goalitems = None
 
-        def reset(self):
-                # See comment in superclass.
-                self.__init__(self.name)
+    def reset(self):
+        # See comment in superclass.
+        self.__init__(self.name)
 
-        # start 'starttime' when items gets set to non-zero
-        def __setattr__(self, attrname, value):
-                # Special behavior only for 'items' and only when not resetting
-                if attrname != "items" or self.starttime == -1:
-                        self.__dict__[attrname] = value
-                        return
+    # start 'starttime' when items gets set to non-zero
+    def __setattr__(self, attrname, value):
+        # Special behavior only for 'items' and only when not resetting
+        if attrname != "items" or self.starttime == -1:
+            self.__dict__[attrname] = value
+            return
 
-                assert not getattr(self, "endtime", None), \
-                    "can't set values after explicit done(). " \
-                    "Tried to set {0}={1} (is {2})".format(
-                    attrname, value, self.__dict__[attrname])
+        assert not getattr(self, "endtime", None), (
+            "can't set values after explicit done(). "
+            "Tried to set {0}={1} (is {2})".format(
+                attrname, value, self.__dict__[attrname]
+            )
+        )
 
-                # see if this is the first time we're setting items
-                if self.starttime is None:
-                        if self.goalitems is None:
-                                raise RuntimeError(
-                                    "Cannot alter items until goalitems is set")
-                        self.starttime = time.time()
-                self.__dict__[attrname] = value
+        # see if this is the first time we're setting items
+        if self.starttime is None:
+            if self.goalitems is None:
+                raise RuntimeError("Cannot alter items until goalitems is set")
+            self.starttime = time.time()
+        self.__dict__[attrname] = value
 
-        def done(self, goalcheck=True):
-                # Arguments number differs from overridden method;
-                #     pylint: disable=W0221
-                TrackerItem.done(self)
+    def done(self, goalcheck=True):
+        # Arguments number differs from overridden method;
+        #     pylint: disable=W0221
+        TrackerItem.done(self)
 
-                # See if we indeed met our goal.
-                if goalcheck and not self.metgoal():
-                        exstr = _("Goal mismatch '{name}': "
-                            "expected goal: {expected}, "
-                            "current value: {current}").format(
-                            name=self.name,
-                            expected=self.goalitems,
-                            current=self.items)
-                        logger.error("\n" + exstr)
-                        assert self.metgoal(), exstr
+        # See if we indeed met our goal.
+        if goalcheck and not self.metgoal():
+            exstr = _(
+                "Goal mismatch '{name}': "
+                "expected goal: {expected}, "
+                "current value: {current}"
+            ).format(
+                name=self.name, expected=self.goalitems, current=self.items
+            )
+            logger.error("\n" + exstr)
+            assert self.metgoal(), exstr
 
-        def metgoal(self):
-                if self.items == 0 and self.goalitems is None:
-                        return True
-                return self.items == self.goalitems
+    def metgoal(self):
+        if self.items == 0 and self.goalitems is None:
+            return True
+        return self.items == self.goalitems
 
-        def pair(self):
-                if self.goalitems is None:
-                        assert self.items == 0
-                        return format_pair("{0:d}", 0, 0)
-                return format_pair("{0:d}", self.items, self.goalitems)
+    def pair(self):
+        if self.goalitems is None:
+            assert self.items == 0
+            return format_pair("{0:d}", 0, 0)
+        return format_pair("{0:d}", self.items, self.goalitems)
 
-        def pairplus1(self):
-                # For use when you want to display something happening,
-                # such as: Downloading item 3/3, since typically items is
-                # not incremented until after the operation completes.
-                #
-                # To ensure that we don't print 4/3 in the last iteration of
-                # output, we also account for that case.
-                if self.goalitems is None:
-                        assert self.items == 0
-                        return format_pair("{0:d}", 1, 1)
-                if self.items == self.goalitems:
-                        items = self.items
-                else:
-                        items = self.items + 1
-                return format_pair("{0:d}", items, self.goalitems)
+    def pairplus1(self):
+        # For use when you want to display something happening,
+        # such as: Downloading item 3/3, since typically items is
+        # not incremented until after the operation completes.
+        #
+        # To ensure that we don't print 4/3 in the last iteration of
+        # output, we also account for that case.
+        if self.goalitems is None:
+            assert self.items == 0
+            return format_pair("{0:d}", 1, 1)
+        if self.items == self.goalitems:
+            items = self.items
+        else:
+            items = self.items + 1
+        return format_pair("{0:d}", items, self.goalitems)
 
-        def pctdone(self):
-                """Returns progress towards a goal as a percentage.
-                i.e. 37 / 100 would yield 37.0"""
-                if self.goalitems is None or self.goalitems == 0:
-                        return 0
-                # pylint is picky about this message:
-                # old-division; pylint: disable=W1619
-                return math.floor(100.0 *
-                    self.items / self.goalitems)
+    def pctdone(self):
+        """Returns progress towards a goal as a percentage.
+        i.e. 37 / 100 would yield 37.0"""
+        if self.goalitems is None or self.goalitems == 0:
+            return 0
+        # pylint is picky about this message:
+        # old-division; pylint: disable=W1619
+        return math.floor(100.0 * self.items / self.goalitems)
 
-        def __str__(self):
-                info = ""
-                if self.curinfo:
-                        info = " ({0})".format(str(self.curinfo))
-                return "<{0}: {1}{2}>".format(self.name, self.pair(), info)
+    def __str__(self):
+        info = ""
+        if self.curinfo:
+            info = " ({0})".format(str(self.curinfo))
+        return "<{0}: {1}{2}>".format(self.name, self.pair(), info)
+
 
 #
 # This implements a decorator which is used to mark methods in
@@ -539,14 +559,16 @@ class GoalTrackerItem(TrackerItem):
 # the required methods at __init__ time.
 #
 def pt_abstract(func):
-        # Unused argument 'args', 'kwargs'; pylint: disable=W0613
-        @wraps(func)
-        def enforce_abstract(*args, **kwargs):
-                raise NotImplementedError("{0} is abstract in "
-                    "superclass; you must implement it in your "
-                    "subclass.".format(func.__name__))
+    # Unused argument 'args', 'kwargs'; pylint: disable=W0613
+    @wraps(func)
+    def enforce_abstract(*args, **kwargs):
+        raise NotImplementedError(
+            "{0} is abstract in "
+            "superclass; you must implement it in your "
+            "subclass.".format(func.__name__)
+        )
 
-        return enforce_abstract
+    return enforce_abstract
 
 
 #
@@ -556,2633 +578,2848 @@ def pt_abstract(func):
 # versus front-end APIs.
 #
 class ProgressTrackerBackend(object):
-        # allow def func(args): pass
-        # More than one statement on a line; pylint: disable=C0321
+    # allow def func(args): pass
+    # More than one statement on a line; pylint: disable=C0321
 
-        def __init__(self): pass
+    def __init__(self):
+        pass
 
-        #
-        # This set of methods should be regarded as abstract *and* protected.
-        #
-        @pt_abstract
-        def _output_flush(self): pass
+    #
+    # This set of methods should be regarded as abstract *and* protected.
+    #
+    @pt_abstract
+    def _output_flush(self):
+        pass
 
-        @pt_abstract
-        def _change_purpose(self, old_purpose, new_purpose): pass
+    @pt_abstract
+    def _change_purpose(self, old_purpose, new_purpose):
+        pass
 
-        @pt_abstract
-        def _cache_cats_output(self, outspec): pass
+    @pt_abstract
+    def _cache_cats_output(self, outspec):
+        pass
 
-        @pt_abstract
-        def _load_cat_cache_output(self, outspec): pass
+    @pt_abstract
+    def _load_cat_cache_output(self, outspec):
+        pass
 
-        @pt_abstract
-        def _refresh_output_progress(self, outspec): pass
+    @pt_abstract
+    def _refresh_output_progress(self, outspec):
+        pass
 
-        @pt_abstract
-        def _plan_output(self, outspec, planitem): pass
+    @pt_abstract
+    def _plan_output(self, outspec, planitem):
+        pass
 
-        @pt_abstract
-        def _plan_output_all_done(self): pass
+    @pt_abstract
+    def _plan_output_all_done(self):
+        pass
 
-        @pt_abstract
-        def _mfst_fetch(self, outspec): pass
+    @pt_abstract
+    def _mfst_fetch(self, outspec):
+        pass
 
-        @pt_abstract
-        def _mfst_commit(self, outspec): pass
+    @pt_abstract
+    def _mfst_commit(self, outspec):
+        pass
 
-        @pt_abstract
-        def _repo_ver_output(self, outspec, repository_scan=False): pass
+    @pt_abstract
+    def _repo_ver_output(self, outspec, repository_scan=False):
+        pass
 
-        @pt_abstract
-        def _repo_ver_output_error(self, errors): pass
+    @pt_abstract
+    def _repo_ver_output_error(self, errors):
+        pass
 
-        @pt_abstract
-        def _repo_ver_output_done(self): pass
+    @pt_abstract
+    def _repo_ver_output_done(self):
+        pass
 
-        def _repo_fix_output(self, outspec): pass
+    def _repo_fix_output(self, outspec):
+        pass
 
-        @pt_abstract
-        def _repo_fix_output_error(self, errors): pass
+    @pt_abstract
+    def _repo_fix_output_error(self, errors):
+        pass
 
-        @pt_abstract
-        def _repo_fix_output_info(self, errors): pass
+    @pt_abstract
+    def _repo_fix_output_info(self, errors):
+        pass
 
-        @pt_abstract
-        def _repo_fix_output_done(self): pass
+    @pt_abstract
+    def _repo_fix_output_done(self):
+        pass
 
-        @pt_abstract
-        def _archive_output(self, outspec): pass
+    @pt_abstract
+    def _archive_output(self, outspec):
+        pass
 
-        @pt_abstract
-        def _dl_output(self, outspec): pass
+    @pt_abstract
+    def _dl_output(self, outspec):
+        pass
 
-        @pt_abstract
-        def _act_output(self, outspec, actionitem): pass
+    @pt_abstract
+    def _act_output(self, outspec, actionitem):
+        pass
 
-        @pt_abstract
-        def _act_output_all_done(self): pass
+    @pt_abstract
+    def _act_output_all_done(self):
+        pass
 
-        @pt_abstract
-        def _job_output(self, outspec, jobitem): pass
+    @pt_abstract
+    def _job_output(self, outspec, jobitem):
+        pass
 
-        @pt_abstract
-        def _republish_output(self, outspec): pass
+    @pt_abstract
+    def _republish_output(self, outspec):
+        pass
 
-        @pt_abstract
-        def _lint_output(self, outspec): pass
+    @pt_abstract
+    def _lint_output(self, outspec):
+        pass
 
-        @pt_abstract
-        def _li_recurse_start_output(self): pass
+    @pt_abstract
+    def _li_recurse_start_output(self):
+        pass
 
-        @pt_abstract
-        def _li_recurse_end_output(self): pass
+    @pt_abstract
+    def _li_recurse_end_output(self):
+        pass
 
-        @pt_abstract
-        def _li_recurse_output_output(self, lin, stdout, stderr): pass
+    @pt_abstract
+    def _li_recurse_output_output(self, lin, stdout, stderr):
+        pass
 
-        @pt_abstract
-        def _li_recurse_status_output(self, done): pass
+    @pt_abstract
+    def _li_recurse_status_output(self, done):
+        pass
 
-        @pt_abstract
-        def _li_recurse_progress_output(self, lin): pass
+    @pt_abstract
+    def _li_recurse_progress_output(self, lin):
+        pass
 
-        @pt_abstract
-        def _reversion(self, pfmri, outspec): pass
+    @pt_abstract
+    def _reversion(self, pfmri, outspec):
+        pass
+
 
 class ProgressTrackerFrontend(object):
-        """This essentially abstract class forms the interface that other
-        modules in the system use to record progress against various goals."""
-
-        # More than one statement on a line; pylint: disable=C0321
-
-        # Major phases of operation
-        PHASE_PREPLAN = 1
-        PHASE_PLAN = 2
-        PHASE_DOWNLOAD = 3
-        PHASE_EXECUTE = 4
-        PHASE_FINALIZE = 5
-        # Extra phase used when we're doing some part of a subphase
-        # (such as rebuilding the search index) in a standalone operation.
-        PHASE_UTILITY = 6
-        MAJOR_PHASE = [PHASE_PREPLAN, PHASE_PLAN, PHASE_DOWNLOAD, PHASE_EXECUTE,
-            PHASE_FINALIZE, PHASE_UTILITY]
-
-        # Planning phases
-        PLAN_SOLVE_SETUP = 100
-        PLAN_SOLVE_SOLVER = 101
-        PLAN_FIND_MFST = 102
-        PLAN_PKGPLAN = 103
-        PLAN_ACTION_MERGE = 104
-        PLAN_ACTION_CONFLICT = 105
-        PLAN_ACTION_CONSOLIDATE = 106
-        PLAN_ACTION_MEDIATION = 107
-        PLAN_ACTION_FINALIZE = 108
-        PLAN_MEDIATION_CHG = 109 # for set-mediator
-        PLAN_PKG_VERIFY = 110
-        PLAN_PKG_FIX = 111
-
-        # Action phases
-        ACTION_REMOVE = 200
-        ACTION_INSTALL = 201
-        ACTION_UPDATE = 202
-
-        # Finalization/Job phases
-        JOB_STATE_DB = 300
-        JOB_IMAGE_STATE = 301
-        JOB_FAST_LOOKUP = 302
-        JOB_PKG_CACHE = 303
-        JOB_READ_SEARCH = 304
-        JOB_UPDATE_SEARCH = 305
-        JOB_REBUILD_SEARCH = 306
-        # pkgrepo job items
-        JOB_REPO_DELSEARCH = 307
-        JOB_REPO_UPDATE_CAT = 308
-        JOB_REPO_ANALYZE_RM = 309
-        JOB_REPO_ANALYZE_REPO = 310
-        JOB_REPO_RM_MFST = 311
-        JOB_REPO_RM_FILES = 312
-        JOB_REPO_VERIFY_REPO = 313
-        JOB_REPO_FIX_REPO = 314
-
-        # Operation purpose.  This set of modes is used by callers to indicate
-        # to the progress tracker what's going on at a high level.  This allows
-        # output to be customized by subclasses to meet the needs of a
-        # particular purpose.
-
-        #
-        # The purpose of current operations is in the "normal" set of things,
-        # including install, uninstall, change-variant, and other operations
-        # in which we can print arbitrary status information with impunity
-        #
-        PURPOSE_NORMAL = 0
-
-        #
-        # The purpose of current operations is in the service of trying to
-        # output a listing (list, contents, etc.) to the end user.  Subclasses
-        # will likely want to suppress various bits of status (for non-tty
-        # output) or erase it (for tty output).
-        #
-        PURPOSE_LISTING = 1
-
-        #
-        # The purpose of current operations is in the service of figuring out
-        # if the packaging system itself is up to date.
-        #
-        PURPOSE_PKG_UPDATE_CHK = 2
-
-        #
-        # Types of lint phases
-        #
-        LINT_PHASETYPE_SETUP = 0
-        LINT_PHASETYPE_EXECUTE = 1
-
-        def __init__(self):
-                # needs to be here due to use of _()
-                self.phase_names = {
-                    self.PHASE_PREPLAN:  _("Startup"),
-                    self.PHASE_PLAN:     _("Planning"),
-                    self.PHASE_DOWNLOAD: _("Download"),
-                    self.PHASE_EXECUTE:  _("Actions"),
-                    self.PHASE_FINALIZE: _("Finalize"),
-                    self.PHASE_UTILITY:  "",
-                }
-
-                # find the widest string in the list of phases so we can
-                # set column width properly.
-                self.phase_max_width = \
-                    max(len(x) for x in self.phase_names.values())
-
-                self.li_phase_names = {
-                    self.PHASE_PREPLAN:  _("Startup"),
-                    self.PHASE_PLAN:     _("Planning"),
-                    self.PHASE_DOWNLOAD: _("Downloading"),
-                    self.PHASE_FINALIZE: _("Executing"),
-                    self.PHASE_UTILITY:  _("Processing"),
-                }
-
-        @pt_abstract
-        def set_purpose(self, purpose): pass
-
-        @pt_abstract
-        def get_purpose(self): pass
-
-        @pt_abstract
-        def reset_download(self): pass
-
-        @pt_abstract
-        def reset(self): pass
-
-        @pt_abstract
-        def set_major_phase(self, majorphase): pass
-
-        @pt_abstract
-        def flush(self): pass
-
-        @pt_abstract
-        def cache_catalogs_start(self): pass
-
-        @pt_abstract
-        def cache_catalogs_done(self): pass
-
-        @pt_abstract
-        def load_catalog_cache_start(self): pass
-
-        @pt_abstract
-        def load_catalog_cache_done(self): pass
-
-        # fetching catalogs
-        @pt_abstract
-        def refresh_start(self, pub_cnt, full_refresh, target_catalog=False):
-                pass
-
-        @pt_abstract
-        def refresh_start_pub(self, pub): pass
-
-        @pt_abstract
-        def refresh_end_pub(self, pub): pass
-
-        @pt_abstract
-        def refresh_progress(self, pub, nbytes): pass
-
-        @pt_abstract
-        def refresh_done(self): pass
-
-        # planning an operation
-        @pt_abstract
-        def plan_all_start(self): pass
-
-        @pt_abstract
-        def plan_start(self, planid, goal=None): pass
-
-        @pt_abstract
-        def plan_add_progress(self, planid, nitems=1): pass
-
-        @pt_abstract
-        def plan_done(self, planid): pass
-
-        @pt_abstract
-        def plan_all_done(self): pass
-
-        # getting manifests over the network
-        @pt_abstract
-        def manifest_fetch_start(self, goal_mfsts): pass
-
-        @pt_abstract
-        def manifest_fetch_progress(self, completion): pass
-
-        @pt_abstract
-        def manifest_commit(self): pass
-
-        @pt_abstract
-        def manifest_fetch_done(self): pass
-
-        # verifying the content of a repository
-        @pt_abstract
-        def repo_verify_start(self, npkgs): pass
-
-        @pt_abstract
-        def repo_verify_start_pkg(self, pkgfmri, repository_scan=False): pass
-
-        @pt_abstract
-        def repo_verify_add_progress(self, pkgfmri): pass
-
-        @pt_abstract
-        def repo_verify_yield_error(self, pkgfmri, errors): pass
-
-        @pt_abstract
-        def repo_verify_yield_warning(self, pkgfmri, warnings): pass
-
-        @pt_abstract
-        def repo_verify_yield_info(self, pkgfmri, info): pass
-
-        @pt_abstract
-        def repo_verify_end_pkg(self, pkgfmri): pass
-
-        @pt_abstract
-        def repo_verify_done(self): pass
-
-        # fixing the content of a repository
-        @pt_abstract
-        def repo_fix_start(self, npkgs): pass
-
-        @pt_abstract
-        def repo_fix_add_progress(self, pkgfmri): pass
-
-        @pt_abstract
-        def repo_fix_yield_error(self, pkgfmri, errors): pass
-
-        @pt_abstract
-        def repo_fix_yield_info(self, pkgfmri, info): pass
-
-        @pt_abstract
-        def repo_fix_done(self): pass
-
-        # archiving to .p5p files
-        @pt_abstract
-        def archive_set_goal(self, arcname, nitems, nbytes): pass
-
-        @pt_abstract
-        def archive_add_progress(self, nitems, nbytes): pass
-
-        @pt_abstract
-        def archive_done(self): pass
-
-        # Called when bits arrive, either from on-disk cache or over-the-wire.
-        @pt_abstract
-        def download_set_goal(self, npkgs, nfiles, nbytes): pass
-
-        @pt_abstract
-        def download_start_pkg(self, pkgfmri): pass
-
-        @pt_abstract
-        def download_end_pkg(self, pkgfmri): pass
-
-        @pt_abstract
-        def download_add_progress(self, nfiles, nbytes, cachehit=False):
-                """Call to provide news that the download has made progress."""
-                pass
-
-        @pt_abstract
-        def download_done(self, dryrun=False):
-                """Call when all downloading is finished."""
-                pass
-
-        @pt_abstract
-        def download_get_progress(self): pass
-
-        # Running actions
-        @pt_abstract
-        def actions_set_goal(self, actionid, nactions): pass
-
-        @pt_abstract
-        def actions_add_progress(self, actionid): pass
-
-        @pt_abstract
-        def actions_done(self, actionid): pass
-
-        @pt_abstract
-        def actions_all_done(self): pass
-
-        @pt_abstract
-        def job_start(self, jobid, goal=None): pass
-
-        @pt_abstract
-        def job_add_progress(self, jobid, nitems=1): pass
-
-        @pt_abstract
-        def job_done(self, jobid): pass
-
-        @pt_abstract
-        def republish_set_goal(self, npkgs, ngetbytes, nsendbytes): pass
-
-        @pt_abstract
-        def republish_start_pkg(self, pkgfmri, getbytes=None, sendbytes=None):
-                pass
-
-        @pt_abstract
-        def republish_end_pkg(self, pkgfmri): pass
-
-        @pt_abstract
-        def upload_add_progress(self, nbytes):
-                """Call to provide news that the upload has made progress."""
-                pass
-
-        @pt_abstract
-        def republish_done(self, dryrun=False):
-                """Call when all republishing is finished."""
-                pass
-
-        @pt_abstract
-        def lint_next_phase(self, goalitems, lint_phasetype):
-                """Call to indicate a new phase of lint progress."""
-                pass
-
-        @pt_abstract
-        def lint_add_progress(self): pass
-
-        @pt_abstract
-        def lint_done(self): pass
-
-        @pt_abstract
-        def set_linked_name(self, lin):
-                """Called once an image determines its linked image name."""
-                pass
-
-        @pt_abstract
-        def li_recurse_start(self, pkg_op, total):
-                """Call when we recurse into a child linked image."""
-                pass
-
-        @pt_abstract
-        def li_recurse_end(self):
-                """Call when we return from a child linked image."""
-                pass
-
-        @pt_abstract
-        def li_recurse_status(self, lin_running, done):
-                """Call to update the progress tracker with the list of
-                images being operated on."""
-                pass
-
-        @pt_abstract
-        def li_recurse_output(self, lin, stdout, stderr):
-                """Call to display output from linked image operations."""
-                pass
-
-        @pt_abstract
-        def li_recurse_progress(self, lin):
-                """Call to indicate that the named child made progress."""
-                pass
-
-        @pt_abstract
-        def reversion_start(self, goal_pkgs, goal_revs): pass
-
-        @pt_abstract
-        def reversion_add_progress(self, pfmri, pkgs=0, reversioned=0,
-            adjusted=0):
-                pass
-
-        @pt_abstract
-        def reversion_done(self): pass
+    """This essentially abstract class forms the interface that other
+    modules in the system use to record progress against various goals."""
+
+    # More than one statement on a line; pylint: disable=C0321
+
+    # Major phases of operation
+    PHASE_PREPLAN = 1
+    PHASE_PLAN = 2
+    PHASE_DOWNLOAD = 3
+    PHASE_EXECUTE = 4
+    PHASE_FINALIZE = 5
+    # Extra phase used when we're doing some part of a subphase
+    # (such as rebuilding the search index) in a standalone operation.
+    PHASE_UTILITY = 6
+    MAJOR_PHASE = [
+        PHASE_PREPLAN,
+        PHASE_PLAN,
+        PHASE_DOWNLOAD,
+        PHASE_EXECUTE,
+        PHASE_FINALIZE,
+        PHASE_UTILITY,
+    ]
+
+    # Planning phases
+    PLAN_SOLVE_SETUP = 100
+    PLAN_SOLVE_SOLVER = 101
+    PLAN_FIND_MFST = 102
+    PLAN_PKGPLAN = 103
+    PLAN_ACTION_MERGE = 104
+    PLAN_ACTION_CONFLICT = 105
+    PLAN_ACTION_CONSOLIDATE = 106
+    PLAN_ACTION_MEDIATION = 107
+    PLAN_ACTION_FINALIZE = 108
+    PLAN_MEDIATION_CHG = 109  # for set-mediator
+    PLAN_PKG_VERIFY = 110
+    PLAN_PKG_FIX = 111
+
+    # Action phases
+    ACTION_REMOVE = 200
+    ACTION_INSTALL = 201
+    ACTION_UPDATE = 202
+
+    # Finalization/Job phases
+    JOB_STATE_DB = 300
+    JOB_IMAGE_STATE = 301
+    JOB_FAST_LOOKUP = 302
+    JOB_PKG_CACHE = 303
+    JOB_READ_SEARCH = 304
+    JOB_UPDATE_SEARCH = 305
+    JOB_REBUILD_SEARCH = 306
+    # pkgrepo job items
+    JOB_REPO_DELSEARCH = 307
+    JOB_REPO_UPDATE_CAT = 308
+    JOB_REPO_ANALYZE_RM = 309
+    JOB_REPO_ANALYZE_REPO = 310
+    JOB_REPO_RM_MFST = 311
+    JOB_REPO_RM_FILES = 312
+    JOB_REPO_VERIFY_REPO = 313
+    JOB_REPO_FIX_REPO = 314
+
+    # Operation purpose.  This set of modes is used by callers to indicate
+    # to the progress tracker what's going on at a high level.  This allows
+    # output to be customized by subclasses to meet the needs of a
+    # particular purpose.
+
+    #
+    # The purpose of current operations is in the "normal" set of things,
+    # including install, uninstall, change-variant, and other operations
+    # in which we can print arbitrary status information with impunity
+    #
+    PURPOSE_NORMAL = 0
+
+    #
+    # The purpose of current operations is in the service of trying to
+    # output a listing (list, contents, etc.) to the end user.  Subclasses
+    # will likely want to suppress various bits of status (for non-tty
+    # output) or erase it (for tty output).
+    #
+    PURPOSE_LISTING = 1
+
+    #
+    # The purpose of current operations is in the service of figuring out
+    # if the packaging system itself is up to date.
+    #
+    PURPOSE_PKG_UPDATE_CHK = 2
+
+    #
+    # Types of lint phases
+    #
+    LINT_PHASETYPE_SETUP = 0
+    LINT_PHASETYPE_EXECUTE = 1
+
+    def __init__(self):
+        # needs to be here due to use of _()
+        self.phase_names = {
+            self.PHASE_PREPLAN: _("Startup"),
+            self.PHASE_PLAN: _("Planning"),
+            self.PHASE_DOWNLOAD: _("Download"),
+            self.PHASE_EXECUTE: _("Actions"),
+            self.PHASE_FINALIZE: _("Finalize"),
+            self.PHASE_UTILITY: "",
+        }
+
+        # find the widest string in the list of phases so we can
+        # set column width properly.
+        self.phase_max_width = max(len(x) for x in self.phase_names.values())
+
+        self.li_phase_names = {
+            self.PHASE_PREPLAN: _("Startup"),
+            self.PHASE_PLAN: _("Planning"),
+            self.PHASE_DOWNLOAD: _("Downloading"),
+            self.PHASE_FINALIZE: _("Executing"),
+            self.PHASE_UTILITY: _("Processing"),
+        }
+
+    @pt_abstract
+    def set_purpose(self, purpose):
+        pass
+
+    @pt_abstract
+    def get_purpose(self):
+        pass
+
+    @pt_abstract
+    def reset_download(self):
+        pass
+
+    @pt_abstract
+    def reset(self):
+        pass
+
+    @pt_abstract
+    def set_major_phase(self, majorphase):
+        pass
+
+    @pt_abstract
+    def flush(self):
+        pass
+
+    @pt_abstract
+    def cache_catalogs_start(self):
+        pass
+
+    @pt_abstract
+    def cache_catalogs_done(self):
+        pass
+
+    @pt_abstract
+    def load_catalog_cache_start(self):
+        pass
+
+    @pt_abstract
+    def load_catalog_cache_done(self):
+        pass
+
+    # fetching catalogs
+    @pt_abstract
+    def refresh_start(self, pub_cnt, full_refresh, target_catalog=False):
+        pass
+
+    @pt_abstract
+    def refresh_start_pub(self, pub):
+        pass
+
+    @pt_abstract
+    def refresh_end_pub(self, pub):
+        pass
+
+    @pt_abstract
+    def refresh_progress(self, pub, nbytes):
+        pass
+
+    @pt_abstract
+    def refresh_done(self):
+        pass
+
+    # planning an operation
+    @pt_abstract
+    def plan_all_start(self):
+        pass
+
+    @pt_abstract
+    def plan_start(self, planid, goal=None):
+        pass
+
+    @pt_abstract
+    def plan_add_progress(self, planid, nitems=1):
+        pass
+
+    @pt_abstract
+    def plan_done(self, planid):
+        pass
+
+    @pt_abstract
+    def plan_all_done(self):
+        pass
+
+    # getting manifests over the network
+    @pt_abstract
+    def manifest_fetch_start(self, goal_mfsts):
+        pass
+
+    @pt_abstract
+    def manifest_fetch_progress(self, completion):
+        pass
+
+    @pt_abstract
+    def manifest_commit(self):
+        pass
+
+    @pt_abstract
+    def manifest_fetch_done(self):
+        pass
+
+    # verifying the content of a repository
+    @pt_abstract
+    def repo_verify_start(self, npkgs):
+        pass
+
+    @pt_abstract
+    def repo_verify_start_pkg(self, pkgfmri, repository_scan=False):
+        pass
+
+    @pt_abstract
+    def repo_verify_add_progress(self, pkgfmri):
+        pass
+
+    @pt_abstract
+    def repo_verify_yield_error(self, pkgfmri, errors):
+        pass
+
+    @pt_abstract
+    def repo_verify_yield_warning(self, pkgfmri, warnings):
+        pass
+
+    @pt_abstract
+    def repo_verify_yield_info(self, pkgfmri, info):
+        pass
+
+    @pt_abstract
+    def repo_verify_end_pkg(self, pkgfmri):
+        pass
+
+    @pt_abstract
+    def repo_verify_done(self):
+        pass
+
+    # fixing the content of a repository
+    @pt_abstract
+    def repo_fix_start(self, npkgs):
+        pass
+
+    @pt_abstract
+    def repo_fix_add_progress(self, pkgfmri):
+        pass
+
+    @pt_abstract
+    def repo_fix_yield_error(self, pkgfmri, errors):
+        pass
+
+    @pt_abstract
+    def repo_fix_yield_info(self, pkgfmri, info):
+        pass
+
+    @pt_abstract
+    def repo_fix_done(self):
+        pass
+
+    # archiving to .p5p files
+    @pt_abstract
+    def archive_set_goal(self, arcname, nitems, nbytes):
+        pass
+
+    @pt_abstract
+    def archive_add_progress(self, nitems, nbytes):
+        pass
+
+    @pt_abstract
+    def archive_done(self):
+        pass
+
+    # Called when bits arrive, either from on-disk cache or over-the-wire.
+    @pt_abstract
+    def download_set_goal(self, npkgs, nfiles, nbytes):
+        pass
+
+    @pt_abstract
+    def download_start_pkg(self, pkgfmri):
+        pass
+
+    @pt_abstract
+    def download_end_pkg(self, pkgfmri):
+        pass
+
+    @pt_abstract
+    def download_add_progress(self, nfiles, nbytes, cachehit=False):
+        """Call to provide news that the download has made progress."""
+        pass
+
+    @pt_abstract
+    def download_done(self, dryrun=False):
+        """Call when all downloading is finished."""
+        pass
+
+    @pt_abstract
+    def download_get_progress(self):
+        pass
+
+    # Running actions
+    @pt_abstract
+    def actions_set_goal(self, actionid, nactions):
+        pass
+
+    @pt_abstract
+    def actions_add_progress(self, actionid):
+        pass
+
+    @pt_abstract
+    def actions_done(self, actionid):
+        pass
+
+    @pt_abstract
+    def actions_all_done(self):
+        pass
+
+    @pt_abstract
+    def job_start(self, jobid, goal=None):
+        pass
+
+    @pt_abstract
+    def job_add_progress(self, jobid, nitems=1):
+        pass
+
+    @pt_abstract
+    def job_done(self, jobid):
+        pass
+
+    @pt_abstract
+    def republish_set_goal(self, npkgs, ngetbytes, nsendbytes):
+        pass
+
+    @pt_abstract
+    def republish_start_pkg(self, pkgfmri, getbytes=None, sendbytes=None):
+        pass
+
+    @pt_abstract
+    def republish_end_pkg(self, pkgfmri):
+        pass
+
+    @pt_abstract
+    def upload_add_progress(self, nbytes):
+        """Call to provide news that the upload has made progress."""
+        pass
+
+    @pt_abstract
+    def republish_done(self, dryrun=False):
+        """Call when all republishing is finished."""
+        pass
+
+    @pt_abstract
+    def lint_next_phase(self, goalitems, lint_phasetype):
+        """Call to indicate a new phase of lint progress."""
+        pass
+
+    @pt_abstract
+    def lint_add_progress(self):
+        pass
+
+    @pt_abstract
+    def lint_done(self):
+        pass
+
+    @pt_abstract
+    def set_linked_name(self, lin):
+        """Called once an image determines its linked image name."""
+        pass
+
+    @pt_abstract
+    def li_recurse_start(self, pkg_op, total):
+        """Call when we recurse into a child linked image."""
+        pass
+
+    @pt_abstract
+    def li_recurse_end(self):
+        """Call when we return from a child linked image."""
+        pass
+
+    @pt_abstract
+    def li_recurse_status(self, lin_running, done):
+        """Call to update the progress tracker with the list of
+        images being operated on."""
+        pass
+
+    @pt_abstract
+    def li_recurse_output(self, lin, stdout, stderr):
+        """Call to display output from linked image operations."""
+        pass
+
+    @pt_abstract
+    def li_recurse_progress(self, lin):
+        """Call to indicate that the named child made progress."""
+        pass
+
+    @pt_abstract
+    def reversion_start(self, goal_pkgs, goal_revs):
+        pass
+
+    @pt_abstract
+    def reversion_add_progress(self, pfmri, pkgs=0, reversioned=0, adjusted=0):
+        pass
+
+    @pt_abstract
+    def reversion_done(self):
+        pass
 
 
 class ProgressTracker(ProgressTrackerFrontend, ProgressTrackerBackend):
-        """This class is used by the client to render and track progress
-        towards the completion of various tasks, such as download,
-        installation, update, etc.
-
-        The superclass is largely concerned with tracking the raw numbers, and
-        with calling various callback routines when events of interest occur.
-        The callback routines are defined in the ProgressTrackerBackend class,
-        below.
-
-        Different subclasses provide the actual rendering to the user, with
-        differing levels of detail and prettiness.
-
-        Note that as currently envisioned, this class is concerned with
-        tracking the progress of long-running operations: it is NOT a general
-        purpose output mechanism nor an error collector.
-
-        Most subclasses of ProgressTracker need not override the methods of
-        this class.  However, most subclasses will need need to mix in and
-        define ALL of the methods from the ProgressTrackerBackend class."""
-
-        DL_MODE_DOWNLOAD = 1
-        DL_MODE_REPUBLISH = 2
-
-        def __init__(self):
-                ProgressTrackerBackend.__init__(self)
-                ProgressTrackerFrontend.__init__(self)
-                self.reset()
-
-        def reset_download(self):
-                # Attribute defined outside __init__; pylint: disable=W0201
-                self.dl_mode = None
-                self.dl_estimator = None
-
-                self.dl_pkgs = GoalTrackerItem(_("Download packages"))
-                self.dl_files = GoalTrackerItem(_("Download files"))
-                self.dl_bytes = GoalTrackerItem(_("Download bytes"))
-                self._dl_items = [self.dl_pkgs, self.dl_files, self.dl_bytes]
-
-                # republishing support; republishing also uses dl_bytes
-                self.repub_pkgs = \
-                    GoalTrackerItem(_("Republished pkgs"))
-                self.repub_send_bytes = \
-                    GoalTrackerItem(_("Republish sent bytes"))
-
-        def reset(self):
-                # Attribute defined outside __init__; pylint: disable=W0201
-                self.major_phase = self.PHASE_PREPLAN
-                self.purpose = self.PURPOSE_NORMAL
-
-                self.pub_refresh = GoalTrackerItem(_("Refresh Publishers"))
-                # We don't know the goal in advance for this one
-                self.pub_refresh_bytes = TrackerItem(_("Refresh bytes"))
-                self.refresh_target_catalog = None
-                self.refresh_full_refresh = False
-
-                self.mfst_fetch = GoalTrackerItem(_("Download Manifests"))
-                self.mfst_commit = GoalTrackerItem(_("Committed Manifests"))
-
-                self.repo_ver_pkgs = GoalTrackerItem(
-                    _("Verify Repository Content"))
-                self.repo_fix = GoalTrackerItem(_("Fix Repository Content"))
-
-                # archiving support
-                self.archive_items = GoalTrackerItem(_("Archived items"))
-                self.archive_bytes = GoalTrackerItem(_("Archived bytes"))
-
-                # reversioning support
-                self.reversion_pkgs = GoalTrackerItem(_("Processed Packages"))
-                self.reversion_revs = GoalTrackerItem(_("Reversioned Packages"))
-                self.reversion_adjs = GoalTrackerItem(_("Adjusted Packages"))
-
-                # Used to measure elapsed time of entire planning; not otherwise
-                # rendered to the user.
-                self.plan_generic = TrackerItem("")
-
-                self._planitems = {
-                        self.PLAN_SOLVE_SETUP:
-                            TrackerItem(_("Solver setup")),
-                        self.PLAN_SOLVE_SOLVER:
-                            TrackerItem(_("Running solver")),
-                        self.PLAN_FIND_MFST:
-                            TrackerItem(_("Finding local manifests")),
-                        self.PLAN_PKGPLAN:
-                            GoalTrackerItem(_("Package planning")),
-                        self.PLAN_ACTION_MERGE:
-                            TrackerItem(_("Merging actions")),
-                        self.PLAN_ACTION_CONFLICT:
-                            TrackerItem(_("Checking for conflicting actions")),
-                        self.PLAN_ACTION_CONSOLIDATE:
-                            TrackerItem(_("Consolidating action changes")),
-                        self.PLAN_ACTION_MEDIATION:
-                            TrackerItem(_("Evaluating mediators")),
-                        self.PLAN_ACTION_FINALIZE:
-                            TrackerItem(_("Finalizing action plan")),
-                        self.PLAN_MEDIATION_CHG:
-                            TrackerItem(_("Evaluating mediator changes")),
-                        self.PLAN_PKG_VERIFY:
-                            GoalTrackerItem(_("Verifying Packages")),
-                        self.PLAN_PKG_FIX:
-                            GoalTrackerItem(_("Fixing Packages")),
-                }
-
-                self._actionitems = {
-                        self.ACTION_REMOVE:
-                            GoalTrackerItem(_("Removing old actions")),
-                        self.ACTION_INSTALL:
-                            GoalTrackerItem(_("Installing new actions")),
-                        self.ACTION_UPDATE:
-                            GoalTrackerItem(_("Updating modified actions")),
-                }
-
-                self._jobitems = {
-                        self.JOB_STATE_DB:
-                            TrackerItem(_("Updating package state database")),
-                        self.JOB_IMAGE_STATE:
-                            TrackerItem(_("Updating image state")),
-                        self.JOB_FAST_LOOKUP:
-                            TrackerItem(_("Creating fast lookup database")),
-                        self.JOB_PKG_CACHE:
-                            GoalTrackerItem(_("Updating package cache")),
-                        self.JOB_READ_SEARCH:
-                            TrackerItem(_("Reading search index")),
-                        self.JOB_UPDATE_SEARCH:
-                            GoalTrackerItem(_("Updating search index")),
-                        self.JOB_REBUILD_SEARCH:
-                            GoalTrackerItem(_("Building new search index")),
-
-                        # pkgrepo job items
-                        self.JOB_REPO_DELSEARCH:
-                            TrackerItem(_("Deleting search index")),
-                        self.JOB_REPO_UPDATE_CAT:
-                            TrackerItem(_("Updating catalog")),
-                        self.JOB_REPO_ANALYZE_RM:
-                            GoalTrackerItem(_("Analyzing removed packages")),
-                        self.JOB_REPO_ANALYZE_REPO:
-                            GoalTrackerItem(_("Analyzing repository packages")),
-                        self.JOB_REPO_RM_MFST:
-                            GoalTrackerItem(_("Removing package manifests")),
-                        self.JOB_REPO_RM_FILES:
-                            GoalTrackerItem(_("Removing package files")),
-                        self.JOB_REPO_VERIFY_REPO:
-                            GoalTrackerItem(_("Verifying repository content")),
-                        self.JOB_REPO_FIX_REPO:
-                            GoalTrackerItem(_("Fixing repository content"))
-
-                }
-
-                self.reset_download()
-
-                self._archive_name = None
-
-                # Lint's interaction with the progresstracker probably
-                # needs further work.
-                self.lint_phase = None
-                self.lint_phasetype = None
-                # This GoalTrackerItem is created on the fly.
-                self.lintitems = None
-
-                # Linked images
-                self.linked_name = None
-                self.linked_running = []
-                self.linked_pkg_op = None
-                self.linked_total = 0
-
-        def set_major_phase(self, majorphase):
-                # Attribute defined outside __init__; pylint: disable=W0201
-                self.major_phase = majorphase
-
-        def flush(self):
-                """Used to signal to the progresstracker that it should make
-                the output ready for use by another subsystem.  In a
-                terminal-based environment, this would make sure that no
-                partially printed lines were present, and flush e.g. stdout."""
-                self._output_flush()
-
-        def set_purpose(self, purpose):
-                op = self.purpose
-                self.purpose = purpose # pylint: disable=W0201
-                if op != self.purpose:
-                        self._change_purpose(op, purpose)
-
-        def get_purpose(self):
-                return self.purpose
-
-        def cache_catalogs_start(self):
-                self._cache_cats_output(OutSpec(first=True))
-
-        def cache_catalogs_done(self):
-                self._cache_cats_output(OutSpec(last=True))
-
-        def load_catalog_cache_start(self):
-                self._load_cat_cache_output(OutSpec(first=True))
-
-        def load_catalog_cache_done(self):
-                self._load_cat_cache_output(OutSpec(last=True))
-
-        def refresh_start(self, pub_cnt, full_refresh, target_catalog=False):
-                #
-                # We can wind up doing multiple refreshes in some cases,
-                # for example when we have to check if pkg(7) is up-to-date,
-                # so we reset these each time we start.
-                #
-                self.pub_refresh.reset()
-                self.pub_refresh.goalitems = pub_cnt
-                self.pub_refresh_bytes.reset()
-                # Attribute defined outside __init__; pylint: disable=W0201
-                self.refresh_full_refresh = full_refresh
-                self.refresh_target_catalog = target_catalog
-                if self.refresh_target_catalog:
-                        assert self.refresh_full_refresh
-
-        def refresh_start_pub(self, pub):
-                outspec = OutSpec()
-                # for now we only refresh one at a time, so we stash
-                # this here, and then assert for it in end_pub and
-                # in refresh_progress.
-                self.pub_refresh.curinfo = pub
-                if not self.pub_refresh.printed:
-                        outspec.first = True
-                outspec.changed.append("startpublisher")
-                self.pub_refresh.printed = True
-                self._refresh_output_progress(outspec)
-
-        def refresh_end_pub(self, pub):
-                assert pub == self.pub_refresh.curinfo
-                assert self.pub_refresh.printed
-                outspec = OutSpec()
-                outspec.changed.append("endpublisher")
-                self.pub_refresh.items += 1
-                self._refresh_output_progress(outspec)
-
-        def refresh_progress(self, pub, nbytes):
-                # when called back from the transport we lose the knowledge
-                # of what 'pub' is, at least for now.
-                assert pub is None or pub == self.pub_refresh.curinfo
-                assert self.pub_refresh.printed
-                self.pub_refresh_bytes.items += nbytes
-                self._refresh_output_progress(OutSpec())
-
-        def refresh_done(self):
-                # If refreshes fail, we might not meet the goal.
-                self.pub_refresh.done(goalcheck=False)
-                self.pub_refresh_bytes.done()
-                self._refresh_output_progress(OutSpec(last=True))
-
-        def plan_all_start(self):
-                self.set_major_phase(self.PHASE_PLAN)
-                self.plan_generic.reset()
-                self.plan_generic.start()
-
-        def plan_start(self, planid, goal=None):
-                planitem = self._planitems[planid]
-                planitem.reset()
-                if goal:
-                        if not isinstance(planitem, GoalTrackerItem):
-                                raise RuntimeError(
-                                    "can't set goal on non-goal tracker")
-                        planitem.goalitems = goal
-                planitem.start()
-
-        def plan_add_progress(self, planid, nitems=1):
-                planitem = self._planitems[planid]
-                outspec = OutSpec(first=not planitem.printed)
-                planitem.items += nitems
-                self._plan_output(outspec, planitem)
-                planitem.printed = True
-
-        def plan_done(self, planid):
-                planitem = self._planitems[planid]
-                planitem.done()
-                if planitem.printed:
-                        self._plan_output(OutSpec(last=True), planitem)
-
-        def plan_all_done(self):
-                self.plan_generic.done()
-                self._plan_output_all_done()
-
-        def manifest_fetch_start(self, goal_mfsts):
-                self.mfst_fetch.reset()
-                self.mfst_commit.reset()
-                self.mfst_fetch.goalitems = goal_mfsts
-                self.mfst_commit.goalitems = goal_mfsts
-
-        def manifest_fetch_progress(self, completion):
-                assert self.major_phase in [self.PHASE_PLAN, self.PHASE_UTILITY]
-                outspec = OutSpec(first=not self.mfst_fetch.printed)
-                self.mfst_fetch.printed = True
-                if completion:
-                        self.mfst_fetch.items += 1
-                        outspec.changed.append("manifests")
-                self._mfst_fetch(outspec)
-
-        def manifest_commit(self):
-                assert self.major_phase in [self.PHASE_PLAN, self.PHASE_UTILITY]
-                outspec = OutSpec(first=not self.mfst_commit.printed)
-                self.mfst_commit.printed = True
-                self.mfst_commit.items += 1
-                self._mfst_commit(outspec)
-
-        def manifest_fetch_done(self):
-                # These can fail to reach their goals due to various transport
-                # errors, depot misconfigurations, etc.  So disable goal check.
-                self.mfst_fetch.done(goalcheck=False)
-                self.mfst_commit.done(goalcheck=False)
-                if self.mfst_fetch.printed:
-                        self._mfst_fetch(OutSpec(last=True))
-
-        def repo_verify_start(self, npkgs):
-                self.repo_ver_pkgs.reset()
-                self.repo_ver_pkgs.goalitems = npkgs
-
-        def repo_verify_start_pkg(self, pkgfmri, repository_scan=False):
-                if pkgfmri != self.repo_ver_pkgs.curinfo:
-                        self.repo_ver_pkgs.items += 1
-                        self.repo_ver_pkgs.curinfo = pkgfmri
-                self._repo_ver_output(OutSpec(changed=["startpkg"]),
-                    repository_scan=repository_scan)
-
-        def repo_verify_add_progress(self, pkgfmri):
-                self._repo_ver_output(OutSpec())
-
-        def repo_verify_yield_error(self, pkgfmri, errors):
-                self._repo_ver_output_error(errors)
-
-        def repo_verify_end_pkg(self, pkgfmri):
-                self._repo_ver_output(OutSpec(changed=["endpkg"]))
-                self.repo_ver_pkgs.curinfo = None
-
-        def repo_verify_done(self):
-                self.repo_ver_pkgs.done()
-
-        def repo_fix_start(self, nitems):
-                self.repo_fix.reset()
-                self.repo_fix.goalitems = nitems
-
-        def repo_fix_add_progress(self, pkgfmri):
-                self._repo_fix_output(OutSpec())
-
-        def repo_fix_yield_error(self, pkgfmri, errors):
-                self._repo_fix_output_error(errors)
-
-        def repo_fix_yield_info(self, pkgfmri, info):
-                self._repo_fix_output_info(info)
-
-        def repo_fix_done(self):
-                self.repo_fix.done()
-
-        def archive_set_goal(self, arcname, nitems, nbytes):
-                self._archive_name = arcname # pylint: disable=W0201
-                self.archive_items.goalitems = nitems
-                self.archive_bytes.goalitems = nbytes
-
-        def archive_add_progress(self, nitems, nbytes):
-                outspec = OutSpec()
-                if not self.archive_bytes.printed:
-                        self.archive_bytes.printed = True
-                        outspec.first = True
-                self.archive_items.items += nitems
-                self.archive_bytes.items += nbytes
-                self._archive_output(outspec)
-
-        def archive_done(self):
-                """Call when all archiving is finished"""
-                self.archive_items.done()
-                self.archive_bytes.done()
-                # only print 'last' if we printed 'first'
-                if self.archive_bytes.printed:
-                        self._archive_output(OutSpec(last=True))
-
-        def download_set_goal(self, npkgs, nfiles, nbytes):
-                # Attribute defined outside __init__; pylint: disable=W0201
-                self.dl_mode = self.DL_MODE_DOWNLOAD
-                self.dl_pkgs.goalitems = npkgs
-                self.dl_files.goalitems = nfiles
-                self.dl_bytes.goalitems = nbytes
-                self.dl_estimator = SpeedEstimator(self.dl_bytes.goalitems)
-
-        def download_start_pkg(self, pkgfmri):
-                self.set_major_phase(self.PHASE_DOWNLOAD)
-                self.dl_pkgs.curinfo = pkgfmri
-                outspec = OutSpec(changed=["startpkg"])
-                if self.dl_bytes.goalitems != 0:
-                        if not self.dl_bytes.printed:
-                                # indicate that this is the first _dl_output
-                                # call
-                                self.dl_bytes.printed = True
-                                self.dl_estimator.start()
-                                outspec.first = True
-                        self._dl_output(outspec)
-
-        def download_end_pkg(self, pkgfmri):
-                self.dl_pkgs.items += 1
-                if self.dl_bytes.goalitems != 0:
-                        self._dl_output(OutSpec(changed=["endpkg"]))
-
-        def download_add_progress(self, nfiles, nbytes, cachehit=False):
-                """Call to provide news that the download has made progress"""
-                #
-                # These guards are present because download_add_progress can
-                # be called when an *upload* aborts; we want to prevent updates
-                # to these items, since they in this case might have no goals.
-                #
-                if self.dl_bytes.goalitems > 0:
-                        self.dl_bytes.items += nbytes
-                if self.dl_files.goalitems > 0:
-                        self.dl_files.items += nfiles
-
-                if cachehit:
-                        self.dl_estimator.goalbytes -= nbytes
-                else:
-                        self.dl_estimator.newdata(nbytes)
-
-                if self.dl_bytes.goalitems != 0:
-                        outspec = OutSpec()
-                        if nbytes > 0:
-                                outspec.changed.append("dl_bytes")
-                        if nfiles > 0:
-                                outspec.changed.append("dl_files")
-                        if self.dl_mode == self.DL_MODE_DOWNLOAD:
-                                self._dl_output(outspec)
-                        if self.dl_mode == self.DL_MODE_REPUBLISH:
-                                self._republish_output(outspec)
-
-        def download_done(self, dryrun=False):
-                """Call when all downloading is finished."""
-                if dryrun:
-                        # Dryrun mode is used by pkgrecv in order to
-                        # simulate a download; we do what we have to
-                        # in order to fake up a download result.
-                        self.dl_pkgs.items = self.dl_pkgs.goalitems
-                        self.dl_files.items = self.dl_files.goalitems
-                        self.dl_bytes.items = self.dl_bytes.goalitems
-                        self.dl_estimator.start(timestamp=0)
-                        self.dl_estimator.newdata(self.dl_bytes.goalitems,
-                            timestamp=0)
-                        self.dl_estimator.done(timestamp=0)
-                else:
-                        self.dl_estimator.done()
-
-                self.dl_pkgs.done()
-                self.dl_files.done()
-                self.dl_bytes.done()
-
-                if self.dl_bytes.goalitems != 0:
-                        self._dl_output(OutSpec(last=True))
-
-        def actions_set_goal(self, actionid, nactions):
-                """Called to set the goal for a particular phase of action
-                activity (i.e. ACTION_REMOVE, ACTION_INSTALL, or ACTION_UPDATE.
-                """
-                assert self.major_phase == self.PHASE_EXECUTE
-                actionitem = self._actionitems[actionid]
-                actionitem.reset()
-                actionitem.goalitems = nactions
-
-        def actions_add_progress(self, actionid):
-                assert self.major_phase == self.PHASE_EXECUTE
-                actionitem = self._actionitems[actionid]
-                actionitem.items += 1
-                self._act_output(OutSpec(first=(actionitem.items == 1)),
-                    actionitem)
-
-        def actions_done(self, actionid):
-                """Called when done each phase of actions processing."""
-                assert self.major_phase == self.PHASE_EXECUTE
-                actionitem = self._actionitems[actionid]
-                actionitem.done()
-                if actionitem.goalitems != 0:
-                        self._act_output(OutSpec(last=True), actionitem)
-
-        def actions_all_done(self):
-                total_actions = sum(x.items for x in self._actionitems.values())
-                if total_actions != 0:
-                        self._act_output_all_done()
-
-        def job_start(self, jobid, goal=None):
-                jobitem = self._jobitems[jobid]
-                jobitem.reset()
-                outspec = OutSpec()
-                if goal:
-                        if not isinstance(jobitem, GoalTrackerItem):
-                                raise RuntimeError(
-                                    "can't set goal on non-goal tracker")
-                        jobitem.goalitems = goal
-                jobitem.printed = True
-                self._job_output(outspec, jobitem)
-
-        def job_add_progress(self, jobid, nitems=1):
-                jobitem = self._jobitems[jobid]
-                outspec = OutSpec(first=not jobitem.printed)
-                jobitem.printed = True
-                jobitem.items += nitems
-                self._job_output(outspec, jobitem)
-
-        def job_done(self, jobid):
-                jobitem = self._jobitems[jobid]
-                # only print the 'done' if we printed the 'start'
-                jobitem.done()
-                if jobitem.printed:
-                        self._job_output(OutSpec(last=True), jobitem)
-
-        def republish_set_goal(self, npkgs, ngetbytes, nsendbytes):
-                self.dl_mode = self.DL_MODE_REPUBLISH # pylint: disable=W0201
-
-                self.repub_pkgs.goalitems = npkgs
-                self.repub_send_bytes.goalitems = nsendbytes
-
-                self.dl_bytes.goalitems = ngetbytes
-                # We don't have a good value to set this to.
-                self.dl_files.goalitems = 1 << 64
-                # Attribute defined outside __init__; pylint: disable=W0201
-                self.dl_estimator = SpeedEstimator(self.dl_bytes.goalitems)
-
-        def republish_start_pkg(self, pkgfmri, getbytes=None, sendbytes=None):
-                assert isinstance(pkgfmri, pkg.fmri.PkgFmri)
-
-                if getbytes is not None:
-                        # Allow reset of GET and SEND amounts on a per-package
-                        # basis.  This allows the user to monitor the overall
-                        # progress of the operation in terms of total packages
-                        # while not requiring the program to pre-process all
-                        # packages to determine total byte sizes before starting
-                        # the operation.
-                        assert sendbytes is not None
-                        self.dl_bytes.items = 0
-                        self.dl_bytes.goalitems = getbytes
-                        self.dl_estimator.goalbytes = getbytes
-
-                        self.repub_send_bytes.items = 0
-                        self.repub_send_bytes.goalitems = sendbytes
-
-                self.repub_pkgs.curinfo = pkgfmri
-                outspec = OutSpec(changed=["startpkg"])
-                #
-                # We can't do our normal trick of checking to see if
-                # dl_bytes.items is zero because it might have been reset
-                # above.
-                #
-                if not self.repub_pkgs.printed:
-                        # indicate that this is the first _republish_output call
-                        outspec.first = True
-                        self.repub_pkgs.printed = True
-                        self.dl_estimator.start()
-                if self.repub_pkgs.goalitems != 0:
-                        self._republish_output(outspec)
-
-        def republish_end_pkg(self, pkgfmri):
-                self.repub_pkgs.items += 1
-                self._republish_output(OutSpec(changed=["endpkg"]))
-
-        def upload_add_progress(self, nbytes):
-                """Call to provide news that the upload has made progress"""
-                #
-                # upload_add_progress can be called when a *download* aborts;
-                # this guard prevents us from updating the item (which has
-                # no goal set, and will raise an exception).
-                #
-                if self.repub_send_bytes.goalitems and \
-                    self.repub_send_bytes.goalitems > 0:
-                        self.repub_send_bytes.items += nbytes
-                        self._republish_output(OutSpec())
-
-        def republish_done(self, dryrun=False):
-                """Call when all republishing is finished"""
-                if dryrun:
-                        self.repub_pkgs.items = self.repub_pkgs.goalitems
-                        self.repub_send_bytes.items = \
-                            self.repub_send_bytes.goalitems
-                        self.dl_bytes.items = self.dl_bytes.goalitems
-
-                self.repub_pkgs.done()
-                self.repub_send_bytes.done()
-                self.dl_bytes.done()
-
-                if self.repub_pkgs.goalitems != 0:
-                        outspec = OutSpec(last=True)
-                        # Get the header printed if we've not printed
-                        # anything else thus far (happens in dryrun mode).
-                        outspec.first = not self.repub_pkgs.printed
-                        self._republish_output(outspec)
-                        self.repub_pkgs.printed = True
-
-        def lint_next_phase(self, goalitems, lint_phasetype):
-                # Attribute defined outside __init__; pylint: disable=W0201
-                self.lint_phasetype = lint_phasetype
-                if self.lint_phase is not None:
-                        self._lint_output(OutSpec(last=True))
-                if self.lint_phase is None:
-                        self.lint_phase = 0
-                self.lint_phase += 1
-                if lint_phasetype == self.LINT_PHASETYPE_SETUP:
-                        phasename = _("Lint setup {0:d}".format(
-                            self.lint_phase))
-                else:
-                        phasename = _("Lint phase {0:d}".format(
-                            self.lint_phase))
-                self.lintitems = GoalTrackerItem(phasename)
-                self.lintitems.goalitems = goalitems
-                self._lint_output(OutSpec(first=True))
-
-        def lint_add_progress(self):
-                self.lintitems.items += 1
-                self._lint_output(OutSpec())
-
-        def lint_done(self):
-                self.lint_phase = None # pylint: disable=W0201
-                if self.lintitems:
-                        self._lint_output(OutSpec(last=True))
-
-        def set_linked_name(self, lin):
-                """Called once an image determines its linked image name."""
-                self.linked_name = lin # pylint: disable=W0201
-
-        def li_recurse_start(self, pkg_op, total):
-                """Called when we recurse into a child linked image."""
-                # Attribute defined outside __init__; pylint: disable=W0201
-                self.linked_pkg_op = pkg_op
-                self.linked_total = total
-                self._li_recurse_start_output()
-
-        def li_recurse_end(self):
-                """Called when we return from a child linked image."""
-                self._li_recurse_end_output()
-
-        def li_recurse_status(self, lin_running, done):
-                """Call to update the progress tracker with the list of
-                images being operated on."""
-                # Attribute defined outside __init__; pylint: disable=W0201
-                self.linked_running = sorted(lin_running)
-                self._li_recurse_status_output(done)
-
-        def li_recurse_output(self, lin, stdout, stderr):
-                """Call to display output from linked image operations."""
-                self._li_recurse_output_output(lin, stdout, stderr)
-
-        def li_recurse_progress(self, lin):
-                """Call to indicate that the named child made progress."""
-                self._li_recurse_progress_output(lin)
-
-        def reversion_start(self, goal_pkgs, goal_revs):
-                self.reversion_adjs.reset()
-                self.reversion_revs.reset()
-                self.reversion_pkgs.reset()
-                self.reversion_revs.goalitems = goal_revs
-                self.reversion_pkgs.goalitems = goal_pkgs
-                self.reversion_adjs.goalitems = -1
-
-        def reversion_add_progress(self, pfmri, pkgs=0, reversioned=0,
-            adjusted=0):
-                outspec = OutSpec()
-                if not self.reversion_pkgs.printed:
-                        self.reversion_pkgs.printed = True
-                        outspec.first = True
-
-                self.reversion_revs.items += reversioned
-                self.reversion_adjs.items += adjusted
-                self.reversion_pkgs.items += pkgs
-                self._reversion(pfmri, outspec)
-
-        def reversion_done(self):
-                self.reversion_pkgs.done()
-                self.reversion_revs.done()
-                self.reversion_adjs.done(goalcheck=False)
-                if self.reversion_pkgs.printed:
-                        self._reversion("Done", OutSpec(last=True))
+    """This class is used by the client to render and track progress
+    towards the completion of various tasks, such as download,
+    installation, update, etc.
+
+    The superclass is largely concerned with tracking the raw numbers, and
+    with calling various callback routines when events of interest occur.
+    The callback routines are defined in the ProgressTrackerBackend class,
+    below.
+
+    Different subclasses provide the actual rendering to the user, with
+    differing levels of detail and prettiness.
+
+    Note that as currently envisioned, this class is concerned with
+    tracking the progress of long-running operations: it is NOT a general
+    purpose output mechanism nor an error collector.
+
+    Most subclasses of ProgressTracker need not override the methods of
+    this class.  However, most subclasses will need need to mix in and
+    define ALL of the methods from the ProgressTrackerBackend class."""
+
+    DL_MODE_DOWNLOAD = 1
+    DL_MODE_REPUBLISH = 2
+
+    def __init__(self):
+        ProgressTrackerBackend.__init__(self)
+        ProgressTrackerFrontend.__init__(self)
+        self.reset()
+
+    def reset_download(self):
+        # Attribute defined outside __init__; pylint: disable=W0201
+        self.dl_mode = None
+        self.dl_estimator = None
+
+        self.dl_pkgs = GoalTrackerItem(_("Download packages"))
+        self.dl_files = GoalTrackerItem(_("Download files"))
+        self.dl_bytes = GoalTrackerItem(_("Download bytes"))
+        self._dl_items = [self.dl_pkgs, self.dl_files, self.dl_bytes]
+
+        # republishing support; republishing also uses dl_bytes
+        self.repub_pkgs = GoalTrackerItem(_("Republished pkgs"))
+        self.repub_send_bytes = GoalTrackerItem(_("Republish sent bytes"))
+
+    def reset(self):
+        # Attribute defined outside __init__; pylint: disable=W0201
+        self.major_phase = self.PHASE_PREPLAN
+        self.purpose = self.PURPOSE_NORMAL
+
+        self.pub_refresh = GoalTrackerItem(_("Refresh Publishers"))
+        # We don't know the goal in advance for this one
+        self.pub_refresh_bytes = TrackerItem(_("Refresh bytes"))
+        self.refresh_target_catalog = None
+        self.refresh_full_refresh = False
+
+        self.mfst_fetch = GoalTrackerItem(_("Download Manifests"))
+        self.mfst_commit = GoalTrackerItem(_("Committed Manifests"))
+
+        self.repo_ver_pkgs = GoalTrackerItem(_("Verify Repository Content"))
+        self.repo_fix = GoalTrackerItem(_("Fix Repository Content"))
+
+        # archiving support
+        self.archive_items = GoalTrackerItem(_("Archived items"))
+        self.archive_bytes = GoalTrackerItem(_("Archived bytes"))
+
+        # reversioning support
+        self.reversion_pkgs = GoalTrackerItem(_("Processed Packages"))
+        self.reversion_revs = GoalTrackerItem(_("Reversioned Packages"))
+        self.reversion_adjs = GoalTrackerItem(_("Adjusted Packages"))
+
+        # Used to measure elapsed time of entire planning; not otherwise
+        # rendered to the user.
+        self.plan_generic = TrackerItem("")
+
+        self._planitems = {
+            self.PLAN_SOLVE_SETUP: TrackerItem(_("Solver setup")),
+            self.PLAN_SOLVE_SOLVER: TrackerItem(_("Running solver")),
+            self.PLAN_FIND_MFST: TrackerItem(_("Finding local manifests")),
+            self.PLAN_PKGPLAN: GoalTrackerItem(_("Package planning")),
+            self.PLAN_ACTION_MERGE: TrackerItem(_("Merging actions")),
+            self.PLAN_ACTION_CONFLICT: TrackerItem(
+                _("Checking for conflicting actions")
+            ),
+            self.PLAN_ACTION_CONSOLIDATE: TrackerItem(
+                _("Consolidating action changes")
+            ),
+            self.PLAN_ACTION_MEDIATION: TrackerItem(_("Evaluating mediators")),
+            self.PLAN_ACTION_FINALIZE: TrackerItem(_("Finalizing action plan")),
+            self.PLAN_MEDIATION_CHG: TrackerItem(
+                _("Evaluating mediator changes")
+            ),
+            self.PLAN_PKG_VERIFY: GoalTrackerItem(_("Verifying Packages")),
+            self.PLAN_PKG_FIX: GoalTrackerItem(_("Fixing Packages")),
+        }
+
+        self._actionitems = {
+            self.ACTION_REMOVE: GoalTrackerItem(_("Removing old actions")),
+            self.ACTION_INSTALL: GoalTrackerItem(_("Installing new actions")),
+            self.ACTION_UPDATE: GoalTrackerItem(_("Updating modified actions")),
+        }
+
+        self._jobitems = {
+            self.JOB_STATE_DB: TrackerItem(
+                _("Updating package state database")
+            ),
+            self.JOB_IMAGE_STATE: TrackerItem(_("Updating image state")),
+            self.JOB_FAST_LOOKUP: TrackerItem(
+                _("Creating fast lookup database")
+            ),
+            self.JOB_PKG_CACHE: GoalTrackerItem(_("Updating package cache")),
+            self.JOB_READ_SEARCH: TrackerItem(_("Reading search index")),
+            self.JOB_UPDATE_SEARCH: GoalTrackerItem(_("Updating search index")),
+            self.JOB_REBUILD_SEARCH: GoalTrackerItem(
+                _("Building new search index")
+            ),
+            # pkgrepo job items
+            self.JOB_REPO_DELSEARCH: TrackerItem(_("Deleting search index")),
+            self.JOB_REPO_UPDATE_CAT: TrackerItem(_("Updating catalog")),
+            self.JOB_REPO_ANALYZE_RM: GoalTrackerItem(
+                _("Analyzing removed packages")
+            ),
+            self.JOB_REPO_ANALYZE_REPO: GoalTrackerItem(
+                _("Analyzing repository packages")
+            ),
+            self.JOB_REPO_RM_MFST: GoalTrackerItem(
+                _("Removing package manifests")
+            ),
+            self.JOB_REPO_RM_FILES: GoalTrackerItem(
+                _("Removing package files")
+            ),
+            self.JOB_REPO_VERIFY_REPO: GoalTrackerItem(
+                _("Verifying repository content")
+            ),
+            self.JOB_REPO_FIX_REPO: GoalTrackerItem(
+                _("Fixing repository content")
+            ),
+        }
+
+        self.reset_download()
+
+        self._archive_name = None
+
+        # Lint's interaction with the progresstracker probably
+        # needs further work.
+        self.lint_phase = None
+        self.lint_phasetype = None
+        # This GoalTrackerItem is created on the fly.
+        self.lintitems = None
+
+        # Linked images
+        self.linked_name = None
+        self.linked_running = []
+        self.linked_pkg_op = None
+        self.linked_total = 0
+
+    def set_major_phase(self, majorphase):
+        # Attribute defined outside __init__; pylint: disable=W0201
+        self.major_phase = majorphase
+
+    def flush(self):
+        """Used to signal to the progresstracker that it should make
+        the output ready for use by another subsystem.  In a
+        terminal-based environment, this would make sure that no
+        partially printed lines were present, and flush e.g. stdout."""
+        self._output_flush()
+
+    def set_purpose(self, purpose):
+        op = self.purpose
+        self.purpose = purpose  # pylint: disable=W0201
+        if op != self.purpose:
+            self._change_purpose(op, purpose)
+
+    def get_purpose(self):
+        return self.purpose
+
+    def cache_catalogs_start(self):
+        self._cache_cats_output(OutSpec(first=True))
+
+    def cache_catalogs_done(self):
+        self._cache_cats_output(OutSpec(last=True))
+
+    def load_catalog_cache_start(self):
+        self._load_cat_cache_output(OutSpec(first=True))
+
+    def load_catalog_cache_done(self):
+        self._load_cat_cache_output(OutSpec(last=True))
+
+    def refresh_start(self, pub_cnt, full_refresh, target_catalog=False):
+        #
+        # We can wind up doing multiple refreshes in some cases,
+        # for example when we have to check if pkg(7) is up-to-date,
+        # so we reset these each time we start.
+        #
+        self.pub_refresh.reset()
+        self.pub_refresh.goalitems = pub_cnt
+        self.pub_refresh_bytes.reset()
+        # Attribute defined outside __init__; pylint: disable=W0201
+        self.refresh_full_refresh = full_refresh
+        self.refresh_target_catalog = target_catalog
+        if self.refresh_target_catalog:
+            assert self.refresh_full_refresh
+
+    def refresh_start_pub(self, pub):
+        outspec = OutSpec()
+        # for now we only refresh one at a time, so we stash
+        # this here, and then assert for it in end_pub and
+        # in refresh_progress.
+        self.pub_refresh.curinfo = pub
+        if not self.pub_refresh.printed:
+            outspec.first = True
+        outspec.changed.append("startpublisher")
+        self.pub_refresh.printed = True
+        self._refresh_output_progress(outspec)
+
+    def refresh_end_pub(self, pub):
+        assert pub == self.pub_refresh.curinfo
+        assert self.pub_refresh.printed
+        outspec = OutSpec()
+        outspec.changed.append("endpublisher")
+        self.pub_refresh.items += 1
+        self._refresh_output_progress(outspec)
+
+    def refresh_progress(self, pub, nbytes):
+        # when called back from the transport we lose the knowledge
+        # of what 'pub' is, at least for now.
+        assert pub is None or pub == self.pub_refresh.curinfo
+        assert self.pub_refresh.printed
+        self.pub_refresh_bytes.items += nbytes
+        self._refresh_output_progress(OutSpec())
+
+    def refresh_done(self):
+        # If refreshes fail, we might not meet the goal.
+        self.pub_refresh.done(goalcheck=False)
+        self.pub_refresh_bytes.done()
+        self._refresh_output_progress(OutSpec(last=True))
+
+    def plan_all_start(self):
+        self.set_major_phase(self.PHASE_PLAN)
+        self.plan_generic.reset()
+        self.plan_generic.start()
+
+    def plan_start(self, planid, goal=None):
+        planitem = self._planitems[planid]
+        planitem.reset()
+        if goal:
+            if not isinstance(planitem, GoalTrackerItem):
+                raise RuntimeError("can't set goal on non-goal tracker")
+            planitem.goalitems = goal
+        planitem.start()
+
+    def plan_add_progress(self, planid, nitems=1):
+        planitem = self._planitems[planid]
+        outspec = OutSpec(first=not planitem.printed)
+        planitem.items += nitems
+        self._plan_output(outspec, planitem)
+        planitem.printed = True
+
+    def plan_done(self, planid):
+        planitem = self._planitems[planid]
+        planitem.done()
+        if planitem.printed:
+            self._plan_output(OutSpec(last=True), planitem)
+
+    def plan_all_done(self):
+        self.plan_generic.done()
+        self._plan_output_all_done()
+
+    def manifest_fetch_start(self, goal_mfsts):
+        self.mfst_fetch.reset()
+        self.mfst_commit.reset()
+        self.mfst_fetch.goalitems = goal_mfsts
+        self.mfst_commit.goalitems = goal_mfsts
+
+    def manifest_fetch_progress(self, completion):
+        assert self.major_phase in [self.PHASE_PLAN, self.PHASE_UTILITY]
+        outspec = OutSpec(first=not self.mfst_fetch.printed)
+        self.mfst_fetch.printed = True
+        if completion:
+            self.mfst_fetch.items += 1
+            outspec.changed.append("manifests")
+        self._mfst_fetch(outspec)
+
+    def manifest_commit(self):
+        assert self.major_phase in [self.PHASE_PLAN, self.PHASE_UTILITY]
+        outspec = OutSpec(first=not self.mfst_commit.printed)
+        self.mfst_commit.printed = True
+        self.mfst_commit.items += 1
+        self._mfst_commit(outspec)
+
+    def manifest_fetch_done(self):
+        # These can fail to reach their goals due to various transport
+        # errors, depot misconfigurations, etc.  So disable goal check.
+        self.mfst_fetch.done(goalcheck=False)
+        self.mfst_commit.done(goalcheck=False)
+        if self.mfst_fetch.printed:
+            self._mfst_fetch(OutSpec(last=True))
+
+    def repo_verify_start(self, npkgs):
+        self.repo_ver_pkgs.reset()
+        self.repo_ver_pkgs.goalitems = npkgs
+
+    def repo_verify_start_pkg(self, pkgfmri, repository_scan=False):
+        if pkgfmri != self.repo_ver_pkgs.curinfo:
+            self.repo_ver_pkgs.items += 1
+            self.repo_ver_pkgs.curinfo = pkgfmri
+        self._repo_ver_output(
+            OutSpec(changed=["startpkg"]), repository_scan=repository_scan
+        )
+
+    def repo_verify_add_progress(self, pkgfmri):
+        self._repo_ver_output(OutSpec())
+
+    def repo_verify_yield_error(self, pkgfmri, errors):
+        self._repo_ver_output_error(errors)
+
+    def repo_verify_end_pkg(self, pkgfmri):
+        self._repo_ver_output(OutSpec(changed=["endpkg"]))
+        self.repo_ver_pkgs.curinfo = None
+
+    def repo_verify_done(self):
+        self.repo_ver_pkgs.done()
+
+    def repo_fix_start(self, nitems):
+        self.repo_fix.reset()
+        self.repo_fix.goalitems = nitems
+
+    def repo_fix_add_progress(self, pkgfmri):
+        self._repo_fix_output(OutSpec())
+
+    def repo_fix_yield_error(self, pkgfmri, errors):
+        self._repo_fix_output_error(errors)
+
+    def repo_fix_yield_info(self, pkgfmri, info):
+        self._repo_fix_output_info(info)
+
+    def repo_fix_done(self):
+        self.repo_fix.done()
+
+    def archive_set_goal(self, arcname, nitems, nbytes):
+        self._archive_name = arcname  # pylint: disable=W0201
+        self.archive_items.goalitems = nitems
+        self.archive_bytes.goalitems = nbytes
+
+    def archive_add_progress(self, nitems, nbytes):
+        outspec = OutSpec()
+        if not self.archive_bytes.printed:
+            self.archive_bytes.printed = True
+            outspec.first = True
+        self.archive_items.items += nitems
+        self.archive_bytes.items += nbytes
+        self._archive_output(outspec)
+
+    def archive_done(self):
+        """Call when all archiving is finished"""
+        self.archive_items.done()
+        self.archive_bytes.done()
+        # only print 'last' if we printed 'first'
+        if self.archive_bytes.printed:
+            self._archive_output(OutSpec(last=True))
+
+    def download_set_goal(self, npkgs, nfiles, nbytes):
+        # Attribute defined outside __init__; pylint: disable=W0201
+        self.dl_mode = self.DL_MODE_DOWNLOAD
+        self.dl_pkgs.goalitems = npkgs
+        self.dl_files.goalitems = nfiles
+        self.dl_bytes.goalitems = nbytes
+        self.dl_estimator = SpeedEstimator(self.dl_bytes.goalitems)
+
+    def download_start_pkg(self, pkgfmri):
+        self.set_major_phase(self.PHASE_DOWNLOAD)
+        self.dl_pkgs.curinfo = pkgfmri
+        outspec = OutSpec(changed=["startpkg"])
+        if self.dl_bytes.goalitems != 0:
+            if not self.dl_bytes.printed:
+                # indicate that this is the first _dl_output
+                # call
+                self.dl_bytes.printed = True
+                self.dl_estimator.start()
+                outspec.first = True
+            self._dl_output(outspec)
+
+    def download_end_pkg(self, pkgfmri):
+        self.dl_pkgs.items += 1
+        if self.dl_bytes.goalitems != 0:
+            self._dl_output(OutSpec(changed=["endpkg"]))
+
+    def download_add_progress(self, nfiles, nbytes, cachehit=False):
+        """Call to provide news that the download has made progress"""
+        #
+        # These guards are present because download_add_progress can
+        # be called when an *upload* aborts; we want to prevent updates
+        # to these items, since they in this case might have no goals.
+        #
+        if self.dl_bytes.goalitems > 0:
+            self.dl_bytes.items += nbytes
+        if self.dl_files.goalitems > 0:
+            self.dl_files.items += nfiles
+
+        if cachehit:
+            self.dl_estimator.goalbytes -= nbytes
+        else:
+            self.dl_estimator.newdata(nbytes)
+
+        if self.dl_bytes.goalitems != 0:
+            outspec = OutSpec()
+            if nbytes > 0:
+                outspec.changed.append("dl_bytes")
+            if nfiles > 0:
+                outspec.changed.append("dl_files")
+            if self.dl_mode == self.DL_MODE_DOWNLOAD:
+                self._dl_output(outspec)
+            if self.dl_mode == self.DL_MODE_REPUBLISH:
+                self._republish_output(outspec)
+
+    def download_done(self, dryrun=False):
+        """Call when all downloading is finished."""
+        if dryrun:
+            # Dryrun mode is used by pkgrecv in order to
+            # simulate a download; we do what we have to
+            # in order to fake up a download result.
+            self.dl_pkgs.items = self.dl_pkgs.goalitems
+            self.dl_files.items = self.dl_files.goalitems
+            self.dl_bytes.items = self.dl_bytes.goalitems
+            self.dl_estimator.start(timestamp=0)
+            self.dl_estimator.newdata(self.dl_bytes.goalitems, timestamp=0)
+            self.dl_estimator.done(timestamp=0)
+        else:
+            self.dl_estimator.done()
+
+        self.dl_pkgs.done()
+        self.dl_files.done()
+        self.dl_bytes.done()
+
+        if self.dl_bytes.goalitems != 0:
+            self._dl_output(OutSpec(last=True))
+
+    def actions_set_goal(self, actionid, nactions):
+        """Called to set the goal for a particular phase of action
+        activity (i.e. ACTION_REMOVE, ACTION_INSTALL, or ACTION_UPDATE.
+        """
+        assert self.major_phase == self.PHASE_EXECUTE
+        actionitem = self._actionitems[actionid]
+        actionitem.reset()
+        actionitem.goalitems = nactions
+
+    def actions_add_progress(self, actionid):
+        assert self.major_phase == self.PHASE_EXECUTE
+        actionitem = self._actionitems[actionid]
+        actionitem.items += 1
+        self._act_output(OutSpec(first=(actionitem.items == 1)), actionitem)
+
+    def actions_done(self, actionid):
+        """Called when done each phase of actions processing."""
+        assert self.major_phase == self.PHASE_EXECUTE
+        actionitem = self._actionitems[actionid]
+        actionitem.done()
+        if actionitem.goalitems != 0:
+            self._act_output(OutSpec(last=True), actionitem)
+
+    def actions_all_done(self):
+        total_actions = sum(x.items for x in self._actionitems.values())
+        if total_actions != 0:
+            self._act_output_all_done()
+
+    def job_start(self, jobid, goal=None):
+        jobitem = self._jobitems[jobid]
+        jobitem.reset()
+        outspec = OutSpec()
+        if goal:
+            if not isinstance(jobitem, GoalTrackerItem):
+                raise RuntimeError("can't set goal on non-goal tracker")
+            jobitem.goalitems = goal
+        jobitem.printed = True
+        self._job_output(outspec, jobitem)
+
+    def job_add_progress(self, jobid, nitems=1):
+        jobitem = self._jobitems[jobid]
+        outspec = OutSpec(first=not jobitem.printed)
+        jobitem.printed = True
+        jobitem.items += nitems
+        self._job_output(outspec, jobitem)
+
+    def job_done(self, jobid):
+        jobitem = self._jobitems[jobid]
+        # only print the 'done' if we printed the 'start'
+        jobitem.done()
+        if jobitem.printed:
+            self._job_output(OutSpec(last=True), jobitem)
+
+    def republish_set_goal(self, npkgs, ngetbytes, nsendbytes):
+        self.dl_mode = self.DL_MODE_REPUBLISH  # pylint: disable=W0201
+
+        self.repub_pkgs.goalitems = npkgs
+        self.repub_send_bytes.goalitems = nsendbytes
+
+        self.dl_bytes.goalitems = ngetbytes
+        # We don't have a good value to set this to.
+        self.dl_files.goalitems = 1 << 64
+        # Attribute defined outside __init__; pylint: disable=W0201
+        self.dl_estimator = SpeedEstimator(self.dl_bytes.goalitems)
+
+    def republish_start_pkg(self, pkgfmri, getbytes=None, sendbytes=None):
+        assert isinstance(pkgfmri, pkg.fmri.PkgFmri)
+
+        if getbytes is not None:
+            # Allow reset of GET and SEND amounts on a per-package
+            # basis.  This allows the user to monitor the overall
+            # progress of the operation in terms of total packages
+            # while not requiring the program to pre-process all
+            # packages to determine total byte sizes before starting
+            # the operation.
+            assert sendbytes is not None
+            self.dl_bytes.items = 0
+            self.dl_bytes.goalitems = getbytes
+            self.dl_estimator.goalbytes = getbytes
+
+            self.repub_send_bytes.items = 0
+            self.repub_send_bytes.goalitems = sendbytes
+
+        self.repub_pkgs.curinfo = pkgfmri
+        outspec = OutSpec(changed=["startpkg"])
+        #
+        # We can't do our normal trick of checking to see if
+        # dl_bytes.items is zero because it might have been reset
+        # above.
+        #
+        if not self.repub_pkgs.printed:
+            # indicate that this is the first _republish_output call
+            outspec.first = True
+            self.repub_pkgs.printed = True
+            self.dl_estimator.start()
+        if self.repub_pkgs.goalitems != 0:
+            self._republish_output(outspec)
+
+    def republish_end_pkg(self, pkgfmri):
+        self.repub_pkgs.items += 1
+        self._republish_output(OutSpec(changed=["endpkg"]))
+
+    def upload_add_progress(self, nbytes):
+        """Call to provide news that the upload has made progress"""
+        #
+        # upload_add_progress can be called when a *download* aborts;
+        # this guard prevents us from updating the item (which has
+        # no goal set, and will raise an exception).
+        #
+        if (
+            self.repub_send_bytes.goalitems
+            and self.repub_send_bytes.goalitems > 0
+        ):
+            self.repub_send_bytes.items += nbytes
+            self._republish_output(OutSpec())
+
+    def republish_done(self, dryrun=False):
+        """Call when all republishing is finished"""
+        if dryrun:
+            self.repub_pkgs.items = self.repub_pkgs.goalitems
+            self.repub_send_bytes.items = self.repub_send_bytes.goalitems
+            self.dl_bytes.items = self.dl_bytes.goalitems
+
+        self.repub_pkgs.done()
+        self.repub_send_bytes.done()
+        self.dl_bytes.done()
+
+        if self.repub_pkgs.goalitems != 0:
+            outspec = OutSpec(last=True)
+            # Get the header printed if we've not printed
+            # anything else thus far (happens in dryrun mode).
+            outspec.first = not self.repub_pkgs.printed
+            self._republish_output(outspec)
+            self.repub_pkgs.printed = True
+
+    def lint_next_phase(self, goalitems, lint_phasetype):
+        # Attribute defined outside __init__; pylint: disable=W0201
+        self.lint_phasetype = lint_phasetype
+        if self.lint_phase is not None:
+            self._lint_output(OutSpec(last=True))
+        if self.lint_phase is None:
+            self.lint_phase = 0
+        self.lint_phase += 1
+        if lint_phasetype == self.LINT_PHASETYPE_SETUP:
+            phasename = _("Lint setup {0:d}".format(self.lint_phase))
+        else:
+            phasename = _("Lint phase {0:d}".format(self.lint_phase))
+        self.lintitems = GoalTrackerItem(phasename)
+        self.lintitems.goalitems = goalitems
+        self._lint_output(OutSpec(first=True))
+
+    def lint_add_progress(self):
+        self.lintitems.items += 1
+        self._lint_output(OutSpec())
+
+    def lint_done(self):
+        self.lint_phase = None  # pylint: disable=W0201
+        if self.lintitems:
+            self._lint_output(OutSpec(last=True))
+
+    def set_linked_name(self, lin):
+        """Called once an image determines its linked image name."""
+        self.linked_name = lin  # pylint: disable=W0201
+
+    def li_recurse_start(self, pkg_op, total):
+        """Called when we recurse into a child linked image."""
+        # Attribute defined outside __init__; pylint: disable=W0201
+        self.linked_pkg_op = pkg_op
+        self.linked_total = total
+        self._li_recurse_start_output()
+
+    def li_recurse_end(self):
+        """Called when we return from a child linked image."""
+        self._li_recurse_end_output()
+
+    def li_recurse_status(self, lin_running, done):
+        """Call to update the progress tracker with the list of
+        images being operated on."""
+        # Attribute defined outside __init__; pylint: disable=W0201
+        self.linked_running = sorted(lin_running)
+        self._li_recurse_status_output(done)
+
+    def li_recurse_output(self, lin, stdout, stderr):
+        """Call to display output from linked image operations."""
+        self._li_recurse_output_output(lin, stdout, stderr)
+
+    def li_recurse_progress(self, lin):
+        """Call to indicate that the named child made progress."""
+        self._li_recurse_progress_output(lin)
+
+    def reversion_start(self, goal_pkgs, goal_revs):
+        self.reversion_adjs.reset()
+        self.reversion_revs.reset()
+        self.reversion_pkgs.reset()
+        self.reversion_revs.goalitems = goal_revs
+        self.reversion_pkgs.goalitems = goal_pkgs
+        self.reversion_adjs.goalitems = -1
+
+    def reversion_add_progress(self, pfmri, pkgs=0, reversioned=0, adjusted=0):
+        outspec = OutSpec()
+        if not self.reversion_pkgs.printed:
+            self.reversion_pkgs.printed = True
+            outspec.first = True
+
+        self.reversion_revs.items += reversioned
+        self.reversion_adjs.items += adjusted
+        self.reversion_pkgs.items += pkgs
+        self._reversion(pfmri, outspec)
+
+    def reversion_done(self):
+        self.reversion_pkgs.done()
+        self.reversion_revs.done()
+        self.reversion_adjs.done(goalcheck=False)
+        if self.reversion_pkgs.printed:
+            self._reversion("Done", OutSpec(last=True))
 
 
 class MultiProgressTracker(ProgressTrackerFrontend):
-        """This class is a proxy, dispatching incoming progress tracking calls
-        to one or more contained (in self._trackers) additional progress
-        trackers.  So, you can use this class to route progress tracking calls
-        to multiple places at once (for example, to the screen and to a log
-        file).
+    """This class is a proxy, dispatching incoming progress tracking calls
+    to one or more contained (in self._trackers) additional progress
+    trackers.  So, you can use this class to route progress tracking calls
+    to multiple places at once (for example, to the screen and to a log
+    file).
 
-        We hijack most of the methods of the front-end superclass, except for
-        the constructor.  For each hijacked method, we substitute a closure of
-        the multido() routine bound with the appropriate arguments."""
+    We hijack most of the methods of the front-end superclass, except for
+    the constructor.  For each hijacked method, we substitute a closure of
+    the multido() routine bound with the appropriate arguments."""
 
-        def __init__(self, ptlist):
-                ProgressTrackerFrontend.__init__(self)
+    def __init__(self, ptlist):
+        ProgressTrackerFrontend.__init__(self)
 
-                self._trackers = [t for t in ptlist]
-                if len(self._trackers) == 0:
-                        raise ProgressTrackerException("No trackers specified")
+        self._trackers = [t for t in ptlist]
+        if len(self._trackers) == 0:
+            raise ProgressTrackerException("No trackers specified")
 
-                #
-                # Returns a multido closure, which will iterate and call the
-                # named method for each tracker registered with the class.
-                #
-                def make_multido(method_name):
-                        # self and method_name are bound in this context.
-                        def multido(*args, **kwargs):
-                                for trk in self._trackers:
-                                        f = getattr(trk, method_name)
-                                        f(*args, **kwargs)
-                        return multido
+        #
+        # Returns a multido closure, which will iterate and call the
+        # named method for each tracker registered with the class.
+        #
+        def make_multido(method_name):
+            # self and method_name are bound in this context.
+            def multido(*args, **kwargs):
+                for trk in self._trackers:
+                    f = getattr(trk, method_name)
+                    f(*args, **kwargs)
 
-                #
-                # Look in the ProgressTrackerFrontend for a list of frontend
-                # methods to multiplex.
-                #
-                for methname, m in six.iteritems(
-                    ProgressTrackerFrontend.__dict__):
-                        if methname == "__init__":
-                                continue
-                        if not inspect.isfunction(m):
-                                continue
-                        # Override all methods which aren't the constructor.
-                        # Yes, this is a big hammer.
-                        setattr(self, methname, make_multido(methname))
-                return
+            return multido
+
+        #
+        # Look in the ProgressTrackerFrontend for a list of frontend
+        # methods to multiplex.
+        #
+        for methname, m in six.iteritems(ProgressTrackerFrontend.__dict__):
+            if methname == "__init__":
+                continue
+            if not inspect.isfunction(m):
+                continue
+            # Override all methods which aren't the constructor.
+            # Yes, this is a big hammer.
+            setattr(self, methname, make_multido(methname))
+        return
 
 
 class QuietProgressTracker(ProgressTracker):
-        """This progress tracker outputs nothing, but is semantically
-        intended to be "quiet."  See also NullProgressTracker below."""
+    """This progress tracker outputs nothing, but is semantically
+    intended to be "quiet."  See also NullProgressTracker below."""
 
-        #
-        # At construction, we inspect the ProgressTrackerBackend abstract
-        # superclass, and implement all of its methods as empty stubs.
-        #
-        def __init__(self):
-                ProgressTracker.__init__(self)
+    #
+    # At construction, we inspect the ProgressTrackerBackend abstract
+    # superclass, and implement all of its methods as empty stubs.
+    #
+    def __init__(self):
+        ProgressTracker.__init__(self)
 
-                # We modify the object such that all of the methods it needs to
-                # implement are set to this __donothing empty method.
+        # We modify the object such that all of the methods it needs to
+        # implement are set to this __donothing empty method.
 
-                def __donothing(*args, **kwargs):
-                        # Unused argument 'args', 'kwargs';
-                        #     pylint: disable=W0613
-                        pass
+        def __donothing(*args, **kwargs):
+            # Unused argument 'args', 'kwargs';
+            #     pylint: disable=W0613
+            pass
 
-                for methname in ProgressTrackerBackend.__dict__:
-                        if methname == "__init__":
-                                continue
-                        boundmeth = getattr(self, methname)
-                        if not inspect.ismethod(boundmeth):
-                                continue
-                        setattr(self, methname, __donothing)
+        for methname in ProgressTrackerBackend.__dict__:
+            if methname == "__init__":
+                continue
+            boundmeth = getattr(self, methname)
+            if not inspect.ismethod(boundmeth):
+                continue
+            setattr(self, methname, __donothing)
 
 
 class NullProgressTracker(QuietProgressTracker):
-        """This ProgressTracker is a subclass of QuietProgressTracker because
-        that's convenient for now.  It is semantically intended to be a no-op
-        progress tracker, and is useful for short-running operations which
-        need not display progress of any kind.
+    """This ProgressTracker is a subclass of QuietProgressTracker because
+    that's convenient for now.  It is semantically intended to be a no-op
+    progress tracker, and is useful for short-running operations which
+    need not display progress of any kind.
 
-        This subclass should be used by external consumers wanting to create
-        their own ProgressTracker class as any new output methods added to the
-        ProgressTracker class will also be handled here, insulating them from
-        additions to the ProgressTracker class."""
+    This subclass should be used by external consumers wanting to create
+    their own ProgressTracker class as any new output methods added to the
+    ProgressTracker class will also be handled here, insulating them from
+    additions to the ProgressTracker class."""
 
 
 class FunctionProgressTracker(ProgressTracker):
-        """This ProgressTracker is principally used for debugging.
-        Essentially it uses method replacement in order to create a
-        "tracing" ProgressTracker that shows calls to front end methods
-        and calls from the frontend to the backend."""
+    """This ProgressTracker is principally used for debugging.
+    Essentially it uses method replacement in order to create a
+    "tracing" ProgressTracker that shows calls to front end methods
+    and calls from the frontend to the backend."""
 
-        #
-        # When an instance of this class is initialized, we use inspection to
-        # insert a new method for each method; for frontend methods "chain"
-        # the old one behind the new one.  The new method dumps out the
-        # arguments.
-        #
-        def __init__(self, output_file=sys.stdout):
-                ProgressTracker.__init__(self)
-                self.output_file = output_file
+    #
+    # When an instance of this class is initialized, we use inspection to
+    # insert a new method for each method; for frontend methods "chain"
+    # the old one behind the new one.  The new method dumps out the
+    # arguments.
+    #
+    def __init__(self, output_file=sys.stdout):
+        ProgressTracker.__init__(self)
+        self.output_file = output_file
 
-                def __donothing(*args, **kwargs):
-                        # Unused argument 'args', 'kwargs';
-                        #     pylint: disable=W0613
-                        pass
+        def __donothing(*args, **kwargs):
+            # Unused argument 'args', 'kwargs';
+            #     pylint: disable=W0613
+            pass
 
-                # We modify the instance such that all of the methods it needs
-                # to implement are set to this __printargs method.
-                def make_printargs(methname, chainedmeth):
-                        def __printargs(*args, **kwargs):
-                                s = ""
-                                for x in args:
-                                        s += "{0}, ".format(str(x))
-                                for x in sorted(kwargs):
-                                        s += "{0}={1}, ".format(x, kwargs[x])
-                                s = s[:-2]
+        # We modify the instance such that all of the methods it needs
+        # to implement are set to this __printargs method.
+        def make_printargs(methname, chainedmeth):
+            def __printargs(*args, **kwargs):
+                s = ""
+                for x in args:
+                    s += "{0}, ".format(str(x))
+                for x in sorted(kwargs):
+                    s += "{0}={1}, ".format(x, kwargs[x])
+                s = s[:-2]
 
-                                #
-                                # Invoke chained method implementation; it's
-                                # counter-intuitive, but we do this before
-                                # printing things out, because under the
-                                # circumstances we create in
-                                # test_progress_tracker(), the chained method
-                                # could throw an exception, aborting an
-                                # upstream MultiProgressTracker's multido(),
-                                # and spoiling the test_multi() test case.
-                                #
-                                chainedmeth(*args, **kwargs)
-                                print("{0}({1})".format(methname, s),
-                                    file=self.output_file)
+                #
+                # Invoke chained method implementation; it's
+                # counter-intuitive, but we do this before
+                # printing things out, because under the
+                # circumstances we create in
+                # test_progress_tracker(), the chained method
+                # could throw an exception, aborting an
+                # upstream MultiProgressTracker's multido(),
+                # and spoiling the test_multi() test case.
+                #
+                chainedmeth(*args, **kwargs)
+                print("{0}({1})".format(methname, s), file=self.output_file)
 
-                        return __printargs
+            return __printargs
 
-                for methname in ProgressTrackerFrontend.__dict__:
-                        if methname == "__init__":
-                                continue
-                        #
-                        # this gets us the bound method, which we say here
-                        # is "chained"-- we'll call it next after our inserted
-                        # method.
-                        #
-                        chainedmeth = getattr(self, methname, None)
-                        if not inspect.ismethod(chainedmeth):
-                                continue
-                        setattr(self, methname,
-                            make_printargs(methname, chainedmeth))
+        for methname in ProgressTrackerFrontend.__dict__:
+            if methname == "__init__":
+                continue
+            #
+            # this gets us the bound method, which we say here
+            # is "chained"-- we'll call it next after our inserted
+            # method.
+            #
+            chainedmeth = getattr(self, methname, None)
+            if not inspect.ismethod(chainedmeth):
+                continue
+            setattr(self, methname, make_printargs(methname, chainedmeth))
 
-                for methname in ProgressTrackerBackend.__dict__:
-                        if methname == "__init__":
-                                continue
-                        chainedmeth = getattr(self, methname, None)
-                        if not inspect.ismethod(chainedmeth):
-                                continue
-                        chainedmeth = __donothing
-                        setattr(self, methname,
-                            make_printargs(methname, chainedmeth))
+        for methname in ProgressTrackerBackend.__dict__:
+            if methname == "__init__":
+                continue
+            chainedmeth = getattr(self, methname, None)
+            if not inspect.ismethod(chainedmeth):
+                continue
+            chainedmeth = __donothing
+            setattr(self, methname, make_printargs(methname, chainedmeth))
 
 
 class DotProgressTracker(ProgressTracker):
-        """This tracker writes a series of dots for every operation.
-        This is intended for use by linked images."""
+    """This tracker writes a series of dots for every operation.
+    This is intended for use by linked images."""
 
-        TERM_DELAY = 0.1
+    TERM_DELAY = 0.1
 
-        def __init__(self, output_file=sys.stdout, term_delay=TERM_DELAY):
-                ProgressTracker.__init__(self)
+    def __init__(self, output_file=sys.stdout, term_delay=TERM_DELAY):
+        ProgressTracker.__init__(self)
 
-                self._pe = printengine.POSIXPrintEngine(output_file,
-                    ttymode=False)
-                self._ptimer = PrintTimer(term_delay)
+        self._pe = printengine.POSIXPrintEngine(output_file, ttymode=False)
+        self._ptimer = PrintTimer(term_delay)
 
-                def make_dot():
-                        def dot(*args, **kwargs):
-                                # Unused argument 'args', 'kwargs';
-                                #     pylint: disable=W0613
-                                if self._ptimer.time_to_print():
-                                        self._pe.cprint(".", end='')
-                        return dot
+        def make_dot():
+            def dot(*args, **kwargs):
+                # Unused argument 'args', 'kwargs';
+                #     pylint: disable=W0613
+                if self._ptimer.time_to_print():
+                    self._pe.cprint(".", end="")
 
-                for methname in ProgressTrackerBackend.__dict__:
-                        if methname == "__init__":
-                                continue
-                        boundmeth = getattr(self, methname, None)
-                        if not inspect.ismethod(boundmeth):
-                                continue
-                        setattr(self, methname, make_dot())
+            return dot
+
+        for methname in ProgressTrackerBackend.__dict__:
+            if methname == "__init__":
+                continue
+            boundmeth = getattr(self, methname, None)
+            if not inspect.ismethod(boundmeth):
+                continue
+            setattr(self, methname, make_dot())
 
 
 class CommandLineProgressTracker(ProgressTracker):
-        """This progress tracker is a generically useful tracker for command
-        line output.  It needs no special terminal features and so is
-        appropriate for sending through a pipe.  This code is intended to be
-        platform neutral."""
+    """This progress tracker is a generically useful tracker for command
+    line output.  It needs no special terminal features and so is
+    appropriate for sending through a pipe.  This code is intended to be
+    platform neutral."""
 
-        # Default to printing periodic output every 5 seconds.
-        TERM_DELAY = 5.0
+    # Default to printing periodic output every 5 seconds.
+    TERM_DELAY = 5.0
 
-        def __init__(self, output_file=sys.stdout, print_engine=None,
-            term_delay=TERM_DELAY):
-                ProgressTracker.__init__(self)
-                if not print_engine:
-                        self._pe = printengine.POSIXPrintEngine(output_file,
-                            ttymode=False)
-                else:
-                        self._pe = print_engine
-                self._ptimer = PrintTimer(term_delay)
+    def __init__(
+        self, output_file=sys.stdout, print_engine=None, term_delay=TERM_DELAY
+    ):
+        ProgressTracker.__init__(self)
+        if not print_engine:
+            self._pe = printengine.POSIXPrintEngine(output_file, ttymode=False)
+        else:
+            self._pe = print_engine
+        self._ptimer = PrintTimer(term_delay)
 
-        def _phase_prefix(self):
-                if self.major_phase == self.PHASE_UTILITY:
-                        return ""
+    def _phase_prefix(self):
+        if self.major_phase == self.PHASE_UTILITY:
+            return ""
 
-                # The following string was originally expressed as
-                # "%*s: ". % \
-                #     (self.phase_max_width, self.phase_names[self.major_phase]
-                #     )
-                # however xgettext incorrectly flags this as an improper use of
-                # non-parameterized messages, which gets detected as an error
-                # during our build.  So instead, we express the string using
-                # an equivalent <str>.format(..) function
-                s = _("{{phase:>{0:d}}}: ").format(self.phase_max_width)
-                return s.format(phase=self.phase_names[self.major_phase])
+        # The following string was originally expressed as
+        # "%*s: ". % \
+        #     (self.phase_max_width, self.phase_names[self.major_phase]
+        #     )
+        # however xgettext incorrectly flags this as an improper use of
+        # non-parameterized messages, which gets detected as an error
+        # during our build.  So instead, we express the string using
+        # an equivalent <str>.format(..) function
+        s = _("{{phase:>{0:d}}}: ").format(self.phase_max_width)
+        return s.format(phase=self.phase_names[self.major_phase])
 
-        #
-        # Helper routines
-        #
-        def __generic_start(self, msg):
-                # In the case of listing/up-to-date check operations, we
-                # we don't want to output planning information, so skip.
-                if self.purpose != self.PURPOSE_NORMAL:
-                        return
-                self._pe.cprint(self._phase_prefix() + msg, end='')
-                # indicate that we just printed.
-                self._ptimer.reset_now()
+    #
+    # Helper routines
+    #
+    def __generic_start(self, msg):
+        # In the case of listing/up-to-date check operations, we
+        # we don't want to output planning information, so skip.
+        if self.purpose != self.PURPOSE_NORMAL:
+            return
+        self._pe.cprint(self._phase_prefix() + msg, end="")
+        # indicate that we just printed.
+        self._ptimer.reset_now()
 
-        def __generic_done(self, msg=None):
-                # See __generic_start above.
-                if self.purpose != self.PURPOSE_NORMAL:
-                        return
-                if msg is None:
-                        msg = " " + _("Done")
-                self._pe.cprint(msg, end='\n')
-                self._ptimer.reset()
+    def __generic_done(self, msg=None):
+        # See __generic_start above.
+        if self.purpose != self.PURPOSE_NORMAL:
+            return
+        if msg is None:
+            msg = " " + _("Done")
+        self._pe.cprint(msg, end="\n")
+        self._ptimer.reset()
 
-        def __generic_done_item(self, item, msg=None):
-                # See __generic_start above.
-                if self.purpose != self.PURPOSE_NORMAL:
-                        return
-                if msg is None:
-                        if global_settings.client_output_verbose > 0:
-                                msg = " " + _("Done ({elapsed:>.3f}s)")
-                        else:
-                                msg = " " + _("Done")
-                outmsg = msg.format(elapsed=item.elapsed())
-                self._pe.cprint(outmsg, end='\n')
-                self._ptimer.reset()
+    def __generic_done_item(self, item, msg=None):
+        # See __generic_start above.
+        if self.purpose != self.PURPOSE_NORMAL:
+            return
+        if msg is None:
+            if global_settings.client_output_verbose > 0:
+                msg = " " + _("Done ({elapsed:>.3f}s)")
+            else:
+                msg = " " + _("Done")
+        outmsg = msg.format(elapsed=item.elapsed())
+        self._pe.cprint(outmsg, end="\n")
+        self._ptimer.reset()
 
-        #
-        # Overridden methods from ProgressTrackerBackend
-        #
-        def _output_flush(self):
-                self._pe.flush()
+    #
+    # Overridden methods from ProgressTrackerBackend
+    #
+    def _output_flush(self):
+        self._pe.flush()
 
-        def _change_purpose(self, op, np):
-                self._ptimer.reset()
-                if np == self.PURPOSE_PKG_UPDATE_CHK:
-                        self._pe.cprint(self._phase_prefix() +
-                            _("Checking that pkg(7) is up to date ..."), end='')
-                if op == self.PURPOSE_PKG_UPDATE_CHK:
-                        self._pe.cprint(" "  + _("Done"))
+    def _change_purpose(self, op, np):
+        self._ptimer.reset()
+        if np == self.PURPOSE_PKG_UPDATE_CHK:
+            self._pe.cprint(
+                self._phase_prefix()
+                + _("Checking that pkg(7) is up to date ..."),
+                end="",
+            )
+        if op == self.PURPOSE_PKG_UPDATE_CHK:
+            self._pe.cprint(" " + _("Done"))
 
-        def _cache_cats_output(self, outspec):
-                if outspec.first:
-                        self.__generic_start(_("Caching catalogs ..."))
-                if outspec.last:
-                        self.__generic_done()
+    def _cache_cats_output(self, outspec):
+        if outspec.first:
+            self.__generic_start(_("Caching catalogs ..."))
+        if outspec.last:
+            self.__generic_done()
 
-        def _load_cat_cache_output(self, outspec):
-                if outspec.first:
-                        self.__generic_start(_("Loading catalog cache ..."))
-                if outspec.last:
-                        self.__generic_done()
+    def _load_cat_cache_output(self, outspec):
+        if outspec.first:
+            self.__generic_start(_("Loading catalog cache ..."))
+        if outspec.last:
+            self.__generic_done()
 
-        def _refresh_output_progress(self, outspec):
-                # See __generic_start above.
-                if self.purpose != self.PURPOSE_NORMAL:
-                        return
-                if "startpublisher" in outspec.changed:
-                        p = self.pub_refresh.curinfo.prefix
-                        if self.refresh_target_catalog:
-                                m = _("Retrieving target catalog '{0}' "
-                                    "...").format(p)
-                        elif self.refresh_full_refresh:
-                                m = _("Retrieving catalog '{0}' ...").format(p)
-                        else:
-                                m = _("Refreshing catalog '{0}' ...").format(p)
-                        self.__generic_start(m)
-                elif "endpublisher" in outspec.changed:
-                        self.__generic_done()
+    def _refresh_output_progress(self, outspec):
+        # See __generic_start above.
+        if self.purpose != self.PURPOSE_NORMAL:
+            return
+        if "startpublisher" in outspec.changed:
+            p = self.pub_refresh.curinfo.prefix
+            if self.refresh_target_catalog:
+                m = _("Retrieving target catalog '{0}' " "...").format(p)
+            elif self.refresh_full_refresh:
+                m = _("Retrieving catalog '{0}' ...").format(p)
+            else:
+                m = _("Refreshing catalog '{0}' ...").format(p)
+            self.__generic_start(m)
+        elif "endpublisher" in outspec.changed:
+            self.__generic_done()
 
-        def _plan_output(self, outspec, planitem):
-                if outspec.first:
-                        self.__generic_start(_("{0} ...").format(planitem.name))
-                if outspec.last:
-                        self.__generic_done_item(planitem)
+    def _plan_output(self, outspec, planitem):
+        if outspec.first:
+            self.__generic_start(_("{0} ...").format(planitem.name))
+        if outspec.last:
+            self.__generic_done_item(planitem)
 
-        def _plan_output_all_done(self):
-                self.__generic_done(self._phase_prefix() + \
-                    _("Planning completed in {0:>.2f} seconds").format(
-                    self.plan_generic.elapsed()))
+    def _plan_output_all_done(self):
+        self.__generic_done(
+            self._phase_prefix()
+            + _("Planning completed in {0:>.2f} seconds").format(
+                self.plan_generic.elapsed()
+            )
+        )
 
-        def _mfst_fetch(self, outspec):
-                if not self._ptimer.time_to_print() and \
-                    not outspec.first and not outspec.last:
-                        return
-                if self.purpose != self.PURPOSE_NORMAL:
-                        return
+    def _mfst_fetch(self, outspec):
+        if (
+            not self._ptimer.time_to_print()
+            and not outspec.first
+            and not outspec.last
+        ):
+            return
+        if self.purpose != self.PURPOSE_NORMAL:
+            return
 
-                # Reset timer; this prevents double printing for
-                # outspec.first and then again for the timer expiration
-                if outspec.first:
-                        self._ptimer.reset_now()
-
-                #
-                # There are a couple of reasons we might fetch manifests--
-                # pkgrecv, pkglint, etc. can all do this.  _phase_prefix()
-                # adjusts the output based on the major phase.
-                #
-                self._pe.cprint(self._phase_prefix() +
-                    _("Fetching manifests: {num}  {pctcomplete}% "
-                    "complete").format(
-                    num=self.mfst_fetch.pair(),
-                    pctcomplete=int(self.mfst_fetch.pctdone())))
-
-        def _mfst_commit(self, outspec):
-                # For now, manifest commit is hard to handle in this
-                # line-oriented prog tracker, as we alternate back and forth
-                # between fetching and committing, and we don't want to
-                # spam the user with this too much.
-                pass
-
-        def _repo_ver_output(self, outspec, repository_scan=False):
-                pass
-
-        def _repo_ver_output_error(self, errors):
-                self._pe.cprint(errors)
-
-        def _repo_ver_output_warning(self, warnings):
-                pass
-
-        def _repo_ver_output_info(self, info):
-                pass
-
-        def _repo_ver_output_done(self):
-                pass
-
-        def _repo_fix_output(self, outspec):
-                pass
-
-        def _repo_fix_output_error(self, errors):
-                self._pe.cprint(errors)
-
-        def _repo_fix_output_info(self, info):
-                self._pe.cprint(info)
-
-        def _repo_fix_output_done(self):
-                pass
-
-        def _dl_output(self, outspec):
-                if not self._ptimer.time_to_print() and not outspec.first and \
-                    not outspec.last:
-                        return
-
-                # Reset timer; this prevents double printing for
-                # outspec.first and then again for the timer expiration
-                if outspec.first:
-                        self._ptimer.reset_now()
-
-                if not outspec.last:
-                        speed = self.dl_estimator.get_speed_estimate()
-                else:
-                        speed = self.dl_estimator.get_final_speed()
-                speedstr = "" if speed is None else \
-                    "({0})".format(self.dl_estimator.format_speed(speed))
-
-                if not outspec.last:
-                        # 'first' or time to print
-                        mbs = format_pair("{0:.1f}", self.dl_bytes.items,
-                            self.dl_bytes.goalitems, scale=(1024 * 1024))
-                        self._pe.cprint(
-                            _("Download: {num} items  {mbs}MB  "
-                            "{pctcomplete}% complete {speed}").format(
-                            num=self.dl_files.pair(), mbs=mbs,
-                            pctcomplete=int(self.dl_bytes.pctdone()),
-                            speed=speedstr))
-                else:
-                        # 'last'
-                        goal = misc.bytes_to_str(self.dl_bytes.goalitems)
-                        self.__generic_done(
-                            msg=_("Download: Completed {num} in {sec:>.2f} "
-                            "seconds {speed}").format(
-                            num=goal, sec=self.dl_estimator.elapsed(),
-                            speed=speedstr))
-
-        def _republish_output(self, outspec):
-                if "startpkg" in outspec.changed:
-                        pkgfmri = self.repub_pkgs.curinfo
-                        self.__generic_start(_("Republish: {0} ... ").format(
-                            pkgfmri.get_fmri(anarchy=True)))
-                if "endpkg" in outspec.changed:
-                        self.__generic_done()
-
-        def _archive_output(self, outspec):
-                if not self._ptimer.time_to_print() and not outspec:
-                        return
-                if outspec.first:
-                        # tell ptimer that we just printed.
-                        self._ptimer.reset_now()
-
-                if outspec.last:
-                        goal = misc.bytes_to_str(self.archive_bytes.goalitems)
-                        self.__generic_done(
-                            msg=_("Archiving: Completed {num} in {secs:>.2f} "
-                            "seconds").format(
-                            num=goal, secs=self.archive_items.elapsed()))
-                        return
-
-                mbs = format_pair("{0:.1f}", self.archive_bytes.items,
-                    self.archive_bytes.goalitems, scale=(1024 * 1024))
-                self._pe.cprint(
-                    _("Archiving: {pair} items  {mbs}MB  {pctcomplete}% "
-                    "complete").format(
-                    pair=self.archive_items.pair(), mbs=mbs,
-                    pctcomplete=int(self.archive_bytes.pctdone())))
+        # Reset timer; this prevents double printing for
+        # outspec.first and then again for the timer expiration
+        if outspec.first:
+            self._ptimer.reset_now()
 
         #
-        # The progress tracking infrastructure wants to tell us about each
-        # kind of action activity (install, remove, update).  For this
-        # progress tracker, we don't really care to expose that to the user,
-        # so we work in terms of total actions instead.
+        # There are a couple of reasons we might fetch manifests--
+        # pkgrecv, pkglint, etc. can all do this.  _phase_prefix()
+        # adjusts the output based on the major phase.
         #
-        def _act_output(self, outspec, actionitem):
-                if not self._ptimer.time_to_print() and not outspec.first:
-                        return
-                # reset timer, since we're definitely printing now...
-                self._ptimer.reset_now()
-                total_actions = \
-                    sum(x.items for x in self._actionitems.values())
-                total_goal = \
-                    sum(x.goalitems for x in self._actionitems.values())
-                self._pe.cprint(self._phase_prefix() +
-                    _("{num} actions ({type})").format(
-                    num=format_pair("{0:d}", total_actions, total_goal),
-                    type=actionitem.name))
+        self._pe.cprint(
+            self._phase_prefix()
+            + _("Fetching manifests: {num}  {pctcomplete}% " "complete").format(
+                num=self.mfst_fetch.pair(),
+                pctcomplete=int(self.mfst_fetch.pctdone()),
+            )
+        )
 
-        def _act_output_all_done(self):
-                total_goal = \
-                    sum(x.goalitems for x in self._actionitems.values())
-                total_time = \
-                    sum(x.elapsed() for x in self._actionitems.values())
-                if total_goal == 0:
-                        return
-                self._pe.cprint(self._phase_prefix() +
-                    _("Completed {numactions:d} actions in {time:>.2f} "
-                    "seconds.").format(
-                    numactions=total_goal, time=total_time))
+    def _mfst_commit(self, outspec):
+        # For now, manifest commit is hard to handle in this
+        # line-oriented prog tracker, as we alternate back and forth
+        # between fetching and committing, and we don't want to
+        # spam the user with this too much.
+        pass
 
-        def _job_output(self, outspec, jobitem):
-                if outspec.first:
-                        self.__generic_start("{0} ... ".format(jobitem.name))
-                if outspec.last:
-                        self.__generic_done_item(jobitem)
+    def _repo_ver_output(self, outspec, repository_scan=False):
+        pass
 
-        def _lint_output(self, outspec):
-                if outspec.first:
-                        if self.lint_phasetype == self.LINT_PHASETYPE_SETUP:
-                                self._pe.cprint("{0} ... ".format(
-                                    self.lintitems.name), end='')
-                        elif self.lint_phasetype == self.LINT_PHASETYPE_EXECUTE:
-                                self._pe.cprint("# --- {0} ---".format(
-                                    self.lintitems.name))
-                if outspec.last:
-                        if self.lint_phasetype == self.LINT_PHASETYPE_SETUP:
-                                self.__generic_done()
-                        elif self.lint_phasetype == self.LINT_PHASETYPE_EXECUTE:
-                                pass
+    def _repo_ver_output_error(self, errors):
+        self._pe.cprint(errors)
 
-        def _li_recurse_start_output(self):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
-                        self.__generic_start(
-                            _("Linked image publisher check ..."))
-                        return
-                elif self.linked_pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
-                        self.__generic_start(
-                            _("Cleaning up hot-fix origins ..."))
-                        return
+    def _repo_ver_output_warning(self, warnings):
+        pass
 
-        def _li_recurse_end_output(self):
-                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
-                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
-                        self.__generic_done()
-                        return
-                self._pe.cprint(self._phase_prefix() +
-                    _("Finished processing linked images."))
+    def _repo_ver_output_info(self, info):
+        pass
 
-        def __li_dump_output(self, output):
-                if not output:
-                        return
-                lines = output.splitlines()
-                nlines = len(lines)
-                for linenum, line in enumerate(lines):
-                        line = misc.force_str(line)
-                        if linenum < nlines - 1:
-                                self._pe.cprint("| " + line)
-                        else:
-                                if lines[linenum].strip() != "":
-                                        self._pe.cprint("| " + line)
-                                self._pe.cprint("`")
+    def _repo_ver_output_done(self):
+        pass
 
-        def _li_recurse_output_output(self, lin, stdout, stderr):
-                if not stdout and not stderr:
-                        return
-                self._pe.cprint(self._phase_prefix() +
-                    _("Linked image '{0}' output:").format(lin))
-                self.__li_dump_output(stdout)
-                self.__li_dump_output(stderr)
+    def _repo_fix_output(self, outspec):
+        pass
 
-        def _li_recurse_status_output(self, done):
-                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
-                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
-                        return
+    def _repo_fix_output_error(self, errors):
+        self._pe.cprint(errors)
 
-                running = " ".join([str(i) for i in self.linked_running])
-                msg = _("Linked images: {pair} done; {numworking:d} working: "
-                    "{running}").format(
-                    pair=format_pair("{0:d}", done, self.linked_total),
-                    numworking=len(self.linked_running),
-                    running=running)
-                self._pe.cprint(self._phase_prefix() + msg)
+    def _repo_fix_output_info(self, info):
+        self._pe.cprint(info)
 
-        def _li_recurse_progress_output(self, lin):
-                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
-                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
-                        return
+    def _repo_fix_output_done(self):
+        pass
 
-        def _reversion(self, pfmri, outspec):
-                if not self._ptimer.time_to_print() and not outspec:
-                        return
+    def _dl_output(self, outspec):
+        if (
+            not self._ptimer.time_to_print()
+            and not outspec.first
+            and not outspec.last
+        ):
+            return
 
-                if outspec.first:
-                        # tell ptimer that we just printed.
-                        self._ptimer.reset_now()
+        # Reset timer; this prevents double printing for
+        # outspec.first and then again for the timer expiration
+        if outspec.first:
+            self._ptimer.reset_now()
 
-                if outspec.last:
-                        self.__generic_done(
-                            msg=_("Reversioned {revs} of {pkgs} packages "
-                            "and adjusted {adjs} packages.").format(
-                            revs=self.reversion_revs.items,
-                            pkgs=self.reversion_pkgs.items,
-                            adjs=self.reversion_adjs.items))
-                        return
+        if not outspec.last:
+            speed = self.dl_estimator.get_speed_estimate()
+        else:
+            speed = self.dl_estimator.get_final_speed()
+        speedstr = (
+            ""
+            if speed is None
+            else "({0})".format(self.dl_estimator.format_speed(speed))
+        )
 
-                self._pe.cprint(
-                    _("Reversioning: {pkgs} processed, {revs} reversioned, "
-                    "{adjs} adjusted").format(
-                    pkgs=self.reversion_pkgs.pair(),
-                    revs=self.reversion_revs.pair(),
-                    adjs=self.reversion_adjs.items))
+        if not outspec.last:
+            # 'first' or time to print
+            mbs = format_pair(
+                "{0:.1f}",
+                self.dl_bytes.items,
+                self.dl_bytes.goalitems,
+                scale=(1024 * 1024),
+            )
+            self._pe.cprint(
+                _(
+                    "Download: {num} items  {mbs}MB  "
+                    "{pctcomplete}% complete {speed}"
+                ).format(
+                    num=self.dl_files.pair(),
+                    mbs=mbs,
+                    pctcomplete=int(self.dl_bytes.pctdone()),
+                    speed=speedstr,
+                )
+            )
+        else:
+            # 'last'
+            goal = misc.bytes_to_str(self.dl_bytes.goalitems)
+            self.__generic_done(
+                msg=_(
+                    "Download: Completed {num} in {sec:>.2f} " "seconds {speed}"
+                ).format(
+                    num=goal, sec=self.dl_estimator.elapsed(), speed=speedstr
+                )
+            )
+
+    def _republish_output(self, outspec):
+        if "startpkg" in outspec.changed:
+            pkgfmri = self.repub_pkgs.curinfo
+            self.__generic_start(
+                _("Republish: {0} ... ").format(pkgfmri.get_fmri(anarchy=True))
+            )
+        if "endpkg" in outspec.changed:
+            self.__generic_done()
+
+    def _archive_output(self, outspec):
+        if not self._ptimer.time_to_print() and not outspec:
+            return
+        if outspec.first:
+            # tell ptimer that we just printed.
+            self._ptimer.reset_now()
+
+        if outspec.last:
+            goal = misc.bytes_to_str(self.archive_bytes.goalitems)
+            self.__generic_done(
+                msg=_(
+                    "Archiving: Completed {num} in {secs:>.2f} " "seconds"
+                ).format(num=goal, secs=self.archive_items.elapsed())
+            )
+            return
+
+        mbs = format_pair(
+            "{0:.1f}",
+            self.archive_bytes.items,
+            self.archive_bytes.goalitems,
+            scale=(1024 * 1024),
+        )
+        self._pe.cprint(
+            _(
+                "Archiving: {pair} items  {mbs}MB  {pctcomplete}% " "complete"
+            ).format(
+                pair=self.archive_items.pair(),
+                mbs=mbs,
+                pctcomplete=int(self.archive_bytes.pctdone()),
+            )
+        )
+
+    #
+    # The progress tracking infrastructure wants to tell us about each
+    # kind of action activity (install, remove, update).  For this
+    # progress tracker, we don't really care to expose that to the user,
+    # so we work in terms of total actions instead.
+    #
+    def _act_output(self, outspec, actionitem):
+        if not self._ptimer.time_to_print() and not outspec.first:
+            return
+        # reset timer, since we're definitely printing now...
+        self._ptimer.reset_now()
+        total_actions = sum(x.items for x in self._actionitems.values())
+        total_goal = sum(x.goalitems for x in self._actionitems.values())
+        self._pe.cprint(
+            self._phase_prefix()
+            + _("{num} actions ({type})").format(
+                num=format_pair("{0:d}", total_actions, total_goal),
+                type=actionitem.name,
+            )
+        )
+
+    def _act_output_all_done(self):
+        total_goal = sum(x.goalitems for x in self._actionitems.values())
+        total_time = sum(x.elapsed() for x in self._actionitems.values())
+        if total_goal == 0:
+            return
+        self._pe.cprint(
+            self._phase_prefix()
+            + _(
+                "Completed {numactions:d} actions in {time:>.2f} " "seconds."
+            ).format(numactions=total_goal, time=total_time)
+        )
+
+    def _job_output(self, outspec, jobitem):
+        if outspec.first:
+            self.__generic_start("{0} ... ".format(jobitem.name))
+        if outspec.last:
+            self.__generic_done_item(jobitem)
+
+    def _lint_output(self, outspec):
+        if outspec.first:
+            if self.lint_phasetype == self.LINT_PHASETYPE_SETUP:
+                self._pe.cprint("{0} ... ".format(self.lintitems.name), end="")
+            elif self.lint_phasetype == self.LINT_PHASETYPE_EXECUTE:
+                self._pe.cprint("# --- {0} ---".format(self.lintitems.name))
+        if outspec.last:
+            if self.lint_phasetype == self.LINT_PHASETYPE_SETUP:
+                self.__generic_done()
+            elif self.lint_phasetype == self.LINT_PHASETYPE_EXECUTE:
+                pass
+
+    def _li_recurse_start_output(self):
+        if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+            self.__generic_start(_("Linked image publisher check ..."))
+            return
+        elif self.linked_pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
+            self.__generic_start(_("Cleaning up hot-fix origins ..."))
+            return
+
+    def _li_recurse_end_output(self):
+        if self.linked_pkg_op in [
+            pkgdefs.PKG_OP_PUBCHECK,
+            pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+        ]:
+            self.__generic_done()
+            return
+        self._pe.cprint(
+            self._phase_prefix() + _("Finished processing linked images.")
+        )
+
+    def __li_dump_output(self, output):
+        if not output:
+            return
+        lines = output.splitlines()
+        nlines = len(lines)
+        for linenum, line in enumerate(lines):
+            line = misc.force_str(line)
+            if linenum < nlines - 1:
+                self._pe.cprint("| " + line)
+            else:
+                if lines[linenum].strip() != "":
+                    self._pe.cprint("| " + line)
+                self._pe.cprint("`")
+
+    def _li_recurse_output_output(self, lin, stdout, stderr):
+        if not stdout and not stderr:
+            return
+        self._pe.cprint(
+            self._phase_prefix() + _("Linked image '{0}' output:").format(lin)
+        )
+        self.__li_dump_output(stdout)
+        self.__li_dump_output(stderr)
+
+    def _li_recurse_status_output(self, done):
+        if self.linked_pkg_op in [
+            pkgdefs.PKG_OP_PUBCHECK,
+            pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+        ]:
+            return
+
+        running = " ".join([str(i) for i in self.linked_running])
+        msg = _(
+            "Linked images: {pair} done; {numworking:d} working: " "{running}"
+        ).format(
+            pair=format_pair("{0:d}", done, self.linked_total),
+            numworking=len(self.linked_running),
+            running=running,
+        )
+        self._pe.cprint(self._phase_prefix() + msg)
+
+    def _li_recurse_progress_output(self, lin):
+        if self.linked_pkg_op in [
+            pkgdefs.PKG_OP_PUBCHECK,
+            pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+        ]:
+            return
+
+    def _reversion(self, pfmri, outspec):
+        if not self._ptimer.time_to_print() and not outspec:
+            return
+
+        if outspec.first:
+            # tell ptimer that we just printed.
+            self._ptimer.reset_now()
+
+        if outspec.last:
+            self.__generic_done(
+                msg=_(
+                    "Reversioned {revs} of {pkgs} packages "
+                    "and adjusted {adjs} packages."
+                ).format(
+                    revs=self.reversion_revs.items,
+                    pkgs=self.reversion_pkgs.items,
+                    adjs=self.reversion_adjs.items,
+                )
+            )
+            return
+
+        self._pe.cprint(
+            _(
+                "Reversioning: {pkgs} processed, {revs} reversioned, "
+                "{adjs} adjusted"
+            ).format(
+                pkgs=self.reversion_pkgs.pair(),
+                revs=self.reversion_revs.pair(),
+                adjs=self.reversion_adjs.items,
+            )
+        )
 
 
 class RADProgressTracker(CommandLineProgressTracker):
-        """This progress tracker is a subclass of CommandLineProgressTracker
-        which is specific for RAD progress event.
-        """
+    """This progress tracker is a subclass of CommandLineProgressTracker
+    which is specific for RAD progress event.
+    """
 
-        # Default to printing periodic output every 5 seconds.
-        TERM_DELAY = 5.0
+    # Default to printing periodic output every 5 seconds.
+    TERM_DELAY = 5.0
 
-        # Output constants.
-        O_PHASE = "phase"
-        O_MESSAGE = "message"
-        O_TIME = "time_taken"
-        O_TIME_U = "time_unit"
-        O_TYPE = "type"
-        O_PRO_ITEMS = "processed_items"
-        O_GOAL_ITEMS = "goal_items"
-        O_PCT_DONE = "percent_done"
-        O_ITEM_U = "item_unit"
-        O_SPEED = "speed"
-        O_RUNNING = "running"
-        O_GOAL_PRO_ITEMS = "goal_processed_items"
-        O_REV_ITEMS = "reversioned_items"
-        O_GOAL_REV_ITEMS = "goal_reversion_items"
-        O_ADJ_ITEMS = "adjusted_items"
-        O_LI_OUTPUT = "li_output"
-        O_LI_ERROR = "li_errors"
+    # Output constants.
+    O_PHASE = "phase"
+    O_MESSAGE = "message"
+    O_TIME = "time_taken"
+    O_TIME_U = "time_unit"
+    O_TYPE = "type"
+    O_PRO_ITEMS = "processed_items"
+    O_GOAL_ITEMS = "goal_items"
+    O_PCT_DONE = "percent_done"
+    O_ITEM_U = "item_unit"
+    O_SPEED = "speed"
+    O_RUNNING = "running"
+    O_GOAL_PRO_ITEMS = "goal_processed_items"
+    O_REV_ITEMS = "reversioned_items"
+    O_GOAL_REV_ITEMS = "goal_reversion_items"
+    O_ADJ_ITEMS = "adjusted_items"
+    O_LI_OUTPUT = "li_output"
+    O_LI_ERROR = "li_errors"
 
-        def __init__(self, term_delay=TERM_DELAY, prog_event_handler=None):
-                CommandLineProgressTracker.__init__(self,
-                    term_delay=term_delay)
-                self.__prog_event_handler = prog_event_handler
+    def __init__(self, term_delay=TERM_DELAY, prog_event_handler=None):
+        CommandLineProgressTracker.__init__(self, term_delay=term_delay)
+        self.__prog_event_handler = prog_event_handler
 
-        def _phase_prefix(self):
-                if self.major_phase == self.PHASE_UTILITY:
-                        return "Utility"
+    def _phase_prefix(self):
+        if self.major_phase == self.PHASE_UTILITY:
+            return "Utility"
 
-                return self.phase_names[self.major_phase]
+        return self.phase_names[self.major_phase]
 
-        #
-        # Helper routines
-        #
-        def __prep_prog_json(self, msg=None, phase=None, prog_json=None):
-                # prepare progress json.
-                phase_name = self._phase_prefix()
-                if phase:
-                        phase_name = phase
-                if prog_json:
-                        return prog_json
-                else:
-                        return {self.O_PHASE: phase_name,
-                            self.O_MESSAGE: msg}
+    #
+    # Helper routines
+    #
+    def __prep_prog_json(self, msg=None, phase=None, prog_json=None):
+        # prepare progress json.
+        phase_name = self._phase_prefix()
+        if phase:
+            phase_name = phase
+        if prog_json:
+            return prog_json
+        else:
+            return {self.O_PHASE: phase_name, self.O_MESSAGE: msg}
 
-        def __handle_prog_output(self, prog_json, end="\n"):
-                # If event handler is set, report an event. Otherwise, print.
-                if self.__prog_event_handler:
-                        self.__prog_event_handler(event=prog_json)
-                else:
-                        self._pe.cprint(json.dumps(prog_json), end=end)
+    def __handle_prog_output(self, prog_json, end="\n"):
+        # If event handler is set, report an event. Otherwise, print.
+        if self.__prog_event_handler:
+            self.__prog_event_handler(event=prog_json)
+        else:
+            self._pe.cprint(json.dumps(prog_json), end=end)
 
-        def __generic_start(self, msg):
-                # In the case of listing/up-to-date check operations, we
-                # don't want to output planning information, so skip.
-                if self.purpose != self.PURPOSE_NORMAL:
-                        return
+    def __generic_start(self, msg):
+        # In the case of listing/up-to-date check operations, we
+        # don't want to output planning information, so skip.
+        if self.purpose != self.PURPOSE_NORMAL:
+            return
 
-                prog_json = self.__prep_prog_json(msg)
-                self.__handle_prog_output(prog_json)
-                # indicate that we just printed.
-                self._ptimer.reset_now()
+        prog_json = self.__prep_prog_json(msg)
+        self.__handle_prog_output(prog_json)
+        # indicate that we just printed.
+        self._ptimer.reset_now()
 
-        def __generic_done(self, msg=None, phase=None, prog_json=None):
-                # See __generic_start above.
-                if self.purpose != self.PURPOSE_NORMAL:
-                        return
-                if msg is None:
-                        msg = _("Done")
-                prog_json = self.__prep_prog_json(msg, phase, prog_json)
-                self.__handle_prog_output(prog_json, end='\n')
-                self._ptimer.reset()
+    def __generic_done(self, msg=None, phase=None, prog_json=None):
+        # See __generic_start above.
+        if self.purpose != self.PURPOSE_NORMAL:
+            return
+        if msg is None:
+            msg = _("Done")
+        prog_json = self.__prep_prog_json(msg, phase, prog_json)
+        self.__handle_prog_output(prog_json, end="\n")
+        self._ptimer.reset()
 
-        def __generic_done_item(self, item, msg=None):
-                # See __generic_start above.
-                if self.purpose != self.PURPOSE_NORMAL:
-                        return
-                if msg is None:
-                        if global_settings.client_output_verbose > 0:
-                                msg = _("Done ({elapsed:>.3f}s)")
-                        else:
-                                msg = _("Done")
-                outmsg = msg.format(elapsed=item.elapsed())
-                prog_json = self.__prep_prog_json(outmsg)
-                self.__handle_prog_output(prog_json, end='\n')
-                self._ptimer.reset()
+    def __generic_done_item(self, item, msg=None):
+        # See __generic_start above.
+        if self.purpose != self.PURPOSE_NORMAL:
+            return
+        if msg is None:
+            if global_settings.client_output_verbose > 0:
+                msg = _("Done ({elapsed:>.3f}s)")
+            else:
+                msg = _("Done")
+        outmsg = msg.format(elapsed=item.elapsed())
+        prog_json = self.__prep_prog_json(outmsg)
+        self.__handle_prog_output(prog_json, end="\n")
+        self._ptimer.reset()
 
-        def _change_purpose(self, op, np):
-                self._ptimer.reset()
-                if np == self.PURPOSE_PKG_UPDATE_CHK:
-                        prog_json = self.__prep_prog_json(
-                            _("Checking that pkg(7) is up to date ..."))
-                        self.__handle_prog_output(prog_json)
+    def _change_purpose(self, op, np):
+        self._ptimer.reset()
+        if np == self.PURPOSE_PKG_UPDATE_CHK:
+            prog_json = self.__prep_prog_json(
+                _("Checking that pkg(7) is up to date ...")
+            )
+            self.__handle_prog_output(prog_json)
 
-        def _cache_cats_output(self, outspec):
-                if outspec.first:
-                        self.__generic_start(_("Caching catalogs ..."))
-                if outspec.last:
-                        self.__generic_done()
+    def _cache_cats_output(self, outspec):
+        if outspec.first:
+            self.__generic_start(_("Caching catalogs ..."))
+        if outspec.last:
+            self.__generic_done()
 
-        def _load_cat_cache_output(self, outspec):
-                if outspec.first:
-                        self.__generic_start(_("Loading catalog cache ..."))
-                if outspec.last:
-                        self.__generic_done()
+    def _load_cat_cache_output(self, outspec):
+        if outspec.first:
+            self.__generic_start(_("Loading catalog cache ..."))
+        if outspec.last:
+            self.__generic_done()
 
-        def _refresh_output_progress(self, outspec):
-                # See __generic_start above.
-                if self.purpose != self.PURPOSE_NORMAL:
-                        return
-                if "startpublisher" in outspec.changed:
-                        p = self.pub_refresh.curinfo.prefix
-                        if self.refresh_target_catalog:
-                                m = _("Retrieving target catalog '{0}' "
-                                    "...").format(p)
-                        elif self.refresh_full_refresh:
-                                m = _("Retrieving catalog '{0}' ...").format(p)
-                        else:
-                                m = _("Refreshing catalog '{0}' ...").format(p)
-                        self.__generic_start(m)
-                elif "endpublisher" in outspec.changed:
-                        self.__generic_done()
+    def _refresh_output_progress(self, outspec):
+        # See __generic_start above.
+        if self.purpose != self.PURPOSE_NORMAL:
+            return
+        if "startpublisher" in outspec.changed:
+            p = self.pub_refresh.curinfo.prefix
+            if self.refresh_target_catalog:
+                m = _("Retrieving target catalog '{0}' " "...").format(p)
+            elif self.refresh_full_refresh:
+                m = _("Retrieving catalog '{0}' ...").format(p)
+            else:
+                m = _("Refreshing catalog '{0}' ...").format(p)
+            self.__generic_start(m)
+        elif "endpublisher" in outspec.changed:
+            self.__generic_done()
 
-        def _plan_output(self, outspec, planitem):
-                if outspec.first:
-                        self.__generic_start(_("{0} ...").format(planitem.name))
-                if outspec.last:
-                        self.__generic_done_item(planitem)
+    def _plan_output(self, outspec, planitem):
+        if outspec.first:
+            self.__generic_start(_("{0} ...").format(planitem.name))
+        if outspec.last:
+            self.__generic_done_item(planitem)
 
-        def _plan_output_all_done(self):
-                prog_json = {self.O_PHASE: self._phase_prefix(),
-                    self.O_MESSAGE: _("Planning completed"),
-                    self.O_TIME: self.plan_generic.elapsed(),
-                    self.O_TIME_U: _("second")}
-                self.__generic_done(prog_json=prog_json)
+    def _plan_output_all_done(self):
+        prog_json = {
+            self.O_PHASE: self._phase_prefix(),
+            self.O_MESSAGE: _("Planning completed"),
+            self.O_TIME: self.plan_generic.elapsed(),
+            self.O_TIME_U: _("second"),
+        }
+        self.__generic_done(prog_json=prog_json)
 
-        def _mfst_fetch(self, outspec):
-                if not self._ptimer.time_to_print() and \
-                    not outspec.first and not outspec.last:
-                        return
-                if self.purpose != self.PURPOSE_NORMAL:
-                        return
+    def _mfst_fetch(self, outspec):
+        if (
+            not self._ptimer.time_to_print()
+            and not outspec.first
+            and not outspec.last
+        ):
+            return
+        if self.purpose != self.PURPOSE_NORMAL:
+            return
 
-                # Reset timer; this prevents double printing for
-                # outspec.first and then again for the timer expiration
-                if outspec.first:
-                        self._ptimer.reset_now()
-
-                #
-                # There are a couple of reasons we might fetch manifests--
-                # pkgrecv, pkglint, etc. can all do this.  _phase_prefix()
-                # adjusts the output based on the major phase.
-                #
-                goalitems = self.mfst_fetch.goalitems
-                if goalitems is None:
-                        goalitems = 0
-                prog_json = {self.O_PHASE: self._phase_prefix(),
-                    self.O_MESSAGE: _("Fetching manifests"),
-                    self.O_PRO_ITEMS: self.mfst_fetch.items,
-                    self.O_GOAL_ITEMS: goalitems,
-                    self.O_PCT_DONE: int(self.mfst_fetch.pctdone()),
-                    self.O_ITEM_U: _("manifest")
-                    }
-                self.__handle_prog_output(prog_json)
-
-        def _dl_output(self, outspec):
-                if not self._ptimer.time_to_print() and not outspec.first and \
-                    not outspec.last:
-                        return
-
-                # Reset timer; this prevents double printing for
-                # outspec.first and then again for the timer expiration
-                if outspec.first:
-                        self._ptimer.reset_now()
-
-                if not outspec.last:
-                        speed = self.dl_estimator.get_speed_estimate()
-                else:
-                        speed = self.dl_estimator.get_final_speed()
-                speedstr = "" if speed is None else \
-                    "({0})".format(self.dl_estimator.format_speed(speed))
-
-                if not outspec.last:
-                        # 'first' or time to print
-                        prog_json = {
-                            self.O_PHASE: self._phase_prefix(),
-                            self.O_MESSAGE: _("Downloading"),
-                            self.O_PRO_ITEMS: self.dl_bytes.items,
-                            self.O_GOAL_ITEMS: self.dl_bytes.goalitems,
-                            self.O_PCT_DONE: int(self.dl_bytes.pctdone()),
-                            self.O_SPEED: speedstr,
-                            self.O_ITEM_U: _("byte")
-                            }
-                        self.__handle_prog_output(prog_json)
-                else:
-                        # 'last'
-                        prog_json = {self.O_PHASE: self._phase_prefix(),
-                            self.O_MESSAGE: _("Download completed"),
-                            self.O_PRO_ITEMS: self.dl_bytes.goalitems,
-                            self.O_SPEED: speedstr,
-                            self.O_ITEM_U: _("byte"),
-                            self.O_TIME: self.dl_estimator.elapsed(),
-                            self.O_TIME_U: _("second")
-                            }
-                        self.__generic_done(prog_json=prog_json)
-
-        def _republish_output(self, outspec):
-                if "startpkg" in outspec.changed:
-                        pkgfmri = self.repub_pkgs.curinfo
-                        self.__generic_start(_("Republish: {0} ... ").format(
-                            pkgfmri.get_fmri(anarchy=True)))
-                if "endpkg" in outspec.changed:
-                        self.__generic_done()
-
-        def _archive_output(self, outspec):
-                if not self._ptimer.time_to_print() and not outspec:
-                        return
-                if outspec.first:
-                        # tell ptimer that we just printed.
-                        self._ptimer.reset_now()
-
-                if outspec.last:
-                        prog_json = {self.O_PHASE: self._phase_prefix(),
-                            self.O_MESSAGE: _("Archiving completed"),
-                            self.O_PRO_ITEMS: self.archive_bytes.goalitems,
-                            self.O_ITEM_U: _("byte"),
-                            self.O_TIME: self.archive_items.elapsed(),
-                            self.O_TIME_U: _("second")
-                            }
-                        self.__generic_done(prog_json=prog_json)
-                        return
-
-                prog_json = {self.O_PHASE: self._phase_prefix(),
-                    self.O_MESSAGE: _("Archiving"),
-                    self.O_PRO_ITEMS: self.archive_bytes.items,
-                    self.O_GOAL_ITEMS: self.archive_bytes.goalitems,
-                    self.O_PCT_DONE: int(self.archive_bytes.pctdone()),
-                    self.O_ITEM_U: _("byte")
-                    }
-                self.__handle_prog_output(prog_json)
+        # Reset timer; this prevents double printing for
+        # outspec.first and then again for the timer expiration
+        if outspec.first:
+            self._ptimer.reset_now()
 
         #
-        # The progress tracking infrastructure wants to tell us about each
-        # kind of action activity (install, remove, update).  For this
-        # progress tracker, we don't really care to expose that to the user,
-        # so we work in terms of total actions instead.
+        # There are a couple of reasons we might fetch manifests--
+        # pkgrecv, pkglint, etc. can all do this.  _phase_prefix()
+        # adjusts the output based on the major phase.
         #
-        def _act_output(self, outspec, actionitem):
-                if not self._ptimer.time_to_print() and not outspec.first:
-                        return
-                # reset timer, since we're definitely printing now...
-                self._ptimer.reset_now()
-                total_actions = \
-                    sum(x.items for x in self._actionitems.values())
-                total_goal = \
-                    sum(x.goalitems for x in self._actionitems.values())
-                prog_json = {self.O_PHASE: self._phase_prefix(),
-                    self.O_MESSAGE: _("Action activity"),
-                    self.O_PRO_ITEMS: total_actions,
-                    self.O_GOAL_ITEMS: total_goal,
-                    self.O_TYPE: actionitem.name,
-                    self.O_ITEM_U: _("action")
-                    }
+        goalitems = self.mfst_fetch.goalitems
+        if goalitems is None:
+            goalitems = 0
+        prog_json = {
+            self.O_PHASE: self._phase_prefix(),
+            self.O_MESSAGE: _("Fetching manifests"),
+            self.O_PRO_ITEMS: self.mfst_fetch.items,
+            self.O_GOAL_ITEMS: goalitems,
+            self.O_PCT_DONE: int(self.mfst_fetch.pctdone()),
+            self.O_ITEM_U: _("manifest"),
+        }
+        self.__handle_prog_output(prog_json)
+
+    def _dl_output(self, outspec):
+        if (
+            not self._ptimer.time_to_print()
+            and not outspec.first
+            and not outspec.last
+        ):
+            return
+
+        # Reset timer; this prevents double printing for
+        # outspec.first and then again for the timer expiration
+        if outspec.first:
+            self._ptimer.reset_now()
+
+        if not outspec.last:
+            speed = self.dl_estimator.get_speed_estimate()
+        else:
+            speed = self.dl_estimator.get_final_speed()
+        speedstr = (
+            ""
+            if speed is None
+            else "({0})".format(self.dl_estimator.format_speed(speed))
+        )
+
+        if not outspec.last:
+            # 'first' or time to print
+            prog_json = {
+                self.O_PHASE: self._phase_prefix(),
+                self.O_MESSAGE: _("Downloading"),
+                self.O_PRO_ITEMS: self.dl_bytes.items,
+                self.O_GOAL_ITEMS: self.dl_bytes.goalitems,
+                self.O_PCT_DONE: int(self.dl_bytes.pctdone()),
+                self.O_SPEED: speedstr,
+                self.O_ITEM_U: _("byte"),
+            }
+            self.__handle_prog_output(prog_json)
+        else:
+            # 'last'
+            prog_json = {
+                self.O_PHASE: self._phase_prefix(),
+                self.O_MESSAGE: _("Download completed"),
+                self.O_PRO_ITEMS: self.dl_bytes.goalitems,
+                self.O_SPEED: speedstr,
+                self.O_ITEM_U: _("byte"),
+                self.O_TIME: self.dl_estimator.elapsed(),
+                self.O_TIME_U: _("second"),
+            }
+            self.__generic_done(prog_json=prog_json)
+
+    def _republish_output(self, outspec):
+        if "startpkg" in outspec.changed:
+            pkgfmri = self.repub_pkgs.curinfo
+            self.__generic_start(
+                _("Republish: {0} ... ").format(pkgfmri.get_fmri(anarchy=True))
+            )
+        if "endpkg" in outspec.changed:
+            self.__generic_done()
+
+    def _archive_output(self, outspec):
+        if not self._ptimer.time_to_print() and not outspec:
+            return
+        if outspec.first:
+            # tell ptimer that we just printed.
+            self._ptimer.reset_now()
+
+        if outspec.last:
+            prog_json = {
+                self.O_PHASE: self._phase_prefix(),
+                self.O_MESSAGE: _("Archiving completed"),
+                self.O_PRO_ITEMS: self.archive_bytes.goalitems,
+                self.O_ITEM_U: _("byte"),
+                self.O_TIME: self.archive_items.elapsed(),
+                self.O_TIME_U: _("second"),
+            }
+            self.__generic_done(prog_json=prog_json)
+            return
+
+        prog_json = {
+            self.O_PHASE: self._phase_prefix(),
+            self.O_MESSAGE: _("Archiving"),
+            self.O_PRO_ITEMS: self.archive_bytes.items,
+            self.O_GOAL_ITEMS: self.archive_bytes.goalitems,
+            self.O_PCT_DONE: int(self.archive_bytes.pctdone()),
+            self.O_ITEM_U: _("byte"),
+        }
+        self.__handle_prog_output(prog_json)
+
+    #
+    # The progress tracking infrastructure wants to tell us about each
+    # kind of action activity (install, remove, update).  For this
+    # progress tracker, we don't really care to expose that to the user,
+    # so we work in terms of total actions instead.
+    #
+    def _act_output(self, outspec, actionitem):
+        if not self._ptimer.time_to_print() and not outspec.first:
+            return
+        # reset timer, since we're definitely printing now...
+        self._ptimer.reset_now()
+        total_actions = sum(x.items for x in self._actionitems.values())
+        total_goal = sum(x.goalitems for x in self._actionitems.values())
+        prog_json = {
+            self.O_PHASE: self._phase_prefix(),
+            self.O_MESSAGE: _("Action activity"),
+            self.O_PRO_ITEMS: total_actions,
+            self.O_GOAL_ITEMS: total_goal,
+            self.O_TYPE: actionitem.name,
+            self.O_ITEM_U: _("action"),
+        }
+        self.__handle_prog_output(prog_json)
+
+    def _act_output_all_done(self):
+        total_goal = sum(x.goalitems for x in self._actionitems.values())
+        total_time = sum(x.elapsed() for x in self._actionitems.values())
+        if total_goal == 0:
+            return
+
+        prog_json = {
+            self.O_PHASE: self._phase_prefix(),
+            self.O_MESSAGE: _("Completed actions activities"),
+            self.O_PRO_ITEMS: total_goal,
+            self.O_ITEM_U: _("action"),
+            self.O_TIME: total_time,
+            self.O_TIME_U: _("second"),
+        }
+        self.__handle_prog_output(prog_json)
+
+    def _job_output(self, outspec, jobitem):
+        if outspec.first:
+            self.__generic_start("{0} ... ".format(jobitem.name))
+        if outspec.last:
+            self.__generic_done_item(jobitem)
+
+    def _lint_output(self, outspec):
+        if outspec.first:
+            if self.lint_phasetype == self.LINT_PHASETYPE_SETUP:
+                msg = "{0} ... ".format(self.lintitems.name)
+                prog_json = {self.O_PHASE: _("Setup"), self.O_MESSAGE: msg}
                 self.__handle_prog_output(prog_json)
-
-        def _act_output_all_done(self):
-                total_goal = \
-                    sum(x.goalitems for x in self._actionitems.values())
-                total_time = \
-                    sum(x.elapsed() for x in self._actionitems.values())
-                if total_goal == 0:
-                        return
-
-                prog_json = {self.O_PHASE: self._phase_prefix(),
-                    self.O_MESSAGE: _("Completed actions activities"),
-                    self.O_PRO_ITEMS: total_goal,
-                    self.O_ITEM_U: _("action"),
-                    self.O_TIME: total_time,
-                    self.O_TIME_U: _("second")
-                    }
+            elif self.lint_phasetype == self.LINT_PHASETYPE_EXECUTE:
+                msg = "# --- {0} ---".format(self.lintitems.name)
+                prog_json = {self.O_PHASE: _("Execute"), self.O_MESSAGE: msg}
                 self.__handle_prog_output(prog_json)
-
-        def _job_output(self, outspec, jobitem):
-                if outspec.first:
-                        self.__generic_start("{0} ... ".format(jobitem.name))
-                if outspec.last:
-                        self.__generic_done_item(jobitem)
-
-        def _lint_output(self, outspec):
-                if outspec.first:
-                        if self.lint_phasetype == self.LINT_PHASETYPE_SETUP:
-                                msg = "{0} ... ".format(
-                                    self.lintitems.name)
-                                prog_json = {self.O_PHASE: _("Setup"),
-                                    self.O_MESSAGE: msg
-                                    }
-                                self.__handle_prog_output(prog_json)
-                        elif self.lint_phasetype == self.LINT_PHASETYPE_EXECUTE:
-                                msg = "# --- {0} ---".format(
-                                    self.lintitems.name)
-                                prog_json = {self.O_PHASE: _("Execute"),
-                                    self.O_MESSAGE: msg
-                                    }
-                                self.__handle_prog_output(prog_json)
-                if outspec.last:
-                        if self.lint_phasetype == self.LINT_PHASETYPE_SETUP:
-                                self.__generic_done(phase=_("Setup"))
-                        elif self.lint_phasetype == self.LINT_PHASETYPE_EXECUTE:
-                                pass
-
-        def _li_recurse_start_output(self):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
-                        self.__generic_start(
-                            _("Linked image publisher check ..."))
-                        return
-                elif self.linked_pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
-                        self.__generic_start(
-                            _("Cleaning up hot-fix origins ..."))
-                        return
-
-        def _li_recurse_end_output(self):
-                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
-                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
-                        self.__generic_done()
-                        return
-                prog_json = self.__prep_prog_json(
-                    _("Finished processing linked images."))
-                self.__handle_prog_output(prog_json)
-
-        def __li_dump_output(self, output):
-                if not output:
-                        return []
-                lines = output.splitlines()
-                return lines
-
-        def _li_recurse_output_output(self, lin, stdout, stderr):
-                if not stdout and not stderr:
-                        return
-                prog_json = {self.O_PHASE: self._phase_prefix(),
-                    self.O_MESSAGE: _("Linked image '{0}' output:").format(lin)}
-                prog_json[self.O_LI_OUTPUT] = self.__li_dump_output(stdout)
-                prog_json[self.O_LI_ERROR] = self.__li_dump_output(stderr)
-                self.__handle_prog_output(prog_json)
-
-        def _li_recurse_status_output(self, done):
-                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
-                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
-                        return
-
-                prog_json = {self.O_PHASE: self._phase_prefix(),
-                    self.O_MESSAGE: _("Linked images status"),
-                    self.O_PRO_ITEMS: done,
-                    self.O_GOAL_ITEMS: self.linked_total,
-                    self.O_ITEM_U: _("linked image"),
-                    self.O_RUNNING: [str(i) for i in self.linked_running]
-                    }
-
-                self.__handle_prog_output(prog_json)
-
-        def _li_recurse_progress_output(self, lin):
-                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
-                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
-                        return
-
-        def _reversion(self, pfmri, outspec):
-                if not self._ptimer.time_to_print() and not outspec:
-                        return
-
-                if outspec.first:
-                        # tell ptimer that we just printed.
-                        self._ptimer.reset_now()
-
-                if outspec.last:
-                        prog_json = {self.O_PHASE: _("Reversion"),
-                            self.O_MESSAGE: _("Done"),
-                            self.O_PRO_ITEMS: self.reversion_pkgs.items,
-                            self.O_REV_ITEMS: self.reversion_revs.items,
-                            self.O_ADJ_ITEMS: self.reversion_adjs.items,
-                            self.O_ITEM_U: _("package")
-                            }
-                        self.__generic_done(prog_json=prog_json)
-                        return
-
-                prog_json = {self.O_PHASE: _("Reversion"),
-                    self.O_MESSAGE: "Reversioning",
-                    self.O_PRO_ITEMS: self.reversion_pkgs.items,
-                    self.O_GOAL_PRO_ITEMS: self.reversion_pkgs.goalitems,
-                    self.O_REV_ITEMS: self.reversion_revs.items,
-                    self.O_GOAL_REV_ITEMS: self.reversion_revs.goalitems,
-                    self.O_ADJ_ITEMS: self.reversion_adjs.items,
-                    self.O_ITEM_U: _("package")
-                    }
-                self.__handle_prog_output(prog_json)
-
-        @classmethod
-        def get_json_schema(cls):
-                """Construct json schema."""
-
-                json_schema = {"$schema":
-                    "http://json-schema.org/draft-04/schema#",
-                    "title": "progress schema",
-                    "type": "object",
-                    "properties": {cls.O_PHASE:  {"type": "string"},
-                        cls.O_MESSAGE: {"type": "string"},
-                        cls.O_TIME: {"type": "number"},
-                        cls.O_TIME_U: {"type": "string"},
-                        cls.O_TYPE: {"type": "string"},
-                        cls.O_PRO_ITEMS: {"type": "number"},
-                        cls.O_GOAL_ITEMS: {"type": "number"},
-                        cls.O_PCT_DONE: {"type": "number"},
-                        cls.O_ITEM_U: {"type": "string"},
-                        cls.O_SPEED: {"type": "string"},
-                        cls.O_RUNNING: {"type": "array"},
-                        cls.O_GOAL_PRO_ITEMS: {"type": "number"},
-                        cls.O_REV_ITEMS : {"type": "number"},
-                        cls.O_GOAL_REV_ITEMS: {"type": "number"},
-                        cls.O_ADJ_ITEMS: {"type": "number"},
-                        cls.O_LI_OUTPUT : {"type": "array"},
-                        cls.O_LI_ERROR : {"type": "array"},
-                        },
-                    "required":  [cls.O_PHASE, cls.O_MESSAGE]
-                }
-                return json_schema
-
-class LinkedChildProgressTracker(CommandLineProgressTracker):
-        """This tracker is used for recursion with linked children.
-        This is intended for use only by linked images."""
-
-        def __init__(self, output_file):
-                CommandLineProgressTracker.__init__(self, output_file)
-
-                # We modify the instance such that everything except for the
-                # linked image methods are no-opped out.  In multi-level
-                # recursion, this ensures that output from children is
-                # displayed.
-
-                def __donothing(*args, **kwargs):
-                        # Unused argument 'args', 'kwargs';
-                        #     pylint: disable=W0613
-                        pass
-
-                for methname in ProgressTrackerBackend.__dict__:
-                        if methname == "__init__":
-                                continue
-                        if methname.startswith("_li_recurse"):
-                                continue
-                        boundmeth = getattr(self, methname)
-                        if not inspect.ismethod(boundmeth):
-                                continue
-                        setattr(self, methname, __donothing)
-
-class FancyUNIXProgressTracker(ProgressTracker):
-        """This progress tracker is designed for UNIX-like OS's-- those which
-        have UNIX-like terminal semantics.  It attempts to load the 'curses'
-        package.  If that or other terminal-liveness tests fail, it gives up:
-        the client should pick some other more suitable tracker.  (Probably
-        CommandLineProgressTracker)."""
-
-        #
-        # The minimum interval (in seconds) at which we should update the
-        # display during operations which produce a lot of output.  Needed to
-        # avoid spamming a slow terminal.
-        #
-        TERM_DELAY = 0.10
-        TERM_DELAY_SLOW = 0.25
-
-        def __init__(self, output_file=sys.stdout, term_delay=None):
-                ProgressTracker.__init__(self)
-
-                try:
-                        self._pe = printengine.POSIXPrintEngine(output_file,
-                            ttymode=True)
-                except printengine.PrintEngineException as e:
-                        raise ProgressTrackerException(
-                            "Couldn't create print engine: {0}".format(
-                            " ".join(e.args)))
-
-                if term_delay is None:
-                        term_delay = self.TERM_DELAY_SLOW if self._pe.isslow() \
-                            else self.TERM_DELAY
-                self._ptimer = PrintTimer(term_delay)
-
-                self._phases_hdr_printed = False
-                self._jobs_lastjob = None
-
-                if not output_file.isatty():
-                        raise ProgressTrackerException(
-                            "output_file is not a TTY")
-
-                self.__spinner_chars = "|/-\\"
-
-                # For linked image spinners.
-                self.__linked_spinners = []
-
-        #
-        # Overridden methods from ProgressTrackerBackend
-        #
-        def _output_flush(self):
-                self._pe.flush()
-
-        def __generic_start(self, msg):
-                # Ensure the last message displayed is flushed in case the
-                # corresponding operation did not complete successfully.
-                self.__generic_done()
-                self._pe.cprint(msg, end='', erase=True)
-
-        def __generic_done(self):
-                self._pe.cprint("", end='', erase=True)
-                self._ptimer.reset()
-
-        def __generic_done_newline(self):
-                self._pe.cprint("")
-                self._ptimer.reset()
-
-        def _spinner(self):
-                sp = self._ptimer.print_value % len(self.__spinner_chars)
-                return self.__spinner_chars[sp]
-
-        def _up2date(self):
-                if not self._ptimer.time_to_print():
-                        return
-                self._pe.cprint(
-                    _("Checking that pkg(7) is up to date {0}").format(
-                    self._spinner()), end='', erase=True)
-
-        # Unused argument 'op'; pylint: disable=W0613
-        def _change_purpose(self, op, np):
-                self._ptimer.reset()
-                if np == self.PURPOSE_PKG_UPDATE_CHK:
-                        self._up2date()
-
-        def _cache_cats_output(self, outspec):
-                if outspec.first:
-                        self.__generic_start(_("Caching catalogs ..."))
-                if outspec.last:
-                        self.__generic_done()
-
-        def _load_cat_cache_output(self, outspec):
-                if outspec.first:
-                        self.__generic_start(_("Loading catalog cache ..."))
-                if outspec.last:
-                        self.__generic_done()
-
-        def _refresh_output_progress(self, outspec):
-                if self.purpose == self.PURPOSE_PKG_UPDATE_CHK:
-                        self._up2date()
-                        return
-                if self._ptimer.time_to_print() and not outspec:
-                        return
-
-                # for very small xfers (like when we just get the attrs) this
-                # isn't very interesting, so elide it.
-                if self.pub_refresh_bytes.items <= 32 * 1024:
-                        nbytes = ""
-                else:
-                        nbytes = " " + \
-                            misc.bytes_to_str(self.pub_refresh_bytes.items)
-
-                if self.refresh_target_catalog:
-                        prefix = _("Retrieving target catalog")
-                elif self.refresh_full_refresh:
-                        prefix = _("Retrieving catalog")
-                else:
-                        prefix = _("Refreshing catalog")
-                msg = _("{prefix} {pub_cnt} {publisher}{bytes}").format(
-                    prefix=prefix,
-                    pub_cnt=self.pub_refresh.pairplus1(),
-                    publisher=self.pub_refresh.curinfo,
-                    bytes=nbytes)
-
-                self._pe.cprint(msg, end="", erase=True)
-                if outspec.last:
-                        self.__generic_done()
-
-        def _plan_output(self, outspec, planitem):
-                if self.purpose == self.PURPOSE_PKG_UPDATE_CHK:
-                        self._up2date()
-                        return
-                if outspec.first:
-                        self.__generic_start("")
-                if not self._ptimer.time_to_print() and not outspec:
-                        return
-
-                extra_info = ""
-                if isinstance(planitem, GoalTrackerItem):
-                        extra_info = ": {0}".format(planitem.pair())
-                msg = _("Creating Plan ({name}{info}): {spinner}").format(
-                    name=planitem.name,
-                    info=extra_info,
-                    spinner=self._spinner())
-                self._pe.cprint(msg, sep='', end='', erase=True)
-
-        def _plan_output_all_done(self):
-                self.__generic_done()
-
-        def _mfst_fetch(self, outspec):
-                if self.purpose == self.PURPOSE_PKG_UPDATE_CHK:
-                        self._up2date()
-                        return
-                if outspec.first:
-                        self.__generic_start("")
-                if not self._ptimer.time_to_print() and not outspec:
-                        return
-
-                #
-                # There are a couple of reasons we might fetch manifests--
-                # pkgrecv, pkglint, etc. can all do this.  So we adjust
-                # the output based on the major mode.
-                #
-                if self.major_phase == self.PHASE_PLAN:
-                        msg = _("Creating Plan ({name} {pair}) "
-                            "{spinner}").format(
-                            name=self.mfst_fetch.name,
-                            pair=self.mfst_fetch.pair(),
-                            spinner=self._spinner())
-                if self.major_phase == self.PHASE_UTILITY:
-                        # note to translators: the position of these strings
-                        # should probably be left alone, as they form part of
-                        # the progress output text.
-                        msg = _("{name} ({fetchpair}) {spinchar}").format(
-                            name=self.mfst_fetch.name,
-                            fetchpair=self.mfst_fetch.pair(),
-                            spinchar=self._spinner())
-                self._pe.cprint(msg, sep='', end='', erase=True)
-
-                if outspec.last:
-                        self.__generic_done()
-
-        def _reversion(self, pfmri, outspec):
-
-                if not self._ptimer.time_to_print() and not outspec:
-                        return
-
-                if isinstance(pfmri, pkg.fmri.PkgFmri):
-                        stem = pfmri.get_pkg_stem(anarchy=True)
-                else:
-                        stem = pfmri
-
-                # The first time, emit header.
-                if outspec.first:
-                        self._pe.cprint("{0:38} {1:>13} {2:>13} {3:>11}".format(
-                            _("PKG"), _("Processed"), _("Reversioned"),
-                            _("Adjusted")))
-
-                s = "{0:<40.40} {1:>11} {2:>13} {3:>11}".format(
-                    stem, self.reversion_pkgs.pair(),
-                    self.reversion_revs.pair(), self.reversion_adjs.items)
-                self._pe.cprint(s, end='', erase=True)
-
-                if outspec.last:
-                        self.__generic_done_newline()
-
-        def _mfst_commit(self, outspec):
-                if self.purpose == self.PURPOSE_PKG_UPDATE_CHK:
-                        self._up2date()
-                        return
-                if not self._ptimer.time_to_print():
-                        return
-                if self.major_phase == self.PHASE_PLAN:
-                        msg = _("Creating Plan (Committing Manifests): "
-                            "{0}").format(self._spinner())
-                if self.major_phase == self.PHASE_UTILITY:
-                        msg = _("Committing Manifests {0}").format(
-                            self._spinner())
-                self._pe.cprint(msg, sep='', end='', erase=True)
-                return
-
-        def _repo_ver_output(self, outspec, repository_scan=False):
-                """If 'repository_scan' is set and we have no FRMRI set, we emit
-                a message saying that we're performing a scan if the repository.
-                If we have no FMRI, we emit a message saying we don't know what
-                package we're looking at.
-
-                """
-                if not self.repo_ver_pkgs.curinfo:
-                        if repository_scan:
-                                pkg_stem = _("Scanning repository "
-                                    "(this could take some time)")
-                        else:
-                                pkg_stem = _("Unknown package")
-                else:
-                        pkg_stem = self.repo_ver_pkgs.curinfo.get_pkg_stem()
-                if not self._ptimer.time_to_print() and not outspec:
-                        return
-                if "endpkg" in outspec.changed:
-                        self._pe.cprint("", end='', erase=True)
-                        return
-                s = "{0:64} {1} {2}".format(
-                    pkg_stem, self.repo_ver_pkgs.pair(), self._spinner())
-                self._pe.cprint(s, end='', erase=True)
-
-        def _repo_ver_output_error(self, errors):
-                self._output_flush()
-                self._pe.cprint(errors)
-
-        def _repo_fix_output(self, outspec):
-                s = "{0}".format( self._spinner())
-                self._pe.cprint(s, end='', erase=True)
-
-        def _repo_fix_output_error(self, errors):
-                self._output_flush()
-                self._pe.cprint(errors)
-
-        def _repo_fix_output_info(self, info):
-                self._output_flush()
-                self._pe.cprint(info)
-
-        def _archive_output(self, outspec):
-                if not self._ptimer.time_to_print() and not outspec:
-                        return
-
-                # The first time, emit header.
-                if outspec.first:
-                        self._pe.cprint("{0:44} {1:>13} {2:>11}".format(
-                            _("ARCHIVE"), _("FILES"), _("STORE (MB)")))
-
-                mbs = format_pair("{0:.1f}", self.archive_bytes.items,
-                    self.archive_bytes.goalitems, scale=(1024 * 1024),
-                    targetwidth=5, format2="{0:d}")
-                s = "{0:<44.44} {1:>11} {2:>11}".format(
-                    self._archive_name, self.archive_items.pair(), mbs)
-                self._pe.cprint(s, end='', erase=True)
-
-                if outspec.last:
-                        self.__generic_done_newline()
-
-        def _dl_output(self, outspec):
-                if not self._ptimer.time_to_print() and not outspec.first \
-                    and not outspec.last and not "startpkg" in outspec.changed \
-                    and not "endpkg" in outspec.changed:
-                        return
-
-                # The first time, emit header.
-                if outspec.first:
-                        self._pe.cprint("{0:34} {1:>9} {2:>13} {3:>12} "
-                            "{4:>7}".format(_("DOWNLOAD"), _("PKGS"),
-                            _("FILES"), _("XFER (MB)"), _("SPEED")))
-
-                if outspec.last:
-                        pkg_name = _("Completed")
-                        speed = self.dl_estimator.get_final_speed()
-                else:
-                        pkg_name = self.dl_pkgs.curinfo.get_name()
-                        speed = self.dl_estimator.get_speed_estimate()
-                if len(pkg_name) > 34:
-                        pkg_name = "..." + pkg_name[-30:]
-                # show speed if greater than 0, otherwise "--"
-                if speed is not None and speed > 0:
-                        speedstr = self.dl_estimator.format_speed(speed)
-                else:
-                        speedstr = "--"
-
-                # Use floats unless it makes the field too wide
-                mbstr = format_pair("{0:.1f}", self.dl_bytes.items,
-                    self.dl_bytes.goalitems, scale=1024.0 * 1024.0,
-                    targetwidth=5, format2="{0:d}")
-                s = "{0:<34.34} {1:>9} {2:>13} {3:>12} {4:>7}".format(
-                    pkg_name, self.dl_pkgs.pair(), self.dl_files.pair(),
-                    mbstr, speedstr)
-                self._pe.cprint(s, end='', erase=True)
-
-                if outspec.last:
-                        self.__generic_done_newline()
-                        self.__generic_done_newline()
-
-        def _republish_output(self, outspec):
-                if not outspec.first and not outspec.last \
-                    and not self._ptimer.time_to_print():
-                        return
-
-                # The first time, emit header.
-                if outspec.first:
-                        self._pe.cprint("{0:40} {1:>12} {2:>11} {3:>11}".format(
-                            _("PROCESS"), _("ITEMS"), _("GET (MB)"),
-                            _("SEND (MB)")))
-
-                if outspec.last:
-                        pkg_name = "Completed"
-                else:
-                        pkg_name = self.repub_pkgs.curinfo.get_name()
-                if len(pkg_name) > 40:
-                        pkg_name = "..." + pkg_name[-37:]
-
-                s = "{0:<40.40} {1:>12} {2:>11} {3:>11}".format(
-                    pkg_name, self.repub_pkgs.pair(),
-                    format_pair("{0:.1f}", self.dl_bytes.items,
-                        self.dl_bytes.goalitems, scale=(1024 * 1024),
-                        targetwidth=5, format2="{0:d}"),
-                    format_pair("{0:.1f}", self.repub_send_bytes.items,
-                        self.repub_send_bytes.goalitems, scale=(1024 * 1024),
-                        targetwidth=5, format2="{0:d}"))
-                self._pe.cprint(s, erase=True, end='')
-
-                if outspec.last:
-                        self.__generic_done_newline()
-                        self.__generic_done_newline()
-
-        def _print_phases_hdr(self):
-                if self._phases_hdr_printed:
-                        return
-                self._pe.cprint("{0:40} {1:>11}".format(_("PHASE"), _("ITEMS")))
-                self._phases_hdr_printed = True
-
-        def _act_output(self, outspec, actionitem):
-                if actionitem.goalitems == 0:
-                        return
-                # emit header if needed
-                if outspec.first:
-                        self._print_phases_hdr()
-
-                if not self._ptimer.time_to_print() and \
-                    not outspec.last and not outspec.first:
-                        return
-                self._pe.cprint("{0:40} {1:>11}".format(
-                    actionitem.name, actionitem.pair()), end='', erase=True)
-                if outspec.last:
-                        self.__generic_done_newline()
-
-        def _act_output_all_done(self):
+        if outspec.last:
+            if self.lint_phasetype == self.LINT_PHASETYPE_SETUP:
+                self.__generic_done(phase=_("Setup"))
+            elif self.lint_phasetype == self.LINT_PHASETYPE_EXECUTE:
                 pass
 
-        def _job_output(self, outspec, jobitem):
-                if not self._ptimer.time_to_print() and not outspec and \
-                    jobitem == self._jobs_lastjob:
-                        return
-                self._jobs_lastjob = jobitem
+    def _li_recurse_start_output(self):
+        if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+            self.__generic_start(_("Linked image publisher check ..."))
+            return
+        elif self.linked_pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
+            self.__generic_start(_("Cleaning up hot-fix origins ..."))
+            return
 
-                # emit phases header if needed
-                if outspec.first:
-                        self._print_phases_hdr()
+    def _li_recurse_end_output(self):
+        if self.linked_pkg_op in [
+            pkgdefs.PKG_OP_PUBCHECK,
+            pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+        ]:
+            self.__generic_done()
+            return
+        prog_json = self.__prep_prog_json(
+            _("Finished processing linked images.")
+        )
+        self.__handle_prog_output(prog_json)
 
-                spin = "" if outspec.last else self._spinner()
-                if isinstance(jobitem, GoalTrackerItem):
-                        val = jobitem.pair()
-                else:
-                        val = _("Done") if outspec.last else _("working")
+    def __li_dump_output(self, output):
+        if not output:
+            return []
+        lines = output.splitlines()
+        return lines
 
-                self._pe.cprint("{0:40} {1:>11} {2}".format(jobitem.name,
-                    val, spin), end='', erase=True)
-                if outspec.last:
-                        self.__generic_done_newline()
+    def _li_recurse_output_output(self, lin, stdout, stderr):
+        if not stdout and not stderr:
+            return
+        prog_json = {
+            self.O_PHASE: self._phase_prefix(),
+            self.O_MESSAGE: _("Linked image '{0}' output:").format(lin),
+        }
+        prog_json[self.O_LI_OUTPUT] = self.__li_dump_output(stdout)
+        prog_json[self.O_LI_ERROR] = self.__li_dump_output(stderr)
+        self.__handle_prog_output(prog_json)
 
-        def _lint_output(self, outspec):
-                if not self._ptimer.time_to_print() and not outspec.last:
-                        return
-                self._pe.cprint("{0:40} {1:>11}".format(self.lintitems.name,
-                    self.lintitems.pair()), end='', erase=True)
-                if outspec.last:
-                        self.__generic_done()
+    def _li_recurse_status_output(self, done):
+        if self.linked_pkg_op in [
+            pkgdefs.PKG_OP_PUBCHECK,
+            pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+        ]:
+            return
 
-        def _li_recurse_start_output(self):
-                if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
-                        self.__generic_start(
-                            _("Linked image publisher check"))
-                        return
-                elif self.linked_pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
-                        self.__generic_start(
-                            _("Cleaning up hot-fix origins ..."))
-                        return
+        prog_json = {
+            self.O_PHASE: self._phase_prefix(),
+            self.O_MESSAGE: _("Linked images status"),
+            self.O_PRO_ITEMS: done,
+            self.O_GOAL_ITEMS: self.linked_total,
+            self.O_ITEM_U: _("linked image"),
+            self.O_RUNNING: [str(i) for i in self.linked_running],
+        }
 
-        def _li_recurse_end_output(self):
-                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
-                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
-                        return
-                msg = _("{phasename} linked: {numdone} done").format(
-                    phasename=self.li_phase_names[self.major_phase],
-                    numdone=format_pair("{0:d}", self.linked_total,
-                        self.linked_total))
-                self._pe.cprint(msg, erase=True)
+        self.__handle_prog_output(prog_json)
 
-        def __li_dump_output(self, output):
-                if not output:
-                        return
-                lines = output.splitlines()
-                nlines = len(lines)
-                for linenum, line in enumerate(lines):
-                        line = misc.force_str(line)
-                        if linenum < nlines - 1:
-                                self._pe.cprint("| " + line)
-                        else:
-                                if lines[linenum].strip() != "":
-                                        self._pe.cprint("| " + line)
-                                self._pe.cprint("`")
+    def _li_recurse_progress_output(self, lin):
+        if self.linked_pkg_op in [
+            pkgdefs.PKG_OP_PUBCHECK,
+            pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+        ]:
+            return
 
-        def _li_recurse_output_output(self, lin, stdout, stderr):
-                if not stdout and not stderr:
-                        self._pe.cprint("", erase=True, end='')
-                        return
+    def _reversion(self, pfmri, outspec):
+        if not self._ptimer.time_to_print() and not outspec:
+            return
 
-                self._pe.cprint(_("Linked image '{0}' output:").format(lin),
-                    erase=True)
-                self.__li_dump_output(stdout)
-                self.__li_dump_output(stderr)
+        if outspec.first:
+            # tell ptimer that we just printed.
+            self._ptimer.reset_now()
 
-        def _li_recurse_status_output(self, done):
-                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
-                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
-                        return
+        if outspec.last:
+            prog_json = {
+                self.O_PHASE: _("Reversion"),
+                self.O_MESSAGE: _("Done"),
+                self.O_PRO_ITEMS: self.reversion_pkgs.items,
+                self.O_REV_ITEMS: self.reversion_revs.items,
+                self.O_ADJ_ITEMS: self.reversion_adjs.items,
+                self.O_ITEM_U: _("package"),
+            }
+            self.__generic_done(prog_json=prog_json)
+            return
 
-                assert self.major_phase in self.li_phase_names, self.major_phase
+        prog_json = {
+            self.O_PHASE: _("Reversion"),
+            self.O_MESSAGE: "Reversioning",
+            self.O_PRO_ITEMS: self.reversion_pkgs.items,
+            self.O_GOAL_PRO_ITEMS: self.reversion_pkgs.goalitems,
+            self.O_REV_ITEMS: self.reversion_revs.items,
+            self.O_GOAL_REV_ITEMS: self.reversion_revs.goalitems,
+            self.O_ADJ_ITEMS: self.reversion_adjs.items,
+            self.O_ITEM_U: _("package"),
+        }
+        self.__handle_prog_output(prog_json)
 
-                running = " ".join([str(i) for i in self.linked_running])
-                msg = _("{phase} linked: {numdone} done; "
-                    "{numworking:d} working: {running}").format(
-                    phase=self.li_phase_names[self.major_phase],
-                    numdone=format_pair("{0:d}", done, self.linked_total),
-                    numworking=len(self.linked_running),
-                    running=running)
-                self._pe.cprint(msg, erase=True)
+    @classmethod
+    def get_json_schema(cls):
+        """Construct json schema."""
 
-                self.__linked_spinners = list(
-                    itertools.repeat(0, len(self.linked_running)))
+        json_schema = {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "title": "progress schema",
+            "type": "object",
+            "properties": {
+                cls.O_PHASE: {"type": "string"},
+                cls.O_MESSAGE: {"type": "string"},
+                cls.O_TIME: {"type": "number"},
+                cls.O_TIME_U: {"type": "string"},
+                cls.O_TYPE: {"type": "string"},
+                cls.O_PRO_ITEMS: {"type": "number"},
+                cls.O_GOAL_ITEMS: {"type": "number"},
+                cls.O_PCT_DONE: {"type": "number"},
+                cls.O_ITEM_U: {"type": "string"},
+                cls.O_SPEED: {"type": "string"},
+                cls.O_RUNNING: {"type": "array"},
+                cls.O_GOAL_PRO_ITEMS: {"type": "number"},
+                cls.O_REV_ITEMS: {"type": "number"},
+                cls.O_GOAL_REV_ITEMS: {"type": "number"},
+                cls.O_ADJ_ITEMS: {"type": "number"},
+                cls.O_LI_OUTPUT: {"type": "array"},
+                cls.O_LI_ERROR: {"type": "array"},
+            },
+            "required": [cls.O_PHASE, cls.O_MESSAGE],
+        }
+        return json_schema
 
-        def _li_recurse_progress_output(self, lin):
-                if self.linked_pkg_op in [pkgdefs.PKG_OP_PUBCHECK,
-                    pkgdefs.PKG_OP_HOTFIX_CLEANUP]:
-                        return
-                if not self._ptimer.time_to_print():
-                        return
-                # find the index of the child that made progress
-                i = self.linked_running.index(lin)
 
-                # update that child's spinner
-                self.__linked_spinners[i] = \
-                    (self.__linked_spinners[i] + 1) % len(self.__spinner_chars)
-                spinners = "".join([
-                        self.__spinner_chars[i]
-                        for i in self.__linked_spinners
-                ])
-                self._pe.cprint(_("Linked progress: {0}").format(spinners),
-                    end='', erase=True)
+class LinkedChildProgressTracker(CommandLineProgressTracker):
+    """This tracker is used for recursion with linked children.
+    This is intended for use only by linked images."""
+
+    def __init__(self, output_file):
+        CommandLineProgressTracker.__init__(self, output_file)
+
+        # We modify the instance such that everything except for the
+        # linked image methods are no-opped out.  In multi-level
+        # recursion, this ensures that output from children is
+        # displayed.
+
+        def __donothing(*args, **kwargs):
+            # Unused argument 'args', 'kwargs';
+            #     pylint: disable=W0613
+            pass
+
+        for methname in ProgressTrackerBackend.__dict__:
+            if methname == "__init__":
+                continue
+            if methname.startswith("_li_recurse"):
+                continue
+            boundmeth = getattr(self, methname)
+            if not inspect.ismethod(boundmeth):
+                continue
+            setattr(self, methname, __donothing)
+
+
+class FancyUNIXProgressTracker(ProgressTracker):
+    """This progress tracker is designed for UNIX-like OS's-- those which
+    have UNIX-like terminal semantics.  It attempts to load the 'curses'
+    package.  If that or other terminal-liveness tests fail, it gives up:
+    the client should pick some other more suitable tracker.  (Probably
+    CommandLineProgressTracker)."""
+
+    #
+    # The minimum interval (in seconds) at which we should update the
+    # display during operations which produce a lot of output.  Needed to
+    # avoid spamming a slow terminal.
+    #
+    TERM_DELAY = 0.10
+    TERM_DELAY_SLOW = 0.25
+
+    def __init__(self, output_file=sys.stdout, term_delay=None):
+        ProgressTracker.__init__(self)
+
+        try:
+            self._pe = printengine.POSIXPrintEngine(output_file, ttymode=True)
+        except printengine.PrintEngineException as e:
+            raise ProgressTrackerException(
+                "Couldn't create print engine: {0}".format(" ".join(e.args))
+            )
+
+        if term_delay is None:
+            term_delay = (
+                self.TERM_DELAY_SLOW if self._pe.isslow() else self.TERM_DELAY
+            )
+        self._ptimer = PrintTimer(term_delay)
+
+        self._phases_hdr_printed = False
+        self._jobs_lastjob = None
+
+        if not output_file.isatty():
+            raise ProgressTrackerException("output_file is not a TTY")
+
+        self.__spinner_chars = "|/-\\"
+
+        # For linked image spinners.
+        self.__linked_spinners = []
+
+    #
+    # Overridden methods from ProgressTrackerBackend
+    #
+    def _output_flush(self):
+        self._pe.flush()
+
+    def __generic_start(self, msg):
+        # Ensure the last message displayed is flushed in case the
+        # corresponding operation did not complete successfully.
+        self.__generic_done()
+        self._pe.cprint(msg, end="", erase=True)
+
+    def __generic_done(self):
+        self._pe.cprint("", end="", erase=True)
+        self._ptimer.reset()
+
+    def __generic_done_newline(self):
+        self._pe.cprint("")
+        self._ptimer.reset()
+
+    def _spinner(self):
+        sp = self._ptimer.print_value % len(self.__spinner_chars)
+        return self.__spinner_chars[sp]
+
+    def _up2date(self):
+        if not self._ptimer.time_to_print():
+            return
+        self._pe.cprint(
+            _("Checking that pkg(7) is up to date {0}").format(self._spinner()),
+            end="",
+            erase=True,
+        )
+
+    # Unused argument 'op'; pylint: disable=W0613
+    def _change_purpose(self, op, np):
+        self._ptimer.reset()
+        if np == self.PURPOSE_PKG_UPDATE_CHK:
+            self._up2date()
+
+    def _cache_cats_output(self, outspec):
+        if outspec.first:
+            self.__generic_start(_("Caching catalogs ..."))
+        if outspec.last:
+            self.__generic_done()
+
+    def _load_cat_cache_output(self, outspec):
+        if outspec.first:
+            self.__generic_start(_("Loading catalog cache ..."))
+        if outspec.last:
+            self.__generic_done()
+
+    def _refresh_output_progress(self, outspec):
+        if self.purpose == self.PURPOSE_PKG_UPDATE_CHK:
+            self._up2date()
+            return
+        if self._ptimer.time_to_print() and not outspec:
+            return
+
+        # for very small xfers (like when we just get the attrs) this
+        # isn't very interesting, so elide it.
+        if self.pub_refresh_bytes.items <= 32 * 1024:
+            nbytes = ""
+        else:
+            nbytes = " " + misc.bytes_to_str(self.pub_refresh_bytes.items)
+
+        if self.refresh_target_catalog:
+            prefix = _("Retrieving target catalog")
+        elif self.refresh_full_refresh:
+            prefix = _("Retrieving catalog")
+        else:
+            prefix = _("Refreshing catalog")
+        msg = _("{prefix} {pub_cnt} {publisher}{bytes}").format(
+            prefix=prefix,
+            pub_cnt=self.pub_refresh.pairplus1(),
+            publisher=self.pub_refresh.curinfo,
+            bytes=nbytes,
+        )
+
+        self._pe.cprint(msg, end="", erase=True)
+        if outspec.last:
+            self.__generic_done()
+
+    def _plan_output(self, outspec, planitem):
+        if self.purpose == self.PURPOSE_PKG_UPDATE_CHK:
+            self._up2date()
+            return
+        if outspec.first:
+            self.__generic_start("")
+        if not self._ptimer.time_to_print() and not outspec:
+            return
+
+        extra_info = ""
+        if isinstance(planitem, GoalTrackerItem):
+            extra_info = ": {0}".format(planitem.pair())
+        msg = _("Creating Plan ({name}{info}): {spinner}").format(
+            name=planitem.name, info=extra_info, spinner=self._spinner()
+        )
+        self._pe.cprint(msg, sep="", end="", erase=True)
+
+    def _plan_output_all_done(self):
+        self.__generic_done()
+
+    def _mfst_fetch(self, outspec):
+        if self.purpose == self.PURPOSE_PKG_UPDATE_CHK:
+            self._up2date()
+            return
+        if outspec.first:
+            self.__generic_start("")
+        if not self._ptimer.time_to_print() and not outspec:
+            return
+
+        #
+        # There are a couple of reasons we might fetch manifests--
+        # pkgrecv, pkglint, etc. can all do this.  So we adjust
+        # the output based on the major mode.
+        #
+        if self.major_phase == self.PHASE_PLAN:
+            msg = _("Creating Plan ({name} {pair}) " "{spinner}").format(
+                name=self.mfst_fetch.name,
+                pair=self.mfst_fetch.pair(),
+                spinner=self._spinner(),
+            )
+        if self.major_phase == self.PHASE_UTILITY:
+            # note to translators: the position of these strings
+            # should probably be left alone, as they form part of
+            # the progress output text.
+            msg = _("{name} ({fetchpair}) {spinchar}").format(
+                name=self.mfst_fetch.name,
+                fetchpair=self.mfst_fetch.pair(),
+                spinchar=self._spinner(),
+            )
+        self._pe.cprint(msg, sep="", end="", erase=True)
+
+        if outspec.last:
+            self.__generic_done()
+
+    def _reversion(self, pfmri, outspec):
+        if not self._ptimer.time_to_print() and not outspec:
+            return
+
+        if isinstance(pfmri, pkg.fmri.PkgFmri):
+            stem = pfmri.get_pkg_stem(anarchy=True)
+        else:
+            stem = pfmri
+
+        # The first time, emit header.
+        if outspec.first:
+            self._pe.cprint(
+                "{0:38} {1:>13} {2:>13} {3:>11}".format(
+                    _("PKG"), _("Processed"), _("Reversioned"), _("Adjusted")
+                )
+            )
+
+        s = "{0:<40.40} {1:>11} {2:>13} {3:>11}".format(
+            stem,
+            self.reversion_pkgs.pair(),
+            self.reversion_revs.pair(),
+            self.reversion_adjs.items,
+        )
+        self._pe.cprint(s, end="", erase=True)
+
+        if outspec.last:
+            self.__generic_done_newline()
+
+    def _mfst_commit(self, outspec):
+        if self.purpose == self.PURPOSE_PKG_UPDATE_CHK:
+            self._up2date()
+            return
+        if not self._ptimer.time_to_print():
+            return
+        if self.major_phase == self.PHASE_PLAN:
+            msg = _("Creating Plan (Committing Manifests): " "{0}").format(
+                self._spinner()
+            )
+        if self.major_phase == self.PHASE_UTILITY:
+            msg = _("Committing Manifests {0}").format(self._spinner())
+        self._pe.cprint(msg, sep="", end="", erase=True)
+        return
+
+    def _repo_ver_output(self, outspec, repository_scan=False):
+        """If 'repository_scan' is set and we have no FRMRI set, we emit
+        a message saying that we're performing a scan if the repository.
+        If we have no FMRI, we emit a message saying we don't know what
+        package we're looking at.
+
+        """
+        if not self.repo_ver_pkgs.curinfo:
+            if repository_scan:
+                pkg_stem = _(
+                    "Scanning repository " "(this could take some time)"
+                )
+            else:
+                pkg_stem = _("Unknown package")
+        else:
+            pkg_stem = self.repo_ver_pkgs.curinfo.get_pkg_stem()
+        if not self._ptimer.time_to_print() and not outspec:
+            return
+        if "endpkg" in outspec.changed:
+            self._pe.cprint("", end="", erase=True)
+            return
+        s = "{0:64} {1} {2}".format(
+            pkg_stem, self.repo_ver_pkgs.pair(), self._spinner()
+        )
+        self._pe.cprint(s, end="", erase=True)
+
+    def _repo_ver_output_error(self, errors):
+        self._output_flush()
+        self._pe.cprint(errors)
+
+    def _repo_fix_output(self, outspec):
+        s = "{0}".format(self._spinner())
+        self._pe.cprint(s, end="", erase=True)
+
+    def _repo_fix_output_error(self, errors):
+        self._output_flush()
+        self._pe.cprint(errors)
+
+    def _repo_fix_output_info(self, info):
+        self._output_flush()
+        self._pe.cprint(info)
+
+    def _archive_output(self, outspec):
+        if not self._ptimer.time_to_print() and not outspec:
+            return
+
+        # The first time, emit header.
+        if outspec.first:
+            self._pe.cprint(
+                "{0:44} {1:>13} {2:>11}".format(
+                    _("ARCHIVE"), _("FILES"), _("STORE (MB)")
+                )
+            )
+
+        mbs = format_pair(
+            "{0:.1f}",
+            self.archive_bytes.items,
+            self.archive_bytes.goalitems,
+            scale=(1024 * 1024),
+            targetwidth=5,
+            format2="{0:d}",
+        )
+        s = "{0:<44.44} {1:>11} {2:>11}".format(
+            self._archive_name, self.archive_items.pair(), mbs
+        )
+        self._pe.cprint(s, end="", erase=True)
+
+        if outspec.last:
+            self.__generic_done_newline()
+
+    def _dl_output(self, outspec):
+        if (
+            not self._ptimer.time_to_print()
+            and not outspec.first
+            and not outspec.last
+            and not "startpkg" in outspec.changed
+            and not "endpkg" in outspec.changed
+        ):
+            return
+
+        # The first time, emit header.
+        if outspec.first:
+            self._pe.cprint(
+                "{0:34} {1:>9} {2:>13} {3:>12} "
+                "{4:>7}".format(
+                    _("DOWNLOAD"),
+                    _("PKGS"),
+                    _("FILES"),
+                    _("XFER (MB)"),
+                    _("SPEED"),
+                )
+            )
+
+        if outspec.last:
+            pkg_name = _("Completed")
+            speed = self.dl_estimator.get_final_speed()
+        else:
+            pkg_name = self.dl_pkgs.curinfo.get_name()
+            speed = self.dl_estimator.get_speed_estimate()
+        if len(pkg_name) > 34:
+            pkg_name = "..." + pkg_name[-30:]
+        # show speed if greater than 0, otherwise "--"
+        if speed is not None and speed > 0:
+            speedstr = self.dl_estimator.format_speed(speed)
+        else:
+            speedstr = "--"
+
+        # Use floats unless it makes the field too wide
+        mbstr = format_pair(
+            "{0:.1f}",
+            self.dl_bytes.items,
+            self.dl_bytes.goalitems,
+            scale=1024.0 * 1024.0,
+            targetwidth=5,
+            format2="{0:d}",
+        )
+        s = "{0:<34.34} {1:>9} {2:>13} {3:>12} {4:>7}".format(
+            pkg_name, self.dl_pkgs.pair(), self.dl_files.pair(), mbstr, speedstr
+        )
+        self._pe.cprint(s, end="", erase=True)
+
+        if outspec.last:
+            self.__generic_done_newline()
+            self.__generic_done_newline()
+
+    def _republish_output(self, outspec):
+        if (
+            not outspec.first
+            and not outspec.last
+            and not self._ptimer.time_to_print()
+        ):
+            return
+
+        # The first time, emit header.
+        if outspec.first:
+            self._pe.cprint(
+                "{0:40} {1:>12} {2:>11} {3:>11}".format(
+                    _("PROCESS"), _("ITEMS"), _("GET (MB)"), _("SEND (MB)")
+                )
+            )
+
+        if outspec.last:
+            pkg_name = "Completed"
+        else:
+            pkg_name = self.repub_pkgs.curinfo.get_name()
+        if len(pkg_name) > 40:
+            pkg_name = "..." + pkg_name[-37:]
+
+        s = "{0:<40.40} {1:>12} {2:>11} {3:>11}".format(
+            pkg_name,
+            self.repub_pkgs.pair(),
+            format_pair(
+                "{0:.1f}",
+                self.dl_bytes.items,
+                self.dl_bytes.goalitems,
+                scale=(1024 * 1024),
+                targetwidth=5,
+                format2="{0:d}",
+            ),
+            format_pair(
+                "{0:.1f}",
+                self.repub_send_bytes.items,
+                self.repub_send_bytes.goalitems,
+                scale=(1024 * 1024),
+                targetwidth=5,
+                format2="{0:d}",
+            ),
+        )
+        self._pe.cprint(s, erase=True, end="")
+
+        if outspec.last:
+            self.__generic_done_newline()
+            self.__generic_done_newline()
+
+    def _print_phases_hdr(self):
+        if self._phases_hdr_printed:
+            return
+        self._pe.cprint("{0:40} {1:>11}".format(_("PHASE"), _("ITEMS")))
+        self._phases_hdr_printed = True
+
+    def _act_output(self, outspec, actionitem):
+        if actionitem.goalitems == 0:
+            return
+        # emit header if needed
+        if outspec.first:
+            self._print_phases_hdr()
+
+        if (
+            not self._ptimer.time_to_print()
+            and not outspec.last
+            and not outspec.first
+        ):
+            return
+        self._pe.cprint(
+            "{0:40} {1:>11}".format(actionitem.name, actionitem.pair()),
+            end="",
+            erase=True,
+        )
+        if outspec.last:
+            self.__generic_done_newline()
+
+    def _act_output_all_done(self):
+        pass
+
+    def _job_output(self, outspec, jobitem):
+        if (
+            not self._ptimer.time_to_print()
+            and not outspec
+            and jobitem == self._jobs_lastjob
+        ):
+            return
+        self._jobs_lastjob = jobitem
+
+        # emit phases header if needed
+        if outspec.first:
+            self._print_phases_hdr()
+
+        spin = "" if outspec.last else self._spinner()
+        if isinstance(jobitem, GoalTrackerItem):
+            val = jobitem.pair()
+        else:
+            val = _("Done") if outspec.last else _("working")
+
+        self._pe.cprint(
+            "{0:40} {1:>11} {2}".format(jobitem.name, val, spin),
+            end="",
+            erase=True,
+        )
+        if outspec.last:
+            self.__generic_done_newline()
+
+    def _lint_output(self, outspec):
+        if not self._ptimer.time_to_print() and not outspec.last:
+            return
+        self._pe.cprint(
+            "{0:40} {1:>11}".format(self.lintitems.name, self.lintitems.pair()),
+            end="",
+            erase=True,
+        )
+        if outspec.last:
+            self.__generic_done()
+
+    def _li_recurse_start_output(self):
+        if self.linked_pkg_op == pkgdefs.PKG_OP_PUBCHECK:
+            self.__generic_start(_("Linked image publisher check"))
+            return
+        elif self.linked_pkg_op == pkgdefs.PKG_OP_HOTFIX_CLEANUP:
+            self.__generic_start(_("Cleaning up hot-fix origins ..."))
+            return
+
+    def _li_recurse_end_output(self):
+        if self.linked_pkg_op in [
+            pkgdefs.PKG_OP_PUBCHECK,
+            pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+        ]:
+            return
+        msg = _("{phasename} linked: {numdone} done").format(
+            phasename=self.li_phase_names[self.major_phase],
+            numdone=format_pair("{0:d}", self.linked_total, self.linked_total),
+        )
+        self._pe.cprint(msg, erase=True)
+
+    def __li_dump_output(self, output):
+        if not output:
+            return
+        lines = output.splitlines()
+        nlines = len(lines)
+        for linenum, line in enumerate(lines):
+            line = misc.force_str(line)
+            if linenum < nlines - 1:
+                self._pe.cprint("| " + line)
+            else:
+                if lines[linenum].strip() != "":
+                    self._pe.cprint("| " + line)
+                self._pe.cprint("`")
+
+    def _li_recurse_output_output(self, lin, stdout, stderr):
+        if not stdout and not stderr:
+            self._pe.cprint("", erase=True, end="")
+            return
+
+        self._pe.cprint(_("Linked image '{0}' output:").format(lin), erase=True)
+        self.__li_dump_output(stdout)
+        self.__li_dump_output(stderr)
+
+    def _li_recurse_status_output(self, done):
+        if self.linked_pkg_op in [
+            pkgdefs.PKG_OP_PUBCHECK,
+            pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+        ]:
+            return
+
+        assert self.major_phase in self.li_phase_names, self.major_phase
+
+        running = " ".join([str(i) for i in self.linked_running])
+        msg = _(
+            "{phase} linked: {numdone} done; "
+            "{numworking:d} working: {running}"
+        ).format(
+            phase=self.li_phase_names[self.major_phase],
+            numdone=format_pair("{0:d}", done, self.linked_total),
+            numworking=len(self.linked_running),
+            running=running,
+        )
+        self._pe.cprint(msg, erase=True)
+
+        self.__linked_spinners = list(
+            itertools.repeat(0, len(self.linked_running))
+        )
+
+    def _li_recurse_progress_output(self, lin):
+        if self.linked_pkg_op in [
+            pkgdefs.PKG_OP_PUBCHECK,
+            pkgdefs.PKG_OP_HOTFIX_CLEANUP,
+        ]:
+            return
+        if not self._ptimer.time_to_print():
+            return
+        # find the index of the child that made progress
+        i = self.linked_running.index(lin)
+
+        # update that child's spinner
+        self.__linked_spinners[i] = (self.__linked_spinners[i] + 1) % len(
+            self.__spinner_chars
+        )
+        spinners = "".join(
+            [self.__spinner_chars[i] for i in self.__linked_spinners]
+        )
+        self._pe.cprint(
+            _("Linked progress: {0}").format(spinners), end="", erase=True
+        )
 
 
 #
@@ -3191,219 +3428,223 @@ class FancyUNIXProgressTracker(ProgressTracker):
 # utility.
 #
 def test_progress_tracker(t, gofast=False):
-        # Unused variables (in several loops) pylint: disable=W0612
-        import random
+    # Unused variables (in several loops) pylint: disable=W0612
+    import random
 
-        print("Use ctrl-c to skip sections")
+    print("Use ctrl-c to skip sections")
 
-        if not gofast:
-                fast = 1.0
-        else:
-                fast = 0.10
+    if not gofast:
+        fast = 1.0
+    else:
+        fast = 0.10
 
-        global_settings.client_output_verbose = 1
+    global_settings.client_output_verbose = 1
 
-        dlscript = {
-            "chrysler/lebaron": [],
-            "mazda/mx-5": [],
-            "acura/tsx": [],
-            "honda/civic-si": [],
-            "a-very-very-long-package-name-which-will-have-to-be-truncated": [],
-        }
+    dlscript = {
+        "chrysler/lebaron": [],
+        "mazda/mx-5": [],
+        "acura/tsx": [],
+        "honda/civic-si": [],
+        "a-very-very-long-package-name-which-will-have-to-be-truncated": [],
+    }
 
-        for purp in [ProgressTracker.PURPOSE_PKG_UPDATE_CHK,
-            ProgressTracker.PURPOSE_NORMAL]:
-                t.set_purpose(purp)
+    for purp in [
+        ProgressTracker.PURPOSE_PKG_UPDATE_CHK,
+        ProgressTracker.PURPOSE_NORMAL,
+    ]:
+        t.set_purpose(purp)
+        try:
+            t.refresh_start(4, full_refresh=False)
+            for x in ["woop", "gub", "zip", "yowee"]:
+                p = publisher.Publisher(x)
+                t.refresh_start_pub(p)
+                time.sleep(0.10 * fast)
+                t.refresh_progress(x, 1024 * 8)
+                time.sleep(0.10 * fast)
+                t.refresh_progress(x, 0)
+                time.sleep(0.10 * fast)
+                t.refresh_progress(x, 1024 * 128)
+                t.refresh_end_pub(p)
+            t.refresh_done()
+
+            t.cache_catalogs_start()
+            time.sleep(0.25 * fast)
+            t.cache_catalogs_done()
+
+            t.load_catalog_cache_start()
+            time.sleep(0.25 * fast)
+            t.load_catalog_cache_done()
+
+        except KeyboardInterrupt:
+            t.flush()
+
+        try:
+            t.set_major_phase(t.PHASE_PLAN)
+            planids = sorted(
+                [
+                    v
+                    for k, v in ProgressTrackerFrontend.__dict__.items()
+                    if k.startswith("PLAN_")
+                ]
+            )
+            t.plan_all_start()
+            for planid in planids:
+                r = random.randint(20, 100)
+                # we always try to set a goal; this will fail
+                # for ungoaled items, so then we try again
+                # without a goal.  This saves us the complicated
+                # task of inspecting the tracker-- and
+                # multiprogress makes such inspection much
+                # harder.
                 try:
-                        t.refresh_start(4, full_refresh=False)
-                        for x in ["woop", "gub", "zip", "yowee"]:
-                                p = publisher.Publisher(x)
-                                t.refresh_start_pub(p)
-                                time.sleep(0.10 * fast)
-                                t.refresh_progress(x, 1024 * 8)
-                                time.sleep(0.10 * fast)
-                                t.refresh_progress(x, 0)
-                                time.sleep(0.10 * fast)
-                                t.refresh_progress(x, 1024 * 128)
-                                t.refresh_end_pub(p)
-                        t.refresh_done()
-
-                        t.cache_catalogs_start()
-                        time.sleep(0.25 * fast)
-                        t.cache_catalogs_done()
-
-                        t.load_catalog_cache_start()
-                        time.sleep(0.25 * fast)
-                        t.load_catalog_cache_done()
-
-                except KeyboardInterrupt:
-                        t.flush()
-
-                try:
-                        t.set_major_phase(t.PHASE_PLAN)
-                        planids = sorted([v for k, v in
-                            ProgressTrackerFrontend.__dict__.items()
-                            if k.startswith("PLAN_")])
-                        t.plan_all_start()
-                        for planid in planids:
-                                r = random.randint(20, 100)
-                                # we always try to set a goal; this will fail
-                                # for ungoaled items, so then we try again
-                                # without a goal.  This saves us the complicated
-                                # task of inspecting the tracker-- and
-                                # multiprogress makes such inspection much
-                                # harder.
-                                try:
-                                        t.plan_start(planid, goal=r)
-                                except RuntimeError:
-                                        t.plan_start(planid)
-                                for x in range(0, r):
-                                        t.plan_add_progress(planid)
-                                        time.sleep(0.02 * fast)
-                                t.plan_done(planid)
-                        t.plan_all_done()
-                except KeyboardInterrupt:
-                        t.flush()
-
-                try:
-                        t.manifest_fetch_start(len(dlscript))
-                        for pkgnm in dlscript:
-                                t.manifest_fetch_progress(
-                                    completion=False)
-                                time.sleep(0.05 * fast)
-                                t.manifest_fetch_progress(
-                                    completion=True)
-                                time.sleep(0.05 * fast)
-                        for pkgnm in dlscript:
-                                t.manifest_commit()
-                                time.sleep(0.05 * fast)
-                        t.manifest_fetch_done()
-                except KeyboardInterrupt:
-                        t.flush()
-
-        perpkgfiles = 50
-        pkggoalfiles = len(dlscript) * perpkgfiles
-        pkggoalbytes = 0
-        filesizemax = 250000
-        hunkmax = 8192
-        approx_time = 5.0 * fast   # how long we want the dl to take
-        # invent a list of random download chunks.
-        for pkgname, filelist in six.iteritems(dlscript):
-                for f in range(0, perpkgfiles):
-                        filesize = random.randint(0, filesizemax)
-                        hunks = []
-                        while filesize > 0:
-                                delta = min(filesize,
-                                    random.randint(0, hunkmax))
-                                hunks.append(delta)
-                                filesize -= delta
-                                pkggoalbytes += delta
-                        filelist.append(hunks)
-
-        # pylint is picky about this message:
-        # old-division; pylint: disable=W1619
-        pauseperfile = approx_time / pkggoalfiles
+                    t.plan_start(planid, goal=r)
+                except RuntimeError:
+                    t.plan_start(planid)
+                for x in range(0, r):
+                    t.plan_add_progress(planid)
+                    time.sleep(0.02 * fast)
+                t.plan_done(planid)
+            t.plan_all_done()
+        except KeyboardInterrupt:
+            t.flush()
 
         try:
-                t.download_set_goal(len(dlscript), pkggoalfiles, pkggoalbytes)
-                n = 0
-                for pkgname, pkgfiles in six.iteritems(dlscript):
-                        fmri = pkg.fmri.PkgFmri(pkgname)
-                        t.download_start_pkg(fmri)
-                        for pkgfile in pkgfiles:
-                                for hunk in pkgfile:
-                                        t.download_add_progress(0, hunk)
-                                t.download_add_progress(1, 0)
-                                time.sleep(pauseperfile)
-                        t.download_end_pkg(fmri)
-                t.download_done()
+            t.manifest_fetch_start(len(dlscript))
+            for pkgnm in dlscript:
+                t.manifest_fetch_progress(completion=False)
+                time.sleep(0.05 * fast)
+                t.manifest_fetch_progress(completion=True)
+                time.sleep(0.05 * fast)
+            for pkgnm in dlscript:
+                t.manifest_commit()
+                time.sleep(0.05 * fast)
+            t.manifest_fetch_done()
         except KeyboardInterrupt:
-                t.flush()
+            t.flush()
 
-        try:
-                t.reset_download()
-                t.republish_set_goal(len(dlscript), pkggoalbytes, pkggoalbytes)
-                n = 0
-                for pkgname, pkgfiles in six.iteritems(dlscript):
-                        fmri = pkg.fmri.PkgFmri(pkgname)
-                        t.republish_start_pkg(fmri)
-                        for pkgfile in pkgfiles:
-                                for hunk in pkgfile:
-                                        t.download_add_progress(0, hunk)
-                                        t.upload_add_progress(hunk)
-                                t.download_add_progress(1, 0)
-                                time.sleep(pauseperfile)
-                        t.republish_end_pkg(fmri)
-                t.republish_done()
-        except KeyboardInterrupt:
-                t.flush()
+    perpkgfiles = 50
+    pkggoalfiles = len(dlscript) * perpkgfiles
+    pkggoalbytes = 0
+    filesizemax = 250000
+    hunkmax = 8192
+    approx_time = 5.0 * fast  # how long we want the dl to take
+    # invent a list of random download chunks.
+    for pkgname, filelist in six.iteritems(dlscript):
+        for f in range(0, perpkgfiles):
+            filesize = random.randint(0, filesizemax)
+            hunks = []
+            while filesize > 0:
+                delta = min(filesize, random.randint(0, hunkmax))
+                hunks.append(delta)
+                filesize -= delta
+                pkggoalbytes += delta
+            filelist.append(hunks)
 
-        try:
-                t.reset_download()
-                t.archive_set_goal("testarchive", pkggoalfiles, pkggoalbytes)
-                n = 0
-                for pkgname, pkgfiles in six.iteritems(dlscript):
-                        for pkgfile in pkgfiles:
-                                for hunk in pkgfile:
-                                        t.archive_add_progress(0, hunk)
-                                t.archive_add_progress(1, 0)
-                                time.sleep(pauseperfile)
-                t.archive_done()
-        except KeyboardInterrupt:
-                t.flush()
-        try:
-                t.set_major_phase(t.PHASE_EXECUTE)
+    # pylint is picky about this message:
+    # old-division; pylint: disable=W1619
+    pauseperfile = approx_time / pkggoalfiles
 
-                nactions = 100
-                t.actions_set_goal(t.ACTION_REMOVE, nactions)
-                t.actions_set_goal(t.ACTION_INSTALL, nactions)
-                t.actions_set_goal(t.ACTION_UPDATE, nactions)
-                for act in [t.ACTION_REMOVE, t.ACTION_INSTALL, t.ACTION_UPDATE]:
-                        for x in range(0, nactions):
-                                t.actions_add_progress(act)
-                                time.sleep(0.0015 * fast)
-                        t.actions_done(act)
-                t.actions_all_done()
-        except KeyboardInterrupt:
-                t.flush()
+    try:
+        t.download_set_goal(len(dlscript), pkggoalfiles, pkggoalbytes)
+        n = 0
+        for pkgname, pkgfiles in six.iteritems(dlscript):
+            fmri = pkg.fmri.PkgFmri(pkgname)
+            t.download_start_pkg(fmri)
+            for pkgfile in pkgfiles:
+                for hunk in pkgfile:
+                    t.download_add_progress(0, hunk)
+                t.download_add_progress(1, 0)
+                time.sleep(pauseperfile)
+            t.download_end_pkg(fmri)
+        t.download_done()
+    except KeyboardInterrupt:
+        t.flush()
 
-        try:
-                t.set_major_phase(t.PHASE_FINALIZE)
-                for jobname, job in ProgressTrackerFrontend.__dict__.items():
-                        if not jobname.startswith("JOB_"):
-                                continue
-                        r = random.randint(5, 30)
-                        # we always try to set a goal; this will fail for
-                        # ungoaled items, so then we try again without a goal.
-                        # This saves us the complicated task of inspecting the
-                        # tracker-- and multiprogress makes such inspection
-                        # much harder.
-                        try:
-                                t.job_start(job, goal=r)
-                        except RuntimeError:
-                                t.job_start(job)
+    try:
+        t.reset_download()
+        t.republish_set_goal(len(dlscript), pkggoalbytes, pkggoalbytes)
+        n = 0
+        for pkgname, pkgfiles in six.iteritems(dlscript):
+            fmri = pkg.fmri.PkgFmri(pkgname)
+            t.republish_start_pkg(fmri)
+            for pkgfile in pkgfiles:
+                for hunk in pkgfile:
+                    t.download_add_progress(0, hunk)
+                    t.upload_add_progress(hunk)
+                t.download_add_progress(1, 0)
+                time.sleep(pauseperfile)
+            t.republish_end_pkg(fmri)
+        t.republish_done()
+    except KeyboardInterrupt:
+        t.flush()
 
-                        for x in range(0, r):
-                                t.job_add_progress(job)
-                                time.sleep(0.02 * fast)
-                        t.job_done(job)
-        except KeyboardInterrupt:
-                t.flush()
+    try:
+        t.reset_download()
+        t.archive_set_goal("testarchive", pkggoalfiles, pkggoalbytes)
+        n = 0
+        for pkgname, pkgfiles in six.iteritems(dlscript):
+            for pkgfile in pkgfiles:
+                for hunk in pkgfile:
+                    t.archive_add_progress(0, hunk)
+                t.archive_add_progress(1, 0)
+                time.sleep(pauseperfile)
+        t.archive_done()
+    except KeyboardInterrupt:
+        t.flush()
+    try:
+        t.set_major_phase(t.PHASE_EXECUTE)
 
-        try:
-                # do some other things to drive up test coverage.
-                t.flush()
+        nactions = 100
+        t.actions_set_goal(t.ACTION_REMOVE, nactions)
+        t.actions_set_goal(t.ACTION_INSTALL, nactions)
+        t.actions_set_goal(t.ACTION_UPDATE, nactions)
+        for act in [t.ACTION_REMOVE, t.ACTION_INSTALL, t.ACTION_UPDATE]:
+            for x in range(0, nactions):
+                t.actions_add_progress(act)
+                time.sleep(0.0015 * fast)
+            t.actions_done(act)
+        t.actions_all_done()
+    except KeyboardInterrupt:
+        t.flush()
 
-                # test lint
-                for phase in [t.LINT_PHASETYPE_SETUP, t.LINT_PHASETYPE_EXECUTE]:
-                        t.lint_next_phase(2, phase)
-                        for x in range(0, 100):
-                                t.lint_add_progress()
-                                time.sleep(0.02 * fast)
-                t.lint_done()
-        except KeyboardInterrupt:
-                t.flush()
-        return
+    try:
+        t.set_major_phase(t.PHASE_FINALIZE)
+        for jobname, job in ProgressTrackerFrontend.__dict__.items():
+            if not jobname.startswith("JOB_"):
+                continue
+            r = random.randint(5, 30)
+            # we always try to set a goal; this will fail for
+            # ungoaled items, so then we try again without a goal.
+            # This saves us the complicated task of inspecting the
+            # tracker-- and multiprogress makes such inspection
+            # much harder.
+            try:
+                t.job_start(job, goal=r)
+            except RuntimeError:
+                t.job_start(job)
+
+            for x in range(0, r):
+                t.job_add_progress(job)
+                time.sleep(0.02 * fast)
+            t.job_done(job)
+    except KeyboardInterrupt:
+        t.flush()
+
+    try:
+        # do some other things to drive up test coverage.
+        t.flush()
+
+        # test lint
+        for phase in [t.LINT_PHASETYPE_SETUP, t.LINT_PHASETYPE_EXECUTE]:
+            t.lint_next_phase(2, phase)
+            for x in range(0, 100):
+                t.lint_add_progress()
+                time.sleep(0.02 * fast)
+        t.lint_done()
+    except KeyboardInterrupt:
+        t.flush()
+    return
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/publisher.py
+++ b/src/modules/client/publisher.py
@@ -55,8 +55,13 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from io import BytesIO
-from six.moves.urllib.parse import quote, urlsplit, urlparse, urlunparse, \
-    ParseResult
+from six.moves.urllib.parse import (
+    quote,
+    urlsplit,
+    urlparse,
+    urlunparse,
+    ParseResult,
+)
 from six.moves.urllib.request import url2pathname
 
 import pkg.catalog
@@ -70,6 +75,7 @@ import pkg.server.catalog as old_catalog
 
 from pkg.client import global_settings
 from pkg.client.debugvalues import DebugValues
+
 logger = global_settings.logger
 from pkg.misc import EmptyDict, EmptyI, SIGNATURE_POLICY, DictProperty
 
@@ -92,7 +98,7 @@ REPO_COLLECTION_TYPES = {
 
 # Supported Protocol Schemes
 SUPPORTED_SCHEMES = set(("file", "http", "https"))
-SUPPORTED_PROXY_SCHEMES = ("http")
+SUPPORTED_PROXY_SCHEMES = "http"
 
 # SSL Protocol Schemes
 SSL_SCHEMES = set(("https",))
@@ -111,9 +117,17 @@ URI_SORT_POLICIES = {
 # and vice versa.
 EXTENSIONS_VALUES = {
     x509.BasicConstraints: ["ca", "path_length"],
-    x509.KeyUsage: ["digital_signature", "content_commitment",
-    "key_encipherment", "data_encipherment", "key_agreement", "key_cert_sign",
-    "crl_sign", "encipher_only", "decipher_only"]
+    x509.KeyUsage: [
+        "digital_signature",
+        "content_commitment",
+        "key_encipherment",
+        "data_encipherment",
+        "key_agreement",
+        "key_cert_sign",
+        "crl_sign",
+        "encipher_only",
+        "decipher_only",
+    ],
 }
 
 # Only listed extension values (properties) here can have a value True set in a
@@ -121,7 +135,7 @@ EXTENSIONS_VALUES = {
 # treated as unsupported.
 SUPPORTED_EXTENSION_VALUES = {
     x509.BasicConstraints: ("ca", "path_length"),
-    x509.KeyUsage: ("digital_signature", "key_cert_sign", "crl_sign")
+    x509.KeyUsage: ("digital_signature", "key_cert_sign", "crl_sign"),
 }
 
 # These dictionaries map uses into their extensions.
@@ -145,981 +159,1139 @@ POSSIBLE_USES = [CODE_SIGNING_USE, CERT_SIGNING_USE, CRL_SIGNING_USE]
 # system-repository.
 SYSREPO_PROXY = "<sysrepo>"
 
+
 class RepositoryURI(object):
-        """Class representing a repository URI and any transport-related
-        information."""
+    """Class representing a repository URI and any transport-related
+    information."""
 
-        # These properties are declared here so that they show up in the pydoc
-        # documentation as private, and for clarity in the property declarations
-        # found near the end of the class definition.
-        __priority = None
-        __proxies = None
-        __ssl_cert = None
-        __ssl_key = None
-        __trailing_slash = None
-        __uri = None
-        __disabled = False
-        __system = False
+    # These properties are declared here so that they show up in the pydoc
+    # documentation as private, and for clarity in the property declarations
+    # found near the end of the class definition.
+    __priority = None
+    __proxies = None
+    __ssl_cert = None
+    __ssl_key = None
+    __trailing_slash = None
+    __uri = None
+    __disabled = False
+    __system = False
 
-        # Used to store the id of the original object this one was copied
-        # from during __copy__.
-        _source_object_id = None
+    # Used to store the id of the original object this one was copied
+    # from during __copy__.
+    _source_object_id = None
 
-        def __init__(self, uri, priority=None, ssl_cert=None, ssl_key=None,
-            trailing_slash=True, proxy=None, system=False, proxies=None,
-            disabled=False):
+    def __init__(
+        self,
+        uri,
+        priority=None,
+        ssl_cert=None,
+        ssl_key=None,
+        trailing_slash=True,
+        proxy=None,
+        system=False,
+        proxies=None,
+        disabled=False,
+    ):
+        # Must set first.
+        self.__trailing_slash = trailing_slash
+        self.__scheme = None
+        self.__netloc = None
+        self.__proxies = []
 
-
-                # Must set first.
-                self.__trailing_slash = trailing_slash
-                self.__scheme = None
-                self.__netloc = None
-                self.__proxies = []
-
-                # Note that the properties set here are intentionally lacking
-                # the '__' prefix which means assignment will occur using the
-                # get/set methods declared for the property near the end of
-                # the class definition.
-                self.priority = priority
-                self.uri = uri
-                self.ssl_cert = ssl_cert
-                self.ssl_key = ssl_key
-                self.disabled = disabled
-                # The proxy parameter is deprecated and remains for backwards
-                # compatibity, for now.  If we get given both, then we must
-                # complain - this error is for internal use only.
-                if proxy and proxies:
-                        raise api_errors.PublisherError("Both 'proxies' and "
-                            "'proxy' values were used to create a "
-                            "RepositoryURI object.")
-
-                if proxy:
-                        self.proxies = [ProxyURI(proxy)]
-                if proxies:
-                        self.proxies = proxies
-                self.system = system
-
-        def __copy__(self):
-                uri = RepositoryURI(self.__uri, priority=self.__priority,
-                    ssl_cert=self.__ssl_cert, ssl_key=self.__ssl_key,
-                    trailing_slash=self.__trailing_slash,
-                    proxies=self.__proxies, system=self.system,
-                    disabled=self.__disabled)
-                uri._source_object_id = id(self)
-                return uri
-
-        def __eq__(self, other):
-                if isinstance(other, RepositoryURI):
-                        return self.uri == other.uri
-                if isinstance(other, str):
-                        return self.uri == other
-                return False
-
-        def __ne__(self, other):
-                if isinstance(other, RepositoryURI):
-                        return self.uri != other.uri
-                if isinstance(other, str):
-                        return self.uri != other
-                return True
-
-        __hash__ = object.__hash__
-
-        def __lt__(self, other):
-                if not other:
-                        return False
-                if not isinstance(other, RepositoryURI):
-                        other = RepositoryURI(other)
-                return self.uri < other.uri
-
-        def __gt__(self, other):
-                if not other:
-                        return True
-                if not isinstance(other, RepositoryURI):
-                        other = RepositoryURI(other)
-                return self.uri > other.uri
-
-        def __le__(self, other):
-                return self == other or self < other
-
-        def __ge__(self, other):
-                return self == other or self > other
-
-        def __set_disabled(self, disable):
-                if self.system:
-                        raise api_errors.ModifyingSyspubException(_("Cannot "
-                            "enable or disable origin(s) for a system "
-                            "publisher"))
-                if not isinstance(disable, bool):
-                        raise api_errors.BadRepositoryAttributeValue(
-                            "disabled", value=disable)
-                if not disable:
-                        self.__disabled = False
-                else:
-                        self.__disabled = True
-
-        def __set_system(self, system):
-                if not isinstance(system, bool):
-                        raise api_errors.BadRepositoryAttributeValue(
-                            "system", value=system)
-                if not system:
-                        self.__system = False
-                else:
-                        self.__system = True
-
-        def __set_priority(self, value):
-                if value is not None:
-                        try:
-                                value = int(value)
-                        except (TypeError, ValueError):
-                                raise api_errors.BadRepositoryURIPriority(value)
-                self.__priority = value
-
-        def __get_proxy(self):
-                if not self.__proxies:
-                        return None
-                else:
-                        return self.__proxies[0].uri
-
-        def __set_proxy(self, proxy):
-                if not proxy:
-                        return
-                if not isinstance(proxy, ProxyURI):
-                        p = ProxyURI(proxy)
-                else:
-                        p = proxy
-
-                self.__proxies = [p]
-
-        def __set_proxies(self, proxies):
-
-                for proxy in proxies:
-                        if not isinstance(proxy, ProxyURI):
-                                raise api_errors.BadRepositoryAttributeValue(
-                                    "proxies", value=proxy)
-
-                if proxies and self.scheme == "file":
-                        raise api_errors.UnsupportedRepositoryURIAttribute(
-                            "proxies", scheme=self.scheme)
-
-                if not (isinstance(proxies, list) or
-                    isinstance(proxies, tuple)):
-                        raise api_errors.BadRepositoryAttributeValue(
-                            "proxies", value=proxies)
-
-                # for now, we only support a single proxy per RepositoryURI
-                if len(proxies) > 1:
-                        raise api_errors.BadRepositoryAttributeValue(
-                            "proxies", value=proxies)
-
-                if proxies:
-                        self.__proxies = proxies
-                else:
-                        self.__proxies = []
-
-        def __set_ssl_cert(self, filename):
-                if self.scheme not in SSL_SCHEMES and filename:
-                        raise api_errors.UnsupportedRepositoryURIAttribute(
-                            "ssl_cert", scheme=self.scheme)
-                if filename:
-                        if not isinstance(filename, six.string_types):
-                                raise api_errors.BadRepositoryAttributeValue(
-                                    "ssl_cert", value=filename)
-                        filename = os.path.normpath(filename)
-                if filename == "":
-                        filename = None
-                self.__ssl_cert = filename
-
-        def __set_ssl_key(self, filename):
-                if self.scheme not in SSL_SCHEMES and filename:
-                        raise api_errors.UnsupportedRepositoryURIAttribute(
-                            "ssl_key", scheme=self.scheme)
-                if filename:
-                        if not isinstance(filename, six.string_types):
-                                raise api_errors.BadRepositoryAttributeValue(
-                                    "ssl_key", value=filename)
-                        filename = os.path.normpath(filename)
-                if filename == "":
-                        filename = None
-                self.__ssl_key = filename
-
-        def __set_trailing_slash(self, value):
-                if value not in (True, False):
-                        raise api_errors.BadRepositoryAttributeValue(
-                            "trailing_slash", value=value)
-                self.__trailing_slash = value
-
-        def __set_uri(self, uri):
-                if uri is None:
-                        raise api_errors.BadRepositoryURI(uri)
-
-                # if we're setting the URI to an existing value, do nothing.
-                if uri == self.__uri:
-                        return
-
-                # This is not ideal, but determining whether we're operating
-                # on a ProxyURI saves us duplicating code in that class,
-                # which we would otherwise need, due to __protected members
-                # here.
-                if isinstance(self, ProxyURI):
-                        is_proxy = True
-                else:
-                        is_proxy = False
-
-                # Decompose URI to verify attributes.
-                scheme, netloc, path, params, query = \
-                    urlsplit(uri, allow_fragments=0)
-
-                self.__scheme = scheme.lower()
-                self.__netloc = netloc
-
-                # The set of currently supported protocol schemes.
-                if is_proxy and self.__scheme not in \
-                    SUPPORTED_PROXY_SCHEMES:
-                        raise api_errors.UnsupportedProxyURI(uri)
-                else:
-                        if self.__scheme not in SUPPORTED_SCHEMES:
-                                raise api_errors.UnsupportedRepositoryURI(uri)
-
-                # XXX valid_pub_url's check isn't quite right and could prevent
-                # usage of IDNs (international domain names).
-                if (self.__scheme.startswith("http") and not netloc) or \
-                    not misc.valid_pub_url(uri, proxy=is_proxy):
-                        raise api_errors.BadRepositoryURI(uri)
-
-                if self.__scheme == "file" and netloc:
-                        raise api_errors.BadRepositoryURI(uri)
-
-                # Normalize URI scheme.
-                uri = uri.replace(scheme, self.__scheme, 1)
-
-                if self.__trailing_slash:
-                        uri = uri.rstrip("/")
-                        uri = misc.url_affix_trailing_slash(uri)
-
-                if self.__scheme not in SSL_SCHEMES:
-                        self.__ssl_cert = None
-                        self.__ssl_key = None
-
-                self.__uri = uri
-
-        def _override_uri(self, uri):
-                """Allow the __uri field of the object to be overridden in
-                special cases."""
-                if uri not in [None, SYSREPO_PROXY]:
-                        raise api_errors.BadRepositoryURI(uri)
-                self.__uri = uri
-
-        def __str__(self):
-                return str(self.__uri)
-
-        def change_scheme(self, new_scheme):
-                """Change the scheme of this uri."""
-
-                assert self.__uri
-                scheme, netloc, path, params, query, fragment = \
-                    urlparse(self.__uri, allow_fragments=False)
-                if new_scheme == scheme:
-                        return
-                self.uri = urlunparse(
-                    (new_scheme, netloc, path, params, query, fragment))
-
-        def get_host(self):
-                """Get the host and port of this URI if it's a http uri."""
-
-                scheme, netloc, path, params, query, fragment = \
-                    urlparse(self.__uri, allow_fragments=0)
-                if scheme != "file":
-                        return netloc
-                return ""
-
-        def get_pathname(self):
-                """Returns the URI path as a pathname if the URI is a file
-                URI or '' otherwise."""
-
-                scheme, netloc, path, params, query, fragment = \
-                    urlparse(self.__uri, allow_fragments=0)
-                if scheme == "file":
-                        return url2pathname(path)
-                return ""
-
-        disabled = property(lambda self: self.__disabled, __set_disabled, None,
-            "A boolean value indicating whether this repository URI should be "
-            "used for packaging operations.")
-
-        ssl_cert = property(lambda self: self.__ssl_cert, __set_ssl_cert, None,
-            "The absolute pathname of a PEM-encoded SSL certificate file.")
-
-        ssl_key = property(lambda self: self.__ssl_key, __set_ssl_key, None,
-            "The absolute pathname of a PEM-encoded SSL key file.")
-
-        uri = property(lambda self: self.__uri, __set_uri, None,
-            "The URI used to access a repository.")
-
-        priority = property(lambda self: self.__priority, __set_priority, None,
-            "An integer value representing the importance of this repository "
-            "URI relative to others.")
-
-        proxy = property(__get_proxy, __set_proxy, None, "The proxy to use to "
-            "access this repository.")
-
-        proxies = property(lambda self: self.__proxies, __set_proxies, None,
-            "A list of proxies that can be used to access this repository."
-            "At runtime, a $http_proxy environment variable might override this."
+        # Note that the properties set here are intentionally lacking
+        # the '__' prefix which means assignment will occur using the
+        # get/set methods declared for the property near the end of
+        # the class definition.
+        self.priority = priority
+        self.uri = uri
+        self.ssl_cert = ssl_cert
+        self.ssl_key = ssl_key
+        self.disabled = disabled
+        # The proxy parameter is deprecated and remains for backwards
+        # compatibity, for now.  If we get given both, then we must
+        # complain - this error is for internal use only.
+        if proxy and proxies:
+            raise api_errors.PublisherError(
+                "Both 'proxies' and "
+                "'proxy' values were used to create a "
+                "RepositoryURI object."
             )
 
-        system = property(lambda self: self.__system, __set_system, None,
-            "A boolean value indicating whether this repository URI is for"
-            "a system repository.")
+        if proxy:
+            self.proxies = [ProxyURI(proxy)]
+        if proxies:
+            self.proxies = proxies
+        self.system = system
 
-        @property
-        def scheme(self):
-                """The URI scheme."""
-                if not self.__uri:
-                        return ""
-                return urlsplit(self.__uri, allow_fragments=0)[0]
+    def __copy__(self):
+        uri = RepositoryURI(
+            self.__uri,
+            priority=self.__priority,
+            ssl_cert=self.__ssl_cert,
+            ssl_key=self.__ssl_key,
+            trailing_slash=self.__trailing_slash,
+            proxies=self.__proxies,
+            system=self.system,
+            disabled=self.__disabled,
+        )
+        uri._source_object_id = id(self)
+        return uri
 
-        trailing_slash = property(lambda self: self.__trailing_slash,
-            __set_trailing_slash, None,
-            "A boolean value indicating whether any URI provided for this "
-            "object should have a trailing slash appended when setting the "
-            "URI property.")
+    def __eq__(self, other):
+        if isinstance(other, RepositoryURI):
+            return self.uri == other.uri
+        if isinstance(other, str):
+            return self.uri == other
+        return False
+
+    def __ne__(self, other):
+        if isinstance(other, RepositoryURI):
+            return self.uri != other.uri
+        if isinstance(other, str):
+            return self.uri != other
+        return True
+
+    __hash__ = object.__hash__
+
+    def __lt__(self, other):
+        if not other:
+            return False
+        if not isinstance(other, RepositoryURI):
+            other = RepositoryURI(other)
+        return self.uri < other.uri
+
+    def __gt__(self, other):
+        if not other:
+            return True
+        if not isinstance(other, RepositoryURI):
+            other = RepositoryURI(other)
+        return self.uri > other.uri
+
+    def __le__(self, other):
+        return self == other or self < other
+
+    def __ge__(self, other):
+        return self == other or self > other
+
+    def __set_disabled(self, disable):
+        if self.system:
+            raise api_errors.ModifyingSyspubException(
+                _(
+                    "Cannot "
+                    "enable or disable origin(s) for a system "
+                    "publisher"
+                )
+            )
+        if not isinstance(disable, bool):
+            raise api_errors.BadRepositoryAttributeValue(
+                "disabled", value=disable
+            )
+        if not disable:
+            self.__disabled = False
+        else:
+            self.__disabled = True
+
+    def __set_system(self, system):
+        if not isinstance(system, bool):
+            raise api_errors.BadRepositoryAttributeValue("system", value=system)
+        if not system:
+            self.__system = False
+        else:
+            self.__system = True
+
+    def __set_priority(self, value):
+        if value is not None:
+            try:
+                value = int(value)
+            except (TypeError, ValueError):
+                raise api_errors.BadRepositoryURIPriority(value)
+        self.__priority = value
+
+    def __get_proxy(self):
+        if not self.__proxies:
+            return None
+        else:
+            return self.__proxies[0].uri
+
+    def __set_proxy(self, proxy):
+        if not proxy:
+            return
+        if not isinstance(proxy, ProxyURI):
+            p = ProxyURI(proxy)
+        else:
+            p = proxy
+
+        self.__proxies = [p]
+
+    def __set_proxies(self, proxies):
+        for proxy in proxies:
+            if not isinstance(proxy, ProxyURI):
+                raise api_errors.BadRepositoryAttributeValue(
+                    "proxies", value=proxy
+                )
+
+        if proxies and self.scheme == "file":
+            raise api_errors.UnsupportedRepositoryURIAttribute(
+                "proxies", scheme=self.scheme
+            )
+
+        if not (isinstance(proxies, list) or isinstance(proxies, tuple)):
+            raise api_errors.BadRepositoryAttributeValue(
+                "proxies", value=proxies
+            )
+
+        # for now, we only support a single proxy per RepositoryURI
+        if len(proxies) > 1:
+            raise api_errors.BadRepositoryAttributeValue(
+                "proxies", value=proxies
+            )
+
+        if proxies:
+            self.__proxies = proxies
+        else:
+            self.__proxies = []
+
+    def __set_ssl_cert(self, filename):
+        if self.scheme not in SSL_SCHEMES and filename:
+            raise api_errors.UnsupportedRepositoryURIAttribute(
+                "ssl_cert", scheme=self.scheme
+            )
+        if filename:
+            if not isinstance(filename, six.string_types):
+                raise api_errors.BadRepositoryAttributeValue(
+                    "ssl_cert", value=filename
+                )
+            filename = os.path.normpath(filename)
+        if filename == "":
+            filename = None
+        self.__ssl_cert = filename
+
+    def __set_ssl_key(self, filename):
+        if self.scheme not in SSL_SCHEMES and filename:
+            raise api_errors.UnsupportedRepositoryURIAttribute(
+                "ssl_key", scheme=self.scheme
+            )
+        if filename:
+            if not isinstance(filename, six.string_types):
+                raise api_errors.BadRepositoryAttributeValue(
+                    "ssl_key", value=filename
+                )
+            filename = os.path.normpath(filename)
+        if filename == "":
+            filename = None
+        self.__ssl_key = filename
+
+    def __set_trailing_slash(self, value):
+        if value not in (True, False):
+            raise api_errors.BadRepositoryAttributeValue(
+                "trailing_slash", value=value
+            )
+        self.__trailing_slash = value
+
+    def __set_uri(self, uri):
+        if uri is None:
+            raise api_errors.BadRepositoryURI(uri)
+
+        # if we're setting the URI to an existing value, do nothing.
+        if uri == self.__uri:
+            return
+
+        # This is not ideal, but determining whether we're operating
+        # on a ProxyURI saves us duplicating code in that class,
+        # which we would otherwise need, due to __protected members
+        # here.
+        if isinstance(self, ProxyURI):
+            is_proxy = True
+        else:
+            is_proxy = False
+
+        # Decompose URI to verify attributes.
+        scheme, netloc, path, params, query = urlsplit(uri, allow_fragments=0)
+
+        self.__scheme = scheme.lower()
+        self.__netloc = netloc
+
+        # The set of currently supported protocol schemes.
+        if is_proxy and self.__scheme not in SUPPORTED_PROXY_SCHEMES:
+            raise api_errors.UnsupportedProxyURI(uri)
+        else:
+            if self.__scheme not in SUPPORTED_SCHEMES:
+                raise api_errors.UnsupportedRepositoryURI(uri)
+
+        # XXX valid_pub_url's check isn't quite right and could prevent
+        # usage of IDNs (international domain names).
+        if (
+            self.__scheme.startswith("http") and not netloc
+        ) or not misc.valid_pub_url(uri, proxy=is_proxy):
+            raise api_errors.BadRepositoryURI(uri)
+
+        if self.__scheme == "file" and netloc:
+            raise api_errors.BadRepositoryURI(uri)
+
+        # Normalize URI scheme.
+        uri = uri.replace(scheme, self.__scheme, 1)
+
+        if self.__trailing_slash:
+            uri = uri.rstrip("/")
+            uri = misc.url_affix_trailing_slash(uri)
+
+        if self.__scheme not in SSL_SCHEMES:
+            self.__ssl_cert = None
+            self.__ssl_key = None
+
+        self.__uri = uri
+
+    def _override_uri(self, uri):
+        """Allow the __uri field of the object to be overridden in
+        special cases."""
+        if uri not in [None, SYSREPO_PROXY]:
+            raise api_errors.BadRepositoryURI(uri)
+        self.__uri = uri
+
+    def __str__(self):
+        return str(self.__uri)
+
+    def change_scheme(self, new_scheme):
+        """Change the scheme of this uri."""
+
+        assert self.__uri
+        scheme, netloc, path, params, query, fragment = urlparse(
+            self.__uri, allow_fragments=False
+        )
+        if new_scheme == scheme:
+            return
+        self.uri = urlunparse(
+            (new_scheme, netloc, path, params, query, fragment)
+        )
+
+    def get_host(self):
+        """Get the host and port of this URI if it's a http uri."""
+
+        scheme, netloc, path, params, query, fragment = urlparse(
+            self.__uri, allow_fragments=0
+        )
+        if scheme != "file":
+            return netloc
+        return ""
+
+    def get_pathname(self):
+        """Returns the URI path as a pathname if the URI is a file
+        URI or '' otherwise."""
+
+        scheme, netloc, path, params, query, fragment = urlparse(
+            self.__uri, allow_fragments=0
+        )
+        if scheme == "file":
+            return url2pathname(path)
+        return ""
+
+    disabled = property(
+        lambda self: self.__disabled,
+        __set_disabled,
+        None,
+        "A boolean value indicating whether this repository URI should be "
+        "used for packaging operations.",
+    )
+
+    ssl_cert = property(
+        lambda self: self.__ssl_cert,
+        __set_ssl_cert,
+        None,
+        "The absolute pathname of a PEM-encoded SSL certificate file.",
+    )
+
+    ssl_key = property(
+        lambda self: self.__ssl_key,
+        __set_ssl_key,
+        None,
+        "The absolute pathname of a PEM-encoded SSL key file.",
+    )
+
+    uri = property(
+        lambda self: self.__uri,
+        __set_uri,
+        None,
+        "The URI used to access a repository.",
+    )
+
+    priority = property(
+        lambda self: self.__priority,
+        __set_priority,
+        None,
+        "An integer value representing the importance of this repository "
+        "URI relative to others.",
+    )
+
+    proxy = property(
+        __get_proxy,
+        __set_proxy,
+        None,
+        "The proxy to use to " "access this repository.",
+    )
+
+    proxies = property(
+        lambda self: self.__proxies,
+        __set_proxies,
+        None,
+        "A list of proxies that can be used to access this repository."
+        "At runtime, a $http_proxy environment variable might override this.",
+    )
+
+    system = property(
+        lambda self: self.__system,
+        __set_system,
+        None,
+        "A boolean value indicating whether this repository URI is for"
+        "a system repository.",
+    )
+
+    @property
+    def scheme(self):
+        """The URI scheme."""
+        if not self.__uri:
+            return ""
+        return urlsplit(self.__uri, allow_fragments=0)[0]
+
+    trailing_slash = property(
+        lambda self: self.__trailing_slash,
+        __set_trailing_slash,
+        None,
+        "A boolean value indicating whether any URI provided for this "
+        "object should have a trailing slash appended when setting the "
+        "URI property.",
+    )
 
 
 class ProxyURI(RepositoryURI):
-        """A class to represent the URI of a proxy. The 'uri' value can be
-        'None' if 'system' is set to True."""
+    """A class to represent the URI of a proxy. The 'uri' value can be
+    'None' if 'system' is set to True."""
 
-        def __init__(self, uri, system=False):
-                self.__system = None
-                self.system = system
-                if not system:
-                        self.uri = uri
+    def __init__(self, uri, system=False):
+        self.__system = None
+        self.system = system
+        if not system:
+            self.uri = uri
 
-        def __set_system(self, value):
-                """A property to specify whether we should use the system
-                publisher as the proxy.  Note that this method modifies the
-                'uri' property when set or cleared."""
-                if value not in (True, False):
-                        raise api_errors.BadRepositoryAttributeValue(
-                            "system", value=value)
-                self.__system = value
-                if value:
-                        # Set a special value for the uri, intentionally an
-                        # invalid URI which should get caught by any consumers
-                        # using it by mistake.  This also allows us to reuse
-                        # the __eq__, __cmp__, etc. methods from the parent
-                        # (where there is no public way of setting the URI to
-                        # SYSREPO_PROXY, '<sysrepo>')
-                        self._override_uri(SYSREPO_PROXY)
-                else:
-                        self._override_uri(None)
+    def __set_system(self, value):
+        """A property to specify whether we should use the system
+        publisher as the proxy.  Note that this method modifies the
+        'uri' property when set or cleared."""
+        if value not in (True, False):
+            raise api_errors.BadRepositoryAttributeValue("system", value=value)
+        self.__system = value
+        if value:
+            # Set a special value for the uri, intentionally an
+            # invalid URI which should get caught by any consumers
+            # using it by mistake.  This also allows us to reuse
+            # the __eq__, __cmp__, etc. methods from the parent
+            # (where there is no public way of setting the URI to
+            # SYSREPO_PROXY, '<sysrepo>')
+            self._override_uri(SYSREPO_PROXY)
+        else:
+            self._override_uri(None)
 
-        def __unsupported(self, value):
-                """A method used to prevent certain properties defined in the
-                parent class from being set on ProxyURI objects."""
+    def __unsupported(self, value):
+        """A method used to prevent certain properties defined in the
+        parent class from being set on ProxyURI objects."""
 
-                # We don't expect this string to be exposed to users.
-                raise ValueError("This property cannot be set to {0} on a "
-                    "ProxyURI object.".format(value))
+        # We don't expect this string to be exposed to users.
+        raise ValueError(
+            "This property cannot be set to {0} on a "
+            "ProxyURI object.".format(value)
+        )
 
-        system = property(lambda self: self.__system, __set_system, None,
-            "True, if we should use the system publisher as a proxy.")
+    system = property(
+        lambda self: self.__system,
+        __set_system,
+        None,
+        "True, if we should use the system publisher as a proxy.",
+    )
 
-        # Ensure we can't set any of the following properties.
-        proxies = property(lambda self: None, __unsupported, None,
-            "proxies is an invalid property for ProxyURI properties")
+    # Ensure we can't set any of the following properties.
+    proxies = property(
+        lambda self: None,
+        __unsupported,
+        None,
+        "proxies is an invalid property for ProxyURI properties",
+    )
 
-        ssl_cert = property(lambda self:  None, __unsupported, None,
-            "ssl_cert is an invalid property for ProxyURI properties")
+    ssl_cert = property(
+        lambda self: None,
+        __unsupported,
+        None,
+        "ssl_cert is an invalid property for ProxyURI properties",
+    )
 
-        ssl_key = property(lambda self: None, __unsupported, None,
-            "ssl_key is an invalid property for ProxyURI properties")
+    ssl_key = property(
+        lambda self: None,
+        __unsupported,
+        None,
+        "ssl_key is an invalid property for ProxyURI properties",
+    )
 
-        priority = property(lambda self: None, __unsupported, None,
-            "priority is an invalid property for ProxyURI properties")
+    priority = property(
+        lambda self: None,
+        __unsupported,
+        None,
+        "priority is an invalid property for ProxyURI properties",
+    )
 
-        trailing_slash = property(lambda self: None, __unsupported, None,
-            "trailing_slash is an invalid property for ProxyURI properties")
+    trailing_slash = property(
+        lambda self: None,
+        __unsupported,
+        None,
+        "trailing_slash is an invalid property for ProxyURI properties",
+    )
 
 
 class TransportRepoURI(RepositoryURI):
-        """A TransportRepoURI allows for multiple representations of a given
-        RepositoryURI, each with different properties.
+    """A TransportRepoURI allows for multiple representations of a given
+    RepositoryURI, each with different properties.
 
-        One RepositoryURI could be represented by several TransportRepoURIs,
-        used to allow the transport to properly track repo statistics for
-        for each discrete path to a given URI, perhaps using different proxies
-        or trying one of several SSL key/cert pairs."""
+    One RepositoryURI could be represented by several TransportRepoURIs,
+    used to allow the transport to properly track repo statistics for
+    for each discrete path to a given URI, perhaps using different proxies
+    or trying one of several SSL key/cert pairs."""
 
-        def __init__(self, uri, priority=None, ssl_cert=None, ssl_key=None,
-            trailing_slash=True, proxy=None, system=False):
-                # Must set first.
-                self.__proxy = None
-                self.__runtime_proxy = None
-                self.proxy = proxy
+    def __init__(
+        self,
+        uri,
+        priority=None,
+        ssl_cert=None,
+        ssl_key=None,
+        trailing_slash=True,
+        proxy=None,
+        system=False,
+    ):
+        # Must set first.
+        self.__proxy = None
+        self.__runtime_proxy = None
+        self.proxy = proxy
 
-                RepositoryURI.__init__(self, uri, priority=priority,
-                    ssl_cert=ssl_cert, ssl_key=ssl_key,
-                    trailing_slash=trailing_slash, system=system)
+        RepositoryURI.__init__(
+            self,
+            uri,
+            priority=priority,
+            ssl_cert=ssl_cert,
+            ssl_key=ssl_key,
+            trailing_slash=trailing_slash,
+            system=system,
+        )
 
-        def __eq__(self, other):
-                if isinstance(other, TransportRepoURI):
-                        return self.uri == other.uri and \
-                            self.proxy == other.proxy
-                if isinstance(other, six.string_types):
-                        return self.uri == other and self.proxy == None
-                return False
+    def __eq__(self, other):
+        if isinstance(other, TransportRepoURI):
+            return self.uri == other.uri and self.proxy == other.proxy
+        if isinstance(other, six.string_types):
+            return self.uri == other and self.proxy == None
+        return False
 
-        def __ne__(self, other):
-                if isinstance(other, TransportRepoURI):
-                        return self.uri != other.uri or \
-                            self.proxy != other.proxy
-                if isinstance(other, six.string_types):
-                        return self.uri != other or self.proxy != None
-                return True
+    def __ne__(self, other):
+        if isinstance(other, TransportRepoURI):
+            return self.uri != other.uri or self.proxy != other.proxy
+        if isinstance(other, six.string_types):
+            return self.uri != other or self.proxy != None
+        return True
 
-        __hash__ = object.__hash__
+    __hash__ = object.__hash__
 
-        def __lt__(self, other):
-                if not other:
-                        return False
-                if isinstance(other, six.string_types):
-                        other = TransportRepoURI(other)
-                elif not isinstance(other, TransportRepoURI):
-                        return False
-                if self.uri < other.uri:
-                        return True
-                if self.uri != other.uri:
-                        return False
-                return self.proxy < other.proxy
+    def __lt__(self, other):
+        if not other:
+            return False
+        if isinstance(other, six.string_types):
+            other = TransportRepoURI(other)
+        elif not isinstance(other, TransportRepoURI):
+            return False
+        if self.uri < other.uri:
+            return True
+        if self.uri != other.uri:
+            return False
+        return self.proxy < other.proxy
 
-        def __gt__(self, other):
-                if not other:
-                        return True
-                if isinstance(other, six.string_types):
-                        other = TransportRepoURI(other)
-                elif not isinstance(other, TransportRepoURI):
-                        return True
-                if self.uri > other.uri:
-                        return True
-                if self.uri != other.uri:
-                        return False
-                return self.proxy > other.proxy
+    def __gt__(self, other):
+        if not other:
+            return True
+        if isinstance(other, six.string_types):
+            other = TransportRepoURI(other)
+        elif not isinstance(other, TransportRepoURI):
+            return True
+        if self.uri > other.uri:
+            return True
+        if self.uri != other.uri:
+            return False
+        return self.proxy > other.proxy
 
-        def __le__(self, other):
-                return self == other or self < other
+    def __le__(self, other):
+        return self == other or self < other
 
-        def __ge__(self, other):
-                return self == other or self > other
+    def __ge__(self, other):
+        return self == other or self > other
 
-        def key(self):
-                """Returns a value that can be used to identify this RepoURI
-                uniquely for the transport system.  Normally, this would be done
-                using __hash__() however, TransportRepoURI objects are not
-                guaranteed to be immutable.
+    def key(self):
+        """Returns a value that can be used to identify this RepoURI
+        uniquely for the transport system.  Normally, this would be done
+        using __hash__() however, TransportRepoURI objects are not
+        guaranteed to be immutable.
 
-                The key is a (uri, proxy) tuple, where the proxy is
-                the proxy used to reach that URI.  Note that in the transport
-                system, we may choose to override the proxy value here.
+        The key is a (uri, proxy) tuple, where the proxy is
+        the proxy used to reach that URI.  Note that in the transport
+        system, we may choose to override the proxy value here.
 
-                If this key format changes, a corresponding change should be
-                made in pkg.client.transport.engine.__cleanup_requests(..)"""
+        If this key format changes, a corresponding change should be
+        made in pkg.client.transport.engine.__cleanup_requests(..)"""
 
-                u = self.uri
-                p = self.__proxy
+        u = self.uri
+        p = self.__proxy
 
-                if self.uri:
-                        u = self.uri.rstrip("/")
-                return (u, p)
+        if self.uri:
+            u = self.uri.rstrip("/")
+        return (u, p)
 
-        def __set_proxy(self, proxy):
-                assert not self.ssl_cert
-                assert not self.ssl_key
+    def __set_proxy(self, proxy):
+        assert not self.ssl_cert
+        assert not self.ssl_key
 
-                if proxy and self.scheme == "file":
-                        raise api_errors.UnsupportedRepositoryURIAttribute(
-                            "proxy", scheme=self.scheme)
-                if proxy:
-                        self.__proxy = proxy.rstrip("/")
-                else:
-                        self.__proxy = None
-                # Changing the proxy value causes us to clear any cached
-                # value we have in __runtime_proxy.
-                self.__runtime_proxy = None
-
-        def __get_runtime_proxy(self):
-                """Returns the proxy that should be used at runtime, which may
-                differ from the persisted proxy value.  We check for http_proxy,
-                https_proxy and all_proxy OS environment variables.
-
-                To avoid repeated environment lookups, we cache the results."""
-
-                # we don't permit the proxy used by system publishers to be
-                # overridden by environment variables.
-                if self.system:
-                        return self.proxy
-
-                if not self.__runtime_proxy:
-                        self.__runtime_proxy = misc.get_runtime_proxy(
-                            self.__proxy, self.uri)
-                return self.__runtime_proxy
-
-        def __set_runtime_proxy(self, runtime_proxy):
-                """The runtime proxy value is always computed dynamically,
-                we should not allow a caller to set it."""
-
-                assert False, "Refusing to set a runtime_proxy value."
-
-        @staticmethod
-        def fromrepouri(repouri):
-                """Build a list of TransportRepositoryURI objects using
-                properties from the given RepositoryURI, 'repouri'.
-
-                This is to allow the transport to try different paths to
-                a given RepositoryURI, if more than one is possible."""
-
-                trans_repouris = []
-                # we just use the proxies for now, but in future, we may want
-                # other per-origin/mirror properties
-                if repouri.proxies:
-                        for p in repouri.proxies:
-                                t = TransportRepoURI(repouri.uri,
-                                    priority=repouri.priority,
-                                    ssl_cert=repouri.ssl_cert,
-                                    ssl_key=repouri.ssl_key,
-                                    system=repouri.system,
-                                    trailing_slash=repouri.trailing_slash,
-                                    proxy=p.uri)
-                                trans_repouris.append(t)
-                else:
-                        trans_repouris.append(TransportRepoURI(repouri.uri,
-                            priority=repouri.priority,
-                            ssl_cert=repouri.ssl_cert,
-                            ssl_key=repouri.ssl_key,
-                            system=repouri.system,
-                            trailing_slash=repouri.trailing_slash))
-                return trans_repouris
-
-        proxy = property(lambda self: self.__proxy, __set_proxy, None,
-            "The proxy that is used to access this repository."
-            "At runtime, a $http_proxy environnent variable might override this."
+        if proxy and self.scheme == "file":
+            raise api_errors.UnsupportedRepositoryURIAttribute(
+                "proxy", scheme=self.scheme
             )
+        if proxy:
+            self.__proxy = proxy.rstrip("/")
+        else:
+            self.__proxy = None
+        # Changing the proxy value causes us to clear any cached
+        # value we have in __runtime_proxy.
+        self.__runtime_proxy = None
 
-        runtime_proxy = property(__get_runtime_proxy, __set_runtime_proxy, None,
-            "The proxy to use to access this repository.  This value checks"
-            "OS environment variables, and expands any $user:$password values.")
+    def __get_runtime_proxy(self):
+        """Returns the proxy that should be used at runtime, which may
+        differ from the persisted proxy value.  We check for http_proxy,
+        https_proxy and all_proxy OS environment variables.
+
+        To avoid repeated environment lookups, we cache the results."""
+
+        # we don't permit the proxy used by system publishers to be
+        # overridden by environment variables.
+        if self.system:
+            return self.proxy
+
+        if not self.__runtime_proxy:
+            self.__runtime_proxy = misc.get_runtime_proxy(
+                self.__proxy, self.uri
+            )
+        return self.__runtime_proxy
+
+    def __set_runtime_proxy(self, runtime_proxy):
+        """The runtime proxy value is always computed dynamically,
+        we should not allow a caller to set it."""
+
+        assert False, "Refusing to set a runtime_proxy value."
+
+    @staticmethod
+    def fromrepouri(repouri):
+        """Build a list of TransportRepositoryURI objects using
+        properties from the given RepositoryURI, 'repouri'.
+
+        This is to allow the transport to try different paths to
+        a given RepositoryURI, if more than one is possible."""
+
+        trans_repouris = []
+        # we just use the proxies for now, but in future, we may want
+        # other per-origin/mirror properties
+        if repouri.proxies:
+            for p in repouri.proxies:
+                t = TransportRepoURI(
+                    repouri.uri,
+                    priority=repouri.priority,
+                    ssl_cert=repouri.ssl_cert,
+                    ssl_key=repouri.ssl_key,
+                    system=repouri.system,
+                    trailing_slash=repouri.trailing_slash,
+                    proxy=p.uri,
+                )
+                trans_repouris.append(t)
+        else:
+            trans_repouris.append(
+                TransportRepoURI(
+                    repouri.uri,
+                    priority=repouri.priority,
+                    ssl_cert=repouri.ssl_cert,
+                    ssl_key=repouri.ssl_key,
+                    system=repouri.system,
+                    trailing_slash=repouri.trailing_slash,
+                )
+            )
+        return trans_repouris
+
+    proxy = property(
+        lambda self: self.__proxy,
+        __set_proxy,
+        None,
+        "The proxy that is used to access this repository."
+        "At runtime, a $http_proxy environnent variable might override this.",
+    )
+
+    runtime_proxy = property(
+        __get_runtime_proxy,
+        __set_runtime_proxy,
+        None,
+        "The proxy to use to access this repository.  This value checks"
+        "OS environment variables, and expands any $user:$password values.",
+    )
 
 
 class Repository(object):
-        """Class representing a repository object.
-
-        A repository object represents a location where clients can publish
-        and retrieve package content and/or metadata.  It has the following
-        characteristics:
-
-                - may have one or more origins (URIs) for publication and
-                  retrieval of package metadata and content.
-
-                - may have zero or more mirrors (URIs) for retrieval of package
-                  content."""
-
-        # These properties are declared here so that they show up in the pydoc
-        # documentation as private, and for clarity in the property declarations
-        # found near the end of the class definition.
-        __collection_type = None
-        __legal_uris = []
-        __mirrors = []
-        __origins = []
-        __refresh_seconds = None
-        __registration_uri = None
-        __related_uris = []
-        __sort_policy = URI_SORT_PRIORITY
-
-        # Used to store the id of the original object this one was copied
-        # from during __copy__.
-        _source_object_id = None
-
-        name = None
-        description = None
-        registered = False
-
-        def __init__(self, collection_type=REPO_CTYPE_CORE, description=None,
-            legal_uris=None, mirrors=None, name=None, origins=None,
-            refresh_seconds=None, registered=False, registration_uri=None,
-            related_uris=None, sort_policy=URI_SORT_PRIORITY):
-                """Initializes a repository object.
-
-                'collection_type' is an optional constant value indicating the
-                type of packages in the repository.
-
-                'description' is an optional string value containing a
-                descriptive paragraph for the repository.
-
-                'legal_uris' should be a list of RepositoryURI objects or URI
-                strings indicating where licensing, legal, and terms of service
-                information for the repository can be found.
-
-                'mirrors' is an optional list of RepositoryURI objects or URI
-                strings indicating where package content can be retrieved.
-
-                'name' is an optional, short, descriptive name for the
-                repository.
-
-                'origins' should be a list of RepositoryURI objects or URI
-                strings indicating where package metadata can be retrieved.
-
-                'refresh_seconds' is an optional integer value indicating the
-                number of seconds clients should wait before refreshing cached
-                repository catalog or repository metadata information.
-
-                'registered' is an optional boolean value indicating whether
-                a client has registered with the repository's publisher.
-
-                'registration_uri' is an optional RepositoryURI object or a URI
-                string indicating a location clients can use to register or
-                obtain credentials needed to access the repository.
-
-                'related_uris' is an optional list of RepositoryURI objects or a
-                list of URI strings indicating the location of related
-                repositories that a client may be interested in.
-
-                'sort_policy' is an optional constant value indicating how
-                legal_uris, mirrors, origins, and related_uris should be
-                sorted."""
-
-                # Note that the properties set here are intentionally lacking
-                # the '__' prefix which means assignment will occur using the
-                # get/set methods declared for the property near the end of
-                # the class definition.
-
-                # Must be set first so that it will apply to attributes set
-                # afterwards.
-                self.sort_policy = sort_policy
-
-                self.collection_type = collection_type
-                self.description = description
-                self.legal_uris = legal_uris
-                self.mirrors = mirrors
-                self.name = name
-                self.origins = origins
-                self.refresh_seconds = refresh_seconds
-                self.registered = registered
-                self.registration_uri = registration_uri
-                self.related_uris = related_uris
-
-        def __add_uri(self, attr, uri, dup_check=None, priority=None,
-            ssl_cert=None, ssl_key=None, trailing_slash=True):
-                if not isinstance(uri, RepositoryURI):
-                        uri = RepositoryURI(uri, priority=priority,
-                            ssl_cert=ssl_cert, ssl_key=ssl_key,
-                            trailing_slash=trailing_slash)
-
-                if dup_check:
-                        dup_check(uri)
-
-                ulist = getattr(self, attr)
-                ulist.append(uri)
-                ulist.sort(key=URI_SORT_POLICIES[self.__sort_policy])
-
-        def __copy__(self):
-                cluris = [copy.copy(u) for u in self.legal_uris]
-                cmirrors = [copy.copy(u) for u in self.mirrors]
-                cruris = [copy.copy(u) for u in self.related_uris]
-                corigins = [copy.copy(u) for u in self.origins]
-
-                repo = Repository(collection_type=self.collection_type,
-                    description=self.description,
-                    legal_uris=cluris,
-                    mirrors=cmirrors, name=self.name,
-                    origins=corigins,
-                    refresh_seconds=self.refresh_seconds,
-                    registered=self.registered,
-                    registration_uri=copy.copy(self.registration_uri),
-                    related_uris=cruris)
-                repo._source_object_id = id(self)
-                return repo
-
-        def __replace_uris(self, attr, value, trailing_slash=True):
-                if value is None:
-                        value = []
-                if not isinstance(value, list):
-                        raise api_errors.BadRepositoryAttributeValue(attr,
-                            value=value)
-                uris = []
-                for u in value:
-                        if not isinstance(u, RepositoryURI):
-                                u = RepositoryURI(u,
-                                    trailing_slash=trailing_slash)
-                        elif trailing_slash:
-                                u.uri = misc.url_affix_trailing_slash(u.uri)
-                        uris.append(u)
-                uris.sort(key=URI_SORT_POLICIES[self.__sort_policy])
-                return uris
-
-        def __set_collection_type(self, value):
-                if value not in REPO_COLLECTION_TYPES:
-                        raise api_errors.BadRepositoryCollectionType(value)
-                self.__collection_type = value
-
-        def __set_legal_uris(self, value):
-                self.__legal_uris = self.__replace_uris("legal_uris", value,
-                    trailing_slash=False)
-
-        def __set_mirrors(self, value):
-                self.__mirrors = self.__replace_uris("mirrors", value)
-
-        def __set_origins(self, value):
-                self.__origins = self.__replace_uris("origins", value)
-
-        def __set_registration_uri(self, value):
-                if value and not isinstance(value, RepositoryURI):
-                        value = RepositoryURI(value, trailing_slash=False)
-                self.__registration_uri = value
-
-        def __set_related_uris(self, value):
-                self.__related_uris = self.__replace_uris("related_uris",
-                    value, trailing_slash=False)
-
-        def __set_refresh_seconds(self, value):
-                if value is not None:
-                        try:
-                                value = int(value)
-                        except (TypeError, ValueError):
-                                raise api_errors.BadRepositoryAttributeValue(
-                                    "refresh_seconds", value=value)
-                        if value < 0:
-                                raise api_errors.BadRepositoryAttributeValue(
-                                    "refresh_seconds", value=value)
-                self.__refresh_seconds = value
-
-        def __set_sort_policy(self, value):
-                if value not in URI_SORT_POLICIES:
-                        raise api_errors.BadRepositoryURISortPolicy(value)
-                self.__sort_policy = value
-
-        def add_legal_uri(self, uri, priority=None, ssl_cert=None,
-            ssl_key=None):
-                """Adds the specified legal URI to the repository.
-
-                'uri' can be a RepositoryURI object or a URI string.  If
-                it is a RepositoryURI object, all other parameters will be
-                ignored."""
-
-                self.__add_uri("legal_uris", uri, priority=priority,
-                    ssl_cert=ssl_cert, ssl_key=ssl_key, trailing_slash=False)
-
-        def add_mirror(self, mirror, priority=None, ssl_cert=None,
-            ssl_key=None):
-                """Adds the specified mirror to the repository.
-
-                'mirror' can be a RepositoryURI object or a URI string.  If
-                it is a RepositoryURI object, all other parameters will be
-                ignored."""
-
-                def dup_check(mirror):
-                        if self.has_mirror(mirror):
-                                o = self.get_mirror(mirror)
-                                if o.system:
-                                        raise api_errors.DuplicateSyspubMirror(
-                                            mirror)
-                                raise api_errors.DuplicateRepositoryMirror(
-                                    mirror)
-
-                self.__add_uri("mirrors", mirror, dup_check=dup_check,
-                    priority=priority, ssl_cert=ssl_cert, ssl_key=ssl_key)
-
-        def add_origin(self, origin, priority=None, ssl_cert=None,
-            ssl_key=None):
-                """Adds the specified origin to the repository.
-
-                'origin' can be a RepositoryURI object or a URI string.  If
-                it is a RepositoryURI object, all other parameters will be
-                ignored."""
-
-                def dup_check(origin):
-                        if self.has_origin(origin):
-                                o = self.get_origin(origin)
-                                if o.system:
-                                        raise api_errors.DuplicateSyspubOrigin(
-                                            origin)
-                                raise api_errors.DuplicateRepositoryOrigin(
-                                    origin)
-
-                self.__add_uri("origins", origin, dup_check=dup_check,
-                    priority=priority, ssl_cert=ssl_cert, ssl_key=ssl_key)
-
-        def add_related_uri(self, uri, priority=None, ssl_cert=None,
-            ssl_key=None):
-                """Adds the specified related URI to the repository.
-
-                'uri' can be a RepositoryURI object or a URI string.  If
-                it is a RepositoryURI object, all other parameters will be
-                ignored."""
-
-                self.__add_uri("related_uris", uri, priority=priority,
-                    ssl_cert=ssl_cert, ssl_key=ssl_key, trailing_slash=False)
-
-        def get_mirror(self, mirror):
-                """Returns a RepositoryURI object representing the mirror
-                that matches 'mirror'.
-
-                'mirror' can be a RepositoryURI object or a URI string."""
-
-                if not isinstance(mirror, RepositoryURI):
-                        mirror = misc.url_affix_trailing_slash(mirror)
-                for m in self.mirrors:
-                        if mirror == m.uri:
-                                return m
-                raise api_errors.UnknownRepositoryMirror(mirror)
-
-        def get_origin(self, origin):
-                """Returns a RepositoryURI object representing the origin
-                that matches 'origin'.
-
-                'origin' can be a RepositoryURI object or a URI string."""
-
-                if not isinstance(origin, RepositoryURI):
-                        origin = misc.url_affix_trailing_slash(origin)
-                for o in self.origins:
-                        if origin == o.uri:
-                                return o
-                raise api_errors.UnknownRepositoryOrigin(origin)
-
-        def has_mirror(self, mirror):
-                """Returns a boolean value indicating whether a matching
-                'mirror' exists for the repository.
-
-                'mirror' can be a RepositoryURI object or a URI string."""
-
-                if not isinstance(mirror, RepositoryURI):
-                        mirror = RepositoryURI(mirror)
-                return mirror in self.mirrors
-
-        def has_origin(self, origin):
-                """Returns a boolean value indicating whether a matching
-                'origin' exists for the repository.
-
-                'origin' can be a RepositoryURI object or a URI string."""
-
-                if not isinstance(origin, RepositoryURI):
-                        origin = RepositoryURI(origin)
-                return origin in self.origins
-
-        def remove_legal_uri(self, uri):
-                """Removes the legal URI matching 'uri' from the repository.
-
-                'uri' can be a RepositoryURI object or a URI string."""
-
-                for i, m in enumerate(self.legal_uris):
-                        if uri == m.uri:
-                                # Immediate return as the index into the array
-                                # changes with each removal.
-                                del self.legal_uris[i]
-                                return
-                raise api_errors.UnknownLegalURI(uri)
-
-        def remove_mirror(self, mirror):
-                """Removes the mirror matching 'mirror' from the repository.
-
-                'mirror' can be a RepositoryURI object or a URI string."""
-
-                if not isinstance(mirror, RepositoryURI):
-                        mirror = misc.url_affix_trailing_slash(mirror)
-                for i, m in enumerate(self.mirrors):
-                        if mirror == m.uri:
-                                if m.system:
-                                        api_errors.RemoveSyspubMirror(
-                                            mirror.uri)
-                                # Immediate return as the index into the array
-                                # changes with each removal.
-                                del self.mirrors[i]
-                                return
-                raise api_errors.UnknownRepositoryMirror(mirror)
-
-        def remove_origin(self, origin):
-                """Removes the origin matching 'origin' from the repository.
-
-                'origin' can be a RepositoryURI object or a URI string."""
-
-                if not isinstance(origin, RepositoryURI):
-                        origin = RepositoryURI(origin)
-                for i, o in enumerate(self.origins):
-                        if origin == o.uri:
-                                if o.system:
-                                        raise api_errors.RemoveSyspubOrigin(
-                                            origin.uri)
-                                # Immediate return as the index into the array
-                                # changes with each removal.
-                                del self.origins[i]
-                                return
-                raise api_errors.UnknownRepositoryOrigin(origin)
-
-        def remove_related_uri(self, uri):
-                """Removes the related URI matching 'uri' from the repository.
-
-                'uri' can be a RepositoryURI object or a URI string."""
-
-                for i, m in enumerate(self.related_uris):
-                        if uri == m.uri:
-                                # Immediate return as the index into the array
-                                # changes with each removal.
-                                del self.related_uris[i]
-                                return
-                raise api_errors.UnknownRelatedURI(uri)
-
-        def update_mirror(self, mirror, priority=None, ssl_cert=None,
-            ssl_key=None):
-                """Updates an existing mirror object matching 'mirror'.
-
-                'mirror' can be a RepositoryURI object or a URI string.
-
-                This method is deprecated, and may be removed in future API
-                versions."""
-
-                if not isinstance(mirror, RepositoryURI):
-                        mirror = RepositoryURI(mirror, priority=priority,
-                            ssl_cert=ssl_cert, ssl_key=ssl_key)
-
-                target = self.get_mirror(mirror)
-                target.priority = mirror.priority
-                target.ssl_cert = mirror.ssl_cert
-                target.ssl_key = mirror.ssl_key
-                target.proxies = mirror.proxies
-                self.mirrors.sort(key=URI_SORT_POLICIES[self.__sort_policy])
-
-        def update_origin(self, origin, priority=None, ssl_cert=None,
-            ssl_key=None):
-                """Updates an existing origin object matching 'origin'.
-
-                'origin' can be a RepositoryURI object or a URI string.
-
-                This method is deprecated, and may be removed in future API
-                versions."""
-
-                if not isinstance(origin, RepositoryURI):
-                        origin = RepositoryURI(origin, priority=priority,
-                            ssl_cert=ssl_cert, ssl_key=ssl_key)
-
-                target = self.get_origin(origin)
-                target.priority = origin.priority
-                target.ssl_cert = origin.ssl_cert
-                target.ssl_key = origin.ssl_key
-                target.proxies = origin.proxies
-                self.origins.sort(key=URI_SORT_POLICIES[self.__sort_policy])
-
-        def reset_mirrors(self):
-                """Discards the current list of repository mirrors."""
-
-                self.mirrors = []
-
-        def reset_origins(self):
-                """Discards the current list of repository origins."""
-
-                self.origins = []
-
-        collection_type = property(lambda self: self.__collection_type,
-            __set_collection_type, None,
-            """A constant value indicating the type of packages in the
+    """Class representing a repository object.
+
+    A repository object represents a location where clients can publish
+    and retrieve package content and/or metadata.  It has the following
+    characteristics:
+
+            - may have one or more origins (URIs) for publication and
+              retrieval of package metadata and content.
+
+            - may have zero or more mirrors (URIs) for retrieval of package
+              content."""
+
+    # These properties are declared here so that they show up in the pydoc
+    # documentation as private, and for clarity in the property declarations
+    # found near the end of the class definition.
+    __collection_type = None
+    __legal_uris = []
+    __mirrors = []
+    __origins = []
+    __refresh_seconds = None
+    __registration_uri = None
+    __related_uris = []
+    __sort_policy = URI_SORT_PRIORITY
+
+    # Used to store the id of the original object this one was copied
+    # from during __copy__.
+    _source_object_id = None
+
+    name = None
+    description = None
+    registered = False
+
+    def __init__(
+        self,
+        collection_type=REPO_CTYPE_CORE,
+        description=None,
+        legal_uris=None,
+        mirrors=None,
+        name=None,
+        origins=None,
+        refresh_seconds=None,
+        registered=False,
+        registration_uri=None,
+        related_uris=None,
+        sort_policy=URI_SORT_PRIORITY,
+    ):
+        """Initializes a repository object.
+
+        'collection_type' is an optional constant value indicating the
+        type of packages in the repository.
+
+        'description' is an optional string value containing a
+        descriptive paragraph for the repository.
+
+        'legal_uris' should be a list of RepositoryURI objects or URI
+        strings indicating where licensing, legal, and terms of service
+        information for the repository can be found.
+
+        'mirrors' is an optional list of RepositoryURI objects or URI
+        strings indicating where package content can be retrieved.
+
+        'name' is an optional, short, descriptive name for the
+        repository.
+
+        'origins' should be a list of RepositoryURI objects or URI
+        strings indicating where package metadata can be retrieved.
+
+        'refresh_seconds' is an optional integer value indicating the
+        number of seconds clients should wait before refreshing cached
+        repository catalog or repository metadata information.
+
+        'registered' is an optional boolean value indicating whether
+        a client has registered with the repository's publisher.
+
+        'registration_uri' is an optional RepositoryURI object or a URI
+        string indicating a location clients can use to register or
+        obtain credentials needed to access the repository.
+
+        'related_uris' is an optional list of RepositoryURI objects or a
+        list of URI strings indicating the location of related
+        repositories that a client may be interested in.
+
+        'sort_policy' is an optional constant value indicating how
+        legal_uris, mirrors, origins, and related_uris should be
+        sorted."""
+
+        # Note that the properties set here are intentionally lacking
+        # the '__' prefix which means assignment will occur using the
+        # get/set methods declared for the property near the end of
+        # the class definition.
+
+        # Must be set first so that it will apply to attributes set
+        # afterwards.
+        self.sort_policy = sort_policy
+
+        self.collection_type = collection_type
+        self.description = description
+        self.legal_uris = legal_uris
+        self.mirrors = mirrors
+        self.name = name
+        self.origins = origins
+        self.refresh_seconds = refresh_seconds
+        self.registered = registered
+        self.registration_uri = registration_uri
+        self.related_uris = related_uris
+
+    def __add_uri(
+        self,
+        attr,
+        uri,
+        dup_check=None,
+        priority=None,
+        ssl_cert=None,
+        ssl_key=None,
+        trailing_slash=True,
+    ):
+        if not isinstance(uri, RepositoryURI):
+            uri = RepositoryURI(
+                uri,
+                priority=priority,
+                ssl_cert=ssl_cert,
+                ssl_key=ssl_key,
+                trailing_slash=trailing_slash,
+            )
+
+        if dup_check:
+            dup_check(uri)
+
+        ulist = getattr(self, attr)
+        ulist.append(uri)
+        ulist.sort(key=URI_SORT_POLICIES[self.__sort_policy])
+
+    def __copy__(self):
+        cluris = [copy.copy(u) for u in self.legal_uris]
+        cmirrors = [copy.copy(u) for u in self.mirrors]
+        cruris = [copy.copy(u) for u in self.related_uris]
+        corigins = [copy.copy(u) for u in self.origins]
+
+        repo = Repository(
+            collection_type=self.collection_type,
+            description=self.description,
+            legal_uris=cluris,
+            mirrors=cmirrors,
+            name=self.name,
+            origins=corigins,
+            refresh_seconds=self.refresh_seconds,
+            registered=self.registered,
+            registration_uri=copy.copy(self.registration_uri),
+            related_uris=cruris,
+        )
+        repo._source_object_id = id(self)
+        return repo
+
+    def __replace_uris(self, attr, value, trailing_slash=True):
+        if value is None:
+            value = []
+        if not isinstance(value, list):
+            raise api_errors.BadRepositoryAttributeValue(attr, value=value)
+        uris = []
+        for u in value:
+            if not isinstance(u, RepositoryURI):
+                u = RepositoryURI(u, trailing_slash=trailing_slash)
+            elif trailing_slash:
+                u.uri = misc.url_affix_trailing_slash(u.uri)
+            uris.append(u)
+        uris.sort(key=URI_SORT_POLICIES[self.__sort_policy])
+        return uris
+
+    def __set_collection_type(self, value):
+        if value not in REPO_COLLECTION_TYPES:
+            raise api_errors.BadRepositoryCollectionType(value)
+        self.__collection_type = value
+
+    def __set_legal_uris(self, value):
+        self.__legal_uris = self.__replace_uris(
+            "legal_uris", value, trailing_slash=False
+        )
+
+    def __set_mirrors(self, value):
+        self.__mirrors = self.__replace_uris("mirrors", value)
+
+    def __set_origins(self, value):
+        self.__origins = self.__replace_uris("origins", value)
+
+    def __set_registration_uri(self, value):
+        if value and not isinstance(value, RepositoryURI):
+            value = RepositoryURI(value, trailing_slash=False)
+        self.__registration_uri = value
+
+    def __set_related_uris(self, value):
+        self.__related_uris = self.__replace_uris(
+            "related_uris", value, trailing_slash=False
+        )
+
+    def __set_refresh_seconds(self, value):
+        if value is not None:
+            try:
+                value = int(value)
+            except (TypeError, ValueError):
+                raise api_errors.BadRepositoryAttributeValue(
+                    "refresh_seconds", value=value
+                )
+            if value < 0:
+                raise api_errors.BadRepositoryAttributeValue(
+                    "refresh_seconds", value=value
+                )
+        self.__refresh_seconds = value
+
+    def __set_sort_policy(self, value):
+        if value not in URI_SORT_POLICIES:
+            raise api_errors.BadRepositoryURISortPolicy(value)
+        self.__sort_policy = value
+
+    def add_legal_uri(self, uri, priority=None, ssl_cert=None, ssl_key=None):
+        """Adds the specified legal URI to the repository.
+
+        'uri' can be a RepositoryURI object or a URI string.  If
+        it is a RepositoryURI object, all other parameters will be
+        ignored."""
+
+        self.__add_uri(
+            "legal_uris",
+            uri,
+            priority=priority,
+            ssl_cert=ssl_cert,
+            ssl_key=ssl_key,
+            trailing_slash=False,
+        )
+
+    def add_mirror(self, mirror, priority=None, ssl_cert=None, ssl_key=None):
+        """Adds the specified mirror to the repository.
+
+        'mirror' can be a RepositoryURI object or a URI string.  If
+        it is a RepositoryURI object, all other parameters will be
+        ignored."""
+
+        def dup_check(mirror):
+            if self.has_mirror(mirror):
+                o = self.get_mirror(mirror)
+                if o.system:
+                    raise api_errors.DuplicateSyspubMirror(mirror)
+                raise api_errors.DuplicateRepositoryMirror(mirror)
+
+        self.__add_uri(
+            "mirrors",
+            mirror,
+            dup_check=dup_check,
+            priority=priority,
+            ssl_cert=ssl_cert,
+            ssl_key=ssl_key,
+        )
+
+    def add_origin(self, origin, priority=None, ssl_cert=None, ssl_key=None):
+        """Adds the specified origin to the repository.
+
+        'origin' can be a RepositoryURI object or a URI string.  If
+        it is a RepositoryURI object, all other parameters will be
+        ignored."""
+
+        def dup_check(origin):
+            if self.has_origin(origin):
+                o = self.get_origin(origin)
+                if o.system:
+                    raise api_errors.DuplicateSyspubOrigin(origin)
+                raise api_errors.DuplicateRepositoryOrigin(origin)
+
+        self.__add_uri(
+            "origins",
+            origin,
+            dup_check=dup_check,
+            priority=priority,
+            ssl_cert=ssl_cert,
+            ssl_key=ssl_key,
+        )
+
+    def add_related_uri(self, uri, priority=None, ssl_cert=None, ssl_key=None):
+        """Adds the specified related URI to the repository.
+
+        'uri' can be a RepositoryURI object or a URI string.  If
+        it is a RepositoryURI object, all other parameters will be
+        ignored."""
+
+        self.__add_uri(
+            "related_uris",
+            uri,
+            priority=priority,
+            ssl_cert=ssl_cert,
+            ssl_key=ssl_key,
+            trailing_slash=False,
+        )
+
+    def get_mirror(self, mirror):
+        """Returns a RepositoryURI object representing the mirror
+        that matches 'mirror'.
+
+        'mirror' can be a RepositoryURI object or a URI string."""
+
+        if not isinstance(mirror, RepositoryURI):
+            mirror = misc.url_affix_trailing_slash(mirror)
+        for m in self.mirrors:
+            if mirror == m.uri:
+                return m
+        raise api_errors.UnknownRepositoryMirror(mirror)
+
+    def get_origin(self, origin):
+        """Returns a RepositoryURI object representing the origin
+        that matches 'origin'.
+
+        'origin' can be a RepositoryURI object or a URI string."""
+
+        if not isinstance(origin, RepositoryURI):
+            origin = misc.url_affix_trailing_slash(origin)
+        for o in self.origins:
+            if origin == o.uri:
+                return o
+        raise api_errors.UnknownRepositoryOrigin(origin)
+
+    def has_mirror(self, mirror):
+        """Returns a boolean value indicating whether a matching
+        'mirror' exists for the repository.
+
+        'mirror' can be a RepositoryURI object or a URI string."""
+
+        if not isinstance(mirror, RepositoryURI):
+            mirror = RepositoryURI(mirror)
+        return mirror in self.mirrors
+
+    def has_origin(self, origin):
+        """Returns a boolean value indicating whether a matching
+        'origin' exists for the repository.
+
+        'origin' can be a RepositoryURI object or a URI string."""
+
+        if not isinstance(origin, RepositoryURI):
+            origin = RepositoryURI(origin)
+        return origin in self.origins
+
+    def remove_legal_uri(self, uri):
+        """Removes the legal URI matching 'uri' from the repository.
+
+        'uri' can be a RepositoryURI object or a URI string."""
+
+        for i, m in enumerate(self.legal_uris):
+            if uri == m.uri:
+                # Immediate return as the index into the array
+                # changes with each removal.
+                del self.legal_uris[i]
+                return
+        raise api_errors.UnknownLegalURI(uri)
+
+    def remove_mirror(self, mirror):
+        """Removes the mirror matching 'mirror' from the repository.
+
+        'mirror' can be a RepositoryURI object or a URI string."""
+
+        if not isinstance(mirror, RepositoryURI):
+            mirror = misc.url_affix_trailing_slash(mirror)
+        for i, m in enumerate(self.mirrors):
+            if mirror == m.uri:
+                if m.system:
+                    api_errors.RemoveSyspubMirror(mirror.uri)
+                # Immediate return as the index into the array
+                # changes with each removal.
+                del self.mirrors[i]
+                return
+        raise api_errors.UnknownRepositoryMirror(mirror)
+
+    def remove_origin(self, origin):
+        """Removes the origin matching 'origin' from the repository.
+
+        'origin' can be a RepositoryURI object or a URI string."""
+
+        if not isinstance(origin, RepositoryURI):
+            origin = RepositoryURI(origin)
+        for i, o in enumerate(self.origins):
+            if origin == o.uri:
+                if o.system:
+                    raise api_errors.RemoveSyspubOrigin(origin.uri)
+                # Immediate return as the index into the array
+                # changes with each removal.
+                del self.origins[i]
+                return
+        raise api_errors.UnknownRepositoryOrigin(origin)
+
+    def remove_related_uri(self, uri):
+        """Removes the related URI matching 'uri' from the repository.
+
+        'uri' can be a RepositoryURI object or a URI string."""
+
+        for i, m in enumerate(self.related_uris):
+            if uri == m.uri:
+                # Immediate return as the index into the array
+                # changes with each removal.
+                del self.related_uris[i]
+                return
+        raise api_errors.UnknownRelatedURI(uri)
+
+    def update_mirror(self, mirror, priority=None, ssl_cert=None, ssl_key=None):
+        """Updates an existing mirror object matching 'mirror'.
+
+        'mirror' can be a RepositoryURI object or a URI string.
+
+        This method is deprecated, and may be removed in future API
+        versions."""
+
+        if not isinstance(mirror, RepositoryURI):
+            mirror = RepositoryURI(
+                mirror, priority=priority, ssl_cert=ssl_cert, ssl_key=ssl_key
+            )
+
+        target = self.get_mirror(mirror)
+        target.priority = mirror.priority
+        target.ssl_cert = mirror.ssl_cert
+        target.ssl_key = mirror.ssl_key
+        target.proxies = mirror.proxies
+        self.mirrors.sort(key=URI_SORT_POLICIES[self.__sort_policy])
+
+    def update_origin(self, origin, priority=None, ssl_cert=None, ssl_key=None):
+        """Updates an existing origin object matching 'origin'.
+
+        'origin' can be a RepositoryURI object or a URI string.
+
+        This method is deprecated, and may be removed in future API
+        versions."""
+
+        if not isinstance(origin, RepositoryURI):
+            origin = RepositoryURI(
+                origin, priority=priority, ssl_cert=ssl_cert, ssl_key=ssl_key
+            )
+
+        target = self.get_origin(origin)
+        target.priority = origin.priority
+        target.ssl_cert = origin.ssl_cert
+        target.ssl_key = origin.ssl_key
+        target.proxies = origin.proxies
+        self.origins.sort(key=URI_SORT_POLICIES[self.__sort_policy])
+
+    def reset_mirrors(self):
+        """Discards the current list of repository mirrors."""
+
+        self.mirrors = []
+
+    def reset_origins(self):
+        """Discards the current list of repository origins."""
+
+        self.origins = []
+
+    collection_type = property(
+        lambda self: self.__collection_type,
+        __set_collection_type,
+        None,
+        """A constant value indicating the type of packages in the
             repository.  The following collection types are recognized:
 
                     REPO_CTYPE_CORE
@@ -1131,417 +1303,481 @@ class Repository(object):
                     REPO_CTYPE_SUPPLEMENTAL
                         The "supplemental" type indicates that the repository
                         contains packages that rely on or are intended to be
-                        used with packages located in another repository.""")
+                        used with packages located in another repository.""",
+    )
 
-        legal_uris = property(lambda self: self.__legal_uris,
-            __set_legal_uris, None,
-            """A list of RepositoryURI objects indicating where licensing,
+    legal_uris = property(
+        lambda self: self.__legal_uris,
+        __set_legal_uris,
+        None,
+        """A list of RepositoryURI objects indicating where licensing,
             legal, and terms of service information for the repository can be
-            found.""")
+            found.""",
+    )
 
-        mirrors = property(lambda self: self.__mirrors, __set_mirrors, None,
-            """A list of RepositoryURI objects indicating where package content
+    mirrors = property(
+        lambda self: self.__mirrors,
+        __set_mirrors,
+        None,
+        """A list of RepositoryURI objects indicating where package content
             can be retrieved.  If any value in the list provided is a URI
-            string, it will be replaced with a RepositoryURI object.""")
+            string, it will be replaced with a RepositoryURI object.""",
+    )
 
-        origins = property(lambda self: self.__origins, __set_origins, None,
-            """A list of RepositoryURI objects indicating where package content
+    origins = property(
+        lambda self: self.__origins,
+        __set_origins,
+        None,
+        """A list of RepositoryURI objects indicating where package content
             can be retrieved.  If any value in the list provided is a URI
-            string, it will be replaced with a RepositoryURI object.""")
+            string, it will be replaced with a RepositoryURI object.""",
+    )
 
-        registration_uri = property(lambda self: self.__registration_uri,
-            __set_registration_uri, None,
-            """A RepositoryURI object indicating a location clients can use to
+    registration_uri = property(
+        lambda self: self.__registration_uri,
+        __set_registration_uri,
+        None,
+        """A RepositoryURI object indicating a location clients can use to
             register or obtain credentials needed to access the repository.  If
             the value provided is a URI string, it will be replaced with a
-            RepositoryURI object.""")
+            RepositoryURI object.""",
+    )
 
-        related_uris = property(lambda self: self.__related_uris,
-            __set_related_uris, None,
-            """A list of RepositoryURI objects indicating the location of
+    related_uris = property(
+        lambda self: self.__related_uris,
+        __set_related_uris,
+        None,
+        """A list of RepositoryURI objects indicating the location of
             related repositories that a client may be interested in.  If any
             value in the list provided is a URI string, it will be replaced with
-            a RepositoryURI object.""")
+            a RepositoryURI object.""",
+    )
 
-        refresh_seconds = property(lambda self: self.__refresh_seconds,
-            __set_refresh_seconds, None,
-            """An integer value indicating the number of seconds clients should
+    refresh_seconds = property(
+        lambda self: self.__refresh_seconds,
+        __set_refresh_seconds,
+        None,
+        """An integer value indicating the number of seconds clients should
             wait before refreshing cached repository metadata information.  A
             value of None indicates that refreshes should be performed at the
-            client's discretion.""")
+            client's discretion.""",
+    )
 
-        sort_policy = property(lambda self: self.__sort_policy,
-            __set_sort_policy, None,
-            """A constant value indicating how legal_uris, mirrors, origins, and
+    sort_policy = property(
+        lambda self: self.__sort_policy,
+        __set_sort_policy,
+        None,
+        """A constant value indicating how legal_uris, mirrors, origins, and
             related_uris should be sorted.  The following policies are
             recognized:
 
                     URI_SORT_PRIORITY
                         The "priority" policy indicate that URIs should be
                         sorted according to the value of their priority
-                        attribute.""")
+                        attribute.""",
+    )
 
 
 class Publisher(object):
-        """Class representing a publisher object and a set of interfaces to set
-        and retrieve its information.
+    """Class representing a publisher object and a set of interfaces to set
+    and retrieve its information.
 
-        A publisher is a forward or reverse domain name identifying a source
-        (e.g. "publisher") of packages."""
+    A publisher is a forward or reverse domain name identifying a source
+    (e.g. "publisher") of packages."""
 
-        # These properties are declared here so that they show up in the pydoc
-        # documentation as private, and for clarity in the property declarations
-        # found near the end of the class definition.
-        _catalog = None
-        __alias = None
-        __client_uuid = None
-        __client_uuid_time = None
-        __disabled = False
-        __meta_root = None
-        __origin_root = None
-        __prefix = None
-        __repository = None
-        __sticky = True
-        transport = None
+    # These properties are declared here so that they show up in the pydoc
+    # documentation as private, and for clarity in the property declarations
+    # found near the end of the class definition.
+    _catalog = None
+    __alias = None
+    __client_uuid = None
+    __client_uuid_time = None
+    __disabled = False
+    __meta_root = None
+    __origin_root = None
+    __prefix = None
+    __repository = None
+    __sticky = True
+    transport = None
 
-        # Used to store the id of the original object this one was copied
-        # from during __copy__.
-        _source_object_id = None
+    # Used to store the id of the original object this one was copied
+    # from during __copy__.
+    _source_object_id = None
 
+    def __init__(
+        self,
+        prefix,
+        alias=None,
+        catalog=None,
+        client_uuid=None,
+        disabled=False,
+        meta_root=None,
+        repository=None,
+        transport=None,
+        sticky=True,
+        props=None,
+        revoked_ca_certs=EmptyI,
+        approved_ca_certs=EmptyI,
+        sys_pub=False,
+        client_uuid_time=None,
+    ):
+        """Initialize a new publisher object.
 
-        def __init__(self, prefix, alias=None, catalog=None, client_uuid=None,
-            disabled=False, meta_root=None, repository=None,
-            transport=None, sticky=True, props=None, revoked_ca_certs=EmptyI,
-            approved_ca_certs=EmptyI, sys_pub=False, client_uuid_time=None):
-                """Initialize a new publisher object.
+        'catalog' is an optional Catalog object to use in place of
+        retrieving one from the publisher's meta_root.  This option
+        may only be used when meta_root is not provided.
+        """
 
-                'catalog' is an optional Catalog object to use in place of
-                retrieving one from the publisher's meta_root.  This option
-                may only be used when meta_root is not provided.
-                """
+        assert not (catalog and meta_root)
 
-                assert not (catalog and meta_root)
+        if (
+            client_uuid is None
+            or client_uuid_time is None
+            or not len(client_uuid_time)
+        ):
+            self.reset_client_uuid()
+        else:
+            self.__client_uuid = client_uuid
+            self.__client_uuid_time = client_uuid_time
 
-                if (client_uuid is None or client_uuid_time is None
-                    or not len(client_uuid_time)):
-                        self.reset_client_uuid()
-                else:
-                        self.__client_uuid = client_uuid
-                        self.__client_uuid_time = client_uuid_time
+        self.sys_pub = False
 
-                self.sys_pub = False
+        # Note that the properties set here are intentionally lacking
+        # the '__' prefix which means assignment will occur using the
+        # get/set methods declared for the property near the end of
+        # the class definition.
+        self.alias = alias
+        self.disabled = disabled
+        self.prefix = prefix
+        self.transport = transport
+        self.meta_root = meta_root
+        self.sticky = sticky
 
-                # Note that the properties set here are intentionally lacking
-                # the '__' prefix which means assignment will occur using the
-                # get/set methods declared for the property near the end of
-                # the class definition.
-                self.alias = alias
-                self.disabled = disabled
-                self.prefix = prefix
-                self.transport = transport
-                self.meta_root = meta_root
-                self.sticky = sticky
+        self.__sig_policy = None
+        self.__delay_validation = False
 
+        self.__properties = {}
 
-                self.__sig_policy = None
-                self.__delay_validation = False
+        # Writing out an EmptyI to a config file and reading it back
+        # in doesn't work correctly at the moment, but reading and
+        # writing an empty list does. So if intermediate_certs is empty,
+        # make sure it's stored as an empty list.
+        #
+        # The relevant implementation is probably the line which
+        # strips ][ from the input in imageconfig.read_list.
+        if revoked_ca_certs:
+            self.revoked_ca_certs = revoked_ca_certs
+        else:
+            self.revoked_ca_certs = []
 
-                self.__properties = {}
+        if approved_ca_certs:
+            self.approved_ca_certs = approved_ca_certs
+        else:
+            self.approved_ca_certs = []
 
-                # Writing out an EmptyI to a config file and reading it back
-                # in doesn't work correctly at the moment, but reading and
-                # writing an empty list does. So if intermediate_certs is empty,
-                # make sure it's stored as an empty list.
-                #
-                # The relevant implementation is probably the line which
-                # strips ][ from the input in imageconfig.read_list.
-                if revoked_ca_certs:
-                        self.revoked_ca_certs = revoked_ca_certs
-                else:
-                        self.revoked_ca_certs = []
+        if props:
+            self.properties.update(props)
 
-                if approved_ca_certs:
-                        self.approved_ca_certs = approved_ca_certs
-                else:
-                        self.approved_ca_certs = []
+        self.ca_dict = None
 
-                if props:
-                        self.properties.update(props)
+        if repository:
+            self.repository = repository
+        self.sys_pub = sys_pub
 
-                self.ca_dict = None
+        # A dictionary to story the mapping for subject -> certificate
+        # for those certificates we couldn't store on disk.
+        self.__issuers = {}
 
-                if repository:
-                        self.repository = repository
-                self.sys_pub = sys_pub
+        # Must be done last.
+        self._catalog = catalog
 
-                # A dictionary to story the mapping for subject -> certificate
-                # for those certificates we couldn't store on disk.
-                self.__issuers = {}
+    def __lt__(self, other):
+        if other is None:
+            return False
+        if isinstance(other, Publisher):
+            return self.prefix < other.prefix
+        return self.prefix < other
 
-                # Must be done last.
-                self._catalog = catalog
+    def __gt__(self, other):
+        if other is None:
+            return True
+        if isinstance(other, Publisher):
+            return self.prefix > other.prefix
+        return self.prefix > other
 
-        def __lt__(self, other):
-                if other is None:
-                        return False
-                if isinstance(other, Publisher):
-                        return self.prefix < other.prefix
-                return self.prefix < other
+    def __le__(self, other):
+        return not self > other
 
-        def __gt__(self, other):
-                if other is None:
-                        return True
-                if isinstance(other, Publisher):
-                        return self.prefix > other.prefix
-                return self.prefix > other
+    def __ge__(self, other):
+        return not self < other
 
-        def __le__(self, other):
-                return not self > other
+    @staticmethod
+    def __contains__(key):
+        """Supports deprecated compatibility interface."""
 
-        def __ge__(self, other):
-                return not self < other
+        return key in (
+            "client_uuid",
+            "disabled",
+            "mirrors",
+            "origin",
+            "prefix",
+            "ssl_cert",
+            "ssl_key",
+        )
 
-        @staticmethod
-        def __contains__(key):
-                """Supports deprecated compatibility interface."""
+    def __copy__(self):
+        selected = None
+        pub = Publisher(
+            self.__prefix,
+            alias=self.__alias,
+            client_uuid=self.__client_uuid,
+            disabled=self.__disabled,
+            meta_root=self.meta_root,
+            repository=copy.copy(self.repository),
+            transport=self.transport,
+            sticky=self.__sticky,
+            props=self.properties,
+            revoked_ca_certs=self.revoked_ca_certs,
+            approved_ca_certs=self.approved_ca_certs,
+            sys_pub=self.sys_pub,
+            client_uuid_time=self.__client_uuid_time,
+        )
+        pub._catalog = self._catalog
+        pub._source_object_id = id(self)
+        return pub
 
-                return key in ("client_uuid", "disabled", "mirrors", "origin",
-                    "prefix", "ssl_cert", "ssl_key")
+    def __eq__(self, other):
+        if isinstance(other, Publisher):
+            return self.prefix == other.prefix
+        if isinstance(other, str):
+            return self.prefix == other
+        return False
 
-        def __copy__(self):
-                selected = None
-                pub = Publisher(self.__prefix, alias=self.__alias,
-                    client_uuid=self.__client_uuid, disabled=self.__disabled,
-                    meta_root=self.meta_root,
-                    repository=copy.copy(self.repository),
-                    transport=self.transport, sticky=self.__sticky,
-                    props=self.properties,
-                    revoked_ca_certs=self.revoked_ca_certs,
-                    approved_ca_certs=self.approved_ca_certs,
-                    sys_pub=self.sys_pub,
-                    client_uuid_time=self.__client_uuid_time)
-                pub._catalog = self._catalog
-                pub._source_object_id = id(self)
-                return pub
+    __hash__ = object.__hash__
 
-        def __eq__(self, other):
-                if isinstance(other, Publisher):
-                        return self.prefix == other.prefix
-                if isinstance(other, str):
-                        return self.prefix == other
-                return False
+    def __getitem__(self, key):
+        """Deprecated compatibility interface allowing publisher
+        attributes to be read as pub["attribute"]."""
 
-        __hash__ = object.__hash__
+        if key == "client_uuid":
+            return self.__client_uuid
+        if key == "disabled":
+            return self.__disabled
+        if key == "prefix":
+            return self.__prefix
 
-        def __getitem__(self, key):
-                """Deprecated compatibility interface allowing publisher
-                attributes to be read as pub["attribute"]."""
+        repo = self.repository
+        if key == "mirrors":
+            return [str(m) for m in repo.mirrors]
+        if key == "origin":
+            if not repo.origins[0]:
+                return None
+            return repo.origins[0].uri
+        if key == "ssl_cert":
+            if not repo.origins[0]:
+                return None
+            return repo.origins[0].ssl_cert
+        if key == "ssl_key":
+            if not repo.origins[0]:
+                return None
+            return repo.origins[0].ssl_key
 
-                if key == "client_uuid":
-                        return self.__client_uuid
-                if key == "disabled":
-                        return self.__disabled
-                if key == "prefix":
-                        return self.__prefix
+    def __get_last_refreshed(self):
+        if not self.meta_root:
+            return None
 
-                repo = self.repository
-                if key == "mirrors":
-                        return [str(m) for m in repo.mirrors]
-                if key == "origin":
-                        if not repo.origins[0]:
-                                return None
-                        return repo.origins[0].uri
-                if key == "ssl_cert":
-                        if not repo.origins[0]:
-                                return None
-                        return repo.origins[0].ssl_cert
-                if key == "ssl_key":
-                        if not repo.origins[0]:
-                                return None
-                        return repo.origins[0].ssl_key
+        lcfile = os.path.join(self.meta_root, "last_refreshed")
+        try:
+            mod_time = os.stat(lcfile).st_mtime
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                return None
+            raise
+        return dt.datetime.utcfromtimestamp(mod_time)
 
-        def __get_last_refreshed(self):
-                if not self.meta_root:
-                        return None
+    def __get_nochild(self):
+        try:
+            return self.__properties["nochild"]
+        except KeyError:
+            return False
 
-                lcfile = os.path.join(self.meta_root, "last_refreshed")
-                try:
-                        mod_time = os.stat(lcfile).st_mtime
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                return None
-                        raise
-                return dt.datetime.utcfromtimestamp(mod_time)
+    def __ne__(self, other):
+        if isinstance(other, Publisher):
+            return self.prefix != other.prefix
+        if isinstance(other, str):
+            return self.prefix != other
+        return True
 
-        def __get_nochild(self):
-                try:
-                        return self.__properties['nochild']
-                except KeyError:
-                        return False
+    def __set_alias(self, value):
+        if self.sys_pub:
+            raise api_errors.ModifyingSyspubException(
+                "Cannot set the alias of a system publisher"
+            )
+        # Aliases must comply with the same restrictions that prefixes
+        # have as they are intended to be useable in any case where
+        # a prefix may be used.
+        if (
+            value is not None
+            and value != ""
+            and not misc.valid_pub_prefix(value)
+        ):
+            raise api_errors.BadPublisherAlias(value)
+        self.__alias = value
 
-        def __ne__(self, other):
-                if isinstance(other, Publisher):
-                        return self.prefix != other.prefix
-                if isinstance(other, str):
-                        return self.prefix != other
-                return True
+    def __set_disabled(self, disabled):
+        if self.sys_pub:
+            raise api_errors.ModifyingSyspubException(
+                _("Cannot " "enable or disable a system publisher")
+            )
 
-        def __set_alias(self, value):
-                if self.sys_pub:
-                        raise api_errors.ModifyingSyspubException(
-                            "Cannot set the alias of a system publisher")
-                # Aliases must comply with the same restrictions that prefixes
-                # have as they are intended to be useable in any case where
-                # a prefix may be used.
-                if value is not None and value != "" and \
-                    not misc.valid_pub_prefix(value):
-                        raise api_errors.BadPublisherAlias(value)
-                self.__alias = value
+        if disabled:
+            self.__disabled = True
+        else:
+            self.__disabled = False
 
-        def __set_disabled(self, disabled):
-                if self.sys_pub:
-                        raise api_errors.ModifyingSyspubException(_("Cannot "
-                            "enable or disable a system publisher"))
+    def __set_last_refreshed(self, value):
+        if not self.meta_root:
+            return
 
-                if disabled:
-                        self.__disabled = True
-                else:
-                        self.__disabled = False
+        if value is not None and not isinstance(value, dt.datetime):
+            raise api_errors.BadRepositoryAttributeValue(
+                "last_refreshed", value=value
+            )
 
-        def __set_last_refreshed(self, value):
-                if not self.meta_root:
-                        return
+        lcfile = os.path.join(self.meta_root, "last_refreshed")
+        if not value:
+            # If no value was provided, attempt to remove the
+            # tracking file.
+            try:
+                portable.remove(lcfile)
+            except EnvironmentError as e:
+                # If the file can't be removed due to
+                # permissions, a read-only filesystem, or
+                # because it doesn't exist, continue on.
+                if e.errno not in (errno.ENOENT, errno.EACCES, errno.EROFS):
+                    raise
+            return
 
-                if value is not None and not isinstance(value, dt.datetime):
-                        raise api_errors.BadRepositoryAttributeValue(
-                            "last_refreshed", value=value)
+        def create_tracker():
+            try:
+                # If the file is a symlink we catch an
+                # exception and do not update the file.
+                fd = os.open(lcfile, os.O_WRONLY | os.O_NOFOLLOW | os.O_CREAT)
+                os.write(
+                    fd,
+                    misc.force_bytes(
+                        "{0}\n".format(
+                            misc.time_to_timestamp(
+                                calendar.timegm(value.utctimetuple())
+                            )
+                        )
+                    ),
+                )
+                os.close(fd)
+            except EnvironmentError as e:
+                if e.errno == errno.ELOOP:
+                    raise api_errors.UnexpectedLinkError(
+                        os.path.dirname(lcfile),
+                        os.path.basename(lcfile),
+                        e.errno,
+                    )
+                # If the file can't be written due to
+                # permissions or because the filesystem is
+                # read-only, continue on.
+                if e.errno not in (errno.EACCES, errno.EROFS):
+                    raise
 
-                lcfile = os.path.join(self.meta_root, "last_refreshed")
-                if not value:
-                        # If no value was provided, attempt to remove the
-                        # tracking file.
-                        try:
-                                portable.remove(lcfile)
-                        except EnvironmentError as e:
-                                # If the file can't be removed due to
-                                # permissions, a read-only filesystem, or
-                                # because it doesn't exist, continue on.
-                                if e.errno not in (errno.ENOENT, errno.EACCES,
-                                    errno.EROFS):
-                                        raise
-                        return
+        try:
+            # If a time was provided, write out a special file that
+            # can be used to track the information with the actual
+            # time (in UTC) contained within.
+            create_tracker()
+        except EnvironmentError as e:
+            if e.errno != errno.ENOENT:
+                raise
 
-                def create_tracker():
-                        try:
-                                # If the file is a symlink we catch an
-                                # exception and do not update the file.
-                                fd = os.open(lcfile,
-                                    os.O_WRONLY|os.O_NOFOLLOW|os.O_CREAT)
-                                os.write(fd, misc.force_bytes("{0}\n".format(
-                                    misc.time_to_timestamp(
-                                    calendar.timegm(value.utctimetuple())))))
-                                os.close(fd)
-                        except EnvironmentError as e:
-                                if e.errno == errno.ELOOP:
-                                        raise api_errors.UnexpectedLinkError(
-                                            os.path.dirname(lcfile),
-                                            os.path.basename(lcfile),
-                                            e.errno)
-                                # If the file can't be written due to
-                                # permissions or because the filesystem is
-                                # read-only, continue on.
-                                if e.errno not in (errno.EACCES, errno.EROFS):
-                                        raise
-                try:
-                        # If a time was provided, write out a special file that
-                        # can be used to track the information with the actual
-                        # time (in UTC) contained within.
-                        create_tracker()
-                except EnvironmentError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
+            # Assume meta_root doesn't exist and create it.
+            try:
+                self.create_meta_root()
+            except api_errors.PermissionsException:
+                # If the directory can't be created due to
+                # permissions, move on.
+                pass
+            except EnvironmentError as e:
+                # If the directory can't be created due to a
+                # read-only filesystem, move on.
+                if e.errno != errno.EROFS:
+                    raise
+            else:
+                # Try one last time.
+                create_tracker()
 
-                        # Assume meta_root doesn't exist and create it.
-                        try:
-                                self.create_meta_root()
-                        except api_errors.PermissionsException:
-                                # If the directory can't be created due to
-                                # permissions, move on.
-                                pass
-                        except EnvironmentError as e:
-                                # If the directory can't be created due to a
-                                # read-only filesystem, move on.
-                                if e.errno != errno.EROFS:
-                                        raise
-                        else:
-                                # Try one last time.
-                                create_tracker()
+    def __set_meta_root(self, pathname):
+        if pathname:
+            pathname = os.path.abspath(pathname)
+        self.__meta_root = pathname
+        if self._catalog:
+            self._catalog.meta_root = self.catalog_root
+        if self.__meta_root:
+            self.__origin_root = os.path.join(self.__meta_root, "origins")
+            self.cert_root = os.path.join(self.__meta_root, "certs")
+            self.__subj_root = os.path.join(self.cert_root, "subject_hashes")
+            self.__crl_root = os.path.join(self.cert_root, "crls")
 
-        def __set_meta_root(self, pathname):
-                if pathname:
-                        pathname = os.path.abspath(pathname)
-                self.__meta_root = pathname
-                if self._catalog:
-                        self._catalog.meta_root = self.catalog_root
-                if self.__meta_root:
-                        self.__origin_root = os.path.join(self.__meta_root,
-                            "origins")
-                        self.cert_root = os.path.join(self.__meta_root, "certs")
-                        self.__subj_root = os.path.join(self.cert_root,
-                            "subject_hashes")
-                        self.__crl_root = os.path.join(self.cert_root, "crls")
+    def __set_prefix(self, prefix):
+        if not misc.valid_pub_prefix(prefix):
+            raise api_errors.BadPublisherPrefix(prefix)
+        self.__prefix = prefix
 
-        def __set_prefix(self, prefix):
-                if not misc.valid_pub_prefix(prefix):
-                        raise api_errors.BadPublisherPrefix(prefix)
-                self.__prefix = prefix
+    def __set_repository(self, value):
+        if not isinstance(value, Repository):
+            raise api_errors.UnknownRepository(value)
+        self.__repository = value
+        self._catalog = None
 
-        def __set_repository(self, value):
-                if not isinstance(value, Repository):
-                        raise api_errors.UnknownRepository(value)
-                self.__repository = value
-                self._catalog = None
+    def __set_client_uuid(self, value):
+        self.__client_uuid = value
 
-        def __set_client_uuid(self, value):
-                self.__client_uuid = value
+    def __set_client_uuid_time(self, value):
+        self.__client_uuid_time = value
 
-        def __set_client_uuid_time(self, value):
-                self.__client_uuid_time = value
+    def __set_stickiness(self, value):
+        if self.sys_pub:
+            raise api_errors.ModifyingSyspubException(
+                _("Cannot " "change the stickiness of a system publisher")
+            )
+        self.__sticky = bool(value)
 
-        def __set_stickiness(self, value):
-                if self.sys_pub:
-                        raise api_errors.ModifyingSyspubException(_("Cannot "
-                            "change the stickiness of a system publisher"))
-                self.__sticky = bool(value)
+    def __str__(self):
+        return self.prefix
 
-        def __str__(self):
-                return self.prefix
+    def __validate_metadata(self, croot, repo):
+        """Private helper function to check the publisher's metadata
+        for configuration or other issues and log appropriate warnings
+        or errors.  Currently only checks catalog metadata."""
 
-        def __validate_metadata(self, croot, repo):
-                """Private helper function to check the publisher's metadata
-                for configuration or other issues and log appropriate warnings
-                or errors.  Currently only checks catalog metadata."""
+        c = pkg.catalog.Catalog(meta_root=croot, read_only=True)
+        if not c.exists:
+            # Nothing to validate.
+            return
+        if not c.version > 0:
+            # Validation doesn't apply.
+            return
+        if not c.package_count:
+            # Nothing to do.
+            return
 
-                c = pkg.catalog.Catalog(meta_root=croot, read_only=True)
-                if not c.exists:
-                        # Nothing to validate.
-                        return
-                if not c.version > 0:
-                        # Validation doesn't apply.
-                        return
-                if not c.package_count:
-                        # Nothing to do.
-                        return
+        # XXX For now, perform this check using the catalog data.
+        # In the future, it should be done using the output of the
+        # publisher/0 operation.
+        pubs = c.publishers()
 
-                # XXX For now, perform this check using the catalog data.
-                # In the future, it should be done using the output of the
-                # publisher/0 operation.
-                pubs = c.publishers()
-
-                if self.prefix not in pubs:
-                        origins = repo.origins
-                        origin = origins[0]
-                        logger.error(_("""
+        if self.prefix not in pubs:
+            origins = repo.origins
+            origin = origins[0]
+            logger.error(
+                _(
+                    """
 Unable to retrieve package data for publisher '{prefix}' from one
 of the following origin(s):
 
@@ -1549,1778 +1785,1939 @@ of the following origin(s):
 
 The catalog retrieved from one of the origin(s) listed above only
 contains package data for: {pubs}.
-""").format(origins="\n".join(str(o) for o in origins), prefix=self.prefix,
-    pubs=", ".join(pubs)))
+"""
+                ).format(
+                    origins="\n".join(str(o) for o in origins),
+                    prefix=self.prefix,
+                    pubs=", ".join(pubs),
+                )
+            )
 
-                        if global_settings.client_name != "pkg":
-                                logger.error(_("""\
+            if global_settings.client_name != "pkg":
+                logger.error(
+                    _(
+                        """\
 This is either a result of invalid origin information being provided
 for publisher '{0}', or because the wrong publisher name was
 provided when this publisher was added.
-""").format(self.prefix))
-                                # Remaining messages are for pkg client only.
-                                return
+"""
+                    ).format(self.prefix)
+                )
+                # Remaining messages are for pkg client only.
+                return
 
-                        logger.error(_("""\
+            logger.error(
+                _(
+                    """\
 To resolve this issue, correct the origin information provided for
 publisher '{prefix}' using the pkg set-publisher subcommand, or re-add
 the publisher using the correct name and remove the '{prefix}'
 publisher.
-""").format(prefix=self.prefix))
+"""
+                ).format(prefix=self.prefix)
+            )
 
-                        if len(pubs) == 1:
-                                logger.warning(_("""\
+            if len(pubs) == 1:
+                logger.warning(
+                    _(
+                        """\
 To re-add this publisher with the correct name, execute the following
 commands as a privileged user:
 
 pkg set-publisher -P -g {origin} {pub}
 pkg unset-publisher {prefix}
-""").format(origin=origin, prefix=self.prefix, pub=list(pubs)[0]))
-                                return
+"""
+                    ).format(
+                        origin=origin, prefix=self.prefix, pub=list(pubs)[0]
+                    )
+                )
+                return
 
-                        logger.warning(_("""\
+            logger.warning(
+                _(
+                    """\
 The origin(s) listed above contain package data for more than one
 publisher, but this issue can likely be resolved by executing one
 of the following commands as a privileged user:
-"""))
+"""
+                )
+            )
 
-                        for pfx in pubs:
-                                logger.warning(_("pkg set-publisher -P -g "
-                                    "{origin} {pub}\n").format(
-                                    origin=origin, pub=pfx))
+            for pfx in pubs:
+                logger.warning(
+                    _("pkg set-publisher -P -g " "{origin} {pub}\n").format(
+                        origin=origin, pub=pfx
+                    )
+                )
 
-                        logger.warning(_("""\
+            logger.warning(
+                _(
+                    """\
 Afterwards, the old publisher should be removed by executing the
 following command as a privileged user:
 
 pkg unset-publisher {0}
-""").format(self.prefix))
+"""
+                ).format(self.prefix)
+            )
 
-        @property
-        def catalog(self):
-                """A reference to the Catalog object for the publisher's
-                selected repository, or None if available."""
+    @property
+    def catalog(self):
+        """A reference to the Catalog object for the publisher's
+        selected repository, or None if available."""
 
-                if not self.meta_root:
-                        if self._catalog:
-                                return self._catalog
-                        return None
-
-                if not self._catalog:
-                        croot = self.catalog_root
-                        if not os.path.isdir(croot):
-                                # Current meta_root structure is likely in
-                                # a state of transition, so don't provide a
-                                # meta_root.  Assume that an empty catalog
-                                # is desired instead.  (This can happen during
-                                # an image format upgrade.)
-                                croot = None
-                        self._catalog = pkg.catalog.Catalog(
-                            meta_root=croot)
+        if not self.meta_root:
+            if self._catalog:
                 return self._catalog
-
-        @property
-        def catalog_root(self):
-                """The absolute pathname of the directory containing the
-                Catalog data for the publisher, or None if meta_root is
-                not defined."""
-
-                if self.meta_root:
-                        return os.path.join(self.meta_root, "catalog")
-
-        def create_meta_root(self):
-                """Create the publisher's meta_root."""
-
-                if not self.meta_root:
-                        raise api_errors.BadPublisherMetaRoot(self.meta_root,
-                            operation="create_meta_root")
-
-                for path in (self.meta_root, self.catalog_root):
-                        try:
-                                os.makedirs(path)
-                        except EnvironmentError as e:
-                                if e.errno == errno.EACCES:
-                                        raise api_errors.PermissionsException(
-                                            e.filename)
-                                if e.errno == errno.EROFS:
-                                        raise api_errors.ReadOnlyFileSystemException(
-                                            e.filename)
-                                elif e.errno != errno.EEXIST:
-                                        # If the path already exists, move on.
-                                        # Otherwise, raise the exception.
-                                        raise
-                # Optional roots not needed for all operations.
-                for path in (self.cert_root, self.__origin_root,
-                    self.__subj_root, self.__crl_root):
-                        try:
-                                os.makedirs(path)
-                        except EnvironmentError as e:
-                                if e.errno in (errno.EACCES, errno.EROFS):
-                                        pass
-                                elif e.errno != errno.EEXIST:
-                                        # If the path already exists, move on.
-                                        # Otherwise, raise the exception.
-                                        raise
-
-        def get_origin_sets(self):
-                """Returns a list of Repository objects representing the unique
-                groups of origins available.  Each group is based on the origins
-                that share identical package catalog data."""
-
-                if not self.repository or not self.repository.origins:
-                        # Guard against failure for publishers with no
-                        # transport information.
-                        return []
-
-                if not self.meta_root or not os.path.exists(self.__origin_root):
-                        # No way to identify unique sets.
-                        return [self.repository]
-
-                # Index origins by tuple of (catalog creation, catalog modified)
-                osets = collections.defaultdict(list)
-
-                for origin, opath in self.__gen_origin_paths():
-                        cat = pkg.catalog.Catalog(meta_root=opath,
-                            read_only=True)
-                        if not cat.exists:
-                                key = None
-                        else:
-                                key = (str(cat.created), str(cat.last_modified))
-                        osets[key].append(origin)
-
-                # Now return a list of Repository objects (copies of the
-                # currently selected one) assigning each set of origins.
-                # Sort by index to ensure consistent ordering.
-                rval = []
-                for k in sorted(osets):
-                        nrepo = copy.copy(self.repository)
-                        nrepo.origins = osets[k]
-                        rval.append(nrepo)
-
-                return rval
-
-        def has_configuration(self):
-                """Returns whether this publisher has any configuration which
-                should prevent its removal."""
-
-                return bool(self.__repository.origins or
-                    self.__repository.mirrors or self.__sig_policy or
-                    self.approved_ca_certs or self.revoked_ca_certs)
-
-        @property
-        def needs_refresh(self):
-                """A boolean value indicating whether the publisher's
-                metadata for the currently selected repository needs to be
-                refreshed."""
-
-                if not self.repository or not self.meta_root:
-                        # Nowhere to obtain metadata from; this should rarely
-                        # occur except during publisher initialization.
-                        return False
-
-                lc = self.last_refreshed
-                if not lc:
-                        # There is no record of when the publisher metadata was
-                        # last refreshed, so assume it should be refreshed now.
-                        return True
-
-                ts_now = time.time()
-                ts_last = calendar.timegm(lc.utctimetuple())
-
-                rs = self.repository.refresh_seconds
-                if not rs:
-                        # There is no indicator of how often often publisher
-                        # metadata should be refreshed, so assume it should be
-                        # now.
-                        return True
-
-                if (ts_now - ts_last) >= rs:
-                        # The number of seconds that has elapsed since the
-                        # publisher metadata was last refreshed exceeds or
-                        # equals the specified interval.
-                        return True
-                return False
-
-        def __get_origin_path(self, origin):
-                if not os.path.exists(self.__origin_root):
-                        return
-                # A digest of the URI string is used here to attempt to avoid
-                # path length problems. In order for this image to interoperate
-                # with older clients, we must use sha-1 here.
-                return os.path.join(self.__origin_root,
-                    hashlib.sha1(misc.force_bytes(origin.uri)).hexdigest())
-
-        def __gen_origin_paths(self):
-                if not os.path.exists(self.__origin_root):
-                        return
-                for origin in self.repository.origins:
-                        if not origin.disabled:
-                                yield origin, self.__get_origin_path(origin)
-
-        def __rebuild_catalog(self):
-                """Private helper function that builds publisher catalog based
-                on catalog from each origin."""
-
-                # First, remove catalogs for any origins that no longer exist or
-                # are disabled.
-                # We must interoperate with older clients, so force the use of
-                # sha-1 here.
-                ohashes = [
-                    hashlib.sha1(misc.force_bytes(o.uri)).hexdigest()
-                    for o in self.repository.origins
-                    if not o.disabled
-                ]
-
-                removals = False
-                for entry in os.listdir(self.__origin_root):
-                        opath = os.path.join(self.__origin_root, entry)
-                        try:
-                                if entry in ohashes:
-                                        continue
-                        except Exception:
-                                # Discard anything that isn't an origin.
-                                pass
-
-                        # An origin was removed or disabled, so publisher should
-                        # inform image to force image catalog rebuild.
-                        removals = True
-
-                        # Not an origin or origin no longer exists; either way,
-                        # it shouldn't exist here.
-                        try:
-                                if os.path.isdir(opath):
-                                        shutil.rmtree(opath)
-                                else:
-                                        portable.remove(opath)
-                        except EnvironmentError as e:
-                                raise api_errors._convert_error(e)
-
-                # if the catalog already exists on disk, is empty, and if
-                # no origins are configured or all origins are disabled, we're
-                # done.
-                if self.catalog.exists and \
-                    self.catalog.package_count == 0 and \
-                    (not self.repository.origins
-                    or all(o.disabled for o in self.repository.origins)):
-                        return removals
-
-                # Discard existing catalog.
-                self.catalog.destroy()
-                self._catalog = None
-
-                # Ensure all old catalog files are removed.
-                for entry in os.listdir(self.catalog_root):
-                        if entry == "attrs" or entry == "catalog" or \
-                            entry.startswith("catalog."):
-                                try:
-                                        portable.remove(os.path.join(
-                                            self.catalog_root, entry))
-                                except EnvironmentError as e:
-                                        raise apx._convert_error(e)
-
-                # If there's only one origin, then just symlink its catalog
-                # files into place.
-                # Symlinking includes updates for publication tools.
-                opaths = [entry for entry in self.__gen_origin_paths()]
-                if len(opaths) == 1:
-                        opath = opaths[0][1]
-                        for fname in os.listdir(opath):
-                                if fname.startswith("catalog.") or \
-                                    fname.startswith("update."):
-                                        src = os.path.join(opath, fname)
-                                        dest = os.path.join(self.catalog_root,
-                                            fname)
-                                        os.symlink(misc.relpath(src,
-                                            self.catalog_root), dest)
-                        return removals
-
-                # If there's more than one origin, then create a new catalog
-                # based on a composite of the catalogs for all origins.
-                ncat = pkg.catalog.Catalog(batch_mode=True,
-                    meta_root=self.catalog_root, sign=False)
-
-                # Mark all operations as occurring at this time.
-                op_time = dt.datetime.utcnow()
-
-                for origin, opath in opaths:
-                        src_cat = pkg.catalog.Catalog(meta_root=opath,
-                            read_only=True)
-                        for name in src_cat.parts:
-                                spart = src_cat.get_part(name, must_exist=True)
-                                if spart is None:
-                                        # Client hasn't retrieved this part.
-                                        continue
-
-                                npart = ncat.get_part(name)
-                                base = name.startswith("catalog.base.")
-
-                                # Avoid accessor overhead since these will be
-                                # used for every entry.
-                                cat_ver = src_cat.version
-
-                                for t, sentry in spart.tuple_entries(
-                                    pubs=[self.prefix]):
-                                        pub, stem, ver = t
-
-                                        entry = dict(six.iteritems(sentry))
-                                        try:
-                                                npart.add(metadata=entry,
-                                                    op_time=op_time, pub=pub,
-                                                    stem=stem, ver=ver)
-                                        except api_errors.DuplicateCatalogEntry:
-                                                if not base:
-                                                        # Don't care.
-                                                        continue
-
-                                                # Destination entry is in
-                                                # catalog already.
-                                                entry = npart.get_entry(
-                                                    pub=pub, stem=stem, ver=ver)
-
-                                                src_sigs = set(
-                                                    s
-                                                    for s in sentry
-                                                    if s.startswith("signature-")
-                                                )
-                                                dest_sigs = set(
-                                                    s
-                                                    for s in entry
-                                                    if s.startswith("signature-")
-                                                )
-
-                                                if src_sigs != dest_sigs:
-                                                        # Ignore any packages
-                                                        # that are different
-                                                        # from the first
-                                                        # encountered for this
-                                                        # package version.
-                                                        # The client expects
-                                                        # these to always be
-                                                        # the same.  This seems
-                                                        # saner than failing.
-                                                        continue
-                                        else:
-                                                if not base:
-                                                        # Nothing to do.
-                                                        continue
-
-                                                # Destination entry is one just
-                                                # added.
-                                                entry["metadata"] = {
-                                                    "sources": [],
-                                                    "states": [],
-                                                }
-
-                                        entry["metadata"]["sources"].append(
-                                            origin.uri)
-
-                                        states = entry["metadata"]["states"]
-                                        if src_cat.version == 0:
-                                                states.append(
-                                                    pkgdefs.PKG_STATE_V0)
-
-                # Now go back and trim each entry to minimize footprint.  This
-                # ensures each package entry only has state and source info
-                # recorded when needed.
-                for t, entry in ncat.tuple_entries():
-                        pub, stem, ver = t
-                        mdata = entry["metadata"]
-                        if len(mdata["sources"]) == len(opaths):
-                                # Package is available from all origins, so
-                                # there's no need to require which ones
-                                # have it.
-                                del mdata["sources"]
-
-                        if len(mdata["states"]) < len(opaths):
-                                # At least one source is not V0, so the lazy-
-                                # load fallback for the package metadata isn't
-                                # needed.
-                                del mdata["states"]
-                        elif len(mdata["states"]) > 1:
-                                # Ensure only one instance of state value.
-                                mdata["states"] = [pkgdefs.PKG_STATE_V0]
-                        if not mdata:
-                                mdata = None
-                        ncat.update_entry(mdata, pub=pub, stem=stem, ver=ver)
-
-                # Finally, write out publisher catalog.
-                ncat.batch_mode = False
-                ncat.finalize()
-                ncat.save()
-                return removals
-
-        def __convert_v0_catalog(self, v0_cat, v1_root):
-                """Transforms the contents of the provided version 0 Catalog
-                into a version 1 Catalog, replacing the current Catalog."""
-
-                v0_lm = v0_cat.last_modified()
-                if v0_lm:
-                        # last_modified can be none if the catalog is empty.
-                        v0_lm = pkg.catalog.ts_to_datetime(v0_lm)
-
-                # There's no point in signing this catalog since it's simply
-                # a transformation of a v0 catalog.
-                v1_cat = pkg.catalog.Catalog(batch_mode=True,
-                    meta_root=v1_root, sign=False)
-
-                # A check for a previous non-zero package count is made to
-                # determine whether the last_modified date alone can be
-                # relied on.  This works around some oddities with empty
-                # v0 catalogs.
-                try:
-                        # Could be 'None'
-                        n0_pkgs = int(v0_cat.npkgs())
-                except (TypeError, ValueError):
-                        n0_pkgs = 0
-
-                if v1_cat.exists and n0_pkgs != v1_cat.package_version_count:
-                        if v0_lm == v1_cat.last_modified:
-                                # Already converted.
-                                return
-                        # Simply rebuild the entire v1 catalog every time, this
-                        # avoids many of the problems that could happen due to
-                        # deficiencies in the v0 implementation.
-                        v1_cat.destroy()
-                        self._catalog = None
-                        v1_cat = pkg.catalog.Catalog(meta_root=v1_root,
-                            sign=False)
-
-                # Now populate the v1 Catalog with the v0 Catalog's data.
-                for f in v0_cat.fmris():
-                        v1_cat.add_package(f)
-
-                # Normally, the Catalog's attributes are automatically
-                # populated as a result of catalog operations.  But in
-                # this case, we want the v1 Catalog's attributes to
-                # match those of the v0 catalog.
-                v1_cat.last_modified = v0_lm
-
-                # While this is a v1 catalog format-wise, v0 data is stored.
-                # This allows consumers to be aware that certain data won't be
-                # available in this catalog (such as dependencies, etc.).
-                v1_cat.version = 0
-
-                # Finally, save the new Catalog, and replace the old in-memory
-                # catalog.
-                v1_cat.batch_mode = False
-                v1_cat.finalize()
-                v1_cat.save()
-
-        def __refresh_v0(self, croot, full_refresh, immediate, repo):
-                """The method to refresh the publisher's metadata against
-                a catalog/0 source.  If the more recent catalog/1 version
-                isn't supported, this routine gets invoked as a fallback.
-                Returns a tuple of (changed, refreshed) where 'changed'
-                indicates whether new catalog data was found and 'refreshed'
-                indicates that catalog data was actually retrieved to determine
-                if there were any updates."""
-
-                if full_refresh:
-                        immediate = True
-
-                # Catalog needs v0 -> v1 transformation if repository only
-                # offers v0 catalog.
-                v0_cat = old_catalog.ServerCatalog(croot, read_only=True,
-                    publisher=self.prefix)
-
-                new_cat = True
-                v0_lm = None
-                if v0_cat.exists:
-                        repo = self.repository
-                        if full_refresh or v0_cat.origin() not in repo.origins:
-                                try:
-                                        v0_cat.destroy(root=croot)
-                                except EnvironmentError as e:
-                                        if e.errno == errno.EACCES:
-                                                raise api_errors.PermissionsException(
-                                                    e.filename)
-                                        if e.errno == errno.EROFS:
-                                                raise api_errors.ReadOnlyFileSystemException(
-                                                    e.filename)
-                                        raise
-                                immediate = True
-                        else:
-                                new_cat = False
-                                v0_lm = v0_cat.last_modified()
-
-                if not immediate and not self.needs_refresh:
-                        # No refresh needed.
-                        return False, False
-
-                import pkg.updatelog as old_ulog
-                try:
-                        # Note that this currently retrieves a v0 catalog that
-                        # has to be converted to v1 format.
-                        self.transport.get_catalog(self, v0_lm, path=croot,
-                            alt_repo=repo)
-                except old_ulog.UpdateLogException:
-                        # If an incremental update fails, attempt a full
-                        # catalog retrieval instead.
-                        try:
-                                v0_cat.destroy(root=croot)
-                        except EnvironmentError as e:
-                                if e.errno == errno.EACCES:
-                                        raise api_errors.PermissionsException(
-                                            e.filename)
-                                if e.errno == errno.EROFS:
-                                        raise api_errors.ReadOnlyFileSystemException(
-                                            e.filename)
-                                raise
-                        self.transport.get_catalog(self, path=croot,
-                            alt_repo=repo)
-
-                v0_cat = pkg.server.catalog.ServerCatalog(croot, read_only=True,
-                    publisher=self.prefix)
-
-                self.__convert_v0_catalog(v0_cat, croot)
-                if new_cat or v0_lm != v0_cat.last_modified():
-                        # If the catalog was rebuilt, or the timestamp of the
-                        # catalog changed, then an update has occurred.
-                        return True, True
-                return False, True
-
-        def __refresh_v1(self, croot, tempdir, full_refresh, immediate,
-            mismatched, repo, progtrack=None, include_updates=False):
-                """The method to refresh the publisher's metadata against
-                a catalog/1 source.  If the more recent catalog/1 version
-                isn't supported, __refresh_v0 is invoked as a fallback.
-                Returns a tuple of (changed, refreshed) where 'changed'
-                indicates whether new catalog data was found and 'refreshed'
-                indicates that catalog data was actually retrieved to determine
-                if there were any updates."""
-
-                # If full_refresh is True, then redownload should be True to
-                # ensure a non-cached version of the catalog is retrieved.
-                # If full_refresh is False, but mismatched is True, then
-                # the retrieval requests should indicate that content should
-                # be revalidated before being returned.  Note that this
-                # only applies to the catalog v1 case.
-                redownload = full_refresh
-                revalidate = not redownload and mismatched
-
-                v1_cat = pkg.catalog.Catalog(meta_root=croot)
-                try:
-                        self.transport.get_catalog1(self, ["catalog.attrs"],
-                            path=tempdir, redownload=redownload,
-                            revalidate=revalidate, alt_repo=repo,
-                            progtrack=progtrack)
-                except api_errors.UnsupportedRepositoryOperation:
-                        # No v1 catalogs available.
-                        if v1_cat.exists:
-                                # Ensure v1 -> v0 transition works right.
-                                v1_cat.destroy()
-                                self._catalog = None
-                        return self.__refresh_v0(croot, full_refresh, immediate,
-                            repo)
-
-                # If a v0 catalog is present, remove it before proceeding to
-                # ensure transitions between catalog versions work correctly.
-                v0_cat = old_catalog.ServerCatalog(croot, read_only=True,
-                    publisher=self.prefix)
-                if v0_cat.exists:
-                        v0_cat.destroy(root=croot)
-
-                # If above succeeded, we now have a catalog.attrs file.  Parse
-                # this to determine what other constituent parts need to be
-                # downloaded.
-                flist = []
-                if not full_refresh and v1_cat.exists:
-                        flist = v1_cat.get_updates_needed(tempdir)
-                        if flist == None:
-                                return False, True
+            return None
+
+        if not self._catalog:
+            croot = self.catalog_root
+            if not os.path.isdir(croot):
+                # Current meta_root structure is likely in
+                # a state of transition, so don't provide a
+                # meta_root.  Assume that an empty catalog
+                # is desired instead.  (This can happen during
+                # an image format upgrade.)
+                croot = None
+            self._catalog = pkg.catalog.Catalog(meta_root=croot)
+        return self._catalog
+
+    @property
+    def catalog_root(self):
+        """The absolute pathname of the directory containing the
+        Catalog data for the publisher, or None if meta_root is
+        not defined."""
+
+        if self.meta_root:
+            return os.path.join(self.meta_root, "catalog")
+
+    def create_meta_root(self):
+        """Create the publisher's meta_root."""
+
+        if not self.meta_root:
+            raise api_errors.BadPublisherMetaRoot(
+                self.meta_root, operation="create_meta_root"
+            )
+
+        for path in (self.meta_root, self.catalog_root):
+            try:
+                os.makedirs(path)
+            except EnvironmentError as e:
+                if e.errno == errno.EACCES:
+                    raise api_errors.PermissionsException(e.filename)
+                if e.errno == errno.EROFS:
+                    raise api_errors.ReadOnlyFileSystemException(e.filename)
+                elif e.errno != errno.EEXIST:
+                    # If the path already exists, move on.
+                    # Otherwise, raise the exception.
+                    raise
+        # Optional roots not needed for all operations.
+        for path in (
+            self.cert_root,
+            self.__origin_root,
+            self.__subj_root,
+            self.__crl_root,
+        ):
+            try:
+                os.makedirs(path)
+            except EnvironmentError as e:
+                if e.errno in (errno.EACCES, errno.EROFS):
+                    pass
+                elif e.errno != errno.EEXIST:
+                    # If the path already exists, move on.
+                    # Otherwise, raise the exception.
+                    raise
+
+    def get_origin_sets(self):
+        """Returns a list of Repository objects representing the unique
+        groups of origins available.  Each group is based on the origins
+        that share identical package catalog data."""
+
+        if not self.repository or not self.repository.origins:
+            # Guard against failure for publishers with no
+            # transport information.
+            return []
+
+        if not self.meta_root or not os.path.exists(self.__origin_root):
+            # No way to identify unique sets.
+            return [self.repository]
+
+        # Index origins by tuple of (catalog creation, catalog modified)
+        osets = collections.defaultdict(list)
+
+        for origin, opath in self.__gen_origin_paths():
+            cat = pkg.catalog.Catalog(meta_root=opath, read_only=True)
+            if not cat.exists:
+                key = None
+            else:
+                key = (str(cat.created), str(cat.last_modified))
+            osets[key].append(origin)
+
+        # Now return a list of Repository objects (copies of the
+        # currently selected one) assigning each set of origins.
+        # Sort by index to ensure consistent ordering.
+        rval = []
+        for k in sorted(osets):
+            nrepo = copy.copy(self.repository)
+            nrepo.origins = osets[k]
+            rval.append(nrepo)
+
+        return rval
+
+    def has_configuration(self):
+        """Returns whether this publisher has any configuration which
+        should prevent its removal."""
+
+        return bool(
+            self.__repository.origins
+            or self.__repository.mirrors
+            or self.__sig_policy
+            or self.approved_ca_certs
+            or self.revoked_ca_certs
+        )
+
+    @property
+    def needs_refresh(self):
+        """A boolean value indicating whether the publisher's
+        metadata for the currently selected repository needs to be
+        refreshed."""
+
+        if not self.repository or not self.meta_root:
+            # Nowhere to obtain metadata from; this should rarely
+            # occur except during publisher initialization.
+            return False
+
+        lc = self.last_refreshed
+        if not lc:
+            # There is no record of when the publisher metadata was
+            # last refreshed, so assume it should be refreshed now.
+            return True
+
+        ts_now = time.time()
+        ts_last = calendar.timegm(lc.utctimetuple())
+
+        rs = self.repository.refresh_seconds
+        if not rs:
+            # There is no indicator of how often often publisher
+            # metadata should be refreshed, so assume it should be
+            # now.
+            return True
+
+        if (ts_now - ts_last) >= rs:
+            # The number of seconds that has elapsed since the
+            # publisher metadata was last refreshed exceeds or
+            # equals the specified interval.
+            return True
+        return False
+
+    def __get_origin_path(self, origin):
+        if not os.path.exists(self.__origin_root):
+            return
+        # A digest of the URI string is used here to attempt to avoid
+        # path length problems. In order for this image to interoperate
+        # with older clients, we must use sha-1 here.
+        return os.path.join(
+            self.__origin_root,
+            hashlib.sha1(misc.force_bytes(origin.uri)).hexdigest(),
+        )
+
+    def __gen_origin_paths(self):
+        if not os.path.exists(self.__origin_root):
+            return
+        for origin in self.repository.origins:
+            if not origin.disabled:
+                yield origin, self.__get_origin_path(origin)
+
+    def __rebuild_catalog(self):
+        """Private helper function that builds publisher catalog based
+        on catalog from each origin."""
+
+        # First, remove catalogs for any origins that no longer exist or
+        # are disabled.
+        # We must interoperate with older clients, so force the use of
+        # sha-1 here.
+        ohashes = [
+            hashlib.sha1(misc.force_bytes(o.uri)).hexdigest()
+            for o in self.repository.origins
+            if not o.disabled
+        ]
+
+        removals = False
+        for entry in os.listdir(self.__origin_root):
+            opath = os.path.join(self.__origin_root, entry)
+            try:
+                if entry in ohashes:
+                    continue
+            except Exception:
+                # Discard anything that isn't an origin.
+                pass
+
+            # An origin was removed or disabled, so publisher should
+            # inform image to force image catalog rebuild.
+            removals = True
+
+            # Not an origin or origin no longer exists; either way,
+            # it shouldn't exist here.
+            try:
+                if os.path.isdir(opath):
+                    shutil.rmtree(opath)
                 else:
-                        attrs = pkg.catalog.CatalogAttrs(meta_root=tempdir)
-                        for name in attrs.parts:
-                                locale = name.split(".", 2)[2]
-                                # XXX Skip parts that aren't in the C locale for
-                                # now.
-                                if locale != "C":
-                                        continue
-                                flist.append(name)
-                        if include_updates:
-                                for update in attrs.updates:
-                                        flist.append(update)
+                    portable.remove(opath)
+            except EnvironmentError as e:
+                raise api_errors._convert_error(e)
 
-                if flist:
-                        # More catalog files to retrieve.
-                        try:
-                                self.transport.get_catalog1(self, flist,
-                                    path=tempdir, redownload=redownload,
-                                    revalidate=revalidate, alt_repo=repo,
-                                    progtrack=progtrack)
-                        except api_errors.UnsupportedRepositoryOperation:
-                                # Couldn't find a v1 catalog after getting one
-                                # before.  This would be a bizzare error, but we
-                                # can try for a v0 catalog anyway.
-                                return self.__refresh_v0(croot, full_refresh,
-                                    immediate, repo)
+        # if the catalog already exists on disk, is empty, and if
+        # no origins are configured or all origins are disabled, we're
+        # done.
+        if (
+            self.catalog.exists
+            and self.catalog.package_count == 0
+            and (
+                not self.repository.origins
+                or all(o.disabled for o in self.repository.origins)
+            )
+        ):
+            return removals
 
-                # Clear _catalog, so we'll read in the new catalog.
-                self._catalog = None
-                v1_cat = pkg.catalog.Catalog(meta_root=croot)
+        # Discard existing catalog.
+        self.catalog.destroy()
+        self._catalog = None
 
-                # At this point the client should have a set of the constituent
-                # pieces that are necessary to construct a catalog.  If a
-                # catalog already exists, call apply_updates.  Otherwise,
-                # move the files to the appropriate location.
-                validate = False
-                if not full_refresh and v1_cat.exists:
-                        v1_cat.apply_updates(tempdir)
-                else:
-                        if v1_cat.exists:
-                                # This is a full refresh.  Destroy
-                                # the existing catalog.
-                                v1_cat.destroy()
-
-                        for fn in os.listdir(tempdir):
-                                srcpath = os.path.join(tempdir, fn)
-                                dstpath = os.path.join(croot, fn)
-                                pkg.portable.rename(srcpath, dstpath)
-
-                        # Apply_updates validates the newly constructed catalog.
-                        # If refresh didn't call apply_updates, arrange to
-                        # have the new catalog validated.
-                        validate = True
-
-                if validate:
-                        try:
-                                v1_cat = pkg.catalog.Catalog(meta_root=croot)
-                                v1_cat.validate()
-                        except api_errors.BadCatalogSignatures:
-                                # If signature validation fails here, that means
-                                # that the attributes and individual parts were
-                                # self-consistent and not corrupt, but that the
-                                # attributes and parts didn't match.  This could
-                                # be the result of a broken source providing
-                                # an attributes file that is much older or newer
-                                # than the catalog parts being provided.
-                                v1_cat.destroy()
-                                raise api_errors.MismatchedCatalog(self.prefix)
-                return True, True
-
-        def __refresh_origin(self, croot, full_refresh, immediate, mismatched,
-            origin, progtrack=None, include_updates=False):
-                """Private helper method used to refresh catalog data for each
-                origin.  Returns a tuple of (changed, refreshed) where 'changed'
-                indicates whether new catalog data was found and 'refreshed'
-                indicates that catalog data was actually retrieved to determine
-                if there were any updates."""
-
-                # Create a copy of the current repository object that only
-                # contains the origin specified.
-                repo = copy.copy(self.repository)
-                repo.origins = [origin]
-
-                # Create temporary directory for assembly of catalog pieces.
+        # Ensure all old catalog files are removed.
+        for entry in os.listdir(self.catalog_root):
+            if (
+                entry == "attrs"
+                or entry == "catalog"
+                or entry.startswith("catalog.")
+            ):
                 try:
-                        misc.makedirs(croot)
-                        tempdir = tempfile.mkdtemp(dir=croot)
+                    portable.remove(os.path.join(self.catalog_root, entry))
                 except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise api_errors.ReadOnlyFileSystemException(
-                                    e.filename)
+                    raise apx._convert_error(e)
+
+        # If there's only one origin, then just symlink its catalog
+        # files into place.
+        # Symlinking includes updates for publication tools.
+        opaths = [entry for entry in self.__gen_origin_paths()]
+        if len(opaths) == 1:
+            opath = opaths[0][1]
+            for fname in os.listdir(opath):
+                if fname.startswith("catalog.") or fname.startswith("update."):
+                    src = os.path.join(opath, fname)
+                    dest = os.path.join(self.catalog_root, fname)
+                    os.symlink(misc.relpath(src, self.catalog_root), dest)
+            return removals
+
+        # If there's more than one origin, then create a new catalog
+        # based on a composite of the catalogs for all origins.
+        ncat = pkg.catalog.Catalog(
+            batch_mode=True, meta_root=self.catalog_root, sign=False
+        )
+
+        # Mark all operations as occurring at this time.
+        op_time = dt.datetime.utcnow()
+
+        for origin, opath in opaths:
+            src_cat = pkg.catalog.Catalog(meta_root=opath, read_only=True)
+            for name in src_cat.parts:
+                spart = src_cat.get_part(name, must_exist=True)
+                if spart is None:
+                    # Client hasn't retrieved this part.
+                    continue
+
+                npart = ncat.get_part(name)
+                base = name.startswith("catalog.base.")
+
+                # Avoid accessor overhead since these will be
+                # used for every entry.
+                cat_ver = src_cat.version
+
+                for t, sentry in spart.tuple_entries(pubs=[self.prefix]):
+                    pub, stem, ver = t
+
+                    entry = dict(six.iteritems(sentry))
+                    try:
+                        npart.add(
+                            metadata=entry,
+                            op_time=op_time,
+                            pub=pub,
+                            stem=stem,
+                            ver=ver,
+                        )
+                    except api_errors.DuplicateCatalogEntry:
+                        if not base:
+                            # Don't care.
+                            continue
+
+                        # Destination entry is in
+                        # catalog already.
+                        entry = npart.get_entry(pub=pub, stem=stem, ver=ver)
+
+                        src_sigs = set(
+                            s for s in sentry if s.startswith("signature-")
+                        )
+                        dest_sigs = set(
+                            s for s in entry if s.startswith("signature-")
+                        )
+
+                        if src_sigs != dest_sigs:
+                            # Ignore any packages
+                            # that are different
+                            # from the first
+                            # encountered for this
+                            # package version.
+                            # The client expects
+                            # these to always be
+                            # the same.  This seems
+                            # saner than failing.
+                            continue
+                    else:
+                        if not base:
+                            # Nothing to do.
+                            continue
+
+                        # Destination entry is one just
+                        # added.
+                        entry["metadata"] = {
+                            "sources": [],
+                            "states": [],
+                        }
+
+                    entry["metadata"]["sources"].append(origin.uri)
+
+                    states = entry["metadata"]["states"]
+                    if src_cat.version == 0:
+                        states.append(pkgdefs.PKG_STATE_V0)
+
+        # Now go back and trim each entry to minimize footprint.  This
+        # ensures each package entry only has state and source info
+        # recorded when needed.
+        for t, entry in ncat.tuple_entries():
+            pub, stem, ver = t
+            mdata = entry["metadata"]
+            if len(mdata["sources"]) == len(opaths):
+                # Package is available from all origins, so
+                # there's no need to require which ones
+                # have it.
+                del mdata["sources"]
+
+            if len(mdata["states"]) < len(opaths):
+                # At least one source is not V0, so the lazy-
+                # load fallback for the package metadata isn't
+                # needed.
+                del mdata["states"]
+            elif len(mdata["states"]) > 1:
+                # Ensure only one instance of state value.
+                mdata["states"] = [pkgdefs.PKG_STATE_V0]
+            if not mdata:
+                mdata = None
+            ncat.update_entry(mdata, pub=pub, stem=stem, ver=ver)
+
+        # Finally, write out publisher catalog.
+        ncat.batch_mode = False
+        ncat.finalize()
+        ncat.save()
+        return removals
+
+    def __convert_v0_catalog(self, v0_cat, v1_root):
+        """Transforms the contents of the provided version 0 Catalog
+        into a version 1 Catalog, replacing the current Catalog."""
+
+        v0_lm = v0_cat.last_modified()
+        if v0_lm:
+            # last_modified can be none if the catalog is empty.
+            v0_lm = pkg.catalog.ts_to_datetime(v0_lm)
+
+        # There's no point in signing this catalog since it's simply
+        # a transformation of a v0 catalog.
+        v1_cat = pkg.catalog.Catalog(
+            batch_mode=True, meta_root=v1_root, sign=False
+        )
+
+        # A check for a previous non-zero package count is made to
+        # determine whether the last_modified date alone can be
+        # relied on.  This works around some oddities with empty
+        # v0 catalogs.
+        try:
+            # Could be 'None'
+            n0_pkgs = int(v0_cat.npkgs())
+        except (TypeError, ValueError):
+            n0_pkgs = 0
+
+        if v1_cat.exists and n0_pkgs != v1_cat.package_version_count:
+            if v0_lm == v1_cat.last_modified:
+                # Already converted.
+                return
+            # Simply rebuild the entire v1 catalog every time, this
+            # avoids many of the problems that could happen due to
+            # deficiencies in the v0 implementation.
+            v1_cat.destroy()
+            self._catalog = None
+            v1_cat = pkg.catalog.Catalog(meta_root=v1_root, sign=False)
+
+        # Now populate the v1 Catalog with the v0 Catalog's data.
+        for f in v0_cat.fmris():
+            v1_cat.add_package(f)
+
+        # Normally, the Catalog's attributes are automatically
+        # populated as a result of catalog operations.  But in
+        # this case, we want the v1 Catalog's attributes to
+        # match those of the v0 catalog.
+        v1_cat.last_modified = v0_lm
+
+        # While this is a v1 catalog format-wise, v0 data is stored.
+        # This allows consumers to be aware that certain data won't be
+        # available in this catalog (such as dependencies, etc.).
+        v1_cat.version = 0
+
+        # Finally, save the new Catalog, and replace the old in-memory
+        # catalog.
+        v1_cat.batch_mode = False
+        v1_cat.finalize()
+        v1_cat.save()
+
+    def __refresh_v0(self, croot, full_refresh, immediate, repo):
+        """The method to refresh the publisher's metadata against
+        a catalog/0 source.  If the more recent catalog/1 version
+        isn't supported, this routine gets invoked as a fallback.
+        Returns a tuple of (changed, refreshed) where 'changed'
+        indicates whether new catalog data was found and 'refreshed'
+        indicates that catalog data was actually retrieved to determine
+        if there were any updates."""
+
+        if full_refresh:
+            immediate = True
+
+        # Catalog needs v0 -> v1 transformation if repository only
+        # offers v0 catalog.
+        v0_cat = old_catalog.ServerCatalog(
+            croot, read_only=True, publisher=self.prefix
+        )
+
+        new_cat = True
+        v0_lm = None
+        if v0_cat.exists:
+            repo = self.repository
+            if full_refresh or v0_cat.origin() not in repo.origins:
+                try:
+                    v0_cat.destroy(root=croot)
+                except EnvironmentError as e:
+                    if e.errno == errno.EACCES:
+                        raise api_errors.PermissionsException(e.filename)
+                    if e.errno == errno.EROFS:
+                        raise api_errors.ReadOnlyFileSystemException(e.filename)
+                    raise
+                immediate = True
+            else:
+                new_cat = False
+                v0_lm = v0_cat.last_modified()
+
+        if not immediate and not self.needs_refresh:
+            # No refresh needed.
+            return False, False
+
+        import pkg.updatelog as old_ulog
+
+        try:
+            # Note that this currently retrieves a v0 catalog that
+            # has to be converted to v1 format.
+            self.transport.get_catalog(self, v0_lm, path=croot, alt_repo=repo)
+        except old_ulog.UpdateLogException:
+            # If an incremental update fails, attempt a full
+            # catalog retrieval instead.
+            try:
+                v0_cat.destroy(root=croot)
+            except EnvironmentError as e:
+                if e.errno == errno.EACCES:
+                    raise api_errors.PermissionsException(e.filename)
+                if e.errno == errno.EROFS:
+                    raise api_errors.ReadOnlyFileSystemException(e.filename)
+                raise
+            self.transport.get_catalog(self, path=croot, alt_repo=repo)
+
+        v0_cat = pkg.server.catalog.ServerCatalog(
+            croot, read_only=True, publisher=self.prefix
+        )
+
+        self.__convert_v0_catalog(v0_cat, croot)
+        if new_cat or v0_lm != v0_cat.last_modified():
+            # If the catalog was rebuilt, or the timestamp of the
+            # catalog changed, then an update has occurred.
+            return True, True
+        return False, True
+
+    def __refresh_v1(
+        self,
+        croot,
+        tempdir,
+        full_refresh,
+        immediate,
+        mismatched,
+        repo,
+        progtrack=None,
+        include_updates=False,
+    ):
+        """The method to refresh the publisher's metadata against
+        a catalog/1 source.  If the more recent catalog/1 version
+        isn't supported, __refresh_v0 is invoked as a fallback.
+        Returns a tuple of (changed, refreshed) where 'changed'
+        indicates whether new catalog data was found and 'refreshed'
+        indicates that catalog data was actually retrieved to determine
+        if there were any updates."""
+
+        # If full_refresh is True, then redownload should be True to
+        # ensure a non-cached version of the catalog is retrieved.
+        # If full_refresh is False, but mismatched is True, then
+        # the retrieval requests should indicate that content should
+        # be revalidated before being returned.  Note that this
+        # only applies to the catalog v1 case.
+        redownload = full_refresh
+        revalidate = not redownload and mismatched
+
+        v1_cat = pkg.catalog.Catalog(meta_root=croot)
+        try:
+            self.transport.get_catalog1(
+                self,
+                ["catalog.attrs"],
+                path=tempdir,
+                redownload=redownload,
+                revalidate=revalidate,
+                alt_repo=repo,
+                progtrack=progtrack,
+            )
+        except api_errors.UnsupportedRepositoryOperation:
+            # No v1 catalogs available.
+            if v1_cat.exists:
+                # Ensure v1 -> v0 transition works right.
+                v1_cat.destroy()
+                self._catalog = None
+            return self.__refresh_v0(croot, full_refresh, immediate, repo)
+
+        # If a v0 catalog is present, remove it before proceeding to
+        # ensure transitions between catalog versions work correctly.
+        v0_cat = old_catalog.ServerCatalog(
+            croot, read_only=True, publisher=self.prefix
+        )
+        if v0_cat.exists:
+            v0_cat.destroy(root=croot)
+
+        # If above succeeded, we now have a catalog.attrs file.  Parse
+        # this to determine what other constituent parts need to be
+        # downloaded.
+        flist = []
+        if not full_refresh and v1_cat.exists:
+            flist = v1_cat.get_updates_needed(tempdir)
+            if flist == None:
+                return False, True
+        else:
+            attrs = pkg.catalog.CatalogAttrs(meta_root=tempdir)
+            for name in attrs.parts:
+                locale = name.split(".", 2)[2]
+                # XXX Skip parts that aren't in the C locale for
+                # now.
+                if locale != "C":
+                    continue
+                flist.append(name)
+            if include_updates:
+                for update in attrs.updates:
+                    flist.append(update)
+
+        if flist:
+            # More catalog files to retrieve.
+            try:
+                self.transport.get_catalog1(
+                    self,
+                    flist,
+                    path=tempdir,
+                    redownload=redownload,
+                    revalidate=revalidate,
+                    alt_repo=repo,
+                    progtrack=progtrack,
+                )
+            except api_errors.UnsupportedRepositoryOperation:
+                # Couldn't find a v1 catalog after getting one
+                # before.  This would be a bizzare error, but we
+                # can try for a v0 catalog anyway.
+                return self.__refresh_v0(croot, full_refresh, immediate, repo)
+
+        # Clear _catalog, so we'll read in the new catalog.
+        self._catalog = None
+        v1_cat = pkg.catalog.Catalog(meta_root=croot)
+
+        # At this point the client should have a set of the constituent
+        # pieces that are necessary to construct a catalog.  If a
+        # catalog already exists, call apply_updates.  Otherwise,
+        # move the files to the appropriate location.
+        validate = False
+        if not full_refresh and v1_cat.exists:
+            v1_cat.apply_updates(tempdir)
+        else:
+            if v1_cat.exists:
+                # This is a full refresh.  Destroy
+                # the existing catalog.
+                v1_cat.destroy()
+
+            for fn in os.listdir(tempdir):
+                srcpath = os.path.join(tempdir, fn)
+                dstpath = os.path.join(croot, fn)
+                pkg.portable.rename(srcpath, dstpath)
+
+            # Apply_updates validates the newly constructed catalog.
+            # If refresh didn't call apply_updates, arrange to
+            # have the new catalog validated.
+            validate = True
+
+        if validate:
+            try:
+                v1_cat = pkg.catalog.Catalog(meta_root=croot)
+                v1_cat.validate()
+            except api_errors.BadCatalogSignatures:
+                # If signature validation fails here, that means
+                # that the attributes and individual parts were
+                # self-consistent and not corrupt, but that the
+                # attributes and parts didn't match.  This could
+                # be the result of a broken source providing
+                # an attributes file that is much older or newer
+                # than the catalog parts being provided.
+                v1_cat.destroy()
+                raise api_errors.MismatchedCatalog(self.prefix)
+        return True, True
+
+    def __refresh_origin(
+        self,
+        croot,
+        full_refresh,
+        immediate,
+        mismatched,
+        origin,
+        progtrack=None,
+        include_updates=False,
+    ):
+        """Private helper method used to refresh catalog data for each
+        origin.  Returns a tuple of (changed, refreshed) where 'changed'
+        indicates whether new catalog data was found and 'refreshed'
+        indicates that catalog data was actually retrieved to determine
+        if there were any updates."""
+
+        # Create a copy of the current repository object that only
+        # contains the origin specified.
+        repo = copy.copy(self.repository)
+        repo.origins = [origin]
+
+        # Create temporary directory for assembly of catalog pieces.
+        try:
+            misc.makedirs(croot)
+            tempdir = tempfile.mkdtemp(dir=croot)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise api_errors.ReadOnlyFileSystemException(e.filename)
+            raise
+
+        # Make a test contact to the repo to see if it is responding.
+        # We need to pass in a publisher object which only has one
+        # origin so create one from our current publisher.
+        test_pub = copy.copy(self)
+        test_pub.repository = repo
+        self.transport.version_check(test_pub)
+
+        # Ensure that the temporary directory gets removed regardless
+        # of success or failure.
+        try:
+            rval = self.__refresh_v1(
+                croot,
+                tempdir,
+                full_refresh,
+                immediate,
+                mismatched,
+                repo,
+                progtrack=progtrack,
+                include_updates=include_updates,
+            )
+
+            # Perform publisher metadata sanity checks.
+            self.__validate_metadata(croot, repo)
+
+            return rval
+        finally:
+            # Cleanup tempdir.
+            shutil.rmtree(tempdir, True)
+
+    def __refresh(
+        self,
+        full_refresh,
+        immediate,
+        mismatched=False,
+        progtrack=None,
+        include_updates=False,
+        ignore_errors=False,
+    ):
+        """The method to handle the overall refresh process.  It
+        determines if a refresh is actually needed, and then calls
+        the first version-specific refresh method in the chain."""
+
+        assert self.transport
+
+        if full_refresh:
+            immediate = True
+
+        for origin, opath in self.__gen_origin_paths():
+            misc.makedirs(opath)
+            cat = pkg.catalog.Catalog(meta_root=opath, read_only=True)
+            if not cat.exists:
+                # If a catalog hasn't been retrieved for
+                # any of the origins, then a refresh is
+                # needed now.
+                immediate = True
+                break
+
+        # Ensure consistent directory structure.
+        self.create_meta_root()
+
+        # Check if we already have a v1 catalog on disk.
+        if not full_refresh and self.catalog.exists:
+            # If catalog is on disk, check if refresh is necessary.
+            if not immediate and not self.needs_refresh:
+                # No refresh needed.
+                return False, None
+
+        any_changed = False
+        any_refreshed = False
+        failed = []
+        total = 0
+        for origin, opath in self.__gen_origin_paths():
+            total += 1
+            try:
+                changed, refreshed = self.__refresh_origin(
+                    opath,
+                    full_refresh,
+                    immediate,
+                    mismatched,
+                    origin,
+                    progtrack=progtrack,
+                    include_updates=include_updates,
+                )
+            except api_errors.InvalidDepotResponseException as e:
+                failed.append((origin, e))
+            else:
+                if changed:
+                    any_changed = True
+                if refreshed:
+                    any_refreshed = True
+
+        if any_refreshed:
+            # Update refresh time.
+            self.last_refreshed = dt.datetime.utcnow()
+
+        # Finally, build a new catalog for this publisher based on a
+        # composite of the catalogs from all origins.
+        if self.__rebuild_catalog():
+            any_changed = True
+
+        errors = None
+        if failed:
+            errors = api_errors.CatalogOriginRefreshException(failed, total)
+
+        return any_changed, errors
+
+    def refresh(
+        self,
+        full_refresh=False,
+        immediate=False,
+        progtrack=None,
+        include_updates=False,
+    ):
+        """Refreshes the publisher's metadata, returning a tuple
+        containing a boolean value indicating whether any updates to the
+        publisher's metadata occurred and an error object, which is
+        either a CatalogOriginRefreshException containing all the failed
+        origins for this publisher or None.
+
+        'full_refresh' is an optional boolean value indicating whether
+        a full retrieval of publisher metadata (e.g. catalogs) or only
+        an update to the existing metadata should be performed.  When
+        True, 'immediate' is also set to True.
+
+        'immediate' is an optional boolean value indicating whether
+        a refresh should occur now.  If False, a publisher's selected
+        repository will be checked for updates only if needs_refresh
+        is True.
+
+        'include_updates' is an optional boolean value indicating
+        whether all catalog updates should be retrieved additionally to
+        the catalog."""
+
+        try:
+            return self.__refresh(
+                full_refresh,
+                immediate,
+                progtrack=progtrack,
+                include_updates=include_updates,
+            )
+        except (
+            api_errors.BadCatalogUpdateIdentity,
+            api_errors.DuplicateCatalogEntry,
+            api_errors.ObsoleteCatalogUpdate,
+            api_errors.UnknownUpdateType,
+        ):
+            if full_refresh:
+                # Completely unexpected failure.
+                # These exceptions should never
+                # be raised for a full refresh
+                # case anyway, so the error should
+                # definitely be raised.
+                raise
+
+            # The incremental update likely failed for one or
+            # more of the following reasons:
+            #
+            # * The origin for the publisher has changed.
+            #
+            # * The catalog that the publisher is offering
+            #   is now completely different (due to a restore
+            #   from backup or --rebuild possibly).
+            #
+            # * The catalog that the publisher is offering
+            #   has been restored to an older version, and
+            #   packages that already exist in this client's
+            #   copy of the catalog have been re-addded.
+            #
+            # * The type of incremental update operation that
+            #   that was performed on the catalog isn't supported
+            #   by this version of the client, so a full retrieval
+            #   is required.
+            #
+            return self.__refresh(True, True, progtrack=progtrack)
+        except api_errors.MismatchedCatalog:
+            if full_refresh:
+                # If this was a full refresh, don't bother
+                # retrying as it implies that the content
+                # retrieved wasn't cached.
+                raise
+
+            # Retrieval of the catalog attributes and/or parts was
+            # successful, but the identity (digest or other
+            # information) didn't match the catalog attributes.
+            # This could be the result of a misbehaving or stale
+            # cache.
+            return self.__refresh(
+                False, True, mismatched=True, progtrack=progtrack
+            )
+        except (api_errors.BadCatalogSignatures, api_errors.InvalidCatalogFile):
+            # Assembly of the catalog failed, but this could be due
+            # to a transient error.  So, retry at least once more.
+            return self.__refresh(True, True, progtrack=progtrack)
+        except (api_errors.BadCatalogSignatures, api_errors.InvalidCatalogFile):
+            # Assembly of the catalog failed, but this could be due
+            # to a transient error.  So, retry at least once more.
+            return self.__refresh(True, True, progtrack=progtrack)
+
+    def remove_meta_root(self):
+        """Removes the publisher's meta_root."""
+
+        if not self.meta_root:
+            raise api_errors.BadPublisherMetaRoot(
+                self.meta_root, operation="remove_meta_root"
+            )
+
+        try:
+            shutil.rmtree(self.meta_root)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise api_errors.ReadOnlyFileSystemException(e.filename)
+            if e.errno not in (errno.ENOENT, errno.ESRCH):
+                raise
+
+    def reset_client_uuid(self):
+        """Replaces the current client_uuid with a new UUID."""
+
+        self.__client_uuid = str(uuid.uuid1())
+        self.__client_uuid_time = dt.datetime.utcnow().ctime()
+
+    def validate_config(self, repo_uri=None):
+        """Verify that the publisher's configuration (such as prefix)
+        matches that provided by the repository.  If the configuration
+        does not match as expected, an UnknownRepositoryPublishers
+        exception will be raised.
+
+        'repo_uri' is an optional RepositoryURI object or URI string
+        containing the location of the repository.  If not provided,
+        the publisher's repository will be used instead."""
+
+        if repo_uri and not isinstance(repo_uri, RepositoryURI):
+            repo = RepositoryURI(repo_uri)
+        elif not repo_uri:
+            # Transport actually allows both type of objects.
+            repo = self
+        else:
+            repo = repo_uri
+
+        pubs = None
+        try:
+            pubs = self.transport.get_publisherdata(repo)
+        except (
+            api_errors.TransportError,
+            api_errors.UnsupportedRepositoryOperation,
+        ):
+            # Nothing more can be done (because the target origin
+            # can't be contacted, or because it doesn't support
+            # retrieval of publisher configuration data).
+            return
+
+        if not pubs:
+            raise api_errors.RepoPubConfigUnavailable(
+                location=repo_uri, pub=self
+            )
+
+        if self.prefix not in pubs:
+            known = [p.prefix for p in pubs]
+            if repo_uri:
+                raise api_errors.UnknownRepositoryPublishers(
+                    known=known, unknown=[self.prefix], location=repo_uri
+                )
+            raise api_errors.UnknownRepositoryPublishers(
+                known=known,
+                unknown=[self.prefix],
+                origins=self.repository.origins,
+            )
+
+    def approve_ca_cert(self, cert):
+        """Add the cert as a CA for manifest signing for this publisher.
+
+        The 'cert' parameter is a string of the certificate to add.
+        """
+
+        cert = self.__string_to_cert(cert)
+        hsh = self.__add_cert(cert)
+        # If the user had previously revoked this certificate, remove
+        # the certificate from that list.
+        if hsh in self.revoked_ca_certs:
+            t = set(self.revoked_ca_certs)
+            t.remove(hsh)
+            self.revoked_ca_certs = list(t)
+        self.approved_ca_certs.append(hsh)
+
+    def revoke_ca_cert(self, s):
+        """Record that the cert with hash 's' is no longer trusted
+        as a CA.  This method currently assumes it's only invoked as
+        a result of user action."""
+
+        self.revoked_ca_certs.append(s)
+        self.revoked_ca_certs = list(set(self.revoked_ca_certs))
+        if s in self.approved_ca_certs:
+            t = set(self.approved_ca_certs)
+            t.remove(s)
+            self.approved_ca_certs = list(t)
+
+    def unset_ca_cert(self, s):
+        """If the cert with hash 's' has been added or removed by the
+        user, undo the add or removal."""
+
+        if s in self.approved_ca_certs:
+            t = set(self.approved_ca_certs)
+            t.remove(s)
+            self.approved_ca_certs = list(t)
+        if s in self.revoked_ca_certs:
+            t = set(self.revoked_ca_certs)
+            t.remove(s)
+            self.revoked_ca_certs = list(t)
+
+    @staticmethod
+    def __hash_cert(c):
+        # In order to interoperate with older images, we must use SHA-1
+        # here.
+        return hashlib.sha1(
+            c.public_bytes(serialization.Encoding.PEM)
+        ).hexdigest()
+
+    @staticmethod
+    def __string_to_cert(s, pkg_hash=None):
+        """Convert a string to a X509 cert."""
+
+        try:
+            return x509.load_pem_x509_certificate(
+                misc.force_bytes(s), default_backend()
+            )
+        except ValueError:
+            if pkg_hash is not None:
+                raise api_errors.BadFileFormat(
+                    _(
+                        "The file "
+                        "with hash {0} was expected to be a PEM "
+                        "certificate but it could not be "
+                        "read."
+                    ).format(pkg_hash)
+                )
+            raise api_errors.BadFileFormat(
+                _(
+                    "The following string "
+                    "was expected to be a PEM certificate, but it "
+                    "could not be parsed as such:\n{0}".format(s)
+                )
+            )
+
+    def __add_cert(self, cert, pkg_hash=None):
+        """Add the pem representation of the certificate 'cert' to the
+        certificates this publisher knows about."""
+
+        self.create_meta_root()
+        if not pkg_hash:
+            pkg_hash = self.__hash_cert(cert)
+        pkg_hash_pth = os.path.join(self.cert_root, pkg_hash)
+        file_problem = False
+        try:
+            with open(pkg_hash_pth, "wb") as fh:
+                fh.write(cert.public_bytes(serialization.Encoding.PEM))
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(e.filename)
+            file_problem = True
+
+        # Note that while we store certs by their subject hashes,
+        # we use our own hashing since cryptography has no interface
+        # for the subject hash and other crypto frameworks have been
+        # inconsistent with OpenSSL.
+        subj_hsh = hashlib.sha1(misc.force_bytes(cert.subject)).hexdigest()
+        c = 0
+        made_link = False
+        while not made_link:
+            fn = os.path.join(self.__subj_root, "{0}.{1}".format(subj_hsh, c))
+            if os.path.exists(fn):
+                c += 1
+                continue
+            if not file_problem:
+                try:
+                    portable.link(pkg_hash_pth, fn)
+                    made_link = True
+                except EnvironmentError as e:
+                    pass
+            if not made_link:
+                self.__issuers.setdefault(subj_hsh, []).append(c)
+                made_link = True
+        return pkg_hash
+
+    def get_cert_by_hash(
+        self,
+        pkg_hash,
+        verify_hash=False,
+        only_retrieve=False,
+        hash_func=digest.DEFAULT_HASH_FUNC,
+    ):
+        """Given a pkg5 hash, retrieve the cert that's associated with
+        it.
+
+        The 'pkg_hash' parameter contains the file hash of the
+        certificate to retrieve.
+
+        The 'verify_hash' parameter determines the file that's read
+        from disk matches the expected hash.
+
+        The 'only_retrieve' parameter determines whether a X509 object
+        is built from the certificate retrieved or if the certificate
+        is only stored on disk."""
+
+        assert not (verify_hash and only_retrieve)
+        pth = os.path.join(self.cert_root, pkg_hash)
+        pth_exists = os.path.exists(pth)
+        if pth_exists and only_retrieve:
+            return None
+        if pth_exists:
+            with open(pth, "rb") as fh:
+                s = fh.read()
+        else:
+            s = self.transport.get_content(self, pkg_hash, hash_func=hash_func)
+        c = self.__string_to_cert(s, pkg_hash)
+        if not pth_exists:
+            try:
+                self.__add_cert(c, pkg_hash=pkg_hash)
+            except api_errors.PermissionsException:
+                pass
+        if only_retrieve:
+            return None
+
+        if verify_hash:
+            h = misc.get_data_digest(
+                BytesIO(misc.force_bytes(s)), length=len(s), hash_func=hash_func
+            )[0]
+            if h != pkg_hash:
+                raise api_errors.ModifiedCertificateException(c, pth)
+        return c
+
+    def __rebuild_subj_root(self):
+        """Rebuild subject hash metadata."""
+
+        # clean up the old subject hash files to prevent
+        # junk files residing in the directory
+        try:
+            shutil.rmtree(self.__subj_root)
+        except EnvironmentError:
+            # if unprivileged user, we can't add
+            # certs to it
+            pass
+        else:
+            for p in os.listdir(self.cert_root):
+                path = os.path.join(self.cert_root, p)
+                if not os.path.isfile(path):
+                    continue
+                with open(path, "rb") as fh:
+                    s = fh.read()
+                cert = self.__string_to_cert(s)
+                self.__add_cert(cert)
+
+    def __get_certs_by_name(self, name):
+        """Given 'name', a Cryptograhy 'Name' object, return the certs
+        with that name as a subject."""
+
+        res = []
+        count = 0
+        name_hsh = hashlib.sha1(misc.force_bytes(name)).hexdigest()
+
+        def load_cert(pth):
+            with open(pth, "rb") as f:
+                return x509.load_pem_x509_certificate(
+                    f.read(), default_backend()
+                )
+
+        try:
+            while True:
+                pth = os.path.join(
+                    self.__subj_root, "{0}.{1}".format(name_hsh, count)
+                )
+                res.append(load_cert(pth))
+                count += 1
+        except EnvironmentError as e:
+            # When switching to a different hash algorithm, the hash
+            # name of file changes so that we couldn't find the
+            # file. We try harder to rebuild the subject's metadata
+            # if it's the first time we fail (count == 0).
+            if count == 0 and e.errno == errno.ENOENT:
+                self.__rebuild_subj_root()
+                try:
+                    res.append(load_cert(pth))
+                except EnvironmentError as ex:
+                    if ex.errno != errno.ENOENT:
                         raise
 
-                # Make a test contact to the repo to see if it is responding.
-                # We need to pass in a publisher object which only has one
-                # origin so create one from our current publisher.
-                test_pub = copy.copy(self)
-                test_pub.repository = repo
-                self.transport.version_check(test_pub)
+            t = api_errors._convert_error(e, [errno.ENOENT])
+            if t:
+                raise t
+        res.extend(self.__issuers.get(name_hsh, []))
+        return res
 
-                # Ensure that the temporary directory gets removed regardless
-                # of success or failure.
+    def get_ca_certs(self):
+        """Return a dictionary of the CA certificates for this
+        publisher."""
+
+        if self.ca_dict is not None:
+            return self.ca_dict
+        self.ca_dict = {}
+        # CA certs approved for this publisher are stored by hash to
+        # prevent the later substitution or confusion over what certs
+        # have or have not been approved.
+        for h in set(self.approved_ca_certs):
+            c = self.get_cert_by_hash(h, verify_hash=True)
+            s = hashlib.sha1(misc.force_bytes(c.subject)).hexdigest()
+            self.ca_dict.setdefault(s, [])
+            self.ca_dict[s].append(c)
+        return self.ca_dict
+
+    def update_props(
+        self,
+        set_props=EmptyI,
+        add_prop_values=EmptyDict,
+        remove_prop_values=EmptyDict,
+        unset_props=EmptyI,
+    ):
+        """Update the properties set for this publisher with the ones
+        provided as arguments.  The order of application is that any
+        existing properties are unset, then properties are set to their
+        new values, then values are added to properties, and finally
+        values are removed from properties."""
+
+        # Delay validation so that any intermittent inconsistent state
+        # doesn't cause problems.
+        self.__delay_validation = True
+        # Remove existing properties.
+        for n in unset_props:
+            self.properties.pop(n, None)
+        # Add or reset new properties.
+        self.properties.update(set_props)
+        # Add new values to properties.
+        for n in add_prop_values.keys():
+            self.properties.setdefault(n, [])
+            if not isinstance(self.properties[n], list):
+                raise api_errors.InvalidPropertyValue(
+                    _(
+                        "Cannot add a value to a single valued "
+                        "property, The property name is '{name}' "
+                        "and the current value is '{value}'"
+                    ).format(name=n, value=self.properties[n])
+                )
+            self.properties[n].extend(add_prop_values[n])
+        # Remove values from properties.
+        for n in remove_prop_values.keys():
+            if n not in self.properties:
+                raise api_errors.InvalidPropertyValue(
+                    _(
+                        "Cannot remove a value from the property "
+                        "{name} because the property does not "
+                        "exist."
+                    ).format(name=n)
+                )
+            if not isinstance(self.properties[n], list):
+                raise api_errors.InvalidPropertyValue(
+                    _(
+                        "Cannot remove a value from a single "
+                        "valued property, unset must be used. The "
+                        "property name is '{name}' and the "
+                        "current value is '{value}'"
+                    ).format(name=n, value=self.properties[n])
+                )
+            for v in remove_prop_values[n]:
                 try:
-                        rval = self.__refresh_v1(croot, tempdir,
-                            full_refresh, immediate, mismatched, repo,
-                            progtrack=progtrack,
-                            include_updates=include_updates)
-
-                        # Perform publisher metadata sanity checks.
-                        self.__validate_metadata(croot, repo)
-
-                        return rval
-                finally:
-                        # Cleanup tempdir.
-                        shutil.rmtree(tempdir, True)
-
-        def __refresh(self, full_refresh, immediate, mismatched=False,
-	    progtrack=None, include_updates=False, ignore_errors=False):
-                """The method to handle the overall refresh process.  It
-                determines if a refresh is actually needed, and then calls
-                the first version-specific refresh method in the chain."""
-
-                assert self.transport
-
-                if full_refresh:
-                        immediate = True
-
-                for origin, opath in self.__gen_origin_paths():
-                        misc.makedirs(opath)
-                        cat = pkg.catalog.Catalog(meta_root=opath,
-                            read_only=True)
-                        if not cat.exists:
-                                # If a catalog hasn't been retrieved for
-                                # any of the origins, then a refresh is
-                                # needed now.
-                                immediate = True
-                                break
-
-                # Ensure consistent directory structure.
-                self.create_meta_root()
-
-                # Check if we already have a v1 catalog on disk.
-                if not full_refresh and self.catalog.exists:
-                        # If catalog is on disk, check if refresh is necessary.
-                        if not immediate and not self.needs_refresh:
-                                # No refresh needed.
-                                return False, None
-
-                any_changed = False
-                any_refreshed = False
-                failed = []
-                total = 0
-                for origin, opath in self.__gen_origin_paths():
-                        total += 1
-                        try:
-                                changed, refreshed = self.__refresh_origin(
-                                    opath, full_refresh, immediate, mismatched,
-                                    origin, progtrack=progtrack,
-                                    include_updates=include_updates)
-                        except api_errors.InvalidDepotResponseException as e:
-                                failed.append((origin, e))
-                        else:
-                                if changed:
-                                        any_changed = True
-                                if refreshed:
-                                        any_refreshed = True
-
-                if any_refreshed:
-                        # Update refresh time.
-                        self.last_refreshed = dt.datetime.utcnow()
-
-                # Finally, build a new catalog for this publisher based on a
-                # composite of the catalogs from all origins.
-                if self.__rebuild_catalog():
-                        any_changed = True
-
-                errors = None
-                if failed:
-                        errors = api_errors.CatalogOriginRefreshException(
-                            failed, total)
-
-                return any_changed, errors
-
-        def refresh(self, full_refresh=False, immediate=False, progtrack=None,
-            include_updates=False):
-                """Refreshes the publisher's metadata, returning a tuple
-                containing a boolean value indicating whether any updates to the 
-                publisher's metadata occurred and an error object, which is
-                either a CatalogOriginRefreshException containing all the failed
-                origins for this publisher or None.
-
-                'full_refresh' is an optional boolean value indicating whether
-                a full retrieval of publisher metadata (e.g. catalogs) or only
-                an update to the existing metadata should be performed.  When
-                True, 'immediate' is also set to True.
-
-                'immediate' is an optional boolean value indicating whether
-                a refresh should occur now.  If False, a publisher's selected
-                repository will be checked for updates only if needs_refresh
-                is True.
-
-                'include_updates' is an optional boolean value indicating
-                whether all catalog updates should be retrieved additionally to
-                the catalog."""
-
-                try:
-                        return self.__refresh(full_refresh, immediate,
-                            progtrack=progtrack,
-                            include_updates=include_updates)
-                except (api_errors.BadCatalogUpdateIdentity,
-                    api_errors.DuplicateCatalogEntry,
-                    api_errors.ObsoleteCatalogUpdate,
-                    api_errors.UnknownUpdateType):
-                        if full_refresh:
-                                # Completely unexpected failure.
-                                # These exceptions should never
-                                # be raised for a full refresh
-                                # case anyway, so the error should
-                                # definitely be raised.
-                                raise
-
-                        # The incremental update likely failed for one or
-                        # more of the following reasons:
-                        #
-                        # * The origin for the publisher has changed.
-                        #
-                        # * The catalog that the publisher is offering
-                        #   is now completely different (due to a restore
-                        #   from backup or --rebuild possibly).
-                        #
-                        # * The catalog that the publisher is offering
-                        #   has been restored to an older version, and
-                        #   packages that already exist in this client's
-                        #   copy of the catalog have been re-addded.
-                        #
-                        # * The type of incremental update operation that
-                        #   that was performed on the catalog isn't supported
-                        #   by this version of the client, so a full retrieval
-                        #   is required.
-                        #
-                        return self.__refresh(True, True, progtrack=progtrack)
-                except api_errors.MismatchedCatalog:
-                        if full_refresh:
-                                # If this was a full refresh, don't bother
-                                # retrying as it implies that the content
-                                # retrieved wasn't cached.
-                                raise
-
-                        # Retrieval of the catalog attributes and/or parts was
-                        # successful, but the identity (digest or other
-                        # information) didn't match the catalog attributes.
-                        # This could be the result of a misbehaving or stale
-                        # cache.
-                        return self.__refresh(False, True, mismatched=True,
-                            progtrack=progtrack)
-                except (api_errors.BadCatalogSignatures,
-                    api_errors.InvalidCatalogFile):
-                        # Assembly of the catalog failed, but this could be due
-                        # to a transient error.  So, retry at least once more.
-                        return self.__refresh(True, True, progtrack=progtrack)
-                except (api_errors.BadCatalogSignatures,
-                    api_errors.InvalidCatalogFile):
-                        # Assembly of the catalog failed, but this could be due
-                        # to a transient error.  So, retry at least once more.
-                        return self.__refresh(True, True, progtrack=progtrack)
-
-        def remove_meta_root(self):
-                """Removes the publisher's meta_root."""
-
-                if not self.meta_root:
-                        raise api_errors.BadPublisherMetaRoot(self.meta_root,
-                            operation="remove_meta_root")
-
-                try:
-                        shutil.rmtree(self.meta_root)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise api_errors.ReadOnlyFileSystemException(
-                                    e.filename)
-                        if e.errno not in (errno.ENOENT, errno.ESRCH):
-                                raise
-
-        def reset_client_uuid(self):
-                """Replaces the current client_uuid with a new UUID."""
-
-                self.__client_uuid = str(uuid.uuid1())
-                self.__client_uuid_time = dt.datetime.utcnow().ctime()
-
-        def validate_config(self, repo_uri=None):
-                """Verify that the publisher's configuration (such as prefix)
-                matches that provided by the repository.  If the configuration
-                does not match as expected, an UnknownRepositoryPublishers
-                exception will be raised.
-
-                'repo_uri' is an optional RepositoryURI object or URI string
-                containing the location of the repository.  If not provided,
-                the publisher's repository will be used instead."""
-
-                if repo_uri and not isinstance(repo_uri, RepositoryURI):
-                        repo = RepositoryURI(repo_uri)
-                elif not repo_uri:
-                        # Transport actually allows both type of objects.
-                        repo = self
-                else:
-                        repo = repo_uri
-
-                pubs = None
-                try:
-                        pubs = self.transport.get_publisherdata(repo)
-                except (api_errors.TransportError,
-                    api_errors.UnsupportedRepositoryOperation):
-                        # Nothing more can be done (because the target origin
-                        # can't be contacted, or because it doesn't support
-                        # retrieval of publisher configuration data).
-                        return
-
-                if not pubs:
-                        raise api_errors.RepoPubConfigUnavailable(
-                            location=repo_uri, pub=self)
-
-                if self.prefix not in pubs:
-                        known = [p.prefix for p in pubs]
-                        if repo_uri:
-                                raise api_errors.UnknownRepositoryPublishers(
-                                    known=known, unknown=[self.prefix],
-                                    location=repo_uri)
-                        raise api_errors.UnknownRepositoryPublishers(
-                            known=known, unknown=[self.prefix],
-                            origins=self.repository.origins)
-
-        def approve_ca_cert(self, cert):
-                """Add the cert as a CA for manifest signing for this publisher.
-
-                The 'cert' parameter is a string of the certificate to add.
-                """
-
-                cert = self.__string_to_cert(cert)
-                hsh = self.__add_cert(cert)
-                # If the user had previously revoked this certificate, remove
-                # the certificate from that list.
-                if hsh in self.revoked_ca_certs:
-                        t = set(self.revoked_ca_certs)
-                        t.remove(hsh)
-                        self.revoked_ca_certs = list(t)
-                self.approved_ca_certs.append(hsh)
-
-        def revoke_ca_cert(self, s):
-                """Record that the cert with hash 's' is no longer trusted
-                as a CA.  This method currently assumes it's only invoked as
-                a result of user action."""
-
-                self.revoked_ca_certs.append(s)
-                self.revoked_ca_certs = list(set(
-                    self.revoked_ca_certs))
-                if s in self.approved_ca_certs:
-                        t = set(self.approved_ca_certs)
-                        t.remove(s)
-                        self.approved_ca_certs = list(t)
-
-        def unset_ca_cert(self, s):
-                """If the cert with hash 's' has been added or removed by the
-                user, undo the add or removal."""
-
-                if s in self.approved_ca_certs:
-                        t = set(self.approved_ca_certs)
-                        t.remove(s)
-                        self.approved_ca_certs = list(t)
-                if s in self.revoked_ca_certs:
-                        t = set(self.revoked_ca_certs)
-                        t.remove(s)
-                        self.revoked_ca_certs = list(t)
-
-        @staticmethod
-        def __hash_cert(c):
-                # In order to interoperate with older images, we must use SHA-1
-                # here.
-                return hashlib.sha1(
-                    c.public_bytes(serialization.Encoding.PEM)).hexdigest()
-
-        @staticmethod
-        def __string_to_cert(s, pkg_hash=None):
-                """Convert a string to a X509 cert."""
-
-                try:
-                        return x509.load_pem_x509_certificate(
-                            misc.force_bytes(s), default_backend())
+                    self.properties[n].remove(v)
                 except ValueError:
-                        if pkg_hash is not None:
-                                raise api_errors.BadFileFormat(_("The file "
-                                    "with hash {0} was expected to be a PEM "
-                                    "certificate but it could not be "
-                                    "read.").format(pkg_hash))
-                        raise api_errors.BadFileFormat(_("The following string "
-                            "was expected to be a PEM certificate, but it "
-                            "could not be parsed as such:\n{0}".format(s)))
+                    raise api_errors.InvalidPropertyValue(
+                        _(
+                            "Cannot remove the value {value} "
+                            "from the property {name} "
+                            "because the value is not in the "
+                            "property's list."
+                        ).format(value=v, name=n)
+                    )
+        self.__delay_validation = False
+        self.__validate_properties()
 
-        def __add_cert(self, cert, pkg_hash=None):
-                """Add the pem representation of the certificate 'cert' to the
-                certificates this publisher knows about."""
+    def __validate_properties(self):
+        """Check that the properties set for this publisher are
+        consistent with each other."""
 
-                self.create_meta_root()
-                if not pkg_hash:
-                        pkg_hash = self.__hash_cert(cert)
-                pkg_hash_pth = os.path.join(self.cert_root, pkg_hash)
-                file_problem = False
-                try:
-                        with open(pkg_hash_pth, "wb") as fh:
-                                fh.write(cert.public_bytes(
-                                    serialization.Encoding.PEM))
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    e.filename)
-                        file_problem = True
+        if self.__properties.get(SIGNATURE_POLICY, "") == "require-names":
+            if not self.__properties.get("signature-required-names", None):
+                raise api_errors.InvalidPropertyValue(
+                    _(
+                        "At least one name must be provided for "
+                        "the signature-required-names policy."
+                    )
+                )
 
-                # Note that while we store certs by their subject hashes,
-                # we use our own hashing since cryptography has no interface
-                # for the subject hash and other crypto frameworks have been
-                # inconsistent with OpenSSL.
-                subj_hsh = hashlib.sha1(misc.force_bytes(
-                    cert.subject)).hexdigest()
-                c = 0
-                made_link = False
-                while not made_link:
-                        fn = os.path.join(self.__subj_root,
-                            "{0}.{1}".format(subj_hsh, c))
-                        if os.path.exists(fn):
-                                c += 1
-                                continue
-                        if not file_problem:
-                                try:
-                                        portable.link(pkg_hash_pth, fn)
-                                        made_link = True
-                                except EnvironmentError as e:
-                                        pass
-                        if not made_link:
-                                self.__issuers.setdefault(subj_hsh, []).append(
-                                    c)
-                                made_link = True
-                return pkg_hash
+    def __verify_x509_signature(self, c, key):
+        """Verify the signature of a certificate or CRL 'c' against a
+        provided public key 'key'."""
 
-        def get_cert_by_hash(self, pkg_hash, verify_hash=False,
-            only_retrieve=False, hash_func=digest.DEFAULT_HASH_FUNC):
-                """Given a pkg5 hash, retrieve the cert that's associated with
-                it.
+        if isinstance(c, x509.Certificate):
+            data = c.tbs_certificate_bytes
+        elif isinstance(c, x509.CertificateRevocationList):
+            data = c.tbs_certlist_bytes
+        else:
+            raise AssertionError(
+                "Invalid x509 object for "
+                "signature verification: {0}".format(type(c))
+            )
 
-                The 'pkg_hash' parameter contains the file hash of the
-                certificate to retrieve.
+        try:
+            key.verify(
+                c.signature,
+                data,
+                padding.PKCS1v15(),
+                c.signature_hash_algorithm,
+            )
+            return True
+        except Exception:
+            return False
 
-                The 'verify_hash' parameter determines the file that's read
-                from disk matches the expected hash.
+    def __check_crl(self, cert, ca_dict, crl_uri, more_uris=False):
+        """Determines whether the certificate has been revoked by the
+        CRL located at 'crl_uri'.
 
-                The 'only_retrieve' parameter determines whether a X509 object
-                is built from the certificate retrieved or if the certificate
-                is only stored on disk. """
+        The 'cert' parameter is the certificate to check for revocation.
 
-                assert not (verify_hash and only_retrieve)
-                pth = os.path.join(self.cert_root, pkg_hash)
-                pth_exists = os.path.exists(pth)
-                if pth_exists and only_retrieve:
-                        return None
-                if pth_exists:
-                        with open(pth, "rb") as fh:
-                                s = fh.read()
-                else:
-                        s = self.transport.get_content(self, pkg_hash,
-                            hash_func=hash_func)
-                c = self.__string_to_cert(s, pkg_hash)
-                if not pth_exists:
-                        try:
-                                self.__add_cert(c, pkg_hash=pkg_hash)
-                        except api_errors.PermissionsException:
-                                pass
-                if only_retrieve:
-                        return None
+        The 'ca_dict' is a dictionary which maps subject hashes to
+        certs treated as trust anchors."""
 
-                if verify_hash:
-                        h = misc.get_data_digest(BytesIO(misc.force_bytes(s)),
-                            length=len(s), hash_func=hash_func)[0]
-                        if h != pkg_hash:
-                                raise api_errors.ModifiedCertificateException(c,
-                                    pth)
-                return c
+        crl = None
+        if self.transport:
+            crl = self.transport.get_crl(
+                crl_uri, self.__crl_root, more_uris=more_uris
+            )
 
-        def __rebuild_subj_root(self):
-                """Rebuild subject hash metadata."""
+        # If we couldn't retrieve a CRL from the distribution point
+        # and no CRL is cached on disk, assume the cert has not been
+        # revoked.  It's possible that this should be an image or
+        # publisher setting in the future.
+        if not crl:
+            return True
 
-                # clean up the old subject hash files to prevent
-                # junk files residing in the directory
-                try:
-                        shutil.rmtree(self.__subj_root)
-                except EnvironmentError:
-                        # if unprivileged user, we can't add
-                        # certs to it
+        # A CRL has been found, now it needs to be validated like
+        # a certificate is.
+        verified_crl = False
+        crl_issuer = crl.issuer
+        tas = ca_dict.get(
+            hashlib.sha1(misc.force_bytes(crl_issuer)).hexdigest(), []
+        )
+        for t in tas:
+            try:
+                if self.__verify_x509_signature(crl, t.public_key()):
+                    # If t isn't approved for signing crls,
+                    # the exception __check_extensions
+                    # raises will take the code to the
+                    # except below.
+                    self.__check_extensions(t, CRL_SIGNING_USE, 0)
+                    verified_crl = True
+            except api_errors.SigningException:
+                pass
+        if not verified_crl:
+            crl_cas = self.__get_certs_by_name(crl_issuer)
+            for c in crl_cas:
+                if self.__verify_x509_signature(crl, c.public_key()):
+                    try:
+                        self.verify_chain(
+                            c, ca_dict, 0, True, usages=CRL_SIGNING_USE
+                        )
+                    except api_errors.SigningException:
                         pass
+                    else:
+                        verified_crl = True
+                        break
+        if not verified_crl:
+            return True
+
+        # For a certificate to be revoked, its CRL must be validated
+        # and revoked the certificate.
+
+        assert crl.issuer == cert.issuer
+        for rev in crl:
+            if rev.serial_number != cert.serial_number:
+                continue
+            try:
+                reason = rev.extensions.get_extension_for_oid(
+                    x509.OID_CRL_REASON
+                ).value
+            except x509.ExtensionNotFound:
+                reason = None
+            raise api_errors.RevokedCertificate(cert, reason)
+
+    def __check_crls(self, cert, ca_dict):
+        """Determines whether the certificate has been revoked by one of
+        its CRLs.
+
+        The 'cert' parameter is the certificate to check for revocation.
+
+        The 'ca_dict' is a dictionary which maps subject hashes to
+        certs treated as trust anchors."""
+
+        # If the certificate doesn't have a CRL location listed, treat
+        # it as valid.
+
+        # The CRLs to be retrieved are stored in the
+        # CRLDistributionPoints extensions which is structured like
+        # this:
+        #
+        # CRLDitsributionPoints = [
+        #     CRLDistributionPoint = [
+        #         union  {
+        #             full_name     = [ GeneralName, ... ]
+        #             relative_name = [ GeneralName, ... ]
+        #         }, ... ]
+        #     , ... ]
+        #
+        # Relative names are a feature in X509 certs which allow to
+        # specify a location relative to another certificate. We are not
+        # supporting this and I'm not sure anybody is using this for
+        # CRLs.
+        # Full names are absolute locations but can be in different
+        # formats (refer to RFC5280) but in general only the URI type is
+        # used for CRLs. So this is the only thing we support here.
+
+        try:
+            dps = cert.extensions.get_extension_for_oid(
+                x509.oid.ExtensionOID.CRL_DISTRIBUTION_POINTS
+            ).value
+        except x509.ExtensionNotFound:
+            return
+
+        crl_uris = []
+        for dp in dps:
+            if not dp.full_name:
+                # we don't support relative names
+                continue
+            for uri in dp.full_name:
+                if not isinstance(uri, x509.UniformResourceIdentifier):
+                    # we only support URIs
+                    continue
+                crl_uris.append(str(uri.value))
+
+        for i, uri in enumerate(crl_uris):
+            more_uris = i < len(crl_uris) - 1
+            self.__check_crl(cert, ca_dict, uri, more_uris=more_uris)
+
+    def __check_revocation(self, cert, ca_dict, use_crls):
+        hsh = self.__hash_cert(cert)
+        if hsh in self.revoked_ca_certs:
+            raise api_errors.RevokedCertificate(
+                cert, "User manually revoked certificate."
+            )
+        if use_crls:
+            self.__check_crls(cert, ca_dict)
+
+    def __check_extensions(self, cert, usages, cur_pathlen):
+        """Check whether the critical extensions in this certificate
+        are supported and allow the provided use(s)."""
+
+        try:
+            exts = cert.extensions
+        except ValueError as e:
+            raise api_errors.InvalidCertificateExtensions(cert, e)
+
+        def check_values(vs):
+            for v in vs:
+                if v in supported_vs:
+                    continue
+                # If there is only one extension value, it must
+                # be the problematic one. Otherwise, we also
+                # output the first unsupported value as the
+                # problematic value following extension value.
+                if len(vs) < 2:
+                    raise api_errors.UnsupportedExtensionValue(
+                        cert, ext, ", ".join(vs)
+                    )
+                raise api_errors.UnsupportedExtensionValue(
+                    cert, ext, ", ".join(vs), v
+                )
+
+        for ext in exts:
+            etype = type(ext.value)
+            if etype in SUPPORTED_EXTENSION_VALUES:
+                supported_vs = SUPPORTED_EXTENSION_VALUES[etype]
+                keys = EXTENSIONS_VALUES[etype]
+                if etype == x509.BasicConstraints:
+                    pathlen = ext.value.path_length
+                    if pathlen is not None and cur_pathlen > pathlen:
+                        raise api_errors.PathlenTooShort(
+                            cert, cur_pathlen, pathlen
+                        )
+                elif etype == x509.KeyUsage:
+                    keys = list(EXTENSIONS_VALUES[etype])
+                    if not getattr(ext.value, "key_agreement"):
+                        # Cryptography error:
+                        # encipher_only/decipher_only is
+                        # undefined unless key_agreement
+                        # is true
+                        keys.remove("encipher_only")
+                        keys.remove("decipher_only")
+                vs = [key for key in keys if getattr(ext.value, key)]
+                # Check whether the values for the extension are
+                # recognized.
+                check_values(vs)
+                # For each use, check to see whether it's
+                # permitted by the certificate's extension
+                # values.
+                if etype not in usages:
+                    continue
+                for u in usages[etype]:
+                    if u not in vs:
+                        raise api_errors.InappropriateCertificateUse(
+                            cert, ext, u, ", ".join(vs)
+                        )
+            # If the extension name is unrecognized and critical,
+            # then the chain cannot be verified.
+            elif ext.critical:
+                raise api_errors.UnsupportedCriticalExtension(cert, ext)
+
+    def verify_chain(
+        self,
+        cert,
+        ca_dict,
+        cur_pathlen,
+        use_crls,
+        required_names=None,
+        usages=None,
+    ):
+        """Validates the certificate against the given trust anchors.
+
+        The 'cert' parameter is the certificate to validate.
+
+        The 'ca_dict' parameter is a dictionary which maps subject
+        hashes to certs treated as trust anchors.
+
+        The 'cur_pathlen' parameter is an integer indicating how many
+        certificates have been found between cert and the leaf cert.
+
+        The 'use_crls' parameter is a boolean indicating whether
+        certificates should be checked to see if they've been revoked.
+
+        The 'required_names' parameter is a set of strings that must
+        be seen as a CN in the chain of trust for the certificate."""
+
+        if required_names is None:
+            required_names = set()
+        verified = False
+        continue_loop = True
+        certs_with_problems = []
+
+        ca_dict = copy.copy(ca_dict)
+        for k, v in six.iteritems(self.get_ca_certs()):
+            if k in ca_dict:
+                ca_dict[k].extend(v)
+            else:
+                ca_dict[k] = v
+
+        def merge_dicts(d1, d2):
+            """Function for merging usage dictionaries."""
+            res = copy.deepcopy(d1)
+            for k in d2:
+                if k in res:
+                    res[k].extend(d2[k])
                 else:
-                        for p in os.listdir(self.cert_root):
-                                path = os.path.join(self.cert_root, p)
-                                if not os.path.isfile(path):
-                                        continue
-                                with open(path, "rb") as fh:
-                                        s = fh.read()
-                                cert = self.__string_to_cert(s)
-                                self.__add_cert(cert)
+                    res[k] = d2[k]
+            return res
 
-        def __get_certs_by_name(self, name):
-                """Given 'name', a Cryptograhy 'Name' object, return the certs
-                with that name as a subject."""
+        def discard_names(cert, required_names):
+            for cert_cn in [
+                str(c.value)
+                for c in cert.subject.get_attributes_for_oid(
+                    x509.oid.NameOID.COMMON_NAME
+                )
+            ]:
+                required_names.discard(cert_cn)
 
-                res = []
-                count = 0
-                name_hsh = hashlib.sha1(misc.force_bytes(name)).hexdigest()
+        if not usages:
+            usages = {}
+            for u in POSSIBLE_USES:
+                usages = merge_dicts(usages, u)
 
-                def load_cert(pth):
-                        with open(pth, "rb") as f:
-                                return x509.load_pem_x509_certificate(
-                                    f.read(), default_backend())
+        # Check whether we can validate this certificate.
+        self.__check_extensions(cert, usages, cur_pathlen)
 
-                try:
-                        while True:
-                                pth = os.path.join(self.__subj_root,
-                                    "{0}.{1}".format(name_hsh, count))
-                                res.append(load_cert(pth))
-                                count += 1
-                except EnvironmentError as e:
-                        # When switching to a different hash algorithm, the hash
-                        # name of file changes so that we couldn't find the
-                        # file. We try harder to rebuild the subject's metadata
-                        # if it's the first time we fail (count == 0).
-                        if count == 0 and e.errno == errno.ENOENT:
-                                self.__rebuild_subj_root()
-                                try:
-                                        res.append(load_cert(pth))
-                                except EnvironmentError as ex:
-                                        if ex.errno != errno.ENOENT:
-                                                raise
+        # Check whether this certificate has been revoked.
+        self.__check_revocation(cert, ca_dict, use_crls)
 
-                        t = api_errors._convert_error(e,
-                            [errno.ENOENT])
-                        if t:
-                                raise t
-                res.extend(self.__issuers.get(name_hsh, []))
-                return res
+        while continue_loop:
+            # If this certificate's CN is in the set of required
+            # names, remove it.
+            discard_names(cert, required_names)
 
-        def get_ca_certs(self):
-                """Return a dictionary of the CA certificates for this
-                publisher."""
+            # Find the certificate that issued this certificate.
+            issuer = cert.issuer
+            issuer_hash = hashlib.sha1(misc.force_bytes(issuer)).hexdigest()
 
-                if self.ca_dict is not None:
-                        return self.ca_dict
-                self.ca_dict = {}
-                # CA certs approved for this publisher are stored by hash to
-                # prevent the later substitution or confusion over what certs
-                # have or have not been approved.
-                for h in set(self.approved_ca_certs):
-                        c = self.get_cert_by_hash(h, verify_hash=True)
-                        s = hashlib.sha1(misc.force_bytes(
-                            c.subject)).hexdigest()
-                        self.ca_dict.setdefault(s, [])
-                        self.ca_dict[s].append(c)
-                return self.ca_dict
+            # See whether this certificate was issued by any of the
+            # given trust anchors.
+            for c in ca_dict.get(issuer_hash, []):
+                if self.__verify_x509_signature(cert, c.public_key()):
+                    verified = True
+                    # Remove any required names found in the
+                    # trust anchor.
+                    discard_names(c, required_names)
+                    # If there are more names to check for
+                    # continue up the chain of trust to look
+                    # for them.
+                    if not required_names:
+                        continue_loop = False
+                    break
 
-        def update_props(self, set_props=EmptyI, add_prop_values=EmptyDict,
-            remove_prop_values=EmptyDict, unset_props=EmptyI):
-                """Update the properties set for this publisher with the ones
-                provided as arguments.  The order of application is that any
-                existing properties are unset, then properties are set to their
-                new values, then values are added to properties, and finally
-                values are removed from properties."""
-
-                # Delay validation so that any intermittent inconsistent state
-                # doesn't cause problems.
-                self.__delay_validation = True
-                # Remove existing properties.
-                for n in unset_props:
-                        self.properties.pop(n, None)
-                # Add or reset new properties.
-                self.properties.update(set_props)
-                # Add new values to properties.
-                for n in add_prop_values.keys():
-                        self.properties.setdefault(n, [])
-                        if not isinstance(self.properties[n], list):
-                                raise api_errors.InvalidPropertyValue(_(
-                                    "Cannot add a value to a single valued "
-                                    "property, The property name is '{name}' "
-                                    "and the current value is '{value}'"
-                                    ).format(name=n, value=self.properties[n]))
-                        self.properties[n].extend(add_prop_values[n])
-                # Remove values from properties.
-                for n in remove_prop_values.keys():
-                        if n not in self.properties:
-                                raise api_errors.InvalidPropertyValue(_(
-                                    "Cannot remove a value from the property "
-                                    "{name} because the property does not "
-                                    "exist.").format(name=n))
-                        if not isinstance(self.properties[n], list):
-                                raise api_errors.InvalidPropertyValue(_(
-                                    "Cannot remove a value from a single "
-                                    "valued property, unset must be used. The "
-                                    "property name is '{name}' and the "
-                                    "current value is '{value}'").format(
-                                    name=n, value=self.properties[n]))
-                        for v in remove_prop_values[n]:
-                                try:
-                                        self.properties[n].remove(v)
-                                except ValueError:
-                                        raise api_errors.InvalidPropertyValue(_(
-                                            "Cannot remove the value {value} "
-                                            "from the property {name} "
-                                            "because the value is not in the "
-                                            "property's list.").format(
-                                            value=v, name=n))
-                self.__delay_validation = False
-                self.__validate_properties()
-
-        def __validate_properties(self):
-                """Check that the properties set for this publisher are
-                consistent with each other."""
-
-                if self.__properties.get(SIGNATURE_POLICY, "") == \
-                    "require-names":
-                        if not self.__properties.get("signature-required-names",
-                            None):
-                                raise api_errors.InvalidPropertyValue(_(
-                                    "At least one name must be provided for "
-                                    "the signature-required-names policy."))
-
-        def __verify_x509_signature(self, c, key):
-                """Verify the signature of a certificate or CRL 'c' against a
-                provided public key 'key'."""
-
-                if isinstance(c, x509.Certificate):
-                        data = c.tbs_certificate_bytes
-                elif isinstance(c, x509.CertificateRevocationList):
-                        data = c.tbs_certlist_bytes
-                else:
-                        raise AssertionError("Invalid x509 object for "
-                            "signature verification: {0}".format(type(c)))
-
-                try:
-                        key.verify(c.signature, data, padding.PKCS1v15(),
-                            c.signature_hash_algorithm)
-                        return True
-                except Exception:
-                        return False
-
-        def __check_crl(self, cert, ca_dict, crl_uri, more_uris=False):
-                """Determines whether the certificate has been revoked by the
-                CRL located at 'crl_uri'.
-
-                The 'cert' parameter is the certificate to check for revocation.
-
-                The 'ca_dict' is a dictionary which maps subject hashes to
-                certs treated as trust anchors."""
-
-                crl = None
-                if self.transport:
-                        crl = self.transport.get_crl(crl_uri, self.__crl_root,
-                            more_uris=more_uris)
-
-                # If we couldn't retrieve a CRL from the distribution point
-                # and no CRL is cached on disk, assume the cert has not been
-                # revoked.  It's possible that this should be an image or
-                # publisher setting in the future.
-                if not crl:
-                        return True
-
-                # A CRL has been found, now it needs to be validated like
-                # a certificate is.
-                verified_crl = False
-                crl_issuer = crl.issuer
-                tas = ca_dict.get(hashlib.sha1(misc.force_bytes(
-                    crl_issuer)).hexdigest(), [])
-                for t in tas:
-                        try:
-                                if self.__verify_x509_signature(crl,
-                                    t.public_key()):
-                                        # If t isn't approved for signing crls,
-                                        # the exception __check_extensions
-                                        # raises will take the code to the
-                                        # except below.
-                                        self.__check_extensions(t,
-                                            CRL_SIGNING_USE, 0)
-                                        verified_crl = True
-                        except api_errors.SigningException:
-                                pass
-                if not verified_crl:
-                        crl_cas = self.__get_certs_by_name(crl_issuer)
-                        for c in crl_cas:
-                                if self.__verify_x509_signature(crl,
-                                    c.public_key()):
-                                        try:
-                                                self.verify_chain(c, ca_dict, 0,
-                                                    True,
-                                                    usages=CRL_SIGNING_USE)
-                                        except api_errors.SigningException:
-                                                pass
-                                        else:
-                                                verified_crl = True
-                                                break
-                if not verified_crl:
-                        return True
-
-                # For a certificate to be revoked, its CRL must be validated
-                # and revoked the certificate.
-
-                assert crl.issuer == cert.issuer
-                for rev in crl:
-                        if rev.serial_number != cert.serial_number:
-                                continue
-                        try:
-                                reason = rev.extensions.get_extension_for_oid(
-                                    x509.OID_CRL_REASON).value
-                        except x509.ExtensionNotFound:
-                                reason = None
-                        raise api_errors.RevokedCertificate(cert, reason)
-
-        def __check_crls(self, cert, ca_dict):
-                """Determines whether the certificate has been revoked by one of
-                its CRLs.
-
-                The 'cert' parameter is the certificate to check for revocation.
-
-                The 'ca_dict' is a dictionary which maps subject hashes to
-                certs treated as trust anchors."""
-
-                # If the certificate doesn't have a CRL location listed, treat
-                # it as valid.
-
-                # The CRLs to be retrieved are stored in the
-                # CRLDistributionPoints extensions which is structured like
-                # this:
-                #
-                # CRLDitsributionPoints = [
-                #     CRLDistributionPoint = [
-                #         union  {
-                #             full_name     = [ GeneralName, ... ]
-                #             relative_name = [ GeneralName, ... ]
-                #         }, ... ]
-                #     , ... ]
-                # 
-                # Relative names are a feature in X509 certs which allow to
-                # specify a location relative to another certificate. We are not
-                # supporting this and I'm not sure anybody is using this for
-                # CRLs.
-                # Full names are absolute locations but can be in different
-                # formats (refer to RFC5280) but in general only the URI type is
-                # used for CRLs. So this is the only thing we support here.
-
-                try:
-                        dps = cert.extensions.get_extension_for_oid(
-                            x509.oid.ExtensionOID.CRL_DISTRIBUTION_POINTS).value
-                except x509.ExtensionNotFound:
-                        return
-
-                crl_uris = []
-                for dp in dps:
-                        if not dp.full_name:
-                                # we don't support relative names
-                                continue
-                        for uri in dp.full_name:
-                                if not isinstance(uri,
-                                    x509.UniformResourceIdentifier):
-                                        # we only support URIs
-                                        continue
-                                crl_uris.append(str(uri.value))
-
-                for i, uri in enumerate(crl_uris):
-                        more_uris = i < len(crl_uris) - 1
-                        self.__check_crl(cert, ca_dict, uri,
-                            more_uris=more_uris)
-
-        def __check_revocation(self, cert, ca_dict, use_crls):
-                hsh = self.__hash_cert(cert)
-                if hsh in self.revoked_ca_certs:
-                        raise api_errors.RevokedCertificate(cert,
-                            "User manually revoked certificate.")
-                if use_crls:
-                        self.__check_crls(cert, ca_dict)
-
-        def __check_extensions(self, cert, usages, cur_pathlen):
-                """Check whether the critical extensions in this certificate
-                are supported and allow the provided use(s)."""
-
-                try:
-                        exts = cert.extensions
-                except ValueError as e:
-                        raise api_errors.InvalidCertificateExtensions(
-                            cert, e)
-
-                def check_values(vs):
-                        for v in vs:
-                                if v in supported_vs:
-                                        continue
-                                # If there is only one extension value, it must
-                                # be the problematic one. Otherwise, we also
-                                # output the first unsupported value as the
-                                # problematic value following extension value.
-                                if len(vs) < 2:
-                                        raise api_errors.UnsupportedExtensionValue(
-                                            cert, ext, ", ".join(vs))
-                                raise api_errors.UnsupportedExtensionValue(
-                                    cert, ext, ", ".join(vs), v)
-
-                for ext in exts:
-                        etype = type(ext.value)
-                        if etype in SUPPORTED_EXTENSION_VALUES:
-                                supported_vs = SUPPORTED_EXTENSION_VALUES[etype]
-                                keys = EXTENSIONS_VALUES[etype]
-                                if etype == x509.BasicConstraints:
-                                        pathlen = ext.value.path_length
-                                        if pathlen is not None and \
-                                            cur_pathlen > pathlen:
-                                                raise api_errors.PathlenTooShort(cert,
-                                                    cur_pathlen, pathlen)
-                                elif etype == x509.KeyUsage:
-                                        keys = list(EXTENSIONS_VALUES[etype])
-                                        if not getattr(ext.value,
-                                            "key_agreement"):
-                                                # Cryptography error:
-                                                # encipher_only/decipher_only is
-                                                # undefined unless key_agreement
-                                                # is true
-                                                keys.remove("encipher_only")
-                                                keys.remove("decipher_only")
-                                vs = [
-                                    key
-                                    for key in keys
-                                    if getattr(ext.value, key)
-                                ]
-                                # Check whether the values for the extension are
-                                # recognized.
-                                check_values(vs)
-                                # For each use, check to see whether it's
-                                # permitted by the certificate's extension
-                                # values.
-                                if etype not in usages:
-                                        continue
-                                for u in usages[etype]:
-                                        if u not in vs:
-                                                raise api_errors.InappropriateCertificateUse(
-                                                    cert, ext, u, ", ".join(vs))
-                        # If the extension name is unrecognized and critical,
-                        # then the chain cannot be verified.
-                        elif ext.critical:
-                                raise api_errors.UnsupportedCriticalExtension(
-                                    cert, ext)
-
-        def verify_chain(self, cert, ca_dict, cur_pathlen, use_crls,
-            required_names=None, usages=None):
-                """Validates the certificate against the given trust anchors.
-
-                The 'cert' parameter is the certificate to validate.
-
-                The 'ca_dict' parameter is a dictionary which maps subject
-                hashes to certs treated as trust anchors.
-
-                The 'cur_pathlen' parameter is an integer indicating how many
-                certificates have been found between cert and the leaf cert.
-
-                The 'use_crls' parameter is a boolean indicating whether
-                certificates should be checked to see if they've been revoked.
-
-                The 'required_names' parameter is a set of strings that must
-                be seen as a CN in the chain of trust for the certificate."""
-
-                if required_names is None:
-                        required_names = set()
-                verified = False
-                continue_loop = True
-                certs_with_problems = []
-
-                ca_dict = copy.copy(ca_dict)
-                for k, v in six.iteritems(self.get_ca_certs()):
-                        if k in ca_dict:
-                                ca_dict[k].extend(v)
-                        else:
-                                ca_dict[k] = v
-
-                def merge_dicts(d1, d2):
-                        """Function for merging usage dictionaries."""
-                        res = copy.deepcopy(d1)
-                        for k in d2:
-                                if k in res:
-                                        res[k].extend(d2[k])
-                                else:
-                                        res[k] = d2[k]
-                        return res
-
-                def discard_names(cert, required_names):
-                        for cert_cn in [
-                            str(c.value)
-                            for c
-                            in cert.subject.get_attributes_for_oid(
-                                x509.oid.NameOID.COMMON_NAME)
-                        ]:
-                                required_names.discard(cert_cn)
-
-                if not usages:
-                        usages = {}
-                        for u in POSSIBLE_USES:
-                                usages = merge_dicts(usages, u)
-
-                # Check whether we can validate this certificate.
-                self.__check_extensions(cert, usages, cur_pathlen)
-
-                # Check whether this certificate has been revoked.
-                self.__check_revocation(cert, ca_dict, use_crls)
-
-                while continue_loop:
-                        # If this certificate's CN is in the set of required
-                        # names, remove it.
-                        discard_names(cert, required_names)
-
-                        # Find the certificate that issued this certificate.
-                        issuer = cert.issuer
-                        issuer_hash = hashlib.sha1(misc.force_bytes(
-                            issuer)).hexdigest()
-
-                        # See whether this certificate was issued by any of the
-                        # given trust anchors.
-                        for c in ca_dict.get(issuer_hash, []):
-                                if self.__verify_x509_signature(cert,
-                                    c.public_key()):
-                                        verified = True
-                                        # Remove any required names found in the
-                                        # trust anchor.
-                                        discard_names(c, required_names)
-                                        # If there are more names to check for
-                                        # continue up the chain of trust to look
-                                        # for them.
-                                        if not required_names:
-                                                continue_loop = False
-                                        break
-
-                        # If the subject and issuer for this certificate are
-                        # identical and the certificate hasn't been verified
-                        # then this is an untrusted self-signed cert and should
-                        # be rejected.
-                        if hashlib.sha1(misc.force_bytes(
-                            cert.subject)).hexdigest() == issuer_hash:
-                                if not verified:
-                                        raise \
-                                            api_errors.UntrustedSelfSignedCert(
-                                            cert)
-                                # This break should break the
-                                # while continue_loop loop.
-                                break
-
-                        # If the certificate hasn't been issued by a trust
-                        # anchor or more names need to be found, continue
-                        # looking up the chain of trust.
-                        if continue_loop:
-                                up_chain = False
-                                # Keep track of certs that would have verified
-                                # this certificate but had critical extensions
-                                # we can't handle yet for error reporting.
-                                certs_with_problems = []
-                                for c in self.__get_certs_by_name(issuer):
-                                        # If the certificate is approved to
-                                        # sign another certificate, verifies
-                                        # the current certificate, and hasn't
-                                        # been revoked, consider it as the
-                                        # next link in the chain.  check_ca
-                                        # checks both the basicConstraints
-                                        # extension and the keyUsage extension.
-                                        if misc.check_ca(c) and \
-                                            self.__verify_x509_signature(cert,
-                                            c.public_key()):
-                                                problem = False
-                                                # Check whether this certificate
-                                                # has a critical extension we
-                                                # don't understand.
-                                                try:
-                                                        self.__check_extensions(
-                                                            c, CERT_SIGNING_USE,
-                                                            cur_pathlen)
-                                                        self.__check_revocation(c,
-                                                            ca_dict, use_crls)
-                                                except (api_errors.UnsupportedCriticalExtension, api_errors.RevokedCertificate) as e:
-                                                        certs_with_problems.append(e)
-                                                        problem = True
-                                                # If this certificate has no
-                                                # problems with it, it's the
-                                                # next link in the chain so make
-                                                # it the current certificate and
-                                                # add one to cur_pathlen since
-                                                # there's one more chain cert
-                                                # between the code signing cert
-                                                # and the root of the chain.
-                                                if not problem:
-                                                        up_chain = True
-                                                        cert = c
-                                                        cur_pathlen += 1
-                                                        break
-                                # If there's not another link in the chain to be
-                                # found, stop the iteration.
-                                if not up_chain:
-                                        continue_loop = False
-                # If the certificate wasn't verified against a trust anchor,
-                # raise an exception.
+            # If the subject and issuer for this certificate are
+            # identical and the certificate hasn't been verified
+            # then this is an untrusted self-signed cert and should
+            # be rejected.
+            if (
+                hashlib.sha1(misc.force_bytes(cert.subject)).hexdigest()
+                == issuer_hash
+            ):
                 if not verified:
-                        raise api_errors.BrokenChain(cert,
-                            certs_with_problems)
+                    raise api_errors.UntrustedSelfSignedCert(cert)
+                # This break should break the
+                # while continue_loop loop.
+                break
 
-        alias = property(lambda self: self.__alias, __set_alias,
-            doc="An alternative name for a publisher.")
+            # If the certificate hasn't been issued by a trust
+            # anchor or more names need to be found, continue
+            # looking up the chain of trust.
+            if continue_loop:
+                up_chain = False
+                # Keep track of certs that would have verified
+                # this certificate but had critical extensions
+                # we can't handle yet for error reporting.
+                certs_with_problems = []
+                for c in self.__get_certs_by_name(issuer):
+                    # If the certificate is approved to
+                    # sign another certificate, verifies
+                    # the current certificate, and hasn't
+                    # been revoked, consider it as the
+                    # next link in the chain.  check_ca
+                    # checks both the basicConstraints
+                    # extension and the keyUsage extension.
+                    if misc.check_ca(c) and self.__verify_x509_signature(
+                        cert, c.public_key()
+                    ):
+                        problem = False
+                        # Check whether this certificate
+                        # has a critical extension we
+                        # don't understand.
+                        try:
+                            self.__check_extensions(
+                                c, CERT_SIGNING_USE, cur_pathlen
+                            )
+                            self.__check_revocation(c, ca_dict, use_crls)
+                        except (
+                            api_errors.UnsupportedCriticalExtension,
+                            api_errors.RevokedCertificate,
+                        ) as e:
+                            certs_with_problems.append(e)
+                            problem = True
+                        # If this certificate has no
+                        # problems with it, it's the
+                        # next link in the chain so make
+                        # it the current certificate and
+                        # add one to cur_pathlen since
+                        # there's one more chain cert
+                        # between the code signing cert
+                        # and the root of the chain.
+                        if not problem:
+                            up_chain = True
+                            cert = c
+                            cur_pathlen += 1
+                            break
+                # If there's not another link in the chain to be
+                # found, stop the iteration.
+                if not up_chain:
+                    continue_loop = False
+        # If the certificate wasn't verified against a trust anchor,
+        # raise an exception.
+        if not verified:
+            raise api_errors.BrokenChain(cert, certs_with_problems)
 
-        client_uuid = property(lambda self: self.__client_uuid,
-            __set_client_uuid,
-            doc="A Universally Unique Identifier (UUID) used to identify a "
-            "client image to a publisher.")
+    alias = property(
+        lambda self: self.__alias,
+        __set_alias,
+        doc="An alternative name for a publisher.",
+    )
 
-        client_uuid_time = property(lambda self: self.__client_uuid_time,
-            __set_client_uuid_time,
-            doc="The last time that the UUID was generated")
+    client_uuid = property(
+        lambda self: self.__client_uuid,
+        __set_client_uuid,
+        doc="A Universally Unique Identifier (UUID) used to identify a "
+        "client image to a publisher.",
+    )
 
-        disabled = property(lambda self: self.__disabled, __set_disabled,
-            doc="A boolean value indicating whether the publisher should be "
-            "used for packaging operations.")
+    client_uuid_time = property(
+        lambda self: self.__client_uuid_time,
+        __set_client_uuid_time,
+        doc="The last time that the UUID was generated",
+    )
 
-        nochild = property(__get_nochild, None,
-            doc="A boolean value indicating whether the publisher should be "
-            "present in children.")
+    disabled = property(
+        lambda self: self.__disabled,
+        __set_disabled,
+        doc="A boolean value indicating whether the publisher should be "
+        "used for packaging operations.",
+    )
 
-        last_refreshed = property(__get_last_refreshed, __set_last_refreshed,
-            doc="A datetime object representing the time (in UTC) the "
-                "publisher's selected repository was last refreshed for new "
-                "metadata (such as catalog updates).  'None' if the publisher "
-                "hasn't been refreshed yet or the time is not available.")
+    nochild = property(
+        __get_nochild,
+        None,
+        doc="A boolean value indicating whether the publisher should be "
+        "present in children.",
+    )
 
-        meta_root = property(lambda self: self.__meta_root, __set_meta_root,
-            doc="The absolute pathname of the directory where the publisher's "
-                "metadata should be written to and read from.")
+    last_refreshed = property(
+        __get_last_refreshed,
+        __set_last_refreshed,
+        doc="A datetime object representing the time (in UTC) the "
+        "publisher's selected repository was last refreshed for new "
+        "metadata (such as catalog updates).  'None' if the publisher "
+        "hasn't been refreshed yet or the time is not available.",
+    )
 
-        prefix = property(lambda self: self.__prefix, __set_prefix,
-            doc="The name of the publisher.")
+    meta_root = property(
+        lambda self: self.__meta_root,
+        __set_meta_root,
+        doc="The absolute pathname of the directory where the publisher's "
+        "metadata should be written to and read from.",
+    )
 
-        repository = property(lambda self: self.__repository,
-            __set_repository,
-            doc="A reference to the selected repository object.")
+    prefix = property(
+        lambda self: self.__prefix,
+        __set_prefix,
+        doc="The name of the publisher.",
+    )
 
-        sticky = property(lambda self: self.__sticky, __set_stickiness,
-            doc="Whether or not installed packages from this publisher are"
-                " always preferred to other publishers.")
+    repository = property(
+        lambda self: self.__repository,
+        __set_repository,
+        doc="A reference to the selected repository object.",
+    )
 
-        def __get_prop(self, name):
-                """Accessor method for properties dictionary"""
-                return self.__properties[name]
+    sticky = property(
+        lambda self: self.__sticky,
+        __set_stickiness,
+        doc="Whether or not installed packages from this publisher are"
+        " always preferred to other publishers.",
+    )
 
-        @staticmethod
-        def __read_list(list_str):
-                """Take a list in string representation and convert it back
-                to a Python list."""
+    def __get_prop(self, name):
+        """Accessor method for properties dictionary"""
+        return self.__properties[name]
 
-                list_str = misc.force_str(list_str)
-                # Strip brackets and any whitespace
-                list_str = list_str.strip("][ ")
-                # Strip comma and any whitespeace
-                lst = list_str.split(", ")
-                # Strip empty whitespace, single, and double quotation marks
-                lst = [ s.strip("' \"") for s in lst ]
-                # Eliminate any empty strings
-                lst = [ s for s in lst if s != '' ]
+    @staticmethod
+    def __read_list(list_str):
+        """Take a list in string representation and convert it back
+        to a Python list."""
 
-                return lst
+        list_str = misc.force_str(list_str)
+        # Strip brackets and any whitespace
+        list_str = list_str.strip("][ ")
+        # Strip comma and any whitespeace
+        lst = list_str.split(", ")
+        # Strip empty whitespace, single, and double quotation marks
+        lst = [s.strip("' \"") for s in lst]
+        # Eliminate any empty strings
+        lst = [s for s in lst if s != ""]
 
-        def __set_prop(self, name, values):
-                """Accessor method to add a property"""
-                if self.sys_pub:
-                        raise api_errors.ModifyingSyspubException(_("Cannot "
-                            "set a property for a system publisher. The "
-                            "property was:{0}").format(name))
+        return lst
 
-                if name == SIGNATURE_POLICY:
-                        self.__sig_policy = None
-                        if isinstance(values, six.string_types):
-                                values = [values]
-                        policy_name = values[0]
-                        if policy_name not in sigpolicy.Policy.policies():
-                                raise api_errors.InvalidPropertyValue(_(
-                                    "{val} is not a valid value for this "
-                                    "property:{prop}").format(val=policy_name,
-                                    prop=SIGNATURE_POLICY))
-                        if policy_name == "require-names":
-                                if self.__delay_validation:
-                                        # If __delay_validation is set, then
-                                        # it's possible that
-                                        # signature-required-names was
-                                        # set by a previous call to set_prop
-                                        # file.  If so, don't overwrite the
-                                        # values that have already been read.
-                                        self.__properties.setdefault(
-                                            "signature-required-names", [])
-                                        self.__properties[
-                                            "signature-required-names"].extend(
-                                            values[1:])
-                                else:
-                                        self.__properties[
-                                            "signature-required-names"] = \
-                                            values[1:]
-                                        self.__validate_properties()
-                        else:
-                                if len(values) > 1:
-                                        raise api_errors.InvalidPropertyValue(_(
-                                            "The {0} signature-policy takes no "
-                                            "argument.").format(policy_name))
-                        self.__properties[SIGNATURE_POLICY] = policy_name
-                        return
-                if name == "signature-required-names":
-                        if isinstance(values, six.string_types):
-                                values = self.__read_list(values)
-                self.__properties[name] = values
+    def __set_prop(self, name, values):
+        """Accessor method to add a property"""
+        if self.sys_pub:
+            raise api_errors.ModifyingSyspubException(
+                _(
+                    "Cannot "
+                    "set a property for a system publisher. The "
+                    "property was:{0}"
+                ).format(name)
+            )
 
-        def __del_prop(self, name):
-                """Accessor method for properties"""
-                if self.sys_pub:
-                        raise api_errors.ModifyingSyspubException(_("Cannot "
-                            "unset a property for a system publisher. The "
-                            "property was:{0}").format(name))
-                del self.__properties[name]
+        if name == SIGNATURE_POLICY:
+            self.__sig_policy = None
+            if isinstance(values, six.string_types):
+                values = [values]
+            policy_name = values[0]
+            if policy_name not in sigpolicy.Policy.policies():
+                raise api_errors.InvalidPropertyValue(
+                    _(
+                        "{val} is not a valid value for this " "property:{prop}"
+                    ).format(val=policy_name, prop=SIGNATURE_POLICY)
+                )
+            if policy_name == "require-names":
+                if self.__delay_validation:
+                    # If __delay_validation is set, then
+                    # it's possible that
+                    # signature-required-names was
+                    # set by a previous call to set_prop
+                    # file.  If so, don't overwrite the
+                    # values that have already been read.
+                    self.__properties.setdefault("signature-required-names", [])
+                    self.__properties["signature-required-names"].extend(
+                        values[1:]
+                    )
+                else:
+                    self.__properties["signature-required-names"] = values[1:]
+                    self.__validate_properties()
+            else:
+                if len(values) > 1:
+                    raise api_errors.InvalidPropertyValue(
+                        _(
+                            "The {0} signature-policy takes no " "argument."
+                        ).format(policy_name)
+                    )
+            self.__properties[SIGNATURE_POLICY] = policy_name
+            return
+        if name == "signature-required-names":
+            if isinstance(values, six.string_types):
+                values = self.__read_list(values)
+        self.__properties[name] = values
 
-        def __prop_iter(self):
-                return self.__properties.__iter__()
+    def __del_prop(self, name):
+        """Accessor method for properties"""
+        if self.sys_pub:
+            raise api_errors.ModifyingSyspubException(
+                _(
+                    "Cannot "
+                    "unset a property for a system publisher. The "
+                    "property was:{0}"
+                ).format(name)
+            )
+        del self.__properties[name]
 
-        def __prop_iteritems(self):
-                """Support iteritems on properties"""
-                return six.iteritems(self.__properties)
+    def __prop_iter(self):
+        return self.__properties.__iter__()
 
-        def __prop_keys(self):
-                """Support keys() on properties"""
-                return list(self.__properties.keys())
+    def __prop_iteritems(self):
+        """Support iteritems on properties"""
+        return six.iteritems(self.__properties)
 
-        def __prop_values(self):
-                """Support values() on properties"""
-                return list(self.__properties.values())
+    def __prop_keys(self):
+        """Support keys() on properties"""
+        return list(self.__properties.keys())
 
-        def __prop_getdefault(self, name, value):
-                """Support getdefault() on properties"""
-                return self.__properties.get(name, value)
+    def __prop_values(self):
+        """Support values() on properties"""
+        return list(self.__properties.values())
 
-        def __prop_setdefault(self, name, value):
-                """Support setdefault() on properties"""
-                # Must set it this way so that the logic in __set_prop is used.
-                try:
-                        return self.__properties[name]
-                except KeyError:
-                        self.properties[name] = value
-                        return value
+    def __prop_getdefault(self, name, value):
+        """Support getdefault() on properties"""
+        return self.__properties.get(name, value)
 
-        def __prop_update(self, d):
-                """Support update() on properties"""
+    def __prop_setdefault(self, name, value):
+        """Support setdefault() on properties"""
+        # Must set it this way so that the logic in __set_prop is used.
+        try:
+            return self.__properties[name]
+        except KeyError:
+            self.properties[name] = value
+            return value
 
-                # The logic in __set_prop requires that the item with key
-                # 'SIGNATURE_POLICY' comes before the item with key
-                # 'signature-required-names'.
-                od = collections.OrderedDict(sorted(six.iteritems(d)))
-                for k, v in six.iteritems(od):
-                        # Must iterate through each value and
-                        # set it this way so that the logic
-                        # in __set_prop is used.
-                        self.properties[k] = v
+    def __prop_update(self, d):
+        """Support update() on properties"""
 
-        def __prop_pop(self, d, default):
-                """Support pop() on properties"""
-                if self.sys_pub:
-                        raise api_errors.ModifyingSyspubException(_("Cannot "
-                            "unset a property for a system publisher."))
-                return self.__properties.pop(d, default)
+        # The logic in __set_prop requires that the item with key
+        # 'SIGNATURE_POLICY' comes before the item with key
+        # 'signature-required-names'.
+        od = collections.OrderedDict(sorted(six.iteritems(d)))
+        for k, v in six.iteritems(od):
+            # Must iterate through each value and
+            # set it this way so that the logic
+            # in __set_prop is used.
+            self.properties[k] = v
 
-        properties = DictProperty(__get_prop, __set_prop, __del_prop,
-            __prop_iteritems, __prop_keys, __prop_values, __prop_iter,
-            doc="A dict holding the properties for an image.",
-            fgetdefault=__prop_getdefault, fsetdefault=__prop_setdefault,
-            update=__prop_update, pop=__prop_pop)
+    def __prop_pop(self, d, default):
+        """Support pop() on properties"""
+        if self.sys_pub:
+            raise api_errors.ModifyingSyspubException(
+                _("Cannot " "unset a property for a system publisher.")
+            )
+        return self.__properties.pop(d, default)
 
-        @property
-        def signature_policy(self):
-                """Return the signature policy for the publisher."""
+    properties = DictProperty(
+        __get_prop,
+        __set_prop,
+        __del_prop,
+        __prop_iteritems,
+        __prop_keys,
+        __prop_values,
+        __prop_iter,
+        doc="A dict holding the properties for an image.",
+        fgetdefault=__prop_getdefault,
+        fsetdefault=__prop_setdefault,
+        update=__prop_update,
+        pop=__prop_pop,
+    )
 
-                if self.__sig_policy is not None:
-                        return self.__sig_policy
-                txt = self.properties.get(SIGNATURE_POLICY,
-                    sigpolicy.DEFAULT_POLICY)
-                names = self.properties.get("signature-required-names", [])
-                self.__sig_policy = sigpolicy.Policy.policy_factory(txt, names)
-                return self.__sig_policy
+    @property
+    def signature_policy(self):
+        """Return the signature policy for the publisher."""
+
+        if self.__sig_policy is not None:
+            return self.__sig_policy
+        txt = self.properties.get(SIGNATURE_POLICY, sigpolicy.DEFAULT_POLICY)
+        names = self.properties.get("signature-required-names", [])
+        self.__sig_policy = sigpolicy.Policy.policy_factory(txt, names)
+        return self.__sig_policy
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/query_parser.py
+++ b/src/modules/client/query_parser.py
@@ -32,422 +32,433 @@ import pkg.fmri as fmri
 from pkg.choose import choose
 
 import pkg.query_parser as qp
-from pkg.query_parser import BooleanQueryException, ParseError, QueryLengthExceeded
+from pkg.query_parser import (
+    BooleanQueryException,
+    ParseError,
+    QueryLengthExceeded,
+)
 import itertools
 
+
 class QueryLexer(qp.QueryLexer):
-        pass
+    pass
+
 
 class QueryParser(qp.QueryParser):
-        """This class exists so that the classes the parent class query parser
-        uses to build the AST are the ones defined in this module and not the
-        parent class's module.  This is done so that a single query parser can
-        be shared between the client and server modules but will construct an
-        AST using the appropriate classes."""
-        
-        def __init__(self, lexer):
-                qp.QueryParser.__init__(self, lexer)
-                mod = sys.modules[QueryParser.__module__]
-                tmp = {}
-                for class_name in self.query_objs.keys():
-                        assert hasattr(mod, class_name)
-                        tmp[class_name] = getattr(mod, class_name)
-                self.query_objs = tmp
+    """This class exists so that the classes the parent class query parser
+    uses to build the AST are the ones defined in this module and not the
+    parent class's module.  This is done so that a single query parser can
+    be shared between the client and server modules but will construct an
+    AST using the appropriate classes."""
+
+    def __init__(self, lexer):
+        qp.QueryParser.__init__(self, lexer)
+        mod = sys.modules[QueryParser.__module__]
+        tmp = {}
+        for class_name in self.query_objs.keys():
+            assert hasattr(mod, class_name)
+            tmp[class_name] = getattr(mod, class_name)
+        self.query_objs = tmp
+
 
 # Because many classes do not have client specific modifications, they
 # simply subclass the parent module's classes.
 class Query(qp.Query):
-        pass
+    pass
 
 
 class AndQuery(qp.AndQuery):
-        def remove_root(self, img_dir):
-                lcv = self.lc.remove_root(img_dir)
-                rcv = self.rc.remove_root(img_dir)
-                return lcv or rcv
+    def remove_root(self, img_dir):
+        lcv = self.lc.remove_root(img_dir)
+        rcv = self.rc.remove_root(img_dir)
+        return lcv or rcv
 
 
 class EmptyQuery(object):
-        def __init__(self, return_type):
-                self.return_type = return_type
-        
-        def search(self, *args):
-                return []
+    def __init__(self, return_type):
+        self.return_type = return_type
 
-        def set_info(self, **kwargs):
-                return
+    def search(self, *args):
+        return []
 
-        def __str__(self):
-                if self.return_type == qp.Query.RETURN_ACTIONS:
-                        return "(a AND b)"
-                else:
-                        return "<(a AND b)>"
+    def set_info(self, **kwargs):
+        return
 
-        def propagate_pkg_return(self):
-                """Makes this node return packages instead of actions.
-                Returns None because no changes need to be made to the tree."""
-                self.return_type = qp.Query.RETURN_PACKAGES
-                return None
+    def __str__(self):
+        if self.return_type == qp.Query.RETURN_ACTIONS:
+            return "(a AND b)"
+        else:
+            return "<(a AND b)>"
+
+    def propagate_pkg_return(self):
+        """Makes this node return packages instead of actions.
+        Returns None because no changes need to be made to the tree."""
+        self.return_type = qp.Query.RETURN_PACKAGES
+        return None
 
 
 class OrQuery(qp.OrQuery):
-        def remove_root(self, img_dir):
-                lcv = self.lc.remove_root(img_dir)
-                if not lcv:
-                        self.lc = EmptyQuery(self.lc.return_type)
-                rcv = self.rc.remove_root(img_dir)
-                if not rcv:
-                        self.rc = EmptyQuery(self.rc.return_type)
-                return lcv or rcv
+    def remove_root(self, img_dir):
+        lcv = self.lc.remove_root(img_dir)
+        if not lcv:
+            self.lc = EmptyQuery(self.lc.return_type)
+        rcv = self.rc.remove_root(img_dir)
+        if not rcv:
+            self.rc = EmptyQuery(self.rc.return_type)
+        return lcv or rcv
 
 
 class PkgConversion(qp.PkgConversion):
-        def remove_root(self, img_dir):
-                return self.query.remove_root(img_dir)
+    def remove_root(self, img_dir):
+        return self.query.remove_root(img_dir)
 
 
 class PhraseQuery(qp.PhraseQuery):
-        def remove_root(self, img_dir):
-                return self.query.remove_root(img_dir)
+    def remove_root(self, img_dir):
+        return self.query.remove_root(img_dir)
 
 
 class FieldQuery(qp.FieldQuery):
-        def remove_root(self, img_dir):
-                return self.query.remove_root(img_dir)
+    def remove_root(self, img_dir):
+        return self.query.remove_root(img_dir)
 
 
 class TopQuery(qp.TopQuery):
-        """This class handles raising the exception if the search was conducted
-        without using indexes.  It yields all results, then raises the
-        exception."""
+    """This class handles raising the exception if the search was conducted
+    without using indexes.  It yields all results, then raises the
+    exception."""
 
-        def __init__(self, *args, **kwargs):
-                qp.TopQuery.__init__(self, *args, **kwargs)
-                self.__use_slow_search = False
+    def __init__(self, *args, **kwargs):
+        qp.TopQuery.__init__(self, *args, **kwargs)
+        self.__use_slow_search = False
 
-        def get_use_slow_search(self):
-                """Return whether slow search has been used."""
+    def get_use_slow_search(self):
+        """Return whether slow search has been used."""
 
-                return self.__use_slow_search
+        return self.__use_slow_search
 
-        def set_use_slow_search(self, val):
-                """Set whether slow search has been used."""
+    def set_use_slow_search(self, val):
+        """Set whether slow search has been used."""
 
-                self.__use_slow_search = val
-                
-        def set_info(self, **kwargs):
-                """This function provides the necessary information to the AST
-                so that a search can be performed."""
+        self.__use_slow_search = val
 
-                qp.TopQuery.set_info(self,
-                    get_use_slow_search=self.get_use_slow_search,
-                    set_use_slow_search=self.set_use_slow_search,
-                    **kwargs)
+    def set_info(self, **kwargs):
+        """This function provides the necessary information to the AST
+        so that a search can be performed."""
 
-        def search(self, *args):
-                """This function performs performs local client side search.
+        qp.TopQuery.set_info(
+            self,
+            get_use_slow_search=self.get_use_slow_search,
+            set_use_slow_search=self.set_use_slow_search,
+            **kwargs,
+        )
 
-                If slow search was used, then after all results have been
-                returned, it raises SlowSearchUsed."""
+    def search(self, *args):
+        """This function performs performs local client side search.
 
-                for i in qp.TopQuery.search(self, *args):
-                        yield i
-                if self.__use_slow_search:
-                        raise api_errors.SlowSearchUsed()
+        If slow search was used, then after all results have been
+        returned, it raises SlowSearchUsed."""
 
-        def remove_root(self, img_dir):
-                return self.query.remove_root(img_dir)
+        for i in qp.TopQuery.search(self, *args):
+            yield i
+        if self.__use_slow_search:
+            raise api_errors.SlowSearchUsed()
 
-        def add_or(self, rc):
-                lc = self.query
-                if isinstance(rc, TopQuery):
-                        rc = rc.query
-                self.query = OrQuery(lc, rc)
+    def remove_root(self, img_dir):
+        return self.query.remove_root(img_dir)
+
+    def add_or(self, rc):
+        lc = self.query
+        if isinstance(rc, TopQuery):
+            rc = rc.query
+        self.query = OrQuery(lc, rc)
 
 
 class TermQuery(qp.TermQuery):
-        """This class handles the client specific search logic for searching
-        for a base query term."""
+    """This class handles the client specific search logic for searching
+    for a base query term."""
 
-        __client_dict_locks = {}
-        _global_data_dict = {}
+    __client_dict_locks = {}
+    _global_data_dict = {}
 
-        def __init__(self, term):
-                qp.TermQuery.__init__(self, term)
-                self._impl_fmri_to_path = None
-                self._efn = None
-                self._data_fast_remove = None
-                self.full_fmri_hash = None
-                self._data_fast_add = None
+    def __init__(self, term):
+        qp.TermQuery.__init__(self, term)
+        self._impl_fmri_to_path = None
+        self._efn = None
+        self._data_fast_remove = None
+        self.full_fmri_hash = None
+        self._data_fast_add = None
 
-        def __init_gdd(self, path):
-                gdd = self._global_data_dict
-                if path in gdd:
-                        return
+    def __init_gdd(self, path):
+        gdd = self._global_data_dict
+        if path in gdd:
+            return
 
-                # Setup default global dictionary for this index path.
-                qp.TermQuery.__init_gdd(self, path)
+        # Setup default global dictionary for this index path.
+        qp.TermQuery.__init_gdd(self, path)
 
-                # Client search needs to account for the packages which have
-                # been installed or removed since the last time the indexes
-                # were rebuilt. Add client-specific global data dictionaries
-                # for this index path.
-                tq_gdd = gdd[path]
-                tq_gdd["fast_add"] = ss.IndexStoreSet(ss.FAST_ADD)
-                tq_gdd["fast_remove"] = ss.IndexStoreSet(ss.FAST_REMOVE)
-                tq_gdd["fmri_hash"] = ss.IndexStoreSetHash(
-                    ss.FULL_FMRI_HASH_FILE)
+        # Client search needs to account for the packages which have
+        # been installed or removed since the last time the indexes
+        # were rebuilt. Add client-specific global data dictionaries
+        # for this index path.
+        tq_gdd = gdd[path]
+        tq_gdd["fast_add"] = ss.IndexStoreSet(ss.FAST_ADD)
+        tq_gdd["fast_remove"] = ss.IndexStoreSet(ss.FAST_REMOVE)
+        tq_gdd["fmri_hash"] = ss.IndexStoreSetHash(ss.FULL_FMRI_HASH_FILE)
 
-        def _lock_client_gdd(self, index_dir):
-                # This lock is used so that only one instance of a term query
-                # object is ever modifying the class wide variable for this
-                # index.
-                self.__client_dict_locks.setdefault(index_dir,
-                    threading.Lock()).acquire()
+    def _lock_client_gdd(self, index_dir):
+        # This lock is used so that only one instance of a term query
+        # object is ever modifying the class wide variable for this
+        # index.
+        self.__client_dict_locks.setdefault(
+            index_dir, threading.Lock()
+        ).acquire()
 
-        def _unlock_client_gdd(self, index_dir):
-                self.__client_dict_locks[index_dir].release()
+    def _unlock_client_gdd(self, index_dir):
+        self.__client_dict_locks[index_dir].release()
 
-        def set_info(self, gen_installed_pkg_names, get_use_slow_search,
-            set_use_slow_search, **kwargs):
-                """This function provides the necessary information to the AST
-                so that a search can be performed.
+    def set_info(
+        self,
+        gen_installed_pkg_names,
+        get_use_slow_search,
+        set_use_slow_search,
+        **kwargs,
+    ):
+        """This function provides the necessary information to the AST
+        so that a search can be performed.
 
-                The "gen_installed_pkg_names" parameter is a function which
-                returns a generator function which iterates over the names of
-                the installed packages in the image.
+        The "gen_installed_pkg_names" parameter is a function which
+        returns a generator function which iterates over the names of
+        the installed packages in the image.
 
-                The "get_use_slow_search" parameter is a function that returns
-                whether slow search has been used.
+        The "get_use_slow_search" parameter is a function that returns
+        whether slow search has been used.
 
-                The "set_use_slow_search" parameter is a function that sets
-                whether slow search was used."""
+        The "set_use_slow_search" parameter is a function that sets
+        whether slow search was used."""
 
-                self.get_use_slow_search = get_use_slow_search
-                self._efn = gen_installed_pkg_names()
-                index_dir = kwargs["index_dir"]
-                self._lock_client_gdd(index_dir)
-                try:
-                        try:
-                                qp.TermQuery.set_info(self,
-                                    gen_installed_pkg_names=\
-                                        gen_installed_pkg_names,
-                                    get_use_slow_search=get_use_slow_search,
-                                    set_use_slow_search=set_use_slow_search,
-                                    **kwargs)
-                                # Take local copies of the client-only
-                                # dictionaries so that if another thread
-                                # changes the shared data structure, this
-                                # instance's objects won't be affected.
-                                tq_gdd = self._get_gdd(index_dir)
-                                self._data_fast_add = tq_gdd["fast_add"]
-                                self._data_fast_remove = tq_gdd["fast_remove"]
-                                self.full_fmri_hash = tq_gdd["fmri_hash"]
-                                set_use_slow_search(False)
-                        except se.NoIndexException:
-                                # If no index was found, the slower version of
-                                # search will be used.
-                                set_use_slow_search(True)
-                finally:
-                        self._unlock_client_gdd(index_dir)
-                
-        def search(self, restriction, fmris, manifest_func, excludes):
-                """This function performs performs local client side search.
-                
-                The "restriction" parameter is a generator over the results that
-                another branch of the AST has already found.  If it exists,
-                those results are treated as the domain for search.  If it does
-                not exist, search uses the set of actions from installed
-                packages as the domain.
-
-                The "fmris" parameter is a function which produces an object
-                which iterates over the names of installed fmris.
-
-                The "manifest_func" parameter is a function which takes a fmri
-                and returns a path to the manifest for that fmri.
-
-                The "excludes" parameter is a list of the variants defined for
-                this image."""
-
-                if restriction:
-                        return self._restricted_search_internal(restriction)
-                elif not self.get_use_slow_search():
-                        try:
-                                self.full_fmri_hash.check_against_file(
-                                    self._efn)
-                        except se.IncorrectIndexFileHash:
-                                raise \
-                                    api_errors.IncorrectIndexFileHash()
-                        base_res = \
-                            self._search_internal(fmris)
-                        client_res = \
-                            self._search_fast_update(manifest_func,
-                            excludes)
-                        base_res = self._check_fast_remove(base_res)
-                        it = itertools.chain(self._get_results(base_res),
-                            self._get_fast_results(client_res))
-                        return it
-                else:
-                        return self.slow_search(fmris, manifest_func, excludes)
-
-        def _check_fast_remove(self, res):
-                """This function removes any results from the generator "res"
-                (the search results) that are actions from packages known to
-                have been removed from the image since the last time the index
-                was built."""
-
-                return (
-                    (p_str, o, a, s, f)
-                    for p_str, o, a, s, f
-                    in res
-                    if not self._data_fast_remove.has_entity(p_str)
+        self.get_use_slow_search = get_use_slow_search
+        self._efn = gen_installed_pkg_names()
+        index_dir = kwargs["index_dir"]
+        self._lock_client_gdd(index_dir)
+        try:
+            try:
+                qp.TermQuery.set_info(
+                    self,
+                    gen_installed_pkg_names=gen_installed_pkg_names,
+                    get_use_slow_search=get_use_slow_search,
+                    set_use_slow_search=set_use_slow_search,
+                    **kwargs,
                 )
+                # Take local copies of the client-only
+                # dictionaries so that if another thread
+                # changes the shared data structure, this
+                # instance's objects won't be affected.
+                tq_gdd = self._get_gdd(index_dir)
+                self._data_fast_add = tq_gdd["fast_add"]
+                self._data_fast_remove = tq_gdd["fast_remove"]
+                self.full_fmri_hash = tq_gdd["fmri_hash"]
+                set_use_slow_search(False)
+            except se.NoIndexException:
+                # If no index was found, the slower version of
+                # search will be used.
+                set_use_slow_search(True)
+        finally:
+            self._unlock_client_gdd(index_dir)
 
-        def _search_fast_update(self, manifest_func, excludes):
-                """This function searches the packages which have been
-                installed since the last time the index was rebuilt.
+    def search(self, restriction, fmris, manifest_func, excludes):
+        """This function performs performs local client side search.
 
-                The "manifest_func" parameter is a function which maps fmris to
-                the path to their manifests.
+        The "restriction" parameter is a generator over the results that
+        another branch of the AST has already found.  If it exists,
+        those results are treated as the domain for search.  If it does
+        not exist, search uses the set of actions from installed
+        packages as the domain.
 
-                The "excludes" parameter is a list of variants defined in the
-                image."""
+        The "fmris" parameter is a function which produces an object
+        which iterates over the names of installed fmris.
 
-                assert self._data_main_dict.get_file_handle() is not None
+        The "manifest_func" parameter is a function which takes a fmri
+        and returns a path to the manifest for that fmri.
 
-                glob = self._glob
-                term = self._term
-                case_sensitive = self._case_sensitive
+        The "excludes" parameter is a list of the variants defined for
+        this image."""
 
-                if not case_sensitive:
-                        glob = True
-                        
-                fast_update_dict = {}
+        if restriction:
+            return self._restricted_search_internal(restriction)
+        elif not self.get_use_slow_search():
+            try:
+                self.full_fmri_hash.check_against_file(self._efn)
+            except se.IncorrectIndexFileHash:
+                raise api_errors.IncorrectIndexFileHash()
+            base_res = self._search_internal(fmris)
+            client_res = self._search_fast_update(manifest_func, excludes)
+            base_res = self._check_fast_remove(base_res)
+            it = itertools.chain(
+                self._get_results(base_res), self._get_fast_results(client_res)
+            )
+            return it
+        else:
+            return self.slow_search(fmris, manifest_func, excludes)
 
-                fast_update_res = []
+    def _check_fast_remove(self, res):
+        """This function removes any results from the generator "res"
+        (the search results) that are actions from packages known to
+        have been removed from the image since the last time the index
+        was built."""
 
-                # self._data_fast_add holds the names of the fmris added
-                # since the last time the index was rebuilt.
-                for fmri_str in self._data_fast_add._set:
-                        if not (self.pkg_name_wildcard or
-                            self.pkg_name_match(fmri_str)):
-                                continue
-                        f = fmri.PkgFmri(fmri_str)
-                        path = manifest_func(f)
-                        search_dict = manifest.Manifest.search_dict(path,
-                            return_line=True, excludes=excludes)
-                        for tmp in search_dict:
-                                tok, at, st, fv = tmp
-                                if not (self.action_type_wildcard or
-                                    at == self.action_type) or \
-                                    not (self.key_wildcard or st == self.key):
-                                        continue
-                                if tok not in fast_update_dict:
-                                        fast_update_dict[tok] = []
-                                fast_update_dict[tok].append((at, st, fv,
-                                    fmri_str, search_dict[tmp]))
-                if glob:
-                        keys = fast_update_dict.keys()
-                        matches = choose(keys, term, case_sensitive)
-                        fast_update_res = [
-                            fast_update_dict[m] for m in matches
-                        ]
-                        
-                else:
-                        if term in fast_update_dict:
-                                fast_update_res.append(fast_update_dict[term])
-                return fast_update_res
+        return (
+            (p_str, o, a, s, f)
+            for p_str, o, a, s, f in res
+            if not self._data_fast_remove.has_entity(p_str)
+        )
 
-        def _get_fast_results(self, fast_update_res):
-                """This function transforms the output of _search_fast_update
-                to match that of _search_internal."""
+    def _search_fast_update(self, manifest_func, excludes):
+        """This function searches the packages which have been
+        installed since the last time the index was rebuilt.
 
-                for sub_list in fast_update_res:
-                        for at, st, fv, fmri_str, line_list in sub_list:
-                                for l in line_list:
-                                        yield at, st, fmri_str, fv, l
+        The "manifest_func" parameter is a function which maps fmris to
+        the path to their manifests.
 
-        def slow_search(self, fmris, manifest_func, excludes):
-                """This function performs search when no prebuilt index is
-                available.
+        The "excludes" parameter is a list of variants defined in the
+        image."""
 
-                The "fmris" parameter is a generator function which iterates
-                over the packages to be searched.
+        assert self._data_main_dict.get_file_handle() is not None
 
-                The "manifest_func" parameter is a function which maps fmris to
-                the path to their manifests.
+        glob = self._glob
+        term = self._term
+        case_sensitive = self._case_sensitive
 
-                The "excludes" parameter is a list of variants defined in the
-                image."""
+        if not case_sensitive:
+            glob = True
 
-                for pfmri in list(fmris()):
-                        fmri_str = pfmri.get_fmri(anarchy=True,
-                            include_scheme=False)
-                        if not (self.pkg_name_wildcard or
-                            self.pkg_name_match(fmri_str)):
-                                continue
-                        manf = manifest_func(pfmri)
-                        fast_update_dict = {}
-                        fast_update_res = []
-                        glob = self._glob
-                        term = self._term
-                        case_sensitive = self._case_sensitive
+        fast_update_dict = {}
 
-                        if not case_sensitive:
-                                glob = True
+        fast_update_res = []
 
-                        search_dict = manifest.Manifest.search_dict(manf,
-                            return_line=True, excludes=excludes)
-                        for tmp in search_dict:
-                                tok, at, st, fv = tmp
-                                if not (self.action_type_wildcard or
-                                    at == self.action_type) or \
-                                    not (self.key_wildcard or st == self.key):
-                                        continue
-                                if tok not in fast_update_dict:
-                                        fast_update_dict[tok] = []
-                                fast_update_dict[tok].append((at, st, fv,
-                                    fmri_str, search_dict[tmp]))
-                        if glob:
-                                keys = fast_update_dict.keys()
-                                matches = choose(keys, term, case_sensitive)
-                                fast_update_res = [
-                                    fast_update_dict[m] for m in matches
-                                ]
-                        else:
-                                if term in fast_update_dict:
-                                        fast_update_res.append(
-                                            fast_update_dict[term])
-                        for sub_list in fast_update_res:
-                                for at, st, fv, fmri_str, line_list in sub_list:
-                                        for l in line_list:
-                                                yield at, st, fmri_str, fv, l
+        # self._data_fast_add holds the names of the fmris added
+        # since the last time the index was rebuilt.
+        for fmri_str in self._data_fast_add._set:
+            if not (self.pkg_name_wildcard or self.pkg_name_match(fmri_str)):
+                continue
+            f = fmri.PkgFmri(fmri_str)
+            path = manifest_func(f)
+            search_dict = manifest.Manifest.search_dict(
+                path, return_line=True, excludes=excludes
+            )
+            for tmp in search_dict:
+                tok, at, st, fv = tmp
+                if not (
+                    self.action_type_wildcard or at == self.action_type
+                ) or not (self.key_wildcard or st == self.key):
+                    continue
+                if tok not in fast_update_dict:
+                    fast_update_dict[tok] = []
+                fast_update_dict[tok].append(
+                    (at, st, fv, fmri_str, search_dict[tmp])
+                )
+        if glob:
+            keys = fast_update_dict.keys()
+            matches = choose(keys, term, case_sensitive)
+            fast_update_res = [fast_update_dict[m] for m in matches]
 
-        def _read_pkg_dirs(self, fmris):
-                """Legacy function used to search indexes which have a pkg
-                directory with fmri offset information instead of the
-                fmri_offsets.v1 file.  This function is in this subclass to
-                translate the error from a search_error to an api_error."""
+        else:
+            if term in fast_update_dict:
+                fast_update_res.append(fast_update_dict[term])
+        return fast_update_res
 
-                try:
-                        return qp.TermQuery._read_pkg_dirs(self, fmris)
-                except se.InconsistentIndexException as e:
-                        raise api_errors.InconsistentIndexException(e)
+    def _get_fast_results(self, fast_update_res):
+        """This function transforms the output of _search_fast_update
+        to match that of _search_internal."""
 
-        def remove_root(self, img_root):
-                if (not self.action_type_wildcard and
-                    self.action_type != "file" and
-                    self.action_type != "link" and
-                    self.action_type != "hardlink" and
-                    self.action_type != "directory") or \
-                    (not self.key_wildcard and self.key != "path") or \
-                    (not self._term.startswith(img_root) or img_root == "/"):
-                        return False
-                img_root = img_root.rstrip("/")
-                self._term = self._term[len(img_root):]
-                self.key = "path"
-                self.key_wildcard = False
-                return True
+        for sub_list in fast_update_res:
+            for at, st, fv, fmri_str, line_list in sub_list:
+                for l in line_list:
+                    yield at, st, fmri_str, fv, l
+
+    def slow_search(self, fmris, manifest_func, excludes):
+        """This function performs search when no prebuilt index is
+        available.
+
+        The "fmris" parameter is a generator function which iterates
+        over the packages to be searched.
+
+        The "manifest_func" parameter is a function which maps fmris to
+        the path to their manifests.
+
+        The "excludes" parameter is a list of variants defined in the
+        image."""
+
+        for pfmri in list(fmris()):
+            fmri_str = pfmri.get_fmri(anarchy=True, include_scheme=False)
+            if not (self.pkg_name_wildcard or self.pkg_name_match(fmri_str)):
+                continue
+            manf = manifest_func(pfmri)
+            fast_update_dict = {}
+            fast_update_res = []
+            glob = self._glob
+            term = self._term
+            case_sensitive = self._case_sensitive
+
+            if not case_sensitive:
+                glob = True
+
+            search_dict = manifest.Manifest.search_dict(
+                manf, return_line=True, excludes=excludes
+            )
+            for tmp in search_dict:
+                tok, at, st, fv = tmp
+                if not (
+                    self.action_type_wildcard or at == self.action_type
+                ) or not (self.key_wildcard or st == self.key):
+                    continue
+                if tok not in fast_update_dict:
+                    fast_update_dict[tok] = []
+                fast_update_dict[tok].append(
+                    (at, st, fv, fmri_str, search_dict[tmp])
+                )
+            if glob:
+                keys = fast_update_dict.keys()
+                matches = choose(keys, term, case_sensitive)
+                fast_update_res = [fast_update_dict[m] for m in matches]
+            else:
+                if term in fast_update_dict:
+                    fast_update_res.append(fast_update_dict[term])
+            for sub_list in fast_update_res:
+                for at, st, fv, fmri_str, line_list in sub_list:
+                    for l in line_list:
+                        yield at, st, fmri_str, fv, l
+
+    def _read_pkg_dirs(self, fmris):
+        """Legacy function used to search indexes which have a pkg
+        directory with fmri offset information instead of the
+        fmri_offsets.v1 file.  This function is in this subclass to
+        translate the error from a search_error to an api_error."""
+
+        try:
+            return qp.TermQuery._read_pkg_dirs(self, fmris)
+        except se.InconsistentIndexException as e:
+            raise api_errors.InconsistentIndexException(e)
+
+    def remove_root(self, img_root):
+        if (
+            (
+                not self.action_type_wildcard
+                and self.action_type != "file"
+                and self.action_type != "link"
+                and self.action_type != "hardlink"
+                and self.action_type != "directory"
+            )
+            or (not self.key_wildcard and self.key != "path")
+            or (not self._term.startswith(img_root) or img_root == "/")
+        ):
+            return False
+        img_root = img_root.rstrip("/")
+        self._term = self._term[len(img_root) :]
+        self.key = "path"
+        self.key_wildcard = False
+        return True
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/sigpolicy.py
+++ b/src/modules/client/sigpolicy.py
@@ -28,171 +28,179 @@ import six
 import pkg.client.api_errors as apx
 from functools import total_ordering
 
+
 @total_ordering
 class Policy(object):
-        """Abstract base Policy class.  It defines the interface all subclasses
-        must provide.
+    """Abstract base Policy class.  It defines the interface all subclasses
+    must provide.
 
-        Each subclass must also define its "strictness".
-        Strictness is a positive integer and is relative to the other
-        subclasses in existence.  More than one subclass may have the same
-        strictness level.  In the abscence of other information, when combining
-        two policies, the result is the stricter policy."""
+    Each subclass must also define its "strictness".
+    Strictness is a positive integer and is relative to the other
+    subclasses in existence.  More than one subclass may have the same
+    strictness level.  In the abscence of other information, when combining
+    two policies, the result is the stricter policy."""
 
-        _policies = {}
+    _policies = {}
 
-        def __init__(self, *args, **kwargs):
-                # This method exists to provide a consistent __init__ method
-                # for the factory below.
-                object.__init__(self)
+    def __init__(self, *args, **kwargs):
+        # This method exists to provide a consistent __init__ method
+        # for the factory below.
+        object.__init__(self)
 
-        def process_signatures(self, sigs, acts, pub, trust_anchors,
-            use_crls):
-                """Check that the signatures ("sigs") verify against the actions
-                ("acts") using the publisher ("pub") as the repository for
-                certificates and "trust_anchors" as the dictionary of trust
-                anchors.
+    def process_signatures(self, sigs, acts, pub, trust_anchors, use_crls):
+        """Check that the signatures ("sigs") verify against the actions
+        ("acts") using the publisher ("pub") as the repository for
+        certificates and "trust_anchors" as the dictionary of trust
+        anchors.
 
-                Not implemented in the base class."""
-                raise NotImplementedError()
+        Not implemented in the base class."""
+        raise NotImplementedError()
 
-        def __lt__(self, other):
-                return self.strictness < other.strictness
+    def __lt__(self, other):
+        return self.strictness < other.strictness
 
-        def __eq__(self, other):
-                return self.strictness == other.strictness
+    def __eq__(self, other):
+        return self.strictness == other.strictness
 
-        __hash__ = None
+    __hash__ = None
 
-        def combine(self, other):
-                """If the other signature policy is more strict than this
-                policy, use the other policy.  Otherwise, use this policy."""
+    def combine(self, other):
+        """If the other signature policy is more strict than this
+        policy, use the other policy.  Otherwise, use this policy."""
 
-                if self > other:
-                        return self
-                return other
+        if self > other:
+            return self
+        return other
 
-        def __str__(self):
-                return self.name
+    def __str__(self):
+        return self.name
 
-        @staticmethod
-        def policies():
-                """Return the names of the signature policies available."""
+    @staticmethod
+    def policies():
+        """Return the names of the signature policies available."""
 
-                return set(Policy._policies.keys())
+        return set(Policy._policies.keys())
 
-        @staticmethod
-        def policy_factory(name, *args, **kwargs):
-                """Given the name of a policy, return a new policy object of
-                that type."""
+    @staticmethod
+    def policy_factory(name, *args, **kwargs):
+        """Given the name of a policy, return a new policy object of
+        that type."""
 
-                assert name in Policy._policies
-                return Policy._policies[name](*args, **kwargs)
+        assert name in Policy._policies
+        return Policy._policies[name](*args, **kwargs)
 
 
 class Ignore(Policy):
-        """This policy ignores all signatures except to attempt to retrieve
-        any certificates that might be needed if the policy changes."""
+    """This policy ignores all signatures except to attempt to retrieve
+    any certificates that might be needed if the policy changes."""
 
-        strictness = 1
-        name = "ignore"
+    strictness = 1
+    name = "ignore"
 
-        def process_signatures(self, sigs, acts, pub, trust_anchors,
-            use_crls):
-                """Since this policy ignores signatures, only download the
-                certificates that might be needed so that they're present if
-                the policy changes later."""
+    def process_signatures(self, sigs, acts, pub, trust_anchors, use_crls):
+        """Since this policy ignores signatures, only download the
+        certificates that might be needed so that they're present if
+        the policy changes later."""
 
-                for s in sigs:
-                        s.retrieve_chain_certs(pub)
+        for s in sigs:
+            s.retrieve_chain_certs(pub)
+
 
 Policy._policies[Ignore.name] = Ignore
 
 
 class Verify(Policy):
-        """This policy verifies that all signatures present are valid but
-        doesn't require that a signature be present."""
+    """This policy verifies that all signatures present are valid but
+    doesn't require that a signature be present."""
 
-        strictness = 2
-        name = "verify"
+    strictness = 2
+    name = "verify"
 
-        def process_signatures(self, sigs, acts, pub, trust_anchors,
-            use_crls):
-                """Check that all signatures present are valid signatures."""
+    def process_signatures(self, sigs, acts, pub, trust_anchors, use_crls):
+        """Check that all signatures present are valid signatures."""
 
-                # Ensure that acts can be iterated over repeatedly.
-                acts = list(acts)
-                for s in sigs:
-                        s.verify_sig(acts, pub, trust_anchors, use_crls)
+        # Ensure that acts can be iterated over repeatedly.
+        acts = list(acts)
+        for s in sigs:
+            s.verify_sig(acts, pub, trust_anchors, use_crls)
+
 
 Policy._policies[Verify.name] = Verify
 
+
 class RequireSigs(Policy):
-        """This policy that all signatures present are valid and insists that
-        at least one signature is seen with each package."""
+    """This policy that all signatures present are valid and insists that
+    at least one signature is seen with each package."""
 
-        strictness = 3
-        name = "require-signatures"
+    strictness = 3
+    name = "require-signatures"
 
-        def process_signatures(self, sigs, acts, pub, trust_anchors,
-            use_crls):
-                """Check that all signatures present are valid signatures and
-                at least one signature action which has been signed with a
-                private key is present."""
+    def process_signatures(self, sigs, acts, pub, trust_anchors, use_crls):
+        """Check that all signatures present are valid signatures and
+        at least one signature action which has been signed with a
+        private key is present."""
 
-                # Ensure that acts can be iterated over repeatedly.
-                acts = list(acts)
-                verified = False
-                for s in sigs:
-                        verified |= \
-                            bool(s.verify_sig(acts, pub, trust_anchors,
-                                use_crls)) and \
-                            s.is_signed()
-                if not verified:
-                        raise apx.RequiredSignaturePolicyException(pub)
+        # Ensure that acts can be iterated over repeatedly.
+        acts = list(acts)
+        verified = False
+        for s in sigs:
+            verified |= (
+                bool(s.verify_sig(acts, pub, trust_anchors, use_crls))
+                and s.is_signed()
+            )
+        if not verified:
+            raise apx.RequiredSignaturePolicyException(pub)
+
 
 Policy._policies[RequireSigs.name] = RequireSigs
 
 
 class RequireNames(Policy):
-        """This policy that all signatures present are valid and insists that
-        at least one signature is seen with each package.  In addition, it has
-        a set of names that must seen as CN's in the chain of trust."""
+    """This policy that all signatures present are valid and insists that
+    at least one signature is seen with each package.  In addition, it has
+    a set of names that must seen as CN's in the chain of trust."""
 
-        strictness = 4
-        name = "require-names"
-        def __init__(self, req_names, *args, **kwargs):
-                assert req_names, "RequireNames requires at least one name " \
-                    "to be passed to the constructor."
-                Policy.__init__(self, *args, **kwargs)
-                if isinstance(req_names, six.string_types):
-                        req_names = [req_names]
-                self.required_names = frozenset(req_names)
+    strictness = 4
+    name = "require-names"
 
-        def process_signatures(self, sigs, acts, pub, trust_anchors,
-            use_crls):
-                acts = list(acts)
-                missing_names = set(self.required_names)
-                verified = False
-                for s in sigs:
-                        verified |= bool(s.verify_sig(acts, pub, trust_anchors,
-                            use_crls, missing_names)) and \
-                            s.is_signed()
-                if missing_names:
-                        raise apx.MissingRequiredNamesException(pub,
-                            missing_names)
+    def __init__(self, req_names, *args, **kwargs):
+        assert req_names, (
+            "RequireNames requires at least one name "
+            "to be passed to the constructor."
+        )
+        Policy.__init__(self, *args, **kwargs)
+        if isinstance(req_names, six.string_types):
+            req_names = [req_names]
+        self.required_names = frozenset(req_names)
 
-        def combine(self, other):
-                """Determines how RequireNames policies combine with another
-                policy.  If the other policy is also a RequireNames policy,
-                the result is a policy which requires the union of both policies
-                required names."""
+    def process_signatures(self, sigs, acts, pub, trust_anchors, use_crls):
+        acts = list(acts)
+        missing_names = set(self.required_names)
+        verified = False
+        for s in sigs:
+            verified |= (
+                bool(
+                    s.verify_sig(
+                        acts, pub, trust_anchors, use_crls, missing_names
+                    )
+                )
+                and s.is_signed()
+            )
+        if missing_names:
+            raise apx.MissingRequiredNamesException(pub, missing_names)
 
-                if self > other:
-                        return self
-                if other > self:
-                        return other
-                return RequireNames(self.required_names | other.required_names)
+    def combine(self, other):
+        """Determines how RequireNames policies combine with another
+        policy.  If the other policy is also a RequireNames policy,
+        the result is a policy which requires the union of both policies
+        required names."""
+
+        if self > other:
+            return self
+        if other > self:
+            return other
+        return RequireNames(self.required_names | other.required_names)
+
 
 Policy._policies[RequireNames.name] = RequireNames
 
@@ -200,4 +208,4 @@ DEFAULT_POLICY = "verify"
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/transport/__init__.py
+++ b/src/modules/client/transport/__init__.py
@@ -24,8 +24,8 @@
 # Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
 #
 
-__all__ = [ "transport" ]
+__all__ = ["transport"]
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/transport/engine.py
+++ b/src/modules/client/transport/engine.py
@@ -38,1150 +38,1270 @@ from six.moves.urllib.parse import urlsplit
 
 # Need to ignore SIGPIPE if using pycurl in NOSIGNAL mode.
 try:
-        import signal
-        if hasattr(signal, "SIGPIPE"):
-                signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    import signal
+
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 except ImportError:
-        pass
+    pass
 
-import pkg.client.api_errors            as api_errors
-import pkg.client.transport.exception   as tx
-import pkg.client.transport.fileobj     as fileobj
-import pkg.misc                         as misc
+import pkg.client.api_errors as api_errors
+import pkg.client.transport.exception as tx
+import pkg.client.transport.fileobj as fileobj
+import pkg.misc as misc
 
-from collections        import deque
-from pkg.client         import global_settings
+from collections import deque
+from pkg.client import global_settings
 from pkg.client.debugvalues import DebugValues
 
 pipelined_protocols = ()
 response_protocols = ("ftp", "http", "https")
 
+
 class TransportEngine(object):
-        """This is an abstract class.  It shouldn't implement any
-        of the methods that it contains.  Leave that to transport-specific
-        implementations."""
+    """This is an abstract class.  It shouldn't implement any
+    of the methods that it contains.  Leave that to transport-specific
+    implementations."""
 
 
 class CurlTransportEngine(TransportEngine):
-        """Concrete class of TransportEngine for libcurl transport."""
-
-        def __init__(self, transport, max_conn=20):
-
-                # Backpointer to transport object
-                self.__xport = transport
-                # Curl handles
-                self.__mhandle = pycurl.CurlMulti()
-                self.__chandles = []
-                self.__active_handles = 0
-                self.__max_handles = max_conn
-                # Request queue
-                self.__req_q = deque()
-                # List of failures
-                self.__failures = []
-                # List of URLs successfully transferred
-                self.__success = []
-                # List of Orphaned URLs.
-                self.__orphans = set()
-                # Set default file buffer size at 128k, callers override
-                # this setting after looking at VFS block size.
-                self.__file_bufsz = 131072
-                # Header bits and pieces
-                self.__user_agent = None
-                self.__common_header = {}
-                self.__last_stall_check = 0
-
-                # Set options on multi-handle
-                self.__mhandle.setopt(pycurl.M_PIPELINING, 0)
-
-                # initialize easy handles
-                for i in range(self.__max_handles):
-                        eh = pycurl.Curl()
-                        eh.url = None
-                        eh.repourl = None
-                        eh.fobj = None
-                        eh.r_fobj = None
-                        eh.filepath = None
-                        eh.success = False
-                        eh.fileprog = None
-                        eh.filetime = -1
-                        eh.starttime = -1
-                        eh.uuid = None
-                        self.__chandles.append(eh)
-
-                # copy handles into handle freelist
-                self.__freehandles = self.__chandles[:]
-
-        def __call_perform(self):
-                """An internal method that invokes the multi-handle's
-                perform method."""
-
-                while 1:
-                        ret, active_handles = self.__mhandle.perform()
-                        if ret != pycurl.E_CALL_MULTI_PERFORM:
-                                break
-
-                self.__active_handles = active_handles
-                return ret
-
-        def add_url(self, url, filepath=None, writefunc=None, header=None,
-            progclass=None, progtrack=None, sslcert=None, sslkey=None,
-            repourl=None, compressible=False, failonerror=True, proxy=None,
-            runtime_proxy=None):
-                """Add a URL to the transport engine.  Caller must supply
-                either a filepath where the file should be downloaded,
-                or a callback to a function that will peform the write.
-                It may also optionally supply header information
-                in a dictionary.  If the caller has a ProgressTracker,
-                it should pass the tracker in progtrack.  The caller should
-                also supply a class that wraps the tracker in progclass.
-
-                'proxy' is the persistent proxy value for this url and is
-                stored as part of the transport stats accounting.
-
-                'runtime_proxy' is the actual proxy value that is used by pycurl
-                to retrieve this resource."""
-
-                t = TransportRequest(url, filepath=filepath,
-                    writefunc=writefunc, header=header, progclass=progclass,
-                    progtrack=progtrack, sslcert=sslcert, sslkey=sslkey,
-                    repourl=repourl, compressible=compressible,
-                    failonerror=failonerror, proxy=proxy,
-                    runtime_proxy=runtime_proxy)
-
-                self.__req_q.appendleft(t)
-
-        def __check_for_stalls(self):
-                """In some situations, libcurl can get itself
-                tied in a knot, and fail to make progress.  Check that the
-                active handles are making progress.  If none of the active
-                handles have downloaded any content for the timeout period,
-                reset the transport and generate exceptions for the failed
-                requests."""
-
-                timeout = global_settings.PKG_CLIENT_LOWSPEED_TIMEOUT
-                if timeout == 0:
-                        return
-                current_time = time.time()
-                time_list = []
-                size_list = []
-                failures = []
-                q_hdls = [
-                    hdl for hdl in self.__chandles
-                    if hdl not in self.__freehandles
-                ]
-
-                # time.time() is based upon system clock.  Check that
-                # our time hasn't been set backwards.  If time is set forward,
-                # we'll have to expire the handles.  There's no way to detect
-                # this until python properly implements gethrtime().  Solaris
-                # implementations of time.clock() appear broken.
-
-                for h in q_hdls:
-                        time_elapsed = current_time - h.starttime
-                        if time_elapsed < 0:
-                                h.starttime = current_time
-                                time_elapsed = 0
-                        size_xfrd = h.getinfo(pycurl.SIZE_DOWNLOAD) + \
-                            h.getinfo(pycurl.SIZE_UPLOAD)
-                        time_list.append(time_elapsed)
-                        size_list.append(size_xfrd)
-
-                # If timeout is smaller than smallest elapsed time,
-                # and no data has been transferred, abort.
-                if timeout < min(time_list) and max(size_list) == 0:
-                        for h in q_hdls:
-                                url = h.url
-                                uuid = h.uuid
-                                urlstem = h.repourl
-                                ex = tx.TransportStallError(url,
-                                    repourl=urlstem, uuid=uuid)
-
-                                self.__mhandle.remove_handle(h)
-                                self.__teardown_handle(h)
-                                self.__freehandles.append(h)
-
-                                failures.append(ex)
-
-                self.__failures.extend(failures)
-
-
-        def __cleanup_requests(self):
-                """Cleanup handles that have finished their request.
-                Return the handles to the freelist.  Generate any
-                relevant error information."""
-
-                count, good, bad = self.__mhandle.info_read()
-                failures = self.__failures
-                success = self.__success
-                done_handles = []
-                ex_to_raise = None
-                visited_repos = set()
-                errors_seen = 0
-
-                for h, en, em in bad:
-                        # Get statistics for each handle.
-                        # As new properties are added to URIs that differentiate
-                        # them, the tuple used to index the __xport.stats entry
-                        # should also include those properties so that we can
-                        # track statistics uniquely for each RepoURI. That is,
-                        # the format of the keys of the __xport.stats dictionary
-                        # should match the one generated by
-                        # pkg.client.publisher.TransportRepoURI.key()
-                        repostats = self.__xport.stats[(h.repourl, h.proxy)]
-                        visited_repos.add(repostats)
-                        repostats.record_tx()
-                        nbytes = h.getinfo(pycurl.SIZE_DOWNLOAD)
-                        seconds = h.getinfo(pycurl.TOTAL_TIME)
-                        conn_count = h.getinfo(pycurl.NUM_CONNECTS)
-                        conn_time = h.getinfo(pycurl.CONNECT_TIME)
-
-                        url = h.url
-                        uuid = h.uuid
-                        urlstem = h.repourl
-                        proto = urlsplit(url)[0]
-
-                        # When using pipelined operations, libcurl tracks the
-                        # amount of time taken for the entire pipelined request
-                        # as opposed to just the amount of time for a single
-                        # file in the pipeline.  So, if the connection time is 0
-                        # for a request using http(s), then it was pipelined and
-                        # the total time must be obtained by subtracting the
-                        # time the transfer of the individual request started
-                        # from the total time.
-                        if conn_time == 0 and proto in pipelined_protocols:
-                                # Only performing this subtraction when the
-                                # conn_time is 0 allows the first request in
-                                # the pipeline to properly include connection
-                                # time, etc. to initiate the transfer.
-                                seconds -= h.getinfo(pycurl.STARTTRANSFER_TIME)
-                        elif conn_time > 0:
-                                seconds -= conn_time
-
-                        # Sometimes libcurl will report no transfer time.
-                        # In that case, just use starttransfer time if it's
-                        # non-zero.
-                        if seconds < 0:
-                                seconds = h.getinfo(pycurl.STARTTRANSFER_TIME)
-
-                        repostats.record_progress(nbytes, seconds)
-
-                        # Only count connections if the connection time is
-                        # positive for http(s); for all other protocols,
-                        # record the connection regardless.
-                        if conn_count > 0 and conn_time > 0:
-                                repostats.record_connection(conn_time)
-
-                        respcode = h.getinfo(pycurl.RESPONSE_CODE)
-
-                        # If we were cancelled, raise an API error.
-                        # Otherwise fall through to transport's exception
-                        # generation.
-                        if en == pycurl.E_ABORTED_BY_CALLBACK:
-                                ex = None
-                                ex_to_raise = api_errors.CanceledException
-                        elif en in (pycurl.E_HTTP_RETURNED_ERROR,
-                            pycurl.E_FILE_COULDNT_READ_FILE):
-                                # E_HTTP_RETURNED_ERROR is only used for http://
-                                # and https://, but a more specific reason for
-                                # failure can be obtained from respcode.
-                                #
-                                # E_FILE_COULDNT_READ_FILE is only used for
-                                # file://, but unfortunately can mean ENOENT,
-                                # EPERM, etc. and libcurl doesn't differentiate
-                                # or provide a respcode.
-                                if proto not in response_protocols:
-                                        # For protocols that don't provide a
-                                        # pycurl.RESPONSE_CODE, use the
-                                        # pycurl error number instead.
-                                        respcode = en
-                                proto_reason = None
-                                if proto in tx.proto_code_map:
-                                        # Look up protocol error code map
-                                        # from transport exception's table.
-                                        pmap = tx.proto_code_map[proto]
-                                        if respcode in pmap:
-                                                proto_reason = pmap[respcode]
-                                ex = tx.TransportProtoError(proto, respcode,
-                                    url, reason=proto_reason, repourl=urlstem,
-                                    uuid=uuid)
-                                repostats.record_error(decayable=ex.decayable)
-                                errors_seen += 1
-                        else:
-                                timeout = en == pycurl.E_OPERATION_TIMEOUTED
-                                ex = tx.TransportFrameworkError(en, url, em,
-                                    repourl=urlstem, uuid=uuid)
-                                repostats.record_error(decayable=ex.decayable,
-                                    timeout=timeout)
-                                errors_seen += 1
-
-                        if ex and ex.retryable:
-                                failures.append(ex)
-                        elif ex and not ex_to_raise:
-                                ex_to_raise = ex
-
-                        done_handles.append(h)
-
-                for h in good:
-                        # Get statistics for each handle.
-                        repostats = self.__xport.stats[(h.repourl, h.proxy)]
-                        visited_repos.add(repostats)
-                        repostats.record_tx()
-                        nbytes = h.getinfo(pycurl.SIZE_DOWNLOAD)
-                        seconds = h.getinfo(pycurl.TOTAL_TIME)
-                        conn_count = h.getinfo(pycurl.NUM_CONNECTS)
-                        conn_time = h.getinfo(pycurl.CONNECT_TIME)
-                        h.filetime = h.getinfo(pycurl.INFO_FILETIME)
-
-                        url = h.url
-                        uuid = h.uuid
-                        urlstem = h.repourl
-                        proto = urlsplit(url)[0]
-
-                        # When using pipelined operations, libcurl tracks the
-                        # amount of time taken for the entire pipelined request
-                        # as opposed to just the amount of time for a single
-                        # file in the pipeline.  So, if the connection time is 0
-                        # for a request using http(s), then it was pipelined and
-                        # the total time must be obtained by subtracting the
-                        # time the transfer of the individual request started
-                        # from the total time.
-                        if conn_time == 0 and proto in pipelined_protocols:
-                                # Only performing this subtraction when the
-                                # conn_time is 0 allows the first request in
-                                # the pipeline to properly include connection
-                                # time, etc. to initiate the transfer and
-                                # the correct calculations of bytespersec.
-                                seconds -= h.getinfo(pycurl.STARTTRANSFER_TIME)
-                        elif conn_time > 0:
-                                seconds -= conn_time
-
-                        if seconds > 0:
-                                bytespersec = nbytes // seconds
-                        else:
-                                bytespersec = 0
-
-                        # If a request ahead of a successful request fails due
-                        # to a timeout, sometimes libcurl will report impossibly
-                        # large total time values.  In this case, check that the
-                        # nbytes/sec exceeds our minimum threshold.  If it does
-                        # not, and the total time is longer than our timeout,
-                        # discard the time calculation as it is bogus.
-                        if (bytespersec <
-                            global_settings.pkg_client_lowspeed_limit) and (
-                            seconds >
-                            global_settings.PKG_CLIENT_LOWSPEED_TIMEOUT):
-                                nbytes = 0
-                                seconds = 0
-                        repostats.record_progress(nbytes, seconds)
-
-                        # Only count connections if the connection time is
-                        # positive for http(s); for all other protocols,
-                        # record the connection regardless.
-                        if conn_count > 0 and conn_time > 0:
-                                repostats.record_connection(conn_time)
-
-                        respcode = h.getinfo(pycurl.RESPONSE_CODE)
-
-                        if proto not in response_protocols or \
-                            respcode == http_client.OK:
-                                h.success = True
-                                repostats.clear_consecutive_errors()
-                                success.append(url)
-                        else:
-                                proto_reason = None
-                                if proto in tx.proto_code_map:
-                                        # Look up protocol error code map
-                                        # from transport exception's table.
-                                        pmap = tx.proto_code_map[proto]
-                                        if respcode in pmap:
-                                                proto_reason = pmap[respcode]
-                                ex = tx.TransportProtoError(proto,
-                                    respcode, url, reason=proto_reason,
-                                    repourl=urlstem, uuid=uuid)
-
-                                # If code >= 400, record this as an error.
-                                # Handlers above the engine get to decide
-                                # for 200/300 codes that aren't OK
-                                if respcode >= 400:
-                                        repostats.record_error(
-                                            decayable=ex.decayable)
-                                        errors_seen += 1
-                                # If code == 0, libcurl failed to read
-                                # any HTTP status.  Response is almost
-                                # certainly corrupted.
-                                elif respcode == 0:
-                                        repostats.record_error()
-                                        errors_seen += 1
-                                        reason = "Invalid HTTP status code " \
-                                            "from server"
-                                        ex = tx.TransportProtoError(proto,
-                                            url=url, reason=reason,
-                                            repourl=urlstem, uuid=uuid)
-                                        ex.retryable = True
-
-                                # Stash retryable failures, arrange
-                                # to raise first fatal error after
-                                # cleanup.
-                                if ex.retryable:
-                                        failures.append(ex)
-                                elif not ex_to_raise:
-                                        ex_to_raise = ex
-
-                        done_handles.append(h)
-
-                # Call to remove_handle must be separate from info_read()
-                for h in done_handles:
-                        self.__mhandle.remove_handle(h)
-                        self.__teardown_handle(h)
-                        self.__freehandles.append(h)
-
-                self.__failures = failures
-                self.__success = success
-
-                if ex_to_raise:
-                        raise ex_to_raise
-
-                # Don't bother to check the transient error count if no errors
-                # were encountered in this transaction.
-                if errors_seen == 0:
-                        return
-
-                # If errors were encountered, but no exception raised,
-                # check if the maximum number of transient failures has
-                # been exceeded at any of the endpoints that were visited
-                # during this transaction.
-                for rs in visited_repos:
-                        numce = rs.consecutive_errors
-                        if numce >= \
-                            global_settings.PKG_CLIENT_MAX_CONSECUTIVE_ERROR:
-                                # Reset consecutive error count before raising
-                                # this exception.
-                                rs.clear_consecutive_errors()
-                                raise tx.ExcessiveTransientFailure(rs.url,
-                                    numce)
-
-        def check_status(self, urllist=None, good_reqs=False):
-                """Return information about retryable failures that occured
-                during the request.
-
-                This is a list of transport exceptions.  Caller
-                may raise these, or process them for failure information.
-
-                Urllist is an optional argument to return only failures
-                for a specific URLs.  Not all callers of check status
-                want to claim the error state of all pending transactions.
-
-                Transient errors are part of standard control flow.
-                The caller will look at these and decide whether
-                to throw them or not.  Permanent failures are raised
-                by the transport engine as soon as they occur.
-
-                If good_reqs is set to true, then check_stats will
-                return a tuple of lists, the first list contains the
-                transient errors that were encountered, the second list
-                contains successfully transferred urls.  Because the
-                list of successfully transferred URLs may be long,
-                it is discarded if not requested by the caller."""
-
-                # if list not specified, return all failures
-                if not urllist:
-                        rf = self.__failures
-                        rs = self.__success
-                        self.__failures = []
-                        self.__success = []
-
-                        if good_reqs:
-                                return rf, rs
-
-                        return rf
-
-                # otherwise, look for failures that match just the URLs
-                # in urllist.
-                rf = [
-                    tf
-                    for tf in self.__failures
-                    if hasattr(tf, "url") and tf.url in urllist
-                ]
-
-                # remove failues in separate pass, or else for loop gets
-                # confused.
-                for f in rf:
-                        self.__failures.remove(f)
-
-                if not good_reqs:
-                        self.__success = []
-                        return rf
-
-                rs = []
-
-                for ts in self.__success:
-                        if ts in urllist:
-                                rs.append(ts)
-
-                for s in rs:
-                        self.__success.remove(s)
-
+    """Concrete class of TransportEngine for libcurl transport."""
+
+    def __init__(self, transport, max_conn=20):
+        # Backpointer to transport object
+        self.__xport = transport
+        # Curl handles
+        self.__mhandle = pycurl.CurlMulti()
+        self.__chandles = []
+        self.__active_handles = 0
+        self.__max_handles = max_conn
+        # Request queue
+        self.__req_q = deque()
+        # List of failures
+        self.__failures = []
+        # List of URLs successfully transferred
+        self.__success = []
+        # List of Orphaned URLs.
+        self.__orphans = set()
+        # Set default file buffer size at 128k, callers override
+        # this setting after looking at VFS block size.
+        self.__file_bufsz = 131072
+        # Header bits and pieces
+        self.__user_agent = None
+        self.__common_header = {}
+        self.__last_stall_check = 0
+
+        # Set options on multi-handle
+        self.__mhandle.setopt(pycurl.M_PIPELINING, 0)
+
+        # initialize easy handles
+        for i in range(self.__max_handles):
+            eh = pycurl.Curl()
+            eh.url = None
+            eh.repourl = None
+            eh.fobj = None
+            eh.r_fobj = None
+            eh.filepath = None
+            eh.success = False
+            eh.fileprog = None
+            eh.filetime = -1
+            eh.starttime = -1
+            eh.uuid = None
+            self.__chandles.append(eh)
+
+        # copy handles into handle freelist
+        self.__freehandles = self.__chandles[:]
+
+    def __call_perform(self):
+        """An internal method that invokes the multi-handle's
+        perform method."""
+
+        while 1:
+            ret, active_handles = self.__mhandle.perform()
+            if ret != pycurl.E_CALL_MULTI_PERFORM:
+                break
+
+        self.__active_handles = active_handles
+        return ret
+
+    def add_url(
+        self,
+        url,
+        filepath=None,
+        writefunc=None,
+        header=None,
+        progclass=None,
+        progtrack=None,
+        sslcert=None,
+        sslkey=None,
+        repourl=None,
+        compressible=False,
+        failonerror=True,
+        proxy=None,
+        runtime_proxy=None,
+    ):
+        """Add a URL to the transport engine.  Caller must supply
+        either a filepath where the file should be downloaded,
+        or a callback to a function that will peform the write.
+        It may also optionally supply header information
+        in a dictionary.  If the caller has a ProgressTracker,
+        it should pass the tracker in progtrack.  The caller should
+        also supply a class that wraps the tracker in progclass.
+
+        'proxy' is the persistent proxy value for this url and is
+        stored as part of the transport stats accounting.
+
+        'runtime_proxy' is the actual proxy value that is used by pycurl
+        to retrieve this resource."""
+
+        t = TransportRequest(
+            url,
+            filepath=filepath,
+            writefunc=writefunc,
+            header=header,
+            progclass=progclass,
+            progtrack=progtrack,
+            sslcert=sslcert,
+            sslkey=sslkey,
+            repourl=repourl,
+            compressible=compressible,
+            failonerror=failonerror,
+            proxy=proxy,
+            runtime_proxy=runtime_proxy,
+        )
+
+        self.__req_q.appendleft(t)
+
+    def __check_for_stalls(self):
+        """In some situations, libcurl can get itself
+        tied in a knot, and fail to make progress.  Check that the
+        active handles are making progress.  If none of the active
+        handles have downloaded any content for the timeout period,
+        reset the transport and generate exceptions for the failed
+        requests."""
+
+        timeout = global_settings.PKG_CLIENT_LOWSPEED_TIMEOUT
+        if timeout == 0:
+            return
+        current_time = time.time()
+        time_list = []
+        size_list = []
+        failures = []
+        q_hdls = [
+            hdl for hdl in self.__chandles if hdl not in self.__freehandles
+        ]
+
+        # time.time() is based upon system clock.  Check that
+        # our time hasn't been set backwards.  If time is set forward,
+        # we'll have to expire the handles.  There's no way to detect
+        # this until python properly implements gethrtime().  Solaris
+        # implementations of time.clock() appear broken.
+
+        for h in q_hdls:
+            time_elapsed = current_time - h.starttime
+            if time_elapsed < 0:
+                h.starttime = current_time
+                time_elapsed = 0
+            size_xfrd = h.getinfo(pycurl.SIZE_DOWNLOAD) + h.getinfo(
+                pycurl.SIZE_UPLOAD
+            )
+            time_list.append(time_elapsed)
+            size_list.append(size_xfrd)
+
+        # If timeout is smaller than smallest elapsed time,
+        # and no data has been transferred, abort.
+        if timeout < min(time_list) and max(size_list) == 0:
+            for h in q_hdls:
+                url = h.url
+                uuid = h.uuid
+                urlstem = h.repourl
+                ex = tx.TransportStallError(url, repourl=urlstem, uuid=uuid)
+
+                self.__mhandle.remove_handle(h)
+                self.__teardown_handle(h)
+                self.__freehandles.append(h)
+
+                failures.append(ex)
+
+        self.__failures.extend(failures)
+
+    def __cleanup_requests(self):
+        """Cleanup handles that have finished their request.
+        Return the handles to the freelist.  Generate any
+        relevant error information."""
+
+        count, good, bad = self.__mhandle.info_read()
+        failures = self.__failures
+        success = self.__success
+        done_handles = []
+        ex_to_raise = None
+        visited_repos = set()
+        errors_seen = 0
+
+        for h, en, em in bad:
+            # Get statistics for each handle.
+            # As new properties are added to URIs that differentiate
+            # them, the tuple used to index the __xport.stats entry
+            # should also include those properties so that we can
+            # track statistics uniquely for each RepoURI. That is,
+            # the format of the keys of the __xport.stats dictionary
+            # should match the one generated by
+            # pkg.client.publisher.TransportRepoURI.key()
+            repostats = self.__xport.stats[(h.repourl, h.proxy)]
+            visited_repos.add(repostats)
+            repostats.record_tx()
+            nbytes = h.getinfo(pycurl.SIZE_DOWNLOAD)
+            seconds = h.getinfo(pycurl.TOTAL_TIME)
+            conn_count = h.getinfo(pycurl.NUM_CONNECTS)
+            conn_time = h.getinfo(pycurl.CONNECT_TIME)
+
+            url = h.url
+            uuid = h.uuid
+            urlstem = h.repourl
+            proto = urlsplit(url)[0]
+
+            # When using pipelined operations, libcurl tracks the
+            # amount of time taken for the entire pipelined request
+            # as opposed to just the amount of time for a single
+            # file in the pipeline.  So, if the connection time is 0
+            # for a request using http(s), then it was pipelined and
+            # the total time must be obtained by subtracting the
+            # time the transfer of the individual request started
+            # from the total time.
+            if conn_time == 0 and proto in pipelined_protocols:
+                # Only performing this subtraction when the
+                # conn_time is 0 allows the first request in
+                # the pipeline to properly include connection
+                # time, etc. to initiate the transfer.
+                seconds -= h.getinfo(pycurl.STARTTRANSFER_TIME)
+            elif conn_time > 0:
+                seconds -= conn_time
+
+            # Sometimes libcurl will report no transfer time.
+            # In that case, just use starttransfer time if it's
+            # non-zero.
+            if seconds < 0:
+                seconds = h.getinfo(pycurl.STARTTRANSFER_TIME)
+
+            repostats.record_progress(nbytes, seconds)
+
+            # Only count connections if the connection time is
+            # positive for http(s); for all other protocols,
+            # record the connection regardless.
+            if conn_count > 0 and conn_time > 0:
+                repostats.record_connection(conn_time)
+
+            respcode = h.getinfo(pycurl.RESPONSE_CODE)
+
+            # If we were cancelled, raise an API error.
+            # Otherwise fall through to transport's exception
+            # generation.
+            if en == pycurl.E_ABORTED_BY_CALLBACK:
+                ex = None
+                ex_to_raise = api_errors.CanceledException
+            elif en in (
+                pycurl.E_HTTP_RETURNED_ERROR,
+                pycurl.E_FILE_COULDNT_READ_FILE,
+            ):
+                # E_HTTP_RETURNED_ERROR is only used for http://
+                # and https://, but a more specific reason for
+                # failure can be obtained from respcode.
+                #
+                # E_FILE_COULDNT_READ_FILE is only used for
+                # file://, but unfortunately can mean ENOENT,
+                # EPERM, etc. and libcurl doesn't differentiate
+                # or provide a respcode.
+                if proto not in response_protocols:
+                    # For protocols that don't provide a
+                    # pycurl.RESPONSE_CODE, use the
+                    # pycurl error number instead.
+                    respcode = en
+                proto_reason = None
+                if proto in tx.proto_code_map:
+                    # Look up protocol error code map
+                    # from transport exception's table.
+                    pmap = tx.proto_code_map[proto]
+                    if respcode in pmap:
+                        proto_reason = pmap[respcode]
+                ex = tx.TransportProtoError(
+                    proto,
+                    respcode,
+                    url,
+                    reason=proto_reason,
+                    repourl=urlstem,
+                    uuid=uuid,
+                )
+                repostats.record_error(decayable=ex.decayable)
+                errors_seen += 1
+            else:
+                timeout = en == pycurl.E_OPERATION_TIMEOUTED
+                ex = tx.TransportFrameworkError(
+                    en, url, em, repourl=urlstem, uuid=uuid
+                )
+                repostats.record_error(decayable=ex.decayable, timeout=timeout)
+                errors_seen += 1
+
+            if ex and ex.retryable:
+                failures.append(ex)
+            elif ex and not ex_to_raise:
+                ex_to_raise = ex
+
+            done_handles.append(h)
+
+        for h in good:
+            # Get statistics for each handle.
+            repostats = self.__xport.stats[(h.repourl, h.proxy)]
+            visited_repos.add(repostats)
+            repostats.record_tx()
+            nbytes = h.getinfo(pycurl.SIZE_DOWNLOAD)
+            seconds = h.getinfo(pycurl.TOTAL_TIME)
+            conn_count = h.getinfo(pycurl.NUM_CONNECTS)
+            conn_time = h.getinfo(pycurl.CONNECT_TIME)
+            h.filetime = h.getinfo(pycurl.INFO_FILETIME)
+
+            url = h.url
+            uuid = h.uuid
+            urlstem = h.repourl
+            proto = urlsplit(url)[0]
+
+            # When using pipelined operations, libcurl tracks the
+            # amount of time taken for the entire pipelined request
+            # as opposed to just the amount of time for a single
+            # file in the pipeline.  So, if the connection time is 0
+            # for a request using http(s), then it was pipelined and
+            # the total time must be obtained by subtracting the
+            # time the transfer of the individual request started
+            # from the total time.
+            if conn_time == 0 and proto in pipelined_protocols:
+                # Only performing this subtraction when the
+                # conn_time is 0 allows the first request in
+                # the pipeline to properly include connection
+                # time, etc. to initiate the transfer and
+                # the correct calculations of bytespersec.
+                seconds -= h.getinfo(pycurl.STARTTRANSFER_TIME)
+            elif conn_time > 0:
+                seconds -= conn_time
+
+            if seconds > 0:
+                bytespersec = nbytes // seconds
+            else:
+                bytespersec = 0
+
+            # If a request ahead of a successful request fails due
+            # to a timeout, sometimes libcurl will report impossibly
+            # large total time values.  In this case, check that the
+            # nbytes/sec exceeds our minimum threshold.  If it does
+            # not, and the total time is longer than our timeout,
+            # discard the time calculation as it is bogus.
+            if (bytespersec < global_settings.pkg_client_lowspeed_limit) and (
+                seconds > global_settings.PKG_CLIENT_LOWSPEED_TIMEOUT
+            ):
+                nbytes = 0
+                seconds = 0
+            repostats.record_progress(nbytes, seconds)
+
+            # Only count connections if the connection time is
+            # positive for http(s); for all other protocols,
+            # record the connection regardless.
+            if conn_count > 0 and conn_time > 0:
+                repostats.record_connection(conn_time)
+
+            respcode = h.getinfo(pycurl.RESPONSE_CODE)
+
+            if proto not in response_protocols or respcode == http_client.OK:
+                h.success = True
+                repostats.clear_consecutive_errors()
+                success.append(url)
+            else:
+                proto_reason = None
+                if proto in tx.proto_code_map:
+                    # Look up protocol error code map
+                    # from transport exception's table.
+                    pmap = tx.proto_code_map[proto]
+                    if respcode in pmap:
+                        proto_reason = pmap[respcode]
+                ex = tx.TransportProtoError(
+                    proto,
+                    respcode,
+                    url,
+                    reason=proto_reason,
+                    repourl=urlstem,
+                    uuid=uuid,
+                )
+
+                # If code >= 400, record this as an error.
+                # Handlers above the engine get to decide
+                # for 200/300 codes that aren't OK
+                if respcode >= 400:
+                    repostats.record_error(decayable=ex.decayable)
+                    errors_seen += 1
+                # If code == 0, libcurl failed to read
+                # any HTTP status.  Response is almost
+                # certainly corrupted.
+                elif respcode == 0:
+                    repostats.record_error()
+                    errors_seen += 1
+                    reason = "Invalid HTTP status code " "from server"
+                    ex = tx.TransportProtoError(
+                        proto,
+                        url=url,
+                        reason=reason,
+                        repourl=urlstem,
+                        uuid=uuid,
+                    )
+                    ex.retryable = True
+
+                # Stash retryable failures, arrange
+                # to raise first fatal error after
+                # cleanup.
+                if ex.retryable:
+                    failures.append(ex)
+                elif not ex_to_raise:
+                    ex_to_raise = ex
+
+            done_handles.append(h)
+
+        # Call to remove_handle must be separate from info_read()
+        for h in done_handles:
+            self.__mhandle.remove_handle(h)
+            self.__teardown_handle(h)
+            self.__freehandles.append(h)
+
+        self.__failures = failures
+        self.__success = success
+
+        if ex_to_raise:
+            raise ex_to_raise
+
+        # Don't bother to check the transient error count if no errors
+        # were encountered in this transaction.
+        if errors_seen == 0:
+            return
+
+        # If errors were encountered, but no exception raised,
+        # check if the maximum number of transient failures has
+        # been exceeded at any of the endpoints that were visited
+        # during this transaction.
+        for rs in visited_repos:
+            numce = rs.consecutive_errors
+            if numce >= global_settings.PKG_CLIENT_MAX_CONSECUTIVE_ERROR:
+                # Reset consecutive error count before raising
+                # this exception.
+                rs.clear_consecutive_errors()
+                raise tx.ExcessiveTransientFailure(rs.url, numce)
+
+    def check_status(self, urllist=None, good_reqs=False):
+        """Return information about retryable failures that occured
+        during the request.
+
+        This is a list of transport exceptions.  Caller
+        may raise these, or process them for failure information.
+
+        Urllist is an optional argument to return only failures
+        for a specific URLs.  Not all callers of check status
+        want to claim the error state of all pending transactions.
+
+        Transient errors are part of standard control flow.
+        The caller will look at these and decide whether
+        to throw them or not.  Permanent failures are raised
+        by the transport engine as soon as they occur.
+
+        If good_reqs is set to true, then check_stats will
+        return a tuple of lists, the first list contains the
+        transient errors that were encountered, the second list
+        contains successfully transferred urls.  Because the
+        list of successfully transferred URLs may be long,
+        it is discarded if not requested by the caller."""
+
+        # if list not specified, return all failures
+        if not urllist:
+            rf = self.__failures
+            rs = self.__success
+            self.__failures = []
+            self.__success = []
+
+            if good_reqs:
                 return rf, rs
 
-        def get_url(self, url, header=None, sslcert=None, sslkey=None,
-            repourl=None, compressible=False, ccancel=None,
-            failonerror=True, proxy=None, runtime_proxy=None, system=False):
-                """Invoke the engine to retrieve a single URL.  Callers
-                wishing to obtain multiple URLs at once should use
-                addUrl() and run().
-
-                getUrl will return a read-only file object that allows access
-                to the URL's data.
-
-                'proxy' is the persistent proxy value for this url and is
-                stored as part of the transport stats accounting.
-
-                'runtime_proxy' is the actual proxy value that is used by pycurl
-                to retrieve this resource.
-
-                'system' whether the resource is being retrieved on behalf of
-                a system-publisher or directly from the system-repository.
-                """
-
-                fobj = fileobj.StreamingFileObj(url, self, ccancel=ccancel)
-                progfunc = None
-
-                if ccancel:
-                        progfunc = fobj.get_progress_func()
-
-                t = TransportRequest(url, writefunc=fobj.get_write_func(),
-                    hdrfunc=fobj.get_header_func(), header=header,
-                    sslcert=sslcert, sslkey=sslkey, repourl=repourl,
-                    compressible=compressible, progfunc=progfunc,
-                    uuid=fobj.uuid, failonerror=failonerror, proxy=proxy,
-                    runtime_proxy=runtime_proxy, system=system)
-
-                self.__req_q.appendleft(t)
-
-                return fobj
-
-        def get_url_header(self, url, header=None, sslcert=None, sslkey=None,
-            repourl=None, ccancel=None, failonerror=True, proxy=None,
-            runtime_proxy=None):
-                """Invoke the engine to retrieve a single URL's headers.
-
-                getUrlHeader will return a read-only file object that
-                contains no data.
-
-                'proxy' is the persistent proxy value for this url and is
-                stored as part of the transport stats accounting.
-
-                'runtime_proxy' is the actual proxy value that is used by pycurl
-                to retrieve this resource.
-                """
-
-                fobj = fileobj.StreamingFileObj(url, self, ccancel=ccancel)
-                progfunc = None
-
-                if ccancel:
-                        progfunc = fobj.get_progress_func()
-
-                t = TransportRequest(url, writefunc=fobj.get_write_func(),
-                    hdrfunc=fobj.get_header_func(), header=header,
-                    httpmethod="HEAD", sslcert=sslcert, sslkey=sslkey,
-                    repourl=repourl, progfunc=progfunc, uuid=fobj.uuid,
-                    failonerror=failonerror, proxy=proxy,
-                    runtime_proxy=runtime_proxy)
-
-                self.__req_q.appendleft(t)
-
-                return fobj
-
-        @property
-        def pending(self):
-                """Returns true if the engine still has outstanding
-                work to perform, false otherwise."""
-
-                return bool(self.__req_q) or self.__active_handles > 0
-
-        def run(self):
-                """Run the transport engine.  This polls the underlying
-                framework to complete any asynchronous I/O.  Synchronous
-                operations should have completed when startRequest
-                was invoked."""
-
-                if not self.pending:
-                        return
-
-                if self.__active_handles > 0:
-                        # timeout returned in milliseconds
-                        timeout = self.__mhandle.timeout()
-                        if timeout == -1:
-                                # Pick our own timeout.
-                                timeout = 1.0
-                        elif timeout > 0:
-                                # Timeout of 0 means skip call
-                                # to select.
-                                #
-                                # Convert from milliseconds to seconds.
-                                timeout = timeout / 1000.0
-
-                        if timeout:
-                                self.__mhandle.select(timeout)
-
-                # If object deletion has given the transport engine orphaned
-                # requests to purge, do this first, in case the cleanup yields
-                # free handles.
-                while self.__orphans:
-                        url, uuid = self.__orphans.pop()
-                        self.remove_request(url, uuid)
-
-                while self.__freehandles and self.__req_q:
-                        t = self.__req_q.pop()
-                        eh = self.__freehandles.pop(-1)
-                        self.__setup_handle(eh, t)
-                        self.__mhandle.add_handle(eh)
-
-                self.__call_perform()
-
-                self.__cleanup_requests()
-
-                if self.__active_handles and (not self.__freehandles or not
-                    self.__req_q):
-                        cur_clock = time.time()
-                        if cur_clock - self.__last_stall_check > 1:
-                                self.__last_stall_check = cur_clock
-                                self.__check_for_stalls()
-                        elif cur_clock - self.__last_stall_check < 0:
-                                self.__last_stall_check = cur_clock
-                                self.__check_for_stalls()
-
-        def orphaned_request(self, url, uuid):
-                """Add the URL to the list of orphaned requests.  Any URL in
-                list will be removed from the transport next time run() is
-                invoked.  This is used by the fileobj's __del__ method
-                to prevent unintended modifications to transport state
-                when StreamingFileObjs that aren't close()'d get cleaned
-                up."""
-
-                self.__orphans.add((url, uuid))
-
-        def remove_request(self, url, uuid):
-                """In order to remove a request, it may be necessary
-                to walk all of the items in the request queue, all of the
-                currently active handles, and the list of any transient
-                failures.  This is expensive, so only remove a request
-                if absolutely necessary."""
-
-                for h in self.__chandles:
-                        if h.url == url and h.uuid == uuid and \
-                            h not in self.__freehandles:
-                                try:
-                                        self.__mhandle.remove_handle(h)
-                                except pycurl.error:
-                                        # If cleanup is interrupted, it's
-                                        # possible that a handle was removed but
-                                        # not placed in freelist.  In that case,
-                                        # finish cleanup and appened to
-                                        # freehandles.
-                                        pass
-                                self.__teardown_handle(h)
-                                self.__freehandles.append(h)
-                                return
-
-                for i, t in enumerate(self.__req_q):
-                        if t.url == url and t.uuid == uuid:
-                                del self.__req_q[i]
-                                return
-
-                for ex in self.__failures:
-                        if ex.url == url and ex.uuid == uuid:
-                                self.__failures.remove(ex)
-                                return
-
-        def reset(self):
-                """Reset the state of the transport engine.  Do this
-                before performing another type of request."""
-
-                for c in self.__chandles:
-                        if c not in self.__freehandles:
-                                try:
-                                        self.__mhandle.remove_handle(c)
-                                except pycurl.error:
-                                        # If cleanup is interrupted, it's
-                                        # possible that a handle was removed but
-                                        # not placed in freelist.  In that case,
-                                        # finish cleanup and appened to
-                                        # freehandles.
-                                        pass
-                                self.__teardown_handle(c)
-
-                self.__active_handles = 0
-                self.__freehandles = self.__chandles[:]
-                self.__req_q = deque()
-                self.__failures = []
-                self.__success = []
-                self.__orphans = set()
-
-        def send_data(self, url, data=None, header=None, sslcert=None,
-            sslkey=None, repourl=None, ccancel=None,
-            data_fobj=None, data_fp=None, failonerror=True,
-            progclass=None, progtrack=None, proxy=None, runtime_proxy=None):
-                """Invoke the engine to retrieve a single URL.
-                This routine sends the data in data, and returns the
-                server's response.
-
-                Callers wishing to obtain multiple URLs at once should use
-                addUrl() and run().
-
-                sendData will return a read-only file object that allows access
-                to the server's response.."""
-
-                fobj = fileobj.StreamingFileObj(url, self, ccancel=ccancel)
-                progfunc = None
-
-                if ccancel and not progtrack and not progclass:
-                        progfunc = fobj.get_progress_func()
-
-                t = TransportRequest(url, writefunc=fobj.get_write_func(),
-                    hdrfunc=fobj.get_header_func(), header=header, data=data,
-                    httpmethod="POST", sslcert=sslcert, sslkey=sslkey,
-                    repourl=repourl, progfunc=progfunc, uuid=fobj.uuid,
-                    read_fobj=data_fobj, read_filepath=data_fp,
-                    failonerror=failonerror, progclass=progclass,
-                    progtrack=progtrack, proxy=proxy,
-                    runtime_proxy=runtime_proxy)
-
-                self.__req_q.appendleft(t)
-
-                return fobj
-
-        def set_file_bufsz(self, size):
-                """If the downloaded files are being written out by
-                the file() mechanism, and not written using a callback,
-                the I/O is buffered.  Set the buffer size using
-                this function.  If it's not set, a default of 131072 (128k)
-                is used."""
-
-                if size <= 0:
-                        self.__file_bufsz = 8192
-                        return
-
-                self.__file_bufsz = size
-
-        def set_header(self, hdrdict=None):
-                """Supply a dictionary of name/value pairs in hdrdict.
-                These will be included on all requests issued by the transport
-                engine.  To append a specific header to a certain request,
-                supply a dictionary to the header argument of addUrl."""
-
-                if not hdrdict:
-                        self.__common_header = {}
-                        return
-
-                self.__common_header = hdrdict
-
-        def set_user_agent(self, ua_str):
-                """Supply a string str and the transport engine will
-                use this string as its User-Agent header.  This is
-                a header that will be common to all transport requests."""
-
-                self.__user_agent = ua_str
-
-        def __setup_handle(self, hdl, treq):
-                """Setup the curl easy handle, hdl, with the parameters
-                specified in the TransportRequest treq.  If global
-                parameters are set, apply these to the handle as well."""
-
-                # Set nosignal, so timeouts don't crash client
-                hdl.setopt(pycurl.NOSIGNAL, 1)
-
-                if DebugValues.get("curlverbose", False):
-                        hdl.setopt(pycurl.VERBOSE, 1)
-
-                # Set connect timeout.  Its value is defined in global_settings.
-                hdl.setopt(pycurl.CONNECTTIMEOUT,
-                    global_settings.PKG_CLIENT_CONNECT_TIMEOUT)
-
-                # Set lowspeed limit and timeout.  Clients that are too
-                # slow or have hung after specified amount of time will
-                # abort the connection.
-                hdl.setopt(pycurl.LOW_SPEED_LIMIT,
-                    global_settings.pkg_client_lowspeed_limit)
-                hdl.setopt(pycurl.LOW_SPEED_TIME,
-                    global_settings.PKG_CLIENT_LOWSPEED_TIMEOUT)
-
-                # Follow redirects
-                hdl.setopt(pycurl.FOLLOWLOCATION, True)
-                # Set limit on maximum number of redirects
-                hdl.setopt(pycurl.MAXREDIRS,
-                    global_settings.PKG_CLIENT_MAX_REDIRECT)
-
-                # Use HTTP/1.1
-                hdl.setopt(pycurl.HTTP_VERSION, pycurl.CURL_HTTP_VERSION_1_1)
-
-                # Store the proxy in the handle so it can be used to retrieve
-                # transport statistics later.
-                hdl.proxy = None
-                hdl.runtime_proxy = None
-
-                if treq.system:
-                        # For requests that are proxied through the system
-                        # repository, we do not want to use $http_proxy
-                        # variables.  For direct access to the
-                        # system-repository, we set an empty proxy, which has
-                        # the same effect.
-                        if treq.proxy:
-                                hdl.proxy = treq.proxy
-                                hdl.setopt(pycurl.PROXY, treq.proxy)
-                        else:
-                                hdl.setopt(pycurl.PROXY, "")
-                elif treq.runtime_proxy:
-                        # Allow $http_proxy environment variables
-                        if treq.runtime_proxy != "-":
-                                # a runtime_proxy of '-' means we've found a
-                                # no-proxy environment variable.
-                                hdl.setopt(pycurl.PROXY, treq.runtime_proxy)
-                        hdl.proxy = treq.proxy
-                        hdl.runtime_proxy = treq.runtime_proxy
-                else:
-                        # Make sure that we don't use a proxy if the destination
-                        # is localhost.
-                        hdl.setopt(pycurl.NOPROXY, "localhost")
-
-                # Set user agent, if client has defined it
-                if self.__user_agent:
-                        hdl.setopt(pycurl.USERAGENT, self.__user_agent)
-
-                # Take header dictionaries and convert them into lists
-                # of header strings.
-                if self.__common_header or treq.header:
-                        headerlist = []
-
-                        # Headers common to all requests
-                        for k, v in six.iteritems(self.__common_header):
-                                headerstr = "{0}: {1}".format(k, v)
-                                headerlist.append(headerstr)
-
-                        # Headers specific to this request
-                        if treq.header:
-                                for k, v in six.iteritems(treq.header):
-                                        headerstr = "{0}: {1}".format(k, v)
-                                        headerlist.append(headerstr)
-
-                        hdl.setopt(pycurl.HTTPHEADER, headerlist)
-
-                # Set request url.  Also set attribute on handle.
-                hdl.setopt(pycurl.URL, treq.url.encode('ascii', 'ignore'))
-                hdl.url = treq.url
-                hdl.uuid = treq.uuid
-                hdl.starttime = time.time()
-                # The repourl is the url stem that identifies the
-                # repository. This is useful to have around for coalescing
-                # error output, and statistics reporting.
-                hdl.repourl = treq.repourl
-                if treq.filepath:
-                        try:
-                                hdl.fobj = open(treq.filepath, "wb+",
-                                    self.__file_bufsz)
-                        except EnvironmentError as e:
-                                if e.errno == errno.EACCES:
-                                        raise api_errors.PermissionsException(
-                                            e.filename)
-                                if e.errno == errno.EROFS:
-                                        raise api_errors.ReadOnlyFileSystemException(
-                                            e.filename)
-                                # Raise OperationError if it's not EACCES
-                                # or EROFS.
-                                raise tx.TransportOperationError(
-                                    "Unable to open file: {0}".format(e))
-
-                        hdl.setopt(pycurl.WRITEDATA, hdl.fobj)
-                        # Request filetime, if endpoint knows it.
-                        hdl.setopt(pycurl.OPT_FILETIME, True)
-                        hdl.filepath = treq.filepath
-                elif treq.writefunc:
-                        hdl.setopt(pycurl.WRITEFUNCTION, treq.writefunc)
-                        hdl.filepath = None
-                        hdl.fobj = None
-                else:
-                        raise tx.TransportOperationError("Transport invocation"
-                            " for URL {0} did not specify filepath or write"
-                            " function.".format(treq.url))
-
-                if treq.failonerror:
-                        hdl.setopt(pycurl.FAILONERROR, True)
-
-                if treq.progtrack and treq.progclass:
-                        hdl.setopt(pycurl.NOPROGRESS, 0)
-                        hdl.fileprog = treq.progclass(treq.progtrack)
-                        hdl.setopt(pycurl.PROGRESSFUNCTION,
-                            hdl.fileprog.progress_callback)
-                elif treq.progfunc:
-                        # For light-weight progress tracking / cancelation.
-                        hdl.setopt(pycurl.NOPROGRESS, 0)
-                        hdl.setopt(pycurl.PROGRESSFUNCTION, treq.progfunc)
-
-                proto = urlsplit(treq.url)[0]
-                if not proto in ("http", "https"):
-                        return
-
-                if treq.read_filepath:
-                        try:
-                                hdl.r_fobj = open(treq.read_filepath, "rb",
-                                    self.__file_bufsz)
-                        except EnvironmentError as e:
-                                if e.errno == errno.EACCES:
-                                        raise api_errors.PermissionsException(
-                                            e.filename)
-                                # Raise OperationError if it's not EACCES
-                                # or EROFS.
-                                raise tx.TransportOperationError(
-                                    "Unable to open file: {0}".format(e))
-
-                if treq.compressible:
-                        hdl.setopt(pycurl.ENCODING, "")
-
-                if treq.hdrfunc:
-                        hdl.setopt(pycurl.HEADERFUNCTION, treq.hdrfunc)
-
-                if treq.httpmethod == "GET":
-                        hdl.setopt(pycurl.HTTPGET, True)
-                elif treq.httpmethod == "HEAD":
-                        hdl.setopt(pycurl.NOBODY, True)
-                elif treq.httpmethod == "POST":
-                        hdl.setopt(pycurl.POST, True)
-                        if treq.data is not None:
-                                hdl.setopt(pycurl.POSTFIELDS, treq.data)
-                        elif hdl.r_fobj or treq.read_fobj:
-                                if not hdl.r_fobj:
-                                        hdl.r_fobj = treq.read_fobj
-                                hdl.setopt(pycurl.READDATA, hdl.r_fobj)
-                                hdl.setopt(pycurl.POSTFIELDSIZE,
-                                    os.fstat(hdl.r_fobj.fileno()).st_size)
-                        else:
-                                raise tx.TransportOperationError("Transport "
-                                    "operation for POST URL {0} did not "
-                                    "supply data or read_fobj.  At least one "
-                                    "is required.".format(treq.url))
-                elif treq.httpmethod == "PUT":
-                        hdl.setopt(pycurl.UPLOAD, True)
-                        if hdl.r_fobj or treq.read_fobj:
-                                if not hdl.r_fobj:
-                                        hdl.r_fobj = treq.read_fobj
-                                hdl.setopt(pycurl.READDATA, hdl.r_fobj)
-                                hdl.setopt(pycurl.INFILESIZE,
-                                    os.fstat(hdl.r_fobj.fileno()).st_size)
-                        else:
-                                raise tx.TransportOperationError("Transport "
-                                    "operation for PUT URL {0} did not "
-                                    "supply a read_fobj.  One is "
-                                    "required.".format(treq.url))
-                elif treq.httpmethod == "DELETE":
-                        hdl.setopt(pycurl.CUSTOMREQUEST, "DELETE")
-                else:
-                        raise tx.TransportOperationError("Invalid http method "
-                            "'{0}' specified.".format(treq.httpmethod))
-
-                # Set up SSL options
-                if treq.sslcert:
-                        hdl.setopt(pycurl.SSLCERT, treq.sslcert)
-                if treq.sslkey:
-                        hdl.setopt(pycurl.SSLKEY, treq.sslkey)
-
-                # Options that apply when SSL is enabled
-                if proto == "https":
-                        # Verify that peer's CN matches CN on certificate
-                        hdl.setopt(pycurl.SSL_VERIFYHOST, 2)
-                        hdl.setopt(pycurl.SSL_VERIFYPEER, 1)
-                        cadir = self.__xport.get_ca_dir()
-                        hdl.setopt(pycurl.CAPATH, cadir)
-                        if "ssl_ca_file" in DebugValues:
-                                cafile = DebugValues["ssl_ca_file"]
-                                hdl.setopt(pycurl.CAINFO, cafile)
-                                hdl.unsetopt(pycurl.CAPATH)
-                        else:
-                                hdl.unsetopt(pycurl.CAINFO)
-
-        def shutdown(self):
-                """Shutdown the transport engine, perform cleanup."""
-
-                for c in self.__chandles:
-                        c.close()
-
-                self.__chandles = None
-                self.__freehandles = None
-                self.__mhandle.close()
-                self.__mhandle = None
-                self.__req_q = None
-                self.__failures = None
-                self.__success = None
-                self.__orphans = None
-                self.__active_handles = 0
-
-        @staticmethod
-        def __teardown_handle(hdl):
-                """Cleanup any state that we've associated with this handle.
-                After a handle has been torn down, it should still be valid
-                for use, but should have no previous state.  To remove
-                handles from use completely, use __shutdown."""
-
-                hdl.reset()
-                if hdl.fobj:
-                        hdl.fobj.close()
-                        hdl.fobj = None
-                        if not hdl.success:
-                                if hdl.fileprog:
-                                        hdl.fileprog.abort()
-                                try:
-                                        os.remove(hdl.filepath)
-                                except EnvironmentError as e:
-                                        if e.errno != errno.ENOENT:
-                                                raise \
-                                                    tx.TransportOperationError(
-                                                    "Unable to remove file: "
-                                                    "{0}".format(e))
-                        else:
-                                if hdl.fileprog:
-                                        filesz = os.stat(hdl.filepath).st_size
-                                        hdl.fileprog.commit(filesz)
-                                if hdl.filepath and hdl.filetime > -1:
-                                        # Set atime/mtime, if we were able to
-                                        # figure it out.  File action will
-                                        # override this at install time, if the
-                                        # action has a timestamp property.
-                                        ft = hdl.filetime
-                                        os.utime(hdl.filepath, (ft, ft))
-
-                if hdl.r_fobj:
-                        hdl.r_fobj.close()
-                        hdl.r_fobj = None
-
-                hdl.url = None
-                hdl.repourl = None
-                hdl.success = False
-                hdl.filepath = None
-                hdl.fileprog = None
-                hdl.uuid = None
-                hdl.filetime = -1
-                hdl.starttime = -1
+            return rf
+
+        # otherwise, look for failures that match just the URLs
+        # in urllist.
+        rf = [
+            tf
+            for tf in self.__failures
+            if hasattr(tf, "url") and tf.url in urllist
+        ]
+
+        # remove failues in separate pass, or else for loop gets
+        # confused.
+        for f in rf:
+            self.__failures.remove(f)
+
+        if not good_reqs:
+            self.__success = []
+            return rf
+
+        rs = []
+
+        for ts in self.__success:
+            if ts in urllist:
+                rs.append(ts)
+
+        for s in rs:
+            self.__success.remove(s)
+
+        return rf, rs
+
+    def get_url(
+        self,
+        url,
+        header=None,
+        sslcert=None,
+        sslkey=None,
+        repourl=None,
+        compressible=False,
+        ccancel=None,
+        failonerror=True,
+        proxy=None,
+        runtime_proxy=None,
+        system=False,
+    ):
+        """Invoke the engine to retrieve a single URL.  Callers
+        wishing to obtain multiple URLs at once should use
+        addUrl() and run().
+
+        getUrl will return a read-only file object that allows access
+        to the URL's data.
+
+        'proxy' is the persistent proxy value for this url and is
+        stored as part of the transport stats accounting.
+
+        'runtime_proxy' is the actual proxy value that is used by pycurl
+        to retrieve this resource.
+
+        'system' whether the resource is being retrieved on behalf of
+        a system-publisher or directly from the system-repository.
+        """
+
+        fobj = fileobj.StreamingFileObj(url, self, ccancel=ccancel)
+        progfunc = None
+
+        if ccancel:
+            progfunc = fobj.get_progress_func()
+
+        t = TransportRequest(
+            url,
+            writefunc=fobj.get_write_func(),
+            hdrfunc=fobj.get_header_func(),
+            header=header,
+            sslcert=sslcert,
+            sslkey=sslkey,
+            repourl=repourl,
+            compressible=compressible,
+            progfunc=progfunc,
+            uuid=fobj.uuid,
+            failonerror=failonerror,
+            proxy=proxy,
+            runtime_proxy=runtime_proxy,
+            system=system,
+        )
+
+        self.__req_q.appendleft(t)
+
+        return fobj
+
+    def get_url_header(
+        self,
+        url,
+        header=None,
+        sslcert=None,
+        sslkey=None,
+        repourl=None,
+        ccancel=None,
+        failonerror=True,
+        proxy=None,
+        runtime_proxy=None,
+    ):
+        """Invoke the engine to retrieve a single URL's headers.
+
+        getUrlHeader will return a read-only file object that
+        contains no data.
+
+        'proxy' is the persistent proxy value for this url and is
+        stored as part of the transport stats accounting.
+
+        'runtime_proxy' is the actual proxy value that is used by pycurl
+        to retrieve this resource.
+        """
+
+        fobj = fileobj.StreamingFileObj(url, self, ccancel=ccancel)
+        progfunc = None
+
+        if ccancel:
+            progfunc = fobj.get_progress_func()
+
+        t = TransportRequest(
+            url,
+            writefunc=fobj.get_write_func(),
+            hdrfunc=fobj.get_header_func(),
+            header=header,
+            httpmethod="HEAD",
+            sslcert=sslcert,
+            sslkey=sslkey,
+            repourl=repourl,
+            progfunc=progfunc,
+            uuid=fobj.uuid,
+            failonerror=failonerror,
+            proxy=proxy,
+            runtime_proxy=runtime_proxy,
+        )
+
+        self.__req_q.appendleft(t)
+
+        return fobj
+
+    @property
+    def pending(self):
+        """Returns true if the engine still has outstanding
+        work to perform, false otherwise."""
+
+        return bool(self.__req_q) or self.__active_handles > 0
+
+    def run(self):
+        """Run the transport engine.  This polls the underlying
+        framework to complete any asynchronous I/O.  Synchronous
+        operations should have completed when startRequest
+        was invoked."""
+
+        if not self.pending:
+            return
+
+        if self.__active_handles > 0:
+            # timeout returned in milliseconds
+            timeout = self.__mhandle.timeout()
+            if timeout == -1:
+                # Pick our own timeout.
+                timeout = 1.0
+            elif timeout > 0:
+                # Timeout of 0 means skip call
+                # to select.
+                #
+                # Convert from milliseconds to seconds.
+                timeout = timeout / 1000.0
+
+            if timeout:
+                self.__mhandle.select(timeout)
+
+        # If object deletion has given the transport engine orphaned
+        # requests to purge, do this first, in case the cleanup yields
+        # free handles.
+        while self.__orphans:
+            url, uuid = self.__orphans.pop()
+            self.remove_request(url, uuid)
+
+        while self.__freehandles and self.__req_q:
+            t = self.__req_q.pop()
+            eh = self.__freehandles.pop(-1)
+            self.__setup_handle(eh, t)
+            self.__mhandle.add_handle(eh)
+
+        self.__call_perform()
+
+        self.__cleanup_requests()
+
+        if self.__active_handles and (
+            not self.__freehandles or not self.__req_q
+        ):
+            cur_clock = time.time()
+            if cur_clock - self.__last_stall_check > 1:
+                self.__last_stall_check = cur_clock
+                self.__check_for_stalls()
+            elif cur_clock - self.__last_stall_check < 0:
+                self.__last_stall_check = cur_clock
+                self.__check_for_stalls()
+
+    def orphaned_request(self, url, uuid):
+        """Add the URL to the list of orphaned requests.  Any URL in
+        list will be removed from the transport next time run() is
+        invoked.  This is used by the fileobj's __del__ method
+        to prevent unintended modifications to transport state
+        when StreamingFileObjs that aren't close()'d get cleaned
+        up."""
+
+        self.__orphans.add((url, uuid))
+
+    def remove_request(self, url, uuid):
+        """In order to remove a request, it may be necessary
+        to walk all of the items in the request queue, all of the
+        currently active handles, and the list of any transient
+        failures.  This is expensive, so only remove a request
+        if absolutely necessary."""
+
+        for h in self.__chandles:
+            if h.url == url and h.uuid == uuid and h not in self.__freehandles:
+                try:
+                    self.__mhandle.remove_handle(h)
+                except pycurl.error:
+                    # If cleanup is interrupted, it's
+                    # possible that a handle was removed but
+                    # not placed in freelist.  In that case,
+                    # finish cleanup and appened to
+                    # freehandles.
+                    pass
+                self.__teardown_handle(h)
+                self.__freehandles.append(h)
+                return
+
+        for i, t in enumerate(self.__req_q):
+            if t.url == url and t.uuid == uuid:
+                del self.__req_q[i]
+                return
+
+        for ex in self.__failures:
+            if ex.url == url and ex.uuid == uuid:
+                self.__failures.remove(ex)
+                return
+
+    def reset(self):
+        """Reset the state of the transport engine.  Do this
+        before performing another type of request."""
+
+        for c in self.__chandles:
+            if c not in self.__freehandles:
+                try:
+                    self.__mhandle.remove_handle(c)
+                except pycurl.error:
+                    # If cleanup is interrupted, it's
+                    # possible that a handle was removed but
+                    # not placed in freelist.  In that case,
+                    # finish cleanup and appened to
+                    # freehandles.
+                    pass
+                self.__teardown_handle(c)
+
+        self.__active_handles = 0
+        self.__freehandles = self.__chandles[:]
+        self.__req_q = deque()
+        self.__failures = []
+        self.__success = []
+        self.__orphans = set()
+
+    def send_data(
+        self,
+        url,
+        data=None,
+        header=None,
+        sslcert=None,
+        sslkey=None,
+        repourl=None,
+        ccancel=None,
+        data_fobj=None,
+        data_fp=None,
+        failonerror=True,
+        progclass=None,
+        progtrack=None,
+        proxy=None,
+        runtime_proxy=None,
+    ):
+        """Invoke the engine to retrieve a single URL.
+        This routine sends the data in data, and returns the
+        server's response.
+
+        Callers wishing to obtain multiple URLs at once should use
+        addUrl() and run().
+
+        sendData will return a read-only file object that allows access
+        to the server's response.."""
+
+        fobj = fileobj.StreamingFileObj(url, self, ccancel=ccancel)
+        progfunc = None
+
+        if ccancel and not progtrack and not progclass:
+            progfunc = fobj.get_progress_func()
+
+        t = TransportRequest(
+            url,
+            writefunc=fobj.get_write_func(),
+            hdrfunc=fobj.get_header_func(),
+            header=header,
+            data=data,
+            httpmethod="POST",
+            sslcert=sslcert,
+            sslkey=sslkey,
+            repourl=repourl,
+            progfunc=progfunc,
+            uuid=fobj.uuid,
+            read_fobj=data_fobj,
+            read_filepath=data_fp,
+            failonerror=failonerror,
+            progclass=progclass,
+            progtrack=progtrack,
+            proxy=proxy,
+            runtime_proxy=runtime_proxy,
+        )
+
+        self.__req_q.appendleft(t)
+
+        return fobj
+
+    def set_file_bufsz(self, size):
+        """If the downloaded files are being written out by
+        the file() mechanism, and not written using a callback,
+        the I/O is buffered.  Set the buffer size using
+        this function.  If it's not set, a default of 131072 (128k)
+        is used."""
+
+        if size <= 0:
+            self.__file_bufsz = 8192
+            return
+
+        self.__file_bufsz = size
+
+    def set_header(self, hdrdict=None):
+        """Supply a dictionary of name/value pairs in hdrdict.
+        These will be included on all requests issued by the transport
+        engine.  To append a specific header to a certain request,
+        supply a dictionary to the header argument of addUrl."""
+
+        if not hdrdict:
+            self.__common_header = {}
+            return
+
+        self.__common_header = hdrdict
+
+    def set_user_agent(self, ua_str):
+        """Supply a string str and the transport engine will
+        use this string as its User-Agent header.  This is
+        a header that will be common to all transport requests."""
+
+        self.__user_agent = ua_str
+
+    def __setup_handle(self, hdl, treq):
+        """Setup the curl easy handle, hdl, with the parameters
+        specified in the TransportRequest treq.  If global
+        parameters are set, apply these to the handle as well."""
+
+        # Set nosignal, so timeouts don't crash client
+        hdl.setopt(pycurl.NOSIGNAL, 1)
+
+        if DebugValues.get("curlverbose", False):
+            hdl.setopt(pycurl.VERBOSE, 1)
+
+        # Set connect timeout.  Its value is defined in global_settings.
+        hdl.setopt(
+            pycurl.CONNECTTIMEOUT, global_settings.PKG_CLIENT_CONNECT_TIMEOUT
+        )
+
+        # Set lowspeed limit and timeout.  Clients that are too
+        # slow or have hung after specified amount of time will
+        # abort the connection.
+        hdl.setopt(
+            pycurl.LOW_SPEED_LIMIT, global_settings.pkg_client_lowspeed_limit
+        )
+        hdl.setopt(
+            pycurl.LOW_SPEED_TIME, global_settings.PKG_CLIENT_LOWSPEED_TIMEOUT
+        )
+
+        # Follow redirects
+        hdl.setopt(pycurl.FOLLOWLOCATION, True)
+        # Set limit on maximum number of redirects
+        hdl.setopt(pycurl.MAXREDIRS, global_settings.PKG_CLIENT_MAX_REDIRECT)
+
+        # Use HTTP/1.1
+        hdl.setopt(pycurl.HTTP_VERSION, pycurl.CURL_HTTP_VERSION_1_1)
+
+        # Store the proxy in the handle so it can be used to retrieve
+        # transport statistics later.
+        hdl.proxy = None
+        hdl.runtime_proxy = None
+
+        if treq.system:
+            # For requests that are proxied through the system
+            # repository, we do not want to use $http_proxy
+            # variables.  For direct access to the
+            # system-repository, we set an empty proxy, which has
+            # the same effect.
+            if treq.proxy:
+                hdl.proxy = treq.proxy
+                hdl.setopt(pycurl.PROXY, treq.proxy)
+            else:
+                hdl.setopt(pycurl.PROXY, "")
+        elif treq.runtime_proxy:
+            # Allow $http_proxy environment variables
+            if treq.runtime_proxy != "-":
+                # a runtime_proxy of '-' means we've found a
+                # no-proxy environment variable.
+                hdl.setopt(pycurl.PROXY, treq.runtime_proxy)
+            hdl.proxy = treq.proxy
+            hdl.runtime_proxy = treq.runtime_proxy
+        else:
+            # Make sure that we don't use a proxy if the destination
+            # is localhost.
+            hdl.setopt(pycurl.NOPROXY, "localhost")
+
+        # Set user agent, if client has defined it
+        if self.__user_agent:
+            hdl.setopt(pycurl.USERAGENT, self.__user_agent)
+
+        # Take header dictionaries and convert them into lists
+        # of header strings.
+        if self.__common_header or treq.header:
+            headerlist = []
+
+            # Headers common to all requests
+            for k, v in six.iteritems(self.__common_header):
+                headerstr = "{0}: {1}".format(k, v)
+                headerlist.append(headerstr)
+
+            # Headers specific to this request
+            if treq.header:
+                for k, v in six.iteritems(treq.header):
+                    headerstr = "{0}: {1}".format(k, v)
+                    headerlist.append(headerstr)
+
+            hdl.setopt(pycurl.HTTPHEADER, headerlist)
+
+        # Set request url.  Also set attribute on handle.
+        hdl.setopt(pycurl.URL, treq.url.encode("ascii", "ignore"))
+        hdl.url = treq.url
+        hdl.uuid = treq.uuid
+        hdl.starttime = time.time()
+        # The repourl is the url stem that identifies the
+        # repository. This is useful to have around for coalescing
+        # error output, and statistics reporting.
+        hdl.repourl = treq.repourl
+        if treq.filepath:
+            try:
+                hdl.fobj = open(treq.filepath, "wb+", self.__file_bufsz)
+            except EnvironmentError as e:
+                if e.errno == errno.EACCES:
+                    raise api_errors.PermissionsException(e.filename)
+                if e.errno == errno.EROFS:
+                    raise api_errors.ReadOnlyFileSystemException(e.filename)
+                # Raise OperationError if it's not EACCES
+                # or EROFS.
+                raise tx.TransportOperationError(
+                    "Unable to open file: {0}".format(e)
+                )
+
+            hdl.setopt(pycurl.WRITEDATA, hdl.fobj)
+            # Request filetime, if endpoint knows it.
+            hdl.setopt(pycurl.OPT_FILETIME, True)
+            hdl.filepath = treq.filepath
+        elif treq.writefunc:
+            hdl.setopt(pycurl.WRITEFUNCTION, treq.writefunc)
+            hdl.filepath = None
+            hdl.fobj = None
+        else:
+            raise tx.TransportOperationError(
+                "Transport invocation"
+                " for URL {0} did not specify filepath or write"
+                " function.".format(treq.url)
+            )
+
+        if treq.failonerror:
+            hdl.setopt(pycurl.FAILONERROR, True)
+
+        if treq.progtrack and treq.progclass:
+            hdl.setopt(pycurl.NOPROGRESS, 0)
+            hdl.fileprog = treq.progclass(treq.progtrack)
+            hdl.setopt(pycurl.PROGRESSFUNCTION, hdl.fileprog.progress_callback)
+        elif treq.progfunc:
+            # For light-weight progress tracking / cancelation.
+            hdl.setopt(pycurl.NOPROGRESS, 0)
+            hdl.setopt(pycurl.PROGRESSFUNCTION, treq.progfunc)
+
+        proto = urlsplit(treq.url)[0]
+        if not proto in ("http", "https"):
+            return
+
+        if treq.read_filepath:
+            try:
+                hdl.r_fobj = open(treq.read_filepath, "rb", self.__file_bufsz)
+            except EnvironmentError as e:
+                if e.errno == errno.EACCES:
+                    raise api_errors.PermissionsException(e.filename)
+                # Raise OperationError if it's not EACCES
+                # or EROFS.
+                raise tx.TransportOperationError(
+                    "Unable to open file: {0}".format(e)
+                )
+
+        if treq.compressible:
+            hdl.setopt(pycurl.ENCODING, "")
+
+        if treq.hdrfunc:
+            hdl.setopt(pycurl.HEADERFUNCTION, treq.hdrfunc)
+
+        if treq.httpmethod == "GET":
+            hdl.setopt(pycurl.HTTPGET, True)
+        elif treq.httpmethod == "HEAD":
+            hdl.setopt(pycurl.NOBODY, True)
+        elif treq.httpmethod == "POST":
+            hdl.setopt(pycurl.POST, True)
+            if treq.data is not None:
+                hdl.setopt(pycurl.POSTFIELDS, treq.data)
+            elif hdl.r_fobj or treq.read_fobj:
+                if not hdl.r_fobj:
+                    hdl.r_fobj = treq.read_fobj
+                hdl.setopt(pycurl.READDATA, hdl.r_fobj)
+                hdl.setopt(
+                    pycurl.POSTFIELDSIZE, os.fstat(hdl.r_fobj.fileno()).st_size
+                )
+            else:
+                raise tx.TransportOperationError(
+                    "Transport "
+                    "operation for POST URL {0} did not "
+                    "supply data or read_fobj.  At least one "
+                    "is required.".format(treq.url)
+                )
+        elif treq.httpmethod == "PUT":
+            hdl.setopt(pycurl.UPLOAD, True)
+            if hdl.r_fobj or treq.read_fobj:
+                if not hdl.r_fobj:
+                    hdl.r_fobj = treq.read_fobj
+                hdl.setopt(pycurl.READDATA, hdl.r_fobj)
+                hdl.setopt(
+                    pycurl.INFILESIZE, os.fstat(hdl.r_fobj.fileno()).st_size
+                )
+            else:
+                raise tx.TransportOperationError(
+                    "Transport "
+                    "operation for PUT URL {0} did not "
+                    "supply a read_fobj.  One is "
+                    "required.".format(treq.url)
+                )
+        elif treq.httpmethod == "DELETE":
+            hdl.setopt(pycurl.CUSTOMREQUEST, "DELETE")
+        else:
+            raise tx.TransportOperationError(
+                "Invalid http method "
+                "'{0}' specified.".format(treq.httpmethod)
+            )
+
+        # Set up SSL options
+        if treq.sslcert:
+            hdl.setopt(pycurl.SSLCERT, treq.sslcert)
+        if treq.sslkey:
+            hdl.setopt(pycurl.SSLKEY, treq.sslkey)
+
+        # Options that apply when SSL is enabled
+        if proto == "https":
+            # Verify that peer's CN matches CN on certificate
+            hdl.setopt(pycurl.SSL_VERIFYHOST, 2)
+            hdl.setopt(pycurl.SSL_VERIFYPEER, 1)
+            cadir = self.__xport.get_ca_dir()
+            hdl.setopt(pycurl.CAPATH, cadir)
+            if "ssl_ca_file" in DebugValues:
+                cafile = DebugValues["ssl_ca_file"]
+                hdl.setopt(pycurl.CAINFO, cafile)
+                hdl.unsetopt(pycurl.CAPATH)
+            else:
+                hdl.unsetopt(pycurl.CAINFO)
+
+    def shutdown(self):
+        """Shutdown the transport engine, perform cleanup."""
+
+        for c in self.__chandles:
+            c.close()
+
+        self.__chandles = None
+        self.__freehandles = None
+        self.__mhandle.close()
+        self.__mhandle = None
+        self.__req_q = None
+        self.__failures = None
+        self.__success = None
+        self.__orphans = None
+        self.__active_handles = 0
+
+    @staticmethod
+    def __teardown_handle(hdl):
+        """Cleanup any state that we've associated with this handle.
+        After a handle has been torn down, it should still be valid
+        for use, but should have no previous state.  To remove
+        handles from use completely, use __shutdown."""
+
+        hdl.reset()
+        if hdl.fobj:
+            hdl.fobj.close()
+            hdl.fobj = None
+            if not hdl.success:
+                if hdl.fileprog:
+                    hdl.fileprog.abort()
+                try:
+                    os.remove(hdl.filepath)
+                except EnvironmentError as e:
+                    if e.errno != errno.ENOENT:
+                        raise tx.TransportOperationError(
+                            "Unable to remove file: " "{0}".format(e)
+                        )
+            else:
+                if hdl.fileprog:
+                    filesz = os.stat(hdl.filepath).st_size
+                    hdl.fileprog.commit(filesz)
+                if hdl.filepath and hdl.filetime > -1:
+                    # Set atime/mtime, if we were able to
+                    # figure it out.  File action will
+                    # override this at install time, if the
+                    # action has a timestamp property.
+                    ft = hdl.filetime
+                    os.utime(hdl.filepath, (ft, ft))
+
+        if hdl.r_fobj:
+            hdl.r_fobj.close()
+            hdl.r_fobj = None
+
+        hdl.url = None
+        hdl.repourl = None
+        hdl.success = False
+        hdl.filepath = None
+        hdl.fileprog = None
+        hdl.uuid = None
+        hdl.filetime = -1
+        hdl.starttime = -1
 
 
 class TransportRequest(object):
-        """A class that contains per-request information for the underlying
-        transport engines.  This is used to set per-request options that
-        are used either by the framework, the transport, or both."""
+    """A class that contains per-request information for the underlying
+    transport engines.  This is used to set per-request options that
+    are used either by the framework, the transport, or both."""
 
-        def __init__(self, url, filepath=None, writefunc=None,
-            hdrfunc=None, header=None, data=None, httpmethod="GET",
-            progclass=None, progtrack=None, sslcert=None, sslkey=None,
-            repourl=None, compressible=False, progfunc=None, uuid=None,
-            read_fobj=None, read_filepath=None, failonerror=False, proxy=None,
-            runtime_proxy=None, system=False):
-                """Create a TransportRequest with the following parameters:
+    def __init__(
+        self,
+        url,
+        filepath=None,
+        writefunc=None,
+        hdrfunc=None,
+        header=None,
+        data=None,
+        httpmethod="GET",
+        progclass=None,
+        progtrack=None,
+        sslcert=None,
+        sslkey=None,
+        repourl=None,
+        compressible=False,
+        progfunc=None,
+        uuid=None,
+        read_fobj=None,
+        read_filepath=None,
+        failonerror=False,
+        proxy=None,
+        runtime_proxy=None,
+        system=False,
+    ):
+        """Create a TransportRequest with the following parameters:
 
-                url - The url that the transport engine should retrieve
+        url - The url that the transport engine should retrieve
 
-                filepath - If defined, the transport engine will download the
-                file to this path.  If not defined, the caller should
-                supply a write function.
+        filepath - If defined, the transport engine will download the
+        file to this path.  If not defined, the caller should
+        supply a write function.
 
-                writefunc - A function, supplied instead of filepath, that
-                reads the bytes supplied by the transport engine and writes
-                them somewhere for processing.  This is a callback.
+        writefunc - A function, supplied instead of filepath, that
+        reads the bytes supplied by the transport engine and writes
+        them somewhere for processing.  This is a callback.
 
-                hdrfunc - A callback for examining the contents of header
-                data in a response to a transport request.
+        hdrfunc - A callback for examining the contents of header
+        data in a response to a transport request.
 
-                header - A dictionary of key/value pairs to be included
-                in the request's header.
+        header - A dictionary of key/value pairs to be included
+        in the request's header.
 
-                compressible - A boolean value that indicates whether
-                the content that is requested is a candidate for transport
-                level compression.
+        compressible - A boolean value that indicates whether
+        the content that is requested is a candidate for transport
+        level compression.
 
-                data - If the request is sending a data payload, include
-                the data in this argument.
+        data - If the request is sending a data payload, include
+        the data in this argument.
 
-                failonerror - If the request returns a HTTP code >= 400,
-                terminate the request early, instead of running it to
-                completion.
+        failonerror - If the request returns a HTTP code >= 400,
+        terminate the request early, instead of running it to
+        completion.
 
-                httpmethod - If the request is a HTTP/HTTPS request,
-                this can override the default HTTP method of GET.
+        httpmethod - If the request is a HTTP/HTTPS request,
+        this can override the default HTTP method of GET.
 
-                progtrack - If the transport wants the engine to update
-                the progress of the download, supply a ProgressTracker
-                object in this argument.
+        progtrack - If the transport wants the engine to update
+        the progress of the download, supply a ProgressTracker
+        object in this argument.
 
-                progclass - If the transport was supplied with a ProgressTracker
-                this must point to a class that knows how to wrap the progress
-                tracking object in way that allows the transport to invoke
-                the proper callbacks.  The transport instantiates an object
-                of this class before beginning the request.
+        progclass - If the transport was supplied with a ProgressTracker
+        this must point to a class that knows how to wrap the progress
+        tracking object in way that allows the transport to invoke
+        the proper callbacks.  The transport instantiates an object
+        of this class before beginning the request.
 
-                progfunc - A function to be used as a progress callback.
-                The preferred method is is use progtrack/progclass, but
-                light-weight implementations may use progfunc instead,
-                especially if they don't need per-file updates.
+        progfunc - A function to be used as a progress callback.
+        The preferred method is is use progtrack/progclass, but
+        light-weight implementations may use progfunc instead,
+        especially if they don't need per-file updates.
 
-                read_filepath - If the request is sending a file, include
-                the path here, as this is the most efficient way to send
-                the data.
+        read_filepath - If the request is sending a file, include
+        the path here, as this is the most efficient way to send
+        the data.
 
-                read_fobj - If the request is sending a large payload,
-                this points to a fileobject from which the data may be
-                read.
+        read_fobj - If the request is sending a large payload,
+        this points to a fileobject from which the data may be
+        read.
 
-                repouri - This is the URL stem that identifies the repo.
-                It's a subset of url.  It's also used by the stats system.
+        repouri - This is the URL stem that identifies the repo.
+        It's a subset of url.  It's also used by the stats system.
 
-                sslcert - If the request is using SSL, HTTPS for example,
-                provide a path to the SSL certificate here.
+        sslcert - If the request is using SSL, HTTPS for example,
+        provide a path to the SSL certificate here.
 
-                sslkey - If the request is using SSL, like HTTPS for example,
-                provide a path to the SSL key here.
+        sslkey - If the request is using SSL, like HTTPS for example,
+        provide a path to the SSL key here.
 
-                uuid - In order to remove the request from the list of
-                many possible requests, supply a unique identifier in uuid.
+        uuid - In order to remove the request from the list of
+        many possible requests, supply a unique identifier in uuid.
 
-                proxy - If the request should be performed using a proxy,
-                that proxy should be specified here.
+        proxy - If the request should be performed using a proxy,
+        that proxy should be specified here.
 
-                runtime_proxy - In order to avoid repeated environment lookups
-                we pass the proxy that should be used at runtime, which may
-                differ from the 'proxy' value.
+        runtime_proxy - In order to avoid repeated environment lookups
+        we pass the proxy that should be used at runtime, which may
+        differ from the 'proxy' value.
 
-                system - whether this request is on behalf of a system
-                publisher.  Usually this isn't necessary, as the
-                TransportRepoURI will have been configured with correct proxy
-                and runtime_proxy properties.  However, for direct access to
-                resources served by the system-repository, we use this to
-                prevent $http_proxy environment variables from being used.
+        system - whether this request is on behalf of a system
+        publisher.  Usually this isn't necessary, as the
+        TransportRepoURI will have been configured with correct proxy
+        and runtime_proxy properties.  However, for direct access to
+        resources served by the system-repository, we use this to
+        prevent $http_proxy environment variables from being used.
 
-                A TransportRequest must contain enough information to uniquely
-                identify any pkg.client.publisher.TransportRepoURI - in
-                particular, it must contain all fields used by
-                TransportRepoURI.key() which is currently the (url, proxy)
-                tuple, and is used as the key when recording/retrieving
-                transport statistics."""
+        A TransportRequest must contain enough information to uniquely
+        identify any pkg.client.publisher.TransportRepoURI - in
+        particular, it must contain all fields used by
+        TransportRepoURI.key() which is currently the (url, proxy)
+        tuple, and is used as the key when recording/retrieving
+        transport statistics."""
 
-                self.url = url
-                self.filepath = filepath
-                self.writefunc = writefunc
-                self.hdrfunc = hdrfunc
-                self.header = header
-                self.data = data
-                self.httpmethod = httpmethod
-                self.progclass = progclass
-                self.progtrack = progtrack
-                self.progfunc = progfunc
-                self.repourl = repourl
-                self.sslcert = sslcert
-                self.sslkey = sslkey
-                self.compressible = compressible
-                self.uuid = uuid
-                self.read_fobj = read_fobj
-                self.read_filepath = read_filepath
-                self.failonerror = failonerror
-                self.proxy = proxy
-                self.runtime_proxy = runtime_proxy
-                self.system = system
+        self.url = url
+        self.filepath = filepath
+        self.writefunc = writefunc
+        self.hdrfunc = hdrfunc
+        self.header = header
+        self.data = data
+        self.httpmethod = httpmethod
+        self.progclass = progclass
+        self.progtrack = progtrack
+        self.progfunc = progfunc
+        self.repourl = repourl
+        self.sslcert = sslcert
+        self.sslkey = sslkey
+        self.compressible = compressible
+        self.uuid = uuid
+        self.read_fobj = read_fobj
+        self.read_filepath = read_filepath
+        self.failonerror = failonerror
+        self.proxy = proxy
+        self.runtime_proxy = runtime_proxy
+        self.system = system
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/transport/exception.py
+++ b/src/modules/client/transport/exception.py
@@ -30,19 +30,28 @@ import pycurl
 from functools import total_ordering
 from six.moves import http_client
 
-retryable_http_errors = set((http_client.REQUEST_TIMEOUT, http_client.BAD_GATEWAY,
-        http_client.GATEWAY_TIMEOUT, http_client.NOT_FOUND))
-retryable_file_errors = set((pycurl.E_FILE_COULDNT_READ_FILE, errno.EAGAIN,
-    errno.ENOENT))
+retryable_http_errors = set(
+    (
+        http_client.REQUEST_TIMEOUT,
+        http_client.BAD_GATEWAY,
+        http_client.GATEWAY_TIMEOUT,
+        http_client.NOT_FOUND,
+    )
+)
+retryable_file_errors = set(
+    (pycurl.E_FILE_COULDNT_READ_FILE, errno.EAGAIN, errno.ENOENT)
+)
 
 import pkg.client.api_errors as api_errors
 
 # Errors that stats.py may include in a decay-able error rate
 decayable_http_errors = set((http_client.NOT_FOUND,))
-decayable_file_errors = set((pycurl.E_FILE_COULDNT_READ_FILE, errno.EAGAIN,
-    errno.ENOENT))
-decayable_pycurl_errors = set((pycurl.E_OPERATION_TIMEOUTED,
-        pycurl.E_COULDNT_CONNECT))
+decayable_file_errors = set(
+    (pycurl.E_FILE_COULDNT_READ_FILE, errno.EAGAIN, errno.ENOENT)
+)
+decayable_pycurl_errors = set(
+    (pycurl.E_OPERATION_TIMEOUTED, pycurl.E_COULDNT_CONNECT)
+)
 
 # Different protocols may have different retryable errors.  Map proto
 # to set of retryable errors.
@@ -59,439 +68,459 @@ decayable_proto_errors = {
     "https": decayable_http_errors,
 }
 
-proto_code_map = {
-    "http": http_client.responses,
-    "https": http_client.responses
-}
+proto_code_map = {"http": http_client.responses, "https": http_client.responses}
 
-retryable_pycurl_errors = set((pycurl.E_COULDNT_CONNECT, pycurl.E_PARTIAL_FILE,
-    pycurl.E_OPERATION_TIMEOUTED, pycurl.E_GOT_NOTHING, pycurl.E_SEND_ERROR,
-    pycurl.E_RECV_ERROR, pycurl.E_COULDNT_RESOLVE_HOST,
-    pycurl.E_TOO_MANY_REDIRECTS, pycurl.E_BAD_CONTENT_ENCODING))
+retryable_pycurl_errors = set(
+    (
+        pycurl.E_COULDNT_CONNECT,
+        pycurl.E_PARTIAL_FILE,
+        pycurl.E_OPERATION_TIMEOUTED,
+        pycurl.E_GOT_NOTHING,
+        pycurl.E_SEND_ERROR,
+        pycurl.E_RECV_ERROR,
+        pycurl.E_COULDNT_RESOLVE_HOST,
+        pycurl.E_TOO_MANY_REDIRECTS,
+        pycurl.E_BAD_CONTENT_ENCODING,
+    )
+)
+
 
 class TransportException(api_errors.TransportError):
-        """Base class for various exceptions thrown by code in transport
-        package."""
+    """Base class for various exceptions thrown by code in transport
+    package."""
 
-        def __init__(self):
-                self.count = 1
-                self.decayable = False
-                self.retryable = False
+    def __init__(self):
+        self.count = 1
+        self.decayable = False
+        self.retryable = False
 
 
 class TransportOperationError(TransportException):
-        """Used when transport operations fail for miscellaneous reasons."""
+    """Used when transport operations fail for miscellaneous reasons."""
 
-        def __init__(self, data):
-                TransportException.__init__(self)
-                self.data = data
+    def __init__(self, data):
+        TransportException.__init__(self)
+        self.data = data
 
-        def __str__(self):
-                return str(self.data)
+    def __str__(self):
+        return str(self.data)
 
 
 class TransportFailures(TransportException):
-        """This exception encapsulates multiple transport exceptions."""
+    """This exception encapsulates multiple transport exceptions."""
 
-        #
-        # This class is a subclass of TransportException so that calling
-        # code can reasonably 'except TransportException' and get either
-        # a single-valued or in this case a multi-valued instance.
-        #
-        def __init__(self, pfmri=None):
-                TransportException.__init__(self)
-                self.exceptions = []
-                self.pfmri = pfmri
+    #
+    # This class is a subclass of TransportException so that calling
+    # code can reasonably 'except TransportException' and get either
+    # a single-valued or in this case a multi-valued instance.
+    #
+    def __init__(self, pfmri=None):
+        TransportException.__init__(self)
+        self.exceptions = []
+        self.pfmri = pfmri
 
-        def append(self, exc):
-                found = False
+    def append(self, exc):
+        found = False
 
-                assert isinstance(exc, TransportException)
-                for x in self.exceptions:
-                        if x == exc:
-                                x.count += 1
-                                found = True
-                                break
+        assert isinstance(exc, TransportException)
+        for x in self.exceptions:
+            if x == exc:
+                x.count += 1
+                found = True
+                break
 
-                if not found:
-                        self.exceptions.append(exc)
+        if not found:
+            self.exceptions.append(exc)
 
-        def extend(self, exc_list):
-                for exc in exc_list:
-                        self.append(exc)
+    def extend(self, exc_list):
+        for exc in exc_list:
+            self.append(exc)
 
-        def __str__(self):
-                if len(self.exceptions) == 0:
-                        return "[no errors accumulated]"
+    def __str__(self):
+        if len(self.exceptions) == 0:
+            return "[no errors accumulated]"
 
-                s = ""
-                if self.pfmri:
-                        s += "{0}\n".format(self.pfmri)
+        s = ""
+        if self.pfmri:
+            s += "{0}\n".format(self.pfmri)
 
-                for i, x in enumerate(self.exceptions):
-                        s += "  "
-                        if len(self.exceptions) > 1:
-                                s += "{0:d}: ".format(i + 1)
-                        s += str(x)
-                        if x.count > 1:
-                                s += _(" (happened {0:d} times)").format(
-                                    x.count)
-                        s += "\n"
-                s += self._str_autofix()
-                return s
+        for i, x in enumerate(self.exceptions):
+            s += "  "
+            if len(self.exceptions) > 1:
+                s += "{0:d}: ".format(i + 1)
+            s += str(x)
+            if x.count > 1:
+                s += _(" (happened {0:d} times)").format(x.count)
+            s += "\n"
+        s += self._str_autofix()
+        return s
 
-        def __len__(self):
-                return len(self.exceptions)
+    def __len__(self):
+        return len(self.exceptions)
 
 
 @total_ordering
 class TransportProtoError(TransportException):
-        """Raised when errors occur in the transport protocol."""
+    """Raised when errors occur in the transport protocol."""
 
-        def __init__(self, proto, code=None, url=None, reason=None,
-            repourl=None, request=None, uuid=None, details=None, proxy=None):
-                TransportException.__init__(self)
-                self.proto = proto
-                self.code = code
-                self.url = url
-                self.urlstem = repourl
-                self.reason = reason
-                self.request = request
-                self.decayable = self.code in decayable_proto_errors[self.proto]
-                self.retryable = self.code in retryable_proto_errors[self.proto]
-                self.uuid = uuid
-                self.details = details
-                self.proxy = proxy
-                self.codename = ""
-                codenames = [
-                        name
-                        for name in vars(pycurl)
-                        if len(name) > 1 and name[:2] == "E_" and \
-                            getattr(pycurl, name) == code
-                ]
-                if len(codenames) >= 1:
-                        self.codename = codenames[0]
+    def __init__(
+        self,
+        proto,
+        code=None,
+        url=None,
+        reason=None,
+        repourl=None,
+        request=None,
+        uuid=None,
+        details=None,
+        proxy=None,
+    ):
+        TransportException.__init__(self)
+        self.proto = proto
+        self.code = code
+        self.url = url
+        self.urlstem = repourl
+        self.reason = reason
+        self.request = request
+        self.decayable = self.code in decayable_proto_errors[self.proto]
+        self.retryable = self.code in retryable_proto_errors[self.proto]
+        self.uuid = uuid
+        self.details = details
+        self.proxy = proxy
+        self.codename = ""
+        codenames = [
+            name
+            for name in vars(pycurl)
+            if len(name) > 1
+            and name[:2] == "E_"
+            and getattr(pycurl, name) == code
+        ]
+        if len(codenames) >= 1:
+            self.codename = codenames[0]
 
-        def __str__(self):
-                s = "{0} protocol error".format(self.proto)
-                if self.code and self.codename:
-                        s += ": code: {0} ({1:d})".format(
-                            self.codename, self.code)
-                elif self.code:
-                        s += ": Unknown error code: {0:d}".format(self.code)
-                if self.reason:
-                        s += " reason: {0}".format(self.reason)
-                if self.url:
-                        s += "\nURL: '{0}'".format(self.url)
-                elif self.urlstem:
-                        # If the location of the resource isn't known because
-                        # the error was encountered while attempting to find
-                        # the location, then at least knowing where it was
-                        # looking will be helpful.
-                        s += "\nRepository URL: '{0}'.".format(self.urlstem)
-                if self.proxy:
-                        s += "\nProxy: '{0}'".format(self.proxy)
-                if self.details:
-                        s +="\nAdditional Details:\n{0}".format(self.details)
-                return s
+    def __str__(self):
+        s = "{0} protocol error".format(self.proto)
+        if self.code and self.codename:
+            s += ": code: {0} ({1:d})".format(self.codename, self.code)
+        elif self.code:
+            s += ": Unknown error code: {0:d}".format(self.code)
+        if self.reason:
+            s += " reason: {0}".format(self.reason)
+        if self.url:
+            s += "\nURL: '{0}'".format(self.url)
+        elif self.urlstem:
+            # If the location of the resource isn't known because
+            # the error was encountered while attempting to find
+            # the location, then at least knowing where it was
+            # looking will be helpful.
+            s += "\nRepository URL: '{0}'.".format(self.urlstem)
+        if self.proxy:
+            s += "\nProxy: '{0}'".format(self.proxy)
+        if self.details:
+            s += "\nAdditional Details:\n{0}".format(self.details)
+        return s
 
-        def key(self):
-                return (self.proto, self.code, self.url, self.details,
-                    self.reason)
+    def key(self):
+        return (self.proto, self.code, self.url, self.details, self.reason)
 
-        def __eq__(self, other):
-                if not isinstance(other, TransportProtoError):
-                        return False
-                return self.key() == other.key()
+    def __eq__(self, other):
+        if not isinstance(other, TransportProtoError):
+            return False
+        return self.key() == other.key()
 
-        def __lt__(self, other):
-                if not isinstance(other, TransportProtoError):
-                        return True
-                return self.key() < other.key()
+    def __lt__(self, other):
+        if not isinstance(other, TransportProtoError):
+            return True
+        return self.key() < other.key()
 
-        def __hash__(self):
-                return hash(self.key())
+    def __hash__(self):
+        return hash(self.key())
 
 
 @total_ordering
 class TransportFrameworkError(TransportException):
-        """Raised when errors occur in the transport framework."""
+    """Raised when errors occur in the transport framework."""
 
-        def __init__(self, code, url=None, reason=None, repourl=None,
-            uuid=None, proxy=None):
-                TransportException.__init__(self)
-                self.code = code
-                self.url = url
-                self.urlstem = repourl
-                self.reason = reason
-                self.decayable = self.code in decayable_pycurl_errors
-                self.retryable = self.code in retryable_pycurl_errors
-                self.uuid = uuid
-                self.proxy = proxy
-                self.codename = ""
-                codenames = [
-                        name
-                        for name in vars(pycurl)
-                        if len(name) > 1 and name[:2] == "E_" and \
-                            getattr(pycurl, name) == code
-                ]
-                if len(codenames) >= 1:
-                        self.codename = codenames[0]
+    def __init__(
+        self, code, url=None, reason=None, repourl=None, uuid=None, proxy=None
+    ):
+        TransportException.__init__(self)
+        self.code = code
+        self.url = url
+        self.urlstem = repourl
+        self.reason = reason
+        self.decayable = self.code in decayable_pycurl_errors
+        self.retryable = self.code in retryable_pycurl_errors
+        self.uuid = uuid
+        self.proxy = proxy
+        self.codename = ""
+        codenames = [
+            name
+            for name in vars(pycurl)
+            if len(name) > 1
+            and name[:2] == "E_"
+            and getattr(pycurl, name) == code
+        ]
+        if len(codenames) >= 1:
+            self.codename = codenames[0]
 
-        def __str__(self):
-                if self.codename:
-                        s = "Framework error: code: {0} ({1:d})".format(
-                            self.codename, self.code)
-                else:
-                        s = "Unkown Framework error code: {0:d}".format(
-                            self.code)
-                if self.reason:
-                        s += " reason: {0}".format(self.reason)
-                if self.url:
-                        s += "\nURL: '{0}'".format(self.url)
-                if self.proxy:
-                        s += "\nProxy: '{0}'".format(self.proxy)
-                s += self._str_autofix()
-                return s
+    def __str__(self):
+        if self.codename:
+            s = "Framework error: code: {0} ({1:d})".format(
+                self.codename, self.code
+            )
+        else:
+            s = "Unkown Framework error code: {0:d}".format(self.code)
+        if self.reason:
+            s += " reason: {0}".format(self.reason)
+        if self.url:
+            s += "\nURL: '{0}'".format(self.url)
+        if self.proxy:
+            s += "\nProxy: '{0}'".format(self.proxy)
+        s += self._str_autofix()
+        return s
 
-        def key(self):
-                return (self.code, self.url, self.proxy, self.reason)
+    def key(self):
+        return (self.code, self.url, self.proxy, self.reason)
 
-        def __eq__(self, other):
-                if not isinstance(other, TransportFrameworkError):
-                        return False
-                return self.key() == other.key()
+    def __eq__(self, other):
+        if not isinstance(other, TransportFrameworkError):
+            return False
+        return self.key() == other.key()
 
-        def __lt__(self, other):
-                if not isinstance(other, TransportFrameworkError):
-                        return True
-                return self.key() < other.key()
+    def __lt__(self, other):
+        if not isinstance(other, TransportFrameworkError):
+            return True
+        return self.key() < other.key()
 
-        def __hash__(self):
-                return hash(self.key())
+    def __hash__(self):
+        return hash(self.key())
 
 
 @total_ordering
 class TransportStallError(TransportException):
-        """Raised when stalls occur in the transport framework."""
+    """Raised when stalls occur in the transport framework."""
 
-        def __init__(self, url=None, repourl=None, uuid=None, proxy=None):
-                TransportException.__init__(self)
-                self.url = url
-                self.urlstem = repourl
-                self.retryable = True
-                self.uuid = uuid
-                self.proxy = proxy
+    def __init__(self, url=None, repourl=None, uuid=None, proxy=None):
+        TransportException.__init__(self)
+        self.url = url
+        self.urlstem = repourl
+        self.retryable = True
+        self.uuid = uuid
+        self.proxy = proxy
 
-        def __str__(self):
-                s = "Framework stall"
-                if self.url or self.proxy:
-                        s += ":"
-                if self.url:
-                        s += "\nURL: '{0}'".format(self.url)
-                if self.proxy:
-                        s += "\nProxy: '{0}'".format(self.proxy)
-                return s
+    def __str__(self):
+        s = "Framework stall"
+        if self.url or self.proxy:
+            s += ":"
+        if self.url:
+            s += "\nURL: '{0}'".format(self.url)
+        if self.proxy:
+            s += "\nProxy: '{0}'".format(self.proxy)
+        return s
 
-        def key(self):
-                return (self.url, self.proxy)
+    def key(self):
+        return (self.url, self.proxy)
 
-        def __eq__(self, other):
-                if not isinstance(other, TransportStallError):
-                        return False
-                return self.key() == other.key()
+    def __eq__(self, other):
+        if not isinstance(other, TransportStallError):
+            return False
+        return self.key() == other.key()
 
-        def __lt__(self, other):
-                if not isinstance(other, TransportStallError):
-                        return True
-                return self.key() < other.key()
+    def __lt__(self, other):
+        if not isinstance(other, TransportStallError):
+            return True
+        return self.key() < other.key()
 
-        def __hash__(self):
-                return hash(self.key())
+    def __hash__(self):
+        return hash(self.key())
 
 
 @total_ordering
 class TransferContentException(TransportException):
-        """Raised when there are problems downloading the requested content."""
+    """Raised when there are problems downloading the requested content."""
 
-        def __init__(self, url, reason=None, proxy=None):
-                TransportException.__init__(self)
-                self.url = url
-                self.reason = reason
-                self.retryable = True
-                self.proxy = proxy
+    def __init__(self, url, reason=None, proxy=None):
+        TransportException.__init__(self)
+        self.url = url
+        self.reason = reason
+        self.retryable = True
+        self.proxy = proxy
 
-        def __str__(self):
-                if self.proxy:
-                        s = "Transfer from '{0}' via proxy '{1}' failed".format(
-                            self.url, self.proxy)
-                else:
-                        s = "Transfer from '{0}' failed".format(self.url)
-                if self.reason:
-                        s += ": {0}".format(self.reason)
-                s += "."
-                return s
+    def __str__(self):
+        if self.proxy:
+            s = "Transfer from '{0}' via proxy '{1}' failed".format(
+                self.url, self.proxy
+            )
+        else:
+            s = "Transfer from '{0}' failed".format(self.url)
+        if self.reason:
+            s += ": {0}".format(self.reason)
+        s += "."
+        return s
 
-        def key(self):
-                return (self.url, self.proxy, self.reason)
+    def key(self):
+        return (self.url, self.proxy, self.reason)
 
-        def __eq__(self, other):
-                if not isinstance(other, TransferContentException):
-                        return False
-                return self.key() == other.key()
+    def __eq__(self, other):
+        if not isinstance(other, TransferContentException):
+            return False
+        return self.key() == other.key()
 
-        def __lt__(self, other):
-                if not isinstance(other, TransferContentException):
-                        return True
-                return self.key() < other.key()
+    def __lt__(self, other):
+        if not isinstance(other, TransferContentException):
+            return True
+        return self.key() < other.key()
 
-        def __hash__(self):
-                return hash(self.key())
+    def __hash__(self):
+        return hash(self.key())
 
 
 @total_ordering
 class InvalidContentException(TransportException):
-        """Raised when the content's hash/chash doesn't verify, or the
-        content is received in an unreadable format."""
+    """Raised when the content's hash/chash doesn't verify, or the
+    content is received in an unreadable format."""
 
-        def __init__(self, path=None, reason=None, size=0, url=None, proxy=None):
-                TransportException.__init__(self)
-                self.path = path
-                self.reason = reason
-                self.size = size
-                self.retryable = True
-                self.url = url
-                self.proxy = proxy
+    def __init__(self, path=None, reason=None, size=0, url=None, proxy=None):
+        TransportException.__init__(self)
+        self.path = path
+        self.reason = reason
+        self.size = size
+        self.retryable = True
+        self.url = url
+        self.proxy = proxy
 
-        def __str__(self):
-                s = "Invalid content"
-                if self.path:
-                        s += "path {0}".format(self.path)
-                if self.reason:
-                        s += ": {0}.".format(self.reason)
-                if self.url:
-                        s += "\nURL: {0}".format(self.url)
-                if self.proxy:
-                        s += "\nProxy: {0}".format(self.proxy)
-                return s
+    def __str__(self):
+        s = "Invalid content"
+        if self.path:
+            s += "path {0}".format(self.path)
+        if self.reason:
+            s += ": {0}.".format(self.reason)
+        if self.url:
+            s += "\nURL: {0}".format(self.url)
+        if self.proxy:
+            s += "\nProxy: {0}".format(self.proxy)
+        return s
 
-        def key(self):
-                return (self.path, self.reason, self.proxy, self.url)
+    def key(self):
+        return (self.path, self.reason, self.proxy, self.url)
 
-        def __eq__(self, other):
-                if not isinstance(other, InvalidContentException):
-                        return False
-                return self.key() == other.key()
+    def __eq__(self, other):
+        if not isinstance(other, InvalidContentException):
+            return False
+        return self.key() == other.key()
 
-        def __lt__(self, other):
-                if not isinstance(other, InvalidContentException):
-                        return True
-                return self.key() < other.key()
+    def __lt__(self, other):
+        if not isinstance(other, InvalidContentException):
+            return True
+        return self.key() < other.key()
 
-        def __hash__(self):
-                return hash(self.key())
+    def __hash__(self):
+        return hash(self.key())
 
 
 @total_ordering
 class PkgProtoError(TransportException):
-        """Raised when the pkg protocol doesn't behave according to
-        specification.  This is different than TransportProtoError, which
-        deals with the L7 protocols that we can use to perform a pkg(7)
-        transport operation.  Although it doesn't exist, this is essentially
-        a L8 error, since our pkg protocol is built on top of application
-        level protocols.  The Framework errors deal with L3-6 errors."""
+    """Raised when the pkg protocol doesn't behave according to
+    specification.  This is different than TransportProtoError, which
+    deals with the L7 protocols that we can use to perform a pkg(7)
+    transport operation.  Although it doesn't exist, this is essentially
+    a L8 error, since our pkg protocol is built on top of application
+    level protocols.  The Framework errors deal with L3-6 errors."""
 
-        def __init__(self, url, operation=None, version=None, reason=None,
-            proxy=None):
-                TransportException.__init__(self)
-                self.url = url
-                self.reason = reason
-                self.operation = operation
-                self.version = version
-                self.proxy = proxy
+    def __init__(
+        self, url, operation=None, version=None, reason=None, proxy=None
+    ):
+        TransportException.__init__(self)
+        self.url = url
+        self.reason = reason
+        self.operation = operation
+        self.version = version
+        self.proxy = proxy
 
-        def __str__(self):
-                if self.proxy:
-                        s = "Invalid pkg(7) response from {0} (proxy {1})".format(
-                            self.url, self.proxy)
-                else:
-                        s = "Invalid pkg(7) response from {0}".format(self.url)
-                if self.operation:
-                        s += ": Attempting operation '{0}'".format(self.operation)
-                if self.version is not None:
-                        s += " version {0}".format(self.version)
-                if self.reason:
-                        s += ":\n{0}".format(self.reason)
-                return s
+    def __str__(self):
+        if self.proxy:
+            s = "Invalid pkg(7) response from {0} (proxy {1})".format(
+                self.url, self.proxy
+            )
+        else:
+            s = "Invalid pkg(7) response from {0}".format(self.url)
+        if self.operation:
+            s += ": Attempting operation '{0}'".format(self.operation)
+        if self.version is not None:
+            s += " version {0}".format(self.version)
+        if self.reason:
+            s += ":\n{0}".format(self.reason)
+        return s
 
-        def key(self):
-                return (self.url, self.operation, self.version,
-                    self.proxy, self.reason)
+    def key(self):
+        return (self.url, self.operation, self.version, self.proxy, self.reason)
 
-        def __eq__(self, other):
-                if not isinstance(other, PkgProtoError):
-                        return False
-                return self.key() == other.key()
+    def __eq__(self, other):
+        if not isinstance(other, PkgProtoError):
+            return False
+        return self.key() == other.key()
 
-        def __lt__(self, other):
-                if not isinstance(other, PkgProtoError):
-                        return True
-                return self.key() < other.key()
+    def __lt__(self, other):
+        if not isinstance(other, PkgProtoError):
+            return True
+        return self.key() < other.key()
 
-        def __hash__(self):
-                return hash(self.key())
+    def __hash__(self):
+        return hash(self.key())
 
 
 @total_ordering
 class ExcessiveTransientFailure(TransportException):
-        """Raised when the transport encounters too many retryable errors
-        at a single endpoint."""
+    """Raised when the transport encounters too many retryable errors
+    at a single endpoint."""
 
-        def __init__(self, url, count, proxy=None):
-                TransportException.__init__(self)
-                self.url = url
-                self.count = count
-                self.retryable = True
-                self.failures = None
-                self.success = None
-                self.proxy = proxy
+    def __init__(self, url, count, proxy=None):
+        TransportException.__init__(self)
+        self.url = url
+        self.count = count
+        self.retryable = True
+        self.failures = None
+        self.success = None
+        self.proxy = proxy
 
-        def __str__(self):
-                s = "Too many retryable errors encountered during transfer.\n"
-                if self.url:
-                        s += "URL: {0} ".format(self.url)
-                if self.proxy:
-                        s += "Proxy: {0}".format(self.proxy)
-                if self.count:
-                        s += "Count: {0} ".format(self.count)
-                return s
+    def __str__(self):
+        s = "Too many retryable errors encountered during transfer.\n"
+        if self.url:
+            s += "URL: {0} ".format(self.url)
+        if self.proxy:
+            s += "Proxy: {0}".format(self.proxy)
+        if self.count:
+            s += "Count: {0} ".format(self.count)
+        return s
 
-        def key(self):
-                return (self.url, self.proxy, self.count)
+    def key(self):
+        return (self.url, self.proxy, self.count)
 
-        def __eq__(self, other):
-                if not isinstance(other, ExcessiveTransientFailure):
-                        return False
-                return self.key() == other.key()
+    def __eq__(self, other):
+        if not isinstance(other, ExcessiveTransientFailure):
+            return False
+        return self.key() == other.key()
 
-        def __lt__(self, other):
-                if not isinstance(other, ExcessiveTransientFailure):
-                        return True
-                return self.key() < other.key()
+    def __lt__(self, other):
+        if not isinstance(other, ExcessiveTransientFailure):
+            return True
+        return self.key() < other.key()
 
-        def __hash__(self):
-                return hash(self.key())
+    def __hash__(self):
+        return hash(self.key())
 
 
 class mDNSException(TransportException):
-        """Used when mDNS operations fail."""
+    """Used when mDNS operations fail."""
 
-        def __init__(self, errstr):
-                TransportException.__init__(self)
-                self.err = errstr
+    def __init__(self, errstr):
+        TransportException.__init__(self)
+        self.err = errstr
 
-        def __str__(self):
-                return self.err
+    def __str__(self):
+        return self.err
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/transport/fileobj.py
+++ b/src/modules/client/transport/fileobj.py
@@ -30,375 +30,373 @@ import pkg.client.transport.exception as tx
 
 from pkg.misc import DummyLock, force_str
 
+
 class StreamingFileObj(object):
+    def __init__(self, url, engine, ccancel=None):
+        """Create a streaming file object that wraps around a
+        transport engine.  This is only necessary if the underlying
+        transport doesn't have its own streaming interface and the
+        repo operation needs a streaming response."""
 
-        def __init__(self, url, engine, ccancel=None):
-                """Create a streaming file object that wraps around a
-                transport engine.  This is only necessary if the underlying
-                transport doesn't have its own streaming interface and the
-                repo operation needs a streaming response."""
+        self.__buf = b""
+        self.__url = url
+        self.__engine = engine
+        self.__data_callback_invoked = False
+        self.__headers_arrived = False
+        self.__httpmsg = None
+        self.__headers = {}
+        self.__done = False
+        self.__check_cancelation = ccancel
+        self.__lock = DummyLock()
+        self.__uuid = uuidm.uuid4().int
+        # Free buffer on exception.  Set to False if caller may
+        # read buffer after exception.  Caller should call close()
+        # to cleanup afterwards.
+        self.free_buffer = True
 
-                self.__buf = b""
-                self.__url = url
-                self.__engine = engine
-                self.__data_callback_invoked = False
-                self.__headers_arrived = False
-                self.__httpmsg = None
-                self.__headers = {}
-                self.__done = False
-                self.__check_cancelation = ccancel
-                self.__lock = DummyLock()
-                self.__uuid = uuidm.uuid4().int
-                # Free buffer on exception.  Set to False if caller may
-                # read buffer after exception.  Caller should call close()
-                # to cleanup afterwards.
-                self.free_buffer = True
+    def __del__(self):
+        release = False
+        try:
+            if not self.__done:
+                if not self.__lock._is_owned():
+                    self.__lock.acquire()
+                    release = True
+                self.__engine.orphaned_request(self.__url, self.__uuid)
+        except AttributeError:
+            # Ignore attribute error if instance is deleted
+            # before initialization completes.
+            pass
+        finally:
+            if release:
+                self.__lock.release()
 
-        def __del__(self):
-                release = False
-                try:
-                        if not self.__done:
-                                if not self.__lock._is_owned():
-                                        self.__lock.acquire()
-                                        release = True
-                                self.__engine.orphaned_request(self.__url,
-                                    self.__uuid)
-                except AttributeError:
-                        # Ignore attribute error if instance is deleted
-                        # before initialization completes.
-                        pass
-                finally:
-                        if release:
-                                self.__lock.release()
+    # File object methods
 
-        # File object methods
+    def close(self):
+        # Caller shouldn't hold lock when calling this method
+        assert not self.__lock._is_owned()
 
-        def close(self):
-                # Caller shouldn't hold lock when calling this method
-                assert not self.__lock._is_owned()
+        if not self.__done:
+            self.__lock.acquire()
+            try:
+                self.__engine.remove_request(self.__url, self.__uuid)
+                self.__done = True
+            finally:
+                self.__lock.release()
+        self.__buf = b""
+        self.__engine = None
+        self.__url = None
 
-                if not self.__done:
-                        self.__lock.acquire()
-                        try:
-                                self.__engine.remove_request(self.__url,
-                                    self.__uuid)
-                                self.__done = True
-                        finally:
-                                self.__lock.release()
-                self.__buf = b""
-                self.__engine = None
-                self.__url = None
+    def flush(self):
+        """flush the buffer.  Since this supports read, but
+        not write, this is a noop."""
+        return
 
-        def flush(self):
-                """flush the buffer.  Since this supports read, but
-                not write, this is a noop."""
-                return
+    def read(self, size=-1):
+        """Read size bytes from the remote connection.
+        If size isn't specified, read all of the data from
+        the remote side."""
 
-        def read(self, size=-1):
-                """Read size bytes from the remote connection.
-                If size isn't specified, read all of the data from
-                the remote side."""
+        # Caller shouldn't hold lock when calling this method
+        assert not self.__lock._is_owned()
 
-                # Caller shouldn't hold lock when calling this method
-                assert not self.__lock._is_owned()
+        if size < 0:
+            while self.__fill_buffer():
+                # just fill the buffer
+                pass
+            curdata = self.__buf
+            self.__buf = b""
+            return curdata
+        else:
+            curdata = self.__buf
+            datalen = len(curdata)
+            if datalen >= size:
+                self.__buf = curdata[size:]
+                return curdata[:size]
+            while self.__fill_buffer():
+                datalen = len(self.__buf)
+                if datalen >= size:
+                    break
 
-                if size < 0:
-                        while self.__fill_buffer():
-                                # just fill the buffer
-                                pass
-                        curdata = self.__buf
-                        self.__buf = b""
-                        return curdata
-                else:
-                        curdata = self.__buf
-                        datalen = len(curdata)
-                        if datalen >= size:
-                                self.__buf = curdata[size:]
-                                return curdata[:size]
-                        while self.__fill_buffer():
-                                datalen = len(self.__buf)
-                                if datalen >= size:
-                                        break
+            curdata = self.__buf
+            datalen = len(curdata)
+            if datalen >= size:
+                self.__buf = curdata[size:]
+                return curdata[:size]
 
-                        curdata = self.__buf
-                        datalen = len(curdata)
-                        if datalen >= size:
-                                self.__buf = curdata[size:]
-                                return curdata[:size]
+            self.__buf = b""
+            return curdata
 
-                        self.__buf = b""
-                        return curdata
+    def readline(self, size=-1):
+        """Read a line from the remote host.  If size is
+        specified, read to newline or size, whichever is smaller.
+        We force the return value to be str here since the caller
+        expect str."""
 
-        def readline(self, size=-1):
-                """Read a line from the remote host.  If size is
-                specified, read to newline or size, whichever is smaller.
-                We force the return value to be str here since the caller
-                expect str."""
+        # Caller shouldn't hold lock when calling this method
+        assert not self.__lock._is_owned()
 
-                # Caller shouldn't hold lock when calling this method
-                assert not self.__lock._is_owned()
+        if size < 0:
+            curdata = self.__buf
+            newline = curdata.find(b"\n")
+            if newline >= 0:
+                newline += 1
+                self.__buf = curdata[newline:]
+                return force_str(curdata[:newline])
+            while self.__fill_buffer():
+                newline = self.__buf.find(b"\n")
+                if newline >= 0:
+                    break
 
-                if size < 0:
-                        curdata = self.__buf
-                        newline = curdata.find(b"\n")
-                        if newline >= 0:
-                                newline += 1
-                                self.__buf = curdata[newline:]
-                                return force_str(curdata[:newline])
-                        while self.__fill_buffer():
-                                newline = self.__buf.find(b"\n")
-                                if newline >= 0:
-                                        break
+            curdata = self.__buf
+            newline = curdata.find(b"\n")
+            if newline >= 0:
+                newline += 1
+                self.__buf = curdata[newline:]
+                return force_str(curdata[:newline])
+            self.__buf = b""
+            return force_str(curdata)
+        else:
+            curdata = self.__buf
+            newline = curdata.find(b"\n", 0, size)
+            datalen = len(curdata)
+            if newline >= 0:
+                newline += 1
+                self.__buf = curdata[newline:]
+                return force_str(curdata[:newline])
+            if datalen >= size:
+                self.__buf = curdata[size:]
+                return force_str(curdata[:size])
+            while self.__fill_buffer():
+                newline = self.__buf.find(b"\n", 0, size)
+                datalen = len(self.__buf)
+                if newline >= 0:
+                    break
+                if datalen >= size:
+                    break
 
-                        curdata = self.__buf
-                        newline = curdata.find(b"\n")
-                        if newline >= 0:
-                                newline += 1
-                                self.__buf = curdata[newline:]
-                                return force_str(curdata[:newline])
-                        self.__buf = b""
-                        return force_str(curdata)
-                else:
-                        curdata = self.__buf
-                        newline = curdata.find(b"\n", 0, size)
-                        datalen = len(curdata)
-                        if newline >= 0:
-                                newline += 1
-                                self.__buf = curdata[newline:]
-                                return force_str(curdata[:newline])
-                        if datalen >= size:
-                                self.__buf = curdata[size:]
-                                return force_str(curdata[:size])
-                        while self.__fill_buffer():
-                                newline = self.__buf.find(b"\n", 0, size)
-                                datalen = len(self.__buf)
-                                if newline >= 0:
-                                        break
-                                if datalen >= size:
-                                        break
+            curdata = self.__buf
+            newline = curdata.find(b"\n", 0, size)
+            datalen = len(curdata)
+            if newline >= 0:
+                newline += 1
+                self.__buf = curdata[newline:]
+                return force_str(curdata[:newline])
+            if datalen >= size:
+                self.__buf = curdata[size:]
+                return force_str(curdata[:size])
+            self.__buf = b""
+            return force_str(curdata)
 
-                        curdata = self.__buf
-                        newline = curdata.find(b"\n", 0, size)
-                        datalen = len(curdata)
-                        if newline >= 0:
-                                newline += 1
-                                self.__buf = curdata[newline:]
-                                return force_str(curdata[:newline])
-                        if datalen >= size:
-                                self.__buf = curdata[size:]
-                                return force_str(curdata[:size])
-                        self.__buf = b""
-                        return force_str(curdata)
+    def readlines(self, sizehint=0):
+        """Read lines from the remote host, returning an
+        array of the lines that were read.  sizehint specifies
+        an approximate size, in bytes, of the total amount of data,
+        as lines, that should be returned to the caller."""
 
-        def readlines(self, sizehint=0):
-                """Read lines from the remote host, returning an
-                array of the lines that were read.  sizehint specifies
-                an approximate size, in bytes, of the total amount of data,
-                as lines, that should be returned to the caller."""
+        # Caller shouldn't hold lock when calling this method
+        assert not self.__lock._is_owned()
 
-                # Caller shouldn't hold lock when calling this method
-                assert not self.__lock._is_owned()
+        read = 0
+        lines = []
+        while True:
+            l = self.readline()
+            if not l:
+                break
+            lines.append(l)
+            read += len(l)
+            if sizehint and read >= sizehint:
+                break
 
-                read = 0
-                lines = []
-                while True:
-                        l = self.readline()
-                        if not l:
-                                break
-                        lines.append(l)
-                        read += len(l)
-                        if sizehint and read >= sizehint:
-                                break
+        return lines
 
-                return lines
+    def write(self, data):
+        raise NotImplementedError
 
-        def write(self, data):
-                raise NotImplementedError
+    def writelines(self, llist):
+        raise NotImplementedError
 
-        def writelines(self, llist):
-                raise NotImplementedError
+    # Methods that access the callbacks
 
-        # Methods that access the callbacks
+    def get_write_func(self):
+        return self.__write_callback
 
-        def get_write_func(self):
-                return self.__write_callback
+    def get_header_func(self):
+        return self.__header_callback
 
-        def get_header_func(self):
-                return self.__header_callback
+    def get_progress_func(self):
+        return self.__progress_callback
 
-        def get_progress_func(self):
-                return self.__progress_callback
+    # Miscellaneous accessors
 
-        # Miscellaneous accessors
+    def set_lock(self, lock):
+        self.__lock = lock
 
-        def set_lock(self, lock):
-                self.__lock = lock
+    @property
+    def uuid(self):
+        return self.__uuid
 
-        @property
-        def uuid(self):
-                return self.__uuid
+    # Header and message methods
 
-        # Header and message methods
+    @property
+    def headers(self):
+        if not self.__headers_arrived:
+            self.__fill_headers()
+        return self.__headers
 
-        @property
-        def headers(self):
-                if not self.__headers_arrived:
-                        self.__fill_headers()
-                return self.__headers
+    def get_http_message(self):
+        """Return the status message that may be included
+        with a numerical HTTP response code.  Not all HTTP
+        implementations are guaranteed to return this value.
+        In some cases it may be None."""
 
-        def get_http_message(self):
-                """Return the status message that may be included
-                with a numerical HTTP response code.  Not all HTTP
-                implementations are guaranteed to return this value.
-                In some cases it may be None."""
+        return self.__httpmsg
 
-                return self.__httpmsg
+    def getheader(self, hdr, default):
+        """Return the HTTP header named hdr.  If the hdr
+        isn't present, return default value instead."""
 
-        def getheader(self, hdr, default):
-                """Return the HTTP header named hdr.  If the hdr
-                isn't present, return default value instead."""
+        if not self.__headers_arrived:
+            self.__fill_headers()
 
-                if not self.__headers_arrived:
-                        self.__fill_headers()
+        return self.__headers.get(hdr.lower(), default)
 
-                return self.__headers.get(hdr.lower(), default)
+    def _prime(self):
+        """Used by the underlying transport before handing this
+        object off to other layers.  It ensures that the object's
+        creator can catch errors that occur at connection time.
+        All callers must still catch transport exceptions, however."""
 
-        def _prime(self):
-                """Used by the underlying transport before handing this
-                object off to other layers.  It ensures that the object's
-                creator can catch errors that occur at connection time.
-                All callers must still catch transport exceptions, however."""
+        self.__fill_buffer(1)
 
-                self.__fill_buffer(1)
+    # Iterator methods
 
-        # Iterator methods
+    def __iter__(self):
+        return self
 
-        def __iter__(self):
-                return self
+    def __next__(self):
+        line = self.readline()
+        if not line:
+            raise StopIteration
+        return line
 
-        def __next__(self):
-                line = self.readline()
-                if not line:
-                        raise StopIteration
-                return line
+    next = __next__
 
-        next = __next__
+    # Private methods
 
-        # Private methods
-        
-        def __fill_buffer(self, size=-1):
-                """Call engine.run() to fill the file object's buffer.
-                Read until we might block.  If size is specified, stop
-                once we get at least size bytes, or might block,
-                whichever comes first."""
+    def __fill_buffer(self, size=-1):
+        """Call engine.run() to fill the file object's buffer.
+        Read until we might block.  If size is specified, stop
+        once we get at least size bytes, or might block,
+        whichever comes first."""
 
-                engine = self.__engine
+        engine = self.__engine
 
-                if not engine:
-                        return False
+        if not engine:
+            return False
 
-                self.__lock.acquire()
-                while 1:
-                        if self.__done:
-                                self.__lock.release()
-                                return False
-                        elif not engine.pending:
-                                # nothing pending means no more transfer
-                                self.__done = True
-                                s = engine.check_status([self.__url])
-                                if s:
-                                        # Cleanup prior to raising exception
-                                        self.__lock.release()
-                                        if self.free_buffer:
-                                                self.close()
-                                        raise s[0]
-
-                                self.__lock.release()
-                                return False
-
-                        try:
-                                engine.run()
-                        except tx.ExcessiveTransientFailure as ex:
-                                s = engine.check_status([self.__url])
-                                ex.failures = s
-                                self.__lock.release()
-                                if self.free_buffer:
-                                        self.close()
-                                raise
-                        except:
-                                # Cleanup and close, if exception
-                                # raised by run.
-                                self.__lock.release()
-                                if self.free_buffer:
-                                        self.close()
-                                raise
-
-                        if size > 0 and len(self.__buf) < size:
-                                # loop if we need more data in the buffer
-                                continue
-                        else:
-                                # break out of this loop
-                                break
+        self.__lock.acquire()
+        while 1:
+            if self.__done:
+                self.__lock.release()
+                return False
+            elif not engine.pending:
+                # nothing pending means no more transfer
+                self.__done = True
+                s = engine.check_status([self.__url])
+                if s:
+                    # Cleanup prior to raising exception
+                    self.__lock.release()
+                    if self.free_buffer:
+                        self.close()
+                    raise s[0]
 
                 self.__lock.release()
-                return True
+                return False
 
-        def __fill_headers(self):
-                """Run the transport until headers arrive.  When the data
-                callback gets invoked, all headers have arrived.  The
-                alternate scenario is when no data arrives, but the server
-                isn't providing more input isi over the network.  In that case,
-                the client either received just headers, or had the transfer
-                close unexpectedly."""
+            try:
+                engine.run()
+            except tx.ExcessiveTransientFailure as ex:
+                s = engine.check_status([self.__url])
+                ex.failures = s
+                self.__lock.release()
+                if self.free_buffer:
+                    self.close()
+                raise
+            except:
+                # Cleanup and close, if exception
+                # raised by run.
+                self.__lock.release()
+                if self.free_buffer:
+                    self.close()
+                raise
 
-                while not self.__data_callback_invoked:
-                        if not self.__fill_buffer():
-                                # We hit this case if we get headers
-                                # but no data.
-                                break
+            if size > 0 and len(self.__buf) < size:
+                # loop if we need more data in the buffer
+                continue
+            else:
+                # break out of this loop
+                break
 
-                self.__headers_arrived = True
+        self.__lock.release()
+        return True
 
-        def __progress_callback(self, dltot, dlcur, ultot, ulcur):
-                """Called by pycurl/libcurl framework to update
-                progress tracking."""
+    def __fill_headers(self):
+        """Run the transport until headers arrive.  When the data
+        callback gets invoked, all headers have arrived.  The
+        alternate scenario is when no data arrives, but the server
+        isn't providing more input isi over the network.  In that case,
+        the client either received just headers, or had the transfer
+        close unexpectedly."""
 
-                if self.__check_cancelation and self.__check_cancelation():
-                        return -1
+        while not self.__data_callback_invoked:
+            if not self.__fill_buffer():
+                # We hit this case if we get headers
+                # but no data.
+                break
 
-                return 0
+        self.__headers_arrived = True
 
-        def __write_callback(self, data):
-                """A callback given to transport engine that writes data
-                into a buffer in this object."""
+    def __progress_callback(self, dltot, dlcur, ultot, ulcur):
+        """Called by pycurl/libcurl framework to update
+        progress tracking."""
 
-                if not self.__data_callback_invoked:
-                        self.__data_callback_invoked = True
+        if self.__check_cancelation and self.__check_cancelation():
+            return -1
 
-                # We don't force data to str here because data could be from a
-                # gizpped file, which contains gzip magic number that can't be
-                # decoded by 'utf-8'.
-                self.__buf = self.__buf + data
+        return 0
 
-        def __header_callback(self, data):
-                """A callback given to the transport engine.  It reads header
-                information from the transport.  This function saves
-                the message from the http response, as well as a dictionary
-                of headers that it can parse."""
+    def __write_callback(self, data):
+        """A callback given to transport engine that writes data
+        into a buffer in this object."""
 
-                if data.startswith(b"HTTP/"):
-                        rtup = data.split(None, 2)
-                        try:
-                                self.__httpmsg = rtup[2]
-                        except IndexError:
-                                pass
+        if not self.__data_callback_invoked:
+            self.__data_callback_invoked = True
 
-                elif data.find(b":") > -1:
-                        k, v = data.split(b":", 1)
-                        if v:
-                                # convert to str as early as we can
-                                self.__headers[force_str(k.lower())] = \
-                                        force_str(v.strip())
+        # We don't force data to str here because data could be from a
+        # gizpped file, which contains gzip magic number that can't be
+        # decoded by 'utf-8'.
+        self.__buf = self.__buf + data
+
+    def __header_callback(self, data):
+        """A callback given to the transport engine.  It reads header
+        information from the transport.  This function saves
+        the message from the http response, as well as a dictionary
+        of headers that it can parse."""
+
+        if data.startswith(b"HTTP/"):
+            rtup = data.split(None, 2)
+            try:
+                self.__httpmsg = rtup[2]
+            except IndexError:
+                pass
+
+        elif data.find(b":") > -1:
+            k, v = data.split(b":", 1)
+            if v:
+                # convert to str as early as we can
+                self.__headers[force_str(k.lower())] = force_str(v.strip())
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/transport/mdetect.py
+++ b/src/modules/client/transport/mdetect.py
@@ -32,137 +32,147 @@ import pkg.client.publisher as pub
 import pkg.client.transport.exception as tx
 
 try:
-        import pybonjour
+    import pybonjour
 except (OSError, ImportError):
-        pass
+    pass
 else:
-        import select
+    import select
 
 
 class MirrorDetector(object):
-        """This class uses mDNS and DNS-SD to find link-local content
-        mirrors that may be present on the client's subnet."""
+    """This class uses mDNS and DNS-SD to find link-local content
+    mirrors that may be present on the client's subnet."""
 
-        def __init__(self):
-                self._mirrors = []
-                self.__timeout = 1
-                self.__service = "_pkg5._tcp"
+    def __init__(self):
+        self._mirrors = []
+        self.__timeout = 1
+        self.__service = "_pkg5._tcp"
 
-        def __contains__(self, key):
-                return key in self._mirrors
+    def __contains__(self, key):
+        return key in self._mirrors
 
-        def __getitem__(self, pos):
-                return self._mirrors[pos]
+    def __getitem__(self, pos):
+        return self._mirrors[pos]
 
-        def __iter__(self):
-                """Each time iterator is invoked, randomly select up to
-                five mirrors from the list of available mirrors."""
+    def __iter__(self):
+        """Each time iterator is invoked, randomly select up to
+        five mirrors from the list of available mirrors."""
 
-                listlen = len(self._mirrors)
-                iterlst = random.sample(range(listlen), min(listlen, 5))
+        listlen = len(self._mirrors)
+        iterlst = random.sample(range(listlen), min(listlen, 5))
 
-                for v in iterlst:
-                        yield self._mirrors[v]
+        for v in iterlst:
+            yield self._mirrors[v]
 
-        def locate(self):
-                """When invoked, this populates the MirrorDetector object with
-                URLs that name dynamically discovered content mirrors."""
+    def locate(self):
+        """When invoked, this populates the MirrorDetector object with
+        URLs that name dynamically discovered content mirrors."""
 
-                # Clear the list of mirrors.  It will be repopulated later.
-                self._mirrors = []      
+        # Clear the list of mirrors.  It will be repopulated later.
+        self._mirrors = []
 
-                if not "pybonjour" in globals():
-                        return
+        if not "pybonjour" in globals():
+            return
 
-                timedout = False
-                tval = self.__timeout
+        timedout = False
+        tval = self.__timeout
 
-                def browse_cb(sd_hdl, flags, interface_idx, error_code,
-                    service_name, regtype, reply_domain):
+        def browse_cb(
+            sd_hdl,
+            flags,
+            interface_idx,
+            error_code,
+            service_name,
+            regtype,
+            reply_domain,
+        ):
+            if error_code != pybonjour.kDNSServiceErr_NoError:
+                return
 
-                        if error_code != pybonjour.kDNSServiceErr_NoError:
-                                return
+            if not (flags & pybonjour.kDNSServiceFlagsAdd):
+                return
 
-                        if not (flags & pybonjour.kDNSServiceFlagsAdd):
-                                return
+            self._resolve_server(
+                interface_idx, error_code, service_name, regtype, reply_domain
+            )
 
-                        self._resolve_server(interface_idx, error_code,
-                            service_name, regtype, reply_domain)
+        try:
+            sd_hdl = pybonjour.DNSServiceBrowse(
+                regtype=self.__service, callBack=browse_cb
+            )
+        except pybonjour.BonjourError as e:
+            errstr = "mDNS Service Browse Failed: {0}\n".format(e.args[0][1])
+            raise tx.mDNSException(errstr)
 
-                try:
-                        sd_hdl = pybonjour.DNSServiceBrowse(
-                            regtype=self.__service, callBack=browse_cb)
-                except pybonjour.BonjourError as e:
-                        errstr = "mDNS Service Browse Failed: {0}\n".format(
-                            e.args[0][1])
-                        raise tx.mDNSException(errstr)
+        try:
+            while not timedout:
+                avail = select.select([sd_hdl], [], [], tval)
+                if sd_hdl in avail[0]:
+                    pybonjour.DNSServiceProcessResult(sd_hdl)
+                    tval = 0
+                else:
+                    timedout = True
+        except select.error as e:
+            errstr = "Select failed: {0}\n".format(e.args[1])
+            raise tx.mDNSException(errstr)
+        except pybonjour.BonjourError as e:
+            errstr = "mDNS Process Result failed: {0}\n".format(e.args[0][1])
+            raise tx.mDNSException(errstr)
+        finally:
+            sd_hdl.close()
 
-                try:
-                        while not timedout:
-                                avail = select.select([sd_hdl], [], [], tval)
-                                if sd_hdl in avail[0]:
-                                        pybonjour.DNSServiceProcessResult(
-                                            sd_hdl)
-                                        tval = 0
-                                else:
-                                        timedout = True
-                except select.error as e:
-                        errstr = "Select failed: {0}\n".format(e.args[1])
-                        raise tx.mDNSException(errstr)
-                except pybonjour.BonjourError as e:
-                        errstr = "mDNS Process Result failed: {0}\n".format(
-                            e.args[0][1])
-                        raise tx.mDNSException(errstr)
-                finally:
-                        sd_hdl.close()
+    def _resolve_server(self, if_idx, ec, service_name, regtype, reply_domain):
+        """Invoked to resolve mDNS information about a service that
+        was discovered by a Browse call."""
 
-        def _resolve_server(self, if_idx, ec, service_name, regtype,
-            reply_domain):
-                """Invoked to resolve mDNS information about a service that
-                was discovered by a Browse call."""
+        timedout = False
+        tval = self.__timeout
 
-                timedout = False
-                tval = self.__timeout
+        def resolve_cb(
+            sd_hdl,
+            flags,
+            interface_idx,
+            error_code,
+            full_name,
+            host_target,
+            port,
+            txt_record,
+        ):
+            if error_code != pybonjour.kDNSServiceErr_NoError:
+                return
 
-                def resolve_cb(sd_hdl, flags, interface_idx, error_code,
-                    full_name, host_target, port, txt_record):
+            tr = pybonjour.TXTRecord.parse(txt_record)
+            if "url" in tr:
+                url = tr["url"]
+                if not misc.valid_pub_url(url):
+                    return
+                self._mirrors.append(pub.RepositoryURI(url))
 
-                        if error_code != pybonjour.kDNSServiceErr_NoError:
-                                return
+        try:
+            sd_hdl = pybonjour.DNSServiceResolve(
+                0, if_idx, service_name, regtype, reply_domain, resolve_cb
+            )
+        except pybonjour.BonjourError as e:
+            errstr = "mDNS Service Resolve Failed: {0}\n".format(e.args[0][1])
+            raise tx.mDNSException(errstr)
 
-                        tr = pybonjour.TXTRecord.parse(txt_record)
-                        if "url" in tr:
-                                url = tr["url"]
-                                if not misc.valid_pub_url(url):
-                                        return
-                                self._mirrors.append(pub.RepositoryURI(url))
+        try:
+            while not timedout:
+                avail = select.select([sd_hdl], [], [], tval)
+                if sd_hdl in avail[0]:
+                    pybonjour.DNSServiceProcessResult(sd_hdl)
+                    tval = 0
+                else:
+                    timedout = True
+        except select.error as e:
+            errstr = "Select failed; {0}\n".format(e.args[1])
+            raise tx.mDNSException(errstr)
+        except pybonjour.BonjourError as e:
+            errstr = "mDNS Process Result Failed: {0}\n".format(e.args[0][1])
+            raise tx.mDNSException(errstr)
+        finally:
+            sd_hdl.close()
 
-                try:
-                        sd_hdl =  pybonjour.DNSServiceResolve(0, if_idx,
-                            service_name, regtype, reply_domain, resolve_cb)
-                except pybonjour.BonjourError as e:
-                        errstr = "mDNS Service Resolve Failed: {0}\n".format(
-                            e.args[0][1])
-                        raise tx.mDNSException(errstr)
-
-                try:
-                        while not timedout:
-                                avail = select.select([sd_hdl], [], [], tval)
-                                if sd_hdl in avail[0]:
-                                        pybonjour.DNSServiceProcessResult(
-                                            sd_hdl)
-                                        tval = 0
-                                else:
-                                        timedout = True
-                except select.error as e:
-                        errstr = "Select failed; {0}\n".format(e.args[1])
-                        raise tx.mDNSException(errstr)
-                except pybonjour.BonjourError as e:
-                        errstr = "mDNS Process Result Failed: {0}\n".format(
-                            e.args[0][1])
-                        raise tx.mDNSException(errstr)
-                finally:
-                        sd_hdl.close()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/transport/repo.py
+++ b/src/modules/client/transport/repo.py
@@ -35,8 +35,14 @@ import tempfile
 
 from email.utils import formatdate
 from six.moves import cStringIO, http_client
-from six.moves.urllib.parse import quote, urlencode, urlsplit, urlparse, \
-    urlunparse, urljoin
+from six.moves.urllib.parse import (
+    quote,
+    urlencode,
+    urlsplit,
+    urlparse,
+    urlunparse,
+    urljoin,
+)
 from six.moves.urllib.request import url2pathname, pathname2url
 
 import pkg
@@ -52,2574 +58,2916 @@ import pkg.server.query_parser as sqp
 
 from pkg.misc import N_, compute_compressed_attrs, EmptyDict
 
+
 class TransportRepo(object):
-        """The TransportRepo class handles transport requests.
-        It represents a repo, and provides the same interfaces as
-        the operations that are performed against a repo.  Subclasses
-        should implement protocol specific repo modifications."""
+    """The TransportRepo class handles transport requests.
+    It represents a repo, and provides the same interfaces as
+    the operations that are performed against a repo.  Subclasses
+    should implement protocol specific repo modifications."""
 
-        def do_search(self, data, header=None, ccancel=None, pub=None):
-                """Perform a search request."""
+    def do_search(self, data, header=None, ccancel=None, pub=None):
+        """Perform a search request."""
 
-                raise NotImplementedError
+        raise NotImplementedError
 
-        def get_catalog(self, ts=None, header=None, ccancel=None, pub=None):
-                """Get the catalog from the repo.  If ts is defined,
-                request only changes newer than timestamp ts."""
+    def get_catalog(self, ts=None, header=None, ccancel=None, pub=None):
+        """Get the catalog from the repo.  If ts is defined,
+        request only changes newer than timestamp ts."""
 
-                raise NotImplementedError
+        raise NotImplementedError
 
-        def get_catalog1(self, filelist, destloc, header=None, ts=None,
-            progtrack=None, pub=None, revalidate=False, redownload=False):
-                """Get the files that make up the catalog components
-                that are listed in 'filelist'.  Download the files to
-                the directory specified in 'destloc'.  The caller
-                may optionally specify a dictionary with header
-                elements in 'header'.  If a conditional get is
-                to be performed, 'ts' should contain a floating point
-                value of seconds since the epoch.
+    def get_catalog1(
+        self,
+        filelist,
+        destloc,
+        header=None,
+        ts=None,
+        progtrack=None,
+        pub=None,
+        revalidate=False,
+        redownload=False,
+    ):
+        """Get the files that make up the catalog components
+        that are listed in 'filelist'.  Download the files to
+        the directory specified in 'destloc'.  The caller
+        may optionally specify a dictionary with header
+        elements in 'header'.  If a conditional get is
+        to be performed, 'ts' should contain a floating point
+        value of seconds since the epoch.
 
-                Revalidate and redownload are used to control upstream
-                caching behavior, for protocols that support caching. (HTTP)"""
+        Revalidate and redownload are used to control upstream
+        caching behavior, for protocols that support caching. (HTTP)"""
+
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def get_datastream(
+        self, fhash, version, header=None, ccancel=None, pub=None
+    ):
+        """Get a datastream from a repo.  The name of the
+        file is given in fhash."""
 
-        def get_datastream(self, fhash, version, header=None, ccancel=None, pub=None):
-                """Get a datastream from a repo.  The name of the
-                file is given in fhash."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def get_files(
+        self, filelist, dest, progtrack, version, header=None, pub=None
+    ):
+        """Get multiple files from the repo at once.
+        The files are named by hash and supplied in filelist.
+        If dest is specified, download to the destination
+        directory that is given. Progtrack is a ProgressTracker"""
 
-        def get_files(self, filelist, dest, progtrack, version, header=None, pub=None):
-                """Get multiple files from the repo at once.
-                The files are named by hash and supplied in filelist.
-                If dest is specified, download to the destination
-                directory that is given. Progtrack is a ProgressTracker"""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def get_manifest(self, fmri, header=None, ccancel=None, pub=None):
+        """Get a manifest from repo.  The name of the
+        package is given in fmri.  If dest is set, download
+        the manifest to dest."""
 
-        def get_manifest(self, fmri, header=None, ccancel=None, pub=None):
-                """Get a manifest from repo.  The name of the
-                package is given in fmri.  If dest is set, download
-                the manifest to dest."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def get_manifests(self, mfstlist, dest, progtrack=None, pub=None):
+        """Get manifests named in list.  The mfstlist argument contains
+        tuples (fmri, header).  This is so that each manifest may have
+        unique header information.  The destination directory is spec-
+        ified in the dest argument."""
 
-        def get_manifests(self, mfstlist, dest, progtrack=None, pub=None):
-                """Get manifests named in list.  The mfstlist argument contains
-                tuples (fmri, header).  This is so that each manifest may have
-                unique header information.  The destination directory is spec-
-                ified in the dest argument."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def get_publisherinfo(self, header=None, ccancel=None):
+        """Get publisher configuration information from the
+        repository."""
 
-        def get_publisherinfo(self, header=None, ccancel=None):
-                """Get publisher configuration information from the
-                repository."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def get_status(self, header=None, ccancel=None):
+        """Get status from the repository."""
 
-        def get_status(self, header=None, ccancel=None):
-                """Get status from the repository."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def get_url(self):
+        """Return's the Repo's URL."""
 
-        def get_url(self):
-                """Return's the Repo's URL."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def get_repouri_key(self):
+        """Returns the repo's RepositoryURI."""
 
-        def get_repouri_key(self):
-                """Returns the repo's RepositoryURI."""
+        return NotImplementedError
 
-                return NotImplementedError
+    def get_versions(self, header=None, ccancel=None):
+        """Query the repo for versions information.
+        Returns a fileobject."""
 
-        def get_versions(self, header=None, ccancel=None):
-                """Query the repo for versions information.
-                Returns a fileobject."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def publish_add(self, action, header=None, progtrack=None, trans_id=None):
+        """The publish operation that adds content to a repository.
+        The action must be populated with a data property.
+        Callers may supply a header, and should supply a transaction
+        id in trans_id."""
 
-        def publish_add(self, action, header=None, progtrack=None,
-            trans_id=None):
-                """The publish operation that adds content to a repository.
-                The action must be populated with a data property.
-                Callers may supply a header, and should supply a transaction
-                id in trans_id."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def publish_add_file(
+        self, pth, header=None, trans_id=None, basename=None, progtrack=None
+    ):
+        raise NotImplementedError
 
-        def publish_add_file(self, pth, header=None, trans_id=None,
-            basename=None, progtrack=None):
-                raise NotImplementedError
+    def publish_add_manifest(self, pth, header=None, trans_id=None):
+        raise NotImplementedError
 
-        def publish_add_manifest(self, pth, header=None, trans_id=None):
-                raise NotImplementedError
+    def publish_abandon(self, header=None, trans_id=None):
+        """The 'abandon' publication operation, that tells a
+        Repository to abort the current transaction.  The caller
+        must specify the transaction id in trans_id. Returns
+        a (publish-state, fmri) tuple."""
 
-        def publish_abandon(self, header=None, trans_id=None):
-                """The 'abandon' publication operation, that tells a
-                Repository to abort the current transaction.  The caller
-                must specify the transaction id in trans_id. Returns
-                a (publish-state, fmri) tuple."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def publish_close(self, header=None, trans_id=None, add_to_catalog=False):
+        """The close operation tells the Repository to commit
+        the transaction identified by trans_id.  The caller may
+        specify add_to_catalog, if needed.  This method returns a
+        (publish-state, fmri) tuple."""
 
-        def publish_close(self, header=None, trans_id=None,
-            add_to_catalog=False):
-                """The close operation tells the Repository to commit
-                the transaction identified by trans_id.  The caller may
-                specify add_to_catalog, if needed.  This method returns a
-                (publish-state, fmri) tuple."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def publish_open(self, header=None, client_release=None, pkg_name=None):
+        """Begin a publication operation by calling 'open'.
+        The caller must specify the client's OS release in
+        client_release, and the package's name in pkg_name.
+        Returns a transaction-ID."""
 
-        def publish_open(self, header=None, client_release=None, pkg_name=None):
-                """Begin a publication operation by calling 'open'.
-                The caller must specify the client's OS release in
-                client_release, and the package's name in pkg_name.
-                Returns a transaction-ID."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def publish_rebuild(self, header=None, pub=None):
+        """Attempt to rebuild the package data and search data in the
+        repository."""
 
-        def publish_rebuild(self, header=None, pub=None):
-                """Attempt to rebuild the package data and search data in the
-                repository."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def publish_rebuild_indexes(self, header=None, pub=None):
+        """Attempt to rebuild the search data in the repository."""
 
-        def publish_rebuild_indexes(self, header=None, pub=None):
-                """Attempt to rebuild the search data in the repository."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def publish_rebuild_packages(self, header=None, pub=None):
+        """Attempt to rebuild the package data in the repository."""
 
-        def publish_rebuild_packages(self, header=None, pub=None):
-                """Attempt to rebuild the package data in the repository."""
-
-                raise NotImplementedError
+        raise NotImplementedError
 
-        def publish_refresh(self, header=None, pub=None):
-                """Attempt to refresh the package data and search data in the
-                repository."""
+    def publish_refresh(self, header=None, pub=None):
+        """Attempt to refresh the package data and search data in the
+        repository."""
 
-                raise NotImplementedError
-
-        def publish_refresh_indexes(self, header=None, pub=None):
-                """Attempt to refresh the search data in the repository."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def publish_refresh_indexes(self, header=None, pub=None):
+        """Attempt to refresh the search data in the repository."""
 
-        def publish_refresh_packages(self, header=None, pub=None):
-                """Attempt to refresh the package data in the repository."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def publish_refresh_packages(self, header=None, pub=None):
+        """Attempt to refresh the package data in the repository."""
 
-        def touch_manifest(self, fmri, header=None, ccancel=None, pub=None):
-                """Send data about operation intent without actually
-                downloading a manifest."""
+        raise NotImplementedError
 
-                raise NotImplementedError
+    def touch_manifest(self, fmri, header=None, ccancel=None, pub=None):
+        """Send data about operation intent without actually
+        downloading a manifest."""
 
-        def get_compressed_attrs(self, fhash, header=None, pub=None,
-            trans_id=None, hashes=True):
-                """Given a fhash, returns a tuple of (csize, chashes) where
-                'csize' is the size of the file in the repository and 'chashes'
-                is a dictionary containing any hashes of the compressed data
-                known by the repository.  If the repository cannot provide the
-                hash information or 'hashes' is False, chashes will be an empty
-                dictionary.  If the repository does not have the file, a tuple
-                of (None, None) will be returned instead."""
+        raise NotImplementedError
+
+    def get_compressed_attrs(
+        self, fhash, header=None, pub=None, trans_id=None, hashes=True
+    ):
+        """Given a fhash, returns a tuple of (csize, chashes) where
+        'csize' is the size of the file in the repository and 'chashes'
+        is a dictionary containing any hashes of the compressed data
+        known by the repository.  If the repository cannot provide the
+        hash information or 'hashes' is False, chashes will be an empty
+        dictionary.  If the repository does not have the file, a tuple
+        of (None, None) will be returned instead."""
 
-                raise NotImplementedError
+        raise NotImplementedError
 
-        def build_refetch_header(self, header):
-                """Based on existing header contents, build a header that
-                should be used for a subsequent retry when fetching content
-                from the repository."""
+    def build_refetch_header(self, header):
+        """Based on existing header contents, build a header that
+        should be used for a subsequent retry when fetching content
+        from the repository."""
 
-                raise NotImplementedError
+        raise NotImplementedError
 
-        @staticmethod
-        def _annotate_exceptions(errors, mapping=None):
-                """Walk a list of transport errors, examine the
-                url, and add a field that names the request.  This request
-                information is derived from the URL."""
+    @staticmethod
+    def _annotate_exceptions(errors, mapping=None):
+        """Walk a list of transport errors, examine the
+        url, and add a field that names the request.  This request
+        information is derived from the URL."""
 
-                for e in errors:
-                        if not e.url:
-                                # Error may have been raised before request path
-                                # was determined; nothing to annotate.
-                                continue
+        for e in errors:
+            if not e.url:
+                # Error may have been raised before request path
+                # was determined; nothing to annotate.
+                continue
 
-                        if not mapping:
-                                # Request is basename of path portion of URI.
-                                e.request = os.path.basename(urlsplit(
-                                    e.url)[2])
-                                continue
+            if not mapping:
+                # Request is basename of path portion of URI.
+                e.request = os.path.basename(urlsplit(e.url)[2])
+                continue
 
-                        # If caller specified a mapping object, use that
-                        # instead of trying to deduce the request's name.
-                        if e.url not in mapping:
-                                raise tx.TransportOperationError(
-                                    "No mapping found for URL {0}".format(
-                                    e.url))
+            # If caller specified a mapping object, use that
+            # instead of trying to deduce the request's name.
+            if e.url not in mapping:
+                raise tx.TransportOperationError(
+                    "No mapping found for URL {0}".format(e.url)
+                )
 
-                        e.request = mapping[e.url]
+            e.request = mapping[e.url]
 
-                return errors
+        return errors
 
-        @staticmethod
-        def _parse_html_error(content):
-                """Parse a html document that contains error information.
-                Return the html as a plain text string."""
+    @staticmethod
+    def _parse_html_error(content):
+        """Parse a html document that contains error information.
+        Return the html as a plain text string."""
 
-                msg = None
-                if not content:
-                        return msg
+        msg = None
+        if not content:
+            return msg
 
-                from xml.dom.minidom import Document, parse
-                dom = parse(cStringIO(content))
-                msg = ""
+        from xml.dom.minidom import Document, parse
 
-                paragraphs = []
-                if not isinstance(dom, Document):
-                        # Assume the output was the message.
-                        msg = content
-                else:
-                        paragraphs = dom.getElementsByTagName("p")
+        dom = parse(cStringIO(content))
+        msg = ""
 
-                # XXX this is specific to the depot server's current
-                # error output style.
-                for p in paragraphs:
-                        for c in p.childNodes:
-                                if c.nodeType == c.TEXT_NODE:
-                                        value = c.nodeValue
-                                        if value is not None:
-                                                msg += ("\n{0}".format(value))
+        paragraphs = []
+        if not isinstance(dom, Document):
+            # Assume the output was the message.
+            msg = content
+        else:
+            paragraphs = dom.getElementsByTagName("p")
 
-                return msg
+        # XXX this is specific to the depot server's current
+        # error output style.
+        for p in paragraphs:
+            for c in p.childNodes:
+                if c.nodeType == c.TEXT_NODE:
+                    value = c.nodeValue
+                    if value is not None:
+                        msg += "\n{0}".format(value)
 
-        @staticmethod
-        def _url_to_request(urllist, mapping=None):
-                """Take a list of urls and remove the protocol information,
-                leaving just the information about the request."""
+        return msg
 
-                reqlist = []
+    @staticmethod
+    def _url_to_request(urllist, mapping=None):
+        """Take a list of urls and remove the protocol information,
+        leaving just the information about the request."""
 
-                for u in urllist:
+        reqlist = []
 
-                        if not mapping:
-                                utup = urlsplit(u)
-                                req = utup[2]
-                                req = os.path.basename(req)
-                                reqlist.append(req)
-                                continue
+        for u in urllist:
+            if not mapping:
+                utup = urlsplit(u)
+                req = utup[2]
+                req = os.path.basename(req)
+                reqlist.append(req)
+                continue
 
-                        if u not in mapping:
-                                raise tx.TransportOperationError(
-                                    "No mapping found for URL {0}".format(u))
+            if u not in mapping:
+                raise tx.TransportOperationError(
+                    "No mapping found for URL {0}".format(u)
+                )
 
-                        req = mapping[u]
-                        reqlist.append(req)
+            req = mapping[u]
+            reqlist.append(req)
 
-                return reqlist
+        return reqlist
 
-        @staticmethod
-        def _analyze_server_error(error_header):
-                """ Decode the X-Ipkg-Error header which is appended by the
-                module doing entitlement checks on the server side. Let the user
-                know why they can't access the repository. """
+    @staticmethod
+    def _analyze_server_error(error_header):
+        """Decode the X-Ipkg-Error header which is appended by the
+        module doing entitlement checks on the server side. Let the user
+        know why they can't access the repository."""
 
-                ENTITLEMENT_ERROR = "ENT"
-                LICENSE_ERROR = "LIC"
-                SERVER_ERROR = "SVR"
-                MAINTENANCE = "MNT"
+        ENTITLEMENT_ERROR = "ENT"
+        LICENSE_ERROR = "LIC"
+        SERVER_ERROR = "SVR"
+        MAINTENANCE = "MNT"
 
-                entitlement_err_msg = N_("""
+        entitlement_err_msg = N_(
+            """
 This account is not entitled to access this repository. Ensure that the correct
 certificate is being used and that the support contract for the product being
 accessed is still valid.
-""")
+"""
+        )
 
-                license_err_msg = N_("""
+        license_err_msg = N_(
+            """
 The license agreement required to access this repository has not been
 accepted yet or the license agreement for the product has changed. Please go to
 https://pkg-register.oracle.com and accept the license for the product you are
 trying to access.
-""")
+"""
+        )
 
-                server_err_msg = N_("""
+        server_err_msg = N_(
+            """
 Repository access is currently unavailable due to service issues. Please retry
 later or contact your customer service representative.
-""")
+"""
+        )
 
-                maintenance_msg = N_("""
+        maintenance_msg = N_(
+            """
 Repository access rights can currently not be verified due to server
 maintenance. Please retry later.
-""")
-                msg = ""
+"""
+        )
+        msg = ""
 
-                # multiple errors possible (e.g. license and entitlement not ok)
-                error_codes = error_header.split(",")
+        # multiple errors possible (e.g. license and entitlement not ok)
+        error_codes = error_header.split(",")
 
-                for e in error_codes:
-                        code = e.strip().upper()
+        for e in error_codes:
+            code = e.strip().upper()
 
-                        if code == ENTITLEMENT_ERROR:
-                                 msg += _(entitlement_err_msg)
-                        elif code == LICENSE_ERROR:
-                                msg += _(license_err_msg)
-                        elif code == SERVER_ERROR:
-                                msg += _(server_err_msg)
-                        elif code == MAINTENANCE:
-                                msg += _(maintenance_msg)
+            if code == ENTITLEMENT_ERROR:
+                msg += _(entitlement_err_msg)
+            elif code == LICENSE_ERROR:
+                msg += _(license_err_msg)
+            elif code == SERVER_ERROR:
+                msg += _(server_err_msg)
+            elif code == MAINTENANCE:
+                msg += _(maintenance_msg)
 
-                if msg == "":
-                        return None
+        if msg == "":
+            return None
 
-                return msg
+        return msg
 
 
 class HTTPRepo(TransportRepo):
+    def __init__(self, repostats, repouri, engine):
+        """Create a http repo.  Repostats is a RepoStats object.
+        Repouri is a TransportRepoURI object.  Engine is a transport
+        engine object.
 
-        def __init__(self, repostats, repouri, engine):
-                """Create a http repo.  Repostats is a RepoStats object.
-                Repouri is a TransportRepoURI object.  Engine is a transport
-                engine object.
+        The convenience function new_repo() can be used to create
+        the correct repo."""
+        self._url = repostats.url
+        self._repouri = repouri
+        self._engine = engine
+        self._verdata = None
 
-                The convenience function new_repo() can be used to create
-                the correct repo."""
-                self._url = repostats.url
-                self._repouri = repouri
-                self._engine = engine
-                self._verdata = None
+    def __str__(self):
+        return "HTTPRepo url: {0} repouri: {1}".format(self._url, self._repouri)
 
-        def __str__(self):
-                return "HTTPRepo url: {0} repouri: {1}".format(self._url,
-                    self._repouri)
+    def _add_file_url(
+        self,
+        url,
+        filepath=None,
+        progclass=None,
+        progtrack=None,
+        header=None,
+        compress=False,
+    ):
+        self._engine.add_url(
+            url,
+            filepath=filepath,
+            progclass=progclass,
+            progtrack=progtrack,
+            repourl=self._url,
+            header=header,
+            compressible=compress,
+            runtime_proxy=self._repouri.runtime_proxy,
+            proxy=self._repouri.proxy,
+        )
 
-        def _add_file_url(self, url, filepath=None, progclass=None,
-            progtrack=None, header=None, compress=False):
-                self._engine.add_url(url, filepath=filepath,
-                    progclass=progclass, progtrack=progtrack, repourl=self._url,
-                    header=header, compressible=compress,
-                    runtime_proxy=self._repouri.runtime_proxy,
-                    proxy=self._repouri.proxy)
+    def _fetch_url(
+        self,
+        url,
+        header=None,
+        compress=False,
+        ccancel=None,
+        failonerror=True,
+        system=False,
+    ):
+        return self._engine.get_url(
+            url,
+            header,
+            repourl=self._url,
+            compressible=compress,
+            ccancel=ccancel,
+            failonerror=failonerror,
+            runtime_proxy=self._repouri.runtime_proxy,
+            proxy=self._repouri.proxy,
+            system=system,
+        )
 
-        def _fetch_url(self, url, header=None, compress=False, ccancel=None,
-            failonerror=True, system=False):
-                return self._engine.get_url(url, header, repourl=self._url,
-                    compressible=compress, ccancel=ccancel,
-                    failonerror=failonerror,
-                    runtime_proxy=self._repouri.runtime_proxy,
-                    proxy=self._repouri.proxy, system=system)
+    def _fetch_url_header(
+        self, url, header=None, ccancel=None, failonerror=True
+    ):
+        return self._engine.get_url_header(
+            url,
+            header,
+            repourl=self._url,
+            ccancel=ccancel,
+            failonerror=failonerror,
+            runtime_proxy=self._repouri.runtime_proxy,
+            proxy=self._repouri.proxy,
+        )
 
-        def _fetch_url_header(self, url, header=None, ccancel=None,
-            failonerror=True):
-                return self._engine.get_url_header(url, header,
-                    repourl=self._url, ccancel=ccancel,
-                    failonerror=failonerror,
-                    runtime_proxy=self._repouri.runtime_proxy,
-                    proxy=self._repouri.proxy)
+    def _post_url(
+        self,
+        url,
+        data=None,
+        header=None,
+        ccancel=None,
+        data_fobj=None,
+        data_fp=None,
+        failonerror=True,
+        progclass=None,
+        progtrack=None,
+    ):
+        return self._engine.send_data(
+            url,
+            data=data,
+            header=header,
+            repourl=self._url,
+            ccancel=ccancel,
+            data_fobj=data_fobj,
+            data_fp=data_fp,
+            failonerror=failonerror,
+            progclass=progclass,
+            progtrack=progtrack,
+            runtime_proxy=self._repouri.runtime_proxy,
+            proxy=self._repouri.proxy,
+        )
 
-        def _post_url(self, url, data=None, header=None, ccancel=None,
-            data_fobj=None, data_fp=None, failonerror=True, progclass=None,
-            progtrack=None):
-                return self._engine.send_data(url, data=data, header=header,
-                    repourl=self._url, ccancel=ccancel,
-                    data_fobj=data_fobj, data_fp=data_fp,
-                    failonerror=failonerror, progclass=progclass,
-                    progtrack=progtrack,
-                    runtime_proxy=self._repouri.runtime_proxy,
-                    proxy=self._repouri.proxy)
+    def __check_response_body(self, fobj):
+        """Parse the response body found accessible using the provided
+        filestream object and raise an exception if appropriate."""
 
-        def __check_response_body(self, fobj):
-                """Parse the response body found accessible using the provided
-                filestream object and raise an exception if appropriate."""
-
+        try:
+            fobj.free_buffer = False
+            fobj.read()
+        except tx.TransportProtoError as e:
+            if e.code == http_client.BAD_REQUEST:
+                exc_type, exc_value, exc_tb = sys.exc_info()
                 try:
-                        fobj.free_buffer = False
-                        fobj.read()
-                except tx.TransportProtoError as e:
-                        if e.code == http_client.BAD_REQUEST:
-                                exc_type, exc_value, exc_tb = sys.exc_info()
-                                try:
-                                        e.details = self._parse_html_error(
-                                            fobj.read())
-                                # six.reraise requires the first argument
-                                # callable if the second argument is None.
-                                # Also the traceback is automatically attached,
-                                # in Python 3, so we can simply raise it.
-                                except:
-                                        # If parse fails, raise original
-                                        # exception.
-                                        if six.PY2:
-                                                six.reraise(exc_value, None,
-                                                    exc_tb)
-                                        else:
-                                                raise exc_value
-                        raise
-                finally:
-                        fobj.close()
+                    e.details = self._parse_html_error(fobj.read())
+                # six.reraise requires the first argument
+                # callable if the second argument is None.
+                # Also the traceback is automatically attached,
+                # in Python 3, so we can simply raise it.
+                except:
+                    # If parse fails, raise original
+                    # exception.
+                    if six.PY2:
+                        six.reraise(exc_value, None, exc_tb)
+                    else:
+                        raise exc_value
+            raise
+        finally:
+            fobj.close()
 
-        def add_version_data(self, verdict):
-                """Cache the information about what versions a repository
-                supports."""
+    def add_version_data(self, verdict):
+        """Cache the information about what versions a repository
+        supports."""
 
-                self._verdata = verdict
+        self._verdata = verdict
 
-        def __get_request_url(self, methodstr, query=None, pub=None):
-                """Generate the request URL for the given method and
-                publisher.
-                """
+    def __get_request_url(self, methodstr, query=None, pub=None):
+        """Generate the request URL for the given method and
+        publisher.
+        """
 
-                base = self._repouri.uri
+        base = self._repouri.uri
 
-                # Only append the publisher prefix if the publisher of the
-                # request is known, not already part of the URI, if this isn't
-                # an open operation, and if the repository supports version 1
-                # of the publisher operation.  The prefix shouldn't be appended
-                # for open because the publisher may not yet be known to the
-                # repository, and not in other cases because the repository
-                # doesn't support it.
-                pub_prefix = getattr(pub, "prefix", None)
-                if pub_prefix and not methodstr.startswith("open/") and \
-                    not base.endswith("/{0}/".format(pub_prefix)) and \
-                    self.supports_version("publisher", [1]) > -1:
-                        # Append the publisher prefix to the repository URL.
-                        base = urljoin(base, pub_prefix) + "/"
+        # Only append the publisher prefix if the publisher of the
+        # request is known, not already part of the URI, if this isn't
+        # an open operation, and if the repository supports version 1
+        # of the publisher operation.  The prefix shouldn't be appended
+        # for open because the publisher may not yet be known to the
+        # repository, and not in other cases because the repository
+        # doesn't support it.
+        pub_prefix = getattr(pub, "prefix", None)
+        if (
+            pub_prefix
+            and not methodstr.startswith("open/")
+            and not base.endswith("/{0}/".format(pub_prefix))
+            and self.supports_version("publisher", [1]) > -1
+        ):
+            # Append the publisher prefix to the repository URL.
+            base = urljoin(base, pub_prefix) + "/"
 
-                uri = urljoin(base, methodstr)
-                if not query:
-                        return uri
+        uri = urljoin(base, methodstr)
+        if not query:
+            return uri
 
-                # If a set of query data was provided, then decompose the URI
-                # into its component parts and replace the query portion with
-                # the encoded version of the new query data.
-                components = list(urlparse(uri))
-                components[4] = urlencode(query)
-                return urlunparse(components)
+        # If a set of query data was provided, then decompose the URI
+        # into its component parts and replace the query portion with
+        # the encoded version of the new query data.
+        components = list(urlparse(uri))
+        components[4] = urlencode(query)
+        return urlunparse(components)
 
-        def do_search(self, data, header=None, ccancel=None, pub=None):
-                """Perform a remote search against origin repos."""
+    def do_search(self, data, header=None, ccancel=None, pub=None):
+        """Perform a remote search against origin repos."""
 
-                requesturl = self.__get_request_url("search/1/", pub=pub)
-                if len(data) > 1:
-                        # Post and retrieve.
-                        request_data = urlencode(
-                            [(i, str(q)) for i, q in enumerate(data)])
-                        return self._post_url(requesturl, request_data,
-                            header, ccancel=ccancel)
+        requesturl = self.__get_request_url("search/1/", pub=pub)
+        if len(data) > 1:
+            # Post and retrieve.
+            request_data = urlencode([(i, str(q)) for i, q in enumerate(data)])
+            return self._post_url(
+                requesturl, request_data, header, ccancel=ccancel
+            )
 
-                # Retrieval only.
-                requesturl = urljoin(requesturl, quote(
-                    str(data[0]), safe=''))
-                return self._fetch_url(requesturl, header, ccancel=ccancel)
+        # Retrieval only.
+        requesturl = urljoin(requesturl, quote(str(data[0]), safe=""))
+        return self._fetch_url(requesturl, header, ccancel=ccancel)
 
-        def get_catalog(self, ts=None, header=None, ccancel=None, pub=None):
-                """Get the catalog from the repo.  If ts is defined,
-                request only changes newer than timestamp ts."""
+    def get_catalog(self, ts=None, header=None, ccancel=None, pub=None):
+        """Get the catalog from the repo.  If ts is defined,
+        request only changes newer than timestamp ts."""
 
-                requesturl = self.__get_request_url("catalog/0/", pub=pub)
-                if ts:
-                        if not header:
-                                header = {"If-Modified-Since": ts}
-                        else:
-                                header["If-Modified-Since"] = ts
+        requesturl = self.__get_request_url("catalog/0/", pub=pub)
+        if ts:
+            if not header:
+                header = {"If-Modified-Since": ts}
+            else:
+                header["If-Modified-Since"] = ts
 
-                return self._fetch_url(requesturl, header, compress=True,
-                    ccancel=ccancel)
+        return self._fetch_url(
+            requesturl, header, compress=True, ccancel=ccancel
+        )
 
-        def get_catalog1(self, filelist, destloc, header=None, ts=None,
-            progtrack=None, pub=None, revalidate=False, redownload=False):
-                """Get the files that make up the catalog components
-                that are listed in 'filelist'.  Download the files to
-                the directory specified in 'destloc'.  The caller
-                may optionally specify a dictionary with header
-                elements in 'header'.  If a conditional get is
-                to be performed, 'ts' should contain a floating point
-                value of seconds since the epoch.
+    def get_catalog1(
+        self,
+        filelist,
+        destloc,
+        header=None,
+        ts=None,
+        progtrack=None,
+        pub=None,
+        revalidate=False,
+        redownload=False,
+    ):
+        """Get the files that make up the catalog components
+        that are listed in 'filelist'.  Download the files to
+        the directory specified in 'destloc'.  The caller
+        may optionally specify a dictionary with header
+        elements in 'header'.  If a conditional get is
+        to be performed, 'ts' should contain a floating point
+        value of seconds since the epoch.
 
-                If 'redownload' or 'revalidate' is set, cache control
-                headers are appended to the request.  Re-download
-                uses http's no-cache header, while revalidate uses
-                max-age=0."""
+        If 'redownload' or 'revalidate' is set, cache control
+        headers are appended to the request.  Re-download
+        uses http's no-cache header, while revalidate uses
+        max-age=0."""
 
-                baseurl = self.__get_request_url("catalog/1/", pub=pub)
-                urllist = []
-                progclass = None
-                headers = {}
+        baseurl = self.__get_request_url("catalog/1/", pub=pub)
+        urllist = []
+        progclass = None
+        headers = {}
 
-                if redownload and revalidate:
-                        raise ValueError("Either revalidate or redownload"
-                            " may be used, but not both.")
-                if ts:
-                        # Convert date to RFC 1123 compliant string
-                        tsstr = formatdate(timeval=ts, localtime=False,
-                            usegmt=True)
-                        headers["If-Modified-Since"] = tsstr
-                if revalidate:
-                        headers["Cache-Control"] = "max-age=0"
-                if redownload:
-                        headers["Cache-Control"] = "no-cache"
-                        headers["Pragma"] = "no-cache"
-                if header:
-                        headers.update(header)
-                if progtrack:
-                        progclass = CatalogProgress
+        if redownload and revalidate:
+            raise ValueError(
+                "Either revalidate or redownload" " may be used, but not both."
+            )
+        if ts:
+            # Convert date to RFC 1123 compliant string
+            tsstr = formatdate(timeval=ts, localtime=False, usegmt=True)
+            headers["If-Modified-Since"] = tsstr
+        if revalidate:
+            headers["Cache-Control"] = "max-age=0"
+        if redownload:
+            headers["Cache-Control"] = "no-cache"
+            headers["Pragma"] = "no-cache"
+        if header:
+            headers.update(header)
+        if progtrack:
+            progclass = CatalogProgress
 
-                for f in filelist:
-                        url = urljoin(baseurl, f)
-                        urllist.append(url)
-                        fn = os.path.join(destloc, f)
-                        self._add_file_url(url, filepath=fn, header=headers,
-                            compress=True, progtrack=progtrack,
-                            progclass=progclass)
+        for f in filelist:
+            url = urljoin(baseurl, f)
+            urllist.append(url)
+            fn = os.path.join(destloc, f)
+            self._add_file_url(
+                url,
+                filepath=fn,
+                header=headers,
+                compress=True,
+                progtrack=progtrack,
+                progclass=progclass,
+            )
 
+        try:
+            while self._engine.pending:
+                self._engine.run()
+        except tx.ExcessiveTransientFailure as e:
+            # Attach a list of failed and successful
+            # requests to this exception.
+            errors, success = self._engine.check_status(urllist, True)
+
+            errors = self._annotate_exceptions(errors)
+            success = self._url_to_request(success)
+            e.failures = errors
+            e.success = success
+
+            # Reset the engine before propagating exception.
+            self._engine.reset()
+            raise
+
+        errors = self._engine.check_status(urllist)
+
+        # Transient errors are part of standard control flow.
+        # The repo's caller will look at these and decide whether
+        # to throw them or not.  Permanent failures are raised
+        # by the transport engine as soon as they occur.
+        #
+        # This adds an attribute that describes the request to the
+        # exception, if we were able to figure it out.
+
+        return self._annotate_exceptions(errors)
+
+    def get_datastream(
+        self, fhash, version, header=None, ccancel=None, pub=None
+    ):
+        """Get a datastream from a repo.  The name of the
+        file is given in fhash."""
+
+        # The only versions this operation is compatible with.
+        assert version == 0 or version == 1
+
+        baseurl = self.__get_request_url("file/{0}/".format(version), pub=pub)
+        requesturl = urljoin(baseurl, fhash)
+        return self._fetch_url(requesturl, header, ccancel=ccancel)
+
+    def get_publisherinfo(self, header=None, ccancel=None):
+        """Get publisher information from the repository."""
+
+        requesturl = self.__get_request_url("publisher/0/")
+        return self._fetch_url(requesturl, header, ccancel=ccancel)
+
+    def get_syspub_info(self, header=None, ccancel=None):
+        """Get configuration from the system depot."""
+
+        requesturl = self.__get_request_url("syspub/0/")
+        # We set 'system=True' to cause the transport to override any
+        # $http_proxy environment variables. Syspub origins/mirrors
+        # that are normally proxied through the system-repository will
+        # have a proxy attached to their RepositoryURI, and the
+        # corresponding TransportRepoURI runtime_proxy value will be set
+        # to the same value, so we don't need to pass the 'system'
+        # kwarg in those cases.
+        return self._fetch_url(requesturl, header, ccancel=ccancel, system=True)
+
+    def get_status(self, header=None, ccancel=None):
+        """Get status/0 information from the repository."""
+
+        requesturl = self.__get_request_url("status/0")
+        return self._fetch_url(requesturl, header, ccancel=ccancel)
+
+    def get_manifest(self, fmri, header=None, ccancel=None, pub=None):
+        """Get a package manifest from repo.  The FMRI of the
+        package is given in fmri."""
+
+        mfst = fmri.get_url_path()
+        baseurl = self.__get_request_url("manifest/0/", pub=pub)
+        requesturl = urljoin(baseurl, mfst)
+
+        return self._fetch_url(
+            requesturl, header, compress=True, ccancel=ccancel
+        )
+
+    def get_manifests(self, mfstlist, dest, progtrack=None, pub=None):
+        """Get manifests named in list.  The mfstlist argument contains
+        tuples (fmri, header).  This is so that each manifest may have
+        unique header information.  The destination directory is spec-
+        ified in the dest argument."""
+
+        baseurl = self.__get_request_url("manifest/0/", pub=pub)
+        urlmapping = {}
+        progclass = None
+
+        if progtrack:
+            progclass = ManifestProgress
+
+        for fmri, h in mfstlist:
+            f = fmri.get_url_path()
+            url = urljoin(baseurl, f)
+            urlmapping[url] = fmri
+            fn = os.path.join(dest, f)
+            self._add_file_url(
+                url,
+                filepath=fn,
+                header=h,
+                compress=True,
+                progtrack=progtrack,
+                progclass=progclass,
+            )
+
+        # Compute urllist from keys in mapping
+        urllist = urlmapping.keys()
+
+        try:
+            while self._engine.pending:
+                self._engine.run()
+        except tx.ExcessiveTransientFailure as e:
+            # Attach a list of failed and successful
+            # requests to this exception.
+            errors, success = self._engine.check_status(urllist, True)
+
+            errors = self._annotate_exceptions(errors, urlmapping)
+            success = self._url_to_request(success, urlmapping)
+            e.failures = errors
+            e.success = success
+
+            # Reset the engine before propagating exception.
+            self._engine.reset()
+            raise
+
+        errors = self._engine.check_status(urllist)
+
+        # Transient errors are part of standard control flow.
+        # The repo's caller will look at these and decide whether
+        # to throw them or not.  Permanent failures are raised
+        # by the transport engine as soon as they occur.
+        #
+        # This adds an attribute that describes the request to the
+        # exception, if we were able to figure it out.
+
+        return self._annotate_exceptions(errors, urlmapping)
+
+    def get_files(
+        self, filelist, dest, progtrack, version, header=None, pub=None
+    ):
+        """Get multiple files from the repo at once.
+        The files are named by hash and supplied in filelist.
+        If dest is specified, download to the destination
+        directory that is given.  If progtrack is not None,
+        it contains a ProgressTracker object for the
+        downloads."""
+
+        baseurl = self.__get_request_url("file/{0}/".format(version), pub=pub)
+        urllist = []
+        progclass = None
+
+        if progtrack:
+            progclass = FileProgress
+
+        for f in filelist:
+            url = urljoin(baseurl, f)
+            urllist.append(url)
+            fn = os.path.join(dest, f)
+            self._add_file_url(
+                url,
+                filepath=fn,
+                progclass=progclass,
+                progtrack=progtrack,
+                header=header,
+            )
+
+        try:
+            while self._engine.pending:
+                self._engine.run()
+        except tx.ExcessiveTransientFailure as e:
+            # Attach a list of failed and successful
+            # requests to this exception.
+            errors, success = self._engine.check_status(urllist, True)
+
+            errors = self._annotate_exceptions(errors)
+            success = self._url_to_request(success)
+            e.failures = errors
+            e.success = success
+
+            # Reset the engine before propagating exception.
+            self._engine.reset()
+            raise
+
+        errors = self._engine.check_status(urllist)
+
+        # Transient errors are part of standard control flow.
+        # The repo's caller will look at these and decide whether
+        # to throw them or not.  Permanent failures are raised
+        # by the transport engine as soon as they occur.
+        #
+        # This adds an attribute that describes the request to the
+        # exception, if we were able to figure it out.
+
+        return self._annotate_exceptions(errors)
+
+    def get_url(self):
+        """Returns the repo's url."""
+
+        return self._url
+
+    def get_repouri_key(self):
+        """Returns the repo's TransportRepoURI key, used to uniquely
+        identify this TransportRepoURI."""
+
+        return self._repouri.key()
+
+    def get_versions(self, header=None, ccancel=None):
+        """Query the repo for versions information.
+        Returns a fileobject. If server returns 401 (Unauthorized)
+        check for presence of X-IPkg-Error header and decode."""
+
+        requesturl = self.__get_request_url("versions/0/")
+        fobj = self._fetch_url(
+            requesturl, header, ccancel=ccancel, failonerror=False
+        )
+
+        try:
+            # Bogus request to trigger
+            # StreamingFileObj.__fill_buffer(), otherwise the
+            # TransportProtoError won't be raised here. We can't
+            # use .read() since this will empty the data buffer.
+            fobj.getheader("octopus", None)
+        except tx.TransportProtoError as e:
+            if e.code == http_client.UNAUTHORIZED:
+                exc_type, exc_value, exc_tb = sys.exc_info()
                 try:
-                        while self._engine.pending:
-                                self._engine.run()
-                except tx.ExcessiveTransientFailure as e:
-                        # Attach a list of failed and successful
-                        # requests to this exception.
-                        errors, success = self._engine.check_status(urllist,
-                            True)
+                    e.details = self._analyze_server_error(
+                        fobj.getheader("X-IPkg-Error", None)
+                    )
+                except:
+                    # If analysis fails, raise original
+                    # exception.
+                    if six.PY2:
+                        six.reraise(exc_value, None, exc_tb)
+                    else:
+                        raise exc_value
+            raise
+        return fobj
 
-                        errors = self._annotate_exceptions(errors)
-                        success = self._url_to_request(success)
-                        e.failures = errors
-                        e.success = success
+    def has_version_data(self):
+        """Returns true if this repo knows its version information."""
 
-                        # Reset the engine before propagating exception.
-                        self._engine.reset()
-                        raise
+        return self._verdata is not None
 
-                errors = self._engine.check_status(urllist)
+    def publish_add(self, action, header=None, progtrack=None, trans_id=None):
+        """The publish operation that adds content to a repository.
+        The action must be populated with a data property.
+        Callers may supply a header, and should supply a transaction
+        id in trans_id."""
 
-                # Transient errors are part of standard control flow.
-                # The repo's caller will look at these and decide whether
-                # to throw them or not.  Permanent failures are raised
-                # by the transport engine as soon as they occur.
-                #
-                # This adds an attribute that describes the request to the
-                # exception, if we were able to figure it out.
+        attrs = action.attrs
+        data_fobj = None
+        data = None
+        progclass = None
 
-                return self._annotate_exceptions(errors)
+        if progtrack:
+            progclass = FileProgress
 
-        def get_datastream(self, fhash, version, header=None, ccancel=None,
-            pub=None):
-                """Get a datastream from a repo.  The name of the
-                file is given in fhash."""
+        baseurl = self.__get_request_url("add/0/")
+        request_str = "{0}/{1}".format(trans_id, action.name)
+        requesturl = urljoin(baseurl, request_str)
 
-                # The only versions this operation is compatible with.
-                assert version == 0 or version == 1
+        if action.data:
+            data_fobj = action.data()
+        else:
+            data = ""
 
-                baseurl = self.__get_request_url("file/{0}/".format(version),
-                    pub=pub)
-                requesturl = urljoin(baseurl, fhash)
-                return self._fetch_url(requesturl, header, ccancel=ccancel)
+        headers = dict(
+            ("X-IPkg-SetAttr{0}".format(i), "{0}={1}".format(k, attrs[k]))
+            for i, k in enumerate(attrs)
+        )
 
-        def get_publisherinfo(self, header=None, ccancel=None):
-                """Get publisher information from the repository."""
+        if header:
+            headers.update(header)
 
-                requesturl = self.__get_request_url("publisher/0/")
-                return self._fetch_url(requesturl, header, ccancel=ccancel)
+        fobj = self._post_url(
+            requesturl,
+            header=headers,
+            data_fobj=data_fobj,
+            data=data,
+            failonerror=False,
+            progclass=progclass,
+            progtrack=progtrack,
+        )
+        self.__check_response_body(fobj)
 
-        def get_syspub_info(self, header=None, ccancel=None):
-                """Get configuration from the system depot."""
+    def publish_add_file(
+        self, pth, header=None, trans_id=None, basename=None, progtrack=None
+    ):
+        """The publish operation that adds content to a repository.
+        Callers may supply a header, and should supply a transaction
+        id in trans_id."""
 
-                requesturl = self.__get_request_url("syspub/0/")
-                # We set 'system=True' to cause the transport to override any
-                # $http_proxy environment variables. Syspub origins/mirrors
-                # that are normally proxied through the system-repository will
-                # have a proxy attached to their RepositoryURI, and the
-                # corresponding TransportRepoURI runtime_proxy value will be set
-                # to the same value, so we don't need to pass the 'system'
-                # kwarg in those cases.
-                return self._fetch_url(requesturl, header, ccancel=ccancel,
-                    system=True)
+        attrs = {}
+        progclass = None
 
-        def get_status(self, header=None, ccancel=None):
-                """Get status/0 information from the repository."""
+        if progtrack:
+            progclass = FileProgress
 
-                requesturl = self.__get_request_url("status/0")
-                return self._fetch_url(requesturl, header, ccancel=ccancel)
+        if basename:
+            attrs["basename"] = basename
 
-        def get_manifest(self, fmri, header=None, ccancel=None, pub=None):
-                """Get a package manifest from repo.  The FMRI of the
-                package is given in fmri."""
+        baseurl = self.__get_request_url("file/1/")
+        requesturl = urljoin(baseurl, trans_id)
 
-                mfst = fmri.get_url_path()
-                baseurl = self.__get_request_url("manifest/0/", pub=pub)
-                requesturl = urljoin(baseurl, mfst)
+        headers = dict(
+            ("X-IPkg-SetAttr{0}".format(i), "{0}={1}".format(k, attrs[k]))
+            for i, k in enumerate(attrs)
+        )
 
-                return self._fetch_url(requesturl, header, compress=True,
-                    ccancel=ccancel)
+        if header:
+            headers.update(header)
 
-        def get_manifests(self, mfstlist, dest, progtrack=None, pub=None):
-                """Get manifests named in list.  The mfstlist argument contains
-                tuples (fmri, header).  This is so that each manifest may have
-                unique header information.  The destination directory is spec-
-                ified in the dest argument."""
+        fobj = self._post_url(
+            requesturl,
+            header=headers,
+            data_fp=pth,
+            progclass=progclass,
+            progtrack=progtrack,
+        )
+        self.__check_response_body(fobj)
 
-                baseurl = self.__get_request_url("manifest/0/", pub=pub)
-                urlmapping = {}
-                progclass = None
+    def publish_add_manifest(self, pth, header=None, trans_id=None):
+        """The publish operation that adds content to a repository.
+        Callers may supply a header, and should supply a transaction
+        id in trans_id."""
 
-                if progtrack:
-                        progclass = ManifestProgress
+        baseurl = self.__get_request_url("manifest/1/")
+        requesturl = urljoin(baseurl, trans_id)
+        # Compress the manifest for the HTTPRepo case.
+        size = int(os.path.getsize(pth))
+        with open(pth, "rb") as f:
+            data = f.read()
+        basename = os.path.basename(pth) + ".gz"
+        dirname = os.path.dirname(pth)
+        pathname = os.path.join(dirname, basename)
+        compute_compressed_attrs(
+            basename, data=data, size=size, compress_dir=dirname
+        )
 
-                for fmri, h in mfstlist:
-                        f = fmri.get_url_path()
-                        url = urljoin(baseurl, f)
-                        urlmapping[url] = fmri
-                        fn = os.path.join(dest, f)
-                        self._add_file_url(url, filepath=fn, header=h,
-                            compress=True, progtrack=progtrack,
-                            progclass=progclass)
+        headers = {}
+        if header:
+            headers.update(header)
 
-                # Compute urllist from keys in mapping
-                urllist = urlmapping.keys()
+        fobj = self._post_url(requesturl, header=header, data_fp=pathname)
+        self.__check_response_body(fobj)
 
+    def publish_abandon(self, header=None, trans_id=None):
+        """The 'abandon' publication operation, that tells a
+        Repository to abort the current transaction.  The caller
+        must specify the transaction id in trans_id. Returns
+        a (publish-state, fmri) tuple."""
+
+        baseurl = self.__get_request_url("abandon/0/")
+        requesturl = urljoin(baseurl, trans_id)
+        fobj = self._fetch_url(requesturl, header=header, failonerror=False)
+
+        try:
+            fobj.free_buffer = False
+            fobj.read()
+            state = fobj.getheader("State", None)
+            pkgfmri = fobj.getheader("Package-FMRI", None)
+        except tx.TransportProtoError as e:
+            if e.code == http_client.BAD_REQUEST:
+                exc_type, exc_value, exc_tb = sys.exc_info()
                 try:
-                        while self._engine.pending:
-                                self._engine.run()
-                except tx.ExcessiveTransientFailure as e:
-                        # Attach a list of failed and successful
-                        # requests to this exception.
-                        errors, success = self._engine.check_status(urllist,
-                            True)
+                    e.details = self._parse_html_error(fobj.read())
+                except:
+                    # If parse fails, raise original
+                    # exception.
+                    if six.PY2:
+                        six.reraise(exc_value, None, exc_tb)
+                    else:
+                        raise exc_value
+            raise
+        finally:
+            fobj.close()
 
-                        errors = self._annotate_exceptions(errors, urlmapping)
-                        success = self._url_to_request(success, urlmapping)
-                        e.failures = errors
-                        e.success = success
+        return state, pkgfmri
 
-                        # Reset the engine before propagating exception.
-                        self._engine.reset()
-                        raise
+    def publish_close(self, header=None, trans_id=None, add_to_catalog=False):
+        """The close operation tells the Repository to commit
+        the transaction identified by trans_id.  The caller may
+        specify add_to_catalog, if needed.  This method returns a
+        (publish-state, fmri) tuple."""
 
-                errors = self._engine.check_status(urllist)
+        headers = {}
+        if not add_to_catalog:
+            headers["X-IPkg-Add-To-Catalog"] = 0
+        if header:
+            headers.update(header)
 
-                # Transient errors are part of standard control flow.
-                # The repo's caller will look at these and decide whether
-                # to throw them or not.  Permanent failures are raised
-                # by the transport engine as soon as they occur.
-                #
-                # This adds an attribute that describes the request to the
-                # exception, if we were able to figure it out.
+        baseurl = self.__get_request_url("close/0/")
+        requesturl = urljoin(baseurl, trans_id)
 
-                return self._annotate_exceptions(errors, urlmapping)
+        fobj = self._fetch_url(requesturl, header=headers, failonerror=False)
 
-        def get_files(self, filelist, dest, progtrack, version, header=None, pub=None):
-                """Get multiple files from the repo at once.
-                The files are named by hash and supplied in filelist.
-                If dest is specified, download to the destination
-                directory that is given.  If progtrack is not None,
-                it contains a ProgressTracker object for the
-                downloads."""
-
-                baseurl = self.__get_request_url("file/{0}/".format(version),
-                    pub=pub)
-                urllist = []
-                progclass = None
-
-                if progtrack:
-                        progclass = FileProgress
-
-                for f in filelist:
-                        url = urljoin(baseurl, f)
-                        urllist.append(url)
-                        fn = os.path.join(dest, f)
-                        self._add_file_url(url, filepath=fn,
-                            progclass=progclass, progtrack=progtrack,
-                            header=header)
-
+        try:
+            fobj.free_buffer = False
+            fobj.read()
+            state = fobj.getheader("State", None)
+            pkgfmri = fobj.getheader("Package-FMRI", None)
+        except tx.TransportProtoError as e:
+            if e.code == http_client.BAD_REQUEST:
+                exc_type, exc_value, exc_tb = sys.exc_info()
                 try:
-                        while self._engine.pending:
-                                self._engine.run()
-                except tx.ExcessiveTransientFailure as e:
-                        # Attach a list of failed and successful
-                        # requests to this exception.
-                        errors, success = self._engine.check_status(urllist,
-                            True)
+                    e.details = self._parse_html_error(fobj.read())
+                except:
+                    # If parse fails, raise original
+                    # exception.
+                    if six.PY2:
+                        six.reraise(exc_value, None, exc_tb)
+                    else:
+                        raise exc_value
 
-                        errors = self._annotate_exceptions(errors)
-                        success = self._url_to_request(success)
-                        e.failures = errors
-                        e.success = success
+            raise
+        finally:
+            fobj.close()
 
-                        # Reset the engine before propagating exception.
-                        self._engine.reset()
-                        raise
+        return state, pkgfmri
 
-                errors = self._engine.check_status(urllist)
+    def publish_open(self, header=None, client_release=None, pkg_name=None):
+        """Begin a publication operation by calling 'open'.
+        The caller must specify the client's OS release in
+        client_release, and the package's name in pkg_name.
+        Returns a transaction-ID."""
 
-                # Transient errors are part of standard control flow.
-                # The repo's caller will look at these and decide whether
-                # to throw them or not.  Permanent failures are raised
-                # by the transport engine as soon as they occur.
-                #
-                # This adds an attribute that describes the request to the
-                # exception, if we were able to figure it out.
+        baseurl = self.__get_request_url("open/0/")
+        return self.__start_trans(baseurl, header, client_release, pkg_name)
 
-                return self._annotate_exceptions(errors)
+    def __start_trans(self, baseurl, header, client_release, pkg_name):
+        """Start a publication transaction."""
 
-        def get_url(self):
-                """Returns the repo's url."""
+        request_str = quote(pkg_name, "")
+        requesturl = urljoin(baseurl, request_str)
 
-                return self._url
+        headers = {"Client-Release": client_release}
+        if header:
+            headers.update(header)
 
-        def get_repouri_key(self):
-                """Returns the repo's TransportRepoURI key, used to uniquely
-                identify this TransportRepoURI."""
+        fobj = self._fetch_url(requesturl, header=headers, failonerror=False)
 
-                return self._repouri.key()
-
-        def get_versions(self, header=None, ccancel=None):
-                """Query the repo for versions information.
-                Returns a fileobject. If server returns 401 (Unauthorized)
-                check for presence of X-IPkg-Error header and decode."""
-
-                requesturl = self.__get_request_url("versions/0/")
-                fobj = self._fetch_url(requesturl, header, ccancel=ccancel,
-                    failonerror=False)
-
+        try:
+            fobj.free_buffer = False
+            fobj.read()
+            trans_id = fobj.getheader("Transaction-ID", None)
+        except tx.TransportProtoError as e:
+            if e.code == http_client.BAD_REQUEST:
+                exc_type, exc_value, exc_tb = sys.exc_info()
                 try:
-                        # Bogus request to trigger
-                        # StreamingFileObj.__fill_buffer(), otherwise the
-                        # TransportProtoError won't be raised here. We can't
-                        # use .read() since this will empty the data buffer.
-                        fobj.getheader("octopus", None)
-                except tx.TransportProtoError as e:
-                        if e.code == http_client.UNAUTHORIZED:
-                                exc_type, exc_value, exc_tb = sys.exc_info()
-                                try:
-                                        e.details = self._analyze_server_error(
-                                             fobj.getheader("X-IPkg-Error",
-                                             None))
-                                except:
-                                        # If analysis fails, raise original
-                                        # exception.
-                                        if six.PY2:
-                                                six.reraise(exc_value, None,
-                                                    exc_tb)
-                                        else:
-                                                raise exc_value
-                        raise
-                return fobj
-
-        def has_version_data(self):
-                """Returns true if this repo knows its version information."""
-
-                return self._verdata is not None
-
-        def publish_add(self, action, header=None, progtrack=None,
-            trans_id=None):
-                """The publish operation that adds content to a repository.
-                The action must be populated with a data property.
-                Callers may supply a header, and should supply a transaction
-                id in trans_id."""
-
-                attrs = action.attrs
-                data_fobj = None
-                data = None
-                progclass = None
-
-                if progtrack:
-                        progclass = FileProgress
-
-                baseurl = self.__get_request_url("add/0/")
-                request_str = "{0}/{1}".format(trans_id, action.name)
-                requesturl = urljoin(baseurl, request_str)
-
-                if action.data:
-                        data_fobj = action.data()
-                else:
-                        data = ""
-
-                headers = dict(
-                    ("X-IPkg-SetAttr{0}".format(i), "{0}={1}".format(k,
-                    attrs[k]))
-                    for i, k in enumerate(attrs)
-                )
-
-                if header:
-                        headers.update(header)
-
-                fobj = self._post_url(requesturl, header=headers,
-                    data_fobj=data_fobj, data=data, failonerror=False,
-                    progclass=progclass, progtrack=progtrack)
-                self.__check_response_body(fobj)
-
-        def publish_add_file(self, pth, header=None, trans_id=None,
-            basename=None, progtrack=None):
-                """The publish operation that adds content to a repository.
-                Callers may supply a header, and should supply a transaction
-                id in trans_id."""
-
-                attrs = {}
-                progclass = None
-
-                if progtrack:
-                        progclass = FileProgress
-
-                if basename:
-                        attrs["basename"] = basename
-
-                baseurl = self.__get_request_url("file/1/")
-                requesturl = urljoin(baseurl, trans_id)
-
-                headers = dict(
-                    ("X-IPkg-SetAttr{0}".format(i), "{0}={1}".format(k, attrs[k]))
-                    for i, k in enumerate(attrs)
-                )
-
-                if header:
-                        headers.update(header)
-
-                fobj = self._post_url(requesturl, header=headers, data_fp=pth,
-                    progclass=progclass, progtrack=progtrack)
-                self.__check_response_body(fobj)
-
-        def publish_add_manifest(self, pth, header=None, trans_id=None):
-                """The publish operation that adds content to a repository.
-                Callers may supply a header, and should supply a transaction
-                id in trans_id."""
-
-                baseurl = self.__get_request_url("manifest/1/")
-                requesturl = urljoin(baseurl, trans_id)
-                # Compress the manifest for the HTTPRepo case.
-                size = int(os.path.getsize(pth))
-                with open(pth, "rb") as f:
-                        data = f.read()
-                basename = os.path.basename(pth) + ".gz"
-                dirname = os.path.dirname(pth)
-                pathname = os.path.join(dirname, basename)
-                compute_compressed_attrs(basename,
-                    data=data, size=size, compress_dir=dirname)
-
-                headers = {}
-                if header:
-                        headers.update(header)
-
-                fobj = self._post_url(requesturl, header=header,
-                    data_fp=pathname)
-                self.__check_response_body(fobj)
-
-        def publish_abandon(self, header=None, trans_id=None):
-                """The 'abandon' publication operation, that tells a
-                Repository to abort the current transaction.  The caller
-                must specify the transaction id in trans_id. Returns
-                a (publish-state, fmri) tuple."""
-
-                baseurl = self.__get_request_url("abandon/0/")
-                requesturl = urljoin(baseurl, trans_id)
-                fobj = self._fetch_url(requesturl, header=header,
-                    failonerror=False)
-
-                try:
-                        fobj.free_buffer = False
-                        fobj.read()
-                        state = fobj.getheader("State", None)
-                        pkgfmri = fobj.getheader("Package-FMRI", None)
-                except tx.TransportProtoError as e:
-                        if e.code == http_client.BAD_REQUEST:
-                                exc_type, exc_value, exc_tb = sys.exc_info()
-                                try:
-                                        e.details = self._parse_html_error(
-                                            fobj.read())
-                                except:
-                                        # If parse fails, raise original
-                                        # exception.
-                                        if six.PY2:
-                                                six.reraise(exc_value, None,
-                                                    exc_tb)
-                                        else:
-                                                raise exc_value
-                        raise
-                finally:
-                        fobj.close()
-
-                return state, pkgfmri
-
-        def publish_close(self, header=None, trans_id=None,
-            add_to_catalog=False):
-                """The close operation tells the Repository to commit
-                the transaction identified by trans_id.  The caller may
-                specify add_to_catalog, if needed.  This method returns a
-                (publish-state, fmri) tuple."""
-
-                headers = {}
-                if not add_to_catalog:
-                        headers["X-IPkg-Add-To-Catalog"] = 0
-                if header:
-                        headers.update(header)
-
-                baseurl = self.__get_request_url("close/0/")
-                requesturl = urljoin(baseurl, trans_id)
-
-                fobj = self._fetch_url(requesturl, header=headers,
-                    failonerror=False)
-
-                try:
-                        fobj.free_buffer = False
-                        fobj.read()
-                        state = fobj.getheader("State", None)
-                        pkgfmri = fobj.getheader("Package-FMRI", None)
-                except tx.TransportProtoError as e:
-                        if e.code == http_client.BAD_REQUEST:
-                                exc_type, exc_value, exc_tb = sys.exc_info()
-                                try:
-                                        e.details = self._parse_html_error(
-                                            fobj.read())
-                                except:
-                                        # If parse fails, raise original
-                                        # exception.
-                                        if six.PY2:
-                                                six.reraise(exc_value, None,
-                                                    exc_tb)
-                                        else:
-                                                raise exc_value
-
-                        raise
-                finally:
-                        fobj.close()
-
-                return state, pkgfmri
-
-        def publish_open(self, header=None, client_release=None, pkg_name=None):
-                """Begin a publication operation by calling 'open'.
-                The caller must specify the client's OS release in
-                client_release, and the package's name in pkg_name.
-                Returns a transaction-ID."""
-
-                baseurl = self.__get_request_url("open/0/")
-                return self.__start_trans(baseurl, header, client_release,
-                    pkg_name)
-
-        def __start_trans(self, baseurl, header, client_release, pkg_name):
-                """Start a publication transaction."""
-
-                request_str = quote(pkg_name, "")
-                requesturl = urljoin(baseurl, request_str)
-
-                headers = {"Client-Release": client_release}
-                if header:
-                        headers.update(header)
-
-                fobj = self._fetch_url(requesturl, header=headers,
-                    failonerror=False)
-
-                try:
-                        fobj.free_buffer = False
-                        fobj.read()
-                        trans_id = fobj.getheader("Transaction-ID", None)
-                except tx.TransportProtoError as e:
-                        if e.code == http_client.BAD_REQUEST:
-                                exc_type, exc_value, exc_tb = sys.exc_info()
-                                try:
-                                        e.details = self._parse_html_error(
-                                            fobj.read())
-                                except:
-                                        # If parse fails, raise original
-                                        # exception.
-                                        if six.PY2:
-                                                six.reraise(exc_value, None,
-                                                    exc_tb)
-                                        else:
-                                                raise exc_value
-                        raise
-                finally:
-                        fobj.close()
-
-                return trans_id
-
-        def publish_append(self, header=None, client_release=None,
-            pkg_name=None):
-                """Begin a publication operation by calling 'append'.
-                The caller must specify the client's OS release in
-                client_release, and the package's name in pkg_name.
-                Returns a transaction-ID."""
-
-                baseurl = self.__get_request_url("append/0/")
-                return self.__start_trans(baseurl, header, client_release,
-                    pkg_name)
-
-        def publish_rebuild(self, header=None, pub=None):
-                """Attempt to rebuild the package data and search data in the
-                repository."""
-
-                requesturl = self.__get_request_url("admin/0", query={
-                    "cmd": "rebuild" }, pub=pub)
-                fobj = self._fetch_url(requesturl, header=header,
-                    failonerror=False)
-                self.__check_response_body(fobj)
-
-        def publish_rebuild_indexes(self, header=None, pub=None):
-                """Attempt to rebuild the search data in the repository."""
-
-                requesturl = self.__get_request_url("admin/0", query={
-                    "cmd": "rebuild-indexes" }, pub=pub)
-                fobj = self._fetch_url(requesturl, header=header,
-                    failonerror=False)
-                self.__check_response_body(fobj)
-
-        def publish_rebuild_packages(self, header=None, pub=None):
-                """Attempt to rebuild the package data in the repository."""
-
-                requesturl = self.__get_request_url("admin/0", query={
-                    "cmd": "rebuild-packages" }, pub=pub)
-                fobj = self._fetch_url(requesturl, header=header,
-                    failonerror=False)
-                self.__check_response_body(fobj)
-
-        def publish_refresh(self, header=None, pub=None):
-                """Attempt to refresh the package data and search data in the
-                repository."""
-
-                requesturl = self.__get_request_url("admin/0", query={
-                    "cmd": "refresh" }, pub=pub)
-                fobj = self._fetch_url(requesturl, header=header,
-                    failonerror=False)
-                self.__check_response_body(fobj)
-
-        def publish_refresh_indexes(self, header=None, pub=None):
-                """Attempt to refresh the search data in the repository."""
-
-                if self.supports_version("admin", [0]) > -1:
-                        requesturl = self.__get_request_url("admin/0", query={
-                            "cmd": "refresh-indexes" }, pub=pub)
-                else:
-                        requesturl = self.__get_request_url("index/0/refresh")
-
-                fobj = self._fetch_url(requesturl, header=header,
-                    failonerror=False)
-                self.__check_response_body(fobj)
-
-        def publish_refresh_packages(self, header=None, pub=None):
-                """Attempt to refresh the package data in the repository."""
-
-                requesturl = self.__get_request_url("admin/0", query={
-                    "cmd": "refresh-packages" }, pub=pub)
-                fobj = self._fetch_url(requesturl, header=header,
-                    failonerror=False)
-                self.__check_response_body(fobj)
-
-        def supports_version(self, op, verlist):
-                """Returns version-id of highest supported version.
-                If the version is not supported, or no data is available,
-                -1 is returned instead."""
-
-                if not self.has_version_data() or op not in self._verdata:
-                        return -1
-
-                # This code assumes that both the verlist and verdata
-                # are sorted in reverse order.  This behavior is currently
-                # implemented in the transport code.
-
-                for v in verlist:
-                        if v in self._verdata[op]:
-                                return v
-                return -1
-
-        def touch_manifest(self, mfst, header=None, ccancel=None, pub=None):
-                """Invoke HTTP HEAD to send manifest intent data."""
-
-                baseurl = self.__get_request_url("manifest/0/", pub=pub)
-                requesturl = urljoin(baseurl, mfst)
-
-                resp = self._fetch_url_header(requesturl, header,
-                    ccancel=ccancel)
-
-                # response is empty, or should be.
-                resp.read()
-
-                return True
-
-        def get_compressed_attrs(self, fhash, header=None, pub=None,
-            trans_id=None, hashes=True):
-                """Given a fhash, returns a tuple of (csize, chashes) where
-                'csize' is the size of the file in the repository and 'chashes'
-                is a dictionary containing any hashes of the compressed data
-                known by the repository.  If the repository cannot provide the
-                hash information or 'hashes' is False, chashes will be an empty
-                dictionary.  If the repository does not have the file, a tuple
-                of (None, None) will be returned instead."""
-
-                # If the publisher's prefix isn't contained in trans_id,
-                # assume the server doesn't have the file.
-                pfx = getattr(pub, "prefix", None)
-                if (pfx and trans_id and
-                    quote("pkg://{0}/".format(pfx), safe='') not in trans_id):
-                        return (None, None)
-
-                # If caller requests hashes and server supports providing them
-                # (v2 of file operation), then attempt to retrieve size and
-                # hashes.  Otherwise, fallback to the v0 file operation which
-                # only returns size (so is faster).
-                if hashes and self.supports_version("file", [2]) > -1:
-                        version = 2
-                else:
-                        version = 0
-
-                baseurl = self.__get_request_url("file/{0}/".format(version),
-                    pub=pub)
-                requesturl = urljoin(baseurl, fhash)
-
-                try:
-                        # see if repository has file
-                        resp = self._fetch_url_header(requesturl, header)
-                        resp.read()
-                        csize = resp.getheader("Content-Length", None)
-                        chashes = dict(
-                            val.split("=", 1)
-                            for hdr, val in six.iteritems(resp.headers)
-                            if hdr.lower().startswith("x-ipkg-attr")
-                        )
-                        return (csize, chashes)
-                except Exception:
-                        # repository transport issue or does not have file
-                        return (None, None)
-
-        def build_refetch_header(self, header):
-                """For HTTP requests that have failed due to corrupt content,
-                if that request didn't specify 'Cache-control: no-cache' in
-                its headers then we can try the request with that additional
-                header, which can help where a web cache is serving corrupt
-                content.
-                """
-
-                if header is None:
-                        header = {}
-
-                if header.get("Cache-Control", "") != "no-cache":
-                        header["Cache-Control"] = "no-cache"
-                        header["Pragma"] = "no-cache"
-                        return header
-                return header
+                    e.details = self._parse_html_error(fobj.read())
+                except:
+                    # If parse fails, raise original
+                    # exception.
+                    if six.PY2:
+                        six.reraise(exc_value, None, exc_tb)
+                    else:
+                        raise exc_value
+            raise
+        finally:
+            fobj.close()
+
+        return trans_id
+
+    def publish_append(self, header=None, client_release=None, pkg_name=None):
+        """Begin a publication operation by calling 'append'.
+        The caller must specify the client's OS release in
+        client_release, and the package's name in pkg_name.
+        Returns a transaction-ID."""
+
+        baseurl = self.__get_request_url("append/0/")
+        return self.__start_trans(baseurl, header, client_release, pkg_name)
+
+    def publish_rebuild(self, header=None, pub=None):
+        """Attempt to rebuild the package data and search data in the
+        repository."""
+
+        requesturl = self.__get_request_url(
+            "admin/0", query={"cmd": "rebuild"}, pub=pub
+        )
+        fobj = self._fetch_url(requesturl, header=header, failonerror=False)
+        self.__check_response_body(fobj)
+
+    def publish_rebuild_indexes(self, header=None, pub=None):
+        """Attempt to rebuild the search data in the repository."""
+
+        requesturl = self.__get_request_url(
+            "admin/0", query={"cmd": "rebuild-indexes"}, pub=pub
+        )
+        fobj = self._fetch_url(requesturl, header=header, failonerror=False)
+        self.__check_response_body(fobj)
+
+    def publish_rebuild_packages(self, header=None, pub=None):
+        """Attempt to rebuild the package data in the repository."""
+
+        requesturl = self.__get_request_url(
+            "admin/0", query={"cmd": "rebuild-packages"}, pub=pub
+        )
+        fobj = self._fetch_url(requesturl, header=header, failonerror=False)
+        self.__check_response_body(fobj)
+
+    def publish_refresh(self, header=None, pub=None):
+        """Attempt to refresh the package data and search data in the
+        repository."""
+
+        requesturl = self.__get_request_url(
+            "admin/0", query={"cmd": "refresh"}, pub=pub
+        )
+        fobj = self._fetch_url(requesturl, header=header, failonerror=False)
+        self.__check_response_body(fobj)
+
+    def publish_refresh_indexes(self, header=None, pub=None):
+        """Attempt to refresh the search data in the repository."""
+
+        if self.supports_version("admin", [0]) > -1:
+            requesturl = self.__get_request_url(
+                "admin/0", query={"cmd": "refresh-indexes"}, pub=pub
+            )
+        else:
+            requesturl = self.__get_request_url("index/0/refresh")
+
+        fobj = self._fetch_url(requesturl, header=header, failonerror=False)
+        self.__check_response_body(fobj)
+
+    def publish_refresh_packages(self, header=None, pub=None):
+        """Attempt to refresh the package data in the repository."""
+
+        requesturl = self.__get_request_url(
+            "admin/0", query={"cmd": "refresh-packages"}, pub=pub
+        )
+        fobj = self._fetch_url(requesturl, header=header, failonerror=False)
+        self.__check_response_body(fobj)
+
+    def supports_version(self, op, verlist):
+        """Returns version-id of highest supported version.
+        If the version is not supported, or no data is available,
+        -1 is returned instead."""
+
+        if not self.has_version_data() or op not in self._verdata:
+            return -1
+
+        # This code assumes that both the verlist and verdata
+        # are sorted in reverse order.  This behavior is currently
+        # implemented in the transport code.
+
+        for v in verlist:
+            if v in self._verdata[op]:
+                return v
+        return -1
+
+    def touch_manifest(self, mfst, header=None, ccancel=None, pub=None):
+        """Invoke HTTP HEAD to send manifest intent data."""
+
+        baseurl = self.__get_request_url("manifest/0/", pub=pub)
+        requesturl = urljoin(baseurl, mfst)
+
+        resp = self._fetch_url_header(requesturl, header, ccancel=ccancel)
+
+        # response is empty, or should be.
+        resp.read()
+
+        return True
+
+    def get_compressed_attrs(
+        self, fhash, header=None, pub=None, trans_id=None, hashes=True
+    ):
+        """Given a fhash, returns a tuple of (csize, chashes) where
+        'csize' is the size of the file in the repository and 'chashes'
+        is a dictionary containing any hashes of the compressed data
+        known by the repository.  If the repository cannot provide the
+        hash information or 'hashes' is False, chashes will be an empty
+        dictionary.  If the repository does not have the file, a tuple
+        of (None, None) will be returned instead."""
+
+        # If the publisher's prefix isn't contained in trans_id,
+        # assume the server doesn't have the file.
+        pfx = getattr(pub, "prefix", None)
+        if (
+            pfx
+            and trans_id
+            and quote("pkg://{0}/".format(pfx), safe="") not in trans_id
+        ):
+            return (None, None)
+
+        # If caller requests hashes and server supports providing them
+        # (v2 of file operation), then attempt to retrieve size and
+        # hashes.  Otherwise, fallback to the v0 file operation which
+        # only returns size (so is faster).
+        if hashes and self.supports_version("file", [2]) > -1:
+            version = 2
+        else:
+            version = 0
+
+        baseurl = self.__get_request_url("file/{0}/".format(version), pub=pub)
+        requesturl = urljoin(baseurl, fhash)
+
+        try:
+            # see if repository has file
+            resp = self._fetch_url_header(requesturl, header)
+            resp.read()
+            csize = resp.getheader("Content-Length", None)
+            chashes = dict(
+                val.split("=", 1)
+                for hdr, val in six.iteritems(resp.headers)
+                if hdr.lower().startswith("x-ipkg-attr")
+            )
+            return (csize, chashes)
+        except Exception:
+            # repository transport issue or does not have file
+            return (None, None)
+
+    def build_refetch_header(self, header):
+        """For HTTP requests that have failed due to corrupt content,
+        if that request didn't specify 'Cache-control: no-cache' in
+        its headers then we can try the request with that additional
+        header, which can help where a web cache is serving corrupt
+        content.
+        """
+
+        if header is None:
+            header = {}
+
+        if header.get("Cache-Control", "") != "no-cache":
+            header["Cache-Control"] = "no-cache"
+            header["Pragma"] = "no-cache"
+            return header
+        return header
 
 
 class HTTPSRepo(HTTPRepo):
+    def __init__(self, repostats, repouri, engine):
+        """Create a http repo.  Repostats is a RepoStats object.
+        Repouri is a TransportRepoURI object.  Engine is a transport
+        engine object.
 
-        def __init__(self, repostats, repouri, engine):
-                """Create a http repo.  Repostats is a RepoStats object.
-                Repouri is a TransportRepoURI object.  Engine is a transport
-                engine object.
+        The convenience function new_repo() can be used to create
+        the correct repo."""
 
-                The convenience function new_repo() can be used to create
-                the correct repo."""
+        HTTPRepo.__init__(self, repostats, repouri, engine)
 
-                HTTPRepo.__init__(self, repostats, repouri, engine)
+    # override the download functions to use ssl cert/key
+    def _add_file_url(
+        self,
+        url,
+        filepath=None,
+        progclass=None,
+        progtrack=None,
+        header=None,
+        compress=False,
+    ):
+        self._engine.add_url(
+            url,
+            filepath=filepath,
+            progclass=progclass,
+            progtrack=progtrack,
+            sslcert=self._repouri.ssl_cert,
+            sslkey=self._repouri.ssl_key,
+            repourl=self._url,
+            header=header,
+            compressible=compress,
+            runtime_proxy=self._repouri.runtime_proxy,
+            proxy=self._repouri.proxy,
+        )
 
-        # override the download functions to use ssl cert/key
-        def _add_file_url(self, url, filepath=None, progclass=None,
-            progtrack=None, header=None, compress=False):
-                self._engine.add_url(url, filepath=filepath,
-                    progclass=progclass, progtrack=progtrack,
-                    sslcert=self._repouri.ssl_cert,
-                    sslkey=self._repouri.ssl_key, repourl=self._url,
-                    header=header, compressible=compress,
-                    runtime_proxy=self._repouri.runtime_proxy,
-                    proxy=self._repouri.proxy)
+    def _fetch_url(
+        self, url, header=None, compress=False, ccancel=None, failonerror=True
+    ):
+        return self._engine.get_url(
+            url,
+            header=header,
+            sslcert=self._repouri.ssl_cert,
+            sslkey=self._repouri.ssl_key,
+            repourl=self._url,
+            compressible=compress,
+            ccancel=ccancel,
+            failonerror=failonerror,
+            runtime_proxy=self._repouri.runtime_proxy,
+            proxy=self._repouri.proxy,
+        )
 
-        def _fetch_url(self, url, header=None, compress=False, ccancel=None,
-            failonerror=True):
-                return self._engine.get_url(url, header=header,
-                    sslcert=self._repouri.ssl_cert,
-                    sslkey=self._repouri.ssl_key, repourl=self._url,
-                    compressible=compress, ccancel=ccancel,
-                    failonerror=failonerror,
-                    runtime_proxy=self._repouri.runtime_proxy,
-                    proxy=self._repouri.proxy)
+    def _fetch_url_header(
+        self, url, header=None, ccancel=None, failonerror=True
+    ):
+        return self._engine.get_url_header(
+            url,
+            header=header,
+            sslcert=self._repouri.ssl_cert,
+            sslkey=self._repouri.ssl_key,
+            repourl=self._url,
+            ccancel=ccancel,
+            failonerror=failonerror,
+            runtime_proxy=self._repouri.runtime_proxy,
+            proxy=self._repouri.proxy,
+        )
 
-        def _fetch_url_header(self, url, header=None, ccancel=None,
-            failonerror=True):
-                return self._engine.get_url_header(url, header=header,
-                    sslcert=self._repouri.ssl_cert,
-                    sslkey=self._repouri.ssl_key, repourl=self._url,
-                    ccancel=ccancel, failonerror=failonerror,
-                    runtime_proxy=self._repouri.runtime_proxy,
-                    proxy=self._repouri.proxy)
-
-        def _post_url(self, url, data=None, header=None, ccancel=None,
-            data_fobj=None, data_fp=None, failonerror=True, progclass=None,
-            progtrack=None):
-                return self._engine.send_data(url, data=data, header=header,
-                    sslcert=self._repouri.ssl_cert,
-                    sslkey=self._repouri.ssl_key, repourl=self._url,
-                    ccancel=ccancel, data_fobj=data_fobj,
-                    data_fp=data_fp, failonerror=failonerror,
-                    progclass=progclass, progtrack=progtrack,
-                    runtime_proxy=self._repouri.runtime_proxy,
-                    proxy=self._repouri.proxy)
+    def _post_url(
+        self,
+        url,
+        data=None,
+        header=None,
+        ccancel=None,
+        data_fobj=None,
+        data_fp=None,
+        failonerror=True,
+        progclass=None,
+        progtrack=None,
+    ):
+        return self._engine.send_data(
+            url,
+            data=data,
+            header=header,
+            sslcert=self._repouri.ssl_cert,
+            sslkey=self._repouri.ssl_key,
+            repourl=self._url,
+            ccancel=ccancel,
+            data_fobj=data_fobj,
+            data_fp=data_fp,
+            failonerror=failonerror,
+            progclass=progclass,
+            progtrack=progtrack,
+            runtime_proxy=self._repouri.runtime_proxy,
+            proxy=self._repouri.proxy,
+        )
 
 
 class _FilesystemRepo(TransportRepo):
-        """Private implementation of transport repository logic for filesystem
-        repositories.
-        """
+    """Private implementation of transport repository logic for filesystem
+    repositories.
+    """
 
-        def __init__(self, repostats, repouri, engine, frepo=None):
-                """Create a file repo.  Repostats is a RepoStats object.
-                Repouri is a TransportRepoURI object.  Engine is a transport
-                engine object.  If the caller wants to pass a Repository
-                object instead of having FileRepo create one, it should
-                pass the object in the frepo argument.
+    def __init__(self, repostats, repouri, engine, frepo=None):
+        """Create a file repo.  Repostats is a RepoStats object.
+        Repouri is a TransportRepoURI object.  Engine is a transport
+        engine object.  If the caller wants to pass a Repository
+        object instead of having FileRepo create one, it should
+        pass the object in the frepo argument.
 
-                The convenience function new_repo() can be used to create
-                the correct repo."""
+        The convenience function new_repo() can be used to create
+        the correct repo."""
 
-                self._frepo = frepo
-                self._url = repostats.url
-                self._repouri = repouri
-                self._engine = engine
-                self._verdata = None
-                self.__stats = repostats
+        self._frepo = frepo
+        self._url = repostats.url
+        self._repouri = repouri
+        self._engine = engine
+        self._verdata = None
+        self.__stats = repostats
 
-                # If caller supplied a Repository object, we're done. Return.
-                if self._frepo:
-                        return
+        # If caller supplied a Repository object, we're done. Return.
+        if self._frepo:
+            return
 
-                try:
-                        scheme, netloc, path, params, query, fragment = \
-                            urlparse(self._repouri.uri, "file",
-                            allow_fragments=0)
-                        path = url2pathname(path)
-                        self._frepo = svr_repo.Repository(read_only=True,
-                            root=path)
-                except cfg.ConfigError as e:
-                        reason = _("The configuration file for the repository "
-                            "is invalid or incomplete:\n{0}").format(e)
-                        ex = tx.TransportProtoError("file", errno.EINVAL,
-                            reason=reason, repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
-                except svr_repo.RepositoryInvalidError as e:
-                        ex = tx.TransportProtoError("file", errno.EINVAL,
-                            reason=str(e), repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
-                except Exception as e:
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=str(e), repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
+        try:
+            scheme, netloc, path, params, query, fragment = urlparse(
+                self._repouri.uri, "file", allow_fragments=0
+            )
+            path = url2pathname(path)
+            self._frepo = svr_repo.Repository(read_only=True, root=path)
+        except cfg.ConfigError as e:
+            reason = _(
+                "The configuration file for the repository "
+                "is invalid or incomplete:\n{0}"
+            ).format(e)
+            ex = tx.TransportProtoError(
+                "file", errno.EINVAL, reason=reason, repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        except svr_repo.RepositoryInvalidError as e:
+            ex = tx.TransportProtoError(
+                "file", errno.EINVAL, reason=str(e), repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        except Exception as e:
+            ex = tx.TransportProtoError(
+                "file", errno.EPROTO, reason=str(e), repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
 
-        def __del__(self):
-                # Dump search cache if repo goes out of scope.
-                if self._frepo:
-                        self._frepo.reset_search()
-                        self._frepo = None
+    def __del__(self):
+        # Dump search cache if repo goes out of scope.
+        if self._frepo:
+            self._frepo.reset_search()
+            self._frepo = None
 
-        def _add_file_url(self, url, filepath=None, progclass=None,
-            progtrack=None, header=None, compress=False):
-                self._engine.add_url(url, filepath=filepath,
-                    progclass=progclass, progtrack=progtrack, repourl=self._url,
-                    header=header, compressible=False)
+    def _add_file_url(
+        self,
+        url,
+        filepath=None,
+        progclass=None,
+        progtrack=None,
+        header=None,
+        compress=False,
+    ):
+        self._engine.add_url(
+            url,
+            filepath=filepath,
+            progclass=progclass,
+            progtrack=progtrack,
+            repourl=self._url,
+            header=header,
+            compressible=False,
+        )
 
-        def _fetch_url(self, url, header=None, compress=False, ccancel=None,
-            failonerror=True):
-                return self._engine.get_url(url, header, repourl=self._url,
-                    compressible=False, ccancel=ccancel,
-                    failonerror=failonerror)
+    def _fetch_url(
+        self, url, header=None, compress=False, ccancel=None, failonerror=True
+    ):
+        return self._engine.get_url(
+            url,
+            header,
+            repourl=self._url,
+            compressible=False,
+            ccancel=ccancel,
+            failonerror=failonerror,
+        )
 
-        def _fetch_url_header(self, url, header=None, ccancel=None,
-            failonerror=True):
-                return self._engine.get_url_header(url, header,
-                    repourl=self._url, ccancel=ccancel, failonerror=failonerror)
+    def _fetch_url_header(
+        self, url, header=None, ccancel=None, failonerror=True
+    ):
+        return self._engine.get_url_header(
+            url,
+            header,
+            repourl=self._url,
+            ccancel=ccancel,
+            failonerror=failonerror,
+        )
 
-        def __record_proto_error(self, ex):
-                """Private helper function that records a protocol error that
-                was raised by the class instead of the transport engine.  It
-                records both that a transaction was initiated and that an
-                error occurred."""
+    def __record_proto_error(self, ex):
+        """Private helper function that records a protocol error that
+        was raised by the class instead of the transport engine.  It
+        records both that a transaction was initiated and that an
+        error occurred."""
 
+        self.__stats.record_tx()
+        self.__stats.record_error(decayable=ex.decayable)
+
+    def add_version_data(self, verdict):
+        """Cache the information about what versions a repository
+        supports."""
+
+        self._verdata = verdict
+
+    def do_search(self, data, header=None, ccancel=None, pub=None):
+        """Perform a search against repo."""
+
+        pub_prefix = getattr(pub, "prefix", None)
+        try:
+            res_list = self._frepo.search(data, pub=pub_prefix)
+        except svr_repo.RepositorySearchUnavailableError:
+            ex = tx.TransportProtoError(
+                "file",
+                errno.EAGAIN,
+                reason=_("Search temporarily unavailable."),
+                repourl=self._url,
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        except sqp.QueryException as e:
+            ex = tx.TransportProtoError(
+                "file", errno.EINVAL, reason=str(e), repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        except Exception as e:
+            ex = tx.TransportProtoError(
+                "file", errno.EPROTO, reason=str(e), repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
+
+        # In order to be able to have a return code distinguish between
+        # no results and search unavailable, we need to use a different
+        # http code.  Check and see if there's at least one item in
+        # the results.  If not, set the result code to be NO_CONTENT
+        # and return.  If there is at least one result, put the result
+        # examined back at the front of the results and stream them
+        # to the user.
+        if len(res_list) == 1:
+            try:
+                tmp = next(res_list[0])
+                res_list = [itertools.chain([tmp], res_list[0])]
+            except StopIteration:
                 self.__stats.record_tx()
-                self.__stats.record_error(decayable=ex.decayable)
-
-        def add_version_data(self, verdict):
-                """Cache the information about what versions a repository
-                supports."""
-
-                self._verdata = verdict
-
-        def do_search(self, data, header=None, ccancel=None, pub=None):
-                """Perform a search against repo."""
-
-                pub_prefix = getattr(pub, "prefix", None)
-                try:
-                        res_list = self._frepo.search(data, pub=pub_prefix)
-                except svr_repo.RepositorySearchUnavailableError:
-                        ex = tx.TransportProtoError("file", errno.EAGAIN,
-                            reason=_("Search temporarily unavailable."),
-                            repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
-                except sqp.QueryException as e:
-                        ex = tx.TransportProtoError("file", errno.EINVAL,
-                            reason=str(e), repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
-                except Exception as e:
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=str(e), repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
-
-                # In order to be able to have a return code distinguish between
-                # no results and search unavailable, we need to use a different
-                # http code.  Check and see if there's at least one item in
-                # the results.  If not, set the result code to be NO_CONTENT
-                # and return.  If there is at least one result, put the result
-                # examined back at the front of the results and stream them
-                # to the user.
-                if len(res_list) == 1:
-                        try:
-                                tmp = next(res_list[0])
-                                res_list = [itertools.chain([tmp], res_list[0])]
-                        except StopIteration:
-                                self.__stats.record_tx()
-                                raise apx.NegativeSearchResult(self._url)
-
-                def output():
-                        # Yield the string used to let the client know it's
-                        # talking to a valid search server.
-                        yield str(sqp.Query.VALIDATION_STRING[1])
-                        for i, res in enumerate(res_list):
-                                for v, return_type, vals in res:
-                                        if return_type == \
-                                            sqp.Query.RETURN_ACTIONS:
-                                                fmri_str, fv, line = vals
-                                                yield "{0} {1} {2} {3} {4}\n".format(
-                                                    i, return_type, fmri_str,
-                                                    quote(fv),
-                                                    line.rstrip())
-                                        elif return_type == \
-                                            sqp.Query.RETURN_PACKAGES:
-                                                fmri_str = vals
-                                                yield "{0} {1} {2}\n".format(
-                                                    i, return_type, fmri_str)
-                return output()
-
-        def get_catalog1(self, filelist, destloc, header=None, ts=None,
-            progtrack=None, pub=None, revalidate=False, redownload=False):
-                """Get the files that make up the catalog components
-                that are listed in 'filelist'.  Download the files to
-                the directory specified in 'destloc'.  The caller
-                may optionally specify a dictionary with header
-                elements in 'header'.  If a conditional get is
-                to be performed, 'ts' should contain a floating point
-                value of seconds since the epoch.  This protocol
-                doesn't implment revalidate and redownload.  The options
-                are ignored."""
-
-                urllist = []
-                progclass = None
-                pub_prefix = getattr(pub, "prefix", None)
-
-                if progtrack:
-                        progclass = ProgressCallback
-
-                # create URL for requests
-                for f in filelist:
-                        try:
-                                url = urlunparse(("file", None,
-                                    pathname2url(self._frepo.catalog_1(f,
-                                    pub=pub_prefix)), None, None, None))
-                        except svr_repo.RepositoryError as e:
-                                ex = tx.TransportProtoError("file",
-                                    errno.EPROTO, reason=str(e),
-                                    repourl=self._url, request=f)
-                                self.__record_proto_error(ex)
-                                raise ex
-
-                        urllist.append(url)
-                        fn = os.path.join(destloc, f)
-                        self._add_file_url(url, filepath=fn, header=header,
-                            progtrack=progtrack, progclass=progclass)
-
-                try:
-                        while self._engine.pending:
-                                self._engine.run()
-                except tx.ExcessiveTransientFailure as e:
-                        # Attach a list of failed and successful
-                        # requests to this exception.
-                        errors, success = self._engine.check_status(urllist,
-                            True)
-
-                        errors = self._annotate_exceptions(errors)
-                        success = self._url_to_request(success)
-                        e.failures = errors
-                        e.success = success
-
-                        # Reset the engine before propagating exception.
-                        self._engine.reset()
-                        raise
-
-                errors = self._engine.check_status(urllist)
-
-                # Transient errors are part of standard control flow.
-                # The repo's caller will look at these and decide whether
-                # to throw them or not.  Permanent failures are raised
-                # by the transport engine as soon as they occur.
-                #
-                # This adds an attribute that describes the request to the
-                # exception, if we were able to figure it out.
-
-                return self._annotate_exceptions(errors)
-
-        def get_datastream(self, fhash, version, header=None, ccancel=None, pub=None):
-                """Get a datastream from a repo.  The name of the
-                file is given in fhash."""
-
-                pub_prefix = getattr(pub, "prefix", None)
-                try:
-                        requesturl = urlunparse(("file", None,
-                            pathname2url(self._frepo.file(fhash,
-                            pub=pub_prefix)), None, None, None))
-                except svr_repo.RepositoryFileNotFoundError as e:
-                        ex = tx.TransportProtoError("file", errno.ENOENT,
-                            reason=str(e), repourl=self._url, request=fhash)
-                        self.__record_proto_error(ex)
-                        raise ex
-                except svr_repo.RepositoryError as e:
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=str(e), repourl=self._url, request=fhash)
-                        self.__record_proto_error(ex)
-                        raise ex
-                return self._fetch_url(requesturl, header, ccancel=ccancel)
-
-        def get_publisherinfo(self, header=None, ccancel=None):
-                """Get publisher information from the repository."""
-
-                try:
-                        pubs = self._frepo.get_publishers()
-                        buf = cStringIO()
-                        p5i.write(buf, pubs)
-                except Exception as e:
-                        reason = "Unable to retrieve publisher configuration " \
-                            "data:\n{0}".format(e)
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=reason, repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
-                buf.seek(0)
-                return buf
-
-        def get_status(self, header=None, ccancel=None):
-                """Get status/0 information from the repository."""
-
-                buf = cStringIO()
-                try:
-                        rstatus = self._frepo.get_status()
-                        json.dump(rstatus, buf, ensure_ascii=False, indent=2,
-                            sort_keys=True)
-                        buf.write("\n")
-                except Exception as e:
-                        reason = "Unable to retrieve status data:\n{0}".format(e)
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=reason, repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
-                buf.seek(0)
-                return buf
-
-        def get_manifest(self, fmri, header=None, ccancel=None, pub=None):
-                """Get a manifest from repo.  The fmri of the package for the
-                manifest is given in fmri."""
-
-                pub_prefix = getattr(pub, "prefix", None)
-                try:
-                        requesturl = urlunparse(("file", None,
-                            pathname2url(self._frepo.manifest(fmri,
-                            pub=pub_prefix)), None, None, None))
-                except svr_repo.RepositoryError as e:
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=str(e), repourl=self._url, request=str(fmri))
-                        self.__record_proto_error(ex)
-                        raise ex
-
-                return self._fetch_url(requesturl, header, ccancel=ccancel)
-
-        def get_manifests(self, mfstlist, dest, progtrack=None, pub=None):
-                """Get manifests named in list.  The mfstlist argument contains
-                tuples (fmri, header).  This is so that each manifest may have
-                unique header information.  The destination directory is spec-
-                ified in the dest argument."""
-
-                urlmapping = {}
-                progclass = None
-                pub_prefix = getattr(pub, "prefix", None)
-
-                if progtrack:
-                        progclass = ManifestProgress
-
-                # Errors that happen before the engine is executed must be
-                # collected and added to the errors raised during engine
-                # execution so that batch processing occurs as expected.
-                pre_exec_errors = []
-                for fmri, h in mfstlist:
-                        try:
-                                url = urlunparse(("file", None,
-                                    pathname2url(self._frepo.manifest(
-                                    fmri, pub=pub_prefix)), None, None, None))
-                        except svr_repo.RepositoryError as e:
-                                ex = tx.TransportProtoError("file",
-                                    errno.EPROTO, reason=str(e),
-                                    repourl=self._url, request=str(fmri))
-                                self.__record_proto_error(ex)
-                                pre_exec_errors.append(ex)
-                                continue
-                        urlmapping[url] = fmri
-                        fn = os.path.join(dest, fmri.get_url_path())
-                        self._add_file_url(url, filepath=fn, header=h,
-                            progtrack=progtrack, progclass=progclass)
-
-                urllist = urlmapping.keys()
-
-                try:
-                        while self._engine.pending:
-                                self._engine.run()
-                except tx.ExcessiveTransientFailure as e:
-                        # Attach a list of failed and successful
-                        # requests to this exception.
-                        errors, success = self._engine.check_status(urllist,
-                            True)
-
-                        errors = self._annotate_exceptions(errors, urlmapping)
-                        errors.extend(pre_exec_errors)
-                        success = self._url_to_request(success, urlmapping)
-                        e.failures = errors
-                        e.success = success
-
-                        # Reset the engine before propagating exception.
-                        self._engine.reset()
-                        raise
-
-                errors = self._engine.check_status(urllist)
-
-                # Transient errors are part of standard control flow.
-                # The repo's caller will look at these and decide whether
-                # to throw them or not.  Permanent failures are raised
-                # by the transport engine as soon as they occur.
-                #
-                # This adds an attribute that describes the request to the
-                # exception, if we were able to figure it out.
-                errors = self._annotate_exceptions(errors, urlmapping)
-
-                return errors + pre_exec_errors
-
-        def get_files(self, filelist, dest, progtrack, version, header=None, pub=None):
-                """Get multiple files from the repo at once.
-                The files are named by hash and supplied in filelist.
-                If dest is specified, download to the destination
-                directory that is given.  If progtrack is not None,
-                it contains a ProgressTracker object for the
-                downloads."""
-
-                urllist = []
-                progclass = None
-                pub_prefix = getattr(pub, "prefix", None)
-
-                if progtrack:
-                        progclass = FileProgress
-
-                # Errors that happen before the engine is executed must be
-                # collected and added to the errors raised during engine
-                # execution so that batch processing occurs as expected.
-                pre_exec_errors = []
-                for f in filelist:
-                        try:
-                                url = urlunparse(("file", None,
-                                    pathname2url(self._frepo.file(f,
-                                    pub=pub_prefix)), None, None, None))
-                        except svr_repo.RepositoryFileNotFoundError as e:
-                                ex = tx.TransportProtoError("file",
-                                    errno.ENOENT, reason=str(e),
-                                    repourl=self._url, request=f)
-                                self.__record_proto_error(ex)
-                                pre_exec_errors.append(ex)
-                                continue
-                        except svr_repo.RepositoryError as e:
-                                ex = tx.TransportProtoError("file",
-                                    errno.EPROTO, reason=str(e),
-                                    repourl=self._url, request=f)
-                                self.__record_proto_error(ex)
-                                pre_exec_errors.append(ex)
-                                continue
-                        urllist.append(url)
-                        fn = os.path.join(dest, f)
-                        self._add_file_url(url, filepath=fn,
-                            progclass=progclass, progtrack=progtrack,
-                            header=header)
-
-                try:
-                        while self._engine.pending:
-                                self._engine.run()
-                except tx.ExcessiveTransientFailure as e:
-                        # Attach a list of failed and successful
-                        # requests to this exception.
-                        errors, success = self._engine.check_status(urllist,
-                            True)
-
-                        errors = self._annotate_exceptions(errors)
-                        errors.extend(pre_exec_errors)
-                        success = self._url_to_request(success)
-                        e.failures = errors
-                        e.success = success
-
-                        # Reset the engine before propagating exception.
-                        self._engine.reset()
-                        raise
-
-                errors = self._engine.check_status(urllist)
-
-                # Transient errors are part of standard control flow.
-                # The repo's caller will look at these and decide whether
-                # to throw them or not.  Permanent failures are raised
-                # by the transport engine as soon as they occur.
-                #
-                # This adds an attribute that describes the request to the
-                # exception, if we were able to figure it out.
-                errors = self._annotate_exceptions(errors)
-
-                return errors + pre_exec_errors
-
-        def get_url(self):
-                """Returns the repo's url."""
-
-                return self._url
-
-        def get_repouri_key(self):
-                """Returns a key from the TransportRepoURI that can be
-                used in a dictionary"""
-
-                return self._repouri.key()
-
-        def get_versions(self, header=None, ccancel=None):
-                """Query the repo for versions information.
-                Returns a file-like object."""
-
-                buf = cStringIO()
-                vops = {
-                    "abandon": ["0"],
-                    "add": ["0"],
-                    "admin": ["0"],
-                    "append": ["0"],
-                    "catalog": ["1"],
-                    "close": ["0"],
-                    "file": ["0", "1"],
-                    "manifest": ["0", "1"],
-                    "open": ["0"],
-                    "publisher": ["0", "1"],
-                    "search": ["1"],
-                    "status": ["0"],
-                    "versions": ["0"],
-                }
-
-                buf.write("pkg-server {0}\n".format(pkg.VERSION))
-                buf.write("\n".join(
-                    "{0} {1}".format(op, " ".join(vers))
-                    for op, vers in six.iteritems(vops)
-                ) + "\n")
-                buf.seek(0)
-                self.__stats.record_tx()
-                return buf
-
-        def has_version_data(self):
-                """Returns true if this repo knows its version information."""
-
-                return self._verdata is not None
-
-        def publish_add(self, action, header=None, progtrack=None,
-            trans_id=None):
-                """The publish operation that adds an action and its
-                payload (if applicable) to an existing transaction in a
-                repository.  The action must be populated with a data property.
-                Callers may supply a header, and should supply a transaction
-                id in trans_id."""
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                progclass = None
-                if progtrack:
-                        progclass = FileProgress
-                        progtrack = progclass(progtrack)
-
-                try:
-                        self._frepo.add(trans_id, action)
-                except svr_repo.RepositoryError as e:
-                        if progtrack:
-                                progtrack.abort()
-                        raise tx.TransportOperationError(str(e))
-                else:
-                        if progtrack:
-                                sz = int(action.attrs.get("pkg.size", 0))
-                                progtrack.progress_callback(0, 0, sz, sz)
-
-        def publish_add_file(self, pth, header=None, trans_id=None,
-            basename=None, progtrack=None):
-                """The publish operation that adds a file to an existing
-                transaction."""
-
-                progclass = None
-                if progtrack:
-                        progclass = FileProgress
-                        progtrack = progclass(progtrack)
-                sz = int(os.path.getsize(pth))
-
-                try:
-                        self._frepo.add_file(trans_id, pth, basename, size=sz)
-                except svr_repo.RepositoryError as e:
-                        if progtrack:
-                                progtrack.abort()
-                        raise tx.TransportOperationError(str(e))
-                else:
-                        if progtrack:
-
-                                progtrack.progress_callback(0, 0, sz, sz)
-
-        def publish_add_manifest(self, pth, header=None, trans_id=None):
-                """The publish operation that adds a manifest to an existing
-                transaction."""
-
-                try:
-                        self._frepo.add_manifest(trans_id, pth)
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-        def publish_abandon(self, header=None, trans_id=None):
-                """The abandon operation, that tells a Repository to abort
-                the current transaction.  The caller must specify the
-                transaction id in trans_id. Returns a (publish-state, fmri)
-                tuple."""
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                try:
-                        pkg_state = self._frepo.abandon(trans_id)
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-                return None, pkg_state
-
-        def publish_close(self, header=None, trans_id=None,
-            add_to_catalog=False):
-                """The close operation tells the Repository to commit
-                the transaction identified by trans_id.  The caller may
-                specify add_to_catalog, if needed.  This method returns a
-                (publish-state, fmri) tuple."""
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                try:
-                        pkg_fmri, pkg_state = self._frepo.close(trans_id,
-                            add_to_catalog=add_to_catalog)
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-                return pkg_fmri, pkg_state
-
-        def publish_open(self, header=None, client_release=None, pkg_name=None):
-                """Begin a publication operation by calling 'open'.
-                The caller must specify the client's OS release in
-                client_release, and the package's name in pkg_name.
-                Returns a transaction-ID string."""
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                try:
-                        trans_id = self._frepo.open(client_release, pkg_name)
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-                return trans_id
-
-        def publish_append(self, header=None, client_release=None,
-            pkg_name=None):
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                try:
-                        trans_id = self._frepo.append(client_release, pkg_name)
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-                return trans_id
-
-        def publish_rebuild(self, header=None, pub=None):
-                """Attempt to rebuild the package data and search data in the
-                repository."""
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                pub_prefix = getattr(pub, "prefix", None)
-                try:
-                        self._frepo.rebuild(pub=pub_prefix,
-                            build_catalog=True, build_index=True)
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-        def publish_rebuild_indexes(self, header=None, pub=None):
-                """Attempt to rebuild the search data in the repository."""
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                pub_prefix = getattr(pub, "prefix", None)
-                try:
-                        self._frepo.rebuild(pub=pub_prefix,
-                            build_catalog=False, build_index=True)
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-        def publish_rebuild_packages(self, header=None, pub=None):
-                """Attempt to rebuild the package data in the repository."""
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                pub_prefix = getattr(pub, "prefix", None)
-                try:
-                        self._frepo.rebuild(pub=pub_prefix,
-                            build_catalog=True, build_index=False)
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-        def publish_refresh(self, header=None, pub=None):
-                """Attempt to refresh the package data and search data in the
-                repository."""
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                pub_prefix = getattr(pub, "prefix", None)
-                try:
-                        self._frepo.add_content(pub=pub_prefix,
-                            refresh_index=True)
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-        def publish_refresh_indexes(self, header=None, pub=None):
-                """Attempt to refresh the search data in the repository."""
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                try:
-                        self._frepo.refresh_index()
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-        def publish_refresh_packages(self, header=None, pub=None):
-                """Attempt to refresh the package data in the repository."""
-
-                # Calling any publication operation sets read_only to False.
-                self._frepo.read_only = False
-
-                pub_prefix = getattr(pub, "prefix", None)
-                try:
-                        self._frepo.add_content(pub=pub_prefix,
-                            refresh_index=False)
-                except svr_repo.RepositoryError as e:
-                        raise tx.TransportOperationError(str(e))
-
-        def supports_version(self, op, verlist):
-                """Returns version-id of highest supported version.
-                If the version is not supported, or no data is available,
-                -1 is returned instead."""
-
-                if not self.has_version_data() or op not in self._verdata:
-                        return -1
-
-                # This code assumes that both the verlist and verdata
-                # are sorted in reverse order.  This behavior is currently
-                # implemented in the transport code.
-
-                for v in verlist:
-                        if v in self._verdata[op]:
-                                return v
-                return -1
-
-        def touch_manifest(self, mfst, header=None, ccancel=None, pub=None):
-                """No-op for file://."""
-
-                return True
-
-        def get_compressed_attrs(self, fhash, header=None, pub=None,
-            trans_id=None, hashes=True):
-                """Given a fhash, returns a tuple of (csize, chashes) where
-                'csize' is the size of the file in the repository and 'chashes'
-                is a dictionary containing any hashes of the compressed data
-                known by the repository.  If the repository cannot provide the
-                hash information or 'hashes' is False, chashes will be an empty
-                dictionary.  If the repository does not have the file, a tuple
-                of (None, None) will be returned instead."""
-
-                # If the publisher's prefix isn't contained in trans_id,
-                # assume the server doesn't have the file.
-                pfx = getattr(pub, "prefix", None)
-                if (pfx and trans_id and
-                    quote("pkg://{0}/".format(pfx), safe='') not in trans_id):
-                        return (None, None)
-
-                try:
-                        # see if repository has file
-                        fpath = self._frepo.file(fhash, pub=pfx)
-                        if hashes:
-                                csize, chashes = compute_compressed_attrs(fhash,
-                                    file_path=fpath)
-                        else:
-                                csize = os.stat(fpath).st_size
-                                chashes = EmptyDict
-                        return (csize, chashes)
-                except (EnvironmentError,
-                        svr_repo.RepositoryError,
-                        svr_repo.RepositoryFileNotFoundError):
-                        # repository transport issue or does not have file
-                        return (None, None)
-
-        def build_refetch_header(self, header):
-                """Pointless to attempt refetch of corrupt content for
-                this protocol."""
-
-                return header
+                raise apx.NegativeSearchResult(self._url)
+
+        def output():
+            # Yield the string used to let the client know it's
+            # talking to a valid search server.
+            yield str(sqp.Query.VALIDATION_STRING[1])
+            for i, res in enumerate(res_list):
+                for v, return_type, vals in res:
+                    if return_type == sqp.Query.RETURN_ACTIONS:
+                        fmri_str, fv, line = vals
+                        yield "{0} {1} {2} {3} {4}\n".format(
+                            i, return_type, fmri_str, quote(fv), line.rstrip()
+                        )
+                    elif return_type == sqp.Query.RETURN_PACKAGES:
+                        fmri_str = vals
+                        yield "{0} {1} {2}\n".format(i, return_type, fmri_str)
+
+        return output()
+
+    def get_catalog1(
+        self,
+        filelist,
+        destloc,
+        header=None,
+        ts=None,
+        progtrack=None,
+        pub=None,
+        revalidate=False,
+        redownload=False,
+    ):
+        """Get the files that make up the catalog components
+        that are listed in 'filelist'.  Download the files to
+        the directory specified in 'destloc'.  The caller
+        may optionally specify a dictionary with header
+        elements in 'header'.  If a conditional get is
+        to be performed, 'ts' should contain a floating point
+        value of seconds since the epoch.  This protocol
+        doesn't implment revalidate and redownload.  The options
+        are ignored."""
+
+        urllist = []
+        progclass = None
+        pub_prefix = getattr(pub, "prefix", None)
+
+        if progtrack:
+            progclass = ProgressCallback
+
+        # create URL for requests
+        for f in filelist:
+            try:
+                url = urlunparse(
+                    (
+                        "file",
+                        None,
+                        pathname2url(self._frepo.catalog_1(f, pub=pub_prefix)),
+                        None,
+                        None,
+                        None,
+                    )
+                )
+            except svr_repo.RepositoryError as e:
+                ex = tx.TransportProtoError(
+                    "file",
+                    errno.EPROTO,
+                    reason=str(e),
+                    repourl=self._url,
+                    request=f,
+                )
+                self.__record_proto_error(ex)
+                raise ex
+
+            urllist.append(url)
+            fn = os.path.join(destloc, f)
+            self._add_file_url(
+                url,
+                filepath=fn,
+                header=header,
+                progtrack=progtrack,
+                progclass=progclass,
+            )
+
+        try:
+            while self._engine.pending:
+                self._engine.run()
+        except tx.ExcessiveTransientFailure as e:
+            # Attach a list of failed and successful
+            # requests to this exception.
+            errors, success = self._engine.check_status(urllist, True)
+
+            errors = self._annotate_exceptions(errors)
+            success = self._url_to_request(success)
+            e.failures = errors
+            e.success = success
+
+            # Reset the engine before propagating exception.
+            self._engine.reset()
+            raise
+
+        errors = self._engine.check_status(urllist)
+
+        # Transient errors are part of standard control flow.
+        # The repo's caller will look at these and decide whether
+        # to throw them or not.  Permanent failures are raised
+        # by the transport engine as soon as they occur.
+        #
+        # This adds an attribute that describes the request to the
+        # exception, if we were able to figure it out.
+
+        return self._annotate_exceptions(errors)
+
+    def get_datastream(
+        self, fhash, version, header=None, ccancel=None, pub=None
+    ):
+        """Get a datastream from a repo.  The name of the
+        file is given in fhash."""
+
+        pub_prefix = getattr(pub, "prefix", None)
+        try:
+            requesturl = urlunparse(
+                (
+                    "file",
+                    None,
+                    pathname2url(self._frepo.file(fhash, pub=pub_prefix)),
+                    None,
+                    None,
+                    None,
+                )
+            )
+        except svr_repo.RepositoryFileNotFoundError as e:
+            ex = tx.TransportProtoError(
+                "file",
+                errno.ENOENT,
+                reason=str(e),
+                repourl=self._url,
+                request=fhash,
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        except svr_repo.RepositoryError as e:
+            ex = tx.TransportProtoError(
+                "file",
+                errno.EPROTO,
+                reason=str(e),
+                repourl=self._url,
+                request=fhash,
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        return self._fetch_url(requesturl, header, ccancel=ccancel)
+
+    def get_publisherinfo(self, header=None, ccancel=None):
+        """Get publisher information from the repository."""
+
+        try:
+            pubs = self._frepo.get_publishers()
+            buf = cStringIO()
+            p5i.write(buf, pubs)
+        except Exception as e:
+            reason = (
+                "Unable to retrieve publisher configuration "
+                "data:\n{0}".format(e)
+            )
+            ex = tx.TransportProtoError(
+                "file", errno.EPROTO, reason=reason, repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        buf.seek(0)
+        return buf
+
+    def get_status(self, header=None, ccancel=None):
+        """Get status/0 information from the repository."""
+
+        buf = cStringIO()
+        try:
+            rstatus = self._frepo.get_status()
+            json.dump(
+                rstatus, buf, ensure_ascii=False, indent=2, sort_keys=True
+            )
+            buf.write("\n")
+        except Exception as e:
+            reason = "Unable to retrieve status data:\n{0}".format(e)
+            ex = tx.TransportProtoError(
+                "file", errno.EPROTO, reason=reason, repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        buf.seek(0)
+        return buf
+
+    def get_manifest(self, fmri, header=None, ccancel=None, pub=None):
+        """Get a manifest from repo.  The fmri of the package for the
+        manifest is given in fmri."""
+
+        pub_prefix = getattr(pub, "prefix", None)
+        try:
+            requesturl = urlunparse(
+                (
+                    "file",
+                    None,
+                    pathname2url(self._frepo.manifest(fmri, pub=pub_prefix)),
+                    None,
+                    None,
+                    None,
+                )
+            )
+        except svr_repo.RepositoryError as e:
+            ex = tx.TransportProtoError(
+                "file",
+                errno.EPROTO,
+                reason=str(e),
+                repourl=self._url,
+                request=str(fmri),
+            )
+            self.__record_proto_error(ex)
+            raise ex
+
+        return self._fetch_url(requesturl, header, ccancel=ccancel)
+
+    def get_manifests(self, mfstlist, dest, progtrack=None, pub=None):
+        """Get manifests named in list.  The mfstlist argument contains
+        tuples (fmri, header).  This is so that each manifest may have
+        unique header information.  The destination directory is spec-
+        ified in the dest argument."""
+
+        urlmapping = {}
+        progclass = None
+        pub_prefix = getattr(pub, "prefix", None)
+
+        if progtrack:
+            progclass = ManifestProgress
+
+        # Errors that happen before the engine is executed must be
+        # collected and added to the errors raised during engine
+        # execution so that batch processing occurs as expected.
+        pre_exec_errors = []
+        for fmri, h in mfstlist:
+            try:
+                url = urlunparse(
+                    (
+                        "file",
+                        None,
+                        pathname2url(
+                            self._frepo.manifest(fmri, pub=pub_prefix)
+                        ),
+                        None,
+                        None,
+                        None,
+                    )
+                )
+            except svr_repo.RepositoryError as e:
+                ex = tx.TransportProtoError(
+                    "file",
+                    errno.EPROTO,
+                    reason=str(e),
+                    repourl=self._url,
+                    request=str(fmri),
+                )
+                self.__record_proto_error(ex)
+                pre_exec_errors.append(ex)
+                continue
+            urlmapping[url] = fmri
+            fn = os.path.join(dest, fmri.get_url_path())
+            self._add_file_url(
+                url,
+                filepath=fn,
+                header=h,
+                progtrack=progtrack,
+                progclass=progclass,
+            )
+
+        urllist = urlmapping.keys()
+
+        try:
+            while self._engine.pending:
+                self._engine.run()
+        except tx.ExcessiveTransientFailure as e:
+            # Attach a list of failed and successful
+            # requests to this exception.
+            errors, success = self._engine.check_status(urllist, True)
+
+            errors = self._annotate_exceptions(errors, urlmapping)
+            errors.extend(pre_exec_errors)
+            success = self._url_to_request(success, urlmapping)
+            e.failures = errors
+            e.success = success
+
+            # Reset the engine before propagating exception.
+            self._engine.reset()
+            raise
+
+        errors = self._engine.check_status(urllist)
+
+        # Transient errors are part of standard control flow.
+        # The repo's caller will look at these and decide whether
+        # to throw them or not.  Permanent failures are raised
+        # by the transport engine as soon as they occur.
+        #
+        # This adds an attribute that describes the request to the
+        # exception, if we were able to figure it out.
+        errors = self._annotate_exceptions(errors, urlmapping)
+
+        return errors + pre_exec_errors
+
+    def get_files(
+        self, filelist, dest, progtrack, version, header=None, pub=None
+    ):
+        """Get multiple files from the repo at once.
+        The files are named by hash and supplied in filelist.
+        If dest is specified, download to the destination
+        directory that is given.  If progtrack is not None,
+        it contains a ProgressTracker object for the
+        downloads."""
+
+        urllist = []
+        progclass = None
+        pub_prefix = getattr(pub, "prefix", None)
+
+        if progtrack:
+            progclass = FileProgress
+
+        # Errors that happen before the engine is executed must be
+        # collected and added to the errors raised during engine
+        # execution so that batch processing occurs as expected.
+        pre_exec_errors = []
+        for f in filelist:
+            try:
+                url = urlunparse(
+                    (
+                        "file",
+                        None,
+                        pathname2url(self._frepo.file(f, pub=pub_prefix)),
+                        None,
+                        None,
+                        None,
+                    )
+                )
+            except svr_repo.RepositoryFileNotFoundError as e:
+                ex = tx.TransportProtoError(
+                    "file",
+                    errno.ENOENT,
+                    reason=str(e),
+                    repourl=self._url,
+                    request=f,
+                )
+                self.__record_proto_error(ex)
+                pre_exec_errors.append(ex)
+                continue
+            except svr_repo.RepositoryError as e:
+                ex = tx.TransportProtoError(
+                    "file",
+                    errno.EPROTO,
+                    reason=str(e),
+                    repourl=self._url,
+                    request=f,
+                )
+                self.__record_proto_error(ex)
+                pre_exec_errors.append(ex)
+                continue
+            urllist.append(url)
+            fn = os.path.join(dest, f)
+            self._add_file_url(
+                url,
+                filepath=fn,
+                progclass=progclass,
+                progtrack=progtrack,
+                header=header,
+            )
+
+        try:
+            while self._engine.pending:
+                self._engine.run()
+        except tx.ExcessiveTransientFailure as e:
+            # Attach a list of failed and successful
+            # requests to this exception.
+            errors, success = self._engine.check_status(urllist, True)
+
+            errors = self._annotate_exceptions(errors)
+            errors.extend(pre_exec_errors)
+            success = self._url_to_request(success)
+            e.failures = errors
+            e.success = success
+
+            # Reset the engine before propagating exception.
+            self._engine.reset()
+            raise
+
+        errors = self._engine.check_status(urllist)
+
+        # Transient errors are part of standard control flow.
+        # The repo's caller will look at these and decide whether
+        # to throw them or not.  Permanent failures are raised
+        # by the transport engine as soon as they occur.
+        #
+        # This adds an attribute that describes the request to the
+        # exception, if we were able to figure it out.
+        errors = self._annotate_exceptions(errors)
+
+        return errors + pre_exec_errors
+
+    def get_url(self):
+        """Returns the repo's url."""
+
+        return self._url
+
+    def get_repouri_key(self):
+        """Returns a key from the TransportRepoURI that can be
+        used in a dictionary"""
+
+        return self._repouri.key()
+
+    def get_versions(self, header=None, ccancel=None):
+        """Query the repo for versions information.
+        Returns a file-like object."""
+
+        buf = cStringIO()
+        vops = {
+            "abandon": ["0"],
+            "add": ["0"],
+            "admin": ["0"],
+            "append": ["0"],
+            "catalog": ["1"],
+            "close": ["0"],
+            "file": ["0", "1"],
+            "manifest": ["0", "1"],
+            "open": ["0"],
+            "publisher": ["0", "1"],
+            "search": ["1"],
+            "status": ["0"],
+            "versions": ["0"],
+        }
+
+        buf.write("pkg-server {0}\n".format(pkg.VERSION))
+        buf.write(
+            "\n".join(
+                "{0} {1}".format(op, " ".join(vers))
+                for op, vers in six.iteritems(vops)
+            )
+            + "\n"
+        )
+        buf.seek(0)
+        self.__stats.record_tx()
+        return buf
+
+    def has_version_data(self):
+        """Returns true if this repo knows its version information."""
+
+        return self._verdata is not None
+
+    def publish_add(self, action, header=None, progtrack=None, trans_id=None):
+        """The publish operation that adds an action and its
+        payload (if applicable) to an existing transaction in a
+        repository.  The action must be populated with a data property.
+        Callers may supply a header, and should supply a transaction
+        id in trans_id."""
+
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        progclass = None
+        if progtrack:
+            progclass = FileProgress
+            progtrack = progclass(progtrack)
+
+        try:
+            self._frepo.add(trans_id, action)
+        except svr_repo.RepositoryError as e:
+            if progtrack:
+                progtrack.abort()
+            raise tx.TransportOperationError(str(e))
+        else:
+            if progtrack:
+                sz = int(action.attrs.get("pkg.size", 0))
+                progtrack.progress_callback(0, 0, sz, sz)
+
+    def publish_add_file(
+        self, pth, header=None, trans_id=None, basename=None, progtrack=None
+    ):
+        """The publish operation that adds a file to an existing
+        transaction."""
+
+        progclass = None
+        if progtrack:
+            progclass = FileProgress
+            progtrack = progclass(progtrack)
+        sz = int(os.path.getsize(pth))
+
+        try:
+            self._frepo.add_file(trans_id, pth, basename, size=sz)
+        except svr_repo.RepositoryError as e:
+            if progtrack:
+                progtrack.abort()
+            raise tx.TransportOperationError(str(e))
+        else:
+            if progtrack:
+                progtrack.progress_callback(0, 0, sz, sz)
+
+    def publish_add_manifest(self, pth, header=None, trans_id=None):
+        """The publish operation that adds a manifest to an existing
+        transaction."""
+
+        try:
+            self._frepo.add_manifest(trans_id, pth)
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+    def publish_abandon(self, header=None, trans_id=None):
+        """The abandon operation, that tells a Repository to abort
+        the current transaction.  The caller must specify the
+        transaction id in trans_id. Returns a (publish-state, fmri)
+        tuple."""
+
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        try:
+            pkg_state = self._frepo.abandon(trans_id)
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+        return None, pkg_state
+
+    def publish_close(self, header=None, trans_id=None, add_to_catalog=False):
+        """The close operation tells the Repository to commit
+        the transaction identified by trans_id.  The caller may
+        specify add_to_catalog, if needed.  This method returns a
+        (publish-state, fmri) tuple."""
+
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        try:
+            pkg_fmri, pkg_state = self._frepo.close(
+                trans_id, add_to_catalog=add_to_catalog
+            )
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+        return pkg_fmri, pkg_state
+
+    def publish_open(self, header=None, client_release=None, pkg_name=None):
+        """Begin a publication operation by calling 'open'.
+        The caller must specify the client's OS release in
+        client_release, and the package's name in pkg_name.
+        Returns a transaction-ID string."""
+
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        try:
+            trans_id = self._frepo.open(client_release, pkg_name)
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+        return trans_id
+
+    def publish_append(self, header=None, client_release=None, pkg_name=None):
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        try:
+            trans_id = self._frepo.append(client_release, pkg_name)
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+        return trans_id
+
+    def publish_rebuild(self, header=None, pub=None):
+        """Attempt to rebuild the package data and search data in the
+        repository."""
+
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        pub_prefix = getattr(pub, "prefix", None)
+        try:
+            self._frepo.rebuild(
+                pub=pub_prefix, build_catalog=True, build_index=True
+            )
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+    def publish_rebuild_indexes(self, header=None, pub=None):
+        """Attempt to rebuild the search data in the repository."""
+
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        pub_prefix = getattr(pub, "prefix", None)
+        try:
+            self._frepo.rebuild(
+                pub=pub_prefix, build_catalog=False, build_index=True
+            )
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+    def publish_rebuild_packages(self, header=None, pub=None):
+        """Attempt to rebuild the package data in the repository."""
+
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        pub_prefix = getattr(pub, "prefix", None)
+        try:
+            self._frepo.rebuild(
+                pub=pub_prefix, build_catalog=True, build_index=False
+            )
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+    def publish_refresh(self, header=None, pub=None):
+        """Attempt to refresh the package data and search data in the
+        repository."""
+
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        pub_prefix = getattr(pub, "prefix", None)
+        try:
+            self._frepo.add_content(pub=pub_prefix, refresh_index=True)
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+    def publish_refresh_indexes(self, header=None, pub=None):
+        """Attempt to refresh the search data in the repository."""
+
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        try:
+            self._frepo.refresh_index()
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+    def publish_refresh_packages(self, header=None, pub=None):
+        """Attempt to refresh the package data in the repository."""
+
+        # Calling any publication operation sets read_only to False.
+        self._frepo.read_only = False
+
+        pub_prefix = getattr(pub, "prefix", None)
+        try:
+            self._frepo.add_content(pub=pub_prefix, refresh_index=False)
+        except svr_repo.RepositoryError as e:
+            raise tx.TransportOperationError(str(e))
+
+    def supports_version(self, op, verlist):
+        """Returns version-id of highest supported version.
+        If the version is not supported, or no data is available,
+        -1 is returned instead."""
+
+        if not self.has_version_data() or op not in self._verdata:
+            return -1
+
+        # This code assumes that both the verlist and verdata
+        # are sorted in reverse order.  This behavior is currently
+        # implemented in the transport code.
+
+        for v in verlist:
+            if v in self._verdata[op]:
+                return v
+        return -1
+
+    def touch_manifest(self, mfst, header=None, ccancel=None, pub=None):
+        """No-op for file://."""
+
+        return True
+
+    def get_compressed_attrs(
+        self, fhash, header=None, pub=None, trans_id=None, hashes=True
+    ):
+        """Given a fhash, returns a tuple of (csize, chashes) where
+        'csize' is the size of the file in the repository and 'chashes'
+        is a dictionary containing any hashes of the compressed data
+        known by the repository.  If the repository cannot provide the
+        hash information or 'hashes' is False, chashes will be an empty
+        dictionary.  If the repository does not have the file, a tuple
+        of (None, None) will be returned instead."""
+
+        # If the publisher's prefix isn't contained in trans_id,
+        # assume the server doesn't have the file.
+        pfx = getattr(pub, "prefix", None)
+        if (
+            pfx
+            and trans_id
+            and quote("pkg://{0}/".format(pfx), safe="") not in trans_id
+        ):
+            return (None, None)
+
+        try:
+            # see if repository has file
+            fpath = self._frepo.file(fhash, pub=pfx)
+            if hashes:
+                csize, chashes = compute_compressed_attrs(
+                    fhash, file_path=fpath
+                )
+            else:
+                csize = os.stat(fpath).st_size
+                chashes = EmptyDict
+            return (csize, chashes)
+        except (
+            EnvironmentError,
+            svr_repo.RepositoryError,
+            svr_repo.RepositoryFileNotFoundError,
+        ):
+            # repository transport issue or does not have file
+            return (None, None)
+
+    def build_refetch_header(self, header):
+        """Pointless to attempt refetch of corrupt content for
+        this protocol."""
+
+        return header
+
 
 class _ArchiveRepo(TransportRepo):
-        """Private implementation of transport repository logic for repositories
-        contained within an archive.
-        """
+    """Private implementation of transport repository logic for repositories
+    contained within an archive.
+    """
 
-        def __init__(self, repostats, repouri, engine):
-                """Create a file repo.  Repostats is a RepoStats object.
-                Repouri is a TransportRepoURI object.  Engine is a transport
-                engine object.
+    def __init__(self, repostats, repouri, engine):
+        """Create a file repo.  Repostats is a RepoStats object.
+        Repouri is a TransportRepoURI object.  Engine is a transport
+        engine object.
 
-                The convenience function new_repo() can be used to create
-                the correct repo."""
+        The convenience function new_repo() can be used to create
+        the correct repo."""
 
-                self._arc = None
-                self._url = repostats.url
-                self._repouri = repouri
-                self._engine = engine
-                self._verdata = None
-                self.__stats = repostats
+        self._arc = None
+        self._url = repostats.url
+        self._repouri = repouri
+        self._engine = engine
+        self._verdata = None
+        self.__stats = repostats
 
-                try:
-                        scheme, netloc, path, params, query, fragment = \
-                            urlparse(self._repouri.uri, "file",
-                            allow_fragments=0)
-                        # Path must be rstripped of separators to be used as
-                        # a file.
-                        path = url2pathname(path.rstrip(os.path.sep))
-                        self._arc = pkg.p5p.Archive(path, mode="r")
-                except pkg.p5p.InvalidArchive as e:
-                        ex = tx.TransportProtoError("file", errno.EINVAL,
-                            reason=str(e), repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
-                except Exception as e:
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=str(e), repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
+        try:
+            scheme, netloc, path, params, query, fragment = urlparse(
+                self._repouri.uri, "file", allow_fragments=0
+            )
+            # Path must be rstripped of separators to be used as
+            # a file.
+            path = url2pathname(path.rstrip(os.path.sep))
+            self._arc = pkg.p5p.Archive(path, mode="r")
+        except pkg.p5p.InvalidArchive as e:
+            ex = tx.TransportProtoError(
+                "file", errno.EINVAL, reason=str(e), repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        except Exception as e:
+            ex = tx.TransportProtoError(
+                "file", errno.EPROTO, reason=str(e), repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
 
-        def __record_proto_error(self, ex):
-                """Private helper function that records a protocol error that
-                was raised by the class instead of the transport engine.  It
-                records both that a transaction was initiated and that an
-                error occurred."""
+    def __record_proto_error(self, ex):
+        """Private helper function that records a protocol error that
+        was raised by the class instead of the transport engine.  It
+        records both that a transaction was initiated and that an
+        error occurred."""
 
-                self.__stats.record_tx()
-                self.__stats.record_error(decayable=ex.decayable)
+        self.__stats.record_tx()
+        self.__stats.record_error(decayable=ex.decayable)
 
-        def add_version_data(self, verdict):
-                """Cache the information about what versions a repository
-                supports."""
+    def add_version_data(self, verdict):
+        """Cache the information about what versions a repository
+        supports."""
 
-                self._verdata = verdict
+        self._verdata = verdict
 
-        def get_status(self, header=None, ccancel=None):
-                """Get the archive status."""
+    def get_status(self, header=None, ccancel=None):
+        """Get the archive status."""
 
-                pubsinfo = {}
-                arcdata = {
-                    "repository": {
-                        "publishers": pubsinfo,
-                        "version": self._arc.version, # Version of archive.
-                    }
+        pubsinfo = {}
+        arcdata = {
+            "repository": {
+                "publishers": pubsinfo,
+                "version": self._arc.version,  # Version of archive.
+            }
+        }
+
+        for pub in self._arc.get_publishers():
+            try:
+                # Create temporary directory.
+                tmpdir = tempfile.mkdtemp(prefix="tmp.repo.")
+                # Get catalog.
+                self.get_catalog1(
+                    ["catalog.attrs"], tmpdir, pub=pub, header=header
+                )
+
+                cat = pkg.catalog.Catalog(meta_root=tmpdir)
+                pubinfo = {}
+                pubinfo[
+                    "last-catalog-update"
+                ] = pkg.catalog.datetime_to_basic_ts(cat.last_modified)
+                pubinfo["package-count"] = cat.package_count
+                pubinfo["status"] = "online"
+                pubsinfo[pub.prefix] = {
+                    "package-count": cat.package_count,
+                    "last-catalog-update": pkg.catalog.datetime_to_basic_ts(
+                        cat.last_modified
+                    ),
+                    "status": "online",
                 }
+            finally:
+                # Remove temporary directory if possible.
+                shutil.rmtree(tmpdir, ignore_errors=True)
 
-                for pub in self._arc.get_publishers():
-                        try:
-                                # Create temporary directory.
-                                tmpdir = tempfile.mkdtemp(prefix="tmp.repo.")
-                                # Get catalog.
-                                self.get_catalog1(["catalog.attrs"], tmpdir,
-                                    pub=pub, header=header)
+        buf = cStringIO()
+        try:
+            json.dump(
+                arcdata, buf, ensure_ascii=False, indent=2, sort_keys=True
+            )
+            buf.write("\n")
+        except Exception as e:
+            reason = "Unable to retrieve status data:\n{0}".format(e)
+            ex = tx.TransportProtoError(
+                "file", errno.EPROTO, reason=reason, repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        buf.seek(0)
+        return buf
 
-                                cat = pkg.catalog.Catalog(meta_root=tmpdir)
-                                pubinfo = {}
-                                pubinfo["last-catalog-update"] = \
-                                        pkg.catalog.datetime_to_basic_ts(
-                                            cat.last_modified)
-                                pubinfo["package-count"] = cat.package_count
-                                pubinfo["status"] = "online"
-                                pubsinfo[pub.prefix] = {
-                                    "package-count": cat.package_count,
-                                    "last-catalog-update":
-                                    pkg.catalog.datetime_to_basic_ts(
-                                    cat.last_modified),
-                                    "status": "online",
-                                }
-                        finally:
-                                # Remove temporary directory if possible.
-                                shutil.rmtree(tmpdir, ignore_errors=True)
+    def get_catalog1(
+        self,
+        filelist,
+        destloc,
+        header=None,
+        ts=None,
+        progtrack=None,
+        pub=None,
+        revalidate=False,
+        redownload=False,
+    ):
+        """Get the files that make up the catalog components
+        that are listed in 'filelist'.  Download the files to
+        the directory specified in 'destloc'.  The caller
+        may optionally specify a dictionary with header
+        elements in 'header'.  If a conditional get is
+        to be performed, 'ts' should contain a floating point
+        value of seconds since the epoch.  This protocol
+        doesn't implment revalidate and redownload.  The options
+        are ignored."""
 
-                buf = cStringIO()
-                try:
-                        json.dump(arcdata, buf, ensure_ascii=False, indent=2,
-                            sort_keys=True)
-                        buf.write("\n")
-                except Exception as e:
-                        reason = "Unable to retrieve status data:\n{0}".format(e)
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=reason, repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
-                buf.seek(0)
-                return buf
+        pub_prefix = getattr(pub, "prefix", None)
+        errors = []
+        for f in filelist:
+            try:
+                self._arc.extract_catalog1(f, destloc, pub=pub_prefix)
+                if progtrack:
+                    fs = os.stat(os.path.join(destloc, f))
+                    progtrack.refresh_progress(pub, fs.st_size)
+            except pkg.p5p.UnknownArchiveFiles as e:
+                ex = tx.TransportProtoError(
+                    "file",
+                    errno.ENOENT,
+                    reason=str(e),
+                    repourl=self._url,
+                    request=f,
+                )
+                self.__record_proto_error(ex)
+                errors.append(ex)
+                continue
+            except Exception as e:
+                ex = tx.TransportProtoError(
+                    "file",
+                    errno.EPROTO,
+                    reason=str(e),
+                    repourl=self._url,
+                    request=f,
+                )
+                self.__record_proto_error(ex)
+                errors.append(ex)
+                continue
+        return errors
 
-        def get_catalog1(self, filelist, destloc, header=None, ts=None,
-            progtrack=None, pub=None, revalidate=False, redownload=False):
-                """Get the files that make up the catalog components
-                that are listed in 'filelist'.  Download the files to
-                the directory specified in 'destloc'.  The caller
-                may optionally specify a dictionary with header
-                elements in 'header'.  If a conditional get is
-                to be performed, 'ts' should contain a floating point
-                value of seconds since the epoch.  This protocol
-                doesn't implment revalidate and redownload.  The options
-                are ignored."""
+    def get_datastream(
+        self, fhash, version, header=None, ccancel=None, pub=None
+    ):
+        """Get a datastream from a repo.  The name of the file is given
+        in fhash."""
 
-                pub_prefix = getattr(pub, "prefix", None)
-                errors = []
-                for f in filelist:
-                        try:
-                                self._arc.extract_catalog1(f, destloc,
-                                   pub=pub_prefix)
-                                if progtrack:
-                                        fs = os.stat(os.path.join(destloc, f))
-                                        progtrack.refresh_progress(pub,
-                                            fs.st_size)
-                        except pkg.p5p.UnknownArchiveFiles as e:
-                                ex = tx.TransportProtoError("file",
-                                    errno.ENOENT, reason=str(e),
-                                    repourl=self._url, request=f)
-                                self.__record_proto_error(ex)
-                                errors.append(ex)
-                                continue
-                        except Exception as e:
-                                ex = tx.TransportProtoError("file",
-                                    errno.EPROTO, reason=str(e),
-                                    repourl=self._url, request=f)
-                                self.__record_proto_error(ex)
-                                errors.append(ex)
-                                continue
-                return errors
+        pub_prefix = getattr(pub, "prefix", None)
+        try:
+            return self._arc.get_package_file(fhash, pub=pub_prefix)
+        except pkg.p5p.UnknownArchiveFiles as e:
+            ex = tx.TransportProtoError(
+                "file",
+                errno.ENOENT,
+                reason=str(e),
+                repourl=self._url,
+                request=fhash,
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        except Exception as e:
+            ex = tx.TransportProtoError(
+                "file",
+                errno.EPROTO,
+                reason=str(e),
+                repourl=self._url,
+                request=fhash,
+            )
+            self.__record_proto_error(ex)
+            raise ex
 
-        def get_datastream(self, fhash, version, header=None, ccancel=None,
-            pub=None):
-                """Get a datastream from a repo.  The name of the file is given
-                in fhash."""
+    def get_publisherinfo(self, header=None, ccancel=None):
+        """Get publisher information from the repository."""
 
-                pub_prefix = getattr(pub, "prefix", None)
-                try:
-                        return self._arc.get_package_file(fhash,
-                            pub=pub_prefix)
-                except pkg.p5p.UnknownArchiveFiles as e:
-                        ex = tx.TransportProtoError("file", errno.ENOENT,
-                            reason=str(e), repourl=self._url, request=fhash)
-                        self.__record_proto_error(ex)
-                        raise ex
-                except Exception as e:
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=str(e), repourl=self._url, request=fhash)
-                        self.__record_proto_error(ex)
-                        raise ex
+        try:
+            pubs = self._arc.get_publishers()
+            buf = cStringIO()
+            p5i.write(buf, pubs)
+        except Exception as e:
+            reason = (
+                "Unable to retrieve publisher configuration "
+                "data:\n{0}".format(e)
+            )
+            ex = tx.TransportProtoError(
+                "file", errno.EPROTO, reason=reason, repourl=self._url
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        buf.seek(0)
+        return buf
 
-        def get_publisherinfo(self, header=None, ccancel=None):
-                """Get publisher information from the repository."""
+    def get_manifest(self, fmri, header=None, ccancel=None, pub=None):
+        """Get a manifest from repo.  The fmri of the package for the
+        manifest is given in fmri."""
 
-                try:
-                        pubs = self._arc.get_publishers()
-                        buf = cStringIO()
-                        p5i.write(buf, pubs)
-                except Exception as e:
-                        reason = "Unable to retrieve publisher configuration " \
-                            "data:\n{0}".format(e)
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=reason, repourl=self._url)
-                        self.__record_proto_error(ex)
-                        raise ex
-                buf.seek(0)
-                return buf
+        try:
+            return self._arc.get_package_manifest(fmri, raw=True)
+        except pkg.p5p.UnknownPackageManifest as e:
+            ex = tx.TransportProtoError(
+                "file",
+                errno.ENOENT,
+                reason=str(e),
+                repourl=self._url,
+                request=fmri,
+            )
+            self.__record_proto_error(ex)
+            raise ex
+        except Exception as e:
+            ex = tx.TransportProtoError(
+                "file",
+                errno.EPROTO,
+                reason=str(e),
+                repourl=self._url,
+                request=fmri,
+            )
+            self.__record_proto_error(ex)
+            raise ex
 
-        def get_manifest(self, fmri, header=None, ccancel=None, pub=None):
-                """Get a manifest from repo.  The fmri of the package for the
-                manifest is given in fmri."""
+    def get_manifests(self, mfstlist, dest, progtrack=None, pub=None):
+        """Get manifests named in list.  The mfstlist argument contains
+        tuples (fmri, header).  This is so that each manifest may have
+        unique header information.  The destination directory is spec-
+        ified in the dest argument."""
 
-                try:
-                        return self._arc.get_package_manifest(fmri, raw=True)
-                except pkg.p5p.UnknownPackageManifest as e:
-                        ex = tx.TransportProtoError("file", errno.ENOENT,
-                            reason=str(e), repourl=self._url, request=fmri)
-                        self.__record_proto_error(ex)
-                        raise ex
-                except Exception as e:
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=str(e), repourl=self._url, request=fmri)
-                        self.__record_proto_error(ex)
-                        raise ex
+        errors = []
+        for fmri, h in mfstlist:
+            try:
+                self._arc.extract_package_manifest(
+                    fmri, dest, filename=fmri.get_url_path()
+                )
+                if progtrack:
+                    fs = os.stat(os.path.join(dest, fmri.get_url_path()))
+                    progtrack.manifest_fetch_progress(completion=True)
+            except pkg.p5p.UnknownPackageManifest as e:
+                ex = tx.TransportProtoError(
+                    "file",
+                    errno.ENOENT,
+                    reason=str(e),
+                    repourl=self._url,
+                    request=fmri,
+                )
+                self.__record_proto_error(ex)
+                errors.append(ex)
+                continue
+            except Exception as e:
+                ex = tx.TransportProtoError(
+                    "file",
+                    errno.EPROTO,
+                    reason=str(e),
+                    repourl=self._url,
+                    request=fmri,
+                )
+                self.__record_proto_error(ex)
+                errors.append(ex)
+                continue
+        return errors
 
-        def get_manifests(self, mfstlist, dest, progtrack=None, pub=None):
-                """Get manifests named in list.  The mfstlist argument contains
-                tuples (fmri, header).  This is so that each manifest may have
-                unique header information.  The destination directory is spec-
-                ified in the dest argument."""
+    def get_files(
+        self, filelist, dest, progtrack, version, header=None, pub=None
+    ):
+        """Get multiple files from the repo at once.
+        The files are named by hash and supplied in filelist.
+        If dest is specified, download to the destination
+        directory that is given.  If progtrack is not None,
+        it contains a ProgressTracker object for the
+        downloads."""
 
-                errors = []
-                for fmri, h in mfstlist:
-                        try:
-                                self._arc.extract_package_manifest(fmri, dest,
-                                   filename=fmri.get_url_path())
-                                if progtrack:
-                                        fs = os.stat(os.path.join(dest,
-                                            fmri.get_url_path()))
-                                        progtrack.manifest_fetch_progress(
-                                            completion=True)
-                        except pkg.p5p.UnknownPackageManifest as e:
-                                ex = tx.TransportProtoError("file",
-                                    errno.ENOENT, reason=str(e),
-                                    repourl=self._url, request=fmri)
-                                self.__record_proto_error(ex)
-                                errors.append(ex)
-                                continue
-                        except Exception as e:
-                                ex = tx.TransportProtoError("file",
-                                    errno.EPROTO, reason=str(e),
-                                    repourl=self._url, request=fmri)
-                                self.__record_proto_error(ex)
-                                errors.append(ex)
-                                continue
-                return errors
+        pub_prefix = getattr(pub, "prefix", None)
+        errors = []
+        for f in filelist:
+            try:
+                self._arc.extract_package_files([f], dest, pub=pub_prefix)
+                if progtrack:
+                    fs = os.stat(os.path.join(dest, f))
+                    progtrack.download_add_progress(1, fs.st_size)
+            except pkg.p5p.UnknownArchiveFiles as e:
+                ex = tx.TransportProtoError(
+                    "file",
+                    errno.ENOENT,
+                    reason=str(e),
+                    repourl=self._url,
+                    request=f,
+                )
+                self.__record_proto_error(ex)
+                errors.append(ex)
+                continue
+            except Exception as e:
+                ex = tx.TransportProtoError(
+                    "file",
+                    errno.EPROTO,
+                    reason=str(e),
+                    repourl=self._url,
+                    request=f,
+                )
+                self.__record_proto_error(ex)
+                errors.append(ex)
+                continue
+        return errors
 
-        def get_files(self, filelist, dest, progtrack, version, header=None, pub=None):
-                """Get multiple files from the repo at once.
-                The files are named by hash and supplied in filelist.
-                If dest is specified, download to the destination
-                directory that is given.  If progtrack is not None,
-                it contains a ProgressTracker object for the
-                downloads."""
+    def get_url(self):
+        """Returns the repo's url."""
 
-                pub_prefix = getattr(pub, "prefix", None)
-                errors = []
-                for f in filelist:
-                        try:
-                                self._arc.extract_package_files([f], dest,
-                                    pub=pub_prefix)
-                                if progtrack:
-                                        fs = os.stat(os.path.join(dest, f))
-                                        progtrack.download_add_progress(1,
-                                            fs.st_size)
-                        except pkg.p5p.UnknownArchiveFiles as e:
-                                ex = tx.TransportProtoError("file",
-                                    errno.ENOENT, reason=str(e),
-                                    repourl=self._url, request=f)
-                                self.__record_proto_error(ex)
-                                errors.append(ex)
-                                continue
-                        except Exception as e:
-                                ex = tx.TransportProtoError("file",
-                                    errno.EPROTO, reason=str(e),
-                                    repourl=self._url, request=f)
-                                self.__record_proto_error(ex)
-                                errors.append(ex)
-                                continue
-                return errors
+        return self._url
 
-        def get_url(self):
-                """Returns the repo's url."""
+    def get_repouri_key(self):
+        """Returns the repo's RepositoryURI."""
 
-                return self._url
+        return self._repouri.key()
 
-        def get_repouri_key(self):
-                """Returns the repo's RepositoryURI."""
+    def get_versions(self, header=None, ccancel=None):
+        """Query the repo for versions information.
+        Returns a file-like object."""
 
-                return self._repouri.key()
+        buf = cStringIO()
+        vops = {
+            "catalog": ["1"],
+            "file": ["0"],
+            "manifest": ["0"],
+            "publisher": ["0", "1"],
+            "versions": ["0"],
+            "status": ["0"],
+        }
 
-        def get_versions(self, header=None, ccancel=None):
-                """Query the repo for versions information.
-                Returns a file-like object."""
+        buf.write("pkg-server {0}\n".format(pkg.VERSION))
+        buf.write(
+            "\n".join(
+                "{0} {1}".format(op, " ".join(vers))
+                for op, vers in six.iteritems(vops)
+            )
+            + "\n"
+        )
+        buf.seek(0)
+        self.__stats.record_tx()
+        return buf
 
-                buf = cStringIO()
-                vops = {
-                    "catalog": ["1"],
-                    "file": ["0"],
-                    "manifest": ["0"],
-                    "publisher": ["0", "1"],
-                    "versions": ["0"],
-                    "status": ["0"]
-                }
+    def has_version_data(self):
+        """Returns true if this repo knows its version information."""
 
-                buf.write("pkg-server {0}\n".format(pkg.VERSION))
-                buf.write("\n".join(
-                    "{0} {1}".format(op, " ".join(vers))
-                    for op, vers in six.iteritems(vops)
-                ) + "\n")
-                buf.seek(0)
-                self.__stats.record_tx()
-                return buf
+        return self._verdata is not None
 
-        def has_version_data(self):
-                """Returns true if this repo knows its version information."""
+    def supports_version(self, op, verlist):
+        """Returns version-id of highest supported version.
+        If the version is not supported, or no data is available,
+        -1 is returned instead."""
 
-                return self._verdata is not None
+        if not self.has_version_data() or op not in self._verdata:
+            return -1
 
-        def supports_version(self, op, verlist):
-                """Returns version-id of highest supported version.
-                If the version is not supported, or no data is available,
-                -1 is returned instead."""
+        # This code assumes that both the verlist and verdata
+        # are sorted in reverse order.  This behavior is currently
+        # implemented in the transport code.
 
-                if not self.has_version_data() or op not in self._verdata:
-                        return -1
+        for v in verlist:
+            if v in self._verdata[op]:
+                return v
+        return -1
 
-                # This code assumes that both the verlist and verdata
-                # are sorted in reverse order.  This behavior is currently
-                # implemented in the transport code.
+    def touch_manifest(self, mfst, header=None, ccancel=None, pub=None):
+        """No-op."""
+        return True
 
-                for v in verlist:
-                        if v in self._verdata[op]:
-                                return v
-                return -1
-
-        def touch_manifest(self, mfst, header=None, ccancel=None, pub=None):
-                """No-op."""
-                return True
-
-        def build_refetch_header(self, header):
-                """Pointless to attempt refetch of corrupt content for
-                  this protocol."""
-                return header
+    def build_refetch_header(self, header):
+        """Pointless to attempt refetch of corrupt content for
+        this protocol."""
+        return header
 
 
 class FileRepo(object):
-        """Factory class for creating transport repository objects for
-        filesystem-based repository sources.
-        """
+    """Factory class for creating transport repository objects for
+    filesystem-based repository sources.
+    """
 
-        def __new__(cls, repostats, repouri, engine, frepo=None):
-                """Returns a new transport repository object based on the
-                provided information.
+    def __new__(cls, repostats, repouri, engine, frepo=None):
+        """Returns a new transport repository object based on the
+        provided information.
 
-                'repostats' is a RepoStats object.
+        'repostats' is a RepoStats object.
 
-                'repouri' is a TransportRepoURI object.
+        'repouri' is a TransportRepoURI object.
 
-                'engine' is a transport engine object.
+        'engine' is a transport engine object.
 
-                'frepo' is an optional Repository object to use instead
-                of creating one.
+        'frepo' is an optional Repository object to use instead
+        of creating one.
 
-                The convenience function new_repo() can be used to create
-                the correct repo."""
+        The convenience function new_repo() can be used to create
+        the correct repo."""
 
-                try:
-                        scheme, netloc, path, params, query, fragment = \
-                            urlparse(repouri.uri, "file",
-                            allow_fragments=0)
-                        path = url2pathname(path)
-                except Exception as e:
-                        ex = tx.TransportProtoError("file", errno.EPROTO,
-                            reason=str(e), repourl=repostats.url)
-                        repostats.record_tx()
-                        repostats.record_error(decayable=ex.decayable)
-                        raise ex
+        try:
+            scheme, netloc, path, params, query, fragment = urlparse(
+                repouri.uri, "file", allow_fragments=0
+            )
+            path = url2pathname(path)
+        except Exception as e:
+            ex = tx.TransportProtoError(
+                "file", errno.EPROTO, reason=str(e), repourl=repostats.url
+            )
+            repostats.record_tx()
+            repostats.record_error(decayable=ex.decayable)
+            raise ex
 
-                # Path must be rstripped of separators for this check to
-                # succeed.
-                if not frepo and os.path.isfile(path.rstrip(os.path.sep)):
-                        # Assume target is a repository archive.
-                        return _ArchiveRepo(repostats, repouri, engine)
+        # Path must be rstripped of separators for this check to
+        # succeed.
+        if not frepo and os.path.isfile(path.rstrip(os.path.sep)):
+            # Assume target is a repository archive.
+            return _ArchiveRepo(repostats, repouri, engine)
 
-                # Assume target is a filesystem repository.
-                return _FilesystemRepo(repostats, repouri, engine, frepo=frepo)
+        # Assume target is a filesystem repository.
+        return _FilesystemRepo(repostats, repouri, engine, frepo=frepo)
 
 
 # ProgressCallback objects that bridge the interfaces between ProgressTracker,
 # and the necessary callbacks for the TransportEngine.
 
+
 class ProgressCallback(object):
-        """This class bridges the interfaces between a ProgressTracker
-        object and the progress callback that's provided by Pycurl.
-        Since progress callbacks are per curl handle, and handles aren't
-        guaranteed to succeed, this object watches a handle's progress
-        and updates the tracker accordingly."""
+    """This class bridges the interfaces between a ProgressTracker
+    object and the progress callback that's provided by Pycurl.
+    Since progress callbacks are per curl handle, and handles aren't
+    guaranteed to succeed, this object watches a handle's progress
+    and updates the tracker accordingly."""
 
-        def __init__(self, progtrack):
-                self.progtrack = progtrack
+    def __init__(self, progtrack):
+        self.progtrack = progtrack
 
-        def abort(self):
-                """Download failed."""
-                pass
+    def abort(self):
+        """Download failed."""
+        pass
 
-        def commit(self, size):
-                """This download has succeeded.  The size argument is
-                the total size that the client received."""
-                pass
+    def commit(self, size):
+        """This download has succeeded.  The size argument is
+        the total size that the client received."""
+        pass
 
-        def progress_callback(self, dltot, dlcur, ultot, ulcur):
-                """Called by pycurl/libcurl framework to update
-                progress tracking."""
+    def progress_callback(self, dltot, dlcur, ultot, ulcur):
+        """Called by pycurl/libcurl framework to update
+        progress tracking."""
 
-                if hasattr(self.progtrack, "check_cancelation") and \
-                    self.progtrack.check_cancelation():
-                        return -1
+        if (
+            hasattr(self.progtrack, "check_cancelation")
+            and self.progtrack.check_cancelation()
+        ):
+            return -1
 
-                return 0
+        return 0
+
 
 class CatalogProgress(ProgressCallback):
-        """This class bridges the interfaces between a ProgressTracker's
-        refresh code and the progress callback for that's provided by Pycurl."""
+    """This class bridges the interfaces between a ProgressTracker's
+    refresh code and the progress callback for that's provided by Pycurl."""
 
-        def __init__(self, progtrack):
-                ProgressCallback.__init__(self, progtrack)
-                self.dltotal = 0
-                self.dlcurrent = 0
-                self.completed = False
+    def __init__(self, progtrack):
+        ProgressCallback.__init__(self, progtrack)
+        self.dltotal = 0
+        self.dlcurrent = 0
+        self.completed = False
 
-        def abort(self):
-                """Download failed.  Remove the amount of bytes downloaded
-                by this file from the ProgressTracker."""
+    def abort(self):
+        """Download failed.  Remove the amount of bytes downloaded
+        by this file from the ProgressTracker."""
 
-                self.progtrack.refresh_progress(None, -self.dlcurrent)
-                self.completed = True
+        self.progtrack.refresh_progress(None, -self.dlcurrent)
+        self.completed = True
 
-        def commit(self, size):
-                #
-                # This callback is not interesting to us because
-                # catalogs are stored uncompressed-- and size is the
-                # size of the resultant object on disk, not the total
-                # xfer size.
-                #
-                pass
+    def commit(self, size):
+        #
+        # This callback is not interesting to us because
+        # catalogs are stored uncompressed-- and size is the
+        # size of the resultant object on disk, not the total
+        # xfer size.
+        #
+        pass
 
+    def progress_callback(self, dltot, dlcur, ultot, ulcur):
+        """Called by pycurl/libcurl framework to update
+        progress tracking."""
 
-        def progress_callback(self, dltot, dlcur, ultot, ulcur):
-                """Called by pycurl/libcurl framework to update
-                progress tracking."""
+        if (
+            hasattr(self.progtrack, "check_cancelation")
+            and self.progtrack.check_cancelation()
+        ):
+            return -1
 
-                if hasattr(self.progtrack, "check_cancelation") and \
-                    self.progtrack.check_cancelation():
-                        return -1
+        if self.dltotal != dltot:
+            self.dltotal = dltot
 
-                if self.dltotal != dltot:
-                        self.dltotal = dltot
+        new_progress = int(dlcur - self.dlcurrent)
+        if new_progress > 0:
+            self.dlcurrent += new_progress
+            self.progtrack.refresh_progress(None, new_progress)
 
-                new_progress = int(dlcur - self.dlcurrent)
-                if new_progress > 0:
-                        self.dlcurrent += new_progress
-                        self.progtrack.refresh_progress(None, new_progress)
+        return 0
 
-                return 0
 
 class ManifestProgress(ProgressCallback):
-        """This class bridges the interfaces between a ProgressTracker's
-        manifest fetching code and the progress callback for that's provided by
-        Pycurl."""
+    """This class bridges the interfaces between a ProgressTracker's
+    manifest fetching code and the progress callback for that's provided by
+    Pycurl."""
 
-        def abort(self):
-                """Download failed.  Remove the amount of bytes downloaded
-                by this file from the ProgressTracker."""
-                pass
+    def abort(self):
+        """Download failed.  Remove the amount of bytes downloaded
+        by this file from the ProgressTracker."""
+        pass
 
-        def commit(self, size):
-                """Indicate that this download has succeeded."""
-                self.progtrack.manifest_fetch_progress(completion=True)
+    def commit(self, size):
+        """Indicate that this download has succeeded."""
+        self.progtrack.manifest_fetch_progress(completion=True)
 
-        def progress_callback(self, dltot, dlcur, ultot, ulcur):
-                """Called by pycurl/libcurl framework to update
-                progress tracking."""
+    def progress_callback(self, dltot, dlcur, ultot, ulcur):
+        """Called by pycurl/libcurl framework to update
+        progress tracking."""
 
-                if hasattr(self.progtrack, "check_cancelation") and \
-                    self.progtrack.check_cancelation():
-                        return -1
-                self.progtrack.manifest_fetch_progress(completion=False)
-                return 0
+        if (
+            hasattr(self.progtrack, "check_cancelation")
+            and self.progtrack.check_cancelation()
+        ):
+            return -1
+        self.progtrack.manifest_fetch_progress(completion=False)
+        return 0
+
 
 class FileProgress(ProgressCallback):
-        """This class bridges the interfaces between a ProgressTracker
-        object and the progress callback that's provided by Pycurl.
-        Since progress callbacks are per curl handle, and handles aren't
-        guaranteed to succeed, this object watches a handle's progress
-        and updates the tracker accordingly.  If the handle fails,
-        it will correctly remove the bytes from the file.  The curl
-        callback reports bytes even when it doesn't make progress.
-        It's necessary to keep additonal state here, since the client's
-        ProgressTracker has global counts of the bytes.  If we're
-        unable to keep a per-file count, the numbers will get
-        lost quickly."""
+    """This class bridges the interfaces between a ProgressTracker
+    object and the progress callback that's provided by Pycurl.
+    Since progress callbacks are per curl handle, and handles aren't
+    guaranteed to succeed, this object watches a handle's progress
+    and updates the tracker accordingly.  If the handle fails,
+    it will correctly remove the bytes from the file.  The curl
+    callback reports bytes even when it doesn't make progress.
+    It's necessary to keep additonal state here, since the client's
+    ProgressTracker has global counts of the bytes.  If we're
+    unable to keep a per-file count, the numbers will get
+    lost quickly."""
 
-        def __init__(self, progtrack):
-                ProgressCallback.__init__(self, progtrack)
-                self.dltotal = 0
-                self.dlcurrent = 0
-                self.ultotal = 0
-                self.ulcurrent = 0
-                self.completed = False
+    def __init__(self, progtrack):
+        ProgressCallback.__init__(self, progtrack)
+        self.dltotal = 0
+        self.dlcurrent = 0
+        self.ultotal = 0
+        self.ulcurrent = 0
+        self.completed = False
 
-        def abort(self):
-                """Download failed.  Remove the amount of bytes downloaded
-                by this file from the ProgressTracker."""
+    def abort(self):
+        """Download failed.  Remove the amount of bytes downloaded
+        by this file from the ProgressTracker."""
 
-                self.progtrack.download_add_progress(0, -self.dlcurrent)
-                self.progtrack.upload_add_progress(-self.ulcurrent)
-                self.completed = True
+        self.progtrack.download_add_progress(0, -self.dlcurrent)
+        self.progtrack.upload_add_progress(-self.ulcurrent)
+        self.completed = True
 
-        def commit(self, size):
-                """Indicate that this download has succeeded.  The size
-                argument is the total size that we received.  Compare this
-                value against the dlcurrent.  If it's out of sync, which
-                can happen if the underlying framework swaps our request
-                across connections, adjust the progress tracker by the
-                amount we're off."""
+    def commit(self, size):
+        """Indicate that this download has succeeded.  The size
+        argument is the total size that we received.  Compare this
+        value against the dlcurrent.  If it's out of sync, which
+        can happen if the underlying framework swaps our request
+        across connections, adjust the progress tracker by the
+        amount we're off."""
 
-                adjustment = int(size - self.dlcurrent)
+        adjustment = int(size - self.dlcurrent)
 
-                self.progtrack.download_add_progress(1, adjustment)
-                self.completed = True
+        self.progtrack.download_add_progress(1, adjustment)
+        self.completed = True
 
-        def progress_callback(self, dltot, dlcur, ultot, ulcur):
-                """Called by pycurl/libcurl framework to update
-                progress tracking."""
+    def progress_callback(self, dltot, dlcur, ultot, ulcur):
+        """Called by pycurl/libcurl framework to update
+        progress tracking."""
 
-                if hasattr(self.progtrack, "check_cancelation") and \
-                    self.progtrack.check_cancelation():
-                        return -1
+        if (
+            hasattr(self.progtrack, "check_cancelation")
+            and self.progtrack.check_cancelation()
+        ):
+            return -1
 
-                if self.completed:
-                        return 0
+        if self.completed:
+            return 0
 
-                if self.dltotal != dltot:
-                        self.dltotal = dltot
+        if self.dltotal != dltot:
+            self.dltotal = dltot
 
-                new_progress = int(dlcur - self.dlcurrent)
-                if new_progress > 0:
-                        self.dlcurrent += new_progress
-                        self.progtrack.download_add_progress(0, new_progress)
+        new_progress = int(dlcur - self.dlcurrent)
+        if new_progress > 0:
+            self.dlcurrent += new_progress
+            self.progtrack.download_add_progress(0, new_progress)
 
-                if self.ultotal != ultot:
-                        self.ultotal = ultot
+        if self.ultotal != ultot:
+            self.ultotal = ultot
 
-                new_progress = int(ulcur - self.ulcurrent)
-                if new_progress > 0:
-                        self.ulcurrent += new_progress
-                        self.progtrack.upload_add_progress(new_progress)
+        new_progress = int(ulcur - self.ulcurrent)
+        if new_progress > 0:
+            self.ulcurrent += new_progress
+            self.progtrack.upload_add_progress(new_progress)
 
-                return 0
+        return 0
 
 
 # cache transport repo objects, so one isn't created on every operation
 
+
 class RepoCache(object):
-        """An Object that caches repository objects.  Used to make
-        sure that repos are re-used instead of re-created for each
-        operation. The objects are keyed by TransportRepoURI.key()
-        objects."""
+    """An Object that caches repository objects.  Used to make
+    sure that repos are re-used instead of re-created for each
+    operation. The objects are keyed by TransportRepoURI.key()
+    objects."""
 
-        # Schemes supported by the cache.
-        supported_schemes = {
-            "file": FileRepo,
-            "http": HTTPRepo,
-            "https": HTTPSRepo,
-        }
+    # Schemes supported by the cache.
+    supported_schemes = {
+        "file": FileRepo,
+        "http": HTTPRepo,
+        "https": HTTPSRepo,
+    }
 
-        update_schemes = {
-            "file": FileRepo
-        }
+    update_schemes = {"file": FileRepo}
 
-        def __init__(self, engine):
-                """Caller must include a TransportEngine."""
+    def __init__(self, engine):
+        """Caller must include a TransportEngine."""
 
-                self.__engine = engine
-                self.__cache = {}
+        self.__engine = engine
+        self.__cache = {}
 
-        def __contains__(self, repouri):
-                return repouri.key() in self.__cache
+    def __contains__(self, repouri):
+        return repouri.key() in self.__cache
 
-        def clear_cache(self):
-                """Flush the contents of the cache."""
+    def clear_cache(self):
+        """Flush the contents of the cache."""
 
-                self.__cache = {}
+        self.__cache = {}
 
-        def new_repo(self, repostats, repouri):
-                """Create a new repo server for the given repouri object."""
+    def new_repo(self, repostats, repouri):
+        """Create a new repo server for the given repouri object."""
 
-                scheme = repouri.scheme
+        scheme = repouri.scheme
 
-                if scheme not in RepoCache.supported_schemes:
-                        raise tx.TransportOperationError("Scheme {0} not"
-                            " supported by transport.".format(scheme))
+        if scheme not in RepoCache.supported_schemes:
+            raise tx.TransportOperationError(
+                "Scheme {0} not" " supported by transport.".format(scheme)
+            )
 
-                if repouri.key() in self.__cache:
-                        return self.__cache[repouri.key()]
+        if repouri.key() in self.__cache:
+            return self.__cache[repouri.key()]
 
-                repo = RepoCache.supported_schemes[scheme](repostats, repouri,
-                    self.__engine)
+        repo = RepoCache.supported_schemes[scheme](
+            repostats, repouri, self.__engine
+        )
 
-                self.__cache[repouri.key()] = repo
-                return repo
+        self.__cache[repouri.key()] = repo
+        return repo
 
-        def update_repo(self, repostats, repouri, repository):
-                """For the FileRepo, some callers need to update its
-                Repository object.  They should use this method to do so.
-                If the Repo isn't in the cache, it's created and added."""
+    def update_repo(self, repostats, repouri, repository):
+        """For the FileRepo, some callers need to update its
+        Repository object.  They should use this method to do so.
+        If the Repo isn't in the cache, it's created and added."""
 
-                scheme = repouri.scheme
+        scheme = repouri.scheme
 
-                if scheme not in RepoCache.update_schemes:
-                        return
+        if scheme not in RepoCache.update_schemes:
+            return
 
-                if repouri.key() in self.__cache:
-                        repo = self.__cache[repouri.key()]
-                        repo._frepo = repository
-                        return
+        if repouri.key() in self.__cache:
+            repo = self.__cache[repouri.key()]
+            repo._frepo = repository
+            return
 
-                repo = RepoCache.update_schemes[scheme](repostats, repouri,
-                    self.__engine, frepo=repository)
+        repo = RepoCache.update_schemes[scheme](
+            repostats, repouri, self.__engine, frepo=repository
+        )
 
-                self.__cache[repouri.key()] = repo
+        self.__cache[repouri.key()] = repo
 
-        def remove_repo(self, repo=None, url=None):
-                """Remove a repo from the cache.  Caller must supply
-                either a TransportRepoURI object or a URL."""
-                self.contents()
+    def remove_repo(self, repo=None, url=None):
+        """Remove a repo from the cache.  Caller must supply
+        either a TransportRepoURI object or a URL."""
+        self.contents()
 
-                if repo:
-                        repouri = repo
-                if url:
-                        repouri = TransportRepoURI(url)
-                else:
-                        raise ValueError("Must supply either a repo or a uri.")
+        if repo:
+            repouri = repo
+        if url:
+            repouri = TransportRepoURI(url)
+        else:
+            raise ValueError("Must supply either a repo or a uri.")
 
-                if repouri.key() in self.__cache:
-                        del self.__cache[repouri.key()]
+        if repouri.key() in self.__cache:
+            del self.__cache[repouri.key()]
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/transport/stats.py
+++ b/src/modules/client/transport/stats.py
@@ -34,517 +34,547 @@ import pkg.misc as misc
 
 
 class RepoChooser(object):
-        """An object that contains repo statistics.  It applies algorithms
-        to choose an optimal set of repos for a given publisher, based
-        upon the observed repo statistics.
+    """An object that contains repo statistics.  It applies algorithms
+    to choose an optimal set of repos for a given publisher, based
+    upon the observed repo statistics.
 
-        The RepoChooser object is a container for RepoStats objects.
-        It's used to return the RepoStats in an ordered list, which
-        helps the transport pick the best performing destination."""
+    The RepoChooser object is a container for RepoStats objects.
+    It's used to return the RepoStats in an ordered list, which
+    helps the transport pick the best performing destination."""
 
-        def __init__(self):
-                # A dictionary containing the RepoStats objects. The dictionary
-                # uses TransportRepoURI.key() values as its key.
-                self.__rsobj = {}
+    def __init__(self):
+        # A dictionary containing the RepoStats objects. The dictionary
+        # uses TransportRepoURI.key() values as its key.
+        self.__rsobj = {}
 
-        def __getitem__(self, key):
-                return self.__rsobj[key]
+    def __getitem__(self, key):
+        return self.__rsobj[key]
 
-        def __contains__(self, key):
-                return key in self.__rsobj
+    def __contains__(self, key):
+        return key in self.__rsobj
 
-        def __get_proxy(self, ds):
-                """Gets the proxy that was used at runtime for a given
-                RepoStats object.  This may differ from the persistent
-                configuration of any given TransportRepoURI.  We do not use the
-                ds.runtime_proxy value, since that may include cleartext
-                passwords."""
+    def __get_proxy(self, ds):
+        """Gets the proxy that was used at runtime for a given
+        RepoStats object.  This may differ from the persistent
+        configuration of any given TransportRepoURI.  We do not use the
+        ds.runtime_proxy value, since that may include cleartext
+        passwords."""
 
-                # we don't allow the proxy used for the system publisher to be
-                # overridden
-                if ds.system:
-                        if not ds.proxy:
-                                return "-"
-                        return ds.proxy
+        # we don't allow the proxy used for the system publisher to be
+        # overridden
+        if ds.system:
+            if not ds.proxy:
+                return "-"
+            return ds.proxy
 
-                proxy = misc.get_runtime_proxy(ds.proxy, ds.url)
-                if not proxy:
-                        return "-"
-                return proxy
+        proxy = misc.get_runtime_proxy(ds.proxy, ds.url)
+        if not proxy:
+            return "-"
+        return proxy
 
-        def dump(self):
-                """Write the repo statistics to stdout."""
+    def dump(self):
+        """Write the repo statistics to stdout."""
 
-                hfmt = "{0:41.41} {1:30} {2:6} {3:4} {4:4} {5:8} {6:10} {7:5} {8:7} {9:4}"
-                dfmt = "{0:41.41} {1:30} {2:6} {3:4} {4:4} {5:8} {6:10} {7:5} {8:6f} {9:4}"
-                misc.msg(hfmt.format("URL", "Proxy", "Good", "Err", "Conn",
-                    "Speed", "Size", "Used", "CSpeed", "Qual"))
+        hfmt = (
+            "{0:41.41} {1:30} {2:6} {3:4} {4:4} {5:8} {6:10} {7:5} {8:7} {9:4}"
+        )
+        dfmt = (
+            "{0:41.41} {1:30} {2:6} {3:4} {4:4} {5:8} {6:10} {7:5} {8:6f} {9:4}"
+        )
+        misc.msg(
+            hfmt.format(
+                "URL",
+                "Proxy",
+                "Good",
+                "Err",
+                "Conn",
+                "Speed",
+                "Size",
+                "Used",
+                "CSpeed",
+                "Qual",
+            )
+        )
 
-                for ds in self.__rsobj.values():
+        for ds in self.__rsobj.values():
+            speedstr = misc.bytes_to_str(
+                ds.transfer_speed, "{num:>.0f} {unit}/s"
+            )
 
-                        speedstr = misc.bytes_to_str(ds.transfer_speed,
-                            "{num:>.0f} {unit}/s")
+            sizestr = misc.bytes_to_str(ds.bytes_xfr)
+            proxy = self.__get_proxy(ds)
+            misc.msg(
+                dfmt.format(
+                    ds.url,
+                    proxy,
+                    ds.success,
+                    ds.failures,
+                    ds.num_connect,
+                    speedstr,
+                    sizestr,
+                    ds.used,
+                    ds.connect_time,
+                    ds.quality,
+                )
+            )
 
-                        sizestr = misc.bytes_to_str(ds.bytes_xfr)
-                        proxy = self.__get_proxy(ds)
-                        misc.msg(dfmt.format(ds.url, proxy, ds.success,
-                            ds.failures, ds.num_connect, speedstr, sizestr,
-                            ds.used, ds.connect_time, ds.quality))
+    def get_num_visited(self, repouri_list):
+        """Walk a list of TransportRepoURIs and return the number
+        that have been visited as an integer.  If a repository
+        is in the list, but we don't know about it yet, create a
+        stats object to keep track of it, and include it in
+        the visited count."""
 
-        def get_num_visited(self, repouri_list):
-                """Walk a list of TransportRepoURIs and return the number
-                that have been visited as an integer.  If a repository
-                is in the list, but we don't know about it yet, create a
-                stats object to keep track of it, and include it in
-                the visited count."""
+        found_rs = []
 
-                found_rs = []
+        for ruri in repouri_list:
+            key = ruri.key()
+            if key in self.__rsobj:
+                rs = self.__rsobj[key]
+            else:
+                rs = RepoStats(ruri)
+                self.__rsobj[key] = rs
+            found_rs.append((rs, ruri))
 
-                for ruri in repouri_list:
-                        key = ruri.key()
-                        if key in self.__rsobj:
-                                rs = self.__rsobj[key]
-                        else:
-                                rs = RepoStats(ruri)
-                                self.__rsobj[key] = rs
-                        found_rs.append((rs, ruri))
+        return len([x for x in found_rs if x[0].used])
 
-                return len([x for x in found_rs if x[0].used])
+    def get_repostats(self, repouri_list, origin_list=misc.EmptyI):
+        """Walk a list of TransportRepoURIs and return a sorted list of
+        status objects.  The better choices should be at the
+        beginning of the list."""
 
-        def get_repostats(self, repouri_list, origin_list=misc.EmptyI):
-                """Walk a list of TransportRepoURIs and return a sorted list of
-                status objects.  The better choices should be at the
-                beginning of the list."""
+        found_rs = []
+        origin_speed = 0
+        origin_count = 0
+        origin_avg_speed = 0
+        origin_cspeed = 0
+        origin_ccount = 0
+        origin_avg_cspeed = 0
 
-                found_rs = []
-                origin_speed = 0
-                origin_count = 0
-                origin_avg_speed = 0
-                origin_cspeed = 0
-                origin_ccount = 0
-                origin_avg_cspeed = 0
+        for ouri in origin_list:
+            key = ouri.key()
+            if key in self.__rsobj:
+                rs = self.__rsobj[key]
+                if rs.bytes_xfr > 0:
+                    # Exclude sources that don't
+                    # contribute to transfer speed.
+                    origin_speed += rs.transfer_speed
+                    origin_count += 1
+                if rs.connect_time > 0:
+                    # Exclude sources that don't
+                    # contribute to connection
+                    # time.
+                    origin_cspeed += rs.connect_time
+                    origin_ccount += 1
+            else:
+                rs = RepoStats(ouri)
+                self.__rsobj[key] = rs
 
-                for ouri in origin_list:
-                        key = ouri.key()
-                        if key in self.__rsobj:
-                                rs = self.__rsobj[key]
-                                if rs.bytes_xfr > 0:
-                                        # Exclude sources that don't
-                                        # contribute to transfer speed.
-                                        origin_speed += rs.transfer_speed
-                                        origin_count += 1
-                                if rs.connect_time > 0:
-                                        # Exclude sources that don't
-                                        # contribute to connection
-                                        # time.
-                                        origin_cspeed += rs.connect_time
-                                        origin_ccount += 1
-                        else:
-                                rs = RepoStats(ouri)
-                                self.__rsobj[key] = rs
+        if origin_count > 0:
+            origin_avg_speed = origin_speed // origin_count
+        if origin_ccount > 0:
+            origin_avg_cspeed = origin_cspeed // origin_ccount
 
-                if origin_count > 0:
-                        origin_avg_speed = origin_speed // origin_count
-                if origin_ccount > 0:
-                        origin_avg_cspeed = origin_cspeed // origin_ccount
+        # Walk the list of repouris that we were provided.
+        # If they're already in the dictionary, copy a reference
+        # into the found_rs list, otherwise create the object
+        # and then add it to our list of found objects.
+        num_origins = len(origin_list)
+        num_mirrors = len(repouri_list) - len(origin_list)
+        o_idx = 0
+        m_idx = 0
+        for ruri in repouri_list:
+            key = ruri.key()
+            if key in self.__rsobj:
+                rs = self.__rsobj[key]
+            else:
+                rs = RepoStats(ruri)
+                self.__rsobj[key] = rs
+            found_rs.append((rs, ruri))
+            if ruri in origin_list:
+                n = num_origins - o_idx
+                # old-division; pylint: disable=W1619
+                rs.origin_factor = n / num_origins
+                o_idx += 1
+            else:
+                n = num_mirrors - m_idx
+                # old-division; pylint: disable=W1619
+                rs.origin_factor = n / num_mirrors
+                m_idx += 1
+            if origin_count > 0:
+                rs.origin_speed = origin_avg_speed
+                rs.origin_count = origin_count
+            if origin_ccount > 0:
+                rs.origin_cspeed = origin_avg_cspeed
 
-                # Walk the list of repouris that we were provided.
-                # If they're already in the dictionary, copy a reference
-                # into the found_rs list, otherwise create the object
-                # and then add it to our list of found objects.
-                num_origins = len(origin_list)
-                num_mirrors = len(repouri_list) - len(origin_list)
-                o_idx = 0
-                m_idx = 0
-                for ruri in repouri_list:
-                        key = ruri.key()
-                        if key in self.__rsobj:
-                                rs = self.__rsobj[key]
-                        else:
-                                rs = RepoStats(ruri)
-                                self.__rsobj[key] = rs
-                        found_rs.append((rs, ruri))
-                        if ruri in origin_list:
-                                n = num_origins - o_idx
-                                # old-division; pylint: disable=W1619
-                                rs.origin_factor = n / num_origins
-                                o_idx += 1
-                        else:
-                                n = num_mirrors - m_idx
-                                # old-division; pylint: disable=W1619
-                                rs.origin_factor = n / num_mirrors
-                                m_idx += 1
-                        if origin_count > 0:
-                                rs.origin_speed = origin_avg_speed
-                                rs.origin_count = origin_count
-                        if origin_ccount > 0:
-                                rs.origin_cspeed = origin_avg_cspeed
+            # Decay error rate for transient errors.
+            # Reduce the error penalty by .1% each iteration.
+            # In other words, keep 99.9% of the current value.
+            rs._err_decay *= 0.999
+            # Decay origin bonus each iteration to gradually give
+            # up slow and erroneous origins.
+            rs.origin_decay *= 0.95
 
-                        # Decay error rate for transient errors.
-                        # Reduce the error penalty by .1% each iteration.
-                        # In other words, keep 99.9% of the current value.
-                        rs._err_decay *= 0.999
-                        # Decay origin bonus each iteration to gradually give
-                        # up slow and erroneous origins.
-                        rs.origin_decay *= 0.95
+        found_rs.sort(key=lambda x: x[0].quality, reverse=True)
 
-                found_rs.sort(key=lambda x: x[0].quality, reverse=True)
+        # list of tuples, (repostatus, repouri)
+        return found_rs
 
-                # list of tuples, (repostatus, repouri)
-                return found_rs
+    def clear(self):
+        """Clear all statistics count."""
 
-        def clear(self):
-                """Clear all statistics count."""
+        self.__rsobj = {}
 
-                self.__rsobj = {}
+    def reset(self):
+        """reset each stats object"""
 
-        def reset(self):
-                """reset each stats object"""
-
-                for v in self.__rsobj.values():
-                        v.reset()
+        for v in self.__rsobj.values():
+            v.reset()
 
 
 class RepoStats(object):
-        """An object for keeping track of observed statistics for a particular
-        TransportRepoURI.  This includes things like observed performance,
-        availability, successful and unsuccessful transaction rates, etc.
-
-        There's one RepoStats object per transport destination.
-        This allows the transport to keep statistics about each
-        host that it visits."""
-
-        def __init__(self, repouri):
-                """Initialize a RepoStats object.  Pass a TransportRepoURI
-                object in repouri to configure an object for a particular
-                repository URI."""
-
-                self.__url = repouri.uri.rstrip("/")
-                self.__scheme = urlsplit(self.__url)[0]
-                self.__priority = repouri.priority
-
-                self.__proxy = repouri.proxy
-                self.__system = repouri.system
-
-                self._err_decay = 0
-                self.__failed_tx = 0
-                self.__content_err = 0
-                self.__decayable_err = 0
-                self.__timeout_err = 0
-                self.__total_tx = 0
-                self.__consecutive_errors = 0
-
-                self.__connections = 0
-                self.__connect_time = 0.0
-
-                self.__used = False
-
-                self.__bytes_xfr = 0.0
-                self.__seconds_xfr = 0.0
-                self.origin_speed = 0.0
-                self.origin_cspeed = 0.0
-                self.origin_count = 1
-                self.origin_factor = 1
-                self.origin_decay = 1
-
-        def clear_consecutive_errors(self):
-                """Set the count of consecutive errors to zero.  This is
-                done once we know a transaction has been successfully
-                completed."""
-
-                self.__consecutive_errors = 0
-
-        def record_connection(self, time):
-                """Record amount of time spent connecting."""
-
-                if not self.__used:
-                        self.__used = True
-
-                self.__connections += 1
-                self.__connect_time += time
-
-        def record_error(self, decayable=False, content=False, timeout=False):
-                """Record that an operation to the TransportRepoURI represented
-                by this RepoStats object failed with an error.
-
-                Set decayable to true if the error is a transient
-                error that may be decayed by the stats framework.
-
-                Set content to true if the error is caused by
-                corrupted or invalid content."""
-
-                if not self.__used:
-                        self.__used = True
-
-                self.__consecutive_errors += 1
-                if decayable:
-                        self.__decayable_err += 1
-                        self._err_decay += 1
-                elif content:
-                        self.__content_err += 1
-                else:
-                        self.__failed_tx += 1
-                # A timeout may be decayable or not, so track it in addition
-                # to the other classes of errors.
-                if timeout:
-                        self.__timeout_err += 1
-
-
-        def record_progress(self, bytes, seconds):
-                """Record time and size of a network operation to a
-                particular TransportRepoURI, represented by the RepoStats
-                object.
-                Place the number of bytes transferred in the bytes argument.
-                The time, in seconds, should be supplied in the
-                seconds argument."""
-
-                if not self.__used:
-                        self.__used = True
-                self.__bytes_xfr += bytes
-                self.__seconds_xfr += seconds
-
-        def record_tx(self):
-                """Record that an operation to the URI represented
-                by this RepoStats object was initiated."""
-
-                if not self.__used:
-                        self.__used = True
-                self.__total_tx += 1
-
-        def reset(self):
-                """Reset transport stats in preparation for next operation."""
-
-                # The connection stats (such as number, cspeed, time) are not
-                # reset because the metadata bandwidth calculation would be
-                # skewed when picking a host that gives us fast data.  In that
-                # case, keeping track of the latency helps quality make a
-                # better choice.
-                self.__bytes_xfr = 0.0
-                self.__seconds_xfr = 0.0
-                self.__failed_tx = 0
-                self.__content_err = 0
-                self.__decayable_err = 0
-                self._err_decay = 0
-                self.__total_tx = 0
-                self.__consecutive_errors = 0
-                self.origin_speed = 0.0
-
-        @property
-        def bytes_xfr(self):
-                """Return the number of bytes transferred."""
-
-                return self.__bytes_xfr
-
-        @property
-        def connect_time(self):
-                """The average connection time for this host."""
-
-                if self.__connections == 0:
-                        if self.__used and self.__timeout_err > 0:
-                                return 1.0
-                        else:
-                                return 0.0
-
-                # old-division; pylint: disable=W1619
-                return self.__connect_time / self.__connections
-
-        @property
-        def consecutive_errors(self):
-                """Return the number of successive errors this endpoint
-                has encountered."""
-
-                return self.__consecutive_errors
-
-        @property
-        def failures(self):
-                """Return the number of failures that the client has encountered
-                   while trying to perform operations on this repository."""
-
-                return self.__failed_tx + self.__content_err + \
-                    self.__decayable_err
-
-        @property
-        def content_errors(self):
-                """Return the number of content errors that the client has
-                encountered while trying to perform operation on this
-                repository."""
-
-                return self.__content_err
-
-        @property
-        def num_connect(self):
-                """Return the number of times that the host has had a
-                connection established.  This is less than or equal to the
-                number of transactions."""
-
-                return self.__connections
-
-        @property
-        def priority(self):
-                """Return the priority of the URI, if one is assigned."""
-
-                if self.__priority is None:
-                        return 0
-
-                return self.__priority
-
-        @property
-        def scheme(self):
-                """Return the scheme of the RepoURI. (e.g. http, file.)"""
-
-                return self.__scheme
-
-        @property
-        def quality(self):
-                """Return the quality, as an integer value, of the
-                repository.  A higher value means better quality.
-
-                This particular implementation of quality() contains
-                a random term.  Two successive calls to this function
-                may return different values."""
-
-                Nused = 20
-                Cused = 10
-
-                Cspeed = 100
-                Cconn_speed = 66
-                Cerror = 500
-                Ccontent_err = 1000
-                Crand_max = 20
-                Cospeed_none = 100000
-                Cocspeed_none = 1
-
-                if self.origin_speed > 0:
-                        ospeed = self.origin_speed
-                else:
-                        ospeed = Cospeed_none
-
-                if self.origin_cspeed > 0:
-                        ocspeed = self.origin_cspeed
-                else:
-                        ocspeed = Cocspeed_none
-
-                # This function applies a bonus to hosts that have little or
-                # no usage.  It started out life as a Heaviside step function,
-                # but it has since been adjusted so that it scales back the
-                # bonus as the host approaches the limit where the bonus
-                # is applied.  Hosts with no use recieve the largest bonus,
-                # while hosts at <= Nused transactions receive the none.
-                def unused_bonus(self):
-                        tx = 0
-
-                        tx = self.__total_tx
-
-                        if tx < 0:
-                                return 0
-
-                        if tx < Nused:
-                                return Cused * (Nused - tx)**2
-
-                        return 0
-
-                def origin_order_bonus(self):
-                        b = Cspeed * (self.origin_count) ** 2 + Nused ** 2 * \
-                            Cused
-                        return self.origin_factor * b * self.origin_decay
-
-
-                #
-                # Quality function:
-                #
-                # This function presents the quality of a repository as an
-                # integer value.  The quality is determined by observing
-                # different aspects of the repository's performance.  This
-                # includes how often it has been used, the transfer speed, the
-                # connect speed, and the number of errors classified by type.
-                #
-                # The equation is currently defined as:
-                #
-                # Q = Origin_order_bonus() + Unused_bonus() + Cspeed *
-                # ((bytes/.001+seconds) / origin_speed)^2 + random_bonus(
-                # Crand_max) - Cconn_speed * (connect_speed /
-                # origin_connect_speed)^2 - Ccontent_error * (content_errors)^2
-                # - Cerror * (non_decayable_errors + value_of_decayed_errors)^2
-                #
-                # Unused_bonus = Cused * (MaxUsed - total tx)^2 if total_tx
-                # is less than MaxUsed, otherwise return 0.
-                #
-                # random_bonus is a gaussian distribution where random_max is
-                # set as the argument for the stddev.  Most numbers generated
-                # will fall between 0 and -/+ random_max, but some will fall
-                # outside of the first standard deviation.
-                #
-                # The constants were derived by live testing, and using
-                # a simulated environment.
-                #
-                # old-division; pylint: disable=W1619
-                q = origin_order_bonus(self) + unused_bonus(self) + \
-                    (Cspeed * ((self.__bytes_xfr / (.001 + self.__seconds_xfr))
-                    / ospeed)**2) + \
-                    int(random.gauss(0, Crand_max)) - \
-                    (Cconn_speed * (self.connect_time / ocspeed)**2) - \
-                    (Ccontent_err * (self.__content_err)**2) - \
-                    (Cerror * (self.__failed_tx + self._err_decay)**2)
-                return int(q)
-
-        @property
-        def seconds_xfr(self):
-                """Return the total amount of time elapsed while performing
-                operations against this host."""
-
-                return self.__seconds_xfr
-
-        @property
-        def success(self):
-                """Return the number of successful transaction that this client
-                   has performed while communicating with this repository."""
-
-                return self.__total_tx - (self.__failed_tx +
-                    self.__content_err +  self.__decayable_err)
-
-
-        @property
-        def transfer_speed(self):
-                """Return the average transfer speed in bytes/sec for
-                   operations against this uri."""
-
-                if self.__seconds_xfr == 0:
-                        return 0.0
-
-                # old-division; pylint: disable=W1619
-                return self.__bytes_xfr / self.__seconds_xfr
-
-        @property
-        def url(self):
-                """Return the URL that identifies the repository that we're
-                   keeping statistics about."""
-
-                return self.__url
-
-        @property
-        def proxy(self):
-                """Return the default proxy being used to contact the repository
-                that we're keeping statistics about.  Note that OS
-                environment variables, "http_proxy", "https_proxy", "all_proxy"
-                and "no_proxy" values will override this value in
-                pkg.client.transport.engine."""
-
-                return self.__proxy
-
-        @property
-        def system(self):
-                """Return whether these statistics are being used to track the
-                system publisher, in which case, we always use the proxy
-                provided rather than proxy environment variables."""
-
-                return self.__system
-
-        @property
-        def used(self):
-                """A boolean value that indicates whether the URI
-                   has been used for network operations."""
-
-                return self.__used
+    """An object for keeping track of observed statistics for a particular
+    TransportRepoURI.  This includes things like observed performance,
+    availability, successful and unsuccessful transaction rates, etc.
+
+    There's one RepoStats object per transport destination.
+    This allows the transport to keep statistics about each
+    host that it visits."""
+
+    def __init__(self, repouri):
+        """Initialize a RepoStats object.  Pass a TransportRepoURI
+        object in repouri to configure an object for a particular
+        repository URI."""
+
+        self.__url = repouri.uri.rstrip("/")
+        self.__scheme = urlsplit(self.__url)[0]
+        self.__priority = repouri.priority
+
+        self.__proxy = repouri.proxy
+        self.__system = repouri.system
+
+        self._err_decay = 0
+        self.__failed_tx = 0
+        self.__content_err = 0
+        self.__decayable_err = 0
+        self.__timeout_err = 0
+        self.__total_tx = 0
+        self.__consecutive_errors = 0
+
+        self.__connections = 0
+        self.__connect_time = 0.0
+
+        self.__used = False
+
+        self.__bytes_xfr = 0.0
+        self.__seconds_xfr = 0.0
+        self.origin_speed = 0.0
+        self.origin_cspeed = 0.0
+        self.origin_count = 1
+        self.origin_factor = 1
+        self.origin_decay = 1
+
+    def clear_consecutive_errors(self):
+        """Set the count of consecutive errors to zero.  This is
+        done once we know a transaction has been successfully
+        completed."""
+
+        self.__consecutive_errors = 0
+
+    def record_connection(self, time):
+        """Record amount of time spent connecting."""
+
+        if not self.__used:
+            self.__used = True
+
+        self.__connections += 1
+        self.__connect_time += time
+
+    def record_error(self, decayable=False, content=False, timeout=False):
+        """Record that an operation to the TransportRepoURI represented
+        by this RepoStats object failed with an error.
+
+        Set decayable to true if the error is a transient
+        error that may be decayed by the stats framework.
+
+        Set content to true if the error is caused by
+        corrupted or invalid content."""
+
+        if not self.__used:
+            self.__used = True
+
+        self.__consecutive_errors += 1
+        if decayable:
+            self.__decayable_err += 1
+            self._err_decay += 1
+        elif content:
+            self.__content_err += 1
+        else:
+            self.__failed_tx += 1
+        # A timeout may be decayable or not, so track it in addition
+        # to the other classes of errors.
+        if timeout:
+            self.__timeout_err += 1
+
+    def record_progress(self, bytes, seconds):
+        """Record time and size of a network operation to a
+        particular TransportRepoURI, represented by the RepoStats
+        object.
+        Place the number of bytes transferred in the bytes argument.
+        The time, in seconds, should be supplied in the
+        seconds argument."""
+
+        if not self.__used:
+            self.__used = True
+        self.__bytes_xfr += bytes
+        self.__seconds_xfr += seconds
+
+    def record_tx(self):
+        """Record that an operation to the URI represented
+        by this RepoStats object was initiated."""
+
+        if not self.__used:
+            self.__used = True
+        self.__total_tx += 1
+
+    def reset(self):
+        """Reset transport stats in preparation for next operation."""
+
+        # The connection stats (such as number, cspeed, time) are not
+        # reset because the metadata bandwidth calculation would be
+        # skewed when picking a host that gives us fast data.  In that
+        # case, keeping track of the latency helps quality make a
+        # better choice.
+        self.__bytes_xfr = 0.0
+        self.__seconds_xfr = 0.0
+        self.__failed_tx = 0
+        self.__content_err = 0
+        self.__decayable_err = 0
+        self._err_decay = 0
+        self.__total_tx = 0
+        self.__consecutive_errors = 0
+        self.origin_speed = 0.0
+
+    @property
+    def bytes_xfr(self):
+        """Return the number of bytes transferred."""
+
+        return self.__bytes_xfr
+
+    @property
+    def connect_time(self):
+        """The average connection time for this host."""
+
+        if self.__connections == 0:
+            if self.__used and self.__timeout_err > 0:
+                return 1.0
+            else:
+                return 0.0
+
+        # old-division; pylint: disable=W1619
+        return self.__connect_time / self.__connections
+
+    @property
+    def consecutive_errors(self):
+        """Return the number of successive errors this endpoint
+        has encountered."""
+
+        return self.__consecutive_errors
+
+    @property
+    def failures(self):
+        """Return the number of failures that the client has encountered
+        while trying to perform operations on this repository."""
+
+        return self.__failed_tx + self.__content_err + self.__decayable_err
+
+    @property
+    def content_errors(self):
+        """Return the number of content errors that the client has
+        encountered while trying to perform operation on this
+        repository."""
+
+        return self.__content_err
+
+    @property
+    def num_connect(self):
+        """Return the number of times that the host has had a
+        connection established.  This is less than or equal to the
+        number of transactions."""
+
+        return self.__connections
+
+    @property
+    def priority(self):
+        """Return the priority of the URI, if one is assigned."""
+
+        if self.__priority is None:
+            return 0
+
+        return self.__priority
+
+    @property
+    def scheme(self):
+        """Return the scheme of the RepoURI. (e.g. http, file.)"""
+
+        return self.__scheme
+
+    @property
+    def quality(self):
+        """Return the quality, as an integer value, of the
+        repository.  A higher value means better quality.
+
+        This particular implementation of quality() contains
+        a random term.  Two successive calls to this function
+        may return different values."""
+
+        Nused = 20
+        Cused = 10
+
+        Cspeed = 100
+        Cconn_speed = 66
+        Cerror = 500
+        Ccontent_err = 1000
+        Crand_max = 20
+        Cospeed_none = 100000
+        Cocspeed_none = 1
+
+        if self.origin_speed > 0:
+            ospeed = self.origin_speed
+        else:
+            ospeed = Cospeed_none
+
+        if self.origin_cspeed > 0:
+            ocspeed = self.origin_cspeed
+        else:
+            ocspeed = Cocspeed_none
+
+        # This function applies a bonus to hosts that have little or
+        # no usage.  It started out life as a Heaviside step function,
+        # but it has since been adjusted so that it scales back the
+        # bonus as the host approaches the limit where the bonus
+        # is applied.  Hosts with no use recieve the largest bonus,
+        # while hosts at <= Nused transactions receive the none.
+        def unused_bonus(self):
+            tx = 0
+
+            tx = self.__total_tx
+
+            if tx < 0:
+                return 0
+
+            if tx < Nused:
+                return Cused * (Nused - tx) ** 2
+
+            return 0
+
+        def origin_order_bonus(self):
+            b = Cspeed * (self.origin_count) ** 2 + Nused**2 * Cused
+            return self.origin_factor * b * self.origin_decay
+
+        #
+        # Quality function:
+        #
+        # This function presents the quality of a repository as an
+        # integer value.  The quality is determined by observing
+        # different aspects of the repository's performance.  This
+        # includes how often it has been used, the transfer speed, the
+        # connect speed, and the number of errors classified by type.
+        #
+        # The equation is currently defined as:
+        #
+        # Q = Origin_order_bonus() + Unused_bonus() + Cspeed *
+        # ((bytes/.001+seconds) / origin_speed)^2 + random_bonus(
+        # Crand_max) - Cconn_speed * (connect_speed /
+        # origin_connect_speed)^2 - Ccontent_error * (content_errors)^2
+        # - Cerror * (non_decayable_errors + value_of_decayed_errors)^2
+        #
+        # Unused_bonus = Cused * (MaxUsed - total tx)^2 if total_tx
+        # is less than MaxUsed, otherwise return 0.
+        #
+        # random_bonus is a gaussian distribution where random_max is
+        # set as the argument for the stddev.  Most numbers generated
+        # will fall between 0 and -/+ random_max, but some will fall
+        # outside of the first standard deviation.
+        #
+        # The constants were derived by live testing, and using
+        # a simulated environment.
+        #
+        # old-division; pylint: disable=W1619
+        q = (
+            origin_order_bonus(self)
+            + unused_bonus(self)
+            + (
+                Cspeed
+                * ((self.__bytes_xfr / (0.001 + self.__seconds_xfr)) / ospeed)
+                ** 2
+            )
+            + int(random.gauss(0, Crand_max))
+            - (Cconn_speed * (self.connect_time / ocspeed) ** 2)
+            - (Ccontent_err * (self.__content_err) ** 2)
+            - (Cerror * (self.__failed_tx + self._err_decay) ** 2)
+        )
+        return int(q)
+
+    @property
+    def seconds_xfr(self):
+        """Return the total amount of time elapsed while performing
+        operations against this host."""
+
+        return self.__seconds_xfr
+
+    @property
+    def success(self):
+        """Return the number of successful transaction that this client
+        has performed while communicating with this repository."""
+
+        return self.__total_tx - (
+            self.__failed_tx + self.__content_err + self.__decayable_err
+        )
+
+    @property
+    def transfer_speed(self):
+        """Return the average transfer speed in bytes/sec for
+        operations against this uri."""
+
+        if self.__seconds_xfr == 0:
+            return 0.0
+
+        # old-division; pylint: disable=W1619
+        return self.__bytes_xfr / self.__seconds_xfr
+
+    @property
+    def url(self):
+        """Return the URL that identifies the repository that we're
+        keeping statistics about."""
+
+        return self.__url
+
+    @property
+    def proxy(self):
+        """Return the default proxy being used to contact the repository
+        that we're keeping statistics about.  Note that OS
+        environment variables, "http_proxy", "https_proxy", "all_proxy"
+        and "no_proxy" values will override this value in
+        pkg.client.transport.engine."""
+
+        return self.__proxy
+
+    @property
+    def system(self):
+        """Return whether these statistics are being used to track the
+        system publisher, in which case, we always use the proxy
+        provided rather than proxy environment variables."""
+
+        return self.__system
+
+    @property
+    def used(self):
+        """A boolean value that indicates whether the URI
+        has been used for network operations."""
+
+        return self.__used
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/client/transport/transport.py
+++ b/src/modules/client/transport/transport.py
@@ -25,7 +25,7 @@
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
-from __future__ import  print_function
+from __future__ import print_function
 import copy
 import datetime as dt
 import errno
@@ -39,8 +39,13 @@ from io import BytesIO
 from six.moves import http_client, range
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
-from six.moves.urllib.parse import quote, urlsplit, urlparse, urlunparse, \
-    ParseResult
+from six.moves.urllib.parse import (
+    quote,
+    urlsplit,
+    urlparse,
+    urlunparse,
+    ParseResult,
+)
 
 import pkg.catalog as catalog
 import pkg.client.api_errors as apx
@@ -69,3791 +74,4007 @@ from pkg.actions import ActionError
 from pkg.client import global_settings
 from pkg.client.debugvalues import DebugValues
 from pkg.misc import PKG_RO_FILE_MODE
+
 logger = global_settings.logger
 
+
 class TransportCfg(object):
-        """Contains configuration needed by the transport for proper
-        operations.  Clients must create one of these objects, and then pass
-        it to a transport instance when it is initialized.  This is the base
-        class.
+    """Contains configuration needed by the transport for proper
+    operations.  Clients must create one of these objects, and then pass
+    it to a transport instance when it is initialized.  This is the base
+    class.
+    """
+
+    def __init__(self):
+        self.__caches = {}
+
+        # Used to track if reset_caches() has been called at least
+        # once.
+        self.__caches_set = False
+
+        self.pkg_pub_map = None
+        self.alt_pubs = None
+        # An integer that indicates the maximum times to check if a
+        # file needs to be uploaded for the transport.
+        self.max_transfer_checks = 20
+
+    def add_cache(self, path, layout=None, pub=None, readonly=True):
+        """Adds the directory specified by 'path' as a location to read
+        file data from, and optionally to store to for the specified
+        publisher. 'path' must be a directory created for use with the
+        pkg.file_manager module.  If the cache already exists for the
+        specified 'pub', its 'readonly' status will be updated.
+
+        'layout' is an optional FileManager layout object that indicates
+        how file content in the cache is structured.  If None, the
+        structure will automatically be determined at runtime for each
+        cache lookup request.
+
+        'pub' is an optional publisher prefix to restrict usage of this
+        cache to.  If not provided, it is assumed that file data for any
+        publisher could be contained within this cache.
+
+        'readonly' is an optional boolean value indicating whether file
+        data should be stored here as well.  Only one writeable cache
+        can exist for each 'pub' at a time."""
+
+        if not self.__caches_set:
+            self.reset_caches(shared=True)
+
+        if not pub:
+            pub = "__all"
+
+        pub_caches = self.__caches.setdefault(pub, [])
+
+        write_caches = [cache for cache in pub_caches if not cache.readonly]
+
+        # For now, there should be no write caches or a single one.
+        assert len(write_caches) <= 1
+
+        path = path.rstrip(os.path.sep)
+        for cache in pub_caches:
+            if cache.root != path:
+                continue
+
+            if readonly:
+                # Nothing more to do.
+                cache.readonly = True
+                return
+
+            # Ensure no other writeable caches exist for this
+            # publisher.
+            for wr_cache in write_caches:
+                if id(wr_cache) == id(cache):
+                    continue
+                raise tx.TransportOperationError(
+                    "Only one "
+                    "cache that is writable for all or a "
+                    "specific publisher may exist at a time."
+                )
+
+            cache.readonly = False
+            break
+        else:
+            # Either no caches exist for this publisher, or this is
+            # a new cache.
+            pub_caches.append(fm.FileManager(path, readonly, layouts=layout))
+
+    def gen_publishers(self):
+        raise NotImplementedError
+
+    def get_caches(self, pub=None, readonly=True):
+        """Returns the file_manager cache objects for the specified
+        publisher in order of preference.  That is, caches should
+        be checked for file content in the order returned.
+
+        'pub' is an optional publisher prefix.  If provided, caches
+        designated for use with the given publisher will be returned
+        first followed by any caches applicable to all publishers.
+
+        'readonly' is an optional boolean value indicating whether
+        a cache for storing file data should be returned.  By default,
+        only caches for reading file data are returned."""
+
+        if not self.__caches_set:
+            self.reset_caches(shared=True)
+
+        if isinstance(pub, publisher.Publisher):
+            pub = pub.prefix
+        elif not pub or not isinstance(pub, six.string_types):
+            pub = None
+
+        caches = [
+            cache
+            for cache in self.__caches.get(pub, [])
+            if readonly or not cache.readonly
+        ]
+
+        if not readonly and caches:
+            # If a publisher-specific writeable cache has been
+            # found, return it alone.
+            return caches
+
+        # If not filtering on publisher, this is a readonly case, or no
+        # writeable cache exists for the specified publisher, return any
+        # publisher-specific caches first and any additional ones after.
+        return caches + [
+            cache
+            for cache in self.__caches.get("__all", [])
+            if readonly or not cache.readonly
+        ]
+
+    def get_policy(self, policy_name):
+        raise NotImplementedError
+
+    def get_property(self, property_name):
+        raise NotImplementedError
+
+    def get_pkg_dir(self, pfmri):
+        """Returns the absolute path of the directory that should be
+        used to store and load manifest data.
+        """
+        raise NotImplementedError
+
+    def get_pkg_pathname(self, pfmri):
+        """Returns the absolute pathname of the file that manifest data
+        should be stored in and loaded from.
+        """
+        raise NotImplementedError
+
+    def get_pkg_sigs(self, fmri, pub):
+        """Returns a dictionary of the signature data found in the
+        catalog for the given package FMRI and Publisher object or None
+        if no catalog is available."""
+
+        # Check provided publisher's catalog for signature data.
+        if pub.catalog:
+            return dict(pub.catalog.get_entry_signatures(fmri))
+
+    def get_pkg_alt_repo(self, pfmri):
+        """Returns the repository object containing the origins that
+        should be used to retrieve the specified package or None.
+
+        'pfmri' is the FMRI object for the package."""
+
+        if not self.pkg_pub_map:
+            return
+
+        # Package data should be retrieved from an alternative location.
+        pfx, stem, ver = pfmri.tuple()
+        sver = str(ver)
+        pmap = self.pkg_pub_map
+        try:
+            return pmap[pfx][stem][sver].repository
+        except KeyError:
+            # No alternate known for source.
+            return
+
+    def get_publisher(self, publisher_name):
+        raise NotImplementedError
+
+    def clear_caches(self, shared=False):
+        """Discard any cache information.
+
+        'shared' is an optional boolean value indicating that any
+        shared cache information (caches not specific to any publisher)
+        should also be discarded.  If True, callers are responsible for
+        ensuring a new set of shared cache information is added again.
         """
 
-        def __init__(self):
-                self.__caches = {}
+        # Caches fully set at least once.
+        self.__caches_set = True
 
-                # Used to track if reset_caches() has been called at least
-                # once.
-                self.__caches_set = False
+        for pub in list(self.__caches.keys()):
+            if shared or pub != "__all":
+                # Remove any publisher specific caches so that
+                # the most current publisher information can be
+                # used.
+                del self.__caches[pub]
 
-                self.pkg_pub_map = None
-                self.alt_pubs = None
-                # An integer that indicates the maximum times to check if a
-                # file needs to be uploaded for the transport.
-                self.max_transfer_checks = 20
+    def reset_caches(self, shared=False):
+        """Discard any cache information and reconfigure based on
+        current publisher configuration data.
 
-        def add_cache(self, path, layout=None, pub=None, readonly=True):
-                """Adds the directory specified by 'path' as a location to read
-                file data from, and optionally to store to for the specified
-                publisher. 'path' must be a directory created for use with the
-                pkg.file_manager module.  If the cache already exists for the
-                specified 'pub', its 'readonly' status will be updated.
+        'shared' is an optional boolean value indicating that any
+        shared cache information (caches not specific to any publisher)
+        should also be discarded.  If True, callers are responsible for
+        ensuring a new set of shared cache information is added again.
+        """
 
-                'layout' is an optional FileManager layout object that indicates
-                how file content in the cache is structured.  If None, the
-                structure will automatically be determined at runtime for each
-                cache lookup request.
+        # Clear the old cache setup.
+        self.clear_caches(shared=shared)
 
-                'pub' is an optional publisher prefix to restrict usage of this
-                cache to.  If not provided, it is assumed that file data for any
-                publisher could be contained within this cache.
+        # Automatically add any publisher repository origins
+        # or mirrors that are filesystem-based as readonly caches.
+        for pub in self.gen_publishers():
+            repo = pub.repository
+            if not repo:
+                continue
 
-                'readonly' is an optional boolean value indicating whether file
-                data should be stored here as well.  Only one writeable cache
-                can exist for each 'pub' at a time."""
+            for ruri in repo.origins + repo.mirrors:
+                if ruri.scheme != "file":
+                    continue
 
-                if not self.__caches_set:
-                        self.reset_caches(shared=True)
-
-                if not pub:
-                        pub = "__all"
-
-                pub_caches = self.__caches.setdefault(pub, [])
-
-                write_caches = [
-                    cache
-                    for cache in pub_caches
-                    if not cache.readonly
-                ]
-
-                # For now, there should be no write caches or a single one.
-                assert len(write_caches) <= 1
-
-                path = path.rstrip(os.path.sep)
-                for cache in pub_caches:
-                        if cache.root != path:
-                                continue
-
-                        if readonly:
-                                # Nothing more to do.
-                                cache.readonly = True
-                                return
-
-                        # Ensure no other writeable caches exist for this
-                        # publisher.
-                        for wr_cache in write_caches:
-                                if id(wr_cache) == id(cache):
-                                        continue
-                                raise tx.TransportOperationError("Only one "
-                                    "cache that is writable for all or a "
-                                    "specific publisher may exist at a time.")
-
-                        cache.readonly = False
-                        break
-                else:
-                        # Either no caches exist for this publisher, or this is
-                        # a new cache.
-                        pub_caches.append(fm.FileManager(path, readonly,
-                            layouts=layout))
-
-        def gen_publishers(self):
-                raise NotImplementedError
-
-        def get_caches(self, pub=None, readonly=True):
-                """Returns the file_manager cache objects for the specified
-                publisher in order of preference.  That is, caches should
-                be checked for file content in the order returned.
-
-                'pub' is an optional publisher prefix.  If provided, caches
-                designated for use with the given publisher will be returned
-                first followed by any caches applicable to all publishers.
-
-                'readonly' is an optional boolean value indicating whether
-                a cache for storing file data should be returned.  By default,
-                only caches for reading file data are returned."""
-
-                if not self.__caches_set:
-                        self.reset_caches(shared=True)
-
-                if isinstance(pub, publisher.Publisher):
-                        pub = pub.prefix
-                elif not pub or not isinstance(pub, six.string_types):
-                        pub = None
-
-                caches = [
-                    cache
-                    for cache in self.__caches.get(pub, [])
-                    if readonly or not cache.readonly
-                ]
-
-                if not readonly and caches:
-                        # If a publisher-specific writeable cache has been
-                        # found, return it alone.
-                        return caches
-
-                # If not filtering on publisher, this is a readonly case, or no
-                # writeable cache exists for the specified publisher, return any
-                # publisher-specific caches first and any additional ones after.
-                return caches + [
-                    cache
-                    for cache in self.__caches.get("__all", [])
-                    if readonly or not cache.readonly
-                ]
-
-        def get_policy(self, policy_name):
-                raise NotImplementedError
-
-        def get_property(self, property_name):
-                raise NotImplementedError
-
-        def get_pkg_dir(self, pfmri):
-                """Returns the absolute path of the directory that should be
-                used to store and load manifest data.
-                """
-                raise NotImplementedError
-
-        def get_pkg_pathname(self, pfmri):
-                """Returns the absolute pathname of the file that manifest data
-                should be stored in and loaded from.
-                """
-                raise NotImplementedError
-
-        def get_pkg_sigs(self, fmri, pub):
-                """Returns a dictionary of the signature data found in the
-                catalog for the given package FMRI and Publisher object or None
-                if no catalog is available."""
-
-                # Check provided publisher's catalog for signature data.
-                if pub.catalog:
-                        return dict(pub.catalog.get_entry_signatures(
-                            fmri))
-
-        def get_pkg_alt_repo(self, pfmri):
-                """Returns the repository object containing the origins that
-                should be used to retrieve the specified package or None.
-
-                'pfmri' is the FMRI object for the package."""
-
-                if not self.pkg_pub_map:
-                        return
-
-                # Package data should be retrieved from an alternative location.
-                pfx, stem, ver = pfmri.tuple()
-                sver = str(ver)
-                pmap = self.pkg_pub_map
+                path = ruri.get_pathname()
                 try:
-                        return pmap[pfx][stem][sver].repository
-                except KeyError:
-                        # No alternate known for source.
-                        return
+                    frepo = sr.Repository(root=path, read_only=True)
+                    for rstore in frepo.rstores:
+                        if not rstore.file_root:
+                            continue
+                        if rstore.publisher and rstore.publisher != pub.prefix:
+                            # If the repository
+                            # storage object is for
+                            # a different publisher,
+                            # skip it.
+                            continue
 
-        def get_publisher(self, publisher_name):
-                raise NotImplementedError
+                        # Only add caches if they
+                        # physically exist at this
+                        # point.  This avoids a storm of
+                        # ENOENT errors that might occur
+                        # during transfers for caches
+                        # that will never exist on-disk.
+                        # This is especially important
+                        # for NFS-based repositories as
+                        # they can significantly degrade
+                        # transfer performance.  This
+                        # should be ok as transport will
+                        # attempt to retrieve any
+                        # resources that might have been
+                        # cached here instead and fail
+                        # gracefully if necessary.
+                        if os.path.exists(rstore.file_root):
+                            self.add_cache(
+                                rstore.file_root,
+                                layout=rstore.file_layout,
+                                pub=rstore.publisher,
+                                readonly=True,
+                            )
+                except (sr.RepositoryError, apx.ApiException):
+                    # Cache isn't currently valid, so skip
+                    # it for now.  This essentially defers
+                    # any errors that might be encountered
+                    # accessing this repository until
+                    # later when transport attempts to
+                    # retrieve data through the engine.
+                    continue
 
-        def clear_caches(self, shared=False):
-                """Discard any cache information.
+    incoming_root = property(
+        doc="The absolute pathname of the "
+        "directory where in-progress downloads should be stored."
+    )
 
-                'shared' is an optional boolean value indicating that any
-                shared cache information (caches not specific to any publisher)
-                should also be discarded.  If True, callers are responsible for
-                ensuring a new set of shared cache information is added again.
-                """
+    pkg_root = property(
+        doc="The absolute pathname of the directory "
+        "where manifest files should be stored to and loaded from."
+    )
 
-                # Caches fully set at least once.
-                self.__caches_set = True
-
-                for pub in list(self.__caches.keys()):
-                        if shared or pub != "__all":
-                                # Remove any publisher specific caches so that
-                                # the most current publisher information can be
-                                # used.
-                                del self.__caches[pub]
-
-        def reset_caches(self, shared=False):
-                """Discard any cache information and reconfigure based on
-                current publisher configuration data.
-
-                'shared' is an optional boolean value indicating that any
-                shared cache information (caches not specific to any publisher)
-                should also be discarded.  If True, callers are responsible for
-                ensuring a new set of shared cache information is added again.
-                """
-
-                # Clear the old cache setup.
-                self.clear_caches(shared=shared)
-
-                # Automatically add any publisher repository origins
-                # or mirrors that are filesystem-based as readonly caches.
-                for pub in self.gen_publishers():
-                        repo = pub.repository
-                        if not repo:
-                                continue
-
-                        for ruri in repo.origins + repo.mirrors:
-                                if ruri.scheme != "file":
-                                        continue
-
-                                path = ruri.get_pathname()
-                                try:
-                                        frepo = sr.Repository(root=path,
-                                            read_only=True)
-                                        for rstore in frepo.rstores:
-                                                if not rstore.file_root:
-                                                        continue
-                                                if rstore.publisher and \
-                                                    rstore.publisher != pub.prefix:
-                                                        # If the repository
-                                                        # storage object is for
-                                                        # a different publisher,
-                                                        # skip it.
-                                                        continue
-
-                                                # Only add caches if they
-                                                # physically exist at this
-                                                # point.  This avoids a storm of
-                                                # ENOENT errors that might occur
-                                                # during transfers for caches
-                                                # that will never exist on-disk.
-                                                # This is especially important
-                                                # for NFS-based repositories as
-                                                # they can significantly degrade
-                                                # transfer performance.  This
-                                                # should be ok as transport will
-                                                # attempt to retrieve any
-                                                # resources that might have been
-                                                # cached here instead and fail
-                                                # gracefully if necessary.
-                                                if os.path.exists(
-                                                    rstore.file_root):
-                                                        self.add_cache(
-                                                            rstore.file_root,
-                                                            layout=rstore.file_layout,
-                                                            pub=rstore.publisher,
-                                                            readonly=True)
-                                except (sr.RepositoryError, apx.ApiException):
-                                        # Cache isn't currently valid, so skip
-                                        # it for now.  This essentially defers
-                                        # any errors that might be encountered
-                                        # accessing this repository until
-                                        # later when transport attempts to
-                                        # retrieve data through the engine.
-                                        continue
-
-        incoming_root = property(doc="The absolute pathname of the "
-            "directory where in-progress downloads should be stored.")
-
-        pkg_root = property(doc="The absolute pathname of the directory "
-            "where manifest files should be stored to and loaded from.")
-
-        user_agent = property(doc="A string that identifies the user agent for "
-            "the transport.")
+    user_agent = property(
+        doc="A string that identifies the user agent for " "the transport."
+    )
 
 
 class ImageTransportCfg(TransportCfg):
-        """A subclass of TransportCfg that gets its configuration information
-        from an Image object.
+    """A subclass of TransportCfg that gets its configuration information
+    from an Image object.
+    """
+
+    def __init__(self, image):
+        TransportCfg.__init__(self)
+        self.__img = image
+
+    def gen_publishers(self):
+        return self.__img.gen_publishers()
+
+    def get_policy(self, policy_name):
+        if not self.__img.cfg:
+            return False
+        return self.__img.cfg.get_policy(policy_name)
+
+    def get_pkg_dir(self, pfmri):
+        """Returns the absolute path of the directory that should be
+        used to store and load manifest data.
         """
 
-        def __init__(self, image):
-                TransportCfg.__init__(self)
-                self.__img = image
+        return self.__img.get_manifest_dir(pfmri)
 
-        def gen_publishers(self):
-                return self.__img.gen_publishers()
+    def get_pkg_pathname(self, pfmri):
+        """Returns the absolute pathname of the file that the manifest
+        should be stored in and loaded from."""
 
-        def get_policy(self, policy_name):
-                if not self.__img.cfg:
-                        return False
-                return self.__img.cfg.get_policy(policy_name)
+        return self.__img.get_manifest_path(pfmri)
 
-        def get_pkg_dir(self, pfmri):
-                """Returns the absolute path of the directory that should be
-                used to store and load manifest data.
-                """
+    def get_pkg_sigs(self, fmri, pub):
+        """Returns a dictionary of the signature data found in the
+        catalog for the given package FMRI and Publisher object or None
+        if no catalog is available."""
 
-                return self.__img.get_manifest_dir(pfmri)
+        # Check publisher for entry first.
+        try:
+            sigs = TransportCfg.get_pkg_sigs(self, fmri, pub)
+        except apx.UnknownCatalogEntry:
+            sigs = None
 
-        def get_pkg_pathname(self, pfmri):
-                """Returns the absolute pathname of the file that the manifest
-                should be stored in and loaded from."""
+        if sigs is None:
+            # Either package was unknown or publisher catalog
+            # contained no signature data.  Fallback to the known
+            # catalog as temporary sources may be in use.
+            kcat = self.__img.get_catalog(self.__img.IMG_CATALOG_KNOWN)
+            return dict(kcat.get_entry_signatures(fmri))
+        return sigs
 
-                return self.__img.get_manifest_path(pfmri)
+    def get_pkg_alt_repo(self, pfmri):
+        """Returns the repository object containing the origins that
+        should be used to retrieve the specified package or None.
 
-        def get_pkg_sigs(self, fmri, pub):
-                """Returns a dictionary of the signature data found in the
-                catalog for the given package FMRI and Publisher object or None
-                if no catalog is available."""
+        'pfmri' is the FMRI object for the package."""
 
-                # Check publisher for entry first.
-                try:
-                        sigs = TransportCfg.get_pkg_sigs(self, fmri, pub)
-                except apx.UnknownCatalogEntry:
-                        sigs = None
+        alt_repo = TransportCfg.get_pkg_alt_repo(self, pfmri)
+        if not alt_repo:
+            alt_repo = self.__img.get_pkg_repo(pfmri)
+        return alt_repo
 
-                if sigs is None:
-                        # Either package was unknown or publisher catalog
-                        # contained no signature data.  Fallback to the known
-                        # catalog as temporary sources may be in use.
-                        kcat = self.__img.get_catalog(
-                            self.__img.IMG_CATALOG_KNOWN)
-                        return dict(kcat.get_entry_signatures(fmri))
-                return sigs
+    def get_property(self, property_name):
+        if not self.__img.cfg:
+            raise KeyError
+        return self.__img.get_property(property_name)
 
-        def get_pkg_alt_repo(self, pfmri):
-                """Returns the repository object containing the origins that
-                should be used to retrieve the specified package or None.
+    def get_variant(self, variant_name):
+        if not self.__img.cfg:
+            raise KeyError
+        return self.__img.cfg.get_property("variant", "variant." + variant_name)
 
-                'pfmri' is the FMRI object for the package."""
+    def get_publisher(self, publisher_name):
+        return self.__img.get_publisher(publisher_name)
 
-                alt_repo = TransportCfg.get_pkg_alt_repo(self, pfmri)
-                if not alt_repo:
-                        alt_repo = self.__img.get_pkg_repo(pfmri)
-                return alt_repo
+    def reset_caches(self, shared=True):
+        """Discard any publisher specific cache information and
+        reconfigure based on current publisher configuration data.
 
-        def get_property(self, property_name):
-                if not self.__img.cfg:
-                        raise KeyError
-                return self.__img.get_property(property_name)
+        'shared' is ignored and exists only for compatibility with
+        the interface defined by TransportCfg.
+        """
 
-        def get_variant(self, variant_name):
-                if not self.__img.cfg:
-                        raise KeyError
-                return self.__img.cfg.get_property('variant',
-                    'variant.' + variant_name)
+        # Call base class method to perform initial reset of all
+        # cache information.
+        TransportCfg.reset_caches(self, shared=True)
 
-        def get_publisher(self, publisher_name):
-                return self.__img.get_publisher(publisher_name)
+        # Then add image-specific cache data after.
+        for path, readonly, pub, layout in self.__img.get_cachedirs():
+            self.add_cache(path, layout=layout, pub=pub, readonly=readonly)
 
-        def reset_caches(self, shared=True):
-                """Discard any publisher specific cache information and
-                reconfigure based on current publisher configuration data.
+    def __get_user_agent(self):
+        return misc.user_agent_str(self.__img, global_settings.client_name)
 
-                'shared' is ignored and exists only for compatibility with
-                the interface defined by TransportCfg.
-                """
+    incoming_root = property(
+        lambda self: self.__img._incoming_cache_dir,
+        doc="The absolute pathname of the directory where in-progress "
+        "downloads should be stored.",
+    )
 
-                # Call base class method to perform initial reset of all
-                # cache information.
-                TransportCfg.reset_caches(self, shared=True)
-
-                # Then add image-specific cache data after.
-                for path, readonly, pub, layout in self.__img.get_cachedirs():
-                        self.add_cache(path, layout=layout, pub=pub,
-                            readonly=readonly)
-
-        def __get_user_agent(self):
-                return misc.user_agent_str(self.__img,
-                    global_settings.client_name)
-
-        incoming_root = property(lambda self: self.__img._incoming_cache_dir,
-            doc="The absolute pathname of the directory where in-progress "
-            "downloads should be stored.")
-
-        user_agent = property(__get_user_agent, doc="A string that identifies "
-            "the user agent for the transport.")
+    user_agent = property(
+        __get_user_agent,
+        doc="A string that identifies " "the user agent for the transport.",
+    )
 
 
 class GenericTransportCfg(TransportCfg):
-        """A subclass of TransportCfg for use by transport clients that
-        do not have an image."""
+    """A subclass of TransportCfg for use by transport clients that
+    do not have an image."""
 
-        def __init__(self, publishers=misc.EmptyI, incoming_root=None,
-            pkg_root=None, policy_map=misc.EmptyDict,
-            property_map=misc.EmptyDict):
+    def __init__(
+        self,
+        publishers=misc.EmptyI,
+        incoming_root=None,
+        pkg_root=None,
+        policy_map=misc.EmptyDict,
+        property_map=misc.EmptyDict,
+    ):
+        TransportCfg.__init__(self)
+        self.__publishers = {}
+        self.__incoming_root = incoming_root
+        self.__pkg_root = pkg_root
+        self.__policy_map = policy_map
+        self.__property_map = property_map
 
-                TransportCfg.__init__(self)
-                self.__publishers = {}
-                self.__incoming_root = incoming_root
-                self.__pkg_root = pkg_root
-                self.__policy_map = policy_map
-                self.__property_map = property_map
+        for p in publishers:
+            self.__publishers[p.prefix] = p
 
-                for p in publishers:
-                        self.__publishers[p.prefix] = p
+    def add_publisher(self, pub):
+        self.__publishers[pub.prefix] = pub
 
-        def add_publisher(self, pub):
-                self.__publishers[pub.prefix] = pub
+    def gen_publishers(self):
+        return (p for p in self.__publishers.values())
 
-        def gen_publishers(self):
-                return (p for p in self.__publishers.values())
+    def get_pkg_dir(self, pfmri):
+        """Returns the absolute pathname of the directory that should be
+        used to store and load manifest data."""
 
-        def get_pkg_dir(self, pfmri):
-                """Returns the absolute pathname of the directory that should be
-                used to store and load manifest data."""
+        return os.path.join(self.pkg_root, pfmri.get_dir_path())
 
-                return os.path.join(self.pkg_root, pfmri.get_dir_path())
+    def get_pkg_pathname(self, pfmri):
+        """Returns the absolute pathname of the file that manifest data
+        should be stored in and loaded from."""
 
-        def get_pkg_pathname(self, pfmri):
-                """Returns the absolute pathname of the file that manifest data
-                should be stored in and loaded from."""
+        return os.path.join(self.get_pkg_dir(pfmri), "manifest")
 
-                return os.path.join(self.get_pkg_dir(pfmri), "manifest")
+    def get_policy(self, policy_name):
+        return self.__policy_map.get(policy_name, False)
 
-        def get_policy(self, policy_name):
-                return self.__policy_map.get(policy_name, False)
+    def get_property(self, property_name):
+        return self.__property_map[property_name]
 
-        def get_property(self, property_name):
-                return self.__property_map[property_name]
+    def get_publisher(self, publisher_name):
+        pub = self.__publishers.get(publisher_name)
+        if not pub:
+            raise apx.UnknownPublisher(publisher_name)
+        return pub
 
-        def get_publisher(self, publisher_name):
-                pub = self.__publishers.get(publisher_name)
-                if not pub:
-                        raise apx.UnknownPublisher(publisher_name)
-                return pub
+    def remove_publisher(self, publisher_name):
+        return self.__publishers.pop(publisher_name, None)
 
-        def remove_publisher(self, publisher_name):
-                return self.__publishers.pop(publisher_name, None)
+    def __get_user_agent(self):
+        return misc.user_agent_str(None, global_settings.client_name)
 
-        def __get_user_agent(self):
-                return misc.user_agent_str(None, global_settings.client_name)
+    def __set_inc_root(self, inc_root):
+        self.__incoming_root = inc_root
 
-        def __set_inc_root(self, inc_root):
-                self.__incoming_root = inc_root
+    def __set_pkg_root(self, pkg_root):
+        self.__pkg_root = pkg_root
 
-        def __set_pkg_root(self, pkg_root):
-                self.__pkg_root = pkg_root
+    incoming_root = property(
+        lambda self: self.__incoming_root,
+        __set_inc_root,
+        doc="Absolute pathname to directory of in-progress downloads.",
+    )
 
-        incoming_root = property(
-            lambda self: self.__incoming_root, __set_inc_root,
-            doc="Absolute pathname to directory of in-progress downloads.")
+    pkg_root = property(
+        lambda self: self.__pkg_root,
+        __set_pkg_root,
+        doc="The absolute pathname of the directory where in-progress "
+        "downloads should be stored.",
+    )
 
-        pkg_root = property(lambda self: self.__pkg_root, __set_pkg_root,
-            doc="The absolute pathname of the directory where in-progress "
-            "downloads should be stored.")
+    user_agent = property(
+        __get_user_agent,
+        doc="A string that identifies the user agent for the transport.",
+    )
 
-        user_agent = property(__get_user_agent,
-            doc="A string that identifies the user agent for the transport.")
 
 class LockedTransport(object):
-        """A decorator class that wraps transport functions, calling
-        their lock and unlock methods.  Due to implementation differences
-        in the decorator protocol, the decorator must be used with
-        parenthesis in order for this to function correctly.  Always
-        decorate functions @LockedTransport()."""
+    """A decorator class that wraps transport functions, calling
+    their lock and unlock methods.  Due to implementation differences
+    in the decorator protocol, the decorator must be used with
+    parenthesis in order for this to function correctly.  Always
+    decorate functions @LockedTransport()."""
 
-        def __init__(self, *d_args, **d_kwargs):
-                object.__init__(self)
+    def __init__(self, *d_args, **d_kwargs):
+        object.__init__(self)
 
-        def __call__(self, f):
-                def wrapper(*fargs, **f_kwargs):
-                        instance, fargs = fargs[0], fargs[1:]
-                        lock = instance._lock
-                        lock.acquire()
-                        try:
-                                return f(instance, *fargs, **f_kwargs)
-                        finally:
-                                lock.release()
-                return wrapper
+    def __call__(self, f):
+        def wrapper(*fargs, **f_kwargs):
+            instance, fargs = fargs[0], fargs[1:]
+            lock = instance._lock
+            lock.acquire()
+            try:
+                return f(instance, *fargs, **f_kwargs)
+            finally:
+                lock.release()
+
+        return wrapper
+
 
 def _convert_repouris(repolist):
-        """Given a list of RepositoryURI objects, expand them into a list of
-        TransportRepoURI objects, each representing a different transport path
-        to the given RepositoryURI, allowing the transport to eg. try all
-        configured proxies for a given RepositoryURI."""
+    """Given a list of RepositoryURI objects, expand them into a list of
+    TransportRepoURI objects, each representing a different transport path
+    to the given RepositoryURI, allowing the transport to eg. try all
+    configured proxies for a given RepositoryURI."""
 
-        trans_repouris = []
-        for repouri in repolist:
-                trans_repouris.extend(
-                    publisher.TransportRepoURI.fromrepouri(repouri))
-        return trans_repouris
+    trans_repouris = []
+    for repouri in repolist:
+        trans_repouris.extend(publisher.TransportRepoURI.fromrepouri(repouri))
+    return trans_repouris
 
 
 class Transport(object):
-        """The generic transport wrapper object.  Its public methods should
-        be used by all client code that wishes to perform file/network
-        packaging operations."""
+    """The generic transport wrapper object.  Its public methods should
+    be used by all client code that wishes to perform file/network
+    packaging operations."""
 
-        def __init__(self, tcfg):
-                """Initialize the Transport object. Caller must supply
-                a TransportCfg object."""
+    def __init__(self, tcfg):
+        """Initialize the Transport object. Caller must supply
+        a TransportCfg object."""
 
-                self.__engine = None
-                self.__cadir = None
-                self.__portal_test_executed = False
-                self.__version_check_executed = False
-                self.__repo_cache = None
-                self.__dynamic_mirrors = []
-                self._lock = nrlock.NRLock()
-                self.cfg = tcfg
-                self.stats = tstats.RepoChooser()
-                self.repo_status = {}
-                self.__tmp_crls = {}
-                # Used to record those actions that will have their payload
-                # transferred.
-                self.__hashes = defaultdict(set)
-                # Used to record those CRLs which are unreachable during the
-                # current operation.
-                self.__bad_crls = set()
+        self.__engine = None
+        self.__cadir = None
+        self.__portal_test_executed = False
+        self.__version_check_executed = False
+        self.__repo_cache = None
+        self.__dynamic_mirrors = []
+        self._lock = nrlock.NRLock()
+        self.cfg = tcfg
+        self.stats = tstats.RepoChooser()
+        self.repo_status = {}
+        self.__tmp_crls = {}
+        # Used to record those actions that will have their payload
+        # transferred.
+        self.__hashes = defaultdict(set)
+        # Used to record those CRLs which are unreachable during the
+        # current operation.
+        self.__bad_crls = set()
 
-        def __setup(self):
-                self.__engine = engine.CurlTransportEngine(self)
+    def __setup(self):
+        self.__engine = engine.CurlTransportEngine(self)
 
-                # Configure engine's user agent
-                self.__engine.set_user_agent(self.cfg.user_agent)
+        # Configure engine's user agent
+        self.__engine.set_user_agent(self.cfg.user_agent)
 
-                self.__repo_cache = trepo.RepoCache(self.__engine)
+        self.__repo_cache = trepo.RepoCache(self.__engine)
 
-                if self.cfg.get_policy(imageconfig.MIRROR_DISCOVERY):
-                        self.__dynamic_mirrors = mdetect.MirrorDetector()
-                        try:
-                                self.__dynamic_mirrors.locate()
-                        except tx.mDNSException:
-                                # Not fatal.  Suppress.
-                                pass
+        if self.cfg.get_policy(imageconfig.MIRROR_DISCOVERY):
+            self.__dynamic_mirrors = mdetect.MirrorDetector()
+            try:
+                self.__dynamic_mirrors.locate()
+            except tx.mDNSException:
+                # Not fatal.  Suppress.
+                pass
 
+    def reset(self):
+        """Resets the transport.  This needs to be done
+        if an install plan has been canceled and needs to
+        be restarted.  This clears the state of the
+        transport and its associated components."""
 
-        def reset(self):
-                """Resets the transport.  This needs to be done
-                if an install plan has been canceled and needs to
-                be restarted.  This clears the state of the
-                transport and its associated components."""
+        if not self.__engine:
+            # Don't reset if not configured
+            return
 
-                if not self.__engine:
-                        # Don't reset if not configured
-                        return
-
-                self._lock.acquire()
+        self._lock.acquire()
+        try:
+            self.__engine.reset()
+            self.__repo_cache.clear_cache()
+            self.cfg.reset_caches()
+            if self.__dynamic_mirrors:
                 try:
-                        self.__engine.reset()
-                        self.__repo_cache.clear_cache()
-                        self.cfg.reset_caches()
-                        if self.__dynamic_mirrors:
-                                try:
-                                        self.__dynamic_mirrors.locate()
-                                except tx.mDNSException:
-                                        # Not fatal. Suppress.
-                                        pass
-                finally:
-                        self._lock.release()
+                    self.__dynamic_mirrors.locate()
+                except tx.mDNSException:
+                    # Not fatal. Suppress.
+                    pass
+        finally:
+            self._lock.release()
 
-        def shutdown(self):
-                """Shuts down any portions of the transport that can
-                actively be connected to remote endpoints."""
+    def shutdown(self):
+        """Shuts down any portions of the transport that can
+        actively be connected to remote endpoints."""
 
-                if not self.__engine:
-                        # Already shut down
-                        return
+        if not self.__engine:
+            # Already shut down
+            return
 
-                self._lock.acquire()
-                try:
-                        self.__engine.shutdown()
-                        self.__engine = None
-                        if self.__repo_cache:
-                                self.__repo_cache.clear_cache()
-                        self.__repo_cache = None
-                        self.__dynamic_mirrors = []
-                finally:
-                        self._lock.release()
+        self._lock.acquire()
+        try:
+            self.__engine.shutdown()
+            self.__engine = None
+            if self.__repo_cache:
+                self.__repo_cache.clear_cache()
+            self.__repo_cache = None
+            self.__dynamic_mirrors = []
+        finally:
+            self._lock.release()
 
-        @LockedTransport()
-        def do_search(self, pub, data, ccancel=None, alt_repo=None):
-                """Perform a search request.  Returns a file-like object or an
-                iterable that contains the search results.  Callers need to
-                catch transport exceptions that this object may generate."""
+    @LockedTransport()
+    def do_search(self, pub, data, ccancel=None, alt_repo=None):
+        """Perform a search request.  Returns a file-like object or an
+        iterable that contains the search results.  Callers need to
+        catch transport exceptions that this object may generate."""
 
-                failures = tx.TransportFailures()
-                fobj = None
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = None
+        failures = tx.TransportFailures()
+        fobj = None
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = None
 
-                if isinstance(pub, publisher.Publisher):
-                        header = self.__build_header(uuid=self.__get_uuid(pub),
-                            variant=self.__get_variant(pub))
+        if isinstance(pub, publisher.Publisher):
+            header = self.__build_header(
+                uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+            )
 
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
 
-                # If version check hasn't been executed, run it prior to this
-                # operation.
-                self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
+        # If version check hasn't been executed, run it prior to this
+        # operation.
+        self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
 
-                # For search, prefer remote sources if available.  This allows
-                # consumers to configure both a file-based and network-based set
-                # of origins for a publisher without incurring the significant
-                # overhead of performing file-based search unless the network-
-                # based resource is unavailable.
+        # For search, prefer remote sources if available.  This allows
+        # consumers to configure both a file-based and network-based set
+        # of origins for a publisher without incurring the significant
+        # overhead of performing file-based search unless the network-
+        # based resource is unavailable.
+        no_result_url = None
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            prefer_remote=True,
+            alt_repo=alt_repo,
+            operation="search",
+            versions=[0, 1],
+        ):
+            if retries == 1:
                 no_result_url = None
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, prefer_remote=True, alt_repo=alt_repo,
-                    operation="search", versions=[0, 1]):
+            elif retries > 1 and no_result_url:
+                continue
 
-                        if retries == 1:
-                                no_result_url = None
-                        elif retries > 1 and no_result_url:
-                                continue
+            try:
+                fobj = d.do_search(data, header, ccancel=ccancel, pub=pub)
+                if hasattr(fobj, "_prime"):
+                    fobj._prime()
 
-                        try:
-                                fobj = d.do_search(data, header,
-                                    ccancel=ccancel, pub=pub)
-                                if hasattr(fobj, "_prime"):
-                                        fobj._prime()
+                if hasattr(fobj, "set_lock"):
+                    # Since we're returning a file object
+                    # that's using the same engine as the
+                    # rest of this transport, assign our
+                    # lock to the fobj.  It must synchronize
+                    # with us too.
+                    fobj.set_lock(self._lock)
 
-                                if hasattr(fobj, "set_lock"):
-                                        # Since we're returning a file object
-                                        # that's using the same engine as the
-                                        # rest of this transport, assign our
-                                        # lock to the fobj.  It must synchronize
-                                        # with us too.
-                                        fobj.set_lock(self._lock)
+                return fobj
 
-                                return fobj
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
 
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-
-                        except tx.TransportProtoError as e:
-                                if e.code in (http_client.NOT_FOUND, errno.ENOENT):
-                                        raise apx.UnsupportedSearchError(e.url,
-                                            "search/1")
-                                elif e.code == http_client.NO_CONTENT:
-                                        no_result_url = e.url
-                                elif e.code in (http_client.BAD_REQUEST,
-                                    errno.EINVAL):
-                                        raise apx.MalformedSearchRequest(e.url)
-                                elif e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                        fobj = None
-                                else:
-                                        raise
-                if no_result_url:
-                        raise apx.NegativeSearchResult(no_result_url)
+            except tx.TransportProtoError as e:
+                if e.code in (http_client.NOT_FOUND, errno.ENOENT):
+                    raise apx.UnsupportedSearchError(e.url, "search/1")
+                elif e.code == http_client.NO_CONTENT:
+                    no_result_url = e.url
+                elif e.code in (http_client.BAD_REQUEST, errno.EINVAL):
+                    raise apx.MalformedSearchRequest(e.url)
+                elif e.retryable:
+                    failures.append(e)
                 else:
-                        raise failures
+                    raise
 
-        def get_ca_dir(self):
-                """Return the path to the directory that contains CA
-                certificates."""
-                if self.__cadir is None:
-                        # If transport isn't connected to image, or no
-                        # ca-dir is specified, fallback to this one.
-                        fb_cadir = os.path.join(os.path.sep, "etc",
-                            "ssl", "certs")
-
-                        try:
-                                cadir = self.cfg.get_property("ca-path")
-                                cadir = os.path.normpath(cadir)
-                        except KeyError:
-                                cadir = fb_cadir
-
-                        if not os.path.exists(cadir):
-                                raise tx.TransportOperationError("Unable to "
-                                    "locate a CA directory: {0}\n"
-                                    "Secure connection is not "
-                                    "available.".format(cadir))
-
-                        self.__cadir = cadir
-                        return cadir
-
-                return self.__cadir
-
-        @LockedTransport()
-        def get_catalog(self, pub, ts=None, ccancel=None, path=None,
-            alt_repo=None):
-                """Get the catalog for the specified publisher.  If
-                ts is defined, request only changes newer than timestamp
-                ts."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-                download_dir = self.cfg.incoming_root
-                if path:
-                        croot = path
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                    fobj = None
                 else:
-                        croot = pub.catalog_root
+                    raise
+        if no_result_url:
+            raise apx.NegativeSearchResult(no_result_url)
+        else:
+            raise failures
 
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
+    def get_ca_dir(self):
+        """Return the path to the directory that contains CA
+        certificates."""
+        if self.__cadir is None:
+            # If transport isn't connected to image, or no
+            # ca-dir is specified, fallback to this one.
+            fb_cadir = os.path.join(os.path.sep, "etc", "ssl", "certs")
 
-                # If version check hasn't been executed, run it prior to this
-                # operation.
-                self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
+            try:
+                cadir = self.cfg.get_property("ca-path")
+                cadir = os.path.normpath(cadir)
+            except KeyError:
+                cadir = fb_cadir
 
-                for d, retries in self.__gen_repo(pub, retry_count,
-                    origin_only=True, alt_repo=alt_repo):
+            if not os.path.exists(cadir):
+                raise tx.TransportOperationError(
+                    "Unable to "
+                    "locate a CA directory: {0}\n"
+                    "Secure connection is not "
+                    "available.".format(cadir)
+                )
 
-                        repostats = self.stats[d.get_repouri_key()]
+            self.__cadir = cadir
+            return cadir
 
-                        # If a transport exception occurs,
-                        # save it if it's retryable, otherwise
-                        # raise the error to a higher-level handler.
-                        try:
+        return self.__cadir
 
-                                resp = d.get_catalog(ts, header,
-                                    ccancel=ccancel, pub=pub)
+    @LockedTransport()
+    def get_catalog(self, pub, ts=None, ccancel=None, path=None, alt_repo=None):
+        """Get the catalog for the specified publisher.  If
+        ts is defined, request only changes newer than timestamp
+        ts."""
 
-                                updatelog.recv(resp, croot, ts, pub)
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+        download_dir = self.cfg.incoming_root
+        if path:
+            croot = path
+        else:
+            croot = pub.catalog_root
 
-                                return
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
 
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportProtoError as e:
-                                if e.code == http_client.NOT_MODIFIED:
-                                        return
-                                elif e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-                        except pkg.fmri.IllegalFmri as e:
-                                repostats.record_error()
-                                raise tx.TransportOperationError(
-                                    "Could not retrieve catalog from '{0}'\n"
-                                    " Unable to parse FMRI. Details "
-                                    "follow:\n{1}".format(pub.prefix, e))
-                        except EnvironmentError as e:
-                                repostats.record_error()
-                                raise tx.TransportOperationError(
-                                    "Could not retrieve catalog from '{0}'\n"
-                                    " Exception: str:{1!s} repr:{2!r}".format(
-                                    pub.prefix, e, e))
+        # If version check hasn't been executed, run it prior to this
+        # operation.
+        self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
 
-                raise failures
+        for d, retries in self.__gen_repo(
+            pub, retry_count, origin_only=True, alt_repo=alt_repo
+        ):
+            repostats = self.stats[d.get_repouri_key()]
 
-        @staticmethod
-        def __ignore_network_cache():
-                """Check if transport should ignore network cache."""
+            # If a transport exception occurs,
+            # save it if it's retryable, otherwise
+            # raise the error to a higher-level handler.
+            try:
+                resp = d.get_catalog(ts, header, ccancel=ccancel, pub=pub)
 
-                inc_debug = False
-                inc_global = global_settings.client_no_network_cache
-                # Try to read from DebugValues.
-                if DebugValues.get("no_network_cache", False):
-                        inc_debug = True
+                updatelog.recv(resp, croot, ts, pub)
 
-                return inc_debug or inc_global
-
-        @staticmethod
-        def __get_request_header(header, repostats, retries, repo):
-                """Get request header based on repository status and client
-                specified network cache option."""
-
-                if (repostats.content_errors and retries > 1) or \
-                    Transport.__ignore_network_cache():
-                        return repo.build_refetch_header(header)
-                return header
-
-        @staticmethod
-        def _verify_catalog(filename, dirname):
-                """A wrapper for catalog.verify() that catches
-                CatalogErrors and translates them to the appropriate
-                InvalidContentException that the transport uses for content
-                verification."""
-
-                filepath = os.path.join(dirname, filename)
-
-                try:
-                        catalog.verify(filepath)
-                except apx.CatalogError as e:
-                        portable.remove(filepath)
-                        te = tx.InvalidContentException(filepath,
-                            "CatalogPart failed validation: {0}".format(e))
-                        te.request = filename
-                        raise te
                 return
 
-        @LockedTransport()
-        def get_catalog1(self, pub, flist, ts=None, path=None,
-            progtrack=None, ccancel=None, revalidate=False, redownload=False,
-            alt_repo=None):
-                """Get the catalog1 files from publisher 'pub' that
-                are given as a list in 'flist'.  If the caller supplies
-                an optional timestamp argument, only get the files that
-                have been modified since the timestamp.  At the moment,
-                this interface only supports supplying a timestamp
-                if the length of flist is 1.
-
-                The timestamp, 'ts', should be provided as a floating
-                point value of seconds since the epoch in UTC.  If callers
-                have a datetime object, they should use something like:
-
-                time.mktime(dtobj.timetuple()) -> float
-
-                If the caller has a UTC datetime object, the following
-                should be used instead:
-
-                calendar.timegm(dtobj.utctimetuple()) -> float
-
-                The examples above convert the object to the appropriate format
-                for get_catalog1.
-
-                If the caller wants the completed download to be placed
-                in an alternate directory (pub.catalog_root is standard),
-                set a directory path in 'path'.
-
-                If the caller knows that the upstream metadata is cached,
-                and needs a refresh it should set 'revalidate' to True.
-                If the caller knows that the upstream metadata is cached and
-                is corrupted, it should set 'redownload' to True.  Either
-                'revalidate' or 'redownload' may be used, but not both."""
-
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                failures = []
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                if progtrack and ccancel:
-                        progtrack.check_cancelation = ccancel
-
-                # Ensure that caller only passed one item, if ts was
-                # used.
-                if ts and len(flist) > 1:
-                        raise ValueError("Ts may only be used with a single"
-                            " item flist.")
-
-                if redownload and revalidate:
-                        raise ValueError("Either revalidate or redownload"
-                            " may be used, but not both.")
-
-                # download_dir is temporary download path.  Completed_dir
-                # is the cache where valid content lives.
-                if path:
-                        completed_dir = path
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportProtoError as e:
+                if e.code == http_client.NOT_MODIFIED:
+                    return
+                elif e.retryable:
+                    failures.append(e)
                 else:
-                        completed_dir = pub.catalog_root
-                download_dir = self.cfg.incoming_root
+                    raise
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+            except pkg.fmri.IllegalFmri as e:
+                repostats.record_error()
+                raise tx.TransportOperationError(
+                    "Could not retrieve catalog from '{0}'\n"
+                    " Unable to parse FMRI. Details "
+                    "follow:\n{1}".format(pub.prefix, e)
+                )
+            except EnvironmentError as e:
+                repostats.record_error()
+                raise tx.TransportOperationError(
+                    "Could not retrieve catalog from '{0}'\n"
+                    " Exception: str:{1!s} repr:{2!r}".format(pub.prefix, e, e)
+                )
 
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
+        raise failures
 
-                # If version check hasn't been executed, run it prior to this
-                # operation.
-                self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
+    @staticmethod
+    def __ignore_network_cache():
+        """Check if transport should ignore network cache."""
 
-                # Check if the download_dir exists.  If it doesn't, create
-                # the directories.
-                self._makedirs(download_dir)
-                self._makedirs(completed_dir)
+        inc_debug = False
+        inc_global = global_settings.client_no_network_cache
+        # Try to read from DebugValues.
+        if DebugValues.get("no_network_cache", False):
+            inc_debug = True
 
-                # Call statvfs to find the blocksize of download_dir's
-                # filesystem.
+        return inc_debug or inc_global
+
+    @staticmethod
+    def __get_request_header(header, repostats, retries, repo):
+        """Get request header based on repository status and client
+        specified network cache option."""
+
+        if (
+            repostats.content_errors and retries > 1
+        ) or Transport.__ignore_network_cache():
+            return repo.build_refetch_header(header)
+        return header
+
+    @staticmethod
+    def _verify_catalog(filename, dirname):
+        """A wrapper for catalog.verify() that catches
+        CatalogErrors and translates them to the appropriate
+        InvalidContentException that the transport uses for content
+        verification."""
+
+        filepath = os.path.join(dirname, filename)
+
+        try:
+            catalog.verify(filepath)
+        except apx.CatalogError as e:
+            portable.remove(filepath)
+            te = tx.InvalidContentException(
+                filepath, "CatalogPart failed validation: {0}".format(e)
+            )
+            te.request = filename
+            raise te
+        return
+
+    @LockedTransport()
+    def get_catalog1(
+        self,
+        pub,
+        flist,
+        ts=None,
+        path=None,
+        progtrack=None,
+        ccancel=None,
+        revalidate=False,
+        redownload=False,
+        alt_repo=None,
+    ):
+        """Get the catalog1 files from publisher 'pub' that
+        are given as a list in 'flist'.  If the caller supplies
+        an optional timestamp argument, only get the files that
+        have been modified since the timestamp.  At the moment,
+        this interface only supports supplying a timestamp
+        if the length of flist is 1.
+
+        The timestamp, 'ts', should be provided as a floating
+        point value of seconds since the epoch in UTC.  If callers
+        have a datetime object, they should use something like:
+
+        time.mktime(dtobj.timetuple()) -> float
+
+        If the caller has a UTC datetime object, the following
+        should be used instead:
+
+        calendar.timegm(dtobj.utctimetuple()) -> float
+
+        The examples above convert the object to the appropriate format
+        for get_catalog1.
+
+        If the caller wants the completed download to be placed
+        in an alternate directory (pub.catalog_root is standard),
+        set a directory path in 'path'.
+
+        If the caller knows that the upstream metadata is cached,
+        and needs a refresh it should set 'revalidate' to True.
+        If the caller knows that the upstream metadata is cached and
+        is corrupted, it should set 'redownload' to True.  Either
+        'revalidate' or 'redownload' may be used, but not both."""
+
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        failures = []
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        if progtrack and ccancel:
+            progtrack.check_cancelation = ccancel
+
+        # Ensure that caller only passed one item, if ts was
+        # used.
+        if ts and len(flist) > 1:
+            raise ValueError("Ts may only be used with a single" " item flist.")
+
+        if redownload and revalidate:
+            raise ValueError(
+                "Either revalidate or redownload" " may be used, but not both."
+            )
+
+        # download_dir is temporary download path.  Completed_dir
+        # is the cache where valid content lives.
+        if path:
+            completed_dir = path
+        else:
+            completed_dir = pub.catalog_root
+        download_dir = self.cfg.incoming_root
+
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        # If version check hasn't been executed, run it prior to this
+        # operation.
+        self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
+
+        # Check if the download_dir exists.  If it doesn't, create
+        # the directories.
+        self._makedirs(download_dir)
+        self._makedirs(completed_dir)
+
+        # Call statvfs to find the blocksize of download_dir's
+        # filesystem.
+        try:
+            destvfs = os.statvfs(download_dir)
+            # Set the file buffer size to the blocksize of our
+            # filesystem.
+            self.__engine.set_file_bufsz(destvfs.f_bsize)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            else:
+                raise tx.TransportOperationError(
+                    "Unable to stat VFS: {0}".format(e)
+                )
+        except AttributeError as e:
+            # os.statvfs is not available on Windows
+            pass
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            operation="catalog",
+            versions=[1],
+            ccancel=ccancel,
+            alt_repo=alt_repo,
+        ):
+            failedreqs = []
+            repostats = self.stats[d.get_repouri_key()]
+            gave_up = False
+            header = Transport.__get_request_header(
+                header, repostats, retries, d
+            )
+
+            # This returns a list of transient errors
+            # that occurred during the transport operation.
+            # An exception handler here isn't necessary
+            # unless we want to supress a permanent failure.
+            try:
+                errlist = d.get_catalog1(
+                    flist,
+                    download_dir,
+                    header,
+                    ts,
+                    progtrack=progtrack,
+                    pub=pub,
+                    redownload=redownload,
+                    revalidate=revalidate,
+                )
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that the client just gave up, make a note
+                # of this condition and try another host.
+                gave_up = True
+                errlist = ex.failures
+                success = ex.success
+
+            for e in errlist:
+                # General case: Fish the request information
+                # out of the exception, so the transport
+                # can retry the request at another host.
+                req = getattr(e, "request", None)
+                if req:
+                    failedreqs.append(req)
+                    failures.append(e)
+                else:
+                    raise e
+
+            if gave_up:
+                # If the transport gave up due to excessive
+                # consecutive errors, the caller is returned a
+                # list of successful requests, and a list of
+                # failures.  We need to consider the requests
+                # that were not attempted because we gave up
+                # early.  In this situation, they're failed
+                # requests, even though no exception was
+                # returned.  Filter the flist to remove the
+                # successful requests.  Everything else failed.
+                failedreqs = [x for x in flist if x not in success]
+                flist = failedreqs
+            elif failedreqs:
+                success = [x for x in flist if x not in failedreqs]
+                flist = failedreqs
+            else:
+                success = flist
+                flist = None
+
+            for s in success:
+                dl_path = os.path.join(download_dir, s)
+
                 try:
-                        destvfs = os.statvfs(download_dir)
-                        # Set the file buffer size to the blocksize of our
-                        # filesystem.
-                        self.__engine.set_file_bufsz(destvfs.f_bsize)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        else:
-                                raise tx.TransportOperationError(
-                                    "Unable to stat VFS: {0}".format(e))
-                except AttributeError as e:
-                        # os.statvfs is not available on Windows
-                        pass
+                    self._verify_catalog(s, download_dir)
+                except tx.InvalidContentException as e:
+                    repostats.record_error(content=True)
+                    failedreqs.append(e.request)
+                    failures.append(e)
+                    if not flist:
+                        flist = failedreqs
+                    continue
 
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, operation="catalog", versions=[1],
-                    ccancel=ccancel, alt_repo=alt_repo):
+                final_path = os.path.normpath(os.path.join(completed_dir, s))
 
-                        failedreqs = []
-                        repostats = self.stats[d.get_repouri_key()]
-                        gave_up = False
-                        header = Transport.__get_request_header(header,
-                            repostats, retries, d)
+                finaldir = os.path.dirname(final_path)
 
-                        # This returns a list of transient errors
-                        # that occurred during the transport operation.
-                        # An exception handler here isn't necessary
-                        # unless we want to supress a permanent failure.
-                        try:
-                                errlist = d.get_catalog1(flist, download_dir,
-                                    header, ts, progtrack=progtrack, pub=pub,
-                                    redownload=redownload,
-                                    revalidate=revalidate)
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that the client just gave up, make a note
-                                # of this condition and try another host.
-                                gave_up = True
-                                errlist = ex.failures
-                                success = ex.success
+                self._makedirs(finaldir)
+                portable.rename(dl_path, final_path)
 
-                        for e in errlist:
-                                # General case: Fish the request information
-                                # out of the exception, so the transport
-                                # can retry the request at another host.
-                                req = getattr(e, "request", None)
-                                if req:
-                                        failedreqs.append(req)
-                                        failures.append(e)
-                                else:
-                                        raise e
+            # Return if everything was successful
+            if not flist and not errlist:
+                return
 
+        if failedreqs and failures:
+            failures = [x for x in failures if x.request in failedreqs]
+            tfailurex = tx.TransportFailures()
+            for f in failures:
+                tfailurex.append(f)
+            raise tfailurex
 
-                        if gave_up:
-                                # If the transport gave up due to excessive
-                                # consecutive errors, the caller is returned a
-                                # list of successful requests, and a list of
-                                # failures.  We need to consider the requests
-                                # that were not attempted because we gave up
-                                # early.  In this situation, they're failed
-                                # requests, even though no exception was
-                                # returned.  Filter the flist to remove the
-                                # successful requests.  Everything else failed.
-                                failedreqs = [
-                                    x for x in flist
-                                    if x not in success
-                                ]
-                                flist = failedreqs
-                        elif failedreqs:
-                                success = [
-                                    x for x in flist
-                                    if x not in failedreqs
-                                ]
-                                flist = failedreqs
-                        else:
-                                success = flist
-                                flist = None
+    @LockedTransport()
+    def get_publisherdata(self, pub, ccancel=None):
+        """Given a publisher pub, return the publisher/0
+        information as a list of publisher objects.  If
+        no publisher information was contained in the
+        response, the list will be empty."""
 
-                        for s in success:
-                                dl_path = os.path.join(download_dir, s)
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        failures = tx.TransportFailures()
+        header = None
 
-                                try:
-                                        self._verify_catalog(s, download_dir)
-                                except tx.InvalidContentException as e:
-                                        repostats.record_error(content=True)
-                                        failedreqs.append(e.request)
-                                        failures.append(e)
-                                        if not flist:
-                                                flist = failedreqs
-                                        continue
+        if isinstance(pub, publisher.Publisher):
+            header = self.__build_header(
+                uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+            )
 
-                                final_path = os.path.normpath(
-                                    os.path.join(completed_dir, s))
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            operation="publisher",
+            versions=[0],
+            ccancel=ccancel,
+        ):
+            try:
+                resp = d.get_publisherinfo(header, ccancel=ccancel)
+                infostr = resp.read()
 
-                                finaldir = os.path.dirname(final_path)
+                # If parse succeeds, then the data is valid.
+                pub_data = p5i.parse(data=infostr)
+                return [pub for pub, ignored in pub_data if pub]
+            except tx.ExcessiveTransientFailure as e:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(e.failures)
 
-                                self._makedirs(finaldir)
-                                portable.rename(dl_path, final_path)
+            except apx.InvalidP5IFile as e:
+                repouri_key = d.get_repouri_key()
+                exc = tx.TransferContentException(
+                    repouri_key[0],
+                    "api_errors.InvalidP5IFile:{0}".format(
+                        " ".join([str(a) for a in e.args])
+                    ),
+                )
+                repostats = self.stats[repouri_key]
+                repostats.record_error(content=True)
+                if exc.retryable:
+                    failures.append(exc)
+                else:
+                    raise exc
 
-                        # Return if everything was successful
-                        if not flist and not errlist:
-                                return
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
 
-                if failedreqs and failures:
-                        failures = [
-                            x for x in failures
-                            if x.request in failedreqs
-                        ]
-                        tfailurex = tx.TransportFailures()
-                        for f in failures:
-                                tfailurex.append(f)
-                        raise tfailurex
+        raise failures
 
-        @LockedTransport()
-        def get_publisherdata(self, pub, ccancel=None):
-                """Given a publisher pub, return the publisher/0
-                information as a list of publisher objects.  If
-                no publisher information was contained in the
-                response, the list will be empty."""
+    @LockedTransport()
+    def get_syspub_data(self, repo_uri, ccancel=None):
+        """Get the publisher and image configuration from the system
+        repo given in repo_uri."""
 
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                failures = tx.TransportFailures()
-                header = None
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        failures = tx.TransportFailures()
+        header = None
 
-                if isinstance(pub, publisher.Publisher):
-                        header = self.__build_header(uuid=self.__get_uuid(pub),
-                            variant=self.__get_variant(pub))
+        assert isinstance(self.cfg, ImageTransportCfg)
+        assert isinstance(repo_uri, publisher.RepositoryURI)
 
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, operation="publisher", versions=[0],
-                    ccancel=ccancel):
-                        try:
-                                resp = d.get_publisherinfo(header,
-                                    ccancel=ccancel)
-                                infostr = resp.read()
+        for d, retries, v in self.__gen_repo(
+            repo_uri,
+            retry_count,
+            origin_only=True,
+            operation="syspub",
+            versions=[0],
+            ccancel=ccancel,
+        ):
+            try:
+                resp = d.get_syspub_info(header, ccancel=ccancel)
+                infostr = resp.read()
+                return p5s.parse(repo_uri.get_host(), infostr)
+            except tx.ExcessiveTransientFailure as e:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(e.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
 
-                                # If parse succeeds, then the data is valid.
-                                pub_data = p5i.parse(data=infostr)
-                                return [pub for pub, ignored in pub_data if pub]
-                        except tx.ExcessiveTransientFailure as e:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(e.failures)
+        raise failures
 
-                        except apx.InvalidP5IFile as e:
-                                repouri_key = d.get_repouri_key()
-                                exc = tx.TransferContentException(
-                                    repouri_key[0],
-                                    "api_errors.InvalidP5IFile:{0}".format(
-                                    " ".join([str(a) for a in e.args])))
-                                repostats = self.stats[repouri_key]
-                                repostats.record_error(content=True)
-                                if exc.retryable:
-                                        failures.append(exc)
-                                else:
-                                        raise exc
+    @LockedTransport()
+    def get_datastream(self, pub, fhash, ccancel=None):
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        failures = tx.TransportFailures()
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
 
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
+        for d, retries, v in self.__gen_repo(
+            pub, retry_count, operation="file", versions=[0, 1]
+        ):
+            repouri_key = d.get_repouri_key()
+            repostats = self.stats[repouri_key]
+            header = Transport.__get_request_header(
+                header, repostats, retries, d
+            )
+            try:
+                return d.get_datastream(
+                    fhash, v, header, ccancel=ccancel, pub=pub
+                )
+            except tx.ExcessiveTransientFailure as e:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(e.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+        raise failures
 
-                raise failures
+    @LockedTransport()
+    def get_content(
+        self,
+        pub,
+        fhash,
+        fmri=None,
+        ccancel=None,
+        hash_func=None,
+        errors="strict",
+    ):
+        """Given a fhash, return the uncompressed content content from
+        the remote object.  This is similar to get_datastream, except
+        that the transport handles retrieving and decompressing the
+        content.
 
-        @LockedTransport()
-        def get_syspub_data(self, repo_uri, ccancel=None):
-                """Get the publisher and image configuration from the system
-                repo given in repo_uri."""
+        'fmri' If the fhash corresponds to a known package, the fmri
+        should be specified for optimal transport performance.
 
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                failures = tx.TransportFailures()
-                header = None
+        'hash_func' is the hash function that was used to compute fhash.
 
-                assert isinstance(self.cfg, ImageTransportCfg)
-                assert isinstance(repo_uri, publisher.RepositoryURI)
+        'errors' allows us to deal with UTF-8 encoding issues. This
+        really only makes sense to use when showing the content of
+        a license or release-note, all other cases should use 'strict'
+        """
 
-                for d, retries, v in self.__gen_repo(repo_uri, retry_count,
-                    origin_only=True, operation="syspub", versions=[0],
-                    ccancel=ccancel):
-                        try:
-                                resp = d.get_syspub_info(header,
-                                    ccancel=ccancel)
-                                infostr = resp.read()
-                                return p5s.parse(repo_uri.get_host(), infostr)
-                        except tx.ExcessiveTransientFailure as e:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(e.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        failures = tx.TransportFailures()
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
 
-                raise failures
+        alt_repo = None
+        if not fmri and self.cfg.alt_pubs:
+            # No FMRI was provided, but alternate package sources
+            # are available, so create a new repository object
+            # that composites the repository information returned
+            # from the image with the alternate sources for this
+            # publisher.
+            alt_repo = pub.repository
+            if alt_repo:
+                alt_repo = copy.copy(alt_repo)
+            else:
+                alt_repo = publisher.Repository()
 
-        @LockedTransport()
-        def get_datastream(self, pub, fhash, ccancel=None):
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                failures = tx.TransportFailures()
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
+            for tpub in self.cfg.alt_pubs:
+                if tpub.prefix != pub.prefix:
+                    continue
+                for o in tpub.repository.origins:
+                    if not alt_repo.has_origin(o):
+                        alt_repo.add_origin(o)
+        elif fmri:
+            alt_repo = self.cfg.get_pkg_alt_repo(fmri)
 
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    operation="file", versions=[0, 1]):
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            operation="file",
+            versions=[0, 1],
+            alt_repo=alt_repo,
+        ):
+            repouri_key = d.get_repouri_key()
+            repostats = self.stats[repouri_key]
+            header = Transport.__get_request_header(
+                header, repostats, retries, d
+            )
+            try:
+                resp = d.get_datastream(
+                    fhash, v, header, ccancel=ccancel, pub=pub
+                )
+                s = BytesIO()
+                hash_val = misc.gunzip_from_stream(resp, s, hash_func=hash_func)
 
-                        repouri_key = d.get_repouri_key()
-                        repostats = self.stats[repouri_key]
-                        header = Transport.__get_request_header(header,
-                            repostats, retries, d)
-                        try:
-                                return d.get_datastream(fhash, v, header,
-                                    ccancel=ccancel, pub=pub)
-                        except tx.ExcessiveTransientFailure as e:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(e.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-                raise failures
+                if hash_val != fhash:
+                    exc = tx.InvalidContentException(
+                        reason="hash failure: expected: {0}"
+                        " computed: {1}".format(fhash, hash_val),
+                        url=repouri_key[0],
+                        proxy=repouri_key[1],
+                    )
+                    repostats.record_error(content=True)
+                    raise exc
 
-        @LockedTransport()
-        def get_content(self, pub, fhash, fmri=None, ccancel=None,
-            hash_func=None, errors="strict"):
-                """Given a fhash, return the uncompressed content content from
-                the remote object.  This is similar to get_datastream, except
-                that the transport handles retrieving and decompressing the
-                content.
+                content = s.getvalue()
+                s.close()
 
-                'fmri' If the fhash corresponds to a known package, the fmri
-                should be specified for optimal transport performance.
+                # we want str internally
+                return misc.force_str(content, errors=errors)
 
-                'hash_func' is the hash function that was used to compute fhash.
+            except tx.ExcessiveTransientFailure as e:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(e.failures)
 
-                'errors' allows us to deal with UTF-8 encoding issues. This
-                really only makes sense to use when showing the content of
-                a license or release-note, all other cases should use 'strict'
-                """
+            except zlib.error as e:
+                exc = tx.TransferContentException(
+                    repouri_key[0],
+                    "zlib.error:{0}".format(" ".join([str(a) for a in e.args])),
+                    proxy=repouri_key[1],
+                )
+                repostats.record_error(content=True)
+                if exc.retryable:
+                    failures.append(exc)
+                else:
+                    raise exc
 
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                failures = tx.TransportFailures()
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+        raise failures
 
-                alt_repo = None
-                if not fmri and self.cfg.alt_pubs:
-                        # No FMRI was provided, but alternate package sources
-                        # are available, so create a new repository object
-                        # that composites the repository information returned
-                        # from the image with the alternate sources for this
-                        # publisher.
-                        alt_repo = pub.repository
-                        if alt_repo:
-                                alt_repo = copy.copy(alt_repo)
-                        else:
-                                alt_repo = publisher.Repository()
+    @LockedTransport()
+    def get_status(self, pub, ccancel=None):
+        """Given a publisher pub, return the stats information
+        for the repository as a dictionary."""
 
-                        for tpub in self.cfg.alt_pubs:
-                                if tpub.prefix != pub.prefix:
-                                        continue
-                                for o in tpub.repository.origins:
-                                        if not alt_repo.has_origin(o):
-                                                alt_repo.add_origin(o)
-                elif fmri:
-                        alt_repo = self.cfg.get_pkg_alt_repo(fmri)
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        failures = tx.TransportFailures()
+        header = None
 
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    operation="file", versions=[0, 1], alt_repo=alt_repo):
+        if isinstance(pub, publisher.Publisher):
+            header = self.__build_header(
+                uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+            )
 
-                        repouri_key = d.get_repouri_key()
-                        repostats = self.stats[repouri_key]
-                        header = Transport.__get_request_header(header,
-                            repostats, retries, d)
-                        try:
-                                resp = d.get_datastream(fhash, v, header,
-                                    ccancel=ccancel, pub=pub)
-                                s = BytesIO()
-                                hash_val = misc.gunzip_from_stream(resp, s,
-                                    hash_func=hash_func)
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            operation="status",
+            versions=[0],
+            ccancel=ccancel,
+        ):
+            try:
+                repouri_key = d.get_repouri_key()
+                repostats = self.stats[repouri_key]
+                header = Transport.__get_request_header(
+                    header, repostats, retries, d
+                )
+                resp = d.get_status(header, ccancel=ccancel)
+                infostr = resp.read()
 
-                                if hash_val != fhash:
-                                        exc = tx.InvalidContentException(
-                                            reason="hash failure: expected: {0}"
-                                            " computed: {1}".format(fhash,
-                                            hash_val), url=repouri_key[0],
-                                            proxy=repouri_key[1])
-                                        repostats.record_error(content=True)
-                                        raise exc
+                # If parse succeeds, then the data is valid.
+                return dict(json.loads(infostr))
+            except tx.ExcessiveTransientFailure as e:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(e.failures)
 
-                                content = s.getvalue()
-                                s.close()
+            except (TypeError, ValueError) as e:
+                exc = tx.TransferContentException(
+                    repouri_key[0],
+                    "Invalid stats response: {0}".format(e),
+                    proxy=repouri_key[1],
+                )
+                repostats.record_error(content=True)
+                if exc.retryable:
+                    failures.append(exc)
+                else:
+                    raise exc
 
-                                # we want str internally
-                                return misc.force_str(content, errors=errors)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
 
-                        except tx.ExcessiveTransientFailure as e:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(e.failures)
+        raise failures
 
-                        except zlib.error as e:
-                                exc = tx.TransferContentException(
-                                    repouri_key[0],
-                                    "zlib.error:{0}".format(
-                                    " ".join([str(a) for a in e.args])),
-                                    proxy=repouri_key[1])
-                                repostats.record_error(content=True)
-                                if exc.retryable:
-                                        failures.append(exc)
-                                else:
-                                        raise exc
+    @LockedTransport()
+    def touch_manifest(self, fmri, intent=None, ccancel=None, alt_repo=None):
+        """Touch a manifest.  This operation does not
+        return the manifest's content.  The FMRI is given
+        as fmri.  An optional intent string may be supplied
+        as intent."""
 
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-                raise failures
+        failures = tx.TransportFailures(pfmri=fmri)
+        pub_prefix = fmri.publisher
+        pub = self.cfg.get_publisher(pub_prefix)
+        mfst = fmri.get_url_path()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            intent=intent,
+            uuid=self.__get_uuid(pub),
+            variant=self.__get_variant(pub),
+        )
 
-        @LockedTransport()
-        def get_status(self, pub, ccancel=None):
-                """Given a publisher pub, return the stats information
-                for the repository as a dictionary."""
+        if not alt_repo:
+            alt_repo = self.cfg.get_pkg_alt_repo(fmri)
 
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                failures = tx.TransportFailures()
-                header = None
+        for d, retries in self.__gen_repo(
+            pub, retry_count, origin_only=True, alt_repo=alt_repo
+        ):
+            # If a transport exception occurs,
+            # save it if it's retryable, otherwise
+            # raise the error to a higher-level handler.
+            try:
+                d.touch_manifest(mfst, header, ccancel=ccancel, pub=pub)
+                return
 
-                if isinstance(pub, publisher.Publisher):
-                        header = self.__build_header(uuid=self.__get_uuid(pub),
-                            variant=self.__get_variant(pub))
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
 
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, operation="status", versions=[0],
-                    ccancel=ccancel):
-                        try:
-                                repouri_key = d.get_repouri_key()
-                                repostats = self.stats[repouri_key]
-                                header = Transport.__get_request_header(header,
-                                    repostats, retries, d)
-                                resp = d.get_status(header, ccancel=ccancel)
-                                infostr = resp.read()
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
 
-                                # If parse succeeds, then the data is valid.
-                                return dict(json.loads(infostr))
-                        except tx.ExcessiveTransientFailure as e:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(e.failures)
+        raise failures
 
-                        except (TypeError, ValueError) as e:
+    @LockedTransport()
+    def get_compressed_attrs(self, fhash, pub=None, trans_id=None, hashes=True):
+        """Given a fhash, returns a tuple of (csize, chashes) where
+        'csize' is the size of the file in the repository and 'chashes'
+        is a dictionary containing any hashes of the compressed data
+        known by the repository.  If the repository cannot provide the
+        hash information or 'hashes' is False, chashes will be an empty
+        dictionary.  If the repository does not have the file, a tuple
+        of (None, None) will be returned instead."""
 
-                                exc = tx.TransferContentException(
-                                    repouri_key[0],
-                                    "Invalid stats response: {0}".format(e),
-                                    proxy=repouri_key[1])
-                                repostats.record_error(content=True)
-                                if exc.retryable:
-                                        failures.append(exc)
-                                else:
-                                        raise exc
+        failures = tx.TransportFailures()
+        # If the operation fails, it doesn't matter as it won't cause a
+        # correctness issue, and it could be the repository simply
+        # doesn't have the file, so don't try more than once.
+        retry_count = 1
+        header = self.__build_header(uuid=self.__get_uuid(pub))
 
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
+        for d, retries in self.__gen_repo(
+            pub, retry_count, origin_only=True, single_repository=True
+        ):
+            return d.get_compressed_attrs(
+                fhash, header, pub=pub, trans_id=trans_id, hashes=hashes
+            )
 
-                raise failures
+    @LockedTransport()
+    def get_manifest(
+        self,
+        fmri,
+        excludes=misc.EmptyI,
+        intent=None,
+        ccancel=None,
+        pub=None,
+        content_only=False,
+        alt_repo=None,
+    ):
+        """Given a fmri, and optional excludes, return a manifest
+        object."""
 
-        @LockedTransport()
-        def touch_manifest(self, fmri, intent=None, ccancel=None,
-            alt_repo=None):
-                """Touch a manifest.  This operation does not
-                return the manifest's content.  The FMRI is given
-                as fmri.  An optional intent string may be supplied
-                as intent."""
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        failures = tx.TransportFailures(pfmri=fmri)
+        pub_prefix = fmri.publisher
+        download_dir = self.cfg.incoming_root
+        mcontent = None
+        header = None
 
-                failures = tx.TransportFailures(pfmri=fmri)
-                pub_prefix = fmri.publisher
+        if not pub:
+            try:
                 pub = self.cfg.get_publisher(pub_prefix)
-                mfst = fmri.get_url_path()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(intent=intent,
-                    uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
+            except apx.UnknownPublisher:
+                # Publisher has likely been removed but we need
+                # data from it.
+                raise apx.NoPublisherRepositories(pub_prefix)
 
-                if not alt_repo:
-                        alt_repo = self.cfg.get_pkg_alt_repo(fmri)
+        if isinstance(pub, publisher.Publisher):
+            header = self.__build_header(
+                intent=intent,
+                uuid=self.__get_uuid(pub),
+                variant=self.__get_variant(pub),
+            )
 
-                for d, retries in self.__gen_repo(pub, retry_count,
-                    origin_only=True, alt_repo=alt_repo):
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
 
-                        # If a transport exception occurs,
-                        # save it if it's retryable, otherwise
-                        # raise the error to a higher-level handler.
-                        try:
-                                d.touch_manifest(mfst, header, ccancel=ccancel,
-                                    pub=pub)
-                                return
+        # If version check hasn't been executed, run it prior to this
+        # operation.
+        self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
 
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
+        # Check if the download_dir exists.  If it doesn't create
+        # the directories.
+        self._makedirs(download_dir)
 
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
+        if not alt_repo:
+            alt_repo = self.cfg.get_pkg_alt_repo(fmri)
 
-                raise failures
+        for d, retries in self.__gen_repo(
+            pub, retry_count, origin_only=True, alt_repo=alt_repo
+        ):
+            repouri_key = d.get_repouri_key()
+            repostats = self.stats[repouri_key]
+            verified = False
+            header = Transport.__get_request_header(
+                header, repostats, retries, d
+            )
+            try:
+                resp = d.get_manifest(fmri, header, ccancel=ccancel, pub=pub)
+                # If resp is a StreamingFileObj obj, its read()
+                # methods will return bytes. We need str for
+                # manifest and here's the earliest point that
+                # we can convert it to str.
+                mcontent = misc.force_str(resp.read())
 
-        @LockedTransport()
-        def get_compressed_attrs(self, fhash, pub=None, trans_id=None,
-            hashes=True):
-                """Given a fhash, returns a tuple of (csize, chashes) where
-                'csize' is the size of the file in the repository and 'chashes'
-                is a dictionary containing any hashes of the compressed data
-                known by the repository.  If the repository cannot provide the
-                hash information or 'hashes' is False, chashes will be an empty
-                dictionary.  If the repository does not have the file, a tuple
-                of (None, None) will be returned instead."""
+                verified = self._verify_manifest(
+                    fmri, content=mcontent, pub=pub
+                )
 
-                failures = tx.TransportFailures()
-                # If the operation fails, it doesn't matter as it won't cause a
-                # correctness issue, and it could be the repository simply
-                # doesn't have the file, so don't try more than once.
-                retry_count = 1
-                header = self.__build_header(uuid=self.__get_uuid(pub))
+                if content_only:
+                    return mcontent
 
-                for d, retries in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True):
-                        return d.get_compressed_attrs(fhash, header,
-                            pub=pub, trans_id=trans_id, hashes=hashes)
+                m = manifest.FactoredManifest(
+                    fmri,
+                    self.cfg.get_pkg_dir(fmri),
+                    contents=mcontent,
+                    excludes=excludes,
+                    pathname=self.cfg.get_pkg_pathname(fmri),
+                )
 
-        @LockedTransport()
-        def get_manifest(self, fmri, excludes=misc.EmptyI, intent=None,
-            ccancel=None, pub=None, content_only=False, alt_repo=None):
-                """Given a fmri, and optional excludes, return a manifest
-                object."""
+                return m
 
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                failures = tx.TransportFailures(pfmri=fmri)
-                pub_prefix = fmri.publisher
-                download_dir = self.cfg.incoming_root
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
                 mcontent = None
-                header = None
 
-                if not pub:
-                        try:
-                                pub = self.cfg.get_publisher(pub_prefix)
-                        except apx.UnknownPublisher:
-                                # Publisher has likely been removed but we need
-                                # data from it.
-                                raise apx.NoPublisherRepositories(pub_prefix)
+            except tx.InvalidContentException as e:
+                # We might be able to retrive uncorrupted
+                # content. If this was the last retry, then
+                # we're out of luck.
+                failures.append(e)
+                mcontent = None
+                repostats.record_error(content=True)
 
-                if isinstance(pub, publisher.Publisher):
-                        header = self.__build_header(intent=intent,
-                            uuid=self.__get_uuid(pub),
-                            variant=self.__get_variant(pub))
-
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
-
-                # If version check hasn't been executed, run it prior to this
-                # operation.
-                self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
-
-                # Check if the download_dir exists.  If it doesn't create
-                # the directories.
-                self._makedirs(download_dir)
-
-                if not alt_repo:
-                        alt_repo = self.cfg.get_pkg_alt_repo(fmri)
-
-                for d, retries in self.__gen_repo(pub, retry_count,
-                    origin_only=True, alt_repo=alt_repo):
-
-                        repouri_key = d.get_repouri_key()
-                        repostats = self.stats[repouri_key]
-                        verified = False
-                        header = Transport.__get_request_header(header,
-                            repostats, retries, d)
-                        try:
-                                resp = d.get_manifest(fmri, header,
-                                    ccancel=ccancel, pub=pub)
-                                # If resp is a StreamingFileObj obj, its read()
-                                # methods will return bytes. We need str for
-                                # manifest and here's the earliest point that
-                                # we can convert it to str.
-                                mcontent = misc.force_str(resp.read())
-
-                                verified = self._verify_manifest(fmri,
-                                    content=mcontent, pub=pub)
-
-                                if content_only:
-                                        return mcontent
-
-                                m = manifest.FactoredManifest(fmri,
-                                    self.cfg.get_pkg_dir(fmri),
-                                    contents=mcontent, excludes=excludes,
-                                    pathname=self.cfg.get_pkg_pathname(fmri))
-
-                                return m
-
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                                mcontent = None
-
-                        except tx.InvalidContentException as e:
-                                # We might be able to retrive uncorrupted
-                                # content. If this was the last retry, then
-                                # we're out of luck.
-                                failures.append(e)
-                                mcontent = None
-                                repostats.record_error(content=True)
-
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                        mcontent = None
-                                else:
-                                        raise
-
-                        except (apx.InvalidPackageErrors, ActionError) as e:
-                                if verified:
-                                        raise
-                                repostats.record_error(content=True)
-                                te = tx.TransferContentException(
-                                    repouri_key[0], reason=str(e),
-                                    proxy=repouri_key[1])
-                                failures.append(te)
-
-                raise failures
-
-        @LockedTransport()
-        def prefetch_manifests(self, fetchlist, excludes=misc.EmptyI,
-            progtrack=None, ccancel=None, alt_repo=None):
-                """Given a list of tuples [(fmri, intent), ...], prefetch
-                the manifests specified by the fmris in argument
-                fetchlist.  Caller may supply a progress tracker in
-                'progtrack' as well as the check-cancellation callback in
-                'ccancel.'
-
-                This method will not return transient transport errors,
-                but it should raise any that would cause an immediate
-                failure."""
-
-                download_dir = self.cfg.incoming_root
-
-                if not fetchlist:
-                        return
-
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-                progtrack.manifest_fetch_start(len(fetchlist))
-
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
-
-                # If version check hasn't been executed, run it prior to this
-                # operation.
-                try:
-                        self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
-                except apx.InvalidDepotResponseException:
-                        return
-
-                # Check if the download_dir exists.  If it doesn't create
-                # the directories.
-                self._makedirs(download_dir)
-
-                # Call statvfs to find the blocksize of download_dir's
-                # filesystem.
-                try:
-                        destvfs = os.statvfs(download_dir)
-                        # set the file buffer size to the blocksize of
-                        # our filesystem
-                        self.__engine.set_file_bufsz(destvfs.f_bsize)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                return
-                        else:
-                                raise tx.TransportOperationError(
-                                    "Unable to stat VFS: {0}".format(e))
-                except AttributeError as e:
-                        # os.statvfs is not available on Windows
-                        pass
-
-                # Walk the tuples in fetchlist and create a MultiXfr
-                # instance for each publisher's worth of requests that
-                # this routine must process.
-                mx_pub = {}
-
-                get_alt = not alt_repo
-                for fmri, intent in fetchlist:
-                        if get_alt:
-                                alt_repo = self.cfg.get_pkg_alt_repo(fmri)
-
-                        # Multi transfer object must be created for each unique
-                        # publisher or repository.
-                        if alt_repo:
-                                eid = id(alt_repo)
-                        else:
-                                eid = fmri.publisher
-
-                        try:
-                                pub = self.cfg.get_publisher(fmri.publisher)
-                        except apx.UnknownPublisher:
-                                # Publisher has likely been removed but we need
-                                # data from it.
-                                raise apx.NoPublisherRepositories(
-                                    fmri.publisher)
-
-                        header = self.__build_header(intent=intent,
-                            uuid=self.__get_uuid(pub),
-                            variant=self.__get_variant(pub))
-
-                        if eid not in mx_pub:
-                                mx_pub[eid] = MultiXfr(pub,
-                                    progtrack=progtrack,
-                                    ccancel=ccancel,
-                                    alt_repo=alt_repo)
-
-                        # Add requests keyed by requested package
-                        # fmri.  Value contains (header, fmri) tuple.
-                        mx_pub[eid].add_hash(fmri, (header, fmri))
-
-                for mxfr in mx_pub.values():
-                        namelist = [k for k in mxfr]
-                        while namelist:
-                                chunksz = self.__chunk_size(pub,
-                                    alt_repo=mxfr.get_alt_repo(),
-                                    origin_only=True)
-                                mfstlist = [
-                                    (n, mxfr[n][0])
-                                    for n in namelist[:chunksz]
-                                ]
-                                del namelist[:chunksz]
-
-                                try:
-                                        self._prefetch_manifests_list(mxfr,
-                                            mfstlist, excludes)
-                                except apx.PermissionsException:
-                                        progtrack.manifest_fetch_done()
-                                        return
-
-                progtrack.manifest_fetch_done()
-
-        def _prefetch_manifests_list(self, mxfr, mlist, excludes=misc.EmptyI):
-                """Perform bulk manifest prefetch.  This is the routine
-                that downloads initiates the downloads in chunks
-                determined by its caller _prefetch_manifests.  The mxfr
-                argument should be a MultiXfr object, and mlist
-                should be a list of tuples (fmri, header)."""
-
-                # Don't perform multiple retries, since we're just prefetching.
-                retry_count = 1
-                mfstlist = mlist
-                pub = mxfr.get_publisher()
-                progtrack = mxfr.get_progtrack()
-                assert(progtrack)
-
-                # download_dir is temporary download path.
-                download_dir = self.cfg.incoming_root
-
-                for d, retries in self.__gen_repo(pub, retry_count,
-                    origin_only=True, alt_repo=mxfr.get_alt_repo()):
-
-                        failedreqs = []
-                        repostats = self.stats[d.get_repouri_key()]
-                        gave_up = False
-
-                        # Possibly overkill, if any content errors were seen
-                        # we modify the headers of all requests, not just the
-                        # ones that failed before. Also do this if we force
-                        # cache validation.
-                        if (repostats.content_errors and retries > 1) or \
-                            Transport.__ignore_network_cache():
-                                mfstlist = [(fmri, d.build_refetch_header(h))
-                                    for fmri, h in mfstlist]
-
-                        # This returns a list of transient errors
-                        # that occurred during the transport operation.
-                        # An exception handler here isn't necessary
-                        # unless we want to suppress a permanent failure.
-                        try:
-                                errlist = d.get_manifests(mfstlist,
-                                    download_dir, progtrack=progtrack, pub=pub)
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, record this for later
-                                # and try a different host.
-                                gave_up = True
-                                errlist = ex.failures
-                                success = ex.success
-
-                        for e in errlist:
-                                req = getattr(e, "request", None)
-                                if req:
-                                        failedreqs.append(req)
-                                else:
-                                        raise e
-
-                        if gave_up:
-                                # If the transport gave up due to excessive
-                                # consecutive errors, the caller is returned a
-                                # list of successful requests, and a list of
-                                # failures.  We need to consider the requests
-                                # that were not attempted because we gave up
-                                # early.  In this situation, they're failed
-                                # requests, even though no exception was
-                                # returned.  Filter the flist to remove the
-                                # successful requests.  Everything else failed.
-                                failedreqs = [
-                                    x[0] for x in mfstlist
-                                    if x[0] not in success
-                                ]
-                        elif failedreqs:
-                                success = [
-                                    x[0] for x in mfstlist
-                                    if x[0] not in failedreqs
-                                ]
-                        else:
-                                success = [ x[0] for x in mfstlist ]
-
-                        for s in success:
-
-                                dl_path = os.path.join(download_dir,
-                                    s.get_url_path())
-
-                                try:
-                                        # Verify manifest content.
-                                        fmri = mxfr[s][1]
-                                        verified = self._verify_manifest(fmri,
-                                            dl_path)
-                                except tx.InvalidContentException as e:
-                                        e.request = s
-                                        repostats.record_error(content=True)
-                                        failedreqs.append(s)
-                                        continue
-
-                                try:
-                                        mf = open(dl_path)
-                                        mcontent = mf.read()
-                                        mf.close()
-                                        manifest.FactoredManifest(fmri,
-                                            self.cfg.get_pkg_dir(fmri),
-                                            contents=mcontent, excludes=excludes,
-                                            pathname=self.cfg.get_pkg_pathname(fmri))
-                                except (apx.InvalidPackageErrors,
-                                    ActionError) as e:
-                                        if verified:
-                                                # If the manifest was physically
-                                                # valid, but can't be logically
-                                                # parsed, drive on.
-                                                portable.remove(dl_path)
-                                                progtrack.manifest_commit()
-                                                mxfr.del_hash(s)
-                                                continue
-                                        repostats.record_error(content=True)
-                                        failedreqs.append(s)
-                                        portable.remove(dl_path)
-                                        continue
-
-                                portable.remove(dl_path)
-                                progtrack.manifest_commit()
-                                mxfr.del_hash(s)
-
-                        # If there were failures, re-generate list for just
-                        # failed requests.
-                        if failedreqs:
-                                # Generate mfstlist here, which included any
-                                # reqs that failed during verification.
-                                mfstlist = [
-                                    (x,y) for x,y in mfstlist
-                                    if x in failedreqs
-                                ]
-                        # Return if everything was successful
-                        else:
-                                return
-
-        def _verify_manifest(self, fmri, mfstpath=None, content=None, pub=None):
-                """Verify a manifest.  The caller must supply the FMRI
-                for the package in 'fmri', as well as the path to the
-                manifest file that will be verified.  If signature information
-                is not present, this routine returns False.  If signature
-                information is present, and the manifest verifies, this
-                method returns true.  If the manifest fails to verify,
-                this function throws an InvalidContentException.
-
-                The caller may either specify a pathname to a file that
-                contains the manifest in 'mfstpath' or a string that contains
-                the manifest content in 'content'.  One of these arguments
-                must be used."""
-
-                # Bail if manifest validation has been turned off for
-                # debugging/testing purposes.
-                if DebugValues.get("manifest_validate") == "Never":
-                        return True
-
-                must_verify = \
-                    DebugValues.get("manifest_validate") == "Always"
-
-                if not isinstance(pub, publisher.Publisher):
-                        # Get publisher using information from FMRI.
-                        try:
-                                pub = self.cfg.get_publisher(fmri.publisher)
-                        except apx.UnknownPublisher:
-                                if must_verify:
-                                        assert False, \
-                                            "Did not validate manifest; " \
-                                            "unknown publisher {0} ({1}).".format(
-                                            fmri.publisher, fmri)
-                                return False
-
-                try:
-                        sigs = self.cfg.get_pkg_sigs(fmri, pub)
-                except apx.UnknownCatalogEntry:
-                        if must_verify:
-                                assert False, "Did not validate manifest; " \
-                                    "couldn't find sigs."
-                        return False
-
-                if sigs and "sha-1" in sigs:
-                        chash = sigs["sha-1"]
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                    mcontent = None
                 else:
-                        if must_verify:
-                                assert False, \
-                                    "Did not validate manifest; no sha-1 sig."
-                        return False
+                    raise
 
-                if mfstpath:
-                        mf = open(mfstpath)
-                        mcontent = mf.read()
-                        mf.close()
-                elif content is not None:
-                        mcontent = content
+            except (apx.InvalidPackageErrors, ActionError) as e:
+                if verified:
+                    raise
+                repostats.record_error(content=True)
+                te = tx.TransferContentException(
+                    repouri_key[0], reason=str(e), proxy=repouri_key[1]
+                )
+                failures.append(te)
+
+        raise failures
+
+    @LockedTransport()
+    def prefetch_manifests(
+        self,
+        fetchlist,
+        excludes=misc.EmptyI,
+        progtrack=None,
+        ccancel=None,
+        alt_repo=None,
+    ):
+        """Given a list of tuples [(fmri, intent), ...], prefetch
+        the manifests specified by the fmris in argument
+        fetchlist.  Caller may supply a progress tracker in
+        'progtrack' as well as the check-cancellation callback in
+        'ccancel.'
+
+        This method will not return transient transport errors,
+        but it should raise any that would cause an immediate
+        failure."""
+
+        download_dir = self.cfg.incoming_root
+
+        if not fetchlist:
+            return
+
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+        progtrack.manifest_fetch_start(len(fetchlist))
+
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        # If version check hasn't been executed, run it prior to this
+        # operation.
+        try:
+            self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
+        except apx.InvalidDepotResponseException:
+            return
+
+        # Check if the download_dir exists.  If it doesn't create
+        # the directories.
+        self._makedirs(download_dir)
+
+        # Call statvfs to find the blocksize of download_dir's
+        # filesystem.
+        try:
+            destvfs = os.statvfs(download_dir)
+            # set the file buffer size to the blocksize of
+            # our filesystem
+            self.__engine.set_file_bufsz(destvfs.f_bsize)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                return
+            else:
+                raise tx.TransportOperationError(
+                    "Unable to stat VFS: {0}".format(e)
+                )
+        except AttributeError as e:
+            # os.statvfs is not available on Windows
+            pass
+
+        # Walk the tuples in fetchlist and create a MultiXfr
+        # instance for each publisher's worth of requests that
+        # this routine must process.
+        mx_pub = {}
+
+        get_alt = not alt_repo
+        for fmri, intent in fetchlist:
+            if get_alt:
+                alt_repo = self.cfg.get_pkg_alt_repo(fmri)
+
+            # Multi transfer object must be created for each unique
+            # publisher or repository.
+            if alt_repo:
+                eid = id(alt_repo)
+            else:
+                eid = fmri.publisher
+
+            try:
+                pub = self.cfg.get_publisher(fmri.publisher)
+            except apx.UnknownPublisher:
+                # Publisher has likely been removed but we need
+                # data from it.
+                raise apx.NoPublisherRepositories(fmri.publisher)
+
+            header = self.__build_header(
+                intent=intent,
+                uuid=self.__get_uuid(pub),
+                variant=self.__get_variant(pub),
+            )
+
+            if eid not in mx_pub:
+                mx_pub[eid] = MultiXfr(
+                    pub, progtrack=progtrack, ccancel=ccancel, alt_repo=alt_repo
+                )
+
+            # Add requests keyed by requested package
+            # fmri.  Value contains (header, fmri) tuple.
+            mx_pub[eid].add_hash(fmri, (header, fmri))
+
+        for mxfr in mx_pub.values():
+            namelist = [k for k in mxfr]
+            while namelist:
+                chunksz = self.__chunk_size(
+                    pub, alt_repo=mxfr.get_alt_repo(), origin_only=True
+                )
+                mfstlist = [(n, mxfr[n][0]) for n in namelist[:chunksz]]
+                del namelist[:chunksz]
+
+                try:
+                    self._prefetch_manifests_list(mxfr, mfstlist, excludes)
+                except apx.PermissionsException:
+                    progtrack.manifest_fetch_done()
+                    return
+
+        progtrack.manifest_fetch_done()
+
+    def _prefetch_manifests_list(self, mxfr, mlist, excludes=misc.EmptyI):
+        """Perform bulk manifest prefetch.  This is the routine
+        that downloads initiates the downloads in chunks
+        determined by its caller _prefetch_manifests.  The mxfr
+        argument should be a MultiXfr object, and mlist
+        should be a list of tuples (fmri, header)."""
+
+        # Don't perform multiple retries, since we're just prefetching.
+        retry_count = 1
+        mfstlist = mlist
+        pub = mxfr.get_publisher()
+        progtrack = mxfr.get_progtrack()
+        assert progtrack
+
+        # download_dir is temporary download path.
+        download_dir = self.cfg.incoming_root
+
+        for d, retries in self.__gen_repo(
+            pub, retry_count, origin_only=True, alt_repo=mxfr.get_alt_repo()
+        ):
+            failedreqs = []
+            repostats = self.stats[d.get_repouri_key()]
+            gave_up = False
+
+            # Possibly overkill, if any content errors were seen
+            # we modify the headers of all requests, not just the
+            # ones that failed before. Also do this if we force
+            # cache validation.
+            if (
+                repostats.content_errors and retries > 1
+            ) or Transport.__ignore_network_cache():
+                mfstlist = [
+                    (fmri, d.build_refetch_header(h)) for fmri, h in mfstlist
+                ]
+
+            # This returns a list of transient errors
+            # that occurred during the transport operation.
+            # An exception handler here isn't necessary
+            # unless we want to suppress a permanent failure.
+            try:
+                errlist = d.get_manifests(
+                    mfstlist, download_dir, progtrack=progtrack, pub=pub
+                )
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, record this for later
+                # and try a different host.
+                gave_up = True
+                errlist = ex.failures
+                success = ex.success
+
+            for e in errlist:
+                req = getattr(e, "request", None)
+                if req:
+                    failedreqs.append(req)
                 else:
-                        raise ValueError("Caller must supply either mfstpath "
-                            "or content arguments.")
+                    raise e
 
-                newhash = manifest.Manifest.hash_create(mcontent)
+            if gave_up:
+                # If the transport gave up due to excessive
+                # consecutive errors, the caller is returned a
+                # list of successful requests, and a list of
+                # failures.  We need to consider the requests
+                # that were not attempted because we gave up
+                # early.  In this situation, they're failed
+                # requests, even though no exception was
+                # returned.  Filter the flist to remove the
+                # successful requests.  Everything else failed.
+                failedreqs = [x[0] for x in mfstlist if x[0] not in success]
+            elif failedreqs:
+                success = [x[0] for x in mfstlist if x[0] not in failedreqs]
+            else:
+                success = [x[0] for x in mfstlist]
 
-                if chash != newhash:
-                        if mfstpath:
-                                sz = os.stat(mfstpath).st_size
-                                portable.remove(mfstpath)
-                        else:
-                                sz = None
-                        raise tx.InvalidContentException(mfstpath,
-                            "manifest hash failure: fmri: {0} \n"
-                            "expected: {1} computed: {2}".format(
-                            fmri, chash, newhash), size=sz)
-                return True
-
-        @staticmethod
-        def __build_header(intent=None, uuid=None, variant=None):
-                """Return a dictionary that contains various
-                header fields, depending upon what arguments
-                were passed to the function.  Supply intent header in intent
-                argument, uuid information in uuid argument."""
-
-                header = {}
-
-                if intent:
-                        header["X-IPkg-Intent"] = intent
-
-                if uuid:
-                        header["X-IPkg-UUID"] = uuid
-
-                if variant:
-                        header["X-IPkg-Variant"] = variant
-
-                if not header:
-                        return None
-
-                return header
-
-        def __get_uuid(self, pub):
-                if not self.cfg.get_policy(imageconfig.SEND_UUID):
-                        return None
+            for s in success:
+                dl_path = os.path.join(download_dir, s.get_url_path())
 
                 try:
-                        return pub.client_uuid
-                except KeyError:
-                        return None
-
-        def __get_variant(self, pub):
-                if not self.cfg.get_policy(imageconfig.SEND_UUID):
-                        return None
-
-                try:
-                        return (
-                            self.cfg.get_variant('opensolaris.zone') + ',' +
-                            self.cfg.get_variant('opensolaris.imagetype'))
-                except KeyError:
-                        return None
-
-        @staticmethod
-        def _makedirs(newdir):
-                """A helper function for _get_files that makes directories,
-                if needed."""
-
-                if not os.path.exists(newdir):
-                        try:
-                                os.makedirs(newdir)
-                        except EnvironmentError as e:
-                                if e.errno == errno.EACCES:
-                                        raise apx.PermissionsException(
-                                            e.filename)
-                                if e.errno == errno.EROFS:
-                                        raise apx.ReadOnlyFileSystemException(
-                                            e.filename)
-                                raise tx.TransportOperationError("Unable to "
-                                    "make directory: {0}".format(e))
-
-        def _get_files_list(self, mfile, flist):
-                """Download the files given in argument 'flist'.  This
-                allows us to break up download operations into multiple
-                chunks.  Since we re-evaluate our host selection after
-                each chunk, this gives us a better way of reacting to
-                changing conditions in the network."""
-
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                failures = []
-                filelist = flist
-                pub = mfile.get_publisher()
-                progtrack = mfile.get_progtrack()
-                header = None
-
-                if isinstance(pub, publisher.Publisher):
-                        header = self.__build_header(uuid=self.__get_uuid(pub),
-                            variant=self.__get_variant(pub))
-
-                # download_dir is temporary download path.
-                download_dir = self.cfg.incoming_root
-
-                cache = self.cfg.get_caches(pub, readonly=False)
-                if cache:
-                        # For now, pick first cache in list, if any are
-                        # present.
-                        cache = cache[0]
-                else:
-                        cache = None
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    operation="file", versions=[0, 1],
-                    alt_repo=mfile.get_alt_repo()):
-
-                        failedreqs = []
-                        repostats = self.stats[d.get_repouri_key()]
-                        header = Transport.__get_request_header(header,
-                            repostats, retries, d)
-
-                        gave_up = False
-
-                        # This returns a list of transient errors
-                        # that occurred during the transport operation.
-                        # An exception handler here isn't necessary
-                        # unless we want to supress a permanant failure.
-                        try:
-                                errlist = d.get_files(filelist, download_dir,
-                                    progtrack, v, header, pub=pub)
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, record this for later
-                                # and try a different host.
-                                gave_up = True
-                                errlist = ex.failures
-                                success = ex.success
-
-                        for e in errlist:
-                                req = getattr(e, "request", None)
-                                if req:
-                                        failedreqs.append(req)
-                                        failures.append(e)
-                                else:
-                                        raise e
-
-                        if gave_up:
-                                # If the transport gave up due to excessive
-                                # consecutive errors, the caller is returned a
-                                # list of successful requests, and a list of
-                                # failures.  We need to consider the requests
-                                # that were not attempted because we gave up
-                                # early.  In this situation, they're failed
-                                # requests, even though no exception was
-                                # returned.  Filter the flist to remove the
-                                # successful requests.  Everything else failed.
-                                failedreqs = [
-                                    x for x in filelist
-                                    if x not in success
-                                ]
-                                filelist = failedreqs
-                        elif failedreqs:
-                                success = [
-                                    x for x in filelist
-                                    if x not in failedreqs
-                                ]
-                                filelist = failedreqs
-                        else:
-                                success = filelist
-                                filelist = None
-
-                        for s in success:
-
-                                dl_path = os.path.join(download_dir, s)
-
-                                try:
-                                        self._verify_content(mfile[s][0],
-                                            dl_path)
-                                except tx.InvalidContentException as e:
-                                        mfile.subtract_progress(e.size)
-                                        e.request = s
-                                        repostats.record_error(content=True)
-                                        failedreqs.append(s)
-                                        failures.append(e)
-                                        if not filelist:
-                                                filelist = failedreqs
-                                        continue
-
-                                if cache:
-                                        cpath = cache.insert(s, dl_path)
-                                        mfile.file_done(s, cpath)
-                                else:
-                                        mfile.file_done(s, dl_path)
-
-                        # Return if everything was successful
-                        if not filelist and not errlist:
-                                return
-
-                if failedreqs and failures:
-                        failures = [
-                            x for x in failures
-                            if x.request in failedreqs
-                        ]
-                        tfailurex = tx.TransportFailures(pfmri=mfile.pfmri)
-                        for f in failures:
-                                tfailurex.append(f)
-                        raise tfailurex
-
-        @LockedTransport()
-        def _get_files(self, mfile):
-                """Perform an operation that gets multiple files at once.
-                A mfile object contains information about the multiple-file
-                request that will be performed."""
-
-                download_dir = self.cfg.incoming_root
-                pub = mfile.get_publisher()
-
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
-
-                # If version check hasn't been executed, run it prior to this
-                # operation.
-                self._version_check_all(ccancel=mfile.get_ccancel(),
-                    alt_repo=mfile.get_alt_repo())
-
-                # Check if the download_dir exists.  If it doesn't create
-                # the directories.
-                self._makedirs(download_dir)
-
-                # Call statvfs to find the blocksize of download_dir's
-                # filesystem.
-                try:
-                        destvfs = os.statvfs(download_dir)
-                        # set the file buffer size to the blocksize of
-                        # our filesystem
-                        self.__engine.set_file_bufsz(destvfs.f_bsize)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        else:
-                                raise tx.TransportOperationError(
-                                    "Unable to stat VFS: {0}".format(e))
-                except AttributeError as e:
-                        # os.statvfs is not available on Windows
-                        pass
-
-                while mfile:
-
-                        filelist = []
-                        chunksz = self.__chunk_size(pub,
-                            alt_repo=mfile.get_alt_repo())
-
-                        for i, v in enumerate(mfile):
-                                if i >= chunksz:
-                                        break
-                                filelist.append(v)
-
-                        self._get_files_list(mfile, filelist)
-
-        def __format_safe_read_crl(self, pth):
-                """CRLs seem to frequently come in DER format, so try reading
-                the CRL using both of the formats before giving up."""
-
-                with open(pth, "rb") as f:
-                        raw = f.read()
+                    # Verify manifest content.
+                    fmri = mxfr[s][1]
+                    verified = self._verify_manifest(fmri, dl_path)
+                except tx.InvalidContentException as e:
+                    e.request = s
+                    repostats.record_error(content=True)
+                    failedreqs.append(s)
+                    continue
 
                 try:
-                        return x509.load_pem_x509_crl(raw, default_backend())
-                except ValueError:
-                        try:
-                                return x509.load_der_x509_crl(raw,
-                                    default_backend())
-                        except ValueError:
-                                raise apx.BadFileFormat(_("The CRL file "
-                                    "{0} is not in a recognized "
-                                    "format.").format(pth))
+                    mf = open(dl_path)
+                    mcontent = mf.read()
+                    mf.close()
+                    manifest.FactoredManifest(
+                        fmri,
+                        self.cfg.get_pkg_dir(fmri),
+                        contents=mcontent,
+                        excludes=excludes,
+                        pathname=self.cfg.get_pkg_pathname(fmri),
+                    )
+                except (apx.InvalidPackageErrors, ActionError) as e:
+                    if verified:
+                        # If the manifest was physically
+                        # valid, but can't be logically
+                        # parsed, drive on.
+                        portable.remove(dl_path)
+                        progtrack.manifest_commit()
+                        mxfr.del_hash(s)
+                        continue
+                    repostats.record_error(content=True)
+                    failedreqs.append(s)
+                    portable.remove(dl_path)
+                    continue
 
-        @LockedTransport()
-        def get_crl(self, uri, crl_root, more_uris=False):
-                """Given a URI (for now only http URIs are supported), return
-                the CRL object created from the file stored at that uri.
+                portable.remove(dl_path)
+                progtrack.manifest_commit()
+                mxfr.del_hash(s)
 
-                uri: URI for a CRL.
+            # If there were failures, re-generate list for just
+            # failed requests.
+            if failedreqs:
+                # Generate mfstlist here, which included any
+                # reqs that failed during verification.
+                mfstlist = [(x, y) for x, y in mfstlist if x in failedreqs]
+            # Return if everything was successful
+            else:
+                return
 
-                crl_root: file-system based crl root directory for storing
-                retrieved the CRL.
-                """
+    def _verify_manifest(self, fmri, mfstpath=None, content=None, pub=None):
+        """Verify a manifest.  The caller must supply the FMRI
+        for the package in 'fmri', as well as the path to the
+        manifest file that will be verified.  If signature information
+        is not present, this routine returns False.  If signature
+        information is present, and the manifest verifies, this
+        method returns true.  If the manifest fails to verify,
+        this function throws an InvalidContentException.
 
-                uri = uri.strip()
-                if uri.startswith("Full Name:"):
-                        uri = uri[len("Full Name:"):]
-                        uri = uri.strip()
-                if uri.startswith("URI:"):
-                        uri = uri[4:]
-                if not uri.startswith("http://") and \
-                    not uri.startswith("file://"):
-                        raise apx.InvalidResourceLocation(uri.strip())
-                crl_host = DebugValues.get_value("crl_host")
-                if crl_host:
-                        orig = urlparse(uri)
-                        crl = urlparse(crl_host)
-                        uri = urlunparse(ParseResult(
-                            scheme=crl.scheme, netloc=crl.netloc,
-                            path=orig.path,
-                            params=orig.params, query=orig.params,
-                            fragment=orig.fragment))
-                # If we've already read the CRL, use the previously created
-                # object.
-                if uri in self.__tmp_crls:
-                        return self.__tmp_crls[uri]
-                fn = quote(uri, "")
-                if not os.path.isdir(crl_root):
-                        raise apx.InvalidResourceLocation(_("CRL root: {0}"
-                            ).format(crl_root))
+        The caller may either specify a pathname to a file that
+        contains the manifest in 'mfstpath' or a string that contains
+        the manifest content in 'content'.  One of these arguments
+        must be used."""
 
-                fpath = os.path.join(crl_root, fn)
-                crl = None
-                # Check if we already have a CRL for this URI.
-                if os.path.exists(fpath):
-                        # If we already have a CRL that we can read, check
-                        # whether it's time to retrieve a new one from the
-                        # location.
-                        try:
-                                crl = self.__format_safe_read_crl(fpath)
-                        except EnvironmentError:
-                                pass
-                        else:
-                                nu = crl.next_update
-                                cur_time = dt.datetime.utcnow()
+        # Bail if manifest validation has been turned off for
+        # debugging/testing purposes.
+        if DebugValues.get("manifest_validate") == "Never":
+            return True
 
-                                if cur_time < nu:
-                                        self.__tmp_crls[uri] = crl
-                                        return crl
+        must_verify = DebugValues.get("manifest_validate") == "Always"
 
-                # If the CRL is already known to be unavailable, don't try
-                # connecting to it again.
-                if uri in self.__bad_crls:
-                        return crl
-
-                # If no CRL already exists or it's time to try to get a new one,
-                # try to retrieve it from the server.
-                try:
-                        tmp_fd, tmp_pth = tempfile.mkstemp(dir=crl_root)
-                except EnvironmentError as e:
-                        if e.errno in (errno.EACCES, errno.EPERM):
-                                tmp_fd, tmp_pth = tempfile.mkstemp()
-                        else:
-                                raise apx._convert_error(e)
-
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
-
-                orig = urlparse(uri)
-                # To utilize the transport engine, we need to pretend uri for
-                # a crl is like a repo, because the transport engine has some
-                # specific bookkeeping stats keyed by repouri and proxy.
-                # We did this to utilize it as much as possible.
-                repouri = urlunparse(ParseResult(scheme=orig.scheme,
-                    netloc=orig.netloc, path="", params="", query="",
-                    fragment=""))
-                proxy = misc.get_runtime_proxy(None, uri)
-                t_repouris = _convert_repouris([publisher.RepositoryURI(repouri,
-                    proxy=proxy)])
-
-                retries = 2
-                # We need to call get_repostats to establish the initial
-                # stats.
-                self.stats.get_repostats(t_repouris)
-                for i in range(retries):
-                        self.__engine.add_url(uri, filepath=tmp_pth,
-                            repourl=repouri, proxy=proxy)
-                        try:
-                                while self.__engine.pending:
-                                        self.__engine.run()
-                                rf = self.__engine.check_status()
-                                if rf:
-                                        # If there are non-retryable failure
-                                        # cases or more uris available, do not
-                                        # retry this one and add it to bad crl
-                                        # list.
-                                        if any(not f.retryable for f in rf) or \
-                                            more_uris:
-                                                self.__bad_crls.add(uri)
-                                                return crl
-                                        # Last retry failed, also consider it as
-                                        # a bad crl.
-                                        elif i >= retries - 1:
-                                                self.__bad_crls.add(uri)
-                                                return crl
-                                else:
-                                        break
-                        except tx.ExcessiveTransientFailure as e:
-                                # Since there are too many consecutive errors,
-                                # we probably just consider it as a bad crl.
-                                self.__bad_crls.add(uri)
-                                # Reset the engine.
-                                self.__engine.reset()
-                                return crl
-
-                try:
-                        ncrl = self.__format_safe_read_crl(tmp_pth)
-                except apx.BadFileFormat:
-                        portable.remove(tmp_pth)
-                        return crl
-                except EnvironmentError:
-                        # If the tmp_pth was deleted by transport engine or
-                        # anything else about opening files, do the following.
-                        try:
-                                portable.remove(tmp_pth)
-                        except EnvironmentError:
-                                pass
-                        return crl
-
-                try:
-                        portable.rename(tmp_pth, fpath)
-                        # Because the file was made using mkstemp, we need to
-                        # chmod it to match the other files in var/pkg.
-                        os.chmod(fpath, PKG_RO_FILE_MODE)
-                except EnvironmentError:
-                        self.__tmp_crls[uri] = ncrl
-                        try:
-                                portable.remove(tmp_pth)
-                        except EnvironmentError:
-                                pass
-                return ncrl
-
-        def get_versions(self, pub, ccancel=None, alt_repo=None):
-                """Query the publisher's origin servers for versions
-                information.  Return a dictionary of "name":"versions" """
-
-                self._lock.acquire()
-                try:
-                        v = self._get_versions(pub, ccancel=ccancel,
-                            alt_repo=alt_repo)
-                finally:
-                        self._lock.release()
-
-                return v
-
-        def _get_versions(self, pub, ccancel=None, alt_repo=None):
-                """Implementation of get_versions"""
-
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                failures = tx.TransportFailures()
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
-
-                # If version check hasn't been executed, run it prior to this
-                # operation.
-                self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
-
-                for d, retries in self.__gen_repo(pub, retry_count,
-                    origin_only=True, alt_repo=alt_repo):
-
-                        repostats = self.stats[d.get_repouri_key()]
-                        header = Transport.__get_request_header(header,
-                            repostats, retries, d)
-
-                        # If a transport exception occurs,
-                        # save it if it's retryable, otherwise
-                        # raise the error to a higher-level handler.
-                        try:
-                                vers = self.__get_version(d, header,
-                                    ccancel=ccancel)
-                                # Save this information for later use, too.
-                                self.__fill_repo_vers(d, vers)
-                                return vers
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                for f in ex.failures:
-                                        f.url = d.get_url()
-                                        failures.append(f)
-
-                        except tx.InvalidContentException as e:
-                                repostats.record_error(content=True)
-                                e.reason = "Unable to parse repository's " \
-                                    "versions/0 response"
-                                failures.append(e)
-
-                        except tx.TransportException as e:
-                                e.url = d.get_url()
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-                raise failures
-
-        @staticmethod
-        def __get_version(repo, header=None, ccancel=None):
-                """An internal method that returns a versions dictionary
-                given a transport repo object."""
-
-                resp = repo.get_versions(header, ccancel=ccancel)
-                verlines = resp.readlines()
-
-                try:
-                        return dict(
-                            s.split(None, 1)
-                            for s in (l.strip() for l in verlines)
+        if not isinstance(pub, publisher.Publisher):
+            # Get publisher using information from FMRI.
+            try:
+                pub = self.cfg.get_publisher(fmri.publisher)
+            except apx.UnknownPublisher:
+                if must_verify:
+                    assert False, (
+                        "Did not validate manifest; "
+                        "unknown publisher {0} ({1}).".format(
+                            fmri.publisher, fmri
                         )
-                except ValueError as e:
-                        raise tx.InvalidContentException(e)
-
-        def __fill_repo_vers(self, repo, vers=None, ccancel=None):
-                """Download versions information for the transport
-                repository object and store that information inside
-                of it."""
-
-                # Call __get_version to get the version dictionary
-                # from the repo.
-
-                if not vers:
-                        try:
-                                vers = self.__get_version(repo, ccancel=ccancel)
-                        except tx.InvalidContentException:
-                                raise tx.PkgProtoError(repo.get_url(),
-                                    "versions", 0,
-                                    "InvalidContentException while parsing "
-                                    "response")
-
-                for key, val in vers.items():
-                        # Don't turn this line into a list of versions.
-                        if key == "pkg-server":
-                                continue
-
-                        try:
-                                versids = [
-                                    int(v)
-                                    for v in val.split()
-                                ]
-                        except ValueError:
-                                raise tx.PkgProtoError(repo.get_url(),
-                                    "versions", 0,
-                                    "Unable to parse version ids.")
-
-                        # Insert the list back into the dictionary.
-                        versids.sort(reverse=True)
-                        vers[key] = versids
-
-                repo.add_version_data(vers)
-
-        def __gen_repo(self, pub, count, prefer_remote=False, origin_only=False,
-            single_repository=False, operation=None, versions=None,
-            ccancel=None, alt_repo=None):
-                """An internal method that returns the list of Repo objects
-                for a given Publisher.  Callers use this method to generate
-                lists of endpoints for transport operations, and to retry
-                operations to a single endpoint.
-
-                The 'pub' argument is a Publisher object or RepositoryURI
-                object.  This is used to lookup a transport.Repo object.
-
-                The 'count' argument determines how many times the routine
-                will iterate through a list of endpoints.  The number of times
-                we've iterated when calling this method is included in the
-                tuple that is yielded.
-
-                'prefer_remote' is an optional boolean value indicating whether
-                network-based sources are preferred over local sources.  If
-                True, network-based origins will be returned first after the
-                default order criteria has been applied.  This is a very
-                special case operation, and should not be used liberally.
-
-                'origin_only' returns only endpoints that are Origins.
-                This allows the caller to exclude mirrors from the list,
-                for operations that are meta-data only.
-
-                If callers are performing a publication operation and want
-                to ensure that only one Repository is used as an endpoint,
-                'single_repository' should be set to True.
-
-                If callers wish to only obtain repositories that support
-                a particular version of an operation, they should supply
-                the operation's name as a string to the 'operation' argument.
-                The 'versions' argument should contain the desired available
-                versions for the operation.  This must be given as integers
-                in a list.
-
-                If a versioned operation is requested, this routine may have
-                to perform network operations to complete the request.  If
-                cancellation is desired, a cancellation object should be
-                passed in the 'ccancel' argument.
-
-                By default, this routine looks at a Publisher's
-                repository.  If the caller would like to use a
-                different Repository object, it should pass one in
-                'alt_repo.'
-
-                This function returns a tuple containing a Repo object and
-                the number of times we've iterated through the endpoints.  If
-                versions and operation are specified, it returns a tuple of
-                (Repo, iteration, highest supported version).
-                """
-
-                if not self.__engine:
-                        self.__setup()
-
-                # If alt_repo supplied, use that as the Repository.
-                # Otherwise, check that a Publisher was passed, and use
-                # its repository.
-                repo = None
-                if alt_repo:
-                        repo = alt_repo
-                elif isinstance(pub, publisher.Publisher):
-                        repo = pub.repository
-                        if not repo:
-                                raise apx.NoPublisherRepositories(pub)
-
-                if repo and origin_only:
-                        repolist = repo.origins
-                        origins = repo.origins
-                        if single_repository:
-                                assert len(repolist) == 1
-                elif repo:
-                        repolist = repo.mirrors[:]
-                        repolist.extend(repo.origins)
-                        repolist.extend(self.__dynamic_mirrors)
-                        origins = repo.origins
-                else:
-                        # Caller passed RepositoryURI object in as
-                        # pub argument, repolist is the RepoURI
-                        repolist = [pub]
-                        origins = repolist
-
-                repolist = _convert_repouris(repolist)
-                origins = _convert_repouris(origins)
-
-                def remote_first(a, b):
-                        # For now, any URI using the file scheme is considered
-                        # local.  Realistically, it could be an NFS mount, etc.
-                        # However, that's a further refinement that can be done
-                        # later.
-                        aremote = a[0].scheme != "file"
-                        bremote = b[0].scheme != "file"
-                        return misc.cmp(aremote, bremote) * -1
-
-                if versions:
-                        versions = sorted(versions, reverse=True)
-
-                fail = None
-                iteration = 0
-                for i in range(count):
-                        iteration += 1
-                        rslist = self.stats.get_repostats(repolist, origins)
-                        if prefer_remote:
-                                rslist.sort(key=cmp_to_key(remote_first))
-
-                        fail = tx.TransportFailures()
-                        repo_found = False
-                        for rs, ruri in rslist:
-                                if operation and versions:
-                                        repo = self.__repo_cache.new_repo(rs,
-                                            ruri)
-                                        if not repo.has_version_data():
-                                                try:
-                                                        self.__fill_repo_vers(
-                                                            repo,
-                                                            ccancel=ccancel)
-                                                except tx.TransportException as ex:
-                                                        # Encountered a
-                                                        # transport error while
-                                                        # trying to contact this
-                                                        # origin.  Save the
-                                                        # errors on each retry
-                                                        # so that they can be
-                                                        # raised instead of
-                                                        # an unsupported
-                                                        # operation error.
-                                                        if isinstance(ex,
-                                                            tx.TransportFailures):
-                                                                fail.extend(
-                                                                    ex.exceptions)
-                                                        else:
-                                                                fail.append(ex)
-                                                        continue
-
-                                        verid = repo.supports_version(operation,
-                                            versions)
-                                        if verid >= 0:
-                                                repo_found = True
-                                                yield repo, iteration, verid
-                                else:
-                                        repo_found = True
-                                        yield self.__repo_cache.new_repo(rs,
-                                            ruri), iteration
-
-                        if not repo_found and fail:
-                                raise fail
-
-                        if not origins and \
-                            isinstance(pub, publisher.Publisher):
-                                # Special error case; no transport configuration
-                                # available for this publisher.
-                                raise apx.NoPublisherRepositories(pub)
-
-                        if not repo_found and operation and versions:
-                                # If a versioned operation was requested and
-                                # wasn't found, then raise an unsupported
-                                # exception using the newest version allowed.
-                                raise apx.UnsupportedRepositoryOperation(pub,
-                                    "{0}/{1:d}".format(operation, versions[-1]))
-
-        def __chunk_size(self, pub, alt_repo=None, origin_only=False):
-                """Determine the chunk size based upon how many of the known
-                mirrors have been visited.  If not all mirrors have been
-                visited, choose a small size so that if it ends up being
-                a poor choice, the client doesn't transfer too much data."""
-
-                CHUNK_SMALL = 10
-                CHUNK_LARGE = 100
-                CHUNK_HUGE = 1024
-
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
-
-                if alt_repo:
-                        repolist = alt_repo.origins[:]
-                        if not origin_only:
-                                repolist.extend(alt_repo.mirrors)
-                elif isinstance(pub, publisher.Publisher):
-                        repo = pub.repository
-                        if not repo:
-                                raise apx.NoPublisherRepositories(pub)
-                        repolist = repo.origins[:]
-                        if not origin_only:
-                                repolist.extend(repo.mirrors)
-                else:
-                        # If caller passed RepositoryURI object in as
-                        # pub argument, repolist is the RepoURI.
-                        repolist = [pub]
-
-                repolist = _convert_repouris(repolist)
-                n = len(repolist)
-                m = self.stats.get_num_visited(repolist)
-                if n == 1:
-                        return CHUNK_HUGE
-                if m < n:
-                        return CHUNK_SMALL
-                return CHUNK_LARGE
-
-        @LockedTransport()
-        def valid_publisher_test(self, pub, ccancel=None):
-                """Test that the publisher supplied in pub actually
-                points to a valid packaging server."""
-
-                try:
-                        vd = self._get_versions(pub, ccancel=ccancel)
-                except tx.TransportException as e:
-                        # Failure when contacting server.  Report
-                        # this as an error.  Attempt to report
-                        # the specific origin that failed, and
-                        # if not available, fallback to the
-                        # first one for the publisher.
-                        url = getattr(e, "url", pub["origin"])
-                        raise apx.InvalidDepotResponseException(url,
-                            "Transport errors encountered when trying to "
-                            "contact repository.\nReported the following "
-                            "errors:\n{0}".format(e))
-
-                if not self._valid_versions_test(vd):
-                        url = pub["origin"]
-                        raise apx.InvalidDepotResponseException(url,
-                            "Invalid or unparseable version information.")
-
-                return True
-
-        def _version_check_all(self, alt_repo=None, ccancel=None):
-                # Retrieve version info for all publishers to fill version info
-                # and test if repositories are responding.
-
-                if self.__version_check_executed:
-                        return
-
-                self.__version_check_executed = True
-
-                pubs = [pub for pub in self.cfg.gen_publishers()]
-                if not pubs and alt_repo:
-                        # Special case -- no configured publishers exist, but
-                        # an alternate package source was specified, so create
-                        # a temporary publisher using alternate repository.
-                        pubs = [publisher.Publisher("temporary",
-                            repository=alt_repo)]
-
-                fail = tx.TransportFailures()
-                for pub in pubs:
-                        if pub.prefix in self.repo_status:
-                                # This publisher has already been tested, ignore
-                                continue
-                        for origin in pub.repository.origins:
-                                p = copy.copy(pub)
-                                p.repository.origins = [origin]
-                                try:
-                                        self._version_check(p, ccancel=ccancel)
-                                except apx.InvalidDepotResponseException as e:
-                                        # If there is a network connection issue
-                                        # with this repo ignore here. It will
-                                        # get recorded in self.repo_status. 
-                                        pass
-
-        def version_check(self, pub, ccancel=None):
-                """Retrieve version info from publisher and fill internal
-                version caches. If we encounter problems contacting the repo,
-                store that information for later."""
-                self._lock.acquire()
-                try:
-                        self._version_check(pub, ccancel=ccancel)
-                finally:
-                        self._lock.release()
-
-        def _version_check(self, pub, ccancel=None):
-                """Implementation of version check."""
-
-                fail = tx.TransportFailures()
-                vd = None
-
-                if "total" in self.repo_status.setdefault(pub.prefix, {}):
-                        self.repo_status[pub.prefix]["total"] += 1
-                else:
-                        self.repo_status[pub.prefix]["total"] = 1
-
-                try:
-                        vd = self._get_versions(pub, ccancel=ccancel)
-                except tx.TransportException as ex:
-                        if isinstance(ex, tx.TransportFailures):
-                                fail.extend(ex.exceptions)
-                        else:
-                                fail.append(ex)
-                except apx.CanceledException:
-                        raise
-
-                if not vd or not self._valid_versions_test(vd):
-                        exc = apx.InvalidDepotResponseException(
-                            pub.repository.origins[0].uri, fail)
-                        # Publisher names can't start with _ so this is safe.
-                        self.repo_status["_failures"] = None
-                        self.repo_status[pub.prefix].setdefault(
-                            "errors", set([])).add(exc)
-                        raise exc
-
-        @staticmethod
-        def _valid_versions_test(versdict):
-                """Check that the versions information contained in
-                versdict contains valid version specifications.
-
-                In order to test for this condition, pick a publisher
-                from the list of active publishers.  Check to see if
-                we can connect to it.  If so, test to see if it supports
-                the versions/0 operation.  If versions/0 is not found,
-                we get an unparseable response, or the response does
-                not contain pkg-server, or versions 0 then we're not
-                talking to a depot.  Return an error in these cases."""
-
-                if "pkg-server" in versdict:
-                        # success!
-                        return True
-                elif "versions" in versdict:
-                        try:
-                                versids = [
-                                    int(v)
-                                    for v in versdict["versions"]
-                                ]
-                        except ValueError:
-                                # Unable to determine version number.  Fail.
-                                return False
-
-                        if 0 not in versids:
-                                # Paranoia.  Version 0 should be in the
-                                # output for versions/0.  If we're here,
-                                # something has gone very wrong.  EPIC FAIL!
-                                return False
-
-                        # Found versions/0, success!
-                        return True
-
-                # Some other error encountered. Fail.
+                    )
                 return False
 
-        def multi_file(self, fmri, progtrack, ccancel, alt_repo=None):
-                """Creates a MultiFile object for this transport.
-                The caller may add actions to the multifile object
-                and wait for the download to complete."""
+        try:
+            sigs = self.cfg.get_pkg_sigs(fmri, pub)
+        except apx.UnknownCatalogEntry:
+            if must_verify:
+                assert False, (
+                    "Did not validate manifest; " "couldn't find sigs."
+                )
+            return False
 
-                if not fmri:
-                        return None
+        if sigs and "sha-1" in sigs:
+            chash = sigs["sha-1"]
+        else:
+            if must_verify:
+                assert False, "Did not validate manifest; no sha-1 sig."
+            return False
 
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
+        if mfstpath:
+            mf = open(mfstpath)
+            mcontent = mf.read()
+            mf.close()
+        elif content is not None:
+            mcontent = content
+        else:
+            raise ValueError(
+                "Caller must supply either mfstpath " "or content arguments."
+            )
 
-                if not alt_repo:
-                        alt_repo = self.cfg.get_pkg_alt_repo(fmri)
+        newhash = manifest.Manifest.hash_create(mcontent)
+
+        if chash != newhash:
+            if mfstpath:
+                sz = os.stat(mfstpath).st_size
+                portable.remove(mfstpath)
+            else:
+                sz = None
+            raise tx.InvalidContentException(
+                mfstpath,
+                "manifest hash failure: fmri: {0} \n"
+                "expected: {1} computed: {2}".format(fmri, chash, newhash),
+                size=sz,
+            )
+        return True
+
+    @staticmethod
+    def __build_header(intent=None, uuid=None, variant=None):
+        """Return a dictionary that contains various
+        header fields, depending upon what arguments
+        were passed to the function.  Supply intent header in intent
+        argument, uuid information in uuid argument."""
+
+        header = {}
+
+        if intent:
+            header["X-IPkg-Intent"] = intent
+
+        if uuid:
+            header["X-IPkg-UUID"] = uuid
+
+        if variant:
+            header["X-IPkg-Variant"] = variant
+
+        if not header:
+            return None
+
+        return header
+
+    def __get_uuid(self, pub):
+        if not self.cfg.get_policy(imageconfig.SEND_UUID):
+            return None
+
+        try:
+            return pub.client_uuid
+        except KeyError:
+            return None
+
+    def __get_variant(self, pub):
+        if not self.cfg.get_policy(imageconfig.SEND_UUID):
+            return None
+
+        try:
+            return (
+                self.cfg.get_variant("opensolaris.zone")
+                + ","
+                + self.cfg.get_variant("opensolaris.imagetype")
+            )
+        except KeyError:
+            return None
+
+    @staticmethod
+    def _makedirs(newdir):
+        """A helper function for _get_files that makes directories,
+        if needed."""
+
+        if not os.path.exists(newdir):
+            try:
+                os.makedirs(newdir)
+            except EnvironmentError as e:
+                if e.errno == errno.EACCES:
+                    raise apx.PermissionsException(e.filename)
+                if e.errno == errno.EROFS:
+                    raise apx.ReadOnlyFileSystemException(e.filename)
+                raise tx.TransportOperationError(
+                    "Unable to " "make directory: {0}".format(e)
+                )
+
+    def _get_files_list(self, mfile, flist):
+        """Download the files given in argument 'flist'.  This
+        allows us to break up download operations into multiple
+        chunks.  Since we re-evaluate our host selection after
+        each chunk, this gives us a better way of reacting to
+        changing conditions in the network."""
+
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        failures = []
+        filelist = flist
+        pub = mfile.get_publisher()
+        progtrack = mfile.get_progtrack()
+        header = None
+
+        if isinstance(pub, publisher.Publisher):
+            header = self.__build_header(
+                uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+            )
+
+        # download_dir is temporary download path.
+        download_dir = self.cfg.incoming_root
+
+        cache = self.cfg.get_caches(pub, readonly=False)
+        if cache:
+            # For now, pick first cache in list, if any are
+            # present.
+            cache = cache[0]
+        else:
+            cache = None
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            operation="file",
+            versions=[0, 1],
+            alt_repo=mfile.get_alt_repo(),
+        ):
+            failedreqs = []
+            repostats = self.stats[d.get_repouri_key()]
+            header = Transport.__get_request_header(
+                header, repostats, retries, d
+            )
+
+            gave_up = False
+
+            # This returns a list of transient errors
+            # that occurred during the transport operation.
+            # An exception handler here isn't necessary
+            # unless we want to supress a permanant failure.
+            try:
+                errlist = d.get_files(
+                    filelist, download_dir, progtrack, v, header, pub=pub
+                )
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, record this for later
+                # and try a different host.
+                gave_up = True
+                errlist = ex.failures
+                success = ex.success
+
+            for e in errlist:
+                req = getattr(e, "request", None)
+                if req:
+                    failedreqs.append(req)
+                    failures.append(e)
+                else:
+                    raise e
+
+            if gave_up:
+                # If the transport gave up due to excessive
+                # consecutive errors, the caller is returned a
+                # list of successful requests, and a list of
+                # failures.  We need to consider the requests
+                # that were not attempted because we gave up
+                # early.  In this situation, they're failed
+                # requests, even though no exception was
+                # returned.  Filter the flist to remove the
+                # successful requests.  Everything else failed.
+                failedreqs = [x for x in filelist if x not in success]
+                filelist = failedreqs
+            elif failedreqs:
+                success = [x for x in filelist if x not in failedreqs]
+                filelist = failedreqs
+            else:
+                success = filelist
+                filelist = None
+
+            for s in success:
+                dl_path = os.path.join(download_dir, s)
 
                 try:
-                        pub = self.cfg.get_publisher(fmri.publisher)
-                except apx.UnknownPublisher:
-                        # Allow publishers that don't exist in configuration
-                        # to be used so that if data exists in the cache for
-                        # them, the operation will still succeed.  This only
-                        # needs to be done here as multi_file_ni is only used
-                        # for publication tools.
-                        pub = publisher.Publisher(fmri.publisher)
+                    self._verify_content(mfile[s][0], dl_path)
+                except tx.InvalidContentException as e:
+                    mfile.subtract_progress(e.size)
+                    e.request = s
+                    repostats.record_error(content=True)
+                    failedreqs.append(s)
+                    failures.append(e)
+                    if not filelist:
+                        filelist = failedreqs
+                    continue
 
-                mfile = MultiFile(pub, self, progtrack, ccancel,
-                    alt_repo=alt_repo, pfmri=fmri)
+                if cache:
+                    cpath = cache.insert(s, dl_path)
+                    mfile.file_done(s, cpath)
+                else:
+                    mfile.file_done(s, dl_path)
 
-                return mfile
+            # Return if everything was successful
+            if not filelist and not errlist:
+                return
 
-        def multi_file_ni(self, publisher, final_dir, decompress=False,
-            progtrack=None, ccancel=None, alt_repo=None):
-                """Creates a MultiFileNI object for this transport.
-                The caller may add actions to the multifile object
-                and wait for the download to complete.
+        if failedreqs and failures:
+            failures = [x for x in failures if x.request in failedreqs]
+            tfailurex = tx.TransportFailures(pfmri=mfile.pfmri)
+            for f in failures:
+                tfailurex.append(f)
+            raise tfailurex
 
-                This is used by callers who want to download files,
-                but not install them through actions."""
+    @LockedTransport()
+    def _get_files(self, mfile):
+        """Perform an operation that gets multiple files at once.
+        A mfile object contains information about the multiple-file
+        request that will be performed."""
 
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
+        download_dir = self.cfg.incoming_root
+        pub = mfile.get_publisher()
 
-                mfile = MultiFileNI(publisher, self, final_dir,
-                    decompress=decompress, progtrack=progtrack, ccancel=ccancel,
-                    alt_repo=alt_repo)
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
 
-                return mfile
+        # If version check hasn't been executed, run it prior to this
+        # operation.
+        self._version_check_all(
+            ccancel=mfile.get_ccancel(), alt_repo=mfile.get_alt_repo()
+        )
 
-        def _action_cached(self, action, pub, in_hash=None, verify=None):
-                """If a file with the name action.hash is cached, and if it has
-                the same content hash as action.chash, then return the path to
-                the file.  If the file can't be found, return None.
+        # Check if the download_dir exists.  If it doesn't create
+        # the directories.
+        self._makedirs(download_dir)
 
-                The in_hash parameter allows an alternative hash to be used to
-                check if this action is cached.  This is used for actions which
-                have more than one effective payload.
+        # Call statvfs to find the blocksize of download_dir's
+        # filesystem.
+        try:
+            destvfs = os.statvfs(download_dir)
+            # set the file buffer size to the blocksize of
+            # our filesystem
+            self.__engine.set_file_bufsz(destvfs.f_bsize)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            else:
+                raise tx.TransportOperationError(
+                    "Unable to stat VFS: {0}".format(e)
+                )
+        except AttributeError as e:
+            # os.statvfs is not available on Windows
+            pass
 
-                The verify parameter specifies whether the payload of the action
-                should be validated if needed.  The content of readonly caches
-                will not be validated now; package operations will validate the
-                content later at the time of installation or update and fail if
-                it is invalid."""
+        while mfile:
+            filelist = []
+            chunksz = self.__chunk_size(pub, alt_repo=mfile.get_alt_repo())
 
-                hash_attr, hash_val, hash_func = \
-                    digest.get_least_preferred_hash(action)
+            for i, v in enumerate(mfile):
+                if i >= chunksz:
+                    break
+                filelist.append(v)
 
-                if in_hash:
-                        hash_val = in_hash
+            self._get_files_list(mfile, filelist)
 
-                for cache in self.cfg.get_caches(pub=pub, readonly=True):
-                        cache_path = cache.lookup(hash_val)
-                        if not cache_path:
-                                continue
-                        if verify is None:
-                                # Assume readonly caches are valid (likely a
-                                # file:// repository).  The content will be
-                                # validated later at the time of install /
-                                # update, so if it isn't valid here, there's
-                                # nothing we can do anyway since it's likely the
-                                # repository we would retrieve it from.  This
-                                # can be a significant performance improvement
-                                # when using NFS repositories.
-                                verify = not cache.readonly
+    def __format_safe_read_crl(self, pth):
+        """CRLs seem to frequently come in DER format, so try reading
+        the CRL using both of the formats before giving up."""
 
+        with open(pth, "rb") as f:
+            raw = f.read()
+
+        try:
+            return x509.load_pem_x509_crl(raw, default_backend())
+        except ValueError:
+            try:
+                return x509.load_der_x509_crl(raw, default_backend())
+            except ValueError:
+                raise apx.BadFileFormat(
+                    _(
+                        "The CRL file " "{0} is not in a recognized " "format."
+                    ).format(pth)
+                )
+
+    @LockedTransport()
+    def get_crl(self, uri, crl_root, more_uris=False):
+        """Given a URI (for now only http URIs are supported), return
+        the CRL object created from the file stored at that uri.
+
+        uri: URI for a CRL.
+
+        crl_root: file-system based crl root directory for storing
+        retrieved the CRL.
+        """
+
+        uri = uri.strip()
+        if uri.startswith("Full Name:"):
+            uri = uri[len("Full Name:") :]
+            uri = uri.strip()
+        if uri.startswith("URI:"):
+            uri = uri[4:]
+        if not uri.startswith("http://") and not uri.startswith("file://"):
+            raise apx.InvalidResourceLocation(uri.strip())
+        crl_host = DebugValues.get_value("crl_host")
+        if crl_host:
+            orig = urlparse(uri)
+            crl = urlparse(crl_host)
+            uri = urlunparse(
+                ParseResult(
+                    scheme=crl.scheme,
+                    netloc=crl.netloc,
+                    path=orig.path,
+                    params=orig.params,
+                    query=orig.params,
+                    fragment=orig.fragment,
+                )
+            )
+        # If we've already read the CRL, use the previously created
+        # object.
+        if uri in self.__tmp_crls:
+            return self.__tmp_crls[uri]
+        fn = quote(uri, "")
+        if not os.path.isdir(crl_root):
+            raise apx.InvalidResourceLocation(
+                _("CRL root: {0}").format(crl_root)
+            )
+
+        fpath = os.path.join(crl_root, fn)
+        crl = None
+        # Check if we already have a CRL for this URI.
+        if os.path.exists(fpath):
+            # If we already have a CRL that we can read, check
+            # whether it's time to retrieve a new one from the
+            # location.
+            try:
+                crl = self.__format_safe_read_crl(fpath)
+            except EnvironmentError:
+                pass
+            else:
+                nu = crl.next_update
+                cur_time = dt.datetime.utcnow()
+
+                if cur_time < nu:
+                    self.__tmp_crls[uri] = crl
+                    return crl
+
+        # If the CRL is already known to be unavailable, don't try
+        # connecting to it again.
+        if uri in self.__bad_crls:
+            return crl
+
+        # If no CRL already exists or it's time to try to get a new one,
+        # try to retrieve it from the server.
+        try:
+            tmp_fd, tmp_pth = tempfile.mkstemp(dir=crl_root)
+        except EnvironmentError as e:
+            if e.errno in (errno.EACCES, errno.EPERM):
+                tmp_fd, tmp_pth = tempfile.mkstemp()
+            else:
+                raise apx._convert_error(e)
+
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        orig = urlparse(uri)
+        # To utilize the transport engine, we need to pretend uri for
+        # a crl is like a repo, because the transport engine has some
+        # specific bookkeeping stats keyed by repouri and proxy.
+        # We did this to utilize it as much as possible.
+        repouri = urlunparse(
+            ParseResult(
+                scheme=orig.scheme,
+                netloc=orig.netloc,
+                path="",
+                params="",
+                query="",
+                fragment="",
+            )
+        )
+        proxy = misc.get_runtime_proxy(None, uri)
+        t_repouris = _convert_repouris(
+            [publisher.RepositoryURI(repouri, proxy=proxy)]
+        )
+
+        retries = 2
+        # We need to call get_repostats to establish the initial
+        # stats.
+        self.stats.get_repostats(t_repouris)
+        for i in range(retries):
+            self.__engine.add_url(
+                uri, filepath=tmp_pth, repourl=repouri, proxy=proxy
+            )
+            try:
+                while self.__engine.pending:
+                    self.__engine.run()
+                rf = self.__engine.check_status()
+                if rf:
+                    # If there are non-retryable failure
+                    # cases or more uris available, do not
+                    # retry this one and add it to bad crl
+                    # list.
+                    if any(not f.retryable for f in rf) or more_uris:
+                        self.__bad_crls.add(uri)
+                        return crl
+                    # Last retry failed, also consider it as
+                    # a bad crl.
+                    elif i >= retries - 1:
+                        self.__bad_crls.add(uri)
+                        return crl
+                else:
+                    break
+            except tx.ExcessiveTransientFailure as e:
+                # Since there are too many consecutive errors,
+                # we probably just consider it as a bad crl.
+                self.__bad_crls.add(uri)
+                # Reset the engine.
+                self.__engine.reset()
+                return crl
+
+        try:
+            ncrl = self.__format_safe_read_crl(tmp_pth)
+        except apx.BadFileFormat:
+            portable.remove(tmp_pth)
+            return crl
+        except EnvironmentError:
+            # If the tmp_pth was deleted by transport engine or
+            # anything else about opening files, do the following.
+            try:
+                portable.remove(tmp_pth)
+            except EnvironmentError:
+                pass
+            return crl
+
+        try:
+            portable.rename(tmp_pth, fpath)
+            # Because the file was made using mkstemp, we need to
+            # chmod it to match the other files in var/pkg.
+            os.chmod(fpath, PKG_RO_FILE_MODE)
+        except EnvironmentError:
+            self.__tmp_crls[uri] = ncrl
+            try:
+                portable.remove(tmp_pth)
+            except EnvironmentError:
+                pass
+        return ncrl
+
+    def get_versions(self, pub, ccancel=None, alt_repo=None):
+        """Query the publisher's origin servers for versions
+        information.  Return a dictionary of "name":"versions" """
+
+        self._lock.acquire()
+        try:
+            v = self._get_versions(pub, ccancel=ccancel, alt_repo=alt_repo)
+        finally:
+            self._lock.release()
+
+        return v
+
+    def _get_versions(self, pub, ccancel=None, alt_repo=None):
+        """Implementation of get_versions"""
+
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        failures = tx.TransportFailures()
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        # If version check hasn't been executed, run it prior to this
+        # operation.
+        self._version_check_all(ccancel=ccancel, alt_repo=alt_repo)
+
+        for d, retries in self.__gen_repo(
+            pub, retry_count, origin_only=True, alt_repo=alt_repo
+        ):
+            repostats = self.stats[d.get_repouri_key()]
+            header = Transport.__get_request_header(
+                header, repostats, retries, d
+            )
+
+            # If a transport exception occurs,
+            # save it if it's retryable, otherwise
+            # raise the error to a higher-level handler.
+            try:
+                vers = self.__get_version(d, header, ccancel=ccancel)
+                # Save this information for later use, too.
+                self.__fill_repo_vers(d, vers)
+                return vers
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                for f in ex.failures:
+                    f.url = d.get_url()
+                    failures.append(f)
+
+            except tx.InvalidContentException as e:
+                repostats.record_error(content=True)
+                e.reason = "Unable to parse repository's " "versions/0 response"
+                failures.append(e)
+
+            except tx.TransportException as e:
+                e.url = d.get_url()
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+        raise failures
+
+    @staticmethod
+    def __get_version(repo, header=None, ccancel=None):
+        """An internal method that returns a versions dictionary
+        given a transport repo object."""
+
+        resp = repo.get_versions(header, ccancel=ccancel)
+        verlines = resp.readlines()
+
+        try:
+            return dict(s.split(None, 1) for s in (l.strip() for l in verlines))
+        except ValueError as e:
+            raise tx.InvalidContentException(e)
+
+    def __fill_repo_vers(self, repo, vers=None, ccancel=None):
+        """Download versions information for the transport
+        repository object and store that information inside
+        of it."""
+
+        # Call __get_version to get the version dictionary
+        # from the repo.
+
+        if not vers:
+            try:
+                vers = self.__get_version(repo, ccancel=ccancel)
+            except tx.InvalidContentException:
+                raise tx.PkgProtoError(
+                    repo.get_url(),
+                    "versions",
+                    0,
+                    "InvalidContentException while parsing " "response",
+                )
+
+        for key, val in vers.items():
+            # Don't turn this line into a list of versions.
+            if key == "pkg-server":
+                continue
+
+            try:
+                versids = [int(v) for v in val.split()]
+            except ValueError:
+                raise tx.PkgProtoError(
+                    repo.get_url(),
+                    "versions",
+                    0,
+                    "Unable to parse version ids.",
+                )
+
+            # Insert the list back into the dictionary.
+            versids.sort(reverse=True)
+            vers[key] = versids
+
+        repo.add_version_data(vers)
+
+    def __gen_repo(
+        self,
+        pub,
+        count,
+        prefer_remote=False,
+        origin_only=False,
+        single_repository=False,
+        operation=None,
+        versions=None,
+        ccancel=None,
+        alt_repo=None,
+    ):
+        """An internal method that returns the list of Repo objects
+        for a given Publisher.  Callers use this method to generate
+        lists of endpoints for transport operations, and to retry
+        operations to a single endpoint.
+
+        The 'pub' argument is a Publisher object or RepositoryURI
+        object.  This is used to lookup a transport.Repo object.
+
+        The 'count' argument determines how many times the routine
+        will iterate through a list of endpoints.  The number of times
+        we've iterated when calling this method is included in the
+        tuple that is yielded.
+
+        'prefer_remote' is an optional boolean value indicating whether
+        network-based sources are preferred over local sources.  If
+        True, network-based origins will be returned first after the
+        default order criteria has been applied.  This is a very
+        special case operation, and should not be used liberally.
+
+        'origin_only' returns only endpoints that are Origins.
+        This allows the caller to exclude mirrors from the list,
+        for operations that are meta-data only.
+
+        If callers are performing a publication operation and want
+        to ensure that only one Repository is used as an endpoint,
+        'single_repository' should be set to True.
+
+        If callers wish to only obtain repositories that support
+        a particular version of an operation, they should supply
+        the operation's name as a string to the 'operation' argument.
+        The 'versions' argument should contain the desired available
+        versions for the operation.  This must be given as integers
+        in a list.
+
+        If a versioned operation is requested, this routine may have
+        to perform network operations to complete the request.  If
+        cancellation is desired, a cancellation object should be
+        passed in the 'ccancel' argument.
+
+        By default, this routine looks at a Publisher's
+        repository.  If the caller would like to use a
+        different Repository object, it should pass one in
+        'alt_repo.'
+
+        This function returns a tuple containing a Repo object and
+        the number of times we've iterated through the endpoints.  If
+        versions and operation are specified, it returns a tuple of
+        (Repo, iteration, highest supported version).
+        """
+
+        if not self.__engine:
+            self.__setup()
+
+        # If alt_repo supplied, use that as the Repository.
+        # Otherwise, check that a Publisher was passed, and use
+        # its repository.
+        repo = None
+        if alt_repo:
+            repo = alt_repo
+        elif isinstance(pub, publisher.Publisher):
+            repo = pub.repository
+            if not repo:
+                raise apx.NoPublisherRepositories(pub)
+
+        if repo and origin_only:
+            repolist = repo.origins
+            origins = repo.origins
+            if single_repository:
+                assert len(repolist) == 1
+        elif repo:
+            repolist = repo.mirrors[:]
+            repolist.extend(repo.origins)
+            repolist.extend(self.__dynamic_mirrors)
+            origins = repo.origins
+        else:
+            # Caller passed RepositoryURI object in as
+            # pub argument, repolist is the RepoURI
+            repolist = [pub]
+            origins = repolist
+
+        repolist = _convert_repouris(repolist)
+        origins = _convert_repouris(origins)
+
+        def remote_first(a, b):
+            # For now, any URI using the file scheme is considered
+            # local.  Realistically, it could be an NFS mount, etc.
+            # However, that's a further refinement that can be done
+            # later.
+            aremote = a[0].scheme != "file"
+            bremote = b[0].scheme != "file"
+            return misc.cmp(aremote, bremote) * -1
+
+        if versions:
+            versions = sorted(versions, reverse=True)
+
+        fail = None
+        iteration = 0
+        for i in range(count):
+            iteration += 1
+            rslist = self.stats.get_repostats(repolist, origins)
+            if prefer_remote:
+                rslist.sort(key=cmp_to_key(remote_first))
+
+            fail = tx.TransportFailures()
+            repo_found = False
+            for rs, ruri in rslist:
+                if operation and versions:
+                    repo = self.__repo_cache.new_repo(rs, ruri)
+                    if not repo.has_version_data():
                         try:
-                                if verify:
-                                        self._verify_content(action, cache_path)
-                                return cache_path
-                        except tx.InvalidContentException:
-                                # If the content in the cache doesn't match the
-                                # hash of the action, verify will have already
-                                # purged the item from the cache.
-                                pass
-                return None
+                            self.__fill_repo_vers(repo, ccancel=ccancel)
+                        except tx.TransportException as ex:
+                            # Encountered a
+                            # transport error while
+                            # trying to contact this
+                            # origin.  Save the
+                            # errors on each retry
+                            # so that they can be
+                            # raised instead of
+                            # an unsupported
+                            # operation error.
+                            if isinstance(ex, tx.TransportFailures):
+                                fail.extend(ex.exceptions)
+                            else:
+                                fail.append(ex)
+                            continue
 
-        @staticmethod
-        def _make_opener(cache_path):
-                if cache_path is None:
-                        return
-                def opener():
-                        f = open(cache_path, "rb")
-                        return f
-                return opener
+                    verid = repo.supports_version(operation, versions)
+                    if verid >= 0:
+                        repo_found = True
+                        yield repo, iteration, verid
+                else:
+                    repo_found = True
+                    yield self.__repo_cache.new_repo(rs, ruri), iteration
 
-        def action_cached(self, fmri, action):
-                """If a file with the name action.hash is cached, and if it has
-                the same content hash as action.chash, then return the path to
-                the file.  If the file can't be found, return None.
+            if not repo_found and fail:
+                raise fail
 
-                'fmri' is a FMRI object for the package that delivers the
-                action.
+            if not origins and isinstance(pub, publisher.Publisher):
+                # Special error case; no transport configuration
+                # available for this publisher.
+                raise apx.NoPublisherRepositories(pub)
 
-                'action' is an action object to retrieve the cache file path
-                for."""
+            if not repo_found and operation and versions:
+                # If a versioned operation was requested and
+                # wasn't found, then raise an unsupported
+                # exception using the newest version allowed.
+                raise apx.UnsupportedRepositoryOperation(
+                    pub, "{0}/{1:d}".format(operation, versions[-1])
+                )
 
+    def __chunk_size(self, pub, alt_repo=None, origin_only=False):
+        """Determine the chunk size based upon how many of the known
+        mirrors have been visited.  If not all mirrors have been
+        visited, choose a small size so that if it ends up being
+        a poor choice, the client doesn't transfer too much data."""
+
+        CHUNK_SMALL = 10
+        CHUNK_LARGE = 100
+        CHUNK_HUGE = 1024
+
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        if alt_repo:
+            repolist = alt_repo.origins[:]
+            if not origin_only:
+                repolist.extend(alt_repo.mirrors)
+        elif isinstance(pub, publisher.Publisher):
+            repo = pub.repository
+            if not repo:
+                raise apx.NoPublisherRepositories(pub)
+            repolist = repo.origins[:]
+            if not origin_only:
+                repolist.extend(repo.mirrors)
+        else:
+            # If caller passed RepositoryURI object in as
+            # pub argument, repolist is the RepoURI.
+            repolist = [pub]
+
+        repolist = _convert_repouris(repolist)
+        n = len(repolist)
+        m = self.stats.get_num_visited(repolist)
+        if n == 1:
+            return CHUNK_HUGE
+        if m < n:
+            return CHUNK_SMALL
+        return CHUNK_LARGE
+
+    @LockedTransport()
+    def valid_publisher_test(self, pub, ccancel=None):
+        """Test that the publisher supplied in pub actually
+        points to a valid packaging server."""
+
+        try:
+            vd = self._get_versions(pub, ccancel=ccancel)
+        except tx.TransportException as e:
+            # Failure when contacting server.  Report
+            # this as an error.  Attempt to report
+            # the specific origin that failed, and
+            # if not available, fallback to the
+            # first one for the publisher.
+            url = getattr(e, "url", pub["origin"])
+            raise apx.InvalidDepotResponseException(
+                url,
+                "Transport errors encountered when trying to "
+                "contact repository.\nReported the following "
+                "errors:\n{0}".format(e),
+            )
+
+        if not self._valid_versions_test(vd):
+            url = pub["origin"]
+            raise apx.InvalidDepotResponseException(
+                url, "Invalid or unparseable version information."
+            )
+
+        return True
+
+    def _version_check_all(self, alt_repo=None, ccancel=None):
+        # Retrieve version info for all publishers to fill version info
+        # and test if repositories are responding.
+
+        if self.__version_check_executed:
+            return
+
+        self.__version_check_executed = True
+
+        pubs = [pub for pub in self.cfg.gen_publishers()]
+        if not pubs and alt_repo:
+            # Special case -- no configured publishers exist, but
+            # an alternate package source was specified, so create
+            # a temporary publisher using alternate repository.
+            pubs = [publisher.Publisher("temporary", repository=alt_repo)]
+
+        fail = tx.TransportFailures()
+        for pub in pubs:
+            if pub.prefix in self.repo_status:
+                # This publisher has already been tested, ignore
+                continue
+            for origin in pub.repository.origins:
+                p = copy.copy(pub)
+                p.repository.origins = [origin]
                 try:
-                        pub = self.cfg.get_publisher(fmri.publisher)
-                except apx.UnknownPublisher:
-                        # Allow publishers that don't exist in configuration
-                        # to be used so that if data exists in the cache for
-                        # them, the operation will still succeed.  This only
-                        # needs to be done here as multi_file_ni is only used
-                        # for publication tools.
-                        pub = publisher.Publisher(fmri.publisher)
-
-                # cache content has already been verified
-                return self._make_opener(self._action_cached(action, pub,
-                    verify=False))
-
-        def _verify_content(self, action, filepath):
-                """If action contains an attribute that has the compressed
-                hash, read the file specified in filepath and verify
-                that the hash values match.  If the values do not match,
-                remove the file and raise an InvalidContentException."""
-
-                chash_attr, chash, chash_func = digest.get_preferred_hash(
-                    action, hash_type=digest.CHASH)
-                if action.name == "signature":
-                        #
-                        # If we're checking a signature action and the filepath
-                        # parameter points to one of the chain certificates, we
-                        # need to verify against the most-preferred
-                        # [pkg.]chain.chash[.<alg>] attribute that corresponds
-                        # to the filepath we're looking at. We determine the
-                        # index of the least-preferred chain hash that matches
-                        # our filename, and use the most-preferred chash to
-                        # verify against.
-                        #
-                        # i.e. if we have attributes:
-                        # chain="a.a b.b c.c"
-                        # chain.chash="aa bb cc" \
-                        #   pkg.chain.chashes.sha512t_256="AA BB CC"
-                        #
-                        # and we're looking at file "b.b" then we must compare
-                        # our computed value against the "BB" chash.
-                        #
-                        name = os.path.basename(filepath)
-                        found = False
-                        assert len(action.get_chain_certs(
-                            least_preferred=True)) == \
-                            len(action.get_chain_certs_chashes())
-                        for n, c in zip(
-                            action.get_chain_certs(least_preferred=True),
-                            action.get_chain_certs_chashes()):
-                                if name == n:
-                                        found = True
-                                        chash = c
-                                        break
-                path = action.attrs.get("path", None)
-                if not chash:
-                        # Compressed hash doesn't exist.  Decompress and
-                        # generate hash of uncompressed content.
-                        ifile = open(filepath, "rb")
-                        ofile = open(os.devnull, "wb")
-
-                        try:
-                                hash_attr, hash_val, hash_func = \
-                                    digest.get_preferred_hash(action,
-                                        hash_type=digest.HASH)
-                                fhash = misc.gunzip_from_stream(ifile, ofile,
-                                    hash_func=hash_func)
-                        except zlib.error as e:
-                                s = os.stat(filepath)
-                                portable.remove(filepath)
-                                raise tx.InvalidContentException(path,
-                                    "zlib.error:{0}".format(
-                                    " ".join([str(a) for a in e.args])),
-                                    size=s.st_size)
-
-                        ifile.close()
-                        ofile.close()
-
-                        if hash_val != fhash:
-                                s = os.stat(filepath)
-                                portable.remove(filepath)
-                                raise tx.InvalidContentException(action.path,
-                                    "hash failure: expected: {0}"
-                                    " computed: {1}".format(hash, fhash),
-                                    size=s.st_size)
-                        return
-
-                newhash = misc.get_data_digest(filepath,
-                    hash_func=chash_func)[0]
-                if chash != newhash:
-                        s = os.stat(filepath)
-                        # Check whether we're using the path as a part of the
-                        # content cache, or whether we're actually looking at a
-                        # file:// repository. It's safe to remove the corrupted
-                        # file only if it is part of a cache. Otherwise,
-                        # "pkgrepo verify/fix" should be used to check
-                        # repositories.
-                        cache_fms = self.cfg.get_caches(readonly=False)
-                        remove_content = False
-                        for fm in cache_fms:
-                                if filepath.startswith(fm.root):
-                                        remove_content = True
-                        if remove_content:
-                                portable.remove(filepath)
-                        raise tx.InvalidContentException(path,
-                            "chash failure: expected: {0} computed: {1}".format(
-                            chash, newhash), size=s.st_size)
-
-        @LockedTransport()
-        def publish_add(self, pub, action=None, ccancel=None, progtrack=None,
-            trans_id=None):
-                """Perform the 'add' publication operation to the publisher
-                supplied in pub.  The transaction-id is passed in trans_id."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                if progtrack and ccancel:
-                        progtrack.check_cancelation = ccancel
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True, operation="add",
-                    versions=[0]):
-                        try:
-                                d.publish_add(action, header=header,
-                                    progtrack=progtrack, trans_id=trans_id)
-                                return
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_add_file(self, pub, pth, trans_id=None, basename=None,
-            progtrack=None):
-                """Perform the 'add_file' publication operation to the publisher
-                supplied in pub.  The caller should include the path in the
-                pth argument. The transaction-id is passed in trans_id."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True, operation="file",
-                    versions=[1]):
-                        try:
-                                d.publish_add_file(pth, header=header,
-                                    trans_id=trans_id, basename=basename,
-                                    progtrack=progtrack)
-                                return
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_add_manifest(self, pub, pth, trans_id=None):
-                """Perform the 'add_manifest' publication operation to the publisher
-                supplied in pub.  The caller should include the path in the
-                pth argument. The transaction-id is passed in trans_id."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub))
-
-                # Call setup if the transport isn't configured or was shutdown.
-                if not self.__engine:
-                        self.__setup()
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True,
-                    operation="manifest", versions=[1]):
-                        try:
-                                d.publish_add_manifest(pth, header=header,
-                                    trans_id=trans_id)
-                                return
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_abandon(self, pub, trans_id=None):
-                """Perform an 'abandon' publication operation to the
-                publisher supplied in the pub argument.  The caller should
-                also include the transaction id in trans_id."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True,
-                    operation="abandon", versions=[0]):
-                        try:
-                                state, fmri = d.publish_abandon(header=header,
-                                    trans_id=trans_id)
-                                return state, fmri
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_close(self, pub, trans_id=None, refresh_index=False,
-            add_to_catalog=False):
-                """Perform a 'close' publication operation to the
-                publisher supplied in the pub argument.  The caller should
-                also include the transaction id in trans_id.  If add_to_catalog
-                is true, the pkg will be added to the catalog once
-                the transactions close.  Not all transport methods
-                recognize this parameter."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True, operation="close",
-                    versions=[0]):
-                        try:
-                                state, fmri = d.publish_close(header=header,
-                                    trans_id=trans_id,
-                                    add_to_catalog=add_to_catalog)
-                                return state, fmri
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_open(self, pub, client_release=None, pkg_name=None):
-                """Perform an 'open' transaction to start a publication
-                transaction to the publisher named in pub.  The caller should
-                supply the client's OS release in client_release, and the
-                package's name in pkg_name."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True, operation="open",
-                    versions=[0]):
-                        try:
-                                trans_id = d.publish_open(header=header,
-                                    client_release=client_release,
-                                    pkg_name=pkg_name)
-                                return trans_id
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-                raise failures
-
-        @LockedTransport()
-        def publish_rebuild(self, pub):
-                """Instructs the repositories named by Publisher pub
-                to rebuild package and search data."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True, operation="admin",
-                    versions=[0]):
-                        try:
-                                d.publish_rebuild(header=header, pub=pub)
-                                return
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_append(self, pub, client_release=None, pkg_name=None):
-                """Perform an 'append' transaction to start a publication
-                transaction to the publisher named in pub.  The caller should
-                supply the client's OS release in client_release, and the
-                package's name in pkg_name."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                # Call setup if transport isn't configured, or was shutdown.
-                if not self.__engine:
-                        self.__setup()
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True,
-                    operation="append", versions=[0]):
-                        try:
-                                trans_id = d.publish_append(header=header,
-                                    client_release=client_release,
-                                    pkg_name=pkg_name)
-                                return trans_id
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_rebuild_indexes(self, pub):
-                """Instructs the repositories named by Publisher pub
-                to rebuild their search indexes."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True, operation="admin",
-                    versions=[0]):
-                        try:
-                                d.publish_rebuild_indexes(header=header,
-                                    pub=pub)
-                                return
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_rebuild_packages(self, pub):
-                """Instructs the repositories named by Publisher pub
-                to rebuild package data."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True, operation="admin",
-                    versions=[0]):
-                        try:
-                                d.publish_rebuild_packages(header=header,
-                                    pub=pub)
-                                return
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_refresh(self, pub):
-                """Instructs the repositories named by Publisher pub
-                to refresh package and search data."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True, operation="admin",
-                    versions=[0]):
-                        try:
-                                d.publish_refresh(header=header, pub=pub)
-                                return
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_refresh_indexes(self, pub):
-                """Instructs the repositories named by Publisher pub
-                to refresh their search indexes."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                # In this case, the operation and versions keywords are
-                # purposefully avoided as the underlying repo function
-                # will automatically determine what operation to use
-                # for the single origin returned by __gen_repo.
-                for d, retries in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True):
-                        try:
-                                d.publish_refresh_indexes(header=header,
-                                    pub=pub)
-                                return
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        @LockedTransport()
-        def publish_refresh_packages(self, pub):
-                """Instructs the repositories named by Publisher pub
-                to refresh package data."""
-
-                failures = tx.TransportFailures()
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-                header = self.__build_header(uuid=self.__get_uuid(pub),
-                    variant=self.__get_variant(pub))
-
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True, operation="admin",
-                    versions=[0]):
-                        try:
-                                d.publish_refresh_packages(header=header,
-                                    pub=pub)
-                                return
-                        except tx.ExcessiveTransientFailure as ex:
-                                # If an endpoint experienced so many failures
-                                # that we just gave up, grab the list of
-                                # failures that it contains
-                                failures.extend(ex.failures)
-                        except tx.TransportException as e:
-                                if e.retryable:
-                                        failures.append(e)
-                                else:
-                                        raise
-
-                raise failures
-
-        def publish_cache_repository(self, pub, repo):
-                """If the caller needs to override the underlying Repository
-                object kept by the transport, it should use this method
-                to replace the cached Repository object."""
-
-                assert(isinstance(pub, publisher.Publisher))
-
-                if not self.__engine:
-                        self.__setup()
-
-                origins = _convert_repouris([pub.repository.origins[0]])
-                rslist = self.stats.get_repostats(origins, origins)
-                rs, ruri = rslist[0]
-
-                self.__repo_cache.update_repo(rs, ruri, repo)
-
-        def publish_cache_contains(self, pub):
-                """Returns true if the publisher's origin is cached
-                in the repo cache."""
-
-                if not self.__engine:
-                        self.__setup()
-
-                # we need to check that all TransportRepoURIs are present
-                turis = _convert_repouris([pub.repository.origins[0]])
-                for turi in turis:
-                        if turi not in self.__repo_cache:
-                                return False
-                return True
-
-        def supports_version(self, pub, op, verlist):
-                """Returns version-id of highest supported version.
-                If the version is not supported, or no data is available,
-                -1 is returned instead."""
-
-                retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
-
-                # Call setup if transport isn't configured, or was shutdown.
-                if not self.__engine:
-                        self.__setup()
-
-                # For backward compatibility, we pass version 0 to __gen_repo
-                # so that unsupported operation exception won't be raised if
-                # higher version is not supported, such as manifest/1.
-                for d, retries, v in self.__gen_repo(pub, retry_count,
-                    origin_only=True, single_repository=True,
-                    operation=op, versions=[0]):
-                        return d.supports_version(op, verlist)
-
-        def get_transfer_info(self, pub):
-                """Return a tuple of (compressed, hashes) where 'compressed'
-                indicates whether files can be transferred compressed and
-                'hashes', the set of hashes of those actions that will have
-                their payload transferred."""
-
-                compressed = self.supports_version(pub, 'manifest', [1]) > -1
-                return compressed, self.__hashes[pub]
-
-        def get_transfer_size(self, pub, actions):
-                """Return estimated transfer size given a list of actions that
-                will have their payload transferred."""
-
-                for d, retries in self.__gen_repo(pub, 1,
-                    origin_only=True, single_repository=True):
-                        scheme, netloc, path, params, query, fragment = \
-                            urlparse(d._url, "http", allow_fragments=0)
-                        break
-
-                local = scheme == "file"
-                sendb = 0
-                uploaded = 0
-                support = self.supports_version(pub, "manifest", [1]) > -1
-                for a in actions:
-                        if not a.has_payload:
-                                continue
-                        if not support:
-                                sendb += int(a.attrs.get("pkg.size", 0))
-                                continue
-                        if a.hash not in self.__hashes[pub]:
-                                if (local or uploaded <
-                                     self.cfg.max_transfer_checks):
-                                        # If the repository is local
-                                        # (filesystem-based) or less than
-                                        # max_transfer_checks, call
-                                        # get_compressed_attrs()...
-                                        has_file, dummy = \
-                                            self.get_compressed_attrs(
-                                            a.hash, pub=pub, hashes=False)
-                                        if has_file:
-                                                continue
-                                # If server doesn't have file, assume it will be
-                                # uploaded.
-                                sendb += int(a.attrs.get("pkg.csize", 0))
-                                self.__hashes[pub].add(a.hash)
-                                uploaded += 1
-                return sendb
+                    self._version_check(p, ccancel=ccancel)
+                except apx.InvalidDepotResponseException as e:
+                    # If there is a network connection issue
+                    # with this repo ignore here. It will
+                    # get recorded in self.repo_status.
+                    pass
+
+    def version_check(self, pub, ccancel=None):
+        """Retrieve version info from publisher and fill internal
+        version caches. If we encounter problems contacting the repo,
+        store that information for later."""
+        self._lock.acquire()
+        try:
+            self._version_check(pub, ccancel=ccancel)
+        finally:
+            self._lock.release()
+
+    def _version_check(self, pub, ccancel=None):
+        """Implementation of version check."""
+
+        fail = tx.TransportFailures()
+        vd = None
+
+        if "total" in self.repo_status.setdefault(pub.prefix, {}):
+            self.repo_status[pub.prefix]["total"] += 1
+        else:
+            self.repo_status[pub.prefix]["total"] = 1
+
+        try:
+            vd = self._get_versions(pub, ccancel=ccancel)
+        except tx.TransportException as ex:
+            if isinstance(ex, tx.TransportFailures):
+                fail.extend(ex.exceptions)
+            else:
+                fail.append(ex)
+        except apx.CanceledException:
+            raise
+
+        if not vd or not self._valid_versions_test(vd):
+            exc = apx.InvalidDepotResponseException(
+                pub.repository.origins[0].uri, fail
+            )
+            # Publisher names can't start with _ so this is safe.
+            self.repo_status["_failures"] = None
+            self.repo_status[pub.prefix].setdefault("errors", set([])).add(exc)
+            raise exc
+
+    @staticmethod
+    def _valid_versions_test(versdict):
+        """Check that the versions information contained in
+        versdict contains valid version specifications.
+
+        In order to test for this condition, pick a publisher
+        from the list of active publishers.  Check to see if
+        we can connect to it.  If so, test to see if it supports
+        the versions/0 operation.  If versions/0 is not found,
+        we get an unparseable response, or the response does
+        not contain pkg-server, or versions 0 then we're not
+        talking to a depot.  Return an error in these cases."""
+
+        if "pkg-server" in versdict:
+            # success!
+            return True
+        elif "versions" in versdict:
+            try:
+                versids = [int(v) for v in versdict["versions"]]
+            except ValueError:
+                # Unable to determine version number.  Fail.
+                return False
+
+            if 0 not in versids:
+                # Paranoia.  Version 0 should be in the
+                # output for versions/0.  If we're here,
+                # something has gone very wrong.  EPIC FAIL!
+                return False
+
+            # Found versions/0, success!
+            return True
+
+        # Some other error encountered. Fail.
+        return False
+
+    def multi_file(self, fmri, progtrack, ccancel, alt_repo=None):
+        """Creates a MultiFile object for this transport.
+        The caller may add actions to the multifile object
+        and wait for the download to complete."""
+
+        if not fmri:
+            return None
+
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        if not alt_repo:
+            alt_repo = self.cfg.get_pkg_alt_repo(fmri)
+
+        try:
+            pub = self.cfg.get_publisher(fmri.publisher)
+        except apx.UnknownPublisher:
+            # Allow publishers that don't exist in configuration
+            # to be used so that if data exists in the cache for
+            # them, the operation will still succeed.  This only
+            # needs to be done here as multi_file_ni is only used
+            # for publication tools.
+            pub = publisher.Publisher(fmri.publisher)
+
+        mfile = MultiFile(
+            pub, self, progtrack, ccancel, alt_repo=alt_repo, pfmri=fmri
+        )
+
+        return mfile
+
+    def multi_file_ni(
+        self,
+        publisher,
+        final_dir,
+        decompress=False,
+        progtrack=None,
+        ccancel=None,
+        alt_repo=None,
+    ):
+        """Creates a MultiFileNI object for this transport.
+        The caller may add actions to the multifile object
+        and wait for the download to complete.
+
+        This is used by callers who want to download files,
+        but not install them through actions."""
+
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        mfile = MultiFileNI(
+            publisher,
+            self,
+            final_dir,
+            decompress=decompress,
+            progtrack=progtrack,
+            ccancel=ccancel,
+            alt_repo=alt_repo,
+        )
+
+        return mfile
+
+    def _action_cached(self, action, pub, in_hash=None, verify=None):
+        """If a file with the name action.hash is cached, and if it has
+        the same content hash as action.chash, then return the path to
+        the file.  If the file can't be found, return None.
+
+        The in_hash parameter allows an alternative hash to be used to
+        check if this action is cached.  This is used for actions which
+        have more than one effective payload.
+
+        The verify parameter specifies whether the payload of the action
+        should be validated if needed.  The content of readonly caches
+        will not be validated now; package operations will validate the
+        content later at the time of installation or update and fail if
+        it is invalid."""
+
+        hash_attr, hash_val, hash_func = digest.get_least_preferred_hash(action)
+
+        if in_hash:
+            hash_val = in_hash
+
+        for cache in self.cfg.get_caches(pub=pub, readonly=True):
+            cache_path = cache.lookup(hash_val)
+            if not cache_path:
+                continue
+            if verify is None:
+                # Assume readonly caches are valid (likely a
+                # file:// repository).  The content will be
+                # validated later at the time of install /
+                # update, so if it isn't valid here, there's
+                # nothing we can do anyway since it's likely the
+                # repository we would retrieve it from.  This
+                # can be a significant performance improvement
+                # when using NFS repositories.
+                verify = not cache.readonly
+
+            try:
+                if verify:
+                    self._verify_content(action, cache_path)
+                return cache_path
+            except tx.InvalidContentException:
+                # If the content in the cache doesn't match the
+                # hash of the action, verify will have already
+                # purged the item from the cache.
+                pass
+        return None
+
+    @staticmethod
+    def _make_opener(cache_path):
+        if cache_path is None:
+            return
+
+        def opener():
+            f = open(cache_path, "rb")
+            return f
+
+        return opener
+
+    def action_cached(self, fmri, action):
+        """If a file with the name action.hash is cached, and if it has
+        the same content hash as action.chash, then return the path to
+        the file.  If the file can't be found, return None.
+
+        'fmri' is a FMRI object for the package that delivers the
+        action.
+
+        'action' is an action object to retrieve the cache file path
+        for."""
+
+        try:
+            pub = self.cfg.get_publisher(fmri.publisher)
+        except apx.UnknownPublisher:
+            # Allow publishers that don't exist in configuration
+            # to be used so that if data exists in the cache for
+            # them, the operation will still succeed.  This only
+            # needs to be done here as multi_file_ni is only used
+            # for publication tools.
+            pub = publisher.Publisher(fmri.publisher)
+
+        # cache content has already been verified
+        return self._make_opener(self._action_cached(action, pub, verify=False))
+
+    def _verify_content(self, action, filepath):
+        """If action contains an attribute that has the compressed
+        hash, read the file specified in filepath and verify
+        that the hash values match.  If the values do not match,
+        remove the file and raise an InvalidContentException."""
+
+        chash_attr, chash, chash_func = digest.get_preferred_hash(
+            action, hash_type=digest.CHASH
+        )
+        if action.name == "signature":
+            #
+            # If we're checking a signature action and the filepath
+            # parameter points to one of the chain certificates, we
+            # need to verify against the most-preferred
+            # [pkg.]chain.chash[.<alg>] attribute that corresponds
+            # to the filepath we're looking at. We determine the
+            # index of the least-preferred chain hash that matches
+            # our filename, and use the most-preferred chash to
+            # verify against.
+            #
+            # i.e. if we have attributes:
+            # chain="a.a b.b c.c"
+            # chain.chash="aa bb cc" \
+            #   pkg.chain.chashes.sha512t_256="AA BB CC"
+            #
+            # and we're looking at file "b.b" then we must compare
+            # our computed value against the "BB" chash.
+            #
+            name = os.path.basename(filepath)
+            found = False
+            assert len(action.get_chain_certs(least_preferred=True)) == len(
+                action.get_chain_certs_chashes()
+            )
+            for n, c in zip(
+                action.get_chain_certs(least_preferred=True),
+                action.get_chain_certs_chashes(),
+            ):
+                if name == n:
+                    found = True
+                    chash = c
+                    break
+        path = action.attrs.get("path", None)
+        if not chash:
+            # Compressed hash doesn't exist.  Decompress and
+            # generate hash of uncompressed content.
+            ifile = open(filepath, "rb")
+            ofile = open(os.devnull, "wb")
+
+            try:
+                hash_attr, hash_val, hash_func = digest.get_preferred_hash(
+                    action, hash_type=digest.HASH
+                )
+                fhash = misc.gunzip_from_stream(
+                    ifile, ofile, hash_func=hash_func
+                )
+            except zlib.error as e:
+                s = os.stat(filepath)
+                portable.remove(filepath)
+                raise tx.InvalidContentException(
+                    path,
+                    "zlib.error:{0}".format(" ".join([str(a) for a in e.args])),
+                    size=s.st_size,
+                )
+
+            ifile.close()
+            ofile.close()
+
+            if hash_val != fhash:
+                s = os.stat(filepath)
+                portable.remove(filepath)
+                raise tx.InvalidContentException(
+                    action.path,
+                    "hash failure: expected: {0}"
+                    " computed: {1}".format(hash, fhash),
+                    size=s.st_size,
+                )
+            return
+
+        newhash = misc.get_data_digest(filepath, hash_func=chash_func)[0]
+        if chash != newhash:
+            s = os.stat(filepath)
+            # Check whether we're using the path as a part of the
+            # content cache, or whether we're actually looking at a
+            # file:// repository. It's safe to remove the corrupted
+            # file only if it is part of a cache. Otherwise,
+            # "pkgrepo verify/fix" should be used to check
+            # repositories.
+            cache_fms = self.cfg.get_caches(readonly=False)
+            remove_content = False
+            for fm in cache_fms:
+                if filepath.startswith(fm.root):
+                    remove_content = True
+            if remove_content:
+                portable.remove(filepath)
+            raise tx.InvalidContentException(
+                path,
+                "chash failure: expected: {0} computed: {1}".format(
+                    chash, newhash
+                ),
+                size=s.st_size,
+            )
+
+    @LockedTransport()
+    def publish_add(
+        self, pub, action=None, ccancel=None, progtrack=None, trans_id=None
+    ):
+        """Perform the 'add' publication operation to the publisher
+        supplied in pub.  The transaction-id is passed in trans_id."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        if progtrack and ccancel:
+            progtrack.check_cancelation = ccancel
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="add",
+            versions=[0],
+        ):
+            try:
+                d.publish_add(
+                    action,
+                    header=header,
+                    progtrack=progtrack,
+                    trans_id=trans_id,
+                )
+                return
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_add_file(
+        self, pub, pth, trans_id=None, basename=None, progtrack=None
+    ):
+        """Perform the 'add_file' publication operation to the publisher
+        supplied in pub.  The caller should include the path in the
+        pth argument. The transaction-id is passed in trans_id."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="file",
+            versions=[1],
+        ):
+            try:
+                d.publish_add_file(
+                    pth,
+                    header=header,
+                    trans_id=trans_id,
+                    basename=basename,
+                    progtrack=progtrack,
+                )
+                return
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_add_manifest(self, pub, pth, trans_id=None):
+        """Perform the 'add_manifest' publication operation to the publisher
+        supplied in pub.  The caller should include the path in the
+        pth argument. The transaction-id is passed in trans_id."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(uuid=self.__get_uuid(pub))
+
+        # Call setup if the transport isn't configured or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="manifest",
+            versions=[1],
+        ):
+            try:
+                d.publish_add_manifest(pth, header=header, trans_id=trans_id)
+                return
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_abandon(self, pub, trans_id=None):
+        """Perform an 'abandon' publication operation to the
+        publisher supplied in the pub argument.  The caller should
+        also include the transaction id in trans_id."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="abandon",
+            versions=[0],
+        ):
+            try:
+                state, fmri = d.publish_abandon(
+                    header=header, trans_id=trans_id
+                )
+                return state, fmri
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_close(
+        self, pub, trans_id=None, refresh_index=False, add_to_catalog=False
+    ):
+        """Perform a 'close' publication operation to the
+        publisher supplied in the pub argument.  The caller should
+        also include the transaction id in trans_id.  If add_to_catalog
+        is true, the pkg will be added to the catalog once
+        the transactions close.  Not all transport methods
+        recognize this parameter."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="close",
+            versions=[0],
+        ):
+            try:
+                state, fmri = d.publish_close(
+                    header=header,
+                    trans_id=trans_id,
+                    add_to_catalog=add_to_catalog,
+                )
+                return state, fmri
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_open(self, pub, client_release=None, pkg_name=None):
+        """Perform an 'open' transaction to start a publication
+        transaction to the publisher named in pub.  The caller should
+        supply the client's OS release in client_release, and the
+        package's name in pkg_name."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="open",
+            versions=[0],
+        ):
+            try:
+                trans_id = d.publish_open(
+                    header=header,
+                    client_release=client_release,
+                    pkg_name=pkg_name,
+                )
+                return trans_id
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+        raise failures
+
+    @LockedTransport()
+    def publish_rebuild(self, pub):
+        """Instructs the repositories named by Publisher pub
+        to rebuild package and search data."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="admin",
+            versions=[0],
+        ):
+            try:
+                d.publish_rebuild(header=header, pub=pub)
+                return
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_append(self, pub, client_release=None, pkg_name=None):
+        """Perform an 'append' transaction to start a publication
+        transaction to the publisher named in pub.  The caller should
+        supply the client's OS release in client_release, and the
+        package's name in pkg_name."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        # Call setup if transport isn't configured, or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="append",
+            versions=[0],
+        ):
+            try:
+                trans_id = d.publish_append(
+                    header=header,
+                    client_release=client_release,
+                    pkg_name=pkg_name,
+                )
+                return trans_id
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_rebuild_indexes(self, pub):
+        """Instructs the repositories named by Publisher pub
+        to rebuild their search indexes."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="admin",
+            versions=[0],
+        ):
+            try:
+                d.publish_rebuild_indexes(header=header, pub=pub)
+                return
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_rebuild_packages(self, pub):
+        """Instructs the repositories named by Publisher pub
+        to rebuild package data."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="admin",
+            versions=[0],
+        ):
+            try:
+                d.publish_rebuild_packages(header=header, pub=pub)
+                return
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_refresh(self, pub):
+        """Instructs the repositories named by Publisher pub
+        to refresh package and search data."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="admin",
+            versions=[0],
+        ):
+            try:
+                d.publish_refresh(header=header, pub=pub)
+                return
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_refresh_indexes(self, pub):
+        """Instructs the repositories named by Publisher pub
+        to refresh their search indexes."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        # In this case, the operation and versions keywords are
+        # purposefully avoided as the underlying repo function
+        # will automatically determine what operation to use
+        # for the single origin returned by __gen_repo.
+        for d, retries in self.__gen_repo(
+            pub, retry_count, origin_only=True, single_repository=True
+        ):
+            try:
+                d.publish_refresh_indexes(header=header, pub=pub)
+                return
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    @LockedTransport()
+    def publish_refresh_packages(self, pub):
+        """Instructs the repositories named by Publisher pub
+        to refresh package data."""
+
+        failures = tx.TransportFailures()
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+        header = self.__build_header(
+            uuid=self.__get_uuid(pub), variant=self.__get_variant(pub)
+        )
+
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation="admin",
+            versions=[0],
+        ):
+            try:
+                d.publish_refresh_packages(header=header, pub=pub)
+                return
+            except tx.ExcessiveTransientFailure as ex:
+                # If an endpoint experienced so many failures
+                # that we just gave up, grab the list of
+                # failures that it contains
+                failures.extend(ex.failures)
+            except tx.TransportException as e:
+                if e.retryable:
+                    failures.append(e)
+                else:
+                    raise
+
+        raise failures
+
+    def publish_cache_repository(self, pub, repo):
+        """If the caller needs to override the underlying Repository
+        object kept by the transport, it should use this method
+        to replace the cached Repository object."""
+
+        assert isinstance(pub, publisher.Publisher)
+
+        if not self.__engine:
+            self.__setup()
+
+        origins = _convert_repouris([pub.repository.origins[0]])
+        rslist = self.stats.get_repostats(origins, origins)
+        rs, ruri = rslist[0]
+
+        self.__repo_cache.update_repo(rs, ruri, repo)
+
+    def publish_cache_contains(self, pub):
+        """Returns true if the publisher's origin is cached
+        in the repo cache."""
+
+        if not self.__engine:
+            self.__setup()
+
+        # we need to check that all TransportRepoURIs are present
+        turis = _convert_repouris([pub.repository.origins[0]])
+        for turi in turis:
+            if turi not in self.__repo_cache:
+                return False
+        return True
+
+    def supports_version(self, pub, op, verlist):
+        """Returns version-id of highest supported version.
+        If the version is not supported, or no data is available,
+        -1 is returned instead."""
+
+        retry_count = global_settings.PKG_CLIENT_MAX_TIMEOUT
+
+        # Call setup if transport isn't configured, or was shutdown.
+        if not self.__engine:
+            self.__setup()
+
+        # For backward compatibility, we pass version 0 to __gen_repo
+        # so that unsupported operation exception won't be raised if
+        # higher version is not supported, such as manifest/1.
+        for d, retries, v in self.__gen_repo(
+            pub,
+            retry_count,
+            origin_only=True,
+            single_repository=True,
+            operation=op,
+            versions=[0],
+        ):
+            return d.supports_version(op, verlist)
+
+    def get_transfer_info(self, pub):
+        """Return a tuple of (compressed, hashes) where 'compressed'
+        indicates whether files can be transferred compressed and
+        'hashes', the set of hashes of those actions that will have
+        their payload transferred."""
+
+        compressed = self.supports_version(pub, "manifest", [1]) > -1
+        return compressed, self.__hashes[pub]
+
+    def get_transfer_size(self, pub, actions):
+        """Return estimated transfer size given a list of actions that
+        will have their payload transferred."""
+
+        for d, retries in self.__gen_repo(
+            pub, 1, origin_only=True, single_repository=True
+        ):
+            scheme, netloc, path, params, query, fragment = urlparse(
+                d._url, "http", allow_fragments=0
+            )
+            break
+
+        local = scheme == "file"
+        sendb = 0
+        uploaded = 0
+        support = self.supports_version(pub, "manifest", [1]) > -1
+        for a in actions:
+            if not a.has_payload:
+                continue
+            if not support:
+                sendb += int(a.attrs.get("pkg.size", 0))
+                continue
+            if a.hash not in self.__hashes[pub]:
+                if local or uploaded < self.cfg.max_transfer_checks:
+                    # If the repository is local
+                    # (filesystem-based) or less than
+                    # max_transfer_checks, call
+                    # get_compressed_attrs()...
+                    has_file, dummy = self.get_compressed_attrs(
+                        a.hash, pub=pub, hashes=False
+                    )
+                    if has_file:
+                        continue
+                # If server doesn't have file, assume it will be
+                # uploaded.
+                sendb += int(a.attrs.get("pkg.csize", 0))
+                self.__hashes[pub].add(a.hash)
+                uploaded += 1
+        return sendb
 
 
 class MultiXfr(object):
-        """A transport object for performing multiple simultaneous
-        requests.  This object matches publisher to list of requests, and
-        allows the caller to associate a piece of data with the request key."""
+    """A transport object for performing multiple simultaneous
+    requests.  This object matches publisher to list of requests, and
+    allows the caller to associate a piece of data with the request key."""
 
-        def __init__(self, pub, progtrack=None, ccancel=None, alt_repo=None):
-                """Supply the publisher as argument 'pub'."""
+    def __init__(self, pub, progtrack=None, ccancel=None, alt_repo=None):
+        """Supply the publisher as argument 'pub'."""
 
-                self._publisher = pub
-                self._hash = {}
-                self._progtrack = progtrack
-                self._alt_repo = alt_repo
-                # Add the check_cancelation to the progress tracker
-                if progtrack and ccancel:
-                        self._progtrack.check_cancelation = ccancel
+        self._publisher = pub
+        self._hash = {}
+        self._progtrack = progtrack
+        self._alt_repo = alt_repo
+        # Add the check_cancelation to the progress tracker
+        if progtrack and ccancel:
+            self._progtrack.check_cancelation = ccancel
 
-        def __contains__(self, key):
-                return key in self._hash
+    def __contains__(self, key):
+        return key in self._hash
 
-        def __getitem__(self, key):
-                return self._hash[key]
+    def __getitem__(self, key):
+        return self._hash[key]
 
-        def __iter__(self):
-                for k in self._hash:
-                        yield k
+    def __iter__(self):
+        for k in self._hash:
+            yield k
 
-        def __len__(self):
-                return len(self._hash)
+    def __len__(self):
+        return len(self._hash)
 
-        # Defining "boolness" of a class, Python 2 uses the special method
-        # called __nonzero__() while Python 3 uses __bool__(). For Python
-        # 2 and 3 compatibility, define __bool__() only, and let
-        # __nonzero__ = __bool__
-        def __bool__(self):
-                return bool(self._hash)
+    # Defining "boolness" of a class, Python 2 uses the special method
+    # called __nonzero__() while Python 3 uses __bool__(). For Python
+    # 2 and 3 compatibility, define __bool__() only, and let
+    # __nonzero__ = __bool__
+    def __bool__(self):
+        return bool(self._hash)
 
-        __nonzero__ = __bool__
+    __nonzero__ = __bool__
 
-        def add_hash(self, hashval, item):
-                """Add 'item' to list of values that exist for
-                hash value 'hashval'."""
+    def add_hash(self, hashval, item):
+        """Add 'item' to list of values that exist for
+        hash value 'hashval'."""
 
-                self._hash[hashval] = item
+        self._hash[hashval] = item
 
-        def del_hash(self, hashval):
-                """Remove the hashval from the dictionary, if it exists."""
+    def del_hash(self, hashval):
+        """Remove the hashval from the dictionary, if it exists."""
 
-                self._hash.pop(hashval, None)
+        self._hash.pop(hashval, None)
 
-        def get_alt_repo(self):
-                """Return the alternate Repository object, if one has
-                been selected.  Otherwise, return None."""
+    def get_alt_repo(self):
+        """Return the alternate Repository object, if one has
+        been selected.  Otherwise, return None."""
 
-                return self._alt_repo
+        return self._alt_repo
 
-        def get_ccancel(self):
-                """If the progress tracker has an associated ccancel,
-                return it.  Otherwise, return None."""
+    def get_ccancel(self):
+        """If the progress tracker has an associated ccancel,
+        return it.  Otherwise, return None."""
 
-                return getattr(self._progtrack, "check_cancelation", None)
+        return getattr(self._progtrack, "check_cancelation", None)
 
-        def get_progtrack(self):
-                """Return the progress tracker object for this MFile,
-                if it has one."""
+    def get_progtrack(self):
+        """Return the progress tracker object for this MFile,
+        if it has one."""
 
-                return self._progtrack
+        return self._progtrack
 
-        def get_publisher(self):
-                """Return the publisher object that will be used
-                for this MultiFile request."""
+    def get_publisher(self):
+        """Return the publisher object that will be used
+        for this MultiFile request."""
 
-                return self._publisher
+        return self._publisher
 
-        def keys(self):
-                """Return a list of the keys in the hash."""
+    def keys(self):
+        """Return a list of the keys in the hash."""
 
-                return list(self._hash.keys())
+        return list(self._hash.keys())
 
 
 class MultiFile(MultiXfr):
-        """A transport object for performing multi-file requests
-        using pkg actions.  This takes care of matching the publisher
-        with the actions, and performs the download and content
-        verification necessary to assure correct content installation."""
+    """A transport object for performing multi-file requests
+    using pkg actions.  This takes care of matching the publisher
+    with the actions, and performs the download and content
+    verification necessary to assure correct content installation."""
 
-        def __init__(self, pub, xport, progtrack, ccancel, alt_repo=None,
-            pfmri=None):
-                """Supply the destination publisher in the pub argument.
-                The transport object should be passed in xport."""
+    def __init__(
+        self, pub, xport, progtrack, ccancel, alt_repo=None, pfmri=None
+    ):
+        """Supply the destination publisher in the pub argument.
+        The transport object should be passed in xport."""
 
-                MultiXfr.__init__(self, pub, progtrack=progtrack,
-                    ccancel=ccancel, alt_repo=alt_repo)
+        MultiXfr.__init__(
+            self, pub, progtrack=progtrack, ccancel=ccancel, alt_repo=alt_repo
+        )
 
-                self._transport = xport
-                self.pfmri = pfmri
+        self._transport = xport
+        self.pfmri = pfmri
 
-        def add_action(self, action):
-                """The multiple file retrieval operation is asynchronous.
-                Add files to retrieve with this function.  The caller
-                should pass the action, which causes its file to
-                be added to an internal retrieval list."""
+    def add_action(self, action):
+        """The multiple file retrieval operation is asynchronous.
+        Add files to retrieve with this function.  The caller
+        should pass the action, which causes its file to
+        be added to an internal retrieval list."""
 
-                cpath = self._transport._action_cached(action,
-                    self.get_publisher())
-                if cpath:
-                        if self._progtrack:
-                                filesz = int(misc.get_pkg_otw_size(action))
-                                file_cnt = 1
-                                if action.name == "signature":
-                                        filesz += \
-                                            action.get_action_chain_csize()
-                                        file_cnt += \
-                                            len(action.attrs.get("chain",
-                                            "").split())
-                                self._progtrack.download_add_progress(file_cnt,
-                                    filesz, cachehit=True)
-                        return
-
-                # only retrieve the least preferred hash for this action
-                hash_attr, hash_val, hash_func = \
-                    digest.get_least_preferred_hash(action)
-                self.add_hash(hash_val, action)
+        cpath = self._transport._action_cached(action, self.get_publisher())
+        if cpath:
+            if self._progtrack:
+                filesz = int(misc.get_pkg_otw_size(action))
+                file_cnt = 1
                 if action.name == "signature":
-                        for c in action.get_chain_certs(least_preferred=True):
-                                self.add_hash(c, action)
+                    filesz += action.get_action_chain_csize()
+                    file_cnt += len(action.attrs.get("chain", "").split())
+                self._progtrack.download_add_progress(
+                    file_cnt, filesz, cachehit=True
+                )
+            return
 
-        def add_hash(self, hashval, item):
-                """Add 'item' to list of values that exist for
-                hash value 'hashval'."""
+        # only retrieve the least preferred hash for this action
+        hash_attr, hash_val, hash_func = digest.get_least_preferred_hash(action)
+        self.add_hash(hash_val, action)
+        if action.name == "signature":
+            for c in action.get_chain_certs(least_preferred=True):
+                self.add_hash(c, action)
 
-                self._hash.setdefault(hashval, []).append(item)
+    def add_hash(self, hashval, item):
+        """Add 'item' to list of values that exist for
+        hash value 'hashval'."""
 
-        def file_done(self, hashval, current_path):
-                """Tell MFile that the transfer completed successfully."""
+        self._hash.setdefault(hashval, []).append(item)
 
-                self._update_dlstats(hashval, current_path)
-                self.del_hash(hashval)
+    def file_done(self, hashval, current_path):
+        """Tell MFile that the transfer completed successfully."""
 
-        def _update_dlstats(self, hashval, cache_path):
-                """Find each action associated with the hash value hashval.
-                Update the download statistics for this file."""
+        self._update_dlstats(hashval, current_path)
+        self.del_hash(hashval)
 
-                totalsz = 0
-                nfiles = 0
+    def _update_dlstats(self, hashval, cache_path):
+        """Find each action associated with the hash value hashval.
+        Update the download statistics for this file."""
 
-                filesz = os.stat(cache_path).st_size
-                for action in self._hash[hashval]:
-                        nfiles += 1
-                        bn = os.path.basename(cache_path)
-                        if action.name != "signature" or action.hash == bn:
-                                totalsz += misc.get_pkg_otw_size(action)
-                        else:
-                                totalsz += action.get_chain_csize(bn)
+        totalsz = 0
+        nfiles = 0
 
-                # The progress tracker accounts for the sizes of all actions
-                # even if we only have to perform one download to satisfy
-                # multiple actions with the same hashval.  Since we know
-                # the size of the file we downloaded, but not necessarily
-                # the size of the action responsible for the download,
-                # generate the total size and subtract the size that was
-                # downloaded.  The downloaded size was already accounted for in
-                # the engine's progress tracking.  Adjust the progress tracker
-                # by the difference between what we have and the total we should
-                # have received.
-                nbytes = int(totalsz - filesz)
-                if self._progtrack:
-                        self._progtrack.download_add_progress((nfiles - 1),
-                            nbytes)
+        filesz = os.stat(cache_path).st_size
+        for action in self._hash[hashval]:
+            nfiles += 1
+            bn = os.path.basename(cache_path)
+            if action.name != "signature" or action.hash == bn:
+                totalsz += misc.get_pkg_otw_size(action)
+            else:
+                totalsz += action.get_chain_csize(bn)
 
-        def subtract_progress(self, size):
-                """Subtract the progress accumulated by the download of
-                file with hash of hashval.  make_openers accounts for
-                hashes with multiple actions.  If this has been invoked,
-                it has happened before make_openers, so it's only necessary
-                to adjust the progress for a single file."""
+        # The progress tracker accounts for the sizes of all actions
+        # even if we only have to perform one download to satisfy
+        # multiple actions with the same hashval.  Since we know
+        # the size of the file we downloaded, but not necessarily
+        # the size of the action responsible for the download,
+        # generate the total size and subtract the size that was
+        # downloaded.  The downloaded size was already accounted for in
+        # the engine's progress tracking.  Adjust the progress tracker
+        # by the difference between what we have and the total we should
+        # have received.
+        nbytes = int(totalsz - filesz)
+        if self._progtrack:
+            self._progtrack.download_add_progress((nfiles - 1), nbytes)
 
-                if not self._progtrack:
-                        return
+    def subtract_progress(self, size):
+        """Subtract the progress accumulated by the download of
+        file with hash of hashval.  make_openers accounts for
+        hashes with multiple actions.  If this has been invoked,
+        it has happened before make_openers, so it's only necessary
+        to adjust the progress for a single file."""
 
-                self._progtrack.download_add_progress(-1, int(-size))
+        if not self._progtrack:
+            return
 
-        def wait_files(self):
-                """Wait for outstanding file retrieval operations to
-                complete."""
+        self._progtrack.download_add_progress(-1, int(-size))
 
-                if self._hash:
-                        self._transport._get_files(self)
+    def wait_files(self):
+        """Wait for outstanding file retrieval operations to
+        complete."""
+
+        if self._hash:
+            self._transport._get_files(self)
+
 
 class MultiFileNI(MultiFile):
-        """A transport object for performing multi-file requests
-        using pkg actions.  This takes care of matching the publisher
-        with the actions, and performs the download and content
-        verification necessary to assure correct content installation.
+    """A transport object for performing multi-file requests
+    using pkg actions.  This takes care of matching the publisher
+    with the actions, and performs the download and content
+    verification necessary to assure correct content installation.
 
-        This subclass is used when the actions won't be installed, but
-        are used to identify and verify the content.  Additional parameters
-        define what happens when download finishes successfully."""
+    This subclass is used when the actions won't be installed, but
+    are used to identify and verify the content.  Additional parameters
+    define what happens when download finishes successfully."""
 
-        def __init__(self, pub, xport, final_dir=None, decompress=False,
-            progtrack=None, ccancel=None, alt_repo=None):
-                """Supply the destination publisher in the pub argument.
-                The transport object should be passed in xport.
+    def __init__(
+        self,
+        pub,
+        xport,
+        final_dir=None,
+        decompress=False,
+        progtrack=None,
+        ccancel=None,
+        alt_repo=None,
+    ):
+        """Supply the destination publisher in the pub argument.
+        The transport object should be passed in xport.
 
-                'final_dir' indicates the directory the retrieved files should
-                be moved to after retrieval. If it is set to None, files will
-                not be moved and remain in the cache directory specified
-                in the 'xport' object."""
+        'final_dir' indicates the directory the retrieved files should
+        be moved to after retrieval. If it is set to None, files will
+        not be moved and remain in the cache directory specified
+        in the 'xport' object."""
 
-                MultiFile.__init__(self, pub, xport, progtrack=progtrack,
-                    ccancel=ccancel, alt_repo=alt_repo)
+        MultiFile.__init__(
+            self,
+            pub,
+            xport,
+            progtrack=progtrack,
+            ccancel=ccancel,
+            alt_repo=alt_repo,
+        )
 
-                self._final_dir = final_dir
-                self._decompress = decompress
+        self._final_dir = final_dir
+        self._decompress = decompress
 
-        def add_action(self, action):
-                """The multiple file retrieval operation is asynchronous.
-                Add files to retrieve with this function.  The caller
-                should pass the action, which causes its file to
-                be added to an internal retrieval list."""
+    def add_action(self, action):
+        """The multiple file retrieval operation is asynchronous.
+        Add files to retrieve with this function.  The caller
+        should pass the action, which causes its file to
+        be added to an internal retrieval list."""
 
-                cpath = self._transport._action_cached(action,
-                    self.get_publisher())
-                hash_attr, hash_val, hash_func = \
-                    digest.get_least_preferred_hash(action)
+        cpath = self._transport._action_cached(action, self.get_publisher())
+        hash_attr, hash_val, hash_func = digest.get_least_preferred_hash(action)
 
+        if cpath and self._final_dir:
+            self._final_copy(hash_val, cpath)
+            if self._progtrack:
+                filesz = int(misc.get_pkg_otw_size(action))
+                self._progtrack.download_add_progress(1, filesz, cachehit=True)
+        else:
+            self.add_hash(hash_val, action)
+        if action.name == "signature":
+            for c in action.get_chain_certs(least_preferred=True):
+                cpath = self._transport._action_cached(
+                    action, self.get_publisher(), in_hash=c
+                )
                 if cpath and self._final_dir:
-                        self._final_copy(hash_val, cpath)
-                        if self._progtrack:
-                                filesz = int(misc.get_pkg_otw_size(action))
-                                self._progtrack.download_add_progress(1, filesz,
-                                    cachehit=True)
-                else:
-                        self.add_hash(hash_val, action)
-                if action.name == "signature":
-                        for c in action.get_chain_certs(least_preferred=True):
-                                cpath = self._transport._action_cached(action,
-                                    self.get_publisher(), in_hash=c)
-                                if cpath and self._final_dir:
-                                        self._final_copy(c, cpath)
-                                        if self._progtrack:
-                                                self._progtrack.download_add_progress(
-                                                    1, int(
-                                                    action.get_chain_csize(c)))
-                                        continue
-                                # file_done does some magical accounting for
-                                # files which may have been downloaded multiple
-                                # times but this accounting breaks when the
-                                # chain certificates are involved.  For now,
-                                # adjusting the pkg size and csize for the
-                                # action associated with the certificates solves
-                                # the problem by working around the special
-                                # accounting.  This fixes the problem because it
-                                # tells file_done that no other data was
-                                # expected for this hash of this action.
-                                a = copy.copy(action)
-                                # Copying the attrs separately is needed because
-                                # otherwise the two copies of the actions share
-                                # the dictionary.
-                                a.attrs = copy.copy(action.attrs)
-                                a.attrs["pkg.size"] = str(
-                                    action.get_chain_size(c))
-                                a.attrs["pkg.csize"] = str(
-                                    action.get_chain_csize(c))
-                                self.add_hash(c, a)
+                    self._final_copy(c, cpath)
+                    if self._progtrack:
+                        self._progtrack.download_add_progress(
+                            1, int(action.get_chain_csize(c))
+                        )
+                    continue
+                # file_done does some magical accounting for
+                # files which may have been downloaded multiple
+                # times but this accounting breaks when the
+                # chain certificates are involved.  For now,
+                # adjusting the pkg size and csize for the
+                # action associated with the certificates solves
+                # the problem by working around the special
+                # accounting.  This fixes the problem because it
+                # tells file_done that no other data was
+                # expected for this hash of this action.
+                a = copy.copy(action)
+                # Copying the attrs separately is needed because
+                # otherwise the two copies of the actions share
+                # the dictionary.
+                a.attrs = copy.copy(action.attrs)
+                a.attrs["pkg.size"] = str(action.get_chain_size(c))
+                a.attrs["pkg.csize"] = str(action.get_chain_csize(c))
+                self.add_hash(c, a)
 
-        def file_done(self, hashval, current_path):
-                """Tell MFile that the transfer completed successfully."""
+    def file_done(self, hashval, current_path):
+        """Tell MFile that the transfer completed successfully."""
 
-                totalsz = 0
-                nactions = 0
+        totalsz = 0
+        nactions = 0
 
-                filesz = os.stat(current_path).st_size
-                for action in self._hash[hashval]:
-                        nactions += 1
-                        totalsz += misc.get_pkg_otw_size(action)
+        filesz = os.stat(current_path).st_size
+        for action in self._hash[hashval]:
+            nactions += 1
+            totalsz += misc.get_pkg_otw_size(action)
 
-                # The progress tracker accounts for the sizes of all actions
-                # even if we only have to perform one download to satisfy
-                # multiple actions with the same hashval.  Since we know
-                # the size of the file we downloaded, but not necessarily
-                # the size of the action responsible for the download,
-                # generate the total size and subtract the size that was
-                # downloaded.  The downloaded size was already accounted for in
-                # the engine's progress tracking.  Adjust the progress tracker
-                # by the difference between what we have and the total we should
-                # have received.
-                nbytes = int(totalsz - filesz)
-                if self._progtrack:
-                        self._progtrack.download_add_progress((nactions - 1),
-                            nbytes)
+        # The progress tracker accounts for the sizes of all actions
+        # even if we only have to perform one download to satisfy
+        # multiple actions with the same hashval.  Since we know
+        # the size of the file we downloaded, but not necessarily
+        # the size of the action responsible for the download,
+        # generate the total size and subtract the size that was
+        # downloaded.  The downloaded size was already accounted for in
+        # the engine's progress tracking.  Adjust the progress tracker
+        # by the difference between what we have and the total we should
+        # have received.
+        nbytes = int(totalsz - filesz)
+        if self._progtrack:
+            self._progtrack.download_add_progress((nactions - 1), nbytes)
 
-                if self._final_dir:
-                        self._final_copy(hashval, current_path)
-                self.del_hash(hashval)
+        if self._final_dir:
+            self._final_copy(hashval, current_path)
+        self.del_hash(hashval)
 
-        def _final_copy(self, hashval, current_path):
-                """Copy the file named by hashval from current_path
-                to the final destination, decompressing, if necessary."""
+    def _final_copy(self, hashval, current_path):
+        """Copy the file named by hashval from current_path
+        to the final destination, decompressing, if necessary."""
 
-                dest = os.path.join(self._final_dir, hashval)
-                tmp_prefix = "{0}.".format(hashval)
+        dest = os.path.join(self._final_dir, hashval)
+        tmp_prefix = "{0}.".format(hashval)
 
-                try:
-                        os.makedirs(self._final_dir, mode=misc.PKG_DIR_MODE)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        if e.errno != errno.EEXIST:
-                                raise
+        try:
+            os.makedirs(self._final_dir, mode=misc.PKG_DIR_MODE)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            if e.errno != errno.EEXIST:
+                raise
 
-                try:
-                        fd, fn = tempfile.mkstemp(dir=self._final_dir,
-                            prefix=tmp_prefix)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
+        try:
+            fd, fn = tempfile.mkstemp(dir=self._final_dir, prefix=tmp_prefix)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
 
-                src = open(current_path, "rb")
-                outfile = os.fdopen(fd, "wb")
-                if self._decompress:
-                        misc.gunzip_from_stream(src, outfile, ignore_hash=True)
-                else:
-                        while True:
-                                buf = src.read(64 * 1024)
-                                if buf == b"":
-                                        break
-                                outfile.write(buf)
-                outfile.close()
-                src.close()
+        src = open(current_path, "rb")
+        outfile = os.fdopen(fd, "wb")
+        if self._decompress:
+            misc.gunzip_from_stream(src, outfile, ignore_hash=True)
+        else:
+            while True:
+                buf = src.read(64 * 1024)
+                if buf == b"":
+                    break
+                outfile.write(buf)
+        outfile.close()
+        src.close()
 
-                try:
-                        os.chmod(fn, misc.PKG_FILE_MODE)
-                        portable.rename(fn, dest)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
+        try:
+            os.chmod(fn, misc.PKG_FILE_MODE)
+            portable.rename(fn, dest)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
+
 
 # The following two methods are to be used by clients without an Image that
 # need to configure a transport and or publishers.
 
-def setup_publisher(repo_uri, prefix, xport, xport_cfg,
-    remote_prefix=False, remote_publishers=False, ssl_key=None,
-    ssl_cert=None):
-        """Given transport 'xport' and publisher configuration 'xport_cfg'
-        take the string that identifies a repository by uri in 'repo_uri'
-        and create a publisher object.  The caller must specify the prefix.
 
-        If remote_prefix is True, the caller will contact the remote host
-        and use its publisher info to determine the publisher's actual prefix.
+def setup_publisher(
+    repo_uri,
+    prefix,
+    xport,
+    xport_cfg,
+    remote_prefix=False,
+    remote_publishers=False,
+    ssl_key=None,
+    ssl_cert=None,
+):
+    """Given transport 'xport' and publisher configuration 'xport_cfg'
+    take the string that identifies a repository by uri in 'repo_uri'
+    and create a publisher object.  The caller must specify the prefix.
 
-        If remote_publishers is True, the caller will obtain the prefix and
-        repository information from the repo's publisher info."""
+    If remote_prefix is True, the caller will contact the remote host
+    and use its publisher info to determine the publisher's actual prefix.
 
-        if isinstance(repo_uri, list):
-                repo = publisher.Repository(origins=repo_uri)
-                repouri_list = repo_uri
+    If remote_publishers is True, the caller will obtain the prefix and
+    repository information from the repo's publisher info."""
+
+    if isinstance(repo_uri, list):
+        repo = publisher.Repository(origins=repo_uri)
+        repouri_list = repo_uri
+    else:
+        repouri_list = [publisher.RepositoryURI(repo_uri)]
+        repo = publisher.Repository(origins=repouri_list)
+
+    for origin in repo.origins:
+        if origin.scheme == "https":
+            origin.ssl_key = ssl_key
+            origin.ssl_cert = ssl_cert
+
+    pub = publisher.Publisher(prefix=prefix, repository=repo)
+
+    if not remote_prefix and not remote_publishers:
+        xport_cfg.add_publisher(pub)
+        return pub
+
+    try:
+        newpubs = xport.get_publisherdata(pub)
+    except apx.UnsupportedRepositoryOperation:
+        newpubs = None
+
+    if not newpubs:
+        xport_cfg.add_publisher(pub)
+        return pub
+
+    for p in newpubs:
+        psr = p.repository
+
+        if not psr:
+            p.repository = repo
+        elif remote_publishers:
+            if not psr.origins:
+                for r in repouri_list:
+                    psr.add_origin(r)
+            elif repo not in psr.origins:
+                for i, r in enumerate(repouri_list):
+                    psr.origins.insert(i, r)
         else:
-                repouri_list = [publisher.RepositoryURI(repo_uri)]
-                repo = publisher.Repository(origins=repouri_list)
+            psr.origins = repouri_list
 
-        for origin in repo.origins:
-                if origin.scheme == "https":
-                        origin.ssl_key = ssl_key
-                        origin.ssl_cert = ssl_cert
+        if p.repository:
+            for origin in p.repository.origins:
+                if origin.scheme == pkg.client.publisher.SSL_SCHEMES:
+                    origin.ssl_key = ssl_key
+                    origin.ssl_cert = ssl_cert
 
-        pub = publisher.Publisher(prefix=prefix, repository=repo)
+        xport_cfg.add_publisher(p)
 
-        if not remote_prefix and not remote_publishers:
-                xport_cfg.add_publisher(pub)
-                return pub
+    # Return first publisher in list
+    return newpubs[0]
 
-        try:
-                newpubs = xport.get_publisherdata(pub)
-        except apx.UnsupportedRepositoryOperation:
-                newpubs = None
-
-        if not newpubs:
-                xport_cfg.add_publisher(pub)
-                return pub
-
-        for p in newpubs:
-                psr = p.repository
-
-                if not psr:
-                        p.repository = repo
-                elif remote_publishers:
-                        if not psr.origins:
-                                for r in repouri_list:
-                                        psr.add_origin(r)
-                        elif repo not in psr.origins:
-                                for i, r in enumerate(repouri_list):
-                                        psr.origins.insert(i, r)
-                else:
-                        psr.origins = repouri_list
-
-                if p.repository:
-                        for origin in p.repository.origins:
-                                if origin.scheme == \
-                                    pkg.client.publisher.SSL_SCHEMES:
-                                        origin.ssl_key = ssl_key
-                                        origin.ssl_cert = ssl_cert
-
-                xport_cfg.add_publisher(p)
-
-        # Return first publisher in list
-        return newpubs[0]
 
 def setup_transport():
-        """Initialize the transport and transport configuration. The caller
-        must manipulate the transport configuration and add publishers
-        once it receives control of the objects."""
+    """Initialize the transport and transport configuration. The caller
+    must manipulate the transport configuration and add publishers
+    once it receives control of the objects."""
 
-        xport_cfg = GenericTransportCfg()
-        xport = Transport(xport_cfg)
+    xport_cfg = GenericTransportCfg()
+    xport = Transport(xport_cfg)
 
-        return xport, xport_cfg
+    return xport, xport_cfg
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/config.py
+++ b/src/modules/config.py
@@ -69,1862 +69,1886 @@ import pkg.client.api_errors as api_errors
 
 
 class ConfigError(api_errors.ApiException):
-        """Base exception class for property errors."""
+    """Base exception class for property errors."""
 
 
 class PropertyConfigError(ConfigError):
-        """Base exception class for property errors."""
+    """Base exception class for property errors."""
 
-        def __init__(self, section=None, prop=None):
-                api_errors.ApiException.__init__(self)
-                assert section is not None or prop is not None
-                self.section = section
-                self.prop = prop
+    def __init__(self, section=None, prop=None):
+        api_errors.ApiException.__init__(self)
+        assert section is not None or prop is not None
+        self.section = section
+        self.prop = prop
 
 
 class InvalidPropertyNameError(PropertyConfigError):
-        """Exception class used to indicate an invalid property name."""
+    """Exception class used to indicate an invalid property name."""
 
-        def __init__(self, prop):
-                assert prop is not None
-                PropertyConfigError.__init__(self, prop=prop)
+    def __init__(self, prop):
+        assert prop is not None
+        PropertyConfigError.__init__(self, prop=prop)
 
-        def __str__(self):
-                return _("Property name '{0}' is not valid.  Section names "
-                    "may not contain: tabs, newlines, carriage returns, "
-                    "form feeds, vertical tabs, slashes, backslashes, or "
-                    "non-ASCII characters.").format(self.prop)
+    def __str__(self):
+        return _(
+            "Property name '{0}' is not valid.  Section names "
+            "may not contain: tabs, newlines, carriage returns, "
+            "form feeds, vertical tabs, slashes, backslashes, or "
+            "non-ASCII characters."
+        ).format(self.prop)
 
 
 class InvalidPropertyTemplateNameError(PropertyConfigError):
-        """Exception class used to indicate an invalid property template name.
-        """
+    """Exception class used to indicate an invalid property template name."""
 
-        def __init__(self, prop):
-                assert prop is not None
-                PropertyConfigError.__init__(self, prop=prop)
+    def __init__(self, prop):
+        assert prop is not None
+        PropertyConfigError.__init__(self, prop=prop)
 
-        def __str__(self):
-                return _("Property template name '{0}' is not valid.").format(
-                    self.prop)
+    def __str__(self):
+        return _("Property template name '{0}' is not valid.").format(self.prop)
 
 
 class InvalidPropertyValueError(PropertyConfigError):
-        """Exception class used to indicate an invalid property value."""
+    """Exception class used to indicate an invalid property value."""
 
-        def __init__(self, maximum=None, minimum=None, section=None, prop=None,
-            value=None):
-                PropertyConfigError.__init__(self, section=section, prop=prop)
-                assert not (minimum is not None and maximum is not None)
-                self.maximum = maximum
-                self.minimum = minimum
-                self.value = value
+    def __init__(
+        self, maximum=None, minimum=None, section=None, prop=None, value=None
+    ):
+        PropertyConfigError.__init__(self, section=section, prop=prop)
+        assert not (minimum is not None and maximum is not None)
+        self.maximum = maximum
+        self.minimum = minimum
+        self.value = value
 
-        def __str__(self):
-                if self.minimum is not None:
-                        return _("'{value}' is less than the minimum "
-                            "of '{minimum}' permitted for property "
-                            "'{prop}' in section '{section}'.").format(
-                            **self.__dict__)
-                if self.maximum is not None:
-                        return _("'{value}' is greater than the maximum "
-                            "of '{maximum}' permitted for property "
-                            "'{prop}' in section '{section}'.").format(
-                            **self.__dict__)
-                if self.section:
-                        return _("Invalid value '{value}' for property "
-                            "'{prop}' in section '{section}'.").format(
-                            **self.__dict__)
-                return _("Invalid value '{value}' for {prop}.").format(
-                    **self.__dict__)
+    def __str__(self):
+        if self.minimum is not None:
+            return _(
+                "'{value}' is less than the minimum "
+                "of '{minimum}' permitted for property "
+                "'{prop}' in section '{section}'."
+            ).format(**self.__dict__)
+        if self.maximum is not None:
+            return _(
+                "'{value}' is greater than the maximum "
+                "of '{maximum}' permitted for property "
+                "'{prop}' in section '{section}'."
+            ).format(**self.__dict__)
+        if self.section:
+            return _(
+                "Invalid value '{value}' for property "
+                "'{prop}' in section '{section}'."
+            ).format(**self.__dict__)
+        return _("Invalid value '{value}' for {prop}.").format(**self.__dict__)
 
 
 class PropertyMultiValueError(InvalidPropertyValueError):
-        """Exception class used to indicate the property in question doesn't
-        allow multiple values."""
+    """Exception class used to indicate the property in question doesn't
+    allow multiple values."""
 
-        def __str__(self):
-                if self.section:
-                        return _("Property '{prop}' in section '{section}' "
-                            "doesn't allow multiple values.").format(
-                            **self.__dict__)
-                return _("Property {0} doesn't allow multiple values.").format(
-                    self.prop)
+    def __str__(self):
+        if self.section:
+            return _(
+                "Property '{prop}' in section '{section}' "
+                "doesn't allow multiple values."
+            ).format(**self.__dict__)
+        return _("Property {0} doesn't allow multiple values.").format(
+            self.prop
+        )
 
 
 class UnknownPropertyValueError(PropertyConfigError):
-        """Exception class used to indicate that the value specified
-        could not be found in the property's list of values."""
+    """Exception class used to indicate that the value specified
+    could not be found in the property's list of values."""
 
-        def __init__(self, section=None, prop=None, value=None):
-                PropertyConfigError.__init__(self, section=section, prop=prop)
-                self.value = value
+    def __init__(self, section=None, prop=None, value=None):
+        PropertyConfigError.__init__(self, section=section, prop=prop)
+        self.value = value
 
-        def __str__(self):
-                if self.section:
-                        return _("Value '{value}' not found in the list of "
-                            "values for property '{prop}' in section "
-                            "'{section}'.").format(**self.__dict__)
-                return _("Value '{value}' not found in the list of values "
-                    "for {prop} .").format(**self.__dict__)
+    def __str__(self):
+        if self.section:
+            return _(
+                "Value '{value}' not found in the list of "
+                "values for property '{prop}' in section "
+                "'{section}'."
+            ).format(**self.__dict__)
+        return _(
+            "Value '{value}' not found in the list of values " "for {prop} ."
+        ).format(**self.__dict__)
 
 
 class InvalidSectionNameError(PropertyConfigError):
-        """Exception class used to indicate an invalid section name."""
+    """Exception class used to indicate an invalid section name."""
 
-        def __init__(self, section):
-                assert section is not None
-                PropertyConfigError.__init__(self, section=section)
+    def __init__(self, section):
+        assert section is not None
+        PropertyConfigError.__init__(self, section=section)
 
-        def __str__(self):
-                return _("Section name '{0}' is not valid.  Section names "
-                    "may not contain: tabs, newlines, carriage returns, "
-                    "form feeds, vertical tabs, slashes, backslashes, or "
-                    "non-ASCII characters.").format(self.section)
+    def __str__(self):
+        return _(
+            "Section name '{0}' is not valid.  Section names "
+            "may not contain: tabs, newlines, carriage returns, "
+            "form feeds, vertical tabs, slashes, backslashes, or "
+            "non-ASCII characters."
+        ).format(self.section)
 
 
 class InvalidSectionTemplateNameError(PropertyConfigError):
-        """Exception class used to indicate an invalid section template name."""
+    """Exception class used to indicate an invalid section template name."""
 
-        def __init__(self, section):
-                assert section is not None
-                PropertyConfigError.__init__(self, section=section)
+    def __init__(self, section):
+        assert section is not None
+        PropertyConfigError.__init__(self, section=section)
 
-        def __str__(self):
-                return _("Section template name '{0}' is not valid.").format(
-                    self.section)
+    def __str__(self):
+        return _("Section template name '{0}' is not valid.").format(
+            self.section
+        )
 
 
 class UnknownPropertyError(PropertyConfigError):
-        """Exception class used to indicate an invalid property."""
+    """Exception class used to indicate an invalid property."""
 
-        def __str__(self):
-                if self.section:
-                        return _("Unknown property '{prop}' in section "
-                            "'{section}'.").format(**self.__dict__)
-                return _("Unknown property {0}").format(self.prop)
+    def __str__(self):
+        if self.section:
+            return _(
+                "Unknown property '{prop}' in section " "'{section}'."
+            ).format(**self.__dict__)
+        return _("Unknown property {0}").format(self.prop)
 
 
 class UnknownSectionError(PropertyConfigError):
-        """Exception class used to indicate an invalid section."""
+    """Exception class used to indicate an invalid section."""
 
-        def __str__(self):
-                return _("Unknown property section: {0}.").format(
-                    self.section)
+    def __str__(self):
+        return _("Unknown property section: {0}.").format(self.section)
 
 
 @python_2_unicode_compatible
 class Property(object):
-        """Base class for properties."""
+    """Base class for properties."""
 
-        # Whitespace (except single space), '/', and '\' are never allowed.
-        __name_re = re.compile(r"\A[^\t\n\r\f\v\\/]+\Z")
+    # Whitespace (except single space), '/', and '\' are never allowed.
+    __name_re = re.compile(r"\A[^\t\n\r\f\v\\/]+\Z")
 
-        _value = None
-        _value_map = misc.EmptyDict
+    _value = None
+    _value_map = misc.EmptyDict
 
-        def __init__(self, name, default="", value_map=misc.EmptyDict):
-                if not isinstance(name, six.string_types) or \
-                    not self.__name_re.match(name):
-                        raise InvalidPropertyNameError(prop=name)
+    def __init__(self, name, default="", value_map=misc.EmptyDict):
+        if not isinstance(name, six.string_types) or not self.__name_re.match(
+            name
+        ):
+            raise InvalidPropertyNameError(prop=name)
+        try:
+            name.encode("ascii")
+        except ValueError:
+            # Name contains non-ASCII characters.
+            raise InvalidPropertyNameError(prop=name)
+        self.__name = name
+
+        # Last, set the property's initial value.
+        self.value = default
+        self._value_map = value_map
+
+    def __lt__(self, other):
+        if not isinstance(other, Property):
+            return True
+        return self.name < other.name
+
+    def __gt__(self, other):
+        if not isinstance(other, Property):
+            return False
+        return self.name > other.name
+
+    def __le__(self, other):
+        return self == other or self < other
+
+    def __ge__(self, other):
+        return self == other or self > other
+
+    def __eq__(self, other):
+        if not isinstance(other, Property):
+            return False
+        if self.name != other.name:
+            return False
+        return self.value == other.value
+
+    def __ne__(self, other):
+        if not isinstance(other, Property):
+            return True
+        if self.name != other.name:
+            return True
+        return self.value != other.value
+
+    def __hash__(self):
+        return hash((self.name, self.value))
+
+    def __copy__(self):
+        return self.__class__(
+            self.name, default=self.value, value_map=self._value_map
+        )
+
+    def __str__(self):
+        # Assume that value can be represented in utf-8.
+        return misc.force_text(self.value)
+
+    def _is_allowed(self, value):
+        """Raises an InvalidPropertyValueError if 'value' is not allowed
+        for this property.
+        """
+        if not isinstance(value, six.string_types):
+            # Only string values are allowed.
+            raise InvalidPropertyValueError(prop=self.name, value=value)
+
+    def _transform_string(self, value):
+        # Transform encoded UTF-8 data into unicode objects if needed.
+        if isinstance(value, bytes):
+            # Automatically transform encoded UTF-8 data into
+            # unicode objects if needed.
+            try:
+                value = value.encode("ascii")
+            except ValueError:
                 try:
-                        name.encode("ascii")
+                    value = value.decode("utf-8")
                 except ValueError:
-                        # Name contains non-ASCII characters.
-                        raise InvalidPropertyNameError(prop=name)
-                self.__name = name
+                    # Assume sequence of arbitrary
+                    # 8-bit data.
+                    pass
+        return value
 
-                # Last, set the property's initial value.
-                self.value = default
-                self._value_map = value_map
+    @property
+    def name(self):
+        """The name of the property."""
+        return self.__name
 
-        def __lt__(self, other):
-                if not isinstance(other, Property):
-                        return True
-                return self.name < other.name
+    @property
+    def value(self):
+        """The value of the property."""
+        return self._value
 
-        def __gt__(self, other):
-                if not isinstance(other, Property):
-                        return False
-                return self.name > other.name
-
-        def __le__(self, other):
-                return self == other or self < other
-
-        def __ge__(self, other):
-                return self == other or self > other
-
-        def __eq__(self, other):
-                if not isinstance(other, Property):
-                        return False
-                if self.name != other.name:
-                        return False
-                return self.value == other.value
-
-        def __ne__(self, other):
-                if not isinstance(other, Property):
-                        return True
-                if self.name != other.name:
-                        return True
-                return self.value != other.value
-
-        def __hash__(self):
-                return hash((self.name, self.value))
-
-        def __copy__(self):
-                return self.__class__(self.name, default=self.value,
-                    value_map=self._value_map)
-
-        def __str__(self):
-                # Assume that value can be represented in utf-8.
-                return misc.force_text(self.value)
-
-        def _is_allowed(self, value):
-                """Raises an InvalidPropertyValueError if 'value' is not allowed
-                for this property.
-                """
-                if not isinstance(value, six.string_types):
-                        # Only string values are allowed.
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=value)
-
-        def _transform_string(self, value):
-                # Transform encoded UTF-8 data into unicode objects if needed.
-                if isinstance(value, bytes):
-                        # Automatically transform encoded UTF-8 data into
-                        # unicode objects if needed.
-                        try:
-                                value = value.encode("ascii")
-                        except ValueError:
-                                try:
-                                        value = value.decode("utf-8")
-                                except ValueError:
-                                        # Assume sequence of arbitrary
-                                        # 8-bit data.
-                                        pass
-                return value
-
-        @property
-        def name(self):
-                """The name of the property."""
-                return self.__name
-
-        @property
-        def value(self):
-                """The value of the property."""
-                return self._value
-
-        @value.setter
-        def value(self, value):
-                """Sets the property's value."""
-                if isinstance(value, six.string_types):
-                        value = self._value_map.get(value, value)
-                if value is None:
-                        value = ""
-                elif isinstance(value, (bool, int)):
-                        value = str(value)
-                else:
-                        value = self._transform_string(value)
-                self._is_allowed(value)
-                self._value = value
+    @value.setter
+    def value(self, value):
+        """Sets the property's value."""
+        if isinstance(value, six.string_types):
+            value = self._value_map.get(value, value)
+        if value is None:
+            value = ""
+        elif isinstance(value, (bool, int)):
+            value = str(value)
+        else:
+            value = self._transform_string(value)
+        self._is_allowed(value)
+        self._value = value
 
 
 class PropertyTemplate(object):
-        """A class representing a template for a property.  These templates are
-        used when loading existing configuration data or when adding new
-        properties to an existing configuration object if the property name
-        found matches the pattern name given for the template.
+    """A class representing a template for a property.  These templates are
+    used when loading existing configuration data or when adding new
+    properties to an existing configuration object if the property name
+    found matches the pattern name given for the template.
+    """
+
+    def __init__(
+        self,
+        name_pattern,
+        allowed=None,
+        default=None,
+        prop_type=Property,
+        value_map=None,
+    ):
+        assert prop_type
+        if not isinstance(name_pattern, six.string_types) or not name_pattern:
+            raise InvalidPropertyTemplateNameError(prop=name_pattern)
+        self.__name = name_pattern
+        try:
+            self.__pattern = re.compile(name_pattern)
+        except Exception:
+            # Unfortunately, python doesn't have a public exception
+            # class to catch re parse issues; but this only happens
+            # for misbehaved programs anyway.
+            raise InvalidPropertyTemplateNameError(prop=name_pattern)
+
+        self.__allowed = allowed
+        self.__default = default
+        self.__prop_type = prop_type
+        self.__value_map = value_map
+
+    def __copy__(self):
+        return self.__class__(
+            self.__name,
+            allowed=self.__allowed,
+            default=self.__default,
+            prop_type=self.__prop_type,
+            value_map=self.__value_map,
+        )
+
+    def create(self, name):
+        """Returns a new PropertySection object based on the template
+        using the given name.
         """
+        assert self.match(name)
+        pargs = {}
+        if self.__allowed is not None:
+            pargs["allowed"] = self.__allowed
+        if self.__default is not None:
+            pargs["default"] = self.__default
+        if self.__value_map is not None:
+            pargs["value_map"] = self.__value_map
+        return self.__prop_type(name, **pargs)
 
-        def __init__(self, name_pattern, allowed=None, default=None,
-            prop_type=Property, value_map=None):
-                assert prop_type
-                if not isinstance(name_pattern, six.string_types) or not name_pattern:
-                        raise InvalidPropertyTemplateNameError(
-                            prop=name_pattern)
-                self.__name = name_pattern
-                try:
-                        self.__pattern = re.compile(name_pattern)
-                except Exception:
-                        # Unfortunately, python doesn't have a public exception
-                        # class to catch re parse issues; but this only happens
-                        # for misbehaved programs anyway.
-                        raise InvalidPropertyTemplateNameError(
-                            prop=name_pattern)
+    def match(self, name):
+        """Returns a boolean indicating whether the given name matches
+        the pattern for this template.
+        """
+        return self.__pattern.match(name) is not None
 
-                self.__allowed = allowed
-                self.__default = default
-                self.__prop_type = prop_type
-                self.__value_map = value_map
-
-        def __copy__(self):
-                return self.__class__(self.__name, allowed=self.__allowed,
-                    default=self.__default, prop_type=self.__prop_type,
-                    value_map=self.__value_map)
-
-        def create(self, name):
-                """Returns a new PropertySection object based on the template
-                using the given name.
-                """
-                assert self.match(name)
-                pargs = {}
-                if self.__allowed is not None:
-                        pargs["allowed"] = self.__allowed
-                if self.__default is not None:
-                        pargs["default"] = self.__default
-                if self.__value_map is not None:
-                        pargs["value_map"] = self.__value_map
-                return self.__prop_type(name, **pargs)
-
-        def match(self, name):
-                """Returns a boolean indicating whether the given name matches
-                the pattern for this template.
-                """
-                return self.__pattern.match(name) is not None
-
-        @property
-        def name(self):
-                """The name (pattern string) of the property template."""
-                # Must return a string.
-                return self.__name
+    @property
+    def name(self):
+        """The name (pattern string) of the property template."""
+        # Must return a string.
+        return self.__name
 
 
 class PropBool(Property):
-        """Class representing properties with a boolean value."""
+    """Class representing properties with a boolean value."""
 
-        def __init__(self, name, default=False, value_map=misc.EmptyDict):
-                Property.__init__(self, name, default=default,
-                    value_map=value_map)
+    def __init__(self, name, default=False, value_map=misc.EmptyDict):
+        Property.__init__(self, name, default=default, value_map=value_map)
 
-        @Property.value.setter
-        def value(self, value):
-                if isinstance(value, six.string_types):
-                        value = self._value_map.get(value, value)
-                if value is None or value == "":
-                        self._value = False
-                        return
-                elif isinstance(value, six.string_types):
-                        if value.lower() == "true":
-                                self._value = True
-                                return
-                        elif value.lower() == "false":
-                                self._value = False
-                                return
-                elif isinstance(value, bool):
-                        self._value = value
-                        return
-                raise InvalidPropertyValueError(prop=self.name, value=value)
+    @Property.value.setter
+    def value(self, value):
+        if isinstance(value, six.string_types):
+            value = self._value_map.get(value, value)
+        if value is None or value == "":
+            self._value = False
+            return
+        elif isinstance(value, six.string_types):
+            if value.lower() == "true":
+                self._value = True
+                return
+            elif value.lower() == "false":
+                self._value = False
+                return
+        elif isinstance(value, bool):
+            self._value = value
+            return
+        raise InvalidPropertyValueError(prop=self.name, value=value)
 
 
 class PropInt(Property):
-        """Class representing a property with an integer value."""
+    """Class representing a property with an integer value."""
 
-        def __init__(self, name, default=0, maximum=None,
-            minimum=0, value_map=misc.EmptyDict):
-                assert minimum is None or type(minimum) == int
-                assert maximum is None or type(maximum) == int
-                self.__maximum = maximum
-                self.__minimum = minimum
-                Property.__init__(self, name, default=default,
-                    value_map=value_map)
+    def __init__(
+        self, name, default=0, maximum=None, minimum=0, value_map=misc.EmptyDict
+    ):
+        assert minimum is None or type(minimum) == int
+        assert maximum is None or type(maximum) == int
+        self.__maximum = maximum
+        self.__minimum = minimum
+        Property.__init__(self, name, default=default, value_map=value_map)
 
-        def __copy__(self):
-                prop = Property.__copy__(self)
-                prop.__maximum = self.__maximum
-                prop.__minimum = self.__minimum
-                return prop
+    def __copy__(self):
+        prop = Property.__copy__(self)
+        prop.__maximum = self.__maximum
+        prop.__minimum = self.__minimum
+        return prop
 
-        @property
-        def minimum(self):
-                """Minimum value permitted for this property or None."""
-                return self.__minimum
+    @property
+    def minimum(self):
+        """Minimum value permitted for this property or None."""
+        return self.__minimum
 
-        @property
-        def maximum(self):
-                """Maximum value permitted for this property or None."""
-                return self.__maximum
+    @property
+    def maximum(self):
+        """Maximum value permitted for this property or None."""
+        return self.__maximum
 
-        @Property.value.setter
-        def value(self, value):
-                if isinstance(value, six.string_types):
-                        value = self._value_map.get(value, value)
-                if value is None or value == "":
-                        value = 0
+    @Property.value.setter
+    def value(self, value):
+        if isinstance(value, six.string_types):
+            value = self._value_map.get(value, value)
+        if value is None or value == "":
+            value = 0
 
-                try:
-                        nvalue = int(value)
-                except Exception:
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=value)
+        try:
+            nvalue = int(value)
+        except Exception:
+            raise InvalidPropertyValueError(prop=self.name, value=value)
 
-                if self.minimum is not None and nvalue < self.minimum:
-                        raise InvalidPropertyValueError(prop=self.name,
-                            minimum=self.minimum, value=value)
-                if self.maximum is not None and nvalue > self.maximum:
-                        raise InvalidPropertyValueError(prop=self.name,
-                            maximum=self.maximum, value=value)
-                self._value = nvalue
+        if self.minimum is not None and nvalue < self.minimum:
+            raise InvalidPropertyValueError(
+                prop=self.name, minimum=self.minimum, value=value
+            )
+        if self.maximum is not None and nvalue > self.maximum:
+            raise InvalidPropertyValueError(
+                prop=self.name, maximum=self.maximum, value=value
+            )
+        self._value = nvalue
 
 
 class PropPublisher(Property):
-        """Class representing properties with a publisher prefix/alias value."""
+    """Class representing properties with a publisher prefix/alias value."""
 
-        @Property.value.setter
-        def value(self, value):
-                if isinstance(value, six.string_types):
-                        value = self._value_map.get(value, value)
-                if value is None or value == "":
-                        self._value = ""
-                        return
+    @Property.value.setter
+    def value(self, value):
+        if isinstance(value, six.string_types):
+            value = self._value_map.get(value, value)
+        if value is None or value == "":
+            self._value = ""
+            return
 
-                if not isinstance(value, six.string_types) or \
-                    not misc.valid_pub_prefix(value):
-                        # Only string values are allowed.
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=value)
-                self._value = value
+        if not isinstance(value, six.string_types) or not misc.valid_pub_prefix(
+            value
+        ):
+            # Only string values are allowed.
+            raise InvalidPropertyValueError(prop=self.name, value=value)
+        self._value = value
 
 
 class PropDefined(Property):
-        """Class representing properties with that can only have one of a set
-        of pre-defined values."""
+    """Class representing properties with that can only have one of a set
+    of pre-defined values."""
 
-        def __init__(self, name, allowed=misc.EmptyI, default="",
-            value_map=misc.EmptyDict):
-                self.__allowed = allowed
-                Property.__init__(self, name, default=default,
-                    value_map=value_map)
+    def __init__(
+        self, name, allowed=misc.EmptyI, default="", value_map=misc.EmptyDict
+    ):
+        self.__allowed = allowed
+        Property.__init__(self, name, default=default, value_map=value_map)
 
-        def __copy__(self):
-                prop = Property.__copy__(self)
-                prop.__allowed = copy.copy(self.__allowed)
-                return prop
+    def __copy__(self):
+        prop = Property.__copy__(self)
+        prop.__allowed = copy.copy(self.__allowed)
+        return prop
 
-        def _is_allowed(self, value):
-                """Raises an InvalidPropertyValueError if 'value' is not allowed
-                for this property.
-                """
-
-                # Enforce base class rules.
-                Property._is_allowed(self, value)
-
-                if len(self.__allowed) == 0:
-                        return
-
-                for a in self.__allowed:
-                        if value == a:
-                                break
-                        if a == "<exec:pathname>" and \
-                            value.startswith("exec:") and \
-                            len(value) > 5:
-                                # Don't try to determine if path is valid;
-                                # just that the value starts with 'exec:'.
-                                break
-                        if a == "<smffmri>" and value.startswith("svc:") and \
-                            len(value) > 4:
-                                # Don't try to determine if FMRI is valid;
-                                # just that the value starts with 'svc:'.
-                                break
-                        if a == "<abspathname>" and os.path.isabs(value):
-                                break
-                        if a == "<pathname>" and len(value) > 1:
-                                # Don't try to determine if path is valid;
-                                # just that the length is greater than 1.
-                                break
-                else:
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=value)
-
-        @property
-        def allowed(self):
-                """A list of allowed values for this property."""
-                return self.__allowed
-
-class PropList(PropDefined):
-        """Class representing properties with a list of string values that may
-        contain arbitrary character data.
+    def _is_allowed(self, value):
+        """Raises an InvalidPropertyValueError if 'value' is not allowed
+        for this property.
         """
 
-        def _parse_str(self, value):
-                """Parse the provided python string literal and return the
-                resulting data structure."""
-                try:
-                        value = ast.literal_eval(value)
-                except (SyntaxError, ValueError):
-                        # ast raises ValueError if input isn't safe or
-                        # valid.
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=value)
-                return value
+        # Enforce base class rules.
+        Property._is_allowed(self, value)
 
-        @PropDefined.value.setter
-        def value(self, value):
-                # the value can be arbitrary 8-bit data, so we allow bytes here
-                if isinstance(value, (six.string_types, bytes)):
-                        value = self._value_map.get(value, value)
-                if value is None or value == "":
-                        value = []
-                elif isinstance(value, (six.string_types, bytes)):
-                        value = self._parse_str(value)
-                        if not isinstance(value, list):
-                                # Only accept lists for literal string form.
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
-                else:
-                        try:
-                                iter(value)
-                        except TypeError:
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
+        if len(self.__allowed) == 0:
+            return
 
-                nvalue = []
-                for v in value:
-                        if v is None:
-                                v = ""
-                        elif isinstance(v, (bool, int)):
-                                v = str(v)
-                        elif not isinstance(v, six.string_types):
-                                # Only string values are allowed.
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
-                        self._is_allowed(v)
-                        nvalue.append(v)
+        for a in self.__allowed:
+            if value == a:
+                break
+            if (
+                a == "<exec:pathname>"
+                and value.startswith("exec:")
+                and len(value) > 5
+            ):
+                # Don't try to determine if path is valid;
+                # just that the value starts with 'exec:'.
+                break
+            if a == "<smffmri>" and value.startswith("svc:") and len(value) > 4:
+                # Don't try to determine if FMRI is valid;
+                # just that the value starts with 'svc:'.
+                break
+            if a == "<abspathname>" and os.path.isabs(value):
+                break
+            if a == "<pathname>" and len(value) > 1:
+                # Don't try to determine if path is valid;
+                # just that the length is greater than 1.
+                break
+        else:
+            raise InvalidPropertyValueError(prop=self.name, value=value)
 
-                if self.allowed and "" not in self.allowed and not len(nvalue):
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=nvalue)
+    @property
+    def allowed(self):
+        """A list of allowed values for this property."""
+        return self.__allowed
 
-                self._value = nvalue
+
+class PropList(PropDefined):
+    """Class representing properties with a list of string values that may
+    contain arbitrary character data.
+    """
+
+    def _parse_str(self, value):
+        """Parse the provided python string literal and return the
+        resulting data structure."""
+        try:
+            value = ast.literal_eval(value)
+        except (SyntaxError, ValueError):
+            # ast raises ValueError if input isn't safe or
+            # valid.
+            raise InvalidPropertyValueError(prop=self.name, value=value)
+        return value
+
+    @PropDefined.value.setter
+    def value(self, value):
+        # the value can be arbitrary 8-bit data, so we allow bytes here
+        if isinstance(value, (six.string_types, bytes)):
+            value = self._value_map.get(value, value)
+        if value is None or value == "":
+            value = []
+        elif isinstance(value, (six.string_types, bytes)):
+            value = self._parse_str(value)
+            if not isinstance(value, list):
+                # Only accept lists for literal string form.
+                raise InvalidPropertyValueError(prop=self.name, value=value)
+        else:
+            try:
+                iter(value)
+            except TypeError:
+                raise InvalidPropertyValueError(prop=self.name, value=value)
+
+        nvalue = []
+        for v in value:
+            if v is None:
+                v = ""
+            elif isinstance(v, (bool, int)):
+                v = str(v)
+            elif not isinstance(v, six.string_types):
+                # Only string values are allowed.
+                raise InvalidPropertyValueError(prop=self.name, value=value)
+            self._is_allowed(v)
+            nvalue.append(v)
+
+        if self.allowed and "" not in self.allowed and not len(nvalue):
+            raise InvalidPropertyValueError(prop=self.name, value=nvalue)
+
+        self._value = nvalue
 
 
 class PropDictionaryList(PropList):
-        """Class representing properties with a value specified as a list of
-        dictionaries. Each dictionary must contain string key/value pairs, or
-        a string key, with None as a value.
-        """
+    """Class representing properties with a value specified as a list of
+    dictionaries. Each dictionary must contain string key/value pairs, or
+    a string key, with None as a value.
+    """
 
-        @PropDefined.value.setter
-        def value(self, value):
-                if isinstance(value, six.string_types):
-                        value = self._value_map.get(value, value)
-                if value is None or value == "":
-                        value = []
-                elif isinstance(value, six.string_types):
-                        value = self._parse_str(value)
-                        if not isinstance(value, list):
-                                # Only accept lists for literal string form.
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
-                else:
-                        try:
-                                iter(value)
-                        except TypeError:
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
+    @PropDefined.value.setter
+    def value(self, value):
+        if isinstance(value, six.string_types):
+            value = self._value_map.get(value, value)
+        if value is None or value == "":
+            value = []
+        elif isinstance(value, six.string_types):
+            value = self._parse_str(value)
+            if not isinstance(value, list):
+                # Only accept lists for literal string form.
+                raise InvalidPropertyValueError(prop=self.name, value=value)
+        else:
+            try:
+                iter(value)
+            except TypeError:
+                raise InvalidPropertyValueError(prop=self.name, value=value)
 
-                self._is_allowed(value)
-                nvalue = []
-                for v in value:
-                        if v is None:
-                                v = {}
-                        elif not isinstance(v, dict):
-                                # Only dict values are allowed.
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
-                        for item in v:
-                                # we allow None values, but always store them
-                                # as an empty string to prevent them getting
-                                # serialised as "None"
-                                if not v[item]:
-                                        v[item] = ""
-                        nvalue.append(v)
+        self._is_allowed(value)
+        nvalue = []
+        for v in value:
+            if v is None:
+                v = {}
+            elif not isinstance(v, dict):
+                # Only dict values are allowed.
+                raise InvalidPropertyValueError(prop=self.name, value=value)
+            for item in v:
+                # we allow None values, but always store them
+                # as an empty string to prevent them getting
+                # serialised as "None"
+                if not v[item]:
+                    v[item] = ""
+            nvalue.append(v)
 
-                # if we don't allow an empty list, raise an error
-                if self.allowed and "" not in self.allowed and not len(nvalue):
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=nvalue)
-                self._value = nvalue
+        # if we don't allow an empty list, raise an error
+        if self.allowed and "" not in self.allowed and not len(nvalue):
+            raise InvalidPropertyValueError(prop=self.name, value=nvalue)
+        self._value = nvalue
 
-        def _is_allowed(self, value):
-                if not isinstance(value, list):
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=value)
+    def _is_allowed(self, value):
+        if not isinstance(value, list):
+            raise InvalidPropertyValueError(prop=self.name, value=value)
 
-                # ensure that we only have dictionary values
-                for dic in value:
-                        if not isinstance(dic, dict):
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
+        # ensure that we only have dictionary values
+        for dic in value:
+            if not isinstance(dic, dict):
+                raise InvalidPropertyValueError(prop=self.name, value=value)
 
-                if not self.allowed:
-                        return
+        if not self.allowed:
+            return
 
-                # ensure that each dictionary in the value is allowed
-                for dic in value:
-                        if not isinstance(dic, dict):
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
-                        if dic not in self.allowed:
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
-                        for key, val in dic.items():
-                                Property._is_allowed(self, key)
-                                if not val:
-                                        continue
-                                Property._is_allowed(self, val)
+        # ensure that each dictionary in the value is allowed
+        for dic in value:
+            if not isinstance(dic, dict):
+                raise InvalidPropertyValueError(prop=self.name, value=value)
+            if dic not in self.allowed:
+                raise InvalidPropertyValueError(prop=self.name, value=value)
+            for key, val in dic.items():
+                Property._is_allowed(self, key)
+                if not val:
+                    continue
+                Property._is_allowed(self, val)
+
 
 @python_2_unicode_compatible
 class PropSimpleList(PropList):
-        """Class representing a property with a list of string values that are
-        simple in nature.  Output is in a comma-separated format that may not
-        be suitable for some datasets such as those containing arbitrary data,
-        newlines, commas or that may contain zero-length strings.  This class
-        exists for compatibility with older configuration files that stored
-        lists of data in this format and should not be used for new consumers.
+    """Class representing a property with a list of string values that are
+    simple in nature.  Output is in a comma-separated format that may not
+    be suitable for some datasets such as those containing arbitrary data,
+    newlines, commas or that may contain zero-length strings.  This class
+    exists for compatibility with older configuration files that stored
+    lists of data in this format and should not be used for new consumers.
+    """
+
+    def _is_allowed(self, value):
+        """Raises an InvalidPropertyValueError if 'value' is not allowed
+        for this property.
         """
 
-        def _is_allowed(self, value):
-                """Raises an InvalidPropertyValueError if 'value' is not allowed
-                for this property.
-                """
+        # Enforce base class rules.
+        PropList._is_allowed(self, value)
 
-                # Enforce base class rules.
-                PropList._is_allowed(self, value)
+        if isinstance(value, bytes):
+            try:
+                value.decode("utf-8")
+            except ValueError:
+                # Arbitrary 8-bit data not supported for simple
+                # lists.
+                raise InvalidPropertyValueError(prop=self.name, value=value)
 
-                if isinstance(value, bytes):
-                        try:
-                                value.decode("utf-8")
-                        except ValueError:
-                                # Arbitrary 8-bit data not supported for simple
-                                # lists.
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
-
-        def _parse_str(self, value):
-                """Parse the provided list string and return it as a list."""
-                # Automatically transform encoded UTF-8 data into Unicode
-                # objects if needed.  This results in ASCII data being
-                # stored using str() objects, and UTF-8 data using
-                # unicode() objects. In Python 3, we just want UTF-8 data
-                # using str(unicode) objects.
-                result = []
-                if isinstance(value, bytes):
-                        value = value.split(b",")
+    def _parse_str(self, value):
+        """Parse the provided list string and return it as a list."""
+        # Automatically transform encoded UTF-8 data into Unicode
+        # objects if needed.  This results in ASCII data being
+        # stored using str() objects, and UTF-8 data using
+        # unicode() objects. In Python 3, we just want UTF-8 data
+        # using str(unicode) objects.
+        result = []
+        if isinstance(value, bytes):
+            value = value.split(b",")
+        else:
+            value = value.split(",")
+        for v in value:
+            try:
+                if six.PY2:
+                    v = v.encode("ascii")
                 else:
-                        value = value.split(",")
-                for v in value:
-                        try:
-                                if six.PY2:
-                                        v = v.encode("ascii")
-                                else:
-                                        v= misc.force_str(v)
-                        except ValueError:
-                                if not isinstance(v, six.text_type):
-                                        try:
-                                                v = v.decode("utf-8")
-                                        except ValueError:
-                                                # Arbitrary 8-bit data not
-                                                # supported for simple lists.
-                                                raise InvalidPropertyValueError(
-                                                    prop=self.name,
-                                                    value=value)
-                        result.append(v)
-                return result
+                    v = misc.force_str(v)
+            except ValueError:
+                if not isinstance(v, six.text_type):
+                    try:
+                        v = v.decode("utf-8")
+                    except ValueError:
+                        # Arbitrary 8-bit data not
+                        # supported for simple lists.
+                        raise InvalidPropertyValueError(
+                            prop=self.name, value=value
+                        )
+            result.append(v)
+        return result
 
-        def __str__(self):
-                if self.value and len(self.value):
-                        # Performing the join using a unicode string results in
-                        # a single unicode string object.
-                        return u",".join(self.value)
-                return u""
+    def __str__(self):
+        if self.value and len(self.value):
+            # Performing the join using a unicode string results in
+            # a single unicode string object.
+            return ",".join(self.value)
+        return ""
 
 
 class PropPubURI(Property):
-        """Class representing publisher URI properties."""
+    """Class representing publisher URI properties."""
 
-        def _is_allowed(self, value):
-                """Raises an InvalidPropertyValueError if 'value' is not allowed
-                for this property.
-                """
+    def _is_allowed(self, value):
+        """Raises an InvalidPropertyValueError if 'value' is not allowed
+        for this property.
+        """
 
-                # Enforce base class rules.
-                Property._is_allowed(self, value)
+        # Enforce base class rules.
+        Property._is_allowed(self, value)
 
-                if value == "":
-                        return
+        if value == "":
+            return
 
-                valid = misc.valid_pub_url(value)
-                if not valid:
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=value)
+        valid = misc.valid_pub_url(value)
+        if not valid:
+            raise InvalidPropertyValueError(prop=self.name, value=value)
 
 
 class PropSimplePubURIList(PropSimpleList):
-        """Class representing a property for a list of publisher URIs.  Output
-        is in a basic comma-separated format that may not be suitable for some
-        datasets.  This class exists for compatibility with older configuration
-        files that stored lists of data in this format and should not be used
-        for new consumers.
+    """Class representing a property for a list of publisher URIs.  Output
+    is in a basic comma-separated format that may not be suitable for some
+    datasets.  This class exists for compatibility with older configuration
+    files that stored lists of data in this format and should not be used
+    for new consumers.
+    """
+
+    def _is_allowed(self, value):
+        """Raises an InvalidPropertyValueError if 'value' is not allowed
+        for this property.
         """
 
-        def _is_allowed(self, value):
-                """Raises an InvalidPropertyValueError if 'value' is not allowed
-                for this property.
-                """
+        # Enforce base class rules.
+        PropSimpleList._is_allowed(self, value)
 
-                # Enforce base class rules.
-                PropSimpleList._is_allowed(self, value)
-
-                valid = misc.valid_pub_url(value)
-                if not valid:
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=value)
+        valid = misc.valid_pub_url(value)
+        if not valid:
+            raise InvalidPropertyValueError(prop=self.name, value=value)
 
 
 class PropPubURIList(PropList):
-        """Class representing a property for a list of publisher URIs."""
+    """Class representing a property for a list of publisher URIs."""
 
-        def _is_allowed(self, value):
-                """Raises an InvalidPropertyValueError if 'value' is not allowed
-                for this property.
-                """
+    def _is_allowed(self, value):
+        """Raises an InvalidPropertyValueError if 'value' is not allowed
+        for this property.
+        """
 
-                # Enforce base class rules.
-                PropList._is_allowed(self, value)
+        # Enforce base class rules.
+        PropList._is_allowed(self, value)
 
-                valid = misc.valid_pub_url(value)
-                if not valid:
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=value)
+        valid = misc.valid_pub_url(value)
+        if not valid:
+            raise InvalidPropertyValueError(prop=self.name, value=value)
 
 
 class PropPubURIDictionaryList(PropDictionaryList):
-        """Class representing a list of values associated with a given publisher
-        URI.
+    """Class representing a list of values associated with a given publisher
+    URI.
 
-        A PropPubURIDictionaryList contains a series of dictionaries, where
-        each dictionary must have a "uri" key with a valid URI as a value.
+    A PropPubURIDictionaryList contains a series of dictionaries, where
+    each dictionary must have a "uri" key with a valid URI as a value.
 
-        eg.
+    eg.
 
-        [ {'uri':'http://foo',
-           'proxy': 'http://foo-proxy'},
-          {'uri': 'http://bar',
-           'proxy': http://bar-proxy'}
-         ... ]
+    [ {'uri':'http://foo',
+       'proxy': 'http://foo-proxy'},
+      {'uri': 'http://bar',
+       'proxy': http://bar-proxy'}
+     ... ]
+    """
+
+    def _is_allowed(self, value):
+        """Raises an InvalidPropertyValueError if 'value' is not allowed
+        for this property.
         """
 
-        def _is_allowed(self, value):
-                """Raises an InvalidPropertyValueError if 'value' is not allowed
-                for this property.
-                """
+        # Enforce base class rules.
+        PropDictionaryList._is_allowed(self, value)
 
-                # Enforce base class rules.
-                PropDictionaryList._is_allowed(self, value)
-
-                for dic in value:
-                        if 'uri' not in dic:
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
-                        if not misc.valid_pub_url(dic["uri"]):
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
+        for dic in value:
+            if "uri" not in dic:
+                raise InvalidPropertyValueError(prop=self.name, value=value)
+            if not misc.valid_pub_url(dic["uri"]):
+                raise InvalidPropertyValueError(prop=self.name, value=value)
 
 
 class PropUUID(Property):
-        """Class representing a Universally Unique Identifier property."""
+    """Class representing a Universally Unique Identifier property."""
 
-        def _is_allowed(self, value):
-                if value == "":
-                        return
+    def _is_allowed(self, value):
+        if value == "":
+            return
 
-                try:
-                        uuid.UUID(hex=str(value))
-                except Exception:
-                        # Not a valid UUID.
-                        raise InvalidPropertyValueError(prop=self.name,
-                            value=value)
+        try:
+            uuid.UUID(hex=str(value))
+        except Exception:
+            # Not a valid UUID.
+            raise InvalidPropertyValueError(prop=self.name, value=value)
 
 
 class PropVersion(Property):
-        """Class representing a property with a non-negative integer dotsequence
-        value."""
+    """Class representing a property with a non-negative integer dotsequence
+    value."""
 
-        def __init__(self, name, default="0", value_map=misc.EmptyDict):
-                Property.__init__(self, name, default=default,
-                    value_map=value_map)
+    def __init__(self, name, default="0", value_map=misc.EmptyDict):
+        Property.__init__(self, name, default=default, value_map=value_map)
 
-        def __str__(self):
-                return self.value.get_short_version()
+    def __str__(self):
+        return self.value.get_short_version()
 
-        @Property.value.setter
-        def value(self, value):
-                if isinstance(value, six.string_types):
-                        value = self._value_map.get(value, value)
-                if value is None or value == "":
-                        value = "0"
+    @Property.value.setter
+    def value(self, value):
+        if isinstance(value, six.string_types):
+            value = self._value_map.get(value, value)
+        if value is None or value == "":
+            value = "0"
 
-                if isinstance(value, pkg.version.Version):
-                        nvalue = value
-                else:
-                        try:
-                                nvalue = pkg.version.Version(value)
-                        except Exception:
-                                raise InvalidPropertyValueError(prop=self.name,
-                                    value=value)
+        if isinstance(value, pkg.version.Version):
+            nvalue = value
+        else:
+            try:
+                nvalue = pkg.version.Version(value)
+            except Exception:
+                raise InvalidPropertyValueError(prop=self.name, value=value)
 
-                self._value = nvalue
+        self._value = nvalue
 
 
 @python_2_unicode_compatible
 class PropertySection(object):
-        """A class representing a section of the configuration that also
-        provides an interface for adding and managing properties and sections
-        for the section."""
+    """A class representing a section of the configuration that also
+    provides an interface for adding and managing properties and sections
+    for the section."""
 
-        # Whitespace (except single space), '/', and '\' are never allowed
-        # although consumers can place additional restrictions by providing
-        # a name re. In addition, the name "CONFIGURATION" is reserved for
-        # use by the configuration serialization classes.
-        __name_re = re.compile(r"\A[^\t\n\r\f\v\\/]+\Z")
+    # Whitespace (except single space), '/', and '\' are never allowed
+    # although consumers can place additional restrictions by providing
+    # a name re. In addition, the name "CONFIGURATION" is reserved for
+    # use by the configuration serialization classes.
+    __name_re = re.compile(r"\A[^\t\n\r\f\v\\/]+\Z")
 
-        def __init__(self, name, properties=misc.EmptyI):
-                if not isinstance(name, six.string_types) or \
-                    not self.__name_re.match(name) or \
-                    name == "CONFIGURATION":
-                        raise InvalidSectionNameError(name)
-                try:
-                        name.encode("ascii")
-                except ValueError:
-                        # Name contains non-ASCII characters.
-                        raise InvalidSectionNameError(name)
-                self.__name = name
+    def __init__(self, name, properties=misc.EmptyI):
+        if (
+            not isinstance(name, six.string_types)
+            or not self.__name_re.match(name)
+            or name == "CONFIGURATION"
+        ):
+            raise InvalidSectionNameError(name)
+        try:
+            name.encode("ascii")
+        except ValueError:
+            # Name contains non-ASCII characters.
+            raise InvalidSectionNameError(name)
+        self.__name = name
 
-                # Should be set last.
-                # Dict is in arbitrary order, sort it first to ensure the
-                # order is same in Python 2 and 3.
-                self.__properties = OrderedDict((p.name, p) for p in properties)
+        # Should be set last.
+        # Dict is in arbitrary order, sort it first to ensure the
+        # order is same in Python 2 and 3.
+        self.__properties = OrderedDict((p.name, p) for p in properties)
 
-        def __lt__(self, other):
-                if not isinstance(other, PropertySection):
-                        return True
-                return self.name < other.name
+    def __lt__(self, other):
+        if not isinstance(other, PropertySection):
+            return True
+        return self.name < other.name
 
-        def __gt__(self, other):
-                if not isinstance(other, PropertySection):
-                        return False
-                return self.name > other.name
+    def __gt__(self, other):
+        if not isinstance(other, PropertySection):
+            return False
+        return self.name > other.name
 
-        def __eq__(self, other):
-                if not isinstance(other, PropertySection):
-                        return False
-                return self.name == other.name
+    def __eq__(self, other):
+        if not isinstance(other, PropertySection):
+            return False
+        return self.name == other.name
 
-        def __hash__(self):
-                return hash(self.name)
+    def __hash__(self):
+        return hash(self.name)
 
-        def __copy__(self):
-                propsec = self.__class__(self.__name)
-                for p in self.get_properties():
-                        propsec.add_property(copy.copy(p))
-                return propsec
+    def __copy__(self):
+        propsec = self.__class__(self.__name)
+        for p in self.get_properties():
+            propsec.add_property(copy.copy(p))
+        return propsec
 
-        def __str__(self):
-                return six.text_type(self.name)
+    def __str__(self):
+        return six.text_type(self.name)
 
-        def add_property(self, prop):
-                """Adds the specified property object to the section.  The
-                property must not already exist."""
-                assert prop.name not in self.__properties
-                self.__properties[prop.name] = prop
-                return prop
+    def add_property(self, prop):
+        """Adds the specified property object to the section.  The
+        property must not already exist."""
+        assert prop.name not in self.__properties
+        self.__properties[prop.name] = prop
+        return prop
 
-        def get_index(self):
-                """Returns a dictionary of property values indexed by property
-                name."""
-                return dict(
-                    (pname, p.value)
-                    for pname, p in six.iteritems(self.__properties)
-                    if hasattr(p, "value")
-                )
+    def get_index(self):
+        """Returns a dictionary of property values indexed by property
+        name."""
+        return dict(
+            (pname, p.value)
+            for pname, p in six.iteritems(self.__properties)
+            if hasattr(p, "value")
+        )
 
-        def get_property(self, name):
-                """Returns the property object with the specified name.  If
-                not found, an UnknownPropertyError will be raised."""
-                try:
-                        return self.__properties[name]
-                except KeyError:
-                        raise UnknownPropertyError(section=self.__name,
-                            prop=name)
+    def get_property(self, name):
+        """Returns the property object with the specified name.  If
+        not found, an UnknownPropertyError will be raised."""
+        try:
+            return self.__properties[name]
+        except KeyError:
+            raise UnknownPropertyError(section=self.__name, prop=name)
 
-        def get_properties(self):
-                """Returns a generator that yields the list of property objects.
-                """
-                return six.itervalues(self.__properties)
+    def get_properties(self):
+        """Returns a generator that yields the list of property objects."""
+        return six.itervalues(self.__properties)
 
-        def remove_property(self, name):
-                """Removes any matching property object from the section."""
-                try:
-                        del self.__properties[name]
-                except KeyError:
-                        raise UnknownPropertyError(section=self.__name,
-                            prop=name)
+    def remove_property(self, name):
+        """Removes any matching property object from the section."""
+        try:
+            del self.__properties[name]
+        except KeyError:
+            raise UnknownPropertyError(section=self.__name, prop=name)
 
-        @property
-        def name(self):
-                """The name of the section."""
-                return self.__name
+    @property
+    def name(self):
+        """The name of the section."""
+        return self.__name
 
 
 class PropertySectionTemplate(object):
-        """A class representing a template for a section of the configuration.
-        These templates are used when loading existing configuration data
-        or when adding new sections to an existing configuration object if
-        the section name found matches the pattern name given for the template.
+    """A class representing a template for a section of the configuration.
+    These templates are used when loading existing configuration data
+    or when adding new sections to an existing configuration object if
+    the section name found matches the pattern name given for the template.
+    """
+
+    def __init__(self, name_pattern, properties=misc.EmptyI):
+        if not isinstance(name_pattern, six.string_types) or not name_pattern:
+            raise InvalidSectionTemplateNameError(section=name_pattern)
+        self.__name = name_pattern
+        try:
+            self.__pattern = re.compile(name_pattern)
+        except Exception:
+            # Unfortunately, python doesn't have a public exception
+            # class to catch re parse issues; but this only happens
+            # for misbehaved programs anyway.
+            raise InvalidSectionTemplateNameError(section=name_pattern)
+        self.__properties = properties
+
+    def __copy__(self):
+        return self.__class__(
+            self.__name, properties=copy.copy(self.__properties)
+        )
+
+    def create(self, name):
+        """Returns a new PropertySection object based on the template
+        using the given name.
         """
+        assert self.match(name)
+        # A *copy* of the properties must be used to construct the new
+        # section; otherwise all sections created by this template will
+        # share the same property *objects* (which is bad).
+        return PropertySection(
+            name, properties=[copy.copy(p) for p in self.__properties]
+        )
 
-        def __init__(self, name_pattern, properties=misc.EmptyI):
-                if not isinstance(name_pattern, six.string_types) or not name_pattern:
-                        raise InvalidSectionTemplateNameError(
-                            section=name_pattern)
-                self.__name = name_pattern
-                try:
-                        self.__pattern = re.compile(name_pattern)
-                except Exception:
-                        # Unfortunately, python doesn't have a public exception
-                        # class to catch re parse issues; but this only happens
-                        # for misbehaved programs anyway.
-                        raise InvalidSectionTemplateNameError(
-                            section=name_pattern)
-                self.__properties = properties
+    def match(self, name):
+        """Returns a boolean indicating whether the given name matches
+        the pattern for this template.
+        """
+        return self.__pattern.match(name) is not None
 
-        def __copy__(self):
-                return self.__class__(self.__name,
-                    properties=copy.copy(self.__properties))
-
-        def create(self, name):
-                """Returns a new PropertySection object based on the template
-                using the given name.
-                """
-                assert self.match(name)
-                # A *copy* of the properties must be used to construct the new
-                # section; otherwise all sections created by this template will
-                # share the same property *objects* (which is bad).
-                return PropertySection(name, properties=[
-                    copy.copy(p) for p in self.__properties
-                ])
-
-        def match(self, name):
-                """Returns a boolean indicating whether the given name matches
-                the pattern for this template.
-                """
-                return self.__pattern.match(name) is not None
-
-        @property
-        def name(self):
-                """The name (pattern text) of the property section template."""
-                # Must return a string.
-                return self.__name
+    @property
+    def name(self):
+        """The name (pattern text) of the property section template."""
+        # Must return a string.
+        return self.__name
 
 
 @python_2_unicode_compatible
 class Config(object):
-        """The Config class provides basic in-memory management of configuration
-        data."""
+    """The Config class provides basic in-memory management of configuration
+    data."""
 
-        _dirty = False
-        _target = None
+    _dirty = False
+    _target = None
 
-        def __init__(self, definitions=misc.EmptyDict, overrides=misc.EmptyDict,
-            version=None):
-                """Initializes a Config object.
+    def __init__(
+        self, definitions=misc.EmptyDict, overrides=misc.EmptyDict, version=None
+    ):
+        """Initializes a Config object.
 
-                'definitions' is a dictionary of PropertySection objects indexed
-                by configuration version defining the initial set of property
-                sections, properties, and values for a Config object.
+        'definitions' is a dictionary of PropertySection objects indexed
+        by configuration version defining the initial set of property
+        sections, properties, and values for a Config object.
 
-                'overrides' is an optional dictionary of property values indexed
-                by section name and property name.  If provided, it will be used
-                to override any default values initially assigned during
-                initialization.
+        'overrides' is an optional dictionary of property values indexed
+        by section name and property name.  If provided, it will be used
+        to override any default values initially assigned during
+        initialization.
 
-                'version' is an integer value that will be used to determine
-                which configuration definition to use.  If not provided, the
-                newest version found in 'definitions' will be used.
-                """
+        'version' is an integer value that will be used to determine
+        which configuration definition to use.  If not provided, the
+        newest version found in 'definitions' will be used.
+        """
 
-                assert version is None or isinstance(version, int)
+        assert version is None or isinstance(version, int)
 
-                self.__sections = OrderedDict()
-                self._defs = definitions
-                if version is None:
-                        if definitions:
-                                version = max(definitions.keys())
-                        else:
-                                version = 0
-                self._version = version
-                self.reset(overrides=overrides)
+        self.__sections = OrderedDict()
+        self._defs = definitions
+        if version is None:
+            if definitions:
+                version = max(definitions.keys())
+            else:
+                version = 0
+        self._version = version
+        self.reset(overrides=overrides)
 
-        def __str__(self):
-                """Returns a unicode object representation of the configuration
-                object.
-                """
-                out = u""
-                for sec, props in self.get_properties():
-                        out += u"[{0}]\n".format(sec.name)
-                        for p in props:
-                                out += u"{0} = {1}\n".format(p.name, six.text_type(p))
-                        out += u"\n"
-                return out
+    def __str__(self):
+        """Returns a unicode object representation of the configuration
+        object.
+        """
+        out = ""
+        for sec, props in self.get_properties():
+            out += "[{0}]\n".format(sec.name)
+            for p in props:
+                out += "{0} = {1}\n".format(p.name, six.text_type(p))
+            out += "\n"
+        return out
 
-        def _get_matching_property(self, section, name, default_type=Property):
-                """Returns the Property object matching the given name for
-                the given PropertySection object, or adds a new one (if it
-                does not already exist) based on class definitions.
+    def _get_matching_property(self, section, name, default_type=Property):
+        """Returns the Property object matching the given name for
+        the given PropertySection object, or adds a new one (if it
+        does not already exist) based on class definitions.
 
-                'default_type' is an optional parameter specifying the type of
-                property to create if a class definition does not exist for the
-                given property.
-                """
+        'default_type' is an optional parameter specifying the type of
+        property to create if a class definition does not exist for the
+        given property.
+        """
 
-                self._validate_section_name(section)
-                self._validate_property_name(name)
+        self._validate_section_name(section)
+        self._validate_property_name(name)
 
-                try:
-                        secobj = self.get_section(section)
-                except UnknownSectionError:
-                        # Get a copy of the definition for this section.
-                        secobj = self.__get_section_def(section)
+        try:
+            secobj = self.get_section(section)
+        except UnknownSectionError:
+            # Get a copy of the definition for this section.
+            secobj = self.__get_section_def(section)
 
-                        # Elide property templates.
-                        elide = [
-                            p.name for p in secobj.get_properties()
-                            if not isinstance(p, Property)
-                        ]
-                        # force map() to process elements
-                        list(map(secobj.remove_property, elide))
-                        self.add_section(secobj)
+            # Elide property templates.
+            elide = [
+                p.name
+                for p in secobj.get_properties()
+                if not isinstance(p, Property)
+            ]
+            # force map() to process elements
+            list(map(secobj.remove_property, elide))
+            self.add_section(secobj)
 
-                try:
-                        return secobj.get_property(name)
-                except UnknownPropertyError:
-                        # See if there is an existing definition for this
-                        # property; if there is, duplicate it, and add it
-                        # to the section.
-                        secdef = self.__get_section_def(secobj.name)
-                        propobj = self.__get_property_def(secdef, name,
-                            default_type=default_type)
-                        secobj.add_property(propobj)
-                        return propobj
+        try:
+            return secobj.get_property(name)
+        except UnknownPropertyError:
+            # See if there is an existing definition for this
+            # property; if there is, duplicate it, and add it
+            # to the section.
+            secdef = self.__get_section_def(secobj.name)
+            propobj = self.__get_property_def(
+                secdef, name, default_type=default_type
+            )
+            secobj.add_property(propobj)
+            return propobj
 
-        # Subclasses can redefine these to impose additional restrictions on
-        # section and property names.  These methods should return if the name
-        # is valid, or raise an exception if it is not.  These methods are only
-        # used during __init__, add_section, reset, set_property, and write.
-        def _validate_property_name(self, name):
-                """Raises an exception if property name is not valid for this
-                class.
-                """
-                pass
+    # Subclasses can redefine these to impose additional restrictions on
+    # section and property names.  These methods should return if the name
+    # is valid, or raise an exception if it is not.  These methods are only
+    # used during __init__, add_section, reset, set_property, and write.
+    def _validate_property_name(self, name):
+        """Raises an exception if property name is not valid for this
+        class.
+        """
+        pass
 
-        def _validate_section_name(self, name):
-                """Raises an exception if section name is not valid for this
-                class.
-                """
-                pass
+    def _validate_section_name(self, name):
+        """Raises an exception if section name is not valid for this
+        class.
+        """
+        pass
 
-        def __get_property_def(self, secdef, name, default_type=Property):
-                """Returns a new Property object for the given name based on
-                class definitions (if available).
-                """
+    def __get_property_def(self, secdef, name, default_type=Property):
+        """Returns a new Property object for the given name based on
+        class definitions (if available).
+        """
 
-                try:
-                        propobj = secdef.get_property(name)
-                        return copy.copy(propobj)
-                except UnknownPropertyError:
-                        # No specific definition found for this section,
-                        # see if there is a suitable template for creating
-                        # one.
-                        for p in secdef.get_properties():
-                                if not isinstance(p, PropertyTemplate):
-                                        continue
-                                if p.match(name):
-                                        return p.create(name)
+        try:
+            propobj = secdef.get_property(name)
+            return copy.copy(propobj)
+        except UnknownPropertyError:
+            # No specific definition found for this section,
+            # see if there is a suitable template for creating
+            # one.
+            for p in secdef.get_properties():
+                if not isinstance(p, PropertyTemplate):
+                    continue
+                if p.match(name):
+                    return p.create(name)
 
-                        # Not a known property; create a new one using
-                        # the default type.
-                        return default_type(name)
+            # Not a known property; create a new one using
+            # the default type.
+            return default_type(name)
 
-        def __get_section_def(self, name):
-                """Returns a new PropertySection object for the given name based
-                on class definitions (if available).
-                """
+    def __get_section_def(self, name):
+        """Returns a new PropertySection object for the given name based
+        on class definitions (if available).
+        """
 
-                # See if there is an existing definition for this
-                # section; if there is, return a copy.
-                for s in self._defs.get(self._version, misc.EmptyDict):
-                        if not isinstance(s, PropertySection):
-                                # Ignore section templates.
-                                continue
-                        if s.name == name:
-                                return copy.copy(s)
-                else:
-                        # No specific definition found for this section,
-                        # see if there is a suitable template for creating
-                        # one.
-                        for s in self._defs.get(self._version,
-                            misc.EmptyDict):
-                                if not isinstance(s,
-                                    PropertySectionTemplate):
-                                        continue
-                                if s.match(name):
-                                        return s.create(name)
-                return PropertySection(name)
+        # See if there is an existing definition for this
+        # section; if there is, return a copy.
+        for s in self._defs.get(self._version, misc.EmptyDict):
+            if not isinstance(s, PropertySection):
+                # Ignore section templates.
+                continue
+            if s.name == name:
+                return copy.copy(s)
+        else:
+            # No specific definition found for this section,
+            # see if there is a suitable template for creating
+            # one.
+            for s in self._defs.get(self._version, misc.EmptyDict):
+                if not isinstance(s, PropertySectionTemplate):
+                    continue
+                if s.match(name):
+                    return s.create(name)
+        return PropertySection(name)
 
-        def __reset(self, overrides=misc.EmptyDict):
-                """Returns the configuration object to its default state."""
-                self.__sections = OrderedDict()
-                for s in self._defs.get(self._version, misc.EmptyDict):
-                        if not isinstance(s, PropertySection):
-                                # Templates should be skipped during reset.
-                                continue
-                        self._validate_section_name(s.name)
+    def __reset(self, overrides=misc.EmptyDict):
+        """Returns the configuration object to its default state."""
+        self.__sections = OrderedDict()
+        for s in self._defs.get(self._version, misc.EmptyDict):
+            if not isinstance(s, PropertySection):
+                # Templates should be skipped during reset.
+                continue
+            self._validate_section_name(s.name)
 
-                        # Elide property templates.
-                        secobj = copy.copy(s)
-                        elide = [
-                            p.name for p in secobj.get_properties()
-                            if not isinstance(p, Property)
-                        ]
-                        list(map(secobj.remove_property, elide))
-                        self.add_section(secobj)
+            # Elide property templates.
+            secobj = copy.copy(s)
+            elide = [
+                p.name
+                for p in secobj.get_properties()
+                if not isinstance(p, Property)
+            ]
+            list(map(secobj.remove_property, elide))
+            self.add_section(secobj)
 
-                for sname, props in six.iteritems(overrides):
-                        for pname, val in six.iteritems(props):
-                                self.set_property(sname, pname, val)
+        for sname, props in six.iteritems(overrides):
+            for pname, val in six.iteritems(props):
+                self.set_property(sname, pname, val)
 
-        def add_property_value(self, section, name, value):
-                """Adds the value to the property object matching the given
-                section and name.  If the section or property does not already
-                exist, it will be added.  Raises InvalidPropertyValueError if
-                the value is not valid for the given property or if the target
-                property isn't a list."""
+    def add_property_value(self, section, name, value):
+        """Adds the value to the property object matching the given
+        section and name.  If the section or property does not already
+        exist, it will be added.  Raises InvalidPropertyValueError if
+        the value is not valid for the given property or if the target
+        property isn't a list."""
 
-                propobj = self._get_matching_property(section, name,
-                    default_type=PropList)
-                if not isinstance(propobj.value, list):
-                        raise PropertyMultiValueError(section=section,
-                            prop=name, value=value)
+        propobj = self._get_matching_property(
+            section, name, default_type=PropList
+        )
+        if not isinstance(propobj.value, list):
+            raise PropertyMultiValueError(
+                section=section, prop=name, value=value
+            )
 
-                # If a value was just appended directly, the property class
-                # set method wouldn't be executed and the value added wouldn't
-                # get verified, so append to a copy of the property's value and
-                # then set the property to the new value.  This allows the new
-                # value to be verified and/or rejected without affecting the
-                # property.
-                pval = copy.copy(propobj.value)
-                pval.append(value)
-                try:
-                        propobj.value = pval
-                except PropertyConfigError as e:
-                        if hasattr(e, "section") and not e.section:
-                                e.section = section
-                        raise
-                self._dirty = True
+        # If a value was just appended directly, the property class
+        # set method wouldn't be executed and the value added wouldn't
+        # get verified, so append to a copy of the property's value and
+        # then set the property to the new value.  This allows the new
+        # value to be verified and/or rejected without affecting the
+        # property.
+        pval = copy.copy(propobj.value)
+        pval.append(value)
+        try:
+            propobj.value = pval
+        except PropertyConfigError as e:
+            if hasattr(e, "section") and not e.section:
+                e.section = section
+            raise
+        self._dirty = True
 
-        def add_section(self, section):
-                """Adds the specified property section object.  The section must
-                not already exist.
-                """
-                assert isinstance(section, PropertySection)
-                assert section.name not in self.__sections
-                self._validate_section_name(section.name)
-                self.__sections[section.name] = section
+    def add_section(self, section):
+        """Adds the specified property section object.  The section must
+        not already exist.
+        """
+        assert isinstance(section, PropertySection)
+        assert section.name not in self.__sections
+        self._validate_section_name(section.name)
+        self.__sections[section.name] = section
 
-        def get_index(self):
-                """Returns a dictionary of dictionaries indexed by section name
-                and then property name for all properties."""
-                return dict(
-                    (s.name, s.get_index())
-                    for s in self.get_sections()
-                )
+    def get_index(self):
+        """Returns a dictionary of dictionaries indexed by section name
+        and then property name for all properties."""
+        return dict((s.name, s.get_index()) for s in self.get_sections())
 
-        def get_property(self, section, name):
-                """Returns the value of the property object matching the given
-                section and name.  Raises UnknownPropertyError if it does not
-                exist.
+    def get_property(self, section, name):
+        """Returns the value of the property object matching the given
+        section and name.  Raises UnknownPropertyError if it does not
+        exist.
 
-                Be aware that references to the original value are returned;
-                if the return value is not an immutable object (such as a list),
-                changes to the object will affect the property.  If the return
-                value needs to be modified, consumers are advised to create a
-                copy first, and then call set_property() to update the value.
-                Calling set_property() with the updated value is the only way
-                to ensure that changes to a property's value are persistent.
-                """
-                try:
-                        sec = self.get_section(section)
-                except UnknownSectionError:
-                        # To aid in debugging, re-raise as a property error
-                        # so that both the unknown section and property are
-                        # in the error message.
-                        raise UnknownPropertyError(section=section, prop=name)
-                return sec.get_property(name).value
+        Be aware that references to the original value are returned;
+        if the return value is not an immutable object (such as a list),
+        changes to the object will affect the property.  If the return
+        value needs to be modified, consumers are advised to create a
+        copy first, and then call set_property() to update the value.
+        Calling set_property() with the updated value is the only way
+        to ensure that changes to a property's value are persistent.
+        """
+        try:
+            sec = self.get_section(section)
+        except UnknownSectionError:
+            # To aid in debugging, re-raise as a property error
+            # so that both the unknown section and property are
+            # in the error message.
+            raise UnknownPropertyError(section=section, prop=name)
+        return sec.get_property(name).value
 
-        def get_properties(self):
-                """Returns a generator that yields a list of tuples of the form
-                (section object, property generator).  The property generator
-                yields the list of property objects for the section.
-                """
-                return (
-                    (s, s.get_properties())
-                    for s in self.get_sections()
-                )
+    def get_properties(self):
+        """Returns a generator that yields a list of tuples of the form
+        (section object, property generator).  The property generator
+        yields the list of property objects for the section.
+        """
+        return ((s, s.get_properties()) for s in self.get_sections())
 
-        def get_section(self, name):
-                """Returns the PropertySection object with the given name.
-                Raises UnknownSectionError if it does not exist.
-                """
-                try:
-                        return self.__sections[name]
-                except KeyError:
-                        raise UnknownSectionError(section=name)
+    def get_section(self, name):
+        """Returns the PropertySection object with the given name.
+        Raises UnknownSectionError if it does not exist.
+        """
+        try:
+            return self.__sections[name]
+        except KeyError:
+            raise UnknownSectionError(section=name)
 
-        def get_sections(self):
-                """Returns a generator that yields the list of property section
-                objects."""
-                return six.itervalues(self.__sections)
+    def get_sections(self):
+        """Returns a generator that yields the list of property section
+        objects."""
+        return six.itervalues(self.__sections)
 
-        def remove_property(self, section, name):
-                """Remove the property object matching the given section and
-                name.  Raises UnknownPropertyError if it does not exist.
-                """
-                try:
-                        sec = self.get_section(section)
-                except UnknownSectionError:
-                        # To aid in debugging, re-raise as a property error
-                        # so that both the unknown section and property are
-                        # in the error message.
-                        raise UnknownPropertyError(section=section, prop=name)
-                sec.remove_property(name)
-                self._dirty = True
+    def remove_property(self, section, name):
+        """Remove the property object matching the given section and
+        name.  Raises UnknownPropertyError if it does not exist.
+        """
+        try:
+            sec = self.get_section(section)
+        except UnknownSectionError:
+            # To aid in debugging, re-raise as a property error
+            # so that both the unknown section and property are
+            # in the error message.
+            raise UnknownPropertyError(section=section, prop=name)
+        sec.remove_property(name)
+        self._dirty = True
 
-        def remove_property_value(self, section, name, value):
-                """Removes the value from the list of values for the property
-                object matching the given section and name.  Raises
-                UnknownPropertyError if the property or section does not
-                exist.  Raises InvalidPropertyValueError if the value is not
-                valid for the given property or if the target property isn't a
-                list."""
+    def remove_property_value(self, section, name, value):
+        """Removes the value from the list of values for the property
+        object matching the given section and name.  Raises
+        UnknownPropertyError if the property or section does not
+        exist.  Raises InvalidPropertyValueError if the value is not
+        valid for the given property or if the target property isn't a
+        list."""
 
-                self._validate_section_name(section)
-                self._validate_property_name(name)
+        self._validate_section_name(section)
+        self._validate_property_name(name)
 
-                try:
-                        secobj = self.get_section(section)
-                except UnknownSectionError:
-                        # To aid in debugging, re-raise as a property error
-                        # so that both the unknown section and property are
-                        # in the error message.
-                        raise UnknownPropertyError(section=section, prop=name)
+        try:
+            secobj = self.get_section(section)
+        except UnknownSectionError:
+            # To aid in debugging, re-raise as a property error
+            # so that both the unknown section and property are
+            # in the error message.
+            raise UnknownPropertyError(section=section, prop=name)
 
-                propobj = secobj.get_property(name)
-                if not isinstance(propobj.value, list):
-                        raise PropertyMultiValueError(section=section,
-                            prop=name, value=value)
+        propobj = secobj.get_property(name)
+        if not isinstance(propobj.value, list):
+            raise PropertyMultiValueError(
+                section=section, prop=name, value=value
+            )
 
-                # Remove the value from a copy of the actual property object
-                # value so that the property's set verification can happen.
-                pval = copy.copy(propobj.value)
-                try:
-                        pval.remove(value)
-                except ValueError:
-                        raise UnknownPropertyValueError(section=section,
-                            prop=name, value=value)
-                else:
-                        try:
-                                propobj.value = pval
-                        except PropertyConfigError as e:
-                                if hasattr(e, "section") and not e.section:
-                                        e.section = section
-                                raise
-                self._dirty = True
+        # Remove the value from a copy of the actual property object
+        # value so that the property's set verification can happen.
+        pval = copy.copy(propobj.value)
+        try:
+            pval.remove(value)
+        except ValueError:
+            raise UnknownPropertyValueError(
+                section=section, prop=name, value=value
+            )
+        else:
+            try:
+                propobj.value = pval
+            except PropertyConfigError as e:
+                if hasattr(e, "section") and not e.section:
+                    e.section = section
+                raise
+        self._dirty = True
 
-        def remove_section(self, name):
-                """Remove the object matching the given section name.  Raises
-                UnknownSectionError if it does not exist.
-                """
-                try:
-                        del self.__sections[name]
-                except KeyError:
-                        raise UnknownSectionError(section=name)
-                self._dirty = True
+    def remove_section(self, name):
+        """Remove the object matching the given section name.  Raises
+        UnknownSectionError if it does not exist.
+        """
+        try:
+            del self.__sections[name]
+        except KeyError:
+            raise UnknownSectionError(section=name)
+        self._dirty = True
 
-        def reset(self, overrides=misc.EmptyDict):
-                """Discards current configuration data and returns the
-                configuration object to its initial state.
+    def reset(self, overrides=misc.EmptyDict):
+        """Discards current configuration data and returns the
+        configuration object to its initial state.
 
-                'overrides' is an optional dictionary of property values
-                indexed by section name and property name.  If provided,
-                it will be used to override any default values initially
-                assigned during reset.
-                """
+        'overrides' is an optional dictionary of property values
+        indexed by section name and property name.  If provided,
+        it will be used to override any default values initially
+        assigned during reset.
+        """
 
-                # Initialize to default state.
-                self._dirty = True
-                self.__reset(overrides=overrides)
+        # Initialize to default state.
+        self._dirty = True
+        self.__reset(overrides=overrides)
 
-        def set_property(self, section, name, value):
-                """Sets the value of the property object matching the given
-                section and name.  If the section or property does not already
-                exist, it will be added.  Raises InvalidPropertyValueError if
-                the value is not valid for the given property."""
+    def set_property(self, section, name, value):
+        """Sets the value of the property object matching the given
+        section and name.  If the section or property does not already
+        exist, it will be added.  Raises InvalidPropertyValueError if
+        the value is not valid for the given property."""
 
-                self._validate_section_name(section)
-                self._validate_property_name(name)
+        self._validate_section_name(section)
+        self._validate_property_name(name)
 
-                propobj = self._get_matching_property(section, name)
-                try:
-                        propobj.value = value
-                except PropertyConfigError as e:
-                        if hasattr(e, "section") and not e.section:
-                                e.section = section
-                        raise
-                self._dirty = True
+        propobj = self._get_matching_property(section, name)
+        try:
+            propobj.value = value
+        except PropertyConfigError as e:
+            if hasattr(e, "section") and not e.section:
+                e.section = section
+            raise
+        self._dirty = True
 
-        def set_properties(self, properties):
-                """Sets the values of the property objects matching those found
-                in the provided dictionary.  If any section or property does not
-                already exist, it will be added.  An InvalidPropertyValueError
-                will be raised if the value is not valid for the given
-                properties.
+    def set_properties(self, properties):
+        """Sets the values of the property objects matching those found
+        in the provided dictionary.  If any section or property does not
+        already exist, it will be added.  An InvalidPropertyValueError
+        will be raised if the value is not valid for the given
+        properties.
 
-                'properties' should be a dictionary of dictionaries indexed by
-                section and then by property name.  As an example:
+        'properties' should be a dictionary of dictionaries indexed by
+        section and then by property name.  As an example:
 
-                    {
-                        'section': {
-                            'property': value
-                        }
-                    }
-                """
+            {
+                'section': {
+                    'property': value
+                }
+            }
+        """
 
-                # Dict is in arbitrary order, sort it first to ensure the
-                # order is same in Python 2 and 3.
-                properties = OrderedDict(sorted(properties.items()))
-                for section, props in six.iteritems(properties):
-                        props = OrderedDict(sorted(props.items()))
-                        for pname, pval in six.iteritems(props):
-                                self.set_property(section, pname, pval)
+        # Dict is in arbitrary order, sort it first to ensure the
+        # order is same in Python 2 and 3.
+        properties = OrderedDict(sorted(properties.items()))
+        for section, props in six.iteritems(properties):
+            props = OrderedDict(sorted(props.items()))
+            for pname, pval in six.iteritems(props):
+                self.set_property(section, pname, pval)
 
-        @property
-        def target(self):
-                """Returns the target used for storage and retrieval of
-                configuration data.  This can be None, a pathname, or
-                an SMF FMRI.
-                """
-                return self._target
+    @property
+    def target(self):
+        """Returns the target used for storage and retrieval of
+        configuration data.  This can be None, a pathname, or
+        an SMF FMRI.
+        """
+        return self._target
 
-        @property
-        def version(self):
-                """Returns an integer value used to indicate what set of
-                configuration data is in use."""
+    @property
+    def version(self):
+        """Returns an integer value used to indicate what set of
+        configuration data is in use."""
 
-                return self._version
+        return self._version
 
-        def write(self):
-                """Saves the current configuration object to the target
-                provided at initialization.
-                """
-                pass
+    def write(self):
+        """Saves the current configuration object to the target
+        provided at initialization.
+        """
+        pass
 
 
 class FileConfig(Config):
-        """The FileConfig class provides file-based retrieval and storage of
-        non-structured (one-level deep) configuration data.  This particular
-        class uses Python's ConfigParser module for configuration storage and
-        management.
+    """The FileConfig class provides file-based retrieval and storage of
+    non-structured (one-level deep) configuration data.  This particular
+    class uses Python's ConfigParser module for configuration storage and
+    management.
 
-        ConfigParser uses a simple text format that consists of sections, lead
-        by a "[section]" header, and followed by "name = value" entries, with
-        continuations, etc. in the style of RFC 822.  Values can be split over
-        multiple lines by beginning continuation lines with whitespace.  A
-        sample configuration file might look like this:
+    ConfigParser uses a simple text format that consists of sections, lead
+    by a "[section]" header, and followed by "name = value" entries, with
+    continuations, etc. in the style of RFC 822.  Values can be split over
+    multiple lines by beginning continuation lines with whitespace.  A
+    sample configuration file might look like this:
 
-        [pkg]
-        port = 80
-        inst_root = /export/repo
+    [pkg]
+    port = 80
+    inst_root = /export/repo
 
-        [pub_example_com]
-        feed_description = example.com's software
-          update log
+    [pub_example_com]
+    feed_description = example.com's software
+      update log
+    """
+
+    def __init__(
+        self,
+        pathname,
+        definitions=misc.EmptyDict,
+        overrides=misc.EmptyDict,
+        version=None,
+    ):
+        """Initializes the object.
+
+        'pathname' is the name of the file to read existing
+        configuration data from or to write new configuration
+        data to.  If the file does not already exist, defaults
+        are set based on the version provided and the file will
+        be created when the configuration is written.
+
+        'definitions' is a dictionary of PropertySection objects indexed
+        by configuration version defining the initial set of property
+        sections, properties, and values for a Config object.
+
+        'overrides' is an optional dictionary of property values indexed
+        by section name and property name.  If provided, it will be used
+        to override any default values initially assigned during
+        initialization.
+
+        'version' is an integer value that will be used to determine
+        which configuration definition to use.  If not provided, the
+        version will be based on the contents of the configuration
+        file or the newest version found in 'definitions'.
+        """
+        # Must be set first.
+        self._target = pathname
+
+        Config.__init__(
+            self, definitions=definitions, overrides=overrides, version=version
+        )
+
+    def __read(self, overrides=misc.EmptyDict):
+        """Reads the specified pathname and populates the configuration
+        object based on the data contained within.  The file is
+        expected to be in a ConfigParser-compatible format.
         """
 
-        def __init__(self, pathname, definitions=misc.EmptyDict,
-            overrides=misc.EmptyDict, version=None):
-                """Initializes the object.
+        # First, attempt to read the target.
+        cp = configparser.RawConfigParser()
+        # Disabled ConfigParser's inane option transformation to ensure
+        # option case is preserved.
+        cp.optionxform = lambda x: x
 
-                'pathname' is the name of the file to read existing
-                configuration data from or to write new configuration
-                data to.  If the file does not already exist, defaults
-                are set based on the version provided and the file will
-                be created when the configuration is written.
-
-                'definitions' is a dictionary of PropertySection objects indexed
-                by configuration version defining the initial set of property
-                sections, properties, and values for a Config object.
-
-                'overrides' is an optional dictionary of property values indexed
-                by section name and property name.  If provided, it will be used
-                to override any default values initially assigned during
-                initialization.
-
-                'version' is an integer value that will be used to determine
-                which configuration definition to use.  If not provided, the
-                version will be based on the contents of the configuration
-                file or the newest version found in 'definitions'.
-                """
-                # Must be set first.
-                self._target = pathname
-
-                Config.__init__(self, definitions=definitions,
-                    overrides=overrides, version=version)
-
-        def __read(self, overrides=misc.EmptyDict):
-                """Reads the specified pathname and populates the configuration
-                object based on the data contained within.  The file is
-                expected to be in a ConfigParser-compatible format.
-                """
-
-                # First, attempt to read the target.
-                cp = configparser.RawConfigParser()
-                # Disabled ConfigParser's inane option transformation to ensure
-                # option case is preserved.
-                cp.optionxform = lambda x: x
-
-                try:
-                        efile = codecs.open(self._target, mode="rb",
-                            encoding="utf-8")
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                # Assume default configuration.
-                                pass
-                        elif e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    e.filename)
-                        else:
-                                raise
+        try:
+            efile = codecs.open(self._target, mode="rb", encoding="utf-8")
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                # Assume default configuration.
+                pass
+            elif e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(e.filename)
+            else:
+                raise
+        else:
+            try:
+                # readfp() will be removed in futher Python
+                # versions, use read_file() instead.
+                if six.PY2:
+                    cp.readfp(efile)
                 else:
-                        try:
-                                # readfp() will be removed in futher Python
-                                # versions, use read_file() instead.
-                                if six.PY2:
-                                        cp.readfp(efile)
-                                else:
-                                        cp.read_file(efile)
-                        except (configparser.ParsingError,
-                            configparser.MissingSectionHeaderError) as e:
-                                raise api_errors.InvalidConfigFile(
-                                    self._target)
-                        # Attempt to determine version from contents.
-                        try:
-                                version = cp.getint("CONFIGURATION", "version")
-                                self._version = version
-                        except (configparser.NoSectionError,
-                            configparser.NoOptionError, ValueError):
-                                # Assume current version.
-                                pass
-                        efile.close()
+                    cp.read_file(efile)
+            except (
+                configparser.ParsingError,
+                configparser.MissingSectionHeaderError,
+            ) as e:
+                raise api_errors.InvalidConfigFile(self._target)
+            # Attempt to determine version from contents.
+            try:
+                version = cp.getint("CONFIGURATION", "version")
+                self._version = version
+            except (
+                configparser.NoSectionError,
+                configparser.NoOptionError,
+                ValueError,
+            ):
+                # Assume current version.
+                pass
+            efile.close()
 
-                # Reset to initial state to ensure the default set of properties
-                # and values exists so that any values not specified by the
-                # saved configuration or overrides will be correct.  This must
-                # be done after the version is determined above so that the
-                # saved configuration data can be merged with the correct
-                # configuration definition.
-                Config.reset(self, overrides=overrides)
+        # Reset to initial state to ensure the default set of properties
+        # and values exists so that any values not specified by the
+        # saved configuration or overrides will be correct.  This must
+        # be done after the version is determined above so that the
+        # saved configuration data can be merged with the correct
+        # configuration definition.
+        Config.reset(self, overrides=overrides)
 
-                for section in cp.sections():
-                        if section == "CONFIGURATION":
-                                # Reserved for configuration file management.
-                                continue
-                        for prop, value in cp.items(section):
-                                if section in overrides and \
-                                    prop in overrides[section]:
-                                        continue
+        for section in cp.sections():
+            if section == "CONFIGURATION":
+                # Reserved for configuration file management.
+                continue
+            for prop, value in cp.items(section):
+                if section in overrides and prop in overrides[section]:
+                    continue
 
-                                propobj = self._get_matching_property(section,
-                                    prop)
+                propobj = self._get_matching_property(section, prop)
 
-                                # Try to convert unicode object to str object
-                                # to ensure comparisons works as expected for
-                                # consumers.
-                                try:
-                                        value = str(value)
-                                except UnicodeEncodeError:
-                                        # Value contains unicode.
-                                        pass
-                                try:
-                                        propobj.value = value
-                                except PropertyConfigError as e:
-                                        if hasattr(e, "section") and \
-                                            not e.section:
-                                                e.section = section
-                                        raise
-
-        def reset(self, overrides=misc.EmptyDict):
-                """Discards current configuration state and returns the
-                configuration object to its initial state.
-
-                'overrides' is an optional dictionary of property values
-                indexed by section name and property name.  If provided,
-                it will be used to override any default values initially
-                assigned during reset.
-                """
-
-                # Reload the configuration.
-                self.__read(overrides=overrides)
-
-                if not overrides:
-                        # Unless there were overrides, ignore any initial
-                        # values for the purpose of determining whether a
-                        # write should occur.  This isn't strictly correct,
-                        # but is the desired behaviour in most cases.  This
-                        # also matches the historical behaviour of the
-                        # configuration classes used in pkg(7).
-                        self._dirty = False
-
-        def write(self):
-                """Saves the configuration data using the pathname provided at
-                initialization.
-                """
-
-                if os.path.exists(self._target) and not self._dirty:
-                        return
-
-                cp = configparser.RawConfigParser()
-                # Disabled ConfigParser's inane option transformation to ensure
-                # option case is preserved.
-                cp.optionxform = lambda x: x
-
-                for section, props in self.get_properties():
-                        assert isinstance(section, PropertySection)
-                        cp.add_section(section.name)
-                        for p in props:
-                                assert isinstance(p, Property)
-                                cp.set(section.name, p.name, misc.force_str(p))
-
-                # Used to track configuration management information.
-                cp.add_section("CONFIGURATION")
-                cp.set("CONFIGURATION", "version", str(self._version))
-
-                fn = None
+                # Try to convert unicode object to str object
+                # to ensure comparisons works as expected for
+                # consumers.
                 try:
-                        dirname = os.path.dirname(self._target)
+                    value = str(value)
+                except UnicodeEncodeError:
+                    # Value contains unicode.
+                    pass
+                try:
+                    propobj.value = value
+                except PropertyConfigError as e:
+                    if hasattr(e, "section") and not e.section:
+                        e.section = section
+                    raise
 
-                        fd = None
-                        st = None
-                        try:
-                                fd, fn = tempfile.mkstemp(dir=dirname)
-                                st = os.stat(self._target)
-                        except OSError as e:
-                                if e.errno != errno.ENOENT:
-                                        raise
+    def reset(self, overrides=misc.EmptyDict):
+        """Discards current configuration state and returns the
+        configuration object to its initial state.
 
-                        if st:
-                                os.fchmod(fd, stat.S_IMODE(st.st_mode))
-                                try:
-                                        portable.chown(fn, st.st_uid, st.st_gid)
-                                except OSError as e:
-                                        if e.errno != errno.EPERM:
-                                                raise
-                        else:
-                                os.fchmod(fd, misc.PKG_FILE_MODE)
+        'overrides' is an optional dictionary of property values
+        indexed by section name and property name.  If provided,
+        it will be used to override any default values initially
+        assigned during reset.
+        """
 
-                        if six.PY2:
-                                with os.fdopen(fd, "wb") as f:
-                                        with codecs.EncodedFile(f, "utf-8") as ef:
-                                                cp.write(ef)
-                        else:
-                                # it becomes easier to open the file
-                                with open(fd, "w", encoding="utf-8") as f:
-                                        cp.write(f)
-                        portable.rename(fn, self._target)
-                        self._dirty = False
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    e.filename)
-                        elif e.errno == errno.EROFS:
-                                raise api_errors.ReadOnlyFileSystemException(
-                                    e.filename)
+        # Reload the configuration.
+        self.__read(overrides=overrides)
+
+        if not overrides:
+            # Unless there were overrides, ignore any initial
+            # values for the purpose of determining whether a
+            # write should occur.  This isn't strictly correct,
+            # but is the desired behaviour in most cases.  This
+            # also matches the historical behaviour of the
+            # configuration classes used in pkg(7).
+            self._dirty = False
+
+    def write(self):
+        """Saves the configuration data using the pathname provided at
+        initialization.
+        """
+
+        if os.path.exists(self._target) and not self._dirty:
+            return
+
+        cp = configparser.RawConfigParser()
+        # Disabled ConfigParser's inane option transformation to ensure
+        # option case is preserved.
+        cp.optionxform = lambda x: x
+
+        for section, props in self.get_properties():
+            assert isinstance(section, PropertySection)
+            cp.add_section(section.name)
+            for p in props:
+                assert isinstance(p, Property)
+                cp.set(section.name, p.name, misc.force_str(p))
+
+        # Used to track configuration management information.
+        cp.add_section("CONFIGURATION")
+        cp.set("CONFIGURATION", "version", str(self._version))
+
+        fn = None
+        try:
+            dirname = os.path.dirname(self._target)
+
+            fd = None
+            st = None
+            try:
+                fd, fn = tempfile.mkstemp(dir=dirname)
+                st = os.stat(self._target)
+            except OSError as e:
+                if e.errno != errno.ENOENT:
+                    raise
+
+            if st:
+                os.fchmod(fd, stat.S_IMODE(st.st_mode))
+                try:
+                    portable.chown(fn, st.st_uid, st.st_gid)
+                except OSError as e:
+                    if e.errno != errno.EPERM:
                         raise
-                finally:
-                        if fn and os.path.exists(fn):
-                                os.unlink(fn)
+            else:
+                os.fchmod(fd, misc.PKG_FILE_MODE)
+
+            if six.PY2:
+                with os.fdopen(fd, "wb") as f:
+                    with codecs.EncodedFile(f, "utf-8") as ef:
+                        cp.write(ef)
+            else:
+                # it becomes easier to open the file
+                with open(fd, "w", encoding="utf-8") as f:
+                    cp.write(f)
+            portable.rename(fn, self._target)
+            self._dirty = False
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(e.filename)
+            elif e.errno == errno.EROFS:
+                raise api_errors.ReadOnlyFileSystemException(e.filename)
+            raise
+        finally:
+            if fn and os.path.exists(fn):
+                os.unlink(fn)
 
 
 # For SMF properties and property groups, this defines the naming restrictions.
 # Although, additional restrictions may be imposed by the property and section
 # classes in this module.
-_SMF_name_re = '^([A-Za-z][ A-Za-z0-9.-]*,)?[A-Za-z][ A-Za-z0-9-_]*$'
+_SMF_name_re = "^([A-Za-z][ A-Za-z0-9.-]*,)?[A-Za-z][ A-Za-z0-9-_]*$"
+
 
 class SMFInvalidPropertyNameError(PropertyConfigError):
-        """Exception class used to indicate an invalid SMF property name."""
+    """Exception class used to indicate an invalid SMF property name."""
 
-        def __init__(self, prop):
-                assert prop is not None
-                PropertyConfigError.__init__(self, prop=prop)
+    def __init__(self, prop):
+        assert prop is not None
+        PropertyConfigError.__init__(self, prop=prop)
 
-        def __str__(self):
-                return _("Property name '{name}' is not valid.  Property "
-                    "names may not contain: tabs, newlines, carriage returns, "
-                    "form feeds, vertical tabs, slashes, or backslashes and "
-                    "must also match the regular expression: {exp}").format(
-                    name=self.prop, exp=_SMF_name_re)
+    def __str__(self):
+        return _(
+            "Property name '{name}' is not valid.  Property "
+            "names may not contain: tabs, newlines, carriage returns, "
+            "form feeds, vertical tabs, slashes, or backslashes and "
+            "must also match the regular expression: {exp}"
+        ).format(name=self.prop, exp=_SMF_name_re)
 
 
 class SMFInvalidSectionNameError(PropertyConfigError):
-        """Exception class used to indicate an invalid SMF section name."""
+    """Exception class used to indicate an invalid SMF section name."""
 
-        def __init__(self, section):
-                assert section is not None
-                PropertyConfigError.__init__(self, section=section)
+    def __init__(self, section):
+        assert section is not None
+        PropertyConfigError.__init__(self, section=section)
 
-        def __str__(self):
-                return _("Section name '{name}' is not valid.  Section names "
-                    "may not contain: tabs, newlines, carriage returns, form "
-                    "feeds, vertical tabs, slashes, or backslashes and must "
-                    "also match the regular expression: {exp}").format(
-                    name=self.prop, exp=_SMF_name_re)
+    def __str__(self):
+        return _(
+            "Section name '{name}' is not valid.  Section names "
+            "may not contain: tabs, newlines, carriage returns, form "
+            "feeds, vertical tabs, slashes, or backslashes and must "
+            "also match the regular expression: {exp}"
+        ).format(name=self.prop, exp=_SMF_name_re)
 
 
 class SMFReadError(ConfigError):
-        """Exception classes used to indicate that an error was encountered
-        while attempting to read configuration data from SMF."""
+    """Exception classes used to indicate that an error was encountered
+    while attempting to read configuration data from SMF."""
 
-        def __init__(self, svc_fmri, errmsg):
-                ConfigError.__init__(self)
-                assert svc_fmri and errmsg
-                self.fmri = svc_fmri
-                self.errmsg = errmsg
+    def __init__(self, svc_fmri, errmsg):
+        ConfigError.__init__(self)
+        assert svc_fmri and errmsg
+        self.fmri = svc_fmri
+        self.errmsg = errmsg
 
-        def __str__(self):
-                return _("Unable to read configuration data for SMF FMRI "
-                    "'{fmri}':\n{errmsg}").format(**self.__dict__)
+    def __str__(self):
+        return _(
+            "Unable to read configuration data for SMF FMRI "
+            "'{fmri}':\n{errmsg}"
+        ).format(**self.__dict__)
 
 
 class SMFWriteError(ConfigError):
-        """Exception classes used to indicate that an error was encountered
-        while attempting to write configuration data to SMF."""
+    """Exception classes used to indicate that an error was encountered
+    while attempting to write configuration data to SMF."""
 
-        def __init__(self, svc_fmri, errmsg):
-                ConfigError.__init__(self)
-                assert svc_fmri and errmsg
-                self.fmri = svc_fmri
-                self.errmsg = errmsg
+    def __init__(self, svc_fmri, errmsg):
+        ConfigError.__init__(self)
+        assert svc_fmri and errmsg
+        self.fmri = svc_fmri
+        self.errmsg = errmsg
 
-        def __str__(self):
-                return _("Unable to write configuration data for SMF FMRI "
-                    "'{fmri}':\n{errmsg}").format(**self.__dict__)
+    def __str__(self):
+        return _(
+            "Unable to write configuration data for SMF FMRI "
+            "'{fmri}':\n{errmsg}"
+        ).format(**self.__dict__)
 
 
 class SMFConfig(Config):
-        """The SMFConfig class provides SMF-based retrieval of non-structured
-        (one-level deep) configuration data.  Property groups should be named
-        after property sections.  Properties with list-based values should be
-        stored using SMF list properties."""
+    """The SMFConfig class provides SMF-based retrieval of non-structured
+    (one-level deep) configuration data.  Property groups should be named
+    after property sections.  Properties with list-based values should be
+    stored using SMF list properties."""
 
-        __name_re = re.compile(_SMF_name_re)
-        __reserved_sections = ("general", "restarter", "fs", "autofs", "ntp",
-            "network", "startd", "manifestfiles", "start", "stop",
-            "tm_common_name")
+    __name_re = re.compile(_SMF_name_re)
+    __reserved_sections = (
+        "general",
+        "restarter",
+        "fs",
+        "autofs",
+        "ntp",
+        "network",
+        "startd",
+        "manifestfiles",
+        "start",
+        "stop",
+        "tm_common_name",
+    )
 
-        def __init__(self, svc_fmri, definitions=misc.EmptyDict,
-            doorpath=None, overrides=misc.EmptyDict, version=0):
-                """Initializes the object.
+    def __init__(
+        self,
+        svc_fmri,
+        definitions=misc.EmptyDict,
+        doorpath=None,
+        overrides=misc.EmptyDict,
+        version=0,
+    ):
+        """Initializes the object.
 
-                'svc_fmri' is the FMRI of the SMF service to use for property
-                data storage and retrieval.
+        'svc_fmri' is the FMRI of the SMF service to use for property
+        data storage and retrieval.
 
-                'definitions' is a dictionary of PropertySection objects indexed
-                by configuration version defining the initial set of property
-                sections, properties, and values for a Config object.
+        'definitions' is a dictionary of PropertySection objects indexed
+        by configuration version defining the initial set of property
+        sections, properties, and values for a Config object.
 
-                'doorpath' is an optional pathname indicating the location of
-                a door file to be used to communicate with SMF.  This is
-                intended for use with an alternative svc.configd daemon.
+        'doorpath' is an optional pathname indicating the location of
+        a door file to be used to communicate with SMF.  This is
+        intended for use with an alternative svc.configd daemon.
 
-                'overrides' is an optional dictionary of property values indexed
-                by section name and property name.  If provided, it will be used
-                to override any default values initially assigned during
-                initialization.
+        'overrides' is an optional dictionary of property values indexed
+        by section name and property name.  If provided, it will be used
+        to override any default values initially assigned during
+        initialization.
 
-                'version' is an integer value that will be used to determine
-                which configuration definition to use.  If not provided, the
-                version will be based on the newest version found in
-                'definitions'.
-                """
-                # Must be set first.
-                self.__doorpath = doorpath
-                self._target = svc_fmri
+        'version' is an integer value that will be used to determine
+        which configuration definition to use.  If not provided, the
+        version will be based on the newest version found in
+        'definitions'.
+        """
+        # Must be set first.
+        self.__doorpath = doorpath
+        self._target = svc_fmri
 
-                Config.__init__(self, definitions=definitions,
-                    overrides=overrides, version=version)
+        Config.__init__(
+            self, definitions=definitions, overrides=overrides, version=version
+        )
 
-        def _validate_property_name(self, name):
-                """Raises an exception if property name is not valid for this
-                class.
-                """
-                if not self.__name_re.match(name):
-                        raise SMFInvalidPropertyNameError(name)
+    def _validate_property_name(self, name):
+        """Raises an exception if property name is not valid for this
+        class.
+        """
+        if not self.__name_re.match(name):
+            raise SMFInvalidPropertyNameError(name)
 
-        def _validate_section_name(self, name):
-                """Raises an exception if section name is not valid for this
-                class.
-                """
-                if not self.__name_re.match(name) or \
-                    name in self.__reserved_sections:
-                        raise SMFInvalidSectionNameError(name)
+    def _validate_section_name(self, name):
+        """Raises an exception if section name is not valid for this
+        class.
+        """
+        if not self.__name_re.match(name) or name in self.__reserved_sections:
+            raise SMFInvalidSectionNameError(name)
 
-        def __read(self, overrides=misc.EmptyDict):
-                """Reads the configuration from the SMF FMRI specified at init
-                time.
-                """
+    def __read(self, overrides=misc.EmptyDict):
+        """Reads the configuration from the SMF FMRI specified at init
+        time.
+        """
 
-                doorpath = ""
-                if self.__doorpath:
-                        doorpath = "LIBSCF_DOORPATH={0} ".format(
-                            self.__doorpath)
+        doorpath = ""
+        if self.__doorpath:
+            doorpath = "LIBSCF_DOORPATH={0} ".format(self.__doorpath)
 
-                cmd = "{0}/usr/bin/svcprop -c -t {1}".format(doorpath,
-                    self._target)
-                p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE)
-                out, err = p.communicate()
-                status, result = p.returncode, misc.force_str(out)
-                if status:
-                        raise SMFReadError(self._target,
-                            "{cmd}: {result}".format(**locals()))
+        cmd = "{0}/usr/bin/svcprop -c -t {1}".format(doorpath, self._target)
+        p = subprocess.Popen(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        out, err = p.communicate()
+        status, result = p.returncode, misc.force_str(out)
+        if status:
+            raise SMFReadError(
+                self._target, "{cmd}: {result}".format(**locals())
+            )
 
-                cfgdata = {}
+        cfgdata = {}
+        prop = None
+        for line in result.split("\n"):
+            if prop is None:
+                prop = line
+            else:
+                prop += line
+
+            # Output from svcprop can be spread over multiple lines
+            # if a property value has embedded newlines.  As such,
+            # look for the escape sequence at the end of the string
+            # to determine if output should be accumulated.
+            if re.search(r"(^|[^\\])(\\\\)*\\$", prop):
+                prop += "\n"
+                continue
+
+            if len(prop) < 2:
+                continue
+            n, t, v = prop.split(" ", 2)
+            pg, pn = n.split("/", 1)
+            if pg in self.__reserved_sections:
+                # SMF-specific groups ignored.
                 prop = None
-                for line in result.split("\n"):
-                        if prop is None:
-                                prop = line
-                        else:
-                                prop += line
+                continue
 
-                        # Output from svcprop can be spread over multiple lines
-                        # if a property value has embedded newlines.  As such,
-                        # look for the escape sequence at the end of the string
-                        # to determine if output should be accumulated.
-                        if re.search(r"(^|[^\\])(\\\\)*\\$", prop):
-                                prop += "\n"
-                                continue
+            if (t == "astring" or t == "ustring") and v == '""':
+                v = ""
+            cfgdata.setdefault(pg, {})
+            cfgdata[pg][pn] = v
+            prop = None
 
-                        if len(prop) < 2:
-                                continue
-                        n, t, v = prop.split(' ', 2)
-                        pg, pn = n.split('/', 1)
-                        if pg in self.__reserved_sections:
-                                # SMF-specific groups ignored.
-                                prop = None
-                                continue
+        # Reset to initial state to ensure the default set of properties
+        # and values exists so that any values not specified by the
+        # saved configuration or overrides will be correct.  This must
+        # be done after the version is determined above so that the
+        # saved configuration data can be merged with the correct
+        # configuration definition.
+        Config.reset(self, overrides=overrides)
 
-                        if (t == "astring" or t == "ustring") and v == '""':
-                                v = ''
-                        cfgdata.setdefault(pg, {})
-                        cfgdata[pg][pn] = v
-                        prop = None
+        # shlex.split() automatically does escaping for a list of values
+        # so no need to do it here.
+        for section, props in six.iteritems(cfgdata):
+            if section == "CONFIGURATION":
+                # Reserved for configuration file management.
+                continue
+            for prop, value in six.iteritems(props):
+                if section in overrides and prop in overrides[section]:
+                    continue
 
-                # Reset to initial state to ensure the default set of properties
-                # and values exists so that any values not specified by the
-                # saved configuration or overrides will be correct.  This must
-                # be done after the version is determined above so that the
-                # saved configuration data can be merged with the correct
-                # configuration definition.
-                Config.reset(self, overrides=overrides)
+                propobj = self._get_matching_property(section, prop)
+                if isinstance(propobj, PropList):
+                    nvalue = []
+                    for v in shlex.split(value):
+                        try:
+                            if six.PY2:
+                                v = v.encode("ascii")
+                            else:
+                                v = misc.force_str(v, "ascii")
+                        except ValueError:
+                            try:
+                                v = v.decode("utf-8")
+                            except ValueError:
+                                # Permit opaque
+                                # data.  It's
+                                # up to each
+                                # class whether
+                                # to allow it.
+                                pass
+                        nvalue.append(v)
+                    value = nvalue
+                else:
+                    # Allow shlex to unescape the value,
+                    # but rejoin all components as one.
+                    value = "".join(shlex.split(value))
 
-                # shlex.split() automatically does escaping for a list of values
-                # so no need to do it here.
-                for section, props in six.iteritems(cfgdata):
-                        if section == "CONFIGURATION":
-                                # Reserved for configuration file management.
-                                continue
-                        for prop, value in six.iteritems(props):
-                                if section in overrides and \
-                                    prop in overrides[section]:
-                                        continue
+                # Finally, set the property value.
+                try:
+                    propobj.value = value
+                except PropertyConfigError as e:
+                    if hasattr(e, "section") and not e.section:
+                        e.section = section
+                    raise
 
-                                propobj = self._get_matching_property(section,
-                                    prop)
-                                if isinstance(propobj, PropList):
-                                        nvalue = []
-                                        for v in shlex.split(value):
-                                                try:
-                                                        if six.PY2:
-                                                                v = v.encode(
-                                                                    "ascii")
-                                                        else:
-                                                                v = misc.force_str(
-                                                                    v, "ascii")
-                                                except ValueError:
-                                                        try:
-                                                                v = v.decode(
-                                                                    "utf-8")
-                                                        except ValueError:
-                                                                # Permit opaque
-                                                                # data.  It's
-                                                                # up to each
-                                                                # class whether
-                                                                # to allow it.
-                                                                pass
-                                                nvalue.append(v)
-                                        value = nvalue
-                                else:
-                                        # Allow shlex to unescape the value,
-                                        # but rejoin all components as one.
-                                        value = ''.join(shlex.split(value))
+    def reset(self, overrides=misc.EmptyDict):
+        """Discards current configuration state and returns the
+        configuration object to its initial state.
 
-                                # Finally, set the property value.
-                                try:
-                                        propobj.value = value
-                                except PropertyConfigError as e:
-                                        if hasattr(e, "section") and \
-                                            not e.section:
-                                                e.section = section
-                                        raise
+        'overrides' is an optional dictionary of property values
+        indexed by section name and property name.  If provided,
+        it will be used to override any default values initially
+        assigned during reset.
+        """
 
-        def reset(self, overrides=misc.EmptyDict):
-                """Discards current configuration state and returns the
-                configuration object to its initial state.
+        # Reload the configuration.
+        self.__read(overrides=overrides)
 
-                'overrides' is an optional dictionary of property values
-                indexed by section name and property name.  If provided,
-                it will be used to override any default values initially
-                assigned during reset.
-                """
+        if not overrides:
+            # Unless there were overrides, ignore any initial
+            # values for the purpose of determining whether a
+            # write should occur.  This isn't strictly correct,
+            # but is the desired behaviour in most cases.  This
+            # also matches the historical behaviour of the
+            # configuration classes used in pkg(7).
+            self._dirty = False
 
-                # Reload the configuration.
-                self.__read(overrides=overrides)
+    def write(self):
+        """Saves the current configuration object to the target
+        provided at initialization.
+        """
 
-                if not overrides:
-                        # Unless there were overrides, ignore any initial
-                        # values for the purpose of determining whether a
-                        # write should occur.  This isn't strictly correct,
-                        # but is the desired behaviour in most cases.  This
-                        # also matches the historical behaviour of the
-                        # configuration classes used in pkg(7).
-                        self._dirty = False
+        raise SMFWriteError(
+            self._target,
+            _(
+                "Writing configuration "
+                "data to SMF is not supported at this time."
+            ),
+        )
 
-        def write(self):
-                """Saves the current configuration object to the target
-                provided at initialization.
-                """
-
-                raise SMFWriteError(self._target, _("Writing configuration "
-                    "data to SMF is not supported at this time."))
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/cpiofile.py
+++ b/src/modules/cpiofile.py
@@ -33,12 +33,13 @@
 
 from __future__ import print_function
 
-#---------
+# ---------
 # Imports
-#---------
+# ---------
 import sys
-if sys.version > '3':
-        long = int
+
+if sys.version > "3":
+    long = int
 import os
 import stat
 import time
@@ -48,945 +49,991 @@ import pkg.pkgsubprocess as subprocess
 
 # cpio magic numbers
 # XXX matches actual cpio archives and /etc/magic, but not archives.h
-CMN_ASC = 0o70701        # Cpio Magic Number for ASCII header
-CMN_BIN = 0o70707        # Cpio Magic Number for Binary header
-CMN_BBS = 0o143561       # Cpio Magic Number for Byte-Swap header
-CMN_CRC = 0o70702        # Cpio Magic Number for CRC header
-CMS_ASC = "070701"       # Cpio Magic String for ASCII header
-CMS_CHR = "070707"       # Cpio Magic String for CHR (-c) header
-CMS_CRC = "070702"       # Cpio Magic String for CRC header
-CMS_LEN = 6              # Cpio Magic String length
+CMN_ASC = 0o70701  # Cpio Magic Number for ASCII header
+CMN_BIN = 0o70707  # Cpio Magic Number for Binary header
+CMN_BBS = 0o143561  # Cpio Magic Number for Byte-Swap header
+CMN_CRC = 0o70702  # Cpio Magic Number for CRC header
+CMS_ASC = "070701"  # Cpio Magic String for ASCII header
+CMS_CHR = "070707"  # Cpio Magic String for CHR (-c) header
+CMS_CRC = "070702"  # Cpio Magic String for CRC header
+CMS_LEN = 6  # Cpio Magic String length
 
 BLOCKSIZE = 512
 
+
 class CpioError(Exception):
-        """Base exception."""
-        pass
+    """Base exception."""
+
+    pass
+
+
 class ExtractError(CpioError):
-        """General exception for extract errors."""
-        pass
+    """General exception for extract errors."""
+
+    pass
+
+
 class ReadError(CpioError):
-        """Exception for unreadble cpio archives."""
-        pass
+    """Exception for unreadble cpio archives."""
+
+    pass
+
+
 class CompressionError(CpioError):
-        """Exception for unavailable compression methods."""
-        pass
+    """Exception for unavailable compression methods."""
+
+    pass
+
+
 class StreamError(CpioError):
-        """Exception for unsupported operations on stream-like CpioFiles."""
-        pass
+    """Exception for unsupported operations on stream-like CpioFiles."""
 
-#---------------------------
+    pass
+
+
+# ---------------------------
 # internal stream interface
-#---------------------------
+# ---------------------------
 class _LowLevelFile:
-        """Low-level file object. Supports reading and writing.
-        It is used instead of a regular file object for streaming
-        access.
-        """
+    """Low-level file object. Supports reading and writing.
+    It is used instead of a regular file object for streaming
+    access.
+    """
 
-        def __init__(self, name, mode):
-                mode = {
-                        "r": os.O_RDONLY,
+    def __init__(self, name, mode):
+        mode = {
+            "r": os.O_RDONLY,
             "w": os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                }[mode]
-                if hasattr(os, "O_BINARY"):
-                        mode |= os.O_BINARY
-                self.fd = os.open(name, mode)
+        }[mode]
+        if hasattr(os, "O_BINARY"):
+            mode |= os.O_BINARY
+        self.fd = os.open(name, mode)
 
-        def close(self):
-                os.close(self.fd)
+    def close(self):
+        os.close(self.fd)
 
-        def read(self, size):
-                return os.read(self.fd, size)
+    def read(self, size):
+        return os.read(self.fd, size)
 
-        def write(self, s):
-                os.write(self.fd, s)
+    def write(self, s):
+        os.write(self.fd, s)
+
 
 class _Stream:
-        """Class that serves as an adapter between CpioFile and
-        a stream-like object.  The stream-like object only
-        needs to have a read() or write() method and is accessed
-        blockwise.  Use of gzip or bzip2 compression is possible.
-        A stream-like object could be for example: sys.stdin,
-        sys.stdout, a socket, a tape device etc.
+    """Class that serves as an adapter between CpioFile and
+    a stream-like object.  The stream-like object only
+    needs to have a read() or write() method and is accessed
+    blockwise.  Use of gzip or bzip2 compression is possible.
+    A stream-like object could be for example: sys.stdin,
+    sys.stdout, a socket, a tape device etc.
 
-        _Stream is intended to be used only internally.
-        """
+    _Stream is intended to be used only internally.
+    """
 
-        def __init__(self, name, mode, type, fileobj, bufsize):
-                """Construct a _Stream object.
-                """
-                self._extfileobj = True
-                if fileobj is None:
-                        fileobj = _LowLevelFile(name, mode)
-                        self._extfileobj = False
+    def __init__(self, name, mode, type, fileobj, bufsize):
+        """Construct a _Stream object."""
+        self._extfileobj = True
+        if fileobj is None:
+            fileobj = _LowLevelFile(name, mode)
+            self._extfileobj = False
 
-                self.name = name or ""
-                self.mode = mode
-                self.type = type
-                self.fileobj = fileobj
-                self.bufsize = bufsize
-                self.buf = ""
-                self.pos = long(0)
-                self.closed = False
+        self.name = name or ""
+        self.mode = mode
+        self.type = type
+        self.fileobj = fileobj
+        self.bufsize = bufsize
+        self.buf = ""
+        self.pos = long(0)
+        self.closed = False
 
-                if type == "gz":
-                        try:
-                                import zlib
-                        except ImportError:
-                                raise CompressionError("zlib module is not available")
-                        self.zlib = zlib
-                        self.crc = zlib.crc32("")
-                        if mode == "r":
-                                self._init_read_gz()
-                        else:
-                                self._init_write_gz()
+        if type == "gz":
+            try:
+                import zlib
+            except ImportError:
+                raise CompressionError("zlib module is not available")
+            self.zlib = zlib
+            self.crc = zlib.crc32("")
+            if mode == "r":
+                self._init_read_gz()
+            else:
+                self._init_write_gz()
 
-                if type == "bz2":
-                        try:
-                                import bz2
-                        except ImportError:
-                                raise CompressionError("bz2 module is not available")
-                        if mode == "r":
-                                self.dbuf = ""
-                                self.cmp = bz2.BZ2Decompressor()
-                        else:
-                                self.cmp = bz2.BZ2Compressor()
-
-        def __del__(self):
-                if not self.closed:
-                        self.close()
-
-        def _init_write_gz(self):
-                """Initialize for writing with gzip compression.
-                """
-                self.cmp = self.zlib.compressobj(9, self.zlib.DEFLATED,
-                        -self.zlib.MAX_WBITS, self.zlib.DEF_MEM_LEVEL, 0)
-                timestamp = struct.pack("<L", long(time.time()))
-                self.__write("\037\213\010\010{0}\002\377".format(timestamp))
-                if self.name.endswith(".gz"):
-                        self.name = self.name[:-3]
-                self.__write(self.name + NUL)
-
-        def write(self, s):
-                """Write string s to the stream.
-                """
-                if self.type == "gz":
-                        self.crc = self.zlib.crc32(s, self.crc)
-                self.pos += len(s)
-                if self.type != "cpio":
-                        s = self.cmp.compress(s)
-                self.__write(s)
-
-        def __write(self, s):
-                """Write string s to the stream if a whole new block
-                is ready to be written.
-                """
-                self.buf += s
-                while len(self.buf) > self.bufsize:
-                        self.fileobj.write(self.buf[:self.bufsize])
-                        self.buf = self.buf[self.bufsize:]
-
-        def close(self):
-                """Close the _Stream object.  No operation should be
-                done on it afterwards.
-                """
-                if self.closed:
-                        return
-
-                if self.mode == "w" and self.type != "cpio":
-                        self.buf += self.cmp.flush()
-                if self.mode == "w" and self.buf:
-                        self.fileobj.write(self.buf)
-                        self.buf = ""
-                        if self.type == "gz":
-                                self.fileobj.write(struct.pack("<l", self.crc))
-                                self.fileobj.write(struct.pack("<L", self.pos &
-                                    long(0xffffFFFF)))
-                if not self._extfileobj:
-                        self.fileobj.close()
-
-                self.closed = True
-
-        def _init_read_gz(self):
-                """Initialize for reading a gzip compressed fileobj.
-                """
-                self.cmp = self.zlib.decompressobj(-self.zlib.MAX_WBITS)
+        if type == "bz2":
+            try:
+                import bz2
+            except ImportError:
+                raise CompressionError("bz2 module is not available")
+            if mode == "r":
                 self.dbuf = ""
+                self.cmp = bz2.BZ2Decompressor()
+            else:
+                self.cmp = bz2.BZ2Compressor()
 
-                # taken from gzip.GzipFile with some alterations
-                if self.__read(2) != "\037\213":
-                        raise ReadError("not a gzip file")
-                if self.__read(1) != "\010":
-                        raise CompressionError("unsupported compression method")
+    def __del__(self):
+        if not self.closed:
+            self.close()
 
-                flag = ord(self.__read(1))
-                self.__read(6)
+    def _init_write_gz(self):
+        """Initialize for writing with gzip compression."""
+        self.cmp = self.zlib.compressobj(
+            9,
+            self.zlib.DEFLATED,
+            -self.zlib.MAX_WBITS,
+            self.zlib.DEF_MEM_LEVEL,
+            0,
+        )
+        timestamp = struct.pack("<L", long(time.time()))
+        self.__write("\037\213\010\010{0}\002\377".format(timestamp))
+        if self.name.endswith(".gz"):
+            self.name = self.name[:-3]
+        self.__write(self.name + NUL)
 
-                if flag & 4:
-                        xlen = ord(self.__read(1)) + 256 * ord(self.__read(1))
-                        self.read(xlen)
-                if flag & 8:
-                        while True:
-                                s = self.__read(1)
-                                if not s or s == NUL:
-                                        break
-                if flag & 16:
-                        while True:
-                                s = self.__read(1)
-                                if not s or s == NUL:
-                                        break
-                if flag & 2:
-                        self._read(2)
+    def write(self, s):
+        """Write string s to the stream."""
+        if self.type == "gz":
+            self.crc = self.zlib.crc32(s, self.crc)
+        self.pos += len(s)
+        if self.type != "cpio":
+            s = self.cmp.compress(s)
+        self.__write(s)
 
-        def tell(self):
-                """Return the stream's file pointer position.
-                """
-                return self.pos
+    def __write(self, s):
+        """Write string s to the stream if a whole new block
+        is ready to be written.
+        """
+        self.buf += s
+        while len(self.buf) > self.bufsize:
+            self.fileobj.write(self.buf[: self.bufsize])
+            self.buf = self.buf[self.bufsize :]
 
-        def seek(self, pos=0):
-                """Set the stream's file pointer to pos. Negative seeking
-                is forbidden.
-                """
-                if pos - self.pos >= 0:
-                        blocks, remainder = divmod(pos - self.pos, self.bufsize)
-                        for i in range(blocks):
-                                self.read(self.bufsize)
-                        self.read(remainder)
-                else:
-                        raise StreamError("seeking backwards is not allowed")
-                return self.pos
+    def close(self):
+        """Close the _Stream object.  No operation should be
+        done on it afterwards.
+        """
+        if self.closed:
+            return
 
-        def read(self, size=None):
-                """Return the next size number of bytes from the stream.
-                If size is not defined, return all bytes of the stream
-                up to EOF.
-                """
-                if size is None:
-                        t = []
-                        while True:
-                                buf = self._read(self.bufsize)
-                                if not buf:
-                                        break
-                                t.append(buf)
-                        buf = "".join(t)
-                else:
-                        buf = self._read(size)
-                self.pos += len(buf)
-                # print("reading {0} bytes to {1} ({2})".format(size, self.pos, self.fileobj.tell()))
-                return buf
+        if self.mode == "w" and self.type != "cpio":
+            self.buf += self.cmp.flush()
+        if self.mode == "w" and self.buf:
+            self.fileobj.write(self.buf)
+            self.buf = ""
+            if self.type == "gz":
+                self.fileobj.write(struct.pack("<l", self.crc))
+                self.fileobj.write(
+                    struct.pack("<L", self.pos & long(0xFFFFFFFF))
+                )
+        if not self._extfileobj:
+            self.fileobj.close()
 
-        def _read(self, size):
-                """Return size bytes from the stream.
-                """
-                if self.type == "cpio":
-                        return self.__read(size)
+        self.closed = True
 
-                c = len(self.dbuf)
-                t = [self.dbuf]
-                while c < size:
-                        buf = self.__read(self.bufsize)
-                        if not buf:
-                                break
-                        buf = self.cmp.decompress(buf)
-                        t.append(buf)
-                        c += len(buf)
-                t = "".join(t)
-                self.dbuf = t[size:]
-                return t[:size]
+    def _init_read_gz(self):
+        """Initialize for reading a gzip compressed fileobj."""
+        self.cmp = self.zlib.decompressobj(-self.zlib.MAX_WBITS)
+        self.dbuf = ""
 
-        def __read(self, size):
-                """Return size bytes from stream. If internal buffer is empty,
-                read another block from the stream.
-                """
-                c = len(self.buf)
-                t = [self.buf]
-                while c < size:
-                        buf = self.fileobj.read(self.bufsize)
-                        if not buf:
-                                break
-                        t.append(buf)
-                        c += len(buf)
-                t = "".join(t)
-                self.buf = t[size:]
-                return t[:size]
+        # taken from gzip.GzipFile with some alterations
+        if self.__read(2) != "\037\213":
+            raise ReadError("not a gzip file")
+        if self.__read(1) != "\010":
+            raise CompressionError("unsupported compression method")
+
+        flag = ord(self.__read(1))
+        self.__read(6)
+
+        if flag & 4:
+            xlen = ord(self.__read(1)) + 256 * ord(self.__read(1))
+            self.read(xlen)
+        if flag & 8:
+            while True:
+                s = self.__read(1)
+                if not s or s == NUL:
+                    break
+        if flag & 16:
+            while True:
+                s = self.__read(1)
+                if not s or s == NUL:
+                    break
+        if flag & 2:
+            self._read(2)
+
+    def tell(self):
+        """Return the stream's file pointer position."""
+        return self.pos
+
+    def seek(self, pos=0):
+        """Set the stream's file pointer to pos. Negative seeking
+        is forbidden.
+        """
+        if pos - self.pos >= 0:
+            blocks, remainder = divmod(pos - self.pos, self.bufsize)
+            for i in range(blocks):
+                self.read(self.bufsize)
+            self.read(remainder)
+        else:
+            raise StreamError("seeking backwards is not allowed")
+        return self.pos
+
+    def read(self, size=None):
+        """Return the next size number of bytes from the stream.
+        If size is not defined, return all bytes of the stream
+        up to EOF.
+        """
+        if size is None:
+            t = []
+            while True:
+                buf = self._read(self.bufsize)
+                if not buf:
+                    break
+                t.append(buf)
+            buf = "".join(t)
+        else:
+            buf = self._read(size)
+        self.pos += len(buf)
+        # print("reading {0} bytes to {1} ({2})".format(size, self.pos, self.fileobj.tell()))
+        return buf
+
+    def _read(self, size):
+        """Return size bytes from the stream."""
+        if self.type == "cpio":
+            return self.__read(size)
+
+        c = len(self.dbuf)
+        t = [self.dbuf]
+        while c < size:
+            buf = self.__read(self.bufsize)
+            if not buf:
+                break
+            buf = self.cmp.decompress(buf)
+            t.append(buf)
+            c += len(buf)
+        t = "".join(t)
+        self.dbuf = t[size:]
+        return t[:size]
+
+    def __read(self, size):
+        """Return size bytes from stream. If internal buffer is empty,
+        read another block from the stream.
+        """
+        c = len(self.buf)
+        t = [self.buf]
+        while c < size:
+            buf = self.fileobj.read(self.bufsize)
+            if not buf:
+                break
+            t.append(buf)
+            c += len(buf)
+        t = "".join(t)
+        self.buf = t[size:]
+        return t[:size]
+
+
 # class _Stream
 
-#------------------------
+
+# ------------------------
 # Extraction file object
-#------------------------
+# ------------------------
 class ExFileObject(object):
-        """File-like object for reading an archive member.
-           Is returned by CpioFile.extractfile().
+    """File-like object for reading an archive member.
+    Is returned by CpioFile.extractfile().
+    """
+
+    def __init__(self, cpiofile, cpioinfo):
+        self.fileobj = cpiofile.fileobj
+        self.name = cpioinfo.name
+        self.mode = "r"
+        self.closed = False
+        self.offset = cpioinfo.offset_data
+        self.size = cpioinfo.size
+        self.pos = long(0)
+        self.linebuffer = ""
+
+    def read(self, size=None):
+        if self.closed:
+            raise ValueError("file is closed")
+        self.fileobj.seek(self.offset + self.pos)
+        bytesleft = self.size - self.pos
+        if size is None:
+            bytestoread = bytesleft
+        else:
+            bytestoread = min(size, bytesleft)
+        self.pos += bytestoread
+        return self.fileobj.read(bytestoread)
+
+    def readline(self, size=-1):
+        """Read a line with approx. size. If size is negative,
+        read a whole line. readline() and read() must not
+        be mixed up (!).
         """
+        if size < 0:
+            size = sys.maxsize
 
-        def __init__(self, cpiofile, cpioinfo):
-                self.fileobj    = cpiofile.fileobj
-                self.name       = cpioinfo.name
-                self.mode       = "r"
-                self.closed     = False
-                self.offset     = cpioinfo.offset_data
-                self.size       = cpioinfo.size
-                self.pos        = long(0)
-                self.linebuffer = ""
-
-        def read(self, size=None):
-                if self.closed:
-                        raise ValueError("file is closed")
-                self.fileobj.seek(self.offset + self.pos)
-                bytesleft = self.size - self.pos
-                if size is None:
-                        bytestoread = bytesleft
-                else:
-                        bytestoread = min(size, bytesleft)
-                self.pos += bytestoread
-                return self.fileobj.read(bytestoread)
-
-        def readline(self, size=-1):
-                """Read a line with approx. size. If size is negative,
-                read a whole line. readline() and read() must not
-                be mixed up (!).
-                """
-                if size < 0:
-                        size = sys.maxsize
-
+        nl = self.linebuffer.find("\n")
+        if nl >= 0:
+            nl = min(nl, size)
+        else:
+            size -= len(self.linebuffer)
+            while nl < 0 and size > 0:
+                buf = self.read(min(size, 100))
+                if not buf:
+                    break
+                self.linebuffer += buf
+                size -= len(buf)
                 nl = self.linebuffer.find("\n")
-                if nl >= 0:
-                        nl = min(nl, size)
-                else:
-                        size -= len(self.linebuffer)
-                        while (nl < 0 and size > 0):
-                                buf = self.read(min(size, 100))
-                                if not buf:
-                                        break
-                                self.linebuffer += buf
-                                size -= len(buf)
-                                nl = self.linebuffer.find("\n")
-                        if nl == -1:
-                                s = self.linebuffer
-                                self.linebuffer = ""
-                                return s
-                buf = self.linebuffer[:nl]
-                self.linebuffer = self.linebuffer[nl + 1:]
-                while buf[-1:] == "\r":
-                        buf = buf[:-1]
-                return buf + "\n"
-
-        def readlines(self):
-                """Return a list with all (following) lines.
-                """
-                result = []
-                while True:
-                        line = self.readline()
-                        if not line: break
-                        result.append(line)
-                return result
-
-        def tell(self):
-                """Return the current file position.
-                """
-                return self.pos
-
-        def seek(self, pos, whence=0):
-                """Seek to a position in the file.
-                """
+            if nl == -1:
+                s = self.linebuffer
                 self.linebuffer = ""
-                if whence == 0:
-                        self.pos = min(max(pos, 0), self.size)
-                elif whence == 1:
-                        if pos < 0:
-                                self.pos = max(self.pos + pos, 0)
-                        else:
-                                self.pos = min(self.pos + pos, self.size)
-                elif whence == 2:
-                        self.pos = max(min(self.size + pos, self.size), 0)
+                return s
+        buf = self.linebuffer[:nl]
+        self.linebuffer = self.linebuffer[nl + 1 :]
+        while buf[-1:] == "\r":
+            buf = buf[:-1]
+        return buf + "\n"
 
-        def close(self):
-                """Close the file object.
-                """
-                self.closed = True
-#class ExFileObject
+    def readlines(self):
+        """Return a list with all (following) lines."""
+        result = []
+        while True:
+            line = self.readline()
+            if not line:
+                break
+            result.append(line)
+        return result
 
-#------------------
+    def tell(self):
+        """Return the current file position."""
+        return self.pos
+
+    def seek(self, pos, whence=0):
+        """Seek to a position in the file."""
+        self.linebuffer = ""
+        if whence == 0:
+            self.pos = min(max(pos, 0), self.size)
+        elif whence == 1:
+            if pos < 0:
+                self.pos = max(self.pos + pos, 0)
+            else:
+                self.pos = min(self.pos + pos, self.size)
+        elif whence == 2:
+            self.pos = max(min(self.size + pos, self.size), 0)
+
+    def close(self):
+        """Close the file object."""
+        self.closed = True
+
+
+# class ExFileObject
+
+
+# ------------------
 # Exported Classes
-#------------------
+# ------------------
 class CpioInfo(object):
-        """Informational class which holds the details about an
-        archive member given by a cpio header block.
-        CpioInfo objects are returned by CpioFile.getmember(),
-        CpioFile.getmembers() and CpioFile.getcpioinfo() and are
-        usually created internally.
+    """Informational class which holds the details about an
+    archive member given by a cpio header block.
+    CpioInfo objects are returned by CpioFile.getmember(),
+    CpioFile.getmembers() and CpioFile.getcpioinfo() and are
+    usually created internally.
+    """
+
+    def __init__(self, name="", cpiofile=None):
+        """Construct a CpioInfo object. name is the optional name
+        of the member.
         """
 
-        def __init__(self, name="", cpiofile=None):
-                """Construct a CpioInfo object. name is the optional name
-                of the member.
-                """
+        self.name = name
+        self.mode = 0o666
+        self.uid = 0
+        self.gid = 0
+        self.size = 0
+        self.mtime = 0
+        self.chksum = 0
+        self.type = "0"
+        self.linkname = ""
+        self.uname = "user"
+        self.gname = "group"
+        self.devmajor = 0
+        self.devminor = 0
+        self.prefix = ""
+        self.cpiofile = cpiofile
 
-                self.name       = name
-                self.mode       = 0o666
-                self.uid        = 0
-                self.gid        = 0
-                self.size       = 0
-                self.mtime      = 0
-                self.chksum     = 0
-                self.type       = "0"
-                self.linkname   = ""
-                self.uname      = "user"
-                self.gname      = "group"
-                self.devmajor   = 0
-                self.devminor   = 0
-                self.prefix     = ""
-                self.cpiofile   = cpiofile
+        self.offset = 0
+        self.offset_data = 0
+        self.padding = 1
 
-                self.offset     = 0
-                self.offset_data = 0
-                self.padding    = 1
+    def __repr__(self):
+        return "<{0} {1!r} at {2:#x}>".format(
+            self.__class__.__name__, self.name, id(self)
+        )
 
-        def __repr__(self):
-                return "<{0} {1!r} at {2:#x}>".format(
-                    self.__class__.__name__, self.name, id(self))
+    @classmethod
+    def frombuf(cls, buf, fileobj, cpiofile=None):
+        """Construct a CpioInfo object from a buffer.  The buffer should
+        be at least 6 octets long to determine the type of archive.  The
+        rest of the data will be read in on demand.
+        """
+        cpioinfo = cls(cpiofile=cpiofile)
 
-        @classmethod
-        def frombuf(cls, buf, fileobj, cpiofile=None):
-                """Construct a CpioInfo object from a buffer.  The buffer should
-                be at least 6 octets long to determine the type of archive.  The
-                rest of the data will be read in on demand.
-                """
-                cpioinfo = cls(cpiofile=cpiofile)
+        # Read enough for the ASCII magic
+        if buf[:6] == CMS_ASC:
+            hdrtype = "CMS_ASC"
+        elif buf[:6] == CMS_CHR:
+            hdrtype = "CMS_CHR"
+        elif buf[:6] == CMS_CRC:
+            hdrtype = "CMS_CRC"
+        else:
+            b = struct.unpack("h", buf[:2])[0]
+            if b == CMN_ASC:
+                hdrtype = "CMN_ASC"
+            elif b == CMN_BIN:
+                hdrtype = "CMN_BIN"
+            elif b == CMN_BBS:
+                hdrtype = "CMN_BBS"
+            elif b == CMN_CRC:
+                hdrtype = "CMN_CRC"
+            else:
+                raise ValueError("invalid cpio header")
 
-                # Read enough for the ASCII magic
-                if buf[:6] == CMS_ASC:
-                        hdrtype = "CMS_ASC"
-                elif buf[:6] == CMS_CHR:
-                        hdrtype = "CMS_CHR"
-                elif buf[:6] == CMS_CRC:
-                        hdrtype = "CMS_CRC"
-                else:
-                        b = struct.unpack("h", buf[:2])[0]
-                        if b == CMN_ASC:
-                                hdrtype = "CMN_ASC"
-                        elif b == CMN_BIN:
-                                hdrtype = "CMN_BIN"
-                        elif b == CMN_BBS:
-                                hdrtype = "CMN_BBS"
-                        elif b == CMN_CRC:
-                                hdrtype = "CMN_CRC"
-                        else:
-                                raise ValueError("invalid cpio header")
+        if hdrtype == "CMN_BIN":
+            buf += fileobj.read(26 - len(buf))
+            (
+                magic,
+                dev,
+                inode,
+                cpioinfo.mode,
+                cpioinfo.uid,
+                cpioinfo.gid,
+                nlink,
+                rdev,
+                cpioinfo.mtime,
+                namesize,
+                cpioinfo.size,
+            ) = struct.unpack("=hhHHHHhhihi", buf[:26])
+            buf += fileobj.read(namesize)
+            cpioinfo.name = buf[26 : 26 + namesize - 1]
+            # Header is padded to halfword boundaries
+            cpioinfo.padding = 2
+            cpioinfo.hdrsize = 26 + namesize + (namesize % 2)
+            buf += fileobj.read(namesize % 2)
+        elif hdrtype == "CMS_ASC":
+            buf += fileobj.read(110 - len(buf))
+            cpioinfo.mode = int(buf[14:22], 16)
+            cpioinfo.uid = int(buf[22:30], 16)
+            cpioinfo.gid = int(buf[30:38], 16)
+            cpioinfo.mtime = int(buf[46:54], 16)
+            cpioinfo.size = int(buf[54:62], 16)
+            cpioinfo.devmajor = int(buf[62:70], 16)
+            cpioinfo.devminor = int(buf[70:78], 16)
+            namesize = int(buf[94:102], 16)
+            cpioinfo.chksum = int(buf[102:110], 16)
+            buf += fileobj.read(namesize)
+            cpioinfo.name = buf[110 : 110 + namesize - 1]
+            cpioinfo.hdrsize = 110 + namesize
+            # Pad to the nearest 4 byte block, 0-3 bytes.
+            cpioinfo.hdrsize += 4 - ((cpioinfo.hdrsize - 1) % 4) - 1
+            buf += fileobj.read(cpioinfo.hdrsize - 110 - namesize)
+            cpioinfo.padding = 4
+        else:
+            raise ValueError("unsupported cpio header")
 
-                if hdrtype == "CMN_BIN":
-                        buf += fileobj.read(26 - len(buf))
-                        (magic, dev, inode, cpioinfo.mode, cpioinfo.uid,
-                        cpioinfo.gid, nlink, rdev, cpioinfo.mtime, namesize,
-                        cpioinfo.size) = struct.unpack("=hhHHHHhhihi", buf[:26])
-                        buf += fileobj.read(namesize)
-                        cpioinfo.name = buf[26:26 + namesize - 1]
-                        # Header is padded to halfword boundaries
-                        cpioinfo.padding = 2
-                        cpioinfo.hdrsize = 26 + namesize + (namesize % 2)
-                        buf += fileobj.read(namesize % 2)
-                elif hdrtype == "CMS_ASC":
-                        buf += fileobj.read(110 - len(buf))
-                        cpioinfo.mode = int(buf[14:22], 16)
-                        cpioinfo.uid  = int(buf[22:30], 16)
-                        cpioinfo.gid  = int(buf[30:38], 16)
-                        cpioinfo.mtime = int(buf[46:54], 16)
-                        cpioinfo.size = int(buf[54:62], 16)
-                        cpioinfo.devmajor = int(buf[62:70], 16)
-                        cpioinfo.devminor = int(buf[70:78], 16)
-                        namesize = int(buf[94:102], 16)
-                        cpioinfo.chksum = int(buf[102:110], 16)
-                        buf += fileobj.read(namesize)
-                        cpioinfo.name = buf[110:110 + namesize - 1]
-                        cpioinfo.hdrsize = 110 + namesize
-                        # Pad to the nearest 4 byte block, 0-3 bytes.
-                        cpioinfo.hdrsize += 4 - ((cpioinfo.hdrsize - 1) % 4) - 1
-                        buf += fileobj.read(cpioinfo.hdrsize - 110 - namesize)
-                        cpioinfo.padding = 4
-                else:
-                        raise ValueError("unsupported cpio header")
+        return cpioinfo
 
-                return cpioinfo
+    def isreg(self):
+        return stat.S_ISREG(self.mode)
 
-        def isreg(self):
-                return stat.S_ISREG(self.mode)
+    # This isn't in tarfile, but it's too useful.  It's required
+    # modifications to frombuf(), as well as CpioFile.next() to pass the
+    # CpioFile object in.  I'm not sure that isn't poor OO style.
+    def extractfile(self):
+        """Return a file-like object which can be read to extract the contents."""
 
-        # This isn't in tarfile, but it's too useful.  It's required
-        # modifications to frombuf(), as well as CpioFile.next() to pass the
-        # CpioFile object in.  I'm not sure that isn't poor OO style.
-        def extractfile(self):
-                """Return a file-like object which can be read to extract the contents.
-                """
+        if self.isreg():
+            return ExFileObject(self.cpiofile, self)
+        else:
+            return None
 
-                if self.isreg():
-                        return ExFileObject(self.cpiofile, self)
-                else:
-                        return None
 
 class CpioFile(object):
-        """The CpioFile Class provides an interface to cpio archives.
+    """The CpioFile Class provides an interface to cpio archives."""
+
+    fileobject = ExFileObject
+
+    def __init__(self, name=None, mode="r", fileobj=None, cfobj=None):
+        """Open an (uncompressed) cpio archive `name'. `mode' is either 'r' to
+        read from an existing archive, 'a' to append data to an existing
+        file or 'w' to create a new file overwriting an existing one.  `mode'
+        defaults to 'r'.
+        If  `fileobj' is given, it is used for reading or writing data.  If it
+        can be determined, `mode' is overridden by `fileobj's mode.
+        `fileobj' is not closed, when CpioFile is closed.
+        """
+        self.name = name
+
+        if len(mode) > 1 or mode not in "raw":
+            raise ValueError("mode must be 'r', 'a' or 'w'")
+        self._mode = mode
+        self.mode = {"r": "rb", "a": "r+b", "w": "wb"}[mode]
+
+        if not fileobj and not cfobj:
+            fileobj = open(self.name, self.mode)
+            self._extfileobj = False
+        else:
+            # Copy constructor: just copy fileobj over and reset the
+            # _Stream object's idea of where we are back to the
+            # beginning.  Everything else will be reset normally.
+            # XXX clear closed flag?
+            if cfobj:
+                fileobj = cfobj.fileobj
+                fileobj.pos = 0
+            if self.name is None and hasattr(fileobj, "name"):
+                self.name = fileobj.name
+            if hasattr(fileobj, "mode"):
+                self.mode = fileobj.mode
+            self._extfileobj = True
+        self.fileobj = fileobj
+
+        # Init datastructures
+        self.closed = False
+        self.members = []  # list of members as CpioInfo objects
+        self._loaded = False  # flag if all members have been read
+        self.offset = long(0)  # current position in the archive file
+
+        if self._mode == "r":
+            self.firstmember = None
+            self.firstmember = next(self)
+
+        if self._mode == "a":
+            # Move to the end of the archive,
+            # before the first empty block.
+            self.firstmember = None
+            while True:
+                try:
+                    cpioinfo = next(self)
+                except ReadError:
+                    self.fileobj.seek(0)
+                    break
+                if cpioinfo is None:
+                    self.fileobj.seek(-BLOCKSIZE, 1)
+                    break
+
+        if self._mode in "aw":
+            self._loaded = True
+
+    # --------------------------------------------------------------------------
+    # Below are the classmethods which act as alternate constructors to the
+    # CpioFile class. The open() method is the only one that is needed for
+    # public use; it is the "super"-constructor and is able to select an
+    # adequate "sub"-constructor for a particular compression using the mapping
+    # from OPEN_METH.
+    #
+    # This concept allows one to subclass CpioFile without losing the comfort of
+    # the super-constructor. A sub-constructor is registered and made available
+    # by adding it to the mapping in OPEN_METH.
+    @classmethod
+    def open(cls, name=None, mode="r", fileobj=None, bufsize=20 * 512):
+        """Open a cpio archive for reading, writing or appending. Return
+        an appropriate CpioFile class.
+
+        mode:
+        'r'             open for reading with transparent compression
+        'r:'            open for reading exclusively uncompressed
+        'r:gz'          open for reading with gzip compression
+        'r:bz2'         open for reading with bzip2 compression
+        'a' or 'a:'     open for appending
+        'w' or 'w:'     open for writing without compression
+        'w:gz'          open for writing with gzip compression
+        'w:bz2'         open for writing with bzip2 compression
+        'r|'            open an uncompressed stream of cpio blocks for reading
+        'r|gz'          open a gzip compressed stream of cpio blocks
+        'r|bz2'         open a bzip2 compressed stream of cpio blocks
+        'w|'            open an uncompressed stream for writing
+        'w|gz'          open a gzip compressed stream for writing
+        'w|bz2'         open a bzip2 compressed stream for writing
         """
 
-        fileobject = ExFileObject
+        if not name and not fileobj:
+            raise ValueError("nothing to open")
 
-        def __init__(self, name=None, mode="r", fileobj=None, cfobj=None):
-                """Open an (uncompressed) cpio archive `name'. `mode' is either 'r' to
-                read from an existing archive, 'a' to append data to an existing
-                file or 'w' to create a new file overwriting an existing one.  `mode'
-                defaults to 'r'.
-                If  `fileobj' is given, it is used for reading or writing data.  If it
-                can be determined, `mode' is overridden by `fileobj's mode.
-                `fileobj' is not closed, when CpioFile is closed.
-                """
-                self.name = name
+        if ":" in mode:
+            filemode, comptype = mode.split(":", 1)
+            filemode = filemode or "r"
+            comptype = comptype or "cpio"
 
-                if len(mode) > 1 or mode not in "raw":
-                        raise ValueError("mode must be 'r', 'a' or 'w'")
-                self._mode = mode
-                self.mode = {"r": "rb", "a": "r+b", "w": "wb"}[mode]
+            # Select the *open() function according to
+            # given compression.
+            if comptype in cls.OPEN_METH:
+                func = getattr(cls, cls.OPEN_METH[comptype])
+            else:
+                raise CompressionError(
+                    "unknown compression type {0!r}".format(comptype)
+                )
+            return func(name, filemode, fileobj)
 
-                if not fileobj and not cfobj:
-                        fileobj = open(self.name, self.mode)
-                        self._extfileobj = False
-                else:
-                        # Copy constructor: just copy fileobj over and reset the
-                        # _Stream object's idea of where we are back to the
-                        # beginning.  Everything else will be reset normally.
-                        # XXX clear closed flag?
-                        if cfobj:
-                                fileobj = cfobj.fileobj
-                                fileobj.pos = 0
-                        if self.name is None and hasattr(fileobj, "name"):
-                                self.name = fileobj.name
-                        if hasattr(fileobj, "mode"):
-                                self.mode = fileobj.mode
-                        self._extfileobj = True
-                self.fileobj = fileobj
+        elif "|" in mode:
+            filemode, comptype = mode.split("|", 1)
+            filemode = filemode or "r"
+            comptype = comptype or "cpio"
 
-                # Init datastructures
-                self.closed     = False
-                self.members    = []    # list of members as CpioInfo objects
-                self._loaded    = False # flag if all members have been read
-                self.offset     = long(0)    # current position in the archive file
+            if filemode not in "rw":
+                raise ValueError("mode must be 'r' or 'w'")
 
-                if self._mode == "r":
-                        self.firstmember = None
-                        self.firstmember = next(self)
+            t = cls(
+                name,
+                filemode,
+                _Stream(name, filemode, comptype, fileobj, bufsize),
+            )
+            t._extfileobj = False
+            return t
 
-                if self._mode == "a":
-                        # Move to the end of the archive,
-                        # before the first empty block.
-                        self.firstmember = None
-                        while True:
-                                try:
-                                        cpioinfo = next(self)
-                                except ReadError:
-                                        self.fileobj.seek(0)
-                                        break
-                                if cpioinfo is None:
-                                        self.fileobj.seek(- BLOCKSIZE, 1)
-                                        break
-
-                if self._mode in "aw":
-                        self._loaded = True
-
-        #--------------------------------------------------------------------------
-        # Below are the classmethods which act as alternate constructors to the
-        # CpioFile class. The open() method is the only one that is needed for
-        # public use; it is the "super"-constructor and is able to select an
-        # adequate "sub"-constructor for a particular compression using the mapping
-        # from OPEN_METH.
-        #
-        # This concept allows one to subclass CpioFile without losing the comfort of
-        # the super-constructor. A sub-constructor is registered and made available
-        # by adding it to the mapping in OPEN_METH.
-        @classmethod
-        def open(cls, name=None, mode="r", fileobj=None, bufsize=20*512):
-                """Open a cpio archive for reading, writing or appending. Return
-                an appropriate CpioFile class.
-
-                mode:
-                'r'             open for reading with transparent compression
-                'r:'            open for reading exclusively uncompressed
-                'r:gz'          open for reading with gzip compression
-                'r:bz2'         open for reading with bzip2 compression
-                'a' or 'a:'     open for appending
-                'w' or 'w:'     open for writing without compression
-                'w:gz'          open for writing with gzip compression
-                'w:bz2'         open for writing with bzip2 compression
-                'r|'            open an uncompressed stream of cpio blocks for reading
-                'r|gz'          open a gzip compressed stream of cpio blocks
-                'r|bz2'         open a bzip2 compressed stream of cpio blocks
-                'w|'            open an uncompressed stream for writing
-                'w|gz'          open a gzip compressed stream for writing
-                'w|bz2'         open a bzip2 compressed stream for writing
-                """
-
-                if not name and not fileobj:
-                        raise ValueError("nothing to open")
-
-                if ":" in mode:
-                        filemode, comptype = mode.split(":", 1)
-                        filemode = filemode or "r"
-                        comptype = comptype or "cpio"
-
-                        # Select the *open() function according to
-                        # given compression.
-                        if comptype in cls.OPEN_METH:
-                                func = getattr(cls, cls.OPEN_METH[comptype])
-                        else:
-                                raise CompressionError("unknown compression type {0!r}".format(comptype))
-                        return func(name, filemode, fileobj)
-
-                elif "|" in mode:
-                        filemode, comptype = mode.split("|", 1)
-                        filemode = filemode or "r"
-                        comptype = comptype or "cpio"
-
-                        if filemode not in "rw":
-                                raise ValueError("mode must be 'r' or 'w'")
-
-                        t = cls(name, filemode,
-                                _Stream(name, filemode, comptype, fileobj, bufsize))
-                        t._extfileobj = False
-                        return t
-
-                elif mode == "r":
-                        # Find out which *open() is appropriate for opening the file.
-                        for comptype in cls.OPEN_METH:
-                                func = getattr(cls, cls.OPEN_METH[comptype])
-                                try:
-                                        return func(name, "r", fileobj)
-                                except (ReadError, CompressionError):
-                                        continue
-                        raise ReadError("file could not be opened successfully")
-
-                elif mode in "aw":
-                        return cls.cpioopen(name, mode, fileobj)
-
-                raise ValueError("undiscernible mode")
-
-        @classmethod
-        def cpioopen(cls, name, mode="r", fileobj=None):
-                """Open uncompressed cpio archive name for reading or writing.
-                """
-                if len(mode) > 1 or mode not in "raw":
-                        raise ValueError("mode must be 'r', 'a' or 'w'")
-                return cls(name, mode, fileobj)
-
-        @classmethod
-        def gzopen(cls, name, mode="r", fileobj=None, compresslevel=9):
-                """Open gzip compressed cpio archive name for reading or writing.
-                Appending is not allowed.
-                """
-                if len(mode) > 1 or mode not in "rw":
-                        raise ValueError("mode must be 'r' or 'w'")
-
+        elif mode == "r":
+            # Find out which *open() is appropriate for opening the file.
+            for comptype in cls.OPEN_METH:
+                func = getattr(cls, cls.OPEN_METH[comptype])
                 try:
-                        import gzip
-                        gzip.GzipFile
-                except (ImportError, AttributeError):
-                        raise CompressionError("gzip module is not available")
+                    return func(name, "r", fileobj)
+                except (ReadError, CompressionError):
+                    continue
+            raise ReadError("file could not be opened successfully")
 
-                pre, ext = os.path.splitext(name)
-                pre = os.path.basename(pre)
-                if ext == ".gz":
-                        ext = ""
-                cpioname = pre + ext
+        elif mode in "aw":
+            return cls.cpioopen(name, mode, fileobj)
 
-                if fileobj is None:
-                        fileobj = open(name, mode + "b")
+        raise ValueError("undiscernible mode")
 
-                if mode != "r":
-                        name = tarname
+    @classmethod
+    def cpioopen(cls, name, mode="r", fileobj=None):
+        """Open uncompressed cpio archive name for reading or writing."""
+        if len(mode) > 1 or mode not in "raw":
+            raise ValueError("mode must be 'r', 'a' or 'w'")
+        return cls(name, mode, fileobj)
 
-                try:
-                        t = cls.cpioopen(cpioname, mode,
-                                gzip.GzipFile(name, mode, compresslevel,
-                                        fileobj))
-                except IOError:
-                        raise ReadError("not a gzip file")
-                t._extfileobj = False
-                return t
+    @classmethod
+    def gzopen(cls, name, mode="r", fileobj=None, compresslevel=9):
+        """Open gzip compressed cpio archive name for reading or writing.
+        Appending is not allowed.
+        """
+        if len(mode) > 1 or mode not in "rw":
+            raise ValueError("mode must be 'r' or 'w'")
 
-        @classmethod
-        def bz2open(cls, name, mode="r", fileobj=None, compresslevel=9):
-                """Open bzip2 compressed cpio archive name for reading or writing.
-                Appending is not allowed.
-                """
-                if len(mode) > 1 or mode not in "rw":
-                        raise ValueError("mode must be 'r' or 'w'.")
+        try:
+            import gzip
 
-                try:
-                        import bz2
-                except ImportError:
-                        raise CompressionError("bz2 module is not available")
+            gzip.GzipFile
+        except (ImportError, AttributeError):
+            raise CompressionError("gzip module is not available")
 
-                pre, ext = os.path.splitext(name)
-                pre = os.path.basename(pre)
-                if ext == ".bz2":
-                        ext = ""
-                cpioname = pre + ext
+        pre, ext = os.path.splitext(name)
+        pre = os.path.basename(pre)
+        if ext == ".gz":
+            ext = ""
+        cpioname = pre + ext
 
-                if fileobj is not None:
-                        raise ValueError("no support for external file objects")
+        if fileobj is None:
+            fileobj = open(name, mode + "b")
 
-                try:
-                        t = cls.cpioopen(cpioname, mode,
-                            bz2.BZ2File(name, mode, compresslevel=compresslevel))
-                except IOError:
-                        raise ReadError("not a bzip2 file")
-                t._extfileobj = False
-                return t
+        if mode != "r":
+            name = tarname
 
-        @classmethod
-        def p7zopen(cls, name, mode="r", fileobj=None):
-                """Open 7z compressed cpio archive name for reading, writing.
+        try:
+            t = cls.cpioopen(
+                cpioname,
+                mode,
+                gzip.GzipFile(name, mode, compresslevel, fileobj),
+            )
+        except IOError:
+            raise ReadError("not a gzip file")
+        t._extfileobj = False
+        return t
 
-                Appending is not allowed
-                """
-                if len(mode) > 1 or mode not in "rw":
-                        raise ValueError("mode must be 'r' or 'w'.")
+    @classmethod
+    def bz2open(cls, name, mode="r", fileobj=None, compresslevel=9):
+        """Open bzip2 compressed cpio archive name for reading or writing.
+        Appending is not allowed.
+        """
+        if len(mode) > 1 or mode not in "rw":
+            raise ValueError("mode must be 'r' or 'w'.")
 
-                pre, ext = os.path.splitext(name)
-                pre = os.path.basename(pre)
-                if ext == ".7z":
-                        ext = ""
-                cpioname = pre + ext
+        try:
+            import bz2
+        except ImportError:
+            raise CompressionError("bz2 module is not available")
 
-                try:
-                        # To extract: 7z e -so <fname>
-                        # To create an archive: 7z a -si <fname>
-                        cmd = "7z {0} -{1} {2}".format(
-                            {'r':'e',  'w':'a'}[mode],
-                            {'r':'so', 'w':'si'}[mode],
-                            name)
-                        p = subprocess.Popen(cmd.split(),
-                            stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-                        pobj = p.stdout
-                        if mode == "w":
-                                pobj = p.stdin
+        pre, ext = os.path.splitext(name)
+        pre = os.path.basename(pre)
+        if ext == ".bz2":
+            ext = ""
+        cpioname = pre + ext
 
-                        comptype = "cpio"
-                        bufsize = 20*512
+        if fileobj is not None:
+            raise ValueError("no support for external file objects")
 
-                        obj = _Stream(cpioname, mode, comptype, pobj, bufsize)
-                        t = cls.cpioopen(cpioname, mode, obj)
-                except IOError:
-                        raise ReadError("read/write via 7z failed")
-                t._extfileobj = False
-                return t
+        try:
+            t = cls.cpioopen(
+                cpioname,
+                mode,
+                bz2.BZ2File(name, mode, compresslevel=compresslevel),
+            )
+        except IOError:
+            raise ReadError("not a bzip2 file")
+        t._extfileobj = False
+        return t
 
-        # All *open() methods are registered here.
-        OPEN_METH = {
-                "cpio": "cpioopen",     # uncompressed
-                "gz":   "gzopen",       # gzip compressed
-                "bz2":  "bz2open",      # bzip2 compressed
-                "p7z":  "p7zopen"       # 7z compressed
-        }
+    @classmethod
+    def p7zopen(cls, name, mode="r", fileobj=None):
+        """Open 7z compressed cpio archive name for reading, writing.
 
-        def getmember(self, name):
-                """Return a CpioInfo object for member `name'. If `name' can not be
-                found in the archive, KeyError is raised. If a member occurs more
-                than once in the archive, its last occurence is assumed to be the
-                most up-to-date version.
-                """
-                cpioinfo = self._getmember(name)
-                if cpioinfo is None:
-                        raise KeyError("filename {0!r} not found".format(name))
-                return cpioinfo
+        Appending is not allowed
+        """
+        if len(mode) > 1 or mode not in "rw":
+            raise ValueError("mode must be 'r' or 'w'.")
 
-        def getmembers(self):
-                """Return the members of the archive as a list of CpioInfo objects. The
-                list has the same order as the members in the archive.
-                """
-                self._check()
-                if not self._loaded:    # if we want to obtain a list of
-                        self._load()    # all members, we first have to
-                                        # scan the whole archive.
-                return self.members
+        pre, ext = os.path.splitext(name)
+        pre = os.path.basename(pre)
+        if ext == ".7z":
+            ext = ""
+        cpioname = pre + ext
 
-        def __next__(self):
-                self._check("ra")
-                if self.firstmember is not None:
-                        m = self.firstmember
-                        self.firstmember = None
-                        return m
+        try:
+            # To extract: 7z e -so <fname>
+            # To create an archive: 7z a -si <fname>
+            cmd = "7z {0} -{1} {2}".format(
+                {"r": "e", "w": "a"}[mode], {"r": "so", "w": "si"}[mode], name
+            )
+            p = subprocess.Popen(
+                cmd.split(),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            pobj = p.stdout
+            if mode == "w":
+                pobj = p.stdin
 
-                self.fileobj.seek(self.offset)
-                while True:
-                        # Read in enough for frombuf() to be able to determine
-                        # what kind of archive it is.  It will have to read the
-                        # rest of the header.
-                        buf = self.fileobj.read(6)
-                        if not buf:
-                                return None
-                        try:
-                                cpioinfo = CpioInfo.frombuf(buf, self.fileobj, self)
-                        except ValueError as e:
-                                if self.offset == 0:
-                                        raise ReadError("empty, unreadable or compressed file")
-                                return None
-                        break
+            comptype = "cpio"
+            bufsize = 20 * 512
 
-                # if cpioinfo.chksum != calc_chksum(buf):
-                #         self._dbg(1, "cpiofile: Bad Checksum {0!r}".format(cpioinfo.name))
+            obj = _Stream(cpioname, mode, comptype, pobj, bufsize)
+            t = cls.cpioopen(cpioname, mode, obj)
+        except IOError:
+            raise ReadError("read/write via 7z failed")
+        t._extfileobj = False
+        return t
 
-                cpioinfo.offset = self.offset
+    # All *open() methods are registered here.
+    OPEN_METH = {
+        "cpio": "cpioopen",  # uncompressed
+        "gz": "gzopen",  # gzip compressed
+        "bz2": "bz2open",  # bzip2 compressed
+        "p7z": "p7zopen",  # 7z compressed
+    }
 
-                cpioinfo.offset_data = self.offset + cpioinfo.hdrsize
-                if cpioinfo.isreg() or cpioinfo.type not in (0,): # XXX SUPPORTED_TYPES?
-                        self.offset += cpioinfo.hdrsize + cpioinfo.size
-                        if self.offset % cpioinfo.padding != 0:
-                                self.offset += cpioinfo.padding - \
-                                                (self.offset % cpioinfo.padding)
+    def getmember(self, name):
+        """Return a CpioInfo object for member `name'. If `name' can not be
+        found in the archive, KeyError is raised. If a member occurs more
+        than once in the archive, its last occurence is assumed to be the
+        most up-to-date version.
+        """
+        cpioinfo = self._getmember(name)
+        if cpioinfo is None:
+            raise KeyError("filename {0!r} not found".format(name))
+        return cpioinfo
 
-                if cpioinfo.name == "TRAILER!!!":
-                        return None
+    def getmembers(self):
+        """Return the members of the archive as a list of CpioInfo objects. The
+        list has the same order as the members in the archive.
+        """
+        self._check()
+        if not self._loaded:  # if we want to obtain a list of
+            self._load()  # all members, we first have to
+            # scan the whole archive.
+        return self.members
 
-                self.members.append(cpioinfo)
-                return cpioinfo
+    def __next__(self):
+        self._check("ra")
+        if self.firstmember is not None:
+            m = self.firstmember
+            self.firstmember = None
+            return m
 
-        next = __next__
+        self.fileobj.seek(self.offset)
+        while True:
+            # Read in enough for frombuf() to be able to determine
+            # what kind of archive it is.  It will have to read the
+            # rest of the header.
+            buf = self.fileobj.read(6)
+            if not buf:
+                return None
+            try:
+                cpioinfo = CpioInfo.frombuf(buf, self.fileobj, self)
+            except ValueError as e:
+                if self.offset == 0:
+                    raise ReadError("empty, unreadable or compressed file")
+                return None
+            break
 
-        def extractfile(self, member):
-                self._check("r")
+        # if cpioinfo.chksum != calc_chksum(buf):
+        #         self._dbg(1, "cpiofile: Bad Checksum {0!r}".format(cpioinfo.name))
 
-                if isinstance(member, CpioInfo):
-                        cpioinfo = member
-                else:
-                        cpioinfo = self.getmember(member)
+        cpioinfo.offset = self.offset
 
-                if cpioinfo.isreg():
-                        return self.fileobject(self, cpioinfo)
-                # XXX deal with other types
-                else:
-                        return None
+        cpioinfo.offset_data = self.offset + cpioinfo.hdrsize
+        if cpioinfo.isreg() or cpioinfo.type not in (
+            0,
+        ):  # XXX SUPPORTED_TYPES?
+            self.offset += cpioinfo.hdrsize + cpioinfo.size
+            if self.offset % cpioinfo.padding != 0:
+                self.offset += cpioinfo.padding - (
+                    self.offset % cpioinfo.padding
+                )
 
-        def _block(self, count):
-                blocks, remainder = divmod(count, BLOCKSIZE)
-                if remainder:
-                        blocks += 1
-                return blocks * BLOCKSIZE
+        if cpioinfo.name == "TRAILER!!!":
+            return None
 
-        def _getmember(self, name, cpioinfo=None):
-                members = self.getmembers()
+        self.members.append(cpioinfo)
+        return cpioinfo
 
-                if cpioinfo is None:
-                        end = len(members)
-                else:
-                        end = members.index(cpioinfo)
+    next = __next__
 
-                for i in range(end - 1, -1, -1):
-                        if name == members[i].name:
-                                return members[i]
+    def extractfile(self, member):
+        self._check("r")
 
-        def _load(self):
-                while True:
-                        cpioinfo = next(self)
-                        if cpioinfo is None:
-                                break
-                self._loaded = True
+        if isinstance(member, CpioInfo):
+            cpioinfo = member
+        else:
+            cpioinfo = self.getmember(member)
 
-        def _check(self, mode=None):
-                if self.closed:
-                        raise IOError("{0} is closed".format(
-                            self.__class__.__name__))
-                if mode is not None and self._mode not in mode:
-                        raise IOError("bad operation for mode {0!r}".format(
-                            self._mode))
+        if cpioinfo.isreg():
+            return self.fileobject(self, cpioinfo)
+        # XXX deal with other types
+        else:
+            return None
 
-        def __iter__(self):
-                if self._loaded:
-                        return iter(self.members)
-                else:
-                        return CpioIter(self)
+    def _block(self, count):
+        blocks, remainder = divmod(count, BLOCKSIZE)
+        if remainder:
+            blocks += 1
+        return blocks * BLOCKSIZE
 
-        def find_next_archive(self, padding=512):
-                """Find the next cpio archive glommed on to the end of the current one.
+    def _getmember(self, name, cpioinfo=None):
+        members = self.getmembers()
 
-                Some applications, like Solaris package datastreams, concatenate
-                multiple cpio archives together, separated by a bit of padding.
-                This routine puts all the file pointers in position to start
-                reading from the next archive, which can be done by creating a
-                new CpioFile object given the original one as an argument (after
-                this routine is called).
-                """
+        if cpioinfo is None:
+            end = len(members)
+        else:
+            end = members.index(cpioinfo)
 
-                bytes = 0
-                if self.fileobj.tell() % padding != 0:
-                        bytes = padding - self.fileobj.tell() % padding
-                self.fileobj.seek(self.fileobj.tell() + bytes)
-                self.offset += bytes
+        for i in range(end - 1, -1, -1):
+            if name == members[i].name:
+                return members[i]
 
-        def get_next_archive(self, padding=512):
-                """Return the next cpio archive glommed on to the end of the current one.
+    def _load(self):
+        while True:
+            cpioinfo = next(self)
+            if cpioinfo is None:
+                break
+        self._loaded = True
 
-                Return the CpioFile object based on the repositioning done by
-                find_next_archive().
-                """
+    def _check(self, mode=None):
+        if self.closed:
+            raise IOError("{0} is closed".format(self.__class__.__name__))
+        if mode is not None and self._mode not in mode:
+            raise IOError("bad operation for mode {0!r}".format(self._mode))
 
-                self.find_next_archive(padding)
-                return CpioFile(cfobj=self)
+    def __iter__(self):
+        if self._loaded:
+            return iter(self.members)
+        else:
+            return CpioIter(self)
+
+    def find_next_archive(self, padding=512):
+        """Find the next cpio archive glommed on to the end of the current one.
+
+        Some applications, like Solaris package datastreams, concatenate
+        multiple cpio archives together, separated by a bit of padding.
+        This routine puts all the file pointers in position to start
+        reading from the next archive, which can be done by creating a
+        new CpioFile object given the original one as an argument (after
+        this routine is called).
+        """
+
+        bytes = 0
+        if self.fileobj.tell() % padding != 0:
+            bytes = padding - self.fileobj.tell() % padding
+        self.fileobj.seek(self.fileobj.tell() + bytes)
+        self.offset += bytes
+
+    def get_next_archive(self, padding=512):
+        """Return the next cpio archive glommed on to the end of the current one.
+
+        Return the CpioFile object based on the repositioning done by
+        find_next_archive().
+        """
+
+        self.find_next_archive(padding)
+        return CpioFile(cfobj=self)
+
 
 class CpioIter:
-        def __init__(self, cpiofile):
-                self.cpiofile = cpiofile
-                self.index = 0
+    def __init__(self, cpiofile):
+        self.cpiofile = cpiofile
+        self.index = 0
 
-        def __iter__(self):
-                return self
+    def __iter__(self):
+        return self
 
-        def __next__(self):
-                if not self.cpiofile._loaded:
-                        cpioinfo = next(self.cpiofile)
-                        if not cpioinfo:
-                                self.cpiofile._loaded = True
-                                raise StopIteration
-                else:
-                        try:
-                                cpioinfo = self.cpiofile.members[self.index]
-                        except IndexError:
-                                raise StopIteration
-                self.index += 1
-                return cpioinfo
+    def __next__(self):
+        if not self.cpiofile._loaded:
+            cpioinfo = next(self.cpiofile)
+            if not cpioinfo:
+                self.cpiofile._loaded = True
+                raise StopIteration
+        else:
+            try:
+                cpioinfo = self.cpiofile.members[self.index]
+            except IndexError:
+                raise StopIteration
+        self.index += 1
+        return cpioinfo
 
-        next = __next__
+    next = __next__
+
 
 def is_cpiofile(name):
+    magic = open(name).read(CMS_LEN)
 
-        magic = open(name).read(CMS_LEN)
+    if magic in (CMS_ASC, CMS_CHR, CMS_CRC):
+        return True
+    elif struct.unpack("h", magic[:2])[0] in (
+        CMN_ASC,
+        CMN_BIN,
+        CMN_BBS,
+        CMN_CRC,
+    ):
+        return True
 
-        if magic in (CMS_ASC, CMS_CHR, CMS_CRC):
-                return True
-        elif struct.unpack("h", magic[:2])[0] in \
-                (CMN_ASC, CMN_BIN, CMN_BBS, CMN_CRC):
-                return True
+    return False
 
-        return False
 
 if __name__ == "__main__":
-        print(is_cpiofile(sys.argv[1]))
+    print(is_cpiofile(sys.argv[1]))
 
-        cf = CpioFile.open(sys.argv[1])
-        print("cpiofile is:", cf)
+    cf = CpioFile.open(sys.argv[1])
+    print("cpiofile is:", cf)
 
-        for ci in cf:
-                print("cpioinfo is:", ci)
-                print("  mode: {:04o}".format(ci.mode))
-                print("  uid:", ci.uid)
-                print("  gid:", ci.gid)
-                print("  mtime:", ci.mtime, "({0})".format(
-                    time.ctime(ci.mtime)))
-                print("  size:", ci.size)
-                print("  name:", ci.name)
-                # f = cf.extractfile(ci)
-                # for l in f.readlines():
-                #         print(l, end=" ")
-                # f.close()
+    for ci in cf:
+        print("cpioinfo is:", ci)
+        print("  mode: {:04o}".format(ci.mode))
+        print("  uid:", ci.uid)
+        print("  gid:", ci.gid)
+        print("  mtime:", ci.mtime, "({0})".format(time.ctime(ci.mtime)))
+        print("  size:", ci.size)
+        print("  name:", ci.name)
+        # f = cf.extractfile(ci)
+        # for l in f.readlines():
+        #         print(l, end=" ")
+        # f.close()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/dependency.py
+++ b/src/modules/dependency.py
@@ -28,37 +28,34 @@ REQUIRE = 0
 OPTIONAL = 1
 INCORPORATE = 10
 
+
 class Dependency(object):
-        """A Dependency object is a relationship between one Package and
-        another.  It is a bidirectional expression.
+    """A Dependency object is a relationship between one Package and
+    another.  It is a bidirectional expression.
 
-        A package may require a minimum version of another package."""
+    A package may require a minimum version of another package."""
 
-        def __init__(self, host_pkg_fmri, req_pkg_fmri, type = REQUIRE):
-                self.host_pkg_fmri = host_pkg_fmri
-                self.req_pkg_fmri = req_pkg_fmri
+    def __init__(self, host_pkg_fmri, req_pkg_fmri, type=REQUIRE):
+        self.host_pkg_fmri = host_pkg_fmri
+        self.req_pkg_fmri = req_pkg_fmri
 
-                assert type == REQUIRE \
-                    or type == INCORPORATE \
-                    or type == OPTIONAL
+        assert type == REQUIRE or type == INCORPORATE or type == OPTIONAL
 
-                self.type = type
+        self.type = type
 
-        def satisfied(self, pkg_fmri):
-                # compare pkg_fmri to req_pkg_fmri
-                # compare versions
-                return False
+    def satisfied(self, pkg_fmri):
+        # compare pkg_fmri to req_pkg_fmri
+        # compare versions
+        return False
 
-        def __repr__(self):
-                if self.type == REQUIRE:
-                        return "{0} => {1}".format(
-                            self.host_pkg_fmri, self.req_pkg_fmri)
-                elif self.type == OPTIONAL:
-                        return "{0} o> {1}".format(
-                            self.host_pkg_fmri, self.req_pkg_fmri)
-                elif self.type == INCORPORATE:
-                        return "{0} >> {1}".format(
-                            self.host_pkg_fmri, self.req_pkg_fmri)
+    def __repr__(self):
+        if self.type == REQUIRE:
+            return "{0} => {1}".format(self.host_pkg_fmri, self.req_pkg_fmri)
+        elif self.type == OPTIONAL:
+            return "{0} o> {1}".format(self.host_pkg_fmri, self.req_pkg_fmri)
+        elif self.type == INCORPORATE:
+            return "{0} >> {1}".format(self.host_pkg_fmri, self.req_pkg_fmri)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/depotcontroller.py
+++ b/src/modules/depotcontroller.py
@@ -40,560 +40,573 @@ from six.moves.urllib.parse import urlunparse, urljoin
 import pkg.pkgsubprocess as subprocess
 import pkg.server.repository as sr
 
-class DepotStateException(Exception):
 
-        def __init__(self, reason):
-                Exception.__init__(self, reason)
+class DepotStateException(Exception):
+    def __init__(self, reason):
+        Exception.__init__(self, reason)
+
 
 class DepotController(object):
+    HALTED = 0
+    STARTING = 1
+    RUNNING = 2
 
-        HALTED = 0
-        STARTING = 1
-        RUNNING = 2
+    def __init__(self, wrapper_start=None, wrapper_end="", env=None):
+        self.__add_content = False
+        self.__auto_port = True
+        self.__cfg_file = None
+        self.__debug_features = {}
+        self.__depot_handle = None
+        self.__depot_path = "/usr/lib/pkg.depotd"
+        self.__depot_content_root = None
+        self.__dir = None
+        self.__disable_ops = None
+        self.__exit_ready = False
+        self.__file_root = None
+        self.__logpath = "/tmp/depot.log"
+        self.__mirror = False
+        self.__output = None
+        self.__address = None
+        self.__port = -1
+        self.__props = {}
+        self.__readonly = False
+        self.__rebuild = False
+        self.__refresh_index = False
+        self.__state = self.HALTED
+        self.__writable_root = None
+        self.__sort_file_max_size = None
+        self.__ssl_dialog = None
+        self.__ssl_cert_file = None
+        self.__ssl_key_file = None
+        self.__starttime = 0
+        self.__wrapper_start = []
+        self.__wrapper_end = wrapper_end
+        self.__env = {}
+        self.__nasty = None
+        self.__nasty_sleep = None
+        if wrapper_start:
+            self.__wrapper_start = wrapper_start
+        if env:
+            self.__env = env
+        #
+        # Enable special unit-test depot mode in which it doesn't
+        # do its normal double-fork, providing us good control
+        # over the process.
+        #
+        self.__env["PKGDEPOT_CONTROLLER"] = "1"
+        return
 
-        def __init__(self, wrapper_start=None, wrapper_end="", env=None):
-                self.__add_content = False
-                self.__auto_port = True
-                self.__cfg_file = None
-                self.__debug_features = {}
-                self.__depot_handle = None
-                self.__depot_path = "/usr/lib/pkg.depotd"
-                self.__depot_content_root = None
-                self.__dir = None
-                self.__disable_ops = None
-                self.__exit_ready = False
-                self.__file_root = None
-                self.__logpath = "/tmp/depot.log"
-                self.__mirror = False
-                self.__output = None
-                self.__address = None
-                self.__port = -1
-                self.__props = {}
-                self.__readonly = False
-                self.__rebuild = False
-                self.__refresh_index = False
-                self.__state = self.HALTED
-                self.__writable_root = None
-                self.__sort_file_max_size = None
-                self.__ssl_dialog = None
-                self.__ssl_cert_file = None
-                self.__ssl_key_file = None
-                self.__starttime = 0
-                self.__wrapper_start = []
-                self.__wrapper_end = wrapper_end
-                self.__env = {}
-                self.__nasty = None
-                self.__nasty_sleep = None
-                if wrapper_start:
-                        self.__wrapper_start = wrapper_start
-                if env:
-                        self.__env = env
-                #
-                # Enable special unit-test depot mode in which it doesn't
-                # do its normal double-fork, providing us good control
-                # over the process.
-                #
-                self.__env["PKGDEPOT_CONTROLLER"] = "1"
+    def get_wrapper(self):
+        return self.__wrapper_start, self.__wrapper_end
+
+    def set_wrapper(self, start, end):
+        self.__wrapper_start = start
+        self.__wrapper_end = end
+
+    def unset_wrapper(self):
+        self.__wrapper_start = []
+        self.__wrapper_end = ""
+
+    def set_depotd_path(self, path):
+        self.__depot_path = path
+
+    def set_depotd_content_root(self, path):
+        self.__depot_content_root = path
+
+    def get_depotd_content_root(self):
+        return self.__depot_content_root
+
+    def set_auto_port(self):
+        self.__auto_port = True
+
+    def set_address(self, address):
+        self.__address = address
+
+    def get_address(self):
+        return self.__address
+
+    def set_port(self, port):
+        self.__auto_port = False
+        self.__port = port
+
+    def get_port(self):
+        return self.__port
+
+    def clear_property(self, section, prop):
+        del self.__props[section][prop]
+
+    def set_property(self, section, prop, value):
+        self.__props.setdefault(section, {})
+        self.__props[section][prop] = value
+
+    def get_property(self, section, prop):
+        return self.__props.get(section, {}).get(prop)
+
+    def set_file_root(self, f_root):
+        self.__file_root = f_root
+
+    def get_file_root(self):
+        return self.__file_root
+
+    def set_repodir(self, repodir):
+        self.__dir = repodir
+
+    def get_repodir(self):
+        return self.__dir
+
+    def get_repo(self, auto_create=False):
+        if auto_create:
+            try:
+                sr.repository_create(self.__dir)
+            except sr.RepositoryExistsError:
+                # Already exists, nothing to do.
+                pass
+        return sr.Repository(
+            cfgpathname=self.__cfg_file,
+            root=self.__dir,
+            writable_root=self.__writable_root,
+        )
+
+    def get_repo_url(self):
+        return urlunparse(("file", "", pathname2url(self.__dir), "", "", ""))
+
+    def set_readonly(self):
+        self.__readonly = True
+
+    def set_readwrite(self):
+        self.__readonly = False
+
+    def set_mirror(self):
+        self.__mirror = True
+
+    def unset_mirror(self):
+        self.__mirror = False
+
+    def set_rebuild(self):
+        self.__rebuild = True
+
+    def set_norebuild(self):
+        self.__rebuild = False
+
+    def set_exit_ready(self):
+        self.__exit_ready = True
+
+    def set_add_content(self):
+        self.__add_content = True
+
+    def set_logpath(self, logpath):
+        self.__logpath = logpath
+
+    def get_logpath(self):
+        return self.__logpath
+
+    def set_refresh_index(self):
+        self.__refresh_index = True
+
+    def set_norefresh_index(self):
+        self.__refresh_index = False
+
+    def get_state(self):
+        return self.__state
+
+    def set_cfg_file(self, f):
+        self.__cfg_file = f
+
+    def get_cfg_file(self):
+        return self.__cfg_file
+
+    def get_depot_url(self):
+        if self.__address:
+            host = self.__address
+            if ":" in host:
+                # Special syntax needed for IPv6 addresses.
+                host = "[{0}]".format(host)
+        else:
+            host = "localhost"
+
+        if self.__ssl_key_file:
+            scheme = "https"
+        else:
+            scheme = "http"
+
+        return "{0}://{1}:{2:d}".format(scheme, host, self.__port)
+
+    def set_writable_root(self, wr):
+        self.__writable_root = wr
+
+    def get_writable_root(self):
+        return self.__writable_root
+
+    def set_sort_file_max_size(self, sort):
+        self.__sort_file_max_size = sort
+
+    def get_sort_file_max_size(self):
+        return self.__sort_file_max_size
+
+    def set_debug_feature(self, feature):
+        self.__debug_features[feature] = True
+
+    def unset_debug_feature(self, feature):
+        del self.__debug_features[feature]
+
+    def set_disable_ops(self, ops):
+        self.__disable_ops = ops
+
+    def unset_disable_ops(self):
+        self.__disable_ops = None
+
+    def set_nasty(self, nastiness):
+        """Set the nastiness level of the depot.  Also works on
+        running depots."""
+        self.__nasty = nastiness
+        if self.__depot_handle != None:
+            nastyurl = urljoin(
+                self.get_depot_url(), "nasty/{0:d}".format(self.__nasty)
+            )
+            url = urlopen(nastyurl)
+            url.close()
+
+    def get_nasty(self):
+        return self.__nasty
+
+    def set_nasty_sleep(self, sleep):
+        self.__nasty_sleep = sleep
+
+    def get_nasty_sleep(self):
+        return self.__nasty_sleep
+
+    def enable_ssl(self, key_path=None, cert_path=None, dialog=None):
+        self.__ssl_key_file = key_path
+        self.__ssl_cert_file = cert_path
+        self.__ssl_dialog = dialog
+
+    def disable_ssl(self):
+        self.__ssl_key_file = None
+        self.__ssl_cert_file = None
+        self.__ssl_dialog = None
+
+    def __network_ping(self):
+        try:
+            repourl = urljoin(self.get_depot_url(), "versions/0")
+            # Disable SSL peer verification, we just want to check
+            # if the depot is running.
+            url = urlopen(repourl, context=ssl._create_unverified_context())
+            url.close()
+        except HTTPError as e:
+            # Server returns NOT_MODIFIED if catalog is up
+            # to date
+            if e.code == http_client.NOT_MODIFIED:
+                return True
+            else:
+                return False
+        except URLError as e:
+            return False
+        return True
+
+    def is_alive(self):
+        """First, check that the depot process seems to be alive.
+        Then make a little HTTP request to see if the depot is
+        responsive to requests"""
+
+        if self.__depot_handle == None:
+            return False
+
+        status = self.__depot_handle.poll()
+        if status != None:
+            return False
+        return self.__network_ping()
+
+    @property
+    def started(self):
+        """Return a boolean value indicating whether a depot process
+        has been started using this depotcontroller."""
+
+        return self.__depot_handle != None
+
+    def get_args(self):
+        """Return the equivalent command line invocation (as an
+        array) for the depot as currently configured."""
+
+        args = []
+
+        # The depot may fork off children of its own, so we place
+        # them all together in a process group.  This allows us to
+        # nuke everything later on.
+        args.append("setpgrp")
+        args.extend(self.__wrapper_start[:])
+        args.append(sys.executable)
+        args.append(self.__depot_path)
+        if self.__depot_content_root:
+            args.append("--content-root")
+            args.append(self.__depot_content_root)
+        if self.__address:
+            args.append("-a")
+            args.append("{0}".format(self.__address))
+        if self.__port != -1:
+            args.append("-p")
+            args.append("{0:d}".format(self.__port))
+        if self.__dir != None:
+            args.append("-d")
+            args.append(self.__dir)
+        if self.__file_root != None:
+            args.append("--file-root={0}".format(self.__file_root))
+        if self.__readonly:
+            args.append("--readonly")
+        if self.__rebuild:
+            args.append("--rebuild")
+        if self.__mirror:
+            args.append("--mirror")
+        if self.__refresh_index:
+            args.append("--refresh-index")
+        if self.__add_content:
+            args.append("--add-content")
+        if self.__exit_ready:
+            args.append("--exit-ready")
+        if self.__cfg_file:
+            args.append("--cfg-file={0}".format(self.__cfg_file))
+        if self.__ssl_cert_file:
+            args.append("--ssl-cert-file={0}".format(self.__ssl_cert_file))
+        if self.__ssl_key_file:
+            args.append("--ssl-key-file={0}".format(self.__ssl_key_file))
+        if self.__ssl_dialog:
+            args.append("--ssl-dialog={0}".format(self.__ssl_dialog))
+        if self.__debug_features:
+            args.append("--debug={0}".format(",".join(self.__debug_features)))
+        if self.__disable_ops:
+            args.append(
+                "--disable-ops={0}".format(",".join(self.__disable_ops))
+            )
+        if self.__nasty:
+            args.append("--nasty {0:d}".format(self.__nasty))
+        if self.__nasty_sleep:
+            args.append("--nasty-sleep {0:d}".format(self.__nasty_sleep))
+        for section in self.__props:
+            for prop, val in six.iteritems(self.__props[section]):
+                args.append(
+                    "--set-property={0}.{1}='{2}'".format(section, prop, val)
+                )
+        if self.__writable_root:
+            args.append("--writable-root={0}".format(self.__writable_root))
+
+        if self.__sort_file_max_size:
+            args.append(
+                "--sort-file-max-size={0}".format(self.__sort_file_max_size)
+            )
+
+        # Always log access and error information.
+        args.append("--log-access=stdout")
+        args.append("--log-errors=stderr")
+        args.append(self.__wrapper_end)
+
+        return args
+
+    def __initial_start(self):
+        """'env_arg' can be a dictionary of additional os.environ
+        entries to use when starting the depot."""
+
+        if self.__state != self.HALTED:
+            raise DepotStateException("Depot already starting or " "running")
+
+        # XXX what about stdin and stdout redirection?
+        args = self.get_args()
+
+        if self.__network_ping():
+            raise DepotStateException(
+                "A depot (or some "
+                + "other network process) seems to be "
+                + "running on port {0:d} already!".format(self.__port)
+            )
+
+        self.__state = self.STARTING
+
+        # Unbuffer is only allowed in binary mode.
+        self.__output = open(self.__logpath, "wb", 0)
+        # Use shlex to re-parse args.
+        pargs = shlex.split(" ".join(args))
+
+        newenv = os.environ.copy()
+        newenv.update(self.__env)
+        self.__depot_handle = subprocess.Popen(
+            pargs,
+            env=newenv,
+            stdin=subprocess.PIPE,
+            stdout=self.__output,
+            stderr=self.__output,
+            close_fds=True,
+        )
+        if self.__depot_handle == None:
+            raise DepotStateException("Could not start Depot")
+        self.__starttime = time.time()
+        self.__output.close()
+
+    def start(self):
+        try:
+            self.__initial_start()
+
+            if self.__refresh_index:
                 return
 
-        def get_wrapper(self):
-                return self.__wrapper_start, self.__wrapper_end
+            begintime = time.time()
 
-        def set_wrapper(self, start, end):
-                self.__wrapper_start = start
-                self.__wrapper_end = end
+            sleeptime = 0.0
+            check_interval = 0.20
+            contact = False
+            while (time.time() - begintime) <= 40.0:
+                rc = self.__depot_handle.poll()
+                if rc is not None:
+                    err = ""
+                    with open(self.__logpath, "rb", 0) as errf:
+                        err = errf.read()
+                    raise DepotStateException(
+                        "Depot exited "
+                        "with exit code {0:d} unexpectedly "
+                        "while starting.  Output follows:\n"
+                        "{1}\n".format(rc, err)
+                    )
 
-        def unset_wrapper(self):
-                self.__wrapper_start = []
-                self.__wrapper_end = ""
+                if self.is_alive():
+                    contact = True
+                    break
+                time.sleep(check_interval)
+            if contact == False:
+                self.kill()
+                self.__state = self.HALTED
+                raise DepotStateException(
+                    "Depot did not respond to "
+                    "repeated attempts to make contact"
+                )
 
-        def set_depotd_path(self, path):
-                self.__depot_path = path
+            self.__state = self.RUNNING
+        except KeyboardInterrupt:
+            if self.__depot_handle:
+                self.kill(now=True)
+            raise
 
-        def set_depotd_content_root(self, path):
-                self.__depot_content_root = path
+    def start_expected_fail(self, exit=2):
+        try:
+            self.__initial_start()
 
-        def get_depotd_content_root(self):
-                return self.__depot_content_root
+            sleeptime = 0.05
+            died = False
+            rc = None
+            while sleeptime <= 10.0:
+                rc = self.__depot_handle.poll()
+                if rc is not None:
+                    died = True
+                    break
+                time.sleep(sleeptime)
+                sleeptime *= 2
 
-        def set_auto_port(self):
-                self.__auto_port = True
-
-        def set_address(self, address):
-                self.__address = address
-
-        def get_address(self):
-                return self.__address
-
-        def set_port(self, port):
-                self.__auto_port = False
-                self.__port = port
-
-        def get_port(self):
-                return self.__port
-
-        def clear_property(self, section, prop):
-                del self.__props[section][prop]
-
-        def set_property(self, section, prop, value):
-                self.__props.setdefault(section, {})
-                self.__props[section][prop] = value
-
-        def get_property(self, section, prop):
-                return self.__props.get(section, {}).get(prop)
-
-        def set_file_root(self, f_root):
-                self.__file_root = f_root
-
-        def get_file_root(self):
-                return self.__file_root
-
-        def set_repodir(self, repodir):
-                self.__dir = repodir
-
-        def get_repodir(self):
-                return self.__dir
-
-        def get_repo(self, auto_create=False):
-                if auto_create:
-                        try:
-                                sr.repository_create(self.__dir)
-                        except sr.RepositoryExistsError:
-                                # Already exists, nothing to do.
-                                pass
-                return sr.Repository(cfgpathname=self.__cfg_file,
-                    root=self.__dir, writable_root=self.__writable_root)
-
-        def get_repo_url(self):
-                return urlunparse(("file", "", pathname2url(
-                    self.__dir), "", "", ""))
-
-        def set_readonly(self):
-                self.__readonly = True
-
-        def set_readwrite(self):
-                self.__readonly = False
-
-        def set_mirror(self):
-                self.__mirror = True
-
-        def unset_mirror(self):
-                self.__mirror = False
-
-        def set_rebuild(self):
-                self.__rebuild = True
-
-        def set_norebuild(self):
-                self.__rebuild = False
-
-        def set_exit_ready(self):
-                self.__exit_ready = True
-
-        def set_add_content(self):
-                self.__add_content = True
-
-        def set_logpath(self, logpath):
-                self.__logpath = logpath
-
-        def get_logpath(self):
-                return self.__logpath
-
-        def set_refresh_index(self):
-                self.__refresh_index = True
-
-        def set_norefresh_index(self):
-                self.__refresh_index = False
-
-        def get_state(self):
-                return self.__state
-
-        def set_cfg_file(self, f):
-                self.__cfg_file = f
-
-        def get_cfg_file(self):
-                return self.__cfg_file
-
-        def get_depot_url(self):
-                if self.__address:
-                        host = self.__address
-                        if ":" in host:
-                                # Special syntax needed for IPv6 addresses.
-                                host = "[{0}]".format(host)
-                else:
-                        host = "localhost"
-
-                if self.__ssl_key_file:
-                        scheme = "https"
-                else:
-                        scheme = "http"
-
-                return "{0}://{1}:{2:d}".format(scheme, host, self.__port)
-
-        def set_writable_root(self, wr):
-                self.__writable_root = wr
-
-        def get_writable_root(self):
-                return self.__writable_root
-
-        def set_sort_file_max_size(self, sort):
-                self.__sort_file_max_size = sort
-
-        def get_sort_file_max_size(self):
-                return self.__sort_file_max_size
-
-        def set_debug_feature(self, feature):
-                self.__debug_features[feature] = True
-
-        def unset_debug_feature(self, feature):
-                del self.__debug_features[feature]
-
-        def set_disable_ops(self, ops):
-                self.__disable_ops = ops
-
-        def unset_disable_ops(self):
-                self.__disable_ops = None
-
-        def set_nasty(self, nastiness):
-                """Set the nastiness level of the depot.  Also works on
-                running depots."""
-                self.__nasty = nastiness
-                if self.__depot_handle != None:
-                        nastyurl = urljoin(self.get_depot_url(),
-                            "nasty/{0:d}".format(self.__nasty))
-                        url = urlopen(nastyurl)
-                        url.close()
-
-        def get_nasty(self):
-                return self.__nasty
-
-        def set_nasty_sleep(self, sleep):
-                self.__nasty_sleep = sleep
-
-        def get_nasty_sleep(self):
-                return self.__nasty_sleep
-
-        def enable_ssl(self, key_path=None, cert_path=None, dialog=None):
-                self.__ssl_key_file = key_path
-                self.__ssl_cert_file = cert_path
-                self.__ssl_dialog = dialog
-
-        def disable_ssl(self):
-                self.__ssl_key_file = None
-                self.__ssl_cert_file = None
-                self.__ssl_dialog = None
-
-        def __network_ping(self):
-                try:
-                        repourl = urljoin(self.get_depot_url(),
-                            "versions/0")
-                        # Disable SSL peer verification, we just want to check
-                        # if the depot is running.
-                        url = urlopen(repourl,
-                            context=ssl._create_unverified_context())
-                        url.close()
-                except HTTPError as e:
-                        # Server returns NOT_MODIFIED if catalog is up
-                        # to date
-                        if e.code == http_client.NOT_MODIFIED:
-                                return True
-                        else:
-                                return False
-                except URLError as e:
-                        return False
+            if died and rc == exit:
+                self.__state = self.HALTED
                 return True
+            else:
+                self.stop()
+                return False
+        except KeyboardInterrupt:
+            if self.__depot_handle:
+                self.kill(now=True)
+            raise
 
-        def is_alive(self):
-                """ First, check that the depot process seems to be alive.
-                    Then make a little HTTP request to see if the depot is
-                    responsive to requests """
+    def refresh(self):
+        if self.__depot_handle == None:
+            # XXX might want to remember and return saved
+            # exit status
+            return 0
 
-                if self.__depot_handle == None:
-                        return False
+        os.kill(self.__depot_handle.pid, signal.SIGUSR1)
+        return self.__depot_handle.poll()
 
-                status = self.__depot_handle.poll()
-                if status != None:
-                        return False
-                return self.__network_ping()
+    def kill(self, now=False):
+        """kill the depot; letting it live for
+        a little while helps get reliable death"""
 
-        @property
-        def started(self):
-                """ Return a boolean value indicating whether a depot process
-                    has been started using this depotcontroller. """
+        if self.__depot_handle == None:
+            # XXX might want to remember and return saved
+            # exit status
+            return 0
 
-                return self.__depot_handle != None
+        try:
+            lifetime = time.time() - self.__starttime
+            if now == False and lifetime < 1.0:
+                time.sleep(1.0 - lifetime)
 
-        def get_args(self):
-                """ Return the equivalent command line invocation (as an
-                    array) for the depot as currently configured. """
+        finally:
+            # By sticking in this finally: block we ensure that
+            # even if the kill gets ctrl-c'd, we'll at least take
+            # a good final whack at the depot by killing -9 its
+            # process group.
+            try:
+                os.kill(-1 * self.__depot_handle.pid, signal.SIGKILL)
+            except OSError:
+                pass
+            self.__state = self.HALTED
+            self.__depot_handle.wait()
+            self.__depot_handle = None
 
-                args = []
+    def stop(self):
+        if self.__state == self.HALTED:
+            raise DepotStateException("Depot already stopped")
 
-                # The depot may fork off children of its own, so we place
-                # them all together in a process group.  This allows us to
-                # nuke everything later on.
-                args.append("setpgrp")
-                args.extend(self.__wrapper_start[:])
-                args.append(sys.executable)
-                args.append(self.__depot_path)
-                if self.__depot_content_root:
-                        args.append("--content-root")
-                        args.append(self.__depot_content_root)
-                if self.__address:
-                        args.append("-a")
-                        args.append("{0}".format(self.__address))
-                if self.__port != -1:
-                        args.append("-p")
-                        args.append("{0:d}".format(self.__port))
-                if self.__dir != None:
-                        args.append("-d")
-                        args.append(self.__dir)
-                if self.__file_root != None:
-                        args.append("--file-root={0}".format(self.__file_root))
-                if self.__readonly:
-                        args.append("--readonly")
-                if self.__rebuild:
-                        args.append("--rebuild")
-                if self.__mirror:
-                        args.append("--mirror")
-                if self.__refresh_index:
-                        args.append("--refresh-index")
-                if self.__add_content:
-                        args.append("--add-content")
-                if self.__exit_ready:
-                        args.append("--exit-ready")
-                if self.__cfg_file:
-                        args.append("--cfg-file={0}".format(self.__cfg_file))
-                if self.__ssl_cert_file:
-                        args.append("--ssl-cert-file={0}".format(self.__ssl_cert_file))
-                if self.__ssl_key_file:
-                        args.append("--ssl-key-file={0}".format(self.__ssl_key_file))
-                if self.__ssl_dialog:
-                        args.append("--ssl-dialog={0}".format(self.__ssl_dialog))
-                if self.__debug_features:
-                        args.append("--debug={0}".format(",".join(
-                            self.__debug_features)))
-                if self.__disable_ops:
-                        args.append("--disable-ops={0}".format(",".join(
-                            self.__disable_ops)))
-                if self.__nasty:
-                        args.append("--nasty {0:d}".format(self.__nasty))
-                if self.__nasty_sleep:
-                        args.append("--nasty-sleep {0:d}".format(self.__nasty_sleep))
-                for section in self.__props:
-                        for prop, val in six.iteritems(self.__props[section]):
-                                args.append("--set-property={0}.{1}='{2}'".format(
-                                    section, prop, val))
-                if self.__writable_root:
-                        args.append("--writable-root={0}".format(self.__writable_root))
-
-                if self.__sort_file_max_size:
-                        args.append("--sort-file-max-size={0}".format(self.__sort_file_max_size))
-
-                # Always log access and error information.
-                args.append("--log-access=stdout")
-                args.append("--log-errors=stderr")
-                args.append(self.__wrapper_end)
-
-                return args
-
-        def __initial_start(self):
-                """'env_arg' can be a dictionary of additional os.environ
-                entries to use when starting the depot."""
-
-                if self.__state != self.HALTED:
-                        raise DepotStateException("Depot already starting or "
-                            "running")
-
-                # XXX what about stdin and stdout redirection?
-                args = self.get_args()
-
-                if self.__network_ping():
-                        raise DepotStateException("A depot (or some " +
-                            "other network process) seems to be " +
-                            "running on port {0:d} already!".format(self.__port))
-
-                self.__state = self.STARTING
-
-                # Unbuffer is only allowed in binary mode.
-                self.__output = open(self.__logpath, "wb", 0)
-                # Use shlex to re-parse args.
-                pargs = shlex.split(" ".join(args))
-
-                newenv = os.environ.copy()
-                newenv.update(self.__env)
-                self.__depot_handle = subprocess.Popen(pargs, env=newenv,
-                    stdin=subprocess.PIPE,
-                    stdout=self.__output,
-                    stderr=self.__output,
-                    close_fds=True)
-                if self.__depot_handle == None:
-                        raise DepotStateException("Could not start Depot")
-                self.__starttime = time.time()
-                self.__output.close()
-
-        def start(self):
-
-                try:
-                        self.__initial_start()
-
-                        if self.__refresh_index:
-                                return
-
-                        begintime = time.time()
-
-                        sleeptime = 0.0
-                        check_interval = 0.20
-                        contact = False
-                        while (time.time() - begintime) <= 40.0:
-                                rc = self.__depot_handle.poll()
-                                if rc is not None:
-                                        err = ""
-                                        with open(self.__logpath, "rb", 0) as \
-                                            errf:
-                                                err = errf.read()
-                                        raise DepotStateException("Depot exited "
-                                            "with exit code {0:d} unexpectedly "
-                                            "while starting.  Output follows:\n"
-                                            "{1}\n".format(rc, err))
-
-                                if self.is_alive():
-                                        contact = True
-                                        break
-                                time.sleep(check_interval)
-                        if contact == False:
-                                self.kill()
-                                self.__state = self.HALTED
-                                raise DepotStateException("Depot did not respond to "
-                                    "repeated attempts to make contact")
-
-                        self.__state = self.RUNNING
-                except KeyboardInterrupt:
-                        if self.__depot_handle:
-                                self.kill(now=True)
-                        raise
-
-        def start_expected_fail(self, exit=2):
-                try:
-                        self.__initial_start()
-
-                        sleeptime = 0.05
-                        died = False
-                        rc = None
-                        while sleeptime <= 10.0:
-
-                                rc = self.__depot_handle.poll()
-                                if rc is not None:
-                                        died = True
-                                        break
-                                time.sleep(sleeptime)
-                                sleeptime *= 2
-
-                        if died and rc == exit:
-                                self.__state = self.HALTED
-                                return True
-                        else:
-                                self.stop()
-                                return False
-                except KeyboardInterrupt:
-                        if self.__depot_handle:
-                                self.kill(now=True)
-                        raise
-
-        def refresh(self):
-                if self.__depot_handle == None:
-                        # XXX might want to remember and return saved
-                        # exit status
-                        return 0
-
-                os.kill(self.__depot_handle.pid, signal.SIGUSR1)
-                return self.__depot_handle.poll()
-
-        def kill(self, now=False):
-                """kill the depot; letting it live for
-                a little while helps get reliable death"""
-
-                if self.__depot_handle == None:
-                        # XXX might want to remember and return saved
-                        # exit status
-                        return 0
-
-                try:
-                        lifetime = time.time() - self.__starttime
-                        if now == False and lifetime < 1.0:
-                                time.sleep(1.0 - lifetime)
-
-                finally:
-                        # By sticking in this finally: block we ensure that
-                        # even if the kill gets ctrl-c'd, we'll at least take
-                        # a good final whack at the depot by killing -9 its
-                        # process group.
-                        try:
-                                os.kill(-1 * self.__depot_handle.pid,
-                                    signal.SIGKILL)
-                        except OSError:
-                                pass
-                        self.__state = self.HALTED
-                        self.__depot_handle.wait()
-                        self.__depot_handle = None
-
-        def stop(self):
-                if self.__state == self.HALTED:
-                        raise DepotStateException("Depot already stopped")
-
-                return self.kill()
+        return self.kill()
 
 
 def test_func(testdir):
-        dc = DepotController()
-        dc.set_port(22222)
+    dc = DepotController()
+    dc.set_port(22222)
+    try:
+        os.mkdir(testdir)
+    except OSError:
+        pass
+
+    dc.set_repodir(testdir)
+
+    for j in range(0, 10):
+        print(
+            "{0:>4d}: Starting Depot... ({1})".format(
+                j, " ".join(dc.get_args())
+            ),
+            end=" ",
+        )
         try:
-                os.mkdir(testdir)
-        except OSError:
+            dc.start()
+            print(" Done.    ", end=" ")
+            print("... Ping ", end=" ")
+            sys.stdout.flush()
+            time.sleep(0.2)
+            while dc.is_alive() == False:
                 pass
+            print("... Done.  ", end=" ")
 
-        dc.set_repodir(testdir)
+            print("Stopping Depot...", end=" ")
+            status = dc.stop()
+            if status is None:
+                print(" Result: Exited {0}".format(status), end=" ")
+            elif status == 0:
+                print(" Done.", end=" ")
+            elif status < 0:
+                print(" Result: Signal {0:d}".format(-1 * status), end=" ")
+            else:
+                print(" Result: Exited {0:d}".format(status), end=" ")
+            print()
+            f = open("/tmp/depot.log", "r")
+            print(f.read())
+            f.close()
+        except KeyboardInterrupt:
+            print("\nKeyboard Interrupt: Cleaning up Depots...")
+            dc.stop()
+            raise
 
-        for j in range(0, 10):
-                print("{0:>4d}: Starting Depot... ({1})".format(
-                    j, " ".join(dc.get_args())), end=" ")
-                try:
-                        dc.start()
-                        print(" Done.    ", end=" ")
-                        print("... Ping ", end=" ")
-                        sys.stdout.flush()
-                        time.sleep(0.2)
-                        while dc.is_alive() == False:
-                                pass
-                        print("... Done.  ", end=" ")
-
-                        print("Stopping Depot...", end=" ")
-                        status = dc.stop()
-                        if status is None:
-                                print(" Result: Exited {0}".format(status), end=" ")
-                        elif status == 0:
-                                print(" Done.", end=" ")
-                        elif status < 0:
-                                print(" Result: Signal {0:d}".format(-1 * status), end=" ")
-                        else:
-                                print(" Result: Exited {0:d}".format(status), end=" ")
-                        print()
-                        f = open("/tmp/depot.log", "r")
-                        print(f.read())
-                        f.close()
-                except KeyboardInterrupt:
-                        print("\nKeyboard Interrupt: Cleaning up Depots...")
-                        dc.stop()
-                        raise
 
 if __name__ == "__main__":
-        __testdir = "/tmp/depotcontrollertest.{0:d}".format(os.getpid())
-        try:
-                test_func(__testdir)
-        except KeyboardInterrupt:
-                pass
-        os.system("rm -fr {0}".format(__testdir))
-        print("\nDone")
+    __testdir = "/tmp/depotcontrollertest.{0:d}".format(os.getpid())
+    try:
+        test_func(__testdir)
+    except KeyboardInterrupt:
+        pass
+    os.system("rm -fr {0}".format(__testdir))
+    print("\nDone")
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/digest.py
+++ b/src/modules/digest.py
@@ -28,10 +28,11 @@ import hashlib
 import six
 
 try:
-        import pkg.sha512_t
-        sha512_supported = True
+    import pkg.sha512_t
+
+    sha512_supported = True
 except ImportError:
-        sha512_supported = False
+    sha512_supported = False
 
 # When running the test suite, we alter our behaviour depending on certain
 # debug flags.
@@ -86,15 +87,15 @@ LEGACY_CHAIN_CHASH_ATTRS = ["chain.chashes"]
 
 RANKED_HASHES = []
 if DebugValues["hash"]:
-        _hashes = reversed(DebugValues["hash"].split("+"))
+    _hashes = reversed(DebugValues["hash"].split("+"))
 else:
-        _hashes = ("sha512t_256", "sha256", "sha1")
+    _hashes = ("sha512t_256", "sha256", "sha1")
 
 for alg in _hashes:
-        if alg == "sha512t_256":
-                if not sha512_supported:
-                        continue
-        RANKED_HASHES.append(alg)
+    if alg == "sha512t_256":
+        if not sha512_supported:
+            continue
+    RANKED_HASHES.append(alg)
 
 PREFERRED_HASH = RANKED_HASHES[0]
 REVERSE_RANKED_HASHES = RANKED_HASHES[::-1]
@@ -106,18 +107,20 @@ DEFAULT_CHAIN_ATTRS = []
 DEFAULT_CHAIN_CHASH_ATTRS = []
 
 if "sha1" in RANKED_HASHES:
-        DEFAULT_HASH_ATTRS.append("hash")
-        DEFAULT_CHASH_ATTRS.append("chash")
-        DEFAULT_GELF_HASH_ATTRS.append("elfhash")
-        DEFAULT_CHAIN_ATTRS.append("chain")
-        DEFAULT_CHAIN_CHASH_ATTRS.append("chain.chashes")
+    DEFAULT_HASH_ATTRS.append("hash")
+    DEFAULT_CHASH_ATTRS.append("chash")
+    DEFAULT_GELF_HASH_ATTRS.append("elfhash")
+    DEFAULT_CHAIN_ATTRS.append("chain")
+    DEFAULT_CHAIN_CHASH_ATTRS.append("chain.chashes")
 
 if PREFERRED_HASH != "sha1":
-        DEFAULT_HASH_ATTRS.append("pkg.content-hash")
-        DEFAULT_CHASH_ATTRS.append("pkg.content-hash")
-        DEFAULT_GELF_HASH_ATTRS.append("pkg.content-hash")
-        DEFAULT_CHAIN_ATTRS.append("pkg.chain.{0}".format(PREFERRED_HASH))
-        DEFAULT_CHAIN_CHASH_ATTRS.append("pkg.chain.chashes.{0}".format(PREFERRED_HASH))
+    DEFAULT_HASH_ATTRS.append("pkg.content-hash")
+    DEFAULT_CHASH_ATTRS.append("pkg.content-hash")
+    DEFAULT_GELF_HASH_ATTRS.append("pkg.content-hash")
+    DEFAULT_CHAIN_ATTRS.append("pkg.chain.{0}".format(PREFERRED_HASH))
+    DEFAULT_CHAIN_CHASH_ATTRS.append(
+        "pkg.chain.chashes.{0}".format(PREFERRED_HASH)
+    )
 
 UNSIGNED_GELF_HASH_MAP = {
     "gelf:" + PREFERRED_HASH: "gelf.unsigned:" + PREFERRED_HASH
@@ -148,306 +151,321 @@ EXTRACT_GZIP = "gzip"
 
 # Dictionaries of the pkg(7) hash and content-hash attributes we know about.
 if DebugValues["hash"] == "sha1":
-        # Simulate older non-SHA2 aware pkg(7) code
-        HASH_ALGS = {"hash": hashlib.sha1}
-        GELF_HASH_ALGS = {"elfhash": hashlib.sha1}
+    # Simulate older non-SHA2 aware pkg(7) code
+    HASH_ALGS = {"hash": hashlib.sha1}
+    GELF_HASH_ALGS = {"elfhash": hashlib.sha1}
 else:
-        HASH_ALGS = {
-            "hash":            hashlib.sha1,
-            "pkg.hash.sha256": hashlib.sha256,
-            "file:sha256": hashlib.sha256,
-            "gzip:sha256": hashlib.sha256,
-        }
+    HASH_ALGS = {
+        "hash": hashlib.sha1,
+        "pkg.hash.sha256": hashlib.sha256,
+        "file:sha256": hashlib.sha256,
+        "gzip:sha256": hashlib.sha256,
+    }
 
-        GELF_HASH_ALGS = {
-            "elfhash":     hashlib.sha1,
-            "gelf:sha256": hashlib.sha256,
-            "file:sha256": hashlib.sha256
-        }
+    GELF_HASH_ALGS = {
+        "elfhash": hashlib.sha1,
+        "gelf:sha256": hashlib.sha256,
+        "file:sha256": hashlib.sha256,
+    }
 
-        if sha512_supported:
-                HASH_ALGS["pkg.hash.sha512t_256"] = pkg.sha512_t.SHA512_t
-                HASH_ALGS["file:sha512t_256"] = pkg.sha512_t.SHA512_t
-                HASH_ALGS["gzip:sha512t_256"] = pkg.sha512_t.SHA512_t
-                GELF_HASH_ALGS["gelf:sha512t_256"] = pkg.sha512_t.SHA512_t
-                GELF_HASH_ALGS["file:sha512t_256"] = pkg.sha512_t.SHA512_t
+    if sha512_supported:
+        HASH_ALGS["pkg.hash.sha512t_256"] = pkg.sha512_t.SHA512_t
+        HASH_ALGS["file:sha512t_256"] = pkg.sha512_t.SHA512_t
+        HASH_ALGS["gzip:sha512t_256"] = pkg.sha512_t.SHA512_t
+        GELF_HASH_ALGS["gelf:sha512t_256"] = pkg.sha512_t.SHA512_t
+        GELF_HASH_ALGS["file:sha512t_256"] = pkg.sha512_t.SHA512_t
 
 # A dictionary of the compressed hash attributes we know about.
 CHASH_ALGS = {}
 for key in HASH_ALGS:
-        CHASH_ALGS[key.replace("hash", "chash")] = HASH_ALGS[key]
+    CHASH_ALGS[key.replace("hash", "chash")] = HASH_ALGS[key]
 
 # A dictionary of signature action chain hash attributes we know about.
 CHAIN_ALGS = {}
 for key in HASH_ALGS:
-        CHAIN_ALGS[key.replace("hash", "chain")] = HASH_ALGS[key]
+    CHAIN_ALGS[key.replace("hash", "chain")] = HASH_ALGS[key]
 
 # A dictionary of signature action chain chash attributes we know about.
 CHAIN_CHASH_ALGS = {}
 for key in HASH_ALGS:
-        CHAIN_CHASH_ALGS[key.replace("hash", "chain.chashes")] = HASH_ALGS[key]
+    CHAIN_CHASH_ALGS[key.replace("hash", "chain.chashes")] = HASH_ALGS[key]
 
-ALL_HASH_ATTRS = (DEFAULT_HASH_ATTRS + DEFAULT_CHASH_ATTRS +
-    DEFAULT_GELF_HASH_ATTRS)
+ALL_HASH_ATTRS = (
+    DEFAULT_HASH_ATTRS + DEFAULT_CHASH_ATTRS + DEFAULT_GELF_HASH_ATTRS
+)
+
 
 def is_hash_attr(attr_name):
-        """Tells whether or not the named attribute contains a hash value."""
+    """Tells whether or not the named attribute contains a hash value."""
 
-        return attr_name in ALL_HASH_ATTRS
+    return attr_name in ALL_HASH_ATTRS
+
 
 def _get_hash_dics(hash_type):
-        """Based on the 'hash_type', return a tuple describing the ranking of
-        hash attributes from "most preferred" to "least preferred" and a mapping
-        of those attributes to the hash algorithms that are used to
-        compute those attributes.
+    """Based on the 'hash_type', return a tuple describing the ranking of
+    hash attributes from "most preferred" to "least preferred" and a mapping
+    of those attributes to the hash algorithms that are used to
+    compute those attributes.
 
-        If 'reverse' is true, return the rank_tuple in reverse order, from least
-        preferred hash to most preferred hash.
-        """
+    If 'reverse' is true, return the rank_tuple in reverse order, from least
+    preferred hash to most preferred hash.
+    """
 
-        if hash_type == HASH:
-                hash_attrs = DEFAULT_HASH_ATTRS
-                hash_dic = HASH_ALGS
-        elif hash_type == CHASH:
-                hash_attrs = DEFAULT_CHASH_ATTRS
-                hash_dic = CHASH_ALGS
-        elif hash_type == HASH_GELF:
-                hash_attrs = DEFAULT_GELF_HASH_ATTRS
-                hash_dic = GELF_HASH_ALGS
-        elif hash_type == CHAIN:
-                hash_attrs = DEFAULT_CHAIN_ATTRS
-                hash_dic = CHAIN_ALGS
-        elif hash_type == CHAIN_CHASH:
-                hash_attrs = DEFAULT_CHAIN_CHASH_ATTRS
-                hash_dic = CHAIN_CHASH_ALGS
-        else:
-                hash_attrs = None
-                hash_dic = None
+    if hash_type == HASH:
+        hash_attrs = DEFAULT_HASH_ATTRS
+        hash_dic = HASH_ALGS
+    elif hash_type == CHASH:
+        hash_attrs = DEFAULT_CHASH_ATTRS
+        hash_dic = CHASH_ALGS
+    elif hash_type == HASH_GELF:
+        hash_attrs = DEFAULT_GELF_HASH_ATTRS
+        hash_dic = GELF_HASH_ALGS
+    elif hash_type == CHAIN:
+        hash_attrs = DEFAULT_CHAIN_ATTRS
+        hash_dic = CHAIN_ALGS
+    elif hash_type == CHAIN_CHASH:
+        hash_attrs = DEFAULT_CHAIN_CHASH_ATTRS
+        hash_dic = CHAIN_CHASH_ALGS
+    else:
+        hash_attrs = None
+        hash_dic = None
 
-        return hash_attrs, hash_dic
+    return hash_attrs, hash_dic
 
 
 class ContentHash(dict):
-        """This class breaks out the stringified tuples from
-        pkg.content-hash
+    """This class breaks out the stringified tuples from
+    pkg.content-hash
 
-        "extract_method:hash_alg:hash_val"
+    "extract_method:hash_alg:hash_val"
 
-        into a dict with entries
+    into a dict with entries
 
-		"extract_method:hash_alg": "hash_val"
-        """
-        def __init__(self, vals):
-                dict.__init__(self)
+            "extract_method:hash_alg": "hash_val"
+    """
 
-                if isinstance(vals, six.string_types):
-                        vals = (vals,)
+    def __init__(self, vals):
+        dict.__init__(self)
 
-                for v in vals:
-                        vs = v.rsplit(":", 1)
-                        self[vs[0]] = vs[1]
+        if isinstance(vals, six.string_types):
+            vals = (vals,)
+
+        for v in vals:
+            vs = v.rsplit(":", 1)
+            self[vs[0]] = vs[1]
 
 
 def get_preferred_hash(action, hash_type=HASH, reversed=False):
-        """Returns a tuple of the form (hash_attr, hash_val, hash_func)
-        where 'hash_attr' is the preferred hash attribute name, 'hash_val'
-        is the preferred hash value, and 'hash_func' is the function
-        used to compute the preferred hash based on the available
-        pkg.content-hash or pkg.*hash.* attributes declared in the action."""
+    """Returns a tuple of the form (hash_attr, hash_val, hash_func)
+    where 'hash_attr' is the preferred hash attribute name, 'hash_val'
+    is the preferred hash value, and 'hash_func' is the function
+    used to compute the preferred hash based on the available
+    pkg.content-hash or pkg.*hash.* attributes declared in the action."""
 
-        hash_attrs, hash_dic = _get_hash_dics(hash_type)
-        if not (hash_attrs and hash_dic):
-                raise ValueError("Unknown hash_type {0} passed to "
-                    "get_preferred_hash".format(hash_type))
+    hash_attrs, hash_dic = _get_hash_dics(hash_type)
+    if not (hash_attrs and hash_dic):
+        raise ValueError(
+            "Unknown hash_type {0} passed to "
+            "get_preferred_hash".format(hash_type)
+        )
 
-        if hash_type == HASH_GELF:
-                extract_method = EXTRACT_GELF
-        elif hash_type == CHASH:
-                extract_method = EXTRACT_GZIP
-        else:
-                extract_method = EXTRACT_FILE
-        if reversed:
-                ranked_hashes = REVERSE_RANKED_HASHES
-        else:
-                ranked_hashes = RANKED_HASHES
+    if hash_type == HASH_GELF:
+        extract_method = EXTRACT_GELF
+    elif hash_type == CHASH:
+        extract_method = EXTRACT_GZIP
+    else:
+        extract_method = EXTRACT_FILE
+    if reversed:
+        ranked_hashes = REVERSE_RANKED_HASHES
+    else:
+        ranked_hashes = RANKED_HASHES
 
-        for alg in ranked_hashes:
-                if alg == "sha1":
-                        # The corresponding hash attr should be in the
-                        # first position if "sha1" is enabled.
-                        attr = hash_attrs[0]
-                        if not action:
-                                return attr, None, hash_dic[attr]
-                        if hash_type == HASH:
-                                if action.hash:
-                                        return attr, action.hash, hash_dic[attr]
-                        else:
-                                if attr in action.attrs:
-                                        return (attr, action.attrs[attr],
-                                            hash_dic[attr])
-                elif hash_type in (HASH, HASH_GELF, CHASH):
-                        # Currently only HASH, HASH_GELF and CHASH support
-                        # pkg.content-hash.
-                        ch_type = "{0}:{1}".format(extract_method, alg)
-                        attr = "pkg.content-hash"
-                        if not action:
-                                return attr, None, hash_dic[ch_type]
-                        if attr in action.attrs:
-                                ch = ContentHash(action.attrs[attr])
-                                if ch_type in ch:
-                                        return (attr, ch[ch_type],
-                                            hash_dic[ch_type])
-                elif hash_type in (CHAIN, CHAIN_CHASH):
-                        # The corresponding hash attr should be in the
-                        # last position if sha2 or higher algorithm is enabled.
-                        attr = hash_attrs[-1]
-                        if attr in action.attrs:
-                                return attr, action.attrs[attr], hash_dic[attr]
+    for alg in ranked_hashes:
+        if alg == "sha1":
+            # The corresponding hash attr should be in the
+            # first position if "sha1" is enabled.
+            attr = hash_attrs[0]
+            if not action:
+                return attr, None, hash_dic[attr]
+            if hash_type == HASH:
+                if action.hash:
+                    return attr, action.hash, hash_dic[attr]
+            else:
+                if attr in action.attrs:
+                    return (attr, action.attrs[attr], hash_dic[attr])
+        elif hash_type in (HASH, HASH_GELF, CHASH):
+            # Currently only HASH, HASH_GELF and CHASH support
+            # pkg.content-hash.
+            ch_type = "{0}:{1}".format(extract_method, alg)
+            attr = "pkg.content-hash"
+            if not action:
+                return attr, None, hash_dic[ch_type]
+            if attr in action.attrs:
+                ch = ContentHash(action.attrs[attr])
+                if ch_type in ch:
+                    return (attr, ch[ch_type], hash_dic[ch_type])
+        elif hash_type in (CHAIN, CHAIN_CHASH):
+            # The corresponding hash attr should be in the
+            # last position if sha2 or higher algorithm is enabled.
+            attr = hash_attrs[-1]
+            if attr in action.attrs:
+                return attr, action.attrs[attr], hash_dic[attr]
 
-        # fallback to the default hash member since it's not in action.attrs
-        if hash_type == HASH:
-                return None, action.hash, hashlib.sha1
-        # an action can legitimately have no chash
-        if hash_type == CHASH:
-                return None, None, hashlib.sha1
-        # an action can legitimately have no GELF content-hash if it's not a
-        # file type we know about
-        if hash_type == HASH_GELF:
-                return None, None, None
-        # an action can legitimately have no chain
-        if hash_type == CHAIN:
-                return None, None, None
-        # an action can legitimately have no chain_chash
-        if hash_type == CHAIN_CHASH:
-                return None, None, None
+    # fallback to the default hash member since it's not in action.attrs
+    if hash_type == HASH:
+        return None, action.hash, hashlib.sha1
+    # an action can legitimately have no chash
+    if hash_type == CHASH:
+        return None, None, hashlib.sha1
+    # an action can legitimately have no GELF content-hash if it's not a
+    # file type we know about
+    if hash_type == HASH_GELF:
+        return None, None, None
+    # an action can legitimately have no chain
+    if hash_type == CHAIN:
+        return None, None, None
+    # an action can legitimately have no chain_chash
+    if hash_type == CHAIN_CHASH:
+        return None, None, None
 
-        # This should never happen.
-        if reversed:
-                raise Exception("Error determining the least preferred hash "
-                    "for {0} {1}".format(action, hash_type))
-        else:
-                raise Exception("Error determining the preferred hash for "
-                    "{0} {1}".format(action, hash_type))
+    # This should never happen.
+    if reversed:
+        raise Exception(
+            "Error determining the least preferred hash "
+            "for {0} {1}".format(action, hash_type)
+        )
+    else:
+        raise Exception(
+            "Error determining the preferred hash for "
+            "{0} {1}".format(action, hash_type)
+        )
 
 
 def get_least_preferred_hash(action, hash_type=HASH):
-        """Returns a tuple of the least preferred hash attribute name, the hash
-        value that should result when we compute the hash, and the function used
-        to compute the hash based on the available hash and pkg.*hash.*
-        attributes declared in the action."""
+    """Returns a tuple of the least preferred hash attribute name, the hash
+    value that should result when we compute the hash, and the function used
+    to compute the hash based on the available hash and pkg.*hash.*
+    attributes declared in the action."""
 
-        return get_preferred_hash(action, hash_type=hash_type, reversed=True)
+    return get_preferred_hash(action, hash_type=hash_type, reversed=True)
 
 
-def get_common_preferred_hash(action, old_action, hash_type=HASH,
-    cmp_policy=None):
-        """Returns the most preferred hash attribute of those present
-        on a new action and/or an installed (old) version of that
-        action. We return the name of the hash attribute, the new and
-        original values of that attribute, and the function used
-        to compute the hash.
+def get_common_preferred_hash(
+    action, old_action, hash_type=HASH, cmp_policy=None
+):
+    """Returns the most preferred hash attribute of those present
+    on a new action and/or an installed (old) version of that
+    action. We return the name of the hash attribute, the new and
+    original values of that attribute, and the function used
+    to compute the hash.
 
-        The pkg.content-hash attribute may be multi-valued. When
-        selecting this attribute, a secondary selection will be made
-        based on a ranked list of value prefixes. The most preferred
-        value will then be returned.
+    The pkg.content-hash attribute may be multi-valued. When
+    selecting this attribute, a secondary selection will be made
+    based on a ranked list of value prefixes. The most preferred
+    value will then be returned.
 
-        Normally, payload comparisons should only be made based on
-        hashes that include signatures in the extracted data. This
-        constraint can be relaxed by setting cmp_policy=CMP_UNSIGNED. In
-        this case, the most preferred hash will be selected first, and
-        then we'll check for unsigned versions of that hash on both
-        actions. When both actions have that unsigned hash, its values
-        will be returned in place of the signed values.
+    Normally, payload comparisons should only be made based on
+    hashes that include signatures in the extracted data. This
+    constraint can be relaxed by setting cmp_policy=CMP_UNSIGNED. In
+    this case, the most preferred hash will be selected first, and
+    then we'll check for unsigned versions of that hash on both
+    actions. When both actions have that unsigned hash, its values
+    will be returned in place of the signed values.
 
-        If no common attribute is found, we fallback to the legacy
-        <Action>.hash member assuming it is not None for the new and
-        orig actions, and specify hashlib.sha1 as the algorithm. If no
-        'hash' member is set, we return a tuple of None objects.
+    If no common attribute is found, we fallback to the legacy
+    <Action>.hash member assuming it is not None for the new and
+    orig actions, and specify hashlib.sha1 as the algorithm. If no
+    'hash' member is set, we return a tuple of None objects.
 
-        """
+    """
 
-        if not old_action:
-                return None, None, None, None
-
-        hash_attrs, hash_dic = _get_hash_dics(hash_type)
-        if hash_type == HASH_GELF:
-                extract_method = EXTRACT_GELF
-        elif hash_type == CHASH:
-                extract_method = EXTRACT_GZIP
-        else:
-                extract_method = EXTRACT_FILE
-
-        if not (hash_attrs and hash_dic):
-                raise ValueError("Unknown hash_type {0} passed to "
-                    "get_preferred_common_hash".format(hash_type))
-
-        new_hashes = frozenset(a for a in action.attrs if a in hash_attrs)
-        old_hashes = frozenset(a for a in old_action.attrs if a in hash_attrs)
-
-        all_hashes = new_hashes | old_hashes
-
-        for alg in RANKED_HASHES:
-                if alg == "sha1":
-                        attr = hash_attrs[0]
-                        # The corresponding hash attr should be in the
-                        # first position if "sha1" is enabled.
-                        if attr not in all_hashes:
-                                continue
-                        new_hash = action.attrs.get(attr)
-                        old_hash = old_action.attrs.get(attr)
-                        return attr, new_hash, old_hash, hash_dic[attr]
-                elif hash_type in (HASH, HASH_GELF, CHASH):
-                        # Currently only HASH, HASH_GELF and CHASH support
-                        # pkg.content-hash.
-                        attr = "pkg.content-hash"
-                        if attr not in all_hashes:
-                                continue
-                        nh = ContentHash(
-                                action.attrs.get(attr, {}))
-                        oh = ContentHash(
-                                old_action.attrs.get(attr, {}))
-                        new_types = frozenset(nh)
-                        old_types = frozenset(oh)
-                        all_types = new_types | old_types
-
-                        ch_type = "{0}:{1}".format(extract_method, alg)
-                        if ch_type not in all_types:
-                                continue
-
-                        new_hash = nh.get(ch_type)
-                        old_hash = oh.get(ch_type)
-
-                        # Here we've matched a ranked hash type in at
-                        # least one of the pkg.content-hash value
-                        # sets, so we know we'll be returning. If
-                        # we're allowing comparison on unsigned hash
-                        # values, and both value sets have this hash
-                        # type, and both value sets have a
-                        # corresponding unsigned hash, swap in those
-                        # unsigned hash values.
-                        from pkg.misc import CMP_UNSIGNED
-                        if (cmp_policy == CMP_UNSIGNED and new_hash and
-                            old_hash and ch_type in UNSIGNED_GELF_HASH_MAP):
-                                ut = UNSIGNED_GELF_HASH_MAP[ch_type]
-                                if ut in nh and ut in oh:
-                                        new_hash = nh[ut]
-                                        old_hash = oh[ut]
-
-                        return attr, new_hash, old_hash, hash_dic.get(ch_type)
-                elif hash_type in (CHAIN, CHAIN_CHASH):
-                        # The corresponding hash attr should be in the
-                        # last position if sha2 or higher algorithm is enabled.
-                        attr = hash_attrs[-1]
-                        if attr not in all_hashes:
-                                continue
-                        new_hash = action.attrs.get(attr)
-                        old_hash = old_action.attrs.get(attr)
-                        return attr, new_hash, old_hash, hash_dic[attr]
-
-        if action.hash and old_action.hash:
-                return None, action.hash, old_action.hash, hashlib.sha1
+    if not old_action:
         return None, None, None, None
 
+    hash_attrs, hash_dic = _get_hash_dics(hash_type)
+    if hash_type == HASH_GELF:
+        extract_method = EXTRACT_GELF
+    elif hash_type == CHASH:
+        extract_method = EXTRACT_GZIP
+    else:
+        extract_method = EXTRACT_FILE
+
+    if not (hash_attrs and hash_dic):
+        raise ValueError(
+            "Unknown hash_type {0} passed to "
+            "get_preferred_common_hash".format(hash_type)
+        )
+
+    new_hashes = frozenset(a for a in action.attrs if a in hash_attrs)
+    old_hashes = frozenset(a for a in old_action.attrs if a in hash_attrs)
+
+    all_hashes = new_hashes | old_hashes
+
+    for alg in RANKED_HASHES:
+        if alg == "sha1":
+            attr = hash_attrs[0]
+            # The corresponding hash attr should be in the
+            # first position if "sha1" is enabled.
+            if attr not in all_hashes:
+                continue
+            new_hash = action.attrs.get(attr)
+            old_hash = old_action.attrs.get(attr)
+            return attr, new_hash, old_hash, hash_dic[attr]
+        elif hash_type in (HASH, HASH_GELF, CHASH):
+            # Currently only HASH, HASH_GELF and CHASH support
+            # pkg.content-hash.
+            attr = "pkg.content-hash"
+            if attr not in all_hashes:
+                continue
+            nh = ContentHash(action.attrs.get(attr, {}))
+            oh = ContentHash(old_action.attrs.get(attr, {}))
+            new_types = frozenset(nh)
+            old_types = frozenset(oh)
+            all_types = new_types | old_types
+
+            ch_type = "{0}:{1}".format(extract_method, alg)
+            if ch_type not in all_types:
+                continue
+
+            new_hash = nh.get(ch_type)
+            old_hash = oh.get(ch_type)
+
+            # Here we've matched a ranked hash type in at
+            # least one of the pkg.content-hash value
+            # sets, so we know we'll be returning. If
+            # we're allowing comparison on unsigned hash
+            # values, and both value sets have this hash
+            # type, and both value sets have a
+            # corresponding unsigned hash, swap in those
+            # unsigned hash values.
+            from pkg.misc import CMP_UNSIGNED
+
+            if (
+                cmp_policy == CMP_UNSIGNED
+                and new_hash
+                and old_hash
+                and ch_type in UNSIGNED_GELF_HASH_MAP
+            ):
+                ut = UNSIGNED_GELF_HASH_MAP[ch_type]
+                if ut in nh and ut in oh:
+                    new_hash = nh[ut]
+                    old_hash = oh[ut]
+
+            return attr, new_hash, old_hash, hash_dic.get(ch_type)
+        elif hash_type in (CHAIN, CHAIN_CHASH):
+            # The corresponding hash attr should be in the
+            # last position if sha2 or higher algorithm is enabled.
+            attr = hash_attrs[-1]
+            if attr not in all_hashes:
+                continue
+            new_hash = action.attrs.get(attr)
+            old_hash = old_action.attrs.get(attr)
+            return attr, new_hash, old_hash, hash_dic[attr]
+
+    if action.hash and old_action.hash:
+        return None, action.hash, old_action.hash, hashlib.sha1
+    return None, None, None, None
+
+
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/facet.py
+++ b/src/modules/facet.py
@@ -37,501 +37,501 @@ import pkg.misc as misc
 from pkg._varcet import _allow_facet
 from pkg.misc import EmptyI, ImmutableDict
 
+
 class Facets(dict):
-        # store information on facets; subclass dict
-        # and maintain ordered list of keys sorted
-        # by length.
-
-        # subclass __getitem__ so that queries w/
-        # actual facets find match
-
-        #
-        # For image planning purposes and to be able to compare facet objects
-        # deterministically, facets must be sorted.  They are first sorted by
-        # source (more details below), then by length, then lexically.
-        #
-        # Facets can come from three different sources.
-        #
-        # SYSTEM facets are facets whose values are assigned by the system.
-        # These are usually facets defined in packages which are not set in an
-        # image, and the value assigned by the system is always true.  These
-        # facets will usually never be found in a Facets dictionary.  (Facets
-        # dictionaries only contain facets which are explicitly set.)
-        #
-        # LOCAL facets are facets which have been set locally in an image
-        # using pkg(1) or the pkg api.  Explicitly set LOCAL facets are stored
-        # in Facets.__local.  Facets which are not explicitly set but match an
-        # explicitly set LOCAL facet glob pattern are also considered to be
-        # LOCAL.
-        #
-        # PARENT facets are facets which are inherited from a parent image.
-        # they are managed internally by the packaging subsystem.  Explicitly
-        # inherited facets are stored in Facets.__inherited.  Facets which are
-        # not explicitly set but match an explicitly set PARENT facet glob
-        # pattern are also considered to be PARENT.
-        #
-        # When evaluating facets, all PARENT facets are evaluated before LOCAL
-        # facets.  This is done by ensuring that all PARENT facets come before
-        # any LOCAL facets in __keylist.  This is done because PARENT facets
-        # exist to propagate faceted dependencies between linked images, which
-        # is needed to ensure the solver can run successfully.  ie, if a
-        # parent image relaxes dependencies via facet version-locks, then the
-        # child needs to inherit those facets since otherwise it is more
-        # constrained in possible solutions than it's parent and likely won't
-        # be able to plan an update that keeps it in sync with it's parent.
-        #
-        # Sine PARENT facets take priority over LOCAL facets, it's possible to
-        # have conflicts between the two.  In the case where a facet is both
-        # inherited and set locally, both values are preserved, but the
-        # inherited value masks the local value.  Users can list and update
-        # local values while they are masked using pkg(1), but as long as the
-        # values are masked they will not affect image planning operations.
-        # Once an inherited facet that masks a local facet is removed, the
-        # local facet will be restored.
-        #
-
-        FACET_SRC_SYSTEM = "system"
-        FACET_SRC_LOCAL = "local"
-        FACET_SRC_PARENT = "parent"
-
-        def __init__(self, init=EmptyI):
-                dict.__init__(self)
-                self.__keylist = []
-                self.__res = {}
-                self.__local = {}
-                self.__local_ro = None
-                self.__inherited = {}
-                self.__inherited_ro = None
-
-                # initialize ourselves
-                self.update(init)
-
-        @staticmethod
-        def getstate(obj, je_state=None):
-                """Returns the serialized state of this object in a format
-                that that can be easily stored using JSON, pickle, etc."""
-
-                return [
-                        [misc.force_text(k), v, True]
-                        for k, v in six.iteritems(obj.__inherited)
-                ] + [
-                        [misc.force_text(k), v, False]
-                        for k, v in six.iteritems(obj.__local)
-                ]
-
-        @staticmethod
-        def fromstate(state, jd_state=None):
-                """Update the state of this object using previously serialized
-                state obtained via getstate()."""
-
-                rv = Facets()
-                for k, v, inhertited in state:
-                        if not inhertited:
-                                rv[k] = v
-                        else:
-                                rv._set_inherited(k, v)
-                return rv
-
-        def _cmp_priority(self, other):
-                """Compare the facet match priority of two Facets objects.
-                Since the match priority of a Facets object is dependent upon
-                facet sources (local vs parent) and names, we're essentially
-                ensuring that both objects have the same set of facet sources
-                and names."""
-
-                assert type(other) is Facets
-                return misc.cmp(self.__keylist, other.__keylist)
-
-        def _cmp_values(self, other):
-                """Compare the facet values of two Facets objects.  This
-                comparison ignores any masked values."""
-
-                assert type(other) is Facets
-                return misc.cmp(self, other)
-
-        def _cmp_all_values(self, other):
-                """Compare all the facet values of two Facets objects.  This
-                comparison takes masked values into account."""
-
-                assert type(other) is Facets
-                rv = misc.cmp(self.__inherited, other.__inherited)
-                if rv == 0:
-                        rv = misc.cmp(self.__local, other.__local)
-                return rv
-
-        # this __cmp__ is used as a helper function for the rich comparison
-        # methods.
-        # __cmp__ defined; pylint: disable=W1630
-        def __cmp__(self, other):
-                """Compare two Facets objects.  This comparison takes masked
-                values into account."""
-
-                # check if we're getting compared against something other than
-                # another Factes object.
-                if type(other) is not Facets:
-                        return 1
-
-                # Check for effective facet value changes that could affect
-                # solver computations.
-                rv = self._cmp_values(other)
-                if rv != 0:
-                        return rv
-
-                # Check for facet priority changes that could affect solver
-                # computations.  (Priority changes can occur when local or
-                # inherited facets are added or removed.)
-                rv = self._cmp_priority(other)
-                if rv != 0:
-                        return rv
-
-                # There are no outwardly visible facet priority or value
-                # changes that could affect solver computations, but it's
-                # still possible that we're changing the set of local or
-                # inherited facets in a way that doesn't affect solver
-                # computations.  For example:  we could be adding a local
-                # facet with a value that is masked by an inherited facet, or
-                # having a facet transition from being inherited to being
-                # local without a priority or value change.  Check if this is
-                # the case.
-                rv = self._cmp_all_values(other)
-                return rv
-
-        def __hash__(self):
-                return hash(str(self))
-
-        def __eq__(self, other):
-                """redefine in terms of __cmp__()"""
-                return (Facets.__cmp__(self, other) == 0)
-
-        def __ne__(self, other):
-                """redefine in terms of __cmp__()"""
-                return (Facets.__cmp__(self, other) != 0)
-
-        def __ge__(self, other):
-                """redefine in terms of __cmp__()"""
-                return (Facets.__cmp__(self, other) >= 0)
-
-        def __gt__(self, other):
-                """redefine in terms of __cmp__()"""
-                return (Facets.__cmp__(self, other) > 0)
-
-        def __le__(self, other):
-                """redefine in terms of __cmp__()"""
-                return (Facets.__cmp__(self, other) <= 0)
-
-        def __lt__(self, other):
-                """redefine in terms of __cmp__()"""
-                return (Facets.__cmp__(self, other) < 0)
-
-        def __repr__(self):
-                s =  "<"
-                s += ", ".join([
-                    "{0}:{1}".format(k, dict.__getitem__(self, k))
-                    for k in self.__keylist
-                ])
-                s += ">"
-
-                return s
-
-        def __keylist_sort(self):
-                """Update __keysort, which is used to determine facet matching
-                order.  Inherited facets always take priority over local
-                facets so make sure all inherited facets come before local
-                facets in __keylist.  All facets from a given source are
-                sorted by length, and facets of equal length are sorted
-                lexically."""
-
-                def facet_sort(x, y):
-                        i = len(y) - len(x)
-                        if i != 0:
-                                return i
-                        return misc.cmp(x, y)
-
-                self.__keylist = []
-                self.__keylist += sorted([
-                        i
-                        for i in self
-                        if i in self.__inherited
-                ], key=cmp_to_key(facet_sort))
-                self.__keylist += sorted([
-                        i
-                        for i in self
-                        if i not in self.__inherited
-                ], key=cmp_to_key(facet_sort))
-
-        def __setitem_internal(self, item, value, inherited=False):
-                if not item.startswith("facet."):
-                        raise KeyError('key must start with "facet".')
-
-                if not (value == True or value == False):
-                        raise ValueError("value must be boolean")
-
-                keylist_sort = False
-                if (inherited and item not in self.__inherited) or \
-                    (not inherited and item not in self):
-                        keylist_sort = True
-
-                # save the facet in the local or inherited dictionary
-                # clear the corresponding read-only dictionary
-                if inherited:
-                        self.__inherited[item] = value
-                        self.__inherited_ro = None
-                else:
-                        self.__local[item] = value
-                        self.__local_ro = None
-
-                # Inherited facets always take priority over local facets.
-                if inherited or item not in self.__inherited:
-                        dict.__setitem__(self, item, value)
-                        self.__res[item] = re.compile(fnmatch.translate(item))
-
-                if keylist_sort:
-                        self.__keylist_sort()
-
-        def __setitem__(self, item, value):
-                """__setitem__ only operates on local facets."""
-                self.__setitem_internal(item, value)
-
-        def __getitem_internal(self, item):
-                """Implement facet lookup algorithm here
-
-                Note that _allow_facet bypasses __getitem__ for performance
-                reasons; if __getitem__ changes, _allow_facet in _varcet.c
-                must also be updated.
-
-                We return a tuple of the form (<key>, <value>) where key is
-                the explicitly set facet name (which may be a glob pattern)
-                that matched the caller specific facet name."""
-
-                if not item.startswith("facet."):
-                        raise KeyError("key must start w/ facet.")
-
-                if item in self:
-                        return item, dict.__getitem__(self, item)
-                for k in self.__keylist:
-                        if self.__res[k].match(item):
-                                return k, dict.__getitem__(self, k)
-
-                # The trailing '.' is to encourage namespace usage.
-                if item.startswith("facet.debug.") or \
-                    item.startswith("facet.optional."):
-                        return None, False # exclude by default
-                return None, True # be inclusive
-
-        def __getitem__(self, item):
-                return self.__getitem_internal(item)[1]
-
-        def __delitem_internal(self, item, inherited=False):
-
-                # check for an attempt to delete an invalid facet
-                if not dict.__contains__(self, item):
-                        raise KeyError(item)
-
-                # check for an attempt to delete an invalid local facet
-                if not inherited and item not in self.__local:
-                        raise KeyError(item)
-
-                # we should never try to delete an invalid inherited facet
-                assert not inherited or item in self.inherited
-
-                keylist_sort = False
-                if inherited and item in self.__local:
-                        # the inherited value was overriding a local value
-                        # that should now be exposed
-                        dict.__setitem__(self, item, self.__local[item])
-                        self.__res[item] = re.compile(fnmatch.translate(item))
-                        keylist_sort = True
-                else:
-                        # delete the item
-                        dict.__delitem__(self, item)
-                        del self.__res[item]
-                        self.__keylist.remove(item)
-
-                # delete item from the local or inherited dictionary
-                # clear the corresponding read-only dictionary
-                if inherited:
-                        rv = self.__inherited[item]
-                        del self.__inherited[item]
-                        self.__inherited_ro = None
-                else:
-                        rv = self.__local[item]
-                        del self.__local[item]
-                        self.__local_ro = None
-
-                if keylist_sort:
-                        self.__keylist_sort()
-                return rv
-
-        def __delitem__(self, item):
-                """__delitem__ only operates on local facets."""
-                self.__delitem_internal(item)
-
-        # allow_action is provided as a native function (see end of class
-        # declaration).
-
-        def _set_inherited(self, item, value):
-                """Set an inherited facet."""
-                self.__setitem_internal(item, value, inherited=True)
-
-        def _clear_inherited(self):
-                """Clear all inherited facet."""
-                for k in list(self.__inherited.keys()):
-                        self.__delitem_internal(k, inherited=True)
-
-        def _action_match(self, act):
-                """Find the subset of facet key/values pairs which match any
-                facets present on an action."""
-
-                # find all the facets present in the current action
-                action_facets = frozenset([
-                        a
-                        for a in act.attrs
-                        if a.startswith("facet.")
-                ])
-
-                rv = set()
-                for facet in self.__keylist:
-                        if facet in action_facets:
-                                # we found a matching facet.
-                                rv.add((facet, self[facet]))
-                                continue
-                        for action_facet in action_facets:
-                                if self.__res[facet].match(action_facet):
-                                        # we found a matching facet.
-                                        rv.add((facet, self[facet]))
-                                        break
-
-                return (frozenset(rv))
-
-        def pop(self, item, *args, **kwargs):
-                """pop() only operates on local facets."""
-
-                assert len(args) == 0 or (len(args) == 1 and
-                    "default" not in kwargs)
-
-                if item not in self.__local:
-                        # check if the user specified a default value
-                        if args:
-                                return args[0]
-                        elif "default" in kwargs:
-                                return kwargs["default"]
-                        if len(self) == 0:
-                                raise KeyError('pop(): dictionary is empty')
-                        raise KeyError(item)
-
-                return self.__delitem_internal(item, inherited=False)
-
-        def popitem(self):
-                """popitem() only operates on local facets."""
-
-                item = None
-                for item, value in self.__local:
-                        break
-
-                if item is None:
-                        raise KeyError('popitem(): dictionary is empty')
-
-                self.__delitem_internal(item)
-                return (item, value)
-
-        def setdefault(self, item, default=None):
-                if item not in self:
-                        self[item] = default
-                return self[item]
-
-        def update(self, d):
-                if type(d) == Facets:
-                        # preserve inherited facets.
-                        for k, v in six.iteritems(d.__inherited):
-                                self._set_inherited(k, v)
-                        for k, v in six.iteritems(d.__local):
-                                self[k] = v
-                        return
-
-                for k in d:
-                        self[k] = d[k]
-
-        def keys(self):
-                return self.__keylist[:]
-
-        def values(self):
-                return [self[k] for k in self.__keylist]
-
-        def _src_values(self, name):
-                """A facet may be set via multiple sources and hence have
-                multiple values.  If there are multiple values for a facet,
-                all but one of those values will be masked.  So for a given
-                facet, return a list of tuples of the form (<value>, <src>,
-                <masked>) which represent all currently set values for this
-                facet."""
-
-                rv = []
-                if name in self.__inherited:
-                        src = self.FACET_SRC_PARENT
-                        value = self.__inherited[name]
-                        masked = False
-                        rv.append((value, src, masked))
-                if name in self.__local:
-                        src = self.FACET_SRC_LOCAL
-                        value = self.__local[name]
-                        masked = False
-                        if name in self.__inherited:
-                                masked = True
-                        rv.append((value, src, masked))
-                return rv
-
-        def items(self):
-                return [a for a in self.iteritems()]
-
-        def iteritems(self): # return in sorted order for display
-                for k in self.__keylist:
-                        yield k, self[k]
-
-        def copy(self):
-                return Facets(self)
-
-        def clear(self):
-                self.__keylist = []
-                self.__res = {}
-                self.__local = {}
-                self.__local_ro = None
-                self.__inherited = {}
-                self.__inherited_ro = None
-                dict.clear(self)
-
-        def _match_src(self, name):
-                """Report the source of a facet value if we were to attempt to
-                look it up in the current Facets object dictionary."""
-
-                k = self.__getitem_internal(name)[0]
-                if k in self.__inherited:
-                        return self.FACET_SRC_PARENT
-                if k in self.__local:
-                        return self.FACET_SRC_LOCAL
-                assert k is None and k not in self
-                return self.FACET_SRC_SYSTEM
-
-        # For convenience, provide callers with direct access to local and
-        # parent facets via cached read-only dictionaries.
-        @property
-        def local(self):
-                if self.__local_ro is None:
-                        self.__local_ro = ImmutableDict(self.__local)
-                return self.__local_ro
-
-        @property
-        def inherited(self):
-                if self.__inherited_ro is None:
-                        self.__inherited_ro = ImmutableDict(self.__inherited)
-                return self.__inherited_ro
-
-
-        if six.PY3:
-                def allow_action(self, action, publisher=None):
-                        return _allow_facet(self, action, publisher=publisher)
+    # store information on facets; subclass dict
+    # and maintain ordered list of keys sorted
+    # by length.
+
+    # subclass __getitem__ so that queries w/
+    # actual facets find match
+
+    #
+    # For image planning purposes and to be able to compare facet objects
+    # deterministically, facets must be sorted.  They are first sorted by
+    # source (more details below), then by length, then lexically.
+    #
+    # Facets can come from three different sources.
+    #
+    # SYSTEM facets are facets whose values are assigned by the system.
+    # These are usually facets defined in packages which are not set in an
+    # image, and the value assigned by the system is always true.  These
+    # facets will usually never be found in a Facets dictionary.  (Facets
+    # dictionaries only contain facets which are explicitly set.)
+    #
+    # LOCAL facets are facets which have been set locally in an image
+    # using pkg(1) or the pkg api.  Explicitly set LOCAL facets are stored
+    # in Facets.__local.  Facets which are not explicitly set but match an
+    # explicitly set LOCAL facet glob pattern are also considered to be
+    # LOCAL.
+    #
+    # PARENT facets are facets which are inherited from a parent image.
+    # they are managed internally by the packaging subsystem.  Explicitly
+    # inherited facets are stored in Facets.__inherited.  Facets which are
+    # not explicitly set but match an explicitly set PARENT facet glob
+    # pattern are also considered to be PARENT.
+    #
+    # When evaluating facets, all PARENT facets are evaluated before LOCAL
+    # facets.  This is done by ensuring that all PARENT facets come before
+    # any LOCAL facets in __keylist.  This is done because PARENT facets
+    # exist to propagate faceted dependencies between linked images, which
+    # is needed to ensure the solver can run successfully.  ie, if a
+    # parent image relaxes dependencies via facet version-locks, then the
+    # child needs to inherit those facets since otherwise it is more
+    # constrained in possible solutions than it's parent and likely won't
+    # be able to plan an update that keeps it in sync with it's parent.
+    #
+    # Sine PARENT facets take priority over LOCAL facets, it's possible to
+    # have conflicts between the two.  In the case where a facet is both
+    # inherited and set locally, both values are preserved, but the
+    # inherited value masks the local value.  Users can list and update
+    # local values while they are masked using pkg(1), but as long as the
+    # values are masked they will not affect image planning operations.
+    # Once an inherited facet that masks a local facet is removed, the
+    # local facet will be restored.
+    #
+
+    FACET_SRC_SYSTEM = "system"
+    FACET_SRC_LOCAL = "local"
+    FACET_SRC_PARENT = "parent"
+
+    def __init__(self, init=EmptyI):
+        dict.__init__(self)
+        self.__keylist = []
+        self.__res = {}
+        self.__local = {}
+        self.__local_ro = None
+        self.__inherited = {}
+        self.__inherited_ro = None
+
+        # initialize ourselves
+        self.update(init)
+
+    @staticmethod
+    def getstate(obj, je_state=None):
+        """Returns the serialized state of this object in a format
+        that that can be easily stored using JSON, pickle, etc."""
+
+        return [
+            [misc.force_text(k), v, True]
+            for k, v in six.iteritems(obj.__inherited)
+        ] + [
+            [misc.force_text(k), v, False]
+            for k, v in six.iteritems(obj.__local)
+        ]
+
+    @staticmethod
+    def fromstate(state, jd_state=None):
+        """Update the state of this object using previously serialized
+        state obtained via getstate()."""
+
+        rv = Facets()
+        for k, v, inhertited in state:
+            if not inhertited:
+                rv[k] = v
+            else:
+                rv._set_inherited(k, v)
+        return rv
+
+    def _cmp_priority(self, other):
+        """Compare the facet match priority of two Facets objects.
+        Since the match priority of a Facets object is dependent upon
+        facet sources (local vs parent) and names, we're essentially
+        ensuring that both objects have the same set of facet sources
+        and names."""
+
+        assert type(other) is Facets
+        return misc.cmp(self.__keylist, other.__keylist)
+
+    def _cmp_values(self, other):
+        """Compare the facet values of two Facets objects.  This
+        comparison ignores any masked values."""
+
+        assert type(other) is Facets
+        return misc.cmp(self, other)
+
+    def _cmp_all_values(self, other):
+        """Compare all the facet values of two Facets objects.  This
+        comparison takes masked values into account."""
+
+        assert type(other) is Facets
+        rv = misc.cmp(self.__inherited, other.__inherited)
+        if rv == 0:
+            rv = misc.cmp(self.__local, other.__local)
+        return rv
+
+    # this __cmp__ is used as a helper function for the rich comparison
+    # methods.
+    # __cmp__ defined; pylint: disable=W1630
+    def __cmp__(self, other):
+        """Compare two Facets objects.  This comparison takes masked
+        values into account."""
+
+        # check if we're getting compared against something other than
+        # another Factes object.
+        if type(other) is not Facets:
+            return 1
+
+        # Check for effective facet value changes that could affect
+        # solver computations.
+        rv = self._cmp_values(other)
+        if rv != 0:
+            return rv
+
+        # Check for facet priority changes that could affect solver
+        # computations.  (Priority changes can occur when local or
+        # inherited facets are added or removed.)
+        rv = self._cmp_priority(other)
+        if rv != 0:
+            return rv
+
+        # There are no outwardly visible facet priority or value
+        # changes that could affect solver computations, but it's
+        # still possible that we're changing the set of local or
+        # inherited facets in a way that doesn't affect solver
+        # computations.  For example:  we could be adding a local
+        # facet with a value that is masked by an inherited facet, or
+        # having a facet transition from being inherited to being
+        # local without a priority or value change.  Check if this is
+        # the case.
+        rv = self._cmp_all_values(other)
+        return rv
+
+    def __hash__(self):
+        return hash(str(self))
+
+    def __eq__(self, other):
+        """redefine in terms of __cmp__()"""
+        return Facets.__cmp__(self, other) == 0
+
+    def __ne__(self, other):
+        """redefine in terms of __cmp__()"""
+        return Facets.__cmp__(self, other) != 0
+
+    def __ge__(self, other):
+        """redefine in terms of __cmp__()"""
+        return Facets.__cmp__(self, other) >= 0
+
+    def __gt__(self, other):
+        """redefine in terms of __cmp__()"""
+        return Facets.__cmp__(self, other) > 0
+
+    def __le__(self, other):
+        """redefine in terms of __cmp__()"""
+        return Facets.__cmp__(self, other) <= 0
+
+    def __lt__(self, other):
+        """redefine in terms of __cmp__()"""
+        return Facets.__cmp__(self, other) < 0
+
+    def __repr__(self):
+        s = "<"
+        s += ", ".join(
+            [
+                "{0}:{1}".format(k, dict.__getitem__(self, k))
+                for k in self.__keylist
+            ]
+        )
+        s += ">"
+
+        return s
+
+    def __keylist_sort(self):
+        """Update __keysort, which is used to determine facet matching
+        order.  Inherited facets always take priority over local
+        facets so make sure all inherited facets come before local
+        facets in __keylist.  All facets from a given source are
+        sorted by length, and facets of equal length are sorted
+        lexically."""
+
+        def facet_sort(x, y):
+            i = len(y) - len(x)
+            if i != 0:
+                return i
+            return misc.cmp(x, y)
+
+        self.__keylist = []
+        self.__keylist += sorted(
+            [i for i in self if i in self.__inherited],
+            key=cmp_to_key(facet_sort),
+        )
+        self.__keylist += sorted(
+            [i for i in self if i not in self.__inherited],
+            key=cmp_to_key(facet_sort),
+        )
+
+    def __setitem_internal(self, item, value, inherited=False):
+        if not item.startswith("facet."):
+            raise KeyError('key must start with "facet".')
+
+        if not (value == True or value == False):
+            raise ValueError("value must be boolean")
+
+        keylist_sort = False
+        if (inherited and item not in self.__inherited) or (
+            not inherited and item not in self
+        ):
+            keylist_sort = True
+
+        # save the facet in the local or inherited dictionary
+        # clear the corresponding read-only dictionary
+        if inherited:
+            self.__inherited[item] = value
+            self.__inherited_ro = None
+        else:
+            self.__local[item] = value
+            self.__local_ro = None
+
+        # Inherited facets always take priority over local facets.
+        if inherited or item not in self.__inherited:
+            dict.__setitem__(self, item, value)
+            self.__res[item] = re.compile(fnmatch.translate(item))
+
+        if keylist_sort:
+            self.__keylist_sort()
+
+    def __setitem__(self, item, value):
+        """__setitem__ only operates on local facets."""
+        self.__setitem_internal(item, value)
+
+    def __getitem_internal(self, item):
+        """Implement facet lookup algorithm here
+
+        Note that _allow_facet bypasses __getitem__ for performance
+        reasons; if __getitem__ changes, _allow_facet in _varcet.c
+        must also be updated.
+
+        We return a tuple of the form (<key>, <value>) where key is
+        the explicitly set facet name (which may be a glob pattern)
+        that matched the caller specific facet name."""
+
+        if not item.startswith("facet."):
+            raise KeyError("key must start w/ facet.")
+
+        if item in self:
+            return item, dict.__getitem__(self, item)
+        for k in self.__keylist:
+            if self.__res[k].match(item):
+                return k, dict.__getitem__(self, k)
+
+        # The trailing '.' is to encourage namespace usage.
+        if item.startswith("facet.debug.") or item.startswith(
+            "facet.optional."
+        ):
+            return None, False  # exclude by default
+        return None, True  # be inclusive
+
+    def __getitem__(self, item):
+        return self.__getitem_internal(item)[1]
+
+    def __delitem_internal(self, item, inherited=False):
+        # check for an attempt to delete an invalid facet
+        if not dict.__contains__(self, item):
+            raise KeyError(item)
+
+        # check for an attempt to delete an invalid local facet
+        if not inherited and item not in self.__local:
+            raise KeyError(item)
+
+        # we should never try to delete an invalid inherited facet
+        assert not inherited or item in self.inherited
+
+        keylist_sort = False
+        if inherited and item in self.__local:
+            # the inherited value was overriding a local value
+            # that should now be exposed
+            dict.__setitem__(self, item, self.__local[item])
+            self.__res[item] = re.compile(fnmatch.translate(item))
+            keylist_sort = True
+        else:
+            # delete the item
+            dict.__delitem__(self, item)
+            del self.__res[item]
+            self.__keylist.remove(item)
+
+        # delete item from the local or inherited dictionary
+        # clear the corresponding read-only dictionary
+        if inherited:
+            rv = self.__inherited[item]
+            del self.__inherited[item]
+            self.__inherited_ro = None
+        else:
+            rv = self.__local[item]
+            del self.__local[item]
+            self.__local_ro = None
+
+        if keylist_sort:
+            self.__keylist_sort()
+        return rv
+
+    def __delitem__(self, item):
+        """__delitem__ only operates on local facets."""
+        self.__delitem_internal(item)
+
+    # allow_action is provided as a native function (see end of class
+    # declaration).
+
+    def _set_inherited(self, item, value):
+        """Set an inherited facet."""
+        self.__setitem_internal(item, value, inherited=True)
+
+    def _clear_inherited(self):
+        """Clear all inherited facet."""
+        for k in list(self.__inherited.keys()):
+            self.__delitem_internal(k, inherited=True)
+
+    def _action_match(self, act):
+        """Find the subset of facet key/values pairs which match any
+        facets present on an action."""
+
+        # find all the facets present in the current action
+        action_facets = frozenset(
+            [a for a in act.attrs if a.startswith("facet.")]
+        )
+
+        rv = set()
+        for facet in self.__keylist:
+            if facet in action_facets:
+                # we found a matching facet.
+                rv.add((facet, self[facet]))
+                continue
+            for action_facet in action_facets:
+                if self.__res[facet].match(action_facet):
+                    # we found a matching facet.
+                    rv.add((facet, self[facet]))
+                    break
+
+        return frozenset(rv)
+
+    def pop(self, item, *args, **kwargs):
+        """pop() only operates on local facets."""
+
+        assert len(args) == 0 or (len(args) == 1 and "default" not in kwargs)
+
+        if item not in self.__local:
+            # check if the user specified a default value
+            if args:
+                return args[0]
+            elif "default" in kwargs:
+                return kwargs["default"]
+            if len(self) == 0:
+                raise KeyError("pop(): dictionary is empty")
+            raise KeyError(item)
+
+        return self.__delitem_internal(item, inherited=False)
+
+    def popitem(self):
+        """popitem() only operates on local facets."""
+
+        item = None
+        for item, value in self.__local:
+            break
+
+        if item is None:
+            raise KeyError("popitem(): dictionary is empty")
+
+        self.__delitem_internal(item)
+        return (item, value)
+
+    def setdefault(self, item, default=None):
+        if item not in self:
+            self[item] = default
+        return self[item]
+
+    def update(self, d):
+        if type(d) == Facets:
+            # preserve inherited facets.
+            for k, v in six.iteritems(d.__inherited):
+                self._set_inherited(k, v)
+            for k, v in six.iteritems(d.__local):
+                self[k] = v
+            return
+
+        for k in d:
+            self[k] = d[k]
+
+    def keys(self):
+        return self.__keylist[:]
+
+    def values(self):
+        return [self[k] for k in self.__keylist]
+
+    def _src_values(self, name):
+        """A facet may be set via multiple sources and hence have
+        multiple values.  If there are multiple values for a facet,
+        all but one of those values will be masked.  So for a given
+        facet, return a list of tuples of the form (<value>, <src>,
+        <masked>) which represent all currently set values for this
+        facet."""
+
+        rv = []
+        if name in self.__inherited:
+            src = self.FACET_SRC_PARENT
+            value = self.__inherited[name]
+            masked = False
+            rv.append((value, src, masked))
+        if name in self.__local:
+            src = self.FACET_SRC_LOCAL
+            value = self.__local[name]
+            masked = False
+            if name in self.__inherited:
+                masked = True
+            rv.append((value, src, masked))
+        return rv
+
+    def items(self):
+        return [a for a in self.iteritems()]
+
+    def iteritems(self):  # return in sorted order for display
+        for k in self.__keylist:
+            yield k, self[k]
+
+    def copy(self):
+        return Facets(self)
+
+    def clear(self):
+        self.__keylist = []
+        self.__res = {}
+        self.__local = {}
+        self.__local_ro = None
+        self.__inherited = {}
+        self.__inherited_ro = None
+        dict.clear(self)
+
+    def _match_src(self, name):
+        """Report the source of a facet value if we were to attempt to
+        look it up in the current Facets object dictionary."""
+
+        k = self.__getitem_internal(name)[0]
+        if k in self.__inherited:
+            return self.FACET_SRC_PARENT
+        if k in self.__local:
+            return self.FACET_SRC_LOCAL
+        assert k is None and k not in self
+        return self.FACET_SRC_SYSTEM
+
+    # For convenience, provide callers with direct access to local and
+    # parent facets via cached read-only dictionaries.
+    @property
+    def local(self):
+        if self.__local_ro is None:
+            self.__local_ro = ImmutableDict(self.__local)
+        return self.__local_ro
+
+    @property
+    def inherited(self):
+        if self.__inherited_ro is None:
+            self.__inherited_ro = ImmutableDict(self.__inherited)
+        return self.__inherited_ro
+
+    if six.PY3:
+
+        def allow_action(self, action, publisher=None):
+            return _allow_facet(self, action, publisher=publisher)
+
 
 if six.PY2:
-        Facets.allow_action = types.MethodType(_allow_facet, None, Facets)
+    Facets.allow_action = types.MethodType(_allow_facet, None, Facets)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/file_layout/__init__.py
+++ b/src/modules/file_layout/__init__.py
@@ -25,9 +25,8 @@
 # Use is subject to license terms.
 #
 
-__all__ = [
-]
-    
+__all__ = []
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/file_layout/file_manager.py
+++ b/src/modules/file_layout/file_manager.py
@@ -47,335 +47,327 @@ import pkg.client.api_errors as apx
 import pkg.portable as portable
 import pkg.file_layout.layout as layout
 
+
 class NeedToModifyReadOnlyFileManager(apx.ApiException):
-        """This exception is raised when the caller attempts to modify a
-        read-only FileManager."""
+    """This exception is raised when the caller attempts to modify a
+    read-only FileManager."""
 
-        def __init__(self, thing_to_change, create="create"):
-                """Create a NeedToModifyReadOnlyFileManager exception.
+    def __init__(self, thing_to_change, create="create"):
+        """Create a NeedToModifyReadOnlyFileManager exception.
 
-                The "thing_to_change" parameter is the entity that the file
-                manager was asked to modify.
+        The "thing_to_change" parameter is the entity that the file
+        manager was asked to modify.
 
-                The "create" parameter describes what kind of modification
-                was being attempted."""
+        The "create" parameter describes what kind of modification
+        was being attempted."""
 
-                apx.ApiException.__init__(self)
-                self.ent = thing_to_change
-                self.create = create
+        apx.ApiException.__init__(self)
+        self.ent = thing_to_change
+        self.create = create
 
-        def __str__(self):
-                return _("The FileManager cannot {cre} {ent} because it "
-                    "is configured read-only.").format(
-                    cre=self.create, ent=self.ent)
+    def __str__(self):
+        return _(
+            "The FileManager cannot {cre} {ent} because it "
+            "is configured read-only."
+        ).format(cre=self.create, ent=self.ent)
 
 
 class FMInsertionFailure(apx.ApiException):
-        """Used to indicate that an in-progress insert failed because the
-        item to be inserted went missing during the operation and wasn't
-        already found in the cache."""
+    """Used to indicate that an in-progress insert failed because the
+    item to be inserted went missing during the operation and wasn't
+    already found in the cache."""
 
-        def __init__(self, src, dest):
-                apx.ApiException.__init__(self)
-                self.src = src
-                self.dest = dest
+    def __init__(self, src, dest):
+        apx.ApiException.__init__(self)
+        self.src = src
+        self.dest = dest
 
-        def __str__(self):
-                return _("{src} was removed while FileManager was attempting "
-                    "to insert it into the cache as {dest}.").format(
-                    **self.__dict__)
+    def __str__(self):
+        return _(
+            "{src} was removed while FileManager was attempting "
+            "to insert it into the cache as {dest}."
+        ).format(**self.__dict__)
 
 
 class FMPermissionsException(apx.PermissionsException):
-        """This exception is raised when a FileManager does not have the
-        permissions to operate as needed on the file system."""
+    """This exception is raised when a FileManager does not have the
+    permissions to operate as needed on the file system."""
 
-        def __str__(self):
-                return _("FileManager was unable to create {0} or the "
-                    "directories containing it.").format(self.path)
+    def __str__(self):
+        return _(
+            "FileManager was unable to create {0} or the "
+            "directories containing it."
+        ).format(self.path)
 
 
 class UnrecognizedFilePaths(apx.ApiException):
-        """This exception is raised when files are found under the FileManager's
-        root which cannot be accounted for."""
+    """This exception is raised when files are found under the FileManager's
+    root which cannot be accounted for."""
 
-        def __init__(self, filepaths):
-                apx.ApiException.__init__(self)
-                self.fps = filepaths
+    def __init__(self, filepaths):
+        apx.ApiException.__init__(self)
+        self.fps = filepaths
 
-        def __str__(self):
-                return _("The following paths were found but cannot be "
-                    "accounted for by any of the known layouts:\n{0}").format(
-                    "\n".join(self.fps))
+    def __str__(self):
+        return _(
+            "The following paths were found but cannot be "
+            "accounted for by any of the known layouts:\n{0}"
+        ).format("\n".join(self.fps))
 
 
 class FileManager(object):
-        """The FileManager class handles the insertion and removal of files
-        within its directory according to a strategy for organizing the
-        files."""
+    """The FileManager class handles the insertion and removal of files
+    within its directory according to a strategy for organizing the
+    files."""
 
-        def __init__(self, root, readonly, layouts=None):
-                """Initialize the FileManager object.
+    def __init__(self, root, readonly, layouts=None):
+        """Initialize the FileManager object.
 
-                The "root" parameter is a path to the directory to manage.
+        The "root" parameter is a path to the directory to manage.
 
-                The "readonly" parameter determines whether files can be
-                inserted, removed, or moved."""
+        The "readonly" parameter determines whether files can be
+        inserted, removed, or moved."""
 
-                if not root:
-                        raise ValueError("root must not be none")
-                self.root = root
-                self.readonly = readonly
-                if layouts is not None:
-                        if not isinstance(layouts, collections.abc.Iterable):
-                                layouts = [layouts]
-                        self.layouts = layouts
+        if not root:
+            raise ValueError("root must not be none")
+        self.root = root
+        self.readonly = readonly
+        if layouts is not None:
+            if not isinstance(layouts, collections.abc.Iterable):
+                layouts = [layouts]
+            self.layouts = layouts
+        else:
+            self.layouts = layout.get_default_layouts()
+
+    def set_read_only(self):
+        """Make the FileManager read only."""
+        self.readonly = True
+
+    def __select_path(self, hashval, check_existence):
+        """Find the path to the file with name hashval.
+
+        The "hashval" parameter is the name of the file to find.
+
+        The "check_existence" parameter determines whether the function
+        will ensure that a file exists at the returned path."""
+
+        cur_path = None
+        cur_full_path = None
+        dest_full_path = None
+        for l in self.layouts:
+            cur_path = l.lookup(hashval)
+            cur_full_path = os.path.join(self.root, cur_path)
+            # The first layout in self.layouts is the desired
+            # location.  If that location has not been stored,
+            # record it.
+            if dest_full_path is None:
+                dest_full_path = cur_full_path
+            if not check_existence or os.path.exists(cur_full_path):
+                return cur_full_path, dest_full_path
+        return None, dest_full_path
+
+    def lookup(self, hashval, opener=False, check_existence=True):
+        """Find the file for hashval.
+
+        The "hashval" parameter contains the name of the file to be
+        found.
+
+        The "opener" parameter determines whether the function will
+        return a path or an open file handle."""
+
+        cur_full_path, dest_full_path = self.__select_path(
+            hashval, check_existence
+        )
+        if not cur_full_path:
+            return None
+
+        # If the depot isn't readonly and the file isn't in the location
+        # that the primary layout thinks it should be, try to move the
+        # file into the right place.
+        if dest_full_path != cur_full_path and not self.readonly:
+            p_sdir = os.path.dirname(cur_full_path)
+            try:
+                # Attempt to move the file from the old location
+                # to the preferred location.
+                try:
+                    portable.rename(cur_full_path, dest_full_path)
+                except OSError as e:
+                    if e.errno != errno.ENOENT:
+                        raise
+
+                    p_ddir = os.path.dirname(dest_full_path)
+                    if os.path.isdir(p_ddir):
+                        raise
+
+                    try:
+                        os.makedirs(p_ddir)
+                    except EnvironmentError as e:
+                        if e.errno == errno.EACCES or e.errno == errno.EROFS:
+                            raise FMPermissionsException(e.filename)
+                        # If directory creation failed
+                        # due to EEXIST, but the entry
+                        # it failed for isn't the
+                        # immediate parent, assume
+                        # there's a larger problem
+                        # and re-raise the exception.
+                        # For file_manager, this is
+                        # believed to be unlikely.
+                        if not (
+                            e.errno == errno.EEXIST and e.filename == p_ddir
+                        ):
+                            raise
+
+                    portable.rename(cur_full_path, dest_full_path)
+
+                # Since the file has been moved, point at the
+                # new destination *before* attempting to remove
+                # the (now possibly empty) parent directory of
+                # of the source file.
+                cur_full_path = dest_full_path
+
+                # This may fail because other files can still
+                # exist in the parent path for the source, so
+                # must be done last.
+                os.removedirs(p_sdir)
+            except EnvironmentError:
+                # If there's an error during these operations,
+                # check that cur_full_path still exists.  If
+                # it's gone, return None.
+                if not os.path.exists(cur_full_path):
+                    return None
+
+        if opener:
+            return open(cur_full_path, "rb")
+        return cur_full_path
+
+    def copy(self, hashval, src_path):
+        """Copy the content at "src_path" to the files under the name
+        "hashval".  Returns the path to the copied file."""
+        return self.__place(hashval, src_path, portable.copyfile)
+
+    def insert(self, hashval, src_path):
+        """Add the content at "src_path" to the files under the name
+        "hashval".  Returns the path to the inserted file."""
+        return self.__place(hashval, src_path, portable.rename)
+
+    def __place(self, hashval, src_path, pfunc):
+        """Add the content at "src_path" to the files under the name
+        "hashval".  Returns the path to the inserted file."""
+
+        if self.readonly:
+            raise NeedToModifyReadOnlyFileManager(hashval)
+        cur_full_path, dest_full_path = self.__select_path(hashval, True)
+
+        if cur_full_path and cur_full_path != dest_full_path:
+            # The file is stored in an old location and needs to be
+            # moved to a new location.  To prevent disruption of
+            # service or other race conditions, rename the source
+            # file into the old place first.
+            try:
+                portable.rename(src_path, cur_full_path)
+            except EnvironmentError as e:
+                if e.errno == errno.EACCES or e.errno == errno.EROFS:
+                    raise FMPermissionsException(e.filename)
+                raise
+            src_path = cur_full_path
+
+        while True:
+            try:
+                # Place the file.
+                pfunc(src_path, dest_full_path)
+            except EnvironmentError as e:
+                p_dir = os.path.dirname(dest_full_path)
+                if e.errno == errno.ENOENT and not os.path.isdir(p_dir):
+                    try:
+                        os.makedirs(p_dir)
+                    except EnvironmentError as e:
+                        if e.errno == errno.EACCES or e.errno == errno.EROFS:
+                            raise FMPermissionsException(e.filename)
+                        # If directory creation failed
+                        # due to EEXIST, but the entry
+                        # it failed for isn't the
+                        # immediate parent, assume
+                        # there's a larger problem and
+                        # re-raise the exception.  For
+                        # file_manager, this is believed
+                        # to be unlikely.
+                        if not (
+                            e.errno == errno.EEXIST and e.filename == p_dir
+                        ):
+                            raise
+
+                    # Parent directory created successsfully
+                    # so loop again to retry place.
+                elif e.errno == errno.ENOENT and not os.path.exists(src_path):
+                    if os.path.exists(dest_full_path):
+                        # Item has already been moved
+                        # into cache by another process;
+                        # nothing more to do.  (This
+                        # could happen during parallel
+                        # publication.)
+                        return dest_full_path
+                    raise FMInsertionFailure(src_path, dest_full_path)
+                elif e.errno == errno.EACCES or e.errno == errno.EROFS:
+                    raise FMPermissionsException(e.filename)
+                elif e.errno != errno.ENOENT:
+                    raise apx._convert_error(e)
+            else:
+                # Success!
+                break
+
+        # Attempt to remove the parent directory of the file's original
+        # location to ensure empty directories aren't left behind.
+        if cur_full_path:
+            try:
+                os.removedirs(os.path.dirname(cur_full_path))
+            except EnvironmentError as e:
+                if e.errno == errno.ENOENT or e.errno == errno.EEXIST:
+                    pass
+                elif e.errno == errno.EACCES or e.errno == errno.EROFS:
+                    raise FMPermissionsException(e.filename)
                 else:
-                        self.layouts = layout.get_default_layouts()
+                    raise
 
-        def set_read_only(self):
-                """Make the FileManager read only."""
-                self.readonly = True
+        # Return the location of the placed file to the caller.
+        return dest_full_path
 
-        def __select_path(self, hashval, check_existence):
-                """Find the path to the file with name hashval.
+    def remove(self, hashval):
+        """This function removes the file associated with the name
+        "hashval"."""
 
-                The "hashval" parameter is the name of the file to find.
+        if self.readonly:
+            raise NeedToModifyReadOnlyFileManager(hashval, "remove")
+        for l in self.layouts:
+            cur_path = l.lookup(hashval)
+            cur_full_path = os.path.join(self.root, cur_path)
+            try:
+                portable.remove(cur_full_path)
+                os.removedirs(os.path.dirname(cur_full_path))
+            except EnvironmentError as e:
+                if e.errno == errno.ENOENT or e.errno == errno.EEXIST:
+                    pass
+                elif e.errno == errno.EACCES or e.errno == errno.EROFS:
+                    raise FMPermissionsException(e.filename)
+                else:
+                    raise
 
-                The "check_existence" parameter determines whether the function
-                will ensure that a file exists at the returned path."""
+    def walk(self):
+        """Generate all the hashes of all files known."""
 
-                cur_path = None
-                cur_full_path = None
-                dest_full_path = None
+        unrecognized = []
+        for dirpath, dirnames, filenames in os.walk(self.root):
+            for fn in filenames:
+                fp = os.path.join(dirpath, fn)
+                fp = fp[len(self.root) :].lstrip(os.path.sep)
                 for l in self.layouts:
-                        cur_path = l.lookup(hashval)
-                        cur_full_path = os.path.join(self.root, cur_path)
-                        # The first layout in self.layouts is the desired
-                        # location.  If that location has not been stored,
-                        # record it.
-                        if dest_full_path is None:
-                                dest_full_path = cur_full_path
-                        if not check_existence or os.path.exists(cur_full_path):
-                                return cur_full_path, dest_full_path
-                return None, dest_full_path
+                    if l.contains(fp, fn):
+                        yield l.path_to_hash(fp)
+                        break
+                else:
+                    unrecognized.append(fp)
+        if unrecognized:
+            raise UnrecognizedFilePaths(unrecognized)
 
-        def lookup(self, hashval, opener=False, check_existence=True):
-                """Find the file for hashval.
-
-                The "hashval" parameter contains the name of the file to be
-                found.
-
-                The "opener" parameter determines whether the function will
-                return a path or an open file handle."""
-
-                cur_full_path, dest_full_path = self.__select_path(hashval,
-                    check_existence)
-                if not cur_full_path:
-                        return None
-
-                # If the depot isn't readonly and the file isn't in the location
-                # that the primary layout thinks it should be, try to move the
-                # file into the right place.
-                if dest_full_path != cur_full_path and not self.readonly:
-                        p_sdir = os.path.dirname(cur_full_path)
-                        try:
-                                # Attempt to move the file from the old location
-                                # to the preferred location.
-                                try:
-                                        portable.rename(cur_full_path,
-                                            dest_full_path)
-                                except OSError as e:
-                                        if e.errno != errno.ENOENT:
-                                                raise
-
-                                        p_ddir = os.path.dirname(
-                                            dest_full_path)
-                                        if os.path.isdir(p_ddir):
-                                                raise
-
-                                        try:
-                                                os.makedirs(p_ddir)
-                                        except EnvironmentError as e:
-                                                if e.errno == errno.EACCES or \
-                                                    e.errno == errno.EROFS:
-                                                        raise FMPermissionsException(
-                                                            e.filename)
-                                                # If directory creation failed
-                                                # due to EEXIST, but the entry
-                                                # it failed for isn't the
-                                                # immediate parent, assume
-                                                # there's a larger problem
-                                                # and re-raise the exception.
-                                                # For file_manager, this is
-                                                # believed to be unlikely.
-                                                if not (e.errno == errno.EEXIST and
-                                                    e.filename == p_ddir):
-                                                        raise
-
-                                        portable.rename(cur_full_path,
-                                            dest_full_path)
-
-                                # Since the file has been moved, point at the
-                                # new destination *before* attempting to remove
-                                # the (now possibly empty) parent directory of
-                                # of the source file.
-                                cur_full_path = dest_full_path
-
-                                # This may fail because other files can still
-                                # exist in the parent path for the source, so
-                                # must be done last.
-                                os.removedirs(p_sdir)
-                        except EnvironmentError:
-                                # If there's an error during these operations,
-                                # check that cur_full_path still exists.  If
-                                # it's gone, return None.
-                                if not os.path.exists(cur_full_path):
-                                        return None
-
-                if opener:
-                        return open(cur_full_path, "rb")
-                return cur_full_path
-
-        def copy(self, hashval, src_path):
-                """Copy the content at "src_path" to the files under the name
-                "hashval".  Returns the path to the copied file."""
-                return self.__place(hashval, src_path, portable.copyfile)
-
-        def insert(self, hashval, src_path):
-                """Add the content at "src_path" to the files under the name
-                "hashval".  Returns the path to the inserted file."""
-                return self.__place(hashval, src_path, portable.rename)
-
-        def __place(self, hashval, src_path, pfunc):
-                """Add the content at "src_path" to the files under the name
-                "hashval".  Returns the path to the inserted file."""
-
-                if self.readonly:
-                        raise NeedToModifyReadOnlyFileManager(hashval)
-                cur_full_path, dest_full_path = \
-                    self.__select_path(hashval, True)
-
-                if cur_full_path and cur_full_path != dest_full_path:
-                        # The file is stored in an old location and needs to be
-                        # moved to a new location.  To prevent disruption of
-                        # service or other race conditions, rename the source
-                        # file into the old place first.
-                        try:
-                                portable.rename(src_path, cur_full_path)
-                        except EnvironmentError as e:
-                                if e.errno == errno.EACCES or \
-                                    e.errno == errno.EROFS:
-                                        raise FMPermissionsException(e.filename)
-                                raise
-                        src_path = cur_full_path
-
-                while True:
-                        try:
-                                # Place the file.
-                                pfunc(src_path, dest_full_path)
-                        except EnvironmentError as e:
-                                p_dir = os.path.dirname(dest_full_path)
-                                if e.errno == errno.ENOENT and \
-                                    not os.path.isdir(p_dir):
-                                        try:
-                                                os.makedirs(p_dir)
-                                        except EnvironmentError as e:
-                                                if e.errno == errno.EACCES or \
-                                                    e.errno == errno.EROFS:
-                                                        raise FMPermissionsException(
-                                                            e.filename)
-                                                # If directory creation failed
-                                                # due to EEXIST, but the entry
-                                                # it failed for isn't the
-                                                # immediate parent, assume
-                                                # there's a larger problem and
-                                                # re-raise the exception.  For
-                                                # file_manager, this is believed
-                                                # to be unlikely.
-                                                if not (e.errno == errno.EEXIST
-                                                    and e.filename == p_dir):
-                                                        raise
-
-                                        # Parent directory created successsfully
-                                        # so loop again to retry place.
-                                elif e.errno == errno.ENOENT and \
-                                    not os.path.exists(src_path):
-                                        if os.path.exists(dest_full_path):
-                                                # Item has already been moved
-                                                # into cache by another process;
-                                                # nothing more to do.  (This
-                                                # could happen during parallel
-                                                # publication.)
-                                                return dest_full_path
-                                        raise FMInsertionFailure(src_path,
-                                            dest_full_path)
-                                elif e.errno == errno.EACCES or \
-                                    e.errno == errno.EROFS:
-                                        raise FMPermissionsException(e.filename)
-                                elif e.errno != errno.ENOENT:
-                                        raise apx._convert_error(e)
-                        else:
-                                # Success!
-                                break
-
-                # Attempt to remove the parent directory of the file's original
-                # location to ensure empty directories aren't left behind.
-                if cur_full_path:
-                        try:
-                                os.removedirs(os.path.dirname(cur_full_path))
-                        except EnvironmentError as e:
-                                if e.errno == errno.ENOENT or \
-                                    e.errno == errno.EEXIST:
-                                        pass
-                                elif e.errno == errno.EACCES or \
-                                    e.errno == errno.EROFS:
-                                        raise FMPermissionsException(e.filename)
-                                else:
-                                        raise
-
-                # Return the location of the placed file to the caller.
-                return dest_full_path
-
-        def remove(self, hashval):
-                """This function removes the file associated with the name
-                "hashval"."""
-
-                if self.readonly:
-                        raise NeedToModifyReadOnlyFileManager(hashval,
-                            "remove")
-                for l in self.layouts:
-                        cur_path = l.lookup(hashval)
-                        cur_full_path = os.path.join(self.root, cur_path)
-                        try:
-                                portable.remove(cur_full_path)
-                                os.removedirs(os.path.dirname(cur_full_path))
-                        except EnvironmentError as e:
-                                if e.errno == errno.ENOENT or \
-                                    e.errno == errno.EEXIST:
-                                        pass
-                                elif e.errno == errno.EACCES or \
-                                    e.errno == errno.EROFS:
-                                        raise FMPermissionsException(e.filename)
-                                else:
-                                        raise
-
-        def walk(self):
-                """Generate all the hashes of all files known."""
-
-                unrecognized = []
-                for dirpath, dirnames, filenames in os.walk(self.root):
-                        for fn in filenames:
-                                fp = os.path.join(dirpath, fn)
-                                fp = fp[len(self.root):].lstrip(os.path.sep)
-                                for l in self.layouts:
-                                        if l.contains(fp, fn):
-                                                yield l.path_to_hash(fp)
-                                                break
-                                else:
-                                        unrecognized.append(fp)
-                if unrecognized:
-                        raise UnrecognizedFilePaths(unrecognized)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/file_layout/layout.py
+++ b/src/modules/file_layout/layout.py
@@ -60,60 +60,63 @@ to asses the scalability of the different layouts."""
 
 import os
 
+
 class Layout(object):
-        """This class is the parent class to all layouts. It defines the
-        interface which those subclasses must satisfy."""
-        
-        def lookup(self, hashval):
-                """Return the path to the file with name "hashval"."""
-                raise NotImplementedError
+    """This class is the parent class to all layouts. It defines the
+    interface which those subclasses must satisfy."""
 
-        def path_to_hash(self, path):
-                """Return the hash which would map to "path"."""
-                raise NotImplementedError
+    def lookup(self, hashval):
+        """Return the path to the file with name "hashval"."""
+        raise NotImplementedError
 
-        def contains(self, rel_path, file_name):
-                """Returns whether this layout would place a file named
-                "file_name" at "rel_path"."""
-                return self.lookup(file_name) == rel_path
+    def path_to_hash(self, path):
+        """Return the hash which would map to "path"."""
+        raise NotImplementedError
+
+    def contains(self, rel_path, file_name):
+        """Returns whether this layout would place a file named
+        "file_name" at "rel_path"."""
+        return self.lookup(file_name) == rel_path
 
 
 class V0Layout(Layout):
-        """This class implements the original layout used.  It uses a 256 way
-        split (2 hex digits) followed by a 16.7M way split (6 hex digits)."""
+    """This class implements the original layout used.  It uses a 256 way
+    split (2 hex digits) followed by a 16.7M way split (6 hex digits)."""
 
-        def lookup(self, hashval):
-                """Return the path to the file with name "hashval"."""
-                return os.path.join(hashval[0:2], hashval[2:8], hashval)
+    def lookup(self, hashval):
+        """Return the path to the file with name "hashval"."""
+        return os.path.join(hashval[0:2], hashval[2:8], hashval)
 
-        def path_to_hash(self, path):
-                """Return the hash which would map to "path"."""
-                return os.path.basename(path)
+    def path_to_hash(self, path):
+        """Return the hash which would map to "path"."""
+        return os.path.basename(path)
 
 
 class V1Layout(Layout):
-        """This class implements the new layout approach which is a single 256
-        way fanout using the first two digits of the hash."""
+    """This class implements the new layout approach which is a single 256
+    way fanout using the first two digits of the hash."""
 
-        def lookup(self, hashval):
-                """Return the path to the file with name "hashval"."""
-                return os.path.join(hashval[0:2], hashval)
+    def lookup(self, hashval):
+        """Return the path to the file with name "hashval"."""
+        return os.path.join(hashval[0:2], hashval)
 
-        def path_to_hash(self, path):
-                """Return the hash which would map to "path"."""
-                return os.path.basename(path)
+    def path_to_hash(self, path):
+        """Return the hash which would map to "path"."""
+        return os.path.basename(path)
 
 
 def get_default_layouts():
-        """This function describes the default order in which to use the
-        layouts defined above."""
+    """This function describes the default order in which to use the
+    layouts defined above."""
 
-        return [V1Layout(), V0Layout()]
+    return [V1Layout(), V0Layout()]
+
 
 def get_preferred_layout():
-        """This function returns the single preferred layout to use."""
+    """This function returns the single preferred layout to use."""
 
-        return V1Layout()
+    return V1Layout()
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/flavor/__init__.py
+++ b/src/modules/flavor/__init__.py
@@ -24,14 +24,7 @@
 # Copyright (c) 2009, 2010, Oracle and/or its affiliates. All rights reserved.
 #
 
-__all__ = [
-    "base"
-    "elf"
-    "hardlink"
-    "pound_bang"
-    "python"
-    "smf_manifest"
-]
+__all__ = ["base" "elf" "hardlink" "pound_bang" "python" "smf_manifest"]
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/flavor/base.py
+++ b/src/modules/flavor/base.py
@@ -32,410 +32,444 @@ import pkg.variant as variant
 
 from pkg.portable import PD_DEFAULT_RUNPATH
 
+
 class DependencyAnalysisError(Exception):
-        pass
+    pass
 
 
 class MissingFile(DependencyAnalysisError):
-        """Exception that is raised when a dependency checker can't find the
-        file provided."""
+    """Exception that is raised when a dependency checker can't find the
+    file provided."""
 
-        def __init__(self, file_path, dirs=None, hash=None):
-                Exception.__init__(self)
-                self.file_path = file_path
-                self.dirs = dirs
-                self.hash = hash
+    def __init__(self, file_path, dirs=None, hash=None):
+        Exception.__init__(self)
+        self.file_path = file_path
+        self.dirs = dirs
+        self.hash = hash
 
-        def __str__(self):
-                if not self.dirs:
-                        return _("Couldn't find '{0}'").format(self.file_path)
-                elif self.hash != "NOHASH":
-                        return _("Couldn't find '{hash}' needed for '{path}'"
-                            " in any of the specified search directories:\n"
-                            "{dirs}").format(hash=self.hash,
-                                path=self.file_path, dirs="\n".join(
-                                    ["\t" + d for d in sorted(self.dirs)]))
-                else:
-                        return _("Couldn't find '{path}' in any of the "
-                            "specified search directories:\n{dirs}").format(
-                            path=self.file_path,
-                            dirs="\n".join(
-                            ["\t" + d for d in sorted(self.dirs)]))
+    def __str__(self):
+        if not self.dirs:
+            return _("Couldn't find '{0}'").format(self.file_path)
+        elif self.hash != "NOHASH":
+            return _(
+                "Couldn't find '{hash}' needed for '{path}'"
+                " in any of the specified search directories:\n"
+                "{dirs}"
+            ).format(
+                hash=self.hash,
+                path=self.file_path,
+                dirs="\n".join(["\t" + d for d in sorted(self.dirs)]),
+            )
+        else:
+            return _(
+                "Couldn't find '{path}' in any of the "
+                "specified search directories:\n{dirs}"
+            ).format(
+                path=self.file_path,
+                dirs="\n".join(["\t" + d for d in sorted(self.dirs)]),
+            )
+
 
 class MultipleDefaultRunpaths(DependencyAnalysisError):
-        """Exception that is raised when multiple $PGKDEPEND_RUNPATH tokens
-        are found in a pkg.depend.runpath attribute value."""
+    """Exception that is raised when multiple $PGKDEPEND_RUNPATH tokens
+    are found in a pkg.depend.runpath attribute value."""
 
-        def __init__(self):
-                Exception.__init__(self)
+    def __init__(self):
+        Exception.__init__(self)
 
-        def __str__(self):
-                return _(
-                    "More than one $PKGDEPEND_RUNPATH token was set on the "
-                    "same action in this manifest.")
+    def __str__(self):
+        return _(
+            "More than one $PKGDEPEND_RUNPATH token was set on the "
+            "same action in this manifest."
+        )
+
 
 class InvalidDependBypassValue(DependencyAnalysisError):
-        """Exception that is raised when we encounter an incorrect
-        pkg.depend.bypass-generate attribute value."""
+    """Exception that is raised when we encounter an incorrect
+    pkg.depend.bypass-generate attribute value."""
 
-        def __init__(self, value, error):
-                self.value = value
-                self.error = error
-                Exception.__init__(self)
+    def __init__(self, value, error):
+        self.value = value
+        self.error = error
+        Exception.__init__(self)
 
-        def __str__(self):
-                return _(
-                    "Invalid pkg.depend.bypass-generate value {val}: "
-                    "{err}").format(val=self.value, err=self.error)
+    def __str__(self):
+        return _(
+            "Invalid pkg.depend.bypass-generate value {val}: " "{err}"
+        ).format(val=self.value, err=self.error)
 
 
 class InvalidPublishingDependency(DependencyAnalysisError):
-        """Exception that is raised when base_names or run_paths as well as
-        full_paths are specified for a PublishingDependency."""
+    """Exception that is raised when base_names or run_paths as well as
+    full_paths are specified for a PublishingDependency."""
 
-        def __init__(self, error):
-                self.error = error
-                Exception.__init__(self)
+    def __init__(self, error):
+        self.error = error
+        Exception.__init__(self)
 
-        def __str__(self):
-                return _(
-                    "Invalid publishing dependency: {0}").format(self.error)
+    def __str__(self):
+        return _("Invalid publishing dependency: {0}").format(self.error)
 
 
 @total_ordering
 class Dependency(depend.DependencyAction):
-        """Base, abstract class to represent the dependencies a dependency
-        generator can produce."""
+    """Base, abstract class to represent the dependencies a dependency
+    generator can produce."""
 
-        ERROR = 0
-        WARNING = 1
+    ERROR = 0
+    WARNING = 1
 
-        DUMMY_FMRI = "__TBD"
-        DEPEND_DEBUG_PREFIX = "pkg.debug.depend"
-        DEPEND_TYPE = "require"
+    DUMMY_FMRI = "__TBD"
+    DEPEND_DEBUG_PREFIX = "pkg.debug.depend"
+    DEPEND_TYPE = "require"
 
-        def __init__(self, action, pkg_vars, proto_dir, attrs):
-                """Each dependency needs to know the action that generated it
-                and the variants for the package containing that action.
+    def __init__(self, action, pkg_vars, proto_dir, attrs):
+        """Each dependency needs to know the action that generated it
+        and the variants for the package containing that action.
 
-                'action' is the action which produced this dependency.
+        'action' is the action which produced this dependency.
 
-                'pkg_vars' is the list of variants against which the package
-                delivering the action was published.
+        'pkg_vars' is the list of variants against which the package
+        delivering the action was published.
 
-                'proto_dir' is the proto area where the file the action delivers
-                lives.
+        'proto_dir' is the proto area where the file the action delivers
+        lives.
 
-                'attrs' is a dictionary to containing the relevant action tags
-                for the dependency.
-                """
-                self.action = action
-                self.pkg_vars = pkg_vars
-                self.proto_dir = proto_dir
-                self.dep_vars = self.get_variant_combinations()
+        'attrs' is a dictionary to containing the relevant action tags
+        for the dependency.
+        """
+        self.action = action
+        self.pkg_vars = pkg_vars
+        self.proto_dir = proto_dir
+        self.dep_vars = self.get_variant_combinations()
 
-                attrs.update([
-                    ("fmri", self.DUMMY_FMRI),
-                    ("type", self.DEPEND_TYPE),
-                    ("{0}.reason".format(self.DEPEND_DEBUG_PREFIX),
-                    self.action_path())
-                ])
+        attrs.update(
+            [
+                ("fmri", self.DUMMY_FMRI),
+                ("type", self.DEPEND_TYPE),
+                (
+                    "{0}.reason".format(self.DEPEND_DEBUG_PREFIX),
+                    self.action_path(),
+                ),
+            ]
+        )
 
-                attrs.update(action.get_variant_template())
-                # Only lists are permitted for multi-value action attributes.
-                for k, v in attrs.items():
-                        if isinstance(v, set):
-                                attrs[k] = list(v)
+        attrs.update(action.get_variant_template())
+        # Only lists are permitted for multi-value action attributes.
+        for k, v in attrs.items():
+            if isinstance(v, set):
+                attrs[k] = list(v)
 
-                depend.DependencyAction.__init__(self, **attrs)
+        depend.DependencyAction.__init__(self, **attrs)
 
-        def is_error(self):
-                """Return true if failing to resolve this external dependency
-                should be considered an error."""
+    def is_error(self):
+        """Return true if failing to resolve this external dependency
+        should be considered an error."""
 
-                return True
+        return True
 
-        def dep_key(self):
-                """Return a representation of the location the action depends
-                on in a way that is hashable."""
+    def dep_key(self):
+        """Return a representation of the location the action depends
+        on in a way that is hashable."""
 
-                raise NotImplementedError(_("Subclasses of Dependency must "
-                    "implement dep_key. Current class is {0}").format(
-                    self.__class__.__name__))
+        raise NotImplementedError(
+            _(
+                "Subclasses of Dependency must "
+                "implement dep_key. Current class is {0}"
+            ).format(self.__class__.__name__)
+        )
 
-        def get_variant_combinations(self, satisfied=False):
-                """Create the combinations of variants that this action
-                satisfies or needs satisfied.
+    def get_variant_combinations(self, satisfied=False):
+        """Create the combinations of variants that this action
+        satisfies or needs satisfied.
 
-                'satisfied' determines whether the combination produced is
-                satisfied or unsatisfied."""
+        'satisfied' determines whether the combination produced is
+        satisfied or unsatisfied."""
 
-                variants = self.action.get_variant_template()
-                variants.merge_unknown(self.pkg_vars)
-                return variant.VariantCombinations(variants,
-                    satisfied=satisfied)
+        variants = self.action.get_variant_template()
+        variants.merge_unknown(self.pkg_vars)
+        return variant.VariantCombinations(variants, satisfied=satisfied)
 
-        def action_path(self):
-                """Return the path to the file that generated this dependency.
-                """
+    def action_path(self):
+        """Return the path to the file that generated this dependency."""
 
-                return self.action.attrs["path"]
+        return self.action.attrs["path"]
 
-        def key(self):
-                """Keys for ordering two Dependency objects. Use ComparableMinxin
-                to do the rich comparison."""
-                return (self.dep_key(), self.action_path(),
-                    self.__class__.__name__)
+    def key(self):
+        """Keys for ordering two Dependency objects. Use ComparableMinxin
+        to do the rich comparison."""
+        return (self.dep_key(), self.action_path(), self.__class__.__name__)
 
-        def __eq__(self, other):
-                return self.key() == other.key()
+    def __eq__(self, other):
+        return self.key() == other.key()
 
-        def __lt__(self, other):
-                return self.key() < other.key()
+    def __lt__(self, other):
+        return self.key() < other.key()
 
-        def __hash__(self):
-                return hash(self.key())
+    def __hash__(self):
+        return hash(self.key())
 
-        def get_vars_str(self):
-                """Produce a string representation of the variants that apply
-                to the dependency."""
+    def get_vars_str(self):
+        """Produce a string representation of the variants that apply
+        to the dependency."""
 
-                if self.dep_vars is not None:
-                        return " " + " ".join([
-                            ("{0}={1}".format(k, ",".join(self.dep_vars[k])))
-                            for k in sorted(self.dep_vars.keys())
-                        ])
+        if self.dep_vars is not None:
+            return " " + " ".join(
+                [
+                    ("{0}={1}".format(k, ",".join(self.dep_vars[k])))
+                    for k in sorted(self.dep_vars.keys())
+                ]
+            )
 
-                return ""
+        return ""
 
-        @staticmethod
-        def make_relative(path, dir):
-                """If 'path' is an absolute path, make it relative to the
-                directory path given, otherwise, make it relative to root."""
-                if path.startswith(dir):
-                        path = path[len(dir):]
-                return path.lstrip("/")
+    @staticmethod
+    def make_relative(path, dir):
+        """If 'path' is an absolute path, make it relative to the
+        directory path given, otherwise, make it relative to root."""
+        if path.startswith(dir):
+            path = path[len(dir) :]
+        return path.lstrip("/")
 
 
 class PublishingDependency(Dependency):
-        """This class serves as a base for all dependencies.  It handles
-        dependencies with multiple files, multiple paths, or both.
+    """This class serves as a base for all dependencies.  It handles
+    dependencies with multiple files, multiple paths, or both.
 
-        File dependencies are stored either as a list of base_names and
-        a list of run_paths, or are expanded, and stored as a list of
-        full_paths to each file that could satisfy the dependency.
+    File dependencies are stored either as a list of base_names and
+    a list of run_paths, or are expanded, and stored as a list of
+    full_paths to each file that could satisfy the dependency.
+    """
+
+    def __init__(
+        self,
+        action,
+        base_names,
+        run_paths,
+        pkg_vars,
+        proto_dir,
+        kind,
+        full_paths=None,
+    ):
+        """Construct a PublishingDependency object.
+
+        'action' is the action which produced this dependency.
+
+        'base_names' is the list of files of the dependency.
+
+        'run_paths' is the list of directory paths to the file of the
+        dependency.
+
+        'pkg_vars' is the list of variants against which the package
+        delivering the action was published.
+
+        'proto_dir' is the proto area where the file the action delivers
+        lives.  It may be None if the notion of a proto_dir is
+        meaningless for a particular PublishingDependency.
+
+        'kind' is the kind of dependency that this is.
+
+        'full_paths' if not None, is used instead of the combination of
+        'base_names' and 'run_paths' when defining dependencies where
+        exact paths to files matter (for example, SMF dependencies which
+        are satisfied by more than one SMF manifest are not searched for
+        using the manifest base_name in a list of run_paths, unlike
+        python modules, which use $PYTHONPATH.)  Specifying full_paths
+        as well as base_names/run_paths combinations is not allowed.
         """
 
-        def __init__(self, action, base_names, run_paths, pkg_vars, proto_dir,
-            kind, full_paths=None):
-                """Construct a PublishingDependency object.
+        if full_paths and (base_names or run_paths):
+            # this should never happen, as consumers should always
+            # construct PublishingDependency objects using either
+            # full_paths or a combination of base_names and
+            # run_paths.
+            raise InvalidPublishingDependency(
+                "A dependency was specified using full_paths={0} as "
+                "well as base_names={1} and run_paths={2}".format(
+                    full_paths, base_names, run_paths
+                )
+            )
 
-                'action' is the action which produced this dependency.
+        self.base_names = sorted(base_names)
 
-                'base_names' is the list of files of the dependency.
+        if full_paths == None:
+            self.full_paths = []
+        else:
+            self.full_paths = full_paths
 
-                'run_paths' is the list of directory paths to the file of the
-                dependency.
+        if proto_dir is None:
+            self.run_paths = sorted(run_paths)
+            # proto_dir is set to "" so that the proto_dir can be
+            # joined unconditionally with other paths.  This makes
+            # the code path in _check_path simpler.
+            proto_dir = ""
+        else:
+            self.run_paths = sorted(
+                [self.make_relative(rp, proto_dir) for rp in run_paths]
+            )
 
-                'pkg_vars' is the list of variants against which the package
-                delivering the action was published.
-
-                'proto_dir' is the proto area where the file the action delivers
-                lives.  It may be None if the notion of a proto_dir is
-                meaningless for a particular PublishingDependency.
-
-                'kind' is the kind of dependency that this is.
-
-                'full_paths' if not None, is used instead of the combination of
-                'base_names' and 'run_paths' when defining dependencies where
-                exact paths to files matter (for example, SMF dependencies which
-                are satisfied by more than one SMF manifest are not searched for
-                using the manifest base_name in a list of run_paths, unlike
-                python modules, which use $PYTHONPATH.)  Specifying full_paths
-                as well as base_names/run_paths combinations is not allowed.
-                """
-
-                if full_paths and (base_names or run_paths):
-                        # this should never happen, as consumers should always
-                        # construct PublishingDependency objects using either
-                        # full_paths or a combination of base_names and
-                        # run_paths.
-                        raise InvalidPublishingDependency(
-                            "A dependency was specified using full_paths={0} as "
-                            "well as base_names={1} and run_paths={2}".format(
-                            full_paths, base_names, run_paths))
-
-                self.base_names = sorted(base_names)
-
-                if full_paths == None:
-                        self.full_paths = []
-                else:
-                        self.full_paths = full_paths
-
-                if proto_dir is None:
-                        self.run_paths = sorted(run_paths)
-                        # proto_dir is set to "" so that the proto_dir can be
-                        # joined unconditionally with other paths.  This makes
-                        # the code path in _check_path simpler.
-                        proto_dir = ""
-                else:
-                        self.run_paths = sorted([
-                            self.make_relative(rp, proto_dir)
-                            for rp in run_paths
-                        ])
-
-                attrs = {"{0}.type".format(self.DEPEND_DEBUG_PREFIX): kind}
-                if self.full_paths:
-                        attrs["{0}.fullpath".format(self.DEPEND_DEBUG_PREFIX)] = \
-                            self.full_paths
-                else:
-                        attrs.update({
-                            "{0}.file".format(
-                            self.DEPEND_DEBUG_PREFIX): self.base_names,
-                            "{0}.path".format(
-                            self.DEPEND_DEBUG_PREFIX): self.run_paths,
-                        })
-
-                Dependency.__init__(self, action, pkg_vars, proto_dir, attrs)
-
-        def dep_key(self):
-                """Return the a value that represents the path of the
-                dependency. It must be hashable."""
-                if self.full_paths:
-                        return (tuple(self.full_paths))
-                else:
-                        return (tuple(self.base_names), tuple(self.run_paths))
-
-        def _check_path(self, path_to_check, delivered_files):
-                """Takes a dictionary of files that are known to exist, and
-                returns the path to the file that satisfies this dependency, or
-                None if no such delivered file exists."""
-
-                # Using normpath and realpath are ok here because the dependency
-                # is being checked against the files, directories, and links
-                # delivered in the proto area.
-                if path_to_check in delivered_files:
-                        return path_to_check
-                norm_path = os.path.normpath(os.path.join(self.proto_dir,
-                    path_to_check))
-                if norm_path in delivered_files:
-                        return norm_path
-
-                real_path = os.path.realpath(norm_path)
-                if real_path in delivered_files:
-                        return real_path
-
-                return None
-
-        def possibly_delivered(self, delivered_files, links, resolve_links,
-            orig_dep_vars):
-                """Finds a list of files which satisfy this dependency, and the
-                variants under which each file satisfies it.  It takes into
-                account links and hardlinks.
-
-                'delivered_files' is a dictionary which maps paths to the
-                packages that deliver the path and the variants under which the
-                path is present.
-
-                'links' is an Entries namedtuple which contains two
-                dictionaries.  One dictionary maps package identity to the links
-                that it delivers.  The other dictionary, in this case, should be
-                empty.
-
-                'resolve_links' is a function which finds the real paths that a
-                path can resolve into, given a set of known links.
-
-                'orig_dep_vars' is the set of variants under which this
-                dependency exists."""
-
-                res = []
-                # A dependency may be built using this dictionary of attributes.
-                # Seeding it with the type is necessary to create a Dependency
-                # object.
-                attrs = {
-                        "type":"require"
+        attrs = {"{0}.type".format(self.DEPEND_DEBUG_PREFIX): kind}
+        if self.full_paths:
+            attrs[
+                "{0}.fullpath".format(self.DEPEND_DEBUG_PREFIX)
+            ] = self.full_paths
+        else:
+            attrs.update(
+                {
+                    "{0}.file".format(
+                        self.DEPEND_DEBUG_PREFIX
+                    ): self.base_names,
+                    "{0}.path".format(self.DEPEND_DEBUG_PREFIX): self.run_paths,
                 }
-                def process_path(path_to_check):
-                        res = []
-                        # Find the potential real paths that path_to_check could
-                        # resolve to.
-                        res_pths, res_links = resolve_links(
-                            path_to_check, delivered_files, links,
-                            orig_dep_vars, attrs)
-                        for res_pth, res_pfmri, nearest_fmri, res_vc, \
-                            res_via_links in res_pths:
-                                p = self._check_path(res_pth, delivered_files)
-                                if p:
-                                        res.append((p, res_vc))
-                        return res
+            )
 
-                # if this is an expanded dependency, we iterate over the list of
-                # full paths
-                if self.full_paths:
-                        for path_to_check in self.full_paths:
-                                res.extend(process_path(path_to_check))
+        Dependency.__init__(self, action, pkg_vars, proto_dir, attrs)
 
-                # otherwise, it's a dependency with run_path and base_names
-                # entries
-                else:
-                        for bn in self.base_names:
-                                for rp in self.run_paths:
-                                        path_to_check = os.path.normpath(
-                                            os.path.join(rp, bn))
-                                        res.extend(process_path(path_to_check))
-                return res
+    def dep_key(self):
+        """Return the a value that represents the path of the
+        dependency. It must be hashable."""
+        if self.full_paths:
+            return tuple(self.full_paths)
+        else:
+            return (tuple(self.base_names), tuple(self.run_paths))
 
-        def resolve_internal(self, delivered_files, links, resolve_links, *args,
-            **kwargs):
-                """Determines whether this dependency (self) can be satisfied by
-                the other items in the package which delivers it.  A tuple of
-                two values is produced.  The first is either None, meaning the
-                dependency was satisfied, or self.ERROR, meaning the dependency
-                wasn't totally satisfied by the delivered files.  The second
-                value is the set of variants for which the dependency isn't
-                satisfied.
+    def _check_path(self, path_to_check, delivered_files):
+        """Takes a dictionary of files that are known to exist, and
+        returns the path to the file that satisfies this dependency, or
+        None if no such delivered file exists."""
 
-                'delivered_files' is a dictionary which maps package identity
-                to the files the package delivers.
+        # Using normpath and realpath are ok here because the dependency
+        # is being checked against the files, directories, and links
+        # delivered in the proto area.
+        if path_to_check in delivered_files:
+            return path_to_check
+        norm_path = os.path.normpath(
+            os.path.join(self.proto_dir, path_to_check)
+        )
+        if norm_path in delivered_files:
+            return norm_path
 
-                'links' is an Entries namedtuple which contains two
-                dictionaries.  One dictionary maps package identity to the links
-                that it delivers.  The other dictionary, in this case, should be
-                empty.
+        real_path = os.path.realpath(norm_path)
+        if real_path in delivered_files:
+            return real_path
 
-                'resolve_links' is a function which finds the real paths a path
-                can resolve into given a set of known links.
+        return None
 
-                '*args' and '**kwargs' are used because subclasses may need
-                more information for their implementations. See pkg.flavor.elf
-                for an example of this."""
+    def possibly_delivered(
+        self, delivered_files, links, resolve_links, orig_dep_vars
+    ):
+        """Finds a list of files which satisfy this dependency, and the
+        variants under which each file satisfies it.  It takes into
+        account links and hardlinks.
 
-                missing_vars = self.get_variant_combinations()
-                orig_dep_vars = self.get_variant_combinations()
-                for p, vc in self.possibly_delivered(delivered_files, links,
-                    resolve_links, orig_dep_vars):
-                        missing_vars.mark_as_satisfied(vc)
-                        if missing_vars.is_satisfied():
-                                return None, missing_vars
-                return self.ERROR, missing_vars
+        'delivered_files' is a dictionary which maps paths to the
+        packages that deliver the path and the variants under which the
+        path is present.
+
+        'links' is an Entries namedtuple which contains two
+        dictionaries.  One dictionary maps package identity to the links
+        that it delivers.  The other dictionary, in this case, should be
+        empty.
+
+        'resolve_links' is a function which finds the real paths that a
+        path can resolve into, given a set of known links.
+
+        'orig_dep_vars' is the set of variants under which this
+        dependency exists."""
+
+        res = []
+        # A dependency may be built using this dictionary of attributes.
+        # Seeding it with the type is necessary to create a Dependency
+        # object.
+        attrs = {"type": "require"}
+
+        def process_path(path_to_check):
+            res = []
+            # Find the potential real paths that path_to_check could
+            # resolve to.
+            res_pths, res_links = resolve_links(
+                path_to_check, delivered_files, links, orig_dep_vars, attrs
+            )
+            for (
+                res_pth,
+                res_pfmri,
+                nearest_fmri,
+                res_vc,
+                res_via_links,
+            ) in res_pths:
+                p = self._check_path(res_pth, delivered_files)
+                if p:
+                    res.append((p, res_vc))
+            return res
+
+        # if this is an expanded dependency, we iterate over the list of
+        # full paths
+        if self.full_paths:
+            for path_to_check in self.full_paths:
+                res.extend(process_path(path_to_check))
+
+        # otherwise, it's a dependency with run_path and base_names
+        # entries
+        else:
+            for bn in self.base_names:
+                for rp in self.run_paths:
+                    path_to_check = os.path.normpath(os.path.join(rp, bn))
+                    res.extend(process_path(path_to_check))
+        return res
+
+    def resolve_internal(
+        self, delivered_files, links, resolve_links, *args, **kwargs
+    ):
+        """Determines whether this dependency (self) can be satisfied by
+        the other items in the package which delivers it.  A tuple of
+        two values is produced.  The first is either None, meaning the
+        dependency was satisfied, or self.ERROR, meaning the dependency
+        wasn't totally satisfied by the delivered files.  The second
+        value is the set of variants for which the dependency isn't
+        satisfied.
+
+        'delivered_files' is a dictionary which maps package identity
+        to the files the package delivers.
+
+        'links' is an Entries namedtuple which contains two
+        dictionaries.  One dictionary maps package identity to the links
+        that it delivers.  The other dictionary, in this case, should be
+        empty.
+
+        'resolve_links' is a function which finds the real paths a path
+        can resolve into given a set of known links.
+
+        '*args' and '**kwargs' are used because subclasses may need
+        more information for their implementations. See pkg.flavor.elf
+        for an example of this."""
+
+        missing_vars = self.get_variant_combinations()
+        orig_dep_vars = self.get_variant_combinations()
+        for p, vc in self.possibly_delivered(
+            delivered_files, links, resolve_links, orig_dep_vars
+        ):
+            missing_vars.mark_as_satisfied(vc)
+            if missing_vars.is_satisfied():
+                return None, missing_vars
+        return self.ERROR, missing_vars
 
 
 def insert_default_runpath(default_runpath, run_paths):
-        """Insert our default search path where the PD_DEFAULT_PATH token was
-        found, returning an updated list of run paths."""
-        try:
-                new_paths = run_paths
-                index = run_paths.index(PD_DEFAULT_RUNPATH)
-                new_paths = run_paths[:index] + \
-                    default_runpath + run_paths[index + 1:]
-                if PD_DEFAULT_RUNPATH in new_paths:
-                        raise MultipleDefaultRunpaths()
-                return new_paths
+    """Insert our default search path where the PD_DEFAULT_PATH token was
+    found, returning an updated list of run paths."""
+    try:
+        new_paths = run_paths
+        index = run_paths.index(PD_DEFAULT_RUNPATH)
+        new_paths = run_paths[:index] + default_runpath + run_paths[index + 1 :]
+        if PD_DEFAULT_RUNPATH in new_paths:
+            raise MultipleDefaultRunpaths()
+        return new_paths
 
-        except ValueError:
-                # no PD_DEFAULT_PATH token, so we override the
-                # whole default search path
-                return run_paths
+    except ValueError:
+        # no PD_DEFAULT_PATH token, so we override the
+        # whole default search path
+        return run_paths
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/flavor/depthlimitedmf.py
+++ b/src/modules/flavor/depthlimitedmf.py
@@ -23,13 +23,14 @@ about a module it couldn't analyze."""
 # Python 2 and Python 3 syntax.
 
 if __name__ != "__main__":
-        import pkg.flavor.base as base
+    import pkg.flavor.base as base
 
 import modulefinder
 import os
 import sys
+
 if sys.version_info[0] == 3:
-        from importlib.machinery import EXTENSION_SUFFIXES
+    from importlib.machinery import EXTENSION_SUFFIXES
 
 # A string used as a component of the pkg.depend.runpath value as a special
 # token to determine where to insert the runpath that pkgdepend generates itself
@@ -38,377 +39,382 @@ PD_DEFAULT_RUNPATH = "$PKGDEPEND_RUNPATH"
 
 python_path = "PYTHONPATH"
 
+
 class ModuleInfo(object):
-        """This class contains information about from where a python module
-        might be loaded."""
+    """This class contains information about from where a python module
+    might be loaded."""
 
-        def __init__(self, name, dirs, builtin=False):
-                """Build a ModuleInfo object.
+    def __init__(self, name, dirs, builtin=False):
+        """Build a ModuleInfo object.
 
-                The 'name' parameter is the name of the module.
+        The 'name' parameter is the name of the module.
 
-                The 'dirs' parameter is the list of directories where the module
-                might be found.
+        The 'dirs' parameter is the list of directories where the module
+        might be found.
 
-                The 'builtin' parameter sets whether the module is a python
-                builtin (like sys)."""
+        The 'builtin' parameter sets whether the module is a python
+        builtin (like sys)."""
 
-                self.name = name
-                self.builtin = builtin
-                self.patterns = [ "{0}.py", "{0}.pyc", "{0}.pyo", "{0}/__init__.py" ]
-                if sys.version_info[0] == 2:
-                        self.patterns += [
-                            "{0}.so", "{0}module.so", "64/{0}.so", "64/{0}module.so"
-                        ]
-                else:
-                        self.patterns += \
-                            ["{{0}}{0}".format(s) for s in EXTENSION_SUFFIXES] + \
-                            ["64/{{0}}{0}".format(s) for s in EXTENSION_SUFFIXES]
-                self.dirs = sorted(dirs)
+        self.name = name
+        self.builtin = builtin
+        self.patterns = ["{0}.py", "{0}.pyc", "{0}.pyo", "{0}/__init__.py"]
+        if sys.version_info[0] == 2:
+            self.patterns += [
+                "{0}.so",
+                "{0}module.so",
+                "64/{0}.so",
+                "64/{0}module.so",
+            ]
+        else:
+            self.patterns += [
+                "{{0}}{0}".format(s) for s in EXTENSION_SUFFIXES
+            ] + ["64/{{0}}{0}".format(s) for s in EXTENSION_SUFFIXES]
+        self.dirs = sorted(dirs)
 
-        def make_package(self):
-                """Declare that this module is a package."""
+    def make_package(self):
+        """Declare that this module is a package."""
 
-                if self.dirs:
-                        self.patterns = ["{0}/__init__.py"]
-                else:
-                        self.patterns = []
+        if self.dirs:
+            self.patterns = ["{0}/__init__.py"]
+        else:
+            self.patterns = []
 
-        def get_package_dirs(self):
-                """Get the directories where this package might be defined."""
+    def get_package_dirs(self):
+        """Get the directories where this package might be defined."""
 
-                return [os.path.join(p, self.name) for p in self.dirs]
+        return [os.path.join(p, self.name) for p in self.dirs]
 
-        def get_file_names(self):
-                """Return all the file names under which this module might be
-                found."""
+    def get_file_names(self):
+        """Return all the file names under which this module might be
+        found."""
 
-                return [ pat.format(self.name) for pat in self.patterns ]
+        return [pat.format(self.name) for pat in self.patterns]
 
-        def __str__(self):
-                return "name:{0} suffixes:{1} dirs:{2}".format(self.name,
-                    " ".join(self.patterns), len(self.dirs))
+    def __str__(self):
+        return "name:{0} suffixes:{1} dirs:{2}".format(
+            self.name, " ".join(self.patterns), len(self.dirs)
+        )
 
 
 if __name__ == "__main__":
-        try:
-                import pkg.misc as misc
-                import gettext
-                import locale
-                misc.setlocale(locale.LC_ALL, "")
-                gettext.install("pkg", "/usr/share/locale")
-        except ImportError:
-                pass
+    try:
+        import pkg.misc as misc
+        import gettext
+        import locale
 
-        class MultipleDefaultRunPaths(Exception):
+        misc.setlocale(locale.LC_ALL, "")
+        gettext.install("pkg", "/usr/share/locale")
+    except ImportError:
+        pass
 
-                def __str__(self):
-                        return _(
-                            "More than one $PKGDEPEND_RUNPATH token was set on "
-                            "the same action in this manifest.")
+    class MultipleDefaultRunPaths(Exception):
+        def __str__(self):
+            return _(
+                "More than one $PKGDEPEND_RUNPATH token was set on "
+                "the same action in this manifest."
+            )
 
 
 class DepthLimitedModuleFinder(modulefinder.ModuleFinder):
+    def __init__(self, install_dir, *args, **kwargs):
+        """Produce a module finder that ignores PYTHONPATH and only
+        reports the direct imports of a module.
 
-        def __init__(self, install_dir, *args, **kwargs):
-                """Produce a module finder that ignores PYTHONPATH and only
-                reports the direct imports of a module.
+        run_paths as a keyword argument specifies a list of additional
+        paths to use when searching for modules."""
 
-                run_paths as a keyword argument specifies a list of additional
-                paths to use when searching for modules."""
+        # ModuleFinder.__init__ doesn't expect run_paths
+        run_paths = kwargs.pop("run_paths", [])
 
-                # ModuleFinder.__init__ doesn't expect run_paths
-                run_paths = kwargs.pop("run_paths", [])
+        # Check to see whether a python path has been set.
+        if python_path in os.environ:
+            py_path = [
+                os.path.normpath(fp)
+                for fp in os.environ[python_path].split(os.pathsep)
+            ]
+        else:
+            py_path = []
 
-                # Check to see whether a python path has been set.
-                if python_path in os.environ:
-                        py_path = [
-                            os.path.normpath(fp)
-                            for fp in os.environ[python_path].split(os.pathsep)
-                        ]
-                else:
-                        py_path = []
+        # Remove any paths that start with the defined python paths.
+        new_path = [
+            fp for fp in sys.path[1:] if not self.startswith_path(fp, py_path)
+        ]
+        new_path.append(install_dir)
 
-                # Remove any paths that start with the defined python paths.
-                new_path = [
-                    fp
-                    for fp in sys.path[1:]
-                    if not self.startswith_path(fp, py_path)
-                ]
-                new_path.append(install_dir)
-
-                if run_paths:
-                        if __name__ != "__main__":
-                                # add our detected runpath into the
-                                # user-supplied one (if any)
-                                new_path = base.insert_default_runpath(new_path,
-                                    run_paths)
-                        else:
-                                # This is a copy of the above function call.
-                                # insert our default search path where the
-                                # PD_DEFAULT_RUNPATH token was found
-                                try:
-                                        index = run_paths.index(
-                                            PD_DEFAULT_RUNPATH)
-                                        run_paths = run_paths[:index] + \
-                                            new_path + run_paths[index + 1:]
-                                        if PD_DEFAULT_RUNPATH in run_paths:
-                                                raise MultipleDefaultRunPaths()
-                                except ValueError:
-                                        # no PD_DEFAULT_PATH token, so we
-                                        # override the whole default search path
-                                        pass
-                                new_path = run_paths
-
-                modulefinder.ModuleFinder.__init__(self, path=new_path,
-                    *args, **kwargs)
-
-        @staticmethod
-        def startswith_path(path, lst):
-                for l in lst:
-                        if path.startswith(l):
-                                return True
-                return False
-
-        def run_script(self, pathname):
-                """Find all the modules the module at pathname directly
-                imports."""
-
-                fp = open(pathname, "r")
-                return self.load_module('__main__', fp, pathname)
-
-        def load_module(self, fqname, fp, pathname):
-                """This code has been slightly modified from the function of
-                the parent class. Specifically, it checks the current depth
-                of the loading and halts if it exceeds the depth that was given
-                to run_script."""
-
-                self.msgin(2, "load_module", fqname, fp and "fp", pathname)
-                co = compile(fp.read()+'\n', pathname, 'exec')
-                m = self.add_module(fqname)
-                m.__file__ = pathname
-                res = []
-                if co:
-                        if self.replace_paths:
-                                co = self.replace_paths_in_code(co)
-                        m.__code__ = co
-                        try:
-                                res.extend(self.scan_code(co, m))
-                        except ImportError as msg:
-                                self.msg(2, "ImportError:", str(msg), fqname,
-                                    pathname)
-                                self._add_badmodule(fqname, m)
-
-                self.msgout(2, "load_module ->", m)
-                return res
-
-        def scan_code(self, co, m):
-                """Scan the code looking for import statements."""
-
-                res = []
-                code = co.co_code
-                if sys.version_info >= (2, 5) and sys.version_info < (3, 6):
-                        # Python 3.6's modulefinder.py got rid of
-                        # scan_opcodes_25() and renamed scan_opcodes_25()
-                        # to scan_opcodes(). Previously old scan_opcodes()
-                        # was for Python 2.4 and earlier.
-                        scanner = self.scan_opcodes_25
-                else:
-                        scanner = self.scan_opcodes
-                for what, args in scanner(co):
-                        if what == "store":
-                                name, = args
-                                m.globalnames[name] = 1
-                        elif what in ("import", "absolute_import"):
-                                fromlist, name = args
-                                have_star = 0
-                                if fromlist is not None:
-                                        if "*" in fromlist:
-                                                have_star = 1
-                                        fromlist = [
-                                            f for f in fromlist if f != "*"
-                                        ]
-                                if what == "absolute_import":
-                                        level = 0
-                                else:
-                                        level = -1
-                                res.extend(self._safe_import_hook(name, m,
-                                    fromlist, level=level))
-                        elif what == "relative_import":
-                                level, fromlist, name = args
-                                if name:
-                                        res.extend(self._safe_import_hook(name,
-                                            m, fromlist, level=level))
-                                else:
-                                        parent = self.determine_parent(m,
-                                            level=level)
-                                        res.extend(self._safe_import_hook(
-                                            parent.__name__, None, fromlist,
-                                            level=0))
-                        else:
-                                # We don't expect anything else from the
-                                # generator.
-                                raise RuntimeError(what)
-
-                for c in co.co_consts:
-                        if isinstance(c, type(co)):
-                                res.extend(self.scan_code(c, m))
-                return res
-
-
-        def _safe_import_hook(self, name, caller, fromlist, level=-1):
-                """Wrapper for self.import_hook() that won't raise ImportError.
-                """
-
-                res = []
-                if name in self.badmodules:
-                        self._add_badmodule(name, caller)
-                        return []
+        if run_paths:
+            if __name__ != "__main__":
+                # add our detected runpath into the
+                # user-supplied one (if any)
+                new_path = base.insert_default_runpath(new_path, run_paths)
+            else:
+                # This is a copy of the above function call.
+                # insert our default search path where the
+                # PD_DEFAULT_RUNPATH token was found
                 try:
-                        res.extend(self.import_hook(name, caller, level=level))
-                except ImportError as msg:
-                        self.msg(2, "ImportError:", str(msg))
-                        self._add_badmodule(name, caller)
+                    index = run_paths.index(PD_DEFAULT_RUNPATH)
+                    run_paths = (
+                        run_paths[:index] + new_path + run_paths[index + 1 :]
+                    )
+                    if PD_DEFAULT_RUNPATH in run_paths:
+                        raise MultipleDefaultRunPaths()
+                except ValueError:
+                    # no PD_DEFAULT_PATH token, so we
+                    # override the whole default search path
+                    pass
+                new_path = run_paths
+
+        modulefinder.ModuleFinder.__init__(self, path=new_path, *args, **kwargs)
+
+    @staticmethod
+    def startswith_path(path, lst):
+        for l in lst:
+            if path.startswith(l):
+                return True
+        return False
+
+    def run_script(self, pathname):
+        """Find all the modules the module at pathname directly
+        imports."""
+
+        fp = open(pathname, "r")
+        return self.load_module("__main__", fp, pathname)
+
+    def load_module(self, fqname, fp, pathname):
+        """This code has been slightly modified from the function of
+        the parent class. Specifically, it checks the current depth
+        of the loading and halts if it exceeds the depth that was given
+        to run_script."""
+
+        self.msgin(2, "load_module", fqname, fp and "fp", pathname)
+        co = compile(fp.read() + "\n", pathname, "exec")
+        m = self.add_module(fqname)
+        m.__file__ = pathname
+        res = []
+        if co:
+            if self.replace_paths:
+                co = self.replace_paths_in_code(co)
+            m.__code__ = co
+            try:
+                res.extend(self.scan_code(co, m))
+            except ImportError as msg:
+                self.msg(2, "ImportError:", str(msg), fqname, pathname)
+                self._add_badmodule(fqname, m)
+
+        self.msgout(2, "load_module ->", m)
+        return res
+
+    def scan_code(self, co, m):
+        """Scan the code looking for import statements."""
+
+        res = []
+        code = co.co_code
+        if sys.version_info >= (2, 5) and sys.version_info < (3, 6):
+            # Python 3.6's modulefinder.py got rid of
+            # scan_opcodes_25() and renamed scan_opcodes_25()
+            # to scan_opcodes(). Previously old scan_opcodes()
+            # was for Python 2.4 and earlier.
+            scanner = self.scan_opcodes_25
+        else:
+            scanner = self.scan_opcodes
+        for what, args in scanner(co):
+            if what == "store":
+                (name,) = args
+                m.globalnames[name] = 1
+            elif what in ("import", "absolute_import"):
+                fromlist, name = args
+                have_star = 0
+                if fromlist is not None:
+                    if "*" in fromlist:
+                        have_star = 1
+                    fromlist = [f for f in fromlist if f != "*"]
+                if what == "absolute_import":
+                    level = 0
                 else:
-                        if fromlist:
-                                for sub in fromlist:
-                                        if sub in self.badmodules:
-                                                self._add_badmodule(sub, caller)
-                                                continue
-                                        res.extend(self.import_hook(name,
-                                            caller, [sub], level=level))
-                return res
-
-        def import_hook(self, name, caller=None, fromlist=None, level=-1):
-                """Find all the modules that importing name will import."""
-
-                # Special handling for os.path is needed because the os module
-                # manipulates sys.modules directly to provide both os and
-                # os.path.
-                if name == "os.path":
-                        self.msg(2, "bypassing os.path import - importing os "
-                            "instead", name, caller, fromlist, level)
-                        name = "os"
-
-                self.msg(3, "import_hook", name, caller, fromlist, level)
-                parent = self.determine_parent(caller, level=level)
-                q, tail = self.find_head_package(parent, name)
-                if not tail:
-                        # If q is a builtin module, don't report it because it
-                        # doesn't live in the normal module space and it's part
-                        # of python itself, which is handled by a different
-                        # kind of dependency.
-                        if isinstance(q, ModuleInfo) and q.builtin:
-                                return []
-                        elif isinstance(q, modulefinder.Module):
-                                name = q.__name__
-                                path = q.__path__
-                                # some Module objects don't get a path
-                                if not path:
-                                        if name in sys.builtin_module_names or \
-                                            name == "__future__":
-                                                return [ModuleInfo(name, [],
-                                                    builtin=True)]
-                                        else:
-                                                return [ModuleInfo(name, [])]
-                                return [ModuleInfo(name, path)]
-                        else:
-                                return [q]
-                res = self.load_tail(q, tail)
-                q.make_package()
-                res.append(q)
-                return res
-
-        def import_module(self, partname, fqname, parent):
-                """Find where this module lives relative to its parent."""
-
-                parent_dirs = None
-                self.msgin(3, "import_module", partname, fqname, parent)
-                try:
-                        m = self.modules[fqname]
-                except KeyError:
-                        pass
+                    level = -1
+                res.extend(
+                    self._safe_import_hook(name, m, fromlist, level=level)
+                )
+            elif what == "relative_import":
+                level, fromlist, name = args
+                if name:
+                    res.extend(
+                        self._safe_import_hook(name, m, fromlist, level=level)
+                    )
                 else:
-                        self.msgout(3, "import_module ->", m)
-                        return m
-                if fqname in self.badmodules:
-                        self.msgout(3, "import_module -> None")
-                        return None
-                if parent:
-                        if not parent.dirs:
-                                self.msgout(3, "import_module -> None")
-                                return None
-                        else:
-                                parent_dirs = parent.get_package_dirs()
-                try:
-                        mod = self.find_module(partname, parent_dirs, parent)
-                except ImportError:
-                        self.msgout(3, "import_module ->", None)
-                        return None
-                return mod
+                    parent = self.determine_parent(m, level=level)
+                    res.extend(
+                        self._safe_import_hook(
+                            parent.__name__, None, fromlist, level=0
+                        )
+                    )
+            else:
+                # We don't expect anything else from the
+                # generator.
+                raise RuntimeError(what)
 
-        def find_module(self, name, path, parent=None):
-                """Calculate the potential paths on the file system where the
-                module could be found."""
+        for c in co.co_consts:
+            if isinstance(c, type(co)):
+                res.extend(self.scan_code(c, m))
+        return res
 
+    def _safe_import_hook(self, name, caller, fromlist, level=-1):
+        """Wrapper for self.import_hook() that won't raise ImportError."""
+
+        res = []
+        if name in self.badmodules:
+            self._add_badmodule(name, caller)
+            return []
+        try:
+            res.extend(self.import_hook(name, caller, level=level))
+        except ImportError as msg:
+            self.msg(2, "ImportError:", str(msg))
+            self._add_badmodule(name, caller)
+        else:
+            if fromlist:
+                for sub in fromlist:
+                    if sub in self.badmodules:
+                        self._add_badmodule(sub, caller)
+                        continue
+                    res.extend(
+                        self.import_hook(name, caller, [sub], level=level)
+                    )
+        return res
+
+    def import_hook(self, name, caller=None, fromlist=None, level=-1):
+        """Find all the modules that importing name will import."""
+
+        # Special handling for os.path is needed because the os module
+        # manipulates sys.modules directly to provide both os and
+        # os.path.
+        if name == "os.path":
+            self.msg(
+                2,
+                "bypassing os.path import - importing os " "instead",
+                name,
+                caller,
+                fromlist,
+                level,
+            )
+            name = "os"
+
+        self.msg(3, "import_hook", name, caller, fromlist, level)
+        parent = self.determine_parent(caller, level=level)
+        q, tail = self.find_head_package(parent, name)
+        if not tail:
+            # If q is a builtin module, don't report it because it
+            # doesn't live in the normal module space and it's part
+            # of python itself, which is handled by a different
+            # kind of dependency.
+            if isinstance(q, ModuleInfo) and q.builtin:
+                return []
+            elif isinstance(q, modulefinder.Module):
+                name = q.__name__
+                path = q.__path__
+                # some Module objects don't get a path
                 if not path:
                     if name in sys.builtin_module_names or name == "__future__":
-                            return ModuleInfo(name, [], builtin=True)
-                    path = self.path
-                return ModuleInfo(name, path)
+                        return [ModuleInfo(name, [], builtin=True)]
+                    else:
+                        return [ModuleInfo(name, [])]
+                return [ModuleInfo(name, path)]
+            else:
+                return [q]
+        res = self.load_tail(q, tail)
+        q.make_package()
+        res.append(q)
+        return res
 
-        def load_tail(self, q, tail):
-                """Determine where each component of a multilevel import would
-                be found on the file system."""
+    def import_module(self, partname, fqname, parent):
+        """Find where this module lives relative to its parent."""
 
-                self.msgin(4, "load_tail", q, tail)
-                res = []
-                name = q.name
-                cur_parent = q
-                while tail:
-                        i = tail.find('.')
-                        if i < 0:
-                                i = len(tail)
-                        head, tail = tail[:i], tail[i+1:]
-                        new_name = "{0}.{1}".format(name, head)
-                        r = self.import_module(head, new_name, cur_parent)
-                        res.append(r)
-                        name = new_name
-                        cur_parent = r
+        parent_dirs = None
+        self.msgin(3, "import_module", partname, fqname, parent)
+        try:
+            m = self.modules[fqname]
+        except KeyError:
+            pass
+        else:
+            self.msgout(3, "import_module ->", m)
+            return m
+        if fqname in self.badmodules:
+            self.msgout(3, "import_module -> None")
+            return None
+        if parent:
+            if not parent.dirs:
+                self.msgout(3, "import_module -> None")
+                return None
+            else:
+                parent_dirs = parent.get_package_dirs()
+        try:
+            mod = self.find_module(partname, parent_dirs, parent)
+        except ImportError:
+            self.msgout(3, "import_module ->", None)
+            return None
+        return mod
 
-                # All but the last module found must be packages because they
-                # contained other packages.
-                for i in range(0, len(res) - 1):
-                        res[i].make_package()
+    def find_module(self, name, path, parent=None):
+        """Calculate the potential paths on the file system where the
+        module could be found."""
 
-                self.msgout(4, "load_tail ->", q)
-                return res
+        if not path:
+            if name in sys.builtin_module_names or name == "__future__":
+                return ModuleInfo(name, [], builtin=True)
+            path = self.path
+        return ModuleInfo(name, path)
+
+    def load_tail(self, q, tail):
+        """Determine where each component of a multilevel import would
+        be found on the file system."""
+
+        self.msgin(4, "load_tail", q, tail)
+        res = []
+        name = q.name
+        cur_parent = q
+        while tail:
+            i = tail.find(".")
+            if i < 0:
+                i = len(tail)
+            head, tail = tail[:i], tail[i + 1 :]
+            new_name = "{0}.{1}".format(name, head)
+            r = self.import_module(head, new_name, cur_parent)
+            res.append(r)
+            name = new_name
+            cur_parent = r
+
+        # All but the last module found must be packages because they
+        # contained other packages.
+        for i in range(0, len(res) - 1):
+            res[i].make_package()
+
+        self.msgout(4, "load_tail ->", q)
+        return res
 
 
 if __name__ == "__main__":
-        """Usage:
-              depthlimitedmf.py <install_path> <script>
-                  [ run_path run_path ... ]
-        """
-        run_paths = sys.argv[3:]
-        try:
-                mf = DepthLimitedModuleFinder(sys.argv[1], run_paths=run_paths)
-                loaded_modules = mf.run_script(sys.argv[2])
-                for res in set([
-                    (tuple(m.get_file_names()), tuple(m.dirs))
-                    for m in loaded_modules
-                ]):
-                        sys.stdout.write("DEP {0}\n".format(res))
-                missing, maybe =  mf.any_missing_maybe()
-                sys.stdout.writelines(("ERR MISSING {0}\n"\
-                                      .format(name) for name in missing))
-        except SyntaxError as e:
-                sys.stdout.writelines(("ERR SYNTAX [{0}:{1}] {2}\n"\
-                                      .format(e.lineno, e.offset, e)))
-        except ValueError as e:
-                sys.stdout.write("ERR {0}\n".format(e))
-        except MultipleDefaultRunPaths as e:
-                sys.stdout.write("{0}\n".format(e))
+    """Usage:
+    depthlimitedmf.py <install_path> <script>
+        [ run_path run_path ... ]
+    """
+    run_paths = sys.argv[3:]
+    try:
+        mf = DepthLimitedModuleFinder(sys.argv[1], run_paths=run_paths)
+        loaded_modules = mf.run_script(sys.argv[2])
+        for res in set(
+            [(tuple(m.get_file_names()), tuple(m.dirs)) for m in loaded_modules]
+        ):
+            sys.stdout.write("DEP {0}\n".format(res))
+        missing, maybe = mf.any_missing_maybe()
+        sys.stdout.writelines(
+            ("ERR MISSING {0}\n".format(name) for name in missing)
+        )
+    except SyntaxError as e:
+        sys.stdout.writelines(
+            ("ERR SYNTAX [{0}:{1}] {2}\n".format(e.lineno, e.offset, e))
+        )
+    except ValueError as e:
+        sys.stdout.write("ERR {0}\n".format(e))
+    except MultipleDefaultRunPaths as e:
+        sys.stdout.write("{0}\n".format(e))
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/flavor/elf.py
+++ b/src/modules/flavor/elf.py
@@ -31,244 +31,267 @@ import pkg.flavor.base as base
 
 from pkg.portable import PD_LOCAL_PATH, PD_PROTO_DIR, PD_DEFAULT_RUNPATH
 
+
 class BadElfFile(base.DependencyAnalysisError):
-        """Exception that is raised when the elf dependency checker is given
-        a file that errors when it tries to get the dynamic section from the
-        file."""
+    """Exception that is raised when the elf dependency checker is given
+    a file that errors when it tries to get the dynamic section from the
+    file."""
 
-        def __init__(self, fp, ex):
-                base.DependencyAnalysisError.__init__(self)
-                self.fp = fp
-                self.ex = ex
+    def __init__(self, fp, ex):
+        base.DependencyAnalysisError.__init__(self)
+        self.fp = fp
+        self.ex = ex
 
-        def __str__(self):
-                return _("{file} had this elf error:{err}").format(
-                    file="self.fp", err=self.ex)
+    def __str__(self):
+        return _("{file} had this elf error:{err}").format(
+            file="self.fp", err=self.ex
+        )
+
 
 class UnsupportedDynamicToken(base.DependencyAnalysisError):
-        """Exception that is used for elf dependencies which have a dynamic
-        token in their path that we're unable to decode."""
+    """Exception that is used for elf dependencies which have a dynamic
+    token in their path that we're unable to decode."""
 
-        def __init__(self, proto_path, installed_path, run_path, token):
-                base.DependencyAnalysisError.__init__(self)
-                self.pp = proto_path
-                self.ip = installed_path
-                self.rp = run_path
-                self.tok = token
+    def __init__(self, proto_path, installed_path, run_path, token):
+        base.DependencyAnalysisError.__init__(self)
+        self.pp = proto_path
+        self.ip = installed_path
+        self.rp = run_path
+        self.tok = token
 
-        def __str__(self):
-                return  _("{pp} (which will be installed at {ip}) had this "
-                    "token, {tok}, in its run path: {rp}.  It is not "
-                    "currently possible to automatically expand this token. "
-                    "Please specify its value on the command line.").format(
-                    **self.__dict__)
+    def __str__(self):
+        return _(
+            "{pp} (which will be installed at {ip}) had this "
+            "token, {tok}, in its run path: {rp}.  It is not "
+            "currently possible to automatically expand this token. "
+            "Please specify its value on the command line."
+        ).format(**self.__dict__)
 
 
 class ElfDependency(base.PublishingDependency):
-        """Class representing a dependency from one file to another library
-        as determined by elf."""
+    """Class representing a dependency from one file to another library
+    as determined by elf."""
 
-        def __init__(self, action, base_name, run_paths, pkg_vars, proto_dir):
-                self.err_type = self.ERROR
+    def __init__(self, action, base_name, run_paths, pkg_vars, proto_dir):
+        self.err_type = self.ERROR
 
-                base.PublishingDependency.__init__(self, action,
-                    [base_name], run_paths, pkg_vars, proto_dir, "elf")
+        base.PublishingDependency.__init__(
+            self, action, [base_name], run_paths, pkg_vars, proto_dir, "elf"
+        )
 
-        def is_error(self):
-                """Because elf dependencies can be either warnings or errors,
-                it's necessary to check whether this dependency is an error
-                or not."""
+    def is_error(self):
+        """Because elf dependencies can be either warnings or errors,
+        it's necessary to check whether this dependency is an error
+        or not."""
 
-                return self.err_type == self.ERROR
+        return self.err_type == self.ERROR
 
-        def resolve_internal(self, delivered_base_names, **kwargs):
-                """Checks whether this dependency has been delivered. If the
-                full path has not been delivered, check whether the base name
-                has. If it has, it's likely that the run path is being set
-                externally. Report a warning, but not an error in this case."""
-                err, vars = base.PublishingDependency.resolve_internal(
-                    self, delivered_base_names=delivered_base_names, **kwargs)
-                # If the none of the paths pointed to a file with the desired
-                # basename, but a file with that basename was delivered by this
-                # package, then treat the dependency as a warning instead of
-                # an error. The failure to find the path to the right file
-                # may be due to the library search path being set outside the
-                # file that generates the dependency.
-                if err == self.ERROR and vars.is_satisfied() and \
-                    self.base_names and self.base_names[0] in delivered_base_names:
-                        self.err_type = self.WARNING
-                        self.attrs["{0}.severity".format(self.DEPEND_DEBUG_PREFIX)] =\
-                            "warning"
-                        missing_vars = self.get_variant_combinations()
-                        missing_vars.mark_as_satisfied(
-                            delivered_base_names[self.base_names[0]])
-                        return self.WARNING, missing_vars
-                else:
-                        return err, vars
+    def resolve_internal(self, delivered_base_names, **kwargs):
+        """Checks whether this dependency has been delivered. If the
+        full path has not been delivered, check whether the base name
+        has. If it has, it's likely that the run path is being set
+        externally. Report a warning, but not an error in this case."""
+        err, vars = base.PublishingDependency.resolve_internal(
+            self, delivered_base_names=delivered_base_names, **kwargs
+        )
+        # If the none of the paths pointed to a file with the desired
+        # basename, but a file with that basename was delivered by this
+        # package, then treat the dependency as a warning instead of
+        # an error. The failure to find the path to the right file
+        # may be due to the library search path being set outside the
+        # file that generates the dependency.
+        if (
+            err == self.ERROR
+            and vars.is_satisfied()
+            and self.base_names
+            and self.base_names[0] in delivered_base_names
+        ):
+            self.err_type = self.WARNING
+            self.attrs[
+                "{0}.severity".format(self.DEPEND_DEBUG_PREFIX)
+            ] = "warning"
+            missing_vars = self.get_variant_combinations()
+            missing_vars.mark_as_satisfied(
+                delivered_base_names[self.base_names[0]]
+            )
+            return self.WARNING, missing_vars
+        else:
+            return err, vars
 
-        def __repr__(self):
-                if self.base_names:
-                        return "ElfDep({0}, {1}, {2}, {3})".format(self.action,
-                            self.base_names[0], self.run_paths, self.pkg_vars)
-                return "ElfDep({0}, {1}, {2}, {3})".format(self.action,
-                    self.base_names, self.run_paths, self.pkg_vars)
+    def __repr__(self):
+        if self.base_names:
+            return "ElfDep({0}, {1}, {2}, {3})".format(
+                self.action, self.base_names[0], self.run_paths, self.pkg_vars
+            )
+        return "ElfDep({0}, {1}, {2}, {3})".format(
+            self.action, self.base_names, self.run_paths, self.pkg_vars
+        )
+
 
 def expand_variables(paths, dyn_tok_conv):
-        """Replace dynamic tokens, such as $PLATFORM, in the paths in the
-        parameter 'paths' with the values for that token provided in the
-        dictionary 'dyn_tok_conv.'
-        """
+    """Replace dynamic tokens, such as $PLATFORM, in the paths in the
+    parameter 'paths' with the values for that token provided in the
+    dictionary 'dyn_tok_conv.'
+    """
 
-        res = []
-        elist = []
-        for p in paths:
-                tok_start = p.find("$")
-                if tok_start > -1:
-                        tok = p[tok_start:]
-                        tok_end = tok.find("/")
-                        if tok_end > -1:
-                                tok = tok[:tok_end]
-                        if tok not in dyn_tok_conv:
-                                elist.append((p, tok))
-                        else:
-                                np = [
-                                    p[:tok_start] + dc + \
-                                    p[tok_start + len(tok):]
-                                    for dc in dyn_tok_conv[tok]
-                                ]
-                                # The first dynamic token has been replaced, but
-                                # more may remain so process the path again.
-                                rec_res, rec_elist = expand_variables(np,
-                                    dyn_tok_conv)
-                                res.extend(rec_res)
-                                elist.extend(rec_elist)
-                else:
-                        res.append(p)
-        return res, elist
+    res = []
+    elist = []
+    for p in paths:
+        tok_start = p.find("$")
+        if tok_start > -1:
+            tok = p[tok_start:]
+            tok_end = tok.find("/")
+            if tok_end > -1:
+                tok = tok[:tok_end]
+            if tok not in dyn_tok_conv:
+                elist.append((p, tok))
+            else:
+                np = [
+                    p[:tok_start] + dc + p[tok_start + len(tok) :]
+                    for dc in dyn_tok_conv[tok]
+                ]
+                # The first dynamic token has been replaced, but
+                # more may remain so process the path again.
+                rec_res, rec_elist = expand_variables(np, dyn_tok_conv)
+                res.extend(rec_res)
+                elist.extend(rec_elist)
+        else:
+            res.append(p)
+    return res, elist
+
 
 default_run_paths = ["/lib", "/usr/lib"]
 
-def process_elf_dependencies(action, pkg_vars, dyn_tok_conv, run_paths,
-    **kwargs):
-        """Produce the elf dependencies for the file delivered in the action
-        provided.
 
-        'action' is the file action to analyze.
+def process_elf_dependencies(
+    action, pkg_vars, dyn_tok_conv, run_paths, **kwargs
+):
+    """Produce the elf dependencies for the file delivered in the action
+    provided.
 
-        'pkg_vars' is the list of variants against which the package delivering
-        the action was published.
+    'action' is the file action to analyze.
 
-        'dyn_tok_conv' is the dictionary which maps the dynamic tokens, like
-        $PLATFORM, to the values they should be expanded to.
+    'pkg_vars' is the list of variants against which the package delivering
+    the action was published.
 
-        'run_paths' contains the run paths which elf binaries should use.
-        """
+    'dyn_tok_conv' is the dictionary which maps the dynamic tokens, like
+    $PLATFORM, to the values they should be expanded to.
 
-        if not action.name == "file":
-                return [], [], {}
+    'run_paths' contains the run paths which elf binaries should use.
+    """
 
-        installed_path = action.attrs[action.key_attr]
+    if not action.name == "file":
+        return [], [], {}
 
-        proto_file = action.attrs[PD_LOCAL_PATH]
+    installed_path = action.attrs[action.key_attr]
 
-        if not os.path.exists(proto_file):
-                raise base.MissingFile(proto_file)
+    proto_file = action.attrs[PD_LOCAL_PATH]
 
-        if not elf.is_elf_object(proto_file):
-                return [], [], {}
+    if not os.path.exists(proto_file):
+        raise base.MissingFile(proto_file)
 
-        try:
-                ei = elf.get_info(proto_file)
-                ed = elf.get_dynamic(proto_file)
-        except elf.ElfError as e:
-                raise BadElfFile(proto_file, e)
-        deps = [
-            d[0]
-            for d in ed.get("deps", [])
-        ]
-        rp = ed.get("runpath", "").split(":")
-        if len(rp) == 1 and rp[0] == "":
-                rp = []
+    if not elf.is_elf_object(proto_file):
+        return [], [], {}
 
-        dyn_tok_conv["$ORIGIN"] = [os.path.join("/",
-            os.path.dirname(installed_path))]
+    try:
+        ei = elf.get_info(proto_file)
+        ed = elf.get_dynamic(proto_file)
+    except elf.ElfError as e:
+        raise BadElfFile(proto_file, e)
+    deps = [d[0] for d in ed.get("deps", [])]
+    rp = ed.get("runpath", "").split(":")
+    if len(rp) == 1 and rp[0] == "":
+        rp = []
 
-        kernel64 = None
+    dyn_tok_conv["$ORIGIN"] = [
+        os.path.join("/", os.path.dirname(installed_path))
+    ]
 
-        # For kernel modules, default path resolution is /platform/<platform>,
-        # /kernel, /usr/kernel.  But how do we know what <platform> would be for
-        # a given module?  Does it do fallbacks to, say, sun4u?
-        if installed_path.startswith("kernel") or \
-            installed_path.startswith("usr/kernel") or \
-            (installed_path.startswith("platform") and \
-            installed_path.split("/")[2] == "kernel"):
-                if rp and (len(rp) > 1 or
-                    not re.match(r'^/usr/gcc/\d+/lib$', rp[0])):
-                        raise RuntimeError("RUNPATH set for kernel module "
-                            "({0}): {1}".format(installed_path, rp))
-                # Add this platform to the search path.
-                if installed_path.startswith("platform"):
-                        rp.append("/platform/{0}/kernel".format(
-                            installed_path.split("/")[1]))
-                else:
-                        for p in dyn_tok_conv.get("$PLATFORM", []):
-                                rp.append("/platform/{0}/kernel".format(p))
-                # Default kernel search path
-                rp.extend(["/kernel", "/usr/kernel"])
-                # What subdirectory should we look in for 64-bit kernel modules?
-                if ei["bits"] == 64:
-                        if ei["arch"] == "i386":
-                                kernel64 = "amd64"
-                        elif ei["arch"] == "sparc":
-                                kernel64 = "sparcv9"
-                        elif ei["arch"] == "aarch64":
-                                kernel64 = "aarch64"
-                        else:
-                                raise RuntimeError("Unknown arch:{0}".format(
-                                    ei["arch"]))
+    kernel64 = None
+
+    # For kernel modules, default path resolution is /platform/<platform>,
+    # /kernel, /usr/kernel.  But how do we know what <platform> would be for
+    # a given module?  Does it do fallbacks to, say, sun4u?
+    if (
+        installed_path.startswith("kernel")
+        or installed_path.startswith("usr/kernel")
+        or (
+            installed_path.startswith("platform")
+            and installed_path.split("/")[2] == "kernel"
+        )
+    ):
+        if rp and (len(rp) > 1 or not re.match(r"^/usr/gcc/\d+/lib$", rp[0])):
+            raise RuntimeError(
+                "RUNPATH set for kernel module "
+                "({0}): {1}".format(installed_path, rp)
+            )
+        # Add this platform to the search path.
+        if installed_path.startswith("platform"):
+            rp.append(
+                "/platform/{0}/kernel".format(installed_path.split("/")[1])
+            )
         else:
-                for p in default_run_paths:
-                        if ei["bits"] == 64 and ei["arch"] != "aarch64":
-                                p += "/64"
-                        if p not in rp:
-                                rp.append(p)
+            for p in dyn_tok_conv.get("$PLATFORM", []):
+                rp.append("/platform/{0}/kernel".format(p))
+        # Default kernel search path
+        rp.extend(["/kernel", "/usr/kernel"])
+        # What subdirectory should we look in for 64-bit kernel modules?
+        if ei["bits"] == 64:
+            if ei["arch"] == "i386":
+                kernel64 = "amd64"
+            elif ei["arch"] == "sparc":
+                kernel64 = "sparcv9"
+            elif ei["arch"] == "aarch64":
+                kernel64 = "aarch64"
+            else:
+                raise RuntimeError("Unknown arch:{0}".format(ei["arch"]))
+    else:
+        for p in default_run_paths:
+            if ei["bits"] == 64 and ei["arch"] != "aarch64":
+                p += "/64"
+            if p not in rp:
+                rp.append(p)
 
-        elist = []
-        if run_paths:
-                # add our detected runpaths into the user-supplied one (if any)
-                rp = base.insert_default_runpath(rp, run_paths)
+    elist = []
+    if run_paths:
+        # add our detected runpaths into the user-supplied one (if any)
+        rp = base.insert_default_runpath(rp, run_paths)
 
-        rp, errs = expand_variables(rp, dyn_tok_conv)
+    rp, errs = expand_variables(rp, dyn_tok_conv)
 
-        elist.extend([
+    elist.extend(
+        [
             UnsupportedDynamicToken(proto_file, installed_path, p, tok)
             for p, tok in errs
-        ])
+        ]
+    )
 
-        res = []
+    res = []
 
-        for d in deps:
-                pn, fn = os.path.split(d)
-                pathlist = []
-                for p in rp:
-                        if kernel64:
-                                # Find 64-bit modules the way krtld does.
-                                # XXX We don't resolve dependencies found in
-                                # /platform, since we don't know where under
-                                # /platform to look.
-                                deppath = \
-                                    os.path.join(p, pn, kernel64, fn).lstrip(
-                                    os.path.sep)
-                        else:
-                                deppath = os.path.join(p, d).lstrip(os.path.sep)
-                        # deppath includes filename; remove that.
-                        head, tail = os.path.split(deppath)
-                        if head:
-                                pathlist.append(head)
-                res.append(ElfDependency(action, fn, pathlist, pkg_vars,
-                    action.attrs[PD_PROTO_DIR]))
-        del dyn_tok_conv["$ORIGIN"]
-        return res, elist, {}
+    for d in deps:
+        pn, fn = os.path.split(d)
+        pathlist = []
+        for p in rp:
+            if kernel64:
+                # Find 64-bit modules the way krtld does.
+                # XXX We don't resolve dependencies found in
+                # /platform, since we don't know where under
+                # /platform to look.
+                deppath = os.path.join(p, pn, kernel64, fn).lstrip(os.path.sep)
+            else:
+                deppath = os.path.join(p, d).lstrip(os.path.sep)
+            # deppath includes filename; remove that.
+            head, tail = os.path.split(deppath)
+            if head:
+                pathlist.append(head)
+        res.append(
+            ElfDependency(
+                action, fn, pathlist, pkg_vars, action.attrs[PD_PROTO_DIR]
+            )
+        )
+    del dyn_tok_conv["$ORIGIN"]
+    return res, elist, {}
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/flavor/hardlink.py
+++ b/src/modules/flavor/hardlink.py
@@ -28,27 +28,36 @@ import os
 
 import pkg.flavor.base as base
 
-class HardlinkDependency(base.PublishingDependency):
-        """Class representing the dependency by having an action that's a
-        hardlink to a path."""
-        def __init__(self, action, path, pkg_vars):
-                base_names = [os.path.basename(path)]
-                paths = [os.path.dirname(path)]
-                base.PublishingDependency.__init__(self, action,
-                    base_names, paths, pkg_vars, None, "hardlink")
 
-        def __repr__(self):
-                return "HLDep({0}, {1}, {2}, {3}, {4})".format(self.action,
-                    self.base_names, self.run_paths, self.pkg_vars,
-                    self.dep_vars)
+class HardlinkDependency(base.PublishingDependency):
+    """Class representing the dependency by having an action that's a
+    hardlink to a path."""
+
+    def __init__(self, action, path, pkg_vars):
+        base_names = [os.path.basename(path)]
+        paths = [os.path.dirname(path)]
+        base.PublishingDependency.__init__(
+            self, action, base_names, paths, pkg_vars, None, "hardlink"
+        )
+
+    def __repr__(self):
+        return "HLDep({0}, {1}, {2}, {3}, {4})".format(
+            self.action,
+            self.base_names,
+            self.run_paths,
+            self.pkg_vars,
+            self.dep_vars,
+        )
+
 
 def process_hardlink_deps(action, pkg_vars):
-        """Given an action, and the variants against which the action's package
-        was published, produce a list with one HardlinkDependency object in
-        it."""
+    """Given an action, and the variants against which the action's package
+    was published, produce a list with one HardlinkDependency object in
+    it."""
 
-        target = action.get_target_path()
-        return [HardlinkDependency(action, target, pkg_vars)]
+    target = action.get_target_path()
+    return [HardlinkDependency(action, target, pkg_vars)]
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/flavor/python.py
+++ b/src/modules/flavor/python.py
@@ -35,310 +35,365 @@ import pkg.flavor.depthlimitedmf as modulefinder
 from pkg.misc import force_str
 from pkg.portable import PD_LOCAL_PATH, PD_PROTO_DIR
 
+
 class PythonModuleMissingPath(base.DependencyAnalysisError):
-        """Exception that is raised when a module reports a module as a
-        dependency without a path to that module."""
+    """Exception that is raised when a module reports a module as a
+    dependency without a path to that module."""
 
-        def __init__(self, name, localpath):
-                Exception.__init__(self)
-                self.name = name
-                self.localpath = localpath
+    def __init__(self, name, localpath):
+        Exception.__init__(self)
+        self.name = name
+        self.localpath = localpath
 
-        def __str__(self):
-                return _("Could not find the file for {name} imported "
-                    "in {localpath}").format(**self.__dict__)
+    def __str__(self):
+        return _(
+            "Could not find the file for {name} imported " "in {localpath}"
+        ).format(**self.__dict__)
 
 
 class PythonMismatchedVersion(base.DependencyAnalysisError):
-        """Exception that is raised when a module is installed into a path
-        associated with a known version of python (/usr/lib/python3.9 for
-        example) but has a different version of python specified in its
-        #! line (#!/usr/bin/python3.4 for example)."""
+    """Exception that is raised when a module is installed into a path
+    associated with a known version of python (/usr/lib/python3.9 for
+    example) but has a different version of python specified in its
+    #! line (#!/usr/bin/python3.4 for example)."""
 
-        def __init__(self, installed_version, declared_version, local_file,
-            installed_path):
-                self.inst_v = installed_version
-                self.decl_v = declared_version
-                self.lp = local_file
-                self.ip = installed_path
+    def __init__(
+        self, installed_version, declared_version, local_file, installed_path
+    ):
+        self.inst_v = installed_version
+        self.decl_v = declared_version
+        self.lp = local_file
+        self.ip = installed_path
 
-        def __str__(self):
-                return _("The file to be installed at {ip} declares a "
-                    "python version of {decl_v}.  However, the path suggests "
-                    "that the version should be {inst_v}.  The text of the "
-                    "file can be found at {lp}").format(**self.__dict__)
+    def __str__(self):
+        return _(
+            "The file to be installed at {ip} declares a "
+            "python version of {decl_v}.  However, the path suggests "
+            "that the version should be {inst_v}.  The text of the "
+            "file can be found at {lp}"
+        ).format(**self.__dict__)
 
 
 class PythonSyntaxError(base.DependencyAnalysisError):
-        """Exception that is raised when a python file to be analyzed contains a
-        syntax error."""
+    """Exception that is raised when a python file to be analyzed contains a
+    syntax error."""
 
-        def __init__(self, installed_path, local_file, s_err=None, msg=None):
-                self.ip = installed_path
-                self.lp = local_file
-                if s_err:
-                    self.line = s_err.lineno
-                    self.col = s_err.offset
-                    self.txt = str(s_err)
-                else:
-                    # This is very dependent upon the message from the
-                    # depthlimitedmf.py output for a SyntaxError:
-                    # ERR SYNTAX [lineno:column] actual error text
-                    # Error text is after the last ']'
-                    self.txt = msg[msg.index(']') + 2:]
-                    # Extract the lineno and column from the [lineno:column]
-                    values = re.search(r"\[(.+):(.+)\]", msg)
-                    self.line = values.group(1)
-                    self.col = values.group(2)
+    def __init__(self, installed_path, local_file, s_err=None, msg=None):
+        self.ip = installed_path
+        self.lp = local_file
+        if s_err:
+            self.line = s_err.lineno
+            self.col = s_err.offset
+            self.txt = str(s_err)
+        else:
+            # This is very dependent upon the message from the
+            # depthlimitedmf.py output for a SyntaxError:
+            # ERR SYNTAX [lineno:column] actual error text
+            # Error text is after the last ']'
+            self.txt = msg[msg.index("]") + 2 :]
+            # Extract the lineno and column from the [lineno:column]
+            values = re.search(r"\[(.+):(.+)\]", msg)
+            self.line = values.group(1)
+            self.col = values.group(2)
 
-        def __str__(self):
-                return _("The file to be installed at {ip} appears to be a "
-                    "python file but contains a syntax error that prevents "
-                    "it from being analyzed.  The text of the file can be found"
-                    " at {lp}.  The error happened on line {line} at offset "
-                    "{col}. The problem was:\n{txt}").format(**self.__dict__)
+    def __str__(self):
+        return _(
+            "The file to be installed at {ip} appears to be a "
+            "python file but contains a syntax error that prevents "
+            "it from being analyzed.  The text of the file can be found"
+            " at {lp}.  The error happened on line {line} at offset "
+            "{col}. The problem was:\n{txt}"
+        ).format(**self.__dict__)
 
 
 class PythonSubprocessError(base.DependencyAnalysisError):
-        """This exception is raised when the subprocess created to analyze the
-        module using a different version of python exits with an error code."""
+    """This exception is raised when the subprocess created to analyze the
+    module using a different version of python exits with an error code."""
 
-        def __init__(self, rc, cmd, err):
-                self.rc = rc
-                self.cmd = cmd
-                self.err = err
+    def __init__(self, rc, cmd, err):
+        self.rc = rc
+        self.cmd = cmd
+        self.err = err
 
-        def __str__(self):
-                return _("The command {cmd}\nexited with return code {rc} "
-                    "and this message:\n{err}").format(**self.__dict__)
+    def __str__(self):
+        return _(
+            "The command {cmd}\nexited with return code {rc} "
+            "and this message:\n{err}"
+        ).format(**self.__dict__)
 
 
 class PythonSubprocessBadLine(base.DependencyAnalysisError):
-        """This exception is used when the output from the subprocess does not
-        follow the expected format."""
+    """This exception is used when the output from the subprocess does not
+    follow the expected format."""
 
-        def __init__(self, cmd, lines):
-                self.lines = "\n".join(lines)
-                self.cmd = cmd
+    def __init__(self, cmd, lines):
+        self.lines = "\n".join(lines)
+        self.cmd = cmd
 
-        def __str__(self):
-                return _("The command {cmd} produced the following lines "
-                    "which cannot be understood:\n{lines}").format(
-                    **self.__dict__)
+    def __str__(self):
+        return _(
+            "The command {cmd} produced the following lines "
+            "which cannot be understood:\n{lines}"
+        ).format(**self.__dict__)
 
 
 class PythonUnspecifiedVersion(base.PublishingDependency):
-        """This exception is used when an executable file starts with
-        #!/usr/bin/python and is not installed into a location from which its
-        python version may be inferred."""
+    """This exception is used when an executable file starts with
+    #!/usr/bin/python and is not installed into a location from which its
+    python version may be inferred."""
 
-        def __init__(self, local_file, installed_path):
-                self.lp = local_file
-                self.ip = installed_path
+    def __init__(self, local_file, installed_path):
+        self.lp = local_file
+        self.ip = installed_path
 
-        def __str__(self):
-                return _("The file to be installed in {ip} does not specify "
-                    "a specific version of python either in its installed path "
-                    "nor in its text.  Such a file cannot be analyzed for "
-                    "dependencies since the version of python it will be used "
-                    "with is unknown.  The text of the file is here: "
-                    "{lp}.").format(**self.__dict__)
+    def __str__(self):
+        return _(
+            "The file to be installed in {ip} does not specify "
+            "a specific version of python either in its installed path "
+            "nor in its text.  Such a file cannot be analyzed for "
+            "dependencies since the version of python it will be used "
+            "with is unknown.  The text of the file is here: "
+            "{lp}."
+        ).format(**self.__dict__)
 
 
 class PythonDependency(base.PublishingDependency):
-        """Class representing the dependency created by importing a module
-        in python."""
+    """Class representing the dependency created by importing a module
+    in python."""
 
-        def __init__(self, action, base_names, run_paths, pkg_vars, proto_dir):
-                base.PublishingDependency.__init__(self, action,
-                    base_names, run_paths, pkg_vars, proto_dir, "python")
+    def __init__(self, action, base_names, run_paths, pkg_vars, proto_dir):
+        base.PublishingDependency.__init__(
+            self, action, base_names, run_paths, pkg_vars, proto_dir, "python"
+        )
 
-        def __repr__(self):
-                return "PythonDep({0}, {1}, {2}, {3})".format(self.action,
-                    self.base_names, self.run_paths, self.pkg_vars)
+    def __repr__(self):
+        return "PythonDep({0}, {1}, {2}, {3})".format(
+            self.action, self.base_names, self.run_paths, self.pkg_vars
+        )
 
 
 py_bin_re = re.compile(
-    r"^\#\!\s*/usr/bin/([^/]+/)?python(?P<major>\d+)\.(?P<minor>\d+)")
+    r"^\#\!\s*/usr/bin/([^/]+/)?python(?P<major>\d+)\.(?P<minor>\d+)"
+)
 py_lib_re = re.compile(r"^usr/lib/python(?P<major>\d+)\.(?P<minor>\d+)/")
 
+
 def process_python_dependencies(action, pkg_vars, script_path, run_paths):
-        """Analyze the file delivered by the action for any python dependencies.
+    """Analyze the file delivered by the action for any python dependencies.
 
-        The 'action' parameter contain the action which delivers the file.
+    The 'action' parameter contain the action which delivers the file.
 
-        The 'pkg_vars' parameter contains the variants against which
-        the action's package was published.
+    The 'pkg_vars' parameter contains the variants against which
+    the action's package was published.
 
-        The 'script_path' parameter is None of the file is not executable, or
-        is the path for the binary which is used to execute the file.
+    The 'script_path' parameter is None of the file is not executable, or
+    is the path for the binary which is used to execute the file.
 
-        The 'run_paths' parameter is a list of paths that should be searched
-        for modules.
-        """
+    The 'run_paths' parameter is a list of paths that should be searched
+    for modules.
+    """
 
-        # There are three conditions which determine whether python dependency
-        # analysis is performed on a file with python in its #! line.
-        # 1) Is the file executable. (Represented in the table below by X)
-        # 2) Is the file installed into a directory which provides information
-        #     about what version of python should be used for it.
-        #     (Represented by D)
-        # 3) Does the first line of the file include a specific version of
-        #     python. (Represented by F)
-        #
-        # Conditions || Perform Analysis
-        #  X  D  F   || Y, if F and D disagree, display a warning in the output
-        #            ||     and use D to analyze the file.
-        #  X  D !F   || Y
-        #  X !D  F   || Y
-        #  X !D !F   || N, and display a warning in the output.
-        # !X  D  F   || Y
-        # !X  D !F   || Y
-        # !X !D  F   || N
-        # !X !D !F   || N
+    # There are three conditions which determine whether python dependency
+    # analysis is performed on a file with python in its #! line.
+    # 1) Is the file executable. (Represented in the table below by X)
+    # 2) Is the file installed into a directory which provides information
+    #     about what version of python should be used for it.
+    #     (Represented by D)
+    # 3) Does the first line of the file include a specific version of
+    #     python. (Represented by F)
+    #
+    # Conditions || Perform Analysis
+    #  X  D  F   || Y, if F and D disagree, display a warning in the output
+    #            ||     and use D to analyze the file.
+    #  X  D !F   || Y
+    #  X !D  F   || Y
+    #  X !D !F   || N, and display a warning in the output.
+    # !X  D  F   || Y
+    # !X  D !F   || Y
+    # !X !D  F   || N
+    # !X !D !F   || N
 
-        local_file = action.attrs[PD_LOCAL_PATH]
-        deps = []
-        errs = []
-        path_version = None
+    local_file = action.attrs[PD_LOCAL_PATH]
+    deps = []
+    errs = []
+    path_version = None
 
-        dir_major = None
-        dir_minor = None
-        file_major = None
-        file_minor = None
-        cur_major = None
-        cur_minor = None
-        executable = bool(script_path)
+    dir_major = None
+    dir_minor = None
+    file_major = None
+    file_minor = None
+    cur_major = None
+    cur_minor = None
+    executable = bool(script_path)
 
-        # Version of python to use to do the analysis.
-        analysis_major = None
-        analysis_minor = None
+    # Version of python to use to do the analysis.
+    analysis_major = None
+    analysis_minor = None
 
-        cur_major, cur_minor = sys.version_info[0:2]
-        install_match = py_lib_re.match(action.attrs["path"])
+    cur_major, cur_minor = sys.version_info[0:2]
+    install_match = py_lib_re.match(action.attrs["path"])
+    if install_match:
+        dir_major = install_match.group("major")
+        dir_minor = install_match.group("minor")
+
+    script_match = None
+    if script_path:
+        script_match = py_bin_re.match(script_path)
+        if script_match:
+            file_major = script_match.group("major")
+            file_minor = script_match.group("minor")
+
+    if executable:
+        # Check whether the version of python declared in the #! line
+        # of the file and the version of python implied by the directory
+        # the file is delivered into match.
+        if (
+            install_match
+            and script_match
+            and (file_major != dir_major or file_minor != dir_minor)
+        ):
+            errs.append(
+                PythonMismatchedVersion(
+                    "{0}.{1}".format(dir_major, dir_minor),
+                    "{0}.{1}".format(file_major, file_minor),
+                    local_file,
+                    action.attrs["path"],
+                )
+            )
         if install_match:
-                dir_major = install_match.group("major")
-                dir_minor = install_match.group("minor")
+            analysis_major = dir_major
+            analysis_minor = dir_minor
+        elif script_match:
+            analysis_major = file_major
+            analysis_minor = file_minor
+        else:
+            # An example of this case is an executable file in
+            # /usr/bin with #!/usr/bin/python as its first line.
+            errs.append(
+                PythonUnspecifiedVersion(local_file, action.attrs["path"])
+            )
+    elif install_match:
+        analysis_major = dir_major
+        analysis_minor = dir_minor
 
-        script_match = None
-        if script_path:
-                script_match = py_bin_re.match(script_path)
-                if script_match:
-                        file_major = script_match.group("major")
-                        file_minor = script_match.group("minor")
-
-        if executable:
-                # Check whether the version of python declared in the #! line
-                # of the file and the version of python implied by the directory
-                # the file is delivered into match.
-                if install_match and script_match and \
-                    (file_major != dir_major or file_minor != dir_minor):
-                        errs.append(PythonMismatchedVersion(
-                            "{0}.{1}".format(dir_major, dir_minor),
-                            "{0}.{1}".format(file_major, file_minor),
-                            local_file, action.attrs["path"]))
-                if install_match:
-                        analysis_major = dir_major
-                        analysis_minor = dir_minor
-                elif script_match:
-                        analysis_major = file_major
-                        analysis_minor = file_minor
-                else:
-                        # An example of this case is an executable file in
-                        # /usr/bin with #!/usr/bin/python as its first line.
-                        errs.append(PythonUnspecifiedVersion(
-                            local_file, action.attrs["path"]))
-        elif install_match:
-                analysis_major = dir_major
-                analysis_minor = dir_minor
-
-        if analysis_major is None or analysis_minor is None:
-                return deps, errs, {}
-
-        analysis_major = int(analysis_major)
-        analysis_minor = int(analysis_minor)
-
-        # If the version implied by the directory hierarchy matches the version
-        # of python running, use the default analyzer and don't fork and exec.
-        if cur_major == analysis_major and cur_minor == analysis_minor:
-                mf = modulefinder.DepthLimitedModuleFinder(
-                    os.path.dirname(action.attrs["path"]), run_paths=run_paths)
-                try:
-                        loaded_modules = mf.run_script(local_file)
-
-                        for names, dirs in set([
-                            (tuple(m.get_file_names()), tuple(m.dirs))
-                            for m in loaded_modules
-                        ]):
-                                # Add the directory the python file will be
-                                # installed in to the paths used to find modules
-                                # for import.  This allows relative imports to
-                                # work correctly.
-                                deps.append(PythonDependency(action, names,
-                                    dirs, pkg_vars, action.attrs[PD_PROTO_DIR]))
-                        missing, maybe = mf.any_missing_maybe()
-                        for name in missing:
-                                errs.append(PythonModuleMissingPath(name,
-                                    action.attrs[PD_LOCAL_PATH]))
-                except SyntaxError as e:
-                        errs.append(PythonSyntaxError(action.attrs["path"],
-                            local_file, s_err=e))
-                except Exception as e:
-                        errs.append(e)
-                return deps, errs, {}
-
-        # If the version implied by the directory hierarchy does not match the
-        # version of python running, it's necessary to fork and run the
-        # appropriate version of python.
-        root_dir = os.path.dirname(__file__)
-        exec_file = os.path.join(root_dir, "depthlimitedmf.py")
-        cmd = ["python{0}.{1}".format(analysis_major, analysis_minor), exec_file,
-            os.path.dirname(action.attrs["path"]), local_file]
-        newenv = os.environ.copy()
-        # Tell Python to not create .pyc, .pyo, etc. cache files for any Python
-        # modules our script imports.
-        newenv["PYTHONDONTWRITEBYTECODE"] = "1"
-
-        if run_paths:
-                cmd.extend(run_paths)
-        try:
-                sp = subprocess.Popen(cmd, env=newenv, stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE, encoding="utf-8")
-        except Exception as e:
-                return [], [PythonSubprocessError(None, " ".join(cmd),\
-                    str(e))], {}
-        out, err = sp.communicate()
-        out = force_str(out)
-        if sp.returncode:
-                errs.append(PythonSubprocessError(sp.returncode, " ".join(cmd),
-                    err))
-        bad_lines = []
-        for l in out.splitlines():
-                l = l.strip()
-                if l.startswith("DEP "):
-                        try:
-                                names, dirs = eval(l[4:])
-                        except Exception:
-                                bad_lines.append(l)
-                        else:
-                                deps.append(PythonDependency(action, names,
-                                    dirs, pkg_vars, action.attrs[PD_PROTO_DIR]))
-                elif l.startswith("ERR MISSING "):
-                        errs.append(
-                            PythonModuleMissingPath(l[len("ERR MISSING "):],
-                            action.attrs[PD_LOCAL_PATH]))
-                elif l.startswith("ERR SYNTAX "):
-                        errs.append(PythonSyntaxError(action.attrs["path"],
-                            local_file, msg=l))
-                elif l.startswith("ERR "):
-                        # Generic error which is assigned as a missing path
-                        errs.append(PythonModuleMissingPath(l[4:],
-                            action.attrs[PD_LOCAL_PATH]))
-                else:
-                        bad_lines.append(l)
-        if bad_lines:
-                errs.append(PythonSubprocessBadLine(" ".join(cmd), bad_lines))
+    if analysis_major is None or analysis_minor is None:
         return deps, errs, {}
 
+    analysis_major = int(analysis_major)
+    analysis_minor = int(analysis_minor)
+
+    # If the version implied by the directory hierarchy matches the version
+    # of python running, use the default analyzer and don't fork and exec.
+    if cur_major == analysis_major and cur_minor == analysis_minor:
+        mf = modulefinder.DepthLimitedModuleFinder(
+            os.path.dirname(action.attrs["path"]), run_paths=run_paths
+        )
+        try:
+            loaded_modules = mf.run_script(local_file)
+
+            for names, dirs in set(
+                [
+                    (tuple(m.get_file_names()), tuple(m.dirs))
+                    for m in loaded_modules
+                ]
+            ):
+                # Add the directory the python file will be
+                # installed in to the paths used to find modules
+                # for import.  This allows relative imports to
+                # work correctly.
+                deps.append(
+                    PythonDependency(
+                        action,
+                        names,
+                        dirs,
+                        pkg_vars,
+                        action.attrs[PD_PROTO_DIR],
+                    )
+                )
+            missing, maybe = mf.any_missing_maybe()
+            for name in missing:
+                errs.append(
+                    PythonModuleMissingPath(name, action.attrs[PD_LOCAL_PATH])
+                )
+        except SyntaxError as e:
+            errs.append(
+                PythonSyntaxError(action.attrs["path"], local_file, s_err=e)
+            )
+        except Exception as e:
+            errs.append(e)
+        return deps, errs, {}
+
+    # If the version implied by the directory hierarchy does not match the
+    # version of python running, it's necessary to fork and run the
+    # appropriate version of python.
+    root_dir = os.path.dirname(__file__)
+    exec_file = os.path.join(root_dir, "depthlimitedmf.py")
+    cmd = [
+        "python{0}.{1}".format(analysis_major, analysis_minor),
+        exec_file,
+        os.path.dirname(action.attrs["path"]),
+        local_file,
+    ]
+    newenv = os.environ.copy()
+    # Tell Python to not create .pyc, .pyo, etc. cache files for any Python
+    # modules our script imports.
+    newenv["PYTHONDONTWRITEBYTECODE"] = "1"
+
+    if run_paths:
+        cmd.extend(run_paths)
+    try:
+        sp = subprocess.Popen(
+            cmd,
+            env=newenv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+        )
+    except Exception as e:
+        return [], [PythonSubprocessError(None, " ".join(cmd), str(e))], {}
+    out, err = sp.communicate()
+    out = force_str(out)
+    if sp.returncode:
+        errs.append(PythonSubprocessError(sp.returncode, " ".join(cmd), err))
+    bad_lines = []
+    for l in out.splitlines():
+        l = l.strip()
+        if l.startswith("DEP "):
+            try:
+                names, dirs = eval(l[4:])
+            except Exception:
+                bad_lines.append(l)
+            else:
+                deps.append(
+                    PythonDependency(
+                        action,
+                        names,
+                        dirs,
+                        pkg_vars,
+                        action.attrs[PD_PROTO_DIR],
+                    )
+                )
+        elif l.startswith("ERR MISSING "):
+            errs.append(
+                PythonModuleMissingPath(
+                    l[len("ERR MISSING ") :], action.attrs[PD_LOCAL_PATH]
+                )
+            )
+        elif l.startswith("ERR SYNTAX "):
+            errs.append(
+                PythonSyntaxError(action.attrs["path"], local_file, msg=l)
+            )
+        elif l.startswith("ERR "):
+            # Generic error which is assigned as a missing path
+            errs.append(
+                PythonModuleMissingPath(l[4:], action.attrs[PD_LOCAL_PATH])
+            )
+        else:
+            bad_lines.append(l)
+    if bad_lines:
+        errs.append(PythonSubprocessBadLine(" ".join(cmd), bad_lines))
+    return deps, errs, {}
+
+
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/flavor/script.py
+++ b/src/modules/flavor/script.py
@@ -33,88 +33,103 @@ import pkg.flavor.python as python
 from pkg.portable import PD_LOCAL_PATH, PD_PROTO_DIR
 from pkg.misc import force_str
 
+
 class ScriptNonAbsPath(base.DependencyAnalysisError):
-        """Exception that is raised when a file uses a relative path for the
-        binary with which it should be run."""
+    """Exception that is raised when a file uses a relative path for the
+    binary with which it should be run."""
 
-        def __init__(self, lp, bin):
-                Exception.__init__(self)
-                self.lp = lp
-                self.bin = bin
+    def __init__(self, lp, bin):
+        Exception.__init__(self)
+        self.lp = lp
+        self.bin = bin
 
-        def __str__(self):
-                return _("{lp} says it should be run with '{bin}' which is "
-                    "a relative path.").format(**vars(self))
+    def __str__(self):
+        return _(
+            "{lp} says it should be run with '{bin}' which is "
+            "a relative path."
+        ).format(**vars(self))
+
 
 class ScriptDependency(base.PublishingDependency):
-        """Class representing the dependency created by having #! at the top
-        of a file."""
+    """Class representing the dependency created by having #! at the top
+    of a file."""
 
-        def __init__(self, action, path, pkg_vars, proto_dir):
-                base_names = [os.path.basename(path)]
-                paths = [os.path.dirname(path)]
-                base.PublishingDependency.__init__(self, action,
-                    base_names, paths, pkg_vars, proto_dir, "script")
+    def __init__(self, action, path, pkg_vars, proto_dir):
+        base_names = [os.path.basename(path)]
+        paths = [os.path.dirname(path)]
+        base.PublishingDependency.__init__(
+            self, action, base_names, paths, pkg_vars, proto_dir, "script"
+        )
 
-        def __repr__(self):
-                return "PBDep({0}, {1}, {2}, {3}, {4})".format(self.action,
-                    self.base_names, self.run_paths, self.pkg_vars,
-                    self.dep_vars)
+    def __repr__(self):
+        return "PBDep({0}, {1}, {2}, {3}, {4})".format(
+            self.action,
+            self.base_names,
+            self.run_paths,
+            self.pkg_vars,
+            self.dep_vars,
+        )
+
 
 def process_script_deps(action, pkg_vars, **kwargs):
-        """Given an action, if the file starts with #! a list containing a
-        ScriptDependency is returned. Further, if the file is of a known type,
-        it is further analyzed and any dependencies found are added to the list
-        returned."""
+    """Given an action, if the file starts with #! a list containing a
+    ScriptDependency is returned. Further, if the file is of a known type,
+    it is further analyzed and any dependencies found are added to the list
+    returned."""
 
-        if action.name != "file":
-                return [], [], {}
+    if action.name != "file":
+        return [], [], {}
 
-        f = action.data()
-        l = force_str(f.readline())
-        f.close()
+    f = action.data()
+    l = force_str(f.readline())
+    f.close()
 
-        deps = []
-        elist = []
-        pkg_attrs = {}
+    deps = []
+    elist = []
+    pkg_attrs = {}
 
-        script_path = None
-        run_paths = kwargs.get("run_paths", [])
-        # add #! dependency
-        if l.startswith("#!"):
-                # Determine whether the file will be delivered executable.
-                ex_bit = int(action.attrs.get("mode", "0"), 8) & \
-                    (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-                if ex_bit:
-                        p = (l[2:].split()[0])
-                        # first part of string is path (removes options)
-                        # we don't handle dependencies through links, so fix up
-                        # the common one
-                        p = p.strip()
-                        if not os.path.isabs(p):
-                                elist.append(ScriptNonAbsPath(
-                                    action.attrs[PD_LOCAL_PATH], p))
-                        else:
-                                if p.startswith("/bin"):
-                                        # Use p[1:] to strip off the leading /.
-                                        p = os.path.join("/usr", p[1:])
-                                deps.append(ScriptDependency(action, p,
-                                    pkg_vars, action.attrs[PD_PROTO_DIR]))
-                                script_path = l
-                if "python" in l:
-                        ds, errs, py_attrs = python.process_python_dependencies(
-                            action, pkg_vars, script_path, run_paths)
-                        elist.extend(errs)
-                        deps.extend(ds)
-                        for key in py_attrs:
-                                if key in pkg_attrs:
-                                        pkg_attrs[key].extend(py_attrs[key])
-                                else:
-                                        pkg_attrs[key] = py_attrs[key]
-        # Ensure that the reported dependencies are
-        # always in the same order.
-        deps.sort()
-        return deps, elist, pkg_attrs
+    script_path = None
+    run_paths = kwargs.get("run_paths", [])
+    # add #! dependency
+    if l.startswith("#!"):
+        # Determine whether the file will be delivered executable.
+        ex_bit = int(action.attrs.get("mode", "0"), 8) & (
+            stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        )
+        if ex_bit:
+            p = l[2:].split()[0]
+            # first part of string is path (removes options)
+            # we don't handle dependencies through links, so fix up
+            # the common one
+            p = p.strip()
+            if not os.path.isabs(p):
+                elist.append(ScriptNonAbsPath(action.attrs[PD_LOCAL_PATH], p))
+            else:
+                if p.startswith("/bin"):
+                    # Use p[1:] to strip off the leading /.
+                    p = os.path.join("/usr", p[1:])
+                deps.append(
+                    ScriptDependency(
+                        action, p, pkg_vars, action.attrs[PD_PROTO_DIR]
+                    )
+                )
+                script_path = l
+        if "python" in l:
+            ds, errs, py_attrs = python.process_python_dependencies(
+                action, pkg_vars, script_path, run_paths
+            )
+            elist.extend(errs)
+            deps.extend(ds)
+            for key in py_attrs:
+                if key in pkg_attrs:
+                    pkg_attrs[key].extend(py_attrs[key])
+                else:
+                    pkg_attrs[key] = py_attrs[key]
+    # Ensure that the reported dependencies are
+    # always in the same order.
+    deps.sort()
+    return deps, elist, pkg_attrs
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/flavor/smf_manifest.py
+++ b/src/modules/flavor/smf_manifest.py
@@ -35,471 +35,500 @@ from pkg.portable import PD_LOCAL_PATH, PD_PROTO_DIR, PD_PROTO_DIR_LIST
 
 # A list of locations beneath a given proto_dir where we expect to
 # find SMF manifest files
-manifest_locations = [ "lib/svc/manifest", "var/svc/manifest" ]
+manifest_locations = ["lib/svc/manifest", "var/svc/manifest"]
+
 
 class SMFManifestDependency(base.PublishingDependency):
+    # maps SMF fmris to the manifest files that defined them
+    instance_mf = None
 
-        # maps SMF fmris to the manifest files that defined them
-        instance_mf = None
+    # maps SMF FMRIs to a list the SMF FMRIs they declare as dependencies
+    instance_deps = None
 
-        # maps SMF FMRIs to a list the SMF FMRIs they declare as dependencies
-        instance_deps = None
+    manifest = None
 
-        manifest = None
+    def __init__(self, action, path, pkg_vars, proto_dir):
+        """See __init__ for PublishingDependency."""
+        self.manifest = path
+        full_paths = None
+        if isinstance(path, six.string_types):
+            base_names = [os.path.basename(path)]
+            paths = [os.path.dirname(path)]
 
-        def __init__(self, action, path, pkg_vars, proto_dir):
-                """ See __init__ for PublishingDependency.
-                """
-                self.manifest = path
-                full_paths = None
-                if isinstance(path, six.string_types):
-                        base_names = [os.path.basename(path)]
-                        paths = [os.path.dirname(path)]
+        elif isinstance(path, tuple):
+            # we can depend on multiple files delivering instances
+            # of a service that was marked as a dependency.  If we
+            # do, we must specify the full paths to the manifests
+            # and not a basenames/paths pair, since SMF does not
+            # search for SMF manifests this way.
+            base_names = []
+            paths = []
+            full_paths = [p.replace(proto_dir, "").lstrip("/") for p in path]
+        else:
+            raise base.InvalidPublishingDependency(
+                "A string or " "tuple must be specified for 'path'."
+            )
 
-                elif isinstance(path, tuple):
-                        # we can depend on multiple files delivering instances
-                        # of a service that was marked as a dependency.  If we
-                        # do, we must specify the full paths to the manifests
-                        # and not a basenames/paths pair, since SMF does not
-                        # search for SMF manifests this way.
-                        base_names = []
-                        paths = []
-                        full_paths = [p.replace(proto_dir, "").lstrip("/")
-                            for p in path]
-                else:
-                        raise base.InvalidPublishingDependency("A string or "
-                            "tuple must be specified for 'path'.")
+        base.PublishingDependency.__init__(
+            self,
+            action,
+            base_names,
+            paths,
+            pkg_vars,
+            proto_dir,
+            "smf_manifest",
+            full_paths=full_paths,
+        )
 
-                base.PublishingDependency.__init__(self, action,
-                    base_names, paths, pkg_vars, proto_dir, "smf_manifest",
-                    full_paths=full_paths)
+    def __repr__(self):
+        return "SMFDep({0}, {1}, {2}, {3})".format(
+            self.action, self.base_names, self.run_paths, self.pkg_vars
+        )
 
-        def __repr__(self):
-                return "SMFDep({0}, {1}, {2}, {3})".format(self.action,
-                    self.base_names, self.run_paths, self.pkg_vars)
+    @staticmethod
+    def _clear_cache():
+        """Clear our manifest caches.  This is primarily provided for
+        test code."""
+        SMFManifestDependency.instance_mf = None
+        SMFManifestDependency.instance_deps = None
 
-        @staticmethod
-        def _clear_cache():
-                """Clear our manifest caches.  This is primarily provided for
-                test code."""
-                SMFManifestDependency.instance_mf = None
-                SMFManifestDependency.instance_deps = None
+    @staticmethod
+    def populate_cache(proto_dirs, force_update=False):
+        """Build our instance_mf and instance_deps dictionaries
+        from the known SMF manifests installed on the current system
+        and those that appear in the proto_dirs.
+        """
 
-        @staticmethod
-        def populate_cache(proto_dirs, force_update=False):
-                """Build our instance_mf and instance_deps dictionaries
-                from the known SMF manifests installed on the current system
-                and those that appear in the proto_dirs.
-                """
+        if not force_update:
+            if SMFManifestDependency.instance_mf != None:
+                return
 
-                if not force_update:
-                        if SMFManifestDependency.instance_mf != None:
-                                return
+        SMFManifestDependency.instance_mf = {}
+        SMFManifestDependency.instance_deps = {}
 
-                SMFManifestDependency.instance_mf = {}
-                SMFManifestDependency.instance_deps = {}
+        manifest_paths = []
 
-                manifest_paths = []
+        # we want our proto_dirs to be the authoritative source
+        # for SMF manifests, so scan the local system first, then
+        # iterate through the proto_dirs, starting from the
+        # oldest, overwriting with progressively newer proto_dirs
+        for location in manifest_locations:
+            manifest_paths.append(os.path.join("/", location))
+        for proto_dir in reversed(proto_dirs):
+            for location in manifest_locations:
+                manifest_paths.append(os.path.join(proto_dir, location))
 
-                # we want our proto_dirs to be the authoritative source
-                # for SMF manifests, so scan the local system first, then
-                # iterate through the proto_dirs, starting from the
-                # oldest, overwriting with progressively newer proto_dirs
-                for location in manifest_locations:
-                        manifest_paths.append(os.path.join("/", location))
-                for proto_dir in reversed(proto_dirs):
-                        for location in manifest_locations:
-                                manifest_paths.append(os.path.join(proto_dir,
-                                    location))
+        for location in manifest_paths:
+            for dirpath, dirnames, filenames in os.walk(location):
+                for f in filenames:
+                    manifest_file = os.path.join(dirpath, f)
+                    SMFManifestDependency.__populate_smf_dics(manifest_file)
 
-                for location in manifest_paths:
-                        for dirpath, dirnames, filenames in os.walk(location):
-                                for f in filenames:
-                                        manifest_file = os.path.join(
-                                            dirpath, f)
-                                        SMFManifestDependency.__populate_smf_dics(
-                                            manifest_file)
-        @staticmethod
-        def __populate_smf_dics(manifest_file):
-                """Add a information information about the SMF instances and
-                their dependencies from the given manifest_file to a global
-                set of dictionaries."""
+    @staticmethod
+    def __populate_smf_dics(manifest_file):
+        """Add a information information about the SMF instances and
+        their dependencies from the given manifest_file to a global
+        set of dictionaries."""
 
-                instance_mf, instance_deps = parse_smf_manifest(
-                    manifest_file)
+        instance_mf, instance_deps = parse_smf_manifest(manifest_file)
 
-                # more work is needed here when
-                # multiple-manifests per service is supported by
-                # SMF: we'll need to merge additional
-                # service-level dependencies into each service
-                # instance as each manifest gets added.
-                if instance_mf:
-                        SMFManifestDependency.instance_mf.update(
-                            instance_mf)
-                if instance_deps:
-                        SMFManifestDependency.instance_deps.update(
-                            instance_deps)
+        # more work is needed here when
+        # multiple-manifests per service is supported by
+        # SMF: we'll need to merge additional
+        # service-level dependencies into each service
+        # instance as each manifest gets added.
+        if instance_mf:
+            SMFManifestDependency.instance_mf.update(instance_mf)
+        if instance_deps:
+            SMFManifestDependency.instance_deps.update(instance_deps)
+
 
 def split_smf_fmri(fmri):
-        """Split an SMF FMRI into constituent parts, returning the svc protocol,
-        the service name, and the instance name, if any."""
+    """Split an SMF FMRI into constituent parts, returning the svc protocol,
+    the service name, and the instance name, if any."""
 
-        protocol = None
-        service = None
-        instance = None
+    protocol = None
+    service = None
+    instance = None
 
-        arr = fmri.split(":")
-        if len(arr) == 2 and arr[0] == "svc":
-                protocol = "svc"
-                service = arr[1]
-        elif len(arr) == 3 and arr[0] == "svc":
-                protocol = "svc"
-                service = arr[1]
-                instance = arr[2]
-        else:
-                raise ValueError(_("FMRI does not appear to be valid"))
-        return protocol, service, instance
+    arr = fmri.split(":")
+    if len(arr) == 2 and arr[0] == "svc":
+        protocol = "svc"
+        service = arr[1]
+    elif len(arr) == 3 and arr[0] == "svc":
+        protocol = "svc"
+        service = arr[1]
+        instance = arr[2]
+    else:
+        raise ValueError(_("FMRI does not appear to be valid"))
+    return protocol, service, instance
+
 
 def search_smf_dic(fmri, dictionary):
-        """Search a dictionary of SMF FMRI mappings, returning a list of
-        results. If the FMRI points to an instance, we can return quickly. If
-        the FMRI points to a service, we return all matching instances.  Note
-        if the dictionary contains service FMRIs, those won't appear in the
-        results - we only ever return instances."""
+    """Search a dictionary of SMF FMRI mappings, returning a list of
+    results. If the FMRI points to an instance, we can return quickly. If
+    the FMRI points to a service, we return all matching instances.  Note
+    if the dictionary contains service FMRIs, those won't appear in the
+    results - we only ever return instances."""
 
-        protocol, service, instance = split_smf_fmri(fmri)
-        results = []
-        if instance is not None:
-                if fmri in dictionary:
-                        results.append(dictionary[fmri])
-        else:
-                # return all matching instances of this service
-                for item in dictionary:
-                        if item.startswith(protocol + ":" + service + ":"):
-                                results.append(dictionary[item])
-        return results
+    protocol, service, instance = split_smf_fmri(fmri)
+    results = []
+    if instance is not None:
+        if fmri in dictionary:
+            results.append(dictionary[fmri])
+    else:
+        # return all matching instances of this service
+        for item in dictionary:
+            if item.startswith(protocol + ":" + service + ":"):
+                results.append(dictionary[item])
+    return results
+
 
 def get_smf_dependencies(fmri, instance_deps):
-        """Given an instance FMRI, determine the FMRIs it depends on.  If we
-        match more than one fmri, we raise an exception. """
+    """Given an instance FMRI, determine the FMRIs it depends on.  If we
+    match more than one fmri, we raise an exception."""
 
-        results = search_smf_dic(fmri, instance_deps)
-        if len(results) == 1:
-                return results[0]
-        elif len(results) > 1:
-                # this can only happen if we've been asked to resolve a
-                # service-level FMRI, not a fully qualified instance FMRI
-                raise ValueError(
-                    _("more than one set of dependencies found: {0}").format(
-                    results))
+    results = search_smf_dic(fmri, instance_deps)
+    if len(results) == 1:
+        return results[0]
+    elif len(results) > 1:
+        # this can only happen if we've been asked to resolve a
+        # service-level FMRI, not a fully qualified instance FMRI
+        raise ValueError(
+            _("more than one set of dependencies found: {0}").format(results)
+        )
 
-        results = search_smf_dic(fmri, SMFManifestDependency.instance_deps)
-        if len(results) == 1:
-                return results[0]
-        elif len(results) > 1:
-                raise ValueError(
-                    _("more than one set of dependencies found: {0}").format(
-                    results))
+    results = search_smf_dic(fmri, SMFManifestDependency.instance_deps)
+    if len(results) == 1:
+        return results[0]
+    elif len(results) > 1:
+        raise ValueError(
+            _("more than one set of dependencies found: {0}").format(results)
+        )
 
-        return []
+    return []
+
 
 def resolve_smf_dependency(fmri, instance_mf):
-        """Given an SMF FMRI that satisfies a given SMF dependency, determine
-        which file(s) deliver that dependency using both the provided
-        instance_mf dictionary and the global SmfManifestDependency dictionary.
-        If multiple files match, we have a problem."""
+    """Given an SMF FMRI that satisfies a given SMF dependency, determine
+    which file(s) deliver that dependency using both the provided
+    instance_mf dictionary and the global SmfManifestDependency dictionary.
+    If multiple files match, we have a problem."""
 
-        manifests = set()
+    manifests = set()
 
-        manifests.update(search_smf_dic(fmri, instance_mf))
+    manifests.update(search_smf_dic(fmri, instance_mf))
 
-        manifests.update(search_smf_dic(
-            fmri, SMFManifestDependency.instance_mf))
+    manifests.update(search_smf_dic(fmri, SMFManifestDependency.instance_mf))
 
-        if len(manifests) == 0:
-                # we can't satisfy the dependency at all
-                raise ValueError(_("cannot resolve FMRI to a delivered file"))
+    if len(manifests) == 0:
+        # we can't satisfy the dependency at all
+        raise ValueError(_("cannot resolve FMRI to a delivered file"))
 
-        return list(manifests)
+    return list(manifests)
+
 
 def process_smf_manifest_deps(action, pkg_vars, **kwargs):
-        """Given an action and a place to find the file it references, if the
-        file is an SMF manifest, we return a list of SmfManifestDependencies
-        pointing to the SMF manifests in the proto area that would satisfy each
-        dependency, a list of errors, and a dictionary containing the SMF FMRIs
-        that were contained in the SMF manifest that this action delivers.
+    """Given an action and a place to find the file it references, if the
+    file is an SMF manifest, we return a list of SmfManifestDependencies
+    pointing to the SMF manifests in the proto area that would satisfy each
+    dependency, a list of errors, and a dictionary containing the SMF FMRIs
+    that were contained in the SMF manifest that this action delivers.
 
-        Note that while we resolve SMF dependencies from SMF FMRIs to the files
-        that deliver them, we don't attempt to further resolve those files to
-        pkg(7) packages at this point.
-        That stage is done using the normal "pkgdepend resolve" mechanism."""
+    Note that while we resolve SMF dependencies from SMF FMRIs to the files
+    that deliver them, we don't attempt to further resolve those files to
+    pkg(7) packages at this point.
+    That stage is done using the normal "pkgdepend resolve" mechanism."""
 
-        if action.name != "file":
-                return [], \
-                    [ _("{0} actions cannot deliver SMF manifests").format(
-                    action.name)], {}
+    if action.name != "file":
+        return (
+            [],
+            [_("{0} actions cannot deliver SMF manifests").format(action.name)],
+            {},
+        )
 
-        # we don't report an error here, as SMF manifest files may be delivered
-        # to a location specifically not intended to be imported to the SMF
-        # repository.
-        if not has_smf_manifest_dir(action.attrs["path"]):
-                return [], [], {}
+    # we don't report an error here, as SMF manifest files may be delivered
+    # to a location specifically not intended to be imported to the SMF
+    # repository.
+    if not has_smf_manifest_dir(action.attrs["path"]):
+        return [], [], {}
 
-        proto_file = action.attrs[PD_LOCAL_PATH]
-        SMFManifestDependency.populate_cache(action.attrs[PD_PROTO_DIR_LIST])
+    proto_file = action.attrs[PD_LOCAL_PATH]
+    SMFManifestDependency.populate_cache(action.attrs[PD_PROTO_DIR_LIST])
 
-        deps = []
-        elist = []
-        dep_manifests = set()
+    deps = []
+    elist = []
+    dep_manifests = set()
 
-        instance_mf, instance_deps = parse_smf_manifest(proto_file)
-        if instance_mf is None:
-                return [], [ _("Unable to parse SMF manifest {0}").format(
-                    proto_file)], {}
+    instance_mf, instance_deps = parse_smf_manifest(proto_file)
+    if instance_mf is None:
+        return (
+            [],
+            [_("Unable to parse SMF manifest {0}").format(proto_file)],
+            {},
+        )
 
-        for fmri in instance_mf:
-                try:
-                        protocol, service, instance = split_smf_fmri(fmri)
-                        # we're only interested in trying to resolve
-                        # dependencies that instances have declared
-                        if instance is None:
-                                continue
+    for fmri in instance_mf:
+        try:
+            protocol, service, instance = split_smf_fmri(fmri)
+            # we're only interested in trying to resolve
+            # dependencies that instances have declared
+            if instance is None:
+                continue
 
-                except ValueError as err:
-                        elist.append(_("Problem resolving {fmri}: {err}").format(
-                            **locals()))
-                        continue
+        except ValueError as err:
+            elist.append(
+                _("Problem resolving {fmri}: {err}").format(**locals())
+            )
+            continue
 
-                # determine the set of SMF FMRIs we depend on
-                dep_fmris = set()
-                try:
-                        dep_fmris = set(
-                            get_smf_dependencies(fmri, instance_deps))
-                except ValueError as err:
-                        elist.append(
-                            _("Problem determining dependencies for {fmri}:"
-                            "{err}").format(**locals()))
+        # determine the set of SMF FMRIs we depend on
+        dep_fmris = set()
+        try:
+            dep_fmris = set(get_smf_dependencies(fmri, instance_deps))
+        except ValueError as err:
+            elist.append(
+                _(
+                    "Problem determining dependencies for {fmri}:" "{err}"
+                ).format(**locals())
+            )
 
-                # determine the file paths that deliver those dependencies
-                for dep_fmri in dep_fmris:
-                        try:
-                                manifests = resolve_smf_dependency(dep_fmri,
-                                    instance_mf)
-                        except ValueError as err:
-                                # we've declared an SMF dependency, but can't
-                                # determine what file delivers it from the known
-                                # SMF manifests in either the proto area or the
-                                # local machine.
-                                manifests = []
-                                elist.append(
-                                    _("Unable to generate SMF dependency on "
-                                    "{dep_fmri} declared in {proto_file} by "
-                                    "{fmri}: {err}").format(**locals()))
+        # determine the file paths that deliver those dependencies
+        for dep_fmri in dep_fmris:
+            try:
+                manifests = resolve_smf_dependency(dep_fmri, instance_mf)
+            except ValueError as err:
+                # we've declared an SMF dependency, but can't
+                # determine what file delivers it from the known
+                # SMF manifests in either the proto area or the
+                # local machine.
+                manifests = []
+                elist.append(
+                    _(
+                        "Unable to generate SMF dependency on "
+                        "{dep_fmri} declared in {proto_file} by "
+                        "{fmri}: {err}"
+                    ).format(**locals())
+                )
 
-                        if len(manifests) == 1:
-                                dep_manifests.add(manifests[0])
+            if len(manifests) == 1:
+                dep_manifests.add(manifests[0])
 
-                        elif len(manifests) > 1:
-                                protocol, service, instance = \
-                                    split_smf_fmri(dep_fmri)
+            elif len(manifests) > 1:
+                protocol, service, instance = split_smf_fmri(dep_fmri)
 
-                                # This should never happen, as it implies a
-                                # service FMRI, not an instance FMRI has been
-                                # returned from search_smf_dic via
-                                # resolve_smf_dependency.
-                                if instance is not None:
-                                        elist.append(
-                                            _("Unable to generate SMF "
-                                            "dependency on the service FMRI "
-                                            "{dep_fmri} declared in "
-                                            "{proto_file} by {fmri}. "
-                                            "SMF dependencies should always "
-                                            "resolve to SMF instances rather "
-                                            "than SMF services and multiple "
-                                            "files deliver instances of this "
-                                            "service: {manifests}").format(
-                                            dep_fmri=dep_fmri,
-                                            proto_file=proto_file,
-                                            fmri=fmri,
-                                            manifests=", ".join(manifests)))
+                # This should never happen, as it implies a
+                # service FMRI, not an instance FMRI has been
+                # returned from search_smf_dic via
+                # resolve_smf_dependency.
+                if instance is not None:
+                    elist.append(
+                        _(
+                            "Unable to generate SMF "
+                            "dependency on the service FMRI "
+                            "{dep_fmri} declared in "
+                            "{proto_file} by {fmri}. "
+                            "SMF dependencies should always "
+                            "resolve to SMF instances rather "
+                            "than SMF services and multiple "
+                            "files deliver instances of this "
+                            "service: {manifests}"
+                        ).format(
+                            dep_fmri=dep_fmri,
+                            proto_file=proto_file,
+                            fmri=fmri,
+                            manifests=", ".join(manifests),
+                        )
+                    )
 
-                                dep_manifests.add(tuple(manifests))
+                dep_manifests.add(tuple(manifests))
 
-        for manifest in dep_manifests:
-                deps.append(SMFManifestDependency(action, manifest, pkg_vars,
-                    action.attrs[PD_PROTO_DIR]))
-        pkg_attrs = {
-            "org.opensolaris.smf.fmri": list(instance_mf.keys())
-        }
-        return deps, elist, pkg_attrs
+    for manifest in dep_manifests:
+        deps.append(
+            SMFManifestDependency(
+                action, manifest, pkg_vars, action.attrs[PD_PROTO_DIR]
+            )
+        )
+    pkg_attrs = {"org.opensolaris.smf.fmri": list(instance_mf.keys())}
+    return deps, elist, pkg_attrs
+
 
 def __get_smf_dependencies(deps):
-        """Given a minidom Element deps, search for the <service_fmri> elements
-        inside it, and return the values as a list of strings."""
+    """Given a minidom Element deps, search for the <service_fmri> elements
+    inside it, and return the values as a list of strings."""
 
-        dependencies = []
-        for dependency in deps:
-                fmris = dependency.getElementsByTagName("service_fmri")
-                dep_type = dependency.getAttribute("type")
-                grouping = dependency.getAttribute("grouping")
-                delete = dependency.getAttribute("delete")
+    dependencies = []
+    for dependency in deps:
+        fmris = dependency.getElementsByTagName("service_fmri")
+        dep_type = dependency.getAttribute("type")
+        grouping = dependency.getAttribute("grouping")
+        delete = dependency.getAttribute("delete")
 
-                # we don't include SMF path dependencies as these are often
-                # not packaged files.
-                if fmris and dep_type == "service" and \
-                    grouping == "require_all" and \
-                    delete != "true":
-                        for service_fmri in fmris:
-                                dependency = service_fmri.getAttribute("value")
-                                if dependency:
-                                        dependencies.append(dependency)
-        return dependencies
+        # we don't include SMF path dependencies as these are often
+        # not packaged files.
+        if (
+            fmris
+            and dep_type == "service"
+            and grouping == "require_all"
+            and delete != "true"
+        ):
+            for service_fmri in fmris:
+                dependency = service_fmri.getAttribute("value")
+                if dependency:
+                    dependencies.append(dependency)
+    return dependencies
+
 
 def is_smf_manifest(smf_file):
-        """Quickly determine if smf_file is a valid SMF manifest."""
-        try:
-                smf_doc = minidom.parse(smf_file)
-        # catching ValueError, as minidom has been seen to raise this on some
-        # invalid XML files.
-        except (xml.parsers.expat.ExpatError, ValueError):
-                return False
-
-        if not smf_doc.doctype:
-                return False
-
-        if smf_doc.doctype.systemId != \
-            "/usr/share/lib/xml/dtd/service_bundle.dtd.1":
-                return False
-        return True
-
-def parse_smf_manifest(smf_file):
-        """Returns a tuple of two dictionaries. The first maps the SMF FMRIs
-        found in that manifest to the path of the manifest file. The second maps
-        each SMF FMRI found in the file to the list of FMRIs that are declared
-        as dependencies.
-
-        Note this method makes no distinction between service FMRIs and instance
-        FMRIs; both get added to the dictionaries, but only the instance FMRIs
-        should be used to determine dependencies.
-
-        Calling this with a path to the file, we include manifest_paths in the
-        first dictionary, otherwise with raw file data, we don't.
-
-        If we weren't handed an SMF XML file, or have trouble parsing it, we
-        return a tuple of None, None.
-        """
-
-        instance_mf = {}
-        instance_deps = {}
-
-        try:
-                smf_doc = minidom.parse(smf_file)
-        # catching ValueError, as minidom has been seen to raise this on some
-        # invalid XML files.
-        # catching IOError to ensure we don't fail for files not accessible
-        # by the current user.
-        except (xml.parsers.expat.ExpatError, ValueError, IOError):
-                return None, None
-
-        if not smf_doc.doctype:
-                return None, None
-
-        if smf_doc.doctype.systemId != \
-            "/usr/share/lib/xml/dtd/service_bundle.dtd.1":
-                return None, None
-
-        manifest_path = None
-
-        if isinstance(smf_file, str):
-                manifest_path = smf_file
-
-        svcs = smf_doc.getElementsByTagName("service")
-        for service in svcs:
-
-                fmris = []
-                svc_dependencies = []
-                create_default = False
-                duplicate_default = False
-
-                # get the service name
-                svc_name = service.getAttribute("name")
-                if svc_name and not svc_name.startswith("/"):
-                        svc_name = "/" + svc_name
-                        fmris.append("svc:{0}".format(svc_name))
-                else:
-                        # no defined service name, so no dependencies here
-                        continue
-
-                # Get the FMRIs we declare dependencies on. When splitting SMF
-                # services across multiple manifests is supported, more work
-                # will be needed here.
-                svc_deps = []
-                for child in service.childNodes:
-                        if isinstance(child, minidom.Element) and \
-                            child.tagName == "dependency":
-                                svc_deps.append(child)
-
-                svc_dependencies.extend(__get_smf_dependencies(svc_deps))
-
-                # determine our instances
-                if service.getElementsByTagName("create_default_instance"):
-                        create_default = True
-
-                insts = service.getElementsByTagName("instance")
-                for instance in insts:
-                        inst_dependencies = []
-                        inst_name = instance.getAttribute("name")
-                        fmri = None
-                        if inst_name:
-                                if inst_name == "default" and create_default:
-                                        # we've declared a
-                                        # create_default_instance tag but we've
-                                        # also explicitly created an instance
-                                        # called "default"
-                                        duplicate_default = True
-
-                                fmri = "svc:{0}:{1}".format(svc_name, inst_name)
-
-                                # we can use getElementsByTagName here, since
-                                # there are no nested <dependency> tags that
-                                # won't apply, unlike for <service> above, when
-                                # we needed to look strictly at immediate
-                                # children.
-                                inst_deps = instance.getElementsByTagName(
-                                    "dependency")
-                                inst_dependencies.extend(
-                                    __get_smf_dependencies(inst_deps))
-
-                        if fmri is not None:
-                                instance_deps[fmri] = svc_dependencies + \
-                                    inst_dependencies
-                                fmris.append(fmri)
-
-                if create_default and not duplicate_default:
-                        fmri = "svc:{0}:default".format(svc_name)
-                        fmris.append(fmri)
-                        instance_deps[fmri] = svc_dependencies
-
-                # add the service FMRI
-                instance_deps["svc:{0}".format(svc_name)] = svc_dependencies
-                for fmri in fmris:
-                        instance_mf[fmri] = manifest_path
-
-        return instance_mf, instance_deps
-
-def has_smf_manifest_dir(path, prefix=None):
-        """Determine if the given path string contains any of the directories
-        where SMF manifests are usually delivered.  An optional named parameter
-        prefix gets stripped from the path before checking.
-        """
-        global manifest_locations
-        check_path = path
-        if prefix:
-                check_path = path.replace(prefix, "", 1)
-        for location in manifest_locations:
-                if check_path and check_path.startswith(location):
-                        return True
+    """Quickly determine if smf_file is a valid SMF manifest."""
+    try:
+        smf_doc = minidom.parse(smf_file)
+    # catching ValueError, as minidom has been seen to raise this on some
+    # invalid XML files.
+    except (xml.parsers.expat.ExpatError, ValueError):
         return False
 
+    if not smf_doc.doctype:
+        return False
+
+    if (
+        smf_doc.doctype.systemId
+        != "/usr/share/lib/xml/dtd/service_bundle.dtd.1"
+    ):
+        return False
+    return True
+
+
+def parse_smf_manifest(smf_file):
+    """Returns a tuple of two dictionaries. The first maps the SMF FMRIs
+    found in that manifest to the path of the manifest file. The second maps
+    each SMF FMRI found in the file to the list of FMRIs that are declared
+    as dependencies.
+
+    Note this method makes no distinction between service FMRIs and instance
+    FMRIs; both get added to the dictionaries, but only the instance FMRIs
+    should be used to determine dependencies.
+
+    Calling this with a path to the file, we include manifest_paths in the
+    first dictionary, otherwise with raw file data, we don't.
+
+    If we weren't handed an SMF XML file, or have trouble parsing it, we
+    return a tuple of None, None.
+    """
+
+    instance_mf = {}
+    instance_deps = {}
+
+    try:
+        smf_doc = minidom.parse(smf_file)
+    # catching ValueError, as minidom has been seen to raise this on some
+    # invalid XML files.
+    # catching IOError to ensure we don't fail for files not accessible
+    # by the current user.
+    except (xml.parsers.expat.ExpatError, ValueError, IOError):
+        return None, None
+
+    if not smf_doc.doctype:
+        return None, None
+
+    if (
+        smf_doc.doctype.systemId
+        != "/usr/share/lib/xml/dtd/service_bundle.dtd.1"
+    ):
+        return None, None
+
+    manifest_path = None
+
+    if isinstance(smf_file, str):
+        manifest_path = smf_file
+
+    svcs = smf_doc.getElementsByTagName("service")
+    for service in svcs:
+        fmris = []
+        svc_dependencies = []
+        create_default = False
+        duplicate_default = False
+
+        # get the service name
+        svc_name = service.getAttribute("name")
+        if svc_name and not svc_name.startswith("/"):
+            svc_name = "/" + svc_name
+            fmris.append("svc:{0}".format(svc_name))
+        else:
+            # no defined service name, so no dependencies here
+            continue
+
+        # Get the FMRIs we declare dependencies on. When splitting SMF
+        # services across multiple manifests is supported, more work
+        # will be needed here.
+        svc_deps = []
+        for child in service.childNodes:
+            if (
+                isinstance(child, minidom.Element)
+                and child.tagName == "dependency"
+            ):
+                svc_deps.append(child)
+
+        svc_dependencies.extend(__get_smf_dependencies(svc_deps))
+
+        # determine our instances
+        if service.getElementsByTagName("create_default_instance"):
+            create_default = True
+
+        insts = service.getElementsByTagName("instance")
+        for instance in insts:
+            inst_dependencies = []
+            inst_name = instance.getAttribute("name")
+            fmri = None
+            if inst_name:
+                if inst_name == "default" and create_default:
+                    # we've declared a
+                    # create_default_instance tag but we've
+                    # also explicitly created an instance
+                    # called "default"
+                    duplicate_default = True
+
+                fmri = "svc:{0}:{1}".format(svc_name, inst_name)
+
+                # we can use getElementsByTagName here, since
+                # there are no nested <dependency> tags that
+                # won't apply, unlike for <service> above, when
+                # we needed to look strictly at immediate
+                # children.
+                inst_deps = instance.getElementsByTagName("dependency")
+                inst_dependencies.extend(__get_smf_dependencies(inst_deps))
+
+            if fmri is not None:
+                instance_deps[fmri] = svc_dependencies + inst_dependencies
+                fmris.append(fmri)
+
+        if create_default and not duplicate_default:
+            fmri = "svc:{0}:default".format(svc_name)
+            fmris.append(fmri)
+            instance_deps[fmri] = svc_dependencies
+
+        # add the service FMRI
+        instance_deps["svc:{0}".format(svc_name)] = svc_dependencies
+        for fmri in fmris:
+            instance_mf[fmri] = manifest_path
+
+    return instance_mf, instance_deps
+
+
+def has_smf_manifest_dir(path, prefix=None):
+    """Determine if the given path string contains any of the directories
+    where SMF manifests are usually delivered.  An optional named parameter
+    prefix gets stripped from the path before checking.
+    """
+    global manifest_locations
+    check_path = path
+    if prefix:
+        check_path = path.replace(prefix, "", 1)
+    for location in manifest_locations:
+        if check_path and check_path.startswith(location):
+            return True
+    return False
+
+
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/fmri.py
+++ b/src/modules/fmri.py
@@ -43,599 +43,624 @@ PREF_PUB_PFX = "_PRE"
 #
 PREF_PUB_PFX_ = PREF_PUB_PFX + "_"
 
-g_valid_pkg_name = \
-    re.compile(r"^[A-Za-z0-9][A-Za-z0-9_\-\.\+]*(/[A-Za-z0-9][A-Za-z0-9_\-\.\+]*)*$")
+g_valid_pkg_name = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_\-\.\+]*(/[A-Za-z0-9][A-Za-z0-9_\-\.\+]*)*$"
+)
+
 
 class FmriError(Exception):
-        """Base exception class for FMRI errors."""
+    """Base exception class for FMRI errors."""
 
-        def __init__(self, fmri):
-                Exception.__init__(self)
-                self.fmri = fmri
+    def __init__(self, fmri):
+        Exception.__init__(self)
+        self.fmri = fmri
 
 
 class IllegalFmri(FmriError):
+    BAD_VERSION = 1
+    BAD_PACKAGENAME = 2
+    SYNTAX_ERROR = 3
 
-        BAD_VERSION = 1
-        BAD_PACKAGENAME = 2
-        SYNTAX_ERROR = 3
+    msg_prefix = "Illegal FMRI"
 
-        msg_prefix = "Illegal FMRI"
+    def __init__(self, fmri, reason, detail=None, nested_exc=None):
+        FmriError.__init__(self, fmri)
+        self.reason = reason
+        self.detail = detail
+        self.nested_exc = nested_exc
 
-        def __init__(self, fmri, reason, detail=None, nested_exc=None):
-                FmriError.__init__(self, fmri)
-                self.reason = reason
-                self.detail = detail
-                self.nested_exc = nested_exc
-
-        def __str__(self):
-                outstr = "{0} '{1}': ".format(self.msg_prefix, self.fmri)
-                if self.reason == IllegalFmri.BAD_VERSION:
-                        return outstr + str(self.nested_exc)
-                if self.reason == IllegalFmri.BAD_PACKAGENAME:
-                        return outstr + "Invalid Package Name: " + self.detail
-                if self.reason == IllegalFmri.SYNTAX_ERROR:
-                        return outstr + self.detail
+    def __str__(self):
+        outstr = "{0} '{1}': ".format(self.msg_prefix, self.fmri)
+        if self.reason == IllegalFmri.BAD_VERSION:
+            return outstr + str(self.nested_exc)
+        if self.reason == IllegalFmri.BAD_PACKAGENAME:
+            return outstr + "Invalid Package Name: " + self.detail
+        if self.reason == IllegalFmri.SYNTAX_ERROR:
+            return outstr + self.detail
 
 
 class IllegalMatchingFmri(IllegalFmri):
-        msg_prefix = "Illegal matching pattern"
+    msg_prefix = "Illegal matching pattern"
 
 
 class MissingVersionError(FmriError):
-        """Used to indicate that the requested operation is not supported for
-        the fmri since version information is missing."""
+    """Used to indicate that the requested operation is not supported for
+    the fmri since version information is missing."""
 
-        def __str__(self):
-                return _("FMRI '{0}' is missing version information.").format(
-                    self.fmri)
+    def __str__(self):
+        return _("FMRI '{0}' is missing version information.").format(self.fmri)
 
 
 class PkgFmri(object):
-        """The publisher is the anchor of a package namespace.  Clients can
-        choose to take packages from multiple publishers, and specify a default
-        search path.  In general, package names may also be prefixed by a domain
-        name, reverse domain name, or a stock symbol to avoid conflict.  The
-        unprefixed namespace is expected to be managed by architectural review.
-
-        The primary equivalence relationship assumes that packages of the same
-        package name are forwards compatible across all versions of that
-        package, and that higher build release versions are superior
-        publications than lower build release versions."""
-
-        # Stored in a class variable so that subclasses can override
-        valid_pkg_name = g_valid_pkg_name
-
-        __slots__ = ["version", "publisher", "pkg_name", "_hash", "__weakref__"]
-
-        def __init__(self, fmri=None, build_release=None, publisher=None,
-            name=None, version=None):
-                if fmri is not None:
-                        fmri = fmri.rstrip()
-
-                        veridx, nameidx, pubidx = \
-                            PkgFmri._gen_fmri_indexes(fmri)
-
-                        if pubidx != None:
-                                # Always use publisher information provided in
-                                # FMRI string.  (It could be ""; pkg:///name is
-                                # valid.)
-                                publisher = fmri[pubidx:nameidx - 1]
-
-                        if veridx != None:
-                                self.pkg_name = fmri[nameidx:veridx]
-                                try:
-                                        self.version = Version(
-                                            fmri[veridx + 1:], build_release)
-                                except VersionError as iv:
-                                        raise IllegalFmri(fmri,
-                                            IllegalFmri.BAD_VERSION,
-                                            nested_exc=iv)
-                        else:
-                                self.pkg_name = fmri[nameidx:]
-                                self.version = None
-                else:
-                        # pkg_name and version must be explicitly set.
-                        self.pkg_name = name
-                        if version:
-                                self.version = Version(version, build_release)
-                        else:
-                                self.version = None
-
-                # Ensure publisher is always None if one was not specified.
-                if publisher:
-                        self.publisher = publisher
-                else:
-                        self.publisher = None
-
-                if not self.pkg_name:
-                        raise IllegalFmri(fmri, IllegalFmri.SYNTAX_ERROR,
-                            detail="Missing package name")
-
-                if not self.valid_pkg_name.match(self.pkg_name):
-                        raise IllegalFmri(fmri, IllegalFmri.BAD_PACKAGENAME,
-                            detail=self.pkg_name)
-
-                self._hash = None
-
-        @staticmethod
-        def getstate(obj, je_state=None):
-                """Returns the serialized state of this object in a format
-                that that can be easily stored using JSON, pickle, etc."""
-                return str(obj)
-
-        @staticmethod
-        def fromstate(state, jd_state=None):
-                """Allocate a new object using previously serialized state
-                obtained via getstate()."""
-                return PkgFmri(state)
-
-        def copy(self):
-                return PkgFmri(str(self))
-
-        @staticmethod
-        def _gen_fmri_indexes(fmri):
-                """Return a tuple of offsets, used to extract different
-                components of the FMRI."""
-
-                veridx = fmri.rfind("@")
-                if veridx == -1:
-                        veridx = None
-
-                pubidx = None
-                if fmri.startswith("pkg://"):
-                        nameidx = fmri.find("/", 6, veridx)
-                        if nameidx == -1:
-                                raise IllegalFmri(fmri,
-                                    IllegalFmri.SYNTAX_ERROR,
-                                    detail=_("Missing '/' after "
-                                        "publisher name"))
-
-                        # Publisher starts after //.
-                        pubidx = 6
-
-                        # Name starts after / which terminates publisher
-                        nameidx += 1
-
-                elif fmri.startswith("pkg:/"):
-                        # Name starts after / which terminates scheme
-                        nameidx = 5
-                elif fmri.startswith("//"):
-                        nameidx = fmri.find("/", 2, veridx)
-                        if nameidx == -1:
-                                raise IllegalFmri(fmri,
-                                    IllegalFmri.SYNTAX_ERROR,
-                                    detail=_("Missing '/' after "
-                                        "publisher name"))
-
-                        # Publisher starts after //.
-                        pubidx = 2
-
-                        # Name starts after / which terminates publisher
-                        nameidx += 1
-                elif fmri.startswith("/"):
-                        # Name starts after / which terminates scheme
-                        nameidx = 1
-                else:
-                        nameidx = 0
-
-                return (veridx, nameidx, pubidx)
-
-        def get_publisher(self):
-                """Return the name of the publisher that is contained
-                within this FMRI.  This strips off extraneous data
-                that may be attached to the publisher.  The output
-                is suitable as a key into the publisher["prefix"] table."""
-
-                # Strip off preferred publisher prefix, if it exists.
-                if self.publisher and self.publisher.startswith(PREF_PUB_PFX):
-                        r = self.publisher.rsplit('_', 1)
-                        a = r[len(r) - 1]
-                        return a
-
-                # Otherwise just return the publisher
-                return self.publisher
-
-        def set_publisher(self, publisher, preferred = False):
-                """Set the FMRI's publisher.  If this is a preferred
-                publisher, set preferred to True."""
-
-                if preferred and not publisher.startswith(PREF_PUB_PFX):
-                        self.publisher = "{0}_{1}".format(PREF_PUB_PFX,
-                            publisher)
-                else:
-                        self.publisher = publisher
-
-        def remove_publisher(self):
-                self.publisher = None
-                return self
-
-        def has_publisher(self):
-                """Returns true if the FMRI has a publisher."""
-
-                if self.publisher:
-                        return True
-
-                return False
-
-        def has_version(self):
-                """Returns True if the FMRI has a version"""
-                if self.version:
-                        return True
-                return False
-
-        def preferred_publisher(self):
-                """Returns true if this FMRI's publisher is the preferred
-                publisher."""
-
-                if not self.publisher or \
-                    self.publisher.startswith(PREF_PUB_PFX):
-                        return True
-
-                return False
-
-        def get_publisher_str(self):
-                """Return the bare string that specifies everything about
-                the publisher.  This should only be used by code that
-                must write out (or restore) the complete publisher
-                information to disk."""
-
-                return self.publisher
-
-        def get_name(self):
-                return self.pkg_name
-
-        def set_name(self, name):
-                self.pkg_name = name
-                self._hash = None
-
-        def set_timestamp(self, new_ts):
-                self.version.set_timestamp(new_ts)
-                self._hash = None
-
-        def get_timestamp(self):
-                return self.version.get_timestamp()
-
-        def get_version(self):
-                return self.version.get_short_version()
-
-        def get_pkg_stem(self, anarchy=False, include_scheme=True):
-                """Return a string representation of the FMRI without a specific
-                version.  Anarchy returns a stem without any publisher."""
-                pkg_str = ""
-                if not self.publisher or \
-                    self.publisher.startswith(PREF_PUB_PFX) or anarchy:
-                        if include_scheme:
-                                pkg_str = "pkg:/"
-                        return "{0}{1}".format(pkg_str, self.pkg_name)
-                if include_scheme:
-                        pkg_str = "pkg://"
-                return "{0}{1}/{2}".format(pkg_str, self.publisher,
-                    self.pkg_name)
-
-        def get_short_fmri(self, default_publisher=None, anarchy=False,
-            include_scheme=True):
-                """Return a string representation of the FMRI without a specific
-                version."""
-                pkg_str = ""
-                publisher = self.publisher
-                if not publisher:
-                        publisher = default_publisher
-
-                if self.version == None:
-                        version = ""
-                else:
-                        version = "@" + self.version.get_short_version()
-
-                if (not publisher or publisher.startswith(PREF_PUB_PFX) or
-                    anarchy):
-                        if include_scheme:
-                                pkg_str = "pkg:/"
-                        return "{0}{1}{2}".format(pkg_str, self.pkg_name,
-                            version)
-
-                if include_scheme:
-                        pkg_str = "pkg://"
-                return "{0}{1}/{2}{3}".format(pkg_str, publisher, self.pkg_name,
-                    version)
-
-        def get_fmri(self, default_publisher=None, anarchy=False,
-            include_scheme=True, include_build=True):
-                """Return a string representation of the FMRI.
-                Anarchy returns a string without any publisher."""
-                pkg_str = ""
-                publisher = self.publisher
-                if publisher == None:
-                        publisher = default_publisher
-
-                if not publisher or publisher.startswith(PREF_PUB_PFX) \
-                    or anarchy:
-                        if include_scheme:
-                                pkg_str = "pkg:/"
-                        if self.version == None:
-                                return "{0}{1}".format(pkg_str, self.pkg_name)
-
-                        return "{0}{1}@{2}".format(pkg_str, self.pkg_name,
-                            self.version.get_version(
-                                include_build=include_build))
-
-                if include_scheme:
-                        pkg_str = "pkg://"
-                if self.version == None:
-                        return "{0}{1}/{2}".format(pkg_str, publisher,
-                            self.pkg_name)
-
-                return "{0}{1}/{2}@{3}".format(pkg_str, publisher,
-                    self.pkg_name,
-                    self.version.get_version(include_build=include_build))
-
-        def hierarchical_names(self):
-                """Generate the different hierarchical names that could be used
-                to reference this fmri."""
-
-                names = self.pkg_name.split("/")
-                res = names[-1:]
-                for n in reversed(names[:-1]):
-                        res.append("{0}/{1}".format(n, res[-1]))
-                return res
-
-        def __str__(self):
-                """Return as specific an FMRI representation as possible."""
-                return self.get_fmri()
-
-        def __repr__(self):
-                """Return as specific an FMRI representation as possible."""
-                if not self.publisher:
-                        if not self.version:
-                                fmristr = "pkg:/{0}".format(self.pkg_name)
-                        else:
-                                fmristr = "pkg:/{0}@{1}".format(self.pkg_name,
-                                    self.version)
-                elif not self.version:
-                        fmristr = "pkg://{0}/{1}".format(self.publisher,
-                            self.pkg_name)
-                else:
-                        fmristr = "pkg://{0}/{1}@{2}".format(self.publisher,
-                            self.pkg_name, self.version)
-
-                return "<pkg.fmri.PkgFmri '{0}' at {1:#x}".format(fmristr,
-                    id(self))
-
-        def __hash__(self):
-                #
-                # __hash__ need not generate a unique hash value for all
-                # possible objects-- it must simply guarantee that two
-                # items which are equal (i.e. a = b) always hash to
-                # the same value.
-                #
-                h = self._hash
-                if h is None:
-                        h = self._hash = hash(self.version) + hash(self.pkg_name)
-                return h
-
-        def __eq__(self, other):
-                if not other:
-                        return False
-
-                if not isinstance(other, PkgFmri):
-                        return False
-
-                if self.publisher == other.publisher and \
-                    self.pkg_name == other.pkg_name and \
-                    self.version == other.version:
-                        return True
-                return False
-
-        def __ne__(self, other):
-                return not self == other
-
-        def __lt__(self, other):
-                if not other:
-                        return False
-
-                if not isinstance(other, PkgFmri):
-                        return True
-
-                if self.publisher != other.publisher:
-                        if self.publisher is None and other.publisher:
-                                return True
-                        if self.publisher and other.publisher is None:
-                                return False
-                        if self.publisher < other.publisher:
-                                return True
-                        return False
-
-                if self.pkg_name < other.pkg_name:
-                        return True
-                if self.pkg_name != other.pkg_name:
-                        return False
-
-                if self.version is None and other.version is None:
-                        return False
-                return self.version < other.version
-
-        def __gt__(self, other):
-                if not other:
-                        return True
-
-                if not isinstance(other, PkgFmri):
-                        return False
-
-                if self.publisher != other.publisher:
-                        if self.publisher and other.publisher is None:
-                                return True
-                        if self.publisher is None and other.publisher:
-                                return False
-                        if self.publisher > other.publisher:
-                                return True
-                        return False
-
-                if self.pkg_name > other.pkg_name:
-                        return True
-                if self.pkg_name != other.pkg_name:
-                        return False
-
-                if self.version is None and other.version is None:
-                        return False
-                return self.version > other.version
-
-        def __ge__(self, other):
-                return not self < other
-
-        def __le__(self, other):
-                return not self > other
-
-        def get_link_path(self, stemonly = False):
-                """Return the escaped link (or file) path fragment for this
-                FMRI."""
-
-                if stemonly:
-                        return "{0}".format(quote(self.pkg_name, ""))
-
-                if self.version is None:
-                        raise MissingVersionError(self)
-
-                return "{0}@{1}".format(quote(self.pkg_name, ""),
-                    quote(str(self.version), ""))
-
-        def get_dir_path(self, stemonly = False):
-                """Return the escaped directory path fragment for this FMRI."""
-
-                if stemonly:
-                        return "{0}".format(quote(self.pkg_name, ""))
-
-                if self.version is None:
-                        raise MissingVersionError(self)
-
-                return "{0}/{1}".format(quote(self.pkg_name, ""),
-                    quote(self.version.__str__(), ""))
-
-        def get_url_path(self):
-                """Return the escaped URL path fragment for this FMRI.
-                Requires a version to be defined."""
-
-                if self.version is None:
-                        raise MissingVersionError(self)
-
-                return "{0}@{1}".format(quote(self.pkg_name, ""),
-                    quote(self.version.__str__(), ""))
-
-        def is_same_pkg(self, other):
-                """Return true if these packages are the same (although
-                potentially of different versions.)"""
-                return self.pkg_name == other.pkg_name
-
-        def tuple(self):
-                return self.get_publisher_str(), self.pkg_name, self.version
-
-        def is_name_match(self, fmristr):
-                """True if the regular expression given in fmristr matches the
-                stem of this pkg: FMRI."""
-                m = re.match(fmristr, self.pkg_name)
-                return m != None
-
-        def is_similar(self, other):
-                """True if package names match exactly.  Not a pattern-based
-                query."""
-                return self.pkg_name == other.pkg_name
-
-        def is_successor(self, other):
-                """ returns True if self >= other """
-
-                # Fastest path for most common case.
-                if self.pkg_name != other.pkg_name:
-                        return False
-
-                if self.version is None and other.version is None:
-                        return True
-                if self.version < other.version:
-                        return False
-
+    """The publisher is the anchor of a package namespace.  Clients can
+    choose to take packages from multiple publishers, and specify a default
+    search path.  In general, package names may also be prefixed by a domain
+    name, reverse domain name, or a stock symbol to avoid conflict.  The
+    unprefixed namespace is expected to be managed by architectural review.
+
+    The primary equivalence relationship assumes that packages of the same
+    package name are forwards compatible across all versions of that
+    package, and that higher build release versions are superior
+    publications than lower build release versions."""
+
+    # Stored in a class variable so that subclasses can override
+    valid_pkg_name = g_valid_pkg_name
+
+    __slots__ = ["version", "publisher", "pkg_name", "_hash", "__weakref__"]
+
+    def __init__(
+        self,
+        fmri=None,
+        build_release=None,
+        publisher=None,
+        name=None,
+        version=None,
+    ):
+        if fmri is not None:
+            fmri = fmri.rstrip()
+
+            veridx, nameidx, pubidx = PkgFmri._gen_fmri_indexes(fmri)
+
+            if pubidx != None:
+                # Always use publisher information provided in
+                # FMRI string.  (It could be ""; pkg:///name is
+                # valid.)
+                publisher = fmri[pubidx : nameidx - 1]
+
+            if veridx != None:
+                self.pkg_name = fmri[nameidx:veridx]
+                try:
+                    self.version = Version(fmri[veridx + 1 :], build_release)
+                except VersionError as iv:
+                    raise IllegalFmri(
+                        fmri, IllegalFmri.BAD_VERSION, nested_exc=iv
+                    )
+            else:
+                self.pkg_name = fmri[nameidx:]
+                self.version = None
+        else:
+            # pkg_name and version must be explicitly set.
+            self.pkg_name = name
+            if version:
+                self.version = Version(version, build_release)
+            else:
+                self.version = None
+
+        # Ensure publisher is always None if one was not specified.
+        if publisher:
+            self.publisher = publisher
+        else:
+            self.publisher = None
+
+        if not self.pkg_name:
+            raise IllegalFmri(
+                fmri, IllegalFmri.SYNTAX_ERROR, detail="Missing package name"
+            )
+
+        if not self.valid_pkg_name.match(self.pkg_name):
+            raise IllegalFmri(
+                fmri, IllegalFmri.BAD_PACKAGENAME, detail=self.pkg_name
+            )
+
+        self._hash = None
+
+    @staticmethod
+    def getstate(obj, je_state=None):
+        """Returns the serialized state of this object in a format
+        that that can be easily stored using JSON, pickle, etc."""
+        return str(obj)
+
+    @staticmethod
+    def fromstate(state, jd_state=None):
+        """Allocate a new object using previously serialized state
+        obtained via getstate()."""
+        return PkgFmri(state)
+
+    def copy(self):
+        return PkgFmri(str(self))
+
+    @staticmethod
+    def _gen_fmri_indexes(fmri):
+        """Return a tuple of offsets, used to extract different
+        components of the FMRI."""
+
+        veridx = fmri.rfind("@")
+        if veridx == -1:
+            veridx = None
+
+        pubidx = None
+        if fmri.startswith("pkg://"):
+            nameidx = fmri.find("/", 6, veridx)
+            if nameidx == -1:
+                raise IllegalFmri(
+                    fmri,
+                    IllegalFmri.SYNTAX_ERROR,
+                    detail=_("Missing '/' after " "publisher name"),
+                )
+
+            # Publisher starts after //.
+            pubidx = 6
+
+            # Name starts after / which terminates publisher
+            nameidx += 1
+
+        elif fmri.startswith("pkg:/"):
+            # Name starts after / which terminates scheme
+            nameidx = 5
+        elif fmri.startswith("//"):
+            nameidx = fmri.find("/", 2, veridx)
+            if nameidx == -1:
+                raise IllegalFmri(
+                    fmri,
+                    IllegalFmri.SYNTAX_ERROR,
+                    detail=_("Missing '/' after " "publisher name"),
+                )
+
+            # Publisher starts after //.
+            pubidx = 2
+
+            # Name starts after / which terminates publisher
+            nameidx += 1
+        elif fmri.startswith("/"):
+            # Name starts after / which terminates scheme
+            nameidx = 1
+        else:
+            nameidx = 0
+
+        return (veridx, nameidx, pubidx)
+
+    def get_publisher(self):
+        """Return the name of the publisher that is contained
+        within this FMRI.  This strips off extraneous data
+        that may be attached to the publisher.  The output
+        is suitable as a key into the publisher["prefix"] table."""
+
+        # Strip off preferred publisher prefix, if it exists.
+        if self.publisher and self.publisher.startswith(PREF_PUB_PFX):
+            r = self.publisher.rsplit("_", 1)
+            a = r[len(r) - 1]
+            return a
+
+        # Otherwise just return the publisher
+        return self.publisher
+
+    def set_publisher(self, publisher, preferred=False):
+        """Set the FMRI's publisher.  If this is a preferred
+        publisher, set preferred to True."""
+
+        if preferred and not publisher.startswith(PREF_PUB_PFX):
+            self.publisher = "{0}_{1}".format(PREF_PUB_PFX, publisher)
+        else:
+            self.publisher = publisher
+
+    def remove_publisher(self):
+        self.publisher = None
+        return self
+
+    def has_publisher(self):
+        """Returns true if the FMRI has a publisher."""
+
+        if self.publisher:
+            return True
+
+        return False
+
+    def has_version(self):
+        """Returns True if the FMRI has a version"""
+        if self.version:
+            return True
+        return False
+
+    def preferred_publisher(self):
+        """Returns true if this FMRI's publisher is the preferred
+        publisher."""
+
+        if not self.publisher or self.publisher.startswith(PREF_PUB_PFX):
+            return True
+
+        return False
+
+    def get_publisher_str(self):
+        """Return the bare string that specifies everything about
+        the publisher.  This should only be used by code that
+        must write out (or restore) the complete publisher
+        information to disk."""
+
+        return self.publisher
+
+    def get_name(self):
+        return self.pkg_name
+
+    def set_name(self, name):
+        self.pkg_name = name
+        self._hash = None
+
+    def set_timestamp(self, new_ts):
+        self.version.set_timestamp(new_ts)
+        self._hash = None
+
+    def get_timestamp(self):
+        return self.version.get_timestamp()
+
+    def get_version(self):
+        return self.version.get_short_version()
+
+    def get_pkg_stem(self, anarchy=False, include_scheme=True):
+        """Return a string representation of the FMRI without a specific
+        version.  Anarchy returns a stem without any publisher."""
+        pkg_str = ""
+        if (
+            not self.publisher
+            or self.publisher.startswith(PREF_PUB_PFX)
+            or anarchy
+        ):
+            if include_scheme:
+                pkg_str = "pkg:/"
+            return "{0}{1}".format(pkg_str, self.pkg_name)
+        if include_scheme:
+            pkg_str = "pkg://"
+        return "{0}{1}/{2}".format(pkg_str, self.publisher, self.pkg_name)
+
+    def get_short_fmri(
+        self, default_publisher=None, anarchy=False, include_scheme=True
+    ):
+        """Return a string representation of the FMRI without a specific
+        version."""
+        pkg_str = ""
+        publisher = self.publisher
+        if not publisher:
+            publisher = default_publisher
+
+        if self.version == None:
+            version = ""
+        else:
+            version = "@" + self.version.get_short_version()
+
+        if not publisher or publisher.startswith(PREF_PUB_PFX) or anarchy:
+            if include_scheme:
+                pkg_str = "pkg:/"
+            return "{0}{1}{2}".format(pkg_str, self.pkg_name, version)
+
+        if include_scheme:
+            pkg_str = "pkg://"
+        return "{0}{1}/{2}{3}".format(
+            pkg_str, publisher, self.pkg_name, version
+        )
+
+    def get_fmri(
+        self,
+        default_publisher=None,
+        anarchy=False,
+        include_scheme=True,
+        include_build=True,
+    ):
+        """Return a string representation of the FMRI.
+        Anarchy returns a string without any publisher."""
+        pkg_str = ""
+        publisher = self.publisher
+        if publisher == None:
+            publisher = default_publisher
+
+        if not publisher or publisher.startswith(PREF_PUB_PFX) or anarchy:
+            if include_scheme:
+                pkg_str = "pkg:/"
+            if self.version == None:
+                return "{0}{1}".format(pkg_str, self.pkg_name)
+
+            return "{0}{1}@{2}".format(
+                pkg_str,
+                self.pkg_name,
+                self.version.get_version(include_build=include_build),
+            )
+
+        if include_scheme:
+            pkg_str = "pkg://"
+        if self.version == None:
+            return "{0}{1}/{2}".format(pkg_str, publisher, self.pkg_name)
+
+        return "{0}{1}/{2}@{3}".format(
+            pkg_str,
+            publisher,
+            self.pkg_name,
+            self.version.get_version(include_build=include_build),
+        )
+
+    def hierarchical_names(self):
+        """Generate the different hierarchical names that could be used
+        to reference this fmri."""
+
+        names = self.pkg_name.split("/")
+        res = names[-1:]
+        for n in reversed(names[:-1]):
+            res.append("{0}/{1}".format(n, res[-1]))
+        return res
+
+    def __str__(self):
+        """Return as specific an FMRI representation as possible."""
+        return self.get_fmri()
+
+    def __repr__(self):
+        """Return as specific an FMRI representation as possible."""
+        if not self.publisher:
+            if not self.version:
+                fmristr = "pkg:/{0}".format(self.pkg_name)
+            else:
+                fmristr = "pkg:/{0}@{1}".format(self.pkg_name, self.version)
+        elif not self.version:
+            fmristr = "pkg://{0}/{1}".format(self.publisher, self.pkg_name)
+        else:
+            fmristr = "pkg://{0}/{1}@{2}".format(
+                self.publisher, self.pkg_name, self.version
+            )
+
+        return "<pkg.fmri.PkgFmri '{0}' at {1:#x}".format(fmristr, id(self))
+
+    def __hash__(self):
+        #
+        # __hash__ need not generate a unique hash value for all
+        # possible objects-- it must simply guarantee that two
+        # items which are equal (i.e. a = b) always hash to
+        # the same value.
+        #
+        h = self._hash
+        if h is None:
+            h = self._hash = hash(self.version) + hash(self.pkg_name)
+        return h
+
+    def __eq__(self, other):
+        if not other:
+            return False
+
+        if not isinstance(other, PkgFmri):
+            return False
+
+        if (
+            self.publisher == other.publisher
+            and self.pkg_name == other.pkg_name
+            and self.version == other.version
+        ):
+            return True
+        return False
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __lt__(self, other):
+        if not other:
+            return False
+
+        if not isinstance(other, PkgFmri):
+            return True
+
+        if self.publisher != other.publisher:
+            if self.publisher is None and other.publisher:
                 return True
+            if self.publisher and other.publisher is None:
+                return False
+            if self.publisher < other.publisher:
+                return True
+            return False
+
+        if self.pkg_name < other.pkg_name:
+            return True
+        if self.pkg_name != other.pkg_name:
+            return False
+
+        if self.version is None and other.version is None:
+            return False
+        return self.version < other.version
+
+    def __gt__(self, other):
+        if not other:
+            return True
+
+        if not isinstance(other, PkgFmri):
+            return False
+
+        if self.publisher != other.publisher:
+            if self.publisher and other.publisher is None:
+                return True
+            if self.publisher is None and other.publisher:
+                return False
+            if self.publisher > other.publisher:
+                return True
+            return False
+
+        if self.pkg_name > other.pkg_name:
+            return True
+        if self.pkg_name != other.pkg_name:
+            return False
+
+        if self.version is None and other.version is None:
+            return False
+        return self.version > other.version
+
+    def __ge__(self, other):
+        return not self < other
+
+    def __le__(self, other):
+        return not self > other
+
+    def get_link_path(self, stemonly=False):
+        """Return the escaped link (or file) path fragment for this
+        FMRI."""
+
+        if stemonly:
+            return "{0}".format(quote(self.pkg_name, ""))
+
+        if self.version is None:
+            raise MissingVersionError(self)
+
+        return "{0}@{1}".format(
+            quote(self.pkg_name, ""), quote(str(self.version), "")
+        )
+
+    def get_dir_path(self, stemonly=False):
+        """Return the escaped directory path fragment for this FMRI."""
+
+        if stemonly:
+            return "{0}".format(quote(self.pkg_name, ""))
+
+        if self.version is None:
+            raise MissingVersionError(self)
+
+        return "{0}/{1}".format(
+            quote(self.pkg_name, ""), quote(self.version.__str__(), "")
+        )
+
+    def get_url_path(self):
+        """Return the escaped URL path fragment for this FMRI.
+        Requires a version to be defined."""
+
+        if self.version is None:
+            raise MissingVersionError(self)
+
+        return "{0}@{1}".format(
+            quote(self.pkg_name, ""), quote(self.version.__str__(), "")
+        )
+
+    def is_same_pkg(self, other):
+        """Return true if these packages are the same (although
+        potentially of different versions.)"""
+        return self.pkg_name == other.pkg_name
+
+    def tuple(self):
+        return self.get_publisher_str(), self.pkg_name, self.version
+
+    def is_name_match(self, fmristr):
+        """True if the regular expression given in fmristr matches the
+        stem of this pkg: FMRI."""
+        m = re.match(fmristr, self.pkg_name)
+        return m != None
+
+    def is_similar(self, other):
+        """True if package names match exactly.  Not a pattern-based
+        query."""
+        return self.pkg_name == other.pkg_name
+
+    def is_successor(self, other):
+        """returns True if self >= other"""
+
+        # Fastest path for most common case.
+        if self.pkg_name != other.pkg_name:
+            return False
+
+        if self.version is None and other.version is None:
+            return True
+        if self.version < other.version:
+            return False
+
+        return True
 
 
 class MatchingPkgFmri(PkgFmri):
-        """ A subclass of PkgFmri with (much) weaker rules about package names.
-        This is intended to accept user input with globbing characters. """
-        valid_pkg_name = re.compile(r"^[A-Za-z0-9_/\-\.\+\*\?]*$")
+    """A subclass of PkgFmri with (much) weaker rules about package names.
+    This is intended to accept user input with globbing characters."""
 
-        def __init__(self, *args, **kwargs):
-                try:
-                        PkgFmri.__init__(self, *args, **kwargs)
-                except IllegalFmri as e:
-                        raise IllegalMatchingFmri(e.fmri, e.reason,
-                            detail=e.detail, nested_exc=e.nested_exc)
+    valid_pkg_name = re.compile(r"^[A-Za-z0-9_/\-\.\+\*\?]*$")
+
+    def __init__(self, *args, **kwargs):
+        try:
+            PkgFmri.__init__(self, *args, **kwargs)
+        except IllegalFmri as e:
+            raise IllegalMatchingFmri(
+                e.fmri, e.reason, detail=e.detail, nested_exc=e.nested_exc
+            )
 
 
 def fmri_match(pkg_name, pattern):
-        """Returns true if 'pattern' is a proper subset of 'pkg_name'."""
-        return ("/" + pkg_name).endswith("/" + pattern)
+    """Returns true if 'pattern' is a proper subset of 'pkg_name'."""
+    return ("/" + pkg_name).endswith("/" + pattern)
+
 
 def glob_match(pkg_name, pattern):
-        return fnmatch.fnmatchcase(pkg_name, pattern)
+    return fnmatch.fnmatchcase(pkg_name, pattern)
+
 
 def regex_match(pkg_name, pattern):
-        """Returns true if 'pattern' is a regular expression matching
-        'pkg_name'."""
-        return re.search(pattern, pkg_name)
+    """Returns true if 'pattern' is a regular expression matching
+    'pkg_name'."""
+    return re.search(pattern, pkg_name)
+
 
 def exact_name_match(pkg_name, pattern):
-        """Returns true if 'pattern' matches 'pkg_name' exactly."""
-        return pkg_name == pattern
+    """Returns true if 'pattern' matches 'pkg_name' exactly."""
+    return pkg_name == pattern
+
 
 def extract_pkg_name(fmri):
-        """Given a string that can be converted to a FMRI.  Return the
-        substring that is the FMRI's pkg_name."""
-        fmri = fmri.rstrip()
+    """Given a string that can be converted to a FMRI.  Return the
+    substring that is the FMRI's pkg_name."""
+    fmri = fmri.rstrip()
 
-        veridx, nameidx, pubidx = PkgFmri._gen_fmri_indexes(fmri)
+    veridx, nameidx, pubidx = PkgFmri._gen_fmri_indexes(fmri)
 
-        if veridx:
-                pkg_name = fmri[nameidx:veridx]
-        else:
-                pkg_name = fmri[nameidx:]
+    if veridx:
+        pkg_name = fmri[nameidx:veridx]
+    else:
+        pkg_name = fmri[nameidx:]
 
-        return pkg_name
+    return pkg_name
+
 
 def strip_pub_pfx(pub):
-        """Strip the PREF_PUB_PFX off of a publisher."""
-        if pub.startswith(PREF_PUB_PFX_):
-                outstr = pub[len(PREF_PUB_PFX_):]
-        else:
-                outstr = pub
+    """Strip the PREF_PUB_PFX off of a publisher."""
+    if pub.startswith(PREF_PUB_PFX_):
+        outstr = pub[len(PREF_PUB_PFX_) :]
+    else:
+        outstr = pub
 
-        return outstr
+    return outstr
 
 
 def is_same_publisher(pub1, pub2):
-        """Compare two publishers.  Return true if they are the same, false
-           otherwise. """
-        #
-        # This code is performance sensitive.  Ensure that you benchmark
-        # changes to it.
-        #
+    """Compare two publishers.  Return true if they are the same, false
+    otherwise."""
+    #
+    # This code is performance sensitive.  Ensure that you benchmark
+    # changes to it.
+    #
 
-        # Fastest path for most common case.
-        if pub1 == pub2:
-                return True
+    # Fastest path for most common case.
+    if pub1 == pub2:
+        return True
 
-        if pub1 == None:
-                pub1 = ""
-        if pub2 == None:
-                pub2 = ""
+    if pub1 == None:
+        pub1 = ""
+    if pub2 == None:
+        pub2 = ""
 
-        # String concatenation and string equality are both pretty fast.
-        if ((PREF_PUB_PFX_ + pub1) == pub2) or \
-            (pub1 == (PREF_PUB_PFX_ + pub2)):
-                return True
-        if pub1.startswith(PREF_PUB_PFX_) and \
-            pub2.startswith(PREF_PUB_PFX_):
-                return True
-        return False
+    # String concatenation and string equality are both pretty fast.
+    if ((PREF_PUB_PFX_ + pub1) == pub2) or (pub1 == (PREF_PUB_PFX_ + pub2)):
+        return True
+    if pub1.startswith(PREF_PUB_PFX_) and pub2.startswith(PREF_PUB_PFX_):
+        return True
+    return False
 
 
 def is_valid_pkg_name(name):
-        return g_valid_pkg_name.match(name)
+    return g_valid_pkg_name.match(name)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/gui/repository.py
+++ b/src/modules/gui/repository.py
@@ -32,7 +32,7 @@ MODIFY_NOTEBOOK_SIG_POLICY_PAGE = 2
 
 PUBCERT_APPROVED_STR = _("Approved")
 PUBCERT_REVOKED_STR = _("Revoked")
-PUBCERT_NOTSET_HASH = "HASH-NOTSET" #No L10N required
+PUBCERT_NOTSET_HASH = "HASH-NOTSET"  # No L10N required
 PUBCERT_NOTAVAILABLE = _("Not available")
 
 import sys
@@ -48,13 +48,15 @@ from threading import Thread
 from gettext import ngettext
 
 try:
-        import gobject
-        gobject.threads_init()
-        import gtk
-        import pygtk
-        pygtk.require("2.0")
+    import gobject
+
+    gobject.threads_init()
+    import gtk
+    import pygtk
+
+    pygtk.require("2.0")
 except ImportError:
-        sys.exit(1)
+    sys.exit(1)
 
 import pkg.client.publisher as publisher
 import pkg.client.api_errors as api_errors
@@ -65,2963 +67,3301 @@ from pkg.client import global_settings
 
 logger = global_settings.logger
 
-ERROR_FORMAT = "<span color = \"red\">%s</span>"
+ERROR_FORMAT = '<span color = "red">%s</span>'
+
 
 class Repository(progress.GuiProgressTracker):
-        def __init__(self, parent, image_directory, action = -1,
-            webinstall_new = False, main_window = None, gconf = None):
-                progress.GuiProgressTracker.__init__(self)
-                self.parent = parent
-                self.gconf = gconf
-                self.action = action
-                self.main_window = main_window
-                self.api_o = gui_misc.get_api_object(image_directory,
-                    self, main_window)
-                if self.api_o == None:
-                        return
-                self.webinstall_new = webinstall_new
-                self.progress_stop_thread = False
-                self.repository_selection = None
-                self.cancel_progress_thread = False
-                self.cancel_function = None
-                self.is_alias_valid = True
-                self.is_url_valid = False
-                self.new_pub = None
-                self.priority_changes = []
-                self.url_err = None
-                self.name_error = None
-                self.publisher_info = _("e.g. https://pkg.omnios.org/r151030/core")
-                self.publishers_list = None
-                self.repository_modify_publisher = None
-                self.no_changes = 0
-                self.pylintstub = None
-                builder = gtk.Builder()
-                builder.add_from_file(self.parent.gladefile)
-                # Dialog reused in the beadmin.py
-                self.w_confirmation_dialog =  \
-                    builder.get_object("confirmationdialog")
-                self.w_confirmation_label = \
-                    builder.get_object("confirm_label")
-                self.w_confirmation_dialog.set_icon(self.parent.window_icon)
-                self.w_confirmation_textview = \
-                    builder.get_object("confirmtext")
-                self.w_confirm_cancel_btn = builder.get_object("cancel_conf")
-                self.w_confirm_ok_btn = builder.get_object("ok_conf")
-                confirmbuffer = self.w_confirmation_textview.get_buffer()
-                confirmbuffer.create_tag("bold", weight=pango.WEIGHT_BOLD)
-                self.w_confirmation_dialog.set_title(
-                    _("Manage Publishers Confirmation"))
-                self.w_publishers_treeview = \
-                    builder.get_object("publishers_treeview")
-                self.w_add_publisher_dialog = \
-                    builder.get_object("add_publisher")
-                self.w_add_publisher_dialog.set_icon(self.parent.window_icon)
-                self.w_add_error_label = \
-                    builder.get_object("add_error_label")
-                self.w_add_sslerror_label = \
-                    builder.get_object("add_sslerror_label")
-                self.w_publisher_add_button = \
-                    builder.get_object("add_button")
-                self.w_publisher_add_cancel_button = \
-                    builder.get_object("add_publisher_cancel_button")
-                self.w_ssl_box = \
-                    builder.get_object("ssl_box")
-                self.w_add_publisher_alias = \
-                    builder.get_object("add_publisher_alias")
-                self.w_add_pub_label = \
-                    builder.get_object("add_pub_label")
-                self.w_add_pub_instr_label = \
-                    builder.get_object("add_pub_instr_label")
-                self.w_add_publisher_url = \
-                    builder.get_object("add_publisher_url")
-                self.w_cert_entry = \
-                    builder.get_object("certentry")
-                self.w_key_entry = \
-                    builder.get_object("keyentry")
-                self.w_certbrowse_button = \
-                    builder.get_object("certbrowse")
-                self.w_keybrowse_button = \
-                    builder.get_object("keybrowse")
-                self.w_add_pub_help_button = \
-                    builder.get_object("add_pub_help")
-                self.w_publisher_add_button.set_sensitive(False)
-                self.w_add_publisher_comp_dialog = \
-                    builder.get_object("add_publisher_complete")
-                self.w_add_image = \
-                    builder.get_object("add_image")
-                self.w_add_publisher_comp_dialog.set_icon(self.parent.window_icon)
-                self.w_add_publisher_c_name = \
-                    builder.get_object("add_publisher_name_c")
-                self.w_add_publisher_c_alias = \
-                    builder.get_object("add_publisher_alias_c")
-                self.w_add_publisher_c_alias_l = \
-                    builder.get_object("add_publisher_alias_l")
-                self.w_add_publisher_c_url = \
-                    builder.get_object("add_publisher_url_c")
-                self.w_add_publisher_c_desc = \
-                    builder.get_object("add_publisher_desc_c")
-                self.w_add_publisher_c_desc_l = \
-                    builder.get_object("add_publisher_desc_l")
-                self.w_add_publisher_c_close = \
-                    builder.get_object("add_publisher_c_close")
-                self.w_registration_box = \
-                    builder.get_object("add_registration_box")
-                self.w_registration_link = \
-                    builder.get_object("registration_button")
-                self.w_modify_repository_dialog = \
-                    builder.get_object("modify_repository")
-                self.w_modify_repository_dialog.set_icon(self.parent.window_icon)
-                self.w_modkeybrowse = \
-                    builder.get_object("modkeybrowse")
-                self.w_modcertbrowse = \
-                    builder.get_object("modcertbrowse")
-                self.w_addmirror_entry = \
-                    builder.get_object("addmirror_entry")
-                self.w_addorigin_entry = \
-                    builder.get_object("add_repo")
-                self.w_addmirror_button = \
-                    builder.get_object("addmirror_button")
-                self.w_rmmirror_button = \
-                    builder.get_object("mirrorremove")
-                self.w_addorigin_button = \
-                    builder.get_object("pub_add_repo")
-                self.w_rmorigin_button = \
-                    builder.get_object("pub_remove_repo")
-                self.w_modify_pub_alias = \
-                    builder.get_object("repositorymodifyalias")
-                self.w_repositorymodifyok_button = \
-                    builder.get_object("repositorymodifyok")
-                self.w_repositorymodifycancel_button = \
-                    builder.get_object("repositorymodifycancel")
-                self.w_repositorymodifyhelp_button = \
-                    builder.get_object("modify_repo_help")
-                self.modify_repo_mirrors_treeview = \
-                    builder.get_object("modify_repo_mirrors_treeview")
-                self.modify_repo_origins_treeview = \
-                    builder.get_object("modify_pub_repos_treeview")
-                self.w_modmirrerror_label = \
-                    builder.get_object("modmirrerror_label")
-                self.w_modoriginerror_label = \
-                    builder.get_object("modrepoerror_label")
-                self.w_modsslerror_label = \
-                    builder.get_object("modsslerror_label")
-                self.w_repositorymodify_name = \
-                    builder.get_object("repository_name_label")
-                self.w_repositorymodify_registration_link = \
-                    builder.get_object(
-                    "repositorymodifyregistrationlinkbutton")
-                self.w_repositorymirror_expander = \
-                    builder.get_object(
-                    "repositorymodifymirrorsexpander")
-                self.w_repositorymodify_registration_box = \
-                    builder.get_object("modify_registration_box")
-                self.w_repositorymodify_key_entry = \
-                    builder.get_object("modkeyentry")
-                self.w_repositorymodify_cert_entry = \
-                    builder.get_object("modcertentry")
-                self.w_manage_publishers_dialog = \
-                    builder.get_object("manage_publishers")
-                self.w_manage_publishers_dialog.set_icon(self.parent.window_icon)
-                self.w_manage_publishers_details = \
-                    builder.get_object("manage_publishers_details")
-                self.w_manage_publishers_details.set_wrap_mode(gtk.WRAP_WORD)
-                manage_pub_details_buf =  self.w_manage_publishers_details.get_buffer()
-                manage_pub_details_buf.create_tag("level0", weight=pango.WEIGHT_BOLD)
-                self.w_manage_add_btn =  builder.get_object("manage_add")
-                self.w_manage_ok_btn =  builder.get_object("manage_ok")
-                self.w_manage_remove_btn = builder.get_object("manage_remove")
-                self.w_manage_modify_btn = \
-                    builder.get_object("manage_modify")
-                self.w_manage_up_btn = \
-                    builder.get_object("manage_move_up")
-                self.w_manage_down_btn = \
-                    builder.get_object("manage_move_down")
-                self.w_manage_cancel_btn = \
-                    builder.get_object("manage_cancel")
-                self.w_manage_help_btn = \
-                    builder.get_object("manage_help")
+    def __init__(
+        self,
+        parent,
+        image_directory,
+        action=-1,
+        webinstall_new=False,
+        main_window=None,
+        gconf=None,
+    ):
+        progress.GuiProgressTracker.__init__(self)
+        self.parent = parent
+        self.gconf = gconf
+        self.action = action
+        self.main_window = main_window
+        self.api_o = gui_misc.get_api_object(image_directory, self, main_window)
+        if self.api_o == None:
+            return
+        self.webinstall_new = webinstall_new
+        self.progress_stop_thread = False
+        self.repository_selection = None
+        self.cancel_progress_thread = False
+        self.cancel_function = None
+        self.is_alias_valid = True
+        self.is_url_valid = False
+        self.new_pub = None
+        self.priority_changes = []
+        self.url_err = None
+        self.name_error = None
+        self.publisher_info = _("e.g. https://pkg.omnios.org/r151030/core")
+        self.publishers_list = None
+        self.repository_modify_publisher = None
+        self.no_changes = 0
+        self.pylintstub = None
+        builder = gtk.Builder()
+        builder.add_from_file(self.parent.gladefile)
+        # Dialog reused in the beadmin.py
+        self.w_confirmation_dialog = builder.get_object("confirmationdialog")
+        self.w_confirmation_label = builder.get_object("confirm_label")
+        self.w_confirmation_dialog.set_icon(self.parent.window_icon)
+        self.w_confirmation_textview = builder.get_object("confirmtext")
+        self.w_confirm_cancel_btn = builder.get_object("cancel_conf")
+        self.w_confirm_ok_btn = builder.get_object("ok_conf")
+        confirmbuffer = self.w_confirmation_textview.get_buffer()
+        confirmbuffer.create_tag("bold", weight=pango.WEIGHT_BOLD)
+        self.w_confirmation_dialog.set_title(
+            _("Manage Publishers Confirmation")
+        )
+        self.w_publishers_treeview = builder.get_object("publishers_treeview")
+        self.w_add_publisher_dialog = builder.get_object("add_publisher")
+        self.w_add_publisher_dialog.set_icon(self.parent.window_icon)
+        self.w_add_error_label = builder.get_object("add_error_label")
+        self.w_add_sslerror_label = builder.get_object("add_sslerror_label")
+        self.w_publisher_add_button = builder.get_object("add_button")
+        self.w_publisher_add_cancel_button = builder.get_object(
+            "add_publisher_cancel_button"
+        )
+        self.w_ssl_box = builder.get_object("ssl_box")
+        self.w_add_publisher_alias = builder.get_object("add_publisher_alias")
+        self.w_add_pub_label = builder.get_object("add_pub_label")
+        self.w_add_pub_instr_label = builder.get_object("add_pub_instr_label")
+        self.w_add_publisher_url = builder.get_object("add_publisher_url")
+        self.w_cert_entry = builder.get_object("certentry")
+        self.w_key_entry = builder.get_object("keyentry")
+        self.w_certbrowse_button = builder.get_object("certbrowse")
+        self.w_keybrowse_button = builder.get_object("keybrowse")
+        self.w_add_pub_help_button = builder.get_object("add_pub_help")
+        self.w_publisher_add_button.set_sensitive(False)
+        self.w_add_publisher_comp_dialog = builder.get_object(
+            "add_publisher_complete"
+        )
+        self.w_add_image = builder.get_object("add_image")
+        self.w_add_publisher_comp_dialog.set_icon(self.parent.window_icon)
+        self.w_add_publisher_c_name = builder.get_object("add_publisher_name_c")
+        self.w_add_publisher_c_alias = builder.get_object(
+            "add_publisher_alias_c"
+        )
+        self.w_add_publisher_c_alias_l = builder.get_object(
+            "add_publisher_alias_l"
+        )
+        self.w_add_publisher_c_url = builder.get_object("add_publisher_url_c")
+        self.w_add_publisher_c_desc = builder.get_object("add_publisher_desc_c")
+        self.w_add_publisher_c_desc_l = builder.get_object(
+            "add_publisher_desc_l"
+        )
+        self.w_add_publisher_c_close = builder.get_object(
+            "add_publisher_c_close"
+        )
+        self.w_registration_box = builder.get_object("add_registration_box")
+        self.w_registration_link = builder.get_object("registration_button")
+        self.w_modify_repository_dialog = builder.get_object(
+            "modify_repository"
+        )
+        self.w_modify_repository_dialog.set_icon(self.parent.window_icon)
+        self.w_modkeybrowse = builder.get_object("modkeybrowse")
+        self.w_modcertbrowse = builder.get_object("modcertbrowse")
+        self.w_addmirror_entry = builder.get_object("addmirror_entry")
+        self.w_addorigin_entry = builder.get_object("add_repo")
+        self.w_addmirror_button = builder.get_object("addmirror_button")
+        self.w_rmmirror_button = builder.get_object("mirrorremove")
+        self.w_addorigin_button = builder.get_object("pub_add_repo")
+        self.w_rmorigin_button = builder.get_object("pub_remove_repo")
+        self.w_modify_pub_alias = builder.get_object("repositorymodifyalias")
+        self.w_repositorymodifyok_button = builder.get_object(
+            "repositorymodifyok"
+        )
+        self.w_repositorymodifycancel_button = builder.get_object(
+            "repositorymodifycancel"
+        )
+        self.w_repositorymodifyhelp_button = builder.get_object(
+            "modify_repo_help"
+        )
+        self.modify_repo_mirrors_treeview = builder.get_object(
+            "modify_repo_mirrors_treeview"
+        )
+        self.modify_repo_origins_treeview = builder.get_object(
+            "modify_pub_repos_treeview"
+        )
+        self.w_modmirrerror_label = builder.get_object("modmirrerror_label")
+        self.w_modoriginerror_label = builder.get_object("modrepoerror_label")
+        self.w_modsslerror_label = builder.get_object("modsslerror_label")
+        self.w_repositorymodify_name = builder.get_object(
+            "repository_name_label"
+        )
+        self.w_repositorymodify_registration_link = builder.get_object(
+            "repositorymodifyregistrationlinkbutton"
+        )
+        self.w_repositorymirror_expander = builder.get_object(
+            "repositorymodifymirrorsexpander"
+        )
+        self.w_repositorymodify_registration_box = builder.get_object(
+            "modify_registration_box"
+        )
+        self.w_repositorymodify_key_entry = builder.get_object("modkeyentry")
+        self.w_repositorymodify_cert_entry = builder.get_object("modcertentry")
+        self.w_manage_publishers_dialog = builder.get_object(
+            "manage_publishers"
+        )
+        self.w_manage_publishers_dialog.set_icon(self.parent.window_icon)
+        self.w_manage_publishers_details = builder.get_object(
+            "manage_publishers_details"
+        )
+        self.w_manage_publishers_details.set_wrap_mode(gtk.WRAP_WORD)
+        manage_pub_details_buf = self.w_manage_publishers_details.get_buffer()
+        manage_pub_details_buf.create_tag("level0", weight=pango.WEIGHT_BOLD)
+        self.w_manage_add_btn = builder.get_object("manage_add")
+        self.w_manage_ok_btn = builder.get_object("manage_ok")
+        self.w_manage_remove_btn = builder.get_object("manage_remove")
+        self.w_manage_modify_btn = builder.get_object("manage_modify")
+        self.w_manage_up_btn = builder.get_object("manage_move_up")
+        self.w_manage_down_btn = builder.get_object("manage_move_down")
+        self.w_manage_cancel_btn = builder.get_object("manage_cancel")
+        self.w_manage_help_btn = builder.get_object("manage_help")
 
-                self.publishers_apply = \
-                    builder.get_object("publishers_apply")
-                self.publishers_apply.set_icon(self.parent.window_icon)
-                self.publishers_apply_expander = \
-                    builder.get_object("apply_expander")
-                self.publishers_apply_textview = \
-                    builder.get_object("apply_textview")
-                applybuffer = self.publishers_apply_textview.get_buffer()
-                applybuffer.create_tag("level1", left_margin=30, right_margin=10)
-                self.publishers_apply_cancel = \
-                    builder.get_object("apply_cancel")
-                self.publishers_apply_progress = \
-                    builder.get_object("publishers_apply_progress")
+        self.publishers_apply = builder.get_object("publishers_apply")
+        self.publishers_apply.set_icon(self.parent.window_icon)
+        self.publishers_apply_expander = builder.get_object("apply_expander")
+        self.publishers_apply_textview = builder.get_object("apply_textview")
+        applybuffer = self.publishers_apply_textview.get_buffer()
+        applybuffer.create_tag("level1", left_margin=30, right_margin=10)
+        self.publishers_apply_cancel = builder.get_object("apply_cancel")
+        self.publishers_apply_progress = builder.get_object(
+            "publishers_apply_progress"
+        )
 
-                self.w_modify_alias_error_label = builder.get_object(
-                        "mod_alias_error_label")
-                self.w_pub_cert_treeview = \
-                    builder.get_object("pub_certificate_treeview")
-                self.w_modify_pub_notebook = builder.get_object(
-                        "modify_pub_notebook")
-                self.w_pub_cert_details_textview = builder.get_object(
-                        "pub_certificate_details_textview")
-                manage_pub_cert_details_buf =  \
-                        self.w_pub_cert_details_textview.get_buffer()
-                manage_pub_cert_details_buf.create_tag("level0",
-                    weight=pango.WEIGHT_BOLD)
-                manage_pub_cert_details_buf.create_tag("bold",
-                    weight=pango.WEIGHT_BOLD)
-                manage_pub_cert_details_buf.create_tag("normal",
-                    weight=pango.WEIGHT_NORMAL)
-                self.w_pub_cert_label = \
-                    builder.get_object("mods_pub_label")
-                self.w_pub_cert_add_btn =  builder.get_object(
-                    "pub_certificate_add_button")
-                self.w_pub_cert_remove_btn =  builder.get_object(
-                    "pub_certificate_remove_button")
-                self.w_pub_cert_revoke_btn =  builder.get_object(
-                    "pub_certificate_revoke_button")
-                self.w_pub_cert_reinstate_btn =  builder.get_object(
-                    "pub_certificate_reinstate_button")
+        self.w_modify_alias_error_label = builder.get_object(
+            "mod_alias_error_label"
+        )
+        self.w_pub_cert_treeview = builder.get_object(
+            "pub_certificate_treeview"
+        )
+        self.w_modify_pub_notebook = builder.get_object("modify_pub_notebook")
+        self.w_pub_cert_details_textview = builder.get_object(
+            "pub_certificate_details_textview"
+        )
+        manage_pub_cert_details_buf = (
+            self.w_pub_cert_details_textview.get_buffer()
+        )
+        manage_pub_cert_details_buf.create_tag(
+            "level0", weight=pango.WEIGHT_BOLD
+        )
+        manage_pub_cert_details_buf.create_tag("bold", weight=pango.WEIGHT_BOLD)
+        manage_pub_cert_details_buf.create_tag(
+            "normal", weight=pango.WEIGHT_NORMAL
+        )
+        self.w_pub_cert_label = builder.get_object("mods_pub_label")
+        self.w_pub_cert_add_btn = builder.get_object(
+            "pub_certificate_add_button"
+        )
+        self.w_pub_cert_remove_btn = builder.get_object(
+            "pub_certificate_remove_button"
+        )
+        self.w_pub_cert_revoke_btn = builder.get_object(
+            "pub_certificate_revoke_button"
+        )
+        self.w_pub_cert_reinstate_btn = builder.get_object(
+            "pub_certificate_reinstate_button"
+        )
 
+        self.w_pub_sig_ignored_radiobutton = builder.get_object(
+            "sig_ignored_radiobutton"
+        )
+        self.w_pub_sig_optional_radiobutton = builder.get_object(
+            "sig_optional_but_valid_radiobutton"
+        )
+        self.w_pub_sig_valid_radiobutton = builder.get_object(
+            "sig_valid_radiobutton"
+        )
+        self.w_pub_sig_name_radiobutton = builder.get_object(
+            "sig_name_radiobutton"
+        )
+        self.w_pub_sig_name_entry = builder.get_object("sig_name_entry")
+        self.w_pub_sig_view_globpol_button = builder.get_object(
+            "sig_view_globpol_button"
+        )
+        self.w_pub_sig_cert_names_vbox = builder.get_object(
+            "sig_cert_names_vbox"
+        )
 
-                self.w_pub_sig_ignored_radiobutton =  builder.get_object(
-                    "sig_ignored_radiobutton")
-                self.w_pub_sig_optional_radiobutton =  builder.get_object(
-                    "sig_optional_but_valid_radiobutton")
-                self.w_pub_sig_valid_radiobutton =  builder.get_object(
-                    "sig_valid_radiobutton")
-                self.w_pub_sig_name_radiobutton =  builder.get_object(
-                    "sig_name_radiobutton")
-                self.w_pub_sig_name_entry =  builder.get_object(
-                    "sig_name_entry")
-                self.w_pub_sig_view_globpol_button =  builder.get_object(
-                    "sig_view_globpol_button")
-                self.w_pub_sig_cert_names_vbox =  builder.get_object(
-                    "sig_cert_names_vbox")
+        checkmark_icon = gui_misc.get_icon(
+            self.parent.icon_theme, "pm-check", 24
+        )
 
-                checkmark_icon = gui_misc.get_icon(
-                    self.parent.icon_theme, "pm-check", 24)
+        self.w_add_image.set_from_pixbuf(checkmark_icon)
 
-                self.w_add_image.set_from_pixbuf(checkmark_icon)
+        self.__setup_signals()
 
-                self.__setup_signals()
+        self.publishers_list = self.__get_publishers_liststore()
+        self.__init_pubs_tree_view(self.publishers_list)
+        self.__init_mirrors_tree_view(self.modify_repo_mirrors_treeview)
+        self.__init_origins_tree_view(self.modify_repo_origins_treeview)
 
-                self.publishers_list = self.__get_publishers_liststore()
-                self.__init_pubs_tree_view(self.publishers_list)
-                self.__init_mirrors_tree_view(self.modify_repo_mirrors_treeview)
-                self.__init_origins_tree_view(self.modify_repo_origins_treeview)
+        self.pub_cert_list = self.__get_pub_cert_liststore()
+        self.orig_pub_cert_added_dict = {}  # Orig Pub Certs added to model:
+        # - key/val: [ips-hash] = status
+        self.all_pub_cert_added_dict = {}  # New/ Orig Pub Certs added to model
+        # - key/val: [sha-hash] = ips-hash
+        self.removed_orig_pub_cert_dict = (
+            {}
+        )  # Removed Orig Pub Certs from model
+        # - key/val: [sha-hash] = ips-hash
+        self.orig_sig_policy = {}
+        self.pub_certs_setup = False
 
-                self.pub_cert_list = self.__get_pub_cert_liststore()
-                self.orig_pub_cert_added_dict = {}  # Orig Pub Certs added to model:
-                                                    # - key/val: [ips-hash] = status
-                self.all_pub_cert_added_dict = {}   # New/ Orig Pub Certs added to model
-                                                    # - key/val: [sha-hash] = ips-hash
-                self.removed_orig_pub_cert_dict = {}# Removed Orig Pub Certs from model
-                                                    # - key/val: [sha-hash] = ips-hash
-                self.orig_sig_policy = {}
-                self.pub_certs_setup = False
+        if self.action == enumerations.ADD_PUBLISHER:
+            gui_misc.set_modal_and_transient(
+                self.w_add_publisher_dialog, self.main_window
+            )
+            self.__on_manage_add_clicked(None)
+            return
+        elif self.action == enumerations.MANAGE_PUBLISHERS:
+            gui_misc.set_modal_and_transient(
+                self.w_manage_publishers_dialog, self.main_window
+            )
+            gui_misc.set_modal_and_transient(
+                self.w_confirmation_dialog, self.w_manage_publishers_dialog
+            )
+            self.__prepare_publisher_list()
+            publisher_selection = self.w_publishers_treeview.get_selection()
+            publisher_selection.set_mode(gtk.SELECTION_SINGLE)
+            publisher_selection.connect(
+                "changed", self.__on_publisher_selection_changed, None
+            )
+            mirrors_selection = (
+                self.modify_repo_mirrors_treeview.get_selection()
+            )
+            mirrors_selection.set_mode(gtk.SELECTION_SINGLE)
+            mirrors_selection.connect(
+                "changed", self.__on_mirror_selection_changed, None
+            )
+            origins_selection = (
+                self.modify_repo_origins_treeview.get_selection()
+            )
+            origins_selection.set_mode(gtk.SELECTION_SINGLE)
+            origins_selection.connect(
+                "changed", self.__on_origin_selection_changed, None
+            )
 
-                if self.action == enumerations.ADD_PUBLISHER:
-                        gui_misc.set_modal_and_transient(self.w_add_publisher_dialog,
-                            self.main_window)
-                        self.__on_manage_add_clicked(None)
-                        return
-                elif self.action == enumerations.MANAGE_PUBLISHERS:
-                        gui_misc.set_modal_and_transient(self.w_manage_publishers_dialog,
-                            self.main_window)
-                        gui_misc.set_modal_and_transient(self.w_confirmation_dialog,
-                            self.w_manage_publishers_dialog)
-                        self.__prepare_publisher_list()
-                        publisher_selection = self.w_publishers_treeview.get_selection()
-                        publisher_selection.set_mode(gtk.SELECTION_SINGLE)
-                        publisher_selection.connect("changed",
-                            self.__on_publisher_selection_changed, None)
-                        mirrors_selection = \
-                            self.modify_repo_mirrors_treeview.get_selection()
-                        mirrors_selection.set_mode(gtk.SELECTION_SINGLE)
-                        mirrors_selection.connect("changed",
-                            self.__on_mirror_selection_changed, None)
-                        origins_selection = \
-                            self.modify_repo_origins_treeview.get_selection()
-                        origins_selection.set_mode(gtk.SELECTION_SINGLE)
-                        origins_selection.connect("changed",
-                            self.__on_origin_selection_changed, None)
+            gui_misc.set_modal_and_transient(
+                self.w_add_publisher_dialog, self.w_manage_publishers_dialog
+            )
+            self.__init_pub_cert_tree_view(self.pub_cert_list)
+            self.w_manage_publishers_dialog.show_all()
+            return
 
-                        gui_misc.set_modal_and_transient(self.w_add_publisher_dialog,
-                            self.w_manage_publishers_dialog)
-                        self.__init_pub_cert_tree_view(self.pub_cert_list)
-                        self.w_manage_publishers_dialog.show_all()
-                        return
+    def __setup_signals(self):
+        signals_table = [
+            (
+                self.w_add_publisher_dialog,
+                "delete_event",
+                self.__on_add_publisher_delete_event,
+            ),
+            (
+                self.w_add_publisher_url,
+                "changed",
+                self.__on_publisherurl_changed,
+            ),
+            (
+                self.w_add_publisher_url,
+                "activate",
+                self.__on_add_publisher_add_clicked,
+            ),
+            (
+                self.w_add_publisher_alias,
+                "changed",
+                self.__on_publisheralias_changed,
+            ),
+            (
+                self.w_add_publisher_alias,
+                "activate",
+                self.__on_add_publisher_add_clicked,
+            ),
+            (
+                self.w_publisher_add_button,
+                "clicked",
+                self.__on_add_publisher_add_clicked,
+            ),
+            (self.w_key_entry, "changed", self.__on_keyentry_changed),
+            (self.w_cert_entry, "changed", self.__on_certentry_changed),
+            (
+                self.w_publisher_add_cancel_button,
+                "clicked",
+                self.__on_add_publisher_cancel_clicked,
+            ),
+            (self.w_keybrowse_button, "clicked", self.__on_keybrowse_clicked),
+            (self.w_certbrowse_button, "clicked", self.__on_certbrowse_clicked),
+            (
+                self.w_add_pub_help_button,
+                "clicked",
+                self.__on_add_pub_help_clicked,
+            ),
+            (
+                self.w_add_publisher_comp_dialog,
+                "delete_event",
+                self.__on_add_publisher_complete_delete_event,
+            ),
+            (
+                self.w_add_publisher_c_close,
+                "clicked",
+                self.__on_add_publisher_c_close_clicked,
+            ),
+            (
+                self.w_manage_publishers_dialog,
+                "delete_event",
+                self.__on_manage_publishers_delete_event,
+            ),
+            (self.w_manage_add_btn, "clicked", self.__on_manage_add_clicked),
+            (
+                self.w_manage_modify_btn,
+                "clicked",
+                self.__on_manage_modify_clicked,
+            ),
+            (
+                self.w_manage_remove_btn,
+                "clicked",
+                self.__on_manage_remove_clicked,
+            ),
+            (self.w_manage_up_btn, "clicked", self.__on_manage_move_up_clicked),
+            (
+                self.w_manage_down_btn,
+                "clicked",
+                self.__on_manage_move_down_clicked,
+            ),
+            (
+                self.w_manage_cancel_btn,
+                "clicked",
+                self.__on_manage_cancel_clicked,
+            ),
+            (self.w_manage_ok_btn, "clicked", self.__on_manage_ok_clicked),
+            (self.w_manage_help_btn, "clicked", self.__on_manage_help_clicked),
+            (
+                self.w_modify_repository_dialog,
+                "delete_event",
+                self.__on_modifydialog_delete_event,
+            ),
+            (
+                self.w_modify_pub_alias,
+                "changed",
+                self.__on_modify_pub_alias_changed,
+            ),
+            (self.w_modkeybrowse, "clicked", self.__on_modkeybrowse_clicked),
+            (self.w_modcertbrowse, "clicked", self.__on_modcertbrowse_clicked),
+            (
+                self.w_addmirror_entry,
+                "changed",
+                self.__on_addmirror_entry_changed,
+            ),
+            (
+                self.w_addorigin_entry,
+                "changed",
+                self.__on_addorigin_entry_changed,
+            ),
+            (
+                self.w_addmirror_button,
+                "clicked",
+                self.__on_addmirror_button_clicked,
+            ),
+            (
+                self.w_addorigin_button,
+                "clicked",
+                self.__on_addorigin_button_clicked,
+            ),
+            (
+                self.w_rmmirror_button,
+                "clicked",
+                self.__on_rmmirror_button_clicked,
+            ),
+            (
+                self.w_rmorigin_button,
+                "clicked",
+                self.__on_rmorigin_button_clicked,
+            ),
+            (
+                self.w_repositorymodify_key_entry,
+                "changed",
+                self.__on_modcertkeyentry_changed,
+            ),
+            (
+                self.w_repositorymodify_cert_entry,
+                "changed",
+                self.__on_modcertkeyentry_changed,
+            ),
+            (
+                self.w_repositorymodifyok_button,
+                "clicked",
+                self.__on_repositorymodifyok_clicked,
+            ),
+            (
+                self.w_repositorymodifycancel_button,
+                "clicked",
+                self.__on_repositorymodifycancel_clicked,
+            ),
+            (
+                self.w_repositorymodifyhelp_button,
+                "clicked",
+                self.__on_modify_repo_help_clicked,
+            ),
+            (
+                self.w_confirmation_dialog,
+                "delete_event",
+                self.__delete_widget_handler_hide,
+            ),
+            (
+                self.w_confirm_cancel_btn,
+                "clicked",
+                self.__on_cancel_conf_clicked,
+            ),
+            (self.w_confirm_ok_btn, "clicked", self.__on_ok_conf_clicked),
+            (
+                self.publishers_apply,
+                "delete_event",
+                self.__on_publishers_apply_delete_event,
+            ),
+            (
+                self.publishers_apply_cancel,
+                "clicked",
+                self.__on_apply_cancel_clicked,
+            ),
+            (
+                self.w_pub_cert_add_btn,
+                "clicked",
+                self.__on_pub_cert_add_clicked,
+            ),
+            (
+                self.w_pub_cert_remove_btn,
+                "clicked",
+                self.__on_pub_cert_remove_clicked,
+            ),
+            (
+                self.w_pub_cert_revoke_btn,
+                "clicked",
+                self.__on_pub_cert_revoke_clicked,
+            ),
+            (
+                self.w_pub_cert_reinstate_btn,
+                "clicked",
+                self.__on_pub_cert_reinstate_clicked,
+            ),
+            (
+                self.w_modify_pub_notebook,
+                "switch_page",
+                self.__on_notebook_change,
+            ),
+            (
+                self.w_pub_sig_ignored_radiobutton,
+                "toggled",
+                self.__on_pub_sig_radiobutton_toggled,
+            ),
+            (
+                self.w_pub_sig_optional_radiobutton,
+                "toggled",
+                self.__on_pub_sig_radiobutton_toggled,
+            ),
+            (
+                self.w_pub_sig_valid_radiobutton,
+                "toggled",
+                self.__on_pub_sig_radiobutton_toggled,
+            ),
+            (
+                self.w_pub_sig_name_radiobutton,
+                "toggled",
+                self.__on_pub_sig_radiobutton_toggled,
+            ),
+            (
+                self.w_pub_sig_view_globpol_button,
+                "clicked",
+                self.__on_pub_sig_view_globpol_clicked,
+            ),
+        ]
+        for widget, signal_name, callback in signals_table:
+            widget.connect(signal_name, callback)
 
+    def __on_pub_sig_radiobutton_toggled(self, widget):
+        self.w_pub_sig_cert_names_vbox.set_sensitive(
+            self.w_pub_sig_name_radiobutton.get_active()
+        )
 
-        def __setup_signals(self):
-                signals_table = [
-                    (self.w_add_publisher_dialog, "delete_event",
-                     self.__on_add_publisher_delete_event),
-                    (self.w_add_publisher_url, "changed",
-                     self.__on_publisherurl_changed),
-                    (self.w_add_publisher_url, "activate",
-                     self.__on_add_publisher_add_clicked),
-                    (self.w_add_publisher_alias, "changed",
-                     self.__on_publisheralias_changed),
-                    (self.w_add_publisher_alias, "activate",
-                     self.__on_add_publisher_add_clicked),
-                    (self.w_publisher_add_button, "clicked",
-                     self.__on_add_publisher_add_clicked),
-                    (self.w_key_entry, "changed", self.__on_keyentry_changed),
-                    (self.w_cert_entry, "changed", self.__on_certentry_changed),
-                    (self.w_publisher_add_cancel_button, "clicked",
-                     self.__on_add_publisher_cancel_clicked),
-                    (self.w_keybrowse_button, "clicked",
-                     self.__on_keybrowse_clicked),
-                    (self.w_certbrowse_button, "clicked",
-                     self.__on_certbrowse_clicked),
-                    (self.w_add_pub_help_button, "clicked",
-                     self.__on_add_pub_help_clicked),
+    def __on_pub_sig_view_globpol_clicked(self, widget):
+        # Preferences Dialog is modal so no need to hide the Modify Dialog
+        self.parent.preferences.show_signature_policy()
 
-                    (self.w_add_publisher_comp_dialog, "delete_event",
-                     self.__on_add_publisher_complete_delete_event),
-                    (self.w_add_publisher_c_close, "clicked",
-                     self.__on_add_publisher_c_close_clicked),
+    def __update_pub_sig_policy_prop(self, set_props):
+        errors = []
+        try:
+            pub = self.repository_modify_publisher
+            if pub != None:
+                pub.update_props(set_props=set_props)
+        except api_errors.ApiException as e:
+            errors.append(("", e))
+        return errors
 
-                    (self.w_manage_publishers_dialog, "delete_event",
-                     self.__on_manage_publishers_delete_event),
-                    (self.w_manage_add_btn, "clicked",
-                     self.__on_manage_add_clicked),
-                    (self.w_manage_modify_btn, "clicked",
-                     self.__on_manage_modify_clicked),
-                    (self.w_manage_remove_btn, "clicked",
-                     self.__on_manage_remove_clicked),
-                    (self.w_manage_up_btn, "clicked",
-                     self.__on_manage_move_up_clicked),
-                    (self.w_manage_down_btn, "clicked",
-                     self.__on_manage_move_down_clicked),
-                    (self.w_manage_cancel_btn, "clicked",
-                     self.__on_manage_cancel_clicked),
-                    (self.w_manage_ok_btn, "clicked",
-                     self.__on_manage_ok_clicked),
-                    (self.w_manage_help_btn, "clicked",
-                     self.__on_manage_help_clicked),
+    def __update_pub_sig_policy(self):
+        errors = []
+        orig = self.orig_sig_policy
+        if not orig:
+            return errors
+        ignore = self.w_pub_sig_ignored_radiobutton.get_active()
+        verify = self.w_pub_sig_optional_radiobutton.get_active()
+        req_sigs = self.w_pub_sig_valid_radiobutton.get_active()
+        req_names = self.w_pub_sig_name_radiobutton.get_active()
+        names = gui_misc.fetch_signature_policy_names_from_textfield(
+            self.w_pub_sig_name_entry.get_text()
+        )
+        set_props = gui_misc.setup_signature_policy_properties(
+            ignore, verify, req_sigs, req_names, names, orig
+        )
+        if len(set_props) > 0:
+            errors = self.__update_pub_sig_policy_prop(set_props)
+        return errors
 
-                    (self.w_modify_repository_dialog, "delete_event",
-                     self.__on_modifydialog_delete_event),
-                    (self.w_modify_pub_alias, "changed",
-                     self.__on_modify_pub_alias_changed),
-                    (self.w_modkeybrowse, "clicked",
-                     self.__on_modkeybrowse_clicked),
-                    (self.w_modcertbrowse, "clicked",
-                     self.__on_modcertbrowse_clicked),
-                    (self.w_addmirror_entry, "changed",
-                     self.__on_addmirror_entry_changed),
-                    (self.w_addorigin_entry, "changed",
-                     self.__on_addorigin_entry_changed),
-                    (self.w_addmirror_button, "clicked",
-                     self.__on_addmirror_button_clicked),
-                    (self.w_addorigin_button, "clicked",
-                     self.__on_addorigin_button_clicked),
-                    (self.w_rmmirror_button, "clicked",
-                     self.__on_rmmirror_button_clicked),
-                    (self.w_rmorigin_button, "clicked",
-                     self.__on_rmorigin_button_clicked),
-                    (self.w_repositorymodify_key_entry, "changed",
-                     self.__on_modcertkeyentry_changed),
-                    (self.w_repositorymodify_cert_entry, "changed",
-                     self.__on_modcertkeyentry_changed),
-                    (self.w_repositorymodifyok_button, "clicked",
-                     self.__on_repositorymodifyok_clicked),
-                    (self.w_repositorymodifycancel_button, "clicked",
-                     self.__on_repositorymodifycancel_clicked),
-                    (self.w_repositorymodifyhelp_button, "clicked",
-                     self.__on_modify_repo_help_clicked),
+    def __prepare_pub_signature_policy(self):
+        if self.orig_sig_policy:
+            return
 
-                    (self.w_confirmation_dialog, "delete_event",
-                        self.__delete_widget_handler_hide),
-                    (self.w_confirm_cancel_btn, "clicked",
-                        self.__on_cancel_conf_clicked),
-                    (self.w_confirm_ok_btn, "clicked",
-                        self.__on_ok_conf_clicked),
+        sig_policy = self.__fetch_pub_signature_policy()
+        self.orig_sig_policy = sig_policy
+        self.w_pub_sig_ignored_radiobutton.set_active(
+            sig_policy[gui_misc.SIG_POLICY_IGNORE]
+        )
+        self.w_pub_sig_optional_radiobutton.set_active(
+            sig_policy[gui_misc.SIG_POLICY_VERIFY]
+        )
+        self.w_pub_sig_valid_radiobutton.set_active(
+            sig_policy[gui_misc.SIG_POLICY_REQUIRE_SIGNATURES]
+        )
+        self.w_pub_sig_cert_names_vbox.set_sensitive(False)
 
-                    (self.publishers_apply, "delete_event",
-                     self.__on_publishers_apply_delete_event),
-                    (self.publishers_apply_cancel, "clicked",
-                     self.__on_apply_cancel_clicked),
+        if sig_policy[gui_misc.SIG_POLICY_REQUIRE_NAMES]:
+            self.w_pub_sig_name_radiobutton.set_active(True)
+            self.w_pub_sig_cert_names_vbox.set_sensitive(True)
 
-                    (self.w_pub_cert_add_btn, "clicked",
-                        self.__on_pub_cert_add_clicked),
-                    (self.w_pub_cert_remove_btn, "clicked",
-                        self.__on_pub_cert_remove_clicked),
-                    (self.w_pub_cert_revoke_btn, "clicked",
-                        self.__on_pub_cert_revoke_clicked),
-                    (self.w_pub_cert_reinstate_btn, "clicked",
-                        self.__on_pub_cert_reinstate_clicked),
-                    (self.w_modify_pub_notebook, "switch_page",
-                     self.__on_notebook_change),
+        names = sig_policy[gui_misc.PROP_SIGNATURE_REQUIRED_NAMES]
+        gui_misc.set_signature_policy_names_for_textfield(
+            self.w_pub_sig_name_entry, names
+        )
 
-                    (self.w_pub_sig_ignored_radiobutton, "toggled",
-                        self.__on_pub_sig_radiobutton_toggled),
-                    (self.w_pub_sig_optional_radiobutton, "toggled",
-                        self.__on_pub_sig_radiobutton_toggled),
-                    (self.w_pub_sig_valid_radiobutton, "toggled",
-                        self.__on_pub_sig_radiobutton_toggled),
-                    (self.w_pub_sig_name_radiobutton, "toggled",
-                        self.__on_pub_sig_radiobutton_toggled),
-                    (self.w_pub_sig_view_globpol_button, "clicked",
-                        self.__on_pub_sig_view_globpol_clicked),
-                    ]
-                for widget, signal_name, callback in signals_table:
-                        widget.connect(signal_name, callback)
+    def __fetch_pub_signature_policy(self):
+        pub = self.repository_modify_publisher
+        prop_sig_pol = pub.signature_policy.name
+        prop_sig_req_names = None
+        if gui_misc.PROP_SIGNATURE_REQUIRED_NAMES in pub.properties:
+            prop_sig_req_names = pub.properties[
+                gui_misc.PROP_SIGNATURE_REQUIRED_NAMES
+            ]
+        return gui_misc.create_sig_policy_from_property(
+            prop_sig_pol, prop_sig_req_names
+        )
 
-        def __on_pub_sig_radiobutton_toggled(self, widget):
-                self.w_pub_sig_cert_names_vbox.set_sensitive(
-                    self.w_pub_sig_name_radiobutton.get_active())
+    def __on_notebook_change(self, widget, event, pagenum):
+        if pagenum == MODIFY_NOTEBOOK_CERTIFICATE_PAGE:
+            gobject.idle_add(self.__prepare_pub_certs)
+        elif pagenum == MODIFY_NOTEBOOK_SIG_POLICY_PAGE:
+            gobject.idle_add(self.__prepare_pub_signature_policy)
 
-        def __on_pub_sig_view_globpol_clicked(self, widget):
-                #Preferences Dialog is modal so no need to hide the Modify Dialog
-                self.parent.preferences.show_signature_policy()
+    @staticmethod
+    def __get_pub_cert_liststore():
+        return gtk.ListStore(
+            gobject.TYPE_STRING,  # enumerations.PUBCERT_ORGANIZATION
+            gobject.TYPE_STRING,  # enumerations.PUBCERT_NAME
+            gobject.TYPE_STRING,  # enumerations.PUBCERT_STATUS
+            gobject.TYPE_STRING,  # enumerations.PUBCERT_IPSHASH
+            gobject.TYPE_STRING,  # enumerations.PUBCERT_PATH
+            gobject.TYPE_PYOBJECT,  # enumerations.PUBCERT_XCERT_OBJ
+            gobject.TYPE_BOOLEAN,  # enumerations.PUBCERT_NEW
+        )
 
-        def __update_pub_sig_policy_prop(self, set_props):
-                errors = []
-                try:
-                        pub = self.repository_modify_publisher
-                        if pub != None:
-                                pub.update_props(set_props=set_props)
-                except api_errors.ApiException as e:
-                        errors.append(("", e))
-                return errors
+    @staticmethod
+    def __sort_func(treemodel, iter1, iter2, column):
+        col_val1 = treemodel.get_value(iter1, column)
+        col_val2 = treemodel.get_value(iter2, column)
+        ret = cmp(col_val1, col_val2)
+        if ret != 0:
+            return ret
+        if column == enumerations.PUBCERT_ORGANIZATION:
+            name1 = treemodel.get_value(iter1, enumerations.PUBCERT_NAME)
+            name2 = treemodel.get_value(iter2, enumerations.PUBCERT_NAME)
+            ret = cmp(name1, name2)
+        elif column == enumerations.PUBCERT_NAME:
+            org1 = treemodel.get_value(iter1, enumerations.PUBCERT_ORGANIZATION)
+            org2 = treemodel.get_value(iter2, enumerations.PUBCERT_ORGANIZATION)
+            ret = cmp(org1, org2)
+        return ret
 
-        def __update_pub_sig_policy(self):
-                errors = []
-                orig = self.orig_sig_policy
-                if not orig:
-                        return errors
-                ignore = self.w_pub_sig_ignored_radiobutton.get_active()
-                verify = self.w_pub_sig_optional_radiobutton.get_active()
-                req_sigs = self.w_pub_sig_valid_radiobutton.get_active()
-                req_names = self.w_pub_sig_name_radiobutton.get_active()
-                names = gui_misc.fetch_signature_policy_names_from_textfield(
-                    self.w_pub_sig_name_entry.get_text())
-                set_props = gui_misc.setup_signature_policy_properties(ignore,
-                    verify, req_sigs, req_names, names, orig)
-                if len(set_props) > 0:
-                        errors = self.__update_pub_sig_policy_prop(set_props)
-                return errors
+    def __init_pub_cert_tree_view(self, pub_cert_list):
+        pub_cert_sort_model = gtk.TreeModelSort(pub_cert_list)
+        pub_cert_sort_model.set_sort_column_id(
+            enumerations.PUBCERT_ORGANIZATION, gtk.SORT_ASCENDING
+        )
 
-        def __prepare_pub_signature_policy(self):
-                if self.orig_sig_policy:
-                        return
+        pub_cert_sort_model.set_sort_func(
+            enumerations.PUBCERT_ORGANIZATION,
+            self.__sort_func,
+            enumerations.PUBCERT_ORGANIZATION,
+        )
+        pub_cert_sort_model.set_sort_func(
+            enumerations.PUBCERT_NAME,
+            self.__sort_func,
+            enumerations.PUBCERT_NAME,
+        )
 
-                sig_policy = self.__fetch_pub_signature_policy()
-                self.orig_sig_policy = sig_policy
-                self.w_pub_sig_ignored_radiobutton.set_active(
-                    sig_policy[gui_misc.SIG_POLICY_IGNORE])
-                self.w_pub_sig_optional_radiobutton.set_active(
-                    sig_policy[gui_misc.SIG_POLICY_VERIFY])
-                self.w_pub_sig_valid_radiobutton.set_active(
-                    sig_policy[gui_misc.SIG_POLICY_REQUIRE_SIGNATURES])
-                self.w_pub_sig_cert_names_vbox.set_sensitive(False)
+        # Organization column - sort using custom __sort_func()
+        org_renderer = gtk.CellRendererText()
+        column = gtk.TreeViewColumn(
+            _("Organization"),
+            org_renderer,
+            text=enumerations.PUBCERT_ORGANIZATION,
+        )
+        column.set_expand(False)
+        column.set_sort_column_id(enumerations.PUBCERT_ORGANIZATION)
+        column.set_sort_indicator(True)
+        column.set_resizable(True)
+        self.w_pub_cert_treeview.append_column(column)
 
-                if sig_policy[gui_misc.SIG_POLICY_REQUIRE_NAMES]:
-                        self.w_pub_sig_name_radiobutton.set_active(True)
-                        self.w_pub_sig_cert_names_vbox.set_sensitive(True)
+        # Name column - sort using custom __sort_func()
+        name_renderer = gtk.CellRendererText()
+        column = gtk.TreeViewColumn(
+            _("Name"), name_renderer, text=enumerations.PUBCERT_NAME
+        )
+        column.set_expand(True)
+        column.set_sort_column_id(enumerations.PUBCERT_NAME)
+        column.set_sort_indicator(True)
+        column.set_resizable(True)
+        self.w_pub_cert_treeview.append_column(column)
 
-                names = sig_policy[gui_misc.PROP_SIGNATURE_REQUIRED_NAMES]
-                gui_misc.set_signature_policy_names_for_textfield(
-                    self.w_pub_sig_name_entry, names)
+        # Status column
+        status_renderer = gtk.CellRendererText()
+        column = gtk.TreeViewColumn(
+            _("Status"), status_renderer, text=enumerations.PUBCERT_STATUS
+        )
+        column.set_expand(False)
+        column.set_sort_column_id(enumerations.PUBCERT_STATUS)
+        self.w_pub_cert_treeview.append_column(column)
 
-        def __fetch_pub_signature_policy(self):
-                pub = self.repository_modify_publisher
-                prop_sig_pol = pub.signature_policy.name
-                prop_sig_req_names = None
-                if gui_misc.PROP_SIGNATURE_REQUIRED_NAMES in pub.properties:
-                        prop_sig_req_names = \
-                                pub.properties[gui_misc.PROP_SIGNATURE_REQUIRED_NAMES]
-                return gui_misc.create_sig_policy_from_property(
-                    prop_sig_pol, prop_sig_req_names)
+        self.w_pub_cert_treeview.get_selection().connect(
+            "changed", self.__on_pub_cert_treeview_changed
+        )
+        self.w_pub_cert_treeview.set_model(pub_cert_sort_model)
 
-        def __on_notebook_change(self, widget, event, pagenum):
-                if pagenum == MODIFY_NOTEBOOK_CERTIFICATE_PAGE:
-                        gobject.idle_add(self.__prepare_pub_certs)
-                elif pagenum == MODIFY_NOTEBOOK_SIG_POLICY_PAGE:
-                        gobject.idle_add(self.__prepare_pub_signature_policy)
+    @staticmethod
+    def __get_pub_display_name(pub):
+        display_name = ""
+        if not pub:
+            return display_name
 
-        @staticmethod
-        def __get_pub_cert_liststore():
-                return gtk.ListStore(
-                        gobject.TYPE_STRING,   # enumerations.PUBCERT_ORGANIZATION
-                        gobject.TYPE_STRING,   # enumerations.PUBCERT_NAME
-                        gobject.TYPE_STRING,   # enumerations.PUBCERT_STATUS
-                        gobject.TYPE_STRING,   # enumerations.PUBCERT_IPSHASH
-                        gobject.TYPE_STRING,   # enumerations.PUBCERT_PATH
-                        gobject.TYPE_PYOBJECT, # enumerations.PUBCERT_XCERT_OBJ
-                        gobject.TYPE_BOOLEAN,  # enumerations.PUBCERT_NEW
-                        )
+        name = pub.prefix
+        alias = pub.alias
+        use_name = False
+        use_alias = False
+        if len(name) > 0:
+            use_name = True
+        if alias and len(alias) > 0 and alias != name:
+            use_alias = True
 
-        @staticmethod
-        def __sort_func(treemodel, iter1, iter2, column):
-                col_val1 = treemodel.get_value(iter1, column)
-                col_val2 = treemodel.get_value(iter2, column)
-                ret = cmp(col_val1, col_val2)
-                if ret != 0:
-                        return ret
-                if column == enumerations.PUBCERT_ORGANIZATION:
-                        name1 = treemodel.get_value(iter1,
-                            enumerations.PUBCERT_NAME)
-                        name2 = treemodel.get_value(iter2,
-                            enumerations.PUBCERT_NAME)
-                        ret = cmp(name1, name2)
-                elif column == enumerations.PUBCERT_NAME:
-                        org1 = treemodel.get_value(iter1,
-                            enumerations.PUBCERT_ORGANIZATION)
-                        org2 = treemodel.get_value(iter2,
-                            enumerations.PUBCERT_ORGANIZATION)
-                        ret = cmp(org1, org2)
-                return ret
+        if use_name and not use_alias:
+            display_name = name
+        elif use_name and use_alias:
+            display_name = "%s (%s)" % (name, alias)
+        return display_name
 
-        def __init_pub_cert_tree_view(self, pub_cert_list):
-                pub_cert_sort_model = gtk.TreeModelSort(pub_cert_list)
-                pub_cert_sort_model.set_sort_column_id(enumerations.PUBCERT_ORGANIZATION,
-                    gtk.SORT_ASCENDING)
+    def __prepare_pub_certs(self):
+        if self.pub_certs_setup:
+            return
 
-                pub_cert_sort_model.set_sort_func(enumerations.PUBCERT_ORGANIZATION,
-                    self.__sort_func,
-                    enumerations.PUBCERT_ORGANIZATION)
-                pub_cert_sort_model.set_sort_func(enumerations.PUBCERT_NAME,
-                    self.__sort_func,
-                    enumerations.PUBCERT_NAME)
+        pub = self.repository_modify_publisher
+        if not pub:
+            return
+        sorted_model = self.w_pub_cert_treeview.get_model()
+        selection = self.w_pub_cert_treeview.get_selection()
+        selected_rows = selection.get_selected_rows()
+        self.w_pub_cert_treeview.set_model(None)
+        if not sorted_model:
+            return
+        model = sorted_model.get_model()
+        if not model:
+            return
+        model.clear()
 
-                # Organization column - sort using custom __sort_func()
-                org_renderer = gtk.CellRendererText()
-                column = gtk.TreeViewColumn(_("Organization"),
-                    org_renderer,  text = enumerations.PUBCERT_ORGANIZATION)
-                column.set_expand(False)
-                column.set_sort_column_id(enumerations.PUBCERT_ORGANIZATION)
-                column.set_sort_indicator(True)
-                column.set_resizable(True)
-                self.w_pub_cert_treeview.append_column(column)
+        self.orig_pub_cert_added_dict.clear()
+        self.all_pub_cert_added_dict.clear()
+        self.removed_orig_pub_cert_dict.clear()
 
-                # Name column - sort using custom __sort_func()
-                name_renderer = gtk.CellRendererText()
-                column = gtk.TreeViewColumn(_("Name"),
-                    name_renderer,  text = enumerations.PUBCERT_NAME)
-                column.set_expand(True)
-                column.set_sort_column_id(enumerations.PUBCERT_NAME)
-                column.set_sort_indicator(True)
-                column.set_resizable(True)
-                self.w_pub_cert_treeview.append_column(column)
+        pub_display_name = self.__get_pub_display_name(pub)
+        if pub_display_name != "":
+            self.w_pub_cert_label.set_markup(
+                _("<b>Certificates for publisher %s</b>") % pub_display_name
+            )
+        else:
+            self.w_pub_cert_label.set_markup(_("<b>Publisher certificates</b>"))
 
-                # Status column
-                status_renderer = gtk.CellRendererText()
-                column = gtk.TreeViewColumn(_("Status"),
-                    status_renderer,  text = enumerations.PUBCERT_STATUS)
-                column.set_expand(False)
-                column.set_sort_column_id(enumerations.PUBCERT_STATUS)
-                self.w_pub_cert_treeview.append_column(column)
+        for h in pub.approved_ca_certs:
+            self.__add_cert_to_model(
+                model, pub.get_cert_by_hash(h), h, PUBCERT_APPROVED_STR
+            )
+        for h in pub.revoked_ca_certs:
+            self.__add_cert_to_model(
+                model, pub.get_cert_by_hash(h), h, PUBCERT_REVOKED_STR
+            )
 
-                self.w_pub_cert_treeview.get_selection().connect('changed',
-                    self.__on_pub_cert_treeview_changed)
-                self.w_pub_cert_treeview.set_model(pub_cert_sort_model)
+        self.w_pub_cert_treeview.set_model(sorted_model)
+        if len(pub.revoked_ca_certs) == 0 and len(pub.approved_ca_certs) == 0:
+            self.__set_empty_pub_cert()
+            self.pub_certs_setup = True
+            return
 
-        @staticmethod
-        def __get_pub_display_name(pub):
-                display_name = ""
-                if not pub:
-                        return display_name
+        sel_path = (0,)
+        if len(selected_rows) > 1 and len(selected_rows[1]) > 0:
+            sel_path = selected_rows[1][0]
+        self.__set_pub_cert_selection(sorted_model, sel_path)
+        self.pub_certs_setup = True
 
+    def __add_cert_to_model(
+        self, model, cert, ips_hash, status, path="", scroll_to=False, new=False
+    ):
+        pub = self.repository_modify_publisher
+        if not cert or not pub:
+            return
+        i = cert.get_subject()
+        organization = PUBCERT_NOTAVAILABLE
+        if len(i.get_entries_by_nid(i.nid["O"])) > 0:
+            organization = (
+                i.get_entries_by_nid(i.nid["O"])[0].get_data().as_text()
+            )
+        name = PUBCERT_NOTAVAILABLE
+        if len(i.get_entries_by_nid(i.nid["CN"])) > 0:
+            name = i.get_entries_by_nid(i.nid["CN"])[0].get_data().as_text()
+        if self.all_pub_cert_added_dict.has_key(cert.get_fingerprint("sha1")):
+            err = _(
+                "The publisher certificate:\n  %s\n" "has already been added."
+            ) % self.__get_cert_display_name(cert)
+            gui_misc.error_occurred(
+                None,
+                err,
+                _("Modify Publisher - %s") % self.__get_pub_display_name(pub),
+                gtk.MESSAGE_INFO,
+            )
+            return
+
+        self.all_pub_cert_added_dict[cert.get_fingerprint("sha1")] = ips_hash
+        itr = model.append(
+            [organization, name, status, ips_hash, path, cert, new]
+        )
+        if not new:
+            self.orig_pub_cert_added_dict[ips_hash] = status
+
+        if scroll_to:
+            path = model.get_path(itr)
+            sorted_model = self.w_pub_cert_treeview.get_model()
+            if not sorted_model:
+                return
+            sorted_path = sorted_model.convert_child_path_to_path(path)
+            self.w_pub_cert_treeview.scroll_to_cell(sorted_path)
+            selection = self.w_pub_cert_treeview.get_selection()
+            selection.select_path(sorted_path)
+
+    def __on_pub_cert_treeview_changed(self, treeselection):
+        selection = treeselection.get_selected_rows()
+        pathlist = selection[1]
+        if not pathlist or len(pathlist) == 0:
+            return
+        sorted_model = self.w_pub_cert_treeview.get_model()
+        if not sorted_model:
+            return
+        model = sorted_model.get_model()
+        path = pathlist[0]
+        child_path = sorted_model.convert_path_to_child_path(path)
+        self.__enable_disable_pub_cert_buttons(model, child_path)
+        self.__set_pub_cert_details(model, child_path)
+
+    def __enable_disable_pub_cert_buttons(self, model, path):
+        if not model or not path:
+            return
+        itr = model.get_iter(path)
+        status = model.get_value(itr, enumerations.PUBCERT_STATUS)
+        new = model.get_value(itr, enumerations.PUBCERT_NEW)
+
+        if status == PUBCERT_APPROVED_STR:
+            self.w_pub_cert_revoke_btn.set_sensitive(True)
+            self.w_pub_cert_reinstate_btn.set_sensitive(False)
+        else:
+            self.w_pub_cert_revoke_btn.set_sensitive(False)
+            self.w_pub_cert_reinstate_btn.set_sensitive(True)
+        if new:
+            self.w_pub_cert_revoke_btn.set_sensitive(False)
+            self.w_pub_cert_reinstate_btn.set_sensitive(False)
+        self.w_pub_cert_remove_btn.set_sensitive(True)
+
+    def __set_pub_cert_details(self, model, path):
+        itr = model.get_iter(path)
+        ips_hash = model.get_value(itr, enumerations.PUBCERT_IPSHASH)
+        cert = model.get_value(itr, enumerations.PUBCERT_XCERT_OBJ)
+        new = model.get_value(itr, enumerations.PUBCERT_NEW)
+        if not cert:
+            return
+        details_buffer = self.w_pub_cert_details_textview.get_buffer()
+        details_buffer.set_text("")
+        itr = details_buffer.get_end_iter()
+
+        labs = {}
+        labs["issued_to"] = _("Issued To:")
+        labs["common_name_to"] = gui_misc.PUBCERT_COMMON_NAME
+        labs["org_to"] = gui_misc.PUBCERT_ORGANIZATION
+        labs["org_unit_to"] = gui_misc.PUBCERT_ORGANIZATIONAL_UNIT
+        labs["issued_by"] = _("Issued By:")
+        labs["common_name_by"] = _("  Common Name (CN):")
+        labs["org_by"] = gui_misc.PUBCERT_ORGANIZATION
+        labs["org_unit_by"] = gui_misc.PUBCERT_ORGANIZATIONAL_UNIT
+        labs["validity"] = _("Validity:")
+        labs["issued_on"] = _("  Issued On:")
+        labs["fingerprints"] = _("Fingerprints:")
+        labs["sha1"] = _("  SHA1:")
+        labs["md5"] = _("  MD5:")
+        labs["ips"] = _("  IPS:")
+
+        text = {}
+        text["issued_to"] = ""
+        text["common_name_to"] = ""
+        text["org_to"] = ""
+        text["org_unit_to"] = ""
+        text["issued_by"] = ""
+        text["common_name_by"] = ""
+        text["org_by"] = ""
+        text["org_unit_by"] = ""
+        text["validity"] = ""
+        text["issued_on"] = ""
+        text["fingerprints"] = ""
+        text["sha1"] = ""
+        text["md5"] = ""
+        text["ips"] = ""
+
+        self._set_cert_issuer(text, cert.get_subject(), "to")
+        self._set_cert_issuer(text, cert.get_issuer(), "by")
+
+        eo = cert.get_not_after().get_datetime().date().isoformat()
+        today = datetime.datetime.today().date().isoformat()
+        validity_str = _("Validity:")
+        # TBD: may have an issue here in some locales if Validity string
+        # is very long then would only need one \t.
+        if eo < today:
+            validity_str += _("\t\t EXPIRED")
+        labs["validity"] = validity_str
+
+        io_str = cert.get_not_before().get_datetime().date().strftime("%x")
+        eo_str = cert.get_not_after().get_datetime().date().strftime("%x")
+        labs["issued_on"] += " " + io_str
+        text["issued_on"] = _("Expires On: %s") % eo_str
+
+        sha = cert.get_fingerprint("sha1")
+        md5 = cert.get_fingerprint("md5")
+        text["sha1"] = sha.lower()
+        text["md5"] = md5.lower()
+        text["ips"] = ips_hash.lower()
+
+        added = False
+        reinstated = False
+        if new:
+            if ips_hash == PUBCERT_NOTSET_HASH:
+                added = True
+                reinstated = False
+            else:
+                reinstated = True
+                added = False
+
+        gui_misc.set_pub_cert_details_text(
+            labs, text, self.w_pub_cert_details_textview, added, reinstated
+        )
+
+    @staticmethod
+    def _set_cert_issuer(text, issuer, itype):
+        if len(issuer.get_entries_by_nid(issuer.nid["CN"])) > 0:
+            text["common_name_" + itype] = (
+                issuer.get_entries_by_nid(issuer.nid["CN"])[0]
+                .get_data()
+                .as_text()
+            )
+        if len(issuer.get_entries_by_nid(issuer.nid["O"])) > 0:
+            text["org_" + itype] = (
+                issuer.get_entries_by_nid(issuer.nid["O"])[0]
+                .get_data()
+                .as_text()
+            )
+        if len(issuer.get_entries_by_nid(issuer.nid["OU"])) > 0:
+            text["org_unit_" + itype] = (
+                issuer.get_entries_by_nid(issuer.nid["OU"])[0]
+                .get_data()
+                .as_text()
+            )
+        else:
+            text["org_unit_" + itype] = PUBCERT_NOTAVAILABLE
+
+    def __get_pub_cert_filename(self, title, path=None):
+        if path == None or path == "":
+            path = tempfile.gettempdir()
+        filename = None
+        chooser = gtk.FileChooserDialog(
+            title,
+            self.w_manage_publishers_dialog,
+            gtk.FILE_CHOOSER_ACTION_OPEN,
+            (
+                gtk.STOCK_CANCEL,
+                gtk.RESPONSE_CANCEL,
+                gtk.STOCK_OK,
+                gtk.RESPONSE_OK,
+            ),
+        )
+
+        file_filter = gtk.FileFilter()
+        file_filter.set_name(_("Certificate Files"))
+        file_filter.add_pattern("*.pem")
+        chooser.add_filter(file_filter)
+        chooser.set_current_folder(path)
+
+        response = chooser.run()
+        if response == gtk.RESPONSE_OK:
+            filename = chooser.get_filename()
+        chooser.destroy()
+
+        if filename != None:
+            info = os.path.split(filename)
+            self.gconf.last_add_pubcert_path = info[0]
+        return filename
+
+    def __on_pub_cert_add_clicked(self, widget):
+        filename = self.__get_pub_cert_filename(
+            _("Add Publisher Certificate"), self.gconf.last_add_pubcert_path
+        )
+        if filename == None:
+            return
+        try:
+            cert = self.__get_new_cert(filename)
+            sha = hashlib.sha1(misc.force_bytes(cert.subject)).hexdigest()
+            ips_hash = PUBCERT_NOTSET_HASH
+            status = PUBCERT_APPROVED_STR
+            new = True
+            # Restore orig cert if it was already added but just removed
+            if self.removed_orig_pub_cert_dict.has_key(sha):
+                ips_hash = self.removed_orig_pub_cert_dict[sha]
+                status = self.orig_pub_cert_added_dict[ips_hash]
+                filename = ""
+                new = False
+                del self.removed_orig_pub_cert_dict[sha]
+            sorted_model = self.w_pub_cert_treeview.get_model()
+            if not sorted_model:
+                return
+            model = sorted_model.get_model()
+            self.__add_cert_to_model(
+                model,
+                cert,
+                ips_hash,
+                status,
+                path=filename,
+                scroll_to=True,
+                new=new,
+            )
+        except api_errors.ApiException as e:
+            self.__show_errors([("", e)])
+            return
+
+    @staticmethod
+    def __get_new_cert(filename):
+        cert = None
+        try:
+            with open(filename, "rb") as fh:
+                s = fh.read()
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                raise api_errors.MissingFileArgumentException(filename)
+            elif e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(filename)
+            raise api_errors.ApiException(e)
+        try:
+            cert = x509.load_pem_x509_certificate(s, default_backend())
+        except ValueError as e:
+            raise api_errors.BadFileFormat(
+                _(
+                    "The file:\n"
+                    " %s\nwas expected to be a PEM certificate but it "
+                    "could not be read."
+                )
+                % filename
+            )
+        return cert
+
+    def __on_pub_cert_reinstate_clicked(self, widget):
+        itr, sorted_model = self.__get_selected_pub_cert_itr_model()
+        if not itr or not sorted_model:
+            return
+        model = sorted_model.get_model()
+        child_itr = sorted_model.convert_iter_to_child_iter(None, itr)
+
+        ips_hash = model.get_value(child_itr, enumerations.PUBCERT_IPSHASH)
+        orig_status = ""
+        if self.orig_pub_cert_added_dict.has_key(ips_hash):
+            orig_status = self.orig_pub_cert_added_dict[ips_hash]
+        else:
+            # Should not be able to reinstate new cert, only existing ones
+            return
+        # Originally approved so just reset as there is nothing to do
+        if orig_status == PUBCERT_APPROVED_STR:
+            model.set_value(
+                child_itr, enumerations.PUBCERT_STATUS, PUBCERT_APPROVED_STR
+            )
+            self.__set_pub_cert_details(model, model.get_path(child_itr))
+            self.__enable_disable_pub_cert_buttons(
+                model, model.get_path(child_itr)
+            )
+            return
+
+        filename = self.__get_pub_cert_filename(
+            _("Reinstate Publisher Certificate"),
+            self.gconf.last_add_pubcert_path,
+        )
+        if filename == None:
+            return
+
+        # Check the old cert and new ones match according to the sha fingerprint
+        cert = model.get_value(child_itr, enumerations.PUBCERT_XCERT_OBJ)
+        new_cert = self.__get_new_cert(filename)
+        if cert == None or new_cert == None:
+            # Must have exisitng cert and new one to reinstate
+            return
+        orig_sha = cert.get_fingerprint("sha1")
+        new_sha = hashlib.sha1(misc.force_bytes(new_cert.subject)).hexdigest()
+        if orig_sha != new_sha:
+            pub = self.repository_modify_publisher
+            if not pub:
+                return
+            gui_misc.error_occurred(
+                None,
+                _(
+                    "To reinstate the publisher certificate:\n  %s\n"
+                    "the original certificate file must be selected."
+                )
+                % self.__get_cert_display_name(cert),
+                _("Modify Publisher - %s") % self.__get_pub_display_name(pub),
+                gtk.MESSAGE_INFO,
+            )
+            return
+        # Update model of existing cert which is to be reinstated by
+        # re-adding the cert as new
+        model.set_value(
+            child_itr, enumerations.PUBCERT_STATUS, PUBCERT_APPROVED_STR
+        )
+        model.set_value(child_itr, enumerations.PUBCERT_PATH, filename)
+        model.set_value(child_itr, enumerations.PUBCERT_XCERT_OBJ, new_cert)
+        model.set_value(child_itr, enumerations.PUBCERT_NEW, True)
+        self.__set_pub_cert_details(model, model.get_path(child_itr))
+        self.__enable_disable_pub_cert_buttons(model, model.get_path(child_itr))
+
+    @staticmethod
+    def __get_cert_display_name(cert):
+        cert_display_name = ""
+        if cert == None:
+            return cert_display_name
+        issuer = cert.get_subject()
+        cn = "-"
+        org = "-"
+        ou = "-"
+        if len(issuer.get_entries_by_nid(issuer.nid["CN"])) > 0:
+            cn = (
+                issuer.get_entries_by_nid(issuer.nid["CN"])[0]
+                .get_data()
+                .as_text()
+            )
+        if len(issuer.get_entries_by_nid(issuer.nid["O"])) > 0:
+            org = (
+                issuer.get_entries_by_nid(issuer.nid["O"])[0]
+                .get_data()
+                .as_text()
+            )
+        if len(issuer.get_entries_by_nid(issuer.nid["OU"])) > 0:
+            ou = (
+                issuer.get_entries_by_nid(issuer.nid["OU"])[0]
+                .get_data()
+                .as_text()
+            )
+        else:
+            ou = PUBCERT_NOTAVAILABLE
+
+        if ou != PUBCERT_NOTAVAILABLE:
+            cert_display_name = "%s (CN) %s (O) %s (OU)" % (
+                cn,
+                org,
+                ou,
+            )  # No l10n required
+        else:
+            cert_display_name = "%s (CN) %s (O)" % (cn, org)  # No l10n required
+        return cert_display_name
+
+    def __on_pub_cert_revoke_clicked(self, widget):
+        selection = self.w_pub_cert_treeview.get_selection()
+        if not selection:
+            return
+        selected_rows = selection.get_selected_rows()
+        if not selected_rows or len(selected_rows) < 2:
+            return
+        pathlist = selected_rows[1]
+        if not pathlist or len(pathlist) == 0:
+            return
+        path = pathlist[0]
+        self.__revoked(None, path)
+
+    def __revoked(self, cell, sorted_path):
+        sorted_model = self.w_pub_cert_treeview.get_model()
+        if not sorted_model:
+            return
+        model = sorted_model.get_model()
+        path = sorted_model.convert_path_to_child_path(sorted_path)
+        itr = model.get_iter(path)
+        if not itr:
+            return
+        status = model.get_value(itr, enumerations.PUBCERT_STATUS)
+        if status == PUBCERT_APPROVED_STR:
+            model.set_value(
+                itr, enumerations.PUBCERT_STATUS, PUBCERT_REVOKED_STR
+            )
+            self.__enable_disable_pub_cert_buttons(model, path)
+            self.__set_pub_cert_details(model, path)
+
+    def __on_pub_cert_remove_clicked(self, widget):
+        itr, sorted_model = self.__get_selected_pub_cert_itr_model()
+        if not itr or not sorted_model:
+            return
+        sel_path = sorted_model.get_path(itr)
+        model = sorted_model.get_model()
+        child_itr = sorted_model.convert_iter_to_child_iter(None, itr)
+
+        cert = model.get_value(child_itr, enumerations.PUBCERT_XCERT_OBJ)
+        if self.all_pub_cert_added_dict.has_key(cert.get_fingerprint("sha1")):
+            del self.all_pub_cert_added_dict[cert.get_fingerprint("sha1")]
+
+        new = model.get_value(child_itr, enumerations.PUBCERT_NEW)
+        if not new:
+            sha = cert.get_fingerprint("sha1")
+            ips_hash = model.get_value(child_itr, enumerations.PUBCERT_IPSHASH)
+            self.removed_orig_pub_cert_dict[sha] = ips_hash
+
+        model.remove(child_itr)
+        self.__set_pub_cert_selection(sorted_model, sel_path)
+
+    def __set_pub_cert_selection(self, sorted_model, sel_path):
+        len_smodel = len(sorted_model)
+        if len_smodel == 0:
+            self.__set_empty_pub_cert()
+            return
+        if len_smodel <= sel_path[0]:
+            sel_path = (len_smodel - 1,)
+        if sel_path[0] < 0:
+            sel_path = (0,)
+
+        self.w_pub_cert_treeview.scroll_to_cell(sel_path)
+        selection = self.w_pub_cert_treeview.get_selection()
+        selection.select_path(sel_path)
+
+    def __set_empty_pub_cert(self):
+        details_buffer = self.w_pub_cert_details_textview.get_buffer()
+        details_buffer.set_text("")
+        self.w_pub_cert_remove_btn.set_sensitive(False)
+        self.w_pub_cert_revoke_btn.set_sensitive(False)
+        self.w_pub_cert_reinstate_btn.set_sensitive(False)
+
+    def __get_selected_pub_cert_itr_model(self):
+        return self.__get_fitr_model_from_tree(self.w_pub_cert_treeview)
+
+    def __update_pub_certs(self):
+        errors = []
+        sorted_model = self.w_pub_cert_treeview.get_model()
+        if not sorted_model:
+            return errors
+        model = sorted_model.get_model()
+        if not model:
+            return errors
+
+        updated_pub_cert_dict = {}
+        add_pub_cert_dict = {}
+        iter_next = sorted_model.get_iter_first()
+        while iter_next != None:
+            itr = sorted_model.convert_iter_to_child_iter(None, iter_next)
+            ips_hash = model.get_value(itr, enumerations.PUBCERT_IPSHASH)
+            status = model.get_value(itr, enumerations.PUBCERT_STATUS)
+            path = model.get_value(itr, enumerations.PUBCERT_PATH)
+            new = model.get_value(itr, enumerations.PUBCERT_NEW)
+            # Both new and reinstated certs treated as new and to be added
+            if new:
+                add_pub_cert_dict[path] = True
+            else:
+                updated_pub_cert_dict[ips_hash] = status
+            iter_next = sorted_model.iter_next(iter_next)
+        for ips_hash, status in self.orig_pub_cert_added_dict.items():
+            if not updated_pub_cert_dict.has_key(ips_hash):
+                errors += self.__remove_pub_cert_for_publisher(ips_hash)
+            elif (
+                status != updated_pub_cert_dict[ips_hash]
+                and updated_pub_cert_dict[ips_hash] == PUBCERT_REVOKED_STR
+            ):
+                errors += self.__revoke_pub_cert_for_publisher(ips_hash)
+        # Add and reinstate pub certs for publisher
+        for path in add_pub_cert_dict.keys():
+            errors += self.__add_pub_cert_to_publisher(path)
+
+        return errors
+
+    def __add_pub_cert_to_publisher(self, path):
+        errors = []
+        try:
+            with open(path, "rb") as fh:
+                s = fh.read()
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                errors.append(
+                    ("", api_errors.MissingFileArgumentException(path))
+                )
+            elif e.errno == errno.EACCES:
+                errors.append(("", api_errors.PermissionsException(path)))
+            else:
+                errors.append(("", e))
+        try:
+            pub = self.repository_modify_publisher
+            if pub != None:
+                pub.approve_ca_cert(s)
+        except api_errors.ApiException as e:
+            errors.append(("", e))
+        return errors
+
+    def __revoke_pub_cert_for_publisher(self, ips_hash):
+        errors = []
+        try:
+            pub = self.repository_modify_publisher
+            if pub != None:
+                pub.revoke_ca_cert(ips_hash)
+        except api_errors.ApiException as e:
+            errors.append(("", e))
+        return errors
+
+    def __remove_pub_cert_for_publisher(self, ips_hash):
+        errors = []
+        try:
+            pub = self.repository_modify_publisher
+            if pub != None:
+                pub.unset_ca_cert(ips_hash)
+        except api_errors.ApiException as e:
+            errors.append(("", e))
+        return errors
+
+    def __init_pubs_tree_view(self, publishers_list):
+        publishers_list_filter = publishers_list.filter_new()
+        publishers_list_sort = gtk.TreeModelSort(publishers_list_filter)
+        publishers_list_sort.set_sort_column_id(
+            enumerations.PUBLISHER_PRIORITY_CHANGED, gtk.SORT_ASCENDING
+        )
+        # Name column
+        name_renderer = gtk.CellRendererText()
+        column = gtk.TreeViewColumn(
+            _("Publisher"), name_renderer, text=enumerations.PUBLISHER_NAME
+        )
+        column.set_expand(True)
+        self.w_publishers_treeview.append_column(column)
+        # Alias column
+        alias_renderer = gtk.CellRendererText()
+        alias_renderer.set_property("ellipsize", pango.ELLIPSIZE_END)
+        column = gtk.TreeViewColumn(
+            _("Alias"), alias_renderer, text=enumerations.PUBLISHER_ALIAS
+        )
+        column.set_expand(True)
+        self.w_publishers_treeview.append_column(column)
+        # Enabled column
+        toggle_renderer = gtk.CellRendererToggle()
+        column = gtk.TreeViewColumn(
+            _("Enabled"), toggle_renderer, active=enumerations.PUBLISHER_ENABLED
+        )
+        toggle_renderer.set_property("activatable", True)
+        column.set_expand(False)
+        toggle_renderer.connect("toggled", self.__enable_disable)
+        column.set_cell_data_func(
+            toggle_renderer, self.__toggle_data_function, None
+        )
+        self.w_publishers_treeview.append_column(column)
+        # Sticky column
+        toggle_renderer = gtk.CellRendererToggle()
+        column = gtk.TreeViewColumn(
+            _("Sticky"), toggle_renderer, active=enumerations.PUBLISHER_STICKY
+        )
+        toggle_renderer.set_property("activatable", True)
+        column.set_expand(False)
+        toggle_renderer.connect("toggled", self.__sticky_unsticky)
+        column.set_cell_data_func(
+            toggle_renderer, self.__toggle_data_function, None
+        )
+        self.w_publishers_treeview.append_column(column)
+        publishers_list_filter.set_visible_func(self.__publishers_filter)
+        self.w_publishers_treeview.set_model(publishers_list_sort)
+
+    def __prepare_publisher_list(self, restore_changes=False):
+        sorted_model = self.w_publishers_treeview.get_model()
+        selection = self.w_publishers_treeview.get_selection()
+        selected_rows = selection.get_selected_rows()
+        self.w_publishers_treeview.set_model(None)
+        try:
+            pubs = self.api_o.get_publishers(duplicate=True)
+        except api_errors.ApiException as e:
+            self.__show_errors([("", e)])
+            return
+        if not sorted_model:
+            return
+        filtered_model = sorted_model.get_model()
+        model = filtered_model.get_model()
+
+        if restore_changes == False:
+            self.no_changes = 0
+            self.priority_changes = []
+            model.clear()
+
+            j = 0
+            for pub in pubs:
                 name = pub.prefix
                 alias = pub.alias
-                use_name = False
-                use_alias = False
-                if len(name) > 0:
-                        use_name = True
-                if alias and len(alias) > 0 and alias != name:
-                        use_alias = True
+                # BUG: alias should be either "None" or None.
+                # in the list it's "None", but when adding pub it's None
+                if not alias or len(alias) == 0 or alias == "None":
+                    alias = name
+                publisher_row = [
+                    j,
+                    j,
+                    name,
+                    alias,
+                    not pub.disabled,
+                    pub.sticky,
+                    pub,
+                    False,
+                    False,
+                    False,
+                ]
+                model.insert(j, publisher_row)
+                j += 1
+        else:
+            j = 0
+            for publisher_row in model:
+                pub = pubs[j]
+                name = pub.prefix
+                alias = pub.alias
+                if not alias or len(alias) == 0 or alias == "None":
+                    alias = name
+                publisher_row[enumerations.PUBLISHER_ALIAS] = alias
+                publisher_row[enumerations.PUBLISHER_OBJECT] = pub
+                j += 1
+            # We handle here the case where a publisher was added
+            if self.new_pub:
+                pub = self.new_pub
+                name = pub.prefix
+                alias = pub.alias
+                if not alias or len(alias) == 0 or alias == "None":
+                    alias = name
+                publisher_row = [
+                    j,
+                    j,
+                    name,
+                    alias,
+                    not pub.disabled,
+                    pub.sticky,
+                    pub,
+                    False,
+                    False,
+                    False,
+                ]
+                model.insert(j, publisher_row)
 
-                if use_name and not use_alias:
-                        display_name = name
-                elif use_name and use_alias:
-                        display_name = "%s (%s)" % (name, alias)
-                return display_name
+        self.w_publishers_treeview.set_model(sorted_model)
+        if len(sorted_model) == 0:
+            self.__set_empty_pub_list()
 
-        def __prepare_pub_certs(self):
-                if self.pub_certs_setup:
-                        return
-
-                pub = self.repository_modify_publisher
-                if not pub:
-                        return
-                sorted_model = self.w_pub_cert_treeview.get_model()
-                selection = self.w_pub_cert_treeview.get_selection()
-                selected_rows = selection.get_selected_rows()
-                self.w_pub_cert_treeview.set_model(None)
-                if not sorted_model:
-                        return
-                model = sorted_model.get_model()
-                if not model:
-                        return
-                model.clear()
-
-                self.orig_pub_cert_added_dict.clear()
-                self.all_pub_cert_added_dict.clear()
-                self.removed_orig_pub_cert_dict.clear()
-
-                pub_display_name = self.__get_pub_display_name(pub)
-                if pub_display_name != "":
-                        self.w_pub_cert_label.set_markup(
-                            _("<b>Certificates for publisher %s</b>") % pub_display_name)
-                else:
-                        self.w_pub_cert_label.set_markup(
-                            _("<b>Publisher certificates</b>"))
-
-                for h in pub.approved_ca_certs:
-                        self.__add_cert_to_model(model,
-                            pub.get_cert_by_hash(h), h, PUBCERT_APPROVED_STR)
-                for h in pub.revoked_ca_certs:
-                        self.__add_cert_to_model(model,
-                            pub.get_cert_by_hash(h), h, PUBCERT_REVOKED_STR)
-
-                self.w_pub_cert_treeview.set_model(sorted_model)
-                if len(pub.revoked_ca_certs) == 0 and len(pub.approved_ca_certs) == 0:
-                        self.__set_empty_pub_cert()
-                        self.pub_certs_setup = True
-                        return
-
-                sel_path = (0,)
+        if restore_changes:
+            if self.new_pub:
+                self.__select_last_publisher()
+                self.new_pub = None
+            else:
+                # We do have gtk.SELECTION_SINGLE mode, so if exists, we are
+                # interested only in the first selected path.
                 if len(selected_rows) > 1 and len(selected_rows[1]) > 0:
-                        sel_path = selected_rows[1][0]
-                self.__set_pub_cert_selection(sorted_model, sel_path)
-                self.pub_certs_setup = True
+                    self.w_publishers_treeview.scroll_to_cell(
+                        selected_rows[1][0]
+                    )
+                    selection.select_path(selected_rows[1][0])
 
-        def __add_cert_to_model(self, model, cert, ips_hash, status, path = "",
-            scroll_to=False, new=False):
-                pub = self.repository_modify_publisher
-                if not cert or not pub:
-                        return
-                i = cert.get_subject()
-                organization = PUBCERT_NOTAVAILABLE
-                if len(i.get_entries_by_nid(i.nid["O"])) > 0:
-                        organization = i.get_entries_by_nid(
-                            i.nid["O"])[0].get_data().as_text()
-                name = PUBCERT_NOTAVAILABLE
-                if len(i.get_entries_by_nid(i.nid["CN"])) > 0:
-                        name = i.get_entries_by_nid(
-                            i.nid["CN"])[0].get_data().as_text()
-                if self.all_pub_cert_added_dict.has_key(cert.get_fingerprint('sha1')):
-                        err = _("The publisher certificate:\n  %s\n"
-                            "has already been added.") % \
-                            self.__get_cert_display_name(cert)
-                        gui_misc.error_occurred(None, err,
-                            _("Modify Publisher - %s") % self.__get_pub_display_name(pub),
-                            gtk.MESSAGE_INFO)
-                        return
+    def __set_empty_pub_list(self):
+        details_buffer = self.w_manage_publishers_details.get_buffer()
+        details_buffer.set_text("")
+        self.w_manage_modify_btn.set_sensitive(False)
+        self.w_manage_remove_btn.set_sensitive(False)
+        self.w_manage_up_btn.set_sensitive(False)
+        self.w_manage_down_btn.set_sensitive(False)
 
-                self.all_pub_cert_added_dict[cert.get_fingerprint('sha1')] = ips_hash
-                itr = model.append(
-                    [organization, name, status, ips_hash, path, cert, new])
-                if not new:
-                        self.orig_pub_cert_added_dict[ips_hash] = status
+    def __select_last_publisher(self):
+        sorted_model = self.w_publishers_treeview.get_model()
+        itr = sorted_model.get_iter_first()
+        next_itr = sorted_model.iter_next(itr)
+        while next_itr != None:
+            itr = next_itr
+            next_itr = sorted_model.iter_next(itr)
+        path = sorted_model.get_path(itr)
+        self.w_publishers_treeview.scroll_to_cell(path)
+        self.w_publishers_treeview.get_selection().select_path(path)
 
-                if scroll_to:
-                        path = model.get_path(itr)
-                        sorted_model = self.w_pub_cert_treeview.get_model()
-                        if not sorted_model:
-                                return
-                        sorted_path = sorted_model.convert_child_path_to_path(path)
-                        self.w_pub_cert_treeview.scroll_to_cell(sorted_path)
-                        selection = self.w_pub_cert_treeview.get_selection()
-                        selection.select_path(sorted_path)
+    def __validate_url(self, url_widget, w_ssl_key=None, w_ssl_cert=None):
+        self.__validate_url_generic(
+            url_widget,
+            self.w_add_error_label,
+            self.w_publisher_add_button,
+            self.is_alias_valid,
+            w_ssl_label=self.w_add_sslerror_label,
+            w_ssl_key=w_ssl_key,
+            w_ssl_cert=w_ssl_cert,
+        )
 
-        def __on_pub_cert_treeview_changed(self, treeselection):
-                selection = treeselection.get_selected_rows()
-                pathlist = selection[1]
-                if not pathlist or len(pathlist) == 0:
-                        return
-                sorted_model = self.w_pub_cert_treeview.get_model()
-                if not sorted_model:
-                        return
-                model = sorted_model.get_model()
-                path = pathlist[0]
-                child_path = sorted_model.convert_path_to_child_path(path)
-                self.__enable_disable_pub_cert_buttons(model, child_path)
-                self.__set_pub_cert_details(model, child_path)
+    def __validate_url_generic(
+        self,
+        w_url_text,
+        w_error_label,
+        w_action_button,
+        alias_valid=False,
+        function=None,
+        w_ssl_label=None,
+        w_ssl_key=None,
+        w_ssl_cert=None,
+    ):
+        ssl_key = None
+        ssl_cert = None
+        ssl_error = None
+        ssl_valid = True
+        url = w_url_text.get_text()
+        self.is_url_valid, self.url_err = self.__is_url_valid(url)
+        if not self.webinstall_new:
+            self.__reset_error_label()
+        if w_ssl_label:
+            w_ssl_label.set_sensitive(False)
+            w_ssl_label.show()
+        valid_url = False
+        valid_func = True
+        if self.is_url_valid:
+            if alias_valid:
+                valid_url = True
+            else:
+                if self.name_error != None:
+                    self.__show_error_label_with_format(
+                        w_error_label, self.name_error
+                    )
+        else:
+            if self.url_err != None:
+                self.__show_error_label_with_format(w_error_label, self.url_err)
+        if w_ssl_key != None and w_ssl_cert != None:
+            if w_ssl_key:
+                ssl_key = w_ssl_key.get_text()
+            if w_ssl_cert:
+                ssl_cert = w_ssl_cert.get_text()
+            ssl_valid, ssl_error = self.__validate_ssl_key_cert(
+                url, ssl_key, ssl_cert, ignore_ssl_check_for_not_https=True
+            )
+            self.__update_repository_dialog_width(ssl_error)
+            if ssl_error != None and w_ssl_label:
+                self.__show_error_label_with_format(w_ssl_label, ssl_error)
+            elif w_ssl_label:
+                w_ssl_label.hide()
+        if function != None:
+            valid_func = function()
+        w_action_button.set_sensitive(valid_url and valid_func and ssl_valid)
 
-        def __enable_disable_pub_cert_buttons(self, model, path):
-                if not model or not path:
-                        return
-                itr = model.get_iter(path)
-                status = model.get_value(itr, enumerations.PUBCERT_STATUS)
-                new = model.get_value(itr, enumerations.PUBCERT_NEW)
+    def __validate_alias_addpub(
+        self, ok_btn, name_widget, url_widget, error_label, function=None
+    ):
+        valid_btn = False
+        valid_func = True
+        name = name_widget.get_text()
+        self.is_alias_valid = self.__is_alias_valid(name)
+        self.__reset_error_label()
+        if self.is_alias_valid:
+            if self.is_url_valid:
+                valid_btn = True
+            else:
+                if self.url_err == None:
+                    self.__validate_url(
+                        url_widget,
+                        w_ssl_key=self.w_key_entry,
+                        w_ssl_cert=self.w_cert_entry,
+                    )
+                if self.url_err != None:
+                    self.__show_error_label_with_format(
+                        error_label, self.url_err
+                    )
+        else:
+            if self.name_error != None:
+                self.__show_error_label_with_format(
+                    error_label, self.name_error
+                )
+        if function != None:
+            valid_func = function()
+        ok_btn.set_sensitive(valid_btn and valid_func)
 
-                if status == PUBCERT_APPROVED_STR:
-                        self.w_pub_cert_revoke_btn.set_sensitive(True)
-                        self.w_pub_cert_reinstate_btn.set_sensitive(False)
+    def __is_alias_valid(self, name):
+        self.name_error = None
+        if len(name) == 0:
+            return True
+        try:
+            publisher.Publisher(prefix=name)
+        except api_errors.BadPublisherPrefix as e:
+            self.name_error = _("Alias contains invalid characters")
+            return False
+        try:
+            self.api_o.get_publisher(prefix=name)
+            self.name_error = _("Alias already in use")
+            return False
+        except api_errors.UnknownPublisher as e:
+            return True
+        except api_errors.ApiException as e:
+            self.__show_errors([("", e)])
+            return False
+
+    def __get_selected_publisher_itr_model(self):
+        itr, sorted_model = self.__get_fitr_model_from_tree(
+            self.w_publishers_treeview
+        )
+        if itr == None or sorted_model == None:
+            return (None, None)
+        sorted_path = sorted_model.get_path(itr)
+        filter_path = sorted_model.convert_path_to_child_path(sorted_path)
+        filter_model = sorted_model.get_model()
+        path = filter_model.convert_path_to_child_path(filter_path)
+        model = filter_model.get_model()
+        itr = model.get_iter(path)
+        return (itr, model)
+
+    def __get_selected_mirror_itr_model(self):
+        return self.__get_fitr_model_from_tree(
+            self.modify_repo_mirrors_treeview
+        )
+
+    def __get_selected_origin_itr_model(self):
+        return self.__get_fitr_model_from_tree(
+            self.modify_repo_origins_treeview
+        )
+
+    def __modify_publisher_dialog(self, pub):
+        self.orig_sig_policy = {}
+        self.pub_certs_setup = False
+
+        gui_misc.set_modal_and_transient(
+            self.w_modify_repository_dialog, self.w_manage_publishers_dialog
+        )
+        try:
+            self.repository_modify_publisher = self.api_o.get_publisher(
+                prefix=pub.prefix, alias=pub.prefix, duplicate=True
+            )
+        except api_errors.ApiException as e:
+            self.__show_errors([("", e)])
+            return
+        updated_modify_repository = self.__update_modify_repository_dialog(
+            True, True, True, True
+        )
+
+        self.w_modify_repository_dialog.set_size_request(
+            MODIFY_DIALOG_WIDTH_DEFAULT, -1
+        )
+
+        if updated_modify_repository:
+            self.w_modify_repository_dialog.set_title(
+                _("Modify Publisher - %s") % self.__get_pub_display_name(pub)
+            )
+            self.w_modify_repository_dialog.show_all()
+
+        pagenum = self.w_modify_pub_notebook.get_current_page()
+        if pagenum == MODIFY_NOTEBOOK_CERTIFICATE_PAGE:
+            gobject.idle_add(self.__prepare_pub_certs)
+        elif pagenum == MODIFY_NOTEBOOK_SIG_POLICY_PAGE:
+            gobject.idle_add(self.__prepare_pub_signature_policy)
+
+    def __update_repository_dialog_width(self, ssl_error):
+        if ssl_error == None:
+            self.w_modify_repository_dialog.set_size_request(
+                MODIFY_DIALOG_WIDTH_DEFAULT, -1
+            )
+            return
+
+        style = self.w_repositorymodify_name.get_style()
+        font_size_in_pango_unit = style.font_desc.get_size()
+        font_size_in_pixel = font_size_in_pango_unit / pango.SCALE
+        ssl_error_len = len(unicode(ssl_error)) * font_size_in_pixel
+        if ssl_error_len > MODIFY_DIALOG_SSL_WIDTH_DEFAULT:
+            new_dialog_width = ssl_error_len * (
+                float(MODIFY_DIALOG_WIDTH_DEFAULT)
+                / MODIFY_DIALOG_SSL_WIDTH_DEFAULT
+            )
+            self.w_modify_repository_dialog.set_size_request(
+                int(new_dialog_width), -1
+            )
+        else:
+            self.w_modify_repository_dialog.set_size_request(
+                MODIFY_DIALOG_WIDTH_DEFAULT, -1
+            )
+
+    def __update_modify_repository_dialog(
+        self,
+        update_alias=False,
+        update_mirrors=False,
+        update_origins=False,
+        update_ssl=False,
+    ):
+        if not self.repository_modify_publisher:
+            return False
+        pub = self.repository_modify_publisher
+        selected_repo = pub.repository
+        prefix = ""
+        ssl_cert = ""
+        ssl_key = ""
+
+        if pub.prefix and len(pub.prefix) > 0:
+            prefix = pub.prefix
+        self.w_repositorymodify_name.set_text(prefix)
+
+        if update_alias:
+            alias = ""
+            if pub.alias and len(pub.alias) > 0 and pub.alias != "None":
+                alias = pub.alias
+            self.w_modify_pub_alias.set_text(alias)
+
+        if update_mirrors or update_ssl:
+            if update_mirrors:
+                insert_count = 0
+                mirrors_list = self.__get_mirrors_origins_liststore()
+            for mirror in selected_repo.mirrors:
+                if mirror.ssl_cert:
+                    ssl_cert = mirror.ssl_cert
+                if mirror.ssl_key:
+                    ssl_key = mirror.ssl_key
+                if update_mirrors:
+                    mirror_uri = [mirror.uri]
+                    mirrors_list.insert(insert_count, mirror_uri)
+                    insert_count += 1
+            if update_mirrors:
+                self.modify_repo_mirrors_treeview.set_model(mirrors_list)
+                if len(selected_repo.mirrors) > 0:
+                    self.w_repositorymirror_expander.set_expanded(True)
                 else:
-                        self.w_pub_cert_revoke_btn.set_sensitive(False)
-                        self.w_pub_cert_reinstate_btn.set_sensitive(True)
-                if new:
-                        self.w_pub_cert_revoke_btn.set_sensitive(False)
-                        self.w_pub_cert_reinstate_btn.set_sensitive(False)
-                self.w_pub_cert_remove_btn.set_sensitive(True)
-
-        def __set_pub_cert_details(self, model, path):
-                itr = model.get_iter(path)
-                ips_hash = model.get_value(itr, enumerations.PUBCERT_IPSHASH)
-                cert = model.get_value(itr, enumerations.PUBCERT_XCERT_OBJ)
-                new = model.get_value(itr, enumerations.PUBCERT_NEW)
-                if not cert:
-                        return
-                details_buffer = self.w_pub_cert_details_textview.get_buffer()
-                details_buffer.set_text("")
-                itr = details_buffer.get_end_iter()
-
-                labs = {}
-                labs["issued_to"] = _("Issued To:")
-                labs["common_name_to"] = gui_misc.PUBCERT_COMMON_NAME
-                labs["org_to"] = gui_misc.PUBCERT_ORGANIZATION
-                labs["org_unit_to"] = gui_misc.PUBCERT_ORGANIZATIONAL_UNIT
-                labs["issued_by"] = _("Issued By:")
-                labs["common_name_by"] = _("  Common Name (CN):")
-                labs["org_by"] = gui_misc.PUBCERT_ORGANIZATION
-                labs["org_unit_by"] = gui_misc.PUBCERT_ORGANIZATIONAL_UNIT
-                labs["validity"] = _("Validity:")
-                labs["issued_on"] = _("  Issued On:")
-                labs["fingerprints"] = _("Fingerprints:")
-                labs["sha1"] = _("  SHA1:")
-                labs["md5"] = _("  MD5:")
-                labs["ips"] = _("  IPS:")
-
-                text = {}
-                text["issued_to"] = ""
-                text["common_name_to"] = ""
-                text["org_to"] = ""
-                text["org_unit_to"] = ""
-                text["issued_by"] = ""
-                text["common_name_by"] = ""
-                text["org_by"] = ""
-                text["org_unit_by"] = ""
-                text["validity"] = ""
-                text["issued_on"] = ""
-                text["fingerprints"] = ""
-                text["sha1"] = ""
-                text["md5"] = ""
-                text["ips"] = ""
-
-                self._set_cert_issuer(text, cert.get_subject(), "to")
-                self._set_cert_issuer(text, cert.get_issuer(), "by")
-
-                eo = cert.get_not_after().get_datetime().date().isoformat()
-                today = datetime.datetime.today().date().isoformat()
-                validity_str = _("Validity:")
-                #TBD: may have an issue here in some locales if Validity string
-                #is very long then would only need one \t.
-                if eo < today:
-                        validity_str += _("\t\t EXPIRED")
-                labs["validity"] = validity_str
-
-                io_str = cert.get_not_before().get_datetime().date().strftime("%x")
-                eo_str = cert.get_not_after().get_datetime().date().strftime("%x")
-                labs["issued_on"] += " " + io_str
-                text["issued_on"] = _("Expires On: %s") % eo_str
-
-                sha = cert.get_fingerprint('sha1')
-                md5 = cert.get_fingerprint('md5')
-                text["sha1"] = sha.lower()
-                text["md5"] = md5.lower()
-                text["ips"] = ips_hash.lower()
-
-                added = False
-                reinstated = False
-                if new:
-                        if ips_hash == PUBCERT_NOTSET_HASH:
-                                added = True
-                                reinstated = False
-                        else:
-                                reinstated = True
-                                added = False
-
-                gui_misc.set_pub_cert_details_text(labs, text,
-                    self.w_pub_cert_details_textview, added, reinstated)
-
-        @staticmethod
-        def _set_cert_issuer(text, issuer, itype):
-                if len(issuer.get_entries_by_nid(issuer.nid["CN"])) > 0:
-                        text["common_name_" + itype] = issuer.get_entries_by_nid(
-                                issuer.nid["CN"])[0].get_data().as_text()
-                if len(issuer.get_entries_by_nid(issuer.nid["O"])) > 0:
-                        text["org_" + itype] = issuer.get_entries_by_nid(
-                                issuer.nid["O"])[0].get_data().as_text()
-                if len(issuer.get_entries_by_nid(issuer.nid["OU"])) > 0:
-                        text["org_unit_" + itype] = issuer.get_entries_by_nid(
-                                issuer.nid["OU"])[0].get_data().as_text()
-                else:
-                        text["org_unit_" + itype] = PUBCERT_NOTAVAILABLE
-
-        def __get_pub_cert_filename(self, title, path = None):
-                if path == None or path == "":
-                        path = tempfile.gettempdir()
-                filename = None
-                chooser = gtk.FileChooserDialog(title,
-                    self.w_manage_publishers_dialog,
-                    gtk.FILE_CHOOSER_ACTION_OPEN,
-                    (gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                    gtk.STOCK_OK, gtk.RESPONSE_OK))
-
-                file_filter = gtk.FileFilter()
-                file_filter.set_name(_("Certificate Files"))
-                file_filter.add_pattern("*.pem")
-                chooser.add_filter(file_filter)
-                chooser.set_current_folder(path)
-
-                response = chooser.run()
-                if response == gtk.RESPONSE_OK:
-                        filename = chooser.get_filename()
-                chooser.destroy()
-
-                if filename != None:
-                        info = os.path.split(filename)
-                        self.gconf.last_add_pubcert_path = info[0]
-                return filename
-
-        def __on_pub_cert_add_clicked(self, widget):
-                filename = self.__get_pub_cert_filename(
-                    _("Add Publisher Certificate"),
-                    self.gconf.last_add_pubcert_path)
-                if filename == None:
-                        return
-                try:
-                        cert = self.__get_new_cert(filename)
-                        sha = hashlib.sha1(
-                            misc.force_bytes(cert.subject)).hexdigest()
-                        ips_hash = PUBCERT_NOTSET_HASH
-                        status = PUBCERT_APPROVED_STR
-                        new = True
-                        #Restore orig cert if it was already added but just removed
-                        if self.removed_orig_pub_cert_dict.has_key(sha):
-                                ips_hash = self.removed_orig_pub_cert_dict[sha]
-                                status = self.orig_pub_cert_added_dict[ips_hash]
-                                filename = ""
-                                new = False
-                                del self.removed_orig_pub_cert_dict[sha]
-                        sorted_model = self.w_pub_cert_treeview.get_model()
-                        if not sorted_model:
-                                return
-                        model = sorted_model.get_model()
-                        self.__add_cert_to_model(model, cert, ips_hash, status,
-                            path=filename, scroll_to=True, new=new)
-                except api_errors.ApiException as e:
-                        self.__show_errors([("", e)])
-                        return
-
-        @staticmethod
-        def __get_new_cert(filename):
-                cert = None
-                try:
-                        with open(filename, "rb") as fh:
-                                s = fh.read()
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                raise api_errors.MissingFileArgumentException(
-                                    filename)
-                        elif e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    filename)
-                        raise api_errors.ApiException(e)
-                try:
-                        cert = x509.load_pem_x509_certificate(s,
-                            default_backend())
-                except ValueError as e:
-                        raise api_errors.BadFileFormat(_("The file:\n"
-                            " %s\nwas expected to be a PEM certificate but it "
-                            "could not be read.") % filename)
-                return cert
-
-        def __on_pub_cert_reinstate_clicked(self, widget):
-                itr, sorted_model = self.__get_selected_pub_cert_itr_model()
-                if not itr or not sorted_model:
-                        return
-                model = sorted_model.get_model()
-                child_itr = sorted_model.convert_iter_to_child_iter(None, itr)
-
-                ips_hash = model.get_value(child_itr, enumerations.PUBCERT_IPSHASH)
-                orig_status = ""
-                if self.orig_pub_cert_added_dict.has_key(ips_hash):
-                        orig_status = self.orig_pub_cert_added_dict[ips_hash]
-                else:
-                        #Should not be able to reinstate new cert, only existing ones
-                        return
-                #Originally approved so just reset as there is nothing to do
-                if orig_status == PUBCERT_APPROVED_STR:
-                        model.set_value(child_itr,
-                            enumerations.PUBCERT_STATUS,
-                            PUBCERT_APPROVED_STR)
-                        self.__set_pub_cert_details(model,
-                            model.get_path(child_itr))
-                        self.__enable_disable_pub_cert_buttons(model,
-                            model.get_path(child_itr))
-                        return
-
-                filename = self.__get_pub_cert_filename(
-                    _("Reinstate Publisher Certificate"),
-                    self.gconf.last_add_pubcert_path)
-                if filename == None:
-                        return
-
-                #Check the old cert and new ones match according to the sha fingerprint
-                cert = model.get_value(child_itr, enumerations.PUBCERT_XCERT_OBJ)
-                new_cert = self.__get_new_cert(filename)
-                if cert == None or new_cert == None:
-                        #Must have exisitng cert and new one to reinstate
-                        return
-                orig_sha = cert.get_fingerprint('sha1')
-                new_sha = hashlib.sha1(
-                    misc.force_bytes(new_cert.subject)).hexdigest()
-                if orig_sha != new_sha:
-                        pub = self.repository_modify_publisher
-                        if not pub:
-                                return
-                        gui_misc.error_occurred(None,
-                            _("To reinstate the publisher certificate:\n  %s\n"
-                            "the original certificate file must be selected.") %
-                            self.__get_cert_display_name(cert),
-                            _("Modify Publisher - %s") % self.__get_pub_display_name(pub),
-                            gtk.MESSAGE_INFO)
-                        return
-                #Update model of existing cert which is to be reinstated by
-                #re-adding the cert as new
-                model.set_value(child_itr, enumerations.PUBCERT_STATUS,
-                    PUBCERT_APPROVED_STR)
-                model.set_value(child_itr, enumerations.PUBCERT_PATH, filename)
-                model.set_value(child_itr, enumerations.PUBCERT_XCERT_OBJ, new_cert)
-                model.set_value(child_itr, enumerations.PUBCERT_NEW, True)
-                self.__set_pub_cert_details(model, model.get_path(child_itr))
-                self.__enable_disable_pub_cert_buttons(model,
-                    model.get_path(child_itr))
-
-        @staticmethod
-        def __get_cert_display_name(cert):
-                cert_display_name = ""
-                if cert == None:
-                        return cert_display_name
-                issuer = cert.get_subject()
-                cn = "-"
-                org = "-"
-                ou = "-"
-                if len(issuer.get_entries_by_nid(issuer.nid["CN"])) > 0:
-                        cn = issuer.get_entries_by_nid(
-                                issuer.nid["CN"])[0].get_data().as_text()
-                if len(issuer.get_entries_by_nid(issuer.nid["O"])) > 0:
-                        org = issuer.get_entries_by_nid(
-                                issuer.nid["O"])[0].get_data().as_text()
-                if len(issuer.get_entries_by_nid(issuer.nid["OU"])) > 0:
-                        ou = issuer.get_entries_by_nid(
-                                issuer.nid["OU"])[0].get_data().as_text()
-                else:
-                        ou = PUBCERT_NOTAVAILABLE
-
-                if ou != PUBCERT_NOTAVAILABLE:
-                        cert_display_name =  \
-                                "%s (CN) %s (O) %s (OU)" % (cn, org, ou) #No l10n required
-                else:
-                        cert_display_name =  "%s (CN) %s (O)" % (cn, org)#No l10n required
-                return cert_display_name
-
-        def __on_pub_cert_revoke_clicked(self, widget):
-                selection = self.w_pub_cert_treeview.get_selection()
-                if not selection:
-                        return
-                selected_rows = selection.get_selected_rows()
-                if not selected_rows or len(selected_rows) < 2:
-                        return
-                pathlist = selected_rows[1]
-                if not pathlist or len(pathlist) == 0:
-                        return
-                path = pathlist[0]
-                self.__revoked(None, path)
-
-
-        def __revoked(self, cell, sorted_path):
-                sorted_model = self.w_pub_cert_treeview.get_model()
-                if not sorted_model:
-                        return
-                model = sorted_model.get_model()
-                path = sorted_model.convert_path_to_child_path(sorted_path)
-                itr = model.get_iter(path)
-                if not itr:
-                        return
-                status = model.get_value(itr, enumerations.PUBCERT_STATUS)
-                if status == PUBCERT_APPROVED_STR:
-                        model.set_value(itr, enumerations.PUBCERT_STATUS,
-                            PUBCERT_REVOKED_STR)
-                        self.__enable_disable_pub_cert_buttons(model, path)
-                        self.__set_pub_cert_details(model, path)
-
-        def __on_pub_cert_remove_clicked(self, widget):
-                itr, sorted_model = self.__get_selected_pub_cert_itr_model()
-                if not itr or not sorted_model:
-                        return
-                sel_path = sorted_model.get_path(itr)
-                model = sorted_model.get_model()
-                child_itr = sorted_model.convert_iter_to_child_iter(None, itr)
-
-                cert = model.get_value(child_itr, enumerations.PUBCERT_XCERT_OBJ)
-                if self.all_pub_cert_added_dict.has_key(cert.get_fingerprint('sha1')):
-                        del self.all_pub_cert_added_dict[cert.get_fingerprint('sha1')]
-
-                new = model.get_value(child_itr, enumerations.PUBCERT_NEW)
-                if not new:
-                        sha = cert.get_fingerprint('sha1')
-                        ips_hash = model.get_value(child_itr,
-                            enumerations.PUBCERT_IPSHASH)
-                        self.removed_orig_pub_cert_dict[sha] = ips_hash
-
-                model.remove(child_itr)
-                self.__set_pub_cert_selection(sorted_model, sel_path)
-
-        def __set_pub_cert_selection(self, sorted_model, sel_path):
-                len_smodel = len(sorted_model)
-                if len_smodel == 0:
-                        self.__set_empty_pub_cert()
-                        return
-                if len_smodel <= sel_path[0]:
-                        sel_path = (len_smodel - 1,)
-                if sel_path[0] < 0:
-                        sel_path = (0,)
-
-                self.w_pub_cert_treeview.scroll_to_cell(sel_path)
-                selection = self.w_pub_cert_treeview.get_selection()
-                selection.select_path(sel_path)
-
-        def __set_empty_pub_cert(self):
-                details_buffer = self.w_pub_cert_details_textview.get_buffer()
-                details_buffer.set_text("")
-                self.w_pub_cert_remove_btn.set_sensitive(False)
-                self.w_pub_cert_revoke_btn.set_sensitive(False)
-                self.w_pub_cert_reinstate_btn.set_sensitive(False)
-
-        def __get_selected_pub_cert_itr_model(self):
-                return self.__get_fitr_model_from_tree(self.w_pub_cert_treeview)
-
-        def __update_pub_certs(self):
-                errors = []
-                sorted_model = self.w_pub_cert_treeview.get_model()
-                if not sorted_model:
-                        return errors
-                model = sorted_model.get_model()
-                if not model:
-                        return errors
-
-                updated_pub_cert_dict = {}
-                add_pub_cert_dict = {}
-                iter_next = sorted_model.get_iter_first()
-                while iter_next != None:
-                        itr = sorted_model.convert_iter_to_child_iter(None, iter_next)
-                        ips_hash = model.get_value(itr, enumerations.PUBCERT_IPSHASH)
-                        status = model.get_value(itr, enumerations.PUBCERT_STATUS)
-                        path = model.get_value(itr, enumerations.PUBCERT_PATH)
-                        new = model.get_value(itr, enumerations.PUBCERT_NEW)
-                        #Both new and reinstated certs treated as new and to be added
-                        if new:
-                                add_pub_cert_dict[path] = True
-                        else:
-                                updated_pub_cert_dict[ips_hash] = status
-                        iter_next = sorted_model.iter_next(iter_next)
-                for ips_hash, status in self.orig_pub_cert_added_dict.items():
-                        if not updated_pub_cert_dict.has_key(ips_hash):
-                                errors += self.__remove_pub_cert_for_publisher(ips_hash)
-                        elif status != updated_pub_cert_dict[ips_hash] and \
-                                updated_pub_cert_dict[ips_hash] == PUBCERT_REVOKED_STR:
-                                errors += self.__revoke_pub_cert_for_publisher(ips_hash)
-                # Add and reinstate pub certs for publisher
-                for path in add_pub_cert_dict.keys():
-                        errors += self.__add_pub_cert_to_publisher(path)
-
-                return errors
-
-        def __add_pub_cert_to_publisher(self, path):
-                errors = []
-                try:
-                        with open(path, "rb") as fh:
-                                s = fh.read()
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                errors.append(("",
-                                    api_errors.MissingFileArgumentException(path)))
-                        elif e.errno == errno.EACCES:
-                                errors.append(("", api_errors.PermissionsException(path)))
-                        else:
-                                errors.append(("", e))
-                try:
-                        pub = self.repository_modify_publisher
-                        if pub != None:
-                                pub.approve_ca_cert(s)
-                except api_errors.ApiException as e:
-                        errors.append(("", e))
-                return errors
-
-        def __revoke_pub_cert_for_publisher(self, ips_hash):
-                errors = []
-                try:
-                        pub = self.repository_modify_publisher
-                        if pub != None:
-                                pub.revoke_ca_cert(ips_hash)
-                except api_errors.ApiException as e:
-                        errors.append(("", e))
-                return errors
-
-        def __remove_pub_cert_for_publisher(self, ips_hash):
-                errors = []
-                try:
-                        pub = self.repository_modify_publisher
-                        if pub != None:
-                                pub.unset_ca_cert(ips_hash)
-                except api_errors.ApiException as e:
-                        errors.append(("", e))
-                return errors
-
-        def __init_pubs_tree_view(self, publishers_list):
-                publishers_list_filter = publishers_list.filter_new()
-                publishers_list_sort = gtk.TreeModelSort(publishers_list_filter)
-                publishers_list_sort.set_sort_column_id(
-                    enumerations.PUBLISHER_PRIORITY_CHANGED, gtk.SORT_ASCENDING)
-                # Name column
-                name_renderer = gtk.CellRendererText()
-                column = gtk.TreeViewColumn(_("Publisher"),
-                    name_renderer,  text = enumerations.PUBLISHER_NAME)
-                column.set_expand(True)
-                self.w_publishers_treeview.append_column(column)
-                # Alias column
-                alias_renderer = gtk.CellRendererText()
-                alias_renderer.set_property("ellipsize", pango.ELLIPSIZE_END)
-                column = gtk.TreeViewColumn(_("Alias"),
-                    alias_renderer, text = enumerations.PUBLISHER_ALIAS)
-                column.set_expand(True)
-                self.w_publishers_treeview.append_column(column)
-                # Enabled column
-                toggle_renderer = gtk.CellRendererToggle()
-                column = gtk.TreeViewColumn(_("Enabled"),
-                    toggle_renderer, active = enumerations.PUBLISHER_ENABLED)
-                toggle_renderer.set_property("activatable", True)
-                column.set_expand(False)
-                toggle_renderer.connect('toggled', self.__enable_disable)
-                column.set_cell_data_func(toggle_renderer,
-                    self.__toggle_data_function, None)
-                self.w_publishers_treeview.append_column(column)
-                # Sticky column
-                toggle_renderer = gtk.CellRendererToggle()
-                column = gtk.TreeViewColumn(_("Sticky"),
-                    toggle_renderer, active = enumerations.PUBLISHER_STICKY)
-                toggle_renderer.set_property("activatable", True)
-                column.set_expand(False)
-                toggle_renderer.connect('toggled', self.__sticky_unsticky)
-                column.set_cell_data_func(toggle_renderer,
-                    self.__toggle_data_function, None)
-                self.w_publishers_treeview.append_column(column)
-                publishers_list_filter.set_visible_func(self.__publishers_filter)
-                self.w_publishers_treeview.set_model(publishers_list_sort)
-
-        def __prepare_publisher_list(self, restore_changes = False):
-                sorted_model = self.w_publishers_treeview.get_model()
-                selection = self.w_publishers_treeview.get_selection()
-                selected_rows = selection.get_selected_rows()
-                self.w_publishers_treeview.set_model(None)
-                try:
-                        pubs = self.api_o.get_publishers(duplicate=True)
-                except api_errors.ApiException as e:
-                        self.__show_errors([("", e)])
-                        return
-                if not sorted_model:
-                        return
-                filtered_model = sorted_model.get_model()
-                model = filtered_model.get_model()
-
-                if restore_changes == False:
-                        self.no_changes = 0
-                        self.priority_changes = []
-                        model.clear()
-
-                        j = 0
-                        for pub in pubs:
-                                name = pub.prefix
-                                alias = pub.alias
-                                # BUG: alias should be either "None" or None.
-                                # in the list it's "None", but when adding pub it's None
-                                if not alias or len(alias) == 0 or alias == "None":
-                                        alias = name
-                                publisher_row = [j, j, name, alias, not pub.disabled,
-                                    pub.sticky, pub, False, False, False]
-                                model.insert(j, publisher_row)
-                                j += 1
-                else:
-                        j = 0
-                        for publisher_row in model:
-                                pub = pubs[j]
-                                name = pub.prefix
-                                alias = pub.alias
-                                if not alias or len(alias) == 0 or alias == "None":
-                                        alias = name
-                                publisher_row[enumerations.PUBLISHER_ALIAS] = alias
-                                publisher_row[enumerations.PUBLISHER_OBJECT] = pub
-                                j += 1
-                        # We handle here the case where a publisher was added
-                        if self.new_pub:
-                                pub = self.new_pub
-                                name = pub.prefix
-                                alias = pub.alias
-                                if not alias or len(alias) == 0 or alias == "None":
-                                        alias = name
-                                publisher_row = [j, j, name, alias, not pub.disabled,
-                                    pub.sticky, pub, False, False, False]
-                                model.insert(j, publisher_row)
-
-                self.w_publishers_treeview.set_model(sorted_model)
-                if len(sorted_model) == 0:
-                        self.__set_empty_pub_list()
-
-                if restore_changes:
-                        if self.new_pub:
-                                self.__select_last_publisher()
-                                self.new_pub = None
-                        else:
-                        # We do have gtk.SELECTION_SINGLE mode, so if exists, we are
-                        # interested only in the first selected path.
-                                if len(selected_rows) > 1 and len(selected_rows[1]) > 0:
-                                        self.w_publishers_treeview.scroll_to_cell(
-                                            selected_rows[1][0])
-                                        selection.select_path(selected_rows[1][0])
-
-        def __set_empty_pub_list(self):
-                details_buffer = self.w_manage_publishers_details.get_buffer()
-                details_buffer.set_text("")
-                self.w_manage_modify_btn.set_sensitive(False)
-                self.w_manage_remove_btn.set_sensitive(False)
-                self.w_manage_up_btn.set_sensitive(False)
-                self.w_manage_down_btn.set_sensitive(False)
-
-        def __select_last_publisher(self):
-                sorted_model = self.w_publishers_treeview.get_model()
-                itr = sorted_model.get_iter_first()
-                next_itr = sorted_model.iter_next(itr)
-                while next_itr != None:
-                        itr = next_itr
-                        next_itr = sorted_model.iter_next(itr)
-                path = sorted_model.get_path(itr)
-                self.w_publishers_treeview.scroll_to_cell(path)
-                self.w_publishers_treeview.get_selection().select_path(path)
-
-        def __validate_url(self, url_widget, w_ssl_key = None, w_ssl_cert = None):
-                self.__validate_url_generic(url_widget, self.w_add_error_label,
-                    self.w_publisher_add_button, self.is_alias_valid,
-                    w_ssl_label=self.w_add_sslerror_label,
-                    w_ssl_key=w_ssl_key, w_ssl_cert=w_ssl_cert)
-
-        def __validate_url_generic(self, w_url_text, w_error_label, w_action_button,
-                alias_valid = False, function = None, w_ssl_label = None,
-                w_ssl_key = None, w_ssl_cert = None):
-                ssl_key = None
-                ssl_cert = None
-                ssl_error = None
-                ssl_valid = True
-                url = w_url_text.get_text()
-                self.is_url_valid, self.url_err = self.__is_url_valid(url)
-                if not self.webinstall_new:
-                        self.__reset_error_label()
-                if w_ssl_label:
-                        w_ssl_label.set_sensitive(False)
-                        w_ssl_label.show()
-                valid_url = False
-                valid_func = True
-                if self.is_url_valid:
-                        if alias_valid:
-                                valid_url = True
-                        else:
-                                if self.name_error != None:
-                                        self.__show_error_label_with_format(w_error_label,
-                                            self.name_error)
-                else:
-                        if self.url_err != None:
-                                self.__show_error_label_with_format(w_error_label,
-                                    self.url_err)
-                if w_ssl_key != None and w_ssl_cert != None:
-                        if w_ssl_key:
-                                ssl_key = w_ssl_key.get_text()
-                        if w_ssl_cert:
-                                ssl_cert = w_ssl_cert.get_text()
-                        ssl_valid, ssl_error = self.__validate_ssl_key_cert(url, ssl_key,
-                            ssl_cert, ignore_ssl_check_for_not_https=True)
-                        self.__update_repository_dialog_width(ssl_error)
-                        if ssl_error != None and w_ssl_label:
-                                self.__show_error_label_with_format(w_ssl_label,
-                                    ssl_error)
-                        elif w_ssl_label:
-                                w_ssl_label.hide()
-                if function != None:
-                        valid_func = function()
-                w_action_button.set_sensitive(valid_url and valid_func and ssl_valid)
-
-        def __validate_alias_addpub(self, ok_btn, name_widget, url_widget, error_label,
-            function = None):
-                valid_btn = False
-                valid_func = True
-                name = name_widget.get_text()
-                self.is_alias_valid = self.__is_alias_valid(name)
-                self.__reset_error_label()
-                if self.is_alias_valid:
-                        if (self.is_url_valid):
-                                valid_btn = True
-                        else:
-                                if self.url_err == None:
-                                        self.__validate_url(url_widget,
-                                            w_ssl_key=self.w_key_entry,
-                                            w_ssl_cert=self.w_cert_entry)
-                                if self.url_err != None:
-                                        self.__show_error_label_with_format(error_label,
-                                            self.url_err)
-                else:
-                        if self.name_error != None:
-                                self.__show_error_label_with_format(error_label,
-                                            self.name_error)
-                if function != None:
-                        valid_func = function()
-                ok_btn.set_sensitive(valid_btn and valid_func)
-
-        def __is_alias_valid(self, name):
-                self.name_error = None
-                if len(name) == 0:
-                        return True
-                try:
-                        publisher.Publisher(prefix=name)
-                except api_errors.BadPublisherPrefix as e:
-                        self.name_error = _("Alias contains invalid characters")
-                        return False
-                try:
-                        self.api_o.get_publisher(prefix=name)
-                        self.name_error = _("Alias already in use")
-                        return False
-                except api_errors.UnknownPublisher as e:
-                        return True
-                except api_errors.ApiException as e:
-                        self.__show_errors([("", e)])
-                        return False
-
-        def __get_selected_publisher_itr_model(self):
-                itr, sorted_model = self.__get_fitr_model_from_tree(
-                    self.w_publishers_treeview)
-                if itr == None or sorted_model == None:
-                        return (None, None)
-                sorted_path = sorted_model.get_path(itr)
-                filter_path = sorted_model.convert_path_to_child_path(sorted_path)
-                filter_model = sorted_model.get_model()
-                path = filter_model.convert_path_to_child_path(filter_path)
-                model = filter_model.get_model()
-                itr = model.get_iter(path)
-                return (itr, model)
-
-        def __get_selected_mirror_itr_model(self):
-                return self.__get_fitr_model_from_tree(\
-                    self.modify_repo_mirrors_treeview)
-
-        def __get_selected_origin_itr_model(self):
-                return self.__get_fitr_model_from_tree(\
-                    self.modify_repo_origins_treeview)
-
-        def __modify_publisher_dialog(self, pub):
-                self.orig_sig_policy = {}
-                self.pub_certs_setup = False
-
-                gui_misc.set_modal_and_transient(self.w_modify_repository_dialog,
-                    self.w_manage_publishers_dialog)
-                try:
-                        self.repository_modify_publisher = self.api_o.get_publisher(
-                            prefix=pub.prefix, alias=pub.prefix, duplicate=True)
-                except api_errors.ApiException as e:
-                        self.__show_errors([("", e)])
-                        return
-                updated_modify_repository = self.__update_modify_repository_dialog(True,
-                    True, True, True)
-
-                self.w_modify_repository_dialog.set_size_request(
-                    MODIFY_DIALOG_WIDTH_DEFAULT, -1)
-
-                if updated_modify_repository:
-                        self.w_modify_repository_dialog.set_title(
-                            _("Modify Publisher - %s") %
-                            self.__get_pub_display_name(pub))
-                        self.w_modify_repository_dialog.show_all()
-
-                pagenum = self.w_modify_pub_notebook.get_current_page()
-                if pagenum == MODIFY_NOTEBOOK_CERTIFICATE_PAGE:
-                        gobject.idle_add(self.__prepare_pub_certs)
-                elif pagenum == MODIFY_NOTEBOOK_SIG_POLICY_PAGE:
-                        gobject.idle_add(self.__prepare_pub_signature_policy)
-
-        def __update_repository_dialog_width(self, ssl_error):
-                if ssl_error == None:
-                        self.w_modify_repository_dialog.set_size_request(
-                            MODIFY_DIALOG_WIDTH_DEFAULT, -1)
-                        return
-
-                style = self.w_repositorymodify_name.get_style()
-                font_size_in_pango_unit = style.font_desc.get_size()
-                font_size_in_pixel = font_size_in_pango_unit / pango.SCALE
-                ssl_error_len = len(unicode(ssl_error)) * font_size_in_pixel
-                if ssl_error_len > MODIFY_DIALOG_SSL_WIDTH_DEFAULT:
-                        new_dialog_width = ssl_error_len * \
-                                (float(MODIFY_DIALOG_WIDTH_DEFAULT)/
-                                    MODIFY_DIALOG_SSL_WIDTH_DEFAULT)
-                        self.w_modify_repository_dialog.set_size_request(
-                            int(new_dialog_width), -1)
-                else:
-                        self.w_modify_repository_dialog.set_size_request(
-                            MODIFY_DIALOG_WIDTH_DEFAULT, -1)
-
-        def __update_modify_repository_dialog(self, update_alias=False,
-            update_mirrors=False, update_origins=False, update_ssl=False):
-                if not self.repository_modify_publisher:
-                        return False
-                pub = self.repository_modify_publisher
-                selected_repo = pub.repository
-                prefix = ""
-                ssl_cert = ""
-                ssl_key = ""
-
-                if pub.prefix and len(pub.prefix) > 0:
-                        prefix = pub.prefix
-                self.w_repositorymodify_name.set_text(prefix)
-
-                if update_alias:
-                        alias = ""
-                        if pub.alias and len(pub.alias) > 0 \
-                            and pub.alias != "None":
-                                alias = pub.alias
-                        self.w_modify_pub_alias.set_text(alias)
-
-                if update_mirrors or update_ssl:
-                        if update_mirrors:
-                                insert_count = 0
-                                mirrors_list = self.__get_mirrors_origins_liststore()
-                        for mirror in selected_repo.mirrors:
-                                if mirror.ssl_cert:
-                                        ssl_cert = mirror.ssl_cert
-                                if mirror.ssl_key:
-                                        ssl_key = mirror.ssl_key
-                                if update_mirrors:
-                                        mirror_uri = [mirror.uri]
-                                        mirrors_list.insert(insert_count, mirror_uri)
-                                        insert_count += 1
-                        if update_mirrors:
-                                self.modify_repo_mirrors_treeview.set_model(mirrors_list)
-                                if len(selected_repo.mirrors) > 0:
-                                        self.w_repositorymirror_expander.set_expanded(
-                                            True)
-                                else:
-                                        self.w_repositorymirror_expander.set_expanded(
-                                            False)
-
-                if update_origins or update_ssl:
-                        if update_origins:
-                                insert_count = 0
-                                origins_list = self.__get_mirrors_origins_liststore()
-                        for origin in selected_repo.origins:
-                                if origin.ssl_cert:
-                                        ssl_cert = origin.ssl_cert
-                                if origin.ssl_key:
-                                        ssl_key = origin.ssl_key
-                                if update_origins:
-                                        origin_uri = [origin.uri]
-                                        origins_list.insert(insert_count, origin_uri)
-                                        insert_count += 1
-                        if update_origins:
-                                self.modify_repo_origins_treeview.set_model(origins_list)
-
-                reg_uri = self.__get_registration_uri(selected_repo)
-                if reg_uri != None:
-                        self.w_repositorymodify_registration_link.set_uri(
-                            reg_uri)
-                        self.w_repositorymodify_registration_box.show()
-                else:
-                        self.w_repositorymodify_registration_box.hide()
-
-                if update_ssl:
-                        self.w_repositorymodify_cert_entry.set_text(ssl_cert)
-                        self.w_repositorymodify_key_entry.set_text(ssl_key)
-                return True
-
-        def __add_mirror(self, new_mirror):
-                pub = self.repository_modify_publisher
-                repo = pub.repository
-                try:
-                        repo.add_mirror(new_mirror)
-                        self.w_addmirror_entry.set_text("")
-                except api_errors.ApiException as e:
-                        self.__show_errors([(pub, e)])
-                self.__update_modify_repository_dialog(update_mirrors=True)
-
-        def __rm_mirror(self):
-                itr, model = self.__get_selected_mirror_itr_model()
-                remove_mirror = None
-                if itr and model:
-                        remove_mirror = model.get_value(itr, 0)
-                pub = self.repository_modify_publisher
-                repo = pub.repository
-                try:
-                        repo.remove_mirror(remove_mirror)
-                except api_errors.ApiException as e:
-                        self.__show_errors([(pub, e)])
-                self.__update_modify_repository_dialog(update_mirrors=True)
-
-        def __add_origin(self, new_origin):
-                pub = self.repository_modify_publisher
-                repo = pub.repository
-                try:
-                        repo.add_origin(new_origin)
-                        self.w_addorigin_entry.set_text("")
-                except api_errors.ApiException as e:
-                        self.__show_errors([(pub, e)])
-                self.__update_modify_repository_dialog(update_origins=True)
-
-        def __rm_origin(self):
-                itr, model = self.__get_selected_origin_itr_model()
-                remove_origin = None
-                if itr and model:
-                        remove_origin = model.get_value(itr, 0)
-                pub = self.repository_modify_publisher
-                repo = pub.repository
-                try:
-                        repo.remove_origin(remove_origin)
-                except api_errors.ApiException as e:
-                        self.__show_errors([(pub, e)])
-                self.__update_modify_repository_dialog(update_origins=True)
-
-        def __sticky_unsticky(self, cell, sorted_path):
-                sorted_model = self.w_publishers_treeview.get_model()
-                filtered_path = sorted_model.convert_path_to_child_path(sorted_path)
-                filtered_model = sorted_model.get_model()
-                path = filtered_model.convert_path_to_child_path(filtered_path)
-                model = filtered_model.get_model()
-                itr = model.get_iter(path)
-                if itr == None:
-                        return
-                pub = model.get_value(itr, enumerations.PUBLISHER_OBJECT)
-                if pub.sys_pub:
-                        return
-                is_sticky = model.get_value(itr, enumerations.PUBLISHER_STICKY)
-                changed = model.get_value(itr, enumerations.PUBLISHER_STICKY_CHANGED)
-                model.set_value(itr, enumerations.PUBLISHER_STICKY, not is_sticky)
-                model.set_value(itr, enumerations.PUBLISHER_STICKY_CHANGED, not changed)
-
-        def __enable_disable(self, cell, sorted_path):
-                sorted_model = self.w_publishers_treeview.get_model()
-                filtered_path = sorted_model.convert_path_to_child_path(sorted_path)
-                filtered_model = sorted_model.get_model()
-                path = filtered_model.convert_path_to_child_path(filtered_path)
-                model = filtered_model.get_model()
-                itr = model.get_iter(path)
-                if itr == None:
-                        self.w_manage_modify_btn.set_sensitive(False)
-                        self.w_manage_remove_btn.set_sensitive(False)
-                        self.w_manage_up_btn.set_sensitive(False)
-                        self.w_manage_down_btn.set_sensitive(False)
-                        return
-                pub = model.get_value(itr, enumerations.PUBLISHER_OBJECT)
-                if pub.sys_pub:
-                        return
-                enabled = model.get_value(itr, enumerations.PUBLISHER_ENABLED)
-                changed = model.get_value(itr, enumerations.PUBLISHER_ENABLE_CHANGED)
-                model.set_value(itr, enumerations.PUBLISHER_ENABLED, not enabled)
-                model.set_value(itr, enumerations.PUBLISHER_ENABLE_CHANGED, not changed)
-                self.__enable_disable_updown_btn(itr, model)
-
-        @staticmethod
-        def __is_at_least_one_entry(treeview):
-                model = treeview.get_model()
-                if len(model) >= 1:
-                        return True
-                return False
-
-        def __enable_disable_remove_modify_btn(self, itr, model):
-                if itr == None:
-                        self.w_manage_modify_btn.set_sensitive(False)
-                        self.w_manage_remove_btn.set_sensitive(False)
-                        self.w_manage_up_btn.set_sensitive(False)
-                        self.w_manage_down_btn.set_sensitive(False)
-                        return
+                    self.w_repositorymirror_expander.set_expanded(False)
+
+        if update_origins or update_ssl:
+            if update_origins:
+                insert_count = 0
+                origins_list = self.__get_mirrors_origins_liststore()
+            for origin in selected_repo.origins:
+                if origin.ssl_cert:
+                    ssl_cert = origin.ssl_cert
+                if origin.ssl_key:
+                    ssl_key = origin.ssl_key
+                if update_origins:
+                    origin_uri = [origin.uri]
+                    origins_list.insert(insert_count, origin_uri)
+                    insert_count += 1
+            if update_origins:
+                self.modify_repo_origins_treeview.set_model(origins_list)
+
+        reg_uri = self.__get_registration_uri(selected_repo)
+        if reg_uri != None:
+            self.w_repositorymodify_registration_link.set_uri(reg_uri)
+            self.w_repositorymodify_registration_box.show()
+        else:
+            self.w_repositorymodify_registration_box.hide()
+
+        if update_ssl:
+            self.w_repositorymodify_cert_entry.set_text(ssl_cert)
+            self.w_repositorymodify_key_entry.set_text(ssl_key)
+        return True
+
+    def __add_mirror(self, new_mirror):
+        pub = self.repository_modify_publisher
+        repo = pub.repository
+        try:
+            repo.add_mirror(new_mirror)
+            self.w_addmirror_entry.set_text("")
+        except api_errors.ApiException as e:
+            self.__show_errors([(pub, e)])
+        self.__update_modify_repository_dialog(update_mirrors=True)
+
+    def __rm_mirror(self):
+        itr, model = self.__get_selected_mirror_itr_model()
+        remove_mirror = None
+        if itr and model:
+            remove_mirror = model.get_value(itr, 0)
+        pub = self.repository_modify_publisher
+        repo = pub.repository
+        try:
+            repo.remove_mirror(remove_mirror)
+        except api_errors.ApiException as e:
+            self.__show_errors([(pub, e)])
+        self.__update_modify_repository_dialog(update_mirrors=True)
+
+    def __add_origin(self, new_origin):
+        pub = self.repository_modify_publisher
+        repo = pub.repository
+        try:
+            repo.add_origin(new_origin)
+            self.w_addorigin_entry.set_text("")
+        except api_errors.ApiException as e:
+            self.__show_errors([(pub, e)])
+        self.__update_modify_repository_dialog(update_origins=True)
+
+    def __rm_origin(self):
+        itr, model = self.__get_selected_origin_itr_model()
+        remove_origin = None
+        if itr and model:
+            remove_origin = model.get_value(itr, 0)
+        pub = self.repository_modify_publisher
+        repo = pub.repository
+        try:
+            repo.remove_origin(remove_origin)
+        except api_errors.ApiException as e:
+            self.__show_errors([(pub, e)])
+        self.__update_modify_repository_dialog(update_origins=True)
+
+    def __sticky_unsticky(self, cell, sorted_path):
+        sorted_model = self.w_publishers_treeview.get_model()
+        filtered_path = sorted_model.convert_path_to_child_path(sorted_path)
+        filtered_model = sorted_model.get_model()
+        path = filtered_model.convert_path_to_child_path(filtered_path)
+        model = filtered_model.get_model()
+        itr = model.get_iter(path)
+        if itr == None:
+            return
+        pub = model.get_value(itr, enumerations.PUBLISHER_OBJECT)
+        if pub.sys_pub:
+            return
+        is_sticky = model.get_value(itr, enumerations.PUBLISHER_STICKY)
+        changed = model.get_value(itr, enumerations.PUBLISHER_STICKY_CHANGED)
+        model.set_value(itr, enumerations.PUBLISHER_STICKY, not is_sticky)
+        model.set_value(itr, enumerations.PUBLISHER_STICKY_CHANGED, not changed)
+
+    def __enable_disable(self, cell, sorted_path):
+        sorted_model = self.w_publishers_treeview.get_model()
+        filtered_path = sorted_model.convert_path_to_child_path(sorted_path)
+        filtered_model = sorted_model.get_model()
+        path = filtered_model.convert_path_to_child_path(filtered_path)
+        model = filtered_model.get_model()
+        itr = model.get_iter(path)
+        if itr == None:
+            self.w_manage_modify_btn.set_sensitive(False)
+            self.w_manage_remove_btn.set_sensitive(False)
+            self.w_manage_up_btn.set_sensitive(False)
+            self.w_manage_down_btn.set_sensitive(False)
+            return
+        pub = model.get_value(itr, enumerations.PUBLISHER_OBJECT)
+        if pub.sys_pub:
+            return
+        enabled = model.get_value(itr, enumerations.PUBLISHER_ENABLED)
+        changed = model.get_value(itr, enumerations.PUBLISHER_ENABLE_CHANGED)
+        model.set_value(itr, enumerations.PUBLISHER_ENABLED, not enabled)
+        model.set_value(itr, enumerations.PUBLISHER_ENABLE_CHANGED, not changed)
+        self.__enable_disable_updown_btn(itr, model)
+
+    @staticmethod
+    def __is_at_least_one_entry(treeview):
+        model = treeview.get_model()
+        if len(model) >= 1:
+            return True
+        return False
+
+    def __enable_disable_remove_modify_btn(self, itr, model):
+        if itr == None:
+            self.w_manage_modify_btn.set_sensitive(False)
+            self.w_manage_remove_btn.set_sensitive(False)
+            self.w_manage_up_btn.set_sensitive(False)
+            self.w_manage_down_btn.set_sensitive(False)
+            return
+        remove_val = False
+        modify_val = False
+        if self.__is_at_least_one_entry(self.w_publishers_treeview):
+            remove_val = True
+            modify_val = True
+            pub = model.get_value(itr, enumerations.PUBLISHER_OBJECT)
+            if pub.sys_pub:
                 remove_val = False
                 modify_val = False
-                if self.__is_at_least_one_entry(self.w_publishers_treeview):
-                        remove_val = True
-                        modify_val = True
-                        pub = model.get_value(itr,
-                                enumerations.PUBLISHER_OBJECT)
-                        if pub.sys_pub:
-                                remove_val = False
-                                modify_val = False
-                self.w_manage_modify_btn.set_sensitive(modify_val)
-                self.w_manage_remove_btn.set_sensitive(remove_val)
+        self.w_manage_modify_btn.set_sensitive(modify_val)
+        self.w_manage_remove_btn.set_sensitive(remove_val)
 
-        def __enable_disable_updown_btn(self, itr, model):
-                up_enabled = True
-                down_enabled = True
-                sorted_size = len(self.w_publishers_treeview.get_model())
+    def __enable_disable_updown_btn(self, itr, model):
+        up_enabled = True
+        down_enabled = True
+        sorted_size = len(self.w_publishers_treeview.get_model())
 
-                if itr:
-                        current_priority = model.get_value(itr,
-                            enumerations.PUBLISHER_PRIORITY_CHANGED)
-                        is_sys_pub = model.get_value(itr,
-                            enumerations.PUBLISHER_OBJECT).sys_pub
-                        next_sys_pub = False
-                        prev_sys_pub = False
-                        path = model.get_path(itr)
-                        next_itr = model.iter_next(itr)
-                        if next_itr:
-                                next_pub = model.get_value(next_itr,
-                                    enumerations.PUBLISHER_OBJECT)
-                                if next_pub.sys_pub:
-                                        next_sys_pub = True
-                        if path[0] > 0:
-                                prev_path = (path[0] - 1,)
-                                prev_itr = model.get_iter(prev_path)
-                                prev_pub = model.get_value(prev_itr,
-                                    enumerations.PUBLISHER_OBJECT)
-                                if prev_pub.sys_pub:
-                                        prev_sys_pub = True
+        if itr:
+            current_priority = model.get_value(
+                itr, enumerations.PUBLISHER_PRIORITY_CHANGED
+            )
+            is_sys_pub = model.get_value(
+                itr, enumerations.PUBLISHER_OBJECT
+            ).sys_pub
+            next_sys_pub = False
+            prev_sys_pub = False
+            path = model.get_path(itr)
+            next_itr = model.iter_next(itr)
+            if next_itr:
+                next_pub = model.get_value(
+                    next_itr, enumerations.PUBLISHER_OBJECT
+                )
+                if next_pub.sys_pub:
+                    next_sys_pub = True
+            if path[0] > 0:
+                prev_path = (path[0] - 1,)
+                prev_itr = model.get_iter(prev_path)
+                prev_pub = model.get_value(
+                    prev_itr, enumerations.PUBLISHER_OBJECT
+                )
+                if prev_pub.sys_pub:
+                    prev_sys_pub = True
 
-                        if current_priority == sorted_size - 1:
-                                down_enabled = False
-                        elif current_priority == 0:
-                                up_enabled = False
+            if current_priority == sorted_size - 1:
+                down_enabled = False
+            elif current_priority == 0:
+                up_enabled = False
 
-                        if sorted_size == 1:
-                                up_enabled = False
-                                down_enabled = False
-                        else:
-                                if next_sys_pub or is_sys_pub:
-                                        down_enabled = False
-                                if prev_sys_pub or is_sys_pub:
-                                        up_enabled = False
-                self.w_manage_up_btn.set_sensitive(up_enabled)
-                self.w_manage_down_btn.set_sensitive(down_enabled)
+            if sorted_size == 1:
+                up_enabled = False
+                down_enabled = False
+            else:
+                if next_sys_pub or is_sys_pub:
+                    down_enabled = False
+                if prev_sys_pub or is_sys_pub:
+                    up_enabled = False
+        self.w_manage_up_btn.set_sensitive(up_enabled)
+        self.w_manage_down_btn.set_sensitive(down_enabled)
 
-        def __do_add_repository(self, alias=None, url=None, ssl_key=None, ssl_cert=None,
-            pub=None):
-                self.publishers_apply.set_title(_("Adding Publisher"))
-                if self.webinstall_new:
-                        self.__run_with_prog_in_thread(self.__add_repository,
-                            self.main_window, self.__stop, None, None,  ssl_key,
-                            ssl_cert, self.repository_modify_publisher)
-                else:
-                        self.__run_with_prog_in_thread(self.__add_repository,
-                            self.w_add_publisher_dialog, self.__stop, alias,
-                            url, ssl_key, ssl_cert, pub)
+    def __do_add_repository(
+        self, alias=None, url=None, ssl_key=None, ssl_cert=None, pub=None
+    ):
+        self.publishers_apply.set_title(_("Adding Publisher"))
+        if self.webinstall_new:
+            self.__run_with_prog_in_thread(
+                self.__add_repository,
+                self.main_window,
+                self.__stop,
+                None,
+                None,
+                ssl_key,
+                ssl_cert,
+                self.repository_modify_publisher,
+            )
+        else:
+            self.__run_with_prog_in_thread(
+                self.__add_repository,
+                self.w_add_publisher_dialog,
+                self.__stop,
+                alias,
+                url,
+                ssl_key,
+                ssl_cert,
+                pub,
+            )
 
-        def __stop(self):
-                if self.cancel_progress_thread == False:
-                        self.__update_details_text(_("Canceling...\n"))
-                        self.cancel_progress_thread = True
-                        self.publishers_apply_cancel.set_sensitive(False)
+    def __stop(self):
+        if self.cancel_progress_thread == False:
+            self.__update_details_text(_("Canceling...\n"))
+            self.cancel_progress_thread = True
+            self.publishers_apply_cancel.set_sensitive(False)
 
-        def __add_repository(self, alias=None, origin_url=None, ssl_key=None,
-            ssl_cert=None, pub=None):
-                errors = []
-                if pub == None:
-                        if self.__check_publisher_exists(self.api_o, alias,
-                                origin_url):
-                                self.progress_stop_thread = True
-                                return
-                        pub, repo, new_pub = self.__setup_publisher_from_uri(
-                            alias, origin_url, ssl_key, ssl_cert)
-                        if pub == None:
-                                self.progress_stop_thread = True
-                                return
-                else:
-                        repo = pub.repository
-                        new_pub = True
-                        name = pub.prefix
-                errors_ssl = self.__update_ssl_creds(pub, repo, ssl_cert, ssl_key)
-                errors_update = []
-                try:
-                        errors_update = self.__update_publisher(pub,
-                            new_publisher=new_pub)
-                except api_errors.UnknownRepositoryPublishers as e:
-                        if len(e.known) > 0:
-                                pub, repo, new_pub = self.__get_or_create_pub_with_url(
-                                    self.api_o, e.known[0], origin_url)
-                                if new_pub:
-                                        errors_ssl = self.__update_ssl_creds(pub, repo,
-                                            ssl_cert, ssl_key)
-                                        pub.alias = name
-                                        errors_update = self.__update_publisher(pub,
-                                            new_publisher=new_pub,
-                                            raise_unknownpubex=False)
-                                else:
-                                        self.progress_stop_thread = True
-                                        return
-                        else:
-                                errors_update.append((pub, e))
-                errors += errors_ssl
-                errors += errors_update
-                if self.cancel_progress_thread:
-                        try:
-                                self.__g_update_details_text(
-                                    _("Removing publisher %s\n") % name)
-                                self.api_o.remove_publisher(prefix=name,
-                                    alias=name)
-                                self.__g_update_details_text(
-                                    _("Publisher %s succesfully removed\n") % name)
-                        except api_errors.ApiException as e:
-                                errors.append((pub, e))
-                        self.progress_stop_thread = True
-                else:
-                        self.progress_stop_thread = True
-                        if len(errors) > 0:
-                                gobject.idle_add(self.__show_errors, errors)
-                        elif not self.webinstall_new:
-                                gobject.idle_add(self.__afteradd_confirmation, pub)
-                                self.progress_stop_thread = True
-                                gobject.idle_add(
-                                   self.__g_on_add_publisher_delete_event,
-                                   self.w_add_publisher_dialog, None)
-                        elif self.webinstall_new:
-                                gobject.idle_add(
-                                   self.__g_on_add_publisher_delete_event,
-                                   self.w_add_publisher_dialog, None)
-                                gobject.idle_add(self.parent.reload_packages)
-
-        def __update_publisher(self, pub, new_publisher=False, raise_unknownpubex=True):
-                errors = []
-                try:
-                        if new_publisher:
-                                self.__g_update_details_text(
-                                    _("Adding publisher %s\n") % pub.prefix)
-                                self.api_o.add_publisher(pub)
-                                self.no_changes += 1
-                        else:
-                                self.__g_update_details_text(
-                                    _("Updating publisher %s\n") % pub.prefix)
-                                self.api_o.update_publisher(pub)
-                                self.no_changes += 1
-                        if new_publisher:
-                                self.__g_update_details_text(
-                                    _("Publisher %s succesfully added\n") % pub.prefix)
-                        else:
-                                self.__g_update_details_text(
-                                    _("Publisher %s succesfully updated\n") % pub.prefix)
-                except api_errors.UnknownRepositoryPublishers as e:
-                        if raise_unknownpubex:
-                                raise e
-                        else:
-                                errors.append((pub, e))
-                except api_errors.ApiException as e:
-                        errors.append((pub, e))
-                return errors
-
-        def __afteradd_confirmation(self, pub):
-                self.new_pub = pub
-                repo = pub.repository
-                origin = repo.origins[0]
-                # Descriptions not available at the moment
-                self.w_add_publisher_c_desc.hide()
-                self.w_add_publisher_c_desc_l.hide()
-                self.w_add_publisher_c_name.set_text(pub.prefix)
-                if pub.alias and len(pub.alias) > 0:
-                        self.w_add_publisher_c_alias.set_text(pub.alias)
-                else:
-                        self.w_add_publisher_c_alias.hide()
-                        self.w_add_publisher_c_alias_l.hide()
-                self.w_add_publisher_c_url.set_text(origin.uri)
-                self.w_add_publisher_comp_dialog.show()
-
-        def __prepare_confirmation_dialog(self):
-                disable = ""
-                enable = ""
-                sticky = ""
-                unsticky = ""
-                delete = ""
-                priority_change = ""
-                disable_no = 0
-                enable_no = 0
-                sticky_no = 0
-                unsticky_no = 0
-                delete_no = 0
-                not_removed = []
-                removed_priorities = []
-                priority_changed = []
-                for row in self.publishers_list:
-                        pub_name = row[enumerations.PUBLISHER_NAME]
-                        if row[enumerations.PUBLISHER_REMOVED]:
-                                delete += "\t" + pub_name + "\n"
-                                delete_no += 1
-                                removed_priorities.append(
-                                    row[enumerations.PUBLISHER_PRIORITY])
-                        else:
-                                if row[enumerations.PUBLISHER_ENABLE_CHANGED]:
-                                        to_enable = row[enumerations.PUBLISHER_ENABLED]
-                                        if not to_enable:
-                                                disable += "\t" + pub_name + "\n"
-                                                disable_no += 1
-                                        else:
-                                                enable += "\t" + pub_name + "\n"
-                                                enable_no += 1
-                                if row[enumerations.PUBLISHER_STICKY_CHANGED]:
-                                        to_sticky = row[enumerations.PUBLISHER_STICKY]
-                                        if not to_sticky:
-                                                unsticky += "\t" + pub_name + "\n"
-                                                unsticky_no += 1
-                                        else:
-                                                sticky += "\t" + pub_name + "\n"
-                                                sticky_no += 1
-                                not_removed.append(row)
-
-                for pub in not_removed:
-                        if not self.__check_if_ignore(pub, removed_priorities):
-                                pub_name = pub[enumerations.PUBLISHER_NAME]
-                                pri = pub[enumerations.PUBLISHER_PRIORITY_CHANGED]
-                                priority_changed.append([pri, pub_name])
-
-                if disable_no == 0 and enable_no == 0 and delete_no == 0 and \
-                    sticky_no == 0 and unsticky_no == 0 and \
-                    len(priority_changed) == 0:
-                        self.__on_manage_cancel_clicked(None)
-                        return
-
-                priority_changed.sort()
-                for pri, pub_name in priority_changed:
-                        priority_change += "\t" + str(pri+1) + \
-                            " - " + pub_name + "\n"
-
-                textbuf = self.w_confirmation_textview.get_buffer()
-                textbuf.set_text("")
-                textiter = textbuf.get_end_iter()
-
-                disable_text = ngettext("Disable Publisher:\n",
-                    "Disable Publishers:\n", disable_no)
-                enable_text = ngettext("Enable Publisher:\n",
-                    "Enable Publishers:\n", enable_no)
-                delete_text = ngettext("Remove Publisher:\n",
-                    "Remove Publishers:\n", delete_no)
-                sticky_text = ngettext("Set sticky Publisher:\n",
-                    "Set sticky Publishers:\n", delete_no)
-                unsticky_text = ngettext("Unset sticky Publisher:\n",
-                    "Unset sticky Publishers:\n", delete_no)
-                priority_text = _("Change Priorities:\n")
-
-                confirm_no = delete_no + enable_no + disable_no + sticky_no + \
-                    unsticky_no
-                confirm_text = ngettext("Apply the following change:",
-                    "Apply the following changes:", confirm_no)
-
-                self.w_confirmation_label.set_markup("<b>" + confirm_text + "</b>")
-
-                if len(delete) > 0:
-                        textbuf.insert_with_tags_by_name(textiter,
-                            delete_text, "bold")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            delete)
-                if len(disable) > 0:
-                        if len(delete) > 0:
-                                textbuf.insert_with_tags_by_name(textiter,
-                                    "\n")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            disable_text, "bold")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            disable)
-                if len(enable) > 0:
-                        if len(delete) > 0 or len(disable) > 0:
-                                textbuf.insert_with_tags_by_name(textiter,
-                                    "\n")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            enable_text, "bold")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            enable)
-                if len(sticky) > 0:
-                        if len(delete) > 0 or len(disable) > 0 or len(enable) > 0:
-                                textbuf.insert_with_tags_by_name(textiter,
-                                    "\n")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            sticky_text, "bold")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            sticky)
-                if len(unsticky) > 0:
-                        if len(delete) > 0 or len(disable) > 0 or \
-                            len(enable) > 0 or len(sticky) > 0:
-                                textbuf.insert_with_tags_by_name(textiter,
-                                    "\n")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            unsticky_text, "bold")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            unsticky)
-                if len(priority_change) > 0:
-                        if len(delete) > 0 or len(disable) or len(enable) > 0:
-                                textbuf.insert_with_tags_by_name(textiter,
-                                    "\n")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            priority_text, "bold")
-                        textbuf.insert_with_tags_by_name(textiter,
-                            priority_change)
-
-                self.w_confirm_cancel_btn.grab_focus()
-                self.w_confirmation_dialog.show_all()
-
-        def __proceed_enable_disable(self, pub_names, to_enable):
-                errors = []
-
-                gobject.idle_add(self.publishers_apply_expander.set_expanded, True)
-                for name in pub_names.keys():
-                        try:
-                                pub = self.api_o.get_publisher(name,
-                                    duplicate = True)
-                                if pub.disabled == (not to_enable):
-                                        continue
-                                pub.disabled = not to_enable
-                                self.no_changes += 1
-                                enable_text = _("Disabling")
-                                if to_enable:
-                                        enable_text = _("Enabling")
-
-                                details_text = \
-                                        _("%(enable)s publisher %(name)s\n")
-                                self.__g_update_details_text(details_text %
-                                    {"enable" : enable_text, "name" : name})
-                                self.api_o.update_publisher(pub)
-                        except api_errors.ApiException as e:
-                                errors.append(pub, e)
+    def __add_repository(
+        self, alias=None, origin_url=None, ssl_key=None, ssl_cert=None, pub=None
+    ):
+        errors = []
+        if pub == None:
+            if self.__check_publisher_exists(self.api_o, alias, origin_url):
                 self.progress_stop_thread = True
-                gobject.idle_add(self.publishers_apply_expander.set_expanded, False)
-                if len(errors) > 0:
-                        gobject.idle_add(self.__show_errors, errors)
-                else:
-                        gobject.idle_add(self.parent.reload_packages, False)
-
-        def __proceed_after_confirmation(self):
-                errors = []
-
-                image_lock_err = False
-                for row in self.priority_changes:
-                        try:
-                                if row[1] == None or row[2] == None:
-                                        continue
-                                pub1 = self.api_o.get_publisher(row[1],
-                                    duplicate=True)
-                                pub2 = self.api_o.get_publisher(row[2],
-                                    duplicate=True)
-                                if row[0] == enumerations.PUBLISHER_MOVE_BEFORE:
-                                        self.api_o.update_publisher(pub1,
-                                            search_before=pub2.prefix)
-                                else:
-                                        self.api_o.update_publisher(pub1,
-                                            search_after=pub2.prefix)
-                                self.no_changes += 1
-                                self.__g_update_details_text(
-                                    _("Changing priority for publisher %s\n")
-                                    % row[1])
-                        except api_errors.ImageLockedError as e:
-                                self.no_changes = 0
-                                if not image_lock_err:
-                                        errors.append((row[1], e))
-                                        image_lock_err = True
-                        except api_errors.ApiException as e:
-                                errors.append((row[1], e))
-
-                for row in self.publishers_list:
-                        name = row[enumerations.PUBLISHER_NAME]
-                        try:
-                                if row[enumerations.PUBLISHER_REMOVED]:
-                                        self.no_changes += 1
-                                        self.__g_update_details_text(
-                                            _("Removing publisher %s\n") % name)
-                                        self.api_o.remove_publisher(prefix=name,
-                                            alias=name)
-                                        self.__g_update_details_text(
-                                            _("Publisher %s succesfully removed\n")
-                                            % name)
-                                elif row[enumerations.PUBLISHER_ENABLE_CHANGED] or \
-                                    row[enumerations.PUBLISHER_STICKY_CHANGED]:
-                                        self.__do_changes_for_row(row, name)
-                        except api_errors.ImageLockedError as e:
-                                self.no_changes = 0
-                                if not image_lock_err:
-                                        errors.append(
-                                            (row[enumerations.PUBLISHER_OBJECT], e))
-                                        image_lock_err = True
-                        except api_errors.ApiException as e:
-                                errors.append((row[enumerations.PUBLISHER_OBJECT], e))
+                return
+            pub, repo, new_pub = self.__setup_publisher_from_uri(
+                alias, origin_url, ssl_key, ssl_cert
+            )
+            if pub == None:
                 self.progress_stop_thread = True
-                if len(errors) > 0:
-                        gobject.idle_add(self.__show_errors, errors)
+                return
+        else:
+            repo = pub.repository
+            new_pub = True
+            name = pub.prefix
+        errors_ssl = self.__update_ssl_creds(pub, repo, ssl_cert, ssl_key)
+        errors_update = []
+        try:
+            errors_update = self.__update_publisher(pub, new_publisher=new_pub)
+        except api_errors.UnknownRepositoryPublishers as e:
+            if len(e.known) > 0:
+                pub, repo, new_pub = self.__get_or_create_pub_with_url(
+                    self.api_o, e.known[0], origin_url
+                )
+                if new_pub:
+                    errors_ssl = self.__update_ssl_creds(
+                        pub, repo, ssl_cert, ssl_key
+                    )
+                    pub.alias = name
+                    errors_update = self.__update_publisher(
+                        pub, new_publisher=new_pub, raise_unknownpubex=False
+                    )
                 else:
-                        gobject.idle_add(self.__after_confirmation)
+                    self.progress_stop_thread = True
+                    return
+            else:
+                errors_update.append((pub, e))
+        errors += errors_ssl
+        errors += errors_update
+        if self.cancel_progress_thread:
+            try:
+                self.__g_update_details_text(
+                    _("Removing publisher %s\n") % name
+                )
+                self.api_o.remove_publisher(prefix=name, alias=name)
+                self.__g_update_details_text(
+                    _("Publisher %s succesfully removed\n") % name
+                )
+            except api_errors.ApiException as e:
+                errors.append((pub, e))
+            self.progress_stop_thread = True
+        else:
+            self.progress_stop_thread = True
+            if len(errors) > 0:
+                gobject.idle_add(self.__show_errors, errors)
+            elif not self.webinstall_new:
+                gobject.idle_add(self.__afteradd_confirmation, pub)
+                self.progress_stop_thread = True
+                gobject.idle_add(
+                    self.__g_on_add_publisher_delete_event,
+                    self.w_add_publisher_dialog,
+                    None,
+                )
+            elif self.webinstall_new:
+                gobject.idle_add(
+                    self.__g_on_add_publisher_delete_event,
+                    self.w_add_publisher_dialog,
+                    None,
+                )
+                gobject.idle_add(self.parent.reload_packages)
 
-        def __do_changes_for_row(self, row, name):
-                pub = self.api_o.get_publisher(name, duplicate = True)
-                if row[enumerations.PUBLISHER_ENABLE_CHANGED]:
-                        to_enable = row[enumerations.PUBLISHER_ENABLED]
-                        pub.disabled = not to_enable
-                if row[enumerations.PUBLISHER_STICKY_CHANGED]:
-                        sticky = row[enumerations.PUBLISHER_STICKY]
-                        pub.sticky = sticky
+    def __update_publisher(
+        self, pub, new_publisher=False, raise_unknownpubex=True
+    ):
+        errors = []
+        try:
+            if new_publisher:
+                self.__g_update_details_text(
+                    _("Adding publisher %s\n") % pub.prefix
+                )
+                self.api_o.add_publisher(pub)
                 self.no_changes += 1
-                update_text = _("Updating")
-                details_text = _("%(update)s publisher %(name)s\n")
-                self.__g_update_details_text(details_text %
-                    {"update" : update_text, "name" : name})
+            else:
+                self.__g_update_details_text(
+                    _("Updating publisher %s\n") % pub.prefix
+                )
                 self.api_o.update_publisher(pub)
-
-        def __after_confirmation(self):
-                self.__on_manage_publishers_delete_event(
-                    self.w_manage_publishers_dialog, None)
-                return False
-
-        def __proceed_modifyrepo_ok(self):
-                errors = []
-                alias = self.w_modify_pub_alias.get_text()
-                ssl_key = self.w_repositorymodify_key_entry.get_text()
-                ssl_cert = self.w_repositorymodify_cert_entry.get_text()
-                pub = self.repository_modify_publisher
-                repo = pub.repository
-                missing_ssl = False
-                try:
-                        prefix = pub.prefix
-                        mirrors = repo.mirrors
-                        origins = repo.origins
-                        self.api_o.reset()
-                        self.repository_modify_publisher = self.api_o.get_publisher(
-                            prefix=prefix, alias=prefix, duplicate=True)
-                        pub = self.repository_modify_publisher
-                        repo = pub.repository
-                        repo.mirrors = mirrors
-                        repo.origins = origins
-                        if pub.alias != alias:
-                                pub.alias = alias
-                        errors += self.__update_ssl_creds(pub, repo, ssl_cert, ssl_key)
-                        errors += self.__update_pub_certs()
-                        errors += self.__update_pub_sig_policy()
-                        errors += self.__update_publisher(pub, new_publisher=False)
-                except api_errors.ApiException as e:
-                        errors.append((pub, e))
-                self.progress_stop_thread = True
-                if len(errors) > 0:
-                        missing_ssl = self.__is_missing_ssl_creds(pub, ssl_key, ssl_cert)
-                        gobject.idle_add(self.__show_errors, errors, missing_ssl)
-                else:
-                        gobject.idle_add(self.__g_delete_widget_handler_hide,
-                            self.w_modify_repository_dialog, None)
-                        if self.action == enumerations.MANAGE_PUBLISHERS:
-                                gobject.idle_add(self.__prepare_publisher_list, True)
-                                self.no_changes += 1
-
-        @staticmethod
-        def __is_missing_ssl_creds(pub, ssl_key, ssl_cert):
-                repo = pub.repository
-                if ssl_key and len(ssl_key) > 0 and ssl_cert and len(ssl_cert) > 0:
-                        return False
-                for uri in repo.origins:
-                        print(uri)
-                        if uri.scheme in publisher.SSL_SCHEMES:
-                                return True
-                for uri in repo.mirrors:
-                        if uri.scheme in publisher.SSL_SCHEMES:
-                                return True
-                return False
-
-        def __run_with_prog_in_thread(self, func, parent_window = None,
-            cancel_func = None, *f_args):
-                self.progress_stop_thread = False
-                self.cancel_progress_thread = False
-                if cancel_func == None:
-                        self.publishers_apply_cancel.set_sensitive(False)
-                else:
-                        self.publishers_apply_cancel.set_sensitive(True)
-                gui_misc.set_modal_and_transient(self.publishers_apply, parent_window)
-                self.publishers_apply_textview.get_buffer().set_text("")
-                self.publishers_apply.show_all()
-                self.cancel_function = cancel_func
-                gobject.timeout_add(100, self.__progress_pulse)
-                Thread(target = func, args = f_args).start()
-
-        def __progress_pulse(self):
-                if not self.progress_stop_thread:
-                        self.publishers_apply_progress.pulse()
-                        return True
-                else:
-                        self.publishers_apply.hide()
-                        return False
-
-        def __g_update_details_text(self, text, *tags):
-                gobject.idle_add(self.__update_details_text, text, *tags)
-
-        def __update_details_text(self, text, *tags):
-                buf = self.publishers_apply_textview.get_buffer()
-                textiter = buf.get_end_iter()
-                if tags:
-                        buf.insert_with_tags_by_name(textiter, text, *tags)
-                else:
-                        buf.insert(textiter, text)
-                self.publishers_apply_textview.scroll_to_iter(textiter, 0.0)
-
-        # Signal handlers
-        def __on_publisher_selection_changed(self, selection, widget):
-                itr, model = self.__get_selected_publisher_itr_model()
-                if itr and model:
-                        self.__enable_disable_updown_btn(itr, model)
-                        self.__enable_disable_remove_modify_btn(itr, model)
-                        self.__update_publisher_details(
-                            model.get_value(itr, enumerations.PUBLISHER_OBJECT),
-                            self.w_manage_publishers_details)
-
-        def __on_mirror_selection_changed(self, selection, widget):
-                model_itr = selection.get_selected()
-                if model_itr[1]:
-                        self.w_rmmirror_button.set_sensitive(True)
-                else:
-                        self.w_rmmirror_button.set_sensitive(False)
-
-        def __on_origin_selection_changed(self, selection, widget):
-                model_itr = selection.get_selected()
-                if model_itr[1] and \
-                    self.__is_at_least_one_entry(self.modify_repo_origins_treeview):
-                        self.w_rmorigin_button.set_sensitive(True)
-                else:
-                        self.w_rmorigin_button.set_sensitive(False)
-
-        def __g_on_add_publisher_delete_event(self, widget, event):
-                self.__on_add_publisher_delete_event(widget, event)
-                return False
-
-        def __on_add_publisher_delete_event(self, widget, event):
-                self.w_add_publisher_url.set_text("")
-                self.w_add_publisher_alias.set_text("")
-                self.__delete_widget_handler_hide(widget, event)
-                return True
-
-        def __on_add_publisher_complete_delete_event(self, widget, event):
-                if self.no_changes > 0:
-                        self.parent.reload_packages()
-                        if self.action == enumerations.MANAGE_PUBLISHERS:
-                                self.__prepare_publisher_list(True)
-                self.__delete_widget_handler_hide(widget, event)
-                return True
-
-        def __on_publisherurl_changed(self, widget):
-                url = widget.get_text()
-                if self.__is_ssl_scheme(url):
-                        self.w_ssl_box.show()
-                else:
-                        self.w_ssl_box.hide()
-                self.__validate_url(widget,
-                    w_ssl_key=self.w_key_entry, w_ssl_cert=self.w_cert_entry)
-
-        def __on_certentry_changed(self, widget):
-                self.__validate_url_generic(self.w_add_publisher_url,
-                    self.w_add_error_label, self.w_publisher_add_button,
-                    self.is_alias_valid, w_ssl_label=self.w_add_sslerror_label,
-                    w_ssl_key=self.w_key_entry, w_ssl_cert=widget)
-
-        def __on_keyentry_changed(self, widget):
-                self.__validate_url_generic(self.w_add_publisher_url,
-                    self.w_add_error_label, self.w_publisher_add_button,
-                    self.is_alias_valid, w_ssl_label=self.w_add_sslerror_label,
-                    w_ssl_key=widget, w_ssl_cert=self.w_cert_entry)
-
-        def __on_modcertkeyentry_changed(self, widget):
-                self.__on_addorigin_entry_changed(None)
-                self.__on_addmirror_entry_changed(None)
-                ssl_key = self.w_repositorymodify_key_entry.get_text()
-                ssl_cert = self.w_repositorymodify_cert_entry.get_text()
-                ssl_valid, ssl_error = self.__validate_ssl_key_cert(None,
-                    ssl_key, ssl_cert)
-                self.__update_repository_dialog_width(ssl_error)
-                self.w_repositorymodifyok_button.set_sensitive(True)
-                if ssl_valid == False and (len(ssl_key) > 0 or len(ssl_cert) > 0):
-                        self.w_repositorymodifyok_button.set_sensitive(False)
-                        if ssl_error != None:
-                                self.__show_error_label_with_format(
-                                    self.w_modsslerror_label, ssl_error)
-                        else:
-                                self.w_modsslerror_label.set_text("")
-                        return
-                self.w_modsslerror_label.set_text("")
-
-        def __on_addmirror_entry_changed(self, widget):
-                uri_list_model = self.modify_repo_mirrors_treeview.get_model()
-                self.__validate_mirror_origin_url(self.w_addmirror_entry.get_text(),
-                    self.w_addmirror_button, self.w_modmirrerror_label, uri_list_model)
-
-        def __on_addorigin_entry_changed(self, widget):
-                uri_list_model = self.modify_repo_origins_treeview.get_model()
-                self.__validate_mirror_origin_url(self.w_addorigin_entry.get_text(),
-                    self.w_addorigin_button, self.w_modoriginerror_label, uri_list_model)
-
-        def __validate_mirror_origin_url(self, url, add_button, error_label,
-            uri_list_model):
-                url_error = None
-                is_url_valid, url_error = self.__is_url_valid(url)
-                add_button.set_sensitive(False)
-                error_label.set_sensitive(False)
-                error_label.set_markup(self.publisher_info)
-                if len(url) <= 4:
-                        if is_url_valid == False and url_error != None:
-                                self.__show_error_label_with_format(
-                                    error_label, url_error)
-                        return
-
-                for uri_row in uri_list_model:
-                        origin_url = uri_row[0].strip("/")
-                        if origin_url.strip("/") == url.strip("/"):
-                                url_error = _("URI already added")
-                                self.__show_error_label_with_format(
-                                            error_label, url_error)
-                                return
-
-                if is_url_valid == False:
-                        if url_error != None:
-                                self.__show_error_label_with_format(error_label,
-                                    url_error)
-                        return
-                add_button.set_sensitive(True)
-
-        def __is_ssl_specified(self):
-                ssl_key = self.w_repositorymodify_key_entry.get_text()
-                ssl_cert = self.w_repositorymodify_cert_entry.get_text()
-                if len(ssl_key) > 0 or len(ssl_cert) > 0:
-                        return True
-                return False
-
-        def __on_publisheralias_changed(self, widget):
-                error_label = self.w_add_error_label
-                url_widget = self.w_add_publisher_url
-                ok_btn = self.w_publisher_add_button
-                self.__validate_alias_addpub(ok_btn, widget, url_widget, error_label)
-
-        def __on_modify_pub_alias_changed(self, widget):
-                error_label = self.w_modify_alias_error_label
-                ok_btn = self.w_repositorymodifyok_button
-                name = widget.get_text()
-                self.is_alias_valid = self.__is_alias_valid(name)
-                if not self.is_alias_valid and self.name_error != None:
-                        self.__show_error_label_with_format(error_label,
-                                    self.name_error)
-                        ok_btn.set_sensitive(False)
-                else:
-                        error_label.set_text("")
-                        ok_btn.set_sensitive(True)
-
-        def __on_add_publisher_add_clicked(self, widget):
-                if self.w_publisher_add_button.get_property('sensitive') == 0:
-                        return
-                alias = self.w_add_publisher_alias.get_text()
-                if len(alias) == 0:
-                        alias = None
-                url = self.w_add_publisher_url.get_text()
-                ssl_key = self.w_key_entry.get_text()
-                ssl_cert = self.w_cert_entry.get_text()
-                if not self.__is_ssl_scheme(url) or not \
-                    (ssl_key and ssl_cert and os.path.isfile(ssl_cert) and
-                    os.path.isfile(ssl_key)):
-                        ssl_key = None
-                        ssl_cert = None
-                self.__do_add_repository(alias, url, ssl_key, ssl_cert)
-
-        def __on_apply_cancel_clicked(self, widget):
-                if self.cancel_function:
-                        self.cancel_function()
-
-        def __on_add_publisher_cancel_clicked(self, widget):
-                self.__on_add_publisher_delete_event(
-                    self.w_add_publisher_dialog, None)
-
-        def __on_modkeybrowse_clicked(self, widget):
-                self.__keybrowse(self.w_modify_repository_dialog,
-                    self.w_repositorymodify_key_entry,
-                    self.w_repositorymodify_cert_entry)
-
-        def __on_modcertbrowse_clicked(self, widget):
-                self.__certbrowse(self.w_modify_repository_dialog,
-                    self.w_repositorymodify_cert_entry)
-
-        def __on_keybrowse_clicked(self, widget):
-                self.__keybrowse(self.w_add_publisher_dialog,
-                    self.w_key_entry, self.w_cert_entry)
-
-        def __on_certbrowse_clicked(self, widget):
-                self.__certbrowse(self.w_add_publisher_dialog,
-                    self.w_cert_entry)
-
-        def __on_add_publisher_c_close_clicked(self, widget):
-                self.__on_add_publisher_complete_delete_event(
-                    self.w_add_publisher_comp_dialog, None)
-
-        def __on_manage_publishers_delete_event(self, widget, event):
-                self.__delete_widget_handler_hide(widget, event)
-                if self.no_changes > 0:
-                        self.parent.reload_packages()
-                return True
-
-        def __g_delete_widget_handler_hide(self, widget, event):
-                self.__delete_widget_handler_hide(widget, event)
-                return False
-
-        def __on_manage_add_clicked(self, widget):
-                self.w_add_publisher_url.grab_focus()
-                self.w_registration_box.hide()
-                self.__reset_error_label()
-                self.w_add_publisher_dialog.show_all()
-
-        def __reset_error_label(self):
-                self.w_add_error_label.set_markup(self.publisher_info)
-                self.w_add_error_label.set_sensitive(False)
-                self.w_add_error_label.show()
-
-        def __on_manage_modify_clicked(self, widget):
-                itr, model = self.__get_selected_publisher_itr_model()
-                if itr and model:
-                        pub = model.get_value(itr, enumerations.PUBLISHER_OBJECT)
-                        self.__modify_publisher_dialog(pub)
-
-        def __on_manage_remove_clicked(self, widget):
-                itr, model = self.__get_selected_publisher_itr_model()
-                tsel = self.w_publishers_treeview.get_selection()
-                selection = tsel.get_selected()
-                sel_itr = selection[1]
-                sorted_model = selection[0]
-                sorted_path = sorted_model.get_path(sel_itr)
-                if itr and model:
-                        current_priority = model.get_value(itr,
-                            enumerations.PUBLISHER_PRIORITY_CHANGED)
-                        model.set_value(itr, enumerations.PUBLISHER_REMOVED, True)
-                        for element in model:
-                                if element[enumerations.PUBLISHER_PRIORITY_CHANGED] > \
-                                    current_priority:
-                                        element[
-                                            enumerations.PUBLISHER_PRIORITY_CHANGED] -= 1
-                        tsel.select_path(sorted_path)
-                        if not tsel.path_is_selected(sorted_path):
-                                row = sorted_path[0]-1
-                                if row >= 0:
-                                        tsel.select_path((row,))
-                if len(sorted_model) == 0:
-                        self.__set_empty_pub_list()
-
-        def __on_manage_move_up_clicked(self, widget):
-                before_name = None
-                itr, model = self.__get_selected_publisher_itr_model()
-                current_priority = model.get_value(itr,
-                            enumerations.PUBLISHER_PRIORITY_CHANGED)
-                current_name = model.get_value(itr, enumerations.PUBLISHER_NAME)
-                for element in model:
-                        if current_priority == \
-                            element[enumerations.PUBLISHER_PRIORITY_CHANGED]:
-                                element[
-                                    enumerations.PUBLISHER_PRIORITY_CHANGED] -= 1
-                        elif element[enumerations.PUBLISHER_PRIORITY_CHANGED] \
-                            == current_priority - 1 :
-                                before_name = element[enumerations.PUBLISHER_NAME]
-                                element[
-                                    enumerations.PUBLISHER_PRIORITY_CHANGED] += 1
-                self.priority_changes.append([enumerations.PUBLISHER_MOVE_BEFORE,
-                    current_name, before_name])
-                self.__enable_disable_updown_btn(itr, model)
-                self.__move_to_cursor()
-
-        def __move_to_cursor(self):
-                itr, model = self.__get_fitr_model_from_tree(self.w_publishers_treeview)
-                if itr and model:
-                        path = model.get_path(itr)
-                        self.w_publishers_treeview.scroll_to_cell(path)
-
-        def __on_manage_move_down_clicked(self, widget):
-                after_name = None
-                itr, model = self.__get_selected_publisher_itr_model()
-                current_priority = model.get_value(itr,
-                            enumerations.PUBLISHER_PRIORITY_CHANGED)
-                current_name = model.get_value(itr, enumerations.PUBLISHER_NAME)
-                for element in model:
-                        if current_priority == \
-                            element[enumerations.PUBLISHER_PRIORITY_CHANGED]:
-                                element[
-                                    enumerations.PUBLISHER_PRIORITY_CHANGED] += 1
-                        elif element[enumerations.PUBLISHER_PRIORITY_CHANGED] \
-                            == current_priority + 1 :
-                                after_name = element[enumerations.PUBLISHER_NAME]
-                                element[
-                                    enumerations.PUBLISHER_PRIORITY_CHANGED] -= 1
-                self.priority_changes.append([enumerations.PUBLISHER_MOVE_AFTER,
-                    current_name, after_name])
-                self.__enable_disable_updown_btn(itr, model)
-                self.__move_to_cursor()
-
-        def __on_manage_cancel_clicked(self, widget):
-                self.__on_manage_publishers_delete_event(
-                    self.w_manage_publishers_dialog, None)
-
-        def __on_manage_ok_clicked(self, widget):
-                self.__prepare_confirmation_dialog()
-
-        def __on_publishers_apply_delete_event(self, widget, event):
-                self.__on_apply_cancel_clicked(None)
-                return True
-
-        def __on_addmirror_button_clicked(self, widget):
-                if self.w_addmirror_button.get_property('sensitive') == 0:
-                        return
-                new_mirror = self.w_addmirror_entry.get_text()
-                self.__add_mirror(new_mirror)
-
-        def __on_addorigin_button_clicked(self, widget):
-                if self.w_addorigin_button.get_property('sensitive') == 0:
-                        return
-                new_origin = self.w_addorigin_entry.get_text()
-                self.__add_origin(new_origin)
-
-        def __on_rmmirror_button_clicked(self, widget):
-                self.__rm_mirror()
-
-        def __on_rmorigin_button_clicked(self, widget):
-                self.__rm_origin()
-
-        def __on_repositorymodifyok_clicked(self, widget):
-                pub = self.repository_modify_publisher
-                if pub == None:
-                        return
-                error_dialog_title = _("Modify Publisher - %s") % \
-                        self.__get_pub_display_name(pub)
-                text = self.w_pub_sig_name_entry.get_text()
-                req_names = self.w_pub_sig_name_radiobutton.get_active()
-                if not gui_misc.check_sig_required_names_policy(text,
-                    req_names, error_dialog_title):
-                        return
-
-                self.publishers_apply.set_title(_("Applying Changes"))
-                self.__run_with_prog_in_thread(self.__proceed_modifyrepo_ok)
-
-        def __on_modifydialog_delete_event(self, widget, event):
-                if self.w_repositorymodifyok_button.get_sensitive():
-                        self.__on_repositorymodifyok_clicked(None)
-                elif not self.is_alias_valid and self.name_error:
-                        pub = self.repository_modify_publisher
-                        gui_misc.error_occurred(None, self.name_error,
-                            _("Modify Publisher - %s") %
-                            self.__get_pub_display_name(pub),
-                            gtk.MESSAGE_INFO)
-                return True
-
-        def __on_repositorymodifycancel_clicked(self, widget):
-                self.__delete_widget_handler_hide(
-                    self.w_modify_repository_dialog, None)
-
-        def __on_cancel_conf_clicked(self, widget):
-                self.__delete_widget_handler_hide(
-                    self.w_confirmation_dialog, None)
-
-        def __on_ok_conf_clicked(self, widget):
-                self.w_confirmation_dialog.hide()
-                self.publishers_apply.set_title(_("Applying Changes"))
-                self.__run_with_prog_in_thread(self.__proceed_after_confirmation,
-                    self.w_manage_publishers_dialog)
-
-#-----------------------------------------------------------------------------#
-# Static Methods
-#-----------------------------------------------------------------------------#
-        @staticmethod
-        def __check_if_ignore(pub, removed_list):
-                """If we remove a publisher from our model, the priorities of
-                   subsequent publishers  are decremented. We need to ignore the
-                   priority changes caused solely by publisher(s) removal.
-                   This function returns True if the priority change for a publisher
-                   is due to publisher(s) removal or False otherwise."""
-                priority_sum = 0
-                priority = pub[enumerations.PUBLISHER_PRIORITY]
-                priority_changed = pub[enumerations.PUBLISHER_PRIORITY_CHANGED]
-                for num in removed_list:
-                        if num < priority:
-                                priority_sum += 1
-                return (priority == priority_changed + priority_sum)
-
-        @staticmethod
-        def __on_add_pub_help_clicked(widget):
-                gui_misc.display_help("add-publisher")
-
-        @staticmethod
-        def __on_manage_help_clicked(widget):
-                gui_misc.display_help("manage-publisher")
-
-        def __on_modify_repo_help_clicked(self, widget):
-                pagenum = self.w_modify_pub_notebook.get_current_page()
-                if pagenum == MODIFY_NOTEBOOK_GENERAL_PAGE:
-                        tag = "modify-publisher"
-                elif pagenum == MODIFY_NOTEBOOK_CERTIFICATE_PAGE:
-                        tag = "manage-certs"
-                else:
-                        tag = "pub-sig-policy"
-                gui_misc.display_help(tag)
-
-        @staticmethod
-        def __update_publisher_details(pub, details_view):
-                if pub == None:
-                        return
-                details_buffer = details_view.get_buffer()
-                details_buffer.set_text("")
-                uri_itr = details_buffer.get_start_iter()
-                repo = pub.repository
-                num = len(repo.origins)
-                if pub.sys_pub:
-                        details_buffer.insert_with_tags_by_name(uri_itr,
-                            _("System Publisher"),
-                            "level0")
-                        sys_pub_str = _("Cannot be modified or removed.")
-                        details_buffer.insert(uri_itr, "\n%s\n" % sys_pub_str)
-                origin_txt = ngettext("Origin:\n", "Origins:\n", num)
-                details_buffer.insert_with_tags_by_name(uri_itr,
-                    origin_txt, "level0")
-                uri_itr = details_buffer.get_end_iter()
-                for origin in repo.origins:
-                        details_buffer.insert(uri_itr, "%s\n" % str(origin))
-
-        def __show_errors(self, errors, missing_ssl = False):
-                error_msg = ""
-                crerr = ""
-                msg_type = gtk.MESSAGE_ERROR
-                framework_error = False
-
-                msg_title = _("Publisher Error")
-                for err in errors:
-                        if isinstance(err[1], api_errors.CatalogRefreshException):
-                                res = gui_misc.get_catalogrefresh_exception_msg(err[1])
-                                crerr = res[0]
-                                framework_error = res[1]
-                                logger.error(crerr)
-                                gui_misc.notify_log_error(self.parent)
-                        else:
-                                error_msg += str(err[1])
-                                error_msg += "\n\n"
-                # If the only error is a CatalogRefreshException, which we
-                # normally just log but do not display to the user, then
-                # display it to the user.
-                if error_msg == "":
-                        error_msg = crerr
-                        error_msg += "\n"
-                        if framework_error and missing_ssl:
-                                error_msg += _("Note: this may may be the result "
-                                             "of specifying a https Origin, "
-                                             "but no SSL key and certificate.\n")
-                elif missing_ssl:
-                        error_msg += _("Note: this error may be the result of "
-                                     "specifing a https URI, "
-                                     "but no SSL key and certificate.\n")
-                if error_msg != "":
-                        gui_misc.error_occurred(None, error_msg, msg_title, msg_type)
-
-        @staticmethod
-        def __keybrowse(w_parent, key_entry, cert_entry):
-                chooser =  gtk.FileChooserDialog(
-                    title=_("Specify SSL Key File"),
-                    parent = w_parent,
-                    action=gtk.FILE_CHOOSER_ACTION_OPEN,
-                    buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                    gtk.STOCK_OPEN, gtk.RESPONSE_OK))
-                chooser.set_default_response(gtk.RESPONSE_OK)
-                chooser.set_transient_for(w_parent)
-                chooser.set_modal(True)
-                response = chooser.run()
-                if response == gtk.RESPONSE_OK:
-                        key = chooser.get_filename()
-                        key_entry.set_text(key)
-                        cert = key.replace("key", "certificate")
-                        if key != cert and \
-                            cert_entry.get_text() == "":
-                                if os.path.isfile(cert):
-                                        cert_entry.set_text(cert)
-                chooser.destroy()
-
-        @staticmethod
-        def __certbrowse(w_parent, cert_entry):
-                chooser =  gtk.FileChooserDialog(
-                    title=_("Specify SSL Certificate File"),
-                    parent = w_parent,
-                    action=gtk.FILE_CHOOSER_ACTION_OPEN,
-                    buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
-                    gtk.STOCK_OPEN, gtk.RESPONSE_OK))
-                chooser.set_default_response(gtk.RESPONSE_OK)
-                chooser.set_transient_for(w_parent)
-                chooser.set_modal(True)
-                response = chooser.run()
-                if response == gtk.RESPONSE_OK:
-                        cert_entry.set_text(
-                            chooser.get_filename())
-                chooser.destroy()
-
-        @staticmethod
-        def __delete_widget_handler_hide(widget, event):
-                widget.hide()
-                return True
-
-        def __check_publisher_exists(self, api_o, name, origin_url):
-                try:
-                        pub = api_o.get_publisher(prefix=name, alias=name,
-                            duplicate=True)
-                        raise URIExistingPublisher(origin_url, pub)
-                except api_errors.UnknownPublisher:
-                        return False
-                except api_errors.ApiException as e:
-                        gobject.idle_add(self.__show_errors, [(name, e)])
-                        return True
-
-        def __setup_publisher_from_uri(self, alias, origin_url, ssl_key, ssl_cert):
-                try:
-                        self.api_o.reset()
-                        repo = publisher.RepositoryURI(origin_url,
-                            ssl_key = ssl_key, ssl_cert = ssl_cert)
-                        pubs = self.api_o.get_publisherdata(repo=repo)
-                        if not pubs:
-                                raise NoPublishersForURI(origin_url)
-                        src_pub = sorted(pubs)[0]
-                        #For now only handling single Pub per Origin
-                        if len(pubs) > 1:
-                                if self.webinstall_new:
-                                        client_name = _("Web Install")
-                                else:
-                                        client_name = _("Package Manager")
-                                user_image_root = ""
-                                if self.parent.image_directory != "/":
-                                        user_image_root = "-R " + \
-                                                self.parent.image_directory + " "
-                                logger.warning(
-                                _("Origin URI: %(origin_url)s"
-                                "\nhas %(number_pubs)d publishers associated with it.\n"
-                                "%(client_name)s will attempt to add the first "
-                                "publisher, %(pub_name)s.\n"
-                                "To add the remaining publishers use the command:\n"
-                                "'pkg %(user_image_root)sset-publisher "
-                                "-p %(origin_url)s'") %
-                                {"origin_url": origin_url,
-                                "number_pubs": len(pubs),
-                                "client_name": client_name,
-                                "pub_name": src_pub.prefix,
-                                "user_image_root": user_image_root,
-                                })
-                                if not self.webinstall_new:
-                                        gui_misc.notify_log_warning(self.parent)
-                        src_repo = src_pub.repository
-                        add_origins = []
-                        if not src_repo or not src_repo.origins:
-                                add_origins.append(origin_url)
-                        repo = src_pub.repository
-                        if not repo:
-                                repo = publisher.Repository()
-                                src_pub.repository = repo
-                        for url in add_origins:
-                                repo.add_origin(url)
-                        return (src_pub, repo, True)
-                except api_errors.ApiException as e:
-                        if  self.__is_ssl_scheme(origin_url) and \
-                            ((not ssl_key or len(ssl_key) == 0) or \
-                            (not ssl_cert or len(ssl_cert) == 0)) and \
-                            gui_misc.is_frameworkerror(e):
-                                ssl_missing = True
-                        else:
-                                ssl_missing = False
-                        gobject.idle_add(self.__show_errors, [(alias, e)], ssl_missing)
-                        return (None, None, False)
-
-        def __get_or_create_pub_with_url(self, api_o, name, origin_url):
-                new_pub = False
-                repo = None
-                pub = None
-                try:
-                        pub = api_o.get_publisher(prefix=name, alias=name,
-                            duplicate=True)
-                        raise URIExistingPublisher(origin_url, pub)
-                except api_errors.UnknownPublisher:
-                        repo = publisher.Repository()
-                        # We need to specify a name when creating a publisher
-                        # object. It does not matter if it is wrong as the
-                        # __update_publisher() call in __add_repository() will
-                        # fail and it is dealt with there.
-                        if name == None:
-                                name = "None"
-                        pub = publisher.Publisher(name, repository=repo)
-                        new_pub = True
-                        # This part is copied from "def publisher_set(img, args)"
-                        # from the client.py as the publisher API is not ready yet.
-                        if not repo.origins:
-                                repo.add_origin(origin_url)
-                                origin = repo.origins[0]
-                        else:
-                                origin = repo.origins[0]
-                                origin.uri = origin_url
-                except api_errors.ApiException as e:
-                        gobject.idle_add(self.__show_errors, [(name, e)])
-                return (pub, repo, new_pub)
-
-        @staticmethod
-        def __update_ssl_creds(pub, repo, ssl_cert, ssl_key):
-                errors = []
-                # Assume the user wanted to update the ssl_cert or ssl_key
-                # information for *all* of the currently selected
-                # repository's origins and mirrors.
-                try:
-                        for uri in repo.origins:
-                                if uri.scheme not in publisher.SSL_SCHEMES:
-                                        continue
-                                uri.ssl_cert = ssl_cert
-                                uri.ssl_key = ssl_key
-                        for uri in repo.mirrors:
-                                if uri.scheme not in publisher.SSL_SCHEMES:
-                                        continue
-                                uri.ssl_cert = ssl_cert
-                                uri.ssl_key = ssl_key
-                except api_errors.ApiException as e:
-                        errors.append((pub, e))
-                return errors
-
-        @staticmethod
-        def __get_fitr_model_from_tree(treeview):
-                tsel = treeview.get_selection()
-                selection = tsel.get_selected()
-                itr = selection[1]
-                if itr == None:
-                        return (None, None)
-                model = selection[0]
-                return (itr, model)
-
-        @staticmethod
-        def __show_error_label_with_format(w_label, error_string):
-                error_str = ERROR_FORMAT % error_string
-                w_label.set_markup(error_str)
-                w_label.set_sensitive(True)
-                w_label.show()
-
-        def __is_url_valid(self, url):
-                url_error = None
-                if len(url) == 0:
-                        return False, url_error
-                try:
-                        publisher.RepositoryURI(url)
-                        return True, url_error
-                except api_errors.PublisherError:
-                        # Check whether the user has started typing a valid URL.
-                        # If he has we do not display an error message.
-                        valid_start = False
-                        for val in publisher.SUPPORTED_SCHEMES:
-                                check_str = "%s://" % val
-                                if check_str.startswith(url):
-                                        valid_start = True
-                                        break
-                        if valid_start:
-                                url_error = None
-                        else:
-                                url_error = _("URI is not valid")
-                        return False, url_error
-                except api_errors.ApiException as e:
-                        self.__show_errors([("", e)])
-                        return False, url_error
-
-        def __validate_ssl_key_cert(self, origin_url, ssl_key, ssl_cert,
-            ignore_ssl_check_for_not_https = False):
-                '''The SSL Cert and SSL Key may be valid and contain no error'''
-                ssl_error = None
-                ssl_valid = True
-                if origin_url and not self.__is_ssl_scheme(origin_url):
-                        if ignore_ssl_check_for_not_https:
-                                return ssl_valid, ssl_error
-                        if (ssl_key != None and len(ssl_key) != 0) or \
-                            (ssl_cert != None and len(ssl_cert) != 0):
-                                ssl_error = _("SSL should not be specified")
-                                ssl_valid = False
-                        elif (ssl_key == None or len(ssl_key) == 0) or \
-                            (ssl_cert == None or len(ssl_cert) == 0):
-                                ssl_valid = True
-                elif origin_url == None or self.__is_ssl_scheme(origin_url):
-                        if (ssl_key == None or len(ssl_key) == 0) or \
-                            (ssl_cert == None or len(ssl_cert) == 0):
-                        # Key and Cert need not be specified
-                                ssl_valid = True
-                        elif not os.path.isfile(ssl_key):
-                                ssl_error = _("SSL Key not found at specified location")
-                                ssl_valid = False
-                        elif not os.path.isfile(ssl_cert):
-                                ssl_error = \
-                                    _("SSL Certificate not found at specified location")
-                                ssl_valid = False
-                return ssl_valid, ssl_error
-
-        @staticmethod
-        def __is_ssl_scheme(uri):
-                ret_val = False
-                for val in publisher.SSL_SCHEMES:
-                        if uri.startswith(val):
-                                ret_val = True
-                                break
-                return ret_val
-
-        @staticmethod
-        def __init_mirrors_tree_view(treeview):
-                # URI column - 0
-                uri_renderer = gtk.CellRendererText()
-                column = gtk.TreeViewColumn(_("Mirror URI"),
-                    uri_renderer,  text = 0)
-                column.set_expand(True)
-                treeview.append_column(column)
-
-        @staticmethod
-        def __init_origins_tree_view(treeview):
-                # URI column - 0
-                uri_renderer = gtk.CellRendererText()
-                column = gtk.TreeViewColumn(_("Origin URI"),
-                    uri_renderer,  text = 0)
-                column.set_expand(True)
-                treeview.append_column(column)
-
-        @staticmethod
-        def __get_publishers_liststore():
-                return gtk.ListStore(
-                        gobject.TYPE_INT,      # enumerations.PUBLISHER_PRIORITY
-                        gobject.TYPE_INT,      # enumerations.PUBLISHER_PRIORITY_CHANGED
-                        gobject.TYPE_STRING,   # enumerations.PUBLISHER_NAME
-                        gobject.TYPE_STRING,   # enumerations.PUBLISHER_ALIAS
-                        gobject.TYPE_BOOLEAN,  # enumerations.PUBLISHER_ENABLED
-                        gobject.TYPE_BOOLEAN,  # enumerations.PUBLISHER_STICKY
-                        gobject.TYPE_PYOBJECT, # enumerations.PUBLISHER_OBJECT
-                        gobject.TYPE_BOOLEAN,  # enumerations.PUBLISHER_ENABLE_CHANGED
-                        gobject.TYPE_BOOLEAN,  # enumerations.PUBLISHER_STICKY_CHANGED
-                        gobject.TYPE_BOOLEAN,  # enumerations.PUBLISHER_REMOVED
-                        )
-
-        @staticmethod
-        def __get_mirrors_origins_liststore():
-                return gtk.ListStore(
-                        gobject.TYPE_STRING,      # name
-                        )
-
-        @staticmethod
-        def __publishers_filter(model, itr):
-                return not model.get_value(itr, enumerations.PUBLISHER_REMOVED)
-
-        @staticmethod
-        def __toggle_data_function(column, renderer, model, itr, data):
-                if itr:
-                        # Do not allow to remove the publisher if it is a system
-                        # publisher
-                        val = True
-                        pub = model.get_value(itr,
-                            enumerations.PUBLISHER_OBJECT)
-                        if pub.sys_pub:
-                                val = False
-                        renderer.set_property("sensitive", val)
-
-        @staticmethod
-        def __get_registration_uri(repo):
-                #TBD: Change Publisher API to return an RegistrationURI or a String
-                # but not either.
-                # Currently RegistrationURI is coming back with a trailing / this should
-                # be removed.
-                if repo == None:
-                        return None
-                if repo.registration_uri == None:
-                        return None
-                ret_uri = None
-                if isinstance(repo.registration_uri, str):
-                        if len(repo.registration_uri) > 0:
-                                ret_uri = repo.registration_uri.strip("/")
-                elif isinstance(repo.registration_uri, publisher.RepositoryURI):
-                        uri = repo.registration_uri.uri
-                        if uri != None and len(uri) > 0:
-                                ret_uri = uri.strip("/")
-                return ret_uri
-
-#-----------------------------------------------------------------------------#
-# Public Methods
-#-----------------------------------------------------------------------------#
-        def webinstall_new_pub(self, parent, pub = None):
-                if pub == None:
-                        return
-                self.repository_modify_publisher = pub
-                repo = pub.repository
-                origin_uri = ""
-                if repo != None and repo.origins != None and len(repo.origins) > 0:
-                        origin_uri = repo.origins[0].uri
-                if origin_uri != None and self.__is_ssl_scheme(origin_uri):
-                        gui_misc.set_modal_and_transient(self.w_add_publisher_dialog,
-                            parent)
-                        self.main_window = self.w_add_publisher_dialog
-                        self.__on_manage_add_clicked(None)
-                        self.w_add_publisher_url.set_text(origin_uri)
-                        self.w_add_publisher_alias.set_text(pub.alias)
-                        self.w_add_pub_label.hide()
-                        self.w_add_pub_instr_label.hide()
-                        self.w_add_publisher_url.set_sensitive(False)
-                        self.w_add_publisher_alias.set_sensitive(False)
-                        reg_uri = self.__get_registration_uri(repo)
-                        if reg_uri == None or len(reg_uri) == 0:
-                                reg_uri = origin_uri
-                        self.w_registration_link.set_uri(reg_uri)
-                        self.w_registration_box.show()
-                        self.w_ssl_box.show()
-                        self.__validate_url(self.w_add_publisher_url,
-                            w_ssl_key=self.w_key_entry, w_ssl_cert=self.w_cert_entry)
-                        self.w_add_error_label.hide()
-                else:
-                        self.main_window = parent
-                        self.w_ssl_box.hide()
-                        self.__do_add_repository()
-
-        def webinstall_enable_disable_pubs(self, parent, pub_names, to_enable):
-                if pub_names == None:
-                        return
-                num = len(pub_names)
+                self.no_changes += 1
+            if new_publisher:
+                self.__g_update_details_text(
+                    _("Publisher %s succesfully added\n") % pub.prefix
+                )
+            else:
+                self.__g_update_details_text(
+                    _("Publisher %s succesfully updated\n") % pub.prefix
+                )
+        except api_errors.UnknownRepositoryPublishers as e:
+            if raise_unknownpubex:
+                raise e
+            else:
+                errors.append((pub, e))
+        except api_errors.ApiException as e:
+            errors.append((pub, e))
+        return errors
+
+    def __afteradd_confirmation(self, pub):
+        self.new_pub = pub
+        repo = pub.repository
+        origin = repo.origins[0]
+        # Descriptions not available at the moment
+        self.w_add_publisher_c_desc.hide()
+        self.w_add_publisher_c_desc_l.hide()
+        self.w_add_publisher_c_name.set_text(pub.prefix)
+        if pub.alias and len(pub.alias) > 0:
+            self.w_add_publisher_c_alias.set_text(pub.alias)
+        else:
+            self.w_add_publisher_c_alias.hide()
+            self.w_add_publisher_c_alias_l.hide()
+        self.w_add_publisher_c_url.set_text(origin.uri)
+        self.w_add_publisher_comp_dialog.show()
+
+    def __prepare_confirmation_dialog(self):
+        disable = ""
+        enable = ""
+        sticky = ""
+        unsticky = ""
+        delete = ""
+        priority_change = ""
+        disable_no = 0
+        enable_no = 0
+        sticky_no = 0
+        unsticky_no = 0
+        delete_no = 0
+        not_removed = []
+        removed_priorities = []
+        priority_changed = []
+        for row in self.publishers_list:
+            pub_name = row[enumerations.PUBLISHER_NAME]
+            if row[enumerations.PUBLISHER_REMOVED]:
+                delete += "\t" + pub_name + "\n"
+                delete_no += 1
+                removed_priorities.append(row[enumerations.PUBLISHER_PRIORITY])
+            else:
+                if row[enumerations.PUBLISHER_ENABLE_CHANGED]:
+                    to_enable = row[enumerations.PUBLISHER_ENABLED]
+                    if not to_enable:
+                        disable += "\t" + pub_name + "\n"
+                        disable_no += 1
+                    else:
+                        enable += "\t" + pub_name + "\n"
+                        enable_no += 1
+                if row[enumerations.PUBLISHER_STICKY_CHANGED]:
+                    to_sticky = row[enumerations.PUBLISHER_STICKY]
+                    if not to_sticky:
+                        unsticky += "\t" + pub_name + "\n"
+                        unsticky_no += 1
+                    else:
+                        sticky += "\t" + pub_name + "\n"
+                        sticky_no += 1
+                not_removed.append(row)
+
+        for pub in not_removed:
+            if not self.__check_if_ignore(pub, removed_priorities):
+                pub_name = pub[enumerations.PUBLISHER_NAME]
+                pri = pub[enumerations.PUBLISHER_PRIORITY_CHANGED]
+                priority_changed.append([pri, pub_name])
+
+        if (
+            disable_no == 0
+            and enable_no == 0
+            and delete_no == 0
+            and sticky_no == 0
+            and unsticky_no == 0
+            and len(priority_changed) == 0
+        ):
+            self.__on_manage_cancel_clicked(None)
+            return
+
+        priority_changed.sort()
+        for pri, pub_name in priority_changed:
+            priority_change += "\t" + str(pri + 1) + " - " + pub_name + "\n"
+
+        textbuf = self.w_confirmation_textview.get_buffer()
+        textbuf.set_text("")
+        textiter = textbuf.get_end_iter()
+
+        disable_text = ngettext(
+            "Disable Publisher:\n", "Disable Publishers:\n", disable_no
+        )
+        enable_text = ngettext(
+            "Enable Publisher:\n", "Enable Publishers:\n", enable_no
+        )
+        delete_text = ngettext(
+            "Remove Publisher:\n", "Remove Publishers:\n", delete_no
+        )
+        sticky_text = ngettext(
+            "Set sticky Publisher:\n", "Set sticky Publishers:\n", delete_no
+        )
+        unsticky_text = ngettext(
+            "Unset sticky Publisher:\n", "Unset sticky Publishers:\n", delete_no
+        )
+        priority_text = _("Change Priorities:\n")
+
+        confirm_no = (
+            delete_no + enable_no + disable_no + sticky_no + unsticky_no
+        )
+        confirm_text = ngettext(
+            "Apply the following change:",
+            "Apply the following changes:",
+            confirm_no,
+        )
+
+        self.w_confirmation_label.set_markup("<b>" + confirm_text + "</b>")
+
+        if len(delete) > 0:
+            textbuf.insert_with_tags_by_name(textiter, delete_text, "bold")
+            textbuf.insert_with_tags_by_name(textiter, delete)
+        if len(disable) > 0:
+            if len(delete) > 0:
+                textbuf.insert_with_tags_by_name(textiter, "\n")
+            textbuf.insert_with_tags_by_name(textiter, disable_text, "bold")
+            textbuf.insert_with_tags_by_name(textiter, disable)
+        if len(enable) > 0:
+            if len(delete) > 0 or len(disable) > 0:
+                textbuf.insert_with_tags_by_name(textiter, "\n")
+            textbuf.insert_with_tags_by_name(textiter, enable_text, "bold")
+            textbuf.insert_with_tags_by_name(textiter, enable)
+        if len(sticky) > 0:
+            if len(delete) > 0 or len(disable) > 0 or len(enable) > 0:
+                textbuf.insert_with_tags_by_name(textiter, "\n")
+            textbuf.insert_with_tags_by_name(textiter, sticky_text, "bold")
+            textbuf.insert_with_tags_by_name(textiter, sticky)
+        if len(unsticky) > 0:
+            if (
+                len(delete) > 0
+                or len(disable) > 0
+                or len(enable) > 0
+                or len(sticky) > 0
+            ):
+                textbuf.insert_with_tags_by_name(textiter, "\n")
+            textbuf.insert_with_tags_by_name(textiter, unsticky_text, "bold")
+            textbuf.insert_with_tags_by_name(textiter, unsticky)
+        if len(priority_change) > 0:
+            if len(delete) > 0 or len(disable) or len(enable) > 0:
+                textbuf.insert_with_tags_by_name(textiter, "\n")
+            textbuf.insert_with_tags_by_name(textiter, priority_text, "bold")
+            textbuf.insert_with_tags_by_name(textiter, priority_change)
+
+        self.w_confirm_cancel_btn.grab_focus()
+        self.w_confirmation_dialog.show_all()
+
+    def __proceed_enable_disable(self, pub_names, to_enable):
+        errors = []
+
+        gobject.idle_add(self.publishers_apply_expander.set_expanded, True)
+        for name in pub_names.keys():
+            try:
+                pub = self.api_o.get_publisher(name, duplicate=True)
+                if pub.disabled == (not to_enable):
+                    continue
+                pub.disabled = not to_enable
+                self.no_changes += 1
+                enable_text = _("Disabling")
                 if to_enable:
-                        msg = ngettext("Enabling Publisher", "Enabling Publishers", num)
+                    enable_text = _("Enabling")
+
+                details_text = _("%(enable)s publisher %(name)s\n")
+                self.__g_update_details_text(
+                    details_text % {"enable": enable_text, "name": name}
+                )
+                self.api_o.update_publisher(pub)
+            except api_errors.ApiException as e:
+                errors.append(pub, e)
+        self.progress_stop_thread = True
+        gobject.idle_add(self.publishers_apply_expander.set_expanded, False)
+        if len(errors) > 0:
+            gobject.idle_add(self.__show_errors, errors)
+        else:
+            gobject.idle_add(self.parent.reload_packages, False)
+
+    def __proceed_after_confirmation(self):
+        errors = []
+
+        image_lock_err = False
+        for row in self.priority_changes:
+            try:
+                if row[1] == None or row[2] == None:
+                    continue
+                pub1 = self.api_o.get_publisher(row[1], duplicate=True)
+                pub2 = self.api_o.get_publisher(row[2], duplicate=True)
+                if row[0] == enumerations.PUBLISHER_MOVE_BEFORE:
+                    self.api_o.update_publisher(pub1, search_before=pub2.prefix)
                 else:
-                        msg = ngettext("Disabling Publisher", "Disabling Publishers", num)
-                self.publishers_apply.set_title(msg)
+                    self.api_o.update_publisher(pub1, search_after=pub2.prefix)
+                self.no_changes += 1
+                self.__g_update_details_text(
+                    _("Changing priority for publisher %s\n") % row[1]
+                )
+            except api_errors.ImageLockedError as e:
+                self.no_changes = 0
+                if not image_lock_err:
+                    errors.append((row[1], e))
+                    image_lock_err = True
+            except api_errors.ApiException as e:
+                errors.append((row[1], e))
 
-                self.__run_with_prog_in_thread(self.__proceed_enable_disable,
-                    parent, None, pub_names, to_enable)
+        for row in self.publishers_list:
+            name = row[enumerations.PUBLISHER_NAME]
+            try:
+                if row[enumerations.PUBLISHER_REMOVED]:
+                    self.no_changes += 1
+                    self.__g_update_details_text(
+                        _("Removing publisher %s\n") % name
+                    )
+                    self.api_o.remove_publisher(prefix=name, alias=name)
+                    self.__g_update_details_text(
+                        _("Publisher %s succesfully removed\n") % name
+                    )
+                elif (
+                    row[enumerations.PUBLISHER_ENABLE_CHANGED]
+                    or row[enumerations.PUBLISHER_STICKY_CHANGED]
+                ):
+                    self.__do_changes_for_row(row, name)
+            except api_errors.ImageLockedError as e:
+                self.no_changes = 0
+                if not image_lock_err:
+                    errors.append((row[enumerations.PUBLISHER_OBJECT], e))
+                    image_lock_err = True
+            except api_errors.ApiException as e:
+                errors.append((row[enumerations.PUBLISHER_OBJECT], e))
+        self.progress_stop_thread = True
+        if len(errors) > 0:
+            gobject.idle_add(self.__show_errors, errors)
+        else:
+            gobject.idle_add(self.__after_confirmation)
 
-        def update_label_text(self, markup_text):
-                self.__g_update_details_text(markup_text)
+    def __do_changes_for_row(self, row, name):
+        pub = self.api_o.get_publisher(name, duplicate=True)
+        if row[enumerations.PUBLISHER_ENABLE_CHANGED]:
+            to_enable = row[enumerations.PUBLISHER_ENABLED]
+            pub.disabled = not to_enable
+        if row[enumerations.PUBLISHER_STICKY_CHANGED]:
+            sticky = row[enumerations.PUBLISHER_STICKY]
+            pub.sticky = sticky
+        self.no_changes += 1
+        update_text = _("Updating")
+        details_text = _("%(update)s publisher %(name)s\n")
+        self.__g_update_details_text(
+            details_text % {"update": update_text, "name": name}
+        )
+        self.api_o.update_publisher(pub)
 
-        def update_details_text(self, text, *tags):
-                self.__g_update_details_text(text, *tags)
+    def __after_confirmation(self):
+        self.__on_manage_publishers_delete_event(
+            self.w_manage_publishers_dialog, None
+        )
+        return False
 
-        def update_progress(self, current_progress, total_progress):
-                pass
+    def __proceed_modifyrepo_ok(self):
+        errors = []
+        alias = self.w_modify_pub_alias.get_text()
+        ssl_key = self.w_repositorymodify_key_entry.get_text()
+        ssl_cert = self.w_repositorymodify_cert_entry.get_text()
+        pub = self.repository_modify_publisher
+        repo = pub.repository
+        missing_ssl = False
+        try:
+            prefix = pub.prefix
+            mirrors = repo.mirrors
+            origins = repo.origins
+            self.api_o.reset()
+            self.repository_modify_publisher = self.api_o.get_publisher(
+                prefix=prefix, alias=prefix, duplicate=True
+            )
+            pub = self.repository_modify_publisher
+            repo = pub.repository
+            repo.mirrors = mirrors
+            repo.origins = origins
+            if pub.alias != alias:
+                pub.alias = alias
+            errors += self.__update_ssl_creds(pub, repo, ssl_cert, ssl_key)
+            errors += self.__update_pub_certs()
+            errors += self.__update_pub_sig_policy()
+            errors += self.__update_publisher(pub, new_publisher=False)
+        except api_errors.ApiException as e:
+            errors.append((pub, e))
+        self.progress_stop_thread = True
+        if len(errors) > 0:
+            missing_ssl = self.__is_missing_ssl_creds(pub, ssl_key, ssl_cert)
+            gobject.idle_add(self.__show_errors, errors, missing_ssl)
+        else:
+            gobject.idle_add(
+                self.__g_delete_widget_handler_hide,
+                self.w_modify_repository_dialog,
+                None,
+            )
+            if self.action == enumerations.MANAGE_PUBLISHERS:
+                gobject.idle_add(self.__prepare_publisher_list, True)
+                self.no_changes += 1
 
-        def start_bouncing_progress(self):
-                pass
-
-        def is_progress_bouncing(self):
-                self.pylintstub = self
+    @staticmethod
+    def __is_missing_ssl_creds(pub, ssl_key, ssl_cert):
+        repo = pub.repository
+        if ssl_key and len(ssl_key) > 0 and ssl_cert and len(ssl_cert) > 0:
+            return False
+        for uri in repo.origins:
+            print(uri)
+            if uri.scheme in publisher.SSL_SCHEMES:
                 return True
+        for uri in repo.mirrors:
+            if uri.scheme in publisher.SSL_SCHEMES:
+                return True
+        return False
 
-        def stop_bouncing_progress(self):
-                pass
+    def __run_with_prog_in_thread(
+        self, func, parent_window=None, cancel_func=None, *f_args
+    ):
+        self.progress_stop_thread = False
+        self.cancel_progress_thread = False
+        if cancel_func == None:
+            self.publishers_apply_cancel.set_sensitive(False)
+        else:
+            self.publishers_apply_cancel.set_sensitive(True)
+        gui_misc.set_modal_and_transient(self.publishers_apply, parent_window)
+        self.publishers_apply_textview.get_buffer().set_text("")
+        self.publishers_apply.show_all()
+        self.cancel_function = cancel_func
+        gobject.timeout_add(100, self.__progress_pulse)
+        Thread(target=func, args=f_args).start()
 
-        def display_download_info(self):
-                pass
+    def __progress_pulse(self):
+        if not self.progress_stop_thread:
+            self.publishers_apply_progress.pulse()
+            return True
+        else:
+            self.publishers_apply.hide()
+            return False
 
-        def display_phase_info(self, phase_name, cur_n, goal_n):
-                pass
+    def __g_update_details_text(self, text, *tags):
+        gobject.idle_add(self.__update_details_text, text, *tags)
 
-        def reset_label_text_after_delay(self):
-                pass
+    def __update_details_text(self, text, *tags):
+        buf = self.publishers_apply_textview.get_buffer()
+        textiter = buf.get_end_iter()
+        if tags:
+            buf.insert_with_tags_by_name(textiter, text, *tags)
+        else:
+            buf.insert(textiter, text)
+        self.publishers_apply_textview.scroll_to_iter(textiter, 0.0)
+
+    # Signal handlers
+    def __on_publisher_selection_changed(self, selection, widget):
+        itr, model = self.__get_selected_publisher_itr_model()
+        if itr and model:
+            self.__enable_disable_updown_btn(itr, model)
+            self.__enable_disable_remove_modify_btn(itr, model)
+            self.__update_publisher_details(
+                model.get_value(itr, enumerations.PUBLISHER_OBJECT),
+                self.w_manage_publishers_details,
+            )
+
+    def __on_mirror_selection_changed(self, selection, widget):
+        model_itr = selection.get_selected()
+        if model_itr[1]:
+            self.w_rmmirror_button.set_sensitive(True)
+        else:
+            self.w_rmmirror_button.set_sensitive(False)
+
+    def __on_origin_selection_changed(self, selection, widget):
+        model_itr = selection.get_selected()
+        if model_itr[1] and self.__is_at_least_one_entry(
+            self.modify_repo_origins_treeview
+        ):
+            self.w_rmorigin_button.set_sensitive(True)
+        else:
+            self.w_rmorigin_button.set_sensitive(False)
+
+    def __g_on_add_publisher_delete_event(self, widget, event):
+        self.__on_add_publisher_delete_event(widget, event)
+        return False
+
+    def __on_add_publisher_delete_event(self, widget, event):
+        self.w_add_publisher_url.set_text("")
+        self.w_add_publisher_alias.set_text("")
+        self.__delete_widget_handler_hide(widget, event)
+        return True
+
+    def __on_add_publisher_complete_delete_event(self, widget, event):
+        if self.no_changes > 0:
+            self.parent.reload_packages()
+            if self.action == enumerations.MANAGE_PUBLISHERS:
+                self.__prepare_publisher_list(True)
+        self.__delete_widget_handler_hide(widget, event)
+        return True
+
+    def __on_publisherurl_changed(self, widget):
+        url = widget.get_text()
+        if self.__is_ssl_scheme(url):
+            self.w_ssl_box.show()
+        else:
+            self.w_ssl_box.hide()
+        self.__validate_url(
+            widget, w_ssl_key=self.w_key_entry, w_ssl_cert=self.w_cert_entry
+        )
+
+    def __on_certentry_changed(self, widget):
+        self.__validate_url_generic(
+            self.w_add_publisher_url,
+            self.w_add_error_label,
+            self.w_publisher_add_button,
+            self.is_alias_valid,
+            w_ssl_label=self.w_add_sslerror_label,
+            w_ssl_key=self.w_key_entry,
+            w_ssl_cert=widget,
+        )
+
+    def __on_keyentry_changed(self, widget):
+        self.__validate_url_generic(
+            self.w_add_publisher_url,
+            self.w_add_error_label,
+            self.w_publisher_add_button,
+            self.is_alias_valid,
+            w_ssl_label=self.w_add_sslerror_label,
+            w_ssl_key=widget,
+            w_ssl_cert=self.w_cert_entry,
+        )
+
+    def __on_modcertkeyentry_changed(self, widget):
+        self.__on_addorigin_entry_changed(None)
+        self.__on_addmirror_entry_changed(None)
+        ssl_key = self.w_repositorymodify_key_entry.get_text()
+        ssl_cert = self.w_repositorymodify_cert_entry.get_text()
+        ssl_valid, ssl_error = self.__validate_ssl_key_cert(
+            None, ssl_key, ssl_cert
+        )
+        self.__update_repository_dialog_width(ssl_error)
+        self.w_repositorymodifyok_button.set_sensitive(True)
+        if ssl_valid == False and (len(ssl_key) > 0 or len(ssl_cert) > 0):
+            self.w_repositorymodifyok_button.set_sensitive(False)
+            if ssl_error != None:
+                self.__show_error_label_with_format(
+                    self.w_modsslerror_label, ssl_error
+                )
+            else:
+                self.w_modsslerror_label.set_text("")
+            return
+        self.w_modsslerror_label.set_text("")
+
+    def __on_addmirror_entry_changed(self, widget):
+        uri_list_model = self.modify_repo_mirrors_treeview.get_model()
+        self.__validate_mirror_origin_url(
+            self.w_addmirror_entry.get_text(),
+            self.w_addmirror_button,
+            self.w_modmirrerror_label,
+            uri_list_model,
+        )
+
+    def __on_addorigin_entry_changed(self, widget):
+        uri_list_model = self.modify_repo_origins_treeview.get_model()
+        self.__validate_mirror_origin_url(
+            self.w_addorigin_entry.get_text(),
+            self.w_addorigin_button,
+            self.w_modoriginerror_label,
+            uri_list_model,
+        )
+
+    def __validate_mirror_origin_url(
+        self, url, add_button, error_label, uri_list_model
+    ):
+        url_error = None
+        is_url_valid, url_error = self.__is_url_valid(url)
+        add_button.set_sensitive(False)
+        error_label.set_sensitive(False)
+        error_label.set_markup(self.publisher_info)
+        if len(url) <= 4:
+            if is_url_valid == False and url_error != None:
+                self.__show_error_label_with_format(error_label, url_error)
+            return
+
+        for uri_row in uri_list_model:
+            origin_url = uri_row[0].strip("/")
+            if origin_url.strip("/") == url.strip("/"):
+                url_error = _("URI already added")
+                self.__show_error_label_with_format(error_label, url_error)
+                return
+
+        if is_url_valid == False:
+            if url_error != None:
+                self.__show_error_label_with_format(error_label, url_error)
+            return
+        add_button.set_sensitive(True)
+
+    def __is_ssl_specified(self):
+        ssl_key = self.w_repositorymodify_key_entry.get_text()
+        ssl_cert = self.w_repositorymodify_cert_entry.get_text()
+        if len(ssl_key) > 0 or len(ssl_cert) > 0:
+            return True
+        return False
+
+    def __on_publisheralias_changed(self, widget):
+        error_label = self.w_add_error_label
+        url_widget = self.w_add_publisher_url
+        ok_btn = self.w_publisher_add_button
+        self.__validate_alias_addpub(ok_btn, widget, url_widget, error_label)
+
+    def __on_modify_pub_alias_changed(self, widget):
+        error_label = self.w_modify_alias_error_label
+        ok_btn = self.w_repositorymodifyok_button
+        name = widget.get_text()
+        self.is_alias_valid = self.__is_alias_valid(name)
+        if not self.is_alias_valid and self.name_error != None:
+            self.__show_error_label_with_format(error_label, self.name_error)
+            ok_btn.set_sensitive(False)
+        else:
+            error_label.set_text("")
+            ok_btn.set_sensitive(True)
+
+    def __on_add_publisher_add_clicked(self, widget):
+        if self.w_publisher_add_button.get_property("sensitive") == 0:
+            return
+        alias = self.w_add_publisher_alias.get_text()
+        if len(alias) == 0:
+            alias = None
+        url = self.w_add_publisher_url.get_text()
+        ssl_key = self.w_key_entry.get_text()
+        ssl_cert = self.w_cert_entry.get_text()
+        if not self.__is_ssl_scheme(url) or not (
+            ssl_key
+            and ssl_cert
+            and os.path.isfile(ssl_cert)
+            and os.path.isfile(ssl_key)
+        ):
+            ssl_key = None
+            ssl_cert = None
+        self.__do_add_repository(alias, url, ssl_key, ssl_cert)
+
+    def __on_apply_cancel_clicked(self, widget):
+        if self.cancel_function:
+            self.cancel_function()
+
+    def __on_add_publisher_cancel_clicked(self, widget):
+        self.__on_add_publisher_delete_event(self.w_add_publisher_dialog, None)
+
+    def __on_modkeybrowse_clicked(self, widget):
+        self.__keybrowse(
+            self.w_modify_repository_dialog,
+            self.w_repositorymodify_key_entry,
+            self.w_repositorymodify_cert_entry,
+        )
+
+    def __on_modcertbrowse_clicked(self, widget):
+        self.__certbrowse(
+            self.w_modify_repository_dialog, self.w_repositorymodify_cert_entry
+        )
+
+    def __on_keybrowse_clicked(self, widget):
+        self.__keybrowse(
+            self.w_add_publisher_dialog, self.w_key_entry, self.w_cert_entry
+        )
+
+    def __on_certbrowse_clicked(self, widget):
+        self.__certbrowse(self.w_add_publisher_dialog, self.w_cert_entry)
+
+    def __on_add_publisher_c_close_clicked(self, widget):
+        self.__on_add_publisher_complete_delete_event(
+            self.w_add_publisher_comp_dialog, None
+        )
+
+    def __on_manage_publishers_delete_event(self, widget, event):
+        self.__delete_widget_handler_hide(widget, event)
+        if self.no_changes > 0:
+            self.parent.reload_packages()
+        return True
+
+    def __g_delete_widget_handler_hide(self, widget, event):
+        self.__delete_widget_handler_hide(widget, event)
+        return False
+
+    def __on_manage_add_clicked(self, widget):
+        self.w_add_publisher_url.grab_focus()
+        self.w_registration_box.hide()
+        self.__reset_error_label()
+        self.w_add_publisher_dialog.show_all()
+
+    def __reset_error_label(self):
+        self.w_add_error_label.set_markup(self.publisher_info)
+        self.w_add_error_label.set_sensitive(False)
+        self.w_add_error_label.show()
+
+    def __on_manage_modify_clicked(self, widget):
+        itr, model = self.__get_selected_publisher_itr_model()
+        if itr and model:
+            pub = model.get_value(itr, enumerations.PUBLISHER_OBJECT)
+            self.__modify_publisher_dialog(pub)
+
+    def __on_manage_remove_clicked(self, widget):
+        itr, model = self.__get_selected_publisher_itr_model()
+        tsel = self.w_publishers_treeview.get_selection()
+        selection = tsel.get_selected()
+        sel_itr = selection[1]
+        sorted_model = selection[0]
+        sorted_path = sorted_model.get_path(sel_itr)
+        if itr and model:
+            current_priority = model.get_value(
+                itr, enumerations.PUBLISHER_PRIORITY_CHANGED
+            )
+            model.set_value(itr, enumerations.PUBLISHER_REMOVED, True)
+            for element in model:
+                if (
+                    element[enumerations.PUBLISHER_PRIORITY_CHANGED]
+                    > current_priority
+                ):
+                    element[enumerations.PUBLISHER_PRIORITY_CHANGED] -= 1
+            tsel.select_path(sorted_path)
+            if not tsel.path_is_selected(sorted_path):
+                row = sorted_path[0] - 1
+                if row >= 0:
+                    tsel.select_path((row,))
+        if len(sorted_model) == 0:
+            self.__set_empty_pub_list()
+
+    def __on_manage_move_up_clicked(self, widget):
+        before_name = None
+        itr, model = self.__get_selected_publisher_itr_model()
+        current_priority = model.get_value(
+            itr, enumerations.PUBLISHER_PRIORITY_CHANGED
+        )
+        current_name = model.get_value(itr, enumerations.PUBLISHER_NAME)
+        for element in model:
+            if (
+                current_priority
+                == element[enumerations.PUBLISHER_PRIORITY_CHANGED]
+            ):
+                element[enumerations.PUBLISHER_PRIORITY_CHANGED] -= 1
+            elif (
+                element[enumerations.PUBLISHER_PRIORITY_CHANGED]
+                == current_priority - 1
+            ):
+                before_name = element[enumerations.PUBLISHER_NAME]
+                element[enumerations.PUBLISHER_PRIORITY_CHANGED] += 1
+        self.priority_changes.append(
+            [enumerations.PUBLISHER_MOVE_BEFORE, current_name, before_name]
+        )
+        self.__enable_disable_updown_btn(itr, model)
+        self.__move_to_cursor()
+
+    def __move_to_cursor(self):
+        itr, model = self.__get_fitr_model_from_tree(self.w_publishers_treeview)
+        if itr and model:
+            path = model.get_path(itr)
+            self.w_publishers_treeview.scroll_to_cell(path)
+
+    def __on_manage_move_down_clicked(self, widget):
+        after_name = None
+        itr, model = self.__get_selected_publisher_itr_model()
+        current_priority = model.get_value(
+            itr, enumerations.PUBLISHER_PRIORITY_CHANGED
+        )
+        current_name = model.get_value(itr, enumerations.PUBLISHER_NAME)
+        for element in model:
+            if (
+                current_priority
+                == element[enumerations.PUBLISHER_PRIORITY_CHANGED]
+            ):
+                element[enumerations.PUBLISHER_PRIORITY_CHANGED] += 1
+            elif (
+                element[enumerations.PUBLISHER_PRIORITY_CHANGED]
+                == current_priority + 1
+            ):
+                after_name = element[enumerations.PUBLISHER_NAME]
+                element[enumerations.PUBLISHER_PRIORITY_CHANGED] -= 1
+        self.priority_changes.append(
+            [enumerations.PUBLISHER_MOVE_AFTER, current_name, after_name]
+        )
+        self.__enable_disable_updown_btn(itr, model)
+        self.__move_to_cursor()
+
+    def __on_manage_cancel_clicked(self, widget):
+        self.__on_manage_publishers_delete_event(
+            self.w_manage_publishers_dialog, None
+        )
+
+    def __on_manage_ok_clicked(self, widget):
+        self.__prepare_confirmation_dialog()
+
+    def __on_publishers_apply_delete_event(self, widget, event):
+        self.__on_apply_cancel_clicked(None)
+        return True
+
+    def __on_addmirror_button_clicked(self, widget):
+        if self.w_addmirror_button.get_property("sensitive") == 0:
+            return
+        new_mirror = self.w_addmirror_entry.get_text()
+        self.__add_mirror(new_mirror)
+
+    def __on_addorigin_button_clicked(self, widget):
+        if self.w_addorigin_button.get_property("sensitive") == 0:
+            return
+        new_origin = self.w_addorigin_entry.get_text()
+        self.__add_origin(new_origin)
+
+    def __on_rmmirror_button_clicked(self, widget):
+        self.__rm_mirror()
+
+    def __on_rmorigin_button_clicked(self, widget):
+        self.__rm_origin()
+
+    def __on_repositorymodifyok_clicked(self, widget):
+        pub = self.repository_modify_publisher
+        if pub == None:
+            return
+        error_dialog_title = _(
+            "Modify Publisher - %s"
+        ) % self.__get_pub_display_name(pub)
+        text = self.w_pub_sig_name_entry.get_text()
+        req_names = self.w_pub_sig_name_radiobutton.get_active()
+        if not gui_misc.check_sig_required_names_policy(
+            text, req_names, error_dialog_title
+        ):
+            return
+
+        self.publishers_apply.set_title(_("Applying Changes"))
+        self.__run_with_prog_in_thread(self.__proceed_modifyrepo_ok)
+
+    def __on_modifydialog_delete_event(self, widget, event):
+        if self.w_repositorymodifyok_button.get_sensitive():
+            self.__on_repositorymodifyok_clicked(None)
+        elif not self.is_alias_valid and self.name_error:
+            pub = self.repository_modify_publisher
+            gui_misc.error_occurred(
+                None,
+                self.name_error,
+                _("Modify Publisher - %s") % self.__get_pub_display_name(pub),
+                gtk.MESSAGE_INFO,
+            )
+        return True
+
+    def __on_repositorymodifycancel_clicked(self, widget):
+        self.__delete_widget_handler_hide(self.w_modify_repository_dialog, None)
+
+    def __on_cancel_conf_clicked(self, widget):
+        self.__delete_widget_handler_hide(self.w_confirmation_dialog, None)
+
+    def __on_ok_conf_clicked(self, widget):
+        self.w_confirmation_dialog.hide()
+        self.publishers_apply.set_title(_("Applying Changes"))
+        self.__run_with_prog_in_thread(
+            self.__proceed_after_confirmation, self.w_manage_publishers_dialog
+        )
+
+    # -----------------------------------------------------------------------------#
+    # Static Methods
+    # -----------------------------------------------------------------------------#
+    @staticmethod
+    def __check_if_ignore(pub, removed_list):
+        """If we remove a publisher from our model, the priorities of
+        subsequent publishers  are decremented. We need to ignore the
+        priority changes caused solely by publisher(s) removal.
+        This function returns True if the priority change for a publisher
+        is due to publisher(s) removal or False otherwise."""
+        priority_sum = 0
+        priority = pub[enumerations.PUBLISHER_PRIORITY]
+        priority_changed = pub[enumerations.PUBLISHER_PRIORITY_CHANGED]
+        for num in removed_list:
+            if num < priority:
+                priority_sum += 1
+        return priority == priority_changed + priority_sum
+
+    @staticmethod
+    def __on_add_pub_help_clicked(widget):
+        gui_misc.display_help("add-publisher")
+
+    @staticmethod
+    def __on_manage_help_clicked(widget):
+        gui_misc.display_help("manage-publisher")
+
+    def __on_modify_repo_help_clicked(self, widget):
+        pagenum = self.w_modify_pub_notebook.get_current_page()
+        if pagenum == MODIFY_NOTEBOOK_GENERAL_PAGE:
+            tag = "modify-publisher"
+        elif pagenum == MODIFY_NOTEBOOK_CERTIFICATE_PAGE:
+            tag = "manage-certs"
+        else:
+            tag = "pub-sig-policy"
+        gui_misc.display_help(tag)
+
+    @staticmethod
+    def __update_publisher_details(pub, details_view):
+        if pub == None:
+            return
+        details_buffer = details_view.get_buffer()
+        details_buffer.set_text("")
+        uri_itr = details_buffer.get_start_iter()
+        repo = pub.repository
+        num = len(repo.origins)
+        if pub.sys_pub:
+            details_buffer.insert_with_tags_by_name(
+                uri_itr, _("System Publisher"), "level0"
+            )
+            sys_pub_str = _("Cannot be modified or removed.")
+            details_buffer.insert(uri_itr, "\n%s\n" % sys_pub_str)
+        origin_txt = ngettext("Origin:\n", "Origins:\n", num)
+        details_buffer.insert_with_tags_by_name(uri_itr, origin_txt, "level0")
+        uri_itr = details_buffer.get_end_iter()
+        for origin in repo.origins:
+            details_buffer.insert(uri_itr, "%s\n" % str(origin))
+
+    def __show_errors(self, errors, missing_ssl=False):
+        error_msg = ""
+        crerr = ""
+        msg_type = gtk.MESSAGE_ERROR
+        framework_error = False
+
+        msg_title = _("Publisher Error")
+        for err in errors:
+            if isinstance(err[1], api_errors.CatalogRefreshException):
+                res = gui_misc.get_catalogrefresh_exception_msg(err[1])
+                crerr = res[0]
+                framework_error = res[1]
+                logger.error(crerr)
+                gui_misc.notify_log_error(self.parent)
+            else:
+                error_msg += str(err[1])
+                error_msg += "\n\n"
+        # If the only error is a CatalogRefreshException, which we
+        # normally just log but do not display to the user, then
+        # display it to the user.
+        if error_msg == "":
+            error_msg = crerr
+            error_msg += "\n"
+            if framework_error and missing_ssl:
+                error_msg += _(
+                    "Note: this may may be the result "
+                    "of specifying a https Origin, "
+                    "but no SSL key and certificate.\n"
+                )
+        elif missing_ssl:
+            error_msg += _(
+                "Note: this error may be the result of "
+                "specifing a https URI, "
+                "but no SSL key and certificate.\n"
+            )
+        if error_msg != "":
+            gui_misc.error_occurred(None, error_msg, msg_title, msg_type)
+
+    @staticmethod
+    def __keybrowse(w_parent, key_entry, cert_entry):
+        chooser = gtk.FileChooserDialog(
+            title=_("Specify SSL Key File"),
+            parent=w_parent,
+            action=gtk.FILE_CHOOSER_ACTION_OPEN,
+            buttons=(
+                gtk.STOCK_CANCEL,
+                gtk.RESPONSE_CANCEL,
+                gtk.STOCK_OPEN,
+                gtk.RESPONSE_OK,
+            ),
+        )
+        chooser.set_default_response(gtk.RESPONSE_OK)
+        chooser.set_transient_for(w_parent)
+        chooser.set_modal(True)
+        response = chooser.run()
+        if response == gtk.RESPONSE_OK:
+            key = chooser.get_filename()
+            key_entry.set_text(key)
+            cert = key.replace("key", "certificate")
+            if key != cert and cert_entry.get_text() == "":
+                if os.path.isfile(cert):
+                    cert_entry.set_text(cert)
+        chooser.destroy()
+
+    @staticmethod
+    def __certbrowse(w_parent, cert_entry):
+        chooser = gtk.FileChooserDialog(
+            title=_("Specify SSL Certificate File"),
+            parent=w_parent,
+            action=gtk.FILE_CHOOSER_ACTION_OPEN,
+            buttons=(
+                gtk.STOCK_CANCEL,
+                gtk.RESPONSE_CANCEL,
+                gtk.STOCK_OPEN,
+                gtk.RESPONSE_OK,
+            ),
+        )
+        chooser.set_default_response(gtk.RESPONSE_OK)
+        chooser.set_transient_for(w_parent)
+        chooser.set_modal(True)
+        response = chooser.run()
+        if response == gtk.RESPONSE_OK:
+            cert_entry.set_text(chooser.get_filename())
+        chooser.destroy()
+
+    @staticmethod
+    def __delete_widget_handler_hide(widget, event):
+        widget.hide()
+        return True
+
+    def __check_publisher_exists(self, api_o, name, origin_url):
+        try:
+            pub = api_o.get_publisher(prefix=name, alias=name, duplicate=True)
+            raise URIExistingPublisher(origin_url, pub)
+        except api_errors.UnknownPublisher:
+            return False
+        except api_errors.ApiException as e:
+            gobject.idle_add(self.__show_errors, [(name, e)])
+            return True
+
+    def __setup_publisher_from_uri(self, alias, origin_url, ssl_key, ssl_cert):
+        try:
+            self.api_o.reset()
+            repo = publisher.RepositoryURI(
+                origin_url, ssl_key=ssl_key, ssl_cert=ssl_cert
+            )
+            pubs = self.api_o.get_publisherdata(repo=repo)
+            if not pubs:
+                raise NoPublishersForURI(origin_url)
+            src_pub = sorted(pubs)[0]
+            # For now only handling single Pub per Origin
+            if len(pubs) > 1:
+                if self.webinstall_new:
+                    client_name = _("Web Install")
+                else:
+                    client_name = _("Package Manager")
+                user_image_root = ""
+                if self.parent.image_directory != "/":
+                    user_image_root = "-R " + self.parent.image_directory + " "
+                logger.warning(
+                    _(
+                        "Origin URI: %(origin_url)s"
+                        "\nhas %(number_pubs)d publishers associated with it.\n"
+                        "%(client_name)s will attempt to add the first "
+                        "publisher, %(pub_name)s.\n"
+                        "To add the remaining publishers use the command:\n"
+                        "'pkg %(user_image_root)sset-publisher "
+                        "-p %(origin_url)s'"
+                    )
+                    % {
+                        "origin_url": origin_url,
+                        "number_pubs": len(pubs),
+                        "client_name": client_name,
+                        "pub_name": src_pub.prefix,
+                        "user_image_root": user_image_root,
+                    }
+                )
+                if not self.webinstall_new:
+                    gui_misc.notify_log_warning(self.parent)
+            src_repo = src_pub.repository
+            add_origins = []
+            if not src_repo or not src_repo.origins:
+                add_origins.append(origin_url)
+            repo = src_pub.repository
+            if not repo:
+                repo = publisher.Repository()
+                src_pub.repository = repo
+            for url in add_origins:
+                repo.add_origin(url)
+            return (src_pub, repo, True)
+        except api_errors.ApiException as e:
+            if (
+                self.__is_ssl_scheme(origin_url)
+                and (
+                    (not ssl_key or len(ssl_key) == 0)
+                    or (not ssl_cert or len(ssl_cert) == 0)
+                )
+                and gui_misc.is_frameworkerror(e)
+            ):
+                ssl_missing = True
+            else:
+                ssl_missing = False
+            gobject.idle_add(self.__show_errors, [(alias, e)], ssl_missing)
+            return (None, None, False)
+
+    def __get_or_create_pub_with_url(self, api_o, name, origin_url):
+        new_pub = False
+        repo = None
+        pub = None
+        try:
+            pub = api_o.get_publisher(prefix=name, alias=name, duplicate=True)
+            raise URIExistingPublisher(origin_url, pub)
+        except api_errors.UnknownPublisher:
+            repo = publisher.Repository()
+            # We need to specify a name when creating a publisher
+            # object. It does not matter if it is wrong as the
+            # __update_publisher() call in __add_repository() will
+            # fail and it is dealt with there.
+            if name == None:
+                name = "None"
+            pub = publisher.Publisher(name, repository=repo)
+            new_pub = True
+            # This part is copied from "def publisher_set(img, args)"
+            # from the client.py as the publisher API is not ready yet.
+            if not repo.origins:
+                repo.add_origin(origin_url)
+                origin = repo.origins[0]
+            else:
+                origin = repo.origins[0]
+                origin.uri = origin_url
+        except api_errors.ApiException as e:
+            gobject.idle_add(self.__show_errors, [(name, e)])
+        return (pub, repo, new_pub)
+
+    @staticmethod
+    def __update_ssl_creds(pub, repo, ssl_cert, ssl_key):
+        errors = []
+        # Assume the user wanted to update the ssl_cert or ssl_key
+        # information for *all* of the currently selected
+        # repository's origins and mirrors.
+        try:
+            for uri in repo.origins:
+                if uri.scheme not in publisher.SSL_SCHEMES:
+                    continue
+                uri.ssl_cert = ssl_cert
+                uri.ssl_key = ssl_key
+            for uri in repo.mirrors:
+                if uri.scheme not in publisher.SSL_SCHEMES:
+                    continue
+                uri.ssl_cert = ssl_cert
+                uri.ssl_key = ssl_key
+        except api_errors.ApiException as e:
+            errors.append((pub, e))
+        return errors
+
+    @staticmethod
+    def __get_fitr_model_from_tree(treeview):
+        tsel = treeview.get_selection()
+        selection = tsel.get_selected()
+        itr = selection[1]
+        if itr == None:
+            return (None, None)
+        model = selection[0]
+        return (itr, model)
+
+    @staticmethod
+    def __show_error_label_with_format(w_label, error_string):
+        error_str = ERROR_FORMAT % error_string
+        w_label.set_markup(error_str)
+        w_label.set_sensitive(True)
+        w_label.show()
+
+    def __is_url_valid(self, url):
+        url_error = None
+        if len(url) == 0:
+            return False, url_error
+        try:
+            publisher.RepositoryURI(url)
+            return True, url_error
+        except api_errors.PublisherError:
+            # Check whether the user has started typing a valid URL.
+            # If he has we do not display an error message.
+            valid_start = False
+            for val in publisher.SUPPORTED_SCHEMES:
+                check_str = "%s://" % val
+                if check_str.startswith(url):
+                    valid_start = True
+                    break
+            if valid_start:
+                url_error = None
+            else:
+                url_error = _("URI is not valid")
+            return False, url_error
+        except api_errors.ApiException as e:
+            self.__show_errors([("", e)])
+            return False, url_error
+
+    def __validate_ssl_key_cert(
+        self,
+        origin_url,
+        ssl_key,
+        ssl_cert,
+        ignore_ssl_check_for_not_https=False,
+    ):
+        """The SSL Cert and SSL Key may be valid and contain no error"""
+        ssl_error = None
+        ssl_valid = True
+        if origin_url and not self.__is_ssl_scheme(origin_url):
+            if ignore_ssl_check_for_not_https:
+                return ssl_valid, ssl_error
+            if (ssl_key != None and len(ssl_key) != 0) or (
+                ssl_cert != None and len(ssl_cert) != 0
+            ):
+                ssl_error = _("SSL should not be specified")
+                ssl_valid = False
+            elif (ssl_key == None or len(ssl_key) == 0) or (
+                ssl_cert == None or len(ssl_cert) == 0
+            ):
+                ssl_valid = True
+        elif origin_url == None or self.__is_ssl_scheme(origin_url):
+            if (ssl_key == None or len(ssl_key) == 0) or (
+                ssl_cert == None or len(ssl_cert) == 0
+            ):
+                # Key and Cert need not be specified
+                ssl_valid = True
+            elif not os.path.isfile(ssl_key):
+                ssl_error = _("SSL Key not found at specified location")
+                ssl_valid = False
+            elif not os.path.isfile(ssl_cert):
+                ssl_error = _("SSL Certificate not found at specified location")
+                ssl_valid = False
+        return ssl_valid, ssl_error
+
+    @staticmethod
+    def __is_ssl_scheme(uri):
+        ret_val = False
+        for val in publisher.SSL_SCHEMES:
+            if uri.startswith(val):
+                ret_val = True
+                break
+        return ret_val
+
+    @staticmethod
+    def __init_mirrors_tree_view(treeview):
+        # URI column - 0
+        uri_renderer = gtk.CellRendererText()
+        column = gtk.TreeViewColumn(_("Mirror URI"), uri_renderer, text=0)
+        column.set_expand(True)
+        treeview.append_column(column)
+
+    @staticmethod
+    def __init_origins_tree_view(treeview):
+        # URI column - 0
+        uri_renderer = gtk.CellRendererText()
+        column = gtk.TreeViewColumn(_("Origin URI"), uri_renderer, text=0)
+        column.set_expand(True)
+        treeview.append_column(column)
+
+    @staticmethod
+    def __get_publishers_liststore():
+        return gtk.ListStore(
+            gobject.TYPE_INT,  # enumerations.PUBLISHER_PRIORITY
+            gobject.TYPE_INT,  # enumerations.PUBLISHER_PRIORITY_CHANGED
+            gobject.TYPE_STRING,  # enumerations.PUBLISHER_NAME
+            gobject.TYPE_STRING,  # enumerations.PUBLISHER_ALIAS
+            gobject.TYPE_BOOLEAN,  # enumerations.PUBLISHER_ENABLED
+            gobject.TYPE_BOOLEAN,  # enumerations.PUBLISHER_STICKY
+            gobject.TYPE_PYOBJECT,  # enumerations.PUBLISHER_OBJECT
+            gobject.TYPE_BOOLEAN,  # enumerations.PUBLISHER_ENABLE_CHANGED
+            gobject.TYPE_BOOLEAN,  # enumerations.PUBLISHER_STICKY_CHANGED
+            gobject.TYPE_BOOLEAN,  # enumerations.PUBLISHER_REMOVED
+        )
+
+    @staticmethod
+    def __get_mirrors_origins_liststore():
+        return gtk.ListStore(
+            gobject.TYPE_STRING,  # name
+        )
+
+    @staticmethod
+    def __publishers_filter(model, itr):
+        return not model.get_value(itr, enumerations.PUBLISHER_REMOVED)
+
+    @staticmethod
+    def __toggle_data_function(column, renderer, model, itr, data):
+        if itr:
+            # Do not allow to remove the publisher if it is a system
+            # publisher
+            val = True
+            pub = model.get_value(itr, enumerations.PUBLISHER_OBJECT)
+            if pub.sys_pub:
+                val = False
+            renderer.set_property("sensitive", val)
+
+    @staticmethod
+    def __get_registration_uri(repo):
+        # TBD: Change Publisher API to return an RegistrationURI or a String
+        # but not either.
+        # Currently RegistrationURI is coming back with a trailing / this should
+        # be removed.
+        if repo == None:
+            return None
+        if repo.registration_uri == None:
+            return None
+        ret_uri = None
+        if isinstance(repo.registration_uri, str):
+            if len(repo.registration_uri) > 0:
+                ret_uri = repo.registration_uri.strip("/")
+        elif isinstance(repo.registration_uri, publisher.RepositoryURI):
+            uri = repo.registration_uri.uri
+            if uri != None and len(uri) > 0:
+                ret_uri = uri.strip("/")
+        return ret_uri
+
+    # -----------------------------------------------------------------------------#
+    # Public Methods
+    # -----------------------------------------------------------------------------#
+    def webinstall_new_pub(self, parent, pub=None):
+        if pub == None:
+            return
+        self.repository_modify_publisher = pub
+        repo = pub.repository
+        origin_uri = ""
+        if repo != None and repo.origins != None and len(repo.origins) > 0:
+            origin_uri = repo.origins[0].uri
+        if origin_uri != None and self.__is_ssl_scheme(origin_uri):
+            gui_misc.set_modal_and_transient(
+                self.w_add_publisher_dialog, parent
+            )
+            self.main_window = self.w_add_publisher_dialog
+            self.__on_manage_add_clicked(None)
+            self.w_add_publisher_url.set_text(origin_uri)
+            self.w_add_publisher_alias.set_text(pub.alias)
+            self.w_add_pub_label.hide()
+            self.w_add_pub_instr_label.hide()
+            self.w_add_publisher_url.set_sensitive(False)
+            self.w_add_publisher_alias.set_sensitive(False)
+            reg_uri = self.__get_registration_uri(repo)
+            if reg_uri == None or len(reg_uri) == 0:
+                reg_uri = origin_uri
+            self.w_registration_link.set_uri(reg_uri)
+            self.w_registration_box.show()
+            self.w_ssl_box.show()
+            self.__validate_url(
+                self.w_add_publisher_url,
+                w_ssl_key=self.w_key_entry,
+                w_ssl_cert=self.w_cert_entry,
+            )
+            self.w_add_error_label.hide()
+        else:
+            self.main_window = parent
+            self.w_ssl_box.hide()
+            self.__do_add_repository()
+
+    def webinstall_enable_disable_pubs(self, parent, pub_names, to_enable):
+        if pub_names == None:
+            return
+        num = len(pub_names)
+        if to_enable:
+            msg = ngettext("Enabling Publisher", "Enabling Publishers", num)
+        else:
+            msg = ngettext("Disabling Publisher", "Disabling Publishers", num)
+        self.publishers_apply.set_title(msg)
+
+        self.__run_with_prog_in_thread(
+            self.__proceed_enable_disable, parent, None, pub_names, to_enable
+        )
+
+    def update_label_text(self, markup_text):
+        self.__g_update_details_text(markup_text)
+
+    def update_details_text(self, text, *tags):
+        self.__g_update_details_text(text, *tags)
+
+    def update_progress(self, current_progress, total_progress):
+        pass
+
+    def start_bouncing_progress(self):
+        pass
+
+    def is_progress_bouncing(self):
+        self.pylintstub = self
+        return True
+
+    def stop_bouncing_progress(self):
+        pass
+
+    def display_download_info(self):
+        pass
+
+    def display_phase_info(self, phase_name, cur_n, goal_n):
+        pass
+
+    def reset_label_text_after_delay(self):
+        pass
+
 
 class URIExistingPublisher(api_errors.ApiException):
-        def __init__(self, uri, pub):
-                api_errors.ApiException.__init__(self)
-                self.uri = uri
-                self.pub = pub
+    def __init__(self, uri, pub):
+        api_errors.ApiException.__init__(self)
+        self.uri = uri
+        self.pub = pub
 
-        def __str__(self):
-                return _("The URI '%(uri)s' points to a publisher "
-                    "'%(publisher)s' which already exists "
-                    "on the system.") % { "uri": self.uri,
-                    "publisher": self.pub }
+    def __str__(self):
+        return _(
+            "The URI '%(uri)s' points to a publisher "
+            "'%(publisher)s' which already exists "
+            "on the system."
+        ) % {"uri": self.uri, "publisher": self.pub}
+
 
 class NoPublishersForURI(api_errors.ApiException):
-        def __init__(self, uri):
-                api_errors.ApiException.__init__(self)
-                self.uri = uri
+    def __init__(self, uri):
+        api_errors.ApiException.__init__(self)
+        self.uri = uri
 
-        def __str__(self):
-                return _("There are no publishers associated with the URI "
-                   "'%s'.") % self.uri
+    def __str__(self):
+        return (
+            _("There are no publishers associated with the URI " "'%s'.")
+            % self.uri
+        )
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/indexer.py
+++ b/src/modules/indexer.py
@@ -59,975 +59,1000 @@ SORT_FILE_MAX_SIZE = 128 * 1024 * 1024
 
 
 def makedirs(pathname):
-        """Create a directory at the specified location if it does not
-        already exist (including any parent directories).
-        """
+    """Create a directory at the specified location if it does not
+    already exist (including any parent directories).
+    """
 
-        try:
-                os.makedirs(pathname, PKG_DIR_MODE)
-        except EnvironmentError as e:
-                if e.filename == pathname and (e.errno == errno.EEXIST or
-                    os.path.exists(e.filename)):
-                        return
-                elif e.errno in (errno.EACCES, errno.EROFS):
-                        raise search_errors.ProblematicPermissionsIndexException(
-                            e.filename)
-                elif e.errno != errno.EEXIST or e.filename != pathname:
-                        raise
+    try:
+        os.makedirs(pathname, PKG_DIR_MODE)
+    except EnvironmentError as e:
+        if e.filename == pathname and (
+            e.errno == errno.EEXIST or os.path.exists(e.filename)
+        ):
+            return
+        elif e.errno in (errno.EACCES, errno.EROFS):
+            raise search_errors.ProblematicPermissionsIndexException(e.filename)
+        elif e.errno != errno.EEXIST or e.filename != pathname:
+            raise
 
 
 class Indexer(object):
-        """Indexer is a class designed to index a set of manifests or pkg plans
-        and provide a compact representation on disk, which is quickly
-        searchable."""
+    """Indexer is a class designed to index a set of manifests or pkg plans
+    and provide a compact representation on disk, which is quickly
+    searchable."""
 
-        file_version_string = "VERSION: "
+    file_version_string = "VERSION: "
 
-        def __init__(self, index_dir, get_manifest_func, get_manifest_path_func,
-            progtrack=None, excludes=EmptyI, log=None,
-            sort_file_max_size=SORT_FILE_MAX_SIZE):
-                self._num_keys = 0
-                self._num_manifests = 0
-                self._num_entries = 0
-                self.get_manifest_func = get_manifest_func
-                self.get_manifest_path_func = get_manifest_path_func
-                self.excludes = excludes
-                self.__log = log
-                self.sort_file_max_size = sort_file_max_size
-                if self.sort_file_max_size <= 0:
-                        raise search_errors.IndexingException(
-                            _("sort_file_max_size must be greater than 0"))
+    def __init__(
+        self,
+        index_dir,
+        get_manifest_func,
+        get_manifest_path_func,
+        progtrack=None,
+        excludes=EmptyI,
+        log=None,
+        sort_file_max_size=SORT_FILE_MAX_SIZE,
+    ):
+        self._num_keys = 0
+        self._num_manifests = 0
+        self._num_entries = 0
+        self.get_manifest_func = get_manifest_func
+        self.get_manifest_path_func = get_manifest_path_func
+        self.excludes = excludes
+        self.__log = log
+        self.sort_file_max_size = sort_file_max_size
+        if self.sort_file_max_size <= 0:
+            raise search_errors.IndexingException(
+                _("sort_file_max_size must be greater than 0")
+            )
 
-                # This structure was used to gather all index files into one
-                # location. If a new index structure is needed, the files can
-                # be added (or removed) from here. Providing a list or
-                # dictionary allows an easy approach to opening or closing all
-                # index files.
+        # This structure was used to gather all index files into one
+        # location. If a new index structure is needed, the files can
+        # be added (or removed) from here. Providing a list or
+        # dictionary allows an easy approach to opening or closing all
+        # index files.
 
-                self._data_dict = {
-                        "fast_add":
-                            ss.IndexStoreSet(ss.FAST_ADD),
-                        "fast_remove":
-                            ss.IndexStoreSet(ss.FAST_REMOVE),
-                        "manf":
-                            ss.IndexStoreListDict(ss.MANIFEST_LIST,
-                                build_function=self.__build_fmri,
-                                decode_function=self.__decode_fmri),
-                        "full_fmri": ss.IndexStoreSet(ss.FULL_FMRI_FILE),
-                        "main_dict": ss.IndexStoreMainDict(ss.MAIN_FILE),
-                        "token_byte_offset":
-                            ss.IndexStoreDictMutable(ss.BYTE_OFFSET_FILE)
-                        }
+        self._data_dict = {
+            "fast_add": ss.IndexStoreSet(ss.FAST_ADD),
+            "fast_remove": ss.IndexStoreSet(ss.FAST_REMOVE),
+            "manf": ss.IndexStoreListDict(
+                ss.MANIFEST_LIST,
+                build_function=self.__build_fmri,
+                decode_function=self.__decode_fmri,
+            ),
+            "full_fmri": ss.IndexStoreSet(ss.FULL_FMRI_FILE),
+            "main_dict": ss.IndexStoreMainDict(ss.MAIN_FILE),
+            "token_byte_offset": ss.IndexStoreDictMutable(ss.BYTE_OFFSET_FILE),
+        }
 
-                self._data_fast_add = self._data_dict["fast_add"]
-                self._data_fast_remove = self._data_dict["fast_remove"]
-                self._data_manf = self._data_dict["manf"]
-                self._data_full_fmri = self._data_dict["full_fmri"]
-                self._data_main_dict = self._data_dict["main_dict"]
-                self._data_token_offset = self._data_dict["token_byte_offset"]
+        self._data_fast_add = self._data_dict["fast_add"]
+        self._data_fast_remove = self._data_dict["fast_remove"]
+        self._data_manf = self._data_dict["manf"]
+        self._data_full_fmri = self._data_dict["full_fmri"]
+        self._data_main_dict = self._data_dict["main_dict"]
+        self._data_token_offset = self._data_dict["token_byte_offset"]
 
-                # This is added to the dictionary after the others because it
-                # needs one of the other mappings as an input.
-                self._data_dict["fmri_offsets"] = \
-                    ss.InvertedDict(ss.FMRI_OFFSETS_FILE, self._data_manf)
-                self._data_fmri_offsets = self._data_dict["fmri_offsets"]
+        # This is added to the dictionary after the others because it
+        # needs one of the other mappings as an input.
+        self._data_dict["fmri_offsets"] = ss.InvertedDict(
+            ss.FMRI_OFFSETS_FILE, self._data_manf
+        )
+        self._data_fmri_offsets = self._data_dict["fmri_offsets"]
 
-                self._index_dir = index_dir
-                self._tmp_dir = os.path.join(self._index_dir, "TMP")
+        self._index_dir = index_dir
+        self._tmp_dir = os.path.join(self._index_dir, "TMP")
 
-                self.__lockfile = lockfile.LockFile(os.path.join(
-                    self._index_dir, "lock"),
-                    set_lockstr=lockfile.generic_lock_set_str,
-                    get_lockstr=lockfile.generic_lock_get_str,
-                    failure_exc=search_errors.IndexLockedException)
+        self.__lockfile = lockfile.LockFile(
+            os.path.join(self._index_dir, "lock"),
+            set_lockstr=lockfile.generic_lock_set_str,
+            get_lockstr=lockfile.generic_lock_get_str,
+            failure_exc=search_errors.IndexLockedException,
+        )
 
-                self._indexed_manifests = 0
-                self.server_repo = True
-                self.empty_index = False
-                self.file_version_number = None
+        self._indexed_manifests = 0
+        self.server_repo = True
+        self.empty_index = False
+        self.file_version_number = None
 
-                if progtrack is None:
-                        self._progtrack = progress.NullProgressTracker()
+        if progtrack is None:
+            self._progtrack = progress.NullProgressTracker()
+        else:
+            self._progtrack = progtrack
+
+        self._file_timeout_secs = FILE_OPEN_TIMEOUT_SECS
+
+        self._sort_fh = None
+        self._sort_file_num = 0
+        self._sort_file_bytes = 0
+
+        # The action type and key indexes, which are necessary for
+        # efficient searches by type or key, store their file handles in
+        # dictionaries.  File handles for actions are in at_fh, while
+        # filehandles for keys are kept in st_fh.
+        self.at_fh = {}
+        self.st_fh = {}
+
+        self.old_out_token = None
+
+    @staticmethod
+    def __decode_fmri(pfmri):
+        """Turn fmris into strings correctly while writing out
+        the fmri offsets file."""
+
+        return pfmri.get_fmri(anarchy=True, include_scheme=False)
+
+    @staticmethod
+    def __build_fmri(s):
+        """Build fmris while reading the fmri offset information."""
+
+        return fmri.PkgFmri(s)
+
+    @staticmethod
+    def _build_version(vers):
+        """Private method for building versions from a string."""
+
+        return pkg.version.Version(unquote(vers), None)
+
+    def _read_input_indexes(self, directory):
+        """Opens all index files using consistent_open and reads all
+        of them into memory except the main dictionary file to avoid
+        inefficient memory usage."""
+
+        res = ss.consistent_open(
+            self._data_dict.values(), directory, self._file_timeout_secs
+        )
+        pt = self._progtrack
+        if res == None:
+            self.file_version_number = INITIAL_VERSION_NUMBER
+            self.empty_index = True
+            return None
+        self.file_version_number = res
+
+        try:
+            pt.job_start(pt.JOB_READ_SEARCH)
+            try:
+                for d in self._data_dict.values():
+                    if (
+                        d == self._data_main_dict
+                        or d == self._data_token_offset
+                    ):
+                        pt.job_add_progress(pt.JOB_READ_SEARCH)
+                        continue
+                    d.read_dict_file()
+                    pt.job_add_progress(pt.JOB_READ_SEARCH)
+            except:
+                self._data_dict["main_dict"].close_file_handle()
+                raise
+        finally:
+            for d in self._data_dict.values():
+                if d == self._data_main_dict:
+                    continue
+                d.close_file_handle()
+            pt.job_done(pt.JOB_READ_SEARCH)
+
+    def __close_sort_fh(self):
+        """Utility function used to close and sort the temporary
+        files used to produce a sorted main_dict file."""
+
+        self._sort_fh.close()
+        self._sort_file_bytes = 0
+        tmp_file_name = os.path.join(
+            self._tmp_dir, SORT_FILE_PREFIX + str(self._sort_file_num - 1)
+        )
+        tmp_fh = open(tmp_file_name, "r", buffering=PKG_FILE_BUFSIZ)
+        l = [
+            (ss.IndexStoreMainDict.parse_main_dict_line_for_token(line), line)
+            for line in tmp_fh
+        ]
+        tmp_fh.close()
+        l.sort()
+        tmp_fh = open(tmp_file_name, "w", buffering=PKG_FILE_BUFSIZ)
+        tmp_fh.writelines((line for tok, line in l))
+        tmp_fh.close()
+
+    def _add_terms(self, pfmri, new_dict):
+        """Adds tokens, and the actions generating them, to the current
+        temporary sort file.
+
+        The "pfmri" parameter is the fmri the information is coming
+        from.
+
+        The "new_dict" parameter maps tokens to the information about
+        the action."""
+
+        p_id = self._data_manf.get_id_and_add(pfmri)
+        pfmri = p_id
+
+        for tok_tup in new_dict.keys():
+            tok, action_type, subtype, fv = tok_tup
+            lst = [
+                (
+                    action_type,
+                    [(subtype, [(fv, [(pfmri, list(new_dict[tok_tup]))])])],
+                )
+            ]
+            s = ss.IndexStoreMainDict.transform_main_dict_line(tok, lst)
+            if len(s) + self._sort_file_bytes >= self.sort_file_max_size:
+                self.__close_sort_fh()
+                self._sort_fh = open(
+                    os.path.join(
+                        self._tmp_dir,
+                        SORT_FILE_PREFIX + str(self._sort_file_num),
+                    ),
+                    "w",
+                    buffering=PKG_FILE_BUFSIZ,
+                )
+                self._sort_file_num += 1
+            self._sort_fh.write(s)
+            self._sort_file_bytes += len(s)
+        return
+
+    def _fast_update(self, filters_pkgplan_list):
+        """Updates the log of packages which have been installed or
+        removed since the last time the index has been rebuilt.
+
+        There are two axes to consider: whether the package is being
+        added or removed; whether this version of the package is
+        already present in an update log.
+
+        Case 1: The package is being installed and is not in the
+            update log.  In this case, the new package is simply added
+            to the install update log.
+        Case 2: The package is being installed and is in the removal
+            update log. In this case, the package is removed from the
+            remove update log.  This has the effect of exposing the
+            entries in the existing index to the user.
+        Case 3: The package is being removed and is not in the
+            update log.  In this case, the new package is simply added
+            to the removed update log.
+        Case 4: The package is being removed and is in the installed
+            update log.  In this case, the package is removed from the
+            install update log.
+
+        The "filters_pkgplan_list" parameter is a tuple of a list of
+        filters, which are currently ignored, and a list of pkgplans
+        that indicated which versions of a package are being added or
+        removed."""
+
+        nfast_add = len(self._data_fast_add._set)
+        nfast_remove = len(self._data_fast_remove._set)
+
+        #
+        # First pass determines whether a fast update makes sense and
+        # updates the list of fmris that will be in the index.
+        #
+        filters, pkgplan_list = filters_pkgplan_list
+        for p in pkgplan_list:
+            d_fmri, o_fmri = p
+            if d_fmri:
+                self._data_full_fmri.add_entity(d_fmri.get_fmri(anarchy=True))
+                d_tmp = d_fmri.get_fmri(anarchy=True, include_scheme=False)
+                if self._data_fast_remove.has_entity(d_tmp):
+                    nfast_remove -= 1
                 else:
-                        self._progtrack = progtrack
+                    nfast_add += 1
+            if o_fmri:
+                self._data_full_fmri.remove_entity(
+                    o_fmri.get_fmri(anarchy=True)
+                )
+                o_tmp = o_fmri.get_fmri(anarchy=True, include_scheme=False)
+                if self._data_fast_add.has_entity(o_tmp):
+                    nfast_add -= 1
+                else:
+                    nfast_remove += 1
 
-                self._file_timeout_secs = FILE_OPEN_TIMEOUT_SECS
+        if nfast_add > MAX_FAST_INDEXED_PKGS:
+            return False
 
-                self._sort_fh = None
-                self._sort_file_num = 0
-                self._sort_file_bytes = 0
+        #
+        # Second pass actually updates the fast_add and fast_remove
+        # sets and updates progress.
+        #
+        self._progtrack.job_start(
+            self._progtrack.JOB_UPDATE_SEARCH, goal=len(pkgplan_list)
+        )
+        for p in pkgplan_list:
+            d_fmri, o_fmri = p
 
-                # The action type and key indexes, which are necessary for
-                # efficient searches by type or key, store their file handles in
-                # dictionaries.  File handles for actions are in at_fh, while
-                # filehandles for keys are kept in st_fh.
-                self.at_fh = {}
-                self.st_fh = {}
+            if d_fmri:
+                d_tmp = d_fmri.get_fmri(anarchy=True, include_scheme=False)
+                assert not self._data_fast_add.has_entity(d_tmp)
+                if self._data_fast_remove.has_entity(d_tmp):
+                    self._data_fast_remove.remove_entity(d_tmp)
+                else:
+                    self._data_fast_add.add_entity(d_tmp)
+            if o_fmri:
+                o_tmp = o_fmri.get_fmri(anarchy=True, include_scheme=False)
+                assert not self._data_fast_remove.has_entity(o_tmp)
+                if self._data_fast_add.has_entity(o_tmp):
+                    self._data_fast_add.remove_entity(o_tmp)
+                else:
+                    self._data_fast_remove.add_entity(o_tmp)
 
-                self.old_out_token = None
+            self._progtrack.job_add_progress(self._progtrack.JOB_UPDATE_SEARCH)
 
-        @staticmethod
-        def __decode_fmri(pfmri):
-                """Turn fmris into strings correctly while writing out
-                the fmri offsets file."""
+        self._progtrack.job_done(self._progtrack.JOB_UPDATE_SEARCH)
 
-                return pfmri.get_fmri(anarchy=True, include_scheme=False)
+        return True
 
-        @staticmethod
-        def __build_fmri(s):
-                """Build fmris while reading the fmri offset information."""
+    def _process_fmris(self, fmris):
+        """Takes a list of fmris and updates the internal storage to
+        reflect the new packages."""
 
-                return fmri.PkgFmri(s)
+        removed_paths = []
 
-        @staticmethod
-        def _build_version(vers):
-                """ Private method for building versions from a string. """
+        for added_fmri in fmris:
+            self._data_full_fmri.add_entity(added_fmri.get_fmri(anarchy=True))
+            new_dict = manifest.Manifest.search_dict(
+                self.get_manifest_path_func(added_fmri),
+                self.excludes,
+                log=self.__log,
+            )
+            self._add_terms(added_fmri, new_dict)
 
-                return pkg.version.Version(unquote(vers), None)
+            self._progtrack.job_add_progress(self._progtrack.JOB_REBUILD_SEARCH)
+        return removed_paths
 
-        def _read_input_indexes(self, directory):
-                """ Opens all index files using consistent_open and reads all
-                of them into memory except the main dictionary file to avoid
-                inefficient memory usage."""
+    def _write_main_dict_line(
+        self, file_handle, token, fv_fmri_pos_list_list, out_dir
+    ):
+        """Writes out the new main dictionary file and also adds the
+        token offsets to _data_token_offset. file_handle is the file
+        handle for the output main dictionary file. token is the token
+        to add to the file. fv_fmri_pos_list_list is a structure of
+        lists inside of lists several layers deep. The top layer is a
+        list of action types. The second layer contains the keys for
+        the action type it's a sublist for. The third layer contains
+        the values which matched the token for the action and key it's
+        contained in. The fourth layer is the fmris which contain those
+        matches. The fifth layer is the offset into the manifest of
+        each fmri for each matching value. out_dir points to the
+        base directory to use to write a file for each package which
+        contains the offsets into the main dictionary for the tokens
+        this package matches."""
 
-                res = ss.consistent_open(self._data_dict.values(), directory,
-                    self._file_timeout_secs)
-                pt = self._progtrack
-                if res == None:
-                        self.file_version_number = INITIAL_VERSION_NUMBER
-                        self.empty_index = True
-                        return None
-                self.file_version_number = res
+        if self.old_out_token is not None and self.old_out_token >= token:
+            raise RuntimeError(
+                "In writing dict line, token:{0}, "
+                "old_out_token:{1}".format(token, self.old_out_token)
+            )
+        self.old_out_token = token
 
+        cur_location_int = file_handle.tell()
+        cur_location = str(cur_location_int)
+        self._data_token_offset.write_entity(token, cur_location)
+
+        for at, st_list in fv_fmri_pos_list_list:
+            self._progtrack.job_add_progress(
+                self._progtrack.JOB_REBUILD_SEARCH, nitems=0
+            )
+            if at not in self.at_fh:
+                self.at_fh[at] = open(os.path.join(out_dir, "__at_" + at), "w")
+            self.at_fh[at].write(cur_location + "\n")
+            for st, fv_list in st_list:
+                if st not in self.st_fh:
+                    self.st_fh[st] = open(
+                        os.path.join(out_dir, "__st_" + st), "w"
+                    )
+                self.st_fh[st].write(cur_location + "\n")
+                for fv, p_list in fv_list:
+                    for p_id, m_off_set in p_list:
+                        p_id = int(p_id)
+                        self._data_fmri_offsets.add_pair(p_id, cur_location_int)
+        file_handle.write(
+            self._data_main_dict.transform_main_dict_line(
+                token, fv_fmri_pos_list_list
+            )
+        )
+
+    @staticmethod
+    def __splice(ret_list, source_list):
+        """Takes two arguments. Each of the arguments must be a list
+        with the type signature list of ('a, list of 'b). Where
+        the lists share a value (A) for 'a, it splices the lists of 'b
+        paired with A from each list into a single list and makes that
+        the new list paired with A in the result.
+
+        Note: This modifies the ret_list rather than building a new one
+        because of the large performance difference between the two
+        approaches."""
+
+        tmp_res = []
+        for val, sublist in source_list:
+            found = False
+            for r_val, r_sublist in ret_list:
+                if val == r_val:
+                    found = True
+                    Indexer.__splice(r_sublist, sublist)
+                    break
+            if not found:
+                tmp_res.append((val, sublist))
+        ret_list.extend(tmp_res)
+
+    def _gen_new_toks_from_files(self):
+        """Produces a stream of ordered tokens and the associated
+        information for those tokens from the sorted temporary files
+        produced by _add_terms. In short, this is the merge part of the
+        merge sort being done on the tokens to be indexed."""
+
+        def get_line(fh):
+            """Helper function to make the initialization of the
+            fh_dict easier to understand."""
+
+            try:
+                return ss.IndexStoreMainDict.parse_main_dict_line(next(fh))
+            except StopIteration:
+                return None
+
+        # Build a mapping from numbers to the file handle for the
+        # temporary sort file with that number.
+        fh_dict = dict(
+            [
+                (
+                    i,
+                    open(
+                        os.path.join(self._tmp_dir, SORT_FILE_PREFIX + str(i)),
+                        "r",
+                        buffering=PKG_FILE_BUFSIZ,
+                    ),
+                )
+                for i in range(self._sort_file_num)
+            ]
+        )
+
+        cur_toks = {}
+        # Seed cur_toks with the first token from each temporary file.
+        # The line may not exist since, for a empty repo, an empty file
+        # is created.
+        for i in list(fh_dict.keys()):
+            line = get_line(fh_dict[i])
+            if line is None:
+                del fh_dict[i]
+            else:
+                cur_toks[i] = line
+
+        old_min_token = None
+        # cur_toks will have items deleted from it as files no longer
+        # have tokens to provide. When no files have tokens, the merge
+        # is done.
+        while cur_toks:
+            min_token = None
+            matches = []
+            # Find smallest available token and the temporary files
+            # which contain that token.
+            for i in fh_dict.keys():
+                cur_tok, info = cur_toks[i]
+                if cur_tok is None:
+                    continue
+                if min_token is None or cur_tok < min_token:
+                    min_token = cur_tok
+                    matches = [i]
+                elif cur_tok == min_token:
+                    matches.append(i)
+            assert min_token is not None
+            assert len(matches) > 0
+            res = None
+            for i in matches:
+                new_tok, new_info = cur_toks[i]
+                assert new_tok == min_token
                 try:
-                        pt.job_start(pt.JOB_READ_SEARCH)
-                        try:
-                                for d in self._data_dict.values():
-                                        if (d == self._data_main_dict or
-                                                d == self._data_token_offset):
-                                                pt.job_add_progress(
-                                                    pt.JOB_READ_SEARCH)
-                                                continue
-                                        d.read_dict_file()
-                                        pt.job_add_progress(pt.JOB_READ_SEARCH)
-                        except:
-                                self._data_dict["main_dict"].close_file_handle()
-                                raise
-                finally:
-                        for d in self._data_dict.values():
-                                if d == self._data_main_dict:
-                                        continue
-                                d.close_file_handle()
-                        pt.job_done(pt.JOB_READ_SEARCH)
-
-        def __close_sort_fh(self):
-                """Utility function used to close and sort the temporary
-                files used to produce a sorted main_dict file."""
-
-                self._sort_fh.close()
-                self._sort_file_bytes = 0
-                tmp_file_name = os.path.join(self._tmp_dir,
-                    SORT_FILE_PREFIX + str(self._sort_file_num - 1))
-                tmp_fh = open(tmp_file_name, "r", buffering=PKG_FILE_BUFSIZ)
-                l = [
-                    (ss.IndexStoreMainDict.parse_main_dict_line_for_token(line),
-                    line)
-                    for line in tmp_fh
-                ]
-                tmp_fh.close()
-                l.sort()
-                tmp_fh = open(tmp_file_name, "w", buffering=PKG_FILE_BUFSIZ)
-                tmp_fh.writelines((line for tok, line in l))
-                tmp_fh.close()
-
-        def _add_terms(self, pfmri, new_dict):
-                """Adds tokens, and the actions generating them, to the current
-                temporary sort file.
-
-                The "pfmri" parameter is the fmri the information is coming
-                from.
-
-                The "new_dict" parameter maps tokens to the information about
-                the action."""
-
-                p_id = self._data_manf.get_id_and_add(pfmri)
-                pfmri = p_id
-
-                for tok_tup in new_dict.keys():
-                        tok, action_type, subtype, fv = tok_tup
-                        lst = [(action_type, [(subtype, [(fv, [(pfmri,
-                            list(new_dict[tok_tup]))])])])]
-                        s = ss.IndexStoreMainDict.transform_main_dict_line(tok,
-                            lst)
-                        if len(s) + self._sort_file_bytes >= \
-                            self.sort_file_max_size:
-                                self.__close_sort_fh()
-                                self._sort_fh = open(os.path.join(self._tmp_dir,
-                                    SORT_FILE_PREFIX +
-                                    str(self._sort_file_num)), "w",
-                                    buffering=PKG_FILE_BUFSIZ)
-                                self._sort_file_num += 1
-                        self._sort_fh.write(s)
-                        self._sort_file_bytes += len(s)
-                return
-
-        def _fast_update(self, filters_pkgplan_list):
-                """Updates the log of packages which have been installed or
-                removed since the last time the index has been rebuilt.
-
-                There are two axes to consider: whether the package is being
-                added or removed; whether this version of the package is
-                already present in an update log.
-
-                Case 1: The package is being installed and is not in the
-                    update log.  In this case, the new package is simply added
-                    to the install update log.
-                Case 2: The package is being installed and is in the removal
-                    update log. In this case, the package is removed from the
-                    remove update log.  This has the effect of exposing the
-                    entries in the existing index to the user.
-                Case 3: The package is being removed and is not in the
-                    update log.  In this case, the new package is simply added
-                    to the removed update log.
-                Case 4: The package is being removed and is in the installed
-                    update log.  In this case, the package is removed from the
-                    install update log.
-
-                The "filters_pkgplan_list" parameter is a tuple of a list of
-                filters, which are currently ignored, and a list of pkgplans
-                that indicated which versions of a package are being added or
-                removed."""
-
-                nfast_add = len(self._data_fast_add._set)
-                nfast_remove = len(self._data_fast_remove._set)
-
-                #
-                # First pass determines whether a fast update makes sense and
-                # updates the list of fmris that will be in the index.
-                #
-                filters, pkgplan_list = filters_pkgplan_list
-                for p in pkgplan_list:
-                        d_fmri, o_fmri = p
-                        if d_fmri:
-                                self._data_full_fmri.add_entity(
-                                    d_fmri.get_fmri(anarchy=True))
-                                d_tmp = d_fmri.get_fmri(anarchy=True,
-                                    include_scheme=False)
-                                if self._data_fast_remove.has_entity(d_tmp):
-                                        nfast_remove -= 1
-                                else:
-                                        nfast_add += 1
-                        if o_fmri:
-                                self._data_full_fmri.remove_entity(
-                                    o_fmri.get_fmri(anarchy=True))
-                                o_tmp = o_fmri.get_fmri(anarchy=True,
-                                    include_scheme=False)
-                                if self._data_fast_add.has_entity(o_tmp):
-                                        nfast_add -= 1
-                                else:
-                                        nfast_remove += 1
-
-                if nfast_add > MAX_FAST_INDEXED_PKGS:
-                        return False
-
-                #
-                # Second pass actually updates the fast_add and fast_remove
-                # sets and updates progress.
-                #
-                self._progtrack.job_start(self._progtrack.JOB_UPDATE_SEARCH,
-                    goal=len(pkgplan_list))
-                for p in pkgplan_list:
-                        d_fmri, o_fmri = p
-
-                        if d_fmri:
-                                d_tmp = d_fmri.get_fmri(anarchy=True,
-                                    include_scheme=False)
-                                assert not self._data_fast_add.has_entity(d_tmp)
-                                if self._data_fast_remove.has_entity(d_tmp):
-                                        self._data_fast_remove.remove_entity(
-                                            d_tmp)
-                                else:
-                                        self._data_fast_add.add_entity(d_tmp)
-                        if o_fmri:
-                                o_tmp = o_fmri.get_fmri(anarchy=True,
-                                    include_scheme=False)
-                                assert not self._data_fast_remove.has_entity(
-                                    o_tmp)
-                                if self._data_fast_add.has_entity(o_tmp):
-                                        self._data_fast_add.remove_entity(o_tmp)
-                                else:
-                                        self._data_fast_remove.add_entity(o_tmp)
-
-                        self._progtrack.job_add_progress(
-                            self._progtrack.JOB_UPDATE_SEARCH)
-
-                self._progtrack.job_done(self._progtrack.JOB_UPDATE_SEARCH)
-
-                return True
-
-        def _process_fmris(self, fmris):
-                """Takes a list of fmris and updates the internal storage to
-                reflect the new packages."""
-
-                removed_paths = []
-
-                for added_fmri in fmris:
-                        self._data_full_fmri.add_entity(
-                            added_fmri.get_fmri(anarchy=True))
-                        new_dict = manifest.Manifest.search_dict(
-                            self.get_manifest_path_func(added_fmri),
-                            self.excludes, log=self.__log)
-                        self._add_terms(added_fmri, new_dict)
-
-                        self._progtrack.job_add_progress(
-                            self._progtrack.JOB_REBUILD_SEARCH)
-                return removed_paths
-
-        def _write_main_dict_line(self, file_handle, token,
-            fv_fmri_pos_list_list, out_dir):
-                """Writes out the new main dictionary file and also adds the
-                token offsets to _data_token_offset. file_handle is the file
-                handle for the output main dictionary file. token is the token
-                to add to the file. fv_fmri_pos_list_list is a structure of
-                lists inside of lists several layers deep. The top layer is a
-                list of action types. The second layer contains the keys for
-                the action type it's a sublist for. The third layer contains
-                the values which matched the token for the action and key it's
-                contained in. The fourth layer is the fmris which contain those
-                matches. The fifth layer is the offset into the manifest of
-                each fmri for each matching value. out_dir points to the
-                base directory to use to write a file for each package which
-                contains the offsets into the main dictionary for the tokens
-                this package matches."""
-
-                if self.old_out_token is not None and \
-                    self.old_out_token >= token:
-                        raise RuntimeError("In writing dict line, token:{0}, "
-                            "old_out_token:{1}".format(token,
-                            self.old_out_token))
-                self.old_out_token = token
-
-                cur_location_int = file_handle.tell()
-                cur_location = str(cur_location_int)
-                self._data_token_offset.write_entity(token, cur_location)
-
-                for at, st_list in fv_fmri_pos_list_list:
-                        self._progtrack.job_add_progress(
-                            self._progtrack.JOB_REBUILD_SEARCH, nitems=0)
-                        if at not in self.at_fh:
-                                self.at_fh[at] = open(os.path.join(out_dir,
-                                    "__at_" + at), "w")
-                        self.at_fh[at].write(cur_location + "\n")
-                        for st, fv_list in st_list:
-                                if st not in self.st_fh:
-                                        self.st_fh[st] = \
-                                            open(os.path.join(out_dir,
-                                            "__st_" + st), "w")
-                                self.st_fh[st].write(cur_location + "\n")
-                                for fv, p_list in fv_list:
-                                        for p_id, m_off_set in p_list:
-                                                p_id = int(p_id)
-                                                self._data_fmri_offsets.add_pair(
-                                                    p_id, cur_location_int)
-                file_handle.write(self._data_main_dict.transform_main_dict_line(
-                    token, fv_fmri_pos_list_list))
-
-        @staticmethod
-        def __splice(ret_list, source_list):
-                """Takes two arguments. Each of the arguments must be a list
-                with the type signature list of ('a, list of 'b). Where
-                the lists share a value (A) for 'a, it splices the lists of 'b
-                paired with A from each list into a single list and makes that
-                the new list paired with A in the result.
-
-                Note: This modifies the ret_list rather than building a new one
-                because of the large performance difference between the two
-                approaches."""
-
-                tmp_res = []
-                for val, sublist in source_list:
-                        found = False
-                        for r_val, r_sublist in ret_list:
-                                if val == r_val:
-                                        found = True
-                                        Indexer.__splice(r_sublist, sublist)
-                                        break
-                        if not found:
-                                tmp_res.append((val, sublist))
-                ret_list.extend(tmp_res)
-
-        def _gen_new_toks_from_files(self):
-                """Produces a stream of ordered tokens and the associated
-                information for those tokens from the sorted temporary files
-                produced by _add_terms. In short, this is the merge part of the
-                merge sort being done on the tokens to be indexed."""
-
-                def get_line(fh):
-                        """Helper function to make the initialization of the
-                        fh_dict easier to understand."""
-
-                        try:
-                                return \
-                                        ss.IndexStoreMainDict.parse_main_dict_line(
-                                        next(fh))
-                        except StopIteration:
-                                return None
-
-                # Build a mapping from numbers to the file handle for the
-                # temporary sort file with that number.
-                fh_dict = dict([
-                    (i, open(os.path.join(self._tmp_dir,
-                    SORT_FILE_PREFIX + str(i)), "r",
-                    buffering=PKG_FILE_BUFSIZ))
-                    for i in range(self._sort_file_num)
-                ])
-
-                cur_toks = {}
-                # Seed cur_toks with the first token from each temporary file.
-                # The line may not exist since, for a empty repo, an empty file
-                # is created.
-                for i in list(fh_dict.keys()):
-                        line = get_line(fh_dict[i])
-                        if line is None:
-                                del fh_dict[i]
+                    # Continue pulling the next tokens from
+                    # and adding them to the result list as
+                    # long as the token matches min_token.
+                    while new_tok == min_token:
+                        if res is None:
+                            res = new_info
                         else:
-                                cur_toks[i] = line
-
-                old_min_token = None
-                # cur_toks will have items deleted from it as files no longer
-                # have tokens to provide. When no files have tokens, the merge
-                # is done.
-                while cur_toks:
-                        min_token = None
-                        matches = []
-                        # Find smallest available token and the temporary files
-                        # which contain that token.
-                        for i in fh_dict.keys():
-                                cur_tok, info = cur_toks[i]
-                                if cur_tok is None:
-                                        continue
-                                if min_token is None or cur_tok < min_token:
-                                        min_token = cur_tok
-                                        matches = [i]
-                                elif cur_tok == min_token:
-                                        matches.append(i)
-                        assert min_token is not None
-                        assert len(matches) > 0
-                        res = None
-                        for i in matches:
-                                new_tok, new_info = cur_toks[i]
-                                assert new_tok == min_token
-                                try:
-                                        # Continue pulling the next tokens from
-                                        # and adding them to the result list as
-                                        # long as the token matches min_token.
-                                        while new_tok == min_token:
-                                                if res is None:
-                                                        res = new_info
-                                                else:
-                                                        self.__splice(res,
-                                                            new_info)
-                                                new_tok, new_info = \
-                                                    ss.IndexStoreMainDict.parse_main_dict_line(next(fh_dict[i]))
-                                        cur_toks[i] = new_tok, new_info
-                                except StopIteration:
-                                        # When a StopIteration happens, the
-                                        # last line in the file has been read
-                                        # and processed. Delete all the
-                                        # information associated with that file
-                                        # so that we no longer check that file.
-                                        fh_dict[i].close()
-                                        del fh_dict[i]
-                                        del cur_toks[i]
-                        assert res is not None
-                        if old_min_token is not None and \
-                            old_min_token >= min_token:
-                                raise RuntimeError("Got min token:{0} greater "
-                                    "than old_min_token:{1}".format(
-                                    min_token, old_min_token))
-                        old_min_token = min_token
-                        if min_token != "":
-                                yield min_token, res
-                return
-
-        def _update_index(self, dicts, out_dir):
-                """Processes the main dictionary file and writes out a new
-                main dictionary file reflecting the changes in the packages.
-
-                The "dicts" parameter is the list of fmris which have been
-                removed during update.
-
-                The "out_dir" parameter is the temporary directory in which to
-                build the indexes."""
-
-                removed_paths = dicts
-
-                if self.empty_index:
-                        file_handle = []
-                else:
-                        file_handle = self._data_main_dict.get_file_handle()
-                        assert file_handle
-
-                if self.file_version_number == None:
-                        self.file_version_number = INITIAL_VERSION_NUMBER
-                else:
-                        self.file_version_number += 1
-
-                self._data_main_dict.write_dict_file(
-                    out_dir, self.file_version_number)
-                # The dictionary file's opened in append mode to avoid removing
-                # the version information the search storage class added.
-                out_main_dict_handle = \
-                    open(os.path.join(out_dir,
-                        self._data_main_dict.get_file_name()), "a",
-                        buffering=PKG_FILE_BUFSIZ)
-
-                self._data_token_offset.open_out_file(out_dir,
-                    self.file_version_number)
-
-                new_toks_available = True
-                new_toks_it = self._gen_new_toks_from_files()
-                try:
-                        tmp = next(new_toks_it)
-                        next_new_tok, new_tok_info = tmp
+                            self.__splice(res, new_info)
+                        (
+                            new_tok,
+                            new_info,
+                        ) = ss.IndexStoreMainDict.parse_main_dict_line(
+                            next(fh_dict[i])
+                        )
+                    cur_toks[i] = new_tok, new_info
                 except StopIteration:
+                    # When a StopIteration happens, the
+                    # last line in the file has been read
+                    # and processed. Delete all the
+                    # information associated with that file
+                    # so that we no longer check that file.
+                    fh_dict[i].close()
+                    del fh_dict[i]
+                    del cur_toks[i]
+            assert res is not None
+            if old_min_token is not None and old_min_token >= min_token:
+                raise RuntimeError(
+                    "Got min token:{0} greater "
+                    "than old_min_token:{1}".format(min_token, old_min_token)
+                )
+            old_min_token = min_token
+            if min_token != "":
+                yield min_token, res
+        return
+
+    def _update_index(self, dicts, out_dir):
+        """Processes the main dictionary file and writes out a new
+        main dictionary file reflecting the changes in the packages.
+
+        The "dicts" parameter is the list of fmris which have been
+        removed during update.
+
+        The "out_dir" parameter is the temporary directory in which to
+        build the indexes."""
+
+        removed_paths = dicts
+
+        if self.empty_index:
+            file_handle = []
+        else:
+            file_handle = self._data_main_dict.get_file_handle()
+            assert file_handle
+
+        if self.file_version_number == None:
+            self.file_version_number = INITIAL_VERSION_NUMBER
+        else:
+            self.file_version_number += 1
+
+        self._data_main_dict.write_dict_file(out_dir, self.file_version_number)
+        # The dictionary file's opened in append mode to avoid removing
+        # the version information the search storage class added.
+        out_main_dict_handle = open(
+            os.path.join(out_dir, self._data_main_dict.get_file_name()),
+            "a",
+            buffering=PKG_FILE_BUFSIZ,
+        )
+
+        self._data_token_offset.open_out_file(out_dir, self.file_version_number)
+
+        new_toks_available = True
+        new_toks_it = self._gen_new_toks_from_files()
+        try:
+            tmp = next(new_toks_it)
+            next_new_tok, new_tok_info = tmp
+        except StopIteration:
+            new_toks_available = False
+
+        try:
+            for line in file_handle:
+                (tok, at_lst) = self._data_main_dict.parse_main_dict_line(line)
+                existing_entries = []
+                for at, st_list in at_lst:
+                    st_res = []
+                    for st, fv_list in st_list:
+                        fv_res = []
+                        for fv, p_list in fv_list:
+                            p_res = []
+                            for p_id, m_off_set in p_list:
+                                p_id = int(p_id)
+                                pfmri = self._data_manf.get_entity(p_id)
+                                if pfmri not in removed_paths:
+                                    p_res.append((p_id, m_off_set))
+                            if p_res:
+                                fv_res.append((fv, p_res))
+                        if fv_res:
+                            st_res.append((st, fv_res))
+                    if st_res:
+                        existing_entries.append((at, st_res))
+                # Add tokens newly discovered in the added
+                # packages which are alphabetically earlier
+                # than the token most recently read from the
+                # existing main dictionary file.
+                while new_toks_available and next_new_tok < tok:
+                    assert len(next_new_tok) > 0
+                    self._write_main_dict_line(
+                        out_main_dict_handle,
+                        next_new_tok,
+                        new_tok_info,
+                        out_dir,
+                    )
+                    try:
+                        next_new_tok, new_tok_info = next(new_toks_it)
+                    except StopIteration:
                         new_toks_available = False
+                        del next_new_tok
+                        del new_tok_info
 
+                # Combine the information about the current
+                # token from the new packages with the existing
+                # information for that token.
+                if new_toks_available and next_new_tok == tok:
+                    self.__splice(existing_entries, new_tok_info)
+                    try:
+                        next_new_tok, new_tok_info = next(new_toks_it)
+                    except StopIteration:
+                        new_toks_available = False
+                        del next_new_tok
+                        del new_tok_info
+                # If this token has any packages still
+                # associated with it, write them to the file.
+                if existing_entries:
+                    assert len(tok) > 0
+                    self._write_main_dict_line(
+                        out_main_dict_handle, tok, existing_entries, out_dir
+                    )
+
+            # For any new tokens which are alphabetically after the
+            # last entry in the existing file, add them to the end
+            # of the file.
+            while new_toks_available:
+                assert len(next_new_tok) > 0
+                self._write_main_dict_line(
+                    out_main_dict_handle, next_new_tok, new_tok_info, out_dir
+                )
                 try:
-                        for line in file_handle:
-                                (tok, at_lst) = \
-                                    self._data_main_dict.parse_main_dict_line(
-                                    line)
-                                existing_entries = []
-                                for at, st_list in at_lst:
-                                        st_res = []
-                                        for st, fv_list in st_list:
-                                                fv_res = []
-                                                for fv, p_list in fv_list:
-                                                        p_res = []
-                                                        for p_id, m_off_set in \
-                                                                    p_list:
-                                                                p_id = int(p_id)
-                                                                pfmri = self._data_manf.get_entity(p_id)
-                                                                if pfmri not in removed_paths:
-                                                                        p_res.append((p_id, m_off_set))
-                                                        if p_res:
-                                                                fv_res.append(
-                                                                    (fv, p_res))
-                                                if fv_res:
-                                                        st_res.append(
-                                                            (st, fv_res))
-                                        if st_res:
-                                                existing_entries.append(
-                                                    (at, st_res))
-                                # Add tokens newly discovered in the added
-                                # packages which are alphabetically earlier
-                                # than the token most recently read from the
-                                # existing main dictionary file.
-                                while new_toks_available and next_new_tok < tok:
-                                        assert len(next_new_tok) > 0
-                                        self._write_main_dict_line(
-                                            out_main_dict_handle, next_new_tok,
-                                            new_tok_info, out_dir)
-                                        try:
-                                                next_new_tok, new_tok_info = \
-                                                    next(new_toks_it)
-                                        except StopIteration:
-                                                new_toks_available = False
-                                                del next_new_tok
-                                                del new_tok_info
+                    next_new_tok, new_tok_info = next(new_toks_it)
+                except StopIteration:
+                    new_toks_available = False
+        finally:
+            if not self.empty_index:
+                file_handle.close()
+                self._data_main_dict.close_file_handle()
 
-                                # Combine the information about the current
-                                # token from the new packages with the existing
-                                # information for that token.
-                                if new_toks_available and next_new_tok == tok:
-                                        self.__splice(existing_entries,
-                                            new_tok_info)
-                                        try:
-                                                next_new_tok, new_tok_info = \
-                                                    next(new_toks_it)
-                                        except StopIteration:
-                                                new_toks_available = False
-                                                del next_new_tok
-                                                del new_tok_info
-                                # If this token has any packages still
-                                # associated with it, write them to the file.
-                                if existing_entries:
-                                        assert len(tok) > 0
-                                        self._write_main_dict_line(
-                                            out_main_dict_handle,
-                                            tok, existing_entries, out_dir)
+            out_main_dict_handle.close()
+            self._data_token_offset.close_file_handle()
+            for fh in self.at_fh.values():
+                fh.close()
+            for fh in self.st_fh.values():
+                fh.close()
 
-                        # For any new tokens which are alphabetically after the
-                        # last entry in the existing file, add them to the end
-                        # of the file.
-                        while new_toks_available:
-                                assert len(next_new_tok) > 0
-                                self._write_main_dict_line(
-                                    out_main_dict_handle, next_new_tok,
-                                    new_tok_info, out_dir)
-                                try:
-                                        next_new_tok, new_tok_info = \
-                                            next(new_toks_it)
-                                except StopIteration:
-                                        new_toks_available = False
-                finally:
-                        if not self.empty_index:
-                                file_handle.close()
-                                self._data_main_dict.close_file_handle()
+            removed_paths = []
 
-                        out_main_dict_handle.close()
-                        self._data_token_offset.close_file_handle()
-                        for fh in self.at_fh.values():
-                                fh.close()
-                        for fh in self.st_fh.values():
-                                fh.close()
+    def _write_assistant_dicts(self, out_dir):
+        """Write out the companion dictionaries needed for
+        translating the internal representation of the main
+        dictionary into human readable information.
 
-                        removed_paths = []
+        The "out_dir" parameter is the temporary directory to write
+        the indexes into."""
 
-        def _write_assistant_dicts(self, out_dir):
-                """Write out the companion dictionaries needed for
-                translating the internal representation of the main
-                dictionary into human readable information.
+        for d in self._data_dict.values():
+            if d == self._data_main_dict or d == self._data_token_offset:
+                continue
+            d.write_dict_file(out_dir, self.file_version_number)
 
-                The "out_dir" parameter is the temporary directory to write
-                the indexes into."""
+    def _generic_update_index(
+        self, inputs, input_type, tmp_index_dir=None, image=None
+    ):
+        """Performs all the steps needed to update the indexes.
 
-                for d in self._data_dict.values():
-                        if d == self._data_main_dict or \
-                            d == self._data_token_offset:
-                                continue
-                        d.write_dict_file(out_dir, self.file_version_number)
+        The "inputs" parameter iterates over the fmris which have been
+        added or the pkgplans for the change in the image.
 
-        def _generic_update_index(self, inputs, input_type,
-            tmp_index_dir=None, image=None):
-                """Performs all the steps needed to update the indexes.
+        The "input_type" parameter is a value specifying whether the
+        input is fmris or pkgplans.
 
-                The "inputs" parameter iterates over the fmris which have been
-                added or the pkgplans for the change in the image.
+        The "tmp_index_dir" parameter allows this function to use a
+        different temporary directory than the default.
 
-                The "input_type" parameter is a value specifying whether the
-                input is fmris or pkgplans.
+        The "image" parameter must be set if "input_type" is pkgplans.
+        It allows the index to automatically be rebuilt if the number
+        of packages added since last index rebuild is greater than
+        MAX_ADDED_NUMBER_PACKAGES."""
 
-                The "tmp_index_dir" parameter allows this function to use a
-                different temporary directory than the default.
+        self.lock()
+        try:
+            # Allow the use of a directory other than the default
+            # directory to store the intermediate results in.
+            if not tmp_index_dir:
+                tmp_index_dir = self._tmp_dir
+            assert not (tmp_index_dir == self._index_dir)
 
-                The "image" parameter must be set if "input_type" is pkgplans.
-                It allows the index to automatically be rebuilt if the number
-                of packages added since last index rebuild is greater than
-                MAX_ADDED_NUMBER_PACKAGES."""
+            # Read the existing dictionaries.
+            self._read_input_indexes(self._index_dir)
+        except:
+            self.unlock()
+            raise
 
-                self.lock()
-                try:
-                        # Allow the use of a directory other than the default
-                        # directory to store the intermediate results in.
-                        if not tmp_index_dir:
-                                tmp_index_dir = self._tmp_dir
-                        assert not (tmp_index_dir == self._index_dir)
+        try:
+            # If the temporary indexing directory already exists,
+            # remove it to ensure its empty.  Since the caller
+            # should have locked the index already, this should
+            # be safe.
+            if os.path.exists(tmp_index_dir):
+                shutil.rmtree(tmp_index_dir)
 
-                        # Read the existing dictionaries.
-                        self._read_input_indexes(self._index_dir)
-                except:
-                        self.unlock()
-                        raise
+            # Create directory.
+            makedirs(os.path.join(tmp_index_dir))
 
-                try:
-                        # If the temporary indexing directory already exists,
-                        # remove it to ensure its empty.  Since the caller
-                        # should have locked the index already, this should
-                        # be safe.
-                        if os.path.exists(tmp_index_dir):
-                                shutil.rmtree(tmp_index_dir)
+            inputs = list(inputs)
+            fast_update = False
 
-                        # Create directory.
-                        makedirs(os.path.join(tmp_index_dir))
+            if input_type == IDX_INPUT_TYPE_PKG:
+                assert image
 
-                        inputs = list(inputs)
-                        fast_update = False
+                #
+                # Try to do a fast update; if that fails,
+                # do a full index rebuild.
+                #
+                fast_update = self._fast_update(inputs)
 
-                        if input_type == IDX_INPUT_TYPE_PKG:
-                                assert image
-
-                                #
-                                # Try to do a fast update; if that fails,
-                                # do a full index rebuild.
-                                #
-                                fast_update = self._fast_update(inputs)
-
-                                if not fast_update:
-                                        self._data_main_dict.close_file_handle()
-                                        self._data_fast_add.clear()
-                                        self._data_fast_remove.clear()
-
-                                        # Before passing control to rebuild
-                                        # index, the index lock must be
-                                        # released.
-                                        self.unlock()
-                                        return self.rebuild_index_from_scratch(
-                                            image.gen_installed_pkgs(),
-                                            tmp_index_dir)
-
-                        elif input_type == IDX_INPUT_TYPE_FMRI:
-                                assert not self._sort_fh
-                                self._sort_fh = open(os.path.join(self._tmp_dir,
-                                    SORT_FILE_PREFIX +
-                                    str(self._sort_file_num)), "w")
-                                self._sort_file_num += 1
-
-                                self._progtrack.job_start(
-                                    self._progtrack.JOB_REBUILD_SEARCH,
-                                    goal=len(inputs))
-                                dicts = self._process_fmris(inputs)
-                                # Update the main dictionary file
-                                self.__close_sort_fh()
-                                self._update_index(dicts, tmp_index_dir)
-                                self._progtrack.job_done(
-                                    self._progtrack.JOB_REBUILD_SEARCH)
-
-                                self.empty_index = False
-                        else:
-                                raise RuntimeError(
-                                    "Got unknown input_type: {0}", input_type)
-
-                        # Write out the helper dictionaries
-                        self._write_assistant_dicts(tmp_index_dir)
-
-                        # Move all files from the tmp directory into the index
-                        # dir. Note: the need for consistent_open is that
-                        # migrate is not an atomic action.
-                        self._migrate(source_dir = tmp_index_dir,
-                            fast_update=fast_update)
-                        self.unlock()
-
-                except:
-                        self.unlock()
-                        raise
-                finally:
-                        self._data_main_dict.close_file_handle()
-
-        def client_update_index(self, pkgplan_list, image, tmp_index_dir=None):
-                """This version of update index is designed to work with the
-                client side of things.  Specifically, it expects a pkg plan
-                list with added and removed FMRIs/manifests.  Note: if
-                tmp_index_dir is specified, it must NOT exist in the current
-                directory structure.  This prevents the indexer from
-                accidentally removing files.  Image the image object. This is
-                needed to allow correct reindexing from scratch to occur."""
-
-                self._generic_update_index(pkgplan_list, IDX_INPUT_TYPE_PKG,
-                    tmp_index_dir=tmp_index_dir, image=image)
-
-        def server_update_index(self, fmris, tmp_index_dir=None):
-                """ This version of update index is designed to work with the
-                server side of things. Specifically, since we don't currently
-                support removal of a package from a repo, this function simply
-                takes a list of FMRIs to be added to the repot.  Currently, the
-                only way to remove a package from the index is to remove it
-                from the depot and reindex.  Note: if tmp_index_dir is
-                specified, it must NOT exist in the current directory structure.
-                This prevents the indexer from accidentally removing files."""
-
-                self._generic_update_index(fmris, IDX_INPUT_TYPE_FMRI,
-                    tmp_index_dir)
-
-        def check_index_existence(self):
-                """ Returns a boolean value indicating whether a consistent
-                index exists. If an index exists but is inconsistent, an
-                exception is raised."""
-
-                try:
-                        try:
-                                res = \
-                                    ss.consistent_open(self._data_dict.values(),
-                                        self._index_dir,
-                                        self._file_timeout_secs)
-                        except (KeyboardInterrupt,
-                            search_errors.InconsistentIndexException):
-                                raise
-                        except Exception:
-                                return False
-                finally:
-                        for d in self._data_dict.values():
-                                d.close_file_handle()
-                assert res != 0
-                return res
-
-        def rebuild_index_from_scratch(self, fmris, tmp_index_dir=None):
-                """Removes any existing index directory and rebuilds the
-                index based on the fmris and manifests provided as an
-                argument.
-
-                The "tmp_index_dir" parameter allows for a different directory
-                than the default to be used."""
-
-                self.file_version_number = INITIAL_VERSION_NUMBER
-                self.empty_index = True
-
-                # A lock can't be held while the index directory is being
-                # removed as that can cause rmtree() to fail when using
-                # NFS.  As such, remove any stale index.old directory (left
-                # behind by a client (pkgrepo for example) dying), attempt
-                # to get the lock first, then unlock, immediately rename
-                # the old index directory, and then remove the old index
-                # directory and create a new one.
-                try:
-                        shutil.rmtree(self._index_dir + ".old")
-                except FileNotFoundError:
-                        pass
-
-                self.lock()
-                self.unlock()
-
-                portable.rename(self._index_dir, self._index_dir + ".old")
-                try:
-                        shutil.rmtree(self._index_dir + ".old")
-                        makedirs(self._index_dir)
-                except OSError as e:
-                        if e.errno == errno.EACCES:
-                                raise search_errors.ProblematicPermissionsIndexException(
-                                    self._index_dir)
-
-                self._generic_update_index(fmris, IDX_INPUT_TYPE_FMRI,
-                    tmp_index_dir)
-                self.empty_index = False
-
-        def setup(self):
-                """Seeds the index directory with empty stubs if the directory
-                is consistently empty.  Does not overwrite existing indexes."""
-
-                absent = False
-                present = False
-
-                makedirs(self._index_dir)
-                for d in self._data_dict.values():
-                        file_path = os.path.join(self._index_dir,
-                            d.get_file_name())
-                        if os.path.exists(file_path):
-                                present = True
-                        else:
-                                absent = True
-                        if absent and present:
-                                raise search_errors.InconsistentIndexException(
-                                        self._index_dir)
-                if present:
-                        return
-                if self.file_version_number:
-                        raise RuntimeError("Got file_version_number other than "
-                            "None in setup.")
-                self.file_version_number = INITIAL_VERSION_NUMBER
-                for d in self._data_dict.values():
-                        d.write_dict_file(self._index_dir,
-                            self.file_version_number)
-
-        @staticmethod
-        def check_for_updates(index_root, cat):
-                """Check to see whether the catalog has fmris which have not
-                been indexed.
-
-                'index_root' is the path to the index to check against.
-
-                'cat' is the catalog to check for new fmris."""
-
-                fmri_set = set((f.remove_publisher() for f in cat.fmris()))
-
-                data = ss.IndexStoreSet("full_fmri_list")
-                try:
-                        data.open(index_root)
-                except IOError as e:
-                        if not os.path.exists(os.path.join(
-                                index_root, data.get_file_name())):
-                                return fmri_set
-                        else:
-                                raise
-                try:
-                        data.read_and_discard_matching_from_argument(fmri_set)
-                finally:
-                        data.close_file_handle()
-                return fmri_set
-
-        def _migrate(self, source_dir=None, dest_dir=None, fast_update=False):
-                """Moves the indexes from a temporary directory to the
-                permanent one.
-
-                The "source_dir" parameter is the directory containing the
-                new information.
-
-                The "dest_dir" parameter is the directory containing the
-                old information.
-
-                The "fast_update" parameter determines whether the main
-                dictionary and the token byte offset files are moved.  This is
-                used so that when only the update logs are touched, the large
-                files don't need to be moved."""
-
-                if not source_dir:
-                        source_dir = self._tmp_dir
-                if not dest_dir:
-                        dest_dir = self._index_dir
-                assert not (source_dir == dest_dir)
-
-                for d in self._data_dict.values():
-                        if fast_update and (d == self._data_main_dict or
-                            d == self._data_token_offset or
-                            d == self._data_fmri_offsets):
-                                continue
-                        else:
-                                shutil.move(os.path.join(source_dir,
-                                    d.get_file_name()),
-                                    os.path.join(dest_dir, d.get_file_name()))
                 if not fast_update:
-                        # Remove legacy index/pkg/ directory which is obsoleted
-                        # by the fmri_offsets.v1 file.
-                        try:
-                                shutil.rmtree(os.path.join(dest_dir, "pkg"))
-                        except KeyboardInterrupt:
-                                raise
-                        except Exception:
-                                pass
+                    self._data_main_dict.close_file_handle()
+                    self._data_fast_add.clear()
+                    self._data_fast_remove.clear()
 
-                        for at, fh in self.at_fh.items():
-                                shutil.move(
-                                    os.path.join(source_dir, "__at_" + at),
-                                    os.path.join(dest_dir, "__at_" + at))
+                    # Before passing control to rebuild
+                    # index, the index lock must be
+                    # released.
+                    self.unlock()
+                    return self.rebuild_index_from_scratch(
+                        image.gen_installed_pkgs(), tmp_index_dir
+                    )
 
-                        for st, fh in self.st_fh.items():
-                                shutil.move(
-                                    os.path.join(source_dir, "__st_" + st),
-                                    os.path.join(dest_dir, "__st_" + st))
-                shutil.rmtree(source_dir)
+            elif input_type == IDX_INPUT_TYPE_FMRI:
+                assert not self._sort_fh
+                self._sort_fh = open(
+                    os.path.join(
+                        self._tmp_dir,
+                        SORT_FILE_PREFIX + str(self._sort_file_num),
+                    ),
+                    "w",
+                )
+                self._sort_file_num += 1
 
-        def lock(self, blocking=False):
-                """Locks the index in preparation for an index-modifying
-                operation.  Raises an IndexLockedException exception on
-                failure.
+                self._progtrack.job_start(
+                    self._progtrack.JOB_REBUILD_SEARCH, goal=len(inputs)
+                )
+                dicts = self._process_fmris(inputs)
+                # Update the main dictionary file
+                self.__close_sort_fh()
+                self._update_index(dicts, tmp_index_dir)
+                self._progtrack.job_done(self._progtrack.JOB_REBUILD_SEARCH)
 
-                'blocking' is an optional boolean value indicating whether
-                to block until the lock can be obtained or to raise an
-                exception immediately if it cannot be."""
+                self.empty_index = False
+            else:
+                raise RuntimeError("Got unknown input_type: {0}", input_type)
 
-                try:
-                        # Attempt to obtain a file lock.
-                        self.__lockfile.lock(blocking=blocking)
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                # If a lock was requested, and the only
-                                # reason for failure was because the
-                                # index directory doesn't exist yet,
-                                # then create it and try once more.
-                                if not os.path.exists(self._index_dir):
-                                        makedirs(self._index_dir)
-                                        return self.lock(blocking=blocking)
-                                raise
-                        if e.errno in (errno.EACCES, errno.EROFS):
-                                raise search_errors.\
-                                    ProblematicPermissionsIndexException(
-                                    e.filename)
-                        raise
+            # Write out the helper dictionaries
+            self._write_assistant_dicts(tmp_index_dir)
 
-        def unlock(self):
-                """Unlocks the index."""
+            # Move all files from the tmp directory into the index
+            # dir. Note: the need for consistent_open is that
+            # migrate is not an atomic action.
+            self._migrate(source_dir=tmp_index_dir, fast_update=fast_update)
+            self.unlock()
 
-                self.__lockfile.unlock()
+        except:
+            self.unlock()
+            raise
+        finally:
+            self._data_main_dict.close_file_handle()
+
+    def client_update_index(self, pkgplan_list, image, tmp_index_dir=None):
+        """This version of update index is designed to work with the
+        client side of things.  Specifically, it expects a pkg plan
+        list with added and removed FMRIs/manifests.  Note: if
+        tmp_index_dir is specified, it must NOT exist in the current
+        directory structure.  This prevents the indexer from
+        accidentally removing files.  Image the image object. This is
+        needed to allow correct reindexing from scratch to occur."""
+
+        self._generic_update_index(
+            pkgplan_list,
+            IDX_INPUT_TYPE_PKG,
+            tmp_index_dir=tmp_index_dir,
+            image=image,
+        )
+
+    def server_update_index(self, fmris, tmp_index_dir=None):
+        """This version of update index is designed to work with the
+        server side of things. Specifically, since we don't currently
+        support removal of a package from a repo, this function simply
+        takes a list of FMRIs to be added to the repot.  Currently, the
+        only way to remove a package from the index is to remove it
+        from the depot and reindex.  Note: if tmp_index_dir is
+        specified, it must NOT exist in the current directory structure.
+        This prevents the indexer from accidentally removing files."""
+
+        self._generic_update_index(fmris, IDX_INPUT_TYPE_FMRI, tmp_index_dir)
+
+    def check_index_existence(self):
+        """Returns a boolean value indicating whether a consistent
+        index exists. If an index exists but is inconsistent, an
+        exception is raised."""
+
+        try:
+            try:
+                res = ss.consistent_open(
+                    self._data_dict.values(),
+                    self._index_dir,
+                    self._file_timeout_secs,
+                )
+            except (
+                KeyboardInterrupt,
+                search_errors.InconsistentIndexException,
+            ):
+                raise
+            except Exception:
+                return False
+        finally:
+            for d in self._data_dict.values():
+                d.close_file_handle()
+        assert res != 0
+        return res
+
+    def rebuild_index_from_scratch(self, fmris, tmp_index_dir=None):
+        """Removes any existing index directory and rebuilds the
+        index based on the fmris and manifests provided as an
+        argument.
+
+        The "tmp_index_dir" parameter allows for a different directory
+        than the default to be used."""
+
+        self.file_version_number = INITIAL_VERSION_NUMBER
+        self.empty_index = True
+
+        # A lock can't be held while the index directory is being
+        # removed as that can cause rmtree() to fail when using
+        # NFS.  As such, remove any stale index.old directory (left
+        # behind by a client (pkgrepo for example) dying), attempt
+        # to get the lock first, then unlock, immediately rename
+        # the old index directory, and then remove the old index
+        # directory and create a new one.
+        try:
+            shutil.rmtree(self._index_dir + ".old")
+        except FileNotFoundError:
+            pass
+
+        self.lock()
+        self.unlock()
+
+        portable.rename(self._index_dir, self._index_dir + ".old")
+        try:
+            shutil.rmtree(self._index_dir + ".old")
+            makedirs(self._index_dir)
+        except OSError as e:
+            if e.errno == errno.EACCES:
+                raise search_errors.ProblematicPermissionsIndexException(
+                    self._index_dir
+                )
+
+        self._generic_update_index(fmris, IDX_INPUT_TYPE_FMRI, tmp_index_dir)
+        self.empty_index = False
+
+    def setup(self):
+        """Seeds the index directory with empty stubs if the directory
+        is consistently empty.  Does not overwrite existing indexes."""
+
+        absent = False
+        present = False
+
+        makedirs(self._index_dir)
+        for d in self._data_dict.values():
+            file_path = os.path.join(self._index_dir, d.get_file_name())
+            if os.path.exists(file_path):
+                present = True
+            else:
+                absent = True
+            if absent and present:
+                raise search_errors.InconsistentIndexException(self._index_dir)
+        if present:
+            return
+        if self.file_version_number:
+            raise RuntimeError(
+                "Got file_version_number other than " "None in setup."
+            )
+        self.file_version_number = INITIAL_VERSION_NUMBER
+        for d in self._data_dict.values():
+            d.write_dict_file(self._index_dir, self.file_version_number)
+
+    @staticmethod
+    def check_for_updates(index_root, cat):
+        """Check to see whether the catalog has fmris which have not
+        been indexed.
+
+        'index_root' is the path to the index to check against.
+
+        'cat' is the catalog to check for new fmris."""
+
+        fmri_set = set((f.remove_publisher() for f in cat.fmris()))
+
+        data = ss.IndexStoreSet("full_fmri_list")
+        try:
+            data.open(index_root)
+        except IOError as e:
+            if not os.path.exists(
+                os.path.join(index_root, data.get_file_name())
+            ):
+                return fmri_set
+            else:
+                raise
+        try:
+            data.read_and_discard_matching_from_argument(fmri_set)
+        finally:
+            data.close_file_handle()
+        return fmri_set
+
+    def _migrate(self, source_dir=None, dest_dir=None, fast_update=False):
+        """Moves the indexes from a temporary directory to the
+        permanent one.
+
+        The "source_dir" parameter is the directory containing the
+        new information.
+
+        The "dest_dir" parameter is the directory containing the
+        old information.
+
+        The "fast_update" parameter determines whether the main
+        dictionary and the token byte offset files are moved.  This is
+        used so that when only the update logs are touched, the large
+        files don't need to be moved."""
+
+        if not source_dir:
+            source_dir = self._tmp_dir
+        if not dest_dir:
+            dest_dir = self._index_dir
+        assert not (source_dir == dest_dir)
+
+        for d in self._data_dict.values():
+            if fast_update and (
+                d == self._data_main_dict
+                or d == self._data_token_offset
+                or d == self._data_fmri_offsets
+            ):
+                continue
+            else:
+                shutil.move(
+                    os.path.join(source_dir, d.get_file_name()),
+                    os.path.join(dest_dir, d.get_file_name()),
+                )
+        if not fast_update:
+            # Remove legacy index/pkg/ directory which is obsoleted
+            # by the fmri_offsets.v1 file.
+            try:
+                shutil.rmtree(os.path.join(dest_dir, "pkg"))
+            except KeyboardInterrupt:
+                raise
+            except Exception:
+                pass
+
+            for at, fh in self.at_fh.items():
+                shutil.move(
+                    os.path.join(source_dir, "__at_" + at),
+                    os.path.join(dest_dir, "__at_" + at),
+                )
+
+            for st, fh in self.st_fh.items():
+                shutil.move(
+                    os.path.join(source_dir, "__st_" + st),
+                    os.path.join(dest_dir, "__st_" + st),
+                )
+        shutil.rmtree(source_dir)
+
+    def lock(self, blocking=False):
+        """Locks the index in preparation for an index-modifying
+        operation.  Raises an IndexLockedException exception on
+        failure.
+
+        'blocking' is an optional boolean value indicating whether
+        to block until the lock can be obtained or to raise an
+        exception immediately if it cannot be."""
+
+        try:
+            # Attempt to obtain a file lock.
+            self.__lockfile.lock(blocking=blocking)
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                # If a lock was requested, and the only
+                # reason for failure was because the
+                # index directory doesn't exist yet,
+                # then create it and try once more.
+                if not os.path.exists(self._index_dir):
+                    makedirs(self._index_dir)
+                    return self.lock(blocking=blocking)
+                raise
+            if e.errno in (errno.EACCES, errno.EROFS):
+                raise search_errors.ProblematicPermissionsIndexException(
+                    e.filename
+                )
+            raise
+
+    def unlock(self):
+        """Unlocks the index."""
+
+        self.__lockfile.unlock()
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/json.py
+++ b/src/modules/json.py
@@ -29,16 +29,20 @@ import rapidjson as _json
 
 JSONDecodeError = _json.JSONDecodeError
 
+
 def _start():
     psinfo = misc.ProcFS.psinfo()
     _start.rss = psinfo.pr_rssize
     _start.start = time.time()
-    if int(DebugValues['json']) > 1:
+    if int(DebugValues["json"]) > 1:
         _start.trace = True
+
+
 _start.rss = 0
 _start.maxrss = 0
 _start.start = 0
 _start.trace = False
+
 
 def _end(func, param, ret):
     taken = time.time() - _start.start
@@ -46,20 +50,33 @@ def _end(func, param, ret):
     mem = (psinfo.pr_rssize - _start.rss) / 1024.0
     if psinfo.pr_rssize > _start.maxrss:
         _start.maxrss = psinfo.pr_rssize
-    print("JSON Mem {:.2f}+{:.2f}={:.2f} Max {:.2f} MiB "
-        "- Time {:.2f}s - {}({}) = {}"
-        .format(_start.rss / 1024.0, mem, psinfo.pr_rssize / 1024.0,
-        _start.maxrss / 1024.0, taken, func, param, ret),
-        file=sys.stderr)
+    print(
+        "JSON Mem {:.2f}+{:.2f}={:.2f} Max {:.2f} MiB "
+        "- Time {:.2f}s - {}({}) = {}".format(
+            _start.rss / 1024.0,
+            mem,
+            psinfo.pr_rssize / 1024.0,
+            _start.maxrss / 1024.0,
+            taken,
+            func,
+            param,
+            ret,
+        ),
+        file=sys.stderr,
+    )
+
 
 def _stack(note, limit=5):
     from traceback import extract_stack, format_list
+
     stack = extract_stack(limit=limit)[:-3]
     print("{}:".format(note), file=sys.stderr)
     for l in format_list(stack):
         for m in l.split("\n"):
-            if m.strip() == '': continue
+            if m.strip() == "":
+                continue
             print("    >> {}".format(m), file=sys.stderr)
+
 
 def _file(stream):
     try:
@@ -69,41 +86,46 @@ def _file(stream):
     except:
         return str(stream)
 
+
 def load(stream, **kw):
     if "json" in DebugValues:
         _start()
         ret = _json.load(stream, **kw)
-        _end('load', _file(stream), '')
+        _end("load", _file(stream), "")
         return ret
     else:
         return _json.load(stream, **kw)
+
 
 def loads(str, **kw):
     if "json" in DebugValues:
         _start()
         ret = _json.loads(str, **kw)
-        _end('loads', len(str), '')
+        _end("loads", len(str), "")
         return ret
     else:
         return _json.loads(str, **kw)
+
 
 def dump(obj, stream, **kw):
     if "json" in DebugValues:
         _start()
         ret = _json.dump(obj, stream, **kw)
-        _end('dump', _file(stream), ret)
+        _end("dump", _file(stream), ret)
         return ret
     else:
         return _json.dump(obj, stream, **kw)
+
 
 def dumps(obj, **kw):
     if "json" in DebugValues:
         _start()
         ret = _json.dumps(obj, **kw)
-        _end('dumps', '', len(ret))
+        _end("dumps", "", len(ret))
         return ret
     else:
         return _json.dumps(obj, **kw)
+
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/lint/__init__.py
+++ b/src/modules/lint/__init__.py
@@ -25,4 +25,4 @@
 #
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/lint/base.py
+++ b/src/modules/lint/base.py
@@ -35,408 +35,433 @@ import pkg.fmri as fmri
 
 
 class LintException(Exception):
-        """An exception thrown when something fatal has gone wrong during
-        the linting."""
-        pass
+    """An exception thrown when something fatal has gone wrong during
+    the linting."""
+
+    pass
+
 
 class DuplicateLintedAttrException(Exception):
-        """An exception thrown when we've found duplicate pkg.linted* keys."""
-        pass
+    """An exception thrown when we've found duplicate pkg.linted* keys."""
+
+    pass
+
 
 class Checker(object):
-        """A base class for all lint checks.  pkg.lint.engine discovers classes
-        to create these objects according to a configuration file.  Methods that
-        implement lint checks within each Checker object must be given a
-        'pkglint_id' keyword argument so that the system can discover and
-        invoke these methods during lint runs.
+    """A base class for all lint checks.  pkg.lint.engine discovers classes
+    to create these objects according to a configuration file.  Methods that
+    implement lint checks within each Checker object must be given a
+    'pkglint_id' keyword argument so that the system can discover and
+    invoke these methods during lint runs.
 
-        The 'pkglint_id' is used as a short-form identifier for the lint
-        check implemented by each method when paired with the checker
-        'name' attribute.
+    The 'pkglint_id' is used as a short-form identifier for the lint
+    check implemented by each method when paired with the checker
+    'name' attribute.
 
-        Subclasses define the method signature for the check(..) method called
-        from pkg.lint.engine.LintEngine.execute() on instances of that
-        subclass.  Subclasses not implementing a new type of lint Checker,
-        likely those outside this base module, should not override check(..)
-        defined in ActionChecker or ManifestChecker.
+    Subclasses define the method signature for the check(..) method called
+    from pkg.lint.engine.LintEngine.execute() on instances of that
+    subclass.  Subclasses not implementing a new type of lint Checker,
+    likely those outside this base module, should not override check(..)
+    defined in ActionChecker or ManifestChecker.
 
-        Attributes for each Checker subclass include:
+    Attributes for each Checker subclass include:
 
-        'name' is an abbreviated name used by the checker
-        'description' is a short (one sentence) description of the class."""
+    'name' is an abbreviated name used by the checker
+    'description' is a short (one sentence) description of the class."""
 
-        name = "unnamed.checker"
-        description = "No description."
+    name = "unnamed.checker"
+    description = "No description."
 
-        def __init__(self, config):
-                """'config' is a ConfigParser object, see pkg.lint.engine for
-                documentation on the keys we expect it to contain."""
-                self.config = config
+    def __init__(self, config):
+        """'config' is a ConfigParser object, see pkg.lint.engine for
+        documentation on the keys we expect it to contain."""
+        self.config = config
 
-                # lists of (lint method, pkglint_id) tuples
-                self.included_checks = []
-                self.excluded_checks = []
+        # lists of (lint method, pkglint_id) tuples
+        self.included_checks = []
+        self.excluded_checks = []
 
-                def get_pkglint_id(method):
-                        """Inspects a given checker method to find the
-                        'pkglint_id' keyword argument default and returns it."""
+        def get_pkglint_id(method):
+            """Inspects a given checker method to find the
+            'pkglint_id' keyword argument default and returns it."""
 
-                        # the short name for this checker class, Checker.name
-                        name = method.__self__.__class__.name
+            # the short name for this checker class, Checker.name
+            name = method.__self__.__class__.name
 
-                        if six.PY2:
-                                arg_spec = inspect.getargspec(method)
-                        else:
-                                arg_spec = inspect.getfullargspec(method)
+            if six.PY2:
+                arg_spec = inspect.getargspec(method)
+            else:
+                arg_spec = inspect.getfullargspec(method)
 
-                        # arg_spec.args is a tuple of the method args,
-                        # populating the tuple with both arg values for
-                        # non-keyword arguments, and keyword arg names
-                        # for keyword args
-                        c = len(arg_spec.args) - 1
-                        try:
-                                i = arg_spec.args.index("pkglint_id")
-                        except ValueError:
-                                return "{0}.?".format(name)
-                        # arg_spec.defaults are the default values for
-                        # any keyword args, in order.
-                        return "{0}{1}".format(name, arg_spec.defaults[c - i])
+            # arg_spec.args is a tuple of the method args,
+            # populating the tuple with both arg values for
+            # non-keyword arguments, and keyword arg names
+            # for keyword args
+            c = len(arg_spec.args) - 1
+            try:
+                i = arg_spec.args.index("pkglint_id")
+            except ValueError:
+                return "{0}.?".format(name)
+            # arg_spec.defaults are the default values for
+            # any keyword args, in order.
+            return "{0}{1}".format(name, arg_spec.defaults[c - i])
 
-                excl = self.config.get("pkglint", "pkglint.exclude")
-                if excl is None:
-                        excl = ""
+        excl = self.config.get("pkglint", "pkglint.exclude")
+        if excl is None:
+            excl = ""
+        else:
+            excl = excl.split()
+        for item in inspect.getmembers(self, inspect.ismethod):
+            method = item[1]
+            # register the methods in the object that correspond
+            # to lint checks
+            if six.PY2:
+                m = inspect.getargspec(method)
+            else:
+                m = inspect.getfullargspec(method)
+            if "pkglint_id" in m[0]:
+                value = "{0}.{1}.{2}".format(
+                    self.__module__, self.__class__.__name__, method.__name__
+                )
+                pkglint_id = get_pkglint_id(method)
+                if value not in excl:
+                    self.included_checks.append((method, pkglint_id))
                 else:
-                        excl = excl.split()
-                for item in inspect.getmembers(self, inspect.ismethod):
-                        method = item[1]
-                        # register the methods in the object that correspond
-                        # to lint checks
-                        if six.PY2:
-                                m = inspect.getargspec(method)
-                        else:
-                                m = inspect.getfullargspec(method)
-                        if "pkglint_id" in m[0]:
-                                value = "{0}.{1}.{2}".format(
-                                    self.__module__,
-                                    self.__class__.__name__, method.__name__)
-                                pkglint_id = get_pkglint_id(method)
-                                if value not in excl:
-                                        self.included_checks.append(
-                                            (method, pkglint_id))
-                                else:
-                                        self.excluded_checks.append(
-                                            (method, pkglint_id))
+                    self.excluded_checks.append((method, pkglint_id))
 
-        def startup(self, engine):
-                """Called to initialise a given checker using the supplied
-                engine."""
-                pass
+    def startup(self, engine):
+        """Called to initialise a given checker using the supplied
+        engine."""
+        pass
 
-        def shutdown(self, engine):
-                pass
+    def shutdown(self, engine):
+        pass
 
-        def conflicting_variants(self, actions, pkg_vars):
-                """Given a set of actions, determine that none of the actions
-                have matching variant values for any variant.
+    def conflicting_variants(self, actions, pkg_vars):
+        """Given a set of actions, determine that none of the actions
+        have matching variant values for any variant.
 
-                We return a list of variants that conflict, and a list of the
-                actions involved.
-                """
+        We return a list of variants that conflict, and a list of the
+        actions involved.
+        """
 
-                conflict_vars = set()
-                conflict_actions = set()
-                action_list = list(actions)
+        conflict_vars = set()
+        conflict_actions = set()
+        action_list = list(actions)
 
-                # compare every action in the list with every other,
-                # determining what actions have conflicting variants
-                # The comparison is commutative.
-                for i in range(0, len(action_list)):
-                        action = action_list[i]
-                        var = action.get_variant_template()
-                        vc = variant.VariantCombinations(var, True)
-                        for j in range(i + 1, len(action_list)):
-                                cmp_action = action_list[j]
-                                cmp_var = variant.VariantCombinations(
-                                    cmp_action.get_variant_template(), True)
-                                if vc.intersects(cmp_var):
-                                        intersection = vc.intersection(cmp_var)
-                                        intersection.simplify(pkg_vars,
-                                            assert_on_different_domains=False)
-                                        conflict_actions.add(action)
-                                        conflict_actions.add(cmp_action)
-                                        for k in intersection.sat_set:
-                                                if len(k) != 0:
-                                                        conflict_vars.add(k)
-                return conflict_vars, list(conflict_actions)
+        # compare every action in the list with every other,
+        # determining what actions have conflicting variants
+        # The comparison is commutative.
+        for i in range(0, len(action_list)):
+            action = action_list[i]
+            var = action.get_variant_template()
+            vc = variant.VariantCombinations(var, True)
+            for j in range(i + 1, len(action_list)):
+                cmp_action = action_list[j]
+                cmp_var = variant.VariantCombinations(
+                    cmp_action.get_variant_template(), True
+                )
+                if vc.intersects(cmp_var):
+                    intersection = vc.intersection(cmp_var)
+                    intersection.simplify(
+                        pkg_vars, assert_on_different_domains=False
+                    )
+                    conflict_actions.add(action)
+                    conflict_actions.add(cmp_action)
+                    for k in intersection.sat_set:
+                        if len(k) != 0:
+                            conflict_vars.add(k)
+        return conflict_vars, list(conflict_actions)
 
-        def conflicting_dep_actions(self, actions, pkg_vars, compared):
-                """Given a set of depend actions, determine that if any of the
-                two actions are conflicting.
+    def conflicting_dep_actions(self, actions, pkg_vars, compared):
+        """Given a set of depend actions, determine that if any of the
+        two actions are conflicting.
 
-                We return a list of variants that conflict, and a list of the
-                actions involved."""
+        We return a list of variants that conflict, and a list of the
+        actions involved."""
 
-                def get_fmri_set(action):
-                        fmris = set()
-                        for dep in action.attrs["fmri"]:
-                                fmris.add(fmri.extract_pkg_name(dep))
-                        return fmris
+        def get_fmri_set(action):
+            fmris = set()
+            for dep in action.attrs["fmri"]:
+                fmris.add(fmri.extract_pkg_name(dep))
+            return fmris
 
-                conflict_vars = set()
-                conflict_actions = set()
-                action_list = list(actions)
+        conflict_vars = set()
+        conflict_actions = set()
+        action_list = list(actions)
 
-                # Record the fmri set of action we have generated.
-                fmris_dict = [None] * len(actions)
-                multidep_type = frozenset(["require-any", "group-any"])
-                # compare every action in the list with every other,
-                # determining what actions have conflicting variants
-                # The comparison is commutative.
-                for i in range(0, len(action_list)):
-                        action = action_list[i]
-                        var = action.get_variant_template()
-                        vc = variant.VariantCombinations(var, True)
-                        if action.attrs["type"] in multidep_type:
-                                if fmris_dict[i] == None:
-                                        fmris_dict[i] = get_fmri_set(action)
-                                fmris = fmris_dict[i]
-                        for j in range(i + 1, len(action_list)):
-                                cmp_action = action_list[j]
-                                # If we have compared this pair of actions,
-                                # don't bother to compare again.
-                                if ((action, cmp_action) in compared or
-                                    (cmp_action, action) in compared):
-                                        continue
-                                compared.add((action, cmp_action))
-                                if (cmp_action.attrs["type"] in multidep_type
-                                    and action.attrs["type"] in multidep_type):
-                                        fmris_dict[j] = get_fmri_set(cmp_action)
-                                        cmp_fmris = fmris_dict[j]
-                                        if fmris != cmp_fmris:
-                                                continue
-                                cmp_var = variant.VariantCombinations(
-                                    cmp_action.get_variant_template(), True)
-                                if vc.intersects(cmp_var):
-                                        intersection = vc.intersection(cmp_var)
-                                        intersection.simplify(pkg_vars,
-                                            assert_on_different_domains=False)
-                                        conflict_actions.add(action)
-                                        conflict_actions.add(cmp_action)
-                                        for k in intersection.sat_set:
-                                                if len(k) != 0:
-                                                        conflict_vars.add(k)
-                return conflict_vars, list(conflict_actions)
+        # Record the fmri set of action we have generated.
+        fmris_dict = [None] * len(actions)
+        multidep_type = frozenset(["require-any", "group-any"])
+        # compare every action in the list with every other,
+        # determining what actions have conflicting variants
+        # The comparison is commutative.
+        for i in range(0, len(action_list)):
+            action = action_list[i]
+            var = action.get_variant_template()
+            vc = variant.VariantCombinations(var, True)
+            if action.attrs["type"] in multidep_type:
+                if fmris_dict[i] == None:
+                    fmris_dict[i] = get_fmri_set(action)
+                fmris = fmris_dict[i]
+            for j in range(i + 1, len(action_list)):
+                cmp_action = action_list[j]
+                # If we have compared this pair of actions,
+                # don't bother to compare again.
+                if (action, cmp_action) in compared or (
+                    cmp_action,
+                    action,
+                ) in compared:
+                    continue
+                compared.add((action, cmp_action))
+                if (
+                    cmp_action.attrs["type"] in multidep_type
+                    and action.attrs["type"] in multidep_type
+                ):
+                    fmris_dict[j] = get_fmri_set(cmp_action)
+                    cmp_fmris = fmris_dict[j]
+                    if fmris != cmp_fmris:
+                        continue
+                cmp_var = variant.VariantCombinations(
+                    cmp_action.get_variant_template(), True
+                )
+                if vc.intersects(cmp_var):
+                    intersection = vc.intersection(cmp_var)
+                    intersection.simplify(
+                        pkg_vars, assert_on_different_domains=False
+                    )
+                    conflict_actions.add(action)
+                    conflict_actions.add(cmp_action)
+                    for k in intersection.sat_set:
+                        if len(k) != 0:
+                            conflict_vars.add(k)
+        return conflict_vars, list(conflict_actions)
 
 
 class ActionChecker(Checker):
-        """A class to check individual actions."""
+    """A class to check individual actions."""
 
-        def check(self, action, manifest, engine):
-                """'action' is a pkg.actions.generic.Action subclass
-                'manifest' is a pkg.manifest.Manifest"""
+    def check(self, action, manifest, engine):
+        """'action' is a pkg.actions.generic.Action subclass
+        'manifest' is a pkg.manifest.Manifest"""
 
-                for func, pkglint_id in self.included_checks:
-                        engine.advise_loggers(action=action, manifest=manifest)
-                        try:
-                                func(action, manifest, engine)
-                        except Exception as err:
-                                # Checks are still run on actions that are
-                                # marked as pkg.linted. If one of those checks
-                                # results in an exception, we need to handle
-                                # that to avoid one bad Checker crashing
-                                # lint session.
-                                if engine.linted(action=action,
-                                    manifest=manifest, lint_id=pkglint_id):
-                                        engine.info("Checker exception ignored "
-                                            "from {check} on linted action "
-                                            "{action} in {mf}: {err}".format(
-                                            check=pkglint_id,
-                                            action=action,
-                                            mf=manifest.fmri,
-                                            err=err),
-                                            msgid="pkglint001.3")
-                                else:
-                                        engine.error("Checker exception from "
-                                            "{check} on action "
-                                            "{action} in {mf}: "
-                                            "{err}".format(check=pkglint_id,
-                                            action=action,
-                                            mf=manifest.fmri,
-                                            err=err), msgid="lint.error")
-                                        engine.debug(traceback.format_exc(err),
-                                            msgid="lint.error")
+        for func, pkglint_id in self.included_checks:
+            engine.advise_loggers(action=action, manifest=manifest)
+            try:
+                func(action, manifest, engine)
+            except Exception as err:
+                # Checks are still run on actions that are
+                # marked as pkg.linted. If one of those checks
+                # results in an exception, we need to handle
+                # that to avoid one bad Checker crashing
+                # lint session.
+                if engine.linted(
+                    action=action, manifest=manifest, lint_id=pkglint_id
+                ):
+                    engine.info(
+                        "Checker exception ignored "
+                        "from {check} on linted action "
+                        "{action} in {mf}: {err}".format(
+                            check=pkglint_id,
+                            action=action,
+                            mf=manifest.fmri,
+                            err=err,
+                        ),
+                        msgid="pkglint001.3",
+                    )
+                else:
+                    engine.error(
+                        "Checker exception from "
+                        "{check} on action "
+                        "{action} in {mf}: "
+                        "{err}".format(
+                            check=pkglint_id,
+                            action=action,
+                            mf=manifest.fmri,
+                            err=err,
+                        ),
+                        msgid="lint.error",
+                    )
+                    engine.debug(traceback.format_exc(err), msgid="lint.error")
 
 
 class ManifestChecker(Checker):
-        """A class to check manifests.
+    """A class to check manifests.
 
-        In order for proper 'pkg.linted.*' functionality, checker methods that
-        examine individual manifest attributes, should obtain the original 'set'
-        action that was the origin of the manifest attribute, advising the
-        logging system of the attributes being examined, then examining the
-        attribute, before advising the logging system that subsequent
-        lint errors on other attributes are no longer related to that action.
+    In order for proper 'pkg.linted.*' functionality, checker methods that
+    examine individual manifest attributes, should obtain the original 'set'
+    action that was the origin of the manifest attribute, advising the
+    logging system of the attributes being examined, then examining the
+    attribute, before advising the logging system that subsequent
+    lint errors on other attributes are no longer related to that action.
 
-        For example, when looking at the pkg.summary attribute, a checker
-        method would do:
+    For example, when looking at the pkg.summary attribute, a checker
+    method would do:
 
-        action = engine.get_attr_action("pkg.summary", manifest)
-        engine.advise_loggers(action=action, manifest=manifest)
-        .
-        . [ perform checks on the attribute ]
-        .
-        engine.advise_loggers(manifest=manifest)
+    action = engine.get_attr_action("pkg.summary", manifest)
+    engine.advise_loggers(action=action, manifest=manifest)
+    .
+    . [ perform checks on the attribute ]
+    .
+    engine.advise_loggers(manifest=manifest)
 
-        """
+    """
 
-        def __init__(self, config):
+    def __init__(self, config):
+        self.classification_data = None
 
-                self.classification_data = None
+        self.classification_path = config.get(
+            "pkglint", "info_classification_path"
+        )
+        self.skip_classification_check = False
 
-                self.classification_path = config.get(
-                    "pkglint", "info_classification_path")
-                self.skip_classification_check = False
+        # a default error message used if we've parsed the
+        # data file, but haven't thrown any exceptions
+        self.bad_classification_data = _(
+            "no sections found in data " "file {0}"
+        ).format(self.classification_path)
 
-                # a default error message used if we've parsed the
-                # data file, but haven't thrown any exceptions
-                self.bad_classification_data = _("no sections found in data "
-                    "file {0}").format(self.classification_path)
-
-                if os.path.exists(self.classification_path):
-                        try:
-                                if six.PY2:
-                                        self.classification_data = \
-                                            configparser.SafeConfigParser()
-                                        self.classification_data.readfp(
-                                            open(self.classification_path))
-                                else:
-                                        # SafeConfigParser has been renamed to
-                                        # ConfigParser in Python 3.2.
-                                        self.classification_data = \
-                                            configparser.ConfigParser()
-                                        self.classification_data.read_file(
-                                            open(self.classification_path))
-                        except Exception as err:
-                                # any exception thrown here results in a null
-                                # classification_data object.  We deal with that
-                                # later.
-                                self.bad_classification_data = _(
-                                    "unable to parse data file {path}: "
-                                    "{err}").format(
-                                    path=self.classification_path,
-                                    err=err)
-                                pass
+        if os.path.exists(self.classification_path):
+            try:
+                if six.PY2:
+                    self.classification_data = configparser.SafeConfigParser()
+                    self.classification_data.readfp(
+                        open(self.classification_path)
+                    )
                 else:
-                        self.bad_classification_data = _("missing file {0}").format(
-                            self.classification_path)
-                super(ManifestChecker, self).__init__(config)
+                    # SafeConfigParser has been renamed to
+                    # ConfigParser in Python 3.2.
+                    self.classification_data = configparser.ConfigParser()
+                    self.classification_data.read_file(
+                        open(self.classification_path)
+                    )
+            except Exception as err:
+                # any exception thrown here results in a null
+                # classification_data object.  We deal with that
+                # later.
+                self.bad_classification_data = _(
+                    "unable to parse data file {path}: " "{err}"
+                ).format(path=self.classification_path, err=err)
+                pass
+        else:
+            self.bad_classification_data = _("missing file {0}").format(
+                self.classification_path
+            )
+        super(ManifestChecker, self).__init__(config)
 
-        def check(self, manifest, engine):
-                """'manifest' is a pkg.manifest.Manifest"""
+    def check(self, manifest, engine):
+        """'manifest' is a pkg.manifest.Manifest"""
 
-                for func, pkglint_id in self.included_checks:
-                        engine.advise_loggers(manifest=manifest)
-                        try:
-                                func(manifest, engine)
-                        except Exception as err:
-                                # see ActionChecker.check(..)
-                                if engine.linted(manifest=manifest,
-                                    lint_id=pkglint_id):
-                                        engine.info("Checker exception ignored "
-                                            "from {check} on linted manifest "
-                                            "{mf}: {err}".format(
-                                            check=pkglint_id,
-                                            mf=manifest.fmri,
-                                            err=err),
-                                            msgid="pkglint001.3")
-                                else:
-                                        engine.error("Checker exception from "
-                                            "{check} on {mf}: "
-                                            "{err}".format(check=pkglint_id,
-                                            mf=manifest.fmri,
-                                            err=err), msgid="lint.error")
-                                        engine.debug(traceback.format_exc(err),
-                                            msgid="lint.error")
+        for func, pkglint_id in self.included_checks:
+            engine.advise_loggers(manifest=manifest)
+            try:
+                func(manifest, engine)
+            except Exception as err:
+                # see ActionChecker.check(..)
+                if engine.linted(manifest=manifest, lint_id=pkglint_id):
+                    engine.info(
+                        "Checker exception ignored "
+                        "from {check} on linted manifest "
+                        "{mf}: {err}".format(
+                            check=pkglint_id, mf=manifest.fmri, err=err
+                        ),
+                        msgid="pkglint001.3",
+                    )
+                else:
+                    engine.error(
+                        "Checker exception from "
+                        "{check} on {mf}: "
+                        "{err}".format(
+                            check=pkglint_id, mf=manifest.fmri, err=err
+                        ),
+                        msgid="lint.error",
+                    )
+                    engine.debug(traceback.format_exc(err), msgid="lint.error")
 
 
 def get_checkers(module, config):
-        """Return a tuple of a list of Checker objects found in module,
-        instantiating each object with the 'config' ConfigParser object, and a
-        list of excluded Checker objects."""
+    """Return a tuple of a list of Checker objects found in module,
+    instantiating each object with the 'config' ConfigParser object, and a
+    list of excluded Checker objects."""
 
-        checkers = []
-        excluded_checkers = []
+    checkers = []
+    excluded_checkers = []
 
-        exclude = config.get("pkglint", "pkglint.exclude")
-        if exclude is None:
-                exclude = ""
-        else:
-                exclude = exclude.split()
-        for cl in inspect.getmembers(module, inspect.isclass):
-                myclass = cl[1]
-                if issubclass(myclass, Checker):
-                        obj = myclass(config)
-                        name = "{0}.{1}".format(myclass.__module__,
-                            myclass.__name__)
-                        if not (name in exclude or
-                            myclass.__module__ in exclude):
-                                checkers.append(obj)
-                        else:
-                                excluded_checkers.append(obj)
+    exclude = config.get("pkglint", "pkglint.exclude")
+    if exclude is None:
+        exclude = ""
+    else:
+        exclude = exclude.split()
+    for cl in inspect.getmembers(module, inspect.isclass):
+        myclass = cl[1]
+        if issubclass(myclass, Checker):
+            obj = myclass(config)
+            name = "{0}.{1}".format(myclass.__module__, myclass.__name__)
+            if not (name in exclude or myclass.__module__ in exclude):
+                checkers.append(obj)
+            else:
+                excluded_checkers.append(obj)
 
-        return (checkers, excluded_checkers)
+    return (checkers, excluded_checkers)
+
 
 def linted(manifest=None, action=None, lint_id=None):
-        """Determine whether a given action or manifest is marked as linted.
-        We check for manifest or action attributes set to "true" where
-        the attribute starts with "pkg.linted" and is a substring of
-        pkg.linted.<lint_id> anchored at the start of the string.
+    """Determine whether a given action or manifest is marked as linted.
+    We check for manifest or action attributes set to "true" where
+    the attribute starts with "pkg.linted" and is a substring of
+    pkg.linted.<lint_id> anchored at the start of the string.
 
-        So, pkg.linted.foo  matches checks for foo, foo001 foo004.5, etc.
+    So, pkg.linted.foo  matches checks for foo, foo001 foo004.5, etc.
 
-        pkglint Checker methods should use
-        pkg.lint.engine.<LintEngine>.linted() instead of this method."""
+    pkglint Checker methods should use
+    pkg.lint.engine.<LintEngine>.linted() instead of this method."""
 
-        if manifest and action:
-                return _linted_action(action, lint_id) or \
-                    _linted_manifest(manifest, lint_id)
-        if manifest:
-                return _linted_manifest(manifest, lint_id)
-        if action:
-                return _linted_action(action, lint_id)
-        return False
+    if manifest and action:
+        return _linted_action(action, lint_id) or _linted_manifest(
+            manifest, lint_id
+        )
+    if manifest:
+        return _linted_manifest(manifest, lint_id)
+    if action:
+        return _linted_action(action, lint_id)
+    return False
+
 
 def _linted_action(action, lint_id):
-        """Determine whether a given action is marked as linted"""
-        linted = "pkg.linted.{0}".format(lint_id)
-        for key in action.attrs.keys():
-                if key.startswith("pkg.linted") and linted.startswith(key):
-                        val = action.attrs.get(key, "false")
-                        if isinstance(val, six.string_types):
-                                if val.lower() == "true":
-                                        return True
-                        else:
-                                raise DuplicateLintedAttrException(
-                                    _("Multiple values for {key} "
-                                    "in {actions}").format(key=key,
-                                    action=str(action)))
-        return False
+    """Determine whether a given action is marked as linted"""
+    linted = "pkg.linted.{0}".format(lint_id)
+    for key in action.attrs.keys():
+        if key.startswith("pkg.linted") and linted.startswith(key):
+            val = action.attrs.get(key, "false")
+            if isinstance(val, six.string_types):
+                if val.lower() == "true":
+                    return True
+            else:
+                raise DuplicateLintedAttrException(
+                    _("Multiple values for {key} " "in {actions}").format(
+                        key=key, action=str(action)
+                    )
+                )
+    return False
+
 
 def _linted_manifest(manifest, lint_id):
-        """Determine whether a given manifest is marked as linted"""
-        linted = "pkg.linted.{0}".format(lint_id)
-        for key in manifest.attributes.keys():
-                if key.startswith("pkg.linted") and linted.startswith(key):
-                        val = manifest.attributes.get(key, "false")
-                        if isinstance(val, six.string_types):
-                                if val.lower() == "true":
-                                        return True
-                        else:
-                                raise DuplicateLintedAttrException(
-                                    _("Multiple values for {key} "
-                                    "in {manifest}").format(key=key,
-                                    manifest=manifest.fmri))
-        return False
+    """Determine whether a given manifest is marked as linted"""
+    linted = "pkg.linted.{0}".format(lint_id)
+    for key in manifest.attributes.keys():
+        if key.startswith("pkg.linted") and linted.startswith(key):
+            val = manifest.attributes.get(key, "false")
+            if isinstance(val, six.string_types):
+                if val.lower() == "true":
+                    return True
+            else:
+                raise DuplicateLintedAttrException(
+                    _("Multiple values for {key} " "in {manifest}").format(
+                        key=key, manifest=manifest.fmri
+                    )
+                )
+    return False
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/lint/config.py
+++ b/src/modules/lint/config.py
@@ -37,65 +37,64 @@ defaults = {
     "log_level": "INFO",
     "do_pub_checks": "True",
     "ignore_different_publishers": "True",
-    "info_classification_path":
-        "/usr/share/lib/pkg/opensolaris.org.sections",
+    "info_classification_path": "/usr/share/lib/pkg/opensolaris.org.sections",
     "use_progress_tracker": "True",
     "pkglint.ext.opensolaris": "pkg.lint.opensolaris",
     "pkglint.ext.pkglint_actions": "pkg.lint.pkglint_action",
     "pkglint.ext.pkglint_manifests": "pkg.lint.pkglint_manifest",
     "pkglint.exclude": "None",
-    "version.pattern": "*,5.11-0."
-    }
+    "version.pattern": "*,5.11-0.",
+}
 
 # Ensure the order of the items is the same.
 defaults = OrderedDict(sorted(defaults.items(), key=lambda t: t[0]))
 
+
 class PkglintConfigException(Exception):
-        """An exception thrown when something fatal happens while reading the
-        config.
-        """
-        pass
+    """An exception thrown when something fatal happens while reading the
+    config.
+    """
+
+    pass
+
 
 class PkglintConfig(object):
-        def __init__(self, config_file=None):
+    def __init__(self, config_file=None):
+        if config_file:
+            try:
+                # ConfigParser doesn't do a good job of
+                # error reporting, so we'll just try to open
+                # the file
+                open(config_file, "r").close()
+            except EnvironmentError as err:
+                raise PkglintConfigException(
+                    _("unable to read config file: {0} ").format(err)
+                )
+        try:
+            if six.PY2:
+                self.config = configparser.SafeConfigParser(defaults)
+            else:
+                # SafeConfigParser has been renamed to
+                # ConfigParser in Python 3.2.
+                self.config = configparser.ConfigParser(defaults)
+            if not config_file:
+                if six.PY2:
+                    self.config.readfp(open("/usr/share/lib/pkg/pkglintrc"))
+                else:
+                    self.config.read_file(open("/usr/share/lib/pkg/pkglintrc"))
+                self.config.read([os.path.expanduser("~/.pkglintrc")])
+            else:
+                self.config.read(config_file)
 
-                if config_file:
-                        try:
-                                # ConfigParser doesn't do a good job of
-                                # error reporting, so we'll just try to open
-                                # the file
-                                open(config_file, "r").close()
-                        except (EnvironmentError) as err:
-                                raise PkglintConfigException(
-                                    _("unable to read config file: {0} ").format(
-                                    err))
-                try:
-                        if six.PY2:
-                                self.config = configparser.SafeConfigParser(
-                                    defaults)
-                        else:
-                                # SafeConfigParser has been renamed to
-                                # ConfigParser in Python 3.2.
-                                self.config = configparser.ConfigParser(
-                                    defaults)
-                        if not config_file:
-                                if six.PY2:
-                                        self.config.readfp(
-                                            open("/usr/share/lib/pkg/pkglintrc"))
-                                else:
-                                        self.config.read_file(
-                                            open("/usr/share/lib/pkg/pkglintrc"))
-                                self.config.read(
-                                    [os.path.expanduser("~/.pkglintrc")])
-                        else:
-                                self.config.read(config_file)
+            # sanity check our config by looking for a known key
+            self.config.get("pkglint", "log_level")
+        except configparser.Error as err:
+            raise PkglintConfigException(
+                _(
+                    "missing or corrupt pkglintrc file " "{config_file}: {err}"
+                ).format(**locals())
+            )
 
-                        # sanity check our config by looking for a known key
-                        self.config.get("pkglint", "log_level")
-                except configparser.Error as err:
-                        raise PkglintConfigException(
-                            _("missing or corrupt pkglintrc file "
-                            "{config_file}: {err}").format(**locals()))
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/lint/engine.py
+++ b/src/modules/lint/engine.py
@@ -46,1278 +46,1315 @@ PKG_CLIENT_NAME = "pkglint"
 CLIENT_API_VERSION = 82
 pkg.client.global_settings.client_name = PKG_CLIENT_NAME
 
+
 class LintEngineException(Exception):
-        """An exception thrown when something fatal goes wrong with the engine,
-        such that linting can no longer continue."""
-        pass
+    """An exception thrown when something fatal goes wrong with the engine,
+    such that linting can no longer continue."""
+
+    pass
 
 
 class LintEngineSetupException(LintEngineException):
-        """An exception thrown when the engine failed to complete its setup."""
-        pass
+    """An exception thrown when the engine failed to complete its setup."""
+
+    pass
 
 
-class LintEngineCache():
-        """This class provides two caches for the LintEngine.  A cache of the
-        latest packages for one or more ImageInterface objects intended to be
-        seeded at startup, and a generic manifest cache"""
+class LintEngineCache:
+    """This class provides two caches for the LintEngine.  A cache of the
+    latest packages for one or more ImageInterface objects intended to be
+    seeded at startup, and a generic manifest cache"""
 
-        def __init__(self, version_pattern, release=None):
-                self.latest_cache = {}
-                self.misc_cache = {}
-                self.logger = logging.getLogger("pkglint")
-                self.seeded = False
+    def __init__(self, version_pattern, release=None):
+        self.latest_cache = {}
+        self.misc_cache = {}
+        self.logger = logging.getLogger("pkglint")
+        self.seeded = False
 
-                # release is a build number, eg. 150
-                # version_pattern used by the engine is a regexp, intended
-                # to be used when searching for images, combined with the
-                # release - eg. "*,5.11-151"
-                #
-                self.version_pattern = version_pattern
-                self.release = release
-                if self.release:
-                        combined = "{0}{1}".format(
-                            version_pattern.split(",")[1], release)
-                        try:
-                                self.branch = DotSequence(
-                                    combined.split("-")[1])
-                        except pkg.version.IllegalDotSequence:
-                                raise LintEngineSetupException(
-                                    _("Invalid release string: {0}").format(
-                                    self.release))
+        # release is a build number, eg. 150
+        # version_pattern used by the engine is a regexp, intended
+        # to be used when searching for images, combined with the
+        # release - eg. "*,5.11-151"
+        #
+        self.version_pattern = version_pattern
+        self.release = release
+        if self.release:
+            combined = "{0}{1}".format(version_pattern.split(",")[1], release)
+            try:
+                self.branch = DotSequence(combined.split("-")[1])
+            except pkg.version.IllegalDotSequence:
+                raise LintEngineSetupException(
+                    _("Invalid release string: {0}").format(self.release)
+                )
 
-        def seed_latest(self, api_inst, tracker, phase):
-                """Builds a cache of latest manifests for this api_inst, using
-                the provided progress tracker, phase and release.
-                """
-                search_type = pkg.client.api.ImageInterface.LIST_NEWEST
-                pattern_list = ["*"]
-                self.seeded = True
+    def seed_latest(self, api_inst, tracker, phase):
+        """Builds a cache of latest manifests for this api_inst, using
+        the provided progress tracker, phase and release.
+        """
+        search_type = pkg.client.api.ImageInterface.LIST_NEWEST
+        pattern_list = ["*"]
+        self.seeded = True
 
-                # a dictionary of PkgFmri objects which we'll use to retrieve
-                # manifests
-                packages = {}
+        # a dictionary of PkgFmri objects which we'll use to retrieve
+        # manifests
+        packages = {}
 
-                # a dictionary of the latest packages for a given release
-                self.latest_cache[api_inst] = {}
-                # a dictionary of packages at other versions
-                self.misc_cache[api_inst] = {}
+        # a dictionary of the latest packages for a given release
+        self.latest_cache[api_inst] = {}
+        # a dictionary of packages at other versions
+        self.misc_cache[api_inst] = {}
 
-                if not self.release:
-                        for item in api_inst.get_pkg_list(
-                            search_type, patterns=pattern_list, variants=True):
-                                pub_name, name, version = item[0]
-                                pub = api_inst.get_publisher(prefix=pub_name)
-                                fmri ="pkg://{0}/{1}@{2}".format(pub, name,
-                                    version)
-                                pfmri = pkg.fmri.PkgFmri(fmri)
-                                # index with just the pkg name, allowing us to
-                                # use this cache when searching for dependencies
-                                packages["pkg:/{0}".format(name)] = pfmri
+        if not self.release:
+            for item in api_inst.get_pkg_list(
+                search_type, patterns=pattern_list, variants=True
+            ):
+                pub_name, name, version = item[0]
+                pub = api_inst.get_publisher(prefix=pub_name)
+                fmri = "pkg://{0}/{1}@{2}".format(pub, name, version)
+                pfmri = pkg.fmri.PkgFmri(fmri)
+                # index with just the pkg name, allowing us to
+                # use this cache when searching for dependencies
+                packages["pkg:/{0}".format(name)] = pfmri
 
-                else:
-                        # take a bit more time building up the latest version
-                        # of all packages not greater than build_release
-                        search_type = pkg.client.api.ImageInterface.LIST_ALL
+        else:
+            # take a bit more time building up the latest version
+            # of all packages not greater than build_release
+            search_type = pkg.client.api.ImageInterface.LIST_ALL
 
-                        for item in api_inst.get_pkg_list(
-                            search_type, variants=True):
-                                pub_name, name, version = item[0]
-                                pub = api_inst.get_publisher(prefix=pub_name)
-                                fmri ="pkg://{0}/{1}@{2}".format(pub, name,
-                                    version)
-                                # obtain just the build branch, e.g. from
-                                # 0.5.11,5.11-0.111:20090508T235707Z, return
-                                # 0.111
-                                branch = Version(version, None).branch
+            for item in api_inst.get_pkg_list(search_type, variants=True):
+                pub_name, name, version = item[0]
+                pub = api_inst.get_publisher(prefix=pub_name)
+                fmri = "pkg://{0}/{1}@{2}".format(pub, name, version)
+                # obtain just the build branch, e.g. from
+                # 0.5.11,5.11-0.111:20090508T235707Z, return
+                # 0.111
+                branch = Version(version, None).branch
 
-                                pfmri = pkg.fmri.PkgFmri(fmri)
-                                key = "pkg:/{0}".format(name)
+                pfmri = pkg.fmri.PkgFmri(fmri)
+                key = "pkg:/{0}".format(name)
 
-                                if key not in packages and \
-                                    branch <= self.branch:
-                                        packages[key] = pfmri
-                                # get_pkg_list returns results sorted by
-                                # publisher, then sorted by version. We may find
-                                # another publisher that has a more recent
-                                # package available, so we need to respect
-                                # timestamps in that case.
-                                elif key in packages:
-                                        prev = packages[key]
-                                        if lint_fmri_successor(pfmri, prev,
-                                            ignore_timestamps=False) and \
-                                            branch <= self.branch:
-                                                packages[key] = pfmri
+                if key not in packages and branch <= self.branch:
+                    packages[key] = pfmri
+                # get_pkg_list returns results sorted by
+                # publisher, then sorted by version. We may find
+                # another publisher that has a more recent
+                # package available, so we need to respect
+                # timestamps in that case.
+                elif key in packages:
+                    prev = packages[key]
+                    if (
+                        lint_fmri_successor(
+                            pfmri, prev, ignore_timestamps=False
+                        )
+                        and branch <= self.branch
+                    ):
+                        packages[key] = pfmri
 
-                # now get the manifests
-                tracker.manifest_fetch_start(len(packages))
-                for item in packages:
-                        self.latest_cache[api_inst][item] = \
-                            api_inst.get_manifest(packages[item])
-                        tracker.manifest_fetch_progress(completion=True)
-                tracker.manifest_fetch_done()
+        # now get the manifests
+        tracker.manifest_fetch_start(len(packages))
+        for item in packages:
+            self.latest_cache[api_inst][item] = api_inst.get_manifest(
+                packages[item]
+            )
+            tracker.manifest_fetch_progress(completion=True)
+        tracker.manifest_fetch_done()
 
-        def gen_latest(self, api_inst, pattern):
-                """ A generator function to return the latest version of the
-                packages matching the supplied pattern from the publishers set
-                for api_inst"""
-                if not self.seeded:
-                        raise LintEngineException("Cache has not been seeded")
+    def gen_latest(self, api_inst, pattern):
+        """A generator function to return the latest version of the
+        packages matching the supplied pattern from the publishers set
+        for api_inst"""
+        if not self.seeded:
+            raise LintEngineException("Cache has not been seeded")
 
-                if api_inst in self.latest_cache:
-                        for item in sorted(self.latest_cache[api_inst]):
-                                mf = self.latest_cache[api_inst][item]
-                                if pattern and pkg.fmri.glob_match(
-                                    str(mf.fmri), pattern):
-                                        yield mf
-                                elif not pattern:
-                                        yield mf
+        if api_inst in self.latest_cache:
+            for item in sorted(self.latest_cache[api_inst]):
+                mf = self.latest_cache[api_inst][item]
+                if pattern and pkg.fmri.glob_match(str(mf.fmri), pattern):
+                    yield mf
+                elif not pattern:
+                    yield mf
 
-        def get_latest(self, api_inst, pkg_name):
-                """ Return the package matching pkg_name from the publishers set
-                for api_inst """
-                if not self.seeded:
-                        raise LintEngineException("Cache has not been seeded")
+    def get_latest(self, api_inst, pkg_name):
+        """Return the package matching pkg_name from the publishers set
+        for api_inst"""
+        if not self.seeded:
+            raise LintEngineException("Cache has not been seeded")
 
-                if api_inst in self.latest_cache:
-                        if pkg_name in self.latest_cache[api_inst]:
-                                return self.latest_cache[api_inst][pkg_name]
-                return None
+        if api_inst in self.latest_cache:
+            if pkg_name in self.latest_cache[api_inst]:
+                return self.latest_cache[api_inst][pkg_name]
+        return None
 
-        def count_latest(self, api_inst, pattern):
-                """Returns the number of manifests in the given api_inst cache
-                that match the provided pattern. If pattern is None,
-                we return the length of the api_inst cache."""
-                if not self.seeded:
-                        raise LintEngineException("Cache has not been seeded")
-                if not pattern:
-                        return len(self.latest_cache[api_inst])
-                count = 0
-                for item in self.latest_cache[api_inst]:
-                        mf = self.latest_cache[api_inst][item]
-                        if pkg.fmri.glob_match(str(mf.fmri), pattern):
-                                count = count + 1
-                return count
+    def count_latest(self, api_inst, pattern):
+        """Returns the number of manifests in the given api_inst cache
+        that match the provided pattern. If pattern is None,
+        we return the length of the api_inst cache."""
+        if not self.seeded:
+            raise LintEngineException("Cache has not been seeded")
+        if not pattern:
+            return len(self.latest_cache[api_inst])
+        count = 0
+        for item in self.latest_cache[api_inst]:
+            mf = self.latest_cache[api_inst][item]
+            if pkg.fmri.glob_match(str(mf.fmri), pattern):
+                count = count + 1
+        return count
 
-        def add(self, api_inst, pkg_name, manifest):
-                """Adds a given manifest to the cache for a given api_inst"""
-                # we don't update latest_cache, since that should have been
-                # pre-seeded on startup.
-                self.misc_cache[api_inst][pkg_name] = manifest
+    def add(self, api_inst, pkg_name, manifest):
+        """Adds a given manifest to the cache for a given api_inst"""
+        # we don't update latest_cache, since that should have been
+        # pre-seeded on startup.
+        self.misc_cache[api_inst][pkg_name] = manifest
 
-        def get(self, api_inst, pkg_name):
-                """Retrieves a given pkg_name entry from the cache.
-                Can raise KeyError if the package isn't in the cache."""
-                if not self.seeded:
-                        raise LintEngineException("Cache has not been seeded")
-                if pkg_name in self.latest_cache[api_inst]:
-                        return self.latest_cache[api_inst][pkg_name]
-                else:
-                        return self.misc_cache[api_inst][pkg_name]
+    def get(self, api_inst, pkg_name):
+        """Retrieves a given pkg_name entry from the cache.
+        Can raise KeyError if the package isn't in the cache."""
+        if not self.seeded:
+            raise LintEngineException("Cache has not been seeded")
+        if pkg_name in self.latest_cache[api_inst]:
+            return self.latest_cache[api_inst][pkg_name]
+        else:
+            return self.misc_cache[api_inst][pkg_name]
 
 
 class LintEngine(object):
-        """LintEngine is the main object used by pkglint to discover lint
-        plugins, and execute lint checks on package manifests, retrieved
-        from a repository or from local objects.
+    """LintEngine is the main object used by pkglint to discover lint
+    plugins, and execute lint checks on package manifests, retrieved
+    from a repository or from local objects.
 
-        Lint plugins are written as subclasses of pkg.lint.base.Checker
-        and are discovered once the module containing them has been listed
-        in either the shipped pkglintrc file, a user-supplied version, or
-        the pkg.lint.config.PkglintConfig defaults.
+    Lint plugins are written as subclasses of pkg.lint.base.Checker
+    and are discovered once the module containing them has been listed
+    in either the shipped pkglintrc file, a user-supplied version, or
+    the pkg.lint.config.PkglintConfig defaults.
 
-        User-supplied manifests for linting are read directly as files
-        provided on the command line.  For cross-checking against a
-        reference repository, or linting the manifests in a repository, we
-        create a reference or lint user-images in a provided cache location,
-        used to obtain manifests from those repositories.
+    User-supplied manifests for linting are read directly as files
+    provided on the command line.  For cross-checking against a
+    reference repository, or linting the manifests in a repository, we
+    create a reference or lint user-images in a provided cache location,
+    used to obtain manifests from those repositories.
 
-        Multiple repositories can be provided, however each must
-        use a different publisher.prefix (as they are added as publishers
-        to a single user image)
+    Multiple repositories can be provided, however each must
+    use a different publisher.prefix (as they are added as publishers
+    to a single user image)
 
-        Our reference image is stored in
+    Our reference image is stored in
 
-        <cache>/ref_image/
+    <cache>/ref_image/
 
-        The image for linting is stored in
+    The image for linting is stored in
 
-        <cache>/lint_image/
+    <cache>/lint_image/
 
-        We can also lint pkg.manifest.Manifest objects, passed as the
-        lint_manifests list to the setup(..) method.
+    We can also lint pkg.manifest.Manifest objects, passed as the
+    lint_manifests list to the setup(..) method.
 
-        The config object for the engine has the following keys:
+    The config object for the engine has the following keys:
 
-        'log_level' The minimum level at which to emit lint messages. Lint
-        messages lower than this level are discarded.
+    'log_level' The minimum level at which to emit lint messages. Lint
+    messages lower than this level are discarded.
 
-        By default, this is set to INFO. Log levels in order of least to most
-        severe are: DEBUG, INFO, WARNING, ERROR, CRITICAL
+    By default, this is set to INFO. Log levels in order of least to most
+    severe are: DEBUG, INFO, WARNING, ERROR, CRITICAL
 
-        'do_pub_checks' Whether to perform checks which may  only  make  sense
-        for published packages. Set to True by default.
+    'do_pub_checks' Whether to perform checks which may  only  make  sense
+    for published packages. Set to True by default.
 
-        'pkglint.ext.*' Multiple keys, specifying modules to load which contain
-        subclasses of pkg.lint.base.Checker.  The value of this property should
-        be fully specified python module name, assumed to be in $PYTHONPATH
+    'pkglint.ext.*' Multiple keys, specifying modules to load which contain
+    subclasses of pkg.lint.base.Checker.  The value of this property should
+    be fully specified python module name, assumed to be in $PYTHONPATH
 
-        'pkglint.exclude' A space-separated list of fully-specified Python
-        modules, classes or function names which should be omitted from the set
-        of checks performed. eg.
+    'pkglint.exclude' A space-separated list of fully-specified Python
+    modules, classes or function names which should be omitted from the set
+    of checks performed. eg.
 
-        'pkg.lint.opensolaris.ActionChecker' or
-        'my.lint.module' or
-        'my.lint.module.ManifestChecker.crosscheck_paths'
+    'pkg.lint.opensolaris.ActionChecker' or
+    'my.lint.module' or
+    'my.lint.module.ManifestChecker.crosscheck_paths'
 
-        'version.pattern' A version pattern, used when specifying a build number
-        to lint against (-b). If not specified in the rcfile, this pattern is
-        "*,5.11-151", matching all components of the '5.11' build, with a branch
-        prefix of '151'
+    'version.pattern' A version pattern, used when specifying a build number
+    to lint against (-b). If not specified in the rcfile, this pattern is
+    "*,5.11-151", matching all components of the '5.11' build, with a branch
+    prefix of '151'
 
-        'info_classification_path' A path the file used to check the values
-        of info.classification attributes in manifests.
+    'info_classification_path' A path the file used to check the values
+    of info.classification attributes in manifests.
 
-        'use_progress_tracker' Whether to use progress tracking.
+    'use_progress_tracker' Whether to use progress tracking.
 
-        'ignore_different_publishers' Whether to ignore differences in publisher
-        when comparing package FMRIs.
+    'ignore_different_publishers' Whether to ignore differences in publisher
+    when comparing package FMRIs.
 
-        The engine has support for a "/* LINTED */"-like functionality,
-        see the comment for <LintEngine>.execute()"""
+    The engine has support for a "/* LINTED */"-like functionality,
+    see the comment for <LintEngine>.execute()"""
 
-        def __init__(self, formatter, verbose=False, config_file=None,
-            use_tracker=None, extension_path=[]):
-                """Creates a lint engine a given pkg.lint.log.LogFormatter.
-                'verbose' overrides any log_level settings in the config file
-                to DEBUG
-                'config_file' specifies a path to a pkglintrc configuration file
-                'use_tracker' overrides any pkglintrc settings to either
-                explicitly enable or disable the use of a tracker, set to None,
-                we don't override the config file setting."""
+    def __init__(
+        self,
+        formatter,
+        verbose=False,
+        config_file=None,
+        use_tracker=None,
+        extension_path=[],
+    ):
+        """Creates a lint engine a given pkg.lint.log.LogFormatter.
+        'verbose' overrides any log_level settings in the config file
+        to DEBUG
+        'config_file' specifies a path to a pkglintrc configuration file
+        'use_tracker' overrides any pkglintrc settings to either
+        explicitly enable or disable the use of a tracker, set to None,
+        we don't override the config file setting."""
 
-                # the directory used to store our user-images.
-                self.basedir = None
+        # the directory used to store our user-images.
+        self.basedir = None
 
-                # a pattern used to narrow searches in the lint image
-                self.pattern = None
-                self.release = None
-                # a prefix for the pattern used to search for given releases
-                self.version_pattern = "*,5.11-151"
+        # a pattern used to narrow searches in the lint image
+        self.pattern = None
+        self.release = None
+        # a prefix for the pattern used to search for given releases
+        self.version_pattern = "*,5.11-151"
 
-                # lists of checker functions and excluded checker functions
-                self.checkers = []
-                self.excluded_checkers = []
+        # lists of checker functions and excluded checker functions
+        self.checkers = []
+        self.excluded_checkers = []
 
-                # A progress tracker, used during the lint run
-                self.tracker = None
+        # A progress tracker, used during the lint run
+        self.tracker = None
 
-                # set up our python logger
-                self.logger = logging.getLogger("pkglint")
+        # set up our python logger
+        self.logger = logging.getLogger("pkglint")
 
-                formatter.engine = self
+        formatter.engine = self
 
-                # the pkglint LogFormatters we are configured with
-                self.logs = [formatter]
+        # the pkglint LogFormatters we are configured with
+        self.logs = [formatter]
 
-                # whether to run checks that may only be valid for published
-                # manifests
-                self.do_pub_checks = True
+        # whether to run checks that may only be valid for published
+        # manifests
+        self.do_pub_checks = True
 
-                # whether to ignore publisher differences when comparing vers
-                self.ignore_pubs = True
+        # whether to ignore publisher differences when comparing vers
+        self.ignore_pubs = True
 
-                # Ensure extension_path is always a list even if empty
-                self.extension_path = extension_path
-                if not self.extension_path:
-                    self.extension_path = []
+        # Ensure extension_path is always a list even if empty
+        self.extension_path = extension_path
+        if not self.extension_path:
+            self.extension_path = []
 
-                self.conf = self.load_config(config_file, verbose=verbose)
+        self.conf = self.load_config(config_file, verbose=verbose)
 
-                # override config_file entry
-                if use_tracker is not None:
-                        self.use_tracker = use_tracker
+        # override config_file entry
+        if use_tracker is not None:
+            self.use_tracker = use_tracker
 
-                self.tracker_phase = 0
-                self.in_setup = False
-                formatter.tracker = self.get_tracker()
+        self.tracker_phase = 0
+        self.in_setup = False
+        formatter.tracker = self.get_tracker()
 
-                self.ref_image = None
-                self.lint_image = None
+        self.ref_image = None
+        self.lint_image = None
 
-                self.lint_uris = []
-                self.ref_uris = []
+        self.lint_uris = []
+        self.ref_uris = []
 
-                # a reference to the pkg.client.api for our reference and lint
-                # images
-                self.ref_api_inst = None
-                self.lint_api_inst = None
+        # a reference to the pkg.client.api for our reference and lint
+        # images
+        self.ref_api_inst = None
+        self.lint_api_inst = None
 
-                # manifests presented to us for parsing on the command line
-                self.lint_manifests = []
+        # manifests presented to us for parsing on the command line
+        self.lint_manifests = []
 
-                self.mf_cache = None
+        self.mf_cache = None
 
-        def _load_checker_module(self, name, config):
-                """Dynamically loads a given checker module, returning new
-                instances of the checker classes the module declares,
-                assuming they haven't been excluded by the config object."""
+    def _load_checker_module(self, name, config):
+        """Dynamically loads a given checker module, returning new
+        instances of the checker classes the module declares,
+        assuming they haven't been excluded by the config object."""
 
-                # Make a copy of sys.path so we can revert it after module load
-                _preserved_sys_path = list(sys.path)
+        # Make a copy of sys.path so we can revert it after module load
+        _preserved_sys_path = list(sys.path)
+        try:
+            self.logger.debug("Loading module {0}".format(name))
+            # Temporarily add the extension paths to sys.path
+            # Any paths specified in the init call take precedence
+            # over the config file.
+            sys.path.extend(self.extension_path)
+
+            # the fifth parameter is 'level', which defautls to -1
+            # in Python 2 and 0 in Python 3.
+            __import__(name, None, None, [])
+            (checkers, excluded) = base.get_checkers(sys.modules[name], config)
+            return (checkers, excluded)
+        except (KeyError, ImportError) as err:
+            raise base.LintException(err)
+        finally:
+            # Reset sys.path
+            sys.path = _preserved_sys_path
+
+    def _unique_checkers(self):
+        """Ensure that the engine has unique names for all of the loaded
+        checks."""
+
+        unique_names = set()
+        for checker in self.checkers:
+            if checker.name in unique_names:
+                raise LintEngineSetupException(
+                    _(
+                        "loading extensions: "
+                        "duplicate checker name {name}: "
+                        "{classname}"
+                    ).format(name=checker.name, classname=checker)
+                )
+            unique_names.add(checker.name)
+            unique_methods = set()
+
+            for method, pkglint_id in (
+                checker.included_checks + checker.excluded_checks
+            ):
+                if pkglint_id in unique_methods:
+                    raise LintEngineSetupException(
+                        _(
+                            "loading extension "
+                            "{checker}: duplicate pkglint_id "
+                            "{pkglint_id} in {method}"
+                        ).format(
+                            checker=checker.name,
+                            pkglint_id=pkglint_id,
+                            method=method,
+                        )
+                    )
+                unique_methods.add(pkglint_id)
+
+    def load_config(self, config, verbose=False):
+        """Loads configuration from supplied config file, allowing
+        a verbosity override."""
+
+        try:
+            conf = pkg.lint.config.PkglintConfig(config_file=config).config
+        except pkg.lint.config.PkglintConfigException as err:
+            raise LintEngineSetupException(err)
+
+        excl = []
+
+        try:
+            excl = conf.get("pkglint", "pkglint.exclude")
+            if excl is None:
+                excl = ""
+            else:
+                excl = excl.split()
+        except configparser.NoOptionError:
+            pass
+
+        try:
+            self.version_pattern = conf.get("pkglint", "version.pattern")
+        except configparser.NoOptionError:
+            pass
+
+        try:
+            self.extension_path.extend(
+                conf.get("pkglint", "extension_path").split(os.pathsep)
+            )
+        except configparser.NoOptionError:
+            pass
+
+        for key, value in conf.items("pkglint"):
+            if "pkglint.ext" in key:
+                if value in excl:
+                    # want to exclude everything from here
+                    (checkers, exclude) = self._load_checker_module(value, conf)
+                    self.excluded_checkers.extend(checkers)
+                    self.excluded_checkers.extend(exclude)
+                    continue
                 try:
-                        self.logger.debug("Loading module {0}".format(name))
-                        # Temporarily add the extension paths to sys.path
-                        # Any paths specified in the init call take precedence
-                        # over the config file.
-                        sys.path.extend(self.extension_path)
+                    (checkers, exclude) = self._load_checker_module(value, conf)
+                    self.checkers.extend(checkers)
+                    self.excluded_checkers.extend(exclude)
+
+                except base.LintException as err:
+                    raise LintEngineSetupException(
+                        _(
+                            "Error parsing config value for " "{key}: {err}"
+                        ).format(**locals())
+                    )
+
+        self._unique_checkers()
+
+        if verbose:
+            for lint_log in self.logs:
+                lint_log.level = "DEBUG"
+        else:
+            for lint_log in self.logs:
+                lint_log.level = conf.get("pkglint", "log_level")
+
+        try:
+            self.do_pub_checks = conf.getboolean("pkglint", "do_pub_checks")
+        except configparser.NoOptionError:
+            pass
+
+        try:
+            self.use_tracker = (
+                conf.get("pkglint", "use_progress_tracker").lower() == "true"
+            )
+        except configparser.NoOptionError:
+            pass
+
+        try:
+            self.ignore_pubs = (
+                conf.get("pkglint", "ignore_different_publishers").lower()
+                == "true"
+            )
+        except configparser.NoOptionError:
+            pass
+
+        return conf
+
+    def setup(
+        self,
+        lint_manifests=[],
+        ref_uris=[],
+        lint_uris=[],
+        cache=None,
+        pattern=None,
+        release=None,
+    ):
+        """Starts a pkglint session, creates our image, pulls manifests,
+        etc. from servers if necessary.
+
+        'cache' An area where we create images to access repos for both
+        reference and linting purposes
+
+        'lint_manifests' An array of paths to manifests for linting
+
+        'ref_uris' A list of repositories which will be added to the
+        image used as a reference for linting
+
+        'lint_uris' A list of repositories which will be added to th
+        image we want to lint
+
+        'pattern' A regexp to match the packages we want to lint, if
+        empty, we match everything.  Note that this is only applied when
+        searching for packages to lint: we lint against all packages for
+        a given release in the reference repository (if configured)
+
+        'release' A release value that narrows the set of packages we
+        lint with.  This affects both the packages presented for linting
+        as well as the packages in the repository we are linting
+        against. If release if set to None, we lint with and against the
+        latest available packages in the repositories."""
+
+        self.ref_uris = ref_uris
+        self.lint_uris = lint_uris
+        self.lint_manifests = lint_manifests
+        self.lint_manifests.sort(key=_manifest_sort_key)
+        self.pattern = pattern
+        self.release = release
+        self.in_setup = True
+        self.mf_cache = LintEngineCache(self.version_pattern, release=release)
+
+        if not cache and not lint_manifests:
+            raise LintEngineSetupException(
+                _(
+                    "Either a cache directory, or some local "
+                    "manifest files must be provided."
+                )
+            )
+
+        if not cache and (ref_uris or lint_uris):
+            raise LintEngineSetupException(
+                _(
+                    "A cache directory must be provided if using "
+                    "reference or lint repositories."
+                )
+            )
+
+        if cache:
+            self.basedir = os.path.abspath(cache)
+
+            try:
+                self.lint_image = os.path.join(self.basedir, "lint_image")
+
+                if os.path.exists(self.lint_image):
+                    self.lint_api_inst = self._get_image(self.lint_image)
+                    if self.lint_api_inst and lint_uris:
+                        self.tracker.flush()
+                        self.logger.info(
+                            _("Ignoring -l option, " "existing image found.")
+                        )
+
+                # only create a new image if we've not been
+                # able to load one, and we have been given a uri
+                if not self.lint_api_inst and lint_uris:
+                    self.lint_api_inst = self._create_image(
+                        self.lint_image, self.lint_uris
+                    )
 
-                        # the fifth parameter is 'level', which defautls to -1
-                        # in Python 2 and 0 in Python 3.
-                        __import__(name, None, None, [])
-                        (checkers, excluded) = \
-                            base.get_checkers(sys.modules[name], config)
-                        return (checkers, excluded)
-                except (KeyError, ImportError) as err:
-                        raise base.LintException(err)
-                finally:
-                        # Reset sys.path
-                        sys.path = _preserved_sys_path
-
-        def _unique_checkers(self):
-                """Ensure that the engine has unique names for all of the loaded
-                checks."""
-
-                unique_names = set()
-                for checker in self.checkers:
-                        if checker.name in unique_names:
-                                raise LintEngineSetupException(
-                                    _("loading extensions: "
-                                    "duplicate checker name {name}: "
-                                    "{classname}").format(
-                                    name=checker.name,
-                                    classname=checker))
-                        unique_names.add(checker.name)
-                        unique_methods = set()
-
-                        for method, pkglint_id in checker.included_checks + \
-                            checker.excluded_checks:
-
-                                if pkglint_id in unique_methods:
-                                        raise LintEngineSetupException(_(
-                                            "loading extension "
-                                            "{checker}: duplicate pkglint_id "
-                                            "{pkglint_id} in {method}").format(
-                                            checker=checker.name,
-                                            pkglint_id=pkglint_id,
-                                            method=method))
-                                unique_methods.add(pkglint_id)
-
-        def load_config(self, config, verbose=False):
-                """Loads configuration from supplied config file, allowing
-                a verbosity override."""
-
-                try:
-                        conf = pkg.lint.config.PkglintConfig(
-                            config_file=config).config
-                except (pkg.lint.config.PkglintConfigException) as err:
-                        raise LintEngineSetupException(err)
-
-                excl = []
-
-                try:
-                        excl = conf.get("pkglint", "pkglint.exclude")
-                        if excl is None:
-                                excl = ""
-                        else:
-                                excl = excl.split()
-                except configparser.NoOptionError:
-                        pass
-
-                try:
-                        self.version_pattern = conf.get("pkglint",
-                            "version.pattern")
-                except configparser.NoOptionError:
-                        pass
-
-                try:
-                        self.extension_path.extend(conf.get("pkglint",
-                            "extension_path").split(os.pathsep))
-                except configparser.NoOptionError:
-                        pass
-
-                for key, value in conf.items("pkglint"):
-                        if "pkglint.ext" in key:
-                                if value in excl:
-                                        # want to exclude everything from here
-                                        (checkers, exclude) = \
-                                            self._load_checker_module(value,
-                                            conf)
-                                        self.excluded_checkers.extend(checkers)
-                                        self.excluded_checkers.extend(exclude)
-                                        continue
-                                try:
-                                        (checkers, exclude) = \
-                                            self._load_checker_module(value,
-                                            conf)
-                                        self.checkers.extend(checkers)
-                                        self.excluded_checkers.extend(exclude)
-
-                                except base.LintException as err:
-                                        raise LintEngineSetupException(
-                                            _("Error parsing config value for "
-                                            "{key}: {err}").format(**locals()))
-
-                self._unique_checkers()
-
-                if verbose:
-                        for lint_log in self.logs:
-                                lint_log.level = "DEBUG"
-                else:
-                        for lint_log in self.logs:
-                                lint_log.level = conf.get("pkglint",
-                                    "log_level")
-
-                try:
-                        self.do_pub_checks = conf.getboolean("pkglint",
-                            "do_pub_checks")
-                except configparser.NoOptionError:
-                        pass
-
-                try:
-                        self.use_tracker = conf.get("pkglint",
-                            "use_progress_tracker").lower() == "true"
-                except configparser.NoOptionError:
-                        pass
-
-                try:
-                        self.ignore_pubs = conf.get("pkglint",
-                            "ignore_different_publishers").lower() == "true"
-                except configparser.NoOptionError:
-                        pass
-
-                return conf
-
-        def setup(self, lint_manifests=[], ref_uris=[], lint_uris=[],
-            cache=None, pattern=None, release=None):
-                """Starts a pkglint session, creates our image, pulls manifests,
-                etc. from servers if necessary.
-
-                'cache' An area where we create images to access repos for both
-                reference and linting purposes
-
-                'lint_manifests' An array of paths to manifests for linting
-
-                'ref_uris' A list of repositories which will be added to the
-                image used as a reference for linting
-
-                'lint_uris' A list of repositories which will be added to th
-                image we want to lint
-
-                'pattern' A regexp to match the packages we want to lint, if
-                empty, we match everything.  Note that this is only applied when
-                searching for packages to lint: we lint against all packages for
-                a given release in the reference repository (if configured)
-
-                'release' A release value that narrows the set of packages we
-                lint with.  This affects both the packages presented for linting
-                as well as the packages in the repository we are linting
-                against. If release if set to None, we lint with and against the
-                latest available packages in the repositories."""
-
-                self.ref_uris = ref_uris
-                self.lint_uris = lint_uris
-                self.lint_manifests = lint_manifests
-                self.lint_manifests.sort(key=_manifest_sort_key)
-                self.pattern = pattern
-                self.release = release
-                self.in_setup = True
-                self.mf_cache = LintEngineCache(self.version_pattern,
-                    release=release)
-
-                if not cache and not lint_manifests:
-                        raise LintEngineSetupException(
-                            _("Either a cache directory, or some local "
-                            "manifest files must be provided."))
-
-                if not cache and (ref_uris or lint_uris):
-                        raise LintEngineSetupException(
-                            _("A cache directory must be provided if using "
-                            "reference or lint repositories."))
-
-                if cache:
-                        self.basedir = os.path.abspath(cache)
-
-                        try:
-                                self.lint_image = os.path.join(self.basedir,
-                                    "lint_image")
-
-                                if os.path.exists(self.lint_image):
-                                        self.lint_api_inst = self._get_image(
-                                            self.lint_image)
-                                        if self.lint_api_inst and lint_uris:
-                                                self.tracker.flush()
-                                                self.logger.info(
-                                                    _("Ignoring -l option, "
-                                                    "existing image found."))
-
-                                # only create a new image if we've not been
-                                # able to load one, and we have been given a uri
-                                if not self.lint_api_inst and lint_uris:
-                                        self.lint_api_inst = self._create_image(
-                                            self.lint_image, self.lint_uris)
-
-                                if self.lint_api_inst:
-                                        self.tracker_phase = \
-                                            self.tracker_phase + 1
-                                        self.mf_cache.seed_latest(
-                                            self.lint_api_inst,
-                                            self.get_tracker(),
-                                            self.tracker_phase)
-
-                        except LintEngineException as err:
-                                raise LintEngineSetupException(
-                                    _("Unable to create lint image: {0}").format(
-                                    str(err)))
-                        try:
-                                self.ref_image = os.path.join(self.basedir,
-                                    "ref_image")
-                                if os.path.exists(self.ref_image):
-                                        self.ref_api_inst = self._get_image(
-                                            self.ref_image)
-                                        if self.ref_api_inst and ref_uris:
-                                                self.tracker.flush()
-                                                self.logger.info(
-                                                    _("Ignoring -r option, "
-                                                    "existing image found."))
-
-                                # only create a new image if we've not been
-                                # able to load one, and we have been given a uri
-                                if not self.ref_api_inst and ref_uris:
-                                        if not (self.lint_api_inst or \
-                                            lint_manifests):
-                                                raise LintEngineSetupException(
-                                                    "No lint image or manifests"
-                                                    " provided.")
-                                        self.ref_api_inst = self._create_image(
-                                            self.ref_image, self.ref_uris)
-
-                                if self.ref_api_inst:
-                                        self.tracker_phase = \
-                                            self.tracker_phase + 1
-                                        self.mf_cache.seed_latest(
-                                            self.ref_api_inst,
-                                            self.get_tracker(),
-                                            self.tracker_phase)
-
-                        except LintEngineException as err:
-                                raise LintEngineSetupException(
-                                    _("Unable to create reference image: {0}").format(
-                                    str(err)))
-
-                        if not (self.ref_api_inst or self.lint_api_inst):
-                                raise LintEngineSetupException(
-                                    _("Unable to access any pkglint images "
-                                   "under {0}").format(cache))
-
-                for checker in self.checkers:
-                        checker.startup(self)
-
-                self.get_tracker().lint_done()
-                self.in_setup = False
-
-        def execute(self):
-                """Run the checks that have been configured for this engine.
-                We run checks on all lint_manifests as well as all manifests
-                in a configured lint repository that match both our pattern
-                and release (if they have been configured).
-
-                We allow for pkg.linted=True and pkg.linted.<name>=True, where
-                <name> is a substring of a pkglint id to skip logging errors
-                for that action or manifest.
-
-                As much of the pkg.linted functionality as possible is handled
-                by the logging system, in combination with the engine calling
-                advise_loggers() as appropriate, however some ManifestChecker
-                methods may still need to use engine.linted() or
-                <LintEngine>.advise_loggers() manually when iterating over
-                manifest actions in order to properly respect pkg.linted
-                attributes."""
-
-                manifest_checks = []
-                action_checks = []
-                count = 0
-                for checker in self.checkers:
-
-                        count = count + len(checker.included_checks)
-                        if isinstance(checker, base.ManifestChecker):
-                                manifest_checks.append(checker)
-                        elif isinstance(checker, base.ActionChecker):
-                                action_checks.append(checker)
-                        else:
-                                raise LintEngineSetupException(
-                                    _("{0} does not subclass a known "
-                                    "Checker subclass intended for use by "
-                                    "pkglint extensions").format(str(checker)))
-
-                self.tracker.flush()
-                self.logger.debug(_("Total number of checks found: {0}").format(
-                    count))
-
-                for mf in self.lint_manifests:
-                        self._check_manifest(mf, manifest_checks,
-                            action_checks)
-
-                for manifest in self.gen_manifests(self.lint_api_inst,
-                    pattern=self.pattern, release=self.release):
-                        self._check_manifest(manifest, manifest_checks,
-                            action_checks)
-                self.tracker.flush()
-
-        def gen_manifests(self, api_inst, pattern=None, release=None):
-                """A generator to return package manifests for a given image.
-                With a given pattern, it narrows the set of manifests
-                returned to match that pattern.
-
-                With the given 'release' number, it searches for manifests for
-                that release using "<pattern>@<version.pattern><release>"
-                where <version.pattern> is set in pkglintrc and
-                <pattern> and <release> are the keyword arguments to this
-                method. """
-
-                if not api_inst:
-                        return
-
-                tracker = self.get_tracker()
-                if self.in_setup:
-                        pt = tracker.LINT_PHASETYPE_SETUP
-                else:
-                        pt = tracker.LINT_PHASETYPE_EXECUTE
-                tracker.lint_next_phase(
-                    self.mf_cache.count_latest(api_inst, pattern), pt)
-
-                for m in self.mf_cache.gen_latest(api_inst, pattern):
-                        tracker.lint_add_progress()
-                        yield m
-                return
-
-        EXACT = 0
-        LATEST_SUCCESSOR = 1
-
-        def get_manifest(self, pkg_name, search_type=EXACT, reference=False):
-                """Returns the first available manifest for a given package
-                name, searching hierarchically in the lint manifests,
-                the lint_repo or the ref_repo for that single package.
-
-                By default, we search for an exact match on the provided
-                pkg_name, throwing a LintEngineException if we get more than
-                one match for the supplied pkg_name.
-                When search_type is LintEngine.LATEST_SUCCESSOR, we return the
-                most recent successor of the provided package, using the
-                lint_fmri_successor() method defined in this module.
-
-                If 'reference' is True, only search for the package using the
-                reference image. If no reference image has been configured, this
-                raises a pkg.lint.base.LintException.
-                """
-
-                if not pkg_name.startswith("pkg:/"):
-                        pkg_name = "pkg:/{0}".format(pkg_name)
-
-                def build_fmri(pkg_name):
-                        """builds a pkg.fmri.PkgFmri from a string."""
-                        try:
-                                fmri = pkg.fmri.PkgFmri(pkg_name)
-                                return fmri
-                        except pkg.fmri.IllegalFmri:
-                                try:
-                                        # FMRIs listed as dependencies often
-                                        # omit build_release, use a dummy one
-                                        # for now
-                                        fmri = pkg.fmri.PkgFmri(pkg_name)
-                                        return fmri
-                                except:
-                                        msg = _("unable to construct fmri from "
-                                            "{0}").format(pkg_name)
-                                        raise base.LintException(msg)
-
-                def get_fmri(api_inst, pkg_name):
-                        """Retrieve an fmri string that matches pkg_name."""
-
-                        if "*" in pkg_name or "?" in pkg_name:
-                                raise base.LintException(
-                                    _("invalid pkg name {0}").format(pkg_name))
-
-                        if "@" not in pkg_name and self.release:
-                                pkg_name = "{0}@{1}{2}".format(
-                                    pkg_name, self.version_pattern,
-                                    self.release)
-
-                        fmris = []
-                        for item in api_inst.get_pkg_list(
-                            pkg.client.api.ImageInterface.LIST_ALL,
-                            patterns=[pkg_name], variants=True,
-                            return_fmris=True):
-                                fmris.append(item[0])
-
-                        fmri_list = []
-                        for item in fmris:
-                                fmri_list.append(item.get_fmri())
-
-                        if len(fmri_list) == 1:
-                                return fmri_list[0]
-
-                        elif len(fmri_list) == 0:
-                                return None
-                        else:
-                                # we expected to get only 1 hit, so
-                                # something has gone wrong
-                                raise LintEngineException(
-                                    _("get_fmri(pattern) {pattern} "
-                                    "matched {count} packages: "
-                                    "{pkgs}").format(
-                                    pattern=pkg_name,
-                                    count=len(fmri_list),
-                                    pkgs=" ".join(fmri_list)
-                                    ))
-
-                def mf_from_image(api_inst, pkg_name, search_type):
-                        """Fetch a manifest for the given package name using
-                        the ImageInterface provided."""
-                        if not api_inst:
-                                return None
-
-                        search_fmri = build_fmri(pkg_name)
-                        if search_type == self.LATEST_SUCCESSOR:
-                                # we want to normalize the pkg_name, removing
-                                # the publisher, if any.
-                                name = "pkg:/{0}".format(search_fmri.get_name())
-                                mf = self.mf_cache.get_latest(api_inst, name)
-                                if not mf:
-                                        return
-                                # double-check the publishers match, since we
-                                # searched for just a package name
-                                if search_fmri.publisher:
-                                        if search_fmri.publisher == \
-                                            mf.fmri.publisher:
-                                                return mf
-                                else:
-                                        return mf
-
-                        # We've either not found a matching publisher, or we're
-                        # doing an exact search.
-                        try:
-                                mf = self.mf_cache.get(api_inst, pkg_name)
-                                return mf
-                        except KeyError:
-                                mf = None
-                                fmri = get_fmri(api_inst, pkg_name)
-                                if fmri:
-                                        mf = api_inst.get_manifest(
-                                            pkg.fmri.PkgFmri(fmri))
-                                self.mf_cache.add(api_inst, pkg_name, mf)
-                                return mf
-
-                # search hierarchically for the given package name in our
-                # local manifests, using our lint image, or using our reference
-                # image and return a manifest for that package.
-                if reference:
-                     if not self.ref_api_inst:
-                             raise base.LintException(
-                                _("No reference repository has been "
-                                "configured"))
-                     return mf_from_image(self.ref_api_inst, pkg_name,
-                        search_type)
-
-                for mf in self.lint_manifests:
-                        search_fmri = build_fmri(pkg_name)
-                        if search_type == self.LATEST_SUCCESSOR and \
-                            lint_fmri_successor(mf.fmri, search_fmri,
-                                ignore_pubs=self.ignore_pubs):
-                                return mf
-
-                        if str(mf.fmri) == pkg_name:
-                                return mf
-                        if mf.fmri.get_name() == pkg_name:
-                                return mf
-                mf = mf_from_image(self.lint_api_inst, pkg_name, search_type)
-                if mf:
-                        return mf
-                # fallback to our reference api, returning None if that's
-                # what we were given.
-                return mf_from_image(self.ref_api_inst, pkg_name, search_type)
-
-        def _get_image(self, image_dir):
-                """Return a pkg.client.api.ImageInterface for the provided
-                image directory."""
-
-                cdir = os.getcwd()
-                tracker = self.get_tracker()
-                api_inst = None
-                try:
-                        api_inst = pkg.client.api.ImageInterface(
-                            image_dir, CLIENT_API_VERSION,
-                            tracker, None, PKG_CLIENT_NAME)
-
-                        if api_inst.root != image_dir:
-                                api_inst = None
-                        else:
-                                # given that pkglint is expected to be used
-                                # during manifest development, we always want
-                                # to refresh now, rather than waiting for some
-                                # update interval
-                                api_inst.refresh(immediate=True)
-                except Exception as err:
-                        raise LintEngineSetupException(
-                            _("Unable to get image at {dir}: {reason}").format(
-                            dir=image_dir,
-                            reason=str(err)))
-
-                # restore the current directory, which ImageInterace had changed
-                os.chdir(cdir)
-                return api_inst
-
-        def _create_image(self, image_dir, repo_uris):
-                """Create image in the given image directory. For now, only
-                a single publisher is supported per image."""
-
-                tracker = self.get_tracker()
-
-                is_zone = False
-                refresh_allowed = True
-
-                self.tracker.flush()
-                self.logger.debug(_("Creating image at {0}").format(image_dir))
-
-                # Check to see if a scheme was used, if not, treat it as a
-                # file:// URI, and get the absolute path.  Missing or invalid
-                # repositories will be caught by pkg.client.api.image_create.
-                for i, uri in enumerate(repo_uris):
-                        if not urlparse(uri).scheme:
-                                repo_uris[i] = "file://{0}".format(
-                                    quote(os.path.abspath(uri)))
-
-                try:
-                        api_inst = pkg.client.api.image_create(
-                            PKG_CLIENT_NAME, CLIENT_API_VERSION, image_dir,
-                            pkg.client.api.IMG_TYPE_USER, is_zone,
-                            facets=pkg.facet.Facets(), force=False,
-                            progtrack=tracker, refresh_allowed=refresh_allowed,
-                            repo_uri=repo_uris[0])
-                except (ApiException, OSError, IOError) as err:
-                        raise LintEngineSetupException(err)
-
-                # Check to see if multiple repositories are specified.
-                repo_uris.pop(0)
-                if repo_uris:
-                        try:
-                                self._set_publisher(api_inst, repo_uris)
-                        except ApiException as e:
-                                api_inst._img.destroy()
-                                if os.path.abspath(image_dir) != "/" and \
-                                    os.path.exists(image_dir):
-                                        shutil.rmtree(image_dir, True)
-                                raise LintEngineSetupException(e)
-
-                return api_inst
-
-        def _set_publisher(self, api_inst, repo_uris):
-                """Helper function to set publishers on a ref or lint image."""
-
-                for repo_uri in repo_uris:
-                        repo = publisher.RepositoryURI(repo_uri)
-                        pubs = []
-                        try:
-                                pubs = api_inst.get_publisherdata(repo=repo)
-                        except apx.UnsupportedRepositoryOperation:
-                                raise
-
-                        for pub in sorted(pubs):
-                                prefix = pub.prefix
-                                src_repo = pub.repository
-                                if api_inst.has_publisher(prefix=prefix):
-                                        add_origins = []
-                                        dest_pub = api_inst.get_publisher(
-                                            prefix=prefix, duplicate=True)
-                                        dest_repo = dest_pub.repository
-                                        # dest_repo.origins is not None here
-                                        # after invoking api.image_create()
-                                        # in _create_image().
-
-                                        if src_repo:
-                                                # Add unknown origins but avoid
-                                                # duplicates.
-                                                add_origins = [
-                                                    u.uri
-                                                    for u in src_repo.origins
-                                                    if u.uri not in \
-                                                        dest_repo.origins
-                                                ]
-
-                                        if not dest_repo.has_origin(repo_uri):
-                                                add_origins.append(repo_uri)
-
-                                        for u in add_origins:
-                                                dest_repo.add_origin(u)
-
-                                        api_inst.update_publisher(dest_pub)
-                                else:
-                                        if not src_repo:
-                                                # Repository configuration info
-                                                # was not provided, assume
-                                                # origin is repo_uri.
-                                                pub.repository = \
-                                                    publisher.Repository(
-                                                    origins=[repo_uri])
-                                        elif not src_repo.origins:
-                                                # No origin was provided in
-                                                # repository configuration,
-                                                # assume origin is repo_uri.
-                                                src_repo.add_origin(repo_uri)
-
-                                        api_inst.add_publisher(pub,
-                                            refresh_allowed=False)
-
-        def _check_manifest(self, manifest, manifest_checks, action_checks):
-                """Check a given manifest."""
-
-                self.debug(_("Checking {0}").format(manifest.fmri),
-                    "pkglint001.3")
-
-                for checker in manifest_checks:
-                        checker.check(manifest, self)
-
-                if action_checks:
-                        for action in manifest.gen_actions():
-                                self._check_action(action, manifest,
-                                    action_checks)
-
-        def _check_action(self, action, manifest, action_checks):
-                """Check a given action."""
-
-                for checker in action_checks:
-                        checker.check(action, manifest, self)
-
-        def advise_loggers(self, action=None, manifest=None):
-                """Called to advise any loggers we have set that we're about
-                to perform lint checks on the given action or manifest.
-
-                In particular, this is used to let the logger objects access
-                the manifest or action being linted without needing to pass
-                those objects each time we log a message.
-
-                Care must be taken in base.ManifestChecker methods to call
-                this any time they're iterating over actions and are likely to
-                report lint errors that may be related to that action.  When
-                finished iterating, they should re-call this method with only
-                the manifest keyword argument, to clear the last action used.
-
-                Between each Checker method invocation, the Checker subclass
-                calls this automatically to clear any state set by those method
-                calls.
-                """
-                for log in self.logs:
-                        log.advise(action=action, manifest=manifest)
-
-        # convenience methods to log lint messages to all loggers
-        # configured for this engine
-        def debug(self, message, msgid=None, ignore_linted=False):
-                """Log a debug message to all loggers."""
-                for log in self.logs:
-                        log.debug(message, msgid=msgid,
-                            ignore_linted=ignore_linted)
-
-        def info(self, message, msgid=None, ignore_linted=False):
-                """Log an info message to all loggers."""
-                for log in self.logs:
-                        log.info(message, msgid=msgid,
-                            ignore_linted=ignore_linted)
-
-        def warning(self, message, msgid=None, ignore_linted=False):
-                """Log a warning message to all loggers."""
-                for log in self.logs:
-                        log.warning(message, msgid=msgid,
-                            ignore_linted=ignore_linted)
-
-        def error(self, message, msgid=None, ignore_linted=False):
-                """Log an error message to all loggers."""
-                for log in self.logs:
-                        log.error(message, msgid=msgid,
-                            ignore_linted=ignore_linted)
-
-        def critical(self, message, msgid=None, ignore_linted=False):
-                """Log a critical message to all loggers."""
-                for log in self.logs:
-                        log.critical(message, msgid=msgid,
-                            ignore_linted=ignore_linted)
-
-        def skip_check_msg(self, action, msgid):
-                """Log a message saying we're skipping a particular check."""
-                self.info(_("Not running {check} checks on linted action "
-                    "{action}").format(check=msgid, action=str(action)),
-                    msgid="pkglint001.4", ignore_linted=True)
-
-        def teardown(self, clear_cache=False):
-                """Ends a pkglint session.
-                clear_cache    False by default, True causes the cache to be
-                               destroyed."""
-                for checker in self.checkers:
-                        try:
-                                checker.shutdown(self)
-                        except base.LintException as err:
-                                self.error(err)
-                self.checkers = []
-
-                # Reset the API object before destroying it; because it does a
-                # chdir(), we need to save and restore our cwd.
-                cwd = os.getcwd()
                 if self.lint_api_inst:
-                        self.lint_api_inst.reset()
-                os.chdir(cwd)
-                self.lint_api_inst = None
+                    self.tracker_phase = self.tracker_phase + 1
+                    self.mf_cache.seed_latest(
+                        self.lint_api_inst,
+                        self.get_tracker(),
+                        self.tracker_phase,
+                    )
 
-                if clear_cache:
-                        shutil.rmtree(self.basedir)
-                self.advise_loggers()
+            except LintEngineException as err:
+                raise LintEngineSetupException(
+                    _("Unable to create lint image: {0}").format(str(err))
+                )
+            try:
+                self.ref_image = os.path.join(self.basedir, "ref_image")
+                if os.path.exists(self.ref_image):
+                    self.ref_api_inst = self._get_image(self.ref_image)
+                    if self.ref_api_inst and ref_uris:
+                        self.tracker.flush()
+                        self.logger.info(
+                            _("Ignoring -r option, " "existing image found.")
+                        )
 
-        def get_tracker(self):
-                """Creates a ProgressTracker if we don't already have one,
-                otherwise resetting our current tracker and returning it"""
+                # only create a new image if we've not been
+                # able to load one, and we have been given a uri
+                if not self.ref_api_inst and ref_uris:
+                    if not (self.lint_api_inst or lint_manifests):
+                        raise LintEngineSetupException(
+                            "No lint image or manifests" " provided."
+                        )
+                    self.ref_api_inst = self._create_image(
+                        self.ref_image, self.ref_uris
+                    )
 
-                if self.tracker:
-                        if not self.in_setup:
-                                self.tracker.reset()
-                        self.tracker.set_major_phase(self.tracker.PHASE_UTILITY)
-                        return self.tracker
-                if not self.use_tracker:
-                        self.tracker = progress.NullProgressTracker()
-                else:
-                        try:
-                                self.tracker = \
-                                    progress.FancyUNIXProgressTracker()
-                        except progress.ProgressTrackerException:
-                                self.tracker = \
-                                    progress.CommandLineProgressTracker()
-                self.tracker.set_major_phase(self.tracker.PHASE_UTILITY)
-                return self.tracker
+                if self.ref_api_inst:
+                    self.tracker_phase = self.tracker_phase + 1
+                    self.mf_cache.seed_latest(
+                        self.ref_api_inst,
+                        self.get_tracker(),
+                        self.tracker_phase,
+                    )
 
-        def follow_renames(self, pkg_name, target=None, old_mfs=[],
-            warn_on_obsolete=False, legacy=False):
-                """Given a package name, and an optional target pfmri that we
-                expect to be ultimately renamed to, follow package renames from
-                pkg_name, looking for the package we expect to be at the end of
-                the chain.
+            except LintEngineException as err:
+                raise LintEngineSetupException(
+                    _("Unable to create reference image: {0}").format(str(err))
+                )
 
-                If there was a break in the renaming chain, we return None.
-                old_mfs, if passed, should be a list of manifests that were
-                sources of this rename.
+            if not (self.ref_api_inst or self.lint_api_inst):
+                raise LintEngineSetupException(
+                    _(
+                        "Unable to access any pkglint images " "under {0}"
+                    ).format(cache)
+                )
 
-                If legacy is True, as well as checking that the target
-                name was reached, we also look for the leaf-name of the target.
-                This lets legacy action checking function properly, allowing,
-                say pkg:/SUNWbip or pkg:/compatibility/package/SUNWbip to
-                satisfy the rename check.
-                """
+        for checker in self.checkers:
+            checker.startup(self)
 
-                # When doing legacy action checks, the leaf of the target pkg
-                # matching the pkg_name is enough so long as that package is
-                # not marked as 'pkg.renamed'
-                if legacy and target:
-                        leaf_name = target.get_name().split("/")[-1]
-                        if leaf_name == pkg_name:
-                                leaf_mf = self.get_manifest(target.get_name(),
-                                    search_type=self.LATEST_SUCCESSOR)
-                                if leaf_mf and leaf_mf.get("pkg.renamed",
-                                    "false") == "false":
-                                        return leaf_mf
+        self.get_tracker().lint_done()
+        self.in_setup = False
 
-                mf = self.get_manifest(pkg_name,
-                    search_type=self.LATEST_SUCCESSOR)
+    def execute(self):
+        """Run the checks that have been configured for this engine.
+        We run checks on all lint_manifests as well as all manifests
+        in a configured lint repository that match both our pattern
+        and release (if they have been configured).
 
-                if not mf:
-                        return None
+        We allow for pkg.linted=True and pkg.linted.<name>=True, where
+        <name> is a substring of a pkglint id to skip logging errors
+        for that action or manifest.
 
-                if warn_on_obsolete and "pkg.obsolete" in mf:
-                        raise base.LintException(
-                            _("obsolete package: {0}").format(mf.fmri))
+        As much of the pkg.linted functionality as possible is handled
+        by the logging system, in combination with the engine calling
+        advise_loggers() as appropriate, however some ManifestChecker
+        methods may still need to use engine.linted() or
+        <LintEngine>.advise_loggers() manually when iterating over
+        manifest actions in order to properly respect pkg.linted
+        attributes."""
 
-                # if we're trying to rename to a package in our history,
-                # we should complain
-                for old_mf in old_mfs:
-                        if old_mf.fmri.get_name() == mf.fmri.get_name():
-                                old_mfs.append(mf)
-                                raise base.LintException(
-                                    _("loop detected in rename: {0}").format(
-                                    " -> ".join(str(s.fmri) for s in old_mfs)))
+        manifest_checks = []
+        action_checks = []
+        count = 0
+        for checker in self.checkers:
+            count = count + len(checker.included_checks)
+            if isinstance(checker, base.ManifestChecker):
+                manifest_checks.append(checker)
+            elif isinstance(checker, base.ActionChecker):
+                action_checks.append(checker)
+            else:
+                raise LintEngineSetupException(
+                    _(
+                        "{0} does not subclass a known "
+                        "Checker subclass intended for use by "
+                        "pkglint extensions"
+                    ).format(str(checker))
+                )
 
-                if "pkg.renamed" in mf and \
-                    mf["pkg.renamed"].lower() == "true":
+        self.tracker.flush()
+        self.logger.debug(_("Total number of checks found: {0}").format(count))
 
-                        old_mfs.append(mf)
+        for mf in self.lint_manifests:
+            self._check_manifest(mf, manifest_checks, action_checks)
 
-                        for dep in mf.gen_actions_by_type("depend"):
-                                # disregard dependencies on incorporations
-                                if "incorporation" in dep.attrs["fmri"]:
-                                        continue
-                                follow = dep.attrs["fmri"]
+        for manifest in self.gen_manifests(
+            self.lint_api_inst, pattern=self.pattern, release=self.release
+        ):
+            self._check_manifest(manifest, manifest_checks, action_checks)
+        self.tracker.flush()
 
-                                # the engine's cache lookup doesn't include
-                                # versions, so remove those and lookup the
-                                # latest available version of this dependency
-                                if "@" in follow:
-                                        follow = follow.split("@")[0]
-                                mf = self.follow_renames(follow,
-                                    target=target, old_mfs=old_mfs,
-                                    warn_on_obsolete=warn_on_obsolete,
-                                    legacy=legacy)
+    def gen_manifests(self, api_inst, pattern=None, release=None):
+        """A generator to return package manifests for a given image.
+        With a given pattern, it narrows the set of manifests
+        returned to match that pattern.
 
-                                # we can stop looking if we've found a package
-                                # of which our target is a successor
-                                if target and mf and \
-                                    lint_fmri_successor(target, mf.fmri,
-                                        ignore_pubs=self.ignore_pubs):
-                                        return mf
-                return mf
+        With the given 'release' number, it searches for manifests for
+        that release using "<pattern>@<version.pattern><release>"
+        where <version.pattern> is set in pkglintrc and
+        <pattern> and <release> are the keyword arguments to this
+        method."""
 
-        def get_param(self, key, action=None, manifest=None):
-                """Returns a string value of a given pkglint parameter,
-                intended for use by pkglint Checker objects to provide hints as
-                to how particular checks should be run.
+        if not api_inst:
+            return
 
-                Keys are searched for first in the action, if provided, then as
-                manifest attributes, finally falling back to the pkglintrc
-                config file.
+        tracker = self.get_tracker()
+        if self.in_setup:
+            pt = tracker.LINT_PHASETYPE_SETUP
+        else:
+            pt = tracker.LINT_PHASETYPE_EXECUTE
+        tracker.lint_next_phase(
+            self.mf_cache.count_latest(api_inst, pattern), pt
+        )
 
-                The return value is a space-separated string of parameters.
+        for m in self.mf_cache.gen_latest(api_inst, pattern):
+            tracker.lint_add_progress()
+            yield m
+        return
 
-                When searching for keys in the manifest or action, we prepend
-                "pkg.lint" to the key name to ensure that we play in our own
-                namespace and don't clash with other manifest or action attrs.
-                """
+    EXACT = 0
+    LATEST_SUCCESSOR = 1
 
-                param_key = "pkg.lint.{0}".format(key)
-                val = None
-                if action and param_key in action.attrs:
-                        val = action.attrs[param_key]
-                if manifest and param_key in manifest:
-                        val = manifest[param_key]
-                if val:
-                        if isinstance(val, six.string_types):
-                                return val
-                        else:
-                                return " ".join(val)
+    def get_manifest(self, pkg_name, search_type=EXACT, reference=False):
+        """Returns the first available manifest for a given package
+        name, searching hierarchically in the lint manifests,
+        the lint_repo or the ref_repo for that single package.
+
+        By default, we search for an exact match on the provided
+        pkg_name, throwing a LintEngineException if we get more than
+        one match for the supplied pkg_name.
+        When search_type is LintEngine.LATEST_SUCCESSOR, we return the
+        most recent successor of the provided package, using the
+        lint_fmri_successor() method defined in this module.
+
+        If 'reference' is True, only search for the package using the
+        reference image. If no reference image has been configured, this
+        raises a pkg.lint.base.LintException.
+        """
+
+        if not pkg_name.startswith("pkg:/"):
+            pkg_name = "pkg:/{0}".format(pkg_name)
+
+        def build_fmri(pkg_name):
+            """builds a pkg.fmri.PkgFmri from a string."""
+            try:
+                fmri = pkg.fmri.PkgFmri(pkg_name)
+                return fmri
+            except pkg.fmri.IllegalFmri:
                 try:
-                        val = self.conf.get("pkglint", key)
-                        if val:
-                                return val.replace("\n", " ")
-                except configparser.NoOptionError:
-                        return None
+                    # FMRIs listed as dependencies often
+                    # omit build_release, use a dummy one
+                    # for now
+                    fmri = pkg.fmri.PkgFmri(pkg_name)
+                    return fmri
+                except:
+                    msg = _("unable to construct fmri from " "{0}").format(
+                        pkg_name
+                    )
+                    raise base.LintException(msg)
 
-        def get_attr_action(self, attr, manifest):
-                """Return the AttributeAction that sets a given attribute in a
-                manifest.
+        def get_fmri(api_inst, pkg_name):
+            """Retrieve an fmri string that matches pkg_name."""
 
-                This is available for clients, particularly ManifestCheckers
-                that need to see whether a lint flag has been set on a given
-                'set' action.
-                """
-                if attr not in manifest:
-                        raise KeyError(
-                            _("{0} is not set in manifest").format(attr))
-                for action in manifest.gen_actions_by_type("set"):
-                        if action.attrs.get("name", "") == attr:
-                                return action
+            if "*" in pkg_name or "?" in pkg_name:
+                raise base.LintException(
+                    _("invalid pkg name {0}").format(pkg_name)
+                )
+
+            if "@" not in pkg_name and self.release:
+                pkg_name = "{0}@{1}{2}".format(
+                    pkg_name, self.version_pattern, self.release
+                )
+
+            fmris = []
+            for item in api_inst.get_pkg_list(
+                pkg.client.api.ImageInterface.LIST_ALL,
+                patterns=[pkg_name],
+                variants=True,
+                return_fmris=True,
+            ):
+                fmris.append(item[0])
+
+            fmri_list = []
+            for item in fmris:
+                fmri_list.append(item.get_fmri())
+
+            if len(fmri_list) == 1:
+                return fmri_list[0]
+
+            elif len(fmri_list) == 0:
+                return None
+            else:
+                # we expected to get only 1 hit, so
+                # something has gone wrong
+                raise LintEngineException(
+                    _(
+                        "get_fmri(pattern) {pattern} "
+                        "matched {count} packages: "
+                        "{pkgs}"
+                    ).format(
+                        pattern=pkg_name,
+                        count=len(fmri_list),
+                        pkgs=" ".join(fmri_list),
+                    )
+                )
+
+        def mf_from_image(api_inst, pkg_name, search_type):
+            """Fetch a manifest for the given package name using
+            the ImageInterface provided."""
+            if not api_inst:
                 return None
 
-        def linted(self, action=None, manifest=None, lint_id=None):
-                """Determine whether pkg.linted.* flags are present on the
-                action and/or manifest passed as arguments.  If lint_id is set,
-                we look for pkg.linted.<lint_id> attributes as well."""
-                ret = False
-                try:
-                        ret = base.linted(action=action, manifest=manifest,
-                            lint_id=lint_id)
-                except base.DuplicateLintedAttrException as err:
-                        self.error(err, msgid="pkglint001.6")
-                return ret
+            search_fmri = build_fmri(pkg_name)
+            if search_type == self.LATEST_SUCCESSOR:
+                # we want to normalize the pkg_name, removing
+                # the publisher, if any.
+                name = "pkg:/{0}".format(search_fmri.get_name())
+                mf = self.mf_cache.get_latest(api_inst, name)
+                if not mf:
+                    return
+                # double-check the publishers match, since we
+                # searched for just a package name
+                if search_fmri.publisher:
+                    if search_fmri.publisher == mf.fmri.publisher:
+                        return mf
+                else:
+                    return mf
+
+            # We've either not found a matching publisher, or we're
+            # doing an exact search.
+            try:
+                mf = self.mf_cache.get(api_inst, pkg_name)
+                return mf
+            except KeyError:
+                mf = None
+                fmri = get_fmri(api_inst, pkg_name)
+                if fmri:
+                    mf = api_inst.get_manifest(pkg.fmri.PkgFmri(fmri))
+                self.mf_cache.add(api_inst, pkg_name, mf)
+                return mf
+
+        # search hierarchically for the given package name in our
+        # local manifests, using our lint image, or using our reference
+        # image and return a manifest for that package.
+        if reference:
+            if not self.ref_api_inst:
+                raise base.LintException(
+                    _("No reference repository has been " "configured")
+                )
+            return mf_from_image(self.ref_api_inst, pkg_name, search_type)
+
+        for mf in self.lint_manifests:
+            search_fmri = build_fmri(pkg_name)
+            if search_type == self.LATEST_SUCCESSOR and lint_fmri_successor(
+                mf.fmri, search_fmri, ignore_pubs=self.ignore_pubs
+            ):
+                return mf
+
+            if str(mf.fmri) == pkg_name:
+                return mf
+            if mf.fmri.get_name() == pkg_name:
+                return mf
+        mf = mf_from_image(self.lint_api_inst, pkg_name, search_type)
+        if mf:
+            return mf
+        # fallback to our reference api, returning None if that's
+        # what we were given.
+        return mf_from_image(self.ref_api_inst, pkg_name, search_type)
+
+    def _get_image(self, image_dir):
+        """Return a pkg.client.api.ImageInterface for the provided
+        image directory."""
+
+        cdir = os.getcwd()
+        tracker = self.get_tracker()
+        api_inst = None
+        try:
+            api_inst = pkg.client.api.ImageInterface(
+                image_dir, CLIENT_API_VERSION, tracker, None, PKG_CLIENT_NAME
+            )
+
+            if api_inst.root != image_dir:
+                api_inst = None
+            else:
+                # given that pkglint is expected to be used
+                # during manifest development, we always want
+                # to refresh now, rather than waiting for some
+                # update interval
+                api_inst.refresh(immediate=True)
+        except Exception as err:
+            raise LintEngineSetupException(
+                _("Unable to get image at {dir}: {reason}").format(
+                    dir=image_dir, reason=str(err)
+                )
+            )
+
+        # restore the current directory, which ImageInterace had changed
+        os.chdir(cdir)
+        return api_inst
+
+    def _create_image(self, image_dir, repo_uris):
+        """Create image in the given image directory. For now, only
+        a single publisher is supported per image."""
+
+        tracker = self.get_tracker()
+
+        is_zone = False
+        refresh_allowed = True
+
+        self.tracker.flush()
+        self.logger.debug(_("Creating image at {0}").format(image_dir))
+
+        # Check to see if a scheme was used, if not, treat it as a
+        # file:// URI, and get the absolute path.  Missing or invalid
+        # repositories will be caught by pkg.client.api.image_create.
+        for i, uri in enumerate(repo_uris):
+            if not urlparse(uri).scheme:
+                repo_uris[i] = "file://{0}".format(quote(os.path.abspath(uri)))
+
+        try:
+            api_inst = pkg.client.api.image_create(
+                PKG_CLIENT_NAME,
+                CLIENT_API_VERSION,
+                image_dir,
+                pkg.client.api.IMG_TYPE_USER,
+                is_zone,
+                facets=pkg.facet.Facets(),
+                force=False,
+                progtrack=tracker,
+                refresh_allowed=refresh_allowed,
+                repo_uri=repo_uris[0],
+            )
+        except (ApiException, OSError, IOError) as err:
+            raise LintEngineSetupException(err)
+
+        # Check to see if multiple repositories are specified.
+        repo_uris.pop(0)
+        if repo_uris:
+            try:
+                self._set_publisher(api_inst, repo_uris)
+            except ApiException as e:
+                api_inst._img.destroy()
+                if os.path.abspath(image_dir) != "/" and os.path.exists(
+                    image_dir
+                ):
+                    shutil.rmtree(image_dir, True)
+                raise LintEngineSetupException(e)
+
+        return api_inst
+
+    def _set_publisher(self, api_inst, repo_uris):
+        """Helper function to set publishers on a ref or lint image."""
+
+        for repo_uri in repo_uris:
+            repo = publisher.RepositoryURI(repo_uri)
+            pubs = []
+            try:
+                pubs = api_inst.get_publisherdata(repo=repo)
+            except apx.UnsupportedRepositoryOperation:
+                raise
+
+            for pub in sorted(pubs):
+                prefix = pub.prefix
+                src_repo = pub.repository
+                if api_inst.has_publisher(prefix=prefix):
+                    add_origins = []
+                    dest_pub = api_inst.get_publisher(
+                        prefix=prefix, duplicate=True
+                    )
+                    dest_repo = dest_pub.repository
+                    # dest_repo.origins is not None here
+                    # after invoking api.image_create()
+                    # in _create_image().
+
+                    if src_repo:
+                        # Add unknown origins but avoid
+                        # duplicates.
+                        add_origins = [
+                            u.uri
+                            for u in src_repo.origins
+                            if u.uri not in dest_repo.origins
+                        ]
+
+                    if not dest_repo.has_origin(repo_uri):
+                        add_origins.append(repo_uri)
+
+                    for u in add_origins:
+                        dest_repo.add_origin(u)
+
+                    api_inst.update_publisher(dest_pub)
+                else:
+                    if not src_repo:
+                        # Repository configuration info
+                        # was not provided, assume
+                        # origin is repo_uri.
+                        pub.repository = publisher.Repository(
+                            origins=[repo_uri]
+                        )
+                    elif not src_repo.origins:
+                        # No origin was provided in
+                        # repository configuration,
+                        # assume origin is repo_uri.
+                        src_repo.add_origin(repo_uri)
+
+                    api_inst.add_publisher(pub, refresh_allowed=False)
+
+    def _check_manifest(self, manifest, manifest_checks, action_checks):
+        """Check a given manifest."""
+
+        self.debug(_("Checking {0}").format(manifest.fmri), "pkglint001.3")
+
+        for checker in manifest_checks:
+            checker.check(manifest, self)
+
+        if action_checks:
+            for action in manifest.gen_actions():
+                self._check_action(action, manifest, action_checks)
+
+    def _check_action(self, action, manifest, action_checks):
+        """Check a given action."""
+
+        for checker in action_checks:
+            checker.check(action, manifest, self)
+
+    def advise_loggers(self, action=None, manifest=None):
+        """Called to advise any loggers we have set that we're about
+        to perform lint checks on the given action or manifest.
+
+        In particular, this is used to let the logger objects access
+        the manifest or action being linted without needing to pass
+        those objects each time we log a message.
+
+        Care must be taken in base.ManifestChecker methods to call
+        this any time they're iterating over actions and are likely to
+        report lint errors that may be related to that action.  When
+        finished iterating, they should re-call this method with only
+        the manifest keyword argument, to clear the last action used.
+
+        Between each Checker method invocation, the Checker subclass
+        calls this automatically to clear any state set by those method
+        calls.
+        """
+        for log in self.logs:
+            log.advise(action=action, manifest=manifest)
+
+    # convenience methods to log lint messages to all loggers
+    # configured for this engine
+    def debug(self, message, msgid=None, ignore_linted=False):
+        """Log a debug message to all loggers."""
+        for log in self.logs:
+            log.debug(message, msgid=msgid, ignore_linted=ignore_linted)
+
+    def info(self, message, msgid=None, ignore_linted=False):
+        """Log an info message to all loggers."""
+        for log in self.logs:
+            log.info(message, msgid=msgid, ignore_linted=ignore_linted)
+
+    def warning(self, message, msgid=None, ignore_linted=False):
+        """Log a warning message to all loggers."""
+        for log in self.logs:
+            log.warning(message, msgid=msgid, ignore_linted=ignore_linted)
+
+    def error(self, message, msgid=None, ignore_linted=False):
+        """Log an error message to all loggers."""
+        for log in self.logs:
+            log.error(message, msgid=msgid, ignore_linted=ignore_linted)
+
+    def critical(self, message, msgid=None, ignore_linted=False):
+        """Log a critical message to all loggers."""
+        for log in self.logs:
+            log.critical(message, msgid=msgid, ignore_linted=ignore_linted)
+
+    def skip_check_msg(self, action, msgid):
+        """Log a message saying we're skipping a particular check."""
+        self.info(
+            _("Not running {check} checks on linted action " "{action}").format(
+                check=msgid, action=str(action)
+            ),
+            msgid="pkglint001.4",
+            ignore_linted=True,
+        )
+
+    def teardown(self, clear_cache=False):
+        """Ends a pkglint session.
+        clear_cache    False by default, True causes the cache to be
+                       destroyed."""
+        for checker in self.checkers:
+            try:
+                checker.shutdown(self)
+            except base.LintException as err:
+                self.error(err)
+        self.checkers = []
+
+        # Reset the API object before destroying it; because it does a
+        # chdir(), we need to save and restore our cwd.
+        cwd = os.getcwd()
+        if self.lint_api_inst:
+            self.lint_api_inst.reset()
+        os.chdir(cwd)
+        self.lint_api_inst = None
+
+        if clear_cache:
+            shutil.rmtree(self.basedir)
+        self.advise_loggers()
+
+    def get_tracker(self):
+        """Creates a ProgressTracker if we don't already have one,
+        otherwise resetting our current tracker and returning it"""
+
+        if self.tracker:
+            if not self.in_setup:
+                self.tracker.reset()
+            self.tracker.set_major_phase(self.tracker.PHASE_UTILITY)
+            return self.tracker
+        if not self.use_tracker:
+            self.tracker = progress.NullProgressTracker()
+        else:
+            try:
+                self.tracker = progress.FancyUNIXProgressTracker()
+            except progress.ProgressTrackerException:
+                self.tracker = progress.CommandLineProgressTracker()
+        self.tracker.set_major_phase(self.tracker.PHASE_UTILITY)
+        return self.tracker
+
+    def follow_renames(
+        self,
+        pkg_name,
+        target=None,
+        old_mfs=[],
+        warn_on_obsolete=False,
+        legacy=False,
+    ):
+        """Given a package name, and an optional target pfmri that we
+        expect to be ultimately renamed to, follow package renames from
+        pkg_name, looking for the package we expect to be at the end of
+        the chain.
+
+        If there was a break in the renaming chain, we return None.
+        old_mfs, if passed, should be a list of manifests that were
+        sources of this rename.
+
+        If legacy is True, as well as checking that the target
+        name was reached, we also look for the leaf-name of the target.
+        This lets legacy action checking function properly, allowing,
+        say pkg:/SUNWbip or pkg:/compatibility/package/SUNWbip to
+        satisfy the rename check.
+        """
+
+        # When doing legacy action checks, the leaf of the target pkg
+        # matching the pkg_name is enough so long as that package is
+        # not marked as 'pkg.renamed'
+        if legacy and target:
+            leaf_name = target.get_name().split("/")[-1]
+            if leaf_name == pkg_name:
+                leaf_mf = self.get_manifest(
+                    target.get_name(), search_type=self.LATEST_SUCCESSOR
+                )
+                if leaf_mf and leaf_mf.get("pkg.renamed", "false") == "false":
+                    return leaf_mf
+
+        mf = self.get_manifest(pkg_name, search_type=self.LATEST_SUCCESSOR)
+
+        if not mf:
+            return None
+
+        if warn_on_obsolete and "pkg.obsolete" in mf:
+            raise base.LintException(_("obsolete package: {0}").format(mf.fmri))
+
+        # if we're trying to rename to a package in our history,
+        # we should complain
+        for old_mf in old_mfs:
+            if old_mf.fmri.get_name() == mf.fmri.get_name():
+                old_mfs.append(mf)
+                raise base.LintException(
+                    _("loop detected in rename: {0}").format(
+                        " -> ".join(str(s.fmri) for s in old_mfs)
+                    )
+                )
+
+        if "pkg.renamed" in mf and mf["pkg.renamed"].lower() == "true":
+            old_mfs.append(mf)
+
+            for dep in mf.gen_actions_by_type("depend"):
+                # disregard dependencies on incorporations
+                if "incorporation" in dep.attrs["fmri"]:
+                    continue
+                follow = dep.attrs["fmri"]
+
+                # the engine's cache lookup doesn't include
+                # versions, so remove those and lookup the
+                # latest available version of this dependency
+                if "@" in follow:
+                    follow = follow.split("@")[0]
+                mf = self.follow_renames(
+                    follow,
+                    target=target,
+                    old_mfs=old_mfs,
+                    warn_on_obsolete=warn_on_obsolete,
+                    legacy=legacy,
+                )
+
+                # we can stop looking if we've found a package
+                # of which our target is a successor
+                if (
+                    target
+                    and mf
+                    and lint_fmri_successor(
+                        target, mf.fmri, ignore_pubs=self.ignore_pubs
+                    )
+                ):
+                    return mf
+        return mf
+
+    def get_param(self, key, action=None, manifest=None):
+        """Returns a string value of a given pkglint parameter,
+        intended for use by pkglint Checker objects to provide hints as
+        to how particular checks should be run.
+
+        Keys are searched for first in the action, if provided, then as
+        manifest attributes, finally falling back to the pkglintrc
+        config file.
+
+        The return value is a space-separated string of parameters.
+
+        When searching for keys in the manifest or action, we prepend
+        "pkg.lint" to the key name to ensure that we play in our own
+        namespace and don't clash with other manifest or action attrs.
+        """
+
+        param_key = "pkg.lint.{0}".format(key)
+        val = None
+        if action and param_key in action.attrs:
+            val = action.attrs[param_key]
+        if manifest and param_key in manifest:
+            val = manifest[param_key]
+        if val:
+            if isinstance(val, six.string_types):
+                return val
+            else:
+                return " ".join(val)
+        try:
+            val = self.conf.get("pkglint", key)
+            if val:
+                return val.replace("\n", " ")
+        except configparser.NoOptionError:
+            return None
+
+    def get_attr_action(self, attr, manifest):
+        """Return the AttributeAction that sets a given attribute in a
+        manifest.
+
+        This is available for clients, particularly ManifestCheckers
+        that need to see whether a lint flag has been set on a given
+        'set' action.
+        """
+        if attr not in manifest:
+            raise KeyError(_("{0} is not set in manifest").format(attr))
+        for action in manifest.gen_actions_by_type("set"):
+            if action.attrs.get("name", "") == attr:
+                return action
+        return None
+
+    def linted(self, action=None, manifest=None, lint_id=None):
+        """Determine whether pkg.linted.* flags are present on the
+        action and/or manifest passed as arguments.  If lint_id is set,
+        we look for pkg.linted.<lint_id> attributes as well."""
+        ret = False
+        try:
+            ret = base.linted(action=action, manifest=manifest, lint_id=lint_id)
+        except base.DuplicateLintedAttrException as err:
+            self.error(err, msgid="pkglint001.6")
+        return ret
 
 
 def lint_fmri_successor(new, old, ignore_pubs=True, ignore_timestamps=True):
-        """Given two FMRIs, determine if new_fmri is a successor of old_fmri.
+    """Given two FMRIs, determine if new_fmri is a successor of old_fmri.
 
-        This differs from pkg.fmri.is_successor() in that it treats un-versioned
-        FMRIs as being newer than versioned FMRIs of the same package name,
-        and un-timestamped packages as being newer than versioned FMRIs of the
-        same package name and version.
+    This differs from pkg.fmri.is_successor() in that it treats un-versioned
+    FMRIs as being newer than versioned FMRIs of the same package name,
+    and un-timestamped packages as being newer than versioned FMRIs of the
+    same package name and version.
 
-        For published packages, where the version and pkg names are identical,
-        but the publisher differs, it also treats the new package as being a
-        successor of the old.
+    For published packages, where the version and pkg names are identical,
+    but the publisher differs, it also treats the new package as being a
+    successor of the old.
 
-        If ignore_pubs is set, any differences in publishers between the
-        provided FMRIs are ignored.
+    If ignore_pubs is set, any differences in publishers between the
+    provided FMRIs are ignored.
 
-        if ignore_timestamps is set, timestamps are not used as a basis for
-        comparison between new and old FMRIs.
+    if ignore_timestamps is set, timestamps are not used as a basis for
+    comparison between new and old FMRIs.
 
-        We use this when looking for dependencies, or when comparing
-        FMRIs presented in manifests for linting against those present in an
-        existing repository (where, eg. a new timestamp would be supplied to a
-        package during the import process and the timestamp would not
-        necessarily be in the manifest file presented for linting)
-        """
+    We use this when looking for dependencies, or when comparing
+    FMRIs presented in manifests for linting against those present in an
+    existing repository (where, eg. a new timestamp would be supplied to a
+    package during the import process and the timestamp would not
+    necessarily be in the manifest file presented for linting)
+    """
 
-        if not ignore_pubs and new.publisher != old.publisher:
-                return False
+    if not ignore_pubs and new.publisher != old.publisher:
+        return False
 
-        new_name = new.get_name()
-        old_name = old.get_name()
+    new_name = new.get_name()
+    old_name = old.get_name()
 
-        if new_name != old_name:
-                return False
+    if new_name != old_name:
+        return False
 
-        if not new.has_version():
-                return True
-
-        # compare everything except the timestamp
-        if new.has_version() and old.has_version():
-                if new.version.release > old.version.release:
-                        return True
-                if new.version.release < old.version.release:
-                        return False
-
-                if new.version.branch and not old.version.branch:
-                        return True
-                if old.version.branch and not new.version.branch:
-                        return False
-
-                if new.version.branch > old.version.branch:
-                        return True
-                if new.version.branch < old.version.branch:
-                        return False
-
-                if new.version.build_release > old.version.build_release:
-                        return True
-                if new.version.build_release < old.version.build_release:
-                        return False
-                if not ignore_timestamps:
-                        new_ts = new.version.get_timestamp()
-                        old_ts = old.version.get_timestamp()
-                        if new_ts > old_ts:
-                                return True
-                        if new_ts < old_ts:
-                                return False
-
-        # everything is equal, or old has no version and we'll favour new
+    if not new.has_version():
         return True
 
+    # compare everything except the timestamp
+    if new.has_version() and old.has_version():
+        if new.version.release > old.version.release:
+            return True
+        if new.version.release < old.version.release:
+            return False
+
+        if new.version.branch and not old.version.branch:
+            return True
+        if old.version.branch and not new.version.branch:
+            return False
+
+        if new.version.branch > old.version.branch:
+            return True
+        if new.version.branch < old.version.branch:
+            return False
+
+        if new.version.build_release > old.version.build_release:
+            return True
+        if new.version.build_release < old.version.build_release:
+            return False
+        if not ignore_timestamps:
+            new_ts = new.version.get_timestamp()
+            old_ts = old.version.get_timestamp()
+            if new_ts > old_ts:
+                return True
+            if new_ts < old_ts:
+                return False
+
+    # everything is equal, or old has no version and we'll favour new
+    return True
+
+
 def _manifest_sort_key(mf):
-        """The lint engine uses the FMRI of a package to deterine the order in
-        which to iterate over manifests.  This is done using the 'key' attribute
-        to the Python sort() and sorted() methods."""
-        if mf.fmri:
-                return mf.fmri
-        return mf.get("pkg.fmri")
+    """The lint engine uses the FMRI of a package to deterine the order in
+    which to iterate over manifests.  This is done using the 'key' attribute
+    to the Python sort() and sorted() methods."""
+    if mf.fmri:
+        return mf.fmri
+    return mf.get("pkg.fmri")
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/lint/log.py
+++ b/src/modules/lint/log.py
@@ -45,202 +45,214 @@ LEVELS = {
     INFO: "INFO",
     WARNING: "WARNING",
     ERROR: "ERROR",
-    CRITICAL: "CRITICAL"
-    }
+    CRITICAL: "CRITICAL",
+}
+
 
 class LintMessage(object):
-        """A base class for all lint messages."""
+    """A base class for all lint messages."""
 
-        msg = ""
-        def __init__(self, msg, level=INFO, producer="unknown", msgid=None):
-                self.msg = msg
-                self.level = level
-                self.producer = producer
-                self.msgid = msgid
+    msg = ""
 
-        def __str__(self):
-                return str(self.msg)
+    def __init__(self, msg, level=INFO, producer="unknown", msgid=None):
+        self.msg = msg
+        self.level = level
+        self.producer = producer
+        self.msgid = msgid
+
+    def __str__(self):
+        return str(self.msg)
 
 
 class TrackerHandler(logging.StreamHandler):
-        """"Inspect a given pkg.client.progress.ProgressTracker, telling it
-        to flush, before emitting output."""
+    """ "Inspect a given pkg.client.progress.ProgressTracker, telling it
+    to flush, before emitting output."""
 
-        def __init__(self, tracker, strm=None):
-                logging.StreamHandler.__init__(self, strm)
+    def __init__(self, tracker, strm=None):
+        logging.StreamHandler.__init__(self, strm)
 
-                if os.isatty(sys.stderr.fileno()) and \
-                    os.isatty(sys.stdout.fileno()):
-                        self.write_crs = True
-                else:
-                        self.write_crs = False
-                self.tracker = tracker
+        if os.isatty(sys.stderr.fileno()) and os.isatty(sys.stdout.fileno()):
+            self.write_crs = True
+        else:
+            self.write_crs = False
+        self.tracker = tracker
 
-        def emit(self, record):
-                if self.write_crs and self.tracker:
-                        self.tracker.flush()
-                logging.StreamHandler.emit(self, record)
+    def emit(self, record):
+        if self.write_crs and self.tracker:
+            self.tracker.flush()
+        logging.StreamHandler.emit(self, record)
 
 
 class LogFormatter(object):
-        """A class that formats log messages."""
+    """A class that formats log messages."""
 
-        def __init__(self, tracker=None, level=INFO):
-                self._level = level
+    def __init__(self, tracker=None, level=INFO):
+        self._level = level
 
-                # install our own logger, writing to stderr
-                self.logger = logging.getLogger("pkglint_checks")
+        # install our own logger, writing to stderr
+        self.logger = logging.getLogger("pkglint_checks")
 
-                self._th = TrackerHandler(tracker, strm=sys.stderr)
-                self.logger.setLevel(logging.INFO)
-                self._th.setLevel(logging.INFO)
-                self.logger.addHandler(self._th)
-                self.emitted = False
+        self._th = TrackerHandler(tracker, strm=sys.stderr)
+        self.logger.setLevel(logging.INFO)
+        self._th.setLevel(logging.INFO)
+        self.logger.addHandler(self._th)
+        self.emitted = False
 
-                # the action and manifest we expect messages from. See advise()
-                self.action = None
-                self.manifest = None
+        # the action and manifest we expect messages from. See advise()
+        self.action = None
+        self.manifest = None
 
-                # when the logger is using an engine, the engine registers
-                # itself here
-                self.engine = None
+        # when the logger is using an engine, the engine registers
+        # itself here
+        self.engine = None
 
-        # setters/getters for the tracker being used, adding that
-        # to our private log handler
-        def _get_tracker(self):
-                return self._th.tracker
+    # setters/getters for the tracker being used, adding that
+    # to our private log handler
+    def _get_tracker(self):
+        return self._th.tracker
 
-        def _set_tracker(self, value):
-                self._th.tracker = value
+    def _set_tracker(self, value):
+        self._th.tracker = value
 
-        def _del_tracker(self):
-                del self._th.tracker
+    def _del_tracker(self):
+        del self._th.tracker
 
-        # setters/getters for log level to allow us to set
-        # string values for what's always stored as an integer
-        def _get_level(self):
-                return self._level
+    # setters/getters for log level to allow us to set
+    # string values for what's always stored as an integer
+    def _get_level(self):
+        return self._level
 
-        def _set_level(self, value):
-                if isinstance(value, str):
-                        if value.upper() not in LEVELS:
-                                raise ValueError(
-                                    _("{value} is not a valid level").format(
-                                    **value))
-                        self._level = LEVELS[value]
-                else:
-                        self._level = value
+    def _set_level(self, value):
+        if isinstance(value, str):
+            if value.upper() not in LEVELS:
+                raise ValueError(
+                    _("{value} is not a valid level").format(**value)
+                )
+            self._level = LEVELS[value]
+        else:
+            self._level = value
 
-        def _del_level(self):
-                del self._level
+    def _del_level(self):
+        del self._level
 
-        level = property(_get_level, _set_level, _del_level)
-        tracker = property(_get_tracker, _set_tracker, _del_tracker)
+    level = property(_get_level, _set_level, _del_level)
+    tracker = property(_get_tracker, _set_tracker, _del_tracker)
 
-        # convenience methods to log messages
-        def debug(self, message, msgid=None, ignore_linted=False):
-                self.format(LintMessage(message, level=DEBUG, msgid=msgid),
-                    ignore_linted=ignore_linted)
+    # convenience methods to log messages
+    def debug(self, message, msgid=None, ignore_linted=False):
+        self.format(
+            LintMessage(message, level=DEBUG, msgid=msgid),
+            ignore_linted=ignore_linted,
+        )
 
-        def info(self, message, msgid=None, ignore_linted=False):
-                self.format(LintMessage(message, level=INFO, msgid=msgid),
-                    ignore_linted=ignore_linted)
+    def info(self, message, msgid=None, ignore_linted=False):
+        self.format(
+            LintMessage(message, level=INFO, msgid=msgid),
+            ignore_linted=ignore_linted,
+        )
 
-        def warning(self, message, msgid=None, ignore_linted=False):
-                self.format(LintMessage(message, level=WARNING, msgid=msgid),
-                    ignore_linted=ignore_linted)
+    def warning(self, message, msgid=None, ignore_linted=False):
+        self.format(
+            LintMessage(message, level=WARNING, msgid=msgid),
+            ignore_linted=ignore_linted,
+        )
 
-        def error(self, message, msgid=None, ignore_linted=False):
-                self.format(LintMessage(message, level=ERROR, msgid=msgid),
-                    ignore_linted=ignore_linted)
+    def error(self, message, msgid=None, ignore_linted=False):
+        self.format(
+            LintMessage(message, level=ERROR, msgid=msgid),
+            ignore_linted=ignore_linted,
+        )
 
-        def critical(self, message, msgid=None, ignore_linted=False):
-                self.format(LintMessage(message, level=CRITICAL, msgid=msgid),
-                    ignore_linted=ignore_linted)
+    def critical(self, message, msgid=None, ignore_linted=False):
+        self.format(
+            LintMessage(message, level=CRITICAL, msgid=msgid),
+            ignore_linted=ignore_linted,
+        )
 
-        def open(self):
-                """Start a new log file"""
-                pass
+    def open(self):
+        """Start a new log file"""
+        pass
 
-        def format(self, message):
-                """Given a LintMessage message, format that object
-                appropriately."""
-                pass
+    def format(self, message):
+        """Given a LintMessage message, format that object
+        appropriately."""
+        pass
 
-        def close(self):
-                """End a log file"""
-                pass
+    def close(self):
+        """End a log file"""
+        pass
 
-        def produced_lint_msgs(self):
-                """Called to determine if this logger produced any lint
-                messages at a level >= its log level."""
-                return self.emitted
+    def produced_lint_msgs(self):
+        """Called to determine if this logger produced any lint
+        messages at a level >= its log level."""
+        return self.emitted
 
-        def advise(self, action=None, manifest=None):
-                """Called to tell the logger to expect lint messages concerning
-                the given action and/or manifest."""
-                if action:
-                        self.action = action
-                if manifest:
-                        self.manifest = manifest
+    def advise(self, action=None, manifest=None):
+        """Called to tell the logger to expect lint messages concerning
+        the given action and/or manifest."""
+        if action:
+            self.action = action
+        if manifest:
+            self.manifest = manifest
 
 
 class PlainLogFormatter(LogFormatter):
-        """A basic log formatter, just prints the message."""
+    """A basic log formatter, just prints the message."""
 
-        def format(self, msg, ignore_linted=False):
+    def format(self, msg, ignore_linted=False):
+        if not isinstance(msg, LintMessage):
+            self.logger.warning(msg)
+            self.emitted = True
+            return
 
-                if not isinstance(msg, LintMessage):
-                        self.logger.warning(msg)
-                        self.emitted = True
-                        return
+        if msg.level >= self._level:
+            if not msg.msgid:
+                msg.msgid = "unknown"
 
-                if msg.level >= self._level:
-                        if not msg.msgid:
-                                msg.msgid = "unknown"
+            # Format the message level and message identifier
+            key = "{0} {1}".format(LEVELS[msg.level], msg.msgid)
+            if not ignore_linted:
+                linted_flag = False
+                try:
+                    linted_flag = linted(
+                        action=self.action,
+                        manifest=self.manifest,
+                        lint_id=msg.msgid,
+                    )
+                except DuplicateLintedAttrException as err:
+                    lint_key = "{0} pkglint001.6".format(LEVELS[ERROR])
+                    self.logger.warning(
+                        "{0}{1}".format(
+                            lint_key.ljust(34),
+                            _("Logging error: {0}").format(err),
+                        )
+                    )
 
-                        # Format the message level and message identifier
-                        key = "{0} {1}".format(LEVELS[msg.level], msg.msgid)
-                        if not ignore_linted:
-                                linted_flag = False
-                                try:
-                                        linted_flag = linted(action=self.action,
-                                            manifest=self.manifest,
-                                            lint_id=msg.msgid)
-                                except DuplicateLintedAttrException as err:
-                                        lint_key = ("{0} pkglint001.6".format(
-                                            LEVELS[ERROR]))
-                                        self.logger.warning("{0}{1}".format(
-                                            lint_key.ljust(34),
-                                            _("Logging error: {0}").format(
-                                            err)))
+                if linted_flag:
+                    # we may have asked not to report errors
+                    # that have been marked as pkg.linted
+                    if self.engine:
+                        report = self.engine.get_param(
+                            "pkglint001.5.report-linted"
+                        )
+                        if report and report.lower() == "false":
+                            return
+                    key = "{0} pkglint001.5".format(LEVELS[INFO])
+                    linted_msg = _("Linted message: {id}  " "{msg}").format(
+                        id=msg.msgid, msg=msg
+                    )
+                    self.logger.warning(
+                        "{0}{1}".format(key.ljust(34), linted_msg)
+                    )
+                    return
 
-                                if linted_flag:
-                                        # we may have asked not to report errors
-                                        # that have been marked as pkg.linted
-                                        if self.engine:
-                                                report = self.engine.get_param(
-                                                    "pkglint001.5.report-linted")
-                                                if report and \
-                                                    report.lower() == "false":
-                                                        return
-                                        key = ("{0} pkglint001.5".format(
-                                            LEVELS[INFO]))
-                                        linted_msg = _(
-                                            "Linted message: {id}  "
-                                            "{msg}").format(
-                                            id=msg.msgid, msg=msg)
-                                        self.logger.warning("{0}{1}".format(
-                                        key.ljust(34), linted_msg))
-                                        return
+            self.logger.warning("{0}{1}".format(key.ljust(34), msg.msg))
 
-                        self.logger.warning("{0}{1}".format(key.ljust(34),
-                            msg.msg))
+            # We only treat errors, and criticals as being worthy
+            # of a flag (pkglint returns non-zero if self.emitted)
+            if msg.level > WARNING:
+                self.emitted = True
 
-                        # We only treat errors, and criticals as being worthy
-                        # of a flag (pkglint returns non-zero if self.emitted)
-                        if msg.level > WARNING:
-                                self.emitted = True
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/lint/opensolaris.py
+++ b/src/modules/lint/opensolaris.py
@@ -28,56 +28,60 @@
 
 import pkg.lint.base as base
 
+
 class OpenSolarisActionChecker(base.ActionChecker):
-        """An opensolaris.org-specific class to check actions."""
+    """An opensolaris.org-specific class to check actions."""
 
-        name = "opensolaris.action"
+    name = "opensolaris.action"
 
-        def __init__(self, config):
-                self.description = _(
-                    "checks OpenSolaris packages for common action errors")
-                super(OpenSolarisActionChecker, self).__init__(config)
+    def __init__(self, config):
+        self.description = _(
+            "checks OpenSolaris packages for common action errors"
+        )
+        super(OpenSolarisActionChecker, self).__init__(config)
 
-        # opensolaris.action001 is obsolete and should not be reused.
+    # opensolaris.action001 is obsolete and should not be reused.
 
 
 class OpenSolarisManifestChecker(base.ManifestChecker):
-        """An opensolaris.org-specific class to check manifests."""
+    """An opensolaris.org-specific class to check manifests."""
 
-        name = "opensolaris.manifest"
+    name = "opensolaris.manifest"
 
-        def __init__(self, config):
-                self.description = _(
-                    "checks OpenSolaris packages for common errors")
-                super(OpenSolarisManifestChecker, self).__init__(config)
+    def __init__(self, config):
+        self.description = _("checks OpenSolaris packages for common errors")
+        super(OpenSolarisManifestChecker, self).__init__(config)
 
-        def missing_attrs(self, manifest, engine, pkglint_id="001"):
-                """Warn when a package doesn't have an
-                org.opensolaris.consolidation attribute.
-                Warn when a package don't have an info.classification value
-                """
-                if "pkg.renamed" in manifest:
-                        return
+    def missing_attrs(self, manifest, engine, pkglint_id="001"):
+        """Warn when a package doesn't have an
+        org.opensolaris.consolidation attribute.
+        Warn when a package don't have an info.classification value
+        """
+        if "pkg.renamed" in manifest:
+            return
 
-                if "pkg.obsolete" in manifest:
-                        return
+        if "pkg.obsolete" in manifest:
+            return
 
-                keys = ["org.opensolaris.consolidation", "info.classification"]
-                for key in keys:
-                        if key not in manifest:
-                                engine.warning(
-                                    _("Missing attribute '{key}' in "
-                                    "{pkg}").format(key=key, pkg=manifest.fmri),
-                                    msgid="{0}{1}.1".format(self.name,
-                                    pkglint_id))
+        keys = ["org.opensolaris.consolidation", "info.classification"]
+        for key in keys:
+            if key not in manifest:
+                engine.warning(
+                    _("Missing attribute '{key}' in " "{pkg}").format(
+                        key=key, pkg=manifest.fmri
+                    ),
+                    msgid="{0}{1}.1".format(self.name, pkglint_id),
+                )
 
-        missing_attrs.pkglint_desc = _(
-            "Standard package attributes should be present.")
+    missing_attrs.pkglint_desc = _(
+        "Standard package attributes should be present."
+    )
 
-        # opensolaris.manifest001.2 is obsolete and should not be reused.
-        # opensolaris.manifest002 is obsolete and should not be reused.
-        # opensolaris.manifest003 is obsolete and should not be reused.
-        # opensolaris.manifest004 is obsolete and should not be reused.
+    # opensolaris.manifest001.2 is obsolete and should not be reused.
+    # opensolaris.manifest002 is obsolete and should not be reused.
+    # opensolaris.manifest003 is obsolete and should not be reused.
+    # opensolaris.manifest004 is obsolete and should not be reused.
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/lint/pkglint_action.py
+++ b/src/modules/lint/pkglint_action.py
@@ -40,1630 +40,1812 @@ import stat
 
 ObsoleteFmri = collections.namedtuple("ObsoleteFmri", "is_obsolete, fmri")
 
+
 class PkgDupActionChecker(base.ActionChecker):
-        """A class to check duplicate actions/attributes."""
+    """A class to check duplicate actions/attributes."""
 
-        name = "pkglint.dupaction"
+    name = "pkglint.dupaction"
 
-        def __init__(self, config):
-                # dictionaries mapping path names to a list of tuples that are
-                # installing to that path name. Each tuple represents a single
-                # action and the fmri that delivers that action, to allow for a
-                # given fmri delivering multiple copies of actions that install
-                # to that path.
-                # eg. pathdb[path] = [(fmri, action), (fmri, action) ... ]
+    def __init__(self, config):
+        # dictionaries mapping path names to a list of tuples that are
+        # installing to that path name. Each tuple represents a single
+        # action and the fmri that delivers that action, to allow for a
+        # given fmri delivering multiple copies of actions that install
+        # to that path.
+        # eg. pathdb[path] = [(fmri, action), (fmri, action) ... ]
 
-                # The paths dictionaries for large repositories are rather
-                # memory hungry and may well be useful services for other
-                # checkers, so could be rolled into the engine itself (at the
-                # cost of all checker classes paying the toll on engine
-                # startup time.
-                # We maintain similar dictionaries for other attributes that
-                # should not be duplicated across (and within) manifests.
+        # The paths dictionaries for large repositories are rather
+        # memory hungry and may well be useful services for other
+        # checkers, so could be rolled into the engine itself (at the
+        # cost of all checker classes paying the toll on engine
+        # startup time.
+        # We maintain similar dictionaries for other attributes that
+        # should not be duplicated across (and within) manifests.
 
-                self.description = _("Checks for duplicate IPS actions.")
+        self.description = _("Checks for duplicate IPS actions.")
 
-                self.ref_paths = {}
-                self.lint_paths = {}
+        self.ref_paths = {}
+        self.lint_paths = {}
 
-                # similar dictionaries for drivers
-                self.ref_drivers = {}
-                self.lint_drivers = {}
+        # similar dictionaries for drivers
+        self.ref_drivers = {}
+        self.lint_drivers = {}
 
-                # and users / groups
-                self.ref_usernames = {}
-                self.ref_uids = {}
-                self.lint_usernames = {}
-                self.lint_uids = {}
+        # and users / groups
+        self.ref_usernames = {}
+        self.ref_uids = {}
+        self.lint_usernames = {}
+        self.lint_uids = {}
 
-                self.ref_groupnames = {}
-                self.lint_groupnames = {}
+        self.ref_groupnames = {}
+        self.lint_groupnames = {}
 
-                self.ref_gids = {}
-                self.lint_gids = {}
+        self.ref_gids = {}
+        self.lint_gids = {}
 
-                self.ref_legacy_pkgs = {}
-                self.lint_legacy_pkgs = {}
+        self.ref_legacy_pkgs = {}
+        self.lint_legacy_pkgs = {}
 
-                self.processed_paths = {}
-                self.processed_drivers = {}
-                self.processed_paths = {}
-                self.processed_usernames = {}
-                self.processed_uids = {}
-                self.processed_groupnames = {}
-                self.processed_gids = {}
+        self.processed_paths = {}
+        self.processed_drivers = {}
+        self.processed_paths = {}
+        self.processed_usernames = {}
+        self.processed_uids = {}
+        self.processed_groupnames = {}
+        self.processed_gids = {}
 
-                self.processed_refcount_paths = {}
-                self.processed_refcount_legacy_pkgs = {}
+        self.processed_refcount_paths = {}
+        self.processed_refcount_legacy_pkgs = {}
 
-                self.processed_overlays = {}
+        self.processed_overlays = {}
 
-                # mark which paths we've done duplicate-type checking on
-                self.seen_dup_types = {}
-                self.seen_mediated_links = []
+        # mark which paths we've done duplicate-type checking on
+        self.seen_dup_types = {}
+        self.seen_mediated_links = []
 
-                super(PkgDupActionChecker, self).__init__(config)
+        super(PkgDupActionChecker, self).__init__(config)
 
-        def startup(self, engine):
-                """Called to initialise a given checker using the supplied
-                    engine."""
+    def startup(self, engine):
+        """Called to initialise a given checker using the supplied
+        engine."""
 
-                def seed_dict(mf, attr, dic, atype=None, verbose=False):
-                        """Updates a dictionary of { attr: [(fmri, action), ..]}
-                        where attr is the value of that attribute from
-                        actions of a given type atype, in the given
-                        manifest."""
+        def seed_dict(mf, attr, dic, atype=None, verbose=False):
+            """Updates a dictionary of { attr: [(fmri, action), ..]}
+            where attr is the value of that attribute from
+            actions of a given type atype, in the given
+            manifest."""
 
-                        pkg_vars = mf.get_all_variants()
+            pkg_vars = mf.get_all_variants()
 
-                        def mf_gen(atype):
-                                if atype:
-                                        for a in mf.gen_actions_by_type(atype):
-                                                yield a
-                                else:
-                                        for a in mf.gen_actions():
-                                                yield a
+            def mf_gen(atype):
+                if atype:
+                    for a in mf.gen_actions_by_type(atype):
+                        yield a
+                else:
+                    for a in mf.gen_actions():
+                        yield a
 
-                        for action in mf_gen(atype):
-                                if atype and action.name != atype:
-                                        continue
-                                if attr not in action.attrs:
-                                        continue
+            for action in mf_gen(atype):
+                if atype and action.name != atype:
+                    continue
+                if attr not in action.attrs:
+                    continue
 
-                                variants = action.get_variant_template()
-                                variants.merge_unknown(pkg_vars)
-                                # Action attributes must be lists or strings.
-                                for k, v in six.iteritems(variants):
-                                        if isinstance(v, set):
-                                                action.attrs[k] = list(v)
-                                        else:
-                                                action.attrs[k] = v
+                variants = action.get_variant_template()
+                variants.merge_unknown(pkg_vars)
+                # Action attributes must be lists or strings.
+                for k, v in six.iteritems(variants):
+                    if isinstance(v, set):
+                        action.attrs[k] = list(v)
+                    else:
+                        action.attrs[k] = v
 
-                                p = action.attrs[attr]
-                                if p not in dic:
-                                        dic[p] = [(mf.fmri, action)]
-                                else:
-                                        dic[p].append((mf.fmri, action))
+                p = action.attrs[attr]
+                if p not in dic:
+                    dic[p] = [(mf.fmri, action)]
+                else:
+                    dic[p].append((mf.fmri, action))
 
-                # construct a set of FMRIs being presented for linting, and
-                # avoid seeding the reference dictionary for any packages
-                # that have new versions available in the lint repository, or
-                # lint manifests given on the command line.
-                lint_fmris = {}
-                for m in engine.gen_manifests(engine.lint_api_inst,
-                    release=engine.release, pattern=engine.pattern):
-                        lint_fmris.setdefault(
-                            m.fmri.get_name(), []).append(m.fmri)
-                for m in engine.lint_manifests:
-                        lint_fmris.setdefault(
-                            m.fmri.get_name(), []).append(m.fmri)
+        # construct a set of FMRIs being presented for linting, and
+        # avoid seeding the reference dictionary for any packages
+        # that have new versions available in the lint repository, or
+        # lint manifests given on the command line.
+        lint_fmris = {}
+        for m in engine.gen_manifests(
+            engine.lint_api_inst, release=engine.release, pattern=engine.pattern
+        ):
+            lint_fmris.setdefault(m.fmri.get_name(), []).append(m.fmri)
+        for m in engine.lint_manifests:
+            lint_fmris.setdefault(m.fmri.get_name(), []).append(m.fmri)
 
-                engine.logger.debug(
-                    _("Seeding reference action duplicates dictionaries."))
+        engine.logger.debug(
+            _("Seeding reference action duplicates dictionaries.")
+        )
 
-                for manifest in engine.gen_manifests(engine.ref_api_inst,
-                    release=engine.release):
-                        # Only put this manifest into the reference dictionary
-                        # if it's not an older version of the same package.
-                        if any(
-                            lint_fmri_successor(fmri, manifest.fmri)
-                            for fmri
-                            in lint_fmris.get(manifest.fmri.get_name(), [])
+        for manifest in engine.gen_manifests(
+            engine.ref_api_inst, release=engine.release
+        ):
+            # Only put this manifest into the reference dictionary
+            # if it's not an older version of the same package.
+            if any(
+                lint_fmri_successor(fmri, manifest.fmri)
+                for fmri in lint_fmris.get(manifest.fmri.get_name(), [])
+            ):
+                continue
+            else:
+                seed_dict(manifest, "path", self.ref_paths)
+                seed_dict(manifest, "pkg", self.ref_legacy_pkgs, atype="legacy")
+                seed_dict(manifest, "name", self.ref_drivers, atype="driver")
+                seed_dict(
+                    manifest, "username", self.ref_usernames, atype="user"
+                )
+                seed_dict(manifest, "uid", self.ref_uids, atype="user")
+                seed_dict(
+                    manifest, "groupname", self.ref_groupnames, atype="group"
+                )
+                seed_dict(manifest, "gid", self.ref_gids, atype="group")
+
+        engine.logger.debug(_("Seeding lint action duplicates dictionaries."))
+
+        # we provide a search pattern, to allow users to lint a
+        # subset of the packages in the lint_repository
+        for manifest in engine.gen_manifests(
+            engine.lint_api_inst, release=engine.release, pattern=engine.pattern
+        ):
+            seed_dict(manifest, "path", self.lint_paths)
+            seed_dict(manifest, "pkg", self.lint_legacy_pkgs, atype="legacy")
+            seed_dict(manifest, "name", self.lint_drivers, atype="driver")
+            seed_dict(manifest, "username", self.lint_usernames, atype="user")
+            seed_dict(manifest, "uid", self.lint_uids, atype="user")
+            seed_dict(
+                manifest, "groupname", self.lint_groupnames, atype="group"
+            )
+            seed_dict(manifest, "gid", self.lint_gids, atype="group")
+
+        engine.logger.debug(_("Seeding local action duplicates dictionaries."))
+
+        for manifest in engine.lint_manifests:
+            seed_dict(manifest, "path", self.lint_paths)
+            seed_dict(manifest, "pkg", self.lint_legacy_pkgs, atype="legacy")
+            seed_dict(manifest, "name", self.lint_drivers, atype="driver")
+            seed_dict(manifest, "username", self.lint_usernames, atype="user")
+            seed_dict(manifest, "uid", self.lint_uids, atype="user")
+            seed_dict(
+                manifest, "groupname", self.lint_groupnames, atype="group"
+            )
+            seed_dict(manifest, "gid", self.lint_gids, atype="group")
+
+        dup_dictionaries = [
+            (self.lint_paths, self.ref_paths),
+            (self.lint_legacy_pkgs, self.ref_legacy_pkgs),
+            (self.lint_drivers, self.ref_drivers),
+            (self.lint_usernames, self.ref_usernames),
+            (self.lint_uids, self.ref_uids),
+            (self.lint_groupnames, self.ref_groupnames),
+            (self.lint_gids, self.ref_gids),
+        ]
+
+        for lint_dic, ref_dic in dup_dictionaries:
+            self._merge_dict(lint_dic, ref_dic, ignore_pubs=engine.ignore_pubs)
+            self.lint_dic = {}
+
+    def duplicate_paths(self, action, manifest, engine, pkglint_id="001"):
+        """Checks for duplicate paths on non-ref-counted actions."""
+
+        self.dup_attr_check(
+            ["file", "license"],
+            "path",
+            self.ref_paths,
+            self.processed_paths,
+            action,
+            engine,
+            manifest.get_all_variants(),
+            msgid=pkglint_id,
+        )
+
+    duplicate_paths.pkglint_desc = _("Paths should be unique.")
+
+    def duplicate_drivers(self, action, manifest, engine, pkglint_id="002"):
+        """Checks for duplicate driver names."""
+
+        self.dup_attr_check(
+            ["driver"],
+            "name",
+            self.ref_drivers,
+            self.processed_drivers,
+            action,
+            engine,
+            manifest.get_all_variants(),
+            msgid=pkglint_id,
+        )
+
+    duplicate_drivers.pkglint_desc = _("Driver names should be unique.")
+
+    def duplicate_usernames(self, action, manifest, engine, pkglint_id="003"):
+        """Checks for duplicate user names."""
+
+        self.dup_attr_check(
+            ["user"],
+            "username",
+            self.ref_usernames,
+            self.processed_usernames,
+            action,
+            engine,
+            manifest.get_all_variants(),
+            msgid=pkglint_id,
+        )
+
+    duplicate_usernames.pkglint_desc = _("User names should be unique.")
+
+    def duplicate_uids(self, action, manifest, engine, pkglint_id="004"):
+        """Checks for duplicate uids."""
+
+        self.dup_attr_check(
+            ["user"],
+            "uid",
+            self.ref_uids,
+            self.processed_uids,
+            action,
+            engine,
+            manifest.get_all_variants(),
+            msgid=pkglint_id,
+        )
+
+    duplicate_uids.pkglint_desc = _("UIDs should be unique.")
+
+    def duplicate_groupnames(self, action, manifest, engine, pkglint_id="005"):
+        """Checks for duplicate group names."""
+
+        self.dup_attr_check(
+            ["group"],
+            "groupname",
+            self.ref_groupnames,
+            self.processed_groupnames,
+            action,
+            engine,
+            manifest.get_all_variants(),
+            msgid=pkglint_id,
+        )
+
+    duplicate_groupnames.pkglint_desc = _("Group names should be unique.")
+
+    def duplicate_gids(self, action, manifest, engine, pkglint_id="006"):
+        """Checks for duplicate gids."""
+
+        self.dup_attr_check(
+            ["group"],
+            "name",
+            self.ref_gids,
+            self.processed_gids,
+            action,
+            engine,
+            manifest.get_all_variants(),
+            msgid=pkglint_id,
+        )
+
+    duplicate_gids.pkglint_desc = _("GIDs should be unique.")
+
+    def duplicate_legacy(self, action, manifest, engine, pkglint_id="015"):
+        """Checks for duplicate legacy package names."""
+
+        self.dup_attr_check(
+            ["legacy"],
+            "pkg",
+            self.ref_legacy_pkgs,
+            self.processed_refcount_legacy_pkgs,
+            action,
+            engine,
+            manifest.get_all_variants(),
+            msgid=pkglint_id,
+        )
+
+    duplicate_legacy.pkglint_desc = _("Legacy package names should be unique.")
+
+    def duplicate_refcount_path_attrs(
+        self, action, manifest, engine, pkglint_id="007"
+    ):
+        """Checks that for duplicated reference-counted actions,
+        all attributes in those duplicates are the same."""
+
+        if not action.refcountable:
+            return
+
+        for attr, ref_dic, processed_dic in [
+            ("path", self.ref_paths, self.processed_refcount_paths),
+            ("pkg", self.ref_legacy_pkgs, self.processed_refcount_legacy_pkgs),
+        ]:
+            p = action.attrs.get(attr, None)
+            if not p:
+                continue
+
+            if p in ref_dic and len(ref_dic[p]) == 1:
+                continue
+
+            if p in processed_dic:
+                continue
+
+            lint_id = "{0}{1}".format(self.name, pkglint_id)
+
+            fmris = set()
+            targ = action
+            differences = set()
+            for pfmri, a in ref_dic[p]:
+                if engine.linted(action=a, manifest=manifest, lint_id=lint_id):
+                    continue
+                fmris.add(pfmri)
+
+                for key in a.differences(targ):
+                    # we allow certain attribute values to
+                    # differ. Mediated-link validation is
+                    # provided by mediated_links(..).
+                    if (
+                        key.startswith("variant")
+                        or key.startswith("facet")
+                        or key.startswith("mediator")
+                        or key.startswith("target")
+                        or key.startswith("pkg.linted")
+                    ):
+                        continue
+
+                    conflict_vars, conflict_actions = self.conflicting_variants(
+                        [a, targ], manifest.get_all_variants()
+                    )
+                    if not conflict_actions:
+                        continue
+                    differences.add(key)
+            suspects = []
+
+            if differences:
+                action_types = set()
+                for key in sorted(differences):
+                    # a dictionary to map unique values for
+                    # this key the fmris that deliver them
+                    attr = {}
+                    for pfmri, a in ref_dic[p]:
+                        if engine.linted(
+                            action=a, manifest=manifest, lint_id=lint_id
                         ):
-                                continue
-                        else:
-                                seed_dict(manifest, "path", self.ref_paths)
-                                seed_dict(manifest, "pkg", self.ref_legacy_pkgs,
-                                    atype="legacy")
-                                seed_dict(manifest, "name", self.ref_drivers,
-                                    atype="driver")
-                                seed_dict(manifest, "username",
-                                    self.ref_usernames, atype="user")
-                                seed_dict(manifest, "uid", self.ref_uids,
-                                    atype="user")
-                                seed_dict(manifest, "groupname",
-                                    self.ref_groupnames, atype="group")
-                                seed_dict(manifest, "gid", self.ref_gids,
-                                    atype="group")
+                            continue
 
-                engine.logger.debug(
-                    _("Seeding lint action duplicates dictionaries."))
+                        action_types.add(a.name)
+                        if not key in a.attrs:
+                            continue
 
-                # we provide a search pattern, to allow users to lint a
-                # subset of the packages in the lint_repository
-                for manifest in engine.gen_manifests(engine.lint_api_inst,
-                    release=engine.release, pattern=engine.pattern):
-                        seed_dict(manifest, "path", self.lint_paths)
-                        seed_dict(manifest, "pkg", self.lint_legacy_pkgs,
-                            atype="legacy")
-                        seed_dict(manifest, "name", self.lint_drivers,
-                            atype="driver")
-                        seed_dict(manifest, "username", self.lint_usernames,
-                            atype="user")
-                        seed_dict(manifest, "uid", self.lint_uids, atype="user")
-                        seed_dict(manifest, "groupname", self.lint_groupnames,
-                            atype="group")
-                        seed_dict(manifest, "gid", self.lint_gids,
-                            atype="group")
+                        for val in a.attrlist(key):
+                            if val in attr:
+                                attr[val].append(pfmri)
+                            else:
+                                attr[val] = [pfmri]
+                    for val in sorted(attr):
+                        suspects.append(
+                            "{0}: {1} -> {2}".format(
+                                key,
+                                val,
+                                " ".join(
+                                    [
+                                        pfmri.get_name()
+                                        for pfmri in sorted(attr[val])
+                                    ]
+                                ),
+                            )
+                        )
 
-                engine.logger.debug(
-                    _("Seeding local action duplicates dictionaries."))
+                # if we deliver different action types, that
+                # gets dealt with by duplicate_path_types().
+                if len(action_types) != 1:
+                    processed_dic[p] = True
+                    continue
 
-                for manifest in engine.lint_manifests:
-                        seed_dict(manifest, "path", self.lint_paths)
-                        seed_dict(manifest, "pkg", self.lint_legacy_pkgs,
-                            atype="legacy")
-                        seed_dict(manifest, "name", self.lint_drivers,
-                            atype="driver")
-                        seed_dict(manifest, "username", self.lint_usernames,
-                            atype="user")
-                        seed_dict(manifest, "uid", self.lint_uids, atype="user")
-                        seed_dict(manifest, "groupname", self.lint_groupnames,
-                            atype="group")
-                        seed_dict(manifest, "gid", self.lint_gids,
-                            atype="group")
+                engine.error(
+                    _(
+                        "{type} action for {attr} "
+                        "is reference-counted but has different "
+                        "attributes across {count} duplicates: "
+                        "{suspects}"
+                    ).format(
+                        type=action.name,
+                        attr=p,
+                        count=len(fmris),
+                        suspects=" ".join([key for key in suspects]),
+                    ),
+                    msgid=lint_id,
+                    ignore_linted=True,
+                )
+            processed_dic[p] = True
 
-                dup_dictionaries = [(self.lint_paths, self.ref_paths),
-                    (self.lint_legacy_pkgs, self.ref_legacy_pkgs),
-                    (self.lint_drivers, self.ref_drivers),
-                    (self.lint_usernames, self.ref_usernames),
-                    (self.lint_uids, self.ref_uids),
-                    (self.lint_groupnames, self.ref_groupnames),
-                    (self.lint_gids, self.ref_gids)]
+    duplicate_refcount_path_attrs.pkglint_desc = _(
+        "Duplicated reference counted actions should have the same attrs."
+    )
 
-                for lint_dic, ref_dic in dup_dictionaries:
-                        self._merge_dict(lint_dic, ref_dic,
-                            ignore_pubs=engine.ignore_pubs)
-                        self.lint_dic = {}
+    def dup_attr_check(
+        self,
+        action_names,
+        attr_name,
+        ref_dic,
+        processed_dic,
+        action,
+        engine,
+        pkg_vars,
+        msgid="",
+        only_overlays=False,
+    ):
+        """This method does generic duplicate action checking where
+        we know the type of action and name of an action attributes
+        across actions/manifests that should not be duplicated.
 
-        def duplicate_paths(self, action, manifest, engine, pkglint_id="001"):
-                """Checks for duplicate paths on non-ref-counted actions."""
+        'action_names' A list of the type of actions to check
 
-                self.dup_attr_check(["file", "license"], "path", self.ref_paths,
-                    self.processed_paths, action, engine,
-                    manifest.get_all_variants(), msgid=pkglint_id)
+        'attr_name' The attribute name we're checking
 
-        duplicate_paths.pkglint_desc = _(
-            "Paths should be unique.")
+        'ref_dic' Built in setup() this dictionary maps attr_name values
+        to a list of all (fmri, action) tuples that deliver that
+        attr_name value.
 
-        def duplicate_drivers(self, action, manifest, engine, pkglint_id="002"):
-                """Checks for duplicate driver names."""
+        'processed_dic' Records whether we've already called this method
+        for a given attr_name value
 
-                self.dup_attr_check(["driver"], "name", self.ref_drivers,
-                    self.processed_drivers, action, engine,
-                    manifest.get_all_variants(), msgid=pkglint_id)
+        'action' The current action we're checking
 
-        duplicate_drivers.pkglint_desc = _("Driver names should be unique.")
+        'engine' The LintEngine calling this method
 
-        def duplicate_usernames(self, action, manifest, engine,
-            pkglint_id="003"):
-                """Checks for duplicate user names."""
+        'msgid' The pkglint_id to use when logging messages.
 
-                self.dup_attr_check(["user"], "username", self.ref_usernames,
-                    self.processed_usernames, action, engine,
-                    manifest.get_all_variants(), msgid=pkglint_id)
+        'only_overlays' Only report about misuse of the 'overlay'
+        attribute for file actions."""
 
-        duplicate_usernames.pkglint_desc = _("User names should be unique.")
+        if attr_name not in action.attrs:
+            return
 
-        def duplicate_uids(self, action, manifest, engine, pkglint_id="004"):
-                """Checks for duplicate uids."""
+        if action.name not in action_names:
+            return
 
-                self.dup_attr_check(["user"], "uid", self.ref_uids,
-                    self.processed_uids, action, engine,
-                    manifest.get_all_variants(), msgid=pkglint_id)
+        name = action.attrs[attr_name]
 
-        duplicate_uids.pkglint_desc = _("UIDs should be unique.")
+        if name in processed_dic:
+            return
 
-        def duplicate_groupnames(self, action, manifest, engine,
-            pkglint_id="005"):
-                """Checks for duplicate group names."""
+        if name in ref_dic and len(ref_dic[name]) == 1:
+            return
 
-                self.dup_attr_check(["group"], "groupname", self.ref_groupnames,
-                    self.processed_groupnames, action, engine,
-                    manifest.get_all_variants(), msgid=pkglint_id)
+        fmris = set()
+        actions = set()
+        for pfmri, a in ref_dic[name]:
+            # mediated links get ignored here
+            if a.name in ["link", "hardlink"] and "mediator" in a.attrs:
+                continue
+            actions.add(a)
+            fmris.add(pfmri)
 
-        duplicate_groupnames.pkglint_desc = _(
-            "Group names should be unique.")
+        conflict_vars, conflict_actions = self.conflicting_variants(
+            actions, pkg_vars
+        )
 
-        def duplicate_gids(self, action, manifest, engine, pkglint_id="006"):
-                """Checks for duplicate gids."""
-
-                self.dup_attr_check(["group"], "name", self.ref_gids,
-                    self.processed_gids, action, engine,
-                    manifest.get_all_variants(), msgid=pkglint_id)
-
-        duplicate_gids.pkglint_desc = _("GIDs should be unique.")
-
-        def duplicate_legacy(self, action, manifest, engine, pkglint_id="015"):
-                """Checks for duplicate legacy package names."""
-
-                self.dup_attr_check(["legacy"], "pkg", self.ref_legacy_pkgs,
-                    self.processed_refcount_legacy_pkgs, action, engine,
-                    manifest.get_all_variants(), msgid=pkglint_id)
-
-        duplicate_legacy.pkglint_desc = _(
-            "Legacy package names should be unique.")
-
-        def duplicate_refcount_path_attrs(self, action, manifest, engine,
-            pkglint_id="007"):
-                """Checks that for duplicated reference-counted actions,
-                all attributes in those duplicates are the same."""
-
-                if not action.refcountable:
-                        return
-
-                for attr, ref_dic, processed_dic in [
-                    ("path", self.ref_paths, self.processed_refcount_paths),
-                    ("pkg", self.ref_legacy_pkgs,
-                    self.processed_refcount_legacy_pkgs)]:
-                        p = action.attrs.get(attr, None)
-                        if not p:
-                                continue
-
-                        if p in ref_dic and len(ref_dic[p]) == 1:
-                                continue
-
-                        if p in processed_dic:
-                                continue
-
-                        lint_id = "{0}{1}".format(self.name, pkglint_id)
-
-                        fmris = set()
-                        targ = action
-                        differences = set()
-                        for (pfmri, a) in ref_dic[p]:
-                                if engine.linted(action=a, manifest=manifest,
-                                    lint_id=lint_id):
-                                        continue
-                                fmris.add(pfmri)
-
-                                for key in a.differences(targ):
-                                        # we allow certain attribute values to
-                                        # differ. Mediated-link validation is
-                                        # provided by mediated_links(..).
-                                        if key.startswith("variant") or \
-                                            key.startswith("facet") or \
-                                            key.startswith("mediator") or \
-                                            key.startswith("target") or \
-                                            key.startswith("pkg.linted"):
-                                                continue
-
-                                        conflict_vars, conflict_actions = \
-                                            self.conflicting_variants([a, targ],
-                                                manifest.get_all_variants())
-                                        if not conflict_actions:
-                                                continue
-                                        differences.add(key)
-                        suspects = []
-
-                        if differences:
-                                action_types = set()
-                                for key in sorted(differences):
-                                        # a dictionary to map unique values for
-                                        # this key the fmris that deliver them
-                                        attr = {}
-                                        for (pfmri, a) in ref_dic[p]:
-                                                if engine.linted(action=a,
-                                                    manifest=manifest,
-                                                    lint_id=lint_id):
-                                                        continue
-
-                                                action_types.add(a.name)
-                                                if not key in a.attrs:
-                                                        continue
-
-                                                for val in a.attrlist(key):
-                                                        if val in attr:
-                                                                attr[val].append(
-                                                                    pfmri)
-                                                        else:
-                                                                attr[val] = \
-                                                                    [pfmri]
-                                        for val in sorted(attr):
-                                                suspects.append(
-                                                    "{0}: {1} -> {2}".format(
-                                                    key, val,
-                                                    " ".join([pfmri.get_name()
-                                                    for pfmri in
-                                                    sorted(attr[val])
-                                                    ])))
-
-                                # if we deliver different action types, that
-                                # gets dealt with by duplicate_path_types().
-                                if len(action_types) != 1:
-                                        processed_dic[p] = True
-                                        continue
-
-                                engine.error(_("{type} action for {attr} "
-                                    "is reference-counted but has different "
-                                    "attributes across {count} duplicates: "
-                                    "{suspects}").format(
-                                    type=action.name,
-                                    attr=p,
-                                    count=len(fmris),
-                                    suspects=
-                                    " ".join([key for key in suspects])),
-                                    msgid=lint_id, ignore_linted=True)
-                        processed_dic[p] = True
-
-        duplicate_refcount_path_attrs.pkglint_desc = _(
-            "Duplicated reference counted actions should have the same attrs.")
-
-        def dup_attr_check(self, action_names, attr_name, ref_dic,
-            processed_dic, action, engine, pkg_vars, msgid="",
-            only_overlays=False):
-                """This method does generic duplicate action checking where
-                we know the type of action and name of an action attributes
-                across actions/manifests that should not be duplicated.
-
-                'action_names' A list of the type of actions to check
-
-                'attr_name' The attribute name we're checking
-
-                'ref_dic' Built in setup() this dictionary maps attr_name values
-                to a list of all (fmri, action) tuples that deliver that
-                attr_name value.
-
-                'processed_dic' Records whether we've already called this method
-                for a given attr_name value
-
-                'action' The current action we're checking
-
-                'engine' The LintEngine calling this method
-
-                'msgid' The pkglint_id to use when logging messages.
-
-                'only_overlays' Only report about misuse of the 'overlay'
-                attribute for file actions."""
-
-                if attr_name not in action.attrs:
-                        return
-
-                if action.name not in action_names:
-                        return
-
-                name = action.attrs[attr_name]
-
-                if name in processed_dic:
-                        return
-
-                if name in ref_dic and len(ref_dic[name]) == 1:
-                        return
-
-                fmris = set()
-                actions = set()
-                for (pfmri, a) in ref_dic[name]:
-                        # mediated links get ignored here
-                        if a.name in ["link", "hardlink"] and \
-                            "mediator" in a.attrs:
-                                continue
-                        actions.add(a)
-                        fmris.add(pfmri)
-
-                conflict_vars, conflict_actions = \
-                    self.conflicting_variants(actions, pkg_vars)
-
-                # prune out any valid overlay file action-pairs.
-                if attr_name == "path" and action.name == "file":
-                        conflict_actions, errors = self._prune_overlays(
-                            conflict_actions, ref_dic, pkg_vars)
-                        if only_overlays:
-                                for error, sub_id in errors:
-                                        engine.error(error,
-                                            msgid="{0}{1}.{2}".format(
-                                            self.name, msgid, sub_id))
-                                processed_dic[name] = True
-                                return
-
-                        if conflict_actions:
-                                 conflict_vars, conflict_actions = \
-                                        self.conflicting_variants(actions,
-                                            pkg_vars)
-                if conflict_actions:
-                        plist = [f.get_fmri() for f in sorted(fmris)]
-
-                        if not conflict_vars:
-                                engine.error(_("{attr_name} {name} is "
-                                    "a duplicate delivered by {pkgs} "
-                                    "under all variant combinations").format(
-                                    attr_name=attr_name,
-                                    name=name,
-                                    pkgs=" ".join(plist)),
-                                    msgid="{0}{1}.1".format(self.name, msgid))
-                        else:
-                                for fz in conflict_vars:
-                                        engine.error(_("{attr_name} {name} "
-                                            "is a duplicate delivered by "
-                                            "{pkgs} declaring overlapping "
-                                            "variants {vars}").format(
-                                            attr_name=attr_name,
-                                            name=name,
-                                            pkgs=" ".join(plist),
-                                            vars=
-                                            " ".join(["{0}={1}".format(k, v)
-                                                for (k, v)
-                                                in sorted(fz)])),
-                                            msgid="{0}{1}.2".format(self.name,
-                                                msgid))
+        # prune out any valid overlay file action-pairs.
+        if attr_name == "path" and action.name == "file":
+            conflict_actions, errors = self._prune_overlays(
+                conflict_actions, ref_dic, pkg_vars
+            )
+            if only_overlays:
+                for error, sub_id in errors:
+                    engine.error(
+                        error,
+                        msgid="{0}{1}.{2}".format(self.name, msgid, sub_id),
+                    )
                 processed_dic[name] = True
+                return
 
-        def duplicate_path_types(self, action, manifest, engine,
-            pkglint_id="008"):
-                """Checks to see if the action containing a path attribute
-                has that action delivered by multiple action types."""
+            if conflict_actions:
+                conflict_vars, conflict_actions = self.conflicting_variants(
+                    actions, pkg_vars
+                )
+        if conflict_actions:
+            plist = [f.get_fmri() for f in sorted(fmris)]
 
-                if "path" not in action.attrs:
-                        return
+            if not conflict_vars:
+                engine.error(
+                    _(
+                        "{attr_name} {name} is "
+                        "a duplicate delivered by {pkgs} "
+                        "under all variant combinations"
+                    ).format(
+                        attr_name=attr_name, name=name, pkgs=" ".join(plist)
+                    ),
+                    msgid="{0}{1}.1".format(self.name, msgid),
+                )
+            else:
+                for fz in conflict_vars:
+                    engine.error(
+                        _(
+                            "{attr_name} {name} "
+                            "is a duplicate delivered by "
+                            "{pkgs} declaring overlapping "
+                            "variants {vars}"
+                        ).format(
+                            attr_name=attr_name,
+                            name=name,
+                            pkgs=" ".join(plist),
+                            vars=" ".join(
+                                [
+                                    "{0}={1}".format(k, v)
+                                    for (k, v) in sorted(fz)
+                                ]
+                            ),
+                        ),
+                        msgid="{0}{1}.2".format(self.name, msgid),
+                    )
+        processed_dic[name] = True
 
-                p = action.attrs["path"]
+    def duplicate_path_types(self, action, manifest, engine, pkglint_id="008"):
+        """Checks to see if the action containing a path attribute
+        has that action delivered by multiple action types."""
 
-                if p in self.seen_dup_types:
-                        return
+        if "path" not in action.attrs:
+            return
 
-                lint_id = "{0}{1}".format(self.name, pkglint_id)
-                types = set()
-                fmris = set()
-                actions = set()
-                for (pfmri, a) in self.ref_paths[p]:
-                        if engine.linted(action=a, manifest=manifest,
-                            lint_id=lint_id):
-                                continue
-                        # we deal with mediated links in mediated_links(..)
-                        # since self.conflicting_variants() would otherwise flag
-                        # these as conflicting
-                        if a.name in ["link", "hardlink"] and \
-                            "mediator" in a.attrs:
-                                continue
-                        actions.add(a)
-                        types.add(a.name)
-                        fmris.add(pfmri)
+        p = action.attrs["path"]
 
-                if len(types) > 1:
-                        conflict_vars, conflict_actions = \
-                            self.conflicting_variants(actions,
-                                manifest.get_all_variants())
-                        if conflict_actions:
-                                plist = [f.get_fmri() for f in sorted(fmris)]
-                                plist.sort()
-                                engine.error(
-                                    _("path {path} is delivered by multiple "
-                                    "action types across {pkgs}").format(
-                                    path=p,
-                                    pkgs=
-                                    " ".join(plist)),
-                                    msgid=lint_id, ignore_linted=True)
-                self.seen_dup_types[p] = True
+        if p in self.seen_dup_types:
+            return
 
-        duplicate_path_types.pkglint_desc = _(
-            "Paths should be delivered by one action type only.")
+        lint_id = "{0}{1}".format(self.name, pkglint_id)
+        types = set()
+        fmris = set()
+        actions = set()
+        for pfmri, a in self.ref_paths[p]:
+            if engine.linted(action=a, manifest=manifest, lint_id=lint_id):
+                continue
+            # we deal with mediated links in mediated_links(..)
+            # since self.conflicting_variants() would otherwise flag
+            # these as conflicting
+            if a.name in ["link", "hardlink"] and "mediator" in a.attrs:
+                continue
+            actions.add(a)
+            types.add(a.name)
+            fmris.add(pfmri)
 
-        def overlays(self, action, manifest, engine, pkglint_id="009"):
-                """Checks that any duplicate file actions which specify overlay
-                attributes do so according to the rules.
+        if len(types) > 1:
+            conflict_vars, conflict_actions = self.conflicting_variants(
+                actions, manifest.get_all_variants()
+            )
+            if conflict_actions:
+                plist = [f.get_fmri() for f in sorted(fmris)]
+                plist.sort()
+                engine.error(
+                    _(
+                        "path {path} is delivered by multiple "
+                        "action types across {pkgs}"
+                    ).format(path=p, pkgs=" ".join(plist)),
+                    msgid=lint_id,
+                    ignore_linted=True,
+                )
+        self.seen_dup_types[p] = True
 
-                Much of the implementation here is done by _prune_overlays(..),
-                called by dup_attr_check."""
+    duplicate_path_types.pkglint_desc = _(
+        "Paths should be delivered by one action type only."
+    )
 
-                if action.name != "file":
-                        return
+    def overlays(self, action, manifest, engine, pkglint_id="009"):
+        """Checks that any duplicate file actions which specify overlay
+        attributes do so according to the rules.
 
-                self.dup_attr_check(["file"], "path", self.ref_paths,
-                    self.processed_overlays, action, engine,
-                    manifest.get_all_variants(), msgid=pkglint_id,
-                    only_overlays=True)
+        Much of the implementation here is done by _prune_overlays(..),
+        called by dup_attr_check."""
 
-        overlays.pkglint_desc = _("Overlaying actions should be valid.")
+        if action.name != "file":
+            return
 
-        def mediated_links(self, action, manifest, engine, pkglint_id="010"):
-                """Checks that groups of mediated-links are valid.  We perform
-                minimal validation of mediated links here, since the generic
-                action-validation check, pkglint.action009, will run the
-                validate() method on each action.
+        self.dup_attr_check(
+            ["file"],
+            "path",
+            self.ref_paths,
+            self.processed_overlays,
+            action,
+            engine,
+            manifest.get_all_variants(),
+            msgid=pkglint_id,
+            only_overlays=True,
+        )
 
-                We check that all mediators for a given path are part of the
-                same mediation namespace, and that all links for a given path
-                have a 'mediator' attribute to declare that namespace.  We also
-                check, that if mediators are being used, that all actions
-                deliver the same type of action for that mediated link.
+    overlays.pkglint_desc = _("Overlaying actions should be valid.")
 
-                There is some overlap with duplicate_path_types here,
-                in that duplicate reference-counted actions with a path
-                attribute where that list of actions contains link or hardlink
-                actions will be reported here instead, in case the user simply
-                got the type of action wrong.
-                """
+    def mediated_links(self, action, manifest, engine, pkglint_id="010"):
+        """Checks that groups of mediated-links are valid.  We perform
+        minimal validation of mediated links here, since the generic
+        action-validation check, pkglint.action009, will run the
+        validate() method on each action.
 
-                if action.name not in ["link", "hardlink"]:
-                        return
+        We check that all mediators for a given path are part of the
+        same mediation namespace, and that all links for a given path
+        have a 'mediator' attribute to declare that namespace.  We also
+        check, that if mediators are being used, that all actions
+        deliver the same type of action for that mediated link.
 
-                # a link without a path will get picked up elsewhere
-                p = action.attrs.get("path", None)
-                if not p:
-                        return
+        There is some overlap with duplicate_path_types here,
+        in that duplicate reference-counted actions with a path
+        attribute where that list of actions contains link or hardlink
+        actions will be reported here instead, in case the user simply
+        got the type of action wrong.
+        """
 
-                if p in self.seen_mediated_links:
-                        return
+        if action.name not in ["link", "hardlink"]:
+            return
 
-                if len(self.ref_paths[p]) == 1:
-                        return
+        # a link without a path will get picked up elsewhere
+        p = action.attrs.get("path", None)
+        if not p:
+            return
 
-                ref_mediator = action.attrs.get("mediator", None)
-                different_namespaces = []
-                missing_mediators = []
+        if p in self.seen_mediated_links:
+            return
 
-                types_id = "{0}{1}.1".format(self.name, pkglint_id)
-                missing_id = "{0}{1}.2".format(self.name, pkglint_id)
-                diff_id = "{0}{1}.3".format(self.name, pkglint_id)
+        if len(self.ref_paths[p]) == 1:
+            return
 
-                # gather the actions and their fmris that have either
-                # different namespaces, or missing mediators.  We ignore
-                # variants at this point.
-                for pfmri, action in self.ref_paths[p]:
-                        mediator = action.attrs.get("mediator", None)
-                        if not mediator:
-                                if engine.linted(action, lint_id=missing_id):
-                                        continue
-                                missing_mediators.append((pfmri, action))
-                        elif mediator != ref_mediator:
-                                if engine.linted(action, lint_id=diff_id):
-                                        continue
-                                different_namespaces.append((pfmri, action))
+        ref_mediator = action.attrs.get("mediator", None)
+        different_namespaces = []
+        missing_mediators = []
 
-                def variant_conflicts(mediator_list, lint_id):
-                        """Look for conflicting variants across the given list,
-                        allowing for pkg.linted values matching lint_id."""
-                        conflicts = []
-                        for pfmri, action in mediator_list:
-                                # compare every action for this path to see if
-                                # we have at least one variant conflict.  We
-                                # need to do this individually since
-                                # conflicting_variants(..) isn't mediator-aware
-                                for pfm, ac in self.ref_paths[p]:
-                                        if ac == action:
-                                                continue
-                                        if engine.linted(ac, lint_id=lint_id):
-                                                continue
-                                        conf_var, conf_ac = \
-                                            self.conflicting_variants(
-                                                [ac, action], {})
-                                        for conf in conf_ac:
-                                                conflicts.append((pfm, conf))
-                        return conflicts
+        types_id = "{0}{1}.1".format(self.name, pkglint_id)
+        missing_id = "{0}{1}.2".format(self.name, pkglint_id)
+        diff_id = "{0}{1}.3".format(self.name, pkglint_id)
 
-                action_types = set([])
+        # gather the actions and their fmris that have either
+        # different namespaces, or missing mediators.  We ignore
+        # variants at this point.
+        for pfmri, action in self.ref_paths[p]:
+            mediator = action.attrs.get("mediator", None)
+            if not mediator:
+                if engine.linted(action, lint_id=missing_id):
+                    continue
+                missing_mediators.append((pfmri, action))
+            elif mediator != ref_mediator:
+                if engine.linted(action, lint_id=diff_id):
+                    continue
+                different_namespaces.append((pfmri, action))
 
-                seen_conflicts = variant_conflicts(different_namespaces,
-                    diff_id)
-                if seen_conflicts:
-                        plist = []
-                        for pfmri, action in seen_conflicts:
-                                plist.append(str(pfmri))
-                                action_types.add((action, pfmri))
+        def variant_conflicts(mediator_list, lint_id):
+            """Look for conflicting variants across the given list,
+            allowing for pkg.linted values matching lint_id."""
+            conflicts = []
+            for pfmri, action in mediator_list:
+                # compare every action for this path to see if
+                # we have at least one variant conflict.  We
+                # need to do this individually since
+                # conflicting_variants(..) isn't mediator-aware
+                for pfm, ac in self.ref_paths[p]:
+                    if ac == action:
+                        continue
+                    if engine.linted(ac, lint_id=lint_id):
+                        continue
+                    conf_var, conf_ac = self.conflicting_variants(
+                        [ac, action], {}
+                    )
+                    for conf in conf_ac:
+                        conflicts.append((pfm, conf))
+            return conflicts
 
-                        plist = sorted(set(plist))
-                        engine.error(_("path {path} uses different "
-                            "mediator namespaces across actions in "
-                            "{fmris}").format(fmris=" ".join(plist),
-                            path=p), msgid=diff_id)
+        action_types = set([])
 
-                if missing_mediators:
-                        seen_conflicts = variant_conflicts(missing_mediators,
-                            missing_id)
-                        if seen_conflicts:
-                                plist = []
-                                ac_names = set([])
-                                for pfmri, action in seen_conflicts:
-                                        plist.append(str(pfmri))
-                                        action_types.add((action, pfmri))
-                                        ac_names.add(action.name)
+        seen_conflicts = variant_conflicts(different_namespaces, diff_id)
+        if seen_conflicts:
+            plist = []
+            for pfmri, action in seen_conflicts:
+                plist.append(str(pfmri))
+                action_types.add((action, pfmri))
 
-                                # if we have more than one action type, then
-                                # this error would only confuse. A user
-                                # mixing 'dir' and 'link' actions should not
-                                # be advised that adding a 'mediator' attribute
-                                # to their dir action would fix things.
-                                if len(ac_names) == 1:
-                                        plist = sorted(set(plist))
-                                        engine.error(_("path {path} has "
-                                            "missing mediator attributes "
-                                            "across actions in {fmris}").format(
-                                            fmris=" ".join(plist),
-                                            path=p), msgid=missing_id)
+            plist = sorted(set(plist))
+            engine.error(
+                _(
+                    "path {path} uses different "
+                    "mediator namespaces across actions in "
+                    "{fmris}"
+                ).format(fmris=" ".join(plist), path=p),
+                msgid=diff_id,
+            )
 
-                if len(set([ac.name for ac, pfmri in action_types])) > 1:
-                        plist = set([])
-                        for ac, pfmri in action_types:
-                                if not engine.linted(ac, lint_id=types_id):
-                                        plist.add(str(pfmri))
-                        if not plist:
-                                self.seen_mediated_links.append(p)
-                                return
-                        plist = sorted(plist)
-                        engine.error(_("path {path} uses multiple action "
-                            "types for potentially mediated links across "
-                            "actions in {fmris}").format(fmris=" ".join(plist),
-                            path=p), msgid=types_id)
+        if missing_mediators:
+            seen_conflicts = variant_conflicts(missing_mediators, missing_id)
+            if seen_conflicts:
+                plist = []
+                ac_names = set([])
+                for pfmri, action in seen_conflicts:
+                    plist.append(str(pfmri))
+                    action_types.add((action, pfmri))
+                    ac_names.add(action.name)
 
+                # if we have more than one action type, then
+                # this error would only confuse. A user
+                # mixing 'dir' and 'link' actions should not
+                # be advised that adding a 'mediator' attribute
+                # to their dir action would fix things.
+                if len(ac_names) == 1:
+                    plist = sorted(set(plist))
+                    engine.error(
+                        _(
+                            "path {path} has "
+                            "missing mediator attributes "
+                            "across actions in {fmris}"
+                        ).format(fmris=" ".join(plist), path=p),
+                        msgid=missing_id,
+                    )
+
+        if len(set([ac.name for ac, pfmri in action_types])) > 1:
+            plist = set([])
+            for ac, pfmri in action_types:
+                if not engine.linted(ac, lint_id=types_id):
+                    plist.add(str(pfmri))
+            if not plist:
                 self.seen_mediated_links.append(p)
+                return
+            plist = sorted(plist)
+            engine.error(
+                _(
+                    "path {path} uses multiple action "
+                    "types for potentially mediated links across "
+                    "actions in {fmris}"
+                ).format(fmris=" ".join(plist), path=p),
+                msgid=types_id,
+            )
 
-        mediated_links.pkglint_desc = _("Mediated-links should be valid.")
+        self.seen_mediated_links.append(p)
 
-        def _merge_dict(self, src, target, ignore_pubs=True):
-                """Merges the given src dictionary into the target
-                dictionary, giving us the target content as it would appear,
-                were the packages in src to get published to the
-                repositories that made up target.
+    mediated_links.pkglint_desc = _("Mediated-links should be valid.")
 
-                We need to only merge packages at the same or successive
-                version from the src dictionary into the target dictionary.
-                If the src dictionary contains a package with no version
-                information, it is assumed to be more recent than the same
-                package with no version in the target."""
+    def _merge_dict(self, src, target, ignore_pubs=True):
+        """Merges the given src dictionary into the target
+        dictionary, giving us the target content as it would appear,
+        were the packages in src to get published to the
+        repositories that made up target.
 
-                for p in src:
-                        if p not in target:
-                                target[p] = src[p]
-                                continue
+        We need to only merge packages at the same or successive
+        version from the src dictionary into the target dictionary.
+        If the src dictionary contains a package with no version
+        information, it is assumed to be more recent than the same
+        package with no version in the target."""
 
-                        def build_dic(arr):
-                                """Builds a dictionary of fmri:action entries"""
-                                dic = {}
-                                for (pfmri, action) in arr:
-                                        if pfmri in dic:
-                                                dic[pfmri].append(action)
-                                        else:
-                                                dic[pfmri] = [action]
-                                return dic
+        for p in src:
+            if p not in target:
+                target[p] = src[p]
+                continue
 
-                        src_dic = build_dic(src[p])
-                        targ_dic = build_dic(target[p])
+            def build_dic(arr):
+                """Builds a dictionary of fmri:action entries"""
+                dic = {}
+                for pfmri, action in arr:
+                    if pfmri in dic:
+                        dic[pfmri].append(action)
+                    else:
+                        dic[pfmri] = [action]
+                return dic
 
-                        for src_pfmri in src_dic:
-                                # we want to remove entries deemed older than
-                                # src_pfmri from targ_dic.
-                                for targ_pfmri in targ_dic.copy():
-                                        sname = src_pfmri.get_name()
-                                        tname = targ_pfmri.get_name()
-                                        if lint_fmri_successor(src_pfmri,
-                                            targ_pfmri,
-                                            ignore_pubs=ignore_pubs):
-                                                targ_dic.pop(targ_pfmri)
-                        targ_dic.update(src_dic)
-                        l = []
-                        for pfmri in targ_dic:
-                                for action in targ_dic[pfmri]:
-                                        l.append((pfmri, action))
-                        target[p] = l
+            src_dic = build_dic(src[p])
+            targ_dic = build_dic(target[p])
 
-        def _prune_overlays(self, actions, ref_dic, pkg_vars):
-                """Given a list of file actions that all deliver to the same
-                path, return that list minus any actions that are attempting to
-                use overlays. Also return a list of tuples containing any
-                overlay-related errors encountered, in the format:
+            for src_pfmri in src_dic:
+                # we want to remove entries deemed older than
+                # src_pfmri from targ_dic.
+                for targ_pfmri in targ_dic.copy():
+                    sname = src_pfmri.get_name()
+                    tname = targ_pfmri.get_name()
+                    if lint_fmri_successor(
+                        src_pfmri, targ_pfmri, ignore_pubs=ignore_pubs
+                    ):
+                        targ_dic.pop(targ_pfmri)
+            targ_dic.update(src_dic)
+            l = []
+            for pfmri in targ_dic:
+                for action in targ_dic[pfmri]:
+                    l.append((pfmri, action))
+            target[p] = l
 
-                    [ (<error msg>, <id>), ... ]
+    def _prune_overlays(self, actions, ref_dic, pkg_vars):
+        """Given a list of file actions that all deliver to the same
+        path, return that list minus any actions that are attempting to
+        use overlays. Also return a list of tuples containing any
+        overlay-related errors encountered, in the format:
 
-                """
+            [ (<error msg>, <id>), ... ]
 
-                if not actions:
-                        return [], []
+        """
 
-                path = actions[0].attrs["path"]
-                # action_fmris is a list of (fmri, action) tuples
-                action_fmris = ref_dic[path]
-                # When printing errors, we emit all FMRIs that are taking part
-                # in the duplication of this path.
-                fmris = sorted(set(
-                    [str(fmri) for fmri, action in action_fmris]))
+        if not actions:
+            return [], []
 
-                def _remove_attrs(action):
-                        """returns a string representation of the given action
-                        with all non-variant attributes other than path and
-                        overlay removed. Used for comparison of overlay actions.
-                        """
-                        action_copy = copy.deepcopy(action)
-                        for key in action_copy.attrs.keys():
-                                if key in ["path", "overlay"]:
-                                        continue
-                                elif key.startswith("variant"):
-                                        continue
-                                else:
-                                        del action_copy.attrs[key]
-                        return str(action_copy)
+        path = actions[0].attrs["path"]
+        # action_fmris is a list of (fmri, action) tuples
+        action_fmris = ref_dic[path]
+        # When printing errors, we emit all FMRIs that are taking part
+        # in the duplication of this path.
+        fmris = sorted(set([str(fmri) for fmri, action in action_fmris]))
 
-                def _get_fmri(action, action_fmris):
-                        """return the fmri for a given action."""
-                        for fmri, ac in action_fmris:
-                                if action == ac:
-                                        return fmri
+        def _remove_attrs(action):
+            """returns a string representation of the given action
+            with all non-variant attributes other than path and
+            overlay removed. Used for comparison of overlay actions.
+            """
+            action_copy = copy.deepcopy(action)
+            for key in action_copy.attrs.keys():
+                if key in ["path", "overlay"]:
+                    continue
+                elif key.startswith("variant"):
+                    continue
+                else:
+                    del action_copy.attrs[key]
+            return str(action_copy)
 
-                # buckets for actions according to their overlay attribute value
-                # any actions that do not specify overlay attributes, or use
-                # them incorrectly get put into ret_actions, and returned for
-                # our generic duplicate-attribute code to deal with.
-                allow_overlay = []
-                overlay = []
-                ret_actions = []
+        def _get_fmri(action, action_fmris):
+            """return the fmri for a given action."""
+            for fmri, ac in action_fmris:
+                if action == ac:
+                    return fmri
 
-                errors = set()
+        # buckets for actions according to their overlay attribute value
+        # any actions that do not specify overlay attributes, or use
+        # them incorrectly get put into ret_actions, and returned for
+        # our generic duplicate-attribute code to deal with.
+        allow_overlay = []
+        overlay = []
+        ret_actions = []
 
-                # sort our list of actions into the corresponding bucket
-                for action in actions:
-                        overlay_attr = action.attrs.get("overlay", None)
-                        if overlay_attr and overlay_attr == "allow":
-                                if not action.attrs.get("preserve", None):
-                                        errors.add(
-                                            (_("path {path} missing "
-                                            "'preserve' attribute for "
-                                            "'overlay=allow' action "
-                                            "in {fmri}").format(path=path,
-                                            fmri=_get_fmri(
-                                            action, action_fmris)), "1"))
-                                else:
-                                        allow_overlay.append(action)
+        errors = set()
 
-                        elif overlay_attr and overlay_attr == "true":
-                                overlay.append(action)
-                        else:
-                                ret_actions.append(action)
+        # sort our list of actions into the corresponding bucket
+        for action in actions:
+            overlay_attr = action.attrs.get("overlay", None)
+            if overlay_attr and overlay_attr == "allow":
+                if not action.attrs.get("preserve", None):
+                    errors.add(
+                        (
+                            _(
+                                "path {path} missing "
+                                "'preserve' attribute for "
+                                "'overlay=allow' action "
+                                "in {fmri}"
+                            ).format(
+                                path=path, fmri=_get_fmri(action, action_fmris)
+                            ),
+                            "1",
+                        )
+                    )
+                else:
+                    allow_overlay.append(action)
 
-                if not (overlay or allow_overlay):
-                        return actions, []
+            elif overlay_attr and overlay_attr == "true":
+                overlay.append(action)
+            else:
+                ret_actions.append(action)
 
-                def _render_variants(conflict_vars):
-                        """pretty print a group of variants"""
-                        vars = set()
-                        for group in conflict_vars:
-                                for key, val in group:
-                                        vars.add("{0}={1}".format(key, val))
-                        return ", ".join(list(vars))
+        if not (overlay or allow_overlay):
+            return actions, []
 
-                def _unique_attrs(action):
-                        """return a dictionary containing only attrs that must
-                        be unique across overlay actions."""
-                        attrs = {}
-                        for key in FileAction.unique_attrs:
-                                if key == "preserve":
-                                        continue
-                                attrs[key] = action.attrs.get(key, None)
-                        return attrs
+        def _render_variants(conflict_vars):
+            """pretty print a group of variants"""
+            vars = set()
+            for group in conflict_vars:
+                for key, val in group:
+                    vars.add("{0}={1}".format(key, val))
+            return ", ".join(list(vars))
 
-                # Ensure none of the groups of overlay actions have
-                # conflicting variants within them.
-                conflict_vars, conflict_overlays = self.conflicting_variants(
-                    overlay, pkg_vars)
-                if conflict_vars:
-                        errors.add(
-                            (_("path {path} has duplicate 'overlay=true' "
-                            "actions for the following variants across across "
-                            "{fmris}: {var}").format(
-                            path=path, fmris=", ".join(list(fmris)),
-                            var=_render_variants(conflict_vars)), "2"))
+        def _unique_attrs(action):
+            """return a dictionary containing only attrs that must
+            be unique across overlay actions."""
+            attrs = {}
+            for key in FileAction.unique_attrs:
+                if key == "preserve":
+                    continue
+                attrs[key] = action.attrs.get(key, None)
+            return attrs
 
-                # verify that if we're only delivering overlay=allow actions,
-                # none of them conflict with each other (we check corresponding
-                # overlay=true actions, if any, later)
-                if not overlay:
-                        conflict_vars, conflict_overlays = \
-                            self.conflicting_variants(allow_overlay, pkg_vars)
-                        if conflict_vars:
-                                errors.add(
-                                    (_("path {path} has duplicate "
-                                    "'overlay=allow' actions for the following "
-                                    "variants across across "
-                                    "{fmris}: {var}").format(
-                                    path=path, fmris=", ".join(
-                                    list(fmris)),
-                                    var=_render_variants(conflict_vars)),
-                                    "3"))
+        # Ensure none of the groups of overlay actions have
+        # conflicting variants within them.
+        conflict_vars, conflict_overlays = self.conflicting_variants(
+            overlay, pkg_vars
+        )
+        if conflict_vars:
+            errors.add(
+                (
+                    _(
+                        "path {path} has duplicate 'overlay=true' "
+                        "actions for the following variants across across "
+                        "{fmris}: {var}"
+                    ).format(
+                        path=path,
+                        fmris=", ".join(list(fmris)),
+                        var=_render_variants(conflict_vars),
+                    ),
+                    "2",
+                )
+            )
 
-                # Check for valid, complimentary sets of overlay and
-                # allow_overlay actions.
-                seen_mismatch = False
-                for a1 in overlay:
-                        # Our assertions on how to detect clashing overlay +
-                        # allow_overlay actions:
-                        #
-                        # 1. each overlay action must have at least one conflict
-                        #    from the set of allow_overlay actions.
-                        #
-                        # 2. from that set of conflicts, when we remove the
-                        #    overlay action itself, there must be no conflicts
-                        #    within that set of overlay=allow actions.
-                        #
-                        # 3. all attributes required to be the same between
-                        #    complimentary sets of allow_overlay and overlay
-                        #    actions are the same.
+        # verify that if we're only delivering overlay=allow actions,
+        # none of them conflict with each other (we check corresponding
+        # overlay=true actions, if any, later)
+        if not overlay:
+            conflict_vars, conflict_overlays = self.conflicting_variants(
+                allow_overlay, pkg_vars
+            )
+            if conflict_vars:
+                errors.add(
+                    (
+                        _(
+                            "path {path} has duplicate "
+                            "'overlay=allow' actions for the following "
+                            "variants across across "
+                            "{fmris}: {var}"
+                        ).format(
+                            path=path,
+                            fmris=", ".join(list(fmris)),
+                            var=_render_variants(conflict_vars),
+                        ),
+                        "3",
+                    )
+                )
 
-                        conflict_vars, conflict_actions = \
-                            self.conflicting_variants([a1] + allow_overlay,
-                            pkg_vars)
+        # Check for valid, complimentary sets of overlay and
+        # allow_overlay actions.
+        seen_mismatch = False
+        for a1 in overlay:
+            # Our assertions on how to detect clashing overlay +
+            # allow_overlay actions:
+            #
+            # 1. each overlay action must have at least one conflict
+            #    from the set of allow_overlay actions.
+            #
+            # 2. from that set of conflicts, when we remove the
+            #    overlay action itself, there must be no conflicts
+            #    within that set of overlay=allow actions.
+            #
+            # 3. all attributes required to be the same between
+            #    complimentary sets of allow_overlay and overlay
+            #    actions are the same.
 
-                        if conflict_actions:
-                                conflict_actions.remove(a1)
-                                conflict_vars_sub, conflict_actions_allow = \
-                                    self.conflicting_variants(conflict_actions,
-                                    pkg_vars)
+            conflict_vars, conflict_actions = self.conflicting_variants(
+                [a1] + allow_overlay, pkg_vars
+            )
 
-                                if conflict_actions_allow:
-                                        errors.add(
-                                            (_("path {path} uses "
-                                            "overlay='true' actions but has "
-                                            "duplicate 'overlay=allow' actions "
-                                            "for the following variants across "
-                                            "{fmris}: {vars}").format(
-                                            path=path,
-                                            fmris=", ".join(list(fmris)),
-                                            vars=_render_variants(
-                                            conflict_vars_sub)), "4"))
-                                else:
-                                        # check that none of the attributes
-                                        # required to be the same between
-                                        # overlay and allow actions differ.
-                                        a1_attrs = _unique_attrs(a1)
-                                        for a2 in conflict_actions:
-                                                if a1_attrs != _unique_attrs(
-                                                    a2):
-                                                        seen_mismatch = True
-                        else:
-                                errors.add(
-                                    (_("path {path} uses 'overlay=true' "
-                                    "actions but has no corresponding "
-                                    "'overlay=allow' actions across {fmris}"
-                                    ).format(
-                                    path=path, fmris=", ".join(
-                                    list(fmris))), "5"))
+            if conflict_actions:
+                conflict_actions.remove(a1)
+                (
+                    conflict_vars_sub,
+                    conflict_actions_allow,
+                ) = self.conflicting_variants(conflict_actions, pkg_vars)
 
-                if seen_mismatch:
-                        errors.add(
-                            (_("path {path} has mismatching attributes for "
-                            "'overlay=true' and 'overlay=allow' action-pairs "
-                            "across {fmris}").format(path=path,
-                            fmris=", ".join(list(fmris))), "6"))
+                if conflict_actions_allow:
+                    errors.add(
+                        (
+                            _(
+                                "path {path} uses "
+                                "overlay='true' actions but has "
+                                "duplicate 'overlay=allow' actions "
+                                "for the following variants across "
+                                "{fmris}: {vars}"
+                            ).format(
+                                path=path,
+                                fmris=", ".join(list(fmris)),
+                                vars=_render_variants(conflict_vars_sub),
+                            ),
+                            "4",
+                        )
+                    )
+                else:
+                    # check that none of the attributes
+                    # required to be the same between
+                    # overlay and allow actions differ.
+                    a1_attrs = _unique_attrs(a1)
+                    for a2 in conflict_actions:
+                        if a1_attrs != _unique_attrs(a2):
+                            seen_mismatch = True
+            else:
+                errors.add(
+                    (
+                        _(
+                            "path {path} uses 'overlay=true' "
+                            "actions but has no corresponding "
+                            "'overlay=allow' actions across {fmris}"
+                        ).format(path=path, fmris=", ".join(list(fmris))),
+                        "5",
+                    )
+                )
 
-                if (overlay or allow_overlay) and ret_actions:
-                        errors.add(
-                            (_("path {path} has both overlay and non-overlay "
-                            "actions across {fmris}").format(
-                            path=path, fmris=", ".join(list(fmris))),
-                            "7"))
+        if seen_mismatch:
+            errors.add(
+                (
+                    _(
+                        "path {path} has mismatching attributes for "
+                        "'overlay=true' and 'overlay=allow' action-pairs "
+                        "across {fmris}"
+                    ).format(path=path, fmris=", ".join(list(fmris))),
+                    "6",
+                )
+            )
 
-                return ret_actions, errors
+        if (overlay or allow_overlay) and ret_actions:
+            errors.add(
+                (
+                    _(
+                        "path {path} has both overlay and non-overlay "
+                        "actions across {fmris}"
+                    ).format(path=path, fmris=", ".join(list(fmris))),
+                    "7",
+                )
+            )
 
-        def dir_parents(self, action, manifest, engine, pkglint_id="011"):
-                """Checks that if any paths are delivered by this action, and
-                if we know about the parent path, that parent must be a
-                directory."""
+        return ret_actions, errors
 
-                if "path" not in action.attrs:
-                        return
-                path = action.attrs["path"]
-                parent_path = os.path.dirname(path)
-                parents = self.ref_paths.get(parent_path, None)
-                if not parents:
-                        return
-                for parent_pfmri, parent_action in parents:
-                        if parent_action.name == "dir":
-                                continue
-                        # check for conflicting variants - if the parent and
-                        # child paths can't be installed together, then this
-                        # is allowed.
-                        conflict_vars, conflict_actions = \
-                            self.conflicting_variants([action, parent_action],
-                            manifest.get_all_variants())
-                        if not conflict_actions:
-                                continue
-                        engine.error(_("Expecting a dir action for "
-                            "{parent_path}, but {parent_fmri} delivers it "
-                            "as a {parent_type}. {child_path} is delivered "
-                            "by {child_fmri}").format(
-                            parent_path=parent_path,
-                            parent_fmri=parent_pfmri,
-                            parent_type=parent_action.name,
-                            child_path=path,
-                            child_fmri=manifest.fmri),
-                            "{0}{1}".format(self.name, pkglint_id))
+    def dir_parents(self, action, manifest, engine, pkglint_id="011"):
+        """Checks that if any paths are delivered by this action, and
+        if we know about the parent path, that parent must be a
+        directory."""
 
-        dir_parents.pkglint_desc = _("Parent paths should be directories.")
+        if "path" not in action.attrs:
+            return
+        path = action.attrs["path"]
+        parent_path = os.path.dirname(path)
+        parents = self.ref_paths.get(parent_path, None)
+        if not parents:
+            return
+        for parent_pfmri, parent_action in parents:
+            if parent_action.name == "dir":
+                continue
+            # check for conflicting variants - if the parent and
+            # child paths can't be installed together, then this
+            # is allowed.
+            conflict_vars, conflict_actions = self.conflicting_variants(
+                [action, parent_action], manifest.get_all_variants()
+            )
+            if not conflict_actions:
+                continue
+            engine.error(
+                _(
+                    "Expecting a dir action for "
+                    "{parent_path}, but {parent_fmri} delivers it "
+                    "as a {parent_type}. {child_path} is delivered "
+                    "by {child_fmri}"
+                ).format(
+                    parent_path=parent_path,
+                    parent_fmri=parent_pfmri,
+                    parent_type=parent_action.name,
+                    child_path=path,
+                    child_fmri=manifest.fmri,
+                ),
+                "{0}{1}".format(self.name, pkglint_id),
+            )
+
+    dir_parents.pkglint_desc = _("Parent paths should be directories.")
 
 
 class PkgActionChecker(base.ActionChecker):
-
-        name = "pkglint.action"
-
-        def __init__(self, config):
-                self.description = _("Various checks on actions")
-
-                # a list of fmris which were declared as dependencies, but
-                # which we weren't able to locate a manifest for.
-                self.missing_deps = []
-
-                # maps package names to tuples of (obsolete, fmri) values where
-                # 'obsolete' is a boolean, True if the package is obsolete
-                self.obsolete_pkgs = {}
-                super(PkgActionChecker, self).__init__(config)
-
-        def startup(self, engine):
-                """Cache all manifest FMRIs, tracking whether they're
-                obsolete or not."""
-
-
-                def seed_obsolete_dict(mf, dic):
-                        """Updates a dictionary of { pkg_name: ObsoleteFmri }
-                        items, tracking which were marked as obsolete."""
-
-                        name = mf.fmri.get_name()
-
-                        if "pkg.obsolete" in mf and \
-                            mf["pkg.obsolete"].lower() == "true":
-                                dic[name] = ObsoleteFmri(True, mf.fmri)
-                        elif "pkg.renamed" not in mf or \
-                            mf["pkg.renamed"].lower() == "false":
-                                # we can't yet tell if a renamed
-                                # package gets obsoleted further down
-                                # its rename chain, so don't decide now
-                                dic[name] = ObsoleteFmri(False, mf.fmri)
-
-                engine.logger.debug(_("Seeding reference action dictionaries."))
-                for manifest in engine.gen_manifests(engine.ref_api_inst,
-                    release=engine.release):
-                        seed_obsolete_dict(manifest, self.obsolete_pkgs)
-
-                engine.logger.debug(_("Seeding lint action dictionaries."))
-                # we provide a search pattern, to allow users to lint a
-                # subset of the packages in the lint_repository
-                for manifest in engine.gen_manifests(engine.lint_api_inst,
-                    release=engine.release, pattern=engine.pattern):
-                        seed_obsolete_dict(manifest, self.obsolete_pkgs)
-
-                engine.logger.debug(_("Seeding local action dictionaries."))
-                for manifest in engine.lint_manifests:
-                        seed_obsolete_dict(manifest, self.obsolete_pkgs)
-
-        def underscores(self, action, manifest, engine, pkglint_id="001"):
-                """In general, pkg(7) discourages the use of underscores in
-                attributes."""
-
-                for key in action.attrs.keys():
-                        if "_" in key:
-                                if (key in ["original_name", "refresh_fmri",
-                                    "restart_fmri", "suspend_fmri",
-                                    "disable_fmri", "clone_perms"] or
-                                        key.startswith("facet.locale.") or
-                                        key.startswith("facet.version-lock.") or
-                                        key.startswith("pkg.")):
-                                        continue
-                                engine.warning(
-                                    _("underscore in attribute name {key} in "
-                                    "{fmri}").format(
-                                    key=key,
-                                    fmri=manifest.fmri),
-                                    msgid="{0}{1}.1".format(self.name,
-                                    pkglint_id))
-
-                if action.name != "set":
-                        return
-
-                name = action.attrs["name"]
-
-                if "_" not in name:
-                        return
-
-                obs_map = {
-                    "info.maintainer_url": "info.maintainer-url",
-                    "info.upstream_url": "info.upstream-url",
-                    "info.source_url": "info.source-url",
-                    "info.repository_url": "info.repository-url",
-                    "info.repository_changeset": "info.repository-changeset",
-                    "info.defect_tracker.url": "info.defect-tracker.url",
-                    "opensolaris.arc_url": "org.opensolaris.caseid"
-                }
-
-                # These names are deprecated, and so we warn, but we're a tiny
-                # bit nicer about it.
-                if name in obs_map:
-                        engine.warning(_("underscore in obsolete 'set' action "
-                            "name {name} should be {new} in {fmri}").format(
-                                name=name,
-                                new=obs_map[name],
-                                fmri=manifest.fmri
-                           ),
-                            msgid="{0}{1}.3".format(self.name, pkglint_id))
-                        return
-
-                engine.warning(_("underscore in 'set' action name {name} in "
-                    "{fmri}").format(name=name,
-                    fmri=manifest.fmri),
-                    msgid="{0}{1}.2".format(self.name, pkglint_id))
-
-        underscores.pkglint_desc = _(
-            "Underscores are discouraged in action attributes.")
-
-        def unusual_perms(self, action, manifest, engine, pkglint_id="002"):
-                """Checks that the permissions in this action look sane."""
-
-                if "mode" in action.attrs:
-                        mode = action.attrs["mode"]
-                        path = action.attrs["path"]
-                        st = None
-                        try:
-                                st = stat.S_IMODE(int(mode, 8))
-                        except ValueError:
-                                pass
-
-                        if action.name == "dir":
-                                # check for at least one executable bit
-                                if st and \
-                                    (stat.S_IXUSR & st or stat.S_IXGRP & st
-                                    or stat.S_IXOTH & st):
-                                        pass
-                                elif st:
-                                        engine.warning(_("directory action for "
-                                            "{path} delivered in {pkg} with "
-                                            "mode={mode} "
-                                            "that has no executable bits").format(
-                                            path=path,
-                                            pkg=manifest.fmri,
-                                            mode=mode),
-                                            msgid="{0}{1}.1".format(
-                                            self.name, pkglint_id))
-
-                        if not st:
-                                engine.error(_("broken mode mode={mode} "
-                                    "delivered in action for {path} in "
-                                    "{pkg}").format(
-                                    path=path,
-                                    pkg=manifest.fmri,
-                                    mode=mode),
-                                    msgid="{0}{1}.2".format(self.name,
-                                    pkglint_id))
-
-                        if len(mode) < 3:
-                                engine.error(_("mode={mode} is too short in "
-                                    "action for {path} in {pkg}").format(
-                                    path=path,
-                                    pkg=manifest.fmri,
-                                    mode=mode),
-                                    msgid="{0}{1}.3".format(self.name,
-                                    pkglint_id))
-                                return
-
-                        # now check for individual access permissions
-                        user = mode[-3]
-                        group = mode[-2]
-                        other = mode[-1]
-
-                        if (other > group or
-                            group > user or
-                            other > user):
-                                engine.warning(_("unusual mode mode={mode} "
-                                    "delivered in action for {path} in "
-                                    "{pkg}").format(
-                                    path=path,
-                                    pkg=manifest.fmri,
-                                    mode=mode),
-                                    msgid="{0}{1}.4".format(self.name,
-                                    pkglint_id))
-
-        unusual_perms.pkglint_desc = _(
-            "Paths should not have unusual permissions.")
-
-        def legacy(self, action, manifest, engine, pkglint_id="003"):
-                """Cross-check that the 'pkg' attribute points to a package
-                that depends on the package containing this legacy action.
-                Also check that all the required tags are present on this
-                legacy action."""
-
-                if action.name != "legacy":
-                        return
-
-                name = manifest.fmri.get_name()
-
-                for required in [ "category", "desc", "hotline", "name",
-                    "pkg", "vendor", "version" ]:
-                        if required not in action.attrs:
-                                engine.error(
-                                    _("{attr} missing from legacy "
-                                    "action in {pkg}").format(
-                                    attr=required,
-                                    pkg=manifest.fmri),
-                                    msgid="{0}{1}.1".format(self.name,
-                                    pkglint_id))
-
-                if "pkg" in action.attrs:
-
-                        legacy = engine.get_manifest(action.attrs["pkg"],
-                            search_type=engine.LATEST_SUCCESSOR)
-                        # Some legacy ancestor packages never existed as pkg(7)
-                        # stubs
-                        if legacy:
-                                self.check_legacy_rename(legacy, action,
-                                    manifest, engine, pkglint_id)
-
-                if "version" in action.attrs:
-                        # this could be refined
-                        if "REV=" not in action.attrs["version"]:
-                                engine.warning(
-                                    _("legacy action in {0} does not "
-                                    "contain a REV= string").format(
-                                    manifest.fmri),
-                                    msgid="{0}{1}.3".format(self.name,
-                                    pkglint_id))
-
-        def check_legacy_rename(self, legacy, action, manifest, engine,
-            lint_id):
-                """Part of the legacy(..) check, not an individual check.
-                Given a legacy action, if the package pointed to by the 'pkg'
-                attribute of that action exists (say pkg=SUNWlegacy), we check
-                that a user who types:
-
-                pkg install SUNWlegacy
-
-                gets the package containing the legacy action installed on their
-                system, possibly following renames along the way.
-
-                legacy          A package manifest with the same name as the
-                                'pkg' attribute of the legacy action
-                action          The legacy action we're investigating
-                manifest        The manifest we're investigating
-                engine          Our lint engine
-                lint_id         The id of this check
-                """
-
-                if "pkg.renamed" in legacy and \
-                    legacy["pkg.renamed"].lower() == "true":
-                        mf = None
-                        try:
-                                mf = engine.follow_renames(action.attrs["pkg"],
-                                    target=manifest.fmri, old_mfs=[],
-                                    legacy=True)
-                        except base.LintException as e:
-                                # we've tried to rename to ourselves
-                                engine.error(
-                                    _("legacy renaming: {0}").format(str(e)),
-                                    msgid="{0}{1}.5".format(self.name, lint_id))
-                                return
-
-                        if mf is None:
-                                engine.error(_("legacy package {legacy} did "
-                                    "not result in a dependency on {pkg} when"
-                                    " following package renames").format(
-                                    legacy=legacy.fmri,
-                                    pkg=manifest.fmri),
-                                    msgid="{0}{1}.4".format(
-                                    self.name, lint_id))
-
-                        elif not lint_fmri_successor(manifest.fmri, mf.fmri,
-                            ignore_pubs=engine.ignore_pubs):
-                                engine.error(_("legacy package {legacy} did "
-                                    "not result in a dependency on {pkg}").format(
-                                    legacy=legacy.fmri,
-                                    pkg=manifest.fmri),
-                                    msgid="{0}{1}.2".format(
-                                    self.name, lint_id))
-
-        legacy.pkglint_desc = _(
-            "'legacy' actions should have valid attributes.")
-
-        def unknown(self, action, manifest, engine, pkglint_id="004"):
-                """We should never have actions called 'unknown'."""
-
-                if action.name == "unknown":
-                        engine.error(_("unknown action found in {0}").format(
-                            manifest.fmri),
-                            msgid="{0}{1}".format(self.name, pkglint_id))
-
-        unknown.pkglint_desc = _("'unknown' actions should never occur.")
-
-        def dep_obsolete(self, action, manifest, engine, pkglint_id="005"):
-                """We should not have a require dependency on a package that has
-                been marked as obsolete.
-
-                This check also produces warnings when it is unable to find
-                manifests marked as dependencies for a given package in order
-                to check for their obsoletion.  This can help to detect errors
-                in the fmri attribute field of the depend action, though can be
-                noisy if all dependencies are intentionally not present in the
-                repository being linted or referenced.
-
-                The pkglint paramater pkglint.action005.1.missing-deps can be
-                used to declare which fmris we know could be missing, and for
-                which we should not emit a warning message if those manifests
-                are not available.
-                """
-
-                msg = _("dependency on obsolete package in {0}:")
-
-                if action.name != "depend":
-                        return
-
-                if action.attrs["type"] != "require":
-                        return
-
-                # We check for renames as part of pkglint.manifest002.5, so
-                # don't do that here.
-                if "pkg.renamed" in manifest and \
-                    manifest["pkg.renamed"].lower() == "true":
-                        return
-
-                name = None
-                declared_fmri = None
-                dep_fmri = action.attrs["fmri"]
-
-                # normalize the fmri
-                if not dep_fmri.startswith("pkg:/"):
-                        dep_fmri = "pkg:/{0}".format(dep_fmri)
-
-                try:
-                        declared_fmri = pkg.fmri.PkgFmri(dep_fmri)
-                        name = declared_fmri.get_name()
-                except pkg.fmri.IllegalFmri:
-                        try:
-                                declared_fmri = pkg.fmri.PkgFmri(dep_fmri)
-                                name = declared_fmri.get_name()
-                        except:
-                                # A very broken fmri value - we'll give up now.
-                                # valid_fmri() will pick up the trail from here.
-                                return
-
-                # if we've been unable to find a dependency for a given
-                # fmri in the past, no need to keep complaining about it
-                if dep_fmri in self.missing_deps:
-                        return
-
-                # There's a good chance that dependencies can be satisfied from
-                # the manifests we cached during startup() Check there first.
-                if name and name in self.obsolete_pkgs:
-
-                        if not self.obsolete_pkgs[name].is_obsolete:
-                                # the cached package is not obsolete, but we'll
-                                # verify the version is valid
-                                found_fmri = self.obsolete_pkgs[name].fmri
-                                if not declared_fmri.has_version():
-                                        return
-                                elif lint_fmri_successor(found_fmri,
-                                    declared_fmri,
-                                    ignore_pubs=engine.ignore_pubs):
-                                        return
-
-                # A non-obsolete dependency wasn't found in the local cache,
-                # or the one in the cache was found not to be a successor of
-                # the fmri in the depend action.
-                lint_id = "{0}{1}".format(self.name, pkglint_id)
-
-                mf = None
-                found_obsolete = False
-                try:
-                        mf = engine.follow_renames(
-                            dep_fmri, old_mfs=[], warn_on_obsolete=True)
-                except base.LintException as err:
-                        found_obsolete = True
-                        engine.error("{0} {1}".format(msg.format(manifest.fmri),
-                            err), msgid=lint_id)
-
-                # We maintain a whitelist of dependencies which may be missing
-                # during this lint run (eg. packages that are present in a
-                # different repository)  Consult that list before complaining
-                # about each fmri being missing.
-
-                # If unversioned FMRIs are present in the list, versioned
-                # dependencies will match those if their package name and
-                # publisher match.
-                known_missing_deps = engine.get_param(
-                    "{0}.1.missing-deps".format(lint_id), action=action,
-                    manifest=manifest)
-                if known_missing_deps:
-                        known_missing_deps = known_missing_deps.split(" ")
-                else:
-                        known_missing_deps = []
-
-                if not mf and not found_obsolete:
-                        self.missing_deps.append(dep_fmri)
-                        if dep_fmri in known_missing_deps:
-                                return
-                        if "@" in dep_fmri and \
-                            dep_fmri.split("@")[0] in known_missing_deps:
-                                return
-                        engine.warning(_("obsolete dependency check "
-                            "skipped: unable to find dependency {dep}"
-                            " for {pkg}").format(
-                            dep=dep_fmri,
-                            pkg=manifest.fmri),
-                            msgid="{0}.1".format(lint_id))
-
-        dep_obsolete.pkglint_desc = _(
-            "Packages should not have dependencies on obsolete packages.")
-
-        def valid_fmri(self, action, manifest, engine, pkglint_id="006"):
-                """We should be given a valid FMRI as a dependency, allowing
-                for a potentially missing component value"""
-
-                if "fmri" not in action.attrs:
-                        return
-                fmris = action.attrs["fmri"]
-                if isinstance(fmris, six.string_types):
-                        fmris = [fmris]
-
-                for fmri in fmris:
-                        try:
-                                pfmri = pkg.fmri.PkgFmri(fmri)
-                        except pkg.fmri.IllegalFmri:
-                                # we also need to just verify that the fmri
-                                # isn't just missing a build_release value
-                                try:
-                                        pfmri = pkg.fmri.PkgFmri(fmri)
-                                except pkg.fmri.IllegalFmri:
-                                        engine.error("invalid FMRI in action "
-                                            "{action} in {pkg}".format(
-                                            pkg=manifest.fmri,
-                                            action=action),
-                                            msgid="{0}{1}".format(
-                                            self.name, pkglint_id))
-
-        valid_fmri.pkglint_desc = _("pkg(7) FMRIs should be valid.")
-
-        def license(self, action, manifest, engine, pkglint_id="007"):
-                """License actions should not have path attributes."""
-
-                if action.name == "license" and "path" in action.attrs:
-                        engine.error(
-                            _("license action in {pkg} has a path attribute, "
-                            "{path}").format(
-                            pkg=manifest.fmri,
-                            path=action.attrs["path"]),
-                            msgid="{0}{1}".format(self.name, pkglint_id))
-
-        license.pkglint_desc = _("'license' actions should not have paths.")
-
-        def linted(self, action, manifest, engine, pkglint_id="008"):
-                """Log an INFO message with the key/value pairs of all
-                pkg.linted* attributes set on this action.
-
-                Essentially this exists to prevent users from adding
-                pkg.linted values to manifests that don't really need them."""
-
-                linted_attrs = [(key, action.attrs[key])
-                    for key in sorted(action.attrs.keys())
-                    if key.startswith("pkg.linted")]
-
-                if linted_attrs:
-                        engine.info(_("pkg.linted attributes detected for "
-                            "{pkg} {action}: {linted}").format(
-                            pkg=manifest.fmri,
-                            action=str(action),
-                            linted=", ".join(["{0}={1}".format(key, val)
-                             for key,val in linted_attrs])),
-                             msgid="{0}{1}".format(self.name, pkglint_id),
-                             ignore_linted=True)
-
-        linted.pkglint_desc = _("Show actions with pkg.linted attributes.")
-
-        def validate(self, action, manifest, engine, pkglint_id="009"):
-                """Validate all actions."""
-                if not engine.do_pub_checks:
-                        return
-                try:
-                        action.validate()
-                except ActionError as err:
-                        # we want the details all on one line to
-                        # stay consistent with the rest of the pkglint
-                        # error messaging
-                        details = "; ".join([val.lstrip()
-                            for val in str(err).split("\n")])
-                        engine.error(
-                            _("Publication error with action in {pkg}: "
-                            "{details}").format(
-                            pkg=manifest.fmri, details=details),
-                            msgid="{0}{1}".format(self.name, pkglint_id))
-
-        validate.pkglint_desc = _("Publication checks for actions.")
-
-        def username_format(self, action, manifest, engine, pkglint_id="010"):
-                """Checks username length, and format."""
-
-                if action.name != "user":
-                        return
-
-                username = action.attrs["username"]
-
-                if len(username) == 0:
-                        engine.error(
-                            _("username attribute value must be set "
-                            "in {pkg}").format(pkg=manifest.fmri),
-                            msgid="{0}{1}.4".format(self.name, pkglint_id))
-                        return
-
-                if len(username) > 32:
-                        engine.error(
-                            _("Username {name} in {pkg} > 32 chars").format(
-                            name=username,
-                            pkg=manifest.fmri),
-                            msgid="{0}{1}.1".format(self.name, pkglint_id))
-
-                if not re.match(r"[a-z].*", username):
-                        engine.warning(
-                            _("Username {name} in {pkg} does not have an "
-                            "initial lower-case alphabetical "
-                            "character").format(
-                            name=username,
-                            pkg=manifest.fmri),
-                            msgid="{0}{1}.2".format(self.name, pkglint_id))
-
-                if len(username)> 0 and not \
-                    re.match(r"^[a-z]([a-zA-Z0-9._-])*$", username):
-                        engine.warning(
-                            _("Username {name} in {pkg} is discouraged - see "
-                            "passwd(5)").format(
-                            name=username,
-                            pkg=manifest.fmri),
-                            msgid="{0}{1}.3".format(self.name, pkglint_id))
-
-        username_format.pkglint_desc = _("User names should be valid.")
-
-        def version_incorporate(self, action, manifest, engine,
-            pkglint_id="011"):
-                """Checks that 'incorporate' dependencies have a version."""
-
-                if action.name != "depend":
-                        return
-                if action.attrs.get("type") != "incorporate":
-                        return
-
-                fmri = action.attrs["fmri"]
+    name = "pkglint.action"
+
+    def __init__(self, config):
+        self.description = _("Various checks on actions")
+
+        # a list of fmris which were declared as dependencies, but
+        # which we weren't able to locate a manifest for.
+        self.missing_deps = []
+
+        # maps package names to tuples of (obsolete, fmri) values where
+        # 'obsolete' is a boolean, True if the package is obsolete
+        self.obsolete_pkgs = {}
+        super(PkgActionChecker, self).__init__(config)
+
+    def startup(self, engine):
+        """Cache all manifest FMRIs, tracking whether they're
+        obsolete or not."""
+
+        def seed_obsolete_dict(mf, dic):
+            """Updates a dictionary of { pkg_name: ObsoleteFmri }
+            items, tracking which were marked as obsolete."""
+
+            name = mf.fmri.get_name()
+
+            if "pkg.obsolete" in mf and mf["pkg.obsolete"].lower() == "true":
+                dic[name] = ObsoleteFmri(True, mf.fmri)
+            elif (
+                "pkg.renamed" not in mf or mf["pkg.renamed"].lower() == "false"
+            ):
+                # we can't yet tell if a renamed
+                # package gets obsoleted further down
+                # its rename chain, so don't decide now
+                dic[name] = ObsoleteFmri(False, mf.fmri)
+
+        engine.logger.debug(_("Seeding reference action dictionaries."))
+        for manifest in engine.gen_manifests(
+            engine.ref_api_inst, release=engine.release
+        ):
+            seed_obsolete_dict(manifest, self.obsolete_pkgs)
+
+        engine.logger.debug(_("Seeding lint action dictionaries."))
+        # we provide a search pattern, to allow users to lint a
+        # subset of the packages in the lint_repository
+        for manifest in engine.gen_manifests(
+            engine.lint_api_inst, release=engine.release, pattern=engine.pattern
+        ):
+            seed_obsolete_dict(manifest, self.obsolete_pkgs)
+
+        engine.logger.debug(_("Seeding local action dictionaries."))
+        for manifest in engine.lint_manifests:
+            seed_obsolete_dict(manifest, self.obsolete_pkgs)
+
+    def underscores(self, action, manifest, engine, pkglint_id="001"):
+        """In general, pkg(7) discourages the use of underscores in
+        attributes."""
+
+        for key in action.attrs.keys():
+            if "_" in key:
+                if (
+                    key
+                    in [
+                        "original_name",
+                        "refresh_fmri",
+                        "restart_fmri",
+                        "suspend_fmri",
+                        "disable_fmri",
+                        "clone_perms",
+                    ]
+                    or key.startswith("facet.locale.")
+                    or key.startswith("facet.version-lock.")
+                    or key.startswith("pkg.")
+                ):
+                    continue
+                engine.warning(
+                    _("underscore in attribute name {key} in " "{fmri}").format(
+                        key=key, fmri=manifest.fmri
+                    ),
+                    msgid="{0}{1}.1".format(self.name, pkglint_id),
+                )
+
+        if action.name != "set":
+            return
+
+        name = action.attrs["name"]
+
+        if "_" not in name:
+            return
+
+        obs_map = {
+            "info.maintainer_url": "info.maintainer-url",
+            "info.upstream_url": "info.upstream-url",
+            "info.source_url": "info.source-url",
+            "info.repository_url": "info.repository-url",
+            "info.repository_changeset": "info.repository-changeset",
+            "info.defect_tracker.url": "info.defect-tracker.url",
+            "opensolaris.arc_url": "org.opensolaris.caseid",
+        }
+
+        # These names are deprecated, and so we warn, but we're a tiny
+        # bit nicer about it.
+        if name in obs_map:
+            engine.warning(
+                _(
+                    "underscore in obsolete 'set' action "
+                    "name {name} should be {new} in {fmri}"
+                ).format(name=name, new=obs_map[name], fmri=manifest.fmri),
+                msgid="{0}{1}.3".format(self.name, pkglint_id),
+            )
+            return
+
+        engine.warning(
+            _("underscore in 'set' action name {name} in " "{fmri}").format(
+                name=name, fmri=manifest.fmri
+            ),
+            msgid="{0}{1}.2".format(self.name, pkglint_id),
+        )
+
+    underscores.pkglint_desc = _(
+        "Underscores are discouraged in action attributes."
+    )
+
+    def unusual_perms(self, action, manifest, engine, pkglint_id="002"):
+        """Checks that the permissions in this action look sane."""
+
+        if "mode" in action.attrs:
+            mode = action.attrs["mode"]
+            path = action.attrs["path"]
+            st = None
+            try:
+                st = stat.S_IMODE(int(mode, 8))
+            except ValueError:
+                pass
+
+            if action.name == "dir":
+                # check for at least one executable bit
+                if st and (
+                    stat.S_IXUSR & st or stat.S_IXGRP & st or stat.S_IXOTH & st
+                ):
+                    pass
+                elif st:
+                    engine.warning(
+                        _(
+                            "directory action for "
+                            "{path} delivered in {pkg} with "
+                            "mode={mode} "
+                            "that has no executable bits"
+                        ).format(path=path, pkg=manifest.fmri, mode=mode),
+                        msgid="{0}{1}.1".format(self.name, pkglint_id),
+                    )
+
+            if not st:
+                engine.error(
+                    _(
+                        "broken mode mode={mode} "
+                        "delivered in action for {path} in "
+                        "{pkg}"
+                    ).format(path=path, pkg=manifest.fmri, mode=mode),
+                    msgid="{0}{1}.2".format(self.name, pkglint_id),
+                )
+
+            if len(mode) < 3:
+                engine.error(
+                    _(
+                        "mode={mode} is too short in "
+                        "action for {path} in {pkg}"
+                    ).format(path=path, pkg=manifest.fmri, mode=mode),
+                    msgid="{0}{1}.3".format(self.name, pkglint_id),
+                )
+                return
+
+            # now check for individual access permissions
+            user = mode[-3]
+            group = mode[-2]
+            other = mode[-1]
+
+            if other > group or group > user or other > user:
+                engine.warning(
+                    _(
+                        "unusual mode mode={mode} "
+                        "delivered in action for {path} in "
+                        "{pkg}"
+                    ).format(path=path, pkg=manifest.fmri, mode=mode),
+                    msgid="{0}{1}.4".format(self.name, pkglint_id),
+                )
+
+    unusual_perms.pkglint_desc = _("Paths should not have unusual permissions.")
+
+    def legacy(self, action, manifest, engine, pkglint_id="003"):
+        """Cross-check that the 'pkg' attribute points to a package
+        that depends on the package containing this legacy action.
+        Also check that all the required tags are present on this
+        legacy action."""
+
+        if action.name != "legacy":
+            return
+
+        name = manifest.fmri.get_name()
+
+        for required in [
+            "category",
+            "desc",
+            "hotline",
+            "name",
+            "pkg",
+            "vendor",
+            "version",
+        ]:
+            if required not in action.attrs:
+                engine.error(
+                    _("{attr} missing from legacy " "action in {pkg}").format(
+                        attr=required, pkg=manifest.fmri
+                    ),
+                    msgid="{0}{1}.1".format(self.name, pkglint_id),
+                )
+
+        if "pkg" in action.attrs:
+            legacy = engine.get_manifest(
+                action.attrs["pkg"], search_type=engine.LATEST_SUCCESSOR
+            )
+            # Some legacy ancestor packages never existed as pkg(7)
+            # stubs
+            if legacy:
+                self.check_legacy_rename(
+                    legacy, action, manifest, engine, pkglint_id
+                )
+
+        if "version" in action.attrs:
+            # this could be refined
+            if "REV=" not in action.attrs["version"]:
+                engine.warning(
+                    _(
+                        "legacy action in {0} does not " "contain a REV= string"
+                    ).format(manifest.fmri),
+                    msgid="{0}{1}.3".format(self.name, pkglint_id),
+                )
+
+    def check_legacy_rename(self, legacy, action, manifest, engine, lint_id):
+        """Part of the legacy(..) check, not an individual check.
+        Given a legacy action, if the package pointed to by the 'pkg'
+        attribute of that action exists (say pkg=SUNWlegacy), we check
+        that a user who types:
+
+        pkg install SUNWlegacy
+
+        gets the package containing the legacy action installed on their
+        system, possibly following renames along the way.
+
+        legacy          A package manifest with the same name as the
+                        'pkg' attribute of the legacy action
+        action          The legacy action we're investigating
+        manifest        The manifest we're investigating
+        engine          Our lint engine
+        lint_id         The id of this check
+        """
+
+        if "pkg.renamed" in legacy and legacy["pkg.renamed"].lower() == "true":
+            mf = None
+            try:
+                mf = engine.follow_renames(
+                    action.attrs["pkg"],
+                    target=manifest.fmri,
+                    old_mfs=[],
+                    legacy=True,
+                )
+            except base.LintException as e:
+                # we've tried to rename to ourselves
+                engine.error(
+                    _("legacy renaming: {0}").format(str(e)),
+                    msgid="{0}{1}.5".format(self.name, lint_id),
+                )
+                return
+
+            if mf is None:
+                engine.error(
+                    _(
+                        "legacy package {legacy} did "
+                        "not result in a dependency on {pkg} when"
+                        " following package renames"
+                    ).format(legacy=legacy.fmri, pkg=manifest.fmri),
+                    msgid="{0}{1}.4".format(self.name, lint_id),
+                )
+
+            elif not lint_fmri_successor(
+                manifest.fmri, mf.fmri, ignore_pubs=engine.ignore_pubs
+            ):
+                engine.error(
+                    _(
+                        "legacy package {legacy} did "
+                        "not result in a dependency on {pkg}"
+                    ).format(legacy=legacy.fmri, pkg=manifest.fmri),
+                    msgid="{0}{1}.2".format(self.name, lint_id),
+                )
+
+    legacy.pkglint_desc = _("'legacy' actions should have valid attributes.")
+
+    def unknown(self, action, manifest, engine, pkglint_id="004"):
+        """We should never have actions called 'unknown'."""
+
+        if action.name == "unknown":
+            engine.error(
+                _("unknown action found in {0}").format(manifest.fmri),
+                msgid="{0}{1}".format(self.name, pkglint_id),
+            )
+
+    unknown.pkglint_desc = _("'unknown' actions should never occur.")
+
+    def dep_obsolete(self, action, manifest, engine, pkglint_id="005"):
+        """We should not have a require dependency on a package that has
+        been marked as obsolete.
+
+        This check also produces warnings when it is unable to find
+        manifests marked as dependencies for a given package in order
+        to check for their obsoletion.  This can help to detect errors
+        in the fmri attribute field of the depend action, though can be
+        noisy if all dependencies are intentionally not present in the
+        repository being linted or referenced.
+
+        The pkglint paramater pkglint.action005.1.missing-deps can be
+        used to declare which fmris we know could be missing, and for
+        which we should not emit a warning message if those manifests
+        are not available.
+        """
+
+        msg = _("dependency on obsolete package in {0}:")
+
+        if action.name != "depend":
+            return
+
+        if action.attrs["type"] != "require":
+            return
+
+        # We check for renames as part of pkglint.manifest002.5, so
+        # don't do that here.
+        if (
+            "pkg.renamed" in manifest
+            and manifest["pkg.renamed"].lower() == "true"
+        ):
+            return
+
+        name = None
+        declared_fmri = None
+        dep_fmri = action.attrs["fmri"]
+
+        # normalize the fmri
+        if not dep_fmri.startswith("pkg:/"):
+            dep_fmri = "pkg:/{0}".format(dep_fmri)
+
+        try:
+            declared_fmri = pkg.fmri.PkgFmri(dep_fmri)
+            name = declared_fmri.get_name()
+        except pkg.fmri.IllegalFmri:
+            try:
+                declared_fmri = pkg.fmri.PkgFmri(dep_fmri)
+                name = declared_fmri.get_name()
+            except:
+                # A very broken fmri value - we'll give up now.
+                # valid_fmri() will pick up the trail from here.
+                return
+
+        # if we've been unable to find a dependency for a given
+        # fmri in the past, no need to keep complaining about it
+        if dep_fmri in self.missing_deps:
+            return
+
+        # There's a good chance that dependencies can be satisfied from
+        # the manifests we cached during startup() Check there first.
+        if name and name in self.obsolete_pkgs:
+            if not self.obsolete_pkgs[name].is_obsolete:
+                # the cached package is not obsolete, but we'll
+                # verify the version is valid
+                found_fmri = self.obsolete_pkgs[name].fmri
+                if not declared_fmri.has_version():
+                    return
+                elif lint_fmri_successor(
+                    found_fmri, declared_fmri, ignore_pubs=engine.ignore_pubs
+                ):
+                    return
+
+        # A non-obsolete dependency wasn't found in the local cache,
+        # or the one in the cache was found not to be a successor of
+        # the fmri in the depend action.
+        lint_id = "{0}{1}".format(self.name, pkglint_id)
+
+        mf = None
+        found_obsolete = False
+        try:
+            mf = engine.follow_renames(
+                dep_fmri, old_mfs=[], warn_on_obsolete=True
+            )
+        except base.LintException as err:
+            found_obsolete = True
+            engine.error(
+                "{0} {1}".format(msg.format(manifest.fmri), err), msgid=lint_id
+            )
+
+        # We maintain a whitelist of dependencies which may be missing
+        # during this lint run (eg. packages that are present in a
+        # different repository)  Consult that list before complaining
+        # about each fmri being missing.
+
+        # If unversioned FMRIs are present in the list, versioned
+        # dependencies will match those if their package name and
+        # publisher match.
+        known_missing_deps = engine.get_param(
+            "{0}.1.missing-deps".format(lint_id),
+            action=action,
+            manifest=manifest,
+        )
+        if known_missing_deps:
+            known_missing_deps = known_missing_deps.split(" ")
+        else:
+            known_missing_deps = []
+
+        if not mf and not found_obsolete:
+            self.missing_deps.append(dep_fmri)
+            if dep_fmri in known_missing_deps:
+                return
+            if "@" in dep_fmri and dep_fmri.split("@")[0] in known_missing_deps:
+                return
+            engine.warning(
+                _(
+                    "obsolete dependency check "
+                    "skipped: unable to find dependency {dep}"
+                    " for {pkg}"
+                ).format(dep=dep_fmri, pkg=manifest.fmri),
+                msgid="{0}.1".format(lint_id),
+            )
+
+    dep_obsolete.pkglint_desc = _(
+        "Packages should not have dependencies on obsolete packages."
+    )
+
+    def valid_fmri(self, action, manifest, engine, pkglint_id="006"):
+        """We should be given a valid FMRI as a dependency, allowing
+        for a potentially missing component value"""
+
+        if "fmri" not in action.attrs:
+            return
+        fmris = action.attrs["fmri"]
+        if isinstance(fmris, six.string_types):
+            fmris = [fmris]
+
+        for fmri in fmris:
+            try:
                 pfmri = pkg.fmri.PkgFmri(fmri)
+            except pkg.fmri.IllegalFmri:
+                # we also need to just verify that the fmri
+                # isn't just missing a build_release value
+                try:
+                    pfmri = pkg.fmri.PkgFmri(fmri)
+                except pkg.fmri.IllegalFmri:
+                    engine.error(
+                        "invalid FMRI in action "
+                        "{action} in {pkg}".format(
+                            pkg=manifest.fmri, action=action
+                        ),
+                        msgid="{0}{1}".format(self.name, pkglint_id),
+                    )
+
+    valid_fmri.pkglint_desc = _("pkg(7) FMRIs should be valid.")
+
+    def license(self, action, manifest, engine, pkglint_id="007"):
+        """License actions should not have path attributes."""
+
+        if action.name == "license" and "path" in action.attrs:
+            engine.error(
+                _(
+                    "license action in {pkg} has a path attribute, " "{path}"
+                ).format(pkg=manifest.fmri, path=action.attrs["path"]),
+                msgid="{0}{1}".format(self.name, pkglint_id),
+            )
+
+    license.pkglint_desc = _("'license' actions should not have paths.")
+
+    def linted(self, action, manifest, engine, pkglint_id="008"):
+        """Log an INFO message with the key/value pairs of all
+        pkg.linted* attributes set on this action.
+
+        Essentially this exists to prevent users from adding
+        pkg.linted values to manifests that don't really need them."""
+
+        linted_attrs = [
+            (key, action.attrs[key])
+            for key in sorted(action.attrs.keys())
+            if key.startswith("pkg.linted")
+        ]
+
+        if linted_attrs:
+            engine.info(
+                _(
+                    "pkg.linted attributes detected for "
+                    "{pkg} {action}: {linted}"
+                ).format(
+                    pkg=manifest.fmri,
+                    action=str(action),
+                    linted=", ".join(
+                        [
+                            "{0}={1}".format(key, val)
+                            for key, val in linted_attrs
+                        ]
+                    ),
+                ),
+                msgid="{0}{1}".format(self.name, pkglint_id),
+                ignore_linted=True,
+            )
+
+    linted.pkglint_desc = _("Show actions with pkg.linted attributes.")
+
+    def validate(self, action, manifest, engine, pkglint_id="009"):
+        """Validate all actions."""
+        if not engine.do_pub_checks:
+            return
+        try:
+            action.validate()
+        except ActionError as err:
+            # we want the details all on one line to
+            # stay consistent with the rest of the pkglint
+            # error messaging
+            details = "; ".join([val.lstrip() for val in str(err).split("\n")])
+            engine.error(
+                _(
+                    "Publication error with action in {pkg}: " "{details}"
+                ).format(pkg=manifest.fmri, details=details),
+                msgid="{0}{1}".format(self.name, pkglint_id),
+            )
+
+    validate.pkglint_desc = _("Publication checks for actions.")
+
+    def username_format(self, action, manifest, engine, pkglint_id="010"):
+        """Checks username length, and format."""
+
+        if action.name != "user":
+            return
+
+        username = action.attrs["username"]
+
+        if len(username) == 0:
+            engine.error(
+                _("username attribute value must be set " "in {pkg}").format(
+                    pkg=manifest.fmri
+                ),
+                msgid="{0}{1}.4".format(self.name, pkglint_id),
+            )
+            return
+
+        if len(username) > 32:
+            engine.error(
+                _("Username {name} in {pkg} > 32 chars").format(
+                    name=username, pkg=manifest.fmri
+                ),
+                msgid="{0}{1}.1".format(self.name, pkglint_id),
+            )
+
+        if not re.match(r"[a-z].*", username):
+            engine.warning(
+                _(
+                    "Username {name} in {pkg} does not have an "
+                    "initial lower-case alphabetical "
+                    "character"
+                ).format(name=username, pkg=manifest.fmri),
+                msgid="{0}{1}.2".format(self.name, pkglint_id),
+            )
+
+        if len(username) > 0 and not re.match(
+            r"^[a-z]([a-zA-Z0-9._-])*$", username
+        ):
+            engine.warning(
+                _(
+                    "Username {name} in {pkg} is discouraged - see " "passwd(5)"
+                ).format(name=username, pkg=manifest.fmri),
+                msgid="{0}{1}.3".format(self.name, pkglint_id),
+            )
+
+    username_format.pkglint_desc = _("User names should be valid.")
+
+    def version_incorporate(self, action, manifest, engine, pkglint_id="011"):
+        """Checks that 'incorporate' dependencies have a version."""
+
+        if action.name != "depend":
+            return
+        if action.attrs.get("type") != "incorporate":
+            return
+
+        fmri = action.attrs["fmri"]
+        pfmri = pkg.fmri.PkgFmri(fmri)
+        if not pfmri.version:
+            engine.error(
+                _(
+                    "'incorporate' depend action on {fmri} in "
+                    "{pkg} does not have a version."
+                ).format(fmri=fmri, pkg=manifest.fmri),
+                msgid="{0}{1}".format(self.name, pkglint_id),
+            )
+
+    version_incorporate.pkglint_desc = _(
+        "'incorporate' dependencies should" " have a version."
+    )
+
+    def facet_value(self, action, manifest, engine, pkglint_id="012"):
+        """facet values should be set to a valid value in pkg(7)"""
+
+        for key in action.attrs.keys():
+            if key.startswith("facet"):
+                value = action.attrs[key].lower()
+                if value not in ["true", "false", "all"]:
+                    engine.warning(
+                        _(
+                            "facet value should be set to "
+                            "'true', 'false' or 'all' in "
+                            "attribute name {key} "
+                            "in {fmri}"
+                        ).format(key=key, fmri=manifest.fmri),
+                        msgid="{0}{1}".format(self.name, pkglint_id),
+                    )
+
+    facet_value.pkglint_desc = _(
+        "facet value should be set to " "a valid value in an action attribute"
+    )
+
+    def supported_pkg_actuator(
+        self, action, manifest, engine, pkglint_id="013"
+    ):
+        """pkg_actuators should be set to a valid value in pkg(7)"""
+
+        start_pattern = "pkg.additional-"
+        supported_actuators = [
+            start_pattern + "update-on-uninstall",
+            start_pattern + "uninstall-on-uninstall",
+        ]
+
+        if not "name" in action.attrs or not action.attrs["name"].startswith(
+            start_pattern
+        ):
+            return
+
+        if not action.attrs["name"] in supported_actuators:
+            engine.warning(
+                _(
+                    "invalid package actuator name {attr} in {fmri}\n"
+                    "supported values: {sact}"
+                ).format(
+                    attr=action.attrs["name"],
+                    fmri=manifest.fmri,
+                    sact=", ".join(supported_actuators),
+                ),
+                msgid="{0}{1}".format(self.name, pkglint_id),
+            )
+
+        if action.attrs["name"] == start_pattern + "uninstall-on-uninstall":
+            for v in action.attrlist("value"):
+                pfmri = pkg.fmri.PkgFmri(v)
                 if not pfmri.version:
-                        engine.error(
-                            _("'incorporate' depend action on {fmri} in "
-                            "{pkg} does not have a version.").format(
-                            fmri=fmri,
-                            pkg=manifest.fmri),
-                            msgid="{0}{1}".format(self.name, pkglint_id))
+                    continue
+                engine.warning(
+                    "invalid package-triggered "
+                    "uninstall FMRI {tf} in {fmri}: should "
+                    "not contain a version".format(
+                        tf=str(pfmri), fmri=manifest.fmri
+                    ),
+                    msgid="{0}{1}".format(self.name, pkglint_id),
+                )
 
-        version_incorporate.pkglint_desc = _("'incorporate' dependencies should"
-            " have a version.")
+        if action.attrs["name"] == start_pattern + "update-on-uninstall":
+            for v in action.attrlist("value"):
+                pfmri = pkg.fmri.PkgFmri(v)
+                if pfmri.version:
+                    continue
+                engine.warning(
+                    "invalid package-triggered "
+                    "update FMRI {tf} in {fmri}: should "
+                    "contain a specific version".format(
+                        tf=str(pfmri), fmri=manifest.fmri
+                    ),
+                    msgid="{0}{1}".format(self.name, pkglint_id),
+                )
 
-        def facet_value(self, action, manifest, engine, pkglint_id="012"):
-                """facet values should be set to a valid value in pkg(7)"""
+    supported_pkg_actuator.pkglint_desc = _(
+        "package actuator should be " "set to a valid value"
+    )
 
-                for key in action.attrs.keys():
-                        if key.startswith("facet"):
-                                value = action.attrs[key].lower()
-                                if value not in ["true", "false", "all"]:
-                                        engine.warning(
-                                            _("facet value should be set to "
-                                            "'true', 'false' or 'all' in "
-                                            "attribute name {key} "
-                                            "in {fmri}").format(
-                                           key=key,
-                                           fmri=manifest.fmri),
-                                           msgid="{0}{1}".format(self.name,
-                                           pkglint_id))
+    def arch64(self, action, manifest, engine, pkglint_id="014"):
+        """ELF files should be delivered as 64-bit objects, other
+        than libraries.
 
-        facet_value.pkglint_desc = _("facet value should be set to "
-            "a valid value in an action attribute")
+        The pkglint paramater pkglint.action0014.report_type can change
+        whether this check issues errors or warnings. The value of
+        this parameter should be "error" or "warning". Any other value
+        defaults to "warning"
+        """
 
-        def supported_pkg_actuator(self, action, manifest, engine,
-            pkglint_id="013"):
-                """pkg_actuators should be set to a valid value in pkg(7)"""
+        # Note that this check is intentionally delivered as disabled
+        # by default in the pkglintrc config file. The check exists
+        # so that we can move packages towards best-practises,
+        # but this may not be appropriate in all cases.
 
-                start_pattern = "pkg.additional-"
-                supported_actuators = [
-                    start_pattern + "update-on-uninstall",
-                    start_pattern  + "uninstall-on-uninstall",
-                ]
+        if action.name != "file":
+            return
+        if "elfbits" not in action.attrs:
+            return
+        elfbits = action.attrs["elfbits"]
+        if elfbits == "64":
+            return
 
-                if not "name" in action.attrs or \
-                    not action.attrs["name"].startswith(start_pattern):
-                        return
+        lint_id = "{}{}".format(self.name, pkglint_id)
+        path = action.attrs["path"]
+        if re.search(r"\.so\.?[0-9\.]*$", path):
+            # we allow libraries to be delivered as 32-bit
+            return
+        report_errors = engine.get_param(
+            "{}.report_errors".format(lint_id), action=action, manifest=manifest
+        )
+        # the parameter might not exist
+        if not report_errors:
+            report_errors = False
 
-                if not action.attrs["name"] in supported_actuators:
-                        engine.warning(
-                            _("invalid package actuator name {attr} in {fmri}\n"
-                            "supported values: {sact}").format(
-                                attr=action.attrs["name"],
-                                fmri=manifest.fmri,
-                                sact=", ".join(supported_actuators)
-                            ), msgid="{0}{1}".format(self.name, pkglint_id))
+        if report_errors and report_errors.lower() == "true":
+            lint_report = engine.error
+            lint_subid = "2"
+        else:
+            lint_report = engine.warning
+            lint_subid = "1"
 
-                if  action.attrs["name"] == \
-                    start_pattern + "uninstall-on-uninstall":
-                        for v in action.attrlist("value"):
-                                pfmri = pkg.fmri.PkgFmri(v)
-                                if not pfmri.version:
-                                        continue
-                                engine.warning("invalid package-triggered "
-                                    "uninstall FMRI {tf} in {fmri}: should "
-                                    "not contain a version".format(
-                                        tf=str(pfmri),
-                                        fmri=manifest.fmri
-                                    ), msgid="{0}{1}".format(self.name,
-                                        pkglint_id))
+        lint_report(
+            _("{elfbits}-bit object delivered for {path} " "in {fmri}.").format(
+                elfbits=elfbits, fmri=manifest.fmri, path=action.attrs["path"]
+            ),
+            msgid="{}.{}".format(lint_id, lint_subid),
+        )
 
-                if  action.attrs["name"] == \
-                    start_pattern + "update-on-uninstall":
-                        for v in action.attrlist("value"):
-                                pfmri = pkg.fmri.PkgFmri(v)
-                                if pfmri.version:
-                                        continue
-                                engine.warning("invalid package-triggered "
-                                    "update FMRI {tf} in {fmri}: should "
-                                    "contain a specific version".format(
-                                        tf=str(pfmri),
-                                        fmri=manifest.fmri
-                                    ), msgid="{0}{1}".format(self.name,
-                                        pkglint_id))
+    arch64.pkglint_desc = _("non-library ELF files should be 64-bit")
 
-        supported_pkg_actuator.pkglint_desc = _("package actuator should be "
-            "set to a valid value")
-
-        def arch64(self, action, manifest, engine, pkglint_id="014"):
-                """ELF files should be delivered as 64-bit objects, other
-                than libraries.
-
-                The pkglint paramater pkglint.action0014.report_type can change
-                whether this check issues errors or warnings. The value of
-                this parameter should be "error" or "warning". Any other value
-                defaults to "warning"
-                """
-
-                # Note that this check is intentionally delivered as disabled
-                # by default in the pkglintrc config file. The check exists
-                # so that we can move packages towards best-practises,
-                # but this may not be appropriate in all cases.
-
-                if action.name != "file":
-                        return
-                if "elfbits" not in action.attrs:
-                        return
-                elfbits = action.attrs["elfbits"]
-                if elfbits == "64":
-                        return
-
-                lint_id = "{}{}".format(self.name, pkglint_id)
-                path = action.attrs["path"]
-                if re.search(r"\.so\.?[0-9\.]*$", path):
-                        # we allow libraries to be delivered as 32-bit
-                        return
-                report_errors = engine.get_param("{}.report_errors".format(
-                    lint_id), action=action, manifest=manifest)
-                # the parameter might not exist
-                if not report_errors:
-                        report_errors = False
-
-                if report_errors and report_errors.lower() == "true":
-                        lint_report = engine.error
-                        lint_subid = "2"
-                else:
-                        lint_report = engine.warning
-                        lint_subid = "1"
-
-                lint_report(
-                    _("{elfbits}-bit object delivered for {path} "
-                    "in {fmri}.").format(elfbits=elfbits,
-                    fmri=manifest.fmri, path=action.attrs["path"]),
-                    msgid="{}.{}".format(lint_id, lint_subid))
-
-        arch64.pkglint_desc = _("non-library ELF files should be 64-bit")
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/lint/pkglint_manifest.py
+++ b/src/modules/lint/pkglint_manifest.py
@@ -37,727 +37,818 @@ from pkg.lint.engine import lint_fmri_successor
 
 
 class PkgManifestChecker(base.ManifestChecker):
-        """A class to check manifests."""
+    """A class to check manifests."""
 
-        name = "pkglint.manifest"
+    name = "pkglint.manifest"
 
-        def __init__(self, config):
-                self.description = _(
-                    "Checks for errors within the scope of a single manifest.")
+    def __init__(self, config):
+        self.description = _(
+            "Checks for errors within the scope of a single manifest."
+        )
 
-                self.ref_lastnames = {}
-                self.lint_lastnames = {}
-                self.processed_lastnames = []
+        self.ref_lastnames = {}
+        self.lint_lastnames = {}
+        self.processed_lastnames = []
 
-                # maps package names to a list of packages which depend on them.
-                self.dependencies = {}
+        # maps package names to a list of packages which depend on them.
+        self.dependencies = {}
 
-                super(PkgManifestChecker, self).__init__(config)
+        super(PkgManifestChecker, self).__init__(config)
 
-        def startup(self, engine):
+    def startup(self, engine):
+        def seed_names_dict(manifest, dic):
+            if "pkg.renamed" in manifest or "pkg.obsolete" in manifest:
+                return
+            name = os.path.basename(manifest.fmri.get_name())
+            if name in dic:
+                dic[name].append(manifest.fmri)
+            else:
+                dic[name] = [manifest.fmri]
 
-                def seed_names_dict(manifest, dic):
-                        if "pkg.renamed" in manifest or \
-                            "pkg.obsolete" in manifest:
-                                return
-                        name = os.path.basename(manifest.fmri.get_name())
-                        if name in dic:
-                                dic[name].append(manifest.fmri)
-                        else:
-                                dic[name] = [manifest.fmri]
+        def seed_depend_dict(mf, dic):
+            """Updates a dictionary of package names that declare
+            dependencies, keyed by the depend action fmri name.
+            We drop versions and consider all dependency types
+            except 'incorporate'."""
 
-                def seed_depend_dict(mf, dic):
-                        """Updates a dictionary of package names that declare
-                        dependencies, keyed by the depend action fmri name.
-                        We drop versions and consider all dependency types
-                        except 'incorporate'."""
-
-                        name = mf.fmri
-                        for action in mf.gen_actions_by_type("depend"):
-                                if action.attrs.get("type") == "incorporate":
-                                        continue
-                                dep = action.attrs["fmri"]
-                                try:
-                                        if isinstance(dep, six.string_types):
-                                                f = fmri.PkgFmri(dep)
-                                                dic.setdefault(
-                                                    f.get_name(), []
-                                                    ).append(name)
-                                        elif isinstance(dep, list):
-                                                for d in dep:
-                                                        f = fmri.PkgFmri(d)
-                                                        dic.setdefault(
-                                                            f.get_name(), []
-                                                            ).append(name)
-                                # If we have a bad FMRI, this will be picked up
-                                # by pkglint.action006 and pkglint.action009.
-                                except fmri.FmriError:
-                                        pass
-
-                engine.logger.debug(
-                    _("Seeding reference manifest dictionaries."))
-                for manifest in engine.gen_manifests(engine.ref_api_inst,
-                    release=engine.release):
-                        seed_depend_dict(manifest, self.dependencies)
-                        seed_names_dict(manifest, self.ref_lastnames)
-
-                engine.logger.debug(
-                    _("Seeding lint manifest dictionaries."))
-                for manifest in engine.gen_manifests(engine.lint_api_inst,
-                    release=engine.release, pattern=engine.pattern):
-                        seed_depend_dict(manifest, self.dependencies)
-                        seed_names_dict(manifest, self.lint_lastnames)
-
-                for manifest in engine.lint_manifests:
-                        seed_depend_dict(manifest, self.dependencies)
-                        seed_names_dict(manifest, self.lint_lastnames)
-
-                self._merge_names(self.lint_lastnames, self.ref_lastnames,
-                    ignore_pubs=engine.ignore_pubs)
-
-        def obsoletion(self, manifest, engine, pkglint_id="001"):
-                """Checks for correct package obsoletion.
-                * error if obsoleted packages contain anything other than
-                  set or signature actions
-                * error if pkg.description or pkg.summary are set.
-                * warn if other packages have non-incorporate dependencies on
-                  this package.
-                """
-
-                if manifest.get("pkg.obsolete", "false") != "true":
-                        return
-
-                for key in [ "pkg.description", "pkg.summary" ]:
-                        if key in manifest:
-                                action = engine.get_attr_action(key, manifest)
-                                engine.advise_loggers(action=action,
-                                    manifest=manifest)
-                                engine.error(_("obsolete package {pkg} has "
-                                    "{key} attribute").format(
-                                    pkg=manifest.fmri,
-                                    key=key),
-                                    msgid="{0}{1}.1".format(self.name,
-                                    pkglint_id))
-
-                # the loggers are no longer concerned about actions
-                engine.advise_loggers(manifest=manifest)
-
-                has_invalid_action = False
-                linted_action = None
-
-                lint_id = "{0}{1}.2".format(self.name, pkglint_id)
-                for action in manifest.gen_actions():
-                        # since we only emit the error once, after iterating
-                        # over all actions, we may lose the action that could
-                        # contain the linted flag, so the logging
-                        # subsystem will not be able to use it to print a
-                        # "lint bypassed" message.  Save it here.
-                        if engine.linted(action=action, manifest=manifest,
-                            lint_id=lint_id):
-                                linted_action = action
-                                continue
-
-                        if action.name not in ["set", "signature"]:
-                                has_invalid_action = True
-
-                if has_invalid_action:
-                        engine.error(
-                            _("obsolete package {0} contains actions other than "
-                            "set or signature actions").format(manifest.fmri),
-                            msgid=lint_id)
-
-                # report that we bypassed a check
-                if linted_action and not has_invalid_action:
-                        engine.advise_loggers(action=linted_action,
-                            manifest=manifest)
-                        engine.error(
-                            _("obsolete package {0} contains actions other than "
-                            "set or signature actions").format(manifest.fmri),
-                            msgid=lint_id)
-
-                # determine whether other packages we know about have
-                # dependencies on this obsolete package.
-                obsolete_depends = set()
-                lint_id = "{0}{1}.3".format(self.name, pkglint_id)
-
-                depends = set(
-                    self.dependencies.get(manifest.fmri.get_name(), []))
-                if depends:
-                        for depending_package in depends:
-                                p = engine.get_manifest(str(depending_package),
-                                    search_type=engine.LATEST_SUCCESSOR)
-                                if p.get("pkg.obsolete", None) != "true":
-                                        obsolete_depends.add(p.fmri)
-                if obsolete_depends:
-                        # this is only a warning, because at install-time the
-                        # solver may still be able to find a non-obsolete
-                        # version of a package.
-                        engine.warning("obsolete package {pkg} is depended "
-                            "upon by the following packages: "
-                            "{deps}".format(pkg=manifest.fmri, deps=" ".join(
-                            [str(fmri) for fmri in obsolete_depends])),
-                            msgid=lint_id)
-
-        obsoletion.pkglint_desc = _(
-            "Obsolete packages should have valid contents.")
-
-        def renames(self, manifest, engine, pkglint_id="002"):
-                """Checks for correct package renaming.
-                * error if renamed packages contain anything other than set,
-                  signature and depend actions.
-                * follows renames, ensuring they're not circular, and don't
-                  end up at an obsolete package.
-                """
-
-                if "pkg.renamed" not in manifest:
-                        return
-
-                has_invalid_action = False
-                seen_linted_action = False
-                invalid_action_id = "{0}{1}.1".format(self.name, pkglint_id)
-                count_depends = 0
-
-                for action in manifest.gen_actions():
-                        if action.name not in ["set", "depend", "signature"]:
-
-                                if engine.linted(action=action,
-                                    manifest=manifest,
-                                    lint_id=invalid_action_id):
-                                        seen_linted_action = action
-                                        continue
-                                has_invalid_action = True
-
-                        if action.name == "depend":
-                                if "incorporation" not in action.attrs["fmri"] or \
-                                    action.attrs["type"] == "require":
-                                        count_depends = count_depends + 1
-
-                if has_invalid_action:
-                        engine.error(_("renamed package {0} contains actions "
-                            "other than set, depend or signature actions").format(
-                            manifest.fmri), msgid=invalid_action_id)
-
-                # if all actions in the manifest that would have caused errors
-                # were marked as linted, we need to advise the logging mechanism
-                # of at least one action that was marked as linted, then log the
-                # error, ultimately resulting in an INFO level message.
-                if seen_linted_action and not has_invalid_action:
-                        engine.advise_loggers(action=seen_linted_action,
-                            manifest=manifest)
-                        engine.error(_("renamed package {0} contains actions "
-                            "other than set, depend or signature actions").format(
-                            manifest.fmri), msgid=invalid_action_id)
-
-                if count_depends == 0:
-                        engine.error(_("renamed package {0} does not declare a "
-                            "'require' dependency indicating what it was "
-                            "renamed to").format(
-                            manifest.fmri), msgid="{0}{1}.2".format(
-                            self.name, pkglint_id))
-
+            name = mf.fmri
+            for action in mf.gen_actions_by_type("depend"):
+                if action.attrs.get("type") == "incorporate":
+                    continue
+                dep = action.attrs["fmri"]
                 try:
-                        mf = engine.follow_renames(str(manifest.fmri),
-                            old_mfs=[])
-                        if not mf:
-                                engine.warning(_("unable to follow renames for "
-                                    "{0}: possible missing package").format(
-                                    manifest.fmri), msgid="{0}{1}.3".format(
-                                    self.name, pkglint_id))
-                        else:
-                                if "pkg.obsolete" not in mf:
-                                        return
-                                engine.error(_("package {pkg} was renamed "
-                                    "to an obsolete package {obs}").format(
-                                    pkg=manifest.fmri, obs=mf.fmri),
-                                    msgid="{0}{1}.5".format(self.name,
-                                    pkglint_id))
+                    if isinstance(dep, six.string_types):
+                        f = fmri.PkgFmri(dep)
+                        dic.setdefault(f.get_name(), []).append(name)
+                    elif isinstance(dep, list):
+                        for d in dep:
+                            f = fmri.PkgFmri(d)
+                            dic.setdefault(f.get_name(), []).append(name)
+                # If we have a bad FMRI, this will be picked up
+                # by pkglint.action006 and pkglint.action009.
+                except fmri.FmriError:
+                    pass
 
-                except base.LintException as err:
-                        engine.error(_("package renaming: {0}").format(str(err)),
-                            msgid="{0}{1}.4".format(self.name, pkglint_id))
+        engine.logger.debug(_("Seeding reference manifest dictionaries."))
+        for manifest in engine.gen_manifests(
+            engine.ref_api_inst, release=engine.release
+        ):
+            seed_depend_dict(manifest, self.dependencies)
+            seed_names_dict(manifest, self.ref_lastnames)
 
-        renames.pkglint_desc = _("Renamed packages should have valid contents.")
+        engine.logger.debug(_("Seeding lint manifest dictionaries."))
+        for manifest in engine.gen_manifests(
+            engine.lint_api_inst, release=engine.release, pattern=engine.pattern
+        ):
+            seed_depend_dict(manifest, self.dependencies)
+            seed_names_dict(manifest, self.lint_lastnames)
 
-        def variants(self, manifest, engine, pkglint_id="003"):
-                """Checks for correct use of variant tags.
-                * if variant tags present, matching variant descriptions
-                  exist and are correctly specified, with the exception of
-                  variant.debug.* variants
-                * All manifests that deliver file actions of a given
-                  architecture declare variant.arch
+        for manifest in engine.lint_manifests:
+            seed_depend_dict(manifest, self.dependencies)
+            seed_names_dict(manifest, self.lint_lastnames)
 
-                These checks are only performed on published packages."""
+        self._merge_names(
+            self.lint_lastnames,
+            self.ref_lastnames,
+            ignore_pubs=engine.ignore_pubs,
+        )
 
-                if not engine.do_pub_checks:
-                        return
+    def obsoletion(self, manifest, engine, pkglint_id="001"):
+        """Checks for correct package obsoletion.
+        * error if obsoleted packages contain anything other than
+          set or signature actions
+        * error if pkg.description or pkg.summary are set.
+        * warn if other packages have non-incorporate dependencies on
+          this package.
+        """
 
-                unknown_variants = set()
-                undefined_variants = set()
-                has_arch_file = False
+        if manifest.get("pkg.obsolete", "false") != "true":
+            return
 
-                pkg_vars = manifest.get_all_variants()
-
-                undefined_lint_id = "{0}{1}.1".format(self.name, pkglint_id)
-                unknown_lint_id = "{0}{1}.2".format(self.name, pkglint_id)
-                missing_arch_lint_id = "{0}{1}.3".format(self.name, pkglint_id)
-
-                def ignore_variant(varname):
-                        """check whether we can ignore this variant."""
-                        return varname.startswith("variant.debug")
-
-                for action in manifest.gen_actions():
-                        if engine.linted(action=action, manifest=manifest):
-                                continue
-
-                        if action.name == "file" and \
-                            action.attrs.get("pkg.filetype") == "elf" or \
-                            "elfarch" in action.attrs:
-                                has_arch_file = True
-
-                        vct = action.get_variant_template()
-                        diff = vct.difference(pkg_vars)
-                        for k in diff.type_diffs:
-                                if not engine.linted(action=action,
-                                    manifest=manifest,
-                                    lint_id=undefined_lint_id):
-                                        if ignore_variant(k):
-                                                continue
-                                        undefined_variants.add(k)
-                        for k, v in diff.value_diffs:
-                                if not engine.linted(action=action,
-                                    manifest=manifest,
-                                    lint_id=unknown_lint_id):
-                                        if ignore_variant(k):
-                                                continue
-                                        unknown_variants.add("{0}={1}".format(k,
-                                            v))
-
-                if len(undefined_variants) > 0:
-                        vlist = sorted((v for v in undefined_variants))
-                        engine.error(_("variant(s) {vars} not defined by "
-                            "{pkg}").format(
-                            vars=" ".join(vlist),
-                            pkg=manifest.fmri), msgid=undefined_lint_id)
-
-                if len(unknown_variants) > 0:
-                        vlist = sorted((v for v in unknown_variants))
-                        engine.error(_("variant(s) {vars} not in list "
-                            "of known values for variants in {pkg}").format(
-                            vars=" ".join(vlist),
-                            pkg=manifest.fmri), msgid=unknown_lint_id)
-
-                if has_arch_file and "variant.arch" not in manifest and \
-                    not engine.linted(manifest=manifest,
-                    lint_id=missing_arch_lint_id):
-                        engine.error(_("variant.arch not declared in {0}").format(
-                            manifest.fmri), msgid=missing_arch_lint_id)
-
-        variants.pkglint_desc = _("Variants used by packages should be valid.")
-
-        def naming(self, manifest, engine, pkglint_id="004"):
-                """Warn when there's a namespace clash where the last component
-                of the pkg name matches an existing one in the catalog."""
-
-                lastname = os.path.basename(manifest.fmri.get_name())
-                if lastname not in self.ref_lastnames:
-                        return
-
-                if lastname in self.processed_lastnames:
-                        return
-
-                fmris = self.ref_lastnames[lastname]
-
-                # we ignored renamed or obsolete packages when building
-                # ref_lastnames, so this package might not be there,
-                # in which case, we can ignore this package too.
-                if manifest.fmri not in fmris:
-                        return
-
-                if len(self.ref_lastnames[lastname]) > 1:
-                        plist = sorted((f.get_fmri() for f in fmris))
-                        engine.warning(
-                            _("last name component {name} in package name "
-                            "clashes across {pkgs}").format(
-                            name=lastname,
-                            pkgs=" ".join(plist)),
-                            msgid="{0}{1}".format(self.name, pkglint_id))
-
-                if not engine.linted(manifest=manifest,
-                    lint_id="{0}{1}".format(self.name, pkglint_id)):
-                        self.processed_lastnames.append(lastname)
-
-        naming.pkglint_desc = _(
-            "Packages are encouraged to use unique leaf names.")
-
-        def duplicate_deps(self, manifest, engine, pkglint_id="005"):
-                """Checks for repeated dependencies, including package version
-                substrings."""
-
-                seen_deps = {}
-                duplicates = []
-                dup_msg = _(
-                    "duplicate depend actions in {pkg} {actions}")
-                duplicates = []
-                for action in manifest.gen_actions_by_type("depend"):
-                        # this only checks require, require-any and group-any
-                        # actions
-                        if action.attrs["type"] not in ["require",
-                            "require-any", "group-any"]:
-                                continue
-
-                        if "fmri" not in action.attrs:
-                                lint_id = "{0}{1}.1".format(self.name,
-                                    pkglint_id)
-                                if not engine.linted(action=action,
-                                    manifest=manifest, lint_id=lint_id):
-                                        engine.critical(
-                                            _("no fmri attribute in depend "
-                                            "action in {0}").format(
-                                            manifest.fmri), msgid=lint_id)
-                                continue
-
-                        lint_id = "{0}{1}.2".format(self.name, pkglint_id)
-                        if engine.linted(action=action, manifest=manifest,
-                            lint_id=lint_id):
-                                    continue
-
-                        deps = action.attrs["fmri"]
-                        if isinstance(deps, six.string_types):
-                                deps = [deps]
-
-                        for dep in deps:
-                                shortname = fmri.extract_pkg_name(dep)
-                                if shortname not in seen_deps:
-                                        seen_deps[shortname] = [action]
-                                else:
-                                        seen_deps[shortname].append(action)
-
-                compared = set()
-                for key in seen_deps:
-                        actions = seen_deps[key]
-                        if len(actions) > 1:
-                                conflict_vars, conflict_actions = \
-                                    self.conflicting_dep_actions(actions,
-                                        manifest.get_all_variants(), compared)
-                                if conflict_actions:
-                                        duplicates.append(key)
-
-                if duplicates:
-                        dlist = sorted((str(d) for d in duplicates))
-                        engine.error(dup_msg.format(
-                            pkg=manifest.fmri,
-                            actions=" ".join(dlist)),
-                            msgid="{0}{1}.2".format(self.name, pkglint_id))
-
-        duplicate_deps.pkglint_desc = _(
-            "Packages should not have duplicate 'depend' actions.")
-
-        def duplicate_sets(self, manifest, engine, pkglint_id="006"):
-                """Checks for duplicate set actions."""
-                seen_sets = {}
-                dup_set_msg = _("duplicate set actions on {names} in {pkg}")
-                duplicates = []
-                lint_id = "{0}{1}".format(self.name, pkglint_id)
-                for action in manifest.gen_actions_by_type("set"):
-                        lint_id = "{0}{1}".format(self.name, pkglint_id)
-                        if engine.linted(action=action, manifest=manifest,
-                            lint_id=lint_id):
-                                continue
-                        if action.attrs["name"] not in seen_sets:
-                                seen_sets[action.attrs["name"]] = [action]
-                        else:
-                                seen_sets[action.attrs["name"]].append(action)
-
-                for key in seen_sets:
-                        actions = seen_sets[key]
-                        if len(actions) > 1:
-                                conflict_vars, conflict_actions = \
-                                    self.conflicting_variants(actions,
-                                        manifest.get_all_variants())
-                                if conflict_actions:
-                                        duplicates.append(key)
-
-                if duplicates:
-                        dlist = sorted((str(d) for d in duplicates))
-                        engine.error(dup_set_msg.format(
-                            names=" ".join(dlist),
-                            pkg=manifest.fmri),
-                            msgid=lint_id)
-
-        duplicate_sets.pkglint_desc = _(
-            "Packages should not have duplicate 'set' actions.")
-
-        def duplicate_licenses(self, manifest, engine, pkglint_id="016"):
-                """Checks for duplicate license actions."""
-                seen_licenses = {}
-                dup_lic_msg = _("duplicate license actions on {names} in {pkg}")
-                duplicates = []
-                lint_id = "{0}{1}".format(self.name, pkglint_id)
-                for action in manifest.gen_actions_by_type("license"):
-                        if engine.linted(action=action, manifest=manifest,
-                            lint_id=lint_id):
-                                continue
-                        lic = action.attrs['license']
-                        if lic not in seen_licenses:
-                                seen_licenses[lic] = [action]
-                        else:
-                                seen_licenses[lic].append(action)
-
-                for key in seen_licenses:
-                        actions = seen_licenses[key]
-                        if len(actions) > 1:
-                                conflict_vars, conflict_actions = \
-                                    self.conflicting_variants(actions,
-                                        manifest.get_all_variants())
-                                if conflict_actions:
-                                        duplicates.append(key)
-
-                if duplicates:
-                        dlist = sorted((str(d) for d in duplicates))
-                        engine.error(dup_lic_msg.format(
-                            names=" ".join(dlist),
-                            pkg=manifest.fmri),
-                            msgid=lint_id)
-
-        duplicate_licenses.pkglint_desc = _(
-            "Packages should not have duplicate 'license' actions.")
-
-        def linted(self, manifest, engine, pkglint_id="007"):
-                """Logs an INFO message with the key/value pairs of all
-                pkg.linted* attributes set on this manifest."""
-
-                linted_attrs = [(key, manifest.attributes[key])
-                    for key in sorted(manifest.attributes.keys())
-                    if key.startswith("pkg.linted")]
-
-                if linted_attrs:
-                        engine.info(_("pkg.linted attributes detected for "
-                            "{pkg}: {linted}").format(pkg=manifest.fmri,
-                            linted=", ".join(["{0}={1}".format(key, val)
-                             for key,val in linted_attrs])),
-                             msgid="{0}{1}".format(self.name, pkglint_id),
-                             ignore_linted=True)
-
-        linted.pkglint_desc = _("Show manifests with pkg.linted attributes.")
-
-        def info_classification(self, manifest, engine, pkglint_id="008"):
-                """Checks that the info.classification attribute is valid."""
-
-                if (not "info.classification" in manifest) or \
-                    self.skip_classification_check:
-                        return
-
-                if not self.classification_data or \
-                    not self.classification_data.sections():
-                        engine.error(_("Unable to perform manifest checks "
-                            "for info.classification attribute: {0}").format(
-                            self.bad_classification_data),
-                            msgid="{0}{1}.1".format(self.name, pkglint_id))
-                        self.skip_classification_check = True
-                        return
-
-                action = engine.get_attr_action("info.classification", manifest)
+        for key in ["pkg.description", "pkg.summary"]:
+            if key in manifest:
+                action = engine.get_attr_action(key, manifest)
                 engine.advise_loggers(action=action, manifest=manifest)
+                engine.error(
+                    _("obsolete package {pkg} has " "{key} attribute").format(
+                        pkg=manifest.fmri, key=key
+                    ),
+                    msgid="{0}{1}.1".format(self.name, pkglint_id),
+                )
 
-                for item in action.attrlist("value"):
-                        self._check_info_classification_value(engine, item,
-                            manifest.fmri, "{0}{1}".format(self.name, pkglint_id))
+        # the loggers are no longer concerned about actions
+        engine.advise_loggers(manifest=manifest)
 
-        info_classification.pkglint_desc = _(
-            "info.classification attribute should be valid.")
+        has_invalid_action = False
+        linted_action = None
 
-        def _check_info_classification_value(self, engine, value, fmri, msgid):
+        lint_id = "{0}{1}.2".format(self.name, pkglint_id)
+        for action in manifest.gen_actions():
+            # since we only emit the error once, after iterating
+            # over all actions, we may lose the action that could
+            # contain the linted flag, so the logging
+            # subsystem will not be able to use it to print a
+            # "lint bypassed" message.  Save it here.
+            if engine.linted(action=action, manifest=manifest, lint_id=lint_id):
+                linted_action = action
+                continue
 
-                prefix = "org.opensolaris.category.2008:"
+            if action.name not in ["set", "signature"]:
+                has_invalid_action = True
 
-                if not prefix in value:
-                        engine.error(_("info.classification attribute "
-                            "does not contain '{prefix}' for {fmri}").format(
-                            **locals()), msgid="{0}.2".format(msgid))
-                        return
+        if has_invalid_action:
+            engine.error(
+                _(
+                    "obsolete package {0} contains actions other than "
+                    "set or signature actions"
+                ).format(manifest.fmri),
+                msgid=lint_id,
+            )
 
-                classification = value.replace(prefix, "")
+        # report that we bypassed a check
+        if linted_action and not has_invalid_action:
+            engine.advise_loggers(action=linted_action, manifest=manifest)
+            engine.error(
+                _(
+                    "obsolete package {0} contains actions other than "
+                    "set or signature actions"
+                ).format(manifest.fmri),
+                msgid=lint_id,
+            )
 
-                components = classification.split("/", 1)
-                if len(components) != 2:
-                        engine.error(_("info.classification value {value} "
-                            "does not match "
-                            "{prefix}<Section>/<Category> for {fmri}").format(
-                            **locals()), msgid="{0}.3".format(msgid))
-                        return
+        # determine whether other packages we know about have
+        # dependencies on this obsolete package.
+        obsolete_depends = set()
+        lint_id = "{0}{1}.3".format(self.name, pkglint_id)
 
-                # the data file looks like:
-                # [Section]
-                # category = Cat1,Cat2,Cat3
-                #
-                # We expect the info.classification action to look like:
-                # org.opensolaris.category.2008:Section/Cat2
-                #
-                section, category = components
-                valid_value = True
-                ref_categories = []
-                try:
-                        ref_categories = self.classification_data.get(section,
-                            "category").split(",")
-                        if category not in ref_categories:
-                                valid_value = False
-                except configparser.NoSectionError:
-                        sections = self.classification_data.sections()
-                        engine.error(_("info.classification value {value} "
-                            "does not contain one of the valid sections "
-                            "{ref_sections} for {fmri}.").format(
-                            value=value,
-                            ref_sections=", ".join(sorted(sections)),
-                            fmri=fmri),
-                            msgid="{0}.4".format(msgid))
-                        return
-                except configparser.NoOptionError:
-                        engine.error(_("Invalid info.classification value for "
-                            "{fmri}: data file {file} does not have a "
-                            "'category' key for section {section}.").format(
-                            file=self.classification_path,
-                            section=section,
-                            fmri=fmri),
-                             msgid="{0}.5".format(msgid))
-                        return
+        depends = set(self.dependencies.get(manifest.fmri.get_name(), []))
+        if depends:
+            for depending_package in depends:
+                p = engine.get_manifest(
+                    str(depending_package), search_type=engine.LATEST_SUCCESSOR
+                )
+                if p.get("pkg.obsolete", None) != "true":
+                    obsolete_depends.add(p.fmri)
+        if obsolete_depends:
+            # this is only a warning, because at install-time the
+            # solver may still be able to find a non-obsolete
+            # version of a package.
+            engine.warning(
+                "obsolete package {pkg} is depended "
+                "upon by the following packages: "
+                "{deps}".format(
+                    pkg=manifest.fmri,
+                    deps=" ".join([str(fmri) for fmri in obsolete_depends]),
+                ),
+                msgid=lint_id,
+            )
 
-                if valid_value:
-                        return
+    obsoletion.pkglint_desc = _("Obsolete packages should have valid contents.")
 
-                ref_cats = self.classification_data.get(section, "category")
-                engine.error(_("info.classification attribute in {fmri} "
-                    "does not contain one of the values defined for the "
-                    "section {section}: {ref_cats} from {path}").format(
-                    section=section,
-                    fmri=fmri,
-                    path=self.classification_path,
-                    ref_cats=ref_cats),
-                    msgid="{0}.6".format(msgid))
+    def renames(self, manifest, engine, pkglint_id="002"):
+        """Checks for correct package renaming.
+        * error if renamed packages contain anything other than set,
+          signature and depend actions.
+        * follows renames, ensuring they're not circular, and don't
+          end up at an obsolete package.
+        """
 
-        def bogus_description(self, manifest, engine, pkglint_id="009"):
-                """Warns when a package has an empty summary or description,
-                or a description which is identical to the summary."""
+        if "pkg.renamed" not in manifest:
+            return
 
-                desc = manifest.get("pkg.description", None)
-                summ = manifest.get("pkg.summary", None)
+        has_invalid_action = False
+        seen_linted_action = False
+        invalid_action_id = "{0}{1}.1".format(self.name, pkglint_id)
+        count_depends = 0
 
-                if desc == "":
-                        action = engine.get_attr_action("pkg.description",
-                            manifest)
-                        engine.advise_loggers(action=action, manifest=manifest)
-                        engine.warning(_("Empty pkg.description in {0}").format(
-                            manifest.fmri),
-                            msgid="{0}{1}.1".format(self.name, pkglint_id))
+        for action in manifest.gen_actions():
+            if action.name not in ["set", "depend", "signature"]:
+                if engine.linted(
+                    action=action, manifest=manifest, lint_id=invalid_action_id
+                ):
+                    seen_linted_action = action
+                    continue
+                has_invalid_action = True
 
-                if summ == "":
-                        action = engine.get_attr_action("pkg.summary",
-                            manifest)
-                        engine.advise_loggers(action=action, manifest=manifest)
-                        engine.warning(_("Empty pkg.summary in {0}").format(
-                            manifest.fmri),
-                            msgid="{0}{1}.3".format(self.name, pkglint_id))
+            if action.name == "depend":
+                if (
+                    "incorporation" not in action.attrs["fmri"]
+                    or action.attrs["type"] == "require"
+                ):
+                    count_depends = count_depends + 1
 
-                if desc == summ and desc:
-                        action = engine.get_attr_action("pkg.summary", manifest)
-                        engine.advise_loggers(action=action, manifest=manifest)
-                        engine.warning(_("pkg.description matches pkg.summary "
-                            "in {0}").format(manifest.fmri),
-                            msgid="{0}{1}.2".format(self.name, pkglint_id))
+        if has_invalid_action:
+            engine.error(
+                _(
+                    "renamed package {0} contains actions "
+                    "other than set, depend or signature actions"
+                ).format(manifest.fmri),
+                msgid=invalid_action_id,
+            )
 
-        bogus_description.pkglint_desc = _(
-            "A package's description should not match its summary.")
+        # if all actions in the manifest that would have caused errors
+        # were marked as linted, we need to advise the logging mechanism
+        # of at least one action that was marked as linted, then log the
+        # error, ultimately resulting in an INFO level message.
+        if seen_linted_action and not has_invalid_action:
+            engine.advise_loggers(action=seen_linted_action, manifest=manifest)
+            engine.error(
+                _(
+                    "renamed package {0} contains actions "
+                    "other than set, depend or signature actions"
+                ).format(manifest.fmri),
+                msgid=invalid_action_id,
+            )
 
-        def missing_attrs(self, manifest, engine, pkglint_id="010"):
-                """Various checks for missing attributes
-                * error when a package doesn't have a pkg.summary
-                (pkg.fmri should be present too, but that would get caught
-                before we get here)
-                """
-                if "pkg.renamed" in manifest:
-                        return
+        if count_depends == 0:
+            engine.error(
+                _(
+                    "renamed package {0} does not declare a "
+                    "'require' dependency indicating what it was "
+                    "renamed to"
+                ).format(manifest.fmri),
+                msgid="{0}{1}.2".format(self.name, pkglint_id),
+            )
 
-                if "pkg.obsolete" in manifest:
-                        return
-
-                if "pkg.summary" not in manifest:
-                        engine.error(
-                            _("Missing attribute 'pkg.summary' in {0}").format(
-                            manifest.fmri),
-                            msgid="{0}{1}.2".format(self.name, pkglint_id))
-
-        missing_attrs.pkglint_desc = _(
-            "Standard package attributes should be present.")
-
-        def missing_smf_fmri(self, manifest, engine, pkglint_id="011"):
-                """If we deliver files to lib/svc/manifest or
-                var/svc/manifest, we should include an org.opensolaris.smf.fmri
-                attribute in the manifest.  This only reports a warning, because
-                without pkglint content-checking support, we do not know whether
-                the file actually contains any services or instances."""
-
-                smf_manifests = []
-                for action in manifest.gen_actions_by_type("file"):
-
-                        if "path" not in action.attrs:
-                                contine
-
-                        path = action.attrs["path"]
-
-                        if not path.endswith(".xml"):
-                                continue
-
-                        if not (path.startswith("lib/svc/manifest") or
-                            path.startswith("var/svc/manifest")):
-                                continue
-                        smf_manifests.append(path)
-
-                if not smf_manifests:
-                        return
-
-                if "org.opensolaris.smf.fmri" in manifest:
-                        return
-
+        try:
+            mf = engine.follow_renames(str(manifest.fmri), old_mfs=[])
+            if not mf:
                 engine.warning(
-                    _("SMF manifests were delivered by {pkg}, but no "
-                    "org.opensolaris.smf.fmri attribute was found. "
-                    "Manifests found were: {manifests}").format(
-                    manifests=" ".join(smf_manifests),
-                    pkg=manifest.fmri),
-                    msgid="{0}{1}".format(self.name, pkglint_id))
+                    _(
+                        "unable to follow renames for "
+                        "{0}: possible missing package"
+                    ).format(manifest.fmri),
+                    msgid="{0}{1}.3".format(self.name, pkglint_id),
+                )
+            else:
+                if "pkg.obsolete" not in mf:
+                    return
+                engine.error(
+                    _(
+                        "package {pkg} was renamed "
+                        "to an obsolete package {obs}"
+                    ).format(pkg=manifest.fmri, obs=mf.fmri),
+                    msgid="{0}{1}.5".format(self.name, pkglint_id),
+                )
 
-        missing_smf_fmri.pkglint_desc = _(
-            "Packages delivering SMF services should have "
-            "org.opensolaris.smf.fmri attributes.")
+        except base.LintException as err:
+            engine.error(
+                _("package renaming: {0}").format(str(err)),
+                msgid="{0}{1}.4".format(self.name, pkglint_id),
+            )
 
-        def _merge_names(self, src, target, ignore_pubs=True):
-                """Merges the given src list into the target list"""
+    renames.pkglint_desc = _("Renamed packages should have valid contents.")
 
-                for p in src:
-                        if p not in target:
-                                target[p] = src[p]
-                                continue
+    def variants(self, manifest, engine, pkglint_id="003"):
+        """Checks for correct use of variant tags.
+        * if variant tags present, matching variant descriptions
+          exist and are correctly specified, with the exception of
+          variant.debug.* variants
+        * All manifests that deliver file actions of a given
+          architecture declare variant.arch
 
-                        src_lst = src[p]
-                        targ_lst = target[p]
+        These checks are only performed on published packages."""
 
-                        def remove_ancestors(pfmri, targ_list):
-                                """Removes older versions of pfmri from
-                                targ_list."""
-                                removals = []
-                                sname = pfmri.get_name()
-                                for old in targ_list:
-                                        tname = old.get_name()
-                                        if lint_fmri_successor(pfmri, old,
-                                            ignore_pubs=ignore_pubs):
-                                                removals.append(old)
-                                for i in removals:
-                                        targ_list.remove(i)
+        if not engine.do_pub_checks:
+            return
 
-                        for pfmri in src_lst:
-                                remove_ancestors(pfmri, targ_lst)
-                                targ_lst.append(pfmri)
+        unknown_variants = set()
+        undefined_variants = set()
+        has_arch_file = False
 
-                        target[p] = targ_lst
+        pkg_vars = manifest.get_all_variants()
+
+        undefined_lint_id = "{0}{1}.1".format(self.name, pkglint_id)
+        unknown_lint_id = "{0}{1}.2".format(self.name, pkglint_id)
+        missing_arch_lint_id = "{0}{1}.3".format(self.name, pkglint_id)
+
+        def ignore_variant(varname):
+            """check whether we can ignore this variant."""
+            return varname.startswith("variant.debug")
+
+        for action in manifest.gen_actions():
+            if engine.linted(action=action, manifest=manifest):
+                continue
+
+            if (
+                action.name == "file"
+                and action.attrs.get("pkg.filetype") == "elf"
+                or "elfarch" in action.attrs
+            ):
+                has_arch_file = True
+
+            vct = action.get_variant_template()
+            diff = vct.difference(pkg_vars)
+            for k in diff.type_diffs:
+                if not engine.linted(
+                    action=action, manifest=manifest, lint_id=undefined_lint_id
+                ):
+                    if ignore_variant(k):
+                        continue
+                    undefined_variants.add(k)
+            for k, v in diff.value_diffs:
+                if not engine.linted(
+                    action=action, manifest=manifest, lint_id=unknown_lint_id
+                ):
+                    if ignore_variant(k):
+                        continue
+                    unknown_variants.add("{0}={1}".format(k, v))
+
+        if len(undefined_variants) > 0:
+            vlist = sorted((v for v in undefined_variants))
+            engine.error(
+                _("variant(s) {vars} not defined by " "{pkg}").format(
+                    vars=" ".join(vlist), pkg=manifest.fmri
+                ),
+                msgid=undefined_lint_id,
+            )
+
+        if len(unknown_variants) > 0:
+            vlist = sorted((v for v in unknown_variants))
+            engine.error(
+                _(
+                    "variant(s) {vars} not in list "
+                    "of known values for variants in {pkg}"
+                ).format(vars=" ".join(vlist), pkg=manifest.fmri),
+                msgid=unknown_lint_id,
+            )
+
+        if (
+            has_arch_file
+            and "variant.arch" not in manifest
+            and not engine.linted(
+                manifest=manifest, lint_id=missing_arch_lint_id
+            )
+        ):
+            engine.error(
+                _("variant.arch not declared in {0}").format(manifest.fmri),
+                msgid=missing_arch_lint_id,
+            )
+
+    variants.pkglint_desc = _("Variants used by packages should be valid.")
+
+    def naming(self, manifest, engine, pkglint_id="004"):
+        """Warn when there's a namespace clash where the last component
+        of the pkg name matches an existing one in the catalog."""
+
+        lastname = os.path.basename(manifest.fmri.get_name())
+        if lastname not in self.ref_lastnames:
+            return
+
+        if lastname in self.processed_lastnames:
+            return
+
+        fmris = self.ref_lastnames[lastname]
+
+        # we ignored renamed or obsolete packages when building
+        # ref_lastnames, so this package might not be there,
+        # in which case, we can ignore this package too.
+        if manifest.fmri not in fmris:
+            return
+
+        if len(self.ref_lastnames[lastname]) > 1:
+            plist = sorted((f.get_fmri() for f in fmris))
+            engine.warning(
+                _(
+                    "last name component {name} in package name "
+                    "clashes across {pkgs}"
+                ).format(name=lastname, pkgs=" ".join(plist)),
+                msgid="{0}{1}".format(self.name, pkglint_id),
+            )
+
+        if not engine.linted(
+            manifest=manifest, lint_id="{0}{1}".format(self.name, pkglint_id)
+        ):
+            self.processed_lastnames.append(lastname)
+
+    naming.pkglint_desc = _("Packages are encouraged to use unique leaf names.")
+
+    def duplicate_deps(self, manifest, engine, pkglint_id="005"):
+        """Checks for repeated dependencies, including package version
+        substrings."""
+
+        seen_deps = {}
+        duplicates = []
+        dup_msg = _("duplicate depend actions in {pkg} {actions}")
+        duplicates = []
+        for action in manifest.gen_actions_by_type("depend"):
+            # this only checks require, require-any and group-any
+            # actions
+            if action.attrs["type"] not in [
+                "require",
+                "require-any",
+                "group-any",
+            ]:
+                continue
+
+            if "fmri" not in action.attrs:
+                lint_id = "{0}{1}.1".format(self.name, pkglint_id)
+                if not engine.linted(
+                    action=action, manifest=manifest, lint_id=lint_id
+                ):
+                    engine.critical(
+                        _(
+                            "no fmri attribute in depend " "action in {0}"
+                        ).format(manifest.fmri),
+                        msgid=lint_id,
+                    )
+                continue
+
+            lint_id = "{0}{1}.2".format(self.name, pkglint_id)
+            if engine.linted(action=action, manifest=manifest, lint_id=lint_id):
+                continue
+
+            deps = action.attrs["fmri"]
+            if isinstance(deps, six.string_types):
+                deps = [deps]
+
+            for dep in deps:
+                shortname = fmri.extract_pkg_name(dep)
+                if shortname not in seen_deps:
+                    seen_deps[shortname] = [action]
+                else:
+                    seen_deps[shortname].append(action)
+
+        compared = set()
+        for key in seen_deps:
+            actions = seen_deps[key]
+            if len(actions) > 1:
+                conflict_vars, conflict_actions = self.conflicting_dep_actions(
+                    actions, manifest.get_all_variants(), compared
+                )
+                if conflict_actions:
+                    duplicates.append(key)
+
+        if duplicates:
+            dlist = sorted((str(d) for d in duplicates))
+            engine.error(
+                dup_msg.format(pkg=manifest.fmri, actions=" ".join(dlist)),
+                msgid="{0}{1}.2".format(self.name, pkglint_id),
+            )
+
+    duplicate_deps.pkglint_desc = _(
+        "Packages should not have duplicate 'depend' actions."
+    )
+
+    def duplicate_sets(self, manifest, engine, pkglint_id="006"):
+        """Checks for duplicate set actions."""
+        seen_sets = {}
+        dup_set_msg = _("duplicate set actions on {names} in {pkg}")
+        duplicates = []
+        lint_id = "{0}{1}".format(self.name, pkglint_id)
+        for action in manifest.gen_actions_by_type("set"):
+            lint_id = "{0}{1}".format(self.name, pkglint_id)
+            if engine.linted(action=action, manifest=manifest, lint_id=lint_id):
+                continue
+            if action.attrs["name"] not in seen_sets:
+                seen_sets[action.attrs["name"]] = [action]
+            else:
+                seen_sets[action.attrs["name"]].append(action)
+
+        for key in seen_sets:
+            actions = seen_sets[key]
+            if len(actions) > 1:
+                conflict_vars, conflict_actions = self.conflicting_variants(
+                    actions, manifest.get_all_variants()
+                )
+                if conflict_actions:
+                    duplicates.append(key)
+
+        if duplicates:
+            dlist = sorted((str(d) for d in duplicates))
+            engine.error(
+                dup_set_msg.format(names=" ".join(dlist), pkg=manifest.fmri),
+                msgid=lint_id,
+            )
+
+    duplicate_sets.pkglint_desc = _(
+        "Packages should not have duplicate 'set' actions."
+    )
+
+    def duplicate_licenses(self, manifest, engine, pkglint_id="016"):
+        """Checks for duplicate license actions."""
+        seen_licenses = {}
+        dup_lic_msg = _("duplicate license actions on {names} in {pkg}")
+        duplicates = []
+        lint_id = "{0}{1}".format(self.name, pkglint_id)
+        for action in manifest.gen_actions_by_type("license"):
+            if engine.linted(action=action, manifest=manifest, lint_id=lint_id):
+                continue
+            lic = action.attrs["license"]
+            if lic not in seen_licenses:
+                seen_licenses[lic] = [action]
+            else:
+                seen_licenses[lic].append(action)
+
+        for key in seen_licenses:
+            actions = seen_licenses[key]
+            if len(actions) > 1:
+                conflict_vars, conflict_actions = self.conflicting_variants(
+                    actions, manifest.get_all_variants()
+                )
+                if conflict_actions:
+                    duplicates.append(key)
+
+        if duplicates:
+            dlist = sorted((str(d) for d in duplicates))
+            engine.error(
+                dup_lic_msg.format(names=" ".join(dlist), pkg=manifest.fmri),
+                msgid=lint_id,
+            )
+
+    duplicate_licenses.pkglint_desc = _(
+        "Packages should not have duplicate 'license' actions."
+    )
+
+    def linted(self, manifest, engine, pkglint_id="007"):
+        """Logs an INFO message with the key/value pairs of all
+        pkg.linted* attributes set on this manifest."""
+
+        linted_attrs = [
+            (key, manifest.attributes[key])
+            for key in sorted(manifest.attributes.keys())
+            if key.startswith("pkg.linted")
+        ]
+
+        if linted_attrs:
+            engine.info(
+                _(
+                    "pkg.linted attributes detected for " "{pkg}: {linted}"
+                ).format(
+                    pkg=manifest.fmri,
+                    linted=", ".join(
+                        [
+                            "{0}={1}".format(key, val)
+                            for key, val in linted_attrs
+                        ]
+                    ),
+                ),
+                msgid="{0}{1}".format(self.name, pkglint_id),
+                ignore_linted=True,
+            )
+
+    linted.pkglint_desc = _("Show manifests with pkg.linted attributes.")
+
+    def info_classification(self, manifest, engine, pkglint_id="008"):
+        """Checks that the info.classification attribute is valid."""
+
+        if (
+            not "info.classification" in manifest
+        ) or self.skip_classification_check:
+            return
+
+        if (
+            not self.classification_data
+            or not self.classification_data.sections()
+        ):
+            engine.error(
+                _(
+                    "Unable to perform manifest checks "
+                    "for info.classification attribute: {0}"
+                ).format(self.bad_classification_data),
+                msgid="{0}{1}.1".format(self.name, pkglint_id),
+            )
+            self.skip_classification_check = True
+            return
+
+        action = engine.get_attr_action("info.classification", manifest)
+        engine.advise_loggers(action=action, manifest=manifest)
+
+        for item in action.attrlist("value"):
+            self._check_info_classification_value(
+                engine,
+                item,
+                manifest.fmri,
+                "{0}{1}".format(self.name, pkglint_id),
+            )
+
+    info_classification.pkglint_desc = _(
+        "info.classification attribute should be valid."
+    )
+
+    def _check_info_classification_value(self, engine, value, fmri, msgid):
+        prefix = "org.opensolaris.category.2008:"
+
+        if not prefix in value:
+            engine.error(
+                _(
+                    "info.classification attribute "
+                    "does not contain '{prefix}' for {fmri}"
+                ).format(**locals()),
+                msgid="{0}.2".format(msgid),
+            )
+            return
+
+        classification = value.replace(prefix, "")
+
+        components = classification.split("/", 1)
+        if len(components) != 2:
+            engine.error(
+                _(
+                    "info.classification value {value} "
+                    "does not match "
+                    "{prefix}<Section>/<Category> for {fmri}"
+                ).format(**locals()),
+                msgid="{0}.3".format(msgid),
+            )
+            return
+
+        # the data file looks like:
+        # [Section]
+        # category = Cat1,Cat2,Cat3
+        #
+        # We expect the info.classification action to look like:
+        # org.opensolaris.category.2008:Section/Cat2
+        #
+        section, category = components
+        valid_value = True
+        ref_categories = []
+        try:
+            ref_categories = self.classification_data.get(
+                section, "category"
+            ).split(",")
+            if category not in ref_categories:
+                valid_value = False
+        except configparser.NoSectionError:
+            sections = self.classification_data.sections()
+            engine.error(
+                _(
+                    "info.classification value {value} "
+                    "does not contain one of the valid sections "
+                    "{ref_sections} for {fmri}."
+                ).format(
+                    value=value,
+                    ref_sections=", ".join(sorted(sections)),
+                    fmri=fmri,
+                ),
+                msgid="{0}.4".format(msgid),
+            )
+            return
+        except configparser.NoOptionError:
+            engine.error(
+                _(
+                    "Invalid info.classification value for "
+                    "{fmri}: data file {file} does not have a "
+                    "'category' key for section {section}."
+                ).format(
+                    file=self.classification_path, section=section, fmri=fmri
+                ),
+                msgid="{0}.5".format(msgid),
+            )
+            return
+
+        if valid_value:
+            return
+
+        ref_cats = self.classification_data.get(section, "category")
+        engine.error(
+            _(
+                "info.classification attribute in {fmri} "
+                "does not contain one of the values defined for the "
+                "section {section}: {ref_cats} from {path}"
+            ).format(
+                section=section,
+                fmri=fmri,
+                path=self.classification_path,
+                ref_cats=ref_cats,
+            ),
+            msgid="{0}.6".format(msgid),
+        )
+
+    def bogus_description(self, manifest, engine, pkglint_id="009"):
+        """Warns when a package has an empty summary or description,
+        or a description which is identical to the summary."""
+
+        desc = manifest.get("pkg.description", None)
+        summ = manifest.get("pkg.summary", None)
+
+        if desc == "":
+            action = engine.get_attr_action("pkg.description", manifest)
+            engine.advise_loggers(action=action, manifest=manifest)
+            engine.warning(
+                _("Empty pkg.description in {0}").format(manifest.fmri),
+                msgid="{0}{1}.1".format(self.name, pkglint_id),
+            )
+
+        if summ == "":
+            action = engine.get_attr_action("pkg.summary", manifest)
+            engine.advise_loggers(action=action, manifest=manifest)
+            engine.warning(
+                _("Empty pkg.summary in {0}").format(manifest.fmri),
+                msgid="{0}{1}.3".format(self.name, pkglint_id),
+            )
+
+        if desc == summ and desc:
+            action = engine.get_attr_action("pkg.summary", manifest)
+            engine.advise_loggers(action=action, manifest=manifest)
+            engine.warning(
+                _("pkg.description matches pkg.summary " "in {0}").format(
+                    manifest.fmri
+                ),
+                msgid="{0}{1}.2".format(self.name, pkglint_id),
+            )
+
+    bogus_description.pkglint_desc = _(
+        "A package's description should not match its summary."
+    )
+
+    def missing_attrs(self, manifest, engine, pkglint_id="010"):
+        """Various checks for missing attributes
+        * error when a package doesn't have a pkg.summary
+        (pkg.fmri should be present too, but that would get caught
+        before we get here)
+        """
+        if "pkg.renamed" in manifest:
+            return
+
+        if "pkg.obsolete" in manifest:
+            return
+
+        if "pkg.summary" not in manifest:
+            engine.error(
+                _("Missing attribute 'pkg.summary' in {0}").format(
+                    manifest.fmri
+                ),
+                msgid="{0}{1}.2".format(self.name, pkglint_id),
+            )
+
+    missing_attrs.pkglint_desc = _(
+        "Standard package attributes should be present."
+    )
+
+    def missing_smf_fmri(self, manifest, engine, pkglint_id="011"):
+        """If we deliver files to lib/svc/manifest or
+        var/svc/manifest, we should include an org.opensolaris.smf.fmri
+        attribute in the manifest.  This only reports a warning, because
+        without pkglint content-checking support, we do not know whether
+        the file actually contains any services or instances."""
+
+        smf_manifests = []
+        for action in manifest.gen_actions_by_type("file"):
+            if "path" not in action.attrs:
+                contine
+
+            path = action.attrs["path"]
+
+            if not path.endswith(".xml"):
+                continue
+
+            if not (
+                path.startswith("lib/svc/manifest")
+                or path.startswith("var/svc/manifest")
+            ):
+                continue
+            smf_manifests.append(path)
+
+        if not smf_manifests:
+            return
+
+        if "org.opensolaris.smf.fmri" in manifest:
+            return
+
+        engine.warning(
+            _(
+                "SMF manifests were delivered by {pkg}, but no "
+                "org.opensolaris.smf.fmri attribute was found. "
+                "Manifests found were: {manifests}"
+            ).format(manifests=" ".join(smf_manifests), pkg=manifest.fmri),
+            msgid="{0}{1}".format(self.name, pkglint_id),
+        )
+
+    missing_smf_fmri.pkglint_desc = _(
+        "Packages delivering SMF services should have "
+        "org.opensolaris.smf.fmri attributes."
+    )
+
+    def _merge_names(self, src, target, ignore_pubs=True):
+        """Merges the given src list into the target list"""
+
+        for p in src:
+            if p not in target:
+                target[p] = src[p]
+                continue
+
+            src_lst = src[p]
+            targ_lst = target[p]
+
+            def remove_ancestors(pfmri, targ_list):
+                """Removes older versions of pfmri from
+                targ_list."""
+                removals = []
+                sname = pfmri.get_name()
+                for old in targ_list:
+                    tname = old.get_name()
+                    if lint_fmri_successor(pfmri, old, ignore_pubs=ignore_pubs):
+                        removals.append(old)
+                for i in removals:
+                    targ_list.remove(i)
+
+            for pfmri in src_lst:
+                remove_ancestors(pfmri, targ_lst)
+                targ_lst.append(pfmri)
+
+            target[p] = targ_lst
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/lockfile.py
+++ b/src/modules/lockfile.py
@@ -37,218 +37,238 @@ import pkg.client.api_errors as api_errors
 from pkg.client import global_settings
 from pkg.misc import DummyLock
 
+
 class LockFile(object):
-        """A class that provides generic lockfile support.  This
-        allows Python processes to perform inter-process locking
-        using the filesystem."""
+    """A class that provides generic lockfile support.  This
+    allows Python processes to perform inter-process locking
+    using the filesystem."""
 
-        def __init__(self, filepath, set_lockstr=None, get_lockstr=None,
-            failure_exc=None, provide_mutex=True):
-                """Create a LockFile object.  The 'filepath' argument
-                should be the path to the file that will be used as the
-                lockfile.  If the caller may supply the following
-                optional arguments:
+    def __init__(
+        self,
+        filepath,
+        set_lockstr=None,
+        get_lockstr=None,
+        failure_exc=None,
+        provide_mutex=True,
+    ):
+        """Create a LockFile object.  The 'filepath' argument
+        should be the path to the file that will be used as the
+        lockfile.  If the caller may supply the following
+        optional arguments:
 
-                set_lockstr - A function that returns a string.  This
-                is called when the lock operation wants to write
-                implementation specific text into the lock file.
+        set_lockstr - A function that returns a string.  This
+        is called when the lock operation wants to write
+        implementation specific text into the lock file.
 
-                get_lockstr - A function that takes a string and returns
-                a dictionary.  This function must be able to parse
-                the lock string created by set_lockstr.  The dictionary
-                object is passed as **kwargs to 'failure_exc' if
-                the lock is non-blocking and fails.
+        get_lockstr - A function that takes a string and returns
+        a dictionary.  This function must be able to parse
+        the lock string created by set_lockstr.  The dictionary
+        object is passed as **kwargs to 'failure_exc' if
+        the lock is non-blocking and fails.
 
-                failure_exc - If a non-blocking lock acquisition fails,
-                this exception will be raised.  It should allow the
-                caller to specify a kwargs argument, but not all
-                invocations will provide kwargs.
+        failure_exc - If a non-blocking lock acquisition fails,
+        this exception will be raised.  It should allow the
+        caller to specify a kwargs argument, but not all
+        invocations will provide kwargs.
 
-                provide_mutex - By default, the LockFile object
-                will use a mutex to sychronize access for threads in
-                the current process.  If the caller is already providing
-                mutual exclusion to the LockFile object, this should
-                be set to False."""
+        provide_mutex - By default, the LockFile object
+        will use a mutex to sychronize access for threads in
+        the current process.  If the caller is already providing
+        mutual exclusion to the LockFile object, this should
+        be set to False."""
 
+        self._fileobj = None
+        self._filepath = filepath
+        self._set_lockstr = set_lockstr
+        self._get_lockstr = get_lockstr
+        self._provide_mutex = False
+        if failure_exc:
+            self._failure_exc = failure_exc
+        else:
+            self._failure_exc = FileLocked
+        if provide_mutex:
+            self._lock = nrlock.NRLock()
+            self._provide_mutex = True
+        else:
+            self._lock = DummyLock()
+
+    @property
+    def locked(self):
+        if self._provide_mutex:
+            return self._lock.locked and self._fileobj
+        return self._fileobj
+
+    def lock(self, blocking=True):
+        """Lock the lockfile, to prevent access from other
+        processes.  If blocking is False, this method will
+        return an exception, instead of blocking, if the lock
+        is held.  If the lockfile cannot be opened,
+        this method may return an EnvironmentError."""
+
+        #
+        # The password locking in cfgfiles.py depends on the behavior
+        # of this function, which imitates that of libc's lckpwdf(3C).
+        # If this function is changed, it either needs to continue to be
+        # compatible with lckpwdf, or changes to cfgfiles.py must be
+        # made.
+        #
+
+        rval = self._lock.acquire(blocking=int(blocking))
+        # Lock acquisition failed.
+        if not rval:
+            raise self._failure_exc()
+
+        lock_type = fcntl.LOCK_EX
+        if not blocking:
+            lock_type |= fcntl.LOCK_NB
+
+        # Attempt an initial open of the lock file.
+        lf = None
+
+        # Caller should catch EACCES and EROFS.
+        try:
+            # If the file is a symlink we catch an exception
+            # and do not update the file.
+            fd = os.open(
+                self._filepath,
+                os.O_RDWR | os.O_APPEND | os.O_CREAT | os.O_NOFOLLOW,
+            )
+            lf = os.fdopen(fd, "ab+")
+        except OSError as e:
+            self._lock.release()
+            if e.errno == errno.ELOOP:
+                raise api_errors.UnexpectedLinkError(
+                    os.path.dirname(self._filepath),
+                    os.path.basename(self._filepath),
+                    e.errno,
+                )
+            raise e
+        except:
+            self._lock.release()
+            raise
+
+        # Attempt to lock the file.
+        try:
+            fcntl.lockf(lf, lock_type)
+        except IOError as e:
+            if e.errno not in (errno.EAGAIN, errno.EACCES):
+                self._lock.release()
+                raise
+
+            # If the lock failed (because it is likely contended),
+            # then extract the information about the lock acquirer
+            # and raise an exception.
+            lock_data = lf.read().strip()
+            self._lock.release()
+            if self._get_lockstr:
+                lock_dict = self._get_lockstr(lock_data)
+            else:
+                lock_dict = {}
+            raise self._failure_exc(**lock_dict)
+
+        # Store information about the lock acquirer and write it.
+        try:
+            lf.truncate(0)
+            lock_str = None
+            if self._set_lockstr:
+                lock_str = self._set_lockstr()
+            if lock_str:
+                lf.write(misc.force_bytes(lock_str))
+            lf.flush()
+            self._fileobj = lf
+        except:
+            self._fileobj = None
+            lf.close()
+            self._lock.release()
+            raise
+
+    def unlock(self):
+        """Unlocks the LockFile."""
+
+        if self._fileobj:
+            # To avoid race conditions with the next caller
+            # waiting for the lock file, it is simply
+            # truncated instead of removed.
+            try:
+                fcntl.lockf(self._fileobj, fcntl.LOCK_UN)
+                self._fileobj.truncate(0)
+                self._fileobj.close()
+                self._lock.release()
+            except EnvironmentError:
+                # If fcntl, or the file operations returned
+                # an exception, drop the lock. Do not catch
+                # the exception that could escape from
+                # releasing the lock.
+                self._lock.release()
+                raise
+            finally:
                 self._fileobj = None
-                self._filepath = filepath
-                self._set_lockstr = set_lockstr
-                self._get_lockstr = get_lockstr
-                self._provide_mutex = False
-                if failure_exc:
-                        self._failure_exc = failure_exc
-                else:
-                        self._failure_exc = FileLocked
-                if provide_mutex:
-                        self._lock = nrlock.NRLock()
-                        self._provide_mutex = True
-                else:
-                        self._lock = DummyLock()
-
-        @property
-        def locked(self):
-                if self._provide_mutex:
-                        return self._lock.locked and self._fileobj
-                return self._fileobj
-
-        def lock(self, blocking=True):
-                """Lock the lockfile, to prevent access from other
-                processes.  If blocking is False, this method will
-                return an exception, instead of blocking, if the lock
-                is held.  If the lockfile cannot be opened,
-                this method may return an EnvironmentError."""
-
-                #
-                # The password locking in cfgfiles.py depends on the behavior
-                # of this function, which imitates that of libc's lckpwdf(3C).
-                # If this function is changed, it either needs to continue to be
-                # compatible with lckpwdf, or changes to cfgfiles.py must be
-                # made.
-                #
-
-                rval = self._lock.acquire(blocking=int(blocking))
-                # Lock acquisition failed.
-                if not rval:
-                        raise self._failure_exc()
-
-                lock_type = fcntl.LOCK_EX
-                if not blocking:
-                        lock_type |= fcntl.LOCK_NB
-
-                # Attempt an initial open of the lock file.
-                lf = None
-
-                # Caller should catch EACCES and EROFS.
-                try:
-                        # If the file is a symlink we catch an exception
-                        # and do not update the file.
-                        fd = os.open(self._filepath,
-                            os.O_RDWR|os.O_APPEND|os.O_CREAT|
-                            os.O_NOFOLLOW)
-                        lf = os.fdopen(fd, "ab+")
-                except OSError as e:
-                        self._lock.release()
-                        if e.errno == errno.ELOOP:
-                                raise api_errors.UnexpectedLinkError(
-                                    os.path.dirname(self._filepath),
-                                    os.path.basename(self._filepath),
-                                    e.errno)
-                        raise e
-                except:
-                        self._lock.release()
-                        raise
-
-                # Attempt to lock the file.
-                try:
-                        fcntl.lockf(lf, lock_type)
-                except IOError as e:
-                        if e.errno not in (errno.EAGAIN, errno.EACCES):
-                                self._lock.release()
-                                raise
-
-                        # If the lock failed (because it is likely contended),
-                        # then extract the information about the lock acquirer
-                        # and raise an exception.
-                        lock_data = lf.read().strip()
-                        self._lock.release()
-                        if self._get_lockstr:
-                                lock_dict = self._get_lockstr(lock_data)
-                        else:
-                                lock_dict = {}
-                        raise self._failure_exc(**lock_dict)
-
-                # Store information about the lock acquirer and write it.
-                try:
-                        lf.truncate(0)
-                        lock_str = None
-                        if self._set_lockstr:
-                                lock_str = self._set_lockstr()
-                        if lock_str:
-                                lf.write(misc.force_bytes(lock_str))
-                        lf.flush()
-                        self._fileobj = lf
-                except:
-                        self._fileobj = None
-                        lf.close()
-                        self._lock.release()
-                        raise
-
-        def unlock(self):
-                """Unlocks the LockFile."""
-
-                if self._fileobj:
-                        # To avoid race conditions with the next caller
-                        # waiting for the lock file, it is simply
-                        # truncated instead of removed.
-                        try:
-                                fcntl.lockf(self._fileobj, fcntl.LOCK_UN)
-                                self._fileobj.truncate(0)
-                                self._fileobj.close()
-                                self._lock.release()
-                        except EnvironmentError:
-                                # If fcntl, or the file operations returned
-                                # an exception, drop the lock. Do not catch
-                                # the exception that could escape from
-                                # releasing the lock.
-                                self._lock.release()
-                                raise
-                        finally:
-                                self._fileobj = None
-                else:
-                        if self._provide_mutex:
-                                assert not self._lock.locked
+        else:
+            if self._provide_mutex:
+                assert not self._lock.locked
 
 
-class FileLocked(Exception):        
-        """Generic exception class used by LockFile.  Raised
-        in non-blocking mode when file or thread is already locked."""
+class FileLocked(Exception):
+    """Generic exception class used by LockFile.  Raised
+    in non-blocking mode when file or thread is already locked."""
 
-        def __init__(self, *args, **kwargs):
-                if args:
-                        self.data = args[0]
-                else:
-                        self.data = None
-                self._args = kwargs
+    def __init__(self, *args, **kwargs):
+        if args:
+            self.data = args[0]
+        else:
+            self.data = None
+        self._args = kwargs
 
-        def __str__(self):
-                errstr = "Unable to lock file"
-                if self.data:
-                        errstr += ": {0}".format(self.data)
-                return errstr
+    def __str__(self):
+        errstr = "Unable to lock file"
+        if self.data:
+            errstr += ": {0}".format(self.data)
+        return errstr
 
 
 def client_lock_get_str(lockstr):
-        lockdict = {}
+    lockdict = {}
 
-        try:
-                pid, pid_name, hostname, lock_ts =  lockstr.split(b"\n", 4)
-                lockdict["pid"] = pid
-                lockdict["pid_name"] = pid_name
-                lockdict["hostname"] = hostname
-                return lockdict
-        except ValueError:
-                return lockdict
+    try:
+        pid, pid_name, hostname, lock_ts = lockstr.split(b"\n", 4)
+        lockdict["pid"] = pid
+        lockdict["pid_name"] = pid_name
+        lockdict["hostname"] = hostname
+        return lockdict
+    except ValueError:
+        return lockdict
+
 
 def client_lock_set_str():
-        lock_ts = pkg.catalog.now_to_basic_ts()
+    lock_ts = pkg.catalog.now_to_basic_ts()
 
-        return "\n".join((str(os.getpid()), global_settings.client_name,
-            platform.node(), lock_ts, "\n"))
+    return "\n".join(
+        (
+            str(os.getpid()),
+            global_settings.client_name,
+            platform.node(),
+            lock_ts,
+            "\n",
+        )
+    )
+
 
 def generic_lock_get_str(lockstr):
-        lock_dict = {}
-        try:
-                pid, hostname, lock_ts = lockstr.split(b"\n", 3)
-                lock_dict["pid"] = pid
-                lock_dict["hostname"] = hostname
-                return lock_dict
-        except ValueError:
-                return lock_dict
+    lock_dict = {}
+    try:
+        pid, hostname, lock_ts = lockstr.split(b"\n", 3)
+        lock_dict["pid"] = pid
+        lock_dict["hostname"] = hostname
+        return lock_dict
+    except ValueError:
+        return lock_dict
+
 
 def generic_lock_set_str():
-        lock_ts = pkg.catalog.now_to_basic_ts()
+    lock_ts = pkg.catalog.now_to_basic_ts()
 
-        return "\n".join((str(os.getpid()), platform.node(), lock_ts, "\n"))
+    return "\n".join((str(os.getpid()), platform.node(), lock_ts, "\n"))
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/manifest.py
+++ b/src/modules/manifest.py
@@ -53,965 +53,992 @@ from pkg.misc import EmptyDict, EmptyI, expanddirs, PKG_FILE_MODE, PKG_DIR_MODE
 from pkg.actions.attribute import AttributeAction
 from pkg.actions.directory import DirectoryAction
 
-def _compile_fnpats(fn_pats):
-        """Private helper function that returns a compiled version of a
-        dictionary of fnmatch patterns."""
 
-        return dict(
-            (key, [
+def _compile_fnpats(fn_pats):
+    """Private helper function that returns a compiled version of a
+    dictionary of fnmatch patterns."""
+
+    return dict(
+        (
+            key,
+            [
                 re.compile(fnmatch.translate(pat), re.IGNORECASE).match
                 for pat in pats
-            ])
-            for (key, pats) in six.iteritems(fn_pats)
+            ],
         )
+        for (key, pats) in six.iteritems(fn_pats)
+    )
 
 
 def _attr_matches(action, attr_match):
-        """Private helper function: given an action, return True if any of its
-        attributes' values matches the pattern for the same attribute in the
-        attr_match dictionary, and False otherwise. Note that the patterns must
-        be pre-comiled using re.compile() or _compile_fnpats."""
+    """Private helper function: given an action, return True if any of its
+    attributes' values matches the pattern for the same attribute in the
+    attr_match dictionary, and False otherwise. Note that the patterns must
+    be pre-comiled using re.compile() or _compile_fnpats."""
 
-        if not attr_match:
-                return True
+    if not attr_match:
+        return True
 
-        for (attr, matches) in six.iteritems(attr_match):
-                if attr in action.attrs:
-                        for match in matches:
-                                for attrval in action.attrlist(attr):
-                                        if match(attrval):
-                                                return True
-        return False
+    for attr, matches in six.iteritems(attr_match):
+        if attr in action.attrs:
+            for match in matches:
+                for attrval in action.attrlist(attr):
+                    if match(attrval):
+                        return True
+    return False
 
 
 class ManifestDifference(
-    namedtuple("ManifestDifference", "added changed removed")):
+    namedtuple("ManifestDifference", "added changed removed")
+):
+    __slots__ = []
 
-        __slots__ = []
+    __state__desc = tuple(
+        [
+            [(actions.generic.NSG, actions.generic.NSG)],
+            [(actions.generic.NSG, actions.generic.NSG)],
+            [(actions.generic.NSG, actions.generic.NSG)],
+        ]
+    )
 
-        __state__desc = tuple([
-            [ ( actions.generic.NSG, actions.generic.NSG ) ],
-            [ ( actions.generic.NSG, actions.generic.NSG ) ],
-            [ ( actions.generic.NSG, actions.generic.NSG ) ],
-        ])
-
-        __state__commonize = frozenset([
+    __state__commonize = frozenset(
+        [
             actions.generic.NSG,
-        ])
+        ]
+    )
 
-        @staticmethod
-        def getstate(obj, je_state=None):
-                """Returns the serialized state of this object in a format
-                that that can be easily stored using JSON, pickle, etc."""
-                return misc.json_encode(ManifestDifference.__name__,
-                    tuple(obj),
-                    ManifestDifference.__state__desc,
-                    commonize=ManifestDifference.__state__commonize,
-                    je_state=je_state)
+    @staticmethod
+    def getstate(obj, je_state=None):
+        """Returns the serialized state of this object in a format
+        that that can be easily stored using JSON, pickle, etc."""
+        return misc.json_encode(
+            ManifestDifference.__name__,
+            tuple(obj),
+            ManifestDifference.__state__desc,
+            commonize=ManifestDifference.__state__commonize,
+            je_state=je_state,
+        )
 
-        @staticmethod
-        def fromstate(state, jd_state=None):
-                """Allocate a new object using previously serialized state
-                obtained via getstate()."""
+    @staticmethod
+    def fromstate(state, jd_state=None):
+        """Allocate a new object using previously serialized state
+        obtained via getstate()."""
 
-                # decode serialized state into python objects
-                state = misc.json_decode(ManifestDifference.__name__,
-                    state,
-                    ManifestDifference.__state__desc,
-                    commonize=ManifestDifference.__state__commonize,
-                    jd_state=jd_state)
+        # decode serialized state into python objects
+        state = misc.json_decode(
+            ManifestDifference.__name__,
+            state,
+            ManifestDifference.__state__desc,
+            commonize=ManifestDifference.__state__commonize,
+            jd_state=jd_state,
+        )
 
-                return ManifestDifference(*state)
+        return ManifestDifference(*state)
+
 
 class Manifest(object):
-        """A Manifest is the representation of the actions composing a specific
-        package version on both the client and the repository.  Both purposes
-        utilize the same storage format.
+    """A Manifest is the representation of the actions composing a specific
+    package version on both the client and the repository.  Both purposes
+    utilize the same storage format.
 
-        The serialized structure of a manifest is an unordered list of actions.
+    The serialized structure of a manifest is an unordered list of actions.
 
-        The special action, "set", represents a package attribute.
+    The special action, "set", represents a package attribute.
 
-        The reserved attribute, "fmri", represents the package and version
-        described by this manifest.  It is available as a string via the
-        attributes dictionary, and as an FMRI object from the fmri member.
+    The reserved attribute, "fmri", represents the package and version
+    described by this manifest.  It is available as a string via the
+    attributes dictionary, and as an FMRI object from the fmri member.
 
-        The list of manifest-wide reserved attributes is
+    The list of manifest-wide reserved attributes is
 
-        base_directory          Default base directory, for non-user images.
-        fmri                    Package FMRI.
-        isa                     Package is intended for a list of ISAs.
-        platform                Package is intended for a list of platforms.
-        relocatable             Suitable for User Image.
+    base_directory          Default base directory, for non-user images.
+    fmri                    Package FMRI.
+    isa                     Package is intended for a list of ISAs.
+    platform                Package is intended for a list of platforms.
+    relocatable             Suitable for User Image.
 
-        All non-prefixed attributes are reserved to the framework.  Third
-        parties may prefix their attributes with a reversed domain name, domain
-        name, or stock symbol.  An example might be
+    All non-prefixed attributes are reserved to the framework.  Third
+    parties may prefix their attributes with a reversed domain name, domain
+    name, or stock symbol.  An example might be
 
-        com.example,supported
+    com.example,supported
 
-        as an indicator that a specific package version is supported by the
-        vendor, example.com.
+    as an indicator that a specific package version is supported by the
+    vendor, example.com.
 
-        manifest.null is provided as the null manifest.  Differences against the
-        null manifest result in the complete set of attributes and actions of
-        the non-null manifest, meaning that all operations can be viewed as
-        transitions between the manifest being installed and the manifest already
-        present in the image (which may be the null manifest).
+    manifest.null is provided as the null manifest.  Differences against the
+    null manifest result in the complete set of attributes and actions of
+    the non-null manifest, meaning that all operations can be viewed as
+    transitions between the manifest being installed and the manifest already
+    present in the image (which may be the null manifest).
+    """
+
+    def __init__(self, pfmri=None):
+        self.fmri = pfmri
+
+        self._cache = {}
+        self._absent_cache = []
+        self.actions = []
+        self.actions_bytype = {}
+        self.attributes = {}  # package-wide attributes
+        self.signatures = EmptyDict
+        self.excludes = EmptyI
+        if pfmri is not None:
+            if not isinstance(pfmri, fmri.PkgFmri):
+                pfmri = fmri.PkgFmri(pfmri)
+            self.publisher = pfmri.publisher
+        else:
+            self.publisher = None
+
+    def __str__(self):
+        r = ""
+        if "pkg.fmri" not in self.attributes and self.fmri != None:
+            r += "set name=pkg.fmri value={0}\n".format(self.fmri)
+
+        for act in sorted(self.actions):
+            r += "{0}\n".format(act)
+        return r
+
+    def as_lines(self):
+        """A generator function that returns the unsorted manifest
+        contents as lines of text."""
+
+        if "pkg.fmri" not in self.attributes and self.fmri != None:
+            yield "set name=pkg.fmri value={0}\n".format(self.fmri)
+
+        for act in self.actions:
+            yield "{0}\n".format(act)
+
+    def tostr_unsorted(self):
+        return "".join((l for l in self.as_lines()))
+
+    def difference(
+        self,
+        origin,
+        origin_exclude=EmptyI,
+        self_exclude=EmptyI,
+        pkgplan=None,
+        cmp_policy=None,
+    ):
+        """Return three lists of action pairs representing origin and
+        destination actions.  The first list contains the pairs
+        representing additions, the second list contains the pairs
+        representing updates, and the third list contains the pairs
+        representing removals.  All three lists are in the order in
+        which they should be executed."""
+        # XXX Do we need to find some way to assert that the keys are
+        # all unique?
+
+        if isinstance(origin, EmptyFactoredManifest):
+            # No origin was provided, so nothing has been changed or
+            # removed; only added.  In addition, this doesn't need
+            # to be sorted since the caller likely already does
+            # (such as pkgplan/imageplan).
+            return ManifestDifference(
+                [(None, a) for a in self.gen_actions(excludes=self_exclude)],
+                [],
+                [],
+            )
+
+        def hashify(v):
+            """handle key values that may be lists"""
+            if type(v) is not list:
+                return v
+            return tuple(v)
+
+        def dictify(mf, excludes):
+            # Transform list of actions into a dictionary keyed by
+            # action key attribute, key attribute and mediator, or
+            # id if there is no key attribute.
+            for a in mf.gen_actions(excludes=excludes):
+                if (a.name == "link" or a.name == "hardlink") and a.attrs.get(
+                    "mediator"
+                ):
+                    akey = (
+                        a.name,
+                        tuple(
+                            [
+                                a.attrs[a.key_attr],
+                                a.attrs.get("mediator-version"),
+                                a.attrs.get("mediator-implementation"),
+                            ]
+                        ),
+                    )
+                else:
+                    akey = (a.name, hashify(a.attrs.get(a.key_attr, id(a))))
+                yield (akey, a)
+
+        sdict = dict(dictify(self, self_exclude))
+        odict = dict(dictify(origin, origin_exclude))
+
+        sset = set(six.iterkeys(sdict))
+        oset = set(six.iterkeys(odict))
+
+        added = [(None, sdict[i]) for i in sset - oset]
+        removed = [(odict[i], None) for i in oset - sset]
+        changed = [
+            (odict[i], sdict[i])
+            for i in oset & sset
+            if odict[i].different(
+                sdict[i], pkgplan=pkgplan, cmp_policy=cmp_policy
+            )
+        ]
+
+        # XXX Do changed actions need to be sorted at all?  This is
+        # likely to be the largest list, so we might save significant
+        # time by not sorting.  Should we sort above?  Insert into a
+        # sorted list?
+
+        # singlesort = lambda x: x[0] or x[1]
+        addsort = itemgetter(1)
+        remsort = itemgetter(0)
+        removed.sort(key=remsort, reverse=True)
+        added.sort(key=addsort)
+        changed.sort(key=addsort)
+
+        return ManifestDifference(added, changed, removed)
+
+    @staticmethod
+    def comm(compare_m, cmp_policy=None):
+        """Like the unix utility comm, except that this function
+        takes an arbitrary number of manifests and compares them,
+        returning a tuple consisting of each manifest's actions
+        that are not the same for all manifests, followed by a
+        list of actions that are the same in each manifest.
+
+        Content hashes for action payloads may be present in
+        both signature-included and signature-excluded
+        variants. In most cases (cmp_policy=None), we only
+        want to compare the signature-included variants. When
+        no-signature-included comparison is requested, simply
+        pass cmp_policy=CMP_UNSIGNED through to Action.different().
         """
 
-        def __init__(self, pfmri=None):
-                self.fmri = pfmri
+        # Must specify at least one manifest.
+        assert compare_m
+        dups = []
 
-                self._cache = {}
-                self._absent_cache = []
-                self.actions = []
-                self.actions_bytype = {}
-                self.attributes = {} # package-wide attributes
-                self.signatures = EmptyDict
-                self.excludes = EmptyI
-                if pfmri is not None:
-                        if not isinstance(pfmri, fmri.PkgFmri):
-                                pfmri = fmri.PkgFmri(pfmri)
-                        self.publisher = pfmri.publisher
-                else:
-                        self.publisher = None
-
-        def __str__(self):
-                r = ""
-                if "pkg.fmri" not in self.attributes and self.fmri != None:
-                        r += "set name=pkg.fmri value={0}\n".format(self.fmri)
-
-                for act in sorted(self.actions):
-                        r += "{0}\n".format(act)
-                return r
-
-        def as_lines(self):
-                """A generator function that returns the unsorted manifest
-                contents as lines of text."""
-
-                if "pkg.fmri" not in self.attributes and self.fmri != None:
-                        yield "set name=pkg.fmri value={0}\n".format(self.fmri)
-
-                for act in self.actions:
-                        yield "{0}\n".format(act)
-
-        def tostr_unsorted(self):
-                return "".join((l for l in self.as_lines()))
-
-        def difference(self, origin, origin_exclude=EmptyI,
-            self_exclude=EmptyI, pkgplan=None, cmp_policy=None):
-                """Return three lists of action pairs representing origin and
-                destination actions.  The first list contains the pairs
-                representing additions, the second list contains the pairs
-                representing updates, and the third list contains the pairs
-                representing removals.  All three lists are in the order in
-                which they should be executed."""
-                # XXX Do we need to find some way to assert that the keys are
-                # all unique?
-
-                if isinstance(origin, EmptyFactoredManifest):
-                        # No origin was provided, so nothing has been changed or
-                        # removed; only added.  In addition, this doesn't need
-                        # to be sorted since the caller likely already does
-                        # (such as pkgplan/imageplan).
-                        return ManifestDifference(
-                            [(None, a) for a in self.gen_actions(
-                            excludes=self_exclude)], [], [])
-
-                def hashify(v):
-                        """handle key values that may be lists"""
-                        if type(v) is not list:
-                                return v
-                        return tuple(v)
-
-                def dictify(mf, excludes):
-                        # Transform list of actions into a dictionary keyed by
-                        # action key attribute, key attribute and mediator, or
-                        # id if there is no key attribute.
-                        for a in mf.gen_actions(excludes=excludes):
-                                if (a.name == "link" or
-                                    a.name == "hardlink") and \
-                                    a.attrs.get("mediator"):
-                                        akey = (a.name, tuple([
-                                            a.attrs[a.key_attr],
-                                            a.attrs.get("mediator-version"),
-                                            a.attrs.get("mediator-implementation")
-                                        ]))
-                                else:
-                                        akey = (a.name, hashify(a.attrs.get(
-                                            a.key_attr, id(a))))
-                                yield (akey, a)
-
-                sdict = dict(dictify(self, self_exclude))
-                odict = dict(dictify(origin, origin_exclude))
-
-                sset = set(six.iterkeys(sdict))
-                oset = set(six.iterkeys(odict))
-
-                added = [(None, sdict[i]) for i in sset - oset]
-                removed = [(odict[i], None) for i in oset - sset]
-                changed = [
-                    (odict[i], sdict[i])
-                    for i in oset & sset
-                    if odict[i].different(sdict[i], pkgplan=pkgplan,
-                        cmp_policy=cmp_policy)
-                ]
-
-                # XXX Do changed actions need to be sorted at all?  This is
-                # likely to be the largest list, so we might save significant
-                # time by not sorting.  Should we sort above?  Insert into a
-                # sorted list?
-
-                # singlesort = lambda x: x[0] or x[1]
-                addsort = itemgetter(1)
-                remsort = itemgetter(0)
-                removed.sort(key=remsort, reverse=True)
-                added.sort(key=addsort)
-                changed.sort(key=addsort)
-
-                return ManifestDifference(added, changed, removed)
-
-        @staticmethod
-        def comm(compare_m, cmp_policy=None):
-                """Like the unix utility comm, except that this function
-                takes an arbitrary number of manifests and compares them,
-                returning a tuple consisting of each manifest's actions
-                that are not the same for all manifests, followed by a
-                list of actions that are the same in each manifest.
-
-                Content hashes for action payloads may be present in
-                both signature-included and signature-excluded
-                variants. In most cases (cmp_policy=None), we only
-                want to compare the signature-included variants. When
-                no-signature-included comparison is requested, simply
-                pass cmp_policy=CMP_UNSIGNED through to Action.different().
-                """
-
-                # Must specify at least one manifest.
-                assert compare_m
-                dups = []
-
-                # construct list of dictionaries of actions in each
-                # manifest, indexed by unique key and variant combination
-                m_dicts = []
-                for m in compare_m:
-                        m_dict = {}
-                        for a in m.gen_actions():
-                                # The unique key for each action is based on its
-                                # type, key attribute, and unique variants set
-                                # on the action.
-                                try:
-                                        key_val = a.attrlist(a.key_attr)
-                                        # For dependencies include the type
-                                        # for the key, or the value of
-                                        # predicate with conditional.
-                                        if a.name == "depend":
-                                            ktype = a.attrs.get("type")
-                                            if ktype == "conditional":
-                                                ktype = a.attrs.\
-                                                    get("predicate")
-                                            key = {"{0}->{1}".format(
-                                                ','.join(sorted(key_val)),
-                                               ktype)}
-                                        else:
-                                            key = set(key_val)
-
-                                        if (a.name == "link" or
-                                           a.name == "hardlink") and \
-                                           a.attrs.get("mediator"):
-                                                for v in ("mediator-version",
-                                                    "mediator-implementation"):
-                                                        key.update([
-                                                            "{0}={1}".format(v,
-                                                            a.attrs.get(v))])
-
-                                        key.update(
-                                            "{0}={1}".format(v, a.attrs[v])
-                                            for v in a.get_varcet_keys()[0]
-                                        )
-
-                                        key = tuple(key)
-                                except KeyError:
-                                        # If there is no key attribute for the
-                                        # action, then fallback to the object
-                                        # id for the action as its identifier.
-                                        key = (id(a),)
-
-                                # For blending of packages (during a pkgmerge)
-                                # there is the possibility of actions defining
-                                # the same path but with different attributes.
-                                # It is not possible to detect which action is
-                                # to be used and so report it as a duplicate.
-                                # Include the fmri so the bad manifest can
-                                # be easily identified.
-                                if m_dict.setdefault((a.name, key), a) != a:
-                                        dups.append((m.fmri or id(m),
-                                                     m_dict[(a.name, key)],
-                                                     a))
-
-                        m_dicts.append(m_dict)
-
-                if dups:
-                        raise ManifestDuplicateError(duplicates=dups)
-
-                # construct list of key sets in each dict
-                m_sets = [
-                    set(m.keys())
-                    for m in m_dicts
-                ]
-
-                common_keys = reduce(lambda a, b: a & b, m_sets)
-
-                # determine which common_keys have common actions
-                for k in common_keys.copy():
-                        for i in range(len(m_dicts) - 1):
-                                if m_dicts[i][k].different(
-                                    m_dicts[i + 1][k],
-                                    cmp_policy=cmp_policy):
-                                        common_keys.remove(k)
-                                        break
-                return tuple(
-                    [
-                        [m_dicts[i][k] for k in m_sets[i] - common_keys]
-                        for i in range(len(m_dicts))
-                    ]
-                    +
-                    [
-                        [ m_dicts[0][k] for k in common_keys ]
-                    ]
-                )
-
-        def combined_difference(self, origin, ov=EmptyI, sv=EmptyI):
-                """Where difference() returns three lists, combined_difference()
-                returns a single list of the concatenation of the three."""
-                return list(chain(*self.difference(origin, ov, sv)))
-
-        def humanized_differences(self, other, ov=EmptyI, sv=EmptyI):
-                """Output expects that self is newer than other.  Use of sets
-                requires that we convert the action objects into some marshalled
-                form, otherwise set member identities are derived from the
-                object pointers, rather than the contents."""
-
-                l = self.difference(other, ov, sv)
-                out = ""
-
-                for src, dest in chain(*l):
-                        if not src:
-                                out += "+ {0}\n".format(str(dest))
-                        elif not dest:
-                                out += "- {0}\n" + str(src)
-                        else:
-                                out += "{0} -> {1}\n".format(src, dest)
-                return out
-
-        def _gen_dirs_to_str(self):
-                """Generate contents of dircache file containing all dirctories
-                referenced explicitly or implicitly from self.actions.  Include
-                variants as values; collapse variants where possible."""
-
-                def gen_references(a):
-                        for d in expanddirs(a.directory_references()):
-                                yield d
-
-                dirs = self._actions_to_dict(gen_references)
-                for d in dirs:
-                        for v in dirs[d]:
-                                a = DirectoryAction(path=d, **v)
-                                yield str(a) + "\n"
-
-        def _gen_mediators_to_str(self):
-                """Generate contents of mediatorcache file containing all
-                mediators referenced explicitly or implicitly from self.actions.
-                Include variants as values; collapse variants where possible."""
-
-                def gen_references(a):
-                        if (a.name == "link" or a.name == "hardlink") and \
-                            "mediator" in a.attrs:
-                                yield (a.attrs.get("mediator"),
-                                   a.attrs.get("mediator-priority"),
-                                   a.attrs.get("mediator-version"),
-                                   a.attrs.get("mediator-implementation"))
-
-                mediators = self._actions_to_dict(gen_references)
-                for mediation, mvariants in six.iteritems(mediators):
-                        values = {
-                            "mediator-priority": mediation[1],
-                            "mediator-version": mediation[2],
-                            "mediator-implementation": mediation[3],
+        # construct list of dictionaries of actions in each
+        # manifest, indexed by unique key and variant combination
+        m_dicts = []
+        for m in compare_m:
+            m_dict = {}
+            for a in m.gen_actions():
+                # The unique key for each action is based on its
+                # type, key attribute, and unique variants set
+                # on the action.
+                try:
+                    key_val = a.attrlist(a.key_attr)
+                    # For dependencies include the type
+                    # for the key, or the value of
+                    # predicate with conditional.
+                    if a.name == "depend":
+                        ktype = a.attrs.get("type")
+                        if ktype == "conditional":
+                            ktype = a.attrs.get("predicate")
+                        key = {
+                            "{0}->{1}".format(",".join(sorted(key_val)), ktype)
                         }
-                        for mvariant in mvariants:
-                                a = "set name=pkg.mediator " \
-                                    "value={0} {1} {2}\n".format(mediation[0],
-                                     " ".join((
-                                         "=".join(t)
-                                          for t in six.iteritems(values)
-                                          if t[1]
-                                     )),
-                                     " ".join((
-                                         "=".join(t)
-                                         for t in six.iteritems(mvariant)
-                                     ))
-                                )
-                                yield a
+                    else:
+                        key = set(key_val)
 
-        def _gen_attrs_to_str(self):
-                """Generate set action supplemental data containing all facets
-                and variants from self.actions and size information.  Each
-                returned line must be newline-terminated."""
+                    if (
+                        a.name == "link" or a.name == "hardlink"
+                    ) and a.attrs.get("mediator"):
+                        for v in (
+                            "mediator-version",
+                            "mediator-implementation",
+                        ):
+                            key.update(["{0}={1}".format(v, a.attrs.get(v))])
 
-                emit_variants = "pkg.variant" not in self
-                emit_facets = "pkg.facet" not in self
-                emit_sizes = "pkg.size" not in self and "pkg.csize" not in self
+                    key.update(
+                        "{0}={1}".format(v, a.attrs[v])
+                        for v in a.get_varcet_keys()[0]
+                    )
 
-                if not any((emit_variants, emit_facets, emit_sizes)):
-                        # Package already has these attributes.
-                        return
-
-                # List of possible variants and possible values for them.
-                variants = defaultdict(set)
-
-                # Seed with declared set of variants as actions may be common to
-                # both and so will not be tagged with variant.
-                for name in self.attributes:
-                        if name[:8] == "variant.":
-                                variants[name] = set(self.attributes[name])
-
-                # List of possible facets and under what variant combinations
-                # they were seen.
-                facets = defaultdict(set)
-
-                # Unique (facet, value) (variant, value) combinations.
-                refs = defaultdict(lambda: defaultdict(int))
-
-                for a in self.gen_actions():
-                        name = a.name
-                        attrs = a.attrs
-                        if name == "set":
-                                if attrs["name"][:12] == "pkg.variant":
-                                        emit_variants = False
-                                elif attrs["name"][:9] == "pkg.facet":
-                                        emit_facets = False
-
-                        afacets = []
-                        avariants = []
-                        for attr in attrs:
-                                if attr[:8] == "variant.":
-                                        for val in a.attrlist(attr):
-                                                variants[attr].add(val)
-                                                avariants.append((attr, val))
-                                elif attr[:6] == "facet.":
-                                        for val in a.attrlist(attr):
-                                                afacets.append((attr, val))
-
-                        for name, val in afacets:
-                                # Facet applicable to this particular variant
-                                # combination.
-                                varkey = tuple(sorted(avariants))
-                                facets[varkey].add(name)
-
-                        # This *must* be sorted to ensure reproducible set
-                        # action generation for sizes and to ensure each
-                        # combination is actually unique.
-                        varcetkeys = tuple(sorted(chain(afacets, avariants)))
-                        refs[varcetkeys]["csize"] += misc.get_pkg_otw_size(a)
-                        if name == "signature":
-                                refs[varcetkeys]["csize"] += \
-                                    a.get_action_chain_csize()
-                        refs[varcetkeys]["size"] += a.get_size()
-
-                # Prevent scope leak.
-                afacets = avariants = attrs = varcetkeys = None
-
-                if emit_variants:
-                        # Unnecessary if we can guarantee all variants will be
-                        # declared at package level.  Omit the "variant." prefix
-                        # from attribute values since that's implicit and can be
-                        # added back when the action is parsed.
-                        yield "{0}\n".format(AttributeAction(None,
-                            name="pkg.variant",
-                            value=sorted(v[8:] for v in variants)))
-
-                # Emit a set action for every variant used with possible values
-                # if one does not already exist.
-                for name in variants:
-                        # merge_facets needs the variant values sorted and this
-                        # is desirable when generating the variant attr anyway.
-                        variants[name] = sorted(variants[name])
-                        if name not in self.attributes:
-                                yield "{0}\n".format(AttributeAction(None,
-                                    name=name, value=variants[name]))
-
-                if emit_facets:
-                        # Get unvarianted facet set.
-                        cfacets = facets.pop((), set())
-
-                        # For each variant combination, remove unvarianted
-                        # facets since they are common to all variants.
-                        for varkey, fnames in list(facets.items()):
-                                fnames.difference_update(cfacets)
-                                if not fnames:
-                                        # No facets unique to this combo;
-                                        # discard.
-                                        del facets[varkey]
-
-                        # If all possible variant combinations supported by the
-                        # package have at least one facet, then the intersection
-                        # of facets for all variants can be merged with the
-                        # common set.
-                        merge_facets = len(facets) > 0
-                        if merge_facets:
-                                # Determine unique set of variant combinations
-                                # seen for faceted actions.
-                                vcombos = set((
-                                    tuple(
-                                        vpair[0]
-                                        for vpair in varkey
-                                    )
-                                    for varkey in facets
-                                ))
-
-                                # For each unique variant combination, determine
-                                # if the cartesian product of all variant values
-                                # supported by the package for the combination
-                                # has been seen.  In other words, if the
-                                # combination is ((variant.arch,)) and the
-                                # package supports (i386, sparc), then both
-                                # (variant.arch, i386) and (variant.arch, sparc)
-                                # must exist.  This code assumes variant values
-                                # for each variant are already sorted.
-                                for pair in chain.from_iterable(
-                                    product(*(
-                                        tuple((name, val)
-                                            for val in variants[name])
-                                        for name in vcombo)
-                                    )
-                                    for vcombo in vcombos
-                                ):
-                                        if pair not in facets:
-                                                # If any combination the package
-                                                # supports has not been seen for
-                                                # one or more facets, then some
-                                                # facets are unique to one or
-                                                # more combinations.
-                                                merge_facets = False
-                                                break
-
-                        if merge_facets:
-                                # Merge the facets common to all variants if safe;
-                                # if we always merged them, then facets only
-                                # used by a single variant (think i386-only or
-                                # sparc-only content) would be seen unvarianted
-                                # (that's bad).
-                                vfacets = list(facets.values())
-                                vcfacets = vfacets[0].intersection(*vfacets[1:])
-
-                                if vcfacets:
-                                        # At least one facet is shared between
-                                        # all variant combinations; move the
-                                        # common ones to the unvarianted set.
-                                        cfacets.update(vcfacets)
-
-                                        # Remove facets common to all combos.
-                                        for varkey, fnames in list(
-                                            facets.items()):
-                                                fnames.difference_update(vcfacets)
-                                                if not fnames:
-                                                        # No facets unique to
-                                                        # this combo; discard.
-                                                        del facets[varkey]
-
-                        # Omit the "facet." prefix from attribute values since
-                        # that's implicit and can be added back when the action
-                        # is parsed.
-                        val = sorted(f[6:] for f in cfacets)
-                        if not val:
-                                # If we don't do this, action stringify will
-                                # emit this as "set name=pkg.facet" which is
-                                # then transformed to "set name=name
-                                # value=pkg.facet".  Not what we wanted, but is
-                                # expected for historical reasons.
-                                val = ""
-
-                        # Always emit an action enumerating the list of facets
-                        # common to all variants, even if there aren't any.
-                        # That way if there are also no variant-specific facets,
-                        # package operations will know that no facets are used
-                        # by the package instead of having to scan the whole
-                        # manifest.
-                        yield "{0}\n".format(AttributeAction(None,
-                            name="pkg.facet.common", value=val))
-
-                        # Now emit a pkg.facet action for each variant
-                        # combination containing the list of facets unique to
-                        # that combination.
-                        for varkey, fnames in six.iteritems(facets):
-                                # A unique key for each combination is needed,
-                                # and using a hash obfuscates that interface
-                                # while giving us a reliable way to generate
-                                # a reproducible, unique identifier.  The key
-                                # string below looks like this before hashing:
-                                #     variant.archi386variant.debug.osnetTrue...
-                                key = hashlib.sha1(
-                                    misc.force_bytes("".join(
-                                    "{0}{1}".format(*v) for v in varkey))
-                                ).hexdigest()
-
-                                # Omit the "facet." prefix from attribute values
-                                # since that's implicit and can be added back
-                                # when the action is parsed.
-                                act = AttributeAction(None,
-                                    name="pkg.facet.{0}".format(key),
-                                    value=sorted(f[6:] for f in fnames))
-                                attrs = act.attrs
-                                # Tag action with variants.
-                                for v in varkey:
-                                        attrs[v[0]] = v[1]
-                                yield "{0}\n".format(act)
-
-                # Emit pkg.[c]size attribute for [compressed] size of package
-                # for each facet/variant combination.
-                csize = 0
-                size = 0
-                for varcetkeys in refs:
-                        rcsize = refs[varcetkeys]["csize"]
-                        rsize = refs[varcetkeys]["size"]
-
-                        if not varcetkeys:
-                                # For unfaceted/unvarianted actions, keep a
-                                # running total so a single [c]size action can
-                                # be generated.
-                                csize += rcsize
-                                size += rsize
-                                continue
-
-                        if emit_sizes and (rcsize > 0 or rsize > 0):
-                                # Only emit if > 0; actions may be
-                                # faceted/variant without payload.
-
-                                # A unique key for each combination is needed,
-                                # and using a hash obfuscates that interface
-                                # while giving us a reliable way to generate
-                                # a reproducible, unique identifier.  The key
-                                # string below looks like this before hashing:
-                                #     facet.docTruevariant.archi386...
-                                key = hashlib.sha1(misc.force_bytes(
-                                    "".join("{0}{1}".format(*v) for v in varcetkeys)
-                                )).hexdigest()
-
-                                # The sizes are abbreviated in the name of byte
-                                # conservation.
-                                act = AttributeAction(None,
-                                    name="pkg.sizes.{0}".format(key),
-                                    value=["csz={0}".format(rcsize),
-                                    "sz={0}".format(rsize)])
-                                attrs = act.attrs
-                                for v in varcetkeys:
-                                        attrs[v[0]] = v[1]
-                                yield "{0}\n".format(act)
-
-                if emit_sizes:
-                        act = AttributeAction(None, name="pkg.sizes.common",
-                            value=["csz={0}".format(csize),
-                            "sz={0}".format(size)])
-                        yield "{0}\n".format(act)
-
-        def _actions_to_dict(self, references):
-                """create dictionary of all actions referenced explicitly or
-                implicitly from self.actions... include variants as values;
-                collapse variants where possible"""
-
-                refs = {}
-                # build a dictionary containing all actions tagged w/
-                # variants
-                for a in self.actions:
-                        v, f = a.get_varcet_keys()
-                        variants = dict((name, a.attrs[name]) for name in v + f)
-                        for ref in references(a):
-                                if ref not in refs:
-                                        refs[ref] = [variants]
-                                elif variants not in refs[ref]:
-                                        refs[ref].append(variants)
-
-                # remove any tags if any entries are always delivered (NULL)
-                for ref in refs:
-                        if {} in refs[ref]:
-                                refs[ref] = [{}]
-                                continue
-                        # could collapse refs where all variants are present
-                        # (the current logic only collapses them if at least
-                        # one reference is delivered without a facet or
-                        # variant)
-                return refs
-
-        def get_directories(self, excludes):
-                """ return a list of directories implicitly or
-                explicitly referenced by this object"""
-
-                if self.excludes == excludes:
-                        excludes = EmptyI
-                assert excludes == EmptyI or self.excludes == EmptyI
-                try:
-                        alist = self._cache["manifest.dircache"]
+                    key = tuple(key)
                 except KeyError:
-                        # generate actions that contain directories
-                        alist = self._cache["manifest.dircache"] = [
-                            actions.fromstr(s.rstrip())
-                            for s in self._gen_dirs_to_str()
-                        ]
+                    # If there is no key attribute for the
+                    # action, then fallback to the object
+                    # id for the action as its identifier.
+                    key = (id(a),)
 
-                s = set([
-                    a.attrs["path"]
-                    for a in alist
-                    if not excludes or a.include_this(excludes,
-                        publisher=self.publisher)
-                ])
+                # For blending of packages (during a pkgmerge)
+                # there is the possibility of actions defining
+                # the same path but with different attributes.
+                # It is not possible to detect which action is
+                # to be used and so report it as a duplicate.
+                # Include the fmri so the bad manifest can
+                # be easily identified.
+                if m_dict.setdefault((a.name, key), a) != a:
+                    dups.append((m.fmri or id(m), m_dict[(a.name, key)], a))
 
-                return list(s)
+            m_dicts.append(m_dict)
 
-        def gen_facets(self, excludes=EmptyI, patterns=EmptyI):
-                """A generator function that returns the supported facet
-                attributes (strings) for this package based on the specified (or
-                current) excludes that also match at least one of the patterns
-                provided.  Facets must be true or false so a list of possible
-                facet values is not returned."""
+        if dups:
+            raise ManifestDuplicateError(duplicates=dups)
 
-                if self.excludes == excludes:
-                        excludes = EmptyI
-                assert excludes == EmptyI or self.excludes == EmptyI
+        # construct list of key sets in each dict
+        m_sets = [set(m.keys()) for m in m_dicts]
 
-                try:
-                        facets = self["pkg.facet"]
-                except KeyError:
-                        facets = None
+        common_keys = reduce(lambda a, b: a & b, m_sets)
 
-                if facets is not None and excludes == EmptyI:
-                        # No excludes? Then use the pre-determined set of
-                        # facets.
-                        for f in misc.yield_matching("facet.", facets, patterns):
-                                yield f
-                        return
+        # determine which common_keys have common actions
+        for k in common_keys.copy():
+            for i in range(len(m_dicts) - 1):
+                if m_dicts[i][k].different(
+                    m_dicts[i + 1][k], cmp_policy=cmp_policy
+                ):
+                    common_keys.remove(k)
+                    break
+        return tuple(
+            [
+                [m_dicts[i][k] for k in m_sets[i] - common_keys]
+                for i in range(len(m_dicts))
+            ]
+            + [[m_dicts[0][k] for k in common_keys]]
+        )
 
-                # If different excludes were specified, then look for pkg.facet
-                # actions containing the list of facets.
-                found = False
-                seen = set()
-                for a in self.gen_actions_by_type("set", excludes=excludes):
-                        if a.attrs["name"][:10] == "pkg.facet.":
-                                # Either a pkg.facet.common action or a
-                                # pkg.facet.X variant-specific action.
-                                found = True
-                                val = a.attrlist("value")
-                                if len(val) == 1 and val[0] == "":
-                                        # No facets.
-                                        continue
+    def combined_difference(self, origin, ov=EmptyI, sv=EmptyI):
+        """Where difference() returns three lists, combined_difference()
+        returns a single list of the concatenation of the three."""
+        return list(chain(*self.difference(origin, ov, sv)))
 
-                                for f in misc.yield_matching("facet.", (
-                                    "facet.{0}".format(n)
-                                    for n in val
-                                ), patterns):
-                                        if f in seen:
-                                                # Prevent duplicates; it's
-                                                # possible a given facet may be
-                                                # valid for more than one unique
-                                                # variant combination that's
-                                                # allowed by current excludes.
-                                                continue
+    def humanized_differences(self, other, ov=EmptyI, sv=EmptyI):
+        """Output expects that self is newer than other.  Use of sets
+        requires that we convert the action objects into some marshalled
+        form, otherwise set member identities are derived from the
+        object pointers, rather than the contents."""
 
-                                        seen.add(f)
-                                        yield f
+        l = self.difference(other, ov, sv)
+        out = ""
 
-                if not found:
-                        # Fallback to sifting actions to yield possible.
-                        facets = self._get_varcets(excludes=excludes)[1]
-                        for f in misc.yield_matching("facet.", facets, patterns):
-                                yield f
+        for src, dest in chain(*l):
+            if not src:
+                out += "+ {0}\n".format(str(dest))
+            elif not dest:
+                out += "- {0}\n" + str(src)
+            else:
+                out += "{0} -> {1}\n".format(src, dest)
+        return out
 
-        def gen_variants(self, excludes=EmptyI, patterns=EmptyI):
-                """A generator function that yields a list of tuples of the form
-                (variant, [values]).  Where 'variant' is the variant attribute
-                name (e.g. 'variant.arch') and '[values]' is a list of the
-                variant values supported by this package.  Variants returned are
-                those allowed by the specified (or current) excludes that also
-                match at least one of the patterns provided."""
+    def _gen_dirs_to_str(self):
+        """Generate contents of dircache file containing all dirctories
+        referenced explicitly or implicitly from self.actions.  Include
+        variants as values; collapse variants where possible."""
 
-                if self.excludes == excludes:
-                        excludes = EmptyI
-                assert excludes == EmptyI or self.excludes == EmptyI
+        def gen_references(a):
+            for d in expanddirs(a.directory_references()):
+                yield d
 
-                try:
-                        variants = self["pkg.variant"]
-                except KeyError:
-                        variants = None
+        dirs = self._actions_to_dict(gen_references)
+        for d in dirs:
+            for v in dirs[d]:
+                a = DirectoryAction(path=d, **v)
+                yield str(a) + "\n"
 
-                if variants is not None and excludes == EmptyI:
-                        # No excludes? Then use the pre-determined set of
-                        # variants.
-                        for v in misc.yield_matching("variant.", variants,
-                            patterns):
-                                yield v, self.attributes.get(v, [])
-                        return
+    def _gen_mediators_to_str(self):
+        """Generate contents of mediatorcache file containing all
+        mediators referenced explicitly or implicitly from self.actions.
+        Include variants as values; collapse variants where possible."""
 
-                # If different excludes were specified, then look for
-                # pkg.variant action containing the list of variants.
-                found = False
-                variants = defaultdict(set)
-                for a in self.gen_actions_by_type("set", excludes=excludes):
-                        aname = a.attrs["name"]
-                        if aname == "pkg.variant":
-                                val = a.attrlist("value")
-                                if len(val) == 1 and val[0] == "":
-                                        # No variants.
-                                        return
-                                for v in val:
-                                        found = True
-                                        # Ensure variant entries exist (debug
-                                        # variants may not) via defaultdict.
-                                        variants["variant.{0}".format(v)]
-                        elif aname[:8] == "variant.":
-                                for v in a.attrlist("value"):
-                                        found = True
-                                        variants[aname].add(v)
-
-                if not found:
-                        # Fallback to sifting actions to get possible.
-                        variants = self._get_varcets(excludes=excludes)[0]
-
-                for v in misc.yield_matching("variant.", variants, patterns):
-                        yield v, variants[v]
-
-        def gen_mediators(self, excludes=EmptyI):
-                """A generator function that yields tuples of the form (mediator,
-                mediations) expressing the set of possible mediations for this
-                package, where 'mediations' is a set() of possible mediations for
-                the mediator.  Each mediation is a tuple of the form (priority,
-                version, implementation).
-                """
-
-                if self.excludes == excludes:
-                        excludes = EmptyI
-                assert excludes == EmptyI or self.excludes == EmptyI
-                try:
-                        alist = self._cache["manifest.mediatorcache"]
-                except KeyError:
-                        # generate actions that contain mediators
-                        alist = self._cache["manifest.mediatorcache"] = [
-                            actions.fromstr(s.rstrip())
-                            for s in self._gen_mediators_to_str()
-                        ]
-
-                ret = defaultdict(set)
-                for attrs in (
-                    act.attrs
-                    for act in alist
-                    if not excludes or act.include_this(excludes)):
-                        med_ver = attrs.get("mediator-version")
-                        if med_ver:
-                                try:
-                                        med_ver = version.Version(med_ver)
-                                except version.VersionError:
-                                        # Consider this mediation unavailable
-                                        # if it can't be parsed for whatever
-                                        # reason.
-                                        continue
-
-                        ret[attrs["value"]].add((
-                            attrs.get("mediator-priority"),
-                            med_ver,
-                            attrs.get("mediator-implementation"),
-                        ))
-
-                for m in ret:
-                        yield m, ret[m]
-
-        def gen_actions(self, attr_match=None, excludes=EmptyI):
-                """Generate actions in manifest through ordered callable list"""
-
-                if self.excludes == excludes:
-                        excludes = EmptyI
-                assert excludes == EmptyI or self.excludes == EmptyI
-
-                if attr_match:
-                        attr_match = _compile_fnpats(attr_match)
-
-                pub = self.publisher
-                for a in self.actions:
-                        for c in excludes:
-                                if not c(a, publisher=pub):
-                                        break
-                        else:
-                                # These conditions are split by performance.
-                                if not attr_match:
-                                        yield a
-                                elif _attr_matches(a, attr_match):
-                                        yield a
-
-        def gen_actions_by_type(self, atype, attr_match=None, excludes=EmptyI):
-                """Generate actions in the manifest of type "type"
-                through ordered callable list"""
-
-                if self.excludes == excludes:
-                        excludes = EmptyI
-                assert excludes == EmptyI or self.excludes == EmptyI
-
-                if attr_match:
-                        attr_match = _compile_fnpats(attr_match)
-
-                pub = self.publisher
-                for a in self.actions_bytype.get(atype, []):
-                        for c in excludes:
-                                if not c(a, publisher=pub):
-                                        break
-                        else:
-                                # These conditions are split by performance.
-                                if not attr_match:
-                                        yield a
-                                elif _attr_matches(a, attr_match):
-                                        yield a
-
-        def gen_actions_by_types(self, atypes, attr_match=None, excludes=EmptyI):
-                """Generate actions in the manifest of types "atypes"
-                through ordered callable list."""
-
-                for atype in atypes:
-                        for a in self.gen_actions_by_type(atype,
-                            attr_match=attr_match, excludes=excludes):
-                                yield a
-
-        def gen_key_attribute_value_by_type(self, atype, excludes=EmptyI):
-                """Generate the value of the key attribute for each action
-                of type "type" in the manifest."""
-
-                return (
-                    a.attrs.get(a.key_attr)
-                    for a in self.gen_actions_by_type(atype, excludes=excludes)
+        def gen_references(a):
+            if (
+                a.name == "link" or a.name == "hardlink"
+            ) and "mediator" in a.attrs:
+                yield (
+                    a.attrs.get("mediator"),
+                    a.attrs.get("mediator-priority"),
+                    a.attrs.get("mediator-version"),
+                    a.attrs.get("mediator-implementation"),
                 )
 
-        def duplicates(self, excludes=EmptyI):
-                """Find actions in the manifest which are duplicates (i.e.,
-                represent the same object) but which are not identical (i.e.,
-                have all the same attributes)."""
+        mediators = self._actions_to_dict(gen_references)
+        for mediation, mvariants in six.iteritems(mediators):
+            values = {
+                "mediator-priority": mediation[1],
+                "mediator-version": mediation[2],
+                "mediator-implementation": mediation[3],
+            }
+            for mvariant in mvariants:
+                a = "set name=pkg.mediator " "value={0} {1} {2}\n".format(
+                    mediation[0],
+                    " ".join(
+                        ("=".join(t) for t in six.iteritems(values) if t[1])
+                    ),
+                    " ".join(("=".join(t) for t in six.iteritems(mvariant))),
+                )
+                yield a
 
-                def fun(a):
-                        """Return a key on which actions can be sorted."""
-                        return a.name, a.attrs.get(a.key_attr, id(a))
+    def _gen_attrs_to_str(self):
+        """Generate set action supplemental data containing all facets
+        and variants from self.actions and size information.  Each
+        returned line must be newline-terminated."""
 
-                alldups = []
-                acts = [a for a in self.gen_actions(excludes=excludes)]
+        emit_variants = "pkg.variant" not in self
+        emit_facets = "pkg.facet" not in self
+        emit_sizes = "pkg.size" not in self and "pkg.csize" not in self
 
-                for k, g in groupby(sorted(acts, key=fun), fun):
-                        glist = list(g)
-                        dups = set()
-                        for i in range(len(glist) - 1):
-                                if glist[i].different(glist[i + 1]):
-                                        dups.add(glist[i])
-                                        dups.add(glist[i + 1])
-                        if dups:
-                                alldups.append((k, dups))
-                return alldups
+        if not any((emit_variants, emit_facets, emit_sizes)):
+            # Package already has these attributes.
+            return
 
-        def __content_to_actions(self, content):
-                """Parse manifest content, stripping line-continuation
+        # List of possible variants and possible values for them.
+        variants = defaultdict(set)
+
+        # Seed with declared set of variants as actions may be common to
+        # both and so will not be tagged with variant.
+        for name in self.attributes:
+            if name[:8] == "variant.":
+                variants[name] = set(self.attributes[name])
+
+        # List of possible facets and under what variant combinations
+        # they were seen.
+        facets = defaultdict(set)
+
+        # Unique (facet, value) (variant, value) combinations.
+        refs = defaultdict(lambda: defaultdict(int))
+
+        for a in self.gen_actions():
+            name = a.name
+            attrs = a.attrs
+            if name == "set":
+                if attrs["name"][:12] == "pkg.variant":
+                    emit_variants = False
+                elif attrs["name"][:9] == "pkg.facet":
+                    emit_facets = False
+
+            afacets = []
+            avariants = []
+            for attr in attrs:
+                if attr[:8] == "variant.":
+                    for val in a.attrlist(attr):
+                        variants[attr].add(val)
+                        avariants.append((attr, val))
+                elif attr[:6] == "facet.":
+                    for val in a.attrlist(attr):
+                        afacets.append((attr, val))
+
+            for name, val in afacets:
+                # Facet applicable to this particular variant
+                # combination.
+                varkey = tuple(sorted(avariants))
+                facets[varkey].add(name)
+
+            # This *must* be sorted to ensure reproducible set
+            # action generation for sizes and to ensure each
+            # combination is actually unique.
+            varcetkeys = tuple(sorted(chain(afacets, avariants)))
+            refs[varcetkeys]["csize"] += misc.get_pkg_otw_size(a)
+            if name == "signature":
+                refs[varcetkeys]["csize"] += a.get_action_chain_csize()
+            refs[varcetkeys]["size"] += a.get_size()
+
+        # Prevent scope leak.
+        afacets = avariants = attrs = varcetkeys = None
+
+        if emit_variants:
+            # Unnecessary if we can guarantee all variants will be
+            # declared at package level.  Omit the "variant." prefix
+            # from attribute values since that's implicit and can be
+            # added back when the action is parsed.
+            yield "{0}\n".format(
+                AttributeAction(
+                    None,
+                    name="pkg.variant",
+                    value=sorted(v[8:] for v in variants),
+                )
+            )
+
+        # Emit a set action for every variant used with possible values
+        # if one does not already exist.
+        for name in variants:
+            # merge_facets needs the variant values sorted and this
+            # is desirable when generating the variant attr anyway.
+            variants[name] = sorted(variants[name])
+            if name not in self.attributes:
+                yield "{0}\n".format(
+                    AttributeAction(None, name=name, value=variants[name])
+                )
+
+        if emit_facets:
+            # Get unvarianted facet set.
+            cfacets = facets.pop((), set())
+
+            # For each variant combination, remove unvarianted
+            # facets since they are common to all variants.
+            for varkey, fnames in list(facets.items()):
+                fnames.difference_update(cfacets)
+                if not fnames:
+                    # No facets unique to this combo;
+                    # discard.
+                    del facets[varkey]
+
+            # If all possible variant combinations supported by the
+            # package have at least one facet, then the intersection
+            # of facets for all variants can be merged with the
+            # common set.
+            merge_facets = len(facets) > 0
+            if merge_facets:
+                # Determine unique set of variant combinations
+                # seen for faceted actions.
+                vcombos = set(
+                    (tuple(vpair[0] for vpair in varkey) for varkey in facets)
+                )
+
+                # For each unique variant combination, determine
+                # if the cartesian product of all variant values
+                # supported by the package for the combination
+                # has been seen.  In other words, if the
+                # combination is ((variant.arch,)) and the
+                # package supports (i386, sparc), then both
+                # (variant.arch, i386) and (variant.arch, sparc)
+                # must exist.  This code assumes variant values
+                # for each variant are already sorted.
+                for pair in chain.from_iterable(
+                    product(
+                        *(
+                            tuple((name, val) for val in variants[name])
+                            for name in vcombo
+                        )
+                    )
+                    for vcombo in vcombos
+                ):
+                    if pair not in facets:
+                        # If any combination the package
+                        # supports has not been seen for
+                        # one or more facets, then some
+                        # facets are unique to one or
+                        # more combinations.
+                        merge_facets = False
+                        break
+
+            if merge_facets:
+                # Merge the facets common to all variants if safe;
+                # if we always merged them, then facets only
+                # used by a single variant (think i386-only or
+                # sparc-only content) would be seen unvarianted
+                # (that's bad).
+                vfacets = list(facets.values())
+                vcfacets = vfacets[0].intersection(*vfacets[1:])
+
+                if vcfacets:
+                    # At least one facet is shared between
+                    # all variant combinations; move the
+                    # common ones to the unvarianted set.
+                    cfacets.update(vcfacets)
+
+                    # Remove facets common to all combos.
+                    for varkey, fnames in list(facets.items()):
+                        fnames.difference_update(vcfacets)
+                        if not fnames:
+                            # No facets unique to
+                            # this combo; discard.
+                            del facets[varkey]
+
+            # Omit the "facet." prefix from attribute values since
+            # that's implicit and can be added back when the action
+            # is parsed.
+            val = sorted(f[6:] for f in cfacets)
+            if not val:
+                # If we don't do this, action stringify will
+                # emit this as "set name=pkg.facet" which is
+                # then transformed to "set name=name
+                # value=pkg.facet".  Not what we wanted, but is
+                # expected for historical reasons.
+                val = ""
+
+            # Always emit an action enumerating the list of facets
+            # common to all variants, even if there aren't any.
+            # That way if there are also no variant-specific facets,
+            # package operations will know that no facets are used
+            # by the package instead of having to scan the whole
+            # manifest.
+            yield "{0}\n".format(
+                AttributeAction(None, name="pkg.facet.common", value=val)
+            )
+
+            # Now emit a pkg.facet action for each variant
+            # combination containing the list of facets unique to
+            # that combination.
+            for varkey, fnames in six.iteritems(facets):
+                # A unique key for each combination is needed,
+                # and using a hash obfuscates that interface
+                # while giving us a reliable way to generate
+                # a reproducible, unique identifier.  The key
+                # string below looks like this before hashing:
+                #     variant.archi386variant.debug.osnetTrue...
+                key = hashlib.sha1(
+                    misc.force_bytes(
+                        "".join("{0}{1}".format(*v) for v in varkey)
+                    )
+                ).hexdigest()
+
+                # Omit the "facet." prefix from attribute values
+                # since that's implicit and can be added back
+                # when the action is parsed.
+                act = AttributeAction(
+                    None,
+                    name="pkg.facet.{0}".format(key),
+                    value=sorted(f[6:] for f in fnames),
+                )
+                attrs = act.attrs
+                # Tag action with variants.
+                for v in varkey:
+                    attrs[v[0]] = v[1]
+                yield "{0}\n".format(act)
+
+        # Emit pkg.[c]size attribute for [compressed] size of package
+        # for each facet/variant combination.
+        csize = 0
+        size = 0
+        for varcetkeys in refs:
+            rcsize = refs[varcetkeys]["csize"]
+            rsize = refs[varcetkeys]["size"]
+
+            if not varcetkeys:
+                # For unfaceted/unvarianted actions, keep a
+                # running total so a single [c]size action can
+                # be generated.
+                csize += rcsize
+                size += rsize
+                continue
+
+            if emit_sizes and (rcsize > 0 or rsize > 0):
+                # Only emit if > 0; actions may be
+                # faceted/variant without payload.
+
+                # A unique key for each combination is needed,
+                # and using a hash obfuscates that interface
+                # while giving us a reliable way to generate
+                # a reproducible, unique identifier.  The key
+                # string below looks like this before hashing:
+                #     facet.docTruevariant.archi386...
+                key = hashlib.sha1(
+                    misc.force_bytes(
+                        "".join("{0}{1}".format(*v) for v in varcetkeys)
+                    )
+                ).hexdigest()
+
+                # The sizes are abbreviated in the name of byte
+                # conservation.
+                act = AttributeAction(
+                    None,
+                    name="pkg.sizes.{0}".format(key),
+                    value=["csz={0}".format(rcsize), "sz={0}".format(rsize)],
+                )
+                attrs = act.attrs
+                for v in varcetkeys:
+                    attrs[v[0]] = v[1]
+                yield "{0}\n".format(act)
+
+        if emit_sizes:
+            act = AttributeAction(
+                None,
+                name="pkg.sizes.common",
+                value=["csz={0}".format(csize), "sz={0}".format(size)],
+            )
+            yield "{0}\n".format(act)
+
+    def _actions_to_dict(self, references):
+        """create dictionary of all actions referenced explicitly or
+        implicitly from self.actions... include variants as values;
+        collapse variants where possible"""
+
+        refs = {}
+        # build a dictionary containing all actions tagged w/
+        # variants
+        for a in self.actions:
+            v, f = a.get_varcet_keys()
+            variants = dict((name, a.attrs[name]) for name in v + f)
+            for ref in references(a):
+                if ref not in refs:
+                    refs[ref] = [variants]
+                elif variants not in refs[ref]:
+                    refs[ref].append(variants)
+
+        # remove any tags if any entries are always delivered (NULL)
+        for ref in refs:
+            if {} in refs[ref]:
+                refs[ref] = [{}]
+                continue
+            # could collapse refs where all variants are present
+            # (the current logic only collapses them if at least
+            # one reference is delivered without a facet or
+            # variant)
+        return refs
+
+    def get_directories(self, excludes):
+        """return a list of directories implicitly or
+        explicitly referenced by this object"""
+
+        if self.excludes == excludes:
+            excludes = EmptyI
+        assert excludes == EmptyI or self.excludes == EmptyI
+        try:
+            alist = self._cache["manifest.dircache"]
+        except KeyError:
+            # generate actions that contain directories
+            alist = self._cache["manifest.dircache"] = [
+                actions.fromstr(s.rstrip()) for s in self._gen_dirs_to_str()
+            ]
+
+        s = set(
+            [
+                a.attrs["path"]
+                for a in alist
+                if not excludes
+                or a.include_this(excludes, publisher=self.publisher)
+            ]
+        )
+
+        return list(s)
+
+    def gen_facets(self, excludes=EmptyI, patterns=EmptyI):
+        """A generator function that returns the supported facet
+        attributes (strings) for this package based on the specified (or
+        current) excludes that also match at least one of the patterns
+        provided.  Facets must be true or false so a list of possible
+        facet values is not returned."""
+
+        if self.excludes == excludes:
+            excludes = EmptyI
+        assert excludes == EmptyI or self.excludes == EmptyI
+
+        try:
+            facets = self["pkg.facet"]
+        except KeyError:
+            facets = None
+
+        if facets is not None and excludes == EmptyI:
+            # No excludes? Then use the pre-determined set of
+            # facets.
+            for f in misc.yield_matching("facet.", facets, patterns):
+                yield f
+            return
+
+        # If different excludes were specified, then look for pkg.facet
+        # actions containing the list of facets.
+        found = False
+        seen = set()
+        for a in self.gen_actions_by_type("set", excludes=excludes):
+            if a.attrs["name"][:10] == "pkg.facet.":
+                # Either a pkg.facet.common action or a
+                # pkg.facet.X variant-specific action.
+                found = True
+                val = a.attrlist("value")
+                if len(val) == 1 and val[0] == "":
+                    # No facets.
+                    continue
+
+                for f in misc.yield_matching(
+                    "facet.", ("facet.{0}".format(n) for n in val), patterns
+                ):
+                    if f in seen:
+                        # Prevent duplicates; it's
+                        # possible a given facet may be
+                        # valid for more than one unique
+                        # variant combination that's
+                        # allowed by current excludes.
+                        continue
+
+                    seen.add(f)
+                    yield f
+
+        if not found:
+            # Fallback to sifting actions to yield possible.
+            facets = self._get_varcets(excludes=excludes)[1]
+            for f in misc.yield_matching("facet.", facets, patterns):
+                yield f
+
+    def gen_variants(self, excludes=EmptyI, patterns=EmptyI):
+        """A generator function that yields a list of tuples of the form
+        (variant, [values]).  Where 'variant' is the variant attribute
+        name (e.g. 'variant.arch') and '[values]' is a list of the
+        variant values supported by this package.  Variants returned are
+        those allowed by the specified (or current) excludes that also
+        match at least one of the patterns provided."""
+
+        if self.excludes == excludes:
+            excludes = EmptyI
+        assert excludes == EmptyI or self.excludes == EmptyI
+
+        try:
+            variants = self["pkg.variant"]
+        except KeyError:
+            variants = None
+
+        if variants is not None and excludes == EmptyI:
+            # No excludes? Then use the pre-determined set of
+            # variants.
+            for v in misc.yield_matching("variant.", variants, patterns):
+                yield v, self.attributes.get(v, [])
+            return
+
+        # If different excludes were specified, then look for
+        # pkg.variant action containing the list of variants.
+        found = False
+        variants = defaultdict(set)
+        for a in self.gen_actions_by_type("set", excludes=excludes):
+            aname = a.attrs["name"]
+            if aname == "pkg.variant":
+                val = a.attrlist("value")
+                if len(val) == 1 and val[0] == "":
+                    # No variants.
+                    return
+                for v in val:
+                    found = True
+                    # Ensure variant entries exist (debug
+                    # variants may not) via defaultdict.
+                    variants["variant.{0}".format(v)]
+            elif aname[:8] == "variant.":
+                for v in a.attrlist("value"):
+                    found = True
+                    variants[aname].add(v)
+
+        if not found:
+            # Fallback to sifting actions to get possible.
+            variants = self._get_varcets(excludes=excludes)[0]
+
+        for v in misc.yield_matching("variant.", variants, patterns):
+            yield v, variants[v]
+
+    def gen_mediators(self, excludes=EmptyI):
+        """A generator function that yields tuples of the form (mediator,
+        mediations) expressing the set of possible mediations for this
+        package, where 'mediations' is a set() of possible mediations for
+        the mediator.  Each mediation is a tuple of the form (priority,
+        version, implementation).
+        """
+
+        if self.excludes == excludes:
+            excludes = EmptyI
+        assert excludes == EmptyI or self.excludes == EmptyI
+        try:
+            alist = self._cache["manifest.mediatorcache"]
+        except KeyError:
+            # generate actions that contain mediators
+            alist = self._cache["manifest.mediatorcache"] = [
+                actions.fromstr(s.rstrip())
+                for s in self._gen_mediators_to_str()
+            ]
+
+        ret = defaultdict(set)
+        for attrs in (
+            act.attrs
+            for act in alist
+            if not excludes or act.include_this(excludes)
+        ):
+            med_ver = attrs.get("mediator-version")
+            if med_ver:
+                try:
+                    med_ver = version.Version(med_ver)
+                except version.VersionError:
+                    # Consider this mediation unavailable
+                    # if it can't be parsed for whatever
+                    # reason.
+                    continue
+
+            ret[attrs["value"]].add(
+                (
+                    attrs.get("mediator-priority"),
+                    med_ver,
+                    attrs.get("mediator-implementation"),
+                )
+            )
+
+        for m in ret:
+            yield m, ret[m]
+
+    def gen_actions(self, attr_match=None, excludes=EmptyI):
+        """Generate actions in manifest through ordered callable list"""
+
+        if self.excludes == excludes:
+            excludes = EmptyI
+        assert excludes == EmptyI or self.excludes == EmptyI
+
+        if attr_match:
+            attr_match = _compile_fnpats(attr_match)
+
+        pub = self.publisher
+        for a in self.actions:
+            for c in excludes:
+                if not c(a, publisher=pub):
+                    break
+            else:
+                # These conditions are split by performance.
+                if not attr_match:
+                    yield a
+                elif _attr_matches(a, attr_match):
+                    yield a
+
+    def gen_actions_by_type(self, atype, attr_match=None, excludes=EmptyI):
+        """Generate actions in the manifest of type "type"
+        through ordered callable list"""
+
+        if self.excludes == excludes:
+            excludes = EmptyI
+        assert excludes == EmptyI or self.excludes == EmptyI
+
+        if attr_match:
+            attr_match = _compile_fnpats(attr_match)
+
+        pub = self.publisher
+        for a in self.actions_bytype.get(atype, []):
+            for c in excludes:
+                if not c(a, publisher=pub):
+                    break
+            else:
+                # These conditions are split by performance.
+                if not attr_match:
+                    yield a
+                elif _attr_matches(a, attr_match):
+                    yield a
+
+    def gen_actions_by_types(self, atypes, attr_match=None, excludes=EmptyI):
+        """Generate actions in the manifest of types "atypes"
+        through ordered callable list."""
+
+        for atype in atypes:
+            for a in self.gen_actions_by_type(
+                atype, attr_match=attr_match, excludes=excludes
+            ):
+                yield a
+
+    def gen_key_attribute_value_by_type(self, atype, excludes=EmptyI):
+        """Generate the value of the key attribute for each action
+        of type "type" in the manifest."""
+
+        return (
+            a.attrs.get(a.key_attr)
+            for a in self.gen_actions_by_type(atype, excludes=excludes)
+        )
+
+    def duplicates(self, excludes=EmptyI):
+        """Find actions in the manifest which are duplicates (i.e.,
+        represent the same object) but which are not identical (i.e.,
+        have all the same attributes)."""
+
+        def fun(a):
+            """Return a key on which actions can be sorted."""
+            return a.name, a.attrs.get(a.key_attr, id(a))
+
+        alldups = []
+        acts = [a for a in self.gen_actions(excludes=excludes)]
+
+        for k, g in groupby(sorted(acts, key=fun), fun):
+            glist = list(g)
+            dups = set()
+            for i in range(len(glist) - 1):
+                if glist[i].different(glist[i + 1]):
+                    dups.add(glist[i])
+                    dups.add(glist[i + 1])
+            if dups:
+                alldups.append((k, dups))
+        return alldups
+
+    def __content_to_actions(self, content):
+        """Parse manifest content, stripping line-continuation
                 characters from the input as it is read; this results in actions
                 with values across multiple lines being passed to the
                 action parsing code whitespace-separated instead.
@@ -1029,1041 +1056,1060 @@ class Manifest(object):
                 set name=pkg.description value="foo " "bar baz"
                 """
 
+        accumulate = ""
+        lineno = 0
+        errors = []
+
+        if isinstance(content, six.string_types):
+            # Get an iterable for the string.
+            content = content.splitlines()
+
+        for l in content:
+            lineno += 1
+            l = l.lstrip()
+            if l.endswith("\\"):  # allow continuation chars
+                accumulate += l[0:-1]  # elide backslash
+                continue
+            elif accumulate:
+                l = accumulate + l
                 accumulate = ""
-                lineno = 0
-                errors = []
 
-                if isinstance(content, six.string_types):
-                        # Get an iterable for the string.
-                        content = content.splitlines()
+            if not l or l[0] == "#":  # ignore blank lines & comments
+                continue
 
-                for l in content:
-                        lineno += 1
-                        l = l.lstrip()
-                        if l.endswith("\\"):          # allow continuation chars
-                                accumulate += l[0:-1] # elide backslash
-                                continue
-                        elif accumulate:
-                                l = accumulate + l
-                                accumulate = ""
+            try:
+                yield actions.fromstr(l)
+            except actions.ActionError as e:
+                # Accumulate errors and continue so that as
+                # much of the action data as possible can be
+                # parsed.
+                e.fmri = self.fmri
+                e.lineno = lineno
+                errors.append(e)
 
-                        if not l or l[0] == "#": # ignore blank lines & comments
-                                continue
+        if errors:
+            raise apx.InvalidPackageErrors(errors)
 
-                        try:
-                                yield actions.fromstr(l)
-                        except actions.ActionError as e:
-                                # Accumulate errors and continue so that as
-                                # much of the action data as possible can be
-                                # parsed.
-                                e.fmri = self.fmri
-                                e.lineno = lineno
-                                errors.append(e)
+    def set_content(
+        self, content=None, excludes=EmptyI, pathname=None, signatures=False
+    ):
+        """Populate the manifest with actions.
 
-                if errors:
-                        raise apx.InvalidPackageErrors(errors)
+        'content' is an optional value containing either the text
+        representation of the manifest or an iterable of
+        action objects.
 
-        def set_content(self, content=None, excludes=EmptyI, pathname=None,
-            signatures=False):
-                """Populate the manifest with actions.
+        'excludes' is optional.  If provided it must be a length two
+        list with the variants to be excluded as the first element and
+        the facets to be excluded as the second element.
 
-                'content' is an optional value containing either the text
-                representation of the manifest or an iterable of
-                action objects.
+        'pathname' is an optional filename containing the location of
+        the manifest content.
 
-                'excludes' is optional.  If provided it must be a length two
-                list with the variants to be excluded as the first element and
-                the facets to be excluded as the second element.
+        'signatures' is an optional boolean value that indicates whether
+        a manifest signature should be generated.  This is only possible
+        when 'content' is a string or 'pathname' is provided.
+        """
 
-                'pathname' is an optional filename containing the location of
-                the manifest content.
+        assert content is not None or pathname is not None
+        assert not (content and pathname)
 
-                'signatures' is an optional boolean value that indicates whether
-                a manifest signature should be generated.  This is only possible
-                when 'content' is a string or 'pathname' is provided.
-                """
+        self.actions = []
+        self.actions_bytype = {}
+        self.attributes = {}
+        self._cache = {}
+        self._absent_cache = []
 
-                assert content is not None or pathname is not None
-                assert not (content and pathname)
+        # So we could build up here the type/key_attr dictionaries like
+        # sdict and odict in difference() above, and have that be our
+        # main datastore, rather than the simple list we have now.  If
+        # we do that here, we can even assert that the "same" action
+        # can't be in a manifest twice.  (The problem of having the same
+        # action more than once in packages that can be installed
+        # together has to be solved somewhere else, though.)
+        if pathname:
+            try:
+                with open(pathname, "r", encoding="UTF-8") as mfile:
+                    content = mfile.read()
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
 
-                self.actions = []
-                self.actions_bytype = {}
-                self.attributes = {}
-                self._cache = {}
-                self._absent_cache = []
+        if six.PY3 and isinstance(content, bytes):
+            raise TypeError("content must be str, not bytes")
 
-                # So we could build up here the type/key_attr dictionaries like
-                # sdict and odict in difference() above, and have that be our
-                # main datastore, rather than the simple list we have now.  If
-                # we do that here, we can even assert that the "same" action
-                # can't be in a manifest twice.  (The problem of having the same
-                # action more than once in packages that can be installed
-                # together has to be solved somewhere else, though.)
-                if pathname:
-                        try:
-                                with open(pathname, "r", encoding='UTF-8') as mfile:
-                                        content = mfile.read()
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
+        if isinstance(content, six.string_types):
+            if signatures:
+                # Generate manifest signature based upon
+                # input content, but only if signatures
+                # were requested. In order to interoperate with
+                # older clients, we must use sha-1 here.
+                self.signatures = {"sha-1": self.hash_create(content)}
+            content = self.__content_to_actions(content)
 
-                if six.PY3 and isinstance(content, bytes):
-                        raise TypeError("content must be str, not bytes")
+        for action in content:
+            self.add_action(action, excludes)
+        self.excludes = excludes
+        # Make sure that either no excludes were provided or that both
+        # variants and facet excludes were or that variant, facet and
+        # hydrate excludes were.
+        assert len(self.excludes) != 1
 
-                if isinstance(content, six.string_types):
-                        if signatures:
-                                # Generate manifest signature based upon
-                                # input content, but only if signatures
-                                # were requested. In order to interoperate with
-                                # older clients, we must use sha-1 here.
-                                self.signatures = {
-                                    "sha-1": self.hash_create(content)
-                                }
-                        content = self.__content_to_actions(content)
+    def exclude_content(self, excludes):
+        """Remove any actions from the manifest which should be
+        excluded."""
 
-                for action in content:
-                        self.add_action(action, excludes)
-                self.excludes = excludes
-                # Make sure that either no excludes were provided or that both
-                # variants and facet excludes were or that variant, facet and
-                # hydrate excludes were.
-                assert len(self.excludes) != 1
+        self.set_content(content=self.actions, excludes=excludes)
 
-        def exclude_content(self, excludes):
-                """Remove any actions from the manifest which should be
-                excluded."""
+    def add_action(self, action, excludes):
+        """Performs any needed transformations on the action then adds
+        it to the manifest.
 
-                self.set_content(content=self.actions, excludes=excludes)
+        The "action" parameter is the action object that should be
+        added to the manifest.
 
-        def add_action(self, action, excludes):
-                """Performs any needed transformations on the action then adds
-                it to the manifest.
+        The "excludes" parameter is the variants to exclude from the
+        manifest."""
 
-                The "action" parameter is the action object that should be
-                added to the manifest.
+        attrs = action.attrs
+        aname = action.name
 
-                The "excludes" parameter is the variants to exclude from the
-                manifest."""
+        # XXX handle legacy transition issues; not needed once support
+        # for upgrading images from older releases (< build 151) has
+        # been removed.
+        if (
+            "opensolaris.zone" in attrs
+            and "variant.opensolaris.zone" not in attrs
+        ):
+            attrs["variant.opensolaris.zone"] = attrs["opensolaris.zone"]
 
-                attrs = action.attrs
-                aname = action.name
+        if aname == "set" and attrs["name"] == "authority":
+            # Translate old action to new.
+            attrs["name"] = "publisher"
 
-                # XXX handle legacy transition issues; not needed once support
-                # for upgrading images from older releases (< build 151) has
-                # been removed.
-                if "opensolaris.zone" in attrs and \
-                    "variant.opensolaris.zone" not in attrs:
-                        attrs["variant.opensolaris.zone"] = \
-                            attrs["opensolaris.zone"]
+        if excludes and not action.include_this(
+            excludes, publisher=self.publisher
+        ):
+            return
+        self.actions.append(action)
+        try:
+            self.actions_bytype[aname].append(action)
+        except KeyError:
+            self.actions_bytype.setdefault(aname, []).append(action)
 
-                if aname == "set" and attrs["name"] == "authority":
-                        # Translate old action to new.
-                        attrs["name"] = "publisher"
+        # add any set actions to attributes
+        if aname == "set":
+            self.fill_attributes(action)
 
-                if excludes and not action.include_this(excludes,
-                    publisher=self.publisher):
-                        return
-                self.actions.append(action)
-                try:
-                        self.actions_bytype[aname].append(action)
-                except KeyError:
-                        self.actions_bytype.setdefault(aname, []).append(action)
+    def fill_attributes(self, action):
+        """Fill attribute array w/ set action contents."""
+        try:
+            keyvalue = action.attrs["name"]
+            if keyvalue[:10] == "pkg.sizes.":
+                # To reduce manifest bloat, size and csize
+                # are set on a single action so need splitting
+                # into separate attributes.
+                attrval = action.attrlist("value")
+                for entry in attrval:
+                    szname, szval = entry.split("=", 1)
+                    if szname == "sz":
+                        szname = "pkg.size"
+                    elif szname == "csz":
+                        szname = "pkg.csize"
+                    else:
+                        # Skip unknowns.
+                        continue
 
-                # add any set actions to attributes
-                if aname == "set":
-                        self.fill_attributes(action)
+                    self.attributes.setdefault(szname, 0)
+                    self.attributes[szname] += int(szval)
+                return
+        except (KeyError, TypeError, ValueError):
+            # ignore broken set actions
+            pass
 
-        def fill_attributes(self, action):
-                """Fill attribute array w/ set action contents."""
-                try:
-                        keyvalue = action.attrs["name"]
-                        if keyvalue[:10] == "pkg.sizes.":
-                                # To reduce manifest bloat, size and csize
-                                # are set on a single action so need splitting
-                                # into separate attributes.
-                                attrval = action.attrlist("value")
-                                for entry in attrval:
-                                        szname, szval = entry.split("=", 1)
-                                        if szname == "sz":
-                                                szname = "pkg.size"
-                                        elif szname == "csz":
-                                                szname = "pkg.csize"
-                                        else:
-                                                # Skip unknowns.
-                                                continue
+        # Ensure facet and variant attributes are always lists.
+        if keyvalue[:10] == "pkg.facet.":
+            # Possible facets list is spread over multiple actions.
+            val = action.attrlist("value")
+            if len(val) == 1 and val[0] == "":
+                # No facets.
+                val = []
 
-                                        self.attributes.setdefault(szname, 0)
-                                        self.attributes[szname] += int(szval)
-                                return
-                except (KeyError, TypeError, ValueError):
-                        # ignore broken set actions
-                        pass
+            seen = self.attributes.setdefault("pkg.facet", [])
+            for f in val:
+                entry = "facet.{0}".format(f)
+                if entry not in seen:
+                    # Prevent duplicates; it's possible a
+                    # given facet may be valid for more than
+                    # one unique variant combination that's
+                    # allowed by current excludes.
+                    seen.append(f)
+            return
+        elif keyvalue == "pkg.variant":
+            val = action.attrlist("value")
+            if len(val) == 1 and val[0] == "":
+                # No variants.
+                val = []
 
-                # Ensure facet and variant attributes are always lists.
-                if keyvalue[:10] == "pkg.facet.":
-                        # Possible facets list is spread over multiple actions.
-                        val = action.attrlist("value")
-                        if len(val) == 1 and val[0] == "":
-                                # No facets.
-                                val = []
+            self.attributes[keyvalue] = ["variant.{0}".format(v) for v in val]
+            return
+        elif keyvalue[:8] == "variant.":
+            self.attributes[keyvalue] = action.attrlist("value")
+            return
 
-                        seen = self.attributes.setdefault("pkg.facet", [])
-                        for f in val:
-                                entry = "facet.{0}".format(f)
-                                if entry not in seen:
-                                        # Prevent duplicates; it's possible a
-                                        # given facet may be valid for more than
-                                        # one unique variant combination that's
-                                        # allowed by current excludes.
-                                        seen.append(f)
-                        return
-                elif keyvalue == "pkg.variant":
-                        val = action.attrlist("value")
-                        if len(val) == 1 and val[0] == "":
-                                # No variants.
-                                val = []
+        if keyvalue == "fmri":
+            # Ancient manifest compatibility.
+            keyvalue = "pkg.fmri"
+        self.attributes[keyvalue] = action.attrs["value"]
 
-                        self.attributes[keyvalue] = [
-                            "variant.{0}".format(v)
-                            for v in val
-                        ]
-                        return
-                elif keyvalue[:8] == "variant.":
-                        self.attributes[keyvalue] = action.attrlist("value")
-                        return
+    @staticmethod
+    def search_dict(file_path, excludes, return_line=False, log=None):
+        """Produces the search dictionary for a specific manifest.
+        A dictionary is constructed which maps a tuple of token,
+        action type, key, and the value that matched the token to
+        the byte offset into the manifest file. file_path is the
+        path to the manifest file. excludes is the variants which
+        should be allowed in this image. return_line is a debugging
+        flag which makes the function map the information to the
+        string of the line, rather than the byte offset to allow
+        easier debugging."""
 
-                if keyvalue == "fmri":
-                        # Ancient manifest compatibility.
-                        keyvalue = "pkg.fmri"
-                self.attributes[keyvalue] = action.attrs["value"]
+        if log is None:
+            log = lambda x: None
 
-        @staticmethod
-        def search_dict(file_path, excludes, return_line=False,
-            log=None):
-                """Produces the search dictionary for a specific manifest.
-                A dictionary is constructed which maps a tuple of token,
-                action type, key, and the value that matched the token to
-                the byte offset into the manifest file. file_path is the
-                path to the manifest file. excludes is the variants which
-                should be allowed in this image. return_line is a debugging
-                flag which makes the function map the information to the
-                string of the line, rather than the byte offset to allow
-                easier debugging."""
+        try:
+            file_handle = open(file_path, "r")
+        except EnvironmentError as e:
+            if e.errno != errno.ENOENT:
+                raise
+            log((_("{fp}:\n{e}").format(fp=file_path, e=e)))
+            return {}
+        cur_pos = 0
+        line = file_handle.readline()
+        action_dict = {}
 
-                if log is None:
-                        log = lambda x: None
+        def __handle_list(lst, cp):
+            """Translates what actions.generate_indices produces
+            into a dictionary mapping token, action_name, key, and
+            the value that should be displayed for matching that
+            token to byte offsets into the manifest file.
 
-                try:
-                        file_handle = open(file_path, "r")
-                except EnvironmentError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
-                        log((_("{fp}:\n{e}").format(
-                            fp=file_path, e=e)))
-                        return {}
-                cur_pos = 0
-                line = file_handle.readline()
-                action_dict = {}
-                def __handle_list(lst, cp):
-                        """Translates what actions.generate_indices produces
-                        into a dictionary mapping token, action_name, key, and
-                        the value that should be displayed for matching that
-                        token to byte offsets into the manifest file.
+            The "lst" parameter is the data to be converted.
 
-                        The "lst" parameter is the data to be converted.
+            The "cp" parameter is the byte offset into the file
+            for the action which produced lst."""
 
-                        The "cp" parameter is the byte offset into the file
-                        for the action which produced lst."""
-
-                        for action_name, subtype, tok, full_value in lst:
-                                if action_name == "set":
-                                        if full_value is None:
-                                                full_value = tok
-                                else:
-                                        if full_value is None:
-                                                full_value = subtype
-                                        if full_value is None:
-                                                full_value = action_name
-                                if isinstance(tok, list):
-                                        __handle_list([
-                                            (action_name, subtype, t,
-                                            full_value)
-                                            for t in tok
-                                        ], cp)
-                                else:
-                                        if (tok, action_name, subtype,
-                                            full_value) in action_dict:
-                                                action_dict[(tok, action_name,
-                                                    subtype, full_value)
-                                                    ].append(cp)
-                                        else:
-                                                action_dict[(tok, action_name,
-                                                    subtype, full_value)] = [cp]
-                while line:
-                        l = line.strip()
-                        if l and l[0] != "#":
-                                try:
-                                        action = actions.fromstr(l)
-                                except actions.ActionError as e:
-                                        log((_("{fp}:\n{e}").format(
-                                            fp=file_path, e=e)))
-                                else:
-                                        if not excludes or \
-                                            action.include_this(excludes):
-                                                if "path" in action.attrs:
-                                                        np = action.attrs["path"].lstrip(os.path.sep)
-                                                        action.attrs["path"] = \
-                                                            np
-                                                try:
-                                                        inds = action.generate_indices()
-                                                except KeyError as k:
-                                                        log(_("{fp} contains "
-                                                            "an action which is"
-                                                            " missing the "
-                                                            "expected attribute"
-                                                            ": {at}.\nThe "
-                                                            "action is:"
-                                                            "{act}").format(
-                                                                fp=file_path,
-                                                                at=k.args[0],
-                                                                act=l
-                                                           ))
-                                                else:
-                                                        arg = cur_pos
-                                                        if return_line:
-                                                                arg = l
-                                                        __handle_list(inds, arg)
-                        cur_pos = file_handle.tell()
-                        line = file_handle.readline()
-                file_handle.close()
-                return action_dict
-
-        @staticmethod
-        def hash_create(mfstcontent):
-                """This method takes a string representing the on-disk
-                manifest content, and returns a hash value."""
-
-                # This must be an SHA-1 hash in order to interoperate with
-                # older clients.
-                sha_1 = hashlib.sha1()
-                if isinstance(mfstcontent, six.text_type):
-                        # Byte stream expected, so pass encoded.
-                        sha_1.update(mfstcontent.encode("utf-8"))
+            for action_name, subtype, tok, full_value in lst:
+                if action_name == "set":
+                    if full_value is None:
+                        full_value = tok
                 else:
-                        sha_1.update(mfstcontent)
+                    if full_value is None:
+                        full_value = subtype
+                    if full_value is None:
+                        full_value = action_name
+                if isinstance(tok, list):
+                    __handle_list(
+                        [(action_name, subtype, t, full_value) for t in tok], cp
+                    )
+                else:
+                    if (tok, action_name, subtype, full_value) in action_dict:
+                        action_dict[
+                            (tok, action_name, subtype, full_value)
+                        ].append(cp)
+                    else:
+                        action_dict[(tok, action_name, subtype, full_value)] = [
+                            cp
+                        ]
 
-                return sha_1.hexdigest()
-
-        def validate(self, signatures):
-                """Verifies whether the signatures for the contents of
-                the manifest match the specified signature data.  Raises
-                the 'BadManifestSignatures' exception on failure."""
-
-                if signatures != self.signatures:
-                        raise apx.BadManifestSignatures(self.fmri)
-
-        def store(self, mfst_path):
-                """Store the manifest contents to disk."""
-
-                t_dir = os.path.dirname(mfst_path)
-                t_prefix = os.path.basename(mfst_path) + "."
-
+        while line:
+            l = line.strip()
+            if l and l[0] != "#":
                 try:
-                        os.makedirs(t_dir, mode=PKG_DIR_MODE)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        if e.errno != errno.EEXIST:
-                                raise
+                    action = actions.fromstr(l)
+                except actions.ActionError as e:
+                    log((_("{fp}:\n{e}").format(fp=file_path, e=e)))
+                else:
+                    if not excludes or action.include_this(excludes):
+                        if "path" in action.attrs:
+                            np = action.attrs["path"].lstrip(os.path.sep)
+                            action.attrs["path"] = np
+                        try:
+                            inds = action.generate_indices()
+                        except KeyError as k:
+                            log(
+                                _(
+                                    "{fp} contains "
+                                    "an action which is"
+                                    " missing the "
+                                    "expected attribute"
+                                    ": {at}.\nThe "
+                                    "action is:"
+                                    "{act}"
+                                ).format(fp=file_path, at=k.args[0], act=l)
+                            )
+                        else:
+                            arg = cur_pos
+                            if return_line:
+                                arg = l
+                            __handle_list(inds, arg)
+            cur_pos = file_handle.tell()
+            line = file_handle.readline()
+        file_handle.close()
+        return action_dict
 
-                try:
-                        fd, fn = tempfile.mkstemp(dir=t_dir, prefix=t_prefix)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
+    @staticmethod
+    def hash_create(mfstcontent):
+        """This method takes a string representing the on-disk
+        manifest content, and returns a hash value."""
 
-                mfile = os.fdopen(fd, "w")
+        # This must be an SHA-1 hash in order to interoperate with
+        # older clients.
+        sha_1 = hashlib.sha1()
+        if isinstance(mfstcontent, six.text_type):
+            # Byte stream expected, so pass encoded.
+            sha_1.update(mfstcontent.encode("utf-8"))
+        else:
+            sha_1.update(mfstcontent)
 
-                #
-                # We specifically avoid sorting manifests before writing
-                # them to disk-- there's really no point in doing so, since
-                # we'll sort actions globally during packaging operations.
-                #
-                mfile.write(self.tostr_unsorted())
-                mfile.close()
+        return sha_1.hexdigest()
 
-                try:
-                        os.chmod(fn, PKG_FILE_MODE)
-                        portable.rename(fn, mfst_path)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
+    def validate(self, signatures):
+        """Verifies whether the signatures for the contents of
+        the manifest match the specified signature data.  Raises
+        the 'BadManifestSignatures' exception on failure."""
 
-        def get_variants(self, name):
-                if name not in self.attributes:
-                        return None
-                variants = self.attributes[name]
-                if not isinstance(variants, str):
-                        return variants
-                return [variants]
+        if signatures != self.signatures:
+            raise apx.BadManifestSignatures(self.fmri)
 
-        def get_all_variants(self):
-                """Return a dictionary mapping variant tags to their values."""
-                return variant.VariantCombinationTemplate(dict((
+    def store(self, mfst_path):
+        """Store the manifest contents to disk."""
+
+        t_dir = os.path.dirname(mfst_path)
+        t_prefix = os.path.basename(mfst_path) + "."
+
+        try:
+            os.makedirs(t_dir, mode=PKG_DIR_MODE)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            if e.errno != errno.EEXIST:
+                raise
+
+        try:
+            fd, fn = tempfile.mkstemp(dir=t_dir, prefix=t_prefix)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
+
+        mfile = os.fdopen(fd, "w")
+
+        #
+        # We specifically avoid sorting manifests before writing
+        # them to disk-- there's really no point in doing so, since
+        # we'll sort actions globally during packaging operations.
+        #
+        mfile.write(self.tostr_unsorted())
+        mfile.close()
+
+        try:
+            os.chmod(fn, PKG_FILE_MODE)
+            portable.rename(fn, mfst_path)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
+
+    def get_variants(self, name):
+        if name not in self.attributes:
+            return None
+        variants = self.attributes[name]
+        if not isinstance(variants, str):
+            return variants
+        return [variants]
+
+    def get_all_variants(self):
+        """Return a dictionary mapping variant tags to their values."""
+        return variant.VariantCombinationTemplate(
+            dict(
+                (
                     (name, self.attributes[name])
                     for name in self.attributes
                     if name.startswith("variant.")
-                )))
+                )
+            )
+        )
 
-        def get(self, key, default):
-                try:
-                        return self[key]
-                except KeyError:
-                        return default
+    def get(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            return default
 
-        def getbool(self, key, default):
-                """Returns the boolean of the value of the attribute 'key'."""
+    def getbool(self, key, default):
+        """Returns the boolean of the value of the attribute 'key'."""
 
-                ret = self.get(key, default).lower()
-                if ret == "true":
-                        return True
-                elif ret == "false":
-                        return False
-                else:
-                        raise ValueError(_("Attribute value '{0}' not 'true' or "
-                            "'false'".format(ret)))
+        ret = self.get(key, default).lower()
+        if ret == "true":
+            return True
+        elif ret == "false":
+            return False
+        else:
+            raise ValueError(
+                _("Attribute value '{0}' not 'true' or " "'false'".format(ret))
+            )
 
-        def get_size(self, excludes=EmptyI):
-                """Returns an integer tuple of the form (size, csize), where
-                'size' represents the total uncompressed size, in bytes, of the
-                Manifest's data payload, and 'csize' represents the compressed
-                version of that.
+    def get_size(self, excludes=EmptyI):
+        """Returns an integer tuple of the form (size, csize), where
+        'size' represents the total uncompressed size, in bytes, of the
+        Manifest's data payload, and 'csize' represents the compressed
+        version of that.
 
-                'excludes' is a list of a list of variants and facets which
-                should be allowed when calculating the total."""
+        'excludes' is a list of a list of variants and facets which
+        should be allowed when calculating the total."""
 
-                if self.excludes == excludes:
-                        excludes = EmptyI
-                assert excludes == EmptyI or self.excludes == EmptyI
+        if self.excludes == excludes:
+            excludes = EmptyI
+        assert excludes == EmptyI or self.excludes == EmptyI
 
-                csize = 0
-                size = 0
+        csize = 0
+        size = 0
 
-                attrs = self.attributes
-                if ("pkg.size" in attrs and "pkg.csize" in attrs) and \
-                    (excludes == EmptyI or self.excludes == excludes):
-                        # If specified excludes match loaded excludes, then use
-                        # cached attributes; this is safe as manifest attributes
-                        # are reset or updated every time exclude_content,
-                        # set_content, or add_action is called.
-                        return (attrs["pkg.size"], attrs["pkg.csize"])
+        attrs = self.attributes
+        if ("pkg.size" in attrs and "pkg.csize" in attrs) and (
+            excludes == EmptyI or self.excludes == excludes
+        ):
+            # If specified excludes match loaded excludes, then use
+            # cached attributes; this is safe as manifest attributes
+            # are reset or updated every time exclude_content,
+            # set_content, or add_action is called.
+            return (attrs["pkg.size"], attrs["pkg.csize"])
 
-                for a in self.gen_actions(excludes=excludes):
-                        size += a.get_size()
-                        csize += misc.get_pkg_otw_size(a)
+        for a in self.gen_actions(excludes=excludes):
+            size += a.get_size()
+            csize += misc.get_pkg_otw_size(a)
 
-                if excludes == EmptyI:
-                        # Cache for future calls.
-                        attrs["pkg.size"] = size
-                        attrs["pkg.csize"] = csize
+        if excludes == EmptyI:
+            # Cache for future calls.
+            attrs["pkg.size"] = size
+            attrs["pkg.csize"] = csize
 
-                return (size, csize)
+        return (size, csize)
 
-        def _get_varcets(self, excludes=EmptyI):
-                """Private helper function to get list of facets/variants."""
+    def _get_varcets(self, excludes=EmptyI):
+        """Private helper function to get list of facets/variants."""
 
-                variants = defaultdict(set)
-                facets = defaultdict(set)
+        variants = defaultdict(set)
+        facets = defaultdict(set)
 
-                nexcludes = excludes
-                if nexcludes:
-                        # Facet filtering should never be applied when excluding
-                        # actions; only variant filtering.  This is ugly, but
-                        # our current variant/facet filtering system doesn't
-                        # allow you to be selective and various bits in
-                        # pkg.manifest assume you always filter on both so we
-                        # have to fake up a filter for facets.
-                        if six.PY2:
-                                nexcludes = [
-                                    x for x in excludes
-                                    if x.__func__ != facet._allow_facet
-                                ]
-                        else:
-                                nexcludes = [
-                                    x for x in excludes
-                                    if x.__func__ != facet.Facets.allow_action
-                                ]
-                        # Excludes list must always have zero or 2+ items; so
-                        # fake second entry.
-                        nexcludes.append(lambda x, publisher: True)
-                        assert len(nexcludes) > 1
+        nexcludes = excludes
+        if nexcludes:
+            # Facet filtering should never be applied when excluding
+            # actions; only variant filtering.  This is ugly, but
+            # our current variant/facet filtering system doesn't
+            # allow you to be selective and various bits in
+            # pkg.manifest assume you always filter on both so we
+            # have to fake up a filter for facets.
+            if six.PY2:
+                nexcludes = [
+                    x for x in excludes if x.__func__ != facet._allow_facet
+                ]
+            else:
+                nexcludes = [
+                    x
+                    for x in excludes
+                    if x.__func__ != facet.Facets.allow_action
+                ]
+            # Excludes list must always have zero or 2+ items; so
+            # fake second entry.
+            nexcludes.append(lambda x, publisher: True)
+            assert len(nexcludes) > 1
 
-                for action in self.gen_actions():
-                        # append any variants and facets to manifest dict
-                        attrs = action.attrs
-                        v_list, f_list = action.get_varcet_keys()
+        for action in self.gen_actions():
+            # append any variants and facets to manifest dict
+            attrs = action.attrs
+            v_list, f_list = action.get_varcet_keys()
 
-                        if not (v_list or f_list):
-                                continue
+            if not (v_list or f_list):
+                continue
 
-                        try:
-                                for v, d in zip(v_list, repeat(variants)):
-                                        d[v].add(attrs[v])
+            try:
+                for v, d in zip(v_list, repeat(variants)):
+                    d[v].add(attrs[v])
 
-                                if not excludes or action.include_this(
-                                    nexcludes, publisher=self.publisher):
-                                        # While variants are package level (you
-                                        # can't install a package without
-                                        # setting the variant first), facets
-                                        # from the current action should only be
-                                        # included if the action is not
-                                        # excluded.
-                                        for v, d in zip(f_list, repeat(facets)):
-                                                d[v].add(attrs[v])
-                        except TypeError:
-                                # Lists can't be set elements.
-                                raise actions.InvalidActionError(action,
-                                    _("{forv} '{v}' specified multiple times").format(
-                                    forv=v.split(".", 1)[0], v=v))
+                if not excludes or action.include_this(
+                    nexcludes, publisher=self.publisher
+                ):
+                    # While variants are package level (you
+                    # can't install a package without
+                    # setting the variant first), facets
+                    # from the current action should only be
+                    # included if the action is not
+                    # excluded.
+                    for v, d in zip(f_list, repeat(facets)):
+                        d[v].add(attrs[v])
+            except TypeError:
+                # Lists can't be set elements.
+                raise actions.InvalidActionError(
+                    action,
+                    _("{forv} '{v}' specified multiple times").format(
+                        forv=v.split(".", 1)[0], v=v
+                    ),
+                )
 
-                return (variants, facets)
+        return (variants, facets)
 
-        def __getitem__(self, key):
-                """Return the value for the package attribute 'key'."""
-                return self.attributes[key]
+    def __getitem__(self, key):
+        """Return the value for the package attribute 'key'."""
+        return self.attributes[key]
 
-        def __setitem__(self, key, value):
-                """Set the value for the package attribute 'key' to 'value'."""
-                self.attributes[key] = value
-                for a in self.actions:
-                        if a.name == "set" and a.attrs["name"] == key:
-                                a.attrs["value"] = value
-                                return
+    def __setitem__(self, key, value):
+        """Set the value for the package attribute 'key' to 'value'."""
+        self.attributes[key] = value
+        for a in self.actions:
+            if a.name == "set" and a.attrs["name"] == key:
+                a.attrs["value"] = value
+                return
 
-                new_attr = AttributeAction(None, name=key, value=value)
-                self.actions.append(new_attr)
-                self.actions_bytype.setdefault("set", []).append(new_attr)
+        new_attr = AttributeAction(None, name=key, value=value)
+        self.actions.append(new_attr)
+        self.actions_bytype.setdefault("set", []).append(new_attr)
 
-        def __contains__(self, key):
-                return key in self.attributes
+    def __contains__(self, key):
+        return key in self.attributes
+
 
 null = Manifest()
 
+
 class FactoredManifest(Manifest):
-        """This class serves as a wrapper for the Manifest class for callers
-        that need efficient access to package data on a per-action type basis.
-        It achieves this by partitioning the manifest into multiple files (one
-        per action type) and then storing an on-disk cache of the directories
-        explictly and implicitly referenced by the manifest each tagged with
-        the appropriate variants/facets."""
+    """This class serves as a wrapper for the Manifest class for callers
+    that need efficient access to package data on a per-action type basis.
+    It achieves this by partitioning the manifest into multiple files (one
+    per action type) and then storing an on-disk cache of the directories
+    explictly and implicitly referenced by the manifest each tagged with
+    the appropriate variants/facets."""
 
-        def __init__(self, fmri, cache_root, contents=None, excludes=EmptyI,
-            pathname=None):
-                """Raises KeyError exception if factored manifest is not present
-                and contents are None; delays reading of manifest until required
-                if cache file is present.
+    def __init__(
+        self, fmri, cache_root, contents=None, excludes=EmptyI, pathname=None
+    ):
+        """Raises KeyError exception if factored manifest is not present
+        and contents are None; delays reading of manifest until required
+        if cache file is present.
 
-                'fmri' is a PkgFmri object representing the identity of the
-                package.
+        'fmri' is a PkgFmri object representing the identity of the
+        package.
 
-                'cache_root' is the pathname of the directory where the manifest
-                and cache files should be stored or loaded from.
+        'cache_root' is the pathname of the directory where the manifest
+        and cache files should be stored or loaded from.
 
-                'contents' is an optional string to use as the contents of the
-                manifest if a cached copy does not already exist.
+        'contents' is an optional string to use as the contents of the
+        manifest if a cached copy does not already exist.
 
-                'excludes' is optional.  If provided it must be a length two
-                list with the variants to be excluded as the first element and
-                the facets to be exclduded as the second element.
+        'excludes' is optional.  If provided it must be a length two
+        list with the variants to be excluded as the first element and
+        the facets to be exclduded as the second element.
 
-                'pathname' is an optional string containing the pathname of a
-                manifest.  If not provided, it is assumed that the manifest is
-                stored in a file named 'manifest' in the directory indicated by
-                'cache_root'.  If provided, and contents is also provided, then
-                'contents' will be stored in 'pathname' if it does not already
-                exist.
-                """
+        'pathname' is an optional string containing the pathname of a
+        manifest.  If not provided, it is assumed that the manifest is
+        stored in a file named 'manifest' in the directory indicated by
+        'cache_root'.  If provided, and contents is also provided, then
+        'contents' will be stored in 'pathname' if it does not already
+        exist.
+        """
 
-                Manifest.__init__(self, fmri)
-                self.__cache_root = cache_root
-                self.__pathname = pathname
-                # Make sure that either no excludes were provided or 2+ excludes
-                # were.
-                assert len(self.excludes) != 1
-                self.loaded = False
+        Manifest.__init__(self, fmri)
+        self.__cache_root = cache_root
+        self.__pathname = pathname
+        # Make sure that either no excludes were provided or 2+ excludes
+        # were.
+        assert len(self.excludes) != 1
+        self.loaded = False
 
-                # Do we have a cached copy?
-                if not os.path.exists(self.pathname):
-                        if contents is None:
-                                raise KeyError(fmri)
-                        # we have no cached copy; save one
-                        # don't specify excludes so on-disk copy has
-                        # all variants
-                        self.set_content(content=contents)
-                        self.__finiload()
-                        if self.__storeback():
-                                self.__unload()
-                        if excludes:
-                                self.exclude_content(excludes)
-                        return
-
-                # we have a cached copy of the manifest
-                mdpath = self.__cache_path("manifest.dircache")
-
-                # have we computed the dircache?
-                if not os.path.exists(mdpath): # we're adding cache
-                        self.excludes = EmptyI # to existing manifest
-                        self.__load()
-                        if self.__storeback():
-                                self.__unload()
-                        if excludes:
-                                self.excludes = excludes
-                                self.__load()
-                        return
+        # Do we have a cached copy?
+        if not os.path.exists(self.pathname):
+            if contents is None:
+                raise KeyError(fmri)
+            # we have no cached copy; save one
+            # don't specify excludes so on-disk copy has
+            # all variants
+            self.set_content(content=contents)
+            self.__finiload()
+            if self.__storeback():
+                self.__unload()
+            if excludes:
                 self.exclude_content(excludes)
+            return
 
-        def __cache_path(self, name):
-                return os.path.join(self.__cache_root, name)
+        # we have a cached copy of the manifest
+        mdpath = self.__cache_path("manifest.dircache")
 
-        def __load(self):
-                """Load all manifest contents from on-disk copy of manifest"""
-                self.set_content(excludes=self.excludes, pathname=self.pathname)
-                self.__finiload()
+        # have we computed the dircache?
+        if not os.path.exists(mdpath):  # we're adding cache
+            self.excludes = EmptyI  # to existing manifest
+            self.__load()
+            if self.__storeback():
+                self.__unload()
+            if excludes:
+                self.excludes = excludes
+                self.__load()
+            return
+        self.exclude_content(excludes)
 
-        def __unload(self):
-                """Unload manifest; used to reduce peak memory comsumption
-                when downloading new manifests"""
-                self.actions = []
-                self.actions_bytype = {}
-                self.attributes = {}
-                self.loaded = False
+    def __cache_path(self, name):
+        return os.path.join(self.__cache_root, name)
 
-        def __finiload(self):
-                """Finish loading.... this part of initialization is common
-                to multiple code paths"""
-                self.loaded = True
+    def __load(self):
+        """Load all manifest contents from on-disk copy of manifest"""
+        self.set_content(excludes=self.excludes, pathname=self.pathname)
+        self.__finiload()
 
-        def __storeback(self):
-                """ store the current action set; also create per-type
-                caches.  Return True if data was saved, False if not"""
-                assert self.loaded
+    def __unload(self):
+        """Unload manifest; used to reduce peak memory comsumption
+        when downloading new manifests"""
+        self.actions = []
+        self.actions_bytype = {}
+        self.attributes = {}
+        self.loaded = False
+
+    def __finiload(self):
+        """Finish loading.... this part of initialization is common
+        to multiple code paths"""
+        self.loaded = True
+
+    def __storeback(self):
+        """store the current action set; also create per-type
+        caches.  Return True if data was saved, False if not"""
+        assert self.loaded
+        try:
+            self.store(self.pathname)
+            self.__storebytype()
+            return True
+        except apx.PermissionsException:
+            # this allows us to try to cache new manifests
+            # when non-root w/o failures.
+            return False
+
+    def __storebytype(self):
+        """create manifest.<typename> files to accelerate partial
+        parsing of manifests.  Separate from __storeback code to
+        allow upgrade to reuse existing on disk manifests"""
+
+        assert self.loaded
+
+        t_dir = self.__cache_root
+
+        # Ensure target cache directory and intermediates exist.
+        misc.makedirs(t_dir)
+
+        # create per-action type cache; use rename to avoid corrupt
+        # files if ^C'd in the middle.  All action types are considered
+        # so that empty cache files are created if no action of that
+        # type exists for the package (avoids full manifest loads
+        # later).
+        for n, acts in six.iteritems(self.actions_bytype):
+            t_prefix = "manifest.{0}.".format(n)
+
+            try:
+                fd, fn = tempfile.mkstemp(dir=t_dir, prefix=t_prefix)
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+
+            f = os.fdopen(fd, "w")
+            try:
+                for a in acts:
+                    f.write("{0}\n".format(a))
+                if n == "set":
+                    # Add supplemental action data; yes this
+                    # does mean the cache is not the same as
+                    # retrieved manifest, but that's ok.
+                    # Signature verification is done using
+                    # the raw manifest.
+                    f.writelines(self._gen_attrs_to_str())
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+            finally:
+                f.close()
+
+            try:
+                os.chmod(fn, PKG_FILE_MODE)
+                portable.rename(fn, self.__cache_path("manifest.{0}".format(n)))
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+
+        def create_cache(name, refs):
+            try:
+                fd, fn = tempfile.mkstemp(dir=t_dir, prefix=name + ".")
+                with os.fdopen(fd, "w") as f:
+                    f.writelines(refs())
+                os.chmod(fn, PKG_FILE_MODE)
+                portable.rename(fn, self.__cache_path(name))
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+
+        create_cache("manifest.dircache", self._gen_dirs_to_str)
+        create_cache("manifest.mediatorcache", self._gen_mediators_to_str)
+
+    @staticmethod
+    def clear_cache(cache_root):
+        """Remove all manifest cache files found in the given directory
+        (excluding the manifest itself) and the cache_root if it is
+        empty afterwards.
+        """
+
+        try:
+            for cname in os.listdir(cache_root):
+                if not cname.startswith("manifest."):
+                    continue
                 try:
-                        self.store(self.pathname)
-                        self.__storebytype()
-                        return True
-                except apx.PermissionsException:
-                        # this allows us to try to cache new manifests
-                        # when non-root w/o failures.
-                        return False
-
-        def __storebytype(self):
-                """ create manifest.<typename> files to accelerate partial
-                parsing of manifests.  Separate from __storeback code to
-                allow upgrade to reuse existing on disk manifests"""
-
-                assert self.loaded
-
-                t_dir = self.__cache_root
-
-                # Ensure target cache directory and intermediates exist.
-                misc.makedirs(t_dir)
-
-                # create per-action type cache; use rename to avoid corrupt
-                # files if ^C'd in the middle.  All action types are considered
-                # so that empty cache files are created if no action of that
-                # type exists for the package (avoids full manifest loads
-                # later).
-                for n, acts in six.iteritems(self.actions_bytype):
-                        t_prefix = "manifest.{0}.".format(n)
-
-                        try:
-                                fd, fn = tempfile.mkstemp(dir=t_dir,
-                                    prefix=t_prefix)
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-
-                        f = os.fdopen(fd, "w")
-                        try:
-                                for a in acts:
-                                        f.write("{0}\n".format(a))
-                                if n == "set":
-                                        # Add supplemental action data; yes this
-                                        # does mean the cache is not the same as
-                                        # retrieved manifest, but that's ok.
-                                        # Signature verification is done using
-                                        # the raw manifest.
-                                        f.writelines(self._gen_attrs_to_str())
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-                        finally:
-                                f.close()
-
-                        try:
-                                os.chmod(fn, PKG_FILE_MODE)
-                                portable.rename(fn,
-                                    self.__cache_path("manifest.{0}".format(n)))
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-
-                def create_cache(name, refs):
-                        try:
-                                fd, fn = tempfile.mkstemp(dir=t_dir,
-                                    prefix=name + ".")
-                                with os.fdopen(fd, "w") as f:
-                                        f.writelines(refs())
-                                os.chmod(fn, PKG_FILE_MODE)
-                                portable.rename(fn, self.__cache_path(name))
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-
-                create_cache("manifest.dircache", self._gen_dirs_to_str)
-                create_cache("manifest.mediatorcache",
-                    self._gen_mediators_to_str)
-
-        @staticmethod
-        def clear_cache(cache_root):
-                """Remove all manifest cache files found in the given directory
-                (excluding the manifest itself) and the cache_root if it is
-                empty afterwards.
-                """
-
-                try:
-                        for cname in os.listdir(cache_root):
-                                if not cname.startswith("manifest."):
-                                        continue
-                                try:
-                                        portable.remove(os.path.join(
-                                            cache_root, cname))
-                                except EnvironmentError as e:
-                                        if e.errno != errno.ENOENT:
-                                                raise
-
-                        # Ensure cache dir is removed if the last cache file is
-                        # removed; we don't care if it fails.
-                        try:
-                                os.rmdir(cache_root)
-                        except:
-                                pass
+                    portable.remove(os.path.join(cache_root, cname))
                 except EnvironmentError as e:
-                        if e.errno != errno.ENOENT:
-                                # Only raise error if failure wasn't due to
-                                # cache directory not existing.
-                                raise apx._convert_error(e)
+                    if e.errno != errno.ENOENT:
+                        raise
 
-        def __load_cached_data(self, name):
-                """Private helper function for loading arbitrary cached manifest
-                data.
-                """
+            # Ensure cache dir is removed if the last cache file is
+            # removed; we don't care if it fails.
+            try:
+                os.rmdir(cache_root)
+            except:
+                pass
+        except EnvironmentError as e:
+            if e.errno != errno.ENOENT:
+                # Only raise error if failure wasn't due to
+                # cache directory not existing.
+                raise apx._convert_error(e)
 
-                mpath = self.__cache_path(name)
-                if os.path.exists(mpath):
-                        # we have cached copy on disk; use it
-                        try:
-                                with open(mpath, "r") as f:
-                                        self._cache[name] = [
-                                            a for a in
-                                            (
-                                                actions.fromstr(s.rstrip())
-                                                for s in f
-                                            )
-                                            if not self.excludes or
-                                                a.include_this(self.excludes,
-                                                    publisher=self.publisher)
-                                        ]
-                                return
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-                        except actions.ActionError as e:
-                                # Cache file is malformed; hopefully due to bugs
-                                # that have been resolved (as opposed to actual
-                                # corruption).  Assume we should just ignore the
-                                # cache and load action data.
-                                try:
-                                        self.clear_cache(self.__cache_root)
-                                except Exception as e:
-                                        # Ignore errors encountered during cache
-                                        # dump for this specific case.
-                                        pass
+    def __load_cached_data(self, name):
+        """Private helper function for loading arbitrary cached manifest
+        data.
+        """
 
-                # no cached copy
-                if not self.loaded:
-                        # need to load from disk
-                        self.__load()
-                assert self.loaded
-
-        def get_directories(self, excludes):
-                """ return a list of directories implicitly or explicitly
-                referenced by this object
-                """
-                self.__load_cached_data("manifest.dircache")
-                return Manifest.get_directories(self, excludes)
-
-        def gen_actions_by_type(self, atype, attr_match=None, excludes=EmptyI):
-                """ generate actions of the specified type;
-                use already in-memory stuff if already loaded,
-                otherwise use per-action types files"""
-
-                if self.loaded: #if already loaded, use in-memory cached version
-                        # invoke subclass method to generate action by action
-                        for a in Manifest.gen_actions_by_type(self, atype,
-                            attr_match=attr_match, excludes=excludes):
-                                yield a
-                        return
-
-                # This checks if we've already written out the factored
-                # manifest files.  If so, we'll use it, and if not, then
-                # we'll load the full manifest.
-                mpath = self.__cache_path("manifest.dircache")
-
-                if not os.path.exists(mpath):
-                        # no cached copy :-(
-                        if not self.loaded:
-                                # get manifest from disk
-                                self.__load()
-                        # invoke subclass method to generate action by action
-                        for a in Manifest.gen_actions_by_type(self, atype,
-                            attr_match=attr_match, excludes=excludes):
-                                yield a
-                        return
-
-                if excludes == EmptyI:
-                        excludes = self.excludes
-                assert excludes == self.excludes or self.excludes == EmptyI
-
-                if atype in self._absent_cache:
-                        # No such action in the manifest; must be done *after*
-                        # asserting excludes are correct to avoid hiding
-                        # failures.
-                        return
-
-                # Assume a cached copy exists; if not, tag the action type to
-                # avoid pointless I/O later.
-                mpath = self.__cache_path("manifest.{0}".format(atype))
-
-                if attr_match:
-                        attr_match = _compile_fnpats(attr_match)
-
-                try:
-                        with open(mpath, "r") as f:
-                                for l in f:
-                                        a = actions.fromstr(l.rstrip())
-                                        if (excludes and
-                                            not a.include_this(excludes,
-                                                publisher=self.publisher)):
-                                                continue
-                                        # These conditions are split by
-                                        # performance.
-                                        if not attr_match:
-                                                yield a
-                                        elif _attr_matches(a, attr_match):
-                                                yield a
-
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                self._absent_cache.append(atype)
-                                return # no such action in this manifest
-                        raise apx._convert_error(e)
-
-        def gen_facets(self, excludes=EmptyI, patterns=EmptyI):
-                """A generator function that returns the supported facet
-                attributes (strings) for this package based on the specified (or
-                current) excludes that also match at least one of the patterns
-                provided.  Facets must be true or false so a list of possible
-                facet values is not returned."""
-
-                if not self.loaded and not self.__load_attributes():
-                        self.__load()
-                return Manifest.gen_facets(self, excludes=excludes,
-                    patterns=patterns)
-
-        def gen_variants(self, excludes=EmptyI, patterns=EmptyI):
-                """A generator function that yields a list of tuples of the form
-                (variant, [values]).  Where 'variant' is the variant attribute
-                name (e.g. 'variant.arch') and '[values]' is a list of the
-                variant values supported by this package.  Variants returned are
-                those allowed by the specified (or current) excludes that also
-                match at least one of the patterns provided."""
-
-                if not self.loaded and not self.__load_attributes():
-                        self.__load()
-                return Manifest.gen_variants(self, excludes=excludes,
-                    patterns=patterns)
-
-        def gen_mediators(self, excludes=EmptyI):
-                """A generator function that yields set actions expressing the
-                set of possible mediations for this package.
-                """
-                self.__load_cached_data("manifest.mediatorcache")
-                return Manifest.gen_mediators(self, excludes=excludes)
-
-        def __load_attributes(self):
-                """Load attributes dictionary from cached set actions;
-                this speeds up pkg info a lot"""
-
-                mpath = self.__cache_path("manifest.set")
-                if not os.path.exists(mpath):
-                        return False
+        mpath = self.__cache_path(name)
+        if os.path.exists(mpath):
+            # we have cached copy on disk; use it
+            try:
                 with open(mpath, "r") as f:
-                        for l in f:
-                                a = actions.fromstr(l.rstrip())
-                                if not self.excludes or \
-                                    a.include_this(self.excludes,
-                                        publisher=self.publisher):
-                                        self.fill_attributes(a)
-
-                return True
-
-        def get_size(self, excludes=EmptyI):
-                """Returns an integer tuple of the form (size, csize), where
-                'size' represents the total uncompressed size, in bytes, of the
-                Manifest's data payload, and 'csize' represents the compressed
-                version of that.
-
-                'excludes' is a list of a list of variants and facets which
-                should be allowed when calculating the total."""
-                if not self.loaded and not self.__load_attributes():
-                        self.__load()
-                return Manifest.get_size(self, excludes=excludes)
-
-        def __getitem__(self, key):
-                if not self.loaded and not self.__load_attributes():
-                        self.__load()
-                return Manifest.__getitem__(self, key)
-
-        def __setitem__(self, key, value):
-                """No assignments to factored manifests allowed."""
-                assert "FactoredManifests are not dicts"
-
-        def __contains__(self, key):
-                if not self.loaded and not self.__load_attributes():
-                        self.__load()
-                return Manifest.__contains__(self, key)
-
-        def get(self, key, default):
+                    self._cache[name] = [
+                        a
+                        for a in (actions.fromstr(s.rstrip()) for s in f)
+                        if not self.excludes
+                        or a.include_this(
+                            self.excludes, publisher=self.publisher
+                        )
+                    ]
+                return
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+            except actions.ActionError as e:
+                # Cache file is malformed; hopefully due to bugs
+                # that have been resolved (as opposed to actual
+                # corruption).  Assume we should just ignore the
+                # cache and load action data.
                 try:
-                        return self[key]
-                except KeyError:
-                        return default
+                    self.clear_cache(self.__cache_root)
+                except Exception as e:
+                    # Ignore errors encountered during cache
+                    # dump for this specific case.
+                    pass
 
-        def get_variants(self, name):
-                if not self.loaded and not self.__load_attributes():
-                        self.__load()
-                return Manifest.get_variants(self, name)
+        # no cached copy
+        if not self.loaded:
+            # need to load from disk
+            self.__load()
+        assert self.loaded
 
-        def get_all_variants(self):
-                if not self.loaded and not self.__load_attributes():
-                        self.__load()
-                return Manifest.get_all_variants(self)
+    def get_directories(self, excludes):
+        """return a list of directories implicitly or explicitly
+        referenced by this object
+        """
+        self.__load_cached_data("manifest.dircache")
+        return Manifest.get_directories(self, excludes)
 
-        @staticmethod
-        def search_dict(cache_path, excludes, return_line=False):
-                return Manifest.search_dict(cache_path, excludes,
-                    return_line=return_line)
+    def gen_actions_by_type(self, atype, attr_match=None, excludes=EmptyI):
+        """generate actions of the specified type;
+        use already in-memory stuff if already loaded,
+        otherwise use per-action types files"""
 
-        def gen_actions(self, attr_match=None, excludes=EmptyI):
-                if not self.loaded:
-                        self.__load()
-                return Manifest.gen_actions(self, attr_match=attr_match,
-                    excludes=excludes)
+        if self.loaded:  # if already loaded, use in-memory cached version
+            # invoke subclass method to generate action by action
+            for a in Manifest.gen_actions_by_type(
+                self, atype, attr_match=attr_match, excludes=excludes
+            ):
+                yield a
+            return
 
-        def __str__(self, excludes=EmptyI):
-                if not self.loaded:
-                        self.__load()
-                return Manifest.__str__(self)
+        # This checks if we've already written out the factored
+        # manifest files.  If so, we'll use it, and if not, then
+        # we'll load the full manifest.
+        mpath = self.__cache_path("manifest.dircache")
 
-        def duplicates(self, excludes=EmptyI):
-                if not self.loaded:
-                        self.__load()
-                return Manifest.duplicates(self, excludes=excludes)
+        if not os.path.exists(mpath):
+            # no cached copy :-(
+            if not self.loaded:
+                # get manifest from disk
+                self.__load()
+            # invoke subclass method to generate action by action
+            for a in Manifest.gen_actions_by_type(
+                self, atype, attr_match=attr_match, excludes=excludes
+            ):
+                yield a
+            return
 
-        def difference(self, origin, origin_exclude=EmptyI,
-            self_exclude=EmptyI, pkgplan=None, cmp_policy=None):
-                if not self.loaded:
-                        self.__load()
-                return Manifest.difference(self, origin,
-                    origin_exclude=origin_exclude,
-                    self_exclude=self_exclude,
-                    pkgplan=pkgplan,
-                    cmp_policy=cmp_policy)
+        if excludes == EmptyI:
+            excludes = self.excludes
+        assert excludes == self.excludes or self.excludes == EmptyI
 
-        def store(self, mfst_path):
-                """Store the manifest contents to disk."""
-                if not self.loaded:
-                        self.__load()
-                super(FactoredManifest, self).store(mfst_path)
+        if atype in self._absent_cache:
+            # No such action in the manifest; must be done *after*
+            # asserting excludes are correct to avoid hiding
+            # failures.
+            return
 
-        @property
-        def pathname(self):
-                """The absolute pathname of the file containing the manifest."""
+        # Assume a cached copy exists; if not, tag the action type to
+        # avoid pointless I/O later.
+        mpath = self.__cache_path("manifest.{0}".format(atype))
 
-                if self.__pathname:
-                        return self.__pathname
-                return os.path.join(self.__cache_root, "manifest")
+        if attr_match:
+            attr_match = _compile_fnpats(attr_match)
+
+        try:
+            with open(mpath, "r") as f:
+                for l in f:
+                    a = actions.fromstr(l.rstrip())
+                    if excludes and not a.include_this(
+                        excludes, publisher=self.publisher
+                    ):
+                        continue
+                    # These conditions are split by
+                    # performance.
+                    if not attr_match:
+                        yield a
+                    elif _attr_matches(a, attr_match):
+                        yield a
+
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                self._absent_cache.append(atype)
+                return  # no such action in this manifest
+            raise apx._convert_error(e)
+
+    def gen_facets(self, excludes=EmptyI, patterns=EmptyI):
+        """A generator function that returns the supported facet
+        attributes (strings) for this package based on the specified (or
+        current) excludes that also match at least one of the patterns
+        provided.  Facets must be true or false so a list of possible
+        facet values is not returned."""
+
+        if not self.loaded and not self.__load_attributes():
+            self.__load()
+        return Manifest.gen_facets(self, excludes=excludes, patterns=patterns)
+
+    def gen_variants(self, excludes=EmptyI, patterns=EmptyI):
+        """A generator function that yields a list of tuples of the form
+        (variant, [values]).  Where 'variant' is the variant attribute
+        name (e.g. 'variant.arch') and '[values]' is a list of the
+        variant values supported by this package.  Variants returned are
+        those allowed by the specified (or current) excludes that also
+        match at least one of the patterns provided."""
+
+        if not self.loaded and not self.__load_attributes():
+            self.__load()
+        return Manifest.gen_variants(self, excludes=excludes, patterns=patterns)
+
+    def gen_mediators(self, excludes=EmptyI):
+        """A generator function that yields set actions expressing the
+        set of possible mediations for this package.
+        """
+        self.__load_cached_data("manifest.mediatorcache")
+        return Manifest.gen_mediators(self, excludes=excludes)
+
+    def __load_attributes(self):
+        """Load attributes dictionary from cached set actions;
+        this speeds up pkg info a lot"""
+
+        mpath = self.__cache_path("manifest.set")
+        if not os.path.exists(mpath):
+            return False
+        with open(mpath, "r") as f:
+            for l in f:
+                a = actions.fromstr(l.rstrip())
+                if not self.excludes or a.include_this(
+                    self.excludes, publisher=self.publisher
+                ):
+                    self.fill_attributes(a)
+
+        return True
+
+    def get_size(self, excludes=EmptyI):
+        """Returns an integer tuple of the form (size, csize), where
+        'size' represents the total uncompressed size, in bytes, of the
+        Manifest's data payload, and 'csize' represents the compressed
+        version of that.
+
+        'excludes' is a list of a list of variants and facets which
+        should be allowed when calculating the total."""
+        if not self.loaded and not self.__load_attributes():
+            self.__load()
+        return Manifest.get_size(self, excludes=excludes)
+
+    def __getitem__(self, key):
+        if not self.loaded and not self.__load_attributes():
+            self.__load()
+        return Manifest.__getitem__(self, key)
+
+    def __setitem__(self, key, value):
+        """No assignments to factored manifests allowed."""
+        assert "FactoredManifests are not dicts"
+
+    def __contains__(self, key):
+        if not self.loaded and not self.__load_attributes():
+            self.__load()
+        return Manifest.__contains__(self, key)
+
+    def get(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def get_variants(self, name):
+        if not self.loaded and not self.__load_attributes():
+            self.__load()
+        return Manifest.get_variants(self, name)
+
+    def get_all_variants(self):
+        if not self.loaded and not self.__load_attributes():
+            self.__load()
+        return Manifest.get_all_variants(self)
+
+    @staticmethod
+    def search_dict(cache_path, excludes, return_line=False):
+        return Manifest.search_dict(
+            cache_path, excludes, return_line=return_line
+        )
+
+    def gen_actions(self, attr_match=None, excludes=EmptyI):
+        if not self.loaded:
+            self.__load()
+        return Manifest.gen_actions(
+            self, attr_match=attr_match, excludes=excludes
+        )
+
+    def __str__(self, excludes=EmptyI):
+        if not self.loaded:
+            self.__load()
+        return Manifest.__str__(self)
+
+    def duplicates(self, excludes=EmptyI):
+        if not self.loaded:
+            self.__load()
+        return Manifest.duplicates(self, excludes=excludes)
+
+    def difference(
+        self,
+        origin,
+        origin_exclude=EmptyI,
+        self_exclude=EmptyI,
+        pkgplan=None,
+        cmp_policy=None,
+    ):
+        if not self.loaded:
+            self.__load()
+        return Manifest.difference(
+            self,
+            origin,
+            origin_exclude=origin_exclude,
+            self_exclude=self_exclude,
+            pkgplan=pkgplan,
+            cmp_policy=cmp_policy,
+        )
+
+    def store(self, mfst_path):
+        """Store the manifest contents to disk."""
+        if not self.loaded:
+            self.__load()
+        super(FactoredManifest, self).store(mfst_path)
+
+    @property
+    def pathname(self):
+        """The absolute pathname of the file containing the manifest."""
+
+        if self.__pathname:
+            return self.__pathname
+        return os.path.join(self.__cache_root, "manifest")
 
 
 class EmptyFactoredManifest(Manifest):
-        """Special class for pkgplan's need for a empty manifest;
-        the regular null manifest doesn't support get_directories
-        and making the factored manifest code handle this case is
-        too ugly..."""
+    """Special class for pkgplan's need for a empty manifest;
+    the regular null manifest doesn't support get_directories
+    and making the factored manifest code handle this case is
+    too ugly..."""
 
-        def __init__(self):
-                Manifest.__init__(self)
+    def __init__(self):
+        Manifest.__init__(self)
 
-        def difference(self, origin, origin_exclude=EmptyI,
-            self_exclude=EmptyI, pkgplan=None, cmp_policy=None):
-                """Return three lists of action pairs representing origin and
-                destination actions.  The first list contains the pairs
-                representing additions, the second list contains the pairs
-                representing updates, and the third list contains the pairs
-                representing removals.  All three lists are in the order in
-                which they should be executed."""
+    def difference(
+        self,
+        origin,
+        origin_exclude=EmptyI,
+        self_exclude=EmptyI,
+        pkgplan=None,
+        cmp_policy=None,
+    ):
+        """Return three lists of action pairs representing origin and
+        destination actions.  The first list contains the pairs
+        representing additions, the second list contains the pairs
+        representing updates, and the third list contains the pairs
+        representing removals.  All three lists are in the order in
+        which they should be executed."""
 
-                # The difference for this case is simply everything in the
-                # origin has been removed.  This is an optimization for
-                # uninstall.
-                return ManifestDifference([], [],
-                    [(a, None) for a in origin.gen_actions(excludes=
-                    origin_exclude)])
+        # The difference for this case is simply everything in the
+        # origin has been removed.  This is an optimization for
+        # uninstall.
+        return ManifestDifference(
+            [],
+            [],
+            [(a, None) for a in origin.gen_actions(excludes=origin_exclude)],
+        )
 
-        @staticmethod
-        def get_directories(excludes):
-                return []
+    @staticmethod
+    def get_directories(excludes):
+        return []
 
-        def exclude_content(self, *args, **kwargs):
-                # This method is overridden so that self.excludes is never set
-                # on the singleton NullFactoredManifest.
-                return
+    def exclude_content(self, *args, **kwargs):
+        # This method is overridden so that self.excludes is never set
+        # on the singleton NullFactoredManifest.
+        return
 
-        def set_content(self, *args, **kwargs):
-                raise RuntimeError("Cannot call set_content on an "
-                    "EmptyFactoredManifest")
+    def set_content(self, *args, **kwargs):
+        raise RuntimeError(
+            "Cannot call set_content on an " "EmptyFactoredManifest"
+        )
+
 
 NullFactoredManifest = EmptyFactoredManifest()
 
+
 class ManifestDuplicateError(Exception):
-        """Simple Exception class to report on duplicate
-           actions within a manifest. """
+    """Simple Exception class to report on duplicate
+    actions within a manifest."""
 
-        def __init__(self, duplicates=EmptyI):
-                self.__duplicates = duplicates
+    def __init__(self, duplicates=EmptyI):
+        self.__duplicates = duplicates
 
-        def __str__(self):
-                ret = []
-                for d in self.__duplicates:
-                        ret.append("{0}\n{1}\n{2}\n".format(*d))
+    def __str__(self):
+        ret = []
+        for d in self.__duplicates:
+            ret.append("{0}\n{1}\n{2}\n".format(*d))
 
-                return "Duplicate action(s):\n{0}".format("\n".join(ret))
+        return "Duplicate action(s):\n{0}".format("\n".join(ret))
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/mediator.py
+++ b/src/modules/mediator.py
@@ -28,165 +28,180 @@ import six
 import pkg.misc as misc
 import pkg.version as version
 
-def valid_mediator(value):
-        """Returns a tuple of (valid, error) indicating whether the provided
-        string is a valid name for a link mediation.  'valid' is a boolean
-        and 'error' is None or a string containing the error."""
 
-        if isinstance(value, six.string_types):
-                if re.match(r"^[a-zA-Z0-9\-]+$", value):
-                        return True, None
-        return False, _("'{0}' is not a valid mediator; only alphanumeric "
-            "characters are allowed").format(value)
+def valid_mediator(value):
+    """Returns a tuple of (valid, error) indicating whether the provided
+    string is a valid name for a link mediation.  'valid' is a boolean
+    and 'error' is None or a string containing the error."""
+
+    if isinstance(value, six.string_types):
+        if re.match(r"^[a-zA-Z0-9\-]+$", value):
+            return True, None
+    return False, _(
+        "'{0}' is not a valid mediator; only alphanumeric "
+        "characters are allowed"
+    ).format(value)
+
 
 def valid_mediator_version(value):
-        """Returns a tuple of (valid, error) indicating whether the provided
-        string is a valid mediator version for a link mediation.  'valid' is
-        a boolean and 'error' is None or a string containing the error."""
+    """Returns a tuple of (valid, error) indicating whether the provided
+    string is a valid mediator version for a link mediation.  'valid' is
+    a boolean and 'error' is None or a string containing the error."""
 
-        error = ""
-        if isinstance(value, six.string_types):
-                try:
-                        version.Version(value)
-                        return True, None
-                except version.VersionError as e:
-                        error = str(e)
+    error = ""
+    if isinstance(value, six.string_types):
+        try:
+            version.Version(value)
+            return True, None
+        except version.VersionError as e:
+            error = str(e)
 
-        if error:
-                return False, _("'{value}' is not a valid mediator-version: "
-                    "{error}").format(**locals())
-        return False, _("'{0}' is not a valid mediator-version").format(value)
+    if error:
+        return False, _(
+            "'{value}' is not a valid mediator-version: " "{error}"
+        ).format(**locals())
+    return False, _("'{0}' is not a valid mediator-version").format(value)
+
 
 def parse_mediator_implementation(value):
-        """Parses the provided mediator implementation string for a link and
-        returns a tuple of (name, version) where 'name' is a string containing
-        the name of the implementation and 'version' is None or a pkg.version
-        object representing the version.  If the implementation is not valid
-        a tuple of (None, None) will be returned."""
+    """Parses the provided mediator implementation string for a link and
+    returns a tuple of (name, version) where 'name' is a string containing
+    the name of the implementation and 'version' is None or a pkg.version
+    object representing the version.  If the implementation is not valid
+    a tuple of (None, None) will be returned."""
 
-        if not isinstance(value, six.string_types):
-                return None, None
+    if not isinstance(value, six.string_types):
+        return None, None
 
-        if "@" in value:
-                try:
-                        impl_name, impl_ver = value.rsplit("@", 1)
-                except (ValueError, AttributeError):
-                        # Can't parse implementation correctly, so
-                        # return a tuple of None.
-                        return None, None
-        else:
-                impl_name = value
-                impl_ver = None
+    if "@" in value:
+        try:
+            impl_name, impl_ver = value.rsplit("@", 1)
+        except (ValueError, AttributeError):
+            # Can't parse implementation correctly, so
+            # return a tuple of None.
+            return None, None
+    else:
+        impl_name = value
+        impl_ver = None
 
-        if impl_ver:
-                try:
-                        impl_ver = version.Version(impl_ver)
-                except version.VersionError:
-                        # If part of implementation can't be parsed, then
-                        # return nothing at all.
-                        return None, None
+    if impl_ver:
+        try:
+            impl_ver = version.Version(impl_ver)
+        except version.VersionError:
+            # If part of implementation can't be parsed, then
+            # return nothing at all.
+            return None, None
 
-        return impl_name, impl_ver
+    return impl_name, impl_ver
+
 
 def valid_mediator_implementation(value, allow_empty_version=False):
-        """Returns a tuple of (valid, error) indicating whether the provided
-        string is a valid mediator implementation for mediated links.  'valid' is
-        a boolean and 'error' is None or a string containing the error."""
+    """Returns a tuple of (valid, error) indicating whether the provided
+    string is a valid mediator implementation for mediated links.  'valid' is
+    a boolean and 'error' is None or a string containing the error."""
 
-        error = ""
-        iname = iver = None
-        if isinstance(value, six.string_types):
-                if "@" in value:
-                        iname, iver = value.rsplit("@", 1)
-                else:
-                        iname = value
+    error = ""
+    iname = iver = None
+    if isinstance(value, six.string_types):
+        if "@" in value:
+            iname, iver = value.rsplit("@", 1)
+        else:
+            iname = value
 
-                if iver or (iver == "" and not allow_empty_version):
-                        try:
-                                version.Version(iver)
-                        except version.VersionError as e:
-                                error = str(e)
+        if iver or (iver == "" and not allow_empty_version):
+            try:
+                version.Version(iver)
+            except version.VersionError as e:
+                error = str(e)
 
-                if not error and iname and re.match(r"^[a-zA-Z0-9\-]+$", iname):
-                        return True, None
+        if not error and iname and re.match(r"^[a-zA-Z0-9\-]+$", iname):
+            return True, None
 
-        if error:
-                return False, _("'{value}' is not a valid "
-                    "mediator-implementation; only alphanumeric characters and "
-                    "a version dot-sequence following a single '@' are allowed: "
-                    "{error}").format(**locals())
-        return False, _("'{0}' is not a valid mediator-implementation; only "
-            "alphanumeric characters and a version dot-sequence following a "
-            "single '@' are allowed").format(value)
+    if error:
+        return False, _(
+            "'{value}' is not a valid "
+            "mediator-implementation; only alphanumeric characters and "
+            "a version dot-sequence following a single '@' are allowed: "
+            "{error}"
+        ).format(**locals())
+    return False, _(
+        "'{0}' is not a valid mediator-implementation; only "
+        "alphanumeric characters and a version dot-sequence following a "
+        "single '@' are allowed"
+    ).format(value)
+
 
 def valid_mediator_priority(value):
-        """Returns a tuple of (valid, error) indicating whether the provided
-        string is a valid mediator priority for mediated links.  'valid' is
-        a boolean and 'error' is None or a string containing the error."""
+    """Returns a tuple of (valid, error) indicating whether the provided
+    string is a valid mediator priority for mediated links.  'valid' is
+    a boolean and 'error' is None or a string containing the error."""
 
-        if value in ("site", "vendor"):
-                return True, None
-        return False, _("'{0}' is not a valid mediator-priority; valid values "
-            "are 'site' or 'vendor'").format(value)
+    if value in ("site", "vendor"):
+        return True, None
+    return False, _(
+        "'{0}' is not a valid mediator-priority; valid values "
+        "are 'site' or 'vendor'"
+    ).format(value)
+
 
 # A ranking dictionary used by cmp_mediations for sorting mediatoins based on
 # mediator priority for mediated links.
-_MED_PRIORITIES = {
-    "site": 1,
-    "vendor": 2
-}
+_MED_PRIORITIES = {"site": 1, "vendor": 2}
+
 
 def cmp_mediations(a, b):
-        """Custom mediation sorting routine.  Sort is done by
-        priority, version, implementation name, implementation
-        version.
-        """
+    """Custom mediation sorting routine.  Sort is done by
+    priority, version, implementation name, implementation
+    version.
+    """
 
-        aprio = _MED_PRIORITIES.get(a[0], 3)
-        bprio = _MED_PRIORITIES.get(b[0], 3)
-        res = misc.cmp(aprio, bprio)
-        if res != 0:
-                return res
+    aprio = _MED_PRIORITIES.get(a[0], 3)
+    bprio = _MED_PRIORITIES.get(b[0], 3)
+    res = misc.cmp(aprio, bprio)
+    if res != 0:
+        return res
 
-        aver = a[1]
-        bver = b[1]
-        res = misc.cmp(aver, bver)
-        if res != 0:
-                # Invert version sort so greatest is first.
-                return res * -1
+    aver = a[1]
+    bver = b[1]
+    res = misc.cmp(aver, bver)
+    if res != 0:
+        # Invert version sort so greatest is first.
+        return res * -1
 
-        aimpl, aver = parse_mediator_implementation(a[2])
-        bimpl, bver = parse_mediator_implementation(b[2])
-        res = misc.cmp(aimpl, bimpl)
-        if res != 0:
-                return res
+    aimpl, aver = parse_mediator_implementation(a[2])
+    bimpl, bver = parse_mediator_implementation(b[2])
+    res = misc.cmp(aimpl, bimpl)
+    if res != 0:
+        return res
 
-        res = misc.cmp(aver, bver)
-        if res != 0:
-                # Invert version sort so greatest is first.
-                return res * -1
-        return 0
+    res = misc.cmp(aver, bver)
+    if res != 0:
+        # Invert version sort so greatest is first.
+        return res * -1
+    return 0
+
 
 def mediator_impl_matches(a, b):
-        """Returns a boolean indicating whether two given mediator implementation
-        strings match.  This is needed because an unversioned implementation is
-        matches both versioned and unversioned implementations.  This function
-        assumes that the values being compared are valid.
-        """
+    """Returns a boolean indicating whether two given mediator implementation
+    strings match.  This is needed because an unversioned implementation is
+    matches both versioned and unversioned implementations.  This function
+    assumes that the values being compared are valid.
+    """
 
-        if a == b:
-                return True
+    if a == b:
+        return True
 
-        aimpl, aver = parse_mediator_implementation(a)
-        bimpl, bver = parse_mediator_implementation(b)
-        if aimpl != bimpl or not (aimpl and bimpl):
-                return False
+    aimpl, aver = parse_mediator_implementation(a)
+    bimpl, bver = parse_mediator_implementation(b)
+    if aimpl != bimpl or not (aimpl and bimpl):
+        return False
 
-        # If version component of either a or b is None, that
-        # means the implementation was specified as 'impl'
-        # which allows any version to match.  Otherwise,
-        # version components must match exactly.
-        return aver == None or bver == None or aver == bver
+    # If version component of either a or b is None, that
+    # means the implementation was specified as 'impl'
+    # which allows any version to match.  Otherwise,
+    # version components must match exactly.
+    return aver == None or bver == None or aver == bver
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/misc.py
+++ b/src/modules/misc.py
@@ -61,9 +61,24 @@ from io import BytesIO
 from io import StringIO
 from operator import itemgetter
 
-from stat import S_IFMT, S_IMODE, S_IRGRP, S_IROTH, S_IRUSR, S_IRWXU, \
-    S_ISBLK, S_ISCHR, S_ISDIR, S_ISFIFO, S_ISLNK, S_ISREG, S_ISSOCK, \
-    S_IWUSR, S_IXGRP, S_IXOTH
+from stat import (
+    S_IFMT,
+    S_IMODE,
+    S_IRGRP,
+    S_IROTH,
+    S_IRUSR,
+    S_IRWXU,
+    S_ISBLK,
+    S_ISCHR,
+    S_ISDIR,
+    S_ISFIFO,
+    S_ISLNK,
+    S_ISREG,
+    S_ISSOCK,
+    S_IWUSR,
+    S_IXGRP,
+    S_IXOTH,
+)
 
 # Redefining built-in 'range'; pylint: disable=W0622
 # Module 'urllib' has no 'parse' member; pylint: disable=E1101
@@ -96,1315 +111,1406 @@ SIGNATURE_POLICY = "signature-policy"
 
 # Bug URI Constants (deprecated)
 # Line too long; pylint: disable=C0301
-BUG_URI_CLI = "https://defect.opensolaris.org/bz/enter_bug.cgi?product=pkg&component=cli"
-BUG_URI_GUI = "https://defect.opensolaris.org/bz/enter_bug.cgi?product=pkg&component=gui"
+BUG_URI_CLI = (
+    "https://defect.opensolaris.org/bz/enter_bug.cgi?product=pkg&component=cli"
+)
+BUG_URI_GUI = (
+    "https://defect.opensolaris.org/bz/enter_bug.cgi?product=pkg&component=gui"
+)
 # pylint: enable=C0301
 
 # Comparison types
 CMP_UNSIGNED = 0
 CMP_ALL = 1
 
+
 # Traceback message.
 def get_traceback_message():
-        """This function returns the standard traceback message.  A function
-        is necessary since the _() call must be done at runtime after locale
-        setup."""
+    """This function returns the standard traceback message.  A function
+    is necessary since the _() call must be done at runtime after locale
+    setup."""
 
-        return _("""\n
+    return _(
+        """\n
 This is an internal error in pkg(7) version {version}.  Please log a
 Service Request about this issue including the information above and this
-message.""").format(version=VERSION)
+message."""
+    ).format(version=VERSION)
+
 
 def get_release_notes_url():
-        """Return a release note URL pointing to the correct release notes
-           for this version"""
+    """Return a release note URL pointing to the correct release notes
+    for this version"""
 
-        # TBD: replace with a call to api.info() that can return a "release"
-        # attribute of form YYYYMM against the SUNWsolnm package
-        return "https://omnios.org/releasenotes"
+    # TBD: replace with a call to api.info() that can return a "release"
+    # attribute of form YYYYMM against the SUNWsolnm package
+    return "https://omnios.org/releasenotes"
+
 
 def time_to_timestamp(t):
-        """convert seconds since epoch to %Y%m%dT%H%M%SZ format"""
-        # XXX optimize?; pylint: disable=W0511
-        return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(t))
+    """convert seconds since epoch to %Y%m%dT%H%M%SZ format"""
+    # XXX optimize?; pylint: disable=W0511
+    return time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(t))
+
 
 def timestamp_to_time(ts):
-        """convert %Y%m%dT%H%M%SZ format to seconds since epoch"""
-        # XXX optimize?; pylint: disable=W0511
-        return calendar.timegm(time.strptime(ts, "%Y%m%dT%H%M%SZ"))
+    """convert %Y%m%dT%H%M%SZ format to seconds since epoch"""
+    # XXX optimize?; pylint: disable=W0511
+    return calendar.timegm(time.strptime(ts, "%Y%m%dT%H%M%SZ"))
+
 
 def timestamp_to_datetime(ts):
-        """convert %Y%m%dT%H%M%SZ format to a datetime object"""
-        return datetime.datetime.strptime(ts,"%Y%m%dT%H%M%SZ")
+    """convert %Y%m%dT%H%M%SZ format to a datetime object"""
+    return datetime.datetime.strptime(ts, "%Y%m%dT%H%M%SZ")
+
 
 def copyfile(src_path, dst_path):
-        """copy a file, preserving attributes, ownership, etc. where possible"""
-        fs = os.lstat(src_path)
-        shutil.copy2(src_path, dst_path)
-        try:
-                portable.chown(dst_path, fs.st_uid, fs.st_gid)
-        except OSError as e:
-                if e.errno != errno.EPERM:
-                        raise
+    """copy a file, preserving attributes, ownership, etc. where possible"""
+    fs = os.lstat(src_path)
+    shutil.copy2(src_path, dst_path)
+    try:
+        portable.chown(dst_path, fs.st_uid, fs.st_gid)
+    except OSError as e:
+        if e.errno != errno.EPERM:
+            raise
+
 
 def copytree(src, dst):
-        """Rewrite of shutil.copytree() that can handle special files such as
-        FIFOs, sockets, and device nodes.  It re-creates all symlinks rather
-        than copying the data behind them, and supports neither the 'symlinks'
-        nor the 'ignore' keyword arguments of the shutil version.
-        """
+    """Rewrite of shutil.copytree() that can handle special files such as
+    FIFOs, sockets, and device nodes.  It re-creates all symlinks rather
+    than copying the data behind them, and supports neither the 'symlinks'
+    nor the 'ignore' keyword arguments of the shutil version.
+    """
 
-        problem = None
-        os.makedirs(dst, PKG_DIR_MODE)
-        src_stat = os.stat(src)
-        for name in sorted(os.listdir(src)):
-                s_path = os.path.join(src, name)
-                d_path = os.path.join(dst, name)
-                s = os.lstat(s_path)
-                if S_ISDIR(s.st_mode):
-                        copytree(s_path, d_path)
-                        os.chmod(d_path, S_IMODE(s.st_mode))
-                        os.chown(d_path, s.st_uid, s.st_gid)
-                        os.utime(d_path, (s.st_atime, s.st_mtime))
-                elif S_ISREG(s.st_mode):
-                        shutil.copyfile(s_path, d_path)
-                        os.chmod(d_path, S_IMODE(s.st_mode))
-                        os.chown(d_path, s.st_uid, s.st_gid)
-                        os.utime(d_path, (s.st_atime, s.st_mtime))
-                elif S_ISLNK(s.st_mode):
-                        os.symlink(os.readlink(s_path), d_path)
-                elif S_ISFIFO(s.st_mode):
-                        os.mkfifo(d_path, S_IMODE(s.st_mode))
-                        os.chown(d_path, s.st_uid, s.st_gid)
-                        os.utime(d_path, (s.st_atime, s.st_mtime))
-                elif S_ISSOCK(s.st_mode):
-                        sock = socket.socket(socket.AF_UNIX)
-                        # os.mknod doesn't work correctly in 64 bit.
-                        run_bit = struct.calcsize("P") * 8
-                        # The s11 fcs version of python doesn't have os.mknod()
-                        # but sock.bind has a path length limitation that we can
-                        # hit when archiving the test suite.
-                        # E1101 Module '{0}' has no '{1}' member
-                        # pylint: disable=E1101
-                        if hasattr(os, "mknod") and run_bit == 32:
-                                os.mknod(d_path, s.st_mode, s.st_dev)
-                        else:
-                                try:
-                                        sock.bind(d_path)
-                                        sock.close()
-                                except sock.error as _e:
-                                        # Store original exception so that the
-                                        # real cause of failure can be raised if
-                                        # this fails.
-                                        problem = sys.exc_info()
-                                        continue
-                        os.chown(d_path, s.st_uid, s.st_gid)
-                        os.utime(d_path, (s.st_atime, s.st_mtime))
-                elif S_ISCHR(s.st_mode) or S_ISBLK(s.st_mode):
-                        # the s11 fcs version of python doesn't have os.mknod()
-                        # E1101 Module '{0}' has no '{1}' member
-                        # pylint: disable=E1101
-                        if hasattr(os, "mknod"):
-                                os.mknod(d_path, s.st_mode, s.st_dev)
-                                os.chown(d_path, s.st_uid, s.st_gid)
-                                os.utime(d_path, (s.st_atime, s.st_mtime))
-                elif S_IFMT(s.st_mode) == 0xd000: # doors
-                        pass
-                elif S_IFMT(s.st_mode) == 0xe000: # event ports
-                        pass
-                else:
-                        print("unknown file type:{:04o}".format(
-                            S_IFMT(s.st_mode)))
+    problem = None
+    os.makedirs(dst, PKG_DIR_MODE)
+    src_stat = os.stat(src)
+    for name in sorted(os.listdir(src)):
+        s_path = os.path.join(src, name)
+        d_path = os.path.join(dst, name)
+        s = os.lstat(s_path)
+        if S_ISDIR(s.st_mode):
+            copytree(s_path, d_path)
+            os.chmod(d_path, S_IMODE(s.st_mode))
+            os.chown(d_path, s.st_uid, s.st_gid)
+            os.utime(d_path, (s.st_atime, s.st_mtime))
+        elif S_ISREG(s.st_mode):
+            shutil.copyfile(s_path, d_path)
+            os.chmod(d_path, S_IMODE(s.st_mode))
+            os.chown(d_path, s.st_uid, s.st_gid)
+            os.utime(d_path, (s.st_atime, s.st_mtime))
+        elif S_ISLNK(s.st_mode):
+            os.symlink(os.readlink(s_path), d_path)
+        elif S_ISFIFO(s.st_mode):
+            os.mkfifo(d_path, S_IMODE(s.st_mode))
+            os.chown(d_path, s.st_uid, s.st_gid)
+            os.utime(d_path, (s.st_atime, s.st_mtime))
+        elif S_ISSOCK(s.st_mode):
+            sock = socket.socket(socket.AF_UNIX)
+            # os.mknod doesn't work correctly in 64 bit.
+            run_bit = struct.calcsize("P") * 8
+            # The s11 fcs version of python doesn't have os.mknod()
+            # but sock.bind has a path length limitation that we can
+            # hit when archiving the test suite.
+            # E1101 Module '{0}' has no '{1}' member
+            # pylint: disable=E1101
+            if hasattr(os, "mknod") and run_bit == 32:
+                os.mknod(d_path, s.st_mode, s.st_dev)
+            else:
+                try:
+                    sock.bind(d_path)
+                    sock.close()
+                except sock.error as _e:
+                    # Store original exception so that the
+                    # real cause of failure can be raised if
+                    # this fails.
+                    problem = sys.exc_info()
+                    continue
+            os.chown(d_path, s.st_uid, s.st_gid)
+            os.utime(d_path, (s.st_atime, s.st_mtime))
+        elif S_ISCHR(s.st_mode) or S_ISBLK(s.st_mode):
+            # the s11 fcs version of python doesn't have os.mknod()
+            # E1101 Module '{0}' has no '{1}' member
+            # pylint: disable=E1101
+            if hasattr(os, "mknod"):
+                os.mknod(d_path, s.st_mode, s.st_dev)
+                os.chown(d_path, s.st_uid, s.st_gid)
+                os.utime(d_path, (s.st_atime, s.st_mtime))
+        elif S_IFMT(s.st_mode) == 0xD000:  # doors
+            pass
+        elif S_IFMT(s.st_mode) == 0xE000:  # event ports
+            pass
+        else:
+            print("unknown file type:{:04o}".format(S_IFMT(s.st_mode)))
 
-        os.chmod(dst, S_IMODE(src_stat.st_mode))
-        os.chown(dst, src_stat.st_uid, src_stat.st_gid)
-        os.utime(dst, (src_stat.st_atime, src_stat.st_mtime))
-        if problem:
-                six.reraise(problem[0], problem[1], problem[2])
+    os.chmod(dst, S_IMODE(src_stat.st_mode))
+    os.chown(dst, src_stat.st_uid, src_stat.st_gid)
+    os.utime(dst, (src_stat.st_atime, src_stat.st_mtime))
+    if problem:
+        six.reraise(problem[0], problem[1], problem[2])
+
 
 def move(src, dst):
-        """Rewrite of shutil.move() that uses our copy of copytree()."""
+    """Rewrite of shutil.move() that uses our copy of copytree()."""
 
-        # If dst is a directory, then we try to move src into it.
-        if os.path.isdir(dst):
-                dst = os.path.join(dst,
-                    os.path.basename(src).rstrip(os.path.sep))
+    # If dst is a directory, then we try to move src into it.
+    if os.path.isdir(dst):
+        dst = os.path.join(dst, os.path.basename(src).rstrip(os.path.sep))
 
-        try:
-                os.rename(src, dst)
-        except EnvironmentError as e:
-                # Access to protected member; pylint: disable=W0212
-                s = os.lstat(src)
+    try:
+        os.rename(src, dst)
+    except EnvironmentError as e:
+        # Access to protected member; pylint: disable=W0212
+        s = os.lstat(src)
 
-                if e.errno == errno.EXDEV:
-                        if S_ISDIR(s.st_mode):
-                                copytree(src, dst)
-                                shutil.rmtree(src)
-                        else:
-                                shutil.copyfile(src, dst)
-                                os.chmod(dst, S_IMODE(s.st_mode))
-                                os.chown(dst, s.st_uid, s.st_gid)
-                                os.utime(dst, (s.st_atime, s.st_mtime))
-                                os.unlink(src)
-                elif e.errno == errno.EINVAL and S_ISDIR(s.st_mode):
-                        raise shutil.Error("Cannot move a directory '{0}' "
-                            "into itself '{1}'.".format(src, dst))
-                elif e.errno == errno.ENOTDIR and S_ISDIR(s.st_mode):
-                        raise shutil.Error("Destination path '{0}' already "
-                            "exists".format(dst))
-                else:
-                        raise api_errors._convert_error(e)
+        if e.errno == errno.EXDEV:
+            if S_ISDIR(s.st_mode):
+                copytree(src, dst)
+                shutil.rmtree(src)
+            else:
+                shutil.copyfile(src, dst)
+                os.chmod(dst, S_IMODE(s.st_mode))
+                os.chown(dst, s.st_uid, s.st_gid)
+                os.utime(dst, (s.st_atime, s.st_mtime))
+                os.unlink(src)
+        elif e.errno == errno.EINVAL and S_ISDIR(s.st_mode):
+            raise shutil.Error(
+                "Cannot move a directory '{0}' "
+                "into itself '{1}'.".format(src, dst)
+            )
+        elif e.errno == errno.ENOTDIR and S_ISDIR(s.st_mode):
+            raise shutil.Error(
+                "Destination path '{0}' already " "exists".format(dst)
+            )
+        else:
+            raise api_errors._convert_error(e)
+
 
 def expanddirs(dirs):
-        """given a set of directories, return expanded set that includes
-        all components"""
-        out = set()
-        for d in dirs:
-                p = d
-                while p != "":
-                        out.add(p)
-                        p = os.path.dirname(p)
-        return out
+    """given a set of directories, return expanded set that includes
+    all components"""
+    out = set()
+    for d in dirs:
+        p = d
+        while p != "":
+            out.add(p)
+            p = os.path.dirname(p)
+    return out
+
 
 def url_affix_trailing_slash(u):
-        """if 'u' donesn't have a trailing '/', append one."""
+    """if 'u' donesn't have a trailing '/', append one."""
 
-        if u[-1] != '/':
-                u = u + '/'
+    if u[-1] != "/":
+        u = u + "/"
 
-        return u
+    return u
+
 
 _client_version = "pkg/{0} ({1} {2}; {3} {4}; {{0}}; {{1}})".format(
-    VERSION, portable.util.get_canonical_os_name(), platform.machine(),
-    portable.util.get_os_release(), platform.version())
+    VERSION,
+    portable.util.get_canonical_os_name(),
+    platform.machine(),
+    portable.util.get_os_release(),
+    platform.version(),
+)
+
 
 def user_agent_str(img, client_name):
-        """Return a string that can use to identify the client."""
+    """Return a string that can use to identify the client."""
 
-        if not img or img.type is None:
-                imgtype = IMG_NONE
-        else:
-                imgtype = img.type
+    if not img or img.type is None:
+        imgtype = IMG_NONE
+    else:
+        imgtype = img.type
 
-        useragent = _client_version.format(img_type_names[imgtype], client_name)
+    useragent = _client_version.format(img_type_names[imgtype], client_name)
 
-        return useragent
+    return useragent
+
 
 # Valid hostname can be : HOSTNAME or IPv4 addr or IPV6 addr
-_hostname_re = re.compile(r"""^(?:[a-zA-Z0-9\-]+[a-zA-Z0-9\-\.]*
+_hostname_re = re.compile(
+    r"""^(?:[a-zA-Z0-9\-]+[a-zA-Z0-9\-\.]*
                    |(?:\d{1,3}\.){3}\d{3}
-                   |\[([a-fA-F0-9\.]*:){,7}[a-fA-F0-9\.]+\])$""", re.X)
+                   |\[([a-fA-F0-9\.]*:){,7}[a-fA-F0-9\.]+\])$""",
+    re.X,
+)
 
 _invalid_host_chars = re.compile(r".*[^a-zA-Z0-9\-\.:\[\]]+")
 _valid_proto = ["file", "http", "https"]
 
+
 def valid_pub_prefix(prefix):
-        """Verify that the publisher prefix only contains valid characters."""
+    """Verify that the publisher prefix only contains valid characters."""
 
-        if not prefix:
-                return False
-
-        # This is a workaround for the hostname_re being slow when
-        # it comes to finding invalid characters in the prefix string.
-        if _invalid_host_chars.match(prefix):
-                # prefix bad chars
-                return False
-
-        if _hostname_re.match(prefix):
-                return True
-
+    if not prefix:
         return False
 
-def valid_pub_url(url, proxy=False):
-        """Verify that the publisher URL contains only valid characters.
-        """
+    # This is a workaround for the hostname_re being slow when
+    # it comes to finding invalid characters in the prefix string.
+    if _invalid_host_chars.match(prefix):
+        # prefix bad chars
+        return False
 
-        if not url:
-                return False
-
-        # First split the URL and check if the scheme is one we support
-        o = urlparse(url)
-
-        if not o.scheme in _valid_proto:
-                return False
-
-        if not proxy and (o.username is not None or o.password is not None):
-                return False
-
-        if o.scheme == "file":
-                path = urlparse(url, allow_fragments=False).path
-                path = url2pathname(path)
-                if not os.path.abspath(path):
-                        return False
-                # No further validation to be done.
-                return True
-
-        # Next verify that the network location is valid
-        host = '[{}]'.format(o.hostname) \
-            if o.hostname and ':' in o.hostname else o.hostname
-        if (not host or _invalid_host_chars.match(host)
-            or not _hostname_re.match(host)):
-                return False
-
+    if _hostname_re.match(prefix):
         return True
 
-def gunzip_from_stream(gz, outfile, hash_func=None, hash_funcs=None,
-    ignore_hash=False):
-        """Decompress a gzipped input stream into an output stream.
+    return False
 
-        The argument 'gz' is an input stream of a gzipped file and 'outfile'
-        is is an output stream.  gunzip_from_stream() decompresses data from
-        'gz' and writes it to 'outfile', and returns the hexadecimal SHA sum
-        of that data using the hash_func supplied.
 
-        'hash_funcs', if supplied, is a list of hash functions which we should
-        use to compute the hash. If 'hash_funcs' is supplied, a list of
-        hexadecimal digests computed using those functions is returned. The
-        returned list is in the same order as 'hash_funcs'.
+def valid_pub_url(url, proxy=False):
+    """Verify that the publisher URL contains only valid characters."""
 
-        If 'ignore_hash' is True, we do not compute a hash when decompressing
-        the content and do not return any value.
-        """
+    if not url:
+        return False
 
-        FHCRC = 2
-        FEXTRA = 4
-        FNAME = 8
-        FCOMMENT = 16
+    # First split the URL and check if the scheme is one we support
+    o = urlparse(url)
 
-        if not (hash_func or hash_funcs) and not ignore_hash:
-                raise ValueError("no hash functions for gunzip_from_stream")
+    if not o.scheme in _valid_proto:
+        return False
 
-        # Read the header
-        magic = gz.read(2)
-        if magic != b"\037\213":
-                raise zlib.error("Not a gzipped file")
-        method = ord(gz.read(1))
-        if method != 8:
-                raise zlib.error("Unknown compression method")
-        flag = ord(gz.read(1))
-        gz.read(6) # Discard modtime, extraflag, os
+    if not proxy and (o.username is not None or o.password is not None):
+        return False
 
-        # Discard an extra field
-        if flag & FEXTRA:
-                xlen = ord(gz.read(1))
-                xlen = xlen + 256 * ord(gz.read(1))
-                gz.read(xlen)
+    if o.scheme == "file":
+        path = urlparse(url, allow_fragments=False).path
+        path = url2pathname(path)
+        if not os.path.abspath(path):
+            return False
+        # No further validation to be done.
+        return True
 
-        # Discard a null-terminated filename
-        if flag & FNAME:
-                while True:
-                        s = gz.read(1)
-                        if not s or s == b"\000":
-                                break
+    # Next verify that the network location is valid
+    host = (
+        "[{}]".format(o.hostname)
+        if o.hostname and ":" in o.hostname
+        else o.hostname
+    )
+    if (
+        not host
+        or _invalid_host_chars.match(host)
+        or not _hostname_re.match(host)
+    ):
+        return False
 
-        # Discard a null-terminated comment
-        if flag & FCOMMENT:
-                while True:
-                        s = gz.read(1)
-                        if not s or s == b"\000":
-                                break
+    return True
 
-        # Discard a 16-bit CRC
-        if flag & FHCRC:
-                gz.read(2)
 
-        if ignore_hash:
-                pass
-        elif hash_funcs:
-                shasums = []
-                for f in hash_funcs:
-                        shasums.append(digest.HASH_ALGS[f]())
-        else:
-                shasum = hash_func()
-        dcobj = zlib.decompressobj(-zlib.MAX_WBITS)
+def gunzip_from_stream(
+    gz, outfile, hash_func=None, hash_funcs=None, ignore_hash=False
+):
+    """Decompress a gzipped input stream into an output stream.
 
-        def writeout(buf):
-               if isinstance(outfile, StringIO):
-                     outfile.write(ubuf.decode())
-               else:
-                     outfile.write(ubuf)
+    The argument 'gz' is an input stream of a gzipped file and 'outfile'
+    is is an output stream.  gunzip_from_stream() decompresses data from
+    'gz' and writes it to 'outfile', and returns the hexadecimal SHA sum
+    of that data using the hash_func supplied.
 
+    'hash_funcs', if supplied, is a list of hash functions which we should
+    use to compute the hash. If 'hash_funcs' is supplied, a list of
+    hexadecimal digests computed using those functions is returned. The
+    returned list is in the same order as 'hash_funcs'.
+
+    If 'ignore_hash' is True, we do not compute a hash when decompressing
+    the content and do not return any value.
+    """
+
+    FHCRC = 2
+    FEXTRA = 4
+    FNAME = 8
+    FCOMMENT = 16
+
+    if not (hash_func or hash_funcs) and not ignore_hash:
+        raise ValueError("no hash functions for gunzip_from_stream")
+
+    # Read the header
+    magic = gz.read(2)
+    if magic != b"\037\213":
+        raise zlib.error("Not a gzipped file")
+    method = ord(gz.read(1))
+    if method != 8:
+        raise zlib.error("Unknown compression method")
+    flag = ord(gz.read(1))
+    gz.read(6)  # Discard modtime, extraflag, os
+
+    # Discard an extra field
+    if flag & FEXTRA:
+        xlen = ord(gz.read(1))
+        xlen = xlen + 256 * ord(gz.read(1))
+        gz.read(xlen)
+
+    # Discard a null-terminated filename
+    if flag & FNAME:
         while True:
-                buf = gz.read(64 * 1024)
-                if buf == b"":
-                        ubuf = dcobj.flush()
-                        if ignore_hash:
-                                pass
-                        elif hash_funcs:
-                                for sha in shasums:
-                                        sha.update(ubuf)
-                        else:
-                                shasum.update(ubuf) # pylint: disable=E1101
-                        writeout(ubuf)
-                        break
-                ubuf = dcobj.decompress(buf)
-                if ignore_hash:
-                        pass
-                elif hash_funcs:
-                        for sha in shasums:
-                                sha.update(ubuf)
-                else:
-                        shasum.update(ubuf) # pylint: disable=E1101
-                writeout(ubuf)
+            s = gz.read(1)
+            if not s or s == b"\000":
+                break
 
-        if ignore_hash:
-                return
-        elif hash_funcs:
-                hexdigests = []
+    # Discard a null-terminated comment
+    if flag & FCOMMENT:
+        while True:
+            s = gz.read(1)
+            if not s or s == b"\000":
+                break
+
+    # Discard a 16-bit CRC
+    if flag & FHCRC:
+        gz.read(2)
+
+    if ignore_hash:
+        pass
+    elif hash_funcs:
+        shasums = []
+        for f in hash_funcs:
+            shasums.append(digest.HASH_ALGS[f]())
+    else:
+        shasum = hash_func()
+    dcobj = zlib.decompressobj(-zlib.MAX_WBITS)
+
+    def writeout(buf):
+        if isinstance(outfile, StringIO):
+            outfile.write(ubuf.decode())
+        else:
+            outfile.write(ubuf)
+
+    while True:
+        buf = gz.read(64 * 1024)
+        if buf == b"":
+            ubuf = dcobj.flush()
+            if ignore_hash:
+                pass
+            elif hash_funcs:
                 for sha in shasums:
-                        hexdigests.append(sha.hexdigest())
-                return hexdigests
-        return shasum.hexdigest()
+                    sha.update(ubuf)
+            else:
+                shasum.update(ubuf)  # pylint: disable=E1101
+            writeout(ubuf)
+            break
+        ubuf = dcobj.decompress(buf)
+        if ignore_hash:
+            pass
+        elif hash_funcs:
+            for sha in shasums:
+                sha.update(ubuf)
+        else:
+            shasum.update(ubuf)  # pylint: disable=E1101
+        writeout(ubuf)
+
+    if ignore_hash:
+        return
+    elif hash_funcs:
+        hexdigests = []
+        for sha in shasums:
+            hexdigests.append(sha.hexdigest())
+        return hexdigests
+    return shasum.hexdigest()
+
 
 class PipeError(Exception):
-        """ Pipe exception. """
+    """Pipe exception."""
 
-        def __init__(self, args=None):
-                Exception.__init__(self)
-                self._args = args
+    def __init__(self, args=None):
+        Exception.__init__(self)
+        self._args = args
+
 
 def msg(*text):
-        """ Emit a message. """
+    """Emit a message."""
 
-        try:
-                print(' '.join([str(l) for l in text]))
-        except IOError as e:
-                if e.errno == errno.EPIPE:
-                        raise PipeError(e)
-                raise
+    try:
+        print(" ".join([str(l) for l in text]))
+    except IOError as e:
+        if e.errno == errno.EPIPE:
+            raise PipeError(e)
+        raise
+
 
 def emsg(*text):
-        """ Emit a message to sys.stderr. """
+    """Emit a message to sys.stderr."""
 
-        try:
-                print(' '.join([str(l) for l in text]), file=sys.stderr)
-        except IOError as e:
-                if e.errno == errno.EPIPE:
-                        raise PipeError(e)
-                raise
+    try:
+        print(" ".join([str(l) for l in text]), file=sys.stderr)
+    except IOError as e:
+        if e.errno == errno.EPIPE:
+            raise PipeError(e)
+        raise
+
 
 def setlocale(category, loc=None, printer=None):
-        """Wraps locale.setlocale(), falling back to the C locale if the desired
-        locale is broken or unavailable.  The 'printer' parameter should be a
-        function which takes a string and displays it.  If 'None' (the default),
-        setlocale() will print the message to stderr."""
+    """Wraps locale.setlocale(), falling back to the C locale if the desired
+    locale is broken or unavailable.  The 'printer' parameter should be a
+    function which takes a string and displays it.  If 'None' (the default),
+    setlocale() will print the message to stderr."""
 
-        if printer is None:
-                printer = emsg
+    if printer is None:
+        printer = emsg
 
+    try:
+        locale.setlocale(category, loc)
+        # Because of Python bug 813449, getdefaultlocale may fail
+        # with a ValueError even if setlocale succeeds. So we call
+        # it here to prevent having this error raised if it is
+        # called later by other non-pkg(7) code.
+        locale.getdefaultlocale()
+    except (locale.Error, ValueError):
         try:
-                locale.setlocale(category, loc)
-                # Because of Python bug 813449, getdefaultlocale may fail
-                # with a ValueError even if setlocale succeeds. So we call
-                # it here to prevent having this error raised if it is
-                # called later by other non-pkg(7) code.
-                locale.getdefaultlocale()
-        except (locale.Error, ValueError):
-                try:
-                        dl = " '{0}.{1}'".format(*locale.getdefaultlocale())
-                except ValueError:
-                        dl = ""
-                printer("Unable to set locale{0}; locale package may be broken "
-                    "or\nnot installed.  Reverting to C locale.".format(dl))
-                locale.setlocale(category, "C")
+            dl = " '{0}.{1}'".format(*locale.getdefaultlocale())
+        except ValueError:
+            dl = ""
+        printer(
+            "Unable to set locale{0}; locale package may be broken "
+            "or\nnot installed.  Reverting to C locale.".format(dl)
+        )
+        locale.setlocale(category, "C")
+
+
 def N_(message):
-        """Return its argument; used to mark strings for localization when
-        their use is delayed by the program."""
-        return message
+    """Return its argument; used to mark strings for localization when
+    their use is delayed by the program."""
+    return message
+
 
 def bytes_to_str(nbytes, fmt="{num:>.2f} {unit}"):
-        """Returns a human-formatted string representing the number of bytes
-        in the largest unit possible.
+    """Returns a human-formatted string representing the number of bytes
+    in the largest unit possible.
 
-        If provided, 'fmt' should be a string which can be formatted
-        with a dictionary containing a float 'num' and strings 'unit' and
-        'shortunit'.  The default format prints, for example, '3.23 MB' """
+    If provided, 'fmt' should be a string which can be formatted
+    with a dictionary containing a float 'num' and strings 'unit' and
+    'shortunit'.  The default format prints, for example, '3.23 MB'"""
 
-        units = [
-            (_("B"), _("B"), 2**10),
-            (_("kB"), _("k"), 2**20),
-            (_("MB"), _("M"), 2**30),
-            (_("GB"), _("G"), 2**40),
-            (_("TB"), _("T"), 2**50),
-            (_("PB"), _("P"), 2**60),
-            (_("EB"), _("E"), 2**70)
-        ]
+    units = [
+        (_("B"), _("B"), 2**10),
+        (_("kB"), _("k"), 2**20),
+        (_("MB"), _("M"), 2**30),
+        (_("GB"), _("G"), 2**40),
+        (_("TB"), _("T"), 2**50),
+        (_("PB"), _("P"), 2**60),
+        (_("EB"), _("E"), 2**70),
+    ]
 
-        for uom, shortuom, limit in units:
-                # pylint is picky about this message:
-                # old-division; pylint: disable=W1619
-                if uom != _("EB") and nbytes >= limit:
-                        # Try the next largest unit of measure unless this is
-                        # the largest or if the byte size is within the current
-                        # unit of measure's range.
-                        continue
+    for uom, shortuom, limit in units:
+        # pylint is picky about this message:
+        # old-division; pylint: disable=W1619
+        if uom != _("EB") and nbytes >= limit:
+            # Try the next largest unit of measure unless this is
+            # the largest or if the byte size is within the current
+            # unit of measure's range.
+            continue
 
-                if "{num:d}" in fmt:
-                        return fmt.format(
-                            num=int(nbytes / (limit // 2**10)),
-                            unit=uom,
-                            shortunit=shortuom
-                        )
-                else:
-                        return fmt.format(
-                            num=round(nbytes / (limit // 2**10), 2),
-                            unit=uom,
-                            shortunit=shortuom
-                        )
+        if "{num:d}" in fmt:
+            return fmt.format(
+                num=int(nbytes / (limit // 2**10)),
+                unit=uom,
+                shortunit=shortuom,
+            )
+        else:
+            return fmt.format(
+                num=round(nbytes / (limit // 2**10), 2),
+                unit=uom,
+                shortunit=shortuom,
+            )
+
 
 def get_rel_path(request, uri, pub=None):
-        """Calculate the depth of the current request path relative to our
-        base uri. path_info always ends with a '/' -- so ignore it when
-        calculating depth."""
+    """Calculate the depth of the current request path relative to our
+    base uri. path_info always ends with a '/' -- so ignore it when
+    calculating depth."""
 
-        rpath = request.path_info
-        if pub:
-                rpath = rpath.replace("/{0}/".format(pub), "/")
-        depth = rpath.count("/") - 1
-        return ("../" * depth) + uri
+    rpath = request.path_info
+    if pub:
+        rpath = rpath.replace("/{0}/".format(pub), "/")
+    depth = rpath.count("/") - 1
+    return ("../" * depth) + uri
+
 
 def get_pkg_otw_size(action):
-        """Takes a file action and returns the over-the-wire size of
-        a package as an integer.  The OTW size is the compressed size,
-        pkg.csize.  If that value isn't available, it returns pkg.size.
-        If pkg.size isn't available, return zero."""
+    """Takes a file action and returns the over-the-wire size of
+    a package as an integer.  The OTW size is the compressed size,
+    pkg.csize.  If that value isn't available, it returns pkg.size.
+    If pkg.size isn't available, return zero."""
 
-        size = action.attrs.get("pkg.csize")
-        if size is None:
-                size = action.attrs.get("pkg.size", 0)
+    size = action.attrs.get("pkg.csize")
+    if size is None:
+        size = action.attrs.get("pkg.size", 0)
 
-        return int(size)
+    return int(size)
 
-def get_data_digest(data, length=None, return_content=False,
-    hash_attrs=None, hash_algs=None, hash_func=None):
-        """Returns a tuple of ({hash attribute name: hash value}, content)
-        or a tuple of (hash value, content) if hash_attrs has only one element.
 
-        'data' should be a file-like object or a pathname to a file.
+def get_data_digest(
+    data,
+    length=None,
+    return_content=False,
+    hash_attrs=None,
+    hash_algs=None,
+    hash_func=None,
+):
+    """Returns a tuple of ({hash attribute name: hash value}, content)
+    or a tuple of (hash value, content) if hash_attrs has only one element.
 
-        'length' should be an integer value representing the size of
-        the contents of data in bytes.
+    'data' should be a file-like object or a pathname to a file.
 
-        'return_content' is a boolean value indicating whether the
-        second tuple value should contain the content of 'data' or
-        if the content should be discarded during processing.
+    'length' should be an integer value representing the size of
+    the contents of data in bytes.
 
-        'hash_attrs' is a list of keys describing the hashes we want to compute
-        for this data. The keys must be present in 'hash_algs', a dictionary
-        mapping keys to the factory methods that are used to create objects
-        to compute them. The factory method must take no parameters, and must
-        return an object that has 'update()' and 'hexdigest()' methods.
+    'return_content' is a boolean value indicating whether the
+    second tuple value should contain the content of 'data' or
+    if the content should be discarded during processing.
 
-        'hash_func' is provided as a convenience to simply hash the data with
-        a single hash algorithm. The value of 'hash_func' should be the factory
-        method used to compute that hash value, as described in the previous
-        paragraph.
-        """
+    'hash_attrs' is a list of keys describing the hashes we want to compute
+    for this data. The keys must be present in 'hash_algs', a dictionary
+    mapping keys to the factory methods that are used to create objects
+    to compute them. The factory method must take no parameters, and must
+    return an object that has 'update()' and 'hexdigest()' methods.
 
-        bufsz = PKG_FILE_BUFSIZ
-        closefobj = False
-        if isinstance(data, six.string_types):
-                f = open(data, "rb", bufsz)
-                closefobj = True
-        else:
-                f = data
+    'hash_func' is provided as a convenience to simply hash the data with
+    a single hash algorithm. The value of 'hash_func' should be the factory
+    method used to compute that hash value, as described in the previous
+    paragraph.
+    """
 
-        if length is None:
-                length = os.stat(data).st_size
+    bufsz = PKG_FILE_BUFSIZ
+    closefobj = False
+    if isinstance(data, six.string_types):
+        f = open(data, "rb", bufsz)
+        closefobj = True
+    else:
+        f = data
 
-        # Setup our results dictionary so that each attribute maps to a
-        # new hash object.
+    if length is None:
+        length = os.stat(data).st_size
+
+    # Setup our results dictionary so that each attribute maps to a
+    # new hash object.
+    if hash_func:
+        hsh = hash_func()
+    else:
+        if hash_algs is None or hash_attrs is None:
+            assert False, "get_data_digest without hash_attrs/algs"
+        hash_results = {}
+        for attr in hash_attrs:
+            # "pkg.content-hash" is provided by default and doesn't
+            # indicate the hash_alg to be used, so when we want to
+            # calculate the content hash, we'll specify the
+            # hash_attrs explicitly, such as "file:sha512t_256".
+            if attr != "pkg.content-hash":
+                hash_results[attr] = hash_algs[attr]()
+
+    # Read the data in chunks and compute the SHA hashes as the data comes
+    # in.  A large read on some platforms (e.g. Windows XP) may fail.
+    content = BytesIO()
+    while length > 0:
+        data = f.read(min(bufsz, length))
+        if return_content:
+            content.write(data)
         if hash_func:
-                hsh = hash_func()
+            hsh.update(data)
         else:
-                if hash_algs is None or hash_attrs is None:
-                        assert False, "get_data_digest without hash_attrs/algs"
-                hash_results = {}
-                for attr in hash_attrs:
-                        # "pkg.content-hash" is provided by default and doesn't
-                        # indicate the hash_alg to be used, so when we want to
-                        # calculate the content hash, we'll specify the
-                        # hash_attrs explicitly, such as "file:sha512t_256".
-                        if attr != "pkg.content-hash":
-                                hash_results[attr] = hash_algs[attr]()
+            # update each hash with this data
+            for attr in hash_attrs:
+                if attr != "pkg.content-hash":
+                    hash_results[attr].update(data)  # pylint: disable=E1101
 
-        # Read the data in chunks and compute the SHA hashes as the data comes
-        # in.  A large read on some platforms (e.g. Windows XP) may fail.
-        content = BytesIO()
-        while length > 0:
-                data = f.read(min(bufsz, length))
-                if return_content:
-                        content.write(data)
-                if hash_func:
-                        hsh.update(data)
-                else:
-                        # update each hash with this data
-                        for attr in hash_attrs:
-                                if attr != "pkg.content-hash":
-                                        hash_results[attr].update(
-                                            data) # pylint: disable=E1101
+        l = len(data)
+        if l == 0:
+            break
+        length -= l
+    content.seek(0)
+    if closefobj:
+        f.close()
 
-                l = len(data)
-                if l == 0:
-                        break
-                length -= l
-        content.seek(0)
-        if closefobj:
-                f.close()
+    if hash_func:
+        return hsh.hexdigest(), content.read()
 
-        if hash_func:
-                return hsh.hexdigest(), content.read()
-
-        # The returned dictionary can now be populated with the hexdigests
-        # instead of the hash objects themselves.
-        for attr in hash_results:
-                hash_results[attr] = hash_results[attr].hexdigest()
-        return hash_results, content.read()
+    # The returned dictionary can now be populated with the hexdigests
+    # instead of the hash objects themselves.
+    for attr in hash_results:
+        hash_results[attr] = hash_results[attr].hexdigest()
+    return hash_results, content.read()
 
 
 class _GZWriteWrapper(object):
-        """Used by compute_compressed_attrs to calculate data size and compute
-        hashes as the data is written instead of having to read the written data
-        again later."""
+    """Used by compute_compressed_attrs to calculate data size and compute
+    hashes as the data is written instead of having to read the written data
+    again later."""
 
-        def __init__(self, path, chashes):
-                """If path is None, the data will be discarded immediately after
-                computing size and hashes."""
+    def __init__(self, path, chashes):
+        """If path is None, the data will be discarded immediately after
+        computing size and hashes."""
 
-                if path:
-                        self._ofile = open(path, "wb")
-                else:
-                        self._ofile = None
-                self._chashes = chashes
-                self._size = 0
+        if path:
+            self._ofile = open(path, "wb")
+        else:
+            self._ofile = None
+        self._chashes = chashes
+        self._size = 0
 
-        def close(self):
-                """Close the file."""
-                if self._ofile:
-                        self._ofile.close()
-                        self._ofile = None
+    def close(self):
+        """Close the file."""
+        if self._ofile:
+            self._ofile.close()
+            self._ofile = None
 
-        def flush(self):
-                """Flush the file."""
-                if self._ofile:
-                        self._ofile.flush()
+    def flush(self):
+        """Flush the file."""
+        if self._ofile:
+            self._ofile.flush()
 
-        @property
-        def size(self):
-                """Return the size of the file."""
-                return self._size
+    @property
+    def size(self):
+        """Return the size of the file."""
+        return self._size
 
-        def write(self, data):
-                """Write data to the file and compute the hashes of the data."""
-                if self._ofile:
-                        self._ofile.write(data)
-                self._size += len(data)
-                for chash_attr in self._chashes:
-                        self._chashes[chash_attr].update(
-                            data) # pylint: disable=E1101
+    def write(self, data):
+        """Write data to the file and compute the hashes of the data."""
+        if self._ofile:
+            self._ofile.write(data)
+        self._size += len(data)
+        for chash_attr in self._chashes:
+            self._chashes[chash_attr].update(data)  # pylint: disable=E1101
 
 
-def compute_compressed_attrs(fname, file_path=None, data=None, size=None,
-    compress_dir=None, bufsz=64*1024, chash_attrs=None, chash_algs=None):
-        """Returns the size and one or more hashes of the compressed data.  If
-        the file located at file_path doesn't exist or isn't gzipped, it creates
-        a file in compress_dir named fname.  If compress_dir is None, the
-        attributes are calculated but no data will be written.
+def compute_compressed_attrs(
+    fname,
+    file_path=None,
+    data=None,
+    size=None,
+    compress_dir=None,
+    bufsz=64 * 1024,
+    chash_attrs=None,
+    chash_algs=None,
+):
+    """Returns the size and one or more hashes of the compressed data.  If
+    the file located at file_path doesn't exist or isn't gzipped, it creates
+    a file in compress_dir named fname.  If compress_dir is None, the
+    attributes are calculated but no data will be written.
 
-        'chash_attrs' is a list of the chash attributes we should compute, with
-        'chash_algs' being a dictionary that maps the attribute names to the
-        algorithms used to compute them.
-        """
+    'chash_attrs' is a list of the chash attributes we should compute, with
+    'chash_algs' being a dictionary that maps the attribute names to the
+    algorithms used to compute them.
+    """
 
-        if chash_attrs is None:
-                chash_attrs = digest.DEFAULT_CHASH_ATTRS
-        if chash_algs is None:
-                chash_algs = digest.CHASH_ALGS
+    if chash_attrs is None:
+        chash_attrs = digest.DEFAULT_CHASH_ATTRS
+    if chash_algs is None:
+        chash_algs = digest.CHASH_ALGS
 
-        chashes = {}
-        for chash_attr in chash_attrs:
-                # "pkg.content-hash" is provided by default and doesn't
-                # indicate the hash_alg to be used, so when we want to
-                # calculate the content hash, we'll specify the
-                # hash_attrs explicitly, such as "gzip:sha512t_256".
-                if chash_attr == "pkg.content-hash":
-                        chashes[chash_attr] = chash_algs["{0}:{1}".format(
-                            digest.EXTRACT_GZIP, digest.PREFERRED_HASH)]()
-                else:
-                        chashes[chash_attr] = chash_algs[chash_attr]()
+    chashes = {}
+    for chash_attr in chash_attrs:
+        # "pkg.content-hash" is provided by default and doesn't
+        # indicate the hash_alg to be used, so when we want to
+        # calculate the content hash, we'll specify the
+        # hash_attrs explicitly, such as "gzip:sha512t_256".
+        if chash_attr == "pkg.content-hash":
+            chashes[chash_attr] = chash_algs[
+                "{0}:{1}".format(digest.EXTRACT_GZIP, digest.PREFERRED_HASH)
+            ]()
+        else:
+            chashes[chash_attr] = chash_algs[chash_attr]()
 
-        #
-        # This check prevents compressing a file which is already compressed.
-        # This takes CPU load off the depot on large imports of mostly-the-same
-        # stuff.  And in general it saves disk bandwidth, and on ZFS in
-        # particular it saves us space in differential snapshots.  We also need
-        # to check that the destination is in the same compression format as
-        # the source, as we must have properly formed files for chash/csize
-        # properties to work right.
-        #
+    #
+    # This check prevents compressing a file which is already compressed.
+    # This takes CPU load off the depot on large imports of mostly-the-same
+    # stuff.  And in general it saves disk bandwidth, and on ZFS in
+    # particular it saves us space in differential snapshots.  We also need
+    # to check that the destination is in the same compression format as
+    # the source, as we must have properly formed files for chash/csize
+    # properties to work right.
+    #
 
-        fileneeded = True
-        if file_path:
-                if PkgGzipFile.test_is_pkggzipfile(file_path):
-                        fileneeded = False
-                        opath = file_path
+    fileneeded = True
+    if file_path:
+        if PkgGzipFile.test_is_pkggzipfile(file_path):
+            fileneeded = False
+            opath = file_path
 
-        if fileneeded:
-                if compress_dir:
-                        opath = os.path.join(compress_dir, fname)
-                else:
-                        opath = None
+    if fileneeded:
+        if compress_dir:
+            opath = os.path.join(compress_dir, fname)
+        else:
+            opath = None
 
-                fobj = _GZWriteWrapper(opath, chashes)
-                ofile = PkgGzipFile(mode="wb", fileobj=fobj)
+        fobj = _GZWriteWrapper(opath, chashes)
+        ofile = PkgGzipFile(mode="wb", fileobj=fobj)
 
-                if isinstance(data, (six.string_types, bytes)):
-                        # caller passed data in string
-                        nbuf = size // bufsz
-                        for n in range(0, nbuf):
-                                l = n * bufsz
-                                h = (n + 1) * bufsz
-                                ofile.write(data[l:h])
+        if isinstance(data, (six.string_types, bytes)):
+            # caller passed data in string
+            nbuf = size // bufsz
+            for n in range(0, nbuf):
+                l = n * bufsz
+                h = (n + 1) * bufsz
+                ofile.write(data[l:h])
 
-                        m = nbuf * bufsz
-                        ofile.write(data[m:])
-                elif data:
-                        # assume caller passed file-like object
-                        if bufsz > size:
-                                bufsz = size
+            m = nbuf * bufsz
+            ofile.write(data[m:])
+        elif data:
+            # assume caller passed file-like object
+            if bufsz > size:
+                bufsz = size
 
-                        while True:
-                                chunk = data.read(bufsz)
-                                if not chunk:
-                                        break
-                                ofile.write(chunk)
+            while True:
+                chunk = data.read(bufsz)
+                if not chunk:
+                    break
+                ofile.write(chunk)
 
-                ofile.close()
-                fobj.close()
-                csize = str(fobj.size)
-                for attr in chashes:
-                        if attr == "pkg.content-hash":
-                                chashes[attr] = "{0}:{1}:{2}".format(
-                                    digest.EXTRACT_GZIP, digest.PREFERRED_HASH,
-                                    chashes[attr].hexdigest())
-                        else:
-                                chashes[attr] = chashes[attr].hexdigest()
-                return csize, chashes
-
-        # Compute the SHA hash of the compressed file.  In order for this to
-        # work correctly, we have to use the PkgGzipFile class.  It omits
-        # filename and timestamp information from the gzip header, allowing us
-        # to generate deterministic hashes for different files with identical
-        # content.
-        fs = os.stat(opath)
-        csize = str(fs.st_size)
-        with open(opath, "rb") as cfile:
-                while True:
-                        cdata = cfile.read(bufsz)
-                        # cdata is bytes
-                        if cdata == b"":
-                                break
-                        for chash_attr in chashes:
-                                chashes[chash_attr].update(
-                                    cdata) # pylint: disable=E1101
-
-        # The returned dictionary can now be populated with the hexdigests
-        # instead of the hash objects themselves.
+        ofile.close()
+        fobj.close()
+        csize = str(fobj.size)
         for attr in chashes:
-                if attr == "pkg.content-hash":
-                        chashes[attr] = "{0}:{1}:{2}".format(
-                                digest.EXTRACT_GZIP, digest.PREFERRED_HASH,
-                                chashes[attr].hexdigest())
-                else:
-                        chashes[attr] = chashes[attr].hexdigest()
+            if attr == "pkg.content-hash":
+                chashes[attr] = "{0}:{1}:{2}".format(
+                    digest.EXTRACT_GZIP,
+                    digest.PREFERRED_HASH,
+                    chashes[attr].hexdigest(),
+                )
+            else:
+                chashes[attr] = chashes[attr].hexdigest()
         return csize, chashes
 
+    # Compute the SHA hash of the compressed file.  In order for this to
+    # work correctly, we have to use the PkgGzipFile class.  It omits
+    # filename and timestamp information from the gzip header, allowing us
+    # to generate deterministic hashes for different files with identical
+    # content.
+    fs = os.stat(opath)
+    csize = str(fs.st_size)
+    with open(opath, "rb") as cfile:
+        while True:
+            cdata = cfile.read(bufsz)
+            # cdata is bytes
+            if cdata == b"":
+                break
+            for chash_attr in chashes:
+                chashes[chash_attr].update(cdata)  # pylint: disable=E1101
+
+    # The returned dictionary can now be populated with the hexdigests
+    # instead of the hash objects themselves.
+    for attr in chashes:
+        if attr == "pkg.content-hash":
+            chashes[attr] = "{0}:{1}:{2}".format(
+                digest.EXTRACT_GZIP,
+                digest.PREFERRED_HASH,
+                chashes[attr].hexdigest(),
+            )
+        else:
+            chashes[attr] = chashes[attr].hexdigest()
+    return csize, chashes
+
+
 class ProcFS(object):
-        """This class is used as an interface to procfs."""
+    """This class is used as an interface to procfs."""
 
-        # Detect whether python is running in 32-bit or 64-bit
-        # environment based on pointer size.
-        _running_bit = struct.calcsize("P") * 8
+    # Detect whether python is running in 32-bit or 64-bit
+    # environment based on pointer size.
+    _running_bit = struct.calcsize("P") * 8
 
-        actual_format = {32: {
-                              "long": "l",
-                              "uintptr_t": "I",
-                              "ulong": "L"
-                             },
-                         64: {
-                              "long": "q",
-                              "uintptr_t": "Q",
-                              "ulong": "Q"
-                             }}
+    actual_format = {
+        32: {"long": "l", "uintptr_t": "I", "ulong": "L"},
+        64: {"long": "q", "uintptr_t": "Q", "ulong": "Q"},
+    }
 
-        _ctype_formats = {
-            # This dictionary maps basic c types into python format characters
-            # that can be used with struct.unpack().  The format of this
-            # dictionary is:
-            #    <ctype>: (<repeat count>, <format char>)
+    _ctype_formats = {
+        # This dictionary maps basic c types into python format characters
+        # that can be used with struct.unpack().  The format of this
+        # dictionary is:
+        #    <ctype>: (<repeat count>, <format char>)
+        # basic c types (repeat count should always be 1)
+        # char[] is used to encode character arrays
+        "char": (1, "c"),
+        "char[]": (1, "s"),
+        "int": (1, "i"),
+        "long": (1, actual_format[_running_bit]["long"]),
+        "uintptr_t": (1, actual_format[_running_bit]["uintptr_t"]),
+        "ushort_t": (1, "H"),
+        # other simple types (repeat count should always be 1)
+        "ctid_t": (1, "i"),  # ctid_t -> id_t -> int
+        # dev_t -> ulong_t
+        "dev_t": (1, actual_format[_running_bit]["ulong"]),
+        "gid_t": (1, "I"),  # gid_t -> uid_t -> uint_t
+        "pid_t": (1, "i"),  # pid_t -> int
+        "poolid_t": (1, "i"),  # poolid_t -> id_t -> int
+        "projid_t": (1, "i"),  # projid_t -> id_t -> int
+        # size_t -> ulong_t
+        "size_t": (1, actual_format[_running_bit]["ulong"]),
+        "taskid_t": (1, "i"),  # taskid_t -> id_t -> int
+        # time_t -> long
+        "time_t": (1, actual_format[_running_bit]["long"]),
+        "uid_t": (1, "I"),  # uid_t -> uint_t
+        "zoneid_t": (1, "i"),  # zoneid_t -> id_t -> int
+        "id_t": (1, "i"),  # id_t -> int
+        # structures must be represented as character arrays
+        # sizeof (timestruc_t) = 8 in 32-bit process, and = 16 in 64-bit.
+        "timestruc_t": (_running_bit // 4, "s"),
+    }
 
-            # basic c types (repeat count should always be 1)
-            # char[] is used to encode character arrays
-            "char":        (1,  "c"),
-            "char[]":      (1,  "s"),
-            "int":         (1,  "i"),
-            "long":        (1,  actual_format[_running_bit]["long"]),
-            "uintptr_t":   (1,  actual_format[_running_bit]["uintptr_t"]),
-            "ushort_t":    (1,  "H"),
+    _timestruct_desc = [
+        # this list describes a timestruc_t structure
+        # the entry format is (<ctype>, <repeat count>, <name>)
+        ("time_t", 1, "tv_sec"),
+        ("long", 1, "tv_nsec"),
+    ]
 
-            # other simple types (repeat count should always be 1)
-            "ctid_t":      (1,  "i"), # ctid_t -> id_t -> int
+    _psinfo_desc = [
+        # this list describes a psinfo_t structure
+        # the entry format is: (<ctype>, <repeat count>, <name>)
+        ("int", 1, "pr_flag"),
+        ("int", 1, "pr_nlwp"),
+        ("pid_t", 1, "pr_pid"),
+        ("pid_t", 1, "pr_ppid"),
+        ("pid_t", 1, "pr_pgid"),
+        ("pid_t", 1, "pr_sid"),
+        ("uid_t", 1, "pr_uid"),
+        ("uid_t", 1, "pr_euid"),
+        ("gid_t", 1, "pr_gid"),
+        ("gid_t", 1, "pr_egid"),
+        ("uintptr_t", 1, "pr_addr"),
+        ("size_t", 1, "pr_size"),
+        ("size_t", 1, "pr_rssize"),
+        ("size_t", 1, "pr_pad1"),
+        ("dev_t", 1, "pr_ttydev"),
+        ("ushort_t", 1, "pr_pctcpu"),
+        ("ushort_t", 1, "pr_pctmem"),
+        ("char[]", 4, "pr_filler2"),  # structure padding for 64-bit.
+        ("timestruc_t", 1, "pr_start"),
+        ("timestruc_t", 1, "pr_time"),
+        ("timestruc_t", 1, "pr_ctime"),
+        ("char[]", 16, "pr_fname"),
+        ("char[]", 80, "pr_psargs"),
+        ("int", 1, "pr_wstat"),
+        ("int", 1, "pr_argc"),
+        ("uintptr_t", 1, "pr_argv"),
+        ("uintptr_t", 1, "pr_envp"),
+        ("char", 1, "pr_dmodel"),
+        ("char[]", 3, "pr_pad2"),
+        ("taskid_t", 1, "pr_taskid"),
+        ("projid_t", 1, "pr_projid"),
+        ("int", 1, "pr_nzomb"),
+        ("poolid_t", 1, "pr_poolid"),
+        ("zoneid_t", 1, "pr_zoneid"),
+        ("id_t", 1, "pr_contract"),
+        ("int", 1, "pr_filler"),
+    ]
 
-            # dev_t -> ulong_t
-            "dev_t":       (1,  actual_format[_running_bit]["ulong"]),
-            "gid_t":       (1,  "I"), # gid_t -> uid_t -> uint_t
-            "pid_t":       (1,  "i"), # pid_t -> int
-            "poolid_t":    (1,  "i"), # poolid_t -> id_t -> int
-            "projid_t":    (1,  "i"), # projid_t -> id_t -> int
+    _struct_descriptions = {
+        # this list contains all the known structure description lists
+        # the entry format is: <structure name>: \
+        #    [ <description>, <format string>, <namedtuple> ]
+        #
+        # Note that <format string> and <namedtuple> should be assigned
+        # None in this table, and then they will get pre-populated
+        # automatically when this class is instantiated
+        #
+        "psinfo_t": [_psinfo_desc, None, None],
+        "timestruc_t": [_timestruct_desc, None, None],
+    }
 
-            # size_t -> ulong_t
-            "size_t":      (1,  actual_format[_running_bit]["ulong"]),
-            "taskid_t":    (1,  "i"), # taskid_t -> id_t -> int
+    # fill in <format string> and <namedtuple> in _struct_descriptions
+    for struct_name, v in six.iteritems(_struct_descriptions):
+        desc = v[0]
 
-            # time_t -> long
-            "time_t":      (1,  actual_format[_running_bit]["long"]),
-            "uid_t":       (1,  "I"), # uid_t -> uint_t
-            "zoneid_t":    (1,  "i"), # zoneid_t -> id_t -> int
-            "id_t":        (1,  "i"), # id_t -> int
+        # update _struct_descriptions with a format string
+        v[1] = ""
+        for ctype, count1, name in desc:
+            count2, fmt_char = _ctype_formats[ctype]
+            v[1] = v[1] + str(count1 * count2) + fmt_char
 
-            # structures must be represented as character arrays
-            # sizeof (timestruc_t) = 8 in 32-bit process, and = 16 in 64-bit.
-            "timestruc_t": (_running_bit // 4,  "s"),
-        }
+        # update _struct_descriptions with a named tuple
+        v[2] = collections.namedtuple(struct_name, [i[2] for i in desc])
 
-        _timestruct_desc = [
-            # this list describes a timestruc_t structure
-            # the entry format is (<ctype>, <repeat count>, <name>)
-            ("time_t", 1, "tv_sec"),
-            ("long",   1, "tv_nsec"),
-        ]
+    @staticmethod
+    def _struct_unpack(data, name):
+        """Unpack 'data' using struct.unpack().  'name' is the name of
+        the data we're unpacking and is used to lookup a description
+        of the data (which in turn is used to build a format string to
+        decode the data)."""
 
-        _psinfo_desc = [
-            # this list describes a psinfo_t structure
-            # the entry format is: (<ctype>, <repeat count>, <name>)
-            ("int",         1,  "pr_flag"),
-            ("int",         1,  "pr_nlwp"),
-            ("pid_t",       1,  "pr_pid"),
-            ("pid_t",       1,  "pr_ppid"),
-            ("pid_t",       1,  "pr_pgid"),
-            ("pid_t",       1,  "pr_sid"),
-            ("uid_t",       1,  "pr_uid"),
-            ("uid_t",       1,  "pr_euid"),
-            ("gid_t",       1,  "pr_gid"),
-            ("gid_t",       1,  "pr_egid"),
-            ("uintptr_t",   1,  "pr_addr"),
-            ("size_t",      1,  "pr_size"),
-            ("size_t",      1,  "pr_rssize"),
-            ("size_t",      1,  "pr_pad1"),
-            ("dev_t",       1,  "pr_ttydev"),
-            ("ushort_t",    1,  "pr_pctcpu"),
-            ("ushort_t",    1,  "pr_pctmem"),
-	    ("char[]",	    4,  "pr_filler2"),	# structure padding for 64-bit.
-            ("timestruc_t", 1,  "pr_start"),
-            ("timestruc_t", 1,  "pr_time"),
-            ("timestruc_t", 1,  "pr_ctime"),
-            ("char[]",      16, "pr_fname"),
-            ("char[]",      80, "pr_psargs"),
-            ("int",         1,  "pr_wstat"),
-            ("int",         1,  "pr_argc"),
-            ("uintptr_t",   1,  "pr_argv"),
-            ("uintptr_t",   1,  "pr_envp"),
-            ("char",        1,  "pr_dmodel"),
-            ("char[]",      3,  "pr_pad2"),
-            ("taskid_t",    1,  "pr_taskid"),
-            ("projid_t",    1,  "pr_projid"),
-            ("int",         1,  "pr_nzomb"),
-            ("poolid_t",    1,  "pr_poolid"),
-            ("zoneid_t",    1,  "pr_zoneid"),
-            ("id_t",        1,  "pr_contract"),
-            ("int",         1,  "pr_filler"),
-        ]
+        # lookup the description of the data to unpack
+        desc, fmt, nt = ProcFS._struct_descriptions[name]
 
-        _struct_descriptions = {
-            # this list contains all the known structure description lists
-            # the entry format is: <structure name>: \
-            #    [ <description>, <format string>, <namedtuple> ]
-            #
-            # Note that <format string> and <namedtuple> should be assigned
-            # None in this table, and then they will get pre-populated
-            # automatically when this class is instantiated
-            #
-            "psinfo_t":    [_psinfo_desc, None, None],
-            "timestruc_t": [_timestruct_desc, None, None],
-        }
+        # unpack the data into a list
+        rv = list(struct.unpack(fmt, data))
+        # check for any nested data that needs unpacking
+        for index, v in enumerate(desc):
+            ctype = v[0]
+            if ctype not in ProcFS._struct_descriptions:
+                continue
+            rv[index] = ProcFS._struct_unpack(rv[index], ctype)
 
-        # fill in <format string> and <namedtuple> in _struct_descriptions
-        for struct_name, v in six.iteritems(_struct_descriptions):
-                desc = v[0]
+        # return the data in a named tuple
+        return nt(*rv)
 
-                # update _struct_descriptions with a format string
-                v[1] = ""
-                for ctype, count1, name in desc:
-                        count2, fmt_char = _ctype_formats[ctype]
-                        v[1] = v[1] + str(count1 * count2) + fmt_char
+    @staticmethod
+    def psinfo():
+        """Read the psinfo file and return its contents."""
 
-                # update _struct_descriptions with a named tuple
-                v[2] = collections.namedtuple(struct_name,
-                    [ i[2] for i in desc ])
+        # This works only on Solaris, in 32-bit or 64-bit mode.  It may
+        # not work on older or newer versions than 5.11.  Ideally, we
+        # would use libproc, or check sbrk(0), but this is expedient.
+        # In most cases (there's a small chance the file will decode,
+        # but incorrectly), failure will raise an exception, and we'll
+        # fail safe.
+        psinfo_size = 232
 
-        @staticmethod
-        def _struct_unpack(data, name):
-                """Unpack 'data' using struct.unpack().  'name' is the name of
-                the data we're unpacking and is used to lookup a description
-                of the data (which in turn is used to build a format string to
-                decode the data)."""
+        if ProcFS._running_bit == 64:
+            psinfo_size = 288
 
-                # lookup the description of the data to unpack
-                desc, fmt, nt = ProcFS._struct_descriptions[name]
+        try:
+            with open("/proc/self/psinfo", "rb") as f:
+                psinfo_data = f.read(psinfo_size)
+        # Catch "Exception"; pylint: disable=W0703
+        except Exception:
+            return None
 
-                # unpack the data into a list
-                rv = list(struct.unpack(fmt, data))
-                # check for any nested data that needs unpacking
-                for index, v in enumerate(desc):
-                        ctype = v[0]
-                        if ctype not in ProcFS._struct_descriptions:
-                                continue
-                        rv[index] = ProcFS._struct_unpack(rv[index], ctype)
+        # make sure we got the expected amount of data, otherwise
+        # unpacking it will fail.
+        if len(psinfo_data) != psinfo_size:
+            return None
 
-                # return the data in a named tuple
-                return nt(*rv)
+        return ProcFS._struct_unpack(psinfo_data, "psinfo_t")
 
-        @staticmethod
-        def psinfo():
-                """Read the psinfo file and return its contents."""
-
-                # This works only on Solaris, in 32-bit or 64-bit mode.  It may
-                # not work on older or newer versions than 5.11.  Ideally, we
-                # would use libproc, or check sbrk(0), but this is expedient.
-                # In most cases (there's a small chance the file will decode,
-                # but incorrectly), failure will raise an exception, and we'll
-                # fail safe.
-                psinfo_size = 232
-
-                if ProcFS._running_bit == 64:
-                        psinfo_size = 288
-
-                try:
-                        with open("/proc/self/psinfo", "rb") as f:
-                                psinfo_data = f.read(psinfo_size)
-                # Catch "Exception"; pylint: disable=W0703
-                except Exception:
-                        return None
-
-                # make sure we got the expected amount of data, otherwise
-                # unpacking it will fail.
-                if len(psinfo_data) != psinfo_size:
-                        return None
-
-                return ProcFS._struct_unpack(psinfo_data, "psinfo_t")
 
 def __getvmusage():
-        """Return the amount of virtual memory in bytes currently in use."""
+    """Return the amount of virtual memory in bytes currently in use."""
 
-        psinfo = ProcFS.psinfo()
-        if psinfo is None:
-                return None
-        return psinfo.pr_size * 1024
+    psinfo = ProcFS.psinfo()
+    if psinfo is None:
+        return None
+    return psinfo.pr_size * 1024
+
 
 def _prstart():
-        """Return the process start time expressed as a floating point number
-        in seconds since the epoch, in UTC."""
-        psinfo = ProcFS.psinfo()
-        if psinfo is None:
-                return 0.0
-        return psinfo.pr_start.tv_sec + (float(psinfo.pr_start.tv_nsec) / 1e9)
+    """Return the process start time expressed as a floating point number
+    in seconds since the epoch, in UTC."""
+    psinfo = ProcFS.psinfo()
+    if psinfo is None:
+        return 0.0
+    return psinfo.pr_start.tv_sec + (float(psinfo.pr_start.tv_nsec) / 1e9)
+
 
 def out_of_memory():
-        """Return an out of memory message, for use in a MemoryError handler."""
+    """Return an out of memory message, for use in a MemoryError handler."""
 
-        # figure out how much memory we're using (note that we could run out
-        # of memory while doing this, so check for that.
-        vsz = None
-        try:
-                vmusage = __getvmusage()
-                if vmusage is not None:
-                        vsz = bytes_to_str(vmusage, fmt="{num:.0f}{unit}")
-        except (MemoryError, EnvironmentError) as __e:
-                if isinstance(__e, EnvironmentError) and \
-                    __e.errno != errno.ENOMEM:
-                        raise
+    # figure out how much memory we're using (note that we could run out
+    # of memory while doing this, so check for that.
+    vsz = None
+    try:
+        vmusage = __getvmusage()
+        if vmusage is not None:
+            vsz = bytes_to_str(vmusage, fmt="{num:.0f}{unit}")
+    except (MemoryError, EnvironmentError) as __e:
+        if isinstance(__e, EnvironmentError) and __e.errno != errno.ENOMEM:
+            raise
 
-        if vsz is not None:
-                error = """\
+    if vsz is not None:
+        error = """\
 There is not enough memory to complete the requested operation.  At least
 {vsz} of virtual memory was in use by this command before it ran out of memory.
 You must add more memory (swap or physical) or allow the system to access more
 existing memory, or quit other programs that may be consuming memory, and try
 the operation again."""
-        else:
-                error = """\
+    else:
+        error = """\
 There is not enough memory to complete the requested operation.  You must
 add more memory (swap or physical) or allow the system to access more existing
 memory, or quit other programs that may be consuming memory, and try the
 operation again."""
 
-        return _(error).format(**locals())
+    return _(error).format(**locals())
 
 
 # EmptyI for argument defaults
 EmptyI = tuple()
 
+
 # ImmutableDict for argument defaults
 class ImmutableDict(dict):
-        # Missing docstring; pylint: disable=C0111
-        # Unused argument; pylint: disable=W0613
+    # Missing docstring; pylint: disable=C0111
+    # Unused argument; pylint: disable=W0613
 
-        def __init__(self, default=EmptyI):
-                dict.__init__(self, default)
+    def __init__(self, default=EmptyI):
+        dict.__init__(self, default)
 
-        def __setitem__(self, item, value):
-                self.__oops()
+    def __setitem__(self, item, value):
+        self.__oops()
 
-        def __delitem__(self, item):
-                self.__oops()
+    def __delitem__(self, item):
+        self.__oops()
 
-        def pop(self, item, default=None):
-                self.__oops()
+    def pop(self, item, default=None):
+        self.__oops()
 
-        def popitem(self):
-                self.__oops()
+    def popitem(self):
+        self.__oops()
 
-        def setdefault(self, item, default=None):
-                self.__oops()
+    def setdefault(self, item, default=None):
+        self.__oops()
 
-        def update(self, d):
-                self.__oops()
+    def update(self, d):
+        self.__oops()
 
-        def copy(self):
-                return ImmutableDict()
+    def copy(self):
+        return ImmutableDict()
 
-        def clear(self):
-                self.__oops()
+    def clear(self):
+        self.__oops()
 
-        @staticmethod
-        def __oops():
-                raise TypeError("Item assignment to ImmutableDict")
+    @staticmethod
+    def __oops():
+        raise TypeError("Item assignment to ImmutableDict")
+
 
 # A way to have a dictionary be a property
 
+
 class DictProperty(object):
-        # Missing docstring; pylint: disable=C0111
+    # Missing docstring; pylint: disable=C0111
 
-        class __InternalProxy(object):
-                def __init__(self, obj, fget, fset, fdel, iteritems, keys,
-                    values, iterator, fgetdefault, fsetdefault, update, pop):
-                        self.__obj = obj
-                        self.__fget = fget
-                        self.__fset = fset
-                        self.__fdel = fdel
-                        self.__iteritems = iteritems
-                        self.__keys = keys
-                        self.__values = values
-                        self.__iter = iterator
-                        self.__fgetdefault = fgetdefault
-                        self.__fsetdefault = fsetdefault
-                        self.__update = update
-                        self.__pop = pop
+    class __InternalProxy(object):
+        def __init__(
+            self,
+            obj,
+            fget,
+            fset,
+            fdel,
+            iteritems,
+            keys,
+            values,
+            iterator,
+            fgetdefault,
+            fsetdefault,
+            update,
+            pop,
+        ):
+            self.__obj = obj
+            self.__fget = fget
+            self.__fset = fset
+            self.__fdel = fdel
+            self.__iteritems = iteritems
+            self.__keys = keys
+            self.__values = values
+            self.__iter = iterator
+            self.__fgetdefault = fgetdefault
+            self.__fsetdefault = fsetdefault
+            self.__update = update
+            self.__pop = pop
 
-                def __getitem__(self, key):
-                        if self.__fget is None:
-                                raise AttributeError("unreadable attribute")
+        def __getitem__(self, key):
+            if self.__fget is None:
+                raise AttributeError("unreadable attribute")
 
-                        return self.__fget(self.__obj, key)
+            return self.__fget(self.__obj, key)
 
-                def __setitem__(self, key, value):
-                        if self.__fset is None:
-                                raise AttributeError("can't set attribute")
-                        self.__fset(self.__obj, key, value)
+        def __setitem__(self, key, value):
+            if self.__fset is None:
+                raise AttributeError("can't set attribute")
+            self.__fset(self.__obj, key, value)
 
-                def __delitem__(self, key):
-                        if self.__fdel is None:
-                                raise AttributeError("can't delete attribute")
-                        self.__fdel(self.__obj, key)
+        def __delitem__(self, key):
+            if self.__fdel is None:
+                raise AttributeError("can't delete attribute")
+            self.__fdel(self.__obj, key)
 
-                def iteritems(self):
-                        if self.__iteritems is None:
-                                raise AttributeError("can't iterate over items")
-                        return self.__iteritems(self.__obj)
+        def iteritems(self):
+            if self.__iteritems is None:
+                raise AttributeError("can't iterate over items")
+            return self.__iteritems(self.__obj)
 
-                # for Python 3 compatibility
-                def items(self):
-                        return self.iteritems()
+        # for Python 3 compatibility
+        def items(self):
+            return self.iteritems()
 
-                def keys(self):
-                        if self.__keys is None:
-                                raise AttributeError("can't iterate over keys")
-                        return self.__keys(self.__obj)
+        def keys(self):
+            if self.__keys is None:
+                raise AttributeError("can't iterate over keys")
+            return self.__keys(self.__obj)
 
-                def values(self):
-                        if self.__values is None:
-                                raise AttributeError("can't iterate over "
-                                    "values")
-                        return self.__values(self.__obj)
+        def values(self):
+            if self.__values is None:
+                raise AttributeError("can't iterate over " "values")
+            return self.__values(self.__obj)
 
-                def get(self, key, default=None):
-                        if self.__fgetdefault is None:
-                                raise AttributeError("can't use get")
-                        return self.__fgetdefault(self.__obj, key, default)
+        def get(self, key, default=None):
+            if self.__fgetdefault is None:
+                raise AttributeError("can't use get")
+            return self.__fgetdefault(self.__obj, key, default)
 
-                def setdefault(self, key, default=None):
-                        if self.__fsetdefault is None:
-                                raise AttributeError("can't use setdefault")
-                        return self.__fsetdefault(self.__obj, key, default)
+        def setdefault(self, key, default=None):
+            if self.__fsetdefault is None:
+                raise AttributeError("can't use setdefault")
+            return self.__fsetdefault(self.__obj, key, default)
 
-                def update(self, d):
-                        if self.__update is None:
-                                raise AttributeError("can't use update")
-                        return self.__update(self.__obj, d)
+        def update(self, d):
+            if self.__update is None:
+                raise AttributeError("can't use update")
+            return self.__update(self.__obj, d)
 
-                def pop(self, d, default):
-                        if self.__pop is None:
-                                raise AttributeError("can't use pop")
-                        return self.__pop(self.__obj, d, default)
+        def pop(self, d, default):
+            if self.__pop is None:
+                raise AttributeError("can't use pop")
+            return self.__pop(self.__obj, d, default)
 
-                def __iter__(self):
-                        if self.__iter is None:
-                                raise AttributeError("can't iterate")
-                        return self.__iter(self.__obj)
+        def __iter__(self):
+            if self.__iter is None:
+                raise AttributeError("can't iterate")
+            return self.__iter(self.__obj)
 
-        def __init__(self, fget=None, fset=None, fdel=None, iteritems=None,
-            keys=None, values=None, iterator=None, doc=None, fgetdefault=None,
-            fsetdefault=None, update=None, pop=None):
-                self.__fget = fget
-                self.__fset = fset
-                self.__fdel = fdel
-                self.__iteritems = iteritems
-                self.__doc__ = doc
-                self.__keys = keys
-                self.__values = values
-                self.__iter = iterator
-                self.__fgetdefault = fgetdefault
-                self.__fsetdefault = fsetdefault
-                self.__update = update
-                self.__pop = pop
+    def __init__(
+        self,
+        fget=None,
+        fset=None,
+        fdel=None,
+        iteritems=None,
+        keys=None,
+        values=None,
+        iterator=None,
+        doc=None,
+        fgetdefault=None,
+        fsetdefault=None,
+        update=None,
+        pop=None,
+    ):
+        self.__fget = fget
+        self.__fset = fset
+        self.__fdel = fdel
+        self.__iteritems = iteritems
+        self.__doc__ = doc
+        self.__keys = keys
+        self.__values = values
+        self.__iter = iterator
+        self.__fgetdefault = fgetdefault
+        self.__fsetdefault = fsetdefault
+        self.__update = update
+        self.__pop = pop
 
-        def __get__(self, obj, objtype=None):
-                # Unused argument; pylint: disable=W0613
+    def __get__(self, obj, objtype=None):
+        # Unused argument; pylint: disable=W0613
 
-                if obj is None:
-                        return self
-                return self.__InternalProxy(obj, self.__fget, self.__fset,
-                    self.__fdel, self.__iteritems, self.__keys, self.__values,
-                    self.__iter, self.__fgetdefault, self.__fsetdefault,
-                    self.__update, self.__pop)
+        if obj is None:
+            return self
+        return self.__InternalProxy(
+            obj,
+            self.__fget,
+            self.__fset,
+            self.__fdel,
+            self.__iteritems,
+            self.__keys,
+            self.__values,
+            self.__iter,
+            self.__fgetdefault,
+            self.__fsetdefault,
+            self.__update,
+            self.__pop,
+        )
 
 
 def build_cert(path, uri=None, pub=None):
-        """Take the file given in path, open it, and use it to create
-        an X509 certificate object.
+    """Take the file given in path, open it, and use it to create
+    an X509 certificate object.
 
-        'uri' is an optional value indicating the uri associated with or that
-        requires the certificate for access.
+    'uri' is an optional value indicating the uri associated with or that
+    requires the certificate for access.
 
-        'pub' is an optional string value containing the name (prefix) of a
-        related publisher."""
+    'pub' is an optional string value containing the name (prefix) of a
+    related publisher."""
 
-        try:
-                cf = open(path, "rb")
-                certdata = cf.read()
-                cf.close()
-        except EnvironmentError as e:
-                if e.errno == errno.ENOENT:
-                        raise api_errors.NoSuchCertificate(path, uri=uri,
-                            publisher=pub)
-                if e.errno == errno.EACCES:
-                        raise api_errors.PermissionsException(e.filename)
-                if e.errno == errno.EROFS:
-                        raise api_errors.ReadOnlyFileSystemException(e.filename)
-                raise
+    try:
+        cf = open(path, "rb")
+        certdata = cf.read()
+        cf.close()
+    except EnvironmentError as e:
+        if e.errno == errno.ENOENT:
+            raise api_errors.NoSuchCertificate(path, uri=uri, publisher=pub)
+        if e.errno == errno.EACCES:
+            raise api_errors.PermissionsException(e.filename)
+        if e.errno == errno.EROFS:
+            raise api_errors.ReadOnlyFileSystemException(e.filename)
+        raise
 
-        try:
-                return osc.load_certificate(osc.FILETYPE_PEM, certdata)
-        except osc.Error as e:
-                # OpenSSL.crypto.Error
-                raise api_errors.InvalidCertificate(path, uri=uri,
-                    publisher=pub)
+    try:
+        return osc.load_certificate(osc.FILETYPE_PEM, certdata)
+    except osc.Error as e:
+        # OpenSSL.crypto.Error
+        raise api_errors.InvalidCertificate(path, uri=uri, publisher=pub)
+
 
 def validate_ssl_cert(ssl_cert, prefix=None, uri=None):
-        """Validates the indicated certificate and returns a pyOpenSSL object
-        representing it if it is valid."""
-        cert = build_cert(ssl_cert, uri=uri, pub=prefix)
+    """Validates the indicated certificate and returns a pyOpenSSL object
+    representing it if it is valid."""
+    cert = build_cert(ssl_cert, uri=uri, pub=prefix)
 
-        if cert.has_expired():
-                raise api_errors.ExpiredCertificate(ssl_cert, uri=uri,
-                    publisher=prefix)
+    if cert.has_expired():
+        raise api_errors.ExpiredCertificate(ssl_cert, uri=uri, publisher=prefix)
 
-        now = datetime.datetime.utcnow()
-        nb = cert.get_notBefore()
-        # strptime's first argument must be str
-        t = time.strptime(force_str(nb), "%Y%m%d%H%M%SZ")
-        nbdt = datetime.datetime.utcfromtimestamp(
-            calendar.timegm(t))
+    now = datetime.datetime.utcnow()
+    nb = cert.get_notBefore()
+    # strptime's first argument must be str
+    t = time.strptime(force_str(nb), "%Y%m%d%H%M%SZ")
+    nbdt = datetime.datetime.utcfromtimestamp(calendar.timegm(t))
 
-        # PyOpenSSL's has_expired() doesn't validate the notBefore
-        # time on the certificate.  Don't ask me why.
+    # PyOpenSSL's has_expired() doesn't validate the notBefore
+    # time on the certificate.  Don't ask me why.
 
-        if nbdt > now:
-                raise api_errors.NotYetValidCertificate(ssl_cert, uri=uri,
-                    publisher=prefix)
+    if nbdt > now:
+        raise api_errors.NotYetValidCertificate(
+            ssl_cert, uri=uri, publisher=prefix
+        )
 
-        na = cert.get_notAfter()
-        t = time.strptime(force_str(na), "%Y%m%d%H%M%SZ")
-        nadt = datetime.datetime.utcfromtimestamp(
-            calendar.timegm(t))
+    na = cert.get_notAfter()
+    t = time.strptime(force_str(na), "%Y%m%d%H%M%SZ")
+    nadt = datetime.datetime.utcfromtimestamp(calendar.timegm(t))
 
-        diff = nadt - now
+    diff = nadt - now
 
-        if diff <= MIN_WARN_DAYS:
-                raise api_errors.ExpiringCertificate(ssl_cert, uri=uri,
-                    publisher=prefix, days=diff.days)
+    if diff <= MIN_WARN_DAYS:
+        raise api_errors.ExpiringCertificate(
+            ssl_cert, uri=uri, publisher=prefix, days=diff.days
+        )
 
-        return cert
+    return cert
+
 
 def binary_to_hex(s):
-        """Converts a string of bytes to a hexadecimal representation.
-        """
-        return force_str(hexlify(s))
+    """Converts a string of bytes to a hexadecimal representation."""
+    return force_str(hexlify(s))
+
 
 def hex_to_binary(s):
-        """Converts a string of hex digits to the binary representation.
-        """
-        return unhexlify(s)
+    """Converts a string of hex digits to the binary representation."""
+    return unhexlify(s)
+
 
 def config_temp_root():
-        """Examine the environment.  If the environment has set TMPDIR, TEMP,
-        or TMP, return None.  This tells tempfile to use the environment
-        settings when creating temporary files/directories.  Otherwise,
-        return a path that the caller should pass to tempfile instead."""
+    """Examine the environment.  If the environment has set TMPDIR, TEMP,
+    or TMP, return None.  This tells tempfile to use the environment
+    settings when creating temporary files/directories.  Otherwise,
+    return a path that the caller should pass to tempfile instead."""
 
-        # In Python's tempfile module, the default temp directory
-        # includes some paths that are suboptimal for holding large numbers
-        # of files.  If the user hasn't set TMPDIR, TEMP, or TMP in the
-        # environment, override the default directory for creating a tempfile.
-        tmp_envs = [ "TMPDIR", "TEMP", "TMP" ]
-        for ev in tmp_envs:
-                env_val = os.getenv(ev)
-                if env_val:
-                        return None
+    # In Python's tempfile module, the default temp directory
+    # includes some paths that are suboptimal for holding large numbers
+    # of files.  If the user hasn't set TMPDIR, TEMP, or TMP in the
+    # environment, override the default directory for creating a tempfile.
+    tmp_envs = ["TMPDIR", "TEMP", "TMP"]
+    for ev in tmp_envs:
+        env_val = os.getenv(ev)
+        if env_val:
+            return None
 
-        return DEFAULT_TEMP_PATH
+    return DEFAULT_TEMP_PATH
+
 
 def get_temp_root_path():
-        """Return the directory path where the temporary directories or
-        files should be created. If the environment has set TMPDIR
-        or TEMP or TMP then return the corresponding value else return the
-        default value."""
+    """Return the directory path where the temporary directories or
+    files should be created. If the environment has set TMPDIR
+    or TEMP or TMP then return the corresponding value else return the
+    default value."""
 
-        temp_env = [ "TMPDIR", "TEMP", "TMP" ]
-        for env in temp_env:
-                env_val = os.getenv(env)
-                if env_val:
-                        return env_val
+    temp_env = ["TMPDIR", "TEMP", "TMP"]
+    for env in temp_env:
+        env_val = os.getenv(env)
+        if env_val:
+            return env_val
 
-        return DEFAULT_TEMP_PATH
+    return DEFAULT_TEMP_PATH
+
 
 def parse_uri(uri, cwd=None):
-        """Parse the repository location provided and attempt to transform it
-        into a valid repository URI.
+    """Parse the repository location provided and attempt to transform it
+    into a valid repository URI.
 
-        'cwd' is the working directory to use to turn paths into an absolute
-        path.  If not provided, the current working directory is used.
-        """
+    'cwd' is the working directory to use to turn paths into an absolute
+    path.  If not provided, the current working directory is used.
+    """
 
-        if uri.find("://") == -1 and not uri.startswith("file:/"):
-                # Convert the file path to a URI.
-                if not cwd:
-                        uri = os.path.abspath(uri)
-                elif not os.path.isabs(uri):
-                        uri = os.path.normpath(os.path.join(cwd, uri))
+    if uri.find("://") == -1 and not uri.startswith("file:/"):
+        # Convert the file path to a URI.
+        if not cwd:
+            uri = os.path.abspath(uri)
+        elif not os.path.isabs(uri):
+            uri = os.path.normpath(os.path.join(cwd, uri))
 
-                uri = urlunparse(("file", "",
-                    pathname2url(uri), "", "", ""))
+        uri = urlunparse(("file", "", pathname2url(uri), "", "", ""))
 
-        scheme, netloc, path, params, query, fragment = \
-            urlparse(uri, "file", allow_fragments=0)
-        scheme = scheme.lower()
+    scheme, netloc, path, params, query, fragment = urlparse(
+        uri, "file", allow_fragments=0
+    )
+    scheme = scheme.lower()
 
-        if scheme == "file":
-                # During urlunparsing below, ensure that the path starts with
-                # only one '/' character, if any are present.
-                if path.startswith("/"):
-                        path = "/" + path.lstrip("/")
+    if scheme == "file":
+        # During urlunparsing below, ensure that the path starts with
+        # only one '/' character, if any are present.
+        if path.startswith("/"):
+            path = "/" + path.lstrip("/")
 
-        # Rebuild the URI with the sanitized components.
-        return urlunparse((scheme, netloc, path, params,
-            query, fragment))
+    # Rebuild the URI with the sanitized components.
+    return urlunparse((scheme, netloc, path, params, query, fragment))
 
 
 def makedirs(pathname):
-        """Create a directory at the specified location if it does not
-        already exist (including any parent directories) re-raising any
-        unexpected exceptions as ApiExceptions.
-        """
+    """Create a directory at the specified location if it does not
+    already exist (including any parent directories) re-raising any
+    unexpected exceptions as ApiExceptions.
+    """
 
-        try:
-                os.makedirs(pathname, PKG_DIR_MODE)
-        except EnvironmentError as e:
-                if e.filename == pathname and (e.errno == errno.EEXIST or
-                    os.path.exists(e.filename)):
-                        return
-                elif e.errno == errno.EACCES:
-                        raise api_errors.PermissionsException(
-                            e.filename)
-                elif e.errno == errno.EROFS:
-                        raise api_errors.ReadOnlyFileSystemException(
-                            e.filename)
-                elif e.errno != errno.EEXIST or e.filename != pathname:
-                        raise
+    try:
+        os.makedirs(pathname, PKG_DIR_MODE)
+    except EnvironmentError as e:
+        if e.filename == pathname and (
+            e.errno == errno.EEXIST or os.path.exists(e.filename)
+        ):
+            return
+        elif e.errno == errno.EACCES:
+            raise api_errors.PermissionsException(e.filename)
+        elif e.errno == errno.EROFS:
+            raise api_errors.ReadOnlyFileSystemException(e.filename)
+        elif e.errno != errno.EEXIST or e.filename != pathname:
+            raise
+
 
 class DummyLock(object):
-        """This has the same external interface as threading.Lock,
-        but performs no locking.  This is a placeholder object for situations
-        where we want to be able to do locking, but don't always need a
-        lock object present.  The object has a held value, that is used
-        for _is_owned.  This is informational and doesn't actually
-        provide mutual exclusion in any way whatsoever."""
-        # Missing docstring; pylint: disable=C0111
+    """This has the same external interface as threading.Lock,
+    but performs no locking.  This is a placeholder object for situations
+    where we want to be able to do locking, but don't always need a
+    lock object present.  The object has a held value, that is used
+    for _is_owned.  This is informational and doesn't actually
+    provide mutual exclusion in any way whatsoever."""
 
-        def __init__(self):
-                self.held = False
+    # Missing docstring; pylint: disable=C0111
 
-        def acquire(self, blocking=1):
-                # Unused argument; pylint: disable=W0613
-                self.held = True
-                return True
+    def __init__(self):
+        self.held = False
 
-        def release(self):
-                self.held = False
-                return
+    def acquire(self, blocking=1):
+        # Unused argument; pylint: disable=W0613
+        self.held = True
+        return True
 
-        def _is_owned(self):
-                return self.held
+    def release(self):
+        self.held = False
+        return
 
-        @property
-        def locked(self):
-                return self.held
+    def _is_owned(self):
+        return self.held
+
+    @property
+    def locked(self):
+        return self.held
 
 
 class Singleton(type):
-        """Set __metaclass__ to Singleton to create a singleton.
-        See http://en.wikipedia.org/wiki/Singleton_pattern """
+    """Set __metaclass__ to Singleton to create a singleton.
+    See http://en.wikipedia.org/wiki/Singleton_pattern"""
 
-        def __init__(cls, name, bases, dictionary):
-                super(Singleton, cls).__init__(name, bases, dictionary)
-                cls.instance = None
+    def __init__(cls, name, bases, dictionary):
+        super(Singleton, cls).__init__(name, bases, dictionary)
+        cls.instance = None
 
-        def __call__(cls, *args, **kw):
-                if cls.instance is None:
-                        cls.instance = super(Singleton, cls).__call__(*args,
-                            **kw)
+    def __call__(cls, *args, **kw):
+        if cls.instance is None:
+            cls.instance = super(Singleton, cls).__call__(*args, **kw)
 
-                return cls.instance
+        return cls.instance
 
 
 EmptyDict = ImmutableDict()
@@ -1414,1747 +1520,1846 @@ EmptyDict = ImmutableDict()
 PKG_FILE_BUFSIZ = 128 * 1024
 
 PKG_FILE_MODE = S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH
-PKG_DIR_MODE = (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)
+PKG_DIR_MODE = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
 PKG_RO_FILE_MODE = S_IRUSR | S_IRGRP | S_IROTH
 
+
 def relpath(path, start="."):
-        """Version of relpath to workaround python bug:
-            http://bugs.python.org/issue5117
-        """
-        if path and start and start == "/" and path[0] == "/":
-                return path.lstrip("/")
-        return os.path.relpath(path, start=start)
+    """Version of relpath to workaround python bug:
+    http://bugs.python.org/issue5117
+    """
+    if path and start and start == "/" and path[0] == "/":
+        return path.lstrip("/")
+    return os.path.relpath(path, start=start)
+
 
 def recursive_chown_dir(d, uid, gid):
-        """Change the ownership of all files under directory d to uid:gid."""
-        for dirpath, dirnames, filenames in os.walk(d):
-                for name in dirnames:
-                        path = os.path.join(dirpath, name)
-                        portable.chown(path, uid, gid)
-                for name in filenames:
-                        path = os.path.join(dirpath, name)
-                        portable.chown(path, uid, gid)
+    """Change the ownership of all files under directory d to uid:gid."""
+    for dirpath, dirnames, filenames in os.walk(d):
+        for name in dirnames:
+            path = os.path.join(dirpath, name)
+            portable.chown(path, uid, gid)
+        for name in filenames:
+            path = os.path.join(dirpath, name)
+            portable.chown(path, uid, gid)
 
 
-def opts_parse(op, args, opts_table, opts_mapping, usage_cb=None,
-    use_cli_opts=True, **opts_kv):
-        """Generic table-based options parsing function.  Returns a tuple
-        consisting of a list of parsed options in the form (option, argument)
-        and the remaining unparsed options. The parsed-option list may contain
-        duplicates if an option is passed multiple times.
+def opts_parse(
+    op,
+    args,
+    opts_table,
+    opts_mapping,
+    usage_cb=None,
+    use_cli_opts=True,
+    **opts_kv  # fmt: skip
+):
+    """Generic table-based options parsing function.  Returns a tuple
+    consisting of a list of parsed options in the form (option, argument)
+    and the remaining unparsed options. The parsed-option list may contain
+    duplicates if an option is passed multiple times.
 
-        'op' is the operation being performed.
+    'op' is the operation being performed.
 
-        'args' is the arguments that should be parsed.
+    'args' is the arguments that should be parsed.
 
-        'opts_table' is a list of options the operation supports.
-        The format of the list entries should be a tuple containing the
-        option and its default value:
-            (option, default_value, [valid values], [json schema])
-        It is valid to have other entries in the list when they are required
-        for additional option processing elsewhere. These are ignore here. If
-        the list entry is a tuple it must conform to the format oulined above.
+    'opts_table' is a list of options the operation supports.
+    The format of the list entries should be a tuple containing the
+    option and its default value:
+        (option, default_value, [valid values], [json schema])
+    It is valid to have other entries in the list when they are required
+    for additional option processing elsewhere. These are ignore here. If
+    the list entry is a tuple it must conform to the format oulined above.
 
-        The default value not only represents the default value assigned to the
-        option, but it also implicitly determines how the option is parsed.  If
-        the default value is True or False, the option doesn't take any
-        arguments, can only be specified once, and if specified it inverts the
-        default value.  If the default value is 0, the option doesn't take any
-        arguments, can be specified multiple times, and if specified its value
-        will be the number of times it was seen.  If the default value is
-        None, the option requires an argument, can only be specified once, and
-        if specified its value will be its argument string.  If the default
-        value is an empty list, the option requires an argument, may be
-        specified multiple times, and if specified its value will be a list
-        with all the specified argument values.
+    The default value not only represents the default value assigned to the
+    option, but it also implicitly determines how the option is parsed.  If
+    the default value is True or False, the option doesn't take any
+    arguments, can only be specified once, and if specified it inverts the
+    default value.  If the default value is 0, the option doesn't take any
+    arguments, can be specified multiple times, and if specified its value
+    will be the number of times it was seen.  If the default value is
+    None, the option requires an argument, can only be specified once, and
+    if specified its value will be its argument string.  If the default
+    value is an empty list, the option requires an argument, may be
+    specified multiple times, and if specified its value will be a list
+    with all the specified argument values.
 
-        'opts_mapping' is a dict containing a mapping between the option name
-        and the short and long CLI specifier for that option in the form
-        { option : (short, long), ... }
+    'opts_mapping' is a dict containing a mapping between the option name
+    and the short and long CLI specifier for that option in the form
+    { option : (short, long), ... }
 
-        An example of a short opt is "f", which maps to a "-f" option.  An
-        example of a long opt is "foo", which maps to a "--foo" option.  Option
-        is the value of this option in the parsed option dictionary.
+    An example of a short opt is "f", which maps to a "-f" option.  An
+    example of a long opt is "foo", which maps to a "--foo" option.  Option
+    is the value of this option in the parsed option dictionary.
 
-        'usage_cb' is a function pointer that should display usage information
-        and will be invoked if invalid arguments are detected.
+    'usage_cb' is a function pointer that should display usage information
+    and will be invoked if invalid arguments are detected.
 
-        'use_cli_opts' is to indicate the option type is a CLI option or
-        a key-value pair option.
+    'use_cli_opts' is to indicate the option type is a CLI option or
+    a key-value pair option.
 
-        'opts_kv' is the user provided opts that should be parsed. It is a
-        dictionary with key as option name and value as option argument.
-        """
+    'opts_kv' is the user provided opts that should be parsed. It is a
+    dictionary with key as option name and value as option argument.
+    """
 
+    if use_cli_opts:
+        # list for getopt long options
+        opts_l_list = []
+        # getopt str for short options
+        opts_s_str = ""
+
+        # dict to map options returned by getopt to keys
+        opts_keys = dict()
+    else:
+        opts_name_mapping = {}
+
+    for entry in opts_table:
+        # option table contains functions for verification, ignore here
+        if type(entry) != tuple:
+            continue
+        if len(entry) == 2:
+            opt, default = entry
+        elif len(entry) == 3:
+            opt, default, dummy_valid_args = entry
+        elif len(entry) == 4:
+            opt, default, dummy_valid_args, dummy_schema = entry
         if use_cli_opts:
-                # list for getopt long options
-                opts_l_list = []
-                # getopt str for short options
-                opts_s_str = ""
-
-                # dict to map options returned by getopt to keys
-                opts_keys = dict()
-        else:
-                opts_name_mapping = {}
-
-        for entry in opts_table:
-                # option table contains functions for verification, ignore here
-                if type(entry) != tuple:
-                        continue
-                if len(entry) == 2:
-                        opt, default = entry
-                elif len(entry) == 3:
-                        opt, default, dummy_valid_args = entry
-                elif len(entry) == 4:
-                        opt, default, dummy_valid_args, dummy_schema = entry
-                if use_cli_opts:
-                        assert opt in opts_mapping
-                        sopt, lopt = opts_mapping[opt]
-                        # make sure an option was specified
-                        assert sopt or lopt
-                        if lopt != "":
-                                if default is None or type(default) == list:
-                                        opts_l_list.append("{0}=".format(lopt))
-                                else:
-                                        opts_l_list.append("{0}".format(lopt))
-                                opts_keys["--{0}".format(lopt)] = opt
-                        if sopt != "":
-                                if default is None or type(default) == list:
-                                        opts_s_str += "{0}:".format(sopt)
-                                else:
-                                        opts_s_str += "{0}".format(sopt)
-                                opts_keys["-{0}".format(sopt)] = opt
+            assert opt in opts_mapping
+            sopt, lopt = opts_mapping[opt]
+            # make sure an option was specified
+            assert sopt or lopt
+            if lopt != "":
+                if default is None or type(default) == list:
+                    opts_l_list.append("{0}=".format(lopt))
                 else:
-                        # Add itself as a mapping for validation.
-                        opts_name_mapping[opt] = opt
-                        if opt in opts_mapping:
-                                optn = opts_mapping[opt]
-                                if optn:
-                                        opts_name_mapping[optn] = opt
-
-        # Parse options.
-        if use_cli_opts:
-                try:
-                        opts, pargs = getopt.getopt(args, opts_s_str,
-                            opts_l_list)
-                except getopt.GetoptError as e:
-                        usage_cb(_("illegal option -- {0}").format(e.opt),
-                            cmd=op)
+                    opts_l_list.append("{0}".format(lopt))
+                opts_keys["--{0}".format(lopt)] = opt
+            if sopt != "":
+                if default is None or type(default) == list:
+                    opts_s_str += "{0}:".format(sopt)
+                else:
+                    opts_s_str += "{0}".format(sopt)
+                opts_keys["-{0}".format(sopt)] = opt
         else:
-                opts = opts_kv
+            # Add itself as a mapping for validation.
+            opts_name_mapping[opt] = opt
+            if opt in opts_mapping:
+                optn = opts_mapping[opt]
+                if optn:
+                    opts_name_mapping[optn] = opt
 
-        def get_default(option):
-                """Find the default value for a given option from opts_table."""
-                for x in opts_table:
-                        if type(x) != tuple:
-                                continue
-                        if len(x) == 2:
-                                opt, default = x
-                        elif len(x) == 3:
-                                opt, default, dummy_valid_args = x
-                        elif len(x) == 4:
-                                opt, default, dummy_valid_args, \
-                                    dummy_schema = x
-                        if option == opt:
-                                return default
+    # Parse options.
+    if use_cli_opts:
+        try:
+            opts, pargs = getopt.getopt(args, opts_s_str, opts_l_list)
+        except getopt.GetoptError as e:
+            usage_cb(_("illegal option -- {0}").format(e.opt), cmd=op)
+    else:
+        opts = opts_kv
 
-        def process_opts(opt, arg, opt_dict):
-                """Process option values."""
-                # Determine required option type based on the default value.
-                default = get_default(opt)
+    def get_default(option):
+        """Find the default value for a given option from opts_table."""
+        for x in opts_table:
+            if type(x) != tuple:
+                continue
+            if len(x) == 2:
+                opt, default = x
+            elif len(x) == 3:
+                opt, default, dummy_valid_args = x
+            elif len(x) == 4:
+                opt, default, dummy_valid_args, dummy_schema = x
+            if option == opt:
+                return default
 
-                if use_cli_opts:
-                        # Handle duplicates for integer and list types.
-                        if type(default) == int:
-                                if opt in opt_dict:
-                                        opt_dict[opt] += 1
-                                else:
-                                        opt_dict[opt] = 1
-                                return
-                        if type(default) == list:
-                                if opt in opt_dict:
-                                        opt_dict[opt].append(arg)
-                                else:
-                                        opt_dict[opt] = [arg]
-                                return
+    def process_opts(opt, arg, opt_dict):
+        """Process option values."""
+        # Determine required option type based on the default value.
+        default = get_default(opt)
 
-                # Boolean and string types can't be repeated.
+        if use_cli_opts:
+            # Handle duplicates for integer and list types.
+            if type(default) == int:
                 if opt in opt_dict:
-                        raise api_errors.InvalidOptionError(
-                            api_errors.InvalidOptionError.OPT_REPEAT, [opt])
-
-                # For boolean options we have to toggle the default value
-                # when in CLI mode.
-                if type(default) == bool:
-                        if use_cli_opts:
-                                opt_dict[opt] = not default
-                        else:
-                                opt_dict[opt] = arg
+                    opt_dict[opt] += 1
                 else:
-                        opt_dict[opt] = arg
-
-        # Assemble the options dictionary by passing in the right data types
-        # and take care of duplicates.
-        opt_dict = {}
-        if use_cli_opts:
-                for x in opts:
-                        cli_opt, arg = x
-                        opt = opts_keys[cli_opt]
-                        process_opts(opt, arg, opt_dict)
-
-                return opt_dict, pargs
-
-        for k, v in opts.items():
-                cli_opt, arg = k, v
-                if cli_opt in opts_name_mapping:
-                        cli_opt = opts_name_mapping[cli_opt]
+                    opt_dict[opt] = 1
+                return
+            if type(default) == list:
+                if opt in opt_dict:
+                    opt_dict[opt].append(arg)
                 else:
-                        raise api_errors.InvalidOptionError(
-                            api_errors.InvalidOptionError.GENERIC,
-                            [cli_opt])
-                process_opts(cli_opt, arg, opt_dict)
+                    opt_dict[opt] = [arg]
+                return
 
-        return opt_dict
+        # Boolean and string types can't be repeated.
+        if opt in opt_dict:
+            raise api_errors.InvalidOptionError(
+                api_errors.InvalidOptionError.OPT_REPEAT, [opt]
+            )
+
+        # For boolean options we have to toggle the default value
+        # when in CLI mode.
+        if type(default) == bool:
+            if use_cli_opts:
+                opt_dict[opt] = not default
+            else:
+                opt_dict[opt] = arg
+        else:
+            opt_dict[opt] = arg
+
+    # Assemble the options dictionary by passing in the right data types
+    # and take care of duplicates.
+    opt_dict = {}
+    if use_cli_opts:
+        for x in opts:
+            cli_opt, arg = x
+            opt = opts_keys[cli_opt]
+            process_opts(opt, arg, opt_dict)
+
+        return opt_dict, pargs
+
+    for k, v in opts.items():
+        cli_opt, arg = k, v
+        if cli_opt in opts_name_mapping:
+            cli_opt = opts_name_mapping[cli_opt]
+        else:
+            raise api_errors.InvalidOptionError(
+                api_errors.InvalidOptionError.GENERIC, [cli_opt]
+            )
+        process_opts(cli_opt, arg, opt_dict)
+
+    return opt_dict
+
 
 def api_cmdpath():
-        """Returns the path to the executable that is invoking the api client
-        interfaces."""
+    """Returns the path to the executable that is invoking the api client
+    interfaces."""
 
-        cmdpath = None
+    cmdpath = None
 
-        if global_settings.client_args[0]:
-                cmdpath = os.path.realpath(os.path.join(sys.path[0],
-                    os.path.basename(global_settings.client_args[0])))
+    if global_settings.client_args[0]:
+        cmdpath = os.path.realpath(
+            os.path.join(
+                sys.path[0], os.path.basename(global_settings.client_args[0])
+            )
+        )
 
-        if "PKG_CMDPATH" in os.environ:
-                cmdpath = os.environ["PKG_CMDPATH"]
+    if "PKG_CMDPATH" in os.environ:
+        cmdpath = os.environ["PKG_CMDPATH"]
 
-        # DebugValues is a singleton, hence no 'self' arg; pylint: disable=E1120
-        if DebugValues.get_value("simulate_cmdpath"):
-                cmdpath = DebugValues.get_value("simulate_cmdpath")
+    # DebugValues is a singleton, hence no 'self' arg; pylint: disable=E1120
+    if DebugValues.get_value("simulate_cmdpath"):
+        cmdpath = DebugValues.get_value("simulate_cmdpath")
 
-        return cmdpath
+    return cmdpath
+
 
 def api_pkgcmd():
-        """When running a pkg(1) command from within a packaging module, try
-        to use the same pkg(1) path as our current invocation.  If we're
-        running pkg(1) from some other command (like the gui updater) then
-        assume that pkg(1) is in the default path."""
+    """When running a pkg(1) command from within a packaging module, try
+    to use the same pkg(1) path as our current invocation.  If we're
+    running pkg(1) from some other command (like the gui updater) then
+    assume that pkg(1) is in the default path."""
 
-        pkg_bin = "pkg"
-        cmdpath = api_cmdpath()
-        if cmdpath and os.path.basename(cmdpath) == "pkg":
-                try:
-                        # check if the currently running pkg command
-                        # exists and is accessible.
-                        os.stat(cmdpath)
-                        pkg_bin = cmdpath
-                except OSError:
-                        pass
+    pkg_bin = "pkg"
+    cmdpath = api_cmdpath()
+    if cmdpath and os.path.basename(cmdpath) == "pkg":
+        try:
+            # check if the currently running pkg command
+            # exists and is accessible.
+            os.stat(cmdpath)
+            pkg_bin = cmdpath
+        except OSError:
+            pass
 
-        pkg_cmd = [sys.executable] + [pkg_bin]
+    pkg_cmd = [sys.executable] + [pkg_bin]
 
-        # propagate debug options
-        for k, v in six.iteritems(DebugValues):
-                pkg_cmd.append("-D")
-                pkg_cmd.append("{0}={1}".format(k, v))
+    # propagate debug options
+    for k, v in six.iteritems(DebugValues):
+        pkg_cmd.append("-D")
+        pkg_cmd.append("{0}={1}".format(k, v))
 
-        return pkg_cmd
+    return pkg_cmd
+
 
 def liveroot():
-        """Return path to the current live root image, i.e. the image
-        that we are running from."""
+    """Return path to the current live root image, i.e. the image
+    that we are running from."""
 
-        # DebugValues is a singleton, hence no 'self' arg; pylint: disable=E1120
-        live_root = DebugValues.get_value("simulate_live_root")
-        if not live_root and "PKG_LIVE_ROOT" in os.environ:
-                live_root = os.environ["PKG_LIVE_ROOT"]
-        if not live_root:
-                live_root = "/"
-        return live_root
+    # DebugValues is a singleton, hence no 'self' arg; pylint: disable=E1120
+    live_root = DebugValues.get_value("simulate_live_root")
+    if not live_root and "PKG_LIVE_ROOT" in os.environ:
+        live_root = os.environ["PKG_LIVE_ROOT"]
+    if not live_root:
+        live_root = "/"
+    return live_root
+
 
 def spaceavail(path):
-        """Find out how much space is available at the specified path if
-        it exists; return -1 if path doesn't exist"""
-        try:
-                res = os.statvfs(path)
-                return res.f_frsize * res.f_bavail
-        except OSError:
-                return -1
+    """Find out how much space is available at the specified path if
+    it exists; return -1 if path doesn't exist"""
+    try:
+        res = os.statvfs(path)
+        return res.f_frsize * res.f_bavail
+    except OSError:
+        return -1
+
 
 def get_dir_size(path):
-        """Return the size (in bytes) of a directory and all of its contents."""
-        try:
-                return sum(
-                    os.path.getsize(os.path.join(d, fname))
-                    for d, dnames, fnames in os.walk(path)
-                    for fname in fnames
+    """Return the size (in bytes) of a directory and all of its contents."""
+    try:
+        return sum(
+            os.path.getsize(os.path.join(d, fname))
+            for d, dnames, fnames in os.walk(path)
+            for fname in fnames
+        )
+    except EnvironmentError as e:
+        # Access to protected member; pylint: disable=W0212
+        raise api_errors._convert_error(e)
+
+
+def get_listing(
+    desired_field_order,
+    field_data,
+    field_values,
+    out_format,
+    def_fmt,
+    omit_headers,
+    escape_output=True,
+):
+    """Returns a string containing a listing defined by provided values
+    in the specified output format.
+
+    'desired_field_order' is the list of the fields to show in the order
+    they should be output left to right.
+
+    'field_data' is a dictionary of lists of the form:
+      {
+        field_name1: {
+          [(output formats), field header, initial field value]
+        },
+        field_nameN: {
+          [(output formats), field header, initial field value]
+        }
+      }
+
+    'field_values' is a generator or list of dictionaries of the form:
+      {
+        field_name1: field_value,
+        field_nameN: field_value
+      }
+
+    'out_format' is the format to use for output.  Currently 'default',
+    'tsv', 'json', and 'json-formatted' are supported.  The first is
+    intended for columnar, human-readable output, and the others for
+    parsable output.
+
+    'def_fmt' is the default Python formatting string to use for the
+    'default' human-readable output.  It must match the fields defined
+    in 'field_data'.
+
+    'omit_headers' is a boolean specifying whether headers should be
+    included in the listing.  (If applicable to the specified output
+    format.)
+
+    'escape_output' is an optional boolean indicating whether shell
+    metacharacters or embedded control sequences should be escaped
+    before display.  (If applicable to the specified output format.)
+    """
+    # Missing docstring; pylint: disable=C0111
+
+    # Custom key function for preserving field ordering
+    def key_fields(item):
+        return desired_field_order.index(get_header(item))
+
+    # Functions for manipulating field_data records
+    def filter_default(record):
+        return "default" in record[0]
+
+    def filter_tsv(record):
+        return "tsv" in record[0]
+
+    def get_header(record):
+        return record[1]
+
+    def get_value(record):
+        return record[2]
+
+    def quote_value(val):
+        if out_format == "tsv":
+            # Expand tabs if tsv output requested.
+            val = val.replace("\t", " " * 8)
+        nval = val
+        # Escape bourne shell metacharacters.
+        for c in (
+            "\\",
+            " ",
+            "\t",
+            "\n",
+            "'",
+            "`",
+            ";",
+            "&",
+            "(",
+            ")",
+            "|",
+            "^",
+            "<",
+            ">",
+        ):
+            nval = nval.replace(c, "\\" + c)
+        return nval
+
+    def set_value(entry):
+        val = entry[1]
+        multi_value = False
+        if isinstance(val, (list, tuple, set, frozenset)):
+            multi_value = True
+        elif val == "":
+            entry[0][2] = '""'
+            return
+        elif val is None:
+            entry[0][2] = ""
+            return
+        else:
+            val = [val]
+
+        nval = []
+        for v in val:
+            if v == "":
+                # Indicate empty string value using "".
+                nval.append('""')
+            elif v is None:
+                # Indicate no value using empty string.
+                nval.append("")
+            elif escape_output:
+                # Otherwise, escape the value to be displayed.
+                nval.append(quote_value(str(v)))
+            else:
+                # Caller requested value not be escaped.
+                nval.append(str(v))
+
+        val = " ".join(nval)
+        nval = None
+        if multi_value:
+            val = "({0})".format(val)
+        entry[0][2] = val
+
+    if out_format == "default":
+        # Create a formatting string for the default output
+        # format.
+        fmt = def_fmt
+        filter_func = filter_default
+    elif out_format == "tsv":
+        # Create a formatting string for the tsv output
+        # format.
+        num_fields = sum(1 for k in field_data if filter_tsv(field_data[k]))
+        fmt = "\t".join("{{{0}}}".format(x) for x in range(num_fields))
+        filter_func = filter_tsv
+    elif out_format == "json" or out_format == "json-formatted":
+        args = {"sort_keys": True}
+        if out_format == "json-formatted":
+            args["indent"] = 2
+
+        # 'json' formats always include any extra fields returned;
+        # any explicitly named fields are only included if 'json'
+        # is explicitly listed.
+        def fmt_val(v):
+            if isinstance(v, six.string_types):
+                return v
+            if isinstance(v, (list, tuple, set, frozenset)):
+                return [fmt_val(e) for e in v]
+            if isinstance(v, dict):
+                for k, e in six.iteritems(v):
+                    v[k] = fmt_val(e)
+                return v
+            return str(v)
+
+        output = json.dumps(
+            [
+                dict(
+                    (k, fmt_val(entry[k]))
+                    for k in entry
+                    if k not in field_data or "json" in field_data[k][0]
                 )
-        except EnvironmentError as e:
-                # Access to protected member; pylint: disable=W0212
-                raise api_errors._convert_error(e)
+                for entry in field_values
+            ],
+            **args  # fmt: skip
+        )
 
-def get_listing(desired_field_order, field_data, field_values, out_format,
-    def_fmt, omit_headers, escape_output=True):
-        """Returns a string containing a listing defined by provided values
-        in the specified output format.
+        if out_format == "json-formatted":
+            # Include a trailing newline for readability.
+            return output + "\n"
+        return output
 
-        'desired_field_order' is the list of the fields to show in the order
-        they should be output left to right.
+    # Extract the list of headers from the field_data dictionary.  Ensure
+    # they are extracted in the desired order by using the custom sort
+    # function.
+    hdrs = map(
+        get_header,
+        sorted(filter(filter_func, field_data.values()), key=key_fields),
+    )
 
-        'field_data' is a dictionary of lists of the form:
-          {
-            field_name1: {
-              [(output formats), field header, initial field value]
-            },
-            field_nameN: {
-              [(output formats), field header, initial field value]
-            }
-          }
+    # Output a header if desired.
+    output = ""
+    if not omit_headers:
+        output += fmt.format(*hdrs)
+        output += "\n"
 
-        'field_values' is a generator or list of dictionaries of the form:
-          {
-            field_name1: field_value,
-            field_nameN: field_value
-          }
-
-        'out_format' is the format to use for output.  Currently 'default',
-        'tsv', 'json', and 'json-formatted' are supported.  The first is
-        intended for columnar, human-readable output, and the others for
-        parsable output.
-
-        'def_fmt' is the default Python formatting string to use for the
-        'default' human-readable output.  It must match the fields defined
-        in 'field_data'.
-
-        'omit_headers' is a boolean specifying whether headers should be
-        included in the listing.  (If applicable to the specified output
-        format.)
-
-        'escape_output' is an optional boolean indicating whether shell
-        metacharacters or embedded control sequences should be escaped
-        before display.  (If applicable to the specified output format.)
-        """
-        # Missing docstring; pylint: disable=C0111
-
-        # Custom key function for preserving field ordering
-        def key_fields(item):
-                return desired_field_order.index(get_header(item))
-
-        # Functions for manipulating field_data records
-        def filter_default(record):
-                return "default" in record[0]
-
-        def filter_tsv(record):
-                return "tsv" in record[0]
-
-        def get_header(record):
-                return record[1]
-
-        def get_value(record):
-                return record[2]
-
-        def quote_value(val):
-                if out_format == "tsv":
-                        # Expand tabs if tsv output requested.
-                        val = val.replace("\t", " " * 8)
-                nval = val
-                # Escape bourne shell metacharacters.
-                for c in ("\\", " ", "\t", "\n", "'", "`", ";", "&", "(", ")",
-                    "|", "^", "<", ">"):
-                        nval = nval.replace(c, "\\" + c)
-                return nval
-
-        def set_value(entry):
-                val = entry[1]
-                multi_value = False
-                if isinstance(val, (list, tuple, set, frozenset)):
-                        multi_value = True
-                elif val == "":
-                        entry[0][2] = '""'
-                        return
-                elif val is None:
-                        entry[0][2] = ''
-                        return
-                else:
-                        val = [val]
-
-                nval = []
-                for v in val:
-                        if v == "":
-                                # Indicate empty string value using "".
-                                nval.append('""')
-                        elif v is None:
-                                # Indicate no value using empty string.
-                                nval.append('')
-                        elif escape_output:
-                                # Otherwise, escape the value to be displayed.
-                                nval.append(quote_value(str(v)))
-                        else:
-                                # Caller requested value not be escaped.
-                                nval.append(str(v))
-
-                val = " ".join(nval)
-                nval = None
-                if multi_value:
-                        val = "({0})".format(val)
-                entry[0][2] = val
-
-        if out_format == "default":
-                # Create a formatting string for the default output
-                # format.
-                fmt = def_fmt
-                filter_func = filter_default
-        elif out_format == "tsv":
-                # Create a formatting string for the tsv output
-                # format.
-                num_fields = sum(
-                    1 for k in field_data
-                    if filter_tsv(field_data[k])
-                )
-                fmt = "\t".join('{{{0}}}'.format(x) for x in range(num_fields))
-                filter_func = filter_tsv
-        elif out_format == "json" or out_format == "json-formatted":
-                args = { "sort_keys": True }
-                if out_format == "json-formatted":
-                        args["indent"] = 2
-
-                # 'json' formats always include any extra fields returned;
-                # any explicitly named fields are only included if 'json'
-                # is explicitly listed.
-                def fmt_val(v):
-                        if isinstance(v, six.string_types):
-                                return v
-                        if isinstance(v, (list, tuple, set, frozenset)):
-                                return [fmt_val(e) for e in v]
-                        if isinstance(v, dict):
-                                for k, e in six.iteritems(v):
-                                        v[k] = fmt_val(e)
-                                return v
-                        return str(v)
-
-                output = json.dumps([
-                    dict(
-                        (k, fmt_val(entry[k]))
-                        for k in entry
-                        if k not in field_data or "json" in field_data[k][0]
-                    )
-                    for entry in field_values
-                ], **args)
-
-                if out_format == "json-formatted":
-                        # Include a trailing newline for readability.
-                        return output + "\n"
-                return output
-
-        # Extract the list of headers from the field_data dictionary.  Ensure
-        # they are extracted in the desired order by using the custom sort
-        # function.
-        hdrs = map(get_header, sorted(filter(filter_func,
-            field_data.values()), key=key_fields))
-
-        # Output a header if desired.
-        output = ""
-        if not omit_headers:
-                output += fmt.format(*hdrs)
-                output += "\n"
-
-        for entry in field_values:
-                # In Python 3, map() returns an iterator and will not process
-                # elements unless being called, so we turn it into a list to
-                # force it to process elements.
-                list(map(set_value, (
+    for entry in field_values:
+        # In Python 3, map() returns an iterator and will not process
+        # elements unless being called, so we turn it into a list to
+        # force it to process elements.
+        list(
+            map(
+                set_value,
+                (
                     (field_data[f], v)
                     for f, v in six.iteritems(entry)
                     if f in field_data
-                )))
-                values = map(get_value, sorted(filter(filter_func,
-                    field_data.values()), key=key_fields))
-                output += fmt.format(*values)
-                output += "\n"
+                ),
+            )
+        )
+        values = map(
+            get_value,
+            sorted(filter(filter_func, field_data.values()), key=key_fields),
+        )
+        output += fmt.format(*values)
+        output += "\n"
 
-        return output
+    return output
+
 
 def truncate_file(f, size=0):
-        """Truncate the specified file."""
-        try:
-                f.truncate(size)
-        except IOError:
-                pass
-        except OSError as e:
-                # Access to protected member; pylint: disable=W0212
-                raise api_errors._convert_error(e)
+    """Truncate the specified file."""
+    try:
+        f.truncate(size)
+    except IOError:
+        pass
+    except OSError as e:
+        # Access to protected member; pylint: disable=W0212
+        raise api_errors._convert_error(e)
+
 
 def flush_output():
-        """flush stdout and stderr"""
+    """flush stdout and stderr"""
 
-        try:
-                sys.stdout.flush()
-        except IOError:
-                pass
-        except OSError as e:
-                # Access to protected member; pylint: disable=W0212
-                raise api_errors._convert_error(e)
+    try:
+        sys.stdout.flush()
+    except IOError:
+        pass
+    except OSError as e:
+        # Access to protected member; pylint: disable=W0212
+        raise api_errors._convert_error(e)
 
-        try:
-                sys.stderr.flush()
-        except IOError:
-                pass
-        except OSError as e:
-                # Access to protected member; pylint: disable=W0212
-                raise api_errors._convert_error(e)
+    try:
+        sys.stderr.flush()
+    except IOError:
+        pass
+    except OSError as e:
+        # Access to protected member; pylint: disable=W0212
+        raise api_errors._convert_error(e)
+
 
 # valid json types
-json_types_immediates = (bool, float, six.integer_types, six.string_types,
-    type(None))
+json_types_immediates = (
+    bool,
+    float,
+    six.integer_types,
+    six.string_types,
+    type(None),
+)
 json_types_collections = (dict, list)
 json_types = tuple(json_types_immediates + json_types_collections)
 json_debug = False
 
+
 def json_encode(name, data, desc, commonize=None, je_state=None):
-        """A generic json encoder.
+    """A generic json encoder.
 
-        'name' a descriptive name of the data we're encoding.  If encoding a
-        class, this would normally be the class name.  'name' is used when
-        displaying errors to identify the data that caused the errors.
+    'name' a descriptive name of the data we're encoding.  If encoding a
+    class, this would normally be the class name.  'name' is used when
+    displaying errors to identify the data that caused the errors.
 
-        'data' data to encode.
+    'data' data to encode.
 
-        'desc' a description of the data to encode.
+    'desc' a description of the data to encode.
 
-        'commonize' a list of objects that should be cached by reference.
-        this is used when encoding objects which may contain multiple
-        references to a single object.  In this case, each reference will be
-        replaced with a unique id, and the object that was pointed to will
-        only be encoded once.  This ensures that upon decoding we can restore
-        the original object and all references to it."""
+    'commonize' a list of objects that should be cached by reference.
+    this is used when encoding objects which may contain multiple
+    references to a single object.  In this case, each reference will be
+    replaced with a unique id, and the object that was pointed to will
+    only be encoded once.  This ensures that upon decoding we can restore
+    the original object and all references to it."""
+
+    # debugging
+    if je_state is None and json_debug:
+        print("json_encode name: ", name, file=sys.stderr)
+        print("json_encode data: ", data, file=sys.stderr)
+
+    # we don't encode None
+    if data is None:
+        return None
+
+    # initialize parameters to default
+    if commonize is None:
+        commonize = frozenset()
+
+    if je_state is None:
+        # this is the first invocation of this function, so "data"
+        # points to the top-level object that we want to encode.  this
+        # means that if we're commonizing any objects we should
+        # finalize the object cache when we're done encoding this
+        # object.
+        finish = True
+
+        # initialize recursion state
+        obj_id = [0]
+        obj_cache = {}
+        je_state = [obj_id, obj_cache, commonize]
+    else:
+        # we're being invoked recursively, do not finalize the object
+        # cache (since that will be done by a previous invocation of
+        # this function).
+        finish = False
+
+        # get recursion state
+        obj_id, obj_cache, commonize_old = je_state
+
+        # check if we're changing the set of objects to commonize
+        if not commonize:
+            commonize = commonize_old
+        else:
+            # update the set of objects to commonize
+            # make a copy so we don't update our callers state
+            commonize = frozenset(commonize_old | commonize)
+            je_state = [obj_id, obj_cache, commonize]
+
+    # verify state
+    assert type(name) == str
+    assert type(obj_cache) == dict
+    assert type(obj_id) == list and len(obj_id) == 1 and obj_id[0] >= 0
+    assert type(commonize) == frozenset
+    assert type(je_state) == list and len(je_state) == 3
+
+    def je_return(name, data, finish, je_state):
+        """if necessary, finalize the object cache and merge it into
+        the state data.
+
+        while encoding, the object cache is a dictionary which
+        contains tuples consisting of an assigned unique object id
+        (obj_id) and an encoded object.  these tuples are hashed by
+        the python object id of the original un-encoded python object.
+        so the hash contains:
+
+               { id(<obj>): ( <obj_id>, <obj_state> ) }
+
+        when we finish the object cache we update it so that it
+        contains just encoded objects hashed by their assigned object
+        id (obj_id).  so the hash contains:
+
+               { str(<obj_id>): <obj_state> }
+
+        then we merge the state data and object cache into a single
+        dictionary and return that.
+        """
+        # Unused argument; pylint: disable=W0613
+
+        if not finish:
+            return data
+
+        # json.dump converts integer dictionary keys into strings, so
+        # we'll convert the object id keys (which are integers) into
+        # strings (that way we're encoder/decoder independent).
+        obj_cache = je_state[1]
+        obj_cache2 = {}
+        for obj_id, obj_state in six.itervalues(obj_cache):
+            obj_cache2[str(obj_id)] = obj_state
+
+        data = {"json_state": data, "json_objects": obj_cache2}
+
+        # Value 'DebugValues' is unsubscriptable;
+        # pylint: disable=E1136
+        if DebugValues["plandesc_validate"]:
+            json_validate(name, data)
 
         # debugging
-        if je_state is None and json_debug:
-                print("json_encode name: ", name, file=sys.stderr)
-                print("json_encode data: ", data, file=sys.stderr)
+        if json_debug:
+            print("json_encode finished name: ", name, file=sys.stderr)
+            print("json_encode finished data: ", data, file=sys.stderr)
 
-        # we don't encode None
-        if data is None:
-                return None
+        return data
 
-        # initialize parameters to default
-        if commonize is None:
-                commonize = frozenset()
+    # check if the description is a type object
+    if isinstance(desc, type):
+        desc_type = desc
+    else:
+        # get the expected data type from the description
+        desc_type = type(desc)
 
-        if je_state is None:
-                # this is the first invocation of this function, so "data"
-                # points to the top-level object that we want to encode.  this
-                # means that if we're commonizing any objects we should
-                # finalize the object cache when we're done encoding this
-                # object.
-                finish = True
+    # get the data type
+    data_type = getattr(data, "__metaclass__", type(data))
 
-                # initialize recursion state
-                obj_id = [0]
-                obj_cache = {}
-                je_state = [obj_id, obj_cache, commonize]
+    # sanity check that the data type matches the description
+    assert issubclass(
+        data_type, desc_type
+    ), "unexpected {0} for {1}, expected: {2}, value: {3}".format(
+        data_type, name, desc_type, data
+    )
+
+    # The following situation is only true for Python 2.
+    # We should not see unicode strings getting passed in. The assert is
+    # necessary since we use the PkgDecoder hook function during json_decode
+    # to convert unicode objects back into escaped str objects, which would
+    # otherwise do that conversion unintentionally.
+    if six.PY2:
+        assert not isinstance(
+            data_type, six.text_type
+        ), "unexpected unicode string: {0}".format(data)
+
+    # we don't need to do anything for basic types
+    for t in json_types_immediates:
+        if issubclass(desc_type, t):
+            return je_return(name, data, finish, je_state)
+
+    # encode elements nested in a dictionary like object
+    # return elements in a dictionary
+    if desc_type in (dict, collections.defaultdict):
+        # we always return a new dictionary
+        rv = {}
+
+        # check if we're not encoding nested elements
+        if len(desc) == 0:
+            rv.update(data)
+            return je_return(name, rv, finish, je_state)
+
+        # lookup the first descriptor to see if we have
+        # generic type description.
+        desc_k, desc_v = list(desc.items())[0]
+
+        # if the key in the first type pair is a type then we
+        # have a generic type description that applies to all
+        # keys and values in the dictionary.
+        # check if the description is a type object
+        if isinstance(desc_k, type):
+            # there can only be one generic type desc
+            assert len(desc) == 1
+
+            # encode all key / value pairs
+            for k, v in six.iteritems(data):
+                # encode the key
+                name2 = "{0}[{1}].key()".format(name, desc_k)
+                k2 = json_encode(name2, k, desc_k, je_state=je_state)
+
+                # encode the value
+                name2 = "{0}[{1}].value()".format(name, desc_k)
+                v2 = json_encode(name2, v, desc_v, je_state=je_state)
+
+                # save the result
+                rv[k2] = v2
+            return je_return(name, rv, finish, je_state)
+
+        # we have element specific value type descriptions.
+        # encode the specific values.
+        rv.update(data)
+        for desc_k, desc_v in six.iteritems(desc):
+            # check for the specific key
+            if desc_k not in rv:
+                continue
+
+            # encode the value
+            name2 = "{0}[{1}].value()".format(name, desc_k)
+            rv[desc_k] = json_encode(
+                name2, rv[desc_k], desc_v, je_state=je_state
+            )
+        return je_return(name, rv, finish, je_state)
+
+    # encode elements nested in a list like object
+    # return elements in a list
+    if desc_type in (tuple, list, set, frozenset):
+        # we always return a new list
+        rv = []
+
+        # check for an empty list since we use izip_longest(zip_longest
+        # in python 3)
+        if len(data) == 0:
+            return je_return(name, rv, finish, je_state)
+
+        # check if we're not encoding nested elements
+        if len(desc) == 0:
+            rv.extend(data)
+            return je_return(name, rv, finish, je_state)
+
+        # don't accidentally generate data via izip_longest(zip_longest
+        # in python 3)
+        assert len(data) >= len(desc), "{0:d} >= {1:d}".format(
+            len(data), len(desc)
+        )
+
+        i = 0
+        for data2, desc2 in zip_longest(data, desc, fillvalue=list(desc)[0]):
+            name2 = "{0}[{1:d}]".format(name, i)
+            i += 1
+            rv.append(json_encode(name2, data2, desc2, je_state=je_state))
+        return je_return(name, rv, finish, je_state)
+
+    # if we're commonizing this object and it's already been encoded then
+    # just return its encoded object id.
+    if desc_type in commonize and id(data) in obj_cache:
+        rv = obj_cache[id(data)][0]
+        return je_return(name, rv, finish, je_state)
+
+    # find an encoder for this class, which should be:
+    #     <class>.getstate(obj, je_state)
+    encoder = getattr(desc_type, "getstate", None)
+    assert encoder is not None, "no json encoder for: {0}".format(desc_type)
+
+    # encode the data
+    rv = encoder(data, je_state)
+    assert rv is not None, "json encoder returned none for: {0}".format(
+        desc_type
+    )
+
+    # if we're commonizing this object, then assign it an object id and
+    # save that object id and the encoded object into the object cache
+    # (which is indexed by the python id for the object).
+    if desc_type in commonize:
+        obj_cache[id(data)] = (obj_id[0], rv)
+        rv = obj_id[0]
+        obj_id[0] += 1
+
+    # return the encoded element
+    return je_return(name, rv, finish, je_state)
+
+
+def json_decode(name, data, desc, commonize=None, jd_state=None):
+    """A generic json decoder.
+
+    'name' a descriptive name of the data.  (used to identify unexpected
+    data errors.)
+
+    'desc' a programmatic description of data types.
+
+    'data' data to decode."""
+
+    # debugging
+    if jd_state is None and json_debug:
+        print("json_decode name: ", name, file=sys.stderr)
+        print("json_decode data: ", data, file=sys.stderr)
+
+    # we don't decode None
+    if data is None:
+        return data
+
+    # initialize parameters to default
+    if commonize is None:
+        commonize = frozenset()
+
+    if jd_state is None:
+        # this is the first invocation of this function, so when we
+        # return we're done decoding data.
+        finish = True
+
+        # first time here, initialize recursion state
+        if not commonize:
+            # no common state
+            obj_cache = {}
         else:
-                # we're being invoked recursively, do not finalize the object
-                # cache (since that will be done by a previous invocation of
-                # this function).
-                finish = False
+            # load commonized state
+            obj_cache = data["json_objects"]
+            data = data["json_state"]
+        jd_state = [obj_cache, commonize]
+    else:
+        # we're being invoked recursively.
+        finish = False
 
-                # get recursion state
-                obj_id, obj_cache, commonize_old = je_state
+        obj_cache, commonize_old = jd_state
 
-                # check if we're changing the set of objects to commonize
-                if not commonize:
-                        commonize = commonize_old
-                else:
-                        # update the set of objects to commonize
-                        # make a copy so we don't update our callers state
-                        commonize = frozenset(commonize_old | commonize)
-                        je_state = [obj_id, obj_cache, commonize]
+        # check if the first object using commonization
+        if not commonize_old and commonize:
+            obj_cache = data["json_objects"]
+            data = data["json_state"]
 
-        # verify state
-        assert type(name) == str
-        assert type(obj_cache) == dict
-        assert type(obj_id) == list and len(obj_id) == 1 and obj_id[0] >= 0
-        assert type(commonize) == frozenset
-        assert type(je_state) == list and len(je_state) == 3
+        # merge in any new commonize requests
+        je_state_changed = False
 
-        def je_return(name, data, finish, je_state):
-                """if necessary, finalize the object cache and merge it into
-                the state data.
+        # check if we're updating the set of objects to commonize
+        if not commonize:
+            commonize = commonize_old
+        else:
+            # update the set of objects to commonize
+            # make a copy so we don't update our callers state.
+            commonize = frozenset(commonize_old | commonize)
+            je_state_changed = True
 
-                while encoding, the object cache is a dictionary which
-                contains tuples consisting of an assigned unique object id
-                (obj_id) and an encoded object.  these tuples are hashed by
-                the python object id of the original un-encoded python object.
-                so the hash contains:
+        if je_state_changed:
+            jd_state = [obj_cache, commonize]
 
-                       { id(<obj>): ( <obj_id>, <obj_state> ) }
+    # verify state
+    assert type(name) == str, "type(name) == {0}".format(type(name))
+    assert type(obj_cache) == dict
+    assert type(commonize) == frozenset
+    assert type(jd_state) == list and len(jd_state) == 2
 
-                when we finish the object cache we update it so that it
-                contains just encoded objects hashed by their assigned object
-                id (obj_id).  so the hash contains:
-
-                       { str(<obj_id>): <obj_state> }
-
-                then we merge the state data and object cache into a single
-                dictionary and return that.
-                """
-                # Unused argument; pylint: disable=W0613
-
-                if not finish:
-                        return data
-
-                # json.dump converts integer dictionary keys into strings, so
-                # we'll convert the object id keys (which are integers) into
-                # strings (that way we're encoder/decoder independent).
-                obj_cache = je_state[1]
-                obj_cache2 = {}
-                for obj_id, obj_state in six.itervalues(obj_cache):
-                        obj_cache2[str(obj_id)] = obj_state
-
-                data = { "json_state": data, "json_objects": obj_cache2 }
-
-                # Value 'DebugValues' is unsubscriptable;
-                # pylint: disable=E1136
-                if DebugValues["plandesc_validate"]:
-                        json_validate(name, data)
-
-                # debugging
-                if json_debug:
-                        print("json_encode finished name: ", name,
-                            file=sys.stderr)
-                        print("json_encode finished data: ", data,
-                            file=sys.stderr)
-
-                return data
+    def jd_return(name, data, desc, finish, jd_state):
+        """Check if we're done decoding data."""
+        # Unused argument; pylint: disable=W0613
 
         # check if the description is a type object
         if isinstance(desc, type):
-                desc_type = desc
+            desc_type = desc
         else:
-                # get the expected data type from the description
-                desc_type = type(desc)
+            # get the expected data type from the description
+            desc_type = type(desc)
 
         # get the data type
         data_type = getattr(data, "__metaclass__", type(data))
 
         # sanity check that the data type matches the description
-        assert issubclass(data_type, desc_type), \
-            "unexpected {0} for {1}, expected: {2}, value: {3}".format(
-                data_type, name, desc_type, data)
+        assert issubclass(
+            data_type, desc_type
+        ), "unexpected {0} for {1}, expected: {2}, value: {3}".format(
+            data_type, name, desc_type, data
+        )
 
-        # The following situation is only true for Python 2.
-        # We should not see unicode strings getting passed in. The assert is
-        # necessary since we use the PkgDecoder hook function during json_decode
-        # to convert unicode objects back into escaped str objects, which would
-        # otherwise do that conversion unintentionally.
-        if six.PY2:
-                assert not isinstance(data_type, six.text_type), \
-                    "unexpected unicode string: {0}".format(data)
-
-        # we don't need to do anything for basic types
-        for t in json_types_immediates:
-                if issubclass(desc_type, t):
-                        return je_return(name, data, finish, je_state)
-
-        # encode elements nested in a dictionary like object
-        # return elements in a dictionary
-        if desc_type in (dict, collections.defaultdict):
-                # we always return a new dictionary
-                rv = {}
-
-                # check if we're not encoding nested elements
-                if len(desc) == 0:
-                        rv.update(data)
-                        return je_return(name, rv, finish, je_state)
-
-                # lookup the first descriptor to see if we have
-                # generic type description.
-                desc_k, desc_v = list(desc.items())[0]
-
-                # if the key in the first type pair is a type then we
-                # have a generic type description that applies to all
-                # keys and values in the dictionary.
-                # check if the description is a type object
-                if isinstance(desc_k, type):
-                        # there can only be one generic type desc
-                        assert len(desc) == 1
-
-                        # encode all key / value pairs
-                        for k, v in six.iteritems(data):
-                                # encode the key
-                                name2 = "{0}[{1}].key()".format(name, desc_k)
-                                k2 = json_encode(name2, k, desc_k,
-                                    je_state=je_state)
-
-                                # encode the value
-                                name2 = "{0}[{1}].value()".format(name, desc_k)
-                                v2 = json_encode(name2, v, desc_v,
-                                    je_state=je_state)
-
-                                # save the result
-                                rv[k2] = v2
-                        return je_return(name, rv, finish, je_state)
-
-                # we have element specific value type descriptions.
-                # encode the specific values.
-                rv.update(data)
-                for desc_k, desc_v in six.iteritems(desc):
-                        # check for the specific key
-                        if desc_k not in rv:
-                                continue
-
-                        # encode the value
-                        name2 = "{0}[{1}].value()".format(name, desc_k)
-                        rv[desc_k] = json_encode(name2, rv[desc_k], desc_v,
-                            je_state=je_state)
-                return je_return(name, rv, finish, je_state)
-
-        # encode elements nested in a list like object
-        # return elements in a list
-        if desc_type in (tuple, list, set, frozenset):
-
-                # we always return a new list
-                rv = []
-
-                # check for an empty list since we use izip_longest(zip_longest
-                # in python 3)
-                if len(data) == 0:
-                        return je_return(name, rv, finish, je_state)
-
-                # check if we're not encoding nested elements
-                if len(desc) == 0:
-                        rv.extend(data)
-                        return je_return(name, rv, finish, je_state)
-
-                # don't accidentally generate data via izip_longest(zip_longest
-                # in python 3)
-                assert len(data) >= len(desc), \
-                    "{0:d} >= {1:d}".format(len(data), len(desc))
-
-                i = 0
-                for data2, desc2 in zip_longest(data, desc,
-                    fillvalue=list(desc)[0]):
-                        name2 = "{0}[{1:d}]".format(name, i)
-                        i += 1
-                        rv.append(json_encode(name2, data2, desc2,
-                            je_state=je_state))
-                return je_return(name, rv, finish, je_state)
-
-        # if we're commonizing this object and it's already been encoded then
-        # just return its encoded object id.
-        if desc_type in commonize and id(data) in obj_cache:
-                rv = obj_cache[id(data)][0]
-                return je_return(name, rv, finish, je_state)
-
-        # find an encoder for this class, which should be:
-        #     <class>.getstate(obj, je_state)
-        encoder = getattr(desc_type, "getstate", None)
-        assert encoder is not None, "no json encoder for: {0}".format(desc_type)
-
-        # encode the data
-        rv = encoder(data, je_state)
-        assert rv is not None, "json encoder returned none for: {0}".format(
-            desc_type)
-
-        # if we're commonizing this object, then assign it an object id and
-        # save that object id and the encoded object into the object cache
-        # (which is indexed by the python id for the object).
-        if desc_type in commonize:
-                obj_cache[id(data)] = (obj_id[0], rv)
-                rv = obj_id[0]
-                obj_id[0] += 1
-
-        # return the encoded element
-        return je_return(name, rv, finish, je_state)
-
-def json_decode(name, data, desc, commonize=None, jd_state=None):
-        """A generic json decoder.
-
-        'name' a descriptive name of the data.  (used to identify unexpected
-        data errors.)
-
-        'desc' a programmatic description of data types.
-
-        'data' data to decode."""
+        if not finish:
+            return data
 
         # debugging
-        if jd_state is None and json_debug:
-                print("json_decode name: ", name, file=sys.stderr)
-                print("json_decode data: ", data, file=sys.stderr)
+        if json_debug:
+            print("json_decode finished name: ", name, file=sys.stderr)
+            print("json_decode finished data: ", data, file=sys.stderr)
+        return data
 
-        # we don't decode None
-        if data is None:
-                return data
+    # check if the description is a type object
+    if isinstance(desc, type):
+        desc_type = desc
+    else:
+        # get the expected data type from the description
+        desc_type = type(desc)
 
-        # initialize parameters to default
-        if commonize is None:
-                commonize = frozenset()
+    # we don't need to do anything for basic types
+    for t in json_types_immediates:
+        if issubclass(desc_type, t):
+            return jd_return(name, data, desc, finish, jd_state)
 
-        if jd_state is None:
-                # this is the first invocation of this function, so when we
-                # return we're done decoding data.
-                finish = True
+    # decode elements nested in a dictionary
+    # return elements in the specified dictionary like object
+    if isinstance(desc, dict):
+        # allocate the return object.  we don't just use
+        # type(desc) because that won't work for things like
+        # collections.defaultdict types.
+        rv = desc.copy()
+        rv.clear()
 
-                # first time here, initialize recursion state
-                if not commonize:
-                        # no common state
-                        obj_cache = {}
-                else:
-                        # load commonized state
-                        obj_cache = data["json_objects"]
-                        data = data["json_state"]
-                jd_state = [obj_cache, commonize]
-        else:
-                # we're being invoked recursively.
-                finish = False
+        # check if we're not decoding nested elements
+        if len(desc) == 0:
+            rv.update(data)
+            return jd_return(name, rv, desc, finish, jd_state)
 
-                obj_cache, commonize_old = jd_state
+        # lookup the first descriptor to see if we have
+        # generic type description.
+        desc_k, desc_v = list(desc.items())[0]
 
-                # check if the first object using commonization
-                if not commonize_old and commonize:
-                        obj_cache = data["json_objects"]
-                        data = data["json_state"]
-
-                # merge in any new commonize requests
-                je_state_changed = False
-
-                # check if we're updating the set of objects to commonize
-                if not commonize:
-                        commonize = commonize_old
-                else:
-                        # update the set of objects to commonize
-                        # make a copy so we don't update our callers state.
-                        commonize = frozenset(commonize_old | commonize)
-                        je_state_changed = True
-
-                if je_state_changed:
-                        jd_state = [obj_cache, commonize]
-
-        # verify state
-        assert type(name) == str, "type(name) == {0}".format(type(name))
-        assert type(obj_cache) == dict
-        assert type(commonize) == frozenset
-        assert type(jd_state) == list and len(jd_state) == 2
-
-        def jd_return(name, data, desc, finish, jd_state):
-                """Check if we're done decoding data."""
-                # Unused argument; pylint: disable=W0613
-
-                # check if the description is a type object
-                if isinstance(desc, type):
-                        desc_type = desc
-                else:
-                        # get the expected data type from the description
-                        desc_type = type(desc)
-
-                # get the data type
-                data_type = getattr(data, "__metaclass__", type(data))
-
-                # sanity check that the data type matches the description
-                assert issubclass(data_type, desc_type), \
-                    "unexpected {0} for {1}, expected: {2}, value: {3}".format(
-                        data_type, name, desc_type, data)
-
-                if not finish:
-                        return data
-
-                # debugging
-                if json_debug:
-                        print("json_decode finished name: ", name,
-                            file=sys.stderr)
-                        print("json_decode finished data: ", data,
-                            file=sys.stderr)
-                return data
-
+        # if the key in the descriptor is a type then we have
+        # a generic type description that applies to all keys
+        # and values in the dictionary.
         # check if the description is a type object
-        if isinstance(desc, type):
-                desc_type = desc
-        else:
-                # get the expected data type from the description
-                desc_type = type(desc)
+        if isinstance(desc_k, type):
+            # there can only be one generic type desc
+            assert len(desc) == 1
 
-        # we don't need to do anything for basic types
-        for t in json_types_immediates:
-                if issubclass(desc_type, t):
-                        return jd_return(name, data, desc, finish, jd_state)
+            # decode all key / value pairs
+            for k, v in six.iteritems(data):
+                # decode the key
+                name2 = "{0}[{1}].key()".format(name, desc_k)
+                k2 = json_decode(name2, k, desc_k, jd_state=jd_state)
 
-        # decode elements nested in a dictionary
-        # return elements in the specified dictionary like object
-        if isinstance(desc, dict):
+                # decode the value
+                name2 = "{0}[{1}].value()".format(name, desc_k)
+                v2 = json_decode(name2, v, desc_v, jd_state=jd_state)
 
-                # allocate the return object.  we don't just use
-                # type(desc) because that won't work for things like
-                # collections.defaultdict types.
-                rv = desc.copy()
-                rv.clear()
+                # save the result
+                rv[k2] = v2
+            return jd_return(name, rv, desc, finish, jd_state)
 
-                # check if we're not decoding nested elements
-                if len(desc) == 0:
-                        rv.update(data)
-                        return jd_return(name, rv, desc, finish, jd_state)
+        # we have element specific value type descriptions.
+        # copy all data and then decode the specific values
+        rv.update(data)
+        for desc_k, desc_v in six.iteritems(desc):
+            # check for the specific key
+            if desc_k not in rv:
+                continue
 
-                # lookup the first descriptor to see if we have
-                # generic type description.
-                desc_k, desc_v = list(desc.items())[0]
-
-                # if the key in the descriptor is a type then we have
-                # a generic type description that applies to all keys
-                # and values in the dictionary.
-                # check if the description is a type object
-                if isinstance(desc_k, type):
-                        # there can only be one generic type desc
-                        assert len(desc) == 1
-
-                        # decode all key / value pairs
-                        for k, v in six.iteritems(data):
-                                # decode the key
-                                name2 = "{0}[{1}].key()".format(name, desc_k)
-                                k2 = json_decode(name2, k, desc_k,
-                                    jd_state=jd_state)
-
-                                # decode the value
-                                name2 = "{0}[{1}].value()".format(name, desc_k)
-                                v2 = json_decode(name2, v, desc_v,
-                                    jd_state=jd_state)
-
-                                # save the result
-                                rv[k2] = v2
-                        return jd_return(name, rv, desc, finish, jd_state)
-
-                # we have element specific value type descriptions.
-                # copy all data and then decode the specific values
-                rv.update(data)
-                for desc_k, desc_v in six.iteritems(desc):
-                        # check for the specific key
-                        if desc_k not in rv:
-                                continue
-
-                        # decode the value
-                        name2 = "{0}[{1}].value()".format(name, desc_k)
-                        rv[desc_k] = json_decode(name2, rv[desc_k],
-                            desc_v, jd_state=jd_state)
-                return jd_return(name, rv, desc, finish, jd_state)
-
-        # decode elements nested in a list
-        # return elements in the specified list like object
-        if isinstance(desc, (tuple, list, set, frozenset)):
-                # get the return type
-                rvtype = type(desc)
-
-                # check for an empty list since we use izip_longest(zip_longest
-                # in python 3)
-                if len(data) == 0:
-                        rv = rvtype([])
-                        return jd_return(name, rv, desc, finish, jd_state)
-
-                # check if we're not decoding nested elements
-                if len(desc) == 0:
-                        rv = rvtype(data)
-                        return jd_return(name, rv, desc, finish, jd_state)
-
-                # don't accidentally generate data via izip_longest(zip_longest
-                # in python 3)
-                assert len(data) >= len(desc), \
-                    "{0:d} >= {1:d}".format(len(data), len(desc))
-
-                rv = []
-                i = 0
-                for data2, desc2 in zip_longest(data, desc,
-                    fillvalue=list(desc)[0]):
-                        name2 = "{0}[{1:d}]".format(name, i)
-                        i += 1
-                        rv.append(json_decode(name2, data2, desc2,
-                            jd_state=jd_state))
-                rv = rvtype(rv)
-                return jd_return(name, rv, desc, finish, jd_state)
-
-        # find a decoder for this data, which should be:
-        #     <class>.fromstate(state, jd_state)
-        decoder = getattr(desc_type, "fromstate", None)
-        assert decoder is not None, "no json decoder for: {0}".format(desc_type)
-
-        # if this object was commonized then get a reference to it from the
-        # object cache.
-        if desc_type in commonize:
-                assert type(data) == int
-                # json.dump converts integer dictionary keys into strings, so
-                # obj_cache was indexed by integer strings.
-                data = str(data)
-                rv = obj_cache[data]
-
-                # get the data type
-                data_type = getattr(rv, "__metaclass__", type(rv))
-
-                if data_type != desc_type:
-                        # this commonized object hasn't been decoded yet
-                        # decode it and update the cache with the decoded obj
-                        rv = decoder(rv, jd_state)
-                        obj_cache[data] = rv
-        else:
-                # decode the data
-                rv = decoder(data, jd_state)
-
+            # decode the value
+            name2 = "{0}[{1}].value()".format(name, desc_k)
+            rv[desc_k] = json_decode(
+                name2, rv[desc_k], desc_v, jd_state=jd_state
+            )
         return jd_return(name, rv, desc, finish, jd_state)
 
+    # decode elements nested in a list
+    # return elements in the specified list like object
+    if isinstance(desc, (tuple, list, set, frozenset)):
+        # get the return type
+        rvtype = type(desc)
+
+        # check for an empty list since we use izip_longest(zip_longest
+        # in python 3)
+        if len(data) == 0:
+            rv = rvtype([])
+            return jd_return(name, rv, desc, finish, jd_state)
+
+        # check if we're not decoding nested elements
+        if len(desc) == 0:
+            rv = rvtype(data)
+            return jd_return(name, rv, desc, finish, jd_state)
+
+        # don't accidentally generate data via izip_longest(zip_longest
+        # in python 3)
+        assert len(data) >= len(desc), "{0:d} >= {1:d}".format(
+            len(data), len(desc)
+        )
+
+        rv = []
+        i = 0
+        for data2, desc2 in zip_longest(data, desc, fillvalue=list(desc)[0]):
+            name2 = "{0}[{1:d}]".format(name, i)
+            i += 1
+            rv.append(json_decode(name2, data2, desc2, jd_state=jd_state))
+        rv = rvtype(rv)
+        return jd_return(name, rv, desc, finish, jd_state)
+
+    # find a decoder for this data, which should be:
+    #     <class>.fromstate(state, jd_state)
+    decoder = getattr(desc_type, "fromstate", None)
+    assert decoder is not None, "no json decoder for: {0}".format(desc_type)
+
+    # if this object was commonized then get a reference to it from the
+    # object cache.
+    if desc_type in commonize:
+        assert type(data) == int
+        # json.dump converts integer dictionary keys into strings, so
+        # obj_cache was indexed by integer strings.
+        data = str(data)
+        rv = obj_cache[data]
+
+        # get the data type
+        data_type = getattr(rv, "__metaclass__", type(rv))
+
+        if data_type != desc_type:
+            # this commonized object hasn't been decoded yet
+            # decode it and update the cache with the decoded obj
+            rv = decoder(rv, jd_state)
+            obj_cache[data] = rv
+    else:
+        # decode the data
+        rv = decoder(data, jd_state)
+
+    return jd_return(name, rv, desc, finish, jd_state)
+
+
 def json_validate(name, data):
-        """Validate that a named piece of data can be represented in json and
-        that the data can be passed directly to json.dump().  If the data
-        can't be represented as json we'll trigger an assert.
+    """Validate that a named piece of data can be represented in json and
+    that the data can be passed directly to json.dump().  If the data
+    can't be represented as json we'll trigger an assert.
 
-        'name' is the name of the data to validate
+    'name' is the name of the data to validate
 
-        'data' is the data to validate
+    'data' is the data to validate
 
-        'recurse' is an optional integer that controls recursion.  if it's a
-        negative number (the default) we recursively check any nested lists or
-        dictionaries.  if it's a positive integer than we only recurse to
-        the specified depth."""
+    'recurse' is an optional integer that controls recursion.  if it's a
+    negative number (the default) we recursively check any nested lists or
+    dictionaries.  if it's a positive integer than we only recurse to
+    the specified depth."""
 
-        assert isinstance(data, json_types), \
-            "invalid json type \"{0}\" for \"{1}\", value: {2}".format(
-            type(data), name, str(data))
+    assert isinstance(
+        data, json_types
+    ), 'invalid json type "{0}" for "{1}", value: {2}'.format(
+        type(data), name, str(data)
+    )
 
-        if type(data) == dict:
-                for k in data:
-                        # json.dump converts integer dictionary keys into
-                        # strings, which is a bit unexpected.  so make sure we
-                        # don't have any of those.
-                        assert type(k) != int, \
-                            "integer dictionary keys detected for: {0}".format(
-                                name)
+    if type(data) == dict:
+        for k in data:
+            # json.dump converts integer dictionary keys into
+            # strings, which is a bit unexpected.  so make sure we
+            # don't have any of those.
+            assert (
+                type(k) != int
+            ), "integer dictionary keys detected for: {0}".format(name)
 
-                        # validate the key and the value
-                        new_name = "{0}[{1}].key()".format(name, k)
-                        json_validate(new_name, k)
-                        new_name = "{0}[{1}].value()".format(name, k)
-                        json_validate(new_name, data[k])
+            # validate the key and the value
+            new_name = "{0}[{1}].key()".format(name, k)
+            json_validate(new_name, k)
+            new_name = "{0}[{1}].value()".format(name, k)
+            json_validate(new_name, data[k])
 
-        if type(data) == list:
-                for i in range(len(data)):
-                        new_name = "{0}[{1:d}]".format(name, i)
-                        json_validate(new_name, data[i])
+    if type(data) == list:
+        for i in range(len(data)):
+            new_name = "{0}[{1:d}]".format(name, i)
+            json_validate(new_name, data[i])
+
 
 def json_diff(name, d0, d1, alld0, alld1):
-        """Compare two json encoded objects to make sure they are
-        identical, assert() if they are not."""
+    """Compare two json encoded objects to make sure they are
+    identical, assert() if they are not."""
 
-        def dbg():
-                """dump debug info for json_diff"""
-                def d(s):
-                        """dbg helper"""
-                        return json.dumps(s, sort_keys=True, indent=4)
-                return "\n--- d0\n" + d(d0) + "\n+++ d1\n" + d(d1) + \
-                    "\n--- alld0\n" + d(alld0) + "\n+++ alld1\n" + d(alld1)
+    def dbg():
+        """dump debug info for json_diff"""
 
-        assert type(d0) == type(d1), ("Json data types differ for \"{0}\":\n"
-                "type 1: {1}\ntype 2: {2}\n").format(name, type(d0),
-                    type(d1)) + dbg()
+        def d(s):
+            """dbg helper"""
+            return json.dumps(s, sort_keys=True, indent=4)
 
-        if type(d0) == dict:
-                assert set(d0) == set(d1), (
-                   "Json dictionary keys differ for \"{0}\":\n"
-                   "dict 1 missing: {1}\n"
-                   "dict 2 missing: {2}\n").format(name,
-                   set(d1) - set(d0), set(d0) - set(d1)) + dbg()
+        return (
+            "\n--- d0\n"
+            + d(d0)
+            + "\n+++ d1\n"
+            + d(d1)
+            + "\n--- alld0\n"
+            + d(alld0)
+            + "\n+++ alld1\n"
+            + d(alld1)
+        )
 
-                for k in d0:
-                        new_name = "{0}[{1}]".format(name, k)
-                        json_diff(new_name, d0[k], d1[k], alld0, alld1)
+    assert type(d0) == type(d1), (
+        'Json data types differ for "{0}":\n' "type 1: {1}\ntype 2: {2}\n"
+    ).format(name, type(d0), type(d1)) + dbg()
 
-        if type(d0) == list:
-                assert len(d0) == len(d1), (
-                   "Json list lengths differ for \"{0}\":\n"
-                   "list 1 length: {1}\n"
-                   "list 2 length: {2}\n").format(name,
-                   len(d0), len(d1)) + dbg()
+    if type(d0) == dict:
+        assert set(d0) == set(d1), (
+            'Json dictionary keys differ for "{0}":\n'
+            "dict 1 missing: {1}\n"
+            "dict 2 missing: {2}\n"
+        ).format(name, set(d1) - set(d0), set(d0) - set(d1)) + dbg()
 
-                for i in range(len(d0)):
-                        new_name = "{0}[{1:d}]".format(name, i)
-                        json_diff(new_name, d0[i], d1[i], alld0, alld1)
+        for k in d0:
+            new_name = "{0}[{1}]".format(name, k)
+            json_diff(new_name, d0[k], d1[k], alld0, alld1)
+
+    if type(d0) == list:
+        assert len(d0) == len(d1), (
+            'Json list lengths differ for "{0}":\n'
+            "list 1 length: {1}\n"
+            "list 2 length: {2}\n"
+        ).format(name, len(d0), len(d1)) + dbg()
+
+        for i in range(len(d0)):
+            new_name = "{0}[{1:d}]".format(name, i)
+            json_diff(new_name, d0[i], d1[i], alld0, alld1)
+
 
 def json_hook(dct):
-        """Hook routine used by the JSON module to ensure that unicode objects
-        are converted to bytes objects in Python 2 and ensures that bytes
-        objects are converted to str objects in Python 3."""
+    """Hook routine used by the JSON module to ensure that unicode objects
+    are converted to bytes objects in Python 2 and ensures that bytes
+    objects are converted to str objects in Python 3."""
 
-        rvdct = {}
-        for k, v in six.iteritems(dct):
-                if isinstance(k, six.string_types):
-                        k = force_str(k)
-                if isinstance(v, six.string_types):
-                        v= force_str(v)
+    rvdct = {}
+    for k, v in six.iteritems(dct):
+        if isinstance(k, six.string_types):
+            k = force_str(k)
+        if isinstance(v, six.string_types):
+            v = force_str(v)
 
-                rvdct[k] = v
-        return rvdct
+        rvdct[k] = v
+    return rvdct
+
 
 class Timer(object):
-        """A class which can be used for measuring process times (user,
-        system, and wait)."""
+    """A class which can be used for measuring process times (user,
+    system, and wait)."""
 
-        __precision = 3
-        __log_fmt = "utime: {0:>7.3f}; stime: {1:>7.3f}; wtime: {2:>7.3f}"
-        __log_fmt_shift = "utime: {1:>7.3f}; stime: {2:>7.3f}; wtime: {3:>7.3f}"
+    __precision = 3
+    __log_fmt = "utime: {0:>7.3f}; stime: {1:>7.3f}; wtime: {2:>7.3f}"
+    __log_fmt_shift = "utime: {1:>7.3f}; stime: {2:>7.3f}; wtime: {3:>7.3f}"
 
-        def __init__(self, module):
-                self.__module = module
-                self.__timings = []
+    def __init__(self, module):
+        self.__module = module
+        self.__timings = []
 
-                # we initialize our time values to account for all time used
-                # since the start of the process.  (user and system time are
-                # obtained relative to process start time, but wall time is an
-                # absolute time value so here we initialize out initial wall
-                # time value to the time our process was started.)
-                self.__utime = self.__stime = 0
-                self.__wtime = _prstart()
+        # we initialize our time values to account for all time used
+        # since the start of the process.  (user and system time are
+        # obtained relative to process start time, but wall time is an
+        # absolute time value so here we initialize out initial wall
+        # time value to the time our process was started.)
+        self.__utime = self.__stime = 0
+        self.__wtime = _prstart()
 
-        def __zero1(self, delta):
-                """Return True if a number is zero (up to a certain level of
-                precision.)"""
-                return int(delta * (10 ** self.__precision)) == 0
+    def __zero1(self, delta):
+        """Return True if a number is zero (up to a certain level of
+        precision.)"""
+        return int(delta * (10**self.__precision)) == 0
 
-        def __zero(self, udelta, sdelta, wdelta):
-                """Return True if all the passed in values are zero."""
-                return self.__zero1(udelta) and \
-                    self.__zero1(sdelta) and \
-                    self.__zero1(wdelta)
+    def __zero(self, udelta, sdelta, wdelta):
+        """Return True if all the passed in values are zero."""
+        return (
+            self.__zero1(udelta)
+            and self.__zero1(sdelta)
+            and self.__zero1(wdelta)
+        )
 
-        def __str__(self):
-                s = "\nTimings for {0}: [\n".format(self.__module)
-                utotal = stotal = wtotal = 0
-                phases = [i[0] for i in self.__timings] + ["total"]
-                phase_width = max([len(i) for i in phases]) + 1
-                fmt = "  {{0:{0}}} {1};\n".format(phase_width,
-                    Timer.__log_fmt_shift)
-                for phase, udelta, sdelta, wdelta in self.__timings:
-                        if self.__zero(udelta, sdelta, wdelta):
-                                continue
-                        utotal += udelta
-                        stotal += sdelta
-                        wtotal += wdelta
-                        s += fmt.format(phase + ":", udelta, sdelta, wdelta)
-                s += fmt.format("total:", utotal, stotal, wtotal)
-                s += "]\n"
-                return s
+    def __str__(self):
+        s = "\nTimings for {0}: [\n".format(self.__module)
+        utotal = stotal = wtotal = 0
+        phases = [i[0] for i in self.__timings] + ["total"]
+        phase_width = max([len(i) for i in phases]) + 1
+        fmt = "  {{0:{0}}} {1};\n".format(phase_width, Timer.__log_fmt_shift)
+        for phase, udelta, sdelta, wdelta in self.__timings:
+            if self.__zero(udelta, sdelta, wdelta):
+                continue
+            utotal += udelta
+            stotal += sdelta
+            wtotal += wdelta
+            s += fmt.format(phase + ":", udelta, sdelta, wdelta)
+        s += fmt.format("total:", utotal, stotal, wtotal)
+        s += "]\n"
+        return s
 
-        def reset(self):
-                """Update saved times to current process values."""
-                self.__utime, self.__stime, self.__wtime = self.__get_time()
+    def reset(self):
+        """Update saved times to current process values."""
+        self.__utime, self.__stime, self.__wtime = self.__get_time()
 
-        @staticmethod
-        def __get_time():
-                """Get current user, system, and wait times for this
-                process."""
+    @staticmethod
+    def __get_time():
+        """Get current user, system, and wait times for this
+        process."""
 
-                rusage = resource.getrusage(resource.RUSAGE_SELF)
-                utime = rusage[0]
-                stime = rusage[1]
-                wtime = time.time()
-                return (utime, stime, wtime)
+        rusage = resource.getrusage(resource.RUSAGE_SELF)
+        utime = rusage[0]
+        stime = rusage[1]
+        wtime = time.time()
+        return (utime, stime, wtime)
 
-        def record(self, phase, logger=None):
-                """Record the difference between the previously saved process
-                time values and the current values.  Then update the saved
-                values to match the current values"""
+    def record(self, phase, logger=None):
+        """Record the difference between the previously saved process
+        time values and the current values.  Then update the saved
+        values to match the current values"""
 
-                utime, stime, wtime = self.__get_time()
+        utime, stime, wtime = self.__get_time()
 
-                udelta = utime - self.__utime
-                sdelta = stime - self.__stime
-                wdelta = wtime - self.__wtime
+        udelta = utime - self.__utime
+        sdelta = stime - self.__stime
+        wdelta = wtime - self.__wtime
 
-                self.__timings.append((phase, udelta, sdelta, wdelta))
-                self.__utime, self.__stime, self.__wtime = utime, stime, wtime
+        self.__timings.append((phase, udelta, sdelta, wdelta))
+        self.__utime, self.__stime, self.__wtime = utime, stime, wtime
 
-                rv = "{0}: {1}: ".format(self.__module, phase)
-                rv += Timer.__log_fmt.format(udelta, sdelta, wdelta)
-                if logger:
-                        logger.debug(rv)
-                return rv
+        rv = "{0}: {1}: ".format(self.__module, phase)
+        rv += Timer.__log_fmt.format(udelta, sdelta, wdelta)
+        if logger:
+            logger.debug(rv)
+        return rv
 
 
 class AsyncCallException(Exception):
-        """Exception class for AsyncCall() errors.
+    """Exception class for AsyncCall() errors.
 
-        Any exceptions caught by the async call thread get bundled into this
-        Exception because otherwise we'll lose the stack trace associated with
-        the original exception."""
+    Any exceptions caught by the async call thread get bundled into this
+    Exception because otherwise we'll lose the stack trace associated with
+    the original exception."""
 
-        def __init__(self, e=None):
-                Exception.__init__(self)
-                self.e = e
-                self.tb = None
+    def __init__(self, e=None):
+        Exception.__init__(self)
+        self.e = e
+        self.tb = None
 
-        def __str__(self):
-                if self.tb:
-                        return str(self.tb) + str(self.e)
-                return str(self.e)
+    def __str__(self):
+        if self.tb:
+            return str(self.tb) + str(self.e)
+        return str(self.e)
 
 
 class AsyncCall(object):
-        """Class which can be used to call a function asynchronously.
-        The call is performed via a dedicated thread."""
+    """Class which can be used to call a function asynchronously.
+    The call is performed via a dedicated thread."""
 
-        def __init__(self):
-                self.rv = None
-                self.e = None
+    def __init__(self):
+        self.rv = None
+        self.e = None
 
-                # keep track of what's been done
-                self.started = False
+        # keep track of what's been done
+        self.started = False
 
-                # internal state
-                self.__thread = None
+        # internal state
+        self.__thread = None
 
-                # pre-allocate an exception that we'll used in case everything
-                # goes horribly wrong.
-                self.__e = AsyncCallException(
-                    Exception("AsyncCall Internal Error"))
+        # pre-allocate an exception that we'll used in case everything
+        # goes horribly wrong.
+        self.__e = AsyncCallException(Exception("AsyncCall Internal Error"))
 
-        def __thread_cb(self, dummy, cb, *args, **kwargs):
-                """Dedicated call thread.
+    def __thread_cb(self, dummy, cb, *args, **kwargs):
+        """Dedicated call thread.
 
-                'dummy' is a dummy parameter that is not used.  this is done
-                because the threading module (which invokes this function)
-                inspects the first argument of "args" to check if it's
-                iterable, and that may cause bizarre failures if cb is a
-                dynamically bound class (like xmlrpclib._Method).
+        'dummy' is a dummy parameter that is not used.  this is done
+        because the threading module (which invokes this function)
+        inspects the first argument of "args" to check if it's
+        iterable, and that may cause bizarre failures if cb is a
+        dynamically bound class (like xmlrpclib._Method).
 
-                We need to be careful here and catch all exceptions.  Since
-                we're executing in our own thread, any exceptions we don't
-                catch get dumped to the console."""
-                # Catch "Exception"; pylint: disable=W0703
+        We need to be careful here and catch all exceptions.  Since
+        we're executing in our own thread, any exceptions we don't
+        catch get dumped to the console."""
+        # Catch "Exception"; pylint: disable=W0703
 
-                try:
-                        # Value 'DebugValues' is unsubscriptable;
-                        # pylint: disable=E1136
-                        if DebugValues["async_thread_error"]:
-                                raise Exception("async_thread_error")
+        try:
+            # Value 'DebugValues' is unsubscriptable;
+            # pylint: disable=E1136
+            if DebugValues["async_thread_error"]:
+                raise Exception("async_thread_error")
 
-                        rv = e = None
-                        try:
-                                rv = cb(*args, **kwargs)
-                        except Exception as e:
-                                self.e = self.__e
-                                self.e.e = e
-                                self.e.tb = traceback.format_exc()
-                                return
+            rv = e = None
+            try:
+                rv = cb(*args, **kwargs)
+            except Exception as e:
+                self.e = self.__e
+                self.e.e = e
+                self.e.tb = traceback.format_exc()
+                return
 
-                        self.rv = rv
+            self.rv = rv
 
-                except Exception as e:
-                        # if we raise an exception here, we're hosed
-                        self.rv = None
-                        self.e = self.__e
-                        self.e.e = e
-                        try:
-                                # Value 'DebugValues' is unsubscriptable;
-                                # pylint: disable=E1136
-                                if DebugValues["async_thread_error"]:
-                                        raise Exception("async_thread_error")
-                                self.e.tb = traceback.format_exc()
-                        except Exception:
-                                pass
+        except Exception as e:
+            # if we raise an exception here, we're hosed
+            self.rv = None
+            self.e = self.__e
+            self.e.e = e
+            try:
+                # Value 'DebugValues' is unsubscriptable;
+                # pylint: disable=E1136
+                if DebugValues["async_thread_error"]:
+                    raise Exception("async_thread_error")
+                self.e.tb = traceback.format_exc()
+            except Exception:
+                pass
 
-        def start(self, cb, *args, **kwargs):
-                """Start a call to an rpc server."""
+    def start(self, cb, *args, **kwargs):
+        """Start a call to an rpc server."""
 
-                assert not self.started
-                self.started = True
-                # prepare the arguments for the thread
-                if args:
-                        args = (0, cb) + args
-                else:
-                        args = (0, cb)
+        assert not self.started
+        self.started = True
+        # prepare the arguments for the thread
+        if args:
+            args = (0, cb) + args
+        else:
+            args = (0, cb)
 
-                # initialize and return the thread
-                self.__thread = threading.Thread(target=self.__thread_cb,
-                    args=args, kwargs=kwargs)
-                self.__thread.daemon = True
-                self.__thread.start()
+        # initialize and return the thread
+        self.__thread = threading.Thread(
+            target=self.__thread_cb, args=args, kwargs=kwargs
+        )
+        self.__thread.daemon = True
+        self.__thread.start()
 
-        def join(self):
-                """Wait for an rpc call to finish."""
-                assert self.started
-                self.__thread.join()
+    def join(self):
+        """Wait for an rpc call to finish."""
+        assert self.started
+        self.__thread.join()
 
-        def is_done(self):
-                """Check if an rpc call is done."""
-                assert self.started
-                return not self.__thread.is_alive()
+    def is_done(self):
+        """Check if an rpc call is done."""
+        assert self.started
+        return not self.__thread.is_alive()
 
-        def result(self):
-                """Finish a call to an rpc server."""
-                assert self.started
-                # wait for the async call thread to exit
-                self.join()
-                assert self.is_done()
-                if self.e:
-                        # if the calling thread hit an exception, re-raise it
-                        # Raising NoneType; pylint: disable=E0702
-                        raise self.e
-                return self.rv
+    def result(self):
+        """Finish a call to an rpc server."""
+        assert self.started
+        # wait for the async call thread to exit
+        self.join()
+        assert self.is_done()
+        if self.e:
+            # if the calling thread hit an exception, re-raise it
+            # Raising NoneType; pylint: disable=E0702
+            raise self.e
+        return self.rv
 
 
 def get_runtime_proxy(proxy, uri):
-        """Given a proxy string and a URI we want to access using it, determine
-        whether any OS environment variables should override that value.
+    """Given a proxy string and a URI we want to access using it, determine
+    whether any OS environment variables should override that value.
 
-        The special value "-" is returned when a no_proxy environment variable
-        was found which should apply to this URI, indicating that no proxy
-        should be used at runtime."""
+    The special value "-" is returned when a no_proxy environment variable
+    was found which should apply to this URI, indicating that no proxy
+    should be used at runtime."""
 
-        runtime_proxy = proxy
-        # There is no upper case version of http_proxy, according to curl(1)
-        environ_http_proxy = os.environ.get("http_proxy")
-        environ_https_proxy = os.environ.get("https_proxy")
-        environ_https_proxy_upper = os.environ.get("HTTPS_PROXY")
-        environ_all_proxy = os.environ.get("all_proxy")
-        environ_all_proxy_upper = os.environ.get("ALL_PROXY")
+    runtime_proxy = proxy
+    # There is no upper case version of http_proxy, according to curl(1)
+    environ_http_proxy = os.environ.get("http_proxy")
+    environ_https_proxy = os.environ.get("https_proxy")
+    environ_https_proxy_upper = os.environ.get("HTTPS_PROXY")
+    environ_all_proxy = os.environ.get("all_proxy")
+    environ_all_proxy_upper = os.environ.get("ALL_PROXY")
 
-        no_proxy = os.environ.get("no_proxy", [])
-        no_proxy_upper = os.environ.get("NO_PROXY", [])
+    no_proxy = os.environ.get("no_proxy", [])
+    no_proxy_upper = os.environ.get("NO_PROXY", [])
 
-        if no_proxy:
-                no_proxy = no_proxy.split(",")
+    if no_proxy:
+        no_proxy = no_proxy.split(",")
 
-        if no_proxy_upper:
-                no_proxy_upper = no_proxy_upper.split(",")
+    if no_proxy_upper:
+        no_proxy_upper = no_proxy_upper.split(",")
 
-        # Give precedence to protocol-specific proxies, and lowercase versions.
-        if uri and uri.startswith("http") and environ_http_proxy:
-                runtime_proxy = environ_http_proxy
-        elif uri and uri.startswith("https") and environ_https_proxy:
-                runtime_proxy = environ_https_proxy
-        elif uri and uri.startswith("https") and environ_https_proxy_upper:
-                runtime_proxy = environ_https_proxy_upper
-        elif environ_all_proxy:
-                runtime_proxy = environ_all_proxy
-        elif environ_all_proxy_upper:
-                runtime_proxy = environ_all_proxy_upper
+    # Give precedence to protocol-specific proxies, and lowercase versions.
+    if uri and uri.startswith("http") and environ_http_proxy:
+        runtime_proxy = environ_http_proxy
+    elif uri and uri.startswith("https") and environ_https_proxy:
+        runtime_proxy = environ_https_proxy
+    elif uri and uri.startswith("https") and environ_https_proxy_upper:
+        runtime_proxy = environ_https_proxy_upper
+    elif environ_all_proxy:
+        runtime_proxy = environ_all_proxy
+    elif environ_all_proxy_upper:
+        runtime_proxy = environ_all_proxy_upper
 
-        if no_proxy or no_proxy_upper:
-                # SplitResult has a netloc member; pylint: disable=E1103
-                netloc = urlsplit(uri, allow_fragments=0).netloc
-                host = netloc.split(":")[0]
-                if host in no_proxy or no_proxy == ["*"]:
-                        return "-"
-                if host in no_proxy_upper or no_proxy_upper == ["*"]:
-                        return "-"
+    if no_proxy or no_proxy_upper:
+        # SplitResult has a netloc member; pylint: disable=E1103
+        netloc = urlsplit(uri, allow_fragments=0).netloc
+        host = netloc.split(":")[0]
+        if host in no_proxy or no_proxy == ["*"]:
+            return "-"
+        if host in no_proxy_upper or no_proxy_upper == ["*"]:
+            return "-"
 
-        if not runtime_proxy:
-                return
+    if not runtime_proxy:
+        return
 
-        return runtime_proxy
+    return runtime_proxy
+
 
 def decode(s):
-        """convert non-ascii strings to unicode;
-        replace non-convertable chars"""
-        if six.PY3:
-                return s
-        try:
-                # this will fail if any 8 bit chars in string
-                # this is a nop if string is ascii.
-                s = s.encode("ascii")
-        except ValueError:
-                # this will encode 8 bit strings into unicode
-                s = s.decode("utf-8", "replace")
+    """convert non-ascii strings to unicode;
+    replace non-convertable chars"""
+    if six.PY3:
         return s
+    try:
+        # this will fail if any 8 bit chars in string
+        # this is a nop if string is ascii.
+        s = s.encode("ascii")
+    except ValueError:
+        # this will encode 8 bit strings into unicode
+        s = s.decode("utf-8", "replace")
+    return s
+
 
 def yield_matching(pat_prefix, items, patterns):
-        """Helper function for yielding items that match one of the provided
-        patterns."""
+    """Helper function for yielding items that match one of the provided
+    patterns."""
 
-        if patterns:
-                # Normalize patterns and determine whether to glob.
-                npatterns = []
-                for p in patterns:
-                        if pat_prefix:
-                                pat = p.startswith(pat_prefix) and \
-                                    p or (pat_prefix + p)
-                        else:
-                                pat = p
-                        if "*" in p or "?" in p:
-                                pat = re.compile(fnmatch.translate(pat)).match
-                                glob_match = True
-                        else:
-                                glob_match = False
+    if patterns:
+        # Normalize patterns and determine whether to glob.
+        npatterns = []
+        for p in patterns:
+            if pat_prefix:
+                pat = p.startswith(pat_prefix) and p or (pat_prefix + p)
+            else:
+                pat = p
+            if "*" in p or "?" in p:
+                pat = re.compile(fnmatch.translate(pat)).match
+                glob_match = True
+            else:
+                glob_match = False
 
-                        npatterns.append((pat, glob_match))
-                patterns = npatterns
-                npatterns = None
+            npatterns.append((pat, glob_match))
+        patterns = npatterns
+        npatterns = None
 
-        for item in items:
-                for (pat, glob_match) in patterns:
-                        if glob_match:
-                                if pat(item):
-                                        break
-                        elif item == pat:
-                                break
-                else:
-                        if patterns:
-                                continue
-                # No patterns or matched at least one.
-                yield item
+    for item in items:
+        for pat, glob_match in patterns:
+            if glob_match:
+                if pat(item):
+                    break
+            elif item == pat:
+                break
+        else:
+            if patterns:
+                continue
+        # No patterns or matched at least one.
+        yield item
 
 
 sigdict = defaultdict(list)
 
+
 def signame(signal_number):
-        """convert signal number to name(s)"""
-        if not sigdict:
-                for name in dir(signal):
-                        if name.startswith("SIG") and "_" not in name:
-                                sigdict[getattr(signal, name)].append(name)
+    """convert signal number to name(s)"""
+    if not sigdict:
+        for name in dir(signal):
+            if name.startswith("SIG") and "_" not in name:
+                sigdict[getattr(signal, name)].append(name)
 
-        return "/".join(sigdict.get(signal_number,
-            ["Unnamed signal: {0:d}".format(signal_number)]))
+    return "/".join(
+        sigdict.get(
+            signal_number, ["Unnamed signal: {0:d}".format(signal_number)]
+        )
+    )
 
-def list_actions_by_attrs(actionlist, attrs, show_all=False,
-    remove_consec_dup_lines=False, last_res=None):
-        """Produces a list of n tuples (where n is the length of attrs)
-        containing the relevant information about the actions.
 
-        The "actionlist" parameter is a list of tuples which contain the fmri
-        of the package that's the source of the action, the action, and the
-        publisher the action's package came from. If the actionlist was
-        generated by searching, the last two pieces, "match" and "match_type"
-        contain information about why this action was selected.
+def list_actions_by_attrs(
+    actionlist,
+    attrs,
+    show_all=False,
+    remove_consec_dup_lines=False,
+    last_res=None,
+):
+    """Produces a list of n tuples (where n is the length of attrs)
+    containing the relevant information about the actions.
 
-        The "attrs" parameter is a list of the attributes of the action that
-        should be displayed.
+    The "actionlist" parameter is a list of tuples which contain the fmri
+    of the package that's the source of the action, the action, and the
+    publisher the action's package came from. If the actionlist was
+    generated by searching, the last two pieces, "match" and "match_type"
+    contain information about why this action was selected.
 
-        The "show_all" parameter determines whether an action that lacks one
-        or more of the desired attributes will be displayed or not.
+    The "attrs" parameter is a list of the attributes of the action that
+    should be displayed.
 
-        The "remove_consec_dup_lines" parameter determines whether consecutive
-        duplicate lines should be removed from the results.
+    The "show_all" parameter determines whether an action that lacks one
+    or more of the desired attributes will be displayed or not.
 
-        The "last_res" parameter is a seed to compare the first result against
-        for duplicate removal.
-        """
+    The "remove_consec_dup_lines" parameter determines whether consecutive
+    duplicate lines should be removed from the results.
 
-        # Assert that if last_res is set, we should be removing duplicate
-        # lines.
-        assert remove_consec_dup_lines or not last_res
-        last_line = last_res
-        for pfmri, action, pub, match, match_type in actionlist:
-                line = []
-                for attr in attrs:
-                        if action and attr in action.attrs:
-                                a = action.attrs[attr]
-                        elif attr == "action.name":
-                                a = action.name
-                        elif attr == "action.key":
-                                a = action.attrs[action.key_attr]
-                        elif attr == "action.raw":
-                                a = action
-                        elif attr in ("hash", "action.hash"):
-                                a = getattr(action, "hash", "")
-                        elif attr == "pkg.name":
-                                a = pfmri.get_name()
-                        elif attr == "pkg.fmri":
-                                a = pfmri.get_fmri(include_build=False)
-                        elif attr == "pkg.shortfmri":
-                                a = pfmri.get_short_fmri()
-                        elif attr == "pkg.publisher":
-                                a = pfmri.get_publisher()
-                                if a is None:
-                                        a = pub
-                                        if a is None:
-                                                a = ""
-                        elif attr == "search.match":
-                                a = match
-                        elif attr == "search.match_type":
-                                a = match_type
-                        else:
-                                a = ""
-                        line.append(a)
+    The "last_res" parameter is a seed to compare the first result against
+    for duplicate removal.
+    """
 
-                # Too many boolean expressions in if statement;
-                # pylint: disable=R0916
-                if (line and [l for l in line if str(l) != ""] or show_all) \
-                    and (not remove_consec_dup_lines or last_line is None or
-                    last_line != line):
-                        last_line = line
-                        yield line
+    # Assert that if last_res is set, we should be removing duplicate
+    # lines.
+    assert remove_consec_dup_lines or not last_res
+    last_line = last_res
+    for pfmri, action, pub, match, match_type in actionlist:
+        line = []
+        for attr in attrs:
+            if action and attr in action.attrs:
+                a = action.attrs[attr]
+            elif attr == "action.name":
+                a = action.name
+            elif attr == "action.key":
+                a = action.attrs[action.key_attr]
+            elif attr == "action.raw":
+                a = action
+            elif attr in ("hash", "action.hash"):
+                a = getattr(action, "hash", "")
+            elif attr == "pkg.name":
+                a = pfmri.get_name()
+            elif attr == "pkg.fmri":
+                a = pfmri.get_fmri(include_build=False)
+            elif attr == "pkg.shortfmri":
+                a = pfmri.get_short_fmri()
+            elif attr == "pkg.publisher":
+                a = pfmri.get_publisher()
+                if a is None:
+                    a = pub
+                    if a is None:
+                        a = ""
+            elif attr == "search.match":
+                a = match
+            elif attr == "search.match_type":
+                a = match_type
+            else:
+                a = ""
+            line.append(a)
+
+        # Too many boolean expressions in if statement;
+        # pylint: disable=R0916
+        if (line and [l for l in line if str(l) != ""] or show_all) and (
+            not remove_consec_dup_lines
+            or last_line is None
+            or last_line != line
+        ):
+            last_line = line
+            yield line
+
 
 def _min_edit_distance(word1, word2):
-        """Calculate the minimal edit distance for converting word1 to word2,
-        based on Wagner-Fischer algorithm."""
+    """Calculate the minimal edit distance for converting word1 to word2,
+    based on Wagner-Fischer algorithm."""
 
-        m = len(word1)
-        n = len(word2)
+    m = len(word1)
+    n = len(word2)
 
-        # dp[i][j] stands for the edit distance between two strings with
-        # length i and j, i.e., word1[0,...,i-1] and word2[0,...,j-1]
-        dp = [[0 for i in range(n+1)] for j in range(m+1)]
+    # dp[i][j] stands for the edit distance between two strings with
+    # length i and j, i.e., word1[0,...,i-1] and word2[0,...,j-1]
+    dp = [[0 for i in range(n + 1)] for j in range(m + 1)]
 
-        ins_cost = 1.0
-        del_cost = 1.0
-        rep_cost = 1.0
-        for i in range(m+1):
-                dp[i][0] = del_cost * i
-        for i in range(n+1):
-                dp[0][i] = ins_cost * i
+    ins_cost = 1.0
+    del_cost = 1.0
+    rep_cost = 1.0
+    for i in range(m + 1):
+        dp[i][0] = del_cost * i
+    for i in range(n + 1):
+        dp[0][i] = ins_cost * i
 
-        for i in range(1, m+1):
-                for j in range(1, n+1):
-                        if word1[i-1] == word2[j-1]:
-                                dp[i][j] = dp[i-1][j-1]
-                        else:
-                                dp[i][j] = min(
-                                    dp[i-1][j-1] + rep_cost,
-                                    dp[i][j-1] + ins_cost,
-                                    dp[i-1][j] + del_cost)
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if word1[i - 1] == word2[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1]
+            else:
+                dp[i][j] = min(
+                    dp[i - 1][j - 1] + rep_cost,
+                    dp[i][j - 1] + ins_cost,
+                    dp[i - 1][j] + del_cost,
+                )
 
-        return dp[m][n]
+    return dp[m][n]
+
 
 def suggest_known_words(text, known_words):
-        """Given a text, a list of known_words, suggest some correct
-        candidates from known_words."""
+    """Given a text, a list of known_words, suggest some correct
+    candidates from known_words."""
 
-        candidates = []
-        if not text:
-                return candidates
+    candidates = []
+    if not text:
+        return candidates
 
-        # We are confident to suggest if the text is part of the known words.
-        for known in known_words:
-                if len(text) < 4:
-                        # If the text's length is short, treat it as a prefix.
-                        if known.startswith(text):
-                                candidates.append(known)
-                elif text in known or known in text:
-                        # Otherwise check if the text is part of the known
-                        # words or vice verse.
-                        candidates.append(known)
+    # We are confident to suggest if the text is part of the known words.
+    for known in known_words:
+        if len(text) < 4:
+            # If the text's length is short, treat it as a prefix.
+            if known.startswith(text):
+                candidates.append(known)
+        elif text in known or known in text:
+            # Otherwise check if the text is part of the known
+            # words or vice verse.
+            candidates.append(known)
 
-        if candidates:
-                if len(candidates) < 4:
-                        return candidates
-                else:
-                        # Give up suggestions if there are too many candidates.
-                        return
+    if candidates:
+        if len(candidates) < 4:
+            return candidates
+        else:
+            # Give up suggestions if there are too many candidates.
+            return
 
-        # If there are no candidates from the "contains" check, use the edit
-        # distance algorithm to seek further.
-        for known in known_words:
-                distance = _min_edit_distance(text, known)
-                if distance <= len(known) / 2.0:
-                        candidates.append((known, distance))
+    # If there are no candidates from the "contains" check, use the edit
+    # distance algorithm to seek further.
+    for known in known_words:
+        distance = _min_edit_distance(text, known)
+        if distance <= len(known) / 2.0:
+            candidates.append((known, distance))
 
-        # Sort the candidates by their distance, and return the words only.
-        return [c[0] for c in sorted(candidates, key=itemgetter(1))]
+    # Sort the candidates by their distance, and return the words only.
+    return [c[0] for c in sorted(candidates, key=itemgetter(1))]
+
 
 def force_bytes(s, encoding="utf-8", errors="strict"):
-        """Force the string into bytes."""
+    """Force the string into bytes."""
 
-        if isinstance(s, bytes):
-                if encoding == "utf-8":
-                        return s
-                return s.decode("utf-8", errors).encode(encoding,
-                    errors)
-        elif isinstance(s, six.string_types):
-                # this case is: unicode in Python 2 and str in Python 3
-                return s.encode(encoding, errors)
-        elif six.PY3:
-                # type not a string and Python 3's bytes() requires
-                # a string argument
-                return six.text_type(s).encode(encoding)
-        # type not a string
-        return bytes(s)
+    if isinstance(s, bytes):
+        if encoding == "utf-8":
+            return s
+        return s.decode("utf-8", errors).encode(encoding, errors)
+    elif isinstance(s, six.string_types):
+        # this case is: unicode in Python 2 and str in Python 3
+        return s.encode(encoding, errors)
+    elif six.PY3:
+        # type not a string and Python 3's bytes() requires
+        # a string argument
+        return six.text_type(s).encode(encoding)
+    # type not a string
+    return bytes(s)
 
 
 def force_text(s, encoding="utf-8", errors="strict"):
-        """Force the string into text."""
+    """Force the string into text."""
 
-        if isinstance(s, six.text_type):
-                return s
-        if isinstance(s, six.string_types):
-                # this case is: str(bytes) in Python 2
-                return s.decode(encoding, errors)
-        elif isinstance(s, bytes):
-                # this case is: bytes in Python 3
-                return s.decode(encoding, errors)
-        # type not a string
-        return six.text_type(s)
+    if isinstance(s, six.text_type):
+        return s
+    if isinstance(s, six.string_types):
+        # this case is: str(bytes) in Python 2
+        return s.decode(encoding, errors)
+    elif isinstance(s, bytes):
+        # this case is: bytes in Python 3
+        return s.decode(encoding, errors)
+    # type not a string
+    return six.text_type(s)
+
 
 if six.PY3:
-        force_str = force_text
+    force_str = force_text
 else:
-        force_str = force_bytes
+    force_str = force_bytes
+
 
 def open_image_file(root, path, flag, mode=None):
-        """Open 'path' ensuring that we don't follow a symlink which may lead
-        outside of the specified image.
-        When it is a symlink open path relative to root.
+    """Open 'path' ensuring that we don't follow a symlink which may lead
+    outside of the specified image.
+    When it is a symlink open path relative to root.
 
-        'root' is a directory that the path must reside in.
-        """
+    'root' is a directory that the path must reside in.
+    """
 
-        try:
-                return os.fdopen(os.open(path, flag|os.O_NOFOLLOW, mode))
-        except EnvironmentError as e:
-                if e.errno != errno.ELOOP:
-                        # Access to protected member; pylint: disable=W0212
-                        raise api_errors._convert_error(e)
-        # If it is a symbolic link, fall back to ar_open. ar_open interprets
-        # 'path' as relative to 'root', that is, 'root' will be prepended to
-        # 'path', so we need to call os.path.relpath here.
-        return os.fdopen(ar_open(root, os.path.relpath(path, root), flag, mode))
+    try:
+        return os.fdopen(os.open(path, flag | os.O_NOFOLLOW, mode))
+    except EnvironmentError as e:
+        if e.errno != errno.ELOOP:
+            # Access to protected member; pylint: disable=W0212
+            raise api_errors._convert_error(e)
+    # If it is a symbolic link, fall back to ar_open. ar_open interprets
+    # 'path' as relative to 'root', that is, 'root' will be prepended to
+    # 'path', so we need to call os.path.relpath here.
+    return os.fdopen(ar_open(root, os.path.relpath(path, root), flag, mode))
 
 
 def check_ca(cert):
-        """Check if 'cert' is a proper CA. For this the BasicConstraints need to
-        identify it as a CA cert and it needs to have the CertSign
-        (key_cert_sign in Cryptography) KeyUsage flag. Based loosely on
-        OpenSSL's check_ca()"""
+    """Check if 'cert' is a proper CA. For this the BasicConstraints need to
+    identify it as a CA cert and it needs to have the CertSign
+    (key_cert_sign in Cryptography) KeyUsage flag. Based loosely on
+    OpenSSL's check_ca()"""
 
-        from cryptography import x509
+    from cryptography import x509
 
-        bconst_ca = None
-        kuse_sign = None
+    bconst_ca = None
+    kuse_sign = None
 
-        for e in cert.extensions:
-                if isinstance(e.value, x509.BasicConstraints):
-                        bconst_ca = e.value.ca
-                elif isinstance(e.value, x509.KeyUsage):
-                        kuse_sign = e.value.key_cert_sign
+    for e in cert.extensions:
+        if isinstance(e.value, x509.BasicConstraints):
+            bconst_ca = e.value.ca
+        elif isinstance(e.value, x509.KeyUsage):
+            kuse_sign = e.value.key_cert_sign
 
-        return kuse_sign is not False and bconst_ca
+    return kuse_sign is not False and bconst_ca
+
 
 def smallest_diff_key(a, b):
-        """Return the smallest key 'k' in 'a' such that a[k] != b[k]."""
-        keys = [k for k in a if a.get(k) != b.get(k)]
-        if not keys:
-                return None
-        return min(keys)
+    """Return the smallest key 'k' in 'a' such that a[k] != b[k]."""
+    keys = [k for k in a if a.get(k) != b.get(k)]
+    if not keys:
+        return None
+    return min(keys)
+
 
 def dict_cmp(a, b):
-        """cmp method for dictionary, translated from the source code
-        http://svn.python.org/projects/python/trunk/Objects/dictobject.c"""
+    """cmp method for dictionary, translated from the source code
+    http://svn.python.org/projects/python/trunk/Objects/dictobject.c"""
 
-        if len(a) != len(b):
-                return cmp(len(a), len(b))
+    if len(a) != len(b):
+        return cmp(len(a), len(b))
 
-        adiff = smallest_diff_key(a, b)
-        bdiff = smallest_diff_key(b, a)
-        if adiff is None and bdiff is None:
-                return 0
-        if adiff != bdiff:
-                return cmp(adiff, bdiff)
-        return cmp(a[adiff], b[bdiff])
+    adiff = smallest_diff_key(a, b)
+    bdiff = smallest_diff_key(b, a)
+    if adiff is None and bdiff is None:
+        return 0
+    if adiff != bdiff:
+        return cmp(adiff, bdiff)
+    return cmp(a[adiff], b[bdiff])
+
 
 def cmp(a, b):
-        """Implementaion for Python 2.7's built-in function cmp(), which is
-        removed in Python 3."""
+    """Implementaion for Python 2.7's built-in function cmp(), which is
+    removed in Python 3."""
 
-        if isinstance(a, dict) and isinstance(b, dict):
-                return dict_cmp(a, b)
+    if isinstance(a, dict) and isinstance(b, dict):
+        return dict_cmp(a, b)
 
-        try:
-                if a == b:
-                        return 0
-                elif a < b:
-                        return -1
-                else:
-                        return 1
-        except TypeError:
-                if a is None and b:
-                        return -1
-                if a and b is None:
-                        return 1
-                return NotImplemented
+    try:
+        if a == b:
+            return 0
+        elif a < b:
+            return -1
+        else:
+            return 1
+    except TypeError:
+        if a is None and b:
+            return -1
+        if a and b is None:
+            return 1
+        return NotImplemented
+
 
 def set_memory_limit(bytes, allow_override=True):
-        """Limit memory consumption of current process to 'bytes'.
-           This only limits the brk() and mmap() calls made by python."""
+    """Limit memory consumption of current process to 'bytes'.
+    This only limits the brk() and mmap() calls made by python."""
 
-        if allow_override:
-                try:
-                        bytes = int(os.environ["PKG_CLIENT_MAX_PROCESS_SIZE"])
-                except (KeyError, ValueError):
-                        pass
-
+    if allow_override:
         try:
-                resource.setrlimit(resource.RLIMIT_VMEM, (bytes, bytes))
-        except AttributeError:
-                # If platform doesn't support RLIMIT_VMEM, just ignore it.
-                pass
-        except ValueError:
-                # An unprivileged user can not raise a previously set limit,
-                # if that ever happens, just ignore it.
-                pass
+            bytes = int(os.environ["PKG_CLIENT_MAX_PROCESS_SIZE"])
+        except (KeyError, ValueError):
+            pass
+
+    try:
+        resource.setrlimit(resource.RLIMIT_VMEM, (bytes, bytes))
+    except AttributeError:
+        # If platform doesn't support RLIMIT_VMEM, just ignore it.
+        pass
+    except ValueError:
+        # An unprivileged user can not raise a previously set limit,
+        # if that ever happens, just ignore it.
+        pass
 
 
 def force_bytes(s, encoding="utf-8", errors="strict"):
-        """Force the string into bytes."""
+    """Force the string into bytes."""
 
-        if isinstance(s, bytes):
-                return s
-        try:
-                if isinstance(s, six.string_types):
-                        # this case is: unicode in Python 2 and str in Python 3
-                        return s.encode(encoding, errors)
-                elif six.PY3:
-                        # type not a string and Python 3's bytes() requires
-                        # a string argument
-                        return six.text_type(s).encode(encoding)
-                # type not a string
-                s = bytes(s)
-        except UnicodeEncodeError:
-                raise
+    if isinstance(s, bytes):
         return s
+    try:
+        if isinstance(s, six.string_types):
+            # this case is: unicode in Python 2 and str in Python 3
+            return s.encode(encoding, errors)
+        elif six.PY3:
+            # type not a string and Python 3's bytes() requires
+            # a string argument
+            return six.text_type(s).encode(encoding)
+        # type not a string
+        s = bytes(s)
+    except UnicodeEncodeError:
+        raise
+    return s
 
 
 def force_text(s, encoding="utf-8", errors="strict"):
-        """Force the string into text."""
+    """Force the string into text."""
 
-        if isinstance(s, six.text_type):
-                return s
-        try:
-                if isinstance(s, (six.string_types, bytes)):
-                        # this case is: str(bytes) in Python 2 and bytes in
-                        # Python 3
-                        s = s.decode(encoding, errors)
-                else:
-                        # type not a string
-                        s = six.text_type(s)
-        except UnicodeDecodeError as e:
-                raise api_errors.PkgUnicodeDecodeError(s, *e.args)
+    if isinstance(s, six.text_type):
         return s
+    try:
+        if isinstance(s, (six.string_types, bytes)):
+            # this case is: str(bytes) in Python 2 and bytes in
+            # Python 3
+            s = s.decode(encoding, errors)
+        else:
+            # type not a string
+            s = six.text_type(s)
+    except UnicodeDecodeError as e:
+        raise api_errors.PkgUnicodeDecodeError(s, *e.args)
+    return s
+
 
 # force_str minimizes the work for compatible string handling between Python
 # 2 and 3 because we will have the native string type in its runtime, that is,
 # bytes in Python 2 and unicode string in Python 3.
 if six.PY2:
-        force_str = force_bytes
+    force_str = force_bytes
 else:
-        force_str = force_text
+    force_str = force_text
 
 FILE_DESCRIPTOR_LIMIT = 4096
 
+
 def set_fd_limits(printer=None):
-        """Set the open file descriptor soft limit."""
-        if printer is None:
-                printer = emsg
-        try:
-                (soft, hard) = resource.getrlimit(resource.RLIMIT_NOFILE)
-                soft = max(hard, FILE_DESCRIPTOR_LIMIT)
-                resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
-        except (OSError, ValueError) as e:
-                printer(_("unable to set open file limit to {0}; please "
-                    "increase the open file limit using 'ulimit -n'"
-                    " and try the requested operation again: {1}")\
-                    .format(soft, e))
-                sys.exit(EXIT_OOPS)
+    """Set the open file descriptor soft limit."""
+    if printer is None:
+        printer = emsg
+    try:
+        (soft, hard) = resource.getrlimit(resource.RLIMIT_NOFILE)
+        soft = max(hard, FILE_DESCRIPTOR_LIMIT)
+        resource.setrlimit(resource.RLIMIT_NOFILE, (soft, hard))
+    except (OSError, ValueError) as e:
+        printer(
+            _(
+                "unable to set open file limit to {0}; please "
+                "increase the open file limit using 'ulimit -n'"
+                " and try the requested operation again: {1}"
+            ).format(soft, e)
+        )
+        sys.exit(EXIT_OOPS)
+
 
 _varcetname_re = re.compile(r"\s")
 
+
 def valid_varcet_name(name):
-        """Check if the variant/facet name is valid. A valid variant/facet
-        name cannot contain whitespace"""
-        return _varcetname_re.search(name) is None
+    """Check if the variant/facet name is valid. A valid variant/facet
+    name cannot contain whitespace"""
+    return _varcetname_re.search(name) is None
+
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/mogrify.py
+++ b/src/modules/mogrify.py
@@ -35,743 +35,868 @@ import pkg.actions
 
 
 def add_transform(transforms, printinfo, transform, filename, lineno):
-        """This routine adds a transform tuple to the list used
-        to process actions."""
+    """This routine adds a transform tuple to the list used
+    to process actions."""
 
-        # strip off transform
-        s = transform[10:]
-        # make error messages familiar
-        transform = "<" + transform + ">"
+    # strip off transform
+    s = transform[10:]
+    # make error messages familiar
+    transform = "<" + transform + ">"
+
+    try:
+        index = s.index("->")
+    except ValueError:
+        raise RuntimeError(_("Missing -> in transform"))
+    matching = s[0:index].strip().split()
+    types = [a for a in matching if "=" not in a]
+    attrdict = pkg.actions.attrsfromstr(
+        " ".join([a for a in matching if "=" in a])
+    )
+
+    for a in attrdict:
+        try:
+            attrdict[a] = re.compile(attrdict[a])
+        except re.error as e:
+            raise RuntimeError(
+                _(
+                    "transform ({transform}) has regexp error "
+                    "({err}) in matching clause"
+                ).format(transform=transform, err=e)
+            )
+
+    op = s[index + 2 :].strip().split(None, 1)
+
+    # use closures to encapsulate desired operation
+
+    if op[0] == "drop":
+        if len(op) > 1:
+            raise RuntimeError(
+                _("transform ({0}) has 'drop' operation syntax error").format(
+                    transform
+                )
+            )
+        operation = lambda a, m, p, f, l: None
+
+    elif op[0] == "set":
+        try:
+            attr, value = shlex.split(op[1])
+        except ValueError:
+            raise RuntimeError(
+                _("transform ({0}) has 'set' operation syntax error").format(
+                    transform
+                )
+            )
+
+        def set_func(action, matches, pkg_attrs, filename, lineno):
+            newattr = substitute_values(
+                attr, action, matches, pkg_attrs, filename, lineno
+            )
+            newval = substitute_values(
+                value, action, matches, pkg_attrs, filename, lineno
+            )
+            if newattr == "action.hash":
+                if hasattr(action, "hash"):
+                    action.hash = newval
+            else:
+                action.attrs[newattr] = newval
+            return action
+
+        operation = set_func
+
+    elif op[0] == "default":
+        try:
+            attr, value = shlex.split(op[1])
+        except ValueError:
+            raise RuntimeError(
+                _(
+                    "transform ({0}) has 'default' operation syntax error"
+                ).format(transform)
+            )
+
+        def default_func(action, matches, pkg_attrs, filename, lineno):
+            newattr = substitute_values(
+                attr, action, matches, pkg_attrs, filename, lineno
+            )
+            if newattr not in action.attrs:
+                newval = substitute_values(
+                    value, action, matches, pkg_attrs, filename, lineno
+                )
+                action.attrs[newattr] = newval
+            return action
+
+        operation = default_func
+
+    elif op[0] == "abort":
+        if len(op) > 1:
+            raise RuntimeError(
+                _(
+                    "transform ({0}) has 'abort' " "operation syntax error"
+                ).format(transform)
+            )
+
+        def abort_func(action, matches, pkg_attrs, filename, lineno):
+            sys.exit(0)
+
+        operation = abort_func
+
+    elif op[0] == "exit":
+        exitval = 0
+        msg = None
+
+        if len(op) == 2:
+            args = op[1].split(None, 1)
+            try:
+                exitval = int(args[0])
+            except ValueError:
+                raise RuntimeError(
+                    _(
+                        "transform ({0}) has 'exit' "
+                        "operation syntax error: illegal exit value"
+                    ).format(transform)
+                )
+            if len(args) == 2:
+                msg = args[1]
+
+        def exit_func(action, matches, pkg_attrs, filename, lineno):
+            if msg:
+                newmsg = substitute_values(
+                    msg,
+                    action,
+                    matches,
+                    pkg_attrs,
+                    filename,
+                    lineno,
+                    quote=True,
+                )
+                print(newmsg, file=sys.stderr)
+            sys.exit(exitval)
+
+        operation = exit_func
+
+    elif op[0] == "add":
+        try:
+            attr, value = shlex.split(op[1])
+        except ValueError:
+            raise RuntimeError(
+                _("transform ({0}) has 'add' operation syntax error").format(
+                    transform
+                )
+            )
+
+        def add_func(action, matches, pkg_attrs, filename, lineno):
+            newattr = substitute_values(
+                attr, action, matches, pkg_attrs, filename, lineno
+            )
+            newval = substitute_values(
+                value, action, matches, pkg_attrs, filename, lineno
+            )
+            if newattr in action.attrs:
+                av = action.attrs[newattr]
+                if isinstance(av, list):
+                    action.attrs[newattr].append(newval)
+                else:
+                    action.attrs[newattr] = [av, newval]
+            else:
+                action.attrs[newattr] = newval
+            return action
+
+        operation = add_func
+
+    elif op[0] == "edit":
+        if len(op) < 2:
+            raise RuntimeError(
+                _("transform ({0}) has 'edit' operation syntax error").format(
+                    transform
+                )
+            )
+
+        args = shlex.split(op[1])
+        if len(args) not in [2, 3]:
+            raise RuntimeError(
+                _("transform ({0}) has 'edit' operation syntax error").format(
+                    transform
+                )
+            )
+        attr = args[0]
+
+        # Run args[1] (the regexp) through substitute_values() with a
+        # bunch of bogus values to see whether it triggers certain
+        # exceptions.  If it does, then substitution would have
+        # occurred, and we can't compile the regex now, but wait until
+        # we can correctly run substitute_values().
+        try:
+            substitute_values(args[1], None, [], None, None, None)
+            regexp = re.compile(args[1])
+        except (AttributeError, RuntimeError):
+            regexp = args[1]
+        except re.error as e:
+            raise RuntimeError(
+                _(
+                    "transform ({transform}) has 'edit' operation "
+                    "with malformed regexp ({err})"
+                ).format(transform=transform, err=e)
+            )
+
+        if len(args) == 3:
+            replace = args[2]
+        else:
+            replace = ""
+
+        def replace_func(action, matches, pkg_attrs, filename, lineno):
+            newattr = substitute_values(
+                attr, action, matches, pkg_attrs, filename, lineno
+            )
+            newrep = substitute_values(
+                replace, action, matches, pkg_attrs, filename, lineno
+            )
+            val = attrval_as_list(action.attrs, newattr)
+
+            if not val:
+                return action
+
+            # It's now appropriate to compile the regexp, if there
+            # are substitutions to be made.  So do the substitution
+            # and compile the result.
+            if isinstance(regexp, six.string_types):
+                rx = re.compile(
+                    substitute_values(
+                        regexp, action, matches, pkg_attrs, filename, lineno
+                    )
+                )
+            else:
+                rx = regexp
+
+            try:
+                action.attrs[newattr] = [rx.sub(newrep, v) for v in val]
+            except re.error as e:
+                raise RuntimeError(
+                    _(
+                        "transform ({transform}) has edit "
+                        "operation with replacement string regexp "
+                        "error {err}"
+                    ).format(transform=transform, err=e)
+                )
+            return action
+
+        operation = replace_func
+
+    elif op[0] == "delete":
+        if len(op) < 2:
+            raise RuntimeError(
+                _("transform ({0}) has 'delete' operation syntax error").format(
+                    transform
+                )
+            )
+
+        args = shlex.split(op[1])
+        if len(args) != 2:
+            raise RuntimeError(
+                _("transform ({0}) has 'delete' operation syntax error").format(
+                    transform
+                )
+            )
+        attr = args[0]
 
         try:
-                index = s.index("->")
-        except ValueError:
-                raise RuntimeError(_("Missing -> in transform"))
-        matching = s[0:index].strip().split()
-        types = [a for a in matching if "=" not in a]
-        attrdict = pkg.actions.attrsfromstr(" ".join([a for a in matching if "=" in a]))
-
-        for a in attrdict:
-                try:
-                        attrdict[a] = re.compile(attrdict[a])
-                except re.error as e:
-                        raise RuntimeError(
-                            _("transform ({transform}) has regexp error "
-                            "({err}) in matching clause"
-                            ).format(transform=transform, err=e))
-
-        op = s[index+2:].strip().split(None, 1)
-
-        # use closures to encapsulate desired operation
-
-        if op[0] == "drop":
-                if len(op) > 1:
-                        raise RuntimeError(
-                            _("transform ({0}) has 'drop' operation syntax error"
-                            ).format(transform))
-                operation = lambda a, m, p, f, l: None
-
-        elif op[0] == "set":
-                try:
-                        attr, value = shlex.split(op[1])
-                except ValueError:
-                        raise RuntimeError(
-                            _("transform ({0}) has 'set' operation syntax error"
-                            ).format(transform))
-                def set_func(action, matches, pkg_attrs, filename, lineno):
-                        newattr = substitute_values(attr, action, matches,
-                            pkg_attrs, filename, lineno)
-                        newval = substitute_values(value, action, matches,
-                            pkg_attrs, filename, lineno)
-                        if newattr == "action.hash":
-                                if hasattr(action, "hash"):
-                                        action.hash = newval
-                        else:
-                                action.attrs[newattr] = newval
-                        return action
-                operation = set_func
-
-        elif op[0] == "default":
-                try:
-                        attr, value = shlex.split(op[1])
-                except ValueError:
-                        raise RuntimeError(
-                            _("transform ({0}) has 'default' operation syntax error"
-                            ).format(transform))
-
-                def default_func(action, matches, pkg_attrs, filename, lineno):
-                        newattr = substitute_values(attr, action, matches,
-                            pkg_attrs, filename, lineno)
-                        if newattr not in action.attrs:
-                                newval = substitute_values(value, action,
-                                    matches, pkg_attrs, filename, lineno)
-                                action.attrs[newattr] = newval
-                        return action
-                operation = default_func
-
-        elif op[0] == "abort":
-                if len(op) > 1:
-                        raise RuntimeError(_("transform ({0}) has 'abort' "
-                            "operation syntax error").format(transform))
-
-                def abort_func(action, matches, pkg_attrs, filename, lineno):
-                        sys.exit(0)
-
-                operation = abort_func
-
-        elif op[0] == "exit":
-                exitval = 0
-                msg = None
-
-                if len(op) == 2:
-                        args = op[1].split(None, 1)
-                        try:
-                                exitval = int(args[0])
-                        except ValueError:
-                                raise RuntimeError(_("transform ({0}) has 'exit' "
-                                    "operation syntax error: illegal exit value").format(
-                                    transform))
-                        if len(args) == 2:
-                                msg = args[1]
-
-                def exit_func(action, matches, pkg_attrs, filename, lineno):
-                        if msg:
-                                newmsg = substitute_values(msg, action,
-                                    matches, pkg_attrs, filename, lineno,
-                                    quote=True)
-                                print(newmsg, file=sys.stderr)
-                        sys.exit(exitval)
-
-                operation = exit_func
-
-        elif op[0] == "add":
-                try:
-                        attr, value = shlex.split(op[1])
-                except ValueError:
-                        raise RuntimeError(
-                            _("transform ({0}) has 'add' operation syntax error"
-                            ).format(transform))
-
-                def add_func(action, matches, pkg_attrs, filename, lineno):
-                        newattr = substitute_values(attr, action, matches,
-                            pkg_attrs, filename, lineno)
-                        newval = substitute_values(value, action, matches,
-                            pkg_attrs, filename, lineno)
-                        if newattr in action.attrs:
-                                av = action.attrs[newattr]
-                                if isinstance(av, list):
-                                        action.attrs[newattr].append(newval)
-                                else:
-                                        action.attrs[newattr] = [ av, newval ]
-                        else:
-                                action.attrs[newattr] = newval
-                        return action
-                operation = add_func
-
-        elif op[0] == "edit":
-                if len(op) < 2:
-                        raise RuntimeError(
-                            _("transform ({0}) has 'edit' operation syntax error"
-                            ).format(transform))
-
-                args = shlex.split(op[1])
-                if len(args) not in [2, 3]:
-                        raise RuntimeError(
-                            _("transform ({0}) has 'edit' operation syntax error"
-                            ).format(transform))
-                attr = args[0]
-
-                # Run args[1] (the regexp) through substitute_values() with a
-                # bunch of bogus values to see whether it triggers certain
-                # exceptions.  If it does, then substitution would have
-                # occurred, and we can't compile the regex now, but wait until
-                # we can correctly run substitute_values().
-                try:
-                        substitute_values(args[1], None, [], None, None, None)
-                        regexp = re.compile(args[1])
-                except (AttributeError, RuntimeError):
-                        regexp = args[1]
-                except re.error as e:
-                        raise RuntimeError(
-                            _("transform ({transform}) has 'edit' operation "
-                            "with malformed regexp ({err})").format(
-                            transform=transform, err=e))
-
-                if len(args) == 3:
-                        replace = args[2]
-                else:
-                        replace = ""
-
-                def replace_func(action, matches, pkg_attrs, filename, lineno):
-                        newattr = substitute_values(attr, action, matches,
-                            pkg_attrs, filename, lineno)
-                        newrep = substitute_values(replace, action, matches,
-                            pkg_attrs, filename, lineno)
-                        val = attrval_as_list(action.attrs, newattr)
-
-                        if not val:
-                                return action
-
-                        # It's now appropriate to compile the regexp, if there
-                        # are substitutions to be made.  So do the substitution
-                        # and compile the result.
-                        if isinstance(regexp, six.string_types):
-                                rx = re.compile(substitute_values(regexp,
-                                    action, matches, pkg_attrs, filename, lineno))
-                        else:
-                                rx = regexp
-
-                        try:
-                                action.attrs[newattr] = [
-                                    rx.sub(newrep, v)
-                                    for v in val
-                                ]
-                        except re.error as e:
-                                raise RuntimeError(
-                                    _("transform ({transform}) has edit "
-                                    "operation with replacement string regexp "
-                                    "error {err}").format(
-                                    transform=transform, err=e))
-                        return action
-
-                operation = replace_func
-
-        elif op[0] == "delete":
-                if len(op) < 2:
-                        raise RuntimeError(
-                            _("transform ({0}) has 'delete' operation syntax error"
-                            ).format(transform))
-
-                args = shlex.split(op[1])
-                if len(args) != 2:
-                        raise RuntimeError(
-                            _("transform ({0}) has 'delete' operation syntax error"
-                            ).format(transform))
-                attr = args[0]
-
-                try:
-                        regexp = re.compile(args[1])
-                except re.error as e:
-                        raise RuntimeError(
-                            _("transform ({transform}) has 'delete' operation"
-                            "with malformed regexp ({err})").format(
-                            transform=transform, err=e))
-
-                def delete_func(action, matches, pkg_attrs, filename, lineno):
-                        val = attrval_as_list(action.attrs, attr)
-                        if not val:
-                                return action
-                        try:
-                                new_val = [
-                                    v
-                                    for v in val
-                                    if not regexp.search(v)
-                                ]
-
-                                if new_val:
-                                        action.attrs[attr] = new_val
-                                else:
-                                        del action.attrs[attr]
-                        except re.error as e:
-                                raise RuntimeError(
-                                    _("transform ({transform}) has delete "
-                                    "operation with replacement string regexp "
-                                    "error {err}").format(
-                                    transform=transform, err=e))
-                        return action
-
-                operation = delete_func
-
-        elif op[0] == "print":
-                if len(op) > 2:
-                        raise RuntimeError(_("transform ({0}) has 'print' "
-                            "operation syntax error").format(transform))
-
-                if len(op) == 1:
-                        msg = ""
-                else:
-                        msg = op[1]
-
-                def print_func(action, matches, pkg_attrs, filename, lineno):
-                        newmsg = substitute_values(msg, action, matches,
-                            pkg_attrs, filename, lineno, quote=True)
-
-                        printinfo.append("{0}".format(newmsg))
-                        return action
-
-                operation = print_func
-
-        elif op[0] == "emit":
-                if len(op) > 2:
-                        raise RuntimeError(_("transform ({0}) has 'emit' "
-                            "operation syntax error").format(transform))
-
-                if len(op) == 1:
-                        msg = ""
-                else:
-                        msg = op[1]
-
-                def emit_func(action, matches, pkg_attrs, filename, lineno):
-                        newmsg = substitute_values(msg, action, matches,
-                            pkg_attrs, filename, lineno, quote=True)
-
-                        if not newmsg.strip() or newmsg.strip()[0] == "#":
-                                return (newmsg, action)
-                        try:
-                                return (pkg.actions.fromstr(newmsg), action)
-                        except (pkg.actions.MalformedActionError,
-                            pkg.actions.UnknownActionError,
-                            pkg.actions.InvalidActionError) as e:
-                                raise RuntimeError(e)
-
-                operation = emit_func
-
-        else:
-                raise RuntimeError(_("unknown transform operation '{0}'").format(op[0]))
-
-        transforms.append((types, attrdict, operation, filename, lineno, transform))
-
-def substitute_values(msg, action, matches, pkg_attrs, filename=None, lineno=None, quote=False):
-        """Substitute tokens in messages which can be expanded to the action's
-        attribute values."""
-
-        newmsg = ""
-        prevend = 0
-        for i in re.finditer(r"%\((.+?)\)|%\{(.+?)\}", msg):
-                m = i.string[slice(*i.span())]
-                assert m[1] in "({"
-                if m[1] == "(":
-                        group = 1
-                elif m[1] == "{":
-                        group = 2
-                d = {}
-                if ";" in i.group(group):
-                        attrname, args = i.group(group).split(";", 1)
-                        tokstream = shlex.shlex(args)
-                        for tok in tokstream:
-                                if tok == ";":
-                                        tok = tokstream.get_token()
-                                eq = tokstream.get_token()
-                                if eq == "" or eq == ";":
-                                        val = True
-                                else:
-                                        assert(eq == "=")
-                                        val = tokstream.get_token()
-                                        if ('"', '"') == (val[0], val[-1]):
-                                                val = val[1:-1]
-                                        elif ("'", "'") == (val[0], val[-1]):
-                                                val = val[1:-1]
-                                d[tok] = val
-                else:
-                        attrname = i.group(group)
-
-                d.setdefault("quote", quote)
-
-                if d.get("noquote", None):
-                        d["quote"] = False
-
-                if group == 2:
-                        attr = pkg_attrs.get(attrname, d.get("notfound", None))
-                        if attr and len(attr) == 1:
-                                attr = attr[0]
-                else:
-                        if attrname == "pkg.manifest.lineno":
-                                attr = str(lineno)
-                        elif attrname == "pkg.manifest.filename":
-                                attr = str(filename)
-                        elif attrname == "action.hash":
-                                attr = getattr(action, "hash",
-                                    d.get("notfound", None))
-                        elif attrname == "action.key":
-                                attr = action.attrs.get(action.key_attr,
-                                    d.get("notfound", None))
-                        elif attrname == "action.name":
-                                attr = action.name
-                        else:
-                                attr = action.attrs.get(attrname,
-                                    d.get("notfound", None))
-
-                if attr is None:
-                        raise RuntimeError(_("attribute '{0}' not found").format(
-                            attrname))
-
-                def q(s):
-                        if " " in s or "'" in s or "\"" in s or s == "":
-                                if "\"" not in s:
-                                        return '"{0}"'.format(s)
-                                elif "'" not in s:
-                                        return "'{0}'".format(s)
-                                else:
-                                        return '"{0}"'.format(s.replace("\"", "\\\""))
-                        else:
-                                return s
-
-                if not d["quote"]:
-                        q = lambda x: x
-
-                if isinstance(attr, six.string_types):
-                        newmsg += msg[prevend:i.start()] + \
-                            d.get("prefix", "") + q(attr) + d.get("suffix", "")
-                else:
-                        newmsg += msg[prevend:i.start()] + \
-                            d.get("sep", " ").join([
-                                d.get("prefix", "") + q(v) + d.get("suffix", "")
-                                for v in attr
-                            ])
-                prevend = i.end()
-
-        newmsg += msg[prevend:]
-
-        # Now see if there are any backreferences to match groups
-        msg = newmsg
-        newmsg = ""
-        prevend = 0
-        backrefs = sum((
-            group
-            for group in (
-                match.groups()
-                for match in matches
-                if match.groups()
+            regexp = re.compile(args[1])
+        except re.error as e:
+            raise RuntimeError(
+                _(
+                    "transform ({transform}) has 'delete' operation"
+                    "with malformed regexp ({err})"
+                ).format(transform=transform, err=e)
             )
-        ), (None,))
-        for i in re.finditer(r"%<\d>", msg):
-                ref = int(i.string[slice(*i.span())][2:-1])
 
-                if ref == 0 or ref > len(backrefs) - 1:
-                        raise RuntimeError(_("no match group {group:d} "
-                            "(max {maxgroups:d})").format(
-                            group=ref, maxgroups=len(backrefs) - 1))
-                if backrefs[ref] is None:
-                        raise RuntimeError(_("Error\nInvalid backreference: "
-                            "%<{ref}> refers to an unmatched string"
-                            ).format(ref=ref))
-                newmsg += msg[prevend:i.start()] + backrefs[ref]
-                prevend = i.end()
+        def delete_func(action, matches, pkg_attrs, filename, lineno):
+            val = attrval_as_list(action.attrs, attr)
+            if not val:
+                return action
+            try:
+                new_val = [v for v in val if not regexp.search(v)]
 
-        newmsg += msg[prevend:]
-        return newmsg
+                if new_val:
+                    action.attrs[attr] = new_val
+                else:
+                    del action.attrs[attr]
+            except re.error as e:
+                raise RuntimeError(
+                    _(
+                        "transform ({transform}) has delete "
+                        "operation with replacement string regexp "
+                        "error {err}"
+                    ).format(transform=transform, err=e)
+                )
+            return action
+
+        operation = delete_func
+
+    elif op[0] == "print":
+        if len(op) > 2:
+            raise RuntimeError(
+                _(
+                    "transform ({0}) has 'print' " "operation syntax error"
+                ).format(transform)
+            )
+
+        if len(op) == 1:
+            msg = ""
+        else:
+            msg = op[1]
+
+        def print_func(action, matches, pkg_attrs, filename, lineno):
+            newmsg = substitute_values(
+                msg, action, matches, pkg_attrs, filename, lineno, quote=True
+            )
+
+            printinfo.append("{0}".format(newmsg))
+            return action
+
+        operation = print_func
+
+    elif op[0] == "emit":
+        if len(op) > 2:
+            raise RuntimeError(
+                _(
+                    "transform ({0}) has 'emit' " "operation syntax error"
+                ).format(transform)
+            )
+
+        if len(op) == 1:
+            msg = ""
+        else:
+            msg = op[1]
+
+        def emit_func(action, matches, pkg_attrs, filename, lineno):
+            newmsg = substitute_values(
+                msg, action, matches, pkg_attrs, filename, lineno, quote=True
+            )
+
+            if not newmsg.strip() or newmsg.strip()[0] == "#":
+                return (newmsg, action)
+            try:
+                return (pkg.actions.fromstr(newmsg), action)
+            except (
+                pkg.actions.MalformedActionError,
+                pkg.actions.UnknownActionError,
+                pkg.actions.InvalidActionError,
+            ) as e:
+                raise RuntimeError(e)
+
+        operation = emit_func
+
+    else:
+        raise RuntimeError(_("unknown transform operation '{0}'").format(op[0]))
+
+    transforms.append((types, attrdict, operation, filename, lineno, transform))
+
+
+def substitute_values(
+    msg, action, matches, pkg_attrs, filename=None, lineno=None, quote=False
+):
+    """Substitute tokens in messages which can be expanded to the action's
+    attribute values."""
+
+    newmsg = ""
+    prevend = 0
+    for i in re.finditer(r"%\((.+?)\)|%\{(.+?)\}", msg):
+        m = i.string[slice(*i.span())]
+        assert m[1] in "({"
+        if m[1] == "(":
+            group = 1
+        elif m[1] == "{":
+            group = 2
+        d = {}
+        if ";" in i.group(group):
+            attrname, args = i.group(group).split(";", 1)
+            tokstream = shlex.shlex(args)
+            for tok in tokstream:
+                if tok == ";":
+                    tok = tokstream.get_token()
+                eq = tokstream.get_token()
+                if eq == "" or eq == ";":
+                    val = True
+                else:
+                    assert eq == "="
+                    val = tokstream.get_token()
+                    if ('"', '"') == (val[0], val[-1]):
+                        val = val[1:-1]
+                    elif ("'", "'") == (val[0], val[-1]):
+                        val = val[1:-1]
+                d[tok] = val
+        else:
+            attrname = i.group(group)
+
+        d.setdefault("quote", quote)
+
+        if d.get("noquote", None):
+            d["quote"] = False
+
+        if group == 2:
+            attr = pkg_attrs.get(attrname, d.get("notfound", None))
+            if attr and len(attr) == 1:
+                attr = attr[0]
+        else:
+            if attrname == "pkg.manifest.lineno":
+                attr = str(lineno)
+            elif attrname == "pkg.manifest.filename":
+                attr = str(filename)
+            elif attrname == "action.hash":
+                attr = getattr(action, "hash", d.get("notfound", None))
+            elif attrname == "action.key":
+                attr = action.attrs.get(
+                    action.key_attr, d.get("notfound", None)
+                )
+            elif attrname == "action.name":
+                attr = action.name
+            else:
+                attr = action.attrs.get(attrname, d.get("notfound", None))
+
+        if attr is None:
+            raise RuntimeError(_("attribute '{0}' not found").format(attrname))
+
+        def q(s):
+            if " " in s or "'" in s or '"' in s or s == "":
+                if '"' not in s:
+                    return '"{0}"'.format(s)
+                elif "'" not in s:
+                    return "'{0}'".format(s)
+                else:
+                    return '"{0}"'.format(s.replace('"', '\\"'))
+            else:
+                return s
+
+        if not d["quote"]:
+            q = lambda x: x
+
+        if isinstance(attr, six.string_types):
+            newmsg += (
+                msg[prevend : i.start()]
+                + d.get("prefix", "")
+                + q(attr)
+                + d.get("suffix", "")
+            )
+        else:
+            newmsg += msg[prevend : i.start()] + d.get("sep", " ").join(
+                [d.get("prefix", "") + q(v) + d.get("suffix", "") for v in attr]
+            )
+        prevend = i.end()
+
+    newmsg += msg[prevend:]
+
+    # Now see if there are any backreferences to match groups
+    msg = newmsg
+    newmsg = ""
+    prevend = 0
+    backrefs = sum(
+        (
+            group
+            for group in (match.groups() for match in matches if match.groups())
+        ),
+        (None,),
+    )
+    for i in re.finditer(r"%<\d>", msg):
+        ref = int(i.string[slice(*i.span())][2:-1])
+
+        if ref == 0 or ref > len(backrefs) - 1:
+            raise RuntimeError(
+                _("no match group {group:d} " "(max {maxgroups:d})").format(
+                    group=ref, maxgroups=len(backrefs) - 1
+                )
+            )
+        if backrefs[ref] is None:
+            raise RuntimeError(
+                _(
+                    "Error\nInvalid backreference: "
+                    "%<{ref}> refers to an unmatched string"
+                ).format(ref=ref)
+            )
+        newmsg += msg[prevend : i.start()] + backrefs[ref]
+        prevend = i.end()
+
+    newmsg += msg[prevend:]
+    return newmsg
+
 
 def attrval_as_list(attrdict, key):
-        """Return specified attribute as list;
-        an empty list if no such attribute exists"""
-        if key not in attrdict:
-                return []
-        val = attrdict[key]
-        if not isinstance(val, list):
-                val = [val]
-        return val
+    """Return specified attribute as list;
+    an empty list if no such attribute exists"""
+    if key not in attrdict:
+        return []
+    val = attrdict[key]
+    if not isinstance(val, list):
+        val = [val]
+    return val
+
 
 class PkgAction(pkg.actions.generic.Action):
-        name = "pkg"
-        def __init__(self, attrs):
-                self.attrs = attrs
+    name = "pkg"
 
-def apply_transforms(transforms, action, pkg_attrs, verbose, act_filename,
-    act_lineno):
-        """Apply all transforms to action, returning modified action
-        or None if action is dropped"""
-        comments = []
-        newactions = []
+    def __init__(self, attrs):
+        self.attrs = attrs
+
+
+def apply_transforms(
+    transforms, action, pkg_attrs, verbose, act_filename, act_lineno
+):
+    """Apply all transforms to action, returning modified action
+    or None if action is dropped"""
+    comments = []
+    newactions = []
+    if verbose:
+        comments.append("#  Action: {0}".format(action))
+    for types, attrdict, operation, filename, lineno, transform in transforms:
+        if action is None:
+            action = PkgAction(pkg_attrs)
+        # skip if types are specified and none match
+        if types and action.name not in types:
+            continue
+        # skip if some attrs don't exist
+        if set(attrdict.keys()) - set(action.attrs.keys()):
+            continue
+
+        # Check to make sure all matching attrs actually match.  The
+        # order is effectively arbitrary, since they come from a dict.
+        matches = [
+            attrdict[key].match(attrval)
+            for key in attrdict
+            for attrval in attrval_as_list(action.attrs, key)
+        ]
+
+        if not all(matches):
+            continue
+
+        s = transform[11 : transform.index("->")]
+        # Map each pattern to its position in the original match string.
+        matchorder = {}
+        for attr, match in six.iteritems(attrdict):
+            # Attributes might be quoted even if they don't need it,
+            # and lead to a mis-match.  These three patterns are all
+            # safe to try.  If we fail to find the match expression,
+            # it's probably because it used different quoting rules
+            # than the action code does, or from these three rules.
+            # It might very well be okay, so we go ahead, but these
+            # oddly quoted patterns will sort at the beginning, and
+            # backref matching may be off.
+            matchorder[match.pattern] = -1
+            for qs in ("{0}={1}", '{0}="{1}"', "{0}='{1}'"):
+                pos = s.find(qs.format(attr, match.pattern))
+                if pos != -1:
+                    matchorder[match.pattern] = pos
+                    break
+
+        # Then sort the matches list by those positions.
+        matches.sort(key=lambda x: matchorder[x.re.pattern])
+
+        # time to apply transform operation
+        try:
+            if verbose:
+                orig_attrs = action.attrs.copy()
+            action = operation(
+                action, matches, pkg_attrs, act_filename, act_lineno
+            )
+        except RuntimeError as e:
+            raise RuntimeError(
+                "Transform specified in file {0}, line {1} reports {2}".format(
+                    filename, lineno, e
+                )
+            )
+        if isinstance(action, tuple):
+            newactions.append(action[0])
+            action = action[1]
         if verbose:
-                comments.append("#  Action: {0}".format(action))
-        for types, attrdict, operation, filename, lineno, transform in transforms:
-                if action is None:
-                        action = PkgAction(pkg_attrs)
-                # skip if types are specified and none match
-                if types and action.name not in types:
-                        continue
-                # skip if some attrs don't exist
-                if set(attrdict.keys()) - set(action.attrs.keys()):
-                        continue
+            if (
+                not action
+                or not isinstance(action, six.string_types)
+                and orig_attrs != action.attrs
+            ):
+                comments.append(
+                    "# Applied: {0} (file {1} line {2})".format(
+                        transform, filename, lineno
+                    )
+                )
+                comments.append("#  Result: {0}".format(action))
+        if not action or isinstance(action, six.string_types):
+            break
 
-                # Check to make sure all matching attrs actually match.  The
-                # order is effectively arbitrary, since they come from a dict.
-                matches = [
-                    attrdict[key].match(attrval)
-                    for key in attrdict
-                    for attrval in attrval_as_list(action.attrs, key)
-                ]
-
-                if not all(matches):
-                        continue
-
-                s = transform[11:transform.index("->")]
-                # Map each pattern to its position in the original match string.
-                matchorder = {}
-                for attr, match in six.iteritems(attrdict):
-                        # Attributes might be quoted even if they don't need it,
-                        # and lead to a mis-match.  These three patterns are all
-                        # safe to try.  If we fail to find the match expression,
-                        # it's probably because it used different quoting rules
-                        # than the action code does, or from these three rules.
-                        # It might very well be okay, so we go ahead, but these
-                        # oddly quoted patterns will sort at the beginning, and
-                        # backref matching may be off.
-                        matchorder[match.pattern] = -1
-                        for qs in ("{0}={1}", "{0}=\"{1}\"", "{0}='{1}'"):
-                                pos = s.find(qs.format(attr, match.pattern))
-                                if pos != -1:
-                                        matchorder[match.pattern] = pos
-                                        break
-
-                # Then sort the matches list by those positions.
-                matches.sort(key=lambda x: matchorder[x.re.pattern])
-
-                # time to apply transform operation
-                try:
-                        if verbose:
-                                orig_attrs = action.attrs.copy()
-                        action = operation(action, matches, pkg_attrs,
-                            act_filename, act_lineno)
-                except RuntimeError as e:
-                        raise RuntimeError("Transform specified in file {0}, line {1} reports {2}".format(
-                            filename, lineno, e))
-                if isinstance(action, tuple):
-                        newactions.append(action[0])
-                        action = action[1]
-                if verbose:
-                        if not action or \
-                            not isinstance(action, six.string_types) and \
-                            orig_attrs != action.attrs:
-                                comments.append("# Applied: {0} (file {1} line {2})".format(
-                                    transform, filename, lineno))
-                                comments.append("#  Result: {0}".format(action))
-                if not action or isinstance(action, six.string_types):
-                        break
-
-        # Any newly-created actions need to have the transforms applied, too.
-        newnewactions = []
-        for act in newactions:
-                if not isinstance(act, six.string_types):
-                        c, al = apply_transforms(transforms, act, pkg_attrs,
-                            verbose, act_filename, act_lineno)
-                        if c:
-                                comments.append(c)
-                        newnewactions += [a for a in al if a is not None]
-                else:
-                        newnewactions.append(act)
-
-        if len(comments) == 1:
-                comments = []
-
-        if action and action.name != "pkg":
-                return (comments, [action] + newnewactions)
+    # Any newly-created actions need to have the transforms applied, too.
+    newnewactions = []
+    for act in newactions:
+        if not isinstance(act, six.string_types):
+            c, al = apply_transforms(
+                transforms, act, pkg_attrs, verbose, act_filename, act_lineno
+            )
+            if c:
+                comments.append(c)
+            newnewactions += [a for a in al if a is not None]
         else:
-                return (comments, [None] + newnewactions)
+            newnewactions.append(act)
+
+    if len(comments) == 1:
+        comments = []
+
+    if action and action.name != "pkg":
+        return (comments, [action] + newnewactions)
+    else:
+        return (comments, [None] + newnewactions)
 
 
 def searching_open(filename, includes, try_cwd=False):
-        """ implement include hierarchy """
+    """implement include hierarchy"""
 
-        if filename == "-":
-                return filename, sys.stdin
+    if filename == "-":
+        return filename, sys.stdin
 
-        if filename.startswith("/") or try_cwd == True and \
-            os.path.exists(filename):
-                try:
-                        return filename, open(filename)
-                except IOError as e:
-                        raise RuntimeError(_("Cannot open file: {0}").format(e))
+    if filename.startswith("/") or try_cwd == True and os.path.exists(filename):
+        try:
+            return filename, open(filename)
+        except IOError as e:
+            raise RuntimeError(_("Cannot open file: {0}").format(e))
 
-        for i in includes:
-                f = os.path.join(i, filename)
-                if os.path.exists(f):
-                        try:
-                                return f, open(f)
-                        except IOError as e:
-                                raise RuntimeError(_("Cannot open file: {0}").format(e))
+    for i in includes:
+        f = os.path.join(i, filename)
+        if os.path.exists(f):
+            try:
+                return f, open(f)
+            except IOError as e:
+                raise RuntimeError(_("Cannot open file: {0}").format(e))
 
-        raise RuntimeError(_("File not found: \'{0}\'").format(filename))
+    raise RuntimeError(_("File not found: '{0}'").format(filename))
+
 
 def apply_macros(s, macros):
-        """Apply macro subs defined on command line... keep applying
-        macros until no translations are found."""
-        while s and "$(" in s:
-                for key in macros.keys():
-                        if key in s:
-                                value = macros[key]
-                                s = s.replace(key, value)
-                                break # look for more substitutions
-                else:
-                        break # no more substitutable tokens
-        return s
+    """Apply macro subs defined on command line... keep applying
+    macros until no translations are found."""
+    while s and "$(" in s:
+        for key in macros.keys():
+            if key in s:
+                value = macros[key]
+                s = s.replace(key, value)
+                break  # look for more substitutions
+        else:
+            break  # no more substitutable tokens
+    return s
 
-def read_file(tp, ignoreincludes, transforms, macros, printinfo, includes,
-    error_print_cb=None):
-        """ return the lines in the file as a list of tuples containing
-        (line, filename, line number); handle continuation and <include "path">
-        """
-        ret = []
-        filename, f = tp
 
-        accumulate = ""
-        for lineno, line in enumerate(f):
-                lineno = lineno + 1 # number from 1
-                line = line.strip()
-                if not line: # preserve blanks
+def read_file(
+    tp,
+    ignoreincludes,
+    transforms,
+    macros,
+    printinfo,
+    includes,
+    error_print_cb=None,
+):
+    """return the lines in the file as a list of tuples containing
+    (line, filename, line number); handle continuation and <include "path">
+    """
+    ret = []
+    filename, f = tp
+
+    accumulate = ""
+    for lineno, line in enumerate(f):
+        lineno = lineno + 1  # number from 1
+        line = line.strip()
+        if not line:  # preserve blanks
+            ret.append((line, filename, lineno))
+            continue
+        if line.endswith("\\"):
+            accumulate += line[0:-1]
+            continue
+        elif accumulate:
+            line = accumulate + line
+            accumulate = ""
+
+        if line:
+            line = apply_macros(line, macros)
+
+        line = line.strip()
+
+        if not line:
+            continue
+
+        try:
+            if line.startswith("<") and line.endswith(">"):
+                if line.startswith("<include"):
+                    if not ignoreincludes:
+                        line = line[1:-1]
+                        line = line[7:].strip()
+                        line = line.strip('"')
+                        ret.extend(
+                            read_file(
+                                searching_open(line, includes, try_cwd=True),
+                                ignoreincludes,
+                                transforms,
+                                macros,
+                                printinfo,
+                                includes,
+                                error_print_cb,
+                            )
+                        )
+                    else:
                         ret.append((line, filename, lineno))
-                        continue
-                if line.endswith("\\"):
-                        accumulate += line[0:-1]
-                        continue
-                elif accumulate:
-                        line = accumulate + line
-                        accumulate = ""
+                elif line.startswith("<transform"):
+                    line = line[1:-1]
+                    add_transform(transforms, printinfo, line, filename, lineno)
+                else:
+                    raise RuntimeError(_("unknown command {0}").format(line))
+            else:
+                ret.append((line, filename, lineno))
+        except RuntimeError as e:
+            if error_print_cb:
+                error_print_cb(
+                    _("File {file}, line {line:d}: " "{exception}").format(
+                        file=filename, line=lineno, exception=e
+                    ),
+                    exitcode=None,
+                )
+            raise RuntimeError("<included from>")
+    f.close()
 
-                if line:
-                        line = apply_macros(line, macros)
+    return ret
 
-                line = line.strip()
-
-                if not line:
-                        continue
-
-                try:
-                        if line.startswith("<") and line.endswith(">"):
-                                if line.startswith("<include"):
-                                        if not ignoreincludes:
-                                                line = line[1:-1]
-                                                line = line[7:].strip()
-                                                line = line.strip('"')
-                                                ret.extend(read_file(
-                                                    searching_open(line, includes,
-                                                        try_cwd=True),
-                                                    ignoreincludes,
-                                                    transforms, macros,
-                                                    printinfo, includes,
-                                                    error_print_cb))
-                                        else:
-                                                ret.append((line, filename, lineno))
-                                elif line.startswith("<transform"):
-                                        line = line[1:-1]
-                                        add_transform(transforms, printinfo,
-                                            line, filename, lineno)
-                                else:
-                                        raise RuntimeError(
-                                            _("unknown command {0}").format(
-                                            line))
-                        else:
-                                ret.append((line, filename, lineno))
-                except RuntimeError as e:
-                        if error_print_cb:
-                                error_print_cb(_("File {file}, line {line:d}: "
-                                    "{exception}").format(file=filename,
-                                    line=lineno,
-                                    exception=e),
-                                    exitcode=None)
-                        raise RuntimeError("<included from>")
-        f.close()
-
-        return ret
 
 def process_error(msg, error_cb=None):
-        """Print the error message or raise the actual exception if no
-        error printing callback specified."""
+    """Print the error message or raise the actual exception if no
+    error printing callback specified."""
 
-        if error_cb:
-                error_cb(msg)
+    if error_cb:
+        error_cb(msg)
+    else:
+        raise
+
+
+def process_mog(
+    file_args,
+    ignoreincludes,
+    verbose,
+    includes,
+    macros,
+    printinfo,
+    output,
+    error_cb=None,
+    sys_supply_files=[],
+):
+    """Entry point for mogrify logic.
+    file_args: input files to be mogrified. If not provided, use stdin
+        instead.
+
+    ingoreincludes: whether to ignore <include ...> directives in input
+    files.
+
+    verbose: whether to include verbose action processing information
+    in mogrify output. Useful for debug.
+
+    includes: a list of directory paths used for searching include files.
+
+    macros: a list of macros for substitution.
+
+    printinfo: used to collect a list print info along processing. Could be
+    empty initially.
+
+    output: used to collect mogrify output. Empty initially.
+
+    error_cb: used to supply a error printing callback.
+
+    sys_supply_files: used for other systems or modules to supply
+    additional input files.
+    """
+
+    transforms = []
+    try:
+        if file_args:
+            infiles = [
+                searching_open(f, includes, try_cwd=True) for f in file_args
+            ]
         else:
-                raise
+            infiles = [("<stdin>", sys.stdin)]
+        if sys_supply_files:
+            infiles.extend(
+                [
+                    searching_open(f, includes, try_cwd=True)
+                    for f in sys_supply_files
+                ]
+            )
+    except RuntimeError as e:
+        process_error(
+            _("Error processing input arguments: {0}").format(e), error_cb
+        )
 
-def process_mog(file_args, ignoreincludes, verbose, includes, macros,
-    printinfo, output, error_cb=None, sys_supply_files=[]):
-        """Entry point for mogrify logic.
-        file_args: input files to be mogrified. If not provided, use stdin
-            instead.
+    try:
+        lines = []
+        for f in infiles:
+            lines.extend(
+                read_file(
+                    f,
+                    ignoreincludes,
+                    transforms,
+                    macros,
+                    printinfo,
+                    includes,
+                    error_cb,
+                )
+            )
+            lines.append((None, f[0], None))
+    except RuntimeError as e:
+        raise
 
-        ingoreincludes: whether to ignore <include ...> directives in input
-        files.
+    pkg_attrs = {}
+    for line, filename, lineno in lines:
+        if line is None:
+            if "pkg.fmri" in pkg_attrs:
+                comment, a = apply_transforms(
+                    transforms, None, pkg_attrs, verbose, filename, lineno
+                )
+                output.append((comment, a, None))
+            pkg_attrs = {}
+            continue
 
-        verbose: whether to include verbose action processing information
-        in mogrify output. Useful for debug.
+        if not line or line.startswith("#") or line.startswith("<"):
+            output.append(([line], [], None))
+            continue
 
-        includes: a list of directory paths used for searching include files.
+        if line.startswith("$("):  # prepended unexpanded macro
+            # doesn't handle nested macros
+            try:
+                eom = line.index(")") + 1
+            except ValueError as e:
+                process_error(
+                    "File {0} line {1:d}: '{2}' {3}".format(
+                        filename, lineno, line, "closing ')' not found"
+                    ),
+                    error_cb,
+                )
+            prepended_macro = line[0:eom]
+            line = line[eom:]
+        else:
+            prepended_macro = None
 
-        macros: a list of macros for substitution.
-
-        printinfo: used to collect a list print info along processing. Could be
-        empty initially.
-
-        output: used to collect mogrify output. Empty initially.
-
-        error_cb: used to supply a error printing callback.
-
-        sys_supply_files: used for other systems or modules to supply
-        additional input files.
-        """
-
-        transforms = []
         try:
-                if file_args:
-                        infiles = [ searching_open(f, includes,
-                            try_cwd=True) for f in file_args ]
-                else:
-                        infiles =  [("<stdin>", sys.stdin)]
-                if sys_supply_files:
-                        infiles.extend([searching_open(f, includes,
-                            try_cwd=True) for f in sys_supply_files])
-        except RuntimeError as e:
-                process_error(_("Error processing input arguments: {0}"
-                    ).format(e), error_cb)
-
+            act = pkg.actions.fromstr(line)
+        except (
+            pkg.actions.MalformedActionError,
+            pkg.actions.UnknownActionError,
+            pkg.actions.InvalidActionError,
+        ) as e:
+            process_error(
+                "File {0} line {1:d}: {2}".format(filename, lineno, e), error_cb
+            )
         try:
-                lines = []
-                for f in infiles:
-                        lines.extend(read_file(f, ignoreincludes,
-                            transforms, macros, printinfo, includes, error_cb))
-                        lines.append((None, f[0], None))
-        except RuntimeError as e:
-                raise
-
-        pkg_attrs = {}
-        for line, filename, lineno in lines:
-                if line is None:
-                        if "pkg.fmri" in pkg_attrs:
-                                comment, a = apply_transforms(transforms,
-                                    None, pkg_attrs,
-                                    verbose, filename, lineno)
-                                output.append((comment, a, None))
-                        pkg_attrs = {}
-                        continue
-
-                if not line or line.startswith("#") or line.startswith("<"):
-                        output.append(([line], [], None))
-                        continue
-
-                if line.startswith("$("): #prepended unexpanded macro
-                        # doesn't handle nested macros
-                        try:
-                                eom = line.index(")") + 1
-                        except ValueError as e:
-                                process_error("File {0} line {1:d}: '{2}' {3}"
-                                    .format(filename, lineno, line,
-                                    "closing ')' not found"), error_cb)
-                        prepended_macro = line[0:eom]
-                        line = line[eom:]
+            if act.name == "set":
+                name = act.attrs["name"]
+                value = act.attrs["value"]
+                if isinstance(value, six.string_types):
+                    pkg_attrs.setdefault(name, []).append(value)
                 else:
-                        prepended_macro = None
+                    pkg_attrs.setdefault(name, []).extend(value)
+            comment, a = apply_transforms(
+                transforms, act, pkg_attrs, verbose, filename, lineno
+            )
+            output.append((comment, a, prepended_macro))
+        except RuntimeError as e:
+            process_error(
+                "File {0} line {1:d}: {2}".format(filename, lineno, e), error_cb
+            )
 
-                try:
-                        act = pkg.actions.fromstr(line)
-                except (pkg.actions.MalformedActionError,
-                    pkg.actions.UnknownActionError,
-                    pkg.actions.InvalidActionError) as e:
-                        process_error("File {0} line {1:d}: {2}".format(
-                            filename, lineno, e), error_cb)
-                try:
-                        if act.name == "set":
-                                name = act.attrs["name"]
-                                value = act.attrs["value"]
-                                if isinstance(value, six.string_types):
-                                        pkg_attrs.setdefault(name, []).append(value)
-                                else:
-                                        pkg_attrs.setdefault(name, []).extend(value)
-                        comment, a = apply_transforms(transforms, act,
-                            pkg_attrs, verbose, filename, lineno)
-                        output.append((comment, a, prepended_macro))
-                except RuntimeError as e:
-                        process_error("File {0} line {1:d}: {2}".format(
-                            filename, lineno, e), error_cb)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/nrlock.py
+++ b/src/modules/nrlock.py
@@ -27,73 +27,76 @@ import threading
 import traceback
 
 # Rename some stuff so "from pkg.nrlock import *" is safe
-__all__ = [ 'NRLock' ]
+__all__ = ["NRLock"]
+
 
 def NRLock(*args, **kwargs):
-        return _NRLock(*args, **kwargs)
+    return _NRLock(*args, **kwargs)
+
 
 class _NRLock(threading._RLock):
-        """Interface and implementation for Non-Reentrant locks.  Derived from
-        RLocks (which are reentrant locks).  The default Python base locking
-        type, threading.Lock(), is non-reentrant but it doesn't support any
-        operations other than aquire() and release(), and we'd like to be
-        able to support things like RLocks._is_owned() so that we can "assert"
-        lock ownership assumptions in our code."""
+    """Interface and implementation for Non-Reentrant locks.  Derived from
+    RLocks (which are reentrant locks).  The default Python base locking
+    type, threading.Lock(), is non-reentrant but it doesn't support any
+    operations other than aquire() and release(), and we'd like to be
+    able to support things like RLocks._is_owned() so that we can "assert"
+    lock ownership assumptions in our code."""
 
-        def __init__(self):
-                threading._RLock.__init__(self)
+    def __init__(self):
+        threading._RLock.__init__(self)
 
-        def acquire(self, blocking=1):
-                if self._is_owned():
-                        raise NRLockException("Recursive NRLock acquire")
-                return threading._RLock.acquire(self, blocking)
+    def acquire(self, blocking=1):
+        if self._is_owned():
+            raise NRLockException("Recursive NRLock acquire")
+        return threading._RLock.acquire(self, blocking)
 
-        @property
-        def locked(self):
-                """A boolean indicating whether the lock is currently locked."""
-                return self._is_owned()
+    @property
+    def locked(self):
+        """A boolean indicating whether the lock is currently locked."""
+        return self._is_owned()
 
-        def _debug_lock_release(self):
-                errbuf = ""
-                owner = self._RLock__owner
-                if not owner:
-                        return errbuf
+    def _debug_lock_release(self):
+        errbuf = ""
+        owner = self._RLock__owner
+        if not owner:
+            return errbuf
 
-                # Get stack of current owner, if lock is owned.
-                for tid, stack in sys._current_frames().items():
-                        if tid != owner.ident:
-                                continue
-                        errbuf += "Stack of owner:\n"
-                        for filenm, lno, func, txt in \
-                            traceback.extract_stack(stack):
-                                errbuf += "  File: \"{0}\", line {1:d},in {2}".format(
-                                    filenm, lno, func)
-                                if txt:
-                                        errbuf += "\n    {0}".format(txt.strip())
-                                errbuf += "\n"
-                        break
+        # Get stack of current owner, if lock is owned.
+        for tid, stack in sys._current_frames().items():
+            if tid != owner.ident:
+                continue
+            errbuf += "Stack of owner:\n"
+            for filenm, lno, func, txt in traceback.extract_stack(stack):
+                errbuf += '  File: "{0}", line {1:d},in {2}'.format(
+                    filenm, lno, func
+                )
+                if txt:
+                    errbuf += "\n    {0}".format(txt.strip())
+                errbuf += "\n"
+            break
 
-                return errbuf
+        return errbuf
 
-        def release(self):
-                try:
-                        threading._RLock.release(self)
-                except RuntimeError:
-                        errbuf = "Release of unacquired lock\n"
-                        errbuf += self._debug_lock_release()
-                        raise NRLockException(errbuf)
+    def release(self):
+        try:
+            threading._RLock.release(self)
+        except RuntimeError:
+            errbuf = "Release of unacquired lock\n"
+            errbuf += self._debug_lock_release()
+            raise NRLockException(errbuf)
+
 
 class NRLockException(Exception):
+    def __init__(self, *args, **kwargs):
+        if args:
+            self.data = args[0]
+        else:
+            self.data = None
+        self._args = kwargs
 
-        def __init__(self, *args, **kwargs):
-                if args:
-                        self.data = args[0]
-                else:
-                        self.data = None
-                self._args = kwargs
+    def __str__(self):
+        return str(self.data)
 
-        def __str__(self):
-                return str(self.data)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/p5i.py
+++ b/src/modules/p5i.py
@@ -39,190 +39,201 @@ import pkg.fmri as fmri
 CURRENT_VERSION = 1
 MIME_TYPE = "application/vnd.pkg5.info"
 
+
 def parse(data=None, fileobj=None, location=None):
-        """Reads the pkg(7) publisher JSON formatted data at 'location'
-        or from the provided file-like object 'fileobj' and returns a
-        list of tuples of the format (publisher object, pkg_names).
-        pkg_names is a list of strings representing package names or
-        FMRIs.  If any pkg_names not specific to a publisher were
-        provided, the last tuple returned will be of the format (None,
-        pkg_names).
+    """Reads the pkg(7) publisher JSON formatted data at 'location'
+    or from the provided file-like object 'fileobj' and returns a
+    list of tuples of the format (publisher object, pkg_names).
+    pkg_names is a list of strings representing package names or
+    FMRIs.  If any pkg_names not specific to a publisher were
+    provided, the last tuple returned will be of the format (None,
+    pkg_names).
 
-        'data' is an optional string containing the p5i data.
+    'data' is an optional string containing the p5i data.
 
-        'fileobj' is an optional file-like object that must support a
-        'read' method for retrieving data.
+    'fileobj' is an optional file-like object that must support a
+    'read' method for retrieving data.
 
-        'location' is an optional string value that should either start
-        with a leading slash and be pathname of a file or a URI string.
-        If it is a URI string, supported protocol schemes are 'file',
-        'ftp', 'http', and 'https'.
+    'location' is an optional string value that should either start
+    with a leading slash and be pathname of a file or a URI string.
+    If it is a URI string, supported protocol schemes are 'file',
+    'ftp', 'http', and 'https'.
 
-        'data' or 'fileobj' or 'location' must be provided."""
+    'data' or 'fileobj' or 'location' must be provided."""
 
-        if data is None and location is None and fileobj is None:
-                raise api_errors.InvalidResourceLocation(location)
+    if data is None and location is None and fileobj is None:
+        raise api_errors.InvalidResourceLocation(location)
 
-        if location is not None:
-                if location.find("://") == -1 and \
-                    not location.startswith("file:/"):
-                        # Convert the file path to a URI.
-                        location = os.path.abspath(location)
-                        location = urlunparse(("file", "",
-                            pathname2url(location), "", "", ""))
-
-                try:
-                        fileobj = urlopen(location)
-                except (EnvironmentError, ValueError,
-                    HTTPError) as e:
-                        raise api_errors.RetrievalError(e,
-                            location=location)
+    if location is not None:
+        if location.find("://") == -1 and not location.startswith("file:/"):
+            # Convert the file path to a URI.
+            location = os.path.abspath(location)
+            location = urlunparse(
+                ("file", "", pathname2url(location), "", "", "")
+            )
 
         try:
-                if data is not None:
-                        dump_struct = json.loads(data)
-                else:
-                        dump_struct = json.load(fileobj)
-        except (EnvironmentError, HTTPError) as e:
-                raise api_errors.RetrievalError(e)
-        except ValueError as e:
-                # Not a valid JSON file.
-                raise api_errors.InvalidP5IFile(e)
+            fileobj = urlopen(location)
+        except (EnvironmentError, ValueError, HTTPError) as e:
+            raise api_errors.RetrievalError(e, location=location)
 
-        try:
-                ver = int(dump_struct["version"])
-        except KeyError:
-                raise api_errors.InvalidP5IFile(_("missing version"))
-        except ValueError:
-                raise api_errors.InvalidP5IFile(_("invalid version"))
+    try:
+        if data is not None:
+            dump_struct = json.loads(data)
+        else:
+            dump_struct = json.load(fileobj)
+    except (EnvironmentError, HTTPError) as e:
+        raise api_errors.RetrievalError(e)
+    except ValueError as e:
+        # Not a valid JSON file.
+        raise api_errors.InvalidP5IFile(e)
 
-        if ver > CURRENT_VERSION:
-                raise api_errors.UnsupportedP5IFile()
+    try:
+        ver = int(dump_struct["version"])
+    except KeyError:
+        raise api_errors.InvalidP5IFile(_("missing version"))
+    except ValueError:
+        raise api_errors.InvalidP5IFile(_("invalid version"))
 
-        result = []
-        try:
-                plist = dump_struct.get("publishers", [])
+    if ver > CURRENT_VERSION:
+        raise api_errors.UnsupportedP5IFile()
 
-                for p in plist:
-                        alias = p.get("alias", None)
-                        prefix = p.get("name", None)
+    result = []
+    try:
+        plist = dump_struct.get("publishers", [])
 
-                        if not prefix:
-                                prefix = "Unknown"
+        for p in plist:
+            alias = p.get("alias", None)
+            prefix = p.get("name", None)
 
-                        pub = publisher.Publisher(prefix, alias=alias)
-                        pkglist = p.get("packages", [])
-                        result.append((pub, pkglist))
+            if not prefix:
+                prefix = "Unknown"
 
-                        for r in p.get("repositories", []):
-                                rargs = {}
-                                for prop in ("collection_type",
-                                    "description", "name",
-                                    "refresh_seconds",
-                                    "registration_uri"):
-                                        val = r.get(prop, None)
-                                        if val is None or val == "None":
-                                                continue
-                                        rargs[prop] = val
+            pub = publisher.Publisher(prefix, alias=alias)
+            pkglist = p.get("packages", [])
+            result.append((pub, pkglist))
 
-                                for prop in ("legal_uris", "mirrors",
-                                    "origins", "related_uris"):
-                                        val = r.get(prop, [])
-                                        if not isinstance(val, list):
-                                                continue
-                                        rargs[prop] = val
+            for r in p.get("repositories", []):
+                rargs = {}
+                for prop in (
+                    "collection_type",
+                    "description",
+                    "name",
+                    "refresh_seconds",
+                    "registration_uri",
+                ):
+                    val = r.get(prop, None)
+                    if val is None or val == "None":
+                        continue
+                    rargs[prop] = val
 
-                                repo = publisher.Repository(**rargs)
-                                pub.repository = repo
+                for prop in (
+                    "legal_uris",
+                    "mirrors",
+                    "origins",
+                    "related_uris",
+                ):
+                    val = r.get(prop, [])
+                    if not isinstance(val, list):
+                        continue
+                    rargs[prop] = val
 
-                pkglist = dump_struct.get("packages", [])
-                if pkglist:
-                        result.append((None, pkglist))
-        except (api_errors.PublisherError, TypeError, ValueError) as e:
-                raise api_errors.InvalidP5IFile(str(e))
-        return result
+                repo = publisher.Repository(**rargs)
+                pub.repository = repo
+
+        pkglist = dump_struct.get("packages", [])
+        if pkglist:
+            result.append((None, pkglist))
+    except (api_errors.PublisherError, TypeError, ValueError) as e:
+        raise api_errors.InvalidP5IFile(str(e))
+    return result
+
 
 def write(fileobj, pubs, pkg_names=None):
-        """Writes the publisher, repository, and provided package names to the
-        provided file-like object 'fileobj' in JSON p5i format.
+    """Writes the publisher, repository, and provided package names to the
+    provided file-like object 'fileobj' in JSON p5i format.
 
-        'fileobj' is an object that has a 'write' method that accepts data to be
-        written as a parameter.
+    'fileobj' is an object that has a 'write' method that accepts data to be
+    written as a parameter.
 
-        'pkg_names' is a dict of lists, tuples, or sets indexed by publisher
-        prefix that contain package names, FMRI strings, or FMRI objects.  A
-        prefix of "" can be used for packages that are that are not specific to
-        a publisher.
+    'pkg_names' is a dict of lists, tuples, or sets indexed by publisher
+    prefix that contain package names, FMRI strings, or FMRI objects.  A
+    prefix of "" can be used for packages that are that are not specific to
+    a publisher.
 
-        'pubs' is a list of Publisher objects."""
+    'pubs' is a list of Publisher objects."""
 
-        dump_struct = {
+    dump_struct = {
+        "packages": [],
+        "publishers": [],
+        "version": CURRENT_VERSION,
+    }
+
+    if pkg_names is None:
+        pkg_names = {}
+
+    def copy_pkg_names(source, dest):
+        for entry in source:
+            # Publisher information is intentionally
+            # omitted as association with this specific
+            # publisher is implied by location in the
+            # output.
+            if isinstance(entry, fmri.PkgFmri):
+                dest.append(entry.get_fmri(anarchy=True))
+            else:
+                dest.append(str(entry))
+
+    dpubs = dump_struct["publishers"]
+    for p in pubs:
+        dpub = {
+            "alias": p.alias,
+            "name": p.prefix,
             "packages": [],
-            "publishers": [],
-            "version": CURRENT_VERSION,
+            "repositories": [],
         }
-
-        if pkg_names is None:
-                pkg_names = {}
-
-        def copy_pkg_names(source, dest):
-                for entry in source:
-                        # Publisher information is intentionally
-                        # omitted as association with this specific
-                        # publisher is implied by location in the
-                        # output.
-                        if isinstance(entry, fmri.PkgFmri):
-                                dest.append(entry.get_fmri(
-                                    anarchy=True))
-                        else:
-                                dest.append(str(entry))
-
-        dpubs = dump_struct["publishers"]
-        for p in pubs:
-
-                dpub = {
-                    "alias": p.alias,
-                    "name": p.prefix,
-                    "packages": [],
-                    "repositories": []
-                }
-                dpubs.append(dpub)
-
-                try:
-                        copy_pkg_names(pkg_names[p.prefix],
-                            dpub["packages"])
-                except KeyError:
-                        pass
-
-                drepos = dpub["repositories"]
-                if p.repository:
-                        r = p.repository
-                        reg_uri = ""
-                        if r.registration_uri:
-                                reg_uri = r.registration_uri.uri
-
-                        drepos.append({
-                            "collection_type": r.collection_type,
-                            "description": r.description,
-                            "legal_uris": [u.uri for u in r.legal_uris],
-                            "mirrors": [u.uri for u in r.mirrors],
-                            "name": r.name,
-                            "origins": [u.uri for u in r.origins],
-                            "refresh_seconds": r.refresh_seconds,
-                            "registration_uri": reg_uri,
-                            "related_uris": [
-                                u.uri for u in r.related_uris
-                            ],
-                        })
+        dpubs.append(dpub)
 
         try:
-                copy_pkg_names(pkg_names[""], dump_struct["packages"])
+            copy_pkg_names(pkg_names[p.prefix], dpub["packages"])
         except KeyError:
-                pass
+            pass
 
-        json.dump(dump_struct, fileobj, ensure_ascii=False,
-            allow_nan=False, indent=2, sort_keys=True)
-        fileobj.write("\n")
+        drepos = dpub["repositories"]
+        if p.repository:
+            r = p.repository
+            reg_uri = ""
+            if r.registration_uri:
+                reg_uri = r.registration_uri.uri
+
+            drepos.append(
+                {
+                    "collection_type": r.collection_type,
+                    "description": r.description,
+                    "legal_uris": [u.uri for u in r.legal_uris],
+                    "mirrors": [u.uri for u in r.mirrors],
+                    "name": r.name,
+                    "origins": [u.uri for u in r.origins],
+                    "refresh_seconds": r.refresh_seconds,
+                    "registration_uri": reg_uri,
+                    "related_uris": [u.uri for u in r.related_uris],
+                }
+            )
+
+    try:
+        copy_pkg_names(pkg_names[""], dump_struct["packages"])
+    except KeyError:
+        pass
+
+    json.dump(
+        dump_struct,
+        fileobj,
+        ensure_ascii=False,
+        allow_nan=False,
+        indent=2,
+        sort_keys=True,
+    )
+    fileobj.write("\n")
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/p5p.py
+++ b/src/modules/p5p.py
@@ -48,1280 +48,1286 @@ import pkg.pkggzip
 import pkg.pkgtarfile as ptf
 from pkg.misc import force_bytes, force_str
 
-if sys.version > '3':
-        long = int
+if sys.version > "3":
+    long = int
+
 
 class ArchiveErrors(apx.ApiException):
-        """Base exception class for archive class errors."""
+    """Base exception class for archive class errors."""
 
 
 class InvalidArchiveIndex(ArchiveErrors):
-        """Used to indicate that the specified index is in a format not
-        supported or recognized by this version of the pkg(7) ArchiveIndex
-        class."""
+    """Used to indicate that the specified index is in a format not
+    supported or recognized by this version of the pkg(7) ArchiveIndex
+    class."""
 
-        def __init__(self, arc_name):
-                ArchiveErrors.__init__(self)
-                self.__name = arc_name
+    def __init__(self, arc_name):
+        ArchiveErrors.__init__(self)
+        self.__name = arc_name
 
-        def __str__(self):
-                return _("{0} is not in a supported or recognizable archive "
-                    "index format.").format(self.__name)
+    def __str__(self):
+        return _(
+            "{0} is not in a supported or recognizable archive " "index format."
+        ).format(self.__name)
 
 
 class ArchiveIndex(object):
-        """Class representing a pkg(7) archive table of contents and a set of
-        interfaces to populate and retrieve entries.
+    """Class representing a pkg(7) archive table of contents and a set of
+    interfaces to populate and retrieve entries.
 
-        Entries in this file are written in the following format:
+    Entries in this file are written in the following format:
 
-            <name>NUL<offset>NUL<entry_size>NUL<size>NUL<typeflag>NULNL
+        <name>NUL<offset>NUL<entry_size>NUL<size>NUL<typeflag>NULNL
 
-            <name> is a string containing the pathname of the file in the
-            archive.  It can be up to 65,535 bytes in length.
+        <name> is a string containing the pathname of the file in the
+        archive.  It can be up to 65,535 bytes in length.
 
-            <offset> is an unsigned long long integer containing the relative
-            offset in bytes of the first header block for the file in the
-            archive.  The offset is relative to the end of the last block of
-            the first file in the archive.
+        <offset> is an unsigned long long integer containing the relative
+        offset in bytes of the first header block for the file in the
+        archive.  The offset is relative to the end of the last block of
+        the first file in the archive.
 
-            <entry_size> is an unsigned long long integer containing the size of
-            the file's entry in bytes in the archive (including archive
-            headers and trailers for the entry).
+        <entry_size> is an unsigned long long integer containing the size of
+        the file's entry in bytes in the archive (including archive
+        headers and trailers for the entry).
 
-            <size> is an unsigned long long integer containing the size of the
-            file in bytes in the archive.
+        <size> is an unsigned long long integer containing the size of the
+        file in bytes in the archive.
 
-            <typeflag> is a single character representing the type of the file
-            in the archive.  Possible values are:
-                0 Regular File
-                1 Hard Link
-                2 Symbolic Link
-                5 Directory or subdirectory"""
+        <typeflag> is a single character representing the type of the file
+        in the archive.  Possible values are:
+            0 Regular File
+            1 Hard Link
+            2 Symbolic Link
+            5 Directory or subdirectory"""
 
-        version = None
-        CURRENT_VERSION = 0
-        COMPATIBLE_VERSIONS = 0,
-        ENTRY_FORMAT = "{0}\0{1:d}\0{2:d}\0{3:d}\0{4}\0\n"
+    version = None
+    CURRENT_VERSION = 0
+    COMPATIBLE_VERSIONS = (0,)
+    ENTRY_FORMAT = "{0}\0{1:d}\0{2:d}\0{3:d}\0{4}\0\n"
 
-        def __init__(self, name, mode="r", version=None):
-                """Open a pkg(7) archive table of contents file.
+    def __init__(self, name, mode="r", version=None):
+        """Open a pkg(7) archive table of contents file.
 
-                'name' should be the absolute path of the file to use when
-                reading or writing index data.
+        'name' should be the absolute path of the file to use when
+        reading or writing index data.
 
-                'mode' indicates whether the index is being used for reading
-                or writing, and can be 'r' or 'w'.  Appending to or updating
-                a table of contents file is not supported.
+        'mode' indicates whether the index is being used for reading
+        or writing, and can be 'r' or 'w'.  Appending to or updating
+        a table of contents file is not supported.
 
-                'version' is an optional integer value specifying the version
-                of the index to be read or written.  If not specified, the
-                current version is assumed.
-                """
+        'version' is an optional integer value specifying the version
+        of the index to be read or written.  If not specified, the
+        current version is assumed.
+        """
 
-                assert os.path.isabs(name)
-                if version is None:
-                        version = self.CURRENT_VERSION
-                if version not in self.COMPATIBLE_VERSIONS:
-                        raise InvalidArchiveIndex(name)
+        assert os.path.isabs(name)
+        if version is None:
+            version = self.CURRENT_VERSION
+        if version not in self.COMPATIBLE_VERSIONS:
+            raise InvalidArchiveIndex(name)
 
-                self.__closed = False
-                self.__name = name
-                self.__mode = mode
-                try:
-                        self.__file = pkg.pkggzip.PkgGzipFile(self.__name,
-                            self.__mode)
-                except IOError as e:
-                        if e.errno:
-                                raise
-                        # Underlying gzip library raises this exception if the
-                        # file isn't a valid gzip file.  So, assume that if
-                        # errno isn't set, this is a gzip error instead.
-                        raise InvalidArchiveIndex(name)
+        self.__closed = False
+        self.__name = name
+        self.__mode = mode
+        try:
+            self.__file = pkg.pkggzip.PkgGzipFile(self.__name, self.__mode)
+        except IOError as e:
+            if e.errno:
+                raise
+            # Underlying gzip library raises this exception if the
+            # file isn't a valid gzip file.  So, assume that if
+            # errno isn't set, this is a gzip error instead.
+            raise InvalidArchiveIndex(name)
 
-                self.version = version
+        self.version = version
 
-        def __exit__(self, exc_type, exc_value, exc_tb):
-                """Context handler that ensures archive is automatically closed
-                in a non-error condition scenario.  This enables 'with' usage.
-                """
-                if exc_type or exc_value or exc_tb:
-                        # Only close filehandles in an error condition.
-                        self.__close_fh()
-                else:
-                        # Close archive normally in all other cases.
-                        self.close()
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        """Context handler that ensures archive is automatically closed
+        in a non-error condition scenario.  This enables 'with' usage.
+        """
+        if exc_type or exc_value or exc_tb:
+            # Only close filehandles in an error condition.
+            self.__close_fh()
+        else:
+            # Close archive normally in all other cases.
+            self.close()
 
-        @property
-        def pathname(self):
-                """The absolute path of the archive index file."""
-                return self.__name
+    @property
+    def pathname(self):
+        """The absolute path of the archive index file."""
+        return self.__name
 
-        def add(self, name, offset, entry_size, size, typeflag):
-                """Add an entry for the given archive file to the table of
-                contents."""
+    def add(self, name, offset, entry_size, size, typeflag):
+        """Add an entry for the given archive file to the table of
+        contents."""
 
-                # GzipFile.write requires bytes input
-                self.__file.write(force_bytes(self.ENTRY_FORMAT.format(
-                    name, offset, entry_size, size, typeflag)))
+        # GzipFile.write requires bytes input
+        self.__file.write(
+            force_bytes(
+                self.ENTRY_FORMAT.format(
+                    name, offset, entry_size, size, typeflag
+                )
+            )
+        )
 
-        def offsets(self):
-                """Returns a generator that yields tuples of the form (name,
-                offset) for each file in the index."""
+    def offsets(self):
+        """Returns a generator that yields tuples of the form (name,
+        offset) for each file in the index."""
 
-                self.__file.seek(0)
+        self.__file.seek(0)
+        l = None
+        try:
+            for line in self.__file:
+                # Under Python 3, indexing on a bytes will
+                # return an integer representing the
+                # unicode code point of that character; we
+                # need to use slicing to get the character.
+                if line[-2:-1] != b"\0":
+                    # Filename contained newline.
+                    if l is None:
+                        l = line
+                    else:
+                        l += b"\n"
+                        l += line
+                    continue
+                elif l is None:
+                    l = line
+
+                name, offset, ignored = l.split(b"\0", 2)
+                yield force_str(name), long(offset)
                 l = None
-                try:
-                        for line in self.__file:
-                                # Under Python 3, indexing on a bytes will
-                                # return an integer representing the
-                                # unicode code point of that character; we
-                                # need to use slicing to get the character.
-                                if line[-2:-1] != b"\0":
-                                        # Filename contained newline.
-                                        if l is None:
-                                                l = line
-                                        else:
-                                                l += b"\n"
-                                                l += line
-                                        continue
-                                elif l is None:
-                                        l = line
+        except ValueError:
+            raise InvalidArchiveIndex(self.__name)
+        except IOError as e:
+            if e.errno:
+                raise
+            # Underlying gzip library raises this exception if the
+            # file isn't a valid gzip file.  So, assume that if
+            # errno isn't set, this is a gzip error instead.
+            raise InvalidArchiveIndex(self.__name)
 
-                                name, offset, ignored = l.split(b"\0", 2)
-                                yield force_str(name), long(offset)
-                                l = None
-                except ValueError:
-                        raise InvalidArchiveIndex(self.__name)
-                except IOError as e:
-                        if e.errno:
-                                raise
-                        # Underlying gzip library raises this exception if the
-                        # file isn't a valid gzip file.  So, assume that if
-                        # errno isn't set, this is a gzip error instead.
-                        raise InvalidArchiveIndex(self.__name)
+    def close(self):
+        """Close the index.  No further operations can be performed
+        using this object once closed."""
 
-        def close(self):
-                """Close the index.  No further operations can be performed
-                using this object once closed."""
-
-                if self.__closed:
-                        return
-                if self.__file:
-                        self.__file.close()
-                        self.__file = None
-                self.__closed = True
+        if self.__closed:
+            return
+        if self.__file:
+            self.__file.close()
+            self.__file = None
+        self.__closed = True
 
 
 class InvalidArchive(ArchiveErrors):
-        """Used to indicate that the specified archive is in a format not
-        supported or recognized by this version of the pkg(7) Archive class.
-        """
+    """Used to indicate that the specified archive is in a format not
+    supported or recognized by this version of the pkg(7) Archive class.
+    """
 
-        def __init__(self, arc_name):
-                ArchiveErrors.__init__(self)
-                self.arc_name = arc_name
+    def __init__(self, arc_name):
+        ArchiveErrors.__init__(self)
+        self.arc_name = arc_name
 
-        def __str__(self):
-                return _("Archive {0} is missing, unsupported, or corrupt.").format(
-                    self.arc_name)
+    def __str__(self):
+        return _("Archive {0} is missing, unsupported, or corrupt.").format(
+            self.arc_name
+        )
 
 
 class CorruptArchiveFiles(ArchiveErrors):
-        """Used to indicate that the specified file(s) could not be found in the
-        archive.
-        """
+    """Used to indicate that the specified file(s) could not be found in the
+    archive.
+    """
 
-        def __init__(self, arc_name, files):
-                ArchiveErrors.__init__(self)
-                self.arc_name = arc_name
-                self.files = files
+    def __init__(self, arc_name, files):
+        ArchiveErrors.__init__(self)
+        self.arc_name = arc_name
+        self.files = files
 
-        def __str__(self):
-                return _("Package archive {arc_name} contains corrupt "
-                    "entries for the requested package file(s):\n{files}.").format(
-                    arc_name=self.arc_name,
-                    files="\n".join(self.files))
+    def __str__(self):
+        return _(
+            "Package archive {arc_name} contains corrupt "
+            "entries for the requested package file(s):\n{files}."
+        ).format(arc_name=self.arc_name, files="\n".join(self.files))
 
 
 class UnknownArchiveFiles(ArchiveErrors):
-        """Used to indicate that the specified file(s) could not be found in the
-        archive.
-        """
+    """Used to indicate that the specified file(s) could not be found in the
+    archive.
+    """
 
-        def __init__(self, arc_name, files):
-                ArchiveErrors.__init__(self)
-                self.arc_name = arc_name
-                self.files = files
+    def __init__(self, arc_name, files):
+        ArchiveErrors.__init__(self)
+        self.arc_name = arc_name
+        self.files = files
 
-        def __str__(self):
-                return _("Package archive {arc_name} does not contain the "
-                    "requested package file(s):\n{files}.").format(
-                    arc_name=self.arc_name,
-                    files="\n".join(self.files))
+    def __str__(self):
+        return _(
+            "Package archive {arc_name} does not contain the "
+            "requested package file(s):\n{files}."
+        ).format(arc_name=self.arc_name, files="\n".join(self.files))
 
 
 class UnknownPackageManifest(ArchiveErrors):
-        """Used to indicate that a manifest for the specified package could not
-        be found in the archive.
-        """
+    """Used to indicate that a manifest for the specified package could not
+    be found in the archive.
+    """
 
-        def __init__(self, arc_name, pfmri):
-                ArchiveErrors.__init__(self)
-                self.arc_name = arc_name
-                self.pfmri = pfmri
+    def __init__(self, arc_name, pfmri):
+        ArchiveErrors.__init__(self)
+        self.arc_name = arc_name
+        self.pfmri = pfmri
 
-        def __str__(self):
-                return _("No package manifest for package '{pfmri}' exists "
-                    "in archive {arc_name}.").format(**self.__dict__)
+    def __str__(self):
+        return _(
+            "No package manifest for package '{pfmri}' exists "
+            "in archive {arc_name}."
+        ).format(**self.__dict__)
 
 
 class Archive(object):
-        """Class representing a pkg(7) archive and a set of interfaces to
-        populate it and retrieve data from it.
+    """Class representing a pkg(7) archive and a set of interfaces to
+    populate it and retrieve data from it.
 
-        This class stores package data in pax archives in version 4 repository
-        format.  Encoding the structure of a repository into the archive is
-        necessary to enable easy composition of package archive contents with
-        existing repositories and to enable consumers to access the contents of
-        a package archive the same as they would a repository.
+    This class stores package data in pax archives in version 4 repository
+    format.  Encoding the structure of a repository into the archive is
+    necessary to enable easy composition of package archive contents with
+    existing repositories and to enable consumers to access the contents of
+    a package archive the same as they would a repository.
 
-        This class can be used to access or extract the contents of almost any
-        tar archive, except for those that are compressed.
+    This class can be used to access or extract the contents of almost any
+    tar archive, except for those that are compressed.
+    """
+
+    __idx_pfx = "pkg5.index."
+    __idx_sfx = ".gz"
+    __idx_name = "pkg5.index.{0}.gz"
+    __idx_ver = ArchiveIndex.CURRENT_VERSION
+    __index = None
+    __arc_tfile = None
+    __arc_file = None
+    version = None
+
+    # If the repository format changes, then the version of the package
+    # archive format should be rev'd and this updated.  (Although that isn't
+    # strictly necessary, as the Repository class should remain backwards
+    # compatible with this format.)
+    CURRENT_VERSION = 0
+    COMPATIBLE_VERSIONS = (0,)
+
+    def __init__(self, pathname, mode="r", archive_index=None):
+        """'pathname' is the absolute path of the archive file to create
+        or read from.
+
+        'mode' is a string used to indicate whether the archive is being
+        opened for reading or writing, which is indicated by 'r' and 'w'
+        respectively.  An archive opened for writing may not be used for
+        any extraction operations, and must not already exist.
+
+        'archive_index', if supplied is the dictionary returned by
+        self.get_index(), allowing multiple Archive objects to be open,
+        sharing the same index object, for efficient use of memory.
+        Using an existing archive_index requires mode='r'.
         """
 
-        __idx_pfx = "pkg5.index."
-        __idx_sfx = ".gz"
-        __idx_name = "pkg5.index.{0}.gz"
-        __idx_ver = ArchiveIndex.CURRENT_VERSION
-        __index = None
-        __arc_tfile = None
-        __arc_file = None
-        version = None
+        assert os.path.isabs(pathname)
+        self.__arc_name = pathname
+        self.__closed = False
+        self.__mode = mode
+        self.__temp_dir = tempfile.mkdtemp()
 
-        # If the repository format changes, then the version of the package
-        # archive format should be rev'd and this updated.  (Although that isn't
-        # strictly necessary, as the Repository class should remain backwards
-        # compatible with this format.)
-        CURRENT_VERSION = 0
-        COMPATIBLE_VERSIONS = (0,)
+        # Used to cache publisher objects.
+        self.__pubs = None
 
-        def __init__(self, pathname, mode="r", archive_index=None):
-                """'pathname' is the absolute path of the archive file to create
-                or read from.
+        # Used to cache location of publisher catalog data.
+        self.__catalogs = {}
 
-                'mode' is a string used to indicate whether the archive is being
-                opened for reading or writing, which is indicated by 'r' and 'w'
-                respectively.  An archive opened for writing may not be used for
-                any extraction operations, and must not already exist.
+        arc_mode = mode + "b"
+        mode += ":"
 
-                'archive_index', if supplied is the dictionary returned by
-                self.get_index(), allowing multiple Archive objects to be open,
-                sharing the same index object, for efficient use of memory.
-                Using an existing archive_index requires mode='r'.
-                """
+        assert "r" in mode or "w" in mode
+        assert "a" not in mode
+        if "w" in mode:
+            # Don't allow overwrite of existing archive.
+            assert not os.path.exists(self.__arc_name)
+            # Ensure we're not sharing an index object.
+            assert not archive_index
 
-                assert os.path.isabs(pathname)
-                self.__arc_name = pathname
-                self.__closed = False
-                self.__mode = mode
-                self.__temp_dir = tempfile.mkdtemp()
+        try:
+            self.__arc_file = open(self.__arc_name, arc_mode, 128 * 1024)
+        except EnvironmentError as e:
+            if e.errno in (errno.ENOENT, errno.EISDIR):
+                raise InvalidArchive(self.__arc_name)
+            raise apx._convert_error(e)
 
-                # Used to cache publisher objects.
-                self.__pubs = None
+        self.__queue_offset = 0
+        self.__queue = collections.deque()
 
-                # Used to cache location of publisher catalog data.
-                self.__catalogs = {}
+        # Ensure cleanup is performed on exit if the archive is not
+        # explicitly closed.
+        def arc_cleanup():
+            if not self.__closed:
+                self.__close_fh()
+            self.__cleanup()
+            return
 
-                arc_mode = mode + "b"
-                mode += ":"
+        atexit.register(arc_cleanup)
 
-                assert "r" in mode or "w" in mode
-                assert "a" not in mode
-                if "w" in mode:
-                        # Don't allow overwrite of existing archive.
-                        assert not os.path.exists(self.__arc_name)
-                        # Ensure we're not sharing an index object.
-                        assert not archive_index
+        # Open the pax archive for the package.
+        try:
+            self.__arc_tfile = ptf.PkgTarFile.open(
+                mode=mode, fileobj=self.__arc_file, format=tf.PAX_FORMAT
+            )
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+        except Exception:
+            # Likely not an archive or the archive is corrupt.
+            raise InvalidArchive(self.__arc_name)
+
+        self.__extract_offsets = {}
+        if "r" in mode:
+            # Opening the tarfile loaded the first member, which
+            # should be the archive index file.
+            member = self.__arc_tfile.firstmember
+            if not member:
+                # Archive is empty.
+                raise InvalidArchive(self.__arc_name)
+
+            # If we have an archive_index use that and return
+            # immediately.  We assume that the caller has obtained
+            # the index from an exising Archive object,
+            # and will have validated the version of that archive.
+            if archive_index:
+                self.__extract_offsets = archive_index
+                return
+
+            if not member.name.startswith(
+                self.__idx_pfx
+            ) or not member.name.endswith(self.__idx_sfx):
+                return
+            else:
+                self.__idx_name = member.name
+
+            comment = member.pax_headers.get("comment", "")
+            if not comment.startswith("pkg5.archive.version."):
+                return
+
+            try:
+                self.version = int(comment.rsplit(".", 1)[-1])
+            except (IndexError, ValueError):
+                raise InvalidArchive(self.__arc_name)
+
+            if self.version not in self.COMPATIBLE_VERSIONS:
+                raise InvalidArchive(self.__arc_name)
+
+            # Create a temporary file to extract the index to,
+            # and then extract it from the archive.
+            fobj, idxfn = self.__mkstemp()
+            fobj.close()
+            try:
+                self.__arc_tfile.extract_to(
+                    member,
+                    path=self.__temp_dir,
+                    filename=os.path.basename(idxfn),
+                )
+            except tf.TarError:
+                # Read error encountered.
+                raise InvalidArchive(self.__arc_name)
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+
+            # After extraction, the current archive file offset
+            # is the base that will be used for all other
+            # extractions.
+            index_offset = self.__arc_tfile.offset
+
+            # Load archive index.
+            try:
+                self.__index = ArchiveIndex(
+                    idxfn, mode="r", version=self.__idx_ver
+                )
+                for name, offset in self.__index.offsets():
+                    self.__extract_offsets[name] = index_offset + offset
+            except InvalidArchiveIndex:
+                # Index is corrupt; rather than driving on
+                # and failing later, bail now.
+                os.unlink(idxfn)
+                raise InvalidArchive(self.__arc_name)
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+
+        elif "w" in mode:
+            self.__pubs = {}
+
+            # Force normalization of archive member mode and
+            # ownership information during archive creation.
+            def gettarinfo(*args, **kwargs):
+                ti = ptf.PkgTarFile.gettarinfo(
+                    self.__arc_tfile, *args, **kwargs
+                )
+                if ti.isreg():
+                    ti.mode = pkg.misc.PKG_FILE_MODE
+                elif ti.isdir():
+                    ti.mode = pkg.misc.PKG_DIR_MODE
+                if ti.name == "pkg5.index.0.gz":
+                    ti.pax_headers[
+                        "comment"
+                    ] = "pkg5.archive.version.{0:d}".format(
+                        self.CURRENT_VERSION
+                    )
+                ti.uid = 0
+                ti.gid = 0
+                ti.uname = "root"
+                ti.gname = "root"
+                return ti
+
+            self.__arc_tfile.gettarinfo = gettarinfo
+
+            self.__idx_name = self.__idx_name.format(self.__idx_ver)
+
+            # Create a temporary file to write the index to,
+            # and then create the index.
+            fobj, idxfn = self.__mkstemp()
+            fobj.close()
+            self.__index = ArchiveIndex(idxfn, mode=arc_mode)
+
+            # Used to determine what the default publisher will be
+            # for the archive file at close().
+            self.__default_pub = ""
+
+            # Used to keep track of which package files have already
+            # been added to archive.
+            self.__processed_pfiles = set()
+
+            # Always create archives using current version.
+            self.version = self.CURRENT_VERSION
+
+            # Always add base publisher directory to start; tarfile
+            # requires an actual filesystem object to do this, so
+            # re-use an existing directory to do so.
+            self.add("/", arcname="publisher")
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        """Context handler that ensures archive is automatically closed
+        in a non-error condition scenario.  This enables 'with' usage.
+        """
+
+        if exc_type or exc_value or exc_tb:
+            # Only close file objects; don't actually write anything
+            # out in an error condition.
+            self.__close_fh()
+            return
+
+        # Close and/or write out archive as needed.
+        self.close()
+
+    def __find_extract_offsets(self):
+        """Private helper method to find offsets for individual archive
+        member extraction.
+        """
+
+        if self.__extract_offsets:
+            return
+
+        # This causes the entire archive to be read, but is the only way
+        # to find the offsets to extract everything.
+        try:
+            for member in self.__arc_tfile.getmembers():
+                self.__extract_offsets[member.name] = member.offset
+        except tf.TarError:
+            # Read error encountered.
+            raise InvalidArchive(self.__arc_name)
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+
+    def __mkdtemp(self):
+        """Creates a temporary directory for use during archive
+        operations, and return its absolute path.  The temporary
+        directory will be removed after the archive is closed.
+        """
+
+        try:
+            return tempfile.mkdtemp(dir=self.__temp_dir)
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+
+    def __mkstemp(self):
+        """Creates a temporary file for use during archive operations,
+        and returns a file object for it and its absolute path.  The
+        temporary file will be removed after the archive is closed.
+        """
+        try:
+            fd, fn = tempfile.mkstemp(dir=self.__temp_dir)
+            fobj = os.fdopen(fd, "w")
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+        return fobj, fn
+
+    def add(self, pathname, arcname=None):
+        """Queue the specified object for addition to the archive.
+        The archive will be created and the object added to it when the
+        close() method is called.  The target object must not change
+        after this method is called while the archive is open.  The
+        item being added must not already exist in the archive.
+
+        'pathname' is an optional string specifying the absolute path
+        of a file to add to the archive.  The file may be a regular
+        file, directory, symbolic link, or hard link.
+
+        'arcname' is an optional string specifying an alternative name
+        for the file in the archive.  If not given, the full pathname
+        provided will be used.
+        """
+
+        assert not self.__closed and "w" in self.__mode
+        tfile = self.__arc_tfile
+        ti = tfile.gettarinfo(pathname, arcname=arcname)
+        buf = ti.tobuf(tfile.format, tfile.encoding, tfile.errors)
+
+        # Pre-calculate size of archive entry by determining where
+        # in the archive the entry would be added.
+        entry_sz = len(buf)
+        blocks, rem = divmod(ti.size, tf.BLOCKSIZE)
+        if rem > 0:
+            blocks += 1
+        entry_sz += blocks * tf.BLOCKSIZE
+
+        # Record name, offset, entry_size, size type for each file.
+        self.__index.add(
+            ti.name, self.__queue_offset, entry_sz, ti.size, ti.type
+        )
+        self.__queue_offset += entry_sz
+        self.__queue.append((pathname, ti.name))
+
+        # Discard tarinfo; it would be more efficient to keep these in
+        # memory, but at a significant memory footprint cost.
+        ti.tarfile = None
+        del ti
+
+    def __add_publisher_files(
+        self, root, file_dir, hashes, fpath=None, repo=None
+    ):
+        """Private helper function for adding package files."""
+
+        if file_dir not in self.__processed_pfiles:
+            # Directory entry needs to be added
+            # for package files.
+            self.add(root, arcname=file_dir)
+            self.__processed_pfiles.add(file_dir)
+
+        for fhash in hashes:
+            hash_dir = os.path.join(file_dir, fhash[:2])
+            if hash_dir not in self.__processed_pfiles:
+                # Directory entry needs to be added
+                # for hash directory.
+                self.add(root, arcname=hash_dir)
+                self.__processed_pfiles.add(hash_dir)
+
+            hash_fname = os.path.join(hash_dir, fhash)
+            if hash_fname in self.__processed_pfiles:
+                # Already added for a different
+                # package.
+                continue
+
+            if repo:
+                src = repo.file(fhash)
+            else:
+                src = os.path.join(fpath, fhash)
+            self.add(src, arcname=hash_fname)
+
+            # A bit expensive potentially in terms of
+            # memory usage, but necessary to prevent
+            # duplicate archive entries.
+            self.__processed_pfiles.add(hash_fname)
+
+    def __add_package(self, pfmri, mpath, fpath=None, repo=None):
+        """Private helper function that queues a package for addition to
+        the archive.
+
+        'mpath' is the absolute path of the package manifest file.
+
+        'fpath' is an optional directory containing the package files
+        stored by hash.
+
+        'repo' is an optional Repository object to use to retrieve the
+        data for the package to be added to the archive.
+
+        'fpath' or 'repo' must be provided.
+        """
+
+        assert not self.__closed and "w" in self.__mode
+        assert mpath
+        assert not (fpath and repo)
+        assert fpath or repo
+
+        if not self.__default_pub:
+            self.__default_pub = pfmri.publisher
+
+        m = pkg.manifest.Manifest(pfmri)
+        m.set_content(pathname=mpath)
+
+        # Throughout this function, the archive root directory is used
+        # as a template to add other directories that should be present
+        # in the archive.  This is necessary as the tarfile class does
+        # not support adding arbitrary archive entries without a real
+        # filesystem object as a source.
+        root = os.path.dirname(self.__arc_name)
+        pub_dir = os.path.join("publisher", pfmri.publisher)
+        pkg_dir = os.path.join(pub_dir, "pkg")
+        for d in pub_dir, pkg_dir:
+            if d not in self.__processed_pfiles:
+                self.add(root, arcname=d)
+                self.__processed_pfiles.add(d)
+
+        # After manifest has been loaded, assume it's ok to queue the
+        # manifest itself for addition to the archive.
+        arcname = os.path.join(pkg_dir, pfmri.get_dir_path())
+
+        # Entry may need to be added for manifest directory.
+        man_dir = os.path.dirname(arcname)
+        if man_dir not in self.__processed_pfiles:
+            self.add(root, arcname=man_dir)
+            self.__processed_pfiles.add(man_dir)
+
+        # Entry needs to be added for manifest file.
+        self.add(mpath, arcname=arcname)
+
+        # Now add any files to the archive for every action that has a
+        # payload.  (That payload can consist of multiple files.)
+        file_dir = os.path.join(pub_dir, "file")
+        for a in m.gen_actions():
+            if not a.has_payload:
+                # Nothing to archive.
+                continue
+
+            pref_hattr, hval, hfunc = digest.get_least_preferred_hash(a)
+            if not hval:
+                # Nothing to archive
+                continue
+
+            payloads = set([hval])
+
+            # Signature actions require special handling.
+            if a.name == "signature":
+                for c in a.get_chain_certs(least_preferred=True):
+                    payloads.add(c)
+
+                if repo:
+                    # This bit of logic only possible if
+                    # package source is a repository.
+                    pub = self.__pubs.get(pfmri.publisher, None)
+                    if not pub:
+                        self.__pubs[pfmri.publisher] = pub = repo.get_publisher(
+                            pfmri.publisher
+                        )
+                        assert pub
+
+            if not payloads:
+                # Nothing more to do.
+                continue
+
+            self.__add_publisher_files(
+                root, file_dir, payloads, fpath=fpath, repo=repo
+            )
+
+    def add_package(self, pfmri, mpath, fpath):
+        """Queues the specified package for addition to the archive.
+        The archive will be created and the package added to it when
+        the close() method is called.  The package contents must not
+        change after this method is called while the archive is open.
+
+        'pfmri' is the FMRI string or object identifying the package to
+        add.
+
+        'mpath' is the absolute path of the package manifest file.
+
+        'fpath' is the directory containing the package files stored
+        by hash.
+        """
+
+        assert pfmri and mpath and fpath
+        if isinstance(pfmri, six.string_types):
+            pfmri = pkg.fmri.PkgFmri(pfmri)
+        assert pfmri.publisher
+        self.__add_package(pfmri, mpath, fpath=fpath)
+
+    def add_repo_package(self, pfmri, repo):
+        """Queues the specified package in a repository for addition to
+        the archive. The archive will be created and the package added
+        to it when the close() method is called.  The package contents
+        must not change after this method is called while the archive is
+        open.
+
+        'pfmri' is the FMRI string or object identifying the package to
+        add.
+
+        'repo' is the Repository object to use to retrieve the data for
+        the package to be added to the archive.
+        """
+
+        assert pfmri and repo
+        if isinstance(pfmri, six.string_types):
+            pfmri = pkg.fmri.PkgFmri(pfmri)
+        assert pfmri.publisher
+        self.__add_package(pfmri, repo.manifest(pfmri), repo=repo)
+
+    def extract_catalog1(self, part, path, pub=None):
+        """Extract the named v1 catalog part to the specified directory.
+
+        'part' is the name of the catalog file part.
+
+        'path' is the absolute path of the directory to extract the
+        file to.  It will be created automatically if it does not
+        exist.
+
+        'pub' is an optional publisher prefix.  If not provided, the
+        first publisher catalog found in the archive will be used.
+        """
+
+        # If the extraction index doesn't exist, scan the
+        # complete archive and build one.
+        self.__find_extract_offsets()
+
+        pubs = [p for p in self.get_publishers() if not pub or p.prefix == pub]
+        if not pubs:
+            raise UnknownArchiveFiles(self.__arc_name, [part])
+
+        if not pub:
+            # Default to first known publisher.
+            pub = pubs[0].prefix
+
+        # Expected locations in archive for various metadata.
+        # A trailing slash is appended so that archive entry
+        # comparisons skip the entries for the directory.
+        pubpath = os.path.join("publisher", pub) + os.path.sep
+        catpath = os.path.join(pubpath, "catalog") + os.path.sep
+        partpath = os.path.join(catpath, part)
+
+        if pub in self.__catalogs:
+            # Catalog file requested for this publisher before.
+            croot = self.__catalogs[pub]
+            if croot:
+                # Catalog data is cached because it was
+                # generated on demand, so just copy it
+                # from there to the destination.
+                src = os.path.join(croot, part)
+                if not os.path.exists(src):
+                    raise UnknownArchiveFiles(self.__arc_name, [partpath])
 
                 try:
-                        self.__arc_file = open(self.__arc_name, arc_mode,
-                            128*1024)
+                    pkg.portable.copyfile(
+                        os.path.join(croot, part), os.path.join(path, part)
+                    )
                 except EnvironmentError as e:
-                        if e.errno in (errno.ENOENT, errno.EISDIR):
-                                raise InvalidArchive(self.__arc_name)
-                        raise apx._convert_error(e)
-
-                self.__queue_offset = 0
-                self.__queue = collections.deque()
-
-                # Ensure cleanup is performed on exit if the archive is not
-                # explicitly closed.
-                def arc_cleanup():
-                        if not self.__closed:
-                                self.__close_fh()
-                        self.__cleanup()
-                        return
-                atexit.register(arc_cleanup)
-
-                # Open the pax archive for the package.
-                try:
-                        self.__arc_tfile = ptf.PkgTarFile.open(mode=mode,
-                            fileobj=self.__arc_file, format=tf.PAX_FORMAT)
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-                except Exception:
-                        # Likely not an archive or the archive is corrupt.
-                        raise InvalidArchive(self.__arc_name)
-
-                self.__extract_offsets = {}
-                if "r" in mode:
-                        # Opening the tarfile loaded the first member, which
-                        # should be the archive index file.
-                        member = self.__arc_tfile.firstmember
-                        if not member:
-                                # Archive is empty.
-                                raise InvalidArchive(self.__arc_name)
-
-                        # If we have an archive_index use that and return
-                        # immediately.  We assume that the caller has obtained
-                        # the index from an exising Archive object,
-                        # and will have validated the version of that archive.
-                        if archive_index:
-                                self.__extract_offsets = archive_index
-                                return
-
-                        if not member.name.startswith(self.__idx_pfx) or \
-                            not member.name.endswith(self.__idx_sfx):
-                                return
-                        else:
-                                self.__idx_name = member.name
-
-                        comment = member.pax_headers.get("comment", "")
-                        if not comment.startswith("pkg5.archive.version."):
-                                return
-
-                        try:
-                                self.version = int(comment.rsplit(".", 1)[-1])
-                        except (IndexError, ValueError):
-                                raise InvalidArchive(self.__arc_name)
-
-                        if self.version not in self.COMPATIBLE_VERSIONS:
-                                raise InvalidArchive(self.__arc_name)
-
-                        # Create a temporary file to extract the index to,
-                        # and then extract it from the archive.
-                        fobj, idxfn = self.__mkstemp()
-                        fobj.close()
-                        try:
-                                self.__arc_tfile.extract_to(member,
-                                    path=self.__temp_dir,
-                                    filename=os.path.basename(idxfn))
-                        except tf.TarError:
-                                # Read error encountered.
-                                raise InvalidArchive(self.__arc_name)
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-
-                        # After extraction, the current archive file offset
-                        # is the base that will be used for all other
-                        # extractions.
-                        index_offset = self.__arc_tfile.offset
-
-                        # Load archive index.
-                        try:
-                                self.__index = ArchiveIndex(idxfn,
-                                    mode="r", version=self.__idx_ver)
-                                for name, offset in \
-                                    self.__index.offsets():
-                                        self.__extract_offsets[name] = \
-                                            index_offset + offset
-                        except InvalidArchiveIndex:
-                                # Index is corrupt; rather than driving on
-                                # and failing later, bail now.
-                                os.unlink(idxfn)
-                                raise InvalidArchive(self.__arc_name)
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-
-                elif "w" in mode:
-                        self.__pubs = {}
-
-                        # Force normalization of archive member mode and
-                        # ownership information during archive creation.
-                        def gettarinfo(*args, **kwargs):
-                                ti = ptf.PkgTarFile.gettarinfo(self.__arc_tfile,
-                                    *args, **kwargs)
-                                if ti.isreg():
-                                        ti.mode = pkg.misc.PKG_FILE_MODE
-                                elif ti.isdir():
-                                        ti.mode = pkg.misc.PKG_DIR_MODE
-                                if ti.name == "pkg5.index.0.gz":
-                                        ti.pax_headers["comment"] = \
-                                            "pkg5.archive.version.{0:d}".format(
-                                            self.CURRENT_VERSION)
-                                ti.uid = 0
-                                ti.gid = 0
-                                ti.uname = "root"
-                                ti.gname = "root"
-                                return ti
-                        self.__arc_tfile.gettarinfo = gettarinfo
-
-                        self.__idx_name = self.__idx_name.format(self.__idx_ver)
-
-                        # Create a temporary file to write the index to,
-                        # and then create the index.
-                        fobj, idxfn = self.__mkstemp()
-                        fobj.close()
-                        self.__index = ArchiveIndex(idxfn, mode=arc_mode)
-
-                        # Used to determine what the default publisher will be
-                        # for the archive file at close().
-                        self.__default_pub = ""
-
-                        # Used to keep track of which package files have already
-                        # been added to archive.
-                        self.__processed_pfiles = set()
-
-                        # Always create archives using current version.
-                        self.version = self.CURRENT_VERSION
-
-                        # Always add base publisher directory to start; tarfile
-                        # requires an actual filesystem object to do this, so
-                        # re-use an existing directory to do so.
-                        self.add("/", arcname="publisher")
-
-        def __exit__(self, exc_type, exc_value, exc_tb):
-                """Context handler that ensures archive is automatically closed
-                in a non-error condition scenario.  This enables 'with' usage.
-                """
-
-                if exc_type or exc_value or exc_tb:
-                        # Only close file objects; don't actually write anything
-                        # out in an error condition.
-                        self.__close_fh()
-                        return
-
-                # Close and/or write out archive as needed.
-                self.close()
-
-        def __find_extract_offsets(self):
-                """Private helper method to find offsets for individual archive
-                member extraction.
-                """
-
-                if self.__extract_offsets:
-                        return
-
-                # This causes the entire archive to be read, but is the only way
-                # to find the offsets to extract everything.
-                try:
-                        for member in self.__arc_tfile.getmembers():
-                                self.__extract_offsets[member.name] = \
-                                    member.offset
-                except tf.TarError:
-                        # Read error encountered.
-                        raise InvalidArchive(self.__arc_name)
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-
-        def __mkdtemp(self):
-                """Creates a temporary directory for use during archive
-                operations, and return its absolute path.  The temporary
-                directory will be removed after the archive is closed.
-                """
-
-                try:
-                        return tempfile.mkdtemp(dir=self.__temp_dir)
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-
-        def __mkstemp(self):
-                """Creates a temporary file for use during archive operations,
-                and returns a file object for it and its absolute path.  The
-                temporary file will be removed after the archive is closed.
-                """
-                try:
-                        fd, fn = tempfile.mkstemp(dir=self.__temp_dir)
-                        fobj = os.fdopen(fd, "w")
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-                return fobj, fn
-
-        def add(self, pathname, arcname=None):
-                """Queue the specified object for addition to the archive.
-                The archive will be created and the object added to it when the
-                close() method is called.  The target object must not change
-                after this method is called while the archive is open.  The
-                item being added must not already exist in the archive.
-
-                'pathname' is an optional string specifying the absolute path
-                of a file to add to the archive.  The file may be a regular
-                file, directory, symbolic link, or hard link.
-
-                'arcname' is an optional string specifying an alternative name
-                for the file in the archive.  If not given, the full pathname
-                provided will be used.
-                """
-
-                assert not self.__closed and "w" in self.__mode
-                tfile = self.__arc_tfile
-                ti = tfile.gettarinfo(pathname, arcname=arcname)
-                buf = ti.tobuf(tfile.format, tfile.encoding, tfile.errors)
-
-                # Pre-calculate size of archive entry by determining where
-                # in the archive the entry would be added.
-                entry_sz = len(buf)
-                blocks, rem = divmod(ti.size, tf.BLOCKSIZE)
-                if rem > 0:
-                        blocks += 1
-                entry_sz += blocks * tf.BLOCKSIZE
-
-                # Record name, offset, entry_size, size type for each file.
-                self.__index.add(ti.name, self.__queue_offset, entry_sz,
-                    ti.size, ti.type)
-                self.__queue_offset += entry_sz
-                self.__queue.append((pathname, ti.name))
-
-                # Discard tarinfo; it would be more efficient to keep these in
-                # memory, but at a significant memory footprint cost.
-                ti.tarfile = None
-                del ti
-
-        def __add_publisher_files(self, root, file_dir, hashes, fpath=None,
-            repo=None):
-                """Private helper function for adding package files."""
-
-                if file_dir not in self.__processed_pfiles:
-                        # Directory entry needs to be added
-                        # for package files.
-                        self.add(root, arcname=file_dir)
-                        self.__processed_pfiles.add(file_dir)
-
-                for fhash in hashes:
-                        hash_dir = os.path.join(file_dir, fhash[:2])
-                        if hash_dir not in self.__processed_pfiles:
-                                # Directory entry needs to be added
-                                # for hash directory.
-                                self.add(root, arcname=hash_dir)
-                                self.__processed_pfiles.add(hash_dir)
-
-                        hash_fname = os.path.join(hash_dir, fhash)
-                        if hash_fname in self.__processed_pfiles:
-                                # Already added for a different
-                                # package.
-                                continue
-
-                        if repo:
-                                src = repo.file(fhash)
-                        else:
-                                src = os.path.join(fpath, fhash)
-                        self.add(src, arcname=hash_fname)
-
-                        # A bit expensive potentially in terms of
-                        # memory usage, but necessary to prevent
-                        # duplicate archive entries.
-                        self.__processed_pfiles.add(hash_fname)
-
-        def __add_package(self, pfmri, mpath, fpath=None, repo=None):
-                """Private helper function that queues a package for addition to
-                the archive.
-
-                'mpath' is the absolute path of the package manifest file.
-
-                'fpath' is an optional directory containing the package files
-                stored by hash.
-
-                'repo' is an optional Repository object to use to retrieve the
-                data for the package to be added to the archive.
-
-                'fpath' or 'repo' must be provided.
-                """
-
-                assert not self.__closed and "w" in self.__mode
-                assert mpath
-                assert not (fpath and repo)
-                assert fpath or repo
-
-                if not self.__default_pub:
-                        self.__default_pub = pfmri.publisher
-
-                m = pkg.manifest.Manifest(pfmri)
-                m.set_content(pathname=mpath)
-
-                # Throughout this function, the archive root directory is used
-                # as a template to add other directories that should be present
-                # in the archive.  This is necessary as the tarfile class does
-                # not support adding arbitrary archive entries without a real
-                # filesystem object as a source.
-                root = os.path.dirname(self.__arc_name)
-                pub_dir = os.path.join("publisher", pfmri.publisher)
-                pkg_dir = os.path.join(pub_dir, "pkg")
-                for d in pub_dir, pkg_dir:
-                        if d not in self.__processed_pfiles:
-                                self.add(root, arcname=d)
-                                self.__processed_pfiles.add(d)
-
-                # After manifest has been loaded, assume it's ok to queue the
-                # manifest itself for addition to the archive.
-                arcname = os.path.join(pkg_dir, pfmri.get_dir_path())
-
-                # Entry may need to be added for manifest directory.
-                man_dir = os.path.dirname(arcname)
-                if man_dir not in self.__processed_pfiles:
-                        self.add(root, arcname=man_dir)
-                        self.__processed_pfiles.add(man_dir)
-
-                # Entry needs to be added for manifest file.
-                self.add(mpath, arcname=arcname)
-
-                # Now add any files to the archive for every action that has a
-                # payload.  (That payload can consist of multiple files.)
-                file_dir = os.path.join(pub_dir, "file")
-                for a in m.gen_actions():
-                        if not a.has_payload:
-                                # Nothing to archive.
-                                continue
-
-                        pref_hattr, hval, hfunc = \
-                            digest.get_least_preferred_hash(a)
-                        if not hval:
-                                # Nothing to archive
-                                continue
-
-                        payloads = set([hval])
-
-                        # Signature actions require special handling.
-                        if a.name == "signature":
-                                for c in a.get_chain_certs(
-                                    least_preferred=True):
-                                        payloads.add(c)
-
-                                if repo:
-                                        # This bit of logic only possible if
-                                        # package source is a repository.
-                                        pub = self.__pubs.get(pfmri.publisher,
-                                            None)
-                                        if not pub:
-                                                self.__pubs[pfmri.publisher] = \
-                                                    pub = repo.get_publisher(
-                                                    pfmri.publisher)
-                                                assert pub
-
-                        if not payloads:
-                                # Nothing more to do.
-                                continue
-
-                        self.__add_publisher_files(root, file_dir, payloads,
-                             fpath=fpath, repo=repo)
-
-        def add_package(self, pfmri, mpath, fpath):
-                """Queues the specified package for addition to the archive.
-                The archive will be created and the package added to it when
-                the close() method is called.  The package contents must not
-                change after this method is called while the archive is open.
-
-                'pfmri' is the FMRI string or object identifying the package to
-                add.
-
-                'mpath' is the absolute path of the package manifest file.
-
-                'fpath' is the directory containing the package files stored
-                by hash.
-                """
-
-                assert pfmri and mpath and fpath
-                if isinstance(pfmri, six.string_types):
-                        pfmri = pkg.fmri.PkgFmri(pfmri)
-                assert pfmri.publisher
-                self.__add_package(pfmri, mpath, fpath=fpath)
-
-        def add_repo_package(self, pfmri, repo):
-                """Queues the specified package in a repository for addition to
-                the archive. The archive will be created and the package added
-                to it when the close() method is called.  The package contents
-                must not change after this method is called while the archive is
-                open.
-
-                'pfmri' is the FMRI string or object identifying the package to
-                add.
-
-                'repo' is the Repository object to use to retrieve the data for
-                the package to be added to the archive.
-                """
-
-                assert pfmri and repo
-                if isinstance(pfmri, six.string_types):
-                        pfmri = pkg.fmri.PkgFmri(pfmri)
-                assert pfmri.publisher
-                self.__add_package(pfmri, repo.manifest(pfmri), repo=repo)
-
-        def extract_catalog1(self, part, path, pub=None):
-                """Extract the named v1 catalog part to the specified directory.
-
-                'part' is the name of the catalog file part.
-
-                'path' is the absolute path of the directory to extract the
-                file to.  It will be created automatically if it does not
-                exist.
-
-                'pub' is an optional publisher prefix.  If not provided, the
-                first publisher catalog found in the archive will be used.
-                """
-
-                # If the extraction index doesn't exist, scan the
-                # complete archive and build one.
-                self.__find_extract_offsets()
-
-                pubs = [
-                    p for p in self.get_publishers()
-                    if not pub or p.prefix == pub
-                ]
-                if not pubs:
-                        raise UnknownArchiveFiles(self.__arc_name, [part])
-
-                if not pub:
-                        # Default to first known publisher.
-                        pub = pubs[0].prefix
-
-                # Expected locations in archive for various metadata.
-                # A trailing slash is appended so that archive entry
-                # comparisons skip the entries for the directory.
-                pubpath = os.path.join("publisher", pub) + os.path.sep
-                catpath = os.path.join(pubpath, "catalog") + os.path.sep
-                partpath = os.path.join(catpath, part)
-
-                if pub in self.__catalogs:
-                        # Catalog file requested for this publisher before.
-                        croot = self.__catalogs[pub]
-                        if croot:
-                                # Catalog data is cached because it was
-                                # generated on demand, so just copy it
-                                # from there to the destination.
-                                src = os.path.join(croot, part)
-                                if not os.path.exists(src):
-                                        raise UnknownArchiveFiles(
-                                            self.__arc_name, [partpath])
-
-                                try:
-                                        pkg.portable.copyfile(
-                                            os.path.join(croot, part),
-                                            os.path.join(path, part))
-                                except EnvironmentError as e:
-                                        raise apx._convert_error(e)
-                        else:
-                                # Use default extraction logic.
-                                self.extract_to(partpath, path, filename=part)
-                        return
-
-                # Determine whether any catalog files are present for this
-                # publisher in the archive.
-                for name in self.__extract_offsets:
-                        if name.startswith(catpath):
-                                # Any catalog file at all means this publisher
-                                # should be marked as being known to have one
-                                # and then the request passed on to extract_to.
-                                self.__catalogs[pub] = None
-                                return self.extract_to(partpath, path,
-                                    filename=part)
-
-                # No catalog data found for publisher; construct a catalog
-                # in memory based on packages found for publisher.
-                cat = pkg.catalog.Catalog(batch_mode=True)
-                manpath = os.path.join(pubpath, "pkg") + os.path.sep
-                lm = None
-                for name in self.__extract_offsets:
-                        if name.startswith(manpath) and name.count("/") == 4:
-                                ignored, stem, ver = name.rsplit("/", 2)
-                                stem = unquote(stem)
-                                ver = unquote(ver)
-                                pfmri = pkg.fmri.PkgFmri(name=stem,
-                                    publisher=pub, version=ver)
-
-                                pfmri_tmp_ts = pfmri.get_timestamp()
-                                if not lm or lm < pfmri_tmp_ts:
-                                        lm = pfmri_tmp_ts
-
-                                fobj = self.get_file(name)
-                                m = pkg.manifest.Manifest(pfmri=pfmri)
-                                m.set_content(content=force_str(fobj.read()),
-                                    signatures=True)
-                                cat.add_package(pfmri, manifest=m)
-
-                # Store catalog in a temporary directory and mark publisher
-                # as having catalog data cached.
-                croot = self.__mkdtemp()
-                cat.meta_root = croot
-                cat.batch_mode = False
-                cat.finalize()
-                if lm:
-                        cat.last_modified = lm
-                cat.save()
-                self.__catalogs[pub] = croot
-
-                # Finally, copy requested file to destination.
-                try:
-                        pkg.portable.copyfile(os.path.join(croot, part),
-                            os.path.join(path, part))
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-
-        def extract_package_files(self, hashes, path, pub=None):
-                """Extract one or more package files from the archive.
-
-                'hashes' is a list of the files to extract named by their hash.
-
-                'path' is the absolute path of the directory to extract the
-                files to.  It will be created automatically if it does not
-                exist.
-
-                'pub' is the prefix (name) of the publisher that the package
-                files are associated with.  If not provided, the first file
-                named after the given hash found in the archive will be used.
-                (This will be noticeably slower depending on the size of the
-                archive.)
-                """
-
-                assert not self.__closed and "r" in self.__mode
-                assert hashes
-
-                # If the extraction index doesn't exist, scan the complete
-                # archive and build one.
-                self.__find_extract_offsets()
-
-                if not pub:
-                        # Scan extract offsets index for the first instance of
-                        # any package file seen for each hash and extract the
-                        # file as each is found.
-                        hashes = set(hashes)
-
-                        for name in self.__extract_offsets:
-                                for fhash in hashes:
-                                        hash_fname = os.path.join("file",
-                                            fhash[:2], fhash)
-                                        if name.endswith(hash_fname):
-                                                self.extract_to(name, path,
-                                                    filename=fhash)
-                                                hashes.discard(fhash)
-                                                break
-                                if not hashes:
-                                        break
-
-                        if hashes:
-                                # Any remaining hashes are for package files
-                                # that couldn't be found.
-                                raise UnknownArchiveFiles(self.__arc_name,
-                                    hashes)
-                        return
-
-                for fhash in hashes:
-                        arcname = os.path.join("publisher", pub, "file",
-                            fhash[:2], fhash)
-                        self.extract_to(arcname, path, filename=fhash)
-
-        def extract_package_manifest(self, pfmri, path, filename=""):
-                """Extract a package manifest from the archive.
-
-                'pfmri' is the FMRI string or object identifying the package
-                manifest to extract.
-
-                'path' is the absolute path of the directory to extract the
-                manifest to.  It will be created automatically if it does not
-                exist.
-
-                'filename' is an optional name to use for the extracted file.
-                If not provided, the default behaviour is to create a directory
-                named after the package stem in 'path' and a file named after
-                the version in that directory; both components will be URI
-                encoded.
-                """
-
-                assert not self.__closed and "r" in self.__mode
-                assert pfmri and path
-                if isinstance(pfmri, six.string_types):
-                        pfmri = pkg.fmri.PkgFmri(pfmri)
-                assert pfmri.publisher
-
-                if not filename:
-                        filename = pfmri.get_dir_path()
-
-                arcname = os.path.join("publisher", pfmri.publisher, "pkg",
-                    pfmri.get_dir_path())
-                try:
-                        self.extract_to(arcname, path, filename=filename)
-                except UnknownArchiveFiles:
-                        raise UnknownPackageManifest(self.__arc_name, pfmri)
-
-        def extract_to(self, src, path, filename=""):
-                """Extract a member from the archive.
-
-                'src' is the pathname of the archive file to extract.
-
-                'path' is the absolute path of the directory to extract the file
-                to.
-
-                'filename' is an optional string indicating the name to use for
-                the extracted file.  If not provided, the full member name in
-                the archive will be used.
-                """
-
-                assert not self.__closed and "r" in self.__mode
-
-                # Get the offset in the archive for the given file, and then
-                # seek to it.
-                offset = self.__extract_offsets.get(src, None)
-                tfile = self.__arc_tfile
-                if offset is not None:
-                        # Prepare the tarfile object for extraction by telling
-                        # it where to look for the file.
-                        self.__arc_file.seek(offset)
-                        tfile.offset = offset
-
-                        # Get the tarinfo object needed to extract the file.
-                        try:
-                                member = tf.TarInfo.fromtarfile(tfile)
-                        except tf.TarError:
-                                # Read error encountered.
-                                raise InvalidArchive(self.__arc_name)
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-
-                        if member.name != src:
-                                # Index must be invalid or tarfile has gone off
-                                # the rails trying to read the archive.
-                                raise InvalidArchive(self.__arc_name)
-
-                elif self.__extract_offsets:
-                        # Assume there is no such archive member if extract
-                        # offsets are known, but the item can't be found.
-                        raise UnknownArchiveFiles(self.__arc_name, [src])
-                else:
-                        # No archive index; fallback to retrieval by name.
-                        member = src
-
-                # Extract the file to the specified location.
-                try:
-                        self.__arc_tfile.extract_to(member, path=path,
-                            filename=filename)
-                except KeyError:
-                        raise UnknownArchiveFiles(self.__arc_name, [src])
-                except tf.TarError:
-                        # Read error encountered.
-                        raise InvalidArchive(self.__arc_name)
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-
-                if not isinstance(member, tf.TarInfo):
-                        # Nothing more to do.
-                        return
-
-                # If possible, validate the size of the extracted object.
-                try:
-                        if not filename:
-                                filename = member.name
-                        dest = os.path.join(path, filename)
-                        if os.stat(dest).st_size != member.size:
-                                raise CorruptArchiveFiles(self.__arc_name,
-                                    [src])
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-
-        def get_file(self, src):
-                """Returns an archive member as a file object.  If the matching
-                member is a regular file, a file-like object will be returned.
-                If it is a link, a file-like object is constructed from the
-                link's target.  In all other cases, None will be returned.  The
-                file-like object is read-only and provides methods: read(),
-                readline(), readlines(), seek() and tell().  The returned object
-                must be closed before the archive is, and must not be used after
-                the archive is closed.
-
-                'src' is the pathname of the archive file to return.
-                """
-
-                assert not self.__closed and "r" in self.__mode
-
-                # Get the offset in the archive for the given file, and then
-                # seek to it.
-                offset = self.__extract_offsets.get(src, None)
-                tfile = self.__arc_tfile
-                if offset is not None:
-                        # Prepare the tarfile object for extraction by telling
-                        # it where to look for the file.
-                        self.__arc_file.seek(offset)
-                        tfile.offset = offset
-
-                        try:
-                                # Get the tarinfo object needed to extract the
-                                # file.
-                                member = tf.TarInfo.fromtarfile(tfile)
-                        except tf.TarError:
-                                # Read error encountered.
-                                raise InvalidArchive(self.__arc_name)
-                elif self.__extract_offsets:
-                        # Assume there is no such archive member if extract
-                        # offsets are known, but the item can't be found.
-                        raise UnknownArchiveFiles(self.__arc_name, [src])
-                else:
-                        # No archive index; fallback to retrieval by name.
-                        member = src
-
-                # Finally, return the object for the matching archive member.
-                try:
-                        return tfile.extractfile(member)
-                except KeyError:
-                        raise UnknownArchiveFiles(self.__arc_name, [src])
-
-        def get_index(self):
-                """Returns the index, and extract_offsets from an Archive
-                opened in read-only mode, allowing additional Archive objects
-                to reuse the index, in a memory-efficient manner."""
-                assert not self.__closed and "r" in self.__mode
-                if not self.__extract_offsets:
-                        # If the extraction index doesn't exist, scan the
-                        # complete archive and build one.
-                        self.__find_extract_offsets()
-                return self.__extract_offsets
-
-        def get_package_file(self, fhash, pub=None):
-                """Returns the first package file matching the given hash as a
-                file-like object. The file-like object is read-only and provides
-                methods: read(), readline(), readlines(), seek() and tell().
-                The returned object  must be closed before the archive is, and
-                must not be used after the archive is closed.
-
-                'fhash' is the hash name of the file to return.
-
-                'pub' is the prefix (name) of the publisher that the package
-                files are associated with.  If not provided, the first file
-                named after the given hash found in the archive will be used.
-                (This will be noticeably slower depending on the size of the
-                archive.)
-                """
-
-                assert not self.__closed and "r" in self.__mode
-
-                if not self.__extract_offsets:
-                        # If the extraction index doesn't exist, scan the
-                        # complete archive and build one.
-                        self.__find_extract_offsets()
-
-                if not pub:
-                        # Scan extract offsets index for the first instance of
-                        # any package file seen for the hash and extract it.
-                        hash_fname = os.path.join("file", fhash[:2], fhash)
-                        for name in self.__extract_offsets:
-                                if name.endswith(hash_fname):
-                                        return self.get_file(name)
-                        raise UnknownArchiveFiles(self.__arc_name, [fhash])
-
-                return self.get_file(os.path.join("publisher", pub, "file",
-                    fhash[:2], fhash))
-
-        def get_package_manifest(self, pfmri, raw=False):
-                """Returns a package manifest from the archive.
-
-                'pfmri' is the FMRI string or object identifying the package
-                manifest to extract.
-
-                'raw' is an optional boolean indicating whether the raw
-                content of the Manifest should be returned.  If True,
-                a file-like object containing the content of the manifest.
-                If False, a Manifest object will be returned.
-                """
-
-                assert not self.__closed and "r" in self.__mode
-                assert pfmri
-                if isinstance(pfmri, six.string_types):
-                        pfmri = pkg.fmri.PkgFmri(pfmri)
-                assert pfmri.publisher
-
-                arcname = os.path.join("publisher", pfmri.publisher, "pkg",
-                    pfmri.get_dir_path())
-
-                try:
-                        fobj = self.get_file(arcname)
-                except UnknownArchiveFiles:
-                        raise UnknownPackageManifest(self.__arc_name, pfmri)
-
-                if raw:
-                        return fobj
-
+                    raise apx._convert_error(e)
+            else:
+                # Use default extraction logic.
+                self.extract_to(partpath, path, filename=part)
+            return
+
+        # Determine whether any catalog files are present for this
+        # publisher in the archive.
+        for name in self.__extract_offsets:
+            if name.startswith(catpath):
+                # Any catalog file at all means this publisher
+                # should be marked as being known to have one
+                # and then the request passed on to extract_to.
+                self.__catalogs[pub] = None
+                return self.extract_to(partpath, path, filename=part)
+
+        # No catalog data found for publisher; construct a catalog
+        # in memory based on packages found for publisher.
+        cat = pkg.catalog.Catalog(batch_mode=True)
+        manpath = os.path.join(pubpath, "pkg") + os.path.sep
+        lm = None
+        for name in self.__extract_offsets:
+            if name.startswith(manpath) and name.count("/") == 4:
+                ignored, stem, ver = name.rsplit("/", 2)
+                stem = unquote(stem)
+                ver = unquote(ver)
+                pfmri = pkg.fmri.PkgFmri(name=stem, publisher=pub, version=ver)
+
+                pfmri_tmp_ts = pfmri.get_timestamp()
+                if not lm or lm < pfmri_tmp_ts:
+                    lm = pfmri_tmp_ts
+
+                fobj = self.get_file(name)
                 m = pkg.manifest.Manifest(pfmri=pfmri)
                 m.set_content(content=force_str(fobj.read()), signatures=True)
-                return m
+                cat.add_package(pfmri, manifest=m)
 
-        def get_publishers(self):
-                """Return a list of publisher objects for all publishers used
-                in the archive."""
+        # Store catalog in a temporary directory and mark publisher
+        # as having catalog data cached.
+        croot = self.__mkdtemp()
+        cat.meta_root = croot
+        cat.batch_mode = False
+        cat.finalize()
+        if lm:
+            cat.last_modified = lm
+        cat.save()
+        self.__catalogs[pub] = croot
 
-                if self.__pubs:
-                        return list(self.__pubs.values())
+        # Finally, copy requested file to destination.
+        try:
+            pkg.portable.copyfile(
+                os.path.join(croot, part), os.path.join(path, part)
+            )
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
 
-                # If the extraction index doesn't exist, scan the complete
-                # archive and build one.
-                self.__find_extract_offsets()
+    def extract_package_files(self, hashes, path, pub=None):
+        """Extract one or more package files from the archive.
 
-                # Search through offset index to find publishers
-                # in use.
-                self.__pubs = {}
-                for name in self.__extract_offsets:
-                        if name.count("/") == 1 and \
-                            name.startswith("publisher/"):
-                                ignored, pfx = name.split("/", 1)
+        'hashes' is a list of the files to extract named by their hash.
 
-                                # See if this publisher has a .p5i file in the
-                                # archive (needed for signed packages).
-                                p5iname = os.path.join("publisher", pfx,
-                                    "pub.p5i")
-                                try:
-                                        fobj = self.get_file(p5iname)
-                                except UnknownArchiveFiles:
-                                        # No p5i; that's ok.
-                                        pub = pkg.client.publisher.Publisher(
-                                            pfx)
-                                else:
-                                        pubs = pkg.p5i.parse(fileobj=fobj)
-                                        assert len(pubs) == 1
-                                        pub = pubs[0][0]
-                                        assert pub
+        'path' is the absolute path of the directory to extract the
+        files to.  It will be created automatically if it does not
+        exist.
 
-                                self.__pubs[pfx] = pub
+        'pub' is the prefix (name) of the publisher that the package
+        files are associated with.  If not provided, the first file
+        named after the given hash found in the archive will be used.
+        (This will be noticeably slower depending on the size of the
+        archive.)
+        """
 
-                return list(self.__pubs.values())
+        assert not self.__closed and "r" in self.__mode
+        assert hashes
 
-        def __cleanup(self):
-                """Private helper method to cleanup temporary files."""
+        # If the extraction index doesn't exist, scan the complete
+        # archive and build one.
+        self.__find_extract_offsets()
 
+        if not pub:
+            # Scan extract offsets index for the first instance of
+            # any package file seen for each hash and extract the
+            # file as each is found.
+            hashes = set(hashes)
+
+            for name in self.__extract_offsets:
+                for fhash in hashes:
+                    hash_fname = os.path.join("file", fhash[:2], fhash)
+                    if name.endswith(hash_fname):
+                        self.extract_to(name, path, filename=fhash)
+                        hashes.discard(fhash)
+                        break
+                if not hashes:
+                    break
+
+            if hashes:
+                # Any remaining hashes are for package files
+                # that couldn't be found.
+                raise UnknownArchiveFiles(self.__arc_name, hashes)
+            return
+
+        for fhash in hashes:
+            arcname = os.path.join("publisher", pub, "file", fhash[:2], fhash)
+            self.extract_to(arcname, path, filename=fhash)
+
+    def extract_package_manifest(self, pfmri, path, filename=""):
+        """Extract a package manifest from the archive.
+
+        'pfmri' is the FMRI string or object identifying the package
+        manifest to extract.
+
+        'path' is the absolute path of the directory to extract the
+        manifest to.  It will be created automatically if it does not
+        exist.
+
+        'filename' is an optional name to use for the extracted file.
+        If not provided, the default behaviour is to create a directory
+        named after the package stem in 'path' and a file named after
+        the version in that directory; both components will be URI
+        encoded.
+        """
+
+        assert not self.__closed and "r" in self.__mode
+        assert pfmri and path
+        if isinstance(pfmri, six.string_types):
+            pfmri = pkg.fmri.PkgFmri(pfmri)
+        assert pfmri.publisher
+
+        if not filename:
+            filename = pfmri.get_dir_path()
+
+        arcname = os.path.join(
+            "publisher", pfmri.publisher, "pkg", pfmri.get_dir_path()
+        )
+        try:
+            self.extract_to(arcname, path, filename=filename)
+        except UnknownArchiveFiles:
+            raise UnknownPackageManifest(self.__arc_name, pfmri)
+
+    def extract_to(self, src, path, filename=""):
+        """Extract a member from the archive.
+
+        'src' is the pathname of the archive file to extract.
+
+        'path' is the absolute path of the directory to extract the file
+        to.
+
+        'filename' is an optional string indicating the name to use for
+        the extracted file.  If not provided, the full member name in
+        the archive will be used.
+        """
+
+        assert not self.__closed and "r" in self.__mode
+
+        # Get the offset in the archive for the given file, and then
+        # seek to it.
+        offset = self.__extract_offsets.get(src, None)
+        tfile = self.__arc_tfile
+        if offset is not None:
+            # Prepare the tarfile object for extraction by telling
+            # it where to look for the file.
+            self.__arc_file.seek(offset)
+            tfile.offset = offset
+
+            # Get the tarinfo object needed to extract the file.
+            try:
+                member = tf.TarInfo.fromtarfile(tfile)
+            except tf.TarError:
+                # Read error encountered.
+                raise InvalidArchive(self.__arc_name)
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+
+            if member.name != src:
+                # Index must be invalid or tarfile has gone off
+                # the rails trying to read the archive.
+                raise InvalidArchive(self.__arc_name)
+
+        elif self.__extract_offsets:
+            # Assume there is no such archive member if extract
+            # offsets are known, but the item can't be found.
+            raise UnknownArchiveFiles(self.__arc_name, [src])
+        else:
+            # No archive index; fallback to retrieval by name.
+            member = src
+
+        # Extract the file to the specified location.
+        try:
+            self.__arc_tfile.extract_to(member, path=path, filename=filename)
+        except KeyError:
+            raise UnknownArchiveFiles(self.__arc_name, [src])
+        except tf.TarError:
+            # Read error encountered.
+            raise InvalidArchive(self.__arc_name)
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+
+        if not isinstance(member, tf.TarInfo):
+            # Nothing more to do.
+            return
+
+        # If possible, validate the size of the extracted object.
+        try:
+            if not filename:
+                filename = member.name
+            dest = os.path.join(path, filename)
+            if os.stat(dest).st_size != member.size:
+                raise CorruptArchiveFiles(self.__arc_name, [src])
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+
+    def get_file(self, src):
+        """Returns an archive member as a file object.  If the matching
+        member is a regular file, a file-like object will be returned.
+        If it is a link, a file-like object is constructed from the
+        link's target.  In all other cases, None will be returned.  The
+        file-like object is read-only and provides methods: read(),
+        readline(), readlines(), seek() and tell().  The returned object
+        must be closed before the archive is, and must not be used after
+        the archive is closed.
+
+        'src' is the pathname of the archive file to return.
+        """
+
+        assert not self.__closed and "r" in self.__mode
+
+        # Get the offset in the archive for the given file, and then
+        # seek to it.
+        offset = self.__extract_offsets.get(src, None)
+        tfile = self.__arc_tfile
+        if offset is not None:
+            # Prepare the tarfile object for extraction by telling
+            # it where to look for the file.
+            self.__arc_file.seek(offset)
+            tfile.offset = offset
+
+            try:
+                # Get the tarinfo object needed to extract the
+                # file.
+                member = tf.TarInfo.fromtarfile(tfile)
+            except tf.TarError:
+                # Read error encountered.
+                raise InvalidArchive(self.__arc_name)
+        elif self.__extract_offsets:
+            # Assume there is no such archive member if extract
+            # offsets are known, but the item can't be found.
+            raise UnknownArchiveFiles(self.__arc_name, [src])
+        else:
+            # No archive index; fallback to retrieval by name.
+            member = src
+
+        # Finally, return the object for the matching archive member.
+        try:
+            return tfile.extractfile(member)
+        except KeyError:
+            raise UnknownArchiveFiles(self.__arc_name, [src])
+
+    def get_index(self):
+        """Returns the index, and extract_offsets from an Archive
+        opened in read-only mode, allowing additional Archive objects
+        to reuse the index, in a memory-efficient manner."""
+        assert not self.__closed and "r" in self.__mode
+        if not self.__extract_offsets:
+            # If the extraction index doesn't exist, scan the
+            # complete archive and build one.
+            self.__find_extract_offsets()
+        return self.__extract_offsets
+
+    def get_package_file(self, fhash, pub=None):
+        """Returns the first package file matching the given hash as a
+        file-like object. The file-like object is read-only and provides
+        methods: read(), readline(), readlines(), seek() and tell().
+        The returned object  must be closed before the archive is, and
+        must not be used after the archive is closed.
+
+        'fhash' is the hash name of the file to return.
+
+        'pub' is the prefix (name) of the publisher that the package
+        files are associated with.  If not provided, the first file
+        named after the given hash found in the archive will be used.
+        (This will be noticeably slower depending on the size of the
+        archive.)
+        """
+
+        assert not self.__closed and "r" in self.__mode
+
+        if not self.__extract_offsets:
+            # If the extraction index doesn't exist, scan the
+            # complete archive and build one.
+            self.__find_extract_offsets()
+
+        if not pub:
+            # Scan extract offsets index for the first instance of
+            # any package file seen for the hash and extract it.
+            hash_fname = os.path.join("file", fhash[:2], fhash)
+            for name in self.__extract_offsets:
+                if name.endswith(hash_fname):
+                    return self.get_file(name)
+            raise UnknownArchiveFiles(self.__arc_name, [fhash])
+
+        return self.get_file(
+            os.path.join("publisher", pub, "file", fhash[:2], fhash)
+        )
+
+    def get_package_manifest(self, pfmri, raw=False):
+        """Returns a package manifest from the archive.
+
+        'pfmri' is the FMRI string or object identifying the package
+        manifest to extract.
+
+        'raw' is an optional boolean indicating whether the raw
+        content of the Manifest should be returned.  If True,
+        a file-like object containing the content of the manifest.
+        If False, a Manifest object will be returned.
+        """
+
+        assert not self.__closed and "r" in self.__mode
+        assert pfmri
+        if isinstance(pfmri, six.string_types):
+            pfmri = pkg.fmri.PkgFmri(pfmri)
+        assert pfmri.publisher
+
+        arcname = os.path.join(
+            "publisher", pfmri.publisher, "pkg", pfmri.get_dir_path()
+        )
+
+        try:
+            fobj = self.get_file(arcname)
+        except UnknownArchiveFiles:
+            raise UnknownPackageManifest(self.__arc_name, pfmri)
+
+        if raw:
+            return fobj
+
+        m = pkg.manifest.Manifest(pfmri=pfmri)
+        m.set_content(content=force_str(fobj.read()), signatures=True)
+        return m
+
+    def get_publishers(self):
+        """Return a list of publisher objects for all publishers used
+        in the archive."""
+
+        if self.__pubs:
+            return list(self.__pubs.values())
+
+        # If the extraction index doesn't exist, scan the complete
+        # archive and build one.
+        self.__find_extract_offsets()
+
+        # Search through offset index to find publishers
+        # in use.
+        self.__pubs = {}
+        for name in self.__extract_offsets:
+            if name.count("/") == 1 and name.startswith("publisher/"):
+                ignored, pfx = name.split("/", 1)
+
+                # See if this publisher has a .p5i file in the
+                # archive (needed for signed packages).
+                p5iname = os.path.join("publisher", pfx, "pub.p5i")
                 try:
-                        if os.path.exists(self.__temp_dir):
-                                shutil.rmtree(self.__temp_dir)
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
+                    fobj = self.get_file(p5iname)
+                except UnknownArchiveFiles:
+                    # No p5i; that's ok.
+                    pub = pkg.client.publisher.Publisher(pfx)
+                else:
+                    pubs = pkg.p5i.parse(fileobj=fobj)
+                    assert len(pubs) == 1
+                    pub = pubs[0][0]
+                    assert pub
 
-        def __close_fh(self):
-                """Private helper method to close filehandles."""
+                self.__pubs[pfx] = pub
 
-                # Some archives may not have an index.
-                if self.__index:
-                        self.__index.close()
-                        self.__index = None
+        return list(self.__pubs.values())
 
-                # A read error during archive load may cause these to have
-                # never been set.
-                if self.__arc_tfile:
-                        self.__arc_tfile.close()
-                        self.__arc_tfile = None
+    def __cleanup(self):
+        """Private helper method to cleanup temporary files."""
 
-                if self.__arc_file:
-                        self.__arc_file.close()
-                        self.__arc_file = None
-                self.__closed = True
+        try:
+            if os.path.exists(self.__temp_dir):
+                shutil.rmtree(self.__temp_dir)
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
 
-        def close(self, progtrack=None):
-                """If mode is 'r', this will close the archive file.  If mode is
-                'w', this will write all queued files to the archive and close
-                it.  Further operations on the archive are not possible after
-                calling this function."""
+    def __close_fh(self):
+        """Private helper method to close filehandles."""
 
-                assert not self.__closed
+        # Some archives may not have an index.
+        if self.__index:
+            self.__index.close()
+            self.__index = None
 
-                if "w" not in self.__mode:
-                        self.__close_fh()
-                        self.__cleanup()
-                        return
+        # A read error during archive load may cause these to have
+        # never been set.
+        if self.__arc_tfile:
+            self.__arc_tfile.close()
+            self.__arc_tfile = None
 
-                # Add the standard pkg5.repository file before closing the
-                # index.
-                fobj, fname = self.__mkstemp()
-                fobj.write("[CONFIGURATION]\nversion = 4\n\n"
-                    "[publisher]\nprefix = {0}\n\n"
-                    "[repository]\nversion = 4\n".format(self.__default_pub))
-                fobj.close()
-                self.add(fname, arcname="pkg5.repository")
+        if self.__arc_file:
+            self.__arc_file.close()
+            self.__arc_file = None
+        self.__closed = True
 
-                # If any publisher objects were cached, then there were
-                # signed packages present, and p5i information for each
-                # must be added to the archive.
-                for pub in self.__pubs.values():
-                        # A new publisher object is created with a copy of only
-                        # the information that's needed for the archive.
-                        npub = pkg.client.publisher.Publisher(pub.prefix,
-                            alias=pub.alias,
-                            revoked_ca_certs=pub.revoked_ca_certs,
-                            approved_ca_certs=pub.approved_ca_certs)
+    def close(self, progtrack=None):
+        """If mode is 'r', this will close the archive file.  If mode is
+        'w', this will write all queued files to the archive and close
+        it.  Further operations on the archive are not possible after
+        calling this function."""
 
-                        # Create a p5i file.
-                        fobj, fn = self.__mkstemp()
-                        pkg.p5i.write(fobj, [npub])
-                        fobj.close()
+        assert not self.__closed
 
-                        # Queue the p5i file for addition to the archive.
-                        arcname = os.path.join("publisher", npub.prefix,
-                            "pub.p5i")
-                        self.add(fn, arcname=arcname)
+        if "w" not in self.__mode:
+            self.__close_fh()
+            self.__cleanup()
+            return
 
-                # Close the index; no more entries can be added.
-                self.__index.close()
+        # Add the standard pkg5.repository file before closing the
+        # index.
+        fobj, fname = self.__mkstemp()
+        fobj.write(
+            "[CONFIGURATION]\nversion = 4\n\n"
+            "[publisher]\nprefix = {0}\n\n"
+            "[repository]\nversion = 4\n".format(self.__default_pub)
+        )
+        fobj.close()
+        self.add(fname, arcname="pkg5.repository")
 
-                # If a tracker was provided, setup a progress goal.
-                idxbytes = 0
-                if progtrack:
-                        nfiles = len(self.__queue)
-                        nbytes = self.__queue_offset
-                        try:
-                                fs = os.stat(self.__index.pathname)
-                                nfiles += 1
-                                idxbytes = fs.st_size
-                                nbytes += idxbytes
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
+        # If any publisher objects were cached, then there were
+        # signed packages present, and p5i information for each
+        # must be added to the archive.
+        for pub in self.__pubs.values():
+            # A new publisher object is created with a copy of only
+            # the information that's needed for the archive.
+            npub = pkg.client.publisher.Publisher(
+                pub.prefix,
+                alias=pub.alias,
+                revoked_ca_certs=pub.revoked_ca_certs,
+                approved_ca_certs=pub.approved_ca_certs,
+            )
 
-                        progtrack.archive_set_goal(
-                            os.path.basename(self.__arc_name), nfiles,
-                            nbytes)
+            # Create a p5i file.
+            fobj, fn = self.__mkstemp()
+            pkg.p5i.write(fobj, [npub])
+            fobj.close()
 
-                # Add the index file to the archive as the first file; it will
-                # automatically be marked with a comment identifying the index
-                # version.
-                tfile = self.__arc_tfile
-                tfile.add(self.__index.pathname, arcname=self.__idx_name)
-                if progtrack:
-                        progtrack.archive_add_progress(1, idxbytes)
-                self.__index = None
+            # Queue the p5i file for addition to the archive.
+            arcname = os.path.join("publisher", npub.prefix, "pub.p5i")
+            self.add(fn, arcname=arcname)
 
-                # Add all queued files to the archive.
-                while self.__queue:
-                        src, arcname = self.__queue.popleft()
+        # Close the index; no more entries can be added.
+        self.__index.close()
 
-                        start_offset = tfile.offset
-                        tfile.add(src, arcname=arcname, recursive=False)
+        # If a tracker was provided, setup a progress goal.
+        idxbytes = 0
+        if progtrack:
+            nfiles = len(self.__queue)
+            nbytes = self.__queue_offset
+            try:
+                fs = os.stat(self.__index.pathname)
+                nfiles += 1
+                idxbytes = fs.st_size
+                nbytes += idxbytes
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
 
-                        # tarfile caches member information for every item
-                        # added by default, which provides fast access to the
-                        # archive contents after generation, but isn't needed
-                        # here (and uses a significant amount of memory).
-                        # Plus popping it off the stack here allows use of
-                        # the object's info to provide progress updates.
-                        ti = tfile.members.pop()
-                        if progtrack:
-                                progtrack.archive_add_progress(1,
-                                    tfile.offset - start_offset)
-                        ti.tarfile = None
-                        del ti
+            progtrack.archive_set_goal(
+                os.path.basename(self.__arc_name), nfiles, nbytes
+            )
 
-                # Cleanup temporary files.
-                self.__cleanup()
+        # Add the index file to the archive as the first file; it will
+        # automatically be marked with a comment identifying the index
+        # version.
+        tfile = self.__arc_tfile
+        tfile.add(self.__index.pathname, arcname=self.__idx_name)
+        if progtrack:
+            progtrack.archive_add_progress(1, idxbytes)
+        self.__index = None
 
-                # Archive created; success!
-                if progtrack:
-                        progtrack.archive_done()
-                self.__close_fh()
+        # Add all queued files to the archive.
+        while self.__queue:
+            src, arcname = self.__queue.popleft()
 
-        @property
-        def pathname(self):
-                """The absolute path of the archive file."""
-                return self.__arc_name
+            start_offset = tfile.offset
+            tfile.add(src, arcname=arcname, recursive=False)
+
+            # tarfile caches member information for every item
+            # added by default, which provides fast access to the
+            # archive contents after generation, but isn't needed
+            # here (and uses a significant amount of memory).
+            # Plus popping it off the stack here allows use of
+            # the object's info to provide progress updates.
+            ti = tfile.members.pop()
+            if progtrack:
+                progtrack.archive_add_progress(1, tfile.offset - start_offset)
+            ti.tarfile = None
+            del ti
+
+        # Cleanup temporary files.
+        self.__cleanup()
+
+        # Archive created; success!
+        if progtrack:
+            progtrack.archive_done()
+        self.__close_fh()
+
+    @property
+    def pathname(self):
+        """The absolute path of the archive file."""
+        return self.__arc_name
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/p5s.py
+++ b/src/modules/p5s.py
@@ -39,247 +39,262 @@ from pkg.misc import force_bytes
 
 CURRENT_VERSION = 0
 
+
 def parse(proxy_host, data):
-        """Reads the pkg(7) publisher JSON formatted data at 'location'
-        or from the provided file-like object 'fileobj' and returns a
-        tuple.  The first element of the tuple is a list of publisher objects.
-        The second element is a dictionary of image properties.
+    """Reads the pkg(7) publisher JSON formatted data at 'location'
+    or from the provided file-like object 'fileobj' and returns a
+    tuple.  The first element of the tuple is a list of publisher objects.
+    The second element is a dictionary of image properties.
 
-        'proxy_host' is the string to replace the special string
-        'http://<sysrepo>' with when it starts any uri.
+    'proxy_host' is the string to replace the special string
+    'http://<sysrepo>' with when it starts any uri.
 
-        'data' is a string containing the p5s data.
-        """
+    'data' is a string containing the p5s data.
+    """
 
-        def transform_urls(urls):
-                res = []
-                for val in urls:
-                        # If the URI contains <sysrepo> then it's served
-                        # directly by the system-repository.
-                        if val.startswith("http://{0}".format(
-                            publisher.SYSREPO_PROXY)):
-                                scheme, netloc, path, params, query, fragment =\
-                                    urlparse(val)
-                                r = publisher.RepositoryURI(
-                                        urlunparse((scheme, proxy_host,
-                                        path, params, query, fragment)))
-                        else:
-                                # This URI needs to be proxied through the
-                                # system-repository, so we assign it a special
-                                # ProxyURI, which gets replaced by the actual
-                                # URI of the system-repository in
-                                # imageconfig.BlendedConfig.__merge_publishers
-                                r = publisher.RepositoryURI(val)
-                                r.proxies = [publisher.ProxyURI(None,
-                                    system=True)]
-                        res.append(r)
-                return res
+    def transform_urls(urls):
+        res = []
+        for val in urls:
+            # If the URI contains <sysrepo> then it's served
+            # directly by the system-repository.
+            if val.startswith("http://{0}".format(publisher.SYSREPO_PROXY)):
+                scheme, netloc, path, params, query, fragment = urlparse(val)
+                r = publisher.RepositoryURI(
+                    urlunparse(
+                        (scheme, proxy_host, path, params, query, fragment)
+                    )
+                )
+            else:
+                # This URI needs to be proxied through the
+                # system-repository, so we assign it a special
+                # ProxyURI, which gets replaced by the actual
+                # URI of the system-repository in
+                # imageconfig.BlendedConfig.__merge_publishers
+                r = publisher.RepositoryURI(val)
+                r.proxies = [publisher.ProxyURI(None, system=True)]
+            res.append(r)
+        return res
 
-        try:
-                dump_struct = json.loads(data)
-        except ValueError as e:
-                # Not a valid JSON file.
-                raise api_errors.InvalidP5SFile(e)
+    try:
+        dump_struct = json.loads(data)
+    except ValueError as e:
+        # Not a valid JSON file.
+        raise api_errors.InvalidP5SFile(e)
 
-        try:
-                ver = int(dump_struct["version"])
-        except KeyError:
-                raise api_errors.InvalidP5SFile(_("missing version"))
-        except ValueError:
-                raise api_errors.InvalidP5SFile(_("invalid version"))
+    try:
+        ver = int(dump_struct["version"])
+    except KeyError:
+        raise api_errors.InvalidP5SFile(_("missing version"))
+    except ValueError:
+        raise api_errors.InvalidP5SFile(_("invalid version"))
 
-        if ver > CURRENT_VERSION:
-                raise api_errors.UnsupportedP5SFile()
+    if ver > CURRENT_VERSION:
+        raise api_errors.UnsupportedP5SFile()
 
-        pubs = []
-        props = {}
-        try:
-                plist = dump_struct.get("publishers", [])
+    pubs = []
+    props = {}
+    try:
+        plist = dump_struct.get("publishers", [])
 
-                # For each set of publisher information in the parsed p5s file,
-                # build a Publisher object.
-                for p in plist:
-                        alias = p.get("alias", None)
-                        prefix = p.get("name", None)
-                        sticky = p.get("sticky", True)
+        # For each set of publisher information in the parsed p5s file,
+        # build a Publisher object.
+        for p in plist:
+            alias = p.get("alias", None)
+            prefix = p.get("name", None)
+            sticky = p.get("sticky", True)
 
-                        if not prefix:
-                                prefix = "Unknown"
+            if not prefix:
+                prefix = "Unknown"
 
-                        pub = publisher.Publisher(prefix, alias=alias,
-                            sticky=sticky)
-                        v = p.get("signature-policy")
-                        if v is not None:
-                                pub.properties["signature-policy"] = v
-                        v = p.get("signature-required-names")
-                        if v is not None:
-                                pub.properties["signature-required-names"] = v
+            pub = publisher.Publisher(prefix, alias=alias, sticky=sticky)
+            v = p.get("signature-policy")
+            if v is not None:
+                pub.properties["signature-policy"] = v
+            v = p.get("signature-required-names")
+            if v is not None:
+                pub.properties["signature-required-names"] = v
 
-                        r = p.get("repository", None)
-                        if r:
-                                rargs = {}
-                                for prop in ("collection_type",
-                                    "description", "name",
-                                    "refresh_seconds", "sticky"):
-                                        val = r.get(prop, None)
-                                        if val is None or val == "None":
-                                                continue
-                                        rargs[prop] = val
+            r = p.get("repository", None)
+            if r:
+                rargs = {}
+                for prop in (
+                    "collection_type",
+                    "description",
+                    "name",
+                    "refresh_seconds",
+                    "sticky",
+                ):
+                    val = r.get(prop, None)
+                    if val is None or val == "None":
+                        continue
+                    rargs[prop] = val
 
-                                for prop in ("legal_uris", "related_uris"):
-                                        val = r.get(prop, [])
-                                        if not isinstance(val, list):
-                                                continue
-                                        rargs[prop] = val
+                for prop in ("legal_uris", "related_uris"):
+                    val = r.get(prop, [])
+                    if not isinstance(val, list):
+                        continue
+                    rargs[prop] = val
 
-                                for prop in ("mirrors", "origins"):
-                                        urls = r.get(prop, [])
-                                        if not isinstance(urls, list):
-                                                continue
-                                        rargs[prop] = transform_urls(urls)
-                                repo = publisher.Repository(**rargs)
-                                pub.repository = repo
-                        pubs.append(pub)
+                for prop in ("mirrors", "origins"):
+                    urls = r.get(prop, [])
+                    if not isinstance(urls, list):
+                        continue
+                    rargs[prop] = transform_urls(urls)
+                repo = publisher.Repository(**rargs)
+                pub.repository = repo
+            pubs.append(pub)
 
-                props["publisher-search-order"] = \
-                    dump_struct["image_properties"]["publisher-search-order"]
-
-                sig_pol = dump_struct["image_properties"].get(
-                    "signature-policy")
-                if sig_pol is not None:
-                        props["signature-policy"] = sig_pol
-
-                req_names = dump_struct["image_properties"].get(
-                    "signature-required-names")
-                if req_names is not None:
-                        props["signature-required-names"] = req_names
-        except (api_errors.PublisherError, TypeError, ValueError) as e:
-                raise api_errors.InvalidP5SFile(str(e))
-        return pubs, props
-
-def write(fileobj, pubs, cfg):
-        """Writes the publisher, repository, and provided package names to the
-        provided file-like object 'fileobj' in JSON p5i format.
-
-        'fileobj' is an object that has a 'write' method that accepts data to be
-        written as a parameter.
-
-        'pubs' is a list of Publisher objects.
-
-        'cfg' is an ImageConfig which contains the properties of the image on
-        which the generated p5s file is based."""
-
-        def transform_uris(urls, prefix):
-                res = []
-
-                for u in urls:
-                        m = copy.copy(u)
-                        if m.scheme == "http":
-                                res.append(m.uri)
-                        elif m.scheme == "https":
-                                # The system depot handles connecting to the
-                                # proxied https repositories, so the client
-                                # should communicate over http to prevent it
-                                # from doing tunneling.
-                                m.change_scheme("http")
-                                res.append(m.uri)
-                        elif m.scheme == "file":
-                                # The system depot provides direct access to
-                                # file repositories.  The token <sysrepo> will
-                                # be replaced in the client with the url it uses
-                                # to communicate with the system repository.
-                                res.append("http://{0}/{1}/{2}".format(
-                                    publisher.SYSREPO_PROXY, prefix,
-                                    digest.DEFAULT_HASH_FUNC(
-                                    force_bytes(m.uri.rstrip("/"))).hexdigest()
-                                    ))
-                        else:
-                                assert False, "{0} is an unknown scheme.".format(
-                                    u.scheme)
-
-                # Remove duplicates, since the system-repository can only
-                # provide one path to a given origin. This can happen if the
-                # image has eg. two origins/mirrors configured for a publisher,
-                # with one using http and the other using https, but both using
-                # the same netloc and path.
-                # We want to preserve origin/mirror order, so simply casting
-                # into a set is not appropriate.
-                values = set()
-                res_unique = []
-                for item in res:
-                        if item not in values:
-                                values.add(item)
-                                res_unique.append(item)
-                return res_unique
-
-        dump_struct = {
-            "publishers": [],
-            "image_properties": {},
-            "version": CURRENT_VERSION,
-        }
-
-        dpubs = dump_struct["publishers"]
-        prefixes = set()
-        for p in pubs:
-
-                d = None
-                if p.repository:
-                        r = p.repository
-                        reg_uri = ""
-
-                        mirrors = transform_uris([u for u in r.mirrors if not
-                            u.disabled], p.prefix)
-                        origins = transform_uris([u for u in r.origins if not
-                            u.disabled], p.prefix)
-                        d = {
-                            "collection_type": r.collection_type,
-                            "description": r.description,
-                            "legal_uris": [u.uri for u in r.legal_uris],
-                            "mirrors": mirrors,
-                            "name": r.name,
-                            "origins": origins,
-                            "refresh_seconds": r.refresh_seconds,
-                            "related_uris": [
-                                u.uri for u in r.related_uris
-                            ],
-                        }
-
-                dpub = {
-                    "alias": p.alias,
-                    "name": p.prefix,
-                    "repository": d,
-                    "sticky": p.sticky,
-                }
-
-                sp = p.properties.get("signature-policy")
-                if sp and sp != DEF_TOKEN:
-                    dpub["signature-policy"] = sp
-
-                srn = p.properties.get("signature-required-names")
-                if srn:
-                    dpub["signature-required-names"] = \
-                        p.properties["signature-required-names"]
-
-                dpubs.append(dpub)
-                prefixes.add(p.prefix)
-
-        dump_struct["image_properties"]["publisher-search-order"] = [
-            p for p in cfg.get_property("property", "publisher-search-order")
-            if p in prefixes
+        props["publisher-search-order"] = dump_struct["image_properties"][
+            "publisher-search-order"
         ]
 
-        sig_pol = cfg.get_property("property", "signature-policy")
-        if sig_pol != DEF_TOKEN:
-                dump_struct["image_properties"]["signature-policy"] = sig_pol
+        sig_pol = dump_struct["image_properties"].get("signature-policy")
+        if sig_pol is not None:
+            props["signature-policy"] = sig_pol
 
-        req_names = cfg.get_property("property", "signature-required-names")
-        if req_names:
-                dump_struct["image_properties"]["signature-required-names"] = \
-                    req_names
+        req_names = dump_struct["image_properties"].get(
+            "signature-required-names"
+        )
+        if req_names is not None:
+            props["signature-required-names"] = req_names
+    except (api_errors.PublisherError, TypeError, ValueError) as e:
+        raise api_errors.InvalidP5SFile(str(e))
+    return pubs, props
 
-        json.dump(dump_struct, fileobj, ensure_ascii=False,
-            allow_nan=False, indent=2, sort_keys=True)
-        fileobj.write("\n")
+
+def write(fileobj, pubs, cfg):
+    """Writes the publisher, repository, and provided package names to the
+    provided file-like object 'fileobj' in JSON p5i format.
+
+    'fileobj' is an object that has a 'write' method that accepts data to be
+    written as a parameter.
+
+    'pubs' is a list of Publisher objects.
+
+    'cfg' is an ImageConfig which contains the properties of the image on
+    which the generated p5s file is based."""
+
+    def transform_uris(urls, prefix):
+        res = []
+
+        for u in urls:
+            m = copy.copy(u)
+            if m.scheme == "http":
+                res.append(m.uri)
+            elif m.scheme == "https":
+                # The system depot handles connecting to the
+                # proxied https repositories, so the client
+                # should communicate over http to prevent it
+                # from doing tunneling.
+                m.change_scheme("http")
+                res.append(m.uri)
+            elif m.scheme == "file":
+                # The system depot provides direct access to
+                # file repositories.  The token <sysrepo> will
+                # be replaced in the client with the url it uses
+                # to communicate with the system repository.
+                res.append(
+                    "http://{0}/{1}/{2}".format(
+                        publisher.SYSREPO_PROXY,
+                        prefix,
+                        digest.DEFAULT_HASH_FUNC(
+                            force_bytes(m.uri.rstrip("/"))
+                        ).hexdigest(),
+                    )
+                )
+            else:
+                assert False, "{0} is an unknown scheme.".format(u.scheme)
+
+        # Remove duplicates, since the system-repository can only
+        # provide one path to a given origin. This can happen if the
+        # image has eg. two origins/mirrors configured for a publisher,
+        # with one using http and the other using https, but both using
+        # the same netloc and path.
+        # We want to preserve origin/mirror order, so simply casting
+        # into a set is not appropriate.
+        values = set()
+        res_unique = []
+        for item in res:
+            if item not in values:
+                values.add(item)
+                res_unique.append(item)
+        return res_unique
+
+    dump_struct = {
+        "publishers": [],
+        "image_properties": {},
+        "version": CURRENT_VERSION,
+    }
+
+    dpubs = dump_struct["publishers"]
+    prefixes = set()
+    for p in pubs:
+        d = None
+        if p.repository:
+            r = p.repository
+            reg_uri = ""
+
+            mirrors = transform_uris(
+                [u for u in r.mirrors if not u.disabled], p.prefix
+            )
+            origins = transform_uris(
+                [u for u in r.origins if not u.disabled], p.prefix
+            )
+            d = {
+                "collection_type": r.collection_type,
+                "description": r.description,
+                "legal_uris": [u.uri for u in r.legal_uris],
+                "mirrors": mirrors,
+                "name": r.name,
+                "origins": origins,
+                "refresh_seconds": r.refresh_seconds,
+                "related_uris": [u.uri for u in r.related_uris],
+            }
+
+        dpub = {
+            "alias": p.alias,
+            "name": p.prefix,
+            "repository": d,
+            "sticky": p.sticky,
+        }
+
+        sp = p.properties.get("signature-policy")
+        if sp and sp != DEF_TOKEN:
+            dpub["signature-policy"] = sp
+
+        srn = p.properties.get("signature-required-names")
+        if srn:
+            dpub["signature-required-names"] = p.properties[
+                "signature-required-names"
+            ]
+
+        dpubs.append(dpub)
+        prefixes.add(p.prefix)
+
+    dump_struct["image_properties"]["publisher-search-order"] = [
+        p
+        for p in cfg.get_property("property", "publisher-search-order")
+        if p in prefixes
+    ]
+
+    sig_pol = cfg.get_property("property", "signature-policy")
+    if sig_pol != DEF_TOKEN:
+        dump_struct["image_properties"]["signature-policy"] = sig_pol
+
+    req_names = cfg.get_property("property", "signature-required-names")
+    if req_names:
+        dump_struct["image_properties"]["signature-required-names"] = req_names
+
+    json.dump(
+        dump_struct,
+        fileobj,
+        ensure_ascii=False,
+        allow_nan=False,
+        indent=2,
+        sort_keys=True,
+    )
+    fileobj.write("\n")
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/pipeutils.py
+++ b/src/modules/pipeutils.py
@@ -84,10 +84,12 @@ import traceback
 # import JSON RPC libraries and objects
 import jsonrpclib as rpclib
 import jsonrpclib.jsonrpc as rpc
-from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCRequestHandler as \
-    SimpleRPCRequestHandler
-from jsonrpclib.SimpleJSONRPCServer import SimpleJSONRPCDispatcher as \
-    SimpleRPCDispatcher
+from jsonrpclib.SimpleJSONRPCServer import (
+    SimpleJSONRPCRequestHandler as SimpleRPCRequestHandler,
+)
+from jsonrpclib.SimpleJSONRPCServer import (
+    SimpleJSONRPCDispatcher as SimpleRPCDispatcher,
+)
 
 #
 # These includes make it easier for clients to catch the specific
@@ -98,6 +100,7 @@ from jsonrpclib import ProtocolError as ProtocolError1
 
 from six.moves import socketserver, http_client
 from six.moves.xmlrpc_client import ProtocolError as ProtocolError2
+
 # Unused import; pylint: enable=W0611
 
 from pkg.misc import force_bytes, force_str
@@ -106,549 +109,561 @@ from pkg.misc import force_bytes, force_str
 # configure logging in this file, so we attach a do-nothing handler to it to
 # prevent error message being output to sys.stderr.
 logging.getLogger("jsonrpclib.SimpleJSONRPCServer").addHandler(
-    logging.NullHandler())
+    logging.NullHandler()
+)
 
 # debugging
-pipeutils_debug = (os.environ.get("PKG_PIPEUTILS_DEBUG", None) is not None)
+pipeutils_debug = os.environ.get("PKG_PIPEUTILS_DEBUG", None) is not None
+
 
 class PipeFile(object):
-        """Object which makes a pipe look like a "file" object.
+    """Object which makes a pipe look like a "file" object.
 
-        Note that all data transmitted via this pipe is transmitted
-        indirectly.  Any data written to or read from the pipe is actually
-        transmitted via temporary files.  For sending data, the data is
-        written to a temporary file and then the associated file descriptor is
-        sent via the pipe.  For receiving data we try to read a file
-        descriptor from the pipe and when we get one we return the data from
-        the temporary file associated with the file descriptor that we just
-        read.  This is done to help ensure that processes don't block while
-        writing to these pipes (otherwise consumers of these interfaces would
-        have to create threads to constantly drain data from these pipes to
-        prevent clients from blocking).
+    Note that all data transmitted via this pipe is transmitted
+    indirectly.  Any data written to or read from the pipe is actually
+    transmitted via temporary files.  For sending data, the data is
+    written to a temporary file and then the associated file descriptor is
+    sent via the pipe.  For receiving data we try to read a file
+    descriptor from the pipe and when we get one we return the data from
+    the temporary file associated with the file descriptor that we just
+    read.  This is done to help ensure that processes don't block while
+    writing to these pipes (otherwise consumers of these interfaces would
+    have to create threads to constantly drain data from these pipes to
+    prevent clients from blocking).
 
-        This class also support additional non-file special operations like
-        sendfd() and recvfd()."""
+    This class also support additional non-file special operations like
+    sendfd() and recvfd()."""
 
-        def __init__(self, fd, debug_label, debug=pipeutils_debug,
-            http_enc=True):
-                self.__pipefd = fd
-                self.__readfh = None
-                self.closed = False
-                self.__http_enc = http_enc
+    def __init__(self, fd, debug_label, debug=pipeutils_debug, http_enc=True):
+        self.__pipefd = fd
+        self.__readfh = None
+        self.closed = False
+        self.__http_enc = http_enc
 
-                # Pipes related objects should never live past an exec
-                flags = fcntl.fcntl(self.__pipefd, fcntl.F_GETFD)
-                flags |= fcntl.FD_CLOEXEC
-                fcntl.fcntl(self.__pipefd, fcntl.F_SETFD, flags)
+        # Pipes related objects should never live past an exec
+        flags = fcntl.fcntl(self.__pipefd, fcntl.F_GETFD)
+        flags |= fcntl.FD_CLOEXEC
+        fcntl.fcntl(self.__pipefd, fcntl.F_SETFD, flags)
 
-                self.debug = debug
-                self.debug_label = debug_label
-                self.debug_msg("__init__")
+        self.debug = debug
+        self.debug_label = debug_label
+        self.debug_msg("__init__")
 
-        def __del__(self):
-                self.debug_msg("__del__")
-                if not self.closed:
-                        self.close()
+    def __del__(self):
+        self.debug_msg("__del__")
+        if not self.closed:
+            self.close()
 
-        def debug_msg(self, op, msg=None):
-                """If debugging is enabled display msg."""
-                if not self.debug:
-                        return
+    def debug_msg(self, op, msg=None):
+        """If debugging is enabled display msg."""
+        if not self.debug:
+            return
 
-                if msg is not None:
-                        msg = ": {0}".format(msg)
+        if msg is not None:
+            msg = ": {0}".format(msg)
+        else:
+            msg = ""
+
+        if self.debug_label is not None:
+            label = "{0}: {1}".format(os.getpid(), self.debug_label)
+        else:
+            label = "{0}".format(os.getpid())
+
+        print(
+            "{0}: {1}.{2}({3:d}){4}".format(
+                label, op, type(self).__name__, self.__pipefd, msg
+            ),
+            file=sys.stderr,
+        )
+
+    def debug_dumpfd(self, op, fd):
+        """If debugging is enabled dump the contents of fd."""
+        if not self.debug:
+            return
+
+        si = os.fstat(fd)
+        if not stat.S_ISREG(si.st_mode):
+            msg = "fd={0:d}".format(fd)
+        else:
+            os.lseek(fd, os.SEEK_SET, 0)
+            msg = "".join(os.fdopen(os.dup(fd)).readlines())
+            msg = "msg={0}".format(msg)
+            os.lseek(fd, os.SEEK_SET, 0)
+
+        self.debug_msg(op, msg)
+
+    def fileno(self):
+        """Required to support select.select()."""
+        return self.__pipefd
+
+    def readline(self, *args):
+        """Read one entire line from the pipe.
+        Can block waiting for input."""
+
+        if self.__readfh is not None:
+            # read from the fd that we received over the pipe
+            data = self.__readfh.readline(*args)
+            if data != "":
+                if self.__http_enc:
+                    # Python 3`http.client`HTTPReponse`_read_status:
+                    # requires a bytes input.
+                    return force_bytes(data, "iso-8859-1")
                 else:
-                        msg = ""
+                    return data
+            # the fd we received over the pipe is empty
+            self.__readfh = None
 
-                if self.debug_label is not None:
-                        label = "{0}: {1}".format(os.getpid(),
-                            self.debug_label)
-                else:
-                        label = "{0}".format(os.getpid())
+        # recieve a file descriptor from the pipe
+        fd = self.recvfd()
+        if fd == -1:
+            return b"" if self.__http_enc else ""
+        self.__readfh = os.fdopen(fd)
+        # return data from the received fd
+        return self.readline(*args)
 
-                print("{0}: {1}.{2}({3:d}){4}".format(
-                    label, op, type(self).__name__, self.__pipefd, msg),
-                    file=sys.stderr)
+    def read(self, size=-1):
+        """Read at most size bytes from the pipe.
+        Can block waiting for input."""
 
-        def debug_dumpfd(self, op, fd):
-                """If debugging is enabled dump the contents of fd."""
-                if not self.debug:
-                        return
+        if self.__readfh is not None:
+            # read from the fd that we received over the pipe
+            data = self.__readfh.read(size)
+            if data != "":
+                return data
+            # the fd we received over the pipe is empty
+            self.__readfh = None
 
-                si = os.fstat(fd)
-                if not stat.S_ISREG(si.st_mode):
-                        msg = "fd={0:d}".format(fd)
-                else:
-                        os.lseek(fd, os.SEEK_SET, 0)
-                        msg = "".join(os.fdopen(os.dup(fd)).readlines())
-                        msg = "msg={0}".format(msg)
-                        os.lseek(fd, os.SEEK_SET, 0)
+        # recieve a file descriptor from the pipe
+        fd = self.recvfd()
+        if fd == -1:
+            return ""
+        self.__readfh = os.fdopen(fd)
+        # return data from the received fd
+        return self.read(size)
 
-                self.debug_msg(op, msg)
+    # For Python 3: self.fp requires a readinto method.
+    def readinto(self, b):
+        """Read up to len(b) bytes into the writable buffer *b* and
+        return the numbers of bytes read."""
+        # not-context-manager for py 2.7;
+        # pylint: disable=E1129
+        with memoryview(b) as view:
+            data = self.read(len(view))
+            view[: len(data)] = force_bytes(data)
+        return len(data)
 
-        def fileno(self):
-                """Required to support select.select()."""
-                return self.__pipefd
+    def write(self, msg):
+        """Write a string to the pipe."""
+        # JSON object must be str to be used in jsonrpclib
+        mf = tempfile.TemporaryFile(mode="w+")
+        mf.write(force_str(msg))
+        mf.flush()
+        self.sendfd(mf.fileno())
+        mf.close()
 
-        def readline(self, *args):
-                """Read one entire line from the pipe.
-                Can block waiting for input."""
+    def close(self):
+        """Close the pipe."""
+        if self.closed:
+            return
+        self.debug_msg("close")
+        os.close(self.__pipefd)
+        self.__readfh = None
+        self.closed = True
 
-                if self.__readfh is not None:
-                        # read from the fd that we received over the pipe
-                        data = self.__readfh.readline(*args)
-                        if data != "":
-                                if self.__http_enc:
-                                # Python 3`http.client`HTTPReponse`_read_status:
-                                # requires a bytes input.
-                                        return force_bytes(data, "iso-8859-1")
-                                else:
-                                        return data
-                        # the fd we received over the pipe is empty
-                        self.__readfh = None
+    def flush(self):
+        """A NOP since we never do any buffering of data."""
+        pass
 
-                # recieve a file descriptor from the pipe
-                fd = self.recvfd()
-                if fd == -1:
-                        return b"" if self.__http_enc else ""
-                self.__readfh = os.fdopen(fd)
-                # return data from the received fd
-                return self.readline(*args)
+    def sendfd(self, fd):
+        """Send a file descriptor via the pipe."""
 
-        def read(self, size=-1):
-                """Read at most size bytes from the pipe.
-                Can block waiting for input."""
+        if self.closed:
+            self.debug_msg("sendfd", "failed (closed)")
+            raise IOError(
+                "sendfd() called for closed {0}".format(type(self).__name__)
+            )
 
-                if self.__readfh is not None:
-                        # read from the fd that we received over the pipe
-                        data = self.__readfh.read(size)
-                        if data != "":
-                                return data
-                        # the fd we received over the pipe is empty
-                        self.__readfh = None
+        self.debug_dumpfd("sendfd", fd)
+        try:
+            fcntl.ioctl(self.__pipefd, fcntl.I_SENDFD, fd)
+        except:
+            self.debug_msg("sendfd", "failed")
+            raise
 
-                # recieve a file descriptor from the pipe
-                fd = self.recvfd()
-                if fd == -1:
-                        return ""
-                self.__readfh = os.fdopen(fd)
-                # return data from the received fd
-                return self.read(size)
+    def recvfd(self):
+        """Receive a file descriptor via the pipe."""
 
-        # For Python 3: self.fp requires a readinto method.
-        def readinto(self, b):
-                """Read up to len(b) bytes into the writable buffer *b* and
-                return the numbers of bytes read."""
-                # not-context-manager for py 2.7;
-                # pylint: disable=E1129
-                with memoryview(b) as view:
-                        data = self.read(len(view))
-                        view[:len(data)] = force_bytes(data)
-                return len(data)
+        if self.closed:
+            self.debug_msg("recvfd", "failed (closed)")
+            raise IOError(
+                "sendfd() called for closed {0}".format(type(self).__name__)
+            )
 
-        def write(self, msg):
-                """Write a string to the pipe."""
-                # JSON object must be str to be used in jsonrpclib
-                mf = tempfile.TemporaryFile(mode="w+")
-                mf.write(force_str(msg))
-                mf.flush()
-                self.sendfd(mf.fileno())
-                mf.close()
+        try:
+            fcntl_args = struct.pack("i", -1)
+            fcntl_rv = fcntl.ioctl(self.__pipefd, fcntl.I_RECVFD, fcntl_args)
+            fd = struct.unpack("i", fcntl_rv)[0]
+        except IOError as e:
+            if e.errno == errno.ENXIO:
+                # other end of the connection was closed
+                return -1
+            self.debug_msg("recvfd", "failed")
+            raise e
+        assert fd != -1
 
-        def close(self):
-                """Close the pipe."""
-                if self.closed:
-                        return
-                self.debug_msg("close")
-                os.close(self.__pipefd)
-                self.__readfh = None
-                self.closed = True
+        # debugging
+        self.debug_dumpfd("recvfd", fd)
 
-        def flush(self):
-                """A NOP since we never do any buffering of data."""
-                pass
+        # reset the current file pointer
+        si = os.fstat(fd)
+        if stat.S_ISREG(si.st_mode):
+            os.lseek(fd, os.SEEK_SET, 0)
 
-        def sendfd(self, fd):
-                """Send a file descriptor via the pipe."""
-
-                if self.closed:
-                        self.debug_msg("sendfd", "failed (closed)")
-                        raise IOError(
-                            "sendfd() called for closed {0}".format(
-                            type(self).__name__))
-
-                self.debug_dumpfd("sendfd", fd)
-                try:
-                        fcntl.ioctl(self.__pipefd, fcntl.I_SENDFD, fd)
-                except:
-                        self.debug_msg("sendfd", "failed")
-                        raise
-
-        def recvfd(self):
-                """Receive a file descriptor via the pipe."""
-
-                if self.closed:
-                        self.debug_msg("recvfd", "failed (closed)")
-                        raise IOError(
-                            "sendfd() called for closed {0}".format(
-                            type(self).__name__))
-
-                try:
-                        fcntl_args = struct.pack('i', -1)
-                        fcntl_rv = fcntl.ioctl(self.__pipefd,
-                            fcntl.I_RECVFD, fcntl_args)
-                        fd = struct.unpack('i', fcntl_rv)[0]
-                except IOError as e:
-                        if e.errno == errno.ENXIO:
-                                # other end of the connection was closed
-                                return -1
-                        self.debug_msg("recvfd", "failed")
-                        raise e
-                assert fd != -1
-
-                # debugging
-                self.debug_dumpfd("recvfd", fd)
-
-                # reset the current file pointer
-                si = os.fstat(fd)
-                if stat.S_ISREG(si.st_mode):
-                        os.lseek(fd, os.SEEK_SET, 0)
-
-                return fd
+        return fd
 
 
 class PipeSocket(PipeFile):
-        """Object which makes a pipe look like a "socket" object."""
+    """Object which makes a pipe look like a "socket" object."""
 
-        def __init__(self, fd, debug_label, debug=pipeutils_debug,
-            http_enc=True):
-                self.__http_enc = http_enc
-                PipeFile.__init__(self, fd, debug_label, debug=debug,
-                    http_enc=http_enc)
+    def __init__(self, fd, debug_label, debug=pipeutils_debug, http_enc=True):
+        self.__http_enc = http_enc
+        PipeFile.__init__(self, fd, debug_label, debug=debug, http_enc=http_enc)
 
-        def makefile(self, mode='r', bufsize=-1):
-                """Return a file-like object associated with this pipe.
-                The pipe will be duped for this new object so that the object
-                can be closed and garbage-collected independently."""
-                # Unused argument; pylint: disable=W0613
+    def makefile(self, mode="r", bufsize=-1):
+        """Return a file-like object associated with this pipe.
+        The pipe will be duped for this new object so that the object
+        can be closed and garbage-collected independently."""
+        # Unused argument; pylint: disable=W0613
 
-                dup_fd = os.dup(self.fileno())
-                self.debug_msg("makefile", "dup fd={0:d}".format(dup_fd))
-                return PipeFile(dup_fd, self.debug_label, debug=self.debug,
-                    http_enc=self.__http_enc)
+        dup_fd = os.dup(self.fileno())
+        self.debug_msg("makefile", "dup fd={0:d}".format(dup_fd))
+        return PipeFile(
+            dup_fd, self.debug_label, debug=self.debug, http_enc=self.__http_enc
+        )
 
-        def recv(self, bufsize, flags=0):
-                """Receive data from the pipe.
-                Can block waiting for input."""
-                # Unused argument; pylint: disable=W0613
-                return self.read(bufsize)
+    def recv(self, bufsize, flags=0):
+        """Receive data from the pipe.
+        Can block waiting for input."""
+        # Unused argument; pylint: disable=W0613
+        return self.read(bufsize)
 
-        def send(self, msg, flags=0):
-                """Send data to the Socket.
-                Should never really block."""
-                # Unused argument; pylint: disable=W0613
-                return self.write(msg)
+    def send(self, msg, flags=0):
+        """Send data to the Socket.
+        Should never really block."""
+        # Unused argument; pylint: disable=W0613
+        return self.write(msg)
 
-        def sendall(self, msg):
-                """Send data to the pipe.
-                Should never really block."""
-                self.write(msg)
+    def sendall(self, msg):
+        """Send data to the pipe.
+        Should never really block."""
+        self.write(msg)
 
-        @staticmethod
-        def shutdown(how):
-                """Nothing to do here.  Move along."""
-                # Unused argument; pylint: disable=W0613
-                return
+    @staticmethod
+    def shutdown(how):
+        """Nothing to do here.  Move along."""
+        # Unused argument; pylint: disable=W0613
+        return
 
-        def setsockopt(self, *args):
-                """set socket opt."""
-                pass
+    def setsockopt(self, *args):
+        """set socket opt."""
+        pass
+
 
 # pylint seems to be panic about these.
 # PipedHTTP: Class has no __init__ method; pylint: disable=W0232
 # PipedHTTPResponse.begin: Attribute 'will_close' defined outside __init__;
 # pylint: disable=W0201
 class PipedHTTPResponse(http_client.HTTPResponse):
-        """Create a httplib.HTTPResponse like object that can be used with
-        a pipe as a transport.  We override the minimum number of parent
-        routines necessary."""
+    """Create a httplib.HTTPResponse like object that can be used with
+    a pipe as a transport.  We override the minimum number of parent
+    routines necessary."""
 
-        def begin(self):
-                """Our connection will never be automatically closed, so set
-                will_close to False."""
+    def begin(self):
+        """Our connection will never be automatically closed, so set
+        will_close to False."""
 
-                http_client.HTTPResponse.begin(self)
-                self.will_close = False
-                return
+        http_client.HTTPResponse.begin(self)
+        self.will_close = False
+        return
 
 
 class PipedHTTPConnection(http_client.HTTPConnection):
-        """Create a httplib.HTTPConnection like object that can be used with
-        a pipe as a transport.  We override the minimum number of parent
-        routines necessary."""
+    """Create a httplib.HTTPConnection like object that can be used with
+    a pipe as a transport.  We override the minimum number of parent
+    routines necessary."""
 
-        # we use PipedHTTPResponse in place of httplib.HTTPResponse
-        response_class = PipedHTTPResponse
+    # we use PipedHTTPResponse in place of httplib.HTTPResponse
+    response_class = PipedHTTPResponse
 
-        def __init__(self, fd, port=None):
-                assert port is None
+    def __init__(self, fd, port=None):
+        assert port is None
 
-                # invoke parent constructor
-                http_client.HTTPConnection.__init__(self, "localhost")
+        # invoke parent constructor
+        http_client.HTTPConnection.__init__(self, "localhost")
 
-                # self.sock was initialized by httplib.HTTPConnection
-                # to point to a socket, overwrite it with a pipe.
-                assert type(fd) == int and os.fstat(fd)
-                self.sock = PipeSocket(fd, "client-connection")
+        # self.sock was initialized by httplib.HTTPConnection
+        # to point to a socket, overwrite it with a pipe.
+        assert type(fd) == int and os.fstat(fd)
+        self.sock = PipeSocket(fd, "client-connection")
 
-        def __del__(self):
-                # make sure the destructor gets called for our pipe
-                if self.sock is not None:
-                        self.close()
+    def __del__(self):
+        # make sure the destructor gets called for our pipe
+        if self.sock is not None:
+            self.close()
 
-        def close(self):
-                """Close our pipe fd."""
-                self.sock.close()
-                self.sock = None
+    def close(self):
+        """Close our pipe fd."""
+        self.sock.close()
+        self.sock = None
 
-        def fileno(self):
-                """Required to support select()."""
-                return self.sock.fileno()
+    def fileno(self):
+        """Required to support select()."""
+        return self.sock.fileno()
 
 
 class _PipedTransport(rpc.Transport):
-        """Create a Transport object which can create new PipedHTTP
-        connections via an existing pipe."""
+    """Create a Transport object which can create new PipedHTTP
+    connections via an existing pipe."""
 
-        def __init__(self, fd, http_enc=True):
-                self.__pipe_file = PipeFile(fd, "client-transport")
-                self.__http_enc = http_enc
-                # This is a workaround to cope with the jsonrpclib update
-                # (version 0.2.6) more safely. Once jsonrpclib is out in
-                # the OS build, we can change it to always pass a 'config'
-                # argument to __init__.
-                if hasattr(rpclib.config, "DEFAULT"):
-                        rpc.Transport.__init__(self, rpclib.config.DEFAULT)
-                else:
-                        rpc.Transport.__init__(self)
-                self.verbose = False
-                self._extra_headers = None
+    def __init__(self, fd, http_enc=True):
+        self.__pipe_file = PipeFile(fd, "client-transport")
+        self.__http_enc = http_enc
+        # This is a workaround to cope with the jsonrpclib update
+        # (version 0.2.6) more safely. Once jsonrpclib is out in
+        # the OS build, we can change it to always pass a 'config'
+        # argument to __init__.
+        if hasattr(rpclib.config, "DEFAULT"):
+            rpc.Transport.__init__(self, rpclib.config.DEFAULT)
+        else:
+            rpc.Transport.__init__(self)
+        self.verbose = False
+        self._extra_headers = None
 
-        def __del__(self):
-                # make sure the destructor gets called for our connection
-                if self.__pipe_file is not None:
-                        self.close()
+    def __del__(self):
+        # make sure the destructor gets called for our connection
+        if self.__pipe_file is not None:
+            self.close()
 
-        def close(self):
-                """Close the pipe associated with this transport."""
-                self.__pipe_file.close()
-                self.__pipe_file = None
+    def close(self):
+        """Close the pipe associated with this transport."""
+        self.__pipe_file.close()
+        self.__pipe_file = None
 
-        def make_connection(self, host): # Unused argument 'host'; pylint: disable=W0613
-                """Create a new PipedHTTP connection to the server.  This
-                involves creating a new pipe, and sending one end of the pipe
-                to the server, and then wrapping the local end of the pipe
-                with a PipedHTTPConnection object.  This object can then be
-                subsequently used to issue http requests."""
-                # Redefining name from outer scope; pylint: disable=W0621
+    def make_connection(
+        self, host
+    ):  # Unused argument 'host'; pylint: disable=W0613
+        """Create a new PipedHTTP connection to the server.  This
+        involves creating a new pipe, and sending one end of the pipe
+        to the server, and then wrapping the local end of the pipe
+        with a PipedHTTPConnection object.  This object can then be
+        subsequently used to issue http requests."""
+        # Redefining name from outer scope; pylint: disable=W0621
 
-                assert self.__pipe_file is not None
+        assert self.__pipe_file is not None
 
-                client_pipefd, server_pipefd = os.pipe()
-                self.__pipe_file.sendfd(server_pipefd)
-                os.close(server_pipefd)
+        client_pipefd, server_pipefd = os.pipe()
+        self.__pipe_file.sendfd(server_pipefd)
+        os.close(server_pipefd)
 
-                if self.__http_enc:
-                        # we're using http encapsulation so return a
-                        # PipedHTTPConnection object
-                        return PipedHTTPConnection(client_pipefd)
+        if self.__http_enc:
+            # we're using http encapsulation so return a
+            # PipedHTTPConnection object
+            return PipedHTTPConnection(client_pipefd)
 
-                # we're not using http encapsulation so return a
-                # PipeSocket object
-                return PipeSocket(client_pipefd, "client-connection",
-                    http_enc=self.__http_enc)
+        # we're not using http encapsulation so return a
+        # PipeSocket object
+        return PipeSocket(
+            client_pipefd, "client-connection", http_enc=self.__http_enc
+        )
 
-        def request(self, host, handler, request_body, verbose=0):
-                """Send a request to the server."""
+    def request(self, host, handler, request_body, verbose=0):
+        """Send a request to the server."""
 
-                if self.__http_enc:
-                        # we're using http encapsulation so just pass the
-                        # request to our parent class.
-                        return rpc.Transport.request(self,
-                            host, handler, request_body, verbose)
+        if self.__http_enc:
+            # we're using http encapsulation so just pass the
+            # request to our parent class.
+            return rpc.Transport.request(
+                self, host, handler, request_body, verbose
+            )
 
-                c = self.make_connection(host)
-                c.send(request_body)
-                return self.parse_response(c.makefile())
+        c = self.make_connection(host)
+        c.send(request_body)
+        return self.parse_response(c.makefile())
 
 
 class _PipedServer(socketserver.BaseServer):
-        """Modeled after SocketServer.TCPServer."""
+    """Modeled after SocketServer.TCPServer."""
 
-        def __init__(self, fd, RequestHandlerClass, http_enc=True):
-                self.__pipe_file = PipeFile(fd, "server-transport")
-                self.__shutdown_initiated = False
-                self.__http_enc = http_enc
+    def __init__(self, fd, RequestHandlerClass, http_enc=True):
+        self.__pipe_file = PipeFile(fd, "server-transport")
+        self.__shutdown_initiated = False
+        self.__http_enc = http_enc
 
-                socketserver.BaseServer.__init__(self,
-                    server_address="localhost",
-                    RequestHandlerClass=RequestHandlerClass)
+        socketserver.BaseServer.__init__(
+            self,
+            server_address="localhost",
+            RequestHandlerClass=RequestHandlerClass,
+        )
 
-        def fileno(self):
-                """Required to support select.select()."""
-                return self.__pipe_file.fileno()
+    def fileno(self):
+        """Required to support select.select()."""
+        return self.__pipe_file.fileno()
 
-        def initiate_shutdown(self):
-                """Trigger a shutdown of the RPC server.  This is done via a
-                separate thread since the shutdown() entry point is
-                non-reentrant."""
+    def initiate_shutdown(self):
+        """Trigger a shutdown of the RPC server.  This is done via a
+        separate thread since the shutdown() entry point is
+        non-reentrant."""
 
-                if self.__shutdown_initiated:
-                        return
-                self.__shutdown_initiated = True
+        if self.__shutdown_initiated:
+            return
+        self.__shutdown_initiated = True
 
-                def shutdown_self(server_obj):
-                        """Shutdown the server thread."""
-                        server_obj.shutdown()
+        def shutdown_self(server_obj):
+            """Shutdown the server thread."""
+            server_obj.shutdown()
 
-                t = threading.Thread(
-                    target=shutdown_self, args=(self,))
-                t.start()
+        t = threading.Thread(target=shutdown_self, args=(self,))
+        t.start()
 
-        def get_request(self):
-                """Get a request from the client.  Returns a tuple containing
-                the request and the client address (mirroring the return value
-                from self.socket.accept())."""
+    def get_request(self):
+        """Get a request from the client.  Returns a tuple containing
+        the request and the client address (mirroring the return value
+        from self.socket.accept())."""
 
-                fd = self.__pipe_file.recvfd()
-                if fd == -1:
-                        self.initiate_shutdown()
-                        raise socket.error()
+        fd = self.__pipe_file.recvfd()
+        if fd == -1:
+            self.initiate_shutdown()
+            raise socket.error()
 
-                return (PipeSocket(fd, "server-connection",
-                    http_enc=self.__http_enc), ("localhost", None))
+        return (
+            PipeSocket(fd, "server-connection", http_enc=self.__http_enc),
+            ("localhost", None),
+        )
 
 
 class _PipedHTTPRequestHandler(SimpleRPCRequestHandler):
-        """Piped RPC request handler that uses HTTP encapsulation."""
+    """Piped RPC request handler that uses HTTP encapsulation."""
 
-        def setup(self):
-                """Prepare to handle a request."""
+    def setup(self):
+        """Prepare to handle a request."""
 
-                rv = SimpleRPCRequestHandler.setup(self)
+        rv = SimpleRPCRequestHandler.setup(self)
 
-                # StreamRequestHandler will have duped our PipeSocket via
-                # makefile(), so close the connection socket here.
-                self.connection.close()
-                return rv
+        # StreamRequestHandler will have duped our PipeSocket via
+        # makefile(), so close the connection socket here.
+        self.connection.close()
+        return rv
 
 
 class _PipedRequestHandler(_PipedHTTPRequestHandler):
-        """Piped RPC request handler that doesn't use HTTP encapsulation."""
+    """Piped RPC request handler that doesn't use HTTP encapsulation."""
 
-        def handle_one_request(self):
-                """Handle one client request."""
+    def handle_one_request(self):
+        """Handle one client request."""
 
-                request = self.rfile.readline()
-                response = ""
-                try:
-                        # Access to protected member; pylint: disable=W0212
-                        response = self.server._marshaled_dispatch(request)
-                # No exception type specified; pylint: disable=W0702
-                except:
-                        # The server had an unexpected exception.
-                        # dump the error to stderr
-                        print(traceback.format_exc(), file=sys.stderr)
+        request = self.rfile.readline()
+        response = ""
+        try:
+            # Access to protected member; pylint: disable=W0212
+            response = self.server._marshaled_dispatch(request)
+        # No exception type specified; pylint: disable=W0702
+        except:
+            # The server had an unexpected exception.
+            # dump the error to stderr
+            print(traceback.format_exc(), file=sys.stderr)
 
-                        # Return the error to the caller.
-                        err_lines = traceback.format_exc().splitlines()
-                        trace_string = '{0} | {1}'.format(
-                            err_lines[-3], err_lines[-1])
-                        fault = rpclib.Fault(-32603,
-                            'Server error: {0}'.format(trace_string))
-                        response = fault.response()
+            # Return the error to the caller.
+            err_lines = traceback.format_exc().splitlines()
+            trace_string = "{0} | {1}".format(err_lines[-3], err_lines[-1])
+            fault = rpclib.Fault(
+                -32603, "Server error: {0}".format(trace_string)
+            )
+            response = fault.response()
 
-                        # tell the server to exit
-                        self.server.initiate_shutdown()
+            # tell the server to exit
+            self.server.initiate_shutdown()
 
-                self.wfile.write(response)
-                self.wfile.flush()
+        self.wfile.write(response)
+        self.wfile.flush()
 
 
 class PipedRPCServer(_PipedServer, SimpleRPCDispatcher):
-        """Modeled after SimpleRPCServer.  Differs in that
-        SimpleRPCServer is derived from SocketServer.TCPServer but we're
-        derived from _PipedServer."""
+    """Modeled after SimpleRPCServer.  Differs in that
+    SimpleRPCServer is derived from SocketServer.TCPServer but we're
+    derived from _PipedServer."""
 
-        def __init__(self, addr,
-            logRequests=False, encoding=None, http_enc=True):
+    def __init__(self, addr, logRequests=False, encoding=None, http_enc=True):
+        self.logRequests = logRequests
+        SimpleRPCDispatcher.__init__(self, encoding)
 
-                self.logRequests = logRequests
-                SimpleRPCDispatcher.__init__(self, encoding)
+        requestHandler = _PipedHTTPRequestHandler
+        if not http_enc:
+            requestHandler = _PipedRequestHandler
 
-                requestHandler = _PipedHTTPRequestHandler
-                if not http_enc:
-                        requestHandler = _PipedRequestHandler
+        _PipedServer.__init__(self, addr, requestHandler, http_enc=http_enc)
 
-                _PipedServer.__init__(self, addr, requestHandler,
-                    http_enc=http_enc)
+    def __check_for_server_errors(self, response):
+        """Check if a response is actually a fault object.  If so
+        then it's time to die."""
 
-        def  __check_for_server_errors(self, response):
-                """Check if a response is actually a fault object.  If so
-                then it's time to die."""
+        if type(response) != rpclib.Fault:
+            return
 
-                if type(response) != rpclib.Fault:
-                        return
+        # server encountered an error, time for seppuku
+        self.initiate_shutdown()
 
-                # server encountered an error, time for seppuku
-                self.initiate_shutdown()
+    def _dispatch(self, *args, **kwargs):
+        """Check for unexpected server exceptions while handling a
+        request."""
+        # pylint: disable=W0221
+        # Arguments differ from overridden method;
 
-        def _dispatch(self, *args, **kwargs):
-                """Check for unexpected server exceptions while handling a
-                request."""
-                # pylint: disable=W0221
-                # Arguments differ from overridden method;
+        response = SimpleRPCDispatcher._dispatch(self, *args, **kwargs)
+        self.__check_for_server_errors(response)
+        return response
 
-                response = SimpleRPCDispatcher._dispatch(
-                    self, *args, **kwargs)
-                self.__check_for_server_errors(response)
-                return response
+    def _marshaled_single_dispatch(self, *args, **kwargs):
+        """Check for unexpected server exceptions while handling a
+        request."""
+        # pylint: disable=W0221
+        # Arguments differ from overridden method;
 
-        def _marshaled_single_dispatch(self, *args, **kwargs):
-                """Check for unexpected server exceptions while handling a
-                request."""
-                # pylint: disable=W0221
-                # Arguments differ from overridden method;
+        response = SimpleRPCDispatcher._marshaled_single_dispatch(
+            self, *args, **kwargs
+        )
+        self.__check_for_server_errors(response)
+        return response
 
-                response = SimpleRPCDispatcher._marshaled_single_dispatch(
-                    self, *args, **kwargs)
-                self.__check_for_server_errors(response)
-                return response
+    def _marshaled_dispatch(self, *args, **kwargs):
+        """Check for unexpected server exceptions while handling a
+        request."""
+        # pylint: disable=W0221
+        # Arguments differ from overridden method;
 
-        def _marshaled_dispatch(self, *args, **kwargs):
-                """Check for unexpected server exceptions while handling a
-                request."""
-                # pylint: disable=W0221
-                # Arguments differ from overridden method;
-
-                response = SimpleRPCDispatcher._marshaled_dispatch(
-                    self, *args, **kwargs)
-                self.__check_for_server_errors(response)
-                return response
+        response = SimpleRPCDispatcher._marshaled_dispatch(
+            self, *args, **kwargs
+        )
+        self.__check_for_server_errors(response)
+        return response
 
 
 class PipedServerProxy(rpc.ServerProxy):
-        """Create a ServerProxy object that can be used to make calls to
-        an RPC server on the other end of a pipe."""
+    """Create a ServerProxy object that can be used to make calls to
+    an RPC server on the other end of a pipe."""
 
-        def __init__(self, pipefd, encoding=None, verbose=0, version=None,
-            http_enc=True):
-                self.__piped_transport = _PipedTransport(pipefd,
-                    http_enc=http_enc)
-                rpc.ServerProxy.__init__(self,
-                    "http://localhost/RPC2",
-                    transport=self.__piped_transport,
-                    encoding=encoding, verbose=verbose, version=version)
+    def __init__(
+        self, pipefd, encoding=None, verbose=0, version=None, http_enc=True
+    ):
+        self.__piped_transport = _PipedTransport(pipefd, http_enc=http_enc)
+        rpc.ServerProxy.__init__(
+            self,
+            "http://localhost/RPC2",
+            transport=self.__piped_transport,
+            encoding=encoding,
+            verbose=verbose,
+            version=version,
+        )
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/pkggzip.py
+++ b/src/modules/pkggzip.py
@@ -27,38 +27,37 @@
 
 import gzip
 
+
 class PkgGzipFile(gzip.GzipFile):
-        """This is a version of GzipFile that does not include a file
-        pathname or timestamp in the gzip header.  This allows us to get
-        deterministic gzip files on compression, so that we can reliably
-        use a cryptographic hash on the compressed content."""
+    """This is a version of GzipFile that does not include a file
+    pathname or timestamp in the gzip header.  This allows us to get
+    deterministic gzip files on compression, so that we can reliably
+    use a cryptographic hash on the compressed content."""
 
-        def __init__(self, filename=None, mode=None, compresslevel=9,
-            fileobj=None):
+    def __init__(self, filename=None, mode=None, compresslevel=9, fileobj=None):
+        gzip.GzipFile.__init__(self, filename, mode, compresslevel, fileobj)
 
-               gzip.GzipFile.__init__(self, filename, mode, compresslevel,
-                    fileobj)
+    #
+    # This is a gzip header conforming to RFC1952.  The first two bytes
+    # (\037,\213) are the gzip magic number.  The third byte is the
+    # compression method (8, deflate).  The fourth byte is the flag byte
+    # (0), which indicates that no FNAME, FCOMMENT or other extended data
+    # is present.  Bytes 5-8 are the MTIME field, zeroed in this case.
+    # Byte 9 is the XFL (Extra Flags) field, set to 2 (compressor used
+    # max compression).  The final bit is the OS type, set to 255 (for
+    # "unknown").
+    magic = b"\037\213\010\000\000\000\000\000\002\377"
 
-        #
-        # This is a gzip header conforming to RFC1952.  The first two bytes
-        # (\037,\213) are the gzip magic number.  The third byte is the
-        # compression method (8, deflate).  The fourth byte is the flag byte
-        # (0), which indicates that no FNAME, FCOMMENT or other extended data
-        # is present.  Bytes 5-8 are the MTIME field, zeroed in this case.
-        # Byte 9 is the XFL (Extra Flags) field, set to 2 (compressor used
-        # max compression).  The final bit is the OS type, set to 255 (for
-        # "unknown").
-        magic = b"\037\213\010\000\000\000\000\000\002\377"
+    def _write_gzip_header(self, compresslevel=None):
+        self.fileobj.write(self.magic)
 
-        def _write_gzip_header(self, compresslevel=None):
-                self.fileobj.write(self.magic)
+    @staticmethod
+    def test_is_pkggzipfile(path):
+        f = open(path, "rb")
+        hdrstr = f.read(len(PkgGzipFile.magic))
+        f.close()
+        return hdrstr == PkgGzipFile.magic
 
-        @staticmethod
-        def test_is_pkggzipfile(path):
-                f = open(path, "rb")
-                hdrstr = f.read(len(PkgGzipFile.magic))
-                f.close()
-                return (hdrstr == PkgGzipFile.magic)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/pkgsubprocess.py
+++ b/src/modules/pkgsubprocess.py
@@ -31,193 +31,282 @@ import types
 import six
 import subprocess
 import pkg.portable
+
 try:
-        import pkg.pspawn
-        from pkg.pspawn import posix_spawnp
-        from pkg.pspawn import SpawnFileAction
+    import pkg.pspawn
+    from pkg.pspawn import posix_spawnp
+    from pkg.pspawn import SpawnFileAction
 except ImportError:
-        pass
+    pass
 
 __all__ = ["Popen", "PIPE", "STDOUT", "call"]
 
+
 def call(*args, **kwargs):
-        return Popen(*args, **kwargs).wait()
+    return Popen(*args, **kwargs).wait()
+
 
 PIPE = subprocess.PIPE
 STDOUT = subprocess.STDOUT
 
+
 class Popen(subprocess.Popen):
-        def __init__(self, args, pass_fds=None, **kwargs):
-                if "bufsize" not in kwargs:
-                        kwargs["bufsize"] = 128 * 1024
-                subprocess.Popen.__init__(self, args, **kwargs)
+    def __init__(self, args, pass_fds=None, **kwargs):
+        if "bufsize" not in kwargs:
+            kwargs["bufsize"] = 128 * 1024
+        subprocess.Popen.__init__(self, args, **kwargs)
 
-        if "posix_spawnp" in globals():
-                if sys.version_info.minor >= 11:
-                        # This is the signature for the private
-                        # _execute_child() method in Python 3.11
-                        def _execute_child(self, args, executable, preexec_fn,
-                            close_fds,
-                            pass_fds, cwd, env,
-                            startupinfo, creationflags, shell,
-                            p2cread, p2cwrite,
-                            c2pread, c2pwrite,
-                            errread, errwrite,
-                            restore_signals,
-                            gid, gids, uid, umask,
-                            start_new_session, process_group):
-                                self._pkg_execute_child(args, executable,
-                                    preexec_fn, close_fds, cwd, env, shell,
-                                    p2cread, p2cwrite, c2pread, c2pwrite,
-                                    errread, errwrite)
-                elif sys.version_info.minor >= 9:
-                        # This is the signature for the private
-                        # _execute_child() method in Python 3.9 and 3.10
-                        def _execute_child(self, args, executable, preexec_fn,
-                            close_fds,
-                            pass_fds, cwd, env,
-                            startupinfo, creationflags, shell,
-                            p2cread, p2cwrite,
-                            c2pread, c2pwrite,
-                            errread, errwrite,
-                            restore_signals,
-                            gid, gids, uid, umask,
-                            start_new_session):
-                                self._pkg_execute_child(args, executable,
-                                    preexec_fn, close_fds, cwd, env, shell,
-                                    p2cread, p2cwrite, c2pread, c2pwrite,
-                                    errread, errwrite)
-                else:
-                        # This is the signature for the private
-                        # _execute_child() method in Python 3.7 and 3.8
-                        def _execute_child(self, args, executable, preexec_fn,
-                            close_fds,
-                            pass_fds, cwd, env,
-                            startupinfo, creationflags, shell,
-                            p2cread, p2cwrite,
-                            c2pread, c2pwrite,
-                            errread, errwrite,
-                            restore_signals,
-                            start_new_session):
-                                self._pkg_execute_child(args, executable,
-                                    preexec_fn, close_fds, cwd, env, shell,
-                                    p2cread, p2cwrite, c2pread, c2pwrite,
-                                    errread, errwrite)
+    if "posix_spawnp" in globals():
+        if sys.version_info.minor >= 11:
+            # This is the signature for the private
+            # _execute_child() method in Python 3.11
+            def _execute_child(
+                self,
+                args,
+                executable,
+                preexec_fn,
+                close_fds,
+                pass_fds,
+                cwd,
+                env,
+                startupinfo,
+                creationflags,
+                shell,
+                p2cread,
+                p2cwrite,
+                c2pread,
+                c2pwrite,
+                errread,
+                errwrite,
+                restore_signals,
+                gid,
+                gids,
+                uid,
+                umask,
+                start_new_session,
+                process_group,
+            ):
+                self._pkg_execute_child(
+                    args,
+                    executable,
+                    preexec_fn,
+                    close_fds,
+                    cwd,
+                    env,
+                    shell,
+                    p2cread,
+                    p2cwrite,
+                    c2pread,
+                    c2pwrite,
+                    errread,
+                    errwrite,
+                )
 
-        # XXX - can this be replaced by the posix_spawn() support in
-        #       subprocess? This implementation is using posix_spawnp()
-        #       via pkg.pspawn.
-        def _pkg_execute_child(self, args, executable, preexec_fn,
-            close_fds, cwd, env, shell, p2cread, p2cwrite, c2pread, c2pwrite,
-            errread, errwrite):
-                if isinstance(args, (str, bytes)):
-                        args = [args]
+        elif sys.version_info.minor >= 9:
+            # This is the signature for the private
+            # _execute_child() method in Python 3.9 and 3.10
+            def _execute_child(
+                self,
+                args,
+                executable,
+                preexec_fn,
+                close_fds,
+                pass_fds,
+                cwd,
+                env,
+                startupinfo,
+                creationflags,
+                shell,
+                p2cread,
+                p2cwrite,
+                c2pread,
+                c2pwrite,
+                errread,
+                errwrite,
+                restore_signals,
+                gid,
+                gids,
+                uid,
+                umask,
+                start_new_session,
+            ):
+                self._pkg_execute_child(
+                    args,
+                    executable,
+                    preexec_fn,
+                    close_fds,
+                    cwd,
+                    env,
+                    shell,
+                    p2cread,
+                    p2cwrite,
+                    c2pread,
+                    c2pwrite,
+                    errread,
+                    errwrite,
+                )
 
-                if shell:
-                        args = ["/bin/sh", "-c"] + args
+        else:
+            # This is the signature for the private
+            # _execute_child() method in Python 3.7 and 3.8
+            def _execute_child(
+                self,
+                args,
+                executable,
+                preexec_fn,
+                close_fds,
+                pass_fds,
+                cwd,
+                env,
+                startupinfo,
+                creationflags,
+                shell,
+                p2cread,
+                p2cwrite,
+                c2pread,
+                c2pwrite,
+                errread,
+                errwrite,
+                restore_signals,
+                start_new_session,
+            ):
+                self._pkg_execute_child(
+                    args,
+                    executable,
+                    preexec_fn,
+                    close_fds,
+                    cwd,
+                    env,
+                    shell,
+                    p2cread,
+                    p2cwrite,
+                    c2pread,
+                    c2pwrite,
+                    errread,
+                    errwrite,
+                )
 
-                if executable is None:
-                        executable = args[0]
+    # XXX - can this be replaced by the posix_spawn() support in
+    #       subprocess? This implementation is using posix_spawnp()
+    #       via pkg.pspawn.
+    def _pkg_execute_child(
+        self,
+        args,
+        executable,
+        preexec_fn,
+        close_fds,
+        cwd,
+        env,
+        shell,
+        p2cread,
+        p2cwrite,
+        c2pread,
+        c2pwrite,
+        errread,
+        errwrite,
+    ):
+        if isinstance(args, (str, bytes)):
+            args = [args]
 
-                sfa = SpawnFileAction()
+        if shell:
+            args = ["/bin/sh", "-c"] + args
 
-                # Child file actions
-                # Close parent's pipe ends
-                closed_fds = []
-                if p2cwrite != -1:
-                        sfa.add_close(p2cwrite)
-                        closed_fds.append(p2cwrite)
-                if c2pread != -1:
-                        sfa.add_close(c2pread)
-                        closed_fds.append(c2pread)
-                if errread != -1:
-                        sfa.add_close(errread)
-                        closed_fds.append(errread)
+        if executable is None:
+            executable = args[0]
 
-                # Dup fds for child
-                if p2cread != -1:
-                        sfa.add_dup2(p2cread, 0)
-                if c2pwrite != -1:
-                        sfa.add_dup2(c2pwrite, 1)
-                if errwrite != -1:
-                        sfa.add_dup2(errwrite, 2)
+        sfa = SpawnFileAction()
 
-                # Close pipe fds.  Make sure we don't close the
-                # same fd more than once, or standard fds.
-                for fd in [p2cread, c2pwrite, errwrite]:
-                        if fd > 2 and fd not in closed_fds:
-                            sfa.add_close(fd)
-                            closed_fds.append(fd)
+        # Child file actions
+        # Close parent's pipe ends
+        closed_fds = []
+        if p2cwrite != -1:
+            sfa.add_close(p2cwrite)
+            closed_fds.append(p2cwrite)
+        if c2pread != -1:
+            sfa.add_close(c2pread)
+            closed_fds.append(c2pread)
+        if errread != -1:
+            sfa.add_close(errread)
+            closed_fds.append(errread)
 
-                if cwd is not None:
-                        os.chdir(cwd)
+        # Dup fds for child
+        if p2cread != -1:
+            sfa.add_dup2(p2cread, 0)
+        if c2pwrite != -1:
+            sfa.add_dup2(c2pwrite, 1)
+        if errwrite != -1:
+            sfa.add_dup2(errwrite, 2)
 
-                if preexec_fn:
-                        preexec_fn()
+        # Close pipe fds.  Make sure we don't close the
+        # same fd more than once, or standard fds.
+        for fd in [p2cread, c2pwrite, errwrite]:
+            if fd > 2 and fd not in closed_fds:
+                sfa.add_close(fd)
+                closed_fds.append(fd)
 
-                # Close all other fds, if asked for - after
-                # preexec_fn(), which may open FDs.
-                if close_fds:
-                #
-                # This is a bit tricky.  Due to a sad
-                # behaviour with posix_spawn in nevada
-                # builds before the fix for 6807216 (in
-                # nevada 110), (and perhaps on other OS's?)
-                # you can't have two close actions close the
-                # same FD, or an error results.  So we track
-                # everything we have closed, then manually
-                # fstat and close up to the max we have
-                # closed) .  Then we close everything above
-                # that efficiently with add_close_childfds().
-                #
-                        # max() can't call on empty list, use a
-                        # trick "close_fds or [0]" to return 0
-                        # when closed_fds is empty.
-                        for i in range(3, max(closed_fds or [0]) + 1):
-                                # scheduled closed already? skip
-                                if i in closed_fds:
-                                        continue
-                                try:
-                                        os.fstat(i)
-                                        sfa.add_close(i)
-                                        closed_fds.append(i)
-                                except OSError:
-                                        pass
-                        closefrom = max([3, max(closed_fds or [0]) + 1])
-                        sfa.add_close_childfds(closefrom)
+        if cwd is not None:
+            os.chdir(cwd)
 
-                if env is None:
-                        # If caller didn't pass us an environment in
-                        # env, borrow the env that the current process
-                        # is using.
-                        env = os.environ.copy()
+        if preexec_fn:
+            preexec_fn()
 
-                if type(env) == dict:
-                        # The bundled subprocess module takes a dict in
-                        # the "env" argument.  Allow that here by doing
-                        # the explicit conversion to a list.
-                        env = [
-                            "{0}={1}".format(k, v)
-                            for k, v in six.iteritems(env)
-                        ]
+        # Close all other fds, if asked for - after
+        # preexec_fn(), which may open FDs.
+        if close_fds:
+            #
+            # This is a bit tricky.  Due to a sad
+            # behaviour with posix_spawn in nevada
+            # builds before the fix for 6807216 (in
+            # nevada 110), (and perhaps on other OS's?)
+            # you can't have two close actions close the
+            # same FD, or an error results.  So we track
+            # everything we have closed, then manually
+            # fstat and close up to the max we have
+            # closed) .  Then we close everything above
+            # that efficiently with add_close_childfds().
+            #
+            # max() can't call on empty list, use a
+            # trick "close_fds or [0]" to return 0
+            # when closed_fds is empty.
+            for i in range(3, max(closed_fds or [0]) + 1):
+                # scheduled closed already? skip
+                if i in closed_fds:
+                    continue
+                try:
+                    os.fstat(i)
+                    sfa.add_close(i)
+                    closed_fds.append(i)
+                except OSError:
+                    pass
+            closefrom = max([3, max(closed_fds or [0]) + 1])
+            sfa.add_close_childfds(closefrom)
 
-                self.pid = posix_spawnp(executable, args, sfa,
-                    env)
-                self._child_created = True
+        if env is None:
+            # If caller didn't pass us an environment in
+            # env, borrow the env that the current process
+            # is using.
+            env = os.environ.copy()
 
-                # parent
-                devnull_fd = getattr(self, "_devnull", None)
-                if p2cread != -1 and p2cwrite != -1 and \
-                    p2cread != devnull_fd:
-                        os.close(p2cread)
-                if c2pwrite != -1 and c2pread != -1 and \
-                    c2pwrite != devnull_fd:
-                        os.close(c2pwrite)
-                if errwrite != -1 and errread != -1 and \
-                    errwrite != devnull_fd:
-                        os.close(errwrite)
-                if devnull_fd is not None:
-                        os.close(devnull_fd)
+        if type(env) == dict:
+            # The bundled subprocess module takes a dict in
+            # the "env" argument.  Allow that here by doing
+            # the explicit conversion to a list.
+            env = ["{0}={1}".format(k, v) for k, v in six.iteritems(env)]
+
+        self.pid = posix_spawnp(executable, args, sfa, env)
+        self._child_created = True
+
+        # parent
+        devnull_fd = getattr(self, "_devnull", None)
+        if p2cread != -1 and p2cwrite != -1 and p2cread != devnull_fd:
+            os.close(p2cread)
+        if c2pwrite != -1 and c2pread != -1 and c2pwrite != devnull_fd:
+            os.close(c2pwrite)
+        if errwrite != -1 and errread != -1 and errwrite != devnull_fd:
+            os.close(errwrite)
+        if devnull_fd is not None:
+            os.close(devnull_fd)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/pkgtarfile.py
+++ b/src/modules/pkgtarfile.py
@@ -27,6 +27,7 @@
 import os
 import stat
 import tarfile
+
 # Without the below statements, tarfile will trigger calls to getpwuid
 # and getgrgid for every file extracted.  This in turn leads to nscd
 # usage which slows down the install phase.  Setting these attributes
@@ -36,79 +37,77 @@ import tarfile
 tarfile.pwd = None
 tarfile.grp = None
 
-class PkgTarFile(tarfile.TarFile):
-        """PkgTarFile is a subclass of TarFile.  It implements
-        a small number of additional instance methods to improve
-        the functionality of the TarFile class for the packaging classes.
 
-        XXX - Push these changes upstream to Python maintainers?
+class PkgTarFile(tarfile.TarFile):
+    """PkgTarFile is a subclass of TarFile.  It implements
+    a small number of additional instance methods to improve
+    the functionality of the TarFile class for the packaging classes.
+
+    XXX - Push these changes upstream to Python maintainers?
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("errorlevel", 2)
+        tarfile.TarFile.__init__(self, *args, **kwargs)
+
+    def extract_to(self, member, path="", filename=""):
+        """Extract a member from the TarFile archive.  This
+        method allows you to specify a new filename and path, using
+        the filename and path arguments, where the file will be
+        extracted.  This method is similar to extract().
+        Extract() only allows the caller to prepend a directory path
+        to the filename specified in the TarInfo object,
+        whereas this method allows the caller to additionally
+        specify a file name.
         """
 
-        def __init__(self, *args, **kwargs):
-                kwargs.setdefault("errorlevel", 2)
-                tarfile.TarFile.__init__(self, *args, **kwargs)
+        self._check("r")
 
-        def extract_to(self, member, path="", filename=""):
-                """Extract a member from the TarFile archive.  This
-                method allows you to specify a new filename and path, using
-                the filename and path arguments, where the file will be
-                extracted.  This method is similar to extract().
-                Extract() only allows the caller to prepend a directory path
-                to the filename specified in the TarInfo object,
-                whereas this method allows the caller to additionally
-                specify a file name.
-                """
+        if isinstance(member, tarfile.TarInfo):
+            tarinfo = member
+        else:
+            tarinfo = self.getmember(member)
 
-                self._check("r")
+        if tarinfo.islnk():
+            tarinfo._link_target = os.path.join(path, tarinfo.linkname)
 
-                if isinstance(member, tarfile.TarInfo):
-                        tarinfo = member
+        if not filename:
+            filename = tarinfo.name
+
+        upperdirs = os.path.dirname(os.path.join(path, filename))
+
+        if upperdirs and not os.path.exists(upperdirs):
+            # The tarfile we receive contains only files, and none
+            # of the containing directories.  The tarfile code will
+            # create the directories as necessary, but with mode
+            # 777, which is insuffficiently secure.  Thus we create
+            # these directories in advance with tighter permissions;
+            # they'll be fixed up later, when the action execute
+            # methods run.  If proper directory actions
+            # don't exist for these directories, the permissions
+            # will be wrong.
+            try:
+                os.makedirs(upperdirs, stat.S_IRWXU)
+            except EnvironmentError:
+                pass
+        try:
+            self._extract_member(tarinfo, os.path.join(path, filename))
+        except EnvironmentError as e:
+            if self.errorlevel > 0:
+                raise
+            else:
+                if e.filename is None:
+                    self._dbg(1, "tarfile {0}".format(e.strerror))
                 else:
-                        tarinfo = self.getmember(member)
+                    self._dbg(
+                        1, "tarfile: {0} {1!r}".format(e.strerror, e.filename)
+                    )
+        except tarfile.ExtractError as e:
+            if self.errorlevel > 1:
+                raise
+            else:
+                self._dbg(1, "tarfile: {0}".format(e))
 
-                if tarinfo.islnk():
-                        tarinfo._link_target = \
-                            os.path.join(path, tarinfo.linkname)
-
-                if not filename:
-                        filename = tarinfo.name
-
-
-                upperdirs = os.path.dirname(os.path.join(path, filename))
-
-                if upperdirs and not os.path.exists(upperdirs):
-                        # The tarfile we receive contains only files, and none
-                        # of the containing directories.  The tarfile code will
-                        # create the directories as necessary, but with mode
-                        # 777, which is insuffficiently secure.  Thus we create
-                        # these directories in advance with tighter permissions;
-                        # they'll be fixed up later, when the action execute
-                        # methods run.  If proper directory actions
-                        # don't exist for these directories, the permissions
-                        # will be wrong.
-                        try:
-                                os.makedirs(upperdirs, stat.S_IRWXU)
-                        except EnvironmentError:
-                                pass
-                try:
-                        self._extract_member(tarinfo, os.path.join(
-                            path, filename))
-                except EnvironmentError as e:
-                        if self.errorlevel > 0:
-                                raise
-                        else:
-                                if e.filename is None:
-                                        self._dbg(1, "tarfile {0}".format(
-                                            e.strerror))
-                                else:
-                                        self._dbg(1,
-                                            "tarfile: {0} {1!r}".format(
-                                            e.strerror, e.filename))
-                except tarfile.ExtractError as e:
-                        if self.errorlevel > 1:
-                                raise
-                        else:
-                                self._dbg(1, "tarfile: {0}".format(e))
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/portable/__init__.py
+++ b/src/modules/portable/__init__.py
@@ -56,190 +56,215 @@
 # not implemented to avoid pylint errors.  The included OS-specific module
 # redefines the methods with an OS-specific implementation.
 
+
 # Platform Methods
 # ----------------
 def get_isainfo():
-        """ Return the information for the OS's supported ISAs.
-        This can be a list or a single string."""
-        raise NotImplementedError
+    """Return the information for the OS's supported ISAs.
+    This can be a list or a single string."""
+    raise NotImplementedError
+
 
 def get_release():
-        """ Return the information for the OS's release version.  This
-        must be a dot-separated set of integers (i.e. no alphabetic
-        or punctuation)."""
-        raise NotImplementedError
+    """Return the information for the OS's release version.  This
+    must be a dot-separated set of integers (i.e. no alphabetic
+    or punctuation)."""
+    raise NotImplementedError
+
 
 def get_platform():
-        """ Return a string representing the current hardware model
-        information, e.g. "i86pc"."""
-        raise NotImplementedError
+    """Return a string representing the current hardware model
+    information, e.g. "i86pc"."""
+    raise NotImplementedError
+
 
 def get_file_type(path):
-        """ Return a value indicating the type of file found at path.
-        The return value is one of file type constants defined below."""
-        raise NotImplementedError
+    """Return a value indicating the type of file found at path.
+    The return value is one of file type constants defined below."""
+    raise NotImplementedError
+
 
 def get_actions_file_type(actions):
-        """ Return an iterator or list containing the file type for each file
-        in the list of provided actions."""
-        raise NotImplementedError
+    """Return an iterator or list containing the file type for each file
+    in the list of provided actions."""
+    raise NotImplementedError
+
 
 # Account access
 # --------------
 def get_group_by_name(name, dirpath, use_file):
-        """ Return the group ID for a group name.
-        If use_file is true, an OS-specific file from within the file tree
-        rooted by dirpath will be consulted, if it exists. Otherwise, the
-        group ID is retrieved from the operating system.
-        Exceptions:
-            KeyError if the specified group does not exist"""
-        raise NotImplementedError
+    """Return the group ID for a group name.
+    If use_file is true, an OS-specific file from within the file tree
+    rooted by dirpath will be consulted, if it exists. Otherwise, the
+    group ID is retrieved from the operating system.
+    Exceptions:
+        KeyError if the specified group does not exist"""
+    raise NotImplementedError
+
 
 def get_user_by_name(name, dirpath, use_file):
-        """ Return the user ID for a user name.
-        If use_file is true, an OS-specific file from within the file tree
-        rooted by dirpath will be consulted, if it exists. Otherwise, the
-        user ID is retrieved from the operating system.
-        Exceptions:
-            KeyError if the specified group does not exist"""
-        raise NotImplementedError
+    """Return the user ID for a user name.
+    If use_file is true, an OS-specific file from within the file tree
+    rooted by dirpath will be consulted, if it exists. Otherwise, the
+    user ID is retrieved from the operating system.
+    Exceptions:
+        KeyError if the specified group does not exist"""
+    raise NotImplementedError
+
 
 def get_name_by_gid(gid, dirpath, use_file):
-        """ Return the group name for a group ID.
-        If use_file is true, an OS-specific file from within the file tree
-        rooted by dirpath will be consulted, if it exists. Otherwise, the
-        group name is retrieved from the operating system.
-        Exceptions:
-            KeyError if the specified group does not exist"""
-        raise NotImplementedError
+    """Return the group name for a group ID.
+    If use_file is true, an OS-specific file from within the file tree
+    rooted by dirpath will be consulted, if it exists. Otherwise, the
+    group name is retrieved from the operating system.
+    Exceptions:
+        KeyError if the specified group does not exist"""
+    raise NotImplementedError
+
 
 def get_name_by_uid(uid, dirpath, use_file):
-        """ Return the user name for a user ID.
-        If use_file is true, an OS-specific file from within the file tree
-        rooted by dirpath will be consulted, if it exists. Otherwise, the
-        user name is retrieved from the operating system.
-        Exceptions:
-            KeyError if the specified group does not exist"""
-        raise NotImplementedError
+    """Return the user name for a user ID.
+    If use_file is true, an OS-specific file from within the file tree
+    rooted by dirpath will be consulted, if it exists. Otherwise, the
+    user name is retrieved from the operating system.
+    Exceptions:
+        KeyError if the specified group does not exist"""
+    raise NotImplementedError
+
 
 def get_usernames_by_gid(gid, dirpath):
-        """ Return all user names associated with a group ID.
-        The user name is first retrieved from an OS-specific file rooted
-        by dirpath. If failed, try to retrieve it from the operating system."""
-        raise NotImplementedError
+    """Return all user names associated with a group ID.
+    The user name is first retrieved from an OS-specific file rooted
+    by dirpath. If failed, try to retrieve it from the operating system."""
+    raise NotImplementedError
+
 
 def is_admin():
-        """ Return true if the invoking user has administrative
-        privileges on the current runtime OS (e.g. are they the
-        root user?)."""
-        raise NotImplementedError
+    """Return true if the invoking user has administrative
+    privileges on the current runtime OS (e.g. are they the
+    root user?)."""
+    raise NotImplementedError
+
 
 def get_userid():
-        """ Return a string representing the invoking user's id.  To be used
-        for display purposes only!"""
-        raise NotImplementedError
+    """Return a string representing the invoking user's id.  To be used
+    for display purposes only!"""
+    raise NotImplementedError
+
 
 def get_username():
-        """ Return a string representing the invoking user's username.  To be
-        used for display purposes only!"""
-        raise NotImplementedError
+    """Return a string representing the invoking user's username.  To be
+    used for display purposes only!"""
+    raise NotImplementedError
 
 
 # Miscellaneous filesystem operations
 # -----------------------------------
 def chown(path, owner, group):
-        """ Change ownership of a file in an OS-specific way.
-        The owner and group ownership information should be applied to
-        the given file, if applicable on the current runtime OS.
-        Exceptions:
-            EnvironmentError (or subclass) if the path does not exist
-            or ownership cannot be changed"""
-        raise NotImplementedError
+    """Change ownership of a file in an OS-specific way.
+    The owner and group ownership information should be applied to
+    the given file, if applicable on the current runtime OS.
+    Exceptions:
+        EnvironmentError (or subclass) if the path does not exist
+        or ownership cannot be changed"""
+    raise NotImplementedError
+
 
 def rename(src, dst):
-        """ Change the name of the given file, using the most
-        appropriate method for the OS.
-        Exceptions:
-            OSError (or subclass) if the source path does not exist
-            EnvironmentError if the rename fails."""
-        raise NotImplementedError
+    """Change the name of the given file, using the most
+    appropriate method for the OS.
+    Exceptions:
+        OSError (or subclass) if the source path does not exist
+        EnvironmentError if the rename fails."""
+    raise NotImplementedError
+
 
 def link(src, dst):
-        """ Link the src to the dst if supported, otherwise copy
-        Exceptions:
-           OSError (or subclass) if the source path does not exist or the link
-           or copy files"""
-        raise NotImplementedError
+    """Link the src to the dst if supported, otherwise copy
+    Exceptions:
+       OSError (or subclass) if the source path does not exist or the link
+       or copy files"""
+    raise NotImplementedError
+
 
 def remove(path):
-        """ Remove the given file in an OS-specific way
-        Exceptions:
-           OSError (or subclass) if the source path does not exist or
-           the file cannot be removed"""
-        raise NotImplementedError
+    """Remove the given file in an OS-specific way
+    Exceptions:
+       OSError (or subclass) if the source path does not exist or
+       the file cannot be removed"""
+    raise NotImplementedError
+
 
 def copyfile(src, dst):
-        """ Copy the contents of the file named src to a file named dst.
-        If dst already exists, it will be replaced. src and dst are
-        path names given as strings.
-        This is similar to python's shutil.copyfile() except that
-        the intention is to deal with platform specifics, such as
-        copying metadata associated with the file (e.g. Resource
-        forks on Mac OS X).
-        Exceptions: IOError if the destination location is not writable"""
-        raise NotImplementedError
+    """Copy the contents of the file named src to a file named dst.
+    If dst already exists, it will be replaced. src and dst are
+    path names given as strings.
+    This is similar to python's shutil.copyfile() except that
+    the intention is to deal with platform specifics, such as
+    copying metadata associated with the file (e.g. Resource
+    forks on Mac OS X).
+    Exceptions: IOError if the destination location is not writable"""
+    raise NotImplementedError
+
 
 def split_path(path):
-        """ Splits a path and gives back the components of the path.
-        This is intended to hide platform-specific details about splitting
-        a path into its components.  This interface is similar to
-        os.path.split() except that the entire path is split, not just
-        the head/tail.
+    """Splits a path and gives back the components of the path.
+    This is intended to hide platform-specific details about splitting
+    a path into its components.  This interface is similar to
+    os.path.split() except that the entire path is split, not just
+    the head/tail.
 
-        For platforms where there are additional components (like
-        a windows drive letter), these should be discarded before
-        performing the split."""
-        raise NotImplementedError
+    For platforms where there are additional components (like
+    a windows drive letter), these should be discarded before
+    performing the split."""
+    raise NotImplementedError
+
 
 def get_root(path):
-        """ Returns the 'root' of the given path.
-        This should include any and all components of a path up to the first
-        non-platform-specific component.  For example, on Windows,
-        it should include the drive letter prefix.
+    """Returns the 'root' of the given path.
+    This should include any and all components of a path up to the first
+    non-platform-specific component.  For example, on Windows,
+    it should include the drive letter prefix.
 
-        This is intended to be used when constructing or deconstructing
-        paths, where the root of the filesystem is significant (and
-        often leads to ambiguity in cross-platform code)."""
-        raise NotImplementedError
+    This is intended to be used when constructing or deconstructing
+    paths, where the root of the filesystem is significant (and
+    often leads to ambiguity in cross-platform code)."""
+    raise NotImplementedError
+
 
 def assert_mode(path, mode):
-        """ Checks that the file identified by path has the given mode to
-        the extent possible by the host operating system.  Otherwise raises
-        an AssertionError where the mode attribute of the assertion is the
-        mode of the file."""
-        raise NotImplementedError
+    """Checks that the file identified by path has the given mode to
+    the extent possible by the host operating system.  Otherwise raises
+    an AssertionError where the mode attribute of the assertion is the
+    mode of the file."""
+    raise NotImplementedError
+
 
 def fsetattr(path, attrs):
-        """ Set system attributes for file specified by 'path'. 'attrs' can be
-        a list of verbose system attributes or a string containing a sequence of
-        short options."""
-        raise NotImplementedError
+    """Set system attributes for file specified by 'path'. 'attrs' can be
+    a list of verbose system attributes or a string containing a sequence of
+    short options."""
+    raise NotImplementedError
+
 
 def fgetattr(path, compact=False):
-        """ Get system attributes for file specified by 'path'. If 'compact' is
-        True, it returns a string of short attribute options, otherwise a list
-        of verbose attributes."""
-        raise NotImplementedError
+    """Get system attributes for file specified by 'path'. If 'compact' is
+    True, it returns a string of short attribute options, otherwise a list
+    of verbose attributes."""
+    raise NotImplementedError
+
 
 def get_sysattr_dict():
-        """ Returns a dictionary containing all supported system attributes. The
-        keys of the dict are verbose attributes, the values short options."""
-        raise NotImplementedError
+    """Returns a dictionary containing all supported system attributes. The
+    keys of the dict are verbose attributes, the values short options."""
+    raise NotImplementedError
+
 
 # File type constants
 # -------------------
-ELF, EXEC, UNFOUND, SMF_MANIFEST, XMLDOC, EMPTYFILE, NOTFILE, UNKNOWN = \
-    range(0, 8)
+ELF, EXEC, UNFOUND, SMF_MANIFEST, XMLDOC, EMPTYFILE, NOTFILE, UNKNOWN = range(
+    0, 8
+)
 
 # String to be used for an action attribute created for the internal use of
 # dependency analysis.
@@ -271,19 +296,20 @@ ostype = os_util.get_canonical_os_type()
 
 fragments = [osname, ostype]
 for fragment in fragments:
-        modname = 'os_' + fragment
+    modname = "os_" + fragment
 
-        # try the most-specific module name first (e.g. os_suse),
-        # then try the more generic OS Name module (e.g. os_linux),
-        # then the OS type module (e.g. os_unix)
-        try:
-                exec('from .{0} import *'.format(modname))
-                break
-        except ImportError:
-                pass
+    # try the most-specific module name first (e.g. os_suse),
+    # then try the more generic OS Name module (e.g. os_linux),
+    # then the OS type module (e.g. os_unix)
+    try:
+        exec("from .{0} import *".format(modname))
+        break
+    except ImportError:
+        pass
 else:
-        raise ImportError(
-            "cannot find portable implementation class for os " + str(fragments))
+    raise ImportError(
+        "cannot find portable implementation class for os " + str(fragments)
+    )
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/portable/os_aix.py
+++ b/src/modules/portable/os_aix.py
@@ -29,25 +29,39 @@ below override the definitions from os_unix
 
 import os
 import errno
-from .os_unix import \
-    get_isainfo, get_release, get_platform, get_group_by_name, \
-    get_user_by_name, get_name_by_gid, get_name_by_uid, get_usernames_by_gid, \
-    is_admin, get_userid, get_username, rename, remove, link, split_path, \
-    get_root, assert_mode, copyfile
+from .os_unix import (
+    get_isainfo,
+    get_release,
+    get_platform,
+    get_group_by_name,
+    get_user_by_name,
+    get_name_by_gid,
+    get_name_by_uid,
+    get_usernames_by_gid,
+    is_admin,
+    get_userid,
+    get_username,
+    rename,
+    remove,
+    link,
+    split_path,
+    get_root,
+    assert_mode,
+    copyfile,
+)
+
 
 def chown(path, owner, group):
-        # The "nobody" user on AIX has uid -2, which is an invalid UID on NFS
-        # file systems mounted from non-AIX hosts.
-        # However, we don't want to fail an install because of this.
-        try:
-                return os.chown(path, owner, group)
-        except EnvironmentError as e:
-                if owner == -2 and e.errno == errno.EINVAL:
-                        return os.chown(path, -1, group)
-                raise
-
-
+    # The "nobody" user on AIX has uid -2, which is an invalid UID on NFS
+    # file systems mounted from non-AIX hosts.
+    # However, we don't want to fail an install because of this.
+    try:
+        return os.chown(path, owner, group)
+    except EnvironmentError as e:
+        if owner == -2 and e.errno == errno.EINVAL:
+            return os.chown(path, -1, group)
+        raise
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/portable/os_darwin.py
+++ b/src/modules/portable/os_darwin.py
@@ -28,21 +28,37 @@ Most if not all of the os_unix methods apply on Darwin. The methods
 below override the definitions from os_unix
 """
 
-from .os_unix import \
-    get_isainfo, get_release, get_platform, get_group_by_name, \
-    get_user_by_name, get_name_by_gid, get_name_by_uid, get_usernames_by_gid, \
-    is_admin, get_userid, get_username, chown, rename, remove, link, \
-    split_path, get_root, assert_mode
+from .os_unix import (
+    get_isainfo,
+    get_release,
+    get_platform,
+    get_group_by_name,
+    get_user_by_name,
+    get_name_by_gid,
+    get_name_by_uid,
+    get_usernames_by_gid,
+    is_admin,
+    get_userid,
+    get_username,
+    chown,
+    rename,
+    remove,
+    link,
+    split_path,
+    get_root,
+    assert_mode,
+)
 
 import macostools
 
+
 def copyfile(src, dst):
-        """
-        Use the Mac OS X-specific version of copyfile() so that
-        Mac OS X stuff gets handled properly.
-        """
-        macostools.copy(src, dst)
+    """
+    Use the Mac OS X-specific version of copyfile() so that
+    Mac OS X stuff gets handled properly.
+    """
+    macostools.copy(src, dst)
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/portable/os_sunos.py
+++ b/src/modules/portable/os_sunos.py
@@ -35,62 +35,91 @@ import six
 import subprocess
 import tempfile
 
-from .os_unix import \
-    get_group_by_name, get_user_by_name, get_name_by_gid, get_name_by_uid, \
-    get_usernames_by_gid, is_admin, get_userid, get_username, chown, rename, \
-    remove, link, copyfile, split_path, get_root, assert_mode
-from pkg.portable import PD_LOCAL_PATH, \
-    ELF, EXEC, UNFOUND, SMF_MANIFEST, XMLDOC, EMPTYFILE, NOTFILE, UNKNOWN
+from .os_unix import (
+    get_group_by_name,
+    get_user_by_name,
+    get_name_by_gid,
+    get_name_by_uid,
+    get_usernames_by_gid,
+    is_admin,
+    get_userid,
+    get_username,
+    chown,
+    rename,
+    remove,
+    link,
+    copyfile,
+    split_path,
+    get_root,
+    assert_mode,
+)
+from pkg.portable import (
+    PD_LOCAL_PATH,
+    ELF,
+    EXEC,
+    UNFOUND,
+    SMF_MANIFEST,
+    XMLDOC,
+    EMPTYFILE,
+    NOTFILE,
+    UNKNOWN,
+)
 
 import pkg.arch as arch
 from pkg.sysattr import fgetattr, fsetattr
 from pkg.sysattr import get_attr_dict as get_sysattr_dict
 
+
 def get_isainfo():
-        return arch.get_isainfo()
+    return arch.get_isainfo()
+
 
 def get_release():
-        return arch.get_release()
+    return arch.get_release()
+
 
 def get_platform():
-        return arch.get_platform()
+    return arch.get_platform()
+
 
 def get_file_type(path):
-        from pkg.flavor.smf_manifest import is_smf_manifest
+    from pkg.flavor.smf_manifest import is_smf_manifest
 
-        if not os.path.isfile(path):
-                return NOTFILE
+    if not os.path.isfile(path):
+        return NOTFILE
 
-        try:
-                # Some tests rely on this being identified
-                if os.stat(path).st_size == 0:
-                        return EMPTYFILE
-                with open(path, 'rb') as f:
-                        magic = f.read(4)
-        except FileNotFoundError:
-                return UNFOUND
-        except OSError:
-                # Most likely EPERM
-                return UNKNOWN
-
-        if magic == b'\x7fELF':
-                return ELF
-
-        if magic[:2] == b'#!':
-                return EXEC
-
-        if path.endswith('.xml'):
-                if is_smf_manifest(path):
-                        return SMF_MANIFEST
-                else:
-                        # Some tests rely on this type being identified
-                        return XMLDOC
-
+    try:
+        # Some tests rely on this being identified
+        if os.stat(path).st_size == 0:
+            return EMPTYFILE
+        with open(path, "rb") as f:
+            magic = f.read(4)
+    except FileNotFoundError:
+        return UNFOUND
+    except OSError:
+        # Most likely EPERM
         return UNKNOWN
 
+    if magic == b"\x7fELF":
+        return ELF
+
+    if magic[:2] == b"#!":
+        return EXEC
+
+    if path.endswith(".xml"):
+        if is_smf_manifest(path):
+            return SMF_MANIFEST
+        else:
+            # Some tests rely on this type being identified
+            return XMLDOC
+
+    return UNKNOWN
+
+
 def get_actions_file_type(actions):
-        for a in actions:
-                yield get_file_type(a.attrs[PD_LOCAL_PATH])
+    for a in actions:
+        yield get_file_type(a.attrs[PD_LOCAL_PATH])
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/portable/os_unix.py
+++ b/src/modules/portable/os_unix.py
@@ -41,6 +41,7 @@ import stat
 import sys
 import tempfile
 from . import util as os_util
+
 # used to cache contents of passwd and group files
 users = {}
 uids = {}
@@ -52,269 +53,295 @@ groups_lastupdate = {}
 # storage to repeat first call to group routines
 __been_here = {}
 
+
 def already_called():
-        callers_name = sys._getframe(1).f_code.co_name
-        if callers_name in __been_here:
-                return True
-        else:
-                __been_here[callers_name] = True
-                return False
+    callers_name = sys._getframe(1).f_code.co_name
+    if callers_name in __been_here:
+        return True
+    else:
+        __been_here[callers_name] = True
+        return False
+
 
 def get_isainfo():
-        return platform.uname()[5]
+    return platform.uname()[5]
+
 
 def get_release():
-        return os_util.get_os_release()
+    return os_util.get_os_release()
+
 
 def get_platform():
-        return platform.uname()[4]
+    return platform.uname()[4]
+
 
 def get_userid():
-        """To be used for display purposes only!"""
+    """To be used for display purposes only!"""
 
-        # If the software is being executed with pfexec, the uid or euid will
-        # likely be 0 which is of no use.  Since the os.getlogin() interface
-        # provided by Python breaks in a number of interesting ways, their
-        # recommendation is to pull the username from the environment instead.
-        user = os.getenv('USER', os.getenv('LOGNAME', os.getenv('USERNAME')))
-        if user:
-                try:
-                        return get_user_by_name(user, None, False)
-                except KeyError:
-                        # The environment username wasn't valid.
-                        pass
-        return os.getuid()
+    # If the software is being executed with pfexec, the uid or euid will
+    # likely be 0 which is of no use.  Since the os.getlogin() interface
+    # provided by Python breaks in a number of interesting ways, their
+    # recommendation is to pull the username from the environment instead.
+    user = os.getenv("USER", os.getenv("LOGNAME", os.getenv("USERNAME")))
+    if user:
+        try:
+            return get_user_by_name(user, None, False)
+        except KeyError:
+            # The environment username wasn't valid.
+            pass
+    return os.getuid()
+
 
 def get_username():
-        """To be used for display purposes only!"""
+    """To be used for display purposes only!"""
 
-        if not already_called():
-                get_username()
-        return pwd.getpwuid(get_userid()).pw_name
+    if not already_called():
+        get_username()
+    return pwd.getpwuid(get_userid()).pw_name
+
 
 def is_admin():
-        return os.getuid() == 0
+    return os.getuid() == 0
+
 
 def get_group_by_name(name, dirpath, use_file):
-        if not already_called():
-                get_group_by_name(name, dirpath, use_file)
+    if not already_called():
+        get_group_by_name(name, dirpath, use_file)
 
-        if not use_file:
-                return grp.getgrnam(name).gr_gid
-        try:
-                load_groups(dirpath)
-                return groups[dirpath][name].gr_gid
-        except OSError as e:
-                if e.errno != errno.ENOENT:
-                        raise
-                # If the password file doesn't exist, bootstrap
-                # ourselves from the current environment.
-                return grp.getgrnam(name).gr_gid
-        except KeyError:
-                raise KeyError("group name not found: {0}".format(name))
+    if not use_file:
+        return grp.getgrnam(name).gr_gid
+    try:
+        load_groups(dirpath)
+        return groups[dirpath][name].gr_gid
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+        # If the password file doesn't exist, bootstrap
+        # ourselves from the current environment.
+        return grp.getgrnam(name).gr_gid
+    except KeyError:
+        raise KeyError("group name not found: {0}".format(name))
+
 
 def get_user_by_name(name, dirpath, use_file):
-        if not already_called():
-                get_user_by_name(name, dirpath, use_file)
+    if not already_called():
+        get_user_by_name(name, dirpath, use_file)
 
-        if not use_file:
-                return pwd.getpwnam(name).pw_uid
-        try:
-                load_passwd(dirpath)
-                return users[dirpath][name].pw_uid
-        except OSError as e:
-                if e.errno != errno.ENOENT:
-                        raise
-                # If the password file doesn't exist, bootstrap
-                # ourselves from the current environment.
-                return pwd.getpwnam(name).pw_uid
-        except KeyError:
-                raise KeyError("user name not found: {0}".format(name))
+    if not use_file:
+        return pwd.getpwnam(name).pw_uid
+    try:
+        load_passwd(dirpath)
+        return users[dirpath][name].pw_uid
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+        # If the password file doesn't exist, bootstrap
+        # ourselves from the current environment.
+        return pwd.getpwnam(name).pw_uid
+    except KeyError:
+        raise KeyError("user name not found: {0}".format(name))
+
 
 def get_name_by_gid(gid, dirpath, use_file):
-        if not already_called():
-                get_name_by_gid(gid, dirpath, use_file)
+    if not already_called():
+        get_name_by_gid(gid, dirpath, use_file)
 
-        if not use_file:
-                return grp.getgrgid(gid).gr_name
-        try:
-                load_groups(dirpath)
-                return gids[dirpath][gid].gr_name
-        except OSError as e:
-                if e.errno != errno.ENOENT:
-                        raise
-                # If the password file doesn't exist, bootstrap
-                # ourselves from the current environment.
-                return grp.getgrgid(gid).gr_name
-        except KeyError:
-                raise KeyError("group ID not found: {0}".format(gid))
+    if not use_file:
+        return grp.getgrgid(gid).gr_name
+    try:
+        load_groups(dirpath)
+        return gids[dirpath][gid].gr_name
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+        # If the password file doesn't exist, bootstrap
+        # ourselves from the current environment.
+        return grp.getgrgid(gid).gr_name
+    except KeyError:
+        raise KeyError("group ID not found: {0}".format(gid))
+
 
 def get_name_by_uid(uid, dirpath, use_file):
-        if not already_called():
-                get_name_by_uid(uid, dirpath, use_file)
+    if not already_called():
+        get_name_by_uid(uid, dirpath, use_file)
 
-        if not use_file:
-                return pwd.getpwuid(uid).pw_name
-        try:
-                load_passwd(dirpath)
-                return uids[dirpath][uid].pw_name
-        except OSError as e:
-                if e.errno != errno.ENOENT:
-                        raise
-                # If the password file doesn't exist, bootstrap
-                # ourselves from the current environment.
-                return pwd.getpwuid(uid).pw_name
-        except KeyError:
-                raise KeyError("user ID not found: {0:d}".format(uid))
+    if not use_file:
+        return pwd.getpwuid(uid).pw_name
+    try:
+        load_passwd(dirpath)
+        return uids[dirpath][uid].pw_name
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+        # If the password file doesn't exist, bootstrap
+        # ourselves from the current environment.
+        return pwd.getpwuid(uid).pw_name
+    except KeyError:
+        raise KeyError("user ID not found: {0:d}".format(uid))
+
 
 def get_usernames_by_gid(gid, dirpath):
-        if not already_called():
-                get_usernames_by_gid(gid, dirpath)
+    if not already_called():
+        get_usernames_by_gid(gid, dirpath)
 
-        try:
-                load_passwd(dirpath)
-                return [unam
-                    for unam, pwdentry in users[dirpath].items()
-                    if str(pwdentry.pw_gid) == gid
-                ]
-        except OSError as e:
-                if e.errno != errno.ENOENT:
-                        raise
-                # If the password file doesn't exist, bootstrap
-                # ourselves from the current environment.
-                # The following call could be expensive.
-                allpwdentries = pwd.getpwall()
-                if not allpwdentries:
-                        allpwdentries = []
-                return [
-                    pwdentry.pw_name
-                    for pwdentry in allpwdentries
-                    if str(pwdentry.pw_gid) == gid
-                ]
+    try:
+        load_passwd(dirpath)
+        return [
+            unam
+            for unam, pwdentry in users[dirpath].items()
+            if str(pwdentry.pw_gid) == gid
+        ]
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+        # If the password file doesn't exist, bootstrap
+        # ourselves from the current environment.
+        # The following call could be expensive.
+        allpwdentries = pwd.getpwall()
+        if not allpwdentries:
+            allpwdentries = []
+        return [
+            pwdentry.pw_name
+            for pwdentry in allpwdentries
+            if str(pwdentry.pw_gid) == gid
+        ]
+
 
 def load_passwd(dirpath):
-        # check if we need to reload cache
-        passwd_file = os.path.join(dirpath, "etc/passwd")
-        passwd_stamp = os.stat(passwd_file).st_mtime
-        if passwd_stamp <= users_lastupdate.get(dirpath, -1):
-                return
-        users[dirpath] = user = {}
-        uids[dirpath] = uid = {}
-        f = open(passwd_file, 'rb')
-        for line in f.readlines():
-                try:
-                        arr = line.decode("utf-8").rstrip().split(":")
-                except UnicodeDecodeError:
-                        # Skip any line we can't make sense of.
-                        continue
-                if len(arr) != 7:
-                        # Skip any line we can't make sense of.
-                        continue
-                try:
-                        arr[2] = int(arr[2])
-                        arr[3] = int(arr[3])
-                except ValueError:
-                        # Skip any line we can't make sense of.
-                        continue
-                pw_entry = pwd.struct_passwd(arr)
+    # check if we need to reload cache
+    passwd_file = os.path.join(dirpath, "etc/passwd")
+    passwd_stamp = os.stat(passwd_file).st_mtime
+    if passwd_stamp <= users_lastupdate.get(dirpath, -1):
+        return
+    users[dirpath] = user = {}
+    uids[dirpath] = uid = {}
+    f = open(passwd_file, "rb")
+    for line in f.readlines():
+        try:
+            arr = line.decode("utf-8").rstrip().split(":")
+        except UnicodeDecodeError:
+            # Skip any line we can't make sense of.
+            continue
+        if len(arr) != 7:
+            # Skip any line we can't make sense of.
+            continue
+        try:
+            arr[2] = int(arr[2])
+            arr[3] = int(arr[3])
+        except ValueError:
+            # Skip any line we can't make sense of.
+            continue
+        pw_entry = pwd.struct_passwd(arr)
 
-                user[pw_entry.pw_name] = pw_entry
-                # Traditional systems allow multiple users to have the same
-                # user id, so only the first one should be mapped to the
-                # current pw_entry.
-                uid.setdefault(pw_entry.pw_uid, pw_entry)
+        user[pw_entry.pw_name] = pw_entry
+        # Traditional systems allow multiple users to have the same
+        # user id, so only the first one should be mapped to the
+        # current pw_entry.
+        uid.setdefault(pw_entry.pw_uid, pw_entry)
 
-        users_lastupdate[dirpath] = passwd_stamp
-        f.close()
+    users_lastupdate[dirpath] = passwd_stamp
+    f.close()
+
 
 def load_groups(dirpath):
-        # check if we need to reload cache
-        group_file = os.path.join(dirpath, "etc/group")
-        group_stamp = os.stat(group_file).st_mtime
-        if group_stamp <= groups_lastupdate.get(dirpath, -1):
-                return
-        groups[dirpath] = group = {}
-        gids[dirpath] = gid = {}
-        f = open(group_file, 'rb')
-        for line in f:
-                try:
-                        arr = line.decode("utf-8").rstrip().split(":")
-                except UnicodeDecodeError:
-                        # Skip any line we can't make sense of.
-                        continue
-                if len(arr) != 4:
-                        # Skip any line we can't make sense of.
-                        continue
-                try:
-                        arr[2] = int(arr[2])
-                except ValueError:
-                        # Skip any line we can't make sense of.
-                        continue
-                gr_entry = grp.struct_group(arr)
+    # check if we need to reload cache
+    group_file = os.path.join(dirpath, "etc/group")
+    group_stamp = os.stat(group_file).st_mtime
+    if group_stamp <= groups_lastupdate.get(dirpath, -1):
+        return
+    groups[dirpath] = group = {}
+    gids[dirpath] = gid = {}
+    f = open(group_file, "rb")
+    for line in f:
+        try:
+            arr = line.decode("utf-8").rstrip().split(":")
+        except UnicodeDecodeError:
+            # Skip any line we can't make sense of.
+            continue
+        if len(arr) != 4:
+            # Skip any line we can't make sense of.
+            continue
+        try:
+            arr[2] = int(arr[2])
+        except ValueError:
+            # Skip any line we can't make sense of.
+            continue
+        gr_entry = grp.struct_group(arr)
 
-                group[gr_entry.gr_name] = gr_entry
-                # Traditional systems allow multiple groups to have the same
-                # group id, so only the first one should be mapped to the
-                # current pw_entry.
-                gid.setdefault(gr_entry.gr_gid, gr_entry)
+        group[gr_entry.gr_name] = gr_entry
+        # Traditional systems allow multiple groups to have the same
+        # group id, so only the first one should be mapped to the
+        # current pw_entry.
+        gid.setdefault(gr_entry.gr_gid, gr_entry)
 
-        groups_lastupdate[dirpath] = group_stamp
-        f.close()
+    groups_lastupdate[dirpath] = group_stamp
+    f.close()
+
 
 def chown(path, owner, group):
-        return os.chown(path, owner, group)
+    return os.chown(path, owner, group)
+
 
 def rename(src, dst):
-        try:
-                os.rename(src, dst)
-        except OSError as e:
-                # Handle the case where we tried to rename a file across a
-                # filesystem boundary.
-                if e.errno != errno.EXDEV or not os.path.isfile(src):
-                        raise
+    try:
+        os.rename(src, dst)
+    except OSError as e:
+        # Handle the case where we tried to rename a file across a
+        # filesystem boundary.
+        if e.errno != errno.EXDEV or not os.path.isfile(src):
+            raise
 
-                # Copy the data and metadata into a temporary file in the same
-                # filesystem as the destination, rename into place, and unlink
-                # the original.
-                try:
-                        fd, tmpdst = tempfile.mkstemp(suffix=".pkg5.xdev",
-                            dir=os.path.dirname(dst))
-                except OSError as e:
-                        # If we don't have sufficient permissions to put the
-                        # file where we want it, then higher levels can deal
-                        # with that effectively, but people will want to know
-                        # the original destination filename.
-                        if e.errno == errno.EACCES:
-                                e.filename=dst
-                        raise
-                os.close(fd)
-                shutil.copy2(src, tmpdst)
-                os.rename(tmpdst, dst)
-                os.unlink(src)
+        # Copy the data and metadata into a temporary file in the same
+        # filesystem as the destination, rename into place, and unlink
+        # the original.
+        try:
+            fd, tmpdst = tempfile.mkstemp(
+                suffix=".pkg5.xdev", dir=os.path.dirname(dst)
+            )
+        except OSError as e:
+            # If we don't have sufficient permissions to put the
+            # file where we want it, then higher levels can deal
+            # with that effectively, but people will want to know
+            # the original destination filename.
+            if e.errno == errno.EACCES:
+                e.filename = dst
+            raise
+        os.close(fd)
+        shutil.copy2(src, tmpdst)
+        os.rename(tmpdst, dst)
+        os.unlink(src)
+
 
 def remove(path):
-        os.unlink(path)
+    os.unlink(path)
+
 
 def link(src, dst):
-        os.link(src, dst)
+    os.link(src, dst)
+
 
 def split_path(path):
-        return path.split('/')
+    return path.split("/")
+
 
 def get_root(path):
-        return '/'
+    return "/"
+
 
 def assert_mode(path, mode):
-        fmode = stat.S_IMODE(os.lstat(path).st_mode)
-        if mode != fmode:
-                ae = AssertionError("mode mismatch for {0}, has {1:o}, "
-                    "want {2:o}".format(path, fmode, mode))
-                ae.mode = fmode;
-                raise ae
+    fmode = stat.S_IMODE(os.lstat(path).st_mode)
+    if mode != fmode:
+        ae = AssertionError(
+            "mode mismatch for {0}, has {1:o}, "
+            "want {2:o}".format(path, fmode, mode)
+        )
+        ae.mode = fmode
+        raise ae
+
 
 def copyfile(src, dst):
-        shutil.copyfile(src, dst)
+    shutil.copyfile(src, dst)
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/portable/os_windows.py
+++ b/src/modules/portable/os_windows.py
@@ -41,95 +41,110 @@ import tempfile
 import threading
 from . import util as os_util
 
+
 def get_isainfo():
-        """ TODO: Detect Windows 64-bit"""
-        return ['i386']
+    """TODO: Detect Windows 64-bit"""
+    return ["i386"]
+
 
 def get_release():
-        return os_util.get_os_release()
+    return os_util.get_os_release()
+
 
 def get_platform():
-        """ TODO: any other windows platforms to support?"""
-        return 'i86pc'
+    """TODO: any other windows platforms to support?"""
+    return "i86pc"
+
 
 def get_group_by_name(name, dirpath, use_file):
-        """group names/numbers are ignored on Windows."""
-        return -1
+    """group names/numbers are ignored on Windows."""
+    return -1
+
 
 def get_user_by_name(name, dirpath, use_file):
-        """group names/numbers are ignored on Windows."""
-        return -1
+    """group names/numbers are ignored on Windows."""
+    return -1
+
 
 def get_name_by_gid(gid, dirpath, use_file):
-        """group names/numbers are ignored on Windows."""
-        return ''
+    """group names/numbers are ignored on Windows."""
+    return ""
+
 
 def get_name_by_uid(uid, dirpath, use_file):
-        """group names/numbers are ignored on Windows."""
-        return ''
+    """group names/numbers are ignored on Windows."""
+    return ""
+
 
 def get_usernames_by_gid(gid, dirpath, use_file):
-        """group names/numbers are ignored on Windows."""
-        return []
+    """group names/numbers are ignored on Windows."""
+    return []
+
 
 def get_userid():
-        """group names/numbers are ignored on Windows."""
-        return -1
+    """group names/numbers are ignored on Windows."""
+    return -1
+
 
 def get_username():
+    try:
+        return getpass.getuser()
+    except ImportError:
+        # getpass.getuser() will fail on systems without
+        # pwd module, so try a common python windows add-on
         try:
-                return getpass.getuser()
+            import win32api
+
+            return win32api.GetUserName()
         except ImportError:
-                # getpass.getuser() will fail on systems without
-                # pwd module, so try a common python windows add-on
-                try:
-                        import win32api
-                        return win32api.GetUserName()
-                except ImportError:
-                        return None
+            return None
+
 
 def is_admin():
-        try:
-                # ctypes only available in python 2.5 or later
-                import ctypes
-                return ctypes.windll.shell32.IsUserAnAdmin() != 0
-        except ImportError:
-                return False
+    try:
+        # ctypes only available in python 2.5 or later
+        import ctypes
+
+        return ctypes.windll.shell32.IsUserAnAdmin() != 0
+    except ImportError:
+        return False
+
 
 def chown(path, owner, group):
-        """
-        group names/numbers are ignored on Windows, so changing
-        ownership of a file makes no sense.
-        """
-        return
+    """
+    group names/numbers are ignored on Windows, so changing
+    ownership of a file makes no sense.
+    """
+    return
+
 
 # On Windows, rename to existing file is not allowed, so the
-# destination file must be deleted first. But if the destination file 
+# destination file must be deleted first. But if the destination file
 # is locked, it cannot be deleted. Windows has 3 types of file locking
-# 
-# 1. Using share access controls that allow applications to specify 
+#
+# 1. Using share access controls that allow applications to specify
 #    whole-file access sharing for read, write or delete;
-# 2. Using byte range locks to arbitrate read and write access to 
+# 2. Using byte range locks to arbitrate read and write access to
 #    regions within a single file; and
-# 3. By Windows file systems disallowing executing files from being 
+# 3. By Windows file systems disallowing executing files from being
 #    opened for write or delete access.
 #
-# The code here deals only with locks of type 3. If the lock on the open 
+# The code here deals only with locks of type 3. If the lock on the open
 # file is for a running executable, then the destination file can be renamed
-# and deleted later when the file is no longer in use. For a rename to a 
+# and deleted later when the file is no longer in use. For a rename to a
 # destination locked with type 1 or 2, rename throws an OSError exception.
 #
 # To accomplish the delayed delete, the file is renamed to a trash folder
-# within the image containing the file. A single image is assumed to be 
-# contained within a single file system, thus making the rename feasible. 
-# The empty_trash method is called at the end of rename to cleanup any 
-# trash files that were left from earlier calls to rename, typically by 
-# previous processes. The empty_trash method needs to be fast most of the 
-# time, so the real work is only done the first time a rename operation is 
+# within the image containing the file. A single image is assumed to be
+# contained within a single file system, thus making the rename feasible.
+# The empty_trash method is called at the end of rename to cleanup any
+# trash files that were left from earlier calls to rename, typically by
+# previous processes. The empty_trash method needs to be fast most of the
+# time, so the real work is only done the first time a rename operation is
 # done on an image. The image module cannot be imported when this module is
 # initialized because that leads to a circular dependency.  So it is imported
 # as needed.
-        
+
 trashname = "trash"
 
 # cached_image_info is a list of tuples (image root, image trash directory) for
@@ -139,107 +154,119 @@ trashname = "trash"
 cached_image_info = []
 cache_lock = threading.Lock()
 
-def get_trashdir(path):
-        """
-        Use path to determine the trash directory.  This method does not create
-        the directory. If path is not contained within an image, return None.
-        The directories for the images that have already been accessed are
-        cached to improve the speed of this method.
-        """
-        global cached_image_info
-        global cache_lock
-        import pkg.client.image as image
-        from pkg.client.api_errors import ImageNotFoundException
-        try:
-            cache_lock.acquire()
-            for iroot, itrash in cached_image_info:
-                    if path.startswith(iroot):
-                            return itrash
 
-            try:
-                    img = image.Image(os.path.dirname(path),
-                        allow_ondisk_upgrade=False)
-            except ImageNotFoundException:
-                    # path is not within an image, no trash dir
-                    return None
-            trashdir = os.path.join(img.imgdir, trashname)
-            # this is the first time putting something in the trash for
-            # this image, so try to empty the trash first
-            shutil.rmtree(trashdir, True)
-            cached_image_info.append((img.get_root(), trashdir))
-            return trashdir
-        finally:
-            cache_lock.release()
+def get_trashdir(path):
+    """
+    Use path to determine the trash directory.  This method does not create
+    the directory. If path is not contained within an image, return None.
+    The directories for the images that have already been accessed are
+    cached to improve the speed of this method.
+    """
+    global cached_image_info
+    global cache_lock
+    import pkg.client.image as image
+    from pkg.client.api_errors import ImageNotFoundException
+
+    try:
+        cache_lock.acquire()
+        for iroot, itrash in cached_image_info:
+            if path.startswith(iroot):
+                return itrash
+
+        try:
+            img = image.Image(os.path.dirname(path), allow_ondisk_upgrade=False)
+        except ImageNotFoundException:
+            # path is not within an image, no trash dir
+            return None
+        trashdir = os.path.join(img.imgdir, trashname)
+        # this is the first time putting something in the trash for
+        # this image, so try to empty the trash first
+        shutil.rmtree(trashdir, True)
+        cached_image_info.append((img.get_root(), trashdir))
+        return trashdir
+    finally:
+        cache_lock.release()
+
 
 def move_to_trash(path):
-        """
-        Move the file to a trash folder within its containing image. If the 
-        file is not in an image, just return without moving it. If the file
-        cannot be removed, raise an OSError exception.
-        """
-        trashdir = get_trashdir(path)
-        if not trashdir:
-                return
-        if not os.path.exists(trashdir):
-                os.mkdir(trashdir)
-        tdir = tempfile.mkdtemp(dir = trashdir)
-        # this rename will raise an exception if the file is
-        # locked and cannot be renamed.
-        os.rename(path, os.path.join(tdir, os.path.basename(path)))
+    """
+    Move the file to a trash folder within its containing image. If the
+    file is not in an image, just return without moving it. If the file
+    cannot be removed, raise an OSError exception.
+    """
+    trashdir = get_trashdir(path)
+    if not trashdir:
+        return
+    if not os.path.exists(trashdir):
+        os.mkdir(trashdir)
+    tdir = tempfile.mkdtemp(dir=trashdir)
+    # this rename will raise an exception if the file is
+    # locked and cannot be renamed.
+    os.rename(path, os.path.join(tdir, os.path.basename(path)))
+
 
 def rename(src, dst):
-        """
-        Rename the src file to the dst name, deleting dst if necessary.
-        """
+    """
+    Rename the src file to the dst name, deleting dst if necessary.
+    """
+    try:
+        os.rename(src, dst)
+    except OSError as err:
+        if err.errno != errno.EEXIST:
+            raise
         try:
-                os.rename(src, dst)
-        except OSError as err:
-                if err.errno != errno.EEXIST:
-                        raise
-                try:
-                        os.unlink(dst)
-                except OSError:
-                        move_to_trash(dst)
-                # finally rename the file
-                os.rename(src, dst)
+            os.unlink(dst)
+        except OSError:
+            move_to_trash(dst)
+        # finally rename the file
+        os.rename(src, dst)
+
 
 def remove(path):
-        """
-        Remove the given path. The file is moved to the trash area of the
-        image if necessary where it will be removed at a later time.
-        """
-        try:
-                os.unlink(path)
-        except OSError as err:
-                if err.errno != errno.EACCES:
-                        raise
-                move_to_trash(path)
+    """
+    Remove the given path. The file is moved to the trash area of the
+    image if necessary where it will be removed at a later time.
+    """
+    try:
+        os.unlink(path)
+    except OSError as err:
+        if err.errno != errno.EACCES:
+            raise
+        move_to_trash(path)
+
 
 def link(src, dst):
-        copyfile(src, dst)
-        
+    copyfile(src, dst)
+
+
 def split_path(path):
-        drivepath = os.path.splitdrive(path)
-        return drivepath[1].split('\\')
+    drivepath = os.path.splitdrive(path)
+    return drivepath[1].split("\\")
+
 
 def get_root(path):
-        drivepath = os.path.splitdrive(path)
-        if drivepath[0] == "":
-                return os.path.sep
-        else:
-                return drivepath[0] + '\\'
+    drivepath = os.path.splitdrive(path)
+    if drivepath[0] == "":
+        return os.path.sep
+    else:
+        return drivepath[0] + "\\"
+
 
 def assert_mode(path, mode):
-        # only compare user's permission bits on Windows
-        fmode = stat.S_IMODE(os.lstat(path).st_mode)
-        if (mode & stat.S_IRWXU) != (fmode & stat.S_IRWXU):
-                ae = AssertionError("mode mismatch for {0}, has {1:o}, "
-                    "want {2:o}".format(path, fmode, mode))
-                ae.mode = fmode;
-                raise ae
+    # only compare user's permission bits on Windows
+    fmode = stat.S_IMODE(os.lstat(path).st_mode)
+    if (mode & stat.S_IRWXU) != (fmode & stat.S_IRWXU):
+        ae = AssertionError(
+            "mode mismatch for {0}, has {1:o}, "
+            "want {2:o}".format(path, fmode, mode)
+        )
+        ae.mode = fmode
+        raise ae
+
 
 def copyfile(src, dst):
-        shutil.copyfile(src, dst)
+    shutil.copyfile(src, dst)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/portable/util.py
+++ b/src/modules/portable/util.py
@@ -26,62 +26,66 @@ import os
 import platform
 import re
 
+
 def get_canonical_os_type():
-        """
-        Return a standardized, lower case version of the "type" of OS family.
-        """
-        if os.name == 'posix':
-                return 'unix'
-        elif os.name == 'mac':
-                # Note that darwin systems return 'posix'.  This is for pre-darwin
-                return 'mac'
-        elif os.name == 'nt':
-                return 'windows'
-        else:
-                return 'unknown'
+    """
+    Return a standardized, lower case version of the "type" of OS family.
+    """
+    if os.name == "posix":
+        return "unix"
+    elif os.name == "mac":
+        # Note that darwin systems return 'posix'.  This is for pre-darwin
+        return "mac"
+    elif os.name == "nt":
+        return "windows"
+    else:
+        return "unknown"
+
 
 def get_canonical_os_name():
-        """
-        Return a standardized, lower case version of the name of the OS.  This is
-        useful to avoid the ambiguity of OS marketing names.
-        """
+    """
+    Return a standardized, lower case version of the name of the OS.  This is
+    useful to avoid the ambiguity of OS marketing names.
+    """
 
-        psl = platform.system().lower()
-        if psl in ['sunos', 'darwin', 'windows', 'aix']:
-                return psl
+    psl = platform.system().lower()
+    if psl in ["sunos", "darwin", "windows", "aix"]:
+        return psl
 
-        if psl == 'linux':
-                # add distro information for Linux
-                return 'linux_{0}'.format(platform.dist()[0])
+    if psl == "linux":
+        # add distro information for Linux
+        return "linux_{0}".format(platform.dist()[0])
 
-        # Workaround for python bug 1082, on Vista, platform.system()
-        # returns 'Microsoft'
-        prl = platform.release().lower()
-        if psl == 'microsoft' or prl == 'vista' or prl == 'windows':
-                return 'windows'
+    # Workaround for python bug 1082, on Vista, platform.system()
+    # returns 'Microsoft'
+    prl = platform.release().lower()
+    if psl == "microsoft" or prl == "vista" or prl == "windows":
+        return "windows"
 
-        return 'unknown'
+    return "unknown"
+
 
 def get_os_release():
-        """
-        Return a standardized, sanitized version string, consisting of a
-        dot-separated list of integers representing the release version of
-        this OS.
-        """
+    """
+    Return a standardized, sanitized version string, consisting of a
+    dot-separated list of integers representing the release version of
+    this OS.
+    """
 
-        ostype = get_canonical_os_type()
-        release = None
-        if ostype == 'unix':
-                release = os.uname()[2]
-        elif ostype == 'windows':
-                # Windows has no os.uname, and platform.release
-                # gives you things like "XP" and "Vista"
-                release = platform.version()
-        else:
-                release = platform.release()
+    ostype = get_canonical_os_type()
+    release = None
+    if ostype == "unix":
+        release = os.uname()[2]
+    elif ostype == "windows":
+        # Windows has no os.uname, and platform.release
+        # gives you things like "XP" and "Vista"
+        release = platform.version()
+    else:
+        release = platform.release()
 
-        # force release into a dot-separated list of integers
-        return '.'.join((re.sub(r'[^0-9]', ' ', release)).split())
+    # force release into a dot-separated list of integers
+    return ".".join((re.sub(r"[^0-9]", " ", release)).split())
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/pspawn.py
+++ b/src/modules/pspawn.py
@@ -104,8 +104,9 @@ class SpawnFileAction(object):
         if not isinstance(path, mode):
             raise TypeError("path must be int type")
 
-        rc = lib.posix_spawn_file_actions_addopen(self.fa, fd, path, oflag,
-                                                  mode)
+        rc = lib.posix_spawn_file_actions_addopen(
+            self.fa, fd, path, oflag, mode
+        )
         _check_error(rc)
 
     def add_dup2(self, fd, newfd):
@@ -189,11 +190,13 @@ def posix_spawnp(filename, args, fileactions=None, env=None):
         s_action = fileactions.fa
 
     # Now do the actual spawn
-    rc = lib.posix_spawnp(pid, filename.encode(), s_action, ffi.NULL,
-                          spawn_args, spawn_env)
+    rc = lib.posix_spawnp(
+        pid, filename.encode(), s_action, ffi.NULL, spawn_args, spawn_env
+    )
     _check_error(rc)
 
     return pid[0]
 
+
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/publish/__init__.py
+++ b/src/modules/publish/__init__.py
@@ -28,4 +28,4 @@
 __all__ = ["transaction"]
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/publish/dependencies.py
+++ b/src/modules/publish/dependencies.py
@@ -68,8 +68,10 @@ Entries = namedtuple("Entries", ["delivered", "installed"])
 # hold items which are part of packages being delivered.  The second, installed,
 # is used to hold items which are part of packages installed on the system.
 
-LinkInfo = namedtuple("LinkInfo", ["path", "pfmri", "nearest_pfmri",
-    "variant_combination", "via_links"])
+LinkInfo = namedtuple(
+    "LinkInfo",
+    ["path", "pfmri", "nearest_pfmri", "variant_combination", "via_links"],
+)
 # This namedtuple is used to hold the information needed when resolving links.
 # The 'path' is the path of the file that ultimately resolved the link.  The
 # 'pfmri' is the package fmri that delivered 'path.'  The 'nearest_pfmri' is the
@@ -77,287 +79,327 @@ LinkInfo = namedtuple("LinkInfo", ["path", "pfmri", "nearest_pfmri",
 # 'variant-combination' is the combination of variants under which the link is
 # satisfied.  'via-links' contains the links used to reach 'path.'
 
+
 class DependencyError(Exception):
-        """The parent class for all dependency exceptions."""
-        pass
+    """The parent class for all dependency exceptions."""
+
+    pass
+
 
 class DropPackageWarning(DependencyError):
-        """This exception is used when a package is dropped as it cannot
-        satisfy all dependencies."""
+    """This exception is used when a package is dropped as it cannot
+    satisfy all dependencies."""
 
-        def __init__(self, pkgs, dep):
-                self.pkgs = pkgs
-                self.dep = dep
+    def __init__(self, pkgs, dep):
+        self.pkgs = pkgs
+        self.dep = dep
 
-        def __str__(self):
-                pkg_str = ", ".join(f.get_pkg_stem() for f in self.pkgs)
-                return _("WARNING: package {0} was ignored as it cannot "
-                    "satisfy all dependencies:\n{1}\n").format(pkg_str,
-                    prune_debug_attrs(self.dep))
+    def __str__(self):
+        pkg_str = ", ".join(f.get_pkg_stem() for f in self.pkgs)
+        return _(
+            "WARNING: package {0} was ignored as it cannot "
+            "satisfy all dependencies:\n{1}\n"
+        ).format(pkg_str, prune_debug_attrs(self.dep))
+
 
 class UnresolvedDependencyError(DependencyError):
-        """This exception is used when no package delivers a file which is
-        depended upon."""
+    """This exception is used when no package delivers a file which is
+    depended upon."""
 
-        def __init__(self, pth, file_dep, pvars):
-                self.path = pth
-                self.file_dep = file_dep
-                self.pvars = pvars
+    def __init__(self, pth, file_dep, pvars):
+        self.path = pth
+        self.file_dep = file_dep
+        self.pvars = pvars
 
-        def __str__(self):
-                dep_str = "\n" + self.file_dep.pretty_print()
-                if self.pvars.not_sat_set:
-                        return _("{pth} has unresolved dependency '{dep}' "
-                            "under the following combinations of "
-                            "variants:\n{combo}").format(
-                                pth=self.path,
-                                dep=dep_str + "\n",
-                                combo="\n".join([
-                                    " ".join([
-                                        ("{0}:{1}".format(name, val))
-                                        for name, val in sorted(grp)
-                                    ])
-                                    for grp in self.pvars.not_sat_set
-                            ]))
-                else:
-                        return _("{pth} has unresolved dependency "
-                            "'{dep}'.").format(
-                            pth=self.path, dep=dep_str)
+    def __str__(self):
+        dep_str = "\n" + self.file_dep.pretty_print()
+        if self.pvars.not_sat_set:
+            return _(
+                "{pth} has unresolved dependency '{dep}' "
+                "under the following combinations of "
+                "variants:\n{combo}"
+            ).format(
+                pth=self.path,
+                dep=dep_str + "\n",
+                combo="\n".join(
+                    [
+                        " ".join(
+                            [
+                                ("{0}:{1}".format(name, val))
+                                for name, val in sorted(grp)
+                            ]
+                        )
+                        for grp in self.pvars.not_sat_set
+                    ]
+                ),
+            )
+        else:
+            return _("{pth} has unresolved dependency " "'{dep}'.").format(
+                pth=self.path, dep=dep_str
+            )
 
 
 class UndeclaredVariantWarning(DependencyError):
-        """This exception is used when an action is tagged with a variant or
-        variant value which the package is not tagged with."""
+    """This exception is used when an action is tagged with a variant or
+    variant value which the package is not tagged with."""
 
-        def __init__(self, act_vars, pkg_vars, pth):
-                self.act_vars = act_vars
-                self.pkg_vars = pkg_vars
-                self.path = pth
+    def __init__(self, act_vars, pkg_vars, pth):
+        self.act_vars = act_vars
+        self.pkg_vars = pkg_vars
+        self.path = pth
 
-        def __str__(self):
-                return _("WARNING: The action delivering {path} is tagged with "
-                    "a variant type or value not declared for the package; use "
-                    "pkglint for details.\n"
-                    "The action's variants are: {act}\nThe package's "
-                    "variants are: {pkg}").format(
-                        path=self.path,
-                        act=self.act_vars,
-                        pkg=self.pkg_vars
-                   )
+    def __str__(self):
+        return _(
+            "WARNING: The action delivering {path} is tagged with "
+            "a variant type or value not declared for the package; use "
+            "pkglint for details.\n"
+            "The action's variants are: {act}\nThe package's "
+            "variants are: {pkg}"
+        ).format(path=self.path, act=self.act_vars, pkg=self.pkg_vars)
 
 
 class BadPackageFmri(DependencyError):
-        """This exception is used when a manifest's fmri isn't a valid fmri."""
+    """This exception is used when a manifest's fmri isn't a valid fmri."""
 
-        def __init__(self, path, e):
-                self.path = path
-                self.exc = e
+    def __init__(self, path, e):
+        self.path = path
+        self.exc = e
 
-        def __str__(self):
-                return _("The manifest '{path}' has an invalid package "
-                    "FMRI:\n\t{exc}").format(path=self.path, exc=self.exc)
+    def __str__(self):
+        return _(
+            "The manifest '{path}' has an invalid package " "FMRI:\n\t{exc}"
+        ).format(path=self.path, exc=self.exc)
 
 
 class ExtraVariantedDependency(DependencyError):
-        """This exception is used when one or more dependency actions have a
-        variant set on them which is not in the package's set of variants."""
+    """This exception is used when one or more dependency actions have a
+    variant set on them which is not in the package's set of variants."""
 
-        def __init__(self, pkg, reason_variants, manual_dep):
-                self.pkg = pkg
-                assert len(reason_variants) > 0
-                self.rvs = reason_variants
-                self.manual = manual_dep
+    def __init__(self, pkg, reason_variants, manual_dep):
+        self.pkg = pkg
+        assert len(reason_variants) > 0
+        self.rvs = reason_variants
+        self.manual = manual_dep
 
-        def __str__(self):
-                s = ""
-                for r, diff in sorted(six.iteritems(self.rvs)):
-                        for kind in diff.type_diffs:
-                                s += _("\t{r:15} Variant '{kind}' is not "
-                                    "declared.\n").format(
-                                    r=r, kind=kind)
-                        for k, v in diff.value_diffs:
-                                s += _("\t{r:15} Variant '{kind}' is not "
-                                    "declared to have value '{val}'.\n").format(
-                                    r=r, val=v, kind=k)
-                if not self.manual:
-                        return _("The package '{pkg}' contains actions with "
-                            "the\npaths seen below which have variants set on "
-                            "them which are not set on the\npackage.  These "
-                            "variants must be set on the package or removed "
-                            "from the actions.\n\n{rvs}").format(
-                            pkg=self.pkg,
-                            rvs=s
-                       )
-                else:
-                        return _("The package '{pkg}' contains manually "
-                            "specified dependencies\nwhich have variants set "
-                            "on them which are not set on the package.  "
-                            "These\nvariants must be set on the package or "
-                            "removed from the actions.\n\n{rvs}").format(
-                            pkg=self.pkg,
-                            rvs=s
-                       )
+    def __str__(self):
+        s = ""
+        for r, diff in sorted(six.iteritems(self.rvs)):
+            for kind in diff.type_diffs:
+                s += _(
+                    "\t{r:15} Variant '{kind}' is not " "declared.\n"
+                ).format(r=r, kind=kind)
+            for k, v in diff.value_diffs:
+                s += _(
+                    "\t{r:15} Variant '{kind}' is not "
+                    "declared to have value '{val}'.\n"
+                ).format(r=r, val=v, kind=k)
+        if not self.manual:
+            return _(
+                "The package '{pkg}' contains actions with "
+                "the\npaths seen below which have variants set on "
+                "them which are not set on the\npackage.  These "
+                "variants must be set on the package or removed "
+                "from the actions.\n\n{rvs}"
+            ).format(pkg=self.pkg, rvs=s)
+        else:
+            return _(
+                "The package '{pkg}' contains manually "
+                "specified dependencies\nwhich have variants set "
+                "on them which are not set on the package.  "
+                "These\nvariants must be set on the package or "
+                "removed from the actions.\n\n{rvs}"
+            ).format(pkg=self.pkg, rvs=s)
+
 
 class NeedConditionalRequireAny(DependencyError):
-        """This exception is used when pkgdepend would need a dependency which
-        was both require-any and conditional to properly represent the
-        dependency."""
+    """This exception is used when pkgdepend would need a dependency which
+    was both require-any and conditional to properly represent the
+    dependency."""
 
-        def __init__(self, conditionals, pkg_vars):
-                self.conditionals = conditionals
-                self.pkg_vct = pkg_vars
+    def __init__(self, conditionals, pkg_vars):
+        self.conditionals = conditionals
+        self.pkg_vct = pkg_vars
 
-        def __str__(self):
-                s = _("""\
+    def __str__(self):
+        s = _(
+            """\
 pkgdepend has inferred conditional dependencies with different targets but
 which share a predicate.  pkg(7) can not represent these dependencies.  This
 issue can be resolved by changing the packaging of the links which generated the
 conditional dependencies so that they have different predicates or share the
 same FMRI.  Each pair of problematic conditional dependencies follows:
-""")
-                for i, (d1, d2, v) in enumerate(self.conditionals):
-                        i += 1
-                        v.simplify(self.pkg_vct)
-                        if v.is_empty() or not v.sat_set:
-                                s += _("Pair {0}\n").format(i)
-                        else:
-                                s += _("Pair {0} is only problematic in the "
-                                    "listed variant combinations:").format(i)
-                                s += "\n\t\t" + "\n\t\t".join([
-                                    " ".join([
-                                        ("{0}:{1}".format(name, val))
-                                        for name, val in sorted(grp)
-                                    ]) for grp in v.sat_set
-                                ])
-                                s += "\n"
-                        s += d1.pretty_print() + "\n"
-                        s += d2.pretty_print() + "\n"
-                return s
+"""
+        )
+        for i, (d1, d2, v) in enumerate(self.conditionals):
+            i += 1
+            v.simplify(self.pkg_vct)
+            if v.is_empty() or not v.sat_set:
+                s += _("Pair {0}\n").format(i)
+            else:
+                s += _(
+                    "Pair {0} is only problematic in the "
+                    "listed variant combinations:"
+                ).format(i)
+                s += "\n\t\t" + "\n\t\t".join(
+                    [
+                        " ".join(
+                            [
+                                ("{0}:{1}".format(name, val))
+                                for name, val in sorted(grp)
+                            ]
+                        )
+                        for grp in v.sat_set
+                    ]
+                )
+                s += "\n"
+            s += d1.pretty_print() + "\n"
+            s += d2.pretty_print() + "\n"
+        return s
+
 
 class __NotSubset(DependencyError):
-        def __init__(self, diff):
-                self.diff = variants.VCTDifference(tuple(diff.type_diffs),
-                    tuple(diff.value_diffs))
+    def __init__(self, diff):
+        self.diff = variants.VCTDifference(
+            tuple(diff.type_diffs), tuple(diff.value_diffs)
+        )
 
 
-def list_implicit_deps(file_path, proto_dirs, dyn_tok_conv, run_paths,
-    remove_internal_deps=True, convert=True, ignore_bypass=False):
-        """Given the manifest provided in file_path, use the known dependency
-        generators to produce a list of dependencies the files delivered by
-        the manifest have.
+def list_implicit_deps(
+    file_path,
+    proto_dirs,
+    dyn_tok_conv,
+    run_paths,
+    remove_internal_deps=True,
+    convert=True,
+    ignore_bypass=False,
+):
+    """Given the manifest provided in file_path, use the known dependency
+    generators to produce a list of dependencies the files delivered by
+    the manifest have.
 
-        'file_path' is the path to the manifest for the package.
+    'file_path' is the path to the manifest for the package.
 
-        'proto_dirs' is a list of paths to proto areas which hold the files that
-        will be delivered by the package.
+    'proto_dirs' is a list of paths to proto areas which hold the files that
+    will be delivered by the package.
 
-        'dyn_tok_conv' is the dictionary which maps the dynamic tokens, like
-        $PLATFORM, to the values they should be expanded to.
+    'dyn_tok_conv' is the dictionary which maps the dynamic tokens, like
+    $PLATFORM, to the values they should be expanded to.
 
-        'run_paths' contains the run paths that are used to find modules.
+    'run_paths' contains the run paths that are used to find modules.
 
-        'convert' determines whether PublishingDependencies will be transformed
-        to DependencyActions prior to being returned.  This is primarily an
-        option to facilitate testing and debugging.
+    'convert' determines whether PublishingDependencies will be transformed
+    to DependencyActions prior to being returned.  This is primarily an
+    option to facilitate testing and debugging.
 
-        'ignore_bypass' determines whether to bypass generation of dependencies
-        against certain files or directories.  This is primarily an option to
-        facilitate testing and debugging.
-        """
+    'ignore_bypass' determines whether to bypass generation of dependencies
+    against certain files or directories.  This is primarily an option to
+    facilitate testing and debugging.
+    """
 
-        m, manifest_errs = __make_manifest(file_path, proto_dirs)
-        pkg_vars = m.get_all_variants()
-        deps, elist, warnings, missing, pkg_attrs = \
-            list_implicit_deps_for_manifest(m, proto_dirs, pkg_vars,
-                dyn_tok_conv, run_paths, ignore_bypass=ignore_bypass)
-        rid_errs = []
-        if remove_internal_deps:
-                deps, rid_errs = resolve_internal_deps(deps, m, proto_dirs,
-                    pkg_vars)
-        if convert:
-                deps = convert_to_standard_dep_actions(deps)
+    m, manifest_errs = __make_manifest(file_path, proto_dirs)
+    pkg_vars = m.get_all_variants()
+    deps, elist, warnings, missing, pkg_attrs = list_implicit_deps_for_manifest(
+        m,
+        proto_dirs,
+        pkg_vars,
+        dyn_tok_conv,
+        run_paths,
+        ignore_bypass=ignore_bypass,
+    )
+    rid_errs = []
+    if remove_internal_deps:
+        deps, rid_errs = resolve_internal_deps(deps, m, proto_dirs, pkg_vars)
+    if convert:
+        deps = convert_to_standard_dep_actions(deps)
 
-        return deps, manifest_errs + elist + rid_errs, warnings, missing, pkg_attrs
+    return deps, manifest_errs + elist + rid_errs, warnings, missing, pkg_attrs
+
 
 def convert_to_standard_dep_actions(deps):
-        """Convert pkg.base.Dependency objects to
-        pkg.actions.dependency.Dependency objects."""
+    """Convert pkg.base.Dependency objects to
+    pkg.actions.dependency.Dependency objects."""
 
-        def norm_attrs(a):
-                """Normalize attribute values as lists instead of sets; only
-                lists are permitted for multi-value action attributes."""
-                for k, v in a.items():
-                        if isinstance(v, set):
-                                a[k] = list(v)
+    def norm_attrs(a):
+        """Normalize attribute values as lists instead of sets; only
+        lists are permitted for multi-value action attributes."""
+        for k, v in a.items():
+            if isinstance(v, set):
+                a[k] = list(v)
 
-        res = []
-        for d in deps:
-                tmp = []
-                for c in d.dep_vars.not_sat_set:
-                        attrs = d.attrs.copy()
-                        attrs.update(c)
-                        norm_attrs(attrs)
-                        tmp.append(actions.depend.DependencyAction(**attrs))
-                if not tmp:
-                        attrs = d.attrs.copy()
-                        norm_attrs(attrs)
-                        tmp.append(actions.depend.DependencyAction(**attrs))
-                res.extend(tmp)
-        return res
+    res = []
+    for d in deps:
+        tmp = []
+        for c in d.dep_vars.not_sat_set:
+            attrs = d.attrs.copy()
+            attrs.update(c)
+            norm_attrs(attrs)
+            tmp.append(actions.depend.DependencyAction(**attrs))
+        if not tmp:
+            attrs = d.attrs.copy()
+            norm_attrs(attrs)
+            tmp.append(actions.depend.DependencyAction(**attrs))
+        res.extend(tmp)
+    return res
+
 
 def resolve_internal_deps(deps, mfst, proto_dirs, pkg_vars):
-        """Given a list of dependencies, remove those which are satisfied by
-        others delivered by the same package.
+    """Given a list of dependencies, remove those which are satisfied by
+    others delivered by the same package.
 
-        'deps' is a list of Dependency objects.
+    'deps' is a list of Dependency objects.
 
-        'mfst' is the Manifest of the package that delivered the dependencies
-        found in deps.
+    'mfst' is the Manifest of the package that delivered the dependencies
+    found in deps.
 
-        'proto_dir' is the path to the proto area which holds the files that
-        will be delivered by the package.
+    'proto_dir' is the path to the proto area which holds the files that
+    will be delivered by the package.
 
-        'pkg_vars' are the variants that this package was published against."""
+    'pkg_vars' are the variants that this package was published against."""
 
-        res = []
-        errs = []
-        delivered = {}
-        delivered_bn = {}
+    res = []
+    errs = []
+    delivered = {}
+    delivered_bn = {}
 
-        files = Entries({}, {})
-        links = {}
+    files = Entries({}, {})
+    links = {}
 
-        # A fake pkg name is used because there is no requirement that a package
-        # name itself to generate its dependencies.  Also, the name is entirely
-        # a private construction which should not escape to the user.
-        add_fmri_path_mapping(files.delivered, links,
-            fmri.PkgFmri("INTERNAL@0-0", "0"), mfst)
-        for a in mfst.gen_actions_by_type("file"):
-                pvars = a.get_variant_template()
-                if not pvars:
-                        pvars = pkg_vars
-                assert pvars.issubset(pkg_vars)
-                pvc = variants.VariantCombinations(pvars, satisfied=True)
-                p = a.attrs["path"]
-                bn = os.path.basename(p)
-                delivered_bn.setdefault(bn, copy.copy(pvc))
+    # A fake pkg name is used because there is no requirement that a package
+    # name itself to generate its dependencies.  Also, the name is entirely
+    # a private construction which should not escape to the user.
+    add_fmri_path_mapping(
+        files.delivered, links, fmri.PkgFmri("INTERNAL@0-0", "0"), mfst
+    )
+    for a in mfst.gen_actions_by_type("file"):
+        pvars = a.get_variant_template()
+        if not pvars:
+            pvars = pkg_vars
+        assert pvars.issubset(pkg_vars)
+        pvc = variants.VariantCombinations(pvars, satisfied=True)
+        p = a.attrs["path"]
+        bn = os.path.basename(p)
+        delivered_bn.setdefault(bn, copy.copy(pvc))
 
-        for d in deps:
-                etype, pvars = d.resolve_internal(
-                    delivered_files=files.delivered,
-                    delivered_base_names=delivered_bn, links=links,
-                    resolve_links=resolve_links)
-                if etype is None:
-                        continue
-                pvars.simplify(pkg_vars)
-                d.dep_vars = pvars
-                res.append(d)
-        return res, errs
+    for d in deps:
+        etype, pvars = d.resolve_internal(
+            delivered_files=files.delivered,
+            delivered_base_names=delivered_bn,
+            links=links,
+            resolve_links=resolve_links,
+        )
+        if etype is None:
+            continue
+        pvars.simplify(pkg_vars)
+        d.dep_vars = pvars
+        res.append(d)
+    return res, errs
+
 
 def no_such_file(action, **kwargs):
-        """Function to handle dispatch of files not found on the system."""
+    """Function to handle dispatch of files not found on the system."""
 
-        return [], [base.MissingFile(action.attrs["path"])], {}
+    return [], [base.MissingFile(action.attrs["path"])], {}
+
 
 # Dictionary which maps codes from portable.get_file_type to the functions which
 # find dependencies for those types of files.
@@ -365,1256 +407,1312 @@ dispatch_dict = {
     portable.ELF: elf_dep.process_elf_dependencies,
     portable.EXEC: script.process_script_deps,
     portable.SMF_MANIFEST: smf_manifest.process_smf_manifest_deps,
-    portable.UNFOUND: no_such_file
+    portable.UNFOUND: no_such_file,
 }
 
-def list_implicit_deps_for_manifest(mfst, proto_dirs, pkg_vars, dyn_tok_conv,
-    run_paths, ignore_bypass=False):
-        """For a manifest, produce the list of dependencies generated by the
-        files it installs.
 
-        'mfst' is the Manifest of the package that delivered the dependencies
-        found in deps.
+def list_implicit_deps_for_manifest(
+    mfst, proto_dirs, pkg_vars, dyn_tok_conv, run_paths, ignore_bypass=False
+):
+    """For a manifest, produce the list of dependencies generated by the
+    files it installs.
 
-        'proto_dirs' are the paths to the proto areas which hold the files that
-        will be delivered by the package.
+    'mfst' is the Manifest of the package that delivered the dependencies
+    found in deps.
 
-        'pkg_vars' are the variants that this package was published against.
+    'proto_dirs' are the paths to the proto areas which hold the files that
+    will be delivered by the package.
 
-        'dyn_tok_conv' is the dictionary which maps the dynamic tokens, like
-        $PLATFORM, to the values they should be expanded to.
+    'pkg_vars' are the variants that this package was published against.
 
-        'run_paths' contains the run paths used to find modules, this is
-        overridden by any manifest or action attributes setting
-        'pkg.depend.runpath' (portable.PD_RUN_PATH)
+    'dyn_tok_conv' is the dictionary which maps the dynamic tokens, like
+    $PLATFORM, to the values they should be expanded to.
 
-        'ignore_bypass' set to True will prevent us from looking up any
-        pkg.depend.bypass-generate attributes - this is primarily to aid
-        debugging and testing.
+    'run_paths' contains the run paths used to find modules, this is
+    overridden by any manifest or action attributes setting
+    'pkg.depend.runpath' (portable.PD_RUN_PATH)
 
-        Returns a tuple of four lists.
+    'ignore_bypass' set to True will prevent us from looking up any
+    pkg.depend.bypass-generate attributes - this is primarily to aid
+    debugging and testing.
 
-        'deps' is a list of dependencies found for the given Manifest.
+    Returns a tuple of four lists.
 
-        'elist' is a list of errors encountered while finding dependencies.
+    'deps' is a list of dependencies found for the given Manifest.
 
-        'warnings' is a list of warnings encountered while finding dependencies.
+    'elist' is a list of errors encountered while finding dependencies.
 
-        'missing' is a dictionary mapping a file type that isn't recognized by
-        portable.get_file_type to a file which produced that filetype.
+    'warnings' is a list of warnings encountered while finding dependencies.
 
-        'pkg_attrs' is a dictionary containing metadata that was gathered
-        during dependency analysis. Typically these would get turned into
-        AttributeActions for that package. """
+    'missing' is a dictionary mapping a file type that isn't recognized by
+    portable.get_file_type to a file which produced that filetype.
 
-        deps = []
-        elist = []
-        missing = {}
-        warnings = []
-        pkg_attrs = {}
-        act_list = list(mfst.gen_actions_by_type("file"))
-        file_types = portable.get_actions_file_type(act_list)
-        var_dict = dict()
+    'pkg_attrs' is a dictionary containing metadata that was gathered
+    during dependency analysis. Typically these would get turned into
+    AttributeActions for that package."""
 
-        # Collect all variants that are used and not declared and emit a warning
-        # for each of them.
-        for a in mfst.gen_actions():
-                pvars = a.get_variant_template()
-                for k, v in six.iteritems(pvars):
-                        if k not in pkg_vars or not v.issubset(pkg_vars[k]):
-                                warnings.append(UndeclaredVariantWarning(
-                                    pvars, pkg_vars.copy(), a.attrs.get(a.key_attr, id(a))))
-                                var_dict.setdefault(k, set()).update(v)
-        pkg_vars.merge_unknown(var_dict)
+    deps = []
+    elist = []
+    missing = {}
+    warnings = []
+    pkg_attrs = {}
+    act_list = list(mfst.gen_actions_by_type("file"))
+    file_types = portable.get_actions_file_type(act_list)
+    var_dict = dict()
 
-        if portable.PD_RUN_PATH in mfst:
-                # check for multiple values in a set attribute
-                run_path_str = mfst[portable.PD_RUN_PATH]
-                es = __verify_run_path(run_path_str)
-                if es:
-                        return deps, elist + es, warnings, missing, pkg_attrs
-                run_paths = run_path_str.split(":")
+    # Collect all variants that are used and not declared and emit a warning
+    # for each of them.
+    for a in mfst.gen_actions():
+        pvars = a.get_variant_template()
+        for k, v in six.iteritems(pvars):
+            if k not in pkg_vars or not v.issubset(pkg_vars[k]):
+                warnings.append(
+                    UndeclaredVariantWarning(
+                        pvars, pkg_vars.copy(), a.attrs.get(a.key_attr, id(a))
+                    )
+                )
+                var_dict.setdefault(k, set()).update(v)
+    pkg_vars.merge_unknown(var_dict)
 
-        mf_bypass = []
-        if portable.PD_BYPASS_GENERATE in mfst:
-                mf_bypass = __makelist(mfst[portable.PD_BYPASS_GENERATE])
+    if portable.PD_RUN_PATH in mfst:
+        # check for multiple values in a set attribute
+        run_path_str = mfst[portable.PD_RUN_PATH]
+        es = __verify_run_path(run_path_str)
+        if es:
+            return deps, elist + es, warnings, missing, pkg_attrs
+        run_paths = run_path_str.split(":")
 
-        for i, file_type in enumerate(file_types):
-                a = act_list[i]
+    mf_bypass = []
+    if portable.PD_BYPASS_GENERATE in mfst:
+        mf_bypass = __makelist(mfst[portable.PD_BYPASS_GENERATE])
 
-                a_run_paths = run_paths
-                if portable.PD_RUN_PATH in a.attrs:
-                        a_run_path_str = a.attrs[portable.PD_RUN_PATH]
-                        es = __verify_run_path(a_run_path_str)
-                        if es:
-                                return (deps, elist + es, warnings, missing,
-                                    pkg_attrs)
-                        a_run_paths = a_run_path_str.split(":")
+    for i, file_type in enumerate(file_types):
+        a = act_list[i]
 
-                bypass = __makelist(
-                    a.attrs.get(portable.PD_BYPASS_GENERATE, mf_bypass))
-                # If we're bypassing all depdendency generation, we can avoid
-                # calling our dispatch_dict function altogether.
-                if (".*" in bypass or "^.*$" in bypass) and not ignore_bypass:
-                        pkg_attrs[bypassed_prefix] = "{0}:.*".format(
-                            a.attrs["path"])
-                        continue
-                try:
-                        func = dispatch_dict[file_type]
-                except KeyError:
-                        if file_type not in missing:
-                                missing[file_type] = \
-                                    a.attrs[portable.PD_LOCAL_PATH]
-                else:
-                        try:
-                                ds, errs, attrs = func(action=a,
-                                    pkg_vars=pkg_vars,
-                                    dyn_tok_conv=dyn_tok_conv,
-                                    run_paths=a_run_paths)
+        a_run_paths = run_paths
+        if portable.PD_RUN_PATH in a.attrs:
+            a_run_path_str = a.attrs[portable.PD_RUN_PATH]
+            es = __verify_run_path(a_run_path_str)
+            if es:
+                return (deps, elist + es, warnings, missing, pkg_attrs)
+            a_run_paths = a_run_path_str.split(":")
 
-                                # prune out any dependencies on the files we've
-                                # been asked to avoid creating dependencies on
-                                if bypass and not ignore_bypass:
-                                        ds = \
-                                            __bypass_deps(ds, bypass, pkg_attrs)
+        bypass = __makelist(a.attrs.get(portable.PD_BYPASS_GENERATE, mf_bypass))
+        # If we're bypassing all depdendency generation, we can avoid
+        # calling our dispatch_dict function altogether.
+        if (".*" in bypass or "^.*$" in bypass) and not ignore_bypass:
+            pkg_attrs[bypassed_prefix] = "{0}:.*".format(a.attrs["path"])
+            continue
+        try:
+            func = dispatch_dict[file_type]
+        except KeyError:
+            if file_type not in missing:
+                missing[file_type] = a.attrs[portable.PD_LOCAL_PATH]
+        else:
+            try:
+                ds, errs, attrs = func(
+                    action=a,
+                    pkg_vars=pkg_vars,
+                    dyn_tok_conv=dyn_tok_conv,
+                    run_paths=a_run_paths,
+                )
 
-                                deps.extend(ds)
-                                elist.extend(errs)
-                                __update_pkg_attrs(pkg_attrs, attrs)
-                        except base.DependencyAnalysisError as e:
-                                elist.append(e)
-        for a in mfst.gen_actions_by_type("hardlink"):
-                deps.extend(hardlink.process_hardlink_deps(a, pkg_vars))
-        return deps, elist, warnings, missing, pkg_attrs
+                # prune out any dependencies on the files we've
+                # been asked to avoid creating dependencies on
+                if bypass and not ignore_bypass:
+                    ds = __bypass_deps(ds, bypass, pkg_attrs)
+
+                deps.extend(ds)
+                elist.extend(errs)
+                __update_pkg_attrs(pkg_attrs, attrs)
+            except base.DependencyAnalysisError as e:
+                elist.append(e)
+    for a in mfst.gen_actions_by_type("hardlink"):
+        deps.extend(hardlink.process_hardlink_deps(a, pkg_vars))
+    return deps, elist, warnings, missing, pkg_attrs
+
 
 def __update_pkg_attrs(pkg_attrs, new_attrs):
-        """Update the pkg_attrs dictionary with the contents of new_attrs."""
-        for key in new_attrs:
-                pkg_attrs.setdefault(key, []).extend(new_attrs[key])
+    """Update the pkg_attrs dictionary with the contents of new_attrs."""
+    for key in new_attrs:
+        pkg_attrs.setdefault(key, []).extend(new_attrs[key])
+
 
 def __verify_run_path(run_path_str):
-        """Verify we've been passed a single item and ensure it contains
-        at least one non-null string."""
-        if not isinstance(run_path_str, str):
-                # require a colon separated string to potentially enforce
-                # ordering in the future
-                return [base.DependencyAnalysisError(
-                    _("Manifest specified multiple values for {0} rather "
-                    "than a single colon-separated string.").format(
-                    portable.PD_RUN_PATH))]
-        if set(run_path_str.split(":")) == set([""]):
-                return [base.DependencyAnalysisError(
-                    _("Manifest did not specify any entries for {0}, expecting "
-                    "a colon-separated string.").format(portable.PD_RUN_PATH))]
-        return []
+    """Verify we've been passed a single item and ensure it contains
+    at least one non-null string."""
+    if not isinstance(run_path_str, str):
+        # require a colon separated string to potentially enforce
+        # ordering in the future
+        return [
+            base.DependencyAnalysisError(
+                _(
+                    "Manifest specified multiple values for {0} rather "
+                    "than a single colon-separated string."
+                ).format(portable.PD_RUN_PATH)
+            )
+        ]
+    if set(run_path_str.split(":")) == set([""]):
+        return [
+            base.DependencyAnalysisError(
+                _(
+                    "Manifest did not specify any entries for {0}, expecting "
+                    "a colon-separated string."
+                ).format(portable.PD_RUN_PATH)
+            )
+        ]
+    return []
+
 
 def __makelist(value):
-        """Given a value, return it if that value is a list, or if it's a
-        string, return a single-element list of just that string."""
-        if isinstance(value, list):
-                return value
-        elif isinstance(value, str):
-                if value:
-                        return [value]
-                else:
-                        return []
+    """Given a value, return it if that value is a list, or if it's a
+    string, return a single-element list of just that string."""
+    if isinstance(value, list):
+        return value
+    elif isinstance(value, str):
+        if value:
+            return [value]
         else:
-                raise ValueError("Value was not a string or a list")
+            return []
+    else:
+        raise ValueError("Value was not a string or a list")
+
 
 def __bypass_deps(ds, bypass, pkg_attrs):
-        """Return a list of dependencies, excluding any of those that should be
-        bypassed.
+    """Return a list of dependencies, excluding any of those that should be
+    bypassed.
 
-        ds         the list of dependencies to operate on
-        bypass     a list of paths on which we should not generate dependencies
-        pkg_attrs  the set of package attributes for this manifest, produced as
-                   a by-product of this dependency generation
+    ds         the list of dependencies to operate on
+    bypass     a list of paths on which we should not generate dependencies
+    pkg_attrs  the set of package attributes for this manifest, produced as
+               a by-product of this dependency generation
 
-        We support regular expressions as entries in the bypass list, matching
-        one or more files.
+    We support regular expressions as entries in the bypass list, matching
+    one or more files.
 
-        If a bypass-list entry is provided that does not contain one of the
-        following characters: ["/", "*", "?"], it is assumed to be a filename,
-        and expanded to the regular expression ".*/<entry>"
+    If a bypass-list entry is provided that does not contain one of the
+    following characters: ["/", "*", "?"], it is assumed to be a filename,
+    and expanded to the regular expression ".*/<entry>"
 
-        All bypass-list entries are assumed to be regular expressions that are
-        rooted at ^ and $.
+    All bypass-list entries are assumed to be regular expressions that are
+    rooted at ^ and $.
 
-        The special match-all wildcard ".*" is dealt with separately,
-        by list_implicit_deps_for_manifest(..)
-        """
+    The special match-all wildcard ".*" is dealt with separately,
+    by list_implicit_deps_for_manifest(..)
+    """
 
-        new_ds = []
-        for dep in ds:
-                full_paths = set(make_paths(dep))
-                bypassed_files = set()
-                bypass_regexps = []
-                try:
-                        for item in bypass:
-                                # try to determine if this is a regexp,
-                                # rather than a filename
-                                if "*" in item or "?" in item:
-                                        pass
-                                # if it appears to be a filename, make it match
-                                # all paths to that filename.
-                                elif "/" not in item:
-                                        item = ".*{0}{1}".format(os.path.sep,
-                                            item)
+    new_ds = []
+    for dep in ds:
+        full_paths = set(make_paths(dep))
+        bypassed_files = set()
+        bypass_regexps = []
+        try:
+            for item in bypass:
+                # try to determine if this is a regexp,
+                # rather than a filename
+                if "*" in item or "?" in item:
+                    pass
+                # if it appears to be a filename, make it match
+                # all paths to that filename.
+                elif "/" not in item:
+                    item = ".*{0}{1}".format(os.path.sep, item)
 
-                                # always anchor our regular expressions,
-                                # otherwise, we get partial matches for files,
-                                # eg. bypassing "foo.c" would otherwise also
-                                # bypass "foo.cc"
-                                if item:
-                                        if not item.endswith("$"):
-                                                item = item + "$"
-                                        if not item.startswith("^"):
-                                                item = "^" + item
-                                        bypass_regexps.append(re.compile(item))
-                except re.error as e:
-                        raise base.InvalidDependBypassValue(item, e)
+                # always anchor our regular expressions,
+                # otherwise, we get partial matches for files,
+                # eg. bypassing "foo.c" would otherwise also
+                # bypass "foo.cc"
+                if item:
+                    if not item.endswith("$"):
+                        item = item + "$"
+                    if not item.startswith("^"):
+                        item = "^" + item
+                    bypass_regexps.append(re.compile(item))
+        except re.error as e:
+            raise base.InvalidDependBypassValue(item, e)
 
-                for path in full_paths:
-                        if path in bypass:
-                                bypassed_files.add(path)
-                                continue
-                        for regexp in bypass_regexps:
-                                if regexp.match(path):
-                                        bypassed_files.add(path)
+        for path in full_paths:
+            if path in bypass:
+                bypassed_files.add(path)
+                continue
+            for regexp in bypass_regexps:
+                if regexp.match(path):
+                    bypassed_files.add(path)
 
-                if bypassed_files:
-                        # remove the old runpath and basename entries from
-                        # the dependency if they were present
-                        dep.attrs.pop(files_prefix, None)
-                        dep.attrs.pop(paths_prefix, None)
-                        dep.base_names = []
-                        dep.run_paths = []
+        if bypassed_files:
+            # remove the old runpath and basename entries from
+            # the dependency if they were present
+            dep.attrs.pop(files_prefix, None)
+            dep.attrs.pop(paths_prefix, None)
+            dep.base_names = []
+            dep.run_paths = []
 
-                        # determine our new list of paths
-                        full_paths = full_paths - bypassed_files
+            # determine our new list of paths
+            full_paths = full_paths - bypassed_files
 
-                        dep.full_paths = sorted(list(full_paths))
-                        dep.attrs[fullpaths_prefix] = dep.full_paths
-                        pkg_attrs[bypassed_prefix] = \
-                            sorted(list(bypassed_files))
+            dep.full_paths = sorted(list(full_paths))
+            dep.attrs[fullpaths_prefix] = dep.full_paths
+            pkg_attrs[bypassed_prefix] = sorted(list(bypassed_files))
 
-                        # only include the dependency if it still contains data
-                        if full_paths:
-                                new_ds.append(dep)
-                else:
-                        new_ds.append(dep)
-        return new_ds
+            # only include the dependency if it still contains data
+            if full_paths:
+                new_ds.append(dep)
+        else:
+            new_ds.append(dep)
+    return new_ds
+
 
 def __make_manifest(fp, basedirs=None, load_data=True):
-        """Given the file path, 'fp', return a Manifest for that path."""
+    """Given the file path, 'fp', return a Manifest for that path."""
 
-        m = manifest.Manifest()
+    m = manifest.Manifest()
+    try:
+        fh = open(fp, "r")
+    except EnvironmentError as e:
+        raise apx._convert_error(e)
+    acts = []
+    missing_files = []
+    action_errs = []
+    accumulate = ""
+    for l in fh:
+        l = l.strip()
+        if l.endswith("\\"):
+            accumulate += l[0:-1]
+            continue
+        elif accumulate:
+            l = accumulate + l
+            accumulate = ""
+        if not l or l[0] == "#":
+            continue
         try:
-                fh = open(fp, "r")
-        except EnvironmentError as e:
-                raise apx._convert_error(e)
-        acts = []
-        missing_files = []
-        action_errs = []
-        accumulate = ""
-        for l in fh:
-                l = l.strip()
-                if l.endswith("\\"):
-                        accumulate += l[0:-1]
-                        continue
-                elif accumulate:
-                        l = accumulate + l
-                        accumulate = ""
-                if not l or l[0] == '#':
-                        continue
-                try:
-                        a, local_path, used_bd = actions.internalizestr(l,
-                            basedirs=basedirs,
-                            load_data=load_data)
+            a, local_path, used_bd = actions.internalizestr(
+                l, basedirs=basedirs, load_data=load_data
+            )
 
-                        # Ensure dependency is a type we understand; the
-                        # manifest could contain a future dependency type.
-                        if (a.name == "depend" and
-                            a.attrs.get("type") not in dep_types):
-                                raise actions.InvalidActionError(str(a),
-                                    "Unknown dependency type '{0}'".
-                                    format(a.attrs.get("type")))
+            # Ensure dependency is a type we understand; the
+            # manifest could contain a future dependency type.
+            if a.name == "depend" and a.attrs.get("type") not in dep_types:
+                raise actions.InvalidActionError(
+                    str(a),
+                    "Unknown dependency type '{0}'".format(a.attrs.get("type")),
+                )
 
-                except actions.ActionDataError as e:
-                        new_a, local_path, used_bd = actions.internalizestr(
-                            l, basedirs=basedirs, load_data=False)
-                        if new_a.name == "license":
-                                local_path = None
-                                a = new_a
-                        else:
-                                missing_files.append(base.MissingFile(
-                                    new_a.attrs["path"], dirs=basedirs,
-                                    hash=new_a.hash))
-                                continue
-                except actions.ActionError as e:
-                        action_errs.append(e)
-                        continue
-                else:
-                        # If this action has a payload, add the information
-                        # about where that payload file lives to the action.
-                        if local_path:
-                                assert portable.PD_LOCAL_PATH not in a.attrs
-                                a.attrs[portable.PD_LOCAL_PATH] = local_path
-                                a.attrs[portable.PD_PROTO_DIR] = used_bd
-                                a.attrs[portable.PD_PROTO_DIR_LIST] = basedirs
-                try:
-                        a.validate()
-                except actions.ActionError as e:
-                        action_errs.append(e)
-                else:
-                        acts.append(a)
-        fh.close()
-        m.set_content(content=acts)
-        return m, missing_files + action_errs
+        except actions.ActionDataError as e:
+            new_a, local_path, used_bd = actions.internalizestr(
+                l, basedirs=basedirs, load_data=False
+            )
+            if new_a.name == "license":
+                local_path = None
+                a = new_a
+            else:
+                missing_files.append(
+                    base.MissingFile(
+                        new_a.attrs["path"], dirs=basedirs, hash=new_a.hash
+                    )
+                )
+                continue
+        except actions.ActionError as e:
+            action_errs.append(e)
+            continue
+        else:
+            # If this action has a payload, add the information
+            # about where that payload file lives to the action.
+            if local_path:
+                assert portable.PD_LOCAL_PATH not in a.attrs
+                a.attrs[portable.PD_LOCAL_PATH] = local_path
+                a.attrs[portable.PD_PROTO_DIR] = used_bd
+                a.attrs[portable.PD_PROTO_DIR_LIST] = basedirs
+        try:
+            a.validate()
+        except actions.ActionError as e:
+            action_errs.append(e)
+        else:
+            acts.append(a)
+    fh.close()
+    m.set_content(content=acts)
+    return m, missing_files + action_errs
+
 
 def choose_name(fp, mfst):
-        """Find the package name for this manifest.  If it's defined in a set
-        action in the manifest, use that.  Otherwise use the basename of the
-        path to the manifest as the name.  If a proper package fmri is found,
-        then also return a PkgFmri object so that we can track which packages
-        are being processed.
+    """Find the package name for this manifest.  If it's defined in a set
+    action in the manifest, use that.  Otherwise use the basename of the
+    path to the manifest as the name.  If a proper package fmri is found,
+    then also return a PkgFmri object so that we can track which packages
+    are being processed.
 
-        'fp' is the path to the file for the manifest.
+    'fp' is the path to the file for the manifest.
 
-        'mfst' is the Manifest object."""
+    'mfst' is the Manifest object."""
 
-        if mfst is None:
-                return unquote(os.path.basename(fp)), None
-        name = mfst.get("pkg.fmri", mfst.get("fmri", None))
-        if name is not None:
-                try:
-                        pfmri = fmri.PkgFmri(name)
-                except fmri.IllegalFmri:
-                        pfmri = None
-                return name, pfmri
+    if mfst is None:
         return unquote(os.path.basename(fp)), None
+    name = mfst.get("pkg.fmri", mfst.get("fmri", None))
+    if name is not None:
+        try:
+            pfmri = fmri.PkgFmri(name)
+        except fmri.IllegalFmri:
+            pfmri = None
+        return name, pfmri
+    return unquote(os.path.basename(fp)), None
+
 
 def make_paths(file_dep):
-        """Find all the possible paths which could satisfy the dependency
-        'file_dep'."""
+    """Find all the possible paths which could satisfy the dependency
+    'file_dep'."""
 
-        if file_dep.attrs.get(fullpaths_prefix, []):
-                return file_dep.attrs[fullpaths_prefix]
+    if file_dep.attrs.get(fullpaths_prefix, []):
+        return file_dep.attrs[fullpaths_prefix]
 
-        rps = file_dep.attrs.get(paths_prefix, [""])
-        files = file_dep.attrs[files_prefix]
-        if isinstance(files, six.string_types):
-                files = [files]
-        if isinstance(rps, six.string_types):
-                rps = [rps]
-        return [os.path.join(rp, f) for rp in rps for f in files]
+    rps = file_dep.attrs.get(paths_prefix, [""])
+    files = file_dep.attrs[files_prefix]
+    if isinstance(files, six.string_types):
+        files = [files]
+    if isinstance(rps, six.string_types):
+        rps = [rps]
+    return [os.path.join(rp, f) for rp in rps for f in files]
+
 
 def resolve_links(path, files_dict, links, path_vars, file_dep_attrs, index=1):
-        """This method maps a path to one or more real paths and the variants
-        under which each real path can exist.
+    """This method maps a path to one or more real paths and the variants
+    under which each real path can exist.
 
-        'path' is the original text of the path which is being resolved to a
-        real path.
+    'path' is the original text of the path which is being resolved to a
+    real path.
 
-        'files_dict' is a dictionary which maps package identity to the files
-        the package delivers and the variants under which each file is present.
+    'files_dict' is a dictionary which maps package identity to the files
+    the package delivers and the variants under which each file is present.
 
-        'links' is an Entries namedtuple which contains two dictionaries.  One
-        dictionary maps package identity to the links that it delivers.  The
-        other dictionary, contains the same information for links that are
-        installed on the system.
+    'links' is an Entries namedtuple which contains two dictionaries.  One
+    dictionary maps package identity to the links that it delivers.  The
+    other dictionary, contains the same information for links that are
+    installed on the system.
 
-        'path_vars' is the set of variants under which 'path' exists.
+    'path_vars' is the set of variants under which 'path' exists.
 
-        'file_dep_attrs' is the dictonary of attributes for the file dependency
-        for 'path'.
+    'file_dep_attrs' is the dictonary of attributes for the file dependency
+    for 'path'.
 
-        'index' indicates how much of 'path' should be checked against the file
-        and link dictionaries."""
+    'index' indicates how much of 'path' should be checked against the file
+    and link dictionaries."""
 
-        res_paths = []
-        res_links = []
+    res_paths = []
+    res_links = []
 
-        # If the current path is a known file, then we might be done resolving
-        # the path.
-        if path in files_dict:
-                # Copy the variants so that marking the variants as satisified
-                # doesn't change the sate of 'path_vars.'
-                tmp_vars = copy.copy(path_vars)
-                # If tmp_vars has been satisfied, then this function should
-                # never have been called.
-                assert(tmp_vars.is_empty() or not tmp_vars.is_satisfied())
-                # Check each package which delivers a file with this path.
-                for pfmri, p_vc in files_dict[path]:
-                        # If the file is delivered under a set of variants which
-                        # are irrelevant to the path being considered, skip it.
-                        if not path_vars.intersects(p_vc):
-                                continue
-                        # The intersection of the variants which apply to the
-                        # current path and the variants for the delivered file
-                        # is the combination of variants where the original
-                        # path resolves to the delivered file.
-                        inter = path_vars.intersection(p_vc)
-                        inter.mark_all_as_satisfied()
-                        tmp_vars.mark_as_satisfied(p_vc)
-                        res_paths.append(LinkInfo(path, pfmri, pfmri, inter,
-                            []))
-                # If the path was resolved under all relevant variants, then
-                # we're done.
-                if res_paths and tmp_vars.is_satisfied():
-                        return res_paths, res_links
+    # If the current path is a known file, then we might be done resolving
+    # the path.
+    if path in files_dict:
+        # Copy the variants so that marking the variants as satisified
+        # doesn't change the sate of 'path_vars.'
+        tmp_vars = copy.copy(path_vars)
+        # If tmp_vars has been satisfied, then this function should
+        # never have been called.
+        assert tmp_vars.is_empty() or not tmp_vars.is_satisfied()
+        # Check each package which delivers a file with this path.
+        for pfmri, p_vc in files_dict[path]:
+            # If the file is delivered under a set of variants which
+            # are irrelevant to the path being considered, skip it.
+            if not path_vars.intersects(p_vc):
+                continue
+            # The intersection of the variants which apply to the
+            # current path and the variants for the delivered file
+            # is the combination of variants where the original
+            # path resolves to the delivered file.
+            inter = path_vars.intersection(p_vc)
+            inter.mark_all_as_satisfied()
+            tmp_vars.mark_as_satisfied(p_vc)
+            res_paths.append(LinkInfo(path, pfmri, pfmri, inter, []))
+        # If the path was resolved under all relevant variants, then
+        # we're done.
+        if res_paths and tmp_vars.is_satisfied():
+            return res_paths, res_links
 
-        lst = path.split(os.path.sep)
-        # If there aren't any more pieces of the path left to check, then
-        # there's nothing to do so return whatever has been found so far.
-        if index > len(lst):
-                return res_paths, res_links
-
-        # Create the path to check for links.
-        cur_path = os.path.join(*lst[0:index])
-        # Find the links which match the path being checked.
-        rel_links = links.get(cur_path, False)
-        # If there weren't any relevant links, then add the next path component
-        # to the path being considered and try again.
-        if not rel_links:
-                return resolve_links(path, files_dict, links, path_vars,
-                    file_dep_attrs, index=index+1)
-
-        links_found = {}
-        for link_pfmri, link_vc, rel_target in rel_links:
-                # If the variants needed to reach the current path and the
-                # variants for the link don't intersect, then the link is
-                # irrelevant.
-                if not path_vars.intersects(link_vc):
-                        continue
-                vc_intersection = path_vars.intersection(link_vc)
-                # If the link only matters under variants that are satisfied,
-                # then it's not an interesting link for this purpose.
-                if vc_intersection.is_satisfied() and \
-                    not vc_intersection.is_empty():
-                        continue
-                # Apply the link to the current path to get the new relevant
-                # path.
-                next_path = os.path.normpath(os.path.join(
-                    os.path.dirname(cur_path), rel_target,
-                    *lst[index:])).lstrip(os.path.sep)
-                # Index is reset back to the default because an element in path
-                # the link provides could actually be a link.
-                rec_paths, link_deps = resolve_links(next_path, files_dict,
-                    links, vc_intersection, file_dep_attrs)
-                if not rec_paths:
-                        continue
-                # The current path was able to be resolved to a real path, so
-                # add the paths and the dependencies from links found to the
-                # results.
-                res_links.extend(link_deps)
-                for rec_path, rec_pfmri, nearest_pfmri, rec_vc, via_links in \
-                    rec_paths:
-                        via_links.append(path)
-                        assert vc_intersection.intersects(rec_vc), \
-                            "vc:{0}\nvc_intersection:{1}".format(
-                            rec_vc, vc_intersection)
-                        links_found.setdefault(next_path, []).append(
-                            (link_pfmri, nearest_pfmri, rec_vc))
-                        res_paths.append(LinkInfo(rec_path, rec_pfmri,
-                            link_pfmri, rec_vc, via_links))
-
-        # Now add in the dependencies for the current link.
-        for next_path in links_found.keys():
-                cur_deps = group_by_variant_combinations(links_found[next_path])
-                for pfmri_pairs, vc in cur_deps:
-                        # Make a copy of path_vars which is unsatisfied, then
-                        # mark the specific combinations which are satisfied by
-                        # this group of pfmris.
-                        dep_vc = path_vars.unsatisfied_copy()
-                        dep_vc.mark_as_satisfied(vc)
-                        for l_pfmri, r_pfmri in pfmri_pairs:
-                                if l_pfmri == r_pfmri:
-                                        continue
-                                dep_type = "conditional"
-                                attrs = file_dep_attrs.copy()
-                                attrs.update({
-                                    "fmri": l_pfmri.get_short_fmri(),
-                                    "predicate": r_pfmri.get_short_fmri(),
-                                    type_prefix: "link",
-                                    files_prefix: [path],
-                                    "type": dep_type,
-                                })
-                                attrs.pop(paths_prefix, None)
-                                attrs.pop(fullpaths_prefix, None)
-                                # The dependency is created with the same
-                                # variants as the path.  This works because the
-                                # set of relevant variants is restricted as
-                                # links are applied so the variants used for the
-                                # path are the intersection of the variants for
-                                # each of the links used to reach the path and
-                                # the variants under which the file is
-                                # delivered.
-                                res_links.append((
-                                    actions.depend.DependencyAction(**attrs),
-                                    dep_vc))
-
+    lst = path.split(os.path.sep)
+    # If there aren't any more pieces of the path left to check, then
+    # there's nothing to do so return whatever has been found so far.
+    if index > len(lst):
         return res_paths, res_links
 
-def find_package_using_delivered_files(files_dict, links, file_dep, dep_vars,
-    orig_dep_vars):
-        """Maps a dependency on a file to the packages which can satisfy that
-        dependency.
+    # Create the path to check for links.
+    cur_path = os.path.join(*lst[0:index])
+    # Find the links which match the path being checked.
+    rel_links = links.get(cur_path, False)
+    # If there weren't any relevant links, then add the next path component
+    # to the path being considered and try again.
+    if not rel_links:
+        return resolve_links(
+            path, files_dict, links, path_vars, file_dep_attrs, index=index + 1
+        )
 
-        'files_dict' is a dictionary mapping paths to a list of fmri, variants
-        pairs.
+    links_found = {}
+    for link_pfmri, link_vc, rel_target in rel_links:
+        # If the variants needed to reach the current path and the
+        # variants for the link don't intersect, then the link is
+        # irrelevant.
+        if not path_vars.intersects(link_vc):
+            continue
+        vc_intersection = path_vars.intersection(link_vc)
+        # If the link only matters under variants that are satisfied,
+        # then it's not an interesting link for this purpose.
+        if vc_intersection.is_satisfied() and not vc_intersection.is_empty():
+            continue
+        # Apply the link to the current path to get the new relevant
+        # path.
+        next_path = os.path.normpath(
+            os.path.join(os.path.dirname(cur_path), rel_target, *lst[index:])
+        ).lstrip(os.path.sep)
+        # Index is reset back to the default because an element in path
+        # the link provides could actually be a link.
+        rec_paths, link_deps = resolve_links(
+            next_path, files_dict, links, vc_intersection, file_dep_attrs
+        )
+        if not rec_paths:
+            continue
+        # The current path was able to be resolved to a real path, so
+        # add the paths and the dependencies from links found to the
+        # results.
+        res_links.extend(link_deps)
+        for rec_path, rec_pfmri, nearest_pfmri, rec_vc, via_links in rec_paths:
+            via_links.append(path)
+            assert vc_intersection.intersects(
+                rec_vc
+            ), "vc:{0}\nvc_intersection:{1}".format(rec_vc, vc_intersection)
+            links_found.setdefault(next_path, []).append(
+                (link_pfmri, nearest_pfmri, rec_vc)
+            )
+            res_paths.append(
+                LinkInfo(rec_path, rec_pfmri, link_pfmri, rec_vc, via_links)
+            )
 
-        'links' is an Entries namedtuple which contains two dictionaries.  One
-        dictionary maps package identity to the links that it delivers.  The
-        other dictionary, contains the same information for links that are
-        installed on the system.
-
-        'file_dep' is the dependency that is being resolved.
-
-        'dep_vars' are the variants for which the dependency has not yet been
-        resolved.
-
-        'orig_dep_vars' is the original set of variants under which the
-        dependency must be satisfied."""
-
-        res = []
-        errs = []
-        link_deps = []
-        cur_deps = []
-
-        pths = sorted(make_paths(file_dep))
-        pth_id = ":".join(pths)
-        for p in pths:
-                # If orig_dep_vars is satisfied, then this function should never
-                # have been called.
-                assert(orig_dep_vars.is_empty() or
-                    not orig_dep_vars.is_satisfied())
-                # Find the packages which satisfy this path of the file
-                # dependency and the links needed to reach the files which those
-                # packages provide.
-                paths_info, path_deps = resolve_links(os.path.normpath(p),
-                    files_dict, links, orig_dep_vars, file_dep.attrs.copy())
-                link_deps.extend(path_deps)
-                cur_deps += paths_info
-        # Because all of the package dependencies are ultimately satisfying the
-        # same file dependency, they should all be grouped together.
-        cur_deps = group_by_variant_combinations([
-            (t.path, t.pfmri, t.via_links, t.variant_combination)
-            for t in cur_deps
-        ])
-
-        for l, vc in cur_deps:
-                dep_vars.mark_as_satisfied(vc)
-                attrs = file_dep.attrs.copy()
-                dep_type = "require-any"
-                # Find the packages which satisify this file dependency.  Using
-                # the short fmri is appropriate for these purposes because
-                # dependencies can never be inferred on different versions of
-                # the same package during a single run of resolve.
-                pfmri_names = sorted(set([
-                    pfmri.get_short_fmri()
-                    for path, pfmri, vl in l
-                ]))
-                paths = sorted(set([
-                    path for path, pfmri, vl in l
-                ]))
-                via_links = []
-                # If only a single package satisfies this dependency, then a
-                # require dependency should be created, otherwise a require-any
-                # is needed.
-                if len(pfmri_names) == 1:
-                        dep_type = "require"
-                        pfmri_names = pfmri_names[0]
-                        via_links = l[0][2]
-                        via_links.reverse()
-                        via_links = ":".join(via_links)
-                else:
-                        for path, pfmri, vl in l:
-                                vl.reverse()
-                                via_links.append(":".join(vl))
+    # Now add in the dependencies for the current link.
+    for next_path in links_found.keys():
+        cur_deps = group_by_variant_combinations(links_found[next_path])
+        for pfmri_pairs, vc in cur_deps:
+            # Make a copy of path_vars which is unsatisfied, then
+            # mark the specific combinations which are satisfied by
+            # this group of pfmris.
+            dep_vc = path_vars.unsatisfied_copy()
+            dep_vc.mark_as_satisfied(vc)
+            for l_pfmri, r_pfmri in pfmri_pairs:
+                if l_pfmri == r_pfmri:
+                    continue
+                dep_type = "conditional"
+                attrs = file_dep_attrs.copy()
+                attrs.update(
+                    {
+                        "fmri": l_pfmri.get_short_fmri(),
+                        "predicate": r_pfmri.get_short_fmri(),
+                        type_prefix: "link",
+                        files_prefix: [path],
+                        "type": dep_type,
+                    }
+                )
                 attrs.pop(paths_prefix, None)
                 attrs.pop(fullpaths_prefix, None)
-                attrs.update({
-                    "type": dep_type,
-                    "fmri": pfmri_names,
-                    files_prefix: paths,
-                })
-                if via_links:
-                        attrs[via_links_prefix] = via_links
-                res.append((actions.depend.DependencyAction(**attrs), vc))
+                # The dependency is created with the same
+                # variants as the path.  This works because the
+                # set of relevant variants is restricted as
+                # links are applied so the variants used for the
+                # path are the intersection of the variants for
+                # each of the links used to reach the path and
+                # the variants under which the file is
+                # delivered.
+                res_links.append(
+                    (actions.depend.DependencyAction(**attrs), dep_vc)
+                )
 
-        res.extend(link_deps)
-        # Add the path id so that these dependencies analyzed for simplification
-        # as a group.
-        for d, v in res:
-                d.attrs[path_id_prefix] = pth_id
-        return res, dep_vars, errs
+    return res_paths, res_links
+
+
+def find_package_using_delivered_files(
+    files_dict, links, file_dep, dep_vars, orig_dep_vars
+):
+    """Maps a dependency on a file to the packages which can satisfy that
+    dependency.
+
+    'files_dict' is a dictionary mapping paths to a list of fmri, variants
+    pairs.
+
+    'links' is an Entries namedtuple which contains two dictionaries.  One
+    dictionary maps package identity to the links that it delivers.  The
+    other dictionary, contains the same information for links that are
+    installed on the system.
+
+    'file_dep' is the dependency that is being resolved.
+
+    'dep_vars' are the variants for which the dependency has not yet been
+    resolved.
+
+    'orig_dep_vars' is the original set of variants under which the
+    dependency must be satisfied."""
+
+    res = []
+    errs = []
+    link_deps = []
+    cur_deps = []
+
+    pths = sorted(make_paths(file_dep))
+    pth_id = ":".join(pths)
+    for p in pths:
+        # If orig_dep_vars is satisfied, then this function should never
+        # have been called.
+        assert orig_dep_vars.is_empty() or not orig_dep_vars.is_satisfied()
+        # Find the packages which satisfy this path of the file
+        # dependency and the links needed to reach the files which those
+        # packages provide.
+        paths_info, path_deps = resolve_links(
+            os.path.normpath(p),
+            files_dict,
+            links,
+            orig_dep_vars,
+            file_dep.attrs.copy(),
+        )
+        link_deps.extend(path_deps)
+        cur_deps += paths_info
+    # Because all of the package dependencies are ultimately satisfying the
+    # same file dependency, they should all be grouped together.
+    cur_deps = group_by_variant_combinations(
+        [
+            (t.path, t.pfmri, t.via_links, t.variant_combination)
+            for t in cur_deps
+        ]
+    )
+
+    for l, vc in cur_deps:
+        dep_vars.mark_as_satisfied(vc)
+        attrs = file_dep.attrs.copy()
+        dep_type = "require-any"
+        # Find the packages which satisify this file dependency.  Using
+        # the short fmri is appropriate for these purposes because
+        # dependencies can never be inferred on different versions of
+        # the same package during a single run of resolve.
+        pfmri_names = sorted(
+            set([pfmri.get_short_fmri() for path, pfmri, vl in l])
+        )
+        paths = sorted(set([path for path, pfmri, vl in l]))
+        via_links = []
+        # If only a single package satisfies this dependency, then a
+        # require dependency should be created, otherwise a require-any
+        # is needed.
+        if len(pfmri_names) == 1:
+            dep_type = "require"
+            pfmri_names = pfmri_names[0]
+            via_links = l[0][2]
+            via_links.reverse()
+            via_links = ":".join(via_links)
+        else:
+            for path, pfmri, vl in l:
+                vl.reverse()
+                via_links.append(":".join(vl))
+        attrs.pop(paths_prefix, None)
+        attrs.pop(fullpaths_prefix, None)
+        attrs.update(
+            {
+                "type": dep_type,
+                "fmri": pfmri_names,
+                files_prefix: paths,
+            }
+        )
+        if via_links:
+            attrs[via_links_prefix] = via_links
+        res.append((actions.depend.DependencyAction(**attrs), vc))
+
+    res.extend(link_deps)
+    # Add the path id so that these dependencies analyzed for simplification
+    # as a group.
+    for d, v in res:
+        d.attrs[path_id_prefix] = pth_id
+    return res, dep_vars, errs
+
 
 def find_package(files, links, file_dep, orig_dep_vars, pkg_vars, use_system):
-        """Find the packages which resolve the dependency. It returns a list of
-        dependency actions with the fmri tag resolved.
+    """Find the packages which resolve the dependency. It returns a list of
+    dependency actions with the fmri tag resolved.
 
-        'files' is an Entries namedtuple which contains two dictionaries.  One
-        dictionary maps package identity to the files that it delivers.  The
-        other dictionary, contains the same information for files that are
-        installed on the system.
+    'files' is an Entries namedtuple which contains two dictionaries.  One
+    dictionary maps package identity to the files that it delivers.  The
+    other dictionary, contains the same information for files that are
+    installed on the system.
 
-        'links' is an Entries namedtuple which contains two dictionaries.  One
-        dictionary maps package identity to the links that it delivers.  The
-        other dictionary, contains the same information for links that are
-        installed on the system.
+    'links' is an Entries namedtuple which contains two dictionaries.  One
+    dictionary maps package identity to the links that it delivers.  The
+    other dictionary, contains the same information for links that are
+    installed on the system.
 
-        'file_dep' is the dependency being resolved.
+    'file_dep' is the dependency being resolved.
 
-        'orig_dep_vars' is the original set of variants under which the
-        dependency must be satisfied.
+    'orig_dep_vars' is the original set of variants under which the
+    dependency must be satisfied.
 
-        'pkg_vars' is the variants against which the package was published."""
+    'pkg_vars' is the variants against which the package was published."""
 
-        # If the file dependency has already satisfied all its variants, then
-        # this function should never have been called.
-        assert(orig_dep_vars.is_empty() or not orig_dep_vars.is_satisfied())
-        dep_vars = copy.copy(orig_dep_vars)
-        # First try to resolve the dependency against the delivered files.
-        res, dep_vars, errs = find_package_using_delivered_files(
-                files.delivered, links, file_dep, dep_vars, orig_dep_vars)
-        # If dep_vars is satisfied then we found at least one solution.  It's
-        # possible that more than one solution was found, causing an error.
-        assert(not dep_vars.is_satisfied() or
-            (res or errs or dep_vars.is_empty()))
-        if ((res or errs) and dep_vars.is_satisfied()) or not use_system:
-                return res, dep_vars, errs
-
-        # If the dependency isn't fully satisfied, resolve it against the
-        # files installed in the current image.
-        #
-        # We only need to resolve for the variants not already satisfied
-        # above.
-        const_dep_vars = copy.copy(dep_vars)
-        # If dep_vars has been satisfied, then we should have exited the
-        # function above.
-        assert(const_dep_vars.is_empty() or not const_dep_vars.is_satisfied())
-        inst_res, dep_vars, inst_errs = find_package_using_delivered_files(
-            files.installed, links, file_dep, dep_vars, const_dep_vars)
-        res.extend(inst_res)
-        errs.extend(inst_errs)
+    # If the file dependency has already satisfied all its variants, then
+    # this function should never have been called.
+    assert orig_dep_vars.is_empty() or not orig_dep_vars.is_satisfied()
+    dep_vars = copy.copy(orig_dep_vars)
+    # First try to resolve the dependency against the delivered files.
+    res, dep_vars, errs = find_package_using_delivered_files(
+        files.delivered, links, file_dep, dep_vars, orig_dep_vars
+    )
+    # If dep_vars is satisfied then we found at least one solution.  It's
+    # possible that more than one solution was found, causing an error.
+    assert not dep_vars.is_satisfied() or (res or errs or dep_vars.is_empty())
+    if ((res or errs) and dep_vars.is_satisfied()) or not use_system:
         return res, dep_vars, errs
 
+    # If the dependency isn't fully satisfied, resolve it against the
+    # files installed in the current image.
+    #
+    # We only need to resolve for the variants not already satisfied
+    # above.
+    const_dep_vars = copy.copy(dep_vars)
+    # If dep_vars has been satisfied, then we should have exited the
+    # function above.
+    assert const_dep_vars.is_empty() or not const_dep_vars.is_satisfied()
+    inst_res, dep_vars, inst_errs = find_package_using_delivered_files(
+        files.installed, links, file_dep, dep_vars, const_dep_vars
+    )
+    res.extend(inst_res)
+    errs.extend(inst_errs)
+    return res, dep_vars, errs
+
+
 def is_file_dependency(act):
-        return act.name == "depend" and \
-            act.attrs.get("fmri", None) == base.Dependency.DUMMY_FMRI and \
-            (files_prefix in act.attrs or fullpaths_prefix in act.attrs)
+    return (
+        act.name == "depend"
+        and act.attrs.get("fmri", None) == base.Dependency.DUMMY_FMRI
+        and (files_prefix in act.attrs or fullpaths_prefix in act.attrs)
+    )
+
 
 def group_by_variant_combinations(lst):
-        """The goal of this function is to produce the smallest list of (info
-        list, VariantCombinations) tuples which has the following properties:
+    """The goal of this function is to produce the smallest list of (info
+    list, VariantCombinations) tuples which has the following properties:
 
-        1. The intersection between any two satisfied sets of the
-        VariantCombinations must be empty.
+    1. The intersection between any two satisfied sets of the
+    VariantCombinations must be empty.
 
-        2. If a piece of information was satisfied under a particular
-        combination of variants, that information must be paired with the
-        VariantCombination which has that combination in its satisfied set.
+    2. If a piece of information was satisfied under a particular
+    combination of variants, that information must be paired with the
+    VariantCombination which has that combination in its satisfied set.
 
-        Note: A piece of information can appear more than once in the result.
+    Note: A piece of information can appear more than once in the result.
 
-        The 'lst' parameter is a list of tuples.  The last item in each tuple
-        must be a VariantCombination. The rest of each tuple is the "piece of
-        information" discussed above."""
+    The 'lst' parameter is a list of tuples.  The last item in each tuple
+    must be a VariantCombination. The rest of each tuple is the "piece of
+    information" discussed above."""
 
-        seed = []
-        for item in lst:
-                # Separate the VariantCombination out from the info to be
-                # grouped.
-                i_vc = item[-1]
-                info = item[:-1]
-                # If there's only a single piece of information, then take it
-                # out of a list.
-                if len(info) == 1:
-                        info = info[0]
-                new_res = []
-                for old_info, old_vc in seed:
-                        # If i_vc is None, then variant combinations under which
-                        # 'info' is satisfied have been covered by previous
-                        # old_vc's and info has already been merged in, so just
-                        # finish extending the list with the existing
-                        # information.
-                        if i_vc is None:
-                                new_res.append((old_info, old_vc))
-                                continue
-                        # Check to see how i_vc and old_vc's satisfied sets
-                        # overlap.
-                        only_i, intersect, only_old = \
-                            i_vc.separate_satisfied(old_vc)
-                        assert only_i or intersect or only_old
-                        assert only_i or i_vc.issubset(old_vc, True)
-                        assert only_old or old_vc.issubset(i_vc, True)
-                        assert intersect or (only_i and only_old)
-                        # If there are any variant combinations where old_vc is
-                        # satisfied but i_vc is not, add the VariantCombination
-                        # for those combinations to the list along with the
-                        # old_info.
-                        if only_old:
-                                new_res.append((old_info, only_old))
-                        # If i_vc and old_vc are both satisfied under some
-                        # variant combinations, then add info into the old_info
-                        # under those variant combinations.
-                        if intersect:
-                                tmp = old_info[:]
-                                tmp.append(info)
-                                new_res.append((tmp, intersect))
-                        # The relevant variant combinations to consider now are
-                        # those that didn't overlap with old_vc.
-                        i_vc = only_i
-                # If i_vc is not None, then i_vc was satisfied under some
-                # variant combinations which no other VariantCombination was, so
-                # add it to the list.
-                if i_vc is not None:
-                        new_res.append(([info], i_vc))
-                seed = new_res
-        return seed
+    seed = []
+    for item in lst:
+        # Separate the VariantCombination out from the info to be
+        # grouped.
+        i_vc = item[-1]
+        info = item[:-1]
+        # If there's only a single piece of information, then take it
+        # out of a list.
+        if len(info) == 1:
+            info = info[0]
+        new_res = []
+        for old_info, old_vc in seed:
+            # If i_vc is None, then variant combinations under which
+            # 'info' is satisfied have been covered by previous
+            # old_vc's and info has already been merged in, so just
+            # finish extending the list with the existing
+            # information.
+            if i_vc is None:
+                new_res.append((old_info, old_vc))
+                continue
+            # Check to see how i_vc and old_vc's satisfied sets
+            # overlap.
+            only_i, intersect, only_old = i_vc.separate_satisfied(old_vc)
+            assert only_i or intersect or only_old
+            assert only_i or i_vc.issubset(old_vc, True)
+            assert only_old or old_vc.issubset(i_vc, True)
+            assert intersect or (only_i and only_old)
+            # If there are any variant combinations where old_vc is
+            # satisfied but i_vc is not, add the VariantCombination
+            # for those combinations to the list along with the
+            # old_info.
+            if only_old:
+                new_res.append((old_info, only_old))
+            # If i_vc and old_vc are both satisfied under some
+            # variant combinations, then add info into the old_info
+            # under those variant combinations.
+            if intersect:
+                tmp = old_info[:]
+                tmp.append(info)
+                new_res.append((tmp, intersect))
+            # The relevant variant combinations to consider now are
+            # those that didn't overlap with old_vc.
+            i_vc = only_i
+        # If i_vc is not None, then i_vc was satisfied under some
+        # variant combinations which no other VariantCombination was, so
+        # add it to the list.
+        if i_vc is not None:
+            new_res.append(([info], i_vc))
+        seed = new_res
+    return seed
+
 
 def merge_deps(dest, src):
-        """Add the information contained in src's attrs to dest."""
+    """Add the information contained in src's attrs to dest."""
 
-        for k, v in src.attrs.items():
-                # If any of these dependencies already have a variant set,
-                # then something's gone horribly wrong.
-                assert(not k.startswith("variant."))
-                if k not in dest.attrs:
-                        dest.attrs[k] = v
-                elif v != dest.attrs[k]:
-                        # For now, just merge the values. Duplicate values
-                        # will be removed in a later step.
-                        if isinstance(v, six.string_types):
-                                v = [v]
-                        if isinstance(dest.attrs[k], list):
-                                dest.attrs[k].extend(v)
-                        else:
-                                t = [dest.attrs[k]]
-                                t.extend(v)
-                                dest.attrs[k] = t
+    for k, v in src.attrs.items():
+        # If any of these dependencies already have a variant set,
+        # then something's gone horribly wrong.
+        assert not k.startswith("variant.")
+        if k not in dest.attrs:
+            dest.attrs[k] = v
+        elif v != dest.attrs[k]:
+            # For now, just merge the values. Duplicate values
+            # will be removed in a later step.
+            if isinstance(v, six.string_types):
+                v = [v]
+            if isinstance(dest.attrs[k], list):
+                dest.attrs[k].extend(v)
+            else:
+                t = [dest.attrs[k]]
+                t.extend(v)
+                dest.attrs[k] = t
+
 
 def __predicate_path_id_attrget(d):
+    # d is a tuple containing two items.  d[0] is the action.  d[1]
+    # is the VariantCombination for this action.  The
+    # VariantCombination isn't useful for our grouping needs.
+    try:
+        return d[0].attrs["predicate"], d[0].attrs.get(path_id_prefix, "")
+    except KeyError:
+        raise RuntimeError("Expected this to have a predicate:{0}".format(d[0]))
+
+
+def __collapse_conditionals(deps):
+    """Under certain conditions, conditional dependencies can be transformed
+    into require-any or require dependencies.  This function is responsible
+    for performing the transformation.
+
+    The 'deps' parameter is a list of dependency action and
+    VariantCombination tuples."""
+
+    # Construct a dictionary which maps a package name to a list of
+    # dependencies which require that package.
+    req_dict = {}
+    for d, v in deps:
+        if d.attrs["type"] != "require":
+            continue
+        t_pfmri = fmri.PkgFmri(d.attrs["fmri"])
+        req_dict.setdefault(
+            t_pfmri.get_pkg_stem(include_scheme=False), []
+        ).append((t_pfmri, d, v))
+
+    cond_deps = {}
+    preds_to_process = set()
+    for (predicate, path_id), group in itertools.groupby(
+        sorted(
+            [(d, v) for d, v in deps if d.attrs["type"] == "conditional"],
+            key=__predicate_path_id_attrget,
+        ),
+        __predicate_path_id_attrget,
+    ):
+        group = list(group)
+        cond_deps.setdefault(predicate, []).append((path_id, group))
+        preds_to_process.add(predicate)
+
+    new_req_deps = []
+
+    # While there are still require dependencies which might be used to
+    # transform a conditional dependency...
+    while preds_to_process:
+        # Pick a fmri which might be the predicate of a conditional
+        # dependency that could be collapsed.
+        predicate = preds_to_process.pop()
+        t_pfmri = fmri.PkgFmri(predicate)
+        t_name = t_pfmri.get_pkg_stem(include_scheme=False)
+        # If there are no require dependencies with that package name as
+        # a target, then there's nothing to do.
+        if t_name not in req_dict:
+            continue
+        rel_reqs = []
+        # Only require dependencies whose fmri is a successor to the
+        # fmri under consideration are interesting.
+        for req_fmri, d, v in req_dict[t_name]:
+            if req_fmri.is_successor(t_pfmri):
+                rel_reqs.append((d, v))
+        if not rel_reqs:
+            continue
+
+        new_group = []
+        for path_id, group in cond_deps.get(predicate, []):
+            tmp_deps = []
+            # Group all of the conditional dependencies inferred for
+            # path_id by the variant combinations under which
+            # they're valid.
+            tmp_deps = group_by_variant_combinations(group)
+
+            collapse_deps = []
+            no_collapse = []
+            # Separate the conditional dependencies into those that
+            # can be collapsed and those that can't.  If a
+            # conditional dependency intersects with any of the
+            # relevant required dependencies found earlier, it can
+            # be collapsed.
+            for ds, v in tmp_deps:
+                for req_d, req_v in rel_reqs:
+                    only_tmp, intersect, only_req = v.separate_satisfied(req_v)
+                    assert only_tmp or intersect or only_req
+                    assert only_tmp or v.issubset(req_v, True)
+                    assert only_req or v.issubset(v, True)
+                    assert intersect or (only_tmp and only_req)
+                    if intersect:
+                        collapse_deps.append((ds, intersect))
+                    v = only_tmp
+                    if v is None:
+                        break
+                if v is not None:
+                    no_collapse.extend([(d, v) for d in ds])
+
+            if no_collapse:
+                new_group.append((path_id, no_collapse))
+
+            # If path_id has no value, then these conditional
+            # dependencies were not inferred links needed to reach a
+            # file dependency.  In that case, the conditional
+            # dependencies can be individually collapsed to require
+            # dependencies but cannot be collapsed together into a
+            # require-any dependency.
+            if len(path_id) == 0:
+                for ds, v in collapse_deps:
+                    for d in ds:
+                        res_dep = actions.depend.DependencyAction(**d.attrs)
+                        del res_dep.attrs["predicate"]
+                        res_dep.attrs["type"] = "require"
+                        new_req_deps.append((res_dep, v))
+                        # Since a new require dependency
+                        # has been created, its possible
+                        # that conditional dependencies
+                        # could be collapsed using that,
+                        # so add the fmri to the
+                        # predicates to be processed.
+                        preds_to_process.add(res_dep.attrs["fmri"])
+                        t_pfmri = fmri.PkgFmri(d.attrs["fmri"])
+                        req_dict.setdefault(
+                            t_pfmri.get_pkg_stem(include_scheme=False), []
+                        ).append((t_pfmri, res_dep, v))
+                continue
+
+            # Since path_id has a value, these conditional
+            # dependencies were all inferred while trying to satisfy
+            # a dependency on the same "file."  Since they all have
+            # the same predicate, they must be collapsed into a
+            # require-any dependency because each represents a valid
+            # step through the link path to reach the dependened
+            # upon file.
+            for ds, v in collapse_deps:
+                res_dep = actions.depend.DependencyAction(**ds[0].attrs)
+                for d in ds[1:]:
+                    merge_deps(res_dep, d)
+                d = ds[-1]
+                res_dep.attrs["fmri"] = list(set(res_dep.attrlist("fmri")))
+                if len(res_dep.attrlist("fmri")) > 1:
+                    res_dep.attrs["type"] = "require-any"
+                else:
+                    res_dep.attrs["type"] = "require"
+                    res_dep.attrs["fmri"] = res_dep.attrs["fmri"][0]
+                    # Since a new require dependency has
+                    # been created, its possible that
+                    # conditional dependencies could be
+                    # collapsed using that, so add the fmri
+                    # to the predicates to be processed.
+                    preds_to_process.add(res_dep.attrs["fmri"])
+                    t_pfmri = fmri.PkgFmri(d.attrs["fmri"])
+                    req_dict.setdefault(
+                        t_pfmri.get_pkg_stem(include_scheme=False), []
+                    ).append((t_pfmri, res_dep, v))
+                del res_dep.attrs["predicate"]
+                new_req_deps.append((res_dep, v))
+        # Now that all the new require dependencies have been removed,
+        # update the remaining conditional dependencies for this
+        # predicate.
+        if new_group:
+            cond_deps[predicate] = new_group
+        elif predicate in cond_deps:
+            del cond_deps[predicate]
+
+    # The result is the original non-conditional dependencies ...
+    res = [(d, v) for d, v in deps if d.attrs["type"] != "conditional"]
+    # plus the new require or require-any dependencies made by collapsing
+    # the conditional dependencies ...
+    res += new_req_deps
+    # plus the conditional dependencies that couldn't be collapsed.
+    for l in cond_deps.values():
+        for path_id, dep_pairs in l:
+            res.extend(dep_pairs)
+    return res
+
+
+def __remove_unneeded_require_and_require_any(deps, pkg_fmri):
+    """Drop any unneeded require or require any dependencies and record any
+    dropped require-any dependencies which were inferred."""
+
+    res = []
+    omitted_req_any = {}
+    fmri_dict = {}
+    warnings = []
+    #
+    # We assume that the subsets are shorter than the supersets.
+    #
+    # Example:
+    # #1 depend fmri=a, fmri=b, fmri=c, type=require-any
+    # #2 depend fmri=a, fmri=b, type=require=any
+    # #2 is treated as a subset of #1
+    #
+    # Sort the dependencies by length to visit the subsets before the
+    # supersets.
+    #
+    for cur_dep, cur_vars in sorted(deps, key=lambda i: len(str(i))):
+        if cur_dep.attrs["type"] not in ("require", "require-any"):
+            res.append((cur_dep, cur_vars))
+            continue
+
+        cur_fmris = []
+        for f in cur_dep.attrlist("fmri"):
+            cur_fmris.append(fmri.PkgFmri(f))
+        skip = False
+        # If we're resolving a pkg with a known name ...
+        if pkg_fmri is not None:
+            for pfmri in cur_fmris:
+                # Then if this package is a successor to any of
+                # the packages the dependency requires, then we
+                # can omit the dependency.
+                if pkg_fmri.is_successor(pfmri):
+                    skip = True
+        if skip:
+            continue
+
+        # If this dependency isn't a require-any dependency, then it
+        # should be included in the output.
+        if cur_dep.attrs["type"] != "require-any":
+            res.append((cur_dep, cur_vars))
+            continue
+
+        marked = False
+        # Now the require-any dependency is going to be compared to all
+        # the known require dependencies to see if it can be omitted.
+        # It can be omitted if one of the packages it requires is
+        # already required.  Because a require-any dependency could be
+        # omitted under some, but not all, variant combinations, the
+        # satisfied set of the variant combination of the require-any
+        # dependency is used for bookkeeping.  Each require dependency
+        # which has a successor to one of the packages in the
+        # require-any dependency marks the variant combinations under
+        # which it's valid as unsatisfied in the require-any dependency.
+        # At the end, if the require-any dependency is still satisfied
+        # under any variant combinations, then it's included in the
+        # result.
+        successors = []
+        for comp_dep, comp_vars in deps:
+            if comp_dep.attrs["type"] != "require":
+                continue
+            successor = False
+            comp_fmri = fmri.PkgFmri(comp_dep.attrs["fmri"])
+            # Check to see whether the package required by the
+            # require dependency is a successor to any of the
+            # packages required by the require-any dependency.
+            for c in cur_fmris:
+                if comp_fmri.is_successor(c):
+                    successor = True
+                    break
+            if not successor:
+                continue
+            # If comp_vars is empty, then no variants have been
+            # declared for these packages, so having a matching
+            # require dependency is enough to omit this require-any
+            # dependency.
+            only_cur, inter, only_comp = cur_vars.separate_satisfied(comp_vars)
+            if cur_vars.mark_as_unsatisfied(comp_vars) or comp_vars.is_empty():
+                marked = True
+                successors.append((comp_fmri, inter))
+
+        # If one require-any dependency is the subset of the other
+        # require-any dependency, we should drop the superset because
+        # ultimately they should end up with the package dependency
+        # as the subset requires.
+        #
+        # Note that we only drop the deps we generate (with the
+        # pkgdepend.debug.depend.* prefix); we ignore the deps a
+        # developer added.
+        is_superset = False
+        if files_prefix in cur_dep.attrs or fullpaths_prefix in cur_dep.attrs:
+            # convert to a set for set operation
+            cur_fmris_set = set(cur_fmris)
+            for (comp_dep, comp_vars), comp_fmris_set in six.iteritems(
+                fmri_dict
+            ):
+                if (
+                    comp_fmris_set != cur_fmris_set
+                    and comp_fmris_set.issubset(cur_fmris_set)
+                    and cur_vars == comp_vars
+                ):
+                    is_superset = True
+                    drop_f = cur_fmris_set - comp_fmris_set
+                    warnings.append(DropPackageWarning(drop_f, comp_dep))
+                    break
+            if not is_superset:
+                fmri_dict.setdefault((cur_dep, cur_vars), cur_fmris_set)
+
+        # If the require-any dependency was never changed or is not a
+        # superset of any other require-any dependency, then include
+        # it.  If it was changed, check whether there are situations
+        # where the require-any dependency is needed.
+        if not marked and not is_superset:
+            res.append((cur_dep, cur_vars))
+            continue
+        if cur_vars.sat_set and not is_superset:
+            res.append((cur_dep, cur_vars))
+        path_id = cur_dep.attrs.get(path_id_prefix, None)
+        if path_id:
+            omitted_req_any[path_id] = successors
+
+    return res, omitted_req_any, warnings
+
+
+def __remove_extraneous_conditionals(deps, omitted_req_any):
+    """Remove conditional dependencies which other dependencies have made
+    unnecessary.  If an inferred require-any dependency was collapsed to a
+    require dependency, then only the conditional dependencies needed to
+    reach the require dependency should be retained."""
+
+    def fmri_attrget(d):
+        return fmri.PkgFmri(d[0].attrs["fmri"]).get_pkg_stem(
+            include_scheme=False
+        )
+
+    def path_id_attrget(d):
+        return d[0].attrs.get(path_id_prefix, "")
+
+    req_dict = {}
+    for target, group in itertools.groupby(
+        sorted(
+            [(d, v) for d, v in deps if d.attrs["type"] == "require"],
+            key=fmri_attrget,
+        ),
+        fmri_attrget,
+    ):
+        req_dict[target] = list(group)
+
+    needed_cond_deps = []
+    for path_id, group in itertools.groupby(
+        sorted(
+            [(d, v) for d, v in deps if d.attrs["type"] == "conditional"],
+            key=path_id_attrget,
+        ),
+        path_id_attrget,
+    ):
+        # Because of how the list was created, each dependency in
+        # successors is not satisfied under the same set of variant
+        # values as any other dependency in successors.
+        successors = omitted_req_any.get(path_id, [])
+        for d, v in group:
+            # If this conditional dependency was part of a path to a
+            # require-any dependency which was reduced to a require
+            # dependency under some combinations of variants, then
+            # make sure this conditional doesn't apply under those
+            # combinations of variants.
+            skip = False
+            for s_d, s_v in successors:
+                # If s_v is empty, then s_d applies under all
+                # variant combinations.
+                if s_v.is_empty():
+                    skip = True
+                    break
+                v.mark_as_unsatisfied(s_v)
+            if skip or (not v.is_empty() and not v.sat_set):
+                continue
+
+            # If this conditional dependency's fmri is also the fmri
+            # of a require dependency, then it can be ignored under
+            # those combinations of variants under which the require
+            # dependency applies.
+            d_fmri = fmri.PkgFmri(d.attrs["fmri"])
+            for r_d, r_v in req_dict.get(
+                d_fmri.get_pkg_stem(include_scheme=False), []
+            ):
+                r_fmri = fmri.PkgFmri(r_d.attrs["fmri"])
+                if not r_fmri.is_successor(d_fmri):
+                    continue
+                if r_v.is_empty():
+                    skip = True
+                    break
+                v.mark_as_unsatisfied(r_v)
+            if not skip and (v.is_empty() or v.sat_set):
+                needed_cond_deps.append((d, v))
+
+    return [
+        (d, v) for d, v in deps if d.attrs["type"] != "conditional"
+    ] + needed_cond_deps
+
+
+def combine(deps, pkg_vars, pkg_fmri, pkg_name):
+    """Combine duplicate dependency actions.
+
+    'deps' is a list of tuples. Each tuple contains a dependency action and
+    the variants associated with that dependency.
+
+    'pkg_vars' are the variants that the package for which dependencies are
+    being generated was published against.
+
+    'pkg_fmri' is the name of the package being resolved.  This can be None.
+
+    'pkg_name' is either the same as 'pkg_fmri', if 'pkg_fmri' is not None,
+    or it's the basename of the path to the manifest being resolved."""
+
+    def action_group_key(d):
+        """Return a key on which the tuples can be sorted and grouped
+        so that the groups match the duplicate actions that the code
+        in pkg.manifest notices."""
+
         # d is a tuple containing two items.  d[0] is the action.  d[1]
         # is the VariantCombination for this action.  The
         # VariantCombination isn't useful for our grouping needs.
-        try:
-                return d[0].attrs["predicate"], \
-                    d[0].attrs.get(path_id_prefix, '')
-        except KeyError:
-                raise RuntimeError("Expected this to have a predicate:{0}".format(
-                    d[0]))
 
-def __collapse_conditionals(deps):
-        """Under certain conditions, conditional dependencies can be transformed
-        into require-any or require dependencies.  This function is responsible
-        for performing the transformation.
+        # If we try to sort elements, containing on 'group-any' or
+        # 'require-any' dependency and elements, containing multiple
+        # dependencies, sort will try to compare string and list of
+        # strings. So, convert string to list.
+        type = d[0].attrs.get("type", "")
+        key_value = d[0].attrs.get(d[0].key_attr, id(d[0]))
 
-        The 'deps' parameter is a list of dependency action and
-        VariantCombination tuples."""
+        if type == "require-any" or type == "group-any":
+            if isinstance(key_value, str):
+                key_value = [key_value]
 
-        # Construct a dictionary which maps a package name to a list of
-        # dependencies which require that package.
-        req_dict = {}
-        for d, v in deps:
-                if d.attrs["type"] != "require":
-                        continue
-                t_pfmri = fmri.PkgFmri(d.attrs["fmri"])
-                req_dict.setdefault(t_pfmri.get_pkg_stem(include_scheme=False),
-                    []).append((t_pfmri, d, v))
+        return (
+            d[0].name,
+            d[0].attrs.get("type", None),
+            d[0].attrs.get("predicate", None),
+            key_value,
+        )
 
-        cond_deps = {}
-        preds_to_process = set()
-        for (predicate, path_id), group in itertools.groupby(sorted(
-            [(d, v) for d, v in deps if d.attrs["type"] == "conditional"],
-            key=__predicate_path_id_attrget), __predicate_path_id_attrget):
-                group = list(group)
-                cond_deps.setdefault(predicate, []).append((path_id, group))
-                preds_to_process.add(predicate)
+    def add_vars(d, d_vars, pkg_vars):
+        """Add the variants 'd_vars' to the dependency 'd', after
+        removing the variants matching those defined in 'pkg_vars'."""
 
-        new_req_deps = []
-
-        # While there are still require dependencies which might be used to
-        # transform a conditional dependency...
-        while preds_to_process:
-                # Pick a fmri which might be the predicate of a conditional
-                # dependency that could be collapsed.
-                predicate = preds_to_process.pop()
-                t_pfmri = fmri.PkgFmri(predicate)
-                t_name = t_pfmri.get_pkg_stem(include_scheme=False)
-                # If there are no require dependencies with that package name as
-                # a target, then there's nothing to do.
-                if t_name not in req_dict:
-                        continue
-                rel_reqs = []
-                # Only require dependencies whose fmri is a successor to the
-                # fmri under consideration are interesting.
-                for req_fmri, d, v in req_dict[t_name]:
-                        if req_fmri.is_successor(t_pfmri):
-                                rel_reqs.append((d, v))
-                if not rel_reqs:
-                        continue
-
-                new_group = []
-                for path_id, group in cond_deps.get(predicate, []):
-                        tmp_deps = []
-                        # Group all of the conditional dependencies inferred for
-                        # path_id by the variant combinations under which
-                        # they're valid.
-                        tmp_deps = group_by_variant_combinations(group)
-
-                        collapse_deps = []
-                        no_collapse = []
-                        # Separate the conditional dependencies into those that
-                        # can be collapsed and those that can't.  If a
-                        # conditional dependency intersects with any of the
-                        # relevant required dependencies found earlier, it can
-                        # be collapsed.
-                        for ds, v in tmp_deps:
-                                for req_d, req_v in rel_reqs:
-                                        only_tmp, intersect, only_req = \
-                                            v.separate_satisfied(req_v)
-                                        assert only_tmp or intersect or only_req
-                                        assert only_tmp or \
-                                            v.issubset(req_v, True)
-                                        assert only_req or v.issubset(v, True)
-                                        assert intersect or \
-                                            (only_tmp and only_req)
-                                        if intersect:
-                                                collapse_deps.append(
-                                                    (ds, intersect))
-                                        v = only_tmp
-                                        if v is None:
-                                                break
-                                if v is not None:
-                                        no_collapse.extend([(d, v) for d in ds])
-
-                        if no_collapse:
-                                new_group.append((path_id, no_collapse))
-
-                        # If path_id has no value, then these conditional
-                        # dependencies were not inferred links needed to reach a
-                        # file dependency.  In that case, the conditional
-                        # dependencies can be individually collapsed to require
-                        # dependencies but cannot be collapsed together into a
-                        # require-any dependency.
-                        if len(path_id) == 0:
-                                for ds, v in collapse_deps:
-                                        for d in ds:
-                                                res_dep = actions.depend.DependencyAction(**d.attrs)
-                                                del res_dep.attrs["predicate"]
-                                                res_dep.attrs["type"] = \
-                                                    "require"
-                                                new_req_deps.append(
-                                                    (res_dep, v))
-                                                # Since a new require dependency
-                                                # has been created, its possible
-                                                # that conditional dependencies
-                                                # could be collapsed using that,
-                                                # so add the fmri to the
-                                                # predicates to be processed.
-                                                preds_to_process.add(
-                                                    res_dep.attrs["fmri"])
-                                                t_pfmri = fmri.PkgFmri(
-                                                    d.attrs["fmri"])
-                                                req_dict.setdefault(
-                                                    t_pfmri.get_pkg_stem(
-                                                        include_scheme=False),
-                                                    []).append(
-                                                        (t_pfmri, res_dep, v))
-                                continue
-
-                        # Since path_id has a value, these conditional
-                        # dependencies were all inferred while trying to satisfy
-                        # a dependency on the same "file."  Since they all have
-                        # the same predicate, they must be collapsed into a
-                        # require-any dependency because each represents a valid
-                        # step through the link path to reach the dependened
-                        # upon file.
-                        for ds, v in collapse_deps:
-                                res_dep = actions.depend.DependencyAction(
-                                    **ds[0].attrs)
-                                for d in ds[1:]:
-                                        merge_deps(res_dep, d)
-                                d = ds[-1]
-                                res_dep.attrs["fmri"] = list(set(
-                                    res_dep.attrlist("fmri")))
-                                if len(res_dep.attrlist("fmri")) > 1:
-                                        res_dep.attrs["type"] = "require-any"
-                                else:
-                                        res_dep.attrs["type"] = "require"
-                                        res_dep.attrs["fmri"] = \
-                                            res_dep.attrs["fmri"][0]
-                                        # Since a new require dependency has
-                                        # been created, its possible that
-                                        # conditional dependencies could be
-                                        # collapsed using that, so add the fmri
-                                        # to the predicates to be processed.
-                                        preds_to_process.add(
-                                            res_dep.attrs["fmri"])
-                                        t_pfmri = fmri.PkgFmri(d.attrs["fmri"])
-                                        req_dict.setdefault(
-                                            t_pfmri.get_pkg_stem(
-                                                include_scheme=False),
-                                            []).append((t_pfmri, res_dep, v))
-                                del res_dep.attrs["predicate"]
-                                new_req_deps.append((res_dep, v))
-                # Now that all the new require dependencies have been removed,
-                # update the remaining conditional dependencies for this
-                # predicate.
-                if new_group:
-                        cond_deps[predicate] = new_group
-                elif predicate in cond_deps:
-                        del cond_deps[predicate]
-
-        # The result is the original non-conditional dependencies ...
-        res = [(d, v) for d, v in deps if d.attrs["type"] != "conditional"]
-        # plus the new require or require-any dependencies made by collapsing
-        # the conditional dependencies ...
-        res += new_req_deps
-        # plus the conditional dependencies that couldn't be collapsed.
-        for l in cond_deps.values():
-                for path_id, dep_pairs in l:
-                        res.extend(dep_pairs)
+        d_vars.simplify(pkg_vars)
+        res = []
+        for s in d_vars.sat_set:
+            attrs = d.attrs.copy()
+            attrs.update(s)
+            t = actions.depend.DependencyAction(**attrs)
+            t.consolidate_attrs()
+            res.append(t)
+        if not res:
+            d.consolidate_attrs()
+            res = [d]
         return res
 
-def __remove_unneeded_require_and_require_any(deps, pkg_fmri):
-        """Drop any unneeded require or require any dependencies and record any
-        dropped require-any dependencies which were inferred."""
+    # Transform conditional dependencies into require or require-any
+    # dependencies where possible.
+    res = __collapse_conditionals(deps)
 
-        res = []
-        omitted_req_any = {}
-        fmri_dict = {}
-        warnings = []
-        #
-        # We assume that the subsets are shorter than the supersets.
-        #
-        # Example:
-        # #1 depend fmri=a, fmri=b, fmri=c, type=require-any
-        # #2 depend fmri=a, fmri=b, type=require=any
-        # #2 is treated as a subset of #1
-        #
-        # Sort the dependencies by length to visit the subsets before the
-        # supersets.
-        #
-        for cur_dep, cur_vars in sorted(deps, key=lambda i: len(str(i))):
-                if cur_dep.attrs["type"] not in ("require", "require-any"):
-                        res.append((cur_dep, cur_vars))
-                        continue
+    errs = []
 
-                cur_fmris = []
-                for f in cur_dep.attrlist("fmri"):
-                        cur_fmris.append(fmri.PkgFmri(f))
-                skip = False
-                # If we're resolving a pkg with a known name ...
-                if pkg_fmri is not None:
-                        for pfmri in cur_fmris:
-                                # Then if this package is a successor to any of
-                                # the packages the dependency requires, then we
-                                # can omit the dependency.
-                                if pkg_fmri.is_successor(pfmri):
-                                        skip = True
-                if skip:
-                        continue
+    # Remove require dependencies on this package and require-any
+    # dependencies which are unneeded.
+    (
+        res,
+        omitted_require_any,
+        warnings,
+    ) = __remove_unneeded_require_and_require_any(res, pkg_fmri)
 
-                # If this dependency isn't a require-any dependency, then it
-                # should be included in the output.
-                if cur_dep.attrs["type"] != "require-any":
-                        res.append((cur_dep, cur_vars))
-                        continue
+    # Now remove all conditionals which are no longer needed.
+    res = __remove_extraneous_conditionals(res, omitted_require_any)
 
-                marked = False
-                # Now the require-any dependency is going to be compared to all
-                # the known require dependencies to see if it can be omitted.
-                # It can be omitted if one of the packages it requires is
-                # already required.  Because a require-any dependency could be
-                # omitted under some, but not all, variant combinations, the
-                # satisfied set of the variant combination of the require-any
-                # dependency is used for bookkeeping.  Each require dependency
-                # which has a successor to one of the packages in the
-                # require-any dependency marks the variant combinations under
-                # which it's valid as unsatisfied in the require-any dependency.
-                # At the end, if the require-any dependency is still satisfied
-                # under any variant combinations, then it's included in the
-                # result.
-                successors = []
-                for comp_dep, comp_vars in deps:
-                        if comp_dep.attrs["type"] != "require":
-                                continue
-                        successor = False
-                        comp_fmri = fmri.PkgFmri(comp_dep.attrs["fmri"])
-                        # Check to see whether the package required by the
-                        # require dependency is a successor to any of the
-                        # packages required by the require-any dependency.
-                        for c in cur_fmris:
-                                if comp_fmri.is_successor(c):
-                                        successor = True
-                                        break
-                        if not successor:
-                                continue
-                        # If comp_vars is empty, then no variants have been
-                        # declared for these packages, so having a matching
-                        # require dependency is enough to omit this require-any
-                        # dependency.
-                        only_cur, inter, only_comp = \
-                            cur_vars.separate_satisfied(comp_vars)
-                        if cur_vars.mark_as_unsatisfied(comp_vars) or \
-                            comp_vars.is_empty():
-                                marked = True
-                                successors.append((comp_fmri, inter))
-
-                # If one require-any dependency is the subset of the other
-                # require-any dependency, we should drop the superset because
-                # ultimately they should end up with the package dependency
-                # as the subset requires.
-                #
-                # Note that we only drop the deps we generate (with the
-                # pkgdepend.debug.depend.* prefix); we ignore the deps a
-                # developer added.
-                is_superset = False
-                if files_prefix in cur_dep.attrs or \
-                    fullpaths_prefix in cur_dep.attrs:
-                        # convert to a set for set operation
-                        cur_fmris_set = set(cur_fmris)
-                        for (comp_dep, comp_vars), comp_fmris_set in \
-                            six.iteritems(fmri_dict):
-                                if comp_fmris_set != cur_fmris_set and \
-                                    comp_fmris_set.issubset(cur_fmris_set) and \
-                                    cur_vars == comp_vars:
-                                        is_superset = True
-                                        drop_f = cur_fmris_set - comp_fmris_set
-                                        warnings.append(DropPackageWarning(
-                                            drop_f, comp_dep))
-                                        break
-                        if not is_superset:
-                                fmri_dict.setdefault((cur_dep, cur_vars),
-                                    cur_fmris_set)
-
-                # If the require-any dependency was never changed or is not a
-                # superset of any other require-any dependency, then include
-                # it.  If it was changed, check whether there are situations
-                # where the require-any dependency is needed.
-                if not marked and not is_superset:
-                        res.append((cur_dep, cur_vars))
-                        continue
-                if cur_vars.sat_set and not is_superset:
-                        res.append((cur_dep, cur_vars))
-                path_id = cur_dep.attrs.get(path_id_prefix, None)
-                if path_id:
-                        omitted_req_any[path_id] = successors
-
-        return res, omitted_req_any, warnings
-
-def __remove_extraneous_conditionals(deps, omitted_req_any):
-        """Remove conditional dependencies which other dependencies have made
-        unnecessary.  If an inferred require-any dependency was collapsed to a
-        require dependency, then only the conditional dependencies needed to
-        reach the require dependency should be retained."""
-
-        def fmri_attrget(d):
-                return fmri.PkgFmri(d[0].attrs["fmri"]).get_pkg_stem(
-                    include_scheme=False)
-
-        def path_id_attrget(d):
-                return d[0].attrs.get(path_id_prefix, '')
-
-        req_dict = {}
-        for target, group in itertools.groupby(sorted(
-            [(d, v) for d, v in deps if d.attrs["type"] == "require"],
-            key=fmri_attrget), fmri_attrget):
-                req_dict[target] = list(group)
-
-        needed_cond_deps = []
-        for path_id, group in itertools.groupby(sorted(
-            [(d, v) for d, v in deps if d.attrs["type"] == "conditional"],
-            key=path_id_attrget), path_id_attrget):
-                # Because of how the list was created, each dependency in
-                # successors is not satisfied under the same set of variant
-                # values as any other dependency in successors.
-                successors = omitted_req_any.get(path_id, [])
-                for d, v in group:
-                        # If this conditional dependency was part of a path to a
-                        # require-any dependency which was reduced to a require
-                        # dependency under some combinations of variants, then
-                        # make sure this conditional doesn't apply under those
-                        # combinations of variants.
-                        skip = False
-                        for s_d, s_v in successors:
-                                # If s_v is empty, then s_d applies under all
-                                # variant combinations.
-                                if s_v.is_empty():
-                                        skip = True
-                                        break
-                                v.mark_as_unsatisfied(s_v)
-                        if skip or (not v.is_empty() and not v.sat_set):
-                                continue
-
-                        # If this conditional dependency's fmri is also the fmri
-                        # of a require dependency, then it can be ignored under
-                        # those combinations of variants under which the require
-                        # dependency applies.
-                        d_fmri = fmri.PkgFmri(d.attrs["fmri"])
-                        for r_d, r_v in req_dict.get(d_fmri.get_pkg_stem(
-                            include_scheme=False), []):
-                                r_fmri = fmri.PkgFmri(r_d.attrs["fmri"])
-                                if not r_fmri.is_successor(d_fmri):
-                                        continue
-                                if r_v.is_empty():
-                                        skip = True
-                                        break
-                                v.mark_as_unsatisfied(r_v)
-                        if not skip and (v.is_empty() or v.sat_set):
-                                needed_cond_deps.append((d, v))
-
-        return [(d, v) for d, v in deps if d.attrs["type"] != "conditional"] + \
-            needed_cond_deps
-
-def combine(deps, pkg_vars, pkg_fmri, pkg_name):
-        """Combine duplicate dependency actions.
-
-        'deps' is a list of tuples. Each tuple contains a dependency action and
-        the variants associated with that dependency.
-
-        'pkg_vars' are the variants that the package for which dependencies are
-        being generated was published against.
-
-        'pkg_fmri' is the name of the package being resolved.  This can be None.
-
-        'pkg_name' is either the same as 'pkg_fmri', if 'pkg_fmri' is not None,
-        or it's the basename of the path to the manifest being resolved."""
-
-        def action_group_key(d):
-                """Return a key on which the tuples can be sorted and grouped
-                so that the groups match the duplicate actions that the code
-                in pkg.manifest notices."""
-
-                # d is a tuple containing two items.  d[0] is the action.  d[1]
-                # is the VariantCombination for this action.  The
-                # VariantCombination isn't useful for our grouping needs.
-
-                # If we try to sort elements, containing on 'group-any' or
-                # 'require-any' dependency and elements, containing multiple
-                # dependencies, sort will try to compare string and list of
-                # strings. So, convert string to list.
-                type = d[0].attrs.get("type", "")
-                key_value = d[0].attrs.get(d[0].key_attr, id(d[0]))
-
-                if type == 'require-any' or type == 'group-any':
-                    if isinstance(key_value, str):
-                        key_value = [ key_value ]
-
-                return d[0].name, d[0].attrs.get("type", None), \
-                    d[0].attrs.get("predicate", None), \
-                    key_value
-
-        def add_vars(d, d_vars, pkg_vars):
-                """Add the variants 'd_vars' to the dependency 'd', after
-                removing the variants matching those defined in 'pkg_vars'."""
-
-                d_vars.simplify(pkg_vars)
-                res = []
-                for s in d_vars.sat_set:
-                        attrs = d.attrs.copy()
-                        attrs.update(s)
-                        t = actions.depend.DependencyAction(**attrs)
-                        t.consolidate_attrs()
-                        res.append(t)
-                if not res:
-                        d.consolidate_attrs()
-                        res = [d]
-                return res
-
-        # Transform conditional dependencies into require or require-any
-        # dependencies where possible.
-        res = __collapse_conditionals(deps)
-
-        errs = []
-
-        # Remove require dependencies on this package and require-any
-        # dependencies which are unneeded.
-        res, omitted_require_any, warnings = \
-            __remove_unneeded_require_and_require_any(res, pkg_fmri)
-
-        # Now remove all conditionals which are no longer needed.
-        res = __remove_extraneous_conditionals(res, omitted_require_any)
-
-        # There are certain dependency relationships between packages that the
-        # current dependency types can't properly represent.  One is the case
-        # where if A is present then either B or C must be installed.  In this
-        # situation, find_package_using_delivered_files will have inferred a
-        # conditional dependency on B if A is present and another one on C if A
-        # is present.  The following code detects this situation and provides an
-        # error to the user.
-        conflicts = []
-        for (predicate, path_id), group in itertools.groupby(sorted(
+    # There are certain dependency relationships between packages that the
+    # current dependency types can't properly represent.  One is the case
+    # where if A is present then either B or C must be installed.  In this
+    # situation, find_package_using_delivered_files will have inferred a
+    # conditional dependency on B if A is present and another one on C if A
+    # is present.  The following code detects this situation and provides an
+    # error to the user.
+    conflicts = []
+    for (predicate, path_id), group in itertools.groupby(
+        sorted(
             [(d, v) for d, v in res if d.attrs["type"] == "conditional"],
-            key=__predicate_path_id_attrget), __predicate_path_id_attrget):
-                if len(path_id) == 0:
-                        continue
-                group = list(group)
-                for i, (d1, v1) in enumerate(group):
-                        for d2, v2 in group[i + 1:]:
-                                only_v1, inter, only_v2 = \
-                                    v1.separate_satisfied(v2)
-                                # If the variant tag of the two conditional
-                                # depend actions are different, 'inter', their
-                                # variant combinations intersection is empty,
-                                # and the two depend actions are different.
-                                # Since only depend actions that have non-empty
-                                # variant combination intersection are
-                                # considered to be conflicts, we thus need to
-                                # check whether 'inter' is None or not.
-                                if inter is not None and \
-                                    (inter.is_empty() or inter.sat_set) and \
-                                    d1.attrs["fmri"] != d2.attrs["fmri"]:
-                                        conflicts.append((d1, d2, inter))
-        if conflicts:
-                errs.append(NeedConditionalRequireAny(conflicts, pkg_vars))
+            key=__predicate_path_id_attrget,
+        ),
+        __predicate_path_id_attrget,
+    ):
+        if len(path_id) == 0:
+            continue
+        group = list(group)
+        for i, (d1, v1) in enumerate(group):
+            for d2, v2 in group[i + 1 :]:
+                only_v1, inter, only_v2 = v1.separate_satisfied(v2)
+                # If the variant tag of the two conditional
+                # depend actions are different, 'inter', their
+                # variant combinations intersection is empty,
+                # and the two depend actions are different.
+                # Since only depend actions that have non-empty
+                # variant combination intersection are
+                # considered to be conflicts, we thus need to
+                # check whether 'inter' is None or not.
+                if (
+                    inter is not None
+                    and (inter.is_empty() or inter.sat_set)
+                    and d1.attrs["fmri"] != d2.attrs["fmri"]
+                ):
+                    conflicts.append((d1, d2, inter))
+    if conflicts:
+        errs.append(NeedConditionalRequireAny(conflicts, pkg_vars))
 
-        # For each group of dependencies (g) for a particular fmri (k) merge
-        # together depedencies on the same fmri with different variants.
-        new_res = []
-        for k, group in itertools.groupby(sorted(res, key=action_group_key),
-            action_group_key):
-                group = list(group)
-                res_dep = group[0][0]
-                res_vars = variants.VariantCombinations(pkg_vars, False)
-                for cur_dep, cur_vars in group:
-                        merge_deps(res_dep, cur_dep)
-                        res_vars.mark_as_satisfied(cur_vars)
-                new_res.append((res_dep, res_vars))
-        res = new_res
+    # For each group of dependencies (g) for a particular fmri (k) merge
+    # together depedencies on the same fmri with different variants.
+    new_res = []
+    for k, group in itertools.groupby(
+        sorted(res, key=action_group_key), action_group_key
+    ):
+        group = list(group)
+        res_dep = group[0][0]
+        res_vars = variants.VariantCombinations(pkg_vars, False)
+        for cur_dep, cur_vars in group:
+            merge_deps(res_dep, cur_dep)
+            res_vars.mark_as_satisfied(cur_vars)
+        new_res.append((res_dep, res_vars))
+    res = new_res
 
-        # Merge the variant information into the depend action.
-        new_res = []
-        for d, vc in res:
-                new_res.extend(add_vars(d, vc, pkg_vars))
-        res = new_res
+    # Merge the variant information into the depend action.
+    new_res = []
+    for d, vc in res:
+        new_res.extend(add_vars(d, vc, pkg_vars))
+    res = new_res
 
-        return res, errs, warnings
+    return res, errs, warnings
+
 
 def split_off_variants(dep, pkg_vars, satisfied=False):
-        """Take a dependency which may be tagged with variants and move those
-        tags into a VariantSet."""
+    """Take a dependency which may be tagged with variants and move those
+    tags into a VariantSet."""
 
-        dep_vars = dep.get_variant_template()
-        if not dep_vars.issubset(pkg_vars):
-                raise __NotSubset(dep_vars.difference(pkg_vars))
-        dep_vars.merge_unknown(pkg_vars)
-        # Since all variant information is being kept in the above VariantSets,
-        # remove the variant information from the action.  This prevents
-        # confusion about which is the authoritative source of information.
-        dep.strip_variants()
-        return dep, variants.VariantCombinations(dep_vars, satisfied=satisfied)
+    dep_vars = dep.get_variant_template()
+    if not dep_vars.issubset(pkg_vars):
+        raise __NotSubset(dep_vars.difference(pkg_vars))
+    dep_vars.merge_unknown(pkg_vars)
+    # Since all variant information is being kept in the above VariantSets,
+    # remove the variant information from the action.  This prevents
+    # confusion about which is the authoritative source of information.
+    dep.strip_variants()
+    return dep, variants.VariantCombinations(dep_vars, satisfied=satisfied)
+
 
 def prune_debug_attrs(action):
-        """Given a dependency action with pkg.debug.depend attributes
-        return a matching action with those attributes removed"""
+    """Given a dependency action with pkg.debug.depend attributes
+    return a matching action with those attributes removed"""
 
-        attrs = dict((k, v) for k, v in six.iteritems(action.attrs)
-                     if not k.startswith(base.Dependency.DEPEND_DEBUG_PREFIX))
-        return actions.depend.DependencyAction(**attrs)
+    attrs = dict(
+        (k, v)
+        for k, v in six.iteritems(action.attrs)
+        if not k.startswith(base.Dependency.DEPEND_DEBUG_PREFIX)
+    )
+    return actions.depend.DependencyAction(**attrs)
+
 
 # In order to resolve dependencies, we build a mapping of all files and
 # symlinks delivered by installed packages. To reduce the size of that working
@@ -1623,335 +1721,379 @@ def prune_debug_attrs(action):
 # because we don't implement a dependency parser for it (e.g. perl).
 
 skip_prefix = (
-        'usr/share/man',
-        'opt/ooce/share/man',
+    "usr/share/man",
+    "opt/ooce/share/man",
 )
 
 skip_suffix = (
-        '.json', '.toml', '.txt', '.html',
-        '.mf', '.p5m',
-        '.png', '.jpg', '.gif',
-        '.pdf',
-        '.pl', '.pm',
-        '.h', '.c',
-        '.rs', '.go', '.js', '.d', '.lua', '.zig', '.rb', '.m4',
-        '.gz', '.zip',
-        '.cmake',
-        '.rst',
-        '.mo',
-        '.vim',
-        '.elc',
-        '.hpp',
-        # texinfo
-        '.tex', '.eps', '.ltx', '.def', '.md', '.ins', '.otf', '.tikz', '.dtx',
-        '.afm', '.fd', '.enc', '.sty', '.pfb', '.htf', '.vf', '.tfm',
-
+    ".json",
+    ".toml",
+    ".txt",
+    ".html",
+    ".mf",
+    ".p5m",
+    ".png",
+    ".jpg",
+    ".gif",
+    ".pdf",
+    ".pl",
+    ".pm",
+    ".h",
+    ".c",
+    ".rs",
+    ".go",
+    ".js",
+    ".d",
+    ".lua",
+    ".zig",
+    ".rb",
+    ".m4",
+    ".gz",
+    ".zip",
+    ".cmake",
+    ".rst",
+    ".mo",
+    ".vim",
+    ".elc",
+    ".hpp",
+    # texinfo
+    ".tex",
+    ".eps",
+    ".ltx",
+    ".def",
+    ".md",
+    ".ins",
+    ".otf",
+    ".tikz",
+    ".dtx",
+    ".afm",
+    ".fd",
+    ".enc",
+    ".sty",
+    ".pfb",
+    ".htf",
+    ".vf",
+    ".tfm",
 )
 
-def add_fmri_path_mapping(files_dict, links_dict, pfmri, mfst,
-    distro_vars=None, use_template=False):
-        """Add mappings from path names to FMRIs and variants.
 
-        'files_dict' is a dictionary which maps package identity to the files
-        the package delivers and the variants under which each file is
-        present.
+def add_fmri_path_mapping(
+    files_dict, links_dict, pfmri, mfst, distro_vars=None, use_template=False
+):
+    """Add mappings from path names to FMRIs and variants.
 
-        'links_dict' is a dictionary which maps package identity to the links
-        the package delivers and the variants under which each link is
-        present.
+    'files_dict' is a dictionary which maps package identity to the files
+    the package delivers and the variants under which each file is
+    present.
 
-        'pfmri' is the FMRI of the current manifest.
+    'links_dict' is a dictionary which maps package identity to the links
+    the package delivers and the variants under which each link is
+    present.
 
-        'mfst' is the manifest to process.
+    'pfmri' is the FMRI of the current manifest.
 
-        'distro_vars' is a VariantCombinationTemplate which contains all the
-        variant types and values known.
+    'mfst' is the manifest to process.
 
-        'use_template is a boolean which indicates whether to fill the
-        dictionaries with VariantCombinationTemplates instead of
-        VariantCombinations."""
+    'distro_vars' is a VariantCombinationTemplate which contains all the
+    variant types and values known.
 
-        def filter(action):
-                path = action.attrs['path']
-                if path.startswith(skip_prefix):
-                        return True
-                if path.endswith(skip_suffix):
-                        return True
-                return False
+    'use_template is a boolean which indicates whether to fill the
+    dictionaries with VariantCombinationTemplates instead of
+    VariantCombinations."""
 
-        assert not distro_vars or not use_template
+    def filter(action):
+        path = action.attrs["path"]
+        if path.startswith(skip_prefix):
+            return True
+        if path.endswith(skip_suffix):
+            return True
+        return False
+
+    assert not distro_vars or not use_template
+    if not use_template:
+        pvariants = mfst.get_all_variants()
+        if distro_vars:
+            pvariants.merge_unknown(distro_vars)
+
+    for f in mfst.gen_actions_by_type("file"):
+        if filter(f):
+            continue
+        vc = f.get_variant_template()
         if not use_template:
-                pvariants = mfst.get_all_variants()
-                if distro_vars:
-                        pvariants.merge_unknown(distro_vars)
+            vc.merge_unknown(pvariants)
+            vc = variants.VariantCombinations(vc, satisfied=True)
+        files_dict.setdefault(f.attrs["path"], []).append((pfmri, vc))
+    for f in itertools.chain(
+        mfst.gen_actions_by_type("hardlink"), mfst.gen_actions_by_type("link")
+    ):
+        if filter(f):
+            continue
+        vc = f.get_variant_template()
+        if not use_template:
+            vc.merge_unknown(pvariants)
+            vc = variants.VariantCombinations(vc, satisfied=True)
+        links_dict.setdefault(f.attrs["path"], []).append(
+            (pfmri, vc, f.attrs["target"])
+        )
 
-        for f in mfst.gen_actions_by_type("file"):
-                if filter(f): continue
-                vc = f.get_variant_template()
-                if not use_template:
-                        vc.merge_unknown(pvariants)
-                        vc = variants.VariantCombinations(vc,
-                            satisfied=True)
-                files_dict.setdefault(f.attrs["path"], []).append(
-                    (pfmri, vc))
-        for f in itertools.chain(mfst.gen_actions_by_type("hardlink"),
-             mfst.gen_actions_by_type("link")):
-                if filter(f): continue
-                vc = f.get_variant_template()
-                if not use_template:
-                        vc.merge_unknown(pvariants)
-                        vc = variants.VariantCombinations(vc,
-                            satisfied=True)
-                links_dict.setdefault(f.attrs["path"], []).append(
-                    (pfmri, vc, f.attrs["target"]))
 
 def __safe_fmri_parse(txt):
-        dep_name = None
-        try:
-                dep_name = fmri.PkgFmri(txt).pkg_name
-        except fmri.IllegalFmri:
-                pass
-        return dep_name
+    dep_name = None
+    try:
+        dep_name = fmri.PkgFmri(txt).pkg_name
+    except fmri.IllegalFmri:
+        pass
+    return dep_name
+
 
 def resolve_deps(manifest_paths, api_inst, system_patterns, prune_attrs=False):
-        """For each manifest given, resolve the file dependencies to package
-        dependencies. It returns a mapping from manifest_path to a list of
-        dependencies and a list of unresolved dependencies.
+    """For each manifest given, resolve the file dependencies to package
+    dependencies. It returns a mapping from manifest_path to a list of
+    dependencies and a list of unresolved dependencies.
 
-        'manifest_paths' is a list of paths to the manifests being resolved.
+    'manifest_paths' is a list of paths to the manifests being resolved.
 
-        'api_inst' is an ImageInterface which references the current image.
+    'api_inst' is an ImageInterface which references the current image.
 
-        'system_patterns' is a list of patterns which determines the system
-        packages that are resolved against.
+    'system_patterns' is a list of patterns which determines the system
+    packages that are resolved against.
 
-        'prune_attrs' is a boolean indicating whether debugging
-        attributes should be stripped from returned actions."""
+    'prune_attrs' is a boolean indicating whether debugging
+    attributes should be stripped from returned actions."""
 
-        # The variable 'manifests' is a list of 5-tuples. The first element
-        # of the tuple is the path to the manifest. The second is the name of
-        # the package contained in the manifest. The third is the manifest
-        # object for the manifest in that location. The fourth is the list of
-        # variants the package was published against. The fifth is the list of
-        # files referenced in the manifest that couldn't be found.
-        manifests = [
-            (mp, choose_name(mp, mfst), mfst, mfst.get_all_variants(),
-            manifest_errs)
-            for mp, (mfst, manifest_errs) in
-            ((mp, __make_manifest(mp, load_data=False))
-            for mp in manifest_paths)
+    # The variable 'manifests' is a list of 5-tuples. The first element
+    # of the tuple is the path to the manifest. The second is the name of
+    # the package contained in the manifest. The third is the manifest
+    # object for the manifest in that location. The fourth is the list of
+    # variants the package was published against. The fifth is the list of
+    # files referenced in the manifest that couldn't be found.
+    manifests = [
+        (
+            mp,
+            choose_name(mp, mfst),
+            mfst,
+            mfst.get_all_variants(),
+            manifest_errs,
+        )
+        for mp, (mfst, manifest_errs) in (
+            (mp, __make_manifest(mp, load_data=False)) for mp in manifest_paths
+        )
+    ]
+
+    files = Entries({}, {})
+    links = {}
+
+    # This records all the variants used in any package known.  It is used
+    # to ensure that all packages live in the same variant universe for
+    # purposes of dependency resolution.
+    distro_vars = variants.VariantCombinationTemplate()
+
+    resolving_pkgs = set()
+
+    for mp, (name, pfmri), mfst, pkg_vars, miss_files in manifests:
+        distro_vars.merge_values(pkg_vars)
+        try:
+            if pfmri is None:
+                pfmri = fmri.PkgFmri(name)
+        except fmri.IllegalFmri as e:
+            raise BadPackageFmri(mp, e)
+        resolving_pkgs.add(pfmri.pkg_name)
+
+    def __merge_actvct_with_pkgvct(act_vct, pkg_vct):
+        act_vct.merge_unknown(pkg_vct)
+        return variants.VariantCombinations(act_vct, satisfied=True)
+
+    sys_fmris = set()
+    unmatched_patterns = set()
+    if system_patterns:
+        pkg_list = api_inst.get_pkg_list(
+            api.ImageInterface.LIST_INSTALLED,
+            patterns=system_patterns,
+            raise_unmatched=True,
+        )
+        tmp_files = {}
+        tmp_links = {}
+        package_vars = {}
+        pkg_cnt = 0
+        # Gather information from installed packages
+        # Because get_pkg_list returns a generator, the
+        # InventoryException raised when a pattern has no matches isn't
+        # raised until all the matching patterns have been iterated
+        # over.
+        try:
+            for (pub, stem, ver), summ, cats, states, attrs in pkg_list:
+                # If this package is being resolved, then that's
+                # the information to use.
+                if stem in resolving_pkgs:
+                    continue
+                # To get the manifest, we need an fmri with a
+                # publisher because we need to be able to check
+                # if the package is installed.
+                pfmri = fmri.PkgFmri(publisher=pub, name=stem, version=ver)
+                mfst = api_inst.get_manifest(pfmri, all_variants=True)
+                # But we don't want fmris with publishers as
+                # targets of dependencies, so remove the
+                # publisher.
+                pfmri.publisher = None
+                sys_fmris.add(pfmri.pkg_name)
+                distro_vars.merge_values(mfst.get_all_variants())
+                package_vars[stem] = mfst.get_all_variants()
+                add_fmri_path_mapping(
+                    tmp_files, tmp_links, pfmri, mfst, use_template=True
+                )
+                pkg_cnt += 1
+        except apx.InventoryException as e:
+            # If "*" didn't match any packages, then the image was
+            # empty.
+            try:
+                e.notfound.remove("*")
+            except ValueError:
+                pass
+            unmatched_patterns.update(e.notfound)
+        del pkg_list
+        # Move all package variants into the same universe.
+        for pkg_vct in package_vars.values():
+            pkg_vct.merge_unknown(distro_vars)
+        # Populate the installed files dictionary.
+        for pth, l in six.iteritems(tmp_files):
+            new_val = [
+                (p, __merge_actvct_with_pkgvct(tmpl, package_vars[p.pkg_name]))
+                for (p, tmpl) in l
+            ]
+            files.installed[pth] = new_val
+        del tmp_files
+
+        # Populate the link dictionary using the installed packages'
+        # information.
+        for pth, l in six.iteritems(tmp_links):
+            new_val = [
+                (
+                    p,
+                    __merge_actvct_with_pkgvct(tmpl, package_vars[p.pkg_name]),
+                    target,
+                )
+                for (p, tmpl, target) in l
+            ]
+            links[pth] = new_val
+        del tmp_links
+        del package_vars
+
+    res_fmris = set()
+    # Build a list of all files delivered in the manifests being resolved.
+    for mp, (name, pfmri), mfst, pkg_vars, miss_files in manifests:
+        try:
+            if pfmri is None:
+                pfmri = fmri.PkgFmri(name)
+        except fmri.IllegalFmri as e:
+            raise BadPackageFmri(mp, e)
+        add_fmri_path_mapping(files.delivered, links, pfmri, mfst, distro_vars)
+        res_fmris.add(pfmri.pkg_name)
+
+    pkg_deps = {}
+    errs = []
+    warnings = []
+    external_deps = set()
+    for mp, (name, pfmri), mfst, pkg_vars, manifest_errs in manifests:
+        name_to_use = pfmri or name
+        # The add_fmri_path_mapping function moved the actions it found
+        # into the distro_vars universe of variants, so we need to move
+        # pkg_vars (and by extension the variants on depend actions)
+        # into that universe too.
+        pkg_vars.merge_unknown(distro_vars)
+        errs.extend(manifest_errs)
+        if mfst is None:
+            pkg_deps[mp] = None
+            continue
+        ds = []
+        bad_ds = {}
+        for d in mfst.gen_actions_by_type("depend"):
+            if not is_file_dependency(d):
+                continue
+            try:
+                r = split_off_variants(d, pkg_vars)
+                ds.append(r)
+            except __NotSubset as e:
+                diff = bad_ds.setdefault(
+                    d.attrs[reason_prefix], variants.VCTDifference(set(), set())
+                )
+                diff.type_diffs.update(e.diff.type_diffs)
+                diff.value_diffs.update(e.diff.value_diffs)
+        if bad_ds:
+            errs.append(ExtraVariantedDependency(name_to_use, bad_ds, False))
+
+        pkg_res = [
+            (
+                d,
+                find_package(
+                    files, links, d, d_vars, pkg_vars, bool(system_patterns)
+                ),
+            )
+            for d, d_vars in ds
         ]
 
-        files = Entries({}, {})
-        links = {}
+        # Seed the final results with those dependencies defined
+        # manually.
+        deps = []
+        bad_deps = {}
+        for d in mfst.gen_actions_by_type("depend"):
+            if is_file_dependency(d):
+                continue
+            try:
+                r = split_off_variants(d, pkg_vars, satisfied=True)
+                deps.append(r)
+            except __NotSubset as e:
+                diff = bad_deps.setdefault(
+                    d.attrs.get("fmri", None),
+                    variants.VCTDifference(set(), set()),
+                )
+                diff.type_diffs.update(e.diff.type_diffs)
+                diff.value_diffs.update(e.diff.value_diffs)
+        if bad_deps:
+            errs.append(ExtraVariantedDependency(name_to_use, bad_deps, True))
 
-        # This records all the variants used in any package known.  It is used
-        # to ensure that all packages live in the same variant universe for
-        # purposes of dependency resolution.
-        distro_vars = variants.VariantCombinationTemplate()
+        for file_dep, (res, dep_vars, pkg_errs) in pkg_res:
+            for e in pkg_errs:
+                if hasattr(e, "pkg_name"):
+                    e.pkg_name = name_to_use
+            errs.extend(pkg_errs)
+            dep_vars.simplify(pkg_vars)
+            if not res:
+                errs.append(UnresolvedDependencyError(mp, file_dep, dep_vars))
+            else:
+                deps.extend(res)
+                if not dep_vars.is_satisfied():
+                    errs.append(
+                        UnresolvedDependencyError(mp, file_dep, dep_vars)
+                    )
+        # Add variant information to the dependency actions and combine
+        # what would otherwise be duplicate dependencies.
+        deps, combine_errs, combine_warnings = combine(
+            deps, pkg_vars, pfmri, name_to_use
+        )
+        errs.extend(combine_errs)
+        warnings.extend(combine_warnings)
 
-        resolving_pkgs = set()
+        ext_pfmris = [
+            pkg_name
+            for pkg_name in (
+                __safe_fmri_parse(pfmri)
+                for a in deps
+                for pfmri in a.attrlist("fmri")
+                if a.attrs["type"] in ("conditional", "require", "require-any")
+            )
+            if pkg_name is not None
+            if pkg_name not in res_fmris
+        ]
+        external_deps.update(ext_pfmris)
+        sys_fmris.difference_update(ext_pfmris)
 
-        for mp, (name, pfmri), mfst, pkg_vars, miss_files in manifests:
-                distro_vars.merge_values(pkg_vars)
-                try:
-                        if pfmri is None:
-                                pfmri = fmri.PkgFmri(name)
-                except fmri.IllegalFmri as e:
-                        raise BadPackageFmri(mp, e)
-                resolving_pkgs.add(pfmri.pkg_name)
+        if prune_attrs:
+            deps = [prune_debug_attrs(d) for d in deps]
+        pkg_deps[mp] = deps
 
-        def __merge_actvct_with_pkgvct(act_vct, pkg_vct):
-                act_vct.merge_unknown(pkg_vct)
-                return variants.VariantCombinations(act_vct, satisfied=True)
+    sys_fmris.update(unmatched_patterns)
+    return pkg_deps, errs, warnings, sys_fmris, external_deps
 
-        sys_fmris = set()
-        unmatched_patterns = set()
-        if system_patterns:
-                pkg_list = api_inst.get_pkg_list(
-                        api.ImageInterface.LIST_INSTALLED,
-                        patterns=system_patterns, raise_unmatched=True)
-                tmp_files = {}
-                tmp_links = {}
-                package_vars = {}
-                pkg_cnt = 0
-                # Gather information from installed packages
-                # Because get_pkg_list returns a generator, the
-                # InventoryException raised when a pattern has no matches isn't
-                # raised until all the matching patterns have been iterated
-                # over.
-                try:
-                        for (pub, stem, ver), summ, cats, states, attrs in \
-                            pkg_list:
-                                # If this package is being resolved, then that's
-                                # the information to use.
-                                if stem in resolving_pkgs:
-                                        continue
-                                # To get the manifest, we need an fmri with a
-                                # publisher because we need to be able to check
-                                # if the package is installed.
-                                pfmri = fmri.PkgFmri(publisher=pub, name=stem,
-                                    version=ver)
-                                mfst = api_inst.get_manifest(pfmri,
-                                    all_variants=True)
-                                # But we don't want fmris with publishers as
-                                # targets of dependencies, so remove the
-                                # publisher.
-                                pfmri.publisher = None
-                                sys_fmris.add(pfmri.pkg_name)
-                                distro_vars.merge_values(
-                                    mfst.get_all_variants())
-                                package_vars[stem] = mfst.get_all_variants()
-                                add_fmri_path_mapping(tmp_files, tmp_links,
-                                    pfmri, mfst, use_template=True)
-                                pkg_cnt += 1
-                except apx.InventoryException as e:
-                        # If "*" didn't match any packages, then the image was
-                        # empty.
-                        try:
-                                e.notfound.remove("*")
-                        except ValueError:
-                                pass
-                        unmatched_patterns.update(e.notfound)
-                del pkg_list
-                # Move all package variants into the same universe.
-                for pkg_vct in package_vars.values():
-                        pkg_vct.merge_unknown(distro_vars)
-                # Populate the installed files dictionary.
-                for pth, l in six.iteritems(tmp_files):
-                        new_val = [
-                            (p, __merge_actvct_with_pkgvct(tmpl,
-                                package_vars[p.pkg_name]))
-                            for (p, tmpl) in l
-                        ]
-                        files.installed[pth] = new_val
-                del tmp_files
-
-                # Populate the link dictionary using the installed packages'
-                # information.
-                for pth, l in six.iteritems(tmp_links):
-                        new_val = [
-                            (p, __merge_actvct_with_pkgvct(tmpl,
-                                package_vars[p.pkg_name]), target)
-                            for (p, tmpl, target) in l
-                        ]
-                        links[pth] = new_val
-                del tmp_links
-                del package_vars
-
-        res_fmris = set()
-        # Build a list of all files delivered in the manifests being resolved.
-        for mp, (name, pfmri), mfst, pkg_vars, miss_files in manifests:
-                try:
-                        if pfmri is None:
-                                pfmri = fmri.PkgFmri(name)
-                except fmri.IllegalFmri as e:
-                        raise BadPackageFmri(mp, e)
-                add_fmri_path_mapping(files.delivered, links, pfmri, mfst,
-                    distro_vars)
-                res_fmris.add(pfmri.pkg_name)
-
-        pkg_deps = {}
-        errs = []
-        warnings = []
-        external_deps = set()
-        for mp, (name, pfmri), mfst, pkg_vars, manifest_errs in manifests:
-                name_to_use = pfmri or name
-                # The add_fmri_path_mapping function moved the actions it found
-                # into the distro_vars universe of variants, so we need to move
-                # pkg_vars (and by extension the variants on depend actions)
-                # into that universe too.
-                pkg_vars.merge_unknown(distro_vars)
-                errs.extend(manifest_errs)
-                if mfst is None:
-                        pkg_deps[mp] = None
-                        continue
-                ds = []
-                bad_ds = {}
-                for d in mfst.gen_actions_by_type("depend"):
-                        if not is_file_dependency(d):
-                                continue
-                        try:
-                                r = split_off_variants(d, pkg_vars)
-                                ds.append(r)
-                        except __NotSubset as e:
-                                diff = bad_ds.setdefault(d.attrs[reason_prefix],
-                                    variants.VCTDifference(set(), set()))
-                                diff.type_diffs.update(e.diff.type_diffs)
-                                diff.value_diffs.update(e.diff.value_diffs)
-                if bad_ds:
-                        errs.append(ExtraVariantedDependency(name_to_use,
-                            bad_ds, False))
-
-                pkg_res = [
-                    (d, find_package(files, links, d, d_vars, pkg_vars,
-                        bool(system_patterns)))
-                    for d, d_vars in ds
-                ]
-
-                # Seed the final results with those dependencies defined
-                # manually.
-                deps = []
-                bad_deps = {}
-                for d in mfst.gen_actions_by_type("depend"):
-                        if is_file_dependency(d):
-                                continue
-                        try:
-                                r = split_off_variants(d, pkg_vars,
-                                    satisfied=True)
-                                deps.append(r)
-                        except __NotSubset as e:
-                                diff = bad_deps.setdefault(
-                                    d.attrs.get("fmri", None),
-                                    variants.VCTDifference(set(), set()))
-                                diff.type_diffs.update(e.diff.type_diffs)
-                                diff.value_diffs.update(e.diff.value_diffs)
-                if bad_deps:
-                        errs.append(ExtraVariantedDependency(name_to_use,
-                            bad_deps, True))
-
-                for file_dep, (res, dep_vars, pkg_errs) in pkg_res:
-                        for e in pkg_errs:
-                                if hasattr(e, "pkg_name"):
-                                        e.pkg_name = name_to_use
-                        errs.extend(pkg_errs)
-                        dep_vars.simplify(pkg_vars)
-                        if not res:
-                                errs.append(UnresolvedDependencyError(mp,
-                                    file_dep, dep_vars))
-                        else:
-                                deps.extend(res)
-                                if not dep_vars.is_satisfied():
-                                        errs.append(UnresolvedDependencyError(
-                                            mp, file_dep, dep_vars))
-                # Add variant information to the dependency actions and combine
-                # what would otherwise be duplicate dependencies.
-                deps, combine_errs, combine_warnings = combine(deps, pkg_vars,
-                    pfmri, name_to_use)
-                errs.extend(combine_errs)
-                warnings.extend(combine_warnings)
-
-                ext_pfmris = [
-                    pkg_name
-                    for pkg_name in (
-                                 __safe_fmri_parse(pfmri)
-                                 for a in deps
-                                 for pfmri in a.attrlist("fmri")
-                                 if a.attrs["type"] in
-                                 ("conditional", "require", "require-any")
-                             )
-                    if pkg_name is not None
-                    if pkg_name not in res_fmris
-                ]
-                external_deps.update(ext_pfmris)
-                sys_fmris.difference_update(ext_pfmris)
-
-                if prune_attrs:
-                        deps = [prune_debug_attrs(d) for d in deps]
-                pkg_deps[mp] = deps
-
-        sys_fmris.update(unmatched_patterns)
-        return pkg_deps, errs, warnings, sys_fmris, external_deps
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/publish/transaction.py
+++ b/src/modules/publish/transaction.py
@@ -41,729 +41,840 @@ import pkg.digest as digest
 
 # If elf module is supported, we will extract ELF information.
 try:
-        import pkg.elf as elf
-        haveelf = True
+    import pkg.elf as elf
+
+    haveelf = True
 except ImportError:
-        haveelf = False
+    haveelf = False
 import pkg.misc as misc
 import pkg.portable.util as os_util
 import pkg.server.repository as sr
 import pkg.client.api_errors as apx
 
+
 class TransactionError(Exception):
-        """Base exception class for all Transaction exceptions."""
+    """Base exception class for all Transaction exceptions."""
 
-        def __init__(self, *args, **kwargs):
-                Exception.__init__(self, *args)
-                if args:
-                        self.data = args[0]
-                self._args = kwargs
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args)
+        if args:
+            self.data = args[0]
+        self._args = kwargs
 
-        def __str__(self):
-                return str(self.data)
+    def __str__(self):
+        return str(self.data)
 
 
 class TransactionRepositoryConfigError(TransactionError):
-        """Used to indicate that the configuration information for the
-        destination repository is invalid or is missing required values."""
+    """Used to indicate that the configuration information for the
+    destination repository is invalid or is missing required values."""
 
 
 class TransactionRepositoryURLError(TransactionError):
-        """Used to indicate the specified repository URL is not valid or is not
-        supported (e.g. because of the scheme).
+    """Used to indicate the specified repository URL is not valid or is not
+    supported (e.g. because of the scheme).
 
-        The first argument, when initializing the class, should be the URL."""
+    The first argument, when initializing the class, should be the URL."""
 
-        def __init__(self, *args, **kwargs):
-                TransactionError.__init__(self, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        TransactionError.__init__(self, *args, **kwargs)
 
-        def __str__(self):
-                if "scheme" in self._args:
-                        return _("Unsupported scheme '{scheme}' in URL: "
-                            "'{url}'.").format(scheme=self._args["scheme"],
-                            url=self.data)
-                elif "netloc" in self._args:
-                        return _("Malformed URL: '{0}'.").format(self.data)
-                return _("Invalid repository URL: '{url}': {msg}").format(
-                    url=self.data, msg=self._args.get("msg", ""))
+    def __str__(self):
+        if "scheme" in self._args:
+            return _(
+                "Unsupported scheme '{scheme}' in URL: " "'{url}'."
+            ).format(scheme=self._args["scheme"], url=self.data)
+        elif "netloc" in self._args:
+            return _("Malformed URL: '{0}'.").format(self.data)
+        return _("Invalid repository URL: '{url}': {msg}").format(
+            url=self.data, msg=self._args.get("msg", "")
+        )
 
 
 class TransactionOperationError(TransactionError):
-        """Used to indicate that a transaction operation failed.
+    """Used to indicate that a transaction operation failed.
 
-        The first argument, when initializing the class, should be the name of
-        the operation that failed."""
+    The first argument, when initializing the class, should be the name of
+    the operation that failed."""
 
-        def __str__(self):
-                if "status" in self._args:
-                        return _("'{op}' failed for transaction ID "
-                            "'{trans_id}'; status '{status}': "
-                            "{msg}").format(op=self.data,
-                            trans_id=self._args.get("trans_id", ""),
-                            status=self._args["status"],
-                            msg=self._args.get("msg", ""))
-                if self._args.get("trans_id", None):
-                        return _("'{op}' failed for transaction ID "
-                            "'{trans_id}': {msg}").format(op=self.data,
-                            trans_id=self._args["trans_id"],
-                            msg=self._args.get("msg", ""),
-                           )
-                if self.data:
-                        return _("'{op}' failed; unable to initiate "
-                            "transaction:\n{msg}").format(op=self.data,
-                            msg=self._args.get("msg", ""))
-                return _("Unable to initiate transaction:\n{0}").format(
-                    self._args.get("msg", ""))
+    def __str__(self):
+        if "status" in self._args:
+            return _(
+                "'{op}' failed for transaction ID "
+                "'{trans_id}'; status '{status}': "
+                "{msg}"
+            ).format(
+                op=self.data,
+                trans_id=self._args.get("trans_id", ""),
+                status=self._args["status"],
+                msg=self._args.get("msg", ""),
+            )
+        if self._args.get("trans_id", None):
+            return _(
+                "'{op}' failed for transaction ID " "'{trans_id}': {msg}"
+            ).format(
+                op=self.data,
+                trans_id=self._args["trans_id"],
+                msg=self._args.get("msg", ""),
+            )
+        if self.data:
+            return _(
+                "'{op}' failed; unable to initiate " "transaction:\n{msg}"
+            ).format(op=self.data, msg=self._args.get("msg", ""))
+        return _("Unable to initiate transaction:\n{0}").format(
+            self._args.get("msg", "")
+        )
 
 
 class TransactionRepositoryInvalidError(TransactionError):
-        """Used to indicate that the specified repository is not valid or can
-        not be found at the requested location."""
+    """Used to indicate that the specified repository is not valid or can
+    not be found at the requested location."""
 
 
 class UnsupportedRepoTypeOperationError(TransactionError):
-        """Used to indicate that a requested operation is not supported for the
-        type of repository being operated on (http, file, etc.)."""
+    """Used to indicate that a requested operation is not supported for the
+    type of repository being operated on (http, file, etc.)."""
 
-        def __str__(self):
-                return _("Unsupported operation '{op}' for the specified "
-                    "repository type '{type}'.").format(op=self.data,
-                    type=self._args.get("type", ""))
+    def __str__(self):
+        return _(
+            "Unsupported operation '{op}' for the specified "
+            "repository type '{type}'."
+        ).format(op=self.data, type=self._args.get("type", ""))
 
 
 class NullTransaction(object):
-        """Provides a simulated publishing interface suitable for testing
-        purposes."""
+    """Provides a simulated publishing interface suitable for testing
+    purposes."""
 
-        def __init__(self, origin_url, create_repo=False, pkg_name=None,
-            repo_props=EmptyDict, trans_id=None, xport=None, pub=None,
-            progtrack=None):
-                self.create_repo = create_repo
-                self.origin_url = origin_url
-                self.pkg_name = pkg_name
-                self.progtrack = progtrack
-                self.trans_id = trans_id
+    def __init__(
+        self,
+        origin_url,
+        create_repo=False,
+        pkg_name=None,
+        repo_props=EmptyDict,
+        trans_id=None,
+        xport=None,
+        pub=None,
+        progtrack=None,
+    ):
+        self.create_repo = create_repo
+        self.origin_url = origin_url
+        self.pkg_name = pkg_name
+        self.progtrack = progtrack
+        self.trans_id = trans_id
 
-        def add(self, action, exact=False, path=None):
-                """Adds an action and its related content to an in-flight
-                transaction.  Returns nothing."""
+    def add(self, action, exact=False, path=None):
+        """Adds an action and its related content to an in-flight
+        transaction.  Returns nothing."""
 
-                try:
-                        # Perform additional publication-time validation of
-                        # actions before further processing is done.
-                        action.validate(fmri=self.pkg_name)
-                except actions.ActionError as e:
-                        raise TransactionOperationError("add",
-                            trans_id=self.trans_id, msg=str(e))
+        try:
+            # Perform additional publication-time validation of
+            # actions before further processing is done.
+            action.validate(fmri=self.pkg_name)
+        except actions.ActionError as e:
+            raise TransactionOperationError(
+                "add", trans_id=self.trans_id, msg=str(e)
+            )
 
-        def add_file(self, pth):
-                """Adds an additional file to the inflight transaction so that
-                it will be available for retrieval once the transaction is
-                closed."""
+    def add_file(self, pth):
+        """Adds an additional file to the inflight transaction so that
+        it will be available for retrieval once the transaction is
+        closed."""
 
-                if not os.path.isfile(pth):
-                        raise TransactionOperationError("add_file",
-                            trans_id=self.trans_id, msg=str(_("The file to "
-                            "be added is not a file.  The path given was {0}.").format(
-                            pth)))
+        if not os.path.isfile(pth):
+            raise TransactionOperationError(
+                "add_file",
+                trans_id=self.trans_id,
+                msg=str(
+                    _(
+                        "The file to "
+                        "be added is not a file.  The path given was {0}."
+                    ).format(pth)
+                ),
+            )
 
-        def close(self, abandon=False, add_to_catalog=True):
-                """Ends an in-flight transaction.  Returns a tuple containing
-                a package fmri (if applicable) and the final state of the
-                related package."""
+    def close(self, abandon=False, add_to_catalog=True):
+        """Ends an in-flight transaction.  Returns a tuple containing
+        a package fmri (if applicable) and the final state of the
+        related package."""
 
-                if abandon:
-                        pkg_fmri = None
-                        pkg_state = "ABANDONED"
-                else:
-                        pkg_fmri = self.pkg_name
-                        pkg_state = "PUBLISHED"
+        if abandon:
+            pkg_fmri = None
+            pkg_state = "ABANDONED"
+        else:
+            pkg_fmri = self.pkg_name
+            pkg_state = "PUBLISHED"
 
-                return pkg_fmri, pkg_state
+        return pkg_fmri, pkg_state
 
-        def open(self):
-                """Starts an in-flight transaction. Returns a URL-encoded
-                transaction ID on success."""
-                return quote(self.pkg_name, "")
+    def open(self):
+        """Starts an in-flight transaction. Returns a URL-encoded
+        transaction ID on success."""
+        return quote(self.pkg_name, "")
 
-        def append(self):
-                """Starts an in-flight transaction to append to an existing
-                manifest. Returns a URL-encoded transaction ID on success."""
-                return self.open()
+    def append(self):
+        """Starts an in-flight transaction to append to an existing
+        manifest. Returns a URL-encoded transaction ID on success."""
+        return self.open()
 
-        @staticmethod
-        def refresh_index():
-                """Instructs the repository to refresh its search indices.
-                Returns nothing."""
-                pass
+    @staticmethod
+    def refresh_index():
+        """Instructs the repository to refresh its search indices.
+        Returns nothing."""
+        pass
 
 
 class TransportTransaction(object):
-        """Provides a publishing interface that uses client transport."""
-
-        def __init__(self, origin_url, create_repo=False, pkg_name=None,
-            repo_props=EmptyDict, trans_id=None, xport=None, pub=None,
-            progtrack=None):
-
-                scheme, netloc, path, params, query, fragment = \
-                    urlparse(origin_url, "http", allow_fragments=0)
-
-                self.pkg_name = pkg_name
-                self.trans_id = trans_id
-                self.scheme = scheme
-                if scheme == "file":
-                        path = unquote(path)
-                self.path = path
-                self.progtrack = progtrack
-                self.transport = xport
-                self.publisher = pub
-                self.__local = False
-                self.__uploaded = 0
-                self.__uploads = {}
-                self.__transactions = {}
-                self._tmpdir = None
-                self._append_mode = False
-                self._upload_mode = None
-
-                if scheme == "file":
-                        self.__local = True
-                        self.create_file_repo(repo_props=repo_props,
-                            create_repo=create_repo)
-                elif scheme != "file" and create_repo:
-                        raise UnsupportedRepoTypeOperationError("create_repo",
-                            type=scheme)
-
-        def create_file_repo(self, repo_props=EmptyDict, create_repo=False):
-
-                if self.transport.publish_cache_contains(self.publisher):
-                        return
-
-                if create_repo:
-                        try:
-                                # For compatibility reasons, assume that
-                                # repositories created using pkgsend
-                                # should be in version 3 format (single
-                                # publisher only).
-                                sr.repository_create(self.path, version=3)
-                        except sr.RepositoryExistsError:
-                                # Already exists, nothing to do.
-                                pass
-                        except (apx.ApiException, sr.RepositoryError) as e:
-                                raise TransactionOperationError(None,
-                                    msg=str(e))
-
-                try:
-                        repo = sr.Repository(properties=repo_props,
-                            root=self.path)
-                except EnvironmentError as e:
-                        raise TransactionOperationError(None, msg=_(
-                            "An error occurred while trying to "
-                            "initialize the repository directory "
-                            "structures:\n{0}").format(e))
-                except cfg.ConfigError as e:
-                        raise TransactionRepositoryConfigError(str(e))
-                except sr.RepositoryInvalidError as e:
-                        raise TransactionRepositoryInvalidError(str(e))
-                except sr.RepositoryError as e:
-                        raise TransactionOperationError(None,
-                            msg=str(e))
-
-                self.transport.publish_cache_repository(self.publisher, repo)
-
-
-        def add(self, action, exact=False, path=None):
-                """Adds an action and its related content to an in-flight
-                transaction.  Returns nothing."""
-
-                try:
-                        # Perform additional publication-time validation of
-                        # actions before further processing is done.
-                        action.validate()
-                except actions.ActionError as e:
-                        raise TransactionOperationError("add",
-                            trans_id=self.trans_id, msg=str(e))
-
-                # If the server supports it, we'll upload the manifest as-is
-                # by accumulating the manifest contents in self.__transactions.
-                man = self.__transactions.get(self.trans_id)
-                if man is not None:
-                        try:
-                                self._process_action(action, exact=exact,
-                                    path=path)
-                        except apx.TransportError as e:
-                                msg = str(e)
-                                raise TransactionOperationError("add",
-                                    trans_id=self.trans_id, msg=msg)
-                        self.__transactions[self.trans_id] = man + \
-                            str(action) + "\n"
-                        return
-
-                # Fallback to older logic.
-                try:
-                        self.transport.publish_add(self.publisher,
-                            action=action, trans_id=self.trans_id,
-                            progtrack=self.progtrack)
-                except apx.TransportError as e:
-                        msg = str(e)
-                        raise TransactionOperationError("add",
-                            trans_id=self.trans_id, msg=msg)
-
-        def __get_elf_attrs(self, action, fname, size):
-                """Helper function to get the ELF information."""
-
-                # This currently uses the presence of "elfhash" to indicate the
-                # need for *any* content hashes to be added. This will work as
-                # expected until elfhash is no longer generated by default, and
-                # then this logic will need to be updated accordingly.
-                need_elf_info = False
-                need_elfhash = False
-
-                bufsz = misc.PKG_FILE_BUFSIZ
-                if bufsz > size:
-                        bufsz = size
-
-                f = action.data()
-                magic = f.read(4)
-                if haveelf and magic == b"\x7fELF":
-                        need_elf_info = (
-                            "elfarch" not in action.attrs or
-                            "elfbits" not in action.attrs)
-                        need_elfhash = "elfhash" not in action.attrs
-                if not need_elf_info or not need_elfhash:
-                        f.close()
-                        return misc.EmptyDict
-
-                elf_name = os.path.join(self._tmpdir,
-                    ".temp-{0}".format(fname))
-                with open(elf_name, "wb") as elf_file:
-                        elf_file.write(magic)
-                        while True:
-                                data = f.read(bufsz)
-                                if not data:
-                                    break
-                                elf_file.write(data)
-                f.close()
-
-                attrs = {}
-                if need_elf_info:
-                        try:
-                                elf_info = elf.get_info(elf_name)
-                        except elf.ElfError as e:
-                                raise TransactionError(e)
-                        attrs["elfbits"] = str(elf_info["bits"])
-                        attrs["elfarch"] = elf_info["arch"]
-
-                # Check which content checksums to compute and add to the action
-                get_elfhash = (need_elfhash and "elfhash" in
-                    digest.DEFAULT_GELF_HASH_ATTRS)
-                get_sha256 = (need_elfhash and
-                    not digest.sha512_supported and
-                    "pkg.content-hash" in
-                    digest.DEFAULT_GELF_HASH_ATTRS)
-                get_sha512t_256 = (need_elfhash and
-                    digest.sha512_supported and
-                    "pkg.content-hash" in
-                    digest.DEFAULT_GELF_HASH_ATTRS)
-
-                if get_elfhash or get_sha256 or get_sha512t_256:
-                        try:
-                                attrs.update(elf.get_hashes(
-                                    elf_name, elfhash=get_elfhash,
-                                    sha256=get_sha256,
-                                    sha512t_256=get_sha512t_256))
-                        except elf.ElfError:
-                                pass
-
-                os.unlink(elf_name)
-                return attrs
-
-        def __get_compressed_attrs(self, fhash):
-                """Given a fhash of a file, returns a tuple
-                of (csize, chashes) where 'csize' is the size of the file
-                in the repository and 'chashes' is a dictionary containing
-                any hashes of the compressed data known by the repository."""
-
-                if self.__local or self.__uploaded < \
-                    self.transport.cfg.max_transfer_checks:
-                        # If the repository is local (filesystem-based) or
-                        # number of files uploaded is less than
-                        # max_transfer_checks, call get_compressed_attrs()...
-                        csize, chashes = self.transport.get_compressed_attrs(
-                            fhash, pub=self.publisher, trans_id=self.trans_id)
-                else:
-                        # ...or the repository is not filesystem-based and
-                        # enough files are missing that we want to avoid the
-                        # overhead of calling get_compressed_attrs().
-                        csize, chashes = None, None
-
-                if chashes:
-                        # If any of the default content hash attributes we need
-                        # is not available from the repository, they must be
-                        # recomputed below.
-                        for k in digest.DEFAULT_CHASH_ATTRS:
-                                if k not in chashes:
-                                        chashes = None
-                                        break
-                return csize, chashes
-
-        def _process_action(self, action, exact=False, path=None):
-                """Adds all expected attributes to the provided action and
-                upload the file for the action if needed.
-
-                If 'exact' is True and 'path' is 'None', the action won't
-                be modified and no file will be uploaded.
-
-                If 'exact' is True and a 'path' is provided, the file of that
-                path will be uploaded as-is (it is assumed that the file is
-                already in repository format).
-                """
-
-                if self._append_mode and action.name != "signature":
-                        raise TransactionOperationError(non_sig=True)
-
-                size = int(action.attrs.get("pkg.size", 0))
-
-                if action.has_payload and size <= 0:
-                        # XXX hack for empty files
-                        action.data = lambda: open(os.devnull, "rb")
-
-                if action.data is None:
-                        return
-
-                if exact:
-                        if path:
-                                self.add_file(path, basename=action.hash,
-                                    progtrack=self.progtrack)
-                        return
-
-                # Get all hashes for this action.
-                hashes, dummy = misc.get_data_digest(action.data(),
-                    length=size, hash_attrs=digest.DEFAULT_HASH_ATTRS,
-                    hash_algs=digest.HASH_ALGS)
-                # Set the hash member for backwards compatibility and
-                # remove it from the dictionary.
-                action.hash = hashes.pop("hash", None)
-                action.attrs.update(hashes)
-
-                # Add file content-hash when preferred_hash is SHA2 or higher.
-                if action.name != "signature" and \
-                    digest.PREFERRED_HASH != "sha1":
-                        hash_attr = "{0}:{1}".format(digest.EXTRACT_FILE,
-                            digest.PREFERRED_HASH)
-                        file_content_hash, dummy = misc.get_data_digest(
-                            action.data(), length=size, return_content=False,
-                            hash_attrs=[hash_attr], hash_algs=digest.HASH_ALGS)
-                        action.attrs["pkg.content-hash"] = "{0}:{1}".format(
-                            hash_attr, file_content_hash[hash_attr])
-
-                # Now set the hash value that will be used for storing the file
-                # in the repository.
-                hash_attr, hash_val, hash_func = \
-                    digest.get_least_preferred_hash(action)
-                fname = hash_val
-
-                hdata = self.__uploads.get(fname)
-                if hdata is not None:
-                        elf_attrs, csize, chashes = hdata
-                else:
-                        # We haven't processed this file before, determine if
-                        # it needs to be uploaded and what information the
-                        # repository knows about it.
-                        elf_attrs = self.__get_elf_attrs(action, fname, size)
-                        csize, chashes = self.__get_compressed_attrs(fname)
-
-                        # 'csize' indicates that if file needs to be uploaded.
-                        fileneeded = csize is None
-                        if fileneeded:
-                                fpath = os.path.join(self._tmpdir, fname)
-                                csize, chashes = misc.compute_compressed_attrs(
-                                    fname, data=action.data(), size=size,
-                                    compress_dir=self._tmpdir)
-                                # Upload the compressed file for each action.
-                                self.add_file(fpath, basename=fname,
-                                    progtrack=self.progtrack)
-                                os.unlink(fpath)
-                                self.__uploaded += 1
-                        elif not chashes:
-                                # If not fileneeded, and repository can't
-                                # provide desired hashes, call
-                                # compute_compressed_attrs() in a way that
-                                # avoids writing the file to get the attributes
-                                # we need.
-                                csize, chashes = misc.compute_compressed_attrs(
-                                    fname, data=action.data(), size=size)
-
-                        self.__uploads[fname] = (elf_attrs, csize, chashes)
-
-                for k, v in six.iteritems(elf_attrs):
-                        if isinstance(v, list):
-                                action.attrs[k] = v + action.attrlist(k)
-                        else:
-                                action.attrs[k] = v
-                for k, v in six.iteritems(chashes):
-                        if k == "pkg.content-hash":
-                                action.attrs[k] = action.attrlist(k) + [v]
-                        else:
-                                action.attrs[k] = v
-                action.attrs["pkg.csize"] = csize
-
-        def add_file(self, pth, basename=None, progtrack=None):
-                """Adds an additional file to the inflight transaction so that
-                it will be available for retrieval once the transaction is
-                closed."""
-
-                if not os.path.isfile(pth):
-                        raise TransactionOperationError("add_file",
-                            trans_id=self.trans_id, msg=str(_("The file to "
-                            "be added is not a file.  The path given was {0}.").format(
-                            pth)))
-
-                try:
-                        self.transport.publish_add_file(self.publisher,
-                            pth=pth, trans_id=self.trans_id, basename=basename,
-                            progtrack=progtrack)
-                except apx.TransportError as e:
-                        msg = str(e)
-                        raise TransactionOperationError("add_file",
-                            trans_id=self.trans_id, msg=msg)
-
-        def add_manifest(self, pth):
-                """Adds an additional manifest to the inflight transaction so
-                that it will be available for retrieval once the transaction is
-                closed."""
-
-                if not os.path.isfile(pth):
-                        raise TransactionOperationError("add_manifest",
-                            trans_id=self.trans_id, msg=str(_("The file to "
-                            "be added is not a file.  The path given was {0}.").format(
-                            pth)))
-
-                try:
-                        self.transport.publish_add_manifest(self.publisher,
-                            pth=pth, trans_id=self.trans_id)
-                except apx.TransportError as e:
-                        msg = str(e)
-                        raise TransactionOperationError("add_manifest",
-                            trans_id=self.trans_id, msg=msg)
-
-        def _cleanup_upload(self):
-                """Remove any temporary files generated in upload mode."""
-
-                if self._tmpdir:
-                        # we don't care if this fails.
-                        shutil.rmtree(self._tmpdir, ignore_errors=True)
-
-        def close(self, abandon=False, add_to_catalog=True):
-                """Ends an in-flight transaction.  Returns a tuple containing
-                a package fmri (if applicable) and the final state of the
-                related package.
-
-                If 'abandon' is omitted or False, the package will be published;
-                otherwise the server will discard the current transaction and
-                its related data.
-
-                'add_to_catalog' tells the depot to add a package to the
-                catalog, if True.
-                """
-
-                if abandon:
-                        self.__transactions.pop(self.trans_id, None)
-                        try:
-                                state, fmri = self.transport.publish_abandon(
-                                    self.publisher, trans_id=self.trans_id)
-                        except apx.TransportError as e:
-                                msg = str(e)
-                                raise TransactionOperationError("abandon",
-                                    trans_id=self.trans_id, msg=msg)
-                        finally:
-                                self._cleanup_upload()
-
-                else:
-                        man = self.__transactions.get(self.trans_id)
-                        if man is not None:
-                                # upload manifest here
-                                path = os.path.join(self._tmpdir, "manifest")
-                                with open(path, "w") as f:
-                                        f.write(man)
-                                self.add_manifest(path)
-                                self.__transactions.pop(self.trans_id, None)
-
-                        try:
-                                state, fmri = self.transport.publish_close(
-                                    self.publisher, trans_id=self.trans_id,
-                                    add_to_catalog=add_to_catalog)
-                        except apx.TransportError as e:
-                                msg = str(e)
-                                raise TransactionOperationError("close",
-                                    trans_id=self.trans_id, msg=msg)
-                        finally:
-                                self._cleanup_upload()
-
-                return state, fmri
-
-        def _init_upload(self):
-                """Initialization for upload mode."""
-
-                if self._upload_mode or self._upload_mode is not None:
-                        return
-
-                op = "init_upload"
-                try:
-                        self._upload_mode = self.transport.supports_version(
-                            self.publisher, "manifest", [1]) > -1
-                except apx.TransportError as e:
-                        msg = str(e)
-                        raise TransactionOperationError(op,
-                            trans_id=self.trans_id, msg=msg)
-
-                if not self._upload_mode:
-                        return
-
-                # Create temporary directory and initialize self.__transactions.
-                temp_root = misc.config_temp_root()
-                self._tmpdir = tempfile.mkdtemp(dir=temp_root)
-                self.__transactions.setdefault(self.trans_id, "")
-
-        def open(self):
-                """Starts an in-flight transaction. Returns a URL-encoded
-                transaction ID on success."""
-
-                trans_id = None
-
-                try:
-                        trans_id = self.transport.publish_open(self.publisher,
-                            client_release=os_util.get_os_release(),
-                            pkg_name=self.pkg_name)
-                except apx.TransportError as e:
-                        msg = str(e)
-                        raise TransactionOperationError("open",
-                            trans_id=self.trans_id, msg=msg)
-
-                self.trans_id = trans_id
-
-                if self.trans_id is None:
-                        raise TransactionOperationError("open",
-                            msg=_("Unknown failure; no transaction ID provided"
-                            " in response."))
-
-                self._init_upload()
-
-                return self.trans_id
-
-        def append(self):
-                """Starts an in-flight transaction to append to an existing
-                manifest. Returns a URL-encoded transaction ID on success."""
-
-                self._append_mode = True
-                trans_id = None
-
-                try:
-                        trans_id = self.transport.publish_append(self.publisher,
-                            client_release=os_util.get_os_release(),
-                            pkg_name=self.pkg_name)
-                except apx.TransportError as e:
-                        msg = str(e)
-                        raise TransactionOperationError("append",
-                            trans_id=self.trans_id, msg=msg)
-
-                self.trans_id = trans_id
-
-                if self.trans_id is None:
-                        raise TransactionOperationError("append",
-                            msg=_("Unknown failure; no transaction ID provided"
-                            " in response."))
-
-                self._init_upload()
-
-                return self.trans_id
-
-        def refresh_index(self):
-                """Instructs the repository to refresh its search indices.
-                Returns nothing."""
-
-                op = "index"
-
-                try:
-                        self.transport.publish_refresh_indexes(self.publisher)
-                except apx.TransportError as e:
-                        msg = str(e)
-                        raise TransactionOperationError(op,
-                            trans_id=self.trans_id, msg=msg)
+    """Provides a publishing interface that uses client transport."""
+
+    def __init__(
+        self,
+        origin_url,
+        create_repo=False,
+        pkg_name=None,
+        repo_props=EmptyDict,
+        trans_id=None,
+        xport=None,
+        pub=None,
+        progtrack=None,
+    ):
+        scheme, netloc, path, params, query, fragment = urlparse(
+            origin_url, "http", allow_fragments=0
+        )
+
+        self.pkg_name = pkg_name
+        self.trans_id = trans_id
+        self.scheme = scheme
+        if scheme == "file":
+            path = unquote(path)
+        self.path = path
+        self.progtrack = progtrack
+        self.transport = xport
+        self.publisher = pub
+        self.__local = False
+        self.__uploaded = 0
+        self.__uploads = {}
+        self.__transactions = {}
+        self._tmpdir = None
+        self._append_mode = False
+        self._upload_mode = None
+
+        if scheme == "file":
+            self.__local = True
+            self.create_file_repo(
+                repo_props=repo_props, create_repo=create_repo
+            )
+        elif scheme != "file" and create_repo:
+            raise UnsupportedRepoTypeOperationError("create_repo", type=scheme)
+
+    def create_file_repo(self, repo_props=EmptyDict, create_repo=False):
+        if self.transport.publish_cache_contains(self.publisher):
+            return
+
+        if create_repo:
+            try:
+                # For compatibility reasons, assume that
+                # repositories created using pkgsend
+                # should be in version 3 format (single
+                # publisher only).
+                sr.repository_create(self.path, version=3)
+            except sr.RepositoryExistsError:
+                # Already exists, nothing to do.
+                pass
+            except (apx.ApiException, sr.RepositoryError) as e:
+                raise TransactionOperationError(None, msg=str(e))
+
+        try:
+            repo = sr.Repository(properties=repo_props, root=self.path)
+        except EnvironmentError as e:
+            raise TransactionOperationError(
+                None,
+                msg=_(
+                    "An error occurred while trying to "
+                    "initialize the repository directory "
+                    "structures:\n{0}"
+                ).format(e),
+            )
+        except cfg.ConfigError as e:
+            raise TransactionRepositoryConfigError(str(e))
+        except sr.RepositoryInvalidError as e:
+            raise TransactionRepositoryInvalidError(str(e))
+        except sr.RepositoryError as e:
+            raise TransactionOperationError(None, msg=str(e))
+
+        self.transport.publish_cache_repository(self.publisher, repo)
+
+    def add(self, action, exact=False, path=None):
+        """Adds an action and its related content to an in-flight
+        transaction.  Returns nothing."""
+
+        try:
+            # Perform additional publication-time validation of
+            # actions before further processing is done.
+            action.validate()
+        except actions.ActionError as e:
+            raise TransactionOperationError(
+                "add", trans_id=self.trans_id, msg=str(e)
+            )
+
+        # If the server supports it, we'll upload the manifest as-is
+        # by accumulating the manifest contents in self.__transactions.
+        man = self.__transactions.get(self.trans_id)
+        if man is not None:
+            try:
+                self._process_action(action, exact=exact, path=path)
+            except apx.TransportError as e:
+                msg = str(e)
+                raise TransactionOperationError(
+                    "add", trans_id=self.trans_id, msg=msg
+                )
+            self.__transactions[self.trans_id] = man + str(action) + "\n"
+            return
+
+        # Fallback to older logic.
+        try:
+            self.transport.publish_add(
+                self.publisher,
+                action=action,
+                trans_id=self.trans_id,
+                progtrack=self.progtrack,
+            )
+        except apx.TransportError as e:
+            msg = str(e)
+            raise TransactionOperationError(
+                "add", trans_id=self.trans_id, msg=msg
+            )
+
+    def __get_elf_attrs(self, action, fname, size):
+        """Helper function to get the ELF information."""
+
+        # This currently uses the presence of "elfhash" to indicate the
+        # need for *any* content hashes to be added. This will work as
+        # expected until elfhash is no longer generated by default, and
+        # then this logic will need to be updated accordingly.
+        need_elf_info = False
+        need_elfhash = False
+
+        bufsz = misc.PKG_FILE_BUFSIZ
+        if bufsz > size:
+            bufsz = size
+
+        f = action.data()
+        magic = f.read(4)
+        if haveelf and magic == b"\x7fELF":
+            need_elf_info = (
+                "elfarch" not in action.attrs or "elfbits" not in action.attrs
+            )
+            need_elfhash = "elfhash" not in action.attrs
+        if not need_elf_info or not need_elfhash:
+            f.close()
+            return misc.EmptyDict
+
+        elf_name = os.path.join(self._tmpdir, ".temp-{0}".format(fname))
+        with open(elf_name, "wb") as elf_file:
+            elf_file.write(magic)
+            while True:
+                data = f.read(bufsz)
+                if not data:
+                    break
+                elf_file.write(data)
+        f.close()
+
+        attrs = {}
+        if need_elf_info:
+            try:
+                elf_info = elf.get_info(elf_name)
+            except elf.ElfError as e:
+                raise TransactionError(e)
+            attrs["elfbits"] = str(elf_info["bits"])
+            attrs["elfarch"] = elf_info["arch"]
+
+        # Check which content checksums to compute and add to the action
+        get_elfhash = (
+            need_elfhash and "elfhash" in digest.DEFAULT_GELF_HASH_ATTRS
+        )
+        get_sha256 = (
+            need_elfhash
+            and not digest.sha512_supported
+            and "pkg.content-hash" in digest.DEFAULT_GELF_HASH_ATTRS
+        )
+        get_sha512t_256 = (
+            need_elfhash
+            and digest.sha512_supported
+            and "pkg.content-hash" in digest.DEFAULT_GELF_HASH_ATTRS
+        )
+
+        if get_elfhash or get_sha256 or get_sha512t_256:
+            try:
+                attrs.update(
+                    elf.get_hashes(
+                        elf_name,
+                        elfhash=get_elfhash,
+                        sha256=get_sha256,
+                        sha512t_256=get_sha512t_256,
+                    )
+                )
+            except elf.ElfError:
+                pass
+
+        os.unlink(elf_name)
+        return attrs
+
+    def __get_compressed_attrs(self, fhash):
+        """Given a fhash of a file, returns a tuple
+        of (csize, chashes) where 'csize' is the size of the file
+        in the repository and 'chashes' is a dictionary containing
+        any hashes of the compressed data known by the repository."""
+
+        if (
+            self.__local
+            or self.__uploaded < self.transport.cfg.max_transfer_checks
+        ):
+            # If the repository is local (filesystem-based) or
+            # number of files uploaded is less than
+            # max_transfer_checks, call get_compressed_attrs()...
+            csize, chashes = self.transport.get_compressed_attrs(
+                fhash, pub=self.publisher, trans_id=self.trans_id
+            )
+        else:
+            # ...or the repository is not filesystem-based and
+            # enough files are missing that we want to avoid the
+            # overhead of calling get_compressed_attrs().
+            csize, chashes = None, None
+
+        if chashes:
+            # If any of the default content hash attributes we need
+            # is not available from the repository, they must be
+            # recomputed below.
+            for k in digest.DEFAULT_CHASH_ATTRS:
+                if k not in chashes:
+                    chashes = None
+                    break
+        return csize, chashes
+
+    def _process_action(self, action, exact=False, path=None):
+        """Adds all expected attributes to the provided action and
+        upload the file for the action if needed.
+
+        If 'exact' is True and 'path' is 'None', the action won't
+        be modified and no file will be uploaded.
+
+        If 'exact' is True and a 'path' is provided, the file of that
+        path will be uploaded as-is (it is assumed that the file is
+        already in repository format).
+        """
+
+        if self._append_mode and action.name != "signature":
+            raise TransactionOperationError(non_sig=True)
+
+        size = int(action.attrs.get("pkg.size", 0))
+
+        if action.has_payload and size <= 0:
+            # XXX hack for empty files
+            action.data = lambda: open(os.devnull, "rb")
+
+        if action.data is None:
+            return
+
+        if exact:
+            if path:
+                self.add_file(
+                    path, basename=action.hash, progtrack=self.progtrack
+                )
+            return
+
+        # Get all hashes for this action.
+        hashes, dummy = misc.get_data_digest(
+            action.data(),
+            length=size,
+            hash_attrs=digest.DEFAULT_HASH_ATTRS,
+            hash_algs=digest.HASH_ALGS,
+        )
+        # Set the hash member for backwards compatibility and
+        # remove it from the dictionary.
+        action.hash = hashes.pop("hash", None)
+        action.attrs.update(hashes)
+
+        # Add file content-hash when preferred_hash is SHA2 or higher.
+        if action.name != "signature" and digest.PREFERRED_HASH != "sha1":
+            hash_attr = "{0}:{1}".format(
+                digest.EXTRACT_FILE, digest.PREFERRED_HASH
+            )
+            file_content_hash, dummy = misc.get_data_digest(
+                action.data(),
+                length=size,
+                return_content=False,
+                hash_attrs=[hash_attr],
+                hash_algs=digest.HASH_ALGS,
+            )
+            action.attrs["pkg.content-hash"] = "{0}:{1}".format(
+                hash_attr, file_content_hash[hash_attr]
+            )
+
+        # Now set the hash value that will be used for storing the file
+        # in the repository.
+        hash_attr, hash_val, hash_func = digest.get_least_preferred_hash(action)
+        fname = hash_val
+
+        hdata = self.__uploads.get(fname)
+        if hdata is not None:
+            elf_attrs, csize, chashes = hdata
+        else:
+            # We haven't processed this file before, determine if
+            # it needs to be uploaded and what information the
+            # repository knows about it.
+            elf_attrs = self.__get_elf_attrs(action, fname, size)
+            csize, chashes = self.__get_compressed_attrs(fname)
+
+            # 'csize' indicates that if file needs to be uploaded.
+            fileneeded = csize is None
+            if fileneeded:
+                fpath = os.path.join(self._tmpdir, fname)
+                csize, chashes = misc.compute_compressed_attrs(
+                    fname,
+                    data=action.data(),
+                    size=size,
+                    compress_dir=self._tmpdir,
+                )
+                # Upload the compressed file for each action.
+                self.add_file(fpath, basename=fname, progtrack=self.progtrack)
+                os.unlink(fpath)
+                self.__uploaded += 1
+            elif not chashes:
+                # If not fileneeded, and repository can't
+                # provide desired hashes, call
+                # compute_compressed_attrs() in a way that
+                # avoids writing the file to get the attributes
+                # we need.
+                csize, chashes = misc.compute_compressed_attrs(
+                    fname, data=action.data(), size=size
+                )
+
+            self.__uploads[fname] = (elf_attrs, csize, chashes)
+
+        for k, v in six.iteritems(elf_attrs):
+            if isinstance(v, list):
+                action.attrs[k] = v + action.attrlist(k)
+            else:
+                action.attrs[k] = v
+        for k, v in six.iteritems(chashes):
+            if k == "pkg.content-hash":
+                action.attrs[k] = action.attrlist(k) + [v]
+            else:
+                action.attrs[k] = v
+        action.attrs["pkg.csize"] = csize
+
+    def add_file(self, pth, basename=None, progtrack=None):
+        """Adds an additional file to the inflight transaction so that
+        it will be available for retrieval once the transaction is
+        closed."""
+
+        if not os.path.isfile(pth):
+            raise TransactionOperationError(
+                "add_file",
+                trans_id=self.trans_id,
+                msg=str(
+                    _(
+                        "The file to "
+                        "be added is not a file.  The path given was {0}."
+                    ).format(pth)
+                ),
+            )
+
+        try:
+            self.transport.publish_add_file(
+                self.publisher,
+                pth=pth,
+                trans_id=self.trans_id,
+                basename=basename,
+                progtrack=progtrack,
+            )
+        except apx.TransportError as e:
+            msg = str(e)
+            raise TransactionOperationError(
+                "add_file", trans_id=self.trans_id, msg=msg
+            )
+
+    def add_manifest(self, pth):
+        """Adds an additional manifest to the inflight transaction so
+        that it will be available for retrieval once the transaction is
+        closed."""
+
+        if not os.path.isfile(pth):
+            raise TransactionOperationError(
+                "add_manifest",
+                trans_id=self.trans_id,
+                msg=str(
+                    _(
+                        "The file to "
+                        "be added is not a file.  The path given was {0}."
+                    ).format(pth)
+                ),
+            )
+
+        try:
+            self.transport.publish_add_manifest(
+                self.publisher, pth=pth, trans_id=self.trans_id
+            )
+        except apx.TransportError as e:
+            msg = str(e)
+            raise TransactionOperationError(
+                "add_manifest", trans_id=self.trans_id, msg=msg
+            )
+
+    def _cleanup_upload(self):
+        """Remove any temporary files generated in upload mode."""
+
+        if self._tmpdir:
+            # we don't care if this fails.
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def close(self, abandon=False, add_to_catalog=True):
+        """Ends an in-flight transaction.  Returns a tuple containing
+        a package fmri (if applicable) and the final state of the
+        related package.
+
+        If 'abandon' is omitted or False, the package will be published;
+        otherwise the server will discard the current transaction and
+        its related data.
+
+        'add_to_catalog' tells the depot to add a package to the
+        catalog, if True.
+        """
+
+        if abandon:
+            self.__transactions.pop(self.trans_id, None)
+            try:
+                state, fmri = self.transport.publish_abandon(
+                    self.publisher, trans_id=self.trans_id
+                )
+            except apx.TransportError as e:
+                msg = str(e)
+                raise TransactionOperationError(
+                    "abandon", trans_id=self.trans_id, msg=msg
+                )
+            finally:
+                self._cleanup_upload()
+
+        else:
+            man = self.__transactions.get(self.trans_id)
+            if man is not None:
+                # upload manifest here
+                path = os.path.join(self._tmpdir, "manifest")
+                with open(path, "w") as f:
+                    f.write(man)
+                self.add_manifest(path)
+                self.__transactions.pop(self.trans_id, None)
+
+            try:
+                state, fmri = self.transport.publish_close(
+                    self.publisher,
+                    trans_id=self.trans_id,
+                    add_to_catalog=add_to_catalog,
+                )
+            except apx.TransportError as e:
+                msg = str(e)
+                raise TransactionOperationError(
+                    "close", trans_id=self.trans_id, msg=msg
+                )
+            finally:
+                self._cleanup_upload()
+
+        return state, fmri
+
+    def _init_upload(self):
+        """Initialization for upload mode."""
+
+        if self._upload_mode or self._upload_mode is not None:
+            return
+
+        op = "init_upload"
+        try:
+            self._upload_mode = (
+                self.transport.supports_version(self.publisher, "manifest", [1])
+                > -1
+            )
+        except apx.TransportError as e:
+            msg = str(e)
+            raise TransactionOperationError(op, trans_id=self.trans_id, msg=msg)
+
+        if not self._upload_mode:
+            return
+
+        # Create temporary directory and initialize self.__transactions.
+        temp_root = misc.config_temp_root()
+        self._tmpdir = tempfile.mkdtemp(dir=temp_root)
+        self.__transactions.setdefault(self.trans_id, "")
+
+    def open(self):
+        """Starts an in-flight transaction. Returns a URL-encoded
+        transaction ID on success."""
+
+        trans_id = None
+
+        try:
+            trans_id = self.transport.publish_open(
+                self.publisher,
+                client_release=os_util.get_os_release(),
+                pkg_name=self.pkg_name,
+            )
+        except apx.TransportError as e:
+            msg = str(e)
+            raise TransactionOperationError(
+                "open", trans_id=self.trans_id, msg=msg
+            )
+
+        self.trans_id = trans_id
+
+        if self.trans_id is None:
+            raise TransactionOperationError(
+                "open",
+                msg=_(
+                    "Unknown failure; no transaction ID provided"
+                    " in response."
+                ),
+            )
+
+        self._init_upload()
+
+        return self.trans_id
+
+    def append(self):
+        """Starts an in-flight transaction to append to an existing
+        manifest. Returns a URL-encoded transaction ID on success."""
+
+        self._append_mode = True
+        trans_id = None
+
+        try:
+            trans_id = self.transport.publish_append(
+                self.publisher,
+                client_release=os_util.get_os_release(),
+                pkg_name=self.pkg_name,
+            )
+        except apx.TransportError as e:
+            msg = str(e)
+            raise TransactionOperationError(
+                "append", trans_id=self.trans_id, msg=msg
+            )
+
+        self.trans_id = trans_id
+
+        if self.trans_id is None:
+            raise TransactionOperationError(
+                "append",
+                msg=_(
+                    "Unknown failure; no transaction ID provided"
+                    " in response."
+                ),
+            )
+
+        self._init_upload()
+
+        return self.trans_id
+
+    def refresh_index(self):
+        """Instructs the repository to refresh its search indices.
+        Returns nothing."""
+
+        op = "index"
+
+        try:
+            self.transport.publish_refresh_indexes(self.publisher)
+        except apx.TransportError as e:
+            msg = str(e)
+            raise TransactionOperationError(op, trans_id=self.trans_id, msg=msg)
 
 
 class Transaction(object):
-        """Returns an object representing a publishing "transaction" interface
-        to a pkg(7) repository.
+    """Returns an object representing a publishing "transaction" interface
+    to a pkg(7) repository.
 
-        The class of the object returned will depend upon the scheme of
-        'origin_url', and the value of the 'noexecute' parameter.
+    The class of the object returned will depend upon the scheme of
+    'origin_url', and the value of the 'noexecute' parameter.
 
-        The 'noexecute' parameter, when provided, will force the returned
-        Transaction to simulate all of the requested operations acting as if
-        they succeeded.  It is intended to be used for testing of client
-        publication tools.
+    The 'noexecute' parameter, when provided, will force the returned
+    Transaction to simulate all of the requested operations acting as if
+    they succeeded.  It is intended to be used for testing of client
+    publication tools.
 
-        Each publishing operation requires different information, and as such
-        the following parameters should be provided to the class constructor
-        as noted:
+    Each publishing operation requires different information, and as such
+    the following parameters should be provided to the class constructor
+    as noted:
 
-                'pkg_name'      should be a partial FMRI representing the
-                                desired name of a package and its version when
-                                opening a Transaction.  Required by: open.
+            'pkg_name'      should be a partial FMRI representing the
+                            desired name of a package and its version when
+                            opening a Transaction.  Required by: open.
 
-                'trans_id'      should be a URL-encoded transaction ID as
-                                returned by open.  Required by: add and
-                                close if open has not been called.
-        """
+            'trans_id'      should be a URL-encoded transaction ID as
+                            returned by open.  Required by: add and
+                            close if open has not been called.
+    """
 
-        __schemes = {
-            "file": TransportTransaction,
-            "http": TransportTransaction,
-            "https": TransportTransaction,
-            "null": NullTransaction,
-        }
+    __schemes = {
+        "file": TransportTransaction,
+        "http": TransportTransaction,
+        "https": TransportTransaction,
+        "null": NullTransaction,
+    }
 
-        def __new__(cls, origin_url, create_repo=False, pkg_name=None,
-            repo_props=EmptyDict, trans_id=None, noexecute=False, xport=None,
-            pub=None, progtrack=None):
+    def __new__(
+        cls,
+        origin_url,
+        create_repo=False,
+        pkg_name=None,
+        repo_props=EmptyDict,
+        trans_id=None,
+        noexecute=False,
+        xport=None,
+        pub=None,
+        progtrack=None,
+    ):
+        scheme, netloc, path, params, query, fragment = urlparse(
+            origin_url, "http", allow_fragments=0
+        )
+        scheme = scheme.lower()
 
-                scheme, netloc, path, params, query, fragment = \
-                    urlparse(origin_url, "http", allow_fragments=0)
-                scheme = scheme.lower()
+        if noexecute:
+            scheme = "null"
+        if scheme != "null" and (not xport or not pub):
+            raise TransactionError(
+                "Caller must supply transport " "and publisher."
+            )
+        if scheme not in cls.__schemes:
+            raise TransactionRepositoryURLError(origin_url, scheme=scheme)
+        if scheme.startswith("http") and not netloc:
+            raise TransactionRepositoryURLError(origin_url, netloc=None)
+        if scheme.startswith("file"):
+            if netloc:
+                raise TransactionRepositoryURLError(
+                    origin_url,
+                    msg="'{0}' contains host information, which "
+                    "is not supported for filesystem "
+                    "operations.".format(netloc),
+                )
+            # as we're urlunparsing below, we need to ensure that
+            # the path starts with only one '/' character, if any
+            # are present
+            if path.startswith("/"):
+                path = "/" + path.lstrip("/")
+            elif not path:
+                raise TransactionRepositoryURLError(origin_url)
 
-                if noexecute:
-                        scheme = "null"
-                if scheme != "null" and (not xport or not pub):
-                        raise TransactionError("Caller must supply transport "
-                            "and publisher.")
-                if scheme not in cls.__schemes:
-                        raise TransactionRepositoryURLError(origin_url,
-                            scheme=scheme)
-                if scheme.startswith("http") and not netloc:
-                        raise TransactionRepositoryURLError(origin_url,
-                            netloc=None)
-                if scheme.startswith("file"):
-                        if netloc:
-                                raise TransactionRepositoryURLError(origin_url,
-                                    msg="'{0}' contains host information, which "
-                                    "is not supported for filesystem "
-                                    "operations.".format(netloc))
-                        # as we're urlunparsing below, we need to ensure that
-                        # the path starts with only one '/' character, if any
-                        # are present
-                        if path.startswith("/"):
-                                path = "/" + path.lstrip("/")
-                        elif not path:
-                                raise TransactionRepositoryURLError(origin_url)
+        # Rebuild the url with the sanitized components.
+        origin_url = urlunparse((scheme, netloc, path, params, query, fragment))
 
-                # Rebuild the url with the sanitized components.
-                origin_url = urlunparse((scheme, netloc, path, params,
-                    query, fragment))
+        return cls.__schemes[scheme](
+            origin_url,
+            create_repo=create_repo,
+            pkg_name=pkg_name,
+            repo_props=repo_props,
+            trans_id=trans_id,
+            xport=xport,
+            pub=pub,
+            progtrack=progtrack,
+        )
 
-                return cls.__schemes[scheme](origin_url,
-                    create_repo=create_repo, pkg_name=pkg_name,
-                    repo_props=repo_props, trans_id=trans_id, xport=xport,
-                    pub=pub, progtrack=progtrack)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/query_parser.py
+++ b/src/modules/query_parser.py
@@ -47,1502 +47,1557 @@ from pkg.misc import EmptyI, force_str
 FILE_OPEN_TIMEOUT_SECS = 1
 MAX_TOKEN_COUNT = 100
 
+
 class QueryLexer(object):
-        """This class defines the lexer used to separate parse queries into
-        its constituents.  It's written for Ply, a python implementation for
-        lex and yacc."""
+    """This class defines the lexer used to separate parse queries into
+    its constituents.  It's written for Ply, a python implementation for
+    lex and yacc."""
 
-        # These are the types of tokens that the lexer can produce.
-        tokens = ("FTERM", "TERM", "LPAREN", "RPAREN", "AND", "OR", "QUOTE1",
-            "QUOTE2", "LBRACE", "RBRACE")
+    # These are the types of tokens that the lexer can produce.
+    tokens = (
+        "FTERM",
+        "TERM",
+        "LPAREN",
+        "RPAREN",
+        "AND",
+        "OR",
+        "QUOTE1",
+        "QUOTE2",
+        "LBRACE",
+        "RBRACE",
+    )
 
-        # These statements define the lexing rules or (, ),', and ". These are
-        # all checked after all lexing defined in functions below.
-        t_LPAREN = r"\("
-        t_RPAREN = r"\)"
-        t_QUOTE1 = r"[\']"
-        t_QUOTE2 = r'[\"]'
+    # These statements define the lexing rules or (, ),', and ". These are
+    # all checked after all lexing defined in functions below.
+    t_LPAREN = r"\("
+    t_RPAREN = r"\)"
+    t_QUOTE1 = r"[\']"
+    t_QUOTE2 = r"[\"]"
 
-        # This rule causes spaces to break tokens, but the space itself is not
-        # reported as a token.
-        t_ignore = r" "
+    # This rule causes spaces to break tokens, but the space itself is not
+    # reported as a token.
+    t_ignore = r" "
 
-        def __init__(self):
-                object.__init__(self)
-                # Set up a dictionary of strings which have special meaning and
-                # are otherwise indistinguishable from normal terms. The
-                # mapping is from the string seen in the query to the lexer
-                # tokens.
-                self.reserved = {
-                    "AND" : "AND",
-                    "OR" : "OR"
-                }
+    def __init__(self):
+        object.__init__(self)
+        # Set up a dictionary of strings which have special meaning and
+        # are otherwise indistinguishable from normal terms. The
+        # mapping is from the string seen in the query to the lexer
+        # tokens.
+        self.reserved = {"AND": "AND", "OR": "OR"}
 
-        # Note: Functions are documented using comments instead of docstrings
-        # below because Ply uses the docstrings for specific purposes.
+    # Note: Functions are documented using comments instead of docstrings
+    # below because Ply uses the docstrings for specific purposes.
 
-        def t_LBRACE(self, t):
-                # This rule is for lexing the left side of the pkgs<>
-                # construction.
-                r"([pP]([kK]([gG][sS]?)?)?)?<"
-                t.type = "LBRACE"
-                return t
+    def t_LBRACE(self, t):
+        # This rule is for lexing the left side of the pkgs<>
+        # construction.
+        r"([pP]([kK]([gG][sS]?)?)?)?<"
+        t.type = "LBRACE"
+        return t
 
-        def t_RBRACE(self, t):
-                # This rule is for lexing the right side of the pkgs<>
-                # construction.
-                r">"
-                t.type = "RBRACE"
-                return t
+    def t_RBRACE(self, t):
+        # This rule is for lexing the right side of the pkgs<>
+        # construction.
+        r">"
+        t.type = "RBRACE"
+        return t
 
-        def t_FTERM(self, t):
-                # This rule handles valid search terms with a colon in them.  If
-                # all colons are escaped, it produces a TERM token whose value
-                # is the original term with the escape characters removed.  If
-                # there are unescaped colons, it produces an FTERM token whose
-                # value is a four tuple consisting of the pkg name, the action
-                # type, the action key, and the token that followed the last
-                # unescaped colon.
-                #
-                # The following regular expresion matches a string with a colon
-                # in it, subject to certain other restrictions, such as not
-                # beginning with a quote.  It consists of three parts: the
-                # part before the colon, the colon, and the part after colon.
-                # The part before the colon is attempting to match anything that
-                # could come before a colon acting as a field deliminater or
-                # the escaped colon in a token.  The colon is matching either a
-                # colon acting as a field separator or an escaped colon in a
-                # token or field.  The part after the colon is attempting to
-                # match the valid term that can follow a colon that's either
-                # a field separator or escaped as part of a term.
-                r"([^\'\"\(\s][^\s]*)?\:([^\s\(\'\"][^\s]*[^\s\)\'\"\>]|[^\s\(\)\'\"\>])?"
-                fields = t.value.split(":")
-                assert len(fields) >= 2
-                tmp = fields[0:1]
-                for field in fields[1:]:
-                        if tmp[-1] and tmp[-1][-1] == "\\":
-                                tmp[-1] = tmp[-1][:-1] + ":" + field
-                        else:
-                                tmp.append(field)
-                fields = tmp
-                token = fields[-1]
-                # If the last item in the list is not the empty string, then
-                # it's possible that there was no field query and that all the
-                # colons were escaped.  In that case, treat the item as a TERM
-                # rather than an FTERM.
-                if len(fields) == 1:
-                        t.type = self.reserved.get(token, "TERM")
-                        t.value = token
-                # If an unescaped colon was in the term, then this was actually
-                # a FTERM, so fill in the fields and set the type to FTERM.
-                else:
-                        key = fields[-2]
-                        action_type = ""
-                        pkg_name = ""
-                        if len(fields) >= 3:
-                                action_type = fields[-3]
-                                if len(fields) >= 4:
-                                        pkg_name = fields[-4]
-                        t.type = "FTERM"
-                        t.value = (pkg_name, action_type, key, token)
-                return t
+    def t_FTERM(self, t):
+        # This rule handles valid search terms with a colon in them.  If
+        # all colons are escaped, it produces a TERM token whose value
+        # is the original term with the escape characters removed.  If
+        # there are unescaped colons, it produces an FTERM token whose
+        # value is a four tuple consisting of the pkg name, the action
+        # type, the action key, and the token that followed the last
+        # unescaped colon.
+        #
+        # The following regular expresion matches a string with a colon
+        # in it, subject to certain other restrictions, such as not
+        # beginning with a quote.  It consists of three parts: the
+        # part before the colon, the colon, and the part after colon.
+        # The part before the colon is attempting to match anything that
+        # could come before a colon acting as a field deliminater or
+        # the escaped colon in a token.  The colon is matching either a
+        # colon acting as a field separator or an escaped colon in a
+        # token or field.  The part after the colon is attempting to
+        # match the valid term that can follow a colon that's either
+        # a field separator or escaped as part of a term.
+        r"([^\'\"\(\s][^\s]*)?\:([^\s\(\'\"][^\s]*[^\s\)\'\"\>]|[^\s\(\)\'\"\>])?"
+        fields = t.value.split(":")
+        assert len(fields) >= 2
+        tmp = fields[0:1]
+        for field in fields[1:]:
+            if tmp[-1] and tmp[-1][-1] == "\\":
+                tmp[-1] = tmp[-1][:-1] + ":" + field
+            else:
+                tmp.append(field)
+        fields = tmp
+        token = fields[-1]
+        # If the last item in the list is not the empty string, then
+        # it's possible that there was no field query and that all the
+        # colons were escaped.  In that case, treat the item as a TERM
+        # rather than an FTERM.
+        if len(fields) == 1:
+            t.type = self.reserved.get(token, "TERM")
+            t.value = token
+        # If an unescaped colon was in the term, then this was actually
+        # a FTERM, so fill in the fields and set the type to FTERM.
+        else:
+            key = fields[-2]
+            action_type = ""
+            pkg_name = ""
+            if len(fields) >= 3:
+                action_type = fields[-3]
+                if len(fields) >= 4:
+                    pkg_name = fields[-4]
+            t.type = "FTERM"
+            t.value = (pkg_name, action_type, key, token)
+        return t
 
-        def t_TERM(self, t):
-                # This rule handles the general search terms as well as
-                # checking for any reserved words such as AND or OR.
-                r'[^\s\(\'\"][^\s]*[^\s\)\'\"\>]|[^\s\(\)\'\"]'
-                t.type = self.reserved.get(t.value, "TERM")
-                return t
+    def t_TERM(self, t):
+        # This rule handles the general search terms as well as
+        # checking for any reserved words such as AND or OR.
+        r"[^\s\(\'\"][^\s]*[^\s\)\'\"\>]|[^\s\(\)\'\"]"
+        t.type = self.reserved.get(t.value, "TERM")
+        return t
 
-        def t_error(self, t):
-                raise RuntimeError("\n".join(
-                    [_("An unparseable character in query at position : {0:d}").format(
-                        self.get_pos() + 1),
+    def t_error(self, t):
+        raise RuntimeError(
+            "\n".join(
+                [
+                    _(
+                        "An unparseable character in query at position : {0:d}"
+                    ).format(self.get_pos() + 1),
                     "{0}".format(self.get_string()),
-                    "{0}".format(" " * self.get_pos() + "^")]))
+                    "{0}".format(" " * self.get_pos() + "^"),
+                ]
+            )
+        )
 
-        def build(self, **kwargs):
-                self.lexer = lex.lex(object=self, **kwargs)
+    def build(self, **kwargs):
+        self.lexer = lex.lex(object=self, **kwargs)
 
-        def set_input(self, input):
-                self.lexer.input(input)
+    def set_input(self, input):
+        self.lexer.input(input)
 
-        def token(self):
-                return self.lexer.token()
+    def token(self):
+        return self.lexer.token()
 
-        def get_pos(self):
-                return self.lexer.lexpos
+    def get_pos(self):
+        return self.lexer.lexpos
 
-        def get_string(self):
-                return self.lexer.lexdata
+    def get_string(self):
+        return self.lexer.lexdata
 
-        def test(self, data):
-                """This is a function useful for testing and debugging as it
-                shows the user exactly which tokens are produced from the input
-                data."""
+    def test(self, data):
+        """This is a function useful for testing and debugging as it
+        shows the user exactly which tokens are produced from the input
+        data."""
 
-                self.lexer.input(data)
-                while 1:
-                        tok = self.lexer.token()
-                        if not tok:
-                                break
-                        print(tok, file=sys.stderr)
+        self.lexer.input(data)
+        while 1:
+            tok = self.lexer.token()
+            if not tok:
+                break
+            print(tok, file=sys.stderr)
 
 
 class QueryParser(object):
-        """This class defines the parser which converts a stream of tokens into
-        an abstract syntax tree representation of the query.  The AST is able
-        to perform the search."""
+    """This class defines the parser which converts a stream of tokens into
+    an abstract syntax tree representation of the query.  The AST is able
+    to perform the search."""
 
-        # Use the same set of tokens as the lexer.
-        tokens = QueryLexer.tokens
+    # Use the same set of tokens as the lexer.
+    tokens = QueryLexer.tokens
 
-        # Define the precendence and associativity of certain tokens to
-        # eliminate shift/reduce conflicts in the grammar.
-        precedence = (
-            ("right", "FTERM"),
-            ("left", "TERM"),
-            ("right", "AND", "OR"),
-            ("right", "QUOTE1", "QUOTE2"),
+    # Define the precendence and associativity of certain tokens to
+    # eliminate shift/reduce conflicts in the grammar.
+    precedence = (
+        ("right", "FTERM"),
+        ("left", "TERM"),
+        ("right", "AND", "OR"),
+        ("right", "QUOTE1", "QUOTE2"),
+    )
+
+    # Note: Like the lexer, Ply uses the doctrings of the functions to
+    # determine the rules.
+
+    def p_top_level(self, p):
+        # This is the top or start node of the AST.
+        """start : xterm"""
+        p[0] = self.query_objs["TopQuery"](p[1])
+
+    def p_xterm(self, p):
+        # This rule parses xterms.  xterms are terms which can connect
+        # smaller terms together.
+        """xterm : basetermlist
+        | andterm
+        | orterm"""
+        p[0] = p[1]
+
+    def p_basetermlist(self, p):
+        # basetermlist handles performing the implicit AND operator
+        # which is placed between a list of terms.  For example the
+        # query 'foo bar' is treated the same as 'foo AND bar'.
+        """basetermlist : baseterm
+        | baseterm basetermlist"""
+        if len(p) == 3:
+            p[0] = self.query_objs["AndQuery"](p[1], p[2])
+        else:
+            p[0] = p[1]
+
+    def p_baseterm(self, p):
+        # baseterms are the minimal units of meaning for the parser.
+        # Any baseterm is a valid query unto itself.
+        """baseterm : term
+        | fterm
+        | phraseterm
+        | parenterm
+        | pkgconv"""
+        p[0] = p[1]
+
+    def p_term(self, p):
+        # terms are the parser's representation of the lexer's TERMs.
+        # The TermQuery object performs most of the work of actually
+        # performing the search.
+        "term : TERM"
+        p[0] = self.query_objs["TermQuery"](p[1])
+
+    def p_fterm(self, p):
+        # fterms are the parser's representation of the lexer's FTERMS
+        # (which are field/structured query terms).  In the query
+        # 'foo:bar:baz:zap', foo, bar, and baz are part of the FTERM,
+        # zap is split into a separate lexer TERM token.  zap flows
+        # up from parsing the ftermarg.  A query like 'foo:bar:baz' has
+        # no ftermarg though.  In that case, an implict wildcard is
+        # explicitly created.
+        """fterm : FTERM ftermarg
+        | FTERM fterm
+        | FTERM"""
+        # If the len of p is 3, then one of the first two cases
+        # was used.
+        pkg_name, at, key, token = p[1]
+        fields = pkg_name, at, key
+        if len(p) == 3:
+            # If no token was attached to the FTERM, then attach
+            # the term found following it.  If a token was attached
+            # to the FTERM then following term is treated like a
+            # basetermlist.
+            if token == "":
+                p[0] = self.query_objs["FieldQuery"](fields, p[2])
+            else:
+                p[0] = self.query_objs["AndQuery"](
+                    self.query_objs["FieldQuery"](
+                        (pkg_name, at, key), self.query_objs["TermQuery"](token)
+                    ),
+                    p[2],
+                )
+
+        # If the length of p isn't 3, then a bare FTERM was found.  If
+        # no token was attached to the FTERM, it's necessary to make
+        # the implicit wildcard explicit.
+        else:
+            if token == "":
+                token = "*"
+            p[0] = self.query_objs["FieldQuery"](
+                fields, self.query_objs["TermQuery"](token)
+            )
+
+    def p_ftermarg(self, p):
+        # ftermargs are the terms which are valid after the final
+        # colon of a field term.
+        """ftermarg : term
+        | phraseterm"""
+        p[0] = p[1]
+
+    def p_phraseterm(self, p):
+        # phraseterms are lists of terms enclosed by quotes.
+        """phraseterm : QUOTE1 term_list QUOTE1
+        | QUOTE2 term_list QUOTE2"""
+        p[2].reverse()
+        p[0] = self.query_objs["PhraseQuery"](
+            p[2], self.query_objs["TermQuery"]
         )
 
-        # Note: Like the lexer, Ply uses the doctrings of the functions to
-        # determine the rules.
+    def p_term_list(self, p):
+        # term_lists consist of one or more space separated TERMs.
+        """term_list : TERM term_list
+        | TERM"""
+        if len(p) == 3:
+            p[2].append(p[1])
+            p[0] = p[2]
+        else:
+            p[0] = [p[1]]
 
-        def p_top_level(self, p):
-                # This is the top or start node of the AST.
-                '''start : xterm'''
-                p[0] = self.query_objs["TopQuery"](p[1])
+    def p_parenterm(self, p):
+        # parenterms contain a single xterm surrounded by parens.
+        # The p[2] argument is simply passed on because the only
+        # role of parens is to perform grouping, which is enforced
+        # by the structure of the AST.
+        """parenterm : LPAREN xterm RPAREN"""
+        p[0] = p[2]
 
-        def p_xterm(self, p):
-                # This rule parses xterms.  xterms are terms which can connect
-                # smaller terms together.
-                ''' xterm : basetermlist
-                          | andterm
-                          | orterm'''
-                p[0] = p[1]
+    def p_packages(self, p):
+        # pkgconv represents the pkgs<> term.
+        "pkgconv : LBRACE xterm RBRACE"
+        p[0] = self.query_objs["PkgConversion"](p[2])
 
-        def p_basetermlist(self, p):
-                # basetermlist handles performing the implicit AND operator
-                # which is placed between a list of terms.  For example the
-                # query 'foo bar' is treated the same as 'foo AND bar'.
-                ''' basetermlist : baseterm
-                                 | baseterm basetermlist '''
-                if len(p) == 3:
-                        p[0] = self.query_objs["AndQuery"](p[1], p[2])
-                else:
-                        p[0] = p[1]
+    def p_andterm(self, p):
+        # andterms perform an intersection of the results of its
+        # two children.
+        """andterm : xterm AND xterm"""
+        p[0] = self.query_objs["AndQuery"](p[1], p[3])
 
-        def p_baseterm(self, p):
-                # baseterms are the minimal units of meaning for the parser.
-                # Any baseterm is a valid query unto itself.
-                ''' baseterm : term
-                             | fterm
-                             | phraseterm
-                             | parenterm
-                             | pkgconv'''
-                p[0] = p[1]
+    def p_orterm(self, p):
+        """orterm : xterm OR xterm"""
+        # orterms returns the union of the results of its
+        # two children.
+        p[0] = self.query_objs["OrQuery"](p[1], p[3])
 
-        def p_term(self, p):
-                # terms are the parser's representation of the lexer's TERMs.
-                # The TermQuery object performs most of the work of actually
-                # performing the search.
-                'term : TERM'
-                p[0] = self.query_objs["TermQuery"](p[1])
+    def p_error(self, p):
+        raise ParseError(p, self.lexer.get_pos(), self.lexer.get_string())
 
-        def p_fterm(self, p):
-                # fterms are the parser's representation of the lexer's FTERMS
-                # (which are field/structured query terms).  In the query
-                # 'foo:bar:baz:zap', foo, bar, and baz are part of the FTERM,
-                # zap is split into a separate lexer TERM token.  zap flows
-                # up from parsing the ftermarg.  A query like 'foo:bar:baz' has
-                # no ftermarg though.  In that case, an implict wildcard is
-                # explicitly created.
-                '''fterm : FTERM ftermarg
-                         | FTERM fterm
-                         | FTERM'''
-                # If the len of p is 3, then one of the first two cases
-                # was used.
-                pkg_name, at, key, token = p[1]
-                fields = pkg_name, at, key
-                if len(p) == 3:
-                        # If no token was attached to the FTERM, then attach
-                        # the term found following it.  If a token was attached
-                        # to the FTERM then following term is treated like a
-                        # basetermlist.
-                        if token == "":
-                                p[0] = self.query_objs["FieldQuery"](
-                                    fields, p[2])
-                        else:
-                                p[0] = self.query_objs["AndQuery"](
-                                    self.query_objs["FieldQuery"](
-                                        (pkg_name, at, key),
-                                        self.query_objs["TermQuery"](token)),
-                                    p[2])
+    def __init__(self, lexer):
+        """Build a parser using the lexer given as an argument."""
+        self.lexer = lexer
+        self.parser = yacc.yacc(module=self, debug=0, write_tables=0)
+        # Store the classes used to build the AST so that child classes
+        # can replace them where needed with alternate classes.
+        self.query_objs = {
+            "AndQuery": AndQuery,
+            "FieldQuery": FieldQuery,
+            "OrQuery": OrQuery,
+            "PhraseQuery": PhraseQuery,
+            "PkgConversion": PkgConversion,
+            "TermQuery": TermQuery,
+            "TopQuery": TopQuery,
+        }
 
-                # If the length of p isn't 3, then a bare FTERM was found.  If
-                # no token was attached to the FTERM, it's necessary to make
-                # the implicit wildcard explicit.
-                else:
-                        if token == "":
-                                token = "*"
-                        p[0] = self.query_objs["FieldQuery"](fields,
-                            self.query_objs["TermQuery"](token))
+    def parse(self, input):
+        """Parse the string, input, into an AST using the rules defined
+        in this class."""
 
-        def p_ftermarg(self, p):
-                # ftermargs are the terms which are valid after the final
-                # colon of a field term.
-                '''ftermarg : term
-                            | phraseterm'''
-                p[0] = p[1]
+        self.lexer.set_input(input)
+        return self.parser.parse(lexer=self.lexer)
 
-        def p_phraseterm(self, p):
-                # phraseterms are lists of terms enclosed by quotes.
-                ''' phraseterm : QUOTE1 term_list QUOTE1
-                               | QUOTE2 term_list QUOTE2'''
-                p[2].reverse()
-                p[0] = self.query_objs["PhraseQuery"](p[2],
-                    self.query_objs["TermQuery"])
-
-        def p_term_list(self, p):
-                # term_lists consist of one or more space separated TERMs.
-                ''' term_list : TERM term_list
-                              | TERM '''
-                if len(p) == 3:
-                        p[2].append(p[1])
-                        p[0] = p[2]
-                else:
-                        p[0] = [p[1]]
-
-        def p_parenterm(self, p):
-                # parenterms contain a single xterm surrounded by parens.
-                # The p[2] argument is simply passed on because the only
-                # role of parens is to perform grouping, which is enforced
-                # by the structure of the AST.
-                ''' parenterm : LPAREN xterm RPAREN '''
-                p[0] = p[2]
-
-        def p_packages(self, p):
-                # pkgconv represents the pkgs<> term.
-                'pkgconv : LBRACE xterm RBRACE'
-                p[0] = self.query_objs["PkgConversion"](p[2])
-
-        def p_andterm(self, p):
-                # andterms perform an intersection of the results of its
-                # two children.
-                ''' andterm : xterm AND xterm'''
-                p[0] = self.query_objs["AndQuery"](p[1], p[3])
-
-        def p_orterm(self, p):
-                ''' orterm : xterm OR xterm'''
-                # orterms returns the union of the results of its
-                # two children.
-                p[0] = self.query_objs["OrQuery"](p[1], p[3])
-
-        def p_error(self, p):
-                raise ParseError(p, self.lexer.get_pos(),
-                    self.lexer.get_string())
-
-        def __init__(self, lexer):
-                """Build a parser using the lexer given as an argument."""
-                self.lexer = lexer
-                self.parser = yacc.yacc(module=self, debug=0, write_tables=0)
-                # Store the classes used to build the AST so that child classes
-                # can replace them where needed with alternate classes.
-                self.query_objs = {
-                    "AndQuery" : AndQuery,
-                    "FieldQuery" : FieldQuery,
-                    "OrQuery" : OrQuery,
-                    "PhraseQuery" : PhraseQuery,
-                    "PkgConversion" : PkgConversion,
-                    "TermQuery" : TermQuery,
-                    "TopQuery" : TopQuery
-                }
-
-        def parse(self, input):
-                """Parse the string, input, into an AST using the rules defined
-                in this class."""
-
-                self.lexer.set_input(input)
-                return self.parser.parse(lexer=self.lexer)
 
 class QueryException(Exception):
-      pass
+    pass
 
 
 class QueryLengthExceeded(QueryException):
+    def __init__(self, token_cnt):
+        QueryException.__init__(self)
+        self.token_cnt = token_cnt
 
-        def __init__(self, token_cnt):
-                QueryException.__init__(self)
-                self.token_cnt = token_cnt
-
-        def __str__(self):
-                return _("The number of terms in the query is {len:d}, "
-                    "which exceeds the maximum supported "
-                    "value of {maxt:d} terms.").format(len=self.token_cnt,
-                    maxt=MAX_TOKEN_COUNT)
+    def __str__(self):
+        return _(
+            "The number of terms in the query is {len:d}, "
+            "which exceeds the maximum supported "
+            "value of {maxt:d} terms."
+        ).format(len=self.token_cnt, maxt=MAX_TOKEN_COUNT)
 
 
 class DetailedValueError(QueryException):
+    def __init__(self, name, bad_value, whole_query):
+        QueryException.__init__(self)
+        self.name = name
+        self.bad_value = bad_value
+        self.query = whole_query
 
-        def __init__(self, name, bad_value, whole_query):
-                QueryException.__init__(self)
-                self.name = name
-                self.bad_value = bad_value
-                self.query = whole_query
-
-        def __str__(self):
-                return _("In query {query}, {name} had a bad value of "
-                    "'{bv}'.").format(
-                        query=self.query,
-                        name=self.name,
-                        bv=self.bad_value
-                    )
+    def __str__(self):
+        return _(
+            "In query {query}, {name} had a bad value of " "'{bv}'."
+        ).format(query=self.query, name=self.name, bv=self.bad_value)
 
 
 class IncompleteQuery(QueryException):
+    def __init__(self, whole_query):
+        QueryException.__init__(self)
+        self.query = whole_query
 
-        def __init__(self, whole_query):
-                QueryException.__init__(self)
-                self.query = whole_query
-
-        def __str__(self):
-                return _("A query is expected to have five fields: "
-                    "case sensitivity, return type, number of results to "
-                    "return, the number at which to start returning results, "
-                    "and the text of the query.  The query provided lacked at "
-                    "least one of those fields:\n{0}").format(self.query)
+    def __str__(self):
+        return _(
+            "A query is expected to have five fields: "
+            "case sensitivity, return type, number of results to "
+            "return, the number at which to start returning results, "
+            "and the text of the query.  The query provided lacked at "
+            "least one of those fields:\n{0}"
+        ).format(self.query)
 
 
 class ParseError(QueryException):
-        def __init__(self, parse_object, string_position, input_string):
-                QueryException.__init__(self)
-                self.p = parse_object
-                self.pos = string_position
-                self.str = input_string
+    def __init__(self, parse_object, string_position, input_string):
+        QueryException.__init__(self)
+        self.p = parse_object
+        self.pos = string_position
+        self.str = input_string
 
-        def __str__(self):
-                # BUI will interpret a line starting with a \t as pre-formatted
-                # and put it in <pre> tags.
-                return "\n".join([_("Could not parse query."),
-                    _("Problem occurred with: {0}\t").format(self.p),
-                    "\t{0}".format(self.str),
-                    "\t{0}".format(" " * max(self.pos - 1, 0) + "^")])
+    def __str__(self):
+        # BUI will interpret a line starting with a \t as pre-formatted
+        # and put it in <pre> tags.
+        return "\n".join(
+            [
+                _("Could not parse query."),
+                _("Problem occurred with: {0}\t").format(self.p),
+                "\t{0}".format(self.str),
+                "\t{0}".format(" " * max(self.pos - 1, 0) + "^"),
+            ]
+        )
 
 
 class Query(object):
-        """General Query object.  It defines various constants and provides for
-        marshalling a Query into and out of a string format."""
+    """General Query object.  It defines various constants and provides for
+    marshalling a Query into and out of a string format."""
 
-        RETURN_EITHER = 0
-        RETURN_PACKAGES = 1
-        RETURN_ACTIONS = 2
-        VALIDATION_STRING = { 1:'Return from search v1\n' }
+    RETURN_EITHER = 0
+    RETURN_PACKAGES = 1
+    RETURN_ACTIONS = 2
+    VALIDATION_STRING = {1: "Return from search v1\n"}
 
-        def __init__(self, text, case_sensitive, return_type, num_to_return,
-            start_point):
-                """Construct a query object.
+    def __init__(
+        self, text, case_sensitive, return_type, num_to_return, start_point
+    ):
+        """Construct a query object.
 
-                The "text" parameter is the tokens and syntax of the query.
+        The "text" parameter is the tokens and syntax of the query.
 
-                The "case_sensitive" parameter is a boolean which determines
-                whether the query is case sensitive or not.
+        The "case_sensitive" parameter is a boolean which determines
+        whether the query is case sensitive or not.
 
-                The "return_type" parameter must be either RETURN_PACKAGES or
-                RETURN_ACTIONS and determines whether the query is expected to
-                return packages or actions to the querier.
+        The "return_type" parameter must be either RETURN_PACKAGES or
+        RETURN_ACTIONS and determines whether the query is expected to
+        return packages or actions to the querier.
 
-                The "num_to_return" parameter is the maximum number of results to
-                return.
+        The "num_to_return" parameter is the maximum number of results to
+        return.
 
-                The "start_point" parameter is the number of results to skip
-                before returning results to the querier."""
+        The "start_point" parameter is the number of results to skip
+        before returning results to the querier."""
 
-                token_cnt = len(text.split(" "))
-                if token_cnt > MAX_TOKEN_COUNT:
-                         raise QueryLengthExceeded(token_cnt)
+        token_cnt = len(text.split(" "))
+        if token_cnt > MAX_TOKEN_COUNT:
+            raise QueryLengthExceeded(token_cnt)
 
-                self.text = text
-                self.case_sensitive = case_sensitive
-                self.return_type = return_type
-                assert self.return_type == Query.RETURN_PACKAGES or \
-                    self.return_type == Query.RETURN_ACTIONS
-                self.num_to_return = num_to_return
-                self.start_point = start_point
+        self.text = text
+        self.case_sensitive = case_sensitive
+        self.return_type = return_type
+        assert (
+            self.return_type == Query.RETURN_PACKAGES
+            or self.return_type == Query.RETURN_ACTIONS
+        )
+        self.num_to_return = num_to_return
+        self.start_point = start_point
 
-        def __str__(self):
-                """Return the v1 string representation of this query."""
+    def __str__(self):
+        """Return the v1 string representation of this query."""
 
-                return "{0}_{1}_{2}_{3}_{4}".format(self.case_sensitive,
-                    self.return_type, self.num_to_return, self.start_point,
-                    self.text)
+        return "{0}_{1}_{2}_{3}_{4}".format(
+            self.case_sensitive,
+            self.return_type,
+            self.num_to_return,
+            self.start_point,
+            self.text,
+        )
 
-        @staticmethod
-        def fromstr(s):
-                """Take the output of the __str__ method of this class and
-                return a Query object from that string."""
+    @staticmethod
+    def fromstr(s):
+        """Take the output of the __str__ method of this class and
+        return a Query object from that string."""
 
-                try:
-                        case_sensitive, return_type, num_to_return, \
-                            start_point, text = s.split("_", 4)
-                except ValueError:
-                        raise IncompleteQuery(s)
-                if case_sensitive == 'True':
-                        case_sensitive = True
-                elif case_sensitive == 'False':
-                        case_sensitive = False
-                else:
-                        raise DetailedValueError("case_sensitive",
-                            case_sensitive, s)
-                if num_to_return == 'None':
-                        num_to_return = None
-                else:
-                        try:
-                                num_to_return = int(num_to_return)
-                        except ValueError:
-                                raise DetailedValueError("num_to_return",
-                                    num_to_return, s)
-                if start_point == 'None':
-                        start_point = None
-                else:
-                        try:
-                                start_point = int(start_point)
-                        except ValueError:
-                                raise DetailedValueError("start_point",
-                                    start_point, s)
-                try:
-                        return_type = int(return_type)
-                except ValueError:
-                        raise DetailedValueError("return_type", return_type, s)
-                if return_type != Query.RETURN_PACKAGES and \
-                    return_type != Query.RETURN_ACTIONS:
-                        raise DetailedValueError("return_type", return_type, s)
-                return Query(text, case_sensitive, return_type,
-                    num_to_return, start_point)
+        try:
+            (
+                case_sensitive,
+                return_type,
+                num_to_return,
+                start_point,
+                text,
+            ) = s.split("_", 4)
+        except ValueError:
+            raise IncompleteQuery(s)
+        if case_sensitive == "True":
+            case_sensitive = True
+        elif case_sensitive == "False":
+            case_sensitive = False
+        else:
+            raise DetailedValueError("case_sensitive", case_sensitive, s)
+        if num_to_return == "None":
+            num_to_return = None
+        else:
+            try:
+                num_to_return = int(num_to_return)
+            except ValueError:
+                raise DetailedValueError("num_to_return", num_to_return, s)
+        if start_point == "None":
+            start_point = None
+        else:
+            try:
+                start_point = int(start_point)
+            except ValueError:
+                raise DetailedValueError("start_point", start_point, s)
+        try:
+            return_type = int(return_type)
+        except ValueError:
+            raise DetailedValueError("return_type", return_type, s)
+        if (
+            return_type != Query.RETURN_PACKAGES
+            and return_type != Query.RETURN_ACTIONS
+        ):
+            raise DetailedValueError("return_type", return_type, s)
+        return Query(
+            text, case_sensitive, return_type, num_to_return, start_point
+        )
 
-        @staticmethod
-        def return_action_to_key(k):
-                """Method which produces the sort key for an action."""
+    @staticmethod
+    def return_action_to_key(k):
+        """Method which produces the sort key for an action."""
 
-                at, st, pfmri, fv, l = k
-                return pfmri
+        at, st, pfmri, fv, l = k
+        return pfmri
 
 
 class BooleanQueryException(QueryException):
-        """This exception is used when the two children of a boolean query
-        don't agree on whether to return actions or packages."""
+    """This exception is used when the two children of a boolean query
+    don't agree on whether to return actions or packages."""
 
-        def __init__(self, ac, pc):
-                """The parameter "ac" is the child which returned actions
-                while "pc" is the child which returned packages."""
-                QueryException.__init__(self)
-                self.ac = ac
-                self.pc = pc
+    def __init__(self, ac, pc):
+        """The parameter "ac" is the child which returned actions
+        while "pc" is the child which returned packages."""
+        QueryException.__init__(self)
+        self.ac = ac
+        self.pc = pc
 
-        def __str__(self):
-                # BUI will interpret a line starting with a \t as pre-formatted
-                # and put it in <pre> tags.
-                ac_s = _("This expression produces action results:")
-                ac_q = "\t{0}".format(self.ac)
-                pc_s = _("This expression produces package results:")
-                pc_q = "\t{0}".format(self.pc)
-                return "\n".join([ac_s, ac_q, pc_s, pc_q,
-                    _("'AND' and 'OR' require those expressions to produce "
-                    "the same type of results.")])
+    def __str__(self):
+        # BUI will interpret a line starting with a \t as pre-formatted
+        # and put it in <pre> tags.
+        ac_s = _("This expression produces action results:")
+        ac_q = "\t{0}".format(self.ac)
+        pc_s = _("This expression produces package results:")
+        pc_q = "\t{0}".format(self.pc)
+        return "\n".join(
+            [
+                ac_s,
+                ac_q,
+                pc_s,
+                pc_q,
+                _(
+                    "'AND' and 'OR' require those expressions to produce "
+                    "the same type of results."
+                ),
+            ]
+        )
 
 
 class BooleanQuery(object):
-        """Superclass for all boolean operations in the AST."""
+    """Superclass for all boolean operations in the AST."""
 
-        def __init__(self, left_query, right_query):
-                """The parameters "left_query" and "right_query" are objects
-                which implement the query interface.  Specifically, they're
-                expected to implement search, allow_version, set_info, and to
-                have a public member called return_type."""
+    def __init__(self, left_query, right_query):
+        """The parameters "left_query" and "right_query" are objects
+        which implement the query interface.  Specifically, they're
+        expected to implement search, allow_version, set_info, and to
+        have a public member called return_type."""
 
-                self.lc = left_query
-                self.rc = right_query
-                self.return_type = self.lc.return_type
-                self.__check_return_types()
+        self.lc = left_query
+        self.rc = right_query
+        self.return_type = self.lc.return_type
+        self.__check_return_types()
 
-        def __check_return_types(self):
-                if self.lc.return_type != self.rc.return_type:
-                        if self.lc.return_type == Query.RETURN_ACTIONS:
-                                raise BooleanQueryException(self.lc, self.rc)
-                        else:
-                                raise BooleanQueryException(self.rc, self.lc)
+    def __check_return_types(self):
+        if self.lc.return_type != self.rc.return_type:
+            if self.lc.return_type == Query.RETURN_ACTIONS:
+                raise BooleanQueryException(self.lc, self.rc)
+            else:
+                raise BooleanQueryException(self.rc, self.lc)
 
-        def add_field_restrictions(self, *params):
-                self.lc.add_field_restrictions(*params)
-                self.rc.add_field_restrictions(*params)
+    def add_field_restrictions(self, *params):
+        self.lc.add_field_restrictions(*params)
+        self.rc.add_field_restrictions(*params)
 
-        def set_info(self, **kwargs):
-                """This function passes information to the terms prior to
-                search being executed.  For a boolean query, it only needs to
-                pass whatever information exists onto its children."""
+    def set_info(self, **kwargs):
+        """This function passes information to the terms prior to
+        search being executed.  For a boolean query, it only needs to
+        pass whatever information exists onto its children."""
 
-                self.lc.set_info(**kwargs)
-                self.rc.set_info(**kwargs)
+        self.lc.set_info(**kwargs)
+        self.rc.set_info(**kwargs)
 
-        def search(self, *args):
-                """Distributes the search to the two children and returns a
-                tuple of the results."""
+    def search(self, *args):
+        """Distributes the search to the two children and returns a
+        tuple of the results."""
 
-                return set(self.lc.search(None, *args)), \
-                    set(self.rc.search(None, *args))
+        return set(self.lc.search(None, *args)), set(
+            self.rc.search(None, *args)
+        )
 
-        def sorted(self, res):
-                """Sort the results.  If the results are actions, sort by the
-                fmris of the packages from which they came."""
+    def sorted(self, res):
+        """Sort the results.  If the results are actions, sort by the
+        fmris of the packages from which they came."""
 
-                key = None
-                if self.return_type == Query.RETURN_ACTIONS:
-                        key = Query.return_action_to_key
-                return sorted(res, key=key)
+        key = None
+        if self.return_type == Query.RETURN_ACTIONS:
+            key = Query.return_action_to_key
+        return sorted(res, key=key)
 
-        def allow_version(self, v):
-                """Returns whether the query supports version v."""
+    def allow_version(self, v):
+        """Returns whether the query supports version v."""
 
-                return v > 0 and self.lc.allow_version(v) and \
-                    self.rc.allow_version(v)
+        return v > 0 and self.lc.allow_version(v) and self.rc.allow_version(v)
 
-        def propagate_pkg_return(self):
-                """Makes each child return packages instead of actions.
+    def propagate_pkg_return(self):
+        """Makes each child return packages instead of actions.
 
-                If a child returns a value that isn't None, that means a new
-                node in the tree has been created which needs to become the
-                new child for this node."""
-                self.return_type = Query.RETURN_PACKAGES
-                new_lc = self.lc.propagate_pkg_return()
-                if new_lc:
-                        self.lc = new_lc
-                new_rc = self.rc.propagate_pkg_return()
-                if new_rc:
-                        self.rc = new_rc
-                self.__check_return_types()
-                return None
+        If a child returns a value that isn't None, that means a new
+        node in the tree has been created which needs to become the
+        new child for this node."""
+        self.return_type = Query.RETURN_PACKAGES
+        new_lc = self.lc.propagate_pkg_return()
+        if new_lc:
+            self.lc = new_lc
+        new_rc = self.rc.propagate_pkg_return()
+        if new_rc:
+            self.rc = new_rc
+        self.__check_return_types()
+        return None
+
 
 class AndQuery(BooleanQuery):
-        """Class representing AND queries in the AST."""
+    """Class representing AND queries in the AST."""
 
-        def search(self, restriction, *args):
-                """Performs a search over the two children and combines
-                the results.
+    def search(self, restriction, *args):
+        """Performs a search over the two children and combines
+        the results.
 
-                The "restriction" parameter is a generator of actions, over
-                which the search shall be performed.  Only boolean queries will
-                set restriction.  Nodes that return packages have, by
-                definition, parents that must return packages.  This means that
-                only queries contained within a boolean query higher up in the
-                AST tree will have restriction set."""
+        The "restriction" parameter is a generator of actions, over
+        which the search shall be performed.  Only boolean queries will
+        set restriction.  Nodes that return packages have, by
+        definition, parents that must return packages.  This means that
+        only queries contained within a boolean query higher up in the
+        AST tree will have restriction set."""
 
-                if self.return_type == Query.RETURN_ACTIONS:
-                        # If actions are being returned, the answers from
-                        # previous terms must be used as the domain of search.
-                        # To do this, restriction is passed to the left
-                        # child and the result from that child is passed to
-                        # the right child as its domain.
-                        lc_it = self.lc.search(restriction, *args)
-                        return self.rc.search(lc_it, *args)
-                else:
-                        # If packages are being returned, holding the names
-                        # of all known packages in memory is feasible. By
-                        # using sets, and their intersection, duplicates are
-                        # also removed from the results.
-                        lc_set, rc_set = BooleanQuery.search(self, *args)
-                        return self.sorted(lc_set & rc_set)
+        if self.return_type == Query.RETURN_ACTIONS:
+            # If actions are being returned, the answers from
+            # previous terms must be used as the domain of search.
+            # To do this, restriction is passed to the left
+            # child and the result from that child is passed to
+            # the right child as its domain.
+            lc_it = self.lc.search(restriction, *args)
+            return self.rc.search(lc_it, *args)
+        else:
+            # If packages are being returned, holding the names
+            # of all known packages in memory is feasible. By
+            # using sets, and their intersection, duplicates are
+            # also removed from the results.
+            lc_set, rc_set = BooleanQuery.search(self, *args)
+            return self.sorted(lc_set & rc_set)
 
+    def __str__(self):
+        return "({0!s} AND {1!s})".format(self.lc, self.rc)
 
-        def __str__(self):
-                return "({0!s} AND {1!s})".format(self.lc, self.rc)
+    def __repr__(self):
+        return "({0!r} AND {1!r})".format(self.lc, self.rc)
 
-        def __repr__(self):
-                return "({0!r} AND {1!r})".format(self.lc, self.rc)
 
 class OrQuery(BooleanQuery):
-        """Class representing OR queries in the AST."""
+    """Class representing OR queries in the AST."""
 
-        def search(self, restriction, *args):
-                """Performs a search over the two children and combines
-                the results.
+    def search(self, restriction, *args):
+        """Performs a search over the two children and combines
+        the results.
 
-                The "restriction" parameter is a generator function that returns
-                actions within the search domain.  If it's not None,
-                then this query is under a higher boolean query which also
-                returns actions."""
+        The "restriction" parameter is a generator function that returns
+        actions within the search domain.  If it's not None,
+        then this query is under a higher boolean query which also
+        returns actions."""
 
-                if self.return_type == Query.RETURN_PACKAGES:
-                        # If packages are being returned, it's feasible to
-                        # hold them all in memory.  This allows the use of
-                        # sets, and their union, to remove duplicates and
-                        # produce a sorted list.
-                        lc_set, rc_set = BooleanQuery.search(self, *args)
-                        for i in self.sorted(lc_set | rc_set):
-                                yield i
-                elif not restriction:
-                        # If restriction doesn't exist, then chain together
-                        # the results from both children.
-                        for i in itertools.chain(self.lc.search(restriction,
-                            *args), self.rc.search(restriction, *args)):
-                                yield i
-                else:
-                        # If restriction exists, then it must serve as the
-                        # domain for the children.  It is a generator so
-                        # only one pass may be made over it.  Also, it is not
-                        # possible, in general, to hold a list of all items
-                        # that the generator will produce in memory.  These
-                        # reasons lead to the construction below, which iterates
-                        # over the results in restriction and uses each as the
-                        # restriction to the child search.  If this turns out
-                        # to be a performance bottleneck, it would be possible
-                        # to gather N of the results in restriction into a list
-                        # and dispatch them to the children results in one shot.
-                        # The tradeoff is the memory to hold O(N) results in
-                        # memory at each level of ORs in the AST.
-                        for i in restriction:
-                                for j in itertools.chain(self.lc.search([i],
-                                    *args), self.rc.search([i], *args)):
-                                        yield j
+        if self.return_type == Query.RETURN_PACKAGES:
+            # If packages are being returned, it's feasible to
+            # hold them all in memory.  This allows the use of
+            # sets, and their union, to remove duplicates and
+            # produce a sorted list.
+            lc_set, rc_set = BooleanQuery.search(self, *args)
+            for i in self.sorted(lc_set | rc_set):
+                yield i
+        elif not restriction:
+            # If restriction doesn't exist, then chain together
+            # the results from both children.
+            for i in itertools.chain(
+                self.lc.search(restriction, *args),
+                self.rc.search(restriction, *args),
+            ):
+                yield i
+        else:
+            # If restriction exists, then it must serve as the
+            # domain for the children.  It is a generator so
+            # only one pass may be made over it.  Also, it is not
+            # possible, in general, to hold a list of all items
+            # that the generator will produce in memory.  These
+            # reasons lead to the construction below, which iterates
+            # over the results in restriction and uses each as the
+            # restriction to the child search.  If this turns out
+            # to be a performance bottleneck, it would be possible
+            # to gather N of the results in restriction into a list
+            # and dispatch them to the children results in one shot.
+            # The tradeoff is the memory to hold O(N) results in
+            # memory at each level of ORs in the AST.
+            for i in restriction:
+                for j in itertools.chain(
+                    self.lc.search([i], *args), self.rc.search([i], *args)
+                ):
+                    yield j
 
-        def __str__(self):
-                return "({0!s} OR {1!s})".format(self.lc, self.rc)
+    def __str__(self):
+        return "({0!s} OR {1!s})".format(self.lc, self.rc)
 
-        def __repr__(self):
-                return "({0!r} OR {1!r})".format(self.lc, self.rc)
+    def __repr__(self):
+        return "({0!r} OR {1!r})".format(self.lc, self.rc)
+
 
 class PkgConversion(object):
-        """Class representing a change from returning actions to returning
-        packages in the AST."""
+    """Class representing a change from returning actions to returning
+    packages in the AST."""
 
-        def __init__(self, query):
-                self.query = query
-                self.return_type = Query.RETURN_PACKAGES
+    def __init__(self, query):
+        self.query = query
+        self.return_type = Query.RETURN_PACKAGES
 
-        def __str__(self):
-                return "p<{0!s}>".format(self.query)
+    def __str__(self):
+        return "p<{0!s}>".format(self.query)
 
-        def __repr__(self):
-                return "p<{0!r}>".format(self.query)
+    def __repr__(self):
+        return "p<{0!r}>".format(self.query)
 
-        def set_info(self, **kwargs):
-                """This function passes information to the terms prior to
-                search being executed.  It only needs to pass whatever
-                information exists to its child."""
+    def set_info(self, **kwargs):
+        """This function passes information to the terms prior to
+        search being executed.  It only needs to pass whatever
+        information exists to its child."""
 
-                self.query.set_info(**kwargs)
+        self.query.set_info(**kwargs)
 
-        @staticmethod
-        def optional_action_to_package(it, return_type, current_type):
-                """Based on the return_type and current type, it converts the
-                iterator over results, it, to a sorted list of packages.
-                return_type is what the caller wants to return and current_type
-                is what it is iterating over."""
+    @staticmethod
+    def optional_action_to_package(it, return_type, current_type):
+        """Based on the return_type and current type, it converts the
+        iterator over results, it, to a sorted list of packages.
+        return_type is what the caller wants to return and current_type
+        is what it is iterating over."""
 
-                if current_type == return_type or return_type == \
-                    Query.RETURN_EITHER:
-                        return it
-                elif return_type == Query.RETURN_PACKAGES and \
-                    current_type == Query.RETURN_ACTIONS:
-                        return sorted(set(
-                            (pfmri for at, st, pfmri, fv, l in it)))
-                else:
-                        assert 0
+        if current_type == return_type or return_type == Query.RETURN_EITHER:
+            return it
+        elif (
+            return_type == Query.RETURN_PACKAGES
+            and current_type == Query.RETURN_ACTIONS
+        ):
+            return sorted(set((pfmri for at, st, pfmri, fv, l in it)))
+        else:
+            assert 0
 
-        def search(self, restriction, *args):
-                """Takes the results of its child's search and converts the
-                results to be a sorted list of packages.
+    def search(self, restriction, *args):
+        """Takes the results of its child's search and converts the
+        results to be a sorted list of packages.
 
-                The "restriction" parameter is a generator of actions which
-                the domain over which search should be performed. It should
-                always be None."""
+        The "restriction" parameter is a generator of actions which
+        the domain over which search should be performed. It should
+        always be None."""
 
-                return self.optional_action_to_package(
-                    self.query.search(restriction, *args),
-                    Query.RETURN_PACKAGES, self.query.return_type)
+        return self.optional_action_to_package(
+            self.query.search(restriction, *args),
+            Query.RETURN_PACKAGES,
+            self.query.return_type,
+        )
 
-        def allow_version(self, v):
-                """Returns whether the query supports a query of version v."""
+    def allow_version(self, v):
+        """Returns whether the query supports a query of version v."""
 
-                return v > 0 and self.query.allow_version(v)
+        return v > 0 and self.query.allow_version(v)
 
-        def propagate_pkg_return(self):
-                """Makes this node return packages instead of actions.
-                Returns None because no changes need to be made to the tree."""
-                return None
+    def propagate_pkg_return(self):
+        """Makes this node return packages instead of actions.
+        Returns None because no changes need to be made to the tree."""
+        return None
+
 
 class PhraseQuery(object):
-        """Class representing a phrase search in the AST"""
+    """Class representing a phrase search in the AST"""
 
-        def __init__(self, str_list, term_query_class):
-                """The "str_list" parameter is the list of strings which make
-                up the phrase to be searched.
+    def __init__(self, str_list, term_query_class):
+        """The "str_list" parameter is the list of strings which make
+        up the phrase to be searched.
 
-                The "term_query_class" parameter is a TermQuery object which
-                handles searching for the initial word in the phrase."""
+        The "term_query_class" parameter is a TermQuery object which
+        handles searching for the initial word in the phrase."""
 
-                assert str_list
-                self.query = term_query_class(str_list[0])
-                self.full_str = " ".join(str_list)
-                self.compare_str = self.full_str
-                self.return_type = Query.RETURN_ACTIONS
-                if len(str_list) > 1:
-                        self.query.add_trailing_wildcard()
-                self._case_sensitive = None
+        assert str_list
+        self.query = term_query_class(str_list[0])
+        self.full_str = " ".join(str_list)
+        self.compare_str = self.full_str
+        self.return_type = Query.RETURN_ACTIONS
+        if len(str_list) > 1:
+            self.query.add_trailing_wildcard()
+        self._case_sensitive = None
 
-        @property
-        def pkg_name(self):
-                return self.query.pkg_name
+    @property
+    def pkg_name(self):
+        return self.query.pkg_name
 
-        @property
-        def action_type(self):
-                return self.query.action_type
+    @property
+    def action_type(self):
+        return self.query.action_type
 
-        @property
-        def key(self):
-                return self.query.key
+    @property
+    def key(self):
+        return self.query.key
 
-        def __repr__(self):
-                return "Phrase Query:'" + self.full_str + "'"
+    def __repr__(self):
+        return "Phrase Query:'" + self.full_str + "'"
 
-        def __str__(self):
-                return "{0}:'{1}'".format(self.query.field_strings(),
-                    self.full_str)
+    def __str__(self):
+        return "{0}:'{1}'".format(self.query.field_strings(), self.full_str)
 
-        def add_field_restrictions(self, *params):
-                self.query.add_field_restrictions(*params)
+    def add_field_restrictions(self, *params):
+        self.query.add_field_restrictions(*params)
 
-        def set_info(self, case_sensitive, **kwargs):
-                """This function passes information to the terms prior to
-                search being executed.  It only needs to pass whatever
-                information exists to its child."""
+    def set_info(self, case_sensitive, **kwargs):
+        """This function passes information to the terms prior to
+        search being executed.  It only needs to pass whatever
+        information exists to its child."""
 
-                self._case_sensitive = case_sensitive
-                if not case_sensitive:
-                        self.compare_str = self.full_str.lower()
-                self.query.set_info(case_sensitive=case_sensitive, **kwargs)
+        self._case_sensitive = case_sensitive
+        if not case_sensitive:
+            self.compare_str = self.full_str.lower()
+        self.query.set_info(case_sensitive=case_sensitive, **kwargs)
 
-        def filter_res(self, l):
-                """Check to see if the phrase is contained in l, the string of
-                the original action."""
+    def filter_res(self, l):
+        """Check to see if the phrase is contained in l, the string of
+        the original action."""
 
-                if self._case_sensitive:
-                        return self.compare_str in l
-                return self.compare_str in l.lower()
+        if self._case_sensitive:
+            return self.compare_str in l
+        return self.compare_str in l.lower()
 
-        @staticmethod
-        def combine(fs, fv, at, case_sensitive):
-                """Checks to see if the phrase being searched for is a subtring
-                of the value which matched the token.  If it is, use the value
-                returned, otherwise use the search phrase."""
+    @staticmethod
+    def combine(fs, fv, at, case_sensitive):
+        """Checks to see if the phrase being searched for is a subtring
+        of the value which matched the token.  If it is, use the value
+        returned, otherwise use the search phrase."""
 
-                if at != "set" or fs in fv or \
-                    (not case_sensitive and fs in fv.lower()):
-                        return fv
-                else:
-                        return fs
+        if at != "set" or fs in fv or (not case_sensitive and fs in fv.lower()):
+            return fv
+        else:
+            return fs
 
-        def search(self, restriction, *args):
-                """Perform a search for the given phrase.  The child is used to
-                find instances of the first word of the phrase.  Those results
-                are then filtered by searching for the longer phrase within
-                the original line of the action.  restriction is a generator
-                function that returns actions within the search domain."""
+    def search(self, restriction, *args):
+        """Perform a search for the given phrase.  The child is used to
+        find instances of the first word of the phrase.  Those results
+        are then filtered by searching for the longer phrase within
+        the original line of the action.  restriction is a generator
+        function that returns actions within the search domain."""
 
-                it = (
-                    (at, st, pfmri, self.combine(self.compare_str, fv, at,
-                    self._case_sensitive), force_str(l))
-                    for at, st, pfmri, fv, l
-                    in self.query.search(restriction, *args)
-                    if self.filter_res(force_str(l))
-                )
-                return it
+        it = (
+            (
+                at,
+                st,
+                pfmri,
+                self.combine(self.compare_str, fv, at, self._case_sensitive),
+                force_str(l),
+            )
+            for at, st, pfmri, fv, l in self.query.search(restriction, *args)
+            if self.filter_res(force_str(l))
+        )
+        return it
 
-        def allow_version(self, v):
-                """Returns whether the query supports a query of version v."""
+    def allow_version(self, v):
+        """Returns whether the query supports a query of version v."""
 
-                return v > 0 and self.query.allow_version(v)
+        return v > 0 and self.query.allow_version(v)
 
-        def propagate_pkg_return(self):
-                """Inserts a conversion to package results into the tree.
+    def propagate_pkg_return(self):
+        """Inserts a conversion to package results into the tree.
 
-                Creates a new node by wrapping a PkgConversion node around
-                itself. It then returns the new node to its parent for
-                insertion into the tree."""
-                return PkgConversion(self)
+        Creates a new node by wrapping a PkgConversion node around
+        itself. It then returns the new node to its parent for
+        insertion into the tree."""
+        return PkgConversion(self)
+
 
 class FieldQuery(object):
-        """Class representing a structured query in the AST."""
+    """Class representing a structured query in the AST."""
 
-        def __init__(self, params, query):
-                """Builds a FieldQuery object.
+    def __init__(self, params, query):
+        """Builds a FieldQuery object.
 
-                The "params" parameter are the three parts of the structured
-                search term pulled apart during parsing.
+        The "params" parameter are the three parts of the structured
+        search term pulled apart during parsing.
 
-                The "query" parameter is the Query object which contains the
-                fourth field (the token) of the structured search."""
+        The "query" parameter is the Query object which contains the
+        fourth field (the token) of the structured search."""
 
-                # For efficiency, especially on queries which search over
-                # '*', instead of filtering the results, this class makes
-                # modifications to its child class so that it will do the
-                # needed filtering as it does the search.
-                self.query = query
-                self.return_type = Query.RETURN_ACTIONS
-                self.query.add_field_restrictions(*params)
+        # For efficiency, especially on queries which search over
+        # '*', instead of filtering the results, this class makes
+        # modifications to its child class so that it will do the
+        # needed filtering as it does the search.
+        self.query = query
+        self.return_type = Query.RETURN_ACTIONS
+        self.query.add_field_restrictions(*params)
 
-        def __repr__(self):
-                return "( PN:{0!r} AT:{1!r} ST:{2!r} Q:{3!r})".format(
-                    self.query.pkg_name, self.query.action_type, self.query.key,
-                    self.query)
+    def __repr__(self):
+        return "( PN:{0!r} AT:{1!r} ST:{2!r} Q:{3!r})".format(
+            self.query.pkg_name,
+            self.query.action_type,
+            self.query.key,
+            self.query,
+        )
 
-        def __str__(self):
-                return str(self.query)
+    def __str__(self):
+        return str(self.query)
 
-        def set_info(self, **kwargs):
-                """This function passes information to the terms prior to
-                search being executed.  It only needs to pass whatever
-                information exists to its child."""
+    def set_info(self, **kwargs):
+        """This function passes information to the terms prior to
+        search being executed.  It only needs to pass whatever
+        information exists to its child."""
 
-                self.query.set_info(**kwargs)
+        self.query.set_info(**kwargs)
 
-        def search(self, restriction, *args):
-                """Perform a search for the structured query.  The child has
-                been modified so that it is able to do the structured query
-                directly."""
+    def search(self, restriction, *args):
+        """Perform a search for the structured query.  The child has
+        been modified so that it is able to do the structured query
+        directly."""
 
-                assert self.query.return_type == Query.RETURN_ACTIONS
-                return self.query.search(restriction, *args)
+        assert self.query.return_type == Query.RETURN_ACTIONS
+        return self.query.search(restriction, *args)
 
-        def allow_version(self, v):
-                """Returns whether the query supports a query of version v."""
+    def allow_version(self, v):
+        """Returns whether the query supports a query of version v."""
 
-                return v > 0 and self.query.allow_version(v)
+        return v > 0 and self.query.allow_version(v)
 
-        def propagate_pkg_return(self):
-                """Inserts a conversion to package results into the tree.
+    def propagate_pkg_return(self):
+        """Inserts a conversion to package results into the tree.
 
-                Creates a new node by wrapping a PkgConversion node around
-                itself. It then returns the new node to its parent for
-                insertion into the tree."""
-                return PkgConversion(self)
+        Creates a new node by wrapping a PkgConversion node around
+        itself. It then returns the new node to its parent for
+        insertion into the tree."""
+        return PkgConversion(self)
+
 
 class TopQuery(object):
-        """Class which must be at the top of all valid ASTs, and may only be
-        at the top of an AST.  It handles starting N results in, or only
-        showing M items.  It also transforms the internal representations of
-        results into the format expected by the callers of search."""
+    """Class which must be at the top of all valid ASTs, and may only be
+    at the top of an AST.  It handles starting N results in, or only
+    showing M items.  It also transforms the internal representations of
+    results into the format expected by the callers of search."""
 
-        def __init__(self, query):
-                self.query = query
-                self.start_point = 0
-                self.num_to_return = None
+    def __init__(self, query):
+        self.query = query
+        self.start_point = 0
+        self.num_to_return = None
 
-        def __repr__(self):
-                return "TopQuery({0!r})".format(self.query)
+    def __repr__(self):
+        return "TopQuery({0!r})".format(self.query)
 
-        def __str__(self):
-                return str(self.query)
+    def __str__(self):
+        return str(self.query)
 
-        def __keep(self, x):
-                """Determines whether the x'th result should be returned."""
+    def __keep(self, x):
+        """Determines whether the x'th result should be returned."""
 
-                return x >= self.start_point and \
-                    (self.num_to_return is None or
-                    x < self.num_to_return + self.start_point)
+        return x >= self.start_point and (
+            self.num_to_return is None
+            or x < self.num_to_return + self.start_point
+        )
 
-        def finalize_results(self, it):
-                """Converts the internal result representation to the format
-                which is expected by the callers of search.  It also handles
-                returning only those results requested by the user."""
+    def finalize_results(self, it):
+        """Converts the internal result representation to the format
+        which is expected by the callers of search.  It also handles
+        returning only those results requested by the user."""
 
-                # Need to replace "1" with current search version, or something
-                # similar
+        # Need to replace "1" with current search version, or something
+        # similar
 
-                if self.query.return_type == Query.RETURN_ACTIONS:
-                        return (
-                            (1, Query.RETURN_ACTIONS,
-                            (fmri.PkgFmri(pfmri), fv, force_str(l)))
-                            for x, (at, st, pfmri, fv, l)
-                            in enumerate(it)
-                            if self.__keep(x)
-                        )
-                else:
-                        return (
-                            (1, Query.RETURN_PACKAGES, fmri.PkgFmri(pfmri))
-                            for x, pfmri
-                            in enumerate(it)
-                            if self.__keep(x)
-                        )
+        if self.query.return_type == Query.RETURN_ACTIONS:
+            return (
+                (
+                    1,
+                    Query.RETURN_ACTIONS,
+                    (fmri.PkgFmri(pfmri), fv, force_str(l)),
+                )
+                for x, (at, st, pfmri, fv, l) in enumerate(it)
+                if self.__keep(x)
+            )
+        else:
+            return (
+                (1, Query.RETURN_PACKAGES, fmri.PkgFmri(pfmri))
+                for x, pfmri in enumerate(it)
+                if self.__keep(x)
+            )
 
-        def set_info(self, num_to_return, start_point, **kwargs):
-                """This function passes information to the terms prior to
-                search being executed.  This is also where the starting point
-                and number of results to return is set.  Both "num_to_return"
-                and "start_point" are expected to be integers."""
+    def set_info(self, num_to_return, start_point, **kwargs):
+        """This function passes information to the terms prior to
+        search being executed.  This is also where the starting point
+        and number of results to return is set.  Both "num_to_return"
+        and "start_point" are expected to be integers."""
 
-                if start_point:
-                        self.start_point = start_point
-                self.num_to_return = num_to_return
-                self.query.set_info(start_point=start_point,
-                    num_to_return=num_to_return, **kwargs)
+        if start_point:
+            self.start_point = start_point
+        self.num_to_return = num_to_return
+        self.query.set_info(
+            start_point=start_point, num_to_return=num_to_return, **kwargs
+        )
 
+    def search(self, *args):
+        """Perform search by taking the result of the child's search
+        and transforming and subselecting the results.  None is passed
+        to the child since initially there is no set of results to
+        restrict subsequent searches to."""
 
-        def search(self, *args):
-                """Perform search by taking the result of the child's search
-                and transforming and subselecting the results.  None is passed
-                to the child since initially there is no set of results to
-                restrict subsequent searches to."""
+        return self.finalize_results(self.query.search(None, *args))
 
-                return self.finalize_results(self.query.search(None, *args))
+    def allow_version(self, v):
+        """Returns whether the query supports a query of version v."""
 
-        def allow_version(self, v):
-                """Returns whether the query supports a query of version v."""
+        return self.query.allow_version(v)
 
-                return self.query.allow_version(v)
+    def propagate_pkg_return(self):
+        """Makes the child return packages instead of actions.
 
-        def propagate_pkg_return(self):
-                """Makes the child return packages instead of actions.
+        If a child returns a value that isn't None, that means a new
+        node in the tree has been created which needs to become the
+        new child for this node."""
+        new_child = self.query.propagate_pkg_return()
+        if new_child:
+            self.query = new_child
+        return None
 
-                If a child returns a value that isn't None, that means a new
-                node in the tree has been created which needs to become the
-                new child for this node."""
-                new_child = self.query.propagate_pkg_return()
-                if new_child:
-                        self.query = new_child
-                return None
 
 class TermQuery(object):
-        """Class representing the a single query term in the AST.  This is an
-        abstract class and should not be used instead of the related client and
-        server classes."""
+    """Class representing the a single query term in the AST.  This is an
+    abstract class and should not be used instead of the related client and
+    server classes."""
 
-        # This structure was used to gather all index files into one
-        # location. If a new index structure is needed, the files can
-        # be added (or removed) from here. Providing a list or
-        # dictionary allows an easy approach to opening or closing all
-        # index files.
+    # This structure was used to gather all index files into one
+    # location. If a new index structure is needed, the files can
+    # be added (or removed) from here. Providing a list or
+    # dictionary allows an easy approach to opening or closing all
+    # index files.
 
-        __dict_locks = {}
+    __dict_locks = {}
 
-        has_non_wildcard_character = re.compile(r'.*[^\*\?].*')
+    has_non_wildcard_character = re.compile(r".*[^\*\?].*")
 
-        fmris = None
+    fmris = None
 
-        def __init__(self, term):
-                """term is a the string for the token to be searched for."""
+    def __init__(self, term):
+        """term is a the string for the token to be searched for."""
 
-                term = term.strip()
-                self._glob = False
-                if '*' in term or '?' in term or '[' in term:
-                        self._glob = True
-                self._term = term
+        term = term.strip()
+        self._glob = False
+        if "*" in term or "?" in term or "[" in term:
+            self._glob = True
+        self._term = term
 
-                self.return_type = Query.RETURN_ACTIONS
-                self._file_timeout_secs = FILE_OPEN_TIMEOUT_SECS
+        self.return_type = Query.RETURN_ACTIONS
+        self._file_timeout_secs = FILE_OPEN_TIMEOUT_SECS
 
-                # This block of options is used by FieldQuery to limit the
-                # domain of search.
-                self.pkg_name = None
-                self.action_type = None
-                self.key = None
-                self.action_type_wildcard = True
-                self.key_wildcard = True
-                self.pkg_name_wildcard = True
-                self.pkg_name_match = None
-                self._case_sensitive = None
-                self._dir_path = None
+        # This block of options is used by FieldQuery to limit the
+        # domain of search.
+        self.pkg_name = None
+        self.action_type = None
+        self.key = None
+        self.action_type_wildcard = True
+        self.key_wildcard = True
+        self.pkg_name_wildcard = True
+        self.pkg_name_match = None
+        self._case_sensitive = None
+        self._dir_path = None
 
-                # These variables are set by set_info and are used to hold
-                # information specific to the particular search index that this
-                # AST is being built for.
-                self._manifest_path_func = None
-                self._data_manf = None
-                self._data_token_offset = None
-                self._data_main_dict = None
+        # These variables are set by set_info and are used to hold
+        # information specific to the particular search index that this
+        # AST is being built for.
+        self._manifest_path_func = None
+        self._data_manf = None
+        self._data_token_offset = None
+        self._data_main_dict = None
 
-        def __init_gdd(self, path):
-                gdd = self._global_data_dict
-                if path in gdd:
-                        return
+    def __init_gdd(self, path):
+        gdd = self._global_data_dict
+        if path in gdd:
+            return
 
-                # Setup default global dictionary for this index path.
-                gdd[path] = {
-                    "manf": ss.IndexStoreDict(ss.MANIFEST_LIST),
-                    "token_byte_offset": ss.IndexStoreDictMutable(
-                        ss.BYTE_OFFSET_FILE),
-                    "fmri_offsets": ss.InvertedDict(ss.FMRI_OFFSETS_FILE, None)
-                }
+        # Setup default global dictionary for this index path.
+        gdd[path] = {
+            "manf": ss.IndexStoreDict(ss.MANIFEST_LIST),
+            "token_byte_offset": ss.IndexStoreDictMutable(ss.BYTE_OFFSET_FILE),
+            "fmri_offsets": ss.InvertedDict(ss.FMRI_OFFSETS_FILE, None),
+        }
 
-        @classmethod
-        def __lock_gdd(cls, index_dir):
-                # This lock is used so that only one instance of a term query
-                # object is ever modifying the class wide variable for this
-                # index.
-                cls.__dict_locks.setdefault(index_dir,
-                    threading.Lock()).acquire()
+    @classmethod
+    def __lock_gdd(cls, index_dir):
+        # This lock is used so that only one instance of a term query
+        # object is ever modifying the class wide variable for this
+        # index.
+        cls.__dict_locks.setdefault(index_dir, threading.Lock()).acquire()
 
-        @classmethod
-        def __unlock_gdd(cls, index_dir):
-                cls.__dict_locks[index_dir].release()
+    @classmethod
+    def __unlock_gdd(cls, index_dir):
+        cls.__dict_locks[index_dir].release()
 
-        @classmethod
-        def _get_gdd(cls, path):
-                return cls._global_data_dict[path]
+    @classmethod
+    def _get_gdd(cls, path):
+        return cls._global_data_dict[path]
 
-        def __repr__(self):
-                return "( TermQuery: " + self._term + " )"
+    def __repr__(self):
+        return "( TermQuery: " + self._term + " )"
 
-        def __str__(self):
-                return "{0}:{1}".format(self.field_strings(),
-                    self.__wc_to_string(False, self._term))
+    def __str__(self):
+        return "{0}:{1}".format(
+            self.field_strings(), self.__wc_to_string(False, self._term)
+        )
 
-        def field_strings(self):
-                return ":".join([
-                    self.__wc_to_string(wc, v)
-                    for wc, v in [(self.pkg_name_wildcard, self.pkg_name),
-                        (self.action_type_wildcard, self.action_type),
-                        (self.key_wildcard, self.key)
-                    ]
-                ])
+    def field_strings(self):
+        return ":".join(
+            [
+                self.__wc_to_string(wc, v)
+                for wc, v in [
+                    (self.pkg_name_wildcard, self.pkg_name),
+                    (self.action_type_wildcard, self.action_type),
+                    (self.key_wildcard, self.key),
+                ]
+            ]
+        )
 
-        def propagate_pkg_return(self):
-                """Inserts a conversion to package results into the tree.
+    def propagate_pkg_return(self):
+        """Inserts a conversion to package results into the tree.
 
-                Creates a new node by wrapping a PkgConversion node around
-                itself. It then returns the new node to its parent for
-                insertion into the tree."""
-                return PkgConversion(self)
+        Creates a new node by wrapping a PkgConversion node around
+        itself. It then returns the new node to its parent for
+        insertion into the tree."""
+        return PkgConversion(self)
 
-        @staticmethod
-        def __wc_to_string(wc, v):
-                if wc:
-                        return ""
-                return "\\:".join(v.split(":"))
+    @staticmethod
+    def __wc_to_string(wc, v):
+        if wc:
+            return ""
+        return "\\:".join(v.split(":"))
 
-        @classmethod
-        def clear_cache(cls, index_dir):
-                """Dump any cached index data for specified index path."""
+    @classmethod
+    def clear_cache(cls, index_dir):
+        """Dump any cached index data for specified index path."""
 
-                gdd = cls._global_data_dict
-                cls.__lock_gdd(index_dir)
-                try:
-                        del gdd[index_dir]
-                except KeyError:
-                        pass
-                finally:
-                        cls.__unlock_gdd(index_dir)
+        gdd = cls._global_data_dict
+        cls.__lock_gdd(index_dir)
+        try:
+            del gdd[index_dir]
+        except KeyError:
+            pass
+        finally:
+            cls.__unlock_gdd(index_dir)
 
-        def add_field_restrictions(self, pkg_name, action_type, key):
-                """Add the information needed to restrict the search domain
-                to the specified fields."""
+    def add_field_restrictions(self, pkg_name, action_type, key):
+        """Add the information needed to restrict the search domain
+        to the specified fields."""
 
-                self.pkg_name = pkg_name
-                self.action_type = action_type
-                self.key = key
-                self.action_type_wildcard = \
-                    self.__is_wildcard(self.action_type)
-                self.key_wildcard = self.__is_wildcard(self.key)
-                self.pkg_name_wildcard = self.__is_wildcard(self.pkg_name)
-                # Because users will rarely want to search on package names
-                # by fully specifying them out to their time stamps, package
-                # name search is treated as a prefix match.  To accomplish
-                # this, a star is appended to the package name if it doesn't
-                # already end in one.
-                if not self.pkg_name_wildcard:
-                        if not self.pkg_name.endswith("*"):
-                                self.pkg_name += "*"
-                        self.pkg_name_match = \
-                            re.compile(fnmatch.translate(self.pkg_name),
-                                re.I).match
+        self.pkg_name = pkg_name
+        self.action_type = action_type
+        self.key = key
+        self.action_type_wildcard = self.__is_wildcard(self.action_type)
+        self.key_wildcard = self.__is_wildcard(self.key)
+        self.pkg_name_wildcard = self.__is_wildcard(self.pkg_name)
+        # Because users will rarely want to search on package names
+        # by fully specifying them out to their time stamps, package
+        # name search is treated as a prefix match.  To accomplish
+        # this, a star is appended to the package name if it doesn't
+        # already end in one.
+        if not self.pkg_name_wildcard:
+            if not self.pkg_name.endswith("*"):
+                self.pkg_name += "*"
+            self.pkg_name_match = re.compile(
+                fnmatch.translate(self.pkg_name), re.I
+            ).match
 
-        @staticmethod
-        def __is_wildcard(s):
-                return s == '*' or s == ''
+    @staticmethod
+    def __is_wildcard(s):
+        return s == "*" or s == ""
 
-        def add_trailing_wildcard(self):
-                """Ensures that the search is a prefix match.  Primarily used
-                by the PhraseQuery class."""
+    def add_trailing_wildcard(self):
+        """Ensures that the search is a prefix match.  Primarily used
+        by the PhraseQuery class."""
 
-                if not self._term.endswith('*'):
-                        self._term += "*"
+        if not self._term.endswith("*"):
+            self._term += "*"
 
-        def set_info(self, index_dir, get_manifest_path,
-            case_sensitive, **kwargs):
-                """Sets the information needed to search which is specific to
-                the particular index used to back the search.
+    def set_info(self, index_dir, get_manifest_path, case_sensitive, **kwargs):
+        """Sets the information needed to search which is specific to
+        the particular index used to back the search.
 
-                'index_dir' is a path to the base directory of the index.
+        'index_dir' is a path to the base directory of the index.
 
-                'get_manifest_path' is a function which when given a
-                fully specified fmri returns the path to the manifest file
-                for that fmri.
+        'get_manifest_path' is a function which when given a
+        fully specified fmri returns the path to the manifest file
+        for that fmri.
 
-                'case_sensitive' is a boolean which determines whether search
-                is case sensitive or not."""
+        'case_sensitive' is a boolean which determines whether search
+        is case sensitive or not."""
 
-                self._dir_path = index_dir
-                assert self._dir_path
+        self._dir_path = index_dir
+        assert self._dir_path
 
-                self._manifest_path_func = get_manifest_path
-                self._case_sensitive = case_sensitive
-                self.__init_gdd(self._dir_path)
+        self._manifest_path_func = get_manifest_path
+        self._case_sensitive = case_sensitive
+        self.__init_gdd(self._dir_path)
 
-                # Take the static class lock because it's possible we'll
-                # modify the shared dictionaries for the class.
-                self.__lock_gdd(self._dir_path)
-                gdd = self._global_data_dict
-                tq_gdd = self._get_gdd(self._dir_path)
-                try:
-                        self._data_main_dict = \
-                            ss.IndexStoreMainDict(ss.MAIN_FILE)
-                        if "fmri_offsets" not in tq_gdd:
-                                tq_gdd["fmri_offsets"] = ss.InvertedDict(
-                                    ss.FMRI_OFFSETS_FILE, None)
-                        # Create a temporary list of dictionaries we need to
-                        # open consistently.
-                        tmp = list(tq_gdd.values())
-                        tmp.append(self._data_main_dict)
-                        try:
-                                # Try to open the index files assuming they
-                                # were made after the conversion to using the
-                                # fmri_offsets.v1 file.
-                                ret = ss.consistent_open(tmp, self._dir_path,
-                                    self._file_timeout_secs)
-                        except search_errors.InconsistentIndexException:
-                                # If opening the index fails, try falling
-                                # back to the index prior to the conversion
-                                # to using the fmri_offsets.v1 file.
-                                del tq_gdd["fmri_offsets"]
-                                tmp = list(tq_gdd.values())
-                                tmp.append(self._data_main_dict)
-                                ret = ss.consistent_open(tmp, self._dir_path,
-                                    self._file_timeout_secs)
+        # Take the static class lock because it's possible we'll
+        # modify the shared dictionaries for the class.
+        self.__lock_gdd(self._dir_path)
+        gdd = self._global_data_dict
+        tq_gdd = self._get_gdd(self._dir_path)
+        try:
+            self._data_main_dict = ss.IndexStoreMainDict(ss.MAIN_FILE)
+            if "fmri_offsets" not in tq_gdd:
+                tq_gdd["fmri_offsets"] = ss.InvertedDict(
+                    ss.FMRI_OFFSETS_FILE, None
+                )
+            # Create a temporary list of dictionaries we need to
+            # open consistently.
+            tmp = list(tq_gdd.values())
+            tmp.append(self._data_main_dict)
+            try:
+                # Try to open the index files assuming they
+                # were made after the conversion to using the
+                # fmri_offsets.v1 file.
+                ret = ss.consistent_open(
+                    tmp, self._dir_path, self._file_timeout_secs
+                )
+            except search_errors.InconsistentIndexException:
+                # If opening the index fails, try falling
+                # back to the index prior to the conversion
+                # to using the fmri_offsets.v1 file.
+                del tq_gdd["fmri_offsets"]
+                tmp = list(tq_gdd.values())
+                tmp.append(self._data_main_dict)
+                ret = ss.consistent_open(
+                    tmp, self._dir_path, self._file_timeout_secs
+                )
+            if ret == None:
+                raise search_errors.NoIndexException(self._dir_path)
+            should_reread = False
+            # Check to see if any of the in-memory stores of the
+            # dictionaries are out of date compared to the ones
+            # on disc.
+            for k, d in tq_gdd.items():
+                if d.should_reread():
+                    should_reread = True
+                    break
+            try:
+                # If any of the in-memory dictionaries are out
+                # of date, create new copies of the shared
+                # dictionaries and make the shared structure
+                # point at them.  This is to prevent changing
+                # the data structures in any other threads
+                # which may be part way through executing a
+                # search.
+                if should_reread:
+                    for i in tmp:
+                        i.close_file_handle()
+                    tq_gdd = gdd[self._dir_path] = dict(
+                        [(k, copy.copy(d)) for k, d in tq_gdd.items()]
+                    )
+                    tmp = list(tq_gdd.values())
+                    tmp.append(self._data_main_dict)
+                    ret = ss.consistent_open(
+                        tmp, self._dir_path, self._file_timeout_secs
+                    )
+                    try:
                         if ret == None:
-                                raise search_errors.NoIndexException(
-                                    self._dir_path)
-                        should_reread = False
-                        # Check to see if any of the in-memory stores of the
-                        # dictionaries are out of date compared to the ones
-                        # on disc.
-                        for k, d in tq_gdd.items():
-                                if d.should_reread():
-                                        should_reread = True
-                                        break
-                        try:
-                                # If any of the in-memory dictionaries are out
-                                # of date, create new copies of the shared
-                                # dictionaries and make the shared structure
-                                # point at them.  This is to prevent changing
-                                # the data structures in any other threads
-                                # which may be part way through executing a
-                                # search.
-                                if should_reread:
-                                        for i in tmp:
-                                                i.close_file_handle()
-                                        tq_gdd = gdd[self._dir_path] = \
-                                            dict([
-                                                (k, copy.copy(d))
-                                                for k, d
-                                                in tq_gdd.items()
-                                            ])
-                                        tmp = list(tq_gdd.values())
-                                        tmp.append(self._data_main_dict)
-                                        ret = ss.consistent_open(tmp,
-                                            self._dir_path,
-                                            self._file_timeout_secs)
-                                        try:
-                                                if ret == None:
-                                                        raise search_errors.NoIndexException(
-                                                            self._dir_path)
-                                                # Reread the dictionaries and
-                                                # store the new information in
-                                                # the shared data structure.
-                                                for d in tq_gdd.values():
-                                                        d.read_dict_file()
-                                        except:
-                                                self._data_main_dict.close_file_handle()
-                                                raise
+                            raise search_errors.NoIndexException(self._dir_path)
+                        # Reread the dictionaries and
+                        # store the new information in
+                        # the shared data structure.
+                        for d in tq_gdd.values():
+                            d.read_dict_file()
+                    except:
+                        self._data_main_dict.close_file_handle()
+                        raise
 
-                        finally:
-                                # Ensure that the files are closed no matter
-                                # what happens.
-                                for d in tq_gdd.values():
-                                        d.close_file_handle()
-                        self._data_manf = tq_gdd["manf"]
+            finally:
+                # Ensure that the files are closed no matter
+                # what happens.
+                for d in tq_gdd.values():
+                    d.close_file_handle()
+            self._data_manf = tq_gdd["manf"]
 
-                        self._data_token_offset = tq_gdd["token_byte_offset"]
-                        self._data_fmri_offsets = tq_gdd.get("fmri_offsets",
-                            None)
-                finally:
-                        self.__unlock_gdd(self._dir_path)
+            self._data_token_offset = tq_gdd["token_byte_offset"]
+            self._data_fmri_offsets = tq_gdd.get("fmri_offsets", None)
+        finally:
+            self.__unlock_gdd(self._dir_path)
 
-        def allow_version(self, v):
-                """Returns whether the query supports a query of version v."""
-                return True
+    def allow_version(self, v):
+        """Returns whether the query supports a query of version v."""
+        return True
 
-        def _close_dicts(self):
-                """Closes the main dictionary file handle, which is handled
-                separately from the other dictionaries since it's not read
-                entirely into memory in one shot."""
+    def _close_dicts(self):
+        """Closes the main dictionary file handle, which is handled
+        separately from the other dictionaries since it's not read
+        entirely into memory in one shot."""
 
-                self._data_main_dict.close_file_handle()
+        self._data_main_dict.close_file_handle()
 
-        @staticmethod
-        def flatten(lst):
-                """Takes a list which may contain one or more sublists and
-                returns a list which contains all the items contained in the
-                original list and its sublists, but without any sublists."""
+    @staticmethod
+    def flatten(lst):
+        """Takes a list which may contain one or more sublists and
+        returns a list which contains all the items contained in the
+        original list and its sublists, but without any sublists."""
 
-                res = []
-                for l in lst:
-                        if isinstance(l, list):
-                                res.extend(TermQuery.flatten(l))
-                        else:
-                                res.append(l)
-                return res
+        res = []
+        for l in lst:
+            if isinstance(l, list):
+                res.extend(TermQuery.flatten(l))
+            else:
+                res.append(l)
+        return res
 
-        def _restricted_search_internal(self, restriction):
-                """Searches for the given term within a restricted domain of
-                search results.  restriction is a generator function that
-                returns actions within the search domain."""
+    def _restricted_search_internal(self, restriction):
+        """Searches for the given term within a restricted domain of
+        search results.  restriction is a generator function that
+        returns actions within the search domain."""
 
-                glob = self._glob
-                term = self._term
-                case_sensitive = self._case_sensitive
+        glob = self._glob
+        term = self._term
+        case_sensitive = self._case_sensitive
 
-                if not case_sensitive:
-                        glob = True
-                for at, st, fmri_str, fv, l in restriction:
-                        # Check if the current action doesn't match any field
-                        # query specifications.
-                        if not (self.pkg_name_wildcard or
-                            self.pkg_name_match(fmri_str)) or \
-                            not (self.action_type_wildcard or
-                            at == self.action_type) or \
-                            not (self.key_wildcard or st == self.key):
-                                continue
-                        l = l.strip()
-                        # Find the possible tokens for this action.
-                        act = actions.fromstr(l)
-                        toks = [t[2] for t in act.generate_indices()]
-                        toks = self.flatten(toks)
-                        matches = []
-                        if glob:
-                                matches = choose(toks, term, case_sensitive)
-                        elif term in toks:
-                                matches = True
-                        # If this search term matches any of the tokens the
-                        # action could generate, yield it.  If not, continue
-                        # on to the next action.
-                        if matches:
-                                yield at, st, fmri_str, fv, l
+        if not case_sensitive:
+            glob = True
+        for at, st, fmri_str, fv, l in restriction:
+            # Check if the current action doesn't match any field
+            # query specifications.
+            if (
+                not (self.pkg_name_wildcard or self.pkg_name_match(fmri_str))
+                or not (self.action_type_wildcard or at == self.action_type)
+                or not (self.key_wildcard or st == self.key)
+            ):
+                continue
+            l = l.strip()
+            # Find the possible tokens for this action.
+            act = actions.fromstr(l)
+            toks = [t[2] for t in act.generate_indices()]
+            toks = self.flatten(toks)
+            matches = []
+            if glob:
+                matches = choose(toks, term, case_sensitive)
+            elif term in toks:
+                matches = True
+            # If this search term matches any of the tokens the
+            # action could generate, yield it.  If not, continue
+            # on to the next action.
+            if matches:
+                yield at, st, fmri_str, fv, l
 
-        def __offset_line_read(self, offsets):
-                """Takes a group of byte offsets into the main dictionary and
-                reads the lines starting at those byte offsets."""
+    def __offset_line_read(self, offsets):
+        """Takes a group of byte offsets into the main dictionary and
+        reads the lines starting at those byte offsets."""
 
-                md_fh = self._data_main_dict.get_file_handle()
-                for o in sorted(offsets):
-                        md_fh.seek(o)
-                        yield md_fh.readline()
+        md_fh = self._data_main_dict.get_file_handle()
+        for o in sorted(offsets):
+            md_fh.seek(o)
+            yield md_fh.readline()
 
-        def _read_pkg_dirs(self, fmris):
-                """Legacy function used to search indexes which have a pkg
-                directory with fmri offset information instead of the
-                fmri_offsets.v1 file."""
+    def _read_pkg_dirs(self, fmris):
+        """Legacy function used to search indexes which have a pkg
+        directory with fmri offset information instead of the
+        fmri_offsets.v1 file."""
 
-                if not os.path.isdir(os.path.join(self._dir_path, "pkg")):
-                        raise search_errors.InconsistentIndexException(
-                            self._dir_path)
+        if not os.path.isdir(os.path.join(self._dir_path, "pkg")):
+            raise search_errors.InconsistentIndexException(self._dir_path)
 
-                if TermQuery.fmris is None and not self.pkg_name_wildcard:
-                        TermQuery.fmris = list(fmris())
-                pkg_offsets = set()
-                for matching_pfmri in (
-                    p
-                    for p in TermQuery.fmris
-                    if self.pkg_name_match(
-                        p.get_fmri(anarchy=True, include_scheme=False))
-                ):
-                        try:
-                                fh = open(os.path.join(
-                                    self._dir_path, "pkg",
-                                    matching_pfmri.get_name(),
-                                    str(matching_pfmri.version)), "rb")
-                        except EnvironmentError as e:
-                                if e.errno != errno.ENOENT:
-                                        raise
-                                continue
-                        for l in fh:
-                                pkg_offsets.add(int(l))
-                return pkg_offsets
+        if TermQuery.fmris is None and not self.pkg_name_wildcard:
+            TermQuery.fmris = list(fmris())
+        pkg_offsets = set()
+        for matching_pfmri in (
+            p
+            for p in TermQuery.fmris
+            if self.pkg_name_match(
+                p.get_fmri(anarchy=True, include_scheme=False)
+            )
+        ):
+            try:
+                fh = open(
+                    os.path.join(
+                        self._dir_path,
+                        "pkg",
+                        matching_pfmri.get_name(),
+                        str(matching_pfmri.version),
+                    ),
+                    "rb",
+                )
+            except EnvironmentError as e:
+                if e.errno != errno.ENOENT:
+                    raise
+                continue
+            for l in fh:
+                pkg_offsets.add(int(l))
+        return pkg_offsets
 
-        def _search_internal(self, fmris):
-                """Searches the indexes in dir_path for any matches of query
-                and the results in self.res.  The method assumes the
-                dictionaries have already been loaded and read appropriately.
+    def _search_internal(self, fmris):
+        """Searches the indexes in dir_path for any matches of query
+        and the results in self.res.  The method assumes the
+        dictionaries have already been loaded and read appropriately.
 
-                The "fmris" parameter is a generator of fmris of installed
-                packages."""
+        The "fmris" parameter is a generator of fmris of installed
+        packages."""
 
-                assert self._data_main_dict.get_file_handle() is not None
+        assert self._data_main_dict.get_file_handle() is not None
 
-                glob = self._glob
-                term = self._term
-                case_sensitive = self._case_sensitive
+        glob = self._glob
+        term = self._term
+        case_sensitive = self._case_sensitive
 
-                if not case_sensitive:
-                        glob = True
-                # If offsets is equal to None, match all possible results.  A
-                # match with no results is represented by an empty set.
-                offsets = None
+        if not case_sensitive:
+            glob = True
+        # If offsets is equal to None, match all possible results.  A
+        # match with no results is represented by an empty set.
+        offsets = None
 
-                if glob:
-                        # If the term has at least one non-wildcard character
-                        # in it, do the glob search.
-                        if TermQuery.has_non_wildcard_character.match(term):
-                                keys = self._data_token_offset.get_keys()
-                                matches = choose(keys, term, case_sensitive)
-                                offsets = set([
-                                    self._data_token_offset.get_id(match)
-                                    for match in matches
-                                ])
-                elif self._data_token_offset.has_entity(term):
-                        offsets = set([
-                            self._data_token_offset.get_id(term)])
+        if glob:
+            # If the term has at least one non-wildcard character
+            # in it, do the glob search.
+            if TermQuery.has_non_wildcard_character.match(term):
+                keys = self._data_token_offset.get_keys()
+                matches = choose(keys, term, case_sensitive)
+                offsets = set(
+                    [self._data_token_offset.get_id(match) for match in matches]
+                )
+        elif self._data_token_offset.has_entity(term):
+            offsets = set([self._data_token_offset.get_id(term)])
+        else:
+            # Close the dictionaries since there are
+            # no more results to yield.
+            self._close_dicts()
+            return
+
+        # Restrict results by package name.
+        if not self.pkg_name_wildcard:
+            try:
+                pkg_offsets = self._data_fmri_offsets.get_offsets(
+                    self.pkg_name_match
+                )
+            except AttributeError:
+                pkg_offsets = self._read_pkg_dirs(fmris)
+            if offsets is None:
+                offsets = pkg_offsets
+            else:
+                offsets &= pkg_offsets
+        # Restrict results by action type.
+        if not self.action_type_wildcard:
+            tmp_set = set()
+            try:
+                fh = open(
+                    os.path.join(self._dir_path, "__at_" + self.action_type),
+                    "rb",
+                )
+                for l in fh:
+                    tmp_set.add(int(l.strip()))
+                if offsets is None:
+                    offsets = tmp_set
                 else:
-                        # Close the dictionaries since there are
-                        # no more results to yield.
-                        self._close_dicts()
-                        return
+                    offsets &= tmp_set
+            except EnvironmentError as e:
+                if e.errno != errno.ENOENT:
+                    raise
+                # If the file doesn't exist, then no actions
+                # with that action type were indexed.
+                offsets = set()
+        # Restrict results by key.
+        if not self.key_wildcard:
+            tmp_set = set()
+            try:
+                fh = open(
+                    os.path.join(self._dir_path, "__st_" + self.key), "rb"
+                )
+                for l in fh:
+                    tmp_set.add(int(l))
+                if offsets is None:
+                    offsets = tmp_set
+                else:
+                    offsets &= tmp_set
+            except EnvironmentError as e:
+                if e.errno != errno.ENOENT:
+                    raise
+                # If the file doesn't exist, then no actions
+                # with that key were indexed.
+                offsets = set()
+        line_iter = EmptyI
+        # If offsets isn't None, then the set of results has been
+        # restricted so iterate through those offsets.
+        if offsets is not None:
+            line_iter = self.__offset_line_read(offsets)
+        # If offsets is None and the term was only wildcard search
+        # tokens, return results for every known token.
+        elif glob and not TermQuery.has_non_wildcard_character.match(term):
+            line_iter = self._data_main_dict.get_file_handle()
 
-                # Restrict results by package name.
-                if not self.pkg_name_wildcard:
-                        try:
-                                pkg_offsets = \
-                                    self._data_fmri_offsets.get_offsets(
-                                        self.pkg_name_match)
-                        except AttributeError:
-                                pkg_offsets = self._read_pkg_dirs(fmris)
-                        if offsets is None:
-                                offsets = pkg_offsets
-                        else:
-                                offsets &= pkg_offsets
-                # Restrict results by action type.
-                if not self.action_type_wildcard:
-                        tmp_set = set()
-                        try:
-                                fh = open(os.path.join(self._dir_path,
-                                    "__at_" + self.action_type), "rb")
-                                for l in fh:
-                                        tmp_set.add(int(l.strip()))
-                                if offsets is None:
-                                        offsets = tmp_set
-                                else:
-                                        offsets &= tmp_set
-                        except EnvironmentError as e:
-                                if e.errno != errno.ENOENT:
-                                        raise
-                                # If the file doesn't exist, then no actions
-                                # with that action type were indexed.
-                                offsets = set()
-                # Restrict results by key.
-                if not self.key_wildcard:
-                        tmp_set = set()
-                        try:
-                                fh = open(os.path.join(self._dir_path,
-                                    "__st_" + self.key), "rb")
-                                for l in fh:
-                                        tmp_set.add(int(l))
-                                if offsets is None:
-                                        offsets = tmp_set
-                                else:
-                                        offsets &= tmp_set
-                        except EnvironmentError as e:
-                                if e.errno != errno.ENOENT:
-                                        raise
-                                # If the file doesn't exist, then no actions
-                                # with that key were indexed.
-                                offsets = set()
-                line_iter = EmptyI
-                # If offsets isn't None, then the set of results has been
-                # restricted so iterate through those offsets.
-                if offsets is not None:
-                        line_iter = self.__offset_line_read(offsets)
-                # If offsets is None and the term was only wildcard search
-                # tokens, return results for every known token.
-                elif glob and \
-                    not TermQuery.has_non_wildcard_character.match(term):
-                        line_iter = self._data_main_dict.get_file_handle()
+        for line in line_iter:
+            assert not line == "\n"
+            tok, at_lst = self._data_main_dict.parse_main_dict_line(line)
+            # Check that the token was what was expected.
+            assert (
+                (term == tok)
+                or (not case_sensitive and term.lower() == tok.lower())
+                or (glob and fnmatch.fnmatch(tok, term))
+                or (
+                    not case_sensitive
+                    and fnmatch.fnmatch(tok.lower(), term.lower())
+                )
+            )
+            # Check the various action types this token was
+            # associated with.
+            for at, st_list in at_lst:
+                if not self.action_type_wildcard and at != self.action_type:
+                    continue
+                # Check the key types this token and action type
+                # were associated with.
+                for st, fv_list in st_list:
+                    if not self.key_wildcard and st != self.key:
+                        continue
+                    # Get the values which matched this
+                    # token.
+                    for fv, p_list in fv_list:
+                        # Get the fmri id and list of
+                        # offsets into the manifest for
+                        # that fmri id.
+                        for p_id, m_off_set in p_list:
+                            p_id = int(p_id)
+                            p_str = self._data_manf.get_entity(p_id)
+                            # Check that the pkg
+                            # name matches the
+                            # restrictions, if any
+                            # exist.
+                            if (
+                                not self.pkg_name_wildcard
+                                and not self.pkg_name_match(p_str)
+                            ):
+                                continue
+                            int_os = [int(o) for o in m_off_set]
+                            yield (p_str, int_os, at, st, fv)
+        # Close the dictionaries since there are no more results to
+        # yield.
+        self._close_dicts()
+        return
 
-                for line in line_iter:
-                        assert not line == '\n'
-                        tok, at_lst = \
-                            self._data_main_dict.parse_main_dict_line(line)
-                        # Check that the token was what was expected.
-                        assert ((term == tok) or
-                            (not case_sensitive and
-                            term.lower() == tok.lower()) or
-                            (glob and fnmatch.fnmatch(tok, term)) or
-                            (not case_sensitive and
-                            fnmatch.fnmatch(tok.lower(), term.lower())))
-                        # Check the various action types this token was
-                        # associated with.
-                        for at, st_list in at_lst:
-                                if not self.action_type_wildcard and \
-                                    at != self.action_type:
-                                        continue
-                                # Check the key types this token and action type
-                                # were associated with.
-                                for st, fv_list in st_list:
-                                        if not self.key_wildcard and \
-                                            st != self.key:
-                                                continue
-                                        # Get the values which matched this
-                                        # token.
-                                        for fv, p_list in fv_list:
-                                                # Get the fmri id and list of
-                                                # offsets into the manifest for
-                                                # that fmri id.
-                                                for p_id, m_off_set in p_list:
-                                                        p_id = int(p_id)
-                                                        p_str = self._data_manf.get_entity(p_id)
-                                                        # Check that the pkg
-                                                        # name matches the
-                                                        # restrictions, if any
-                                                        # exist.
-                                                        if not self.pkg_name_wildcard and not self.pkg_name_match(p_str):
-                                                                continue
-                                                        int_os = [
-                                                            int(o)
-                                                            for o
-                                                            in m_off_set
-                                                        ]
-                                                        yield (p_str, int_os,
-                                                            at, st, fv)
-                # Close the dictionaries since there are no more results to
-                # yield.
-                self._close_dicts()
-                return
+    def _get_results(self, res):
+        """Takes the results from search_internal ("res") and reads the
+        lines from the manifest files at the provided offsets."""
 
-        def _get_results(self, res):
-                """Takes the results from search_internal ("res") and reads the
-                lines from the manifest files at the provided offsets."""
+        for fmri_str, offsets, at, st, fv in res:
+            send_res = []
+            f = fmri.PkgFmri(fmri_str)
+            path = self._manifest_path_func(f)
+            # XXX If action size changes substantially, we should
+            # reexamine whether the buffer size should be changed.
+            file_handle = open(path, "rb", buffering=512)
+            for o in sorted(offsets):
+                file_handle.seek(o)
+                send_res.append((fv, at, st, file_handle.readline()))
+            file_handle.close()
+            for fv, at, st, l in send_res:
+                yield at, st, fmri_str, fv, l
 
-                for fmri_str, offsets, at, st, fv in res:
-                        send_res = []
-                        f = fmri.PkgFmri(fmri_str)
-                        path = self._manifest_path_func(f)
-                        # XXX If action size changes substantially, we should
-                        # reexamine whether the buffer size should be changed.
-                        file_handle = open(path, "rb", buffering=512)
-                        for o in sorted(offsets):
-                                file_handle.seek(o)
-                                send_res.append((fv, at, st,
-                                    file_handle.readline()))
-                        file_handle.close()
-                        for fv, at, st, l in send_res:
-                                yield at, st, fmri_str, fv, l
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/search_errors.py
+++ b/src/modules/search_errors.py
@@ -29,75 +29,88 @@
 # displayed, catch the exception on the client side and display a custom
 # message.
 
-class IndexingException(Exception):
-        """The base class for all exceptions that can occur while indexing."""
 
-        def __init__(self, cause):
-                self.cause = cause
+class IndexingException(Exception):
+    """The base class for all exceptions that can occur while indexing."""
+
+    def __init__(self, cause):
+        self.cause = cause
 
 
 class InconsistentIndexException(IndexingException):
-        """This is used when the existing index is found to have inconsistent
-        versions."""
+    """This is used when the existing index is found to have inconsistent
+    versions."""
 
-        def __str__(self):
-                return "Index corrupted, remove all files and " \
-                    "rebuild from scratch by clearing out {0} " \
-                    " and restarting the depot.".format(self.cause)
+    def __str__(self):
+        return (
+            "Index corrupted, remove all files and "
+            "rebuild from scratch by clearing out {0} "
+            " and restarting the depot.".format(self.cause)
+        )
 
 
 class IndexLockedException(IndexingException):
-        """This is used when an attempt to modify an index locked by another
-        thread or process is made."""
+    """This is used when an attempt to modify an index locked by another
+    thread or process is made."""
 
-        def __init__(self, hostname=None, pid=None):
-                IndexingException.__init__(self, None)
-                self.hostname = hostname
-                self.pid = pid
+    def __init__(self, hostname=None, pid=None):
+        IndexingException.__init__(self, None)
+        self.hostname = hostname
+        self.pid = pid
 
-        def __str__(self):
-                if self.pid is not None:
-                        # Used even if hostname is undefined.
-                        return _("The search index cannot be modified as it "
-                            "is currently in use by another process: "
-                            "pid {pid} on {host}.").format(
-                            pid=self.pid, host=self.hostname)
-                return _("The search index cannot be modified as it is "
-                    "currently in use by another process.")
+    def __str__(self):
+        if self.pid is not None:
+            # Used even if hostname is undefined.
+            return _(
+                "The search index cannot be modified as it "
+                "is currently in use by another process: "
+                "pid {pid} on {host}."
+            ).format(pid=self.pid, host=self.hostname)
+        return _(
+            "The search index cannot be modified as it is "
+            "currently in use by another process."
+        )
 
 
 class ProblematicPermissionsIndexException(IndexingException):
-        """This is used when the indexer is unable to create, move, or remove
-        files or directories it should be able to."""
+    """This is used when the indexer is unable to create, move, or remove
+    files or directories it should be able to."""
 
-        def __str__(self):
-                return "Could not remove or create " \
-                    "{0} because of\nincorrect " \
-                    "permissions. Please correct this issue then " \
-                    "rebuild the index.".format(self.cause)
+    def __str__(self):
+        return (
+            "Could not remove or create "
+            "{0} because of\nincorrect "
+            "permissions. Please correct this issue then "
+            "rebuild the index.".format(self.cause)
+        )
+
 
 class NoIndexException(Exception):
-        """This is used when a search is executed while no index exists."""
+    """This is used when a search is executed while no index exists."""
 
-        def __init__(self, index_dir):
-                self.index_dir = index_dir
+    def __init__(self, index_dir):
+        self.index_dir = index_dir
 
-        def __str__(self):
-                return "Could not find index to search, looked in: " \
-                    "{0}".format(self.index_dir)
+    def __str__(self):
+        return "Could not find index to search, looked in: " "{0}".format(
+            self.index_dir
+        )
+
 
 class IncorrectIndexFileHash(Exception):
-        """This is used when the index hash value doesn't match the hash of the
-        packages installed in the image."""
+    """This is used when the index hash value doesn't match the hash of the
+    packages installed in the image."""
 
-        def __init__(self, existing_val, incoming_val):
-                Exception.__init__(self)
-                self.ev = existing_val
-                self.iv = incoming_val
+    def __init__(self, existing_val, incoming_val):
+        Exception.__init__(self)
+        self.ev = existing_val
+        self.iv = incoming_val
 
-        def __str__(self):
-                return "existing_val was:{0}\nincoming_val was:{1}".format(
-                    self.ev, self.iv)
+    def __str__(self):
+        return "existing_val was:{0}\nincoming_val was:{1}".format(
+            self.ev, self.iv
+        )
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/search_storage.py
+++ b/src/modules/search_storage.py
@@ -35,810 +35,820 @@ import pkg.search_errors as search_errors
 import pkg.portable as portable
 from pkg.misc import PKG_FILE_BUFSIZ, force_bytes
 
-FAST_ADD = 'fast_add.v1'
-FAST_REMOVE = 'fast_remove.v1'
-MANIFEST_LIST = 'manf_list.v1'
-FULL_FMRI_FILE = 'full_fmri_list'
-MAIN_FILE = 'main_dict.ascii.v2'
-BYTE_OFFSET_FILE = 'token_byte_offset.v1'
-FULL_FMRI_HASH_FILE = 'full_fmri_list.hash'
-FMRI_OFFSETS_FILE = 'fmri_offsets.v1'
+FAST_ADD = "fast_add.v1"
+FAST_REMOVE = "fast_remove.v1"
+MANIFEST_LIST = "manf_list.v1"
+FULL_FMRI_FILE = "full_fmri_list"
+MAIN_FILE = "main_dict.ascii.v2"
+BYTE_OFFSET_FILE = "token_byte_offset.v1"
+FULL_FMRI_HASH_FILE = "full_fmri_list.hash"
+FMRI_OFFSETS_FILE = "fmri_offsets.v1"
 
-def consistent_open(data_list, directory, timeout = 1):
-        """Opens all data holders in data_list and ensures that the
-        versions are consistent among all of them.
-        It retries several times in case a race condition between file
-        migration and open is encountered.
-        Note: Do not set timeout to be 0. It will cause an exception to be
-        immediately raised.
-        """
 
-        missing = None
-        cur_version = None
+def consistent_open(data_list, directory, timeout=1):
+    """Opens all data holders in data_list and ensures that the
+    versions are consistent among all of them.
+    It retries several times in case a race condition between file
+    migration and open is encountered.
+    Note: Do not set timeout to be 0. It will cause an exception to be
+    immediately raised.
+    """
 
-        start_time = time.time()
+    missing = None
+    cur_version = None
 
-        while cur_version == None and missing != True:
-                # The assignments to cur_version and missing cannot be
-                # placed here. They must be reset prior to breaking out of the
-                # for loop so that the while loop condition will be true. They
-                # cannot be placed after the for loop since that path is taken
-                # when all files are missing or opened successfully.
-                if timeout != None and ((time.time() - start_time) > timeout):
-                        raise search_errors.InconsistentIndexException(
-                            directory)
-                for d in data_list:
-                        # All indexes must have the same version and all must
-                        # either be present or absent for a successful return.
-                        # If one of these conditions is not met, the function
-                        # tries again until it succeeds or the time spent in
-                        # in the function is greater than timeout.
-                        try:
-                                f = os.path.join(directory, d.get_file_name())
-                                fh = open(f, 'r', encoding='UTF-8')
-                                # If we get here, then the current index file
-                                # is present.
-                                if missing == None:
-                                        missing = False
-                                elif missing:
-                                        for dl in data_list:
-                                                dl.close_file_handle()
-                                        missing = None
-                                        cur_version = None
-                                        break
-                                d.set_file_handle(fh, f)
-                                version_tmp = fh.readline()
-                                version_num = \
-                                    int(version_tmp.split(' ')[1].rstrip('\n'))
-                                # Read the version. If this is the first file,
-                                # set the expected version otherwise check that
-                                # the version matches the expected version.
-                                if cur_version == None:
-                                        cur_version = version_num
-                                elif not (cur_version == version_num):
-                                        # Got inconsistent versions, so close
-                                        # all files and try again.
-                                        for d in data_list:
-                                                d.close_file_handle()
-                                        missing = None
-                                        cur_version = None
-                                        break
-                        except IOError as e:
-                                if e.errno == errno.ENOENT:
-                                        # If the index file is missing, ensure
-                                        # that previous files were missing as
-                                        # well. If not, try again.
-                                        if missing == False:
-                                                for d in data_list:
-                                                        d.close_file_handle()
-                                                missing = None
-                                                cur_version = None
-                                                break
-                                        missing = True
-                                else:
-                                        for d in data_list:
-                                                d.close_file_handle()
-                                        raise
-        if missing:
-                assert cur_version == None
-                # The index is missing (ie, no files were present).
-                return None
-        else:
-                assert cur_version is not None
-                return cur_version
+    start_time = time.time()
+
+    while cur_version == None and missing != True:
+        # The assignments to cur_version and missing cannot be
+        # placed here. They must be reset prior to breaking out of the
+        # for loop so that the while loop condition will be true. They
+        # cannot be placed after the for loop since that path is taken
+        # when all files are missing or opened successfully.
+        if timeout != None and ((time.time() - start_time) > timeout):
+            raise search_errors.InconsistentIndexException(directory)
+        for d in data_list:
+            # All indexes must have the same version and all must
+            # either be present or absent for a successful return.
+            # If one of these conditions is not met, the function
+            # tries again until it succeeds or the time spent in
+            # in the function is greater than timeout.
+            try:
+                f = os.path.join(directory, d.get_file_name())
+                fh = open(f, "r", encoding="UTF-8")
+                # If we get here, then the current index file
+                # is present.
+                if missing == None:
+                    missing = False
+                elif missing:
+                    for dl in data_list:
+                        dl.close_file_handle()
+                    missing = None
+                    cur_version = None
+                    break
+                d.set_file_handle(fh, f)
+                version_tmp = fh.readline()
+                version_num = int(version_tmp.split(" ")[1].rstrip("\n"))
+                # Read the version. If this is the first file,
+                # set the expected version otherwise check that
+                # the version matches the expected version.
+                if cur_version == None:
+                    cur_version = version_num
+                elif not (cur_version == version_num):
+                    # Got inconsistent versions, so close
+                    # all files and try again.
+                    for d in data_list:
+                        d.close_file_handle()
+                    missing = None
+                    cur_version = None
+                    break
+            except IOError as e:
+                if e.errno == errno.ENOENT:
+                    # If the index file is missing, ensure
+                    # that previous files were missing as
+                    # well. If not, try again.
+                    if missing == False:
+                        for d in data_list:
+                            d.close_file_handle()
+                        missing = None
+                        cur_version = None
+                        break
+                    missing = True
+                else:
+                    for d in data_list:
+                        d.close_file_handle()
+                    raise
+    if missing:
+        assert cur_version == None
+        # The index is missing (ie, no files were present).
+        return None
+    else:
+        assert cur_version is not None
+        return cur_version
 
 
 class IndexStoreBase(object):
-        """Base class for all data storage used by the indexer and
-        queryEngine. All members must have a file name and maintain
-        an internal file handle to that file as instructed by external
-        calls.
+    """Base class for all data storage used by the indexer and
+    queryEngine. All members must have a file name and maintain
+    an internal file handle to that file as instructed by external
+    calls.
+    """
+
+    def __init__(self, file_name):
+        self._name = file_name
+        self._file_handle = None
+        self._file_path = None
+        self._size = None
+        self._mtime = None
+        self._inode = None
+        self._have_read = False
+
+    def get_file_name(self):
+        return self._name
+
+    def set_file_handle(self, f_handle, f_path):
+        if self._file_handle:
+            raise RuntimeError(
+                "setting an extant file handle, "
+                "must close first, fp is: " + f_path
+            )
+        else:
+            self._file_handle = f_handle
+            self._file_path = f_path
+            if self._mtime is None:
+                stat_info = os.stat(self._file_path)
+                self._mtime = stat_info.st_mtime
+                self._size = stat_info.st_size
+                self._inode = stat_info.st_ino
+
+    def get_file_path(self):
+        return self._file_path
+
+    def __copy__(self):
+        return self.__class__(self._name)
+
+    def close_file_handle(self):
+        """Closes the file handle and clears it so that it cannot
+        be reused.
         """
 
-        def __init__(self, file_name):
-                self._name = file_name
-                self._file_handle = None
-                self._file_path = None
-                self._size = None
-                self._mtime = None
-                self._inode = None
-                self._have_read = False
+        if self._file_handle:
+            self._file_handle.close()
+            self._file_handle = None
 
-        def get_file_name(self):
-                return self._name
+    def _protected_write_dict_file(self, path, version_num, iterable):
+        """Writes the dictionary in the expected format.
+        Note: Only child classes should call this method.
+        """
+        version_string = "VERSION: "
+        file_handle = open(os.path.join(path, self._name), "w")
+        file_handle.write(version_string + str(version_num) + "\n")
+        for name in iterable:
+            file_handle.write(str(name) + "\n")
+        file_handle.close()
 
-        def set_file_handle(self, f_handle, f_path):
-                if self._file_handle:
-                        raise RuntimeError("setting an extant file handle, "
-                            "must close first, fp is: " + f_path)
-                else:
-                        self._file_handle = f_handle
-                        self._file_path = f_path
-                        if self._mtime is None:
-                                stat_info = os.stat(self._file_path)
-                                self._mtime = stat_info.st_mtime
-                                self._size = stat_info.st_size
-                                self._inode = stat_info.st_ino
+    def should_reread(self):
+        """This method uses the modification time and the file size
+        to (heuristically) determine whether the file backing this
+        storage has changed since it was last read.
+        """
+        stat_info = os.stat(self._file_path)
+        if (
+            self._inode != stat_info.st_ino
+            or self._mtime != stat_info.st_mtime
+            or self._size != stat_info.st_size
+        ):
+            return True
+        return not self._have_read
 
-        def get_file_path(self):
-                return self._file_path
+    def read_dict_file(self):
+        self._have_read = True
 
-        def __copy__(self):
-                return self.__class__(self._name)
-
-        def close_file_handle(self):
-                """Closes the file handle and clears it so that it cannot
-                be reused.
-                """
-
-                if self._file_handle:
-                        self._file_handle.close()
-                        self._file_handle = None
-
-        def _protected_write_dict_file(self, path, version_num, iterable):
-                """Writes the dictionary in the expected format.
-                Note: Only child classes should call this method.
-                """
-                version_string = "VERSION: "
-                file_handle = open(os.path.join(path, self._name), 'w')
-                file_handle.write(version_string + str(version_num) + "\n")
-                for name in iterable:
-                        file_handle.write(str(name) + "\n")
-                file_handle.close()
-
-        def should_reread(self):
-                """This method uses the modification time and the file size
-                to (heuristically) determine whether the file backing this
-                storage has changed since it was last read.
-                """
-                stat_info = os.stat(self._file_path)
-                if self._inode != stat_info.st_ino or \
-                    self._mtime != stat_info.st_mtime or \
-                    self._size != stat_info.st_size:
-                        return True
-                return not self._have_read
-
-        def read_dict_file(self):
-                self._have_read = True
-
-        def open(self, directory):
-                """This uses consistent open to ensure that the version line
-                processing is done consistently and that only a single function
-                actually opens files stored using this class.
-                """
-                return consistent_open([self], directory)
+    def open(self, directory):
+        """This uses consistent open to ensure that the version line
+        processing is done consistently and that only a single function
+        actually opens files stored using this class.
+        """
+        return consistent_open([self], directory)
 
 
 class IndexStoreMainDict(IndexStoreBase):
-        """Class for representing the main dictionary file
+    """Class for representing the main dictionary file"""
+
+    # Here is an example of a line from the main dictionary, it is
+    # explained below:
+    # %25gconf.xml file!basename@basename#579,13249,13692,77391,77628
+    #
+    # Each line begins with a urllib quoted search token. It's followed by
+    # a set of space separated lists.  Each of these lists begin with an
+    # action type.  It's separated from its sublist by a '!'.  Next is the
+    # key type, which is separated from its sublist by a '@'.  Next is the
+    # full value, which is used in set actions to hold the full value which
+    # matched the token.  It's separated from its sublist by a '#'.  The
+    # next token (579) is the fmri id.  The subsequent comma separated
+    # values are the byte offsets into that manifest of the lines containing
+    # that token.
+
+    sep_chars = [" ", "!", "@", "#", ","]
+
+    def __init__(self, file_name):
+        IndexStoreBase.__init__(self, file_name)
+        self._old_suffix = None
+
+    def write_dict_file(self, path, version_num):
+        """This class relies on external methods to write the file.
+        Making this empty call to protected_write_dict_file allows the
+        file to be set up correctly with the version number stored
+        correctly.
         """
-        # Here is an example of a line from the main dictionary, it is
-        # explained below:
-        # %25gconf.xml file!basename@basename#579,13249,13692,77391,77628
-        #
-        # Each line begins with a urllib quoted search token. It's followed by
-        # a set of space separated lists.  Each of these lists begin with an
-        # action type.  It's separated from its sublist by a '!'.  Next is the
-        # key type, which is separated from its sublist by a '@'.  Next is the
-        # full value, which is used in set actions to hold the full value which
-        # matched the token.  It's separated from its sublist by a '#'.  The
-        # next token (579) is the fmri id.  The subsequent comma separated
-        # values are the byte offsets into that manifest of the lines containing
-        # that token.
+        IndexStoreBase._protected_write_dict_file(self, path, version_num, [])
 
-        sep_chars = [" ", "!", "@", "#", ","]
+    def get_file_handle(self):
+        """Return the file handle. Note that doing
+        anything other than sequential reads or writes
+        to or from this file_handle may result in unexpected
+        behavior. In short, don't use seek.
+        """
+        return self._file_handle
 
-        def __init__(self, file_name):
-                IndexStoreBase.__init__(self, file_name)
-                self._old_suffix = None
+    @staticmethod
+    def parse_main_dict_line(line):
+        """Parses one line of a main dictionary file.
+        Changes to this function must be paired with changes to
+        write_main_dict_line below.
 
-        def write_dict_file(self, path, version_num):
-                """This class relies on external methods to write the file.
-                Making this empty call to protected_write_dict_file allows the
-                file to be set up correctly with the version number stored
-                correctly.
-                """
-                IndexStoreBase._protected_write_dict_file(self, path,
-                                                          version_num, [])
+        This should produce the same data structure that
+        _write_main_dict_line in indexer.py creates to write out each
+        line.
+        """
 
-        def get_file_handle(self):
-                """Return the file handle. Note that doing
-                anything other than sequential reads or writes
-                to or from this file_handle may result in unexpected
-                behavior. In short, don't use seek.
-                """
-                return self._file_handle
+        split_chars = IndexStoreMainDict.sep_chars
+        line = line.rstrip("\n")
+        tmp = line.split(split_chars[0])
+        tok = unquote(tmp[0])
+        atl = tmp[1:]
+        res = []
+        for ati in atl:
+            tmp = ati.split(split_chars[1])
+            action_type = tmp[0]
+            stl = tmp[1:]
+            at_res = []
+            for sti in stl:
+                tmp = sti.split(split_chars[2])
+                subtype = tmp[0]
+                fvl = tmp[1:]
+                st_res = []
+                for fvi in fvl:
+                    tmp = fvi.split(split_chars[3])
+                    full_value = unquote(tmp[0])
+                    pfl = tmp[1:]
+                    fv_res = []
+                    for pfi in pfl:
+                        tmp = pfi.split(split_chars[4])
+                        pfmri_index = int(tmp[0])
+                        offsets = [int(t) for t in tmp[1:]]
+                        fv_res.append((pfmri_index, offsets))
+                    st_res.append((full_value, fv_res))
+                at_res.append((subtype, st_res))
+            res.append((action_type, at_res))
+        return tok, res
 
-        @staticmethod
-        def parse_main_dict_line(line):
-                """Parses one line of a main dictionary file.
-                Changes to this function must be paired with changes to
-                write_main_dict_line below.
+    @staticmethod
+    def parse_main_dict_line_for_token(line):
+        """Pulls the token out of a line from a main dictionary file.
+        Changes to this function must be paired with changes to
+        write_main_dict_line below.
+        """
 
-                This should produce the same data structure that
-                _write_main_dict_line in indexer.py creates to write out each
-                line.
-                """
+        line = line.rstrip("\n")
+        lst = line.split(" ", 1)
+        return unquote(lst[0])
 
-                split_chars = IndexStoreMainDict.sep_chars
-                line = line.rstrip('\n')
-                tmp = line.split(split_chars[0])
-                tok = unquote(tmp[0])
-                atl = tmp[1:]
-                res = []
-                for ati in atl:
-                        tmp = ati.split(split_chars[1])
-                        action_type = tmp[0]
-                        stl = tmp[1:]
-                        at_res = []
-                        for sti in stl:
-                                tmp = sti.split(split_chars[2])
-                                subtype = tmp[0]
-                                fvl = tmp[1:]
-                                st_res = []
-                                for fvi in fvl:
-                                        tmp = fvi.split(split_chars[3])
-                                        full_value = unquote(tmp[0])
-                                        pfl = tmp[1:]
-                                        fv_res = []
-                                        for pfi in pfl:
-                                                tmp = pfi.split(split_chars[4])
-                                                pfmri_index = int(tmp[0])
-                                                offsets = [
-                                                    int(t) for t in tmp[1:]
-                                                ]
-                                                fv_res.append(
-                                                    (pfmri_index, offsets))
-                                        st_res.append((full_value, fv_res))
-                                at_res.append((subtype, st_res))
-                        res.append((action_type, at_res))
-                return tok, res
+    @staticmethod
+    def transform_main_dict_line(token, entries):
+        """Paired with parse_main_dict_line above.  Transforms a token
+        and its data into the string which can be written to the main
+        dictionary.
 
-        @staticmethod
-        def parse_main_dict_line_for_token(line):
-                """Pulls the token out of a line from a main dictionary file.
-                Changes to this function must be paired with changes to
-                write_main_dict_line below.
-                """
+        The "token" parameter is the token whose index line is being
+        generated.
 
-                line = line.rstrip("\n")
-                lst = line.split(" ", 1)
-                return unquote(lst[0])
+        The "entries" parameter is a list of lists of lists and so on.
+        It contains information about where and how "token" was seen in
+        manifests.  The depth of all lists at each level must be
+        consistent, and must match the length of "sep_chars" and
+        "quote".  The details of the contents on entries are described
+        in _write_main_dict_line in indexer.py.
+        """
+        sep_chars = IndexStoreMainDict.sep_chars
+        res = "{0}".format(quote(str(token)))
+        for ati, atl in enumerate(entries):
+            action_type, atl = atl
+            res += "{0}{1}".format(sep_chars[0], action_type)
+            for sti, stl in enumerate(atl):
+                subtype, stl = stl
+                res += "{0}{1}".format(sep_chars[1], subtype)
+                for fvi, fvl in enumerate(stl):
+                    full_value, fvl = fvl
+                    res += "{0}{1}".format(sep_chars[2], quote(str(full_value)))
+                    for pfi, pfl in enumerate(fvl):
+                        pfmri_index, pfl = pfl
+                        res += "{0}{1}".format(sep_chars[3], pfmri_index)
+                        for offset in pfl:
+                            res += "{0}{1}".format(sep_chars[4], offset)
+        return res + "\n"
 
-        @staticmethod
-        def transform_main_dict_line(token, entries):
-                """Paired with parse_main_dict_line above.  Transforms a token
-                and its data into the string which can be written to the main
-                dictionary.
+    def count_entries_removed_during_partial_indexing(self):
+        """Returns the number of entries removed during a second phase
+        of indexing.
+        """
+        # This returns 0 because this class is not responsible for
+        # storing anything in memory.
+        return 0
 
-                The "token" parameter is the token whose index line is being
-                generated.
-
-                The "entries" parameter is a list of lists of lists and so on.
-                It contains information about where and how "token" was seen in
-                manifests.  The depth of all lists at each level must be
-                consistent, and must match the length of "sep_chars" and
-                "quote".  The details of the contents on entries are described
-                in _write_main_dict_line in indexer.py.
-                """
-                sep_chars = IndexStoreMainDict.sep_chars
-                res = "{0}".format(quote(str(token)))
-                for ati, atl in enumerate(entries):
-                        action_type, atl = atl
-                        res += "{0}{1}".format(sep_chars[0], action_type)
-                        for sti, stl in enumerate(atl):
-                                subtype, stl = stl
-                                res += "{0}{1}".format(sep_chars[1], subtype)
-                                for fvi, fvl in enumerate(stl):
-                                        full_value, fvl = fvl
-                                        res += "{0}{1}".format(sep_chars[2],
-                                            quote(str(full_value)))
-                                        for pfi, pfl in enumerate(fvl):
-                                                pfmri_index, pfl = pfl
-                                                res += "{0}{1}".format(sep_chars[3],
-                                                    pfmri_index)
-                                                for offset in pfl:
-                                                        res += "{0}{1}".format(
-                                                            sep_chars[4],
-                                                            offset)
-                return res + "\n"
-
-        def count_entries_removed_during_partial_indexing(self):
-                """Returns the number of entries removed during a second phase
-                of indexing.
-                """
-                # This returns 0 because this class is not responsible for
-                # storing anything in memory.
-                return 0
-
-        def shift_file(self, use_dir, suffix):
-                """Moves the existing file with self._name in directory
-                use_dir to a new file named self._name + suffix in directory
-                use_dir. If it has done this previously, it removes the old
-                file it moved. It also opens the newly moved file and uses
-                that as the file for its file handle.
-                """
-                assert self._file_handle is None
-                orig_path = os.path.join(use_dir, self._name)
-                new_path = os.path.join(use_dir, self._name + suffix)
-                portable.rename(orig_path, new_path)
-                tmp_name = self._name
-                self._name = self._name + suffix
-                self.open(use_dir)
-                self._name = tmp_name
-                if self._old_suffix is not None:
-                        os.remove(os.path.join(use_dir, self._old_suffix))
-                self._old_suffix = self._name + suffix
+    def shift_file(self, use_dir, suffix):
+        """Moves the existing file with self._name in directory
+        use_dir to a new file named self._name + suffix in directory
+        use_dir. If it has done this previously, it removes the old
+        file it moved. It also opens the newly moved file and uses
+        that as the file for its file handle.
+        """
+        assert self._file_handle is None
+        orig_path = os.path.join(use_dir, self._name)
+        new_path = os.path.join(use_dir, self._name + suffix)
+        portable.rename(orig_path, new_path)
+        tmp_name = self._name
+        self._name = self._name + suffix
+        self.open(use_dir)
+        self._name = tmp_name
+        if self._old_suffix is not None:
+            os.remove(os.path.join(use_dir, self._old_suffix))
+        self._old_suffix = self._name + suffix
 
 
 class IndexStoreListDict(IndexStoreBase):
-        """Used when both a list and a dictionary are needed to
-        store the information. Used for bidirectional lookup when
-        one item is an int (an id) and the other is not (an entity). It
-        maintains a list of empty spots in the list so that adding entities
-        can take advantage of unused space. It encodes empty space as a blank
-        line in the file format and '' in the internal list.
+    """Used when both a list and a dictionary are needed to
+    store the information. Used for bidirectional lookup when
+    one item is an int (an id) and the other is not (an entity). It
+    maintains a list of empty spots in the list so that adding entities
+    can take advantage of unused space. It encodes empty space as a blank
+    line in the file format and '' in the internal list.
+    """
+
+    def __init__(
+        self, file_name, build_function=lambda x: x, decode_function=lambda x: x
+    ):
+        IndexStoreBase.__init__(self, file_name)
+        self._list = []
+        self._dict = {}
+        self._next_id = 0
+        self._list_of_empties = []
+        self._decode_func = decode_function
+        self._build_func = build_function
+        self._line_cnt = 0
+
+    def add_entity(self, entity, is_empty):
+        """Adds an entity consistently to the list and dictionary
+        allowing bidirectional lookup.
         """
+        assert len(self._list) == self._next_id
+        if self._list_of_empties and not is_empty:
+            use_id = self._list_of_empties.pop(0)
+            assert use_id <= len(self._list)
+            if use_id == len(self._list):
+                self._list.append(entity)
+                self._next_id += 1
+            else:
+                self._list[use_id] = entity
+        else:
+            use_id = self._next_id
+            self._list.append(entity)
+            self._next_id += 1
+        if not (is_empty):
+            self._dict[entity] = use_id
+        assert len(self._list) == self._next_id
+        return use_id
 
-        def __init__(self, file_name, build_function=lambda x: x,
-            decode_function=lambda x: x):
-                IndexStoreBase.__init__(self, file_name)
-                self._list = []
-                self._dict = {}
-                self._next_id = 0
-                self._list_of_empties = []
-                self._decode_func = decode_function
-                self._build_func = build_function
-                self._line_cnt = 0
+    def remove_id(self, in_id):
+        """deletes in_id from the list and the dictionary"""
+        entity = self._list[in_id]
+        self._list[in_id] = ""
+        self._dict[entity] = ""
 
-        def add_entity(self, entity, is_empty):
-                """Adds an entity consistently to the list and dictionary
-                allowing bidirectional lookup.
-                """
-                assert (len(self._list) == self._next_id)
-                if self._list_of_empties and not is_empty:
-                        use_id = self._list_of_empties.pop(0)
-                        assert use_id <= len(self._list)
-                        if use_id == len(self._list):
-                                self._list.append(entity)
-                                self._next_id += 1
-                        else:
-                                self._list[use_id] = entity
+    def remove_entity(self, entity):
+        """deletes the entity from the list and the dictionary"""
+        in_id = self._dict[entity]
+        self._dict[entity] = ""
+        self._list[in_id] = ""
+
+    def get_id(self, entity):
+        """returns the id of entity"""
+        return self._dict[entity]
+
+    def get_id_and_add(self, entity):
+        """Adds entity if it's not previously stored and returns the
+        id for entity.
+        """
+        # This code purposefully reimplements add_entity
+        # code. Replacing the function calls to has_entity, add_entity,
+        # and get_id with direct access to the data structure gave a
+        # speed up of a factor of 4. Because this is a very hot path,
+        # the tradeoff seemed appropriate.
+
+        if entity not in self._dict:
+            assert len(self._list) == self._next_id
+            if self._list_of_empties:
+                use_id = self._list_of_empties.pop(0)
+                assert use_id <= len(self._list)
+                if use_id == len(self._list):
+                    self._list.append(entity)
+                    self._next_id += 1
                 else:
-                        use_id = self._next_id
-                        self._list.append(entity)
-                        self._next_id += 1
-                if not(is_empty):
-                        self._dict[entity] = use_id
-                assert (len(self._list) == self._next_id)
-                return use_id
+                    self._list[use_id] = entity
+            else:
+                use_id = self._next_id
+                self._list.append(entity)
+                self._next_id += 1
+            self._dict[entity] = use_id
+        assert len(self._list) == self._next_id
+        return self._dict[entity]
 
-        def remove_id(self, in_id):
-                """deletes in_id from the list and the dictionary """
-                entity = self._list[in_id]
-                self._list[in_id] = ""
-                self._dict[entity] = ""
+    def get_entity(self, in_id):
+        """return the entity in_id maps to"""
+        return self._list[in_id]
 
-        def remove_entity(self, entity):
-                """deletes the entity from the list and the dictionary """
-                in_id = self._dict[entity]
-                self._dict[entity] = ""
-                self._list[in_id] = ""
+    def has_entity(self, entity):
+        """check if entity is in storage"""
+        return entity in self._dict
 
-        def get_id(self, entity):
-                """returns the id of entity """
-                return self._dict[entity]
+    def has_empty(self):
+        """Check if the structure has any empty elements which
+        can be filled with data.
+        """
+        return len(self._list_of_empties) > 0
 
-        def get_id_and_add(self, entity):
-                """Adds entity if it's not previously stored and returns the
-                id for entity.
-                """
-                # This code purposefully reimplements add_entity
-                # code. Replacing the function calls to has_entity, add_entity,
-                # and get_id with direct access to the data structure gave a
-                # speed up of a factor of 4. Because this is a very hot path,
-                # the tradeoff seemed appropriate.
+    def get_next_empty(self):
+        """returns the next id which maps to no element"""
+        return self._list_of_empties.pop()
 
-                if entity not in self._dict:
-                        assert (len(self._list) == self._next_id)
-                        if self._list_of_empties:
-                                use_id = self._list_of_empties.pop(0)
-                                assert use_id <= len(self._list)
-                                if use_id == len(self._list):
-                                        self._list.append(entity)
-                                        self._next_id += 1
-                                else:
-                                        self._list[use_id] = entity
-                        else:
-                                use_id = self._next_id
-                                self._list.append(entity)
-                                self._next_id += 1
-                        self._dict[entity] = use_id
-                assert (len(self._list) == self._next_id)
-                return self._dict[entity]
+    def write_dict_file(self, path, version_num):
+        """Passes self._list to the parent class to write to a file."""
+        IndexStoreBase._protected_write_dict_file(
+            self, path, version_num, (self._decode_func(l) for l in self._list)
+        )
 
-        def get_entity(self, in_id):
-                """return the entity in_id maps to """
-                return self._list[in_id]
+    def read_dict_file(self):
+        """Reads in a dictionary previously stored using the above
+        call
+        """
+        assert self._file_handle
+        self._dict.clear()
+        self._list = []
+        for i, line in enumerate(self._file_handle):
+            # A blank line means that id can be reused.
+            tmp = self._build_func(line.rstrip("\n"))
+            if line == "\n":
+                self._list_of_empties.append(i)
+            else:
+                self._dict[tmp] = i
+            self._list.append(tmp)
+            self._line_cnt = i + 1
+            self._next_id = i + 1
+        IndexStoreBase.read_dict_file(self)
+        return self._line_cnt
 
-        def has_entity(self, entity):
-                """check if entity is in storage """
-                return entity in self._dict
+    def count_entries_removed_during_partial_indexing(self):
+        """Returns the number of entries removed during a second phase
+        of indexing.
+        """
+        return len(self._list)
 
-        def has_empty(self):
-                """Check if the structure has any empty elements which
-                can be filled with data.
-                """
-                return (len(self._list_of_empties) > 0)
-
-        def get_next_empty(self):
-                """returns the next id which maps to no element """
-                return self._list_of_empties.pop()
-
-        def write_dict_file(self, path, version_num):
-                """Passes self._list to the parent class to write to a file.
-                """
-                IndexStoreBase._protected_write_dict_file(self, path,
-                    version_num, (self._decode_func(l) for l in self._list))
-        def read_dict_file(self):
-                """Reads in a dictionary previously stored using the above
-                call
-                """
-                assert self._file_handle
-                self._dict.clear()
-                self._list = []
-                for i, line in enumerate(self._file_handle):
-                        # A blank line means that id can be reused.
-                        tmp = self._build_func(line.rstrip("\n"))
-                        if line == "\n":
-                                self._list_of_empties.append(i)
-                        else:
-                                self._dict[tmp] = i
-                        self._list.append(tmp)
-                        self._line_cnt = i + 1
-                        self._next_id = i + 1
-                IndexStoreBase.read_dict_file(self)
-                return self._line_cnt
-
-        def count_entries_removed_during_partial_indexing(self):
-                """Returns the number of entries removed during a second phase
-                of indexing.
-                """
-                return len(self._list)
 
 class IndexStoreDict(IndexStoreBase):
-        """Class used when only entity -> id lookup is needed
+    """Class used when only entity -> id lookup is needed"""
+
+    def __init__(self, file_name):
+        IndexStoreBase.__init__(self, file_name)
+        self._dict = {}
+        self._next_id = 0
+
+    def get_dict(self):
+        return self._dict
+
+    def get_entity(self, in_id):
+        return self._dict[in_id]
+
+    def has_entity(self, entity):
+        return entity in self._dict
+
+    def read_dict_file(self):
+        """Reads in a dictionary stored in line number -> entity
+        format
         """
+        self._dict.clear()
+        for line_cnt, line in enumerate(self._file_handle):
+            line = line.rstrip("\n")
+            self._dict[line_cnt] = line
+        IndexStoreBase.read_dict_file(self)
 
-        def __init__(self, file_name):
-                IndexStoreBase.__init__(self, file_name)
-                self._dict = {}
-                self._next_id = 0
+    def count_entries_removed_during_partial_indexing(self):
+        """Returns the number of entries removed during a second phase
+        of indexing.
+        """
+        return len(self._dict)
 
-        def get_dict(self):
-                return self._dict
-
-        def get_entity(self, in_id):
-                return self._dict[in_id]
-
-        def has_entity(self, entity):
-                return entity in self._dict
-
-        def read_dict_file(self):
-                """Reads in a dictionary stored in line number -> entity
-                format
-                """
-                self._dict.clear()
-                for line_cnt, line in enumerate(self._file_handle):
-                        line = line.rstrip("\n")
-                        self._dict[line_cnt] = line
-                IndexStoreBase.read_dict_file(self)
-
-        def count_entries_removed_during_partial_indexing(self):
-                """Returns the number of entries removed during a second phase
-                of indexing.
-                """
-                return len(self._dict)
 
 class IndexStoreDictMutable(IndexStoreBase):
-        """Dictionary which allows dynamic update of its storage
+    """Dictionary which allows dynamic update of its storage"""
+
+    def __init__(self, file_name):
+        IndexStoreBase.__init__(self, file_name)
+        self._dict = {}
+
+    def get_dict(self):
+        return self._dict
+
+    def has_entity(self, entity):
+        return entity in self._dict
+
+    def get_id(self, entity):
+        return self._dict[entity]
+
+    def get_keys(self):
+        return list(self._dict.keys())
+
+    @staticmethod
+    def __quote(str):
+        if " " in str:
+            return "1" + quote(str)
+        else:
+            return "0" + str
+
+    def read_dict_file(self):
+        """Reads in a dictionary stored in with an entity
+        and its number on each line.
         """
+        self._dict.clear()
+        for line in self._file_handle:
+            token, offset = line.split(" ")
+            if token[0] == "1":
+                token = unquote(token[1:])
+            else:
+                token = token[1:]
+            offset = int(offset)
+            self._dict[token] = offset
+        IndexStoreBase.read_dict_file(self)
 
-        def __init__(self, file_name):
-                IndexStoreBase.__init__(self, file_name)
-                self._dict = {}
+    def open_out_file(self, use_dir, version_num):
+        """Opens the output file for this class and prepares it
+        to be written via write_entity.
+        """
+        self.write_dict_file(use_dir, version_num)
+        self._file_handle = open(
+            os.path.join(use_dir, self._name), "a", buffering=PKG_FILE_BUFSIZ
+        )
 
-        def get_dict(self):
-                return self._dict
+    def write_entity(self, entity, my_id):
+        """Writes the entity out to the file with my_id"""
+        assert self._file_handle is not None
+        self._file_handle.write(
+            self.__quote(str(entity)) + " " + str(my_id) + "\n"
+        )
 
-        def has_entity(self, entity):
-                return entity in self._dict
+    def write_dict_file(self, path, version_num):
+        """Generates an iterable list of string representations of
+        the dictionary that the parent's protected_write_dict_file
+        function can call.
+        """
+        IndexStoreBase._protected_write_dict_file(self, path, version_num, [])
 
-        def get_id(self, entity):
-                return self._dict[entity]
+    def count_entries_removed_during_partial_indexing(self):
+        """Returns the number of entries removed during a second phase
+        of indexing.
+        """
+        return 0
 
-        def get_keys(self):
-                return list(self._dict.keys())
-
-        @staticmethod
-        def __quote(str):
-                if " " in str:
-                        return "1" + quote(str)
-                else:
-                        return "0" + str
-
-        def read_dict_file(self):
-                """Reads in a dictionary stored in with an entity
-                and its number on each line.
-                """
-                self._dict.clear()
-                for line in self._file_handle:
-                        token, offset = line.split(" ")
-                        if token[0] == "1":
-                                token = unquote(token[1:])
-                        else:
-                                token = token[1:]
-                        offset = int(offset)
-                        self._dict[token] = offset
-                IndexStoreBase.read_dict_file(self)
-
-        def open_out_file(self, use_dir, version_num):
-                """Opens the output file for this class and prepares it
-                to be written via write_entity.
-                """
-                self.write_dict_file(use_dir, version_num)
-                self._file_handle = open(os.path.join(use_dir, self._name),
-                    'a', buffering=PKG_FILE_BUFSIZ)
-
-        def write_entity(self, entity, my_id):
-                """Writes the entity out to the file with my_id """
-                assert self._file_handle is not None
-                self._file_handle.write(self.__quote(str(entity)) + " " +
-                    str(my_id) + "\n")
-
-        def write_dict_file(self, path, version_num):
-                """ Generates an iterable list of string representations of
-                the dictionary that the parent's protected_write_dict_file
-                function can call.
-                """
-                IndexStoreBase._protected_write_dict_file(self, path,
-                    version_num, [])
-
-        def count_entries_removed_during_partial_indexing(self):
-                """Returns the number of entries removed during a second phase
-                of indexing.
-                """
-                return 0
 
 class IndexStoreSetHash(IndexStoreBase):
-        def __init__(self, file_name):
-                IndexStoreBase.__init__(self, file_name)
-                # In order to interoperate with older clients, we must use sha-1
-                # here.
-                self.hash_val = hashlib.sha1().hexdigest()
+    def __init__(self, file_name):
+        IndexStoreBase.__init__(self, file_name)
+        # In order to interoperate with older clients, we must use sha-1
+        # here.
+        self.hash_val = hashlib.sha1().hexdigest()
 
-        def set_hash(self, vals):
-                """Set the has value."""
-                self.hash_val = self.calc_hash(vals)
+    def set_hash(self, vals):
+        """Set the has value."""
+        self.hash_val = self.calc_hash(vals)
 
-        def calc_hash(self, vals):
-                """Calculate the hash value of the sorted members of vals."""
-                vl = list(vals)
-                vl.sort()
-                # In order to interoperate with older clients, we must use sha-1
-                # here.
-                shasum = hashlib.sha1()
-                for v in vl:
-                         # Unicode-objects must be encoded before hashing.
-                         shasum.update(force_bytes(v))
-                return shasum.hexdigest()
+    def calc_hash(self, vals):
+        """Calculate the hash value of the sorted members of vals."""
+        vl = list(vals)
+        vl.sort()
+        # In order to interoperate with older clients, we must use sha-1
+        # here.
+        shasum = hashlib.sha1()
+        for v in vl:
+            # Unicode-objects must be encoded before hashing.
+            shasum.update(force_bytes(v))
+        return shasum.hexdigest()
 
-        def write_dict_file(self, path, version_num):
-                """Write self.hash_val out to a line in a file """
-                IndexStoreBase._protected_write_dict_file(self, path,
-                    version_num, [self.hash_val])
+    def write_dict_file(self, path, version_num):
+        """Write self.hash_val out to a line in a file"""
+        IndexStoreBase._protected_write_dict_file(
+            self, path, version_num, [self.hash_val]
+        )
 
-        def read_dict_file(self):
-                """Process a dictionary file written using the above method
-                """
-                sp = self._file_handle.tell()
-                res = 0
-                for res, line in enumerate(self._file_handle):
-                        assert res < 1
-                        self.hash_val = line.rstrip()
-                self._file_handle.seek(sp)
-                IndexStoreBase.read_dict_file(self)
-                return res
+    def read_dict_file(self):
+        """Process a dictionary file written using the above method"""
+        sp = self._file_handle.tell()
+        res = 0
+        for res, line in enumerate(self._file_handle):
+            assert res < 1
+            self.hash_val = line.rstrip()
+        self._file_handle.seek(sp)
+        IndexStoreBase.read_dict_file(self)
+        return res
 
-        def check_against_file(self, vals):
-                """Check the hash value of vals against the value stored
-                in the file for this object."""
-                if not self._have_read:
-                        self.read_dict_file()
-                incoming_hash = self.calc_hash(vals)
-                if self.hash_val != incoming_hash:
-                        raise search_errors.IncorrectIndexFileHash(
-                            self.hash_val, incoming_hash)
+    def check_against_file(self, vals):
+        """Check the hash value of vals against the value stored
+        in the file for this object."""
+        if not self._have_read:
+            self.read_dict_file()
+        incoming_hash = self.calc_hash(vals)
+        if self.hash_val != incoming_hash:
+            raise search_errors.IncorrectIndexFileHash(
+                self.hash_val, incoming_hash
+            )
 
-        def count_entries_removed_during_partial_indexing(self):
-                """Returns the number of entries removed during a second phase
-                of indexing."""
-                return 0
+    def count_entries_removed_during_partial_indexing(self):
+        """Returns the number of entries removed during a second phase
+        of indexing."""
+        return 0
+
 
 class IndexStoreSet(IndexStoreBase):
-        """Used when only set membership is desired.
-        This is currently designed for exclusive use
-        with storage of fmri.PkgFmris. However, that impact
-        is only seen in the read_and_discard_matching_from_argument
-        method.
+    """Used when only set membership is desired.
+    This is currently designed for exclusive use
+    with storage of fmri.PkgFmris. However, that impact
+    is only seen in the read_and_discard_matching_from_argument
+    method.
+    """
+
+    def __init__(self, file_name):
+        IndexStoreBase.__init__(self, file_name)
+        self._set = set()
+
+    def get_set(self):
+        return self._set
+
+    def clear(self):
+        self._set.clear()
+
+    def add_entity(self, entity):
+        self._set.add(entity)
+
+    def remove_entity(self, entity):
+        """Remove entity purposfully assumes that entity is
+        already in the set to be removed. This is useful for
+        error checking and debugging.
         """
-        def __init__(self, file_name):
-                IndexStoreBase.__init__(self, file_name)
-                self._set = set()
+        self._set.remove(entity)
 
-        def get_set(self):
-                return self._set
+    def has_entity(self, entity):
+        return entity in self._set
 
-        def clear(self):
-                self._set.clear()
+    def write_dict_file(self, path, version_num):
+        """Write each member of the set out to a line in a file"""
+        IndexStoreBase._protected_write_dict_file(
+            self, path, version_num, self._set
+        )
 
-        def add_entity(self, entity):
-                self._set.add(entity)
+    def read_dict_file(self):
+        """Process a dictionary file written using the above method"""
+        assert self._file_handle
+        res = 0
+        self._set.clear()
+        for i, line in enumerate(self._file_handle):
+            line = line.rstrip("\n")
+            assert i == len(self._set)
+            self.add_entity(line)
+            res = i + 1
+        IndexStoreBase.read_dict_file(self)
+        return res
 
-        def remove_entity(self, entity):
-                """Remove entity purposfully assumes that entity is
-                already in the set to be removed. This is useful for
-                error checking and debugging.
-                """
-                self._set.remove(entity)
+    def read_and_discard_matching_from_argument(self, fmri_set):
+        """Reads the file and removes all frmis in the file
+        from fmri_set.
+        """
+        if self._file_handle:
+            for line in self._file_handle:
+                f = fmri.PkgFmri(line)
+                fmri_set.discard(f)
 
-        def has_entity(self, entity):
-                return (entity in self._set)
-
-        def write_dict_file(self, path, version_num):
-                """Write each member of the set out to a line in a file """
-                IndexStoreBase._protected_write_dict_file(self, path,
-                    version_num, self._set)
-
-        def read_dict_file(self):
-                """Process a dictionary file written using the above method
-                """
-                assert self._file_handle
-                res = 0
-                self._set.clear()
-                for i, line in enumerate(self._file_handle):
-                        line = line.rstrip("\n")
-                        assert i == len(self._set)
-                        self.add_entity(line)
-                        res = i + 1
-                IndexStoreBase.read_dict_file(self)
-                return res
-
-        def read_and_discard_matching_from_argument(self, fmri_set):
-                """Reads the file and removes all frmis in the file
-                from fmri_set.
-                """
-                if self._file_handle:
-                        for line in self._file_handle:
-                                f = fmri.PkgFmri(line)
-                                fmri_set.discard(f)
-
-        def count_entries_removed_during_partial_indexing(self):
-                """Returns the number of entries removed during a second phase
-                of indexing."""
-                return len(self._set)
+    def count_entries_removed_during_partial_indexing(self):
+        """Returns the number of entries removed during a second phase
+        of indexing."""
+        return len(self._set)
 
 
 class InvertedDict(IndexStoreBase):
-        """Class used to store and process fmri to offset mappings.  It does
-        delta compression and deduplication of shared offset sets when writing
-        to a file."""
+    """Class used to store and process fmri to offset mappings.  It does
+    delta compression and deduplication of shared offset sets when writing
+    to a file."""
 
-        def __init__(self, file_name, p_id_trans):
-                """file_name is the name of the file to write to or read from.
-                p_id_trans is an object which has a get entity method which,
-                when given a package id number returns the PkgFmri object
-                for that id number."""
+    def __init__(self, file_name, p_id_trans):
+        """file_name is the name of the file to write to or read from.
+        p_id_trans is an object which has a get entity method which,
+        when given a package id number returns the PkgFmri object
+        for that id number."""
 
-                IndexStoreBase.__init__(self, file_name)
-                self._p_id_trans = p_id_trans
-                self._dict = {}
-                self._fmri_offsets = {}
+        IndexStoreBase.__init__(self, file_name)
+        self._p_id_trans = p_id_trans
+        self._dict = {}
+        self._fmri_offsets = {}
 
-        def __copy__(self):
-                return self.__class__(self._name, self._p_id_trans)
+    def __copy__(self):
+        return self.__class__(self._name, self._p_id_trans)
 
-        def add_pair(self, p_id, offset):
-                """Adds a package id number and an associated offset to the
-                existing dictionary."""
+    def add_pair(self, p_id, offset):
+        """Adds a package id number and an associated offset to the
+        existing dictionary."""
 
-                try:
-                        self._fmri_offsets[p_id].append(offset)
-                except KeyError:
-                        self._fmri_offsets[p_id] = [offset]
+        try:
+            self._fmri_offsets[p_id].append(offset)
+        except KeyError:
+            self._fmri_offsets[p_id] = [offset]
 
-        def invert_id_to_offsets_dict(self):
-                """Does delta encoding of offsets to reduce space by only
-                storing the difference between the current offset and the
-                previous offset.  It also performs deduplication so that all
-                packages with the same set of offsets share a common bucket."""
+    def invert_id_to_offsets_dict(self):
+        """Does delta encoding of offsets to reduce space by only
+        storing the difference between the current offset and the
+        previous offset.  It also performs deduplication so that all
+        packages with the same set of offsets share a common bucket."""
 
-                inv = {}
-                for p_id in list(self._fmri_offsets.keys()):
-                        old_o = 0
-                        bucket = []
-                        for o in sorted(set(self._fmri_offsets[p_id])):
-                                bucket.append(o - old_o)
-                                old_o = o
-                        h = " ".join([str(o) for o in bucket])
-                        del self._fmri_offsets[p_id]
-                        if h not in inv:
-                                inv[h] = []
-                        inv[h].append(p_id)
-                return inv
+        inv = {}
+        for p_id in list(self._fmri_offsets.keys()):
+            old_o = 0
+            bucket = []
+            for o in sorted(set(self._fmri_offsets[p_id])):
+                bucket.append(o - old_o)
+                old_o = o
+            h = " ".join([str(o) for o in bucket])
+            del self._fmri_offsets[p_id]
+            if h not in inv:
+                inv[h] = []
+            inv[h].append(p_id)
+        return inv
 
-        @staticmethod
-        def __make_line(offset_str, p_ids, trans):
-                """For a given offset string, a list of package id numbers,
-                and a translator from package id numbers to PkgFmris, returns
-                the string which represents that information. Its format is
-                space separated package fmris, followed by a !, followed by
-                space separated offsets which have had delta compression
-                performed."""
+    @staticmethod
+    def __make_line(offset_str, p_ids, trans):
+        """For a given offset string, a list of package id numbers,
+        and a translator from package id numbers to PkgFmris, returns
+        the string which represents that information. Its format is
+        space separated package fmris, followed by a !, followed by
+        space separated offsets which have had delta compression
+        performed."""
 
-                return " ".join([
-                    trans.get_entity(p_id).get_fmri(anarchy=True,
-                        include_scheme=False)
+        return (
+            " ".join(
+                [
+                    trans.get_entity(p_id).get_fmri(
+                        anarchy=True, include_scheme=False
+                    )
                     for p_id in p_ids
-                    ]) + "!" + offset_str
+                ]
+            )
+            + "!"
+            + offset_str
+        )
 
-        def write_dict_file(self, path, version_num):
-                """Write the mapping of package fmris to offset sets out
-                to the file."""
+    def write_dict_file(self, path, version_num):
+        """Write the mapping of package fmris to offset sets out
+        to the file."""
 
-                inv = self.invert_id_to_offsets_dict()
-                IndexStoreBase._protected_write_dict_file(self, path,
-                    version_num, (
-                        self.__make_line(o, inv[o], self._p_id_trans)
-                        for o in inv
-                    ))
+        inv = self.invert_id_to_offsets_dict()
+        IndexStoreBase._protected_write_dict_file(
+            self,
+            path,
+            version_num,
+            (self.__make_line(o, inv[o], self._p_id_trans) for o in inv),
+        )
 
-        def read_dict_file(self):
-                """Read a file written by the above function and store the
-                information in a dictionary."""
+    def read_dict_file(self):
+        """Read a file written by the above function and store the
+        information in a dictionary."""
 
-                assert self._file_handle
-                for l in self._file_handle:
-                        fmris, offs = l.split("!")
-                        self._dict[fmris] = offs
-                IndexStoreBase.read_dict_file(self)
+        assert self._file_handle
+        for l in self._file_handle:
+            fmris, offs = l.split("!")
+            self._dict[fmris] = offs
+        IndexStoreBase.read_dict_file(self)
 
-        @staticmethod
-        def de_delta(offs):
-                """For a list of strings of offsets, undo the delta compression
-                that has been performed."""
+    @staticmethod
+    def de_delta(offs):
+        """For a list of strings of offsets, undo the delta compression
+        that has been performed."""
 
-                old_o = 0
-                ret = []
-                for o in offs:
-                        o = int(o) + old_o
-                        ret.append(o)
-                        old_o = o
-                return ret
+        old_o = 0
+        ret = []
+        for o in offs:
+            o = int(o) + old_o
+            ret.append(o)
+            old_o = o
+        return ret
 
-        def get_offsets(self, match_func):
-                """For a given function which returns true if it matches the
-                desired fmri, return the offsets which are associated with the
-                fmris which match."""
+    def get_offsets(self, match_func):
+        """For a given function which returns true if it matches the
+        desired fmri, return the offsets which are associated with the
+        fmris which match."""
 
-                offs = []
-                for fmris in self._dict.keys():
-                        for p in fmris.split():
-                                if match_func(p):
-                                        offs.extend(self.de_delta(
-                                            self._dict[fmris].split()))
-                                        break
-                return set(offs)
+        offs = []
+        for fmris in self._dict.keys():
+            for p in fmris.split():
+                if match_func(p):
+                    offs.extend(self.de_delta(self._dict[fmris].split()))
+                    break
+        return set(offs)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/server/__init__.py
+++ b/src/modules/server/__init__.py
@@ -26,8 +26,15 @@
 
 from __future__ import unicode_literals
 
-__all__ = ["catalog", "config", "depot", "face", "feed", "repository",
-    "transaction"]
+__all__ = [
+    "catalog",
+    "config",
+    "depot",
+    "face",
+    "feed",
+    "repository",
+    "transaction",
+]
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/server/api.py
+++ b/src/modules/server/api.py
@@ -43,811 +43,866 @@ import pkg.server.repository as srepo
 import pkg.server.query_parser as qp
 import pkg.version as version
 
-from pkg.api_common import (PackageInfo, LicenseInfo, PackageCategory,
-    _get_pkg_cat_data)
+from pkg.api_common import (
+    PackageInfo,
+    LicenseInfo,
+    PackageCategory,
+    _get_pkg_cat_data,
+)
 
 CURRENT_API_VERSION = 12
 
+
 class BaseInterface(object):
-        """This class represents a base API object that is provided by the
-        server to clients.  A base API object is required when creating
-        objects for any other interface provided by the API.  This allows
-        the server to provide a set of private object references that are
-        needed by interfaces to provide functionality to clients.
-        """
+    """This class represents a base API object that is provided by the
+    server to clients.  A base API object is required when creating
+    objects for any other interface provided by the API.  This allows
+    the server to provide a set of private object references that are
+    needed by interfaces to provide functionality to clients.
+    """
 
-        def __init__(self, request, depot, pub):
-                # A protected reference to a pkg.server.depot object.
-                self._depot = depot
+    def __init__(self, request, depot, pub):
+        # A protected reference to a pkg.server.depot object.
+        self._depot = depot
 
-                # A protected reference to a cherrypy request object.
-                self._request = request
+        # A protected reference to a cherrypy request object.
+        self._request = request
 
-                # A protected reference to the publisher this interface is for.
-                self._pub = pub
+        # A protected reference to the publisher this interface is for.
+        self._pub = pub
 
 
 class _Interface(object):
-        """Private base class used for api interface objects.
-        """
-        def __init__(self, version_id, base):
-                compatible_versions = set([CURRENT_API_VERSION])
-                if version_id not in compatible_versions:
-                        raise api_errors.VersionException(CURRENT_API_VERSION,
-                            version_id)
+    """Private base class used for api interface objects."""
 
-                self._depot = base._depot
-                self._pub = base._pub
-                self._request = base._request
+    def __init__(self, version_id, base):
+        compatible_versions = set([CURRENT_API_VERSION])
+        if version_id not in compatible_versions:
+            raise api_errors.VersionException(CURRENT_API_VERSION, version_id)
+
+        self._depot = base._depot
+        self._pub = base._pub
+        self._request = base._request
+
 
 class CatalogInterface(_Interface):
-        """This class presents an interface to server catalog objects that
-        clients may use.
-        """
+    """This class presents an interface to server catalog objects that
+    clients may use.
+    """
 
-        # Constants used to reference specific values that info can return.
-        INFO_FOUND = 0
-        INFO_MISSING = 1
-        INFO_ILLEGALS = 3
+    # Constants used to reference specific values that info can return.
+    INFO_FOUND = 0
+    INFO_MISSING = 1
+    INFO_ILLEGALS = 3
 
-        # Constants for some state information returned by package matching
-        # functions.
-        PKG_STATE_OBSOLETE = pkgdefs.PKG_STATE_OBSOLETE
-        PKG_STATE_RENAMED = pkgdefs.PKG_STATE_RENAMED
-        PKG_STATE_LEGACY = pkgdefs.PKG_STATE_LEGACY
+    # Constants for some state information returned by package matching
+    # functions.
+    PKG_STATE_OBSOLETE = pkgdefs.PKG_STATE_OBSOLETE
+    PKG_STATE_RENAMED = pkgdefs.PKG_STATE_RENAMED
+    PKG_STATE_LEGACY = pkgdefs.PKG_STATE_LEGACY
 
-        def fmris(self, ordered=False):
-                """A generator function that produces FMRIs as it iterates
-                over the contents of the server's catalog.
+    def fmris(self, ordered=False):
+        """A generator function that produces FMRIs as it iterates
+        over the contents of the server's catalog.
 
-                'ordered' is an optional boolean value that indicates that
-                results should sorted by stem and then by publisher and
-                be in descending version order.  If False, results will be
-                in a ascending version order on a per-publisher, per-stem
-                basis."""
+        'ordered' is an optional boolean value that indicates that
+        results should sorted by stem and then by publisher and
+        be in descending version order.  If False, results will be
+        in a ascending version order on a per-publisher, per-stem
+        basis."""
 
-                try:
-                        c = self._depot.repo.get_catalog(self._pub)
-                except srepo.RepositoryMirrorError:
-                        return iter(())
-                return c.fmris(ordered=ordered)
+        try:
+            c = self._depot.repo.get_catalog(self._pub)
+        except srepo.RepositoryMirrorError:
+            return iter(())
+        return c.fmris(ordered=ordered)
 
-        def gen_allowed_packages(self, pfmris, build_release=None):
-                """A generator function that produces a list of tuples of the
-                form (fmri, states) in the catalog incorporated by the named
-                package and its dependencies and any packages that are not
-                incorporated by the named packages or their dependencies.  FMRIs
-                are returned ordered by stem and descending version.  State
-                is a set of PKG_STATES applicable to the 'fmri'."""
+    def gen_allowed_packages(self, pfmris, build_release=None):
+        """A generator function that produces a list of tuples of the
+        form (fmri, states) in the catalog incorporated by the named
+        package and its dependencies and any packages that are not
+        incorporated by the named packages or their dependencies.  FMRIs
+        are returned ordered by stem and descending version.  State
+        is a set of PKG_STATES applicable to the 'fmri'."""
 
-                try:
-                        cat = self._depot.repo.get_catalog(self._pub)
-                except srepo.RepositoryMirrorError:
-                        return
+        try:
+            cat = self._depot.repo.get_catalog(self._pub)
+        except srepo.RepositoryMirrorError:
+            return
 
-                pubs = frozenset([pfmri.publisher for pfmri in pfmris])
+        pubs = frozenset([pfmri.publisher for pfmri in pfmris])
 
-                # Avoid unnecessary object creation, pre-define and
-                # pre-populate all possible state combinations.
-                #
-                # Package not renamed or obsolete.
-                sn = frozenset()
-                # Package renamed.
-                sr = frozenset((pkgdefs.PKG_STATE_RENAMED,))
-                # Package obsoleted.
-                so = frozenset((pkgdefs.PKG_STATE_OBSOLETE,))
-                # Package in legacy namespace.
-                sl = frozenset((pkgdefs.PKG_STATE_LEGACY,))
+        # Avoid unnecessary object creation, pre-define and
+        # pre-populate all possible state combinations.
+        #
+        # Package not renamed or obsolete.
+        sn = frozenset()
+        # Package renamed.
+        sr = frozenset((pkgdefs.PKG_STATE_RENAMED,))
+        # Package obsoleted.
+        so = frozenset((pkgdefs.PKG_STATE_OBSOLETE,))
+        # Package in legacy namespace.
+        sl = frozenset((pkgdefs.PKG_STATE_LEGACY,))
 
-                # Seed the set of allowed packages with the set of FMRIs that
-                # were started with since they don't likely incorporate
-                # themselves.
-                allowed = dict(
-                    (pfmri.pkg_name, set([(pfmri, sn)]))
-                    for pfmri in pfmris
+        # Seed the set of allowed packages with the set of FMRIs that
+        # were started with since they don't likely incorporate
+        # themselves.
+        allowed = dict((pfmri.pkg_name, set([(pfmri, sn)])) for pfmri in pfmris)
+
+        # pfmri is not leaked from the above list comprehension in
+        # Python 3, so we need to use pfmris[-1] explicitly.
+        self.__get_allowed_packages(
+            cat, pfmris[-1], allowed, build_release=build_release, pubs=pubs
+        )
+
+        # Add packages not incorporated by the recursively discovered
+        # incorporations above.
+        cat_info = frozenset([cat.DEPENDENCY])
+        remaining = frozenset(cat.names(pubs=pubs)) - set(six.iterkeys(allowed))
+
+        for pkg_name in remaining:
+            allowed.setdefault(pkg_name, [])
+            for v, entries in cat.entries_by_version(
+                pkg_name, info_needed=cat_info, pubs=pubs
+            ):
+                for f, md in entries:
+                    for fa in md.get("actions", misc.EmptyI):
+                        if not fa.startswith("set"):
+                            continue
+
+                        a = pkg.actions.fromstr(fa)
+                        aname = a.attrs["name"]
+                        if aname == "pkg.renamed":
+                            allowed[pkg_name].append((f, sr))
+                            del a
+                            break
+                        if aname == "pkg.obsolete":
+                            allowed[pkg_name].append((f, so))
+                            del a
+                            break
+                        if aname == "pkg.legacy":
+                            allowed[pkg_name].append((f, sl))
+                            del a
+                            break
+                        del a
+                        allowed[pkg_name].append((f, sn))
+
+        sort_ver = itemgetter(0)
+        return (
+            entry
+            for name in sorted(allowed)
+            for entry in sorted(allowed[name], key=sort_ver, reverse=True)
+        )
+
+    def __get_allowed_packages(
+        self,
+        cat,
+        pfmri,
+        allowed,
+        build_release=None,
+        excludes=misc.EmptyI,
+        pubs=misc.EmptyI,
+    ):
+        cat_info = frozenset([cat.DEPENDENCY])
+
+        incs = set()
+        for a in cat.get_entry_actions(pfmri, cat_info, excludes=excludes):
+            if a.name != "depend":
+                continue
+            if a.attrs["type"] != "incorporate":
+                continue
+
+            ifmri = pkg.fmri.PkgFmri(
+                a.attrs["fmri"], build_release=build_release
+            )
+            iver = ifmri.version
+            if iver:
+                # Ignore versionless incorporations.
+                incs.add(ifmri)
+
+        for ifmri in incs:
+            iver = ifmri.version
+            if any(
+                ifmri.pkg_name == f.pkg_name
+                and (
+                    iver != f.version
+                    and f.version.is_successor(iver, version.CONSTRAINT_AUTO)
                 )
+                for f in incs
+            ):
+                # Prefer incorporate dependencies that are
+                # subset of this one so that a multi-level
+                # incorporation dependency scheme (e.g.
+                # incorporate at update level and then again at
+                # SRU level) doesn't allow unexpected versions
+                # and slow down filtering.
+                continue
 
-                # pfmri is not leaked from the above list comprehension in
-                # Python 3, so we need to use pfmris[-1] explicitly.
-                self.__get_allowed_packages(cat, pfmris[-1], allowed,
-                    build_release=build_release, pubs=pubs)
+            recurse = False
+            for ver, flist in cat.fmris_by_version(ifmri.pkg_name, pubs=pubs):
+                if not ver.is_successor(iver, pkg.version.CONSTRAINT_AUTO):
+                    continue
 
-                # Add packages not incorporated by the recursively discovered
-                # incorporations above.
-                cat_info = frozenset([cat.DEPENDENCY])
-                remaining = (frozenset(cat.names(pubs=pubs)) -
-                    set(six.iterkeys(allowed)))
+                aset = allowed.setdefault(ifmri.pkg_name, set())
+                for f in flist:
+                    states = set()
+                    for fa in cat.get_entry_actions(
+                        f, cat_info, excludes=excludes
+                    ):
+                        if fa.name != "set":
+                            continue
 
-                for pkg_name in remaining:
-                        allowed.setdefault(pkg_name, [])
-                        for v, entries in cat.entries_by_version(pkg_name,
-                            info_needed=cat_info, pubs=pubs):
-                                for f, md in entries:
-                                    for fa in md.get("actions", misc.EmptyI):
-                                        if not fa.startswith("set"):
-                                                continue
+                        attrs = fa.attrs
+                        aname = attrs["name"]
+                        avalue = attrs["value"]
+                        if aname == "pkg.renamed":
+                            if avalue == "true":
+                                states.add(pkgdefs.PKG_STATE_RENAMED)
+                            break
+                        if aname == "pkg.obsolete":
+                            if avalue == "true":
+                                states.add(pkgdefs.PKG_STATE_OBSOLETE)
+                            break
+                        if aname == "pkg.legacy":
+                            if avalue == "true":
+                                states.add(pkgdefs.PKG_STATE_LEGACY)
+                            break
 
-                                        a = pkg.actions.fromstr(fa)
-                                        aname = a.attrs["name"]
-                                        if aname == "pkg.renamed":
-                                                allowed[pkg_name].append((f,
-                                                    sr))
-                                                del a
-                                                break
-                                        if aname == "pkg.obsolete":
-                                                allowed[pkg_name].append((f,
-                                                    so))
-                                                del a
-                                                break
-                                        if aname == "pkg.legacy":
-                                                allowed[pkg_name].append((f,
-                                                    sl))
-                                                del a
-                                                break
-                                        del a
-                                        allowed[pkg_name].append((f, sn))
-
-                sort_ver = itemgetter(0)
-                return (
-                    entry
-                    for name in sorted(allowed)
-                    for entry in sorted(allowed[name], key=sort_ver,
-                        reverse=True)
-                )
-
-        def __get_allowed_packages(self, cat, pfmri, allowed,
-            build_release=None, excludes=misc.EmptyI, pubs=misc.EmptyI):
-                cat_info = frozenset([cat.DEPENDENCY])
-
-                incs = set()
-                for a in cat.get_entry_actions(pfmri, cat_info,
-                    excludes=excludes):
-                        if a.name != "depend":
-                                continue
-                        if a.attrs["type"] != "incorporate":
-                                continue
-
-                        ifmri = pkg.fmri.PkgFmri(a.attrs["fmri"],
-                            build_release=build_release)
-                        iver = ifmri.version
-                        if iver:
-                                # Ignore versionless incorporations.
-                                incs.add(ifmri)
-
-                for ifmri in incs:
-                        iver = ifmri.version
-                        if any(ifmri.pkg_name == f.pkg_name and
-                            (iver != f.version and f.version.is_successor(iver,
-                                version.CONSTRAINT_AUTO))
-                            for f in incs):
-                                # Prefer incorporate dependencies that are
-                                # subset of this one so that a multi-level
-                                # incorporation dependency scheme (e.g.
-                                # incorporate at update level and then again at
-                                # SRU level) doesn't allow unexpected versions
-                                # and slow down filtering.
-                                continue
-
-                        recurse = False
-                        for ver, flist in cat.fmris_by_version(ifmri.pkg_name,
-                            pubs=pubs):
-                                if not ver.is_successor(iver,
-                                    pkg.version.CONSTRAINT_AUTO):
-                                        continue
-
-                                aset = allowed.setdefault(ifmri.pkg_name, set())
-                                for f in flist:
-                                        states = set()
-                                        for fa in cat.get_entry_actions(f,
-                                            cat_info, excludes=excludes):
-                                                if fa.name != "set":
-                                                        continue
-
-                                                attrs = fa.attrs
-                                                aname = attrs["name"]
-                                                avalue = attrs["value"]
-                                                if aname == "pkg.renamed":
-                                                        if avalue == "true":
-                                                                states.add(
-                                                                    pkgdefs.PKG_STATE_RENAMED)
-                                                        break
-                                                if aname == "pkg.obsolete":
-                                                        if avalue == "true":
-                                                                states.add(
-                                                                    pkgdefs.PKG_STATE_OBSOLETE)
-                                                        break
-                                                if aname == "pkg.legacy":
-                                                        if avalue == "true":
-                                                                states.add(
-                                                                    pkgdefs.PKG_STATE_LEGACY)
-                                                        break
-
-                                        aset.add((f, frozenset(states)))
-                                        self.__get_allowed_packages(cat, f,
-                                            allowed=allowed, excludes=excludes,
-                                            pubs=pubs)
-
-        def gen_fmris(self, stems=misc.EmptyI):
-                """A generator function that produces FMRIs for the named stems.
-
-                Results are always sorted by order stems were provided,
-                publisher, and then in descending version order."""
-
-                try:
-                        cat = self._depot.repo.get_catalog(self._pub)
-                except srepo.RepositoryMirrorError:
-                        return iter(())
-
-                return (
-                    f
-                    for name in stems
-                    for v, fmris in cat.fmris_by_version(name)
-                    for f in fmris
-                )
-
-        def gen_packages(self, collect_attrs=False, matched=None,
-            patterns=misc.EmptyI, pubs=misc.EmptyI, unmatched=None,
-            return_fmris=False):
-                """A generator function that produces tuples of the form:
-
-                    (
-                        (
-                            pub,    - (string) the publisher of the package
-                            stem,   - (string) the name of the package
-                            version - (string) the version of the package
-                        ),
-                        states,     - (list) states
-                        attributes  - (dict) package attributes
+                    aset.add((f, frozenset(states)))
+                    self.__get_allowed_packages(
+                        cat, f, allowed=allowed, excludes=excludes, pubs=pubs
                     )
 
-                Results are always sorted by stem, publisher, and then in
-                descending version order.
+    def gen_fmris(self, stems=misc.EmptyI):
+        """A generator function that produces FMRIs for the named stems.
 
-                'collect_attrs' is an optional boolean that indicates whether
-                all package attributes should be collected and returned in the
-                fifth element of the return tuple.  If False, that element will
-                be an empty dictionary.
+        Results are always sorted by order stems were provided,
+        publisher, and then in descending version order."""
 
-                'matched' is an optional set to add matched patterns to.
+        try:
+            cat = self._depot.repo.get_catalog(self._pub)
+        except srepo.RepositoryMirrorError:
+            return iter(())
 
-                'patterns' is an optional list of FMRI wildcard strings to
-                filter results by.
+        return (
+            f
+            for name in stems
+            for v, fmris in cat.fmris_by_version(name)
+            for f in fmris
+        )
 
-                'pubs' is an optional list of publisher prefixes to restrict
-                the results to.
+    def gen_packages(
+        self,
+        collect_attrs=False,
+        matched=None,
+        patterns=misc.EmptyI,
+        pubs=misc.EmptyI,
+        unmatched=None,
+        return_fmris=False,
+    ):
+        """A generator function that produces tuples of the form:
 
-                'unmatched' is an optional set to add unmatched patterns to.
+            (
+                (
+                    pub,    - (string) the publisher of the package
+                    stem,   - (string) the name of the package
+                    version - (string) the version of the package
+                ),
+                states,     - (list) states
+                attributes  - (dict) package attributes
+            )
 
-                'return_fmris' is an optional boolean value that indicates that
-                an FMRI object should be returned in place of the (pub, stem,
-                ver) tuple that is normally returned."""
+        Results are always sorted by stem, publisher, and then in
+        descending version order.
 
+        'collect_attrs' is an optional boolean that indicates whether
+        all package attributes should be collected and returned in the
+        fifth element of the return tuple.  If False, that element will
+        be an empty dictionary.
+
+        'matched' is an optional set to add matched patterns to.
+
+        'patterns' is an optional list of FMRI wildcard strings to
+        filter results by.
+
+        'pubs' is an optional list of publisher prefixes to restrict
+        the results to.
+
+        'unmatched' is an optional set to add unmatched patterns to.
+
+        'return_fmris' is an optional boolean value that indicates that
+        an FMRI object should be returned in place of the (pub, stem,
+        ver) tuple that is normally returned."""
+
+        try:
+            cat = self._depot.repo.get_catalog(self._pub)
+        except srepo.RepositoryMirrorError:
+            return iter(())
+
+        return cat.gen_packages(
+            collect_attrs=collect_attrs,
+            matched=matched,
+            patterns=patterns,
+            pubs=pubs,
+            unmatched=unmatched,
+            return_fmris=return_fmris,
+        )
+
+    def info(self, fmri_strings, info_needed, excludes=misc.EmptyI):
+        """Gathers information about fmris.  fmri_strings is a list
+        of fmri_names for which information is desired. It
+        returns a dictionary of lists.  The keys for the dictionary are
+        the constants specified in the class definition.  The values are
+        lists of PackageInfo objects or strings."""
+
+        bad_opts = info_needed - PackageInfo.ALL_OPTIONS
+        if bad_opts:
+            raise api_errors.UnrecognizedOptionsToInfo(bad_opts)
+
+        fmris = []
+        notfound = []
+        illegals = []
+
+        for pattern in fmri_strings:
+            try:
+                pfmri = None
+                pfmri = self.get_matching_pattern_fmris(pattern)
+            except pkg.fmri.IllegalFmri as e:
+                illegals.append(pattern)
+                continue
+            else:
+                fmris.extend(pfmri[0])
+                if not pfmri:
+                    notfound.append(pattern)
+
+        repo_cat = self._depot.repo.get_catalog(self._pub)
+
+        # Set of options that can use catalog data.
+        cat_opts = frozenset(
+            [
+                PackageInfo.SUMMARY,
+                PackageInfo.CATEGORIES,
+                PackageInfo.DESCRIPTION,
+                PackageInfo.DEPENDENCIES,
+            ]
+        )
+
+        # Set of options that require manifest retrieval.
+        act_opts = PackageInfo.ACTION_OPTIONS - frozenset(
+            [PackageInfo.DEPENDENCIES]
+        )
+
+        pis = []
+        for f in fmris:
+            pub = name = version = release = None
+            build_release = branch = packaging_date = None
+            if PackageInfo.IDENTITY in info_needed:
+                pub, name, version = f.tuple()
+                release = version.release
+                build_release = version.build_release
+                branch = version.branch
+                packaging_date = version.get_timestamp().strftime("%c")
+
+            states = None
+
+            links = hardlinks = files = dirs = dependencies = None
+            summary = csize = size = licenses = cat_info = description = None
+
+            if cat_opts & info_needed:
+                (
+                    summary,
+                    description,
+                    cat_info,
+                    dependencies,
+                ) = _get_pkg_cat_data(
+                    repo_cat, info_needed, excludes=excludes, pfmri=f
+                )
+                if cat_info is not None:
+                    cat_info = [
+                        PackageCategory(scheme, cat) for scheme, cat in cat_info
+                    ]
+
+            if (
+                frozenset([PackageInfo.SIZE, PackageInfo.LICENSES]) | act_opts
+            ) & info_needed:
+                mfst = manifest.Manifest(f)
                 try:
-                        cat = self._depot.repo.get_catalog(self._pub)
-                except srepo.RepositoryMirrorError:
-                        return iter(())
+                    mpath = self._depot.repo.manifest(f)
+                except srepo.RepositoryError as e:
+                    notfound.append(f)
+                    continue
 
-                return cat.gen_packages(collect_attrs=collect_attrs,
-                    matched=matched, patterns=patterns, pubs=pubs,
-                    unmatched=unmatched, return_fmris=return_fmris)
+                if not os.path.exists(mpath):
+                    notfound.append(f)
+                    continue
 
-        def info(self, fmri_strings, info_needed, excludes=misc.EmptyI):
-                """Gathers information about fmris.  fmri_strings is a list
-                of fmri_names for which information is desired. It
-                returns a dictionary of lists.  The keys for the dictionary are
-                the constants specified in the class definition.  The values are
-                lists of PackageInfo objects or strings."""
+                mfst.set_content(pathname=mpath)
 
-                bad_opts = info_needed - PackageInfo.ALL_OPTIONS
-                if bad_opts:
-                        raise api_errors.UnrecognizedOptionsToInfo(bad_opts)
+                if PackageInfo.LICENSES in info_needed:
+                    licenses = self.__licenses(mfst)
 
-                fmris = []
-                notfound = []
-                illegals = []
+                if PackageInfo.SIZE in info_needed:
+                    size, csize = mfst.get_size(excludes=excludes)
 
-                for pattern in fmri_strings:
-                        try:
-                                pfmri = None
-                                pfmri = self.get_matching_pattern_fmris(pattern)
-                        except pkg.fmri.IllegalFmri as e:
-                                illegals.append(pattern)
-                                continue
-                        else:
-                                fmris.extend(pfmri[0])
-                                if not pfmri:
-                                        notfound.append(pattern)
+                if act_opts & info_needed:
+                    if PackageInfo.LINKS in info_needed:
+                        links = list(
+                            mfst.gen_key_attribute_value_by_type(
+                                "link", excludes
+                            )
+                        )
+                    if PackageInfo.HARDLINKS in info_needed:
+                        hardlinks = list(
+                            mfst.gen_key_attribute_value_by_type(
+                                "hardlink", excludes
+                            )
+                        )
+                    if PackageInfo.FILES in info_needed:
+                        files = list(
+                            mfst.gen_key_attribute_value_by_type(
+                                "file", excludes
+                            )
+                        )
+                    if PackageInfo.DIRS in info_needed:
+                        dirs = list(
+                            mfst.gen_key_attribute_value_by_type(
+                                "dir", excludes
+                            )
+                        )
 
-                repo_cat = self._depot.repo.get_catalog(self._pub)
+            pis.append(
+                PackageInfo(
+                    pkg_stem=name,
+                    summary=summary,
+                    category_info_list=cat_info,
+                    states=states,
+                    publisher=pub,
+                    version=release,
+                    build_release=build_release,
+                    branch=branch,
+                    packaging_date=packaging_date,
+                    size=size,
+                    csize=csize,
+                    pfmri=f,
+                    licenses=licenses,
+                    links=links,
+                    hardlinks=hardlinks,
+                    files=files,
+                    dirs=dirs,
+                    dependencies=dependencies,
+                    description=description,
+                )
+            )
+        return {
+            self.INFO_FOUND: pis,
+            self.INFO_MISSING: notfound,
+            self.INFO_ILLEGALS: illegals,
+        }
 
-                # Set of options that can use catalog data.
-                cat_opts = frozenset([PackageInfo.SUMMARY,
-                    PackageInfo.CATEGORIES, PackageInfo.DESCRIPTION,
-                    PackageInfo.DEPENDENCIES])
+    @property
+    def last_modified(self):
+        """Returns a datetime object representing the date and time at
+        which the catalog was last modified.  Returns None if not
+        available.
+        """
+        try:
+            c = self._depot.repo.get_catalog(self._pub)
+        except srepo.RepositoryMirrorError:
+            return None
+        return c.last_modified
 
-                # Set of options that require manifest retrieval.
-                act_opts = PackageInfo.ACTION_OPTIONS - \
-                    frozenset([PackageInfo.DEPENDENCIES])
+    @property
+    def package_count(self):
+        """The total number of packages in the catalog.  Returns None
+        if the catalog is not available.
+        """
+        try:
+            c = self._depot.repo.get_catalog(self._pub)
+        except srepo.RepositoryMirrorError:
+            return None
+        return c.package_count
 
-                pis = []
-                for f in fmris:
-                        pub = name = version = release = None
-                        build_release = branch = packaging_date = None
-                        if PackageInfo.IDENTITY in info_needed:
-                                pub, name, version = f.tuple()
-                                release = version.release
-                                build_release = version.build_release
-                                branch = version.branch
-                                packaging_date = \
-                                    version.get_timestamp().strftime("%c")
+    @property
+    def package_version_count(self):
+        """The total number of package versions in the catalog.  Returns
+        None if the catalog is not available.
+        """
+        try:
+            c = self._depot.repo.get_catalog(self._pub)
+        except srepo.RepositoryMirrorError:
+            return None
+        return c.package_version_count
 
-                        states = None
+    def search(
+        self,
+        tokens,
+        case_sensitive=False,
+        return_type=qp.Query.RETURN_PACKAGES,
+        start_point=None,
+        num_to_return=None,
+        matching_version=None,
+        return_latest=False,
+    ):
+        """Searches the catalog for actions or packages (as determined
+        by 'return_type') matching the specified 'tokens'.
 
-                        links = hardlinks = files = dirs = dependencies = None
-                        summary = csize = size = licenses = cat_info = \
-                            description = None
+        'tokens' is a string using pkg(7) query syntax.
 
-                        if cat_opts & info_needed:
-                                summary, description, cat_info, dependencies = \
-                                    _get_pkg_cat_data(repo_cat, info_needed,
-                                        excludes=excludes, pfmri=f)
-                                if cat_info is not None:
-                                        cat_info = [
-                                            PackageCategory(scheme, cat)
-                                            for scheme, cat in cat_info
-                                        ]
+        'case_sensitive' is an optional, boolean value indicating
+        whether matching entries must have the same case as that of
+        the provided tokens.
 
-                        if (frozenset([PackageInfo.SIZE,
-                            PackageInfo.LICENSES]) | act_opts) & info_needed:
-                                mfst = manifest.Manifest(f)
-                                try:
-                                        mpath = self._depot.repo.manifest(f)
-                                except srepo.RepositoryError as e:
-                                        notfound.append(f)
-                                        continue
+        'return_type' is an optional, constant value indicating the
+        type of results to be returned.  This constant value should be
+        one provided by the pkg.server.query_parser.Query class.
 
-                                if not os.path.exists(mpath):
-                                        notfound.append(f)
-                                        continue
+        'start_point' is an optional, integer value indicating how many
+        search results should be discarded before returning any results.
+        None is interpreted to mean 0.
 
-                                mfst.set_content(pathname=mpath)
+        'num_to_return' is an optional, integer value indicating how
+        many search results should be returned.  None means return all
+        results.
 
-                                if PackageInfo.LICENSES in info_needed:
-                                        licenses = self.__licenses(mfst)
+        'matching_version' is a string in the format expected by the
+        pkg.version.MatchingVersion class that will be used to further
+        filter the search results as they are retrieved.
 
-                                if PackageInfo.SIZE in info_needed:
-                                        size, csize = mfst.get_size(
-                                            excludes=excludes)
+        'return_latest' is an optional, boolean value that will cause
+        only the latest versions of packages to be returned.  Ignored
+        if 'return_type' is not qp.Query.RETURN_PACKAGES.
+        """
 
-                                if act_opts & info_needed:
-                                        if PackageInfo.LINKS in info_needed:
-                                                links = list(
-                                                    mfst.gen_key_attribute_value_by_type(
-                                                    "link", excludes))
-                                        if PackageInfo.HARDLINKS in info_needed:
-                                                hardlinks = list(
-                                                    mfst.gen_key_attribute_value_by_type(
-                                                    "hardlink", excludes))
-                                        if PackageInfo.FILES in info_needed:
-                                                files = list(
-                                                    mfst.gen_key_attribute_value_by_type(
-                                                    "file", excludes))
-                                        if PackageInfo.DIRS in info_needed:
-                                                dirs = list(
-                                                    mfst.gen_key_attribute_value_by_type(
-                                                    "dir", excludes))
+        if not tokens:
+            return []
 
-                        pis.append(PackageInfo(pkg_stem=name, summary=summary,
-                            category_info_list=cat_info, states=states,
-                            publisher=pub, version=release,
-                            build_release=build_release, branch=branch,
-                            packaging_date=packaging_date, size=size,
-                            csize=csize, pfmri=f, licenses=licenses,
-                            links=links, hardlinks=hardlinks, files=files,
-                            dirs=dirs, dependencies=dependencies,
-                            description=description))
-                return {
-                    self.INFO_FOUND: pis,
-                    self.INFO_MISSING: notfound,
-                    self.INFO_ILLEGALS: illegals
-                }
+        tokens = tokens.split()
+        if not self.search_available:
+            return []
 
-        @property
-        def last_modified(self):
-                """Returns a datetime object representing the date and time at
-                which the catalog was last modified.  Returns None if not
-                available.
-                """
-                try:
-                        c = self._depot.repo.get_catalog(self._pub)
-                except srepo.RepositoryMirrorError:
-                        return None
-                return c.last_modified
+        if start_point is None:
+            start_point = 0
 
-        @property
-        def package_count(self):
-                """The total number of packages in the catalog.  Returns None
-                if the catalog is not available.
-                """
-                try:
-                        c = self._depot.repo.get_catalog(self._pub)
-                except srepo.RepositoryMirrorError:
-                        return None
-                return c.package_count
+        def filter_results(results, mver):
+            found = 0
+            last_stem = None
+            for result in results:
+                if found and ((found - start_point) >= num_to_return):
+                    break
 
-        @property
-        def package_version_count(self):
-                """The total number of package versions in the catalog.  Returns
-                None if the catalog is not available.
-                """
-                try:
-                        c = self._depot.repo.get_catalog(self._pub)
-                except srepo.RepositoryMirrorError:
-                        return None
-                return c.package_version_count
+                if result[1] == qp.Query.RETURN_PACKAGES:
+                    pfmri = result[2]
+                elif result[1] == qp.Query.RETURN_ACTIONS:
+                    pfmri = result[2][0]
 
-        def search(self, tokens, case_sensitive=False,
-            return_type=qp.Query.RETURN_PACKAGES, start_point=None,
-            num_to_return=None, matching_version=None, return_latest=False):
-                """Searches the catalog for actions or packages (as determined
-                by 'return_type') matching the specified 'tokens'.
+                if mver is not None:
+                    if mver != pfmri.version:
+                        continue
 
-                'tokens' is a string using pkg(7) query syntax.
+                if return_latest and result[1] == qp.Query.RETURN_PACKAGES:
+                    # Latest version filtering can only be
+                    # done for packages as only they are
+                    # guaranteed to be in version order.
+                    stem = result[2].pkg_name
+                    if last_stem == stem:
+                        continue
+                    else:
+                        last_stem = stem
 
-                'case_sensitive' is an optional, boolean value indicating
-                whether matching entries must have the same case as that of
-                the provided tokens.
+                found += 1
+                if found > start_point:
+                    yield result
 
-                'return_type' is an optional, constant value indicating the
-                type of results to be returned.  This constant value should be
-                one provided by the pkg.server.query_parser.Query class.
+        def filtered_search(results, mver):
+            try:
+                result = next(results)
+            except StopIteration:
+                return
 
-                'start_point' is an optional, integer value indicating how many
-                search results should be discarded before returning any results.
-                None is interpreted to mean 0.
+            return_type = result[1]
+            results = itertools.chain([result], results)
 
-                'num_to_return' is an optional, integer value indicating how
-                many search results should be returned.  None means return all
-                results.
+            if return_latest and return_type == qp.Query.RETURN_PACKAGES:
 
-                'matching_version' is a string in the format expected by the
-                pkg.version.MatchingVersion class that will be used to further
-                filter the search results as they are retrieved.
+                def cmp_fmris(resa, resb):
+                    a = resa[2]
+                    b = resb[2]
 
-                'return_latest' is an optional, boolean value that will cause
-                only the latest versions of packages to be returned.  Ignored
-                if 'return_type' is not qp.Query.RETURN_PACKAGES.
-                """
+                    if a.pkg_name == b.pkg_name:
+                        # Version in descending order.
+                        return misc.cmp(a.version, b.version) * -1
+                    return misc.cmp(a, b)
 
-                if not tokens:
-                        return []
+                return filter_results(
+                    sorted(results, key=cmp_to_key(cmp_fmris)), mver
+                )
 
-                tokens = tokens.split()
-                if not self.search_available:
-                        return []
+            return filter_results(results, mver)
 
-                if start_point is None:
-                        start_point = 0
+        if matching_version or return_latest:
+            # Additional filtering needs to be performed and
+            # the results yielded one by one.
+            mver = None
+            if matching_version:
+                mver = version.MatchingVersion(matching_version, None)
 
-                def filter_results(results, mver):
-                        found = 0
-                        last_stem = None
-                        for result in results:
-                                if found and \
-                                    ((found - start_point) >= num_to_return):
-                                        break
+            # Results should be retrieved here so that an exception
+            # can be immediately raised.
+            query = qp.Query(
+                " ".join(tokens), case_sensitive, return_type, None, None
+            )
+            res_list = self._depot.repo.search([str(query)], pub=self._pub)
+            if not res_list:
+                return
 
-                                if result[1] == qp.Query.RETURN_PACKAGES:
-                                        pfmri = result[2]
-                                elif result[1] == qp.Query.RETURN_ACTIONS:
-                                        pfmri = result[2][0]
+            return filtered_search(res_list[0], mver)
 
-                                if mver is not None:
-                                        if mver != pfmri.version:
-                                                continue
+        query = qp.Query(
+            " ".join(tokens),
+            case_sensitive,
+            return_type,
+            num_to_return,
+            start_point,
+        )
+        res_list = self._depot.repo.search([str(query)], pub=self._pub)
+        if not res_list:
+            return
+        return res_list[0]
 
-                                if return_latest and \
-                                    result[1] == qp.Query.RETURN_PACKAGES:
-                                        # Latest version filtering can only be
-                                        # done for packages as only they are
-                                        # guaranteed to be in version order.
-                                        stem = result[2].pkg_name
-                                        if last_stem == stem:
-                                                continue
-                                        else:
-                                                last_stem = stem
+    @property
+    def search_available(self):
+        """Returns a Boolean value indicating whether search
+        functionality is available for the catalog.
+        """
+        try:
+            rstore = self._depot.repo.get_pub_rstore(self._pub)
+        except srepo.RepositoryUnknownPublisher:
+            return False
+        return rstore.search_available
 
-                                found += 1
-                                if found > start_point:
-                                        yield result
+    def __licenses(self, mfst):
+        """Private function. Returns the license info from the
+        manifest mfst."""
+        license_lst = []
+        for lic in mfst.gen_actions_by_type("license"):
+            s = BytesIO()
+            lpath = self._depot.repo.file(lic.hash, pub=self._pub)
+            lfile = open(lpath, "rb")
+            misc.gunzip_from_stream(lfile, s, ignore_hash=True)
+            text = s.getvalue()
+            s.close()
+            license_lst.append(LicenseInfo(mfst.fmri, lic, text=text))
+            lfile.close()
+        return license_lst
 
-                def filtered_search(results, mver):
-                        try:
-                                result = next(results)
-                        except StopIteration:
-                                return
+    @property
+    def version(self):
+        """Returns the version of the catalog or None if no catalog
+        is available.
+        """
 
-                        return_type = result[1]
-                        results = itertools.chain([result], results)
-
-                        if return_latest and \
-                            return_type == qp.Query.RETURN_PACKAGES:
-                                def cmp_fmris(resa, resb):
-                                        a = resa[2]
-                                        b = resb[2]
-
-                                        if a.pkg_name == b.pkg_name:
-                                                # Version in descending order.
-                                                return misc.cmp(a.version,
-                                                    b.version) * -1
-                                        return misc.cmp(a, b)
-                                return filter_results(sorted(results,
-                                    key=cmp_to_key(cmp_fmris)), mver)
-
-                        return filter_results(results, mver)
-
-                if matching_version or return_latest:
-                        # Additional filtering needs to be performed and
-                        # the results yielded one by one.
-                        mver = None
-                        if matching_version:
-                                mver = version.MatchingVersion(matching_version,
-                                    None)
-
-                        # Results should be retrieved here so that an exception
-                        # can be immediately raised.
-                        query = qp.Query(" ".join(tokens), case_sensitive,
-                            return_type, None, None)
-                        res_list = self._depot.repo.search([str(query)],
-                            pub=self._pub)
-                        if not res_list:
-                                return
-
-                        return filtered_search(res_list[0], mver)
-
-                query = qp.Query(" ".join(tokens), case_sensitive,
-                    return_type, num_to_return, start_point)
-                res_list = self._depot.repo.search([str(query)],
-                    pub=self._pub)
-                if not res_list:
-                        return
-                return res_list[0]
-
-        @property
-        def search_available(self):
-                """Returns a Boolean value indicating whether search
-                functionality is available for the catalog.
-                """
-                try:
-                        rstore = self._depot.repo.get_pub_rstore(self._pub)
-                except srepo.RepositoryUnknownPublisher:
-                        return False
-                return rstore.search_available
-
-        def __licenses(self, mfst):
-                """Private function. Returns the license info from the
-                manifest mfst."""
-                license_lst = []
-                for lic in mfst.gen_actions_by_type("license"):
-                        s = BytesIO()
-                        lpath = self._depot.repo.file(lic.hash, pub=self._pub)
-                        lfile = open(lpath, "rb")
-                        misc.gunzip_from_stream(lfile, s, ignore_hash=True)
-                        text = s.getvalue()
-                        s.close()
-                        license_lst.append(LicenseInfo(mfst.fmri, lic,
-                            text=text))
-                        lfile.close()
-                return license_lst
-
-        @property
-        def version(self):
-                """Returns the version of the catalog or None if no catalog
-                is available.
-                """
-
-                try:
-                        c = self._depot.repo.get_catalog(self._pub)
-                except srepo.RepositoryMirrorError:
-                        return None
-                if hasattr(c, "version"):
-                        return c.version
-                # Assume version 0.
-                return 0
+        try:
+            c = self._depot.repo.get_catalog(self._pub)
+        except srepo.RepositoryMirrorError:
+            return None
+        if hasattr(c, "version"):
+            return c.version
+        # Assume version 0.
+        return 0
 
 
 class ConfigInterface(_Interface):
-        """This class presents a read-only interface to configuration
-        information and statistics about the depot that clients may use.
+    """This class presents a read-only interface to configuration
+    information and statistics about the depot that clients may use.
+    """
+
+    @property
+    def catalog_requests(self):
+        """The number of /catalog operation requests that have occurred
+        during the current server session.
         """
+        return self._depot.repo.catalog_requests
 
-        @property
-        def catalog_requests(self):
-                """The number of /catalog operation requests that have occurred
-                during the current server session.
-                """
-                return self._depot.repo.catalog_requests
+    @property
+    def content_root(self):
+        """The file system path where the server's content and web
+        directories are located.
+        """
+        return self._depot.content_root
 
-        @property
-        def content_root(self):
-                """The file system path where the server's content and web
-                directories are located.
-                """
-                return self._depot.content_root
+    @property
+    def file_requests(self):
+        """The number of /file operation requests that have occurred
+        during the current server session.
+        """
+        return self._depot.repo.file_requests
 
-        @property
-        def file_requests(self):
-                """The number of /file operation requests that have occurred
-                during the current server session.
-                """
-                return self._depot.repo.file_requests
+    @property
+    def in_flight_transactions(self):
+        """The number of package transactions awaiting completion."""
+        return self._depot.repo.in_flight_transactions
 
-        @property
-        def in_flight_transactions(self):
-                """The number of package transactions awaiting completion.
-                """
-                return self._depot.repo.in_flight_transactions
+    @property
+    def manifest_requests(self):
+        """The number of /manifest operation requests that have occurred
+        during the current server session.
+        """
+        return self._depot.repo.manifest_requests
 
-        @property
-        def manifest_requests(self):
-                """The number of /manifest operation requests that have occurred
-                during the current server session.
-                """
-                return self._depot.repo.manifest_requests
+    @property
+    def mirror(self):
+        """A Boolean value indicating whether the server is currently
+        operating in mirror mode.
+        """
+        return self._depot.repo.mirror
 
-        @property
-        def mirror(self):
-                """A Boolean value indicating whether the server is currently
-                operating in mirror mode.
-                """
-                return self._depot.repo.mirror
+    @property
+    def readonly(self):
+        """A Boolean value indicating whether the server is currently
+        operating in readonly mode.
+        """
+        return self._depot.repo.read_only
 
-        @property
-        def readonly(self):
-                """A Boolean value indicating whether the server is currently
-                operating in readonly mode.
-                """
-                return self._depot.repo.read_only
+    @property
+    def web_root(self):
+        """The file system path where the server's web content is
+        located.
+        """
+        return self._depot.web_root
 
-        @property
-        def web_root(self):
-                """The file system path where the server's web content is
-                located.
-                """
-                return self._depot.web_root
+    def get_depot_properties(self):
+        """Returns a dictionary of depot configuration properties
+        organized by section, with each section's keys as a list.
 
-        def get_depot_properties(self):
-                """Returns a dictionary of depot configuration properties
-                organized by section, with each section's keys as a list.
+        See pkg.depotd(8) for the list of properties.
+        """
+        rval = {}
+        for sname, props in six.iteritems(self._depot.cfg.get_index()):
+            rval[sname] = [p for p in props]
+        return rval
 
-                See pkg.depotd(8) for the list of properties.
-                """
-                rval = {}
-                for sname, props in six.iteritems(self._depot.cfg.get_index()):
-                        rval[sname] = [p for p in props]
-                return rval
+    def get_depot_property_value(self, section, prop):
+        """Returns the current value of a depot configuration
+        property for the specified section.
+        """
+        return self._depot.cfg.get_property(section, prop)
 
-        def get_depot_property_value(self, section, prop):
-                """Returns the current value of a depot configuration
-                property for the specified section.
-                """
-                return self._depot.cfg.get_property(section, prop)
+    def get_repo_properties(self):
+        """Returns a dictionary of repository configuration
+        properties organized by section, with each section's keys
+        as a list.
 
-        def get_repo_properties(self):
-                """Returns a dictionary of repository configuration
-                properties organized by section, with each section's keys
-                as a list.
+        Available properties are as follows:
 
-                Available properties are as follows:
+        Section     Property            Description
+        ==========  ==========          ===============
+        publisher   prefix              The name of the default
+                                        publisher to use for packaging
+                                        operations if one is not
+                                        provided.
 
-                Section     Property            Description
-                ==========  ==========          ===============
-                publisher   prefix              The name of the default
-                                                publisher to use for packaging
-                                                operations if one is not
-                                                provided.
+        repository  version             An integer value representing
+                                        the version of the repository's
+                                        format.
+        """
+        rval = {}
+        for sname, props in six.iteritems(self._depot.repo.cfg.get_index()):
+            rval[sname] = [p for p in props]
+        return rval
 
-                repository  version             An integer value representing
-                                                the version of the repository's
-                                                format.
-                """
-                rval = {}
-                for sname, props in six.iteritems(self._depot.repo.cfg.get_index()):
-                        rval[sname] = [p for p in props]
-                return rval
-
-        def get_repo_property_value(self, section, prop):
-                """Returns the current value of a repository configuration
-                property for the specified section.
-                """
-                return self._depot.repo.cfg.get_property(section, prop)
+    def get_repo_property_value(self, section, prop):
+        """Returns the current value of a repository configuration
+        property for the specified section.
+        """
+        return self._depot.repo.cfg.get_property(section, prop)
 
 
 class RequestInterface(_Interface):
-        """This class presents an interface to server request objects that
-        clients may use.
+    """This class presents an interface to server request objects that
+    clients may use.
+    """
+
+    def get_accepted_languages(self):
+        """Returns a list of the languages accepted by the client
+        sorted by priority.  This information is derived from the
+        Accept-Language header provided by the client.
         """
+        alist = []
+        for entry in self._request.headers.elements("Accept-Language"):
+            alist.append(str(entry).split(";")[0])
 
-        def get_accepted_languages(self):
-                """Returns a list of the languages accepted by the client
-                sorted by priority.  This information is derived from the
-                Accept-Language header provided by the client.
-                """
-                alist = []
-                for entry in self._request.headers.elements("Accept-Language"):
-                        alist.append(str(entry).split(";")[0])
+        return alist
 
-                return alist
+    def get_rel_path(self, uri):
+        """Returns uri relative to the current request path."""
+        return pkg.misc.get_rel_path(self._request, uri, pub=self._pub)
 
-        def get_rel_path(self, uri):
-                """Returns uri relative to the current request path.
-                """
-                return pkg.misc.get_rel_path(self._request, uri, pub=self._pub)
+    def log(self, msg):
+        """Instruct the server to log the provided message to its error
+        logs.
+        """
+        return cherrypy.log(msg)
 
-        def log(self, msg):
-                """Instruct the server to log the provided message to its error
-                logs.
-                """
-                return cherrypy.log(msg)
+    @property
+    def params(self):
+        """A dict containing the parameters sent in the request, either
+        in the query string or in the request body.
+        """
+        return self._request.params
 
-        @property
-        def params(self):
-                """A dict containing the parameters sent in the request, either
-                in the query string or in the request body.
-                """
-                return self._request.params
+    @property
+    def path_info(self):
+        """A string containing the "path_info" portion of the requested
+        URL.
+        """
+        return self._request.path_info
 
-        @property
-        def path_info(self):
-                """A string containing the "path_info" portion of the requested
-                URL.
-                """
-                return self._request.path_info
+    @property
+    def publisher(self):
+        """The Publisher object for the package data related to this
+        request or None if not available.
+        """
+        try:
+            return self._depot.repo.get_publisher(self._pub)
+        except srepo.RepositoryUnknownPublisher:
+            return None
 
-        @property
-        def publisher(self):
-                """The Publisher object for the package data related to this
-                request or None if not available.
-                """
-                try:
-                        return self._depot.repo.get_publisher(self._pub)
-                except srepo.RepositoryUnknownPublisher:
-                        return None
+    @property
+    def query_string(self):
+        """A string containing the "query_string" portion of the
+        requested URL.
+        """
+        return cherrypy.request.query_string
 
-        @property
-        def query_string(self):
-                """A string containing the "query_string" portion of the
-                requested URL.
-                """
-                return cherrypy.request.query_string
+    def url(self, path="", qs="", script_name=None, relative=None):
+        """Create an absolute URL for the given path.
 
-        def url(self, path="", qs="", script_name=None, relative=None):
-                """Create an absolute URL for the given path.
+        If 'path' starts with a slash ('/'), this will return (base +
+        script_name + path + qs).  If it does not start with a slash,
+        this returns (base url + script_name [+ request.path_info] +
+        path + qs).
 
-                If 'path' starts with a slash ('/'), this will return (base +
-                script_name + path + qs).  If it does not start with a slash,
-                this returns (base url + script_name [+ request.path_info] +
-                path + qs).
+        If script_name is None, an appropriate value will be
+        automatically determined from the current request path.
 
-                If script_name is None, an appropriate value will be
-                automatically determined from the current request path.
+        If no parameters are specified, an absolute URL for the current
+        request path (minus the querystring) by passing no args.  If
+        url(qs=request.query_string), is called, the original client URL
+        (assuming no internal redirections) should be returned.
 
-                If no parameters are specified, an absolute URL for the current
-                request path (minus the querystring) by passing no args.  If
-                url(qs=request.query_string), is called, the original client URL
-                (assuming no internal redirections) should be returned.
+        If relative is None or not provided, an appropriate value will
+        be automatically determined.  If False, the output will be an
+        absolute URL (including the scheme, host, vhost, and
+        script_name).  If True, the output will instead be a URL that
+        is relative to the current request path, perhaps including '..'
+        atoms.  If relative is the string 'server', the output will
+        instead be a URL that is relative to the server root; i.e., it
+        will start with a slash.
+        """
+        return cherrypy.url(
+            path=path, qs=qs, script_name=script_name, relative=relative
+        )
 
-                If relative is None or not provided, an appropriate value will
-                be automatically determined.  If False, the output will be an
-                absolute URL (including the scheme, host, vhost, and
-                script_name).  If True, the output will instead be a URL that
-                is relative to the current request path, perhaps including '..'
-                atoms.  If relative is the string 'server', the output will
-                instead be a URL that is relative to the server root; i.e., it
-                will start with a slash.
-                """
-                return cherrypy.url(path=path, qs=qs, script_name=script_name,
-                    relative=relative)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/server/api_errors.py
+++ b/src/modules/server/api_errors.py
@@ -23,48 +23,57 @@
 # Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
 #
 
-class ApiException(Exception):
-        """Base exception class for all server.api exceptions."""
-        def __init__(self, *args):
-                Exception.__init__(self, *args)
-                if args:
-                        self.data = args[0]
 
-        def __str__(self):
-                return str(self.data)
+class ApiException(Exception):
+    """Base exception class for all server.api exceptions."""
+
+    def __init__(self, *args):
+        Exception.__init__(self, *args)
+        if args:
+            self.data = args[0]
+
+    def __str__(self):
+        return str(self.data)
 
 
 class VersionException(ApiException):
-        """Exception used to indicate that the client's requested api version
-        is not supported.
-        """
-        def __init__(self, expected_version, received_version):
-                ApiException.__init__(self)
-                self.expected_version = expected_version
-                self.received_version = received_version
+    """Exception used to indicate that the client's requested api version
+    is not supported.
+    """
 
-        def __str__(self):
-                return "Incompatible API version '{0}' specified; " \
-                    "expected: '{1}'.".format(self.received_version,
-                    self.expected_version)
+    def __init__(self, expected_version, received_version):
+        ApiException.__init__(self)
+        self.expected_version = expected_version
+        self.received_version = received_version
+
+    def __str__(self):
+        return (
+            "Incompatible API version '{0}' specified; "
+            "expected: '{1}'.".format(
+                self.received_version, self.expected_version
+            )
+        )
 
 
 class RedirectException(ApiException):
-        """Used to indicate that the client should be redirected to a new
-        URI.
-        """
-        pass
+    """Used to indicate that the client should be redirected to a new
+    URI.
+    """
+
+    pass
 
 
 class UnrecognizedOptionsToInfo(ApiException):
-        def __init__(self, opts):
-                ApiException.__init__(self)
-                self._opts = opts
+    def __init__(self, opts):
+        ApiException.__init__(self)
+        self._opts = opts
 
-        def __str__(self):
-                s = _("Info does not recognize the following options: {0}").format(
-                    ", ".join(str(o) for o in self._opts))
-                return s
+    def __str__(self):
+        s = _("Info does not recognize the following options: {0}").format(
+            ", ".join(str(o) for o in self._opts)
+        )
+        return s
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/server/catalog.py
+++ b/src/modules/server/catalog.py
@@ -33,727 +33,741 @@ import re
 import stat
 import tempfile
 
-class CatalogException(Exception):
 
-        def __init__(self, args=None):
-                self._args = args
+class CatalogException(Exception):
+    def __init__(self, args=None):
+        self._args = args
 
 
 class CatalogPermissionsException(CatalogException):
-        """Used to indicate the server catalog files do not have the expected
-        permissions."""
+    """Used to indicate the server catalog files do not have the expected
+    permissions."""
 
-        def __init__(self, files):
-                """files should contain a list object with each entry consisting
-                of a tuple of filename, expected_mode, received_mode."""
-                if not files:
-                        files = []
-                CatalogException.__init__(self, files)
+    def __init__(self, files):
+        """files should contain a list object with each entry consisting
+        of a tuple of filename, expected_mode, received_mode."""
+        if not files:
+            files = []
+        CatalogException.__init__(self, files)
 
-        def __str__(self):
-                msg = _("The following catalog files have incorrect "
-                    "permissions:\n")
-                for f in self._args:
-                        fname, emode, fmode = f
-                        msg += _("\t{fname}: expected mode: {emode}, found "
-                            "mode: {fmode}\n").format(fname=fname,
-                            emode=emode, fmode=fmode)
-                return msg
+    def __str__(self):
+        msg = _("The following catalog files have incorrect " "permissions:\n")
+        for f in self._args:
+            fname, emode, fmode = f
+            msg += _(
+                "\t{fname}: expected mode: {emode}, found " "mode: {fmode}\n"
+            ).format(fname=fname, emode=emode, fmode=fmode)
+        return msg
 
 
 class ServerCatalog(object):
-        """A Catalog is the representation of the package FMRIs available to
-        the repository.  This class is only used for compatibility with v0
-        repositories.
+    """A Catalog is the representation of the package FMRIs available to
+    the repository.  This class is only used for compatibility with v0
+    repositories.
 
-        The serialized structure of the repository is an unordered list of
-        available package versions, followed by an unordered list of
-        incorporation relationships between packages.  This latter section
-        allows the graph to be topologically sorted by the client.
+    The serialized structure of the repository is an unordered list of
+    available package versions, followed by an unordered list of
+    incorporation relationships between packages.  This latter section
+    allows the graph to be topologically sorted by the client.
 
-        S Last-Modified: [timespec]
+    S Last-Modified: [timespec]
 
-        XXX A publisher mirror-uri ...
-        XXX ...
+    XXX A publisher mirror-uri ...
+    XXX ...
 
-        V fmri
-        V fmri
-        ...
-        C fmri
-        C fmri
-        ...
-        I fmri fmri
-        I fmri fmri
-        ...
+    V fmri
+    V fmri
+    ...
+    C fmri
+    C fmri
+    ...
+    I fmri fmri
+    I fmri fmri
+    ...
 
-        In order to improve the time to search the catalog, a cached list
-        of package names is kept in the catalog instance."""
+    In order to improve the time to search the catalog, a cached list
+    of package names is kept in the catalog instance."""
 
-        # The file mode to be used for all catalog files.
-        file_mode = stat.S_IRUSR|stat.S_IWUSR|stat.S_IRGRP|stat.S_IROTH
+    # The file mode to be used for all catalog files.
+    file_mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
 
-        def __init__(self, cat_root, publisher=None, read_only=False):
-                """Create a catalog.  If the path supplied does not exist,
-                this will create the required directory structure.
-                Otherwise, if the directories are already in place, the
-                existing catalog is opened.  publisher names the publisher
-                that is represented by this catalog."""
+    def __init__(self, cat_root, publisher=None, read_only=False):
+        """Create a catalog.  If the path supplied does not exist,
+        this will create the required directory structure.
+        Otherwise, if the directories are already in place, the
+        existing catalog is opened.  publisher names the publisher
+        that is represented by this catalog."""
 
-                self.catalog_root = cat_root
-                self.catalog_file = os.path.normpath(os.path.join(
-                    self.catalog_root, "catalog"))
-                self.attrs = {}
-                self.pub = publisher
-                self.read_only = read_only
-                self.__size = -1
+        self.catalog_root = cat_root
+        self.catalog_file = os.path.normpath(
+            os.path.join(self.catalog_root, "catalog")
+        )
+        self.attrs = {}
+        self.pub = publisher
+        self.read_only = read_only
+        self.__size = -1
 
-                self.attrs["npkgs"] = 0
+        self.attrs["npkgs"] = 0
 
-                if not os.path.exists(cat_root):
-                        try:
-                                os.makedirs(cat_root)
-                        except EnvironmentError as e:
-                                if e.errno in (errno.EACCES, errno.EROFS):
-                                        return
-                                raise
+        if not os.path.exists(cat_root):
+            try:
+                os.makedirs(cat_root)
+            except EnvironmentError as e:
+                if e.errno in (errno.EACCES, errno.EROFS):
+                    return
+                raise
 
-                self.load_attrs()
-                self.check_prefix()
-                self.__set_perms()
+        self.load_attrs()
+        self.check_prefix()
+        self.__set_perms()
 
-        @staticmethod
-        def destroy(root=None):
-                """Removes the on-disk files for the catalog only."""
+    @staticmethod
+    def destroy(root=None):
+        """Removes the on-disk files for the catalog only."""
 
-                for fname in ("attrs", "catalog"):
-                        path = os.path.normpath(os.path.join(root, fname))
-                        try:
-                                portable.remove(path)
-                        except EnvironmentError as e:
-                                if e.errno != errno.ENOENT:
-                                        raise
+        for fname in ("attrs", "catalog"):
+            path = os.path.normpath(os.path.join(root, fname))
+            try:
+                portable.remove(path)
+            except EnvironmentError as e:
+                if e.errno != errno.ENOENT:
+                    raise
 
-        def __set_perms(self):
-                """Sets permissions on catalog files if not read_only and if the
-                current user can do so; raises CatalogPermissionsException if
-                the permissions are wrong and cannot be corrected."""
+    def __set_perms(self):
+        """Sets permissions on catalog files if not read_only and if the
+        current user can do so; raises CatalogPermissionsException if
+        the permissions are wrong and cannot be corrected."""
 
-                apath = os.path.normpath(os.path.join(self.catalog_root,
-                    "attrs"))
-                cpath = os.path.normpath(os.path.join(self.catalog_root,
-                    "catalog"))
+        apath = os.path.normpath(os.path.join(self.catalog_root, "attrs"))
+        cpath = os.path.normpath(os.path.join(self.catalog_root, "catalog"))
 
-                # Force file_mode, so that unprivileged users can read these.
-                bad_modes = []
-                for fpath in (apath, cpath):
-                        try:
-                                if self.read_only:
-                                        try:
-                                                portable.assert_mode(fpath,
-                                                    self.file_mode)
-                                        except AssertionError as ae:
-                                                bad_modes.append((fpath,
-                                                    "{0:o}".format(self.file_mode),
-                                                    "{0:o}".format(ae.mode)))
-                                else:
-                                        os.chmod(fpath, self.file_mode)
-                        except EnvironmentError as e:
-                                # If the files don't exist yet, move on.
-                                if e.errno == errno.ENOENT:
-                                        continue
-
-                                # If the mode change failed for another reason,
-                                # check to see if we actually needed to change
-                                # it, and if so, add it to bad_modes.
-                                try:
-                                        portable.assert_mode(fpath,
-                                            self.file_mode)
-                                except AssertionError as ae:
-                                        bad_modes.append((fpath,
-                                            "{0:o}".format(self.file_mode),
-                                            "{0:o}".format(ae.mode)))
-
-                if bad_modes:
-                        raise CatalogPermissionsException(bad_modes)
-
-        def add_fmri(self, pfmri, critical = False):
-                """Add a package, named by the fmri, to the catalog.
-                Throws an exception if an identical package is already
-                present.  Throws an exception if package has no version."""
-                if pfmri.version == None:
-                        raise CatalogException(
-                            "Unversioned FMRI not supported: {0}".format(pfmri))
-
-                assert not self.read_only
-
-                # Callers should verify that the FMRI they're going to add is
-                # valid; however, this check is here in case they're
-                # lackadaisical
-                if not self.valid_new_fmri(pfmri):
-                        raise CatalogException("FMRI {0} already exists in "
-                            "the catalog.".format(pfmri))
-
-                if critical:
-                        pkgstr = "C {0}\n".format(pfmri.get_fmri(anarchy = True))
+        # Force file_mode, so that unprivileged users can read these.
+        bad_modes = []
+        for fpath in (apath, cpath):
+            try:
+                if self.read_only:
+                    try:
+                        portable.assert_mode(fpath, self.file_mode)
+                    except AssertionError as ae:
+                        bad_modes.append(
+                            (
+                                fpath,
+                                "{0:o}".format(self.file_mode),
+                                "{0:o}".format(ae.mode),
+                            )
+                        )
                 else:
-                        pkgstr = "V {0}\n".format(pfmri.get_fmri(anarchy = True))
+                    os.chmod(fpath, self.file_mode)
+            except EnvironmentError as e:
+                # If the files don't exist yet, move on.
+                if e.errno == errno.ENOENT:
+                    continue
 
-                self.__append_to_catalog(pkgstr)
-
-                # Catalog size has changed, force recalculation on
-                # next send()
-                self.__size = -1
-
-                self.attrs["npkgs"] += 1
-
-                ts = datetime.datetime.now()
-                self.set_time(ts)
-
-                return ts
-
-        def __append_to_catalog(self, pkgstr):
-                """Write string named pkgstr to the catalog.  This
-                routine handles moving the catalog to a temporary file,
-                appending the new string, and renaming the temporary file
-                on top of the existing catalog."""
-
-                # Create tempfile
-                tmp_num, tmpfile = tempfile.mkstemp(dir=self.catalog_root)
-
+                # If the mode change failed for another reason,
+                # check to see if we actually needed to change
+                # it, and if so, add it to bad_modes.
                 try:
-                        # use fdopen since we already have a filehandle
-                        tfile = os.fdopen(tmp_num, "w")
-                except OSError:
-                        portable.remove(tmpfile)
-                        raise
-
-                # Try to open catalog file.  If it doesn't exist,
-                # create an empty catalog file, and then open it read only.
-                try:
-                        pfile = open(self.catalog_file, "rb")
-                except IOError as e:
-                        if e.errno == errno.ENOENT:
-                                # Creating an empty file
-                                open(self.catalog_file, "wb").close()
-                                pfile = open(self.catalog_file, "rb")
-                        else:
-                                portable.remove(tmpfile)
-                                raise
-
-                # Make sure we're at the start of the file
-                pfile.seek(0)
-
-                # Write all of the existing entries in the catalog
-                # into the tempfile.  Then append the new lines at the
-                # end.
-                try:
-                        for entry in pfile:
-                                if entry == pkgstr:
-                                        raise CatalogException(
-                                            "Package {0} is already in "
-                                            "the catalog".format(pkgstr))
-                                else:
-                                        tfile.write(entry)
-                        tfile.write(pkgstr)
-                except Exception:
-                        portable.remove(tmpfile)
-                        raise
-
-                # Close our open files
-                pfile.close()
-                tfile.close()
-
-                # Set the permissions on the tempfile correctly.
-                # Mkstemp creates files as 600.  Rename the new
-                # cataog on top of the old one.
-                try:
-                        os.chmod(tmpfile, self.file_mode)
-                        portable.rename(tmpfile, self.catalog_file)
-                except EnvironmentError:
-                        portable.remove(tmpfile)
-                        raise
-
-        @staticmethod
-        def cache_fmri(d, pfmri, pub, known=True):
-                """Store the fmri in a data structure 'd' for fast lookup.
-
-                'd' is a dict that maps each package name to another dictionary,
-                itself mapping:
-
-                        * each version string, which maps to a tuple of:
-                          -- the fmri object
-                          -- a dict of publisher prefixes with each value
-                             indicating catalog presence
-
-                        * "versions", which maps to a list of version objects,
-                          kept in sorted order
-
-                The structure is as follows:
-                    pkg_name1: {
-                        "versions": [<version1>, <version2>, ... ],
-                        "version1": (
-                            <fmri1>,
-                            { "pub1": known, "pub2": known, ... },
-                        ),
-                        "version2": (
-                            <fmri2>,
-                            { "pub1": known, "pub2": known, ... },
-                        ),
-                        ...
-                    },
-                    pkg_name2: {
-                        ...
-                    },
-                    ...
-
-                (where names in quotes are strings, names in angle brackets are
-                objects, and the rest of the syntax is Pythonic).
-
-                The fmri is expected not to have an embedded publisher.  If it
-                does, it will be ignored."""
-
-                if pfmri.has_publisher():
-                        # Cache entries must not contain the name of the
-                        # publisher, otherwise matching during packaging
-                        # operations may not work correctly.
-                        pfmri = fmri.PkgFmri(pfmri.get_fmri(anarchy=True))
-
-                pversion = str(pfmri.version)
-                if pfmri.pkg_name not in d:
-                        # This is the simplest representation of the cache data
-                        # structure.
-                        d[pfmri.pkg_name] = {
-                            "versions": [pfmri.version],
-                            pversion: (pfmri, { pub: known })
-                        }
-
-                elif pversion not in d[pfmri.pkg_name]:
-                        d[pfmri.pkg_name][pversion] = (pfmri, { pub: known })
-                        bisect.insort(d[pfmri.pkg_name]["versions"],
-                            pfmri.version)
-                elif pub not in d[pfmri.pkg_name][pversion][1]:
-                        d[pfmri.pkg_name][pversion][1][pub] = known
-
-        def attrs_as_lines(self):
-                """Takes the list of in-memory attributes and returns
-                a list of strings, each string naming an attribute."""
-
-                ret = []
-
-                for k, v in self.attrs.items():
-                        s = "S {0}: {1}\n".format(k, v)
-                        ret.append(s)
-
-                return ret
-
-        def as_lines(self):
-                """Returns a generator function that produces the contents of
-                the catalog as a list of strings."""
-
-                try:
-                        cfile = open(self.catalog_file, "r")
-                except EnvironmentError as e:
-                        # Missing catalog is fine; other errors need to
-                        # be reported.
-                        if e.errno == errno.ENOENT:
-                                return
-                        raise
-
-                for e in cfile:
-                        yield e
-
-                cfile.close()
-
-        def check_prefix(self):
-                """If this version of the catalog knows about new prefixes,
-                check the on disk catalog to see if we can perform any
-                transformations based upon previously unknown catalog formats.
-
-                This routine will add a catalog attribute if it doesn't exist,
-                otherwise it checks this attribute against a hard-coded
-                version-specific tuple to see if new methods were added.
-
-                If new methods were added, it will call an additional routine
-                that updates the on-disk catalog, if necessary."""
-
-
-                # If a prefixes attribute doesn't exist, write one and get on
-                # with it.
-                if not "prefix" in self.attrs:
-                        self.attrs["prefix"] = "".join(known_prefixes)
-                        if not self.read_only:
-                                self.save_attrs()
-                        return
-
-                # Prefixes attribute does exist.  Check if it has changed.
-                pfx_set = set(self.attrs["prefix"])
-
-                # Nothing to do if prefixes haven't changed
-                if pfx_set == known_prefixes:
-                        return
-
-                # If known_prefixes contains a prefix not in pfx_set,
-                # add the prefix and perform a catalog transform.
-                new = known_prefixes.difference(pfx_set)
-                if new:
-                        pfx_set.update(new)
-
-                        # Write out updated prefixes list
-                        self.attrs["prefix"] = "".join(pfx_set)
-                        if not self.read_only:
-                                self.save_attrs()
-
-        @property
-        def exists(self):
-                """A boolean value indicating whether the Catalog exists
-                on-disk."""
-
-                if not self.catalog_file:
-                        return False
-                return os.path.exists(self.catalog_file)
-
-        def fmris(self):
-                """A generator function that produces FMRIs as it
-                iterates over the contents of the catalog."""
-
-                try:
-                        pfile = open(os.path.normpath(
-                            os.path.join(self.catalog_root, "catalog")), "r")
-                except IOError as e:
-                        if e.errno == errno.ENOENT:
-                                return
-                        else:
-                                raise
-
-                for entry in pfile:
-                        if not entry.startswith("V pkg") and \
-                            not entry.startswith("C pkg"):
-                                continue
-
-                        try:
-                                yield self.__parse_entry(entry, self.pub)
-                        except (KeyboardInterrupt, SystemExit):
-                                raise
-                        except Exception as e:
-                                raise RuntimeError("corrupt catalog entry for "
-                                    "publisher '{0}': {1}".format(self.pub,
-                                    entry))
-
-                pfile.close()
-
-        def last_modified(self):
-                """Return the time at which the catalog was last modified."""
-
-                return self.attrs.get("Last-Modified", None)
-
-        def load_attrs(self, filenm = "attrs"):
-                """Load attributes from the catalog file into the in-memory
-                attributes dictionary"""
-
-                apath = os.path.normpath(
-                    os.path.join(self.catalog_root, filenm))
-                if not os.path.exists(apath):
-                        return
-
-                afile = open(apath, "r")
-                attrre = re.compile(r'^S ([^:]*): (.*)')
-
-                for entry in afile:
-                        m = attrre.match(entry)
-                        if m != None:
-                                self.attrs[m.group(1)] = m.group(2)
-
-                afile.close()
-
-                # convert npkgs to integer value
-                if "npkgs" in self.attrs:
-                        self.attrs["npkgs"] = int(self.attrs["npkgs"])
-
-        def npkgs(self):
-                """Returns the number of packages in the catalog."""
-
-                return self.attrs["npkgs"]
-
-        def origin(self):
-                """Returns the URL of the catalog's origin."""
-
-                return self.attrs.get("origin", None)
-
-        @property
-        def package_count(self):
-                """Returns the number of packages in the catalog."""
-
-                return self.attrs["npkgs"] or 0
-
-        @classmethod
-        def recv(cls, filep, path, pub=None):
-                """A static method that takes a file-like object and
-                a path.  This is the other half of catalog.send().  It
-                reads a stream as an incoming catalog and lays it down
-                on disk."""
-
-                bad_fmri = None
-
-                if not os.path.exists(path):
-                        os.makedirs(path)
-
-                afd, attrpath = tempfile.mkstemp(dir=path)
-                cfd, catpath = tempfile.mkstemp(dir=path)
-
-                attrf = os.fdopen(afd, "w")
-                catf = os.fdopen(cfd, "w")
-
-                attrpath_final = os.path.normpath(os.path.join(path, "attrs"))
-                catpath_final = os.path.normpath(os.path.join(path, "catalog"))
-
-                try:
-                        for s in filep:
-                                slen = len(s)
-
-                                # If line is too short, process the next one
-                                if slen < 2:
-                                        continue
-                                # check that line is in the proper format
-                                elif not s[1].isspace():
-                                        continue
-                                elif not s[0] in known_prefixes:
-                                        catf.write(s)
-                                elif s.startswith("S "):
-                                        attrf.write(s)
-                                elif s.startswith("R "):
-                                        catf.write(s)
-                                else:
-                                        # XXX Need to be able to handle old and
-                                        # new format catalogs.
-                                        try:
-                                                f = fmri.PkgFmri(s[2:])
-                                        except fmri.IllegalFmri as e:
-                                                bad_fmri = e
-                                                continue
-
-                                        catf.write("{0} {1} {2} {3}\n".format(
-                                            s[0], "pkg", f.pkg_name,
-                                            f.version))
-                except:
-                        # Re-raise all uncaught exceptions after performing
-                        # cleanup.
-                        attrf.close()
-                        catf.close()
-                        os.remove(attrpath)
-                        os.remove(catpath)
-                        raise
-
-                # If we got a parse error on FMRIs and transfer
-                # wasn't truncated, raise a FmriFailures error.
-                if bad_fmri:
-                        attrf.close()
-                        catf.close()
-                        os.remove(attrpath)
-                        os.remove(catpath)
-                        raise bad_fmri
-
-                # Write the publisher's origin into our attributes
-                if pub:
-                        origstr = "S origin: {0}\n".format(pub["origin"])
-                        attrf.write(origstr)
-
-                attrf.close()
-                catf.close()
-
-                # Mkstemp sets mode 600 on these files by default.
-                # Restore them to 644, so that unprivileged users
-                # may read these files.
-                os.chmod(attrpath, cls.file_mode)
-                os.chmod(catpath, cls.file_mode)
-
-                portable.rename(attrpath, attrpath_final)
-                portable.rename(catpath, catpath_final)
-
-        def save_attrs(self, filenm="attrs"):
-                """Save attributes from the in-memory catalog to a file
-                specified by filenm."""
-
-                tmpfile = None
-                assert not self.read_only
-
-                finalpath = os.path.normpath(
-                    os.path.join(self.catalog_root, filenm))
-
-                try:
-                        tmp_num, tmpfile = tempfile.mkstemp(
-                            dir=self.catalog_root)
-
-                        tfile = os.fdopen(tmp_num, "w")
-
-                        for a in self.attrs.keys():
-                                s = "S {0}: {1}\n".format(a, self.attrs[a])
-                                tfile.write(s)
-
-                        tfile.close()
-                        os.chmod(tmpfile, self.file_mode)
-                        portable.rename(tmpfile, finalpath)
-
-                except EnvironmentError as e:
-                        # This may get called in a situation where
-                        # the user does not have write access to the attrs
-                        # file.
-                        if tmpfile:
-                                portable.remove(tmpfile)
-                        if e.errno in (errno.EACCES, errno.EROFS):
-                                return
-                        else:
-                                raise
-
-                # Recalculate size on next send()
-                self.__size = -1
-
-        def send(self, filep, rspobj=None):
-                """Send the contents of this catalog out to the filep
-                specified as an argument."""
-
-                if rspobj is not None:
-                        rspobj.headers['Content-Length'] = str(self.size())
-
-                def output():
-                        # Send attributes first.
-                        for line in self.attrs_as_lines():
-                                yield line
-
-                        try:
-                                cfile = open(os.path.normpath(
-                                    os.path.join(self.catalog_root, "catalog")),
-                                    "r")
-                        except IOError as e:
-                                # Missing catalog is fine; other errors need to
-                                # be reported.
-                                if e.errno == errno.ENOENT:
-                                        return
-                                else:
-                                        raise
-
-                        for e in cfile:
-                                yield e
-
-                        cfile.close()
-
-                if filep:
-                        for line in output():
-                                filep.write(line)
+                    portable.assert_mode(fpath, self.file_mode)
+                except AssertionError as ae:
+                    bad_modes.append(
+                        (
+                            fpath,
+                            "{0:o}".format(self.file_mode),
+                            "{0:o}".format(ae.mode),
+                        )
+                    )
+
+        if bad_modes:
+            raise CatalogPermissionsException(bad_modes)
+
+    def add_fmri(self, pfmri, critical=False):
+        """Add a package, named by the fmri, to the catalog.
+        Throws an exception if an identical package is already
+        present.  Throws an exception if package has no version."""
+        if pfmri.version == None:
+            raise CatalogException(
+                "Unversioned FMRI not supported: {0}".format(pfmri)
+            )
+
+        assert not self.read_only
+
+        # Callers should verify that the FMRI they're going to add is
+        # valid; however, this check is here in case they're
+        # lackadaisical
+        if not self.valid_new_fmri(pfmri):
+            raise CatalogException(
+                "FMRI {0} already exists in " "the catalog.".format(pfmri)
+            )
+
+        if critical:
+            pkgstr = "C {0}\n".format(pfmri.get_fmri(anarchy=True))
+        else:
+            pkgstr = "V {0}\n".format(pfmri.get_fmri(anarchy=True))
+
+        self.__append_to_catalog(pkgstr)
+
+        # Catalog size has changed, force recalculation on
+        # next send()
+        self.__size = -1
+
+        self.attrs["npkgs"] += 1
+
+        ts = datetime.datetime.now()
+        self.set_time(ts)
+
+        return ts
+
+    def __append_to_catalog(self, pkgstr):
+        """Write string named pkgstr to the catalog.  This
+        routine handles moving the catalog to a temporary file,
+        appending the new string, and renaming the temporary file
+        on top of the existing catalog."""
+
+        # Create tempfile
+        tmp_num, tmpfile = tempfile.mkstemp(dir=self.catalog_root)
+
+        try:
+            # use fdopen since we already have a filehandle
+            tfile = os.fdopen(tmp_num, "w")
+        except OSError:
+            portable.remove(tmpfile)
+            raise
+
+        # Try to open catalog file.  If it doesn't exist,
+        # create an empty catalog file, and then open it read only.
+        try:
+            pfile = open(self.catalog_file, "rb")
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                # Creating an empty file
+                open(self.catalog_file, "wb").close()
+                pfile = open(self.catalog_file, "rb")
+            else:
+                portable.remove(tmpfile)
+                raise
+
+        # Make sure we're at the start of the file
+        pfile.seek(0)
+
+        # Write all of the existing entries in the catalog
+        # into the tempfile.  Then append the new lines at the
+        # end.
+        try:
+            for entry in pfile:
+                if entry == pkgstr:
+                    raise CatalogException(
+                        "Package {0} is already in "
+                        "the catalog".format(pkgstr)
+                    )
                 else:
-                        return output()
+                    tfile.write(entry)
+            tfile.write(pkgstr)
+        except Exception:
+            portable.remove(tmpfile)
+            raise
 
-        def set_time(self, ts = None):
-                """Set time to timestamp if supplied by caller.  Otherwise
-                use the system time."""
+        # Close our open files
+        pfile.close()
+        tfile.close()
 
-                assert not self.read_only
+        # Set the permissions on the tempfile correctly.
+        # Mkstemp creates files as 600.  Rename the new
+        # cataog on top of the old one.
+        try:
+            os.chmod(tmpfile, self.file_mode)
+            portable.rename(tmpfile, self.catalog_file)
+        except EnvironmentError:
+            portable.remove(tmpfile)
+            raise
 
-                if ts and isinstance(ts, str):
-                        self.attrs["Last-Modified"] = ts
-                elif ts and isinstance(ts, datetime.datetime):
-                        self.attrs["Last-Modified"] = ts.isoformat()
-                else:
-                        self.attrs["Last-Modified"] = timestamp()
+    @staticmethod
+    def cache_fmri(d, pfmri, pub, known=True):
+        """Store the fmri in a data structure 'd' for fast lookup.
 
+        'd' is a dict that maps each package name to another dictionary,
+        itself mapping:
+
+                * each version string, which maps to a tuple of:
+                  -- the fmri object
+                  -- a dict of publisher prefixes with each value
+                     indicating catalog presence
+
+                * "versions", which maps to a list of version objects,
+                  kept in sorted order
+
+        The structure is as follows:
+            pkg_name1: {
+                "versions": [<version1>, <version2>, ... ],
+                "version1": (
+                    <fmri1>,
+                    { "pub1": known, "pub2": known, ... },
+                ),
+                "version2": (
+                    <fmri2>,
+                    { "pub1": known, "pub2": known, ... },
+                ),
+                ...
+            },
+            pkg_name2: {
+                ...
+            },
+            ...
+
+        (where names in quotes are strings, names in angle brackets are
+        objects, and the rest of the syntax is Pythonic).
+
+        The fmri is expected not to have an embedded publisher.  If it
+        does, it will be ignored."""
+
+        if pfmri.has_publisher():
+            # Cache entries must not contain the name of the
+            # publisher, otherwise matching during packaging
+            # operations may not work correctly.
+            pfmri = fmri.PkgFmri(pfmri.get_fmri(anarchy=True))
+
+        pversion = str(pfmri.version)
+        if pfmri.pkg_name not in d:
+            # This is the simplest representation of the cache data
+            # structure.
+            d[pfmri.pkg_name] = {
+                "versions": [pfmri.version],
+                pversion: (pfmri, {pub: known}),
+            }
+
+        elif pversion not in d[pfmri.pkg_name]:
+            d[pfmri.pkg_name][pversion] = (pfmri, {pub: known})
+            bisect.insort(d[pfmri.pkg_name]["versions"], pfmri.version)
+        elif pub not in d[pfmri.pkg_name][pversion][1]:
+            d[pfmri.pkg_name][pversion][1][pub] = known
+
+    def attrs_as_lines(self):
+        """Takes the list of in-memory attributes and returns
+        a list of strings, each string naming an attribute."""
+
+        ret = []
+
+        for k, v in self.attrs.items():
+            s = "S {0}: {1}\n".format(k, v)
+            ret.append(s)
+
+        return ret
+
+    def as_lines(self):
+        """Returns a generator function that produces the contents of
+        the catalog as a list of strings."""
+
+        try:
+            cfile = open(self.catalog_file, "r")
+        except EnvironmentError as e:
+            # Missing catalog is fine; other errors need to
+            # be reported.
+            if e.errno == errno.ENOENT:
+                return
+            raise
+
+        for e in cfile:
+            yield e
+
+        cfile.close()
+
+    def check_prefix(self):
+        """If this version of the catalog knows about new prefixes,
+        check the on disk catalog to see if we can perform any
+        transformations based upon previously unknown catalog formats.
+
+        This routine will add a catalog attribute if it doesn't exist,
+        otherwise it checks this attribute against a hard-coded
+        version-specific tuple to see if new methods were added.
+
+        If new methods were added, it will call an additional routine
+        that updates the on-disk catalog, if necessary."""
+
+        # If a prefixes attribute doesn't exist, write one and get on
+        # with it.
+        if not "prefix" in self.attrs:
+            self.attrs["prefix"] = "".join(known_prefixes)
+            if not self.read_only:
+                self.save_attrs()
+            return
+
+        # Prefixes attribute does exist.  Check if it has changed.
+        pfx_set = set(self.attrs["prefix"])
+
+        # Nothing to do if prefixes haven't changed
+        if pfx_set == known_prefixes:
+            return
+
+        # If known_prefixes contains a prefix not in pfx_set,
+        # add the prefix and perform a catalog transform.
+        new = known_prefixes.difference(pfx_set)
+        if new:
+            pfx_set.update(new)
+
+            # Write out updated prefixes list
+            self.attrs["prefix"] = "".join(pfx_set)
+            if not self.read_only:
                 self.save_attrs()
 
-        def size(self):
-                """Return the size in bytes of the catalog and attributes."""
+    @property
+    def exists(self):
+        """A boolean value indicating whether the Catalog exists
+        on-disk."""
 
-                if self.__size < 0:
-                        try:
-                                attr_stat = os.stat(os.path.normpath(
-                                    os.path.join(self.catalog_root, "attrs")))
-                                attr_sz = attr_stat.st_size
-                        except OSError as e:
-                                if e.errno == errno.ENOENT:
-                                        attr_sz = 0
-                                else:
-                                        raise
-                        try:
-                                cat_stat =  os.stat(os.path.normpath(
-                                    os.path.join(self.catalog_root, "catalog")))
-                                cat_sz = cat_stat.st_size
-                        except OSError as e:
-                                if e.errno == errno.ENOENT:
-                                        cat_sz = 0
-                                else:
-                                        raise
+        if not self.catalog_file:
+            return False
+        return os.path.exists(self.catalog_file)
 
-                        self.__size = attr_sz + cat_sz
+    def fmris(self):
+        """A generator function that produces FMRIs as it
+        iterates over the contents of the catalog."""
 
-                return self.__size
+        try:
+            pfile = open(
+                os.path.normpath(os.path.join(self.catalog_root, "catalog")),
+                "r",
+            )
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                return
+            else:
+                raise
 
-        @staticmethod
-        def valid_new_fmri(pfmri):
-                """Check that the fmri supplied as an argument would be valid
-                to add to the catalog.  This checks to make sure that any past
-                catalog operations (such as a rename or freeze) would not
-                prohibit the caller from adding this FMRI."""
+        for entry in pfile:
+            if not entry.startswith("V pkg") and not entry.startswith("C pkg"):
+                continue
 
-                if not fmri.is_valid_pkg_name(pfmri.get_name()):
-                        return False
-                return True
+            try:
+                yield self.__parse_entry(entry, self.pub)
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except Exception as e:
+                raise RuntimeError(
+                    "corrupt catalog entry for "
+                    "publisher '{0}': {1}".format(self.pub, entry)
+                )
 
-        @staticmethod
-        def __parse_entry(line, pub):
-                # This allows the ServerCatalog object to parse both
-                # client and server catalog files which are otherwise
-                # identical.
-                #
-                # Server Format:
-                # C pkg:/foo@0.5.11,5.11-0.111:20090507T161015Z
-                #
-                # Client Format:
-                # V pkg foo 0.5.11,5.11-0.111:20090508T161015Z
-                sfmri = line[2:]
-                if sfmri[:4] == "pkg ":
-                        sfmri = sfmri[4:].replace(" ", "@")
-                return fmri.PkgFmri(sfmri, publisher=pub)
+        pfile.close()
 
-        @classmethod
-        def read_catalog(cls, cat, path, pub=None):
-                """Read the catalog file in "path" and combine it with the
-                existing data in "catalog"."""
+    def last_modified(self):
+        """Return the time at which the catalog was last modified."""
 
-                catf = open(os.path.join(path, "catalog"))
-                for line in catf:
-                        if not line.startswith("V pkg") and \
-                            not line.startswith("C pkg"):
-                                continue
-                        f = cls.__parse_entry(line, pub)
-                        ServerCatalog.cache_fmri(cat, f, pub)
+        return self.attrs.get("Last-Modified", None)
 
-                catf.close()
+    def load_attrs(self, filenm="attrs"):
+        """Load attributes from the catalog file into the in-memory
+        attributes dictionary"""
+
+        apath = os.path.normpath(os.path.join(self.catalog_root, filenm))
+        if not os.path.exists(apath):
+            return
+
+        afile = open(apath, "r")
+        attrre = re.compile(r"^S ([^:]*): (.*)")
+
+        for entry in afile:
+            m = attrre.match(entry)
+            if m != None:
+                self.attrs[m.group(1)] = m.group(2)
+
+        afile.close()
+
+        # convert npkgs to integer value
+        if "npkgs" in self.attrs:
+            self.attrs["npkgs"] = int(self.attrs["npkgs"])
+
+    def npkgs(self):
+        """Returns the number of packages in the catalog."""
+
+        return self.attrs["npkgs"]
+
+    def origin(self):
+        """Returns the URL of the catalog's origin."""
+
+        return self.attrs.get("origin", None)
+
+    @property
+    def package_count(self):
+        """Returns the number of packages in the catalog."""
+
+        return self.attrs["npkgs"] or 0
+
+    @classmethod
+    def recv(cls, filep, path, pub=None):
+        """A static method that takes a file-like object and
+        a path.  This is the other half of catalog.send().  It
+        reads a stream as an incoming catalog and lays it down
+        on disk."""
+
+        bad_fmri = None
+
+        if not os.path.exists(path):
+            os.makedirs(path)
+
+        afd, attrpath = tempfile.mkstemp(dir=path)
+        cfd, catpath = tempfile.mkstemp(dir=path)
+
+        attrf = os.fdopen(afd, "w")
+        catf = os.fdopen(cfd, "w")
+
+        attrpath_final = os.path.normpath(os.path.join(path, "attrs"))
+        catpath_final = os.path.normpath(os.path.join(path, "catalog"))
+
+        try:
+            for s in filep:
+                slen = len(s)
+
+                # If line is too short, process the next one
+                if slen < 2:
+                    continue
+                # check that line is in the proper format
+                elif not s[1].isspace():
+                    continue
+                elif not s[0] in known_prefixes:
+                    catf.write(s)
+                elif s.startswith("S "):
+                    attrf.write(s)
+                elif s.startswith("R "):
+                    catf.write(s)
+                else:
+                    # XXX Need to be able to handle old and
+                    # new format catalogs.
+                    try:
+                        f = fmri.PkgFmri(s[2:])
+                    except fmri.IllegalFmri as e:
+                        bad_fmri = e
+                        continue
+
+                    catf.write(
+                        "{0} {1} {2} {3}\n".format(
+                            s[0], "pkg", f.pkg_name, f.version
+                        )
+                    )
+        except:
+            # Re-raise all uncaught exceptions after performing
+            # cleanup.
+            attrf.close()
+            catf.close()
+            os.remove(attrpath)
+            os.remove(catpath)
+            raise
+
+        # If we got a parse error on FMRIs and transfer
+        # wasn't truncated, raise a FmriFailures error.
+        if bad_fmri:
+            attrf.close()
+            catf.close()
+            os.remove(attrpath)
+            os.remove(catpath)
+            raise bad_fmri
+
+        # Write the publisher's origin into our attributes
+        if pub:
+            origstr = "S origin: {0}\n".format(pub["origin"])
+            attrf.write(origstr)
+
+        attrf.close()
+        catf.close()
+
+        # Mkstemp sets mode 600 on these files by default.
+        # Restore them to 644, so that unprivileged users
+        # may read these files.
+        os.chmod(attrpath, cls.file_mode)
+        os.chmod(catpath, cls.file_mode)
+
+        portable.rename(attrpath, attrpath_final)
+        portable.rename(catpath, catpath_final)
+
+    def save_attrs(self, filenm="attrs"):
+        """Save attributes from the in-memory catalog to a file
+        specified by filenm."""
+
+        tmpfile = None
+        assert not self.read_only
+
+        finalpath = os.path.normpath(os.path.join(self.catalog_root, filenm))
+
+        try:
+            tmp_num, tmpfile = tempfile.mkstemp(dir=self.catalog_root)
+
+            tfile = os.fdopen(tmp_num, "w")
+
+            for a in self.attrs.keys():
+                s = "S {0}: {1}\n".format(a, self.attrs[a])
+                tfile.write(s)
+
+            tfile.close()
+            os.chmod(tmpfile, self.file_mode)
+            portable.rename(tmpfile, finalpath)
+
+        except EnvironmentError as e:
+            # This may get called in a situation where
+            # the user does not have write access to the attrs
+            # file.
+            if tmpfile:
+                portable.remove(tmpfile)
+            if e.errno in (errno.EACCES, errno.EROFS):
+                return
+            else:
+                raise
+
+        # Recalculate size on next send()
+        self.__size = -1
+
+    def send(self, filep, rspobj=None):
+        """Send the contents of this catalog out to the filep
+        specified as an argument."""
+
+        if rspobj is not None:
+            rspobj.headers["Content-Length"] = str(self.size())
+
+        def output():
+            # Send attributes first.
+            for line in self.attrs_as_lines():
+                yield line
+
+            try:
+                cfile = open(
+                    os.path.normpath(
+                        os.path.join(self.catalog_root, "catalog")
+                    ),
+                    "r",
+                )
+            except IOError as e:
+                # Missing catalog is fine; other errors need to
+                # be reported.
+                if e.errno == errno.ENOENT:
+                    return
+                else:
+                    raise
+
+            for e in cfile:
+                yield e
+
+            cfile.close()
+
+        if filep:
+            for line in output():
+                filep.write(line)
+        else:
+            return output()
+
+    def set_time(self, ts=None):
+        """Set time to timestamp if supplied by caller.  Otherwise
+        use the system time."""
+
+        assert not self.read_only
+
+        if ts and isinstance(ts, str):
+            self.attrs["Last-Modified"] = ts
+        elif ts and isinstance(ts, datetime.datetime):
+            self.attrs["Last-Modified"] = ts.isoformat()
+        else:
+            self.attrs["Last-Modified"] = timestamp()
+
+        self.save_attrs()
+
+    def size(self):
+        """Return the size in bytes of the catalog and attributes."""
+
+        if self.__size < 0:
+            try:
+                attr_stat = os.stat(
+                    os.path.normpath(os.path.join(self.catalog_root, "attrs"))
+                )
+                attr_sz = attr_stat.st_size
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    attr_sz = 0
+                else:
+                    raise
+            try:
+                cat_stat = os.stat(
+                    os.path.normpath(os.path.join(self.catalog_root, "catalog"))
+                )
+                cat_sz = cat_stat.st_size
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    cat_sz = 0
+                else:
+                    raise
+
+            self.__size = attr_sz + cat_sz
+
+        return self.__size
+
+    @staticmethod
+    def valid_new_fmri(pfmri):
+        """Check that the fmri supplied as an argument would be valid
+        to add to the catalog.  This checks to make sure that any past
+        catalog operations (such as a rename or freeze) would not
+        prohibit the caller from adding this FMRI."""
+
+        if not fmri.is_valid_pkg_name(pfmri.get_name()):
+            return False
+        return True
+
+    @staticmethod
+    def __parse_entry(line, pub):
+        # This allows the ServerCatalog object to parse both
+        # client and server catalog files which are otherwise
+        # identical.
+        #
+        # Server Format:
+        # C pkg:/foo@0.5.11,5.11-0.111:20090507T161015Z
+        #
+        # Client Format:
+        # V pkg foo 0.5.11,5.11-0.111:20090508T161015Z
+        sfmri = line[2:]
+        if sfmri[:4] == "pkg ":
+            sfmri = sfmri[4:].replace(" ", "@")
+        return fmri.PkgFmri(sfmri, publisher=pub)
+
+    @classmethod
+    def read_catalog(cls, cat, path, pub=None):
+        """Read the catalog file in "path" and combine it with the
+        existing data in "catalog"."""
+
+        catf = open(os.path.join(path, "catalog"))
+        for line in catf:
+            if not line.startswith("V pkg") and not line.startswith("C pkg"):
+                continue
+            f = cls.__parse_entry(line, pub)
+            ServerCatalog.cache_fmri(cat, f, pub)
+
+        catf.close()
+
 
 # Prefixes that this catalog knows how to handle
 known_prefixes = frozenset("CSVR")
 
+
 # Method used by Catalog and UpdateLog.  Since UpdateLog needs to know
 # about Catalog, keep it in Catalog to avoid circular dependency problems.
 def timestamp():
-        """Return an integer timestamp that can be used for comparisons."""
+    """Return an integer timestamp that can be used for comparisons."""
 
-        tobj = datetime.datetime.now()
-        tstr = tobj.isoformat()
-        return tstr
+    tobj = datetime.datetime.now()
+    tstr = tobj.isoformat()
+    return tstr
+
 
 def ts_to_datetime(ts):
-        """Take timestamp ts in string isoformat, and convert it to a datetime
-        object."""
+    """Take timestamp ts in string isoformat, and convert it to a datetime
+    object."""
 
-        year = int(ts[0:4])
-        month = int(ts[5:7])
-        day = int(ts[8:10])
-        hour = int(ts[11:13])
-        minutes = int(ts[14:16])
-        sec = int(ts[17:19])
-        # usec is not in the string if 0
-        try:
-                usec = int(ts[20:26])
-        except ValueError:
-                usec = 0
-        return datetime.datetime(year, month, day, hour, minutes, sec, usec)
+    year = int(ts[0:4])
+    month = int(ts[5:7])
+    day = int(ts[8:10])
+    hour = int(ts[11:13])
+    minutes = int(ts[14:16])
+    sec = int(ts[17:19])
+    # usec is not in the string if 0
+    try:
+        usec = int(ts[20:26])
+    except ValueError:
+        usec = 0
+    return datetime.datetime(year, month, day, hour, minutes, sec, usec)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/server/depot.py
+++ b/src/modules/server/depot.py
@@ -35,11 +35,11 @@ from cherrypy.process.plugins import SimplePlugin
 from cherrypy._cperror import _HTTPErrorTemplate
 
 try:
-        import pybonjour
+    import pybonjour
 except (OSError, ImportError):
-        pass
+    pass
 else:
-        import select
+    import select
 
 import atexit
 import ast
@@ -87,1289 +87,1370 @@ import pkg.version
 
 from pkg.server.query_parser import Query, ParseError, BooleanQueryException
 
+
 class Dummy(object):
-        """Dummy object used for dispatch method mapping."""
-        pass
+    """Dummy object used for dispatch method mapping."""
+
+    pass
 
 
 class _Depot(object):
-        """Private, abstract, base class for all Depot classes."""
-        pass
+    """Private, abstract, base class for all Depot classes."""
+
+    pass
 
 
 class DepotHTTP(_Depot):
-        """The DepotHTTP object is intended to be used as a cherrypy
-        application object and represents the set of operations that a
-        pkg.depotd server provides to HTTP-based clients."""
+    """The DepotHTTP object is intended to be used as a cherrypy
+    application object and represents the set of operations that a
+    pkg.depotd server provides to HTTP-based clients."""
 
-        REPO_OPS_DEFAULT = [
-            "versions",
-            "search",
-            "catalog",
-            "info",
-            "manifest",
-            "file",
-            "open",
-            "append",
-            "close",
-            "abandon",
-            "add",
-            "p5i",
-            "publisher",
-            "index",
-            "status",
-            "admin",
+    REPO_OPS_DEFAULT = [
+        "versions",
+        "search",
+        "catalog",
+        "info",
+        "manifest",
+        "file",
+        "open",
+        "append",
+        "close",
+        "abandon",
+        "add",
+        "p5i",
+        "publisher",
+        "index",
+        "status",
+        "admin",
+    ]
+
+    REPO_OPS_READONLY = [
+        "versions",
+        "search",
+        "catalog",
+        "info",
+        "manifest",
+        "file",
+        "p5i",
+        "publisher",
+        "status",
+    ]
+
+    REPO_OPS_MIRROR = [
+        "versions",
+        "file",
+        "publisher",
+        "status",
+    ]
+
+    content_root = None
+    web_root = None
+
+    def __init__(self, repo, dconf, request_pub_func=None):
+        """Initialize and map the valid operations for the depot.  While
+        doing so, ensure that the operations have been explicitly
+        "exposed" for external usage.
+
+        request_pub_func, if set is a function that gets called with
+        cherrypy.request.path_info that returns the publisher used
+        for a given request.
+        """
+
+        # This lock is used to protect the depot from multiple
+        # threads modifying data structures at the same time.
+        self._lock = pkg.nrlock.NRLock()
+
+        self.cfg = dconf
+        self.repo = repo
+        self.request_pub_func = request_pub_func
+
+        content_root = dconf.get_property("pkg", "content_root")
+        pkg_root = dconf.get_property("pkg", "pkg_root")
+        if content_root:
+            if not os.path.isabs(content_root):
+                content_root = os.path.join(pkg_root, content_root)
+            self.content_root = content_root
+            self.web_root = os.path.join(self.content_root, "web")
+        else:
+            self.content_root = None
+            self.web_root = None
+
+        # Ensure a temporary storage area exists for depot components
+        # to use during operations.
+        tmp_root = dconf.get_property("pkg", "writable_root")
+        if not tmp_root:
+            # If no writable root, create a temporary area.
+            tmp_root = tempfile.mkdtemp()
+
+            # Try to ensure temporary area is cleaned up on exit.
+            atexit.register(shutil.rmtree, tmp_root, ignore_errors=True)
+        self.tmp_root = tmp_root
+
+        # Handles the BUI (Browser User Interface).
+        face.init(self)
+
+        # Store any possible configuration changes.
+        repo.write_config()
+
+        if repo.mirror or not repo.root:
+            self.ops_list = self.REPO_OPS_MIRROR[:]
+            if not repo.cfg.get_property("publisher", "prefix"):
+                self.ops_list.remove("publisher")
+        elif repo.read_only:
+            self.ops_list = self.REPO_OPS_READONLY
+        else:
+            self.ops_list = self.REPO_OPS_DEFAULT
+
+        # Transform the property value into a form convenient
+        # for use.
+        disable_ops = {}
+        for entry in dconf.get_property("pkg", "disable_ops"):
+            if "/" in entry:
+                op, ver = entry.rsplit("/", 1)
+            else:
+                op = entry
+                ver = "*"
+            disable_ops.setdefault(op, [])
+            disable_ops[op].append(ver)
+
+        # Determine available operations and disable as requested.
+        self.vops = {}
+        for name, func in inspect.getmembers(self, inspect.ismethod):
+            m = re.match(r"(.*)_(\d+)", name)
+
+            if not m:
+                continue
+
+            op = m.group(1)
+            ver = m.group(2)
+
+            if op not in self.ops_list:
+                continue
+            if op in disable_ops and (
+                ver in disable_ops[op] or "*" in disable_ops[op]
+            ):
+                continue
+            if not repo.supports(op, int(ver)):
+                # Unsupported operation.
+                continue
+
+            func.__dict__["exposed"] = True
+
+            if op in self.vops:
+                self.vops[op].append(int(ver))
+            else:
+                # We need a Dummy object here since we need to
+                # be able to set arbitrary attributes that
+                # contain function pointers to our object
+                # instance.  CherryPy relies on this for its
+                # dispatch tree mapping mechanism.  We can't
+                # use other object types here since Python
+                # won't let us set arbitary attributes on them.
+                opattr = Dummy()
+                setattr(self, op, opattr)
+                self.vops[op] = [int(ver)]
+
+                for pub in self.repo.publishers:
+                    pub = pub.replace(".", "_")
+                    pubattr = getattr(self, pub, None)
+                    if not pubattr:
+                        pubattr = Dummy()
+                        setattr(self, pub, pubattr)
+                    setattr(pubattr, op, opattr)
+
+            opattr = getattr(self, op)
+            setattr(opattr, ver, func)
+
+        cherrypy.config.update({"error_page.default": self.default_error_page})
+
+        if hasattr(cherrypy.engine, "signal_handler"):
+            # This handles SIGUSR1
+            cherrypy.engine.subscribe("graceful", self.refresh)
+
+        # Setup background task execution handler.
+        self.__bgtask = BackgroundTaskPlugin(cherrypy.engine)
+        self.__bgtask.subscribe()
+
+    def _queue_refresh_index(self):
+        """Queues a background task to update search indexes.  This
+        method is a protected helper function for depot consumers."""
+
+        try:
+            self.__bgtask.put(self.repo.refresh_index)
+        except queue.Full:
+            # If another operation is already in progress, just
+            # log a warning and drive on.
+            cherrypy.log(
+                "Skipping indexing; another operation is "
+                "already in progress.",
+                "INDEX",
+            )
+
+    @staticmethod
+    def default_error_page(**kwargs):
+        """This function is registered as the default error page
+        for CherryPy errors.  This sets the response headers to
+        be uncacheable, and then returns a HTTP response that is
+        identical to the default CherryPy message format."""
+
+        response = cherrypy.response
+        for key in ("Cache-Control", "Pragma"):
+            if key in response.headers:
+                del response.headers[key]
+
+        return _HTTPErrorTemplate % kwargs
+
+    def _get_req_pub(self):
+        """Private helper function to retrieve the publisher prefix
+        for the current operation from the request path.  Returns None
+        if a publisher prefix was not found in the request path.  The
+        publisher is assumed to be the first component of the path_info
+        string if it doesn't match the operation's name.  This does mean
+        that a publisher can't be named the same as an operation, but
+        that isn't viewed as an unreasonable limitation.
+        """
+
+        if self.request_pub_func:
+            return self.request_pub_func(cherrypy.request.path_info)
+        try:
+            req_pub = cherrypy.request.path_info.strip("/").split("/")[0]
+        except IndexError:
+            return None
+
+        if req_pub not in self.REPO_OPS_DEFAULT and req_pub != "feed":
+            # Assume that if the first component of the request path
+            # doesn't match a known operation that it's a publisher
+            # prefix.
+            return req_pub
+        return None
+
+    def __set_response_expires(self, op_name, expires, max_age=None):
+        """Used to set expiration headers on a response dynamically
+        based on the name of the operation.
+
+        'op_name' is a string containing the name of the depot
+        operation as listed in the REPO_OPS_* constants.
+
+        'expires' is an integer value in seconds indicating how
+        long from when the request was made the content returned
+        should expire.  The maximum value is 365*86400.
+
+        'max_age' is an integer value in seconds indicating the
+        maximum length of time a response should be considered
+        valid.  For some operations, the maximum value for this
+        parameter is equal to the repository's refresh_seconds
+        property."""
+
+        prefix = self._get_req_pub()
+        if not prefix:
+            prefix = self.repo.cfg.get_property("publisher", "prefix")
+
+        rs = None
+        if prefix:
+            try:
+                pub = self.repo.get_publisher(prefix)
+            except Exception as e:
+                # Couldn't get pub.
+                pass
+            else:
+                repo = pub.repository
+                if repo:
+                    rs = repo.refresh_seconds
+        if rs is None:
+            rs = 14400
+
+        if max_age is None:
+            max_age = min((rs, expires))
+
+        now = cherrypy.response.time
+        if (
+            op_name == "publisher"
+            or op_name == "search"
+            or op_name == "catalog"
+        ):
+            # For these operations, cap the value based on
+            # refresh_seconds.
+            expires = now + min((rs, max_age))
+            max_age = min((rs, max_age))
+        else:
+            expires = now + expires
+
+        headers = cherrypy.response.headers
+        headers[
+            "Cache-Control"
+        ] = "must-revalidate, no-transform, max-age={0:d}".format(max_age)
+        headers["Expires"] = formatdate(timeval=expires, usegmt=True)
+
+    def refresh(self):
+        """Catch SIGUSR1 and reload the depot information."""
+        old_pubs = self.repo.publishers
+        self.repo.reload()
+        if type(self.cfg) == cfg.SMFConfig:
+            # For all other cases, reloading depot configuration
+            # isn't desirable (because of command-line overrides).
+            self.cfg.reset()
+
+        # Handles the BUI (Browser User Interface).
+        face.init(self)
+
+        # Map new publishers into operation space.
+        list(map(self.__map_pub_ops, self.repo.publishers - old_pubs))
+
+    def __map_pub_ops(self, pub_prefix):
+        # Map the publisher into the depot's operation namespace if
+        # needed.
+        self._lock.acquire()  # Prevent race conditions.
+        try:
+            pubattr = getattr(self, pub_prefix, None)
+            if not pubattr:
+                # Might have already been done in
+                # another thread.
+                pubattr = Dummy()
+                setattr(self, pub_prefix, pubattr)
+
+                for op in self.vops:
+                    opattr = getattr(self, op)
+                    setattr(pubattr, op, opattr)
+        finally:
+            self._lock.release()
+
+    @cherrypy.expose
+    def default(self, *tokens, **params):
+        """Any request that is not explicitly mapped to the repository
+        object will be handled by the "externally facing" server
+        code instead."""
+
+        pub = self._get_req_pub()
+        op = None
+        if not pub and tokens:
+            op = tokens[0]
+        elif pub and len(tokens) > 1:
+            op = tokens[1]
+
+        if op in self.REPO_OPS_DEFAULT and op not in self.vops:
+            raise cherrypy.HTTPError(
+                http_client.NOT_FOUND,
+                "Operation not supported in current server mode.",
+            )
+        elif op not in self.vops:
+            request = cherrypy.request
+            response = cherrypy.response
+            if not misc.valid_pub_prefix(pub):
+                pub = None
+            return face.respond(self, request, response, pub)
+
+        # If we get here, we know that 'operation' is supported.
+        # Ensure that we have a integer protocol version.
+        try:
+            if not pub:
+                ver = int(tokens[1])
+            else:
+                ver = int(tokens[2])
+        except IndexError:
+            raise cherrypy.HTTPError(
+                http_client.BAD_REQUEST, "Missing version\n"
+            )
+        except ValueError:
+            raise cherrypy.HTTPError(
+                http_client.BAD_REQUEST, "Non-integer version\n"
+            )
+
+        if ver not in self.vops[op]:
+            # 'version' is not supported for the operation.
+            raise cherrypy.HTTPError(
+                http_client.NOT_FOUND,
+                "Version '{0}' not supported for operation '{1}'\n".format(
+                    ver, op
+                ),
+            )
+        elif op == "open" and pub not in self.repo.publishers:
+            if not misc.valid_pub_prefix(pub):
+                raise cherrypy.HTTPError(
+                    http_client.BAD_REQUEST,
+                    "Invalid publisher prefix: {0}\n".format(pub),
+                )
+
+            # Map operations for new publisher.
+            self.__map_pub_ops(pub)
+
+            # Finally, perform an internal redirect so that cherrypy
+            # will correctly redispatch to the newly mapped
+            # operations.
+            rel_uri = cherrypy.request.path_info
+            if cherrypy.request.query_string:
+                rel_uri += "?{0}".format(cherrypy.request.query_string)
+            raise cherrypy.InternalRedirect(rel_uri)
+        elif pub:
+            raise cherrypy.HTTPError(
+                http_client.BAD_REQUEST, "Unknown publisher: {0}\n".format(pub)
+            )
+
+        # Assume 'version' is not supported for the operation for some
+        # other reason.
+        raise cherrypy.HTTPError(
+            http_client.NOT_FOUND,
+            "Version '{0}' not "
+            "supported for operation '{1}'\n".format(ver, op),
+        )
+
+    @cherrypy.tools.response_headers(
+        headers=[("Content-Type", "text/plain; charset=utf-8")]
+    )
+    def versions_0(self, *tokens):
+        """Output a text/plain list of valid operations, and their
+        versions, supported by the repository."""
+
+        self.__set_response_expires("versions", 5 * 60, 5 * 60)
+        versions = "pkg-server {0}\n".format(pkg.VERSION)
+        versions += (
+            "\n".join(
+                "{0} {1}".format(op, " ".join(str(v) for v in vers))
+                for op, vers in six.iteritems(self.vops)
+            )
+            + "\n"
+        )
+        return versions
+
+    def search_0(self, *tokens):
+        """Based on the request path, return a list of token type / FMRI
+        pairs."""
+
+        response = cherrypy.response
+        response.headers["Content-type"] = "text/plain; charset=utf-8"
+        self.__set_response_expires("search", 86400, 86400)
+
+        try:
+            token = tokens[0]
+        except IndexError:
+            token = None
+
+        query_args_lst = [
+            str(
+                Query(
+                    token,
+                    case_sensitive=False,
+                    return_type=Query.RETURN_ACTIONS,
+                    num_to_return=None,
+                    start_point=None,
+                )
+            )
         ]
 
-        REPO_OPS_READONLY = [
-            "versions",
-            "search",
-            "catalog",
-            "info",
-            "manifest",
-            "file",
-            "p5i",
-            "publisher",
-            "status",
+        try:
+            res_list = self.repo.search(query_args_lst, pub=self._get_req_pub())
+        except srepo.RepositorySearchUnavailableError as e:
+            raise cherrypy.HTTPError(http_client.SERVICE_UNAVAILABLE, str(e))
+        except srepo.RepositoryError as e:
+            # Treat any remaining repository error as a 404, but
+            # log the error and include the real failure
+            # information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+
+        # Translate the results from v1 format into what a v0
+        # searcher expects as results.
+        def output():
+            for i, res in enumerate(res_list):
+                for v, return_type, vals in res:
+                    fmri_str, fv, line = vals
+                    a = actions.fromstr(line.rstrip())
+                    if isinstance(a, actions.attribute.AttributeAction):
+                        yield "{0} {1} {2} {3}\n".format(
+                            a.attrs.get(a.key_attr), fmri_str, a.name, fv
+                        )
+                    else:
+                        yield "{0} {1} {2} {3}\n".format(
+                            fv, fmri_str, a.name, a.attrs.get(a.key_attr)
+                        )
+
+        return output()
+
+    search_0._cp_config = {"response.stream": True}
+
+    def search_1(self, *args, **params):
+        """Based on the request path, return a list of packages that
+        match the specified criteria."""
+        query_str_lst = []
+
+        # Check for the GET method of doing a search request.
+        try:
+            query_str_lst = [args[0]]
+        except IndexError:
+            pass
+
+        # Check for the POST method of doing a search request.
+        if not query_str_lst:
+            query_str_lst = list(params.values())
+        elif list(params.values()):
+            raise cherrypy.HTTPError(
+                http_client.BAD_REQUEST,
+                "args:{0}, params:{1}".format(args, params),
+            )
+
+        if not query_str_lst:
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST)
+
+        try:
+            res_list = self.repo.search(query_str_lst, pub=self._get_req_pub())
+        except (ParseError, BooleanQueryException) as e:
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        except srepo.RepositorySearchUnavailableError as e:
+            raise cherrypy.HTTPError(http_client.SERVICE_UNAVAILABLE, str(e))
+        except srepo.RepositoryError as e:
+            # Treat any remaining repository error as a 404, but
+            # log the error and include the real failure
+            # information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+
+        # In order to be able to have a return code distinguish between
+        # no results and search unavailable, we need to use a different
+        # http code.  Check and see if there's at least one item in
+        # the results.  If not, set the result code to be NO_CONTENT
+        # and return.  If there is at least one result, put the result
+        # examined back at the front of the results and stream them
+        # to the user.
+        if len(res_list) == 1:
+            try:
+                tmp = next(res_list[0])
+                res_list = [itertools.chain([tmp], res_list[0])]
+            except StopIteration:
+                cherrypy.response.status = http_client.NO_CONTENT
+                return
+
+        response = cherrypy.response
+        response.headers["Content-type"] = "text/plain; charset=utf-8"
+        self.__set_response_expires("search", 86400, 86400)
+
+        # The WSGI script depot_index.py will call this method and a WSGI
+        # application under Python 3 must return bytes as the output, so
+        # we force the output to be bytes here.
+        def output():
+            # Yield the string used to let the client know it's
+            # talking to a valid search server.
+            yield misc.force_bytes(Query.VALIDATION_STRING[1])
+            for i, res in enumerate(res_list):
+                for v, return_type, vals in res:
+                    if return_type == Query.RETURN_ACTIONS:
+                        fmri_str, fv, line = vals
+                        yield misc.force_bytes(
+                            "{0} {1} {2} {3} {4}\n".format(
+                                i,
+                                return_type,
+                                fmri_str,
+                                quote(fv),
+                                line.rstrip(),
+                            )
+                        )
+                    elif return_type == Query.RETURN_PACKAGES:
+                        fmri_str = vals
+                        yield misc.force_bytes(
+                            "{0} {1} {2}\n".format(i, return_type, fmri_str)
+                        )
+
+        return output()
+
+    search_1._cp_config = {"response.stream": True}
+
+    def catalog_0(self, *tokens):
+        """Provide a full version of the catalog, as appropriate, to
+        the requesting client.  Incremental catalogs are not supported
+        for v0 catalog clients."""
+
+        request = cherrypy.request
+
+        # Response headers have to be setup *outside* of the function
+        # that yields the catalog content.
+        try:
+            cat = self.repo.get_catalog(pub=self._get_req_pub())
+        except srepo.RepositoryError as e:
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+
+        response = cherrypy.response
+        response.headers["Content-type"] = "text/plain; charset=utf-8"
+        if hasattr(cat, "version"):
+            response.headers["Last-Modified"] = cat.last_modified.isoformat()
+        else:
+            response.headers["Last-Modified"] = old_catalog.ts_to_datetime(
+                cat.last_modified()
+            ).isoformat()
+        response.headers["X-Catalog-Type"] = "full"
+        self.__set_response_expires("catalog", 86400, 86400)
+
+        def output():
+            try:
+                for l in self.repo.catalog_0(pub=self._get_req_pub()):
+                    yield l
+            except srepo.RepositoryError as e:
+                # Can't do anything in a streaming generator
+                # except log the error and return.
+                cherrypy.log("Request failed: {0}".format(str(e)))
+                return
+
+        return output()
+
+    catalog_0._cp_config = {"response.stream": True}
+
+    def catalog_1(self, *tokens):
+        """Outputs the contents of the specified catalog file, using the
+        name in the request path, directly to the client."""
+
+        try:
+            name = tokens[0]
+        except IndexError:
+            raise cherrypy.HTTPError(
+                http_client.FORBIDDEN, _("Directory listing not allowed.")
+            )
+
+        try:
+            fpath = self.repo.catalog_1(name, pub=self._get_req_pub())
+        except srepo.RepositoryError as e:
+            # Treat any remaining repository error as a 404, but
+            # log the error and include the real failure
+            # information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+
+        self.__set_response_expires("catalog", 86400, 86400)
+        return serve_file(fpath, "text/plain; charset=utf-8")
+
+    catalog_1._cp_config = {"response.stream": True}
+
+    def manifest_0(self, *tokens):
+        """The request is an encoded pkg FMRI.  If the version is
+        specified incompletely, we return an error, as the client is
+        expected to form correct requests based on its interpretation
+        of the catalog and its image policies."""
+
+        try:
+            pubs = self.repo.publishers
+        except Exception as e:
+            cherrypy.log("Request failed: {0}".format(e))
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+
+        # A broken proxy (or client) has caused a fully-qualified FMRI
+        # to be split up.
+        comps = [t for t in tokens]
+        if not comps:
+            raise cherrypy.HTTPError(
+                http_client.FORBIDDEN, _("Directory listing not allowed.")
+            )
+
+        if len(comps) > 1 and comps[0] == "pkg:" and comps[1] in pubs:
+            # Only one slash here as another will be added below.
+            comps[0] += "/"
+
+        # Parse request into FMRI component and decode.
+        try:
+            # If more than one token (request path component) was
+            # specified, assume that the extra components are part
+            # of the fmri and have been split out because of bad
+            # proxy behaviour.
+            pfmri = "/".join(comps)
+            pfmri = fmri.PkgFmri(pfmri, None)
+            fpath = self.repo.manifest(pfmri, pub=self._get_req_pub())
+        except (IndexError, fmri.FmriError) as e:
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        except srepo.RepositoryError as e:
+            # Treat any remaining repository error as a 404, but
+            # log the error and include the real failure
+            # information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+
+        # Send manifest
+        self.__set_response_expires("manifest", 86400 * 365, 86400 * 365)
+        return serve_file(fpath, "text/plain; charset=utf-8")
+
+    manifest_0._cp_config = {"response.stream": True}
+
+    def manifest_1(self, *tokens):
+        """Outputs the contents of the manifest or uploads the
+        manifest."""
+
+        method = cherrypy.request.method
+        if method == "GET":
+            return self.manifest_0(*tokens)
+        elif method in ("POST", "PUT"):
+            return self.__upload_manifest(*tokens)
+        raise cherrypy.HTTPError(
+            http_client.METHOD_NOT_ALLOWED, "{0} is not allowed".format(method)
+        )
+
+    # We need to prevent cherrypy from processing the request body so that
+    # manifest can parse the request body itself.  In addition, we also need
+    # to set the timeout higher since the default is five minutes; not
+    # really enough for a slow connection to upload content.
+    manifest_1._cp_config = {
+        "request.process_request_body": False,
+        "response.timeout": 3600,
+        "response.stream": True,
+    }
+
+    @staticmethod
+    def _tar_stream_close(**kwargs):
+        """This is a special function to finish a tar_stream-based
+        request in the event of an exception."""
+
+        tar_stream = cherrypy.request.tar_stream
+        if tar_stream:
+            try:
+                # Attempt to close the tar_stream now that we
+                # are done processing the request.
+                tar_stream.close()
+            except Exception:
+                # All exceptions are intentionally caught as
+                # this is a failsafe function and must happen.
+
+                # tarfile most likely failed trying to flush
+                # its internal buffer.  To prevent tarfile from
+                # causing further exceptions during __del__,
+                # we have to lie and say the fileobj has been
+                # closed.
+                tar_stream.fileobj.closed = True
+                cherrypy.log("Request aborted: ", traceback=True)
+
+            cherrypy.request.tar_stream = None
+
+    def file_0(self, *tokens):
+        """Outputs the contents of the file, named by the SHA-1 hash
+        name in the request path, directly to the client."""
+
+        try:
+            fhash = tokens[0]
+        except IndexError:
+            fhash = None
+
+        try:
+            fpath = self.repo.file(fhash, pub=self._get_req_pub())
+        except srepo.RepositoryFileNotFoundError as e:
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+        except srepo.RepositoryError as e:
+            # Treat any remaining repository error as a 404, but
+            # log the error and include the real failure
+            # information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+
+        self.__set_response_expires("file", 86400 * 365, 86400 * 365)
+        return serve_file(fpath, "application/data")
+
+    file_0._cp_config = {"response.stream": True}
+
+    def file_1(self, *tokens):
+        """Outputs the contents of the file, named by the SHA hash
+        name in the request path, directly to the client."""
+
+        method = cherrypy.request.method
+        if method == "GET":
+            return self.file_0(*tokens)
+        elif method in ("POST", "PUT"):
+            return self.__upload_file(*tokens)
+        raise cherrypy.HTTPError(
+            http_client.METHOD_NOT_ALLOWED, "{0} is not allowed".format(method)
+        )
+
+    # We need to prevent cherrypy from processing the request body so that
+    # file can parse the request body itself.  In addition, we also need to
+    # set the timeout higher since the default is five minutes; not really
+    # enough for a slow connection to upload content.
+    file_1._cp_config = {
+        "request.process_request_body": False,
+        "response.timeout": 3600,
+        "response.stream": True,
+    }
+
+    def file_2(self, *tokens):
+        """Outputs the contents of the file, named by the SHA hash
+        name in the request path, directly to the client."""
+
+        method = cherrypy.request.method
+        if method == "HEAD":
+            try:
+                fhash = tokens[0]
+            except IndexError:
+                fhash = None
+
+            try:
+                fpath = self.repo.file(fhash, pub=self._get_req_pub())
+            except srepo.RepositoryFileNotFoundError as e:
+                raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+            except srepo.RepositoryError as e:
+                # Treat any remaining repository error as a 404,
+                # but log the error and include the real failure
+                # information.
+                cherrypy.log("Request failed: {0}".format(str(e)))
+                raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+
+            csize, chashes = misc.compute_compressed_attrs(
+                fhash, file_path=fpath
+            )
+            response = cherrypy.response
+            for i, attr in enumerate(chashes):
+                response.headers[
+                    "X-Ipkg-Attr-{0}".format(i)
+                ] = "{0}={1}".format(attr, chashes[attr])
+
+            # set expiration of response to one day
+            self.__set_response_expires("file", 86400, 86400)
+
+            return serve_file(fpath, "application/data")
+
+        return self.file_1(*tokens)
+
+    file_2._cp_config = {"response.stream": True}
+
+    @cherrypy.tools.response_headers(
+        headers=[
+            ("Pragma", "no-cache"),
+            ("Cache-Control", "no-cache, no-transform, must-revalidate"),
+            ("Expires", 0),
         ]
+    )
+    def open_0(self, *tokens):
+        """Starts a transaction for the package name specified in the
+        request path.  Returns no output."""
 
-        REPO_OPS_MIRROR = [
-            "versions",
-            "file",
-            "publisher",
-            "status",
+        request = cherrypy.request
+        response = cherrypy.response
+
+        client_release = request.headers.get("Client-Release", None)
+        try:
+            pfmri = tokens[0]
+        except IndexError:
+            pfmri = None
+
+        # XXX Authentication will be handled by virtue of possessing a
+        # signed certificate (or a more elaborate system).
+        if not pfmri:
+            raise cherrypy.HTTPError(
+                http_client.BAD_REQUEST,
+                _("A valid package FMRI must be specified."),
+            )
+
+        try:
+            pfmri = fmri.PkgFmri(pfmri, client_release)
+            trans_id = self.repo.open(client_release, pfmri)
+        except (fmri.FmriError, srepo.RepositoryError) as e:
+            # Assume a bad request was made.  A 404 can't be
+            # returned here as misc.versioned_urlopen will interpret
+            # that to mean that the server doesn't support this
+            # operation.
+            cherrypy.log("Request failed: {0}".format(e))
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+
+        if pfmri.publisher and not self._get_req_pub():
+            self.__map_pub_ops(pfmri.publisher)
+
+        # Set response headers before returning.
+        response.headers["Content-type"] = "text/plain; charset=utf-8"
+        response.headers["Transaction-ID"] = trans_id
+
+    @cherrypy.tools.response_headers(
+        headers=[
+            ("Pragma", "no-cache"),
+            ("Cache-Control", "no-cache, no-transform, must-revalidate"),
+            ("Expires", 0),
         ]
+    )
+    def append_0(self, *tokens):
+        """Starts an append transaction for the package name specified
+        in the request path.  Returns no output."""
 
-        content_root = None
-        web_root = None
+        request = cherrypy.request
+        response = cherrypy.response
 
-        def __init__(self, repo, dconf, request_pub_func=None):
-                """Initialize and map the valid operations for the depot.  While
-                doing so, ensure that the operations have been explicitly
-                "exposed" for external usage.
+        client_release = request.headers.get("Client-Release", None)
+        try:
+            pfmri = tokens[0]
+        except IndexError:
+            pfmri = None
 
-                request_pub_func, if set is a function that gets called with
-                cherrypy.request.path_info that returns the publisher used
-                for a given request.
-                """
+        # XXX Authentication will be handled by virtue of possessing a
+        # signed certificate (or a more elaborate system).
+        if not pfmri:
+            raise cherrypy.HTTPError(
+                http_client.BAD_REQUEST,
+                _("A valid package FMRI must be specified."),
+            )
 
-                # This lock is used to protect the depot from multiple
-                # threads modifying data structures at the same time.
-                self._lock = pkg.nrlock.NRLock()
+        try:
+            pfmri = fmri.PkgFmri(pfmri, client_release)
+            trans_id = self.repo.append(client_release, pfmri)
+        except (fmri.FmriError, srepo.RepositoryError) as e:
+            # Assume a bad request was made.  A 404 can't be
+            # returned here as misc.versioned_urlopen will interpret
+            # that to mean that the server doesn't support this
+            # operation.
+            cherrypy.log("Request failed: {0}".format(e))
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
 
-                self.cfg = dconf
-                self.repo = repo
-                self.request_pub_func = request_pub_func
+        if pfmri.publisher and not self._get_req_pub():
+            self.__map_pub_ops(pfmri.publisher)
 
-                content_root = dconf.get_property("pkg", "content_root")
-                pkg_root = dconf.get_property("pkg", "pkg_root")
-                if content_root:
-                        if not os.path.isabs(content_root):
-                                content_root = os.path.join(pkg_root,
-                                    content_root)
-                        self.content_root = content_root
-                        self.web_root = os.path.join(self.content_root, "web")
-                else:
-                        self.content_root = None
-                        self.web_root = None
+        # Set response headers before returning.
+        response.headers["Content-type"] = "text/plain; charset=utf-8"
+        response.headers["Transaction-ID"] = trans_id
 
-                # Ensure a temporary storage area exists for depot components
-                # to use during operations.
-                tmp_root = dconf.get_property("pkg", "writable_root")
-                if not tmp_root:
-                        # If no writable root, create a temporary area.
-                        tmp_root = tempfile.mkdtemp()
+    @cherrypy.tools.response_headers(
+        headers=[
+            ("Pragma", "no-cache"),
+            ("Cache-Control", "no-cache, no-transform, must-revalidate"),
+            ("Expires", 0),
+        ]
+    )
+    def close_0(self, *tokens):
+        """Ends an in-flight transaction for the Transaction ID
+        specified in the request path.
 
-                        # Try to ensure temporary area is cleaned up on exit.
-                        atexit.register(shutil.rmtree, tmp_root,
-                            ignore_errors=True)
-                self.tmp_root = tmp_root
+        Returns a Package-FMRI and State header in the response
+        indicating the published FMRI and the state of the package
+        in the catalog.  Returns no output."""
 
-                # Handles the BUI (Browser User Interface).
-                face.init(self)
+        try:
+            # cherrypy decoded it, but we actually need it encoded.
+            trans_id = quote(tokens[0], "")
+        except IndexError:
+            trans_id = None
 
-                # Store any possible configuration changes.
-                repo.write_config()
+        request = cherrypy.request
 
-                if repo.mirror or not repo.root:
-                        self.ops_list = self.REPO_OPS_MIRROR[:]
-                        if not repo.cfg.get_property("publisher", "prefix"):
-                                self.ops_list.remove("publisher")
-                elif repo.read_only:
-                        self.ops_list = self.REPO_OPS_READONLY
-                else:
-                        self.ops_list = self.REPO_OPS_DEFAULT
+        try:
+            # Assume "True" for backwards compatibility.
+            add_to_catalog = int(
+                request.headers.get("X-IPkg-Add-To-Catalog", 1)
+            )
 
-                # Transform the property value into a form convenient
-                # for use.
-                disable_ops = {}
-                for entry in dconf.get_property("pkg", "disable_ops"):
-                        if "/" in entry:
-                                op, ver = entry.rsplit("/", 1)
-                        else:
-                                op = entry
-                                ver = "*"
-                        disable_ops.setdefault(op, [])
-                        disable_ops[op].append(ver)
+            # Force a boolean value.
+            if add_to_catalog:
+                add_to_catalog = True
+            else:
+                add_to_catalog = False
+        except ValueError as e:
+            raise cherrypy.HTTPError(
+                http_client.BAD_REQUEST, "X-IPkg-Add-To-Catalog".format(e)
+            )
 
-                # Determine available operations and disable as requested.
-                self.vops = {}
-                for name, func in inspect.getmembers(self, inspect.ismethod):
-                        m = re.match(r"(.*)_(\d+)", name)
+        try:
+            pfmri, pstate = self.repo.close(
+                trans_id, add_to_catalog=add_to_catalog
+            )
+        except srepo.RepositoryError as e:
+            # Assume a bad request was made.  A 404 can't be
+            # returned here as misc.versioned_urlopen will interpret
+            # that to mean that the server doesn't support this
+            # operation.
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
 
-                        if not m:
-                                continue
+        response = cherrypy.response
+        response.headers["Package-FMRI"] = pfmri
+        response.headers["State"] = pstate
 
-                        op = m.group(1)
-                        ver = m.group(2)
+    @cherrypy.tools.response_headers(
+        headers=[
+            ("Pragma", "no-cache"),
+            ("Cache-Control", "no-cache, no-transform, must-revalidate"),
+            ("Expires", 0),
+        ]
+    )
+    def admin_0(self, *tokens, **params):
+        """Execute a specified repository administration operation based
+        on the provided query string.  Example:
 
-                        if op not in self.ops_list:
-                                continue
-                        if op in disable_ops and (ver in disable_ops[op] or
-                            "*" in disable_ops[op]):
-                                continue
-                        if not repo.supports(op, int(ver)):
-                                # Unsupported operation.
-                                continue
+                <repo_uri>[/<publisher>]/admin/0?cmd=refresh-index
 
-                        func.__dict__["exposed"] = True
+        Available commands are:
+                rebuild
+                    Discard search data and package catalogs and
+                    rebuild both.
+                rebuild-indexes
+                    Discard search data and rebuild.
+                rebuild-packages
+                    Discard package catalogs and rebuild.
+                refresh
+                    Update search and package data.
+                refresh-indexes
+                    Update search data.  (Add packages found in the
+                    repository to their related search indexes.)
+                refresh-packages
+                    Update package data.  (Add packages found in the
+                    repository to their related catalog.)
+        """
 
-                        if op in self.vops:
-                                self.vops[op].append(int(ver))
-                        else:
-                                # We need a Dummy object here since we need to
-                                # be able to set arbitrary attributes that
-                                # contain function pointers to our object
-                                # instance.  CherryPy relies on this for its
-                                # dispatch tree mapping mechanism.  We can't
-                                # use other object types here since Python
-                                # won't let us set arbitary attributes on them.
-                                opattr = Dummy()
-                                setattr(self, op, opattr)
-                                self.vops[op] = [int(ver)]
+        cmd = params.get("cmd", "")
 
-                                for pub in self.repo.publishers:
-                                        pub = pub.replace(".", "_")
-                                        pubattr = getattr(self, pub, None)
-                                        if not pubattr:
-                                                pubattr = Dummy()
-                                                setattr(self, pub, pubattr)
-                                        setattr(pubattr, op, opattr)
+        # These commands cause the operation requested to be queued
+        # for later execution.  This does mean that if the operation
+        # fails, the client won't know about it, but this is necessary
+        # since these are long running operations (are likely to exceed
+        # connection timeout limits).
+        try:
+            if cmd == "rebuild":
+                # Discard existing catalog and search data and
+                # rebuild.
+                self.__bgtask.put(
+                    self.repo.rebuild,
+                    pub=self._get_req_pub(),
+                    build_catalog=True,
+                    build_index=True,
+                )
+            elif cmd == "rebuild-indexes":
+                # Discard search data and rebuild.
+                self.__bgtask.put(
+                    self.repo.rebuild,
+                    pub=self._get_req_pub(),
+                    build_catalog=False,
+                    build_index=True,
+                )
+            elif cmd == "rebuild-packages":
+                # Discard package data and rebuild.
+                self.__bgtask.put(
+                    self.repo.rebuild,
+                    pub=self._get_req_pub(),
+                    build_catalog=True,
+                    build_index=False,
+                )
+            elif cmd == "refresh":
+                # Add new packages and update search indexes.
+                self.__bgtask.put(
+                    self.repo.add_content,
+                    pub=self._get_req_pub(),
+                    refresh_index=True,
+                )
+            elif cmd == "refresh-indexes":
+                # Update search indexes.
+                self.__bgtask.put(
+                    self.repo.refresh_index, pub=self._get_req_pub()
+                )
+            elif cmd == "refresh-packages":
+                # Add new packages.
+                self.__bgtask.put(
+                    self.repo.add_content,
+                    pub=self._get_req_pub(),
+                    refresh_index=False,
+                )
+            else:
+                raise cherrypy.HTTPError(
+                    http_client.BAD_REQUEST,
+                    "Unknown or unsupported operation: '{0}'".format(cmd),
+                )
+        except queue.Full:
+            raise cherrypy.HTTPError(
+                http_client.SERVICE_UNAVAILABLE,
+                "Another operation is already in progress; try " "again later.",
+            )
 
-                        opattr = getattr(self, op)
-                        setattr(opattr, ver, func)
+    @cherrypy.tools.response_headers(
+        headers=[
+            ("Pragma", "no-cache"),
+            ("Cache-Control", "no-cache, no-transform, must-revalidate"),
+            ("Expires", 0),
+        ]
+    )
+    def abandon_0(self, *tokens):
+        """Aborts an in-flight transaction for the Transaction ID
+        specified in the request path.  Returns no output."""
 
-                cherrypy.config.update({'error_page.default':
-                    self.default_error_page})
+        try:
+            # cherrypy decoded it, but we actually need it encoded.
+            trans_id = quote(tokens[0], "")
+        except IndexError:
+            trans_id = None
 
-                if hasattr(cherrypy.engine, "signal_handler"):
-                        # This handles SIGUSR1
-                        cherrypy.engine.subscribe("graceful", self.refresh)
+        try:
+            self.repo.abandon(trans_id)
+        except srepo.RepositoryError as e:
+            # Assume a bad request was made.  A 404 can't be
+            # returned here as misc.versioned_urlopen will interpret
+            # that to mean that the server doesn't support this
+            # operation.
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
 
-                # Setup background task execution handler.
-                self.__bgtask = BackgroundTaskPlugin(cherrypy.engine)
-                self.__bgtask.subscribe()
+    def add_0(self, *tokens):
+        """Adds an action and its content to an in-flight transaction
+        for the Transaction ID specified in the request path.  The
+        content is expected to be in the request body.  Returns no
+        output."""
 
-        def _queue_refresh_index(self):
-                """Queues a background task to update search indexes.  This
-                method is a protected helper function for depot consumers."""
+        try:
+            # cherrypy decoded it, but we actually need it encoded.
+            trans_id = quote(tokens[0], "")
+        except IndexError:
+            trans_id = None
 
+        try:
+            entry_type = tokens[1]
+        except IndexError:
+            entry_type = None
+
+        if entry_type not in actions.types:
+            raise cherrypy.HTTPError(
+                http_client.BAD_REQUEST,
+                _("The " "specified Action Type, '{0}', is not valid.").format(
+                    entry_type
+                ),
+            )
+
+        request = cherrypy.request
+        attrs = dict(
+            val.split("=", 1)
+            for hdr, val in request.headers.items()
+            if hdr.lower().startswith("x-ipkg-setattr")
+        )
+
+        # If any attributes appear to be lists, make them lists.
+        for a in attrs:
+            if attrs[a].startswith("[") and attrs[a].endswith("]"):
+                # Ensure input is valid; only a list will be
+                # accepted.
                 try:
-                        self.__bgtask.put(self.repo.refresh_index)
-                except queue.Full:
-                        # If another operation is already in progress, just
-                        # log a warning and drive on.
-                        cherrypy.log("Skipping indexing; another operation is "
-                            "already in progress.", "INDEX")
-
-        @staticmethod
-        def default_error_page(**kwargs):
-                """This function is registered as the default error page
-                for CherryPy errors.  This sets the response headers to
-                be uncacheable, and then returns a HTTP response that is
-                identical to the default CherryPy message format."""
-
-                response = cherrypy.response
-                for key in ('Cache-Control', 'Pragma'):
-                        if key in response.headers:
-                                del response.headers[key]
-
-                return _HTTPErrorTemplate % kwargs
-
-        def _get_req_pub(self):
-                """Private helper function to retrieve the publisher prefix
-                for the current operation from the request path.  Returns None
-                if a publisher prefix was not found in the request path.  The
-                publisher is assumed to be the first component of the path_info
-                string if it doesn't match the operation's name.  This does mean
-                that a publisher can't be named the same as an operation, but
-                that isn't viewed as an unreasonable limitation.
-                """
-
-                if self.request_pub_func:
-                        return self.request_pub_func(cherrypy.request.path_info)
-                try:
-                        req_pub = cherrypy.request.path_info.strip("/").split(
-                            "/")[0]
-                except IndexError:
-                        return None
-
-                if req_pub not in self.REPO_OPS_DEFAULT and req_pub != "feed":
-                        # Assume that if the first component of the request path
-                        # doesn't match a known operation that it's a publisher
-                        # prefix.
-                        return req_pub
-                return None
-
-        def __set_response_expires(self, op_name, expires, max_age=None):
-                """Used to set expiration headers on a response dynamically
-                based on the name of the operation.
-
-                'op_name' is a string containing the name of the depot
-                operation as listed in the REPO_OPS_* constants.
-
-                'expires' is an integer value in seconds indicating how
-                long from when the request was made the content returned
-                should expire.  The maximum value is 365*86400.
-
-                'max_age' is an integer value in seconds indicating the
-                maximum length of time a response should be considered
-                valid.  For some operations, the maximum value for this
-                parameter is equal to the repository's refresh_seconds
-                property."""
-
-                prefix = self._get_req_pub()
-                if not prefix:
-                        prefix = self.repo.cfg.get_property("publisher",
-                            "prefix")
-
-                rs = None
-                if prefix:
-                        try:
-                                pub = self.repo.get_publisher(prefix)
-                        except Exception as e:
-                                # Couldn't get pub.
-                                pass
-                        else:
-                                repo = pub.repository
-                                if repo:
-                                        rs = repo.refresh_seconds
-                if rs is None:
-                        rs = 14400
-
-                if max_age is None:
-                        max_age = min((rs, expires))
-
-                now = cherrypy.response.time
-                if op_name == "publisher" or op_name == "search" or \
-                    op_name == "catalog":
-                        # For these operations, cap the value based on
-                        # refresh_seconds.
-                        expires = now + min((rs, max_age))
-                        max_age = min((rs, max_age))
-                else:
-                        expires = now + expires
-
-                headers = cherrypy.response.headers
-                headers["Cache-Control"] = \
-                    "must-revalidate, no-transform, max-age={0:d}".format(
-                        max_age)
-                headers["Expires"] = formatdate(timeval=expires, usegmt=True)
-
-        def refresh(self):
-                """Catch SIGUSR1 and reload the depot information."""
-                old_pubs = self.repo.publishers
-                self.repo.reload()
-                if type(self.cfg) == cfg.SMFConfig:
-                        # For all other cases, reloading depot configuration
-                        # isn't desirable (because of command-line overrides).
-                        self.cfg.reset()
-
-                # Handles the BUI (Browser User Interface).
-                face.init(self)
-
-                # Map new publishers into operation space.
-                list(map(self.__map_pub_ops, self.repo.publishers - old_pubs))
-
-        def __map_pub_ops(self, pub_prefix):
-                # Map the publisher into the depot's operation namespace if
-                # needed.
-                self._lock.acquire() # Prevent race conditions.
-                try:
-                        pubattr = getattr(self, pub_prefix, None)
-                        if not pubattr:
-                                # Might have already been done in
-                                # another thread.
-                                pubattr = Dummy()
-                                setattr(self, pub_prefix, pubattr)
-
-                                for op in self.vops:
-                                        opattr = getattr(self, op)
-                                        setattr(pubattr, op, opattr)
-                finally:
-                        self._lock.release()
-
-        @cherrypy.expose
-        def default(self, *tokens, **params):
-                """Any request that is not explicitly mapped to the repository
-                object will be handled by the "externally facing" server
-                code instead."""
-
-                pub = self._get_req_pub()
-                op = None
-                if not pub and tokens:
-                        op = tokens[0]
-                elif pub and len(tokens) > 1:
-                        op = tokens[1]
-
-                if op in self.REPO_OPS_DEFAULT and op not in self.vops:
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND,
-                            "Operation not supported in current server mode.")
-                elif op not in self.vops:
-                        request = cherrypy.request
-                        response = cherrypy.response
-                        if not misc.valid_pub_prefix(pub):
-                                pub = None
-                        return face.respond(self, request, response, pub)
-
-                # If we get here, we know that 'operation' is supported.
-                # Ensure that we have a integer protocol version.
-                try:
-                        if not pub:
-                                ver = int(tokens[1])
-                        else:
-                                ver = int(tokens[2])
-                except IndexError:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                            "Missing version\n")
+                    val = ast.literal_eval(attrs[a])
+                    if not isinstance(val, list):
+                        raise ValueError()
+                    attrs[a] = val
                 except ValueError:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                            "Non-integer version\n")
-
-                if ver not in self.vops[op]:
-                        # 'version' is not supported for the operation.
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND,
-                            "Version '{0}' not supported for operation '{1}'\n".format(
-                            ver, op))
-                elif op == "open" and pub not in self.repo.publishers:
-                        if not misc.valid_pub_prefix(pub):
-                                raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                                    "Invalid publisher prefix: {0}\n".format(pub))
-
-                        # Map operations for new publisher.
-                        self.__map_pub_ops(pub)
-
-                        # Finally, perform an internal redirect so that cherrypy
-                        # will correctly redispatch to the newly mapped
-                        # operations.
-                        rel_uri = cherrypy.request.path_info
-                        if cherrypy.request.query_string:
-                                rel_uri += "?{0}".format(
-                                    cherrypy.request.query_string)
-                        raise cherrypy.InternalRedirect(rel_uri)
-                elif pub:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                            "Unknown publisher: {0}\n".format(pub))
-
-                # Assume 'version' is not supported for the operation for some
-                # other reason.
-                raise cherrypy.HTTPError(http_client.NOT_FOUND, "Version '{0}' not "
-                    "supported for operation '{1}'\n".format(ver, op))
-
-        @cherrypy.tools.response_headers(headers=\
-            [("Content-Type", "text/plain; charset=utf-8")])
-        def versions_0(self, *tokens):
-                """Output a text/plain list of valid operations, and their
-                versions, supported by the repository."""
-
-                self.__set_response_expires("versions", 5*60, 5*60)
-                versions = "pkg-server {0}\n".format(pkg.VERSION)
-                versions += "\n".join(
-                    "{0} {1}".format(op, " ".join(str(v) for v in vers))
-                    for op, vers in six.iteritems(self.vops)
-                ) + "\n"
-                return versions
-
-        def search_0(self, *tokens):
-                """Based on the request path, return a list of token type / FMRI
-                pairs."""
-
-                response = cherrypy.response
-                response.headers["Content-type"] = "text/plain; charset=utf-8"
-                self.__set_response_expires("search", 86400, 86400)
-
-                try:
-                        token = tokens[0]
-                except IndexError:
-                        token = None
-
-                query_args_lst = [str(Query(token, case_sensitive=False,
-                    return_type=Query.RETURN_ACTIONS, num_to_return=None,
-                    start_point=None))]
-
-                try:
-                        res_list = self.repo.search(query_args_lst,
-                            pub=self._get_req_pub())
-                except srepo.RepositorySearchUnavailableError as e:
-                        raise cherrypy.HTTPError(http_client.SERVICE_UNAVAILABLE,
-                            str(e))
-                except srepo.RepositoryError as e:
-                        # Treat any remaining repository error as a 404, but
-                        # log the error and include the real failure
-                        # information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-
-                # Translate the results from v1 format into what a v0
-                # searcher expects as results.
-                def output():
-                        for i, res in enumerate(res_list):
-                                for v, return_type, vals in res:
-                                        fmri_str, fv, line = vals
-                                        a = actions.fromstr(line.rstrip())
-                                        if isinstance(a,
-                                            actions.attribute.AttributeAction):
-                                                yield "{0} {1} {2} {3}\n".format(
-                                                    a.attrs.get(a.key_attr),
-                                                    fmri_str, a.name, fv)
-                                        else:
-                                                yield "{0} {1} {2} {3}\n".format(
-                                                    fv, fmri_str, a.name,
-                                                    a.attrs.get(a.key_attr))
-
-                return output()
-
-        search_0._cp_config = { "response.stream": True }
-
-        def search_1(self, *args, **params):
-                """Based on the request path, return a list of packages that
-                match the specified criteria."""
-                query_str_lst = []
-
-                # Check for the GET method of doing a search request.
-                try:
-                        query_str_lst = [args[0]]
-                except IndexError:
-                        pass
-
-                # Check for the POST method of doing a search request.
-                if not query_str_lst:
-                        query_str_lst = list(params.values())
-                elif list(params.values()):
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                            "args:{0}, params:{1}".format(args, params))
-
-                if not query_str_lst:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST)
-
-                try:
-                        res_list = self.repo.search(query_str_lst,
-                            pub=self._get_req_pub())
-                except (ParseError, BooleanQueryException) as e:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-                except srepo.RepositorySearchUnavailableError as e:
-                        raise cherrypy.HTTPError(http_client.SERVICE_UNAVAILABLE,
-                            str(e))
-                except srepo.RepositoryError as e:
-                        # Treat any remaining repository error as a 404, but
-                        # log the error and include the real failure
-                        # information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-
-                # In order to be able to have a return code distinguish between
-                # no results and search unavailable, we need to use a different
-                # http code.  Check and see if there's at least one item in
-                # the results.  If not, set the result code to be NO_CONTENT
-                # and return.  If there is at least one result, put the result
-                # examined back at the front of the results and stream them
-                # to the user.
-                if len(res_list) == 1:
-                        try:
-                                tmp = next(res_list[0])
-                                res_list = [itertools.chain([tmp], res_list[0])]
-                        except StopIteration:
-                                cherrypy.response.status = http_client.NO_CONTENT
-                                return
-
-                response = cherrypy.response
-                response.headers["Content-type"] = "text/plain; charset=utf-8"
-                self.__set_response_expires("search", 86400, 86400)
-
-                # The WSGI script depot_index.py will call this method and a WSGI
-                # application under Python 3 must return bytes as the output, so
-                # we force the output to be bytes here.
-                def output():
-                        # Yield the string used to let the client know it's
-                        # talking to a valid search server.
-                        yield misc.force_bytes(Query.VALIDATION_STRING[1])
-                        for i, res in enumerate(res_list):
-                                for v, return_type, vals in res:
-                                        if return_type == Query.RETURN_ACTIONS:
-                                                fmri_str, fv, line = vals
-                                                yield misc.force_bytes(
-                                                    "{0} {1} {2} {3} {4}\n".format(
-                                                    i, return_type, fmri_str,
-                                                    quote(fv),
-                                                    line.rstrip()))
-                                        elif return_type == \
-                                            Query.RETURN_PACKAGES:
-                                                fmri_str = vals
-                                                yield misc.force_bytes(
-                                                    "{0} {1} {2}\n".format(
-                                                    i, return_type, fmri_str))
-                return output()
-
-        search_1._cp_config = { "response.stream": True }
-
-        def catalog_0(self, *tokens):
-                """Provide a full version of the catalog, as appropriate, to
-                the requesting client.  Incremental catalogs are not supported
-                for v0 catalog clients."""
-
-                request = cherrypy.request
-
-                # Response headers have to be setup *outside* of the function
-                # that yields the catalog content.
-                try:
-                        cat = self.repo.get_catalog(pub=self._get_req_pub())
-                except srepo.RepositoryError as e:
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-
-                response = cherrypy.response
-                response.headers["Content-type"] = "text/plain; charset=utf-8"
-                if hasattr(cat, "version"):
-                        response.headers["Last-Modified"] = \
-                            cat.last_modified.isoformat()
-                else:
-                        response.headers["Last-Modified"] = \
-                            old_catalog.ts_to_datetime(
-                            cat.last_modified()).isoformat()
-                response.headers["X-Catalog-Type"] = "full"
-                self.__set_response_expires("catalog", 86400, 86400)
-
-                def output():
-                        try:
-                                for l in self.repo.catalog_0(
-                                    pub=self._get_req_pub()):
-                                        yield l
-                        except srepo.RepositoryError as e:
-                                # Can't do anything in a streaming generator
-                                # except log the error and return.
-                                cherrypy.log("Request failed: {0}".format(
-                                    str(e)))
-                                return
-
-                return output()
-
-        catalog_0._cp_config = { "response.stream": True }
-
-        def catalog_1(self, *tokens):
-                """Outputs the contents of the specified catalog file, using the
-                name in the request path, directly to the client."""
-
-                try:
-                        name = tokens[0]
-                except IndexError:
-                        raise cherrypy.HTTPError(http_client.FORBIDDEN,
-                            _("Directory listing not allowed."))
-
-                try:
-                        fpath = self.repo.catalog_1(name,
-                            pub=self._get_req_pub())
-                except srepo.RepositoryError as e:
-                        # Treat any remaining repository error as a 404, but
-                        # log the error and include the real failure
-                        # information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-
-                self.__set_response_expires("catalog", 86400, 86400)
-                return serve_file(fpath, "text/plain; charset=utf-8")
-
-        catalog_1._cp_config = { "response.stream": True }
-
-        def manifest_0(self, *tokens):
-                """The request is an encoded pkg FMRI.  If the version is
-                specified incompletely, we return an error, as the client is
-                expected to form correct requests based on its interpretation
-                of the catalog and its image policies."""
-
-                try:
-                        pubs = self.repo.publishers
-                except Exception as e:
-                        cherrypy.log("Request failed: {0}".format(e))
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-
-                # A broken proxy (or client) has caused a fully-qualified FMRI
-                # to be split up.
-                comps = [t for t in tokens]
-                if not comps:
-                        raise cherrypy.HTTPError(http_client.FORBIDDEN,
-                            _("Directory listing not allowed."))
-
-                if len(comps) > 1 and comps[0] == "pkg:" and comps[1] in pubs:
-                        # Only one slash here as another will be added below.
-                        comps[0] += "/"
-
-                # Parse request into FMRI component and decode.
-                try:
-                        # If more than one token (request path component) was
-                        # specified, assume that the extra components are part
-                        # of the fmri and have been split out because of bad
-                        # proxy behaviour.
-                        pfmri = "/".join(comps)
-                        pfmri = fmri.PkgFmri(pfmri, None)
-                        fpath = self.repo.manifest(pfmri,
-                            pub=self._get_req_pub())
-                except (IndexError, fmri.FmriError) as e:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-                except srepo.RepositoryError as e:
-                        # Treat any remaining repository error as a 404, but
-                        # log the error and include the real failure
-                        # information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-
-                # Send manifest
-                self.__set_response_expires("manifest", 86400*365, 86400*365)
-                return serve_file(fpath, "text/plain; charset=utf-8")
-
-        manifest_0._cp_config = { "response.stream": True }
-
-        def manifest_1(self, *tokens):
-                """Outputs the contents of the manifest or uploads the
-                manifest."""
-
-                method = cherrypy.request.method
-                if method == "GET":
-                        return self.manifest_0(*tokens)
-                elif method in ("POST", "PUT"):
-                        return self.__upload_manifest(*tokens)
-                raise cherrypy.HTTPError(http_client.METHOD_NOT_ALLOWED,
-                    "{0} is not allowed".format(method))
-
-        # We need to prevent cherrypy from processing the request body so that
-        # manifest can parse the request body itself.  In addition, we also need
-        # to set the timeout higher since the default is five minutes; not
-        # really enough for a slow connection to upload content.
-        manifest_1._cp_config = {
-            "request.process_request_body": False,
-            "response.timeout": 3600,
-            "response.stream": True
-        }
-
-        @staticmethod
-        def _tar_stream_close(**kwargs):
-                """This is a special function to finish a tar_stream-based
-                request in the event of an exception."""
-
-                tar_stream = cherrypy.request.tar_stream
-                if tar_stream:
-                        try:
-                                # Attempt to close the tar_stream now that we
-                                # are done processing the request.
-                                tar_stream.close()
-                        except Exception:
-                                # All exceptions are intentionally caught as
-                                # this is a failsafe function and must happen.
-
-                                # tarfile most likely failed trying to flush
-                                # its internal buffer.  To prevent tarfile from
-                                # causing further exceptions during __del__,
-                                # we have to lie and say the fileobj has been
-                                # closed.
-                                tar_stream.fileobj.closed = True
-                                cherrypy.log("Request aborted: ",
-                                    traceback=True)
-
-                        cherrypy.request.tar_stream = None
-
-
-        def file_0(self, *tokens):
-                """Outputs the contents of the file, named by the SHA-1 hash
-                name in the request path, directly to the client."""
-
-                try:
-                        fhash = tokens[0]
-                except IndexError:
-                        fhash = None
-
-                try:
-                        fpath = self.repo.file(fhash, pub=self._get_req_pub())
-                except srepo.RepositoryFileNotFoundError as e:
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-                except srepo.RepositoryError as e:
-                        # Treat any remaining repository error as a 404, but
-                        # log the error and include the real failure
-                        # information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-
-                self.__set_response_expires("file", 86400*365, 86400*365)
-                return serve_file(fpath, "application/data")
-
-        file_0._cp_config = { "response.stream": True }
-
-        def file_1(self, *tokens):
-                """Outputs the contents of the file, named by the SHA hash
-                name in the request path, directly to the client."""
-
-                method = cherrypy.request.method
-                if method == "GET":
-                        return self.file_0(*tokens)
-                elif method in ("POST", "PUT"):
-                        return self.__upload_file(*tokens)
-                raise cherrypy.HTTPError(http_client.METHOD_NOT_ALLOWED,
-                    "{0} is not allowed".format(method))
-
-        # We need to prevent cherrypy from processing the request body so that
-        # file can parse the request body itself.  In addition, we also need to
-        # set the timeout higher since the default is five minutes; not really
-        # enough for a slow connection to upload content.
-        file_1._cp_config = {
-            "request.process_request_body": False,
-            "response.timeout": 3600,
-            "response.stream": True
-        }
-
-        def file_2(self, *tokens):
-                """Outputs the contents of the file, named by the SHA hash
-                name in the request path, directly to the client."""
-
-                method = cherrypy.request.method
-                if method == "HEAD":
-                        try:
-                                fhash = tokens[0]
-                        except IndexError:
-                                fhash = None
-
-                        try:
-                                fpath = self.repo.file(fhash,
-                                    pub=self._get_req_pub())
-                        except srepo.RepositoryFileNotFoundError as e:
-                                raise cherrypy.HTTPError(http_client.NOT_FOUND,
-                                    str(e))
-                        except srepo.RepositoryError as e:
-                                # Treat any remaining repository error as a 404,
-                                # but log the error and include the real failure
-                                # information.
-                                cherrypy.log("Request failed: {0}".format(
-                                    str(e)))
-                                raise cherrypy.HTTPError(http_client.NOT_FOUND,
-                                    str(e))
-
-                        csize, chashes = misc.compute_compressed_attrs(fhash,
-                            file_path=fpath)
-                        response = cherrypy.response
-                        for i, attr in enumerate(chashes):
-                                response.headers["X-Ipkg-Attr-{0}".format(i)] = \
-                                    "{0}={1}".format(attr, chashes[attr])
-
-                        # set expiration of response to one day
-                        self.__set_response_expires("file", 86400, 86400)
-
-                        return serve_file(fpath, "application/data")
-
-                return self.file_1(*tokens)
-
-        file_2._cp_config = { "response.stream": True }
-
-        @cherrypy.tools.response_headers(headers=[("Pragma", "no-cache"),
+                    raise cherrypy.HTTPError(
+                        http_client.BAD_REQUEST,
+                        _(
+                            "The "
+                            "specified Action attribute value, "
+                            "'{0}', is not valid."
+                        ).format(attrs[a]),
+                    )
+
+        data = None
+        size = int(request.headers.get("Content-Length", 0))
+        if size > 0:
+            data = request.rfile
+            # Record the size of the payload, if there is one.
+            attrs["pkg.size"] = str(size)
+
+        try:
+            action = actions.types[entry_type](data, **attrs)
+        except actions.ActionError as e:
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+
+        # XXX Once actions are labelled with critical nature.
+        # if entry_type in critical_actions:
+        #         self.critical = True
+
+        try:
+            self.repo.add(trans_id, action)
+        except srepo.RepositoryError as e:
+            # Assume a bad request was made.  A 404 can't be
+            # returned here as misc.versioned_urlopen will interpret
+            # that to mean that the server doesn't support this
+            # operation.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+
+    # We need to prevent cherrypy from processing the request body so that
+    # add can parse the request body itself.  In addition, we also need to
+    # set the timeout higher since the default is five minutes; not really
+    # enough for a slow connection to upload content.
+    add_0._cp_config = {
+        "request.process_request_body": False,
+        "response.timeout": 3600,
+        "tools.response_headers.on": True,
+        "tools.response_headers.headers": [
+            ("Pragma", "no-cache"),
             ("Cache-Control", "no-cache, no-transform, must-revalidate"),
-            ("Expires", 0)])
-        def open_0(self, *tokens):
-                """Starts a transaction for the package name specified in the
-                request path.  Returns no output."""
+            ("Expires", 0),
+        ],
+    }
 
-                request = cherrypy.request
-                response = cherrypy.response
+    def __upload_file(self, *tokens):
+        """Adds a file to an in-flight transaction for the Transaction
+        ID specified in the request path.  The content is expected to be
+        in the request body.  Returns no output."""
 
-                client_release = request.headers.get("Client-Release", None)
-                try:
-                        pfmri = tokens[0]
-                except IndexError:
-                        pfmri = None
+        try:
+            # cherrypy decoded it, but we actually need it encoded.
+            trans_id = quote(tokens[0], "")
+        except IndexError:
+            raise
+            trans_id = None
 
-                # XXX Authentication will be handled by virtue of possessing a
-                # signed certificate (or a more elaborate system).
-                if not pfmri:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                            _("A valid package FMRI must be specified."))
+        request = cherrypy.request
+        response = cherrypy.response
 
-                try:
-                        pfmri = fmri.PkgFmri(pfmri, client_release)
-                        trans_id = self.repo.open(client_release, pfmri)
-                except (fmri.FmriError, srepo.RepositoryError) as e:
-                        # Assume a bad request was made.  A 404 can't be
-                        # returned here as misc.versioned_urlopen will interpret
-                        # that to mean that the server doesn't support this
-                        # operation.
-                        cherrypy.log("Request failed: {0}".format(e))
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        size = int(request.headers.get("Content-Length", 0))
+        if size < 0:
+            raise cherrypy.HTTPError(
+                http_client.BAD_REQUEST, _("file/1 must be sent a file.")
+            )
+        data = request.rfile
+        attrs = dict(
+            val.split("=", 1)
+            for hdr, val in request.headers.items()
+            if hdr.lower().startswith("x-ipkg-setattr")
+        )
+        basename = attrs.get("basename", None)
+        try:
+            self.repo.add_file(trans_id, data, basename, size)
+        except srepo.RepositoryError as e:
+            # Assume a bad request was made.  A 404 can't be
+            # returned here as misc.versioned_urlopen will interpret
+            # that to mean that the server doesn't support this
+            # operation.
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        response.headers["Content-Length"] = "0"
+        return response.body
 
-                if pfmri.publisher and not self._get_req_pub():
-                        self.__map_pub_ops(pfmri.publisher)
+    def __upload_manifest(self, *tokens):
+        """Adds a file to an in-flight transaction for the Transaction
+        ID specified in the request path.  The content is expected to be
+        in the request body.  Returns no output."""
 
-                # Set response headers before returning.
-                response.headers["Content-type"] = "text/plain; charset=utf-8"
-                response.headers["Transaction-ID"] = trans_id
+        try:
+            # cherrypy decoded it, but we actually need it encoded.
+            trans_id = quote(tokens[0], "")
+        except IndexError:
+            raise
+            trans_id = None
 
-        @cherrypy.tools.response_headers(headers=[("Pragma", "no-cache"),
+        request = cherrypy.request
+        response = cherrypy.response
+
+        size = int(request.headers.get("Content-Length", 0))
+        if size < 0:
+            raise cherrypy.HTTPError(
+                http_client.BAD_REQUEST, _("manifest/1 must be sent a file.")
+            )
+        data = request.rfile
+
+        try:
+            self.repo.add_manifest(trans_id, data)
+        except srepo.RepositoryError as e:
+            # Assume a bad request was made.  A 404 can't be
+            # returned here as misc.versioned_urlopen will interpret
+            # that to mean that the server doesn't support this
+            # operation.
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        response.headers["Content-Length"] = "0"
+        return response.body
+
+    @cherrypy.tools.response_headers(
+        headers=[
+            ("Pragma", "no-cache"),
             ("Cache-Control", "no-cache, no-transform, must-revalidate"),
-            ("Expires", 0)])
-        def append_0(self, *tokens):
-                """Starts an append transaction for the package name specified
-                in the request path.  Returns no output."""
+            ("Expires", 0),
+        ]
+    )
+    def index_0(self, *tokens):
+        """Provides an administrative interface for search indexing.
+        Returns no output if successful; otherwise the response body
+        will contain the failure details.
+        """
 
-                request = cherrypy.request
-                response = cherrypy.response
+        try:
+            cmd = tokens[0]
+        except IndexError:
+            cmd = ""
 
-                client_release = request.headers.get("Client-Release", None)
-                try:
-                        pfmri = tokens[0]
-                except IndexError:
-                        pfmri = None
-
-                # XXX Authentication will be handled by virtue of possessing a
-                # signed certificate (or a more elaborate system).
-                if not pfmri:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                            _("A valid package FMRI must be specified."))
-
-                try:
-                        pfmri = fmri.PkgFmri(pfmri, client_release)
-                        trans_id = self.repo.append(client_release, pfmri)
-                except (fmri.FmriError, srepo.RepositoryError) as e:
-                        # Assume a bad request was made.  A 404 can't be
-                        # returned here as misc.versioned_urlopen will interpret
-                        # that to mean that the server doesn't support this
-                        # operation.
-                        cherrypy.log("Request failed: {0}".format(e))
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-
-                if pfmri.publisher and not self._get_req_pub():
-                        self.__map_pub_ops(pfmri.publisher)
-
-                # Set response headers before returning.
-                response.headers["Content-type"] = "text/plain; charset=utf-8"
-                response.headers["Transaction-ID"] = trans_id
-
-        @cherrypy.tools.response_headers(headers=[("Pragma", "no-cache"),
-            ("Cache-Control", "no-cache, no-transform, must-revalidate"),
-            ("Expires", 0)])
-        def close_0(self, *tokens):
-                """Ends an in-flight transaction for the Transaction ID
-                specified in the request path.
-
-                Returns a Package-FMRI and State header in the response
-                indicating the published FMRI and the state of the package
-                in the catalog.  Returns no output."""
-
-                try:
-                        # cherrypy decoded it, but we actually need it encoded.
-                        trans_id = quote(tokens[0], "")
-                except IndexError:
-                        trans_id = None
-
-                request = cherrypy.request
-
-                try:
-                        # Assume "True" for backwards compatibility.
-                        add_to_catalog = int(request.headers.get(
-                            "X-IPkg-Add-To-Catalog", 1))
-
-                        # Force a boolean value.
-                        if add_to_catalog:
-                                add_to_catalog = True
-                        else:
-                                add_to_catalog = False
-                except ValueError as e:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                            "X-IPkg-Add-To-Catalog".format(e))
-
-                try:
-                        pfmri, pstate = self.repo.close(trans_id,
-                            add_to_catalog=add_to_catalog)
-                except srepo.RepositoryError as e:
-                        # Assume a bad request was made.  A 404 can't be
-                        # returned here as misc.versioned_urlopen will interpret
-                        # that to mean that the server doesn't support this
-                        # operation.
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-
-                response = cherrypy.response
-                response.headers["Package-FMRI"] = pfmri
-                response.headers["State"] = pstate
-
-        @cherrypy.tools.response_headers(headers=[("Pragma", "no-cache"),
-            ("Cache-Control", "no-cache, no-transform, must-revalidate"),
-            ("Expires", 0)])
-        def admin_0(self, *tokens, **params):
-                """Execute a specified repository administration operation based
-                on the provided query string.  Example:
-
-                        <repo_uri>[/<publisher>]/admin/0?cmd=refresh-index
-
-                Available commands are:
-                        rebuild
-                            Discard search data and package catalogs and
-                            rebuild both.
-                        rebuild-indexes
-                            Discard search data and rebuild.
-                        rebuild-packages
-                            Discard package catalogs and rebuild.
-                        refresh
-                            Update search and package data.
-                        refresh-indexes
-                            Update search data.  (Add packages found in the
-                            repository to their related search indexes.)
-                        refresh-packages
-                            Update package data.  (Add packages found in the
-                            repository to their related catalog.)
-                """
-
-                cmd = params.get("cmd", "")
-
-                # These commands cause the operation requested to be queued
-                # for later execution.  This does mean that if the operation
-                # fails, the client won't know about it, but this is necessary
-                # since these are long running operations (are likely to exceed
-                # connection timeout limits).
-                try:
-                        if cmd == "rebuild":
-                                # Discard existing catalog and search data and
-                                # rebuild.
-                                self.__bgtask.put(self.repo.rebuild,
-                                    pub=self._get_req_pub(), build_catalog=True,
-                                    build_index=True)
-                        elif cmd == "rebuild-indexes":
-                                # Discard search data and rebuild.
-                                self.__bgtask.put(self.repo.rebuild,
-                                    pub=self._get_req_pub(),
-                                    build_catalog=False, build_index=True)
-                        elif cmd == "rebuild-packages":
-                                # Discard package data and rebuild.
-                                self.__bgtask.put(self.repo.rebuild,
-                                    pub=self._get_req_pub(), build_catalog=True,
-                                    build_index=False)
-                        elif cmd == "refresh":
-                                # Add new packages and update search indexes.
-                                self.__bgtask.put(self.repo.add_content,
-                                    pub=self._get_req_pub(), refresh_index=True)
-                        elif cmd == "refresh-indexes":
-                                # Update search indexes.
-                                self.__bgtask.put(self.repo.refresh_index,
-                                    pub=self._get_req_pub())
-                        elif cmd == "refresh-packages":
-                                # Add new packages.
-                                self.__bgtask.put(self.repo.add_content,
-                                    pub=self._get_req_pub(),
-                                    refresh_index=False)
-                        else:
-                                raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                                   "Unknown or unsupported operation: '{0}'".format(
-                                   cmd))
-                except queue.Full:
-                        raise cherrypy.HTTPError(http_client.SERVICE_UNAVAILABLE,
-                           "Another operation is already in progress; try "
-                           "again later.")
-
-        @cherrypy.tools.response_headers(headers=[("Pragma", "no-cache"),
-            ("Cache-Control", "no-cache, no-transform, must-revalidate"),
-            ("Expires", 0)])
-        def abandon_0(self, *tokens):
-                """Aborts an in-flight transaction for the Transaction ID
-                specified in the request path.  Returns no output."""
-
-                try:
-                        # cherrypy decoded it, but we actually need it encoded.
-                        trans_id = quote(tokens[0], "")
-                except IndexError:
-                        trans_id = None
-
-                try:
-                        self.repo.abandon(trans_id)
-                except srepo.RepositoryError as e:
-                        # Assume a bad request was made.  A 404 can't be
-                        # returned here as misc.versioned_urlopen will interpret
-                        # that to mean that the server doesn't support this
-                        # operation.
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-
-        def add_0(self, *tokens):
-                """Adds an action and its content to an in-flight transaction
-                for the Transaction ID specified in the request path.  The
-                content is expected to be in the request body.  Returns no
-                output."""
-
-                try:
-                        # cherrypy decoded it, but we actually need it encoded.
-                        trans_id = quote(tokens[0], "")
-                except IndexError:
-                        trans_id = None
-
-                try:
-                        entry_type = tokens[1]
-                except IndexError:
-                        entry_type = None
-
-                if entry_type not in actions.types:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, _("The "
-                            "specified Action Type, '{0}', is not valid.").format(
-                            entry_type))
-
-                request = cherrypy.request
-                attrs = dict(
-                    val.split("=", 1)
-                    for hdr, val in request.headers.items()
-                    if hdr.lower().startswith("x-ipkg-setattr")
+        # These commands cause the operation requested to be queued
+        # for later execution.  This does mean that if the operation
+        # fails, the client won't know about it, but this is necessary
+        # since these are long running operations (are likely to exceed
+        # connection timeout limits).
+        try:
+            if cmd == "refresh":
+                # Update search indexes.
+                self.__bgtask.put(
+                    self.repo.refresh_index, pub=self._get_req_pub()
                 )
+            else:
+                err = "Unknown index subcommand: {0}".format(cmd)
+                cherrypy.log(err)
+                raise cherrypy.HTTPError(http_client.NOT_FOUND, err)
+        except queue.Full:
+            raise cherrypy.HTTPError(
+                http_client.SERVICE_UNAVAILABLE,
+                "Another operation is already in progress; try " "again later.",
+            )
 
-                # If any attributes appear to be lists, make them lists.
-                for a in attrs:
-                        if attrs[a].startswith("[") and attrs[a].endswith("]"):
-                                # Ensure input is valid; only a list will be
-                                # accepted.
-                                try:
-                                        val = ast.literal_eval(attrs[a])
-                                        if not isinstance(val, list):
-                                                raise ValueError()
-                                        attrs[a] = val
-                                except ValueError:
-                                        raise cherrypy.HTTPError(
-                                            http_client.BAD_REQUEST, _("The "
-                                            "specified Action attribute value, "
-                                            "'{0}', is not valid.").format(
-                                            attrs[a]))
+    @cherrypy.tools.response_headers(
+        headers=[("Content-Type", "text/plain; charset=utf-8")]
+    )
+    def info_0(self, *tokens):
+        """Output a text/plain summary of information about the
+        specified package. The request is an encoded pkg FMRI.  If
+        the version is specified incompletely, we return an error,
+        as the client is expected to form correct requests, based
+        on its interpretation of the catalog and its image
+        policies."""
 
-                data = None
-                size = int(request.headers.get("Content-Length", 0))
-                if size > 0:
-                        data = request.rfile
-                        # Record the size of the payload, if there is one.
-                        attrs["pkg.size"] = str(size)
+        try:
+            pubs = self.repo.publishers
+        except Exception as e:
+            cherrypy.log("Request failed: {0}".format(e))
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
 
-                try:
-                        action = actions.types[entry_type](data, **attrs)
-                except actions.ActionError as e:
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        # A broken proxy (or client) has caused a fully-qualified FMRI
+        # to be split up.
+        comps = [t for t in tokens]
+        if len(comps) > 1 and comps[0] == "pkg:" and comps[1] in pubs:
+            # Only one slash here as another will be added below.
+            comps[0] += "/"
 
-                # XXX Once actions are labelled with critical nature.
-                # if entry_type in critical_actions:
-                #         self.critical = True
+        # Parse request into FMRI component and decode.
+        try:
+            # If more than one token (request path component) was
+            # specified, assume that the extra components are part
+            # of the fmri and have been split out because of bad
+            # proxy behaviour.
+            pfmri = "/".join(comps)
+            pfmri = fmri.PkgFmri(pfmri, None)
+            pub = self._get_req_pub()
+            if not pfmri.publisher:
+                if not pub:
+                    pub = self.repo.cfg.get_property("publisher", "prefix")
+                if pub:
+                    pfmri.publisher = pub
+            fpath = self.repo.manifest(pfmri, pub=pub)
+        except (IndexError, fmri.FmriError) as e:
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        except srepo.RepositoryError as e:
+            # Treat any remaining repository error as a 404, but
+            # log the error and include the real failure
+            # information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
 
-                try:
-                        self.repo.add(trans_id, action)
-                except srepo.RepositoryError as e:
-                        # Assume a bad request was made.  A 404 can't be
-                        # returned here as misc.versioned_urlopen will interpret
-                        # that to mean that the server doesn't support this
-                        # operation.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        if not os.path.exists(fpath):
+            raise cherrypy.HTTPError(http_client.NOT_FOUND)
 
-        # We need to prevent cherrypy from processing the request body so that
-        # add can parse the request body itself.  In addition, we also need to
-        # set the timeout higher since the default is five minutes; not really
-        # enough for a slow connection to upload content.
-        add_0._cp_config = {
-            "request.process_request_body": False,
-            "response.timeout": 3600,
-            "tools.response_headers.on": True,
-            "tools.response_headers.headers": [
-                ("Pragma", "no-cache"),
-                ("Cache-Control", "no-cache, no-transform, must-revalidate"),
-                ("Expires", 0)
-            ]
-        }
+        m = manifest.Manifest(pfmri)
+        m.set_content(pathname=fpath)
 
-        def __upload_file(self, *tokens):
-                """Adds a file to an in-flight transaction for the Transaction
-                ID specified in the request path.  The content is expected to be
-                in the request body.  Returns no output."""
+        pub, name, ver = pfmri.tuple()
+        summary = m.get("pkg.summary", m.get("description", ""))
 
-                try:
-                        # cherrypy decoded it, but we actually need it encoded.
-                        trans_id = quote(tokens[0], "")
-                except IndexError:
-                        raise
-                        trans_id = None
+        lsummary = io.BytesIO()
+        for i, entry in enumerate(m.gen_actions_by_type("license")):
+            if i > 0:
+                lsummary.write(b"\n")
+            try:
+                lpath = self.repo.file(entry.hash, pub=pub)
+            except srepo.RepositoryFileNotFoundError:
+                # Skip the license.
+                continue
 
-                request = cherrypy.request
-                response = cherrypy.response
+            with open(lpath, "rb") as lfile:
+                misc.gunzip_from_stream(lfile, lsummary, ignore_hash=True)
+        lsummary.seek(0)
 
-                size = int(request.headers.get("Content-Length", 0))
-                if size < 0:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                            _("file/1 must be sent a file."))
-                data = request.rfile
-                attrs = dict(
-                    val.split("=", 1)
-                    for hdr, val in request.headers.items()
-                    if hdr.lower().startswith("x-ipkg-setattr")
-                )
-                basename = attrs.get("basename", None)
-                try:
-                        self.repo.add_file(trans_id, data, basename, size)
-                except srepo.RepositoryError as e:
-                        # Assume a bad request was made.  A 404 can't be
-                        # returned here as misc.versioned_urlopen will interpret
-                        # that to mean that the server doesn't support this
-                        # operation.
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-                response.headers["Content-Length"] = "0"
-                return response.body
+        self.__set_response_expires("info", 86400 * 365, 86400 * 365)
+        size, csize = m.get_size()
 
-        def __upload_manifest(self, *tokens):
-                """Adds a file to an in-flight transaction for the Transaction
-                ID specified in the request path.  The content is expected to be
-                in the request body.  Returns no output."""
-
-                try:
-                        # cherrypy decoded it, but we actually need it encoded.
-                        trans_id = quote(tokens[0], "")
-                except IndexError:
-                        raise
-                        trans_id = None
-
-                request = cherrypy.request
-                response = cherrypy.response
-
-                size = int(request.headers.get("Content-Length", 0))
-                if size < 0:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST,
-                            _("manifest/1 must be sent a file."))
-                data = request.rfile
-
-                try:
-                        self.repo.add_manifest(trans_id, data)
-                except srepo.RepositoryError as e:
-                        # Assume a bad request was made.  A 404 can't be
-                        # returned here as misc.versioned_urlopen will interpret
-                        # that to mean that the server doesn't support this
-                        # operation.
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-                response.headers["Content-Length"] = "0"
-                return response.body
-
-        @cherrypy.tools.response_headers(headers=[("Pragma", "no-cache"),
-            ("Cache-Control", "no-cache, no-transform, must-revalidate"),
-            ("Expires", 0)])
-        def index_0(self, *tokens):
-                """Provides an administrative interface for search indexing.
-                Returns no output if successful; otherwise the response body
-                will contain the failure details.
-                """
-
-                try:
-                        cmd = tokens[0]
-                except IndexError:
-                        cmd = ""
-
-                # These commands cause the operation requested to be queued
-                # for later execution.  This does mean that if the operation
-                # fails, the client won't know about it, but this is necessary
-                # since these are long running operations (are likely to exceed
-                # connection timeout limits).
-                try:
-                        if cmd == "refresh":
-                                # Update search indexes.
-                                self.__bgtask.put(self.repo.refresh_index,
-                                    pub=self._get_req_pub())
-                        else:
-                                err = "Unknown index subcommand: {0}".format(
-                                    cmd)
-                                cherrypy.log(err)
-                                raise cherrypy.HTTPError(http_client.NOT_FOUND, err)
-                except queue.Full:
-                        raise cherrypy.HTTPError(http_client.SERVICE_UNAVAILABLE,
-                           "Another operation is already in progress; try "
-                           "again later.")
-
-        @cherrypy.tools.response_headers(headers=\
-            [("Content-Type", "text/plain; charset=utf-8")])
-        def info_0(self, *tokens):
-                """ Output a text/plain summary of information about the
-                    specified package. The request is an encoded pkg FMRI.  If
-                    the version is specified incompletely, we return an error,
-                    as the client is expected to form correct requests, based
-                    on its interpretation of the catalog and its image
-                    policies. """
-
-                try:
-                        pubs = self.repo.publishers
-                except Exception as e:
-                        cherrypy.log("Request failed: {0}".format(e))
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-
-                # A broken proxy (or client) has caused a fully-qualified FMRI
-                # to be split up.
-                comps = [t for t in tokens]
-                if len(comps) > 1 and comps[0] == "pkg:" and comps[1] in pubs:
-                        # Only one slash here as another will be added below.
-                        comps[0] += "/"
-
-                # Parse request into FMRI component and decode.
-                try:
-                        # If more than one token (request path component) was
-                        # specified, assume that the extra components are part
-                        # of the fmri and have been split out because of bad
-                        # proxy behaviour.
-                        pfmri = "/".join(comps)
-                        pfmri = fmri.PkgFmri(pfmri, None)
-                        pub = self._get_req_pub()
-                        if not pfmri.publisher:
-                                if not pub:
-                                        pub = self.repo.cfg.get_property(
-                                            "publisher", "prefix")
-                                if pub:
-                                        pfmri.publisher = pub
-                        fpath = self.repo.manifest(pfmri, pub=pub)
-                except (IndexError, fmri.FmriError) as e:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-                except srepo.RepositoryError as e:
-                        # Treat any remaining repository error as a 404, but
-                        # log the error and include the real failure
-                        # information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-
-                if not os.path.exists(fpath):
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND)
-
-                m = manifest.Manifest(pfmri)
-                m.set_content(pathname=fpath)
-
-                pub, name, ver = pfmri.tuple()
-                summary = m.get("pkg.summary", m.get("description", ""))
-
-                lsummary = io.BytesIO()
-                for i, entry in enumerate(m.gen_actions_by_type("license")):
-                        if i > 0:
-                                lsummary.write(b"\n")
-                        try:
-                                lpath = self.repo.file(entry.hash, pub=pub)
-                        except srepo.RepositoryFileNotFoundError:
-                                # Skip the license.
-                                continue
-
-                        with open(lpath, "rb") as lfile:
-                                misc.gunzip_from_stream(lfile, lsummary,
-                                    ignore_hash=True)
-                lsummary.seek(0)
-
-                self.__set_response_expires("info", 86400*365, 86400*365)
-                size, csize = m.get_size()
-
-                # Add human version if exist.
-                hum_ver = m.get("pkg.human-version", "")
-                version = ver.release
-                if hum_ver and hum_ver != str(ver.release):
-                        version = "{0} ({1})".format(ver.release, hum_ver)
-                return """\
+        # Add human version if exist.
+        hum_ver = m.get("pkg.human-version", "")
+        version = ver.release
+        if hum_ver and hum_ver != str(ver.release):
+            version = "{0} ({1})".format(ver.release, hum_ver)
+        return """\
            Name: {0}
         Summary: {1}
       Publisher: {2}
@@ -1383,977 +1464,1054 @@ Compressed Size: {8}
 
 License:
 {10}
-""".format(name, summary, pub, version, ver.build_release,
-    ver.branch, ver.get_timestamp().strftime("%c"), misc.bytes_to_str(size),
-    misc.bytes_to_str(csize), pfmri, misc.force_str(lsummary.read(),
-    errors='replace'))
+""".format(
+            name,
+            summary,
+            pub,
+            version,
+            ver.build_release,
+            ver.branch,
+            ver.get_timestamp().strftime("%c"),
+            misc.bytes_to_str(size),
+            misc.bytes_to_str(csize),
+            pfmri,
+            misc.force_str(lsummary.read(), errors="replace"),
+        )
 
-        @cherrypy.tools.response_headers(headers=[(
-            "Content-Type", p5i.MIME_TYPE)])
-        def publisher_0(self, *tokens):
-                """Returns a pkg(7) information datastream based on the
-                repository configuration's publisher information."""
+    @cherrypy.tools.response_headers(headers=[("Content-Type", p5i.MIME_TYPE)])
+    def publisher_0(self, *tokens):
+        """Returns a pkg(7) information datastream based on the
+        repository configuration's publisher information."""
 
-                prefix = self._get_req_pub()
-                pubs = [
-                   pub for pub in self.repo.get_publishers()
-                   if not prefix or pub.prefix == prefix
-                ]
-                if prefix and not pubs:
-                        # Publisher specified in request is unknown.
-                        e = srepo.RepositoryUnknownPublisher(prefix)
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+        prefix = self._get_req_pub()
+        pubs = [
+            pub
+            for pub in self.repo.get_publishers()
+            if not prefix or pub.prefix == prefix
+        ]
+        if prefix and not pubs:
+            # Publisher specified in request is unknown.
+            e = srepo.RepositoryUnknownPublisher(prefix)
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
 
-                buf = cStringIO()
-                try:
-                        p5i.write(buf, pubs)
-                except Exception as e:
-                        # Treat any remaining error as a 404, but log it and
-                        # include the real failure information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-                buf.seek(0)
-                self.__set_response_expires("publisher", 86400*365, 86400*365)
-                # Page handlers MUST return bytes.
-                return misc.force_bytes(buf.getvalue())
+        buf = cStringIO()
+        try:
+            p5i.write(buf, pubs)
+        except Exception as e:
+            # Treat any remaining error as a 404, but log it and
+            # include the real failure information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+        buf.seek(0)
+        self.__set_response_expires("publisher", 86400 * 365, 86400 * 365)
+        # Page handlers MUST return bytes.
+        return misc.force_bytes(buf.getvalue())
 
-        @cherrypy.tools.response_headers(headers=[(
-            "Content-Type", p5i.MIME_TYPE)])
-        def publisher_1(self, *tokens):
-                """Returns a pkg(7) information datastream based on the
-                the request's publisher or all if not specified."""
+    @cherrypy.tools.response_headers(headers=[("Content-Type", p5i.MIME_TYPE)])
+    def publisher_1(self, *tokens):
+        """Returns a pkg(7) information datastream based on the
+        the request's publisher or all if not specified."""
 
-                prefix = self._get_req_pub()
+        prefix = self._get_req_pub()
 
-                pubs = []
-                if not prefix:
-                        pubs = self.repo.get_publishers()
-                else:
-                        try:
-                                pub = self.repo.get_publisher(prefix)
-                                pubs.append(pub)
-                        except Exception as e:
-                                # If the Publisher object creation fails, return
-                                # a not found error to the client so it will
-                                # treat it as an unsupported operation.
-                                cherrypy.log("Request failed: {0}".format(
-                                    str(e)))
-                                raise cherrypy.HTTPError(http_client.NOT_FOUND,
-                                    str(e))
+        pubs = []
+        if not prefix:
+            pubs = self.repo.get_publishers()
+        else:
+            try:
+                pub = self.repo.get_publisher(prefix)
+                pubs.append(pub)
+            except Exception as e:
+                # If the Publisher object creation fails, return
+                # a not found error to the client so it will
+                # treat it as an unsupported operation.
+                cherrypy.log("Request failed: {0}".format(str(e)))
+                raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
 
-                buf = cStringIO()
-                try:
-                        p5i.write(buf, pubs)
-                except Exception as e:
-                        # Treat any remaining error as a 404, but log it and
-                        # include the real failure information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-                buf.seek(0)
-                self.__set_response_expires("publisher", 86400*365, 86400*365)
-                return buf.getvalue()
+        buf = cStringIO()
+        try:
+            p5i.write(buf, pubs)
+        except Exception as e:
+            # Treat any remaining error as a 404, but log it and
+            # include the real failure information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+        buf.seek(0)
+        self.__set_response_expires("publisher", 86400 * 365, 86400 * 365)
+        return buf.getvalue()
 
-        def __get_matching_p5i_data(self, rstore, pfmri):
-                # Attempt to find matching entries in the catalog.
-                try:
-                        pub = self.repo.get_publisher(rstore.publisher)
-                except srepo.RepositoryUnknownPublisher:
-                        return ""
+    def __get_matching_p5i_data(self, rstore, pfmri):
+        # Attempt to find matching entries in the catalog.
+        try:
+            pub = self.repo.get_publisher(rstore.publisher)
+        except srepo.RepositoryUnknownPublisher:
+            return ""
 
-                try:
-                        cat = rstore.catalog
-                except (srepo.RepositoryMirrorError,
-                    srepo.RepositoryUnsupportedOperationError):
-                        return ""
+        try:
+            cat = rstore.catalog
+        except (
+            srepo.RepositoryMirrorError,
+            srepo.RepositoryUnsupportedOperationError,
+        ):
+            return ""
 
-                try:
-                        matches = [fmri for fmri, states, attrs in \
-                            cat.gen_packages(patterns=[pfmri],
-                            return_fmris=True)]
+        try:
+            matches = [
+                fmri
+                for fmri, states, attrs in cat.gen_packages(
+                    patterns=[pfmri], return_fmris=True
+                )
+            ]
 
-                except Exception as e:
-                        # If this fails, it's ok to raise an exception since bad
-                        # input was likely provided.
-                        cherrypy.log("Request failed: {0}".format(e))
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        except Exception as e:
+            # If this fails, it's ok to raise an exception since bad
+            # input was likely provided.
+            cherrypy.log("Request failed: {0}".format(e))
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
 
-                if not matches:
-                        return ""
+        if not matches:
+            return ""
 
-                if not "@" in pfmri or "*" in pfmri:
-                        # When using wildcards or exact name match, trim the
-                        # results to only the unique package stems.
-                        matches = sorted(set([m.pkg_name for m in matches]))
-                else:
-                        # Ensure all fmris are output without publisher prefix
-                        # and without scheme.
-                        matches = [
-                            m.get_fmri(anarchy=True, include_scheme=False)
-                            for m in matches
-                        ]
+        if not "@" in pfmri or "*" in pfmri:
+            # When using wildcards or exact name match, trim the
+            # results to only the unique package stems.
+            matches = sorted(set([m.pkg_name for m in matches]))
+        else:
+            # Ensure all fmris are output without publisher prefix
+            # and without scheme.
+            matches = [
+                m.get_fmri(anarchy=True, include_scheme=False) for m in matches
+            ]
 
-                buf = cStringIO()
-                pkg_names = { pub.prefix: matches }
-                p5i.write(buf, [pub], pkg_names=pkg_names)
-                buf.seek(0)
-                return buf.getvalue()
+        buf = cStringIO()
+        pkg_names = {pub.prefix: matches}
+        p5i.write(buf, [pub], pkg_names=pkg_names)
+        buf.seek(0)
+        return buf.getvalue()
 
-        @cherrypy.tools.response_headers(headers=[(
-            "Content-Type", p5i.MIME_TYPE)])
-        def p5i_0(self, *tokens):
-                """Returns a pkg(7) information datastream for the provided full
-                or partial FMRI using the repository configuration's publisher
-                information.  If a partial FMRI is specified, an attempt to
-                validate it will be made, and it will be put into the p5i
-                datastream as provided."""
+    @cherrypy.tools.response_headers(headers=[("Content-Type", p5i.MIME_TYPE)])
+    def p5i_0(self, *tokens):
+        """Returns a pkg(7) information datastream for the provided full
+        or partial FMRI using the repository configuration's publisher
+        information.  If a partial FMRI is specified, an attempt to
+        validate it will be made, and it will be put into the p5i
+        datastream as provided."""
 
-                try:
-                        pubs = self.repo.publishers
-                except Exception as e:
-                        cherrypy.log("Request failed: {0}".format(e))
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        try:
+            pubs = self.repo.publishers
+        except Exception as e:
+            cherrypy.log("Request failed: {0}".format(e))
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
 
-                # A broken proxy (or client) has caused a fully-qualified FMRI
-                # to be split up.
-                comps = [t for t in tokens]
-                if len(comps) > 1 and comps[0] == "pkg:" and comps[1] in pubs:
-                        # Only one slash here as another will be added below.
-                        comps[0] += "/"
+        # A broken proxy (or client) has caused a fully-qualified FMRI
+        # to be split up.
+        comps = [t for t in tokens]
+        if len(comps) > 1 and comps[0] == "pkg:" and comps[1] in pubs:
+            # Only one slash here as another will be added below.
+            comps[0] += "/"
 
-                try:
-                        # If more than one token (request path component) was
-                        # specified, assume that the extra components are part
-                        # of an FMRI and have been split out because of bad
-                        # proxy behaviour.
-                        pfmri = "/".join(comps)
-                except IndexError:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST)
+        try:
+            # If more than one token (request path component) was
+            # specified, assume that the extra components are part
+            # of an FMRI and have been split out because of bad
+            # proxy behaviour.
+            pfmri = "/".join(comps)
+        except IndexError:
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST)
 
-                # XXX This is a hack to deal with the fact that packagemanager
-                # brokenly expects all p5i URIs or files to have a .p5i
-                # extension instead of just relying on the api to parse it.
-                # This hack allows callers to append a .p5i extension to the
-                # URI without affecting the operation.
-                if pfmri.endswith(".p5i"):
-                        end = len(pfmri) - len(".p5i")
-                        pfmri = pfmri[:end]
+        # XXX This is a hack to deal with the fact that packagemanager
+        # brokenly expects all p5i URIs or files to have a .p5i
+        # extension instead of just relying on the api to parse it.
+        # This hack allows callers to append a .p5i extension to the
+        # URI without affecting the operation.
+        if pfmri.endswith(".p5i"):
+            end = len(pfmri) - len(".p5i")
+            pfmri = pfmri[:end]
 
-                output = ""
-                prefix = self._get_req_pub()
-                for rstore in self.repo.rstores:
-                        if not rstore.publisher:
-                                continue
-                        if prefix and prefix != rstore.publisher:
-                                continue
-                        output += self.__get_matching_p5i_data(rstore, pfmri)
+        output = ""
+        prefix = self._get_req_pub()
+        for rstore in self.repo.rstores:
+            if not rstore.publisher:
+                continue
+            if prefix and prefix != rstore.publisher:
+                continue
+            output += self.__get_matching_p5i_data(rstore, pfmri)
 
-                if output == "":
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, _("No "
-                            "matching package found in repository."))
+        if output == "":
+            raise cherrypy.HTTPError(
+                http_client.NOT_FOUND,
+                _("No " "matching package found in repository."),
+            )
 
-                self.__set_response_expires("p5i", 86400*365, 86400*365)
-                # Page handlers MUST return bytes.
-                return misc.force_bytes(output)
+        self.__set_response_expires("p5i", 86400 * 365, 86400 * 365)
+        # Page handlers MUST return bytes.
+        return misc.force_bytes(output)
 
-        @cherrypy.tools.response_headers(headers=\
-            [("Content-Type", "application/json; charset=utf-8")])
-        def status_0(self, *tokens):
-                """Return a JSON formatted dictionary containing statistics
-                information for the repository being served."""
+    @cherrypy.tools.response_headers(
+        headers=[("Content-Type", "application/json; charset=utf-8")]
+    )
+    def status_0(self, *tokens):
+        """Return a JSON formatted dictionary containing statistics
+        information for the repository being served."""
 
-                self.__set_response_expires("versions", 5*60, 5*60)
+        self.__set_response_expires("versions", 5 * 60, 5 * 60)
 
-                dump_struct = self.repo.get_status()
+        dump_struct = self.repo.get_status()
 
-                try:
-                        out = json.dumps(dump_struct, ensure_ascii=False,
-                            indent=2, sort_keys=True)
-                except Exception as e:
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, _("Unable "
-                            "to generate statistics."))
-                return misc.force_bytes(out + "\n")
+        try:
+            out = json.dumps(
+                dump_struct, ensure_ascii=False, indent=2, sort_keys=True
+            )
+        except Exception as e:
+            raise cherrypy.HTTPError(
+                http_client.NOT_FOUND, _("Unable " "to generate statistics.")
+            )
+        return misc.force_bytes(out + "\n")
+
 
 def nasty_before_handler(nasty_depot, maxroll=100):
-        """Cherrypy Tool callable which generates various problems prior to a
-        request.  Possible outcomes: retryable HTTP error, short nap."""
+    """Cherrypy Tool callable which generates various problems prior to a
+    request.  Possible outcomes: retryable HTTP error, short nap."""
 
-        # Must be set in _cp_config on associated request handler.
-        assert nasty_depot
+    # Must be set in _cp_config on associated request handler.
+    assert nasty_depot
 
-        # Adjust nastiness values once per incoming request.
-        nasty_depot.nasty_housekeeping()
+    # Adjust nastiness values once per incoming request.
+    nasty_depot.nasty_housekeeping()
 
-        # Just roll the main nasty dice once.
-        if not nasty_depot.need_nasty(maxroll=maxroll):
-                return False
-
-        while True:
-                roll = random.randint(0, 10)
-                if roll == 0:
-                        nasty_depot.nasty_nap()
-                        if random.randint(0, 1) == 1:
-                                # Nap was enough. Let the normal handler run.
-                                return False
-                if 1 <= roll <= 8:
-                        nasty_depot.nasty_raise_error()
-                else:
-                        cherrypy.log("NASTY: return bogus or empty response")
-                        response = cherrypy.response
-                        response.body = random.choice(['',
-                            'set this is a bogus action',
-                            'Instead of office chair, '
-                                'package contained bobcat.',
-                            '{"this is a": "fragment of json"}'])
-                        return True
+    # Just roll the main nasty dice once.
+    if not nasty_depot.need_nasty(maxroll=maxroll):
         return False
+
+    while True:
+        roll = random.randint(0, 10)
+        if roll == 0:
+            nasty_depot.nasty_nap()
+            if random.randint(0, 1) == 1:
+                # Nap was enough. Let the normal handler run.
+                return False
+        if 1 <= roll <= 8:
+            nasty_depot.nasty_raise_error()
+        else:
+            cherrypy.log("NASTY: return bogus or empty response")
+            response = cherrypy.response
+            response.body = random.choice(
+                [
+                    "",
+                    "set this is a bogus action",
+                    "Instead of office chair, " "package contained bobcat.",
+                    '{"this is a": "fragment of json"}',
+                ]
+            )
+            return True
+    return False
 
 
 class NastyDepotHTTP(DepotHTTP):
-        """A class that creates a depot that misbehaves.  Naughty
-        depots are useful for testing."""
+    """A class that creates a depot that misbehaves.  Naughty
+    depots are useful for testing."""
 
-        # Nastiness ebbs and flows in a sinusoidal NASTY_CYCLE length pattern.
-        # The magnitude of the effect is governed by NASTY_MULTIPLIER.
-        # See also nasty_housekeeping().
-        NASTY_CYCLE = 200
-        NASTY_MULTIPLIER = 1.0
+    # Nastiness ebbs and flows in a sinusoidal NASTY_CYCLE length pattern.
+    # The magnitude of the effect is governed by NASTY_MULTIPLIER.
+    # See also nasty_housekeeping().
+    NASTY_CYCLE = 200
+    NASTY_MULTIPLIER = 1.0
 
-        def __init__(self, repo, dconf):
-                """Initialize."""
+    def __init__(self, repo, dconf):
+        """Initialize."""
 
-                DepotHTTP.__init__(self, repo, dconf)
+        DepotHTTP.__init__(self, repo, dconf)
 
-                # Handles the BUI (Browser User Interface).
-                face.init(self)
+        # Handles the BUI (Browser User Interface).
+        face.init(self)
 
-                # Store any possible configuration changes.
-                self.repo.write_config()
+        # Store any possible configuration changes.
+        self.repo.write_config()
 
-                self.requested_files = []
-                self.requested_catalogs = []
-                self.requested_manifests = []
+        self.requested_files = []
+        self.requested_catalogs = []
+        self.requested_manifests = []
 
-                self.nasty_level = \
-                    int(dconf.get_property("nasty", "nasty_level"))
-                self.nasty_sleep = \
-                    int(dconf.get_property("nasty", "nasty_sleep"))
+        self.nasty_level = int(dconf.get_property("nasty", "nasty_level"))
+        self.nasty_sleep = int(dconf.get_property("nasty", "nasty_sleep"))
 
-                self.nasty_cycle = self.NASTY_CYCLE
-                self.maxroll_adj = 1.0
+        self.nasty_cycle = self.NASTY_CYCLE
+        self.maxroll_adj = 1.0
 
-                cherrypy.log("NASTY Depot Started")
-                cherrypy.log("NASTY nasty={0:d}, nasty_sleep={1:d}".format(
-                    self.nasty_level, self.nasty_sleep))
+        cherrypy.log("NASTY Depot Started")
+        cherrypy.log(
+            "NASTY nasty={0:d}, nasty_sleep={1:d}".format(
+                self.nasty_level, self.nasty_sleep
+            )
+        )
 
-                # See CherryPy HandlerTool docs; this sets up a special
-                # tool which can prevent the main request body from running
-                # when needed.
-                cherrypy.tools.nasty_before = HandlerTool(nasty_before_handler)
+        # See CherryPy HandlerTool docs; this sets up a special
+        # tool which can prevent the main request body from running
+        # when needed.
+        cherrypy.tools.nasty_before = HandlerTool(nasty_before_handler)
 
-                self._cp_config = {
-                    # Turn on this tool for all requests.
-                    'tools.nasty_before.on': True,
-                    #
-                    # This is tricky: we poke a reference to ourself into our
-                    # own _cp_config, specifically so that we can get this
-                    # reference passed by cherrypy as an input argument to our
-                    # nasty_before tool, so that it can in turn call methods
-                    # back on this object.
-                    #
-                    'tools.nasty_before.nasty_depot': self
-                }
-
-                # Set up a list of errors that we can pick from when we
-                # want to return an error at random to the client.  Errors
-                # are weighted by how often we want them to happen; the loop
-                # below then puts them into a pick-list.
-                errors = {
-                    http_client.REQUEST_TIMEOUT: 10,
-                    http_client.BAD_GATEWAY: 10,
-                    http_client.GATEWAY_TIMEOUT: 10,
-                    http_client.FORBIDDEN: 2,
-                    http_client.NOT_FOUND: 2,
-                    http_client.BAD_REQUEST: 2
-                }
-
-                self.errlist = []
-                for x, n in six.iteritems(errors):
-                        for i in range(0, n):
-                                self.errlist.append(x)
-                cherrypy.log("NASTY Depot Error List: {0}".format(
-                    str(self.errlist)))
-
-        def nasty_housekeeping(self):
-                # Generate a sine wave (well, half of one) which is NASTY_CYCLE
-                # steps long and use that to increase maxroll (thus reducing
-                # the nastiness).  The causes nastiness to come and go in
-                # waves, which helps to prevent excessive nastiness from
-                # impeding all progress.
-                #
-                # The intention is for this to get adjusted once per request.
-
-                # Prevent races updating global nastiness information.
-                # Note that this isn't strictly necessary since nasty_cycle
-                # and maxroll_adj are just numbers and races are essentially
-                # harmless, but this is here so that we don't screw things up
-                # in the future.
-                self._lock.acquire()
-
-                self.nasty_cycle = (self.nasty_cycle + 1) % self.NASTY_CYCLE
-                # old-division; pylint: disable=W1619
-                self.maxroll_adj = 1 + self.NASTY_MULTIPLIER * \
-                    math.sin(self.nasty_cycle *
-                        (math.pi / self.NASTY_CYCLE))
-                if self.nasty_cycle == 0:
-                        cherrypy.log("NASTY nastiness at min")
-                if self.nasty_cycle == self.NASTY_CYCLE // 2:
-                        cherrypy.log("NASTY nastiness at max")
-
-                self._lock.release()
-
-        def need_nasty(self, maxroll=100):
-                """Randomly returns true when the server should misbehave."""
-
-                # Apply the sine wave adjustment to maxroll-- preserving the
-                # possiblity that bad things can still sporadically happen.
-                # n.b. we don't bother to pick up the lock here.
-                maxroll = int(maxroll * self.maxroll_adj)
-
-                roll = random.randint(1, maxroll)
-                if roll <= self.nasty_level:
-                        return True
-                return False
-
-        def need_nasty_2(self):
-                """Nastiness sometimes."""
-                return self.need_nasty(maxroll=500)
-
-        def need_nasty_3(self):
-                """Nastiness less often."""
-                return self.need_nasty(maxroll=2000)
-
-        def need_nasty_4(self):
-                """Nastiness very rarely."""
-                return self.need_nasty(maxroll=20000)
-
-        def nasty_raise_error(self):
-                """Raise an http error from self.errlist."""
-                code = random.choice(self.errlist)
-                cherrypy.log("NASTY: Random HTTP error: {0:d}".format(code))
-                raise cherrypy.HTTPError(code)
-
-        def nasty_nap(self):
-                """Sleep for a few seconds."""
-                cherrypy.log("NASTY: sleep for {0:d} secs".format(
-                    self.nasty_sleep))
-                time.sleep(self.nasty_sleep)
-
-        @cherrypy.expose
-        def nasty(self, *tokens):
-                try:
-                        nasty_level = int(tokens[0])
-                except (IndexError, ValueError):
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST)
-                if nasty_level < 0 or nasty_level > 100:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST)
-                cherrypy.log("Nastiness set to {0:d} by client request".format(
-                    nasty_level))
-                self.nasty_level = nasty_level
-
-        # Disable the before handler for this request.
-        nasty._cp_config = { "tools.nasty_before.on": False }
-
-        @cherrypy.tools.response_headers(headers=\
-            [("Content-Type", "text/plain; charset=utf-8")])
-        def versions_0(self, *tokens):
-                """Output a text/plain list of valid operations, and their
-                versions, supported by the repository."""
-
-                # NASTY
-                # emit an X-Ipkg-Error HTTP unauthorized response.
-                if self.need_nasty_3():
-                        cherrypy.log("NASTY versions_0: X-Ipkg-Error")
-                        response = cherrypy.response
-                        response.status = http_client.UNAUTHORIZED
-                        response.headers["X-Ipkg-Error"] = random.choice(["ENT",
-                            "LIC", "SVR", "MNT", "YYZ", ""])
-                        return ""
-
-                # NASTY
-                # Serve up versions header but no versions
-                if self.need_nasty_3():
-                        cherrypy.log("NASTY versions_0: header but no versions")
-                        versions = "pkg-server {0}\n".format(pkg.VERSION)
-                        return versions
-
-                # NASTY
-                # Serve up bogus versions by adding/subtracting from
-                # the actual version numbers-- we use a normal distribution
-                # to keep the perturbations small.
-                if self.need_nasty_2():
-                        cherrypy.log("NASTY versions_0: modified version #s")
-                        versions = "pkg-server {0}-nasty\n".format(pkg.VERSION)
-                        for op, vers in six.iteritems(self.vops):
-                                versions += op + " "
-                                verlen = len(vers)
-                                for v in vers:
-                                        # if there are multiple versions,
-                                        # then sometimes leave one out
-                                        if verlen > 1 and \
-                                            random.randint(0, 10) <= 1:
-                                                cherrypy.log(
-                                                    "NASTY versions_0: "
-                                                    "dropped {0}/{1}".format(op,
-                                                    v))
-                                                verlen -= 1
-                                                continue
-                                        # Periodically increment or
-                                        # decrement the version.
-                                        oldv = v
-                                        v = int(v +
-                                            random.normalvariate(0, 0.8))
-                                        versions += str(v) + " "
-                                        if v != oldv:
-                                                cherrypy.log(
-                                                    "NASTY versions_0: "
-                                                    "Altered {0}/{1} -> {2}/{3:d}".format(
-                                                    op, oldv, op, v))
-                                versions += "\n"
-                        return versions
-
-                versions = "pkg-server {0}\n".format(pkg.VERSION)
-                versions += "\n".join(
-                    "{0} {1}".format(op, " ".join(str(v) for v in vers))
-                    for op, vers in six.iteritems(self.vops)
-                ) + "\n"
-                return versions
-
-        # Fire the before handler less often for versions/0; when it
-        # fails everything else comes to a halt.
-        versions_0._cp_config = { "tools.nasty_before.maxroll": 200 }
-
-        # Override _cp_config for catalog_0 operation
-        def catalog_0(self, *tokens):
-                """Provide a full version of the catalog, as appropriate, to
-                the requesting client.  Incremental catalogs are not supported
-                for v0 catalog clients."""
-
-                # We always raise BAD_REQUEST here because v0 catalogs
-                # are toxic to clients who are facing a nasty antagonist--
-                # the client has no way to verify that the content, and
-                # things go badly off the rails.
-                raise cherrypy.HTTPError(http_client.BAD_REQUEST)
-
-        catalog_0._cp_config = {
-            "response.stream": True,
+        self._cp_config = {
+            # Turn on this tool for all requests.
+            "tools.nasty_before.on": True,
             #
-            # We disable the nasty_before for catalog 0 because clients
-            # who receive a 0 length response for a catalog_0 see that
-            # as a valid but empty catalog.  This causes many issues when
-            # trying to write tests against the nasty depot.  catalog_0
-            # is going away imminently so we don't really care.
+            # This is tricky: we poke a reference to ourself into our
+            # own _cp_config, specifically so that we can get this
+            # reference passed by cherrypy as an input argument to our
+            # nasty_before tool, so that it can in turn call methods
+            # back on this object.
             #
-            "tools.nasty_before.on": False
+            "tools.nasty_before.nasty_depot": self,
         }
 
-        def manifest_0(self, *tokens):
-                """The request is an encoded pkg FMRI.  If the version is
-                specified incompletely, we return an error, as the client is
-                expected to form correct requests based on its interpretation
-                of the catalog and its image policies."""
-
-                try:
-                        pubs = self.repo.publishers
-                except Exception as e:
-                        cherrypy.log("Request failed: {0}".format(e))
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-
-                # A broken proxy (or client) has caused a fully-qualified FMRI
-                # to be split up.
-                comps = [t for t in tokens]
-                if not comps:
-                        raise cherrypy.HTTPError(http_client.FORBIDDEN,
-                            _("Directory listing not allowed."))
-
-                if len(comps) > 1 and comps[0] == "pkg:" and comps[1] in pubs:
-                        # Only one slash here as another will be added below.
-                        comps[0] += "/"
-
-                # Parse request into FMRI component and decode.
-                try:
-                        # If more than one token (request path component) was
-                        # specified, assume that the extra components are part
-                        # of the fmri and have been split out because of bad
-                        # proxy behaviour.
-                        pfmri = "/".join(comps)
-                        pfmri = fmri.PkgFmri(pfmri, None)
-                        fpath = self.repo.manifest(pfmri,
-                            pub=self._get_req_pub())
-                except (IndexError, fmri.FmriError) as e:
-                        raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
-                except srepo.RepositoryError as e:
-                        # Treat any remaining repository error as a 404, but
-                        # log the error and include the real failure
-                        # information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-
-                # NASTY
-                # Stash manifest entry for later use.
-                # Toss out the list if it's larger than 1024 items.
-                if len(self.requested_manifests) > 1024:
-                        self.requested_manifests = [fpath]
-                else:
-                        self.requested_manifests.append(fpath)
-
-                # NASTY
-                # Send the wrong manifest
-                if self.need_nasty_3():
-                        cherrypy.log("NASTY manifest_0: serve wrong mfst")
-                        badpath = random.choice(self.requested_manifests)
-                        return serve_file(badpath, "text/plain; charset=utf-8")
-
-                # NASTY
-                # Call a misbehaving serve_file
-                return self.nasty_serve_file(fpath, "text/plain; charset=utf-8")
-
-        manifest_0._cp_config = {
-            "response.stream": True,
-            "tools.nasty_before.maxroll": 200
+        # Set up a list of errors that we can pick from when we
+        # want to return an error at random to the client.  Errors
+        # are weighted by how often we want them to happen; the loop
+        # below then puts them into a pick-list.
+        errors = {
+            http_client.REQUEST_TIMEOUT: 10,
+            http_client.BAD_GATEWAY: 10,
+            http_client.GATEWAY_TIMEOUT: 10,
+            http_client.FORBIDDEN: 2,
+            http_client.NOT_FOUND: 2,
+            http_client.BAD_REQUEST: 2,
         }
 
-        def __get_bad_path(self, v):
-                fpath = self.repo.file(v, pub=self._get_req_pub())
-                return os.path.join(os.path.dirname(fpath), fpath)
+        self.errlist = []
+        for x, n in six.iteritems(errors):
+            for i in range(0, n):
+                self.errlist.append(x)
+        cherrypy.log("NASTY Depot Error List: {0}".format(str(self.errlist)))
 
-        def file_0(self, *tokens):
-                """Outputs the contents of the file, named by the SHA-1 hash
-                name in the request path, directly to the client."""
+    def nasty_housekeeping(self):
+        # Generate a sine wave (well, half of one) which is NASTY_CYCLE
+        # steps long and use that to increase maxroll (thus reducing
+        # the nastiness).  The causes nastiness to come and go in
+        # waves, which helps to prevent excessive nastiness from
+        # impeding all progress.
+        #
+        # The intention is for this to get adjusted once per request.
 
-                try:
-                        fhash = tokens[0]
-                except IndexError:
-                        fhash = None
+        # Prevent races updating global nastiness information.
+        # Note that this isn't strictly necessary since nasty_cycle
+        # and maxroll_adj are just numbers and races are essentially
+        # harmless, but this is here so that we don't screw things up
+        # in the future.
+        self._lock.acquire()
 
-                try:
-                        fpath = self.repo.file(fhash, pub=self._get_req_pub())
-                except srepo.RepositoryFileNotFoundError as e:
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
-                except srepo.RepositoryError as e:
-                        # Treat any remaining repository error as a 404, but
-                        # log the error and include the real failure
-                        # information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+        self.nasty_cycle = (self.nasty_cycle + 1) % self.NASTY_CYCLE
+        # old-division; pylint: disable=W1619
+        self.maxroll_adj = 1 + self.NASTY_MULTIPLIER * math.sin(
+            self.nasty_cycle * (math.pi / self.NASTY_CYCLE)
+        )
+        if self.nasty_cycle == 0:
+            cherrypy.log("NASTY nastiness at min")
+        if self.nasty_cycle == self.NASTY_CYCLE // 2:
+            cherrypy.log("NASTY nastiness at max")
 
-                # NASTY
-                # Stash filename for later use.
-                # Toss out the list if it's larger than 1024 items.
-                if len(self.requested_files) > 1024:
-                        self.requested_files = [fhash]
-                else:
-                        self.requested_files.append(fhash)
+        self._lock.release()
 
-                # NASTY
-                if self.need_nasty_4():
-                        # Forget that the file is here
-                        cherrypy.log("NASTY file_0: 404 NOT_FOUND")
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND)
+    def need_nasty(self, maxroll=100):
+        """Randomly returns true when the server should misbehave."""
 
-                # NASTY
-                # Send the wrong file
-                if self.need_nasty_4():
-                        cherrypy.log("NASTY file_0: serve wrong file")
-                        badfn = random.choice(self.requested_files)
-                        badpath = self.__get_bad_path(badfn)
+        # Apply the sine wave adjustment to maxroll-- preserving the
+        # possiblity that bad things can still sporadically happen.
+        # n.b. we don't bother to pick up the lock here.
+        maxroll = int(maxroll * self.maxroll_adj)
 
-                        return serve_file(badpath, "application/data")
+        roll = random.randint(1, maxroll)
+        if roll <= self.nasty_level:
+            return True
+        return False
 
-                # NASTY
-                # Call a misbehaving serve_file
-                return self.nasty_serve_file(fpath, "application/data")
+    def need_nasty_2(self):
+        """Nastiness sometimes."""
+        return self.need_nasty(maxroll=500)
 
-        file_0._cp_config = { "response.stream": True }
+    def need_nasty_3(self):
+        """Nastiness less often."""
+        return self.need_nasty(maxroll=2000)
 
-        # file_1 degenerates to calling file_0 except when publishing, so
-        # there's no need to touch it here.
+    def need_nasty_4(self):
+        """Nastiness very rarely."""
+        return self.need_nasty(maxroll=20000)
 
-        def catalog_1(self, *tokens):
-                """Outputs the contents of the specified catalog file, using the
-                name in the request path, directly to the client."""
+    def nasty_raise_error(self):
+        """Raise an http error from self.errlist."""
+        code = random.choice(self.errlist)
+        cherrypy.log("NASTY: Random HTTP error: {0:d}".format(code))
+        raise cherrypy.HTTPError(code)
 
-                try:
-                        name = tokens[0]
-                except IndexError:
-                        raise cherrypy.HTTPError(http_client.FORBIDDEN,
-                            _("Directory listing not allowed."))
+    def nasty_nap(self):
+        """Sleep for a few seconds."""
+        cherrypy.log("NASTY: sleep for {0:d} secs".format(self.nasty_sleep))
+        time.sleep(self.nasty_sleep)
 
-                try:
-                        fpath = self.repo.catalog_1(name,
-                            pub=self._get_req_pub())
-                except srepo.RepositoryError as e:
-                        # Treat any remaining repository error as a 404, but
-                        # log the error and include the real failure
-                        # information.
-                        cherrypy.log("Request failed: {0}".format(str(e)))
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+    @cherrypy.expose
+    def nasty(self, *tokens):
+        try:
+            nasty_level = int(tokens[0])
+        except (IndexError, ValueError):
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST)
+        if nasty_level < 0 or nasty_level > 100:
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST)
+        cherrypy.log(
+            "Nastiness set to {0:d} by client request".format(nasty_level)
+        )
+        self.nasty_level = nasty_level
 
-                # NASTY
-                # Stash catalog entry for later use.
-                # Toss out the list if it's larger than 1024 items.
-                if len(self.requested_catalogs) > 1024:
-                        self.requested_catalogs = [fpath]
-                else:
-                        self.requested_catalogs.append(fpath)
+    # Disable the before handler for this request.
+    nasty._cp_config = {"tools.nasty_before.on": False}
 
-                # NASTY
-                # Send the wrong catalog
-                if self.need_nasty_3():
-                        cherrypy.log("NASTY catalog_1: wrong catalog file")
-                        badpath = random.choice(self.requested_catalogs)
-                        return serve_file(badpath, "text/plain; charset=utf-8")
+    @cherrypy.tools.response_headers(
+        headers=[("Content-Type", "text/plain; charset=utf-8")]
+    )
+    def versions_0(self, *tokens):
+        """Output a text/plain list of valid operations, and their
+        versions, supported by the repository."""
 
-                # NASTY
-                return self.nasty_serve_file(fpath, "text/plain; charset=utf-8")
+        # NASTY
+        # emit an X-Ipkg-Error HTTP unauthorized response.
+        if self.need_nasty_3():
+            cherrypy.log("NASTY versions_0: X-Ipkg-Error")
+            response = cherrypy.response
+            response.status = http_client.UNAUTHORIZED
+            response.headers["X-Ipkg-Error"] = random.choice(
+                ["ENT", "LIC", "SVR", "MNT", "YYZ", ""]
+            )
+            return ""
 
-        catalog_1._cp_config = {
-            "response.stream": True,
-            "tools.nasty_before.maxroll": 200
-        }
+        # NASTY
+        # Serve up versions header but no versions
+        if self.need_nasty_3():
+            cherrypy.log("NASTY versions_0: header but no versions")
+            versions = "pkg-server {0}\n".format(pkg.VERSION)
+            return versions
 
-        def search_1(self, *args, **params):
-                # Raise assorted errors; if not, call superclass search_1.
-                if self.need_nasty():
-                        errs = [http_client.NOT_FOUND, http_client.BAD_REQUEST,
-                            http_client.SERVICE_UNAVAILABLE]
-                        code = random.choice(errs)
-                        cherrypy.log("NASTY search_1: HTTP {0:d}".format(code))
-                        raise cherrypy.HTTPError(code)
+        # NASTY
+        # Serve up bogus versions by adding/subtracting from
+        # the actual version numbers-- we use a normal distribution
+        # to keep the perturbations small.
+        if self.need_nasty_2():
+            cherrypy.log("NASTY versions_0: modified version #s")
+            versions = "pkg-server {0}-nasty\n".format(pkg.VERSION)
+            for op, vers in six.iteritems(self.vops):
+                versions += op + " "
+                verlen = len(vers)
+                for v in vers:
+                    # if there are multiple versions,
+                    # then sometimes leave one out
+                    if verlen > 1 and random.randint(0, 10) <= 1:
+                        cherrypy.log(
+                            "NASTY versions_0: " "dropped {0}/{1}".format(op, v)
+                        )
+                        verlen -= 1
+                        continue
+                    # Periodically increment or
+                    # decrement the version.
+                    oldv = v
+                    v = int(v + random.normalvariate(0, 0.8))
+                    versions += str(v) + " "
+                    if v != oldv:
+                        cherrypy.log(
+                            "NASTY versions_0: "
+                            "Altered {0}/{1} -> {2}/{3:d}".format(
+                                op, oldv, op, v
+                            )
+                        )
+                versions += "\n"
+            return versions
 
-                return DepotHTTP.search_1(self, *args, **params)
+        versions = "pkg-server {0}\n".format(pkg.VERSION)
+        versions += (
+            "\n".join(
+                "{0} {1}".format(op, " ".join(str(v) for v in vers))
+                for op, vers in six.iteritems(self.vops)
+            )
+            + "\n"
+        )
+        return versions
 
-        def nasty_serve_file(self, filepath, content_type):
-                """A method that imitates the functionality of serve_file(),
-                but behaves in a nasty manner."""
+    # Fire the before handler less often for versions/0; when it
+    # fails everything else comes to a halt.
+    versions_0._cp_config = {"tools.nasty_before.maxroll": 200}
 
-                already_nasty = False
+    # Override _cp_config for catalog_0 operation
+    def catalog_0(self, *tokens):
+        """Provide a full version of the catalog, as appropriate, to
+        the requesting client.  Incremental catalogs are not supported
+        for v0 catalog clients."""
 
-                response = cherrypy.response
-                response.headers["Content-Type"] = content_type
-                try:
-                        fst = os.stat(filepath)
-                        filesz = fst.st_size
-                        nfile = open(filepath, "rb")
-                except EnvironmentError:
-                        raise cherrypy.HTTPError(http_client.NOT_FOUND)
+        # We always raise BAD_REQUEST here because v0 catalogs
+        # are toxic to clients who are facing a nasty antagonist--
+        # the client has no way to verify that the content, and
+        # things go badly off the rails.
+        raise cherrypy.HTTPError(http_client.BAD_REQUEST)
 
-                # NASTY
-                # Send incorrect content length
-                if self.need_nasty_4():
-                        response.headers["Content-Length"] = str(filesz +
-                                random.randint(1, 1024))
-                        already_nasty = True
-                else:
-                        response.headers["Content-Length"] = str(filesz)
+    catalog_0._cp_config = {
+        "response.stream": True,
+        #
+        # We disable the nasty_before for catalog 0 because clients
+        # who receive a 0 length response for a catalog_0 see that
+        # as a valid but empty catalog.  This causes many issues when
+        # trying to write tests against the nasty depot.  catalog_0
+        # is going away imminently so we don't really care.
+        #
+        "tools.nasty_before.on": False,
+    }
 
-                if already_nasty:
-                        response.body = nfile.read(filesz)
-                elif self.need_nasty_3():
-                        # NASTY
-                        # Send truncated file
-                        cherrypy.log("NASTY serve_file: truncated file")
-                        response.body = nfile.read(filesz - random.randint(1,
-                            filesz - 1))
-                        # If we're sending data, lie about the length and
-                        # make the client catch us.
-                        if content_type == "application/data":
-                                response.headers["Content-Length"] = str(
-                                    len(response.body))
-                elif self.need_nasty_3():
-                        # NASTY
-                        # Write garbage into the response
-                        cherrypy.log("NASTY serve_file: prepend garbage")
-                        response.body = "NASTY!"
-                        response.body += nfile.read(filesz)
-                        # If we're sending data, lie about the length and
-                        # make the client catch us.
-                        if content_type == "application/data":
-                                response.headers["Content-Length"] = str(
-                                    len(response.body))
-                elif self.need_nasty_3():
-                        # NASTY
-                        # overwrite some garbage into the response, without
-                        # changing the length.
-                        cherrypy.log("NASTY serve_file: flip bits")
-                        body = nfile.read(filesz)
-                        # pick a low number of bytes to corrupt
-                        ncorrupt = 1 + int(abs(random.gauss(0, 1)))
-                        for x in range(0, ncorrupt):
-                                p = random.randint(0, max(0, filesz - 1))
-                                char = ord(body[p])
-                                # pick a bit to flip; favor low numbers, must
-                                # also cap at bit #7.
-                                bit = min(7, int(abs(random.gauss(0, 3))))
-                                # flip it
-                                char ^= (1 << bit)
-                                body = body[:p] + chr(char) + body[p + 1:]
-                        response.body = body
-                else:
-                        response.body = nfile.read(filesz)
+    def manifest_0(self, *tokens):
+        """The request is an encoded pkg FMRI.  If the version is
+        specified incompletely, we return an error, as the client is
+        expected to form correct requests based on its interpretation
+        of the catalog and its image policies."""
 
-                return response.body
+        try:
+            pubs = self.repo.publishers
+        except Exception as e:
+            cherrypy.log("Request failed: {0}".format(e))
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+
+        # A broken proxy (or client) has caused a fully-qualified FMRI
+        # to be split up.
+        comps = [t for t in tokens]
+        if not comps:
+            raise cherrypy.HTTPError(
+                http_client.FORBIDDEN, _("Directory listing not allowed.")
+            )
+
+        if len(comps) > 1 and comps[0] == "pkg:" and comps[1] in pubs:
+            # Only one slash here as another will be added below.
+            comps[0] += "/"
+
+        # Parse request into FMRI component and decode.
+        try:
+            # If more than one token (request path component) was
+            # specified, assume that the extra components are part
+            # of the fmri and have been split out because of bad
+            # proxy behaviour.
+            pfmri = "/".join(comps)
+            pfmri = fmri.PkgFmri(pfmri, None)
+            fpath = self.repo.manifest(pfmri, pub=self._get_req_pub())
+        except (IndexError, fmri.FmriError) as e:
+            raise cherrypy.HTTPError(http_client.BAD_REQUEST, str(e))
+        except srepo.RepositoryError as e:
+            # Treat any remaining repository error as a 404, but
+            # log the error and include the real failure
+            # information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+
+        # NASTY
+        # Stash manifest entry for later use.
+        # Toss out the list if it's larger than 1024 items.
+        if len(self.requested_manifests) > 1024:
+            self.requested_manifests = [fpath]
+        else:
+            self.requested_manifests.append(fpath)
+
+        # NASTY
+        # Send the wrong manifest
+        if self.need_nasty_3():
+            cherrypy.log("NASTY manifest_0: serve wrong mfst")
+            badpath = random.choice(self.requested_manifests)
+            return serve_file(badpath, "text/plain; charset=utf-8")
+
+        # NASTY
+        # Call a misbehaving serve_file
+        return self.nasty_serve_file(fpath, "text/plain; charset=utf-8")
+
+    manifest_0._cp_config = {
+        "response.stream": True,
+        "tools.nasty_before.maxroll": 200,
+    }
+
+    def __get_bad_path(self, v):
+        fpath = self.repo.file(v, pub=self._get_req_pub())
+        return os.path.join(os.path.dirname(fpath), fpath)
+
+    def file_0(self, *tokens):
+        """Outputs the contents of the file, named by the SHA-1 hash
+        name in the request path, directly to the client."""
+
+        try:
+            fhash = tokens[0]
+        except IndexError:
+            fhash = None
+
+        try:
+            fpath = self.repo.file(fhash, pub=self._get_req_pub())
+        except srepo.RepositoryFileNotFoundError as e:
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+        except srepo.RepositoryError as e:
+            # Treat any remaining repository error as a 404, but
+            # log the error and include the real failure
+            # information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+
+        # NASTY
+        # Stash filename for later use.
+        # Toss out the list if it's larger than 1024 items.
+        if len(self.requested_files) > 1024:
+            self.requested_files = [fhash]
+        else:
+            self.requested_files.append(fhash)
+
+        # NASTY
+        if self.need_nasty_4():
+            # Forget that the file is here
+            cherrypy.log("NASTY file_0: 404 NOT_FOUND")
+            raise cherrypy.HTTPError(http_client.NOT_FOUND)
+
+        # NASTY
+        # Send the wrong file
+        if self.need_nasty_4():
+            cherrypy.log("NASTY file_0: serve wrong file")
+            badfn = random.choice(self.requested_files)
+            badpath = self.__get_bad_path(badfn)
+
+            return serve_file(badpath, "application/data")
+
+        # NASTY
+        # Call a misbehaving serve_file
+        return self.nasty_serve_file(fpath, "application/data")
+
+    file_0._cp_config = {"response.stream": True}
+
+    # file_1 degenerates to calling file_0 except when publishing, so
+    # there's no need to touch it here.
+
+    def catalog_1(self, *tokens):
+        """Outputs the contents of the specified catalog file, using the
+        name in the request path, directly to the client."""
+
+        try:
+            name = tokens[0]
+        except IndexError:
+            raise cherrypy.HTTPError(
+                http_client.FORBIDDEN, _("Directory listing not allowed.")
+            )
+
+        try:
+            fpath = self.repo.catalog_1(name, pub=self._get_req_pub())
+        except srepo.RepositoryError as e:
+            # Treat any remaining repository error as a 404, but
+            # log the error and include the real failure
+            # information.
+            cherrypy.log("Request failed: {0}".format(str(e)))
+            raise cherrypy.HTTPError(http_client.NOT_FOUND, str(e))
+
+        # NASTY
+        # Stash catalog entry for later use.
+        # Toss out the list if it's larger than 1024 items.
+        if len(self.requested_catalogs) > 1024:
+            self.requested_catalogs = [fpath]
+        else:
+            self.requested_catalogs.append(fpath)
+
+        # NASTY
+        # Send the wrong catalog
+        if self.need_nasty_3():
+            cherrypy.log("NASTY catalog_1: wrong catalog file")
+            badpath = random.choice(self.requested_catalogs)
+            return serve_file(badpath, "text/plain; charset=utf-8")
+
+        # NASTY
+        return self.nasty_serve_file(fpath, "text/plain; charset=utf-8")
+
+    catalog_1._cp_config = {
+        "response.stream": True,
+        "tools.nasty_before.maxroll": 200,
+    }
+
+    def search_1(self, *args, **params):
+        # Raise assorted errors; if not, call superclass search_1.
+        if self.need_nasty():
+            errs = [
+                http_client.NOT_FOUND,
+                http_client.BAD_REQUEST,
+                http_client.SERVICE_UNAVAILABLE,
+            ]
+            code = random.choice(errs)
+            cherrypy.log("NASTY search_1: HTTP {0:d}".format(code))
+            raise cherrypy.HTTPError(code)
+
+        return DepotHTTP.search_1(self, *args, **params)
+
+    def nasty_serve_file(self, filepath, content_type):
+        """A method that imitates the functionality of serve_file(),
+        but behaves in a nasty manner."""
+
+        already_nasty = False
+
+        response = cherrypy.response
+        response.headers["Content-Type"] = content_type
+        try:
+            fst = os.stat(filepath)
+            filesz = fst.st_size
+            nfile = open(filepath, "rb")
+        except EnvironmentError:
+            raise cherrypy.HTTPError(http_client.NOT_FOUND)
+
+        # NASTY
+        # Send incorrect content length
+        if self.need_nasty_4():
+            response.headers["Content-Length"] = str(
+                filesz + random.randint(1, 1024)
+            )
+            already_nasty = True
+        else:
+            response.headers["Content-Length"] = str(filesz)
+
+        if already_nasty:
+            response.body = nfile.read(filesz)
+        elif self.need_nasty_3():
+            # NASTY
+            # Send truncated file
+            cherrypy.log("NASTY serve_file: truncated file")
+            response.body = nfile.read(filesz - random.randint(1, filesz - 1))
+            # If we're sending data, lie about the length and
+            # make the client catch us.
+            if content_type == "application/data":
+                response.headers["Content-Length"] = str(len(response.body))
+        elif self.need_nasty_3():
+            # NASTY
+            # Write garbage into the response
+            cherrypy.log("NASTY serve_file: prepend garbage")
+            response.body = "NASTY!"
+            response.body += nfile.read(filesz)
+            # If we're sending data, lie about the length and
+            # make the client catch us.
+            if content_type == "application/data":
+                response.headers["Content-Length"] = str(len(response.body))
+        elif self.need_nasty_3():
+            # NASTY
+            # overwrite some garbage into the response, without
+            # changing the length.
+            cherrypy.log("NASTY serve_file: flip bits")
+            body = nfile.read(filesz)
+            # pick a low number of bytes to corrupt
+            ncorrupt = 1 + int(abs(random.gauss(0, 1)))
+            for x in range(0, ncorrupt):
+                p = random.randint(0, max(0, filesz - 1))
+                char = ord(body[p])
+                # pick a bit to flip; favor low numbers, must
+                # also cap at bit #7.
+                bit = min(7, int(abs(random.gauss(0, 3))))
+                # flip it
+                char ^= 1 << bit
+                body = body[:p] + chr(char) + body[p + 1 :]
+            response.body = body
+        else:
+            response.body = nfile.read(filesz)
+
+        return response.body
 
 
 class DNSSD_Plugin(SimplePlugin):
-        """Allow a depot to configure DNS-SD through mDNS."""
+    """Allow a depot to configure DNS-SD through mDNS."""
 
-        def __init__(self, bus, gconf):
-                """Bus is the cherrypy engine and gconf is a dictionary
-                containing the CherryPy configuration.
-                """
+    def __init__(self, bus, gconf):
+        """Bus is the cherrypy engine and gconf is a dictionary
+        containing the CherryPy configuration.
+        """
 
-                SimplePlugin.__init__(self, bus)
+        SimplePlugin.__init__(self, bus)
 
-                if "pybonjour" not in globals():
-                        self.start = lambda: None
-                        self.exit = lambda: None
-                        return
+        if "pybonjour" not in globals():
+            self.start = lambda: None
+            self.exit = lambda: None
+            return
 
-                self.name = "pkg(7) mirror on {0}".format(socket.gethostname())
-                self.wanted_name = self.name
-                self.regtype = "_pkg5._tcp"
-                self.port = gconf["server.socket_port"]
-                self.sd_hdl = None
-                self.reg_ok = False
+        self.name = "pkg(7) mirror on {0}".format(socket.gethostname())
+        self.wanted_name = self.name
+        self.regtype = "_pkg5._tcp"
+        self.port = gconf["server.socket_port"]
+        self.sd_hdl = None
+        self.reg_ok = False
 
-                if gconf["server.ssl_certificate"] and \
-                    gconf["server.ssl_private_key"]:
-                        proto = "https"
+        if gconf["server.ssl_certificate"] and gconf["server.ssl_private_key"]:
+            proto = "https"
+        else:
+            proto = "http"
+
+        netloc = "{0}:{1}".format(socket.getfqdn(), self.port)
+        self.url = urlunsplit((proto, netloc, "", "", ""))
+
+    def reg_cb(self, sd_hdl, flags, error_code, name, regtype, domain):
+        """Callback invoked by service register function.  Arguments
+        are determined by the pybonjour framework, and must not
+        be changed.
+        """
+
+        if error_code != pybonjour.kDNSServiceErr_NoError:
+            self.bus.log(
+                "Error in DNS-SD registration: {0}".format(
+                    pybonjour.BonjourError(error_code)
+                )
+            )
+
+        self.reg_ok = True
+        self.name = name
+        if self.name != self.wanted_name:
+            self.bus.log(
+                "DNS-SD service name changed to: {0}".format(self.name)
+            )
+
+    def start(self):
+        self.bus.log("Starting DNS-SD registration.")
+
+        txt_r = pybonjour.TXTRecord()
+        txt_r["url"] = self.url
+        txt_r["type"] = "mirror"
+
+        to_val = 10
+        timedout = False
+
+        try:
+            self.sd_hdl = pybonjour.DNSServiceRegister(
+                name=self.name,
+                regtype=self.regtype,
+                port=self.port,
+                txtRecord=txt_r,
+                callBack=self.reg_cb,
+            )
+        except pybonjour.BonjourError as e:
+            self.bus.log("DNS-SD service registration failed: {0}".format(e))
+            return
+
+        try:
+            while not timedout:
+                avail = select.select([self.sd_hdl], [], [], to_val)
+                if self.sd_hdl in avail[0]:
+                    pybonjour.DNSServiceProcessResult(self.sd_hdl)
+                    to_val = 0
                 else:
-                        proto = "http"
+                    timedout = True
+        except pybonjour.BonjourError as e:
+            self.bus.log("DNS-SD service registration failed: {0}".format(e))
 
-                netloc = "{0}:{1}".format(socket.getfqdn(), self.port)
-                self.url = urlunsplit((proto, netloc, '', '', ''))
+        if not self.reg_ok:
+            self.bus.log("DNS-SD registration timed out.")
+            return
+        self.bus.log("Finished DNS-SD registration.")
 
-        def reg_cb(self, sd_hdl, flags, error_code, name, regtype, domain):
-                """Callback invoked by service register function.  Arguments
-                are determined by the pybonjour framework, and must not
-                be changed.
-                """
-
-                if error_code != pybonjour.kDNSServiceErr_NoError:
-                        self.bus.log("Error in DNS-SD registration: {0}".format(
-                            pybonjour.BonjourError(error_code)))
-
-                self.reg_ok = True
-                self.name = name
-                if self.name != self.wanted_name:
-                        self.bus.log("DNS-SD service name changed to: {0}".format(
-                            self.name))
-
-        def start(self):
-                self.bus.log("Starting DNS-SD registration.")
-
-                txt_r = pybonjour.TXTRecord()
-                txt_r["url"] = self.url
-                txt_r["type"] = "mirror"
-
-                to_val = 10
-                timedout = False
-
-                try:
-                        self.sd_hdl = pybonjour.DNSServiceRegister(
-                            name=self.name, regtype=self.regtype,
-                            port=self.port, txtRecord=txt_r,
-                            callBack=self.reg_cb)
-                except pybonjour.BonjourError as e:
-                        self.bus.log("DNS-SD service registration failed: {0}".format(
-                            e))
-                        return
-
-                try:
-                        while not timedout:
-                                avail = select.select([self.sd_hdl], [], [],
-                                    to_val)
-                                if self.sd_hdl in avail[0]:
-                                        pybonjour.DNSServiceProcessResult(
-                                            self.sd_hdl)
-                                        to_val = 0
-                                else:
-                                        timedout = True
-                except pybonjour.BonjourError as e:
-                        self.bus.log("DNS-SD service registration failed: {0}".format(
-                            e))
-
-                if not self.reg_ok:
-                        self.bus.log("DNS-SD registration timed out.")
-                        return
-                self.bus.log("Finished DNS-SD registration.")
-
-        def exit(self):
-                self.bus.log("DNS-SD plugin exited")
-                if self.sd_hdl:
-                        self.sd_hdl.close()
-                self.sd_hdl = None
-                self.bus.log("Service unregistration for DNS-SD complete.")
+    def exit(self):
+        self.bus.log("DNS-SD plugin exited")
+        if self.sd_hdl:
+            self.sd_hdl.close()
+        self.sd_hdl = None
+        self.bus.log("Service unregistration for DNS-SD complete.")
 
 
 class BackgroundTaskPlugin(SimplePlugin):
-        """This class allows background task execution for the depot server.  It
-        is designed in such a way as to only allow a few tasks to be queued
-        for execution at a time.
+    """This class allows background task execution for the depot server.  It
+    is designed in such a way as to only allow a few tasks to be queued
+    for execution at a time.
+    """
+
+    def __init__(self, bus):
+        # Setup the background task queue.
+        SimplePlugin.__init__(self, bus)
+        self.__q = queue.Queue(10)
+        self.__thread = None
+
+    def put(self, task, *args, **kwargs):
+        """Schedule the given task for background execution if queue
+        isn't full.
         """
+        if self.__q.unfinished_tasks > 9:
+            raise queue.Full()
+        self.__q.put_nowait((task, args, kwargs))
 
-        def __init__(self, bus):
-                # Setup the background task queue.
-                SimplePlugin.__init__(self, bus)
-                self.__q = queue.Queue(10)
-                self.__thread = None
+    def run(self):
+        """Run any background task scheduled for execution."""
+        while self.__running:
+            try:
+                try:
+                    # A brief timeout here is necessary
+                    # to reduce CPU usage and to ensure
+                    # that shutdown doesn't wait forever
+                    # for a new task to appear.
+                    task, args, kwargs = self.__q.get(timeout=0.5)
+                except queue.Empty:
+                    continue
+                task(*args, **kwargs)
+                if hasattr(self.__q, "task_done"):
+                    # Task is done; mark it so.
+                    self.__q.task_done()
+            except:
+                self.bus.log(
+                    "Failure encountered executing "
+                    "background task {0!r}.".format(self),
+                    traceback=True,
+                )
 
-        def put(self, task, *args, **kwargs):
-                """Schedule the given task for background execution if queue
-                isn't full.
-                """
-                if self.__q.unfinished_tasks > 9:
-                        raise queue.Full()
-                self.__q.put_nowait((task, args, kwargs))
+    def start(self):
+        """Start the background task plugin."""
+        self.__running = True
+        if not self.__thread:
+            # Create and start a thread for the caller.
+            self.__thread = threading.Thread(target=self.run)
+            self.__thread.start()
 
-        def run(self):
-                """Run any background task scheduled for execution."""
-                while self.__running:
-                        try:
-                                try:
-                                        # A brief timeout here is necessary
-                                        # to reduce CPU usage and to ensure
-                                        # that shutdown doesn't wait forever
-                                        # for a new task to appear.
-                                        task, args, kwargs = \
-                                            self.__q.get(timeout=.5)
-                                except queue.Empty:
-                                        continue
-                                task(*args, **kwargs)
-                                if hasattr(self.__q, "task_done"):
-                                        # Task is done; mark it so.
-                                        self.__q.task_done()
-                        except:
-                                self.bus.log("Failure encountered executing "
-                                    "background task {0!r}.".format(self),
-                                    traceback=True)
+    # Priority must be higher than the Daemonizer plugin to avoid threads
+    # starting before fork().  Daemonizer has a priority of 65, as noted
+    # at this URI: http://www.cherrypy.org/wiki/BuiltinPlugins
+    start.priority = 66
 
-        def start(self):
-                """Start the background task plugin."""
-                self.__running = True
-                if not self.__thread:
-                        # Create and start a thread for the caller.
-                        self.__thread = threading.Thread(target=self.run)
-                        self.__thread.start()
-        # Priority must be higher than the Daemonizer plugin to avoid threads
-        # starting before fork().  Daemonizer has a priority of 65, as noted
-        # at this URI: http://www.cherrypy.org/wiki/BuiltinPlugins
-        start.priority = 66
-
-        def stop(self):
-                """Stop the background task plugin."""
-                self.__running = False
-                if self.__thread:
-                        # Wait for the thread to terminate.
-                        self.__thread.join()
-                        self.__thread = None
+    def stop(self):
+        """Stop the background task plugin."""
+        self.__running = False
+        if self.__thread:
+            # Wait for the thread to terminate.
+            self.__thread.join()
+            self.__thread = None
 
 
 class DepotConfig(object):
-        """Returns an object representing a configuration interface for a
-        a pkg(7) depot server.
+    """Returns an object representing a configuration interface for a
+    a pkg(7) depot server.
 
-        The class of the object returned will depend upon the specified
-        configuration target (which is used as to retrieve and store
-        configuration data).
+    The class of the object returned will depend upon the specified
+    configuration target (which is used as to retrieve and store
+    configuration data).
 
-        'target' is the optional location to retrieve existing configuration
-        data or store the configuration data when requested.  The location
-        can be None, the pathname of a file, or an SMF FMRI.  If a pathname is
-        provided, and does not exist, it will be created if needed.
+    'target' is the optional location to retrieve existing configuration
+    data or store the configuration data when requested.  The location
+    can be None, the pathname of a file, or an SMF FMRI.  If a pathname is
+    provided, and does not exist, it will be created if needed.
 
-        'overrides' is a dictionary of property values indexed by section name
-        and property name.  If provided, it will override any values read from
-        an existing file or any defaults initially assigned.
+    'overrides' is a dictionary of property values indexed by section name
+    and property name.  If provided, it will override any values read from
+    an existing file or any defaults initially assigned.
 
-        'version' is an integer value specifying the set of configuration data
-        to use for the operation.  If not provided, the version will be based
-        on the target if supported.  If a version cannot be determined, the
-        newest version will be assumed.
-        """
+    'version' is an integer value specifying the set of configuration data
+    to use for the operation.  If not provided, the version will be based
+    on the target if supported.  If a version cannot be determined, the
+    newest version will be assumed.
+    """
 
-        # This dictionary defines the set of default properties and property
-        # groups for a depot configuration indexed by version.
-        __defs = {
-            4: [
-                cfg.PropertySection("pkg", [
+    # This dictionary defines the set of default properties and property
+    # groups for a depot configuration indexed by version.
+    __defs = {
+        4: [
+            cfg.PropertySection(
+                "pkg",
+                [
                     cfg.PropList("address"),
                     cfg.PropDefined("cfg_file", allowed=["", "<pathname>"]),
                     cfg.Property("content_root"),
-                    cfg.PropList("debug", allowed=["", "headers",
-                        "hash=sha256", "hash=sha1+sha256", "hash=sha512t_256",
-                        "hash=sha1+sha512t_256"]),
+                    cfg.PropList(
+                        "debug",
+                        allowed=[
+                            "",
+                            "headers",
+                            "hash=sha256",
+                            "hash=sha1+sha256",
+                            "hash=sha512t_256",
+                            "hash=sha1+sha512t_256",
+                        ],
+                    ),
                     cfg.PropList("disable_ops"),
-                    cfg.PropDefined("image_root", allowed=["",
-                        "<abspathname>"]),
+                    cfg.PropDefined(
+                        "image_root", allowed=["", "<abspathname>"]
+                    ),
                     cfg.PropDefined("inst_root", allowed=["", "<pathname>"]),
                     cfg.PropBool("ll_mirror"),
-                    cfg.PropDefined("log_access", allowed=["", "stderr",
-                        "stdout", "none", "<pathname>"]),
-                    cfg.PropDefined("log_errors", allowed=["", "stderr",
-                        "stdout", "none", "<pathname>"], default="stderr"),
+                    cfg.PropDefined(
+                        "log_access",
+                        allowed=["", "stderr", "stdout", "none", "<pathname>"],
+                    ),
+                    cfg.PropDefined(
+                        "log_errors",
+                        allowed=["", "stderr", "stdout", "none", "<pathname>"],
+                        default="stderr",
+                    ),
                     cfg.PropBool("mirror"),
-                    cfg.PropDefined("pkg_root", allowed=["/", "<abspathname>"],
-                        default="/"),
+                    cfg.PropDefined(
+                        "pkg_root", allowed=["/", "<abspathname>"], default="/"
+                    ),
                     cfg.PropInt("port"),
                     cfg.PropPubURI("proxy_base"),
                     cfg.PropBool("readonly"),
                     cfg.PropInt("socket_timeout"),
-                    cfg.PropInt("sort_file_max_size",
+                    cfg.PropInt(
+                        "sort_file_max_size",
                         default=indexer.SORT_FILE_MAX_SIZE,
-                        value_map={ "": indexer.SORT_FILE_MAX_SIZE }),
-                    cfg.PropDefined("ssl_cert_file",
-                        allowed=["", "<pathname>", "none"]),
-                    cfg.PropDefined("ssl_dialog", allowed=["<exec:pathname>",
-                        "builtin", "smf", "<smf:fmri>"], default="builtin"),
-                    cfg.PropDefined("ssl_key_file",
-                        allowed=["", "<pathname>", "none"]),
+                        value_map={"": indexer.SORT_FILE_MAX_SIZE},
+                    ),
+                    cfg.PropDefined(
+                        "ssl_cert_file", allowed=["", "<pathname>", "none"]
+                    ),
+                    cfg.PropDefined(
+                        "ssl_dialog",
+                        allowed=[
+                            "<exec:pathname>",
+                            "builtin",
+                            "smf",
+                            "<smf:fmri>",
+                        ],
+                        default="builtin",
+                    ),
+                    cfg.PropDefined(
+                        "ssl_key_file", allowed=["", "<pathname>", "none"]
+                    ),
                     cfg.PropInt("threads"),
-                    cfg.PropDefined("writable_root",
-                        allowed=["", "<pathname>"]),
-                ]),
-                cfg.PropertySection("pkg_bui", [
+                    cfg.PropDefined(
+                        "writable_root", allowed=["", "<pathname>"]
+                    ),
+                ],
+            ),
+            cfg.PropertySection(
+                "pkg_bui",
+                [
                     cfg.PropDefined("feed_description"),
-                    cfg.PropDefined("feed_icon",
-                        default="web/_themes/pkg-block-icon.png"),
-                    cfg.PropDefined("feed_logo",
-                        default="web/_themes/pkg-block-logo.png"),
-                    cfg.PropDefined("feed_name",
-                        default="package repository feed"),
-                    cfg.PropInt("feed_window", default=24)
-                ]),
-                cfg.PropertySection("pkg_secure", [
+                    cfg.PropDefined(
+                        "feed_icon", default="web/_themes/pkg-block-icon.png"
+                    ),
+                    cfg.PropDefined(
+                        "feed_logo", default="web/_themes/pkg-block-logo.png"
+                    ),
+                    cfg.PropDefined(
+                        "feed_name", default="package repository feed"
+                    ),
+                    cfg.PropInt("feed_window", default=24),
+                ],
+            ),
+            cfg.PropertySection(
+                "pkg_secure",
+                [
                     cfg.PropDefined("ssl_key_passphrase"),
-                ]),
-                cfg.PropertySection("nasty", [
+                ],
+            ),
+            cfg.PropertySection(
+                "nasty",
+                [
                     cfg.PropInt("nasty_level"),
-                    cfg.PropInt("nasty_sleep", default=35)
-                ]),
-            ],
-        }
+                    cfg.PropInt("nasty_sleep", default=35),
+                ],
+            ),
+        ],
+    }
 
-        def __new__(cls, target=None, overrides=misc.EmptyDict, version=None):
-                if not target:
-                        return cfg.Config(definitions=cls.__defs,
-                            overrides=overrides, version=version)
-                elif target.startswith("svc:"):
-                        return cfg.SMFConfig(target, definitions=cls.__defs,
-                            overrides=overrides, version=version)
-                return cfg.FileConfig(target, definitions=cls.__defs,
-                    overrides=overrides, version=version)
+    def __new__(cls, target=None, overrides=misc.EmptyDict, version=None):
+        if not target:
+            return cfg.Config(
+                definitions=cls.__defs, overrides=overrides, version=version
+            )
+        elif target.startswith("svc:"):
+            return cfg.SMFConfig(
+                target,
+                definitions=cls.__defs,
+                overrides=overrides,
+                version=version,
+            )
+        return cfg.FileConfig(
+            target, definitions=cls.__defs, overrides=overrides, version=version
+        )
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/server/face.py
+++ b/src/modules/server/face.py
@@ -41,116 +41,148 @@ import pkg.server.api_errors as sae
 import pkg.server.feed
 
 try:
-        import mako.exceptions
-        import mako.lookup
+    import mako.exceptions
+    import mako.lookup
 except ImportError:
-        # Can't actually perform a version check since Mako doesn't provide
-        # version information, but this is what should be used currently.
-        print("Mako 0.2.2 or greater is required to use this program.",
-            file=sys.stderr)
-        sys.exit(2)
+    # Can't actually perform a version check since Mako doesn't provide
+    # version information, but this is what should be used currently.
+    print(
+        "Mako 0.2.2 or greater is required to use this program.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 tlookup = None
+
+
 def init(depot):
-        """Ensure that the BUI is properly initialized."""
-        global tlookup
-        pkg.server.feed.init(depot)
-        tlookup = mako.lookup.TemplateLookup(directories=[depot.web_root])
+    """Ensure that the BUI is properly initialized."""
+    global tlookup
+    pkg.server.feed.init(depot)
+    tlookup = mako.lookup.TemplateLookup(directories=[depot.web_root])
+
 
 def feed(depot, request, response, pub):
-        if depot.repo.mirror:
-                raise cherrypy.HTTPError(http_client.NOT_FOUND,
-                    "Operation not supported in current server mode.")
-        if not depot.repo.get_catalog(pub).updates:
-                raise cherrypy.HTTPError(http_client.SERVICE_UNAVAILABLE,
-                    "No update history; unable to generate feed.")
-        return pkg.server.feed.handle(depot, request, response, pub)
+    if depot.repo.mirror:
+        raise cherrypy.HTTPError(
+            http_client.NOT_FOUND,
+            "Operation not supported in current server mode.",
+        )
+    if not depot.repo.get_catalog(pub).updates:
+        raise cherrypy.HTTPError(
+            http_client.SERVICE_UNAVAILABLE,
+            "No update history; unable to generate feed.",
+        )
+    return pkg.server.feed.handle(depot, request, response, pub)
+
 
 def __render_template(depot, request, path, pub, http_depot=None):
-        template = tlookup.get_template(path)
-        base = api.BaseInterface(request, depot, pub)
-        # Starting in CherryPy 3.2, cherrypy.response.body only allows
-        # bytes.
-        return misc.force_bytes(template.render(g_vars={ "base": base,
-            "pub": pub, "http_depot": http_depot}))
+    template = tlookup.get_template(path)
+    base = api.BaseInterface(request, depot, pub)
+    # Starting in CherryPy 3.2, cherrypy.response.body only allows
+    # bytes.
+    return misc.force_bytes(
+        template.render(
+            g_vars={"base": base, "pub": pub, "http_depot": http_depot}
+        )
+    )
+
 
 def __handle_error(path, error):
-        # All errors are treated as a 404 since reverse proxies such as Apache
-        # don't handle 500 errors in a desirable way.  For any error but a 404,
-        # an error is logged.
-        if error != http_client.NOT_FOUND:
-                cherrypy.log("Error encountered while processing "
-                    "template: {0}\n".format(path), traceback=True)
+    # All errors are treated as a 404 since reverse proxies such as Apache
+    # don't handle 500 errors in a desirable way.  For any error but a 404,
+    # an error is logged.
+    if error != http_client.NOT_FOUND:
+        cherrypy.log(
+            "Error encountered while processing "
+            "template: {0}\n".format(path),
+            traceback=True,
+        )
 
-        raise cherrypy.NotFound()
+    raise cherrypy.NotFound()
+
 
 def respond(depot, request, response, pub, http_depot=None):
-        """'http_depot' if set should be the resource that points to the top
-        level of repository being served (referred to as the repo_prefix in
-        depot_index.py)"""
-        path = request.path_info.strip("/")
-        if pub and os.path.exists(os.path.join(depot.web_root, pub)):
-                # If an item exists under the web root
-                # with this name, it isn't a publisher
-                # prefix.
-                pub = None
-        elif pub and pub not in depot.repo.publishers:
-                raise cherrypy.NotFound()
+    """'http_depot' if set should be the resource that points to the top
+    level of repository being served (referred to as the repo_prefix in
+    depot_index.py)"""
+    path = request.path_info.strip("/")
+    if pub and os.path.exists(os.path.join(depot.web_root, pub)):
+        # If an item exists under the web root
+        # with this name, it isn't a publisher
+        # prefix.
+        pub = None
+    elif pub and pub not in depot.repo.publishers:
+        raise cherrypy.NotFound()
 
-        if pub:
-                # Strip publisher from path as it can't be used to determine
-                # resource locations.
-                path = path.replace(pub, "").strip("/")
+    if pub:
+        # Strip publisher from path as it can't be used to determine
+        # resource locations.
+        path = path.replace(pub, "").strip("/")
+    else:
+        # No publisher specified in request, so assume default.
+        pub = depot.repo.cfg.get_property("publisher", "prefix")
+        if not pub:
+            pub = None
+
+    if path == "":
+        path = "index.shtml"
+    elif path.split("/")[0] == "feed":
+        response.headers.update(
+            {
+                "Expires": 0,
+                "Pragma": "no-cache",
+                "Cache-Control": "no-cache, no-transform, must-revalidate",
+            }
+        )
+        return feed(depot, request, response, pub)
+
+    if not path.endswith(".shtml"):
+        spath = unquote(path)
+        fname = os.path.join(depot.web_root, spath)
+        if not os.path.normpath(fname).startswith(
+            os.path.normpath(depot.web_root)
+        ):
+            # Ignore requests for files outside of the web root.
+            return __handle_error(path, http_client.NOT_FOUND)
         else:
-                # No publisher specified in request, so assume default.
-                pub = depot.repo.cfg.get_property("publisher", "prefix")
-                if not pub:
-                        pub = None
+            return cherrypy.lib.static.serve_file(
+                os.path.join(depot.web_root, spath)
+            )
 
-        if path == "":
-                path = "index.shtml"
-        elif path.split("/")[0] == "feed":
-                response.headers.update({ "Expires": 0, "Pragma": "no-cache",
-                    "Cache-Control": "no-cache, no-transform, must-revalidate"
-                    })
-                return feed(depot, request, response, pub)
+    try:
+        response.headers.update(
+            {
+                "Expires": 0,
+                "Pragma": "no-cache",
+                "Cache-Control": "no-cache, no-transform, must-revalidate",
+            }
+        )
+        return __render_template(depot, request, path, pub, http_depot)
+    except sae.VersionException as e:
+        # The user shouldn't see why we can't render a template, but
+        # the reason should be logged (cleanly).
+        cherrypy.log(
+            "Template '{path}' is incompatible with current "
+            "server api: {error}".format(path=path, error=str(e))
+        )
+        cherrypy.log(
+            "Ensure that the correct --content-root has been "
+            "provided to pkg.depotd."
+        )
+        return __handle_error(request.path_info, http_client.NOT_FOUND)
+    except IOError as e:
+        return __handle_error(path, http_client.INTERNAL_SERVER_ERROR)
+    except mako.exceptions.TemplateLookupException as e:
+        # The above exception indicates that mako could not locate the
+        # template (in most cases, Mako doesn't seem to always clearly
+        # differentiate).
+        return __handle_error(path, http_client.NOT_FOUND)
+    except sae.RedirectException as e:
+        raise cherrypy.HTTPRedirect(e.data)
+    except:
+        return __handle_error(path, http_client.INTERNAL_SERVER_ERROR)
 
-        if not path.endswith(".shtml"):
-                spath = unquote(path)
-                fname = os.path.join(depot.web_root, spath)
-                if not os.path.normpath(fname).startswith(
-                    os.path.normpath(depot.web_root)):
-                        # Ignore requests for files outside of the web root.
-                        return __handle_error(path, http_client.NOT_FOUND)
-                else:
-                        return cherrypy.lib.static.serve_file(os.path.join(
-                            depot.web_root, spath))
-
-        try:
-                response.headers.update({ "Expires": 0, "Pragma": "no-cache",
-                    "Cache-Control": "no-cache, no-transform, must-revalidate"
-                    })
-                return __render_template(depot, request, path, pub, http_depot)
-        except sae.VersionException as e:
-                # The user shouldn't see why we can't render a template, but
-                # the reason should be logged (cleanly).
-                cherrypy.log("Template '{path}' is incompatible with current "
-                    "server api: {error}".format(path=path,
-                    error=str(e)))
-                cherrypy.log("Ensure that the correct --content-root has been "
-                    "provided to pkg.depotd.")
-                return __handle_error(request.path_info, http_client.NOT_FOUND)
-        except IOError as e:
-                return __handle_error(path, http_client.INTERNAL_SERVER_ERROR)
-        except mako.exceptions.TemplateLookupException as e:
-                # The above exception indicates that mako could not locate the
-                # template (in most cases, Mako doesn't seem to always clearly
-                # differentiate).
-                return __handle_error(path, http_client.NOT_FOUND)
-        except sae.RedirectException as e:
-                raise cherrypy.HTTPRedirect(e.data)
-        except:
-                return __handle_error(path, http_client.INTERNAL_SERVER_ERROR)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/server/feed.py
+++ b/src/modules/server/feed.py
@@ -51,352 +51,367 @@ MIME_TYPE = "application/atom+xml"
 CACHE_FILENAME = "feed.xml"
 RFC3339_FMT = "%Y-%m-%dT%H:%M:%SZ"
 
+
 def dt_to_rfc3339_str(ts):
-        """Returns a string representing a datetime object formatted according
-        to RFC 3339.
-        """
-        return ts.strftime(RFC3339_FMT)
+    """Returns a string representing a datetime object formatted according
+    to RFC 3339.
+    """
+    return ts.strftime(RFC3339_FMT)
+
 
 def rfc3339_str_to_dt(ts_str):
-        """Returns a datetime object representing 'ts_str', which should be in
-        the format specified by RFC 3339.
-        """
-        return datetime.datetime(*time.strptime(ts_str, RFC3339_FMT)[0:6])
+    """Returns a datetime object representing 'ts_str', which should be in
+    the format specified by RFC 3339.
+    """
+    return datetime.datetime(*time.strptime(ts_str, RFC3339_FMT)[0:6])
+
 
 def fmri_to_taguri(f):
-        """Generates a 'tag' uri compliant with RFC 4151.  Visit
-        http://www.taguri.org/ for more information.
-        """
-        return "tag:{0},{1}:{2}".format(f.publisher,
-            f.get_timestamp().strftime("%Y-%m-%d"),
-            unquote(f.get_url_path()))
+    """Generates a 'tag' uri compliant with RFC 4151.  Visit
+    http://www.taguri.org/ for more information.
+    """
+    return "tag:{0},{1}:{2}".format(
+        f.publisher,
+        f.get_timestamp().strftime("%Y-%m-%d"),
+        unquote(f.get_url_path()),
+    )
+
 
 def init(depot):
-        """This function performs general initialization work that is needed
-        for feeds to work correctly.
-        """
+    """This function performs general initialization work that is needed
+    for feeds to work correctly.
+    """
 
-        # Ensure any configuration changes are reflected in the feed.
-        __clear_cache(depot, None)
+    # Ensure any configuration changes are reflected in the feed.
+    __clear_cache(depot, None)
+
 
 def set_title(depot, doc, feed, update_ts):
-        """This function attaches the necessary RSS/Atom feed elements needed
-        to provide title, author and contact information to the provided
-        xmini document object using the provided feed object and update
-        time.
-        """
+    """This function attaches the necessary RSS/Atom feed elements needed
+    to provide title, author and contact information to the provided
+    xmini document object using the provided feed object and update
+    time.
+    """
 
-        t = doc.createElement("title")
-        ti = xmini.Text()
-        ti.replaceWholeText(depot.cfg.get_property("pkg_bui", "feed_name"))
-        t.appendChild(ti)
-        feed.appendChild(t)
+    t = doc.createElement("title")
+    ti = xmini.Text()
+    ti.replaceWholeText(depot.cfg.get_property("pkg_bui", "feed_name"))
+    t.appendChild(ti)
+    feed.appendChild(t)
 
-        l = doc.createElement("link")
-        l.setAttribute("href", cherrypy.url())
-        l.setAttribute("rel", "self")
-        feed.appendChild(l)
+    l = doc.createElement("link")
+    l.setAttribute("href", cherrypy.url())
+    l.setAttribute("rel", "self")
+    feed.appendChild(l)
 
-        # Atom requires each feed to have a permanent, universally unique
-        # identifier.
-        i = doc.createElement("id")
-        it = xmini.Text()
-        netloc, path = urlparse(cherrypy.url())[1:3]
-        netloc = netloc.split(":", 1)[0]
-        tag = "tag:{0},{1}:{2}".format(netloc, update_ts.strftime("%Y-%m-%d"),
-            path)
-        it.replaceWholeText(tag)
-        i.appendChild(it)
-        feed.appendChild(i)
+    # Atom requires each feed to have a permanent, universally unique
+    # identifier.
+    i = doc.createElement("id")
+    it = xmini.Text()
+    netloc, path = urlparse(cherrypy.url())[1:3]
+    netloc = netloc.split(":", 1)[0]
+    tag = "tag:{0},{1}:{2}".format(netloc, update_ts.strftime("%Y-%m-%d"), path)
+    it.replaceWholeText(tag)
+    i.appendChild(it)
+    feed.appendChild(i)
 
-        # Indicate when the feed was last updated.
-        u = doc.createElement("updated")
-        ut = xmini.Text()
-        ut.replaceWholeText(dt_to_rfc3339_str(update_ts))
-        u.appendChild(ut)
-        feed.appendChild(u)
+    # Indicate when the feed was last updated.
+    u = doc.createElement("updated")
+    ut = xmini.Text()
+    ut.replaceWholeText(dt_to_rfc3339_str(update_ts))
+    u.appendChild(ut)
+    feed.appendChild(u)
 
-        # Add our icon.
-        i = doc.createElement("icon")
-        it = xmini.Text()
-        it.replaceWholeText(depot.cfg.get_property("pkg_bui", "feed_icon"))
-        i.appendChild(it)
-        feed.appendChild(i)
+    # Add our icon.
+    i = doc.createElement("icon")
+    it = xmini.Text()
+    it.replaceWholeText(depot.cfg.get_property("pkg_bui", "feed_icon"))
+    i.appendChild(it)
+    feed.appendChild(i)
 
-        # Add our logo.
-        l = doc.createElement("logo")
-        lt = xmini.Text()
-        lt.replaceWholeText(depot.cfg.get_property("pkg_bui", "feed_logo"))
-        l.appendChild(lt)
-        feed.appendChild(l)
+    # Add our logo.
+    l = doc.createElement("logo")
+    lt = xmini.Text()
+    lt.replaceWholeText(depot.cfg.get_property("pkg_bui", "feed_logo"))
+    l.appendChild(lt)
+    feed.appendChild(l)
 
 
 add_op = ("Added", "{0} was added to the repository.")
 remove_op = ("Removed", "{0} was removed from the repository.")
-update_op = ("Updated", "{0}, a new version of an existing package, was added "
-    "to the repository.")
+update_op = (
+    "Updated",
+    "{0}, a new version of an existing package, was added "
+    "to the repository.",
+)
+
 
 def add_transaction(request, doc, feed, entry, first):
-        """Each transaction is an entry.  We have non-trivial content, so we
-        can omit summary elements.
-        """
+    """Each transaction is an entry.  We have non-trivial content, so we
+    can omit summary elements.
+    """
 
-        e = doc.createElement("entry")
+    e = doc.createElement("entry")
 
-        pfmri, op_type, op_time, metadata = entry
+    pfmri, op_type, op_time, metadata = entry
 
-        # Generate a 'tag' uri, to uniquely identify the entry, using the fmri.
-        i = xmini.Text()
-        i.replaceWholeText(fmri_to_taguri(pfmri))
-        eid = doc.createElement("id")
-        eid.appendChild(i)
-        e.appendChild(eid)
+    # Generate a 'tag' uri, to uniquely identify the entry, using the fmri.
+    i = xmini.Text()
+    i.replaceWholeText(fmri_to_taguri(pfmri))
+    eid = doc.createElement("id")
+    eid.appendChild(i)
+    e.appendChild(eid)
 
-        # Attempt to determine the operation that was performed and generate
-        # the entry title and content.
-        if op_type == catalog.CatalogUpdate.ADD:
-                if pfmri != first:
-                        # XXX renaming, obsoletion?
-                        # If this fmri is not the same as the oldest one
-                        # for the FMRI's package stem, assume this is a
-                        # newer version of that package.
-                        op_title, op_content = update_op
-                else:
-                        op_title, op_content = add_op
-        elif op_type == catalog.CatalogUpdate.REMOVE:
-                op_title, op_content = add_op
+    # Attempt to determine the operation that was performed and generate
+    # the entry title and content.
+    if op_type == catalog.CatalogUpdate.ADD:
+        if pfmri != first:
+            # XXX renaming, obsoletion?
+            # If this fmri is not the same as the oldest one
+            # for the FMRI's package stem, assume this is a
+            # newer version of that package.
+            op_title, op_content = update_op
         else:
-                # XXX Better way to reflect an error?  (Aborting will make a
-                # non-well-formed document.)
-                op_title = "Unknown Operation"
-                op_content = "{0} was changed in the repository."
+            op_title, op_content = add_op
+    elif op_type == catalog.CatalogUpdate.REMOVE:
+        op_title, op_content = add_op
+    else:
+        # XXX Better way to reflect an error?  (Aborting will make a
+        # non-well-formed document.)
+        op_title = "Unknown Operation"
+        op_content = "{0} was changed in the repository."
 
-        # Now add a title for our entry.
-        etitle = doc.createElement("title")
-        ti = xmini.Text()
-        ti.replaceWholeText(" ".join([op_title, pfmri.get_pkg_stem()]))
-        etitle.appendChild(ti)
-        e.appendChild(etitle)
+    # Now add a title for our entry.
+    etitle = doc.createElement("title")
+    ti = xmini.Text()
+    ti.replaceWholeText(" ".join([op_title, pfmri.get_pkg_stem()]))
+    etitle.appendChild(ti)
+    e.appendChild(etitle)
 
-        # Indicate when the entry was last updated (in this case, when the
-        # package was added).
-        eu = doc.createElement("updated")
-        ut = xmini.Text()
-        ut.replaceWholeText(dt_to_rfc3339_str(op_time))
-        eu.appendChild(ut)
-        e.appendChild(eu)
+    # Indicate when the entry was last updated (in this case, when the
+    # package was added).
+    eu = doc.createElement("updated")
+    ut = xmini.Text()
+    ut.replaceWholeText(dt_to_rfc3339_str(op_time))
+    eu.appendChild(ut)
+    e.appendChild(eu)
 
-        # Link to the info output for the given package FMRI.
-        e_uri = misc.get_rel_path(request,
-            "info/0/{0}".format(quote(str(pfmri))))
+    # Link to the info output for the given package FMRI.
+    e_uri = misc.get_rel_path(request, "info/0/{0}".format(quote(str(pfmri))))
 
-        l = doc.createElement("link")
-        l.setAttribute("rel", "alternate")
-        l.setAttribute("href", e_uri)
-        e.appendChild(l)
+    l = doc.createElement("link")
+    l.setAttribute("rel", "alternate")
+    l.setAttribute("href", e_uri)
+    e.appendChild(l)
 
-        # Using the description for the operation performed, add the FMRI and
-        # tag information.
-        content_text = op_content.format(pfmri)
+    # Using the description for the operation performed, add the FMRI and
+    # tag information.
+    content_text = op_content.format(pfmri)
 
-        co = xmini.Text()
-        co.replaceWholeText(content_text)
-        ec = doc.createElement("content")
-        ec.appendChild(co)
-        e.appendChild(ec)
+    co = xmini.Text()
+    co.replaceWholeText(content_text)
+    ec = doc.createElement("content")
+    ec.appendChild(co)
+    e.appendChild(ec)
 
-        feed.appendChild(e)
+    feed.appendChild(e)
+
 
 def get_updates_needed(repo, ts, pub):
-        """Returns a list of the CatalogUpdate files that contain the changes
-        that have been made to the catalog since the specified UTC datetime
-        object 'ts'."""
+    """Returns a list of the CatalogUpdate files that contain the changes
+    that have been made to the catalog since the specified UTC datetime
+    object 'ts'."""
 
-        c = repo.get_catalog(pub)
-        if c.last_modified <= ts:
-                # No updates needed.
-                return []
+    c = repo.get_catalog(pub)
+    if c.last_modified <= ts:
+        # No updates needed.
+        return []
 
-        updates = set()
-        for name, mdata in six.iteritems(c.updates):
+    updates = set()
+    for name, mdata in six.iteritems(c.updates):
+        # The last component of the update name is the locale.
+        locale = name.split(".", 2)[2]
 
-                # The last component of the update name is the locale.
-                locale = name.split(".", 2)[2]
+        # For now, only look at CatalogUpdates that for the 'C'
+        # locale.  Any other CatalogUpdates just contain localized
+        # catalog data, so aren't currently interesting.
+        if locale != "C":
+            continue
 
-                # For now, only look at CatalogUpdates that for the 'C'
-                # locale.  Any other CatalogUpdates just contain localized
-                # catalog data, so aren't currently interesting.
-                if locale != "C":
-                        continue
+        ulog_lm = mdata["last-modified"]
+        if ulog_lm <= ts:
+            # CatalogUpdate hasn't changed since 'ts'.
+            continue
+        updates.add(name)
 
-                ulog_lm = mdata["last-modified"]
-                if ulog_lm <= ts:
-                        # CatalogUpdate hasn't changed since 'ts'.
-                        continue
-                updates.add(name)
+    if not updates:
+        # No updates needed.
+        return []
 
-        if not updates:
-                # No updates needed.
-                return []
+    # Ensure updates are in chronological ascending order.
+    return sorted(updates)
 
-        # Ensure updates are in chronological ascending order.
-        return sorted(updates)
 
 def update(request, depot, last, cf, pub):
-        """Generate new Atom document for current updates.  The cached feed
-        file is written to depot.tmp_root/CACHE_FILENAME.
-        """
+    """Generate new Atom document for current updates.  The cached feed
+    file is written to depot.tmp_root/CACHE_FILENAME.
+    """
 
-        # Our configuration is stored in hours, convert it to days and seconds.
-        hours = depot.cfg.get_property("pkg_bui", "feed_window")
-        days, hours = divmod(hours, 24)
-        seconds = hours * 60 * 60
-        feed_ts = last - datetime.timedelta(days=days, seconds=seconds)
+    # Our configuration is stored in hours, convert it to days and seconds.
+    hours = depot.cfg.get_property("pkg_bui", "feed_window")
+    days, hours = divmod(hours, 24)
+    seconds = hours * 60 * 60
+    feed_ts = last - datetime.timedelta(days=days, seconds=seconds)
 
-        d = xmini.Document()
+    d = xmini.Document()
 
-        feed = d.createElementNS("http://www.w3.org/2005/Atom", "feed")
-        feed.setAttribute("xmlns", "http://www.w3.org/2005/Atom")
+    feed = d.createElementNS("http://www.w3.org/2005/Atom", "feed")
+    feed.setAttribute("xmlns", "http://www.w3.org/2005/Atom")
 
-        cat = depot.repo.get_catalog(pub)
-        set_title(depot, d, feed, cat.last_modified)
+    cat = depot.repo.get_catalog(pub)
+    set_title(depot, d, feed, cat.last_modified)
 
-        d.appendChild(feed)
+    d.appendChild(feed)
 
-        # Cache the first entry in the catalog for any given package stem found
-        # in the list of updates so that it can be used to quickly determine if
-        # the fmri in the update is a 'new' package or an update to an existing
-        # package.
-        first = {}
-        def get_first(f):
-                stem = f.get_pkg_stem()
-                if stem in first:
-                        return first[stem]
+    # Cache the first entry in the catalog for any given package stem found
+    # in the list of updates so that it can be used to quickly determine if
+    # the fmri in the update is a 'new' package or an update to an existing
+    # package.
+    first = {}
 
-                for v, entries in cat.entries_by_version(f.pkg_name):
-                        # The first version returned is the oldest version.
-                        # Add all of the unique package stems for that version
-                        # to the list.
-                        for efmri, edata in entries:
-                                first[efmri.get_pkg_stem()] = efmri
-                        break
+    def get_first(f):
+        stem = f.get_pkg_stem()
+        if stem in first:
+            return first[stem]
 
-                if stem not in first:
-                        # A value of None is used to denote that no previous
-                        # version exists for this particular stem.  This could
-                        # happen when a prior version exists for a different
-                        # publisher, or no prior version exists at all.
-                        first[stem] = None
-                return first[stem]
+        for v, entries in cat.entries_by_version(f.pkg_name):
+            # The first version returned is the oldest version.
+            # Add all of the unique package stems for that version
+            # to the list.
+            for efmri, edata in entries:
+                first[efmri.get_pkg_stem()] = efmri
+            break
 
-        # Updates should be presented in reverse chronological order.
-        for name in reversed(get_updates_needed(depot.repo, feed_ts, pub)):
-                ulog = catalog.CatalogUpdate(name, meta_root=cat.meta_root)
-                for entry in ulog.updates():
-                        pfmri = entry[0]
-                        op_time = entry[2]
-                        if op_time <= feed_ts:
-                                # Exclude this particular update.
-                                continue
-                        add_transaction(request, d, feed, entry,
-                            get_first(pfmri))
+        if stem not in first:
+            # A value of None is used to denote that no previous
+            # version exists for this particular stem.  This could
+            # happen when a prior version exists for a different
+            # publisher, or no prior version exists at all.
+            first[stem] = None
+        return first[stem]
 
-        d.writexml(cf)
+    # Updates should be presented in reverse chronological order.
+    for name in reversed(get_updates_needed(depot.repo, feed_ts, pub)):
+        ulog = catalog.CatalogUpdate(name, meta_root=cat.meta_root)
+        for entry in ulog.updates():
+            pfmri = entry[0]
+            op_time = entry[2]
+            if op_time <= feed_ts:
+                # Exclude this particular update.
+                continue
+            add_transaction(request, d, feed, entry, get_first(pfmri))
+
+    d.writexml(cf)
+
 
 def __get_cache_pathname(depot, pub):
-        if not pub:
-                return os.path.join(depot.tmp_root, CACHE_FILENAME)
-        return os.path.join(depot.tmp_root, "publisher", pub, CACHE_FILENAME)
+    if not pub:
+        return os.path.join(depot.tmp_root, CACHE_FILENAME)
+    return os.path.join(depot.tmp_root, "publisher", pub, CACHE_FILENAME)
+
 
 def __clear_cache(depot, pub):
-        if not pub:
-                shutil.rmtree(os.path.join(depot.tmp_root, "feed"), True)
-                return
-        pathname = __get_cache_pathname(depot, pub)
-        try:
-                if os.path.exists(pathname):
-                        os.remove(pathname)
-        except IOError:
-                raise cherrypy.HTTPError(
-                    http_client.INTERNAL_SERVER_ERROR,
-                    "Unable to clear feed cache.")
+    if not pub:
+        shutil.rmtree(os.path.join(depot.tmp_root, "feed"), True)
+        return
+    pathname = __get_cache_pathname(depot, pub)
+    try:
+        if os.path.exists(pathname):
+            os.remove(pathname)
+    except IOError:
+        raise cherrypy.HTTPError(
+            http_client.INTERNAL_SERVER_ERROR, "Unable to clear feed cache."
+        )
+
 
 def __cache_needs_update(depot, pub):
-        """Checks to see if the feed cache file exists and if it is still
-        valid.  Returns False, None if the cache is valid or True, last
-        where last is a timestamp representing when the cache was
-        generated.
-        """
-        cfpath = __get_cache_pathname(depot, pub)
-        last = None
-        need_update = True
-        if os.path.isfile(cfpath):
-                # Attempt to parse the cached copy.  If we can't, for any
-                # reason, assume we need to remove it and start over.
-                try:
-                        d = xmini.parse(cfpath)
-                except Exception:
-                        d = None
-                        __clear_cache(depot, pub)
+    """Checks to see if the feed cache file exists and if it is still
+    valid.  Returns False, None if the cache is valid or True, last
+    where last is a timestamp representing when the cache was
+    generated.
+    """
+    cfpath = __get_cache_pathname(depot, pub)
+    last = None
+    need_update = True
+    if os.path.isfile(cfpath):
+        # Attempt to parse the cached copy.  If we can't, for any
+        # reason, assume we need to remove it and start over.
+        try:
+            d = xmini.parse(cfpath)
+        except Exception:
+            d = None
+            __clear_cache(depot, pub)
 
-                # Get the feed element and attempt to get the time we last
-                # generated the feed to determine whether we need to regenerate
-                # it.  If for some reason we can't get that information, assume
-                # the cache is invalid, clear it, and force regeneration.
-                fe = None
-                if d:
-                        fe = d.childNodes[0]
+        # Get the feed element and attempt to get the time we last
+        # generated the feed to determine whether we need to regenerate
+        # it.  If for some reason we can't get that information, assume
+        # the cache is invalid, clear it, and force regeneration.
+        fe = None
+        if d:
+            fe = d.childNodes[0]
 
-                if fe:
-                        utn = None
-                        for cnode in fe.childNodes:
-                                if cnode.nodeName == "updated":
-                                        utn = cnode.childNodes[0]
-                                        break
+        if fe:
+            utn = None
+            for cnode in fe.childNodes:
+                if cnode.nodeName == "updated":
+                    utn = cnode.childNodes[0]
+                    break
 
-                        if utn:
-                                last = rfc3339_str_to_dt(utn.nodeValue.strip())
+            if utn:
+                last = rfc3339_str_to_dt(utn.nodeValue.strip())
 
-                                # Since our feed cache and updatelog might have
-                                # been created within the same second, we need
-                                # to ignore small variances when determining
-                                # whether to update the feed cache.
-                                cat = depot.repo.get_catalog(pub)
-                                up_ts = copy.copy(cat.last_modified)
-                                up_ts = up_ts.replace(microsecond=0)
-                                if last >= up_ts:
-                                        need_update = False
-                        else:
-                                __clear_cache(depot, pub)
-                else:
-                        __clear_cache(depot, pub)
-        return need_update, last
+                # Since our feed cache and updatelog might have
+                # been created within the same second, we need
+                # to ignore small variances when determining
+                # whether to update the feed cache.
+                cat = depot.repo.get_catalog(pub)
+                up_ts = copy.copy(cat.last_modified)
+                up_ts = up_ts.replace(microsecond=0)
+                if last >= up_ts:
+                    need_update = False
+            else:
+                __clear_cache(depot, pub)
+        else:
+            __clear_cache(depot, pub)
+    return need_update, last
+
 
 def handle(depot, request, response, pub):
-        """If there have been package updates since we last generated the feed,
-        update the feed and send it to the client.  Otherwise, send them the
-        cached copy if it is available.
-        """
+    """If there have been package updates since we last generated the feed,
+    update the feed and send it to the client.  Otherwise, send them the
+    cached copy if it is available.
+    """
 
-        cfpath = __get_cache_pathname(depot, pub)
+    cfpath = __get_cache_pathname(depot, pub)
 
-        # First check to see if we already have a valid cache of the feed.
-        need_update, last = __cache_needs_update(depot, pub)
+    # First check to see if we already have a valid cache of the feed.
+    need_update, last = __cache_needs_update(depot, pub)
 
-        if need_update:
-                # Update always looks at feed.window seconds before the last
-                # update until "now."  If last is none, we want it to use "now"
-                # as its starting point.
-                if last is None:
-                        last = datetime.datetime.utcnow()
+    if need_update:
+        # Update always looks at feed.window seconds before the last
+        # update until "now."  If last is none, we want it to use "now"
+        # as its starting point.
+        if last is None:
+            last = datetime.datetime.utcnow()
 
-                # Generate and cache the feed.
-                misc.makedirs(os.path.dirname(cfpath))
-                cf = open(cfpath, "w")
-                update(request, depot, last, cf, pub)
-                cf.close()
+        # Generate and cache the feed.
+        misc.makedirs(os.path.dirname(cfpath))
+        cf = open(cfpath, "w")
+        update(request, depot, last, cf, pub)
+        cf.close()
 
-        return serve_file(cfpath, MIME_TYPE)
+    return serve_file(cfpath, MIME_TYPE)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/server/query_parser.py
+++ b/src/modules/server/query_parser.py
@@ -26,73 +26,89 @@
 
 import sys
 import pkg.query_parser as qp
-from pkg.query_parser import BooleanQueryException, ParseError, QueryException, QueryLengthExceeded
+from pkg.query_parser import (
+    BooleanQueryException,
+    ParseError,
+    QueryException,
+    QueryLengthExceeded,
+)
+
 
 class QueryLexer(qp.QueryLexer):
-        pass
+    pass
+
 
 class QueryParser(qp.QueryParser):
-        """This class exists so that the classes the parent class query parser
-        uses to build the AST are the ones defined in this module and not the
-        parent class's module.  This is done so that a single query parser can
-        be shared between the client and server modules but will construct an
-        AST using the appropriate classes."""
+    """This class exists so that the classes the parent class query parser
+    uses to build the AST are the ones defined in this module and not the
+    parent class's module.  This is done so that a single query parser can
+    be shared between the client and server modules but will construct an
+    AST using the appropriate classes."""
 
-        def __init__(self, lexer):
-                qp.QueryParser.__init__(self, lexer)
-                mod = sys.modules[QueryParser.__module__]
-                tmp = {}
-                for class_name in self.query_objs.keys():
-                        assert hasattr(mod, class_name)
-                        tmp[class_name] = getattr(mod, class_name)
-                self.query_objs = tmp
+    def __init__(self, lexer):
+        qp.QueryParser.__init__(self, lexer)
+        mod = sys.modules[QueryParser.__module__]
+        tmp = {}
+        for class_name in self.query_objs.keys():
+            assert hasattr(mod, class_name)
+            tmp[class_name] = getattr(mod, class_name)
+        self.query_objs = tmp
+
 
 # Because many classes do not have client specific modifications, they
 # simply subclass the parent module's classes.
 class Query(qp.Query):
-        pass
+    pass
+
 
 class AndQuery(qp.AndQuery):
-        pass
-        
+    pass
+
+
 class OrQuery(qp.OrQuery):
-        pass
+    pass
+
 
 class PkgConversion(qp.PkgConversion):
-        pass
+    pass
+
 
 class PhraseQuery(qp.PhraseQuery):
-        pass
+    pass
+
 
 class FieldQuery(qp.FieldQuery):
-        pass
+    pass
+
 
 class TopQuery(qp.TopQuery):
-        pass
+    pass
+
 
 class TermQuery(qp.TermQuery):
-        """This class handles the client specific search logic for searching
-        for a specific query term."""
+    """This class handles the client specific search logic for searching
+    for a specific query term."""
 
-        _global_data_dict = {}
+    _global_data_dict = {}
 
-        def search(self, restriction, fmris):
-                """This function performs the specific steps needed to do
-                search on a server.
+    def search(self, restriction, fmris):
+        """This function performs the specific steps needed to do
+        search on a server.
 
-                The "restriction" parameter is a generator over results that
-                another branch of the AST has already found.  If it's not None,
-                then it's treated as the domain for search.  If it is None then
-                the actions of all known packages is the domain for search.
+        The "restriction" parameter is a generator over results that
+        another branch of the AST has already found.  If it's not None,
+        then it's treated as the domain for search.  If it is None then
+        the actions of all known packages is the domain for search.
 
-                The "fmris" parameter is a function which produces an object
-                which iterates over all known fmris."""
-                
-                if restriction:
-                        return self._restricted_search_internal(restriction)
-                base_res = self._search_internal(fmris)
-                it = self._get_results(base_res)
-                return it
+        The "fmris" parameter is a function which produces an object
+        which iterates over all known fmris."""
+
+        if restriction:
+            return self._restricted_search_internal(restriction)
+        base_res = self._search_internal(fmris)
+        it = self._get_results(base_res)
+        return it
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/server/repository.py
+++ b/src/modules/server/repository.py
@@ -86,4420 +86,4582 @@ REPO_FIX_ITEM = 0
 REPO_FIX_FAILED = 1
 
 VERIFY_DEPENDENCY = "dependency"
-verify_default_checks = frozenset([
-      VERIFY_DEPENDENCY,
-])
+verify_default_checks = frozenset(
+    [
+        VERIFY_DEPENDENCY,
+    ]
+)
 
 
 class RepositoryError(Exception):
-        """Base exception class for all Repository exceptions."""
+    """Base exception class for all Repository exceptions."""
 
-        def __init__(self, *args):
-                Exception.__init__(self, *args)
-                if args:
-                        self.data = args[0]
+    def __init__(self, *args):
+        Exception.__init__(self, *args)
+        if args:
+            self.data = args[0]
 
-        def __str__(self):
-                return str(self.data)
+    def __str__(self):
+        return str(self.data)
 
 
 class RepositoryExistsError(RepositoryError):
-        """Used to indicate that a repository already exists at the specified
-        location.
-        """
+    """Used to indicate that a repository already exists at the specified
+    location.
+    """
 
-        def __str__(self):
-                return _("A package repository (or a directory with content) "
-                    "already exists at '{0}'.").format(self.data)
+    def __str__(self):
+        return _(
+            "A package repository (or a directory with content) "
+            "already exists at '{0}'."
+        ).format(self.data)
 
 
 class RepositoryFileNotFoundError(RepositoryError):
-        """Used to indicate that the hash name provided for the requested file
-        does not exist."""
+    """Used to indicate that the hash name provided for the requested file
+    does not exist."""
 
-        def __str__(self):
-                return _("No file could be found for the specified "
-                    "hash name: '{0}'.").format(self.data)
+    def __str__(self):
+        return _(
+            "No file could be found for the specified " "hash name: '{0}'."
+        ).format(self.data)
 
 
 class RepositoryInvalidError(RepositoryError):
-        """Used to indicate that a valid repository could not be found at the
-        specified location."""
+    """Used to indicate that a valid repository could not be found at the
+    specified location."""
 
-        def __str__(self):
-                if not self.data:
-                        return _("The specified path does not contain a valid "
-                            "package repository.")
-                return _("The path '{0}' does not contain a valid package "
-                    "repository.").format(self.data)
+    def __str__(self):
+        if not self.data:
+            return _(
+                "The specified path does not contain a valid "
+                "package repository."
+            )
+        return _(
+            "The path '{0}' does not contain a valid package " "repository."
+        ).format(self.data)
 
 
 class RepositoryInvalidFMRIError(RepositoryError):
-        """Used to indicate that the FMRI provided is invalid."""
+    """Used to indicate that the FMRI provided is invalid."""
 
 
 class RepositoryInvalidIgnoreDepFMRIError(RepositoryError):
-        """Used to indicate an invalid FMRI in the ignored dependency
-        file."""
+    """Used to indicate an invalid FMRI in the ignored dependency
+    file."""
 
-        def __init__(self, filename, fmri):
-                Exception.__init__(self)
-                self.filename = filename
-                self.fmri = fmri
+    def __init__(self, filename, fmri):
+        Exception.__init__(self)
+        self.filename = filename
+        self.fmri = fmri
 
-        def __str__(self):
-                return _("The FMRI in ignored-dependency file: {fn} is "
-                    "invalid.\n'{fmri}'.").format(fn=self.filename,
-                    fmri=self.fmri)
+    def __str__(self):
+        return _(
+            "The FMRI in ignored-dependency file: {fn} is "
+            "invalid.\n'{fmri}'."
+        ).format(fn=self.filename, fmri=self.fmri)
 
 
 class RepositoryInvalidIgnoreDepEntryError(RepositoryError):
-        """Used to indicate an invalid entry in the ignored dependency
-        file."""
+    """Used to indicate an invalid entry in the ignored dependency
+    file."""
 
-        def __init__(self, filename, entry):
-                Exception.__init__(self)
-                self.filename = filename
-                self.entry = entry
+    def __init__(self, filename, entry):
+        Exception.__init__(self)
+        self.filename = filename
+        self.entry = entry
 
-        def __str__(self):
-                return _("The entry in ignored-dependency file: {fn} is "
-                    "invalid.\n'{entry}'.").format(fn=self.filename,
-                    entry=self.entry)
+    def __str__(self):
+        return _(
+            "The entry in ignored-dependency file: {fn} is "
+            "invalid.\n'{entry}'."
+        ).format(fn=self.filename, entry=self.entry)
 
 
 class RepositoryIgnoreDepEntryAttrError(RepositoryError):
-        """Used to indicate an unknown attribute for an ignored dep entry."""
+    """Used to indicate an unknown attribute for an ignored dep entry."""
 
-        def __init__(self, etype, entry=None, attrs=None):
-                RepositoryError.__init__(self)
-                self.etype = etype
-                self.entry = entry
-                self.attrs = attrs
+    def __init__(self, etype, entry=None, attrs=None):
+        RepositoryError.__init__(self)
+        self.etype = etype
+        self.entry = entry
+        self.attrs = attrs
 
-        def __str__(self):
-                if self.etype == "missing":
-                        return _("Missing attribute(s) in ignored-"
-                            "dependency entry: '{entry}'.\n{attrs}.").format(
-                            entry=self.entry,
-                            attrs=", ".join(self.attrs))
-                elif self.etype == "unknown":
-                        return _("Unknown attribute(s) found in ignored-"
-                            "dependency entry: '{entry}'.\n{attrs}.").format(
-                            entry=self.entry, attrs=", ".join(self.attrs))
+    def __str__(self):
+        if self.etype == "missing":
+            return _(
+                "Missing attribute(s) in ignored-"
+                "dependency entry: '{entry}'.\n{attrs}."
+            ).format(entry=self.entry, attrs=", ".join(self.attrs))
+        elif self.etype == "unknown":
+            return _(
+                "Unknown attribute(s) found in ignored-"
+                "dependency entry: '{entry}'.\n{attrs}."
+            ).format(entry=self.entry, attrs=", ".join(self.attrs))
 
 
 class RepositoryUnqualifiedFMRIError(RepositoryError):
-        """Used to indicate that the FMRI provided is valid, but is missing
-        publisher information."""
+    """Used to indicate that the FMRI provided is valid, but is missing
+    publisher information."""
 
-        def __str__(self):
-                return _("This operation requires that a default publisher has "
-                    "been set or that a publisher be specified in the FMRI "
-                    "'{0}'.").format(self.data)
+    def __str__(self):
+        return _(
+            "This operation requires that a default publisher has "
+            "been set or that a publisher be specified in the FMRI "
+            "'{0}'."
+        ).format(self.data)
 
 
 class RepositoryInvalidTransactionIDError(RepositoryError):
-        """Used to indicate that an invalid Transaction ID was supplied."""
+    """Used to indicate that an invalid Transaction ID was supplied."""
 
-        def __str__(self):
-                return _("No transaction matching '{0}' could be found.").format(
-                    self.data)
+    def __str__(self):
+        return _("No transaction matching '{0}' could be found.").format(
+            self.data
+        )
 
 
 class RepositoryLockedError(RepositoryError):
-        """Used to indicate that the repository is currently locked by another
-        thread or process and cannot be modified."""
+    """Used to indicate that the repository is currently locked by another
+    thread or process and cannot be modified."""
 
-        def __init__(self, hostname=None, pid=None):
-                RepositoryError.__init__(self)
-                self.hostname = hostname
-                self.pid = pid
+    def __init__(self, hostname=None, pid=None):
+        RepositoryError.__init__(self)
+        self.hostname = hostname
+        self.pid = pid
 
-        def __str__(self):
-                if self.pid is not None:
-                        # Even if the host is none, use this message.
-                        return _("The repository cannot be modified as it is "
-                            "currently in use by another process: "
-                            "pid {pid} on {host}.").format(
-                            pid=self.pid, host=self.hostname)
-                return _("The repository cannot be modified as it is currently "
-                    "in use by another process.")
+    def __str__(self):
+        if self.pid is not None:
+            # Even if the host is none, use this message.
+            return _(
+                "The repository cannot be modified as it is "
+                "currently in use by another process: "
+                "pid {pid} on {host}."
+            ).format(pid=self.pid, host=self.hostname)
+        return _(
+            "The repository cannot be modified as it is currently "
+            "in use by another process."
+        )
 
 
 class RepositoryManifestNotFoundError(RepositoryError):
-        """Used to indicate that the requested manifest could not be found."""
+    """Used to indicate that the requested manifest could not be found."""
 
-        def __str__(self):
-                return _("No manifest could be found for the FMRI: '{0}'.").format(
-                    self.data)
+    def __str__(self):
+        return _("No manifest could be found for the FMRI: '{0}'.").format(
+            self.data
+        )
 
 
 class RepositoryMirrorError(RepositoryError):
-        """Used to indicate that the requested operation could not be performed
-        as the repository is in mirror mode."""
+    """Used to indicate that the requested operation could not be performed
+    as the repository is in mirror mode."""
 
-        def __str__(self):
-                return _("The requested operation cannot be performed when the "
-                    "repository is used in mirror mode.")
+    def __str__(self):
+        return _(
+            "The requested operation cannot be performed when the "
+            "repository is used in mirror mode."
+        )
 
 
 class RepositoryNoPublisherError(RepositoryError):
-        """Used to indicate that the requested repository operation could not be
-        completed as not default publisher has been set and one was not
-        specified.
-        """
+    """Used to indicate that the requested repository operation could not be
+    completed as not default publisher has been set and one was not
+    specified.
+    """
 
-        def __str__(self):
-                return _("The requested operation could not be completed as a "
-                    "default publisher has not been configured.")
+    def __str__(self):
+        return _(
+            "The requested operation could not be completed as a "
+            "default publisher has not been configured."
+        )
 
 
 class RepositoryNoSuchFileError(RepositoryError):
-        """Used to indicate that the file provided does not exist."""
+    """Used to indicate that the file provided does not exist."""
 
-        def __str__(self):
-                return _("No such file '{0}'.").format(self.data)
+    def __str__(self):
+        return _("No such file '{0}'.").format(self.data)
 
 
 class RepositoryReadOnlyError(RepositoryError):
-        """Used to indicate that the requested operation could not be performed
-        as the repository is currently read-only."""
+    """Used to indicate that the requested operation could not be performed
+    as the repository is currently read-only."""
 
-        def __str__(self):
-                return _("The repository is read-only and cannot be modified.")
+    def __str__(self):
+        return _("The repository is read-only and cannot be modified.")
 
 
 class RepositorySearchTokenError(RepositoryError):
-        """Used to indicate that the token(s) provided to search were undefined
-        or invalid."""
+    """Used to indicate that the token(s) provided to search were undefined
+    or invalid."""
 
-        def __str__(self):
-                if self.data is None:
-                        return _("No token was provided to search.").format(
-                            self.data)
+    def __str__(self):
+        if self.data is None:
+            return _("No token was provided to search.").format(self.data)
 
-                return _("The specified search token '{0}' is invalid.").format(
-                    self.data)
+        return _("The specified search token '{0}' is invalid.").format(
+            self.data
+        )
 
 
 class RepositorySearchUnavailableError(RepositoryError):
-        """Used to indicate that search is not currently available."""
+    """Used to indicate that search is not currently available."""
 
-        def __str__(self):
-                return _("Search functionality is temporarily unavailable.")
+    def __str__(self):
+        return _("Search functionality is temporarily unavailable.")
 
 
 class RepositoryDuplicatePublisher(RepositoryError):
-        """Raised when the publisher specified for an operation already exists,
-        and so cannot be added again.
-        """
+    """Raised when the publisher specified for an operation already exists,
+    and so cannot be added again.
+    """
 
-        def __str__(self):
-                return _("Publisher '{0}' already exists.").format(self.data)
+    def __str__(self):
+        return _("Publisher '{0}' already exists.").format(self.data)
 
 
 class RepositoryUnknownPublisher(RepositoryError):
-        """Raised when the publisher specified for an operation is unknown to
-        the repository.
-        """
+    """Raised when the publisher specified for an operation is unknown to
+    the repository.
+    """
 
-        def __str__(self):
-                if not self.data:
-                        return _("No publisher was specified or no default "
-                            "publisher has been configured for the repository.")
-                return _("No publisher matching '{0}' could be found.").format(
-                    self.data)
+    def __str__(self):
+        if not self.data:
+            return _(
+                "No publisher was specified or no default "
+                "publisher has been configured for the repository."
+            )
+        return _("No publisher matching '{0}' could be found.").format(
+            self.data
+        )
 
 
 class RepositoryVersionError(RepositoryError):
-        """Raised when the repository specified uses a format greater than the
-        current format (version).
-        """
+    """Raised when the repository specified uses a format greater than the
+    current format (version).
+    """
 
-        def __init__(self, location, version, current_version):
-                RepositoryError.__init__(self)
-                self.location = location
-                self.version = version
-                self.current_version = current_version
+    def __init__(self, location, version, current_version):
+        RepositoryError.__init__(self)
+        self.location = location
+        self.version = version
+        self.current_version = current_version
 
-        def __str__(self):
-                return("The repository at '{location}' is version "
-                    "'{version}'; only versions up to {current_version} are"
-                    " supported.").format(**self.__dict__)
+    def __str__(self):
+        return (
+            "The repository at '{location}' is version "
+            "'{version}'; only versions up to {current_version} are"
+            " supported."
+        ).format(**self.__dict__)
 
 
 class RepositoryInvalidVersionError(RepositoryError):
-        """Raised when the repository specified uses an unsupported format.
-        (version).
-        """
+    """Raised when the repository specified uses an unsupported format.
+    (version).
+    """
 
-        def __init__(self, location, version, supported):
-                RepositoryError.__init__(self)
-                self.location = location
-                self.version = version
-                self.supported = supported
+    def __init__(self, location, version, supported):
+        RepositoryError.__init__(self)
+        self.location = location
+        self.version = version
+        self.supported = supported
 
-        def __str__(self):
-                return("The repository at '{location}' is version "
-                    "'{version}'; only version {supported} repositories are"
-                    " supported.").format(
-                    **self.__dict__)
+    def __str__(self):
+        return (
+            "The repository at '{location}' is version "
+            "'{version}'; only version {supported} repositories are"
+            " supported."
+        ).format(**self.__dict__)
 
 
 class RepositoryUnsupportedOperationError(RepositoryError):
-        """Raised when the repository is unable to support an operation,
-        based upon its current configuration.
-        """
+    """Raised when the repository is unable to support an operation,
+    based upon its current configuration.
+    """
 
-        def __str__(self):
-                return("Operation not supported for this configuration.")
+    def __str__(self):
+        return "Operation not supported for this configuration."
 
 
 class RepositoryQuarantinedPathExistsError(RepositoryError):
-        """Raised when the repository is unable to quarantine a file because
-        a file of that name is already in quarantine.
-        """
+    """Raised when the repository is unable to quarantine a file because
+    a file of that name is already in quarantine.
+    """
 
-        def __str__(self):
-                return _("Quarantined path already exists.")
+    def __str__(self):
+        return _("Quarantined path already exists.")
 
 
 class RepositorySigNoTrustAnchorDirError(RepositoryError):
-        """Raised when the repository trust anchor directory could not be found
-        while performing repository verification."""
+    """Raised when the repository trust anchor directory could not be found
+    while performing repository verification."""
 
-        def __str__(self):
-                return _("Unable to find trust anchor directory {0}").format(
-                    self.data)
+    def __str__(self):
+        return _("Unable to find trust anchor directory {0}").format(self.data)
+
 
 class _RepoStore(object):
-        """The _RepoStore object provides an interface for performing operations
-        on a set of package data contained within a repository.  This class is
-        intended only for use by the Repository class.
+    """The _RepoStore object provides an interface for performing operations
+    on a set of package data contained within a repository.  This class is
+    intended only for use by the Repository class.
+    """
+
+    def __init__(
+        self,
+        allow_invalid=False,
+        file_layout=None,
+        file_root=None,
+        log_obj=None,
+        mirror=False,
+        pub=None,
+        read_only=False,
+        root=None,
+        catalogue_format="utf8",
+        sort_file_max_size=indexer.SORT_FILE_MAX_SIZE,
+        writable_root=None,
+    ):
+        """Prepare the repository for use."""
+
+        self.__catalog = None
+        self.__catalog_root = None
+        # FileManager supports multiple layouts, but realistically, it
+        # is desirable to only support one per repository format
+        # version.
+        self.__file_layout = file_layout
+        self.__file_root = None
+        self.__in_flight_trans = {}
+        self.__read_only = read_only
+        self.__root = None
+        self.__sort_file_max_size = sort_file_max_size
+        self.__tmp_root = None
+        self.__writable_root = None
+        self.__catalogue_format = catalogue_format
+        self.cache_store = None
+        self.catalog_version = -1
+        self.manifest_root = None
+        self.trans_root = None
+
+        self.log_obj = log_obj
+        self.mirror = mirror
+        self.publisher = pub
+
+        # Set before root, since it's possible to have the
+        # file_root in an entirely different location.  The root
+        # will govern file_root, if a value for file_root is not
+        # supplied.
+        if file_root:
+            self.__set_file_root(file_root)
+
+        # Must be set before remaining roots.
+        self.__set_root(root)
+
+        # Ideally, callers would just specify overrides for the feed
+        # cache root, index_root, etc.  But this must be set after all
+        # of the others above.
+        self.__set_writable_root(writable_root)
+
+        self.__search_available = False
+        self.__refresh_again = False
+
+        self.__lock = pkg.nrlock.NRLock()
+        if self.__tmp_root:
+            self.__lockfile = lockfile.LockFile(
+                os.path.join(self.__tmp_root, "lock"),
+                set_lockstr=lockfile.generic_lock_set_str,
+                get_lockstr=lockfile.generic_lock_get_str,
+                failure_exc=RepositoryLockedError,
+                provide_mutex=False,
+            )
+        else:
+            self.__lockfile = None
+
+        # Initialize.
+        self.__lock_rstore(blocking=True)
+        try:
+            self.__init_state(allow_invalid=allow_invalid)
+        finally:
+            self.__unlock_rstore()
+
+    def __set_read_only(self, value):
+        old_ro = self.__read_only
+        self.__read_only = value
+        if self.__catalog:
+            self.__catalog.read_only = value
+        if self.cache_store:
+            self.cache_store.readonly = value
+        if old_ro and not self.__read_only:
+            self.__lock_rstore(blocking=True)
+            try:
+                self.__init_state()
+            finally:
+                self.__unlock_rstore()
+
+    def __mkdtemp(self):
+        """Create a temp directory under repository directory for
+        various purposes."""
+
+        if not self.root:
+            return
+
+        if self.writable_root:
+            root = self.writable_root
+        else:
+            root = self.root
+
+        tempdir = os.path.normpath(os.path.join(root, "tmp"))
+        misc.makedirs(tempdir)
+        try:
+            return tempfile.mkdtemp(dir=tempdir)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
+
+    def __add_package(self, pfmri, manifest=None):
+        """Private version; caller responsible for repository
+        locking."""
+
+        if not manifest:
+            manifest = self._get_manifest(pfmri, sig=True)
+        c = self.catalog
+        c.add_package(pfmri, manifest=manifest)
+
+    def __replace_package(self, pfmri, manifest=None):
+        """Private version; caller responsible for repository
+        locking."""
+
+        if not manifest:
+            manifest = self._get_manifest(pfmri, sig=True)
+        c = self.catalog
+        c.remove_package(pfmri)
+        c.add_package(pfmri, manifest=manifest)
+
+    def __check_search(self):
+        if not self.index_root:
+            return
+
+        ind = indexer.Indexer(
+            self.index_root,
+            self._get_manifest,
+            self.manifest,
+            log=self.__index_log,
+            sort_file_max_size=self.__sort_file_max_size,
+        )
+        cie = False
+        try:
+            cie = ind.check_index_existence()
+        except se.InconsistentIndexException:
+            pass
+        if cie:
+            if not self.__search_available:
+                # State change to available.
+                self.__index_log("Search Available")
+                self.reset_search()
+            self.__search_available = True
+        else:
+            if self.__search_available:
+                # State change to unavailable.
+                self.__index_log("Search Unavailable")
+                self.reset_search()
+            self.__search_available = False
+
+    def __destroy_catalog(self):
+        """Destroy the catalog."""
+
+        self.__catalog = None
+        if self.catalog_root and os.path.exists(self.catalog_root):
+            shutil.rmtree(self.catalog_root)
+
+    @staticmethod
+    def __fmri_from_path(pkgpath, ver):
+        """Helper method that takes the full path to the package
+        directory and the name of the manifest file, and returns an FMRI
+        constructed from the information in those components."""
+
+        v = pkg.version.Version(unquote(ver), None)
+        f = fmri.PkgFmri(unquote(os.path.basename(pkgpath)))
+        f.version = v
+        return f
+
+    def _get_manifest(self, pfmri, sig=False):
+        """This function should be private; but is protected instead due
+        to its usage as a callback."""
+
+        mpath = self.manifest(pfmri)
+        m = pkg.manifest.Manifest(pfmri)
+        try:
+            m.set_content(pathname=mpath, signatures=sig)
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                raise RepositoryManifestNotFoundError(e.filename)
+            raise
+        return m
+
+    def __index_log(self, msg):
+        return self.__log(msg, "INDEX")
+
+    def __get_transaction(self, trans_id):
+        """Return the in-flight transaction with the matching trans_id."""
+
+        if not self.trans_root:
+            raise RepositoryInvalidTransactionIDError(trans_id)
+
+        try:
+            return self.__in_flight_trans[trans_id]
+        except KeyError:
+            # Transaction not cached already, so load and
+            # cache if possible.
+            t = trans.Transaction()
+            try:
+                t.reopen(self, trans_id)
+            except trans.TransactionUnknownIDError:
+                raise RepositoryInvalidTransactionIDError(trans_id)
+
+            if not t:
+                raise RepositoryInvalidTransactionIDError(trans_id)
+            self.__in_flight_trans[trans_id] = t
+            return t
+
+    def __discard_transaction(self, trans_id):
+        """Discard any state information cached for a Transaction."""
+        self.__in_flight_trans.pop(trans_id, None)
+
+    def get_lock_status(self):
+        """Returns a tuple of booleans of the form (storage_locked,
+        index_locked).
         """
 
-        def __init__(self, allow_invalid=False, file_layout=None,
-            file_root=None, log_obj=None, mirror=False, pub=None,
-            read_only=False, root=None, catalogue_format='utf8',
-            sort_file_max_size=indexer.SORT_FILE_MAX_SIZE, writable_root=None):
-                """Prepare the repository for use."""
+        storage_locked = False
+        try:
+            self.__lock_rstore()
+        except RepositoryLockedError:
+            storage_locked = True
+        except:
+            pass
+        else:
+            self.__unlock_rstore()
 
-                self.__catalog = None
-                self.__catalog_root = None
-                # FileManager supports multiple layouts, but realistically, it
-                # is desirable to only support one per repository format
-                # version.
-                self.__file_layout = file_layout
-                self.__file_root = None
-                self.__in_flight_trans = {}
-                self.__read_only = read_only
-                self.__root = None
-                self.__sort_file_max_size = sort_file_max_size
-                self.__tmp_root = None
-                self.__writable_root = None
-                self.__catalogue_format = catalogue_format
-                self.cache_store = None
-                self.catalog_version = -1
-                self.manifest_root = None
-                self.trans_root = None
-
-                self.log_obj = log_obj
-                self.mirror = mirror
-                self.publisher = pub
-
-                # Set before root, since it's possible to have the
-                # file_root in an entirely different location.  The root
-                # will govern file_root, if a value for file_root is not
-                # supplied.
-                if file_root:
-                        self.__set_file_root(file_root)
-
-                # Must be set before remaining roots.
-                self.__set_root(root)
-
-                # Ideally, callers would just specify overrides for the feed
-                # cache root, index_root, etc.  But this must be set after all
-                # of the others above.
-                self.__set_writable_root(writable_root)
-
-                self.__search_available = False
-                self.__refresh_again = False
-
-                self.__lock = pkg.nrlock.NRLock()
-                if self.__tmp_root:
-                        self.__lockfile = lockfile.LockFile(os.path.join(
-                            self.__tmp_root, "lock"),
-                            set_lockstr=lockfile.generic_lock_set_str,
-                            get_lockstr=lockfile.generic_lock_get_str,
-                            failure_exc=RepositoryLockedError,
-                            provide_mutex=False)
-                else:
-                        self.__lockfile = None
-
-                # Initialize.
-                self.__lock_rstore(blocking=True)
-                try:
-                        self.__init_state(allow_invalid=allow_invalid)
-                finally:
-                        self.__unlock_rstore()
-
-        def __set_read_only(self, value):
-                old_ro = self.__read_only
-                self.__read_only = value
-                if self.__catalog:
-                        self.__catalog.read_only = value
-                if self.cache_store:
-                        self.cache_store.readonly = value
-                if old_ro and not self.__read_only:
-                        self.__lock_rstore(blocking=True)
-                        try:
-                                self.__init_state()
-                        finally:
-                                self.__unlock_rstore()
-
-        def __mkdtemp(self):
-                """Create a temp directory under repository directory for
-                various purposes."""
-
-                if not self.root:
-                        return
-
-                if self.writable_root:
-                        root = self.writable_root
-                else:
-                        root = self.root
-
-                tempdir = os.path.normpath(os.path.join(root, "tmp"))
-                misc.makedirs(tempdir)
-                try:
-                        return tempfile.mkdtemp(dir=tempdir)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
-
-        def __add_package(self, pfmri, manifest=None):
-                """Private version; caller responsible for repository
-                locking."""
-
-                if not manifest:
-                        manifest = self._get_manifest(pfmri, sig=True)
-                c = self.catalog
-                c.add_package(pfmri, manifest=manifest)
-
-        def __replace_package(self, pfmri, manifest=None):
-                """Private version; caller responsible for repository
-                locking."""
-
-                if not manifest:
-                        manifest = self._get_manifest(pfmri, sig=True)
-                c = self.catalog
-                c.remove_package(pfmri)
-                c.add_package(pfmri, manifest=manifest)
-
-        def __check_search(self):
-                if not self.index_root:
-                        return
-
-                ind = indexer.Indexer(self.index_root,
-                    self._get_manifest, self.manifest,
-                    log=self.__index_log,
-                    sort_file_max_size=self.__sort_file_max_size)
-                cie = False
-                try:
-                        cie = ind.check_index_existence()
-                except se.InconsistentIndexException:
-                        pass
-                if cie:
-                        if not self.__search_available:
-                                # State change to available.
-                                self.__index_log("Search Available")
-                                self.reset_search()
-                        self.__search_available = True
-                else:
-                        if self.__search_available:
-                                # State change to unavailable.
-                                self.__index_log("Search Unavailable")
-                                self.reset_search()
-                        self.__search_available = False
-
-        def __destroy_catalog(self):
-                """Destroy the catalog."""
-
-                self.__catalog = None
-                if self.catalog_root and os.path.exists(self.catalog_root):
-                        shutil.rmtree(self.catalog_root)
-
-        @staticmethod
-        def __fmri_from_path(pkgpath, ver):
-                """Helper method that takes the full path to the package
-                directory and the name of the manifest file, and returns an FMRI
-                constructed from the information in those components."""
-
-                v = pkg.version.Version(unquote(ver), None)
-                f = fmri.PkgFmri(unquote(os.path.basename(pkgpath)))
-                f.version = v
-                return f
-
-        def _get_manifest(self, pfmri, sig=False):
-                """This function should be private; but is protected instead due
-                to its usage as a callback."""
-
-                mpath = self.manifest(pfmri)
-                m = pkg.manifest.Manifest(pfmri)
-                try:
-                        m.set_content(pathname=mpath, signatures=sig)
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                raise RepositoryManifestNotFoundError(
-                                    e.filename)
-                        raise
-                return m
-
-        def __index_log(self, msg):
-                return self.__log(msg, "INDEX")
-
-        def __get_transaction(self, trans_id):
-                """Return the in-flight transaction with the matching trans_id.
-                """
-
-                if not self.trans_root:
-                        raise RepositoryInvalidTransactionIDError(trans_id)
-
-                try:
-                        return self.__in_flight_trans[trans_id]
-                except KeyError:
-                        # Transaction not cached already, so load and
-                        # cache if possible.
-                        t = trans.Transaction()
-                        try:
-                                t.reopen(self, trans_id)
-                        except trans.TransactionUnknownIDError:
-                                raise RepositoryInvalidTransactionIDError(
-                                    trans_id)
-
-                        if not t:
-                                raise RepositoryInvalidTransactionIDError(
-                                    trans_id)
-                        self.__in_flight_trans[trans_id] = t
-                        return t
-
-        def __discard_transaction(self, trans_id):
-                """Discard any state information cached for a Transaction."""
-                self.__in_flight_trans.pop(trans_id, None)
-
-        def get_lock_status(self):
-                """Returns a tuple of booleans of the form (storage_locked,
-                index_locked).
-                """
-
-                storage_locked = False
-                try:
-                        self.__lock_rstore()
-                except RepositoryLockedError:
-                        storage_locked = True
-                except:
-                        pass
-                else:
-                        self.__unlock_rstore()
-
-                index_locked = False
-                if self.index_root and os.path.exists(self.index_root) and \
-                    (not self.read_only or self.writable_root):
-                        try:
-                                ind = indexer.Indexer(self.index_root,
-                                    self._get_manifest, self.manifest,
-                                    log=self.__index_log,
-                                    sort_file_max_size=self.__sort_file_max_size)
-                                ind.lock(blocking=False)
-                        except se.IndexLockedException:
-                                index_locked = True
-                        except:
-                                pass
-                        finally:
-                                if ind and not index_locked:
-                                        # If ind is defined, the index exists,
-                                        # and a lock was obtained because
-                                        # index_locked is False, so call
-                                        # unlock().
-                                        ind.unlock()
-                return storage_locked, index_locked
-
-        def get_status(self):
-                """Return a dictionary of status information about the
-                repository storage object.
-                """
-
-                try:
-                        cat = self.catalog
-                        pkg_count = cat.package_count
-                        pkg_ver_count = cat.package_version_count
-                        lcat_update = catalog.datetime_to_basic_ts(
-                            cat.last_modified)
-                except:
-                        # Can't get the info, drive on.
-                        pkg_count = 0
-                        pkg_ver_count = 0
-                        lcat_update = ""
-
-                storage_locked, index_locked = self.get_lock_status()
-                if storage_locked:
-                        rstatus = "processing"
-                elif index_locked:
-                        rstatus = "indexing"
-                else:
-                        rstatus = "online"
-
-                return {
-                    "package-count": pkg_count,
-                    "package-version-count": pkg_ver_count,
-                    "last-catalog-update": lcat_update,
-                    "status": rstatus,
-                }
-
-        def __lock_rstore(self, blocking=False, process=True):
-                """Locks the repository preventing multiple consumers from
-                modifying it during operations."""
-
-                # First, attempt to obtain a thread lock.
-                if not self.__lock.acquire(blocking=blocking):
-                        raise RepositoryLockedError()
-
-                if not process or (self.read_only and
-                    not self.writable_root) or not (self.__tmp_root and
-                    os.path.exists(self.__tmp_root)):
-                        # Process lock wasn't desired, or repository structure
-                        # doesn't exist yet or is readonly so a file lock cannot
-                        # be obtained.
-                        return
-
-                try:
-                        # Attempt to obtain a file lock.
-                        self.__lockfile.lock(blocking=blocking)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                self.__lock.release()
-                                raise apx.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                self.__lock.release()
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        if e.errno == errno.EINVAL:
-                                self.__lock.release()
-                                raise apx.InvalidLockException(
-                                    e.filename)
-
-                        self.__lock.release()
-                        raise
-                except:
-                        # If process lock fails, ensure thread lock is released.
-                        self.__lock.release()
-                        raise
-
-        def __log(self, msg, context="", severity=logging.INFO):
-                if self.log_obj:
-                        self.log_obj.log(msg=msg, context=context,
-                            severity=severity)
-
-        def __purge_search_index(self):
-                """Private helper function to dump repository search data."""
-
-                if not self.index_root or not os.path.exists(self.index_root):
-                        return
-
-                ind = indexer.Indexer(self.index_root,
+        index_locked = False
+        if (
+            self.index_root
+            and os.path.exists(self.index_root)
+            and (not self.read_only or self.writable_root)
+        ):
+            try:
+                ind = indexer.Indexer(
+                    self.index_root,
                     self._get_manifest,
                     self.manifest,
                     log=self.__index_log,
-                    sort_file_max_size=self.__sort_file_max_size)
-
-                # To prevent issues with NFS consumers, attempt to lock the
-                # index first, but don't hold the lock as holding a lock while
-                # removing the directory containing it can cause rmtree() to
-                # fail.
+                    sort_file_max_size=self.__sort_file_max_size,
+                )
                 ind.lock(blocking=False)
-                ind.unlock()
+            except se.IndexLockedException:
+                index_locked = True
+            except:
+                pass
+            finally:
+                if ind and not index_locked:
+                    # If ind is defined, the index exists,
+                    # and a lock was obtained because
+                    # index_locked is False, so call
+                    # unlock().
+                    ind.unlock()
+        return storage_locked, index_locked
 
-                # Since the lock succeeded, immediately try to rename the index
-                # directory to prevent other consumers from using the index
-                # while it is being removed since a lock can't be held.
-                portable.rename(self.index_root, self.index_root + ".old")
-                try:
-                        shutil.rmtree(self.index_root + ".old")
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        if e.errno != errno.ENOENT:
-                                raise
+    def get_status(self):
+        """Return a dictionary of status information about the
+        repository storage object.
+        """
 
-                # Discard in-memory search data.
-                self.reset_search()
+        try:
+            cat = self.catalog
+            pkg_count = cat.package_count
+            pkg_ver_count = cat.package_version_count
+            lcat_update = catalog.datetime_to_basic_ts(cat.last_modified)
+        except:
+            # Can't get the info, drive on.
+            pkg_count = 0
+            pkg_ver_count = 0
+            lcat_update = ""
 
-        def __rebuild(self, build_catalog=True, build_index=False, lm=None,
-            incremental=False):
-                """Private version; caller responsible for repository
-                locking."""
+        storage_locked, index_locked = self.get_lock_status()
+        if storage_locked:
+            rstatus = "processing"
+        elif index_locked:
+            rstatus = "indexing"
+        else:
+            rstatus = "online"
 
-                if not (build_catalog or build_index) or not self.manifest_root:
-                        # Nothing to do.
-                        return
+        return {
+            "package-count": pkg_count,
+            "package-version-count": pkg_ver_count,
+            "last-catalog-update": lcat_update,
+            "status": rstatus,
+        }
 
-                if build_catalog:
+    def __lock_rstore(self, blocking=False, process=True):
+        """Locks the repository preventing multiple consumers from
+        modifying it during operations."""
+
+        # First, attempt to obtain a thread lock.
+        if not self.__lock.acquire(blocking=blocking):
+            raise RepositoryLockedError()
+
+        if (
+            not process
+            or (self.read_only and not self.writable_root)
+            or not (self.__tmp_root and os.path.exists(self.__tmp_root))
+        ):
+            # Process lock wasn't desired, or repository structure
+            # doesn't exist yet or is readonly so a file lock cannot
+            # be obtained.
+            return
+
+        try:
+            # Attempt to obtain a file lock.
+            self.__lockfile.lock(blocking=blocking)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                self.__lock.release()
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                self.__lock.release()
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            if e.errno == errno.EINVAL:
+                self.__lock.release()
+                raise apx.InvalidLockException(e.filename)
+
+            self.__lock.release()
+            raise
+        except:
+            # If process lock fails, ensure thread lock is released.
+            self.__lock.release()
+            raise
+
+    def __log(self, msg, context="", severity=logging.INFO):
+        if self.log_obj:
+            self.log_obj.log(msg=msg, context=context, severity=severity)
+
+    def __purge_search_index(self):
+        """Private helper function to dump repository search data."""
+
+        if not self.index_root or not os.path.exists(self.index_root):
+            return
+
+        ind = indexer.Indexer(
+            self.index_root,
+            self._get_manifest,
+            self.manifest,
+            log=self.__index_log,
+            sort_file_max_size=self.__sort_file_max_size,
+        )
+
+        # To prevent issues with NFS consumers, attempt to lock the
+        # index first, but don't hold the lock as holding a lock while
+        # removing the directory containing it can cause rmtree() to
+        # fail.
+        ind.lock(blocking=False)
+        ind.unlock()
+
+        # Since the lock succeeded, immediately try to rename the index
+        # directory to prevent other consumers from using the index
+        # while it is being removed since a lock can't be held.
+        portable.rename(self.index_root, self.index_root + ".old")
+        try:
+            shutil.rmtree(self.index_root + ".old")
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            if e.errno != errno.ENOENT:
+                raise
+
+        # Discard in-memory search data.
+        self.reset_search()
+
+    def __rebuild(
+        self, build_catalog=True, build_index=False, lm=None, incremental=False
+    ):
+        """Private version; caller responsible for repository
+        locking."""
+
+        if not (build_catalog or build_index) or not self.manifest_root:
+            # Nothing to do.
+            return
+
+        if build_catalog:
+            if not incremental:
+                self.__destroy_catalog()
+            default_pub = self.publisher
+            if self.read_only:
+                # Temporarily mark catalog as not read-only so
+                # that it can be modified.
+                self.catalog.read_only = False
+
+            # Set batch_mode for catalog to speed up rebuild.
+            self.catalog.batch_mode = True
+
+            # Pointless to log incremental updates since a new
+            # catalog is being built.  This also helps speed up
+            # rebuild.
+            self.catalog.log_updates = incremental
+
+            def add_package(f):
+                m = self._get_manifest(f, sig=True)
+                if "pkg.fmri" in m:
+                    f = fmri.PkgFmri(m["pkg.fmri"])
+                if default_pub and not f.publisher:
+                    f.publisher = default_pub
+                self.__add_package(f, manifest=m)
+                self.__log(str(f))
+
+            # XXX eschew os.walk in favor of another os.listdir
+            # here?
+            for pkgpath in os.walk(self.manifest_root):
+                if pkgpath[0] == self.manifest_root:
+                    continue
+
+                for fname in os.listdir(pkgpath[0]):
+                    try:
+                        f = self.__fmri_from_path(pkgpath[0], fname)
+                        add_package(f)
+                    except (
+                        apx.InvalidPackageErrors,
+                        actions.ActionError,
+                        fmri.FmriError,
+                        pkg.version.VersionError,
+                    ) as e:
+                        # Don't add packages with
+                        # corrupt manifests to the
+                        # catalog.
+                        name = os.path.join(pkgpath[0], fname)
+                        self.__log(
+                            _(
+                                "Skipping "
+                                "{name}; invalid "
+                                "manifest: {error}"
+                            ).format(name=name, error=e)
+                        )
+                    except apx.DuplicateCatalogEntry as e:
+                        # Raise dups if not in
+                        # incremental mode.
                         if not incremental:
-                                self.__destroy_catalog()
-                        default_pub = self.publisher
-                        if self.read_only:
-                                # Temporarily mark catalog as not read-only so
-                                # that it can be modified.
-                                self.catalog.read_only = False
-
-                        # Set batch_mode for catalog to speed up rebuild.
-                        self.catalog.batch_mode = True
-
-                        # Pointless to log incremental updates since a new
-                        # catalog is being built.  This also helps speed up
-                        # rebuild.
-                        self.catalog.log_updates = incremental
-
-                        def add_package(f):
-                                m = self._get_manifest(f, sig=True)
-                                if "pkg.fmri" in m:
-                                        f = fmri.PkgFmri(m["pkg.fmri"])
-                                if default_pub and not f.publisher:
-                                        f.publisher = default_pub
-                                self.__add_package(f, manifest=m)
-                                self.__log(str(f))
-
-                        # XXX eschew os.walk in favor of another os.listdir
-                        # here?
-                        for pkgpath in os.walk(self.manifest_root):
-                                if pkgpath[0] == self.manifest_root:
-                                        continue
-
-                                for fname in os.listdir(pkgpath[0]):
-                                        try:
-                                                f = self.__fmri_from_path(
-                                                    pkgpath[0], fname)
-                                                add_package(f)
-                                        except (apx.InvalidPackageErrors,
-                                            actions.ActionError,
-                                            fmri.FmriError,
-                                            pkg.version.VersionError) as e:
-                                                # Don't add packages with
-                                                # corrupt manifests to the
-                                                # catalog.
-                                                name = os.path.join(pkgpath[0],
-                                                    fname)
-                                                self.__log(_("Skipping "
-                                                    "{name}; invalid "
-                                                    "manifest: {error}").format(
-                                                    name=name, error=e))
-                                        except apx.DuplicateCatalogEntry as e:
-                                                # Raise dups if not in
-                                                # incremental mode.
-                                                if not incremental:
-                                                        raise
-
-                        # Private add_package doesn't automatically save catalog
-                        # so that operations can be batched (there is
-                        # significant overhead in writing the catalog).
-                        self.catalog.batch_mode = False
-                        self.catalog.log_updates = True
-                        self.catalog.read_only = self.read_only
-                        self.catalog.finalize()
-                        self.__save_catalog(lm=lm)
-
-                if not incremental:
-                        # Only discard search data if this isn't an incremental
-                        # rebuild.
-                        self.__purge_search_index()
-
-                if build_index:
-                        self.__refresh_index()
-                else:
-                        self.__check_search()
-
-        def __refresh_index(self):
-                """Private version; caller responsible for repository
-                locking."""
-
-                if not self.index_root:
-                        return
-                if self.read_only and not self.writable_root:
-                        raise RepositoryReadOnlyError()
-
-                cat = self.catalog
-                self.__index_log("Checking for updated package data.")
-                fmris_to_index = indexer.Indexer.check_for_updates(
-                    self.index_root, cat)
-
-                if fmris_to_index:
-                        return self.__run_update_index()
-
-                # Since there is nothing to index, setup the index
-                # and declare search available.  This is only logged
-                # if this represents a change in status of the server.
-                ind = indexer.Indexer(self.index_root,
-                    self._get_manifest,
-                    self.manifest,
-                    log=self.__index_log,
-                    sort_file_max_size=self.__sort_file_max_size)
-                ind.setup()
-                if not self.__search_available:
-                        self.__index_log("Search Available")
-                self.__search_available = True
-
-        def __init_state(self, allow_invalid=False):
-                """Private version; caller responsible for repository
-                locking."""
-
-                # Discard current catalog information (it will be re-loaded
-                # when needed).
-                self.__catalog = None
-
-                # Determine location and version of catalog data.
-                self.__init_catalog(allow_invalid=allow_invalid)
-
-                # Prepare search for use (ensuring most current data is loaded).
-                self.reset_search()
-
-                if self.mirror:
-                        # In mirror mode, nothing more to do.
-                        return
-
-                # If no catalog exists on-disk yet, ensure an empty one does
-                # so that clients can discern that a repository has an empty
-                # catalog, as opposed to missing one entirely (which could
-                # easily happen with multiple origins).  This must be done
-                # before the search checks below.
-                if not self.read_only and self.catalog_root and \
-                    not self.catalog.exists:
-                        self.__save_catalog()
-
-                self.__check_search()
-
-        def __init_catalog(self, allow_invalid=False):
-                """Private function to determine version and location of
-                catalog data.  This will also perform any necessary
-                transformations of existing catalog data if the repository
-                is read-only and a writable_root has been provided.
-
-                'allow_invalid', if True, will assume the catalog is version 1
-                and use an empty, in-memory catalog if the existing, on-disk
-                catalog is invalid (i.e. corrupted).  This assumes that the
-                caller intends to use the repository as part of a rebuild
-                operation."""
-
-                # Reset versions to default.
-                self.catalog_version = -1
-
-                if not self.catalog_root or self.mirror:
-                        return
-
-                def get_file_lm(pathname):
-                        try:
-                                mod_time = os.stat(pathname).st_mtime
-                        except EnvironmentError as e:
-                                if e.errno == errno.ENOENT:
-                                        return None
-                                raise
-                        return datetime.datetime.utcfromtimestamp(mod_time)
-
-                # To determine if a transformation is needed, first check for a
-                # v0 catalog attrs file.
-                need_transform = False
-                v0_attrs = os.path.join(self.catalog_root, "attrs")
-
-                # The only place a v1 catalog should exist, at all,
-                # is either in self.catalog_root, or in a subdirectory
-                # of self.writable_root if a v0 catalog exists.
-                v1_cat = None
-                writ_cat_root = None
-                if self.writable_root:
-                        writ_cat_root = os.path.join(
-                            self.writable_root, "catalog")
-                        v1_cat = catalog.Catalog(
-                            meta_root=writ_cat_root, read_only=True)
-
-                v0_lm = None
-                if os.path.exists(v0_attrs):
-                        # If a v0 catalog exists, then assume any existing v1
-                        # catalog needs to be kept in sync if it exists.  If
-                        # one doesn't exist, then it needs to be created.
-                        v0_lm = get_file_lm(v0_attrs)
-                        if not v1_cat or not v1_cat.exists or \
-                            v0_lm != v1_cat.last_modified:
-                                need_transform = True
-
-                if writ_cat_root and not self.read_only:
-                        # If a writable root was specified, but the server is
-                        # not in read-only mode, then the catalog must not be
-                        # stored using the writable root (this is consistent
-                        # with the storage of package data in this case).  As
-                        # such, destroy any v1 catalog data that might exist
-                        # and proceed.
-                        shutil.rmtree(writ_cat_root, True)
-                        writ_cat_root = None
-                        if os.path.exists(v0_attrs) and not self.catalog.exists:
-                                # A v0 catalog exists, but no v1 catalog exists;
-                                # this can happen when a repository that was
-                                # previously run with writable-root and
-                                # read_only is now being run with only
-                                # writable_root.
-                                need_transform = True
-                elif writ_cat_root and v0_lm and self.read_only:
-                        # The catalog lives in the writable_root if a v0 catalog
-                        # exists, writ_cat_root is set, and readonly is True.
-                        self.__set_catalog_root(writ_cat_root)
-
-                if self.mirror:
-                        need_transform = False
-
-                if need_transform and self.read_only and not self.writable_root:
-                        # Catalog data can't be transformed.
-                        need_transform = False
-
-                if need_transform:
-                        # v1 catalog should be destroyed if it exists already.
-                        self.catalog.destroy()
-
-                        # Create the transformed catalog.
-                        self.__log(_("Transforming repository catalog; this "
-                            "process will take some time."))
-                        self.__rebuild(lm=v0_lm)
-
-                        if not self.read_only and self.root:
-                                v0_cat = os.path.join(self.root,
-                                    "catalog", "catalog")
-                                for f in v0_attrs, v0_cat:
-                                        if os.path.exists(f):
-                                                portable.remove(f)
-
-                                # If this fails, it doesn't really matter, but
-                                # it should be removed if possible.
-                                shutil.rmtree(os.path.join(self.root,
-                                    "updatelog"), True)
-
-                # Determine effective catalog version after all transformation
-                # work is complete.
-                if os.path.exists(v0_attrs):
-                        # The only place a v1 catalog should exist, at all, is
-                        # either in catalog_root or in a subdirectory of
-                        # writable_root if a v0 catalog exists.
-                        v1_cat = None
-                        # If a writable root was specified, but the repository
-                        # is not in read-only mode, then the catalog must not be
-                        # stored using the writable root (this is consistent
-                        # with the storage of package data in this case).
-                        if self.writable_root and self.read_only:
-                                writ_cat_root = os.path.join(
-                                    self.writable_root, "catalog")
-                                v1_cat = catalog.Catalog(
-                                    meta_root=writ_cat_root, read_only=True)
-
-                        if v1_cat and v1_cat.exists:
-                                self.catalog_version = 1
-                                self.__set_catalog_root(v1_cat.meta_root)
-                        else:
-                                self.catalog_version = 0
-                else:
-                        try:
-                                if self.catalog.exists:
-                                        self.catalog_version = 1
-                        except apx.CatalogError as e:
-                                if not allow_invalid:
-                                        raise
-
-                                # Catalog is invalid, but consumer wants to
-                                # proceed; assume version 1.  This will allow
-                                # pkgrepo rebuild, etc.
-                                self.__log(str(e))
-                                self.__catalog = catalog.Catalog(
-                                    read_only=self.read_only)
-                                self.catalog_verison = 1
-                                return
-
-                if self.catalog_version >= 1 and not self.publisher:
-                        # If there's no information available to determine
-                        # the publisher identity, then assume it's the first
-                        # publisher in this repository store's catalog.
-                        # (This is reasonably safe since there should only
-                        # ever be one.)
-                        pubs = list(p for p in self.catalog.publishers())
-                        if pubs:
-                                self.publisher = pubs[0]
-
-        def __save_catalog(self, lm=None):
-                """Private helper function that attempts to save the catalog in
-                an atomic fashion."""
-
-                # Ensure new catalog is created in a temporary location so that
-                # it can be renamed into place *after* creation to prevent
-                # unexpected failure causing future updates to fail.
-                old_cat_root = self.catalog_root
-                tmp_cat_root = self.__mkdtemp()
-
-                try:
-                        if os.path.exists(old_cat_root):
-                                # Now remove the temporary directory and then
-                                # copy the contents of the existing catalog
-                                # directory to the new, temporary name.  This
-                                # is necessary since the catalog only saves the
-                                # data that has been loaded or changed, so new
-                                # parts will get written out, but old ones could
-                                # be lost.
-                                shutil.rmtree(tmp_cat_root)
-                                misc.copytree(old_cat_root, tmp_cat_root)
-
-                        # Ensure the permissions on the new temporary catalog
-                        # directory are correct.
-                        os.chmod(tmp_cat_root, misc.PKG_DIR_MODE)
-                except EnvironmentError as e:
-                        # shutil.Error can contains a tuple of lists of errors.
-                        # Some of the error entries may be a tuple others will
-                        # be a string due to poor error handling in shutil.
-                        if isinstance(e, shutil.Error) and \
-                            type(e.args[0]) == list:
-                                msg = ""
-                                for elist in e.args:
-                                        for entry in elist:
-                                                if type(entry) == tuple:
-                                                        msg += "{0}\n".format(
-                                                            entry[-1])
-                                                else:
-                                                        msg += "{0}\n".format(
-                                                            entry)
-                                raise apx.UnknownErrors(msg)
-                        elif e.errno == errno.EACCES or e.errno == errno.EPERM:
-                                raise apx.PermissionsException(
-                                    e.filename)
-                        elif e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
-
-                # Save the new catalog data in the temporary location.
-                self.__set_catalog_root(tmp_cat_root)
-                if lm:
-                        self.catalog.last_modified = lm
-                self.catalog.save(fmt=self.__catalogue_format)
-
-                orig_cat_root = None
-                if os.path.exists(old_cat_root):
-                        # Preserve the old catalog data before continuing.
-                        orig_cat_root = os.path.join(os.path.dirname(
-                            old_cat_root), "old." + os.path.basename(
-                            old_cat_root))
-                        shutil.move(old_cat_root, orig_cat_root)
-
-                # Finally, rename the new catalog data into place, reset the
-                # catalog's location, and remove the old catalog data.
-                shutil.move(tmp_cat_root, old_cat_root)
-                self.__set_catalog_root(old_cat_root)
-                if orig_cat_root:
-                        shutil.rmtree(orig_cat_root)
-
-                # Set catalog version.
-                self.catalog_version = self.catalog.version
-
-        def __set_catalog_root(self, root):
-                self.__catalog_root = root
-                if self.__catalog:
-                        # If the catalog is loaded already, then reset
-                        # its meta_root.
-                        self.catalog.meta_root = root
-
-        def __set_root(self, root):
-                if root:
-                        root = os.path.abspath(root)
-                        self.__root = root
-                        self.__tmp_root = os.path.join(root, "tmp")
-                        self.__set_catalog_root(os.path.join(root, "catalog"))
-                        self.index_root = os.path.join(root, "index")
-                        self.manifest_root = os.path.join(root, "pkg")
-                        self.trans_root = os.path.join(root, "trans")
-                        if not self.file_root:
-                                self.__set_file_root(os.path.join(root, "file"))
-                else:
-                        self.__root = None
-                        self.__set_catalog_root(None)
-                        self.index_root = None
-                        self.manifest_root = None
-                        self.trans_root = None
-
-        def __set_file_root(self, root):
-                self.__file_root = root
-                if not root:
-                        self.cache_store = None
-                        return
-
-                self.cache_store = file_manager.FileManager(root,
-                    self.read_only, layouts=self.__file_layout)
-
-        def __set_writable_root(self, root):
-                if root:
-                        root = os.path.abspath(root)
-                        self.__tmp_root = os.path.join(root, "tmp")
-                        self.index_root = os.path.join(root, "index")
-                elif self.root:
-                        self.__tmp_root = os.path.join(self.root, "tmp")
-                        self.index_root = os.path.join(self.root,
-                            "index")
-                else:
-                        self.__tmp_root = None
-                        self.index_root = None
-                self.__writable_root = root
-
-        def __unlock_rstore(self):
-                """Unlocks the repository so other consumers may modify it."""
-
-                try:
-                        if self.__lockfile:
-                                self.__lockfile.unlock()
-                finally:
-                        self.__lock.release()
-
-        def __update_searchdb_unlocked(self, fmris):
-                """Creates an indexer then hands it fmris; it assumes that all
-                needed locking has already occurred.
-                """
-                assert self.index_root
-
-                if fmris:
-                        index_inst = indexer.Indexer(self.index_root,
-                            self._get_manifest, self.manifest,
-                            log=self.__index_log,
-                            sort_file_max_size=self.__sort_file_max_size)
-                        index_inst.server_update_index(fmris)
-                        if not self.__search_available:
-                                self.__index_log("Search Available")
-                        self.__search_available = True
-
-        def abandon(self, trans_id):
-                """Aborts a transaction with the specified Transaction ID.
-                Returns the current package state."""
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.trans_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                t = self.__get_transaction(trans_id)
-                try:
-                        pstate = t.abandon()
-                        self.__discard_transaction(trans_id)
-                        return pstate
-                except trans.TransactionError as e:
-                        raise RepositoryError(e)
-
-        def add(self, trans_id, action):
-                """Adds an action and its content to a transaction with the
-                specified Transaction ID."""
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.trans_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                t = self.__get_transaction(trans_id)
-                try:
-                        t.add_content(action)
-                except trans.TransactionError as e:
-                        raise RepositoryError(e)
-
-        def add_content(self, refresh_index=False):
-                """Looks for packages added to the repository that are not in
-                the catalog and adds them.
-
-                'refresh_index' is an optional boolean value indicating whether
-                search indexes should be updated.
-                """
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if not self.catalog_root or self.catalog_version == 0:
-                        raise RepositoryUnsupportedOperationError()
-
-                self.__lock_rstore()
-                try:
-                        self.__rebuild(build_catalog=True,
-                            build_index=refresh_index, incremental=True)
-                finally:
-                        self.__unlock_rstore()
-
-        def add_file(self, trans_id, data, basename=None, size=None):
-                """Adds a file to an in-flight transaction.
-
-                'trans_id' is the identifier of a transaction that
-                the file should be added to.
-
-                'data' is the string object containing the payload of the
-                file to add.
-
-                'basename' is the basename of the file.
-
-                'size' is an optional integer value indicating the size of
-                the provided payload.
-                """
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.trans_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                t = self.__get_transaction(trans_id)
-                try:
-                        t.add_file(data, basename, size)
-                except trans.TransactionError as e:
-                        raise RepositoryError(e)
+                            raise
+
+            # Private add_package doesn't automatically save catalog
+            # so that operations can be batched (there is
+            # significant overhead in writing the catalog).
+            self.catalog.batch_mode = False
+            self.catalog.log_updates = True
+            self.catalog.read_only = self.read_only
+            self.catalog.finalize()
+            self.__save_catalog(lm=lm)
+
+        if not incremental:
+            # Only discard search data if this isn't an incremental
+            # rebuild.
+            self.__purge_search_index()
+
+        if build_index:
+            self.__refresh_index()
+        else:
+            self.__check_search()
+
+    def __refresh_index(self):
+        """Private version; caller responsible for repository
+        locking."""
+
+        if not self.index_root:
+            return
+        if self.read_only and not self.writable_root:
+            raise RepositoryReadOnlyError()
+
+        cat = self.catalog
+        self.__index_log("Checking for updated package data.")
+        fmris_to_index = indexer.Indexer.check_for_updates(self.index_root, cat)
+
+        if fmris_to_index:
+            return self.__run_update_index()
+
+        # Since there is nothing to index, setup the index
+        # and declare search available.  This is only logged
+        # if this represents a change in status of the server.
+        ind = indexer.Indexer(
+            self.index_root,
+            self._get_manifest,
+            self.manifest,
+            log=self.__index_log,
+            sort_file_max_size=self.__sort_file_max_size,
+        )
+        ind.setup()
+        if not self.__search_available:
+            self.__index_log("Search Available")
+        self.__search_available = True
+
+    def __init_state(self, allow_invalid=False):
+        """Private version; caller responsible for repository
+        locking."""
+
+        # Discard current catalog information (it will be re-loaded
+        # when needed).
+        self.__catalog = None
+
+        # Determine location and version of catalog data.
+        self.__init_catalog(allow_invalid=allow_invalid)
+
+        # Prepare search for use (ensuring most current data is loaded).
+        self.reset_search()
+
+        if self.mirror:
+            # In mirror mode, nothing more to do.
+            return
+
+        # If no catalog exists on-disk yet, ensure an empty one does
+        # so that clients can discern that a repository has an empty
+        # catalog, as opposed to missing one entirely (which could
+        # easily happen with multiple origins).  This must be done
+        # before the search checks below.
+        if not self.read_only and self.catalog_root and not self.catalog.exists:
+            self.__save_catalog()
+
+        self.__check_search()
+
+    def __init_catalog(self, allow_invalid=False):
+        """Private function to determine version and location of
+        catalog data.  This will also perform any necessary
+        transformations of existing catalog data if the repository
+        is read-only and a writable_root has been provided.
+
+        'allow_invalid', if True, will assume the catalog is version 1
+        and use an empty, in-memory catalog if the existing, on-disk
+        catalog is invalid (i.e. corrupted).  This assumes that the
+        caller intends to use the repository as part of a rebuild
+        operation."""
+
+        # Reset versions to default.
+        self.catalog_version = -1
+
+        if not self.catalog_root or self.mirror:
+            return
+
+        def get_file_lm(pathname):
+            try:
+                mod_time = os.stat(pathname).st_mtime
+            except EnvironmentError as e:
+                if e.errno == errno.ENOENT:
+                    return None
+                raise
+            return datetime.datetime.utcfromtimestamp(mod_time)
+
+        # To determine if a transformation is needed, first check for a
+        # v0 catalog attrs file.
+        need_transform = False
+        v0_attrs = os.path.join(self.catalog_root, "attrs")
+
+        # The only place a v1 catalog should exist, at all,
+        # is either in self.catalog_root, or in a subdirectory
+        # of self.writable_root if a v0 catalog exists.
+        v1_cat = None
+        writ_cat_root = None
+        if self.writable_root:
+            writ_cat_root = os.path.join(self.writable_root, "catalog")
+            v1_cat = catalog.Catalog(meta_root=writ_cat_root, read_only=True)
+
+        v0_lm = None
+        if os.path.exists(v0_attrs):
+            # If a v0 catalog exists, then assume any existing v1
+            # catalog needs to be kept in sync if it exists.  If
+            # one doesn't exist, then it needs to be created.
+            v0_lm = get_file_lm(v0_attrs)
+            if not v1_cat or not v1_cat.exists or v0_lm != v1_cat.last_modified:
+                need_transform = True
+
+        if writ_cat_root and not self.read_only:
+            # If a writable root was specified, but the server is
+            # not in read-only mode, then the catalog must not be
+            # stored using the writable root (this is consistent
+            # with the storage of package data in this case).  As
+            # such, destroy any v1 catalog data that might exist
+            # and proceed.
+            shutil.rmtree(writ_cat_root, True)
+            writ_cat_root = None
+            if os.path.exists(v0_attrs) and not self.catalog.exists:
+                # A v0 catalog exists, but no v1 catalog exists;
+                # this can happen when a repository that was
+                # previously run with writable-root and
+                # read_only is now being run with only
+                # writable_root.
+                need_transform = True
+        elif writ_cat_root and v0_lm and self.read_only:
+            # The catalog lives in the writable_root if a v0 catalog
+            # exists, writ_cat_root is set, and readonly is True.
+            self.__set_catalog_root(writ_cat_root)
+
+        if self.mirror:
+            need_transform = False
+
+        if need_transform and self.read_only and not self.writable_root:
+            # Catalog data can't be transformed.
+            need_transform = False
+
+        if need_transform:
+            # v1 catalog should be destroyed if it exists already.
+            self.catalog.destroy()
+
+            # Create the transformed catalog.
+            self.__log(
+                _(
+                    "Transforming repository catalog; this "
+                    "process will take some time."
+                )
+            )
+            self.__rebuild(lm=v0_lm)
+
+            if not self.read_only and self.root:
+                v0_cat = os.path.join(self.root, "catalog", "catalog")
+                for f in v0_attrs, v0_cat:
+                    if os.path.exists(f):
+                        portable.remove(f)
+
+                # If this fails, it doesn't really matter, but
+                # it should be removed if possible.
+                shutil.rmtree(os.path.join(self.root, "updatelog"), True)
+
+        # Determine effective catalog version after all transformation
+        # work is complete.
+        if os.path.exists(v0_attrs):
+            # The only place a v1 catalog should exist, at all, is
+            # either in catalog_root or in a subdirectory of
+            # writable_root if a v0 catalog exists.
+            v1_cat = None
+            # If a writable root was specified, but the repository
+            # is not in read-only mode, then the catalog must not be
+            # stored using the writable root (this is consistent
+            # with the storage of package data in this case).
+            if self.writable_root and self.read_only:
+                writ_cat_root = os.path.join(self.writable_root, "catalog")
+                v1_cat = catalog.Catalog(
+                    meta_root=writ_cat_root, read_only=True
+                )
+
+            if v1_cat and v1_cat.exists:
+                self.catalog_version = 1
+                self.__set_catalog_root(v1_cat.meta_root)
+            else:
+                self.catalog_version = 0
+        else:
+            try:
+                if self.catalog.exists:
+                    self.catalog_version = 1
+            except apx.CatalogError as e:
+                if not allow_invalid:
+                    raise
+
+                # Catalog is invalid, but consumer wants to
+                # proceed; assume version 1.  This will allow
+                # pkgrepo rebuild, etc.
+                self.__log(str(e))
+                self.__catalog = catalog.Catalog(read_only=self.read_only)
+                self.catalog_verison = 1
                 return
 
-        def add_manifest(self, trans_id, data):
-                """Adds a manifest to an in-flight transaction.
+        if self.catalog_version >= 1 and not self.publisher:
+            # If there's no information available to determine
+            # the publisher identity, then assume it's the first
+            # publisher in this repository store's catalog.
+            # (This is reasonably safe since there should only
+            # ever be one.)
+            pubs = list(p for p in self.catalog.publishers())
+            if pubs:
+                self.publisher = pubs[0]
 
-                'trans_id' is the identifier of a transaction that
-                the manifest should be added to.
+    def __save_catalog(self, lm=None):
+        """Private helper function that attempts to save the catalog in
+        an atomic fashion."""
 
-                'data' is the string object containing the payload of the
-                manifest to add.
-                """
+        # Ensure new catalog is created in a temporary location so that
+        # it can be renamed into place *after* creation to prevent
+        # unexpected failure causing future updates to fail.
+        old_cat_root = self.catalog_root
+        tmp_cat_root = self.__mkdtemp()
 
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.trans_root:
-                        raise RepositoryUnsupportedOperationError()
+        try:
+            if os.path.exists(old_cat_root):
+                # Now remove the temporary directory and then
+                # copy the contents of the existing catalog
+                # directory to the new, temporary name.  This
+                # is necessary since the catalog only saves the
+                # data that has been loaded or changed, so new
+                # parts will get written out, but old ones could
+                # be lost.
+                shutil.rmtree(tmp_cat_root)
+                misc.copytree(old_cat_root, tmp_cat_root)
 
-                t = self.__get_transaction(trans_id)
+            # Ensure the permissions on the new temporary catalog
+            # directory are correct.
+            os.chmod(tmp_cat_root, misc.PKG_DIR_MODE)
+        except EnvironmentError as e:
+            # shutil.Error can contains a tuple of lists of errors.
+            # Some of the error entries may be a tuple others will
+            # be a string due to poor error handling in shutil.
+            if isinstance(e, shutil.Error) and type(e.args[0]) == list:
+                msg = ""
+                for elist in e.args:
+                    for entry in elist:
+                        if type(entry) == tuple:
+                            msg += "{0}\n".format(entry[-1])
+                        else:
+                            msg += "{0}\n".format(entry)
+                raise apx.UnknownErrors(msg)
+            elif e.errno == errno.EACCES or e.errno == errno.EPERM:
+                raise apx.PermissionsException(e.filename)
+            elif e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
+
+        # Save the new catalog data in the temporary location.
+        self.__set_catalog_root(tmp_cat_root)
+        if lm:
+            self.catalog.last_modified = lm
+        self.catalog.save(fmt=self.__catalogue_format)
+
+        orig_cat_root = None
+        if os.path.exists(old_cat_root):
+            # Preserve the old catalog data before continuing.
+            orig_cat_root = os.path.join(
+                os.path.dirname(old_cat_root),
+                "old." + os.path.basename(old_cat_root),
+            )
+            shutil.move(old_cat_root, orig_cat_root)
+
+        # Finally, rename the new catalog data into place, reset the
+        # catalog's location, and remove the old catalog data.
+        shutil.move(tmp_cat_root, old_cat_root)
+        self.__set_catalog_root(old_cat_root)
+        if orig_cat_root:
+            shutil.rmtree(orig_cat_root)
+
+        # Set catalog version.
+        self.catalog_version = self.catalog.version
+
+    def __set_catalog_root(self, root):
+        self.__catalog_root = root
+        if self.__catalog:
+            # If the catalog is loaded already, then reset
+            # its meta_root.
+            self.catalog.meta_root = root
+
+    def __set_root(self, root):
+        if root:
+            root = os.path.abspath(root)
+            self.__root = root
+            self.__tmp_root = os.path.join(root, "tmp")
+            self.__set_catalog_root(os.path.join(root, "catalog"))
+            self.index_root = os.path.join(root, "index")
+            self.manifest_root = os.path.join(root, "pkg")
+            self.trans_root = os.path.join(root, "trans")
+            if not self.file_root:
+                self.__set_file_root(os.path.join(root, "file"))
+        else:
+            self.__root = None
+            self.__set_catalog_root(None)
+            self.index_root = None
+            self.manifest_root = None
+            self.trans_root = None
+
+    def __set_file_root(self, root):
+        self.__file_root = root
+        if not root:
+            self.cache_store = None
+            return
+
+        self.cache_store = file_manager.FileManager(
+            root, self.read_only, layouts=self.__file_layout
+        )
+
+    def __set_writable_root(self, root):
+        if root:
+            root = os.path.abspath(root)
+            self.__tmp_root = os.path.join(root, "tmp")
+            self.index_root = os.path.join(root, "index")
+        elif self.root:
+            self.__tmp_root = os.path.join(self.root, "tmp")
+            self.index_root = os.path.join(self.root, "index")
+        else:
+            self.__tmp_root = None
+            self.index_root = None
+        self.__writable_root = root
+
+    def __unlock_rstore(self):
+        """Unlocks the repository so other consumers may modify it."""
+
+        try:
+            if self.__lockfile:
+                self.__lockfile.unlock()
+        finally:
+            self.__lock.release()
+
+    def __update_searchdb_unlocked(self, fmris):
+        """Creates an indexer then hands it fmris; it assumes that all
+        needed locking has already occurred.
+        """
+        assert self.index_root
+
+        if fmris:
+            index_inst = indexer.Indexer(
+                self.index_root,
+                self._get_manifest,
+                self.manifest,
+                log=self.__index_log,
+                sort_file_max_size=self.__sort_file_max_size,
+            )
+            index_inst.server_update_index(fmris)
+            if not self.__search_available:
+                self.__index_log("Search Available")
+            self.__search_available = True
+
+    def abandon(self, trans_id):
+        """Aborts a transaction with the specified Transaction ID.
+        Returns the current package state."""
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.trans_root:
+            raise RepositoryUnsupportedOperationError()
+
+        t = self.__get_transaction(trans_id)
+        try:
+            pstate = t.abandon()
+            self.__discard_transaction(trans_id)
+            return pstate
+        except trans.TransactionError as e:
+            raise RepositoryError(e)
+
+    def add(self, trans_id, action):
+        """Adds an action and its content to a transaction with the
+        specified Transaction ID."""
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.trans_root:
+            raise RepositoryUnsupportedOperationError()
+
+        t = self.__get_transaction(trans_id)
+        try:
+            t.add_content(action)
+        except trans.TransactionError as e:
+            raise RepositoryError(e)
+
+    def add_content(self, refresh_index=False):
+        """Looks for packages added to the repository that are not in
+        the catalog and adds them.
+
+        'refresh_index' is an optional boolean value indicating whether
+        search indexes should be updated.
+        """
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if not self.catalog_root or self.catalog_version == 0:
+            raise RepositoryUnsupportedOperationError()
+
+        self.__lock_rstore()
+        try:
+            self.__rebuild(
+                build_catalog=True, build_index=refresh_index, incremental=True
+            )
+        finally:
+            self.__unlock_rstore()
+
+    def add_file(self, trans_id, data, basename=None, size=None):
+        """Adds a file to an in-flight transaction.
+
+        'trans_id' is the identifier of a transaction that
+        the file should be added to.
+
+        'data' is the string object containing the payload of the
+        file to add.
+
+        'basename' is the basename of the file.
+
+        'size' is an optional integer value indicating the size of
+        the provided payload.
+        """
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.trans_root:
+            raise RepositoryUnsupportedOperationError()
+
+        t = self.__get_transaction(trans_id)
+        try:
+            t.add_file(data, basename, size)
+        except trans.TransactionError as e:
+            raise RepositoryError(e)
+        return
+
+    def add_manifest(self, trans_id, data):
+        """Adds a manifest to an in-flight transaction.
+
+        'trans_id' is the identifier of a transaction that
+        the manifest should be added to.
+
+        'data' is the string object containing the payload of the
+        manifest to add.
+        """
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.trans_root:
+            raise RepositoryUnsupportedOperationError()
+
+        t = self.__get_transaction(trans_id)
+        try:
+            t.add_manifest(data)
+        except trans.TransactionError as e:
+            raise RepositoryError(e)
+        return
+
+    def add_package(self, pfmri):
+        """Adds the specified FMRI to the repository's catalog."""
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.catalog_root or self.catalog_version < 1:
+            raise RepositoryUnsupportedOperationError()
+
+        self.__lock_rstore(blocking=True)
+        try:
+            self.__add_package(pfmri)
+            self.__save_catalog()
+        finally:
+            self.__unlock_rstore()
+
+    def replace_package(self, pfmri):
+        """Replaces the information for the specified FMRI in the
+        repository's catalog."""
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.catalog_root or self.catalog_version < 1:
+            raise RepositoryUnsupportedOperationError()
+
+        self.__lock_rstore(blocking=True)
+        try:
+            self.__replace_package(pfmri)
+            self.__save_catalog()
+        finally:
+            self.__unlock_rstore()
+
+    @property
+    def catalog(self):
+        """Returns the Catalog object for the repository's catalog."""
+
+        if self.__catalog:
+            # Already loaded.
+            return self.__catalog
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if not self.catalog_root:
+            # Object not available.
+            raise RepositoryUnsupportedOperationError()
+        if self.catalog_version == 0:
+            return old_catalog.ServerCatalog(
+                self.catalog_root, read_only=True, publisher=self.publisher
+            )
+
+        self.__catalog = catalog.Catalog(
+            meta_root=self.catalog_root,
+            log_updates=True,
+            read_only=self.read_only,
+        )
+        return self.__catalog
+
+    def catalog_0(self):
+        """Returns a generator object for the full version of
+        the catalog contents.  Incremental updates are not provided
+        as the v0 updatelog does not support renames, obsoletion,
+        package removal, etc."""
+
+        if not self.catalog_root or self.catalog_version < 0:
+            raise RepositoryUnsupportedOperationError()
+
+        if self.catalog_version == 0:
+            # If catalog is v0, it must be read and returned
+            # directly to the caller.
+            if not self.publisher:
+                raise RepositoryUnsupportedOperationError()
+            c = old_catalog.ServerCatalog(
+                self.catalog_root, read_only=True, publisher=self.publisher
+            )
+            output = cStringIO.StringIO()
+            c.send(output)
+            output.seek(0)
+            for l in output:
+                yield l
+            return
+
+        # For all other cases where the catalog object is available,
+        # fake a v0 catalog for the caller's sake.
+        c = self.catalog
+
+        # Yield each catalog attr in the v0 format:
+        # S Last-Modified: 2009-08-28T15:01:48.546606
+        # S prefix: CRSV
+        # S npkgs: 46292
+        yield "S Last-Modified: {0}\n".format(c.last_modified.isoformat())
+        yield "S prefix: CRSV\n"
+        yield "S npkgs: {0}\n".format(c.package_version_count)
+
+        # Now yield each FMRI in the catalog in the v0 format:
+        # V pkg:/SUNWdvdrw@5.21.4.10.8,5.11-0.86:20080426T173208Z
+        for pub, stem, ver in c.tuples():
+            yield "V pkg:/{0}@{1}\n".format(stem, ver)
+
+    def catalog_1(self, name):
+        """Returns the absolute pathname of the named catalog file."""
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if not self.catalog_root or self.catalog_version < 1:
+            raise RepositoryUnsupportedOperationError()
+
+        assert name
+        return os.path.normpath(os.path.join(self.catalog_root, name))
+
+    def reset_search(self):
+        """Discards currenty loaded search data so that it will be
+        reloaded the next a search is performed.
+        """
+        if not self.index_root:
+            # Nothing to do.
+            return
+        sqp.TermQuery.clear_cache(self.index_root)
+
+    def close(self, trans_id, add_to_catalog=True):
+        """Closes the transaction specified by 'trans_id'.
+
+        Returns a tuple containing the package FMRI and the current
+        package state in the catalog."""
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if not self.trans_root:
+            raise RepositoryUnsupportedOperationError()
+
+        # The repository store should not be locked at this point
+        # as transaction will trigger that indirectly through
+        # add_package().
+        t = self.__get_transaction(trans_id)
+        try:
+            pfmri, pstate = t.close(add_to_catalog=add_to_catalog)
+            self.__discard_transaction(trans_id)
+            return pfmri, pstate
+        except (apx.CatalogError, trans.TransactionError) as e:
+            raise RepositoryError(e)
+
+    def insert_file(self, fhash, src_path):
+        """Add the content at "src_path" to the files under the name
+        "hashval". Returns the path to the inserted file."""
+
+        if not self.file_root:
+            raise RepositoryUnsupportedOperationError()
+
+        if fhash is None:
+            raise RepositoryFileNotFoundError(fhash)
+
+        fp = self.cache_store.insert(fhash, src_path)
+        if fp is not None:
+            return fp
+        raise RepositoryFileNotFoundError(fhash)
+
+    def copy_file(self, fhash, src_path):
+        """Copy the content at "src_path" to the files under the name
+        "hashval".  Returns the path to the copied file."""
+
+        if not self.file_root:
+            raise RepositoryUnsupportedOperationError()
+
+        if fhash is None:
+            raise RepositoryFileNotFoundError(fhash)
+
+        fp = self.cache_store.copy(fhash, src_path)
+        if fp is not None:
+            return fp
+        raise RepositoryFileNotFoundError(fhash)
+
+    def file(self, fhash):
+        """Returns the absolute pathname of the file specified by the
+        provided SHA-n hash name. (At present, the repository format
+        always uses the least-preferred hash to content in order to
+        remain backwards compatible with older clients. Actions may be
+        published that have additional hashes set, but those do not
+        influence where the content is stored in the repository.)"""
+
+        if not self.file_root:
+            raise RepositoryUnsupportedOperationError()
+
+        if fhash is None:
+            raise RepositoryFileNotFoundError(fhash)
+
+        fp = self.cache_store.lookup(fhash)
+        if fp is not None:
+            return fp
+        raise RepositoryFileNotFoundError(fhash)
+
+    def get_publisher(self):
+        """Return the Publisher object for this storage object or None
+        if not available.
+        """
+
+        if not self.publisher:
+            raise RepositoryUnsupportedOperationError()
+
+        if self.root:
+            # Determine if configuration for publisher exists
+            # on-disk already and then return that if it does.
+            p5ipath = os.path.join(self.root, "pub.p5i")
+            if os.path.exists(p5ipath):
+                pubs = p5i.parse(location=p5ipath)
+                if pubs:
+                    # Only expecting one, so only return
+                    # the first.
+                    return pubs[0][0]
+
+        # No p5i exists, or existing one doesn't contain publisher info,
+        # so return a stub publisher object.
+        return publisher.Publisher(self.publisher)
+
+    def has_transaction(self, trans_id):
+        """Returns a boolean value indicating whether the given
+        in-flight Transaction ID exists.
+        """
+
+        try:
+            self.__get_transaction(trans_id)
+            return True
+        except RepositoryInvalidTransactionIDError:
+            return False
+
+    @property
+    def in_flight_transactions(self):
+        """The number of transactions awaiting completion."""
+        return len(self.__in_flight_trans)
+
+    @property
+    def locked(self):
+        """A boolean value indicating whether the repository is locked."""
+
+        return self.__lockfile and self.__lockfile.locked
+
+    def manifest(self, pfmri):
+        """Returns the absolute pathname of the manifest file for the
+        specified FMRI."""
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if not self.manifest_root:
+            raise RepositoryUnsupportedOperationError()
+        return os.path.join(self.manifest_root, pfmri.get_dir_path())
+
+    def open(self, client_release, pfmri):
+        """Starts a transaction for the specified client release and
+        FMRI.  Returns the Transaction ID for the new transaction."""
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.trans_root:
+            raise RepositoryUnsupportedOperationError()
+
+        try:
+            t = trans.Transaction()
+            t.open(self, client_release, pfmri)
+            self.__in_flight_trans[t.get_basename()] = t
+            return t.get_basename()
+        except trans.TransactionError as e:
+            raise RepositoryError(e)
+
+    def append(self, client_release, pfmri):
+        """Starts an append transaction for the specified client
+        release and FMRI.  Returns the Transaction ID for the new
+        transaction."""
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.trans_root:
+            raise RepositoryUnsupportedOperationError()
+
+        try:
+            t = trans.Transaction()
+            t.append(self, client_release, pfmri)
+            self.__in_flight_trans[t.get_basename()] = t
+            return t.get_basename()
+        except trans.TransactionError as e:
+            raise RepositoryError(e)
+
+    def refresh_index(self):
+        """This function refreshes the search indexes if there any new
+        packages.
+        """
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if not self.index_root:
+            raise RepositoryUnsupportedOperationError()
+
+        # Acquire only the thread-lock.  The Indexer has its own
+        # process lock.  This allows indexing and publication to occur
+        # simultaneously.
+        self.__lock_rstore(process=False)
+        try:
+            try:
                 try:
-                        t.add_manifest(data)
-                except trans.TransactionError as e:
-                        raise RepositoryError(e)
-                return
+                    self.__refresh_index()
+                except se.InconsistentIndexException as e:
+                    s = _(
+                        "Index corrupted or out of date. "
+                        "Removing old index directory ({0}) "
+                        " and rebuilding search "
+                        "indexes."
+                    ).format(e.cause)
+                    self.__log(s, "INDEX")
+                    try:
+                        self.__rebuild(build_catalog=False, build_index=True)
+                    except se.IndexingException as e:
+                        self.__log(str(e), "INDEX")
+                except se.IndexingException as e:
+                    self.__log(str(e), "INDEX")
+            except EnvironmentError as e:
+                if e.errno in (errno.EACCES, errno.EROFS):
+                    if self.writable_root:
+                        raise RepositoryError(
+                            _(
+                                "writable root not "
+                                "writable by current user "
+                                "id or group."
+                            )
+                        )
+                    raise RepositoryError(
+                        _("unable to " "write to index directory.")
+                    )
+                raise
+        finally:
+            self.__unlock_rstore()
 
-        def add_package(self, pfmri):
-                """Adds the specified FMRI to the repository's catalog."""
+    def remove_packages(self, packages, progtrack=None):
+        """Removes the specified packages from the repository store.  No
+        other modifying operations may be performed until complete.
 
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.catalog_root or self.catalog_version < 1:
-                        raise RepositoryUnsupportedOperationError()
+        'packages' is a list of FMRIs of packages to remove.
 
-                self.__lock_rstore(blocking=True)
+        'progtrack' is an optional ProgressTracker object.
+        """
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.catalog_root or self.catalog_version < 1:
+            raise RepositoryUnsupportedOperationError()
+        if not self.manifest_root:
+            raise RepositoryUnsupportedOperationError()
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        def get_hashes(pfmri):
+            """Given an FMRI, return a set of tuples containing all
+            of the hashes of the files its manifest references.
+            Each tuple is of the form (hash value, hash function)"""
+
+            m = self._get_manifest(pfmri)
+            hashes = set()
+            for a in m.gen_actions():
+                if not a.has_payload:
+                    # Nothing to archive.
+                    continue
+
+                # Action payload.
+                hattr, hval, hfunc = digest.get_least_preferred_hash(a)
+                hashes.add(hval)
+
+                # Signature actions have additional payloads.
+                if a.name == "signature":
+                    for c in a.get_chain_certs(least_preferred=True):
+                        hashes.add(c)
+            return hashes
+
+        self.__lock_rstore()
+        c = self.catalog
+        try:
+            # First, dump all search data as it will be invalidated
+            # as soon as the catalog is updated.
+            progtrack.job_start(progtrack.JOB_REPO_DELSEARCH)
+            progtrack.job_add_progress(progtrack.JOB_REPO_DELSEARCH)
+            self.__purge_search_index()
+            progtrack.job_add_progress(progtrack.JOB_REPO_DELSEARCH)
+            progtrack.job_done(progtrack.JOB_REPO_DELSEARCH)
+
+            # Next, remove all of the packages to be removed
+            # from the catalog (if they are present).  That way
+            # any active clients are less likely to be surprised
+            # when files for packages start disappearing.
+            progtrack.job_start(progtrack.JOB_REPO_UPDATE_CAT)
+            c.batch_mode = True
+            save_catalog = False
+            for pfmri in packages:
+                progtrack.job_add_progress(progtrack.JOB_REPO_UPDATE_CAT)
                 try:
-                        self.__add_package(pfmri)
-                        self.__save_catalog()
-                finally:
-                        self.__unlock_rstore()
+                    c.remove_package(pfmri)
+                except apx.UnknownCatalogEntry:
+                    # Assume already removed from catalog or
+                    # not yet added to it.
+                    continue
+                save_catalog = True
 
-        def replace_package(self, pfmri):
-                """Replaces the information for the specified FMRI in the
-                repository's catalog."""
+            progtrack.job_add_progress(progtrack.JOB_REPO_UPDATE_CAT)
+            c.batch_mode = False
+            if save_catalog:
+                # Only need to re-write catalog if at least one
+                # package had to be removed from it.
+                c.finalize(pfmris=packages)
+                c.save()
 
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.catalog_root or self.catalog_version < 1:
-                        raise RepositoryUnsupportedOperationError()
+            progtrack.job_done(progtrack.JOB_REPO_UPDATE_CAT)
 
-                self.__lock_rstore(blocking=True)
-                try:
-                        self.__replace_package(pfmri)
-                        self.__save_catalog()
-                finally:
-                        self.__unlock_rstore()
+            # Next, build a list of all of the hashes for the files
+            # that can potentially be removed from the repository.
+            # This will also indirectly abort the operation should
+            # any of the packages not actually have a manifest in
+            # the repository.
+            pfiles = set()
+            progtrack.job_start(
+                progtrack.JOB_REPO_ANALYZE_RM, goal=len(packages)
+            )
+            for pfmri in packages:
+                pfiles.update(get_hashes(pfmri))
+                progtrack.job_add_progress(progtrack.JOB_REPO_ANALYZE_RM)
+            progtrack.job_done(progtrack.JOB_REPO_ANALYZE_RM)
 
-        @property
-        def catalog(self):
-                """Returns the Catalog object for the repository's catalog."""
+            # Now for the slow part; iterate over every manifest in
+            # the repository (excluding the ones being removed) and
+            # remove any hashes in use from the list to be removed.
+            # However, if the package being removed doesn't have any
+            # payloads, then we can skip checking all of the
+            # packages in the repository for files in use.
+            if pfiles:
+                # Number of packages to check is total found in
+                # repo minus number to be removed.
+                slist = os.listdir(self.manifest_root)
+                remaining = sum(
+                    1
+                    for s in slist
+                    for v in os.listdir(os.path.join(self.manifest_root, s))
+                )
 
-                if self.__catalog:
-                        # Already loaded.
-                        return self.__catalog
+                progtrack.job_start(
+                    progtrack.JOB_REPO_ANALYZE_REPO, goal=remaining
+                )
+                for name in slist:
+                    # Stem must be decoded before use.
+                    try:
+                        pname = unquote(name)
+                    except Exception:
+                        # Assume error is result of
+                        # unexpected file in directory;
+                        # just skip it and drive on.
+                        continue
 
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if not self.catalog_root:
-                        # Object not available.
-                        raise RepositoryUnsupportedOperationError()
-                if self.catalog_version == 0:
-                        return old_catalog.ServerCatalog(self.catalog_root,
-                            read_only=True, publisher=self.publisher)
+                    pdir = os.path.join(self.manifest_root, name)
+                    for ver in os.listdir(pdir):
+                        if not pfiles:
+                            # Skip remaining entries
+                            # since no files are
+                            # safe to remove, but
+                            # update progress.
+                            progtrack.job_add_progress(
+                                progtrack.JOB_REPO_ANALYZE_REPO
+                            )
+                            continue
 
-                self.__catalog = catalog.Catalog(meta_root=self.catalog_root,
-                    log_updates=True, read_only=self.read_only)
-                return self.__catalog
-
-        def catalog_0(self):
-                """Returns a generator object for the full version of
-                the catalog contents.  Incremental updates are not provided
-                as the v0 updatelog does not support renames, obsoletion,
-                package removal, etc."""
-
-                if not self.catalog_root or self.catalog_version < 0:
-                        raise RepositoryUnsupportedOperationError()
-
-                if self.catalog_version == 0:
-                        # If catalog is v0, it must be read and returned
-                        # directly to the caller.
-                        if not self.publisher:
-                                raise RepositoryUnsupportedOperationError()
-                        c = old_catalog.ServerCatalog(self.catalog_root,
-                            read_only=True, publisher=self.publisher)
-                        output = cStringIO.StringIO()
-                        c.send(output)
-                        output.seek(0)
-                        for l in output:
-                                yield l
-                        return
-
-                # For all other cases where the catalog object is available,
-                # fake a v0 catalog for the caller's sake.
-                c = self.catalog
-
-                # Yield each catalog attr in the v0 format:
-                # S Last-Modified: 2009-08-28T15:01:48.546606
-                # S prefix: CRSV
-                # S npkgs: 46292
-                yield "S Last-Modified: {0}\n".format(
-                    c.last_modified.isoformat())
-                yield "S prefix: CRSV\n"
-                yield "S npkgs: {0}\n".format(c.package_version_count)
-
-                # Now yield each FMRI in the catalog in the v0 format:
-                # V pkg:/SUNWdvdrw@5.21.4.10.8,5.11-0.86:20080426T173208Z
-                for pub, stem, ver in c.tuples():
-                        yield "V pkg:/{0}@{1}\n".format(stem, ver)
-
-        def catalog_1(self, name):
-                """Returns the absolute pathname of the named catalog file."""
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if not self.catalog_root or self.catalog_version < 1:
-                        raise RepositoryUnsupportedOperationError()
-
-                assert name
-                return os.path.normpath(os.path.join(self.catalog_root, name))
-
-        def reset_search(self):
-                """Discards currenty loaded search data so that it will be
-                reloaded the next a search is performed.
-                """
-                if not self.index_root:
-                        # Nothing to do.
-                        return
-                sqp.TermQuery.clear_cache(self.index_root)
-
-        def close(self, trans_id, add_to_catalog=True):
-                """Closes the transaction specified by 'trans_id'.
-
-                Returns a tuple containing the package FMRI and the current
-                package state in the catalog."""
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if not self.trans_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                # The repository store should not be locked at this point
-                # as transaction will trigger that indirectly through
-                # add_package().
-                t = self.__get_transaction(trans_id)
-                try:
-                        pfmri, pstate = t.close(
-                            add_to_catalog=add_to_catalog)
-                        self.__discard_transaction(trans_id)
-                        return pfmri, pstate
-                except (apx.CatalogError,
-                    trans.TransactionError) as e:
-                        raise RepositoryError(e)
-
-        def insert_file(self, fhash, src_path):
-                """Add the content at "src_path" to the files under the name
-                "hashval". Returns the path to the inserted file."""
-
-                if not self.file_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                if fhash is None:
-                        raise RepositoryFileNotFoundError(fhash)
-
-                fp = self.cache_store.insert(fhash, src_path)
-                if fp is not None:
-                        return fp
-                raise RepositoryFileNotFoundError(fhash)
-
-        def copy_file(self, fhash, src_path):
-                """Copy the content at "src_path" to the files under the name
-                "hashval".  Returns the path to the copied file."""
-
-                if not self.file_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                if fhash is None:
-                        raise RepositoryFileNotFoundError(fhash)
-
-                fp = self.cache_store.copy(fhash, src_path)
-                if fp is not None:
-                        return fp
-                raise RepositoryFileNotFoundError(fhash)
-
-        def file(self, fhash):
-                """Returns the absolute pathname of the file specified by the
-                provided SHA-n hash name. (At present, the repository format
-                always uses the least-preferred hash to content in order to
-                remain backwards compatible with older clients. Actions may be
-                published that have additional hashes set, but those do not
-                influence where the content is stored in the repository.)"""
-
-                if not self.file_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                if fhash is None:
-                        raise RepositoryFileNotFoundError(fhash)
-
-                fp = self.cache_store.lookup(fhash)
-                if fp is not None:
-                        return fp
-                raise RepositoryFileNotFoundError(fhash)
-
-        def get_publisher(self):
-                """Return the Publisher object for this storage object or None
-                if not available.
-                """
-
-                if not self.publisher:
-                        raise RepositoryUnsupportedOperationError()
-
-                if self.root:
-                        # Determine if configuration for publisher exists
-                        # on-disk already and then return that if it does.
-                        p5ipath = os.path.join(self.root, "pub.p5i")
-                        if os.path.exists(p5ipath):
-                                pubs = p5i.parse(location=p5ipath)
-                                if pubs:
-                                        # Only expecting one, so only return
-                                        # the first.
-                                        return pubs[0][0]
-
-                # No p5i exists, or existing one doesn't contain publisher info,
-                # so return a stub publisher object.
-                return publisher.Publisher(self.publisher)
-
-        def has_transaction(self, trans_id):
-                """Returns a boolean value indicating whether the given
-                in-flight Transaction ID exists.
-                """
-
-                try:
-                        self.__get_transaction(trans_id)
-                        return True
-                except RepositoryInvalidTransactionIDError:
-                        return False
-
-        @property
-        def in_flight_transactions(self):
-                """The number of transactions awaiting completion."""
-                return len(self.__in_flight_trans)
-
-        @property
-        def locked(self):
-                """A boolean value indicating whether the repository is locked.
-                """
-
-                return self.__lockfile and self.__lockfile.locked
-
-        def manifest(self, pfmri):
-                """Returns the absolute pathname of the manifest file for the
-                specified FMRI."""
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if not self.manifest_root:
-                        raise RepositoryUnsupportedOperationError()
-                return os.path.join(self.manifest_root, pfmri.get_dir_path())
-
-        def open(self, client_release, pfmri):
-                """Starts a transaction for the specified client release and
-                FMRI.  Returns the Transaction ID for the new transaction."""
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.trans_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                try:
-                        t = trans.Transaction()
-                        t.open(self, client_release, pfmri)
-                        self.__in_flight_trans[t.get_basename()] = t
-                        return t.get_basename()
-                except trans.TransactionError as e:
-                        raise RepositoryError(e)
-
-        def append(self, client_release, pfmri):
-                """Starts an append transaction for the specified client
-                release and FMRI.  Returns the Transaction ID for the new
-                transaction."""
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.trans_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                try:
-                        t = trans.Transaction()
-                        t.append(self, client_release, pfmri)
-                        self.__in_flight_trans[t.get_basename()] = t
-                        return t.get_basename()
-                except trans.TransactionError as e:
-                        raise RepositoryError(e)
-
-        def refresh_index(self):
-                """This function refreshes the search indexes if there any new
-                packages.
-                """
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if not self.index_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                # Acquire only the thread-lock.  The Indexer has its own
-                # process lock.  This allows indexing and publication to occur
-                # simultaneously.
-                self.__lock_rstore(process=False)
-                try:
+                        # Version must be decoded before
+                        # use.
+                        pver = unquote(ver)
                         try:
-                                try:
-                                        self.__refresh_index()
-                                except se.InconsistentIndexException as e:
-                                        s = _("Index corrupted or out of date. "
-                                            "Removing old index directory ({0}) "
-                                            " and rebuilding search "
-                                            "indexes.").format(e.cause)
-                                        self.__log(s, "INDEX")
-                                        try:
-                                                self.__rebuild(
-                                                    build_catalog=False,
-                                                    build_index=True)
-                                        except se.IndexingException as e:
-                                                self.__log(str(e), "INDEX")
-                                except se.IndexingException as e:
-                                        self.__log(str(e), "INDEX")
-                        except EnvironmentError as e:
-                                if e.errno in (errno.EACCES, errno.EROFS):
-                                        if self.writable_root:
-                                                raise RepositoryError(
-                                                    _("writable root not "
-                                                    "writable by current user "
-                                                    "id or group."))
-                                        raise RepositoryError(_("unable to "
-                                            "write to index directory."))
-                                raise
-                finally:
-                        self.__unlock_rstore()
-
-        def remove_packages(self, packages, progtrack=None):
-                """Removes the specified packages from the repository store.  No
-                other modifying operations may be performed until complete.
-
-                'packages' is a list of FMRIs of packages to remove.
-
-                'progtrack' is an optional ProgressTracker object.
-                """
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.catalog_root or self.catalog_version < 1:
-                        raise RepositoryUnsupportedOperationError()
-                if not self.manifest_root:
-                        raise RepositoryUnsupportedOperationError()
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
-
-                def get_hashes(pfmri):
-                        """Given an FMRI, return a set of tuples containing all
-                        of the hashes of the files its manifest references.
-                        Each tuple is of the form (hash value, hash function)"""
-
-                        m = self._get_manifest(pfmri)
-                        hashes = set()
-                        for a in m.gen_actions():
-                                if not a.has_payload:
-                                        # Nothing to archive.
-                                        continue
-
-                                # Action payload.
-                                hattr, hval, hfunc = \
-                                    digest.get_least_preferred_hash(a)
-                                hashes.add(hval)
-
-                                # Signature actions have additional payloads.
-                                if a.name == "signature":
-                                        for c in a.get_chain_certs(
-                                            least_preferred=True):
-                                                hashes.add(c)
-                        return hashes
-
-                self.__lock_rstore()
-                c = self.catalog
-                try:
-                        # First, dump all search data as it will be invalidated
-                        # as soon as the catalog is updated.
-                        progtrack.job_start(progtrack.JOB_REPO_DELSEARCH)
-                        progtrack.job_add_progress(progtrack.JOB_REPO_DELSEARCH)
-                        self.__purge_search_index()
-                        progtrack.job_add_progress(progtrack.JOB_REPO_DELSEARCH)
-                        progtrack.job_done(progtrack.JOB_REPO_DELSEARCH)
-
-                        # Next, remove all of the packages to be removed
-                        # from the catalog (if they are present).  That way
-                        # any active clients are less likely to be surprised
-                        # when files for packages start disappearing.
-                        progtrack.job_start(progtrack.JOB_REPO_UPDATE_CAT)
-                        c.batch_mode = True
-                        save_catalog = False
-                        for pfmri in packages:
-                                progtrack.job_add_progress(
-                                    progtrack.JOB_REPO_UPDATE_CAT)
-                                try:
-                                        c.remove_package(pfmri)
-                                except apx.UnknownCatalogEntry:
-                                        # Assume already removed from catalog or
-                                        # not yet added to it.
-                                        continue
-                                save_catalog = True
-
-                        progtrack.job_add_progress(
-                            progtrack.JOB_REPO_UPDATE_CAT)
-                        c.batch_mode = False
-                        if save_catalog:
-                                # Only need to re-write catalog if at least one
-                                # package had to be removed from it.
-                                c.finalize(pfmris=packages)
-                                c.save()
-
-                        progtrack.job_done(progtrack.JOB_REPO_UPDATE_CAT)
-
-                        # Next, build a list of all of the hashes for the files
-                        # that can potentially be removed from the repository.
-                        # This will also indirectly abort the operation should
-                        # any of the packages not actually have a manifest in
-                        # the repository.
-                        pfiles = set()
-                        progtrack.job_start(progtrack.JOB_REPO_ANALYZE_RM,
-                            goal=len(packages))
-                        for pfmri in packages:
-                                pfiles.update(get_hashes(pfmri))
-                                progtrack.job_add_progress(
-                                    progtrack.JOB_REPO_ANALYZE_RM)
-                        progtrack.job_done(progtrack.JOB_REPO_ANALYZE_RM)
-
-                        # Now for the slow part; iterate over every manifest in
-                        # the repository (excluding the ones being removed) and
-                        # remove any hashes in use from the list to be removed.
-                        # However, if the package being removed doesn't have any
-                        # payloads, then we can skip checking all of the
-                        # packages in the repository for files in use.
-                        if pfiles:
-                                # Number of packages to check is total found in
-                                # repo minus number to be removed.
-                                slist = os.listdir(self.manifest_root)
-                                remaining = sum(
-                                    1
-                                    for s in slist
-                                    for v in os.listdir(os.path.join(
-                                        self.manifest_root, s))
-                                )
-
-                                progtrack.job_start(
-                                    progtrack.JOB_REPO_ANALYZE_REPO,
-                                    goal=remaining)
-                                for name in slist:
-                                        # Stem must be decoded before use.
-                                        try:
-                                                pname = unquote(name)
-                                        except Exception:
-                                                # Assume error is result of
-                                                # unexpected file in directory;
-                                                # just skip it and drive on.
-                                                continue
-
-                                        pdir = os.path.join(self.manifest_root,
-                                            name)
-                                        for ver in os.listdir(pdir):
-                                                if not pfiles:
-                                                        # Skip remaining entries
-                                                        # since no files are
-                                                        # safe to remove, but
-                                                        # update progress.
-                                                        progtrack.job_add_progress(progtrack.JOB_REPO_ANALYZE_REPO)
-                                                        continue
-
-                                                # Version must be decoded before
-                                                # use.
-                                                pver = unquote(ver)
-                                                try:
-                                                        pfmri = fmri.PkgFmri(
-                                                            "@".join((pname,
-                                                            pver)), publisher=self.publisher)
-                                                except Exception:
-                                                        # Assume error is result
-                                                        # of unexpected file in
-                                                        # directory; just skip
-                                                        # it and drive on.
-                                                        progtrack.job_add_progress(progtrack.JOB_REPO_ANALYZE_REPO)
-                                                        continue
-
-                                                if pfmri in packages:
-                                                        # Package is one of
-                                                        # those queued for
-                                                        # removal.
-                                                        progtrack.job_add_progress(progtrack.JOB_REPO_ANALYZE_REPO)
-                                                        continue
-
-                                                # Any files in use by another
-                                                # package can't be removed.
-                                                pfiles -= get_hashes(pfmri)
-                                                progtrack.job_add_progress(progtrack.JOB_REPO_ANALYZE_REPO)
-                                progtrack.job_done(
-                                    progtrack.JOB_REPO_ANALYZE_REPO)
-
-                        # Next, remove the manifests of the packages to be
-                        # removed.  (This is done before removing the files
-                        # so that clients won't have a chance to retrieve a
-                        # manifest which has missing files.)
-                        progtrack.job_start(progtrack.JOB_REPO_RM_MFST,
-                            goal=len(packages))
-                        for pfmri in packages:
-                                mpath = self.manifest(pfmri)
-                                portable.remove(mpath)
-                                progtrack.job_add_progress(
-                                    progtrack.JOB_REPO_RM_MFST)
-                        progtrack.job_done(progtrack.JOB_REPO_RM_MFST)
-
-                        # Next, remove any package files that are not
-                        # referenced by other packages.
-                        progtrack.job_start(progtrack.JOB_REPO_RM_FILES,
-                            goal=len(pfiles))
-                        for h in pfiles:
-                                # File might already be gone (don't care if
-                                # it is).
-                                fpath = self.cache_store.lookup(h)
-                                if fpath is not None:
-                                        portable.remove(fpath)
-                                progtrack.job_add_progress(
-                                        progtrack.JOB_REPO_RM_FILES)
-                        progtrack.job_done(progtrack.JOB_REPO_RM_FILES)
-
-                        # Finally, tidy up repository structure by discarding
-                        # unused package data directories for any packages
-                        # removed.
-                        def rmdir(d):
-                                """rmdir; but ignores non-empty directories."""
-                                try:
-                                        os.rmdir(d)
-                                except OSError as e:
-                                        if e.errno not in (
-                                            errno.ENOTEMPTY,
-                                            errno.EEXIST):
-                                                raise
-
-                        for name in set(
-                            f.get_dir_path(stemonly=True)
-                            for f in packages):
-                                rmdir(os.path.join(self.manifest_root, name))
-
-                        if self.file_root:
-                                try:
-                                        for entry in os.listdir(self.file_root):
-                                                rmdir(os.path.join(
-                                                    self.file_root, entry))
-                                except EnvironmentError as e:
-                                        if e.errno != errno.ENOENT:
-                                                raise
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
-                finally:
-                        # This ensures batch_mode is reset in the event of an
-                        # error.
-                        c.batch_mode = False
-                        self.__unlock_rstore()
-
-        def rebuild(self, build_catalog=True, build_index=False):
-                """Rebuilds the repository catalog and search indexes using the
-                package manifests currently in the repository.
-
-                'build_catalog' is an optional boolean value indicating whether
-                package catalogs should be rebuilt.  If True, existing search
-                data will be discarded.
-
-                'build_index' is an optional boolean value indicating whether
-                search indexes should be built.
-                """
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.catalog_root or self.catalog_version == 0:
-                        raise RepositoryUnsupportedOperationError()
-
-                self.__lock_rstore()
-                try:
-                        self.__rebuild(build_catalog=build_catalog,
-                            build_index=build_index)
-                finally:
-                        self.__unlock_rstore()
-
-        def __run_update_index(self):
-                """ Determines which fmris need to be indexed and passes them
-                to the indexer.
-
-                Note: Only one instance of this method should be running.
-                External locking is expected to ensure this behavior. Calling
-                refresh index is the preferred method to use to reindex.
-                """
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if not self.index_root or self.catalog_version < 1:
-                        raise RepositoryUnsupportedOperationError()
-
-                c = self.catalog
-                fmris_to_index = indexer.Indexer.check_for_updates(
-                    self.index_root, c)
-
-                if fmris_to_index:
-                        self.__index_log("Updating search indexes")
-                        self.__update_searchdb_unlocked(fmris_to_index)
-                else:
-                        ind = indexer.Indexer(self.index_root,
-                            self._get_manifest, self.manifest,
-                            log=self.__index_log,
-                            sort_file_max_size=self.__sort_file_max_size)
-                        ind.setup()
-                        if not self.__search_available:
-                                self.__index_log("Search Available")
-                        self.__search_available = True
-
-        def search(self, queries):
-                """Searches the index for each query in the list of queries.
-                Each entry should be the output of str(Query), or a Query
-                object."""
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if not self.index_root or not self.catalog_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                self.__check_search()
-                if not self.search_available:
-                        raise RepositorySearchUnavailableError()
-
-                def _search(q):
-                        assert self.index_root
-                        l = sqp.QueryLexer()
-                        l.build()
-                        qqp = sqp.QueryParser(l)
-                        query = qqp.parse(q.text)
-                        query.set_info(num_to_return=q.num_to_return,
-                            start_point=q.start_point,
-                            index_dir=self.index_root,
-                            get_manifest_path=self.manifest,
-                            case_sensitive=q.case_sensitive)
-                        if q.return_type == sqp.Query.RETURN_PACKAGES:
-                                query.propagate_pkg_return()
-                        return query.search(self.catalog.fmris)
-
-                query_lst = []
-                try:
-                        for s in queries:
-                                if not isinstance(s, qp.Query):
-                                        query_lst.append(
-                                            sqp.Query.fromstr(s))
-                                else:
-                                        query_lst.append(s)
-                except sqp.QueryException as e:
-                        raise RepositoryError(e)
-                return [_search(q) for q in query_lst]
-
-        @property
-        def search_available(self):
-                return (self.__search_available and self.index_root and
-                    os.path.exists(self.index_root)) or self.__check_search()
-
-        def update_publisher(self, pub):
-                """Updates the configuration information for the publisher
-                defined by the provided Publisher object.
-                """
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.root:
-                        raise RepositoryUnsupportedOperationError()
-
-                p5ipath = os.path.join(self.root, "pub.p5i")
-                fn = None
-                try:
-                        dirname = os.path.dirname(p5ipath)
-                        fd, fn = tempfile.mkstemp(dir=dirname)
-
-                        st = None
-                        try:
-                                st = os.stat(p5ipath)
-                        except OSError as e:
-                                if e.errno != errno.ENOENT:
-                                        raise
-
-                        if st:
-                                os.fchmod(fd, stat.S_IMODE(st.st_mode))
-                                try:
-                                        portable.chown(fn, st.st_uid, st.st_gid)
-                                except OSError as e:
-                                        if e.errno != errno.EPERM:
-                                                raise
-                        else:
-                                os.fchmod(fd, misc.PKG_FILE_MODE)
-
-                        if six.PY2:
-                                with os.fdopen(fd, "wb") as f:
-                                        with codecs.EncodedFile(f, "utf-8") as ef:
-                                                p5i.write(ef, [pub])
-                        else:
-                               # we use json.dump() in p5i.write(),
-                               # json module will produce str objects
-                               # in Python 3, therefore fp.write()
-                               # must support str input.
-
-                                with open(fd, "w", encoding="utf-8") as fp:
-                                        p5i.write(fp, [pub])
-                        portable.rename(fn, p5ipath)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        elif e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
-                finally:
-                        if fn and os.path.exists(fn):
-                                os.unlink(fn)
-
-        def __build_verify_error(self, error, path, reason):
-                """Given an integer error code, a path within the repository,
-                and a 'reason' dictionary containing more information about
-                the error, return a tuple of the form:
-
-                (error_code, message, path, reason)
-                """
-
-                # if we're looking at a path to a file hash, and we have a pfmri
-                # we'd like to print the 'path' attribute as well as its
-                # location within the repository.
-                hsh = reason.get("fname")
-                pfmri = reason.get("pkg")
-                if hsh and pfmri:
-                        m = self._get_manifest(pfmri)
-                        # this is not terribly efficient, but the expectation is
-                        # that this will rarely happen.
-                        for ac in m.gen_actions_by_types(
-                            actions.payload_types.keys()):
-                                for hash in digest.DEFAULT_HASH_ATTRS:
-                                        if ac.attrs.get(hash) == hsh:
-                                                fpath = ac.attrs.get("path")
-                                                if fpath:
-                                                        reason["fpath"] = fpath
-                                if ac.hash == hsh:
-                                        fpath = ac.attrs.get("path")
-                                        if fpath:
-                                                reason["fpath"] = fpath
-
-                message = _("Unknown error")
-                if error == REPO_VERIFY_BADHASH:
-                        message = _("Invalid file hash: {0}").format(
-                            reason["hash"])
-                        del reason["hash"]
-                elif error == REPO_VERIFY_BADMANIFEST:
-                        message = _("Corrupt manifest.")
-                        reason["err"] = _("Use pkglint(1) for more details.")
-                elif error == REPO_VERIFY_NOFILE:
-                        message = _("Missing file: {0}").format(reason["fname"])
-                        del reason["fname"]
-                elif error == REPO_VERIFY_BADGZIP:
-                        message = _("Corrupted gzip file.")
-                elif error in [REPO_VERIFY_PERM, REPO_VERIFY_MFPERM]:
-                        message = _("Verification failure: {0}").format(
-                            reason["err"])
-                        del reason["err"]
-                elif error == REPO_VERIFY_UNKNOWN:
-                        message = _("Bad manifest.")
-                elif error == REPO_VERIFY_BADSIG:
-                        message = _("Bad signature.")
-                elif error == REPO_VERIFY_WARN_OPENPERMS:
-                        # This message constitutes a warning rather than
-                        # an error. No attempt is made by 'pkgrepo fix'
-                        # to rectify this error, as it is potentially
-                        # outside our responsibility to do so.
-                        message = _("Restrictive permissions.")
-                        reason["err"] = \
-                            _("Some repository content for publisher '{0}' "
-                            "or paths leading to the repository were not "
-                            "world-readable or were not readable by "
-                            "'pkg5srv:pkg5srv', which can cause access errors "
-                            "if the repository contents are served by the "
-                            "following services:\n"
-                            " svc:/application/pkg/server\n"
-                            " svc:/application/pkg/system-repository.\n"
-                            "Only the first path found with restrictive "
-                            "permissions is shown.").format(reason["pub"])
-                        del reason["pub"]
-                else:
-                        raise Exception(
-                            "Unknown repository verify error code: {0}".format(
-                            error))
-
-                return error, path, message, reason
-
-        def __get_hashes(self, path, pfmri):
-                """Given a PkgFmri, return a set containing tuples of all of
-                the hashes of the files its manifest references which should
-                correspond to files in the repository. Each tuple is of the form
-                (file_name, hash_value, hash_func) where hash_func is the
-                function used to compute that hash and file_name is the name
-                of the hash used to store the file in the repository."""
-
-                hashes = set()
-                errors = []
-                try:
-                        m = self._get_manifest(pfmri)
-                        for a in m.gen_actions():
-                                if not a.has_payload:
-                                        continue
-
-                                # We store files using the least preferred hash
-                                # in the repository to remain as backwards-
-                                # compatible as possible.
-                                attr, fname, hfunc = \
-                                    digest.get_least_preferred_hash(a)
-                                attr, hval, hfunc = \
-                                    digest.get_preferred_hash(a)
-                                # Action payload.
-                                hashes.add((fname, hval, hfunc))
-
-                                # Signature actions have additional payloads
-                                if a.name == "signature":
-                                        attr, fname, hfunc = \
-                                            digest.get_least_preferred_hash(a,
-                                            hash_type=digest.CHAIN)
-                                        attr, hval, hfunc = \
-                                            digest.get_preferred_hash(a,
-                                            hash_type=digest.CHAIN)
-
-                                        # Since a chain attribute may contain
-                                        # several hashes, we need to add each
-                                        # fname in the chain and corresponding
-                                        # preferred hash to our set of hashes.
-                                        if not fname or not hval:
-                                                continue
-
-                                        fnames = fname.split()
-                                        chains = hval.split()
-                                        for fitem, citem in zip(
-                                            fnames, chains):
-                                                hashes.add((fitem, citem,
-                                                    hfunc))
-                except apx.PermissionsException:
-                        errors.append((REPO_VERIFY_MFPERM, path,
-                            {"err": _("Permission denied.")}))
-                return hashes, errors
-
-        def __verify_manifest(self, path, pfmri):
-                """Verify that a manifest can be found for this pfmri"""
-                try:
-                        m = self._get_manifest(pfmri)
-                except apx.InvalidPackageErrors:
-                        return (REPO_VERIFY_BADMANIFEST, path, {})
-                except apx.PermissionsException as e:
-                        return (REPO_VERIFY_PERM, path, {"err": str(e),
-                            "pkg": pfmri})
-
-        def __verify_hash(self, path, pfmri, h, alg=digest.DEFAULT_HASH_FUNC):
-                """Perform hash verification on the given gzip file.
-                'path' is the full path to the file in the repository. 'pfmri'
-                is the package that we're verifying. 'h' is the expected hash
-                of the path. 'alg' is the hash function used to compute the
-                hash."""
-
-                gzf = None
-                try:
-                        gzf = PkgGzipFile(fileobj=open(path, "rb"))
-                        fhash = alg()
-                        fhash.update(gzf.read())
-                        actual = fhash.hexdigest()
-                        if actual != h:
-                                return (REPO_VERIFY_BADHASH, path,
-                                    {"actual": actual, "hash": h,
-                                    "pkg": pfmri})
-                except (ValueError, EOFError, zlib.error) as e:
-                        return (REPO_VERIFY_BADGZIP, path,
-                            {"hash": h, "pkg": pfmri})
-                except IOError as e:
-                        if e.errno in [errno.EACCES, errno.EPERM]:
-                                return (REPO_VERIFY_PERM, path,
-                                    {"err": str(e), "hash": h,
-                                    "pkg": pfmri})
-                        else:
-                                return (REPO_VERIFY_BADGZIP, path,
-                                    {"hash": h, "pkg": pfmri})
-                finally:
-                        if gzf:
-                                gzf.close()
-
-        def __verify_perm(self, path, pfmri, h):
-                """Check that we don't get any permissions errors when
-                trying to stat the given path."""
-                try:
-                        st = os.stat(path)
-                        # if it's a directory, we'll try to list it
-                        if stat.S_ISDIR(st.st_mode):
-                                os.listdir(path)
-                except OSError as e:
-                        if e.errno in [errno.EPERM, errno.EACCES]:
-                                if not pfmri:
-                                        return (REPO_VERIFY_MFPERM, path,
-                                            {"err": str(e)})
-                                return (REPO_VERIFY_PERM, path,
-                                    {"hash": h, "err": str(e), "pkg": pfmri})
-                        else:
-                                return (REPO_VERIFY_NOFILE, path,
-                                    {"hash": h, "err": str(e), "pkg": pfmri})
-
-        def __verify_signature(self, path, pfmri, pub, trust_anchors,
-            sig_required_names, use_crls):
-                """Verify signatures on a given FMRI."""
-                m = self._get_manifest(pfmri)
-                errors = []
-                for sig in m.gen_actions_by_type("signature"):
-                        try:
-                                sig.verify_sig(m.gen_actions(), pub,
-                                    trust_anchors, use_crls,
-                                    required_names=sig_required_names)
-                        except apx.UnverifiedSignature as e:
-                                errors.append((REPO_VERIFY_BADSIG, path,
-                                    {"err": str(e), "pkg": pfmri}))
-                        except apx.CertificateException as e:
-                                errors.append((REPO_VERIFY_BADSIG, path,
-                                    {"err": str(e), "pkg": pfmri}))
-                        except apx.TransportError as e:
-                                errors.append((REPO_VERIFY_BADSIG, path,
-                                   {"err": str(e), "pkg": pfmri}))
-                return errors
-
-        def __verify_permissions(self):
-                """Determine if any of the files or directories in the
-                repository are not readable by either the pkg5srv user or group,
-                or are not world readable.  We return as soon as we find one
-                inaccessible file, returning the name of that file or directory.
-
-                We also walk up the directory path from the repository to '/'
-                checking that the repository would be accessible.
-
-                We only return the first file found because for large
-                repositories with many files affected, we'd be flooding the user
-                with information.
-
-                This check exists as well as verify_perm() since it causes a
-                warning to be emitted if non-world readable files are found,
-                whereas verify_perm() will emit an error.
-                """
-
-                pkg5srv_uid = \
-                    pkg.portable.get_user_by_name("pkg5srv", "/etc", None)
-                pkg5srv_gid = \
-                    pkg.portable.get_group_by_name("pkg5srv", "/etc", None)
-
-                def pkg5srv_readable(st):
-                        """Returns true if the pkg5srv user can read
-                        this file/dir"""
-                        if stat.S_ISDIR(st.st_mode):
-                                if (st.st_uid == pkg5srv_uid and
-                                    st.st_mode & stat.S_IXUSR and
-                                    st.st_mode & stat.S_IRUSR):
-                                        return True
-                                if (st.st_gid == pkg5srv_gid and
-                                    st.st_mode & stat.S_IXGRP and
-                                    st.st_mode & stat.S_IRGRP):
-                                        return True
-                        else:
-                                if (st.st_uid == pkg5srv_uid and
-                                    st.st_mode & stat.S_IRUSR):
-                                        return True
-                                if (st.st_gid == pkg5srv_gid and
-                                    st.st_mode & stat.S_IRGRP):
-                                        return True
-                        return False
-
-                def world_readable(st):
-                        """Returns true if anyone can read this
-                        file/dir."""
-                        if stat.S_ISDIR(st.st_mode):
-                                if (st.st_mode & stat.S_IROTH and
-                                    st.st_mode & stat.S_IXOTH):
-                                        return True
-                        else:
-                                if st.st_mode & stat.S_IROTH:
-                                        return True
-                        return False
-
-                # Scan directories checking file permissions.  First we
-                # walk up the directory path from self.__root
-                components = self.__root.split("/")
-                path = ""
-                for comp in components:
-                        if not comp:
-                                continue
-                        path = "{0}/{1}".format(path, comp)
-                        st = os.stat(path)
-                        if not (pkg5srv_readable(st) or
-                            world_readable(st)):
-                                return False, path
-
-                for path, dirnames, filenames in os.walk(self.__root):
-                        # we don't care about anything in our quarantine
-                        # directory.
-                        if REPO_QUARANTINE_DIR in path:
-                                continue
-                        st = os.stat(path)
-                        if not (pkg5srv_readable(st) or
-                            world_readable(st)):
-                                return False, path
-                        for fname in filenames:
-                                pth = os.path.join(path, fname)
-                                st = os.stat(pth)
-                                if not (pkg5srv_readable(st) or
-                                    world_readable(st)):
-                                        return False, pth
-                return True, None
-
-        def __gen_verify(self, progtrack, pub, trust_anchors,
-            sig_required_names, use_crls):
-                """A generator that produces verify errors, each a tuple
-                of the form (error_code, path, message, details)"""
-                # We may not have a manifest_root directory if no
-                # packages have ever been published for this publisher.
-                if not os.path.exists(self.manifest_root):
-                        return
-
-                err = self.__verify_perm(self.manifest_root, None, None)
-                if err:
-                        yield self.__build_verify_error(*err)
-                        return
-
-                # Build a list of all of the manifests that must be
-                # verified.
-                mflist = os.listdir(self.manifest_root)
-                goal = len(mflist)
-
-                # If there is more than one version in the manifest dir,
-                # then we add each one to the goal.
-                for name in mflist:
-                        try:
-                                mfdir = os.path.join(self.manifest_root, name)
-                                vers = len(os.listdir(mfdir))
-                                if vers > 1:
-                                        goal += vers - 1
-                        except OSError as e:
-                                # being unable to read the manifest dir is bad,
-                                # but we'll deal with it later
-                                continue
-
-                # Add the repo permissions error check to the number of items
-                # goal.
-                goal +=1
-                progtrack.repo_verify_start(goal)
-
-                # Scan the entire repository for bad file permissions
-                progtrack.repo_verify_start_pkg(None, repository_scan=True)
-                valid_perms, path = self.__verify_permissions()
-                if not valid_perms:
-                        # We intentionally don't use the path as the first
-                        # argument to __build_verify_error(..) as we do not want
-                        # 'pkgrepo fix' to attempt to fix this particular error,
-                        # since it can include paths outside the repository.
-                        yield self.__build_verify_error(
-                            REPO_VERIFY_WARN_OPENPERMS, None,
-                            {"permissionspath": path, "pub": pub.prefix})
-                progtrack.repo_verify_end_pkg(None)
-
-                for name in mflist:
-                        pdir = os.path.join(self.manifest_root, name)
-                        err = self.__verify_perm(pdir, None, None)
-                        if err:
-                                yield self.__build_verify_error(*err)
-                                continue
-
-                        # Stem must be decoded before use.
-                        try:
-                                pname = unquote(name)
+                            pfmri = fmri.PkgFmri(
+                                "@".join((pname, pver)),
+                                publisher=self.publisher,
+                            )
                         except Exception:
-                                # Assume error is result of an
-                                # unexpected file in the directory. We
-                                # don't know the FMRI here, so use None.
-                                progtrack.repo_verify_start_pkg(None)
-                                progtrack.repo_verify_add_progress(None)
-                                yield self.__build_verify_error(
-                                    REPO_VERIFY_UNKNOWN, pdir, {"err": str(e)})
-                                progtrack.repo_verify_end_pkg(None)
-                                continue
+                            # Assume error is result
+                            # of unexpected file in
+                            # directory; just skip
+                            # it and drive on.
+                            progtrack.job_add_progress(
+                                progtrack.JOB_REPO_ANALYZE_REPO
+                            )
+                            continue
 
-                        for ver in os.listdir(pdir):
-                                path = os.path.join(pdir, ver)
-                                # Version must be decoded before
-                                # use.
-                                pver = unquote(ver)
-                                try:
-                                        pfmri = fmri.PkgFmri("@".join((pname,
-                                            pver)),
-                                            publisher=self.publisher)
-                                        if not os.path.isfile(path):
-                                                raise Exception(
-                                                    "{0} is not a file".format(
-                                                    path))
-                                except Exception as e:
-                                        # Assume the error is result of an
-                                        # unexpected file in the directory. We
-                                        # don't know the FMRI here, so use None.
-                                        progtrack.repo_verify_start_pkg(None)
-                                        progtrack.repo_verify_add_progress(None)
-                                        yield self.__build_verify_error(
-                                            REPO_VERIFY_UNKNOWN, path,
-                                            {"err": str(e)})
-                                        progtrack.repo_verify_end_pkg(None)
-                                        continue
+                        if pfmri in packages:
+                            # Package is one of
+                            # those queued for
+                            # removal.
+                            progtrack.job_add_progress(
+                                progtrack.JOB_REPO_ANALYZE_REPO
+                            )
+                            continue
 
-                                progtrack.repo_verify_start_pkg(pfmri)
-                                err = self.__verify_manifest(path, pfmri)
-                                if err:
-                                        # with a bad manifest, we can go no
-                                        # further
-                                        yield self.__build_verify_error(*err)
-                                        progtrack.repo_verify_end_pkg(None)
-                                        continue
+                        # Any files in use by another
+                        # package can't be removed.
+                        pfiles -= get_hashes(pfmri)
+                        progtrack.job_add_progress(
+                            progtrack.JOB_REPO_ANALYZE_REPO
+                        )
+                progtrack.job_done(progtrack.JOB_REPO_ANALYZE_REPO)
 
-                                hashes, errors = self.__get_hashes(path, pfmri)
-                                for err in errors:
-                                        yield self.__build_verify_error(*err)
+            # Next, remove the manifests of the packages to be
+            # removed.  (This is done before removing the files
+            # so that clients won't have a chance to retrieve a
+            # manifest which has missing files.)
+            progtrack.job_start(progtrack.JOB_REPO_RM_MFST, goal=len(packages))
+            for pfmri in packages:
+                mpath = self.manifest(pfmri)
+                portable.remove(mpath)
+                progtrack.job_add_progress(progtrack.JOB_REPO_RM_MFST)
+            progtrack.job_done(progtrack.JOB_REPO_RM_MFST)
 
-                                # verify manifest signatures
-                                errs = self.__verify_signature(path, pfmri, pub,
-                                    trust_anchors, sig_required_names, use_crls)
-                                for err in errs:
-                                        yield self.__build_verify_error(*err)
+            # Next, remove any package files that are not
+            # referenced by other packages.
+            progtrack.job_start(progtrack.JOB_REPO_RM_FILES, goal=len(pfiles))
+            for h in pfiles:
+                # File might already be gone (don't care if
+                # it is).
+                fpath = self.cache_store.lookup(h)
+                if fpath is not None:
+                    portable.remove(fpath)
+                progtrack.job_add_progress(progtrack.JOB_REPO_RM_FILES)
+            progtrack.job_done(progtrack.JOB_REPO_RM_FILES)
 
-                                # verify payload delivered by this pkg
-                                errors = []
-                                for fname, h, alg in hashes:
-                                        try:
-                                                path = self.cache_store.lookup(
-                                                     fname,
-                                                     check_existence=False)
-                                        except apx.PermissionsException as e:
-                                                # if we can't even get the path
-                                                # within the repository, then
-                                                # we'll do the best we can to
-                                                # report the problem.
-                                                errors.append((REPO_VERIFY_PERM,
-                                                    pfmri, {"hash": fname,
-                                                    "err": _("Permission "
-                                                    "denied.", "path", h)}))
-                                                continue
-
-                                        err = self.__verify_perm(path, pfmri, h)
-                                        if err:
-                                                # For backward compatibility,
-                                                # store the SHA1 file name for
-                                                # file retrieval.
-                                                err[2]["fname"] = fname
-                                                errors.append(err)
-                                                continue
-                                        err = self.__verify_hash(path, pfmri, h,
-                                            alg=alg)
-                                        if err:
-                                                err[2]["fname"] = fname
-                                                errors.append(err)
-                                for err in errors:
-                                        yield self.__build_verify_error(*err)
-
-                                progtrack.repo_verify_end_pkg(fmri)
-                progtrack.job_done(progtrack.JOB_REPO_VERIFY_REPO)
-
-        def verify(self, pub=None, progtrack=None,
-            trust_anchor_dir=None, sig_required_names=None, use_crls=False):
-                """A generator which verifies the contents of the repository
-                store, checking for several different types of errors.
-                No modifying operations may be performed until complete.
-
-                'progtrack' is an optional ProgressTracker object.
-
-                'trust_anchor_dir' is set in the repository configuration and
-                corresponds to the image property of the same name.
-
-                'sig_required_names' is set in the repository configuration and
-                corresponds to the image property of the same name.
-
-                'use_crls' is set in the repository configuration and
-                corresponds to the image property of the same name.
-
-                The generator yields tuples of the form:
-
-                (error_code, path, message, reason) where
-
-                'error_code'  an integer error, correponding to REPO_VERIFY_*
-                'path'        the path to the broken file in the repository
-                'message'     a human-readable summary of the error
-                'reason'      a dictionary of strings containing more detail
-                              about the nature of the error.
-                """
-
-                if not self.catalog_root or self.catalog_version < 1:
-                        raise RepositoryUnsupportedOperationError()
-                if not self.manifest_root:
-                        raise RepositoryUnsupportedOperationError()
-
-                if not progtrack:
-                        progtrack = progtrack.NullProgressTracker()
-
-                # For signature verification, we need to setup a publisher
-                # meta_root, and build a dictionary of trust-anchors.
-                tmp_metaroot = tempfile.mkdtemp(prefix="pkgrepo-verify.")
-                pub.meta_root = tmp_metaroot
-                trust_anchors = {}
-
-                if not os.path.isdir(trust_anchor_dir):
-                        raise RepositorySigNoTrustAnchorDirError(
-                            trust_anchor_dir)
-
-                for fn in os.listdir(trust_anchor_dir):
-                        pth = os.path.join(trust_anchor_dir, fn)
-                        if not os.path.isfile(pth) or os.path.islink(pth):
-                                continue
-                        with open(pth, "rb") as f:
-                                try:
-                                        trusted_ca = \
-                                            x509.load_pem_x509_certificate(
-                                                f.read(), default_backend())
-                                except ValueError as e:
-                                        continue
-
-                        # Note that while we store certs by their subject
-                        # hashes, we use our own hashing since cryptography has
-                        # no interface for the subject hash and other crypto
-                        # frameworks have been inconsistent with OpenSSL.
-                        s = hashlib.sha1(misc.force_bytes(
-                            trusted_ca.subject)).hexdigest()
-                        trust_anchors.setdefault(s, [])
-                        trust_anchors[s].append(trusted_ca)
-
-                self.__lock_rstore()
+            # Finally, tidy up repository structure by discarding
+            # unused package data directories for any packages
+            # removed.
+            def rmdir(d):
+                """rmdir; but ignores non-empty directories."""
                 try:
-                        for err in self.__gen_verify(progtrack, pub,
-                            trust_anchors, sig_required_names, use_crls):
-                                yield err
-                except (Exception, EnvironmentError) as e:
-                        import traceback
-                        traceback.print_exc()
-                        raise apx._convert_error(e)
-                finally:
-                        self.__unlock_rstore()
-                        shutil.rmtree(tmp_metaroot)
+                    os.rmdir(d)
+                except OSError as e:
+                    if e.errno not in (errno.ENOTEMPTY, errno.EEXIST):
+                        raise
 
-        def fix(self,  pub=None, progtrack=None, verify_callback=None,
-            trust_anchor_dir=None, sig_required_names=None, use_crls=False):
-                """Verify, then quarantine any packages in the repository that
-                were found to be faulty, according to self.verify(..).
+            for name in set(f.get_dir_path(stemonly=True) for f in packages):
+                rmdir(os.path.join(self.manifest_root, name))
 
-                This method yields tuples of the form:
+            if self.file_root:
+                try:
+                    for entry in os.listdir(self.file_root):
+                        rmdir(os.path.join(self.file_root, entry))
+                except EnvironmentError as e:
+                    if e.errno != errno.ENOENT:
+                        raise
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+        finally:
+            # This ensures batch_mode is reset in the event of an
+            # error.
+            c.batch_mode = False
+            self.__unlock_rstore()
 
-                (status_code, fmri, message, reason) where
+    def rebuild(self, build_catalog=True, build_index=False):
+        """Rebuilds the repository catalog and search indexes using the
+        package manifests currently in the repository.
 
-                'status_code'  an int status code, corresponding to REPO_FIX_*
-                'path'         the path that was fixed
-                'message'      a summary of the operation performed
-                'reason'       a dictionary of strings describing the operation
+        'build_catalog' is an optional boolean value indicating whether
+        package catalogs should be rebuilt.  If True, existing search
+        data will be discarded.
 
-                Note, the 'fmri' value may not be a valid FMRI if the manifest
-                being fixed was corrupt, in which case a path to the corrupted
-                manifest in the repository is used instead.
+        'build_index' is an optional boolean value indicating whether
+        search indexes should be built.
+        """
 
-                If any object referred to by a manifest is quarantined, then
-                the manifest for that package is also quarantined, however other
-                files referenced by the manifest are not moved to quarantine
-                in case they are referenced by other packages.
-                """
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.catalog_root or self.catalog_version == 0:
+            raise RepositoryUnsupportedOperationError()
 
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
+        self.__lock_rstore()
+        try:
+            self.__rebuild(build_catalog=build_catalog, build_index=build_index)
+        finally:
+            self.__unlock_rstore()
 
-                if not progtrack:
-                        progtrack = progress.NullProgressTracker()
+    def __run_update_index(self):
+        """Determines which fmris need to be indexed and passes them
+        to the indexer.
 
-                broken_items = set()
-                for error, path, message, reason in self.verify(pub=pub,
-                    progtrack=progtrack, trust_anchor_dir=trust_anchor_dir,
-                    sig_required_names=sig_required_names, use_crls=use_crls):
-                        if verify_callback:
-                                verify_callback(progtrack, (error, path,
-                                    message, reason))
-                        # we don't attempt to fix this error, since it can
-                        # involve paths outside the repository.
-                        if error == REPO_VERIFY_WARN_OPENPERMS:
-                                continue
-                        fmri = reason.get("pkg")
-                        broken_items.add((path, fmri))
+        Note: Only one instance of this method should be running.
+        External locking is expected to ensure this behavior. Calling
+        refresh index is the preferred method to use to reindex.
+        """
 
-                quarantine_root = None
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if not self.index_root or self.catalog_version < 1:
+            raise RepositoryUnsupportedOperationError()
 
-                def _make_quarantine_root():
-                        """Make a directory where we can quarantine content."""
-                        quarantine_base = os.path.join(self.root,
-                            REPO_QUARANTINE_DIR)
-                        if not os.path.exists(quarantine_base):
-                                os.mkdir(quarantine_base)
-                        qroot = tempfile.mkdtemp(prefix="fix.",
-                            dir=quarantine_base)
-                        return qroot
+        c = self.catalog
+        fmris_to_index = indexer.Indexer.check_for_updates(self.index_root, c)
 
-                # look for broken package content where the bad file doesn't
-                # match the path to the manifest (eg. file content) and add
-                # the manifest path to the list of broken items, so that we
-                # move the manifest to quarantine as well.
-                for path, fmri in broken_items.copy():
-                        if not fmri:
-                                continue
-                        mpath = self.manifest(fmri)
-                        if path == mpath:
-                                continue
-                        broken_items.add((mpath, fmri))
+        if fmris_to_index:
+            self.__index_log("Updating search indexes")
+            self.__update_searchdb_unlocked(fmris_to_index)
+        else:
+            ind = indexer.Indexer(
+                self.index_root,
+                self._get_manifest,
+                self.manifest,
+                log=self.__index_log,
+                sort_file_max_size=self.__sort_file_max_size,
+            )
+            ind.setup()
+            if not self.__search_available:
+                self.__index_log("Search Available")
+            self.__search_available = True
 
-                progtrack.job_start(progtrack.JOB_REPO_FIX_REPO,
-		    goal=len(broken_items))
+    def search(self, queries):
+        """Searches the index for each query in the list of queries.
+        Each entry should be the output of str(Query), or a Query
+        object."""
 
-                # keep a set of all the paths we've applied fixes to
-                fixed_paths = set()
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if not self.index_root or not self.catalog_root:
+            raise RepositoryUnsupportedOperationError()
 
-                for path, fmri in broken_items:
-                        progtrack.job_add_progress(progtrack.JOB_REPO_FIX_REPO)
+        self.__check_search()
+        if not self.search_available:
+            raise RepositorySearchUnavailableError()
 
-                        # we've already applied a fix to this path
-                        if path in fixed_paths:
-                                continue
+        def _search(q):
+            assert self.index_root
+            l = sqp.QueryLexer()
+            l.build()
+            qqp = sqp.QueryParser(l)
+            query = qqp.parse(q.text)
+            query.set_info(
+                num_to_return=q.num_to_return,
+                start_point=q.start_point,
+                index_dir=self.index_root,
+                get_manifest_path=self.manifest,
+                case_sensitive=q.case_sensitive,
+            )
+            if q.return_type == sqp.Query.RETURN_PACKAGES:
+                query.propagate_pkg_return()
+            return query.search(self.catalog.fmris)
 
-                        # we can't do anything about missing files
-                        if not os.path.exists(path):
-                                yield (REPO_FIX_ITEM, path,
-                                    _("Missing file {0} must be fixed by "
-                                    "republishing the package.").format(path),
-                                    {"pkg": fmri})
-                                continue
+        query_lst = []
+        try:
+            for s in queries:
+                if not isinstance(s, qp.Query):
+                    query_lst.append(sqp.Query.fromstr(s))
+                else:
+                    query_lst.append(s)
+        except sqp.QueryException as e:
+            raise RepositoryError(e)
+        return [_search(q) for q in query_lst]
 
-                        basename = os.path.basename(path)
-                        dir = os.path.dirname(path)
-                        dir = dir.replace(self.root, "", 1).lstrip("/")
-                        if not quarantine_root:
-                                quarantine_root = _make_quarantine_root()
-                        qdir = os.path.join(quarantine_root, dir)
-                        try:
-                                os.makedirs(qdir)
-                        except OSError as e:
-                                if e.errno != errno.EEXIST:
-                                        raise
-                        dest = os.path.join(qdir, basename)
-                        if os.path.exists(dest):
-                                # this should never happen, since we have a
-                                # unique quarantine root per fix(..) call
-                                raise RepositoryQuarantinedPathExistsError()
+    @property
+    def search_available(self):
+        return (
+            self.__search_available
+            and self.index_root
+            and os.path.exists(self.index_root)
+        ) or self.__check_search()
 
-                        message = _("Moving {src} to {dest}").format(
-                            src=path, dest=dest)
-                        status = REPO_FIX_ITEM
-                        reason = {"dest": dest, "pkg": fmri}
-                        try:
-                                shutil.move(path, qdir)
-                                fixed_paths.add(path)
-                        except Exception as e:
-                                status = REPO_FIX_FAILED
-                                message = _("Unable to quarantine {path}: "
-                                    "{err}").format(path=path, err=e)
-                        finally:
-                                yield(status, path, message, reason)
+    def update_publisher(self, pub):
+        """Updates the configuration information for the publisher
+        defined by the provided Publisher object.
+        """
 
-                progtrack.job_done(progtrack.JOB_REPO_FIX_REPO)
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.root:
+            raise RepositoryUnsupportedOperationError()
 
-                if broken_items:
-                        self.rebuild()
+        p5ipath = os.path.join(self.root, "pub.p5i")
+        fn = None
+        try:
+            dirname = os.path.dirname(p5ipath)
+            fd, fn = tempfile.mkstemp(dir=dirname)
 
-        def valid_new_fmri(self, pfmri):
-                """Check that the FMRI supplied as an argument would be valid
-                to add to the repository catalog.  This checks to make sure
-                that any past catalog operations (such as a rename or freeze)
-                would not prohibit the caller from adding this FMRI."""
+            st = None
+            try:
+                st = os.stat(p5ipath)
+            except OSError as e:
+                if e.errno != errno.ENOENT:
+                    raise
 
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if not self.catalog_root:
-                        raise RepositoryUnsupportedOperationError()
-                if not fmri.is_valid_pkg_name(pfmri.get_name()):
-                        return False
-                if not pfmri.version:
-                        return False
+            if st:
+                os.fchmod(fd, stat.S_IMODE(st.st_mode))
+                try:
+                    portable.chown(fn, st.st_uid, st.st_gid)
+                except OSError as e:
+                    if e.errno != errno.EPERM:
+                        raise
+            else:
+                os.fchmod(fd, misc.PKG_FILE_MODE)
 
-                c = self.catalog
-                entry = c.get_entry(pfmri)
-                return entry is None
+            if six.PY2:
+                with os.fdopen(fd, "wb") as f:
+                    with codecs.EncodedFile(f, "utf-8") as ef:
+                        p5i.write(ef, [pub])
+            else:
+                # we use json.dump() in p5i.write(),
+                # json module will produce str objects
+                # in Python 3, therefore fp.write()
+                # must support str input.
 
-        def valid_append_fmri(self, pfmri):
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if not self.catalog_root:
-                        raise RepositoryUnsupportedOperationError()
-                if not fmri.is_valid_pkg_name(pfmri.get_name()):
-                        return False
-                if not pfmri.version:
-                        return False
-                if not pfmri.version.timestr:
-                        return False
+                with open(fd, "w", encoding="utf-8") as fp:
+                    p5i.write(fp, [pub])
+            portable.rename(fn, p5ipath)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            elif e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
+        finally:
+            if fn and os.path.exists(fn):
+                os.unlink(fn)
 
-                c = self.catalog
-                entry = c.get_entry(pfmri)
-                return entry is not None
+    def __build_verify_error(self, error, path, reason):
+        """Given an integer error code, a path within the repository,
+        and a 'reason' dictionary containing more information about
+        the error, return a tuple of the form:
 
-        catalog_root = property(lambda self: self.__catalog_root)
-        file_layout = property(lambda self: self.__file_layout)
-        file_root = property(lambda self: self.__file_root)
-        read_only = property(lambda self: self.__read_only, __set_read_only)
-        root = property(lambda self: self.__root)
-        writable_root = property(lambda self: self.__writable_root)
+        (error_code, message, path, reason)
+        """
+
+        # if we're looking at a path to a file hash, and we have a pfmri
+        # we'd like to print the 'path' attribute as well as its
+        # location within the repository.
+        hsh = reason.get("fname")
+        pfmri = reason.get("pkg")
+        if hsh and pfmri:
+            m = self._get_manifest(pfmri)
+            # this is not terribly efficient, but the expectation is
+            # that this will rarely happen.
+            for ac in m.gen_actions_by_types(actions.payload_types.keys()):
+                for hash in digest.DEFAULT_HASH_ATTRS:
+                    if ac.attrs.get(hash) == hsh:
+                        fpath = ac.attrs.get("path")
+                        if fpath:
+                            reason["fpath"] = fpath
+                if ac.hash == hsh:
+                    fpath = ac.attrs.get("path")
+                    if fpath:
+                        reason["fpath"] = fpath
+
+        message = _("Unknown error")
+        if error == REPO_VERIFY_BADHASH:
+            message = _("Invalid file hash: {0}").format(reason["hash"])
+            del reason["hash"]
+        elif error == REPO_VERIFY_BADMANIFEST:
+            message = _("Corrupt manifest.")
+            reason["err"] = _("Use pkglint(1) for more details.")
+        elif error == REPO_VERIFY_NOFILE:
+            message = _("Missing file: {0}").format(reason["fname"])
+            del reason["fname"]
+        elif error == REPO_VERIFY_BADGZIP:
+            message = _("Corrupted gzip file.")
+        elif error in [REPO_VERIFY_PERM, REPO_VERIFY_MFPERM]:
+            message = _("Verification failure: {0}").format(reason["err"])
+            del reason["err"]
+        elif error == REPO_VERIFY_UNKNOWN:
+            message = _("Bad manifest.")
+        elif error == REPO_VERIFY_BADSIG:
+            message = _("Bad signature.")
+        elif error == REPO_VERIFY_WARN_OPENPERMS:
+            # This message constitutes a warning rather than
+            # an error. No attempt is made by 'pkgrepo fix'
+            # to rectify this error, as it is potentially
+            # outside our responsibility to do so.
+            message = _("Restrictive permissions.")
+            reason["err"] = _(
+                "Some repository content for publisher '{0}' "
+                "or paths leading to the repository were not "
+                "world-readable or were not readable by "
+                "'pkg5srv:pkg5srv', which can cause access errors "
+                "if the repository contents are served by the "
+                "following services:\n"
+                " svc:/application/pkg/server\n"
+                " svc:/application/pkg/system-repository.\n"
+                "Only the first path found with restrictive "
+                "permissions is shown."
+            ).format(reason["pub"])
+            del reason["pub"]
+        else:
+            raise Exception(
+                "Unknown repository verify error code: {0}".format(error)
+            )
+
+        return error, path, message, reason
+
+    def __get_hashes(self, path, pfmri):
+        """Given a PkgFmri, return a set containing tuples of all of
+        the hashes of the files its manifest references which should
+        correspond to files in the repository. Each tuple is of the form
+        (file_name, hash_value, hash_func) where hash_func is the
+        function used to compute that hash and file_name is the name
+        of the hash used to store the file in the repository."""
+
+        hashes = set()
+        errors = []
+        try:
+            m = self._get_manifest(pfmri)
+            for a in m.gen_actions():
+                if not a.has_payload:
+                    continue
+
+                # We store files using the least preferred hash
+                # in the repository to remain as backwards-
+                # compatible as possible.
+                attr, fname, hfunc = digest.get_least_preferred_hash(a)
+                attr, hval, hfunc = digest.get_preferred_hash(a)
+                # Action payload.
+                hashes.add((fname, hval, hfunc))
+
+                # Signature actions have additional payloads
+                if a.name == "signature":
+                    attr, fname, hfunc = digest.get_least_preferred_hash(
+                        a, hash_type=digest.CHAIN
+                    )
+                    attr, hval, hfunc = digest.get_preferred_hash(
+                        a, hash_type=digest.CHAIN
+                    )
+
+                    # Since a chain attribute may contain
+                    # several hashes, we need to add each
+                    # fname in the chain and corresponding
+                    # preferred hash to our set of hashes.
+                    if not fname or not hval:
+                        continue
+
+                    fnames = fname.split()
+                    chains = hval.split()
+                    for fitem, citem in zip(fnames, chains):
+                        hashes.add((fitem, citem, hfunc))
+        except apx.PermissionsException:
+            errors.append(
+                (REPO_VERIFY_MFPERM, path, {"err": _("Permission denied.")})
+            )
+        return hashes, errors
+
+    def __verify_manifest(self, path, pfmri):
+        """Verify that a manifest can be found for this pfmri"""
+        try:
+            m = self._get_manifest(pfmri)
+        except apx.InvalidPackageErrors:
+            return (REPO_VERIFY_BADMANIFEST, path, {})
+        except apx.PermissionsException as e:
+            return (REPO_VERIFY_PERM, path, {"err": str(e), "pkg": pfmri})
+
+    def __verify_hash(self, path, pfmri, h, alg=digest.DEFAULT_HASH_FUNC):
+        """Perform hash verification on the given gzip file.
+        'path' is the full path to the file in the repository. 'pfmri'
+        is the package that we're verifying. 'h' is the expected hash
+        of the path. 'alg' is the hash function used to compute the
+        hash."""
+
+        gzf = None
+        try:
+            gzf = PkgGzipFile(fileobj=open(path, "rb"))
+            fhash = alg()
+            fhash.update(gzf.read())
+            actual = fhash.hexdigest()
+            if actual != h:
+                return (
+                    REPO_VERIFY_BADHASH,
+                    path,
+                    {"actual": actual, "hash": h, "pkg": pfmri},
+                )
+        except (ValueError, EOFError, zlib.error) as e:
+            return (REPO_VERIFY_BADGZIP, path, {"hash": h, "pkg": pfmri})
+        except IOError as e:
+            if e.errno in [errno.EACCES, errno.EPERM]:
+                return (
+                    REPO_VERIFY_PERM,
+                    path,
+                    {"err": str(e), "hash": h, "pkg": pfmri},
+                )
+            else:
+                return (REPO_VERIFY_BADGZIP, path, {"hash": h, "pkg": pfmri})
+        finally:
+            if gzf:
+                gzf.close()
+
+    def __verify_perm(self, path, pfmri, h):
+        """Check that we don't get any permissions errors when
+        trying to stat the given path."""
+        try:
+            st = os.stat(path)
+            # if it's a directory, we'll try to list it
+            if stat.S_ISDIR(st.st_mode):
+                os.listdir(path)
+        except OSError as e:
+            if e.errno in [errno.EPERM, errno.EACCES]:
+                if not pfmri:
+                    return (REPO_VERIFY_MFPERM, path, {"err": str(e)})
+                return (
+                    REPO_VERIFY_PERM,
+                    path,
+                    {"hash": h, "err": str(e), "pkg": pfmri},
+                )
+            else:
+                return (
+                    REPO_VERIFY_NOFILE,
+                    path,
+                    {"hash": h, "err": str(e), "pkg": pfmri},
+                )
+
+    def __verify_signature(
+        self, path, pfmri, pub, trust_anchors, sig_required_names, use_crls
+    ):
+        """Verify signatures on a given FMRI."""
+        m = self._get_manifest(pfmri)
+        errors = []
+        for sig in m.gen_actions_by_type("signature"):
+            try:
+                sig.verify_sig(
+                    m.gen_actions(),
+                    pub,
+                    trust_anchors,
+                    use_crls,
+                    required_names=sig_required_names,
+                )
+            except apx.UnverifiedSignature as e:
+                errors.append(
+                    (REPO_VERIFY_BADSIG, path, {"err": str(e), "pkg": pfmri})
+                )
+            except apx.CertificateException as e:
+                errors.append(
+                    (REPO_VERIFY_BADSIG, path, {"err": str(e), "pkg": pfmri})
+                )
+            except apx.TransportError as e:
+                errors.append(
+                    (REPO_VERIFY_BADSIG, path, {"err": str(e), "pkg": pfmri})
+                )
+        return errors
+
+    def __verify_permissions(self):
+        """Determine if any of the files or directories in the
+        repository are not readable by either the pkg5srv user or group,
+        or are not world readable.  We return as soon as we find one
+        inaccessible file, returning the name of that file or directory.
+
+        We also walk up the directory path from the repository to '/'
+        checking that the repository would be accessible.
+
+        We only return the first file found because for large
+        repositories with many files affected, we'd be flooding the user
+        with information.
+
+        This check exists as well as verify_perm() since it causes a
+        warning to be emitted if non-world readable files are found,
+        whereas verify_perm() will emit an error.
+        """
+
+        pkg5srv_uid = pkg.portable.get_user_by_name("pkg5srv", "/etc", None)
+        pkg5srv_gid = pkg.portable.get_group_by_name("pkg5srv", "/etc", None)
+
+        def pkg5srv_readable(st):
+            """Returns true if the pkg5srv user can read
+            this file/dir"""
+            if stat.S_ISDIR(st.st_mode):
+                if (
+                    st.st_uid == pkg5srv_uid
+                    and st.st_mode & stat.S_IXUSR
+                    and st.st_mode & stat.S_IRUSR
+                ):
+                    return True
+                if (
+                    st.st_gid == pkg5srv_gid
+                    and st.st_mode & stat.S_IXGRP
+                    and st.st_mode & stat.S_IRGRP
+                ):
+                    return True
+            else:
+                if st.st_uid == pkg5srv_uid and st.st_mode & stat.S_IRUSR:
+                    return True
+                if st.st_gid == pkg5srv_gid and st.st_mode & stat.S_IRGRP:
+                    return True
+            return False
+
+        def world_readable(st):
+            """Returns true if anyone can read this
+            file/dir."""
+            if stat.S_ISDIR(st.st_mode):
+                if st.st_mode & stat.S_IROTH and st.st_mode & stat.S_IXOTH:
+                    return True
+            else:
+                if st.st_mode & stat.S_IROTH:
+                    return True
+            return False
+
+        # Scan directories checking file permissions.  First we
+        # walk up the directory path from self.__root
+        components = self.__root.split("/")
+        path = ""
+        for comp in components:
+            if not comp:
+                continue
+            path = "{0}/{1}".format(path, comp)
+            st = os.stat(path)
+            if not (pkg5srv_readable(st) or world_readable(st)):
+                return False, path
+
+        for path, dirnames, filenames in os.walk(self.__root):
+            # we don't care about anything in our quarantine
+            # directory.
+            if REPO_QUARANTINE_DIR in path:
+                continue
+            st = os.stat(path)
+            if not (pkg5srv_readable(st) or world_readable(st)):
+                return False, path
+            for fname in filenames:
+                pth = os.path.join(path, fname)
+                st = os.stat(pth)
+                if not (pkg5srv_readable(st) or world_readable(st)):
+                    return False, pth
+        return True, None
+
+    def __gen_verify(
+        self, progtrack, pub, trust_anchors, sig_required_names, use_crls
+    ):
+        """A generator that produces verify errors, each a tuple
+        of the form (error_code, path, message, details)"""
+        # We may not have a manifest_root directory if no
+        # packages have ever been published for this publisher.
+        if not os.path.exists(self.manifest_root):
+            return
+
+        err = self.__verify_perm(self.manifest_root, None, None)
+        if err:
+            yield self.__build_verify_error(*err)
+            return
+
+        # Build a list of all of the manifests that must be
+        # verified.
+        mflist = os.listdir(self.manifest_root)
+        goal = len(mflist)
+
+        # If there is more than one version in the manifest dir,
+        # then we add each one to the goal.
+        for name in mflist:
+            try:
+                mfdir = os.path.join(self.manifest_root, name)
+                vers = len(os.listdir(mfdir))
+                if vers > 1:
+                    goal += vers - 1
+            except OSError as e:
+                # being unable to read the manifest dir is bad,
+                # but we'll deal with it later
+                continue
+
+        # Add the repo permissions error check to the number of items
+        # goal.
+        goal += 1
+        progtrack.repo_verify_start(goal)
+
+        # Scan the entire repository for bad file permissions
+        progtrack.repo_verify_start_pkg(None, repository_scan=True)
+        valid_perms, path = self.__verify_permissions()
+        if not valid_perms:
+            # We intentionally don't use the path as the first
+            # argument to __build_verify_error(..) as we do not want
+            # 'pkgrepo fix' to attempt to fix this particular error,
+            # since it can include paths outside the repository.
+            yield self.__build_verify_error(
+                REPO_VERIFY_WARN_OPENPERMS,
+                None,
+                {"permissionspath": path, "pub": pub.prefix},
+            )
+        progtrack.repo_verify_end_pkg(None)
+
+        for name in mflist:
+            pdir = os.path.join(self.manifest_root, name)
+            err = self.__verify_perm(pdir, None, None)
+            if err:
+                yield self.__build_verify_error(*err)
+                continue
+
+            # Stem must be decoded before use.
+            try:
+                pname = unquote(name)
+            except Exception:
+                # Assume error is result of an
+                # unexpected file in the directory. We
+                # don't know the FMRI here, so use None.
+                progtrack.repo_verify_start_pkg(None)
+                progtrack.repo_verify_add_progress(None)
+                yield self.__build_verify_error(
+                    REPO_VERIFY_UNKNOWN, pdir, {"err": str(e)}
+                )
+                progtrack.repo_verify_end_pkg(None)
+                continue
+
+            for ver in os.listdir(pdir):
+                path = os.path.join(pdir, ver)
+                # Version must be decoded before
+                # use.
+                pver = unquote(ver)
+                try:
+                    pfmri = fmri.PkgFmri(
+                        "@".join((pname, pver)), publisher=self.publisher
+                    )
+                    if not os.path.isfile(path):
+                        raise Exception("{0} is not a file".format(path))
+                except Exception as e:
+                    # Assume the error is result of an
+                    # unexpected file in the directory. We
+                    # don't know the FMRI here, so use None.
+                    progtrack.repo_verify_start_pkg(None)
+                    progtrack.repo_verify_add_progress(None)
+                    yield self.__build_verify_error(
+                        REPO_VERIFY_UNKNOWN, path, {"err": str(e)}
+                    )
+                    progtrack.repo_verify_end_pkg(None)
+                    continue
+
+                progtrack.repo_verify_start_pkg(pfmri)
+                err = self.__verify_manifest(path, pfmri)
+                if err:
+                    # with a bad manifest, we can go no
+                    # further
+                    yield self.__build_verify_error(*err)
+                    progtrack.repo_verify_end_pkg(None)
+                    continue
+
+                hashes, errors = self.__get_hashes(path, pfmri)
+                for err in errors:
+                    yield self.__build_verify_error(*err)
+
+                # verify manifest signatures
+                errs = self.__verify_signature(
+                    path,
+                    pfmri,
+                    pub,
+                    trust_anchors,
+                    sig_required_names,
+                    use_crls,
+                )
+                for err in errs:
+                    yield self.__build_verify_error(*err)
+
+                # verify payload delivered by this pkg
+                errors = []
+                for fname, h, alg in hashes:
+                    try:
+                        path = self.cache_store.lookup(
+                            fname, check_existence=False
+                        )
+                    except apx.PermissionsException as e:
+                        # if we can't even get the path
+                        # within the repository, then
+                        # we'll do the best we can to
+                        # report the problem.
+                        errors.append(
+                            (
+                                REPO_VERIFY_PERM,
+                                pfmri,
+                                {
+                                    "hash": fname,
+                                    "err": _(
+                                        "Permission " "denied.", "path", h
+                                    ),
+                                },
+                            )
+                        )
+                        continue
+
+                    err = self.__verify_perm(path, pfmri, h)
+                    if err:
+                        # For backward compatibility,
+                        # store the SHA1 file name for
+                        # file retrieval.
+                        err[2]["fname"] = fname
+                        errors.append(err)
+                        continue
+                    err = self.__verify_hash(path, pfmri, h, alg=alg)
+                    if err:
+                        err[2]["fname"] = fname
+                        errors.append(err)
+                for err in errors:
+                    yield self.__build_verify_error(*err)
+
+                progtrack.repo_verify_end_pkg(fmri)
+        progtrack.job_done(progtrack.JOB_REPO_VERIFY_REPO)
+
+    def verify(
+        self,
+        pub=None,
+        progtrack=None,
+        trust_anchor_dir=None,
+        sig_required_names=None,
+        use_crls=False,
+    ):
+        """A generator which verifies the contents of the repository
+        store, checking for several different types of errors.
+        No modifying operations may be performed until complete.
+
+        'progtrack' is an optional ProgressTracker object.
+
+        'trust_anchor_dir' is set in the repository configuration and
+        corresponds to the image property of the same name.
+
+        'sig_required_names' is set in the repository configuration and
+        corresponds to the image property of the same name.
+
+        'use_crls' is set in the repository configuration and
+        corresponds to the image property of the same name.
+
+        The generator yields tuples of the form:
+
+        (error_code, path, message, reason) where
+
+        'error_code'  an integer error, correponding to REPO_VERIFY_*
+        'path'        the path to the broken file in the repository
+        'message'     a human-readable summary of the error
+        'reason'      a dictionary of strings containing more detail
+                      about the nature of the error.
+        """
+
+        if not self.catalog_root or self.catalog_version < 1:
+            raise RepositoryUnsupportedOperationError()
+        if not self.manifest_root:
+            raise RepositoryUnsupportedOperationError()
+
+        if not progtrack:
+            progtrack = progtrack.NullProgressTracker()
+
+        # For signature verification, we need to setup a publisher
+        # meta_root, and build a dictionary of trust-anchors.
+        tmp_metaroot = tempfile.mkdtemp(prefix="pkgrepo-verify.")
+        pub.meta_root = tmp_metaroot
+        trust_anchors = {}
+
+        if not os.path.isdir(trust_anchor_dir):
+            raise RepositorySigNoTrustAnchorDirError(trust_anchor_dir)
+
+        for fn in os.listdir(trust_anchor_dir):
+            pth = os.path.join(trust_anchor_dir, fn)
+            if not os.path.isfile(pth) or os.path.islink(pth):
+                continue
+            with open(pth, "rb") as f:
+                try:
+                    trusted_ca = x509.load_pem_x509_certificate(
+                        f.read(), default_backend()
+                    )
+                except ValueError as e:
+                    continue
+
+            # Note that while we store certs by their subject
+            # hashes, we use our own hashing since cryptography has
+            # no interface for the subject hash and other crypto
+            # frameworks have been inconsistent with OpenSSL.
+            s = hashlib.sha1(misc.force_bytes(trusted_ca.subject)).hexdigest()
+            trust_anchors.setdefault(s, [])
+            trust_anchors[s].append(trusted_ca)
+
+        self.__lock_rstore()
+        try:
+            for err in self.__gen_verify(
+                progtrack, pub, trust_anchors, sig_required_names, use_crls
+            ):
+                yield err
+        except (Exception, EnvironmentError) as e:
+            import traceback
+
+            traceback.print_exc()
+            raise apx._convert_error(e)
+        finally:
+            self.__unlock_rstore()
+            shutil.rmtree(tmp_metaroot)
+
+    def fix(
+        self,
+        pub=None,
+        progtrack=None,
+        verify_callback=None,
+        trust_anchor_dir=None,
+        sig_required_names=None,
+        use_crls=False,
+    ):
+        """Verify, then quarantine any packages in the repository that
+        were found to be faulty, according to self.verify(..).
+
+        This method yields tuples of the form:
+
+        (status_code, fmri, message, reason) where
+
+        'status_code'  an int status code, corresponding to REPO_FIX_*
+        'path'         the path that was fixed
+        'message'      a summary of the operation performed
+        'reason'       a dictionary of strings describing the operation
+
+        Note, the 'fmri' value may not be a valid FMRI if the manifest
+        being fixed was corrupt, in which case a path to the corrupted
+        manifest in the repository is used instead.
+
+        If any object referred to by a manifest is quarantined, then
+        the manifest for that package is also quarantined, however other
+        files referenced by the manifest are not moved to quarantine
+        in case they are referenced by other packages.
+        """
+
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+
+        if not progtrack:
+            progtrack = progress.NullProgressTracker()
+
+        broken_items = set()
+        for error, path, message, reason in self.verify(
+            pub=pub,
+            progtrack=progtrack,
+            trust_anchor_dir=trust_anchor_dir,
+            sig_required_names=sig_required_names,
+            use_crls=use_crls,
+        ):
+            if verify_callback:
+                verify_callback(progtrack, (error, path, message, reason))
+            # we don't attempt to fix this error, since it can
+            # involve paths outside the repository.
+            if error == REPO_VERIFY_WARN_OPENPERMS:
+                continue
+            fmri = reason.get("pkg")
+            broken_items.add((path, fmri))
+
+        quarantine_root = None
+
+        def _make_quarantine_root():
+            """Make a directory where we can quarantine content."""
+            quarantine_base = os.path.join(self.root, REPO_QUARANTINE_DIR)
+            if not os.path.exists(quarantine_base):
+                os.mkdir(quarantine_base)
+            qroot = tempfile.mkdtemp(prefix="fix.", dir=quarantine_base)
+            return qroot
+
+        # look for broken package content where the bad file doesn't
+        # match the path to the manifest (eg. file content) and add
+        # the manifest path to the list of broken items, so that we
+        # move the manifest to quarantine as well.
+        for path, fmri in broken_items.copy():
+            if not fmri:
+                continue
+            mpath = self.manifest(fmri)
+            if path == mpath:
+                continue
+            broken_items.add((mpath, fmri))
+
+        progtrack.job_start(progtrack.JOB_REPO_FIX_REPO, goal=len(broken_items))
+
+        # keep a set of all the paths we've applied fixes to
+        fixed_paths = set()
+
+        for path, fmri in broken_items:
+            progtrack.job_add_progress(progtrack.JOB_REPO_FIX_REPO)
+
+            # we've already applied a fix to this path
+            if path in fixed_paths:
+                continue
+
+            # we can't do anything about missing files
+            if not os.path.exists(path):
+                yield (
+                    REPO_FIX_ITEM,
+                    path,
+                    _(
+                        "Missing file {0} must be fixed by "
+                        "republishing the package."
+                    ).format(path),
+                    {"pkg": fmri},
+                )
+                continue
+
+            basename = os.path.basename(path)
+            dir = os.path.dirname(path)
+            dir = dir.replace(self.root, "", 1).lstrip("/")
+            if not quarantine_root:
+                quarantine_root = _make_quarantine_root()
+            qdir = os.path.join(quarantine_root, dir)
+            try:
+                os.makedirs(qdir)
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+            dest = os.path.join(qdir, basename)
+            if os.path.exists(dest):
+                # this should never happen, since we have a
+                # unique quarantine root per fix(..) call
+                raise RepositoryQuarantinedPathExistsError()
+
+            message = _("Moving {src} to {dest}").format(src=path, dest=dest)
+            status = REPO_FIX_ITEM
+            reason = {"dest": dest, "pkg": fmri}
+            try:
+                shutil.move(path, qdir)
+                fixed_paths.add(path)
+            except Exception as e:
+                status = REPO_FIX_FAILED
+                message = _("Unable to quarantine {path}: " "{err}").format(
+                    path=path, err=e
+                )
+            finally:
+                yield (status, path, message, reason)
+
+        progtrack.job_done(progtrack.JOB_REPO_FIX_REPO)
+
+        if broken_items:
+            self.rebuild()
+
+    def valid_new_fmri(self, pfmri):
+        """Check that the FMRI supplied as an argument would be valid
+        to add to the repository catalog.  This checks to make sure
+        that any past catalog operations (such as a rename or freeze)
+        would not prohibit the caller from adding this FMRI."""
+
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if not self.catalog_root:
+            raise RepositoryUnsupportedOperationError()
+        if not fmri.is_valid_pkg_name(pfmri.get_name()):
+            return False
+        if not pfmri.version:
+            return False
+
+        c = self.catalog
+        entry = c.get_entry(pfmri)
+        return entry is None
+
+    def valid_append_fmri(self, pfmri):
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if not self.catalog_root:
+            raise RepositoryUnsupportedOperationError()
+        if not fmri.is_valid_pkg_name(pfmri.get_name()):
+            return False
+        if not pfmri.version:
+            return False
+        if not pfmri.version.timestr:
+            return False
+
+        c = self.catalog
+        entry = c.get_entry(pfmri)
+        return entry is not None
+
+    catalog_root = property(lambda self: self.__catalog_root)
+    file_layout = property(lambda self: self.__file_layout)
+    file_root = property(lambda self: self.__file_root)
+    read_only = property(lambda self: self.__read_only, __set_read_only)
+    root = property(lambda self: self.__root)
+    writable_root = property(lambda self: self.__writable_root)
 
 
 class Repository(object):
-        """A Repository object is a representation of data contained within a
-        pkg(7) repository and an interface to manipulate it."""
+    """A Repository object is a representation of data contained within a
+    pkg(7) repository and an interface to manipulate it."""
 
-        def __init__(self, allow_invalid=False, cfgpathname=None, create=False,
-            file_root=None, log_obj=None, mirror=False,
-            properties=misc.EmptyDict, read_only=False, root=None,
-            sort_file_max_size=indexer.SORT_FILE_MAX_SIZE, writable_root=None):
-                """Prepare the repository for use."""
+    def __init__(
+        self,
+        allow_invalid=False,
+        cfgpathname=None,
+        create=False,
+        file_root=None,
+        log_obj=None,
+        mirror=False,
+        properties=misc.EmptyDict,
+        read_only=False,
+        root=None,
+        sort_file_max_size=indexer.SORT_FILE_MAX_SIZE,
+        writable_root=None,
+    ):
+        """Prepare the repository for use."""
 
-                # This lock is used to protect the repository from multiple
-                # threads modifying it at the same time.  This must be set
-                # first.
-                self.__lock = pkg.nrlock.NRLock()
-                self.__prop_lock = pkg.nrlock.NRLock()
+        # This lock is used to protect the repository from multiple
+        # threads modifying it at the same time.  This must be set
+        # first.
+        self.__lock = pkg.nrlock.NRLock()
+        self.__prop_lock = pkg.nrlock.NRLock()
 
-                # Setup any root overrides or root defaults first.
-                self.__file_root = file_root
-                self.__pub_root = None
+        # Setup any root overrides or root defaults first.
+        self.__file_root = file_root
+        self.__pub_root = None
+        self.__root = None
+        self.__tmp_root = None
+        self.__writable_root = None
+
+        # Set root after roots above.
+        self.__set_root(root)
+
+        # Set writable root last.
+        self.__set_writable_root(writable_root)
+
+        # Stats
+        self.__catalog_requests = 0
+        self.__file_requests = 0
+        self.__manifest_requests = 0
+
+        # Initialize.
+        self.__cfgpathname = cfgpathname
+        self.__cfg = None
+        self.__mirror = mirror
+        self.__read_only = read_only
+        self.__rstores = None
+        self.__sort_file_max_size = sort_file_max_size
+        self.log_obj = log_obj
+        self.version = -1
+
+        self.__lock_repository()
+        try:
+            self.__init_state(
+                allow_invalid=allow_invalid,
+                create=create,
+                properties=properties,
+            )
+        finally:
+            self.__unlock_repository()
+
+    def __init_format(
+        self, allow_invalid=False, create=False, properties=misc.EmptyI
+    ):
+        """Private helper function to determine repository format and
+        validity.
+        """
+
+        try:
+            if not create and self.root and os.path.isfile(self.root):
+                raise RepositoryInvalidError(self.root)
+        except EnvironmentError as e:
+            raise apx._convert_error(e)
+
+        cfgpathname = None
+        if self.__cfgpathname:
+            # Use the custom configuration.
+            cfgpathname = self.__cfgpathname
+        elif self.root:
+            # Fallback to older standard configuration.
+            cfgpathname = os.path.join(self.root, "cfg_cache")
+
+        if self.root:
+            # Determine if the standard configuration file exists,
+            # and if so, ignore any custom location specified as it
+            # is only valid for older formats.
+            cfgpath = os.path.join(self.root, "pkg5.repository")
+            if (
+                cfgpathname and not os.path.exists(cfgpathname)
+            ) or os.path.isfile(cfgpath):
+                cfgpathname = cfgpath
+
+        # Load the repository configuration.
+        self.__cfg = RepositoryConfig(target=cfgpathname, overrides=properties)
+
+        try:
+            self.version = int(self.cfg.get_property("repository", "version"))
+        except (cfg.PropertyConfigError, ValueError):
+            # If version couldn't be read from configuration,
+            # then allow fallback path below to set things right.
+            self.version = -1
+
+        if self.version <= 0 and self.root:
+            # If version doesn't exist, attempt to determine version
+            # based on structure.
+            pub_root = os.path.join(self.root, "publisher")
+            cat_root = os.path.join(self.root, "catalog")
+            if os.path.exists(pub_root) or (
+                self.cfg.version > 3 and not os.path.exists(cat_root)
+            ):
+                # If publisher root exists or new configuration
+                # format exists (and the old catalog root
+                # does not), assume this is a v4 repository.
+                self.version = 4
+            elif self.root:
+                if os.path.exists(cat_root):
+                    if os.path.exists(os.path.join(cat_root, "attrs")):
+                        # Old catalog implies v2.
+                        self.version = 2
+                    else:
+                        # Assume version 3 otherwise.
+                        self.version = 3
+
+                    # Reload the repository configuration
+                    # so that configuration definitions
+                    # can match.
+                    self.__cfg = RepositoryConfig(
+                        target=cfgpathname,
+                        overrides=properties,
+                        version=self.version,
+                    )
+                else:
+                    raise RepositoryInvalidError(self.root)
+            else:
+                raise RepositoryInvalidError()
+
+            self.cfg.set_property("repository", "version", self.version)
+        elif self.version <= 0 and self.file_root:
+            # If only file root specified, treat as version 4
+            # repository.
+            self.version = 4
+
+        # Setup roots.
+        if self.root and not self.file_root:
+            # Don't create the default file root at this point, but
+            # set its default location if it exists.
+            froot = os.path.join(self.root, "file")
+            if not self.file_root and os.path.exists(froot):
+                self.__file_root = froot
+
+        if self.version > CURRENT_REPO_VERSION:
+            raise RepositoryVersionError(
+                self.root, self.version, CURRENT_REPO_VERSION
+            )
+        if self.version == 4:
+            if self.root and not self.pub_root:
+                # Don't create the publisher root at this point,
+                # but set its expected location.
+                self.__pub_root = os.path.join(self.root, "publisher")
+
+            if (
+                not create
+                and cfgpathname
+                and not os.path.exists(cfgpathname)
+                and not (
+                    os.path.exists(self.pub_root)
+                    or os.path.exists(os.path.join(self.root, "pkg5.image"))
+                    and int(
+                        cfg.FileConfig(
+                            os.path.join(self.root, "pkg5.image")
+                        ).get_property("image", "version")
+                    )
+                    >= 3
+                )
+            ):
+                # If this isn't a repository creation operation,
+                # and the base configuration file doesn't exist,
+                # this isn't a valid repository.
+                raise RepositoryInvalidError(self.root)
+
+        # Setup repository stores.
+        def_pub = self.cfg.get_property("publisher", "prefix")
+        try:
+            fmt = self.cfg.get_property("repository", "format")
+        except:
+            fmt = "ascii"
+        if self.version == 4:
+            # For repository versions 4+, there is a repository
+            # store for the top-level file root (and it must
+            # be in V1 Layout)...
+            froot = self.file_root
+            if not froot:
+                froot = os.path.join(self.root, "file")
+            rstore = _RepoStore(
+                file_layout=layout.V1Layout(),
+                file_root=froot,
+                log_obj=self.log_obj,
+                mirror=self.mirror,
+                read_only=self.read_only,
+                catalogue_format=fmt,
+            )
+            self.__rstores[rstore.publisher] = rstore
+
+            # ...and then one for each publisher if any are known.
+            if self.pub_root and os.path.exists(self.pub_root):
+                for pub in os.listdir(self.pub_root):
+                    self.__new_rstore(pub, allow_invalid=allow_invalid)
+
+            # If a default publisher is set, ensure that a storage
+            # object always exists for it.
+            if def_pub and def_pub not in self.__rstores:
+                self.__new_rstore(def_pub, allow_invalid=allow_invalid)
+        else:
+            # For older repository versions, there is only one
+            # repository store, and it might have an associated
+            # publisher prefix.  (This might be in a mix of V0 and
+            # V1 layouts.)
+            rstore = _RepoStore(
+                allow_invalid=allow_invalid,
+                file_root=self.file_root,
+                log_obj=self.log_obj,
+                pub=def_pub,
+                mirror=self.mirror,
+                read_only=self.read_only,
+                root=self.root,
+                writable_root=self.writable_root,
+                catalogue_format=fmt,
+            )
+            self.__rstores[rstore.publisher] = rstore
+
+        if not self.root:
+            # Nothing more to do.
+            return
+
+        try:
+            fs = os.stat(self.root)
+        except OSError as e:
+            # If the stat failed due to this, then assume the
+            # repository is possibly valid but that there is a
+            # permissions issue.
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            elif e.errno == errno.ENOENT:
+                raise RepositoryInvalidError(self.root)
+            raise
+
+        if not stat.S_ISDIR(stat.S_IFMT(fs.st_mode)):
+            # Not a directory.
+            raise RepositoryInvalidError(self.root)
+
+        # Ensure obsolete search data is removed.
+        if self.version >= 3 and not self.read_only:
+            searchdb_file = os.path.join(self.root, "search")
+            for ext in ".pag", ".dir":
+                try:
+                    os.unlink(searchdb_file + ext)
+                except OSError:
+                    # If these can't be removed, it doesn't
+                    # matter.
+                    continue
+
+    def __init_state(
+        self, allow_invalid=False, create=False, properties=misc.EmptyDict
+    ):
+        """Private helper function to initialize state."""
+
+        # Discard current repository storage state data.
+        self.__rstores = {}
+
+        # Determine format, configuration location, and validity.
+        self.__init_format(
+            allow_invalid=allow_invalid, create=create, properties=properties
+        )
+
+        # Ensure default configuration is written.
+        self.__write_config()
+
+    def __lock_repository(self):
+        """Locks the repository preventing multiple consumers from
+        modifying it during operations."""
+
+        # XXX need filesystem lock too?
+        self.__lock.acquire()
+
+    def __log(self, msg, context="", severity=logging.INFO):
+        if self.log_obj:
+            self.log_obj.log(msg=msg, context=context, severity=severity)
+
+    def __set_mirror(self, value):
+        self.__prop_lock.acquire()
+        try:
+            self.__mirror = value
+            for rstore in self.rstores:
+                rstore.mirror = value
+        finally:
+            self.__prop_lock.release()
+
+    def __set_read_only(self, value):
+        self.__prop_lock.acquire()
+        try:
+            self.__read_only = value
+            for rstore in self.rstores:
+                rstore.read_only = value
+        finally:
+            self.__prop_lock.release()
+
+    def __set_root(self, root):
+        self.__prop_lock.acquire()
+        try:
+            if root:
+                root = os.path.abspath(root)
+                self.__root = root
+                self.__tmp_root = os.path.join(root, "tmp")
+            else:
                 self.__root = None
+        finally:
+            self.__prop_lock.release()
+
+    def __set_writable_root(self, root):
+        self.__prop_lock.acquire()
+        try:
+            if root:
+                root = os.path.abspath(root)
+                self.__tmp_root = os.path.join(root, "tmp")
+            elif self.root:
+                self.__tmp_root = os.path.join(self.root, "tmp")
+            else:
                 self.__tmp_root = None
-                self.__writable_root = None
+            self.__writable_root = root
+        finally:
+            self.__prop_lock.release()
 
-                # Set root after roots above.
-                self.__set_root(root)
+    def __unlock_repository(self):
+        """Unlocks the repository so other consumers may modify it."""
 
-                # Set writable root last.
-                self.__set_writable_root(writable_root)
+        # XXX need filesystem unlock too?
+        self.__lock.release()
 
-                # Stats
-                self.__catalog_requests = 0
-                self.__file_requests = 0
-                self.__manifest_requests = 0
+    def __write_config(self):
+        """Save the repository's current configuration data."""
 
-                # Initialize.
-                self.__cfgpathname = cfgpathname
-                self.__cfg = None
-                self.__mirror = mirror
-                self.__read_only = read_only
-                self.__rstores = None
-                self.__sort_file_max_size = sort_file_max_size
-                self.log_obj = log_obj
-                self.version = -1
+        # No changes should be written to disk in readonly mode.
+        if self.read_only:
+            return
 
-                self.__lock_repository()
-                try:
-                        self.__init_state(allow_invalid=allow_invalid,
-                            create=create, properties=properties)
-                finally:
-                        self.__unlock_repository()
+        # Save a new configuration (or refresh existing).
+        try:
+            self.cfg.write()
+        except EnvironmentError as e:
+            # If we're unable to write due to the following
+            # errors, it isn't critical to the operation of
+            # the repository.
+            if e.errno not in (errno.EPERM, errno.EACCES, errno.EROFS):
+                raise
 
-        def __init_format(self, allow_invalid=False, create=False,
-            properties=misc.EmptyI):
-                """Private helper function to determine repository format and
-                validity.
-                """
+    def __new_rstore(self, pub, allow_invalid=False):
+        assert pub
+        if pub in self.__rstores:
+            raise RepositoryDuplicatePublisher(pub)
 
-                try:
-                        if not create and self.root and \
-                            os.path.isfile(self.root):
-                                raise RepositoryInvalidError(self.root)
-                except EnvironmentError as e:
-                        raise apx._convert_error(e)
+        if self.pub_root:
+            # Newer repository format stores repository data
+            # partitioned by publisher.
+            root = os.path.join(self.pub_root, pub)
+        else:
+            # Older repository formats store repository data
+            # in a shared root area.
+            root = self.root
 
-                cfgpathname = None
-                if self.__cfgpathname:
-                        # Use the custom configuration.
-                        cfgpathname = self.__cfgpathname
-                elif self.root:
-                        # Fallback to older standard configuration.
-                        cfgpathname = os.path.join(self.root,
-                            "cfg_cache")
+        writ_root = None
+        if self.writable_root:
+            writ_root = os.path.join(self.writable_root, "publisher", pub)
 
-                if self.root:
-                        # Determine if the standard configuration file exists,
-                        # and if so, ignore any custom location specified as it
-                        # is only valid for older formats.
-                        cfgpath = os.path.join(self.root,
-                            "pkg5.repository")
-                        if (cfgpathname and not os.path.exists(cfgpathname)) or \
-                            os.path.isfile(cfgpath):
-                                cfgpathname = cfgpath
+        froot = self.file_root
+        if self.root and froot and froot.startswith(self.root):
+            # Ignore the file root if it's the default one.
+            froot = None
 
-                # Load the repository configuration.
-                self.__cfg = RepositoryConfig(target=cfgpathname,
-                    overrides=properties)
+        file_layout = None
+        if self.version >= 4:
+            # For version 4 and newer repositories, assume a V1
+            # layout for file content.  Older repository formats
+            # might use a mix of layouts.
+            file_layout = layout.V1Layout()
 
-                try:
-                        self.version = int(self.cfg.get_property("repository",
-                            "version"))
-                except (cfg.PropertyConfigError, ValueError):
-                        # If version couldn't be read from configuration,
-                        # then allow fallback path below to set things right.
-                        self.version = -1
+        try:
+            fmt = self.cfg.get_property("repository", "format")
+        except:
+            fmt = "ascii"
 
-                if self.version <= 0 and self.root:
-                        # If version doesn't exist, attempt to determine version
-                        # based on structure.
-                        pub_root = os.path.join(self.root, "publisher")
-                        cat_root = os.path.join(self.root, "catalog")
-                        if os.path.exists(pub_root) or \
-                            (self.cfg.version > 3 and
-                            not os.path.exists(cat_root)):
-                                # If publisher root exists or new configuration
-                                # format exists (and the old catalog root
-                                # does not), assume this is a v4 repository.
-                                self.version = 4
-                        elif self.root:
-                                if os.path.exists(cat_root):
-                                        if os.path.exists(os.path.join(
-                                            cat_root, "attrs")):
-                                                # Old catalog implies v2.
-                                                self.version = 2
-                                        else:
-                                                # Assume version 3 otherwise.
-                                                self.version = 3
+        rstore = _RepoStore(
+            allow_invalid=allow_invalid,
+            file_layout=file_layout,
+            file_root=froot,
+            log_obj=self.log_obj,
+            mirror=self.mirror,
+            pub=pub,
+            read_only=self.read_only,
+            root=root,
+            sort_file_max_size=self.__sort_file_max_size,
+            writable_root=writ_root,
+            catalogue_format=fmt,
+        )
+        self.__rstores[pub] = rstore
+        return rstore
 
-                                        # Reload the repository configuration
-                                        # so that configuration definitions
-                                        # can match.
-                                        self.__cfg = RepositoryConfig(
-                                            target=cfgpathname,
-                                            overrides=properties,
-                                            version=self.version)
-                                else:
-                                        raise RepositoryInvalidError(
-                                            self.root)
-                        else:
-                                raise RepositoryInvalidError()
+    def abandon(self, trans_id):
+        """Aborts a transaction with the specified Transaction ID.
+        Returns the current package state.
+        """
 
-                        self.cfg.set_property("repository", "version",
-                            self.version)
-                elif self.version <= 0 and self.file_root:
-                        # If only file root specified, treat as version 4
-                        # repository.
-                        self.version = 4
+        rstore = self.get_trans_rstore(trans_id)
+        return rstore.abandon(trans_id)
 
-                # Setup roots.
-                if self.root and not self.file_root:
-                        # Don't create the default file root at this point, but
-                        # set its default location if it exists.
-                        froot = os.path.join(self.root, "file")
-                        if not self.file_root and os.path.exists(froot):
-                                self.__file_root = froot
+    def add(self, trans_id, action):
+        """Adds an action and its content to a transaction with the
+        specified Transaction ID.
+        """
 
-                if self.version > CURRENT_REPO_VERSION:
-                        raise RepositoryVersionError(self.root,
-                            self.version, CURRENT_REPO_VERSION)
-                if self.version == 4:
-                        if self.root and not self.pub_root:
-                                # Don't create the publisher root at this point,
-                                # but set its expected location.
-                                self.__pub_root = os.path.join(self.root,
-                                    "publisher")
+        rstore = self.get_trans_rstore(trans_id)
+        return rstore.add(trans_id, action)
 
-                        if not create and cfgpathname and \
-                            not os.path.exists(cfgpathname) and \
-                            not (os.path.exists(self.pub_root) or
-                            os.path.exists(os.path.join(
-                                self.root, "pkg5.image")) and
-                            int(cfg.FileConfig(os.path.join(
-                                self.root, "pkg5.image")).
-                                    get_property("image", "version")) >= 3):
-                                # If this isn't a repository creation operation,
-                                # and the base configuration file doesn't exist,
-                                # this isn't a valid repository.
-                                raise RepositoryInvalidError(self.root)
+    def add_publisher(self, pub, skip_config=False):
+        """Creates a repository storage area for the publisher defined
+        by the provided Publisher object and then stores the publisher's
+        configuration information.  Only supported for version 4 and
+        later repositories.
+        """
 
-                # Setup repository stores.
-                def_pub = self.cfg.get_property("publisher", "prefix")
-                try:
-                        fmt = self.cfg.get_property("repository", "format")
-                except:
-                        fmt = 'ascii'
-                if self.version == 4:
-                        # For repository versions 4+, there is a repository
-                        # store for the top-level file root (and it must
-                        # be in V1 Layout)...
-                        froot = self.file_root
-                        if not froot:
-                                froot = os.path.join(self.root, "file")
-                        rstore = _RepoStore(file_layout=layout.V1Layout(),
-                            file_root=froot, log_obj=self.log_obj,
-                            mirror=self.mirror, read_only=self.read_only,
-                            catalogue_format=fmt)
-                        self.__rstores[rstore.publisher] = rstore
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.pub_root or self.version < 4:
+            raise RepositoryUnsupportedOperationError()
 
-                        # ...and then one for each publisher if any are known.
-                        if self.pub_root and os.path.exists(self.pub_root):
-                                for pub in os.listdir(self.pub_root):
-                                        self.__new_rstore(pub,
-                                            allow_invalid=allow_invalid)
+        # Create the new repository storage area.
+        rstore = self.__new_rstore(pub.prefix)
 
-                        # If a default publisher is set, ensure that a storage
-                        # object always exists for it.
-                        if def_pub and def_pub not in self.__rstores:
-                                self.__new_rstore(def_pub,
-                                    allow_invalid=allow_invalid)
+        if skip_config:
+            return
+
+        # Update the publisher's configuration.
+        try:
+            rstore.update_publisher(pub)
+        except:
+            # If the above fails, be certain to delete the new
+            # repository storage area and then re-raise the
+            # original exception.
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            try:
+                shutil.rmtree(rstore.root)
+            finally:
+                # This ensures that the original exception and
+                # traceback are used.
+                if six.PY2:
+                    six.reraise(exc_value, None, exc_tb)
                 else:
-                        # For older repository versions, there is only one
-                        # repository store, and it might have an associated
-                        # publisher prefix.  (This might be in a mix of V0 and
-                        # V1 layouts.)
-                        rstore = _RepoStore(allow_invalid=allow_invalid,
-                            file_root=self.file_root,
-                            log_obj=self.log_obj, pub=def_pub,
-                            mirror=self.mirror,
-                            read_only=self.read_only,
-                            root=self.root,
-                            writable_root=self.writable_root,
-                            catalogue_format=fmt)
-                        self.__rstores[rstore.publisher] = rstore
+                    raise exc_value
 
-                if not self.root:
-                        # Nothing more to do.
-                        return
+    def remove_publisher(self, pfxs, repo_path, synch=False):
+        """Removes a repository storage area and configuration
+        information for the publisher defined by the provided
+        publisher prefix. pfxs must be an iterable.
+        """
 
-                try:
-                        fs = os.stat(self.root)
-                except OSError as e:
-                        # If the stat failed due to this, then assume the
-                        # repository is possibly valid but that there is a
-                        # permissions issue.
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(
-                                    e.filename)
-                        elif e.errno == errno.ENOENT:
-                                raise RepositoryInvalidError(self.root)
-                        raise
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.pub_root or self.version < 4:
+            raise RepositoryUnsupportedOperationError()
 
-                if not stat.S_ISDIR(stat.S_IFMT(fs.st_mode)):
-                        # Not a directory.
-                        raise RepositoryInvalidError(self.root)
+        # create a temp folder, move the publisher folder into it
+        # and then remove the temp folder recursively
+        tmp_paths = []
+        self.__lock_repository()
+        try:
+            for pfx in pfxs:
+                repo_tmp_path = self.__mkdtemppub(pfx)
+                tmp_paths.append(repo_tmp_path)
+                pub_path = os.path.join(repo_path, "publisher", pfx)
+                if os.path.exists(pub_path) and os.path.exists(repo_tmp_path):
+                    portable.rename(pub_path, repo_tmp_path)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
+        finally:
+            self.__unlock_repository()
 
-                # Ensure obsolete search data is removed.
-                if self.version >= 3 and not self.read_only:
-                        searchdb_file = os.path.join(self.root, "search")
-                        for ext in ".pag", ".dir":
-                                try:
-                                        os.unlink(searchdb_file + ext)
-                                except OSError:
-                                        # If these can't be removed, it doesn't
-                                        # matter.
-                                        continue
+        nullf = open(os.devnull, "w")
+        args = ["/usr/bin/rm", "-rf"]
+        args.extend(tmp_paths)
+        if not synch:
+            args = ["/usr/bin/nohup"] + args
+        subp = subprocess.Popen(args, stdout=nullf, stderr=nullf)
 
-        def __init_state(self, allow_invalid=False, create=False,
-            properties=misc.EmptyDict):
-                """Private helper function to initialize state."""
+        if synch:
+            subp.wait()
 
-                # Discard current repository storage state data.
-                self.__rstores = {}
+    def __mkdtemppub(self, pfx):
+        """Create a temp directory under repository directory
+        and corresponding temp pub folder with format
+        rm.pubname.xxxxxx under this folder
+        """
 
-                # Determine format, configuration location, and validity.
-                self.__init_format(allow_invalid=allow_invalid, create=create,
-                    properties=properties)
+        if not self.root:
+            return
 
-                # Ensure default configuration is written.
-                self.__write_config()
+        if self.writable_root:
+            root = self.writable_root
+        else:
+            root = self.root
 
-        def __lock_repository(self):
-                """Locks the repository preventing multiple consumers from
-                modifying it during operations."""
+        tempdir = os.path.normpath(os.path.join(root, "tmp"))
 
-                # XXX need filesystem lock too?
-                self.__lock.acquire()
+        try:
+            misc.makedirs(tempdir)
+            return tempfile.mkdtemp(prefix="rm." + pfx + ".", dir=tempdir)
 
-        def __log(self, msg, context="", severity=logging.INFO):
-                if self.log_obj:
-                        self.log_obj.log(msg=msg, context=context,
-                            severity=severity)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
 
-        def __set_mirror(self, value):
-                self.__prop_lock.acquire()
-                try:
-                        self.__mirror = value
-                        for rstore in self.rstores:
-                                rstore.mirror = value
-                finally:
-                        self.__prop_lock.release()
+    def add_package(self, pfmri):
+        """Adds the specified FMRI to the repository's catalog."""
 
-        def __set_read_only(self, value):
-                self.__prop_lock.acquire()
-                try:
-                        self.__read_only = value
-                        for rstore in self.rstores:
-                                rstore.read_only = value
-                finally:
-                        self.__prop_lock.release()
+        rstore = self.get_pub_rstore(pfmri.publisher)
+        return rstore.add_package(pfmri)
 
-        def __set_root(self, root):
-                self.__prop_lock.acquire()
-                try:
-                        if root:
-                                root = os.path.abspath(root)
-                                self.__root = root
-                                self.__tmp_root = os.path.join(root, "tmp")
-                        else:
-                                self.__root = None
-                finally:
-                        self.__prop_lock.release()
+    def append(self, client_release, pfmri, pub=None):
+        """Starts an append transaction for the specified client
+        release and FMRI.  Returns the Transaction ID for the new
+        transaction."""
 
-        def __set_writable_root(self, root):
-                self.__prop_lock.acquire()
-                try:
-                        if root:
-                                root = os.path.abspath(root)
-                                self.__tmp_root = os.path.join(root, "tmp")
-                        elif self.root:
-                                self.__tmp_root = os.path.join(self.root,
-                                    "tmp")
-                        else:
-                                self.__tmp_root = None
-                        self.__writable_root = root
-                finally:
-                        self.__prop_lock.release()
+        try:
+            if not isinstance(pfmri, fmri.PkgFmri):
+                pfmri = fmri.PkgFmri(pfmri, client_release)
+        except fmri.FmriError as e:
+            raise RepositoryInvalidFMRIError(e)
 
-        def __unlock_repository(self):
-                """Unlocks the repository so other consumers may modify it."""
+        if pub and not pfmri.publisher:
+            pfmri.publisher = pub
 
-                # XXX need filesystem unlock too?
-                self.__lock.release()
+        try:
+            rstore = self.get_pub_rstore(pfmri.publisher)
+        except RepositoryUnknownPublisher as e:
+            if not pfmri.publisher:
+                # No publisher given in FMRI and no default
+                # publisher so treat as invalid FMRI.
+                raise RepositoryUnqualifiedFMRIError(pfmri)
+            raise
+        return rstore.append(client_release, pfmri)
 
-        def __write_config(self):
-                """Save the repository's current configuration data."""
+    def catalog_0(self, pub=None):
+        """Returns a generator object for the full version of
+        the catalog contents.  Incremental updates are not provided
+        as the v0 updatelog does not support renames, obsoletion,
+        package removal, etc.
 
-                # No changes should be written to disk in readonly mode.
-                if self.read_only:
-                        return
+        'pub' is the prefix of the publisher to return catalog data for.
+        If not specified, the default publisher will be used.  If no
+        default publisher has been configured, an AssertionError will be
+        raised.
+        """
 
-                # Save a new configuration (or refresh existing).
-                try:
-                        self.cfg.write()
-                except EnvironmentError as e:
-                        # If we're unable to write due to the following
-                        # errors, it isn't critical to the operation of
-                        # the repository.
-                        if e.errno not in (errno.EPERM, errno.EACCES,
-                            errno.EROFS):
-                                raise
+        self.inc_catalog()
+        rstore = self.get_pub_rstore(pub)
+        return rstore.catalog_0()
 
-        def __new_rstore(self, pub, allow_invalid=False):
-                assert pub
-                if pub in self.__rstores:
-                        raise RepositoryDuplicatePublisher(pub)
+    def catalog_1(self, name, pub=None):
+        """Returns the absolute pathname of the named catalog file.
 
-                if self.pub_root:
-                        # Newer repository format stores repository data
-                        # partitioned by publisher.
-                        root = os.path.join(self.pub_root, pub)
-                else:
-                        # Older repository formats store repository data
-                        # in a shared root area.
-                        root = self.root
+        'pub' is the prefix of the publisher to return catalog data for.
+        If not specified, the default publisher will be used.  If no
+        default publisher has been configured, an AssertionError will be
+        raised.
+        """
 
-                writ_root = None
-                if self.writable_root:
-                        writ_root = os.path.join(self.writable_root,
-                            "publisher", pub)
+        self.inc_catalog()
+        rstore = self.get_pub_rstore(pub)
+        return rstore.catalog_1(name)
 
-                froot = self.file_root
-                if self.root and froot and \
-                    froot.startswith(self.root):
-                        # Ignore the file root if it's the default one.
-                        froot = None
+    def close(self, trans_id, add_to_catalog=True):
+        """Closes the transaction specified by 'trans_id'.
 
-                file_layout = None
-                if self.version >= 4:
-                        # For version 4 and newer repositories, assume a V1
-                        # layout for file content.  Older repository formats
-                        # might use a mix of layouts.
-                        file_layout = layout.V1Layout()
+        Returns a tuple containing the package FMRI and the current
+        package state in the catalog.
+        """
 
-                try:
-                        fmt = self.cfg.get_property("repository", "format")
-                except:
-                        fmt = 'ascii'
+        self.inc_catalog()
+        rstore = self.get_trans_rstore(trans_id)
+        return rstore.close(trans_id, add_to_catalog=add_to_catalog)
 
-                rstore = _RepoStore(allow_invalid=allow_invalid,
-                    file_layout=file_layout, file_root=froot,
-                    log_obj=self.log_obj, mirror=self.mirror, pub=pub,
-                    read_only=self.read_only, root=root,
-                    sort_file_max_size=self.__sort_file_max_size,
-                    writable_root=writ_root, catalogue_format=fmt)
-                self.__rstores[pub] = rstore
+    def file(self, fhash, pub=None):
+        """Returns the absolute pathname of the file specified by the
+        provided SHA1-hash name.
+
+        'pub' is the prefix of the publisher to return catalog data for.
+        If not specified, the default publisher will be used.  If no
+        default publisher has been configured, an AssertionError will be
+        raised.
+        """
+
+        self.inc_file()
+        if pub:
+            rstore = self.get_pub_rstore(pub)
+            return rstore.file(fhash)
+
+        # If a publisher wasn't specified, every repository store will
+        # have to be tried since default publisher can't safely apply
+        # here.
+        for rstore in self.rstores:
+            try:
+                return rstore.file(fhash)
+            except RepositoryFileNotFoundError:
+                # Ignore and try next repository store.
+                pass
+
+        # Not found in any repository store.
+        raise RepositoryFileNotFoundError(fhash)
+
+    def get_catalog(self, pub=None):
+        """Return the catalog object for the given publisher.
+
+        'pub' is the optional name of the publisher to return the
+        catalog for.  If not provided, the default publisher's
+        catalog will be returned.
+        """
+
+        try:
+            rstore = self.get_pub_rstore(pub)
+            return rstore.catalog
+        except RepositoryUnknownPublisher:
+            if pub:
+                # In this case, an unknown publisher's
+                # catalog was requested.
+                raise
+            # No catalog to return.
+            raise RepositoryUnsupportedOperationError()
+
+    def get_pub_rstore(self, pub=None):
+        """Return a repository storage object matching the given
+        publisher (if provided).  If not provided, a repository
+        storage object for the default publisher will be returned.
+        A RepositoryUnknownPublisher exception will be raised if
+        no storage object for the given publisher exists.
+        """
+
+        if pub is None:
+            pub = self.cfg.get_property("publisher", "prefix")
+        if not pub:
+            raise RepositoryUnknownPublisher(pub)
+
+        try:
+            rstore = self.__rstores[pub]
+        except KeyError:
+            raise RepositoryUnknownPublisher(pub)
+        return rstore
+
+    def __get_cfg_publisher(self, pub):
+        """Return a publisher object for the given publisher prefix
+        based on the repository's configuration information.
+        """
+        assert self.version < 4
+
+        alias = self.cfg.get_property("publisher", "alias")
+
+        rargs = {}
+        for prop in (
+            "collection_type",
+            "description",
+            "legal_uris",
+            "mirrors",
+            "name",
+            "origins",
+            "refresh_seconds",
+            "registration_uri",
+            "related_uris",
+        ):
+            rargs[prop] = self.cfg.get_property("repository", prop)
+
+        repo = publisher.Repository(**rargs)
+        return publisher.Publisher(pub, alias=alias, repository=repo)
+
+    def get_publishers(self):
+        """Return publisher objects for all publishers known by the
+        repository.
+        """
+        return [self.get_publisher(pub) for pub in self.publishers]
+
+    def get_publisher(self, pub):
+        """Return the publisher object for the given publisher.  Raises
+        RepositoryUnknownPublisher if no matching publisher can be
+        found.
+        """
+
+        if not pub:
+            raise RepositoryUnknownPublisher(pub)
+        if self.version < 4:
+            return self.__get_cfg_publisher(pub)
+
+        rstore = self.get_pub_rstore(pub)
+        if not rstore:
+            raise RepositoryUnknownPublisher(pub)
+        return rstore.get_publisher()
+
+    def get_status(self):
+        """Return a dictionary of status information about the
+        repository.
+        """
+
+        if self.locked:
+            rstatus = "processing"
+        else:
+            rstatus = "online"
+
+        rdata = {
+            "repository": {
+                "configuration": self.cfg.get_index(),
+                "publishers": {},
+                "requests": {
+                    "catalog": self.catalog_requests,
+                    "file": self.file_requests,
+                    "manifests": self.manifest_requests,
+                },
+                "status": rstatus,  # Overall repository state.
+                "version": self.version,  # Version of repository.
+            },
+            "version": 1,  # Version of status structure.
+        }
+
+        for rstore in self.rstores:
+            if not rstore.publisher:
+                continue
+            pubdata = rdata["repository"]["publishers"]
+            pubdata[rstore.publisher] = rstore.get_status()
+        return rdata
+
+    def get_trans_rstore(self, trans_id):
+        """Return a repository storage object matching the given
+        Transaction ID.  If no repository storage object has a
+        matching Transaction ID, a RepositoryInvalidTransactionIDError
+        will be raised.
+        """
+
+        for rstore in self.rstores:
+            if rstore.has_transaction(trans_id):
                 return rstore
+        raise RepositoryInvalidTransactionIDError(trans_id)
 
-        def abandon(self, trans_id):
-                """Aborts a transaction with the specified Transaction ID.
-                Returns the current package state.
-                """
+    @property
+    def in_flight_transactions(self):
+        """The number of transactions awaiting completion."""
 
-                rstore = self.get_trans_rstore(trans_id)
-                return rstore.abandon(trans_id)
+        return sum(rstore.in_flight_transactions for rstore in self.rstores)
 
-        def add(self, trans_id, action):
-                """Adds an action and its content to a transaction with the
-                specified Transaction ID.
-                """
+    def inc_catalog(self):
+        self.__catalog_requests += 1
 
-                rstore = self.get_trans_rstore(trans_id)
-                return rstore.add(trans_id, action)
+    def inc_file(self):
+        self.__file_requests += 1
 
-        def add_publisher(self, pub, skip_config=False):
-                """Creates a repository storage area for the publisher defined
-                by the provided Publisher object and then stores the publisher's
-                configuration information.  Only supported for version 4 and
-                later repositories.
-                """
+    def inc_manifest(self):
+        self.__manifest_requests += 1
 
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.pub_root or self.version < 4:
-                        raise RepositoryUnsupportedOperationError()
+    @property
+    def locked(self):
+        """A boolean value indicating whether the repository is locked."""
 
-                # Create the new repository storage area.
-                rstore = self.__new_rstore(pub.prefix)
+        return self.__lock and self.__lock.locked
 
-                if skip_config:
-                        return
+    def manifest(self, pfmri, pub=None):
+        """Returns the absolute pathname of the manifest file for the
+        specified FMRI.
+        """
 
-                # Update the publisher's configuration.
-                try:
-                        rstore.update_publisher(pub)
-                except:
-                        # If the above fails, be certain to delete the new
-                        # repository storage area and then re-raise the
-                        # original exception.
-                        exc_type, exc_value, exc_tb = sys.exc_info()
-                        try:
-                                shutil.rmtree(rstore.root)
-                        finally:
-                                # This ensures that the original exception and
-                                # traceback are used.
-                                if six.PY2:
-                                        six.reraise(exc_value, None, exc_tb)
-                                else:
-                                        raise exc_value
+        self.inc_manifest()
 
-        def remove_publisher(self, pfxs, repo_path, synch=False):
-                """Removes a repository storage area and configuration
-                information for the publisher defined by the provided
-                publisher prefix. pfxs must be an iterable.
-                """
+        try:
+            if not isinstance(pfmri, fmri.PkgFmri):
+                pfmri = fmri.PkgFmri(pfmri)
+        except fmri.FmriError as e:
+            raise RepositoryInvalidFMRIError(e)
 
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.pub_root or self.version < 4:
-                        raise RepositoryUnsupportedOperationError()
+        if not pub and pfmri.publisher:
+            pub = pfmri.publisher
+        elif pub and not pfmri.publisher:
+            pfmri.publisher = pub
 
-                # create a temp folder, move the publisher folder into it
-                # and then remove the temp folder recursively
-                tmp_paths = []
-                self.__lock_repository()
-                try:
-                        for pfx in pfxs:
-                                repo_tmp_path = self.__mkdtemppub(pfx)
-                                tmp_paths.append(repo_tmp_path)
-                                pub_path = os.path.join(repo_path, "publisher",
-                                    pfx)
-                                if os.path.exists(pub_path) and \
-                                    os.path.exists(repo_tmp_path) :
-                                        portable.rename(pub_path,
-                                        repo_tmp_path)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
-                finally:
-                        self.__unlock_repository()
+        if pub:
+            try:
+                rstore = self.get_pub_rstore(pub)
+            except RepositoryUnknownPublisher as e:
+                raise RepositoryManifestNotFoundError(pfmri)
+            return rstore.manifest(pfmri)
 
-                nullf = open(os.devnull, "w")
-                args = ["/usr/bin/rm", "-rf"]
-                args.extend(tmp_paths)
-                if not synch:
-                        args = ["/usr/bin/nohup"] + args
-                subp = subprocess.Popen(args, stdout=nullf, stderr=nullf)
+        # If a publisher wasn't specified, every repository store will
+        # have to be tried since default publisher can't safely apply
+        # here.  It's assumed that it's unlikely that two publishers
+        # share the exact same FMRI.  Since this case is only for
+        # compatibility, it shouldn't be much of a concern.
+        mpath = None
+        for rstore in self.rstores:
+            if not rstore.publisher:
+                continue
+            mpath = rstore.manifest(pfmri)
+            if not mpath or not os.path.exists(mpath):
+                continue
+            return mpath
+        raise RepositoryManifestNotFoundError(pfmri)
 
-                if synch:
-                        subp.wait()
+    def open(self, client_release, pfmri, pub=None):
+        """Starts a transaction for the specified client release and
+        FMRI.  Returns the Transaction ID for the new transaction.
+        """
 
-        def __mkdtemppub(self, pfx):
-                """Create a temp directory under repository directory
-                and corresponding temp pub folder with format
-                rm.pubname.xxxxxx under this folder
-                """
+        try:
+            if not isinstance(pfmri, fmri.PkgFmri):
+                pfmri = fmri.PkgFmri(pfmri, client_release)
+        except fmri.FmriError as e:
+            raise RepositoryInvalidFMRIError(e)
 
-                if not self.root:
-                        return
+        if pub and not pfmri.publisher:
+            pfmri.publisher = pub
 
-                if self.writable_root:
-                        root = self.writable_root
+        try:
+            rstore = self.get_pub_rstore(pfmri.publisher)
+        except RepositoryUnknownPublisher as e:
+            if not pfmri.publisher:
+                # No publisher given in FMRI and no default
+                # publisher so treat as invalid FMRI.
+                raise RepositoryUnqualifiedFMRIError(pfmri)
+            # A publisher was provided, but no repository storage
+            # object exists yet, so add one.
+            rstore = self.__new_rstore(pfmri.publisher)
+        return rstore.open(client_release, pfmri)
+
+    def get_matching_fmris(self, patterns, pubs=misc.EmptyI):
+        """Given a user-specified list of FMRI pattern strings, return
+        a tuple of ('matching', 'references'), where matching is a dict
+        of matching fmris and references is a dict of the patterns
+        indexed by matching FMRI respectively:
+
+        {
+         pkgname: [fmri1, fmri2, ...],
+         pkgname: [fmri1, fmri2, ...],
+         ...
+        }
+
+        {
+         fmri1: [pat1, pat2, ...],
+         fmri2: [pat1, pat2, ...],
+         ...
+        }
+
+        'patterns' is the list of package patterns to match.
+
+        'pubs' is an optional set of publisher prefixes to restrict the
+        results to.
+
+        Constraint used is always AUTO as per expected UI behavior when
+        determining successor versions.
+
+        Note that patterns starting w/ pkg:/ require an exact match;
+        patterns containing '*' will using fnmatch rules; the default
+        trailing match rules are used for remaining patterns.
+
+        Exactly duplicated patterns are ignored.
+
+        Routine raises PackageMatchErrors if errors occur: it is illegal
+        to specify multiple different patterns that match the same
+        package name.  Only patterns that contain wildcards are allowed
+        to match multiple packages.
+        """
+
+        def merge(src, dest):
+            for k, v in six.iteritems(src):
+                if k in dest:
+                    dest[k].extend(v)
                 else:
-                        root = self.root
+                    dest[k] = v
 
-                tempdir = os.path.normpath(os.path.join(root, "tmp"))
+        matching = {}
+        references = {}
+        unmatched = None
+        for rstore in self.rstores:
+            if not rstore.catalog_root or not rstore.publisher:
+                # No catalog to aggregate matches from.
+                continue
+            if pubs and rstore.publisher not in pubs:
+                # Doesn't match specified publisher.
+                continue
 
-                try:
-                        misc.makedirs(tempdir)
-                        return tempfile.mkdtemp(prefix="rm." + pfx + ".",
-                            dir=tempdir)
+            # Get matching items from target catalog and then
+            # merge the result.
+            mdict, mrefs, munmatched = rstore.catalog.get_matching_fmris(
+                patterns
+            )
+            merge(mdict, matching)
+            merge(mrefs, references)
+            if unmatched is None:
+                unmatched = munmatched
+            else:
+                # The only unmatched entries that are
+                # interesting are the ones that have no
+                # matches for any publisher.
+                unmatched.intersection_update(munmatched)
 
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
+            del mdict, mrefs, munmatched
 
-        def add_package(self, pfmri):
-                """Adds the specified FMRI to the repository's catalog."""
+        if unmatched:
+            # One or more patterns didn't match a package from any
+            # publisher.
+            raise apx.PackageMatchErrors(unmatched_fmris=unmatched)
+        if not matching:
+            # No packages or no publishers matching 'pubs'.
+            raise apx.PackageMatchErrors(unmatched_fmris=patterns)
 
-                rstore = self.get_pub_rstore(pfmri.publisher)
-                return rstore.add_package(pfmri)
+        return matching, references
 
-        def append(self, client_release, pfmri, pub=None):
-                """Starts an append transaction for the specified client
-                release and FMRI.  Returns the Transaction ID for the new
-                transaction."""
+    @property
+    def publishers(self):
+        """A set containing the list of publishers known to the
+        repository."""
 
-                try:
-                        if not isinstance(pfmri, fmri.PkgFmri):
-                                pfmri = fmri.PkgFmri(pfmri, client_release)
-                except fmri.FmriError as e:
-                        raise RepositoryInvalidFMRIError(e)
+        pubs = set()
+        pub = self.cfg.get_property("publisher", "prefix")
+        if pub:
+            pubs.add(pub)
 
+        for rstore in self.rstores:
+            if rstore.publisher:
+                pubs.add(rstore.publisher)
+        return pubs
+
+    def refresh_index(self, pub=None):
+        """This function refreshes the search indexes if there any new
+        packages.
+        """
+
+        for rstore in self.rstores:
+            if not rstore.publisher:
+                continue
+            if pub and rstore.publisher and rstore.publisher != pub:
+                continue
+            rstore.refresh_index()
+
+    def remove_packages(self, packages, progtrack=None, pub=None):
+        """Removes the specified packages from the repository.
+
+        'packages' is a list of FMRIs of packages to remove.
+
+        'progtrack' is an optional ProgressTracker object.
+
+        'pub' is an optional publisher prefix to limit the operation to.
+        """
+
+        plist = set()
+        pubs = set()
+        for p in packages:
+            try:
+                pfmri = p
+                if not isinstance(pfmri, fmri.PkgFmri):
+                    pfmri = fmri.PkgFmri(pfmri)
                 if pub and not pfmri.publisher:
-                        pfmri.publisher = pub
+                    pfmri.publisher = pub
+                if pfmri.publisher:
+                    pubs.add(pfmri.publisher)
+                plist.add(pfmri)
+            except fmri.FmriError as e:
+                raise RepositoryInvalidFMRIError(e)
 
-                try:
-                        rstore = self.get_pub_rstore(pfmri.publisher)
-                except RepositoryUnknownPublisher as e:
-                        if not pfmri.publisher:
-                                # No publisher given in FMRI and no default
-                                # publisher so treat as invalid FMRI.
-                                raise RepositoryUnqualifiedFMRIError(pfmri)
-                        raise
-                return rstore.append(client_release, pfmri)
+        if len(pubs) > 1:
+            # Don't allow removal of packages from different
+            # publishers at the same time.  Current transaction
+            # model relies on a single publisher at a time and
+            # transport is mapped the same way.
+            raise RepositoryUnsupportedOperationError()
 
-        def catalog_0(self, pub=None):
-                """Returns a generator object for the full version of
-                the catalog contents.  Incremental updates are not provided
-                as the v0 updatelog does not support renames, obsoletion,
-                package removal, etc.
+        if not pub and pubs:
+            # Use publisher specified in one of the FMRIs instead
+            # of default publisher.
+            pub = list(pubs)[0]
 
-                'pub' is the prefix of the publisher to return catalog data for.
-                If not specified, the default publisher will be used.  If no
-                default publisher has been configured, an AssertionError will be
-                raised.
-                """
+        try:
+            rstore = self.get_pub_rstore(pub)
+        except RepositoryUnknownPublisher as e:
+            for p in plist:
+                if not pfmri.publisher:
+                    # No publisher given in FMRI and no
+                    # default publisher so treat as
+                    # invalid FMRI.
+                    raise RepositoryUnqualifiedFMRIError(pfmri)
+            raise
 
-                self.inc_catalog()
-                rstore = self.get_pub_rstore(pub)
-                return rstore.catalog_0()
+        # Before moving on, assign publisher for every FMRI that doesn't
+        # have one already.
+        for p in plist:
+            if not pfmri.publisher:
+                pfmri.publisher = rstore.publisher
 
-        def catalog_1(self, name, pub=None):
-                """Returns the absolute pathname of the named catalog file.
+        rstore.remove_packages(packages, progtrack=progtrack)
 
-                'pub' is the prefix of the publisher to return catalog data for.
-                If not specified, the default publisher will be used.  If no
-                default publisher has been configured, an AssertionError will be
-                raised.
-                """
+    def add_content(self, pub=None, refresh_index=False):
+        """Looks for packages added to the repository that are not in
+        the catalog, adds them, and then updates search data by default.
+        """
 
-                self.inc_catalog()
-                rstore = self.get_pub_rstore(pub)
-                return rstore.catalog_1(name)
+        for rstore in self.rstores:
+            if not rstore.publisher:
+                continue
+            if pub and rstore.publisher and rstore.publisher != pub:
+                continue
+            rstore.add_content(refresh_index=refresh_index)
 
-        def close(self, trans_id, add_to_catalog=True):
-                """Closes the transaction specified by 'trans_id'.
+    def add_file(self, trans_id, data, basename=None, size=None):
+        """Adds a file to a transaction with the specified Transaction
+        ID."""
 
-                Returns a tuple containing the package FMRI and the current
-                package state in the catalog.
-                """
+        rstore = self.get_trans_rstore(trans_id)
+        return rstore.add_file(
+            trans_id, data=data, basename=basename, size=size
+        )
 
-                self.inc_catalog()
-                rstore = self.get_trans_rstore(trans_id)
-                return rstore.close(trans_id, add_to_catalog=add_to_catalog)
+    def add_manifest(self, trans_id, data):
+        """Adds a manifest to a transaction with the specified
+        Transaction ID."""
 
-        def file(self, fhash, pub=None):
-                """Returns the absolute pathname of the file specified by the
-                provided SHA1-hash name.
+        rstore = self.get_trans_rstore(trans_id)
+        return rstore.add_manifest(trans_id, data=data)
 
-                'pub' is the prefix of the publisher to return catalog data for.
-                If not specified, the default publisher will be used.  If no
-                default publisher has been configured, an AssertionError will be
-                raised.
-                """
+    def rebuild(self, build_catalog=True, build_index=False, pub=None):
+        """Rebuilds the repository catalog and search indexes using the
+        package manifests currently in the repository.
 
-                self.inc_file()
-                if pub:
-                        rstore = self.get_pub_rstore(pub)
-                        return rstore.file(fhash)
+        'build_catalog' is an optional boolean value indicating whether
+        package catalogs should be rebuilt.  If True, existing search
+        data will be discarded.
 
-                # If a publisher wasn't specified, every repository store will
-                # have to be tried since default publisher can't safely apply
-                # here.
-                for rstore in self.rstores:
-                        try:
-                                return rstore.file(fhash)
-                        except RepositoryFileNotFoundError:
-                                # Ignore and try next repository store.
-                                pass
+        'build_index' is an optional boolean value indicating whether
+        search indexes should be built.
+        """
 
-                # Not found in any repository store.
-                raise RepositoryFileNotFoundError(fhash)
+        for rstore in self.rstores:
+            if not rstore.publisher:
+                continue
+            if pub and rstore.publisher and rstore.publisher != pub:
+                continue
+            rstore.rebuild(build_catalog=build_catalog, build_index=build_index)
 
-        def get_catalog(self, pub=None):
-                """Return the catalog object for the given publisher.
+    def reload(self):
+        """Reloads the repository state information."""
 
-                'pub' is the optional name of the publisher to return the
-                catalog for.  If not provided, the default publisher's
-                catalog will be returned.
-                """
+        self.__lock_repository()
+        self.__init_state()
+        self.__unlock_repository()
 
-                try:
-                        rstore = self.get_pub_rstore(pub)
-                        return rstore.catalog
-                except RepositoryUnknownPublisher:
-                        if pub:
-                                # In this case, an unknown publisher's
-                                # catalog was requested.
-                                raise
-                        # No catalog to return.
-                        raise RepositoryUnsupportedOperationError()
+    def replace_package(self, pfmri):
+        """Replaces the information for the specified FMRI in the
+        repository's catalog."""
 
-        def get_pub_rstore(self, pub=None):
-                """Return a repository storage object matching the given
-                publisher (if provided).  If not provided, a repository
-                storage object for the default publisher will be returned.
-                A RepositoryUnknownPublisher exception will be raised if
-                no storage object for the given publisher exists.
-                """
+        rstore = self.get_pub_rstore(pfmri.publisher)
+        return rstore.replace_package(pfmri)
 
-                if pub is None:
-                        pub = self.cfg.get_property("publisher", "prefix")
-                if not pub:
-                        raise RepositoryUnknownPublisher(pub)
+    def reset_search(self, pub=None):
+        """Discards currenty loaded search data so that it will be
+        reloaded for the next search operation.
+        """
+        for rstore in self.rstores:
+            if pub and rstore.publisher and rstore.publisher != pub:
+                continue
+            rstore.reset_search()
 
-                try:
-                        rstore = self.__rstores[pub]
-                except KeyError:
-                        raise RepositoryUnknownPublisher(pub)
-                return rstore
+    def search(self, queries, pub=None):
+        """Searches the index for each query in the list of queries.
+        Each entry should be the output of str(Query), or a Query
+        object.
+        """
 
-        def __get_cfg_publisher(self, pub):
-                """Return a publisher object for the given publisher prefix
-                based on the repository's configuration information.
-                """
-                assert self.version < 4
+        rstore = self.get_pub_rstore(pub)
+        return rstore.search(queries)
 
-                alias = self.cfg.get_property("publisher", "alias")
+    def supports(self, op, ver):
+        """Returns a boolean value indicating whether the specified
+        operation is supported at the given version.
+        """
 
-                rargs = {}
-                for prop in ("collection_type", "description",
-                    "legal_uris", "mirrors", "name", "origins",
-                    "refresh_seconds", "registration_uri",
-                    "related_uris"):
-                        rargs[prop] = self.cfg.get_property(
-                            "repository", prop)
+        if op == "search" and self.root:
+            return True
+        if op == "catalog" and ver == 1:
+            # For catalog v1 to be "supported", all storage objects
+            # must use it.
+            for rstore in self.rstores:
+                if rstore.catalog_version == 0:
+                    return False
+            return True
+        # Assume operation is supported otherwise.
+        return True
 
-                repo = publisher.Repository(**rargs)
-                return publisher.Publisher(pub, alias=alias,
-                    repository=repo)
+    def update_publisher(self, pub):
+        """Updates the configuration information for the publisher
+        defined by the provided Publisher object.  Only supported
+        for version 4 and later repositories.
+        """
 
-        def get_publishers(self):
-                """Return publisher objects for all publishers known by the
-                repository.
-                """
-                return [
-                    self.get_publisher(pub)
-                    for pub in self.publishers
-                ]
+        if self.mirror:
+            raise RepositoryMirrorError()
+        if self.read_only:
+            raise RepositoryReadOnlyError()
+        if not self.pub_root or self.version < 4:
+            raise RepositoryUnsupportedOperationError()
 
-        def get_publisher(self, pub):
-                """Return the publisher object for the given publisher.  Raises
-                RepositoryUnknownPublisher if no matching publisher can be
-                found.
-                """
+        # Get the repository storage area for the given publisher.
+        rstore = self.get_pub_rstore(pub.prefix)
 
-                if not pub:
-                        raise RepositoryUnknownPublisher(pub)
-                if self.version < 4:
-                        return self.__get_cfg_publisher(pub)
+        # Update the publisher's configuration.
+        rstore.update_publisher(pub)
 
-                rstore = self.get_pub_rstore(pub)
-                if not rstore:
-                        raise RepositoryUnknownPublisher(pub)
-                return rstore.get_publisher()
+    def verify(
+        self,
+        pubs=[],
+        allowed_checks=[],
+        force_dep_check=False,
+        ignored_dep_files=[],
+        progtrack=None,
+    ):
+        """A generator that verifies that repository content matches
+        expected state for all or specified publishers.
 
-        def get_status(self):
-                """Return a dictionary of status information about the
-                repository.
-                """
+        'progtrack' is an optional ProgressTracker object.
 
-                if self.locked:
-                        rstatus = "processing"
-                else:
-                        rstatus = "online"
+        'pubs' is an optional publisher list to limit the
+        operation to.
 
-                rdata = {
-                    "repository": {
-                        "configuration": self.cfg.get_index(),
-                        "publishers": {},
-                        "requests": {
-                            "catalog": self.catalog_requests,
-                            "file": self.file_requests,
-                            "manifests": self.manifest_requests,
-                        },
-                        "status": rstatus, # Overall repository state.
-                        "version": self.version, # Version of repository.
-                    },
-                    "version": 1, # Version of status structure.
-                }
+        'disable_checks' is a list of verfications which should be
+        disabled.
 
-                for rstore in self.rstores:
-                        if not rstore.publisher:
+        'force_dep_check' is a boolean variable to indicate whether we
+        should run complete dependency check.
+
+        'ignored_dep_files' is a list of files which contain
+        ignored dependencies.
+
+        The generator yields tuples of the form:
+
+        (error_code, path, message, details) where
+
+        'error_code'  an integer error, correponding to REPO_VERIFY_*
+        'path'        the path to the broken file in the repository
+        'message'     a summary of the error
+        'details'     a dictionary of strings containing more detail
+                      about the nature of the error.
+        """
+
+        if self.cfg.get_property("repository", "version") != 4:
+            raise RepositoryInvalidVersionError(
+                self.root, self.cfg.get_property("repository", "version"), 4
+            )
+
+        trust_anchor_dir = self.cfg.get_property(
+            "repository", "trust-anchor-directory"
+        )
+        sig_required_names = set(
+            self.cfg.get_property("repository", "signature-required-names")
+        )
+        use_crls = self.cfg.get_property(
+            "repository", "check-certificate-revocation"
+        )
+
+        for pub in pubs:
+            rstore = self.get_pub_rstore(pub.prefix)
+            for verify_tuple in rstore.verify(
+                progtrack=progtrack,
+                pub=pub,
+                trust_anchor_dir=trust_anchor_dir,
+                sig_required_names=sig_required_names,
+                use_crls=use_crls,
+            ):
+                yield verify_tuple
+
+        if VERIFY_DEPENDENCY in allowed_checks:
+            for verify_tuple in self.__verify_depend(
+                [pub.prefix for pub in pubs],
+                force_dep_check,
+                progtrack,
+                ignored_dep_files=ignored_dep_files,
+            ):
+                yield verify_tuple
+
+    def __build_error_tuple(self, fmri, depend, depType, message):
+        """Build a dependency verification error tuple."""
+
+        reason = {"pkg": fmri, "depend": depend, "type": depType}
+        return (REPO_VERIFY_DEPENDERROR, None, message, reason)
+
+    def __find_verify_match(
+        self, afmri, fmris, dep_type, all_pkgs, force_dep_check, ignored_pkgs
+    ):
+        """Generator function to find the matching package given the
+        dependency fmri."""
+
+        # Get the containing package stem for looking up the ignored
+        # deps.
+        astem = afmri.get_pkg_stem(anarchy=True, include_scheme=False)
+        for f in fmris:
+            try:
+                pfmri = fmri.PkgFmri(f)
+            except fmri.IllegalFmri:
+                yield self.__build_error_tuple(
+                    afmri.get_fmri(), f, dep_type, _("Illegal dependency FMRI.")
+                )
+                continue
+
+            pstem = pfmri.get_pkg_stem(anarchy=True, include_scheme=False)
+            # Feature is reserved dependency term. We should ignore
+            # dependency starts with feature.
+            if pstem.startswith("feature/"):
+                continue
+
+            found = False
+            if pstem in all_pkgs:
+                # If the dependency package does not have
+                # publisher and version, then find matched stem
+                # means dependency is found.
+                if not pfmri.publisher and not pfmri.version:
+                    found = True
+                    continue
+
+                rfmris = all_pkgs[pstem]
+                for rf in rfmris:
+                    if pfmri.publisher and rf.publisher != pfmri.publisher:
+                        continue
+                    if pfmri.version:
+                        # For incorporate dependencies,
+                        # we need to do more work to
+                        # see if the dependency is
+                        # satisfied.
+                        if dep_type == "incorporate":
+                            if not rf.version.is_successor(
+                                pfmri.version, pkg.version.CONSTRAINT_AUTO
+                            ):
                                 continue
-                        pubdata = rdata["repository"]["publishers"]
-                        pubdata[rstore.publisher] = rstore.get_status()
-                return rdata
+                        else:
+                            # If the current
+                            # version is less than
+                            # the dependency's,
+                            # skip.
+                            if (
+                                not rf.version.is_successor(
+                                    pfmri.version, pkg.version.CONSTRAINT_NONE
+                                )
+                                and rf.version != pfmri.version
+                            ):
+                                continue
 
-        def get_trans_rstore(self, trans_id):
-                """Return a repository storage object matching the given
-                Transaction ID.  If no repository storage object has a
-                matching Transaction ID, a RepositoryInvalidTransactionIDError
-                will be raised.
-                """
+                    # Dependency match found.
+                    found = True
+                    break
+            # We can ignore missing optional dependencies if not in
+            # force_dep_check mode.
+            elif not force_dep_check and dep_type == "optional":
+                found = True
 
-                for rstore in self.rstores:
-                        if rstore.has_transaction(trans_id):
-                                return rstore
-                raise RepositoryInvalidTransactionIDError(trans_id)
+            if not found:
+                if force_dep_check or astem not in ignored_pkgs:
+                    yield self.__build_error_tuple(
+                        afmri.get_fmri(), f, dep_type, _("Missing dependency.")
+                    )
+                    continue
+            else:
+                continue
 
-        @property
-        def in_flight_transactions(self):
-                """The number of transactions awaiting completion."""
+            # To make sure the not found dependency is actually
+            # ignored, we need to check the ignored deps.
+            for attrs in ignored_pkgs[astem]:
+                pub = fmri.PkgFmri(attrs["pkg"]).publisher
+                if pub != None and pub != afmri.publisher:
+                    continue
+                # Check the lower bound.
+                minfmri = attrs.get("min_ver", None)
+                if minfmri and not (
+                    afmri.version.is_successor(
+                        minfmri.version, pkg.version.CONSTRAINT_NONE
+                    )
+                    or afmri.version.is_successor(
+                        minfmri.version, pkg.version.CONSTRAINT_AUTO
+                    )
+                ):
+                    continue
+                # Check the upper bound.
+                maxfmri = attrs.get("max_ver", None)
+                if maxfmri and not (
+                    maxfmri.version.is_successor(
+                        afmri.version, pkg.version.CONSTRAINT_NONE
+                    )
+                    or afmri.version.is_successor(
+                        maxfmri.version, pkg.version.CONSTRAINT_AUTO
+                    )
+                ):
+                    continue
+                # If verifying dep is not in this entry, then
+                # continue to next.
+                if pstem not in attrs["depend"]:
+                    continue
+                for ifmri in attrs["depend"][pstem]:
+                    # Do not ignore if publishers do not
+                    # match.
+                    if (
+                        pfmri.publisher
+                        and ifmri.publisher
+                        and pfmri.publisher != ifmri.publisher
+                    ):
+                        continue
+                    # If there is no version specified
+                    # for ifmri, ignore all packages
+                    # indicated by ifmri stem. So we
+                    # set found.
+                    if not ifmri.version:
+                        found = True
+                        break
+                    # If there is no version for pfmri but
+                    # there is one for ifmri, we will not
+                    # try to ignore it.
+                    if not pfmri.version:
+                        continue
+                    # If versions match, # we report found.
+                    elif pfmri.version.is_successor(
+                        ifmri.version, pkg.version.CONSTRAINT_AUTO
+                    ):
+                        found = True
+                        break
+                if found:
+                    break
 
-                return sum(
-                    rstore.in_flight_transactions
-                    for rstore in self.rstores
+            # Dependency not matched; report an error.
+            if not found:
+                yield self.__build_error_tuple(
+                    afmri.get_fmri(), f, dep_type, _("Missing dependency.")
                 )
 
-        def inc_catalog(self):
-                self.__catalog_requests += 1
+    def __gen_verify_dependency_actions(self, pubs):
+        """Generator function which provides depend and set actions
+        stored in catalog.dependency.C for verification for a list of
+        given publishers."""
 
-        def inc_file(self):
-                self.__file_requests += 1
+        for pub in pubs:
+            for r, e, acts in pub.catalog.entry_actions(
+                (pub.catalog.DEPENDENCY,)
+            ):
+                apkg = "pkg://{0}/{1}@{2}".format(*r)
+                yield apkg, acts
 
-        def inc_manifest(self):
-                self.__manifest_requests += 1
+    def __get_dep_actions_checklist(self, force_dep_check, acts):
+        """Get a list of dependency actions which need to be
+        checked."""
 
-        @property
-        def locked(self):
-                """A boolean value indicating whether the repository is locked.
-                """
+        check_deps = []
+        for act in acts:
+            if act.name != "depend":
+                continue
+            tmpfmris = act.attrlist("fmri")
+            dep_type = act.attrs.get("type")
 
-                return self.__lock and self.__lock.locked
+            ignore_check = None
+            if not force_dep_check:
+                ic = act.attrs.get("ignore-check")
+                if ic:
+                    ignore_check = ic.lower()
+            if not ignore_check and tmpfmris and dep_type:
+                if dep_type != "exclude" and dep_type != "parent":
+                    check_deps.append((tmpfmris, dep_type))
 
-        def manifest(self, pfmri, pub=None):
-                """Returns the absolute pathname of the manifest file for the
-                specified FMRI.
-                """
+        return check_deps
 
-                self.inc_manifest()
+    def __read_ignored_dep_file(self, filename):
+        """Read ignored dependency file."""
 
+        try:
+            with open(filename) as igfd:
+                lines = igfd.readlines()
+            return lines
+        except EnvironmentError as e:
+            if e.errno == errno.ENOENT:
+                raise RepositoryNoSuchFileError(e.filename)
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            raise
+
+    def __load_ignored_packages(self, ignored_dep_files=None):
+        """Load ignored dependency packages."""
+
+        allowed_attrs = set(["pkg", "min_ver", "max_ver", "depend"])
+        mandatory_attrs = set(["pkg", "depend"])
+
+        ignored_pkgs_dict = {}
+        if not ignored_dep_files:
+            return ignored_pkgs_dict
+
+        for igf in ignored_dep_files:
+            lines = self.__read_ignored_dep_file(igf)
+            for le in lines:
+                entry = le.strip()
+                # If line is empty or comments, do not process.
+                if not entry or entry.startswith("#"):
+                    continue
+                dumentry = "set name='bogus' value=0 " + entry
                 try:
-                        if not isinstance(pfmri, fmri.PkgFmri):
-                                pfmri = fmri.PkgFmri(pfmri)
-                except fmri.FmriError as e:
-                        raise RepositoryInvalidFMRIError(e)
-
-                if not pub and pfmri.publisher:
-                        pub = pfmri.publisher
-                elif pub and not pfmri.publisher:
-                        pfmri.publisher = pub
-
-                if pub:
-                        try:
-                                rstore = self.get_pub_rstore(pub)
-                        except RepositoryUnknownPublisher as e:
-                                raise RepositoryManifestNotFoundError(pfmri)
-                        return rstore.manifest(pfmri)
-
-                # If a publisher wasn't specified, every repository store will
-                # have to be tried since default publisher can't safely apply
-                # here.  It's assumed that it's unlikely that two publishers
-                # share the exact same FMRI.  Since this case is only for
-                # compatibility, it shouldn't be much of a concern.
-                mpath = None
-                for rstore in self.rstores:
-                        if not rstore.publisher:
-                                continue
-                        mpath = rstore.manifest(pfmri)
-                        if not mpath or not os.path.exists(mpath):
-                                continue
-                        return mpath
-                raise RepositoryManifestNotFoundError(pfmri)
-
-        def open(self, client_release, pfmri, pub=None):
-                """Starts a transaction for the specified client release and
-                FMRI.  Returns the Transaction ID for the new transaction.
-                """
-
+                    act = actions._actions.fromstr(dumentry)
+                except actions.ActionError as e:
+                    raise RepositoryInvalidIgnoreDepEntryError(igf, entry)
+                attrs = act.attrs
+                attrs.pop("name")
+                attrs.pop("value")
+                attrks = set(attrs.keys())
+                unknowns = None
+                if not attrks.issubset(allowed_attrs):
+                    unknowns = attrks - allowed_attrs
+                if unknowns:
+                    raise RepositoryIgnoreDepEntryAttrError(
+                        "unknown", entry=entry, attrs=unknowns
+                    )
+                if not mandatory_attrs.issubset(attrks):
+                    missings = mandatory_attrs - attrks
+                    raise RepositoryIgnoreDepEntryAttrError(
+                        "missing", entry=entry, attrs=missings
+                    )
                 try:
-                        if not isinstance(pfmri, fmri.PkgFmri):
-                                pfmri = fmri.PkgFmri(pfmri, client_release)
-                except fmri.FmriError as e:
-                        raise RepositoryInvalidFMRIError(e)
+                    istem = fmri.PkgFmri(attrs["pkg"]).get_pkg_stem(
+                        anarchy=True, include_scheme=False
+                    )
 
-                if pub and not pfmri.publisher:
-                        pfmri.publisher = pub
+                    if attrs.get("min_ver", None):
+                        minfmri = fmri.PkgFmri(
+                            "{0}@{1}".format(attrs["pkg"], attrs["min_ver"])
+                        )
+                        attrs["min_ver"] = minfmri
+                    if attrs.get("max_ver", None):
+                        maxfmri = fmri.PkgFmri(
+                            "{0}@{1}".format(attrs["pkg"], attrs["max_ver"])
+                        )
+                        attrs["max_ver"] = maxfmri
 
-                try:
-                        rstore = self.get_pub_rstore(pfmri.publisher)
-                except RepositoryUnknownPublisher as e:
-                        if not pfmri.publisher:
-                                # No publisher given in FMRI and no default
-                                # publisher so treat as invalid FMRI.
-                                raise RepositoryUnqualifiedFMRIError(pfmri)
-                        # A publisher was provided, but no repository storage
-                        # object exists yet, so add one.
-                        rstore = self.__new_rstore(pfmri.publisher)
-                return rstore.open(client_release, pfmri)
-
-        def get_matching_fmris(self, patterns, pubs=misc.EmptyI):
-                """Given a user-specified list of FMRI pattern strings, return
-                a tuple of ('matching', 'references'), where matching is a dict
-                of matching fmris and references is a dict of the patterns
-                indexed by matching FMRI respectively:
-
-                {
-                 pkgname: [fmri1, fmri2, ...],
-                 pkgname: [fmri1, fmri2, ...],
-                 ...
-                }
-
-                {
-                 fmri1: [pat1, pat2, ...],
-                 fmri2: [pat1, pat2, ...],
-                 ...
-                }
-
-                'patterns' is the list of package patterns to match.
-
-                'pubs' is an optional set of publisher prefixes to restrict the
-                results to.
-
-                Constraint used is always AUTO as per expected UI behavior when
-                determining successor versions.
-
-                Note that patterns starting w/ pkg:/ require an exact match;
-                patterns containing '*' will using fnmatch rules; the default
-                trailing match rules are used for remaining patterns.
-
-                Exactly duplicated patterns are ignored.
-
-                Routine raises PackageMatchErrors if errors occur: it is illegal
-                to specify multiple different patterns that match the same
-                package name.  Only patterns that contain wildcards are allowed
-                to match multiple packages.
-                """
-
-                def merge(src, dest):
-                        for k, v in six.iteritems(src):
-                                if k in dest:
-                                        dest[k].extend(v)
-                                else:
-                                        dest[k] = v
-
-                matching = {}
-                references = {}
-                unmatched = None
-                for rstore in self.rstores:
-                        if not rstore.catalog_root or not rstore.publisher:
-                                # No catalog to aggregate matches from.
-                                continue
-                        if pubs and rstore.publisher not in pubs:
-                                # Doesn't match specified publisher.
-                                continue
-
-                        # Get matching items from target catalog and then
-                        # merge the result.
-                        mdict, mrefs, munmatched = \
-                            rstore.catalog.get_matching_fmris(patterns)
-                        merge(mdict, matching)
-                        merge(mrefs, references)
-                        if unmatched is None:
-                                unmatched = munmatched
+                    depdict = {}
+                    deplist = []
+                    if not isinstance(attrs["depend"], list):
+                        deplist.append(attrs["depend"])
+                    else:
+                        deplist = attrs["depend"]
+                    for dep in deplist:
+                        dfmri = fmri.PkgFmri(dep)
+                        dstem = dfmri.get_pkg_stem(
+                            anarchy=True, include_scheme=False
+                        )
+                        if dstem not in depdict:
+                            depdict[dstem] = [dfmri]
                         else:
-                                # The only unmatched entries that are
-                                # interesting are the ones that have no
-                                # matches for any publisher.
-                                unmatched.intersection_update(munmatched)
-
-                        del mdict, mrefs, munmatched
-
-                if unmatched:
-                        # One or more patterns didn't match a package from any
-                        # publisher.
-                        raise apx.PackageMatchErrors(unmatched_fmris=unmatched)
-                if not matching:
-                        # No packages or no publishers matching 'pubs'.
-                        raise apx.PackageMatchErrors(unmatched_fmris=patterns)
-
-                return matching, references
-
-        @property
-        def publishers(self):
-                """A set containing the list of publishers known to the
-                repository."""
-
-                pubs = set()
-                pub = self.cfg.get_property("publisher", "prefix")
-                if pub:
-                        pubs.add(pub)
-
-                for rstore in self.rstores:
-                        if rstore.publisher:
-                                pubs.add(rstore.publisher)
-                return pubs
-
-        def refresh_index(self, pub=None):
-                """ This function refreshes the search indexes if there any new
-                packages.
-                """
-
-                for rstore in self.rstores:
-                        if not rstore.publisher:
-                                continue
-                        if pub and rstore.publisher and rstore.publisher != pub:
-                                continue
-                        rstore.refresh_index()
-
-        def remove_packages(self, packages, progtrack=None, pub=None):
-                """Removes the specified packages from the repository.
-
-                'packages' is a list of FMRIs of packages to remove.
-
-                'progtrack' is an optional ProgressTracker object.
-
-                'pub' is an optional publisher prefix to limit the operation to.
-                """
-
-                plist = set()
-                pubs = set()
-                for p in packages:
-                        try:
-                                pfmri = p
-                                if not isinstance(pfmri, fmri.PkgFmri):
-                                        pfmri = fmri.PkgFmri(pfmri)
-                                if pub and not pfmri.publisher:
-                                        pfmri.publisher = pub
-                                if pfmri.publisher:
-                                        pubs.add(pfmri.publisher)
-                                plist.add(pfmri)
-                        except fmri.FmriError as e:
-                                raise RepositoryInvalidFMRIError(e)
-
-                if len(pubs) > 1:
-                        # Don't allow removal of packages from different
-                        # publishers at the same time.  Current transaction
-                        # model relies on a single publisher at a time and
-                        # transport is mapped the same way.
-                        raise RepositoryUnsupportedOperationError()
-
-                if not pub and pubs:
-                        # Use publisher specified in one of the FMRIs instead
-                        # of default publisher.
-                        pub = list(pubs)[0]
-
-                try:
-                        rstore = self.get_pub_rstore(pub)
-                except RepositoryUnknownPublisher as e:
-                        for p in plist:
-                                if not pfmri.publisher:
-                                        # No publisher given in FMRI and no
-                                        # default publisher so treat as
-                                        # invalid FMRI.
-                                        raise RepositoryUnqualifiedFMRIError(
-                                            pfmri)
-                        raise
-
-                # Before moving on, assign publisher for every FMRI that doesn't
-                # have one already.
-                for p in plist:
-                        if not pfmri.publisher:
-                                pfmri.publisher = rstore.publisher
-
-                rstore.remove_packages(packages, progtrack=progtrack)
-
-        def add_content(self, pub=None, refresh_index=False):
-                """Looks for packages added to the repository that are not in
-                the catalog, adds them, and then updates search data by default.
-                """
-
-                for rstore in self.rstores:
-                        if not rstore.publisher:
-                                continue
-                        if pub and rstore.publisher and rstore.publisher != pub:
-                                continue
-                        rstore.add_content(refresh_index=refresh_index)
-
-        def add_file(self, trans_id, data, basename=None, size=None):
-                """Adds a file to a transaction with the specified Transaction
-                ID."""
-
-                rstore = self.get_trans_rstore(trans_id)
-                return rstore.add_file(trans_id, data=data, basename=basename,
-                    size=size)
-
-        def add_manifest(self, trans_id, data):
-                """Adds a manifest to a transaction with the specified
-                Transaction ID."""
-
-                rstore = self.get_trans_rstore(trans_id)
-                return rstore.add_manifest(trans_id, data=data)
-
-        def rebuild(self, build_catalog=True, build_index=False, pub=None):
-                """Rebuilds the repository catalog and search indexes using the
-                package manifests currently in the repository.
-
-                'build_catalog' is an optional boolean value indicating whether
-                package catalogs should be rebuilt.  If True, existing search
-                data will be discarded.
-
-                'build_index' is an optional boolean value indicating whether
-                search indexes should be built.
-                """
-
-                for rstore in self.rstores:
-                        if not rstore.publisher:
-                                continue
-                        if pub and rstore.publisher and rstore.publisher != pub:
-                                continue
-                        rstore.rebuild(build_catalog=build_catalog,
-                            build_index=build_index)
-
-        def reload(self):
-                """Reloads the repository state information."""
-
-                self.__lock_repository()
-                self.__init_state()
-                self.__unlock_repository()
-
-        def replace_package(self, pfmri):
-                """Replaces the information for the specified FMRI in the
-                repository's catalog."""
-
-                rstore = self.get_pub_rstore(pfmri.publisher)
-                return rstore.replace_package(pfmri)
-
-        def reset_search(self, pub=None):
-                """Discards currenty loaded search data so that it will be
-                reloaded for the next search operation.
-                """
-                for rstore in self.rstores:
-                        if pub and rstore.publisher and rstore.publisher != pub:
-                                continue
-                        rstore.reset_search()
-
-        def search(self, queries, pub=None):
-                """Searches the index for each query in the list of queries.
-                Each entry should be the output of str(Query), or a Query
-                object.
-                """
-
-                rstore = self.get_pub_rstore(pub)
-                return rstore.search(queries)
-
-        def supports(self, op, ver):
-                """Returns a boolean value indicating whether the specified
-                operation is supported at the given version.
-                """
-
-                if op == "search" and self.root:
-                        return True
-                if op == "catalog" and ver == 1:
-                        # For catalog v1 to be "supported", all storage objects
-                        # must use it.
-                        for rstore in self.rstores:
-                                if rstore.catalog_version == 0:
-                                        return False
-                        return True
-                # Assume operation is supported otherwise.
-                return True
-
-        def update_publisher(self, pub):
-                """Updates the configuration information for the publisher
-                defined by the provided Publisher object.  Only supported
-                for version 4 and later repositories.
-                """
-
-                if self.mirror:
-                        raise RepositoryMirrorError()
-                if self.read_only:
-                        raise RepositoryReadOnlyError()
-                if not self.pub_root or self.version < 4:
-                        raise RepositoryUnsupportedOperationError()
-
-                # Get the repository storage area for the given publisher.
-                rstore = self.get_pub_rstore(pub.prefix)
-
-                # Update the publisher's configuration.
-                rstore.update_publisher(pub)
-
-        def verify(self, pubs=[], allowed_checks=[],
-            force_dep_check=False, ignored_dep_files=[], progtrack=None):
-                """A generator that verifies that repository content matches
-                expected state for all or specified publishers.
-
-                'progtrack' is an optional ProgressTracker object.
-
-                'pubs' is an optional publisher list to limit the
-                operation to.
-
-                'disable_checks' is a list of verfications which should be
-                disabled.
-
-                'force_dep_check' is a boolean variable to indicate whether we
-                should run complete dependency check.
-
-                'ignored_dep_files' is a list of files which contain
-                ignored dependencies.
-
-                The generator yields tuples of the form:
-
-                (error_code, path, message, details) where
-
-                'error_code'  an integer error, correponding to REPO_VERIFY_*
-                'path'        the path to the broken file in the repository
-                'message'     a summary of the error
-                'details'     a dictionary of strings containing more detail
-                              about the nature of the error.
-                """
-
-                if self.cfg.get_property("repository", "version") != 4:
-                        raise RepositoryInvalidVersionError(self.root,
-                            self.cfg.get_property("repository", "version"), 4)
-
-                trust_anchor_dir = self.cfg.get_property("repository",
-                    "trust-anchor-directory")
-                sig_required_names = set(self.cfg.get_property("repository",
-                    "signature-required-names"))
-                use_crls = self.cfg.get_property("repository",
-                    "check-certificate-revocation")
-
-                for pub in pubs:
-                        rstore = self.get_pub_rstore(pub.prefix)
-                        for verify_tuple in rstore.verify(progtrack=progtrack,
-                            pub=pub, trust_anchor_dir=trust_anchor_dir,
-                            sig_required_names=sig_required_names,
-                            use_crls=use_crls):
-                                yield verify_tuple
-
-                if VERIFY_DEPENDENCY in allowed_checks:
-                        for verify_tuple in self.__verify_depend(
-                            [pub.prefix for pub in pubs],
-                            force_dep_check, progtrack,
-                            ignored_dep_files=ignored_dep_files):
-                                yield verify_tuple
-
-        def __build_error_tuple(self, fmri, depend, depType, message):
-                """Build a dependency verification error tuple."""
-
-                reason = {"pkg": fmri, "depend":depend, "type":depType}
-                return (REPO_VERIFY_DEPENDERROR, None, message, reason)
-
-        def __find_verify_match(self, afmri, fmris, dep_type, all_pkgs,
-            force_dep_check, ignored_pkgs):
-                """Generator function to find the matching package given the
-                dependency fmri."""
-
-                # Get the containing package stem for looking up the ignored
-                # deps.
-                astem = afmri.get_pkg_stem(anarchy=True,
-                    include_scheme=False)
-                for f in fmris:
-                        try:
-                                pfmri = fmri.PkgFmri(f)
-                        except fmri.IllegalFmri:
-                                yield self.__build_error_tuple(
-                                    afmri.get_fmri(), f, dep_type,
-                                    _("Illegal dependency FMRI."))
-                                continue
-
-                        pstem = pfmri.get_pkg_stem(anarchy=True,
-                            include_scheme=False)
-                        # Feature is reserved dependency term. We should ignore
-                        # dependency starts with feature.
-                        if pstem.startswith("feature/"):
-                                continue
-
-                        found = False
-                        if pstem in all_pkgs:
-                                # If the dependency package does not have
-                                # publisher and version, then find matched stem
-                                # means dependency is found.
-                                if not pfmri.publisher and \
-                                    not pfmri.version:
-                                        found = True
-                                        continue
-
-                                rfmris = all_pkgs[pstem]
-                                for rf in rfmris:
-                                        if pfmri.publisher and rf.publisher \
-                                            != pfmri.publisher:
-                                                continue
-                                        if pfmri.version:
-                                                # For incorporate dependencies,
-                                                # we need to do more work to
-                                                # see if the dependency is
-                                                # satisfied.
-                                                if dep_type == "incorporate":
-                                                        if not rf.version.is_successor(
-                                                            pfmri.version,
-                                                            pkg.version.CONSTRAINT_AUTO):
-                                                                continue
-                                                else:
-                                                        # If the current
-                                                        # version is less than
-                                                        # the dependency's,
-                                                        # skip.
-                                                        if not rf.version.is_successor(
-                                                            pfmri.version,
-                                                            pkg.version.CONSTRAINT_NONE) \
-                                                            and rf.version != pfmri.version:
-                                                                continue
-
-                                        # Dependency match found.
-                                        found = True
-                                        break
-                        # We can ignore missing optional dependencies if not in
-                        # force_dep_check mode.
-                        elif not force_dep_check and dep_type == "optional":
-                                found = True
-
-                        if not found:
-                                if force_dep_check or astem not in ignored_pkgs:
-                                        yield self.__build_error_tuple(
-                                            afmri.get_fmri(), f, dep_type,
-                                            _("Missing dependency."))
-                                        continue
-                        else:
-                                continue
-
-                        # To make sure the not found dependency is actually
-                        # ignored, we need to check the ignored deps.
-                        for attrs in ignored_pkgs[astem]:
-                                pub = fmri.PkgFmri(
-                                    attrs["pkg"]).publisher
-                                if pub != None and pub != afmri.publisher:
-                                        continue
-                                # Check the lower bound.
-                                minfmri = attrs.get(
-                                    "min_ver", None)
-                                if minfmri and not (
-                                    afmri.version.is_successor(
-                                    minfmri.version,
-                                    pkg.version.CONSTRAINT_NONE) \
-                                    or afmri.version.is_successor(
-                                    minfmri.version,
-                                    pkg.version.CONSTRAINT_AUTO)):
-                                        continue
-                                # Check the upper bound.
-                                maxfmri = attrs.get("max_ver", None)
-                                if maxfmri and not (
-                                    maxfmri.version.is_successor(
-                                    afmri.version,
-                                    pkg.version.CONSTRAINT_NONE) \
-                                    or afmri.version.is_successor(
-                                    maxfmri.version,
-                                    pkg.version.CONSTRAINT_AUTO)):
-                                        continue
-                                # If verifying dep is not in this entry, then
-                                # continue to next.
-                                if pstem not in attrs["depend"]:
-                                        continue
-                                for ifmri in attrs["depend"][pstem]:
-                                        # Do not ignore if publishers do not
-                                        # match.
-                                        if pfmri.publisher and \
-                                            ifmri.publisher and \
-                                            pfmri.publisher \
-                                            != ifmri.publisher:
-                                                continue
-                                        # If there is no version specified
-                                        # for ifmri, ignore all packages
-                                        # indicated by ifmri stem. So we
-                                        # set found.
-                                        if not ifmri.version:
-                                                found = True
-                                                break
-                                        # If there is no version for pfmri but
-                                        # there is one for ifmri, we will not
-                                        # try to ignore it.
-                                        if not pfmri.version:
-                                                continue
-                                        # If versions match, # we report found.
-                                        elif pfmri.version.is_successor(
-                                            ifmri.version,
-                                            pkg.version.CONSTRAINT_AUTO):
-                                                found = True
-                                                break
-                                if found:
-                                        break
-
-                        # Dependency not matched; report an error.
-                        if not found:
-                                yield self.__build_error_tuple(
-                                    afmri.get_fmri(), f, dep_type,
-                                    _("Missing dependency."))
-
-        def __gen_verify_dependency_actions(self, pubs):
-                """Generator function which provides depend and set actions
-                stored in catalog.dependency.C for verification for a list of
-                given publishers."""
-
-                for pub in pubs:
-                        for r, e, acts in pub.catalog.entry_actions(
-                            (pub.catalog.DEPENDENCY,)):
-                                apkg = "pkg://{0}/{1}@{2}".format(*r)
-                                yield apkg, acts
-
-        def __get_dep_actions_checklist(self, force_dep_check, acts):
-                """Get a list of dependency actions which need to be
-                checked."""
-
-                check_deps = []
-                for act in acts:
-                        if act.name != "depend":
-                                continue
-                        tmpfmris = act.attrlist("fmri")
-                        dep_type = act.attrs.get("type")
-
-                        ignore_check = None
-                        if not force_dep_check:
-                                ic = act.attrs.get("ignore-check")
-                                if ic:
-                                        ignore_check = ic.lower()
-                        if not ignore_check and tmpfmris and dep_type:
-                                if dep_type != "exclude" and dep_type != \
-                                    "parent":
-                                        check_deps.append((tmpfmris, dep_type))
-
-                return check_deps
-
-        def __read_ignored_dep_file(self, filename):
-                """Read ignored dependency file."""
-
-                try:
-                        with open(filename) as igfd:
-                                lines = igfd.readlines()
-                        return lines
-                except EnvironmentError as e:
-                        if e.errno == errno.ENOENT:
-                                raise RepositoryNoSuchFileError(e.filename)
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
-
-        def __load_ignored_packages(self, ignored_dep_files=None):
-                """Load ignored dependency packages."""
-
-                allowed_attrs = set(["pkg", "min_ver", "max_ver", "depend"])
-                mandatory_attrs = set(["pkg", "depend"])
-
-                ignored_pkgs_dict = {}
-                if not ignored_dep_files:
-                        return ignored_pkgs_dict
-
-                for igf in ignored_dep_files:
-                        lines = self.__read_ignored_dep_file(igf)
-                        for le in lines:
-                                entry = le.strip()
-                                # If line is empty or comments, do not process.
-                                if not entry or entry.startswith("#"):
-                                        continue
-                                dumentry = "set name='bogus' value=0 " + entry
-                                try:
-                                        act = actions._actions.fromstr(dumentry)
-                                except actions.ActionError as e:
-                                        raise RepositoryInvalidIgnoreDepEntryError(igf, entry)
-                                attrs = act.attrs
-                                attrs.pop("name")
-                                attrs.pop("value")
-                                attrks = set(attrs.keys())
-                                unknowns = None
-                                if not attrks.issubset(
-                                    allowed_attrs):
-                                        unknowns = attrks - allowed_attrs
-                                if unknowns:
-                                        raise RepositoryIgnoreDepEntryAttrError(
-                                            "unknown", entry=entry,
-                                            attrs=unknowns)
-                                if not mandatory_attrs.issubset(attrks):
-                                        missings = mandatory_attrs - attrks
-                                        raise RepositoryIgnoreDepEntryAttrError(
-                                            "missing", entry=entry,
-                                            attrs=missings)
-                                try:
-                                        istem = fmri.PkgFmri(
-                                            attrs["pkg"]).get_pkg_stem(
-                                            anarchy=True,
-                                            include_scheme=False)
-
-                                        if attrs.get("min_ver", None):
-                                                minfmri = fmri.PkgFmri(
-                                                    "{0}@{1}".format(
-                                                    attrs["pkg"],
-                                                    attrs["min_ver"]))
-                                                attrs["min_ver"] = minfmri
-                                        if attrs.get("max_ver", None):
-                                                maxfmri = fmri.PkgFmri(
-                                                    "{0}@{1}".format(
-                                                    attrs["pkg"],
-                                                    attrs["max_ver"])
-                                                    )
-                                                attrs["max_ver"] = maxfmri
-
-                                        depdict = {}
-                                        deplist = []
-                                        if not isinstance(
-                                            attrs["depend"], list):
-                                                deplist.append(attrs["depend"])
-                                        else:
-                                                deplist = attrs["depend"]
-                                        for dep in deplist:
-                                                dfmri = fmri.PkgFmri(dep)
-                                                dstem = dfmri.get_pkg_stem(
-                                                    anarchy=True,
-                                                    include_scheme=False)
-                                                if dstem not in depdict:
-                                                        depdict[dstem] \
-                                                            = [dfmri]
-                                                else:
-                                                        depdict[dstem].append(
-                                                            dfmri)
-                                        attrs["depend"] = depdict
-                                        # Use stem of the package
-                                        # for fast look-up.
-                                        if istem not in ignored_pkgs_dict:
-                                                ignored_pkgs_dict[istem] = \
-                                                    [attrs]
-                                        else:
-                                                ignored_pkgs_dict[istem].append(
-                                                    attrs)
-                                except fmri.FmriError as e:
-                                        raise RepositoryInvalidIgnoreDepFMRIError(igf, e.fmri)
-                return ignored_pkgs_dict
-
-        def __verify_depend(self, found, force_dep_check, tracker,
-            ignored_dep_files=None):
-                """Generator function to determine if the whole repository
-                or packages by given publishers form a complete dependency
-                graph."""
-
-                all_pkgs = {}
-                # Load ignored packages on dependency check.
-                ignored_pkgs = {}
-                # Only load ignored deps when not in force mode.
-                if not force_dep_check:
-                        ignored_pkgs = self.__load_ignored_packages(
-                            ignored_dep_files=ignored_dep_files)
-
-                # Collecting pkgs and fmris for all pubs.
-                allpubrs = [rs for rs in self.rstores if rs.catalog_root]
-                for rs in allpubrs:
-                        pkgs, fmris, unmatched = \
-                            rs.catalog.get_matching_fmris("*")
-                        for k, v in pkgs.items():
-                                if k in all_pkgs:
-                                        # Merge value list as a set.
-                                        all_pkgs[k] |= set(v)
-                                else:
-                                        all_pkgs[k] = set(v)
-
-                foundpubs = [self.get_pub_rstore(pub) for pub in found]
-
-                # Get total number of verification goals.
-                goals = 0
-                for apkg, acts in self.__gen_verify_dependency_actions(
-                    foundpubs):
-                        goals += 1
-
-                tracker.repo_verify_start(goals)
-                for apkg, acts in self.__gen_verify_dependency_actions(
-                    foundpubs):
-                        try:
-                                afmri = fmri.PkgFmri(apkg)
-                        except fmri.FmriError as e:
-                                raise RepositoryInvalidFMRIError(e)
-                        tracker.repo_verify_start_pkg(afmri)
-
-                        tmpacts = [act for act in acts]
-                        selected_deps = \
-                            self.__get_dep_actions_checklist(
-                            force_dep_check, tmpacts)
-                        for tmpfmris, dep_type in selected_deps:
-                                for verify_tuple in self.__find_verify_match(
-                                    afmri, tmpfmris, dep_type, all_pkgs,
-                                    force_dep_check, ignored_pkgs):
-                                        yield verify_tuple
-
-                        tracker.repo_verify_add_progress(afmri)
-                        tracker.repo_verify_end_pkg(afmri)
-
-                tracker.job_done(tracker.JOB_REPO_VERIFY_REPO)
-
-        def fix(self, pubs=[], force_dep_check=False,
-            ignored_dep_files=[], progtrack=None, verify_callback=None):
-                """A generator that corrects any problems in the repository.
-
-                'progtrack' is an optional ProgressTracker object.
-
-                'pubs' is an optional publisher list to limit the
-                operation to.
-
-                'disable_checks' is a list of verfications which should be
-                disabled.
-
-                'force_dep_check' is a boolean variable to indicate whether we
-                should run complete dependency check.
-
-                'ignored_dep_files' is a list of files which contain
-                ignored dependencies.
-
-                During the operation, we emit progress, printing the details
-                using 'verify_callback', a method which requires the following
-                arguments,  progtrack, error_code, message, reason, which
-                correspond exactly to the tuple generated by self.verify(..)
-
-                This method yields tuples of the form:
-
-                (status_code, message, details) where
-
-                'status_code'  an integerstatus code, corresponding to REPO_FIX*
-                'message'      a summary of the operation performed
-                'details'      a dictionary of strings describing the operation
-
-                """
-
-                if self.cfg.get_property("repository", "version") != 4:
-                        raise RepositoryInvalidVersionError(self.root,
-                            self.cfg.get_property("repository", "version"), 4)
-
-                trust_anchor_dir = self.cfg.get_property("repository",
-                    "trust-anchor-directory")
-                sig_required_names = set(self.cfg.get_property("repository",
-                    "signature-required-names"))
-                use_crls = self.cfg.get_property("repository",
-                    "check-certificate-revocation")
-
-                for pub in pubs:
-                        rstore = self.get_pub_rstore(pub.prefix)
-                        for verify_tuple in rstore.fix(progtrack=progtrack,
-                            pub=pub,
-                            verify_callback=verify_callback,
-                            trust_anchor_dir=trust_anchor_dir,
-                            sig_required_names=sig_required_names,
-                            use_crls=use_crls):
-                                yield verify_tuple
-
-                for verify_tuple in self.__verify_depend(
-                    [pub.prefix for pub in pubs], force_dep_check,
-                    progtrack, ignored_dep_files=ignored_dep_files):
-                        verify_callback(progtrack, verify_tuple)
-                        yield verify_tuple
-
-        def valid_new_fmri(self, pfmri):
-                """Check that the FMRI supplied as an argument would be valid
-                to add to the repository catalog.  This checks to make sure
-                that any past catalog operations (such as a rename or freeze)
-                would not prohibit the caller from adding this FMRI."""
-
-                rstore = self.get_pub_rstore(pfmri.publisher)
-                return rstore.valid_new_fmri(pfmri)
-
-        def write_config(self):
-                """Save the repository's current configuration data."""
-
-                self.__lock_repository()
-                try:
-                        self.__write_config()
-                finally:
-                        self.__unlock_repository()
-
-        catalog_requests = property(lambda self: self.__catalog_requests)
-        cfg = property(lambda self: self.__cfg)
-        file_requests = property(lambda self: self.__file_requests)
-        file_root = property(lambda self: self.__file_root)
-        manifest_requests = property(lambda self: self.__manifest_requests)
-        mirror = property(lambda self: self.__mirror, __set_mirror)
-        pub_root = property(lambda self: self.__pub_root)
-        read_only = property(lambda self: self.__read_only, __set_read_only)
-        root = property(lambda self: self.__root)
-        rstores = property(lambda self: self.__rstores.values())
-        writable_root = property(lambda self: self.__writable_root)
-        temp_root = property(lambda self: self.__tmp_root)
+                            depdict[dstem].append(dfmri)
+                    attrs["depend"] = depdict
+                    # Use stem of the package
+                    # for fast look-up.
+                    if istem not in ignored_pkgs_dict:
+                        ignored_pkgs_dict[istem] = [attrs]
+                    else:
+                        ignored_pkgs_dict[istem].append(attrs)
+                except fmri.FmriError as e:
+                    raise RepositoryInvalidIgnoreDepFMRIError(igf, e.fmri)
+        return ignored_pkgs_dict
+
+    def __verify_depend(
+        self, found, force_dep_check, tracker, ignored_dep_files=None
+    ):
+        """Generator function to determine if the whole repository
+        or packages by given publishers form a complete dependency
+        graph."""
+
+        all_pkgs = {}
+        # Load ignored packages on dependency check.
+        ignored_pkgs = {}
+        # Only load ignored deps when not in force mode.
+        if not force_dep_check:
+            ignored_pkgs = self.__load_ignored_packages(
+                ignored_dep_files=ignored_dep_files
+            )
+
+        # Collecting pkgs and fmris for all pubs.
+        allpubrs = [rs for rs in self.rstores if rs.catalog_root]
+        for rs in allpubrs:
+            pkgs, fmris, unmatched = rs.catalog.get_matching_fmris("*")
+            for k, v in pkgs.items():
+                if k in all_pkgs:
+                    # Merge value list as a set.
+                    all_pkgs[k] |= set(v)
+                else:
+                    all_pkgs[k] = set(v)
+
+        foundpubs = [self.get_pub_rstore(pub) for pub in found]
+
+        # Get total number of verification goals.
+        goals = 0
+        for apkg, acts in self.__gen_verify_dependency_actions(foundpubs):
+            goals += 1
+
+        tracker.repo_verify_start(goals)
+        for apkg, acts in self.__gen_verify_dependency_actions(foundpubs):
+            try:
+                afmri = fmri.PkgFmri(apkg)
+            except fmri.FmriError as e:
+                raise RepositoryInvalidFMRIError(e)
+            tracker.repo_verify_start_pkg(afmri)
+
+            tmpacts = [act for act in acts]
+            selected_deps = self.__get_dep_actions_checklist(
+                force_dep_check, tmpacts
+            )
+            for tmpfmris, dep_type in selected_deps:
+                for verify_tuple in self.__find_verify_match(
+                    afmri,
+                    tmpfmris,
+                    dep_type,
+                    all_pkgs,
+                    force_dep_check,
+                    ignored_pkgs,
+                ):
+                    yield verify_tuple
+
+            tracker.repo_verify_add_progress(afmri)
+            tracker.repo_verify_end_pkg(afmri)
+
+        tracker.job_done(tracker.JOB_REPO_VERIFY_REPO)
+
+    def fix(
+        self,
+        pubs=[],
+        force_dep_check=False,
+        ignored_dep_files=[],
+        progtrack=None,
+        verify_callback=None,
+    ):
+        """A generator that corrects any problems in the repository.
+
+        'progtrack' is an optional ProgressTracker object.
+
+        'pubs' is an optional publisher list to limit the
+        operation to.
+
+        'disable_checks' is a list of verfications which should be
+        disabled.
+
+        'force_dep_check' is a boolean variable to indicate whether we
+        should run complete dependency check.
+
+        'ignored_dep_files' is a list of files which contain
+        ignored dependencies.
+
+        During the operation, we emit progress, printing the details
+        using 'verify_callback', a method which requires the following
+        arguments,  progtrack, error_code, message, reason, which
+        correspond exactly to the tuple generated by self.verify(..)
+
+        This method yields tuples of the form:
+
+        (status_code, message, details) where
+
+        'status_code'  an integerstatus code, corresponding to REPO_FIX*
+        'message'      a summary of the operation performed
+        'details'      a dictionary of strings describing the operation
+
+        """
+
+        if self.cfg.get_property("repository", "version") != 4:
+            raise RepositoryInvalidVersionError(
+                self.root, self.cfg.get_property("repository", "version"), 4
+            )
+
+        trust_anchor_dir = self.cfg.get_property(
+            "repository", "trust-anchor-directory"
+        )
+        sig_required_names = set(
+            self.cfg.get_property("repository", "signature-required-names")
+        )
+        use_crls = self.cfg.get_property(
+            "repository", "check-certificate-revocation"
+        )
+
+        for pub in pubs:
+            rstore = self.get_pub_rstore(pub.prefix)
+            for verify_tuple in rstore.fix(
+                progtrack=progtrack,
+                pub=pub,
+                verify_callback=verify_callback,
+                trust_anchor_dir=trust_anchor_dir,
+                sig_required_names=sig_required_names,
+                use_crls=use_crls,
+            ):
+                yield verify_tuple
+
+        for verify_tuple in self.__verify_depend(
+            [pub.prefix for pub in pubs],
+            force_dep_check,
+            progtrack,
+            ignored_dep_files=ignored_dep_files,
+        ):
+            verify_callback(progtrack, verify_tuple)
+            yield verify_tuple
+
+    def valid_new_fmri(self, pfmri):
+        """Check that the FMRI supplied as an argument would be valid
+        to add to the repository catalog.  This checks to make sure
+        that any past catalog operations (such as a rename or freeze)
+        would not prohibit the caller from adding this FMRI."""
+
+        rstore = self.get_pub_rstore(pfmri.publisher)
+        return rstore.valid_new_fmri(pfmri)
+
+    def write_config(self):
+        """Save the repository's current configuration data."""
+
+        self.__lock_repository()
+        try:
+            self.__write_config()
+        finally:
+            self.__unlock_repository()
+
+    catalog_requests = property(lambda self: self.__catalog_requests)
+    cfg = property(lambda self: self.__cfg)
+    file_requests = property(lambda self: self.__file_requests)
+    file_root = property(lambda self: self.__file_root)
+    manifest_requests = property(lambda self: self.__manifest_requests)
+    mirror = property(lambda self: self.__mirror, __set_mirror)
+    pub_root = property(lambda self: self.__pub_root)
+    read_only = property(lambda self: self.__read_only, __set_read_only)
+    root = property(lambda self: self.__root)
+    rstores = property(lambda self: self.__rstores.values())
+    writable_root = property(lambda self: self.__writable_root)
+    temp_root = property(lambda self: self.__tmp_root)
 
 
 class RepositoryConfig(object):
-        """Returns an object representing a configuration interface for a
-        a pkg(7) repository.
+    """Returns an object representing a configuration interface for a
+    a pkg(7) repository.
 
-        The class of the object returned will depend upon the specified
-        configuration target (which is used as to retrieve and store
-        configuration data).
+    The class of the object returned will depend upon the specified
+    configuration target (which is used as to retrieve and store
+    configuration data).
 
-        'target' is the optional location to retrieve existing configuration
-        data or store the configuration data when requested.  The location
-        can be the pathname of a file or an SMF FMRI.  If a pathname is
-        provided, and does not exist, it will be created.
+    'target' is the optional location to retrieve existing configuration
+    data or store the configuration data when requested.  The location
+    can be the pathname of a file or an SMF FMRI.  If a pathname is
+    provided, and does not exist, it will be created.
 
-        'overrides' is a dictionary of property values indexed by section name
-        and property name.  If provided, it will override any values read from
-        an existing file or any defaults initially assigned.
+    'overrides' is a dictionary of property values indexed by section name
+    and property name.  If provided, it will override any values read from
+    an existing file or any defaults initially assigned.
 
-        'version' is an integer value specifying the set of configuration data
-        to use for the operation.  If not provided, the version will be based
-        on the target if supported.  If a version cannot be determined, the
-        newest version will be assumed.
-        """
+    'version' is an integer value specifying the set of configuration data
+    to use for the operation.  If not provided, the version will be based
+    on the target if supported.  If a version cannot be determined, the
+    newest version will be assumed.
+    """
 
-        # This dictionary defines the set of default properties and property
-        # groups for a repository configuration indexed by version.
-        __defs = {
-            2: [
-                cfg.PropertySection("publisher", [
+    # This dictionary defines the set of default properties and property
+    # groups for a repository configuration indexed by version.
+    __defs = {
+        2: [
+            cfg.PropertySection(
+                "publisher",
+                [
                     cfg.PropPublisher("alias"),
                     cfg.PropPublisher("prefix"),
-                ]),
-                cfg.PropertySection("repository", [
-                    cfg.PropDefined("collection_type", ["core",
-                        "supplemental"], default="core"),
+                ],
+            ),
+            cfg.PropertySection(
+                "repository",
+                [
+                    cfg.PropDefined(
+                        "collection_type",
+                        ["core", "supplemental"],
+                        default="core",
+                    ),
                     cfg.PropDefined("description"),
                     cfg.PropPubURI("detailed_url"),
                     cfg.PropSimplePubURIList("legal_uris"),
                     cfg.PropDefined("maintainer"),
                     cfg.PropPubURI("maintainer_url"),
                     cfg.PropSimplePubURIList("mirrors"),
-                    cfg.PropDefined("name",
-                        default="package repository"),
+                    cfg.PropDefined("name", default="package repository"),
                     cfg.PropSimplePubURIList("origins"),
                     cfg.PropInt("refresh_seconds", default=14400),
                     cfg.PropPubURI("registration_uri"),
                     cfg.PropSimplePubURIList("related_uris"),
-                ]),
-                cfg.PropertySection("feed", [
+                ],
+            ),
+            cfg.PropertySection(
+                "feed",
+                [
                     cfg.PropUUID("id"),
-                    cfg.PropDefined("name",
-                        default="package repository feed"),
+                    cfg.PropDefined("name", default="package repository feed"),
                     cfg.PropDefined("description"),
-                    cfg.PropDefined("icon", allowed=["", "<pathname>"],
-                        default="web/_themes/pkg-block-icon.png"),
-                    cfg.PropDefined("logo", allowed=["", "<pathname>"],
-                        default="web/_themes/pkg-block-logo.png"),
+                    cfg.PropDefined(
+                        "icon",
+                        allowed=["", "<pathname>"],
+                        default="web/_themes/pkg-block-icon.png",
+                    ),
+                    cfg.PropDefined(
+                        "logo",
+                        allowed=["", "<pathname>"],
+                        default="web/_themes/pkg-block-logo.png",
+                    ),
                     cfg.PropInt("window", default=24),
-                ]),
-            ],
-            3: [
-                cfg.PropertySection("publisher", [
+                ],
+            ),
+        ],
+        3: [
+            cfg.PropertySection(
+                "publisher",
+                [
                     cfg.PropPublisher("alias"),
                     cfg.PropPublisher("prefix"),
-                ]),
-                cfg.PropertySection("repository", [
-                    cfg.PropDefined("collection_type", ["core",
-                        "supplemental"], default="core"),
+                ],
+            ),
+            cfg.PropertySection(
+                "repository",
+                [
+                    cfg.PropDefined(
+                        "collection_type",
+                        ["core", "supplemental"],
+                        default="core",
+                    ),
                     cfg.PropDefined("description"),
                     cfg.PropPubURI("detailed_url"),
                     cfg.PropSimplePubURIList("legal_uris"),
                     cfg.PropDefined("maintainer"),
                     cfg.PropPubURI("maintainer_url"),
                     cfg.PropSimplePubURIList("mirrors"),
-                    cfg.PropDefined("name",
-                        default="package repository"),
+                    cfg.PropDefined("name", default="package repository"),
                     cfg.PropSimplePubURIList("origins"),
                     cfg.PropInt("refresh_seconds", default=14400),
                     cfg.PropPubURI("registration_uri"),
                     cfg.PropSimplePubURIList("related_uris"),
-                ]),
-                cfg.PropertySection("feed", [
+                ],
+            ),
+            cfg.PropertySection(
+                "feed",
+                [
                     cfg.PropUUID("id"),
-                    cfg.PropDefined("name",
-                        default="package repository feed"),
+                    cfg.PropDefined("name", default="package repository feed"),
                     cfg.PropDefined("description"),
-                    cfg.PropDefined("icon", allowed=["", "<pathname>"],
-                        default="web/_themes/pkg-block-icon.png"),
-                    cfg.PropDefined("logo", allowed=["", "<pathname>"],
-                        default="web/_themes/pkg-block-logo.png"),
+                    cfg.PropDefined(
+                        "icon",
+                        allowed=["", "<pathname>"],
+                        default="web/_themes/pkg-block-icon.png",
+                    ),
+                    cfg.PropDefined(
+                        "logo",
+                        allowed=["", "<pathname>"],
+                        default="web/_themes/pkg-block-logo.png",
+                    ),
                     cfg.PropInt("window", default=24),
-                ]),
-            ],
-            4: [
-                cfg.PropertySection("publisher", [
+                ],
+            ),
+        ],
+        4: [
+            cfg.PropertySection(
+                "publisher",
+                [
                     cfg.PropPublisher("prefix"),
-                ]),
-                cfg.PropertySection("repository", [
+                ],
+            ),
+            cfg.PropertySection(
+                "repository",
+                [
                     cfg.PropInt("version"),
-		    # NOTE: OmniOS uses a different trust anchor directory.
-                    cfg.Property("trust-anchor-directory",
-                        default="/etc/ssl/pkg/"),
+                    # NOTE: OmniOS uses a different trust anchor directory.
+                    cfg.Property(
+                        "trust-anchor-directory", default="/etc/ssl/pkg/"
+                    ),
                     cfg.PropList("signature-required-names"),
-                    cfg.PropBool("check-certificate-revocation", default=False)
-                ]),
-            ],
-        }
+                    cfg.PropBool("check-certificate-revocation", default=False),
+                ],
+            ),
+        ],
+    }
 
-        def __new__(cls, target=None, overrides=misc.EmptyDict, version=None):
-                if not target:
-                        return cfg.Config(definitions=cls.__defs,
-                            overrides=overrides, version=version)
-                elif target.startswith("svc:"):
-                        return cfg.SMFConfig(target, definitions=cls.__defs,
-                            overrides=overrides, version=version)
-                return cfg.FileConfig(target, definitions=cls.__defs,
-                    overrides=overrides, version=version)
+    def __new__(cls, target=None, overrides=misc.EmptyDict, version=None):
+        if not target:
+            return cfg.Config(
+                definitions=cls.__defs, overrides=overrides, version=version
+            )
+        elif target.startswith("svc:"):
+            return cfg.SMFConfig(
+                target,
+                definitions=cls.__defs,
+                overrides=overrides,
+                version=version,
+            )
+        return cfg.FileConfig(
+            target, definitions=cls.__defs, overrides=overrides, version=version
+        )
 
 
 def repository_create(repo_uri, properties=misc.EmptyDict, version=None):
-        """Create a repository at given location and return the Repository
-        object for the new repository.  If a repository (or directory at
-        the given location) already exists, a RepositoryExistsError will be
-        raised.  Other errors can raise exceptions of class ApiException.
-        """
+    """Create a repository at given location and return the Repository
+    object for the new repository.  If a repository (or directory at
+    the given location) already exists, a RepositoryExistsError will be
+    raised.  Other errors can raise exceptions of class ApiException.
+    """
 
-        if isinstance(repo_uri, six.string_types):
-                repo_uri = publisher.RepositoryURI(misc.parse_uri(repo_uri))
+    if isinstance(repo_uri, six.string_types):
+        repo_uri = publisher.RepositoryURI(misc.parse_uri(repo_uri))
 
-        path = repo_uri.get_pathname()
-        if not path:
-                # Bad URI?
-                raise RepositoryInvalidError(str(repo_uri))
+    path = repo_uri.get_pathname()
+    if not path:
+        # Bad URI?
+        raise RepositoryInvalidError(str(repo_uri))
 
-        if version is not None and (version < 3 or
-            version > CURRENT_REPO_VERSION):
-                raise RepositoryUnsupportedOperationError()
+    if version is not None and (version < 3 or version > CURRENT_REPO_VERSION):
+        raise RepositoryUnsupportedOperationError()
 
+    try:
+        os.makedirs(path, misc.PKG_DIR_MODE)
+    except EnvironmentError as e:
+        if e.filename == path and (
+            e.errno == errno.EEXIST or os.path.exists(e.filename)
+        ):
+            entries = os.listdir(e.filename)
+            # If the directory isn't empty (excluding the
+            # special .zfs snapshot directory) don't allow
+            # a repository to be created here.
+            if entries and not entries == [".zfs"]:
+                raise RepositoryExistsError(e.filename)
+        elif e.errno == errno.EACCES:
+            raise apx.PermissionsException(e.filename)
+        elif e.errno == errno.EROFS:
+            raise apx.ReadOnlyFileSystemException(e.filename)
+        elif e.errno != errno.EEXIST or e.filename != path:
+            raise
+
+    if version == 3:
+        # Version 3 repositories are expected to contain an additional
+        # set of specific directories...
+        for d in ("catalog", "file", "index", "pkg", "trans", "tmp"):
+            misc.makedirs(os.path.join(path, d))
+
+        # ...and this file (which can be empty).
         try:
-                os.makedirs(path, misc.PKG_DIR_MODE)
+            with open(os.path.join(path, "cfg_cache"), "w") as cf:
+                cf.write("\n")
         except EnvironmentError as e:
-                if e.filename == path and (e.errno == errno.EEXIST or
-                    os.path.exists(e.filename)):
-                        entries = os.listdir(e.filename)
-                        # If the directory isn't empty (excluding the
-                        # special .zfs snapshot directory) don't allow
-                        # a repository to be created here.
-                        if entries and not entries == [".zfs"]:
-                                raise RepositoryExistsError(e.filename)
-                elif e.errno == errno.EACCES:
-                        raise apx.PermissionsException(e.filename)
-                elif e.errno == errno.EROFS:
-                        raise apx.ReadOnlyFileSystemException(e.filename)
-                elif e.errno != errno.EEXIST or e.filename != path:
-                        raise
+            if e.errno == errno.EACCES:
+                raise apx.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise apx.ReadOnlyFileSystemException(e.filename)
+            elif e.errno != errno.EEXIST:
+                raise
 
-        if version == 3:
-                # Version 3 repositories are expected to contain an additional
-                # set of specific directories...
-                for d in ("catalog", "file", "index", "pkg", "trans", "tmp"):
-                        misc.makedirs(os.path.join(path, d))
+    return Repository(
+        create=True, read_only=False, properties=properties, root=path
+    )
 
-                # ...and this file (which can be empty).
-                try:
-                        with open(os.path.join(path, "cfg_cache"), "w") as cf:
-                                cf.write("\n")
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise apx.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise apx.ReadOnlyFileSystemException(
-                                    e.filename)
-                        elif e.errno != errno.EEXIST:
-                                raise
-
-        return Repository(create=True, read_only=False, properties=properties,
-            root=path)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/server/transaction.py
+++ b/src/modules/server/transaction.py
@@ -44,761 +44,840 @@ import pkg.misc as misc
 import pkg.portable as portable
 
 try:
-        import pkg.elf as elf
-        haveelf = True
+    import pkg.elf as elf
+
+    haveelf = True
 except ImportError:
-        haveelf = False
+    haveelf = False
+
 
 class TransactionError(Exception):
-        """Base exception class for all Transaction exceptions."""
+    """Base exception class for all Transaction exceptions."""
 
-        def __init__(self, *args):
-                Exception.__init__(self, *args)
-                if args:
-                        self.data = args[0]
-                else:
-                        self.data = None
+    def __init__(self, *args):
+        Exception.__init__(self, *args)
+        if args:
+            self.data = args[0]
+        else:
+            self.data = None
 
-        def __str__(self):
-                return str(self.data)
+    def __str__(self):
+        return str(self.data)
 
 
 class TransactionContentError(TransactionError):
-        """Used to indicate that an unexpected error was encountered while
-        processing the payload content for an operation."""
+    """Used to indicate that an unexpected error was encountered while
+    processing the payload content for an operation."""
 
-        def __str__(self):
-                return _("Unrecognized or malformed data in operation payload: "
-                    "'{0}'.").format(self.data)
+    def __str__(self):
+        return _(
+            "Unrecognized or malformed data in operation payload: " "'{0}'."
+        ).format(self.data)
 
 
 class TransactionOperationError(TransactionError):
-        """Used to indicate that a Transaction operation failed.
+    """Used to indicate that a Transaction operation failed.
 
-        Data should be provided as keyword arguments."""
+    Data should be provided as keyword arguments."""
 
-        def __init__(self, *args, **kwargs):
-                TransactionError.__init__(self, *args)
-                if kwargs is None:
-                        kwargs = {}
-                self._args = kwargs
+    def __init__(self, *args, **kwargs):
+        TransactionError.__init__(self, *args)
+        if kwargs is None:
+            kwargs = {}
+        self._args = kwargs
 
-        def __str__(self):
-                if "client_release" in self._args:
-                        return _("The specified client_release is invalid: "
-                            "'{0}'").format(self._args.get("msg", ""))
-                elif "fmri_version" in self._args:
-                        return _("'The specified FMRI, '{0}', has an invalid "
-                            "version.").format(self._args.get("pfmri", ""))
-                elif "valid_new_fmri" in self._args:
-                        return _("The specified FMRI, '{0}', already exists or "
-                            "has been restricted.").format(self._args.get("pfmri",
-                            ""))
-                elif "publisher_required" in self._args:
-                        return _("The specified FMRI, '{0}', must include the "
-                            "publisher prefix as the repository contains "
-                            "package data for more than one publisher or "
-                            "a default publisher has not been defined.").format(
-                            self._args.get("pfmri", ""))
-                elif "missing_fmri" in self._args:
-                        return _("Need an existing instance of {0} to exist to "
-                            "append to it").format(self._args.get("pfmri", ""))
-                elif "non_sig" in self._args:
-                        return _("Only a signature can be appended to an "
-                            "existing package")
-                elif "pfmri" in self._args:
-                        return _("The specified FMRI, '{0}', is invalid.").format(
-                            self._args["pfmri"])
-                return str(self.data)
+    def __str__(self):
+        if "client_release" in self._args:
+            return _(
+                "The specified client_release is invalid: " "'{0}'"
+            ).format(self._args.get("msg", ""))
+        elif "fmri_version" in self._args:
+            return _(
+                "'The specified FMRI, '{0}', has an invalid " "version."
+            ).format(self._args.get("pfmri", ""))
+        elif "valid_new_fmri" in self._args:
+            return _(
+                "The specified FMRI, '{0}', already exists or "
+                "has been restricted."
+            ).format(self._args.get("pfmri", ""))
+        elif "publisher_required" in self._args:
+            return _(
+                "The specified FMRI, '{0}', must include the "
+                "publisher prefix as the repository contains "
+                "package data for more than one publisher or "
+                "a default publisher has not been defined."
+            ).format(self._args.get("pfmri", ""))
+        elif "missing_fmri" in self._args:
+            return _(
+                "Need an existing instance of {0} to exist to " "append to it"
+            ).format(self._args.get("pfmri", ""))
+        elif "non_sig" in self._args:
+            return _(
+                "Only a signature can be appended to an " "existing package"
+            )
+        elif "pfmri" in self._args:
+            return _("The specified FMRI, '{0}', is invalid.").format(
+                self._args["pfmri"]
+            )
+        return str(self.data)
 
 
 class TransactionUnknownIDError(TransactionError):
-        """Used to indicate that the specified transaction ID is unknown."""
+    """Used to indicate that the specified transaction ID is unknown."""
 
-        def __str__(self):
-                return _("No Transaction matching ID '{0}' could be found.").format(
-                    self.data)
+    def __str__(self):
+        return _("No Transaction matching ID '{0}' could be found.").format(
+            self.data
+        )
 
 
 class TransactionAlreadyOpenError(TransactionError):
-        """Used to indicate that a Transaction is already open for use."""
+    """Used to indicate that a Transaction is already open for use."""
 
-        def __str__(self):
-                return _("Transaction ID '{0}' is already open.").format(
-                    self.data)
+    def __str__(self):
+        return _("Transaction ID '{0}' is already open.").format(self.data)
 
 
 class Transaction(object):
-        """A Transaction is a server-side object used to represent the set of
-        incoming changes to a package.  Manipulation of Transaction objects in
-        the repository server is generally initiated by a package publisher,
-        such as pkgsend(8)."""
+    """A Transaction is a server-side object used to represent the set of
+    incoming changes to a package.  Manipulation of Transaction objects in
+    the repository server is generally initiated by a package publisher,
+    such as pkgsend(8)."""
 
-        def __init__(self):
-                # XXX Need to use an FMRI object.
-                self.open_time = None
-                self.pkg_name = ""
-                self.esc_pkg_name = ""
-                self.rstore = None
-                self.client_release = ""
-                self.fmri = None
-                self.dir = ""
-                self.obsolete = False
-                self.renamed = False
-                self.has_reqdeps = False
-                self.types_found = set()
-                self.append_trans = False
-                self.remaining_payload_cnt = 0
+    def __init__(self):
+        # XXX Need to use an FMRI object.
+        self.open_time = None
+        self.pkg_name = ""
+        self.esc_pkg_name = ""
+        self.rstore = None
+        self.client_release = ""
+        self.fmri = None
+        self.dir = ""
+        self.obsolete = False
+        self.renamed = False
+        self.has_reqdeps = False
+        self.types_found = set()
+        self.append_trans = False
+        self.remaining_payload_cnt = 0
 
-        def get_basename(self):
-                assert self.open_time
-                # XXX should the timestamp be in ISO format?
-                return "{0:d}_{1}".format(
-                    calendar.timegm(self.open_time.utctimetuple()),
-                    quote(str(self.fmri), ""))
+    def get_basename(self):
+        assert self.open_time
+        # XXX should the timestamp be in ISO format?
+        return "{0:d}_{1}".format(
+            calendar.timegm(self.open_time.utctimetuple()),
+            quote(str(self.fmri), ""),
+        )
 
-        def open(self, rstore, client_release, pfmri):
-                # Store a reference to the repository storage object.
-                self.rstore = rstore
+    def open(self, rstore, client_release, pfmri):
+        # Store a reference to the repository storage object.
+        self.rstore = rstore
 
-                if client_release is None:
-                        raise TransactionOperationError(client_release=None,
-                            pfmri=pfmri)
-                if pfmri is None:
-                        raise TransactionOperationError(pfmri=None)
+        if client_release is None:
+            raise TransactionOperationError(client_release=None, pfmri=pfmri)
+        if pfmri is None:
+            raise TransactionOperationError(pfmri=None)
 
-                if not isinstance(pfmri, six.string_types):
-                        pfmri = str(pfmri)
+        if not isinstance(pfmri, six.string_types):
+            pfmri = str(pfmri)
 
-                self.client_release = client_release
-                self.pkg_name = pfmri
-                self.esc_pkg_name = quote(pfmri, "")
+        self.client_release = client_release
+        self.pkg_name = pfmri
+        self.esc_pkg_name = quote(pfmri, "")
 
-                # attempt to construct an FMRI object
-                try:
-                        self.fmri = fmri.PkgFmri(self.pkg_name,
-                            self.client_release)
-                except fmri.FmriError as e:
-                        raise TransactionOperationError(e)
+        # attempt to construct an FMRI object
+        try:
+            self.fmri = fmri.PkgFmri(self.pkg_name, self.client_release)
+        except fmri.FmriError as e:
+            raise TransactionOperationError(e)
 
-                # Version is required for publication.
-                if self.fmri.version is None:
-                        raise TransactionOperationError(fmri_version=None,
-                            pfmri=pfmri)
+        # Version is required for publication.
+        if self.fmri.version is None:
+            raise TransactionOperationError(fmri_version=None, pfmri=pfmri)
 
-                # Ensure that the FMRI has been fully qualified with publisher
-                # information or apply the default if appropriate.
-                if not self.fmri.publisher:
-                        default_pub = rstore.publisher
-                        if not default_pub:
-                                # A publisher is required.
-                                raise TransactionOperationError(
-                                    publisher_required=True, pfmri=pfmri)
-
-                        self.fmri.publisher = default_pub
-                        pkg_name = self.pkg_name
-                        pub_string = "pkg://{0}/".format(default_pub)
-                        if not pkg_name.startswith("pkg:/"):
-                                pkg_name = pub_string + pkg_name
-                        else:
-                                pkg_name = pkg_name.replace("pkg:/", pub_string)
-                        self.pkg_name = pkg_name
-                        self.esc_pkg_name = quote(pkg_name, "")
-
-                # record transaction metadata: opening_time, package, user
-                # XXX publishing with a custom timestamp may require
-                # authorization above the basic "can open transactions".
-                self.open_time = self.fmri.get_timestamp()
-                if self.open_time:
-                        # Strip the timestamp information for consistency with
-                        # the case where it was not specified.
-                        self.pkg_name = ":".join(pfmri.split(":")[:-1])
-                        self.esc_pkg_name = quote(self.pkg_name, "")
-                else:
-                        # A timestamp was not provided; try to generate a
-                        # unique one.
-                        while 1:
-                                self.open_time = datetime.datetime.utcnow()
-                                self.fmri.set_timestamp(self.open_time)
-                                cat = rstore.catalog
-                                if not cat.get_entry(self.fmri):
-                                        break
-                                time.sleep(.25)
-
-                # Check that the new FMRI's version is valid.  In other words,
-                # the package has not been renamed or frozen for the new
-                # version.
-                if not self.rstore.valid_new_fmri(self.fmri):
-                        raise TransactionOperationError(valid_new_fmri=False,
-                            pfmri=pfmri)
-
-                trans_basename = self.get_basename()
-                self.dir = os.path.join(self.rstore.trans_root, trans_basename)
-
-                try:
-                        os.makedirs(self.dir, misc.PKG_DIR_MODE)
-                except EnvironmentError as e:
-                        if e.errno == errno.EEXIST:
-                                raise TransactionAlreadyOpenError(
-                                    trans_basename)
-                        raise TransactionOperationError(e)
-
-                #
-                # always create a minimal manifest
-                #
-                tfpath = os.path.join(self.dir, "manifest")
-                tfile = open(tfpath, "a+")
-
-                # Build a set action containing the fully qualified FMRI and add
-                # it to the manifest.  While it may seem inefficient to create
-                # an action string, convert it to an action, and then back, it
-                # does ensure that the server is adding a valid action.
-                fact = actions.fromstr("set name=pkg.fmri value={0}".format(
-                    self.fmri))
-                print(str(fact), file=tfile)
-                tfile.close()
-
-                # XXX:
-                # validate that this version can be opened
-                #   if we specified no release, fail
-                #   if we specified a release without branch, open next branch
-                #   if we specified a release with branch major, open same
-                #     branch minor
-                #   if we specified a release with branch major and minor, use
-                #   as specified
-                # we should disallow new package creation, if so flagged
-
-                # if not found, create package
-                # set package state to TRANSACTING
-
-        def append(self, rstore, client_release, pfmri):
-                self.rstore = rstore
-                self.append_trans = True
-
-                if client_release is None:
-                        raise TransactionOperationError(client_release=None,
-                            pfmri=pfmri)
-                if pfmri is None:
-                        raise TransactionOperationError(pfmri=None)
-
-                if not isinstance(pfmri, six.string_types):
-                        pfmri = str(pfmri)
-
-                self.client_release = client_release
-                self.pkg_name = pfmri
-                self.esc_pkg_name = quote(pfmri, "")
-
-                # attempt to construct an FMRI object
-                try:
-                        self.fmri = fmri.PkgFmri(self.pkg_name,
-                            self.client_release)
-                except fmri.FmriError as e:
-                        raise TransactionOperationError(e)
-
-                # Version and timestamp is required for appending.
-                if self.fmri.version is None or not self.fmri.get_timestamp():
-                        raise TransactionOperationError(fmri_version=None,
-                            pfmri=pfmri)
-
-                # Ensure that the FMRI has been fully qualified with publisher
-                # information or apply the default if appropriate.
-                if not self.fmri.publisher:
-                        default_pub = rstore.publisher
-                        if not default_pub:
-                                # A publisher is required.
-                                raise TransactionOperationError(
-                                    publisher_required=True, pfmri=pfmri)
-
-                        self.fmri.publisher = default_pub
-                        pkg_name = self.pkg_name
-                        pub_string = "pkg://{0}/".format(default_pub)
-                        if not pkg_name.startswith("pkg:/"):
-                                pkg_name = pub_string + pkg_name
-                        else:
-                                pkg_name = pkg_name.replace("pkg:/", pub_string)
-                        self.pkg_name = pkg_name
-                        self.esc_pkg_name = quote(pkg_name, "")
-
-                # record transaction metadata: opening_time, package, user
-                self.open_time = self.fmri.get_timestamp()
-
-                # Strip the timestamp information for consistency with
-                # the case where it was not specified.
-                self.pkg_name = ":".join(pfmri.split(":")[:-1])
-                self.esc_pkg_name = quote(self.pkg_name, "")
-
-                if not rstore.valid_append_fmri(self.fmri):
-                        raise TransactionOperationError(missing_fmri=True,
-                            pfmri=self.fmri)
-
-                trans_basename = self.get_basename()
-                self.dir = os.path.join(rstore.trans_root, trans_basename)
-
-                try:
-                        os.makedirs(self.dir, misc.PKG_DIR_MODE)
-                except EnvironmentError as e:
-                        if e.errno == errno.EEXIST:
-                                raise TransactionAlreadyOpenError(
-                                    trans_basename)
-                        raise TransactionOperationError(e)
-
-                # Record that this is an append operation so that it can be
-                # reopened correctly.
-                open(os.path.join(self.dir, "append"), "wb").close()
-
-                # copy in existing manifest, then open it for appending.
-                portable.copyfile(rstore.manifest(self.fmri),
-                    os.path.join(self.dir, "manifest"))
-
-        def reopen(self, rstore, trans_dir):
-                """The reopen() method is invoked by the repository as needed to
-                load Transaction data."""
-
-                self.rstore = rstore
-                try:
-                        open_time_str, self.esc_pkg_name = \
-                            os.path.basename(trans_dir).split("_", 1)
-                except ValueError:
-                        raise TransactionUnknownIDError(os.path.basename(
-                            trans_dir))
-
-                self.open_time = \
-                    datetime.datetime.utcfromtimestamp(int(open_time_str))
-                self.pkg_name = unquote(self.esc_pkg_name)
-
-                # This conversion should always work, because we encoded the
-                # client release on the initial open of the transaction.
-                self.fmri = fmri.PkgFmri(self.pkg_name, None)
-
-                self.dir = os.path.join(rstore.trans_root, self.get_basename())
-
-                if not os.path.exists(self.dir):
-                        raise TransactionUnknownIDError(self.get_basename())
-
-                tmode = "rb"
-                if not rstore.read_only:
-                        # The mode is important especially when dealing with
-                        # NFS because of problems with opening a file as
-                        # read/write or readonly multiple times.
-                        tmode += "+"
-
-                # Find out if the package is renamed or obsolete.
-                try:
-                        tfpath = os.path.join(self.dir, "manifest")
-                        tfile = open(tfpath, tmode)
-                except IOError as e:
-                        if e.errno == errno.ENOENT:
-                                return
-                        raise
-                m = pkg.manifest.Manifest()
-                # If tfile is a StreamingFileObj obj, its read()
-                # methods will return bytes. We need str for
-                # manifest and here's an earlisest point that
-                # we can convert it to str.
-                m.set_content(content=misc.force_str(tfile.read()))
-                tfile.close()
-                if os.path.exists(os.path.join(self.dir, "append")):
-                        self.append_trans = True
-                self.obsolete = m.getbool("pkg.obsolete", "false")
-                self.renamed = m.getbool("pkg.renamed", "false")
-                self.types_found = set((
-                    action.name for action in m.gen_actions()
-                ))
-                self.has_reqdeps = any(
-                    a.attrs["type"] == "require"
-                    for a in m.gen_actions_by_type("depend")
+        # Ensure that the FMRI has been fully qualified with publisher
+        # information or apply the default if appropriate.
+        if not self.fmri.publisher:
+            default_pub = rstore.publisher
+            if not default_pub:
+                # A publisher is required.
+                raise TransactionOperationError(
+                    publisher_required=True, pfmri=pfmri
                 )
 
-        def close(self, add_to_catalog=True):
-                """Closes an open transaction, returning the published FMRI for
-                the corresponding package, and its current state in the catalog.
-                """
-                def split_trans_id(tid):
-                        m = re.match(r"(\d+)_(.*)", tid)
-                        return m.group(1), unquote(m.group(2))
+            self.fmri.publisher = default_pub
+            pkg_name = self.pkg_name
+            pub_string = "pkg://{0}/".format(default_pub)
+            if not pkg_name.startswith("pkg:/"):
+                pkg_name = pub_string + pkg_name
+            else:
+                pkg_name = pkg_name.replace("pkg:/", pub_string)
+            self.pkg_name = pkg_name
+            self.esc_pkg_name = quote(pkg_name, "")
 
-                trans_id = self.get_basename()
-                pkg_fmri = split_trans_id(trans_id)[1]
+        # record transaction metadata: opening_time, package, user
+        # XXX publishing with a custom timestamp may require
+        # authorization above the basic "can open transactions".
+        self.open_time = self.fmri.get_timestamp()
+        if self.open_time:
+            # Strip the timestamp information for consistency with
+            # the case where it was not specified.
+            self.pkg_name = ":".join(pfmri.split(":")[:-1])
+            self.esc_pkg_name = quote(self.pkg_name, "")
+        else:
+            # A timestamp was not provided; try to generate a
+            # unique one.
+            while 1:
+                self.open_time = datetime.datetime.utcnow()
+                self.fmri.set_timestamp(self.open_time)
+                cat = rstore.catalog
+                if not cat.get_entry(self.fmri):
+                    break
+                time.sleep(0.25)
 
-                # set package state to SUBMITTED
-                pkg_state = "SUBMITTED"
+        # Check that the new FMRI's version is valid.  In other words,
+        # the package has not been renamed or frozen for the new
+        # version.
+        if not self.rstore.valid_new_fmri(self.fmri):
+            raise TransactionOperationError(valid_new_fmri=False, pfmri=pfmri)
 
-                # set state to PUBLISHED
-                if self.append_trans:
-                        pkg_fmri, pkg_state = self.accept_append(add_to_catalog)
+        trans_basename = self.get_basename()
+        self.dir = os.path.join(self.rstore.trans_root, trans_basename)
+
+        try:
+            os.makedirs(self.dir, misc.PKG_DIR_MODE)
+        except EnvironmentError as e:
+            if e.errno == errno.EEXIST:
+                raise TransactionAlreadyOpenError(trans_basename)
+            raise TransactionOperationError(e)
+
+        #
+        # always create a minimal manifest
+        #
+        tfpath = os.path.join(self.dir, "manifest")
+        tfile = open(tfpath, "a+")
+
+        # Build a set action containing the fully qualified FMRI and add
+        # it to the manifest.  While it may seem inefficient to create
+        # an action string, convert it to an action, and then back, it
+        # does ensure that the server is adding a valid action.
+        fact = actions.fromstr("set name=pkg.fmri value={0}".format(self.fmri))
+        print(str(fact), file=tfile)
+        tfile.close()
+
+        # XXX:
+        # validate that this version can be opened
+        #   if we specified no release, fail
+        #   if we specified a release without branch, open next branch
+        #   if we specified a release with branch major, open same
+        #     branch minor
+        #   if we specified a release with branch major and minor, use
+        #   as specified
+        # we should disallow new package creation, if so flagged
+
+        # if not found, create package
+        # set package state to TRANSACTING
+
+    def append(self, rstore, client_release, pfmri):
+        self.rstore = rstore
+        self.append_trans = True
+
+        if client_release is None:
+            raise TransactionOperationError(client_release=None, pfmri=pfmri)
+        if pfmri is None:
+            raise TransactionOperationError(pfmri=None)
+
+        if not isinstance(pfmri, six.string_types):
+            pfmri = str(pfmri)
+
+        self.client_release = client_release
+        self.pkg_name = pfmri
+        self.esc_pkg_name = quote(pfmri, "")
+
+        # attempt to construct an FMRI object
+        try:
+            self.fmri = fmri.PkgFmri(self.pkg_name, self.client_release)
+        except fmri.FmriError as e:
+            raise TransactionOperationError(e)
+
+        # Version and timestamp is required for appending.
+        if self.fmri.version is None or not self.fmri.get_timestamp():
+            raise TransactionOperationError(fmri_version=None, pfmri=pfmri)
+
+        # Ensure that the FMRI has been fully qualified with publisher
+        # information or apply the default if appropriate.
+        if not self.fmri.publisher:
+            default_pub = rstore.publisher
+            if not default_pub:
+                # A publisher is required.
+                raise TransactionOperationError(
+                    publisher_required=True, pfmri=pfmri
+                )
+
+            self.fmri.publisher = default_pub
+            pkg_name = self.pkg_name
+            pub_string = "pkg://{0}/".format(default_pub)
+            if not pkg_name.startswith("pkg:/"):
+                pkg_name = pub_string + pkg_name
+            else:
+                pkg_name = pkg_name.replace("pkg:/", pub_string)
+            self.pkg_name = pkg_name
+            self.esc_pkg_name = quote(pkg_name, "")
+
+        # record transaction metadata: opening_time, package, user
+        self.open_time = self.fmri.get_timestamp()
+
+        # Strip the timestamp information for consistency with
+        # the case where it was not specified.
+        self.pkg_name = ":".join(pfmri.split(":")[:-1])
+        self.esc_pkg_name = quote(self.pkg_name, "")
+
+        if not rstore.valid_append_fmri(self.fmri):
+            raise TransactionOperationError(missing_fmri=True, pfmri=self.fmri)
+
+        trans_basename = self.get_basename()
+        self.dir = os.path.join(rstore.trans_root, trans_basename)
+
+        try:
+            os.makedirs(self.dir, misc.PKG_DIR_MODE)
+        except EnvironmentError as e:
+            if e.errno == errno.EEXIST:
+                raise TransactionAlreadyOpenError(trans_basename)
+            raise TransactionOperationError(e)
+
+        # Record that this is an append operation so that it can be
+        # reopened correctly.
+        open(os.path.join(self.dir, "append"), "wb").close()
+
+        # copy in existing manifest, then open it for appending.
+        portable.copyfile(
+            rstore.manifest(self.fmri), os.path.join(self.dir, "manifest")
+        )
+
+    def reopen(self, rstore, trans_dir):
+        """The reopen() method is invoked by the repository as needed to
+        load Transaction data."""
+
+        self.rstore = rstore
+        try:
+            open_time_str, self.esc_pkg_name = os.path.basename(
+                trans_dir
+            ).split("_", 1)
+        except ValueError:
+            raise TransactionUnknownIDError(os.path.basename(trans_dir))
+
+        self.open_time = datetime.datetime.utcfromtimestamp(int(open_time_str))
+        self.pkg_name = unquote(self.esc_pkg_name)
+
+        # This conversion should always work, because we encoded the
+        # client release on the initial open of the transaction.
+        self.fmri = fmri.PkgFmri(self.pkg_name, None)
+
+        self.dir = os.path.join(rstore.trans_root, self.get_basename())
+
+        if not os.path.exists(self.dir):
+            raise TransactionUnknownIDError(self.get_basename())
+
+        tmode = "rb"
+        if not rstore.read_only:
+            # The mode is important especially when dealing with
+            # NFS because of problems with opening a file as
+            # read/write or readonly multiple times.
+            tmode += "+"
+
+        # Find out if the package is renamed or obsolete.
+        try:
+            tfpath = os.path.join(self.dir, "manifest")
+            tfile = open(tfpath, tmode)
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                return
+            raise
+        m = pkg.manifest.Manifest()
+        # If tfile is a StreamingFileObj obj, its read()
+        # methods will return bytes. We need str for
+        # manifest and here's an earlisest point that
+        # we can convert it to str.
+        m.set_content(content=misc.force_str(tfile.read()))
+        tfile.close()
+        if os.path.exists(os.path.join(self.dir, "append")):
+            self.append_trans = True
+        self.obsolete = m.getbool("pkg.obsolete", "false")
+        self.renamed = m.getbool("pkg.renamed", "false")
+        self.types_found = set((action.name for action in m.gen_actions()))
+        self.has_reqdeps = any(
+            a.attrs["type"] == "require"
+            for a in m.gen_actions_by_type("depend")
+        )
+
+    def close(self, add_to_catalog=True):
+        """Closes an open transaction, returning the published FMRI for
+        the corresponding package, and its current state in the catalog.
+        """
+
+        def split_trans_id(tid):
+            m = re.match(r"(\d+)_(.*)", tid)
+            return m.group(1), unquote(m.group(2))
+
+        trans_id = self.get_basename()
+        pkg_fmri = split_trans_id(trans_id)[1]
+
+        # set package state to SUBMITTED
+        pkg_state = "SUBMITTED"
+
+        # set state to PUBLISHED
+        if self.append_trans:
+            pkg_fmri, pkg_state = self.accept_append(add_to_catalog)
+        else:
+            pkg_fmri, pkg_state = self.accept_publish(add_to_catalog)
+
+        # Discard the in-flight transaction data.
+        try:
+            shutil.rmtree(self.dir)
+        except EnvironmentError as e:
+            # Ensure that the error goes to stderr, and then drive
+            # on as the actual package was published.
+            misc.emsg(e)
+
+        return (pkg_fmri, pkg_state)
+
+    def abandon(self):
+        # state transition from TRANSACTING to ABANDONED
+        try:
+            shutil.rmtree(self.dir)
+        except EnvironmentError as e:
+            if e.filename == self.dir and e.errno != errno.ENOENT:
+                raise
+        return "ABANDONED"
+
+    def add_content(self, action):
+        """Adds the content of the provided action (if applicable) to
+        the Transaction."""
+
+        # Perform additional publication-time validation of actions
+        # before further processing is done.
+        try:
+            action.validate()
+        except actions.ActionError as e:
+            raise TransactionOperationError(e)
+
+        if self.append_trans and action.name != "signature":
+            raise TransactionOperationError(non_sig=True)
+
+        size = int(action.attrs.get("pkg.size", 0))
+
+        if action.has_payload and size <= 0:
+            # XXX hack for empty files
+            action.data = lambda: open(os.devnull, "rb")
+
+        if action.data is not None:
+            # get all hashes for this action
+            hashes, data = misc.get_data_digest(
+                action.data(),
+                length=size,
+                return_content=True,
+                hash_attrs=digest.LEGACY_HASH_ATTRS,
+                hash_algs=digest.HASH_ALGS,
+            )
+
+            # set the hash member for backwards compatibility and
+            # remove it from the dictionary
+            action.hash = hashes.pop("hash", None)
+            action.attrs.update(hashes)
+
+            # now set the hash value that will be used for storing
+            # the file in the repository.
+            hash_attr, hash_val, hash_func = digest.get_least_preferred_hash(
+                action
+            )
+            fname = hash_val
+
+            # Extract ELF information if not already provided.
+            # XXX This needs to be modularized.
+            if (
+                haveelf
+                and data[:4] == b"\x7fELF"
+                and (
+                    "elfarch" not in action.attrs
+                    or "elfbits" not in action.attrs
+                    or "elfhash" not in action.attrs
+                )
+            ):
+                elf_name = os.path.join(self.dir, ".temp-{0}".format(fname))
+                elf_file = open(elf_name, "wb")
+                elf_file.write(data)
+                elf_file.close()
+
+                try:
+                    elf_info = elf.get_info(elf_name)
+                except elf.ElfError as e:
+                    raise TransactionContentError(e)
+
+                try:
+                    # Check which content checksums to
+                    # compute and add to the action
+                    elf1 = "elfhash"
+
+                    if elf1 in digest.LEGACY_CONTENT_HASH_ATTRS:
+                        get_sha1 = True
+                    else:
+                        get_sha1 = False
+
+                    hashes = elf.get_hashes(elf_name, elfhash=get_sha1)
+
+                    if get_sha1:
+                        action.attrs[elf1] = hashes[elf1]
+
+                except elf.ElfError:
+                    pass
+                action.attrs["elfbits"] = str(elf_info["bits"])
+                action.attrs["elfarch"] = elf_info["arch"]
+                os.unlink(elf_name)
+
+            try:
+                dst_path = self.rstore.file(fname)
+            except Exception as e:
+                # The specific exception can't be named here due
+                # to the cyclic dependency between this class
+                # and the repository class.
+                if getattr(e, "data", "") != fname:
+                    raise
+                dst_path = None
+
+            csize, chashes = misc.compute_compressed_attrs(
+                fname, dst_path, data, size, self.dir
+            )
+            for attr in chashes:
+                action.attrs[attr] = chashes[attr]
+            action.attrs["pkg.csize"] = csize
+
+        self.remaining_payload_cnt = len(
+            action.attrs.get("chain.sizes", "").split()
+        )
+
+        # Do some sanity checking on packages marked or being marked
+        # obsolete or renamed.
+        if (
+            action.name == "set"
+            and action.attrs["name"] == "pkg.obsolete"
+            and action.attrs["value"] == "true"
+        ):
+            self.obsolete = True
+            if self.types_found.difference(set(("set", "signature"))):
+                raise TransactionOperationError(
+                    _(
+                        "An obsolete "
+                        "package cannot contain actions other than "
+                        "'set' and 'signature'."
+                    )
+                )
+        elif (
+            action.name == "set"
+            and action.attrs["name"] == "pkg.renamed"
+            and action.attrs["value"] == "true"
+        ):
+            self.renamed = True
+            if self.types_found.difference(set(("depend", "set", "signature"))):
+                raise TransactionOperationError(
+                    _(
+                        "A renamed "
+                        "package cannot contain actions other than "
+                        "'set', 'depend', and 'signature'."
+                    )
+                )
+
+        if (
+            not self.has_reqdeps
+            and action.name == "depend"
+            and action.attrs["type"] == "require"
+        ):
+            self.has_reqdeps = True
+
+        if self.obsolete and self.renamed:
+            # Reset either obsolete or renamed, depending on which
+            # action this was.
+            if action.attrs["name"] == "pkg.obsolete":
+                self.obsolete = False
+            else:
+                self.renamed = False
+            raise TransactionOperationError(
+                _(
+                    "A package may not "
+                    " be marked for both obsoletion and renaming."
+                )
+            )
+        elif self.obsolete and action.name not in ("set", "signature"):
+            raise TransactionOperationError(
+                _(
+                    "A '{type}' action "
+                    "cannot be present in an obsolete package: "
+                    "{action}"
+                ).format(type=action.name, action=action)
+            )
+        elif self.renamed and action.name not in ("depend", "set", "signature"):
+            raise TransactionOperationError(
+                _(
+                    "A '{type}' action "
+                    "cannot be present in a renamed package: "
+                    "{action}"
+                ).format(type=action.name, action=action)
+            )
+
+        # Now that the action is known to be sane, we can add it to the
+        # manifest.
+        tfpath = os.path.join(self.dir, "manifest")
+        tfile = open(tfpath, "a+")
+        print(action, file=tfile)
+        tfile.close()
+
+        self.types_found.add(action.name)
+
+    def add_file(self, f, basename=None, size=None):
+        """Adds the file to the Transaction."""
+
+        # If basename provided, just store the file as-is with the
+        # basename.
+        if basename:
+            fileneeded = True
+            try:
+                dst_path = self.rstore.file(basename)
+                fileneeded = False
+            except Exception as e:
+                dst_path = os.path.join(self.dir, basename)
+
+            if not fileneeded:
+                return
+
+            if isinstance(f, six.string_types):
+                portable.copyfile(f, dst_path)
+                return
+
+            bufsz = 128 * 1024
+            if bufsz > size:
+                bufsz = size
+
+            with open(dst_path, "wb") as wf:
+                while True:
+                    data = f.read(bufsz)
+                    # data is bytes
+                    if data == b"":
+                        break
+                    wf.write(data)
+            return
+
+        hashes, data = misc.get_data_digest(
+            f,
+            length=size,
+            return_content=True,
+            hash_attrs=digest.DEFAULT_HASH_ATTRS,
+            hash_algs=digest.HASH_ALGS,
+        )
+
+        if size is None:
+            size = len(data)
+
+        fname = None
+        try:
+            # We don't have an Action yet, so passing None is fine.
+            default_hash_attr = digest.get_least_preferred_hash(None)[0]
+            fname = hashes[default_hash_attr]
+            dst_path = self.rstore.file(fname)
+        except Exception as e:
+            # The specific exception can't be named here due
+            # to the cyclic dependency between this class
+            # and the repository class.
+            if getattr(e, "data", "") != fname:
+                raise
+            dst_path = None
+
+        misc.compute_compressed_attrs(
+            fname,
+            dst_path,
+            data,
+            size,
+            self.dir,
+            chash_attrs=digest.DEFAULT_CHASH_ATTRS,
+            chash_algs=digest.CHASH_ALGS,
+        )
+
+        self.remaining_payload_cnt -= 1
+
+    def add_manifest(self, f):
+        """Adds the manifest to the Transaction."""
+
+        if isinstance(f, six.string_types):
+            f = open(f, "rb")
+        # Store the manifest file.
+        fpath = os.path.join(self.dir, "manifest")
+        with open(fpath, "ab+") as wf:
+            try:
+                misc.gunzip_from_stream(f, wf, ignore_hash=True)
+                wf.seek(0)
+                content = wf.read()
+            except zlib.error:
+                # No need to decompress it if it's not a gzipped
+                # file.
+                f.seek(0)
+                content = f.read()
+                wf.write(content)
+        # Do some sanity checking on packages marked or being marked
+        # obsolete or renamed.
+        m = pkg.manifest.Manifest()
+        m.set_content(misc.force_str(content))
+        for action in m.gen_actions():
+            if (
+                action.name == "set"
+                and action.attrs["name"] == "pkg.obsolete"
+                and action.attrs["value"] == "true"
+            ):
+                self.obsolete = True
+                if self.types_found.difference(set(("set", "signature"))):
+                    raise TransactionOperationError(
+                        _(
+                            "An obsolete "
+                            "package cannot contain actions other than "
+                            "'set' and 'signature'."
+                        )
+                    )
+            elif (
+                action.name == "set"
+                and action.attrs["name"] == "pkg.renamed"
+                and action.attrs["value"] == "true"
+            ):
+                self.renamed = True
+                if self.types_found.difference(
+                    set(("depend", "set", "signature"))
+                ):
+                    raise TransactionOperationError(
+                        _(
+                            "A renamed "
+                            "package cannot contain actions other than "
+                            "'set', 'depend', and 'signature'."
+                        )
+                    )
+
+            if (
+                not self.has_reqdeps
+                and action.name == "depend"
+                and action.attrs["type"] == "require"
+            ):
+                self.has_reqdeps = True
+
+            if self.obsolete and self.renamed:
+                # Reset either obsolete or renamed, depending on which
+                # action this was.
+                if action.attrs["name"] == "pkg.obsolete":
+                    self.obsolete = False
                 else:
-                        pkg_fmri, pkg_state = self.accept_publish(
-                            add_to_catalog)
+                    self.renamed = False
+                raise TransactionOperationError(
+                    _(
+                        "A package may not "
+                        " be marked for both obsoletion and renaming."
+                    )
+                )
+            elif self.obsolete and action.name not in ("set", "signature"):
+                raise TransactionOperationError(
+                    _(
+                        "A '{type}' action "
+                        "cannot be present in an obsolete package: "
+                        "{action}"
+                    ).format(type=action.name, action=action)
+                )
+            elif self.renamed and action.name not in (
+                "depend",
+                "set",
+                "signature",
+            ):
+                raise TransactionOperationError(
+                    _(
+                        "A '{type}' action "
+                        "cannot be present in a renamed package: "
+                        "{action}"
+                    ).format(type=action.name, action=action)
+                )
 
-                # Discard the in-flight transaction data.
-                try:
-                        shutil.rmtree(self.dir)
-                except EnvironmentError as e:
-                        # Ensure that the error goes to stderr, and then drive
-                        # on as the actual package was published.
-                        misc.emsg(e)
+            self.types_found.add(action.name)
 
-                return (pkg_fmri, pkg_state)
+    def accept_publish(self, add_to_catalog=True):
+        """Transaction meets consistency criteria, and can be published.
+        Publish, making appropriate catalog entries."""
 
-        def abandon(self):
-                # state transition from TRANSACTING to ABANDONED
-                try:
-                        shutil.rmtree(self.dir)
-                except EnvironmentError as e:
-                        if e.filename == self.dir and e.errno != errno.ENOENT:
-                                raise
-                return "ABANDONED"
+        # Ensure that a renamed package has at least one dependency
+        if self.renamed and not self.has_reqdeps:
+            raise TransactionOperationError(
+                _(
+                    "A renamed package "
+                    "must contain at least one 'depend' action."
+                )
+            )
 
-        def add_content(self, action):
-                """Adds the content of the provided action (if applicable) to
-                the Transaction."""
+        # XXX If we are going to publish, then we should augment
+        # our response with any other packages that moved to
+        # PUBLISHED due to the package's arrival.
 
-                # Perform additional publication-time validation of actions
-                # before further processing is done.
-                try:
-                        action.validate()
-                except actions.ActionError as e:
-                        raise TransactionOperationError(e)
+        self.publish_package()
+        if add_to_catalog:
+            self.rstore.add_package(self.fmri)
 
-                if self.append_trans and action.name != "signature":
-                        raise TransactionOperationError(non_sig=True)
+        return (str(self.fmri), "PUBLISHED")
 
-                size = int(action.attrs.get("pkg.size", 0))
+    def accept_append(self, add_to_catalog=True):
+        """Transaction meets consistency criteria, and can be published.
+        Publish, making appropriate catalog replacements."""
 
-                if action.has_payload and size <= 0:
-                        # XXX hack for empty files
-                        action.data = lambda: open(os.devnull, "rb")
+        # Ensure that a renamed package has at least one dependency
+        if self.renamed and not self.has_reqdeps:
+            raise TransactionOperationError(
+                _(
+                    "A renamed package "
+                    "must contain at least one 'depend' action."
+                )
+            )
 
-                if action.data is not None:
-                        # get all hashes for this action
-                        hashes, data = misc.get_data_digest(action.data(),
-                            length=size, return_content=True,
-                            hash_attrs=digest.LEGACY_HASH_ATTRS,
-                            hash_algs=digest.HASH_ALGS)
+        if self.remaining_payload_cnt > 0:
+            raise TransactionOperationError(
+                _(
+                    "At least one "
+                    "certificate has not been delivered for the "
+                    "signature action."
+                )
+            )
 
-                        # set the hash member for backwards compatibility and
-                        # remove it from the dictionary
-                        action.hash = hashes.pop("hash", None)
-                        action.attrs.update(hashes)
+        # XXX If we are going to publish, then we should augment
+        # our response with any other packages that moved to
+        # PUBLISHED due to the package's arrival.
 
-                        # now set the hash value that will be used for storing
-                        # the file in the repository.
-                        hash_attr, hash_val, hash_func = \
-                            digest.get_least_preferred_hash(action)
-                        fname = hash_val
+        self.publish_package()
 
-                        # Extract ELF information if not already provided.
-                        # XXX This needs to be modularized.
-                        if haveelf and data[:4] == b"\x7fELF" and (
-                            "elfarch" not in action.attrs or
-                            "elfbits" not in action.attrs or
-                            "elfhash" not in action.attrs):
-                                elf_name = os.path.join(self.dir,
-                                    ".temp-{0}".format(fname))
-                                elf_file = open(elf_name, "wb")
-                                elf_file.write(data)
-                                elf_file.close()
+        if add_to_catalog:
+            self.rstore.replace_package(self.fmri)
 
-                                try:
-                                        elf_info = elf.get_info(elf_name)
-                                except elf.ElfError as e:
-                                        raise TransactionContentError(e)
+        return (str(self.fmri), "PUBLISHED")
 
-                                try:
-                                        # Check which content checksums to
-                                        # compute and add to the action
-                                        elf1 = "elfhash"
+    def publish_package(self):
+        """This method is called by the server to publish a package.
 
-                                        if elf1 in \
-                                            digest.LEGACY_CONTENT_HASH_ATTRS:
-                                                get_sha1 = True
-                                        else:
-                                                get_sha1 = False
+        It moves the files associated with the transaction into the
+        appropriate position in the server repository.  Callers
+        shall supply a fmri, repo store, and transaction in fmri,
+        rstore, and trans, respectively."""
 
-                                        hashes = elf.get_hashes(elf_name,
-                                            elfhash=get_sha1)
+        pkg_name = self.fmri.pkg_name
 
-                                        if get_sha1:
-                                                action.attrs[elf1] = hashes[elf1]
+        # mv manifest to pkg_name / version
+        src_mpath = os.path.join(self.dir, "manifest")
+        dest_mpath = self.rstore.manifest(self.fmri)
+        misc.makedirs(os.path.dirname(dest_mpath))
+        portable.rename(src_mpath, dest_mpath)
 
-                                except elf.ElfError:
-                                        pass
-                                action.attrs["elfbits"] = str(elf_info["bits"])
-                                action.attrs["elfarch"] = elf_info["arch"]
-                                os.unlink(elf_name)
+        # Move each file to file_root, with appropriate directory
+        # structure.
+        for f in os.listdir(self.dir):
+            if f == "append":
+                continue
+            src_path = os.path.join(self.dir, f)
+            self.rstore.cache_store.insert(f, src_path)
 
-                        try:
-                                dst_path = self.rstore.file(fname)
-                        except Exception as e:
-                                # The specific exception can't be named here due
-                                # to the cyclic dependency between this class
-                                # and the repository class.
-                                if getattr(e, "data", "") != fname:
-                                        raise
-                                dst_path = None
-
-                        csize, chashes = misc.compute_compressed_attrs(
-                            fname, dst_path, data, size, self.dir)
-                        for attr in chashes:
-                                action.attrs[attr] = chashes[attr]
-                        action.attrs["pkg.csize"] = csize
-
-                self.remaining_payload_cnt = \
-                    len(action.attrs.get("chain.sizes", "").split())
-
-                # Do some sanity checking on packages marked or being marked
-                # obsolete or renamed.
-                if action.name == "set" and \
-                    action.attrs["name"] == "pkg.obsolete" and \
-                    action.attrs["value"] == "true":
-                        self.obsolete = True
-                        if self.types_found.difference(
-                            set(("set", "signature"))):
-                                raise TransactionOperationError(_("An obsolete "
-                                    "package cannot contain actions other than "
-                                    "'set' and 'signature'."))
-                elif action.name == "set" and \
-                    action.attrs["name"] == "pkg.renamed" and \
-                    action.attrs["value"] == "true":
-                        self.renamed = True
-                        if self.types_found.difference(
-                            set(("depend", "set", "signature"))):
-                                raise TransactionOperationError(_("A renamed "
-                                    "package cannot contain actions other than "
-                                    "'set', 'depend', and 'signature'."))
-
-                if not self.has_reqdeps and action.name == "depend" and \
-                    action.attrs["type"] == "require":
-                        self.has_reqdeps = True
-
-                if self.obsolete and self.renamed:
-                        # Reset either obsolete or renamed, depending on which
-                        # action this was.
-                        if action.attrs["name"] == "pkg.obsolete":
-                                self.obsolete = False
-                        else:
-                                self.renamed = False
-                        raise TransactionOperationError(_("A package may not "
-                            " be marked for both obsoletion and renaming."))
-                elif self.obsolete and action.name not in ("set", "signature"):
-                        raise TransactionOperationError(_("A '{type}' action "
-                            "cannot be present in an obsolete package: "
-                            "{action}").format(
-                            type=action.name, action=action))
-                elif self.renamed and action.name not in \
-                    ("depend", "set", "signature"):
-                        raise TransactionOperationError(_("A '{type}' action "
-                            "cannot be present in a renamed package: "
-                            "{action}").format(
-                            type=action.name, action=action))
-
-                # Now that the action is known to be sane, we can add it to the
-                # manifest.
-                tfpath = os.path.join(self.dir, "manifest")
-                tfile = open(tfpath, "a+")
-                print(action, file=tfile)
-                tfile.close()
-
-                self.types_found.add(action.name)
-
-        def add_file(self, f, basename=None, size=None):
-                """Adds the file to the Transaction."""
-
-                # If basename provided, just store the file as-is with the
-                # basename.
-                if basename:
-                        fileneeded = True
-                        try:
-                                dst_path = self.rstore.file(basename)
-                                fileneeded = False
-                        except Exception as e:
-                                dst_path = os.path.join(self.dir, basename)
-
-                        if not fileneeded:
-                                return
-
-                        if isinstance(f, six.string_types):
-                                portable.copyfile(f, dst_path)
-                                return
-
-                        bufsz = 128 * 1024
-                        if bufsz > size:
-                                bufsz = size
-
-                        with open(dst_path, "wb") as wf:
-                                while True:
-                                        data = f.read(bufsz)
-                                        # data is bytes
-                                        if data == b"":
-                                                break
-                                        wf.write(data)
-                        return
-
-                hashes, data = misc.get_data_digest(f, length=size,
-                    return_content=True, hash_attrs=digest.DEFAULT_HASH_ATTRS,
-                    hash_algs=digest.HASH_ALGS)
-
-                if size is None:
-                        size = len(data)
-
-                fname = None
-                try:
-                        # We don't have an Action yet, so passing None is fine.
-                        default_hash_attr = digest.get_least_preferred_hash(
-                            None)[0]
-                        fname = hashes[default_hash_attr]
-                        dst_path = self.rstore.file(fname)
-                except Exception as e:
-                        # The specific exception can't be named here due
-                        # to the cyclic dependency between this class
-                        # and the repository class.
-                        if getattr(e, "data", "") != fname:
-                                raise
-                        dst_path = None
-
-                misc.compute_compressed_attrs(fname, dst_path,
-                    data, size, self.dir,
-                    chash_attrs=digest.DEFAULT_CHASH_ATTRS,
-                    chash_algs=digest.CHASH_ALGS)
-
-                self.remaining_payload_cnt -= 1
-
-        def add_manifest(self, f):
-                """Adds the manifest to the Transaction."""
-
-                if isinstance(f, six.string_types):
-                        f = open(f, "rb")
-                # Store the manifest file.
-                fpath = os.path.join(self.dir, "manifest")
-                with open(fpath, "ab+") as wf:
-                        try:
-                                misc.gunzip_from_stream(f, wf, ignore_hash=True)
-                                wf.seek(0)
-                                content = wf.read()
-                        except zlib.error:
-                                # No need to decompress it if it's not a gzipped
-                                # file.
-                                f.seek(0)
-                                content = f.read()
-                                wf.write(content)
-                # Do some sanity checking on packages marked or being marked
-                # obsolete or renamed.
-                m = pkg.manifest.Manifest()
-                m.set_content(misc.force_str(content))
-                for action in m.gen_actions():
-                        if action.name == "set" and \
-                            action.attrs["name"] == "pkg.obsolete" and \
-                            action.attrs["value"] == "true":
-                                self.obsolete = True
-                                if self.types_found.difference(
-                                    set(("set", "signature"))):
-                                        raise TransactionOperationError(_("An obsolete "
-                                            "package cannot contain actions other than "
-                                            "'set' and 'signature'."))
-                        elif action.name == "set" and \
-                            action.attrs["name"] == "pkg.renamed" and \
-                            action.attrs["value"] == "true":
-                                self.renamed = True
-                                if self.types_found.difference(
-                                    set(("depend", "set", "signature"))):
-                                        raise TransactionOperationError(_("A renamed "
-                                            "package cannot contain actions other than "
-                                            "'set', 'depend', and 'signature'."))
-
-                        if not self.has_reqdeps and action.name == "depend" and \
-                            action.attrs["type"] == "require":
-                                self.has_reqdeps = True
-
-                        if self.obsolete and self.renamed:
-                                # Reset either obsolete or renamed, depending on which
-                                # action this was.
-                                if action.attrs["name"] == "pkg.obsolete":
-                                        self.obsolete = False
-                                else:
-                                        self.renamed = False
-                                raise TransactionOperationError(_("A package may not "
-                                    " be marked for both obsoletion and renaming."))
-                        elif self.obsolete and action.name not in ("set", "signature"):
-                                raise TransactionOperationError(_("A '{type}' action "
-                                    "cannot be present in an obsolete package: "
-                                    "{action}").format(
-                                    type=action.name, action=action))
-                        elif self.renamed and action.name not in \
-                            ("depend", "set", "signature"):
-                                raise TransactionOperationError(_("A '{type}' action "
-                                    "cannot be present in a renamed package: "
-                                    "{action}").format(
-                            type=action.name, action=action))
-
-                        self.types_found.add(action.name)
-
-        def accept_publish(self, add_to_catalog=True):
-                """Transaction meets consistency criteria, and can be published.
-                Publish, making appropriate catalog entries."""
-
-                # Ensure that a renamed package has at least one dependency
-                if self.renamed and not self.has_reqdeps:
-                        raise TransactionOperationError(_("A renamed package "
-                            "must contain at least one 'depend' action."))
-
-                # XXX If we are going to publish, then we should augment
-                # our response with any other packages that moved to
-                # PUBLISHED due to the package's arrival.
-
-                self.publish_package()
-                if add_to_catalog:
-                        self.rstore.add_package(self.fmri)
-
-                return (str(self.fmri), "PUBLISHED")
-
-        def accept_append(self, add_to_catalog=True):
-                """Transaction meets consistency criteria, and can be published.
-                Publish, making appropriate catalog replacements."""
-
-                # Ensure that a renamed package has at least one dependency
-                if self.renamed and not self.has_reqdeps:
-                        raise TransactionOperationError(_("A renamed package "
-                            "must contain at least one 'depend' action."))
-
-                if self.remaining_payload_cnt > 0:
-                        raise TransactionOperationError(_("At least one "
-                            "certificate has not been delivered for the "
-                            "signature action."))
-
-                # XXX If we are going to publish, then we should augment
-                # our response with any other packages that moved to
-                # PUBLISHED due to the package's arrival.
-
-                self.publish_package()
-
-                if add_to_catalog:
-                        self.rstore.replace_package(self.fmri)
-
-                return (str(self.fmri), "PUBLISHED")
-
-        def publish_package(self):
-                """This method is called by the server to publish a package.
-
-                It moves the files associated with the transaction into the
-                appropriate position in the server repository.  Callers
-                shall supply a fmri, repo store, and transaction in fmri,
-                rstore, and trans, respectively."""
-
-                pkg_name = self.fmri.pkg_name
-
-                # mv manifest to pkg_name / version
-                src_mpath = os.path.join(self.dir, "manifest")
-                dest_mpath = self.rstore.manifest(self.fmri)
-                misc.makedirs(os.path.dirname(dest_mpath))
-                portable.rename(src_mpath, dest_mpath)
-
-                # Move each file to file_root, with appropriate directory
-                # structure.
-                for f in os.listdir(self.dir):
-                        if f == "append":
-                                continue
-                        src_path = os.path.join(self.dir, f)
-                        self.rstore.cache_store.insert(f, src_path)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/sha512_t.py
+++ b/src/modules/sha512_t.py
@@ -59,7 +59,6 @@ For example:
 
 
 class SHA512_t(object):
-
     def __init__(self, message=None, t=256):
         self.ctx = ffi.new("SHA2_CTX *")
         if t == 256:
@@ -67,13 +66,14 @@ class SHA512_t(object):
         elif t == 224:
             lib.SHA2Init(lib.SHA512_224, self.ctx)
         else:
-            raise ValueError("The module only supports "
-                             "SHA512/256 or SHA512/224.")
+            raise ValueError(
+                "The module only supports " "SHA512/256 or SHA512/224."
+            )
 
         self.hash_size = t
 
         if message:
-                self.update(message)
+            self.update(message)
 
     def update(self, message):
         """Update the hash object with the string arguments."""
@@ -104,7 +104,9 @@ class SHA512_t(object):
 
         # import goes here to prevent circular import
         from pkg.misc import binary_to_hex
+
         return binary_to_hex(self.digest())
+
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/site_paths/__init__.py
+++ b/src/modules/site_paths/__init__.py
@@ -33,28 +33,38 @@
 from site import getsitepackages, getusersitepackages, addsitedir
 import os, sys
 
+
 def strip_site():
-        strip = getsitepackages()
-        strip.append(getusersitepackages())
-        sys.path = [d for d in sys.path if d not in strip
-            and not d.endswith('.zip')]
+    strip = getsitepackages()
+    strip.append(getusersitepackages())
+    sys.path = [
+        d for d in sys.path if d not in strip and not d.endswith(".zip")
+    ]
+
 
 def add_pkglib():
-        # If PYTHONPATH is set in the environment and the environment is not
-        # being ignored, then don't adjust the path. This could, for example,
-        # be running under the testsuite.
-        if ('PYTHONPATH' in os.environ and
-            not getattr(sys.flags, 'ignore_environment')):
-                return
-        import platform
-        sys.path, remainder = sys.path[:2], sys.path[2:]
-        addsitedir("/usr/lib/pkg/python{}".format(
-            '.'.join(platform.python_version_tuple()[:2])))
-        sys.path.extend(remainder)
+    # If PYTHONPATH is set in the environment and the environment is not
+    # being ignored, then don't adjust the path. This could, for example,
+    # be running under the testsuite.
+    if "PYTHONPATH" in os.environ and not getattr(
+        sys.flags, "ignore_environment"
+    ):
+        return
+    import platform
+
+    sys.path, remainder = sys.path[:2], sys.path[2:]
+    addsitedir(
+        "/usr/lib/pkg/python{}".format(
+            ".".join(platform.python_version_tuple()[:2])
+        )
+    )
+    sys.path.extend(remainder)
+
 
 def init():
-        strip_site()
-        add_pkglib()
+    strip_site()
+    add_pkglib()
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/smf.py
+++ b/src/modules/smf.py
@@ -40,220 +40,238 @@ from six.moves.urllib.parse import urlparse
 logger = global_settings.logger
 
 # range of possible SMF service states
-SMF_SVC_UNKNOWN      = 0
-SMF_SVC_DISABLED     = 1
-SMF_SVC_MAINTENANCE  = 2
+SMF_SVC_UNKNOWN = 0
+SMF_SVC_DISABLED = 1
+SMF_SVC_MAINTENANCE = 2
 SMF_SVC_TMP_DISABLED = 3
-SMF_SVC_TMP_ENABLED  = 4
-SMF_SVC_ENABLED      = 5
+SMF_SVC_TMP_ENABLED = 4
+SMF_SVC_ENABLED = 5
 
-EXIT_OK              = 0
-EXIT_FATAL           = 1
-EXIT_INVALID_OPTION  = 2
-EXIT_INSTANCE        = 3
-EXIT_DEPENDENCY      = 4
-EXIT_TIMEOUT         = 5
+EXIT_OK = 0
+EXIT_FATAL = 1
+EXIT_INVALID_OPTION = 2
+EXIT_INSTANCE = 3
+EXIT_DEPENDENCY = 4
+EXIT_TIMEOUT = 5
 
 svcprop_path = "/usr/bin/svcprop"
-svcadm_path  = "/usr/sbin/svcadm"
+svcadm_path = "/usr/sbin/svcadm"
 svccfg_path = "/usr/sbin/svccfg"
 svcs_path = "/usr/bin/svcs"
 zlogin_path = "/usr/sbin/zlogin"
 
-class NonzeroExitException(Exception):
-        def __init__(self, cmd, return_code, output):
-                self.cmd = cmd
-                self.return_code = return_code
-                self.output = output
 
-        def __str__(self):
-                return "Cmd {0} exited with status {1:d}, and output '{2}'".format(
-                    self.cmd, self.return_code, self.output)
+class NonzeroExitException(Exception):
+    def __init__(self, cmd, return_code, output):
+        self.cmd = cmd
+        self.return_code = return_code
+        self.output = output
+
+    def __str__(self):
+        return "Cmd {0} exited with status {1:d}, and output '{2}'".format(
+            self.cmd, self.return_code, self.output
+        )
 
 
 def __call(args, zone=None):
-        # a way to invoke a separate executable for testing
-        cmds_dir = DebugValues.get_value("smf_cmds_dir")
-        # returned values will be in the user's locale
-        # so we need to ensure that the force_str uses
-        # their locale.
-        encoding = locale.getpreferredencoding(do_setlocale=False)
-        if cmds_dir:
-                args = (
-                    os.path.join(cmds_dir,
-                    args[0].lstrip("/")),) + args[1:]
-        if zone:
-                cmd = DebugValues.get_value("bin_zlogin")
-                if cmd is None:
-                        cmd = zlogin_path
-                args = (cmd, zone) + args
+    # a way to invoke a separate executable for testing
+    cmds_dir = DebugValues.get_value("smf_cmds_dir")
+    # returned values will be in the user's locale
+    # so we need to ensure that the force_str uses
+    # their locale.
+    encoding = locale.getpreferredencoding(do_setlocale=False)
+    if cmds_dir:
+        args = (os.path.join(cmds_dir, args[0].lstrip("/")),) + args[1:]
+    if zone:
+        cmd = DebugValues.get_value("bin_zlogin")
+        if cmd is None:
+            cmd = zlogin_path
+        args = (cmd, zone) + args
 
-        try:
-                proc = subprocess.Popen(args, stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT)
-                buf = [misc.force_str(l, encoding=encoding)
-                       for l in proc.stdout.readlines()]
-                ret = proc.wait()
-        except OSError as e:
-                raise RuntimeError("cannot execute {0}: {1}".format(args, e))
+    try:
+        proc = subprocess.Popen(
+            args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        buf = [
+            misc.force_str(l, encoding=encoding)
+            for l in proc.stdout.readlines()
+        ]
+        ret = proc.wait()
+    except OSError as e:
+        raise RuntimeError("cannot execute {0}: {1}".format(args, e))
 
-        if ret != 0:
-                raise NonzeroExitException(args, ret, buf)
-        return buf
+    if ret != 0:
+        raise NonzeroExitException(args, ret, buf)
+    return buf
+
 
 def get_state(fmri, zone=None):
-        """ return state of smf service """
+    """return state of smf service"""
 
-        props = get_props(fmri, zone=zone)
-        if not props:
-                return SMF_SVC_UNKNOWN
+    props = get_props(fmri, zone=zone)
+    if not props:
+        return SMF_SVC_UNKNOWN
 
-        if "maintenance" in props.get("restarter/state", []):
-                return SMF_SVC_MAINTENANCE
+    if "maintenance" in props.get("restarter/state", []):
+        return SMF_SVC_MAINTENANCE
 
-        status = props.get("general_ovr/enabled", None)
-        if status is not None:
-                if "true" in status:
-                        return SMF_SVC_TMP_ENABLED
-                return SMF_SVC_TMP_DISABLED
-        status = props.get("general/enabled", None)
-        if status is not None and "true" in status:
-                return SMF_SVC_ENABLED
-        return SMF_SVC_DISABLED
+    status = props.get("general_ovr/enabled", None)
+    if status is not None:
+        if "true" in status:
+            return SMF_SVC_TMP_ENABLED
+        return SMF_SVC_TMP_DISABLED
+    status = props.get("general/enabled", None)
+    if status is not None and "true" in status:
+        return SMF_SVC_ENABLED
+    return SMF_SVC_DISABLED
+
 
 def is_disabled(fmri, zone=None):
-        return get_state(fmri, zone=zone) < SMF_SVC_TMP_ENABLED
+    return get_state(fmri, zone=zone) < SMF_SVC_TMP_ENABLED
+
 
 def check_fmris(attr, fmris, zone=None):
-        """ Walk a set of fmris checking that each is fully specifed with
-        an instance.
-        If an FMRI is not fully specified and does not contain at least
-        one special match character from fnmatch(7) the fmri is dropped
-        from the set that is returned and an error message is logged.
-        """
+    """Walk a set of fmris checking that each is fully specifed with
+    an instance.
+    If an FMRI is not fully specified and does not contain at least
+    one special match character from fnmatch(7) the fmri is dropped
+    from the set that is returned and an error message is logged.
+    """
 
-        if isinstance(fmris, six.string_types):
-                fmris = set([fmris])
-        chars = "*?[!^"
-        for fmri in fmris.copy():
-                is_glob = False
-                for c in chars:
-                        if c in fmri:
-                                is_glob = True
+    if isinstance(fmris, six.string_types):
+        fmris = set([fmris])
+    chars = "*?[!^"
+    for fmri in fmris.copy():
+        is_glob = False
+        for c in chars:
+            if c in fmri:
+                is_glob = True
 
-                tmp_fmri = fmri
-                if fmri.startswith("svc:"):
-                        tmp_fmri = fmri.replace("svc:", "", 1)
+        tmp_fmri = fmri
+        if fmri.startswith("svc:"):
+            tmp_fmri = fmri.replace("svc:", "", 1)
 
-                # check to see if we've got an instance already
-                if ":" in tmp_fmri and not is_glob:
-                        continue
+        # check to see if we've got an instance already
+        if ":" in tmp_fmri and not is_glob:
+            continue
 
-                fmris.remove(fmri)
-                if is_glob:
-                        cmd = (svcs_path, "-H", "-o", "fmri", "{0}".format(fmri))
-                        try:
-                                instances = __call(cmd, zone=zone)
-                                for instance in instances:
-                                        fmris.add(instance.rstrip())
-                        except NonzeroExitException:
-                                continue # non-zero exit == not installed
+        fmris.remove(fmri)
+        if is_glob:
+            cmd = (svcs_path, "-H", "-o", "fmri", "{0}".format(fmri))
+            try:
+                instances = __call(cmd, zone=zone)
+                for instance in instances:
+                    fmris.add(instance.rstrip())
+            except NonzeroExitException:
+                continue  # non-zero exit == not installed
 
-                else:
-                        logger.error(_("FMRI pattern might implicitly match " \
-                            "more than one service instance."))
-                        logger.error(_("Actuators for {attr} will not be run " \
-                            "for {fmri}.").format(**locals()))
-        return fmris
+        else:
+            logger.error(
+                _(
+                    "FMRI pattern might implicitly match "
+                    "more than one service instance."
+                )
+            )
+            logger.error(
+                _("Actuators for {attr} will not be run " "for {fmri}.").format(
+                    **locals()
+                )
+            )
+    return fmris
+
 
 def get_props(svcfmri, zone=None):
-        args = (svcprop_path, "-c", svcfmri)
+    args = (svcprop_path, "-c", svcfmri)
 
-        try:
-                buf = __call(args, zone=zone)
-        except NonzeroExitException:
-                return {} # empty output == not installed
+    try:
+        buf = __call(args, zone=zone)
+    except NonzeroExitException:
+        return {}  # empty output == not installed
 
-        return dict([
-            l.strip().split(None, 1)
-            for l in buf
-        ])
+    return dict([l.strip().split(None, 1) for l in buf])
+
 
 def set_prop(fmri, prop, value, zone=None):
-        args = (svccfg_path, "-s", fmri, "setprop", "{0}={1}".format(prop,
-            value))
-        __call(args, zone=zone)
+    args = (svccfg_path, "-s", fmri, "setprop", "{0}={1}".format(prop, value))
+    __call(args, zone=zone)
+
 
 def get_prop(fmri, prop, zone=None):
-        args = (svcprop_path, "-c", "-p", prop, fmri)
-        buf = __call(args, zone=zone)
-        assert len(buf) == 1, "Was expecting one entry, got:{0}".format(buf)
-        buf = buf[0].rstrip("\n")
-        return buf
+    args = (svcprop_path, "-c", "-p", prop, fmri)
+    buf = __call(args, zone=zone)
+    assert len(buf) == 1, "Was expecting one entry, got:{0}".format(buf)
+    buf = buf[0].rstrip("\n")
+    return buf
+
 
 def enable(fmris, temporary=False, sync_timeout=0, zone=None):
-        if not fmris:
-                return
-        if isinstance(fmris, six.string_types):
-                fmris = (fmris,)
+    if not fmris:
+        return
+    if isinstance(fmris, six.string_types):
+        fmris = (fmris,)
 
-        args = [svcadm_path, "enable"]
-        if sync_timeout:
-                args.append("-s")
-#                if sync_timeout != -1:
-#                        args.append("-T {0:d}".format(sync_timeout))
-        if temporary:
-                args.append("-t")
-        # fmris could be a list so explicit cast is necessary
-        __call(tuple(args) + tuple(fmris), zone=zone)
+    args = [svcadm_path, "enable"]
+    if sync_timeout:
+        args.append("-s")
+    #                if sync_timeout != -1:
+    #                        args.append("-T {0:d}".format(sync_timeout))
+    if temporary:
+        args.append("-t")
+    # fmris could be a list so explicit cast is necessary
+    __call(tuple(args) + tuple(fmris), zone=zone)
+
 
 def disable(fmris, temporary=False, sync_timeout=0, zone=None):
-        if not fmris:
-                return
-        if isinstance(fmris, six.string_types):
-                fmris = (fmris,)
-        args = [svcadm_path, "disable", "-s"]
-#        if sync_timeout > 0:
-#                args.append("-T {0:d}".format(sync_timeout))
-        if temporary:
-                args.append("-t")
-        # fmris could be a list so explicit cast is necessary
-        __call(tuple(args) + tuple(fmris), zone=zone)
+    if not fmris:
+        return
+    if isinstance(fmris, six.string_types):
+        fmris = (fmris,)
+    args = [svcadm_path, "disable", "-s"]
+    #        if sync_timeout > 0:
+    #                args.append("-T {0:d}".format(sync_timeout))
+    if temporary:
+        args.append("-t")
+    # fmris could be a list so explicit cast is necessary
+    __call(tuple(args) + tuple(fmris), zone=zone)
+
 
 def mark(state, fmris, zone=None):
-        if not fmris:
-                return
-        if isinstance(fmris, six.string_types):
-                fmris = (fmris,)
-        args = [svcadm_path, "mark", state]
-        # fmris could be a list so explicit cast is necessary
-        __call(tuple(args) + tuple(fmris), zone=zone)
+    if not fmris:
+        return
+    if isinstance(fmris, six.string_types):
+        fmris = (fmris,)
+    args = [svcadm_path, "mark", state]
+    # fmris could be a list so explicit cast is necessary
+    __call(tuple(args) + tuple(fmris), zone=zone)
+
 
 def refresh(fmris, sync_timeout=0, zone=None):
-        if not fmris:
-                return
-        if isinstance(fmris, six.string_types):
-                fmris = (fmris,)
-        args = [svcadm_path, "refresh"]
-        if sync_timeout:
-                args.append("-s")
-#                if sync_timeout != -1:
-#                        args.append("-T {0:d}".format(sync_timeout))
-        # fmris could be a list so explicit cast is necessary
-        __call(tuple(args) + tuple(fmris), zone=zone)
+    if not fmris:
+        return
+    if isinstance(fmris, six.string_types):
+        fmris = (fmris,)
+    args = [svcadm_path, "refresh"]
+    if sync_timeout:
+        args.append("-s")
+    #                if sync_timeout != -1:
+    #                        args.append("-T {0:d}".format(sync_timeout))
+    # fmris could be a list so explicit cast is necessary
+    __call(tuple(args) + tuple(fmris), zone=zone)
+
 
 def restart(fmris, sync_timeout=0, zone=None):
-        if not fmris:
-                return
-        if isinstance(fmris, six.string_types):
-                fmris = (fmris,)
-        args = [svcadm_path, "restart"]
-        if sync_timeout:
-                args.append("-s")
-#                if sync_timeout != -1:
-#                        args.append("-T {0:d}".format(sync_timeout))
-        # fmris could be a list so explicit cast is necessary
-        __call(tuple(args) + tuple(fmris), zone=zone)
+    if not fmris:
+        return
+    if isinstance(fmris, six.string_types):
+        fmris = (fmris,)
+    args = [svcadm_path, "restart"]
+    if sync_timeout:
+        args.append("-s")
+    #                if sync_timeout != -1:
+    #                        args.append("-T {0:d}".format(sync_timeout))
+    # fmris could be a list so explicit cast is necessary
+    __call(tuple(args) + tuple(fmris), zone=zone)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/sysattr.py
+++ b/src/modules/sysattr.py
@@ -35,8 +35,16 @@ F_ATTR_ALL = lib.F_ATTR_ALL
 def is_supported(attr):
     """Test if a sys attr is not in the list of ignored attributes."""
 
-    ignore = [lib.F_OWNERSID, lib.F_GROUPSID, lib.F_AV_SCANSTAMP,
-              lib.F_OPAQUE, lib.F_CRTIME, lib.F_FSID, lib.F_GEN, lib.F_REPARSE]
+    ignore = [
+        lib.F_OWNERSID,
+        lib.F_GROUPSID,
+        lib.F_AV_SCANSTAMP,
+        lib.F_OPAQUE,
+        lib.F_CRTIME,
+        lib.F_FSID,
+        lib.F_GEN,
+        lib.F_REPARSE,
+    ]
 
     for i in ignore:
         if i == attr:
@@ -50,6 +58,7 @@ def fgetattr(filename, compact=False):
     return a string consisting of compact option identifiers."""
 
     from pkg.misc import force_text
+
     if not isinstance(filename, six.string_types):
         raise TypeError("filename must be string type")
 
@@ -120,6 +129,7 @@ def fsetattr(filename, attr):
     """
 
     from pkg.misc import force_bytes
+
     if not isinstance(filename, six.string_types):
         raise TypeError("filename must be string type")
     if not attr:
@@ -147,20 +157,32 @@ def fsetattr(filename, attr):
 
         if sys_attr == lib.F_ATTR_INVAL:
             if compact:
-                raise ValueError("{0} is not a valid compact system "
-                                 "attribute".format(attr))
+                raise ValueError(
+                    "{0} is not a valid compact system "
+                    "attribute".format(attr)
+                )
             else:
-                raise ValueError("{0} is not a valid verbose system "
-                                 "attribute".format(attr))
+                raise ValueError(
+                    "{0} is not a valid verbose system "
+                    "attribute".format(attr)
+                )
         if not is_supported(sys_attr):
             if compact:
-                raise ValueError("{0} is not a supported compact system "
-                                 "attribute".format(attr))
+                raise ValueError(
+                    "{0} is not a supported compact system "
+                    "attribute".format(attr)
+                )
             else:
-                raise ValueError("{0} is not a supported verbose system "
-                                 "attribute".format(attr))
-        if lib.nvlist_add_boolean_value(request[0], lib.attr_to_name(sys_attr),
-                                        1) != 0:
+                raise ValueError(
+                    "{0} is not a supported verbose system "
+                    "attribute".format(attr)
+                )
+        if (
+            lib.nvlist_add_boolean_value(
+                request[0], lib.attr_to_name(sys_attr), 1
+            )
+            != 0
+        ):
             raise OSError(ffi.errno, os.strerror(ffi.errno))
 
     fd = os.open(filename, os.O_RDONLY)
@@ -176,12 +198,13 @@ def fsetattr(filename, attr):
 def get_attr_dict():
     """Get a dictionary containing all supported system attributes in the form:
 
-        { <verbose_name>: <compact_option>,
-          ...
-        }
+    { <verbose_name>: <compact_option>,
+      ...
+    }
     """
 
     from pkg.misc import force_text
+
     sys_attrs = {}
     for i in range(F_ATTR_ALL):
         if not is_supported(i):
@@ -191,5 +214,6 @@ def get_attr_dict():
         sys_attrs.setdefault(key, value)
     return sys_attrs
 
+
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/syscallat.py
+++ b/src/modules/syscallat.py
@@ -95,5 +95,6 @@ def unlinkat(dirfd, path, flag):
     if rv < 0:
         raise OSError(ffi.errno, os.strerror(ffi.errno), path)
 
+
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/sysvpkg.py
+++ b/src/modules/sysvpkg.py
@@ -45,69 +45,82 @@ import sys
 from pkg.cpiofile import CpioFile
 from pkg.dependency import Dependency
 
-__all__ = [ 'SolarisPackage' ]
+__all__ = ["SolarisPackage"]
 
 PKG_MAGIC = "# PaCkAgE DaTaStReAm"
 PKG_HDR_END = "# end of header"
 
+
 class PkgMapLine(object):
-        """A class that represents a single line of a SysV package's pkgmap.
+    """A class that represents a single line of a SysV package's pkgmap.
 
-        XXX This class should probably disappear once pkg.manifest? is a bit
-        more fleshed out.
-        """
+    XXX This class should probably disappear once pkg.manifest? is a bit
+    more fleshed out.
+    """
 
-        def __init__(self, line, basedir = ""):
-                array = line.split()
-                try:
-                        self.part = int(array[0])
-                except ValueError:
-                        self.part = 1
-                        array[0:0] = "1"
+    def __init__(self, line, basedir=""):
+        array = line.split()
+        try:
+            self.part = int(array[0])
+        except ValueError:
+            self.part = 1
+            array[0:0] = "1"
 
-                self.type = array[1]
-                self.klass = None
+        self.type = array[1]
+        self.klass = None
 
-                if self.type == 'i':
-                        (self.pathname, self.size, self.chksum,
-                            self.modtime) = array[2:]
-                        return
+        if self.type == "i":
+            (self.pathname, self.size, self.chksum, self.modtime) = array[2:]
+            return
 
-                self.klass = array[2]
+        self.klass = array[2]
 
-                if self.type == 'f' or self.type == 'e' or self.type == 'v':
-                        (self.pathname, self.mode, self.owner, self.group,
-                            self.size, self.chksum, self.modtime) = array[3:]
+        if self.type == "f" or self.type == "e" or self.type == "v":
+            (
+                self.pathname,
+                self.mode,
+                self.owner,
+                self.group,
+                self.size,
+                self.chksum,
+                self.modtime,
+            ) = array[3:]
 
-                elif self.type == 'b' or self.type == 'c':
-                        (self.pathname, self.major, self.minor, self.mode,
-                            self.owner, self.group) = array[3:]
+        elif self.type == "b" or self.type == "c":
+            (
+                self.pathname,
+                self.major,
+                self.minor,
+                self.mode,
+                self.owner,
+                self.group,
+            ) = array[3:]
 
-                elif self.type == 'd' or self.type == 'x' or self.type == 'p':
-                        (self.pathname, self.mode, self.owner, self.group) = \
-                                array[3:]
+        elif self.type == "d" or self.type == "x" or self.type == "p":
+            (self.pathname, self.mode, self.owner, self.group) = array[3:]
 
-                elif self.type == 'l' or self.type == 's':
-                        (self.pathname, self.target) = array[3].split('=')
-                        self.target = self.target.replace("$BASEDIR", basedir)
-                else:
-                        raise ValueError("Invalid file type: " + self.type)
+        elif self.type == "l" or self.type == "s":
+            (self.pathname, self.target) = array[3].split("=")
+            self.target = self.target.replace("$BASEDIR", basedir)
+        else:
+            raise ValueError("Invalid file type: " + self.type)
 
-                # some packages have $BASEDIR in the pkgmap; this needs to
-                # be handled specially
-                if "$BASEDIR" in self.pathname:
-                        self.pathname = self.pathname.replace("$BASEDIR", basedir)
-                        # this will cause the pkg to have a NULL path after 
-                        # basedir removal, which breaks things.  Make this
-                        # entry go away by pretending it is an 'i' type file.
-                        if self.pathname == basedir:
-                                self.type = 'i'
-                else:
-                        self.pathname = os.path.join(basedir, self.pathname)
+        # some packages have $BASEDIR in the pkgmap; this needs to
+        # be handled specially
+        if "$BASEDIR" in self.pathname:
+            self.pathname = self.pathname.replace("$BASEDIR", basedir)
+            # this will cause the pkg to have a NULL path after
+            # basedir removal, which breaks things.  Make this
+            # entry go away by pretending it is an 'i' type file.
+            if self.pathname == basedir:
+                self.type = "i"
+        else:
+            self.pathname = os.path.join(basedir, self.pathname)
 
 
 class MultiPackageDatastreamException(Exception):
-        pass
+    pass
+
 
 # XXX This needs to have a constructor that takes a pkg: FMRI (the new name of
 # the package). - sch
@@ -116,187 +129,183 @@ class MultiPackageDatastreamException(Exception):
 # constructor be able to interpret path as a URI, or should we have an optional
 # "fileobj" argument which can point to an http stream?
 class SolarisPackage(object):
-        """A SolarisPackage represents a System V package for Solaris.
+    """A SolarisPackage represents a System V package for Solaris."""
+
+    def __init__(self, path):
+        """The constructor for the SolarisPackage class.
+
+        The "path" argument may be a directory -- in which case it is
+        assumed to be a directory-format package -- or a file -- in
+        which case it's tested whether or not it's a datastream package.
         """
-
-        def __init__(self, path):
-                """The constructor for the SolarisPackage class.
-
-                The "path" argument may be a directory -- in which case it is
-                assumed to be a directory-format package -- or a file -- in
-                which case it's tested whether or not it's a datastream package.
-                """
-                if os.path.isfile(path):
-                        f = open(path)
-                        if f.readline().strip() == PKG_MAGIC:
-                                fo = f
-                        else:
-                                f.seek(0)
-                                try:
-                                        g = gzip.GzipFile(fileobj=f)
-                                        if g.readline().rstrip() == PKG_MAGIC:
-                                                fo = g
-                                        else:
-                                                raise IOError("not a package")
-                                except IOError as e:
-                                        if e.args[0] not in (
-                                            "Not a gzipped file",
-                                            "not a package"):
-                                                raise
-                                        else:
-                                                g.close()
-                                                raise ValueError("{0} is not a package".format(path))
-
-                        pkgs = []
-                        while True:
-                                line = fo.readline().rstrip()
-                                if line == PKG_HDR_END:
-                                        break
-                                pkgs += [ line.split()[0] ]
-
-                        if len(pkgs) > 1:
-                                raise MultiPackageDatastreamException(
-                                    "{0} contains {1} packages".format(
-                                    path, len(pkgs)))
-
-                        # The cpio archive containing all the packages' pkginfo
-                        # and pkgmap files starts on the next 512-byte boundary
-                        # after the header, so seek to that point.
-                        fo.seek(fo.tell() + 512 - fo.tell() % 512)
-                        self.datastream = CpioFile.open(mode="r|", fileobj=fo)
-
-                        # We're going to need to extract and cache the contents
-                        # of the pkginfo and pkgmap files because we're not
-                        # guaranteed random access to the datastream.  At least
-                        # they should be reasonably small in size; the largest
-                        # delivered in Solaris is a little over 2MB.
-                        for ci in self.datastream:
-                                if ci.name.endswith("/pkginfo"):
-                                        self._pkginfo = self.datastream.extractfile(ci).readlines()
-                                elif ci.name.endswith("/pkgmap"):
-                                        self._pkgmap = self.datastream.extractfile(ci).readlines()
-
-                        # XXX Here we allow for only one package.  :(
-                        self.datastream = self.datastream.get_next_archive()
-
-                else:
-                        self.datastream = None
-                        self.pkgpath = path
-
-                self.pkginfo = self.readPkginfoFile()
-                # Snag BASEDIR, and remove leading and trailing slashes.
+        if os.path.isfile(path):
+            f = open(path)
+            if f.readline().strip() == PKG_MAGIC:
+                fo = f
+            else:
+                f.seek(0)
                 try:
-                        assert self.pkginfo["BASEDIR"][0] == "/"
-                        self.basedir = self.pkginfo["BASEDIR"][1:].rstrip("/")
-                except KeyError:
-                        self.basedir = ""
-                self.deps = self.readDependFile()
-                self.manifest = self.readPkgmapFile()
+                    g = gzip.GzipFile(fileobj=f)
+                    if g.readline().rstrip() == PKG_MAGIC:
+                        fo = g
+                    else:
+                        raise IOError("not a package")
+                except IOError as e:
+                    if e.args[0] not in ("Not a gzipped file", "not a package"):
+                        raise
+                    else:
+                        g.close()
+                        raise ValueError("{0} is not a package".format(path))
 
-        def readDependFile(self):
-                # XXX This is obviously bogus, but the dependency information is
-                # in the main archive, which we haven't read in the constructor
-                if self.datastream:
-                        return []
+            pkgs = []
+            while True:
+                line = fo.readline().rstrip()
+                if line == PKG_HDR_END:
+                    break
+                pkgs += [line.split()[0]]
 
+            if len(pkgs) > 1:
+                raise MultiPackageDatastreamException(
+                    "{0} contains {1} packages".format(path, len(pkgs))
+                )
+
+            # The cpio archive containing all the packages' pkginfo
+            # and pkgmap files starts on the next 512-byte boundary
+            # after the header, so seek to that point.
+            fo.seek(fo.tell() + 512 - fo.tell() % 512)
+            self.datastream = CpioFile.open(mode="r|", fileobj=fo)
+
+            # We're going to need to extract and cache the contents
+            # of the pkginfo and pkgmap files because we're not
+            # guaranteed random access to the datastream.  At least
+            # they should be reasonably small in size; the largest
+            # delivered in Solaris is a little over 2MB.
+            for ci in self.datastream:
+                if ci.name.endswith("/pkginfo"):
+                    self._pkginfo = self.datastream.extractfile(ci).readlines()
+                elif ci.name.endswith("/pkgmap"):
+                    self._pkgmap = self.datastream.extractfile(ci).readlines()
+
+            # XXX Here we allow for only one package.  :(
+            self.datastream = self.datastream.get_next_archive()
+
+        else:
+            self.datastream = None
+            self.pkgpath = path
+
+        self.pkginfo = self.readPkginfoFile()
+        # Snag BASEDIR, and remove leading and trailing slashes.
+        try:
+            assert self.pkginfo["BASEDIR"][0] == "/"
+            self.basedir = self.pkginfo["BASEDIR"][1:].rstrip("/")
+        except KeyError:
+            self.basedir = ""
+        self.deps = self.readDependFile()
+        self.manifest = self.readPkgmapFile()
+
+    def readDependFile(self):
+        # XXX This is obviously bogus, but the dependency information is
+        # in the main archive, which we haven't read in the constructor
+        if self.datastream:
+            return []
+
+        try:
+            fp = open(self.pkgpath + "/install/depend")
+        except IOError as xxx_todo_changeme:
+            # Missing depend file is just fine
+            (err, msg) = xxx_todo_changeme.args
+            # Missing depend file is just fine
+            if err == errno.ENOENT:
+                return []
+            else:
+                raise
+
+        deps = []
+        for line in fp:
+            line = line.rstrip("\n")
+
+            if len(line) == 0 or line[0] == "#":
+                continue
+
+            if line[0] == "P":
                 try:
-                        fp = open(self.pkgpath + "/install/depend")
-                except IOError as xxx_todo_changeme:
-                        # Missing depend file is just fine
-                        (err, msg) = xxx_todo_changeme.args
-                        # Missing depend file is just fine
-                        if err == errno.ENOENT:
-                                return []
-                        else:
-                                raise
+                    type, pkg, desc = line.split(None, 2)
+                except ValueError:
+                    type, pkg = line.split()
+                deps += [Dependency(self.pkginfo["PKG"], pkg)]
 
-                deps = []
-                for line in fp:
-                        line = line.rstrip('\n')
+        return deps
 
-                        if len(line) == 0 or line[0] == '#':
-                                continue
+    def readPkginfoFile(self):
+        pkginfo = {}
 
-                        if line[0] == 'P':
-                                try:
-                                        type, pkg, desc = line.split(None, 2)
-                                except ValueError:
-                                        type, pkg = line.split()
-                                deps += [ Dependency(self.pkginfo['PKG'], pkg) ]
+        if self.datastream:
+            fp = self._pkginfo
+        else:
+            fp = open(self.pkgpath + "/pkginfo")
 
-                return deps
+        for line in fp:
+            line = line.lstrip().rstrip("\n")
 
-        def readPkginfoFile(self):
-                pkginfo = {}
+            if len(line) == 0:
+                continue
 
-                if self.datastream:
-                        fp = self._pkginfo
-                else:
-                        fp = open(self.pkgpath + "/pkginfo")
+            # Eliminate comments, but special-case the faspac turd.
+            if line[0] == "#":
+                if line.startswith("#FASPACD="):
+                    pkginfo["faspac"] = line.lstrip("#FASPACD=").split()
+                continue
 
-                for line in fp:
-                        line = line.lstrip().rstrip('\n')
+            (key, val) = line.split("=", 1)
+            pkginfo[key] = val.strip('"')
 
-                        if len(line) == 0:
-                                continue
+        # Expose the platform-specific package name, too.
+        platext = {
+            "i386.i86pc": ".i",
+            "sparc.sun4u": ".u",
+            "sparc.sun4v": ".v",
+        }
+        pkginfo["PKG.PLAT"] = pkginfo["PKG"] + platext.get(pkginfo["ARCH"], "")
 
-                        # Eliminate comments, but special-case the faspac turd.
-                        if line[0] == '#':
-                                if line.startswith("#FASPACD="):
-                                        pkginfo["faspac"] = \
-                                            line.lstrip("#FASPACD=").split()
-                                continue
+        return pkginfo
 
-                        (key, val) = line.split('=', 1)
-                        pkginfo[key] = val.strip('"')
+    def readPkgmapFile(self):
+        pkgmap = []
 
-                # Expose the platform-specific package name, too.
-                platext = {
-                    "i386.i86pc": ".i",
-                    "sparc.sun4u": ".u",
-                    "sparc.sun4v": ".v",
-                }
-                pkginfo["PKG.PLAT"] = \
-                    pkginfo["PKG"] + platext.get(pkginfo["ARCH"], "")
+        if self.datastream:
+            fp = self._pkgmap
+        else:
+            fp = open(self.pkgpath + "/pkgmap")
 
-                return pkginfo
+        for line in fp:
+            line = line.rstrip("\n")
 
-        def readPkgmapFile(self):
-                pkgmap = []
+            if len(line) == 0 or line[0] == "#":
+                continue
 
-                if self.datastream:
-                        fp = self._pkgmap
-                else:
-                        fp = open(self.pkgpath + "/pkgmap")
+            if line[0] == ":":
+                continue
 
-                for line in fp:
-                        line = line.rstrip('\n')
+            pkgmap += [PkgMapLine(line, self.basedir)]
 
-                        if len(line) == 0 or line[0] == '#':
-                                continue
+        return pkgmap
 
-                        if line[0] == ':':
-                                continue
-
-                        pkgmap += [ PkgMapLine(line, self.basedir) ]
-
-                return pkgmap
 
 if __name__ == "__main__":
-        pkg = SolarisPackage(sys.argv[1])
+    pkg = SolarisPackage(sys.argv[1])
 
-        for key in sorted(pkg.pkginfo):
-                print(key + '=' + str(pkg.pkginfo[key]))
+    for key in sorted(pkg.pkginfo):
+        print(key + "=" + str(pkg.pkginfo[key]))
 
-        print()
+    print()
 
-        for obj in pkg.manifest:
-                print(obj.type + ' ' + obj.pathname)
+    for obj in pkg.manifest:
+        print(obj.type + " " + obj.pathname)
 
-        print()
+    print()
 
-        for d in pkg.deps:
-                print(d)
+    for d in pkg.deps:
+        print(d)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/updatelog.py
+++ b/src/modules/updatelog.py
@@ -33,193 +33,192 @@ import pkg.fmri as fmri
 import pkg.portable as portable
 import pkg.server.catalog as catalog
 
+
 class UpdateLogException(Exception):
-        def __init__(self, args=None):
-                self._args = args
+    def __init__(self, args=None):
+        self._args = args
+
 
 class UpdateLog(object):
-        """Compatibility class for receiving incremental catalog updates from
-        v0 repositories.
+    """Compatibility class for receiving incremental catalog updates from
+    v0 repositories.
 
-        The catalog format is a + or -, an isoformat timestamp, and a catalog
-        entry in server-side format.  They must be in order and separated by
-        spaces."""
+    The catalog format is a + or -, an isoformat timestamp, and a catalog
+    entry in server-side format.  They must be in order and separated by
+    spaces."""
 
-        @staticmethod
-        def recv(c, path, ts, pub):
-                """Take a connection object and a catalog path.  This method
-                receives a catalog from the server.  If it is an incremental
-                update, it is processed by the updatelog.  If it is a full
-                update, we call the catalog to handle the request.
-                Ts is the timestamp when the local copy of the catalog
-                was last modified."""
+    @staticmethod
+    def recv(c, path, ts, pub):
+        """Take a connection object and a catalog path.  This method
+        receives a catalog from the server.  If it is an incremental
+        update, it is processed by the updatelog.  If it is a full
+        update, we call the catalog to handle the request.
+        Ts is the timestamp when the local copy of the catalog
+        was last modified."""
 
-                update_type = c.getheader("X-Catalog-Type", "full")
+        update_type = c.getheader("X-Catalog-Type", "full")
 
-                try:
-                        if update_type == "incremental":
-                                UpdateLog._recv_updates(c, path, ts)
-                        else:
-                                catalog.ServerCatalog.recv(c, path, pub)
-                except EnvironmentError as e:
-                        if e.errno == errno.EACCES:
-                                raise api_errors.PermissionsException(
-                                    e.filename)
-                        if e.errno == errno.EROFS:
-                                raise api_errors.ReadOnlyFileSystemException(
-                                    e.filename)
-                        raise
+        try:
+            if update_type == "incremental":
+                UpdateLog._recv_updates(c, path, ts)
+            else:
+                catalog.ServerCatalog.recv(c, path, pub)
+        except EnvironmentError as e:
+            if e.errno == errno.EACCES:
+                raise api_errors.PermissionsException(e.filename)
+            if e.errno == errno.EROFS:
+                raise api_errors.ReadOnlyFileSystemException(e.filename)
+            raise
 
-        @staticmethod
-        def _recv_updates(filep, path, cts):
-                """A static method that takes a file-like object, a path, and a
-                timestamp.  It reads a stream as an incoming updatelog and
-                modifies the catalog on disk."""
+    @staticmethod
+    def _recv_updates(filep, path, cts):
+        """A static method that takes a file-like object, a path, and a
+        timestamp.  It reads a stream as an incoming updatelog and
+        modifies the catalog on disk."""
 
-                if not os.path.exists(path):
-                        os.makedirs(path)
+        if not os.path.exists(path):
+            os.makedirs(path)
 
-                # Build a list of FMRIs that this update would add, check to
-                # make sure that they aren't present in the catalog, then
-                # append the fmris.
-                mts = catalog.ts_to_datetime(cts)
-                cts = mts
-                pts = mts
-                added = 0
-                npkgs = 0
-                add_lines = []
-                unknown_lines = []
-                bad_fmri = None
-                attrs = {}
+        # Build a list of FMRIs that this update would add, check to
+        # make sure that they aren't present in the catalog, then
+        # append the fmris.
+        mts = catalog.ts_to_datetime(cts)
+        cts = mts
+        pts = mts
+        added = 0
+        npkgs = 0
+        add_lines = []
+        unknown_lines = []
+        bad_fmri = None
+        attrs = {}
 
-                for s in filep:
+        for s in filep:
+            l = s.split(None, 3)
+            if len(l) < 4:
+                continue
 
-                        l = s.split(None, 3)
-                        if len(l) < 4:
-                                continue
+            elif l[2] not in catalog.known_prefixes:
+                # Add unknown line directly to catalog.
+                # This can be post-processed later, when it
+                # becomes known.
+                #
+                # XXX Notify user that unknown entry was added?
+                ts = catalog.ts_to_datetime(l[1])
+                if ts > cts:
+                    if ts > mts:
+                        pts = mts
+                        mts = ts
+                    line = "{0} {1}\n".format(l[2], l[3])
+                    unknown_lines.append(line)
 
-                        elif l[2] not in catalog.known_prefixes:
-                                # Add unknown line directly to catalog.
-                                # This can be post-processed later, when it
-                                # becomes known.
-                                #
-                                # XXX Notify user that unknown entry was added?
-                                ts = catalog.ts_to_datetime(l[1])
-                                if ts > cts:
-                                        if ts > mts:
-                                                pts = mts
-                                                mts = ts
-                                        line = "{0} {1}\n".format(l[2], l[3])
-                                        unknown_lines.append(line)
+            elif l[0] == "+":
+                # This is a known entry type.
+                # Create a list of FMRIs to add, since
+                # additional inspection is required
+                ts = catalog.ts_to_datetime(l[1])
+                if ts > cts:
+                    if ts > mts:
+                        pts = mts
+                        mts = ts
 
-                        elif l[0] == "+":
-                                # This is a known entry type.
-                                # Create a list of FMRIs to add, since
-                                # additional inspection is required
-                                ts = catalog.ts_to_datetime(l[1])
-                                if ts > cts:
-                                        if ts > mts:
-                                                pts = mts
-                                                mts = ts
+                    # The format for C and V records
+                    # is described in the Catalog's
+                    # docstring.
+                    if l[2] in tuple("CV"):
+                        try:
+                            f = fmri.PkgFmri(l[3])
+                        except fmri.IllegalFmri as e:
+                            bad_fmri = e
+                            mts = pts
+                            continue
 
-                                        # The format for C and V records
-                                        # is described in the Catalog's
-                                        # docstring.
-                                        if l[2] in tuple("CV"):
-                                                try:
-                                                        f = fmri.PkgFmri(l[3])
-                                                except fmri.IllegalFmri as e:
-                                                        bad_fmri = e
-                                                        mts = pts
-                                                        continue
+                        line = "{0} {1} {2} {3}\n".format(
+                            l[2], "pkg", f.pkg_name, f.version
+                        )
+                        add_lines.append(line)
+                        added += 1
 
-                                                line = "{0} {1} {2} {3}\n".format(
-                                                    l[2], "pkg", f.pkg_name,
-                                                    f.version)
-                                                add_lines.append(line)
-                                                added += 1
+        # If we got a parse error on FMRIs and transfer
+        # wasn't truncated, raise a retryable transport
+        if bad_fmri:
+            raise bad_fmri
 
-                # If we got a parse error on FMRIs and transfer
-                # wasn't truncated, raise a retryable transport
-                if bad_fmri:
-                        raise bad_fmri
+        # Verify that they aren't already in the catalog
+        catpath = os.path.normpath(os.path.join(path, "catalog"))
 
-                # Verify that they aren't already in the catalog
-                catpath = os.path.normpath(os.path.join(path, "catalog"))
+        tmp_num, tmpfile = tempfile.mkstemp(dir=path)
+        tfile = os.fdopen(tmp_num, "w")
 
-                tmp_num, tmpfile = tempfile.mkstemp(dir=path)
-                tfile = os.fdopen(tmp_num, 'w')
-
-                try:
-                        pfile = open(catpath, "rb")
-                except IOError as e:
-                        if e.errno == errno.ENOENT:
-                                # Creating an empty file
-                                open(catpath, "wb").close()
-                                pfile = open(catpath, "rb")
-                        else:
-                                tfile.close()
-                                portable.remove(tmpfile)
-                                raise
-                pfile.seek(0)
-
-                for c in pfile:
-                        if c[0] in tuple("CV"):
-                                npkgs += 1
-                        if c in add_lines:
-                                pfile.close()
-                                tfile.close()
-                                portable.remove(tmpfile)
-                                raise UpdateLogException(
-                                    "Package {0} is already in the catalog".format(
-                                        c))
-                        tfile.write(c)
-
-                # Write the new entries to the catalog
-                tfile.seek(0, os.SEEK_END)
-                tfile.writelines(add_lines)
-                if len(unknown_lines) > 0:
-                        tfile.writelines(unknown_lines)
+        try:
+            pfile = open(catpath, "rb")
+        except IOError as e:
+            if e.errno == errno.ENOENT:
+                # Creating an empty file
+                open(catpath, "wb").close()
+                pfile = open(catpath, "rb")
+            else:
                 tfile.close()
+                portable.remove(tmpfile)
+                raise
+        pfile.seek(0)
+
+        for c in pfile:
+            if c[0] in tuple("CV"):
+                npkgs += 1
+            if c in add_lines:
                 pfile.close()
-
-                os.chmod(tmpfile, catalog.ServerCatalog.file_mode)
-                portable.rename(tmpfile, catpath)
-
-                # Now re-write npkgs and Last-Modified in attributes file
-                afile = open(os.path.normpath(os.path.join(path, "attrs")),
-                    "r")
-                attrre = re.compile(r'^S ([^:]*): (.*)')
-
-                for entry in afile:
-                        m = attrre.match(entry)
-                        if m != None:
-                                attrs[m.group(1)] = m.group(2)
-
-                afile.close()
-
-                # Update the attributes we care about
-                attrs["npkgs"] = npkgs + added
-                attrs["Last-Modified"] = mts.isoformat()
-
-                # Write attributes back out
-                apath = os.path.normpath(os.path.join(path, "attrs"))
-                tmp_num, tmpfile = tempfile.mkstemp(dir=path)
-                tfile = os.fdopen(tmp_num, 'w')
-
-                for a in attrs.keys():
-                        s = "S {0}: {1}\n".format(a, attrs[a])
-                        tfile.write(s)
-
                 tfile.close()
-                os.chmod(tmpfile, catalog.ServerCatalog.file_mode)
-                portable.rename(tmpfile, apath)
+                portable.remove(tmpfile)
+                raise UpdateLogException(
+                    "Package {0} is already in the catalog".format(c)
+                )
+            tfile.write(c)
 
-                return True
+        # Write the new entries to the catalog
+        tfile.seek(0, os.SEEK_END)
+        tfile.writelines(add_lines)
+        if len(unknown_lines) > 0:
+            tfile.writelines(unknown_lines)
+        tfile.close()
+        pfile.close()
+
+        os.chmod(tmpfile, catalog.ServerCatalog.file_mode)
+        portable.rename(tmpfile, catpath)
+
+        # Now re-write npkgs and Last-Modified in attributes file
+        afile = open(os.path.normpath(os.path.join(path, "attrs")), "r")
+        attrre = re.compile(r"^S ([^:]*): (.*)")
+
+        for entry in afile:
+            m = attrre.match(entry)
+            if m != None:
+                attrs[m.group(1)] = m.group(2)
+
+        afile.close()
+
+        # Update the attributes we care about
+        attrs["npkgs"] = npkgs + added
+        attrs["Last-Modified"] = mts.isoformat()
+
+        # Write attributes back out
+        apath = os.path.normpath(os.path.join(path, "attrs"))
+        tmp_num, tmpfile = tempfile.mkstemp(dir=path)
+        tfile = os.fdopen(tmp_num, "w")
+
+        for a in attrs.keys():
+            s = "S {0}: {1}\n".format(a, attrs[a])
+            tfile.write(s)
+
+        tfile.close()
+        os.chmod(tmpfile, catalog.ServerCatalog.file_mode)
+        portable.rename(tmpfile, apath)
+
+        return True
+
 
 # Allow these methods to be invoked without explictly naming the UpdateLog
 # class.
 recv = UpdateLog.recv
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/variant.py
+++ b/src/modules/variant.py
@@ -35,56 +35,60 @@ from collections import namedtuple
 from pkg._varcet import _allow_variant
 from pkg.misc import EmptyI
 
+
 class _Variants(dict):
-        # store information on variants; subclass dict
-        # and maintain set of keys for performance reasons
+    # store information on variants; subclass dict
+    # and maintain set of keys for performance reasons
 
-        def __init__(self, init=EmptyI):
-                dict.__init__(self)
-                for i in init:
-                        self[i] = init[i]
+    def __init__(self, init=EmptyI):
+        dict.__init__(self)
+        for i in init:
+            self[i] = init[i]
 
-        def copy(self):
-                return Variants(self)
+    def copy(self):
+        return Variants(self)
 
-        # allow_action is provided as a native function (see end of class
-        # declaration).
-        if six.PY3:
-                def allow_action(self, action, publisher=None):
-                        return _allow_variant(self, action, publisher=publisher)
+    # allow_action is provided as a native function (see end of class
+    # declaration).
+    if six.PY3:
+
+        def allow_action(self, action, publisher=None):
+            return _allow_variant(self, action, publisher=publisher)
+
+
 if six.PY2:
-        _Variants.allow_action = types.MethodType(_allow_variant, None, _Variants)
+    _Variants.allow_action = types.MethodType(_allow_variant, None, _Variants)
 
 
 class Variants(_Variants):
-        """This is a wrapper-class used by other consumers that handles implicit
-        variant values.  This class cannot be used by the VariantCombination*
-        classes since they rely on explicit values only to be found."""
+    """This is a wrapper-class used by other consumers that handles implicit
+    variant values.  This class cannot be used by the VariantCombination*
+    classes since they rely on explicit values only to be found."""
 
-        def __getitem_internal(self, item):
-                """Implement variant lookup algorithm here
+    def __getitem_internal(self, item):
+        """Implement variant lookup algorithm here
 
-                Note that _allow_variant bypasses __getitem__ for performance
-                reasons; if __getitem__ changes, _allow_variant in _varcet.c
-                must also be updated.
+        Note that _allow_variant bypasses __getitem__ for performance
+        reasons; if __getitem__ changes, _allow_variant in _varcet.c
+        must also be updated.
 
-                We return a tuple of the form (<key>, <value>) where key is the
-                explicitly set variant name that matched the caller specific
-                variant name."""
+        We return a tuple of the form (<key>, <value>) where key is the
+        explicitly set variant name that matched the caller specific
+        variant name."""
 
-                if not item.startswith("variant."):
-                        raise KeyError("key must start w/ variant.")
+        if not item.startswith("variant."):
+            raise KeyError("key must start w/ variant.")
 
-                if item in self:
-                        return item, dict.__getitem__(self, item)
+        if item in self:
+            return item, dict.__getitem__(self, item)
 
-                # The trailing '.' is to encourage namespace usage.
-                if item.startswith("variant.debug."):
-                        return None, "false" # 'false' by default
-                raise KeyError("unknown variant {0}".format(item))
+        # The trailing '.' is to encourage namespace usage.
+        if item.startswith("variant.debug."):
+            return None, "false"  # 'false' by default
+        raise KeyError("unknown variant {0}".format(item))
 
-        def __getitem__(self, item):
-                return self.__getitem_internal(item)[1]
+    def __getitem__(self, item):
+        return self.__getitem_internal(item)[1]
 
 
 # The two classes which follow are used during dependency calculation when
@@ -107,61 +111,62 @@ class Variants(_Variants):
 # instances while maintaining consistency between the satisfied set and the
 # unsatisfied set.
 
+
 class VariantCombinationTemplate(_Variants):
-        """Class for holding a template of variant types and their potential
-        values."""
+    """Class for holding a template of variant types and their potential
+    values."""
 
-        def __copy__(self):
-                return VariantCombinationTemplate(self)
+    def __copy__(self):
+        return VariantCombinationTemplate(self)
 
-        def __setitem__(self, item, value):
-                """Overrides _Variants.__setitem__ to ensure that all values are
-                sets."""
+    def __setitem__(self, item, value):
+        """Overrides _Variants.__setitem__ to ensure that all values are
+        sets."""
 
-                if isinstance(value, list):
-                        value = set(value)
-                elif not isinstance(value, set):
-                        value = set([value])
-                _Variants.__setitem__(self, item, value)
+        if isinstance(value, list):
+            value = set(value)
+        elif not isinstance(value, set):
+            value = set([value])
+        _Variants.__setitem__(self, item, value)
 
-        def issubset(self, var):
-                """Returns whether self is a subset of variant var."""
-                res = self.difference(var)
-                return not res.type_diffs and not res.value_diffs
+    def issubset(self, var):
+        """Returns whether self is a subset of variant var."""
+        res = self.difference(var)
+        return not res.type_diffs and not res.value_diffs
 
-        def difference(self, var):
-                res = VCTDifference([], [])
-                for k in self:
-                        if k not in var:
-                                res.type_diffs.append(k)
-                        else:
-                                for v in self[k] - var[k]:
-                                        res.value_diffs.append((k, v))
-                return res
+    def difference(self, var):
+        res = VCTDifference([], [])
+        for k in self:
+            if k not in var:
+                res.type_diffs.append(k)
+            else:
+                for v in self[k] - var[k]:
+                    res.value_diffs.append((k, v))
+        return res
 
-        def merge_unknown(self, var):
-                """Pull the values for unknown keys in var into self."""
-                for name in var:
-                        if name not in self:
-                                self[name] = var[name]
+    def merge_unknown(self, var):
+        """Pull the values for unknown keys in var into self."""
+        for name in var:
+            if name not in self:
+                self[name] = var[name]
 
-        def merge_values(self, var):
-                """Pull all unknown values of all keys in var into self."""
-                for name in var:
-                        self.setdefault(name, set([])).update(var[name])
+    def merge_values(self, var):
+        """Pull all unknown values of all keys in var into self."""
+        for name in var:
+            self.setdefault(name, set([])).update(var[name])
 
-        def __repr__(self):
-                return "VariantTemplate({0})".format(dict.__repr__(self))
+    def __repr__(self):
+        return "VariantTemplate({0})".format(dict.__repr__(self))
 
-        def __str__(self):
-                s = ""
-                for k in sorted(self):
-                        t = ",".join(['"{0}"'.format(v) for v in sorted(self[k])])
-                        s += " {0}={1}".format(k, t)
-                if s:
-                        return s
-                else:
-                        return " <none>"
+    def __str__(self):
+        s = ""
+        for k in sorted(self):
+            t = ",".join(['"{0}"'.format(v) for v in sorted(self[k])])
+            s += " {0}={1}".format(k, t)
+        if s:
+            return s
+        else:
+            return " <none>"
 
 
 VCTDifference = namedtuple("VCTDifference", ["type_diffs", "value_diffs"])
@@ -173,407 +178,407 @@ VCTDifference = namedtuple("VCTDifference", ["type_diffs", "value_diffs"])
 
 
 class VariantCombinations(object):
-        """Class for keeping track of which combinations of variant values have
-        and have not been satisfied for a particular action."""
+    """Class for keeping track of which combinations of variant values have
+    and have not been satisfied for a particular action."""
 
-        def __init__(self, vct, satisfied):
-                """Create an instance of VariantCombinations based on the
-                template provided.
+    def __init__(self, vct, satisfied):
+        """Create an instance of VariantCombinations based on the
+        template provided.
 
-                The 'vct' parameter is the template from which to build the
-                combinations.
+        The 'vct' parameter is the template from which to build the
+        combinations.
 
-                The 'satisfied' parameter is a boolean which determines whether
-                the combinations created from the template will be considered
-                satisfied or unsatisfied."""
+        The 'satisfied' parameter is a boolean which determines whether
+        the combinations created from the template will be considered
+        satisfied or unsatisfied."""
 
-                assert(isinstance(vct, VariantCombinationTemplate))
-                self.__sat_set = set()
-                self.__not_sat_set = set()
-                tmp = []
-                # This builds all combinations of variant values presented in
-                # vct.
-                for k in sorted(vct):
-                        if not tmp:
-                                # Initialize tmp with the key-value pairs for
-                                # the first key in vct.
-                                tmp = [[(k, v)] for v in vct[k]]
+        assert isinstance(vct, VariantCombinationTemplate)
+        self.__sat_set = set()
+        self.__not_sat_set = set()
+        tmp = []
+        # This builds all combinations of variant values presented in
+        # vct.
+        for k in sorted(vct):
+            if not tmp:
+                # Initialize tmp with the key-value pairs for
+                # the first key in vct.
+                tmp = [[(k, v)] for v in vct[k]]
+                continue
+            # For each subsequent key in vct, append each of its
+            # key-value pairs to each of the existing combinations.
+            new_tmp = [exist[:] + [(k, v)] for v in vct[k] for exist in tmp]
+            tmp = new_tmp
+        # Here is an example of how the loop above would handle a vct
+        # of { 1:["a", "b"], 2:["x", "y"], 3:["m", "n"] }
+        # First, tmp would be initialized as [[(1, "a")], [(1, "b")]]
+        # Next, a new list is created by adding (2, "x") to a copy
+        # of each item in tmp, and then (2, "y"). This produces
+        # [[(1, "a"), (2, "x")], [(1, "a"), (2, "y")],
+        #  [(1, "b"), (2, "x")], [(1, "b"), (2, "y")]]
+        # That process is repeated one more time for the 3 key,
+        # resulting in:
+        # [[(1, "a"), (2, "x"), (3, "m")],
+        #  [(1, "a"), (2, "x"), (3, "n")],
+        #  [(1, "a"), (2, "y"), (3, "m")],
+        #  [(1, "a"), (2, "y"), (3, "n")],
+        #  [(1, "b"), (2, "x"), (3, "m")],
+        #  [(1, "b"), (2, "x"), (3, "n")],
+        #  [(1, "b"), (2, "y"), (3, "m")],
+        #  [(1, "b"), (2, "y"), (3, "n")]]
+        # The use of frozenset means that the order of the elements
+        # within each frozenset will be non-deterministic,
+        # so any code using them must NOT rely upon the order.
+        self.__combinations = [frozenset(l) for l in tmp]
+        res = set(self.__combinations)
+        if satisfied:
+            self.__sat_set = res
+        else:
+            self.__not_sat_set = res
+        self.__template = copy.copy(vct)
+        self.__simpl_template = None
+
+    @property
+    def template(self):
+        return self.__template
+
+    @property
+    def sat_set(self):
+        if not self.__simpl_template:
+            return self.__sat_set
+        else:
+            return self.__calc_simple(True)
+
+    @property
+    def not_sat_set(self):
+        if not self.__simpl_template:
+            return self.__not_sat_set
+        else:
+            return self.__calc_simple(False)
+
+    def __copy__(self):
+        vc = VariantCombinations(self.__template, True)
+        vc.__sat_set = copy.copy(self.__sat_set)
+        vc.__not_sat_set = copy.copy(self.__not_sat_set)
+        vc.__simpl_template = self.__simpl_template
+        vc.__combinations = self.__combinations
+        return vc
+
+    def __eq__(self, other):
+        return (
+            self.__template == other.__template
+            and self.__sat_set == other.__sat_set
+            and self.__not_sat_set == other.__not_sat_set
+            and self.__simpl_template == other.__simpl_template
+            and self.__combinations == other.__combinations
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    __hash__ = object.__hash__
+
+    def is_empty(self):
+        """Returns whether self was created with any potential variant
+        values."""
+
+        return not self.__sat_set and not self.__not_sat_set
+
+    def issubset(self, vc, satisfied):
+        """Returns whether the instances in self are a subset of the
+        instances in vc. 'satisfied' determines whether the instances
+        compared are drawn from the set of satisfied instances or the
+        set of unsatisfied instances."""
+
+        if satisfied:
+            return self.__sat_set.issubset(vc.__sat_set)
+        else:
+            return self.__not_sat_set.issubset(vc.__not_sat_set)
+
+    def intersects(self, vc, only_not_sat=False):
+        """Returns whether an action whose variants are vc could satisfy
+        dependencies whose variants are self.
+
+        'only_not_sat' determines whether only the unsatisfied set of
+        variants for self is used for comparision.  When only_not_sat
+        is True, then intersects returns wether vc would satisfy at
+        least one instance which is currently unsatisfied."""
+
+        if self.is_empty() or vc.is_empty():
+            return True
+        tmp = self.intersection(vc)
+        if only_not_sat:
+            return bool(tmp.__not_sat_set)
+        return not tmp.is_empty()
+
+    def intersection(self, vc):
+        """Find those variant values in self that are also in var, and
+        return them."""
+        assert len(vc.not_sat_set) == 0
+        res = copy.copy(self)
+        res.__sat_set &= vc.__sat_set
+        res.__not_sat_set &= vc.__sat_set
+        return res
+
+    def separate_satisfied(self, vc):
+        """Find those combinations of variants that are satisfied only
+        in self, in both self and vc, and only in vc."""
+
+        intersect = None
+        only_big = None
+        only_small = None
+
+        if self.is_empty() and vc.is_empty():
+            return None, self, None
+
+        if vc.__template.issubset(self.__template):
+            big = self
+            small = vc
+        elif self.__template.issubset(vc.__template):
+            big = vc
+            small = self
+        else:
+            # If one template isn't a subset of, or identical to,
+            # the other, then no meaningful comparison can be
+            # performed.
+            return self, None, vc
+
+        if big.__sat_set & small.__sat_set:
+            intersect = VariantCombinations(big.__template, False)
+            intersect.__sat_set = big.__sat_set & small.__sat_set
+            intersect.__not_sat_set -= intersect.__sat_set
+
+        if big.__sat_set - small.__sat_set:
+            only_big = VariantCombinations(big.__template, False)
+            only_big.__sat_set = big.__sat_set - small.__sat_set
+            only_big.__not_sat_set -= only_big.__sat_set
+
+        if small.__sat_set - big.__sat_set:
+            only_small = VariantCombinations(big.__template, False)
+            only_small.__sat_set = small.__sat_set - big.__sat_set
+            only_small.__not_sat_set -= only_small.__sat_set
+
+        if big == self:
+            return only_big, intersect, only_small
+        return only_small, intersect, only_big
+
+    def mark_as_satisfied(self, vc):
+        """For all instances in vc, mark those instances as being
+        satisfied.  Returns a boolean indicating whether any changes
+        have been made."""
+
+        i = vc.__sat_set & self.__not_sat_set
+        if not i:
+            return False
+        self.__not_sat_set -= i
+        self.__sat_set |= i
+        return True
+
+    def mark_as_unsatisfied(self, vc):
+        """For all satisfied instances in vc, mark those instances as
+        being unsatisfied."""
+
+        i = vc.__sat_set & self.__sat_set
+        if not i:
+            return False
+        self.__sat_set -= i
+        self.__not_sat_set |= i
+        return True
+
+    def mark_all_as_satisfied(self):
+        """Mark all instances as being satisfied."""
+
+        self.__sat_set |= self.__not_sat_set
+        self.__not_sat_set = set()
+
+    def is_satisfied(self):
+        """Returns whether all variant combinations for this package
+        have been satisfied."""
+
+        return not self.__not_sat_set
+
+    def simplify(self, vct, assert_on_different_domains=True):
+        """Store the provided VariantCombinationTemplate as the template
+        to use when simplifying the combinations."""
+
+        if not self.__template.issubset(vct):
+            self.__simpl_template = {}
+            if assert_on_different_domains:
+                assert self.__template.issubset(
+                    vct
+                ), "template:{0}\nvct:{1}".format(self.__template, vct)
+        self.__simpl_template = vct
+
+    def split_combinations(self):
+        """Create one VariantCombination object for each possible
+        combination of variants.  This is useful when each combination
+        needs to be associated with other information."""
+
+        tmp = []
+        for c in self.__combinations:
+            vc = VariantCombinations(self.__template, False)
+            vc.__sat_set.add(c)
+            vc.__not_sat_set = set()
+            tmp.append(vc)
+        # If there weren't any combinations, then this is an empty
+        # variant combination, so just return a copy of ourselves.
+        if not tmp:
+            tmp.append(copy.copy(self))
+        return tmp
+
+    def unsatisfied_copy(self):
+        """Create a copy of this variant combination, but make sure all
+        the variant combinations are marked as unsatisifed."""
+
+        return VariantCombinations(self.__template, False)
+
+    def __calc_simple(self, sat):
+        """Given VariantCombinationTemplate to be simplified against,
+        reduce the instances to the empty set if the instances cover all
+        possible combinations of the template provided.
+
+        Example:
+        With the following template: A(a, b), Z(x, y) the following
+        combinations are possible:
+            (A(a), Z(x)), (A(a), Z(y)), (A(b), Z(x)), (A(b), Z(y))
+        if a set of combinations, using the above, has the following:
+            (A(a), Z(x)), (A(a), Z(y))
+        then a simplification of this set results in:
+            (A(a))
+        because all possible values of Z are present and so we
+        just need to know what is left to describe the contents
+        of the set.
+
+        A general approach to simplification is currently deemed to
+        difficult in the face of arbitrary numbers of variant types and
+        arbitrary numbers of variant."""
+
+        if not self.__simpl_template:
+            possibilities = 0
+        else:
+            possibilities = 1
+            for k in self.__simpl_template:
+                possibilities *= len(self.__simpl_template[k])
+
+        if sat:
+            rel_set = self.__sat_set
+        else:
+            rel_set = self.__not_sat_set
+
+        # If the size of sat_set or not_sat_set matches the number of
+        # possibilities a template can produce, then it can be
+        # simplified.
+        if possibilities == len(rel_set):
+            return set()
+        # If any dependencies are merged, then another pass over the
+        # variant types is necessary.  'keep_going' tracks whether that
+        # has happened.
+        keep_going = True
+        while keep_going:
+            keep_going = False
+            # For each variant type ...
+            # Sort to ensure variant_name is being visited in a
+            # reversed aliphatic order so that the logic below can
+            # get a deterministic simplified variant combination
+            # between Python 2 and 3.
+            # For example, "variant.opensolaris.zone" should be
+            # visited before "variant.arch".
+            for variant_name in sorted(self.__simpl_template, reverse=True):
+
+                def exclude_name(item):
+                    # item is a frozenset and so we need
+                    # to ensure it is processed in order
+                    # so the returned key (k) will match
+                    # across the values rel_set.
+                    return sorted(
+                        [(k, v) for k, v in item if k != variant_name]
+                    )
+
+                # For sanity, instead of modifying rel_set on
+                # the fly, a new working set is created to which
+                # members or collapsed members of rel_set are
+                # added.
+                new_rel_set = set()
+
+                # Put the combinations of variant values into
+                # groups so that all members of the group are
+                # identical except for the values for
+                # variant_name.
+                for k, g in itertools.groupby(
+                    sorted(rel_set, key=exclude_name), exclude_name
+                ):
+                    g = set(g)
+
+                    # If there are fewer members in the
+                    # group than there are values, then
+                    # there's no way this value can be
+                    # collapsed.
+                    if len(g) < len(self.__simpl_template[variant_name]):
+                        new_rel_set |= g
+                        continue
+
+                    # 'expected' is the set of variant
+                    # values that will need to be seen to
+                    # collapse the combinations in g by
+                    # removing the values associated with
+                    # variant_name.
+                    expected = set(self.__simpl_template[variant_name])
+
+                    # Check to see whether all possible
+                    # variant values are covered.
+                    for tup in g:
+                        for v_name, v_value in tup:
+                            if v_name != variant_name:
                                 continue
-                        # For each subsequent key in vct, append each of its
-                        # key-value pairs to each of the existing combinations.
-                        new_tmp = [
-                            exist[:] + [(k, v)] for v in vct[k]
-                            for exist in tmp
-                        ]
-                        tmp = new_tmp
-                # Here is an example of how the loop above would handle a vct
-                # of { 1:["a", "b"], 2:["x", "y"], 3:["m", "n"] }
-                # First, tmp would be initialized as [[(1, "a")], [(1, "b")]]
-                # Next, a new list is created by adding (2, "x") to a copy
-                # of each item in tmp, and then (2, "y"). This produces
-                # [[(1, "a"), (2, "x")], [(1, "a"), (2, "y")],
-                #  [(1, "b"), (2, "x")], [(1, "b"), (2, "y")]]
-                # That process is repeated one more time for the 3 key,
-                # resulting in:
-                # [[(1, "a"), (2, "x"), (3, "m")],
-                #  [(1, "a"), (2, "x"), (3, "n")],
-                #  [(1, "a"), (2, "y"), (3, "m")],
-                #  [(1, "a"), (2, "y"), (3, "n")],
-                #  [(1, "b"), (2, "x"), (3, "m")],
-                #  [(1, "b"), (2, "x"), (3, "n")],
-                #  [(1, "b"), (2, "y"), (3, "m")],
-                #  [(1, "b"), (2, "y"), (3, "n")]]
-                # The use of frozenset means that the order of the elements
-                # within each frozenset will be non-deterministic,
-                # so any code using them must NOT rely upon the order.
-                self.__combinations = [frozenset(l) for l in tmp]
-                res = set(self.__combinations)
-                if satisfied:
-                        self.__sat_set = res
-                else:
-                        self.__not_sat_set = res
-                self.__template = copy.copy(vct)
-                self.__simpl_template = None
+                            expected.remove(v_value)
 
-        @property
-        def template(self):
-                return self.__template
+                    # If not all the possible values have
+                    # been seen, then the variant
+                    # combinations can't be collapsed.
+                    if expected:
+                        new_rel_set |= g
+                        continue
+                    # If they have, then the variant
+                    # combinations can be collapsed by
+                    # removing variant_name.  The key used
+                    # to group the variant combinations,
+                    # 'k', is identical to each of the
+                    # variant combinations with the value
+                    # for variant_name removed, so 'k' is
+                    # added to the new result set.  Since
+                    # some variant combinations have been
+                    # collapsed, then it's necessary to make
+                    # another pass over the variant types as
+                    # 'k' may be able to collapse with other
+                    # variant combinations.
+                    keep_going = True
+                    new_rel_set.add(frozenset(k))
+                rel_set = new_rel_set
+        return rel_set
 
-        @property
-        def sat_set(self):
-                if not self.__simpl_template:
-                        return self.__sat_set
-                else:
-                        return self.__calc_simple(True)
+    def ppsort(self, k):
+        return str(sorted(k))
 
-        @property
-        def not_sat_set(self):
-                if not self.__simpl_template:
-                        return self.__not_sat_set
-                else:
-                        return self.__calc_simple(False)
+    def pretty_print_set(self, prefix, print_set):
+        ret = ""
+        for ss in sorted(print_set, key=self.ppsort):
+            ret += "    {}:\n".format(prefix)
+            for s in sorted(ss):
+                ret += "        ... {}\n".format(s)
+        return ret
 
-        def __copy__(self):
-                vc = VariantCombinations(self.__template, True)
-                vc.__sat_set = copy.copy(self.__sat_set)
-                vc.__not_sat_set = copy.copy(self.__not_sat_set)
-                vc.__simpl_template = self.__simpl_template
-                vc.__combinations = self.__combinations
-                return vc
+    def pretty_print(self):
+        return (
+            "VariantCombinations:\n"
+            + self.pretty_print_set("+++", self.sat_set)
+            + self.pretty_print_set("!!!", self.not_sat_set)
+        )
 
-        def __eq__(self, other):
-                return self.__template == other.__template and \
-                    self.__sat_set == other.__sat_set and \
-                    self.__not_sat_set == other.__not_sat_set and \
-                    self.__simpl_template == other.__simpl_template and \
-                    self.__combinations == other.__combinations
+    def __repr__(self):
+        return "VC Sat:{0} Unsat:{1}".format(
+            sorted(self.__sat_set, key=self.ppsort),
+            sorted(self.__not_sat_set, key=self.ppsort),
+        )
 
-        def __ne__(self, other):
-                return not self.__eq__(other)
-
-        __hash__ = object.__hash__
-
-        def is_empty(self):
-                """Returns whether self was created with any potential variant
-                values."""
-
-                return not self.__sat_set and not self.__not_sat_set
-
-        def issubset(self, vc, satisfied):
-                """Returns whether the instances in self are a subset of the
-                instances in vc. 'satisfied' determines whether the instances
-                compared are drawn from the set of satisfied instances or the
-                set of unsatisfied instances."""
-
-                if satisfied:
-                        return self.__sat_set.issubset(vc.__sat_set)
-                else:
-                        return self.__not_sat_set.issubset(vc.__not_sat_set)
-
-        def intersects(self, vc, only_not_sat=False):
-                """Returns whether an action whose variants are vc could satisfy
-                dependencies whose variants are self.
-
-                'only_not_sat' determines whether only the unsatisfied set of
-                variants for self is used for comparision.  When only_not_sat
-                is True, then intersects returns wether vc would satisfy at
-                least one instance which is currently unsatisfied."""
-
-                if self.is_empty() or vc.is_empty():
-                        return True
-                tmp = self.intersection(vc)
-                if only_not_sat:
-                        return bool(tmp.__not_sat_set)
-                return not tmp.is_empty()
-
-        def intersection(self, vc):
-                """Find those variant values in self that are also in var, and
-                return them."""
-                assert len(vc.not_sat_set) == 0
-                res = copy.copy(self)
-                res.__sat_set &= vc.__sat_set
-                res.__not_sat_set &= vc.__sat_set
-                return res
-
-        def separate_satisfied(self, vc):
-                """Find those combinations of variants that are satisfied only
-                in self, in both self and vc, and only in vc."""
-
-                intersect = None
-                only_big = None
-                only_small = None
-
-                if self.is_empty() and vc.is_empty():
-                        return None, self, None
-
-                if vc.__template.issubset(self.__template):
-                        big = self
-                        small = vc
-                elif self.__template.issubset(vc.__template):
-                        big = vc
-                        small = self
-                else:
-                        # If one template isn't a subset of, or identical to,
-                        # the other, then no meaningful comparison can be
-                        # performed.
-                        return self, None, vc
-
-                if big.__sat_set & small.__sat_set:
-                        intersect = VariantCombinations(big.__template, False)
-                        intersect.__sat_set = big.__sat_set & small.__sat_set
-                        intersect.__not_sat_set -= intersect.__sat_set
-
-                if big.__sat_set - small.__sat_set:
-                        only_big = VariantCombinations(big.__template, False)
-                        only_big.__sat_set = big.__sat_set - small.__sat_set
-                        only_big.__not_sat_set -= only_big.__sat_set
-
-                if small.__sat_set - big.__sat_set:
-                        only_small = VariantCombinations(big.__template, False)
-                        only_small.__sat_set = small.__sat_set - big.__sat_set
-                        only_small.__not_sat_set -= only_small.__sat_set
-
-                if big == self:
-                        return only_big, intersect, only_small
-                return only_small, intersect, only_big
-
-        def mark_as_satisfied(self, vc):
-                """For all instances in vc, mark those instances as being
-                satisfied.  Returns a boolean indicating whether any changes
-                have been made."""
-
-                i = vc.__sat_set & self.__not_sat_set
-                if not i:
-                        return False
-                self.__not_sat_set -= i
-                self.__sat_set |= i
-                return True
-
-        def mark_as_unsatisfied(self, vc):
-                """For all satisfied instances in vc, mark those instances as
-                being unsatisfied."""
-
-                i = vc.__sat_set & self.__sat_set
-                if not i:
-                        return False
-                self.__sat_set -= i
-                self.__not_sat_set |= i
-                return True
-
-        def mark_all_as_satisfied(self):
-                """Mark all instances as being satisfied."""
-
-                self.__sat_set |= self.__not_sat_set
-                self.__not_sat_set = set()
-
-        def is_satisfied(self):
-                """Returns whether all variant combinations for this package
-                have been satisfied."""
-
-                return not self.__not_sat_set
-
-        def simplify(self, vct, assert_on_different_domains=True):
-                """Store the provided VariantCombinationTemplate as the template
-                to use when simplifying the combinations."""
-
-                if not self.__template.issubset(vct):
-                        self.__simpl_template = {}
-                        if assert_on_different_domains:
-                                assert self.__template.issubset(vct), \
-                                    "template:{0}\nvct:{1}".format(
-                                    self.__template, vct)
-                self.__simpl_template = vct
-
-        def split_combinations(self):
-                """Create one VariantCombination object for each possible
-                combination of variants.  This is useful when each combination
-                needs to be associated with other information."""
-
-                tmp = []
-                for c in self.__combinations:
-                        vc = VariantCombinations(self.__template, False)
-                        vc.__sat_set.add(c)
-                        vc.__not_sat_set = set()
-                        tmp.append(vc)
-                # If there weren't any combinations, then this is an empty
-                # variant combination, so just return a copy of ourselves.
-                if not tmp:
-                        tmp.append(copy.copy(self))
-                return tmp
-
-        def unsatisfied_copy(self):
-                """Create a copy of this variant combination, but make sure all
-                the variant combinations are marked as unsatisifed."""
-
-                return VariantCombinations(self.__template, False)
-
-        def __calc_simple(self, sat):
-                """Given VariantCombinationTemplate to be simplified against,
-                reduce the instances to the empty set if the instances cover all
-                possible combinations of the template provided.
-
-                Example:
-                With the following template: A(a, b), Z(x, y) the following
-                combinations are possible:
-                    (A(a), Z(x)), (A(a), Z(y)), (A(b), Z(x)), (A(b), Z(y))
-                if a set of combinations, using the above, has the following:
-                    (A(a), Z(x)), (A(a), Z(y))
-                then a simplification of this set results in:
-                    (A(a))
-                because all possible values of Z are present and so we
-                just need to know what is left to describe the contents
-                of the set.
-
-                A general approach to simplification is currently deemed to
-                difficult in the face of arbitrary numbers of variant types and
-                arbitrary numbers of variant."""
-
-                if not self.__simpl_template:
-                        possibilities = 0
-                else:
-                        possibilities = 1
-                        for k in self.__simpl_template:
-                                possibilities *= len(self.__simpl_template[k])
-
-                if sat:
-                        rel_set = self.__sat_set
-                else:
-                        rel_set = self.__not_sat_set
-
-                # If the size of sat_set or not_sat_set matches the number of
-                # possibilities a template can produce, then it can be
-                # simplified.
-                if possibilities == len(rel_set):
-                        return set()
-                # If any dependencies are merged, then another pass over the
-                # variant types is necessary.  'keep_going' tracks whether that
-                # has happened.
-                keep_going = True
-                while keep_going:
-                        keep_going = False
-                        # For each variant type ...
-                        # Sort to ensure variant_name is being visited in a
-                        # reversed aliphatic order so that the logic below can
-                        # get a deterministic simplified variant combination
-                        # between Python 2 and 3.
-                        # For example, "variant.opensolaris.zone" should be
-                        # visited before "variant.arch".
-                        for variant_name in sorted(self.__simpl_template,
-                            reverse=True):
-                                def exclude_name(item):
-                                        # item is a frozenset and so we need
-                                        # to ensure it is processed in order
-                                        # so the returned key (k) will match
-                                        # across the values rel_set.
-                                        return sorted([
-                                            (k, v) for k, v in item
-                                            if k != variant_name
-                                        ])
-                                # For sanity, instead of modifying rel_set on
-                                # the fly, a new working set is created to which
-                                # members or collapsed members of rel_set are
-                                # added.
-                                new_rel_set = set()
-
-                                # Put the combinations of variant values into
-                                # groups so that all members of the group are
-                                # identical except for the values for
-                                # variant_name.
-                                for k, g in itertools.groupby(
-                                    sorted(rel_set, key=exclude_name),
-                                    exclude_name):
-                                        g = set(g)
-
-                                        # If there are fewer members in the
-                                        # group than there are values, then
-                                        # there's no way this value can be
-                                        # collapsed.
-                                        if len(g) < len(self.__simpl_template[
-                                            variant_name]):
-                                                new_rel_set |= g
-                                                continue
-
-                                        # 'expected' is the set of variant
-                                        # values that will need to be seen to
-                                        # collapse the combinations in g by
-                                        # removing the values associated with
-                                        # variant_name.
-                                        expected = set(self.__simpl_template[
-                                            variant_name])
-
-                                        # Check to see whether all possible
-                                        # variant values are covered.
-                                        for tup in g:
-                                                for v_name, v_value in tup:
-                                                        if v_name != \
-                                                            variant_name:
-                                                                continue
-                                                        expected.remove(v_value)
-
-                                        # If not all the possible values have
-                                        # been seen, then the variant
-                                        # combinations can't be collapsed.
-                                        if expected:
-                                                new_rel_set |= g
-                                                continue
-                                        # If they have, then the variant
-                                        # combinations can be collapsed by
-                                        # removing variant_name.  The key used
-                                        # to group the variant combinations,
-                                        # 'k', is identical to each of the
-                                        # variant combinations with the value
-                                        # for variant_name removed, so 'k' is
-                                        # added to the new result set.  Since
-                                        # some variant combinations have been
-                                        # collapsed, then it's necessary to make
-                                        # another pass over the variant types as
-                                        # 'k' may be able to collapse with other
-                                        # variant combinations.
-                                        keep_going = True
-                                        new_rel_set.add(frozenset(k))
-                                rel_set = new_rel_set
-                return rel_set
-
-        def ppsort(self, k):
-                return str(sorted(k))
-
-        def pretty_print_set(self, prefix, print_set):
-                ret = ""
-                for ss in sorted(print_set, key=self.ppsort):
-                        ret += "    {}:\n".format(prefix)
-                        for s in sorted(ss):
-                                ret += "        ... {}\n".format(s)
-                return ret
-
-        def pretty_print(self):
-                return ("VariantCombinations:\n" +
-                    self.pretty_print_set("+++", self.sat_set) +
-                    self.pretty_print_set("!!!", self.not_sat_set))
-
-        def __repr__(self):
-                return "VC Sat:{0} Unsat:{1}".format(
-                    sorted(self.__sat_set, key=self.ppsort),
-                    sorted(self.__not_sat_set, key=self.ppsort))
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/modules/version.py
+++ b/src/modules/version.py
@@ -44,782 +44,790 @@ CONSTRAINT_BRANCH_MINOR = 102
 
 CONSTRAINT_SEQUENCE = 300
 
-class VersionError(Exception):
-        """Base exception class for all version errors."""
 
-        def __init__(self, *args):
-                Exception.__init__(self, *args)
+class VersionError(Exception):
+    """Base exception class for all version errors."""
+
+    def __init__(self, *args):
+        Exception.__init__(self, *args)
 
 
 class IllegalDotSequence(VersionError):
-        """Used to indicate that the specified DotSequence is not valid."""
+    """Used to indicate that the specified DotSequence is not valid."""
+
 
 class DotSequence(list):
-        """A DotSequence is the typical "x.y.z" string used in software
-        versioning.  We define the "major release" value and the "minor release"
-        value as the first two numbers in the sequence."""
+    """A DotSequence is the typical "x.y.z" string used in software
+    versioning.  We define the "major release" value and the "minor release"
+    value as the first two numbers in the sequence."""
 
-        #
-        # We employ the Flyweight design pattern for dotsequences, since they
-        # are used immutably, are highly repetitive (0.5.11 over and over) and,
-        # for what they contain, are relatively expensive memory-wise.
-        #
-        __dotseq_pool = weakref.WeakValueDictionary()
+    #
+    # We employ the Flyweight design pattern for dotsequences, since they
+    # are used immutably, are highly repetitive (0.5.11 over and over) and,
+    # for what they contain, are relatively expensive memory-wise.
+    #
+    __dotseq_pool = weakref.WeakValueDictionary()
 
-        # Performance optimization: cache version string instead of using join and map.
-        __version_str = ''
+    # Performance optimization: cache version string instead of using join and map.
+    __version_str = ""
 
-        @staticmethod
-        def dotsequence_val(elem):
-                # Do this first; if the string is zero chars or non-numeric
-                # chars, this will throw.
-                x = int(elem)
-                if elem[0] == "-":
-                        raise ValueError("Negative number")
-                if x > 0 and elem[0] == "0":
-                        raise ValueError("Zero padded number")
-                return x
+    @staticmethod
+    def dotsequence_val(elem):
+        # Do this first; if the string is zero chars or non-numeric
+        # chars, this will throw.
+        x = int(elem)
+        if elem[0] == "-":
+            raise ValueError("Negative number")
+        if x > 0 and elem[0] == "0":
+            raise ValueError("Zero padded number")
+        return x
 
-        def __new__(cls, dotstring):
-                ds = DotSequence.__dotseq_pool.get(dotstring)
-                if ds is None:
-                        cls.__dotseq_pool[dotstring] = ds = \
-                            list.__new__(cls)
-                return ds
+    def __new__(cls, dotstring):
+        ds = DotSequence.__dotseq_pool.get(dotstring)
+        if ds is None:
+            cls.__dotseq_pool[dotstring] = ds = list.__new__(cls)
+        return ds
 
-        def __init__(self, dotstring):
-                # Was I already initialized?  See __new__ above.
-                if len(self) != 0:
-                        return
+    def __init__(self, dotstring):
+        # Was I already initialized?  See __new__ above.
+        if len(self) != 0:
+            return
 
-                try:
-                        list.__init__(self,
-                            list(map(DotSequence.dotsequence_val,
-                                dotstring.split("."))))
-                        self.set_version_string(dotstring)
-                except ValueError:
-                        raise IllegalDotSequence(dotstring)
+        try:
+            list.__init__(
+                self,
+                list(map(DotSequence.dotsequence_val, dotstring.split("."))),
+            )
+            self.set_version_string(dotstring)
+        except ValueError:
+            raise IllegalDotSequence(dotstring)
 
-                if len(self) == 0:
-                        raise IllegalDotSequence("Empty DotSequence")
+        if len(self) == 0:
+            raise IllegalDotSequence("Empty DotSequence")
 
-        def __str__(self):
-                return self.__version_str
+    def __str__(self):
+        return self.__version_str
 
-        def __hash__(self):
-                return hash(tuple(self))
+    def __hash__(self):
+        return hash(tuple(self))
 
-        def set_version_string(self, dotstring):
-                self.__version_str = dotstring
+    def set_version_string(self, dotstring):
+        self.__version_str = dotstring
 
-        def is_subsequence(self, other):
-                """Return true if self is a "subsequence" of other, meaning that
-                other and self have identical components, up to the length of
-                self's sequence."""
+    def is_subsequence(self, other):
+        """Return true if self is a "subsequence" of other, meaning that
+        other and self have identical components, up to the length of
+        self's sequence."""
 
-                if len(self) > len(other):
-                        return False
+        if len(self) > len(other):
+            return False
 
-                for a, b in zip(self, other):
-                        if a != b:
-                                return False
-                return True
+        for a, b in zip(self, other):
+            if a != b:
+                return False
+        return True
 
-        def is_same_major(self, other):
-                """ Test if DotSequences have the same major number """
-                return self[0] == other[0]
+    def is_same_major(self, other):
+        """Test if DotSequences have the same major number"""
+        return self[0] == other[0]
 
-        def is_same_minor(self, other):
-                """ Test if DotSequences have the same major and minor num """
-                return self[0] == other[0] and self[1] == other[1]
+    def is_same_minor(self, other):
+        """Test if DotSequences have the same major and minor num"""
+        return self[0] == other[0] and self[1] == other[1]
 
 
 class MatchingDotSequence(DotSequence):
-        """A subclass of DotSequence with (much) weaker rules about its format.
-        This is intended to accept user input with wildcard characters."""
+    """A subclass of DotSequence with (much) weaker rules about its format.
+    This is intended to accept user input with wildcard characters."""
 
-        #
-        # We employ the Flyweight design pattern for dotsequences, since they
-        # are used immutably, are highly repetitive (0.5.11 over and over) and,
-        # for what they contain, are relatively expensive memory-wise.
-        #
-        __matching_dotseq_pool = weakref.WeakValueDictionary()
+    #
+    # We employ the Flyweight design pattern for dotsequences, since they
+    # are used immutably, are highly repetitive (0.5.11 over and over) and,
+    # for what they contain, are relatively expensive memory-wise.
+    #
+    __matching_dotseq_pool = weakref.WeakValueDictionary()
 
-        @staticmethod
-        def dotsequence_val(elem):
-                # Do this first; if the string is zero chars or non-numeric
-                # chars (other than "*"), an exception will be raised.
-                if elem == "*":
-                        return elem
+    @staticmethod
+    def dotsequence_val(elem):
+        # Do this first; if the string is zero chars or non-numeric
+        # chars (other than "*"), an exception will be raised.
+        if elem == "*":
+            return elem
 
-                return DotSequence.dotsequence_val(elem)
+        return DotSequence.dotsequence_val(elem)
 
-        def __new__(cls, dotstring):
-                ds = MatchingDotSequence.__matching_dotseq_pool.get(dotstring,
-                    None)
-                if ds is not None:
-                        return ds
+    def __new__(cls, dotstring):
+        ds = MatchingDotSequence.__matching_dotseq_pool.get(dotstring, None)
+        if ds is not None:
+            return ds
 
-                ds = list.__new__(cls)
-                cls.__matching_dotseq_pool[dotstring] = ds
-                return ds
+        ds = list.__new__(cls)
+        cls.__matching_dotseq_pool[dotstring] = ds
+        return ds
 
-        def __init__(self, dotstring):
-                try:
-                        list.__init__(self,
-                            list(map(self.dotsequence_val,
-                                dotstring.split("."))))
-                        self.set_version_string(dotstring)
-                except ValueError:
-                        raise IllegalDotSequence(dotstring)
+    def __init__(self, dotstring):
+        try:
+            list.__init__(
+                self, list(map(self.dotsequence_val, dotstring.split(".")))
+            )
+            self.set_version_string(dotstring)
+        except ValueError:
+            raise IllegalDotSequence(dotstring)
 
-                if len(self) == 0:
-                        raise IllegalDotSequence("Empty MatchingDotSequence")
+        if len(self) == 0:
+            raise IllegalDotSequence("Empty MatchingDotSequence")
 
-        def __ne__(self, other):
-                if not isinstance(other, DotSequence):
-                        return True
+    def __ne__(self, other):
+        if not isinstance(other, DotSequence):
+            return True
 
-                ls = len(self)
-                lo = len(other)
-                for i in range(max(ls, lo)):
-                        try:
-                                if self[i] != other[i] and ("*" not in (self[i],
-                                    other[i])):
-                                        return True
-                        except IndexError:
-                                if ls < (i + 1) and "*" not in (self[-1],
-                                    other[i]):
-                                        return True
-                                if lo < (i + 1) and "*" not in (self[i],
-                                    other[-1]):
-                                        return True
+        ls = len(self)
+        lo = len(other)
+        for i in range(max(ls, lo)):
+            try:
+                if self[i] != other[i] and ("*" not in (self[i], other[i])):
+                    return True
+            except IndexError:
+                if ls < (i + 1) and "*" not in (self[-1], other[i]):
+                    return True
+                if lo < (i + 1) and "*" not in (self[i], other[-1]):
+                    return True
+        return False
+
+    def __eq__(self, other):
+        if not isinstance(other, DotSequence):
+            return False
+
+        ls = len(self)
+        lo = len(other)
+        for i in range(max(ls, lo)):
+            try:
+                if self[i] != other[i] and ("*" not in (self[i], other[i])):
+                    return False
+            except IndexError:
+                if ls < (i + 1) and "*" not in (self[-1], other[i]):
+                    return False
+                if lo < (i + 1) and "*" not in (self[i], other[-1]):
+                    return False
+        return True
+
+    __hash__ = DotSequence.__hash__
+
+    def is_subsequence(self, other):
+        """Return true if self is a "subsequence" of other, meaning that
+        other and self have identical components, up to the length of
+        self's sequence or self or other is '*'."""
+
+        if str(self) == "*" or str(other) == "*":
+            return True
+
+        if len(self) > len(other):
+            return False
+
+        for a, b in zip(self, other):
+            if a != b:
                 return False
+        return True
 
-        def __eq__(self, other):
-                if not isinstance(other, DotSequence):
-                        return False
+    def is_same_major(self, other):
+        """Test if DotSequences have the same major number, or major
+        is '*'."""
+        return self[0] == "*" or other[0] == "*" or self[0] == other[0]
 
-                ls = len(self)
-                lo = len(other)
-                for i in range(max(ls, lo)):
-                        try:
-                                if self[i] != other[i] and ("*" not in (self[i],
-                                    other[i])):
-                                        return False
-                        except IndexError:
-                                if ls < (i + 1) and "*" not in (self[-1],
-                                    other[i]):
-                                        return False
-                                if lo < (i + 1) and "*" not in (self[i],
-                                    other[-1]):
-                                        return False
-                return True
-
-        __hash__ = DotSequence.__hash__
-
-        def is_subsequence(self, other):
-                """Return true if self is a "subsequence" of other, meaning that
-                other and self have identical components, up to the length of
-                self's sequence or self or other is '*'."""
-
-                if str(self) == "*" or str(other) == "*":
-                        return True
-
-                if len(self) > len(other):
-                        return False
-
-                for a, b in zip(self, other):
-                        if a != b:
-                                return False
-                return True
-
-        def is_same_major(self, other):
-                """Test if DotSequences have the same major number, or major
-                is '*'."""
-                return self[0] == "*" or other[0] == "*" or self[0] == other[0]
-
-        def is_same_minor(self, other):
-                """ Test if DotSequences have the same major and minor num."""
-                return self[0] == "*" or other[0] == "*" or self[1] == "*" or \
-                    other[1] == "*" or \
-                    (self[0] == other[0] and self[1] == other[1])
+    def is_same_minor(self, other):
+        """Test if DotSequences have the same major and minor num."""
+        return (
+            self[0] == "*"
+            or other[0] == "*"
+            or self[1] == "*"
+            or other[1] == "*"
+            or (self[0] == other[0] and self[1] == other[1])
+        )
 
 
 class IllegalVersion(VersionError):
-        """Used to indicate that the specified version string is not valid."""
+    """Used to indicate that the specified version string is not valid."""
+
 
 class Version(object):
-        """Version format is release[,build_release]-branch:datetime, which we
-        decompose into three DotSequences and a date string.  Time
-        representation is in the ISO8601-compliant form "YYYYMMDDTHHMMSSZ",
-        referring to the UTC time associated with the version.  The release and
-        branch DotSequences are interpreted normally, where v1 < v2 implies that
-        v2 is a later release or branch.  The build_release DotSequence records
-        the system on which the package binaries were constructed."""
+    """Version format is release[,build_release]-branch:datetime, which we
+    decompose into three DotSequences and a date string.  Time
+    representation is in the ISO8601-compliant form "YYYYMMDDTHHMMSSZ",
+    referring to the UTC time associated with the version.  The release and
+    branch DotSequences are interpreted normally, where v1 < v2 implies that
+    v2 is a later release or branch.  The build_release DotSequence records
+    the system on which the package binaries were constructed."""
 
-        __slots__ = ["release", "branch", "build_release", "timestr"]
+    __slots__ = ["release", "branch", "build_release", "timestr"]
 
-        def __init__(self, version_string, build_string=None):
-                # XXX If illegally formatted, raise exception.
+    def __init__(self, version_string, build_string=None):
+        # XXX If illegally formatted, raise exception.
 
-                if not version_string:
-                        raise IllegalVersion("Version cannot be empty")
+        if not version_string:
+            raise IllegalVersion("Version cannot be empty")
 
-                #
-                # Locate and extract the time, branch, and build strings,
-                # if specified.  Error checking happens in the second half of
-                # the routine.  In the event that a given part of the input is
-                # signalled but empty (for example: '0.3-' or '0.3-3.0:',
-                # we'll produce an empty (but not None) string for that portion.
-                #
+        #
+        # Locate and extract the time, branch, and build strings,
+        # if specified.  Error checking happens in the second half of
+        # the routine.  In the event that a given part of the input is
+        # signalled but empty (for example: '0.3-' or '0.3-3.0:',
+        # we'll produce an empty (but not None) string for that portion.
+        #
 
-                # Locate and extract the time string, if specified.
-                timeidx = version_string.find(":")
-                if timeidx != -1:
-                        timestr = version_string[timeidx + 1:]
-                else:
-                        timeidx = None
-                        timestr = None
+        # Locate and extract the time string, if specified.
+        timeidx = version_string.find(":")
+        if timeidx != -1:
+            timestr = version_string[timeidx + 1 :]
+        else:
+            timeidx = None
+            timestr = None
 
-                # Locate and extract the branch string, if specified.
-                branchidx = version_string.find("-")
-                if branchidx != -1:
-                        branch = version_string[branchidx + 1:timeidx]
-                else:
-                        branchidx = timeidx
-                        branch = None
+        # Locate and extract the branch string, if specified.
+        branchidx = version_string.find("-")
+        if branchidx != -1:
+            branch = version_string[branchidx + 1 : timeidx]
+        else:
+            branchidx = timeidx
+            branch = None
 
-                # Locate and extract the build string, if specified.
-                buildidx = version_string.find(",")
-                if buildidx != -1:
-                        build = version_string[buildidx + 1:branchidx]
-                else:
-                        buildidx = branchidx
-                        build = None
+        # Locate and extract the build string, if specified.
+        buildidx = version_string.find(",")
+        if buildidx != -1:
+            build = version_string[buildidx + 1 : branchidx]
+        else:
+            buildidx = branchidx
+            build = None
 
-                if buildidx == 0:
-                        raise IllegalVersion("Versions must have a release value")
+        if buildidx == 0:
+            raise IllegalVersion("Versions must have a release value")
 
-                #
-                # Error checking and conversion from strings to objects
-                # begins here.
-                #
-                try:
-                        self.release = DotSequence(version_string[:buildidx])
+        #
+        # Error checking and conversion from strings to objects
+        # begins here.
+        #
+        try:
+            self.release = DotSequence(version_string[:buildidx])
 
-                        if branch is not None:
-                                self.branch = DotSequence(branch)
-                        else:
-                                self.branch = None
+            if branch is not None:
+                self.branch = DotSequence(branch)
+            else:
+                self.branch = None
 
-                        if build is not None:
-                                self.build_release = DotSequence(build)
-                        else:
-                                if build_string is None:
-                                        build_string = "5.11"
-                                self.build_release = DotSequence(build_string)
+            if build is not None:
+                self.build_release = DotSequence(build)
+            else:
+                if build_string is None:
+                    build_string = "5.11"
+                self.build_release = DotSequence(build_string)
 
-                except IllegalDotSequence as e:
-                        raise IllegalVersion("Bad Version: {0}".format(e))
+        except IllegalDotSequence as e:
+            raise IllegalVersion("Bad Version: {0}".format(e))
 
-                #
-                # In 99% of the cases in which we use date and time, it's solely
-                # for comparison.  Since the ISO date string lexicographically
-                # collates in date order, we just hold onto the string-
-                # converting it to anything else is expensive.
-                #
-                if timestr is not None:
-                        if len(timestr) != 16 or timestr[8] != "T" \
-                            or timestr[15] != "Z":
-                                raise IllegalVersion("Time must be ISO8601 format.")
-                        try:
-                                dateint = int(timestr[0:8])
-                                timeint = int(timestr[9:15])
-                                datetime.datetime(dateint // 10000,
-                                    (dateint // 100) % 100,
-                                    dateint % 100,
-                                    timeint // 10000,
-                                    (timeint // 100) % 100,
-                                    timeint % 100)
-                        except ValueError:
-                                raise IllegalVersion("Time must be ISO8601 format.")
+        #
+        # In 99% of the cases in which we use date and time, it's solely
+        # for comparison.  Since the ISO date string lexicographically
+        # collates in date order, we just hold onto the string-
+        # converting it to anything else is expensive.
+        #
+        if timestr is not None:
+            if len(timestr) != 16 or timestr[8] != "T" or timestr[15] != "Z":
+                raise IllegalVersion("Time must be ISO8601 format.")
+            try:
+                dateint = int(timestr[0:8])
+                timeint = int(timestr[9:15])
+                datetime.datetime(
+                    dateint // 10000,
+                    (dateint // 100) % 100,
+                    dateint % 100,
+                    timeint // 10000,
+                    (timeint // 100) % 100,
+                    timeint % 100,
+                )
+            except ValueError:
+                raise IllegalVersion("Time must be ISO8601 format.")
 
-                        self.timestr = timestr
-                else:
-                        self.timestr = None
+            self.timestr = timestr
+        else:
+            self.timestr = None
 
-        @staticmethod
-        def getstate(obj, je_state=None):
-                """Returns the serialized state of this object in a format
-                that that can be easily stored using JSON, pickle, etc."""
-                return str(obj)
+    @staticmethod
+    def getstate(obj, je_state=None):
+        """Returns the serialized state of this object in a format
+        that that can be easily stored using JSON, pickle, etc."""
+        return str(obj)
 
-        @staticmethod
-        def fromstate(state, jd_state=None):
-                """Allocate a new object using previously serialized state
-                obtained via getstate()."""
-                return Version(state, None)
+    @staticmethod
+    def fromstate(state, jd_state=None):
+        """Allocate a new object using previously serialized state
+        obtained via getstate()."""
+        return Version(state, None)
 
-        def __str__(self):
-                outstr = str(self.release) + "," + str(self.build_release)
-                if self.branch:
-                        outstr += "-" + str(self.branch)
-                if self.timestr:
-                        outstr += ":" + self.timestr
-                return outstr
+    def __str__(self):
+        outstr = str(self.release) + "," + str(self.build_release)
+        if self.branch:
+            outstr += "-" + str(self.branch)
+        if self.timestr:
+            outstr += ":" + self.timestr
+        return outstr
 
-        def __repr__(self):
-                return "<pkg.fmri.Version '{0}' at {1:#x}>".format(self,
-                    id(self))
+    def __repr__(self):
+        return "<pkg.fmri.Version '{0}' at {1:#x}>".format(self, id(self))
 
-        def get_version(self, include_build=True):
-                # A fast path with python's f-strings that is often taken.
-                if include_build and self.branch and self.timestr:
-                        return f'{self.release},{self.build_release}-{self.branch}:{self.timestr}'
+    def get_version(self, include_build=True):
+        # A fast path with python's f-strings that is often taken.
+        if include_build and self.branch and self.timestr:
+            return f"{self.release},{self.build_release}-{self.branch}:{self.timestr}"
 
-                if include_build:
-                        outstr = str(self.release) + "," + str(self.build_release)
-                else:
-                        outstr = str(self.release)
-                if self.branch:
-                        outstr += "-" + str(self.branch)
-                if self.timestr:
-                        outstr += ":" + self.timestr
-                return outstr
+        if include_build:
+            outstr = str(self.release) + "," + str(self.build_release)
+        else:
+            outstr = str(self.release)
+        if self.branch:
+            outstr += "-" + str(self.branch)
+        if self.timestr:
+            outstr += ":" + self.timestr
+        return outstr
 
-        def get_short_version(self):
-                branch_str = ""
-                if self.branch is not None:
-                        branch_str = "-{0}".format(self.branch)
-                return "{0}{1}".format(self.release, branch_str)
+    def get_short_version(self):
+        branch_str = ""
+        if self.branch is not None:
+            branch_str = "-{0}".format(self.branch)
+        return "{0}{1}".format(self.release, branch_str)
 
-        def set_timestamp(self, timestamp=datetime.datetime.utcnow()):
-                assert type(timestamp) == datetime.datetime
-                assert timestamp.tzname() == None or timestamp.tzname() == "UTC"
-                self.timestr = timestamp.strftime("%Y%m%dT%H%M%SZ")
+    def set_timestamp(self, timestamp=datetime.datetime.utcnow()):
+        assert type(timestamp) == datetime.datetime
+        assert timestamp.tzname() == None or timestamp.tzname() == "UTC"
+        self.timestr = timestamp.strftime("%Y%m%dT%H%M%SZ")
 
-        def get_timestamp(self):
-                if not self.timestr:
-                        return None
-                t = time.strptime(self.timestr, "%Y%m%dT%H%M%SZ")
-                return datetime.datetime.utcfromtimestamp(calendar.timegm(t))
+    def get_timestamp(self):
+        if not self.timestr:
+            return None
+        t = time.strptime(self.timestr, "%Y%m%dT%H%M%SZ")
+        return datetime.datetime.utcfromtimestamp(calendar.timegm(t))
 
-        def __ne__(self, other):
-                if not isinstance(other, Version):
-                        return True
+    def __ne__(self, other):
+        if not isinstance(other, Version):
+            return True
 
-                if self.release == other.release and \
-                    self.branch == other.branch and \
-                    self.timestr == other.timestr:
-                        return False
+        if (
+            self.release == other.release
+            and self.branch == other.branch
+            and self.timestr == other.timestr
+        ):
+            return False
+        return True
+
+    def __eq__(self, other):
+        if not isinstance(other, Version):
+            return False
+
+        if (
+            self.release == other.release
+            and self.branch == other.branch
+            and self.timestr == other.timestr
+        ):
+            return True
+        return False
+
+    def __lt__(self, other):
+        """Returns True if 'self' comes before 'other', and vice versa.
+
+        If exactly one of the release values of the versions is None,
+        then that version is less than the other.  The same applies to
+        the branch and timestamp components.
+        """
+        if not isinstance(other, Version):
+            return False
+
+        if self.release < other.release:
+            return True
+        if self.release != other.release:
+            return False
+
+        if self.branch != other.branch:
+            if self.branch is None and other.branch:
                 return True
+            if self.branch and other.branch is None:
+                return False
+            if self.branch < other.branch:
+                return True
+            return False
 
-        def __eq__(self, other):
-                if not isinstance(other, Version):
-                        return False
+        if self.timestr != other.timestr:
+            if self.timestr is None and other.timestr:
+                return True
+            if self.timestr and other.timestr is None:
+                return False
+            if self.timestr < other.timestr:
+                return True
+        return False
 
-                if self.release == other.release and \
-                    self.branch == other.branch and \
-                    self.timestr == other.timestr:
-                        return True
+    def __gt__(self, other):
+        """Returns True if 'self' comes after 'other', and vice versa.
+
+        If exactly one of the release values of the versions is None,
+        then that version is less than the other.  The same applies to
+        the branch and timestamp components.
+        """
+        if not isinstance(other, Version):
+            return True
+
+        if self.release > other.release:
+            return True
+        if self.release != other.release:
+            return False
+
+        if self.branch != other.branch:
+            if self.branch and other.branch is None:
+                return True
+            if self.branch is None and other.branch:
+                return False
+            if self.branch > other.branch:
+                return True
+            return False
+
+        if self.timestr != other.timestr:
+            if self.timestr and other.timestr is None:
+                return True
+            if self.timestr is None and other.timestr:
+                return False
+            if self.timestr > other.timestr:
+                return True
+        return False
+
+    def __le__(self, other):
+        return not self > other
+
+    def __ge__(self, other):
+        return not self < other
+
+    def __hash__(self):
+        # If a timestamp is present, it's enough to hash on, and is
+        # nicely unique.  If not, use release and branch, which are
+        # not very unique.
+        if self.timestr:
+            return hash(self.timestr)
+        else:
+            return hash((self.release, self.branch))
+
+    def is_successor(self, other, constraint):
+        """Evaluate true if self is a successor version to other.
+
+        The loosest constraint is CONSTRAINT_NONE (None is treated
+        equivalently, which is a simple test for self > other.  As we
+        proceed through the policies we get stricter, depending on the
+        selected constraint.
+
+        Slightly less loose is CONSTRAINT_AUTO.  In this case, if any of
+        the release, branch, or timestamp components is None, it acts as
+        a "don't care" value -- a versioned component always succeeds
+        None.
+
+        For CONSTRAINT_RELEASE, self is a successor to other if all of
+        the components of other's release match, and there are later
+        components of self's version.  The branch and datetime
+        components are ignored.
+
+        For CONSTRAINT_RELEASE_MAJOR and CONSTRAINT_RELEASE_MINOR, other
+        is effectively truncated to [other[0]] and [other[0], other[1]]
+        prior to being treated as for CONSTRAINT_RELEASE.
+
+        Similarly for CONSTRAINT_BRANCH, the release fields of other and
+        self are expected to be identical, and then the branches are
+        compared as releases were for the CONSTRAINT_RELEASE* policies.
+        """
+
+        if constraint == None or constraint == CONSTRAINT_NONE:
+            return self > other
+
+        if constraint == CONSTRAINT_AUTO and type(other) == MatchingVersion:
+            if other.release and self.release:
+                if not other.release.is_subsequence(self.release):
+                    return False
+            elif other.release and str(other.release) != "*":
                 return False
 
-        def __lt__(self, other):
-                """Returns True if 'self' comes before 'other', and vice versa.
-
-                If exactly one of the release values of the versions is None,
-                then that version is less than the other.  The same applies to
-                the branch and timestamp components.
-                """
-                if not isinstance(other, Version):
-                        return False
-
-                if self.release < other.release:
-                        return True
-                if self.release != other.release:
-                        return False
-
-                if self.branch != other.branch:
-                        if self.branch is None and other.branch:
-                                return True
-                        if self.branch and other.branch is None:
-                                return False
-                        if self.branch < other.branch:
-                                return True
-                        return False
-
-                if self.timestr != other.timestr:
-                        if self.timestr is None and other.timestr:
-                                return True
-                        if self.timestr and other.timestr is None:
-                                return False
-                        if self.timestr < other.timestr:
-                                return True
+            if other.branch and self.branch:
+                if not other.branch.is_subsequence(self.branch):
+                    return False
+            elif other.branch and str(other.branch) != "*":
                 return False
 
-        def __gt__(self, other):
-                """Returns True if 'self' comes after 'other', and vice versa.
-
-                If exactly one of the release values of the versions is None,
-                then that version is less than the other.  The same applies to
-                the branch and timestamp components.
-                """
-                if not isinstance(other, Version):
-                        return True
-
-                if self.release > other.release:
-                        return True
-                if self.release != other.release:
-                        return False
-
-                if self.branch != other.branch:
-                        if self.branch and other.branch is None:
-                                return True
-                        if self.branch is None and other.branch:
-                                return False
-                        if self.branch > other.branch:
-                                return True
-                        return False
-
-                if self.timestr != other.timestr:
-                        if self.timestr and other.timestr is None:
-                                return True
-                        if self.timestr is None and other.timestr:
-                                return False
-                        if self.timestr > other.timestr:
-                                return True
+            if self.timestr and other.timestr:
+                if not (other.timestr == self.timestr or other.timestr == "*"):
+                    return False
+            elif other.timestr and str(other.timestr) != "*":
                 return False
 
-        def __le__(self, other):
-                return not self > other
+            return True
+        elif constraint == CONSTRAINT_AUTO:
+            if other.release and self.release:
+                if not other.release.is_subsequence(self.release):
+                    return False
+            elif other.release:
+                return False
 
-        def __ge__(self, other):
-                return not self < other
+            if other.branch and self.branch:
+                if not other.branch.is_subsequence(self.branch):
+                    return False
+            elif other.branch:
+                return False
 
-        def __hash__(self):
-                # If a timestamp is present, it's enough to hash on, and is
-                # nicely unique.  If not, use release and branch, which are
-                # not very unique.
-                if self.timestr:
-                        return hash(self.timestr)
-                else:
-                        return hash((self.release, self.branch))
+            if self.timestr and other.timestr:
+                if other.timestr != self.timestr:
+                    return False
+            elif other.timestr:
+                return False
 
-        def is_successor(self, other, constraint):
-                """Evaluate true if self is a successor version to other.
+            return True
 
-                The loosest constraint is CONSTRAINT_NONE (None is treated
-                equivalently, which is a simple test for self > other.  As we
-                proceed through the policies we get stricter, depending on the
-                selected constraint.
+        if constraint == CONSTRAINT_RELEASE:
+            return other.release.is_subsequence(self.release)
 
-                Slightly less loose is CONSTRAINT_AUTO.  In this case, if any of
-                the release, branch, or timestamp components is None, it acts as
-                a "don't care" value -- a versioned component always succeeds
-                None.
+        if constraint == CONSTRAINT_RELEASE_MAJOR:
+            return other.release.is_same_major(self.release)
 
-                For CONSTRAINT_RELEASE, self is a successor to other if all of
-                the components of other's release match, and there are later
-                components of self's version.  The branch and datetime
-                components are ignored.
+        if constraint == CONSTRAINT_RELEASE_MINOR:
+            return other.release.is_same_minor(self.release)
 
-                For CONSTRAINT_RELEASE_MAJOR and CONSTRAINT_RELEASE_MINOR, other
-                is effectively truncated to [other[0]] and [other[0], other[1]]
-                prior to being treated as for CONSTRAINT_RELEASE.
+        if constraint == CONSTRAINT_BRANCH:
+            return other.branch.is_subsequence(self.branch)
 
-                Similarly for CONSTRAINT_BRANCH, the release fields of other and
-                self are expected to be identical, and then the branches are
-                compared as releases were for the CONSTRAINT_RELEASE* policies.
-                """
+        if constraint == CONSTRAINT_BRANCH_MAJOR:
+            return other.branch.is_same_major(self.branch)
 
-                if constraint == None or constraint == CONSTRAINT_NONE:
-                        return self > other
+        if constraint == CONSTRAINT_BRANCH_MINOR:
+            return other.branch.is_same_minor(self.branch)
 
-                if constraint == CONSTRAINT_AUTO and \
-                    type(other) == MatchingVersion:
-                        if other.release and self.release:
-                                if not other.release.is_subsequence(
-                                    self.release):
-                                        return False
-                        elif other.release and str(other.release) != "*":
-                                return False
+        raise ValueError("constraint has unknown value")
 
-                        if other.branch and self.branch:
-                                if not other.branch.is_subsequence(self.branch):
-                                        return False
-                        elif other.branch and str(other.branch) != "*":
-                                return False
+    @classmethod
+    def split(self, ver):
+        """Takes an assumed valid version string and splits it into
+        its components as a tuple of the form ((release, build_release,
+        branch, timestr), short_ver)."""
 
-                        if self.timestr and other.timestr:
-                                if not (other.timestr == self.timestr or \
-                                    other.timestr == "*"):
-                                        return False
-                        elif other.timestr and str(other.timestr) != "*":
-                                return False
+        # Locate and extract the time string.
+        timeidx = ver.find(":")
+        if timeidx != -1:
+            timestr = ver[timeidx + 1 :]
+        else:
+            timeidx = None
+            timestr = None
 
-                        return True
-                elif constraint == CONSTRAINT_AUTO:
-                        if other.release and self.release:
-                                if not other.release.is_subsequence(
-                                    self.release):
-                                        return False
-                        elif other.release:
-                                return False
+        # Locate and extract the branch string.
+        branchidx = ver.find("-")
+        if branchidx != -1:
+            branch = ver[branchidx + 1 : timeidx]
+        else:
+            branchidx = timeidx
+            branch = None
 
-                        if other.branch and self.branch:
-                                if not other.branch.is_subsequence(self.branch):
-                                        return False
-                        elif other.branch:
-                                return False
+        # Locate and extract the build string.
+        buildidx = ver.find(",")
+        if buildidx != -1:
+            build = ver[buildidx + 1 : branchidx]
+        else:
+            buildidx = branchidx
+            build = None
 
-                        if self.timestr and other.timestr:
-                                if other.timestr != self.timestr:
-                                        return False
-                        elif other.timestr:
-                                return False
+        release = ver[:buildidx]
 
-                        return True
+        build_release = ""
+        if build is not None:
+            build_release = build
 
-                if constraint == CONSTRAINT_RELEASE:
-                        return other.release.is_subsequence(self.release)
-
-                if constraint == CONSTRAINT_RELEASE_MAJOR:
-                        return other.release.is_same_major(self.release)
-
-                if constraint == CONSTRAINT_RELEASE_MINOR:
-                        return other.release.is_same_minor(self.release)
-
-                if constraint == CONSTRAINT_BRANCH:
-                        return other.branch.is_subsequence(self.branch)
-
-                if constraint == CONSTRAINT_BRANCH_MAJOR:
-                        return other.branch.is_same_major(self.branch)
-
-                if constraint == CONSTRAINT_BRANCH_MINOR:
-                        return other.branch.is_same_minor(self.branch)
-
-                raise ValueError("constraint has unknown value")
-
-        @classmethod
-        def split(self, ver):
-                """Takes an assumed valid version string and splits it into
-                its components as a tuple of the form ((release, build_release,
-                branch, timestr), short_ver)."""
-
-                # Locate and extract the time string.
-                timeidx = ver.find(":")
-                if timeidx != -1:
-                        timestr = ver[timeidx + 1:]
-                else:
-                        timeidx = None
-                        timestr = None
-
-                # Locate and extract the branch string.
-                branchidx = ver.find("-")
-                if branchidx != -1:
-                        branch = ver[branchidx + 1:timeidx]
-                else:
-                        branchidx = timeidx
-                        branch = None
-
-                # Locate and extract the build string.
-                buildidx = ver.find(",")
-                if buildidx != -1:
-                        build = ver[buildidx + 1:branchidx]
-                else:
-                        buildidx = branchidx
-                        build = None
-
-                release = ver[:buildidx]
-
-                build_release = ""
-                if build is not None:
-                        build_release = build
-
-                if branch is not None:
-                        short_ver = release + "-" + branch
-                else:
-                        short_ver = release
-                return (release, build_release, branch, timestr), short_ver
+        if branch is not None:
+            short_ver = release + "-" + branch
+        else:
+            short_ver = release
+        return (release, build_release, branch, timestr), short_ver
 
 
 class MatchingVersion(Version):
-        """An alternative for Version with (much) weaker rules about its format.
-        This is intended to accept user input with globbing characters."""
+    """An alternative for Version with (much) weaker rules about its format.
+    This is intended to accept user input with globbing characters."""
 
+    __slots__ = ["match_latest", "__original"]
 
-        __slots__ = ["match_latest", "__original"]
+    def __init__(self, version_string, build_string=None):
+        if version_string is None or not len(version_string):
+            raise IllegalVersion("Version cannot be empty")
 
-        def __init__(self, version_string, build_string=None):
-                if version_string is None or not len(version_string):
-                        raise IllegalVersion("Version cannot be empty")
+        if version_string == "latest":
+            # Treat special "latest" syntax as equivalent to '*' for
+            # version comparison purposes.
+            self.match_latest = True
+            version_string = "*"
+        else:
+            self.match_latest = False
 
-                if version_string == "latest":
-                        # Treat special "latest" syntax as equivalent to '*' for
-                        # version comparison purposes.
-                        self.match_latest = True
-                        version_string = "*"
-                else:
-                        self.match_latest = False
+        (release, build_release, branch, timestr), ignored = self.split(
+            version_string
+        )
+        if not build_release:
+            build_release = build_string
 
-                (release, build_release, branch, timestr), ignored = \
-                    self.split(version_string)
-                if not build_release:
-                        build_release = build_string
+        #
+        # Error checking and conversion from strings to objects
+        # begins here.
+        #
+        try:
+            #
+            # Every component of the version (after the first) is
+            # optional, if not provided, assume "*" (wildcard).
+            #
+            for attr, vals in (
+                ("release", (release,)),
+                ("build_release", (build_release, "*")),
+                ("branch", (branch, "*")),
+                ("timestr", (timestr, "*")),
+            ):
+                for val in vals:
+                    if not val:
+                        continue
+                    if attr != "timestr":
+                        val = MatchingDotSequence(val)
+                    setattr(self, attr, val)
+                    break
+        except IllegalDotSequence as e:
+            raise IllegalVersion("Bad Version: {0}".format(e))
 
-                #
-                # Error checking and conversion from strings to objects
-                # begins here.
-                #
-                try:
-                        #
-                        # Every component of the version (after the first) is
-                        # optional, if not provided, assume "*" (wildcard).
-                        #
-                        for attr, vals in (
-                            ('release', (release,)),
-                            ('build_release', (build_release, "*")),
-                            ('branch', (branch, "*")),
-                            ('timestr', (timestr, "*"))):
-                                for val in vals:
-                                        if not val:
-                                                continue
-                                        if attr != 'timestr':
-                                                val = MatchingDotSequence(val)
-                                        setattr(self, attr, val)
-                                        break
-                except IllegalDotSequence as e:
-                        raise IllegalVersion("Bad Version: {0}".format(e))
+        outstr = str(release)
+        if build_release is not None:
+            outstr += "," + str(build_release)
+        if branch is not None:
+            outstr += "-" + str(branch)
+        if timestr is not None:
+            outstr += ":" + timestr
 
-                outstr = str(release)
-                if build_release is not None:
-                        outstr += "," + str(build_release)
-                if branch is not None:
-                        outstr += "-" + str(branch)
-                if timestr is not None:
-                        outstr += ":" + timestr
+        # Store the re-constructed input value for use as a string
+        # representation of this object.
+        self.__original = outstr
 
-                # Store the re-constructed input value for use as a string
-                # representation of this object.
-                self.__original = outstr
+    def __str__(self):
+        if self.match_latest:
+            return "latest"
+        return self.__original
 
-        def __str__(self):
-                if self.match_latest:
-                        return "latest"
-                return self.__original
+    def get_timestamp(self):
+        if self.timestr == "*":
+            return "*"
+        return Version.get_timestamp(self)
 
-        def get_timestamp(self):
-                if self.timestr == "*":
-                        return "*"
-                return Version.get_timestamp(self)
+    def __ne__(self, other):
+        if not isinstance(other, Version):
+            return True
 
-        def __ne__(self, other):
-                if not isinstance(other, Version):
-                        return True
+        if (
+            self.release == other.release
+            and self.build_release == other.build_release
+            and self.branch == other.branch
+            and (
+                (self.timestr == other.timestr)
+                or ("*" in (self.timestr, other.timestr))
+            )
+        ):
+            return False
+        return True
 
-                if self.release == other.release and \
-                    self.build_release == other.build_release and \
-                    self.branch == other.branch and \
-                    ((self.timestr == other.timestr) or ("*" in (self.timestr,
-                        other.timestr))):
-                        return False
-                return True
+    def __eq__(self, other):
+        if not isinstance(other, Version):
+            return False
 
-        def __eq__(self, other):
-                if not isinstance(other, Version):
-                        return False
+        if (
+            self.release == other.release
+            and self.build_release == other.build_release
+            and self.branch == other.branch
+            and (
+                (self.timestr == other.timestr)
+                or ("*" in (self.timestr, other.timestr))
+            )
+        ):
+            return True
+        return False
 
-                if self.release == other.release and \
-                    self.build_release == other.build_release and \
-                    self.branch == other.branch and \
-                    ((self.timestr == other.timestr) or ("*" in (self.timestr,
-                        other.timestr))):
-                        return True
-                return False
+    def __lt__(self, other):
+        """Returns True if 'self' comes before 'other', and vice versa.
 
-        def __lt__(self, other):
-                """Returns True if 'self' comes before 'other', and vice versa.
+        If exactly one of the release values of the versions is None or
+        "*", then that version is less than the other.  The same applies
+        to the branch and timestamp components.
+        """
+        if not isinstance(other, Version):
+            return False
 
-                If exactly one of the release values of the versions is None or
-                "*", then that version is less than the other.  The same applies
-                to the branch and timestamp components.
-                """
-                if not isinstance(other, Version):
-                        return False
+        if str(self.release) == "*" and str(other.release) != "*":
+            return True
+        if self.release < other.release:
+            return True
+        if self.release != other.release:
+            return False
 
-                if str(self.release) == "*" and str(other.release) != "*":
-                        return True
-                if self.release < other.release:
-                        return True
-                if self.release != other.release:
-                        return False
+        if str(self.build_release) == "*" and str(other.build_release) != "*":
+            return True
+        if self.build_release < other.build_release:
+            return True
+        if self.build_release != other.build_release:
+            return False
 
-                if str(self.build_release) == "*" and \
-                    str(other.build_release) != "*":
-                        return True
-                if self.build_release < other.build_release:
-                        return True
-                if self.build_release != other.build_release:
-                        return False
+        if str(self.branch) == "*" and str(other.branch) != "*":
+            return True
+        if self.branch < other.branch:
+            return True
+        if self.branch != other.branch:
+            return False
 
-                if str(self.branch) == "*" and str(other.branch) != "*":
-                        return True
-                if self.branch < other.branch:
-                        return True
-                if self.branch != other.branch:
-                        return False
+        if self.timestr == "*" and other.timestr != "*":
+            return True
 
-                if self.timestr == "*" and other.timestr != "*":
-                        return True
+        return self.timestr < other.timestr
 
-                return self.timestr < other.timestr
+    def __gt__(self, other):
+        """Returns True if 'self' comes after 'other', and vice versa.
 
-        def __gt__(self, other):
-                """Returns True if 'self' comes after 'other', and vice versa.
+        If exactly one of the release values of the versions is None or
+        "*", then that version is less than the other.  The same applies
+        to the branch and timestamp components.
+        """
+        if not isinstance(other, Version):
+            return True
 
-                If exactly one of the release values of the versions is None or
-                "*", then that version is less than the other.  The same applies
-                to the branch and timestamp components.
-                """
-                if not isinstance(other, Version):
-                        return True
+        if str(self.release) == "*" and str(other.release) != "*":
+            return False
+        if self.release > other.release:
+            return True
+        if self.release != other.release:
+            return False
 
-                if str(self.release) == "*" and str(other.release) != "*":
-                        return False
-                if self.release > other.release:
-                        return True
-                if self.release != other.release:
-                        return False
+        if str(self.build_release) == "*" and str(other.build_release) != "*":
+            return False
+        if self.build_release > other.build_release:
+            return True
+        if self.build_release != other.build_release:
+            return False
 
-                if str(self.build_release) == "*" and \
-                    str(other.build_release) != "*":
-                        return False
-                if self.build_release > other.build_release:
-                        return True
-                if self.build_release != other.build_release:
-                        return False
+        if str(self.branch) == "*" and str(other.branch) != "*":
+            return False
+        if self.branch > other.branch:
+            return True
+        if self.branch != other.branch:
+            return False
 
-                if str(self.branch) == "*" and str(other.branch) != "*":
-                        return False
-                if self.branch > other.branch:
-                        return True
-                if self.branch != other.branch:
-                        return False
+        if self.timestr == "*" and other.timestr != "*":
+            return False
 
-                if self.timestr == "*" and other.timestr != "*":
-                        return False
+        return self.timestr > other.timestr
 
-                return self.timestr > other.timestr
+    def __hash__(self):
+        # If a timestamp is present, it's enough to hash on, and is
+        # nicely unique.  If not, use release and branch, which are
+        # not very unique.
+        if self.timestr and self.timestr != "*":
+            return hash(self.timestr)
+        else:
+            return hash((self.release, self.branch))
 
-        def __hash__(self):
-                # If a timestamp is present, it's enough to hash on, and is
-                # nicely unique.  If not, use release and branch, which are
-                # not very unique.
-                if self.timestr and self.timestr != "*":
-                        return hash(self.timestr)
-                else:
-                        return hash((self.release, self.branch))
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/pkgdep.py
+++ b/src/pkgdep.py
@@ -37,7 +37,9 @@ import warnings
 # We should be using pkg.site_paths.init() here but doing so stops us being
 # able to find Python dependencies in site-packages, so we just add the
 # extra pkg lib directory.
-import pkg.site_paths; pkg.site_paths.add_pkglib()
+import pkg.site_paths
+
+pkg.site_paths.add_pkglib()
 
 import pkg
 import pkg.actions as actions
@@ -55,41 +57,50 @@ PKG_CLIENT_NAME = "pkgdepend"
 
 DEFAULT_SUFFIX = ".res"
 
+
 def format_update_error(e):
-        # This message is displayed to the user whenever an
-        # ImageFormatUpdateNeeded exception is encountered.
-        emsg("\n")
-        emsg(str(e))
-        emsg(_("To continue, the target image must be upgraded "
+    # This message is displayed to the user whenever an
+    # ImageFormatUpdateNeeded exception is encountered.
+    emsg("\n")
+    emsg(str(e))
+    emsg(
+        _(
+            "To continue, the target image must be upgraded "
             "before it can be used.  See pkg(1) update-format for more "
-            "information."))
+            "information."
+        )
+    )
+
 
 def error(text, cmd=None):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        if cmd:
-                text = "{0}: {1}".format(cmd, text)
-        else:
-                # If we get passed something like an Exception, we can convert
-                # it down to a string.
-                text = str(text)
+    if cmd:
+        text = "{0}: {1}".format(cmd, text)
+    else:
+        # If we get passed something like an Exception, we can convert
+        # it down to a string.
+        text = str(text)
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        emsg(ws + "pkgdepend: " + text_nows)
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    emsg(ws + "pkgdepend: " + text_nows)
+
 
 def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT):
-        """Emit a usage message and optionally prefix it with a more specific
-        error message.  Causes program to exit."""
+    """Emit a usage message and optionally prefix it with a more specific
+    error message.  Causes program to exit."""
 
-        if usage_error:
-                error(usage_error, cmd=cmd)
-        emsg (_("""\
+    if usage_error:
+        error(usage_error, cmd=cmd)
+    emsg(
+        _(
+            """\
 Usage:
         pkgdepend [options] command [cmd_options] [operands]
 
@@ -103,535 +114,606 @@ Options:
         -R dir
         --help or -?
 Environment:
-        PKG_IMAGE"""))
+        PKG_IMAGE"""
+        )
+    )
 
-        sys.exit(retcode)
+    sys.exit(retcode)
+
 
 def generate(args):
-        """Produce a list of file dependencies from a manfiest and a proto
-        area."""
-        try:
-                opts, pargs = getopt.getopt(args, "d:D:Ik:Mm?",
-                    ["help"])
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
+    """Produce a list of file dependencies from a manfiest and a proto
+    area."""
+    try:
+        opts, pargs = getopt.getopt(args, "d:D:Ik:Mm?", ["help"])
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
 
-        remove_internal_deps = True
-        echo_manf = False
-        show_missing = False
-        show_usage = False
-        isa_paths = []
-        run_paths = []
-        platform_paths = []
-        dyn_tok_conv = {}
-        proto_dirs = []
+    remove_internal_deps = True
+    echo_manf = False
+    show_missing = False
+    show_usage = False
+    isa_paths = []
+    run_paths = []
+    platform_paths = []
+    dyn_tok_conv = {}
+    proto_dirs = []
 
-        for opt, arg in opts:
-                if opt == "-d":
-                        if not os.path.isdir(arg):
-                                usage(_("The proto directory {0} could not be "
-                                    "found.".format(arg)), retcode=EXIT_BADOPT)
-                        proto_dirs.append(os.path.abspath(arg))
-                elif opt == "-D":
-                        try:
-                                dyn_tok_name, dyn_tok_val = arg.split("=", 1)
-                        except:
-                                usage(_("-D arguments must be of the form "
-                                    "'name=value'."))
-                        if not dyn_tok_name[0] == "$":
-                                dyn_tok_name = "$" + dyn_tok_name
-                        dyn_tok_conv.setdefault(dyn_tok_name, []).append(
-                            dyn_tok_val)
-                elif opt == "-I":
-                        remove_internal_deps = False
-                elif opt == "-k":
-                        run_paths.append(arg)
-                elif opt == "-m":
-                        echo_manf = True
-                elif opt == "-M":
-                        show_missing = True
-                elif opt in ("--help", "-?"):
-                        show_usage = True
-        if show_usage:
-                usage(retcode=EXIT_OK)
-        if len(pargs) > 2 or len(pargs) < 1:
-                usage(_("Generate only accepts one or two arguments."))
+    for opt, arg in opts:
+        if opt == "-d":
+            if not os.path.isdir(arg):
+                usage(
+                    _(
+                        "The proto directory {0} could not be "
+                        "found.".format(arg)
+                    ),
+                    retcode=EXIT_BADOPT,
+                )
+            proto_dirs.append(os.path.abspath(arg))
+        elif opt == "-D":
+            try:
+                dyn_tok_name, dyn_tok_val = arg.split("=", 1)
+            except:
+                usage(_("-D arguments must be of the form " "'name=value'."))
+            if not dyn_tok_name[0] == "$":
+                dyn_tok_name = "$" + dyn_tok_name
+            dyn_tok_conv.setdefault(dyn_tok_name, []).append(dyn_tok_val)
+        elif opt == "-I":
+            remove_internal_deps = False
+        elif opt == "-k":
+            run_paths.append(arg)
+        elif opt == "-m":
+            echo_manf = True
+        elif opt == "-M":
+            show_missing = True
+        elif opt in ("--help", "-?"):
+            show_usage = True
+    if show_usage:
+        usage(retcode=EXIT_OK)
+    if len(pargs) > 2 or len(pargs) < 1:
+        usage(_("Generate only accepts one or two arguments."))
 
-        if "$ORIGIN" in dyn_tok_conv:
-                usage(_("ORIGIN may not be specified using -D. It will be "
-                    "inferred from the\ninstall paths of the files."))
+    if "$ORIGIN" in dyn_tok_conv:
+        usage(
+            _(
+                "ORIGIN may not be specified using -D. It will be "
+                "inferred from the\ninstall paths of the files."
+            )
+        )
 
-        retcode = EXIT_OK
+    retcode = EXIT_OK
 
-        manf = pargs[0]
+    manf = pargs[0]
 
-        if not os.path.isfile(manf):
-                usage(_("The manifest file {0} could not be found.").format(manf),
-                    retcode=EXIT_BADOPT)
+    if not os.path.isfile(manf):
+        usage(
+            _("The manifest file {0} could not be found.").format(manf),
+            retcode=EXIT_BADOPT,
+        )
 
-        if len(pargs) > 1:
-                if not os.path.isdir(pargs[1]):
-                        usage(_("The proto directory {0} could not be found.").format(
-                            pargs[1]), retcode=EXIT_BADOPT)
-                proto_dirs.insert(0, os.path.abspath(pargs[1]))
-        if not proto_dirs:
-                usage(_("At least one proto directory must be provided."),
-                    retcode=EXIT_BADOPT)
+    if len(pargs) > 1:
+        if not os.path.isdir(pargs[1]):
+            usage(
+                _("The proto directory {0} could not be found.").format(
+                    pargs[1]
+                ),
+                retcode=EXIT_BADOPT,
+            )
+        proto_dirs.insert(0, os.path.abspath(pargs[1]))
+    if not proto_dirs:
+        usage(
+            _("At least one proto directory must be provided."),
+            retcode=EXIT_BADOPT,
+        )
 
-        try:
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(manf,
-                    proto_dirs, dyn_tok_conv, run_paths, remove_internal_deps)
-        except (actions.MalformedActionError, actions.UnknownActionError) as e:
-                error(_("Could not parse manifest {manifest} because of the "
-                    "following line:\n{line}").format(manifest=manf,
-                    line=e.actionstr))
-                return EXIT_OOPS
-        except api_errors.ApiException as e:
-                error(e)
-                return EXIT_OOPS
+    try:
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            manf, proto_dirs, dyn_tok_conv, run_paths, remove_internal_deps
+        )
+    except (actions.MalformedActionError, actions.UnknownActionError) as e:
+        error(
+            _(
+                "Could not parse manifest {manifest} because of the "
+                "following line:\n{line}"
+            ).format(manifest=manf, line=e.actionstr)
+        )
+        return EXIT_OOPS
+    except api_errors.ApiException as e:
+        error(e)
+        return EXIT_OOPS
 
-        if echo_manf:
-                fh = open(manf, "r")
-                for l in fh:
-                        msg(l.rstrip())
-                fh.close()
+    if echo_manf:
+        fh = open(manf, "r")
+        for l in fh:
+            msg(l.rstrip())
+        fh.close()
 
-        for d in sorted(ds, key=str):
-                msg(d)
+    for d in sorted(ds, key=str):
+        msg(d)
 
-        for key, value in six.iteritems(pkg_attrs):
-                msg(actions.attribute.AttributeAction(**{key: value}))
+    for key, value in six.iteritems(pkg_attrs):
+        msg(actions.attribute.AttributeAction(**{key: value}))
 
-        if show_missing:
-                for m in ms:
-                        emsg(m)
-        for w in ws:
-                emsg(w)
+    if show_missing:
+        for m in ms:
+            emsg(m)
+    for w in ws:
+        emsg(w)
 
-        for e in es:
-                emsg(e)
-                retcode = EXIT_OOPS
-        return retcode
+    for e in es:
+        emsg(e)
+        retcode = EXIT_OOPS
+    return retcode
+
 
 def resolve(args, img_dir):
-        """Take a list of manifests and resolve any file dependencies, first
-        against the other published manifests and then against what is installed
-        on the machine."""
-        out_dir = None
-        echo_manifest = False
-        output_to_screen = False
-        suffix = None
-        verbose = False
-        use_system_to_resolve = True
-        constraint_files = []
-        extra_external_info = False
+    """Take a list of manifests and resolve any file dependencies, first
+    against the other published manifests and then against what is installed
+    on the machine."""
+    out_dir = None
+    echo_manifest = False
+    output_to_screen = False
+    suffix = None
+    verbose = False
+    use_system_to_resolve = True
+    constraint_files = []
+    extra_external_info = False
+    try:
+        opts, pargs = getopt.getopt(args, "d:e:Emos:Sv")
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
+    for opt, arg in opts:
+        if opt == "-d":
+            out_dir = arg
+        elif opt == "-e":
+            constraint_files.append(arg)
+        elif opt == "-E":
+            extra_external_info = True
+        elif opt == "-m":
+            echo_manifest = True
+        elif opt == "-o":
+            output_to_screen = True
+        elif opt == "-s":
+            suffix = arg
+        elif opt == "-S":
+            use_system_to_resolve = False
+        elif opt == "-v":
+            verbose = True
+
+    if (out_dir or suffix) and output_to_screen:
+        usage(_("-o cannot be used with -d or -s"))
+
+    manifest_paths = [os.path.abspath(fp) for fp in pargs]
+
+    for manifest in manifest_paths:
+        if not os.path.isfile(manifest):
+            usage(
+                _("The manifest file {0} could not be found.").format(manifest),
+                retcode=EXIT_BADOPT,
+            )
+
+    if out_dir:
+        out_dir = os.path.abspath(out_dir)
+        if not os.path.isdir(out_dir):
+            usage(
+                _("The output directory {0} is not a directory.").format(
+                    out_dir
+                ),
+                retcode=EXIT_BADOPT,
+            )
+
+    provided_image_dir = True
+    pkg_image_used = False
+    if img_dir == None:
+        orig_cwd = None
         try:
-                opts, pargs = getopt.getopt(args, "d:e:Emos:Sv")
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
-        for opt, arg in opts:
-                if opt == "-d":
-                        out_dir = arg
-                elif opt == "-e":
-                        constraint_files.append(arg)
-                elif opt == "-E":
-                        extra_external_info = True
-                elif opt == "-m":
-                        echo_manifest = True
-                elif opt == "-o":
-                        output_to_screen = True
-                elif opt == "-s":
-                        suffix = arg
-                elif opt == "-S":
-                        use_system_to_resolve = False
-                elif opt == "-v":
-                        verbose = True
+            orig_cwd = os.getcwd()
+        except OSError:
+            # May be unreadable by user or have other problem.
+            pass
 
-        if (out_dir or suffix) and output_to_screen:
-                usage(_("-o cannot be used with -d or -s"))
+        img_dir, provided_image_dir = api.get_default_image_root(
+            orig_cwd=orig_cwd
+        )
+        if os.environ.get("PKG_IMAGE"):
+            # It's assumed that this has been checked by the above
+            # function call and hasn't been removed from the
+            # environment.
+            pkg_image_used = True
 
-        manifest_paths = [os.path.abspath(fp) for fp in pargs]
+    if not img_dir:
+        error(
+            _(
+                "Could not find image.  Use the -R option or set "
+                "$PKG_IMAGE to the\nlocation of an image."
+            )
+        )
+        return EXIT_OOPS
 
-        for manifest in manifest_paths:
-                if not os.path.isfile(manifest):
-                        usage(_("The manifest file {0} could not be found.").format(
-                            manifest), retcode=EXIT_BADOPT)
+    system_patterns = misc.EmptyI
+    if constraint_files:
+        system_patterns = []
+        for f in constraint_files:
+            try:
+                with open(f, "r") as fh:
+                    for l in fh:
+                        l = l.strip()
+                        if l and not l.startswith("#"):
+                            system_patterns.append(l)
+            except EnvironmentError as e:
+                if e.errno in (errno.ENOENT, errno.EISDIR):
+                    error(
+                        "{0}: '{1}'".format(e.args[1], e.filename),
+                        cmd="resolve",
+                    )
+                    return EXIT_OOPS
+                raise api_errors._convert_error(e)
+        if not system_patterns:
+            error(
+                _(
+                    "External package list files were provided but "
+                    "did not contain any fmri patterns."
+                )
+            )
+            return EXIT_OOPS
+    elif use_system_to_resolve:
+        system_patterns = ["*"]
 
-        if out_dir:
-                out_dir = os.path.abspath(out_dir)
-                if not os.path.isdir(out_dir):
-                        usage(_("The output directory {0} is not a directory.").format(
-                            out_dir), retcode=EXIT_BADOPT)
-
-        provided_image_dir = True
-        pkg_image_used = False
-        if img_dir == None:
-                orig_cwd = None
-                try:
-                        orig_cwd = os.getcwd()
-                except OSError:
-                        # May be unreadable by user or have other problem.
-                        pass
-
-                img_dir, provided_image_dir = api.get_default_image_root(
-                    orig_cwd=orig_cwd)
-                if os.environ.get("PKG_IMAGE"):
-                        # It's assumed that this has been checked by the above
-                        # function call and hasn't been removed from the
-                        # environment.
-                        pkg_image_used = True
-
-        if not img_dir:
-                error(_("Could not find image.  Use the -R option or set "
-                    "$PKG_IMAGE to the\nlocation of an image."))
-                return EXIT_OOPS
-
-        system_patterns = misc.EmptyI
-        if constraint_files:
-                system_patterns = []
-                for f in constraint_files:
-                        try:
-                                with open(f, "r") as fh:
-                                        for l in fh:
-                                                l = l.strip()
-                                                if l and not l.startswith("#"):
-                                                        system_patterns.append(
-                                                            l)
-                        except EnvironmentError as e:
-                                if e.errno in (errno.ENOENT, errno.EISDIR):
-                                        error("{0}: '{1}'".format(
-                                            e.args[1], e.filename),
-                                            cmd="resolve")
-                                        return EXIT_OOPS
-                                raise api_errors._convert_error(e)
-                if not system_patterns:
-                        error(_("External package list files were provided but "
-                            "did not contain any fmri patterns."))
-                        return EXIT_OOPS
-        elif use_system_to_resolve:
-                system_patterns = ["*"]
-
-        # Becuase building an ImageInterface permanently changes the cwd for
-        # python, it's necessary to do this step after resolving the paths to
-        # the manifests.
-        try:
-                api_inst = api.ImageInterface(img_dir, CLIENT_API_VERSION,
-                    progress.QuietProgressTracker(), None, PKG_CLIENT_NAME,
-                    exact_match=provided_image_dir)
-        except api_errors.ImageNotFoundException as e:
-                if e.user_specified:
-                        if pkg_image_used:
-                                error(_("No image rooted at '{0}' "
-                                    "(set by $PKG_IMAGE)").format(e.user_dir))
-                        else:
-                                error(_("No image rooted at '{0}'").format(
-                                    e.user_dir))
-                else:
-                        error(_("No image found."))
-                return EXIT_OOPS
-        except api_errors.PermissionsException as e:
-                error(e)
-                return EXIT_OOPS
-        except api_errors.ImageFormatUpdateNeeded as e:
-                # This should be a very rare error case.
-                format_update_error(e)
-                return EXIT_OOPS
-
-        try:
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(manifest_paths, api_inst,
-                        system_patterns, prune_attrs=not verbose)
-        except (actions.MalformedActionError, actions.UnknownActionError) as e:
-                error(_("Could not parse one or more manifests because of "
-                    "the following line:\n{0}").format(e.actionstr))
-                return EXIT_OOPS
-        except dependencies.DependencyError as e:
-                error(e)
-                return EXIT_OOPS
-        except api_errors.ApiException as e:
-                error(e)
-                return EXIT_OOPS
-        ret_code = EXIT_OK
-
-        if output_to_screen:
-                ret_code = pkgdeps_to_screen(pkg_deps, manifest_paths,
-                    echo_manifest)
-        elif out_dir:
-                ret_code = pkgdeps_to_dir(pkg_deps, manifest_paths, out_dir,
-                    suffix, echo_manifest)
+    # Becuase building an ImageInterface permanently changes the cwd for
+    # python, it's necessary to do this step after resolving the paths to
+    # the manifests.
+    try:
+        api_inst = api.ImageInterface(
+            img_dir,
+            CLIENT_API_VERSION,
+            progress.QuietProgressTracker(),
+            None,
+            PKG_CLIENT_NAME,
+            exact_match=provided_image_dir,
+        )
+    except api_errors.ImageNotFoundException as e:
+        if e.user_specified:
+            if pkg_image_used:
+                error(
+                    _("No image rooted at '{0}' " "(set by $PKG_IMAGE)").format(
+                        e.user_dir
+                    )
+                )
+            else:
+                error(_("No image rooted at '{0}'").format(e.user_dir))
         else:
-                ret_code = pkgdeps_in_place(pkg_deps, manifest_paths, suffix,
-                    echo_manifest)
+            error(_("No image found."))
+        return EXIT_OOPS
+    except api_errors.PermissionsException as e:
+        error(e)
+        return EXIT_OOPS
+    except api_errors.ImageFormatUpdateNeeded as e:
+        # This should be a very rare error case.
+        format_update_error(e)
+        return EXIT_OOPS
 
-        if extra_external_info:
-                if constraint_files and unused_fmris:
-                        msg(_("\nThe following fmris matched a pattern in a "
-                            "constraint file but were not used in\ndependency "
-                            "resolution:"))
-                        for pfmri in sorted(unused_fmris):
-                                msg("\t{0}".format(pfmri))
-                if not constraint_files and external_deps:
-                        msg(_("\nThe following fmris had dependencies resolve "
-                            "to them:"))
-                        for pfmri in sorted(external_deps):
-                                msg("\t{0}".format(pfmri))
+    try:
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            manifest_paths, api_inst, system_patterns, prune_attrs=not verbose
+        )
+    except (actions.MalformedActionError, actions.UnknownActionError) as e:
+        error(
+            _(
+                "Could not parse one or more manifests because of "
+                "the following line:\n{0}"
+            ).format(e.actionstr)
+        )
+        return EXIT_OOPS
+    except dependencies.DependencyError as e:
+        error(e)
+        return EXIT_OOPS
+    except api_errors.ApiException as e:
+        error(e)
+        return EXIT_OOPS
+    ret_code = EXIT_OK
 
-        for e in errs:
-                if ret_code == EXIT_OK:
-                        ret_code = EXIT_OOPS
-                emsg(e)
-        for w in warnings:
-                emsg(w)
-        return ret_code
+    if output_to_screen:
+        ret_code = pkgdeps_to_screen(pkg_deps, manifest_paths, echo_manifest)
+    elif out_dir:
+        ret_code = pkgdeps_to_dir(
+            pkg_deps, manifest_paths, out_dir, suffix, echo_manifest
+        )
+    else:
+        ret_code = pkgdeps_in_place(
+            pkg_deps, manifest_paths, suffix, echo_manifest
+        )
+
+    if extra_external_info:
+        if constraint_files and unused_fmris:
+            msg(
+                _(
+                    "\nThe following fmris matched a pattern in a "
+                    "constraint file but were not used in\ndependency "
+                    "resolution:"
+                )
+            )
+            for pfmri in sorted(unused_fmris):
+                msg("\t{0}".format(pfmri))
+        if not constraint_files and external_deps:
+            msg(_("\nThe following fmris had dependencies resolve " "to them:"))
+            for pfmri in sorted(external_deps):
+                msg("\t{0}".format(pfmri))
+
+    for e in errs:
+        if ret_code == EXIT_OK:
+            ret_code = EXIT_OOPS
+        emsg(e)
+    for w in warnings:
+        emsg(w)
+    return ret_code
+
 
 def __resolve_echo_line(l):
-        """Given a line from a manifest, determines whether that line should
-        be repeated in the output file if echo manifest has been set."""
+    """Given a line from a manifest, determines whether that line should
+    be repeated in the output file if echo manifest has been set."""
 
-        try:
-                act = actions.fromstr(l.rstrip())
-        except KeyboardInterrupt:
-                raise
-        except actions.ActionError:
-                return True
-        else:
-                return not act.name == "depend"
+    try:
+        act = actions.fromstr(l.rstrip())
+    except KeyboardInterrupt:
+        raise
+    except actions.ActionError:
+        return True
+    else:
+        return not act.name == "depend"
+
 
 def __echo_manifest(pth, out_func, strip_newline=False):
-        try:
-                with open(pth, "r") as fh:
-                        text = ""
-                        act = ""
-                        for l in fh:
-                                text += l
-                                act += l.rstrip()
-                                if act.endswith("\\"):
-                                        act = act.rstrip("\\")
-                                        continue
-                                if __resolve_echo_line(act):
-                                        if strip_newline:
-                                                text = text.rstrip()
-                                        elif text[-1] != "\n":
-                                                text += "\n"
-                                        out_func(text)
-                                text = ""
-                                act = ""
-                        if text != "" and __resolve_echo_line(act):
-                                if text[-1] != "\n":
-                                        text += "\n"
-                                out_func(text)
-        except EnvironmentError:
-                ret_code = EXIT_OOPS
-                emsg(_("Could not open {0} to echo manifest").format(
-                    manifest_path))
+    try:
+        with open(pth, "r") as fh:
+            text = ""
+            act = ""
+            for l in fh:
+                text += l
+                act += l.rstrip()
+                if act.endswith("\\"):
+                    act = act.rstrip("\\")
+                    continue
+                if __resolve_echo_line(act):
+                    if strip_newline:
+                        text = text.rstrip()
+                    elif text[-1] != "\n":
+                        text += "\n"
+                    out_func(text)
+                text = ""
+                act = ""
+            if text != "" and __resolve_echo_line(act):
+                if text[-1] != "\n":
+                    text += "\n"
+                out_func(text)
+    except EnvironmentError:
+        ret_code = EXIT_OOPS
+        emsg(_("Could not open {0} to echo manifest").format(manifest_path))
+
 
 def pkgdeps_to_screen(pkg_deps, manifest_paths, echo_manifest):
-        """Write the resolved package dependencies to stdout.
+    """Write the resolved package dependencies to stdout.
 
-        'pkg_deps' is a dictionary that maps a path to a manifest to the
-        dependencies that were resolved for that manifest.
+    'pkg_deps' is a dictionary that maps a path to a manifest to the
+    dependencies that were resolved for that manifest.
 
-        'manifest_paths' is a list of the paths to the manifests for which
-        file dependencies were resolved.
+    'manifest_paths' is a list of the paths to the manifests for which
+    file dependencies were resolved.
 
-        'echo_manifest' is a boolean which determines whether the original
-        manifest will be written out or not."""
+    'echo_manifest' is a boolean which determines whether the original
+    manifest will be written out or not."""
 
-        ret_code = EXIT_OK
-        first = True
-        for p in manifest_paths:
-                if not first:
-                        msg("\n\n")
-                first = False
-                msg("# {0}".format(p))
-                if echo_manifest:
-                        __echo_manifest(p, msg, strip_newline=True)
-                for d in pkg_deps[p]:
-                        msg(d)
-        return ret_code
+    ret_code = EXIT_OK
+    first = True
+    for p in manifest_paths:
+        if not first:
+            msg("\n\n")
+        first = False
+        msg("# {0}".format(p))
+        if echo_manifest:
+            __echo_manifest(p, msg, strip_newline=True)
+        for d in pkg_deps[p]:
+            msg(d)
+    return ret_code
+
 
 def write_res(deps, out_file, echo_manifest, manifest_path):
-        """Write the dependencies resolved, and possibly the manifest, to the
-        destination file.
+    """Write the dependencies resolved, and possibly the manifest, to the
+    destination file.
 
-        'deps' is a list of the resolved dependencies.
+    'deps' is a list of the resolved dependencies.
 
-        'out_file' is the path to the destination file.
+    'out_file' is the path to the destination file.
 
-        'echo_manifest' determines whether to repeat the original manifest in
-        the destination file.
+    'echo_manifest' determines whether to repeat the original manifest in
+    the destination file.
 
-        'manifest_path' the path to the manifest which generated the
-        dependencies."""
+    'manifest_path' the path to the manifest which generated the
+    dependencies."""
 
-        ret_code = EXIT_OK
-        try:
-                out_fh = open(out_file, "w")
-        except EnvironmentError:
-                ret_code = EXIT_OOPS
-                emsg(_("Could not open output file {0} for writing").format(
-                    out_file))
-                return ret_code
-        if echo_manifest:
-                __echo_manifest(manifest_path, out_fh.write)
-        for d in deps:
-                out_fh.write("{0}\n".format(d))
-        out_fh.close()
+    ret_code = EXIT_OK
+    try:
+        out_fh = open(out_file, "w")
+    except EnvironmentError:
+        ret_code = EXIT_OOPS
+        emsg(_("Could not open output file {0} for writing").format(out_file))
         return ret_code
+    if echo_manifest:
+        __echo_manifest(manifest_path, out_fh.write)
+    for d in deps:
+        out_fh.write("{0}\n".format(d))
+    out_fh.close()
+    return ret_code
+
 
 def pkgdeps_to_dir(pkg_deps, manifest_paths, out_dir, suffix, echo_manifest):
-        """Given an output directory, for each manifest given, writes the
-        dependencies resolved to a file in the output directory.
+    """Given an output directory, for each manifest given, writes the
+    dependencies resolved to a file in the output directory.
 
-        'pkg_deps' is a dictionary that maps a path to a manifest to the
-        dependencies that were resolved for that manifest.
+    'pkg_deps' is a dictionary that maps a path to a manifest to the
+    dependencies that were resolved for that manifest.
 
-        'manifest_paths' is a list of the paths to the manifests for which
-        file dependencies were resolved.
+    'manifest_paths' is a list of the paths to the manifests for which
+    file dependencies were resolved.
 
-        'out_dir' is the path to the directory into which the dependency files
-        should be written.
+    'out_dir' is the path to the directory into which the dependency files
+    should be written.
 
-        'suffix' is the string to append to the end of each output file.
+    'suffix' is the string to append to the end of each output file.
 
-        'echo_manifest' is a boolean which determines whether the original
-        manifest will be written out or not."""
+    'echo_manifest' is a boolean which determines whether the original
+    manifest will be written out or not."""
 
-        ret_code = EXIT_OK
-        if not os.path.exists(out_dir):
-                try:
-                        os.makedirs(out_dir)
-                except EnvironmentError as e:
-                        e_dic = {"dir": out_dir}
-                        if len(e.args) > 0:
-                                e_dic["err"] = e.args[1]
-                        else:
-                                e_dic["err"] = e.args[0]
-                        emsg(_("Out dir {out_dir} does not exist and could "
-                            "not be created. Error is: {err}").format(**e_dic))
-                        return EXIT_OOPS
-        if suffix and suffix[0] != ".":
-                suffix = "." + suffix
-        for p in manifest_paths:
-                out_file = os.path.join(out_dir, os.path.basename(p))
-                if suffix:
-                        out_file += suffix
-                tmp_rc = write_res(pkg_deps[p], out_file, echo_manifest, p)
-                if not ret_code:
-                        ret_code = tmp_rc
-        return ret_code
+    ret_code = EXIT_OK
+    if not os.path.exists(out_dir):
+        try:
+            os.makedirs(out_dir)
+        except EnvironmentError as e:
+            e_dic = {"dir": out_dir}
+            if len(e.args) > 0:
+                e_dic["err"] = e.args[1]
+            else:
+                e_dic["err"] = e.args[0]
+            emsg(
+                _(
+                    "Out dir {out_dir} does not exist and could "
+                    "not be created. Error is: {err}"
+                ).format(**e_dic)
+            )
+            return EXIT_OOPS
+    if suffix and suffix[0] != ".":
+        suffix = "." + suffix
+    for p in manifest_paths:
+        out_file = os.path.join(out_dir, os.path.basename(p))
+        if suffix:
+            out_file += suffix
+        tmp_rc = write_res(pkg_deps[p], out_file, echo_manifest, p)
+        if not ret_code:
+            ret_code = tmp_rc
+    return ret_code
+
 
 def pkgdeps_in_place(pkg_deps, manifest_paths, suffix, echo_manifest):
-        """Given an output directory, for each manifest given, writes the
-        dependencies resolved to a file in the output directory.
+    """Given an output directory, for each manifest given, writes the
+    dependencies resolved to a file in the output directory.
 
-        'pkg_deps' is a dictionary that maps a path to a manifest to the
-        dependencies that were resolved for that manifest.
+    'pkg_deps' is a dictionary that maps a path to a manifest to the
+    dependencies that were resolved for that manifest.
 
-        'manifest_paths' is a list of the paths to the manifests for which
-        file dependencies were resolved.
+    'manifest_paths' is a list of the paths to the manifests for which
+    file dependencies were resolved.
 
-        'out_dir' is the path to the directory into which the dependency files
-        should be written.
+    'out_dir' is the path to the directory into which the dependency files
+    should be written.
 
-        'suffix' is the string to append to the end of each output file.
+    'suffix' is the string to append to the end of each output file.
 
-        'echo_manifest' is a boolean which determines whether the original
-        manifest will be written out or not."""
+    'echo_manifest' is a boolean which determines whether the original
+    manifest will be written out or not."""
 
-        ret_code = EXIT_OK
-        if not suffix:
-                suffix = DEFAULT_SUFFIX
-        if suffix[0] != ".":
-                suffix = "." + suffix
-        for p in manifest_paths:
-                out_file = p + suffix
-                tmp_rc = write_res(pkg_deps[p], out_file, echo_manifest, p)
-                if not ret_code:
-                        ret_code = tmp_rc
-        return ret_code
+    ret_code = EXIT_OK
+    if not suffix:
+        suffix = DEFAULT_SUFFIX
+    if suffix[0] != ".":
+        suffix = "." + suffix
+    for p in manifest_paths:
+        out_file = p + suffix
+        tmp_rc = write_res(pkg_deps[p], out_file, echo_manifest, p)
+        if not ret_code:
+            ret_code = tmp_rc
+    return ret_code
+
 
 def main_func():
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "R:?",
-                    ["help"])
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
+    try:
+        opts, pargs = getopt.getopt(sys.argv[1:], "R:?", ["help"])
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
 
-        show_usage = False
-        img_dir = None
-        for opt, arg in opts:
-                if opt == "-R":
-                        img_dir = arg
-                elif opt in ("--help", "-?"):
-                        show_usage = True
+    show_usage = False
+    img_dir = None
+    for opt, arg in opts:
+        if opt == "-R":
+            img_dir = arg
+        elif opt in ("--help", "-?"):
+            show_usage = True
 
-        subcommand = None
-        if pargs:
-                subcommand = pargs.pop(0)
-                if subcommand == "help":
-                        show_usage = True
+    subcommand = None
+    if pargs:
+        subcommand = pargs.pop(0)
+        if subcommand == "help":
+            show_usage = True
 
-        if show_usage:
-                usage(retcode=EXIT_OK)
-        elif not subcommand:
-                usage()
+    if show_usage:
+        usage(retcode=EXIT_OK)
+    elif not subcommand:
+        usage()
 
-        if subcommand == "generate":
-                if img_dir:
-                        usage(_("generate subcommand doesn't use -R"))
-                return generate(pargs)
-        elif subcommand == "resolve":
-                return resolve(pargs, img_dir)
-        else:
-                usage(_("unknown subcommand '{0}'").format(subcommand))
+    if subcommand == "generate":
+        if img_dir:
+            usage(_("generate subcommand doesn't use -R"))
+        return generate(pargs)
+    elif subcommand == "resolve":
+        return resolve(pargs, img_dir)
+    else:
+        usage(_("unknown subcommand '{0}'").format(subcommand))
+
 
 #
 # Establish a specific exit status which means: "python barfed an exception"
 # so that we can more easily detect these in testing of the CLI commands.
 #
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        # Make all warnings be errors.
-        warnings.simplefilter('error')
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
+    # Make all warnings be errors.
+    warnings.simplefilter("error")
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
 
-        try:
-                __ret = main_func()
-        except api_errors.MissingFileArgumentException as e:
-                error("The manifest file {0} could not be found.".format(e.path))
-                __ret = EXIT_OOPS
-        except api_errors.VersionException as __e:
-                error(_("The {cmd} command appears out of sync with the lib"
-                    "raries provided\nby pkg:/package/pkg. The client version "
-                    "is {client} while the library\nAPI version is {api}").format(
-                    cmd=PKG_CLIENT_NAME,
-                    client=__e.received_version,
-                    api=__e.expected_version
-                    ))
-                __ret = EXIT_OOPS
-        except api_errors.ApiException as e:
-                error(e)
-                __ret = EXIT_OOPS
-        except RuntimeError as _e:
-                emsg("{0}: {1}".format(PKG_CLIENT_NAME, _e))
-                __ret = EXIT_OOPS
-        except (PipeError, KeyboardInterrupt):
-                # We don't want to display any messages here to prevent
-                # possible further broken pipe (EPIPE) errors.
-                __ret = EXIT_OOPS
-        except SystemExit as _e:
-                raise _e
-        except:
-                traceback.print_exc()
-                error(misc.get_traceback_message())
-                __ret = 99
-        sys.exit(__ret)
+    try:
+        __ret = main_func()
+    except api_errors.MissingFileArgumentException as e:
+        error("The manifest file {0} could not be found.".format(e.path))
+        __ret = EXIT_OOPS
+    except api_errors.VersionException as __e:
+        error(
+            _(
+                "The {cmd} command appears out of sync with the lib"
+                "raries provided\nby pkg:/package/pkg. The client version "
+                "is {client} while the library\nAPI version is {api}"
+            ).format(
+                cmd=PKG_CLIENT_NAME,
+                client=__e.received_version,
+                api=__e.expected_version,
+            )
+        )
+        __ret = EXIT_OOPS
+    except api_errors.ApiException as e:
+        error(e)
+        __ret = EXIT_OOPS
+    except RuntimeError as _e:
+        emsg("{0}: {1}".format(PKG_CLIENT_NAME, _e))
+        __ret = EXIT_OOPS
+    except (PipeError, KeyboardInterrupt):
+        # We don't want to display any messages here to prevent
+        # possible further broken pipe (EPIPE) errors.
+        __ret = EXIT_OOPS
+    except SystemExit as _e:
+        raise _e
+    except:
+        traceback.print_exc()
+        error(misc.get_traceback_message())
+        __ret = 99
+    sys.exit(__ret)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/pkgrepo.py
+++ b/src/pkgrepo.py
@@ -24,14 +24,16 @@
 # Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 
 PKG_CLIENT_NAME = "pkgrepo"
 
 # pkgrepo exit codes
-EXIT_OK      = 0
-EXIT_OOPS    = 1
-EXIT_BADOPT  = 2
+EXIT_OK = 0
+EXIT_OOPS = 1
+EXIT_BADOPT = 2
 EXIT_PARTIAL = 3
 EXIT_DIFF = 10
 
@@ -87,64 +89,64 @@ import pkg.server.repository as sr
 
 logger = global_settings.logger
 
+
 @atexit.register
 def cleanup():
-        """To be called at program finish."""
-        for d in tmpdirs:
-                shutil.rmtree(d, True)
+    """To be called at program finish."""
+    for d in tmpdirs:
+        shutil.rmtree(d, True)
 
 
 def error(text, cmd=None):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        if cmd:
-                text = "{0}: {1}".format(cmd, text)
-                pkg_cmd = "pkgrepo "
-        else:
-                pkg_cmd = "pkgrepo: "
+    if cmd:
+        text = "{0}: {1}".format(cmd, text)
+        pkg_cmd = "pkgrepo "
+    else:
+        pkg_cmd = "pkgrepo: "
 
-                # If we get passed something like an Exception, we can convert
-                # it down to a string.
-                text = str(text)
+        # If we get passed something like an Exception, we can convert
+        # it down to a string.
+        text = str(text)
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        logger.error(ws + pkg_cmd + text_nows)
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    logger.error(ws + pkg_cmd + text_nows)
 
 
 def get_tracker(quiet=False):
-        if quiet:
-                progtrack = pkg.client.progress.QuietProgressTracker()
-        else:
-                try:
-                        progtrack = \
-                            pkg.client.progress.FancyUNIXProgressTracker()
-                except pkg.client.progress.ProgressTrackerException:
-                        progtrack = \
-                            pkg.client.progress.CommandLineProgressTracker()
-        return progtrack
+    if quiet:
+        progtrack = pkg.client.progress.QuietProgressTracker()
+    else:
+        try:
+            progtrack = pkg.client.progress.FancyUNIXProgressTracker()
+        except pkg.client.progress.ProgressTrackerException:
+            progtrack = pkg.client.progress.CommandLineProgressTracker()
+    return progtrack
 
 
 def usage(usage_error=None, cmd=None, retcode=2, full=False):
-        """Emit a usage message and optionally prefix it with a more
-        specific error message.  Causes program to exit.
-        """
+    """Emit a usage message and optionally prefix it with a more
+    specific error message.  Causes program to exit.
+    """
 
-        if usage_error:
-                error(usage_error, cmd=cmd)
+    if usage_error:
+        error(usage_error, cmd=cmd)
 
-        if not full:
-                # The full usage message isn't desired.
-                logger.error(_("Try `pkgrepo --help or -?' for more "
-                    "information."))
-                sys.exit(retcode)
+    if not full:
+        # The full usage message isn't desired.
+        logger.error(_("Try `pkgrepo --help or -?' for more " "information."))
+        sys.exit(retcode)
 
-        msg(_("""\
+    msg(
+        _(
+            """\
 Usage:
         pkgrepo [options] command [cmd_options] [operands]
 
@@ -195,2130 +197,2493 @@ Subcommands:
 
 Options:
         --help or -?
-            Displays a usage message."""))
+            Displays a usage message."""
+        )
+    )
 
-        sys.exit(retcode)
+    sys.exit(retcode)
 
 
 class OptionError(Exception):
-        """Option exception. """
+    """Option exception."""
 
-        def __init__(self, *args):
-                Exception.__init__(self, *args)
+    def __init__(self, *args):
+        Exception.__init__(self, *args)
 
 
 def parse_uri(uri):
-        """Parse the repository location provided and attempt to transform it
-        into a valid repository URI.
-        """
+    """Parse the repository location provided and attempt to transform it
+    into a valid repository URI.
+    """
 
-        return publisher.RepositoryURI(misc.parse_uri(uri))
+    return publisher.RepositoryURI(misc.parse_uri(uri))
 
 
 def subcmd_remove(conf, args):
-        subcommand = "remove"
+    subcommand = "remove"
 
-        opts, pargs = getopt.getopt(args, "np:s:d:")
+    opts, pargs = getopt.getopt(args, "np:s:d:")
 
-        dry_run = False
-        dfilter = False
+    dry_run = False
+    dfilter = False
+    pubs = set()
+    for opt, arg in opts:
+        if opt == "-n":
+            dry_run = True
+        elif opt == "-p":
+            pubs.add(arg)
+        elif opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt == "-d":
+            dfilter = arg
+
+    if not pargs:
+        usage(
+            _("At least one package pattern must be provided."), cmd=subcommand
+        )
+
+    if dfilter and not re.match(r"\d{8}$", dfilter):
+        usage(_("Date filter must be YYYYMMDD"), cmd=subcommand)
+
+    # Get repository object.
+    if not conf.get("repo_uri", None):
+        usage(
+            _("A package repository location must be provided " "using -s."),
+            cmd=subcommand,
+        )
+    repo = get_repo(conf, read_only=False, subcommand=subcommand)
+
+    if "all" in pubs:
         pubs = set()
-        for opt, arg in opts:
-                if opt == "-n":
-                        dry_run = True
-                elif opt == "-p":
-                        pubs.add(arg)
-                elif opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt == "-d":
-                        dfilter = arg
 
-        if not pargs:
-                usage(_("At least one package pattern must be provided."),
-                    cmd=subcommand)
+    # Find matching packages.
+    try:
+        matching, refs = repo.get_matching_fmris(pargs, pubs=pubs)
+    except apx.PackageMatchErrors as e:
+        error(str(e), cmd=subcommand)
+        return EXIT_OOPS
 
-        if dfilter and not re.match(r'\d{8}$', dfilter):
-                usage(_("Date filter must be YYYYMMDD"), cmd=subcommand)
-
-        # Get repository object.
-        if not conf.get("repo_uri", None):
-                usage(_("A package repository location must be provided "
-                    "using -s."), cmd=subcommand)
-        repo = get_repo(conf, read_only=False, subcommand=subcommand)
-
-        if "all" in pubs:
-                pubs = set()
-
-        # Find matching packages.
-        try:
-                matching, refs = repo.get_matching_fmris(pargs, pubs=pubs)
-        except apx.PackageMatchErrors as e:
-                error(str(e), cmd=subcommand)
-                return EXIT_OOPS
-
-        if dry_run:
-                # Don't make any changes; display list of packages to be
-                # removed and exit.
-                packages = set(
-                    f for m in matching.values() for f in m
-                    if not dfilter or f.version.timestr.startswith(dfilter)
-                )
-                count = len(packages)
-                plist = "\n".join("\t{0}".format(
-                    p.get_fmri(include_build=False))
-                    for p in sorted(packages))
-                logger.info(_("{count:d} package(s) will be removed:\n"
-                    "{plist}").format(**locals()))
-                return EXIT_OK
-
-        progtrack = get_tracker()
-        packages = collections.defaultdict(list)
-        for m in matching.values():
-                for f in m:
-                        if (not dfilter or
-                            f.version.timestr.startswith(dfilter)):
-                                packages[f.publisher].append(f)
-
-        for pub in packages:
-                logger.info(
-                    _("Removing packages for publisher {0} ...").format(pub))
-                repo.remove_packages(packages[pub], progtrack=progtrack,
-                    pub=pub)
-                if len(packages) > 1:
-                        # Add a newline between each publisher.
-                        logger.info("")
-
+    if dry_run:
+        # Don't make any changes; display list of packages to be
+        # removed and exit.
+        packages = set(
+            f
+            for m in matching.values()
+            for f in m
+            if not dfilter or f.version.timestr.startswith(dfilter)
+        )
+        count = len(packages)
+        plist = "\n".join(
+            "\t{0}".format(p.get_fmri(include_build=False))
+            for p in sorted(packages)
+        )
+        logger.info(
+            _("{count:d} package(s) will be removed:\n" "{plist}").format(
+                **locals()
+            )
+        )
         return EXIT_OK
+
+    progtrack = get_tracker()
+    packages = collections.defaultdict(list)
+    for m in matching.values():
+        for f in m:
+            if not dfilter or f.version.timestr.startswith(dfilter):
+                packages[f.publisher].append(f)
+
+    for pub in packages:
+        logger.info(_("Removing packages for publisher {0} ...").format(pub))
+        repo.remove_packages(packages[pub], progtrack=progtrack, pub=pub)
+        if len(packages) > 1:
+            # Add a newline between each publisher.
+            logger.info("")
+
+    return EXIT_OK
 
 
 def get_repo(conf, allow_invalid=False, read_only=True, subcommand=None):
-        """Return the repository object for current program configuration.
+    """Return the repository object for current program configuration.
 
-        'allow_invalid' specifies whether potentially corrupt repositories are
-        allowed; should only be True if performing a rebuild operation."""
+    'allow_invalid' specifies whether potentially corrupt repositories are
+    allowed; should only be True if performing a rebuild operation."""
 
-        repo_uri = conf["repo_uri"]
-        if repo_uri.scheme != "file":
-                usage(_("Network repositories are not currently supported "
-                    "for this operation."), cmd=subcommand)
+    repo_uri = conf["repo_uri"]
+    if repo_uri.scheme != "file":
+        usage(
+            _(
+                "Network repositories are not currently supported "
+                "for this operation."
+            ),
+            cmd=subcommand,
+        )
 
-        path = repo_uri.get_pathname()
-        if not path:
-                # Bad URI?
-                raise sr.RepositoryInvalidError(str(repo_uri))
-        return sr.Repository(allow_invalid=allow_invalid, read_only=read_only,
-            root=path)
+    path = repo_uri.get_pathname()
+    if not path:
+        # Bad URI?
+        raise sr.RepositoryInvalidError(str(repo_uri))
+    return sr.Repository(
+        allow_invalid=allow_invalid, read_only=read_only, root=path
+    )
 
 
-def setup_transport(repo_uri, subcommand=None, prefix=None, verbose=False,
-    remote_prefix=True, ssl_key=None, ssl_cert=None):
-        if not repo_uri:
-                usage(_("No repository location specified."), cmd=subcommand)
+def setup_transport(
+    repo_uri,
+    subcommand=None,
+    prefix=None,
+    verbose=False,
+    remote_prefix=True,
+    ssl_key=None,
+    ssl_cert=None,
+):
+    if not repo_uri:
+        usage(_("No repository location specified."), cmd=subcommand)
 
-        global tmpdirs
-        temp_root = misc.config_temp_root()
+    global tmpdirs
+    temp_root = misc.config_temp_root()
 
-        tmp_dir = tempfile.mkdtemp(dir=temp_root)
-        tmpdirs.append(tmp_dir)
+    tmp_dir = tempfile.mkdtemp(dir=temp_root)
+    tmpdirs.append(tmp_dir)
 
-        incoming_dir = tempfile.mkdtemp(dir=temp_root)
-        tmpdirs.append(incoming_dir)
+    incoming_dir = tempfile.mkdtemp(dir=temp_root)
+    tmpdirs.append(incoming_dir)
 
-        cache_dir = tempfile.mkdtemp(dir=temp_root)
-        tmpdirs.append(cache_dir)
+    cache_dir = tempfile.mkdtemp(dir=temp_root)
+    tmpdirs.append(cache_dir)
 
-        # Create transport and transport config.
-        xport, xport_cfg = transport.setup_transport()
-        xport_cfg.add_cache(cache_dir, readonly=False)
-        xport_cfg.incoming_root = incoming_dir
-        xport_cfg.pkg_root = tmp_dir
+    # Create transport and transport config.
+    xport, xport_cfg = transport.setup_transport()
+    xport_cfg.add_cache(cache_dir, readonly=False)
+    xport_cfg.incoming_root = incoming_dir
+    xport_cfg.pkg_root = tmp_dir
 
-        if not prefix:
-                pub = "target"
-        else:
-                pub = prefix
+    if not prefix:
+        pub = "target"
+    else:
+        pub = prefix
 
-        # Configure target publisher.
-        src_pub = transport.setup_publisher(str(repo_uri), pub, xport,
-            xport_cfg, remote_prefix=remote_prefix, ssl_key=ssl_key,
-            ssl_cert=ssl_cert)
+    # Configure target publisher.
+    src_pub = transport.setup_publisher(
+        str(repo_uri),
+        pub,
+        xport,
+        xport_cfg,
+        remote_prefix=remote_prefix,
+        ssl_key=ssl_key,
+        ssl_cert=ssl_cert,
+    )
 
-        return xport, src_pub, tmp_dir
+    return xport, src_pub, tmp_dir
+
 
 def subcmd_add_publisher(conf, args):
-        """Add publisher(s) to the specified repository."""
+    """Add publisher(s) to the specified repository."""
 
-        subcommand = "add-publisher"
+    subcommand = "add-publisher"
 
-        opts, pargs = getopt.getopt(args, "s:")
-        for opt, arg in opts:
-                if opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
+    opts, pargs = getopt.getopt(args, "s:")
+    for opt, arg in opts:
+        if opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
 
-        repo_uri = conf.get("repo_uri", None)
-        if not repo_uri:
-                usage(_("No repository location specified."), cmd=subcommand)
-        if repo_uri.scheme != "file":
-                usage(_("Network repositories are not currently supported "
-                    "for this operation."), cmd=subcommand)
+    repo_uri = conf.get("repo_uri", None)
+    if not repo_uri:
+        usage(_("No repository location specified."), cmd=subcommand)
+    if repo_uri.scheme != "file":
+        usage(
+            _(
+                "Network repositories are not currently supported "
+                "for this operation."
+            ),
+            cmd=subcommand,
+        )
 
-        if not pargs:
-                usage(_("At least one publisher must be specified"),
-                    cmd=subcommand)
+    if not pargs:
+        usage(_("At least one publisher must be specified"), cmd=subcommand)
 
-        abort = False
-        for pfx in pargs:
-                if not misc.valid_pub_prefix(pfx):
-                        error(_("Invalid publisher prefix '{0}'").format(pfx),
-                            cmd=subcommand)
-                        abort = True
-        if abort:
-                return EXIT_OOPS
+    abort = False
+    for pfx in pargs:
+        if not misc.valid_pub_prefix(pfx):
+            error(
+                _("Invalid publisher prefix '{0}'").format(pfx), cmd=subcommand
+            )
+            abort = True
+    if abort:
+        return EXIT_OOPS
 
-        repo = get_repo(conf, read_only=False, subcommand=subcommand)
-        make_default = not repo.publishers
-        existing = repo.publishers & set(pargs)
+    repo = get_repo(conf, read_only=False, subcommand=subcommand)
+    make_default = not repo.publishers
+    existing = repo.publishers & set(pargs)
 
-        # Elide the publishers that already exist, but retain the order
-        # publishers were specified in.
-        new_pubs = [
-            pfx for pfx in pargs
-            if pfx not in repo.publishers
-        ]
+    # Elide the publishers that already exist, but retain the order
+    # publishers were specified in.
+    new_pubs = [pfx for pfx in pargs if pfx not in repo.publishers]
 
-        # Tricky logic; _set_pub will happily add new publishers if necessary
-        # and not set any properties if you didn't specify any.
-        rval = _set_pub(conf, subcommand, {}, new_pubs, repo)
+    # Tricky logic; _set_pub will happily add new publishers if necessary
+    # and not set any properties if you didn't specify any.
+    rval = _set_pub(conf, subcommand, {}, new_pubs, repo)
 
-        if make_default:
-                # No publisher existed previously, so set the default publisher
-                # to be the first new one that was added.
-                _set_repo(conf, subcommand, { "publisher": {
-                    "prefix": new_pubs[0] } }, repo)
+    if make_default:
+        # No publisher existed previously, so set the default publisher
+        # to be the first new one that was added.
+        _set_repo(
+            conf, subcommand, {"publisher": {"prefix": new_pubs[0]}}, repo
+        )
 
-        if rval == EXIT_OK and existing:
-                # Some of the publishers that were requested for addition
-                # were already known.
-                error(_("specified publisher(s) already exist: {0}").format(
-                    ", ".join(existing)), cmd=subcommand)
-                if new_pubs:
-                        return EXIT_PARTIAL
-                return EXIT_OOPS
-        return rval
+    if rval == EXIT_OK and existing:
+        # Some of the publishers that were requested for addition
+        # were already known.
+        error(
+            _("specified publisher(s) already exist: {0}").format(
+                ", ".join(existing)
+            ),
+            cmd=subcommand,
+        )
+        if new_pubs:
+            return EXIT_PARTIAL
+        return EXIT_OOPS
+    return rval
+
 
 def subcmd_remove_publisher(conf, args):
-        """Remove publisher(s) from a repository"""
+    """Remove publisher(s) from a repository"""
 
-        subcommand = "remove-publisher"
+    subcommand = "remove-publisher"
 
-        dry_run = False
-        synch = False
-        opts, pargs = getopt.getopt(args, "ns:", ["synchronous"])
-        for opt, arg in opts:
-                if opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt == "-n":
-                        dry_run = True
-                elif opt == "--synchronous":
-                        synch = True
-        repo_uri = conf.get("repo_uri", None)
-        if not repo_uri:
-                usage(_("No repository location specified."), cmd=subcommand)
-        if repo_uri.scheme != "file":
-                usage(_("Network repositories are not currently supported "
-                    "for this operation."), cmd=subcommand)
+    dry_run = False
+    synch = False
+    opts, pargs = getopt.getopt(args, "ns:", ["synchronous"])
+    for opt, arg in opts:
+        if opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt == "-n":
+            dry_run = True
+        elif opt == "--synchronous":
+            synch = True
+    repo_uri = conf.get("repo_uri", None)
+    if not repo_uri:
+        usage(_("No repository location specified."), cmd=subcommand)
+    if repo_uri.scheme != "file":
+        usage(
+            _(
+                "Network repositories are not currently supported "
+                "for this operation."
+            ),
+            cmd=subcommand,
+        )
 
-        if not pargs:
-                usage(_("At least one publisher must be specified"),
-                    cmd=subcommand)
+    if not pargs:
+        usage(_("At least one publisher must be specified"), cmd=subcommand)
 
-        inv_pfxs = []
-        for pfx in pargs:
-                if not misc.valid_pub_prefix(pfx):
-                        inv_pfxs.append(pfx)
+    inv_pfxs = []
+    for pfx in pargs:
+        if not misc.valid_pub_prefix(pfx):
+            inv_pfxs.append(pfx)
 
-        if inv_pfxs:
-                error(_("Invalid publisher prefix(es):\n {0}").format(
-                    "\n ".join(inv_pfxs)), cmd=subcommand)
-                return EXIT_OOPS
+    if inv_pfxs:
+        error(
+            _("Invalid publisher prefix(es):\n {0}").format(
+                "\n ".join(inv_pfxs)
+            ),
+            cmd=subcommand,
+        )
+        return EXIT_OOPS
 
-        repo = get_repo(conf, read_only=False, subcommand=subcommand)
-        existing = repo.publishers & set(pargs)
-        noexisting = [pfx for pfx in pargs
-            if pfx not in repo.publishers]
-        # Publishers left if remove succeeds.
-        left = [pfx for pfx in repo.publishers if pfx not in pargs]
+    repo = get_repo(conf, read_only=False, subcommand=subcommand)
+    existing = repo.publishers & set(pargs)
+    noexisting = [pfx for pfx in pargs if pfx not in repo.publishers]
+    # Publishers left if remove succeeds.
+    left = [pfx for pfx in repo.publishers if pfx not in pargs]
 
-        if noexisting:
-                error(_("The following publisher(s) could not be found:\n "
-                    "{0}").format("\n ".join(noexisting)), cmd=subcommand)
-                return EXIT_OOPS
+    if noexisting:
+        error(
+            _("The following publisher(s) could not be found:\n " "{0}").format(
+                "\n ".join(noexisting)
+            ),
+            cmd=subcommand,
+        )
+        return EXIT_OOPS
 
-        logger.info(_("Removing publisher(s)"))
-        for pfx in existing:
-                rstore = repo.get_pub_rstore(pfx)
-                numpkg = rstore.catalog.package_count
-                logger.info(_("\'{pfx}\'\t({num} package(s))").format(
-                    pfx=pfx, num=str(numpkg)))
+    logger.info(_("Removing publisher(s)"))
+    for pfx in existing:
+        rstore = repo.get_pub_rstore(pfx)
+        numpkg = rstore.catalog.package_count
+        logger.info(
+            _("'{pfx}'\t({num} package(s))").format(pfx=pfx, num=str(numpkg))
+        )
 
-        if dry_run:
-                return EXIT_OK
-
-        defaultpfx = repo.cfg.get_property("publisher", "prefix")
-        repo_path = repo_uri.get_pathname()
-
-        repo.remove_publisher(existing, repo_path, synch)
-        # Change the repository publisher/prefix property, if necessary.
-        if defaultpfx in existing:
-                if len(left) == 1:
-                        _set_repo(conf, subcommand, { "publisher" :  {
-                            "prefix" :  left[0]} }, repo)
-                        msg(_("The default publisher was removed."
-                            " Setting 'publisher/prefix' to '{0}',"
-                            " the only publisher left").format(left[0]))
-                else:
-                        _set_repo(conf, subcommand, { "publisher": {
-                            "prefix" :  ""} }, repo)
-                        msg(_("The default publisher was removed."
-                            " The 'publisher/prefix' property has been"
-                            " unset"))
-
+    if dry_run:
         return EXIT_OK
+
+    defaultpfx = repo.cfg.get_property("publisher", "prefix")
+    repo_path = repo_uri.get_pathname()
+
+    repo.remove_publisher(existing, repo_path, synch)
+    # Change the repository publisher/prefix property, if necessary.
+    if defaultpfx in existing:
+        if len(left) == 1:
+            _set_repo(
+                conf, subcommand, {"publisher": {"prefix": left[0]}}, repo
+            )
+            msg(
+                _(
+                    "The default publisher was removed."
+                    " Setting 'publisher/prefix' to '{0}',"
+                    " the only publisher left"
+                ).format(left[0])
+            )
+        else:
+            _set_repo(conf, subcommand, {"publisher": {"prefix": ""}}, repo)
+            msg(
+                _(
+                    "The default publisher was removed."
+                    " The 'publisher/prefix' property has been"
+                    " unset"
+                )
+            )
+
+    return EXIT_OK
+
 
 def subcmd_create(conf, args):
-        """Create a package repository at the given location."""
+    """Create a package repository at the given location."""
 
-        subcommand = "create"
+    subcommand = "create"
 
-        opts, pargs = getopt.getopt(args, "s:", ["version="])
+    opts, pargs = getopt.getopt(args, "s:", ["version="])
 
-        version = None
-        for opt, arg in opts:
-                if opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt == "--version":
-                        # This option is currently private and allows creating a
-                        # repository with a specific format based on version.
-                        try:
-                                version = int(arg)
-                        except ValueError:
-                                usage(_("Version must be an integer value."),
-                                    cmd=subcommand)
+    version = None
+    for opt, arg in opts:
+        if opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt == "--version":
+            # This option is currently private and allows creating a
+            # repository with a specific format based on version.
+            try:
+                version = int(arg)
+            except ValueError:
+                usage(_("Version must be an integer value."), cmd=subcommand)
 
-        if len(pargs) > 1:
-                usage(_("Only one repository location may be specified."),
-                    cmd=subcommand)
-        elif pargs:
-                conf["repo_uri"] = parse_uri(pargs[0])
+    if len(pargs) > 1:
+        usage(
+            _("Only one repository location may be specified."), cmd=subcommand
+        )
+    elif pargs:
+        conf["repo_uri"] = parse_uri(pargs[0])
 
-        repo_uri = conf.get("repo_uri", None)
-        if not repo_uri:
-                usage(_("No repository location specified."), cmd=subcommand)
-        if repo_uri.scheme != "file":
-                usage(_("Network repositories are not currently supported "
-                    "for this operation."), cmd=subcommand)
+    repo_uri = conf.get("repo_uri", None)
+    if not repo_uri:
+        usage(_("No repository location specified."), cmd=subcommand)
+    if repo_uri.scheme != "file":
+        usage(
+            _(
+                "Network repositories are not currently supported "
+                "for this operation."
+            ),
+            cmd=subcommand,
+        )
 
-        # Attempt to create a repository at the specified location.  Allow
-        # whatever exceptions are raised to bubble up.
-        sr.repository_create(repo_uri, version=version)
+    # Attempt to create a repository at the specified location.  Allow
+    # whatever exceptions are raised to bubble up.
+    sr.repository_create(repo_uri, version=version)
 
-        return EXIT_OK
+    return EXIT_OK
 
 
 def subcmd_get(conf, args):
-        """Display repository properties."""
+    """Display repository properties."""
 
-        subcommand = "get"
-        omit_headers = False
-        out_format = "default"
-        pubs = set()
-        key = None
-        cert = None
+    subcommand = "get"
+    omit_headers = False
+    out_format = "default"
+    pubs = set()
+    key = None
+    cert = None
 
-        opts, pargs = getopt.getopt(args, "F:Hp:s:", ["key=", "cert="])
-        for opt, arg in opts:
-                if opt == "-F":
-                        if arg not in LISTING_FORMATS:
-                                raise apx.InvalidOptionError(
-                                    apx.InvalidOptionError.ARG_INVALID,
-                                    [arg, opt])
-                        out_format = arg
-                elif opt == "-H":
-                        omit_headers = True
-                elif opt == "-p":
-                        pubs.add(arg)
-                elif opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt == "--key":
-                        key = arg
-                elif opt == "--cert":
-                        cert = arg
+    opts, pargs = getopt.getopt(args, "F:Hp:s:", ["key=", "cert="])
+    for opt, arg in opts:
+        if opt == "-F":
+            if arg not in LISTING_FORMATS:
+                raise apx.InvalidOptionError(
+                    apx.InvalidOptionError.ARG_INVALID, [arg, opt]
+                )
+            out_format = arg
+        elif opt == "-H":
+            omit_headers = True
+        elif opt == "-p":
+            pubs.add(arg)
+        elif opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt == "--key":
+            key = arg
+        elif opt == "--cert":
+            cert = arg
 
-        # Setup transport so configuration can be retrieved.
-        if not conf.get("repo_uri", None):
-                usage(_("A package repository location must be provided "
-                    "using -s."), cmd=subcommand)
-        xport, xpub, tmp_dir = setup_transport(conf.get("repo_uri"),
-            subcommand=subcommand, ssl_key=key, ssl_cert=cert)
+    # Setup transport so configuration can be retrieved.
+    if not conf.get("repo_uri", None):
+        usage(
+            _("A package repository location must be provided " "using -s."),
+            cmd=subcommand,
+        )
+    xport, xpub, tmp_dir = setup_transport(
+        conf.get("repo_uri"), subcommand=subcommand, ssl_key=key, ssl_cert=cert
+    )
 
-        # Get properties.
-        if pubs:
-                return _get_pub(conf, subcommand, xport, xpub, omit_headers,
-                    out_format, pubs, pargs)
-        return _get_repo(conf, subcommand, xport, xpub, omit_headers,
-            out_format, pargs)
+    # Get properties.
+    if pubs:
+        return _get_pub(
+            conf, subcommand, xport, xpub, omit_headers, out_format, pubs, pargs
+        )
+    return _get_repo(
+        conf, subcommand, xport, xpub, omit_headers, out_format, pargs
+    )
 
 
 def _get_repo(conf, subcommand, xport, xpub, omit_headers, out_format, pargs):
-        """Display repository properties."""
+    """Display repository properties."""
 
-        # Configuration index is indexed by section name and property name.
-        # Retrieve and flatten it to simplify listing process.
-        stat_idx = xport.get_status(xpub)
-        cfg_idx = stat_idx.get("repository", {}).get("configuration", {})
-        props = set()
+    # Configuration index is indexed by section name and property name.
+    # Retrieve and flatten it to simplify listing process.
+    stat_idx = xport.get_status(xpub)
+    cfg_idx = stat_idx.get("repository", {}).get("configuration", {})
+    props = set()
 
-        # Set minimum widths for section and property name columns by using the
-        # length of the column headers.
-        max_sname_len = len(_("SECTION"))
-        max_pname_len = len(_("PROPERTY"))
+    # Set minimum widths for section and property name columns by using the
+    # length of the column headers.
+    max_sname_len = len(_("SECTION"))
+    max_pname_len = len(_("PROPERTY"))
 
-        for sname in cfg_idx:
-                max_sname_len = max(max_sname_len, len(sname))
-                for pname in cfg_idx[sname]:
-                        max_pname_len = max(max_pname_len, len(pname))
-                        props.add("/".join((sname, pname)))
+    for sname in cfg_idx:
+        max_sname_len = max(max_sname_len, len(sname))
+        for pname in cfg_idx[sname]:
+            max_pname_len = max(max_pname_len, len(pname))
+            props.add("/".join((sname, pname)))
 
-        req_props = set(pargs)
-        if len(req_props) >= 1:
-                found = props & req_props
-                notfound = req_props - found
-                del props
-        else:
-                found = props
-                notfound = set()
+    req_props = set(pargs)
+    if len(req_props) >= 1:
+        found = props & req_props
+        notfound = req_props - found
+        del props
+    else:
+        found = props
+        notfound = set()
 
-        def gen_listing():
-                for prop in sorted(found):
-                        sname, pname = prop.rsplit("/", 1)
-                        sval = cfg_idx[sname][pname]
-                        yield {
-                            "section": sname,
-                            "property": pname,
-                            "value": sval,
-                        }
+    def gen_listing():
+        for prop in sorted(found):
+            sname, pname = prop.rsplit("/", 1)
+            sval = cfg_idx[sname][pname]
+            yield {
+                "section": sname,
+                "property": pname,
+                "value": sval,
+            }
 
-        #    SECTION PROPERTY VALUE
-        #    <sec_1> <prop_1> <prop_1_value>
-        #    <sec_2> <prop_2> <prop_2_value>
-        #    ...
-        field_data = {
-            "section" : [("default", "json", "tsv"), _("SECTION"), ""],
-            "property" : [("default", "json", "tsv"), _("PROPERTY"), ""],
-            "value" : [("default", "json", "tsv"), _("VALUE"), ""],
+    #    SECTION PROPERTY VALUE
+    #    <sec_1> <prop_1> <prop_1_value>
+    #    <sec_2> <prop_2> <prop_2_value>
+    #    ...
+    field_data = {
+        "section": [("default", "json", "tsv"), _("SECTION"), ""],
+        "property": [("default", "json", "tsv"), _("PROPERTY"), ""],
+        "value": [("default", "json", "tsv"), _("VALUE"), ""],
+    }
+    desired_field_order = (_("SECTION"), _("PROPERTY"), _("VALUE"))
+
+    # Default output formatting.
+    def_fmt = (
+        "{0:" + str(max_sname_len) + "} {1:" + str(max_pname_len) + "} {2}"
+    )
+
+    if found or (not req_props and out_format == "default"):
+        # print without trailing newline.
+        sys.stdout.write(
+            misc.get_listing(
+                desired_field_order,
+                field_data,
+                gen_listing(),
+                out_format,
+                def_fmt,
+                omit_headers,
+            )
+        )
+
+    if found and notfound:
+        return EXIT_PARTIAL
+    if req_props and not found:
+        if out_format == "default":
+            # Don't pollute other output formats.
+            error(_("no matching properties found"), cmd=subcommand)
+        return EXIT_OOPS
+    return EXIT_OK
+
+
+def _get_matching_pubs(
+    subcommand,
+    pubs,
+    xport,
+    xpub,
+    out_format="default",
+    use_transport=False,
+    repo_uri=None,
+):
+    # Retrieve publisher information.
+    pub_data = xport.get_publisherdata(xpub)
+    known_pubs = set(p.prefix for p in pub_data)
+    if len(pubs) > 0 and "all" not in pubs:
+        found = known_pubs & pubs
+        notfound = pubs - found
+        pub_data = [p for p in pub_data if p.prefix in found]
+    else:
+        found = known_pubs
+        notfound = set()
+
+    if use_transport:
+        # Assign transport information.
+        for p in pub_data:
+            p.repository = xpub.repository
+
+    # Establish initial return value and perform early exit if appropriate.
+    rval = EXIT_OK
+    if found and notfound:
+        rval = EXIT_PARTIAL
+    elif pubs and not found:
+        if out_format == "default":
+            # Don't pollute other output formats.
+            err_msg = _("no matching publishers found")
+            if repo_uri:
+                err_msg = _(
+                    "no matching publishers found in " "repository: {0}"
+                ).format(repo_uri)
+            error(err_msg, cmd=subcommand)
+        return EXIT_OOPS, None, None
+    return rval, found, pub_data
+
+
+def _get_pub(
+    conf, subcommand, xport, xpub, omit_headers, out_format, pubs, pargs
+):
+    """Display publisher properties."""
+
+    rval, found, pub_data = _get_matching_pubs(
+        subcommand, pubs, xport, xpub, out_format=out_format
+    )
+    if rval == EXIT_OOPS:
+        return rval
+
+    # Set minimum widths for section and property name columns by using the
+    # length of the column headers and data.
+    max_pubname_len = str(max([len(_("PUBLISHER"))] + [len(p) for p in found]))
+    max_sname_len = len(_("SECTION"))
+    max_pname_len = len(_("PROPERTY"))
+
+    # For each requested publisher, retrieve the requested property data.
+    pub_idx = {}
+    for pub in pub_data:
+        pub_idx[pub.prefix] = {
+            "publisher": {
+                "alias": pub.alias,
+                "prefix": pub.prefix,
+            },
         }
-        desired_field_order = (_("SECTION"), _("PROPERTY"), _("VALUE"))
 
-        # Default output formatting.
-        def_fmt = "{0:" + str(max_sname_len) + "} {1:" + str(max_pname_len) + \
-            "} {2}"
-
-        if found or (not req_props and out_format == "default"):
-                # print without trailing newline.
-                sys.stdout.write(misc.get_listing(desired_field_order,
-                    field_data, gen_listing(), out_format, def_fmt,
-                    omit_headers))
-
-        if found and notfound:
-                return EXIT_PARTIAL
-        if req_props and not found:
-                if out_format == "default":
-                        # Don't pollute other output formats.
-                        error(_("no matching properties found"),
-                            cmd=subcommand)
-                return EXIT_OOPS
-        return EXIT_OK
-
-
-def _get_matching_pubs(subcommand, pubs, xport, xpub, out_format="default",
-    use_transport=False, repo_uri=None):
-
-        # Retrieve publisher information.
-        pub_data = xport.get_publisherdata(xpub)
-        known_pubs = set(p.prefix for p in pub_data)
-        if len(pubs) > 0 and "all" not in pubs:
-                found = known_pubs & pubs
-                notfound = pubs - found
-                pub_data = [p for p in pub_data if p.prefix in found]
+        pub_repo = pub.repository
+        if pub_repo:
+            pub_idx[pub.prefix]["repository"] = {
+                "collection-type": pub_repo.collection_type,
+                "description": pub_repo.description,
+                "legal-uris": pub_repo.legal_uris,
+                "mirrors": pub_repo.mirrors,
+                "name": pub_repo.name,
+                "origins": pub_repo.origins,
+                "refresh-seconds": pub_repo.refresh_seconds,
+                "registration-uri": pub_repo.registration_uri,
+                "related-uris": pub_repo.related_uris,
+            }
         else:
-                found = known_pubs
-                notfound = set()
+            pub_idx[pub.prefix]["repository"] = {
+                "collection-type": "core",
+                "description": "",
+                "legal-uris": [],
+                "mirrors": [],
+                "name": "",
+                "origins": [],
+                "refresh-seconds": "",
+                "registration-uri": "",
+                "related-uris": [],
+            }
 
-        if use_transport:
-                # Assign transport information.
-                for p in pub_data:
-                        p.repository = xpub.repository
+    # Determine possible set of properties and lengths.
+    props = set()
+    for pub in pub_idx:
+        for sname in pub_idx[pub]:
+            max_sname_len = max(max_sname_len, len(sname))
+            for pname in pub_idx[pub][sname]:
+                max_pname_len = max(max_pname_len, len(pname))
+                props.add("/".join((sname, pname)))
 
-        # Establish initial return value and perform early exit if appropriate.
-        rval = EXIT_OK
-        if found and notfound:
-                rval = EXIT_PARTIAL
-        elif pubs and not found:
-                if out_format == "default":
-                        # Don't pollute other output formats.
-                        err_msg = _("no matching publishers found")
-                        if repo_uri:
-                                err_msg = _("no matching publishers found in "
-                                    "repository: {0}").format(repo_uri)
-                        error(err_msg, cmd=subcommand)
-                return EXIT_OOPS, None, None
-        return rval, found, pub_data
+    # Determine properties to display.
+    req_props = set(pargs)
+    if len(req_props) >= 1:
+        found = props & req_props
+        notfound = req_props - found
+        del props
+    else:
+        found = props
+        notfound = set()
 
-
-def _get_pub(conf, subcommand, xport, xpub, omit_headers, out_format, pubs,
-    pargs):
-        """Display publisher properties."""
-
-        rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport,
-            xpub, out_format=out_format)
-        if rval == EXIT_OOPS:
-                return rval
-
-        # Set minimum widths for section and property name columns by using the
-        # length of the column headers and data.
-        max_pubname_len = str(max(
-            [len(_("PUBLISHER"))] + [len(p) for p in found]
-        ))
-        max_sname_len = len(_("SECTION"))
-        max_pname_len = len(_("PROPERTY"))
-
-        # For each requested publisher, retrieve the requested property data.
-        pub_idx = {}
-        for pub in pub_data:
-                pub_idx[pub.prefix] = {
-                    "publisher": {
-                        "alias": pub.alias,
-                        "prefix": pub.prefix,
-                    },
+    def gen_listing():
+        for pub in sorted(pub_idx.keys()):
+            for prop in sorted(found):
+                sname, pname = prop.rsplit("/", 1)
+                sval = pub_idx[pub][sname][pname]
+                yield {
+                    "publisher": pub,
+                    "section": sname,
+                    "property": pname,
+                    "value": sval,
                 }
 
-                pub_repo = pub.repository
-                if pub_repo:
-                        pub_idx[pub.prefix]["repository"] = {
-                            "collection-type": pub_repo.collection_type,
-                            "description": pub_repo.description,
-                            "legal-uris": pub_repo.legal_uris,
-                            "mirrors": pub_repo.mirrors,
-                            "name": pub_repo.name,
-                            "origins": pub_repo.origins,
-                            "refresh-seconds": pub_repo.refresh_seconds,
-                            "registration-uri": pub_repo.registration_uri,
-                            "related-uris": pub_repo.related_uris,
-                        }
-                else:
-                        pub_idx[pub.prefix]["repository"] = {
-                            "collection-type": "core",
-                            "description": "",
-                            "legal-uris": [],
-                            "mirrors": [],
-                            "name": "",
-                            "origins": [],
-                            "refresh-seconds": "",
-                            "registration-uri": "",
-                            "related-uris": [],
-                        }
+    #    PUBLISHER SECTION PROPERTY VALUE
+    #    <pub_1>   <sec_1> <prop_1> <prop_1_value>
+    #    <pub_1>   <sec_2> <prop_2> <prop_2_value>
+    #    ...
+    field_data = {
+        "publisher": [("default", "json", "tsv"), _("PUBLISHER"), ""],
+        "section": [("default", "json", "tsv"), _("SECTION"), ""],
+        "property": [("default", "json", "tsv"), _("PROPERTY"), ""],
+        "value": [("default", "json", "tsv"), _("VALUE"), ""],
+    }
+    desired_field_order = (
+        _("PUBLISHER"),
+        _("SECTION"),
+        _("PROPERTY"),
+        _("VALUE"),
+    )
 
-        # Determine possible set of properties and lengths.
-        props = set()
-        for pub in pub_idx:
-                for sname in pub_idx[pub]:
-                        max_sname_len = max(max_sname_len, len(sname))
-                        for pname in pub_idx[pub][sname]:
-                                max_pname_len = max(max_pname_len, len(pname))
-                                props.add("/".join((sname, pname)))
+    # Default output formatting.
+    def_fmt = (
+        "{0:"
+        + str(max_pubname_len)
+        + "} {1:"
+        + str(max_sname_len)
+        + "} {2:"
+        + str(max_pname_len)
+        + "} {3}"
+    )
 
-        # Determine properties to display.
-        req_props = set(pargs)
-        if len(req_props) >= 1:
-                found = props & req_props
-                notfound = req_props - found
-                del props
-        else:
-                found = props
-                notfound = set()
+    if found or (not req_props and out_format == "default"):
+        # print without trailing newline.
+        sys.stdout.write(
+            misc.get_listing(
+                desired_field_order,
+                field_data,
+                gen_listing(),
+                out_format,
+                def_fmt,
+                omit_headers,
+            )
+        )
 
-        def gen_listing():
-                for pub in sorted(pub_idx.keys()):
-                        for prop in sorted(found):
-                                sname, pname = prop.rsplit("/", 1)
-                                sval = pub_idx[pub][sname][pname]
-                                yield {
-                                    "publisher": pub,
-                                    "section": sname,
-                                    "property": pname,
-                                    "value": sval,
-                                }
-
-        #    PUBLISHER SECTION PROPERTY VALUE
-        #    <pub_1>   <sec_1> <prop_1> <prop_1_value>
-        #    <pub_1>   <sec_2> <prop_2> <prop_2_value>
-        #    ...
-        field_data = {
-            "publisher" : [("default", "json", "tsv"), _("PUBLISHER"), ""],
-            "section" : [("default", "json", "tsv"), _("SECTION"), ""],
-            "property" : [("default", "json", "tsv"), _("PROPERTY"), ""],
-            "value" : [("default", "json", "tsv"), _("VALUE"), ""],
-        }
-        desired_field_order = (_("PUBLISHER"), _("SECTION"), _("PROPERTY"),
-            _("VALUE"))
-
-        # Default output formatting.
-        def_fmt = "{0:" + str(max_pubname_len) + "} {1:" + str(max_sname_len) + \
-            "} {2:" + str(max_pname_len) + "} {3}"
-
-        if found or (not req_props and out_format == "default"):
-                # print without trailing newline.
-                sys.stdout.write(misc.get_listing(desired_field_order,
-                    field_data, gen_listing(), out_format, def_fmt,
-                    omit_headers))
-
-        if found and notfound:
-                rval = EXIT_PARTIAL
-        if req_props and not found:
-                if out_format == "default":
-                        # Don't pollute other output formats.
-                        error(_("no matching properties found"),
-                            cmd=subcommand)
-                rval = EXIT_OOPS
-        return rval
+    if found and notfound:
+        rval = EXIT_PARTIAL
+    if req_props and not found:
+        if out_format == "default":
+            # Don't pollute other output formats.
+            error(_("no matching properties found"), cmd=subcommand)
+        rval = EXIT_OOPS
+    return rval
 
 
 def subcmd_info(conf, args):
-        """Display a list of known publishers and a summary of known packages
-        and when the package data for the given publisher was last updated.
-        """
+    """Display a list of known publishers and a summary of known packages
+    and when the package data for the given publisher was last updated.
+    """
 
-        subcommand = "info"
-        omit_headers = False
-        out_format = "default"
-        pubs = set()
-        key = None
-        cert = None
+    subcommand = "info"
+    omit_headers = False
+    out_format = "default"
+    pubs = set()
+    key = None
+    cert = None
 
-        opts, pargs = getopt.getopt(args, "F:Hp:s:", ["key=", "cert="])
-        for opt, arg in opts:
-                if opt == "-F":
-                        if arg not in LISTING_FORMATS:
-                                raise apx.InvalidOptionError(
-                                    apx.InvalidOptionError.ARG_INVALID,
-                                    [arg, opt])
-                        out_format = arg
-                elif opt == "-H":
-                        omit_headers = True
-                elif opt == "-p":
-                        pubs.add(arg)
-                elif opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt == "--key":
-                        key = arg
-                elif opt == "--cert":
-                        cert = arg
+    opts, pargs = getopt.getopt(args, "F:Hp:s:", ["key=", "cert="])
+    for opt, arg in opts:
+        if opt == "-F":
+            if arg not in LISTING_FORMATS:
+                raise apx.InvalidOptionError(
+                    apx.InvalidOptionError.ARG_INVALID, [arg, opt]
+                )
+            out_format = arg
+        elif opt == "-H":
+            omit_headers = True
+        elif opt == "-p":
+            pubs.add(arg)
+        elif opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt == "--key":
+            key = arg
+        elif opt == "--cert":
+            cert = arg
 
-        if pargs:
-                usage(_("command does not take operands"), cmd=subcommand)
+    if pargs:
+        usage(_("command does not take operands"), cmd=subcommand)
 
-        # Setup transport so status can be retrieved.
-        if not conf.get("repo_uri", None):
-                usage(_("A package repository location must be provided "
-                    "using -s."), cmd=subcommand)
-        xport, xpub, tmp_dir = setup_transport(conf.get("repo_uri"),
-            subcommand=subcommand, ssl_key=key, ssl_cert=cert)
+    # Setup transport so status can be retrieved.
+    if not conf.get("repo_uri", None):
+        usage(
+            _("A package repository location must be provided " "using -s."),
+            cmd=subcommand,
+        )
+    xport, xpub, tmp_dir = setup_transport(
+        conf.get("repo_uri"), subcommand=subcommand, ssl_key=key, ssl_cert=cert
+    )
 
-        # Retrieve repository status information.
-        stat_idx = xport.get_status(xpub)
-        pub_idx = stat_idx.get("repository", {}).get("publishers", {})
-        if len(pubs) > 0 and "all" not in pubs:
-                found = set(pub_idx.keys()) & pubs
-                notfound = pubs - found
-        else:
-                found = set(pub_idx.keys())
-                notfound = set()
+    # Retrieve repository status information.
+    stat_idx = xport.get_status(xpub)
+    pub_idx = stat_idx.get("repository", {}).get("publishers", {})
+    if len(pubs) > 0 and "all" not in pubs:
+        found = set(pub_idx.keys()) & pubs
+        notfound = pubs - found
+    else:
+        found = set(pub_idx.keys())
+        notfound = set()
 
-        def gen_listing():
-                for pfx in sorted(found):
-                        pdata = pub_idx[pfx]
-                        pkg_count = pdata.get("package-count", 0)
-                        last_update = pdata.get("last-catalog-update", "")
-                        if last_update:
-                                # Reformat the date into something more user
-                                # friendly (and locale specific).
-                                last_update = pkg.catalog.basic_ts_to_datetime(
-                                    last_update)
-                                last_update = "{0}Z".format(
-                                    pkg.catalog.datetime_to_ts(last_update))
-                        rstatus = _(pub_idx[pfx].get("status", "online"))
-                        yield {
-                            "publisher": pfx,
-                            "packages": pkg_count,
-                            "status": rstatus,
-                            "updated": last_update,
-                        }
+    def gen_listing():
+        for pfx in sorted(found):
+            pdata = pub_idx[pfx]
+            pkg_count = pdata.get("package-count", 0)
+            last_update = pdata.get("last-catalog-update", "")
+            if last_update:
+                # Reformat the date into something more user
+                # friendly (and locale specific).
+                last_update = pkg.catalog.basic_ts_to_datetime(last_update)
+                last_update = "{0}Z".format(
+                    pkg.catalog.datetime_to_ts(last_update)
+                )
+            rstatus = _(pub_idx[pfx].get("status", "online"))
+            yield {
+                "publisher": pfx,
+                "packages": pkg_count,
+                "status": rstatus,
+                "updated": last_update,
+            }
 
-        #    PUBLISHER PACKAGES        STATUS   UPDATED
-        #    <pub_1>   <num_uniq_pkgs> <status> <cat_last_modified>
-        #    <pub_2>   <num_uniq_pkgs> <status> <cat_last_modified>
-        #    ...
-        field_data = {
-            "publisher" : [("default", "json", "tsv"), _("PUBLISHER"), ""],
-            "packages" : [("default", "json", "tsv"), _("PACKAGES"), ""],
-            "status" : [("default", "json", "tsv"), _("STATUS"), ""],
-            "updated" : [("default", "json", "tsv"), _("UPDATED"), ""],
-        }
+    #    PUBLISHER PACKAGES        STATUS   UPDATED
+    #    <pub_1>   <num_uniq_pkgs> <status> <cat_last_modified>
+    #    <pub_2>   <num_uniq_pkgs> <status> <cat_last_modified>
+    #    ...
+    field_data = {
+        "publisher": [("default", "json", "tsv"), _("PUBLISHER"), ""],
+        "packages": [("default", "json", "tsv"), _("PACKAGES"), ""],
+        "status": [("default", "json", "tsv"), _("STATUS"), ""],
+        "updated": [("default", "json", "tsv"), _("UPDATED"), ""],
+    }
 
-        desired_field_order = (_("PUBLISHER"), "", _("PACKAGES"), _("STATUS"),
-            _("UPDATED"))
+    desired_field_order = (
+        _("PUBLISHER"),
+        "",
+        _("PACKAGES"),
+        _("STATUS"),
+        _("UPDATED"),
+    )
 
-        # Default output formatting.
-        pub_len = str(max(
-            [len(desired_field_order[0])] + [len(p) for p in found]
-        ))
-        def_fmt = "{0:" + pub_len + "} {1:8} {2:16} {3}"
+    # Default output formatting.
+    pub_len = str(max([len(desired_field_order[0])] + [len(p) for p in found]))
+    def_fmt = "{0:" + pub_len + "} {1:8} {2:16} {3}"
 
-        if found or (not pubs and out_format == "default"):
-                # print without trailing newline.
-                sys.stdout.write(misc.get_listing(desired_field_order,
-                    field_data, gen_listing(), out_format, def_fmt,
-                    omit_headers))
+    if found or (not pubs and out_format == "default"):
+        # print without trailing newline.
+        sys.stdout.write(
+            misc.get_listing(
+                desired_field_order,
+                field_data,
+                gen_listing(),
+                out_format,
+                def_fmt,
+                omit_headers,
+            )
+        )
 
-        if found and notfound:
-                return EXIT_PARTIAL
-        if pubs and not found:
-                if out_format == "default":
-                        # Don't pollute other output formats.
-                        error(_("no matching publishers found"),
-                            cmd=subcommand)
-                return EXIT_OOPS
-        return EXIT_OK
+    if found and notfound:
+        return EXIT_PARTIAL
+    if pubs and not found:
+        if out_format == "default":
+            # Don't pollute other output formats.
+            error(_("no matching publishers found"), cmd=subcommand)
+        return EXIT_OOPS
+    return EXIT_OK
+
 
 def subcmd_list(conf, args):
-        """List all packages matching the specified patterns."""
+    """List all packages matching the specified patterns."""
 
-        subcommand = "list"
-        omit_headers = False
-        out_format = "default"
-        pubs = set()
-        key = None
-        cert = None
+    subcommand = "list"
+    omit_headers = False
+    out_format = "default"
+    pubs = set()
+    key = None
+    cert = None
 
-        opts, pargs = getopt.getopt(args, "F:Hp:s:", ["key=", "cert="])
-        for opt, arg in opts:
-                if opt == "-F":
-                        if arg not in LISTING_FORMATS:
-                                raise apx.InvalidOptionError(
-                                    apx.InvalidOptionError.ARG_INVALID,
-                                    [arg, opt])
-                        out_format = arg
-                elif opt == "-H":
-                        omit_headers = True
-                elif opt == "-p":
-                        pubs.add(arg)
-                elif opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt == "--key":
-                        key = arg
-                elif opt == "--cert":
-                        cert = arg
+    opts, pargs = getopt.getopt(args, "F:Hp:s:", ["key=", "cert="])
+    for opt, arg in opts:
+        if opt == "-F":
+            if arg not in LISTING_FORMATS:
+                raise apx.InvalidOptionError(
+                    apx.InvalidOptionError.ARG_INVALID, [arg, opt]
+                )
+            out_format = arg
+        elif opt == "-H":
+            omit_headers = True
+        elif opt == "-p":
+            pubs.add(arg)
+        elif opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt == "--key":
+            key = arg
+        elif opt == "--cert":
+            cert = arg
 
+    # Setup transport so configuration can be retrieved.
+    if not conf.get("repo_uri", None):
+        usage(
+            _("A package repository location must be provided " "using -s."),
+            cmd=subcommand,
+        )
+    xport, xpub, tmp_dir = setup_transport(
+        conf.get("repo_uri"), subcommand=subcommand, ssl_key=key, ssl_cert=cert
+    )
 
-        # Setup transport so configuration can be retrieved.
-        if not conf.get("repo_uri", None):
-                usage(_("A package repository location must be provided "
-                    "using -s."), cmd=subcommand)
-        xport, xpub, tmp_dir = setup_transport(conf.get("repo_uri"),
-            subcommand=subcommand, ssl_key=key, ssl_cert=cert)
+    rval, found, pub_data = _get_matching_pubs(
+        subcommand, pubs, xport, xpub, out_format=out_format, use_transport=True
+    )
+    if rval == EXIT_OOPS:
+        return rval
 
-        rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport,
-            xpub, out_format=out_format, use_transport=True)
-        if rval == EXIT_OOPS:
-                return rval
+    refresh_pub(pub_data, xport)
+    listed = {}
+    matched = set()
+    unmatched = set()
 
-        refresh_pub(pub_data, xport)
-        listed = {}
-        matched = set()
-        unmatched = set()
+    def gen_listing():
+        collect_attrs = out_format.startswith("json")
+        for pub in sorted(pub_data):
+            cat = pub.catalog
+            for f, states, attrs in cat.gen_packages(
+                collect_attrs=collect_attrs,
+                matched=matched,
+                patterns=pargs,
+                pubs=[pub.prefix],
+                unmatched=unmatched,
+                return_fmris=True,
+            ):
+                if not listed:
+                    listed["packages"] = True
 
-        def gen_listing():
-                collect_attrs = out_format.startswith("json")
-                for pub in sorted(pub_data):
-                        cat = pub.catalog
-                        for f, states, attrs in cat.gen_packages(
-                            collect_attrs=collect_attrs, matched=matched,
-                            patterns=pargs, pubs=[pub.prefix],
-                            unmatched=unmatched, return_fmris=True):
-                                if not listed:
-                                        listed["packages"] = True
+                state = None
+                if out_format == "default" or out_format == "tsv":
+                    if pkgdefs.PKG_STATE_OBSOLETE in states:
+                        state = "o"
+                    elif pkgdefs.PKG_STATE_RENAMED in states:
+                        state = "r"
+                    elif pkgdefs.PKG_STATE_LEGACY in states:
+                        state = "l"
 
-                                state = None
-                                if out_format == "default" or \
-                                    out_format == "tsv":
-                                        if pkgdefs.PKG_STATE_OBSOLETE in \
-                                            states:
-                                                state = "o"
-                                        elif pkgdefs.PKG_STATE_RENAMED in \
-                                            states:
-                                                state = "r"
-                                        elif pkgdefs.PKG_STATE_LEGACY in \
-                                            states:
-                                                state = "l"
+                if out_format == "default":
+                    fver = str(f.version.get_version(include_build=False))
+                    ffmri = str(f.get_fmri(include_build=False))
+                else:
+                    fver = str(f.version)
+                    ffmri = str(f)
 
-                                if out_format == "default":
-                                    fver = str(f.version.get_version(
-                                        include_build=False))
-                                    ffmri = str(f.get_fmri(include_build=False))
-                                else:
-                                    fver = str(f.version)
-                                    ffmri = str(f)
+                ret = {
+                    "publisher": f.publisher,
+                    "name": f.pkg_name,
+                    "version": fver,
+                    "release": str(f.version.release),
+                    "build-release": str(f.version.build_release),
+                    "branch": str(f.version.branch),
+                    "timestamp": str(f.version.timestr),
+                    "pkg.fmri": ffmri,
+                    "short_state": state,
+                }
 
-                                ret = {
-                                    "publisher": f.publisher,
-                                    "name": f.pkg_name,
-                                    "version": fver,
-                                    "release": str(f.version.release),
-                                    "build-release":
-                                        str(f.version.build_release),
-                                    "branch": str(f.version.branch),
-                                    "timestamp":
-                                        str(f.version.timestr),
-                                    "pkg.fmri": ffmri,
-                                    "short_state": state,
-                                }
+                for attr in attrs:
+                    ret[attr] = []
+                    for mods in attrs[attr]:
+                        d = dict(mods)
+                        d["value"] = attrs[attr][mods]
+                        ret[attr].append(d)
+                yield ret
 
-                                for attr in attrs:
-                                        ret[attr] = []
-                                        for mods in attrs[attr]:
-                                                d = dict(mods)
-                                                d["value"] = \
-                                                    attrs[attr][mods]
-                                                ret[attr].append(d)
-                                yield ret
+            unmatched.difference_update(matched)
 
-                        unmatched.difference_update(matched)
+    field_data = {
+        "publisher": [("default", "json", "tsv"), _("PUBLISHER"), ""],
+        "name": [("default", "json", "tsv"), _("NAME"), ""],
+        "version": [("default", "json"), _("VERSION"), ""],
+        "release": [
+            (
+                "json",
+                "tsv",
+            ),
+            _("RELEASE"),
+            "",
+        ],
+        "build-release": [
+            (
+                "json",
+                "tsv",
+            ),
+            _("BUILD RELEASE"),
+            "",
+        ],
+        "branch": [
+            (
+                "json",
+                "tsv",
+            ),
+            _("BRANCH"),
+            "",
+        ],
+        "timestamp": [
+            (
+                "json",
+                "tsv",
+            ),
+            _("PACKAGING DATE"),
+            "",
+        ],
+        "pkg.fmri": [
+            (
+                "json",
+                "tsv",
+            ),
+            _("FMRI"),
+            "",
+        ],
+        "short_state": [("default", "tsv"), "O", ""],
+    }
 
-        field_data = {
-            "publisher": [("default", "json", "tsv"), _("PUBLISHER"), ""],
-            "name": [("default", "json", "tsv"), _("NAME"), ""],
-            "version": [("default", "json"), _("VERSION"), ""],
-            "release": [("json", "tsv",), _("RELEASE"), ""],
-            "build-release": [("json", "tsv",), _("BUILD RELEASE"), ""],
-            "branch": [("json", "tsv",), _("BRANCH"), ""],
-            "timestamp": [("json", "tsv",), _("PACKAGING DATE"), ""],
-            "pkg.fmri": [("json", "tsv",), _("FMRI"), ""],
-            "short_state": [("default", "tsv"), "O", ""],
-         }
+    desired_field_order = (
+        _("PUBLISHER"),
+        _("NAME"),
+        "O",
+        _("VERSION"),
+        _("SUMMARY"),
+        _("DESCRIPTION"),
+        _("CATEGORIES"),
+        _("RELEASE"),
+        _("BUILD RELEASE"),
+        _("BRANCH"),
+        _("PACKAGING DATE"),
+        _("FMRI"),
+        _("STATE"),
+    )
 
-        desired_field_order = (_("PUBLISHER"), _("NAME"), "O", _("VERSION"),
-            _("SUMMARY"), _("DESCRIPTION"), _("CATEGORIES"), _("RELEASE"),
-            _("BUILD RELEASE"), _("BRANCH"), _("PACKAGING DATE"), _("FMRI"),
-            _("STATE"))
+    # Default output formatting.
+    max_pub_name_len = str(
+        max(list(len(p) for p in found) + [len(_("PUBLISHER"))])
+    )
+    def_fmt = "{0:" + max_pub_name_len + "} {1:45} {2:1} {3}"
 
-        # Default output formatting.
-        max_pub_name_len = str(
-            max(list(len(p) for p in found) + [len(_("PUBLISHER"))]))
-        def_fmt = "{0:" + max_pub_name_len + "} {1:45} {2:1} {3}"
+    # print without trailing newline.
+    sys.stdout.write(
+        misc.get_listing(
+            desired_field_order,
+            field_data,
+            gen_listing(),
+            out_format,
+            def_fmt,
+            omit_headers,
+        )
+    )
 
-        # print without trailing newline.
-        sys.stdout.write(misc.get_listing(
-            desired_field_order, field_data, gen_listing(),
-            out_format, def_fmt, omit_headers))
+    if not listed and pargs:
+        # No matching packages.
+        logger.error("")
+        if not unmatched:
+            unmatched = pargs
+        error(apx.PackageMatchErrors(unmatched_fmris=unmatched), cmd=subcommand)
+        return EXIT_OOPS
+    elif unmatched:
+        # One or more patterns didn't match a package from any
+        # publisher; only display the error.
+        logger.error("")
+        error(apx.PackageMatchErrors(unmatched_fmris=unmatched), cmd=subcommand)
+        return EXIT_PARTIAL
 
-        if not listed and pargs:
-                # No matching packages.
-                logger.error("")
-                if not unmatched:
-                        unmatched = pargs
-                error(apx.PackageMatchErrors(unmatched_fmris=unmatched),
-                    cmd=subcommand)
-                return EXIT_OOPS
-        elif unmatched:
-                # One or more patterns didn't match a package from any
-                # publisher; only display the error.
-                logger.error("")
-                error(apx.PackageMatchErrors(unmatched_fmris=unmatched),
-                    cmd=subcommand)
-                return EXIT_PARTIAL
-
-        return EXIT_OK
+    return EXIT_OK
 
 
 def refresh_pub(pub_data, xport):
-        """A helper function to refresh all specified publishers."""
+    """A helper function to refresh all specified publishers."""
 
-        global tmpdirs
-        temp_root = misc.config_temp_root()
-        progtrack = get_tracker()
-        progtrack.set_purpose(progtrack.PURPOSE_LISTING)
+    global tmpdirs
+    temp_root = misc.config_temp_root()
+    progtrack = get_tracker()
+    progtrack.set_purpose(progtrack.PURPOSE_LISTING)
 
-        progtrack.refresh_start(pub_cnt=len(pub_data), full_refresh=True,
-            target_catalog=False)
+    progtrack.refresh_start(
+        pub_cnt=len(pub_data), full_refresh=True, target_catalog=False
+    )
 
-        for pub in pub_data:
-                progtrack.refresh_start_pub(pub)
-                meta_root = tempfile.mkdtemp(dir=temp_root)
-                tmpdirs.append(meta_root)
-                pub.meta_root = meta_root
-                pub.transport = xport
+    for pub in pub_data:
+        progtrack.refresh_start_pub(pub)
+        meta_root = tempfile.mkdtemp(dir=temp_root)
+        tmpdirs.append(meta_root)
+        pub.meta_root = meta_root
+        pub.transport = xport
 
-                try:
-                        pub.refresh(True, True, progtrack=progtrack)
-                except apx.TransportError:
-                        # Assume that a catalog doesn't exist for the target
-                        # publisher and drive on.
-                        pass
-                progtrack.refresh_end_pub(pub)
+        try:
+            pub.refresh(True, True, progtrack=progtrack)
+        except apx.TransportError:
+            # Assume that a catalog doesn't exist for the target
+            # publisher and drive on.
+            pass
+        progtrack.refresh_end_pub(pub)
 
-        progtrack.refresh_done()
+    progtrack.refresh_done()
 
 
 def subcmd_contents(conf, args):
-        """List package contents."""
+    """List package contents."""
 
-        subcommand = "contents"
-        display_raw = False
-        pubs = set()
-        key = None
-        cert = None
-        attrs = []
-        action_types = []
+    subcommand = "contents"
+    display_raw = False
+    pubs = set()
+    key = None
+    cert = None
+    attrs = []
+    action_types = []
 
-        opts, pargs = getopt.getopt(args, "ms:t:", ["key=", "cert="])
-        for opt, arg in opts:
-                if opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt == "-m":
-                        display_raw = True
-                elif opt == "-t":
-                        action_types.extend(arg.split(","))
-                elif opt == "--key":
-                        key = arg
-                elif opt == "--cert":
-                        cert = arg
+    opts, pargs = getopt.getopt(args, "ms:t:", ["key=", "cert="])
+    for opt, arg in opts:
+        if opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt == "-m":
+            display_raw = True
+        elif opt == "-t":
+            action_types.extend(arg.split(","))
+        elif opt == "--key":
+            key = arg
+        elif opt == "--cert":
+            cert = arg
 
-        # Setup transport so configuration can be retrieved.
-        if not conf.get("repo_uri", None):
-                usage(_("A package repository location must be provided "
-                    "using -s."), cmd=subcommand)
+    # Setup transport so configuration can be retrieved.
+    if not conf.get("repo_uri", None):
+        usage(
+            _("A package repository location must be provided " "using -s."),
+            cmd=subcommand,
+        )
 
-        xport, xpub, tmp_dir = setup_transport(conf.get("repo_uri"),
-            subcommand=subcommand, ssl_key=key, ssl_cert=cert)
+    xport, xpub, tmp_dir = setup_transport(
+        conf.get("repo_uri"), subcommand=subcommand, ssl_key=key, ssl_cert=cert
+    )
 
-        rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport,
-            xpub, use_transport=True)
-        if rval == EXIT_OOPS:
-                return rval
-
-        # Default output prints out the raw manifest. The -m option is implicit
-        # for now and supported to make the interface equivalent to pkg
-        # contents.
-        if not attrs or display_raw:
-                attrs = ["action.raw"]
-
-        refresh_pub(pub_data, xport)
-        listed = False
-        matched = set()
-        unmatched = set()
-        manifests = []
-
-        for pub in pub_data:
-                cat = pub.catalog
-                for f, states, attr in cat.gen_packages(matched=matched,
-                        patterns=pargs, pubs=[pub.prefix],
-                        unmatched=unmatched, return_fmris=True):
-                        if not listed:
-                                listed = True
-                        manifests.append(xport.get_manifest(f))
-                unmatched.difference_update(matched)
-
-        # Build a generator expression based on whether specific action types
-        # were provided.
-        if action_types:
-                # If query is limited to specific action types, use the more
-                # efficient type-based generation mechanism.
-                gen_expr = (
-                    (m.fmri, a, None, None, None)
-                    for m in manifests
-                    for a in m.gen_actions_by_types(action_types)
-                )
-        else:
-                gen_expr = (
-                    (m.fmri, a, None, None, None)
-                    for m in manifests
-                    for a in m.gen_actions()
-                )
-
-        # Determine if the query returned any results by "peeking" at the first
-        # value returned from the generator expression.
-        try:
-                got = next(gen_expr)
-        except StopIteration:
-                got = None
-                actionlist = []
-
-        if got:
-                actionlist = itertools.chain([got], gen_expr)
-
-        rval = EXIT_OK
-        if action_types and manifests and not got:
-                logger.error(_(gettext.ngettext("""\
-pkgrepo: contents: This package contains no actions with the types specified
-using the -t option""", """\
-pkgrepo: contents: These packages contain no actions with the types specified
-using the -t option.""", len(pargs))))
-                rval = EXIT_OOPS
-
-        if manifests and rval == EXIT_OK:
-                lines = misc.list_actions_by_attrs(actionlist, attrs)
-                for line in lines:
-                        text = ("{0}".format(*line)).rstrip()
-                        if not text:
-                               continue
-                        msg(text)
-
-        if unmatched:
-                if manifests:
-                        logger.error("")
-                logger.error(_("""\
-pkgrepo: contents: no packages matching the following patterns you specified
-were found in the repository."""))
-                logger.error("")
-                for p in unmatched:
-                        logger.error("        {0}".format(p))
-                rval = EXIT_OOPS
-
+    rval, found, pub_data = _get_matching_pubs(
+        subcommand, pubs, xport, xpub, use_transport=True
+    )
+    if rval == EXIT_OOPS:
         return rval
+
+    # Default output prints out the raw manifest. The -m option is implicit
+    # for now and supported to make the interface equivalent to pkg
+    # contents.
+    if not attrs or display_raw:
+        attrs = ["action.raw"]
+
+    refresh_pub(pub_data, xport)
+    listed = False
+    matched = set()
+    unmatched = set()
+    manifests = []
+
+    for pub in pub_data:
+        cat = pub.catalog
+        for f, states, attr in cat.gen_packages(
+            matched=matched,
+            patterns=pargs,
+            pubs=[pub.prefix],
+            unmatched=unmatched,
+            return_fmris=True,
+        ):
+            if not listed:
+                listed = True
+            manifests.append(xport.get_manifest(f))
+        unmatched.difference_update(matched)
+
+    # Build a generator expression based on whether specific action types
+    # were provided.
+    if action_types:
+        # If query is limited to specific action types, use the more
+        # efficient type-based generation mechanism.
+        gen_expr = (
+            (m.fmri, a, None, None, None)
+            for m in manifests
+            for a in m.gen_actions_by_types(action_types)
+        )
+    else:
+        gen_expr = (
+            (m.fmri, a, None, None, None)
+            for m in manifests
+            for a in m.gen_actions()
+        )
+
+    # Determine if the query returned any results by "peeking" at the first
+    # value returned from the generator expression.
+    try:
+        got = next(gen_expr)
+    except StopIteration:
+        got = None
+        actionlist = []
+
+    if got:
+        actionlist = itertools.chain([got], gen_expr)
+
+    rval = EXIT_OK
+    if action_types and manifests and not got:
+        logger.error(
+            _(
+                gettext.ngettext(
+                    """\
+pkgrepo: contents: This package contains no actions with the types specified
+using the -t option""",
+                    """\
+pkgrepo: contents: These packages contain no actions with the types specified
+using the -t option.""",
+                    len(pargs),
+                )
+            )
+        )
+        rval = EXIT_OOPS
+
+    if manifests and rval == EXIT_OK:
+        lines = misc.list_actions_by_attrs(actionlist, attrs)
+        for line in lines:
+            text = ("{0}".format(*line)).rstrip()
+            if not text:
+                continue
+            msg(text)
+
+    if unmatched:
+        if manifests:
+            logger.error("")
+        logger.error(
+            _(
+                """\
+pkgrepo: contents: no packages matching the following patterns you specified
+were found in the repository."""
+            )
+        )
+        logger.error("")
+        for p in unmatched:
+            logger.error("        {0}".format(p))
+        rval = EXIT_OOPS
+
+    return rval
 
 
 def __rebuild_local(subcommand, conf, pubs, build_catalog, build_index):
-        """In an attempt to allow operations on potentially corrupt
-        repositories, 'local' repositories (filesystem-basd ones) are handled
-        separately."""
+    """In an attempt to allow operations on potentially corrupt
+    repositories, 'local' repositories (filesystem-basd ones) are handled
+    separately."""
 
-        repo = get_repo(conf, allow_invalid=build_catalog, read_only=False,
-            subcommand=subcommand)
+    repo = get_repo(
+        conf,
+        allow_invalid=build_catalog,
+        read_only=False,
+        subcommand=subcommand,
+    )
 
-        rpubs = set(repo.publishers)
-        if not pubs:
-                found = rpubs
-        else:
-                found = rpubs & pubs
-        notfound = pubs - found
+    rpubs = set(repo.publishers)
+    if not pubs:
+        found = rpubs
+    else:
+        found = rpubs & pubs
+    notfound = pubs - found
 
-        rval = EXIT_OK
-        if found and notfound:
-                rval = EXIT_PARTIAL
-        elif pubs and not found:
-                error(_("no matching publishers found"), cmd=subcommand)
-                return EXIT_OOPS
+    rval = EXIT_OK
+    if found and notfound:
+        rval = EXIT_PARTIAL
+    elif pubs and not found:
+        error(_("no matching publishers found"), cmd=subcommand)
+        return EXIT_OOPS
 
-        logger.info("Initiating repository rebuild.")
-        for pfx in found:
-                repo.rebuild(build_catalog=build_catalog,
-                    build_index=build_index, pub=pfx)
+    logger.info("Initiating repository rebuild.")
+    for pfx in found:
+        repo.rebuild(
+            build_catalog=build_catalog, build_index=build_index, pub=pfx
+        )
 
+    return rval
+
+
+def __rebuild_remote(
+    subcommand, conf, pubs, key, cert, build_catalog, build_index
+):
+    def do_rebuild(xport, xpub):
+        if build_catalog and build_index:
+            xport.publish_rebuild(xpub)
+        elif build_catalog:
+            xport.publish_rebuild_packages(xpub)
+        elif build_index:
+            xport.publish_rebuild_indexes(xpub)
+
+    xport, xpub, tmp_dir = setup_transport(
+        conf.get("repo_uri"), subcommand=subcommand, ssl_key=key, ssl_cert=cert
+    )
+    rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport, xpub)
+    if rval == EXIT_OOPS:
         return rval
 
+    logger.info("Initiating repository rebuild.")
+    for pfx in found:
+        xpub.prefix = pfx
+        do_rebuild(xport, xpub)
 
-def __rebuild_remote(subcommand, conf, pubs, key, cert, build_catalog,
-    build_index):
-        def do_rebuild(xport, xpub):
-                if build_catalog and build_index:
-                        xport.publish_rebuild(xpub)
-                elif build_catalog:
-                        xport.publish_rebuild_packages(xpub)
-                elif build_index:
-                        xport.publish_rebuild_indexes(xpub)
-
-        xport, xpub, tmp_dir = setup_transport(conf.get("repo_uri"),
-            subcommand=subcommand, ssl_key=key, ssl_cert=cert)
-        rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport,
-            xpub)
-        if rval == EXIT_OOPS:
-                return rval
-
-        logger.info("Initiating repository rebuild.")
-        for pfx in found:
-                xpub.prefix = pfx
-                do_rebuild(xport, xpub)
-
-        return rval
+    return rval
 
 
 def subcmd_rebuild(conf, args):
-        """Rebuild the repository's catalog and index data (as permitted)."""
+    """Rebuild the repository's catalog and index data (as permitted)."""
 
-        subcommand = "rebuild"
-        build_catalog = True
-        build_index = True
-        key = None
-        cert = None
+    subcommand = "rebuild"
+    build_catalog = True
+    build_index = True
+    key = None
+    cert = None
 
-        opts, pargs = getopt.getopt(args, "p:s:", ["no-catalog", "no-index",
-            "key=", "cert="])
-        pubs = set()
-        for opt, arg in opts:
-                if opt == "-p":
-                        if not misc.valid_pub_prefix(arg):
-                                error(_("Invalid publisher prefix '{0}'").format(
-                                    arg), cmd=subcommand)
-                        pubs.add(arg)
-                elif opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt == "--no-catalog":
-                        build_catalog = False
-                elif opt == "--no-index":
-                        build_index = False
-                elif opt == "--key":
-                        key = arg
-                elif opt == "--cert":
-                        cert = arg
+    opts, pargs = getopt.getopt(
+        args, "p:s:", ["no-catalog", "no-index", "key=", "cert="]
+    )
+    pubs = set()
+    for opt, arg in opts:
+        if opt == "-p":
+            if not misc.valid_pub_prefix(arg):
+                error(
+                    _("Invalid publisher prefix '{0}'").format(arg),
+                    cmd=subcommand,
+                )
+            pubs.add(arg)
+        elif opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt == "--no-catalog":
+            build_catalog = False
+        elif opt == "--no-index":
+            build_index = False
+        elif opt == "--key":
+            key = arg
+        elif opt == "--cert":
+            cert = arg
 
-        if pargs:
-                usage(_("command does not take operands"), cmd=subcommand)
+    if pargs:
+        usage(_("command does not take operands"), cmd=subcommand)
 
-        if not build_catalog and not build_index:
-                # Why?  Who knows; but do what was requested--nothing!
-                return EXIT_OK
+    if not build_catalog and not build_index:
+        # Why?  Who knows; but do what was requested--nothing!
+        return EXIT_OK
 
-        # Setup transport so operation can be performed.
-        if not conf.get("repo_uri", None):
-                usage(_("A package repository location must be provided "
-                    "using -s."), cmd=subcommand)
+    # Setup transport so operation can be performed.
+    if not conf.get("repo_uri", None):
+        usage(
+            _("A package repository location must be provided " "using -s."),
+            cmd=subcommand,
+        )
 
-        if conf["repo_uri"].scheme == "file":
-                return __rebuild_local(subcommand, conf, pubs, build_catalog,
-                    build_index)
+    if conf["repo_uri"].scheme == "file":
+        return __rebuild_local(
+            subcommand, conf, pubs, build_catalog, build_index
+        )
 
-        return __rebuild_remote(subcommand, conf, pubs, key, cert,
-            build_catalog, build_index)
+    return __rebuild_remote(
+        subcommand, conf, pubs, key, cert, build_catalog, build_index
+    )
 
 
 def subcmd_refresh(conf, args):
-        """Refresh the repository's catalog and index data (as permitted)."""
+    """Refresh the repository's catalog and index data (as permitted)."""
 
-        subcommand = "refresh"
-        add_content = True
-        refresh_index = True
-        key = None
-        cert = None
+    subcommand = "refresh"
+    add_content = True
+    refresh_index = True
+    key = None
+    cert = None
 
-        opts, pargs = getopt.getopt(args, "p:s:", ["no-catalog", "no-index",
-            "key=", "cert="])
-        pubs = set()
-        for opt, arg in opts:
-                if opt == "-p":
-                        if not misc.valid_pub_prefix(arg):
-                                error(_("Invalid publisher prefix '{0}'").format(
-                                    arg), cmd=subcommand)
-                        pubs.add(arg)
-                elif opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt == "--no-catalog":
-                        add_content = False
-                elif opt == "--no-index":
-                        refresh_index = False
-                elif opt == "--key":
-                        key = arg
-                elif opt == "--cert":
-                        cert = arg
+    opts, pargs = getopt.getopt(
+        args, "p:s:", ["no-catalog", "no-index", "key=", "cert="]
+    )
+    pubs = set()
+    for opt, arg in opts:
+        if opt == "-p":
+            if not misc.valid_pub_prefix(arg):
+                error(
+                    _("Invalid publisher prefix '{0}'").format(arg),
+                    cmd=subcommand,
+                )
+            pubs.add(arg)
+        elif opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt == "--no-catalog":
+            add_content = False
+        elif opt == "--no-index":
+            refresh_index = False
+        elif opt == "--key":
+            key = arg
+        elif opt == "--cert":
+            cert = arg
 
-        if pargs:
-                usage(_("command does not take operands"), cmd=subcommand)
+    if pargs:
+        usage(_("command does not take operands"), cmd=subcommand)
 
-        if not add_content and not refresh_index:
-                # Why?  Who knows; but do what was requested--nothing!
-                return EXIT_OK
+    if not add_content and not refresh_index:
+        # Why?  Who knows; but do what was requested--nothing!
+        return EXIT_OK
 
-        # Setup transport so operation can be performed.
-        if not conf.get("repo_uri", None):
-                usage(_("A package repository location must be provided "
-                    "using -s."), cmd=subcommand)
+    # Setup transport so operation can be performed.
+    if not conf.get("repo_uri", None):
+        usage(
+            _("A package repository location must be provided " "using -s."),
+            cmd=subcommand,
+        )
 
-        def do_refresh(xport, xpub):
-                if add_content and refresh_index:
-                        xport.publish_refresh(xpub)
-                elif add_content:
-                        xport.publish_refresh_packages(xpub)
-                elif refresh_index:
-                        xport.publish_refresh_indexes(xpub)
+    def do_refresh(xport, xpub):
+        if add_content and refresh_index:
+            xport.publish_refresh(xpub)
+        elif add_content:
+            xport.publish_refresh_packages(xpub)
+        elif refresh_index:
+            xport.publish_refresh_indexes(xpub)
 
-        xport, xpub, tmp_dir = setup_transport(conf.get("repo_uri"),
-            subcommand=subcommand, ssl_key=key, ssl_cert=cert)
-        rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport,
-            xpub)
-        if rval == EXIT_OOPS:
-                return rval
-
-        logger.info("Initiating repository refresh.")
-        for pfx in found:
-                xpub.prefix = pfx
-                do_refresh(xport, xpub)
-
+    xport, xpub, tmp_dir = setup_transport(
+        conf.get("repo_uri"), subcommand=subcommand, ssl_key=key, ssl_cert=cert
+    )
+    rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport, xpub)
+    if rval == EXIT_OOPS:
         return rval
+
+    logger.info("Initiating repository refresh.")
+    for pfx in found:
+        xpub.prefix = pfx
+        do_refresh(xport, xpub)
+
+    return rval
 
 
 def subcmd_set(conf, args):
-        """Set repository properties."""
+    """Set repository properties."""
 
-        subcommand = "set"
-        pubs = set()
+    subcommand = "set"
+    pubs = set()
 
-        opts, pargs = getopt.getopt(args, "p:s:")
-        for opt, arg in opts:
-                if opt == "-p":
-                        pubs.add(arg)
-                elif opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
+    opts, pargs = getopt.getopt(args, "p:s:")
+    for opt, arg in opts:
+        if opt == "-p":
+            pubs.add(arg)
+        elif opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
 
-        bad_args = False
-        props = {}
-        if not pargs:
+    bad_args = False
+    props = {}
+    if not pargs:
+        bad_args = True
+    else:
+        for arg in pargs:
+            try:
+                # Attempt to parse property into components.
+                prop, val = arg.split("=", 1)
+                sname, pname = prop.rsplit("/", 1)
+
+                # Store property values by section.
+                props.setdefault(sname, {})
+
+                # Parse the property value into a list if
+                # necessary, otherwise append it to the list
+                # of values for the property.
+                if len(val) > 0 and val[0] == "(" and val[-1] == ")":
+                    val = shlex.split(val.strip("()"))
+
+                if sname in props and pname in props[sname]:
+                    # Determine if previous value is already
+                    # a list, and if not, convert and append
+                    # the value.
+                    pval = props[sname][pname]
+                    if not isinstance(pval, list):
+                        pval = [pval]
+                    if isinstance(val, list):
+                        pval.extend(val)
+                    else:
+                        pval.append(val)
+                    props[sname][pname] = pval
+                else:
+                    # Otherwise, just store the value.
+                    props[sname][pname] = val
+            except ValueError:
                 bad_args = True
-        else:
-                for arg in pargs:
-                        try:
-                                # Attempt to parse property into components.
-                                prop, val = arg.split("=", 1)
-                                sname, pname = prop.rsplit("/", 1)
+                break
 
-                                # Store property values by section.
-                                props.setdefault(sname, {})
+    if bad_args:
+        usage(
+            _(
+                "a property name and value must be provided in the "
+                "form <section/property>=<value> or "
+                '<section/property>=(["<value>" ...])'
+            )
+        )
 
-                                # Parse the property value into a list if
-                                # necessary, otherwise append it to the list
-                                # of values for the property.
-                                if len(val) > 0  and val[0] == "(" and \
-                                    val[-1] == ")":
-                                        val = shlex.split(val.strip("()"))
+    # Get repository object.
+    if not conf.get("repo_uri", None):
+        usage(
+            _("A package repository location must be provided " "using -s."),
+            cmd=subcommand,
+        )
+    repo = get_repo(conf, read_only=False, subcommand=subcommand)
 
-                                if sname in props and pname in props[sname]:
-                                        # Determine if previous value is already
-                                        # a list, and if not, convert and append
-                                        # the value.
-                                        pval = props[sname][pname]
-                                        if not isinstance(pval, list):
-                                                pval = [pval]
-                                        if isinstance(val, list):
-                                                pval.extend(val)
-                                        else:
-                                                pval.append(val)
-                                        props[sname][pname] = pval
-                                else:
-                                        # Otherwise, just store the value.
-                                        props[sname][pname] = val
-                        except ValueError:
-                                bad_args = True
-                                break
+    # Set properties.
+    if pubs:
+        return _set_pub(conf, subcommand, props, pubs, repo)
 
-        if bad_args:
-                usage(_("a property name and value must be provided in the "
-                    "form <section/property>=<value> or "
-                    "<section/property>=([\"<value>\" ...])"))
-
-        # Get repository object.
-        if not conf.get("repo_uri", None):
-                usage(_("A package repository location must be provided "
-                    "using -s."), cmd=subcommand)
-        repo = get_repo(conf, read_only=False, subcommand=subcommand)
-
-        # Set properties.
-        if pubs:
-                return _set_pub(conf, subcommand, props, pubs, repo)
-
-        return _set_repo(conf, subcommand, props, repo)
+    return _set_repo(conf, subcommand, props, repo)
 
 
 def _set_pub(conf, subcommand, props, pubs, repo):
-        """Set publisher properties."""
+    """Set publisher properties."""
 
-        for sname, sprops in six.iteritems(props):
-                if sname not in ("publisher", "repository"):
-                        usage(_("unknown property section "
-                            "'{0}'").format(sname), cmd=subcommand)
-                for pname in sprops:
-                        if sname == "publisher" and pname == "prefix":
-                                usage(_("'{0}' may not be set using "
-                                    "this command".format(pname)))
-                        attrname = pname.replace("-", "_")
-                        if not hasattr(publisher.Publisher, attrname) and \
-                            not hasattr(publisher.Repository, attrname):
-                                usage(_("unknown property '{0}'").format(
-                                    pname), cmd=subcommand)
+    for sname, sprops in six.iteritems(props):
+        if sname not in ("publisher", "repository"):
+            usage(
+                _("unknown property section " "'{0}'").format(sname),
+                cmd=subcommand,
+            )
+        for pname in sprops:
+            if sname == "publisher" and pname == "prefix":
+                usage(
+                    _(
+                        "'{0}' may not be set using "
+                        "this command".format(pname)
+                    )
+                )
+            attrname = pname.replace("-", "_")
+            if not hasattr(publisher.Publisher, attrname) and not hasattr(
+                publisher.Repository, attrname
+            ):
+                usage(_("unknown property '{0}'").format(pname), cmd=subcommand)
 
-        if "all" in pubs:
-                # Default to list of all publishers.
-                pubs = repo.publishers
-                if not pubs:
-                        # If there are still no known publishers, this
-                        # operation cannot succeed, so fail now.
-                        usage(_("One or more publishers must be specified to "
-                            "create and set properties for as none exist yet."),
-                            cmd=subcommand)
+    if "all" in pubs:
+        # Default to list of all publishers.
+        pubs = repo.publishers
+        if not pubs:
+            # If there are still no known publishers, this
+            # operation cannot succeed, so fail now.
+            usage(
+                _(
+                    "One or more publishers must be specified to "
+                    "create and set properties for as none exist yet."
+                ),
+                cmd=subcommand,
+            )
 
-        # Get publishers and update properties.
-        failed = []
-        new_pub = False
-        for pfx in pubs:
-                try:
-                        # Get a copy of the existing publisher.
-                        pub = copy.copy(repo.get_publisher(pfx))
-                except sr.RepositoryUnknownPublisher as e:
-                        pub = publisher.Publisher(pfx)
-                        new_pub = True
-                except sr.RepositoryError as e:
-                        failed.append((pfx, e))
-                        continue
+    # Get publishers and update properties.
+    failed = []
+    new_pub = False
+    for pfx in pubs:
+        try:
+            # Get a copy of the existing publisher.
+            pub = copy.copy(repo.get_publisher(pfx))
+        except sr.RepositoryUnknownPublisher as e:
+            pub = publisher.Publisher(pfx)
+            new_pub = True
+        except sr.RepositoryError as e:
+            failed.append((pfx, e))
+            continue
 
-                try:
-                        # Set/update the publisher's properties.
-                        for sname, sprops in six.iteritems(props):
-                                if sname == "publisher":
-                                        target = pub
-                                elif sname == "repository":
-                                        target = pub.repository
-                                        if not target:
-                                                target = publisher.Repository()
-                                                pub.repository = target
+        try:
+            # Set/update the publisher's properties.
+            for sname, sprops in six.iteritems(props):
+                if sname == "publisher":
+                    target = pub
+                elif sname == "repository":
+                    target = pub.repository
+                    if not target:
+                        target = publisher.Repository()
+                        pub.repository = target
 
-                                for pname, val in six.iteritems(sprops):
-                                        attrname = pname.replace("-", "_")
-                                        pval = getattr(target, attrname)
-                                        if isinstance(pval, list) and \
-                                            not isinstance(val, list):
-                                                # If the target property expects
-                                                # a list, transform the provided
-                                                # value into one if it isn't
-                                                # already.
-                                                if val == "":
-                                                        val = []
-                                                else:
-                                                        val = [val]
-                                        setattr(target, attrname, val)
-                except apx.ApiException as e:
-                        failed.append((pfx, e))
-                        continue
+                for pname, val in six.iteritems(sprops):
+                    attrname = pname.replace("-", "_")
+                    pval = getattr(target, attrname)
+                    if isinstance(pval, list) and not isinstance(val, list):
+                        # If the target property expects
+                        # a list, transform the provided
+                        # value into one if it isn't
+                        # already.
+                        if val == "":
+                            val = []
+                        else:
+                            val = [val]
+                    setattr(target, attrname, val)
+        except apx.ApiException as e:
+            failed.append((pfx, e))
+            continue
 
-                if new_pub:
-                        repo.add_publisher(pub)
-                else:
-                        repo.update_publisher(pub)
+        if new_pub:
+            repo.add_publisher(pub)
+        else:
+            repo.update_publisher(pub)
 
-        if failed:
-                for pfx, details in failed:
-                        error(_("Unable to set properties for publisher "
-                            "'{pfx}':\n{details}").format(**locals()))
-                if len(failed) < len(pubs):
-                        return EXIT_PARTIAL
-                return EXIT_OOPS
-        return EXIT_OK
+    if failed:
+        for pfx, details in failed:
+            error(
+                _(
+                    "Unable to set properties for publisher "
+                    "'{pfx}':\n{details}"
+                ).format(**locals())
+            )
+        if len(failed) < len(pubs):
+            return EXIT_PARTIAL
+        return EXIT_OOPS
+    return EXIT_OK
 
 
 def _set_repo(conf, subcommand, props, repo):
-        """Set repository properties."""
+    """Set repository properties."""
 
-        # Set properties.
-        for sname, props in six.iteritems(props):
-                for pname, val in six.iteritems(props):
-                        repo.cfg.set_property(sname, pname, val)
-        repo.write_config()
+    # Set properties.
+    for sname, props in six.iteritems(props):
+        for pname, val in six.iteritems(props):
+            repo.cfg.set_property(sname, pname, val)
+    repo.write_config()
 
-        return EXIT_OK
+    return EXIT_OK
 
 
 def subcmd_version(conf, args):
-        """Display the version of the pkg(7) API."""
+    """Display the version of the pkg(7) API."""
 
-        subcommand = "version"
-        if args:
-                usage(_("command does not take operands"), cmd=subcommand)
-        msg(pkg.VERSION)
-        return EXIT_OK
+    subcommand = "version"
+    if args:
+        usage(_("command does not take operands"), cmd=subcommand)
+    msg(pkg.VERSION)
+    return EXIT_OK
 
 
 verify_error_header = None
 verify_warning_header = None
 verify_reason_headers = None
 
+
 def __load_verify_msgs():
-        """Since our gettext isn't loaded we need to ensure our globals have
-        correct content by calling this method.  These values are used by both
-        fix when in verbose mode, and verify"""
+    """Since our gettext isn't loaded we need to ensure our globals have
+    correct content by calling this method.  These values are used by both
+    fix when in verbose mode, and verify"""
 
-        global verify_error_header
-        global verify_warning_header
-        global verify_reason_headers
+    global verify_error_header
+    global verify_warning_header
+    global verify_reason_headers
 
-        # A map of error detail types to the human-readable description of each
-        # type.  These correspond to keys in the dictionary returned by
-        # sr.Repository.verify(..)
-        verify_reason_headers = {
-            "path": _("Repository path"),
-            "actual": _("Computed hash"),
-            "fpath": _("Path"),
-            "permissionspath": _("Path"),
-            "pkg": _("Package"),
-            "depend": _("Dependency"),
-            "type":_("Dependency type"),
-            "err": _("Detail")
-        }
+    # A map of error detail types to the human-readable description of each
+    # type.  These correspond to keys in the dictionary returned by
+    # sr.Repository.verify(..)
+    verify_reason_headers = {
+        "path": _("Repository path"),
+        "actual": _("Computed hash"),
+        "fpath": _("Path"),
+        "permissionspath": _("Path"),
+        "pkg": _("Package"),
+        "depend": _("Dependency"),
+        "type": _("Dependency type"),
+        "err": _("Detail"),
+    }
 
-        verify_error_header = _("ERROR")
-        verify_warning_header = _("WARNING")
+    verify_error_header = _("ERROR")
+    verify_warning_header = _("WARNING")
 
 
 def __fmt_verify(verify_tuple):
-        """Format a verify_tuple, of the form (error, path, message, reason)
-        returning a formatted error message, and an FMRI indicating what
-        packages within the repository are affected. Note that the returned FMRI
-        may not be valid, in which case a path to the broken manifest in the
-        repository is returned instead."""
+    """Format a verify_tuple, of the form (error, path, message, reason)
+    returning a formatted error message, and an FMRI indicating what
+    packages within the repository are affected. Note that the returned FMRI
+    may not be valid, in which case a path to the broken manifest in the
+    repository is returned instead."""
 
-        error, path, message, reason = verify_tuple
+    error, path, message, reason = verify_tuple
 
+    formatted_message = "{error_type:>16}: {message}\n".format(
+        error_type=verify_error_header, message=message
+    )
+    reason["path"] = path
+
+    if error == sr.REPO_VERIFY_BADMANIFEST:
+        reason_keys = ["path", "err"]
+    elif error in [sr.REPO_VERIFY_PERM, sr.REPO_VERIFY_MFPERM]:
+        reason_keys = ["pkg", "path"]
+    elif error == sr.REPO_VERIFY_BADHASH:
+        reason_keys = ["pkg", "path", "actual", "fpath"]
+    elif error == sr.REPO_VERIFY_UNKNOWN:
+        reason_keys = ["path", "err"]
+    elif error == sr.REPO_VERIFY_BADSIG:
+        reason_keys = ["pkg", "path", "err"]
+    elif error == sr.REPO_VERIFY_DEPENDERROR:
+        reason_keys = ["pkg", "depend", "type"]
+    elif error == sr.REPO_VERIFY_WARN_OPENPERMS:
         formatted_message = "{error_type:>16}: {message}\n".format(
-            error_type=verify_error_header, message=message)
-        reason["path"] = path
+            error_type=verify_warning_header, message=message
+        )
+        reason_keys = ["permissionspath", "err"]
+    else:
+        # A list of the details we provide.  Some error codes
+        # have different details associated with them.
+        reason_keys = ["pkg", "path", "fpath"]
 
-        if error == sr.REPO_VERIFY_BADMANIFEST:
-                reason_keys = ["path", "err"]
-        elif error in [sr.REPO_VERIFY_PERM, sr.REPO_VERIFY_MFPERM]:
-                reason_keys = ["pkg", "path"]
-        elif error == sr.REPO_VERIFY_BADHASH:
-                reason_keys = ["pkg", "path", "actual", "fpath"]
-        elif error == sr.REPO_VERIFY_UNKNOWN:
-                reason_keys = ["path", "err"]
-        elif error == sr.REPO_VERIFY_BADSIG:
-                reason_keys = ["pkg", "path", "err"]
-        elif error == sr.REPO_VERIFY_DEPENDERROR:
-                reason_keys = ["pkg", "depend", "type"]
-        elif error == sr.REPO_VERIFY_WARN_OPENPERMS:
-                formatted_message = \
-                    "{error_type:>16}: {message}\n".format(
-                    error_type=verify_warning_header, message=message)
-                reason_keys = ["permissionspath", "err"]
+    # the detailed error message can be long, so we'll wrap it.  If what we
+    # have fits on a single line, use it, otherwise begin displaying the
+    # message on the next line.
+    if "err" in reason_keys:
+        err_str = ""
+        lines = textwrap.wrap(reason["err"])
+        if len(lines) != 1:
+            for line in lines:
+                err_str += "{0:>18}\n".format(line)
+            reason["err"] = "\n" + err_str.rstrip()
         else:
-                # A list of the details we provide.  Some error codes
-                # have different details associated with them.
-                reason_keys = ["pkg", "path", "fpath"]
+            reason["err"] = lines[0]
 
+    for key in reason_keys:
+        # sometimes we don't have the key we want, for example we may
+        # not have a file path from the package if the error is a
+        # missing repository file for a 'license' action (which don't
+        # have 'path' attributes, hence no 'fpath' dictionary entry)
+        if key not in reason:
+            continue
+        formatted_message += "{key:>16}: {value}\n".format(
+            key=verify_reason_headers[key], value=reason[key]
+        )
 
-        # the detailed error message can be long, so we'll wrap it.  If what we
-        # have fits on a single line, use it, otherwise begin displaying the
-        # message on the next line.
-        if "err" in reason_keys:
-                err_str = ""
-                lines = textwrap.wrap(reason["err"])
-                if len(lines) != 1:
-                        for line in lines:
-                                err_str += "{0:>18}\n".format(line)
-                        reason["err"] = "\n" + err_str.rstrip()
-                else:
-                        reason["err"] = lines[0]
+    formatted_message += "\n"
 
-        for key in reason_keys:
-                # sometimes we don't have the key we want, for example we may
-                # not have a file path from the package if the error is a
-                # missing repository file for a 'license' action (which don't
-                # have 'path' attributes, hence no 'fpath' dictionary entry)
-                if key not in reason:
-                        continue
-                formatted_message += "{key:>16}: {value}\n".format(
-                    key=verify_reason_headers[key], value=reason[key])
-
-        formatted_message += "\n"
-
-        if error == sr.REPO_VERIFY_WARN_OPENPERMS:
-                return formatted_message, None
-        elif "depend" in reason:
-                return formatted_message, reason["depend"]
-        elif "pkg" in reason:
-                return formatted_message, reason["pkg"]
-        return formatted_message, reason["path"]
+    if error == sr.REPO_VERIFY_WARN_OPENPERMS:
+        return formatted_message, None
+    elif "depend" in reason:
+        return formatted_message, reason["depend"]
+    elif "pkg" in reason:
+        return formatted_message, reason["pkg"]
+    return formatted_message, reason["path"]
 
 
 def __collect_default_ignore_dep_files(ignored_dep_files):
-        """Helpler function to collect default ignored-dependency files."""
+    """Helpler function to collect default ignored-dependency files."""
 
-        root_ignored = "/usr/share/pkg/ignored_deps"
-        altroot = DebugValues.get_value("ignored_deps")
-        if altroot:
-                root_ignored = altroot
-        if os.path.exists(root_ignored):
-                igfiles = os.listdir(root_ignored)
-                for igf in igfiles:
-                        ignored_dep_files.append(os.path.join(root_ignored,
-                            igf))
+    root_ignored = "/usr/share/pkg/ignored_deps"
+    altroot = DebugValues.get_value("ignored_deps")
+    if altroot:
+        root_ignored = altroot
+    if os.path.exists(root_ignored):
+        igfiles = os.listdir(root_ignored)
+        for igf in igfiles:
+            ignored_dep_files.append(os.path.join(root_ignored, igf))
 
 
 def subcmd_verify(conf, args):
-        """Verify the repository content (file, manifest content and
-        dependencies only)."""
+    """Verify the repository content (file, manifest content and
+    dependencies only)."""
 
-        subcommand = "verify"
-        __load_verify_msgs()
+    subcommand = "verify"
+    __load_verify_msgs()
 
-        opts, pargs = getopt.getopt(args, "dp:s:i:", ["disable="])
-        allowed_checks = set(sr.verify_default_checks)
-        force_dep_check = False
-        ignored_dep_files = []
-        pubs = set()
-        for opt, arg in opts:
-                if opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt == "-p":
-                        if not misc.valid_pub_prefix(arg):
-                                error(_("Invalid publisher prefix '{0}'").format(
-                                    arg), cmd=subcommand)
-                        pubs.add(arg)
-                elif opt == "-d":
-                        force_dep_check = True
-                elif opt == "--disable":
-                        arg = arg.lower()
-                        if arg in sr.verify_default_checks:
-                                if arg in allowed_checks:
-                                        allowed_checks.remove(arg)
-                        else:
-                                usage(_("Invalid verification to be disabled, "
-                                    "please consider: {0}").format(", ".join(
-                                    sr.verify_default_checks)), cmd=subcommand)
-                elif opt == "-i":
-                        ignored_dep_files.append(arg)
+    opts, pargs = getopt.getopt(args, "dp:s:i:", ["disable="])
+    allowed_checks = set(sr.verify_default_checks)
+    force_dep_check = False
+    ignored_dep_files = []
+    pubs = set()
+    for opt, arg in opts:
+        if opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt == "-p":
+            if not misc.valid_pub_prefix(arg):
+                error(
+                    _("Invalid publisher prefix '{0}'").format(arg),
+                    cmd=subcommand,
+                )
+            pubs.add(arg)
+        elif opt == "-d":
+            force_dep_check = True
+        elif opt == "--disable":
+            arg = arg.lower()
+            if arg in sr.verify_default_checks:
+                if arg in allowed_checks:
+                    allowed_checks.remove(arg)
+            else:
+                usage(
+                    _(
+                        "Invalid verification to be disabled, "
+                        "please consider: {0}"
+                    ).format(", ".join(sr.verify_default_checks)),
+                    cmd=subcommand,
+                )
+        elif opt == "-i":
+            ignored_dep_files.append(arg)
 
-        if pargs:
-                usage(_("command does not take operands"), cmd=subcommand)
+    if pargs:
+        usage(_("command does not take operands"), cmd=subcommand)
 
-        repo_uri = conf.get("repo_uri", None)
-        if not repo_uri:
-                usage(_("A package repository location must be provided "
-                    "using -s."), cmd=subcommand)
+    repo_uri = conf.get("repo_uri", None)
+    if not repo_uri:
+        usage(
+            _("A package repository location must be provided " "using -s."),
+            cmd=subcommand,
+        )
 
-        if repo_uri.scheme != "file":
-                usage(_("Network repositories are not currently supported "
-                    "for this operation."), cmd=subcommand)
+    if repo_uri.scheme != "file":
+        usage(
+            _(
+                "Network repositories are not currently supported "
+                "for this operation."
+            ),
+            cmd=subcommand,
+        )
 
-        if sr.VERIFY_DEPENDENCY not in allowed_checks and \
-            (force_dep_check or len(ignored_dep_files) > 0):
-                usage(_("-d or -i option cannot be used when dependency "
-                    "verification is disabled."), cmd=subcommand)
+    if sr.VERIFY_DEPENDENCY not in allowed_checks and (
+        force_dep_check or len(ignored_dep_files) > 0
+    ):
+        usage(
+            _(
+                "-d or -i option cannot be used when dependency "
+                "verification is disabled."
+            ),
+            cmd=subcommand,
+        )
 
-        xport, xpub, tmp_dir = setup_transport(repo_uri, subcommand=subcommand)
-        rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport,
-            xpub)
+    xport, xpub, tmp_dir = setup_transport(repo_uri, subcommand=subcommand)
+    rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport, xpub)
 
-        if rval == EXIT_OOPS:
-                return rval
+    if rval == EXIT_OOPS:
+        return rval
 
-        logger.info("Initiating repository verification.")
-        bad_fmris = set()
-        progtrack = get_tracker()
+    logger.info("Initiating repository verification.")
+    bad_fmris = set()
+    progtrack = get_tracker()
 
-        def report_error(verify_tuple):
-                message, bad_fmri = __fmt_verify(verify_tuple)
-                if bad_fmri:
-                        bad_fmris.add(bad_fmri)
-                progtrack.repo_verify_yield_error(bad_fmri, message)
+    def report_error(verify_tuple):
+        message, bad_fmri = __fmt_verify(verify_tuple)
+        if bad_fmri:
+            bad_fmris.add(bad_fmri)
+        progtrack.repo_verify_yield_error(bad_fmri, message)
 
-        if sr.VERIFY_DEPENDENCY in allowed_checks or not force_dep_check:
-                __collect_default_ignore_dep_files(ignored_dep_files)
+    if sr.VERIFY_DEPENDENCY in allowed_checks or not force_dep_check:
+        __collect_default_ignore_dep_files(ignored_dep_files)
 
-        repo = sr.Repository(root=repo_uri.get_pathname())
+    repo = sr.Repository(root=repo_uri.get_pathname())
 
-        found_pubs = []
-        for pfx in found:
-                xport, xpub, tmp_dir = setup_transport(repo_uri, prefix=pfx,
-                    remote_prefix=False,
-                    subcommand=subcommand)
-                xpub.transport = xport
-                found_pubs.append(xpub)
+    found_pubs = []
+    for pfx in found:
+        xport, xpub, tmp_dir = setup_transport(
+            repo_uri, prefix=pfx, remote_prefix=False, subcommand=subcommand
+        )
+        xpub.transport = xport
+        found_pubs.append(xpub)
 
-        for verify_tuple in repo.verify(pubs=found_pubs,
-            allowed_checks=allowed_checks, force_dep_check=force_dep_check,
-            ignored_dep_files=ignored_dep_files, progtrack=progtrack):
-                report_error(verify_tuple)
+    for verify_tuple in repo.verify(
+        pubs=found_pubs,
+        allowed_checks=allowed_checks,
+        force_dep_check=force_dep_check,
+        ignored_dep_files=ignored_dep_files,
+        progtrack=progtrack,
+    ):
+        report_error(verify_tuple)
 
-        if bad_fmris:
-                return EXIT_OOPS
-        return EXIT_OK
+    if bad_fmris:
+        return EXIT_OOPS
+    return EXIT_OK
 
 
 def subcmd_fix(conf, args):
-        """Fix the repository content (file and manifest content only)
-        For index and catalog content corruption, a rebuild should be
-        performed."""
+    """Fix the repository content (file and manifest content only)
+    For index and catalog content corruption, a rebuild should be
+    performed."""
 
-        subcommand = "fix"
-        __load_verify_msgs()
-        verbose = False
+    subcommand = "fix"
+    __load_verify_msgs()
+    verbose = False
 
-        # Dependency verification. Note fix will not force dependency check.
-        force_dep_check = False
-        ignored_dep_files = []
+    # Dependency verification. Note fix will not force dependency check.
+    force_dep_check = False
+    ignored_dep_files = []
 
-        opts, pargs = getopt.getopt(args, "vp:s:")
-        pubs = set()
-        for opt, arg in opts:
-                if opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                if opt == "-v":
-                        verbose = True
-                if opt == "-p":
-                        if not misc.valid_pub_prefix(arg):
-                                error(_("Invalid publisher prefix '{0}'").format(
-                                    arg), cmd=subcommand)
-                        pubs.add(arg)
+    opts, pargs = getopt.getopt(args, "vp:s:")
+    pubs = set()
+    for opt, arg in opts:
+        if opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        if opt == "-v":
+            verbose = True
+        if opt == "-p":
+            if not misc.valid_pub_prefix(arg):
+                error(
+                    _("Invalid publisher prefix '{0}'").format(arg),
+                    cmd=subcommand,
+                )
+            pubs.add(arg)
 
-        if pargs:
-                usage(_("command does not take operands"), cmd=subcommand)
+    if pargs:
+        usage(_("command does not take operands"), cmd=subcommand)
 
-        repo_uri = conf.get("repo_uri", None)
-        if not repo_uri:
-                usage(_("A package repository location must be provided "
-                    "using -s."), cmd=subcommand)
+    repo_uri = conf.get("repo_uri", None)
+    if not repo_uri:
+        usage(
+            _("A package repository location must be provided " "using -s."),
+            cmd=subcommand,
+        )
 
-        if repo_uri.scheme != "file":
-                usage(_("Network repositories are not currently supported "
-                    "for this operation."), cmd=subcommand)
+    if repo_uri.scheme != "file":
+        usage(
+            _(
+                "Network repositories are not currently supported "
+                "for this operation."
+            ),
+            cmd=subcommand,
+        )
 
-        xport, xpub, tmp_dir = setup_transport(repo_uri, subcommand=subcommand)
-        rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport,
-            xpub)
-        if rval == EXIT_OOPS:
-                return rval
+    xport, xpub, tmp_dir = setup_transport(repo_uri, subcommand=subcommand)
+    rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport, xpub)
+    if rval == EXIT_OOPS:
+        return rval
 
-        logger.info("Initiating repository fix.")
+    logger.info("Initiating repository fix.")
 
-        def verify_cb(tracker, verify_tuple):
-                """A method passed to sr.Repository.fix(..) to emit verify
-                messages if verbose mode is enabled."""
-                if not verbose:
-                        return
-                formatted_message, bad_fmri = __fmt_verify(verify_tuple)
-                tracker.repo_verify_yield_error(bad_fmri, formatted_message)
+    def verify_cb(tracker, verify_tuple):
+        """A method passed to sr.Repository.fix(..) to emit verify
+        messages if verbose mode is enabled."""
+        if not verbose:
+            return
+        formatted_message, bad_fmri = __fmt_verify(verify_tuple)
+        tracker.repo_verify_yield_error(bad_fmri, formatted_message)
 
-        repo = sr.Repository(root=repo_uri.get_pathname())
-        bad_deps = set()
-        broken_fmris = set()
-        failed_fix_paths = set()
-        progtrack = get_tracker()
-        __collect_default_ignore_dep_files(ignored_dep_files)
+    repo = sr.Repository(root=repo_uri.get_pathname())
+    bad_deps = set()
+    broken_fmris = set()
+    failed_fix_paths = set()
+    progtrack = get_tracker()
+    __collect_default_ignore_dep_files(ignored_dep_files)
 
-        found_pubs = []
-        for pfx in found:
-                xport, xpub, tmp_dir = setup_transport(repo_uri, prefix=pfx,
-                    remote_prefix=False,
-                    subcommand=subcommand)
-                xpub.transport = xport
-                found_pubs.append(xpub)
+    found_pubs = []
+    for pfx in found:
+        xport, xpub, tmp_dir = setup_transport(
+            repo_uri, prefix=pfx, remote_prefix=False, subcommand=subcommand
+        )
+        xpub.transport = xport
+        found_pubs.append(xpub)
 
-        for status_code, path, message, reason in \
-            repo.fix(pubs=found_pubs, force_dep_check=force_dep_check,
-                ignored_dep_files=ignored_dep_files,
-                progtrack=progtrack,
-                verify_callback=verify_cb):
-                if status_code == sr.REPO_FIX_ITEM:
-                        # When we can't get the FMRI, eg. in the case
-                        # of a corrupt manifest, use the path instead.
-                        fmri = reason["pkg"]
-                        if not fmri:
-                                fmri = path
-                        broken_fmris.add(fmri)
-                        if verbose:
-                                progtrack.repo_fix_yield_info(fmri,
-                                    message)
-                elif status_code == sr.REPO_VERIFY_DEPENDERROR:
-                        bad_deps.add(reason["depend"])
-                else:
-                        failed_fix_paths.add(path)
-
-        progtrack.flush()
-        logger.info("")
-
-        if broken_fmris:
-                logger.info(_("Use pkgsend(1) or pkgrecv(1) to republish the\n"
-                    "following packages or paths which were quarantined:\n\n\t"
-                    "{0}").format(
-                    "\n\t".join([str(f) for f in broken_fmris])))
-        if failed_fix_paths:
-                logger.info(_("\npkgrepo could not repair the following paths "
-                    "in the repository:\n\n\t{0}").format(
-                    "\n\t".join([p for p in failed_fix_paths])))
-        if bad_deps:
-                logger.info(_("\npkgrepo could not repair the following "
-                    "dependency issues in the repository:\n\n\t{0}").format(
-                    "\n\t".join([p for p in bad_deps])))
-        if not (broken_fmris or failed_fix_paths or bad_deps):
-                logger.info(_("No repository fixes required."))
+    for status_code, path, message, reason in repo.fix(
+        pubs=found_pubs,
+        force_dep_check=force_dep_check,
+        ignored_dep_files=ignored_dep_files,
+        progtrack=progtrack,
+        verify_callback=verify_cb,
+    ):
+        if status_code == sr.REPO_FIX_ITEM:
+            # When we can't get the FMRI, eg. in the case
+            # of a corrupt manifest, use the path instead.
+            fmri = reason["pkg"]
+            if not fmri:
+                fmri = path
+            broken_fmris.add(fmri)
+            if verbose:
+                progtrack.repo_fix_yield_info(fmri, message)
+        elif status_code == sr.REPO_VERIFY_DEPENDERROR:
+            bad_deps.add(reason["depend"])
         else:
-                logger.info(_("Repository repairs completed."))
+            failed_fix_paths.add(path)
 
-        if failed_fix_paths or bad_deps:
-                return EXIT_OOPS
-        return EXIT_OK
+    progtrack.flush()
+    logger.info("")
+
+    if broken_fmris:
+        logger.info(
+            _(
+                "Use pkgsend(1) or pkgrecv(1) to republish the\n"
+                "following packages or paths which were quarantined:\n\n\t"
+                "{0}"
+            ).format("\n\t".join([str(f) for f in broken_fmris]))
+        )
+    if failed_fix_paths:
+        logger.info(
+            _(
+                "\npkgrepo could not repair the following paths "
+                "in the repository:\n\n\t{0}"
+            ).format("\n\t".join([p for p in failed_fix_paths]))
+        )
+    if bad_deps:
+        logger.info(
+            _(
+                "\npkgrepo could not repair the following "
+                "dependency issues in the repository:\n\n\t{0}"
+            ).format("\n\t".join([p for p in bad_deps]))
+        )
+    if not (broken_fmris or failed_fix_paths or bad_deps):
+        logger.info(_("No repository fixes required."))
+    else:
+        logger.info(_("Repository repairs completed."))
+
+    if failed_fix_paths or bad_deps:
+        return EXIT_OOPS
+    return EXIT_OK
+
 
 def __get_pub_fmris(pub, xport, tmp_dir):
-        if not pub.meta_root:
-                # Create a temporary directory for catalog.
-                cat_dir = tempfile.mkdtemp(prefix="pkgrepo-diff.", dir=tmp_dir)
-                pub.meta_root = cat_dir
-                pub.transport = xport
-                pub.refresh(full_refresh=True, immediate=True)
+    if not pub.meta_root:
+        # Create a temporary directory for catalog.
+        cat_dir = tempfile.mkdtemp(prefix="pkgrepo-diff.", dir=tmp_dir)
+        pub.meta_root = cat_dir
+        pub.transport = xport
+        pub.refresh(full_refresh=True, immediate=True)
 
-        pkgs, fmris, unmatched = pub.catalog.get_matching_fmris("*")
-        fmris = [f for f in fmris]
-        return fmris, pkgs
+    pkgs, fmris, unmatched = pub.catalog.get_matching_fmris("*")
+    fmris = [f for f in fmris]
+    return fmris, pkgs
+
 
 def __format_diff(diff_type, subject):
-        """formatting diff output.
-        diff_type: can be MINUS, PLUS or COMMON.
+    """formatting diff output.
+    diff_type: can be MINUS, PLUS or COMMON.
 
-        subject: can be a publisher or a package.
-        """
+    subject: can be a publisher or a package.
+    """
 
-        format_pub = "{0}{1}"
-        format_fmri = "        {0}{1}"
-        format_str = "        {0}{1}"
-        text = ""
-        if isinstance(subject, publisher.Publisher):
-                text = format_pub.format(diff_type_f[diff_type],
-                    subject.prefix)
-        elif isinstance(subject, fmri.PkgFmri):
-                text = format_fmri.format(diff_type_f[diff_type],
-                    str(subject))
-        else:
-                text = format_str.format(diff_type_f[diff_type],
-                    subject)
-        return text
+    format_pub = "{0}{1}"
+    format_fmri = "        {0}{1}"
+    format_str = "        {0}{1}"
+    text = ""
+    if isinstance(subject, publisher.Publisher):
+        text = format_pub.format(diff_type_f[diff_type], subject.prefix)
+    elif isinstance(subject, fmri.PkgFmri):
+        text = format_fmri.format(diff_type_f[diff_type], str(subject))
+    else:
+        text = format_str.format(diff_type_f[diff_type], subject)
+    return text
+
 
 def __sorted(subject, stype=None):
-        if stype == "pub":
-                skey = operator.attrgetter("prefix")
-                return sorted(subject, key=skey)
-        return sorted(subject)
+    if stype == "pub":
+        skey = operator.attrgetter("prefix")
+        return sorted(subject, key=skey)
+    return sorted(subject)
+
 
 def __emit_msg(diff_type, subject):
-        text = __format_diff(diff_type, subject)
-        msg(text)
+    text = __format_diff(diff_type, subject)
+    msg(text)
 
-def __repo_diff(conf, pubs, xport, rpubs, rxport, tmp_dir, verbose, quiet,
-    compare_ts, compare_cat, parsable):
-        """Determine the differences between two repositories."""
 
-        same_repo = True
-        if conf["repo_uri"].scheme == "file":
-                conf["repo_uri"] = conf["repo_uri"].get_pathname()
-        if conf["com_repo_uri"].scheme == "file":
-                conf["com_repo_uri"] = conf["com_repo_uri"].get_pathname()
+def __repo_diff(
+    conf,
+    pubs,
+    xport,
+    rpubs,
+    rxport,
+    tmp_dir,
+    verbose,
+    quiet,
+    compare_ts,
+    compare_cat,
+    parsable,
+):
+    """Determine the differences between two repositories."""
 
-        foundpfx = set([pub.prefix for pub in pubs])
-        rfoundpfx = set([pub.prefix for pub in rpubs])
+    same_repo = True
+    if conf["repo_uri"].scheme == "file":
+        conf["repo_uri"] = conf["repo_uri"].get_pathname()
+    if conf["com_repo_uri"].scheme == "file":
+        conf["com_repo_uri"] = conf["com_repo_uri"].get_pathname()
 
-        minus_pfx = __sorted(foundpfx - rfoundpfx)
-        minus_pubs = __sorted([pub for pub in pubs if pub.prefix in minus_pfx],
-            stype="pub")
-        plus_pfx = __sorted(rfoundpfx - foundpfx)
-        plus_pubs = __sorted([pub for pub in rpubs if pub.prefix in plus_pfx],
-            stype="pub")
+    foundpfx = set([pub.prefix for pub in pubs])
+    rfoundpfx = set([pub.prefix for pub in rpubs])
 
-        if minus_pubs or plus_pubs:
-                same_repo = False
-                if quiet:
-                        return EXIT_DIFF
+    minus_pfx = __sorted(foundpfx - rfoundpfx)
+    minus_pubs = __sorted(
+        [pub for pub in pubs if pub.prefix in minus_pfx], stype="pub"
+    )
+    plus_pfx = __sorted(rfoundpfx - foundpfx)
+    plus_pubs = __sorted(
+        [pub for pub in rpubs if pub.prefix in plus_pfx], stype="pub"
+    )
 
-        pcommon_set = foundpfx & rfoundpfx
-        common_pubs = __sorted([p for p in pubs if p.prefix in pcommon_set],
-            stype="pub")
-        common_rpubs = __sorted([p for p in rpubs if p.prefix in pcommon_set],
-            stype="pub")
+    if minus_pubs or plus_pubs:
+        same_repo = False
+        if quiet:
+            return EXIT_DIFF
 
-        res_dict = {"table_legend": [["Repo1", str(conf["repo_uri"])],
-                ["Repo2", str(conf["com_repo_uri"])]],
-            "table_header": [_("Publisher"),
-                # This is a table column header which tells that this
-                # row shows number of packages found in specific
-                # repository only.
-                # Use terse translation to avoid too-wide header.
-                _("{repo} only").format(repo="Repo1"),
-                _("{repo} only").format(repo="Repo2"),
-                # This is a table column header which tells that this
-                # row shows number of packages found in both
-                # repositories being compared together.
-                # Use terse translation to avoid too-wide header.
-                _("In both"), _("Total")],
-            # Row based table contents.
-            "table_data": []
-            }
+    pcommon_set = foundpfx & rfoundpfx
+    common_pubs = __sorted(
+        [p for p in pubs if p.prefix in pcommon_set], stype="pub"
+    )
+    common_rpubs = __sorted(
+        [p for p in rpubs if p.prefix in pcommon_set], stype="pub"
+    )
 
-        verbose_res_dict = {"plus_pubs": [], "minus_pubs": [],
-            "common_pubs": []}
+    res_dict = {
+        "table_legend": [
+            ["Repo1", str(conf["repo_uri"])],
+            ["Repo2", str(conf["com_repo_uri"])],
+        ],
+        "table_header": [
+            _("Publisher"),
+            # This is a table column header which tells that this
+            # row shows number of packages found in specific
+            # repository only.
+            # Use terse translation to avoid too-wide header.
+            _("{repo} only").format(repo="Repo1"),
+            _("{repo} only").format(repo="Repo2"),
+            # This is a table column header which tells that this
+            # row shows number of packages found in both
+            # repositories being compared together.
+            # Use terse translation to avoid too-wide header.
+            _("In both"),
+            _("Total"),
+        ],
+        # Row based table contents.
+        "table_data": [],
+    }
 
-        def __diff_pub_helper(pub, symbol):
-                fmris, pkgs = __get_pub_fmris(pub, xport, tmp_dir)
-                # Summary level.
-                if not verbose:
-                        td_row = [pub.prefix,
-                            {"packages": len(pkgs), "versions": len(fmris)},
-                            None, {"packages": 0, "versions": 0},
-                            {"packages": len(pkgs), "versions": len(fmris)}]
-                        if symbol == PLUS:
-                                td_row[1], td_row[2] = td_row[2], td_row[1]
-                        res_dict["table_data"].append(td_row)
-                        return
+    verbose_res_dict = {"plus_pubs": [], "minus_pubs": [], "common_pubs": []}
 
-                if parsable:
-                        key_name = "minus_pubs"
-                        if symbol == PLUS:
-                                key_name = "plus_pubs"
-                        verbose_res_dict[key_name].append(
-                            {"publisher": pub.prefix, "packages": len(pkgs),
-                            "versions": len(fmris)})
-                        return
+    def __diff_pub_helper(pub, symbol):
+        fmris, pkgs = __get_pub_fmris(pub, xport, tmp_dir)
+        # Summary level.
+        if not verbose:
+            td_row = [
+                pub.prefix,
+                {"packages": len(pkgs), "versions": len(fmris)},
+                None,
+                {"packages": 0, "versions": 0},
+                {"packages": len(pkgs), "versions": len(fmris)},
+            ]
+            if symbol == PLUS:
+                td_row[1], td_row[2] = td_row[2], td_row[1]
+            res_dict["table_data"].append(td_row)
+            return
 
-                __emit_msg(symbol, pub)
-                __emit_msg(symbol, _("({0:d} package(s) with "
-                    "{1:d} different version(s))").format(len(pkgs),
-                    len(fmris)))
+        if parsable:
+            key_name = "minus_pubs"
+            if symbol == PLUS:
+                key_name = "plus_pubs"
+            verbose_res_dict[key_name].append(
+                {
+                    "publisher": pub.prefix,
+                    "packages": len(pkgs),
+                    "versions": len(fmris),
+                }
+            )
+            return
 
-        for pub in minus_pubs:
-                __diff_pub_helper(pub, MINUS)
+        __emit_msg(symbol, pub)
+        __emit_msg(
+            symbol,
+            _("({0:d} package(s) with " "{1:d} different version(s))").format(
+                len(pkgs), len(fmris)
+            ),
+        )
 
-        for pub in plus_pubs:
-                __diff_pub_helper(pub, PLUS)
+    for pub in minus_pubs:
+        __diff_pub_helper(pub, MINUS)
 
-        for pub, rpub in zip(common_pubs, common_rpubs):
-                # Indicates whether those two pubs have same pkgs.
-                same_pkgs = True
-                same_cat = True
-                fmris, pkgs = __get_pub_fmris(pub, xport, tmp_dir)
-                rfmris, rpkgs = __get_pub_fmris(rpub, rxport, tmp_dir)
-                fmris_str = set([str(f) for f in fmris])
-                rfmris_str = set([str(f) for f in rfmris])
-                del fmris, rfmris
+    for pub in plus_pubs:
+        __diff_pub_helper(pub, PLUS)
 
-                minus_fmris = __sorted(fmris_str - rfmris_str)
-                plus_fmris = __sorted(rfmris_str - fmris_str)
-                if minus_fmris or plus_fmris:
-                        same_repo = False
-                        same_pkgs = False
-                        if quiet:
-                                return EXIT_DIFF
+    for pub, rpub in zip(common_pubs, common_rpubs):
+        # Indicates whether those two pubs have same pkgs.
+        same_pkgs = True
+        same_cat = True
+        fmris, pkgs = __get_pub_fmris(pub, xport, tmp_dir)
+        rfmris, rpkgs = __get_pub_fmris(rpub, rxport, tmp_dir)
+        fmris_str = set([str(f) for f in fmris])
+        rfmris_str = set([str(f) for f in rfmris])
+        del fmris, rfmris
 
-                cat_lm_pub = None
-                cat_lm_rpub = None
-                if compare_cat:
-                        cat_lm_pub = pub.catalog.last_modified.isoformat()
-                        cat_lm_rpub = rpub.catalog.last_modified.isoformat()
-                        same_cat = same_repo = cat_lm_pub == cat_lm_rpub
-                        if not same_cat and quiet:
-                                return EXIT_DIFF
-
-                common_fmris = fmris_str & rfmris_str
-                pkg_set = set(pkgs.keys())
-                rpkg_set = set(rpkgs.keys())
-                del pkgs, rpkgs
-                common_pkgs = pkg_set & rpkg_set
-
-                # Print summary.
-                if not verbose:
-                        if not same_cat:
-                                # Common publishers with different catalog
-                                # modification time.
-                                res_dict.setdefault("nonstrict_pubs", []
-                                    ).append(pub.prefix)
-
-                        # Add to the table only if there are differences
-                        # for this publisher.
-                        if not same_pkgs:
-                                minus_pkgs = pkg_set - rpkg_set
-                                minus_pkg_vers = {"packages": len(minus_pkgs),
-                                    "versions": len(minus_fmris)}
-                                del minus_pkgs, minus_fmris
-
-                                plus_pkgs = rpkg_set - pkg_set
-                                plus_pkg_vers = {"packages": len(plus_pkgs),
-                                    "versions": len(plus_fmris)}
-                                del plus_pkgs, plus_fmris
-
-                                total_pkgs = pkg_set | rpkg_set
-                                total_fmris = fmris_str | rfmris_str
-                                total_pkg_vers = {"packages": len(total_pkgs),
-                                    "versions": len(total_fmris)}
-                                del total_pkgs, total_fmris
-
-                                com_pkg_vers = {"packages": len(common_pkgs),
-                                    "versions": len(common_fmris)}
-
-                                res_dict["table_data"].append([pub.prefix,
-                                    minus_pkg_vers, plus_pkg_vers,
-                                    com_pkg_vers,
-                                    total_pkg_vers])
-                        del common_pkgs, common_fmris, pkg_set, rpkg_set
-                        continue
-
-                com_pub_info = {}
-                # Emit publisher name if there are differences.
-                if not same_pkgs or not same_cat:
-                        if parsable:
-                                com_pub_info["publisher"] = pub.prefix
-                                com_pub_info["+"] = []
-                                com_pub_info["-"] = []
-                        else:
-                                __emit_msg(COMMON, pub)
-
-                # Emit catalog differences.
-                if not same_cat:
-                        omsg = _("catalog last modified: {0}")
-                        minus_cat = omsg.format(cat_lm_pub)
-                        plus_cat = omsg.format(cat_lm_rpub)
-                        if parsable:
-                                com_pub_info["catalog"] = {"-": minus_cat,
-                                    "+": plus_cat}
-                        else:
-                                __emit_msg(MINUS, minus_cat)
-                                __emit_msg(PLUS, plus_cat)
-
-                for f in minus_fmris:
-                        if parsable:
-                                com_pub_info["-"].append(str(f))
-                        else:
-                                __emit_msg(MINUS, f)
-                del minus_fmris
-
-                for f in plus_fmris:
-                        if parsable:
-                                com_pub_info["+"].append(str(f))
-                        else:
-                                __emit_msg(PLUS, f)
-                del plus_fmris
-
-                if not same_pkgs:
-                        if parsable:
-                                com_pub_info["common"] = {
-                                    "packages": len(common_pkgs),
-                                    "versions": len(common_fmris)}
-                        else:
-                                msg(_("        ({0:d} pkg(s) with {1:d} "
-                                    "version(s) are in both repositories.)"
-                                    ).format(len(common_pkgs),
-                                    len(common_fmris)))
-                del common_pkgs, common_fmris, pkg_set, rpkg_set
-
-                if com_pub_info:
-                        verbose_res_dict["common_pubs"].append(com_pub_info)
-
-        if same_repo:
-                # Same repo. Will use EXIT_OK to represent.
-                return EXIT_OK
-
-        if verbose:
-                if parsable:
-                        msg(json.dumps(verbose_res_dict))
+        minus_fmris = __sorted(fmris_str - rfmris_str)
+        plus_fmris = __sorted(rfmris_str - fmris_str)
+        if minus_fmris or plus_fmris:
+            same_repo = False
+            same_pkgs = False
+            if quiet:
                 return EXIT_DIFF
 
-        if not parsable:
-                ftemp = "{0:d} [{1:{2}d}]"
-                if "nonstrict_pubs" in res_dict and res_dict["nonstrict_pubs"]:
-                        msg("")
-                        msg(_("The catalog for the following publisher(s) "
-                            "in repository {0} is not an exact copy of the "
-                            "one for the same publisher in repository {1}:"
-                            "\n    {2}").format(conf["repo_uri"],
-                            conf["com_repo_uri"],
-                            ", ".join(res_dict["nonstrict_pubs"])))
-                if res_dict["table_data"]:
-                        info_table = PrettyTable(res_dict["table_header"],
-                            encoding=locale.getpreferredencoding())
-                        info_table.align = "r"
-                        info_table.align[misc.force_text(_("Publisher"),
-                            locale.getpreferredencoding())] = "l"
-                        # Calculate column wise maximum number for formatting.
-                        col_maxs = 4 * [0]
-                        for td in res_dict["table_data"]:
-                                for idx, cell in enumerate(td):
-                                        if idx > 0 and isinstance(cell, dict):
-                                                col_maxs[idx-1] = max(
-                                                    col_maxs[idx-1],
-                                                    cell["versions"])
+        cat_lm_pub = None
+        cat_lm_rpub = None
+        if compare_cat:
+            cat_lm_pub = pub.catalog.last_modified.isoformat()
+            cat_lm_rpub = rpub.catalog.last_modified.isoformat()
+            same_cat = same_repo = cat_lm_pub == cat_lm_rpub
+            if not same_cat and quiet:
+                return EXIT_DIFF
 
-                        for td in res_dict["table_data"]:
-                                t_row = []
-                                for idx, cell in enumerate(td):
-                                        if not cell:
-                                                t_row.append("-")
-                                        elif isinstance(cell, six.string_types):
-                                                t_row.append(cell)
-                                        elif isinstance(cell, dict):
-                                                t_row.append(ftemp.format(
-                                                    cell["packages"],
-                                                    cell["versions"], len(str(
-                                                    col_maxs[idx-1]))))
-                                info_table.add_row(t_row)
+        common_fmris = fmris_str & rfmris_str
+        pkg_set = set(pkgs.keys())
+        rpkg_set = set(rpkgs.keys())
+        del pkgs, rpkgs
+        common_pkgs = pkg_set & rpkg_set
 
-                        # This message explains that each cell of the table
-                        # shows two numbers in a format e.g. "4870 [10227]".
-                        # Here "number of packages" and "total distinct
-                        # versions" are shown outside and inside of square
-                        # brackets respectively.
-                        msg(_("""
+        # Print summary.
+        if not verbose:
+            if not same_cat:
+                # Common publishers with different catalog
+                # modification time.
+                res_dict.setdefault("nonstrict_pubs", []).append(pub.prefix)
+
+            # Add to the table only if there are differences
+            # for this publisher.
+            if not same_pkgs:
+                minus_pkgs = pkg_set - rpkg_set
+                minus_pkg_vers = {
+                    "packages": len(minus_pkgs),
+                    "versions": len(minus_fmris),
+                }
+                del minus_pkgs, minus_fmris
+
+                plus_pkgs = rpkg_set - pkg_set
+                plus_pkg_vers = {
+                    "packages": len(plus_pkgs),
+                    "versions": len(plus_fmris),
+                }
+                del plus_pkgs, plus_fmris
+
+                total_pkgs = pkg_set | rpkg_set
+                total_fmris = fmris_str | rfmris_str
+                total_pkg_vers = {
+                    "packages": len(total_pkgs),
+                    "versions": len(total_fmris),
+                }
+                del total_pkgs, total_fmris
+
+                com_pkg_vers = {
+                    "packages": len(common_pkgs),
+                    "versions": len(common_fmris),
+                }
+
+                res_dict["table_data"].append(
+                    [
+                        pub.prefix,
+                        minus_pkg_vers,
+                        plus_pkg_vers,
+                        com_pkg_vers,
+                        total_pkg_vers,
+                    ]
+                )
+            del common_pkgs, common_fmris, pkg_set, rpkg_set
+            continue
+
+        com_pub_info = {}
+        # Emit publisher name if there are differences.
+        if not same_pkgs or not same_cat:
+            if parsable:
+                com_pub_info["publisher"] = pub.prefix
+                com_pub_info["+"] = []
+                com_pub_info["-"] = []
+            else:
+                __emit_msg(COMMON, pub)
+
+        # Emit catalog differences.
+        if not same_cat:
+            omsg = _("catalog last modified: {0}")
+            minus_cat = omsg.format(cat_lm_pub)
+            plus_cat = omsg.format(cat_lm_rpub)
+            if parsable:
+                com_pub_info["catalog"] = {"-": minus_cat, "+": plus_cat}
+            else:
+                __emit_msg(MINUS, minus_cat)
+                __emit_msg(PLUS, plus_cat)
+
+        for f in minus_fmris:
+            if parsable:
+                com_pub_info["-"].append(str(f))
+            else:
+                __emit_msg(MINUS, f)
+        del minus_fmris
+
+        for f in plus_fmris:
+            if parsable:
+                com_pub_info["+"].append(str(f))
+            else:
+                __emit_msg(PLUS, f)
+        del plus_fmris
+
+        if not same_pkgs:
+            if parsable:
+                com_pub_info["common"] = {
+                    "packages": len(common_pkgs),
+                    "versions": len(common_fmris),
+                }
+            else:
+                msg(
+                    _(
+                        "        ({0:d} pkg(s) with {1:d} "
+                        "version(s) are in both repositories.)"
+                    ).format(len(common_pkgs), len(common_fmris))
+                )
+        del common_pkgs, common_fmris, pkg_set, rpkg_set
+
+        if com_pub_info:
+            verbose_res_dict["common_pubs"].append(com_pub_info)
+
+    if same_repo:
+        # Same repo. Will use EXIT_OK to represent.
+        return EXIT_OK
+
+    if verbose:
+        if parsable:
+            msg(json.dumps(verbose_res_dict))
+        return EXIT_DIFF
+
+    if not parsable:
+        ftemp = "{0:d} [{1:{2}d}]"
+        if "nonstrict_pubs" in res_dict and res_dict["nonstrict_pubs"]:
+            msg("")
+            msg(
+                _(
+                    "The catalog for the following publisher(s) "
+                    "in repository {0} is not an exact copy of the "
+                    "one for the same publisher in repository {1}:"
+                    "\n    {2}"
+                ).format(
+                    conf["repo_uri"],
+                    conf["com_repo_uri"],
+                    ", ".join(res_dict["nonstrict_pubs"]),
+                )
+            )
+        if res_dict["table_data"]:
+            info_table = PrettyTable(
+                res_dict["table_header"], encoding=locale.getpreferredencoding()
+            )
+            info_table.align = "r"
+            info_table.align[
+                misc.force_text(_("Publisher"), locale.getpreferredencoding())
+            ] = "l"
+            # Calculate column wise maximum number for formatting.
+            col_maxs = 4 * [0]
+            for td in res_dict["table_data"]:
+                for idx, cell in enumerate(td):
+                    if idx > 0 and isinstance(cell, dict):
+                        col_maxs[idx - 1] = max(
+                            col_maxs[idx - 1], cell["versions"]
+                        )
+
+            for td in res_dict["table_data"]:
+                t_row = []
+                for idx, cell in enumerate(td):
+                    if not cell:
+                        t_row.append("-")
+                    elif isinstance(cell, six.string_types):
+                        t_row.append(cell)
+                    elif isinstance(cell, dict):
+                        t_row.append(
+                            ftemp.format(
+                                cell["packages"],
+                                cell["versions"],
+                                len(str(col_maxs[idx - 1])),
+                            )
+                        )
+                info_table.add_row(t_row)
+
+            # This message explains that each cell of the table
+            # shows two numbers in a format e.g. "4870 [10227]".
+            # Here "number of packages" and "total distinct
+            # versions" are shown outside and inside of square
+            # brackets respectively.
+            msg(
+                _(
+                    """
 The table below shows the number of packages [total distinct versions]
 by publisher in the specified repositories.
-"""))
-                        for leg in res_dict["table_legend"]:
-                                msg("* " + leg[0] + ": " + leg[1])
-                        msg("")
-                        msg(info_table)
-        else:
-                msg(json.dumps(res_dict))
+"""
+                )
+            )
+            for leg in res_dict["table_legend"]:
+                msg("* " + leg[0] + ": " + leg[1])
+            msg("")
+            msg(info_table)
+    else:
+        msg(json.dumps(res_dict))
 
-        return EXIT_DIFF
+    return EXIT_DIFF
 
 
 def subcmd_diff(conf, args):
-        """Compare two repositories."""
+    """Compare two repositories."""
 
-        opts, pargs = getopt.getopt(args, "vqp:s:", ["strict", "parsable",
-            "key=", "cert="])
-        subcommand = "diff"
-        pubs = set()
-        verbose = 0
-        quiet = False
-        compare_ts = True
-        compare_cat = False
-        parsable = False
+    opts, pargs = getopt.getopt(
+        args, "vqp:s:", ["strict", "parsable", "key=", "cert="]
+    )
+    subcommand = "diff"
+    pubs = set()
+    verbose = 0
+    quiet = False
+    compare_ts = True
+    compare_cat = False
+    parsable = False
 
-        def key_cert_conf_helper(conf_type, arg):
-                """Helper function for collecting key and cert."""
+    def key_cert_conf_helper(conf_type, arg):
+        """Helper function for collecting key and cert."""
 
-                if conf.get("repo_uri") and not conf.get("com_repo_uri"):
-                        conf["repo_" + conf_type] = arg
-                elif conf.get("com_repo_uri"):
-                        conf["com_repo_" + conf_type] = arg
-                else:
-                        usage(_("--{0} must be specified following a "
-                            "-s").format(conf_type), cmd=subcommand)
+        if conf.get("repo_uri") and not conf.get("com_repo_uri"):
+            conf["repo_" + conf_type] = arg
+        elif conf.get("com_repo_uri"):
+            conf["com_repo_" + conf_type] = arg
+        else:
+            usage(
+                _("--{0} must be specified following a " "-s").format(
+                    conf_type
+                ),
+                cmd=subcommand,
+            )
 
-        for opt, arg in opts:
-                if opt == "-s":
-                        if "repo_uri" not in conf:
-                                conf["repo_uri"] = parse_uri(arg)
-                        elif "com_repo_uri" not in conf:
-                                conf["com_repo_uri"] = parse_uri(arg)
-                        else:
-                                usage(_("only two repositories can be "
-                                    "specified"), cmd=subcommand)
-                if opt == "-v":
-                        verbose += 1
-                elif opt == "-q":
-                        quiet = True
-                elif opt == "--strict":
-                        compare_cat = True
-                elif opt == "--parsable":
-                        parsable = True
-                elif opt == "-p":
-                        if not misc.valid_pub_prefix(arg):
-                                error(_("Invalid publisher prefix '{0}'").format(
-                                    arg), cmd=subcommand)
-                                return EXIT_OOPS
-                        pubs.add(arg)
-                elif opt == "--key":
-                        key_cert_conf_helper("key", arg)
-                elif opt == "--cert":
-                        key_cert_conf_helper("cert", arg)
+    for opt, arg in opts:
+        if opt == "-s":
+            if "repo_uri" not in conf:
+                conf["repo_uri"] = parse_uri(arg)
+            elif "com_repo_uri" not in conf:
+                conf["com_repo_uri"] = parse_uri(arg)
+            else:
+                usage(
+                    _("only two repositories can be " "specified"),
+                    cmd=subcommand,
+                )
+        if opt == "-v":
+            verbose += 1
+        elif opt == "-q":
+            quiet = True
+        elif opt == "--strict":
+            compare_cat = True
+        elif opt == "--parsable":
+            parsable = True
+        elif opt == "-p":
+            if not misc.valid_pub_prefix(arg):
+                error(
+                    _("Invalid publisher prefix '{0}'").format(arg),
+                    cmd=subcommand,
+                )
+                return EXIT_OOPS
+            pubs.add(arg)
+        elif opt == "--key":
+            key_cert_conf_helper("key", arg)
+        elif opt == "--cert":
+            key_cert_conf_helper("cert", arg)
 
-        if len(pargs) > 0:
-                usage(_("command does not take any operands"), cmd=subcommand)
+    if len(pargs) > 0:
+        usage(_("command does not take any operands"), cmd=subcommand)
 
-        if quiet and verbose:
-                usage(_("-q and -v can not be combined"), cmd=subcommand)
+    if quiet and verbose:
+        usage(_("-q and -v can not be combined"), cmd=subcommand)
 
-        repo_uri = conf.get("repo_uri")
-        if not repo_uri:
-                usage(_("Two package repository locations must be provided "
-                    "using -s."), cmd=subcommand)
+    repo_uri = conf.get("repo_uri")
+    if not repo_uri:
+        usage(
+            _("Two package repository locations must be provided " "using -s."),
+            cmd=subcommand,
+        )
 
-        com_repo_uri = conf.get("com_repo_uri")
-        if not com_repo_uri:
-                usage(_("A second package repository location must also be "
-                    "provided using -s."), cmd=subcommand)
+    com_repo_uri = conf.get("com_repo_uri")
+    if not com_repo_uri:
+        usage(
+            _(
+                "A second package repository location must also be "
+                "provided using -s."
+            ),
+            cmd=subcommand,
+        )
 
-        xport, xpub, tmp_dir = setup_transport(repo_uri, subcommand=subcommand,
-            ssl_key=conf.get("repo_key"), ssl_cert=conf.get("repo_cert"))
-        cxport, cxpub, c_tmp_dir = setup_transport(com_repo_uri,
-            subcommand=subcommand, prefix="com",
-            ssl_key=conf.get("com_repo_key"),
-            ssl_cert=conf.get("com_repo_cert"))
-        rval, found, pub_data = _get_matching_pubs(subcommand, pubs, xport,
-            xpub, use_transport=True, repo_uri=repo_uri)
-        if rval == EXIT_OOPS:
-                return rval
+    xport, xpub, tmp_dir = setup_transport(
+        repo_uri,
+        subcommand=subcommand,
+        ssl_key=conf.get("repo_key"),
+        ssl_cert=conf.get("repo_cert"),
+    )
+    cxport, cxpub, c_tmp_dir = setup_transport(
+        com_repo_uri,
+        subcommand=subcommand,
+        prefix="com",
+        ssl_key=conf.get("com_repo_key"),
+        ssl_cert=conf.get("com_repo_cert"),
+    )
+    rval, found, pub_data = _get_matching_pubs(
+        subcommand, pubs, xport, xpub, use_transport=True, repo_uri=repo_uri
+    )
+    if rval == EXIT_OOPS:
+        return rval
 
-        rval, cfound, cpub_data = _get_matching_pubs(subcommand, pubs, cxport,
-            cxpub, use_transport=True, repo_uri=com_repo_uri)
-        if rval == EXIT_OOPS:
-                return rval
+    rval, cfound, cpub_data = _get_matching_pubs(
+        subcommand,
+        pubs,
+        cxport,
+        cxpub,
+        use_transport=True,
+        repo_uri=com_repo_uri,
+    )
+    if rval == EXIT_OOPS:
+        return rval
 
-        return  __repo_diff(conf, pub_data, xport, cpub_data, cxport, tmp_dir,
-            verbose, quiet, compare_ts, compare_cat, parsable)
+    return __repo_diff(
+        conf,
+        pub_data,
+        xport,
+        cpub_data,
+        cxport,
+        tmp_dir,
+        verbose,
+        quiet,
+        compare_ts,
+        compare_cat,
+        parsable,
+    )
 
 
 def main_func():
-        global_settings.client_name = PKG_CLIENT_NAME
+    global_settings.client_name = PKG_CLIENT_NAME
 
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "s:D:?",
-                    ["help", "debug="])
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
+    try:
+        opts, pargs = getopt.getopt(sys.argv[1:], "s:D:?", ["help", "debug="])
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
 
-        conf = {}
-        show_usage = False
-        for opt, arg in opts:
-                if opt == "-s":
-                        conf["repo_uri"] = parse_uri(arg)
-                elif opt in ("--help", "-?"):
-                        show_usage = True
-                elif opt == "-D" or opt == "--debug":
-                        try:
-                                key, value = arg.split("=", 1)
-                        except (AttributeError, ValueError):
-                                usage(_("{opt} takes argument of form "
-                                   "name=value, not {arg}").format(
-                                   opt=opt, arg=arg))
-                        DebugValues.set_value(key, value)
+    conf = {}
+    show_usage = False
+    for opt, arg in opts:
+        if opt == "-s":
+            conf["repo_uri"] = parse_uri(arg)
+        elif opt in ("--help", "-?"):
+            show_usage = True
+        elif opt == "-D" or opt == "--debug":
+            try:
+                key, value = arg.split("=", 1)
+            except (AttributeError, ValueError):
+                usage(
+                    _(
+                        "{opt} takes argument of form " "name=value, not {arg}"
+                    ).format(opt=opt, arg=arg)
+                )
+            DebugValues.set_value(key, value)
 
-        if DebugValues:
-                reload(pkg.digest)
+    if DebugValues:
+        reload(pkg.digest)
 
-        subcommand = None
-        if pargs:
-                subcommand = pargs.pop(0)
-                if subcommand == "help":
-                        show_usage = True
+    subcommand = None
+    if pargs:
+        subcommand = pargs.pop(0)
+        if subcommand == "help":
+            show_usage = True
 
-        if show_usage:
-                usage(retcode=0, full=True)
-        elif not subcommand:
-                usage(_("no subcommand specified"))
+    if show_usage:
+        usage(retcode=0, full=True)
+    elif not subcommand:
+        usage(_("no subcommand specified"))
 
-        subcommand = subcommand.replace("-", "_")
-        func = globals().get("subcmd_{0}".format(subcommand), None)
-        if not func:
-                subcommand = subcommand.replace("_", "-")
-                usage(_("unknown subcommand '{0}'").format(subcommand))
+    subcommand = subcommand.replace("-", "_")
+    func = globals().get("subcmd_{0}".format(subcommand), None)
+    if not func:
+        subcommand = subcommand.replace("_", "-")
+        usage(_("unknown subcommand '{0}'").format(subcommand))
 
-        try:
-                return func(conf, pargs)
-        except getopt.GetoptError as e:
-                if e.opt in ("help", "?"):
-                        usage(full=True)
-                usage(_("illegal option -- {0}").format(e.opt), cmd=subcommand)
+    try:
+        return func(conf, pargs)
+    except getopt.GetoptError as e:
+        if e.opt in ("help", "?"):
+            usage(full=True)
+        usage(_("illegal option -- {0}").format(e.opt), cmd=subcommand)
 
 
 #
@@ -2326,75 +2691,76 @@ def main_func():
 # so that we can more easily detect these in testing of the CLI commands.
 #
 def handle_errors(func, *args, **kwargs):
-        """Catch exceptions raised by the main program function and then print
-        a message and/or exit with an appropriate return code.
-        """
+    """Catch exceptions raised by the main program function and then print
+    a message and/or exit with an appropriate return code.
+    """
 
-        traceback_str = misc.get_traceback_message()
+    traceback_str = misc.get_traceback_message()
 
+    try:
+        # Out of memory errors can be raised as EnvironmentErrors with
+        # an errno of ENOMEM, so in order to handle those exceptions
+        # with other errnos, we nest this try block and have the outer
+        # one handle the other instances.
         try:
-                # Out of memory errors can be raised as EnvironmentErrors with
-                # an errno of ENOMEM, so in order to handle those exceptions
-                # with other errnos, we nest this try block and have the outer
-                # one handle the other instances.
-                try:
-                        __ret = func(*args, **kwargs)
-                except (MemoryError, EnvironmentError) as __e:
-                        if isinstance(__e, EnvironmentError) and \
-                            __e.errno != errno.ENOMEM:
-                                raise apx._convert_error(__e)
-                        error("\n" + misc.out_of_memory())
-                        __ret = EXIT_OOPS
-        except SystemExit as __e:
-                raise __e
-        except (IOError, PipeError, KeyboardInterrupt) as __e:
-                # Don't display any messages here to prevent possible further
-                # broken pipe (EPIPE) errors.
-                if isinstance(__e, IOError) and __e.errno != errno.EPIPE:
-                        error(str(__e))
-                __ret = EXIT_OOPS
-        except apx.VersionException as __e:
-                error(_("The pkgrepo command appears out of sync with the "
-                    "libraries provided\nby pkg:/package/pkg. The client "
-                    "version is {client} while the library\nAPI version is "
-                    "{api}.").format(client=__e.received_version,
-                     api=__e.expected_version))
-                __ret = EXIT_OOPS
-        except apx.BadRepositoryURI as __e:
-                error(str(__e))
-                __ret = EXIT_BADOPT
-        except apx.InvalidOptionError as __e:
-                error("{0} Supported formats: {1}".format(
-                    str(__e), LISTING_FORMATS))
-                __ret = EXIT_BADOPT
-        except (apx.ApiException, sr.RepositoryError) as __e:
-                error(str(__e))
-                __ret = EXIT_OOPS
-        except:
-                traceback.print_exc()
-                error(traceback_str)
-                __ret = 99
-        return __ret
+            __ret = func(*args, **kwargs)
+        except (MemoryError, EnvironmentError) as __e:
+            if isinstance(__e, EnvironmentError) and __e.errno != errno.ENOMEM:
+                raise apx._convert_error(__e)
+            error("\n" + misc.out_of_memory())
+            __ret = EXIT_OOPS
+    except SystemExit as __e:
+        raise __e
+    except (IOError, PipeError, KeyboardInterrupt) as __e:
+        # Don't display any messages here to prevent possible further
+        # broken pipe (EPIPE) errors.
+        if isinstance(__e, IOError) and __e.errno != errno.EPIPE:
+            error(str(__e))
+        __ret = EXIT_OOPS
+    except apx.VersionException as __e:
+        error(
+            _(
+                "The pkgrepo command appears out of sync with the "
+                "libraries provided\nby pkg:/package/pkg. The client "
+                "version is {client} while the library\nAPI version is "
+                "{api}."
+            ).format(client=__e.received_version, api=__e.expected_version)
+        )
+        __ret = EXIT_OOPS
+    except apx.BadRepositoryURI as __e:
+        error(str(__e))
+        __ret = EXIT_BADOPT
+    except apx.InvalidOptionError as __e:
+        error("{0} Supported formats: {1}".format(str(__e), LISTING_FORMATS))
+        __ret = EXIT_BADOPT
+    except (apx.ApiException, sr.RepositoryError) as __e:
+        error(str(__e))
+        __ret = EXIT_OOPS
+    except:
+        traceback.print_exc()
+        error(traceback_str)
+        __ret = 99
+    return __ret
 
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        # Make all warnings be errors.
-        warnings.simplefilter('error')
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
+    # Make all warnings be errors.
+    warnings.simplefilter("error")
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
 
-        __retval = handle_errors(main_func)
-        try:
-                logging.shutdown()
-        except IOError:
-                # Ignore python's spurious pipe problems.
-                pass
-        sys.exit(__retval)
+    __retval = handle_errors(main_func)
+    try:
+        logging.shutdown()
+    except IOError:
+        # Ignore python's spurious pipe problems.
+        pass
+    sys.exit(__retval)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/publish.py
+++ b/src/publish.py
@@ -25,7 +25,9 @@
 #
 
 from __future__ import print_function
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 import fnmatch
 import getopt
 import gettext
@@ -53,7 +55,7 @@ from pkg.misc import msg, emsg, PipeError
 from pkg.client import global_settings
 from pkg.client.debugvalues import DebugValues
 
-nopub_actions = [ "unknown" ]
+nopub_actions = ["unknown"]
 
 # These attributes should always be stripped from input manifests for 'publish';
 # they will be re-calculated during publication.
@@ -66,36 +68,40 @@ strip_attrs = [
     "pkg.size",
 ]
 
+
 def error(text, cmd=None):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        if not isinstance(text, six.string_types):
-                # Assume it's an object that can be stringified.
-                text = str(text)
+    if not isinstance(text, six.string_types):
+        # Assume it's an object that can be stringified.
+        text = str(text)
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        if cmd:
-                text_nows = "{0}: {1}".format(cmd, text_nows)
-                pkg_cmd = "pkgsend "
-        else:
-                pkg_cmd = "pkgsend: "
+    if cmd:
+        text_nows = "{0}: {1}".format(cmd, text_nows)
+        pkg_cmd = "pkgsend "
+    else:
+        pkg_cmd = "pkgsend: "
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        emsg(ws + pkg_cmd + text_nows)
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    emsg(ws + pkg_cmd + text_nows)
+
 
 def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT):
-        """Emit a usage message and optionally prefix it with a more specific
-        error message.  Causes program to exit."""
+    """Emit a usage message and optionally prefix it with a more specific
+    error message.  Causes program to exit."""
 
-        if usage_error:
-                error(usage_error, cmd=cmd)
+    if usage_error:
+        error(usage_error, cmd=cmd)
 
-        print(_("""\
+    print(
+        _(
+            """\
 Usage:
         pkgsend [options] command [cmd_options] [operands]
 
@@ -109,775 +115,862 @@ Options:
         --help or -?    display usage message
 
 Environment:
-        PKG_REPO        The path or URI of the destination repository."""))
-        sys.exit(retcode)
+        PKG_REPO        The path or URI of the destination repository."""
+        )
+    )
+    sys.exit(retcode)
+
 
 class SolarisBundleVisitor(object):
-        """Used to gather information about the SVR4 packages we visit"""
+    """Used to gather information about the SVR4 packages we visit"""
 
-        def __init__(self):
-                # a list of classes for which we do not report warnings
-                self.known_classes = ["none", "manifest"]
-                self.errors = set()
-                self.warnings = set()
-                self.visited = False
+    def __init__(self):
+        # a list of classes for which we do not report warnings
+        self.known_classes = ["none", "manifest"]
+        self.errors = set()
+        self.warnings = set()
+        self.visited = False
 
-        def visit(self, bundle):
-                """visit a pkg.bundle.SolarisPackage*Bundle object"""
+    def visit(self, bundle):
+        """visit a pkg.bundle.SolarisPackage*Bundle object"""
 
-                if not bundle.pkg:
-                        return
+        if not bundle.pkg:
+            return
 
-                if self.visited:
-                        self.warnings.add(_(
-                            "WARNING: Several SVR4 packages detected. "
-                            "Multiple pkg.summary and pkg.description "
-                            "attributes may have been generated."))
+        if self.visited:
+            self.warnings.add(
+                _(
+                    "WARNING: Several SVR4 packages detected. "
+                    "Multiple pkg.summary and pkg.description "
+                    "attributes may have been generated."
+                )
+            )
 
-                for action in bundle:
-                        if "path" not in action.attrs:
-                                continue
-                        path = action.attrs["path"]
-                        if path in bundle.class_actions_dir:
-                                svr4_class = bundle.class_actions_dir[path]
-                                if svr4_class and \
-                                    svr4_class not in self.known_classes:
-                                        self.errors.add(
-                                            _("ERROR: class action script "
-                                            "used in {pkg}: {path} belongs "
-                                            "to \"{classname}\" class").format(
-                                            pkg=bundle.pkgname,
-                                            path=path, classname=svr4_class))
-                for script in bundle.scripts:
-                        self.errors.add(
-                            _("ERROR: script present in {pkg}: {script}").format(
-                            pkg=bundle.pkgname, script=script))
+        for action in bundle:
+            if "path" not in action.attrs:
+                continue
+            path = action.attrs["path"]
+            if path in bundle.class_actions_dir:
+                svr4_class = bundle.class_actions_dir[path]
+                if svr4_class and svr4_class not in self.known_classes:
+                    self.errors.add(
+                        _(
+                            "ERROR: class action script "
+                            "used in {pkg}: {path} belongs "
+                            'to "{classname}" class'
+                        ).format(
+                            pkg=bundle.pkgname, path=path, classname=svr4_class
+                        )
+                    )
+        for script in bundle.scripts:
+            self.errors.add(
+                _("ERROR: script present in {pkg}: {script}").format(
+                    pkg=bundle.pkgname, script=script
+                )
+            )
 
-                self.visited = True
+        self.visited = True
 
 
 def trans_create_repository(repo_uri, args):
-        """DEPRECATED"""
+    """DEPRECATED"""
 
-        repo_props = {}
-        opts, pargs = getopt.getopt(args, "", ["set-property="])
-        for opt, arg in opts:
-                if opt == "--set-property":
-                        try:
-                                prop, p_value = arg.split("=", 1)
-                                p_sec, p_name = prop.split(".", 1)
-                        except ValueError:
-                                usage(_("property arguments must be of "
-                                    "the form '<section.property>="
-                                    "<value>'."), cmd="create-repository")
-                        repo_props.setdefault(p_sec, {})
-                        repo_props[p_sec][p_name] = p_value
+    repo_props = {}
+    opts, pargs = getopt.getopt(args, "", ["set-property="])
+    for opt, arg in opts:
+        if opt == "--set-property":
+            try:
+                prop, p_value = arg.split("=", 1)
+                p_sec, p_name = prop.split(".", 1)
+            except ValueError:
+                usage(
+                    _(
+                        "property arguments must be of "
+                        "the form '<section.property>="
+                        "<value>'."
+                    ),
+                    cmd="create-repository",
+                )
+            repo_props.setdefault(p_sec, {})
+            repo_props[p_sec][p_name] = p_value
 
-        xport, pub = setup_transport_and_pubs(repo_uri, remote=False)
+    xport, pub = setup_transport_and_pubs(repo_uri, remote=False)
 
-        try:
-                trans.Transaction(repo_uri, create_repo=True,
-                    repo_props=repo_props, xport=xport, pub=pub)
-        except trans.TransactionRepositoryConfigError as e:
-                error(e, cmd="create-repository")
-                emsg(_("Invalid repository configuration values were "
-                    "specified using --set-property or required values are "
-                    "missing.  Please provide the correct and/or required "
-                    "values using the --set-property option."))
-        except trans.TransactionError as e:
-                error(e, cmd="create-repository")
-                return EXIT_OOPS
-        return EXIT_OK
+    try:
+        trans.Transaction(
+            repo_uri,
+            create_repo=True,
+            repo_props=repo_props,
+            xport=xport,
+            pub=pub,
+        )
+    except trans.TransactionRepositoryConfigError as e:
+        error(e, cmd="create-repository")
+        emsg(
+            _(
+                "Invalid repository configuration values were "
+                "specified using --set-property or required values are "
+                "missing.  Please provide the correct and/or required "
+                "values using the --set-property option."
+            )
+        )
+    except trans.TransactionError as e:
+        error(e, cmd="create-repository")
+        return EXIT_OOPS
+    return EXIT_OK
+
 
 def trans_open(repo_uri, args):
-        """DEPRECATED"""
+    """DEPRECATED"""
 
-        opts, pargs = getopt.getopt(args, "en")
+    opts, pargs = getopt.getopt(args, "en")
 
-        parsed = []
-        eval_form = True
-        for opt, arg in opts:
-                parsed.append(opt)
-                if opt == "-e":
-                        eval_form = True
-                if opt == "-n":
-                        eval_form = False
+    parsed = []
+    eval_form = True
+    for opt, arg in opts:
+        parsed.append(opt)
+        if opt == "-e":
+            eval_form = True
+        if opt == "-n":
+            eval_form = False
 
-        if "-e" in parsed and "-n" in parsed:
-                usage(_("only -e or -n may be specified"), cmd="open")
+    if "-e" in parsed and "-n" in parsed:
+        usage(_("only -e or -n may be specified"), cmd="open")
 
-        if len(pargs) != 1:
-                usage(_("open requires one package name"), cmd="open")
+    if len(pargs) != 1:
+        usage(_("open requires one package name"), cmd="open")
 
-        xport, pub = setup_transport_and_pubs(repo_uri)
+    xport, pub = setup_transport_and_pubs(repo_uri)
 
-        t = trans.Transaction(repo_uri, pkg_name=pargs[0], xport=xport, pub=pub)
-        if eval_form:
-                msg("export PKG_TRANS_ID={0}".format(t.open()))
-        else:
-                msg(t.open())
+    t = trans.Transaction(repo_uri, pkg_name=pargs[0], xport=xport, pub=pub)
+    if eval_form:
+        msg("export PKG_TRANS_ID={0}".format(t.open()))
+    else:
+        msg(t.open())
 
-        return EXIT_OK
+    return EXIT_OK
+
 
 def trans_append(repo_uri, args):
-        """DEPRECATED"""
+    """DEPRECATED"""
 
-        opts, pargs = getopt.getopt(args, "en")
+    opts, pargs = getopt.getopt(args, "en")
 
-        parsed = []
-        eval_form = True
-        for opt, arg in opts:
-                parsed.append(opt)
-                if opt == "-e":
-                        eval_form = True
-                if opt == "-n":
-                        eval_form = False
+    parsed = []
+    eval_form = True
+    for opt, arg in opts:
+        parsed.append(opt)
+        if opt == "-e":
+            eval_form = True
+        if opt == "-n":
+            eval_form = False
 
-        if "-e" in parsed and "-n" in parsed:
-                usage(_("only -e or -n may be specified"), cmd="open")
+    if "-e" in parsed and "-n" in parsed:
+        usage(_("only -e or -n may be specified"), cmd="open")
 
-        if len(pargs) != 1:
-                usage(_("append requires one package name"), cmd="open")
+    if len(pargs) != 1:
+        usage(_("append requires one package name"), cmd="open")
 
-        xport, pub = setup_transport_and_pubs(repo_uri)
+    xport, pub = setup_transport_and_pubs(repo_uri)
 
-        t = trans.Transaction(repo_uri, pkg_name=pargs[0], xport=xport, pub=pub)
-        if eval_form:
-                msg("export PKG_TRANS_ID={0}".format(t.append()))
-        else:
-                msg(t.append())
+    t = trans.Transaction(repo_uri, pkg_name=pargs[0], xport=xport, pub=pub)
+    if eval_form:
+        msg("export PKG_TRANS_ID={0}".format(t.append()))
+    else:
+        msg(t.append())
 
-        return EXIT_OK
+    return EXIT_OK
+
 
 def trans_close(repo_uri, args):
-        """DEPRECATED"""
+    """DEPRECATED"""
 
-        abandon = False
-        trans_id = None
-        add_to_catalog = True
+    abandon = False
+    trans_id = None
+    add_to_catalog = True
 
-        # --no-index is now silently ignored as the publication process no
-        # longer builds search indexes automatically.
-        opts, pargs = getopt.getopt(args, "At:", ["no-index", "no-catalog"])
+    # --no-index is now silently ignored as the publication process no
+    # longer builds search indexes automatically.
+    opts, pargs = getopt.getopt(args, "At:", ["no-index", "no-catalog"])
 
-        for opt, arg in opts:
-                if opt == "-A":
-                        abandon = True
-                elif opt == "-t":
-                        trans_id = arg
-                elif opt == "--no-catalog":
-                        add_to_catalog = False
-        if trans_id is None:
-                try:
-                        trans_id = os.environ["PKG_TRANS_ID"]
-                except KeyError:
-                        usage(_("No transaction ID specified using -t or in "
-                            "$PKG_TRANS_ID."), cmd="close")
+    for opt, arg in opts:
+        if opt == "-A":
+            abandon = True
+        elif opt == "-t":
+            trans_id = arg
+        elif opt == "--no-catalog":
+            add_to_catalog = False
+    if trans_id is None:
+        try:
+            trans_id = os.environ["PKG_TRANS_ID"]
+        except KeyError:
+            usage(
+                _(
+                    "No transaction ID specified using -t or in "
+                    "$PKG_TRANS_ID."
+                ),
+                cmd="close",
+            )
 
-        xport, pub = setup_transport_and_pubs(repo_uri)
-        t = trans.Transaction(repo_uri, trans_id=trans_id, xport=xport, pub=pub)
-        pkg_state, pkg_fmri = t.close(abandon=abandon,
-            add_to_catalog=add_to_catalog)
-        for val in (pkg_state, pkg_fmri):
-                if val is not None:
-                        msg(val)
-        return EXIT_OK
+    xport, pub = setup_transport_and_pubs(repo_uri)
+    t = trans.Transaction(repo_uri, trans_id=trans_id, xport=xport, pub=pub)
+    pkg_state, pkg_fmri = t.close(
+        abandon=abandon, add_to_catalog=add_to_catalog
+    )
+    for val in (pkg_state, pkg_fmri):
+        if val is not None:
+            msg(val)
+    return EXIT_OK
+
 
 def trans_add(repo_uri, args):
-        """DEPRECATED"""
+    """DEPRECATED"""
 
-        try:
-                trans_id = os.environ["PKG_TRANS_ID"]
-        except KeyError:
-                usage(_("No transaction ID specified in $PKG_TRANS_ID"),
-                    cmd="add")
+    try:
+        trans_id = os.environ["PKG_TRANS_ID"]
+    except KeyError:
+        usage(_("No transaction ID specified in $PKG_TRANS_ID"), cmd="add")
 
-        if not args:
-                usage(_("No arguments specified for subcommand."), cmd="add")
+    if not args:
+        usage(_("No arguments specified for subcommand."), cmd="add")
 
-        action, lp = pkg.actions.internalizelist(args[0], args[1:])
+    action, lp = pkg.actions.internalizelist(args[0], args[1:])
 
-        if action.name in nopub_actions:
-                error(_("invalid action for publication: {0}").format(action),
-                    cmd="add")
-                return EXIT_OOPS
+    if action.name in nopub_actions:
+        error(
+            _("invalid action for publication: {0}").format(action), cmd="add"
+        )
+        return EXIT_OOPS
 
-        xport, pub = setup_transport_and_pubs(repo_uri)
-        t = trans.Transaction(repo_uri, trans_id=trans_id, xport=xport,
-            pub=pub)
-        t.add(action)
-        return EXIT_OK
+    xport, pub = setup_transport_and_pubs(repo_uri)
+    t = trans.Transaction(repo_uri, trans_id=trans_id, xport=xport, pub=pub)
+    t.add(action)
+    return EXIT_OK
+
 
 def trans_publish(repo_uri, fargs):
-        """Publish packages in a single step using provided manifest data and
-        sources."""
+    """Publish packages in a single step using provided manifest data and
+    sources."""
 
-        # --no-index is now silently ignored as the publication process no
-        # longer builds search indexes automatically.
-        opts, pargs = getopt.getopt(fargs, "b:d:s:T:", ["fmri-in-manifest",
-            "no-index", "no-catalog", "key=", "cert="])
+    # --no-index is now silently ignored as the publication process no
+    # longer builds search indexes automatically.
+    opts, pargs = getopt.getopt(
+        fargs,
+        "b:d:s:T:",
+        ["fmri-in-manifest", "no-index", "no-catalog", "key=", "cert="],
+    )
 
-        add_to_catalog = True
-        basedirs = []
-        bundles = []
-        timestamp_files = []
-        key = None
-        cert = None
-        for opt, arg in opts:
-                if opt == "-b":
-                        bundles.append(arg)
-                elif opt == "-d":
-                        basedirs.append(arg)
-                elif opt == "-s":
-                        repo_uri = arg
-                        if repo_uri and not repo_uri.startswith("null:"):
-                                repo_uri = misc.parse_uri(repo_uri)
-                elif opt == "-T":
-                        timestamp_files.append(arg)
-                elif opt == "--no-catalog":
-                        add_to_catalog = False
-                elif opt == "--key":
-                        key = arg
-                elif opt == "--cert":
-                        cert = arg
+    add_to_catalog = True
+    basedirs = []
+    bundles = []
+    timestamp_files = []
+    key = None
+    cert = None
+    for opt, arg in opts:
+        if opt == "-b":
+            bundles.append(arg)
+        elif opt == "-d":
+            basedirs.append(arg)
+        elif opt == "-s":
+            repo_uri = arg
+            if repo_uri and not repo_uri.startswith("null:"):
+                repo_uri = misc.parse_uri(repo_uri)
+        elif opt == "-T":
+            timestamp_files.append(arg)
+        elif opt == "--no-catalog":
+            add_to_catalog = False
+        elif opt == "--key":
+            key = arg
+        elif opt == "--cert":
+            cert = arg
 
-        if not repo_uri:
-                usage(_("A destination package repository must be provided "
-                    "using -s."), cmd="publish")
+    if not repo_uri:
+        usage(
+            _("A destination package repository must be provided " "using -s."),
+            cmd="publish",
+        )
 
-        if not pargs:
-                filelist = [("<stdin>", sys.stdin)]
+    if not pargs:
+        filelist = [("<stdin>", sys.stdin)]
+    else:
+        try:
+            filelist = [(f, open(f)) for f in pargs]
+        except IOError as e:
+            error(e, cmd="publish")
+            return EXIT_OOPS
+
+    lines = ""  # giant string of all input files concatenated together
+    linecnts = []  # tuples of starting line number, ending line number
+    linecounter = 0  # running total
+
+    for filename, f in filelist:
+        try:
+            data = f.read()
+        except IOError as e:
+            error(e, cmd="publish")
+            return EXIT_OOPS
+        lines += data
+        linecnt = len(data.splitlines())
+        linecnts.append((linecounter, linecounter + linecnt))
+        linecounter += linecnt
+        f.close()
+
+    m = pkg.manifest.Manifest()
+    try:
+        m.set_content(content=lines)
+    except apx.InvalidPackageErrors as err:
+        e = err.errors[0]
+        lineno = e.lineno
+        for i, tup in enumerate(linecnts):
+            if lineno > tup[0] and lineno <= tup[1]:
+                filename = filelist[i][0]
+                lineno -= tup[0]
+                break
         else:
-                try:
-                        filelist = [(f, open(f)) for f in pargs]
-                except IOError as e:
-                        error(e, cmd="publish")
-                        return EXIT_OOPS
+            filename = "???"
+            lineno = "???"
 
-        lines = ""      # giant string of all input files concatenated together
-        linecnts = []   # tuples of starting line number, ending line number
-        linecounter = 0 # running total
+        error(
+            _("File {filename} line {lineno}: {err}").format(
+                filename=filename, lineno=lineno, err=e
+            ),
+            cmd="publish",
+        )
+        return EXIT_OOPS
 
-        for filename, f in filelist:
-                try:
-                        data = f.read()
-                except IOError as e:
-                        error(e, cmd="publish")
-                        return EXIT_OOPS
-                lines += data
-                linecnt = len(data.splitlines())
-                linecnts.append((linecounter, linecounter + linecnt))
-                linecounter += linecnt
-                f.close()
+    try:
+        pfmri = pkg.fmri.PkgFmri(m["pkg.fmri"])
+        if not pfmri.version:
+            # Cannot have a FMRI without version
+            error(
+                _(
+                    "The pkg.fmri attribute '{0}' in the package "
+                    "manifest must include a version."
+                ).format(pfmri),
+                cmd="publish",
+            )
+            return EXIT_OOPS
+        if not DebugValues["allow-timestamp"]:
+            # If not debugging, timestamps are ignored.
+            pfmri.version.timestr = None
+        pkg_name = pfmri.get_fmri()
+    except KeyError:
+        error(_("Manifest does not set pkg.fmri"))
+        return EXIT_OOPS
 
-        m = pkg.manifest.Manifest()
-        try:
-                m.set_content(content=lines)
-        except apx.InvalidPackageErrors as err:
-                e = err.errors[0]
-                lineno = e.lineno
-                for i, tup in enumerate(linecnts):
-                        if lineno > tup[0] and lineno <= tup[1]:
-                                filename = filelist[i][0]
-                                lineno -= tup[0]
-                                break
-                else:
-                        filename = "???"
-                        lineno = "???"
+    xport, pub = setup_transport_and_pubs(repo_uri, ssl_key=key, ssl_cert=cert)
+    t = trans.Transaction(repo_uri, pkg_name=pkg_name, xport=xport, pub=pub)
+    t.open()
 
-                error(_("File {filename} line {lineno}: {err}").format(
-                    filename=filename, lineno=lineno, err=e),
-                    cmd="publish")
-                return EXIT_OOPS
+    target_files = []
+    if bundles:
+        # Ensure hardlinks marked as files in the manifest are
+        # treated as files.  This necessary when sourcing files
+        # from some bundle types.
+        target_files.extend(
+            a.attrs["path"] for a in m.gen_actions() if a.name == "file"
+        )
 
-        try:
-                pfmri = pkg.fmri.PkgFmri(m["pkg.fmri"])
-                if not pfmri.version:
-                        # Cannot have a FMRI without version
-                        error(_("The pkg.fmri attribute '{0}' in the package "
-                            "manifest must include a version.").format(pfmri),
-                            cmd="publish")
-                        return EXIT_OOPS
-                if not DebugValues["allow-timestamp"]:
-                        # If not debugging, timestamps are ignored.
-                        pfmri.version.timestr = None
-                pkg_name = pfmri.get_fmri()
-        except KeyError:
-                error(_("Manifest does not set pkg.fmri"))
-                return EXIT_OOPS
+    bundles = [
+        pkg.bundle.make_bundle(bundle, targetpaths=target_files)
+        for bundle in bundles
+    ]
 
-        xport, pub = setup_transport_and_pubs(repo_uri, ssl_key=key,
-            ssl_cert=cert)
-        t = trans.Transaction(repo_uri, pkg_name=pkg_name,
-            xport=xport, pub=pub)
-        t.open()
-
-        target_files = []
-        if bundles:
-                # Ensure hardlinks marked as files in the manifest are
-                # treated as files.  This necessary when sourcing files
-                # from some bundle types.
-                target_files.extend(
-                    a.attrs["path"]
-                    for a in m.gen_actions()
-                    if a.name == "file"
-                )
-
-        bundles = [
-            pkg.bundle.make_bundle(bundle, targetpaths=target_files)
-            for bundle in bundles
-        ]
-
-        for a in m.gen_actions():
-                # don't publish these actions
-                if a.name == "signature":
-                        msg(_("WARNING: Omitting signature action '{0}'".format(
-                            a)))
+    for a in m.gen_actions():
+        # don't publish these actions
+        if a.name == "signature":
+            msg(_("WARNING: Omitting signature action '{0}'".format(a)))
+            continue
+        if a.name == "set" and a.attrs["name"] in ["pkg.fmri", "fmri"]:
+            continue
+        elif a.has_payload:
+            # Forcibly discard content-related attributes to prevent
+            # errors when reusing manifests with different content.
+            for attr in strip_attrs:
+                a.attrs.pop(attr, None)
+            path = pkg.actions.set_action_data(
+                a.hash, a, basedirs=basedirs, bundles=bundles
+            )[0]
+        elif a.name in nopub_actions:
+            error(
+                _("invalid action for publication: {0}").format(action),
+                cmd="publish",
+            )
+            t.close(abandon=True)
+            return EXIT_OOPS
+        if a.name == "file":
+            basename = os.path.basename(a.attrs["path"])
+            for pattern in timestamp_files:
+                if fnmatch.fnmatch(basename, pattern):
+                    if not isinstance(path, six.string_types):
+                        # Target is from bundle; can't
+                        # apply timestamp now.
                         continue
-                if a.name == "set" and a.attrs["name"] in ["pkg.fmri", "fmri"]:
-                        continue
-                elif a.has_payload:
-                        # Forcibly discard content-related attributes to prevent
-                        # errors when reusing manifests with different content.
-                        for attr in strip_attrs:
-                                a.attrs.pop(attr, None)
-                        path = pkg.actions.set_action_data(a.hash, a,
-                            basedirs=basedirs, bundles=bundles)[0]
-                elif a.name in nopub_actions:
-                        error(_("invalid action for publication: {0}").format(
-                            action), cmd="publish")
-                        t.close(abandon=True)
-                        return EXIT_OOPS
-                if a.name == "file":
-                        basename = os.path.basename(a.attrs["path"])
-                        for pattern in timestamp_files:
-                                if fnmatch.fnmatch(basename, pattern):
-                                        if not isinstance(path, six.string_types):
-                                                # Target is from bundle; can't
-                                                # apply timestamp now.
-                                                continue
-                                        ts = misc.time_to_timestamp(
-                                            os.stat(path).st_mtime)
-                                        a.attrs["timestamp"] = ts
-                                        break
-                try:
-                        t.add(a)
-                except:
-                        t.close(abandon=True)
-                        raise
+                    ts = misc.time_to_timestamp(os.stat(path).st_mtime)
+                    a.attrs["timestamp"] = ts
+                    break
+        try:
+            t.add(a)
+        except:
+            t.close(abandon=True)
+            raise
 
-        pkg_state, pkg_fmri = t.close(abandon=False,
-            add_to_catalog=add_to_catalog)
-        for val in (pkg_state, pkg_fmri):
-                if val is not None:
-                        msg(val)
-        return EXIT_OK
+    pkg_state, pkg_fmri = t.close(abandon=False, add_to_catalog=add_to_catalog)
+    for val in (pkg_state, pkg_fmri):
+        if val is not None:
+            msg(val)
+    return EXIT_OK
+
 
 def trans_include(repo_uri, fargs, transaction=None):
-        """DEPRECATED"""
+    """DEPRECATED"""
 
-        basedirs = []
-        timestamp_files = []
-        error_occurred = False
+    basedirs = []
+    timestamp_files = []
+    error_occurred = False
 
-        opts, pargs = getopt.getopt(fargs, "d:T:")
-        for opt, arg in opts:
-                if opt == "-d":
-                        basedirs.append(arg)
-                elif opt == "-T":
-                        timestamp_files.append(arg)
+    opts, pargs = getopt.getopt(fargs, "d:T:")
+    for opt, arg in opts:
+        if opt == "-d":
+            basedirs.append(arg)
+        elif opt == "-T":
+            timestamp_files.append(arg)
 
-        if transaction == None:
-                try:
-                        trans_id = os.environ["PKG_TRANS_ID"]
-                except KeyError:
-                        usage(_("No transaction ID specified in $PKG_TRANS_ID"),
-                            cmd="include")
-                xport, pub = setup_transport_and_pubs(repo_uri)
-                t = trans.Transaction(repo_uri, trans_id=trans_id, xport=xport,
-                    pub=pub)
-        else:
-                t = transaction
-
-        if not pargs:
-                filelist = [("<stdin>", sys.stdin)]
-        else:
-                try:
-                        filelist = [(f, open(f)) for f in pargs]
-                except IOError as e:
-                        error(e, cmd="include")
-                        return EXIT_OOPS
-
-        lines = []      # giant string of all input files concatenated together
-        linecnts = []   # tuples of starting line number, ending line number
-        linecounter = 0 # running total
-
-        for filename, f in filelist:
-                try:
-                        data = f.read()
-                except IOError as e:
-                        error(e, cmd="include")
-                        return EXIT_OOPS
-                lines.append(data)
-                linecnt = len(data.splitlines())
-                linecnts.append((linecounter, linecounter + linecnt))
-                linecounter += linecnt
-
-        m = pkg.manifest.Manifest()
+    if transaction == None:
         try:
-                m.set_content(content="\n".join(lines))
-        except apx.InvalidPackageErrors as err:
-                e = err.errors[0]
-                lineno = e.lineno
-                for i, tup in enumerate(linecnts):
-                        if lineno > tup[0] and lineno <= tup[1]:
-                                filename = filelist[i][0]
-                                lineno -= tup[0]
-                                break
-                else:
-                        filename = "???"
-                        lineno = "???"
-
-                error(_("File {filename} line {lineno}: {err}").format(
-                    filename=filename, lineno=lineno, err=e),
-                    cmd="include")
-                return EXIT_OOPS
-
-        invalid_action = False
-
-        for a in m.gen_actions():
-                # don't publish this action
-                if a.name == "set" and a.attrs["name"] in  ["pkg.fmri", "fmri"]:
-                        continue
-                elif a.has_payload:
-                        path, bd = pkg.actions.set_action_data(a.hash, a,
-                            basedirs)
-                if a.name == "file":
-                        basename = os.path.basename(a.attrs["path"])
-                        for pattern in timestamp_files:
-                                if fnmatch.fnmatch(basename, pattern):
-                                        ts = misc.time_to_timestamp(
-                                            os.stat(path).st_mtime)
-                                        a.attrs["timestamp"] = ts
-                                        break
-
-                if a.name in nopub_actions:
-                        error(_("invalid action for publication: {0}").format(
-                            str(a)), cmd="include")
-                        invalid_action = True
-                else:
-                        t.add(a)
-
-        if invalid_action:
-                return EXIT_PARTIAL
-        else:
-                return EXIT_OK
-
-def gen_actions(files, timestamp_files, target_files, minimal=False, visitors=[],
-    use_default_owner=True):
-        for filename in files:
-                bundle = pkg.bundle.make_bundle(filename,
-                    targetpaths=target_files,
-                    use_default_owner=use_default_owner)
-
-                for visitor in visitors:
-                        visitor.visit(bundle)
-
-                for action in bundle:
-                        if action.name in ("file", "dir"):
-                                basename = os.path.basename(action.attrs["path"])
-                                for pattern in timestamp_files:
-                                        if fnmatch.fnmatch(basename, pattern):
-                                                break
-                                else:
-                                        action.attrs.pop("timestamp", None)
-
-                        if minimal:
-                                # pkgsend import needs attributes such as size
-                                # retained so that the publication modules know
-                                # how many bytes to read from the .data prop.
-                                # However, pkgsend generate attempts to
-                                # minimize the attributes output for each
-                                # action to only those necessary for use
-                                # so that the resulting manifest remains valid
-                                # even after mogrification or changing content.
-                                action.attrs.pop("pkg.size", None)
-
-                        yield action, action.name in nopub_actions
-
-def trans_import(repo_uri, args, visitors=[]):
-        """DEPRECATED"""
-
-        try:
-                trans_id = os.environ["PKG_TRANS_ID"]
+            trans_id = os.environ["PKG_TRANS_ID"]
         except KeyError:
-                print(_("No transaction ID specified in $PKG_TRANS_ID"),
-                    file=sys.stderr)
-                sys.exit(1)
-
-        opts, pargs = getopt.getopt(args, "T:", ["target="])
-
-        timestamp_files = []
-        target_files = []
-
-        for opt, arg in opts:
-                if opt == "-T":
-                        timestamp_files.append(arg)
-                elif opt == "--target":
-                        target_files.append(arg)
-
-        if not args:
-                usage(_("No arguments specified for subcommand."),
-                    cmd="import")
-
+            usage(
+                _("No transaction ID specified in $PKG_TRANS_ID"), cmd="include"
+            )
         xport, pub = setup_transport_and_pubs(repo_uri)
         t = trans.Transaction(repo_uri, trans_id=trans_id, xport=xport, pub=pub)
+    else:
+        t = transaction
 
-        ret = EXIT_OK
-        abandon = False
+    if not pargs:
+        filelist = [("<stdin>", sys.stdin)]
+    else:
         try:
-                for action, err in gen_actions(pargs, timestamp_files,
-                    target_files, visitors=visitors, use_default_owner=True):
-                        if err:
-                                error(_("invalid action for publication: {0}").format(
-                                    action), cmd="import")
-                                abandon = True
-                        else:
-                                if not abandon:
-                                        t.add(action)
-        except TypeError as e:
-                error(e, cmd="import")
-                return EXIT_OOPS
-        except EnvironmentError as e:
-                if e.errno == errno.ENOENT:
-                        error("{0}: '{1}'".format(e.args[1], e.filename),
-                            cmd="import")
-                        return EXIT_OOPS
-                else:
-                        raise
+            filelist = [(f, open(f)) for f in pargs]
+        except IOError as e:
+            error(e, cmd="include")
+            return EXIT_OOPS
+
+    lines = []  # giant string of all input files concatenated together
+    linecnts = []  # tuples of starting line number, ending line number
+    linecounter = 0  # running total
+
+    for filename, f in filelist:
+        try:
+            data = f.read()
+        except IOError as e:
+            error(e, cmd="include")
+            return EXIT_OOPS
+        lines.append(data)
+        linecnt = len(data.splitlines())
+        linecnts.append((linecounter, linecounter + linecnt))
+        linecounter += linecnt
+
+    m = pkg.manifest.Manifest()
+    try:
+        m.set_content(content="\n".join(lines))
+    except apx.InvalidPackageErrors as err:
+        e = err.errors[0]
+        lineno = e.lineno
+        for i, tup in enumerate(linecnts):
+            if lineno > tup[0] and lineno <= tup[1]:
+                filename = filelist[i][0]
+                lineno -= tup[0]
+                break
+        else:
+            filename = "???"
+            lineno = "???"
+
+        error(
+            _("File {filename} line {lineno}: {err}").format(
+                filename=filename, lineno=lineno, err=e
+            ),
+            cmd="include",
+        )
+        return EXIT_OOPS
+
+    invalid_action = False
+
+    for a in m.gen_actions():
+        # don't publish this action
+        if a.name == "set" and a.attrs["name"] in ["pkg.fmri", "fmri"]:
+            continue
+        elif a.has_payload:
+            path, bd = pkg.actions.set_action_data(a.hash, a, basedirs)
+        if a.name == "file":
+            basename = os.path.basename(a.attrs["path"])
+            for pattern in timestamp_files:
+                if fnmatch.fnmatch(basename, pattern):
+                    ts = misc.time_to_timestamp(os.stat(path).st_mtime)
+                    a.attrs["timestamp"] = ts
+                    break
+
+        if a.name in nopub_actions:
+            error(
+                _("invalid action for publication: {0}").format(str(a)),
+                cmd="include",
+            )
+            invalid_action = True
+        else:
+            t.add(a)
+
+    if invalid_action:
+        return EXIT_PARTIAL
+    else:
+        return EXIT_OK
+
+
+def gen_actions(
+    files,
+    timestamp_files,
+    target_files,
+    minimal=False,
+    visitors=[],
+    use_default_owner=True,
+):
+    for filename in files:
+        bundle = pkg.bundle.make_bundle(
+            filename,
+            targetpaths=target_files,
+            use_default_owner=use_default_owner,
+        )
 
         for visitor in visitors:
-                if visitor.errors:
-                        abandon = True
-                        ret = EXIT_OOPS
-        if abandon:
-                error("Abandoning transaction due to errors.")
-                t.close(abandon=True)
-        return ret
+            visitor.visit(bundle)
+
+        for action in bundle:
+            if action.name in ("file", "dir"):
+                basename = os.path.basename(action.attrs["path"])
+                for pattern in timestamp_files:
+                    if fnmatch.fnmatch(basename, pattern):
+                        break
+                else:
+                    action.attrs.pop("timestamp", None)
+
+            if minimal:
+                # pkgsend import needs attributes such as size
+                # retained so that the publication modules know
+                # how many bytes to read from the .data prop.
+                # However, pkgsend generate attempts to
+                # minimize the attributes output for each
+                # action to only those necessary for use
+                # so that the resulting manifest remains valid
+                # even after mogrification or changing content.
+                action.attrs.pop("pkg.size", None)
+
+            yield action, action.name in nopub_actions
+
+
+def trans_import(repo_uri, args, visitors=[]):
+    """DEPRECATED"""
+
+    try:
+        trans_id = os.environ["PKG_TRANS_ID"]
+    except KeyError:
+        print(
+            _("No transaction ID specified in $PKG_TRANS_ID"), file=sys.stderr
+        )
+        sys.exit(1)
+
+    opts, pargs = getopt.getopt(args, "T:", ["target="])
+
+    timestamp_files = []
+    target_files = []
+
+    for opt, arg in opts:
+        if opt == "-T":
+            timestamp_files.append(arg)
+        elif opt == "--target":
+            target_files.append(arg)
+
+    if not args:
+        usage(_("No arguments specified for subcommand."), cmd="import")
+
+    xport, pub = setup_transport_and_pubs(repo_uri)
+    t = trans.Transaction(repo_uri, trans_id=trans_id, xport=xport, pub=pub)
+
+    ret = EXIT_OK
+    abandon = False
+    try:
+        for action, err in gen_actions(
+            pargs,
+            timestamp_files,
+            target_files,
+            visitors=visitors,
+            use_default_owner=True,
+        ):
+            if err:
+                error(
+                    _("invalid action for publication: {0}").format(action),
+                    cmd="import",
+                )
+                abandon = True
+            else:
+                if not abandon:
+                    t.add(action)
+    except TypeError as e:
+        error(e, cmd="import")
+        return EXIT_OOPS
+    except EnvironmentError as e:
+        if e.errno == errno.ENOENT:
+            error("{0}: '{1}'".format(e.args[1], e.filename), cmd="import")
+            return EXIT_OOPS
+        else:
+            raise
+
+    for visitor in visitors:
+        if visitor.errors:
+            abandon = True
+            ret = EXIT_OOPS
+    if abandon:
+        error("Abandoning transaction due to errors.")
+        t.close(abandon=True)
+    return ret
+
 
 def trans_generate(args, visitors=[]):
-        """Generate a package manifest based on the provided sources."""
+    """Generate a package manifest based on the provided sources."""
 
-        opts, pargs = getopt.getopt(args , "uT:", ["target="])
+    opts, pargs = getopt.getopt(args, "uT:", ["target="])
 
-        timestamp_files = []
-        target_files = []
-        use_default_owner = True
+    timestamp_files = []
+    target_files = []
+    use_default_owner = True
 
-        for opt, arg in opts:
-                if opt == "-T":
-                        timestamp_files.append(arg)
-                elif opt == "--target":
-                        target_files.append(arg)
-                elif opt == "-u":
-                        use_default_owner = False
+    for opt, arg in opts:
+        if opt == "-T":
+            timestamp_files.append(arg)
+        elif opt == "--target":
+            target_files.append(arg)
+        elif opt == "-u":
+            use_default_owner = False
 
-        if not args:
-                usage(_("No arguments specified for subcommand."),
-                    cmd="generate")
+    if not args:
+        usage(_("No arguments specified for subcommand."), cmd="generate")
 
-        try:
-                for action, err in gen_actions(pargs, timestamp_files,
-                    target_files, minimal=True, visitors=visitors,
-                    use_default_owner=use_default_owner):
-                        if "path" in action.attrs and hasattr(action, "hash") \
-                            and action.hash == "NOHASH":
-                                action.hash = action.attrs["path"]
-                        print(action)
-        except TypeError as e:
-                error(e, cmd="generate")
-                return EXIT_OOPS
-        except EnvironmentError as e:
-                if e.errno == errno.ENOENT:
-                        error("{0}: '{1}'".format(e.args[1], e.filename),
-                            cmd="generate")
-                        return EXIT_OOPS
-                else:
-                        raise
+    try:
+        for action, err in gen_actions(
+            pargs,
+            timestamp_files,
+            target_files,
+            minimal=True,
+            visitors=visitors,
+            use_default_owner=use_default_owner,
+        ):
+            if (
+                "path" in action.attrs
+                and hasattr(action, "hash")
+                and action.hash == "NOHASH"
+            ):
+                action.hash = action.attrs["path"]
+            print(action)
+    except TypeError as e:
+        error(e, cmd="generate")
+        return EXIT_OOPS
+    except EnvironmentError as e:
+        if e.errno == errno.ENOENT:
+            error("{0}: '{1}'".format(e.args[1], e.filename), cmd="generate")
+            return EXIT_OOPS
+        else:
+            raise
 
-        return EXIT_OK
+    return EXIT_OK
+
 
 def trans_refresh_index(repo_uri, args):
-        """DEPRECATED"""
+    """DEPRECATED"""
 
-        if args:
-                usage(_("command does not take operands"),
-                    cmd="refresh-index")
+    if args:
+        usage(_("command does not take operands"), cmd="refresh-index")
 
-        xport, pub = setup_transport_and_pubs(repo_uri)
-        try:
-                t = trans.Transaction(repo_uri, xport=xport,
-                    pub=pub).refresh_index()
-        except trans.TransactionError as e:
-                error(e, cmd="refresh-index")
-                return EXIT_OOPS
-        return EXIT_OK
+    xport, pub = setup_transport_and_pubs(repo_uri)
+    try:
+        t = trans.Transaction(repo_uri, xport=xport, pub=pub).refresh_index()
+    except trans.TransactionError as e:
+        error(e, cmd="refresh-index")
+        return EXIT_OOPS
+    return EXIT_OK
 
-def setup_transport_and_pubs(repo_uri, remote=True, ssl_key=None,
-    ssl_cert=None):
 
-        if repo_uri.startswith("null:"):
-                return None, None
+def setup_transport_and_pubs(
+    repo_uri, remote=True, ssl_key=None, ssl_cert=None
+):
+    if repo_uri.startswith("null:"):
+        return None, None
 
-        xport, xport_cfg = transport.setup_transport()
-        targ_pub = transport.setup_publisher(repo_uri, "default",
-            xport, xport_cfg, remote_prefix=remote, ssl_key=ssl_key,
-            ssl_cert=ssl_cert)
+    xport, xport_cfg = transport.setup_transport()
+    targ_pub = transport.setup_publisher(
+        repo_uri,
+        "default",
+        xport,
+        xport_cfg,
+        remote_prefix=remote,
+        ssl_key=ssl_key,
+        ssl_cert=ssl_cert,
+    )
 
-        return xport, targ_pub
+    return xport, targ_pub
+
 
 def main_func():
+    repo_uri = os.getenv("PKG_REPO", None)
 
-        repo_uri = os.getenv("PKG_REPO", None)
-
-        show_usage = False
-        global_settings.client_name = "pkgsend"
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "s:D:?", ["help", "debug="])
-                for opt, arg in opts:
-                        if opt == "-s":
-                                repo_uri = arg
-                        elif opt == "-D" or opt == "--debug":
-                                if arg == "allow-timestamp":
-                                        key = arg
-                                        value = True
-                                else:
-                                        try:
-                                                key, value = arg.split("=", 1)
-                                        except (AttributeError, ValueError):
-                                                usage(_("{opt} takes argument of form "
-                                                    "name=value, not {arg}").format(
-                                                    opt=opt, arg=arg))
-                                DebugValues.set_value(key, value)
-                        elif opt in ("--help", "-?"):
-                                show_usage = True
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
-
-        if repo_uri and not repo_uri.startswith("null:"):
-                repo_uri = misc.parse_uri(repo_uri)
-
-        if DebugValues:
-                reload(pkg.digest)
-        subcommand = None
-        if pargs:
-                subcommand = pargs.pop(0)
-                if subcommand == "help":
-                        show_usage = True
-
-        if show_usage:
-                usage(retcode=0)
-        elif not subcommand:
-                usage()
-
-        if not repo_uri and subcommand not in ("create-repository", "generate",
-            "publish"):
-                usage(_("A destination package repository must be provided "
-                    "using -s."), cmd=subcommand)
-
-        visitors = [SolarisBundleVisitor()]
-        ret = EXIT_OK
-        try:
-                if subcommand == "create-repository":
-                        ret = trans_create_repository(repo_uri, pargs)
-                elif subcommand == "open":
-                        ret = trans_open(repo_uri, pargs)
-                elif subcommand == "append":
-                        ret = trans_append(repo_uri, pargs)
-                elif subcommand == "close":
-                        ret = trans_close(repo_uri, pargs)
-                elif subcommand == "add":
-                        ret = trans_add(repo_uri, pargs)
-                elif subcommand == "import":
-                        ret = trans_import(repo_uri, pargs,
-                            visitors=visitors)
-                elif subcommand == "include":
-                        ret = trans_include(repo_uri, pargs)
-                elif subcommand == "publish":
-                        ret = trans_publish(repo_uri, pargs)
-                elif subcommand == "generate":
-                        ret = trans_generate(pargs,
-                            visitors=visitors)
-                elif subcommand == "refresh-index":
-                        ret = trans_refresh_index(repo_uri, pargs)
+    show_usage = False
+    global_settings.client_name = "pkgsend"
+    try:
+        opts, pargs = getopt.getopt(sys.argv[1:], "s:D:?", ["help", "debug="])
+        for opt, arg in opts:
+            if opt == "-s":
+                repo_uri = arg
+            elif opt == "-D" or opt == "--debug":
+                if arg == "allow-timestamp":
+                    key = arg
+                    value = True
                 else:
-                        usage(_("unknown subcommand '{0}'").format(subcommand))
+                    try:
+                        key, value = arg.split("=", 1)
+                    except (AttributeError, ValueError):
+                        usage(
+                            _(
+                                "{opt} takes argument of form "
+                                "name=value, not {arg}"
+                            ).format(opt=opt, arg=arg)
+                        )
+                DebugValues.set_value(key, value)
+            elif opt in ("--help", "-?"):
+                show_usage = True
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
 
-                printed_space = False
-                for visitor in visitors:
-                        for warn in visitor.warnings:
-                                if not printed_space:
-                                        print("")
-                                        printed_space = True
-                                error(warn, cmd=subcommand)
+    if repo_uri and not repo_uri.startswith("null:"):
+        repo_uri = misc.parse_uri(repo_uri)
 
-                        for err in visitor.errors:
-                                if not printed_space:
-                                        print("")
-                                        printed_space = True
-                                error(err, cmd=subcommand)
-                                ret = EXIT_OOPS
-        except pkg.bundle.InvalidBundleException as e:
-                error(e, cmd=subcommand)
+    if DebugValues:
+        reload(pkg.digest)
+    subcommand = None
+    if pargs:
+        subcommand = pargs.pop(0)
+        if subcommand == "help":
+            show_usage = True
+
+    if show_usage:
+        usage(retcode=0)
+    elif not subcommand:
+        usage()
+
+    if not repo_uri and subcommand not in (
+        "create-repository",
+        "generate",
+        "publish",
+    ):
+        usage(
+            _("A destination package repository must be provided " "using -s."),
+            cmd=subcommand,
+        )
+
+    visitors = [SolarisBundleVisitor()]
+    ret = EXIT_OK
+    try:
+        if subcommand == "create-repository":
+            ret = trans_create_repository(repo_uri, pargs)
+        elif subcommand == "open":
+            ret = trans_open(repo_uri, pargs)
+        elif subcommand == "append":
+            ret = trans_append(repo_uri, pargs)
+        elif subcommand == "close":
+            ret = trans_close(repo_uri, pargs)
+        elif subcommand == "add":
+            ret = trans_add(repo_uri, pargs)
+        elif subcommand == "import":
+            ret = trans_import(repo_uri, pargs, visitors=visitors)
+        elif subcommand == "include":
+            ret = trans_include(repo_uri, pargs)
+        elif subcommand == "publish":
+            ret = trans_publish(repo_uri, pargs)
+        elif subcommand == "generate":
+            ret = trans_generate(pargs, visitors=visitors)
+        elif subcommand == "refresh-index":
+            ret = trans_refresh_index(repo_uri, pargs)
+        else:
+            usage(_("unknown subcommand '{0}'").format(subcommand))
+
+        printed_space = False
+        for visitor in visitors:
+            for warn in visitor.warnings:
+                if not printed_space:
+                    print("")
+                    printed_space = True
+                error(warn, cmd=subcommand)
+
+            for err in visitor.errors:
+                if not printed_space:
+                    print("")
+                    printed_space = True
+                error(err, cmd=subcommand)
                 ret = EXIT_OOPS
-        except getopt.GetoptError as e:
-                usage(_("illegal {cmd} option -- {opt}").format(
-                    cmd=subcommand, opt=e.opt))
+    except pkg.bundle.InvalidBundleException as e:
+        error(e, cmd=subcommand)
+        ret = EXIT_OOPS
+    except getopt.GetoptError as e:
+        usage(
+            _("illegal {cmd} option -- {opt}").format(cmd=subcommand, opt=e.opt)
+        )
 
-        return ret
+    return ret
+
 
 #
 # Establish a specific exit status which means: "python barfed an exception"
 # so that we can more easily detect these in testing of the CLI commands.
 #
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        # Make all warnings be errors.
-        warnings.simplefilter('error')
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
+    # Make all warnings be errors.
+    warnings.simplefilter("error")
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
 
-        try:
-                __ret = main_func()
-        except (PipeError, KeyboardInterrupt):
-                # We don't want to display any messages here to prevent
-                # possible further broken pipe (EPIPE) errors.
-                __ret = EXIT_OOPS
-        except (pkg.actions.ActionError, trans.TransactionError,
-            EnvironmentError, RuntimeError, pkg.fmri.FmriError,
-            apx.ApiException) as _e:
-                if isinstance(_e, EnvironmentError) and \
-                    _e.errno == errno.ENOMEM:
-                        error("\n" + misc.out_of_memory())
-                if not (isinstance(_e, IOError) and _e.errno == errno.EPIPE):
-                        # Only print message if failure wasn't due to
-                        # broken pipe (EPIPE) error.
-                        print("pkgsend: {0}".format(_e), file=sys.stderr)
-                __ret = EXIT_OOPS
-        except MemoryError:
-                error("\n" + misc.out_of_memory())
-                __ret = EXIT_OOPS
-        except SystemExit as _e:
-                raise _e
-        except:
-                traceback.print_exc()
-                error(misc.get_traceback_message())
-                __ret = 99
-        sys.exit(__ret)
+    try:
+        __ret = main_func()
+    except (PipeError, KeyboardInterrupt):
+        # We don't want to display any messages here to prevent
+        # possible further broken pipe (EPIPE) errors.
+        __ret = EXIT_OOPS
+    except (
+        pkg.actions.ActionError,
+        trans.TransactionError,
+        EnvironmentError,
+        RuntimeError,
+        pkg.fmri.FmriError,
+        apx.ApiException,
+    ) as _e:
+        if isinstance(_e, EnvironmentError) and _e.errno == errno.ENOMEM:
+            error("\n" + misc.out_of_memory())
+        if not (isinstance(_e, IOError) and _e.errno == errno.EPIPE):
+            # Only print message if failure wasn't due to
+            # broken pipe (EPIPE) error.
+            print("pkgsend: {0}".format(_e), file=sys.stderr)
+        __ret = EXIT_OOPS
+    except MemoryError:
+        error("\n" + misc.out_of_memory())
+        __ret = EXIT_OOPS
+    except SystemExit as _e:
+        raise _e
+    except:
+        traceback.print_exc()
+        error(misc.get_traceback_message())
+        __ret = 99
+    sys.exit(__ret)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/pull.py
+++ b/src/pull.py
@@ -25,7 +25,9 @@
 #
 
 from __future__ import print_function
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 import calendar
 import errno
 import getopt
@@ -73,30 +75,34 @@ dest_xport = None
 targ_pub = None
 target = None
 
+
 def error(text):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        # If we get passed something like an Exception, we can convert
-        # it down to a string.
-        text = str(text)
+    # If we get passed something like an Exception, we can convert
+    # it down to a string.
+    text = str(text)
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        emsg(ws + "pkgrecv: " + text_nows)
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    emsg(ws + "pkgrecv: " + text_nows)
+
 
 def usage(usage_error=None, retcode=2):
-        """Emit a usage message and optionally prefix it with a more specific
-        error message.  Causes program to exit."""
+    """Emit a usage message and optionally prefix it with a more specific
+    error message.  Causes program to exit."""
 
-        if usage_error:
-                error(usage_error)
+    if usage_error:
+        error(usage_error)
 
-        msg(_("""\
+    msg(
+        _(
+            """\
 Usage:
         pkgrecv [-aknrv] [-s src_uri] [-d (path|dest_uri)] [-c cache_dir]
             [-m match] [--mog-file file_path ...] [--raw]
@@ -191,1635 +197,1849 @@ Options:
 
 Environment:
         PKG_DEST        Destination directory or URI
-        PKG_SRC         Source URI or path"""))
-        sys.exit(retcode)
+        PKG_SRC         Source URI or path"""
+        )
+    )
+    sys.exit(retcode)
+
 
 def cleanup(caller_error=False):
-        """To be called at program finish."""
+    """To be called at program finish."""
 
-        for d in tmpdirs:
-                # If the cache_dir is in the list of directories that should
-                # be cleaned up, but we're exiting with an error, then preserve
-                # the directory so downloads may be resumed.
-                if d == cache_dir and caller_error and download_start:
-                        error(_("\n\nCached files were preserved in the "
-                            "following directory:\n\t{0}\nUse pkgrecv -c "
-                            "to resume the interrupted download.").format(
-                            cache_dir))
-                        continue
-                shutil.rmtree(d, ignore_errors=True)
+    for d in tmpdirs:
+        # If the cache_dir is in the list of directories that should
+        # be cleaned up, but we're exiting with an error, then preserve
+        # the directory so downloads may be resumed.
+        if d == cache_dir and caller_error and download_start:
+            error(
+                _(
+                    "\n\nCached files were preserved in the "
+                    "following directory:\n\t{0}\nUse pkgrecv -c "
+                    "to resume the interrupted download."
+                ).format(cache_dir)
+            )
+            continue
+        shutil.rmtree(d, ignore_errors=True)
 
-        if caller_error and dest_xport and targ_pub and not archive:
-                try:
-                        dest_xport.publish_refresh_packages(targ_pub)
-                except apx.TransportError:
-                        # If this fails, ignore it as this was a last ditch
-                        # attempt anyway.
-                        pass
+    if caller_error and dest_xport and targ_pub and not archive:
+        try:
+            dest_xport.publish_refresh_packages(targ_pub)
+        except apx.TransportError:
+            # If this fails, ignore it as this was a last ditch
+            # attempt anyway.
+            pass
+
 
 def abort(err=None, retcode=1):
-        """To be called when a fatal error is encountered."""
+    """To be called when a fatal error is encountered."""
 
-        if err:
-                # Clear any possible output first.
-                msg("")
-                error(err)
+    if err:
+        # Clear any possible output first.
+        msg("")
+        error(err)
 
-        cleanup(caller_error=True)
-        sys.exit(retcode)
+    cleanup(caller_error=True)
+    sys.exit(retcode)
+
 
 def get_tracker():
-        try:
-                progresstracker = \
-                    progress.FancyUNIXProgressTracker()
-        except progress.ProgressTrackerException:
-                progresstracker = progress.CommandLineProgressTracker()
-        progresstracker.set_major_phase(progresstracker.PHASE_UTILITY)
-        return progresstracker
+    try:
+        progresstracker = progress.FancyUNIXProgressTracker()
+    except progress.ProgressTrackerException:
+        progresstracker = progress.CommandLineProgressTracker()
+    progresstracker.set_major_phase(progresstracker.PHASE_UTILITY)
+    return progresstracker
+
 
 def get_manifest(pfmri, xport_cfg, validate=False):
+    m = None
+    pkgdir = xport_cfg.get_pkg_dir(pfmri)
+    mpath = xport_cfg.get_pkg_pathname(pfmri)
 
-        m = None
-        pkgdir = xport_cfg.get_pkg_dir(pfmri)
-        mpath = xport_cfg.get_pkg_pathname(pfmri)
+    if not os.path.exists(mpath):
+        m = xport.get_manifest(pfmri)
+    else:
+        # A FactoredManifest is used here to reduce peak memory
+        # usage (notably when -r was specified).
+        try:
+            m = manifest.FactoredManifest(pfmri, pkgdir)
+        except:
+            abort(
+                err=_(
+                    "Unable to parse manifest '{mpath}' for "
+                    "package '{pfmri}'"
+                ).format(**locals())
+            )
 
-        if not os.path.exists(mpath):
-                m = xport.get_manifest(pfmri)
-        else:
-                # A FactoredManifest is used here to reduce peak memory
-                # usage (notably when -r was specified).
-                try:
-                        m = manifest.FactoredManifest(pfmri, pkgdir)
-                except:
-                        abort(err=_("Unable to parse manifest '{mpath}' for "
-                            "package '{pfmri}'").format(**locals()))
+    if validate:
+        errors = []
+        for a in m.gen_actions():
+            try:
+                a.validate(fmri=pfmri)
+            except Exception as e:
+                errors.append(e)
+        if errors:
+            raise apx.InvalidPackageErrors(errors)
 
-        if validate:
-                errors = []
-                for a in m.gen_actions():
-                        try:
-                                a.validate(fmri=pfmri)
-                        except Exception as e:
-                                errors.append(e)
-                if errors:
-                        raise apx.InvalidPackageErrors(errors)
+    return m
 
-        return m
 
 def expand_fmri(pfmri, constraint=version.CONSTRAINT_AUTO):
-        """Find matching fmri using CONSTRAINT_AUTO cache for performance.
-        Returns None if no matching fmri is found."""
-        if isinstance(pfmri, str):
-                pfmri = pkg.fmri.PkgFmri(pfmri)
+    """Find matching fmri using CONSTRAINT_AUTO cache for performance.
+    Returns None if no matching fmri is found."""
+    if isinstance(pfmri, str):
+        pfmri = pkg.fmri.PkgFmri(pfmri)
 
-        # Iterate in reverse so newest version is evaluated first.
-        versions = [e for e in src_cat.fmris_by_version(pfmri.pkg_name)]
-        for v, fmris in reversed(versions):
-                for f in fmris:
-                        if not pfmri.version or \
-                            f.version.is_successor(pfmri.version, constraint):
-                                return f
-        return
+    # Iterate in reverse so newest version is evaluated first.
+    versions = [e for e in src_cat.fmris_by_version(pfmri.pkg_name)]
+    for v, fmris in reversed(versions):
+        for f in fmris:
+            if not pfmri.version or f.version.is_successor(
+                pfmri.version, constraint
+            ):
+                return f
+    return
+
 
 def get_dependencies(fmri_list, xport_cfg, tracker):
+    old_limit = sys.getrecursionlimit()
+    # The user may be recursing 'entire' or 'redistributable'.
+    sys.setrecursionlimit(3000)
 
-        old_limit = sys.getrecursionlimit()
-        # The user may be recursing 'entire' or 'redistributable'.
-        sys.setrecursionlimit(3000)
+    s = set()
+    for f in fmri_list:
+        _get_dependencies(s, f, xport_cfg, tracker)
 
-        s = set()
-        for f in fmri_list:
-                _get_dependencies(s, f, xport_cfg, tracker)
+    # Restore the previous default.
+    sys.setrecursionlimit(old_limit)
 
-        # Restore the previous default.
-        sys.setrecursionlimit(old_limit)
+    return list(s)
 
-        return list(s)
 
 def _get_dependencies(s, pfmri, xport_cfg, tracker):
-        """Expand all dependencies."""
-        # XXX???
-        # tracker.evaluate_progress(pkgfmri=pfmri)
-        s.add(pfmri)
+    """Expand all dependencies."""
+    # XXX???
+    # tracker.evaluate_progress(pkgfmri=pfmri)
+    s.add(pfmri)
 
-        m = get_manifest(pfmri, xport_cfg)
-        for a in m.gen_actions_by_type("depend"):
-                for fmri_str in a.attrlist("fmri"):
-                        new_fmri = expand_fmri(fmri_str)
-                        if new_fmri and new_fmri not in s:
-                                _get_dependencies(s, new_fmri, xport_cfg, tracker)
-        return s
+    m = get_manifest(pfmri, xport_cfg)
+    for a in m.gen_actions_by_type("depend"):
+        for fmri_str in a.attrlist("fmri"):
+            new_fmri = expand_fmri(fmri_str)
+            if new_fmri and new_fmri not in s:
+                _get_dependencies(s, new_fmri, xport_cfg, tracker)
+    return s
+
 
 def get_sizes(mfst):
-        """Takes a manifest and return
-        (get_bytes, get_files, send_bytes, send_comp_bytes) tuple."""
+    """Takes a manifest and return
+    (get_bytes, get_files, send_bytes, send_comp_bytes) tuple."""
 
-        getb = 0
-        getf = 0
-        sendb = 0
-        sendcb = 0
+    getb = 0
+    getf = 0
+    sendb = 0
+    sendcb = 0
 
-        hashes = set()
-        for a in mfst.gen_actions():
-                if a.has_payload and a.hash not in hashes:
-                        hashes.add(a.hash)
-                        getb += get_pkg_otw_size(a)
-                        getf += 1
-                        sendb += int(a.attrs.get("pkg.size", 0))
-                        sendcb += int(a.attrs.get("pkg.csize", 0))
-                        if a.name == "signature":
-                                getf += len(a.get_chain_certs())
-                                getb += a.get_action_chain_csize()
-        return getb, getf, sendb, sendcb
+    hashes = set()
+    for a in mfst.gen_actions():
+        if a.has_payload and a.hash not in hashes:
+            hashes.add(a.hash)
+            getb += get_pkg_otw_size(a)
+            getf += 1
+            sendb += int(a.attrs.get("pkg.size", 0))
+            sendcb += int(a.attrs.get("pkg.csize", 0))
+            if a.name == "signature":
+                getf += len(a.get_chain_certs())
+                getb += a.get_action_chain_csize()
+    return getb, getf, sendb, sendcb
+
 
 def add_hashes_to_multi(mfst, multi):
-        """Takes a manifest and a multi object and adds the hashes to the multi
-        object."""
+    """Takes a manifest and a multi object and adds the hashes to the multi
+    object."""
 
-        hashes = set()
-        for a in mfst.gen_actions():
-                if a.has_payload and a.hash not in hashes:
-                        multi.add_action(a)
-                        hashes.add(a.hash)
+    hashes = set()
+    for a in mfst.gen_actions():
+        if a.has_payload and a.hash not in hashes:
+            multi.add_action(a)
+            hashes.add(a.hash)
+
 
 def prune(fmri_list, all_versions, all_timestamps):
-        """Returns a filtered version of fmri_list based on the provided
-        parameters."""
+    """Returns a filtered version of fmri_list based on the provided
+    parameters."""
 
-        if all_timestamps:
-                pass
-        elif all_versions:
-                dedup = {}
-                for f in fmri_list:
-                        dedup.setdefault(f.get_short_fmri(), []).append(f)
-                fmri_list = [sorted(dedup[f], reverse=True)[0] for f in dedup]
-        else:
-                dedup = {}
-                for f in fmri_list:
-                        dedup.setdefault(f.pkg_name, []).append(f)
-                fmri_list = [sorted(dedup[f], reverse=True)[0] for f in dedup]
-        return fmri_list
+    if all_timestamps:
+        pass
+    elif all_versions:
+        dedup = {}
+        for f in fmri_list:
+            dedup.setdefault(f.get_short_fmri(), []).append(f)
+        fmri_list = [sorted(dedup[f], reverse=True)[0] for f in dedup]
+    else:
+        dedup = {}
+        for f in fmri_list:
+            dedup.setdefault(f.pkg_name, []).append(f)
+        fmri_list = [sorted(dedup[f], reverse=True)[0] for f in dedup]
+    return fmri_list
 
-def fetch_catalog(src_pub, tracker, txport, target_catalog,
-    include_updates=False):
-        """Fetch the catalog from src_uri.
 
-        target_catalog is a hint about whether this is a destination catalog,
-        which helps the progress tracker render the refresh output properly."""
+def fetch_catalog(
+    src_pub, tracker, txport, target_catalog, include_updates=False
+):
+    """Fetch the catalog from src_uri.
 
-        src_uri = src_pub.repository.origins[0].uri
-        tracker.refresh_start(1, full_refresh=True,
-            target_catalog=target_catalog)
-        tracker.refresh_start_pub(src_pub)
+    target_catalog is a hint about whether this is a destination catalog,
+    which helps the progress tracker render the refresh output properly."""
 
-        if not src_pub.meta_root:
-                # Create a temporary directory for catalog.
-                cat_dir = tempfile.mkdtemp(dir=temp_root,
-                    prefix=global_settings.client_name + "-")
-                tmpdirs.append(cat_dir)
-                src_pub.meta_root = cat_dir
+    src_uri = src_pub.repository.origins[0].uri
+    tracker.refresh_start(1, full_refresh=True, target_catalog=target_catalog)
+    tracker.refresh_start_pub(src_pub)
 
-        src_pub.transport = txport
-        try:
-                src_pub.refresh(full_refresh=True, immediate=True,
-                    progtrack=tracker, include_updates=include_updates)
-        except apx.TransportError as e:
-                # Assume that a catalog doesn't exist for the target publisher,
-                # and drive on.  If there was an actual failure due to a
-                # transport issue, let the failure happen whenever some other
-                # operation is attempted later.
-                return catalog.Catalog(read_only=True)
-        finally:
-                tracker.refresh_end_pub(src_pub)
-                tracker.refresh_done()
+    if not src_pub.meta_root:
+        # Create a temporary directory for catalog.
+        cat_dir = tempfile.mkdtemp(
+            dir=temp_root, prefix=global_settings.client_name + "-"
+        )
+        tmpdirs.append(cat_dir)
+        src_pub.meta_root = cat_dir
 
-        return src_pub.catalog
+    src_pub.transport = txport
+    try:
+        src_pub.refresh(
+            full_refresh=True,
+            immediate=True,
+            progtrack=tracker,
+            include_updates=include_updates,
+        )
+    except apx.TransportError as e:
+        # Assume that a catalog doesn't exist for the target publisher,
+        # and drive on.  If there was an actual failure due to a
+        # transport issue, let the failure happen whenever some other
+        # operation is attempted later.
+        return catalog.Catalog(read_only=True)
+    finally:
+        tracker.refresh_end_pub(src_pub)
+        tracker.refresh_done()
+
+    return src_pub.catalog
+
 
 def main_func():
-        global archive, cache_dir, download_start, xport, xport_cfg, \
-            dest_xport, temp_root, targ_pub, target
+    global archive, cache_dir, download_start, xport, xport_cfg, dest_xport, temp_root, targ_pub, target
 
-        all_timestamps = True
-        all_versions = False
-        dry_run = False
-        keep_compressed = False
-        list_newest = False
-        recursive = False
-        src_uri = None
-        incoming_dir = None
-        src_pub = None
-        raw = False
-        key = None
-        cert = None
-        dkey = None
-        dcert = None
-        mog_files = []
-        publishers = []
-        clone = False
-        verbose = False
+    all_timestamps = True
+    all_versions = False
+    dry_run = False
+    keep_compressed = False
+    list_newest = False
+    recursive = False
+    src_uri = None
+    incoming_dir = None
+    src_pub = None
+    raw = False
+    key = None
+    cert = None
+    dkey = None
+    dcert = None
+    mog_files = []
+    publishers = []
+    clone = False
+    verbose = False
 
-        temp_root = misc.config_temp_root()
+    temp_root = misc.config_temp_root()
 
-        # set process limits for memory consumption to 8GB
-        misc.set_memory_limit(8 * 1024 * 1024 * 1024)
+    # set process limits for memory consumption to 8GB
+    misc.set_memory_limit(8 * 1024 * 1024 * 1024)
 
-        global_settings.client_name = "pkgrecv"
-        target = os.environ.get("PKG_DEST", None)
-        src_uri = os.environ.get("PKG_SRC", None)
+    global_settings.client_name = "pkgrecv"
+    target = os.environ.get("PKG_DEST", None)
+    src_uri = os.environ.get("PKG_SRC", None)
 
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "ac:D:d:hkm:np:rs:v",
-                    ["cert=", "key=", "dcert=", "dkey=", "mog-file=", "newest",
-                    "raw", "debug=", "clone"])
-        except getopt.GetoptError as e:
-                usage(_("Illegal option -- {0}").format(e.opt))
+    try:
+        opts, pargs = getopt.getopt(
+            sys.argv[1:],
+            "ac:D:d:hkm:np:rs:v",
+            [
+                "cert=",
+                "key=",
+                "dcert=",
+                "dkey=",
+                "mog-file=",
+                "newest",
+                "raw",
+                "debug=",
+                "clone",
+            ],
+        )
+    except getopt.GetoptError as e:
+        usage(_("Illegal option -- {0}").format(e.opt))
 
-        for opt, arg in opts:
-                if opt == "-a":
-                        archive = True
-                elif opt == "-c":
-                        cache_dir = arg
-                elif opt == "--clone":
-                        clone = True
-                elif opt == "-d":
-                        target = arg
-                elif opt == "-D" or opt == "--debug":
-                        if arg in ["plan", "transport", "mogrify"]:
-                                key = arg
-                                value = "True"
-                        else:
-                                try:
-                                        key, value = arg.split("=", 1)
-                                except (AttributeError, ValueError):
-                                        usage(_("{opt} takes argument of form "
-                                            "name=value, not {arg}").format(
-                                            opt= opt, arg=arg))
-                        DebugValues.set_value(key, value)
-                elif opt == "-h":
-                        usage(retcode=0)
-                elif opt == "-k":
-                        keep_compressed = True
-                elif opt == "-m":
-                        if arg == "all-timestamps":
-                                all_timestamps = True
-                                all_versions = False
-                        elif arg == "all-versions":
-                                all_timestamps = False
-                                all_versions = True
-                        elif arg == "latest":
-                                all_timestamps = False
-                                all_versions = False
-                        else:
-                                usage(_("Illegal option value -- {0}").format(
-                                    arg))
-                elif opt == "-n":
-                        dry_run = True
-                elif opt == "-p":
-                        publishers.append(arg)
-                elif opt == "-r":
-                        recursive = True
-                elif opt == "-s":
-                        src_uri = arg
-                elif opt == "-v":
-                        verbose = True
-                elif opt == "--mog-file":
-                        mog_files.append(arg)
-                elif opt == "--newest":
-                        list_newest = True
-                elif opt == "--raw":
-                        raw = True
-                elif opt == "--key":
-                        key = arg
-                elif opt == "--cert":
-                        cert = arg
-                elif opt == "--dkey":
-                        dkey = arg
-                elif opt == "--dcert":
-                        dcert = arg
+    for opt, arg in opts:
+        if opt == "-a":
+            archive = True
+        elif opt == "-c":
+            cache_dir = arg
+        elif opt == "--clone":
+            clone = True
+        elif opt == "-d":
+            target = arg
+        elif opt == "-D" or opt == "--debug":
+            if arg in ["plan", "transport", "mogrify"]:
+                key = arg
+                value = "True"
+            else:
+                try:
+                    key, value = arg.split("=", 1)
+                except (AttributeError, ValueError):
+                    usage(
+                        _(
+                            "{opt} takes argument of form "
+                            "name=value, not {arg}"
+                        ).format(opt=opt, arg=arg)
+                    )
+            DebugValues.set_value(key, value)
+        elif opt == "-h":
+            usage(retcode=0)
+        elif opt == "-k":
+            keep_compressed = True
+        elif opt == "-m":
+            if arg == "all-timestamps":
+                all_timestamps = True
+                all_versions = False
+            elif arg == "all-versions":
+                all_timestamps = False
+                all_versions = True
+            elif arg == "latest":
+                all_timestamps = False
+                all_versions = False
+            else:
+                usage(_("Illegal option value -- {0}").format(arg))
+        elif opt == "-n":
+            dry_run = True
+        elif opt == "-p":
+            publishers.append(arg)
+        elif opt == "-r":
+            recursive = True
+        elif opt == "-s":
+            src_uri = arg
+        elif opt == "-v":
+            verbose = True
+        elif opt == "--mog-file":
+            mog_files.append(arg)
+        elif opt == "--newest":
+            list_newest = True
+        elif opt == "--raw":
+            raw = True
+        elif opt == "--key":
+            key = arg
+        elif opt == "--cert":
+            cert = arg
+        elif opt == "--dkey":
+            dkey = arg
+        elif opt == "--dcert":
+            dcert = arg
 
-        if not list_newest and not target:
-                usage(_("a destination must be provided"))
+    if not list_newest and not target:
+        usage(_("a destination must be provided"))
 
-        if not src_uri:
-                usage(_("a source repository must be provided"))
-        else:
-                src_uri = misc.parse_uri(src_uri)
+    if not src_uri:
+        usage(_("a source repository must be provided"))
+    else:
+        src_uri = misc.parse_uri(src_uri)
 
-        if not cache_dir:
-                cache_dir = tempfile.mkdtemp(dir=temp_root,
-                    prefix=global_settings.client_name + "-")
-                # Only clean-up cache dir if implicitly created by pkgrecv.
-                # User's cache-dirs should be preserved
-                tmpdirs.append(cache_dir)
-        else:
-                if clone:
-                        usage(_("--clone can not be used with -c.\n"
-                            "Content will be downloaded directly to the "
-                            "destination repository and re-downloading after a "
-                            "pkgrecv failure will not be required."))
-
-        if clone and raw:
-                usage(_("--clone can not be used with --raw.\n"))
-
-        if clone and archive:
-                usage(_("--clone can not be used with -a.\n"))
-
-        if clone and list_newest:
-                usage(_("--clone can not be used with --newest.\n"))
-
-        if clone and pargs:
-                usage(_("--clone does not support FMRI patterns"))
-
-        if publishers and not clone:
-                usage(_("-p can only be used with --clone.\n"))
-
-        if mog_files and clone:
-                usage(_("--mog-file can not be used with --clone.\n"))
-
-        incoming_dir = tempfile.mkdtemp(dir=temp_root,
-            prefix=global_settings.client_name + "-")
-        tmpdirs.append(incoming_dir)
-
-        # Create transport and transport config
-        xport, xport_cfg = transport.setup_transport()
-        xport_cfg.add_cache(cache_dir, readonly=False)
-        xport_cfg.incoming_root = incoming_dir
-
-        # Since publication destinations may only have one repository configured
-        # per publisher, create destination as separate transport in case source
-        # and destination have identical publisher configuration but different
-        # repository endpoints.
-        dest_xport, dest_xport_cfg = transport.setup_transport()
-        dest_xport_cfg.add_cache(cache_dir, readonly=False)
-        dest_xport_cfg.incoming_root = incoming_dir
-
-        # Configure src publisher(s).
-        transport.setup_publisher(src_uri, "source", xport, xport_cfg,
-            remote_prefix=True, ssl_key=key, ssl_cert=cert)
-
-        args = (pargs, target, list_newest, all_versions,
-            all_timestamps, keep_compressed, raw, recursive, dry_run, verbose,
-            dest_xport_cfg, src_uri, dkey, dcert)
-
+    if not cache_dir:
+        cache_dir = tempfile.mkdtemp(
+            dir=temp_root, prefix=global_settings.client_name + "-"
+        )
+        # Only clean-up cache dir if implicitly created by pkgrecv.
+        # User's cache-dirs should be preserved
+        tmpdirs.append(cache_dir)
+    else:
         if clone:
-                args += (publishers,)
-                return clone_repo(*args)
+            usage(
+                _(
+                    "--clone can not be used with -c.\n"
+                    "Content will be downloaded directly to the "
+                    "destination repository and re-downloading after a "
+                    "pkgrecv failure will not be required."
+                )
+            )
 
-        args += (mog_files,)
-        if archive:
-                # Retrieving package data for archival requires a different mode
-                # of operation so gets its own routine.  Notably, it requires
-                # that all package data be retrieved before the archival process
-                # is started.
-                return archive_pkgs(*args)
+    if clone and raw:
+        usage(_("--clone can not be used with --raw.\n"))
 
-        # Normal package transfer allows operations on a per-package basis.
-        return transfer_pkgs(*args)
+    if clone and archive:
+        usage(_("--clone can not be used with -a.\n"))
+
+    if clone and list_newest:
+        usage(_("--clone can not be used with --newest.\n"))
+
+    if clone and pargs:
+        usage(_("--clone does not support FMRI patterns"))
+
+    if publishers and not clone:
+        usage(_("-p can only be used with --clone.\n"))
+
+    if mog_files and clone:
+        usage(_("--mog-file can not be used with --clone.\n"))
+
+    incoming_dir = tempfile.mkdtemp(
+        dir=temp_root, prefix=global_settings.client_name + "-"
+    )
+    tmpdirs.append(incoming_dir)
+
+    # Create transport and transport config
+    xport, xport_cfg = transport.setup_transport()
+    xport_cfg.add_cache(cache_dir, readonly=False)
+    xport_cfg.incoming_root = incoming_dir
+
+    # Since publication destinations may only have one repository configured
+    # per publisher, create destination as separate transport in case source
+    # and destination have identical publisher configuration but different
+    # repository endpoints.
+    dest_xport, dest_xport_cfg = transport.setup_transport()
+    dest_xport_cfg.add_cache(cache_dir, readonly=False)
+    dest_xport_cfg.incoming_root = incoming_dir
+
+    # Configure src publisher(s).
+    transport.setup_publisher(
+        src_uri,
+        "source",
+        xport,
+        xport_cfg,
+        remote_prefix=True,
+        ssl_key=key,
+        ssl_cert=cert,
+    )
+
+    args = (
+        pargs,
+        target,
+        list_newest,
+        all_versions,
+        all_timestamps,
+        keep_compressed,
+        raw,
+        recursive,
+        dry_run,
+        verbose,
+        dest_xport_cfg,
+        src_uri,
+        dkey,
+        dcert,
+    )
+
+    if clone:
+        args += (publishers,)
+        return clone_repo(*args)
+
+    args += (mog_files,)
+    if archive:
+        # Retrieving package data for archival requires a different mode
+        # of operation so gets its own routine.  Notably, it requires
+        # that all package data be retrieved before the archival process
+        # is started.
+        return archive_pkgs(*args)
+
+    # Normal package transfer allows operations on a per-package basis.
+    return transfer_pkgs(*args)
+
 
 def check_processed(any_matched, any_unmatched, total_processed):
-        # Reduce unmatched patterns to those that were unmatched for all
-        # publishers.
-        unmatched = set(any_unmatched) - set(any_matched)
+    # Reduce unmatched patterns to those that were unmatched for all
+    # publishers.
+    unmatched = set(any_unmatched) - set(any_matched)
 
-        if not unmatched:
-                return
+    if not unmatched:
+        return
 
-        # If any match failures remain, abort with an error.
-        rval = 1
-        if total_processed > 0:
-                rval = 3
-        abort(str(apx.PackageMatchErrors(unmatched_fmris=unmatched)),
-            retcode=rval)
+    # If any match failures remain, abort with an error.
+    rval = 1
+    if total_processed > 0:
+        rval = 3
+    abort(str(apx.PackageMatchErrors(unmatched_fmris=unmatched)), retcode=rval)
 
-def get_matches(src_pub, tracker, xport, pargs, any_unmatched, any_matched,
-    all_versions, all_timestamps, recursive):
-        """Returns the set of matching FMRIs for the given arguments."""
-        global src_cat
 
-        src_cat = fetch_catalog(src_pub, tracker, xport, False)
-        # Avoid overhead of going through matching if user requested all
-        # packages.
-        if "*" not in pargs and "*@*" not in pargs:
-                try:
-                        matches, refs, unmatched = \
-                            src_cat.get_matching_fmris(pargs)
-                except apx.PackageMatchErrors as e:
-                        abort(str(e))
+def get_matches(
+    src_pub,
+    tracker,
+    xport,
+    pargs,
+    any_unmatched,
+    any_matched,
+    all_versions,
+    all_timestamps,
+    recursive,
+):
+    """Returns the set of matching FMRIs for the given arguments."""
+    global src_cat
 
-                # Track anything that failed to match.
-                any_unmatched.extend(unmatched)
-                any_matched.extend(set(p for p in refs.values()))
-                matches = list(set(f for m in matches.values() for f in m))
-        else:
-                matches = [f for f in src_cat.fmris()]
+    src_cat = fetch_catalog(src_pub, tracker, xport, False)
+    # Avoid overhead of going through matching if user requested all
+    # packages.
+    if "*" not in pargs and "*@*" not in pargs:
+        try:
+            matches, refs, unmatched = src_cat.get_matching_fmris(pargs)
+        except apx.PackageMatchErrors as e:
+            abort(str(e))
 
-        if not matches:
-                # No matches at all; nothing to do for this publisher.
-                return matches
+        # Track anything that failed to match.
+        any_unmatched.extend(unmatched)
+        any_matched.extend(set(p for p in refs.values()))
+        matches = list(set(f for m in matches.values() for f in m))
+    else:
+        matches = [f for f in src_cat.fmris()]
 
-        matches = prune(matches, all_versions, all_timestamps)
-        if recursive:
-                msg(_("Retrieving manifests for dependency "
-                    "evaluation ..."))
-                matches = prune(get_dependencies(matches, xport_cfg, tracker),
-                    all_versions, all_timestamps)
-
+    if not matches:
+        # No matches at all; nothing to do for this publisher.
         return matches
 
+    matches = prune(matches, all_versions, all_timestamps)
+    if recursive:
+        msg(_("Retrieving manifests for dependency " "evaluation ..."))
+        matches = prune(
+            get_dependencies(matches, xport_cfg, tracker),
+            all_versions,
+            all_timestamps,
+        )
+
+    return matches
+
+
 def __mog_helper(mog_files, fmri, mpathname):
-        """Helper routine for mogrifying manifest. Precondition: mog_files
-        has at least one element."""
+    """Helper routine for mogrifying manifest. Precondition: mog_files
+    has at least one element."""
 
-        ignoreincludes = False
-        mog_verbose = False
-        includes = []
-        macros = {}
-        printinfo = []
-        output = []
-        line_buffer = []
+    ignoreincludes = False
+    mog_verbose = False
+    includes = []
+    macros = {}
+    printinfo = []
+    output = []
+    line_buffer = []
 
-        # Set mogrify in verbose mode for debugging.
-        if DebugValues.get_value("mogrify"):
-                mog_verbose = True
+    # Set mogrify in verbose mode for debugging.
+    if DebugValues.get_value("mogrify"):
+        mog_verbose = True
 
-        # Take out "-" symbol. If the only one element is "-", input_files
-        # will be empty, then stdin is used. If more than elements, the
-        # effect of "-" will be ignored, and system only takes input from
-        # real files provided.
-        input_files = [mf for mf in mog_files if mf != "-"]
-        mog.process_mog(input_files, ignoreincludes, mog_verbose, includes,
-            macros, printinfo, output, error_cb=None,
-            sys_supply_files=[mpathname])
+    # Take out "-" symbol. If the only one element is "-", input_files
+    # will be empty, then stdin is used. If more than elements, the
+    # effect of "-" will be ignored, and system only takes input from
+    # real files provided.
+    input_files = [mf for mf in mog_files if mf != "-"]
+    mog.process_mog(
+        input_files,
+        ignoreincludes,
+        mog_verbose,
+        includes,
+        macros,
+        printinfo,
+        output,
+        error_cb=None,
+        sys_supply_files=[mpathname],
+    )
 
+    try:
+        for p in printinfo:
+            print("{0}".format(p), file=sys.stdout)
+    except IOError as e:
+        error(_("Cannot write extra data {0}").format(e))
+
+    # Collect new contents of mogrified manifest.
+    # emitted tracks output so far to avoid duplicates.
+    emitted = set()
+    for comment, actionlist, prepended_macro in output:
+        if comment:
+            for l in comment:
+                line_buffer.append("{0}".format(l))
+
+        for i, action in enumerate(actionlist):
+            if action is None:
+                continue
+            if prepended_macro is None:
+                s = "{0}".format(action)
+            else:
+                s = "{0}{1}".format(prepended_macro, action)
+            # The first action is the original
+            # action and should be collected;
+            # later actions are all emitted and
+            # should only be collected if not
+            # duplicates.
+            if i == 0:
+                line_buffer.append(s)
+            elif s not in emitted:
+                line_buffer.append(s)
+                emitted.add(s)
+
+    # Print the mogrified result for debugging purpose.
+    if mog_verbose:
+        print(
+            "{0}".format(
+                "Mogrified manifest for {0}: (subject to "
+                "validation)\n".format(
+                    fmri.get_fmri(anarchy=True, include_scheme=False)
+                )
+            ),
+            file=sys.stdout,
+        )
+        for line in line_buffer:
+            print("{0}".format(line), file=sys.stdout)
+
+    # Find the mogrified fmri. Make it equal to the old fmri first just
+    # to make sure it always has a value.
+    nfmri = fmri
+    new_lines = []
+    for al in line_buffer:
+        if not al.strip():
+            continue
+
+        if al.strip().startswith("#"):
+            continue
         try:
-                for p in printinfo:
-                        print("{0}".format(p), file=sys.stdout)
-        except IOError as e:
-                error(_("Cannot write extra data {0}").format(e))
+            act = actions.fromstr(al)
+        except Exception as e:
+            # If any exception encoutered here, that means the
+            # action is corrupted with mogrify.
+            abort(e)
+        if act.name == "set" and act.attrs["name"] == "pkg.fmri":
+            # Construct mogrified new fmri.
+            try:
+                nfmri = pkg.fmri.PkgFmri(act.attrs["value"])
+            except Exception as ex:
+                abort("Invalid FMRI for set action:\n{0}".format(al))
+        if hasattr(act, "hash"):
+            # Drop the signature.
+            if act.name == "signature":
+                continue
+            # Check whether new contents such as files and licenses
+            # was added via mogrify. This should not be allowed.
+            if "pkg.size" not in act.attrs:
+                abort(
+                    "Adding new hashable content {0} is not "
+                    "allowed.".format(act.hash)
+                )
+        elif act.name == "depend":
+            try:
+                fmris = act.attrs["fmri"]
+                if not isinstance(fmris, list):
+                    fmris = [fmris]
+                for f in fmris:
+                    pkg.fmri.PkgFmri(f)
+            except Exception as ex:
+                abort("Invalid FMRI(s) for depend action:\n{0}".format(al))
+        new_lines.append(al)
 
-        # Collect new contents of mogrified manifest.
-        # emitted tracks output so far to avoid duplicates.
-        emitted = set()
-        for comment, actionlist, prepended_macro in output:
-                if comment:
-                        for l in comment:
-                                line_buffer.append("{0}"
-                                    .format(l))
+    return (nfmri, new_lines)
 
-                for i, action in enumerate(actionlist):
-                        if action is None:
-                                continue
-                        if prepended_macro is None:
-                                s = "{0}".format(action)
-                        else:
-                                s = "{0}{1}".format(
-                                    prepended_macro, action)
-                        # The first action is the original
-                        # action and should be collected;
-                        # later actions are all emitted and
-                        # should only be collected if not
-                        # duplicates.
-                        if i == 0:
-                                line_buffer.append(s)
-                        elif s not in emitted:
-                                line_buffer.append(s)
-                                emitted.add(s)
-
-        # Print the mogrified result for debugging purpose.
-        if mog_verbose:
-                print("{0}".format("Mogrified manifest for {0}: (subject to "
-                    "validation)\n".format(fmri.get_fmri(anarchy=True,
-                    include_scheme=False))), file=sys.stdout)
-                for line in line_buffer:
-                        print("{0}".format(line), file=sys.stdout)
-
-        # Find the mogrified fmri. Make it equal to the old fmri first just
-        # to make sure it always has a value.
-        nfmri = fmri
-        new_lines = []
-        for al in line_buffer:
-                if not al.strip():
-                        continue
-
-                if al.strip().startswith("#"):
-                        continue
-                try:
-                        act = actions.fromstr(al)
-                except Exception as e:
-                        # If any exception encoutered here, that means the
-                        # action is corrupted with mogrify.
-                        abort(e)
-                if act.name == "set" and act.attrs["name"] == "pkg.fmri":
-                        # Construct mogrified new fmri.
-                        try:
-                                nfmri = pkg.fmri.PkgFmri(
-                                    act.attrs["value"])
-                        except Exception as ex:
-                                abort("Invalid FMRI for set action:\n{0}"
-                                    .format(al))
-                if hasattr(act, "hash"):
-                        # Drop the signature.
-                        if act.name == "signature":
-                                continue
-                        # Check whether new contents such as files and licenses
-                        # was added via mogrify. This should not be allowed.
-                        if "pkg.size" not in act.attrs:
-                                abort("Adding new hashable content {0} is not "
-                                    "allowed.".format(act.hash))
-                elif act.name == "depend":
-                        try:
-                                fmris = act.attrs["fmri"]
-                                if not isinstance(fmris, list):
-                                        fmris = [fmris]
-                                for f in fmris:
-                                        pkg.fmri.PkgFmri(f)
-                        except Exception as ex:
-                                abort("Invalid FMRI(s) for depend action:\n{0}"
-                                    .format(al))
-                new_lines.append(al)
-
-        return (nfmri, new_lines)
 
 def _rm_temp_raw_files(fmri, xport_cfg, ignore_errors=False):
-        # pkgdir is a directory with format: pkg_name/version.
-        # pkg_parentdir is the actual pkg_name directory.
-        pkgdir = xport_cfg.get_pkg_dir(fmri)
-        pkg_parentdir = os.path.dirname(pkgdir)
-        shutil.rmtree(pkgdir,
-            ignore_errors=ignore_errors)
+    # pkgdir is a directory with format: pkg_name/version.
+    # pkg_parentdir is the actual pkg_name directory.
+    pkgdir = xport_cfg.get_pkg_dir(fmri)
+    pkg_parentdir = os.path.dirname(pkgdir)
+    shutil.rmtree(pkgdir, ignore_errors=ignore_errors)
 
-        # If the parent directory become empty,
-        # remove it as well.
-        if not os.listdir(pkg_parentdir):
-                shutil.rmtree(pkg_parentdir,
-                    ignore_errors=ignore_errors)
-
-def archive_pkgs(pargs, target, list_newest, all_versions, all_timestamps,
-    keep_compresed, raw, recursive, dry_run, verbose, dest_xport_cfg, src_uri,
-    dkey, dcert, mog_files):
-        """Retrieve source package data completely and then archive it."""
-
-        global cache_dir, download_start, xport, xport_cfg
-        do_mog = False
-        if mog_files:
-                do_mog = True
-        target = os.path.abspath(target)
-        if os.path.exists(target):
-                error(_("Target archive '{0}' already "
-                    "exists.").format(target))
-                abort()
-
-        # Open the archive early so that permissions failures, etc. can be
-        # detected before actual work is started.
-        if not dry_run:
-                pkg_arc = pkg.p5p.Archive(target, mode="w")
-
-        basedir = tempfile.mkdtemp(dir=temp_root,
-            prefix=global_settings.client_name + "-")
-        tmpdirs.append(basedir)
-
-        # Retrieve package data for all publishers.
-        any_unmatched = []
-        any_matched = []
-        invalid_manifests = []
-        total_processed = 0
-        arc_bytes = 0
-        archive_list = []
-        for src_pub in xport_cfg.gen_publishers():
-                # Root must be per publisher on the off chance that multiple
-                # publishers have the same package.
-                xport_cfg.pkg_root = os.path.join(basedir, src_pub.prefix)
-
-                tracker = get_tracker()
-                msg(_("Retrieving packages for publisher {0} ...").format(
-                    src_pub.prefix))
-                if pargs is None or len(pargs) == 0:
-                        usage(_("must specify at least one pkgfmri"))
-
-                matches = get_matches(src_pub, tracker, xport, pargs,
-                    any_unmatched, any_matched, all_versions, all_timestamps,
-                    recursive)
-                if not matches:
-                        # No matches at all; nothing to do for this publisher.
-                        continue
-
-                # First, retrieve the manifests and calculate package transfer
-                # sizes.
-                npkgs = len(matches)
-                get_bytes = 0
-                get_files = 0
-
-                if not recursive:
-                        msg(_("Retrieving and evaluating {0:d} package(s)...").format(
-                            npkgs))
+    # If the parent directory become empty,
+    # remove it as well.
+    if not os.listdir(pkg_parentdir):
+        shutil.rmtree(pkg_parentdir, ignore_errors=ignore_errors)
 
 
-                tracker.manifest_fetch_start(npkgs)
+def archive_pkgs(
+    pargs,
+    target,
+    list_newest,
+    all_versions,
+    all_timestamps,
+    keep_compresed,
+    raw,
+    recursive,
+    dry_run,
+    verbose,
+    dest_xport_cfg,
+    src_uri,
+    dkey,
+    dcert,
+    mog_files,
+):
+    """Retrieve source package data completely and then archive it."""
 
-                fmappings = {}
-                good_matches = []
-                for f in matches:
-                        try:
-                                m = get_manifest(f, xport_cfg, validate=True)
-                        except apx.InvalidPackageErrors as e:
-                                invalid_manifests.extend(e.errors)
-                                continue
+    global cache_dir, download_start, xport, xport_cfg
+    do_mog = False
+    if mog_files:
+        do_mog = True
+    target = os.path.abspath(target)
+    if os.path.exists(target):
+        error(_("Target archive '{0}' already " "exists.").format(target))
+        abort()
 
-                        nf = f
-                        if do_mog:
-                                try:
-                                        nf, line_buffer = __mog_helper(mog_files,
-                                            f, m.pathname)
-                                        # Create mogrified manifest.
-                                        # Remove the old raw pkg data first.
-                                        _rm_temp_raw_files(f, xport_cfg)
-                                        nm = pkg.manifest.FactoredManifest(nf,
-                                            xport_cfg.get_pkg_dir(nf),
-                                            contents="\n".join(
-                                            line_buffer))
-                                except EnvironmentError as e:
-                                        _rm_temp_raw_files(nf, xport_cfg,
-                                            ignore_errors=True)
-                                        raise apx._convert_error(e)
-                                except Exception as e:
-                                        _rm_temp_raw_files(nf, xport_cfg,
-                                            ignore_errors=True)
-                                        abort(_("Creating mogrified "
-                                            "manifest failed: {0}"
-                                            ).format(str(e)))
-                        else:
-                                # Use the original manifest if no
-                                # mogrify is done.
-                                nm = m
+    # Open the archive early so that permissions failures, etc. can be
+    # detected before actual work is started.
+    if not dry_run:
+        pkg_arc = pkg.p5p.Archive(target, mode="w")
 
-                        # Store a mapping between new fmri and new manifest for
-                        # future use.
-                        fmappings[nf] = nm
-                        good_matches.append(nf)
-                        getb, getf, arcb, arccb = get_sizes(nm)
-                        get_bytes += getb
-                        get_files += getf
+    basedir = tempfile.mkdtemp(
+        dir=temp_root, prefix=global_settings.client_name + "-"
+    )
+    tmpdirs.append(basedir)
 
-                        # Since files are going into the archive, progress
-                        # can be tracked in terms of compressed bytes for
-                        # the package files themselves.
-                        arc_bytes += arccb
+    # Retrieve package data for all publishers.
+    any_unmatched = []
+    any_matched = []
+    invalid_manifests = []
+    total_processed = 0
+    arc_bytes = 0
+    archive_list = []
+    for src_pub in xport_cfg.gen_publishers():
+        # Root must be per publisher on the off chance that multiple
+        # publishers have the same package.
+        xport_cfg.pkg_root = os.path.join(basedir, src_pub.prefix)
 
-                        # Also include the manifest file itself in the
-                        # amount of bytes to archive.
-                        try:
-                                fs = os.stat(nm.pathname)
-                                arc_bytes += fs.st_size
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
+        tracker = get_tracker()
+        msg(
+            _("Retrieving packages for publisher {0} ...").format(
+                src_pub.prefix
+            )
+        )
+        if pargs is None or len(pargs) == 0:
+            usage(_("must specify at least one pkgfmri"))
 
-                        tracker.manifest_fetch_progress(completion=True)
-                matches = good_matches
+        matches = get_matches(
+            src_pub,
+            tracker,
+            xport,
+            pargs,
+            any_unmatched,
+            any_matched,
+            all_versions,
+            all_timestamps,
+            recursive,
+        )
+        if not matches:
+            # No matches at all; nothing to do for this publisher.
+            continue
 
-                tracker.manifest_fetch_done()
+        # First, retrieve the manifests and calculate package transfer
+        # sizes.
+        npkgs = len(matches)
+        get_bytes = 0
+        get_files = 0
 
-                # Next, retrieve the content for this publisher's packages.
-                tracker.download_set_goal(len(matches), get_files,
-                    get_bytes)
+        if not recursive:
+            msg(
+                _("Retrieving and evaluating {0:d} package(s)...").format(npkgs)
+            )
 
-                if verbose:
-                        if not dry_run:
-                                msg(_("\nArchiving packages ..."))
-                        else:
-                                msg(_("\nArchiving packages (dry-run) ..."))
-                        status = []
-                        status.append((_("Packages to add:"), str(len(matches))))
-                        status.append((_("Files to retrieve:"), str(get_files)))
-                        status.append((_("Estimated transfer size:"),
-                            misc.bytes_to_str(get_bytes)))
+        tracker.manifest_fetch_start(npkgs)
 
-                        rjust_status = max(len(s[0]) for s in status)
-                        rjust_value = max(len(s[1]) for s in status)
-                        for s in status:
-                                msg("{0} {1}".format(s[0].rjust(rjust_status),
-                                    s[1].rjust(rjust_value)))
+        fmappings = {}
+        good_matches = []
+        for f in matches:
+            try:
+                m = get_manifest(f, xport_cfg, validate=True)
+            except apx.InvalidPackageErrors as e:
+                invalid_manifests.extend(e.errors)
+                continue
 
-                        msg(_("\nPackages to archive:"))
-                        for nf in sorted(matches):
-                                fmri = nf.get_fmri(anarchy=True,
-                                    include_scheme=False)
-                                msg(fmri)
-                        msg()
+            nf = f
+            if do_mog:
+                try:
+                    nf, line_buffer = __mog_helper(mog_files, f, m.pathname)
+                    # Create mogrified manifest.
+                    # Remove the old raw pkg data first.
+                    _rm_temp_raw_files(f, xport_cfg)
+                    nm = pkg.manifest.FactoredManifest(
+                        nf,
+                        xport_cfg.get_pkg_dir(nf),
+                        contents="\n".join(line_buffer),
+                    )
+                except EnvironmentError as e:
+                    _rm_temp_raw_files(nf, xport_cfg, ignore_errors=True)
+                    raise apx._convert_error(e)
+                except Exception as e:
+                    _rm_temp_raw_files(nf, xport_cfg, ignore_errors=True)
+                    abort(
+                        _("Creating mogrified " "manifest failed: {0}").format(
+                            str(e)
+                        )
+                    )
+            else:
+                # Use the original manifest if no
+                # mogrify is done.
+                nm = m
 
-                if dry_run:
-                        # Don't call download_done here; it would cause an
-                        # assertion failure since nothing was downloaded.
-                        # Instead, call the method that simply finishes
-                        # up the progress output.
-                        tracker.download_done(dryrun=True)
-                        cleanup()
-                        total_processed = len(matches)
-                        continue
+            # Store a mapping between new fmri and new manifest for
+            # future use.
+            fmappings[nf] = nm
+            good_matches.append(nf)
+            getb, getf, arcb, arccb = get_sizes(nm)
+            get_bytes += getb
+            get_files += getf
 
-                for nf in matches:
-                        tracker.download_start_pkg(nf)
-                        pkgdir = xport_cfg.get_pkg_dir(nf)
-                        mfile = xport.multi_file_ni(src_pub, pkgdir,
-                            progtrack=tracker)
-                        nm = fmappings[nf]
-                        add_hashes_to_multi(nm, mfile)
+            # Since files are going into the archive, progress
+            # can be tracked in terms of compressed bytes for
+            # the package files themselves.
+            arc_bytes += arccb
 
-                        if mfile:
-                                download_start = True
-                                mfile.wait_files()
+            # Also include the manifest file itself in the
+            # amount of bytes to archive.
+            try:
+                fs = os.stat(nm.pathname)
+                arc_bytes += fs.st_size
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
 
-                        if not dry_run:
-                                archive_list.append((nf, nm.pathname, pkgdir))
+            tracker.manifest_fetch_progress(completion=True)
+        matches = good_matches
 
-                        # Nothing more to do for this package.
-                        tracker.download_end_pkg(nf)
-                        total_processed += 1
+        tracker.manifest_fetch_done()
 
-                tracker.download_done()
-                tracker.reset()
+        # Next, retrieve the content for this publisher's packages.
+        tracker.download_set_goal(len(matches), get_files, get_bytes)
 
-        # Check processed patterns and abort with failure if some were
-        # unmatched.
-        check_processed(any_matched, any_unmatched, total_processed)
+        if verbose:
+            if not dry_run:
+                msg(_("\nArchiving packages ..."))
+            else:
+                msg(_("\nArchiving packages (dry-run) ..."))
+            status = []
+            status.append((_("Packages to add:"), str(len(matches))))
+            status.append((_("Files to retrieve:"), str(get_files)))
+            status.append(
+                (_("Estimated transfer size:"), misc.bytes_to_str(get_bytes))
+            )
 
-        if not dry_run:
-                # Now create archive and then archive retrieved package data.
-                while archive_list:
-                        pfmri, mpath, pkgdir = archive_list.pop()
-                        pkg_arc.add_package(pfmri, mpath, pkgdir)
-                pkg_arc.close(progtrack=tracker)
+            rjust_status = max(len(s[0]) for s in status)
+            rjust_value = max(len(s[1]) for s in status)
+            for s in status:
+                msg(
+                    "{0} {1}".format(
+                        s[0].rjust(rjust_status), s[1].rjust(rjust_value)
+                    )
+                )
 
-        # Dump all temporary data.
-        cleanup()
+            msg(_("\nPackages to archive:"))
+            for nf in sorted(matches):
+                fmri = nf.get_fmri(anarchy=True, include_scheme=False)
+                msg(fmri)
+            msg()
 
-        if invalid_manifests:
-                error(_("One or more packages could not be retrieved:\n\n{0}").
-                    format("\n".join(str(im) for im in invalid_manifests)))
-        if invalid_manifests and total_processed:
-                return pkgdefs.EXIT_PARTIAL
-        if invalid_manifests:
-                return pkgdefs.EXIT_OOPS
-        return pkgdefs.EXIT_OK
+        if dry_run:
+            # Don't call download_done here; it would cause an
+            # assertion failure since nothing was downloaded.
+            # Instead, call the method that simply finishes
+            # up the progress output.
+            tracker.download_done(dryrun=True)
+            cleanup()
+            total_processed = len(matches)
+            continue
+
+        for nf in matches:
+            tracker.download_start_pkg(nf)
+            pkgdir = xport_cfg.get_pkg_dir(nf)
+            mfile = xport.multi_file_ni(src_pub, pkgdir, progtrack=tracker)
+            nm = fmappings[nf]
+            add_hashes_to_multi(nm, mfile)
+
+            if mfile:
+                download_start = True
+                mfile.wait_files()
+
+            if not dry_run:
+                archive_list.append((nf, nm.pathname, pkgdir))
+
+            # Nothing more to do for this package.
+            tracker.download_end_pkg(nf)
+            total_processed += 1
+
+        tracker.download_done()
+        tracker.reset()
+
+    # Check processed patterns and abort with failure if some were
+    # unmatched.
+    check_processed(any_matched, any_unmatched, total_processed)
+
+    if not dry_run:
+        # Now create archive and then archive retrieved package data.
+        while archive_list:
+            pfmri, mpath, pkgdir = archive_list.pop()
+            pkg_arc.add_package(pfmri, mpath, pkgdir)
+        pkg_arc.close(progtrack=tracker)
+
+    # Dump all temporary data.
+    cleanup()
+
+    if invalid_manifests:
+        error(
+            _("One or more packages could not be retrieved:\n\n{0}").format(
+                "\n".join(str(im) for im in invalid_manifests)
+            )
+        )
+    if invalid_manifests and total_processed:
+        return pkgdefs.EXIT_PARTIAL
+    if invalid_manifests:
+        return pkgdefs.EXIT_OOPS
+    return pkgdefs.EXIT_OK
 
 
-def clone_repo(pargs, target, list_newest, all_versions, all_timestamps,
-    keep_compressed, raw, recursive, dry_run, verbose, dest_xport_cfg, src_uri,
-    dkey, dcert, publishers):
+def clone_repo(
+    pargs,
+    target,
+    list_newest,
+    all_versions,
+    all_timestamps,
+    keep_compressed,
+    raw,
+    recursive,
+    dry_run,
+    verbose,
+    dest_xport_cfg,
+    src_uri,
+    dkey,
+    dcert,
+    publishers,
+):
+    global cache_dir, download_start, xport, xport_cfg, dest_xport
 
-        global cache_dir, download_start, xport, xport_cfg, dest_xport
+    invalid_manifests = []
+    total_processed = 0
+    modified_pubs = set()
+    deleted_pkgs = False
+    old_c_root = {}
+    del_search_index = set()
 
-        invalid_manifests = []
-        total_processed = 0
-        modified_pubs = set()
-        deleted_pkgs = False
-        old_c_root = {}
-        del_search_index = set()
+    # Turn target into a valid URI.
+    target = publisher.RepositoryURI(misc.parse_uri(target))
 
-        # Turn target into a valid URI.
-        target = publisher.RepositoryURI(misc.parse_uri(target))
+    if target.scheme != "file":
+        abort(
+            err=_("Destination clone repository must be " "filesystem-based.")
+        )
 
-        if target.scheme != "file":
-                abort(err=_("Destination clone repository must be "
-                    "filesystem-based."))
+    # Initialize the target repo.
+    try:
+        repo = sr.Repository(read_only=False, root=target.get_pathname())
+    except sr.RepositoryInvalidError as e:
+        txt = str(e) + "\n\n"
+        txt += _("To create a repository, use the pkgrepo command.")
+        abort(err=txt)
 
-        # Initialize the target repo.
+    def copy_catalog(src_cat_root, pub):
+        # Copy catalog files.
+        c_root = repo.get_pub_rstore(pub).catalog_root
+        rstore_root = repo.get_pub_rstore(pub).root
         try:
-                repo = sr.Repository(read_only=False,
-                    root=target.get_pathname())
-        except sr.RepositoryInvalidError as e:
-                txt = str(e) + "\n\n"
-                txt += _("To create a repository, use the pkgrepo command.")
-                abort(err=txt)
+            # We just use mkdtemp() to find ourselves a directory
+            # which does not already exist. The created dir is not
+            # used.
+            old_c_root = tempfile.mkdtemp(dir=rstore_root, prefix="catalog-")
+            shutil.rmtree(old_c_root)
+            shutil.move(c_root, old_c_root)
+            # Check if the source catalog is empty.
+            if not src_cat_root:
+                msg(_("The source catalog '{0}' is empty").format(pub))
+            else:
+                shutil.copytree(src_cat_root, c_root)
+        except Exception as e:
+            abort(err=_("Unable to copy catalog files: {0}").format(e))
+        return old_c_root
 
-        def copy_catalog(src_cat_root, pub):
-                # Copy catalog files.
-                c_root = repo.get_pub_rstore(pub).catalog_root
-                rstore_root = repo.get_pub_rstore(pub).root
-                try:
-                        # We just use mkdtemp() to find ourselves a directory
-                        # which does not already exist. The created dir is not
-                        # used.
-                        old_c_root = tempfile.mkdtemp(dir=rstore_root,
-                            prefix='catalog-')
-                        shutil.rmtree(old_c_root)
-                        shutil.move(c_root, old_c_root)
-                        # Check if the source catalog is empty.
-                        if not src_cat_root:
-                            msg(_("The source catalog '{0}' is empty").
-                                    format(pub))
-                        else:
-                            shutil.copytree(src_cat_root, c_root)
-                except Exception as e:
-                        abort(err=_("Unable to copy catalog files: {0}").format(
-                            e))
-                return old_c_root
+    # Check if all publishers in src are also in target. If not, add
+    # depending on what publishers were specified by user.
+    pubs_to_sync = []
+    pubs_to_add = []
+    src_pubs = {}
+    for sp in xport_cfg.gen_publishers():
+        src_pubs[sp.prefix] = sp
+    dst_pubs = repo.get_publishers()
 
-        # Check if all publishers in src are also in target. If not, add
-        # depending on what publishers were specified by user.
-        pubs_to_sync = []
-        pubs_to_add = []
-        src_pubs = {}
-        for sp in xport_cfg.gen_publishers():
-                src_pubs[sp.prefix] = sp
-        dst_pubs = repo.get_publishers()
+    pubs_specified = False
+    unknown_pubs = []
+    for p in publishers:
+        if p not in src_pubs and p != "*":
+            abort(
+                err=_(
+                    "The publisher {0} does not exist in the "
+                    "source repository.".format(p)
+                )
+            )
+        pubs_specified = True
 
-        pubs_specified = False
-        unknown_pubs = []
-        for p in publishers:
-                if p not in src_pubs and p != '*':
-                        abort(err=_("The publisher {0} does not exist in the "
-                            "source repository.".format(p)))
-                pubs_specified = True
+    for sp in src_pubs:
+        if sp not in dst_pubs and (sp in publishers or "*" in publishers):
+            pubs_to_add.append(src_pubs[sp])
+            pubs_to_sync.append(src_pubs[sp])
+        elif sp in dst_pubs and (
+            sp in publishers or "*" in publishers or not pubs_specified
+        ):
+            pubs_to_sync.append(src_pubs[sp])
+        elif not pubs_specified:
+            unknown_pubs.append(sp)
 
-        for sp in src_pubs:
-                if sp not in dst_pubs and (sp in publishers or \
-                    '*' in publishers):
-                        pubs_to_add.append(src_pubs[sp])
-                        pubs_to_sync.append(src_pubs[sp])
-                elif sp in dst_pubs and (sp in publishers or '*' in publishers
-                    or not pubs_specified):
-                        pubs_to_sync.append(src_pubs[sp])
-                elif not pubs_specified:
-                        unknown_pubs.append(sp)
+    # We only print warning if the user didn't specify any valid publishers
+    # to add/sync.
+    if len(unknown_pubs):
+        txt = _(
+            "\nThe following publishers are present in the "
+            "source repository but not in the target repository.\n"
+            "Please use -p to specify which publishers need to be "
+            "cloned or -p '*' to clone all publishers."
+        )
+        for p in unknown_pubs:
+            txt += "\n    {0}\n".format(p)
+        abort(err=txt)
 
-        # We only print warning if the user didn't specify any valid publishers
-        # to add/sync.
-        if len(unknown_pubs):
-                txt = _("\nThe following publishers are present in the "
-                    "source repository but not in the target repository.\n"
-                    "Please use -p to specify which publishers need to be "
-                    "cloned or -p '*' to clone all publishers.")
-                for p in unknown_pubs:
-                        txt += "\n    {0}\n".format(p)
-                abort(err=txt)
+    # Create non-existent publishers.
+    for p in pubs_to_add:
+        if not dry_run:
+            msg(_("Adding publisher {0} ...").format(p.prefix))
+            # add_publisher() will create a p5i file in the repo
+            # store, containing origin and possible mirrors from
+            # the src repo. These may not be valid for the new repo
+            # so skip creation of this file.
+            repo.add_publisher(p, skip_config=True)
+        else:
+            msg(_("Adding publisher {0} (dry-run) ...").format(p.prefix))
 
-        # Create non-existent publishers.
-        for p in pubs_to_add:
-                if not dry_run:
-                        msg(_("Adding publisher {0} ...").format(p.prefix))
-                        # add_publisher() will create a p5i file in the repo
-                        # store, containing origin and possible mirrors from
-                        # the src repo. These may not be valid for the new repo
-                        # so skip creation of this file.
-                        repo.add_publisher(p, skip_config=True)
-                else:
-                        msg(_("Adding publisher {0} (dry-run) ...").format(
-                            p.prefix))
+    for src_pub in pubs_to_sync:
+        msg(
+            _("Processing packages for publisher {0} ...").format(
+                src_pub.prefix
+            )
+        )
+        tracker = get_tracker()
 
-        for src_pub in pubs_to_sync:
-                msg(_("Processing packages for publisher {0} ...").format(
-                    src_pub.prefix))
-                tracker = get_tracker()
+        src_basedir = tempfile.mkdtemp(
+            dir=temp_root, prefix=global_settings.client_name + "-"
+        )
+        tmpdirs.append(src_basedir)
 
-                src_basedir = tempfile.mkdtemp(dir=temp_root,
-                    prefix=global_settings.client_name + "-")
-                tmpdirs.append(src_basedir)
+        xport_cfg.pkg_root = src_basedir
 
-                xport_cfg.pkg_root = src_basedir
+        # We make the destination repo our cache directory to save on
+        # IOPs. Have to remove all the old caches first.
+        if not dry_run:
+            xport_cfg.clear_caches(shared=True)
+            xport_cfg.add_cache(
+                repo.get_pub_rstore(src_pub.prefix).file_root, readonly=False
+            )
 
-                # We make the destination repo our cache directory to save on
-                # IOPs. Have to remove all the old caches first.
-                if not dry_run:
-                        xport_cfg.clear_caches(shared=True)
-                        xport_cfg.add_cache(
-                            repo.get_pub_rstore(src_pub.prefix).file_root,
-                            readonly=False)
+        # Retrieve src and dest catalog for comparison.
+        src_pub.meta_root = src_basedir
 
-                # Retrieve src and dest catalog for comparison.
-                src_pub.meta_root = src_basedir
+        src_cat = fetch_catalog(
+            src_pub, tracker, xport, False, include_updates=True
+        )
+        src_cat_root = src_cat.meta_root
 
-                src_cat = fetch_catalog(src_pub, tracker, xport, False,
-                    include_updates=True)
-                src_cat_root = src_cat.meta_root
+        try:
+            targ_cat = repo.get_catalog(pub=src_pub.prefix)
+        except sr.RepositoryUnknownPublisher:
+            targ_cat = catalog.Catalog(read_only=True)
 
-                try:
-                        targ_cat = repo.get_catalog(pub=src_pub.prefix)
-                except sr.RepositoryUnknownPublisher:
-                        targ_cat = catalog.Catalog(read_only=True)
+        src_fmris = set([x for x in src_cat.fmris(last=False)])
+        targ_fmris = set([x for x in targ_cat.fmris(last=False)])
 
-                src_fmris = set([x for x in src_cat.fmris(last=False)])
-                targ_fmris = set([x for x in targ_cat.fmris(last=False)])
+        del src_cat
+        del targ_cat
 
-                del src_cat
-                del targ_cat
+        to_add = []
+        to_rm = []
 
-                to_add = []
-                to_rm = []
+        # We use bulk prefetching for faster transport of the manifests.
+        # Prefetch requires an intent which it sends to the server. Here
+        # we just use operation=clone for all FMRIs.
+        intent = "operation=clone;"
 
-                # We use bulk prefetching for faster transport of the manifests.
-                # Prefetch requires an intent which it sends to the server. Here
-                # we just use operation=clone for all FMRIs.
-                intent = "operation=clone;"
+        # Find FMRIs which need to be added/removed.
+        to_add_set = src_fmris - targ_fmris
+        to_rm = targ_fmris - src_fmris
 
-                # Find FMRIs which need to be added/removed.
-                to_add_set = src_fmris - targ_fmris
-                to_rm = targ_fmris - src_fmris
+        for f in to_add_set:
+            to_add.append((f, intent))
 
-                for f in to_add_set:
-                        to_add.append((f, intent))
+        del src_fmris
+        del targ_fmris
+        del to_add_set
 
-                del src_fmris
-                del targ_fmris
-                del to_add_set
+        # We have to do package removal first because after the sync we
+        # don't have the old catalog anymore and if we delete packages
+        # after the sync based on the current catalog we might delete
+        # files required by packages still in the repo.
+        if len(to_rm) > 0:
+            msg(_("Packages to remove:"))
+            for f in to_rm:
+                msg(
+                    "    {0}".format(
+                        f.get_fmri(anarchy=True, include_build=False)
+                    )
+                )
 
-                # We have to do package removal first because after the sync we
-                # don't have the old catalog anymore and if we delete packages
-                # after the sync based on the current catalog we might delete
-                # files required by packages still in the repo.
-                if len(to_rm) > 0:
-                        msg(_("Packages to remove:"))
-                        for f in to_rm:
-                                msg("    {0}".format(f.get_fmri(anarchy=True,
-                                    include_build=False)))
-
-                        if not dry_run:
-                                msg(_("Removing packages ..."))
-                                if repo.get_pub_rstore(
-                                    src_pub.prefix).search_available:
-                                        del_search_index.add(src_pub.prefix)
-                                repo.remove_packages(to_rm, progtrack=tracker,
-                                    pub=src_pub.prefix)
-                                deleted_pkgs = True
-                                total_processed += len(to_rm)
-                                modified_pubs.add(src_pub.prefix)
-
-                if len(to_add) == 0:
-                        msg(_("No packages to add."))
-                        if deleted_pkgs:
-                                old_c_root[src_pub.prefix] = copy_catalog(
-                                    src_cat_root, src_pub.prefix)
-                        continue
-
-                get_bytes = 0
-                get_files = 0
-
-                msg(_("Retrieving and evaluating {0:d} package(s)...").format(
-                    len(to_add)))
-
-                # Retrieve manifests.
-                # Try prefetching manifests in bulk first for faster, parallel
-                # transport. Retryable errors during prefetch are ignored and
-                # manifests are retrieved again during the "Reading" phase.
-                src_pub.transport.prefetch_manifests(to_add, progtrack=tracker)
-
-                # Need to change the output of mfst_fetch since otherwise we
-                # would see "Download Manifests x/y" twice, once from the
-                # prefetch and once from the actual manifest analysis.
-                old_gti = tracker.mfst_fetch
-                tracker.mfst_fetch = progress.GoalTrackerItem(
-                    _("Reading Manifests"))
-                tracker.manifest_fetch_start(len(to_add))
-                for f, i in to_add:
-                        try:
-                                m = get_manifest(f, xport_cfg, validate=True)
-                        except apx.InvalidPackageErrors as e:
-                                invalid_manifests.extend(e.errors)
-                                continue
-                        getb, getf, sendb, sendcb = get_sizes(m)
-                        get_bytes += getb
-                        get_files += getf
-
-                        if dry_run:
-                                tracker.manifest_fetch_progress(completion=True)
-                                continue
-
-                        # Move manifest into dest repo.
-                        targ_path = os.path.join(
-                            repo.get_pub_rstore(src_pub.prefix).root, 'pkg')
-                        dp = m.fmri.get_dir_path()
-                        dst_path = os.path.join(targ_path, dp)
-                        src_path = os.path.join(src_basedir, dp, 'manifest')
-                        dir_name = os.path.dirname(dst_path)
-                        try:
-                                misc.makedirs(dir_name)
-                                shutil.move(src_path, dst_path)
-                        except Exception as e:
-                                txt = _("Unable to copy manifest: {0}").format(e)
-                                abort(err=txt)
-
-                        tracker.manifest_fetch_progress(completion=True)
-
-                tracker.manifest_fetch_done()
-                # Restore old GoalTrackerItem for manifest download.
-                tracker.mfst_fetch = old_gti
-
-                if verbose:
-                        if not dry_run:
-                                msg(_("\nRetrieving packages ..."))
-                        else:
-                                msg(_("\nRetrieving packages (dry-run) ..."))
-
-                        status = []
-                        status.append((_("Packages to add:"), str(len(to_add))))
-                        status.append((_("Files to retrieve:"), str(get_files)))
-                        status.append((_("Estimated transfer size:"),
-                            misc.bytes_to_str(get_bytes)))
-
-                        rjust_status = max(len(s[0]) for s in status)
-                        rjust_value = max(len(s[1]) for s in status)
-                        for s in status:
-                                msg("{0} {1}".format(s[0].rjust(rjust_status),
-                                    s[1].rjust(rjust_value)))
-
-                        msg(_("\nPackages to transfer:"))
-                        for f, i in sorted(to_add):
-                                fmri = f.get_fmri(anarchy=True,
-                                    include_scheme=False)
-                                msg("{0}".format(fmri))
-                        msg()
-
-                if dry_run:
-                        continue
-
-                tracker.download_set_goal(len(to_add), get_files, get_bytes)
-
-                # Retrieve package files.
-                for f, i in to_add:
-                        tracker.download_start_pkg(f)
-                        mfile = xport.multi_file_ni(src_pub, None,
-                            progtrack=tracker)
-                        m = get_manifest(f, xport_cfg)
-                        add_hashes_to_multi(m, mfile)
-
-                        if mfile:
-                                mfile.wait_files()
-
-                        tracker.download_end_pkg(f)
-                        total_processed += 1
-
-                tracker.download_done
-                tracker.reset()
-
+            if not dry_run:
+                msg(_("Removing packages ..."))
+                if repo.get_pub_rstore(src_pub.prefix).search_available:
+                    del_search_index.add(src_pub.prefix)
+                repo.remove_packages(
+                    to_rm, progtrack=tracker, pub=src_pub.prefix
+                )
+                deleted_pkgs = True
+                total_processed += len(to_rm)
                 modified_pubs.add(src_pub.prefix)
-                old_c_root[src_pub.prefix] = copy_catalog(src_cat_root,
-                    src_pub.prefix)
 
-        if invalid_manifests:
-                error(_("One or more packages could not be retrieved:\n\n{0}").
-                    format("\n".join(str(im) for im in invalid_manifests)))
+        if len(to_add) == 0:
+            msg(_("No packages to add."))
+            if deleted_pkgs:
+                old_c_root[src_pub.prefix] = copy_catalog(
+                    src_cat_root, src_pub.prefix
+                )
+            continue
 
-        ret = 0
-        # Run pkgrepo verify to check repo.
-        if total_processed:
-                msg(_("\n\nVerifying repository contents."))
-                cmd = os.path.join(os.path.dirname(misc.api_cmdpath()),
-                    "pkgrepo")
-                args = [sys.executable, cmd, 'verify', '-s',
-                    target.get_pathname(), '--disable', 'dependency']
+        get_bytes = 0
+        get_files = 0
 
-                try:
-                        ret = subprocess.call(args)
-                except OSError as e:
-                        raise RuntimeError("cannot execute {0}: {1}".format(
-                            args, e))
+        msg(
+            _("Retrieving and evaluating {0:d} package(s)...").format(
+                len(to_add)
+            )
+        )
 
-        # Cleanup. If verification was ok, remove backup copy of old catalog.
-        # If not, move old catalog back into place and remove messed up catalog.
-        for pub in modified_pubs:
-                c_root = repo.get_pub_rstore(pub).catalog_root
-                try:
-                        if ret:
-                                shutil.rmtree(c_root)
-                                shutil.move(old_c_root[pub], c_root)
-                        else:
-                                shutil.rmtree(old_c_root[pub])
-                except Exception as e:
-                        error(_("Unable to remove catalog files: {0}").format(e))
-                        # We don't abort here to make sure we can
-                        # restore/delete as much as we can.
-                        continue
+        # Retrieve manifests.
+        # Try prefetching manifests in bulk first for faster, parallel
+        # transport. Retryable errors during prefetch are ignored and
+        # manifests are retrieved again during the "Reading" phase.
+        src_pub.transport.prefetch_manifests(to_add, progtrack=tracker)
 
-        if ret:
-                txt = _("Pkgrepo verify found errors in the updated repository."
-                    "\nThe original package catalog has been restored.\n")
-                if deleted_pkgs:
-                        txt += _("Deleted packages can not be restored.\n")
-                txt += _("The clone operation can be retried; package content "
-                    "that has already been retrieved will not be downloaded "
-                    "again.")
+        # Need to change the output of mfst_fetch since otherwise we
+        # would see "Download Manifests x/y" twice, once from the
+        # prefetch and once from the actual manifest analysis.
+        old_gti = tracker.mfst_fetch
+        tracker.mfst_fetch = progress.GoalTrackerItem(_("Reading Manifests"))
+        tracker.manifest_fetch_start(len(to_add))
+        for f, i in to_add:
+            try:
+                m = get_manifest(f, xport_cfg, validate=True)
+            except apx.InvalidPackageErrors as e:
+                invalid_manifests.extend(e.errors)
+                continue
+            getb, getf, sendb, sendcb = get_sizes(m)
+            get_bytes += getb
+            get_files += getf
+
+            if dry_run:
+                tracker.manifest_fetch_progress(completion=True)
+                continue
+
+            # Move manifest into dest repo.
+            targ_path = os.path.join(
+                repo.get_pub_rstore(src_pub.prefix).root, "pkg"
+            )
+            dp = m.fmri.get_dir_path()
+            dst_path = os.path.join(targ_path, dp)
+            src_path = os.path.join(src_basedir, dp, "manifest")
+            dir_name = os.path.dirname(dst_path)
+            try:
+                misc.makedirs(dir_name)
+                shutil.move(src_path, dst_path)
+            except Exception as e:
+                txt = _("Unable to copy manifest: {0}").format(e)
                 abort(err=txt)
 
-        if del_search_index:
-                txt = _("\nThe search index for the following publishers has "
-                    "been removed due to package removals.\n")
-                for p in del_search_index:
-                        txt += "    {0}\n".format(p)
-                txt += _("\nTo restore the search index for all publishers run"
-                    "\n'pkgrepo refresh --no-catalog -s {0}'.\n").format(
-                    target.get_pathname())
-                msg(txt)
+            tracker.manifest_fetch_progress(completion=True)
 
-        cleanup()
-        if invalid_manifests and total_processed:
-                return pkgdefs.EXIT_PARTIAL
-        if invalid_manifests:
-                return pkgdefs.EXIT_OOPS
-        return pkgdefs.EXIT_OK
+        tracker.manifest_fetch_done()
+        # Restore old GoalTrackerItem for manifest download.
+        tracker.mfst_fetch = old_gti
 
-def transfer_pkgs(pargs, target, list_newest, all_versions, all_timestamps,
-    keep_compressed, raw, recursive, dry_run, verbose, dest_xport_cfg, src_uri,
-    dkey, dcert, mog_files):
-        """Retrieve source package data and optionally republish it as each
-        package is retrieved.
-        """
+        if verbose:
+            if not dry_run:
+                msg(_("\nRetrieving packages ..."))
+            else:
+                msg(_("\nRetrieving packages (dry-run) ..."))
 
-        global cache_dir, download_start, xport, xport_cfg, dest_xport, targ_pub
+            status = []
+            status.append((_("Packages to add:"), str(len(to_add))))
+            status.append((_("Files to retrieve:"), str(get_files)))
+            status.append(
+                (_("Estimated transfer size:"), misc.bytes_to_str(get_bytes))
+            )
 
-        any_unmatched = []
-        any_matched = []
-        invalid_manifests = []
-        total_processed = 0
-        do_mog = False
+            rjust_status = max(len(s[0]) for s in status)
+            rjust_value = max(len(s[1]) for s in status)
+            for s in status:
+                msg(
+                    "{0} {1}".format(
+                        s[0].rjust(rjust_status), s[1].rjust(rjust_value)
+                    )
+                )
 
-        if mog_files:
-                do_mog = True
+            msg(_("\nPackages to transfer:"))
+            for f, i in sorted(to_add):
+                fmri = f.get_fmri(anarchy=True, include_scheme=False)
+                msg("{0}".format(fmri))
+            msg()
 
-        for src_pub in xport_cfg.gen_publishers():
-                tracker = get_tracker()
-                if list_newest:
-                        # Make sure the prog tracker knows we're doing a listing
-                        # operation so that it suppresses irrelevant output.
-                        tracker.set_purpose(tracker.PURPOSE_LISTING)
+        if dry_run:
+            continue
 
-                        if pargs or len(pargs) > 0:
-                                usage(_("--newest takes no options"))
+        tracker.download_set_goal(len(to_add), get_files, get_bytes)
 
-                        src_cat = fetch_catalog(src_pub, tracker,
-                            xport, False)
-                        for f in src_cat.fmris(ordered=True, last=True):
-                                msg(f.get_fmri(include_build=False))
-                        continue
+        # Retrieve package files.
+        for f, i in to_add:
+            tracker.download_start_pkg(f)
+            mfile = xport.multi_file_ni(src_pub, None, progtrack=tracker)
+            m = get_manifest(f, xport_cfg)
+            add_hashes_to_multi(m, mfile)
 
-                msg(_("Processing packages for publisher {0} ...").format(
-                    src_pub.prefix))
-                if pargs is None or len(pargs) == 0:
-                        usage(_("must specify at least one pkgfmri"))
+            if mfile:
+                mfile.wait_files()
 
-                republish = False
+            tracker.download_end_pkg(f)
+            total_processed += 1
 
-                if not raw:
-                        basedir = tempfile.mkdtemp(dir=temp_root,
-                            prefix=global_settings.client_name + "-")
-                        tmpdirs.append(basedir)
-                        republish = True
+        tracker.download_done
+        tracker.reset()
 
-                        # Turn target into a valid URI.
-                        target = misc.parse_uri(target)
+        modified_pubs.add(src_pub.prefix)
+        old_c_root[src_pub.prefix] = copy_catalog(src_cat_root, src_pub.prefix)
 
-                        # Setup target for transport.
-                        targ_pub = transport.setup_publisher(target,
-                            src_pub.prefix, dest_xport, dest_xport_cfg,
-                            ssl_key=dkey, ssl_cert=dcert)
+    if invalid_manifests:
+        error(
+            _("One or more packages could not be retrieved:\n\n{0}").format(
+                "\n".join(str(im) for im in invalid_manifests)
+            )
+        )
 
-                        # Files have to be decompressed for republishing.
-                        keep_compressed = False
-                        if target.startswith("file://"):
-                                # Check to see if the repository exists first.
-                                try:
-                                        t = trans.Transaction(target,
-                                            xport=dest_xport, pub=targ_pub)
-                                except trans.TransactionRepositoryInvalidError as e:
-                                        txt = str(e) + "\n\n"
-                                        txt += _("To create a repository, use "
-                                            "the pkgrepo command.")
-                                        abort(err=txt)
-                                except trans.TransactionRepositoryConfigError as e:
-                                        txt = str(e) + "\n\n"
-                                        txt += _("The repository configuration "
-                                            "for the repository located at "
-                                            "'{0}' is not valid or the "
-                                            "specified path does not exist.  "
-                                            "Please correct the configuration "
-                                            "of the repository or create a new "
-                                            "one.").format(target)
-                                        abort(err=txt)
-                                except trans.TransactionError as e:
-                                        abort(err=e)
-                else:
-                        basedir = target = os.path.abspath(target)
-                        if not os.path.exists(basedir):
-                                try:
-                                        os.makedirs(basedir, misc.PKG_DIR_MODE)
-                                except Exception as e:
-                                        error(_("Unable to create basedir "
-                                            "'{dir}': {err}").format(
-                                            dir=basedir, err=e))
-                                        abort()
+    ret = 0
+    # Run pkgrepo verify to check repo.
+    if total_processed:
+        msg(_("\n\nVerifying repository contents."))
+        cmd = os.path.join(os.path.dirname(misc.api_cmdpath()), "pkgrepo")
+        args = [
+            sys.executable,
+            cmd,
+            "verify",
+            "-s",
+            target.get_pathname(),
+            "--disable",
+            "dependency",
+        ]
 
-                xport_cfg.pkg_root = basedir
-                dest_xport_cfg.pkg_root = basedir
+        try:
+            ret = subprocess.call(args)
+        except OSError as e:
+            raise RuntimeError("cannot execute {0}: {1}".format(args, e))
 
-                matches = get_matches(src_pub, tracker, xport, pargs,
-                    any_unmatched, any_matched, all_versions, all_timestamps,
-                    recursive)
-                if not matches:
-                        # No matches at all; nothing to do for this publisher.
-                        continue
+    # Cleanup. If verification was ok, remove backup copy of old catalog.
+    # If not, move old catalog back into place and remove messed up catalog.
+    for pub in modified_pubs:
+        c_root = repo.get_pub_rstore(pub).catalog_root
+        try:
+            if ret:
+                shutil.rmtree(c_root)
+                shutil.move(old_c_root[pub], c_root)
+            else:
+                shutil.rmtree(old_c_root[pub])
+        except Exception as e:
+            error(_("Unable to remove catalog files: {0}").format(e))
+            # We don't abort here to make sure we can
+            # restore/delete as much as we can.
+            continue
 
-                def get_basename(pfmri):
-                        open_time = pfmri.get_timestamp()
-                        return "{0:d}_{1}".format(
-                            calendar.timegm(open_time.utctimetuple()),
-                            quote(str(pfmri), ""))
+    if ret:
+        txt = _(
+            "Pkgrepo verify found errors in the updated repository."
+            "\nThe original package catalog has been restored.\n"
+        )
+        if deleted_pkgs:
+            txt += _("Deleted packages can not be restored.\n")
+        txt += _(
+            "The clone operation can be retried; package content "
+            "that has already been retrieved will not be downloaded "
+            "again."
+        )
+        abort(err=txt)
 
-                # First, retrieve the manifests and calculate package transfer
-                # sizes.
-                npkgs = len(matches)
-                get_bytes = 0
-                get_files = 0
-                send_bytes = 0
+    if del_search_index:
+        txt = _(
+            "\nThe search index for the following publishers has "
+            "been removed due to package removals.\n"
+        )
+        for p in del_search_index:
+            txt += "    {0}\n".format(p)
+        txt += _(
+            "\nTo restore the search index for all publishers run"
+            "\n'pkgrepo refresh --no-catalog -s {0}'.\n"
+        ).format(target.get_pathname())
+        msg(txt)
 
-                if not recursive:
-                        msg(_("Retrieving and evaluating {0:d} package(s)...").format(
-                            npkgs))
+    cleanup()
+    if invalid_manifests and total_processed:
+        return pkgdefs.EXIT_PARTIAL
+    if invalid_manifests:
+        return pkgdefs.EXIT_OOPS
+    return pkgdefs.EXIT_OK
 
-                tracker.manifest_fetch_start(npkgs)
 
-                pkgs_to_get = []
-                new_targ_cats = {}
-                new_targ_pubs = {}
-                fmappings = {}
+def transfer_pkgs(
+    pargs,
+    target,
+    list_newest,
+    all_versions,
+    all_timestamps,
+    keep_compressed,
+    raw,
+    recursive,
+    dry_run,
+    verbose,
+    dest_xport_cfg,
+    src_uri,
+    dkey,
+    dcert,
+    mog_files,
+):
+    """Retrieve source package data and optionally republish it as each
+    package is retrieved.
+    """
 
-                while matches:
-                        f = matches.pop()
-                        try:
-                                m = get_manifest(f, xport_cfg, validate=True)
-                        except apx.InvalidPackageErrors as e:
-                                invalid_manifests.extend(e.errors)
-                                continue
+    global cache_dir, download_start, xport, xport_cfg, dest_xport, targ_pub
 
-                        nf = f
-                        if do_mog:
-                                try:
-                                        nf, line_buffer = __mog_helper(mog_files,
-                                            f, m.pathname)
-                                except Exception as e:
-                                        _rm_temp_raw_files(f, xport_cfg,
-                                            ignore_errors=True)
-                                        abort(err=e)
+    any_unmatched = []
+    any_matched = []
+    invalid_manifests = []
+    total_processed = 0
+    do_mog = False
 
-                        # Figure out whether the package is already in
-                        # the target repository or not.
-                        if republish:
-                                # Check whether the fmri already exists in the
-                                # target repository.
-                                if nf.publisher not in new_targ_cats:
-                                        newpub = transport.setup_publisher(
-                                            target, nf.publisher, dest_xport,
-                                            dest_xport_cfg, ssl_key=dkey,
-                                            ssl_cert=dcert)
-                                        # If no publisher transport
-                                        # established. That means it is a
-                                        # remote host. set remote prefix
-                                        # equal to True.
-                                        if not newpub:
-                                                newpub = transport.setup_publisher(
-                                                    target, nf.publisher,
-                                                    dest_xport, dest_xport_cfg,
-                                                    remote_prefix=True,
-                                                    ssl_key=dkey,
-                                                    ssl_cert=dcert)
-                                        new_targ_pubs[nf.publisher] = newpub
-                                        newcat = fetch_catalog(newpub, tracker,
-                                            dest_xport, True)
-                                        new_targ_cats[nf.publisher] = newcat
-                                        if newcat.get_entry(nf):
-                                                tracker.manifest_fetch_progress(
-                                                    completion=True)
-                                                continue
-                                # If we already have a catalog in the
-                                # cache, use it.
-                                elif new_targ_cats[nf.publisher].get_entry(nf):
-                                        tracker.manifest_fetch_progress(
-                                            completion=True)
-                                        continue
+    if mog_files:
+        do_mog = True
 
-                        if do_mog:
-                                # We have examined which packge to
-                                # republish. Then we need store the
-                                # mogrified manifest for future use.
-                                try:
-                                        # Create mogrified manifest.
-                                        # Remove the old raw pkg data first.
-                                        _rm_temp_raw_files(f, xport_cfg)
-                                        nm = pkg.manifest.FactoredManifest(nf,
-                                            xport_cfg.get_pkg_dir(nf),
-                                            contents="\n".join(
-                                            line_buffer))
-                                except EnvironmentError as e:
-                                        _rm_temp_raw_files(nf, xport_cfg,
-                                            ignore_errors=True)
-                                        raise apx._convert_error(e)
-                                except Exception as e:
-                                        _rm_temp_raw_files(nf, xport_cfg,
-                                            ignore_errors=True)
-                                        abort(_("Creating mogrified "
-                                            "manifest failed: {0}"
-                                            ).format(str(e)))
+    for src_pub in xport_cfg.gen_publishers():
+        tracker = get_tracker()
+        if list_newest:
+            # Make sure the prog tracker knows we're doing a listing
+            # operation so that it suppresses irrelevant output.
+            tracker.set_purpose(tracker.PURPOSE_LISTING)
 
-                        else:
-                                # Use the original manifest if no
-                                # mogrify is done.
-                                nm = m
+            if pargs or len(pargs) > 0:
+                usage(_("--newest takes no options"))
 
-                        getb, getf = get_sizes(nm)[:2]
-                        if republish:
-                                send_bytes += dest_xport.get_transfer_size(
-                                    new_targ_pubs[nf.publisher],
-                                    nm.gen_actions())
+            src_cat = fetch_catalog(src_pub, tracker, xport, False)
+            for f in src_cat.fmris(ordered=True, last=True):
+                msg(f.get_fmri(include_build=False))
+            continue
 
-                        # Store a mapping between new fmri and new manifest for
-                        # future use.
-                        fmappings[nf] = nm
-                        pkgs_to_get.append(nf)
+        msg(
+            _("Processing packages for publisher {0} ...").format(
+                src_pub.prefix
+            )
+        )
+        if pargs is None or len(pargs) == 0:
+            usage(_("must specify at least one pkgfmri"))
 
-                        get_bytes += getb
-                        get_files += getf
+        republish = False
 
-                        if dry_run:
-                                _rm_temp_raw_files(nf, xport_cfg,
-                                    ignore_errors=True)
+        if not raw:
+            basedir = tempfile.mkdtemp(
+                dir=temp_root, prefix=global_settings.client_name + "-"
+            )
+            tmpdirs.append(basedir)
+            republish = True
+
+            # Turn target into a valid URI.
+            target = misc.parse_uri(target)
+
+            # Setup target for transport.
+            targ_pub = transport.setup_publisher(
+                target,
+                src_pub.prefix,
+                dest_xport,
+                dest_xport_cfg,
+                ssl_key=dkey,
+                ssl_cert=dcert,
+            )
+
+            # Files have to be decompressed for republishing.
+            keep_compressed = False
+            if target.startswith("file://"):
+                # Check to see if the repository exists first.
+                try:
+                    t = trans.Transaction(
+                        target, xport=dest_xport, pub=targ_pub
+                    )
+                except trans.TransactionRepositoryInvalidError as e:
+                    txt = str(e) + "\n\n"
+                    txt += _(
+                        "To create a repository, use " "the pkgrepo command."
+                    )
+                    abort(err=txt)
+                except trans.TransactionRepositoryConfigError as e:
+                    txt = str(e) + "\n\n"
+                    txt += _(
+                        "The repository configuration "
+                        "for the repository located at "
+                        "'{0}' is not valid or the "
+                        "specified path does not exist.  "
+                        "Please correct the configuration "
+                        "of the repository or create a new "
+                        "one."
+                    ).format(target)
+                    abort(err=txt)
+                except trans.TransactionError as e:
+                    abort(err=e)
+        else:
+            basedir = target = os.path.abspath(target)
+            if not os.path.exists(basedir):
+                try:
+                    os.makedirs(basedir, misc.PKG_DIR_MODE)
+                except Exception as e:
+                    error(
+                        _("Unable to create basedir " "'{dir}': {err}").format(
+                            dir=basedir, err=e
+                        )
+                    )
+                    abort()
+
+        xport_cfg.pkg_root = basedir
+        dest_xport_cfg.pkg_root = basedir
+
+        matches = get_matches(
+            src_pub,
+            tracker,
+            xport,
+            pargs,
+            any_unmatched,
+            any_matched,
+            all_versions,
+            all_timestamps,
+            recursive,
+        )
+        if not matches:
+            # No matches at all; nothing to do for this publisher.
+            continue
+
+        def get_basename(pfmri):
+            open_time = pfmri.get_timestamp()
+            return "{0:d}_{1}".format(
+                calendar.timegm(open_time.utctimetuple()), quote(str(pfmri), "")
+            )
+
+        # First, retrieve the manifests and calculate package transfer
+        # sizes.
+        npkgs = len(matches)
+        get_bytes = 0
+        get_files = 0
+        send_bytes = 0
+
+        if not recursive:
+            msg(
+                _("Retrieving and evaluating {0:d} package(s)...").format(npkgs)
+            )
+
+        tracker.manifest_fetch_start(npkgs)
+
+        pkgs_to_get = []
+        new_targ_cats = {}
+        new_targ_pubs = {}
+        fmappings = {}
+
+        while matches:
+            f = matches.pop()
+            try:
+                m = get_manifest(f, xport_cfg, validate=True)
+            except apx.InvalidPackageErrors as e:
+                invalid_manifests.extend(e.errors)
+                continue
+
+            nf = f
+            if do_mog:
+                try:
+                    nf, line_buffer = __mog_helper(mog_files, f, m.pathname)
+                except Exception as e:
+                    _rm_temp_raw_files(f, xport_cfg, ignore_errors=True)
+                    abort(err=e)
+
+            # Figure out whether the package is already in
+            # the target repository or not.
+            if republish:
+                # Check whether the fmri already exists in the
+                # target repository.
+                if nf.publisher not in new_targ_cats:
+                    newpub = transport.setup_publisher(
+                        target,
+                        nf.publisher,
+                        dest_xport,
+                        dest_xport_cfg,
+                        ssl_key=dkey,
+                        ssl_cert=dcert,
+                    )
+                    # If no publisher transport
+                    # established. That means it is a
+                    # remote host. set remote prefix
+                    # equal to True.
+                    if not newpub:
+                        newpub = transport.setup_publisher(
+                            target,
+                            nf.publisher,
+                            dest_xport,
+                            dest_xport_cfg,
+                            remote_prefix=True,
+                            ssl_key=dkey,
+                            ssl_cert=dcert,
+                        )
+                    new_targ_pubs[nf.publisher] = newpub
+                    newcat = fetch_catalog(newpub, tracker, dest_xport, True)
+                    new_targ_cats[nf.publisher] = newcat
+                    if newcat.get_entry(nf):
                         tracker.manifest_fetch_progress(completion=True)
-                tracker.manifest_fetch_done()
-                # Next, retrieve and store the content for each package.
-                tracker.republish_set_goal(len(pkgs_to_get), get_bytes,
-                    send_bytes)
+                        continue
+                # If we already have a catalog in the
+                # cache, use it.
+                elif new_targ_cats[nf.publisher].get_entry(nf):
+                    tracker.manifest_fetch_progress(completion=True)
+                    continue
 
-                if verbose:
-                        if not dry_run:
-                                msg(_("\nRetrieving packages ..."))
-                        else:
-                                msg(_("\nRetrieving packages (dry-run) ..."))
-                        status = []
-                        status.append((_("Packages to add:"),
-                            str(len(pkgs_to_get))))
-                        status.append((_("Files to retrieve:"),
-                            str(get_files)))
-                        status.append((_("Estimated transfer size:"),
-                            misc.bytes_to_str(get_bytes)))
+            if do_mog:
+                # We have examined which packge to
+                # republish. Then we need store the
+                # mogrified manifest for future use.
+                try:
+                    # Create mogrified manifest.
+                    # Remove the old raw pkg data first.
+                    _rm_temp_raw_files(f, xport_cfg)
+                    nm = pkg.manifest.FactoredManifest(
+                        nf,
+                        xport_cfg.get_pkg_dir(nf),
+                        contents="\n".join(line_buffer),
+                    )
+                except EnvironmentError as e:
+                    _rm_temp_raw_files(nf, xport_cfg, ignore_errors=True)
+                    raise apx._convert_error(e)
+                except Exception as e:
+                    _rm_temp_raw_files(nf, xport_cfg, ignore_errors=True)
+                    abort(
+                        _("Creating mogrified " "manifest failed: {0}").format(
+                            str(e)
+                        )
+                    )
 
-                        rjust_status = max(len(s[0]) for s in status)
-                        rjust_value = max(len(s[1]) for s in status)
-                        for s in status:
-                                msg("{0} {1}".format(s[0].rjust(rjust_status),
-                                    s[1].rjust(rjust_value)))
+            else:
+                # Use the original manifest if no
+                # mogrify is done.
+                nm = m
 
-                        msg(_("\nPackages to transfer:"))
-                        for f in sorted(pkgs_to_get):
-                                fmri = f.get_fmri(anarchy=True,
-                                    include_scheme=False)
-                                msg("{0}".format(fmri))
-                        msg()
+            getb, getf = get_sizes(nm)[:2]
+            if republish:
+                send_bytes += dest_xport.get_transfer_size(
+                    new_targ_pubs[nf.publisher], nm.gen_actions()
+                )
 
-                if dry_run:
-                        tracker.republish_done(dryrun=True)
-                        cleanup()
+            # Store a mapping between new fmri and new manifest for
+            # future use.
+            fmappings[nf] = nm
+            pkgs_to_get.append(nf)
+
+            get_bytes += getb
+            get_files += getf
+
+            if dry_run:
+                _rm_temp_raw_files(nf, xport_cfg, ignore_errors=True)
+            tracker.manifest_fetch_progress(completion=True)
+        tracker.manifest_fetch_done()
+        # Next, retrieve and store the content for each package.
+        tracker.republish_set_goal(len(pkgs_to_get), get_bytes, send_bytes)
+
+        if verbose:
+            if not dry_run:
+                msg(_("\nRetrieving packages ..."))
+            else:
+                msg(_("\nRetrieving packages (dry-run) ..."))
+            status = []
+            status.append((_("Packages to add:"), str(len(pkgs_to_get))))
+            status.append((_("Files to retrieve:"), str(get_files)))
+            status.append(
+                (_("Estimated transfer size:"), misc.bytes_to_str(get_bytes))
+            )
+
+            rjust_status = max(len(s[0]) for s in status)
+            rjust_value = max(len(s[1]) for s in status)
+            for s in status:
+                msg(
+                    "{0} {1}".format(
+                        s[0].rjust(rjust_status), s[1].rjust(rjust_value)
+                    )
+                )
+
+            msg(_("\nPackages to transfer:"))
+            for f in sorted(pkgs_to_get):
+                fmri = f.get_fmri(anarchy=True, include_scheme=False)
+                msg("{0}".format(fmri))
+            msg()
+
+        if dry_run:
+            tracker.republish_done(dryrun=True)
+            cleanup()
+            continue
+
+        processed = 0
+        uploads = set()
+        pkgs_to_get = sorted(pkgs_to_get)
+        hashes = set()
+        if republish and pkgs_to_get:
+            # If files can be transferred compressed, keep them
+            # compressed in the source.
+            keep_compressed, hashes = dest_xport.get_transfer_info(
+                new_targ_pubs[pkgs_to_get[0].publisher]
+            )
+        for nf in pkgs_to_get:
+            tracker.republish_start_pkg(nf)
+            # Processing republish.
+            nm = fmappings[nf]
+            pkgdir = xport_cfg.get_pkg_dir(nf)
+            mfile = xport.multi_file_ni(
+                src_pub, pkgdir, not keep_compressed, tracker
+            )
+            add_hashes_to_multi(nm, mfile)
+            if mfile:
+                download_start = True
+                mfile.wait_files()
+
+            if not republish:
+                # Nothing more to do for this package.
+                tracker.republish_end_pkg(nf)
+                continue
+
+            use_scheme = True
+            # Check whether to include scheme based on new
+            # manifest.
+            if not any(
+                a.name == "set" and str(a).find("pkg:/") >= 0
+                for a in nm.gen_actions()
+            ):
+                use_scheme = False
+
+            pkg_name = nf.get_fmri(include_scheme=use_scheme)
+
+            # Use the new fmri for constructing a transaction id.
+            # This is needed so any previous failures for a package
+            # can be aborted.
+            trans_id = get_basename(nf)
+            try:
+                t = trans.Transaction(
+                    target,
+                    pkg_name=pkg_name,
+                    trans_id=trans_id,
+                    xport=dest_xport,
+                    pub=new_targ_pubs[nf.publisher],
+                    progtrack=tracker,
+                )
+
+                # Remove any previous failed attempt to
+                # to republish this package.
+                try:
+                    t.close(abandon=True)
+                except:
+                    # It might not exist already.
+                    pass
+
+                t.open()
+                for a in nm.gen_actions():
+                    if a.name == "set" and a.attrs.get("name", "") in (
+                        "fmri",
+                        "pkg.fmri",
+                    ):
+                        # To be consistent with the
+                        # server, the fmri can't be
+                        # added to the manifest.
                         continue
 
-                processed = 0
-                uploads = set()
-                pkgs_to_get = sorted(pkgs_to_get)
-                hashes = set()
-                if republish and pkgs_to_get:
-                        # If files can be transferred compressed, keep them
-                        # compressed in the source.
-                        keep_compressed, hashes = dest_xport.get_transfer_info(
-                            new_targ_pubs[pkgs_to_get[0].publisher])
-                for nf in pkgs_to_get:
-                        tracker.republish_start_pkg(nf)
-                        # Processing republish.
-                        nm = fmappings[nf]
-                        pkgdir = xport_cfg.get_pkg_dir(nf)
-                        mfile = xport.multi_file_ni(src_pub, pkgdir,
-                            not keep_compressed, tracker)
-                        add_hashes_to_multi(nm, mfile)
-                        if mfile:
-                                download_start = True
-                                mfile.wait_files()
+                    fname = None
+                    fhash = None
+                    if a.has_payload:
+                        fhash = a.hash
+                        fname = os.path.join(pkgdir, fhash)
 
-                        if not republish:
-                                # Nothing more to do for this package.
-                                tracker.republish_end_pkg(nf)
-                                continue
+                        a.data = lambda: open(fname, "rb")
 
-                        use_scheme = True
-                        # Check whether to include scheme based on new
-                        # manifest.
-                        if not any(a.name == "set" and str(a).find("pkg:/") >= 0
-                            for a in nm.gen_actions()):
-                                use_scheme = False
+                    if fhash in hashes and fhash not in uploads:
+                        # If the payload will be
+                        # transferred and not have been
+                        # uploaded, upload it...
+                        t.add(a, exact=True, path=fname)
+                        uploads.add(fhash)
+                    else:
+                        # ...otherwise, just add the
+                        # action to the transaction.
+                        t.add(a, exact=True)
 
-                        pkg_name = nf.get_fmri(include_scheme=use_scheme)
+                    if a.name == "signature" and not do_mog:
+                        # We always store content in the
+                        # repository by the least-
+                        # preferred hash.
+                        for fp in a.get_chain_certs(least_preferred=True):
+                            fname = os.path.join(pkgdir, fp)
+                            if keep_compressed:
+                                t.add_file(fname, basename=fp)
+                            else:
+                                t.add_file(fname)
+                # Always defer catalog update.
+                t.close(add_to_catalog=False)
+            except trans.TransactionError as e:
+                abort(err=e)
 
-                        # Use the new fmri for constructing a transaction id.
-                        # This is needed so any previous failures for a package
-                        # can be aborted.
-                        trans_id = get_basename(nf)
-                        try:
-                                t = trans.Transaction(target, pkg_name=pkg_name,
-                                    trans_id=trans_id, xport=dest_xport,
-                                    pub=new_targ_pubs[nf.publisher],
-                                    progtrack=tracker)
+            # Dump data retrieved so far after each successful
+            # republish to conserve space.
+            try:
+                shutil.rmtree(dest_xport_cfg.incoming_root)
+                shutil.rmtree(pkgdir)
+                if cache_dir in tmpdirs:
+                    # If cache_dir is listed in tmpdirs,
+                    # then it's safe to dump cache contents.
+                    # Otherwise, it's a user cache directory
+                    # and shouldn't be dumped.
+                    shutil.rmtree(cache_dir)
+                    misc.makedirs(cache_dir)
+            except EnvironmentError as e:
+                raise apx._convert_error(e)
+            misc.makedirs(dest_xport_cfg.incoming_root)
 
-                                # Remove any previous failed attempt to
-                                # to republish this package.
-                                try:
-                                        t.close(abandon=True)
-                                except:
-                                        # It might not exist already.
-                                        pass
+            processed += 1
+            tracker.republish_end_pkg(nf)
 
-                                t.open()
-                                for a in nm.gen_actions():
-                                        if a.name == "set" and \
-                                            a.attrs.get("name", "") in ("fmri",
-                                            "pkg.fmri"):
-                                                # To be consistent with the
-                                                # server, the fmri can't be
-                                                # added to the manifest.
-                                                continue
+        tracker.republish_done()
+        tracker.reset()
 
-                                        fname = None
-                                        fhash = None
-                                        if a.has_payload:
-                                                fhash = a.hash
-                                                fname = os.path.join(pkgdir,
-                                                    fhash)
+        if processed > 0:
+            # If any packages were published, trigger an update of
+            # the catalog.
+            total_processed += processed
+            dest_xport.publish_refresh_packages(targ_pub)
 
-                                                a.data = lambda: open(fname,
-                                                    "rb")
+        # Prevent further use.
+        targ_pub = None
 
-                                        if fhash in hashes and \
-                                            fhash not in uploads:
-                                                # If the payload will be
-                                                # transferred and not have been
-                                                # uploaded, upload it...
-                                                t.add(a, exact=True, path=fname)
-                                                uploads.add(fhash)
-                                        else:
-                                                # ...otherwise, just add the
-                                                # action to the transaction.
-                                                t.add(a, exact=True)
+    # Check processed patterns and abort with failure if some were
+    # unmatched.
+    check_processed(any_matched, any_unmatched, total_processed)
 
-                                        if a.name == "signature" and \
-                                            not do_mog:
-                                                # We always store content in the
-                                                # repository by the least-
-                                                # preferred hash.
-                                                for fp in a.get_chain_certs(
-                                                    least_preferred=True):
-                                                        fname = os.path.join(
-                                                            pkgdir, fp)
-                                                        if keep_compressed:
-                                                                t.add_file(fname,
-                                                                    basename=fp)
-                                                        else:
-                                                                t.add_file(fname)
-                                # Always defer catalog update.
-                                t.close(add_to_catalog=False)
-                        except trans.TransactionError as e:
-                                abort(err=e)
+    # Dump all temporary data.
+    cleanup()
+    if invalid_manifests:
+        error(
+            _("One or more packages could not be retrieved:\n\n{0}").format(
+                "\n".join(str(im) for im in invalid_manifests)
+            )
+        )
+    if invalid_manifests and total_processed:
+        return pkgdefs.EXIT_PARTIAL
+    if invalid_manifests:
+        return pkgdefs.EXIT_OOPS
+    return pkgdefs.EXIT_OK
 
-                        # Dump data retrieved so far after each successful
-                        # republish to conserve space.
-                        try:
-                                shutil.rmtree(dest_xport_cfg.incoming_root)
-                                shutil.rmtree(pkgdir)
-                                if cache_dir in tmpdirs:
-                                        # If cache_dir is listed in tmpdirs,
-                                        # then it's safe to dump cache contents.
-                                        # Otherwise, it's a user cache directory
-                                        # and shouldn't be dumped.
-                                        shutil.rmtree(cache_dir)
-                                        misc.makedirs(cache_dir)
-                        except EnvironmentError as e:
-                                raise apx._convert_error(e)
-                        misc.makedirs(dest_xport_cfg.incoming_root)
-
-                        processed += 1
-                        tracker.republish_end_pkg(nf)
-
-                tracker.republish_done()
-                tracker.reset()
-
-                if processed > 0:
-                        # If any packages were published, trigger an update of
-                        # the catalog.
-                        total_processed += processed
-                        dest_xport.publish_refresh_packages(targ_pub)
-
-                # Prevent further use.
-                targ_pub = None
-
-        # Check processed patterns and abort with failure if some were
-        # unmatched.
-        check_processed(any_matched, any_unmatched, total_processed)
-
-        # Dump all temporary data.
-        cleanup()
-        if invalid_manifests:
-                error(_("One or more packages could not be retrieved:\n\n{0}").
-                    format("\n".join(str(im) for im in invalid_manifests)))
-        if invalid_manifests and total_processed:
-                return pkgdefs.EXIT_PARTIAL
-        if invalid_manifests:
-                return pkgdefs.EXIT_OOPS
-        return pkgdefs.EXIT_OK
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        # Make all warnings be errors.
-        warnings.simplefilter('error')
-        import six
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
+    # Make all warnings be errors.
+    warnings.simplefilter("error")
+    import six
+
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
+    try:
+        __ret = main_func()
+    except (KeyboardInterrupt, apx.CanceledException):
         try:
-                __ret = main_func()
-        except (KeyboardInterrupt, apx.CanceledException):
-                try:
-                        cleanup(True)
-                except:
-                        __ret = 99
-                else:
-                        __ret = 1
-        except (pkg.actions.ActionError, trans.TransactionError, RuntimeError,
-            apx.ApiException) as _e:
-                error(_e)
-                try:
-                        cleanup(True)
-                except:
-                        __ret = 99
-                else:
-                        __ret = 1
-        except PipeError:
-                # We don't want to display any messages here to prevent
-                # possible further broken pipe (EPIPE) errors.
-                try:
-                        cleanup(False)
-                except:
-                        __ret = 99
-                else:
-                        __ret = 1
-        except SystemExit as _e:
-                try:
-                        cleanup(False)
-                except:
-                        __ret = 99
-                raise _e
-        except EnvironmentError as _e:
-                if _e.errno != errno.ENOSPC and _e.errno != errno.EDQUOT:
-                        error(str(apx._convert_error(_e)))
-                        __ret = 1
-                        sys.exit(__ret)
-
-                txt = "\n"
-                if _e.errno == errno.EDQUOT:
-                        txt += _("Storage space quota exceeded.")
-                else:
-                        txt += _("No storage space left.")
-
-                temp_root_path = misc.get_temp_root_path()
-                tdirs = [temp_root_path]
-                if cache_dir not in tmpdirs:
-                        # Only include in message if user specified.
-                        tdirs.append(cache_dir)
-                if target and target.startswith("file://"):
-                        tdirs.append(target)
-
-                txt += "\n"
-                error(txt + _("Please verify that the filesystem containing "
-                   "the following directories has enough space available:\n"
-                   "{0}").format("\n".join(tdirs)))
-                try:
-                        cleanup()
-                except:
-                        __ret = 99
-                else:
-                        __ret = 1
-        except pkg.fmri.IllegalFmri as _e:
-                error(_e)
-                try:
-                        cleanup()
-                except:
-                        __ret = 99
-                else:
-                        __ret = 1
+            cleanup(True)
         except:
-                traceback.print_exc()
-                error(misc.get_traceback_message())
-                __ret = 99
-                # Cleanup must be called *after* error messaging so that
-                # exceptions processed during cleanup don't cause the wrong
-                # traceback to be printed.
-                try:
-                        cleanup(True)
-                except:
-                        pass
-        sys.exit(__ret)
+            __ret = 99
+        else:
+            __ret = 1
+    except (
+        pkg.actions.ActionError,
+        trans.TransactionError,
+        RuntimeError,
+        apx.ApiException,
+    ) as _e:
+        error(_e)
+        try:
+            cleanup(True)
+        except:
+            __ret = 99
+        else:
+            __ret = 1
+    except PipeError:
+        # We don't want to display any messages here to prevent
+        # possible further broken pipe (EPIPE) errors.
+        try:
+            cleanup(False)
+        except:
+            __ret = 99
+        else:
+            __ret = 1
+    except SystemExit as _e:
+        try:
+            cleanup(False)
+        except:
+            __ret = 99
+        raise _e
+    except EnvironmentError as _e:
+        if _e.errno != errno.ENOSPC and _e.errno != errno.EDQUOT:
+            error(str(apx._convert_error(_e)))
+            __ret = 1
+            sys.exit(__ret)
+
+        txt = "\n"
+        if _e.errno == errno.EDQUOT:
+            txt += _("Storage space quota exceeded.")
+        else:
+            txt += _("No storage space left.")
+
+        temp_root_path = misc.get_temp_root_path()
+        tdirs = [temp_root_path]
+        if cache_dir not in tmpdirs:
+            # Only include in message if user specified.
+            tdirs.append(cache_dir)
+        if target and target.startswith("file://"):
+            tdirs.append(target)
+
+        txt += "\n"
+        error(
+            txt
+            + _(
+                "Please verify that the filesystem containing "
+                "the following directories has enough space available:\n"
+                "{0}"
+            ).format("\n".join(tdirs))
+        )
+        try:
+            cleanup()
+        except:
+            __ret = 99
+        else:
+            __ret = 1
+    except pkg.fmri.IllegalFmri as _e:
+        error(_e)
+        try:
+            cleanup()
+        except:
+            __ret = 99
+        else:
+            __ret = 1
+    except:
+        traceback.print_exc()
+        error(misc.get_traceback_message())
+        __ret = 99
+        # Cleanup must be called *after* error messaging so that
+        # exceptions processed during cleanup don't cause the wrong
+        # traceback to be printed.
+        try:
+            cleanup(True)
+        except:
+            pass
+    sys.exit(__ret)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/setup.py
+++ b/src/setup.py
@@ -64,23 +64,23 @@ import distutils.ccompiler
 from distutils.unixccompiler import UnixCCompiler
 
 osname = platform.uname()[0].lower()
-osname = 'sunos' if osname == 'sunos5' else osname
-ostype = arch = 'unknown'
-if osname == 'sunos':
-        arch = platform.processor()
-        ostype = "posix"
-elif osname == 'linux':
-        arch = "linux_" + platform.machine()
-        ostype = "posix"
-elif osname == 'windows':
-        arch = osname
-        ostype = "windows"
-elif osname == 'darwin':
-        arch = osname
-        ostype = "posix"
-elif osname == 'aix':
-        arch = "aix"
-        ostype = "posix"
+osname = "sunos" if osname == "sunos5" else osname
+ostype = arch = "unknown"
+if osname == "sunos":
+    arch = platform.processor()
+    ostype = "posix"
+elif osname == "linux":
+    arch = "linux_" + platform.machine()
+    ostype = "posix"
+elif osname == "windows":
+    arch = osname
+    ostype = "windows"
+elif osname == "darwin":
+    arch = osname
+    ostype = "posix"
+elif osname == "aix":
+    arch = "aix"
+    ostype = "posix"
 
 pwd = os.path.normpath(sys.path[0])
 
@@ -92,55 +92,61 @@ req_pylint_version = "1.4.3"
 # is properly interleaved with output from this program.
 #
 # Can't have unbuffered text I/O in Python 3. This doesn't quite matter.
-#sys.stdout = os.fdopen(sys.stdout.fileno(), "w", 0)
-#sys.stderr = os.fdopen(sys.stderr.fileno(), "w", 0)
+# sys.stdout = os.fdopen(sys.stdout.fileno(), "w", 0)
+# sys.stderr = os.fdopen(sys.stderr.fileno(), "w", 0)
 
-dist_dir = os.path.normpath(os.path.join(pwd, os.pardir, "proto", "dist_" + arch))
-build_dir = os.path.normpath(os.path.join(pwd, os.pardir, "proto", "build_" + arch))
+dist_dir = os.path.normpath(
+    os.path.join(pwd, os.pardir, "proto", "dist_" + arch)
+)
+build_dir = os.path.normpath(
+    os.path.join(pwd, os.pardir, "proto", "build_" + arch)
+)
 if "ROOT" in os.environ and os.environ["ROOT"] != "":
-        root_dir = os.environ["ROOT"]
+    root_dir = os.environ["ROOT"]
 else:
-        root_dir = os.path.normpath(os.path.join(pwd, os.pardir, "proto", "root_" + arch))
+    root_dir = os.path.normpath(
+        os.path.join(pwd, os.pardir, "proto", "root_" + arch)
+    )
 pkgs_dir = os.path.normpath(os.path.join(pwd, os.pardir, "packages", arch))
 extern_dir = os.path.normpath(os.path.join(pwd, "extern"))
 cffi_dir = os.path.normpath(os.path.join(pwd, "cffi_src"))
 
 # Extract Python minor version.
-py_version = '.'.join(platform.python_version_tuple()[:2])
-assert py_version in ('3.10', '3.11')
-py_install_dir = 'usr/lib/python' + py_version + '/vendor-packages'
+py_version = ".".join(platform.python_version_tuple()[:2])
+assert py_version in ("3.10", "3.11")
+py_install_dir = "usr/lib/python" + py_version + "/vendor-packages"
 
-py64_executable = '/usr/bin/python' + py_version
+py64_executable = "/usr/bin/python" + py_version
 
-scripts_dir = 'usr/bin'
-lib_dir = 'usr/lib'
-svc_method_dir = 'lib/svc/method'
-svc_share_dir = 'lib/svc/share'
+scripts_dir = "usr/bin"
+lib_dir = "usr/lib"
+svc_method_dir = "lib/svc/method"
+svc_share_dir = "lib/svc/share"
 
-man1_dir = 'usr/share/man/man1'
-man8_dir = 'usr/share/man/man8'
-man7_dir = 'usr/share/man/man7'
+man1_dir = "usr/share/man/man1"
+man8_dir = "usr/share/man/man8"
+man7_dir = "usr/share/man/man7"
 
-ignored_deps_dir = 'usr/share/pkg/ignored_deps'
-resource_dir = 'usr/share/lib/pkg'
-transform_dir = 'usr/share/pkg/transforms'
-smf_app_dir = 'lib/svc/manifest/application/pkg'
-execattrd_dir = 'etc/security/exec_attr.d'
-authattrd_dir = 'etc/security/auth_attr.d'
-userattrd_dir = 'etc/user_attr.d'
-sysrepo_dir = 'etc/pkg/sysrepo'
-sysrepo_logs_dir = 'var/log/pkg/sysrepo'
-sysrepo_cache_dir = 'var/cache/pkg/sysrepo'
-autostart_dir = 'etc/xdg/autostart'
-desktop_dir = 'usr/share/applications'
-gconf_dir = 'etc/gconf/schemas'
-depot_dir = 'etc/pkg/depot'
-depot_conf_dir = 'etc/pkg/depot/conf.d'
-depot_logs_dir = 'var/log/pkg/depot'
-depot_cache_dir = 'var/cache/pkg/depot'
-locale_dir = 'usr/share/locale'
-mirror_logs_dir = 'var/log/pkg/mirror'
-mirror_cache_dir = 'var/cache/pkg/mirror'
+ignored_deps_dir = "usr/share/pkg/ignored_deps"
+resource_dir = "usr/share/lib/pkg"
+transform_dir = "usr/share/pkg/transforms"
+smf_app_dir = "lib/svc/manifest/application/pkg"
+execattrd_dir = "etc/security/exec_attr.d"
+authattrd_dir = "etc/security/auth_attr.d"
+userattrd_dir = "etc/user_attr.d"
+sysrepo_dir = "etc/pkg/sysrepo"
+sysrepo_logs_dir = "var/log/pkg/sysrepo"
+sysrepo_cache_dir = "var/cache/pkg/sysrepo"
+autostart_dir = "etc/xdg/autostart"
+desktop_dir = "usr/share/applications"
+gconf_dir = "etc/gconf/schemas"
+depot_dir = "etc/pkg/depot"
+depot_conf_dir = "etc/pkg/depot/conf.d"
+depot_logs_dir = "var/log/pkg/depot"
+depot_cache_dir = "var/cache/pkg/depot"
+locale_dir = "usr/share/locale"
+mirror_logs_dir = "var/log/pkg/mirror"
+mirror_cache_dir = "var/cache/pkg/mirror"
 
 
 # A list of source, destination tuples of modules which should be hardlinked
@@ -148,910 +154,960 @@ mirror_cache_dir = 'var/cache/pkg/mirror'
 hardlink_modules = []
 
 scripts_sunos = {
-        scripts_dir: [
-                ['client.py', 'pkg'],
-                ['pkgdep.py', 'pkgdepend'],
-                ['pkgrepo.py', 'pkgrepo'],
-                ['util/publish/pkgdiff.py', 'pkgdiff'],
-                ['util/publish/pkgfmt.py', 'pkgfmt'],
-                ['util/publish/pkglint.py', 'pkglint'],
-                ['util/publish/pkgmerge.py', 'pkgmerge'],
-                ['util/publish/pkgmogrify.py', 'pkgmogrify'],
-                ['util/publish/pkgsurf.py', 'pkgsurf'],
-                ['publish.py', 'pkgsend'],
-                ['pull.py', 'pkgrecv'],
-                ['sign.py', 'pkgsign'],
-                ],
-        lib_dir: [
-                ['depot.py', 'pkg.depotd'],
-                #['sysrepo.py', 'pkg.sysrepo'],
-                #['depot-config.py', "pkg.depot-config"]
-                ],
-        svc_method_dir: [
-                #['svc/svc-pkg-depot', 'svc-pkg-depot'],
-                ['svc/svc-pkg-mdns', 'svc-pkg-mdns'],
-                ['svc/svc-pkg-mirror', 'svc-pkg-mirror'],
-                ['svc/svc-pkg-repositories-setup',
-                    'svc-pkg-repositories-setup'],
-                ['svc/svc-pkg-server', 'svc-pkg-server'],
-                #['svc/svc-pkg-sysrepo', 'svc-pkg-sysrepo'],
-                ],
-        svc_share_dir: [
-                ['svc/pkg5_include.sh', 'pkg5_include.sh'],
-                ],
-        }
+    scripts_dir: [
+        ["client.py", "pkg"],
+        ["pkgdep.py", "pkgdepend"],
+        ["pkgrepo.py", "pkgrepo"],
+        ["util/publish/pkgdiff.py", "pkgdiff"],
+        ["util/publish/pkgfmt.py", "pkgfmt"],
+        ["util/publish/pkglint.py", "pkglint"],
+        ["util/publish/pkgmerge.py", "pkgmerge"],
+        ["util/publish/pkgmogrify.py", "pkgmogrify"],
+        ["util/publish/pkgsurf.py", "pkgsurf"],
+        ["publish.py", "pkgsend"],
+        ["pull.py", "pkgrecv"],
+        ["sign.py", "pkgsign"],
+    ],
+    lib_dir: [
+        ["depot.py", "pkg.depotd"],
+        # ['sysrepo.py', 'pkg.sysrepo'],
+        # ['depot-config.py', "pkg.depot-config"]
+    ],
+    svc_method_dir: [
+        # ['svc/svc-pkg-depot', 'svc-pkg-depot'],
+        ["svc/svc-pkg-mdns", "svc-pkg-mdns"],
+        ["svc/svc-pkg-mirror", "svc-pkg-mirror"],
+        ["svc/svc-pkg-repositories-setup", "svc-pkg-repositories-setup"],
+        ["svc/svc-pkg-server", "svc-pkg-server"],
+        # ['svc/svc-pkg-sysrepo', 'svc-pkg-sysrepo'],
+    ],
+    svc_share_dir: [
+        ["svc/pkg5_include.sh", "pkg5_include.sh"],
+    ],
+}
 
 scripts_windows = {
-        scripts_dir: [
-                ['client.py', 'client.py'],
-                ['pkgrepo.py', 'pkgrepo.py'],
-                ['publish.py', 'publish.py'],
-                ['pull.py', 'pull.py'],
-                ['scripts/pkg.bat', 'pkg.bat'],
-                ['scripts/pkgsend.bat', 'pkgsend.bat'],
-                ['scripts/pkgrecv.bat', 'pkgrecv.bat'],
-                ],
-        lib_dir: [
-                ['depot.py', 'depot.py'],
-                ['scripts/pkg.depotd.bat', 'pkg.depotd.bat'],
-                ],
-        }
+    scripts_dir: [
+        ["client.py", "client.py"],
+        ["pkgrepo.py", "pkgrepo.py"],
+        ["publish.py", "publish.py"],
+        ["pull.py", "pull.py"],
+        ["scripts/pkg.bat", "pkg.bat"],
+        ["scripts/pkgsend.bat", "pkgsend.bat"],
+        ["scripts/pkgrecv.bat", "pkgrecv.bat"],
+    ],
+    lib_dir: [
+        ["depot.py", "depot.py"],
+        ["scripts/pkg.depotd.bat", "pkg.depotd.bat"],
+    ],
+}
 
 scripts_other_unix = {
-        scripts_dir: [
-                ['client.py', 'client.py'],
-                ['pkgdep.py', 'pkgdep'],
-                ['util/publish/pkgdiff.py', 'pkgdiff'],
-                ['util/publish/pkgfmt.py', 'pkgfmt'],
-                ['util/publish/pkgmogrify.py', 'pkgmogrify'],
-                ['pull.py', 'pull.py'],
-                ['publish.py', 'publish.py'],
-                ['scripts/pkg.sh', 'pkg'],
-                ['scripts/pkgsend.sh', 'pkgsend'],
-                ['scripts/pkgrecv.sh', 'pkgrecv'],
-                ],
-        lib_dir: [
-                ['depot.py', 'depot.py'],
-                ['scripts/pkg.depotd.sh', 'pkg.depotd'],
-                ],
-        }
+    scripts_dir: [
+        ["client.py", "client.py"],
+        ["pkgdep.py", "pkgdep"],
+        ["util/publish/pkgdiff.py", "pkgdiff"],
+        ["util/publish/pkgfmt.py", "pkgfmt"],
+        ["util/publish/pkgmogrify.py", "pkgmogrify"],
+        ["pull.py", "pull.py"],
+        ["publish.py", "publish.py"],
+        ["scripts/pkg.sh", "pkg"],
+        ["scripts/pkgsend.sh", "pkgsend"],
+        ["scripts/pkgrecv.sh", "pkgrecv"],
+    ],
+    lib_dir: [
+        ["depot.py", "depot.py"],
+        ["scripts/pkg.depotd.sh", "pkg.depotd"],
+    ],
+}
 
 # indexed by 'osname'
 scripts = {
-        "sunos": scripts_sunos,
-        "linux": scripts_other_unix,
-        "windows": scripts_windows,
-        "darwin": scripts_other_unix,
-        "aix" : scripts_other_unix,
-        "unknown": scripts_sunos,
-        }
+    "sunos": scripts_sunos,
+    "linux": scripts_other_unix,
+    "windows": scripts_windows,
+    "darwin": scripts_other_unix,
+    "aix": scripts_other_unix,
+    "unknown": scripts_sunos,
+}
 
 man1_files = [
-        'man/pkg.1',
-        'man/pkgdepend.1',
-        'man/pkgdiff.1',
-        'man/pkgfmt.1',
-        'man/pkglint.1',
-        'man/pkgmerge.1',
-        'man/pkgmogrify.1',
-        'man/pkgsend.1',
-        'man/pkgsign.1',
-        'man/pkgsurf.1',
-        'man/pkgrecv.1',
-        'man/pkgrepo.1',
-        ]
+    "man/pkg.1",
+    "man/pkgdepend.1",
+    "man/pkgdiff.1",
+    "man/pkgfmt.1",
+    "man/pkglint.1",
+    "man/pkgmerge.1",
+    "man/pkgmogrify.1",
+    "man/pkgsend.1",
+    "man/pkgsign.1",
+    "man/pkgsurf.1",
+    "man/pkgrecv.1",
+    "man/pkgrepo.1",
+]
 man8_files = [
-        'man/pkg.depotd.8',
-        #'man/pkg.depot-config.8',
-        #'man/pkg.sysrepo.8'
-        ]
+    "man/pkg.depotd.8",
+    #'man/pkg.depot-config.8',
+    #'man/pkg.sysrepo.8'
+]
 man7_files = [
-        'man/bhyve.7',
-        'man/emu.7',
-        'man/illumos.7',
-        'man/ipkg.7',
-        'man/kvm.7',
-        'man/lipkg.7',
-        'man/lx.7',
-        'man/pkgsrc.7',
-        'man/pkg.7',
-        'man/sparse.7',
-        ]
+    "man/bhyve.7",
+    "man/emu.7",
+    "man/illumos.7",
+    "man/ipkg.7",
+    "man/kvm.7",
+    "man/lipkg.7",
+    "man/lx.7",
+    "man/pkgsrc.7",
+    "man/pkg.7",
+    "man/sparse.7",
+]
 
 packages = [
-        'pkg',
-        'pkg.actions',
-        'pkg.bundle',
-        'pkg.client',
-        'pkg.client.linkedimage',
-        'pkg.client.transport',
-        'pkg.file_layout',
-        'pkg.flavor',
-        'pkg.lint',
-        'pkg.site_paths',
-        'pkg.portable',
-        'pkg.publish',
-        'pkg.server'
-        ]
+    "pkg",
+    "pkg.actions",
+    "pkg.bundle",
+    "pkg.client",
+    "pkg.client.linkedimage",
+    "pkg.client.transport",
+    "pkg.file_layout",
+    "pkg.flavor",
+    "pkg.lint",
+    "pkg.site_paths",
+    "pkg.portable",
+    "pkg.publish",
+    "pkg.server",
+]
 
 pylint_targets = [
-        'pkg.altroot',
-        'pkg.client.__init__',
-        'pkg.client.api',
-        'pkg.client.linkedimage',
-        'pkg.client.pkg_solver',
-        'pkg.client.pkgdefs',
-        'pkg.client.pkgremote',
-        'pkg.client.plandesc',
-        'pkg.client.printengine',
-        'pkg.client.progress',
-        'pkg.misc',
-        'pkg.pipeutils',
-        ]
+    "pkg.altroot",
+    "pkg.client.__init__",
+    "pkg.client.api",
+    "pkg.client.linkedimage",
+    "pkg.client.pkg_solver",
+    "pkg.client.pkgdefs",
+    "pkg.client.pkgremote",
+    "pkg.client.plandesc",
+    "pkg.client.printengine",
+    "pkg.client.progress",
+    "pkg.misc",
+    "pkg.pipeutils",
+]
 
 web_files = []
 for entry in os.walk("web"):
-        web_dir, dirs, files = entry
-        if not files:
-                continue
-        web_files.append((os.path.join(resource_dir, web_dir), [
-            os.path.join(web_dir, f) for f in files
-            if f != "Makefile"
-            ]))
+    web_dir, dirs, files = entry
+    if not files:
+        continue
+    web_files.append(
+        (
+            os.path.join(resource_dir, web_dir),
+            [os.path.join(web_dir, f) for f in files if f != "Makefile"],
+        )
+    )
 
 # The bandit configuration file does not support an
 # exclude or exclude_dir operation (bandit bug 499).
-bandit_exclude_files = [
-        '*/tests/*'
-        ]
+bandit_exclude_files = ["*/tests/*"]
 smf_app_files = [
-        #'svc/pkg-depot.xml',
-        'svc/pkg-mdns.xml',
-        'svc/pkg-mirror.xml',
-        'svc/pkg-repositories-setup.xml',
-        'svc/pkg-server.xml',
-        #'svc/pkg-system-repository.xml',
-        #'svc/zoneproxy-client.xml',
-        #'svc/zoneproxyd.xml'
-        ]
+    #'svc/pkg-depot.xml',
+    "svc/pkg-mdns.xml",
+    "svc/pkg-mirror.xml",
+    "svc/pkg-repositories-setup.xml",
+    "svc/pkg-server.xml",
+    #'svc/pkg-system-repository.xml',
+    #'svc/zoneproxy-client.xml',
+    #'svc/zoneproxyd.xml'
+]
 resource_files = [
-        'util/opensolaris.org.sections',
-        'util/pkglintrc',
-        ]
+    "util/opensolaris.org.sections",
+    "util/pkglintrc",
+]
 transform_files = [
-        'util/publish/transforms/developer',
-        'util/publish/transforms/documentation',
-        'util/publish/transforms/locale',
-        'util/publish/transforms/smf-manifests'
-        ]
+    "util/publish/transforms/developer",
+    "util/publish/transforms/documentation",
+    "util/publish/transforms/locale",
+    "util/publish/transforms/smf-manifests",
+]
 sysrepo_files = [
-        'util/apache2/sysrepo/sysrepo_p5p.py',
-        'util/apache2/sysrepo/sysrepo_httpd.conf.mako',
-        'util/apache2/sysrepo/sysrepo_publisher_response.mako',
-        ]
+    "util/apache2/sysrepo/sysrepo_p5p.py",
+    "util/apache2/sysrepo/sysrepo_httpd.conf.mako",
+    "util/apache2/sysrepo/sysrepo_publisher_response.mako",
+]
 sysrepo_log_stubs = [
-        'util/apache2/sysrepo/logs/access_log',
-        'util/apache2/sysrepo/logs/error_log'
-        ]
+    "util/apache2/sysrepo/logs/access_log",
+    "util/apache2/sysrepo/logs/error_log",
+]
 depot_files = [
-        'util/apache2/depot/depot.conf.mako',
-        'util/apache2/depot/depot_httpd.conf.mako',
-        'util/apache2/depot/depot_index.py',
-        'util/apache2/depot/depot_httpd_ssl_protocol.conf',
-        ]
+    "util/apache2/depot/depot.conf.mako",
+    "util/apache2/depot/depot_httpd.conf.mako",
+    "util/apache2/depot/depot_index.py",
+    "util/apache2/depot/depot_httpd_ssl_protocol.conf",
+]
 depot_log_stubs = [
-        'util/apache2/depot/logs/access_log',
-        'util/apache2/depot/logs/error_log'
-        ]
+    "util/apache2/depot/logs/access_log",
+    "util/apache2/depot/logs/error_log",
+]
 ignored_deps_files = []
 
 execattrd_files = [
-        'util/misc/exec_attr.d/package:pkg',
+    "util/misc/exec_attr.d/package:pkg",
 ]
-authattrd_files = ['util/misc/auth_attr.d/package:pkg']
-userattrd_files = ['util/misc/user_attr.d/package:pkg']
-pkg_locales = \
-    'ar ca cs de es fr he hu id it ja ko nl pl pt_BR ru sk sv zh_CN zh_HK zh_TW'.split()
+authattrd_files = ["util/misc/auth_attr.d/package:pkg"]
+userattrd_files = ["util/misc/user_attr.d/package:pkg"]
+pkg_locales = "ar ca cs de es fr he hu id it ja ko nl pl pt_BR ru sk sv zh_CN zh_HK zh_TW".split()
 
-sha512_t_srcs = [
-        'cffi_src/_sha512_t.c'
-        ]
-sysattr_srcs = [
-        'cffi_src/_sysattr.c'
-        ]
-syscallat_srcs = [
-        'cffi_src/_syscallat.c'
-        ]
-pspawn_srcs = [
-        'cffi_src/_pspawn.c'
-        ]
+sha512_t_srcs = ["cffi_src/_sha512_t.c"]
+sysattr_srcs = ["cffi_src/_sysattr.c"]
+syscallat_srcs = ["cffi_src/_syscallat.c"]
+pspawn_srcs = ["cffi_src/_pspawn.c"]
 elf_srcs = [
-        'modules/elf.c',
-        'modules/elfextract.c',
-        'modules/liblist.c',
-        ]
-arch_srcs = [
-        'cffi_src/_arch.c'
-        ]
-_actions_srcs = [
-        'modules/actions/_actions.c'
-        ]
-_actcomm_srcs = [
-        'modules/actions/_common.c'
-        ]
-_varcet_srcs = [
-        'modules/_varcet.c'
-        ]
-solver_srcs = [
-        'modules/solver/solver.c',
-        'modules/solver/py_solver.c'
-        ]
+    "modules/elf.c",
+    "modules/elfextract.c",
+    "modules/liblist.c",
+]
+arch_srcs = ["cffi_src/_arch.c"]
+_actions_srcs = ["modules/actions/_actions.c"]
+_actcomm_srcs = ["modules/actions/_common.c"]
+_varcet_srcs = ["modules/_varcet.c"]
+solver_srcs = ["modules/solver/solver.c", "modules/solver/py_solver.c"]
 solver_link_args = ["-lm", "-lc"]
-if osname == 'sunos':
-        solver_link_args = ["-ztext"] + solver_link_args
+if osname == "sunos":
+    solver_link_args = ["-ztext"] + solver_link_args
+
 
 # Runs lint on the extension module source code
 class pylint_func(Command):
-        description = "Runs pylint tools over IPS python source code"
-        user_options = []
+    description = "Runs pylint tools over IPS python source code"
+    user_options = []
 
-        def initialize_options(self):
-                pass
+    def initialize_options(self):
+        pass
 
-        def finalize_options(self):
-                pass
+    def finalize_options(self):
+        pass
 
-        # Make string shell-friendly
-        @staticmethod
-        def escape(astring):
-                return astring.replace(' ', '\\ ')
+    # Make string shell-friendly
+    @staticmethod
+    def escape(astring):
+        return astring.replace(" ", "\\ ")
 
-        def run(self, quiet=False, py3k=False):
+    def run(self, quiet=False, py3k=False):
+        def supported_pylint_ver(version):
+            """Compare the installed version against the version
+            we require to build with, returning False if the version
+            is too old. It's tempting to use pkg.version.Version
+            here, but since that's a build artifact, we'll do it
+            the long way."""
+            inst_pylint_ver = version.split(".")
+            req_pylint_ver = req_pylint_version.split(".")
 
-                def supported_pylint_ver(version):
-                        """Compare the installed version against the version
-                        we require to build with, returning False if the version
-                        is too old. It's tempting to use pkg.version.Version
-                        here, but since that's a build artifact, we'll do it
-                        the long way."""
-                        inst_pylint_ver = version.split(".")
-                        req_pylint_ver = req_pylint_version.split(".")
-
-                        # if the lists are of different lengths, we just
-                        # compare with the precision we have.
-                        vers_comp = zip(inst_pylint_ver, req_pylint_ver)
-                        for inst, req in vers_comp:
-                                try:
-                                        if int(inst) < int(req):
-                                                return False
-                                        elif int(inst) > int(req):
-                                                return True
-                                except ValueError:
-                                        # if we somehow get non-numeric version
-                                        # components, we ignore them.
-                                        continue
+            # if the lists are of different lengths, we just
+            # compare with the precision we have.
+            vers_comp = zip(inst_pylint_ver, req_pylint_ver)
+            for inst, req in vers_comp:
+                try:
+                    if int(inst) < int(req):
+                        return False
+                    elif int(inst) > int(req):
                         return True
+                except ValueError:
+                    # if we somehow get non-numeric version
+                    # components, we ignore them.
+                    continue
+            return True
 
-                # it's fine to default to the required version - the build will
-                # break if the installed version is incompatible and $PYLINT_VER
-                # didn't get set, somehow.
-                pylint_ver_str = os.environ.get("PYLINT_VER",
-                    req_pylint_version)
-                if pylint_ver_str == "":
-                        pylint_ver_str = req_pylint_version
+        # it's fine to default to the required version - the build will
+        # break if the installed version is incompatible and $PYLINT_VER
+        # didn't get set, somehow.
+        pylint_ver_str = os.environ.get("PYLINT_VER", req_pylint_version)
+        if pylint_ver_str == "":
+            pylint_ver_str = req_pylint_version
 
-                if os.environ.get("PKG_SKIP_PYLINT"):
-                        log.warn("WARNING: skipping pylint checks: "
-                            "$PKG_SKIP_PYLINT was set")
-                        return
-                elif not pylint_ver_str or \
-                    not supported_pylint_ver(pylint_ver_str):
-                        log.warn("WARNING: skipping pylint checks: the "
-                            "installed version {0} is older than version {1}".format(
-                            pylint_ver_str, req_pylint_version))
-                        return
+        if os.environ.get("PKG_SKIP_PYLINT"):
+            log.warn(
+                "WARNING: skipping pylint checks: " "$PKG_SKIP_PYLINT was set"
+            )
+            return
+        elif not pylint_ver_str or not supported_pylint_ver(pylint_ver_str):
+            log.warn(
+                "WARNING: skipping pylint checks: the "
+                "installed version {0} is older than version {1}".format(
+                    pylint_ver_str, req_pylint_version
+                )
+            )
+            return
 
-                proto = os.path.join(root_dir, py_install_dir)
-                sys.path.insert(0, proto)
+        proto = os.path.join(root_dir, py_install_dir)
+        sys.path.insert(0, proto)
 
+        # Insert tests directory onto sys.path so any custom checkers
+        # can be found.
+        sys.path.insert(0, os.path.join(pwd, "tests"))
+        # assumes pylint is accessible on the sys.path
+        from pylint import lint
 
-                # Insert tests directory onto sys.path so any custom checkers
-                # can be found.
-                sys.path.insert(0, os.path.join(pwd, 'tests'))
-                # assumes pylint is accessible on the sys.path
-                from pylint import lint
-
-                #
-                # Unfortunately, pylint seems pretty fragile and will crash if
-                # we try to run it over all the current pkg source.  Hence for
-                # now we only run it over a subset of the source.  As source
-                # files are made pylint clean they should be added to the
-                # pylint_targets list.
-                #
-                if not py3k:
-                        args = []
-                        if quiet:
-                                args += ['--reports=no']
-                        args += ['--rcfile={0}'.format(os.path.join(
-                            pwd, 'tests', 'pylintrc'))]
-                        args += pylint_targets
-                        lint.Run(args)
-                else:
-                        #
-                        # In Python 3 porting mode, all checkers will be
-                        # disabled and only messages emitted by the porting
-                        # checker will be displayed. Therefore we need to run
-                        # this checker separately.
-                        #
-                        args = []
-                        if quiet:
-                                args += ['--reports=no']
-                        args += ['--rcfile={0}'.format(os.path.join(
-                            pwd, 'tests', 'pylintrc_py3k'))]
-                        # We check all Python files in the gate.
-                        for root, dirs, files in os.walk(pwd):
-                                for f in files:
-                                    if f.endswith(".py"):
-                                            args += [os.path.join(root, f)]
-                        lint.Run(args)
+        #
+        # Unfortunately, pylint seems pretty fragile and will crash if
+        # we try to run it over all the current pkg source.  Hence for
+        # now we only run it over a subset of the source.  As source
+        # files are made pylint clean they should be added to the
+        # pylint_targets list.
+        #
+        if not py3k:
+            args = []
+            if quiet:
+                args += ["--reports=no"]
+            args += [
+                "--rcfile={0}".format(os.path.join(pwd, "tests", "pylintrc"))
+            ]
+            args += pylint_targets
+            lint.Run(args)
+        else:
+            #
+            # In Python 3 porting mode, all checkers will be
+            # disabled and only messages emitted by the porting
+            # checker will be displayed. Therefore we need to run
+            # this checker separately.
+            #
+            args = []
+            if quiet:
+                args += ["--reports=no"]
+            args += [
+                "--rcfile={0}".format(
+                    os.path.join(pwd, "tests", "pylintrc_py3k")
+                )
+            ]
+            # We check all Python files in the gate.
+            for root, dirs, files in os.walk(pwd):
+                for f in files:
+                    if f.endswith(".py"):
+                        args += [os.path.join(root, f)]
+            lint.Run(args)
 
 
 class pylint_func_quiet(pylint_func):
+    def run(self, quiet=False):
+        pylint_func.run(self, quiet=True)
 
-        def run(self, quiet=False):
-                pylint_func.run(self, quiet=True)
 
 class pylint_func_py3k(pylint_func):
-        def run(self, quiet=False, py3k=False):
-                pylint_func.run(self, py3k=True)
+    def run(self, quiet=False, py3k=False):
+        pylint_func.run(self, py3k=True)
 
-include_dirs = [ 'modules' ]
-lint_flags = [ '-u', '-axms', '-erroff=E_NAME_DEF_NOT_USED2' ]
+
+include_dirs = ["modules"]
+lint_flags = ["-u", "-axms", "-erroff=E_NAME_DEF_NOT_USED2"]
+
 
 # Runs lint on the extension module source code
 class clint_func(Command):
-        description = "Runs lint tools over IPS C extension source code"
-        user_options = []
+    description = "Runs lint tools over IPS C extension source code"
+    user_options = []
 
-        def initialize_options(self):
-                pass
+    def initialize_options(self):
+        pass
 
-        def finalize_options(self):
-                pass
+    def finalize_options(self):
+        pass
 
-        # Make string shell-friendly
-        @staticmethod
-        def escape(astring):
-                return astring.replace(' ', '\\ ')
+    # Make string shell-friendly
+    @staticmethod
+    def escape(astring):
+        return astring.replace(" ", "\\ ")
 
-        def run(self):
-                if "LINT" in os.environ and os.environ["LINT"] != "":
-                        lint = [os.environ["LINT"]]
-                else:
-                        lint = ['lint']
-                if osname == 'sunos' or osname == "linux":
-                        archcmd = lint + lint_flags + \
-                            ['-D_FILE_OFFSET_BITS=64'] + \
-                            ["{0}{1}".format("-I", k) for k in include_dirs] + \
-                            ['-I' + self.escape(get_python_inc())] + \
-                            arch_srcs
-                        elfcmd = lint + lint_flags + \
-                            ["{0}{1}".format("-I", k) for k in include_dirs] + \
-                            ['-I' + self.escape(get_python_inc())] + \
-                            ["{0}{1}".format("-l", k) for k in elf_libraries] + \
-                            elf_srcs
-                        _actionscmd = lint + lint_flags + \
-                            ["{0}{1}".format("-I", k) for k in include_dirs] + \
-                            ['-I' + self.escape(get_python_inc())] + \
-                            _actions_srcs
-                        _actcommcmd = lint + lint_flags + \
-                            ["{0}{1}".format("-I", k) for k in include_dirs] + \
-                            ['-I' + self.escape(get_python_inc())] + \
-                            _actcomm_srcs
-                        _varcetcmd = lint + lint_flags + \
-                            ["{0}{1}".format("-I", k) for k in include_dirs] + \
-                            ['-I' + self.escape(get_python_inc())] + \
-                            _varcet_srcs
-                        pspawncmd = lint + lint_flags + \
-                            ['-D_FILE_OFFSET_BITS=64'] + \
-                            ["{0}{1}".format("-I", k) for k in include_dirs] + \
-                            ['-I' + self.escape(get_python_inc())] + \
-                            pspawn_srcs
-                        syscallatcmd = lint + lint_flags + \
-                            ['-D_FILE_OFFSET_BITS=64'] + \
-                            ["{0}{1}".format("-I", k) for k in include_dirs] + \
-                            ['-I' + self.escape(get_python_inc())] + \
-                            syscallat_srcs
-                        sysattrcmd = lint + lint_flags + \
-                            ['-D_FILE_OFFSET_BITS=64'] + \
-                            ["{0}{1}".format("-I", k) for k in include_dirs] + \
-                            ['-I' + self.escape(get_python_inc())] + \
-                            ["{0}{1}".format("-l", k) for k in sysattr_libraries] + \
-                            sysattr_srcs
-                        sha512_tcmd = lint + lint_flags + \
-                            ['-D_FILE_OFFSET_BITS=64'] + \
-                            ["{0}{1}".format("-I", k) for k in include_dirs] + \
-                            ['-I' + self.escape(get_python_inc())] + \
-                            ["{0}{1}".format("-l", k) for k in sha512_t_libraries] + \
-                            sha512_t_srcs
+    def run(self):
+        if "LINT" in os.environ and os.environ["LINT"] != "":
+            lint = [os.environ["LINT"]]
+        else:
+            lint = ["lint"]
+        if osname == "sunos" or osname == "linux":
+            archcmd = (
+                lint
+                + lint_flags
+                + ["-D_FILE_OFFSET_BITS=64"]
+                + ["{0}{1}".format("-I", k) for k in include_dirs]
+                + ["-I" + self.escape(get_python_inc())]
+                + arch_srcs
+            )
+            elfcmd = (
+                lint
+                + lint_flags
+                + ["{0}{1}".format("-I", k) for k in include_dirs]
+                + ["-I" + self.escape(get_python_inc())]
+                + ["{0}{1}".format("-l", k) for k in elf_libraries]
+                + elf_srcs
+            )
+            _actionscmd = (
+                lint
+                + lint_flags
+                + ["{0}{1}".format("-I", k) for k in include_dirs]
+                + ["-I" + self.escape(get_python_inc())]
+                + _actions_srcs
+            )
+            _actcommcmd = (
+                lint
+                + lint_flags
+                + ["{0}{1}".format("-I", k) for k in include_dirs]
+                + ["-I" + self.escape(get_python_inc())]
+                + _actcomm_srcs
+            )
+            _varcetcmd = (
+                lint
+                + lint_flags
+                + ["{0}{1}".format("-I", k) for k in include_dirs]
+                + ["-I" + self.escape(get_python_inc())]
+                + _varcet_srcs
+            )
+            pspawncmd = (
+                lint
+                + lint_flags
+                + ["-D_FILE_OFFSET_BITS=64"]
+                + ["{0}{1}".format("-I", k) for k in include_dirs]
+                + ["-I" + self.escape(get_python_inc())]
+                + pspawn_srcs
+            )
+            syscallatcmd = (
+                lint
+                + lint_flags
+                + ["-D_FILE_OFFSET_BITS=64"]
+                + ["{0}{1}".format("-I", k) for k in include_dirs]
+                + ["-I" + self.escape(get_python_inc())]
+                + syscallat_srcs
+            )
+            sysattrcmd = (
+                lint
+                + lint_flags
+                + ["-D_FILE_OFFSET_BITS=64"]
+                + ["{0}{1}".format("-I", k) for k in include_dirs]
+                + ["-I" + self.escape(get_python_inc())]
+                + ["{0}{1}".format("-l", k) for k in sysattr_libraries]
+                + sysattr_srcs
+            )
+            sha512_tcmd = (
+                lint
+                + lint_flags
+                + ["-D_FILE_OFFSET_BITS=64"]
+                + ["{0}{1}".format("-I", k) for k in include_dirs]
+                + ["-I" + self.escape(get_python_inc())]
+                + ["{0}{1}".format("-l", k) for k in sha512_t_libraries]
+                + sha512_t_srcs
+            )
 
-                        print(" ".join(archcmd))
-                        os.system(" ".join(archcmd))
-                        print(" ".join(elfcmd))
-                        os.system(" ".join(elfcmd))
-                        print(" ".join(_actionscmd))
-                        os.system(" ".join(_actionscmd))
-                        print(" ".join(_actcommcmd))
-                        os.system(" ".join(_actcommcmd))
-                        print(" ".join(_varcetcmd))
-                        os.system(" ".join(_varcetcmd))
-                        print(" ".join(pspawncmd))
-                        os.system(" ".join(pspawncmd))
-                        print(" ".join(syscallatcmd))
-                        os.system(" ".join(syscallatcmd))
-                        print(" ".join(sysattrcmd))
-                        os.system(" ".join(sysattrcmd))
-                        print(" ".join(sha512_tcmd))
-                        os.system(" ".join(sha512_tcmd))
+            print(" ".join(archcmd))
+            os.system(" ".join(archcmd))
+            print(" ".join(elfcmd))
+            os.system(" ".join(elfcmd))
+            print(" ".join(_actionscmd))
+            os.system(" ".join(_actionscmd))
+            print(" ".join(_actcommcmd))
+            os.system(" ".join(_actcommcmd))
+            print(" ".join(_varcetcmd))
+            os.system(" ".join(_varcetcmd))
+            print(" ".join(pspawncmd))
+            os.system(" ".join(pspawncmd))
+            print(" ".join(syscallatcmd))
+            os.system(" ".join(syscallatcmd))
+            print(" ".join(sysattrcmd))
+            os.system(" ".join(sysattrcmd))
+            print(" ".join(sha512_tcmd))
+            os.system(" ".join(sha512_tcmd))
+
 
 class smflint_func(Command):
-        description = "Validate SMF manifests"
-        user_options = []
+    description = "Validate SMF manifests"
+    user_options = []
 
-        def initialize_options(self):
-                pass
+    def initialize_options(self):
+        pass
 
-        def finalize_options(self):
-                pass
+    def finalize_options(self):
+        pass
 
-        def run(self):
-            for manifest in smf_app_files:
-                args = [ "/usr/sbin/svccfg", "validate", manifest ]
-                print(f"SMF manifest validate: {manifest}")
-                run_cmd(args, os.getcwd())
+    def run(self):
+        for manifest in smf_app_files:
+            args = ["/usr/sbin/svccfg", "validate", manifest]
+            print(f"SMF manifest validate: {manifest}")
+            run_cmd(args, os.getcwd())
+
 
 class bandit_func(Command):
-        """ Run bandit over the source code. setup.py bandit -g
-            will generate a new baseline.
-        """
-        description = "Run Bandit over the source code"
-        user_options = [
-                ("genbaseline", 'g', "generate a bandit baseline")
-                       ]
+    """Run bandit over the source code. setup.py bandit -g
+    will generate a new baseline.
+    """
 
-        def initialize_options(self):
-                self.genbaseline = False
-                pass
+    description = "Run Bandit over the source code"
+    user_options = [("genbaseline", "g", "generate a bandit baseline")]
 
-        def finalize_options(self):
-                pass
+    def initialize_options(self):
+        self.genbaseline = False
+        pass
 
-        def run(self):
-                rcfile = os.path.join(pwd, "tests", "banditrc")
-                # The bandit exclude directive does not work in the
-                # rcfile (bandit bug: 499).
-                excludes = ",".join(bandit_exclude_files)
-                # Use the local directory so that the location of
-                # the workspace does not matter.
-                args = ["/usr/bin/bandit", "-r", "-q", "-c", rcfile,
-                        "-x", excludes, "." ]
-                # A note about bandit baselines: bandit will report
-                # new errors but it will not fail on a new duplicate
-                # issues (bandit bugs: 466 and 558)
-                if self.genbaseline:
-                        args.extend(["-o", "tests/bandit-baseline.json",
-                                     "-f", "json"])
-                else:
-                        args.extend(["-b", "tests/bandit-baseline.json"])
-                # When generating a baseline, if there are warnings/errors
-                # bandit will exit with a value of 1.
-                run_cmd(args, os.getcwd())
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        rcfile = os.path.join(pwd, "tests", "banditrc")
+        # The bandit exclude directive does not work in the
+        # rcfile (bandit bug: 499).
+        excludes = ",".join(bandit_exclude_files)
+        # Use the local directory so that the location of
+        # the workspace does not matter.
+        args = [
+            "/usr/bin/bandit",
+            "-r",
+            "-q",
+            "-c",
+            rcfile,
+            "-x",
+            excludes,
+            ".",
+        ]
+        # A note about bandit baselines: bandit will report
+        # new errors but it will not fail on a new duplicate
+        # issues (bandit bugs: 466 and 558)
+        if self.genbaseline:
+            args.extend(["-o", "tests/bandit-baseline.json", "-f", "json"])
+        else:
+            args.extend(["-b", "tests/bandit-baseline.json"])
+        # When generating a baseline, if there are warnings/errors
+        # bandit will exit with a value of 1.
+        run_cmd(args, os.getcwd())
+
 
 # Runs both C and Python lint
 class lint_func(Command):
-        description = "Runs C and Python lint checkers"
-        user_options = []
+    description = "Runs C and Python lint checkers"
+    user_options = []
 
-        def initialize_options(self):
-                pass
+    def initialize_options(self):
+        pass
 
-        def finalize_options(self):
-                pass
+    def finalize_options(self):
+        pass
 
-        # Make string shell-friendly
-        @staticmethod
-        def escape(astring):
-                return astring.replace(' ', '\\ ')
+    # Make string shell-friendly
+    @staticmethod
+    def escape(astring):
+        return astring.replace(" ", "\\ ")
 
-        def run(self):
-                smflint_func(Distribution()).run()
-                clint_func(Distribution()).run()
-                pylint_func(Distribution()).run()
+    def run(self):
+        smflint_func(Distribution()).run()
+        clint_func(Distribution()).run()
+        pylint_func(Distribution()).run()
+
 
 class install_func(_install):
-        def initialize_options(self):
-                _install.initialize_options(self)
+    def initialize_options(self):
+        _install.initialize_options(self)
 
-                # PRIVATE_BUILD set in the environment tells us to put the build
-                # directory into the .pyc files, rather than the final
-                # installation directory.
-                private_build = os.getenv("PRIVATE_BUILD", None)
+        # PRIVATE_BUILD set in the environment tells us to put the build
+        # directory into the .pyc files, rather than the final
+        # installation directory.
+        private_build = os.getenv("PRIVATE_BUILD", None)
 
-                if private_build is None:
-                        self.install_lib = py_install_dir
-                        self.install_data = os.path.sep
-                        self.root = root_dir
-                else:
-                        self.install_lib = os.path.join(root_dir, py_install_dir)
-                        self.install_data = root_dir
+        if private_build is None:
+            self.install_lib = py_install_dir
+            self.install_data = os.path.sep
+            self.root = root_dir
+        else:
+            self.install_lib = os.path.join(root_dir, py_install_dir)
+            self.install_data = root_dir
 
-                # This is used when installing scripts, below, but it isn't a
-                # standard distutils variable.
-                self.root_dir = root_dir
+        # This is used when installing scripts, below, but it isn't a
+        # standard distutils variable.
+        self.root_dir = root_dir
 
-        def run(self):
-                """At the end of the install function, we need to rename some
-                files because distutils provides no way to rename files as they
-                are placed in their install locations.
-                """
-
-                _install.run(self)
-                for o_src, o_dest in hardlink_modules:
-                        for e in [".py", ".pyc"]:
-                                src = util.change_root(self.root_dir, o_src + e)
-                                dest = util.change_root(
-                                    self.root_dir, o_dest + e)
-                                if ostype == "posix":
-                                        if os.path.exists(dest) and \
-                                            os.stat(src)[stat.ST_INO] != \
-                                            os.stat(dest)[stat.ST_INO]:
-                                                os.remove(dest)
-                                        file_util.copy_file(src, dest,
-                                            link="hard", update=1)
-                                else:
-                                        file_util.copy_file(src, dest, update=1)
-
-                for d, files in scripts[osname].items():
-                        for (srcname, dstname) in files:
-                                dst_dir = util.change_root(self.root_dir, d)
-                                dst_path = util.change_root(self.root_dir,
-                                       os.path.join(d, dstname))
-                                dir_util.mkpath(dst_dir, verbose=True)
-                                file_util.copy_file(srcname, dst_path,
-                                    update=True)
-                                # make scripts executable
-                                os.chmod(dst_path,
-                                    os.stat(dst_path).st_mode
-                                    | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-
-class install_lib_func(_install_lib):
-        """Remove the target files prior to the standard install_lib procedure
-        if the build_py module has determined that they've actually changed.
-        This may be needed when a module's timestamp goes backwards in time, if
-        a working-directory change is reverted, or an older changeset is checked
-        out.
+    def run(self):
+        """At the end of the install function, we need to rename some
+        files because distutils provides no way to rename files as they
+        are placed in their install locations.
         """
 
-        def install(self):
-                build_py = self.get_finalized_command("build_py")
-                prefix_len = len(self.build_dir) + 1
-                for p in build_py.copied:
-                        id_p = os.path.join(self.install_dir, p[prefix_len:])
-                        rm_f(id_p)
-                        if self.compile:
-                                rm_f(id_p + "c")
-                        if self.optimize > 0:
-                                rm_f(id_p + "o")
-                return _install_lib.install(self)
+        _install.run(self)
+        for o_src, o_dest in hardlink_modules:
+            for e in [".py", ".pyc"]:
+                src = util.change_root(self.root_dir, o_src + e)
+                dest = util.change_root(self.root_dir, o_dest + e)
+                if ostype == "posix":
+                    if (
+                        os.path.exists(dest)
+                        and os.stat(src)[stat.ST_INO]
+                        != os.stat(dest)[stat.ST_INO]
+                    ):
+                        os.remove(dest)
+                    file_util.copy_file(src, dest, link="hard", update=1)
+                else:
+                    file_util.copy_file(src, dest, update=1)
+
+        for d, files in scripts[osname].items():
+            for srcname, dstname in files:
+                dst_dir = util.change_root(self.root_dir, d)
+                dst_path = util.change_root(
+                    self.root_dir, os.path.join(d, dstname)
+                )
+                dir_util.mkpath(dst_dir, verbose=True)
+                file_util.copy_file(srcname, dst_path, update=True)
+                # make scripts executable
+                os.chmod(
+                    dst_path,
+                    os.stat(dst_path).st_mode
+                    | stat.S_IXUSR
+                    | stat.S_IXGRP
+                    | stat.S_IXOTH,
+                )
+
+
+class install_lib_func(_install_lib):
+    """Remove the target files prior to the standard install_lib procedure
+    if the build_py module has determined that they've actually changed.
+    This may be needed when a module's timestamp goes backwards in time, if
+    a working-directory change is reverted, or an older changeset is checked
+    out.
+    """
+
+    def install(self):
+        build_py = self.get_finalized_command("build_py")
+        prefix_len = len(self.build_dir) + 1
+        for p in build_py.copied:
+            id_p = os.path.join(self.install_dir, p[prefix_len:])
+            rm_f(id_p)
+            if self.compile:
+                rm_f(id_p + "c")
+            if self.optimize > 0:
+                rm_f(id_p + "o")
+        return _install_lib.install(self)
+
 
 class install_data_func(_install_data):
-        """Enhance the standard install_data subcommand to take not only a list
-        of filenames, but a list of source and destination filename tuples, for
-        the cases where a filename needs to be renamed between the two
-        locations."""
+    """Enhance the standard install_data subcommand to take not only a list
+    of filenames, but a list of source and destination filename tuples, for
+    the cases where a filename needs to be renamed between the two
+    locations."""
 
-        def run(self):
-                self.mkpath(self.install_dir)
-                for f in self.data_files:
-                        dir, files = f
-                        dir = util.convert_path(dir)
-                        if not os.path.isabs(dir):
-                                dir = os.path.join(self.install_dir, dir)
-                        elif self.root:
-                                dir = change_root(self.root, dir)
-                        self.mkpath(dir)
+    def run(self):
+        self.mkpath(self.install_dir)
+        for f in self.data_files:
+            dir, files = f
+            dir = util.convert_path(dir)
+            if not os.path.isabs(dir):
+                dir = os.path.join(self.install_dir, dir)
+            elif self.root:
+                dir = change_root(self.root, dir)
+            self.mkpath(dir)
 
-                        if not files:
-                                self.outfiles.append(dir)
-                        else:
-                                for file in files:
-                                        if isinstance(file, str):
-                                                infile = file
-                                                outfile = os.path.join(dir,
-                                                    os.path.basename(file))
-                                        else:
-                                                infile, outfile = file
-                                        infile = util.convert_path(infile)
-                                        outfile = util.convert_path(outfile)
-                                        if os.path.sep not in outfile:
-                                                outfile = os.path.join(dir,
-                                                    outfile)
-                                        self.copy_file(infile, outfile)
-                                        self.outfiles.append(outfile)
+            if not files:
+                self.outfiles.append(dir)
+            else:
+                for file in files:
+                    if isinstance(file, str):
+                        infile = file
+                        outfile = os.path.join(dir, os.path.basename(file))
+                    else:
+                        infile, outfile = file
+                    infile = util.convert_path(infile)
+                    outfile = util.convert_path(outfile)
+                    if os.path.sep not in outfile:
+                        outfile = os.path.join(dir, outfile)
+                    self.copy_file(infile, outfile)
+                    self.outfiles.append(outfile)
+
 
 def run_cmd(args, swdir, updenv=None, ignerr=False, savestderr=None):
-                if updenv:
-                        # use temp environment modified with the given dict
-                        env = os.environ.copy()
-                        env.update(updenv)
-                else:
-                        # just use environment of this (parent) process as is
-                        env = os.environ
-                if ignerr:
-                        # send stderr to devnull
-                        stderr = open(os.devnull)
-                elif savestderr:
-                        stderr = savestderr
-                else:
-                        # just use stderr of this (parent) process
-                        stderr = None
-                ret = subprocess.Popen(args, cwd=swdir, env=env,
-                    stderr=stderr).wait()
-                if ret != 0:
-                        if stderr:
-                            stderr.close()
-                        print("install failed and returned {0:d}.".format(ret),
-                            file=sys.stderr)
-                        print("Command was: {0}".format(" ".join(args)),
-                            file=sys.stderr)
+    if updenv:
+        # use temp environment modified with the given dict
+        env = os.environ.copy()
+        env.update(updenv)
+    else:
+        # just use environment of this (parent) process as is
+        env = os.environ
+    if ignerr:
+        # send stderr to devnull
+        stderr = open(os.devnull)
+    elif savestderr:
+        stderr = savestderr
+    else:
+        # just use stderr of this (parent) process
+        stderr = None
+    ret = subprocess.Popen(args, cwd=swdir, env=env, stderr=stderr).wait()
+    if ret != 0:
+        if stderr:
+            stderr.close()
+        print("install failed and returned {0:d}.".format(ret), file=sys.stderr)
+        print("Command was: {0}".format(" ".join(args)), file=sys.stderr)
 
-                        sys.exit(1)
-                if stderr:
-                        stderr.close()
+        sys.exit(1)
+    if stderr:
+        stderr.close()
 
-def _copy_file_contents(src, dst, buffer_size=16*1024):
-        """A clone of distutils.file_util._copy_file_contents() that modifies
-        python files as they are installed."""
 
-        # Look for shebang line to replace with arch-specific Python executable.
-        shebang_re = re.compile(r'^#!.*/python[0-9][.0-9]*')
+def _copy_file_contents(src, dst, buffer_size=16 * 1024):
+    """A clone of distutils.file_util._copy_file_contents() that modifies
+    python files as they are installed."""
 
-        if not src.endswith(".py"):
-                shutil.copyfile(src, dst)
-                return
+    # Look for shebang line to replace with arch-specific Python executable.
+    shebang_re = re.compile(r"^#!.*/python[0-9][.0-9]*")
 
-        do_shebang = True
+    if not src.endswith(".py"):
+        shutil.copyfile(src, dst)
+        return
 
-        with open(src, "r") as sfp:
-                try:
-                        os.unlink(dst)
-                except EnvironmentError as e:
-                        if e.errno != errno.ENOENT:
-                                raise DistutilsFileError("could not delete "
-                                    "'{0}': {1}".format(dst, e))
+    do_shebang = True
 
-                with open(dst, "w") as dfp:
-                        while True:
-                                buf = sfp.read(buffer_size)
-                                if not buf:
-                                        break
-                                if do_shebang:
-                                        fl = buf[:buf.find(os.linesep)]
-                                        if shebang_re.search(fl):
-                                                buf = shebang_re.sub(
-                                                    "#!" + py64_executable,
-                                                    buf)
-                                        do_shebang = False
-                                dfp.write(buf)
+    with open(src, "r") as sfp:
+        try:
+            os.unlink(dst)
+        except EnvironmentError as e:
+            if e.errno != errno.ENOENT:
+                raise DistutilsFileError(
+                    "could not delete " "'{0}': {1}".format(dst, e)
+                )
+
+        with open(dst, "w") as dfp:
+            while True:
+                buf = sfp.read(buffer_size)
+                if not buf:
+                    break
+                if do_shebang:
+                    fl = buf[: buf.find(os.linesep)]
+                    if shebang_re.search(fl):
+                        buf = shebang_re.sub("#!" + py64_executable, buf)
+                    do_shebang = False
+                dfp.write(buf)
+
 
 # Make file_util use our version of _copy_file_contents
 file_util._copy_file_contents = _copy_file_contents
 
+
 def intltool_update_maintain():
-        """Check if scope of localization looks up-to-date or possibly not,
-        by comparing file set described in po/POTFILES.{in,skip} and
-        actual source files (e.g. .py) detected.
-        """
-        rm_f("po/missing")
-        rm_f("po/notexist")
+    """Check if scope of localization looks up-to-date or possibly not,
+    by comparing file set described in po/POTFILES.{in,skip} and
+    actual source files (e.g. .py) detected.
+    """
+    rm_f("po/missing")
+    rm_f("po/notexist")
 
-        args = [
-            "/usr/bin/intltool-update", "--maintain"
-        ]
-        print(" ".join(args))
-        podir = os.path.join(os.getcwd(), "po")
-        run_cmd(args, podir, updenv={"LC_ALL": "C"}, ignerr=True)
+    args = ["/usr/bin/intltool-update", "--maintain"]
+    print(" ".join(args))
+    podir = os.path.join(os.getcwd(), "po")
+    run_cmd(args, podir, updenv={"LC_ALL": "C"}, ignerr=True)
 
-        if os.path.exists("po/missing"):
-            print("New file(s) with translatable strings detected:",
-                file=sys.stderr)
-            missing = open("po/missing", "r")
-            print("--------", file=sys.stderr)
-            for fn in missing:
-                print("{0}".format(fn.strip()), file=sys.stderr)
-            print("--------", file=sys.stderr)
-            missing.close()
-            print("""\
+    if os.path.exists("po/missing"):
+        print(
+            "New file(s) with translatable strings detected:", file=sys.stderr
+        )
+        missing = open("po/missing", "r")
+        print("--------", file=sys.stderr)
+        for fn in missing:
+            print("{0}".format(fn.strip()), file=sys.stderr)
+        print("--------", file=sys.stderr)
+        missing.close()
+        print(
+            """\
 Please evaluate whether any of the above file(s) needs localization.
 If so, please add its name to po/POTFILES.in.  If not (e.g., it's not
 delivered), please add its name to po/POTFILES.skip.
-Please be sure to maintain alphabetical ordering in both files.""", file=sys.stderr)
-            sys.exit(1)
+Please be sure to maintain alphabetical ordering in both files.""",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
-        if os.path.exists("po/notexist"):
-            print("""\
+    if os.path.exists("po/notexist"):
+        print(
+            """\
 The following files are listed in po/POTFILES.in, but no longer exist
-in the workspace:""", file=sys.stderr)
-            notexist = open("po/notexist", "r")
-            print("--------", file=sys.stderr)
-            for fn in notexist:
-                print("{0}".format(fn.strip()), file=sys.stderr)
-            print("--------", file=sys.stderr)
+in the workspace:""",
+            file=sys.stderr,
+        )
+        notexist = open("po/notexist", "r")
+        print("--------", file=sys.stderr)
+        for fn in notexist:
+            print("{0}".format(fn.strip()), file=sys.stderr)
+        print("--------", file=sys.stderr)
 
-            notexist.close()
-            print("Please remove the file names from po/POTFILES.in",
-                file=sys.stderr)
-            sys.exit(1)
+        notexist.close()
+        print(
+            "Please remove the file names from po/POTFILES.in", file=sys.stderr
+        )
+        sys.exit(1)
+
 
 def intltool_update_pot():
-        """Generate pkg.pot by extracting localizable strings from source
-        files (e.g. .py)
-        """
-        rm_f("po/pkg.pot")
-        open("configure.in", "w").close()
+    """Generate pkg.pot by extracting localizable strings from source
+    files (e.g. .py)
+    """
+    rm_f("po/pkg.pot")
+    open("configure.in", "w").close()
 
-        args = [
-            "/usr/bin/intltool-update", "--pot"
-        ]
-        print(" ".join(args))
-        podir = os.path.join(os.getcwd(), "po")
-        run_cmd(args, podir,
-            updenv={"LC_ALL": "C", "XGETTEXT": "/usr/gnu/bin/xgettext"})
+    args = ["/usr/bin/intltool-update", "--pot"]
+    print(" ".join(args))
+    podir = os.path.join(os.getcwd(), "po")
+    run_cmd(
+        args, podir, updenv={"LC_ALL": "C", "XGETTEXT": "/usr/gnu/bin/xgettext"}
+    )
 
-        rm_f("configure.in")
+    rm_f("configure.in")
 
-        if not os.path.exists("po/pkg.pot"):
-            print("Failed in generating pkg.pot.", file=sys.stderr)
-            sys.exit(1)
+    if not os.path.exists("po/pkg.pot"):
+        print("Failed in generating pkg.pot.", file=sys.stderr)
+        sys.exit(1)
+
 
 def intltool_merge(src, dst):
-        if not dep_util.newer(src, dst):
-                return
+    if not dep_util.newer(src, dst):
+        return
 
-        args = [
-            "/usr/bin/intltool-merge", "-d", "-u",
-            "-c", "po/.intltool-merge-cache", "po", src, dst
-        ]
-        print(" ".join(args))
-        run_cmd(args, os.getcwd(), updenv={"LC_ALL": "C"})
+    args = [
+        "/usr/bin/intltool-merge",
+        "-d",
+        "-u",
+        "-c",
+        "po/.intltool-merge-cache",
+        "po",
+        src,
+        dst,
+    ]
+    print(" ".join(args))
+    run_cmd(args, os.getcwd(), updenv={"LC_ALL": "C"})
+
 
 def i18n_check():
-        """Checks for common i18n messaging bugs in the source."""
+    """Checks for common i18n messaging bugs in the source."""
 
-        src_files = []
-        # A list of the i18n errors we check for in the code
-        common_i18n_errors = [
-            # This checks that messages with multiple parameters are always
-            # written using "{name}" format, rather than just "{0}"
-            "format string with unnamed arguments cannot be properly localized"
-        ]
+    src_files = []
+    # A list of the i18n errors we check for in the code
+    common_i18n_errors = [
+        # This checks that messages with multiple parameters are always
+        # written using "{name}" format, rather than just "{0}"
+        "format string with unnamed arguments cannot be properly localized"
+    ]
 
-        for line in open("po/POTFILES.in", "r").readlines():
-                if line.startswith("["):
-                        continue
-                if line.startswith("#"):
-                        continue
-                src_files.append(line.rstrip())
+    for line in open("po/POTFILES.in", "r").readlines():
+        if line.startswith("["):
+            continue
+        if line.startswith("#"):
+            continue
+        src_files.append(line.rstrip())
 
-        args = [
-            "/usr/gnu/bin/xgettext", "--from-code=UTF-8", "-o", "/dev/null"]
-        args += src_files
+    args = ["/usr/gnu/bin/xgettext", "--from-code=UTF-8", "-o", "/dev/null"]
+    args += src_files
 
-        xgettext_output_path = tempfile.mkstemp()[1]
-        xgettext_output = open(xgettext_output_path, "w")
-        run_cmd(args, os.getcwd(), updenv={"LC_ALL": "C"},
-            savestderr=xgettext_output)
+    xgettext_output_path = tempfile.mkstemp()[1]
+    xgettext_output = open(xgettext_output_path, "w")
+    run_cmd(
+        args, os.getcwd(), updenv={"LC_ALL": "C"}, savestderr=xgettext_output
+    )
 
-        found_errs = False
-        i18n_errs = open("po/i18n_errs.txt", "w")
-        for line in open(xgettext_output_path, "r").readlines():
-                for err in common_i18n_errors:
-                        if err in line:
-                                i18n_errs.write(line)
-                                found_errs = True
-        i18n_errs.close()
-        if found_errs:
-                print("""\
+    found_errs = False
+    i18n_errs = open("po/i18n_errs.txt", "w")
+    for line in open(xgettext_output_path, "r").readlines():
+        for err in common_i18n_errors:
+            if err in line:
+                i18n_errs.write(line)
+                found_errs = True
+    i18n_errs.close()
+    if found_errs:
+        print(
+            """\
 The following i18n errors were detected and should be corrected:
 (this list is saved in po/i18n_errs.txt)
-""", file=sys.stderr)
-                for line in open("po/i18n_errs.txt", "r"):
-                        print(line.rstrip(), file=sys.stderr)
-                sys.exit(1)
-        os.remove(xgettext_output_path)
+""",
+            file=sys.stderr,
+        )
+        for line in open("po/i18n_errs.txt", "r"):
+            print(line.rstrip(), file=sys.stderr)
+        sys.exit(1)
+    os.remove(xgettext_output_path)
+
 
 def msgfmt(src, dst):
-        if not dep_util.newer(src, dst):
-                return
+    if not dep_util.newer(src, dst):
+        return
 
-        args = ["/usr/bin/msgfmt", "-o", dst, src]
-        print(" ".join(args))
-        run_cmd(args, os.getcwd())
+    args = ["/usr/bin/msgfmt", "-o", dst, src]
+    print(" ".join(args))
+    run_cmd(args, os.getcwd())
+
 
 class installfile(Command):
-        user_options = [
-            ("file=", "f", "source file to copy"),
-            ("dest=", "d", "destination directory"),
-            ("mode=", "m", "file mode"),
-        ]
+    user_options = [
+        ("file=", "f", "source file to copy"),
+        ("dest=", "d", "destination directory"),
+        ("mode=", "m", "file mode"),
+    ]
 
-        description = "Modifying file copy"
+    description = "Modifying file copy"
 
-        def initialize_options(self):
-                self.file = None
-                self.dest = None
-                self.mode = None
+    def initialize_options(self):
+        self.file = None
+        self.dest = None
+        self.mode = None
 
-        def finalize_options(self):
-                if self.mode is None:
-                        self.mode = 0o644
-                elif isinstance(self.mode, str):
-                        try:
-                                self.mode = int(self.mode, 8)
-                        except ValueError:
-                                self.mode = 0o644
+    def finalize_options(self):
+        if self.mode is None:
+            self.mode = 0o644
+        elif isinstance(self.mode, str):
+            try:
+                self.mode = int(self.mode, 8)
+            except ValueError:
+                self.mode = 0o644
 
-        def run(self):
-                dest_file = os.path.join(self.dest, os.path.basename(self.file))
-                ret = self.copy_file(self.file, dest_file)
+    def run(self):
+        dest_file = os.path.join(self.dest, os.path.basename(self.file))
+        ret = self.copy_file(self.file, dest_file)
 
-                os.chmod(dest_file, self.mode)
-                os.utime(dest_file, None)
+        os.chmod(dest_file, self.mode)
+        os.utime(dest_file, None)
 
-                return ret
+        return ret
+
 
 class build_func(_build):
-        sub_commands = _build.sub_commands + [('build_data', None)]
+    sub_commands = _build.sub_commands + [("build_data", None)]
 
-        def initialize_options(self):
-                _build.initialize_options(self)
-                self.build_base = build_dir
+    def initialize_options(self):
+        _build.initialize_options(self)
+        self.build_base = build_dir
+
 
 def get_git_version():
-        try:
-                p = subprocess.Popen(
-                    ['git', 'show', '--format=%h', '--no-patch'],
-                    stdout = subprocess.PIPE)
-                return p.communicate()[0].strip().decode('utf-8', 'strict')
+    try:
+        p = subprocess.Popen(
+            ["git", "show", "--format=%h", "--no-patch"], stdout=subprocess.PIPE
+        )
+        return p.communicate()[0].strip().decode("utf-8", "strict")
 
-        except OSError:
-                print("ERROR: unable to obtain git commit hash",
-                    file=sys.stderr)
-                return "unknown"
+    except OSError:
+        print("ERROR: unable to obtain git commit hash", file=sys.stderr)
+        return "unknown"
+
 
 def syntax_check(filename):
-        """ Run python's compiler over the file, and discard the results.
-            Arrange to generate an exception if the file does not compile.
-            This is needed because distutil's own use of pycompile (in the
-            distutils.utils module) is broken, and doesn't stop on error. """
-        try:
-                tmpfd, tmp_file = tempfile.mkstemp()
-                py_compile.compile(filename, tmp_file, doraise=True)
-        except py_compile.PyCompileError as e:
-                res = ""
-                for err in e.exc_value:
-                        if isinstance(err, str):
-                                res += err + "\n"
-                                continue
+    """Run python's compiler over the file, and discard the results.
+    Arrange to generate an exception if the file does not compile.
+    This is needed because distutil's own use of pycompile (in the
+    distutils.utils module) is broken, and doesn't stop on error."""
+    try:
+        tmpfd, tmp_file = tempfile.mkstemp()
+        py_compile.compile(filename, tmp_file, doraise=True)
+    except py_compile.PyCompileError as e:
+        res = ""
+        for err in e.exc_value:
+            if isinstance(err, str):
+                res += err + "\n"
+                continue
 
-                        # Assume it's a tuple of (filename, lineno, col, code)
-                        fname, line, col, code = err
-                        res += "line {0:d}, column {1}, in {2}:\n{3}".format(
-                            line, col or "unknown", fname, code)
+            # Assume it's a tuple of (filename, lineno, col, code)
+            fname, line, col, code = err
+            res += "line {0:d}, column {1}, in {2}:\n{3}".format(
+                line, col or "unknown", fname, code
+            )
 
-                raise DistutilsError(res)
-        finally:
-                os.remove(tmp_file)
+        raise DistutilsError(res)
+    finally:
+        os.remove(tmp_file)
+
 
 # On Solaris, ld inserts the full argument to the -o option into the symbol
 # table.  This means that the resulting object will be different depending on
@@ -1070,584 +1126,616 @@ def syntax_check(filename):
 # new_compiler() gets to be very simple, since we always know what we want to
 # return.
 class MyUnixCCompiler(UnixCCompiler):
+    def link(self, *args, **kwargs):
+        output_filename = args[2]
+        output_dir = kwargs.get("output_dir")
+        cwd = os.getcwd()
 
-        def link(self, *args, **kwargs):
+        assert not output_dir
+        output_dir = os.path.join(cwd, os.path.dirname(output_filename))
+        output_filename = os.path.basename(output_filename)
+        nargs = args[:2] + (output_filename,) + args[3:]
+        if not os.path.exists(output_dir):
+            os.mkdir(output_dir, 0o755)
+        os.chdir(output_dir)
 
-                output_filename = args[2]
-                output_dir = kwargs.get('output_dir')
-                cwd = os.getcwd()
+        UnixCCompiler.link(self, *nargs, **kwargs)
 
-                assert(not output_dir)
-                output_dir = os.path.join(cwd, os.path.dirname(output_filename))
-                output_filename = os.path.basename(output_filename)
-                nargs = args[:2] + (output_filename,) + args[3:]
-                if not os.path.exists(output_dir):
-                        os.mkdir(output_dir, 0o755)
-                os.chdir(output_dir)
+        os.chdir(cwd)
 
-                UnixCCompiler.link(self, *nargs, **kwargs)
 
-                os.chdir(cwd)
-
-distutils.ccompiler.compiler_class['myunix'] = (
-    'unixccompiler', 'MyUnixCCompiler',
-    'standard Unix-style compiler with a link stage modified for Solaris'
+distutils.ccompiler.compiler_class["myunix"] = (
+    "unixccompiler",
+    "MyUnixCCompiler",
+    "standard Unix-style compiler with a link stage modified for Solaris",
 )
 
-def my_new_compiler(plat=None, compiler=None, verbose=0, dry_run=0, force=0):
-        return MyUnixCCompiler(None, dry_run, force)
 
-if osname == 'sunos':
-        distutils.ccompiler.new_compiler = my_new_compiler
+def my_new_compiler(plat=None, compiler=None, verbose=0, dry_run=0, force=0):
+    return MyUnixCCompiler(None, dry_run, force)
+
+
+if osname == "sunos":
+    distutils.ccompiler.new_compiler = my_new_compiler
+
 
 class build_ext_func(_build_ext):
+    def initialize_options(self):
+        _build_ext.initialize_options(self)
+        self.build64 = False
 
-        def initialize_options(self):
-                _build_ext.initialize_options(self)
-                self.build64 = False
+        if osname == "sunos":
+            self.compiler = "myunix"
 
-                if osname == 'sunos':
-                        self.compiler = 'myunix'
+    def build_extension(self, ext):
+        # Build 32-bit
+        self.build_temp = str(self.build_temp)
+        _build_ext.build_extension(self, ext)
+        if not ext.build_64:
+            return
 
-        def build_extension(self, ext):
-                # Build 32-bit
-                self.build_temp = str(self.build_temp)
-                _build_ext.build_extension(self, ext)
-                if not ext.build_64:
-                        return
+        # Set up for 64-bit
+        old_build_temp = self.build_temp
+        d, f = os.path.split(self.build_temp)
 
-                # Set up for 64-bit
-                old_build_temp = self.build_temp
-                d, f = os.path.split(self.build_temp)
+        # store our 64-bit extensions elsewhere
+        self.build_temp = str(
+            d
+            + "/temp64.{0}".format(
+                os.path.basename(self.build_temp).replace("temp.", "")
+            )
+        )
+        ext.extra_compile_args += ["-m64"]
+        ext.extra_link_args += ["-m64"]
+        self.build64 = True
 
-                # store our 64-bit extensions elsewhere
-                self.build_temp = str(d + "/temp64.{0}".format(
-                    os.path.basename(self.build_temp).replace("temp.", "")))
-                ext.extra_compile_args += ["-m64"]
-                ext.extra_link_args += ["-m64"]
-                self.build64 = True
+        # Build 64-bit
+        _build_ext.build_extension(self, ext)
 
-                # Build 64-bit
-                _build_ext.build_extension(self, ext)
+        # Reset to 32-bit
+        self.build_temp = str(old_build_temp)
+        ext.extra_compile_args.remove("-m64")
+        ext.extra_link_args.remove("-m64")
+        self.build64 = False
 
-                # Reset to 32-bit
-                self.build_temp = str(old_build_temp)
-                ext.extra_compile_args.remove("-m64")
-                ext.extra_link_args.remove("-m64")
-                self.build64 = False
+    def get_ext_fullpath(self, ext_name):
+        path = _build_ext.get_ext_fullpath(self, ext_name)
+        if not self.build64:
+            return path
 
-        def get_ext_fullpath(self, ext_name):
-                path = _build_ext.get_ext_fullpath(self, ext_name)
-                if not self.build64:
-                        return path
-
-                dpath, fpath = os.path.split(path)
-                if py_version < '3.0':
-                        return os.path.join(dpath, "64", fpath)
-                return os.path.join(dpath, fpath)
+        dpath, fpath = os.path.split(path)
+        if py_version < "3.0":
+            return os.path.join(dpath, "64", fpath)
+        return os.path.join(dpath, fpath)
 
 
 class build_py_func(_build_py):
+    def __init__(self, dist):
+        ret = _build_py.__init__(self, dist)
 
-        def __init__(self, dist):
-                ret = _build_py.__init__(self, dist)
+        self.copied = []
 
-                self.copied = []
+        # Gather the timestamps of the .py files in the gate, so we can
+        # force the mtimes of the built and delivered copies to be
+        # consistent across builds, causing their corresponding .pyc
+        # files to be unchanged unless the .py file content changed.
 
-                # Gather the timestamps of the .py files in the gate, so we can
-                # force the mtimes of the built and delivered copies to be
-                # consistent across builds, causing their corresponding .pyc
-                # files to be unchanged unless the .py file content changed.
+        print("Gathering file timestamps from git history")
 
-                print("Gathering file timestamps from git history")
+        self.timestamps = {}
 
-                self.timestamps = {}
+        pydates = "pydates.git"
 
-                pydates = "pydates.git"
+        p = subprocess.Popen(os.path.join(pwd, pydates), stdout=subprocess.PIPE)
 
-                p = subprocess.Popen(
-                    os.path.join(pwd, pydates),
-                    stdout=subprocess.PIPE)
+        for line in p.stdout:
+            stamp, path = line.split()
+            stamp = float(stamp)
+            self.timestamps[path] = stamp
 
-                for line in p.stdout:
-                        stamp, path = line.split()
-                        stamp = float(stamp)
-                        self.timestamps[path] = stamp
+        if p.wait() != 0:
+            print("ERROR: unable to gather .py timestamps", file=sys.stderr)
+            sys.exit(1)
 
-                if p.wait() != 0:
-                        print("ERROR: unable to gather .py timestamps",
-                            file=sys.stderr)
-                        sys.exit(1)
+        # Before building extensions, we need to generate .c files
+        # for the C extension modules by running the CFFI build
+        # script files.
+        for path in os.listdir(cffi_dir):
+            if not path.startswith("build_"):
+                continue
+            path = os.path.join(cffi_dir, path)
+            # make scripts executable
+            os.chmod(
+                path,
+                os.stat(path).st_mode
+                | stat.S_IXUSR
+                | stat.S_IXGRP
+                | stat.S_IXOTH,
+            )
 
-                # Before building extensions, we need to generate .c files
-                # for the C extension modules by running the CFFI build
-                # script files.
-                for path in os.listdir(cffi_dir):
-                        if not path.startswith("build_"):
-                                continue
-                        path = os.path.join(cffi_dir, path)
-                        # make scripts executable
-                        os.chmod(path,
-                            os.stat(path).st_mode
-                            | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            # run the scripts
+            p = subprocess.Popen([sys.executable, path])
 
-                        # run the scripts
-                        p = subprocess.Popen(
-                            [sys.executable, path])
+        return ret
 
-                return ret
+    # override the build_module method to do VERSION substitution on
+    # pkg/__init__.py
+    def build_module(self, module, module_file, package):
+        if module == "__init__" and package == "pkg":
+            versionre = '(?m)^VERSION[^"]*"([^"]*)"'
+            # Grab the previously-built version out of the build
+            # tree.
+            try:
+                ocontent = open(
+                    self.get_module_outfile(self.build_lib, [package], module)
+                ).read()
+                ov = re.search(versionre, ocontent).group(1)
+            except (IOError, AttributeError):
+                ov = None
+            v = get_git_version()
+            vstr = 'VERSION = "{0}"'.format(v)
+            # If the versions haven't changed, there's no need to
+            # recompile.
+            if v == ov:
+                return
 
-        # override the build_module method to do VERSION substitution on
-        # pkg/__init__.py
-        def build_module (self, module, module_file, package):
+            with open(module_file) as f:
+                mcontent = f.read()
+                mcontent = re.sub(versionre, vstr, mcontent)
+                tmpfd, tmp_file = tempfile.mkstemp()
+                with open(tmp_file, "w") as wf:
+                    wf.write(mcontent)
+            print("doing version substitution: ", v)
+            rv = _build_py.build_module(self, module, tmp_file, str(package))
+            os.unlink(tmp_file)
+            return rv
 
-                if module == "__init__" and package == "pkg":
-                        versionre = '(?m)^VERSION[^"]*"([^"]*)"'
-                        # Grab the previously-built version out of the build
-                        # tree.
-                        try:
-                                ocontent = \
-                                    open(self.get_module_outfile(self.build_lib,
-                                        [package], module)).read()
-                                ov = re.search(versionre, ocontent).group(1)
-                        except (IOError, AttributeError):
-                                ov = None
-                        v = get_git_version()
-                        vstr = 'VERSION = "{0}"'.format(v)
-                        # If the versions haven't changed, there's no need to
-                        # recompile.
-                        if v == ov:
-                                return
+        # Will raise a DistutilsError on failure.
+        syntax_check(module_file)
 
-                        with open(module_file) as f:
-                                mcontent = f.read()
-                                mcontent = re.sub(versionre, vstr, mcontent)
-                                tmpfd, tmp_file = tempfile.mkstemp()
-                                with open(tmp_file, "w") as wf:
-                                        wf.write(mcontent)
-                        print("doing version substitution: ", v)
-                        rv = _build_py.build_module(self, module, tmp_file, str(package))
-                        os.unlink(tmp_file)
-                        return rv
+        return _build_py.build_module(self, module, module_file, str(package))
 
-                # Will raise a DistutilsError on failure.
-                syntax_check(module_file)
+    def copy_file(
+        self,
+        infile,
+        outfile,
+        preserve_mode=1,
+        preserve_times=1,
+        link=None,
+        level=1,
+    ):
+        # If the timestamp on the source file (coming from mercurial if
+        # unchanged, or from the filesystem if changed) doesn't match
+        # the filesystem timestamp on the destination, then force the
+        # copy to make sure the right data is in place.
 
-                return _build_py.build_module(self, module, module_file, str(package))
+        try:
+            dst_mtime = os.stat(outfile).st_mtime
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
+            dst_mtime = time.time()
 
-        def copy_file(self, infile, outfile, preserve_mode=1, preserve_times=1,
-            link=None, level=1):
+        # The timestamp for __init__.py is the timestamp for the
+        # workspace itself.
+        if outfile.endswith("/pkg/__init__.py"):
+            src_mtime = self.timestamps[b"."]
+        else:
+            src_mtime = self.timestamps.get(
+                os.path.join("src", infile).encode("utf-8"),
+                self.timestamps[b"."],
+            )
 
-                # If the timestamp on the source file (coming from mercurial if
-                # unchanged, or from the filesystem if changed) doesn't match
-                # the filesystem timestamp on the destination, then force the
-                # copy to make sure the right data is in place.
+        # Force a copy of the file if the source timestamp is different
+        # from that of the destination, not just if it's newer.  This
+        # allows timestamps in the working directory to regress (for
+        # instance, following the reversion of a change).
+        if dst_mtime != src_mtime:
+            f = self.force
+            self.force = True
+            dst, copied = _build_py.copy_file(
+                self,
+                infile,
+                outfile,
+                preserve_mode,
+                preserve_times,
+                link,
+                level,
+            )
+            self.force = f
+        else:
+            dst, copied = outfile, 0
 
-                try:
-                        dst_mtime = os.stat(outfile).st_mtime
-                except OSError as e:
-                        if e.errno != errno.ENOENT:
-                                raise
-                        dst_mtime = time.time()
+        # If we copied the file, then we need to go and readjust the
+        # timestamp on the file to match what we have in our database.
+        # Save the filename aside for our version of install_lib.
+        if copied and dst.endswith(".py"):
+            os.utime(dst, (src_mtime, src_mtime))
+            self.copied.append(dst)
 
-                # The timestamp for __init__.py is the timestamp for the
-                # workspace itself.
-                if outfile.endswith("/pkg/__init__.py"):
-                        src_mtime = self.timestamps[b"."]
-                else:
-                        src_mtime = self.timestamps.get(
-                            os.path.join("src", infile).encode('utf-8'),
-                            self.timestamps[b"."])
+        return dst, copied
 
-                # Force a copy of the file if the source timestamp is different
-                # from that of the destination, not just if it's newer.  This
-                # allows timestamps in the working directory to regress (for
-                # instance, following the reversion of a change).
-                if dst_mtime != src_mtime:
-                        f = self.force
-                        self.force = True
-                        dst, copied = _build_py.copy_file(self, infile, outfile,
-                            preserve_mode, preserve_times, link, level)
-                        self.force = f
-                else:
-                        dst, copied = outfile, 0
+    def get_data_files_without_manifest(self):
+        return ()
 
-                # If we copied the file, then we need to go and readjust the
-                # timestamp on the file to match what we have in our database.
-                # Save the filename aside for our version of install_lib.
-                if copied and dst.endswith(".py"):
-                        os.utime(dst, (src_mtime, src_mtime))
-                        self.copied.append(dst)
-
-                return dst, copied
-
-        def get_data_files_without_manifest(self):
-                return ()
 
 class build_data_func(Command):
-        description = "build data files whose source isn't in deliverable form"
-        user_options = []
+    description = "build data files whose source isn't in deliverable form"
+    user_options = []
 
-        # As a subclass of distutils.cmd.Command, these methods are required to
-        # be implemented.
-        def initialize_options(self):
-                pass
+    # As a subclass of distutils.cmd.Command, these methods are required to
+    # be implemented.
+    def initialize_options(self):
+        pass
 
-        def finalize_options(self):
-                pass
+    def finalize_options(self):
+        pass
 
-        def run(self):
-                # Anything that gets created here should get deleted in
-                # clean_func.run() below.
-                i18n_check()
+    def run(self):
+        # Anything that gets created here should get deleted in
+        # clean_func.run() below.
+        i18n_check()
 
-                for l in pkg_locales:
-                        msgfmt("po/{0}.po".format(l), "po/{0}.mo".format(l))
+        for l in pkg_locales:
+            msgfmt("po/{0}.po".format(l), "po/{0}.mo".format(l))
 
-                # generate pkg.pot for next translation
-                intltool_update_maintain()
-                intltool_update_pot()
+        # generate pkg.pot for next translation
+        intltool_update_maintain()
+        intltool_update_pot()
 
 
 def rm_f(filepath):
-        """Remove a file without caring whether it exists."""
+    """Remove a file without caring whether it exists."""
 
-        try:
-                os.unlink(filepath)
-        except OSError as e:
-                if e.errno != errno.ENOENT:
-                        raise
+    try:
+        os.unlink(filepath)
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise
+
 
 class clean_func(_clean):
-        def initialize_options(self):
-                _clean.initialize_options(self)
-                self.build_base = build_dir
+    def initialize_options(self):
+        _clean.initialize_options(self)
+        self.build_base = build_dir
 
-        def run(self):
-                _clean.run(self)
+    def run(self):
+        _clean.run(self)
 
-                rm_f("po/.intltool-merge-cache")
+        rm_f("po/.intltool-merge-cache")
 
-                for l in pkg_locales:
-                        rm_f("po/{0}.mo".format(l))
+        for l in pkg_locales:
+            rm_f("po/{0}.mo".format(l))
 
-                rm_f("po/pkg.pot")
+        rm_f("po/pkg.pot")
 
-                rm_f("po/i18n_errs.txt")
+        rm_f("po/i18n_errs.txt")
+
 
 class clobber_func(Command):
-        user_options = []
-        description = "Deletes any and all files created by setup"
+    user_options = []
+    description = "Deletes any and all files created by setup"
 
-        def initialize_options(self):
-                pass
-        def finalize_options(self):
-                pass
-        def run(self):
-                # nuke everything
-                print("deleting " + dist_dir)
-                shutil.rmtree(dist_dir, True)
-                print("deleting " + build_dir)
-                shutil.rmtree(build_dir, True)
-                print("deleting " + root_dir)
-                shutil.rmtree(root_dir, True)
-                print("deleting " + pkgs_dir)
-                shutil.rmtree(pkgs_dir, True)
-                print("deleting " + extern_dir)
-                shutil.rmtree(extern_dir, True)
-                # These files generated by the CFFI build scripts are useless
-                # at this point, therefore clean them up.
-                print("deleting temporary files generated by CFFI")
-                for path in os.listdir(cffi_dir):
-                        if not path.startswith("_"):
-                                continue
-                        path = os.path.join(cffi_dir, path)
-                        rm_f(path)
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        # nuke everything
+        print("deleting " + dist_dir)
+        shutil.rmtree(dist_dir, True)
+        print("deleting " + build_dir)
+        shutil.rmtree(build_dir, True)
+        print("deleting " + root_dir)
+        shutil.rmtree(root_dir, True)
+        print("deleting " + pkgs_dir)
+        shutil.rmtree(pkgs_dir, True)
+        print("deleting " + extern_dir)
+        shutil.rmtree(extern_dir, True)
+        # These files generated by the CFFI build scripts are useless
+        # at this point, therefore clean them up.
+        print("deleting temporary files generated by CFFI")
+        for path in os.listdir(cffi_dir):
+            if not path.startswith("_"):
+                continue
+            path = os.path.join(cffi_dir, path)
+            rm_f(path)
+
 
 class test_func(Command):
-        # NOTE: these options need to be in sync with tests/run.py and the
-        # list of options stored in initialize_options below. The first entry
-        # in each tuple must be the exact name of a member variable.
-        user_options = [
-            ("archivedir=", 'a', "archive failed tests <dir>"),
-            ("baselinefile=", 'b', "baseline file <file>"),
-            ("coverage", "c", "collect code coverage data"),
-            ("genbaseline", 'g', "generate test baseline"),
-            ("only=", "o", "only <regex>"),
-            ("parseable", 'p', "parseable output"),
-            ("port=", "z", "lowest port to start a depot on"),
-            ("timing", "t", "timing file <file>"),
-            ("verbosemode", 'v', "run tests in verbose mode"),
-            ("stoponerr", 'x', "stop when a baseline mismatch occurs"),
-            ("debugoutput", 'd', "emit debugging output"),
-            ("showonexpectedfail", 'f',
-                "show all failure info, even for expected fails"),
-            ("startattest=", 's', "start at indicated test"),
-            ("jobs=", 'j', "number of parallel processes to use"),
-            ("quiet", "q", "use the dots as the output format"),
-            ("livesystem", 'l', "run tests on live system"),
-        ]
-        description = "Runs unit and functional tests"
+    # NOTE: these options need to be in sync with tests/run.py and the
+    # list of options stored in initialize_options below. The first entry
+    # in each tuple must be the exact name of a member variable.
+    user_options = [
+        ("archivedir=", "a", "archive failed tests <dir>"),
+        ("baselinefile=", "b", "baseline file <file>"),
+        ("coverage", "c", "collect code coverage data"),
+        ("genbaseline", "g", "generate test baseline"),
+        ("only=", "o", "only <regex>"),
+        ("parseable", "p", "parseable output"),
+        ("port=", "z", "lowest port to start a depot on"),
+        ("timing", "t", "timing file <file>"),
+        ("verbosemode", "v", "run tests in verbose mode"),
+        ("stoponerr", "x", "stop when a baseline mismatch occurs"),
+        ("debugoutput", "d", "emit debugging output"),
+        (
+            "showonexpectedfail",
+            "f",
+            "show all failure info, even for expected fails",
+        ),
+        ("startattest=", "s", "start at indicated test"),
+        ("jobs=", "j", "number of parallel processes to use"),
+        ("quiet", "q", "use the dots as the output format"),
+        ("livesystem", "l", "run tests on live system"),
+    ]
+    description = "Runs unit and functional tests"
 
-        def initialize_options(self):
-                self.only = ""
-                self.baselinefile = ""
-                self.verbosemode = 0
-                self.parseable = 0
-                self.genbaseline = 0
-                self.timing = 0
-                self.coverage = 0
-                self.stoponerr = 0
-                self.debugoutput = 0
-                self.showonexpectedfail = 0
-                self.startattest = ""
-                self.archivedir = ""
-                self.port = 12001
-                self.jobs = 1
-                self.quiet = False
-                self.livesystem = False
+    def initialize_options(self):
+        self.only = ""
+        self.baselinefile = ""
+        self.verbosemode = 0
+        self.parseable = 0
+        self.genbaseline = 0
+        self.timing = 0
+        self.coverage = 0
+        self.stoponerr = 0
+        self.debugoutput = 0
+        self.showonexpectedfail = 0
+        self.startattest = ""
+        self.archivedir = ""
+        self.port = 12001
+        self.jobs = 1
+        self.quiet = False
+        self.livesystem = False
 
-        def finalize_options(self):
-                pass
+    def finalize_options(self):
+        pass
 
-        def run(self):
+    def run(self):
+        os.putenv("PYEXE", sys.executable)
+        os.chdir(os.path.join(pwd, "tests"))
 
-                os.putenv('PYEXE', sys.executable)
-                os.chdir(os.path.join(pwd, "tests"))
+        # Reconstruct the cmdline and send that to run.py
+        cmd = [sys.executable, "run.py"]
+        args = ""
+        if "test" in sys.argv:
+            args = sys.argv[sys.argv.index("test") + 1 :]
+            cmd.extend(args)
+        subprocess.call(cmd)
 
-                # Reconstruct the cmdline and send that to run.py
-                cmd = [sys.executable, "run.py"]
-                args = ""
-                if "test" in sys.argv:
-                        args = sys.argv[sys.argv.index("test")+1:]
-                        cmd.extend(args)
-                subprocess.call(cmd)
 
 class dist_func(_bdist):
-        def initialize_options(self):
-                _bdist.initialize_options(self)
-                self.dist_dir = dist_dir
+    def initialize_options(self):
+        _bdist.initialize_options(self)
+        self.dist_dir = dist_dir
+
 
 class egg_info_func(_egg_info):
-        def write_installer(self):
-                p = os.path.join(self.egg_info, "INSTALLER")
-                self.write_file('installer', p, "pkg\n")
+    def write_installer(self):
+        p = os.path.join(self.egg_info, "INSTALLER")
+        self.write_file("installer", p, "pkg\n")
 
-        def run(self):
-                super().run()
-                self.write_installer()
+    def run(self):
+        super().run()
+        self.write_installer()
+
 
 class Extension(distutils.core.Extension):
-        # This class wraps the distutils Extension class, allowing us to set
-        # build_64 in the object constructor instead of being forced to add it
-        # after the object has been created.
-        def __init__(self, name, sources, build_64=False, **kwargs):
-                # 'name' and the item in 'sources' must be a string literal
-                sources = [str(s) for s in sources]
-                distutils.core.Extension.__init__(self, str(name), sources, **kwargs)
-                self.build_64 = build_64
+    # This class wraps the distutils Extension class, allowing us to set
+    # build_64 in the object constructor instead of being forced to add it
+    # after the object has been created.
+    def __init__(self, name, sources, build_64=False, **kwargs):
+        # 'name' and the item in 'sources' must be a string literal
+        sources = [str(s) for s in sources]
+        distutils.core.Extension.__init__(self, str(name), sources, **kwargs)
+        self.build_64 = build_64
+
 
 # These are set to real values based on the platform, down below
 compile_args = None
 if osname in ("sunos", "linux", "darwin"):
-        compile_args = [ "-O3", "-gstrict-dwarf",
-            "-fno-aggressive-loop-optimizations" ]
+    compile_args = [
+        "-O3",
+        "-gstrict-dwarf",
+        "-fno-aggressive-loop-optimizations",
+    ]
 if osname == "sunos":
-        link_args = []
+    link_args = []
 else:
-        link_args = []
+    link_args = []
 
 ext_modules = [
-        Extension(
-                'actions._actions',
-                _actions_srcs,
-                include_dirs = include_dirs,
-                extra_compile_args = compile_args,
-                extra_link_args = link_args,
-                build_64 = True
-                ),
-        Extension(
-                'actions._common',
-                _actcomm_srcs,
-                include_dirs = include_dirs,
-                extra_compile_args = compile_args,
-                extra_link_args = link_args,
-                build_64 = True
-                ),
-        Extension(
-                '_varcet',
-                _varcet_srcs,
-                include_dirs = include_dirs,
-                extra_compile_args = compile_args,
-                extra_link_args = link_args,
-                build_64 = True
-                ),
-        Extension(
-                'solver',
-                solver_srcs,
-                include_dirs = include_dirs + ["."],
-                extra_compile_args = compile_args + ["-fno-strict-aliasing"],
-                extra_link_args = link_args + solver_link_args,
-                define_macros = [('_FILE_OFFSET_BITS', '64')],
-                build_64 = True
-                ),
-        ]
+    Extension(
+        "actions._actions",
+        _actions_srcs,
+        include_dirs=include_dirs,
+        extra_compile_args=compile_args,
+        extra_link_args=link_args,
+        build_64=True,
+    ),
+    Extension(
+        "actions._common",
+        _actcomm_srcs,
+        include_dirs=include_dirs,
+        extra_compile_args=compile_args,
+        extra_link_args=link_args,
+        build_64=True,
+    ),
+    Extension(
+        "_varcet",
+        _varcet_srcs,
+        include_dirs=include_dirs,
+        extra_compile_args=compile_args,
+        extra_link_args=link_args,
+        build_64=True,
+    ),
+    Extension(
+        "solver",
+        solver_srcs,
+        include_dirs=include_dirs + ["."],
+        extra_compile_args=compile_args + ["-fno-strict-aliasing"],
+        extra_link_args=link_args + solver_link_args,
+        define_macros=[("_FILE_OFFSET_BITS", "64")],
+        build_64=True,
+    ),
+]
 elf_libraries = None
 sysattr_libraries = None
 sha512_t_libraries = None
 data_files = web_files
 cmdclasses = {
-        'install': install_func,
-        'install_data': install_data_func,
-        'install_lib': install_lib_func,
-        'bandit' : bandit_func,
-        'build': build_func,
-        'build_data': build_data_func,
-        'build_ext': build_ext_func,
-        'build_py': build_py_func,
-        'bdist': dist_func,
-        'egg_info': egg_info_func,
-        'lint': lint_func,
-        'clint': clint_func,
-        'pylint': pylint_func,
-        'pylint_quiet': pylint_func_quiet,
-        'pylint_py3k': pylint_func_py3k,
-        'clean': clean_func,
-        'clobber': clobber_func,
-        'test': test_func,
-        'installfile': installfile,
-        }
+    "install": install_func,
+    "install_data": install_data_func,
+    "install_lib": install_lib_func,
+    "bandit": bandit_func,
+    "build": build_func,
+    "build_data": build_data_func,
+    "build_ext": build_ext_func,
+    "build_py": build_py_func,
+    "bdist": dist_func,
+    "egg_info": egg_info_func,
+    "lint": lint_func,
+    "clint": clint_func,
+    "pylint": pylint_func,
+    "pylint_quiet": pylint_func_quiet,
+    "pylint_py3k": pylint_func_py3k,
+    "clean": clean_func,
+    "clobber": clobber_func,
+    "test": test_func,
+    "installfile": installfile,
+}
 
 # all builds of IPS should have manpages
 data_files += [
-        (man1_dir, man1_files),
-        (man8_dir, man8_files),
-        (man7_dir, man7_files),
-        (resource_dir, resource_files),
-        ]
+    (man1_dir, man1_files),
+    (man8_dir, man8_files),
+    (man7_dir, man7_files),
+    (resource_dir, resource_files),
+]
 # add transforms
-data_files += [
-        (transform_dir, transform_files)
-        ]
+data_files += [(transform_dir, transform_files)]
 # add ignored deps
-data_files += [
-        (ignored_deps_dir, ignored_deps_files)
-        ]
-if osname == 'sunos':
-        # Solaris-specific extensions are added here
-        data_files += [
-                (smf_app_dir, smf_app_files),
-                (execattrd_dir, execattrd_files),
-                (authattrd_dir, authattrd_files),
-                (userattrd_dir, userattrd_files),
-                #(sysrepo_dir, sysrepo_files),
-                #(sysrepo_logs_dir, sysrepo_log_stubs),
-                #(sysrepo_cache_dir, {}),
-                #(depot_dir, depot_files),
-                #(depot_conf_dir, {}),
-                #(depot_logs_dir, depot_log_stubs),
-                #(depot_cache_dir, {}),
-                (mirror_cache_dir, {}),
-                (mirror_logs_dir, {}),
-                ]
-        # install localizable .xml and its .pot file to put into localizable file package
-        data_files += [
-            (os.path.join(locale_dir, locale, 'LC_MESSAGES'),
-                [('po/{0}.mo'.format(locale), 'pkg.mo')])
-            for locale in pkg_locales
-        ]
-
-if osname == 'sunos' or osname == "linux":
-        # Unix platforms which the elf extension has been ported to
-        # are specified here, so they are built automatically
-        elf_libraries = ['elf']
-        ext_modules += [
-                Extension(
-                        'elf',
-                        elf_srcs,
-                        include_dirs = include_dirs,
-                        libraries = elf_libraries,
-                        extra_compile_args = compile_args,
-                        extra_link_args = link_args,
-                        build_64 = True
-                        ),
-                ]
-
-        # Solaris has built-in md library and Solaris-specific arch extension
-        # All others use OpenSSL and cross-platform arch module
-        if osname == 'sunos':
-            elf_libraries += [ 'md' ]
-            sysattr_libraries = [ 'nvpair' ]
-            sha512_t_libraries = [ 'md' ]
-            ext_modules += [
-                    Extension(
-                            '_arch',
-                            arch_srcs,
-                            include_dirs = include_dirs,
-                            extra_compile_args = compile_args,
-                            extra_link_args = link_args,
-                            define_macros = [('_FILE_OFFSET_BITS', '64')],
-			    build_64 = True
-                            ),
-                    Extension(
-                            '_pspawn',
-                            pspawn_srcs,
-                            include_dirs = include_dirs,
-                            extra_compile_args = compile_args,
-                            extra_link_args = link_args,
-                            define_macros = [('_FILE_OFFSET_BITS', '64')],
-			    build_64 = True
-                            ),
-                    Extension(
-                            '_syscallat',
-                            syscallat_srcs,
-                            include_dirs = include_dirs,
-                            extra_compile_args = compile_args,
-                            extra_link_args = link_args,
-                            define_macros = [('_FILE_OFFSET_BITS', '64')],
-                            build_64 = True
-                            ),
-                    Extension(
-                            '_sysattr',
-                            sysattr_srcs,
-                            include_dirs = include_dirs,
-                            libraries = sysattr_libraries,
-                            extra_compile_args = compile_args,
-                            extra_link_args = link_args,
-                            define_macros = [('_FILE_OFFSET_BITS', '64')],
-                            build_64 = True
-                            ),
-                    Extension(
-                            '_sha512_t',
-                            sha512_t_srcs,
-                            include_dirs = include_dirs,
-                            libraries = sha512_t_libraries,
-                            extra_compile_args = compile_args,
-                            extra_link_args = link_args,
-                            define_macros = [('_FILE_OFFSET_BITS', '64')],
-                            build_64 = True
-                            ),
-                    ]
-        else:
-            elf_libraries += [ 'ssl' ]
-
-setup(cmdclass = cmdclasses,
-    name = 'pkg',
-    version = '0.1',
-    package_dir = {'pkg':'modules'},
-    packages = packages,
-    data_files = data_files,
-    ext_package = 'pkg',
-    ext_modules = ext_modules,
-    description = "The OmniOS IPS packaging system",
-    long_description = "The OmniOS IPS packaging system",
-    url = "https://github.com/omniosorg/pkg5",
-    license = "CDDL",
-    platforms = "OmniOS",
-    classifiers = [
-        'Programming Language :: Python :: 3',
+data_files += [(ignored_deps_dir, ignored_deps_files)]
+if osname == "sunos":
+    # Solaris-specific extensions are added here
+    data_files += [
+        (smf_app_dir, smf_app_files),
+        (execattrd_dir, execattrd_files),
+        (authattrd_dir, authattrd_files),
+        (userattrd_dir, userattrd_files),
+        # (sysrepo_dir, sysrepo_files),
+        # (sysrepo_logs_dir, sysrepo_log_stubs),
+        # (sysrepo_cache_dir, {}),
+        # (depot_dir, depot_files),
+        # (depot_conf_dir, {}),
+        # (depot_logs_dir, depot_log_stubs),
+        # (depot_cache_dir, {}),
+        (mirror_cache_dir, {}),
+        (mirror_logs_dir, {}),
     ]
+    # install localizable .xml and its .pot file to put into localizable file package
+    data_files += [
+        (
+            os.path.join(locale_dir, locale, "LC_MESSAGES"),
+            [("po/{0}.mo".format(locale), "pkg.mo")],
+        )
+        for locale in pkg_locales
+    ]
+
+if osname == "sunos" or osname == "linux":
+    # Unix platforms which the elf extension has been ported to
+    # are specified here, so they are built automatically
+    elf_libraries = ["elf"]
+    ext_modules += [
+        Extension(
+            "elf",
+            elf_srcs,
+            include_dirs=include_dirs,
+            libraries=elf_libraries,
+            extra_compile_args=compile_args,
+            extra_link_args=link_args,
+            build_64=True,
+        ),
+    ]
+
+    # Solaris has built-in md library and Solaris-specific arch extension
+    # All others use OpenSSL and cross-platform arch module
+    if osname == "sunos":
+        elf_libraries += ["md"]
+        sysattr_libraries = ["nvpair"]
+        sha512_t_libraries = ["md"]
+        ext_modules += [
+            Extension(
+                "_arch",
+                arch_srcs,
+                include_dirs=include_dirs,
+                extra_compile_args=compile_args,
+                extra_link_args=link_args,
+                define_macros=[("_FILE_OFFSET_BITS", "64")],
+                build_64=True,
+            ),
+            Extension(
+                "_pspawn",
+                pspawn_srcs,
+                include_dirs=include_dirs,
+                extra_compile_args=compile_args,
+                extra_link_args=link_args,
+                define_macros=[("_FILE_OFFSET_BITS", "64")],
+                build_64=True,
+            ),
+            Extension(
+                "_syscallat",
+                syscallat_srcs,
+                include_dirs=include_dirs,
+                extra_compile_args=compile_args,
+                extra_link_args=link_args,
+                define_macros=[("_FILE_OFFSET_BITS", "64")],
+                build_64=True,
+            ),
+            Extension(
+                "_sysattr",
+                sysattr_srcs,
+                include_dirs=include_dirs,
+                libraries=sysattr_libraries,
+                extra_compile_args=compile_args,
+                extra_link_args=link_args,
+                define_macros=[("_FILE_OFFSET_BITS", "64")],
+                build_64=True,
+            ),
+            Extension(
+                "_sha512_t",
+                sha512_t_srcs,
+                include_dirs=include_dirs,
+                libraries=sha512_t_libraries,
+                extra_compile_args=compile_args,
+                extra_link_args=link_args,
+                define_macros=[("_FILE_OFFSET_BITS", "64")],
+                build_64=True,
+            ),
+        ]
+    else:
+        elf_libraries += ["ssl"]
+
+setup(
+    cmdclass=cmdclasses,
+    name="pkg",
+    version="0.1",
+    package_dir={"pkg": "modules"},
+    packages=packages,
+    data_files=data_files,
+    ext_package="pkg",
+    ext_modules=ext_modules,
+    description="The OmniOS IPS packaging system",
+    long_description="The OmniOS IPS packaging system",
+    url="https://github.com/omniosorg/pkg5",
+    license="CDDL",
+    platforms="OmniOS",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+    ],
 )
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/sign.py
+++ b/src/sign.py
@@ -25,7 +25,9 @@
 # Copyright 2017 OmniOS Community Edition (OmniOSce) Association.
 #
 
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 import getopt
 import gettext
 import hashlib
@@ -57,366 +59,422 @@ from pkg.misc import emsg, msg, PipeError
 PKG_CLIENT_NAME = "pkgsign"
 
 # pkg exit codes
-EXIT_OK      = 0
-EXIT_OOPS    = 1
-EXIT_BADOPT  = 2
+EXIT_OK = 0
+EXIT_OOPS = 1
+EXIT_BADOPT = 2
 EXIT_PARTIAL = 3
 
 repo_cache = {}
 
+
 def error(text, cmd=None):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        if cmd:
-                text = "{0}: {1}".format(cmd, text)
+    if cmd:
+        text = "{0}: {1}".format(cmd, text)
 
-        else:
-                text = "{0}: {1}".format(PKG_CLIENT_NAME, text)
+    else:
+        text = "{0}: {1}".format(PKG_CLIENT_NAME, text)
 
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    emsg(ws + text_nows)
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        emsg(ws + text_nows)
 
 def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT):
-        """Emit a usage message and optionally prefix it with a more specific
-        error message.  Causes program to exit."""
+    """Emit a usage message and optionally prefix it with a more specific
+    error message.  Causes program to exit."""
 
-        if usage_error:
-                error(usage_error, cmd=cmd)
-        emsg (_("""\
+    if usage_error:
+        error(usage_error, cmd=cmd)
+    emsg(
+        _(
+            """\
 Usage:
         pkgsign -s path_or_uri [-acikn] [--no-index] [--no-catalog]
             [--dkey dest_key --dcert dest_cert]
             (fmri|pattern) ...
-"""))
+"""
+        )
+    )
 
-        sys.exit(retcode)
+    sys.exit(retcode)
+
 
 def fetch_catalog(src_pub, xport, temp_root):
-        """Fetch the catalog from src_uri."""
+    """Fetch the catalog from src_uri."""
 
-        if not src_pub.meta_root:
-                # Create a temporary directory for catalog.
-                cat_dir = tempfile.mkdtemp(dir=temp_root)
-                src_pub.meta_root = cat_dir
+    if not src_pub.meta_root:
+        # Create a temporary directory for catalog.
+        cat_dir = tempfile.mkdtemp(dir=temp_root)
+        src_pub.meta_root = cat_dir
 
-        src_pub.transport = xport
-        src_pub.refresh(True, True)
+    src_pub.transport = xport
+    src_pub.refresh(True, True)
 
-        return src_pub.catalog
+    return src_pub.catalog
+
 
 def __make_tmp_cert(d, pth):
-        try:
-                with open(pth, "rb") as f:
-                        cert = x509.load_pem_x509_certificate(f.read(),
-                            default_backend())
-        except (ValueError, IOError) as e:
-                raise api_errors.BadFileFormat(_("The file {0} was expected to "
-                    "be a PEM certificate but it could not be read.").format(
-                    pth))
-        fd, fp = tempfile.mkstemp(dir=d)
-        with os.fdopen(fd, "wb") as fh:
-                fh.write(cert.public_bytes(serialization.Encoding.PEM))
-        return fp
+    try:
+        with open(pth, "rb") as f:
+            cert = x509.load_pem_x509_certificate(f.read(), default_backend())
+    except (ValueError, IOError) as e:
+        raise api_errors.BadFileFormat(
+            _(
+                "The file {0} was expected to "
+                "be a PEM certificate but it could not be read."
+            ).format(pth)
+        )
+    fd, fp = tempfile.mkstemp(dir=d)
+    with os.fdopen(fd, "wb") as fh:
+        fh.write(cert.public_bytes(serialization.Encoding.PEM))
+    return fp
+
 
 def main_func():
-        global_settings.client_name = "pkgsign"
+    global_settings.client_name = "pkgsign"
 
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "a:c:i:k:ns:D:",
-                    ["help", "no-index", "no-catalog", "dkey=", "dcert="])
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
+    try:
+        opts, pargs = getopt.getopt(
+            sys.argv[1:],
+            "a:c:i:k:ns:D:",
+            ["help", "no-index", "no-catalog", "dkey=", "dcert="],
+        )
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
 
-        show_usage = False
-        sig_alg = "rsa-sha256"
-        cert_path = None
-        key_path = None
-        chain_certs = []
-        add_to_catalog = True
-        set_alg = False
-        dry_run = False
-        dkey = None
-        dcert = None
+    show_usage = False
+    sig_alg = "rsa-sha256"
+    cert_path = None
+    key_path = None
+    chain_certs = []
+    add_to_catalog = True
+    set_alg = False
+    dry_run = False
+    dkey = None
+    dcert = None
 
-        repo_uri = os.getenv("PKG_REPO", None)
-        for opt, arg in opts:
-                if opt == "-a":
-                        sig_alg = arg
-                        set_alg = True
-                elif opt == "-c":
-                        cert_path = os.path.abspath(arg)
-                        if not os.path.isfile(cert_path):
-                                usage(_("{0} was expected to be a certificate "
-                                    "but isn't a file.").format(cert_path))
-                elif opt == "-i":
-                        p = os.path.abspath(arg)
-                        if not os.path.isfile(p):
-                                usage(_("{0} was expected to be a certificate "
-                                    "but isn't a file.").format(p))
-                        chain_certs.append(p)
-                elif opt == "-k":
-                        key_path = os.path.abspath(arg)
-                        if not os.path.isfile(key_path):
-                                usage(_("{0} was expected to be a key file "
-                                    "but isn't a file.").format(key_path))
-                elif opt == "--dkey":
-                        dkey = os.path.abspath(arg)
-                        if not os.path.isfile(dkey):
-                                usage(_("{0} was expected to be a key file "
-                                    "but isn't a file.").format(dkey))
-                elif opt == "--dcert":
-                        dcert = os.path.abspath(arg)
-                        if not os.path.isfile(dcert):
-                                usage(_("{0} was expected to be a certificate "
-                                    "but isn't a file.").format(dcert))
-                elif opt == "-n":
-                        dry_run = True
-                elif opt == "-s":
-                        repo_uri = misc.parse_uri(arg)
-                elif opt == "--help":
-                        show_usage = True
-                elif opt == "--no-catalog":
-                        add_to_catalog = False
-                elif opt == "-D":
-                        try:
-                                key, value = arg.split("=", 1)
-                                DebugValues.set_value(key, value)
-                        except (AttributeError, ValueError):
-                                error(_("{opt} takes argument of form "
-                                    "name=value, not {arg}").format(
-                                    opt=opt, arg=arg))
-        if show_usage:
-                usage(retcode=EXIT_OK)
+    repo_uri = os.getenv("PKG_REPO", None)
+    for opt, arg in opts:
+        if opt == "-a":
+            sig_alg = arg
+            set_alg = True
+        elif opt == "-c":
+            cert_path = os.path.abspath(arg)
+            if not os.path.isfile(cert_path):
+                usage(
+                    _(
+                        "{0} was expected to be a certificate "
+                        "but isn't a file."
+                    ).format(cert_path)
+                )
+        elif opt == "-i":
+            p = os.path.abspath(arg)
+            if not os.path.isfile(p):
+                usage(
+                    _(
+                        "{0} was expected to be a certificate "
+                        "but isn't a file."
+                    ).format(p)
+                )
+            chain_certs.append(p)
+        elif opt == "-k":
+            key_path = os.path.abspath(arg)
+            if not os.path.isfile(key_path):
+                usage(
+                    _(
+                        "{0} was expected to be a key file " "but isn't a file."
+                    ).format(key_path)
+                )
+        elif opt == "--dkey":
+            dkey = os.path.abspath(arg)
+            if not os.path.isfile(dkey):
+                usage(
+                    _(
+                        "{0} was expected to be a key file " "but isn't a file."
+                    ).format(dkey)
+                )
+        elif opt == "--dcert":
+            dcert = os.path.abspath(arg)
+            if not os.path.isfile(dcert):
+                usage(
+                    _(
+                        "{0} was expected to be a certificate "
+                        "but isn't a file."
+                    ).format(dcert)
+                )
+        elif opt == "-n":
+            dry_run = True
+        elif opt == "-s":
+            repo_uri = misc.parse_uri(arg)
+        elif opt == "--help":
+            show_usage = True
+        elif opt == "--no-catalog":
+            add_to_catalog = False
+        elif opt == "-D":
+            try:
+                key, value = arg.split("=", 1)
+                DebugValues.set_value(key, value)
+            except (AttributeError, ValueError):
+                error(
+                    _(
+                        "{opt} takes argument of form " "name=value, not {arg}"
+                    ).format(opt=opt, arg=arg)
+                )
+    if show_usage:
+        usage(retcode=EXIT_OK)
 
-        if not repo_uri:
-                usage(_("a repository must be provided"))
+    if not repo_uri:
+        usage(_("a repository must be provided"))
 
-        if key_path and not cert_path:
-                usage(_("If a key is given to sign with, its associated "
-                    "certificate must be given."))
+    if key_path and not cert_path:
+        usage(
+            _(
+                "If a key is given to sign with, its associated "
+                "certificate must be given."
+            )
+        )
 
-        if cert_path and not key_path:
-                usage(_("If a certificate is given, its associated key must be "
-                    "given."))
+    if cert_path and not key_path:
+        usage(
+            _("If a certificate is given, its associated key must be " "given.")
+        )
 
-        if chain_certs and not cert_path:
-                usage(_("Intermediate certificates are only valid if a key "
-                    "and certificate are also provided."))
+    if chain_certs and not cert_path:
+        usage(
+            _(
+                "Intermediate certificates are only valid if a key "
+                "and certificate are also provided."
+            )
+        )
 
-        if not pargs:
-                usage(_("At least one fmri or pattern must be provided to "
-                    "sign."))
+    if not pargs:
+        usage(_("At least one fmri or pattern must be provided to " "sign."))
 
-        if not set_alg and not key_path:
-                sig_alg = "sha256"
+    if not set_alg and not key_path:
+        sig_alg = "sha256"
 
-        s, h = actions.signature.SignatureAction.decompose_sig_alg(sig_alg)
-        if h is None:
-                usage(_("{0} is not a recognized signature algorithm.").format(
-                    sig_alg))
-        if s and not key_path:
-                usage(_("Using {0} as the signature algorithm requires that a "
-                    "key and certificate pair be presented using the -k and -c "
-                    "options.").format(sig_alg))
-        if not s and key_path:
-                usage(_("The {0} hash algorithm does not use a key or "
-                    "certificate.  Do not use the -k or -c options with this "
-                    "algorithm.").format(sig_alg))
+    s, h = actions.signature.SignatureAction.decompose_sig_alg(sig_alg)
+    if h is None:
+        usage(_("{0} is not a recognized signature algorithm.").format(sig_alg))
+    if s and not key_path:
+        usage(
+            _(
+                "Using {0} as the signature algorithm requires that a "
+                "key and certificate pair be presented using the -k and -c "
+                "options."
+            ).format(sig_alg)
+        )
+    if not s and key_path:
+        usage(
+            _(
+                "The {0} hash algorithm does not use a key or "
+                "certificate.  Do not use the -k or -c options with this "
+                "algorithm."
+            ).format(sig_alg)
+        )
 
-        if DebugValues:
-                reload(digest)
+    if DebugValues:
+        reload(digest)
 
-        errors = []
+    errors = []
 
-        t = misc.config_temp_root()
-        temp_root = tempfile.mkdtemp(dir=t)
-        del t
+    t = misc.config_temp_root()
+    temp_root = tempfile.mkdtemp(dir=t)
+    del t
 
-        cache_dir = tempfile.mkdtemp(dir=temp_root)
-        incoming_dir = tempfile.mkdtemp(dir=temp_root)
-        chash_dir = tempfile.mkdtemp(dir=temp_root)
-        cert_dir = tempfile.mkdtemp(dir=temp_root)
+    cache_dir = tempfile.mkdtemp(dir=temp_root)
+    incoming_dir = tempfile.mkdtemp(dir=temp_root)
+    chash_dir = tempfile.mkdtemp(dir=temp_root)
+    cert_dir = tempfile.mkdtemp(dir=temp_root)
 
-        try:
-                chain_certs = [
-                    __make_tmp_cert(cert_dir, c) for c in chain_certs
-                ]
-                if cert_path is not None:
-                        cert_path = __make_tmp_cert(cert_dir, cert_path)
+    try:
+        chain_certs = [__make_tmp_cert(cert_dir, c) for c in chain_certs]
+        if cert_path is not None:
+            cert_path = __make_tmp_cert(cert_dir, cert_path)
 
-                xport, xport_cfg = transport.setup_transport()
-                xport_cfg.add_cache(cache_dir, readonly=False)
-                xport_cfg.incoming_root = incoming_dir
+        xport, xport_cfg = transport.setup_transport()
+        xport_cfg.add_cache(cache_dir, readonly=False)
+        xport_cfg.incoming_root = incoming_dir
 
-                # Configure publisher(s)
-                transport.setup_publisher(repo_uri, "source", xport,
-                    xport_cfg, remote_prefix=True,
-                    ssl_key=dkey, ssl_cert=dcert)
-                pats = pargs
-                successful_publish = False
+        # Configure publisher(s)
+        transport.setup_publisher(
+            repo_uri,
+            "source",
+            xport,
+            xport_cfg,
+            remote_prefix=True,
+            ssl_key=dkey,
+            ssl_cert=dcert,
+        )
+        pats = pargs
+        successful_publish = False
 
-                concrete_fmris = []
-                unmatched_pats = set(pats)
-                all_pats = frozenset(pats)
-                get_all_pubs = False
-                pub_prefs = set()
-                # Gather the publishers whose catalogs will be needed.
-                for pat in pats:
-                        try:
-                                p_obj = fmri.MatchingPkgFmri(pat)
-                        except fmri.IllegalMatchingFmri as e:
-                                errors.append(e)
-                                continue
-                        pub_prefix = p_obj.get_publisher()
-                        if pub_prefix:
-                                pub_prefs.add(pub_prefix)
-                        else:
-                                get_all_pubs = True
-                # Check each publisher for matches to our patterns.
-                for p in xport_cfg.gen_publishers():
-                        if not get_all_pubs and p.prefix not in pub_prefs:
-                                continue
-                        cat = fetch_catalog(p, xport, temp_root)
-                        ms, tmp1, u = cat.get_matching_fmris(pats)
-                        # Find which patterns matched.
-                        matched_pats = all_pats - u
-                        # Remove those patterns from the unmatched set.
-                        unmatched_pats -= matched_pats
-                        for v_list in ms.values():
-                                concrete_fmris.extend([(v, p) for v in v_list])
-                if unmatched_pats:
-                        raise api_errors.PackageMatchErrors(
-                            unmatched_fmris=unmatched_pats)
+        concrete_fmris = []
+        unmatched_pats = set(pats)
+        all_pats = frozenset(pats)
+        get_all_pubs = False
+        pub_prefs = set()
+        # Gather the publishers whose catalogs will be needed.
+        for pat in pats:
+            try:
+                p_obj = fmri.MatchingPkgFmri(pat)
+            except fmri.IllegalMatchingFmri as e:
+                errors.append(e)
+                continue
+            pub_prefix = p_obj.get_publisher()
+            if pub_prefix:
+                pub_prefs.add(pub_prefix)
+            else:
+                get_all_pubs = True
+        # Check each publisher for matches to our patterns.
+        for p in xport_cfg.gen_publishers():
+            if not get_all_pubs and p.prefix not in pub_prefs:
+                continue
+            cat = fetch_catalog(p, xport, temp_root)
+            ms, tmp1, u = cat.get_matching_fmris(pats)
+            # Find which patterns matched.
+            matched_pats = all_pats - u
+            # Remove those patterns from the unmatched set.
+            unmatched_pats -= matched_pats
+            for v_list in ms.values():
+                concrete_fmris.extend([(v, p) for v in v_list])
+        if unmatched_pats:
+            raise api_errors.PackageMatchErrors(unmatched_fmris=unmatched_pats)
 
-                for pfmri, src_pub in sorted(set(concrete_fmris)):
-                        try:
-                                # Get the existing manifest for the package to
-                                # be signed.
-                                m_str = xport.get_manifest(pfmri,
-                                    content_only=True, pub=src_pub)
-                                m = manifest.Manifest()
-                                m.set_content(content=m_str)
+        for pfmri, src_pub in sorted(set(concrete_fmris)):
+            try:
+                # Get the existing manifest for the package to
+                # be signed.
+                m_str = xport.get_manifest(
+                    pfmri, content_only=True, pub=src_pub
+                )
+                m = manifest.Manifest()
+                m.set_content(content=m_str)
 
-                                # Construct the base signature action.
-                                attrs = { "algorithm": sig_alg }
-                                a = actions.signature.SignatureAction(cert_path,
-                                    **attrs)
-                                a.hash = cert_path
+                # Construct the base signature action.
+                attrs = {"algorithm": sig_alg}
+                a = actions.signature.SignatureAction(cert_path, **attrs)
+                a.hash = cert_path
 
-                                # Add the action to the manifest to be signed
-                                # since the action signs itself.
-                                m.add_action(a, misc.EmptyI)
+                # Add the action to the manifest to be signed
+                # since the action signs itself.
+                m.add_action(a, misc.EmptyI)
 
-                                # Set the signature value and certificate
-                                # information for the signature action.
-                                a.set_signature(m.gen_actions(),
-                                    key_path=key_path, chain_paths=chain_certs,
-                                    chash_dir=chash_dir)
+                # Set the signature value and certificate
+                # information for the signature action.
+                a.set_signature(
+                    m.gen_actions(),
+                    key_path=key_path,
+                    chain_paths=chain_certs,
+                    chash_dir=chash_dir,
+                )
 
-                                # The hash of 'a' is currently a path, we need
-                                # to find the hash of that file to allow
-                                # comparison to existing signatures.
-                                hsh = None
-                                if cert_path:
-                                        # Action identity still uses the 'hash'
-                                        # member of the action, so we need to
-                                        # stay with the sha1 hash.
-                                        hsh, _dummy = \
-                                            misc.get_data_digest(cert_path,
-                                            hash_func=hashlib.sha1)
+                # The hash of 'a' is currently a path, we need
+                # to find the hash of that file to allow
+                # comparison to existing signatures.
+                hsh = None
+                if cert_path:
+                    # Action identity still uses the 'hash'
+                    # member of the action, so we need to
+                    # stay with the sha1 hash.
+                    hsh, _dummy = misc.get_data_digest(
+                        cert_path, hash_func=hashlib.sha1
+                    )
 
-                                # Check whether the signature about to be added
-                                # is identical, or almost identical, to existing
-                                # signatures on the package.  Because 'a' has
-                                # already been added to the manifest, it is
-                                # generated by gen_actions_by_type, so the cnt
-                                # must be 2 or higher to be an issue.
-                                cnt = 0
-                                almost_identical = False
-                                for a2 in m.gen_actions_by_type("signature"):
-                                        try:
-                                                if a.identical(a2, hsh):
-                                                        cnt += 1
-                                        except api_errors.AlmostIdentical as e:
-                                                e.pkg = pfmri
-                                                errors.append(e)
-                                                almost_identical = True
-                                if almost_identical:
-                                        continue
-                                if cnt == 2:
-                                        continue
-                                elif cnt > 2:
-                                        raise api_errors.DuplicateSignaturesAlreadyExist(pfmri)
-                                assert cnt == 1, "Cnt was:{0}".format(cnt)
+                # Check whether the signature about to be added
+                # is identical, or almost identical, to existing
+                # signatures on the package.  Because 'a' has
+                # already been added to the manifest, it is
+                # generated by gen_actions_by_type, so the cnt
+                # must be 2 or higher to be an issue.
+                cnt = 0
+                almost_identical = False
+                for a2 in m.gen_actions_by_type("signature"):
+                    try:
+                        if a.identical(a2, hsh):
+                            cnt += 1
+                    except api_errors.AlmostIdentical as e:
+                        e.pkg = pfmri
+                        errors.append(e)
+                        almost_identical = True
+                if almost_identical:
+                    continue
+                if cnt == 2:
+                    continue
+                elif cnt > 2:
+                    raise api_errors.DuplicateSignaturesAlreadyExist(pfmri)
+                assert cnt == 1, "Cnt was:{0}".format(cnt)
 
-                                if not dry_run:
-                                        # Append the finished signature action
-                                        # to the published manifest.
-                                        t = trans.Transaction(repo_uri,
-                                            pkg_name=str(pfmri), xport=xport,
-                                            pub=src_pub)
-                                        try:
-                                                t.append()
-                                                t.add(a)
-                                                for c in chain_certs:
-                                                        t.add_file(c)
-                                                t.close(add_to_catalog=
-                                                    add_to_catalog)
-                                        except:
-                                                if t.trans_id:
-                                                        t.close(abandon=True)
-                                                raise
-                                msg(_("Signed {0}").format(pfmri.get_fmri(
-                                    include_build=False)))
-                                successful_publish = True
-                        except (api_errors.ApiException, fmri.FmriError,
-                            trans.TransactionError) as e:
-                                errors.append(e)
-                if errors:
-                        error("\n".join([str(e) for e in errors]))
-                        if successful_publish:
-                                return EXIT_PARTIAL
-                        else:
-                                return EXIT_OOPS
-                return EXIT_OK
-        except api_errors.ApiException as e:
-                error(e)
+                if not dry_run:
+                    # Append the finished signature action
+                    # to the published manifest.
+                    t = trans.Transaction(
+                        repo_uri, pkg_name=str(pfmri), xport=xport, pub=src_pub
+                    )
+                    try:
+                        t.append()
+                        t.add(a)
+                        for c in chain_certs:
+                            t.add_file(c)
+                        t.close(add_to_catalog=add_to_catalog)
+                    except:
+                        if t.trans_id:
+                            t.close(abandon=True)
+                        raise
+                msg(_("Signed {0}").format(pfmri.get_fmri(include_build=False)))
+                successful_publish = True
+            except (
+                api_errors.ApiException,
+                fmri.FmriError,
+                trans.TransactionError,
+            ) as e:
+                errors.append(e)
+        if errors:
+            error("\n".join([str(e) for e in errors]))
+            if successful_publish:
+                return EXIT_PARTIAL
+            else:
                 return EXIT_OOPS
-        finally:
-                shutil.rmtree(temp_root)
+        return EXIT_OK
+    except api_errors.ApiException as e:
+        error(e)
+        return EXIT_OOPS
+    finally:
+        shutil.rmtree(temp_root)
+
 
 #
 # Establish a specific exit status which means: "python barfed an exception"
 # so that we can more easily detect these in testing of the CLI commands.
 #
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        try:
-                __ret = main_func()
-        except (PipeError, KeyboardInterrupt):
-                # We don't want to display any messages here to prevent
-                # possible further broken pipe (EPIPE) errors.
-                __ret = EXIT_OOPS
-        except SystemExit as _e:
-                raise _e
-        except EnvironmentError as _e:
-                error(str(api_errors._convert_error(_e)))
-                __ret = 1
-        except:
-                traceback.print_exc()
-                error(misc.get_traceback_message())
-                __ret = 99
-        sys.exit(__ret)
+    try:
+        __ret = main_func()
+    except (PipeError, KeyboardInterrupt):
+        # We don't want to display any messages here to prevent
+        # possible further broken pipe (EPIPE) errors.
+        __ret = EXIT_OOPS
+    except SystemExit as _e:
+        raise _e
+    except EnvironmentError as _e:
+        error(str(api_errors._convert_error(_e)))
+        __ret = 1
+    except:
+        traceback.print_exc()
+        error(misc.get_traceback_message())
+        __ret = 99
+    sys.exit(__ret)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/sysrepo.py
+++ b/src/sysrepo.py
@@ -25,7 +25,9 @@
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 #
 
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 import atexit
 import errno
 import getopt
@@ -68,9 +70,9 @@ CLIENT_API_VERSION = 82
 pkg.client.global_settings.client_name = PKG_CLIENT_NAME
 
 # exit codes
-EXIT_OK      = 0
-EXIT_OOPS    = 1
-EXIT_BADOPT  = 2
+EXIT_OK = 0
+EXIT_OOPS = 1
+EXIT_BADOPT = 2
 
 # Default port used for http traffic.
 HTTP_PORT = 80
@@ -122,904 +124,1020 @@ catalog 1
 file 1
 syspub 0
 manifest 0
-""".format(pkg.VERSION)
+""".format(
+    pkg.VERSION
+)
 
 SYSREPO_USER = "pkg5srv"
 SYSREPO_GROUP = "pkg5srv"
 
+
 class SysrepoException(Exception):
-        pass
+    pass
+
 
 @atexit.register
 def cleanup():
-        """To be called at program finish."""
-        pass
+    """To be called at program finish."""
+    pass
+
 
 def error(text, cmd=None):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        if cmd:
-                text = "{0}: {1}".format(cmd, text)
-                pkg_cmd = "pkg.sysrepo "
-        else:
-                pkg_cmd = "pkg.sysrepo: "
+    if cmd:
+        text = "{0}: {1}".format(cmd, text)
+        pkg_cmd = "pkg.sysrepo "
+    else:
+        pkg_cmd = "pkg.sysrepo: "
 
-                # If we get passed something like an Exception, we can convert
-                # it down to a string.
-                text = str(text)
+        # If we get passed something like an Exception, we can convert
+        # it down to a string.
+        text = str(text)
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        logger.error(ws + pkg_cmd + text_nows)
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    logger.error(ws + pkg_cmd + text_nows)
+
 
 def usage(usage_error=None, cmd=None, retcode=EXIT_BADOPT):
-        """Emit a usage message and optionally prefix it with a more
-        specific error message.  Causes program to exit.
-        """
+    """Emit a usage message and optionally prefix it with a more
+    specific error message.  Causes program to exit.
+    """
 
-        if usage_error:
-                error(usage_error, cmd=cmd)
+    if usage_error:
+        error(usage_error, cmd=cmd)
 
-        msg(_("""\
+    msg(
+        _(
+            """\
 Usage:
         pkg.sysrepo -p <port> [-R image_root] [ -c cache_dir] [-h hostname]
                 [-l logs_dir] [-r runtime_dir] [-s cache_size] [-t template_dir]
                 [-T http_timeout] [-w http_proxy] [-W https_proxy]
-     """))
-        sys.exit(retcode)
+     """
+        )
+    )
+    sys.exit(retcode)
+
 
 def _get_image(image_dir):
-        """Return a pkg.client.api.ImageInterface for the provided
-        image directory."""
+    """Return a pkg.client.api.ImageInterface for the provided
+    image directory."""
 
-        cdir = os.getcwd()
-        if not image_dir:
-                image_dir = "/"
-        api_inst = None
-        tracker = progress.QuietProgressTracker()
-        try:
-                api_inst = pkg.client.api.ImageInterface(
-                    image_dir, CLIENT_API_VERSION,
-                    tracker, None, PKG_CLIENT_NAME)
+    cdir = os.getcwd()
+    if not image_dir:
+        image_dir = "/"
+    api_inst = None
+    tracker = progress.QuietProgressTracker()
+    try:
+        api_inst = pkg.client.api.ImageInterface(
+            image_dir, CLIENT_API_VERSION, tracker, None, PKG_CLIENT_NAME
+        )
 
-                if api_inst.root != image_dir:
-                        msg(_("Problem getting image at {0}").format(
-                            image_dir))
-        except Exception as err:
-                raise SysrepoException(
-                    _("Unable to get image at {dir}: {reason}").format(
-                    dir=image_dir,
-                    reason=str(err)))
+        if api_inst.root != image_dir:
+            msg(_("Problem getting image at {0}").format(image_dir))
+    except Exception as err:
+        raise SysrepoException(
+            _("Unable to get image at {dir}: {reason}").format(
+                dir=image_dir, reason=str(err)
+            )
+        )
 
-        # restore the current directory, which ImageInterace had changed
-        os.chdir(cdir)
-        return api_inst
+    # restore the current directory, which ImageInterace had changed
+    os.chdir(cdir)
+    return api_inst
+
 
 def _clean_publisher(uri):
-        """ Remove the HTTP_PORT from the uri otherwise the rewrite rules 
-        (in the mako file) will incorporate it with the subsequent use of
-        libcurl, adhering to RPF7230 section 5.4, removing it and thus break
-        the matching on the rewrite rules leading to the default response of
-        404. There is no need to deal with the default https port (443) here
-        because the proxying transport from the non-global zone will be over
-        http and so libcurl will not remove the port (443) during the proxying
-        process (it is not the default port for the http protocol). So a global
-        zone publisher of https://example.com:443 will have
-        http://example.com:443 proxy requests which will not be modified by
-        the libcurl proxy rule manipulations. The rewrite rules in this
-        system repository service will, in the global zone, convert the
-        http to https.
-        """
-        urlresult = urlparse(uri)
-        if urlresult.port == HTTP_PORT:
-                uri = urlresult._replace(netloc=urlresult.netloc.replace(":" +
-                    str(urlresult.port), "")).geturl()
-        return uri
+    """Remove the HTTP_PORT from the uri otherwise the rewrite rules
+    (in the mako file) will incorporate it with the subsequent use of
+    libcurl, adhering to RPF7230 section 5.4, removing it and thus break
+    the matching on the rewrite rules leading to the default response of
+    404. There is no need to deal with the default https port (443) here
+    because the proxying transport from the non-global zone will be over
+    http and so libcurl will not remove the port (443) during the proxying
+    process (it is not the default port for the http protocol). So a global
+    zone publisher of https://example.com:443 will have
+    http://example.com:443 proxy requests which will not be modified by
+    the libcurl proxy rule manipulations. The rewrite rules in this
+    system repository service will, in the global zone, convert the
+    http to https.
+    """
+    urlresult = urlparse(uri)
+    if urlresult.port == HTTP_PORT:
+        uri = urlresult._replace(
+            netloc=urlresult.netloc.replace(":" + str(urlresult.port), "")
+        ).geturl()
+    return uri
+
 
 def _clean_pub_info(pub_info):
-        """ Fix up the publisher information so that any uri key does not
-        have the HTTP_PORT in it.
-        """
-        clean_pub_info = {}
-        for uri in pub_info:
-                cleanuri = _clean_publisher(uri)
-                clean_pub_info[cleanuri] = pub_info[uri]
+    """Fix up the publisher information so that any uri key does not
+    have the HTTP_PORT in it.
+    """
+    clean_pub_info = {}
+    for uri in pub_info:
+        cleanuri = _clean_publisher(uri)
+        clean_pub_info[cleanuri] = pub_info[uri]
 
-        return clean_pub_info
+    return clean_pub_info
+
 
 def _follow_redirects(uri_list, http_timeout):
-        """ Follow HTTP redirects from servers.  Needed so that we can create
-        RewriteRules for all repository URLs that pkg clients may encounter.
+    """Follow HTTP redirects from servers.  Needed so that we can create
+    RewriteRules for all repository URLs that pkg clients may encounter.
 
-        We return a sorted list of URIs that were found having followed all
-        redirects in 'uri_list'.  We also return a boolean, True if we timed out
-        when following any of the URIs.
-        """
+    We return a sorted list of URIs that were found having followed all
+    redirects in 'uri_list'.  We also return a boolean, True if we timed out
+    when following any of the URIs.
+    """
 
-        ret_uris = set(uri_list)
-        timed_out = False
+    ret_uris = set(uri_list)
+    timed_out = False
 
-        class SysrepoRedirectHandler(HTTPRedirectHandler):
-                """ A HTTPRedirectHandler that saves URIs we've been
-                redirected to along the path to our eventual destination."""
-                def __init__(self):
-                        self.redirects = set()
+    class SysrepoRedirectHandler(HTTPRedirectHandler):
+        """A HTTPRedirectHandler that saves URIs we've been
+        redirected to along the path to our eventual destination."""
 
-                def redirect_request(self, req, fp, code, msg, hdrs, newurl):
-                        self.redirects.add(newurl)
-                        return HTTPRedirectHandler.redirect_request(
-                            self, req, fp, code, msg, hdrs, newurl)
+        def __init__(self):
+            self.redirects = set()
 
-        for uri in uri_list:
-                handler = SysrepoRedirectHandler()
-                opener = build_opener(handler)
-                if not uri.startswith("http:"):
-                        ret_uris.update([uri])
-                        continue
+        def redirect_request(self, req, fp, code, msg, hdrs, newurl):
+            self.redirects.add(newurl)
+            return HTTPRedirectHandler.redirect_request(
+                self, req, fp, code, msg, hdrs, newurl
+            )
 
-                # otherwise, open a known url to check for redirects
-                try:
-                        opener.open("{0}/versions/0".format(uri), None,
-                            http_timeout)
-                        ret_uris.update(set(
-                            [item.replace("/versions/0", "").rstrip("/")
-                            for item in handler.redirects]))
-                except URLError as err:
-                        # We need to log this, and carry on - the url
-                        # could become available at a later date.
-                        msg(_("WARNING: unable to access {uri} when checking "
-                            "for redirects: {err}").format(**locals()))
-                        timed_out = True
+    for uri in uri_list:
+        handler = SysrepoRedirectHandler()
+        opener = build_opener(handler)
+        if not uri.startswith("http:"):
+            ret_uris.update([uri])
+            continue
 
-        return sorted(list(ret_uris)), timed_out
+        # otherwise, open a known url to check for redirects
+        try:
+            opener.open("{0}/versions/0".format(uri), None, http_timeout)
+            ret_uris.update(
+                set(
+                    [
+                        item.replace("/versions/0", "").rstrip("/")
+                        for item in handler.redirects
+                    ]
+                )
+            )
+        except URLError as err:
+            # We need to log this, and carry on - the url
+            # could become available at a later date.
+            msg(
+                _(
+                    "WARNING: unable to access {uri} when checking "
+                    "for redirects: {err}"
+                ).format(**locals())
+            )
+            timed_out = True
+
+    return sorted(list(ret_uris)), timed_out
+
 
 def __validate_pub_info(pub_info, no_uri_pubs, api_inst):
-        """Determine if pub_info and no_uri_pubs objects, which may have been
-        decoded from a json representation are valid, raising a SysrepoException
-        if they are not.
+    """Determine if pub_info and no_uri_pubs objects, which may have been
+    decoded from a json representation are valid, raising a SysrepoException
+    if they are not.
 
-        We use the api_inst to sanity-check that all publishers configured in
-        the image are represented in pub_info or no_uri_pubs, and that their
-        URIs are present.
+    We use the api_inst to sanity-check that all publishers configured in
+    the image are represented in pub_info or no_uri_pubs, and that their
+    URIs are present.
 
-        SysrepoExceptions are raised with developer-oriented debug messages
-        which are not to be translated or shown to users.
-        """
+    SysrepoExceptions are raised with developer-oriented debug messages
+    which are not to be translated or shown to users.
+    """
 
-        # validate the structure of the pub_info object
-        if not isinstance(pub_info, dict):
-                raise SysrepoException("{0} is not a dict".format(pub_info))
-        for uri in pub_info:
-                if not isinstance(uri, six.string_types):
-                        raise SysrepoException("{0} is not a basestring".format(
-                            uri))
-                uri_info = pub_info[uri]
-                if not isinstance(uri_info, list):
-                        raise SysrepoException("{0} is not a list".format(
-                            uri_info))
-                for props in uri_info:
-                        if len(props) != 6:
-                                raise SysrepoException("{0} does not have 6 "
-                                    "items".format(props))
-                        # props [0] and [3] must be strings
-                        if not isinstance(props[0], six.string_types) or \
-                            not isinstance(props[3], six.string_types):
-                                raise SysrepoException("indices 0 and 3 of {0} "
-                                    "are not basestrings".format(props))
-                        # prop[5] must be a string, either "file" or "dir"
-                        # and prop[0] must start with file://
-                        if not isinstance(props[5], six.string_types) or \
-                            (props[5] not in ["file", "dir"] and
-                            props[0].startswith("file://")):
-                                raise SysrepoException("index 5 of {0} is not a "
-                                    "basestring or is not 'file' or 'dir'".format(
-                                    props))
-        # validate the structure of the no_uri_pubs object
-        if not isinstance(no_uri_pubs, list):
-                raise SysrepoException("{0} is not a list".format(no_uri_pubs))
-        for item in no_uri_pubs:
-                if not isinstance(item, six.string_types):
-                        raise SysrepoException(
-                            "{0} is not a basestring".format(item))
+    # validate the structure of the pub_info object
+    if not isinstance(pub_info, dict):
+        raise SysrepoException("{0} is not a dict".format(pub_info))
+    for uri in pub_info:
+        if not isinstance(uri, six.string_types):
+            raise SysrepoException("{0} is not a basestring".format(uri))
+        uri_info = pub_info[uri]
+        if not isinstance(uri_info, list):
+            raise SysrepoException("{0} is not a list".format(uri_info))
+        for props in uri_info:
+            if len(props) != 6:
+                raise SysrepoException(
+                    "{0} does not have 6 " "items".format(props)
+                )
+            # props [0] and [3] must be strings
+            if not isinstance(props[0], six.string_types) or not isinstance(
+                props[3], six.string_types
+            ):
+                raise SysrepoException(
+                    "indices 0 and 3 of {0} "
+                    "are not basestrings".format(props)
+                )
+            # prop[5] must be a string, either "file" or "dir"
+            # and prop[0] must start with file://
+            if not isinstance(props[5], six.string_types) or (
+                props[5] not in ["file", "dir"]
+                and props[0].startswith("file://")
+            ):
+                raise SysrepoException(
+                    "index 5 of {0} is not a "
+                    "basestring or is not 'file' or 'dir'".format(props)
+                )
+    # validate the structure of the no_uri_pubs object
+    if not isinstance(no_uri_pubs, list):
+        raise SysrepoException("{0} is not a list".format(no_uri_pubs))
+    for item in no_uri_pubs:
+        if not isinstance(item, six.string_types):
+            raise SysrepoException("{0} is not a basestring".format(item))
 
-        # check that we have entries for each URI for each publisher.
-        # (we may have more URIs than these, due to server-side http redirects
-        # that are not reflected as origins or mirrors in the image itself)
-        for pub in api_inst.get_publishers():
-                if pub.disabled:
-                        continue
-                repo = pub.repository
-                for uri in repo.mirrors + repo.origins:
-                        uri_key = uri.uri.rstrip("/")
-                        # the pub_info will have been cleaned to remove
-                        # HTTP_PORT, so need to remove it here.
-                        uri_key = _clean_publisher(uri_key)
-                        if uri_key not in pub_info:
-                                raise SysrepoException("{0} is not in {1}".format(
-                                    uri_key, pub_info))
-                if repo.mirrors + repo.origins == []:
-                        if pub.prefix not in no_uri_pubs:
-                                raise SysrepoException("{0} is not in {1}".format(
-                                    pub.prefix, no_uri_pubs))
-        return
+    # check that we have entries for each URI for each publisher.
+    # (we may have more URIs than these, due to server-side http redirects
+    # that are not reflected as origins or mirrors in the image itself)
+    for pub in api_inst.get_publishers():
+        if pub.disabled:
+            continue
+        repo = pub.repository
+        for uri in repo.mirrors + repo.origins:
+            uri_key = uri.uri.rstrip("/")
+            # the pub_info will have been cleaned to remove
+            # HTTP_PORT, so need to remove it here.
+            uri_key = _clean_publisher(uri_key)
+            if uri_key not in pub_info:
+                raise SysrepoException(
+                    "{0} is not in {1}".format(uri_key, pub_info)
+                )
+        if repo.mirrors + repo.origins == []:
+            if pub.prefix not in no_uri_pubs:
+                raise SysrepoException(
+                    "{0} is not in {1}".format(pub.prefix, no_uri_pubs)
+                )
+    return
+
 
 def _load_publisher_info(api_inst, image_dir):
-        """Loads information about the publishers configured for the
-        given ImageInterface from image_dir in a format identical to that
-        returned by _get_publisher_info(..)  that is, a dictionary mapping
-        URIs to a list of lists. An example entry might be:
-            pub_info[uri] = [[prefix, cert, key, hash of the uri, proxy], ... ]
+    """Loads information about the publishers configured for the
+    given ImageInterface from image_dir in a format identical to that
+    returned by _get_publisher_info(..)  that is, a dictionary mapping
+    URIs to a list of lists. An example entry might be:
+        pub_info[uri] = [[prefix, cert, key, hash of the uri, proxy], ... ]
 
-        and a list of publishers which have no origin or mirror URIs.
+    and a list of publishers which have no origin or mirror URIs.
 
-        If the cache doesn't exist, or is in a format we don't recognise, or
-        we've managed to determine that it's stale, we return None, None
-        indicating that the publisher_info must be rebuilt.
-        """
-        pub_info = None
-        no_uri_pubs = None
-        cache_path = os.path.join(image_dir,
-            pkg.client.global_settings.sysrepo_pub_cache_path)
+    If the cache doesn't exist, or is in a format we don't recognise, or
+    we've managed to determine that it's stale, we return None, None
+    indicating that the publisher_info must be rebuilt.
+    """
+    pub_info = None
+    no_uri_pubs = None
+    cache_path = os.path.join(
+        image_dir, pkg.client.global_settings.sysrepo_pub_cache_path
+    )
+    try:
         try:
-                try:
-                        st_cache = os.lstat(cache_path)
-                except OSError as e:
-                        if e.errno == errno.ENOENT:
-                                return None, None
-                        else:
-                                raise
+            st_cache = os.lstat(cache_path)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                return None, None
+            else:
+                raise
 
-                # the cache must be a regular file
-                if not stat.S_ISREG(st_cache.st_mode):
-                        raise IOError("not a regular file")
+        # the cache must be a regular file
+        if not stat.S_ISREG(st_cache.st_mode):
+            raise IOError("not a regular file")
 
-                with open(cache_path, "r") as cache_file:
-                        try:
-                                pub_info_tuple = json.load(cache_file)
-                        except json.JSONDecodeError:
-                                error(_("Invalid config cache file at {0} "
-                                    "generating fresh configuration.").format(
-                                    cache_path))
-                                return None, None
-
-                        if len(pub_info_tuple) != 2:
-                                error(_("Invalid config cache at {0} "
-                                    "generating fresh configuration.").format(
-                                    cache_path))
-                                return None, None
-
-                        pub_info, no_uri_pubs = pub_info_tuple
-                        # sanity-check the cached configuration
-                        try:
-                                __validate_pub_info(pub_info, no_uri_pubs,
-                                    api_inst)
-                        except SysrepoException as e:
-                                error(_("Invalid config cache at {0} "
-                                    "generating fresh configuration.").format(
-                                    cache_path))
-                                return None, None
-
-        # If we have any problems loading the publisher info, we explain why.
-        except IOError as e:
-                error(_("Unable to load config from {cache_path}: {e}").format(
-                    **locals()))
+        with open(cache_path, "r") as cache_file:
+            try:
+                pub_info_tuple = json.load(cache_file)
+            except json.JSONDecodeError:
+                error(
+                    _(
+                        "Invalid config cache file at {0} "
+                        "generating fresh configuration."
+                    ).format(cache_path)
+                )
                 return None, None
 
-        # The cache file could have HTTP_PORT in it, cleaning it will
-        # cause the cache file to be rewriten due to the checks in the
-        # _validate_pub_info (the cleaned uri will not be in the cache
-        # file).
-        clean_pub_info = _clean_pub_info(pub_info)
+            if len(pub_info_tuple) != 2:
+                error(
+                    _(
+                        "Invalid config cache at {0} "
+                        "generating fresh configuration."
+                    ).format(cache_path)
+                )
+                return None, None
 
-        return clean_pub_info, no_uri_pubs
+            pub_info, no_uri_pubs = pub_info_tuple
+            # sanity-check the cached configuration
+            try:
+                __validate_pub_info(pub_info, no_uri_pubs, api_inst)
+            except SysrepoException as e:
+                error(
+                    _(
+                        "Invalid config cache at {0} "
+                        "generating fresh configuration."
+                    ).format(cache_path)
+                )
+                return None, None
+
+    # If we have any problems loading the publisher info, we explain why.
+    except IOError as e:
+        error(
+            _("Unable to load config from {cache_path}: {e}").format(**locals())
+        )
+        return None, None
+
+    # The cache file could have HTTP_PORT in it, cleaning it will
+    # cause the cache file to be rewriten due to the checks in the
+    # _validate_pub_info (the cleaned uri will not be in the cache
+    # file).
+    clean_pub_info = _clean_pub_info(pub_info)
+
+    return clean_pub_info, no_uri_pubs
+
 
 def _store_publisher_info(uri_pub_map, no_uri_pubs, image_dir):
-        """Stores a given pair of (uri_pub_map, no_uri_pubs) objects to a
-        configuration cache file beneath image_dir."""
-        cache_path = os.path.join(image_dir,
-            pkg.client.global_settings.sysrepo_pub_cache_path)
-        cache_dir = os.path.dirname(cache_path)
+    """Stores a given pair of (uri_pub_map, no_uri_pubs) objects to a
+    configuration cache file beneath image_dir."""
+    cache_path = os.path.join(
+        image_dir, pkg.client.global_settings.sysrepo_pub_cache_path
+    )
+    cache_dir = os.path.dirname(cache_path)
+    try:
+        if not os.path.exists(cache_dir):
+            os.makedirs(cache_dir, 0o700)
         try:
-                if not os.path.exists(cache_dir):
-                        os.makedirs(cache_dir, 0o700)
-                try:
-                        # if the cache exists, it must be a file
-                        st_cache = os.lstat(cache_path)
-                        if not stat.S_ISREG(st_cache.st_mode):
-                                raise IOError("not a regular file")
-                except IOError as e:
-                        # IOError has been merged into OSError in Python 3.4,
-                        # so we need a special case here.
-                        if str(e) == "not a regular file":
-                                raise
-                except OSError:
-                        pass
-
-                with open(cache_path, "w") as cache_file:
-                        json.dump((uri_pub_map, no_uri_pubs), cache_file,
-                            indent=4)
-                        os.chmod(cache_path, 0o600)
+            # if the cache exists, it must be a file
+            st_cache = os.lstat(cache_path)
+            if not stat.S_ISREG(st_cache.st_mode):
+                raise IOError("not a regular file")
         except IOError as e:
-                error(_("Unable to store config to {cache_path}: {e}").format(
-                    **locals()))
+            # IOError has been merged into OSError in Python 3.4,
+            # so we need a special case here.
+            if str(e) == "not a regular file":
+                raise
+        except OSError:
+            pass
+
+        with open(cache_path, "w") as cache_file:
+            json.dump((uri_pub_map, no_uri_pubs), cache_file, indent=4)
+            os.chmod(cache_path, 0o600)
+    except IOError as e:
+        error(
+            _("Unable to store config to {cache_path}: {e}").format(**locals())
+        )
+
 
 def _valid_proxy(proxy):
-        """Checks the given proxy string to make sure that it does not contain
-        any authentication details since these are not supported by ProxyRemote.
-        """
+    """Checks the given proxy string to make sure that it does not contain
+    any authentication details since these are not supported by ProxyRemote.
+    """
 
-        u = urlparse(proxy)
-        netloc_parts = u.netloc.split("@")
-        # If we don't have any authentication details, return.
-        if len(netloc_parts) == 1:
-                return True
-        return False
+    u = urlparse(proxy)
+    netloc_parts = u.netloc.split("@")
+    # If we don't have any authentication details, return.
+    if len(netloc_parts) == 1:
+        return True
+    return False
+
 
 def _get_publisher_info(api_inst, http_timeout, image_dir):
-        """Returns information about the publishers configured for the given
-        ImageInterface.
+    """Returns information about the publishers configured for the given
+    ImageInterface.
 
-        The first item returned is a map of uris to a list of lists of the form
-        [[prefix, cert, key, hash of the uri, proxy, uri type], ... ]
+    The first item returned is a map of uris to a list of lists of the form
+    [[prefix, cert, key, hash of the uri, proxy, uri type], ... ]
 
-        The second item returned is a list of publisher prefixes which specify
-        no uris.
+    The second item returned is a list of publisher prefixes which specify
+    no uris.
 
-        Where possible, we attempt to load cached publisher information, but if
-        that cached information is stale or unavailable, we fall back to
-        querying the image for the publisher information, verifying repository
-        URIs and checking for redirects and write that information to the
-        cache."""
+    Where possible, we attempt to load cached publisher information, but if
+    that cached information is stale or unavailable, we fall back to
+    querying the image for the publisher information, verifying repository
+    URIs and checking for redirects and write that information to the
+    cache."""
 
-        # the cache gets deleted by pkg.client.image.Image.save_config()
-        # any time publisher configuration changes are made.
-        uri_pub_map, no_uri_pubs = _load_publisher_info(api_inst, image_dir)
-        if uri_pub_map:
-                return uri_pub_map, no_uri_pubs
-
-        # map URIs to (pub.prefix, cert, key, hash, proxy, utype) tuples
-        uri_pub_map = {}
-        no_uri_pubs = []
-        timed_out = False
-
-        for pub in api_inst.get_publishers():
-                if pub.disabled:
-                        continue
-
-                prefix = pub.prefix
-                repo = pub.repository
-
-                # Only collect enabled URIs.
-                uris = [u
-                        for u in (repo.mirrors + repo.origins)
-                        if not u.disabled
-                ]
-
-                # Determine the proxies to use per URI
-                proxy_map = {}
-                for uri in uris:
-                        key = uri.uri.rstrip("/")
-                        if uri.proxies:
-                                # Apache can only use a single proxy, even
-                                # if many are configured. Use the first we find.
-                                proxy_map[key] = uri.proxies[0].uri
-
-                # Apache's ProxyRemote directive does not allow proxies that
-                # require authentication.
-                for uri in proxy_map:
-                        if not _valid_proxy(proxy_map[uri]):
-                                raise SysrepoException("proxy value {val} "
-                                    "for {uri} is not supported.".format(
-                                    uri=uri, val=proxy_map[uri]))
-
-                uri_list, timed_out = _follow_redirects(
-                    [repo_uri.uri.rstrip("/") for repo_uri in uris],
-                    http_timeout)
-
-                for uri in uri_list:
-
-                        # We keep a field to store information about the type
-                        # of URI we're looking at, which saves us
-                        # from needing to make os.path.isdir(..) or
-                        # os.path.isfile(..) calls when processing the template.
-                        # This is important when we're rebuilding the
-                        # configuration from cached publisher info and an
-                        # file:// repository is temporarily unreachable.
-                        utype = ""
-                        if uri.startswith("file:"):
-                                # we only support p5p files and directory-based
-                                # repositories of >= version 4.
-                                urlresult = urlparse(uri)
-                                utype = "dir"
-                                if not os.path.exists(urlresult.path):
-                                        raise SysrepoException(
-                                            _("file repository {0} does not "
-                                            "exist or is not accessible").format(uri))
-                                if os.path.isdir(urlresult.path) and \
-                                    not os.path.exists(os.path.join(
-                                    urlresult.path, "pkg5.repository")):
-                                        raise SysrepoException(
-                                            _("file repository {0} cannot be "
-                                            "proxied. Only file "
-                                            "repositories of version 4 or "
-                                            "later are supported.").format(uri))
-                                if not os.path.isdir(urlresult.path):
-                                        utype = "file"
-                                        try:
-                                                p5p.Archive(urlresult.path)
-                                        except p5p.InvalidArchive:
-                                                raise SysrepoException(
-                                                    _("unable to read p5p "
-                                                    "archive file at {0}").format(
-                                                    urlresult.path))
-
-                        clean_uri = _clean_publisher(uri)
-                        hash = _uri_hash(clean_uri)
-                        # we don't have per-uri ssl key/cert information yet,
-                        # so we just pull it from one of the RepositoryURIs.
-                        cert = repo.origins[-1].ssl_cert
-                        key = repo.origins[-1].ssl_key
-                        uri_pub_map.setdefault(clean_uri, []).append(
-                            (prefix, cert, key, hash, proxy_map.get(uri), utype)
-                            )
-
-                if not uris:
-                        no_uri_pubs.append(prefix)
-
-        # if we weren't able to follow all redirects, then we don't write a new
-        # cache, because it could be incomplete.
-        if not timed_out:
-                _store_publisher_info(uri_pub_map, no_uri_pubs, image_dir)
+    # the cache gets deleted by pkg.client.image.Image.save_config()
+    # any time publisher configuration changes are made.
+    uri_pub_map, no_uri_pubs = _load_publisher_info(api_inst, image_dir)
+    if uri_pub_map:
         return uri_pub_map, no_uri_pubs
 
+    # map URIs to (pub.prefix, cert, key, hash, proxy, utype) tuples
+    uri_pub_map = {}
+    no_uri_pubs = []
+    timed_out = False
+
+    for pub in api_inst.get_publishers():
+        if pub.disabled:
+            continue
+
+        prefix = pub.prefix
+        repo = pub.repository
+
+        # Only collect enabled URIs.
+        uris = [u for u in (repo.mirrors + repo.origins) if not u.disabled]
+
+        # Determine the proxies to use per URI
+        proxy_map = {}
+        for uri in uris:
+            key = uri.uri.rstrip("/")
+            if uri.proxies:
+                # Apache can only use a single proxy, even
+                # if many are configured. Use the first we find.
+                proxy_map[key] = uri.proxies[0].uri
+
+        # Apache's ProxyRemote directive does not allow proxies that
+        # require authentication.
+        for uri in proxy_map:
+            if not _valid_proxy(proxy_map[uri]):
+                raise SysrepoException(
+                    "proxy value {val} "
+                    "for {uri} is not supported.".format(
+                        uri=uri, val=proxy_map[uri]
+                    )
+                )
+
+        uri_list, timed_out = _follow_redirects(
+            [repo_uri.uri.rstrip("/") for repo_uri in uris], http_timeout
+        )
+
+        for uri in uri_list:
+            # We keep a field to store information about the type
+            # of URI we're looking at, which saves us
+            # from needing to make os.path.isdir(..) or
+            # os.path.isfile(..) calls when processing the template.
+            # This is important when we're rebuilding the
+            # configuration from cached publisher info and an
+            # file:// repository is temporarily unreachable.
+            utype = ""
+            if uri.startswith("file:"):
+                # we only support p5p files and directory-based
+                # repositories of >= version 4.
+                urlresult = urlparse(uri)
+                utype = "dir"
+                if not os.path.exists(urlresult.path):
+                    raise SysrepoException(
+                        _(
+                            "file repository {0} does not "
+                            "exist or is not accessible"
+                        ).format(uri)
+                    )
+                if os.path.isdir(urlresult.path) and not os.path.exists(
+                    os.path.join(urlresult.path, "pkg5.repository")
+                ):
+                    raise SysrepoException(
+                        _(
+                            "file repository {0} cannot be "
+                            "proxied. Only file "
+                            "repositories of version 4 or "
+                            "later are supported."
+                        ).format(uri)
+                    )
+                if not os.path.isdir(urlresult.path):
+                    utype = "file"
+                    try:
+                        p5p.Archive(urlresult.path)
+                    except p5p.InvalidArchive:
+                        raise SysrepoException(
+                            _(
+                                "unable to read p5p " "archive file at {0}"
+                            ).format(urlresult.path)
+                        )
+
+            clean_uri = _clean_publisher(uri)
+            hash = _uri_hash(clean_uri)
+            # we don't have per-uri ssl key/cert information yet,
+            # so we just pull it from one of the RepositoryURIs.
+            cert = repo.origins[-1].ssl_cert
+            key = repo.origins[-1].ssl_key
+            uri_pub_map.setdefault(clean_uri, []).append(
+                (prefix, cert, key, hash, proxy_map.get(uri), utype)
+            )
+
+        if not uris:
+            no_uri_pubs.append(prefix)
+
+    # if we weren't able to follow all redirects, then we don't write a new
+    # cache, because it could be incomplete.
+    if not timed_out:
+        _store_publisher_info(uri_pub_map, no_uri_pubs, image_dir)
+    return uri_pub_map, no_uri_pubs
+
+
 def _chown_cache_dir(dir):
-        """Sets ownership for cache directory as pkg5srv:bin"""
+    """Sets ownership for cache directory as pkg5srv:bin"""
 
-        uid = portable.get_user_by_name(SYSREPO_USER, None, False)
-        gid = portable.get_group_by_name("bin", None, False)
+    uid = portable.get_user_by_name(SYSREPO_USER, None, False)
+    gid = portable.get_group_by_name("bin", None, False)
+    try:
+        os.chown(dir, uid, gid)
+    except OSError as err:
+        if not os.environ.get("PKG5_TEST_ENV", None):
+            raise SysrepoException(
+                _("Unable to chown to {user}:{group}: " "{err}").format(
+                    user=SYSREPO_USER, group="bin", err=err
+                )
+            )
+
+
+def _write_httpd_conf(
+    runtime_dir,
+    log_dir,
+    template_dir,
+    host,
+    port,
+    cache_dir,
+    cache_size,
+    uri_pub_map,
+    http_proxy,
+    https_proxy,
+):
+    """Writes the apache configuration for the system repository.
+
+    If http_proxy or http_proxy is supplied, it will override any proxy
+    values set in the image we're reading configuration from.
+    """
+
+    try:
+        # check our hostname
+        socket.gethostbyname(host)
+
+        # check our directories
+        dirs = [runtime_dir, log_dir]
+        if cache_dir not in ["None", "memory"]:
+            dirs.append(cache_dir)
+        for dir in dirs + [template_dir]:
+            if os.path.exists(dir) and not os.path.isdir(dir):
+                raise SysrepoException(_("{0} is not a directory").format(dir))
+
+        for dir in dirs:
+            try:
+                os.makedirs(dir, 0o755)
+                # set pkg5srv:bin as ownership for cache
+                # directory.
+                if dir == cache_dir:
+                    _chown_cache_dir(dir)
+            except OSError as err:
+                if err.errno != errno.EEXIST:
+                    raise
+
+        # check our port
         try:
-                os.chown(dir, uid, gid)
-        except OSError as err:
-                if not os.environ.get("PKG5_TEST_ENV", None):
-                        raise SysrepoException(
-                            _("Unable to chown to {user}:{group}: "
-                            "{err}").format(
-                            user=SYSREPO_USER, group="bin",
-                            err=err))
+            num = int(port)
+            if num <= 0 or num >= 65535:
+                raise SysrepoException(_("invalid port: {0}").format(port))
+        except ValueError:
+            raise SysrepoException(_("invalid port: {0}").format(port))
 
-def _write_httpd_conf(runtime_dir, log_dir, template_dir, host, port, cache_dir,
-    cache_size, uri_pub_map, http_proxy, https_proxy):
-        """Writes the apache configuration for the system repository.
-
-        If http_proxy or http_proxy is supplied, it will override any proxy
-        values set in the image we're reading configuration from.
-        """
-
+        # check our cache size
         try:
-                # check our hostname
-                socket.gethostbyname(host)
-
-                # check our directories
-                dirs = [runtime_dir, log_dir]
-                if cache_dir not in ["None", "memory"]:
-                        dirs.append(cache_dir)
-                for dir in dirs + [template_dir]:
-                        if os.path.exists(dir) and not os.path.isdir(dir):
-                                raise SysrepoException(
-                                    _("{0} is not a directory").format(dir))
-
-                for dir in dirs:
-                        try:
-                                os.makedirs(dir, 0o755)
-                                # set pkg5srv:bin as ownership for cache
-                                # directory.
-                                if dir == cache_dir:
-                                        _chown_cache_dir(dir)
-                        except OSError as err:
-                                if err.errno != errno.EEXIST:
-                                        raise
-
-                # check our port
-                try:
-                        num = int(port)
-                        if num <= 0 or num >= 65535:
-                                raise SysrepoException(
-                                    _("invalid port: {0}").format(port))
-                except ValueError:
-                        raise SysrepoException(_("invalid port: {0}").format(
-                            port))
-
-                # check our cache size
-                try:
-                        num = int(cache_size)
-                        if num <= 0:
-                                raise SysrepoException(_("invalid cache size: "
-                                   "{0}").format(num))
-                except ValueError:
-                        raise SysrepoException(
-                            _("invalid cache size: {0}").format(cache_size))
-
-                # check our proxy arguments - we can use a proxy to handle
-                # incoming http or https requests, but that proxy must use http.
-                for key, val in [("http_proxy", http_proxy),
-                    ("https_proxy", https_proxy)]:
-                        if not val:
-                                continue
-                        try:
-                                result = urlparse(val)
-                                if result.scheme != "http":
-                                        raise Exception(
-                                            _("scheme must be http"))
-                                if not result.netloc:
-                                        raise Exception("missing netloc")
-                                if not _valid_proxy(val):
-                                        raise Exception("unsupported proxy")
-                        except Exception as e:
-                                raise SysrepoException(
-                                    _("invalid {key}: {val}: {err}").format(
-                                    key=key, val=val, err=str(e)))
-
-                httpd_conf_template_path = os.path.join(template_dir,
-                    SYSREPO_HTTP_TEMPLATE)
-
-                httpd_conf_template = Template(
-                    filename=httpd_conf_template_path)
-
-                # our template expects cache size expressed in Kb
-                httpd_conf_text = httpd_conf_template.render(
-                    sysrepo_log_dir=log_dir,
-                    sysrepo_runtime_dir=runtime_dir,
-                    sysrepo_template_dir=template_dir,
-                    uri_pub_map=uri_pub_map,
-                    ipv6_addr="::1",
-                    host=host,
-                    port=port,
-                    cache_dir=cache_dir,
-                    cache_size=int(cache_size) * 1024,
-                    http_proxy=http_proxy,
-                    https_proxy=https_proxy)
-                httpd_conf_path = os.path.join(runtime_dir,
-                    SYSREPO_HTTP_FILENAME)
-                httpd_conf_file = open(httpd_conf_path, "w")
-                httpd_conf_file.write(httpd_conf_text)
-                httpd_conf_file.close()
-        except (socket.gaierror, UnicodeError) as err:
-                # socket.gethostbyname raise UnicodeDecodeError in Python 3
-                # for some input, such as '.'
+            num = int(cache_size)
+            if num <= 0:
                 raise SysrepoException(
-                    _("Unable to write sysrepo_httpd.conf: {host}: "
-                    "{err}").format(**locals()))
-        except (OSError, IOError) as err:
+                    _("invalid cache size: " "{0}").format(num)
+                )
+        except ValueError:
+            raise SysrepoException(
+                _("invalid cache size: {0}").format(cache_size)
+            )
+
+        # check our proxy arguments - we can use a proxy to handle
+        # incoming http or https requests, but that proxy must use http.
+        for key, val in [
+            ("http_proxy", http_proxy),
+            ("https_proxy", https_proxy),
+        ]:
+            if not val:
+                continue
+            try:
+                result = urlparse(val)
+                if result.scheme != "http":
+                    raise Exception(_("scheme must be http"))
+                if not result.netloc:
+                    raise Exception("missing netloc")
+                if not _valid_proxy(val):
+                    raise Exception("unsupported proxy")
+            except Exception as e:
                 raise SysrepoException(
-                    _("Unable to write sysrepo_httpd.conf: {0}").format(err))
+                    _("invalid {key}: {val}: {err}").format(
+                        key=key, val=val, err=str(e)
+                    )
+                )
+
+        httpd_conf_template_path = os.path.join(
+            template_dir, SYSREPO_HTTP_TEMPLATE
+        )
+
+        httpd_conf_template = Template(filename=httpd_conf_template_path)
+
+        # our template expects cache size expressed in Kb
+        httpd_conf_text = httpd_conf_template.render(
+            sysrepo_log_dir=log_dir,
+            sysrepo_runtime_dir=runtime_dir,
+            sysrepo_template_dir=template_dir,
+            uri_pub_map=uri_pub_map,
+            ipv6_addr="::1",
+            host=host,
+            port=port,
+            cache_dir=cache_dir,
+            cache_size=int(cache_size) * 1024,
+            http_proxy=http_proxy,
+            https_proxy=https_proxy,
+        )
+        httpd_conf_path = os.path.join(runtime_dir, SYSREPO_HTTP_FILENAME)
+        httpd_conf_file = open(httpd_conf_path, "w")
+        httpd_conf_file.write(httpd_conf_text)
+        httpd_conf_file.close()
+    except (socket.gaierror, UnicodeError) as err:
+        # socket.gethostbyname raise UnicodeDecodeError in Python 3
+        # for some input, such as '.'
+        raise SysrepoException(
+            _("Unable to write sysrepo_httpd.conf: {host}: " "{err}").format(
+                **locals()
+            )
+        )
+    except (OSError, IOError) as err:
+        raise SysrepoException(
+            _("Unable to write sysrepo_httpd.conf: {0}").format(err)
+        )
+
 
 def _write_crypto_conf(runtime_dir, uri_pub_map):
-        """Writes the proxy-creds-${pub}.pem file, containing keys and
-        certificates in order for the system repository to proxy to https
-        repositories."""
+    """Writes the proxy-creds-${pub}.pem file, containing keys and
+    certificates in order for the system repository to proxy to https
+    repositories."""
 
-        try:
-                # It is possible that a remote SSL publisher may not send a CA
-                # name back to identify the key/cert pair to use. 'mod_ssl', in
-                # this instance will use the first key/cert in the
-                # <SSLProxyMachineCertificateFile> but depending upon the order
-                # of the configured publishers it could be wrong. So workaround
-                # this behavior by specifying a file per publisher.
-                for repo_list in uri_pub_map.values():
-                        for (pub, cert_path, key_path, hash, proxy, utype) in \
-                            repo_list:
-                                cred_file = os.path.join(runtime_dir,
-                                    "proxy-creds-" + pub + ".pem")
-                                # Ensure that the file is truncated prior to
-                                # writing to it.
-                                with open(os.open(cred_file, os.O_CREAT |
-                                    os.O_WRONLY, 0o400), 'w') as fh_cred:
-                                        if cert_path and key_path:
-                                                fh_cred.writelines(open(cert_path))
-                                                fh_cred.writelines(open(key_path))
-                                        else:
-                                                fh_cred.write(
-                                                    "# Apache mod_ssl requires "
-                                                    "that this file be more than"
-                                                    " zero length even when it "
-                                                    "does not contain a PEM "
-                                                    "format key/cert.\n")
-        except OSError as err:
-                raise SysrepoException(
-                    _("unable to write crypto.txt file: {0}").format(err))
+    try:
+        # It is possible that a remote SSL publisher may not send a CA
+        # name back to identify the key/cert pair to use. 'mod_ssl', in
+        # this instance will use the first key/cert in the
+        # <SSLProxyMachineCertificateFile> but depending upon the order
+        # of the configured publishers it could be wrong. So workaround
+        # this behavior by specifying a file per publisher.
+        for repo_list in uri_pub_map.values():
+            for pub, cert_path, key_path, hash, proxy, utype in repo_list:
+                cred_file = os.path.join(
+                    runtime_dir, "proxy-creds-" + pub + ".pem"
+                )
+                # Ensure that the file is truncated prior to
+                # writing to it.
+                with open(
+                    os.open(cred_file, os.O_CREAT | os.O_WRONLY, 0o400), "w"
+                ) as fh_cred:
+                    if cert_path and key_path:
+                        fh_cred.writelines(open(cert_path))
+                        fh_cred.writelines(open(key_path))
+                    else:
+                        fh_cred.write(
+                            "# Apache mod_ssl requires "
+                            "that this file be more than"
+                            " zero length even when it "
+                            "does not contain a PEM "
+                            "format key/cert.\n"
+                        )
+    except OSError as err:
+        raise SysrepoException(
+            _("unable to write crypto.txt file: {0}").format(err)
+        )
+
 
 def _write_publisher_response(uri_pub_map, htdocs_path, template_dir):
-        """Writes static html for all file-repository-based publishers that
-        is served as their publisher/0 responses.  Responses for
-        non-file-based publishers are handled by rewrite rules in our
-        Apache configuration."""
+    """Writes static html for all file-repository-based publishers that
+    is served as their publisher/0 responses.  Responses for
+    non-file-based publishers are handled by rewrite rules in our
+    Apache configuration."""
 
-        try:
-                # build a version of our uri_pub_map, keyed by publisher
-                pub_uri_map = {}
-                for uri in uri_pub_map:
-                        for (pub, cert, key, hash, proxy, utype) in \
-                            uri_pub_map[uri]:
-                                if pub not in pub_uri_map:
-                                        pub_uri_map[pub] = []
-                                pub_uri_map[pub].append(
-                                    (uri, cert, key, hash, proxy, utype))
+    try:
+        # build a version of our uri_pub_map, keyed by publisher
+        pub_uri_map = {}
+        for uri in uri_pub_map:
+            for pub, cert, key, hash, proxy, utype in uri_pub_map[uri]:
+                if pub not in pub_uri_map:
+                    pub_uri_map[pub] = []
+                pub_uri_map[pub].append((uri, cert, key, hash, proxy, utype))
 
-                publisher_template_path = os.path.join(template_dir,
-                    SYSREPO_PUB_TEMPLATE)
-                publisher_template = Template(filename=publisher_template_path)
+        publisher_template_path = os.path.join(
+            template_dir, SYSREPO_PUB_TEMPLATE
+        )
+        publisher_template = Template(filename=publisher_template_path)
 
-                for pub in pub_uri_map:
-                        for (uri, cert_path, key_path, hash, proxy, utype) in \
-                            pub_uri_map[pub]:
-                                if uri.startswith("file:"):
-                                        publisher_text = \
-                                            publisher_template.render(
-                                            uri=uri, pub=pub)
-                                        publisher_path = os.path.sep.join(
-                                            [htdocs_path, pub, hash] +
-                                            SYSREPO_PUB_DIRNAME)
-                                        os.makedirs(publisher_path)
-                                        publisher_file = open(
-                                            os.path.sep.join([publisher_path,
-                                            SYSREPO_PUB_FILENAME]), "w")
-                                        publisher_file.write(publisher_text)
-                                        publisher_file.close()
-        except OSError as err:
-                raise SysrepoException(
-                    _("unable to write publisher response: {0}").format(err))
+        for pub in pub_uri_map:
+            for uri, cert_path, key_path, hash, proxy, utype in pub_uri_map[
+                pub
+            ]:
+                if uri.startswith("file:"):
+                    publisher_text = publisher_template.render(uri=uri, pub=pub)
+                    publisher_path = os.path.sep.join(
+                        [htdocs_path, pub, hash] + SYSREPO_PUB_DIRNAME
+                    )
+                    os.makedirs(publisher_path)
+                    publisher_file = open(
+                        os.path.sep.join(
+                            [publisher_path, SYSREPO_PUB_FILENAME]
+                        ),
+                        "w",
+                    )
+                    publisher_file.write(publisher_text)
+                    publisher_file.close()
+    except OSError as err:
+        raise SysrepoException(
+            _("unable to write publisher response: {0}").format(err)
+        )
+
 
 def _write_versions_response(htdocs_path):
-        """Writes a static versions/0 response for the system repository."""
+    """Writes a static versions/0 response for the system repository."""
 
-        try:
-                versions_path = os.path.join(htdocs_path,
-                    os.path.sep.join(SYSREPO_VERSIONS_DIRNAME))
-                os.makedirs(versions_path)
+    try:
+        versions_path = os.path.join(
+            htdocs_path, os.path.sep.join(SYSREPO_VERSIONS_DIRNAME)
+        )
+        os.makedirs(versions_path)
 
-                versions_file = open(os.path.join(versions_path, "index.html"),
-                    "w")
-                versions_file.write(SYSREPO_VERSIONS_STR)
-                versions_file.close()
-        except OSError as err:
-                raise SysrepoException(
-                    _("Unable to write versions response: {0}").format(err))
+        versions_file = open(os.path.join(versions_path, "index.html"), "w")
+        versions_file.write(SYSREPO_VERSIONS_STR)
+        versions_file.close()
+    except OSError as err:
+        raise SysrepoException(
+            _("Unable to write versions response: {0}").format(err)
+        )
+
 
 def _write_sysrepo_response(api_inst, htdocs_path, uri_pub_map, no_uri_pubs):
-        """Writes a static syspub/0 response for the system repository."""
+    """Writes a static syspub/0 response for the system repository."""
 
-        try:
-                sysrepo_path = os.path.join(htdocs_path,
-                    os.path.sep.join(SYSREPO_SYSPUB_DIRNAME))
-                os.makedirs(sysrepo_path)
-                pub_prefixes = [
-                    info[0]
-                    for uri in uri_pub_map.keys()
-                    for info in uri_pub_map[uri]
-                ]
-                pub_prefixes.extend(no_uri_pubs)
-                api_inst.write_syspub(os.path.join(sysrepo_path, "index.html"),
-                    pub_prefixes, 0)
-        except (OSError, apx.ApiException) as err:
-                raise SysrepoException(
-                    _("Unable to write syspub response: {0}").format(err))
+    try:
+        sysrepo_path = os.path.join(
+            htdocs_path, os.path.sep.join(SYSREPO_SYSPUB_DIRNAME)
+        )
+        os.makedirs(sysrepo_path)
+        pub_prefixes = [
+            info[0] for uri in uri_pub_map.keys() for info in uri_pub_map[uri]
+        ]
+        pub_prefixes.extend(no_uri_pubs)
+        api_inst.write_syspub(
+            os.path.join(sysrepo_path, "index.html"), pub_prefixes, 0
+        )
+    except (OSError, apx.ApiException) as err:
+        raise SysrepoException(
+            _("Unable to write syspub response: {0}").format(err)
+        )
+
 
 def _uri_hash(uri):
-        """Returns a string hash of the given URI"""
-        # Unicode-objects must be encoded before hashing 
-        return digest.DEFAULT_HASH_FUNC(misc.force_bytes(uri)).hexdigest()
+    """Returns a string hash of the given URI"""
+    # Unicode-objects must be encoded before hashing
+    return digest.DEFAULT_HASH_FUNC(misc.force_bytes(uri)).hexdigest()
+
 
 def _chown_runtime_dir(runtime_dir):
-        """Change the ownership of all files under runtime_dir to our sysrepo
-        user/group"""
+    """Change the ownership of all files under runtime_dir to our sysrepo
+    user/group"""
 
-        uid = portable.get_user_by_name(SYSREPO_USER, None, False)
-        gid = portable.get_group_by_name(SYSREPO_GROUP, None, False)
-        try:
-                misc.recursive_chown_dir(runtime_dir, uid, gid)
-        except OSError as err:
-                if not os.environ.get("PKG5_TEST_ENV", None):
-                        raise SysrepoException(
-                            _("Unable to chown to {user}:{group}: "
-                            "{err}").format(
-                            user=SYSREPO_USER, group=SYSREPO_GROUP,
-                            err=err))
+    uid = portable.get_user_by_name(SYSREPO_USER, None, False)
+    gid = portable.get_group_by_name(SYSREPO_GROUP, None, False)
+    try:
+        misc.recursive_chown_dir(runtime_dir, uid, gid)
+    except OSError as err:
+        if not os.environ.get("PKG5_TEST_ENV", None):
+            raise SysrepoException(
+                _("Unable to chown to {user}:{group}: " "{err}").format(
+                    user=SYSREPO_USER, group=SYSREPO_GROUP, err=err
+                )
+            )
+
 
 def cleanup_conf(runtime_dir=None):
-        """Destroys an old configuration."""
+    """Destroys an old configuration."""
+    try:
+        shutil.rmtree(runtime_dir, ignore_errors=True)
+    except OSError as err:
+        raise SysrepoException(
+            _("Unable to cleanup old configuration: {0}").format(err)
+        )
+
+
+def refresh_conf(
+    image_root="/",
+    port=None,
+    runtime_dir=None,
+    log_dir=None,
+    template_dir=None,
+    host="127.0.0.1",
+    cache_dir=None,
+    cache_size=1024,
+    http_timeout=3,
+    http_proxy=None,
+    https_proxy=None,
+):
+    """Creates a new configuration for the system repository.
+
+    TODO: a way to map only given zones to given publishers
+    """
+    try:
+        ret = EXIT_OK
+        cleanup_conf(runtime_dir=runtime_dir)
         try:
-                shutil.rmtree(runtime_dir, ignore_errors=True)
-        except OSError as err:
-                raise SysrepoException(
-                    _("Unable to cleanup old configuration: {0}").format(err))
-
-def refresh_conf(image_root="/", port=None, runtime_dir=None,
-    log_dir=None, template_dir=None, host="127.0.0.1", cache_dir=None,
-    cache_size=1024, http_timeout=3, http_proxy=None, https_proxy=None):
-        """Creates a new configuration for the system repository.
-
-        TODO: a way to map only given zones to given publishers
-        """
+            http_timeout = int(http_timeout)
+        except ValueError as err:
+            raise SysrepoException(
+                _("invalid value for http_timeout: {0}").format(err)
+            )
+        if http_timeout < 1:
+            raise SysrepoException(_("http_timeout must a positive integer"))
         try:
-                ret = EXIT_OK
-                cleanup_conf(runtime_dir=runtime_dir)
-                try:
-                        http_timeout = int(http_timeout)
-                except ValueError as err:
-                        raise SysrepoException(
-                            _("invalid value for http_timeout: {0}").format(err))
-                if http_timeout < 1:
-                        raise SysrepoException(
-                            _("http_timeout must a positive integer"))
-                try:
-                        api_inst = _get_image(image_root)
-                        uri_pub_map, no_uri_pubs = _get_publisher_info(api_inst,
-                            http_timeout, api_inst.root)
-                except SysrepoException as err:
-                        raise SysrepoException(
-                            _("unable to get publisher information: {0}").format(
-                            err))
-                try:
-                        htdocs_path = os.path.join(runtime_dir,
-                            SYSREPO_HTDOCS_DIRNAME)
-                        os.makedirs(htdocs_path)
-                except OSError as err:
-                        raise SysrepoException(
-                            _("unable to create htdocs dir: {0}").format(err))
-
-                _write_httpd_conf(runtime_dir, log_dir, template_dir, host,
-                    port, cache_dir, cache_size, uri_pub_map, http_proxy,
-                    https_proxy)
-                _write_crypto_conf(runtime_dir, uri_pub_map)
-                _write_publisher_response(uri_pub_map, htdocs_path,
-                    template_dir)
-                _write_versions_response(htdocs_path)
-                _write_sysrepo_response(api_inst, htdocs_path, uri_pub_map,
-                    no_uri_pubs)
-                _chown_runtime_dir(runtime_dir)
+            api_inst = _get_image(image_root)
+            uri_pub_map, no_uri_pubs = _get_publisher_info(
+                api_inst, http_timeout, api_inst.root
+            )
         except SysrepoException as err:
-                error(err)
-                ret = EXIT_OOPS
-        return ret
+            raise SysrepoException(
+                _("unable to get publisher information: {0}").format(err)
+            )
+        try:
+            htdocs_path = os.path.join(runtime_dir, SYSREPO_HTDOCS_DIRNAME)
+            os.makedirs(htdocs_path)
+        except OSError as err:
+            raise SysrepoException(
+                _("unable to create htdocs dir: {0}").format(err)
+            )
+
+        _write_httpd_conf(
+            runtime_dir,
+            log_dir,
+            template_dir,
+            host,
+            port,
+            cache_dir,
+            cache_size,
+            uri_pub_map,
+            http_proxy,
+            https_proxy,
+        )
+        _write_crypto_conf(runtime_dir, uri_pub_map)
+        _write_publisher_response(uri_pub_map, htdocs_path, template_dir)
+        _write_versions_response(htdocs_path)
+        _write_sysrepo_response(api_inst, htdocs_path, uri_pub_map, no_uri_pubs)
+        _chown_runtime_dir(runtime_dir)
+    except SysrepoException as err:
+        error(err)
+        ret = EXIT_OOPS
+    return ret
+
 
 def main_func():
-        global_settings.client_name = PKG_CLIENT_NAME
+    global_settings.client_name = PKG_CLIENT_NAME
 
-        global orig_cwd
+    global orig_cwd
 
+    try:
+        orig_cwd = os.getcwd()
+    except OSError as e:
         try:
-                orig_cwd = os.getcwd()
-        except OSError as e:
-                try:
-                        orig_cwd = os.environ["PWD"]
-                        if not orig_cwd or orig_cwd[0] != "/":
-                                orig_cwd = None
-                except KeyError:
-                        orig_cwd = None
+            orig_cwd = os.environ["PWD"]
+            if not orig_cwd or orig_cwd[0] != "/":
+                orig_cwd = None
+        except KeyError:
+            orig_cwd = None
 
-        # some sensible defaults
-        host = "127.0.0.1"
-        port = None
-        # an empty image_root means we don't get '//' in the below
-        # _get_image() deals with "" in a sane manner.
-        image_root = ""
-        cache_dir = "{0}/var/cache/pkg/sysrepo".format(image_root)
-        cache_size = "1024"
-        template_dir = "{0}/etc/pkg/sysrepo".format(image_root)
-        runtime_dir = "{0}/var/run/pkg/sysrepo".format(image_root)
-        log_dir = "{0}/var/log/pkg/sysrepo".format(image_root)
-        http_timeout = 4
-        http_proxy = None
-        https_proxy = None
+    # some sensible defaults
+    host = "127.0.0.1"
+    port = None
+    # an empty image_root means we don't get '//' in the below
+    # _get_image() deals with "" in a sane manner.
+    image_root = ""
+    cache_dir = "{0}/var/cache/pkg/sysrepo".format(image_root)
+    cache_size = "1024"
+    template_dir = "{0}/etc/pkg/sysrepo".format(image_root)
+    runtime_dir = "{0}/var/run/pkg/sysrepo".format(image_root)
+    log_dir = "{0}/var/log/pkg/sysrepo".format(image_root)
+    http_timeout = 4
+    http_proxy = None
+    https_proxy = None
 
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:],
-                    "c:h:l:p:r:R:s:t:T:w:W:?", ["help"])
-                for opt, arg in opts:
-                        if opt == "-c":
-                                cache_dir = arg
-                        elif opt == "-h":
-                                host = arg
-                        elif opt == "-l":
-                                log_dir = arg
-                        elif opt == "-p":
-                                port = arg
-                        elif opt == "-r":
-                                runtime_dir = arg
-                        elif opt == "-R":
-                                image_root = arg
-                        elif opt == "-s":
-                                cache_size = arg
-                        elif opt == "-t":
-                                template_dir = arg
-                        elif opt == "-T":
-                                http_timeout = arg
-                        elif opt == "-w":
-                                http_proxy = arg
-                        elif opt == "-W":
-                                https_proxy = arg
-                        else:
-                                usage()
+    try:
+        opts, pargs = getopt.getopt(
+            sys.argv[1:], "c:h:l:p:r:R:s:t:T:w:W:?", ["help"]
+        )
+        for opt, arg in opts:
+            if opt == "-c":
+                cache_dir = arg
+            elif opt == "-h":
+                host = arg
+            elif opt == "-l":
+                log_dir = arg
+            elif opt == "-p":
+                port = arg
+            elif opt == "-r":
+                runtime_dir = arg
+            elif opt == "-R":
+                image_root = arg
+            elif opt == "-s":
+                cache_size = arg
+            elif opt == "-t":
+                template_dir = arg
+            elif opt == "-T":
+                http_timeout = arg
+            elif opt == "-w":
+                http_proxy = arg
+            elif opt == "-W":
+                https_proxy = arg
+            else:
+                usage()
 
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
 
-        if not port:
-                usage(_("required port option missing."))
+    if not port:
+        usage(_("required port option missing."))
 
-        ret = refresh_conf(image_root=image_root, log_dir=log_dir,
-            host=host, port=port, runtime_dir=runtime_dir,
-            template_dir=template_dir, cache_dir=cache_dir,
-            cache_size=cache_size, http_timeout=http_timeout,
-            http_proxy=http_proxy, https_proxy=https_proxy)
-        return ret
+    ret = refresh_conf(
+        image_root=image_root,
+        log_dir=log_dir,
+        host=host,
+        port=port,
+        runtime_dir=runtime_dir,
+        template_dir=template_dir,
+        cache_dir=cache_dir,
+        cache_size=cache_size,
+        http_timeout=http_timeout,
+        http_proxy=http_proxy,
+        https_proxy=https_proxy,
+    )
+    return ret
+
 
 #
 # Establish a specific exit status which means: "python barfed an exception"
 # so that we can more easily detect these in testing of the CLI commands.
 #
 def handle_errors(func, *args, **kwargs):
-        """Catch exceptions raised by the main program function and then print
-        a message and/or exit with an appropriate return code.
-        """
+    """Catch exceptions raised by the main program function and then print
+    a message and/or exit with an appropriate return code.
+    """
 
-        traceback_str = misc.get_traceback_message()
+    traceback_str = misc.get_traceback_message()
 
+    try:
+        # Out of memory errors can be raised as EnvironmentErrors with
+        # an errno of ENOMEM, so in order to handle those exceptions
+        # with other errnos, we nest this try block and have the outer
+        # one handle the other instances.
         try:
-                # Out of memory errors can be raised as EnvironmentErrors with
-                # an errno of ENOMEM, so in order to handle those exceptions
-                # with other errnos, we nest this try block and have the outer
-                # one handle the other instances.
-                try:
-                        __ret = func(*args, **kwargs)
-                except (MemoryError, EnvironmentError) as __e:
-                        if isinstance(__e, EnvironmentError) and \
-                            __e.errno != errno.ENOMEM:
-                                raise
-                        error("\n" + misc.out_of_memory())
-                        __ret = EXIT_OOPS
-        except SystemExit as __e:
-                raise __e
-        except (PipeError, KeyboardInterrupt):
-                # Don't display any messages here to prevent possible further
-                # broken pipe (EPIPE) errors.
-                __ret = EXIT_OOPS
-        except apx.VersionException as __e:
-                error(_("The sysrepo command appears out of sync with the "
-                    "libraries provided\nby pkg:/package/pkg. The client "
-                    "version is {client} while the library\nAPI version is "
-                    "{api}.").format(client=__e.received_version,
-                     api=__e.expected_version))
-                __ret = EXIT_OOPS
-        except:
-                traceback.print_exc()
-                error(traceback_str)
-                __ret = 99
-        return __ret
+            __ret = func(*args, **kwargs)
+        except (MemoryError, EnvironmentError) as __e:
+            if isinstance(__e, EnvironmentError) and __e.errno != errno.ENOMEM:
+                raise
+            error("\n" + misc.out_of_memory())
+            __ret = EXIT_OOPS
+    except SystemExit as __e:
+        raise __e
+    except (PipeError, KeyboardInterrupt):
+        # Don't display any messages here to prevent possible further
+        # broken pipe (EPIPE) errors.
+        __ret = EXIT_OOPS
+    except apx.VersionException as __e:
+        error(
+            _(
+                "The sysrepo command appears out of sync with the "
+                "libraries provided\nby pkg:/package/pkg. The client "
+                "version is {client} while the library\nAPI version is "
+                "{api}."
+            ).format(client=__e.received_version, api=__e.expected_version)
+        )
+        __ret = EXIT_OOPS
+    except:
+        traceback.print_exc()
+        error(traceback_str)
+        __ret = 99
+    return __ret
 
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
 
-        # Make all warnings be errors.
-        warnings.simplefilter('error')
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
+    # Make all warnings be errors.
+    warnings.simplefilter("error")
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
 
-        __retval = handle_errors(main_func)
-        try:
-                logging.shutdown()
-        except IOError:
-                # Ignore python's spurious pipe problems.
-                pass
-        sys.exit(__retval)
+    __retval = handle_errors(main_func)
+    try:
+        logging.shutdown()
+    except IOError:
+        # Ignore python's spurious pipe problems.
+        pass
+    sys.exit(__retval)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/__init__.py
+++ b/src/tests/api/__init__.py
@@ -25,4 +25,4 @@
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_action.py
+++ b/src/tests/api/t_action.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import six
@@ -40,690 +41,816 @@ import pkg.digest
 from pkg.client.debugvalues import DebugValues
 from importlib import reload
 
+
 class TestActions(pkg5unittest.Pkg5TestCase):
+    act_strings = [
+        "set name=foo value=foo",
+        'set name=foo value=""',
+        "set name=foo value=f'o'o",
+        "set name=foo value='f\"o \"o'",
+        "set name=foo value='b\"a \"r' value='f\"o \"o'",
+        "set name=foo value=\"f'o 'o\"",
+        "set name=foo value=\"b'a 'r\" value=\"f'o 'o\"",
+        "set name=foo value='f\"o \\' \"o'",
+        "set name=foo value='b\"a \\' \"r' value='f\"o \\' \"o'",
+        "set name=foo value='\"foo\"'",
+        "set name=foo value='\"bar\"'value='\"foo\"'",
+        "set name=foo value=\"'foo'\"",
+        "set name=foo value=\"'bar'\" value=\"'foo'\"",
+        "set name=foo value='\"fo\\'o\"'",
+        "set name=foo value='\"ba\\'r\"' value='\"fo\\'o\"'",
+        'set name=foo value="\'fo\\"o\'"',
+        'set name=foo value="\'ba\\"r\'" value="\'fo\\"o\'"',
+        'set name=foo value=ab value="" value=c',
+        "file 12345 name=foo path=/tmp/foo",
+        "file 12345 name=foo attr=bar path=/tmp/foo",
+        "file 12345 name=foo attr=bar attr=bar path=/tmp/foo",
+        "file 12345 name=foo     attr=bar path=/tmp/foo",
+        "file 12345 name=foo     path=/tmp/foo attr=bar   ",
+        "file 12345 name=foo     path=/tmp/foo attr=bar   ",
+        'file 12345 name="foo bar"  attr="bar baz" path=/tmp/foo',
+        'file 12345 name="foo bar"  attr="bar baz" path=/tmp/foo',
+        "file 12345 name=foo  value=barbaz path=/tmp/foo",
+        'file 12345 name=foo  value="bar baz" path=/tmp/foo',
+        'file 12345 name="foo bar"  value=baz path=/tmp/foo',
+        "file 12345 name=foo  value=barbazquux path=/tmp/foo",
+        'file 12345 name=foo  value="bar baz quux" path=/tmp/foo',
+        'file 12345 name="foo bar baz"  value=quux path=/tmp/foo',
+        'file 12345 name="foo"  value="bar" path=/tmp/foo',
+        'file 12345 name=foo  value="bar" path=/tmp/foo',
+        'file 12345 name="foo"  value=bar path=/tmp/foo',
+        "file 12345 name='foo' value=bar path=/tmp/foo",
+        "file 12345 name='f\"o\"o' value=bar path=/tmp/foo",
+        "file 12345 name='f\\'o\\'o' value=bar path=/tmp/foo",
+        "file 12345 name=foo\tvalue=bar path=/tmp/foo",
+        "driver alias=pci1234,56 alias=pci4567,89 class=scsi name=lsimega",
+        "signature 12345 algorithm=foo",
+    ]
 
+    def assertAttributeValue(self, action, attr, value):
+        attrs = action.attrs[attr]
 
-        act_strings = [
-            "set name=foo value=foo",
-            "set name=foo value=\"\"",
-            "set name=foo value=f'o'o",
-            "set name=foo value='f\"o \"o'",
-            "set name=foo value='b\"a \"r' value='f\"o \"o'",
-            "set name=foo value=\"f'o 'o\"",
-            "set name=foo value=\"b'a 'r\" value=\"f'o 'o\"",
-            "set name=foo value='f\"o \\' \"o'",
-            "set name=foo value='b\"a \\' \"r' value='f\"o \\' \"o'",
-            "set name=foo value='\"foo\"'",
-            "set name=foo value='\"bar\"'value='\"foo\"'",
-            "set name=foo value=\"'foo'\"",
-            "set name=foo value=\"'bar'\" value=\"'foo'\"",
-            "set name=foo value='\"fo\\\'o\"'",
-            "set name=foo value='\"ba\\\'r\"' value='\"fo\\\'o\"'",
-            "set name=foo value=\"'fo\\\"o'\"",
-            "set name=foo value=\"'ba\\\"r'\" value=\"'fo\\\"o'\"",
-            'set name=foo value=ab value="" value=c',
-            "file 12345 name=foo path=/tmp/foo",
-            "file 12345 name=foo attr=bar path=/tmp/foo",
-            "file 12345 name=foo attr=bar attr=bar path=/tmp/foo",
-            "file 12345 name=foo     attr=bar path=/tmp/foo",
-            "file 12345 name=foo     path=/tmp/foo attr=bar   ",
-            "file 12345 name=foo     path=/tmp/foo attr=bar   ",
-            "file 12345 name=\"foo bar\"  attr=\"bar baz\" path=/tmp/foo",
-            "file 12345 name=\"foo bar\"  attr=\"bar baz\" path=/tmp/foo",
-            "file 12345 name=foo  value=barbaz path=/tmp/foo",
-            "file 12345 name=foo  value=\"bar baz\" path=/tmp/foo",
-            "file 12345 name=\"foo bar\"  value=baz path=/tmp/foo",
-            "file 12345 name=foo  value=barbazquux path=/tmp/foo",
-            "file 12345 name=foo  value=\"bar baz quux\" path=/tmp/foo",
-            "file 12345 name=\"foo bar baz\"  value=quux path=/tmp/foo",
-            "file 12345 name=\"foo\"  value=\"bar\" path=/tmp/foo",
-            "file 12345 name=foo  value=\"bar\" path=/tmp/foo",
-            "file 12345 name=\"foo\"  value=bar path=/tmp/foo",
-            "file 12345 name='foo' value=bar path=/tmp/foo",
-            "file 12345 name='f\"o\"o' value=bar path=/tmp/foo",
-            "file 12345 name='f\\'o\\'o' value=bar path=/tmp/foo",
-            "file 12345 name=foo\tvalue=bar path=/tmp/foo",
-            "driver alias=pci1234,56 alias=pci4567,89 class=scsi name=lsimega",
-            "signature 12345 algorithm=foo",
-        ]
+        if isinstance(attrs, list):
+            attrs.sort()
+        if isinstance(value, list):
+            value.sort()
 
-        def assertAttributeValue(self, action, attr, value):
-                attrs = action.attrs[attr]
-
-                if isinstance(attrs, list):
-                        attrs.sort()
-                if isinstance(value, list):
-                        value.sort()
-
-                if attrs != value:
-                        self.fail("""\
+        if attrs != value:
+            self.fail(
+                """\
 Incorrect attribute value.
     Expected: {0}
-    Actual:   {1}""".format(value, attrs))
+    Actual:   {1}""".format(
+                    value, attrs
+                )
+            )
 
-        def assertAttributes(self, action, attrlist):
-                if sorted(action.attrs.keys()) != sorted(attrlist):
-                        self.fail("""\
+    def assertAttributes(self, action, attrlist):
+        if sorted(action.attrs.keys()) != sorted(attrlist):
+            self.fail(
+                """\
 Incorrect attribute list.
     Expected: {0}
-    Actual:   {1}""".format(sorted(attrlist), sorted(action.attrs.keys())))
+    Actual:   {1}""".format(
+                    sorted(attrlist), sorted(action.attrs.keys())
+                )
+            )
 
-        def test_action_parser(self):
-                action.fromstr("file 12345 name=foo path=/tmp/foo")
-                action.fromstr("file 12345 name=foo attr=bar path=/tmp/foo")
-                action.fromstr("file 12345 name=foo attr=bar attr=bar path=/tmp/foo")
+    def test_action_parser(self):
+        action.fromstr("file 12345 name=foo path=/tmp/foo")
+        action.fromstr("file 12345 name=foo attr=bar path=/tmp/foo")
+        action.fromstr("file 12345 name=foo attr=bar attr=bar path=/tmp/foo")
 
-                action.fromstr("file 12345 name=foo     path=/tmp/foo attr=bar")
-                action.fromstr("file 12345 name=foo     path=/tmp/foo attr=bar   ")
-                action.fromstr("file 12345 name=foo     path=/tmp/foo attr=bar   ")
+        action.fromstr("file 12345 name=foo     path=/tmp/foo attr=bar")
+        action.fromstr("file 12345 name=foo     path=/tmp/foo attr=bar   ")
+        action.fromstr("file 12345 name=foo     path=/tmp/foo attr=bar   ")
 
-                action.fromstr("file 12345 name=\"foo bar\"  path=\"/tmp/foo\" attr=\"bar baz\"")
-                action.fromstr("file 12345 name=\"foo bar\"  path=\"/tmp/foo\" attr=\"bar baz\"")
+        action.fromstr(
+            'file 12345 name="foo bar"  path="/tmp/foo" attr="bar baz"'
+        )
+        action.fromstr(
+            'file 12345 name="foo bar"  path="/tmp/foo" attr="bar baz"'
+        )
 
-                action.fromstr("file 12345 name=foo  value=barbaz path=/tmp/foo")
-                action.fromstr("file 12345 name=foo  value=\"bar baz\" path=/tmp/foo")
-                action.fromstr("file 12345 name=\"foo bar\"  value=baz path=/tmp/foo")
+        action.fromstr("file 12345 name=foo  value=barbaz path=/tmp/foo")
+        action.fromstr('file 12345 name=foo  value="bar baz" path=/tmp/foo')
+        action.fromstr('file 12345 name="foo bar"  value=baz path=/tmp/foo')
 
-                action.fromstr("file 12345 name=foo  value=barbazquux path=/tmp/foo")
-                action.fromstr("file 12345 name=foo  value=\"bar baz quux\" path=/tmp/foo")
-                action.fromstr("file 12345 name=\"foo bar baz\"  value=quux path=/tmp/foo")
+        action.fromstr("file 12345 name=foo  value=barbazquux path=/tmp/foo")
+        action.fromstr(
+            'file 12345 name=foo  value="bar baz quux" path=/tmp/foo'
+        )
+        action.fromstr(
+            'file 12345 name="foo bar baz"  value=quux path=/tmp/foo'
+        )
 
-                action.fromstr("file 12345 name=\"foo\"  value=\"bar\" path=/tmp/foo")
-                action.fromstr("file 12345 name=foo  value=\"bar\" path=/tmp/foo")
-                action.fromstr("file 12345 name=\"foo\"  value=bar path=/tmp/foo")
+        action.fromstr('file 12345 name="foo"  value="bar" path=/tmp/foo')
+        action.fromstr('file 12345 name=foo  value="bar" path=/tmp/foo')
+        action.fromstr('file 12345 name="foo"  value=bar path=/tmp/foo')
 
-                action.fromstr("signature 12345 algorithm=foo")
+        action.fromstr("signature 12345 algorithm=foo")
 
-                # For convenience, we allow set actions to be expressed as
-                # "<name>=<value>", rather than "name=<name> value=<value>", but
-                # we always convert to the latter.  Verify that both forms are
-                # parsed as expected.
-                a = action.fromstr("set pkg.obsolete=true")
-                a2 = action.fromstr("set name=pkg.obsolete value=true")
-                self.assertEqual(str(a), str(a2))
-                self.assertAttributes(a, ["name", "value"])
-                self.assertAttributeValue(a, "name", "pkg.obsolete")
-                self.assertAttributeValue(a, "value", "true")
+        # For convenience, we allow set actions to be expressed as
+        # "<name>=<value>", rather than "name=<name> value=<value>", but
+        # we always convert to the latter.  Verify that both forms are
+        # parsed as expected.
+        a = action.fromstr("set pkg.obsolete=true")
+        a2 = action.fromstr("set name=pkg.obsolete value=true")
+        self.assertEqual(str(a), str(a2))
+        self.assertAttributes(a, ["name", "value"])
+        self.assertAttributeValue(a, "name", "pkg.obsolete")
+        self.assertAttributeValue(a, "value", "true")
 
-                # Single quoted value
-                a = action.fromstr("file 12345 name='foo' value=bar path=/tmp/foo")
-                self.assertAttributes(a, ["name", "value", "path"])
-                self.assertAttributeValue(a, "name", "foo")
-                self.assertAttributeValue(a, "value", "bar")
-                self.assertAttributeValue(a, "path", "tmp/foo")
+        # Single quoted value
+        a = action.fromstr("file 12345 name='foo' value=bar path=/tmp/foo")
+        self.assertAttributes(a, ["name", "value", "path"])
+        self.assertAttributeValue(a, "name", "foo")
+        self.assertAttributeValue(a, "value", "bar")
+        self.assertAttributeValue(a, "path", "tmp/foo")
 
-                # Make sure that unescaped double quotes are parsed properly
-                # inside a single-quoted value.
-                a = action.fromstr("file 12345 name='f\"o\"o' value=bar path=/tmp/foo")
-                self.assertAttributes(a, ["name", "path", "value"])
-                self.assertAttributeValue(a, "name", "f\"o\"o")
-                self.assertAttributeValue(a, "value", "bar")
-                self.assertAttributeValue(a, "path", "tmp/foo")
+        # Make sure that unescaped double quotes are parsed properly
+        # inside a single-quoted value.
+        a = action.fromstr("file 12345 name='f\"o\"o' value=bar path=/tmp/foo")
+        self.assertAttributes(a, ["name", "path", "value"])
+        self.assertAttributeValue(a, "name", 'f"o"o')
+        self.assertAttributeValue(a, "value", "bar")
+        self.assertAttributeValue(a, "path", "tmp/foo")
 
-                # Make sure that escaped single quotes are parsed properly
-                # inside a single-quoted value.
-                a = action.fromstr("file 12345 name='f\\'o\\'o' value=bar path=/tmp/foo")
-                self.assertAttributes(a, ["name", "path", "value"])
-                self.assertAttributeValue(a, "name", "f'o'o")
-                self.assertAttributeValue(a, "value", "bar")
-                self.assertAttributeValue(a, "path", "tmp/foo")
+        # Make sure that escaped single quotes are parsed properly
+        # inside a single-quoted value.
+        a = action.fromstr(
+            "file 12345 name='f\\'o\\'o' value=bar path=/tmp/foo"
+        )
+        self.assertAttributes(a, ["name", "path", "value"])
+        self.assertAttributeValue(a, "name", "f'o'o")
+        self.assertAttributeValue(a, "value", "bar")
+        self.assertAttributeValue(a, "path", "tmp/foo")
 
-                # You should be able to separate key/value pairs with tabs as
-                # well as spaces.
-                a = action.fromstr("file 12345 name=foo\tvalue=bar path=/tmp/foo")
-                self.assertAttributes(a, ["name", "path", "value"])
-                self.assertAttributeValue(a, "name", "foo")
-                self.assertAttributeValue(a, "value", "bar")
-                self.assertAttributeValue(a, "path", "tmp/foo")
+        # You should be able to separate key/value pairs with tabs as
+        # well as spaces.
+        a = action.fromstr("file 12345 name=foo\tvalue=bar path=/tmp/foo")
+        self.assertAttributes(a, ["name", "path", "value"])
+        self.assertAttributeValue(a, "name", "foo")
+        self.assertAttributeValue(a, "value", "bar")
+        self.assertAttributeValue(a, "path", "tmp/foo")
 
-                # Unescaped, unpaired quotes are allowed in the middle of values
-                # without further quoting
-                a = action.fromstr("file 12345 name=foo\"bar path=/tmp/foo")
-                self.assertAttributes(a, ["name", "path"])
-                self.assertAttributeValue(a, "name", "foo\"bar")
-                self.assertAttributeValue(a, "path", "tmp/foo")
+        # Unescaped, unpaired quotes are allowed in the middle of values
+        # without further quoting
+        a = action.fromstr('file 12345 name=foo"bar path=/tmp/foo')
+        self.assertAttributes(a, ["name", "path"])
+        self.assertAttributeValue(a, "name", 'foo"bar')
+        self.assertAttributeValue(a, "path", "tmp/foo")
 
-                # They can even be paired.  Note this is not like shell quoting.
-                a = action.fromstr("file 12345 name=foo\"bar\"baz path=/tmp/foo")
-                self.assertAttributes(a, ["name", "path"])
-                self.assertAttributeValue(a, "name", "foo\"bar\"baz")
-                self.assertAttributeValue(a, "path", "tmp/foo")
+        # They can even be paired.  Note this is not like shell quoting.
+        a = action.fromstr('file 12345 name=foo"bar"baz path=/tmp/foo')
+        self.assertAttributes(a, ["name", "path"])
+        self.assertAttributeValue(a, "name", 'foo"bar"baz')
+        self.assertAttributeValue(a, "path", "tmp/foo")
 
-                # An unquoted value can end in an escaped backslash
-                a = action.fromstr("file 12345 name=foo\\ path=/tmp/foo")
-                self.assertAttributes(a, ["name", "path"])
-                self.assertAttributeValue(a, "name", "foo\\")
-                self.assertAttributeValue(a, "path", "tmp/foo")
+        # An unquoted value can end in an escaped backslash
+        a = action.fromstr("file 12345 name=foo\\ path=/tmp/foo")
+        self.assertAttributes(a, ["name", "path"])
+        self.assertAttributeValue(a, "name", "foo\\")
+        self.assertAttributeValue(a, "path", "tmp/foo")
 
-                # An action with multiple identical attribute names should
-                # result in an attribute with a list value.
-                a = action.fromstr("driver alias=pci1234,56 alias=pci4567,89 class=scsi name=lsimega")
-                self.assertAttributes(a, ["alias", "class", "name"])
-                self.assertAttributeValue(a, "alias", ["pci1234,56", "pci4567,89"])
+        # An action with multiple identical attribute names should
+        # result in an attribute with a list value.
+        a = action.fromstr(
+            "driver alias=pci1234,56 alias=pci4567,89 class=scsi name=lsimega"
+        )
+        self.assertAttributes(a, ["alias", "class", "name"])
+        self.assertAttributeValue(a, "alias", ["pci1234,56", "pci4567,89"])
 
-                # An action with an empty value.
-                a = action.fromstr('set name=foo value=""')
-                self.assertAttributes(a, ["name", "value"])
-                self.assertAttributeValue(a, "name", "foo")
-                self.assertAttributeValue(a, "value", "")
+        # An action with an empty value.
+        a = action.fromstr('set name=foo value=""')
+        self.assertAttributes(a, ["name", "value"])
+        self.assertAttributeValue(a, "name", "foo")
+        self.assertAttributeValue(a, "value", "")
 
-                # An action with an empty value as part of a list.
-                a = action.fromstr('set name=foo value=ab value="" value=c')
-                self.assertAttributes(a, ["name", "value"])
-                self.assertAttributeValue(a, "name", "foo")
-                self.assertAttributeValue(a, "value", ["ab", "c", ""])
+        # An action with an empty value as part of a list.
+        a = action.fromstr('set name=foo value=ab value="" value=c')
+        self.assertAttributes(a, ["name", "value"])
+        self.assertAttributeValue(a, "name", "foo")
+        self.assertAttributeValue(a, "value", ["ab", "c", ""])
 
-                # An action with its key attribute and extra attributes that
-                # are not used by the package system.
-                a = action.fromstr('license license="Common Development and '
-                    'Distribution License 1.0 (CDDL)" custom="foo" '
-                    'bool_val=true')
-                self.assertAttributes(a, ["license", "custom", "bool_val"])
-                self.assertAttributeValue(a, "license", 'Common Development '
-                    'and Distribution License 1.0 (CDDL)')
-                self.assertAttributeValue(a, "custom", "foo")
-                self.assertAttributeValue(a, "bool_val", "true")
+        # An action with its key attribute and extra attributes that
+        # are not used by the package system.
+        a = action.fromstr(
+            'license license="Common Development and '
+            'Distribution License 1.0 (CDDL)" custom="foo" '
+            "bool_val=true"
+        )
+        self.assertAttributes(a, ["license", "custom", "bool_val"])
+        self.assertAttributeValue(
+            a,
+            "license",
+            "Common Development " "and Distribution License 1.0 (CDDL)",
+        )
+        self.assertAttributeValue(a, "custom", "foo")
+        self.assertAttributeValue(a, "bool_val", "true")
 
-                # Really long actions with lots of backslash-escaped quotes
-                # should work.
-                a = action.fromstr(r'set name=pkg.description value="Sphinx is a tool that makes it easy to create intelligent \"and beautiful documentation f\"or Python projects (or \"other documents consisting of\" multiple reStructuredText so\"urces), written by Georg Bran\"dl. It was originally created\" to translate the new Python \"documentation, but has now be\"en cleaned up in the hope tha\"t it will be useful to many o\"ther projects. Sphinx uses re\"StructuredText as its markup \"language, and many of its str\"engths come from the power an\"d straightforwardness of reSt\"ructuredText and its parsing \"and translating suite, the Do\"cutils. Although it is still \"under constant development, t\"he following features are alr\"eady present, work fine and c\"an be seen \"in action\" \"in the Python docs: * Output \"formats: HTML (including Wind\"ows HTML Help) and LaTeX, for\" printable PDF versions * Ext\"ensive cross-references: sema\"ntic markup and automatic lin\"ks for functions, classes, gl\"ossary terms and similar piec\"es of information * Hierarchi\"cal structure: easy definitio\"n of a document tree, with au\"tomatic links to siblings, pa\"rents and children * Automati\"c indices: general index as w\"ell as a module index * Code \"handling: automatic highlight\"ing using the Pygments highli\"ghter * Various extensions ar\"e available, e.g. for automat\"ic testing of snippets and in\"clusion of appropriately formatted docstrings."')
-                self.assertTrue(a.attrs["value"].count('"') == 45)
+        # Really long actions with lots of backslash-escaped quotes
+        # should work.
+        a = action.fromstr(
+            r'set name=pkg.description value="Sphinx is a tool that makes it easy to create intelligent \"and beautiful documentation f\"or Python projects (or \"other documents consisting of\" multiple reStructuredText so\"urces), written by Georg Bran\"dl. It was originally created\" to translate the new Python \"documentation, but has now be\"en cleaned up in the hope tha\"t it will be useful to many o\"ther projects. Sphinx uses re\"StructuredText as its markup \"language, and many of its str\"engths come from the power an\"d straightforwardness of reSt\"ructuredText and its parsing \"and translating suite, the Do\"cutils. Although it is still \"under constant development, t\"he following features are alr\"eady present, work fine and c\"an be seen \"in action\" \"in the Python docs: * Output \"formats: HTML (including Wind\"ows HTML Help) and LaTeX, for\" printable PDF versions * Ext\"ensive cross-references: sema\"ntic markup and automatic lin\"ks for functions, classes, gl\"ossary terms and similar piec\"es of information * Hierarchi\"cal structure: easy definitio\"n of a document tree, with au\"tomatic links to siblings, pa\"rents and children * Automati\"c indices: general index as w\"ell as a module index * Code \"handling: automatic highlight\"ing using the Pygments highli\"ghter * Various extensions ar\"e available, e.g. for automat\"ic testing of snippets and in\"clusion of appropriately formatted docstrings."'
+        )
+        self.assertTrue(a.attrs["value"].count('"') == 45)
 
-                # Make sure that the hash member of the action object properly
-                # contains the value of the "hash" named attribute.
-                a = action.fromstr("file hash=abc123 path=usr/bin/foo mode=0755 owner=root group=bin")
-                self.assertTrue(a.hash == "abc123")
+        # Make sure that the hash member of the action object properly
+        # contains the value of the "hash" named attribute.
+        a = action.fromstr(
+            "file hash=abc123 path=usr/bin/foo mode=0755 owner=root group=bin"
+        )
+        self.assertTrue(a.hash == "abc123")
 
-        def test_action_license(self):
-                """Test license action attributes."""
+    def test_action_license(self):
+        """Test license action attributes."""
 
-                # Verify license attributes for must-accept / must-display
-                # contain expected values.
-                a = action.fromstr('license license="Common Development and '
-                    'Distribution License 1.0 (CDDL)" custom="foo" '
-                    'bool_val=true')
-                self.assertEqual(a.must_accept, False)
-                self.assertEqual(a.must_display, False)
+        # Verify license attributes for must-accept / must-display
+        # contain expected values.
+        a = action.fromstr(
+            'license license="Common Development and '
+            'Distribution License 1.0 (CDDL)" custom="foo" '
+            "bool_val=true"
+        )
+        self.assertEqual(a.must_accept, False)
+        self.assertEqual(a.must_display, False)
 
-                a = action.fromstr('license license="Common Development and '
-                    'Distribution License 1.0 (CDDL)" must-accept=true '
-                    'must-display=False')
-                self.assertEqual(a.must_accept, True)
-                self.assertEqual(a.must_display, False)
+        a = action.fromstr(
+            'license license="Common Development and '
+            'Distribution License 1.0 (CDDL)" must-accept=true '
+            "must-display=False"
+        )
+        self.assertEqual(a.must_accept, True)
+        self.assertEqual(a.must_display, False)
 
-                a = action.fromstr('license license="Common Development and '
-                    'Distribution License 1.0 (CDDL)" must-accept=True '
-                    'must-display=true')
-                self.assertEqual(a.must_accept, True)
-                self.assertEqual(a.must_display, True)
+        a = action.fromstr(
+            'license license="Common Development and '
+            'Distribution License 1.0 (CDDL)" must-accept=True '
+            "must-display=true"
+        )
+        self.assertEqual(a.must_accept, True)
+        self.assertEqual(a.must_display, True)
 
-                a = action.fromstr('license license="Common Development and '
-                    'Distribution License 1.0 (CDDL)" must-accept=True ')
-                self.assertEqual(a.must_accept, True)
-                self.assertEqual(a.must_display, False)
+        a = action.fromstr(
+            'license license="Common Development and '
+            'Distribution License 1.0 (CDDL)" must-accept=True '
+        )
+        self.assertEqual(a.must_accept, True)
+        self.assertEqual(a.must_display, False)
 
-        def __assert_action_str(self, astr, expected, expattrs):
-                """Private helper function for action stringification
-                testing."""
-                act = action.fromstr(astr)
-                self.assertEqualDiff(expected, str(act))
-                self.assertEqualDiff(expattrs, act.attrs)
+    def __assert_action_str(self, astr, expected, expattrs):
+        """Private helper function for action stringification
+        testing."""
+        act = action.fromstr(astr)
+        self.assertEqualDiff(expected, str(act))
+        self.assertEqualDiff(expattrs, act.attrs)
 
-        def test_action_tostr(self):
-                """Test that actions convert to strings properly.  This means
-                that we can feed the resulting string back into fromstr() and
-                get an identical action back (excluding a few cases detailed in
-                the test)."""
+    def test_action_tostr(self):
+        """Test that actions convert to strings properly.  This means
+        that we can feed the resulting string back into fromstr() and
+        get an identical action back (excluding a few cases detailed in
+        the test)."""
 
-                for s in self.act_strings:
-                        self.debug(str(s))
-                        a = action.fromstr(s)
-                        s2 = str(a)
-                        a2 = action.fromstr(s2)
-                        if a.different(a2):
-                                self.debug("a1 " + str(a))
-                                self.debug("a2 " + str(a2))
-                                self.assertTrue(not a.different(a2))
-
-                # The first case that invariant doesn't hold is when you specify
-                # the payload hash as the named attribute "hash", in which case
-                # the resulting re-stringification emits the payload hash as a
-                # positional attribute again ...
-                s = "file hash=abc123 path=usr/bin/foo mode=0755 owner=root group=bin"
-                self.debug(s)
-                a = action.fromstr(s)
-                s2 = str(a)
-                self.assertTrue(s2.startswith("file abc123 "))
-                self.assertTrue("hash=abc123" not in s2)
-                a2 = action.fromstr(s2)
+        for s in self.act_strings:
+            self.debug(str(s))
+            a = action.fromstr(s)
+            s2 = str(a)
+            a2 = action.fromstr(s2)
+            if a.different(a2):
+                self.debug("a1 " + str(a))
+                self.debug("a2 " + str(a2))
                 self.assertTrue(not a.different(a2))
 
-                # ... unless of course the hash can't be represented that way.
-                d = {
-                    "hash=abc=123": "abc=123",
-                    "hash=\"one with spaces\"": "one with spaces",
-                    "hash='one with \" character'": 'one with " character',
-                    "hash=\"'= !@$%^)(*\"": "'= !@$%^)(*",
-                    """hash="\\"'= \\ " """:""""'= \\ """,
-                    '\\' : '\\'
-                }
+        # The first case that invariant doesn't hold is when you specify
+        # the payload hash as the named attribute "hash", in which case
+        # the resulting re-stringification emits the payload hash as a
+        # positional attribute again ...
+        s = "file hash=abc123 path=usr/bin/foo mode=0755 owner=root group=bin"
+        self.debug(s)
+        a = action.fromstr(s)
+        s2 = str(a)
+        self.assertTrue(s2.startswith("file abc123 "))
+        self.assertTrue("hash=abc123" not in s2)
+        a2 = action.fromstr(s2)
+        self.assertTrue(not a.different(a2))
 
-                astr = "file {0} path=usr/bin/foo mode=0755 owner=root group=bin"
-                for k, v  in six.iteritems(d):
-                        a = action.fromstr(astr.format(k))
-                        self.assertTrue(action.fromstr(str(a)) == a)
-                        self.assertTrue(a.hash == v)
-                        self.assertTrue(k in str(a))
+        # ... unless of course the hash can't be represented that way.
+        d = {
+            "hash=abc=123": "abc=123",
+            'hash="one with spaces"': "one with spaces",
+            "hash='one with \" character'": 'one with " character',
+            'hash="\'= !@$%^)(*"': "'= !@$%^)(*",
+            """hash="\\"'= \\ " """: """"'= \\ """,
+            "\\": "\\",
+        }
 
-                # The attributes are verified separately from the stringified
-                # action in the tests below to ensure that the attributes were
-                # parsed independently and not as a single value (e.g.
-                # 'file path=etc/foo\nfacet.debug=true' is parsed as having a
-                # path attribute and a facet.debug attribute).
+        astr = "file {0} path=usr/bin/foo mode=0755 owner=root group=bin"
+        for k, v in six.iteritems(d):
+            a = action.fromstr(astr.format(k))
+            self.assertTrue(action.fromstr(str(a)) == a)
+            self.assertTrue(a.hash == v)
+            self.assertTrue(k in str(a))
 
-                # The next case that invariant doesn't hold is when you have
-                # multiple, quoted values for a single attribute (this case
-                # primarily exists for use with line-continuation support
-                # offered by the Manifest class).
-                expected = 'set name=pkg.description value="foo bar baz"'
-                expattrs = { 'name': 'pkg.description', 'value': 'foo bar baz' }
-                for astr in (
-                    "set name=pkg.description value='foo ''bar ''baz'",
-                    "set name=pkg.description value='foo ' 'bar ' 'baz'",
-                    'set name=pkg.description value="foo " "bar " "baz"'):
-                        self.__assert_action_str(astr, expected, expattrs)
+        # The attributes are verified separately from the stringified
+        # action in the tests below to ensure that the attributes were
+        # parsed independently and not as a single value (e.g.
+        # 'file path=etc/foo\nfacet.debug=true' is parsed as having a
+        # path attribute and a facet.debug attribute).
 
-                expected = "set name=pkg.description value='foo \"bar\" baz'"
-                expattrs = { 'name': 'pkg.description',
-                    'value': 'foo "bar" baz' }
-                for astr in (
-                    "set name=pkg.description value='foo \"bar\" ''baz'",
-                    "set name=pkg.description value='foo \"bar\" '\"baz\""):
-                        self.__assert_action_str(astr, expected, expattrs)
+        # The next case that invariant doesn't hold is when you have
+        # multiple, quoted values for a single attribute (this case
+        # primarily exists for use with line-continuation support
+        # offered by the Manifest class).
+        expected = 'set name=pkg.description value="foo bar baz"'
+        expattrs = {"name": "pkg.description", "value": "foo bar baz"}
+        for astr in (
+            "set name=pkg.description value='foo ''bar ''baz'",
+            "set name=pkg.description value='foo ' 'bar ' 'baz'",
+            'set name=pkg.description value="foo " "bar " "baz"',
+        ):
+            self.__assert_action_str(astr, expected, expattrs)
 
-                # The next case that invariant doesn't hold is when there are
-                # multiple whitespace characters between attributes or after the
-                # action type.
-                expected = 'set name=pkg.description value=foo'
-                expattrs = { 'name': 'pkg.description', 'value': 'foo' }
-                for astr in (
-                    "set  name=pkg.description value=foo",
-                    "set name=pkg.description  value=foo",
-                    "set  name=pkg.description  value=foo",
-                    "set\n name=pkg.description \nvalue=foo",
-                    "set\t\nname=pkg.description\t\nvalue=foo"):
-                        # To force stressing the parsing logic a bit more, we
-                        # parse an action with a multi-value attribute that
-                        # needs concatention each time before we parse a
-                        # single-value attribute that needs concatenation.
-                        #
-                        # This simulates a refcount bug that was found during
-                        # development and serves as an extra stress-test.
-                        self.__assert_action_str(
-                            'set name=multi-value value=bar value="foo ""baz"',
-                            'set name=multi-value value=bar value="foo baz"',
-                            { 'name': 'multi-value',
-                                'value': ['bar', 'foo baz'] })
+        expected = "set name=pkg.description value='foo \"bar\" baz'"
+        expattrs = {"name": "pkg.description", "value": 'foo "bar" baz'}
+        for astr in (
+            "set name=pkg.description value='foo \"bar\" ''baz'",
+            'set name=pkg.description value=\'foo "bar" \'"baz"',
+        ):
+            self.__assert_action_str(astr, expected, expattrs)
 
-                        self.__assert_action_str(astr, expected, expattrs)
+        # The next case that invariant doesn't hold is when there are
+        # multiple whitespace characters between attributes or after the
+        # action type.
+        expected = "set name=pkg.description value=foo"
+        expattrs = {"name": "pkg.description", "value": "foo"}
+        for astr in (
+            "set  name=pkg.description value=foo",
+            "set name=pkg.description  value=foo",
+            "set  name=pkg.description  value=foo",
+            "set\n name=pkg.description \nvalue=foo",
+            "set\t\nname=pkg.description\t\nvalue=foo",
+        ):
+            # To force stressing the parsing logic a bit more, we
+            # parse an action with a multi-value attribute that
+            # needs concatention each time before we parse a
+            # single-value attribute that needs concatenation.
+            #
+            # This simulates a refcount bug that was found during
+            # development and serves as an extra stress-test.
+            self.__assert_action_str(
+                'set name=multi-value value=bar value="foo ""baz"',
+                'set name=multi-value value=bar value="foo baz"',
+                {"name": "multi-value", "value": ["bar", "foo baz"]},
+            )
 
-                astr = 'file path=etc/foo\nfacet.debug=true'
-                expected = 'file NOHASH facet.debug=true path=etc/foo'
-                expattrs = { 'path': 'etc/foo', 'facet.debug': 'true' }
-                self.__assert_action_str(astr, expected, expattrs)
+            self.__assert_action_str(astr, expected, expattrs)
 
-        def test_action_sig_str(self):
-                sig_act = action.fromstr(
-                    "signature 54321 algorithm=baz")
-                for s in self.act_strings:
-                        # action.sig_str should return an identical string each
-                        # time it's called.  Also, parsing the result of
-                        # sig_str so produce the same action.
-                        a = action.fromstr(s)
-                        s2 = a.sig_str(sig_act, generic.Action.sig_version)
-                        s3 = a.sig_str(sig_act, generic.Action.sig_version)
-                        # If s2 is None, then s was a different signature
-                        # action, so there is no output to parse.
-                        if s2 is None:
-                                continue
-                        self.assertEqual(s2, s3)
-                        a2 = action.fromstr(s2)
-                        if a.different(a2):
-                                self.debug("a1 " + str(a))
-                                self.debug("a2 " + str(a2))
-                                self.assertTrue(not a.different(a2))
-                        s4 = a.sig_str(sig_act, generic.Action.sig_version)
-                        self.assertEqual(s2, s4)
-                # Test that using an unknown sig_version triggers the
-                # appropriate exception.
-                self.assertRaises(api_errors.UnsupportedSignatureVersion,
-                    sig_act.sig_str, sig_act, -1)
-                a = action.fromstr(self.act_strings[0])
-                self.assertRaises(api_errors.UnsupportedSignatureVersion,
-                    a.sig_str, sig_act, -1)
-                # Test that the sig_str of a signature action other than the
-                # argument action is None.
-                sig_act2 = action.fromstr(
-                    "signature 98765 algorithm=foobar")
-                self.assertTrue(sig_act.sig_str(sig_act2,
-                    generic.Action.sig_version) is None)
-                self.assertTrue(sig_act2.sig_str(sig_act,
-                    generic.Action.sig_version) is None)
+        astr = "file path=etc/foo\nfacet.debug=true"
+        expected = "file NOHASH facet.debug=true path=etc/foo"
+        expattrs = {"path": "etc/foo", "facet.debug": "true"}
+        self.__assert_action_str(astr, expected, expattrs)
 
-        def assertMalformed(self, text):
-                malformed = False
+    def test_action_sig_str(self):
+        sig_act = action.fromstr("signature 54321 algorithm=baz")
+        for s in self.act_strings:
+            # action.sig_str should return an identical string each
+            # time it's called.  Also, parsing the result of
+            # sig_str so produce the same action.
+            a = action.fromstr(s)
+            s2 = a.sig_str(sig_act, generic.Action.sig_version)
+            s3 = a.sig_str(sig_act, generic.Action.sig_version)
+            # If s2 is None, then s was a different signature
+            # action, so there is no output to parse.
+            if s2 is None:
+                continue
+            self.assertEqual(s2, s3)
+            a2 = action.fromstr(s2)
+            if a.different(a2):
+                self.debug("a1 " + str(a))
+                self.debug("a2 " + str(a2))
+                self.assertTrue(not a.different(a2))
+            s4 = a.sig_str(sig_act, generic.Action.sig_version)
+            self.assertEqual(s2, s4)
+        # Test that using an unknown sig_version triggers the
+        # appropriate exception.
+        self.assertRaises(
+            api_errors.UnsupportedSignatureVersion, sig_act.sig_str, sig_act, -1
+        )
+        a = action.fromstr(self.act_strings[0])
+        self.assertRaises(
+            api_errors.UnsupportedSignatureVersion, a.sig_str, sig_act, -1
+        )
+        # Test that the sig_str of a signature action other than the
+        # argument action is None.
+        sig_act2 = action.fromstr("signature 98765 algorithm=foobar")
+        self.assertTrue(
+            sig_act.sig_str(sig_act2, generic.Action.sig_version) is None
+        )
+        self.assertTrue(
+            sig_act2.sig_str(sig_act, generic.Action.sig_version) is None
+        )
 
-                try:
-                        action.fromstr(text)
-                except action.MalformedActionError as e:
-                        assert e.actionstr == text
-                        self.debug(text)
-                        self.debug(str(e))
-                        malformed = True
+    def assertMalformed(self, text):
+        malformed = False
 
-                # If the action isn't malformed, something is wrong.
-                self.assertTrue(malformed, "Action not malformed: " + text)
+        try:
+            action.fromstr(text)
+        except action.MalformedActionError as e:
+            assert e.actionstr == text
+            self.debug(text)
+            self.debug(str(e))
+            malformed = True
 
-        def assertInvalid(self, text):
-                invalid = False
+        # If the action isn't malformed, something is wrong.
+        self.assertTrue(malformed, "Action not malformed: " + text)
 
-                try:
-                        action.fromstr(text)
-                except action.InvalidActionError:
-                        invalid = True
+    def assertInvalid(self, text):
+        invalid = False
 
-                # If the action isn't invalid, something is wrong.
-                self.assertTrue(invalid, "Action not invalid: " + text)
+        try:
+            action.fromstr(text)
+        except action.InvalidActionError:
+            invalid = True
 
-        def test_action_errors(self):
-                # Unknown action type
-                self.assertRaises(action.UnknownActionError, action.fromstr,
-                    "moop bar=baz")
-                self.assertRaises(action.UnknownActionError, action.fromstr,
-                    "setbar=baz quux=quark")
+        # If the action isn't invalid, something is wrong.
+        self.assertTrue(invalid, "Action not invalid: " + text)
 
-                # Nothing but the action type or type is malformed.
-                self.assertMalformed("moop")
-                self.assertMalformed("setbar=baz")
+    def test_action_errors(self):
+        # Unknown action type
+        self.assertRaises(
+            action.UnknownActionError, action.fromstr, "moop bar=baz"
+        )
+        self.assertRaises(
+            action.UnknownActionError, action.fromstr, "setbar=baz quux=quark"
+        )
 
-                # Bad quoting: missing close quote
-                self.assertMalformed("file 12345 path=/tmp/foo name=\"foo bar")
-                self.assertMalformed("file 12345 path=/tmp/foo name=\"foo bar\\")
+        # Nothing but the action type or type is malformed.
+        self.assertMalformed("moop")
+        self.assertMalformed("setbar=baz")
 
-                # Bad quoting: quote in key
-                self.assertMalformed("file 12345 path=/tmp/foo \"name=foo bar")
-                self.assertMalformed("file 12345 path=/tmp/foo na\"me=foo bar")
-                self.assertMalformed("file 1234 path=/tmp/foo \"foo\"=bar")
+        # Bad quoting: missing close quote
+        self.assertMalformed('file 12345 path=/tmp/foo name="foo bar')
+        self.assertMalformed('file 12345 path=/tmp/foo name="foo bar\\')
 
-                # Missing key
-                self.assertMalformed("file 1234 path=/tmp/foo =\"\"")
-                self.assertMalformed("file path=/tmp/foo =")
-                self.assertMalformed("file 1234 path=/tmp/foo =")
-                self.assertMalformed("file 1234 path=/tmp/foo ==")
-                self.assertMalformed("file 1234 path=/tmp/foo ===")
+        # Bad quoting: quote in key
+        self.assertMalformed('file 12345 path=/tmp/foo "name=foo bar')
+        self.assertMalformed('file 12345 path=/tmp/foo na"me=foo bar')
+        self.assertMalformed('file 1234 path=/tmp/foo "foo"=bar')
 
-                # Missing value
-                self.assertMalformed("file 1234 path=/tmp/foo broken=")
-                self.assertMalformed("file 1234 path=/tmp/foo broken= ")
-                self.assertMalformed("file 1234 path=/tmp/foo broken=\t")
-                self.assertMalformed("file 1234 path=/tmp/foo broken=\n")
-                self.assertMalformed("file 1234 path=/tmp/foo broken")
+        # Missing key
+        self.assertMalformed('file 1234 path=/tmp/foo =""')
+        self.assertMalformed("file path=/tmp/foo =")
+        self.assertMalformed("file 1234 path=/tmp/foo =")
+        self.assertMalformed("file 1234 path=/tmp/foo ==")
+        self.assertMalformed("file 1234 path=/tmp/foo ===")
 
-                # Whitespace in key
-                self.assertMalformed("file 1234 path=/tmp/foo bro ken")
-                self.assertMalformed("file 1234 path=/tmp/foo\tbro\tken")
-                self.assertMalformed("file 1234 path=/tmp/foo\nbro\nken")
-                self.assertMalformed("file 1234 path ='/tmp/foo")
-                self.assertMalformed("file 1234 path\t=/tmp/foo")
-                self.assertMalformed("file 1234 path\n=/tmp/foo")
+        # Missing value
+        self.assertMalformed("file 1234 path=/tmp/foo broken=")
+        self.assertMalformed("file 1234 path=/tmp/foo broken= ")
+        self.assertMalformed("file 1234 path=/tmp/foo broken=\t")
+        self.assertMalformed("file 1234 path=/tmp/foo broken=\n")
+        self.assertMalformed("file 1234 path=/tmp/foo broken")
 
-                # Missing key attribute 'fmri'.
-                self.assertInvalid("depend type=require")
+        # Whitespace in key
+        self.assertMalformed("file 1234 path=/tmp/foo bro ken")
+        self.assertMalformed("file 1234 path=/tmp/foo\tbro\tken")
+        self.assertMalformed("file 1234 path=/tmp/foo\nbro\nken")
+        self.assertMalformed("file 1234 path ='/tmp/foo")
+        self.assertMalformed("file 1234 path\t=/tmp/foo")
+        self.assertMalformed("file 1234 path\n=/tmp/foo")
 
-                # XXX Fails in Python 3.4 due to module import issue; see
-                # set_invalid_action_error in actions/_common.c.
-                if six.PY2:
-                        # Multiple values not allowed for 'fmri' if 'type' is
-                        # multi-valued.
-                        self.assertInvalid("depend type=require "
-                            "type=require-any fmri=foo fmri=bar")
+        # Missing key attribute 'fmri'.
+        self.assertInvalid("depend type=require")
 
-                # 'path' attribute specified multiple times
-                self.assertInvalid("file 1234 path=foo path=foo mode=777 owner=root group=root")
-                self.assertInvalid("link path=foo path=foo target=link")
-                self.assertInvalid("dir path=foo path=foo mode=777 owner=root group=root")
+        # XXX Fails in Python 3.4 due to module import issue; see
+        # set_invalid_action_error in actions/_common.c.
+        if six.PY2:
+            # Multiple values not allowed for 'fmri' if 'type' is
+            # multi-valued.
+            self.assertInvalid(
+                "depend type=require " "type=require-any fmri=foo fmri=bar"
+            )
 
-                # 'data' used as an attribute key
-                self.assertInvalid("file 1234 path=/tmp/foo data=rubbish")
+        # 'path' attribute specified multiple times
+        self.assertInvalid(
+            "file 1234 path=foo path=foo mode=777 owner=root group=root"
+        )
+        self.assertInvalid("link path=foo path=foo target=link")
+        self.assertInvalid(
+            "dir path=foo path=foo mode=777 owner=root group=root"
+        )
 
-                # Missing required attribute 'path'.
-                self.assertRaises(action.InvalidActionError, action.fromstr,
-                    "file 1234 owner=foo")
+        # 'data' used as an attribute key
+        self.assertInvalid("file 1234 path=/tmp/foo data=rubbish")
 
-                # Missing required attribute 'name'.
-                self.assertRaises(action.InvalidActionError, action.fromstr,
-                    "driver alias=pci1234,56 alias=pci4567,89 class=scsi")
+        # Missing required attribute 'path'.
+        self.assertRaises(
+            action.InvalidActionError, action.fromstr, "file 1234 owner=foo"
+        )
 
-                # Verify malformed actions > 255 characters don't cause corrupt
-                # exception action strings.
-                self.assertMalformed("""legacy arch=i386 category=GNOME2,application,JDSosol desc="XScreenSaver is two things: it is both a large collection of screen savers (distributed in the "hacks" packages) and it is also the framework for blanking and locking the screen (this package)." hotline="Please contact your local service provider" name="XScreenSaver is two things: it is both a large collection of screen savers (distributed in the "hacks" packages) and it is also the framework for blanking and locking the screen (this package)." pkg=SUNWxscreensaver vendor="XScreenSaver Community" version=5.11,REV=110.0.4.2010.07.08.22.18""")
-                self.assertMalformed("""legacy arch=i386 category=GNOME2,application,JDSosol desc="XScreenSaver is two things: it is both a large collection of screen savers (distributed in the "hacks" packages) and it is also the framework for blanking and locking the screen (this package)." hotline="Please contact your local service provider" name="XScreenSaver is two things: it is both a large collection of screen savers (distributed in the "hacks" packages) and it is also the framework for blanking and locking the screen (this package)." pkg=SUNWxscreensaver-l10n vendor="XScreenSaver Community" version=5.11,REV=110.0.4.2010.07.08.22.18""")
+        # Missing required attribute 'name'.
+        self.assertRaises(
+            action.InvalidActionError,
+            action.fromstr,
+            "driver alias=pci1234,56 alias=pci4567,89 class=scsi",
+        )
 
-                # Missing required attribute 'algorithm'.
-                self.assertRaises(action.InvalidActionError, action.fromstr,
-                    "signature 12345 pkg.cert=bar")
+        # Verify malformed actions > 255 characters don't cause corrupt
+        # exception action strings.
+        self.assertMalformed(
+            """legacy arch=i386 category=GNOME2,application,JDSosol desc="XScreenSaver is two things: it is both a large collection of screen savers (distributed in the "hacks" packages) and it is also the framework for blanking and locking the screen (this package)." hotline="Please contact your local service provider" name="XScreenSaver is two things: it is both a large collection of screen savers (distributed in the "hacks" packages) and it is also the framework for blanking and locking the screen (this package)." pkg=SUNWxscreensaver vendor="XScreenSaver Community" version=5.11,REV=110.0.4.2010.07.08.22.18"""
+        )
+        self.assertMalformed(
+            """legacy arch=i386 category=GNOME2,application,JDSosol desc="XScreenSaver is two things: it is both a large collection of screen savers (distributed in the "hacks" packages) and it is also the framework for blanking and locking the screen (this package)." hotline="Please contact your local service provider" name="XScreenSaver is two things: it is both a large collection of screen savers (distributed in the "hacks" packages) and it is also the framework for blanking and locking the screen (this package)." pkg=SUNWxscreensaver-l10n vendor="XScreenSaver Community" version=5.11,REV=110.0.4.2010.07.08.22.18"""
+        )
 
-                # The payload hash can't be specified as both a named and a
-                # positional attribute if they're not identical.
-                self.assertInvalid("file xyz789 hash=abc123 path=usr/bin/foo mode=0755 owner=root group=bin")
-                action.fromstr("file abc123 hash=abc123 path=usr/bin/foo mode=0755 owner=root group=bin")
+        # Missing required attribute 'algorithm'.
+        self.assertRaises(
+            action.InvalidActionError,
+            action.fromstr,
+            "signature 12345 pkg.cert=bar",
+        )
 
-        def test_validate(self):
-                """Verify that action validate() works as expected; currently
-                only used during publication or action execution failure."""
+        # The payload hash can't be specified as both a named and a
+        # positional attribute if they're not identical.
+        self.assertInvalid(
+            "file xyz789 hash=abc123 path=usr/bin/foo mode=0755 owner=root group=bin"
+        )
+        action.fromstr(
+            "file abc123 hash=abc123 path=usr/bin/foo mode=0755 owner=root group=bin"
+        )
 
-                fact = "file 12345 name=foo path=/tmp/foo mode=XXX"
-                dact = "dir path=/tmp mode=XXX"
+    def test_validate(self):
+        """Verify that action validate() works as expected; currently
+        only used during publication or action execution failure."""
 
-                def assertActionError(astr,
-                    error=action.InvalidActionAttributesError):
-                        bad_act = action.fromstr(astr)
-                        try:
-                                bad_act.validate()
-                        except Exception as e:
-                                self.debug(str(e))
-                        else:
-                                self.debug("expected failure validating: {0}".format(
-                                    astr))
+        fact = "file 12345 name=foo path=/tmp/foo mode=XXX"
+        dact = "dir path=/tmp mode=XXX"
 
-                        self.assertRaises(error, bad_act.validate)
+        def assertActionError(astr, error=action.InvalidActionAttributesError):
+            bad_act = action.fromstr(astr)
+            try:
+                bad_act.validate()
+            except Exception as e:
+                self.debug(str(e))
+            else:
+                self.debug("expected failure validating: {0}".format(astr))
 
-                # Verify mode attributes for file specified more than once are
-                # rejected.
-                nact = "file path=/usr/bin/foo owner=root group=root " \
-                    "mode=0555 mode=0555"
+            self.assertRaises(error, bad_act.validate)
+
+        # Verify mode attributes for file specified more than once are
+        # rejected.
+        nact = (
+            "file path=/usr/bin/foo owner=root group=root "
+            "mode=0555 mode=0555"
+        )
+        assertActionError(nact)
+
+        # Verify predicate and target attributes of FMRIs must be valid.
+        for nact in (
+            # FMRI value is invalid.
+            "depend type=require-any fmri=foo fmri=bar fmri=invalid@abc",
+            # Missing required attribute 'type'.
+            "depend fmri=foo@1.0"
+            # type is invalid.
+            "depend type=unknown fmri=foo@1.0",
+            # Multiple values never allowed for depend action 'type' attribute.
+            "depend type=require type=require-any fmri=foo",
+            # Mutiple fmri values only allowed for require-any deps.
+            "depend type=require fmri=foo fmri=bar",
+            # Predicate is missing for conditional dependency.
+            "depend type=conditional fmri=foo",
+            # Predicate value is invalid.
+            "depend type=conditional predicate=-invalid fmri=foo",
+            # Predicate isn't valid for dependency type.
+            "depend type=require predicate=1invalid fmri=foo",
+            # root-image attribute is only valid for origin dependencies.
+            "depend type=require fmri=foo root-image=true",
+            # Multiple values for predicate are not allowed.
+            "depend type=conditional predicate=foo predicate=bar fmri=baz",
+            # Multiple values for ignore-check are not allowed.
+            "depend type=require fmri=foo ignore-check=true ignore-check=false",
+        ):
+            assertActionError(nact)
+
+        # Verify multiple values for file attributes are rejected.
+        for attr in (
+            "pkg.size",
+            "pkg.csize",
+            "chash",
+            "preserve",
+            "overlay",
+            "elfhash",
+            "original_name",
+            "facet.doc",
+            "owner",
+            "group",
+            "preserve-version",
+        ):
+            nact = (
+                "file path=/usr/bin/foo owner=root group=root "
+                "mode=0555 {attr}=1 {attr}=2 {attr}=3".format(attr=attr)
+            )
+            assertActionError(nact)
+
+        # Verify invalid values are not allowed for mode attribute on
+        # file and dir actions.
+        for act in (fact, dact):
+            for bad_mode in (
+                "",
+                'mode=""',
+                "mode=???",
+                "mode=44755",
+                "mode=44",
+                "mode=999",
+                "mode=0898",
+            ):
+                nact = act.replace("mode=XXX", bad_mode)
                 assertActionError(nact)
 
-                # Verify predicate and target attributes of FMRIs must be valid.
-                for nact in (
-                    # FMRI value is invalid.
-                    "depend type=require-any fmri=foo fmri=bar fmri=invalid@abc",
-                    # Missing required attribute 'type'.
-                    "depend fmri=foo@1.0"
-                    # type is invalid.
-                    "depend type=unknown fmri=foo@1.0",
-                    # Multiple values never allowed for depend action 'type' attribute.
-                    "depend type=require type=require-any fmri=foo",
-                    # Mutiple fmri values only allowed for require-any deps.
-                    "depend type=require fmri=foo fmri=bar",
-                    # Predicate is missing for conditional dependency.
-                    "depend type=conditional fmri=foo",
-                    # Predicate value is invalid.
-                    "depend type=conditional predicate=-invalid fmri=foo",
-                    # Predicate isn't valid for dependency type.
-                    "depend type=require predicate=1invalid fmri=foo",
-                    # root-image attribute is only valid for origin dependencies.
-                    "depend type=require fmri=foo root-image=true",
-                    # Multiple values for predicate are not allowed.
-                    "depend type=conditional predicate=foo predicate=bar fmri=baz",
-                    # Multiple values for ignore-check are not allowed.
-                    "depend type=require fmri=foo ignore-check=true ignore-check=false"):
-                        assertActionError(nact)
+        # Verify multiple values aren't allowed for legacy action
+        # attributes.
+        for attr in (
+            "category",
+            "desc",
+            "hotline",
+            "name",
+            "vendor",
+            "version",
+        ):
+            nact = "legacy pkg=SUNWcs {attr}=1 {attr}=2".format(attr=attr)
+            assertActionError(nact)
 
-                # Verify multiple values for file attributes are rejected.
-                for attr in ("pkg.size", "pkg.csize", "chash", "preserve",
-                    "overlay", "elfhash", "original_name", "facet.doc",
-                    "owner", "group", "preserve-version"):
-                        nact = "file path=/usr/bin/foo owner=root group=root " \
-                            "mode=0555 {attr}=1 {attr}=2 {attr}=3".format(
-                            attr=attr)
-                        assertActionError(nact)
+        # Verify multiple values aren't allowed for gid of group.
+        nact = "group groupname=staff gid=100 gid=101"
+        assertActionError(nact)
 
-                # Verify invalid values are not allowed for mode attribute on
-                # file and dir actions.
-                for act in (fact, dact):
-                        for bad_mode in ("", 'mode=""', "mode=???",
-                            "mode=44755", "mode=44", "mode=999", "mode=0898"):
-                                nact = act.replace("mode=XXX", bad_mode)
-                                assertActionError(nact)
+        # Verify only numeric value is allowed for gid of group.
+        nact = "group groupname=staff gid=abc"
+        assertActionError(nact)
 
-                # Verify multiple values aren't allowed for legacy action
-                # attributes.
-                for attr in ("category", "desc", "hotline", "name", "vendor",
-                    "version"):
-                        nact = "legacy pkg=SUNWcs {attr}=1 {attr}=2".format(
-                            attr=attr)
-                        assertActionError(nact)
+        # Verify multiple values are not allowed for must-accept and
+        # must-display attributes of license actions.
+        for attr in ("must-accept", "must-display"):
+            nact = (
+                "license license=copyright {attr}=true "
+                "{attr}=false".format(attr=attr)
+            )
+            assertActionError(nact)
 
-                # Verify multiple values aren't allowed for gid of group.
-                nact = "group groupname=staff gid=100 gid=101"
+        # Ensure link and hardlink attributes are validated properly.
+        for aname in ("link", "hardlink"):
+            # Action with mediator without mediator properties is
+            # invalid.
+            nact = (
+                "{0} path=usr/bin/vi target=../sunos/bin/edit "
+                "mediator=vi".format(aname)
+            )
+            assertActionError(nact)
+
+            # Action with multiple mediator values is invalid.
+            nact = (
+                "{0} path=usr/bin/vi target=../sunos/bin/edit "
+                "mediator=vi mediator=vim "
+                "mediator-implementatio=svr4".format(aname)
+            )
+            assertActionError(nact)
+
+            # Action with mediator properties without mediator
+            # is invalid.
+            props = {
+                "mediator-version": "1.0",
+                "mediator-implementation": "svr4",
+                "mediator-priority": "site",
+            }
+            for prop, val in six.iteritems(props):
+                nact = (
+                    "{0} path=usr/bin/vi "
+                    "target=../sunos/bin/edit {1}={2}".format(aname, prop, val)
+                )
                 assertActionError(nact)
 
-                # Verify only numeric value is allowed for gid of group.
-                nact = "group groupname=staff gid=abc"
+            # Action with multiple values for any property is
+            # invalid.
+            for prop, val in six.iteritems(props):
+                nact = (
+                    "{0} path=usr/bin/vi "
+                    "target=../sunos/bin/edit mediator=vi "
+                    "{1}={2} {3}={4} ".format(aname, prop, val, prop, val)
+                )
+                if prop == "mediator-priority":
+                    # mediator-priority alone isn't
+                    # valid, so test multiple value
+                    # invalid, add something.
+                    nact += " mediator-version=1.0"
                 assertActionError(nact)
 
-                # Verify multiple values are not allowed for must-accept and
-                # must-display attributes of license actions.
-                for attr in ("must-accept", "must-display"):
-                        nact = "license license=copyright {attr}=true " \
-                            "{attr}=false".format(attr=attr)
-                        assertActionError(nact)
-
-                # Ensure link and hardlink attributes are validated properly.
-                for aname in ("link", "hardlink"):
-                        # Action with mediator without mediator properties is
-                        # invalid.
-                        nact = "{0} path=usr/bin/vi target=../sunos/bin/edit " \
-                            "mediator=vi".format(aname)
-                        assertActionError(nact)
-
-                        # Action with multiple mediator values is invalid.
-                        nact = "{0} path=usr/bin/vi target=../sunos/bin/edit " \
-                            "mediator=vi mediator=vim " \
-                            "mediator-implementatio=svr4".format(aname)
-                        assertActionError(nact)
-
-                        # Action with mediator properties without mediator
-                        # is invalid.
-                        props = {
-                            "mediator-version": "1.0",
-                            "mediator-implementation": "svr4",
-                            "mediator-priority": "site",
-                        }
-                        for prop, val in six.iteritems(props):
-                                nact = "{0} path=usr/bin/vi " \
-                                    "target=../sunos/bin/edit {1}={2}".format(aname,
-                                    prop, val)
-                                assertActionError(nact)
-
-                        # Action with multiple values for any property is
-                        # invalid.
-                        for prop, val in six.iteritems(props):
-                                nact = "{0} path=usr/bin/vi " \
-                                    "target=../sunos/bin/edit mediator=vi " \
-                                    "{1}={2} {3}={4} ".format(aname, prop, val, prop,
-                                    val)
-                                if prop == "mediator-priority":
-                                        # mediator-priority alone isn't
-                                        # valid, so test multiple value
-                                        # invalid, add something.
-                                        nact += " mediator-version=1.0"
-                                assertActionError(nact)
-
-                        # Verify invalid mediator names are rejected.
-                        for value in ("not/valid", "not valid", "not.valid"):
-                                nact = "{0} path=usr/bin/vi target=vim " \
-                                    "mediator=\"{1}\" mediator-implementation=vim" \
-                                   .format(aname, value)
-                                assertActionError(nact)
-
-                        # Verify invalid mediator-versions are rejected.
-                        for value in ("1.a", "abc", ".1"):
-                                nact = "{0} path=usr/bin/vi target=vim " \
-                                    "mediator=vim mediator-version={1}" \
-                                   .format(aname, value)
-                                assertActionError(nact)
-
-                        # Verify invalid mediator-implementations are rejected.
-                        for value in ("1.a", "@", "@1", "vim@.1",
-                            "vim@abc"):
-                                nact = "{0} path=usr/bin/vi target=vim " \
-                                    "mediator=vim mediator-implementation={1}" \
-                                   .format(aname, value)
-                                assertActionError(nact)
-
-                        # Verify multiple targets are not allowed.
-                        nact = "{0} path=/usr/bin/foo target=bar target=baz".format(
-                            aname)
-                        assertActionError(nact)
-
-                # Verify multiple values are not allowed for set actions such as
-                # pkg.description, pkg.obsolete, pkg.renamed, and pkg.summary.
-                for attr in ("pkg.description", "pkg.obsolete", "pkg.renamed",
-                    "pkg.summary", "pkg.depend.explicit-install"):
-                        nact = "set name={0} value=true value=false".format(attr)
-                        assertActionError(nact)
-
-                # Verify signature action attribute 'value' is required during
-                # publication.
-                nact = "signature 12345 algorithm=foo"
+            # Verify invalid mediator names are rejected.
+            for value in ("not/valid", "not valid", "not.valid"):
+                nact = (
+                    "{0} path=usr/bin/vi target=vim "
+                    'mediator="{1}" mediator-implementation=vim'.format(
+                        aname, value
+                    )
+                )
                 assertActionError(nact)
 
-                # Verify multiple values aren't allowed for user attributes.
-                for attr in ("password", "group", "gcos-field", "home-dir",
-                    "login-shell", "ftpuser"):
-                        nact = "user username=user {attr}=ab {attr}=cd ".format(
-                            attr=attr)
-                        assertActionError(nact)
+            # Verify invalid mediator-versions are rejected.
+            for value in ("1.a", "abc", ".1"):
+                nact = (
+                    "{0} path=usr/bin/vi target=vim "
+                    "mediator=vim mediator-version={1}".format(aname, value)
+                )
+                assertActionError(nact)
 
-                for attr in ("uid", "lastchg", "min","max", "warn", "inactive",
-                    "expire", "flag"):
-                        nact = "user username=user {attr}=1 {attr}=2".format(
-                            attr=attr)
-                        assertActionError(nact)
+            # Verify invalid mediator-implementations are rejected.
+            for value in ("1.a", "@", "@1", "vim@.1", "vim@abc"):
+                nact = (
+                    "{0} path=usr/bin/vi target=vim "
+                    "mediator=vim mediator-implementation={1}".format(
+                        aname, value
+                    )
+                )
+                assertActionError(nact)
 
-                # Verify only numeric values are allowed for user attributes
-                # expecting a number.
-                for attr in ("uid", "lastchg", "min","max", "warn", "inactive",
-                    "expire", "flag"):
-                        nact = "user username=user {0}=abc".format(attr)
-                        assertActionError(nact)
+            # Verify multiple targets are not allowed.
+            nact = "{0} path=/usr/bin/foo target=bar target=baz".format(aname)
+            assertActionError(nact)
 
-                # Malformed pkg actuators
-                assertActionError(
-                    "set name=pkg.additional-update-on-uninstall "
-                    "value=&@M")
-                assertActionError(
-                    "set name=pkg.additional-update-on-uninstall "
-                    "value=A@1 value=&@M")
-                # Unknown actuator (should pass)
-                act = action.fromstr(
-                    "set name=pkg.additional-update-on-update value=A@1")
-                act.validate()
+        # Verify multiple values are not allowed for set actions such as
+        # pkg.description, pkg.obsolete, pkg.renamed, and pkg.summary.
+        for attr in (
+            "pkg.description",
+            "pkg.obsolete",
+            "pkg.renamed",
+            "pkg.summary",
+            "pkg.depend.explicit-install",
+        ):
+            nact = "set name={0} value=true value=false".format(attr)
+            assertActionError(nact)
+
+        # Verify signature action attribute 'value' is required during
+        # publication.
+        nact = "signature 12345 algorithm=foo"
+        assertActionError(nact)
+
+        # Verify multiple values aren't allowed for user attributes.
+        for attr in (
+            "password",
+            "group",
+            "gcos-field",
+            "home-dir",
+            "login-shell",
+            "ftpuser",
+        ):
+            nact = "user username=user {attr}=ab {attr}=cd ".format(attr=attr)
+            assertActionError(nact)
+
+        for attr in (
+            "uid",
+            "lastchg",
+            "min",
+            "max",
+            "warn",
+            "inactive",
+            "expire",
+            "flag",
+        ):
+            nact = "user username=user {attr}=1 {attr}=2".format(attr=attr)
+            assertActionError(nact)
+
+        # Verify only numeric values are allowed for user attributes
+        # expecting a number.
+        for attr in (
+            "uid",
+            "lastchg",
+            "min",
+            "max",
+            "warn",
+            "inactive",
+            "expire",
+            "flag",
+        ):
+            nact = "user username=user {0}=abc".format(attr)
+            assertActionError(nact)
+
+        # Malformed pkg actuators
+        assertActionError(
+            "set name=pkg.additional-update-on-uninstall " "value=&@M"
+        )
+        assertActionError(
+            "set name=pkg.additional-update-on-uninstall " "value=A@1 value=&@M"
+        )
+        # Unknown actuator (should pass)
+        act = action.fromstr(
+            "set name=pkg.additional-update-on-update value=A@1"
+        )
+        act.validate()
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_altroot.py
+++ b/src/tests/api/t_altroot.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -40,175 +41,169 @@ import pkg.client.image as image
 
 
 class TestAltroot(pkg5unittest.Pkg5TestCase):
-        persistent_setup = True
+    persistent_setup = True
 
-        def setUp(self):
-                self.i_count = 4
+    def setUp(self):
+        self.i_count = 4
 
-                # Create images in /var/tmp to run the tests on ZFS
-                # filesystems.
-                self.test_path = tempfile.mkdtemp(prefix="test-suite",
-                    dir="/var/tmp")
+        # Create images in /var/tmp to run the tests on ZFS
+        # filesystems.
+        self.test_path = tempfile.mkdtemp(prefix="test-suite", dir="/var/tmp")
 
-                self.imgs_path = {}
-                for i in range(0, self.i_count):
-                        path = os.path.join(self.test_path,
-                            "image{0:d}".format(i))
-                        self.imgs_path[i] = path
+        self.imgs_path = {}
+        for i in range(0, self.i_count):
+            path = os.path.join(self.test_path, "image{0:d}".format(i))
+            self.imgs_path[i] = path
 
-                # image path
-                self.i = []
+        # image path
+        self.i = []
 
-                # image files and directories
-                self.p_f1 = "f1"
-                self.p_f2 = "f2"
-                self.p_none = "none"
-                self.p_d = "d"
-                self.p_d_f1 = os.path.join(self.p_d, "f1")
-                self.p_d_f2 = os.path.join(self.p_d, "f2")
-                self.p_d_none = os.path.join(self.p_d, "none")
-                self.p_f1_redir = "f1_redir"
-                self.p_f2_redir = "f2_redir"
-                self.p_d_redir = "d_redir"
-                self.p_d_f1_redir = os.path.join(self.p_d_redir, "f1")
-                self.p_d_f2_redir = os.path.join(self.p_d_redir, "f2")
-                self.p_d_none_redir = os.path.join(self.p_d_redir, "none")
+        # image files and directories
+        self.p_f1 = "f1"
+        self.p_f2 = "f2"
+        self.p_none = "none"
+        self.p_d = "d"
+        self.p_d_f1 = os.path.join(self.p_d, "f1")
+        self.p_d_f2 = os.path.join(self.p_d, "f2")
+        self.p_d_none = os.path.join(self.p_d, "none")
+        self.p_f1_redir = "f1_redir"
+        self.p_f2_redir = "f2_redir"
+        self.p_d_redir = "d_redir"
+        self.p_d_f1_redir = os.path.join(self.p_d_redir, "f1")
+        self.p_d_f2_redir = os.path.join(self.p_d_redir, "f2")
+        self.p_d_none_redir = os.path.join(self.p_d_redir, "none")
 
-                for i in range(0, self.i_count):
-                        # first assign paths.  we'll use the image paths even
-                        # though we're not actually doing any testing with
-                        # real images.
-                        r = self.imgs_path[i]
-                        self.i.insert(i, r)
+        for i in range(0, self.i_count):
+            # first assign paths.  we'll use the image paths even
+            # though we're not actually doing any testing with
+            # real images.
+            r = self.imgs_path[i]
+            self.i.insert(i, r)
 
-                        os.makedirs(r)
-                        if i == 0:
-                                # simulate a user image
-                                os.makedirs(
-                                    os.path.join(r, image.img_user_prefix))
-                        elif i == 1:
-                                # simulate a root image
-                                os.makedirs(
-                                    os.path.join(r, image.img_root_prefix))
-                        elif i == 2:
-                                # corrupt image: both root and user
-                                os.makedirs(
-                                    os.path.join(r, image.img_user_prefix))
-                                os.makedirs(
-                                    os.path.join(r, image.img_root_prefix))
+            os.makedirs(r)
+            if i == 0:
+                # simulate a user image
+                os.makedirs(os.path.join(r, image.img_user_prefix))
+            elif i == 1:
+                # simulate a root image
+                os.makedirs(os.path.join(r, image.img_root_prefix))
+            elif i == 2:
+                # corrupt image: both root and user
+                os.makedirs(os.path.join(r, image.img_user_prefix))
+                os.makedirs(os.path.join(r, image.img_root_prefix))
 
-                for i in range(0, self.i_count):
-                        r = self.i[i]
-                        if i > 0:
-                                r_alt = self.i[i - 1]
-                        else:
-                                r_alt = self.i[self.i_count - 1]
-                        r_redir = os.path.basename(r_alt)
+        for i in range(0, self.i_count):
+            r = self.i[i]
+            if i > 0:
+                r_alt = self.i[i - 1]
+            else:
+                r_alt = self.i[self.i_count - 1]
+            r_redir = os.path.basename(r_alt)
 
-                        # create directories and files within the image
-                        self.make_file(os.path.join(r, self.p_f1), "foo")
-                        self.make_file(os.path.join(r, self.p_f2), "foo")
-                        self.make_file(os.path.join(r, self.p_d_f1), "bar")
-                        self.make_file(os.path.join(r, self.p_d_f2), "bar")
+            # create directories and files within the image
+            self.make_file(os.path.join(r, self.p_f1), "foo")
+            self.make_file(os.path.join(r, self.p_f2), "foo")
+            self.make_file(os.path.join(r, self.p_d_f1), "bar")
+            self.make_file(os.path.join(r, self.p_d_f2), "bar")
 
-                        # create sym links that point outside that image
-                        os.symlink(os.path.join("..", r_redir, self.p_f1),
-                            os.path.join(r, self.p_f1_redir))
+            # create sym links that point outside that image
+            os.symlink(
+                os.path.join("..", r_redir, self.p_f1),
+                os.path.join(r, self.p_f1_redir),
+            )
 
-                        os.symlink(os.path.join("..", r_redir, self.p_f2),
-                            os.path.join(r, self.p_f2_redir))
+            os.symlink(
+                os.path.join("..", r_redir, self.p_f2),
+                os.path.join(r, self.p_f2_redir),
+            )
 
-                        os.symlink(os.path.join("..", r_redir, self.p_d),
-                            os.path.join(r, self.p_d_redir))
+            os.symlink(
+                os.path.join("..", r_redir, self.p_d),
+                os.path.join(r, self.p_d_redir),
+            )
 
-        def tearDown(self):
-                shutil.rmtree(self.test_path)
+    def tearDown(self):
+        shutil.rmtree(self.test_path)
 
-        def __eremote(self, func, args):
-                e = None
-                try:
-                        func(*args)
-                except:
-                        e_type, e, e_traceback = sys.exc_info()
+    def __eremote(self, func, args):
+        e = None
+        try:
+            func(*args)
+        except:
+            e_type, e, e_traceback = sys.exc_info()
 
-                if isinstance(e, OSError) and e.errno == errno.EREMOTE:
-                        return
+        if isinstance(e, OSError) and e.errno == errno.EREMOTE:
+            return
 
-                if e == None:
-                        e_str = str(None)
-                else:
-                        e_str = traceback.format_exc()
+        if e == None:
+            e_str = str(None)
+        else:
+            e_str = traceback.format_exc()
 
-                args = ", ".join([str(a) for a in args])
-                self.fail(
-                    "altroot call didn't return OSError EREMOTE exception\n"
-                    "call: {0}({1})\n"
-                    "exception: {2}\n".format(
-                    func.__name__, args, e_str))
+        args = ", ".join([str(a) for a in args])
+        self.fail(
+            "altroot call didn't return OSError EREMOTE exception\n"
+            "call: {0}({1})\n"
+            "exception: {2}\n".format(func.__name__, args, e_str)
+        )
 
-        def test_ar_err_eremote(self):
-                """Verify that all altroot accessor functions return EREMOTE
-                if they traverse a path which contains a symlink that point
-                somewhere outside the specified altroot namespace."""
+    def test_ar_err_eremote(self):
+        """Verify that all altroot accessor functions return EREMOTE
+        if they traverse a path which contains a symlink that point
+        somewhere outside the specified altroot namespace."""
 
-                r = self.i[0]
-                invoke = [
-                    (ar.ar_open, (r, self.p_f1_redir, os.O_RDONLY)),
-                    (ar.ar_open, (r, self.p_d_f1_redir, os.O_RDONLY)),
+        r = self.i[0]
+        invoke = [
+            (ar.ar_open, (r, self.p_f1_redir, os.O_RDONLY)),
+            (ar.ar_open, (r, self.p_d_f1_redir, os.O_RDONLY)),
+            (ar.ar_unlink, (r, self.p_d_f1_redir)),
+            (ar.ar_rename, (r, self.p_d_f1_redir, self.p_d_f1)),
+            (ar.ar_rename, (r, self.p_d_f1, self.p_d_f1_redir)),
+            (ar.ar_rename, (r, self.p_d_f1_redir, self.p_d_f2_redir)),
+            (ar.ar_mkdir, (r, self.p_d_none_redir, 0o777)),
+            (ar.ar_stat, (r, self.p_f1_redir)),
+            (ar.ar_stat, (r, self.p_d_f1_redir)),
+            (ar.ar_isdir, (r, self.p_d_redir)),
+            (ar.ar_isdir, (r, self.p_d_f1_redir)),
+            (ar.ar_exists, (r, self.p_f1_redir)),
+            (ar.ar_exists, (r, self.p_d_redir)),
+            (ar.ar_exists, (r, self.p_d_f1_redir)),
+            (ar.ar_diff, (r, self.p_f1, self.p_f2_redir)),
+            (ar.ar_diff, (r, self.p_f1_redir, self.p_f2)),
+            (ar.ar_diff, (r, self.p_d_f1, self.p_d_f2_redir)),
+            (ar.ar_diff, (r, self.p_d_f1_redir, self.p_d_f2)),
+        ]
+        for func, args in invoke:
+            self.__eremote(func, args)
 
-                    (ar.ar_unlink, (r, self.p_d_f1_redir)),
+    def __bad_img_prefix(self, func, args):
+        rv = func(*args)
+        if rv == None:
+            return
 
-                    (ar.ar_rename, (r, self.p_d_f1_redir, self.p_d_f1)),
-                    (ar.ar_rename, (r, self.p_d_f1, self.p_d_f1_redir)),
-                    (ar.ar_rename, (r, self.p_d_f1_redir, self.p_d_f2_redir)),
+        args = ", ".join([str(a) for a in args])
+        self.fail(
+            "altroot call didn't return None\n"
+            "call: {0}({1})\n"
+            "rv: {0}\n".format(func.__name__, args, str(rv))
+        )
 
-                    (ar.ar_mkdir, (r, self.p_d_none_redir, 0o777)),
+    def test_ar_err_img_prefix(self):
+        """Verify that ar_img_prefix() returns None if we have a
+        corrupt image.  image 2 has both user and root image
+        repositories.  image 3 is not an image, it's an empty
+        directory."""
 
-                    (ar.ar_stat, (r, self.p_f1_redir)),
-                    (ar.ar_stat, (r, self.p_d_f1_redir)),
+        invoke = [
+            (ar.ar_img_prefix, (self.i[2],)),
+            (ar.ar_img_prefix, (self.i[3],)),
+        ]
+        for func, args in invoke:
+            self.__bad_img_prefix(func, args)
 
-                    (ar.ar_isdir, (r, self.p_d_redir)),
-                    (ar.ar_isdir, (r, self.p_d_f1_redir)),
-
-                    (ar.ar_exists, (r, self.p_f1_redir)),
-                    (ar.ar_exists, (r, self.p_d_redir)),
-                    (ar.ar_exists, (r, self.p_d_f1_redir)),
-
-                    (ar.ar_diff, (r, self.p_f1, self.p_f2_redir)),
-                    (ar.ar_diff, (r, self.p_f1_redir, self.p_f2)),
-                    (ar.ar_diff, (r, self.p_d_f1, self.p_d_f2_redir)),
-                    (ar.ar_diff, (r, self.p_d_f1_redir, self.p_d_f2)),
-                ]
-                for func, args in invoke:
-                        self.__eremote(func, args)
-
-        def __bad_img_prefix(self, func, args):
-                rv = func(*args)
-                if rv == None:
-                        return
-
-                args = ", ".join([str(a) for a in args])
-                self.fail(
-                    "altroot call didn't return None\n"
-                    "call: {0}({1})\n"
-                    "rv: {0}\n".format(
-                    func.__name__, args, str(rv)))
-
-        def test_ar_err_img_prefix(self):
-                """Verify that ar_img_prefix() returns None if we have a
-                corrupt image.  image 2 has both user and root image
-                repositories.  image 3 is not an image, it's an empty
-                directory."""
-
-                invoke = [
-                    (ar.ar_img_prefix, (self.i[2],)),
-                    (ar.ar_img_prefix, (self.i[3],)),
-                ]
-                for func, args in invoke:
-                        self.__bad_img_prefix(func, args)
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_api.py
+++ b/src/tests/api/t_api.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 from six.moves import cStringIO
@@ -41,55 +42,56 @@ import tempfile
 import time
 import unittest
 
-class TestPkgApi(pkg5unittest.SingleDepotTestCase):
-        # restart the depot for every test
-        persistent_setup = False
 
-        foo10 = """
+class TestPkgApi(pkg5unittest.SingleDepotTestCase):
+    # restart the depot for every test
+    persistent_setup = False
+
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo12 = """
+    foo12 = """
             open foo@1.2,5.11-0
             add file libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
             close """
 
-        foo11v = """
+    foo11v = """
             open foo@1.1,5.11-0
             add set name=variant.arch value=i386 value=sparc
             add file libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1 variant.arch=i386
             close """
 
-        foo12v = """
+    foo12v = """
             open foo@1.2,5.11-0
             add set name=variant.arch value=i386 value=sparc
             add file libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1 variant.arch=i386
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             close """
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             add license copyright.baz license=copyright.baz
             close """
 
-        quux10 = """
+    quux10 = """
             open quux@1.0,5.11-0
             add depend type=require fmri=foo@1.0
             close """
 
-        # First iteration has just a copyright.
-        licensed10 = """
+    # First iteration has just a copyright.
+    licensed10 = """
             open licensed@1.0,5.11-0
             add depend type=require fmri=baz@1.0
             add license copyright.licensed license=copyright.licensed
             close """
 
-        # Second iteration has copyright that must-display and a new license
-        # that doesn't require acceptance.
-        licensed12 = """
+    # Second iteration has copyright that must-display and a new license
+    # that doesn't require acceptance.
+    licensed12 = """
             open licensed@1.2,5.11-0
             add depend type=require fmri=baz@1.0
             add file libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
@@ -97,8 +99,8 @@ class TestPkgApi(pkg5unittest.SingleDepotTestCase):
             add license license.licensed license=license.licensed
             close """
 
-        # Third iteration now requires acceptance of license.
-        licensed13 = """
+    # Third iteration now requires acceptance of license.
+    licensed13 = """
             open licensed@1.3,5.11-0
             add depend type=require fmri=baz@1.0
             add file libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
@@ -106,9 +108,9 @@ class TestPkgApi(pkg5unittest.SingleDepotTestCase):
             add license license.licensed license=license.licensed must-accept=True
             close """
 
-        # Fourth iteration is completely unchanged, so shouldn't require
-        # acceptance.
-        licensed14 = """
+    # Fourth iteration is completely unchanged, so shouldn't require
+    # acceptance.
+    licensed14 = """
             open licensed@1.4,5.11-0
             add depend type=require fmri=baz@1.0
             add file libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
@@ -116,7 +118,7 @@ class TestPkgApi(pkg5unittest.SingleDepotTestCase):
             add license license.licensed license=license.licensed must-accept=True
             close """
 
-        p5i_bobcat = """{
+    p5i_bobcat = """{
   "packages": [
     "pkg:/bar@1.0,5.11-0",
     "baz"
@@ -151,946 +153,1010 @@ class TestPkgApi(pkg5unittest.SingleDepotTestCase):
 }
 """
 
-
-        misc_files = ["copyright.baz", "copyright.licensed", "libc.so.1",
-            "license.licensed", "license.licensed.addendum"]
-
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self, publisher="bobcat")
-                self.make_misc_files(self.misc_files)
-                self.p5i_bobcat = self.p5i_bobcat.replace("%REAL_ORIGIN%",
-                    self.rurl)
-
-        def __try_bad_installs(self, api_obj):
-
-                self.assertRaises(api_errors.PlanExistsException,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_install(*args, **kwargs)),
-                    ["foo"])
-                self.assertRaises(api_errors.PlanExistsException,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_uninstall(*args, **kwargs)),
-                    ["foo"])
-                self.assertRaises(api_errors.PlanExistsException,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_update(*args, **kwargs)))
-                try:
-                        for pd in api_obj.gen_plan_update():
-                                continue
-                except api_errors.PlanExistsException:
-                        pass
-                else:
-                        assert 0
-
-        def __try_bad_combinations_and_complete(self, api_obj):
-                self.__try_bad_installs(api_obj)
-
-                self.assertRaises(api_errors.PrematureExecutionException,
-                    api_obj.execute_plan)
-
-                api_obj.prepare()
-                self.__try_bad_installs(api_obj)
-
-                self.assertRaises(api_errors.AlreadyPreparedException,
-                    api_obj.prepare)
-
-                api_obj.execute_plan()
-                self.__try_bad_installs(api_obj)
-                self.assertRaises(api_errors.AlreadyPreparedException,
-                    api_obj.prepare)
-                self.assertRaises(api_errors.AlreadyExecutedException,
-                    api_obj.execute_plan)
-
-        def test_bad_orderings(self):
-
-                self.pkgsend_bulk(self.rurl, self.foo10)
-                api_obj = self.image_create(self.rurl, prefix="bobcat")
-
-                self.assertTrue(api_obj.describe() is None)
-
-                self.assertRaises(api_errors.PlanMissingException,
-                    api_obj.prepare)
-
-                for pd in api_obj.gen_plan_install(["foo"]):
-                        continue
-                self.__try_bad_combinations_and_complete(api_obj)
-                api_obj.reset()
-
-                self.assertRaises(api_errors.PlanMissingException,
-                    api_obj.prepare)
-
-                self.assertTrue(api_obj.describe() is None)
-
-                self.pkgsend_bulk(self.rurl, self.foo12)
-                api_obj.refresh(immediate=True)
-
-                for pd in api_obj.gen_plan_update():
-                        continue
-                self.__try_bad_combinations_and_complete(api_obj)
-                api_obj.reset()
-
-                self.assertRaises(api_errors.PlanMissingException,
-                    api_obj.prepare)
-                self.assertTrue(api_obj.describe() is None)
-
-                for pd in api_obj.gen_plan_uninstall(["foo"]):
-                        continue
-                self.__try_bad_combinations_and_complete(api_obj)
-                api_obj.reset()
-
-                self.assertRaises(api_errors.PlanMissingException,
-                    api_obj.prepare)
-                self.assertTrue(api_obj.describe() is None)
-
-        def test_reset(self):
-                """ Send empty package foo@1.0, install and uninstall """
-
-                self.pkgsend_bulk(self.rurl, self.foo10)
-                api_obj = self.image_create(self.rurl, prefix="bobcat")
-
-                facets = facet.Facets({ "facet.devel": True })
-                for pd in api_obj.gen_plan_change_varcets(facets=facets):
-                        continue
-                self._api_finish(api_obj)
-
-                for pd in api_obj.gen_plan_install(["foo"]):
-                        continue
-                self.assertTrue(api_obj.describe() is not None)
-                api_obj.reset()
-                self.assertTrue(api_obj.describe() is None)
-                for pd in api_obj.gen_plan_install(["foo"]):
-                        continue
-                self.assertTrue(api_obj.describe() is not None)
-                api_obj.prepare()
-                api_obj.reset()
-                self.assertTrue(api_obj.describe() is None)
-                for pd in api_obj.gen_plan_install(["foo"]):
-                        continue
-                self.assertTrue(api_obj.describe() is not None)
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-                self.assertTrue(api_obj.describe() is None)
-
-                self.pkg("list")
-                self.pkg("verify")
-
-                self.pkgsend_bulk(self.rurl, self.foo12)
-                api_obj.refresh(immediate=True)
-
-                for pd in api_obj.gen_plan_update():
-                        continue
-                self.assertTrue(api_obj.describe() is not None)
-                api_obj.reset()
-                self.assertTrue(api_obj.describe() is None)
-                for pd in api_obj.gen_plan_update():
-                        continue
-                self.assertTrue(api_obj.describe() is not None)
-                api_obj.prepare()
-                api_obj.reset()
-                self.assertTrue(api_obj.describe() is None)
-                for pd in api_obj.gen_plan_update():
-                        continue
-                self.assertTrue(api_obj.describe() is not None)
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-                self.assertTrue(api_obj.describe() is None)
-
-                self.pkg("list")
-                self.pkg("verify")
-
-                for pd in api_obj.gen_plan_uninstall(["foo"]):
-                        continue
-                self.assertTrue(api_obj.describe() is not None)
-                api_obj.reset()
-                self.assertTrue(api_obj.describe() is None)
-                for pd in api_obj.gen_plan_uninstall(["foo"]):
-                        continue
-                self.assertTrue(api_obj.describe() is not None)
-                api_obj.prepare()
-                api_obj.reset()
-                self.assertTrue(api_obj.describe() is None)
-                for pd in api_obj.gen_plan_uninstall(["foo"]):
-                        continue
-                self.assertTrue(api_obj.describe() is not None)
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-                self.assertTrue(api_obj.describe() is None)
-
-                self.pkg("verify")
-
-        def test_refresh_transition(self):
-                """Verify that refresh works for a v0 catalog source and that
-                if the client transitions from v0 to v1 or back that the correct
-                state information is recorded in the image catalog."""
-
-                # This test requires an actual depot due to v0 operation usage.
-                # First create the image and get v1 catalog.
-                self.dc.start()
-                self.pkgsend_bulk(self.durl, (self.foo10, self.quux10))
-                try:
-                        api_obj = self.image_create(self.durl, prefix="bobcat")
-                except api_errors.CatalogRefreshException as e:
-                        self.debug("\n".join(str(x[-1]) for x in e.failed))
-                        raise
-
-                self.pkg("publisher")
-                img = api_obj.img
-                kcat = img.get_catalog(img.IMG_CATALOG_KNOWN)
-                entry = [e for f, e in kcat.entries()][0]
-                states = entry["metadata"]["states"]
-                self.assertTrue(pkgdefs.PKG_STATE_V1 in states)
-                self.assertTrue(pkgdefs.PKG_STATE_V0 not in states)
-
-                # Next, disable v1 catalog for the depot and force a client
-                # refresh.  Only v0 state should be present.
-                self.dc.stop()
-                self.dc.set_disable_ops(["catalog/1"])
-                self.dc.start()
-
-                # Since the depot state changed while the API object was
-                # still active, it needs to be reset to clear the internal
-                # transport state cache.
-                api_obj.reset()
-
-                api_obj.refresh(immediate=True)
-                api_obj.reset()
-                img = api_obj.img
-
-                kcat = img.get_catalog(img.IMG_CATALOG_KNOWN)
-                entry = [e for f, e in kcat.entries()][0]
-                states = entry["metadata"]["states"]
-                self.assertTrue(pkgdefs.PKG_STATE_V1 not in states)
-                self.assertTrue(pkgdefs.PKG_STATE_V0 in states)
-
-                # Verify that there is no dependency information present
-                # in the known or installed catalog.
-                icat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
-                for cat in kcat, icat:
-                        dpart = cat.get_part("catalog.dependency.C")
-                        dep_acts = [
-                            acts
-                            for t, entry in dpart.tuple_entries()
-                            for acts in entry.get("actions", [])
-                        ]
-                        self.assertEqual(dep_acts, [])
-
-                # Now install a package, and verify that the entries in the
-                # known catalog for installed packages exist in the installed
-                # catalog and are identical.
-                api_obj = self.get_img_api_obj()
-                img = api_obj.img
-
-                # Get image catalogs.
-                kcat = img.get_catalog(img.IMG_CATALOG_KNOWN)
-                icat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
-
-                # Verify quux package is only in known catalog.
-                self.assertTrue("quux" in kcat.names())
-                self.assertTrue("foo" in kcat.names())
-                self.assertTrue("quux" not in icat.names())
-                self.assertTrue("foo" not in icat.names())
-
-                # Install the packages.
-                for pd in api_obj.gen_plan_install(["quux@1.0"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                # Get image catalogs.
-                kcat = img.get_catalog(img.IMG_CATALOG_KNOWN)
-                icat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
-
-                # Verify quux package is in both catalogs.
-                self.assertTrue("quux" in kcat.names())
-                self.assertTrue("foo" in kcat.names())
-                self.assertTrue("quux" in icat.names())
-                self.assertTrue("foo" in icat.names())
-
-                # Verify state info.
-                for cat in kcat, icat:
-                        entry = [e for f, e in cat.entries()][0]
-                        states = entry["metadata"]["states"]
-                        self.assertTrue(pkgdefs.PKG_STATE_INSTALLED in states)
-                        self.assertTrue(pkgdefs.PKG_STATE_V0 in states)
-
-                # Finally, transition back to v1 catalog.  This requires
-                # creating a new api object since transport will think that
-                # v1 catalogs are still unsupported.
-                self.dc.unset_disable_ops()
-                self.dc.stop()
-                self.dc.start()
-
-                api_obj = self.get_img_api_obj()
-                api_obj.refresh(immediate=True)
-                img = api_obj.img
-
-                # Get image catalogs.
-                kcat = img.get_catalog(img.IMG_CATALOG_KNOWN)
-                icat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
-
-                # Verify quux package is in both catalogs.
-                self.assertTrue("quux" in kcat.names())
-                self.assertTrue("foo" in kcat.names())
-                self.assertTrue("quux" in icat.names())
-                self.assertTrue("foo" in icat.names())
-
-                # Verify state info.
-                for f, entry in kcat.entries():
-                        states = entry["metadata"]["states"]
-                        self.assertTrue(pkgdefs.PKG_STATE_V1 in states)
-                        self.assertTrue(pkgdefs.PKG_STATE_V0 not in states)
-
-                # Verify that there is dependency information present
-                # in the known and installed catalog.
-                for cat in kcat, icat:
-                        dpart = cat.get_part("catalog.dependency.C")
-                        entries = [(t, entry) for t, entry in dpart.tuple_entries()]
-                        dep_acts = [
-                            acts
-                            for t, entry in dpart.tuple_entries()
-                            for acts in entry.get("actions", [])
-                            if t[1] == "quux"
-                        ]
-                        self.assertNotEqual(dep_acts, [])
-
-                # Verify that every installed package is in known and has
-                # identical entries and that every installed package in
-                # the installed catalog is in the known catalog and has
-                # entries.
-                for src, dest in ((kcat, icat), (icat, kcat)):
-                        src_base = src.get_part("catalog.base.C",
-                            must_exist=True)
-                        self.assertNotEqual(src_base, None)
-
-                        for f, bentry in src_base.entries():
-                                states = bentry["metadata"]["states"]
-                                if pkgdefs.PKG_STATE_INSTALLED not in states:
-                                        continue
-
-                                for name in src.parts:
-                                        spart = src.get_part(name,
-                                            must_exist=True)
-                                        self.assertNotEqual(spart, None)
-
-                                        dpart = dest.get_part(name,
-                                            must_exist=True)
-                                        self.assertNotEqual(dpart, None)
-
-                                        sentry = spart.get_entry(pfmri=f)
-                                        dentry = dpart.get_entry(pfmri=f)
-                                        self.assertEqual(sentry, dentry)
-
-        def test_properties(self):
-                """Verify that properties of the ImageInterface api object are
-                accessible and return expected values."""
-
-                api_obj = self.image_create(self.rurl, prefix="bobcat")
-                self.assertEqual(api_obj.root, self.img_path())
-
-        def test_snapdir(self):
-                """Verify that image create ignores .zfs snapdir."""
-
-                # snapdir path
-                path = self.img_path()
-                snapdir = os.path.join(path, ".zfs")
-
-                # a .zfs directory is allowed
-                self.image_destroy()
-                os.mkdir(self.img_path())
-                os.mkdir(snapdir)
-                api_obj = self.image_create(destroy=False)
-
-                # a .zfs file is not allowed
-                self.image_destroy()
-                os.mkdir(self.img_path())
-                open(snapdir, 'w').close()
-                self.assertRaises(api_errors.CreatingImageInNonEmptyDir,
-                    self.image_create, destroy=False)
-
-        def test_publisher_apis(self):
-                """Verify that the publisher api methods work as expected.
-
-                Note that not all methods are tested here as this would be
-                redundant since other tests for the client will use those
-                methods indirectly."""
-
-                plist = self.pkgsend_bulk(self.rurl, (self.foo10, self.bar10))
-                api_obj = self.image_create(self.rurl, prefix="bobcat")
-
-                # Verify that existence tests succeed.
-                self.assertTrue(api_obj.has_publisher("bobcat"))
-
-                # Verify preferred publisher prefix is returned correctly.
-                self.assertEqual(api_obj.get_highest_ranked_publisher().prefix,
-                    "bobcat")
-
-                # Verify that get_publisher returned the correct publisher
-                # object.
-                pub = api_obj.get_publisher(prefix="bobcat")
-                self.assertEqual(pub.prefix, "bobcat")
-
-                # Verify that not specifying matching criteria for get_publisher
-                # raises a UnknownPublisher exception.
-                self.assertRaises(api_errors.UnknownPublisher,
-                    api_obj.get_publisher, "zuul")
-                self.assertRaises(api_errors.UnknownPublisher,
-                    api_obj.get_publisher)
-
-                # Verify that publisher objects returned from get_publishers
-                # match those returned by get_publisher.
-                pubs = api_obj.get_publishers()
-                self.assertEqual(pub.prefix, pubs[0].prefix)
-                self.assertEqual(id(pub), id(pubs[0]))
-
-                # Verify that duplicate actually creates duplicates.
-                cpub = api_obj.get_publisher(prefix="bobcat", duplicate=True)
-                self.assertNotEqual(id(pub), id(cpub))
-
-                # Now modify publisher information and update.
-                cpub.alias = "cat"
-                repo = cpub.repository
-                repo.name = "source"
-                repo.description = "xkcd.net/325"
-                repo.legal_uris = ["http://xkcd.com/license.html"]
-                repo.refresh_seconds = 43200
-                repo.registered = False
-                api_obj.update_publisher(cpub)
-
-                # Verify that the update happened.
-                pub = api_obj.get_publisher(prefix="bobcat")
-                self.assertEqual(pub.alias, "cat")
-                repo = pub.repository
-                self.assertEqual(repo.name, "source")
-                self.assertEqual(repo.description, "xkcd.net/325")
-                self.assertEqual(repo.legal_uris[0],
-                    "http://xkcd.com/license.html")
-                self.assertEqual(repo.refresh_seconds, 43200)
-                self.assertEqual(repo.registered, False)
-
-                # Verify that duplicates match their original.
-                cpub = api_obj.get_publisher(alias=pub.alias, duplicate=True)
-                for p in ("alias", "prefix", "meta_root"):
-                        self.assertEqual(getattr(pub, p), getattr(cpub, p))
-
-                for p in ("collection_type", "description", "legal_uris",
-                    "mirrors", "name", "origins", "refresh_seconds",
-                    "registered", "registration_uri", "related_uris",
-                    "sort_policy"):
-                        srepo = pub.repository
-                        crepo = cpub.repository
-                        self.assertEqual(getattr(srepo, p), getattr(crepo, p))
-                cpub = None
-
-                cpubs = api_obj.get_publishers(duplicate=True)
-                self.assertNotEqual(id(pub), id(cpubs[0]))
-                cpubs = None
-
-                # Verify that publisher_last_update_time returns a value.
-                self.assertTrue(
-                    api_obj.get_publisher_last_update_time("bobcat"))
-
-                # Verify that p5i export and parse works as expected.
-
-                # Ensure that PackageInfo, PkgFmri, and strings are all
-                # supported properly.
-
-                # Strip timestamp information so that comparison with
-                # pre-generated test data will succeed.
-                ffoo = fmri.PkgFmri(plist[0])
-                sfoo = str(ffoo).replace(":{0}".format(ffoo.version.timestr), "")
-                ffoo = fmri.PkgFmri(sfoo)
-                sfoo = ffoo.get_fmri(anarchy=True)
-
-                fbar = fmri.PkgFmri(plist[1])
-                sbar = str(fbar).replace(":{0}".format(fbar.version.timestr), "")
-                fbar = fmri.PkgFmri(sbar)
-                sbar = fbar.get_fmri(anarchy=True)
-
-                # Build a simple list of packages.
-                pnames = {
-                    "bobcat": (api.PackageInfo(ffoo),),
-                    "": [fbar, "baz"],
-                }
-
-                # Dump the p5i data.
-                fobj = cStringIO()
-                api_obj.write_p5i(fobj, pkg_names=pnames, pubs=[pub])
-
-                # Verify that output matches expected output.
-                fobj.seek(0)
-                output = fobj.read()
-                self.assertEqualJSON(output, self.p5i_bobcat)
-
-                def validate_results(results):
-                        # First result should be 'bobcat' publisher and its
-                        # pkg_names.
-                        pub, pkg_names = results[0]
-
-                        self.assertEqual(pub.prefix, "bobcat")
-                        self.assertEqual(pub.alias, "cat")
-                        repo = pub.repository
-                        self.assertEqual(repo.name, "source")
-                        self.assertEqual(repo.description, "xkcd.net/325")
-                        self.assertEqual(repo.legal_uris[0],
-                            "http://xkcd.com/license.html")
-                        self.assertEqual(repo.refresh_seconds, 43200)
-                        self.assertEqual(pkg_names, [sfoo])
-
-                        # Last result should be no publisher and a list of
-                        # pkg_names.
-                        pub, pkg_names = results[1]
-                        self.assertEqual(pub, None)
-                        self.assertEqual(pkg_names, [sbar, "baz"])
-
-                # Verify that parse returns the expected object and information
-                # when provided a fileobj.
-                fobj.seek(0)
-                validate_results(api_obj.parse_p5i(fileobj=fobj))
-
-                # Verify that an add of the parsed object works (the name has to
-                # be changed to prevent a duplicate error here).
-                fobj.seek(0)
-                results = api_obj.parse_p5i(fileobj=fobj)
-                pub, pkg_names = results[0]
-
-                pub.prefix = "p5icat"
-                pub.alias = "copycat"
-                api_obj.add_publisher(pub, refresh_allowed=False)
-
-                # Now verify that we can retrieve the added publisher.
-                api_obj.get_publisher(prefix=pub.prefix)
-                cpub = api_obj.get_publisher(alias=pub.alias, duplicate=True)
-
-                # Now verify that the DuplicatePublisher exception is raised
-                # as expected when adding or updating publishers if the prefix
-                # is the same as another publisher's prefix or alias.  This is
-                # because alias and prefix are intended to be interchangeable
-                # (although the API allows clients to make a distinction
-                # internally).
-                dpub = api_obj.get_publisher(alias=pub.alias, duplicate=True)
-                dpub.alias = None
-
-                # Should fail since a publisher exists with this prefix.
-                self.assertRaises(api_errors.DuplicatePublisher,
-                        api_obj.add_publisher, dpub, refresh_allowed=False)
-                dpub.prefix = "bobcat"
-                self.assertRaises(api_errors.DuplicatePublisher,
-                        api_obj.update_publisher, dpub, refresh_allowed=False)
-
-                # Should fail since a publisher exists with an alias the same
-                # as this prefix.
-                dpub.prefix = "copycat"
-                self.assertRaises(api_errors.DuplicatePublisher,
-                        api_obj.add_publisher, dpub, refresh_allowed=False)
-                dpub.prefix = "cat"
-                self.assertRaises(api_errors.DuplicatePublisher,
-                        api_obj.update_publisher, dpub, refresh_allowed=False)
-
-                # Should fail since a publisher exists with an alias the same
-                # as this alias.
-                dpub.prefix = "uniquecat"
-                dpub.alias = "copycat"
-                self.assertRaises(api_errors.DuplicatePublisher,
-                        api_obj.add_publisher, dpub, refresh_allowed=False)
-                dpub.alias = "cat"
-                self.assertRaises(api_errors.DuplicatePublisher,
-                        api_obj.update_publisher, dpub, refresh_allowed=False)
-
-                # Should fail since a publisher exists with a prefix the same
-                # as this alias.
-                dpub.prefix = "uniquecat"
-                dpub.alias = "p5icat"
-                self.assertRaises(api_errors.DuplicatePublisher,
-                        api_obj.add_publisher, dpub, refresh_allowed=False)
-                dpub.alias = "bobcat"
-                self.assertRaises(api_errors.DuplicatePublisher,
-                        api_obj.update_publisher, dpub, refresh_allowed=False)
-
-                # Now update the publisher and set it to disabled, to verify
-                # that api functions still work as expected.
-                cpub.disabled = True
-                api_obj.update_publisher(cpub)
-
-                cpub = api_obj.get_publisher(alias=cpub.alias, duplicate=True)
-                self.assertTrue(cpub.disabled)
-
-                self.assertTrue(api_obj.has_publisher(prefix=cpub.prefix))
-
-                # Now attempt to update the disabled publisher.
-                cpub = api_obj.get_publisher(alias=cpub.alias, duplicate=True)
-                cpub.alias = "copycopycat"
-                api_obj.update_publisher(cpub)
-                cpub = None
-
-                # Verify that parse returns the expected object and information
-                # when provided a file path.
-                fobj.seek(0)
-                (fd1, path1) = tempfile.mkstemp(dir=self.test_root)
-                with open(path1, "w") as f:
-                        f.write(fobj.read())
-                validate_results(api_obj.parse_p5i(location=path1))
-
-                # Verify that parse returns the expected object and information
-                # when provided a file URI.
-                validate_results(api_obj.parse_p5i(location="file://" + path1))
-                fobj.close()
-                fobj = None
-
-                # Verify that appropriate exceptions are raised for p5i
-                # information that can't be retrieved (doesn't exist).
-                nefpath = os.path.join(self.test_root, "non-existent")
-                self.assertRaises(api_errors.RetrievalError,
-                    api_obj.parse_p5i, location="file://{0}".format(nefpath))
-
-                self.assertRaises(api_errors.RetrievalError,
-                    api_obj.parse_p5i, location=nefpath)
-
-                # Verify that appropriate exceptions are raised for invalid
-                # p5i information.
-                lcpath = os.path.join(self.test_root, "libc.so.1")
-                self.assertRaises(api_errors.InvalidP5IFile, api_obj.parse_p5i,
-                    location="file://{0}".format(lcpath))
-
-                self.assertRaises(api_errors.InvalidP5IFile, api_obj.parse_p5i,
-                    location=lcpath)
-
-                # Now install a package and remove all publishers and verify a
-                # publisher obj is returned by get_highest_ranked_publisher().
-                self._api_install(api_obj, ["foo"])
-                api_obj.remove_publisher("bobcat")
-                api_obj.remove_publisher("p5icat")
-                self.assertTrue(api_obj.get_highest_ranked_publisher().prefix,
-                    "bobcat")
-
-        def test_deprecated(self):
-                """Test deprecated api interfaces."""
-
-                self.pkgsend_bulk(self.rurl, self.foo10)
-                api_obj = self.image_create(self.rurl, prefix="bobcat",
-                    variants={"variant.arch": "i386"})
-                api_obj.reset()
-
-                # verify the old install interface
-                stuff_to_do = api_obj.plan_install(["foo"], noexecute=False)
-                self.assertTrue(stuff_to_do)
-                api_obj.prepare()
-                try:
-                        api_obj.execute_plan()
-                except api_errors.WrapSuccessfulIndexingException:
-                        pass
-                api_obj.reset()
-
-                self.pkgsend_bulk(self.rurl, self.foo11v)
-                self.pkgsend_bulk(self.rurl, self.foo12v)
-                api_obj.refresh(immediate=True)
-
-                # verify the old update interface
-                stuff_to_do = api_obj.plan_update(
-                    ["foo@1.1,5.11-0"], noexecute=False)
-                self.assertTrue(stuff_to_do)
-                api_obj.prepare()
-                try:
-                        api_obj.execute_plan()
-                except api_errors.WrapSuccessfulIndexingException:
-                        pass
-                api_obj.reset()
-
-                # verify the old update interface
-                stuff_to_do, s_image = api_obj.plan_update_all(noexecute=False)
-                self.assertTrue(stuff_to_do)
-                self.assertFalse(s_image)
-                api_obj.prepare()
-                try:
-                        api_obj.execute_plan()
-                except api_errors.WrapSuccessfulIndexingException:
-                        pass
-                api_obj.reset()
-
-                # remove a file from the image
-                os.remove(os.path.join(self.img_path(), "lib/libc.so.1"))
-
-                # verify the old revert interface
-                stuff_to_do = api_obj.plan_revert(["/lib/libc.so.1"],
-                    noexecute=False)
-                self.assertTrue(stuff_to_do)
-                api_obj.prepare()
-                try:
-                        api_obj.execute_plan()
-                except api_errors.WrapSuccessfulIndexingException:
-                        pass
-                api_obj.reset()
-
-                # verify the old change varcets interface
-                stuff_to_do = api_obj.plan_change_varcets(
-                    variants={"variant.arch": "sparc"}, noexecute=False)
-                self.assertTrue(stuff_to_do)
-                api_obj.prepare()
-                try:
-                        api_obj.execute_plan()
-                except api_errors.WrapSuccessfulIndexingException:
-                        pass
-                api_obj.reset()
-
-                # verify the old change uninstall interface
-                stuff_to_do = api_obj.plan_uninstall(["foo"], noexecute=False)
-                self.assertTrue(stuff_to_do)
-                api_obj.prepare()
-                try:
-                        api_obj.execute_plan()
-                except api_errors.WrapSuccessfulIndexingException:
-                        pass
-                api_obj.reset()
-
-        def test_license(self):
-                """ Send various packages and then verify that install and
-                update operations will raise the correct exceptions or
-                enforce the requirements of the license actions within. """
-
-                plist = self.pkgsend_bulk(self.rurl, (self.licensed10,
-                    self.licensed12, self.licensed13, self.bar10, self.baz10))
-                api_obj = self.image_create(self.rurl, prefix="bobcat")
-
-                # First, test the basic install case to see if expected license
-                # data is returned.
-                for pd in api_obj.gen_plan_install(["licensed@1.0"]):
-                        continue
-
-                def lic_key(item):
-                        return item[2].license
-
-                plan = api_obj.describe()
-                lics = sorted(plan.get_licenses(), key=lic_key)
-
-                # Expect one license action for each package: "licensed", and
-                # its dependency "baz".
-                self.assertEqual(len(lics), 2)
-
-                # Now verify license entry for "baz@1.0" and "licensed@1.0".
-                for i, p in enumerate([plist[4], plist[0]]):
-                        pfmri = fmri.PkgFmri(p)
-                        dest_fmri, src, dest, accepted, displayed = lics[i]
-
-                        # Expect license information to be for this package.
-                        self.assertEqual(pfmri, dest_fmri)
-
-                        # This is an install, not an update, so there should be
-                        # no src.
-                        self.assertEqual(src, None)
-
-                        # dest should be a LicenseInfo object.
-                        self.assertEqual(type(dest), api.LicenseInfo)
-
-                        # Verify the identity of the LicenseInfo objects.
-                        self.assertEqual(dest.license,
-                            "copyright.{0}".format(pfmri.pkg_name))
-
-                        # The license hasn't been accepted yet.
-                        self.assertEqual(accepted, False)
-
-                        # The license hasn't beend displayed yet.
-                        self.assertEqual(displayed, False)
-
-                        # The license action doesn't require acceptance.
-                        self.assertEqual(dest.must_accept, False)
-
-                        # The license action doesn't require display.
-                        self.assertEqual(dest.must_display, False)
-
-                        # Verify license text.
-                        text = dest.license
-                        self.assertEqual(dest.get_text(), text)
-
-                # Install the packages.
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                # Next, check that an upgrade produces expected license data.
-                for pd in api_obj.gen_plan_install(["licensed@1.2"]):
-                        continue
-
-                plan = api_obj.describe()
-                lics = sorted(plan.get_licenses(), key=lic_key)
-
-                # Expect two license actions, both of which should be for the
-                # licensed@1.2 package.
-                self.assertEqual(len(lics), 2)
-
-                # Now verify license entries for "licensed@1.2".
-                pfmri = fmri.PkgFmri(plist[1])
-                for dest_fmri, src, dest, accepted, displayed in lics:
-                        # License information should only be for "licensed@1.2".
-                        self.assertEqual(pfmri, dest_fmri)
-
-                        must_accept = False
-                        must_display = False
-                        if dest.license.startswith("copyright"):
-                                # This is an an update, so src should be a
-                                # LicenseInfo object.
-                                self.assertEqual(type(src), api.LicenseInfo)
-
-                                # In this version, copyright must be displayed
-                                # for dest.
-                                must_display = True
-
-                        # dest should be a LicenseInfo object.
-                        self.assertEqual(type(dest), api.LicenseInfo)
-
-                        # Verify LicenseInfo attributes.
-                        self.assertEqual(accepted, False)
-                        self.assertEqual(displayed, False)
-                        self.assertEqual(dest.must_accept, must_accept)
-                        self.assertEqual(dest.must_display, must_display)
-
-                        # Verify license text.
-                        text = dest.license
-                        self.assertEqual(dest.get_text(), text)
-
-                # Attempt to prepare plan; this should raise a license
-                # exception.
-                self.assertRaises(api_errors.PlanLicenseErrors,
-                    api_obj.prepare)
-
-                # Plan will have to be re-created first before continuing.
-                api_obj.reset()
-                for pd in api_obj.gen_plan_install(["licensed@1.2"]):
-                        continue
-                plan = api_obj.describe()
-
-                # Set the copyright as having been displayed.
-                api_obj.set_plan_license_status(pfmri, "copyright.licensed",
-                    displayed=True)
-                lics = sorted(plan.get_licenses(pfmri=pfmri), key=lic_key)
-
-                # Verify displayed was updated and accepted remains False.
-                dest_fmri, src, dest, accepted, displayed = lics[0]
-                self.assertEqual(src.license, "copyright.licensed")
-                self.assertEqual(accepted, False)
-                self.assertEqual(displayed, True)
-
-                # Prepare should succeed this time; so execute afterwards.
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                # Next, check that an update produces expected license
-                # data.
-                for pd in api_obj.gen_plan_update():
-                        continue
-
-                plan = api_obj.describe()
-                lics = [l for l in plan.get_licenses()]
-
-                # Expect one license action which should be for the licensed@1.3
-                # package.  (Only one is expected since only one of the license
-                # actions changed since licensed@1.2.)
-                self.assertEqual(len(lics), 1)
-
-                # Now verify license entries for "licensed@1.3".
-                pfmri = fmri.PkgFmri(plist[2])
-                dest_fmri, src, dest, accepted, displayed = lics[0]
-
-                # License information should only be for "licensed@1.3".
-                self.assertEqual(pfmri, dest_fmri)
-
-                must_accept = False
-                must_display = False
-
-                # This is an an update, so src should be a LicenseInfo
-                # object.
+    misc_files = [
+        "copyright.baz",
+        "copyright.licensed",
+        "libc.so.1",
+        "license.licensed",
+        "license.licensed.addendum",
+    ]
+
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self, publisher="bobcat")
+        self.make_misc_files(self.misc_files)
+        self.p5i_bobcat = self.p5i_bobcat.replace("%REAL_ORIGIN%", self.rurl)
+
+    def __try_bad_installs(self, api_obj):
+        self.assertRaises(
+            api_errors.PlanExistsException,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_install(*args, **kwargs)
+            ),
+            ["foo"],
+        )
+        self.assertRaises(
+            api_errors.PlanExistsException,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_uninstall(*args, **kwargs)
+            ),
+            ["foo"],
+        )
+        self.assertRaises(
+            api_errors.PlanExistsException,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_update(*args, **kwargs)
+            ),
+        )
+        try:
+            for pd in api_obj.gen_plan_update():
+                continue
+        except api_errors.PlanExistsException:
+            pass
+        else:
+            assert 0
+
+    def __try_bad_combinations_and_complete(self, api_obj):
+        self.__try_bad_installs(api_obj)
+
+        self.assertRaises(
+            api_errors.PrematureExecutionException, api_obj.execute_plan
+        )
+
+        api_obj.prepare()
+        self.__try_bad_installs(api_obj)
+
+        self.assertRaises(api_errors.AlreadyPreparedException, api_obj.prepare)
+
+        api_obj.execute_plan()
+        self.__try_bad_installs(api_obj)
+        self.assertRaises(api_errors.AlreadyPreparedException, api_obj.prepare)
+        self.assertRaises(
+            api_errors.AlreadyExecutedException, api_obj.execute_plan
+        )
+
+    def test_bad_orderings(self):
+        self.pkgsend_bulk(self.rurl, self.foo10)
+        api_obj = self.image_create(self.rurl, prefix="bobcat")
+
+        self.assertTrue(api_obj.describe() is None)
+
+        self.assertRaises(api_errors.PlanMissingException, api_obj.prepare)
+
+        for pd in api_obj.gen_plan_install(["foo"]):
+            continue
+        self.__try_bad_combinations_and_complete(api_obj)
+        api_obj.reset()
+
+        self.assertRaises(api_errors.PlanMissingException, api_obj.prepare)
+
+        self.assertTrue(api_obj.describe() is None)
+
+        self.pkgsend_bulk(self.rurl, self.foo12)
+        api_obj.refresh(immediate=True)
+
+        for pd in api_obj.gen_plan_update():
+            continue
+        self.__try_bad_combinations_and_complete(api_obj)
+        api_obj.reset()
+
+        self.assertRaises(api_errors.PlanMissingException, api_obj.prepare)
+        self.assertTrue(api_obj.describe() is None)
+
+        for pd in api_obj.gen_plan_uninstall(["foo"]):
+            continue
+        self.__try_bad_combinations_and_complete(api_obj)
+        api_obj.reset()
+
+        self.assertRaises(api_errors.PlanMissingException, api_obj.prepare)
+        self.assertTrue(api_obj.describe() is None)
+
+    def test_reset(self):
+        """Send empty package foo@1.0, install and uninstall"""
+
+        self.pkgsend_bulk(self.rurl, self.foo10)
+        api_obj = self.image_create(self.rurl, prefix="bobcat")
+
+        facets = facet.Facets({"facet.devel": True})
+        for pd in api_obj.gen_plan_change_varcets(facets=facets):
+            continue
+        self._api_finish(api_obj)
+
+        for pd in api_obj.gen_plan_install(["foo"]):
+            continue
+        self.assertTrue(api_obj.describe() is not None)
+        api_obj.reset()
+        self.assertTrue(api_obj.describe() is None)
+        for pd in api_obj.gen_plan_install(["foo"]):
+            continue
+        self.assertTrue(api_obj.describe() is not None)
+        api_obj.prepare()
+        api_obj.reset()
+        self.assertTrue(api_obj.describe() is None)
+        for pd in api_obj.gen_plan_install(["foo"]):
+            continue
+        self.assertTrue(api_obj.describe() is not None)
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+        self.assertTrue(api_obj.describe() is None)
+
+        self.pkg("list")
+        self.pkg("verify")
+
+        self.pkgsend_bulk(self.rurl, self.foo12)
+        api_obj.refresh(immediate=True)
+
+        for pd in api_obj.gen_plan_update():
+            continue
+        self.assertTrue(api_obj.describe() is not None)
+        api_obj.reset()
+        self.assertTrue(api_obj.describe() is None)
+        for pd in api_obj.gen_plan_update():
+            continue
+        self.assertTrue(api_obj.describe() is not None)
+        api_obj.prepare()
+        api_obj.reset()
+        self.assertTrue(api_obj.describe() is None)
+        for pd in api_obj.gen_plan_update():
+            continue
+        self.assertTrue(api_obj.describe() is not None)
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+        self.assertTrue(api_obj.describe() is None)
+
+        self.pkg("list")
+        self.pkg("verify")
+
+        for pd in api_obj.gen_plan_uninstall(["foo"]):
+            continue
+        self.assertTrue(api_obj.describe() is not None)
+        api_obj.reset()
+        self.assertTrue(api_obj.describe() is None)
+        for pd in api_obj.gen_plan_uninstall(["foo"]):
+            continue
+        self.assertTrue(api_obj.describe() is not None)
+        api_obj.prepare()
+        api_obj.reset()
+        self.assertTrue(api_obj.describe() is None)
+        for pd in api_obj.gen_plan_uninstall(["foo"]):
+            continue
+        self.assertTrue(api_obj.describe() is not None)
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+        self.assertTrue(api_obj.describe() is None)
+
+        self.pkg("verify")
+
+    def test_refresh_transition(self):
+        """Verify that refresh works for a v0 catalog source and that
+        if the client transitions from v0 to v1 or back that the correct
+        state information is recorded in the image catalog."""
+
+        # This test requires an actual depot due to v0 operation usage.
+        # First create the image and get v1 catalog.
+        self.dc.start()
+        self.pkgsend_bulk(self.durl, (self.foo10, self.quux10))
+        try:
+            api_obj = self.image_create(self.durl, prefix="bobcat")
+        except api_errors.CatalogRefreshException as e:
+            self.debug("\n".join(str(x[-1]) for x in e.failed))
+            raise
+
+        self.pkg("publisher")
+        img = api_obj.img
+        kcat = img.get_catalog(img.IMG_CATALOG_KNOWN)
+        entry = [e for f, e in kcat.entries()][0]
+        states = entry["metadata"]["states"]
+        self.assertTrue(pkgdefs.PKG_STATE_V1 in states)
+        self.assertTrue(pkgdefs.PKG_STATE_V0 not in states)
+
+        # Next, disable v1 catalog for the depot and force a client
+        # refresh.  Only v0 state should be present.
+        self.dc.stop()
+        self.dc.set_disable_ops(["catalog/1"])
+        self.dc.start()
+
+        # Since the depot state changed while the API object was
+        # still active, it needs to be reset to clear the internal
+        # transport state cache.
+        api_obj.reset()
+
+        api_obj.refresh(immediate=True)
+        api_obj.reset()
+        img = api_obj.img
+
+        kcat = img.get_catalog(img.IMG_CATALOG_KNOWN)
+        entry = [e for f, e in kcat.entries()][0]
+        states = entry["metadata"]["states"]
+        self.assertTrue(pkgdefs.PKG_STATE_V1 not in states)
+        self.assertTrue(pkgdefs.PKG_STATE_V0 in states)
+
+        # Verify that there is no dependency information present
+        # in the known or installed catalog.
+        icat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
+        for cat in kcat, icat:
+            dpart = cat.get_part("catalog.dependency.C")
+            dep_acts = [
+                acts
+                for t, entry in dpart.tuple_entries()
+                for acts in entry.get("actions", [])
+            ]
+            self.assertEqual(dep_acts, [])
+
+        # Now install a package, and verify that the entries in the
+        # known catalog for installed packages exist in the installed
+        # catalog and are identical.
+        api_obj = self.get_img_api_obj()
+        img = api_obj.img
+
+        # Get image catalogs.
+        kcat = img.get_catalog(img.IMG_CATALOG_KNOWN)
+        icat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
+
+        # Verify quux package is only in known catalog.
+        self.assertTrue("quux" in kcat.names())
+        self.assertTrue("foo" in kcat.names())
+        self.assertTrue("quux" not in icat.names())
+        self.assertTrue("foo" not in icat.names())
+
+        # Install the packages.
+        for pd in api_obj.gen_plan_install(["quux@1.0"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        # Get image catalogs.
+        kcat = img.get_catalog(img.IMG_CATALOG_KNOWN)
+        icat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
+
+        # Verify quux package is in both catalogs.
+        self.assertTrue("quux" in kcat.names())
+        self.assertTrue("foo" in kcat.names())
+        self.assertTrue("quux" in icat.names())
+        self.assertTrue("foo" in icat.names())
+
+        # Verify state info.
+        for cat in kcat, icat:
+            entry = [e for f, e in cat.entries()][0]
+            states = entry["metadata"]["states"]
+            self.assertTrue(pkgdefs.PKG_STATE_INSTALLED in states)
+            self.assertTrue(pkgdefs.PKG_STATE_V0 in states)
+
+        # Finally, transition back to v1 catalog.  This requires
+        # creating a new api object since transport will think that
+        # v1 catalogs are still unsupported.
+        self.dc.unset_disable_ops()
+        self.dc.stop()
+        self.dc.start()
+
+        api_obj = self.get_img_api_obj()
+        api_obj.refresh(immediate=True)
+        img = api_obj.img
+
+        # Get image catalogs.
+        kcat = img.get_catalog(img.IMG_CATALOG_KNOWN)
+        icat = img.get_catalog(img.IMG_CATALOG_INSTALLED)
+
+        # Verify quux package is in both catalogs.
+        self.assertTrue("quux" in kcat.names())
+        self.assertTrue("foo" in kcat.names())
+        self.assertTrue("quux" in icat.names())
+        self.assertTrue("foo" in icat.names())
+
+        # Verify state info.
+        for f, entry in kcat.entries():
+            states = entry["metadata"]["states"]
+            self.assertTrue(pkgdefs.PKG_STATE_V1 in states)
+            self.assertTrue(pkgdefs.PKG_STATE_V0 not in states)
+
+        # Verify that there is dependency information present
+        # in the known and installed catalog.
+        for cat in kcat, icat:
+            dpart = cat.get_part("catalog.dependency.C")
+            entries = [(t, entry) for t, entry in dpart.tuple_entries()]
+            dep_acts = [
+                acts
+                for t, entry in dpart.tuple_entries()
+                for acts in entry.get("actions", [])
+                if t[1] == "quux"
+            ]
+            self.assertNotEqual(dep_acts, [])
+
+        # Verify that every installed package is in known and has
+        # identical entries and that every installed package in
+        # the installed catalog is in the known catalog and has
+        # entries.
+        for src, dest in ((kcat, icat), (icat, kcat)):
+            src_base = src.get_part("catalog.base.C", must_exist=True)
+            self.assertNotEqual(src_base, None)
+
+            for f, bentry in src_base.entries():
+                states = bentry["metadata"]["states"]
+                if pkgdefs.PKG_STATE_INSTALLED not in states:
+                    continue
+
+                for name in src.parts:
+                    spart = src.get_part(name, must_exist=True)
+                    self.assertNotEqual(spart, None)
+
+                    dpart = dest.get_part(name, must_exist=True)
+                    self.assertNotEqual(dpart, None)
+
+                    sentry = spart.get_entry(pfmri=f)
+                    dentry = dpart.get_entry(pfmri=f)
+                    self.assertEqual(sentry, dentry)
+
+    def test_properties(self):
+        """Verify that properties of the ImageInterface api object are
+        accessible and return expected values."""
+
+        api_obj = self.image_create(self.rurl, prefix="bobcat")
+        self.assertEqual(api_obj.root, self.img_path())
+
+    def test_snapdir(self):
+        """Verify that image create ignores .zfs snapdir."""
+
+        # snapdir path
+        path = self.img_path()
+        snapdir = os.path.join(path, ".zfs")
+
+        # a .zfs directory is allowed
+        self.image_destroy()
+        os.mkdir(self.img_path())
+        os.mkdir(snapdir)
+        api_obj = self.image_create(destroy=False)
+
+        # a .zfs file is not allowed
+        self.image_destroy()
+        os.mkdir(self.img_path())
+        open(snapdir, "w").close()
+        self.assertRaises(
+            api_errors.CreatingImageInNonEmptyDir,
+            self.image_create,
+            destroy=False,
+        )
+
+    def test_publisher_apis(self):
+        """Verify that the publisher api methods work as expected.
+
+        Note that not all methods are tested here as this would be
+        redundant since other tests for the client will use those
+        methods indirectly."""
+
+        plist = self.pkgsend_bulk(self.rurl, (self.foo10, self.bar10))
+        api_obj = self.image_create(self.rurl, prefix="bobcat")
+
+        # Verify that existence tests succeed.
+        self.assertTrue(api_obj.has_publisher("bobcat"))
+
+        # Verify preferred publisher prefix is returned correctly.
+        self.assertEqual(
+            api_obj.get_highest_ranked_publisher().prefix, "bobcat"
+        )
+
+        # Verify that get_publisher returned the correct publisher
+        # object.
+        pub = api_obj.get_publisher(prefix="bobcat")
+        self.assertEqual(pub.prefix, "bobcat")
+
+        # Verify that not specifying matching criteria for get_publisher
+        # raises a UnknownPublisher exception.
+        self.assertRaises(
+            api_errors.UnknownPublisher, api_obj.get_publisher, "zuul"
+        )
+        self.assertRaises(api_errors.UnknownPublisher, api_obj.get_publisher)
+
+        # Verify that publisher objects returned from get_publishers
+        # match those returned by get_publisher.
+        pubs = api_obj.get_publishers()
+        self.assertEqual(pub.prefix, pubs[0].prefix)
+        self.assertEqual(id(pub), id(pubs[0]))
+
+        # Verify that duplicate actually creates duplicates.
+        cpub = api_obj.get_publisher(prefix="bobcat", duplicate=True)
+        self.assertNotEqual(id(pub), id(cpub))
+
+        # Now modify publisher information and update.
+        cpub.alias = "cat"
+        repo = cpub.repository
+        repo.name = "source"
+        repo.description = "xkcd.net/325"
+        repo.legal_uris = ["http://xkcd.com/license.html"]
+        repo.refresh_seconds = 43200
+        repo.registered = False
+        api_obj.update_publisher(cpub)
+
+        # Verify that the update happened.
+        pub = api_obj.get_publisher(prefix="bobcat")
+        self.assertEqual(pub.alias, "cat")
+        repo = pub.repository
+        self.assertEqual(repo.name, "source")
+        self.assertEqual(repo.description, "xkcd.net/325")
+        self.assertEqual(repo.legal_uris[0], "http://xkcd.com/license.html")
+        self.assertEqual(repo.refresh_seconds, 43200)
+        self.assertEqual(repo.registered, False)
+
+        # Verify that duplicates match their original.
+        cpub = api_obj.get_publisher(alias=pub.alias, duplicate=True)
+        for p in ("alias", "prefix", "meta_root"):
+            self.assertEqual(getattr(pub, p), getattr(cpub, p))
+
+        for p in (
+            "collection_type",
+            "description",
+            "legal_uris",
+            "mirrors",
+            "name",
+            "origins",
+            "refresh_seconds",
+            "registered",
+            "registration_uri",
+            "related_uris",
+            "sort_policy",
+        ):
+            srepo = pub.repository
+            crepo = cpub.repository
+            self.assertEqual(getattr(srepo, p), getattr(crepo, p))
+        cpub = None
+
+        cpubs = api_obj.get_publishers(duplicate=True)
+        self.assertNotEqual(id(pub), id(cpubs[0]))
+        cpubs = None
+
+        # Verify that publisher_last_update_time returns a value.
+        self.assertTrue(api_obj.get_publisher_last_update_time("bobcat"))
+
+        # Verify that p5i export and parse works as expected.
+
+        # Ensure that PackageInfo, PkgFmri, and strings are all
+        # supported properly.
+
+        # Strip timestamp information so that comparison with
+        # pre-generated test data will succeed.
+        ffoo = fmri.PkgFmri(plist[0])
+        sfoo = str(ffoo).replace(":{0}".format(ffoo.version.timestr), "")
+        ffoo = fmri.PkgFmri(sfoo)
+        sfoo = ffoo.get_fmri(anarchy=True)
+
+        fbar = fmri.PkgFmri(plist[1])
+        sbar = str(fbar).replace(":{0}".format(fbar.version.timestr), "")
+        fbar = fmri.PkgFmri(sbar)
+        sbar = fbar.get_fmri(anarchy=True)
+
+        # Build a simple list of packages.
+        pnames = {
+            "bobcat": (api.PackageInfo(ffoo),),
+            "": [fbar, "baz"],
+        }
+
+        # Dump the p5i data.
+        fobj = cStringIO()
+        api_obj.write_p5i(fobj, pkg_names=pnames, pubs=[pub])
+
+        # Verify that output matches expected output.
+        fobj.seek(0)
+        output = fobj.read()
+        self.assertEqualJSON(output, self.p5i_bobcat)
+
+        def validate_results(results):
+            # First result should be 'bobcat' publisher and its
+            # pkg_names.
+            pub, pkg_names = results[0]
+
+            self.assertEqual(pub.prefix, "bobcat")
+            self.assertEqual(pub.alias, "cat")
+            repo = pub.repository
+            self.assertEqual(repo.name, "source")
+            self.assertEqual(repo.description, "xkcd.net/325")
+            self.assertEqual(repo.legal_uris[0], "http://xkcd.com/license.html")
+            self.assertEqual(repo.refresh_seconds, 43200)
+            self.assertEqual(pkg_names, [sfoo])
+
+            # Last result should be no publisher and a list of
+            # pkg_names.
+            pub, pkg_names = results[1]
+            self.assertEqual(pub, None)
+            self.assertEqual(pkg_names, [sbar, "baz"])
+
+        # Verify that parse returns the expected object and information
+        # when provided a fileobj.
+        fobj.seek(0)
+        validate_results(api_obj.parse_p5i(fileobj=fobj))
+
+        # Verify that an add of the parsed object works (the name has to
+        # be changed to prevent a duplicate error here).
+        fobj.seek(0)
+        results = api_obj.parse_p5i(fileobj=fobj)
+        pub, pkg_names = results[0]
+
+        pub.prefix = "p5icat"
+        pub.alias = "copycat"
+        api_obj.add_publisher(pub, refresh_allowed=False)
+
+        # Now verify that we can retrieve the added publisher.
+        api_obj.get_publisher(prefix=pub.prefix)
+        cpub = api_obj.get_publisher(alias=pub.alias, duplicate=True)
+
+        # Now verify that the DuplicatePublisher exception is raised
+        # as expected when adding or updating publishers if the prefix
+        # is the same as another publisher's prefix or alias.  This is
+        # because alias and prefix are intended to be interchangeable
+        # (although the API allows clients to make a distinction
+        # internally).
+        dpub = api_obj.get_publisher(alias=pub.alias, duplicate=True)
+        dpub.alias = None
+
+        # Should fail since a publisher exists with this prefix.
+        self.assertRaises(
+            api_errors.DuplicatePublisher,
+            api_obj.add_publisher,
+            dpub,
+            refresh_allowed=False,
+        )
+        dpub.prefix = "bobcat"
+        self.assertRaises(
+            api_errors.DuplicatePublisher,
+            api_obj.update_publisher,
+            dpub,
+            refresh_allowed=False,
+        )
+
+        # Should fail since a publisher exists with an alias the same
+        # as this prefix.
+        dpub.prefix = "copycat"
+        self.assertRaises(
+            api_errors.DuplicatePublisher,
+            api_obj.add_publisher,
+            dpub,
+            refresh_allowed=False,
+        )
+        dpub.prefix = "cat"
+        self.assertRaises(
+            api_errors.DuplicatePublisher,
+            api_obj.update_publisher,
+            dpub,
+            refresh_allowed=False,
+        )
+
+        # Should fail since a publisher exists with an alias the same
+        # as this alias.
+        dpub.prefix = "uniquecat"
+        dpub.alias = "copycat"
+        self.assertRaises(
+            api_errors.DuplicatePublisher,
+            api_obj.add_publisher,
+            dpub,
+            refresh_allowed=False,
+        )
+        dpub.alias = "cat"
+        self.assertRaises(
+            api_errors.DuplicatePublisher,
+            api_obj.update_publisher,
+            dpub,
+            refresh_allowed=False,
+        )
+
+        # Should fail since a publisher exists with a prefix the same
+        # as this alias.
+        dpub.prefix = "uniquecat"
+        dpub.alias = "p5icat"
+        self.assertRaises(
+            api_errors.DuplicatePublisher,
+            api_obj.add_publisher,
+            dpub,
+            refresh_allowed=False,
+        )
+        dpub.alias = "bobcat"
+        self.assertRaises(
+            api_errors.DuplicatePublisher,
+            api_obj.update_publisher,
+            dpub,
+            refresh_allowed=False,
+        )
+
+        # Now update the publisher and set it to disabled, to verify
+        # that api functions still work as expected.
+        cpub.disabled = True
+        api_obj.update_publisher(cpub)
+
+        cpub = api_obj.get_publisher(alias=cpub.alias, duplicate=True)
+        self.assertTrue(cpub.disabled)
+
+        self.assertTrue(api_obj.has_publisher(prefix=cpub.prefix))
+
+        # Now attempt to update the disabled publisher.
+        cpub = api_obj.get_publisher(alias=cpub.alias, duplicate=True)
+        cpub.alias = "copycopycat"
+        api_obj.update_publisher(cpub)
+        cpub = None
+
+        # Verify that parse returns the expected object and information
+        # when provided a file path.
+        fobj.seek(0)
+        (fd1, path1) = tempfile.mkstemp(dir=self.test_root)
+        with open(path1, "w") as f:
+            f.write(fobj.read())
+        validate_results(api_obj.parse_p5i(location=path1))
+
+        # Verify that parse returns the expected object and information
+        # when provided a file URI.
+        validate_results(api_obj.parse_p5i(location="file://" + path1))
+        fobj.close()
+        fobj = None
+
+        # Verify that appropriate exceptions are raised for p5i
+        # information that can't be retrieved (doesn't exist).
+        nefpath = os.path.join(self.test_root, "non-existent")
+        self.assertRaises(
+            api_errors.RetrievalError,
+            api_obj.parse_p5i,
+            location="file://{0}".format(nefpath),
+        )
+
+        self.assertRaises(
+            api_errors.RetrievalError, api_obj.parse_p5i, location=nefpath
+        )
+
+        # Verify that appropriate exceptions are raised for invalid
+        # p5i information.
+        lcpath = os.path.join(self.test_root, "libc.so.1")
+        self.assertRaises(
+            api_errors.InvalidP5IFile,
+            api_obj.parse_p5i,
+            location="file://{0}".format(lcpath),
+        )
+
+        self.assertRaises(
+            api_errors.InvalidP5IFile, api_obj.parse_p5i, location=lcpath
+        )
+
+        # Now install a package and remove all publishers and verify a
+        # publisher obj is returned by get_highest_ranked_publisher().
+        self._api_install(api_obj, ["foo"])
+        api_obj.remove_publisher("bobcat")
+        api_obj.remove_publisher("p5icat")
+        self.assertTrue(api_obj.get_highest_ranked_publisher().prefix, "bobcat")
+
+    def test_deprecated(self):
+        """Test deprecated api interfaces."""
+
+        self.pkgsend_bulk(self.rurl, self.foo10)
+        api_obj = self.image_create(
+            self.rurl, prefix="bobcat", variants={"variant.arch": "i386"}
+        )
+        api_obj.reset()
+
+        # verify the old install interface
+        stuff_to_do = api_obj.plan_install(["foo"], noexecute=False)
+        self.assertTrue(stuff_to_do)
+        api_obj.prepare()
+        try:
+            api_obj.execute_plan()
+        except api_errors.WrapSuccessfulIndexingException:
+            pass
+        api_obj.reset()
+
+        self.pkgsend_bulk(self.rurl, self.foo11v)
+        self.pkgsend_bulk(self.rurl, self.foo12v)
+        api_obj.refresh(immediate=True)
+
+        # verify the old update interface
+        stuff_to_do = api_obj.plan_update(["foo@1.1,5.11-0"], noexecute=False)
+        self.assertTrue(stuff_to_do)
+        api_obj.prepare()
+        try:
+            api_obj.execute_plan()
+        except api_errors.WrapSuccessfulIndexingException:
+            pass
+        api_obj.reset()
+
+        # verify the old update interface
+        stuff_to_do, s_image = api_obj.plan_update_all(noexecute=False)
+        self.assertTrue(stuff_to_do)
+        self.assertFalse(s_image)
+        api_obj.prepare()
+        try:
+            api_obj.execute_plan()
+        except api_errors.WrapSuccessfulIndexingException:
+            pass
+        api_obj.reset()
+
+        # remove a file from the image
+        os.remove(os.path.join(self.img_path(), "lib/libc.so.1"))
+
+        # verify the old revert interface
+        stuff_to_do = api_obj.plan_revert(["/lib/libc.so.1"], noexecute=False)
+        self.assertTrue(stuff_to_do)
+        api_obj.prepare()
+        try:
+            api_obj.execute_plan()
+        except api_errors.WrapSuccessfulIndexingException:
+            pass
+        api_obj.reset()
+
+        # verify the old change varcets interface
+        stuff_to_do = api_obj.plan_change_varcets(
+            variants={"variant.arch": "sparc"}, noexecute=False
+        )
+        self.assertTrue(stuff_to_do)
+        api_obj.prepare()
+        try:
+            api_obj.execute_plan()
+        except api_errors.WrapSuccessfulIndexingException:
+            pass
+        api_obj.reset()
+
+        # verify the old change uninstall interface
+        stuff_to_do = api_obj.plan_uninstall(["foo"], noexecute=False)
+        self.assertTrue(stuff_to_do)
+        api_obj.prepare()
+        try:
+            api_obj.execute_plan()
+        except api_errors.WrapSuccessfulIndexingException:
+            pass
+        api_obj.reset()
+
+    def test_license(self):
+        """Send various packages and then verify that install and
+        update operations will raise the correct exceptions or
+        enforce the requirements of the license actions within."""
+
+        plist = self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.licensed10,
+                self.licensed12,
+                self.licensed13,
+                self.bar10,
+                self.baz10,
+            ),
+        )
+        api_obj = self.image_create(self.rurl, prefix="bobcat")
+
+        # First, test the basic install case to see if expected license
+        # data is returned.
+        for pd in api_obj.gen_plan_install(["licensed@1.0"]):
+            continue
+
+        def lic_key(item):
+            return item[2].license
+
+        plan = api_obj.describe()
+        lics = sorted(plan.get_licenses(), key=lic_key)
+
+        # Expect one license action for each package: "licensed", and
+        # its dependency "baz".
+        self.assertEqual(len(lics), 2)
+
+        # Now verify license entry for "baz@1.0" and "licensed@1.0".
+        for i, p in enumerate([plist[4], plist[0]]):
+            pfmri = fmri.PkgFmri(p)
+            dest_fmri, src, dest, accepted, displayed = lics[i]
+
+            # Expect license information to be for this package.
+            self.assertEqual(pfmri, dest_fmri)
+
+            # This is an install, not an update, so there should be
+            # no src.
+            self.assertEqual(src, None)
+
+            # dest should be a LicenseInfo object.
+            self.assertEqual(type(dest), api.LicenseInfo)
+
+            # Verify the identity of the LicenseInfo objects.
+            self.assertEqual(
+                dest.license, "copyright.{0}".format(pfmri.pkg_name)
+            )
+
+            # The license hasn't been accepted yet.
+            self.assertEqual(accepted, False)
+
+            # The license hasn't beend displayed yet.
+            self.assertEqual(displayed, False)
+
+            # The license action doesn't require acceptance.
+            self.assertEqual(dest.must_accept, False)
+
+            # The license action doesn't require display.
+            self.assertEqual(dest.must_display, False)
+
+            # Verify license text.
+            text = dest.license
+            self.assertEqual(dest.get_text(), text)
+
+        # Install the packages.
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        # Next, check that an upgrade produces expected license data.
+        for pd in api_obj.gen_plan_install(["licensed@1.2"]):
+            continue
+
+        plan = api_obj.describe()
+        lics = sorted(plan.get_licenses(), key=lic_key)
+
+        # Expect two license actions, both of which should be for the
+        # licensed@1.2 package.
+        self.assertEqual(len(lics), 2)
+
+        # Now verify license entries for "licensed@1.2".
+        pfmri = fmri.PkgFmri(plist[1])
+        for dest_fmri, src, dest, accepted, displayed in lics:
+            # License information should only be for "licensed@1.2".
+            self.assertEqual(pfmri, dest_fmri)
+
+            must_accept = False
+            must_display = False
+            if dest.license.startswith("copyright"):
+                # This is an an update, so src should be a
+                # LicenseInfo object.
                 self.assertEqual(type(src), api.LicenseInfo)
 
-                assert dest.license.startswith("license.")
-                # license must be accepted for dest.
-                must_accept = True
+                # In this version, copyright must be displayed
+                # for dest.
+                must_display = True
 
-                # dest should be a LicenseInfo object.
-                self.assertEqual(type(dest), api.LicenseInfo)
+            # dest should be a LicenseInfo object.
+            self.assertEqual(type(dest), api.LicenseInfo)
 
-                # Verify LicenseInfo attributes.
-                self.assertEqual(accepted, False)
-                self.assertEqual(displayed, False)
-                self.assertEqual(dest.must_accept, must_accept)
-                self.assertEqual(dest.must_display, must_display)
+            # Verify LicenseInfo attributes.
+            self.assertEqual(accepted, False)
+            self.assertEqual(displayed, False)
+            self.assertEqual(dest.must_accept, must_accept)
+            self.assertEqual(dest.must_display, must_display)
 
-                # Verify license text.
-                text = dest.license
-                self.assertEqual(dest.get_text(), text)
+            # Verify license text.
+            text = dest.license
+            self.assertEqual(dest.get_text(), text)
 
-                # Attempt to prepare plan; this should raise a license
-                # exception.
-                self.assertRaises(api_errors.PlanLicenseErrors, api_obj.prepare)
+        # Attempt to prepare plan; this should raise a license
+        # exception.
+        self.assertRaises(api_errors.PlanLicenseErrors, api_obj.prepare)
 
-                # Plan will have to be re-created first before continuing.
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        continue
-                plan = api_obj.describe()
+        # Plan will have to be re-created first before continuing.
+        api_obj.reset()
+        for pd in api_obj.gen_plan_install(["licensed@1.2"]):
+            continue
+        plan = api_obj.describe()
 
-                # Set the license status of only one license.
-                api_obj.set_plan_license_status(pfmri, "license.licensed",
-                    accepted=True)
-                lics = [l for l in plan.get_licenses(pfmri=pfmri)]
+        # Set the copyright as having been displayed.
+        api_obj.set_plan_license_status(
+            pfmri, "copyright.licensed", displayed=True
+        )
+        lics = sorted(plan.get_licenses(pfmri=pfmri), key=lic_key)
 
-                # Verify only license.licensed was updated and exists.
-                dest_fmri, src, dest, accepted, displayed = lics[0]
-                self.assertEqual(src.license, "license.licensed")
-                self.assertEqual(accepted, True)
-                self.assertEqual(displayed, False)
-                self.assertEqual(len(lics), 1)
+        # Verify displayed was updated and accepted remains False.
+        dest_fmri, src, dest, accepted, displayed = lics[0]
+        self.assertEqual(src.license, "copyright.licensed")
+        self.assertEqual(accepted, False)
+        self.assertEqual(displayed, True)
 
-                # Prepare should succeed this time; so execute afterwards.
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
+        # Prepare should succeed this time; so execute afterwards.
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
 
-                plist.extend(self.pkgsend_bulk(self.rurl, self.licensed14))
-                api_obj.refresh()
-                api_obj.reset()
+        # Next, check that an update produces expected license
+        # data.
+        for pd in api_obj.gen_plan_update():
+            continue
 
-                # Next, verify that an update to a newer version of a package
-                # where the license hasn't changed and it previously required
-                # acceptance is treated as already having been accepted.
-                for pd in api_obj.gen_plan_update():
-                        continue
-                plan = api_obj.describe()
-                pfmri = fmri.PkgFmri(plist[5])
-                lics = sorted(plan.get_licenses(), key=lic_key)
-                for dest_fmri, src, dest, accepted, displayed in lics:
-                        # License information should only be for "licensed@1.4".
-                        self.assertEqual(pfmri, dest_fmri)
+        plan = api_obj.describe()
+        lics = [l for l in plan.get_licenses()]
 
-                        if dest.must_accept:
-                                # Since the license hasn't changed and was
-                                # previously accepted, then acceptance shouldn't
-                                # be required here.
-                                self.assertTrue(accepted)
-                api_obj.reset()
+        # Expect one license action which should be for the licensed@1.3
+        # package.  (Only one is expected since only one of the license
+        # actions changed since licensed@1.2.)
+        self.assertEqual(len(lics), 1)
 
-                # Finally, verify that an uninstall won't trigger license
-                # errors as acceptance should never be applied to it.
-                for pd in api_obj.gen_plan_uninstall(["*"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
+        # Now verify license entries for "licensed@1.3".
+        pfmri = fmri.PkgFmri(plist[2])
+        dest_fmri, src, dest, accepted, displayed = lics[0]
 
-        def test_syspub_version_error(self):
-                api_obj = self.image_create()
-                try:
-                        api_obj.write_syspub("", [], 999)
-                except api_errors.UnsupportedP5SVersion as e:
-                        str(e)
-                else:
-                        raise RuntimeError("Expected write_syspub to raise "
-                            "an exception.")
+        # License information should only be for "licensed@1.3".
+        self.assertEqual(pfmri, dest_fmri)
+
+        must_accept = False
+        must_display = False
+
+        # This is an an update, so src should be a LicenseInfo
+        # object.
+        self.assertEqual(type(src), api.LicenseInfo)
+
+        assert dest.license.startswith("license.")
+        # license must be accepted for dest.
+        must_accept = True
+
+        # dest should be a LicenseInfo object.
+        self.assertEqual(type(dest), api.LicenseInfo)
+
+        # Verify LicenseInfo attributes.
+        self.assertEqual(accepted, False)
+        self.assertEqual(displayed, False)
+        self.assertEqual(dest.must_accept, must_accept)
+        self.assertEqual(dest.must_display, must_display)
+
+        # Verify license text.
+        text = dest.license
+        self.assertEqual(dest.get_text(), text)
+
+        # Attempt to prepare plan; this should raise a license
+        # exception.
+        self.assertRaises(api_errors.PlanLicenseErrors, api_obj.prepare)
+
+        # Plan will have to be re-created first before continuing.
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            continue
+        plan = api_obj.describe()
+
+        # Set the license status of only one license.
+        api_obj.set_plan_license_status(
+            pfmri, "license.licensed", accepted=True
+        )
+        lics = [l for l in plan.get_licenses(pfmri=pfmri)]
+
+        # Verify only license.licensed was updated and exists.
+        dest_fmri, src, dest, accepted, displayed = lics[0]
+        self.assertEqual(src.license, "license.licensed")
+        self.assertEqual(accepted, True)
+        self.assertEqual(displayed, False)
+        self.assertEqual(len(lics), 1)
+
+        # Prepare should succeed this time; so execute afterwards.
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        plist.extend(self.pkgsend_bulk(self.rurl, self.licensed14))
+        api_obj.refresh()
+        api_obj.reset()
+
+        # Next, verify that an update to a newer version of a package
+        # where the license hasn't changed and it previously required
+        # acceptance is treated as already having been accepted.
+        for pd in api_obj.gen_plan_update():
+            continue
+        plan = api_obj.describe()
+        pfmri = fmri.PkgFmri(plist[5])
+        lics = sorted(plan.get_licenses(), key=lic_key)
+        for dest_fmri, src, dest, accepted, displayed in lics:
+            # License information should only be for "licensed@1.4".
+            self.assertEqual(pfmri, dest_fmri)
+
+            if dest.must_accept:
+                # Since the license hasn't changed and was
+                # previously accepted, then acceptance shouldn't
+                # be required here.
+                self.assertTrue(accepted)
+        api_obj.reset()
+
+        # Finally, verify that an uninstall won't trigger license
+        # errors as acceptance should never be applied to it.
+        for pd in api_obj.gen_plan_uninstall(["*"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+    def test_syspub_version_error(self):
+        api_obj = self.image_create()
+        try:
+            api_obj.write_syspub("", [], 999)
+        except api_errors.UnsupportedP5SVersion as e:
+            str(e)
+        else:
+            raise RuntimeError(
+                "Expected write_syspub to raise " "an exception."
+            )
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_api_info.py
+++ b/src/tests/api/t_api_info.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -40,30 +41,48 @@ import pkg.client.api_errors as api_errors
 import pkg.client.progress as progress
 import pkg.fmri as fmri
 
+
 class TestApiInfo(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        def test_0_local_remote(self):
-                """Verify that ImageInterface.info() works as expected
-                for both local (installed or cached) and remote packages."""
+    def test_0_local_remote(self):
+        """Verify that ImageInterface.info() works as expected
+        for both local (installed or cached) and remote packages."""
 
-                api_obj = self.image_create(self.rurl)
+        api_obj = self.image_create(self.rurl)
 
-                self.assertRaises(api_errors.NoPackagesInstalledException,
-                    api_obj.info, [], True, api.PackageInfo.ALL_OPTIONS -
-                    (frozenset([api.PackageInfo.LICENSES]) |
-                    api.PackageInfo.ACTION_OPTIONS))
+        self.assertRaises(
+            api_errors.NoPackagesInstalledException,
+            api_obj.info,
+            [],
+            True,
+            api.PackageInfo.ALL_OPTIONS
+            - (
+                frozenset([api.PackageInfo.LICENSES])
+                | api.PackageInfo.ACTION_OPTIONS
+            ),
+        )
 
-                self.assertRaises(api_errors.UnrecognizedOptionsToInfo,
-                    api_obj.info, [], True, set([-1]))
-                self.assertRaises(api_errors.UnrecognizedOptionsToInfo,
-                    api_obj.info, [], True, set('a'))
+        self.assertRaises(
+            api_errors.UnrecognizedOptionsToInfo,
+            api_obj.info,
+            [],
+            True,
+            set([-1]),
+        )
+        self.assertRaises(
+            api_errors.UnrecognizedOptionsToInfo,
+            api_obj.info,
+            [],
+            True,
+            set("a"),
+        )
 
-                misc_files = ["tmp/copyright1", "tmp/example_file"]
-                self.make_misc_files(misc_files)
+        misc_files = ["tmp/copyright1", "tmp/example_file"]
+        self.make_misc_files(misc_files)
 
-                pkg1 = """
+        pkg1 = """
                     open jade@1.0,5.11-0
                     add set name=description value="Ye Olde Summary"
                     add dir mode=0755 owner=root group=bin path=/bin
@@ -71,14 +90,14 @@ class TestApiInfo(pkg5unittest.SingleDepotTestCase):
                     close
                 """
 
-                pkg2 = """
+        pkg2 = """
                     open turquoise@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=/bin
                     add set name=info.classification value=org.opensolaris.category.2008:System/Security/Foo/bar/Baz
                     close
                 """
 
-                pkg4 = """
+        pkg4 = """
                     open example_pkg@1.0,5.11-0
                     add depend fmri=pkg:/amber@2.0 type=require
                     add dir mode=0755 owner=root group=bin path=/bin
@@ -91,7 +110,7 @@ class TestApiInfo(pkg5unittest.SingleDepotTestCase):
                     add set pkg.description="DESCRIPTION 1"
                     close """
 
-                pkg5 = """
+        pkg5 = """
                     open example_pkg5@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=/bin
                     add set pkg.summary='SUMMARY: Example Package 5'
@@ -99,7 +118,7 @@ class TestApiInfo(pkg5unittest.SingleDepotTestCase):
                     close
                 """
 
-                pkg6 = """
+        pkg6 = """
                     open example_pkg6@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=/bin
                     add set description='DESCRIPTION: Example Package 6'
@@ -108,282 +127,302 @@ class TestApiInfo(pkg5unittest.SingleDepotTestCase):
                     close
                 """
 
-                pkg7 = """
+        pkg7 = """
                     open amber@1.0,5.11-0
                     add set name=description value="Amber's Olde Summary"
                     add set name=pkg.summary value="Amber's Actual Summary"
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (pkg1, pkg2, pkg4, pkg5, pkg6,
-                    pkg7))
-                api_obj = self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (pkg1, pkg2, pkg4, pkg5, pkg6, pkg7))
+        api_obj = self.image_create(self.rurl)
 
-                local = True
-                get_license = False
+        local = True
+        get_license = False
 
-                info_needed = api.PackageInfo.ALL_OPTIONS - \
-                    (api.PackageInfo.ACTION_OPTIONS |
-                    frozenset([api.PackageInfo.LICENSES]))
-                
-                ret = api_obj.info(["jade"], local, info_needed)
-                self.assertTrue(not ret[api.ImageInterface.INFO_FOUND])
-                self.assertTrue(len(ret[api.ImageInterface.INFO_MISSING]) == 1)
-                
-                for pd in api_obj.gen_plan_install(["jade"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
+        info_needed = api.PackageInfo.ALL_OPTIONS - (
+            api.PackageInfo.ACTION_OPTIONS
+            | frozenset([api.PackageInfo.LICENSES])
+        )
 
-                self.pkg("verify -v")
-                
-                ret = api_obj.info(["jade", "turquoise", "emerald"],
-                    local, info_needed)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                notfound = ret[api.ImageInterface.INFO_MISSING]
-                illegals = ret[api.ImageInterface.INFO_ILLEGALS]
-                self.assertTrue(len(pis) == 1)
-                self.assertTrue(api.PackageInfo.INSTALLED in pis[0].states)
-                self.assertTrue(pis[0].pkg_stem == 'jade')
-                self.assertTrue(len(notfound) == 2)
-                self.assertTrue(len(illegals) == 0)
-                self.assertTrue(len(pis[0].category_info_list) == 1)
+        ret = api_obj.info(["jade"], local, info_needed)
+        self.assertTrue(not ret[api.ImageInterface.INFO_FOUND])
+        self.assertTrue(len(ret[api.ImageInterface.INFO_MISSING]) == 1)
 
-                ret = api_obj.info(["j*"], local, info_needed)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                notfound = ret[api.ImageInterface.INFO_MISSING]
-                illegals = ret[api.ImageInterface.INFO_ILLEGALS]
-                self.assertTrue(len(pis))
+        for pd in api_obj.gen_plan_install(["jade"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
 
-                ret = api_obj.info(["*a*"], local, info_needed)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                notfound = ret[api.ImageInterface.INFO_MISSING]
-                illegals = ret[api.ImageInterface.INFO_ILLEGALS]
-                self.assertTrue(len(pis))
+        self.pkg("verify -v")
 
-                local = False
+        ret = api_obj.info(["jade", "turquoise", "emerald"], local, info_needed)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        notfound = ret[api.ImageInterface.INFO_MISSING]
+        illegals = ret[api.ImageInterface.INFO_ILLEGALS]
+        self.assertTrue(len(pis) == 1)
+        self.assertTrue(api.PackageInfo.INSTALLED in pis[0].states)
+        self.assertTrue(pis[0].pkg_stem == "jade")
+        self.assertTrue(len(notfound) == 2)
+        self.assertTrue(len(illegals) == 0)
+        self.assertTrue(len(pis[0].category_info_list) == 1)
 
-                ret = api_obj.info(["jade"], local, info_needed)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                notfound = ret[api.ImageInterface.INFO_MISSING]
-                illegals = ret[api.ImageInterface.INFO_ILLEGALS]
-                self.assertTrue(len(pis) == 1)
-                res = pis[0]
-                self.assertTrue(api.PackageInfo.INSTALLED in res.states)
-                self.assertTrue(len(res.category_info_list) == 1)
-                self.assertEqual(res.summary, "Ye Olde Summary")
-                self.assertEqual(res.description, None)
+        ret = api_obj.info(["j*"], local, info_needed)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        notfound = ret[api.ImageInterface.INFO_MISSING]
+        illegals = ret[api.ImageInterface.INFO_ILLEGALS]
+        self.assertTrue(len(pis))
 
-                ret = api_obj.info(["amber"], local, info_needed)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                notfound = ret[api.ImageInterface.INFO_MISSING]
-                illegals = ret[api.ImageInterface.INFO_ILLEGALS]
-                self.assertTrue(len(pis) == 1)
-                res = pis[0]
-                self.assertTrue(api.PackageInfo.INSTALLED not in res.states)
-                self.assertTrue(len(res.category_info_list) == 0)
-                self.assertEqual(res.summary, "Amber's Actual Summary")
-                self.assertEqual(res.description, None)
+        ret = api_obj.info(["*a*"], local, info_needed)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        notfound = ret[api.ImageInterface.INFO_MISSING]
+        illegals = ret[api.ImageInterface.INFO_ILLEGALS]
+        self.assertTrue(len(pis))
 
-                ret = api_obj.info(["turquoise"], local, info_needed)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                notfound = ret[api.ImageInterface.INFO_MISSING]
-                illegals = ret[api.ImageInterface.INFO_ILLEGALS]
-                self.assertTrue(len(pis) == 1)
-                res = pis[0]
-                self.assertTrue(api.PackageInfo.INSTALLED not in res.states)
-                self.assertTrue(len(res.category_info_list) == 1)
-                self.assertEqual(res.summary, "")
-                self.assertEqual(res.description, None)
+        local = False
 
-                ret = api_obj.info(["example_pkg"], local,
-                    api.PackageInfo.ALL_OPTIONS)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                self.assertTrue(len(pis) == 1)
-                res = pis[0]
-                self.assertTrue(api.PackageInfo.INSTALLED not in res.states)
-                self.assertTrue(len(res.category_info_list) == 1)
+        ret = api_obj.info(["jade"], local, info_needed)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        notfound = ret[api.ImageInterface.INFO_MISSING]
+        illegals = ret[api.ImageInterface.INFO_ILLEGALS]
+        self.assertTrue(len(pis) == 1)
+        res = pis[0]
+        self.assertTrue(api.PackageInfo.INSTALLED in res.states)
+        self.assertTrue(len(res.category_info_list) == 1)
+        self.assertEqual(res.summary, "Ye Olde Summary")
+        self.assertEqual(res.description, None)
 
-                self.assertTrue(res.pkg_stem is not None)
-                self.assertTrue(res.summary is not None)
-                self.assertTrue(res.publisher is not None)
-                self.assertTrue(res.version is not None)
-                self.assertTrue(res.build_release is not None)
-                self.assertTrue(res.branch is not None)
-                self.assertTrue(res.packaging_date is not None)
-                total_size = 0
-                for p in misc_files:
-                        total_size += \
-                            os.stat(os.path.join(self.test_root, p)).st_size
-                self.assertEqual(res.size, total_size)
-                self.assertTrue(res.licenses is not None)
-                self.assertTrue(res.links is not None)
-                self.assertTrue(res.hardlinks is not None)
-                self.assertTrue(res.files is not None)
-                self.assertTrue(res.dirs is not None)
-                self.assertTrue(res.dependencies is not None)
-                # A test for bug 8868 which ensures the pkg.description field
-                # is as exected.
-                self.assertEqual(res.description, "DESCRIPTION 1")
+        ret = api_obj.info(["amber"], local, info_needed)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        notfound = ret[api.ImageInterface.INFO_MISSING]
+        illegals = ret[api.ImageInterface.INFO_ILLEGALS]
+        self.assertTrue(len(pis) == 1)
+        res = pis[0]
+        self.assertTrue(api.PackageInfo.INSTALLED not in res.states)
+        self.assertTrue(len(res.category_info_list) == 0)
+        self.assertEqual(res.summary, "Amber's Actual Summary")
+        self.assertEqual(res.description, None)
 
-                # Verify that summary is pulled from the old "name=description"
-                # set action.
-                self.assertEqual(res.summary, "FOOO bAr O OO OOO")
+        ret = api_obj.info(["turquoise"], local, info_needed)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        notfound = ret[api.ImageInterface.INFO_MISSING]
+        illegals = ret[api.ImageInterface.INFO_ILLEGALS]
+        self.assertTrue(len(pis) == 1)
+        res = pis[0]
+        self.assertTrue(api.PackageInfo.INSTALLED not in res.states)
+        self.assertTrue(len(res.category_info_list) == 1)
+        self.assertEqual(res.summary, "")
+        self.assertEqual(res.description, None)
 
-                ret = api_obj.info(["emerald"], local, info_needed)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                notfound = ret[api.ImageInterface.INFO_MISSING]
-                illegals = ret[api.ImageInterface.INFO_ILLEGALS]
-                self.assertTrue(len(notfound) == 1)
+        ret = api_obj.info(["example_pkg"], local, api.PackageInfo.ALL_OPTIONS)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        self.assertTrue(len(pis) == 1)
+        res = pis[0]
+        self.assertTrue(api.PackageInfo.INSTALLED not in res.states)
+        self.assertTrue(len(res.category_info_list) == 1)
 
-                local = True
-                get_license = False
-                get_action_info = True
+        self.assertTrue(res.pkg_stem is not None)
+        self.assertTrue(res.summary is not None)
+        self.assertTrue(res.publisher is not None)
+        self.assertTrue(res.version is not None)
+        self.assertTrue(res.build_release is not None)
+        self.assertTrue(res.branch is not None)
+        self.assertTrue(res.packaging_date is not None)
+        total_size = 0
+        for p in misc_files:
+            total_size += os.stat(os.path.join(self.test_root, p)).st_size
+        self.assertEqual(res.size, total_size)
+        self.assertTrue(res.licenses is not None)
+        self.assertTrue(res.links is not None)
+        self.assertTrue(res.hardlinks is not None)
+        self.assertTrue(res.files is not None)
+        self.assertTrue(res.dirs is not None)
+        self.assertTrue(res.dependencies is not None)
+        # A test for bug 8868 which ensures the pkg.description field
+        # is as exected.
+        self.assertEqual(res.description, "DESCRIPTION 1")
 
-                info_needed = api.PackageInfo.ALL_OPTIONS - \
-                    frozenset([api.PackageInfo.LICENSES])
-                
-                ret = api_obj.info(["jade"],
-                    local, info_needed)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                notfound = ret[api.ImageInterface.INFO_MISSING]
-                illegals = ret[api.ImageInterface.INFO_ILLEGALS]
-                self.assertTrue(len(pis) == 1)
-                self.assertTrue(len(pis[0].dirs) == 1)
-                
-                ret = api_obj.info(["jade"], local, set())
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                self.assertTrue(len(pis) == 1)
-                res = pis[0]
-                self.assertTrue(res.pkg_stem is None)
-                self.assertTrue(res.summary is None)
-                self.assertEqual(res.category_info_list, [])
-                self.assertEqual(res.states, tuple())
-                self.assertTrue(res.publisher is None)
-                self.assertTrue(res.version is None)
-                self.assertTrue(res.build_release is None)
-                self.assertTrue(res.branch is None)
-                self.assertTrue(res.packaging_date is None)
-                self.assertTrue(res.size is None)
-                self.assertTrue(res.licenses is None)
-                self.assertTrue(res.links is None)
-                self.assertTrue(res.hardlinks is None)
-                self.assertTrue(res.files is None)
-                self.assertTrue(res.dirs is None)
-                self.assertEqual(res.dependencies, ())
-                
-                local = False
+        # Verify that summary is pulled from the old "name=description"
+        # set action.
+        self.assertEqual(res.summary, "FOOO bAr O OO OOO")
 
-                ret = api_obj.info(["jade"],
-                    local, info_needed)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                notfound = ret[api.ImageInterface.INFO_MISSING]
-                illegals = ret[api.ImageInterface.INFO_ILLEGALS]
-                self.assertTrue(len(pis) == 1)
-                self.assertTrue(len(pis[0].dirs) == 1)
+        ret = api_obj.info(["emerald"], local, info_needed)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        notfound = ret[api.ImageInterface.INFO_MISSING]
+        illegals = ret[api.ImageInterface.INFO_ILLEGALS]
+        self.assertTrue(len(notfound) == 1)
 
-                self.assertRaises(api_errors.UnrecognizedOptionsToInfo,
-                    api_obj.info, ["jade"], local, set([-1]))
-                self.assertRaises(api_errors.UnrecognizedOptionsToInfo,
-                    api_obj.info, ["jade"], local, set('a'))
+        local = True
+        get_license = False
+        get_action_info = True
 
-                self.assertRaises(api_errors.UnrecognizedOptionsToInfo,
-                    api_obj.info, ["foo"], local, set([-1]))
-                self.assertRaises(api_errors.UnrecognizedOptionsToInfo,
-                    api_obj.info, ["foo"], local, set('a'))
+        info_needed = api.PackageInfo.ALL_OPTIONS - frozenset(
+            [api.PackageInfo.LICENSES]
+        )
 
-                # Test if the package summary has been correctly set if just
-                # a pkg.summary had been set in the package.
-                # See bug #4395 and bug #8829 for more details.
-                ret = api_obj.info(["example_pkg5"], local,
-                    api.PackageInfo.ALL_OPTIONS)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                self.assertTrue(len(pis) == 1)
-                res = pis[0]
-                self.assertTrue(res.summary == "SUMMARY: Example Package 5")
-                # A test for bug 8868 which ensures the pkg.description field
-                # is as exected.
-                self.assertEqual(res.description, "DESCRIPTION 2")
+        ret = api_obj.info(["jade"], local, info_needed)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        notfound = ret[api.ImageInterface.INFO_MISSING]
+        illegals = ret[api.ImageInterface.INFO_ILLEGALS]
+        self.assertTrue(len(pis) == 1)
+        self.assertTrue(len(pis[0].dirs) == 1)
 
-                # Test if the package summary has been correctly set if both
-                # a pkg.summary and a description had been set in the package.
-                # See bug #4395 and bug #8829 for more details.
-                ret = api_obj.info(["example_pkg6"], local,
-                    api.PackageInfo.ALL_OPTIONS)
-                pis = ret[api.ImageInterface.INFO_FOUND]
-                self.assertTrue(len(pis) == 1)
-                res = pis[0]
-                self.assertTrue(res.summary == "SUMMARY: Example Package 6")
-                # A test for bug 8868 which ensures the pkg.description field
-                # is as exected.
-                self.assertEqual(res.description, "DESCRIPTION 3")
+        ret = api_obj.info(["jade"], local, set())
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        self.assertTrue(len(pis) == 1)
+        res = pis[0]
+        self.assertTrue(res.pkg_stem is None)
+        self.assertTrue(res.summary is None)
+        self.assertEqual(res.category_info_list, [])
+        self.assertEqual(res.states, tuple())
+        self.assertTrue(res.publisher is None)
+        self.assertTrue(res.version is None)
+        self.assertTrue(res.build_release is None)
+        self.assertTrue(res.branch is None)
+        self.assertTrue(res.packaging_date is None)
+        self.assertTrue(res.size is None)
+        self.assertTrue(res.licenses is None)
+        self.assertTrue(res.links is None)
+        self.assertTrue(res.hardlinks is None)
+        self.assertTrue(res.files is None)
+        self.assertTrue(res.dirs is None)
+        self.assertEqual(res.dependencies, ())
 
-        def test_1_bad_packages(self):
-                """Verify that the info operation handles packages with invalid
-                metadata."""
+        local = False
 
-                api_obj = self.image_create(self.rurl)
+        ret = api_obj.info(["jade"], local, info_needed)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        notfound = ret[api.ImageInterface.INFO_MISSING]
+        illegals = ret[api.ImageInterface.INFO_ILLEGALS]
+        self.assertTrue(len(pis) == 1)
+        self.assertTrue(len(pis[0].dirs) == 1)
 
-                self.assertRaises(api_errors.NoPackagesInstalledException,
-                    api_obj.info, [], True, api.PackageInfo.ALL_OPTIONS -
-                    (frozenset([api.PackageInfo.LICENSES]) |
-                    api.PackageInfo.ACTION_OPTIONS))
+        self.assertRaises(
+            api_errors.UnrecognizedOptionsToInfo,
+            api_obj.info,
+            ["jade"],
+            local,
+            set([-1]),
+        )
+        self.assertRaises(
+            api_errors.UnrecognizedOptionsToInfo,
+            api_obj.info,
+            ["jade"],
+            local,
+            set("a"),
+        )
 
-                self.make_misc_files("tmp/baz")
+        self.assertRaises(
+            api_errors.UnrecognizedOptionsToInfo,
+            api_obj.info,
+            ["foo"],
+            local,
+            set([-1]),
+        )
+        self.assertRaises(
+            api_errors.UnrecognizedOptionsToInfo,
+            api_obj.info,
+            ["foo"],
+            local,
+            set("a"),
+        )
 
-                badfile10 = """
+        # Test if the package summary has been correctly set if just
+        # a pkg.summary had been set in the package.
+        # See bug #4395 and bug #8829 for more details.
+        ret = api_obj.info(["example_pkg5"], local, api.PackageInfo.ALL_OPTIONS)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        self.assertTrue(len(pis) == 1)
+        res = pis[0]
+        self.assertTrue(res.summary == "SUMMARY: Example Package 5")
+        # A test for bug 8868 which ensures the pkg.description field
+        # is as exected.
+        self.assertEqual(res.description, "DESCRIPTION 2")
+
+        # Test if the package summary has been correctly set if both
+        # a pkg.summary and a description had been set in the package.
+        # See bug #4395 and bug #8829 for more details.
+        ret = api_obj.info(["example_pkg6"], local, api.PackageInfo.ALL_OPTIONS)
+        pis = ret[api.ImageInterface.INFO_FOUND]
+        self.assertTrue(len(pis) == 1)
+        res = pis[0]
+        self.assertTrue(res.summary == "SUMMARY: Example Package 6")
+        # A test for bug 8868 which ensures the pkg.description field
+        # is as exected.
+        self.assertEqual(res.description, "DESCRIPTION 3")
+
+    def test_1_bad_packages(self):
+        """Verify that the info operation handles packages with invalid
+        metadata."""
+
+        api_obj = self.image_create(self.rurl)
+
+        self.assertRaises(
+            api_errors.NoPackagesInstalledException,
+            api_obj.info,
+            [],
+            True,
+            api.PackageInfo.ALL_OPTIONS
+            - (
+                frozenset([api.PackageInfo.LICENSES])
+                | api.PackageInfo.ACTION_OPTIONS
+            ),
+        )
+
+        self.make_misc_files("tmp/baz")
+
+        badfile10 = """
                     open badfile@1.0,5.11-0
                     add file tmp/baz mode=644 owner=root group=bin path=/tmp/baz-file
                     close
                 """
 
-                baddir10 = """
+        baddir10 = """
                     open baddir@1.0,5.11-0
                     add dir mode=755 owner=root group=bin path=/tmp/baz-dir
                     close
                 """
 
-                plist = self.pkgsend_bulk(self.rurl, (badfile10, baddir10))
-                api_obj.refresh(immediate=True)
+        plist = self.pkgsend_bulk(self.rurl, (badfile10, baddir10))
+        api_obj.refresh(immediate=True)
 
-                # This should succeed and cause the manifests to be cached.
-                info_needed = api.PackageInfo.ALL_OPTIONS
-                ret = api_obj.info(plist, False, info_needed)
+        # This should succeed and cause the manifests to be cached.
+        info_needed = api.PackageInfo.ALL_OPTIONS
+        ret = api_obj.info(plist, False, info_needed)
 
-                # Now attempt to corrupt the client's copy of the manifest by
-                # adding malformed actions.
-                for p in plist:
-                        self.debug("Testing package {0} ...".format(p))
-                        pfmri = fmri.PkgFmri(p)
-                        mdata = self.get_img_manifest(pfmri)
-                        if mdata.find("dir") != -1:
-                                src_mode = "mode=755"
-                        else:
-                                src_mode = "mode=644"
+        # Now attempt to corrupt the client's copy of the manifest by
+        # adding malformed actions.
+        for p in plist:
+            self.debug("Testing package {0} ...".format(p))
+            pfmri = fmri.PkgFmri(p)
+            mdata = self.get_img_manifest(pfmri)
+            if mdata.find("dir") != -1:
+                src_mode = "mode=755"
+            else:
+                src_mode = "mode=644"
 
-                        for bad_act in (
-                            'set name=description value="" \" my desc \" ""',
-                            "set name=com.sun.service.escalations value="):
-                                self.debug("Testing with bad action "
-                                    "'{0}'.".format(bad_act))
-                                bad_mdata = mdata + "{0}\n".format(bad_act)
-                                self.write_img_manifest(pfmri, bad_mdata)
+            for bad_act in (
+                'set name=description value="" " my desc " ""',
+                "set name=com.sun.service.escalations value=",
+            ):
+                self.debug("Testing with bad action " "'{0}'.".format(bad_act))
+                bad_mdata = mdata + "{0}\n".format(bad_act)
+                self.write_img_manifest(pfmri, bad_mdata)
 
-                                # Info shouldn't raise an exception.
-                                api_obj.info([pfmri.pkg_name], False,
-                                    info_needed)
+                # Info shouldn't raise an exception.
+                api_obj.info([pfmri.pkg_name], False, info_needed)
 
-        def test_2_renamed_packages(self):
-                """Verify that info returns the expected list of dependencies
-                for renamed packages."""
+    def test_2_renamed_packages(self):
+        """Verify that info returns the expected list of dependencies
+        for renamed packages."""
 
-                target10 = """
+        target10 = """
                     open target@1.0
                     close
                 """
 
-                # Renamed package for all variants, with correct dependencies.
-                ren_correct10 = """
+        # Renamed package for all variants, with correct dependencies.
+        ren_correct10 = """
                     open ren_correct@1.0
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=target@1.0 variant.cat=bobcat
@@ -391,87 +430,96 @@ class TestApiInfo(pkg5unittest.SingleDepotTestCase):
                     close
                 """
 
-                # Renamed package for opposite image variant, with dependencies
-                # only for opposite image variant.
-                ren_op_variant10 = """
+        # Renamed package for opposite image variant, with dependencies
+        # only for opposite image variant.
+        ren_op_variant10 = """
                     open ren_op_variant@1.0
                     add set name=pkg.renamed value=true variant.cat=lynx
                     add depend type=require fmri=target@1.0 variant.cat=lynx
                     close
                 """
 
-                # Renamed package for current image variant, with dependencies
-                # only for other variant.
-                ren_variant_missing10 = """
+        # Renamed package for current image variant, with dependencies
+        # only for other variant.
+        ren_variant_missing10 = """
                     open ren_variant_missing@1.0
                     add set name=pkg.renamed value=true variant.cat=bobcat
                     add depend type=require fmri=target@1.0 variant.cat=lynx
                     close
                 """
 
-                # Renamed package for multiple variants, with dependencies
-                # missing for one variant.
-                ren_partial_variant10 = """
+        # Renamed package for multiple variants, with dependencies
+        # missing for one variant.
+        ren_partial_variant10 = """
                     open ren_partial_variant@1.0
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=target@1.0 variant.cat=lynx
                     close
                 """
 
-                plist = self.pkgsend_bulk(self.rurl, (target10, ren_correct10,
-                    ren_op_variant10, ren_variant_missing10,
-                    ren_partial_variant10))
+        plist = self.pkgsend_bulk(
+            self.rurl,
+            (
+                target10,
+                ren_correct10,
+                ren_op_variant10,
+                ren_variant_missing10,
+                ren_partial_variant10,
+            ),
+        )
 
-                # Create an image and get the api object needed to run tests.
-                variants = { "variant.cat": "bobcat" }
-                api_obj = self.image_create(self.rurl, variants=variants)
+        # Create an image and get the api object needed to run tests.
+        variants = {"variant.cat": "bobcat"}
+        api_obj = self.image_create(self.rurl, variants=variants)
 
-                info_needed = api.PackageInfo.ALL_OPTIONS - \
-                    (api.PackageInfo.ACTION_OPTIONS -
-                    frozenset([api.PackageInfo.DEPENDENCIES,
-                    api.PackageInfo.LICENSES]))
+        info_needed = api.PackageInfo.ALL_OPTIONS - (
+            api.PackageInfo.ACTION_OPTIONS
+            - frozenset(
+                [api.PackageInfo.DEPENDENCIES, api.PackageInfo.LICENSES]
+            )
+        )
 
-                # First, verify that a renamed package (for all variants), and
-                # with the correct dependencies will provide the expected info.
-                ret = api_obj.info(["ren_correct"], False, info_needed)
-                pi = ret[api.ImageInterface.INFO_FOUND][0]
-                self.assertTrue(api.PackageInfo.RENAMED in pi.states)
-                self.assertEqual(pi.dependencies, ["target@1.0"])
+        # First, verify that a renamed package (for all variants), and
+        # with the correct dependencies will provide the expected info.
+        ret = api_obj.info(["ren_correct"], False, info_needed)
+        pi = ret[api.ImageInterface.INFO_FOUND][0]
+        self.assertTrue(api.PackageInfo.RENAMED in pi.states)
+        self.assertEqual(pi.dependencies, ["target@1.0"])
 
-                # Next, verify that a renamed package (for a variant not
-                # applicable to this image), and with dependencies that
-                # are only for that other variant will provide the expected
-                # info.
-                ret = api_obj.info(["ren_op_variant"], False, info_needed)
-                pi = ret[api.ImageInterface.INFO_FOUND][0]
-                self.assertTrue(api.PackageInfo.RENAMED not in pi.states)
+        # Next, verify that a renamed package (for a variant not
+        # applicable to this image), and with dependencies that
+        # are only for that other variant will provide the expected
+        # info.
+        ret = api_obj.info(["ren_op_variant"], False, info_needed)
+        pi = ret[api.ImageInterface.INFO_FOUND][0]
+        self.assertTrue(api.PackageInfo.RENAMED not in pi.states)
 
-                # No dependencies expected; existing don't apply to image.
-                self.assertEqual(pi.dependencies, [])
+        # No dependencies expected; existing don't apply to image.
+        self.assertEqual(pi.dependencies, [])
 
-                # Next, verify that a renamed package (for a variant applicable
-                # to this image), and with dependencies that are only for that
-                # other variant will provide the expected info.
-                ret = api_obj.info(["ren_variant_missing"], False, info_needed)
-                pi = ret[api.ImageInterface.INFO_FOUND][0]
+        # Next, verify that a renamed package (for a variant applicable
+        # to this image), and with dependencies that are only for that
+        # other variant will provide the expected info.
+        ret = api_obj.info(["ren_variant_missing"], False, info_needed)
+        pi = ret[api.ImageInterface.INFO_FOUND][0]
 
-                # Ensure package isn't seen as renamed for current variant.
-                self.assertTrue(api.PackageInfo.RENAMED in pi.states)
+        # Ensure package isn't seen as renamed for current variant.
+        self.assertTrue(api.PackageInfo.RENAMED in pi.states)
 
-                # No dependencies expected; existing don't apply to image.
-                self.assertEqual(pi.dependencies, [])
+        # No dependencies expected; existing don't apply to image.
+        self.assertEqual(pi.dependencies, [])
 
-                # Next, verify that a renamed package (for all variants),
-                # but that is missing a dependency for the current variant
-                # will provide the expected info.
-                ret = api_obj.info(["ren_partial_variant"], False, info_needed)
-                pi = ret[api.ImageInterface.INFO_FOUND][0]
-                self.assertTrue(api.PackageInfo.RENAMED in pi.states)
-                self.assertEqual(pi.dependencies, [])
+        # Next, verify that a renamed package (for all variants),
+        # but that is missing a dependency for the current variant
+        # will provide the expected info.
+        ret = api_obj.info(["ren_partial_variant"], False, info_needed)
+        pi = ret[api.ImageInterface.INFO_FOUND][0]
+        self.assertTrue(api.PackageInfo.RENAMED in pi.states)
+        self.assertEqual(pi.dependencies, [])
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_api_list.py
+++ b/src/tests/api/t_api_list.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import calendar
@@ -44,1663 +45,1623 @@ import pkg.fmri as fmri
 import pkg.misc as misc
 import pkg.version as version
 
+
 class TestApiList(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        packages = [
-            "apple@1,5.11-0",
-            "apple@1.0,5.11-0",
-            "apple@1.1,5.11-0",
-            "apple@1.2.0,5.11-0",
-            "apple@1.2.1,5.11-0",
-            "apple@1.2.1,5.11-0",
-            "apple@1.2.1,5.11-1",
-            "bat/bar@1.2,5.11-0",
-            "baz@1.0",
-            "baz@1.0.1",
-            "baz@1.3",
-            "corge@0.9",
-            "corge@1.0",
-            "entire@1.0",
-            "grault@1.0",
-            "obsolete@1.0",
-            "quux@1.0",
-            "qux@0.9",
-            "qux@1.0",
-            "zoo@1.0",
-            "zoo@2.0",
-            "zzfenix@1.0",
-            "zzcowley@1.1",
-        ]
+    packages = [
+        "apple@1,5.11-0",
+        "apple@1.0,5.11-0",
+        "apple@1.1,5.11-0",
+        "apple@1.2.0,5.11-0",
+        "apple@1.2.1,5.11-0",
+        "apple@1.2.1,5.11-0",
+        "apple@1.2.1,5.11-1",
+        "bat/bar@1.2,5.11-0",
+        "baz@1.0",
+        "baz@1.0.1",
+        "baz@1.3",
+        "corge@0.9",
+        "corge@1.0",
+        "entire@1.0",
+        "grault@1.0",
+        "obsolete@1.0",
+        "quux@1.0",
+        "qux@0.9",
+        "qux@1.0",
+        "zoo@1.0",
+        "zoo@2.0",
+        "zzfenix@1.0",
+        "zzcowley@1.1",
+    ]
 
-        def __tuple_order(self, a, b):
-                apub, astem, aver = a
-                bpub, bstem, bver = b
-                rval = misc.cmp(astem, bstem)
-                if rval != 0:
-                        return rval
-                rval = misc.cmp(apub, bpub)
-                if rval != 0:
-                        return rval
-                aver = version.Version(aver)
-                bver = version.Version(bver)
-                return misc.cmp(aver, bver) * -1
+    def __tuple_order(self, a, b):
+        apub, astem, aver = a
+        bpub, bstem, bver = b
+        rval = misc.cmp(astem, bstem)
+        if rval != 0:
+            return rval
+        rval = misc.cmp(apub, bpub)
+        if rval != 0:
+            return rval
+        aver = version.Version(aver)
+        bver = version.Version(bver)
+        return misc.cmp(aver, bver) * -1
 
-        def __get_pkg_variant(self, stem, ver):
-                var = "true"
-                opvar = "false"
-                if stem == "apple":
-                        return [var]
-                elif stem in ("entire", "bat/bar", "obsolete"):
-                        return
-                elif stem in ("corge", "grault", "qux", "quux",
-                    "zzfenix", "zzcowley"):
-                        return [var, opvar]
-                elif stem == "zoo" and ver.startswith("1.0"):
-                        return [var]
-                return [opvar]
+    def __get_pkg_variant(self, stem, ver):
+        var = "true"
+        opvar = "false"
+        if stem == "apple":
+            return [var]
+        elif stem in ("entire", "bat/bar", "obsolete"):
+            return
+        elif stem in ("corge", "grault", "qux", "quux", "zzfenix", "zzcowley"):
+            return [var, opvar]
+        elif stem == "zoo" and ver.startswith("1.0"):
+            return [var]
+        return [opvar]
 
-        @staticmethod
-        def __get_pkg_cats(stem, ver):
-                if stem == "apple":
-                        return [
-                            "fruit",
-                            "org.opensolaris.category.2008:"
-                            "Applications/Sound and Video"
-                        ]
-                elif stem == "bat/bar":
-                        return [
-                            "food",
-                            "org.opensolaris.category.2008:"
-                            "Development/Python"
-                        ]
-                return []
+    @staticmethod
+    def __get_pkg_cats(stem, ver):
+        if stem == "apple":
+            return [
+                "fruit",
+                "org.opensolaris.category.2008:" "Applications/Sound and Video",
+            ]
+        elif stem == "bat/bar":
+            return [
+                "food",
+                "org.opensolaris.category.2008:" "Development/Python",
+            ]
+        return []
 
-        @staticmethod
-        def __get_pkg_summ_desc(stem, ver):
-                summ = "Summ. is {0} {1}".format(stem, ver)
-                desc = "Desc. is {0} {1}".format(stem, ver)
-                return summ, desc
+    @staticmethod
+    def __get_pkg_summ_desc(stem, ver):
+        summ = "Summ. is {0} {1}".format(stem, ver)
+        desc = "Desc. is {0} {1}".format(stem, ver)
+        return summ, desc
 
-        def __get_pkg_states(self, pub, stem, ver, installed=False):
-                states = [api.PackageInfo.KNOWN]
-                if installed:
-                        states.append(api.PackageInfo.INSTALLED)
-                if stem == "apple":
-                        # Compare with newest version entry for this stem.
-                        if ver != str(self.dlist1[6].version):
-                                states.append(api.PackageInfo.UPGRADABLE)
-                elif stem == "baz":
-                        # Compare with newest version entry for this stem.
-                        if ver != str(self.dlist1[10].version):
-                                states.append(api.PackageInfo.UPGRADABLE)
-                elif stem == "corge":
-                        # Compare with newest version entry for this stem.
-                        nver = str(self.dlist1[12].version)
-                        if ver != nver:
-                                states.append(api.PackageInfo.UPGRADABLE)
-                        if ver == nver:
-                                states.append(api.PackageInfo.RENAMED)
-                elif stem == "obsolete":
-                        states.append(api.PackageInfo.OBSOLETE)
-                elif stem == "qux":
-                        # Compare with newest version entry for this stem.
-                        nver = str(self.dlist1[18].version)
-                        if ver != nver:
-                                states.append(api.PackageInfo.UPGRADABLE)
-                        if ver == nver:
-                                states.append(api.PackageInfo.RENAMED)
-                elif stem == "zoo":
-                        # Compare with newest version entry for this stem.
-                        nver = str(self.dlist1[20].version)
-                        if ver != nver:
-                                states.append(api.PackageInfo.UPGRADABLE)
+    def __get_pkg_states(self, pub, stem, ver, installed=False):
+        states = [api.PackageInfo.KNOWN]
+        if installed:
+            states.append(api.PackageInfo.INSTALLED)
+        if stem == "apple":
+            # Compare with newest version entry for this stem.
+            if ver != str(self.dlist1[6].version):
+                states.append(api.PackageInfo.UPGRADABLE)
+        elif stem == "baz":
+            # Compare with newest version entry for this stem.
+            if ver != str(self.dlist1[10].version):
+                states.append(api.PackageInfo.UPGRADABLE)
+        elif stem == "corge":
+            # Compare with newest version entry for this stem.
+            nver = str(self.dlist1[12].version)
+            if ver != nver:
+                states.append(api.PackageInfo.UPGRADABLE)
+            if ver == nver:
+                states.append(api.PackageInfo.RENAMED)
+        elif stem == "obsolete":
+            states.append(api.PackageInfo.OBSOLETE)
+        elif stem == "qux":
+            # Compare with newest version entry for this stem.
+            nver = str(self.dlist1[18].version)
+            if ver != nver:
+                states.append(api.PackageInfo.UPGRADABLE)
+            if ver == nver:
+                states.append(api.PackageInfo.RENAMED)
+        elif stem == "zoo":
+            # Compare with newest version entry for this stem.
+            nver = str(self.dlist1[20].version)
+            if ver != nver:
+                states.append(api.PackageInfo.UPGRADABLE)
 
-                return frozenset(states)
+        return frozenset(states)
 
-        def __get_pub_entry(self, pub, idx, name, ver):
-                if pub == "test1":
-                        l = self.dlist1
-                else:
-                        l = self.dlist2
+    def __get_pub_entry(self, pub, idx, name, ver):
+        if pub == "test1":
+            l = self.dlist1
+        else:
+            l = self.dlist2
 
-                f = l[idx]
-                self.assertEqual(f.pkg_name, name)
-                v = str(f.version)
-                try:
-                        self.assertTrue(v.startswith(ver + ":"))
-                except AssertionError:
-                        self.debug("\n{0} does not start with {1}:".format(v, ver))
-                        raise
-                return f, v
+        f = l[idx]
+        self.assertEqual(f.pkg_name, name)
+        v = str(f.version)
+        try:
+            self.assertTrue(v.startswith(ver + ":"))
+        except AssertionError:
+            self.debug("\n{0} does not start with {1}:".format(v, ver))
+            raise
+        return f, v
 
-        def __get_exp_pub_entry(self, pub, idx, name, ver, installed=False):
-                f, v = self.__get_pub_entry(pub, idx, name, ver)
-                return self.__get_expected_entry(pub, name, v,
-                    installed=installed)
+    def __get_exp_pub_entry(self, pub, idx, name, ver, installed=False):
+        f, v = self.__get_pub_entry(pub, idx, name, ver)
+        return self.__get_expected_entry(pub, name, v, installed=installed)
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test3", "test1"])
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test1", "test2", "test3", "test1"]
+        )
 
-                pkg_data = ""
-                for p in self.packages:
-                        pkg_data += p
-                        stem, ver = p.split("@")
+        pkg_data = ""
+        for p in self.packages:
+            pkg_data += p
+            stem, ver = p.split("@")
 
-                        sver = version.Version(ver)
-                        sver = str(sver).split(":", 1)[0]
+            sver = version.Version(ver)
+            sver = str(sver).split(":", 1)[0]
 
-                        summ, desc = self.__get_pkg_summ_desc(stem, sver)
-                        pkg_data += """
+            summ, desc = self.__get_pkg_summ_desc(stem, sver)
+            pkg_data += """
 open {stem}@{ver}
 add set name=pkg.summary value="{summ}"
 add set name=pkg.description value="{desc}"
-""".format(stem=stem, ver=ver, summ=summ, desc=desc)
+""".format(
+                stem=stem, ver=ver, summ=summ, desc=desc
+            )
 
-                        cats = self.__get_pkg_cats(stem, sver)
-                        if cats:
-                                pkg_data += "add set name=info.classification"
-                                for cat in cats:
-                                        pkg_data += ' value="{0}"'.format(cat)
-                                pkg_data += "\n"
+            cats = self.__get_pkg_cats(stem, sver)
+            if cats:
+                pkg_data += "add set name=info.classification"
+                for cat in cats:
+                    pkg_data += ' value="{0}"'.format(cat)
+                pkg_data += "\n"
 
-                        var = self.__get_pkg_variant(stem, sver)
-                        if var:
-                                adata = "value="
-                                adata += " value=".join(var)
-                                pkg_data += "add set name=variant.mumble " \
-                                    "{0}\n".format(adata)
+            var = self.__get_pkg_variant(stem, sver)
+            if var:
+                adata = "value="
+                adata += " value=".join(var)
+                pkg_data += "add set name=variant.mumble " "{0}\n".format(adata)
 
-                        if stem == "corge" and sver.startswith("1.0"):
-                                pkg_data += "add set name=pkg.renamed " \
-                                    "value=true\n"
-                                pkg_data += "add depend type=require " \
-                                    "fmri=grault\n"
-                        elif stem == "entire":
-                                pkg_data += "add depend type=incorporate " \
-                                    "fmri=apple@1.2-0\n"
-                                # versionless incorporate dependencies should
-                                # be ignored.
-                                pkg_data += "add depend type=incorporate " \
-                                    "fmri=corge\n"
-                                pkg_data += "add depend type=incorporate " \
-                                    "fmri=qux@1.0\n"
-                                pkg_data += "add depend type=incorporate " \
-                                    "fmri=quux@1.0\n"
-                        elif stem == "obsolete":
-                                pkg_data += "add set name=pkg.obsolete " \
-                                    "value=true\n"
-                        elif stem == "qux" and sver.startswith("1.0"):
-                                pkg_data += "add set name=pkg.renamed " \
-                                    "value=true\n"
-                                pkg_data += "add depend type=require " \
-                                    "fmri=quux\n"
-                        elif stem == "zzfenix":
-                                pkg_data += "add depend type=require " \
-                                    "fmri=zzcowley\n"
+            if stem == "corge" and sver.startswith("1.0"):
+                pkg_data += "add set name=pkg.renamed " "value=true\n"
+                pkg_data += "add depend type=require " "fmri=grault\n"
+            elif stem == "entire":
+                pkg_data += "add depend type=incorporate " "fmri=apple@1.2-0\n"
+                # versionless incorporate dependencies should
+                # be ignored.
+                pkg_data += "add depend type=incorporate " "fmri=corge\n"
+                pkg_data += "add depend type=incorporate " "fmri=qux@1.0\n"
+                pkg_data += "add depend type=incorporate " "fmri=quux@1.0\n"
+            elif stem == "obsolete":
+                pkg_data += "add set name=pkg.obsolete " "value=true\n"
+            elif stem == "qux" and sver.startswith("1.0"):
+                pkg_data += "add set name=pkg.renamed " "value=true\n"
+                pkg_data += "add depend type=require " "fmri=quux\n"
+            elif stem == "zzfenix":
+                pkg_data += "add depend type=require " "fmri=zzcowley\n"
 
-                        pkg_data += "close\n"
+            pkg_data += "close\n"
 
-                self.rurl1 = self.dcs[1].get_repo_url()
-                plist = self.pkgsend_bulk(self.rurl1, pkg_data)
+        self.rurl1 = self.dcs[1].get_repo_url()
+        plist = self.pkgsend_bulk(self.rurl1, pkg_data)
 
-                # Ensure that the second repo's packages have exactly the same
-                # timestamps as those in the first ... by copying the repo over.
-                d1dir = self.dcs[1].get_repodir()
-                d2dir = self.dcs[2].get_repodir()
-                self.copy_repository(d1dir, d2dir, { "test1": "test2" })
+        # Ensure that the second repo's packages have exactly the same
+        # timestamps as those in the first ... by copying the repo over.
+        d1dir = self.dcs[1].get_repodir()
+        d2dir = self.dcs[2].get_repodir()
+        self.copy_repository(d1dir, d2dir, {"test1": "test2"})
 
-                self.dlist1 = []
-                self.dlist2 = []
-                for e in plist:
-                        # Unique FMRI object is needed for each list.
-                        f = fmri.PkgFmri(str(e))
-                        self.dlist1.append(f)
+        self.dlist1 = []
+        self.dlist2 = []
+        for e in plist:
+            # Unique FMRI object is needed for each list.
+            f = fmri.PkgFmri(str(e))
+            self.dlist1.append(f)
 
-                        f = fmri.PkgFmri(str(e))
-                        f.set_publisher("test2")
-                        self.dlist2.append(f)
+            f = fmri.PkgFmri(str(e))
+            f.set_publisher("test2")
+            self.dlist2.append(f)
 
-                self.dlist1.sort()
-                self.dlist2.sort()
+        self.dlist1.sort()
+        self.dlist2.sort()
 
-                # The new repository won't have a catalog, so rebuild it.
-                self.dcs[2].get_repo(auto_create=True).rebuild()
+        # The new repository won't have a catalog, so rebuild it.
+        self.dcs[2].get_repo(auto_create=True).rebuild()
 
-                # The third repository should remain empty and not be
-                # published to.
+        # The third repository should remain empty and not be
+        # published to.
 
-                # The fourth should be for test1, but have only the oldest
-                # version of the 'apple' package.
-                self.rurl4 = self.dcs[4].get_repo_url()
-                self.pkgrecv(self.rurl1, "-d {0} {1}".format(self.rurl4, plist[0]))
+        # The fourth should be for test1, but have only the oldest
+        # version of the 'apple' package.
+        self.rurl4 = self.dcs[4].get_repo_url()
+        self.pkgrecv(self.rurl1, "-d {0} {1}".format(self.rurl4, plist[0]))
 
-                # Next, create the image and configure publishers.
-                self.image_create(self.rurl1, prefix="test1",
-                    variants={ "variant.mumble": "true" })
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.pkg("set-publisher -g " + self.rurl2 + " test2")
+        # Next, create the image and configure publishers.
+        self.image_create(
+            self.rurl1, prefix="test1", variants={"variant.mumble": "true"}
+        )
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.pkg("set-publisher -g " + self.rurl2 + " test2")
 
-        def __get_expected_entry(self, pub, stem, ver, installed=False):
-                states = self.__get_pkg_states(pub, stem, ver,
-                    installed=installed)
+    def __get_expected_entry(self, pub, stem, ver, installed=False):
+        states = self.__get_pkg_states(pub, stem, ver, installed=installed)
+
+        sver = ver.split(":", 1)[0]
+        raw_cats = self.__get_pkg_cats(stem, sver)
+        summ, desc = self.__get_pkg_summ_desc(stem, sver)
+
+        scheme = None
+        cat = None
+        pcats = []
+        for e in raw_cats:
+            if e and ":" in e:
+                scheme, cat = e.split(":", 1)
+            else:
+                scheme = ""
+                cat = e
+            pcats.append((scheme, cat))
+        return ((pub, stem, ver), summ, pcats, states)
+
+    def __get_expected(
+        self, pkg_list, cats=None, pubs=misc.EmptyI, variants=False
+    ):
+        nlist = {}
+        newest = pkg_list == api.ImageInterface.LIST_NEWEST
+        if newest:
+            # Get the newest FMRI for each unique package stem on
+            # a per-publisher basis.
+            for plist in (self.dlist1, self.dlist2):
+                for f in plist:
+                    pstem = f.get_pkg_stem()
+                    pub, stem, ver = f.tuple()
+                    ver = str(f.version)
+                    sver = ver.split(":", 1)[0]
+
+                    var = self.__get_pkg_variant(stem, sver)
+                    if pstem not in nlist:
+                        nlist[pstem] = f
+                    elif not variants and var and "true" not in var:
+                        continue
+                    elif f.version > nlist[pstem]:
+                        nlist[pstem] = f
+        nlist = sorted(nlist.values())
+
+        expected = []
+        for plist in (self.dlist1, self.dlist2):
+            for f in plist:
+                pub, stem, ver = f.tuple()
+                ver = str(f.version)
+                if pubs and pub not in pubs:
+                    continue
 
                 sver = ver.split(":", 1)[0]
-                raw_cats = self.__get_pkg_cats(stem, sver)
-                summ, desc = self.__get_pkg_summ_desc(stem, sver)
+                var = self.__get_pkg_variant(stem, sver)
+                if not variants and var and "true" not in var:
+                    continue
 
-                scheme = None
-                cat = None
-                pcats = []
-                for e in raw_cats:
-                        if e and ":" in e:
-                                scheme, cat = e.split(":", 1)
-                        else:
-                                scheme = ""
-                                cat = e
-                        pcats.append((scheme, cat))
-                return ((pub, stem, ver), summ, pcats, states)
+                if newest and f not in nlist:
+                    continue
 
-        def __get_expected(self, pkg_list, cats=None, pubs=misc.EmptyI,
-            variants=False):
-                nlist = {}
-                newest = pkg_list == api.ImageInterface.LIST_NEWEST
-                if newest:
-                        # Get the newest FMRI for each unique package stem on
-                        # a per-publisher basis.
-                        for plist in (self.dlist1, self.dlist2):
-                                for f in plist:
-                                        pstem = f.get_pkg_stem()
-                                        pub, stem, ver = f.tuple()
-                                        ver = str(f.version)
-                                        sver = ver.split(":", 1)[0]
-
-                                        var = self.__get_pkg_variant(stem, sver)
-                                        if pstem not in nlist:
-                                                nlist[pstem] = f
-                                        elif not variants and var and \
-                                            "true" not in var:
-                                                continue
-                                        elif f.version > nlist[pstem]:
-                                                nlist[pstem] = f
-                nlist = sorted(nlist.values())
-
-                expected = []
-                for plist in (self.dlist1, self.dlist2):
-                        for f in plist:
-                                pub, stem, ver = f.tuple()
-                                ver = str(f.version)
-                                if pubs and pub not in pubs:
-                                        continue
-
-                                sver = ver.split(":", 1)[0]
-                                var = self.__get_pkg_variant(stem, sver)
-                                if not variants and var and "true" not in var:
-                                        continue
-
-                                if newest and f not in nlist:
-                                        continue
-
-                                t, summ, pcats, states = \
-                                    self.__get_expected_entry(pub, stem, ver)
-                                if cats is not None:
-                                        if not cats:
-                                                if pcats:
-                                                        # Want packages with no
-                                                        # category.
-                                                        continue
-                                        elif not \
-                                            [sc for sc in cats if sc in pcats]:
-                                                # Doesn't match specified
-                                                # categories.
-                                                continue
-
-                                expected.append((t, summ, pcats, states))
-
-                def pkg_list_order(a, b):
-                        at = a[0]
-                        bt = b[0]
-                        return self.__tuple_order(at, bt)
-                expected.sort(key=cmp_to_key(pkg_list_order))
-                return expected
-
-        def __get_returned(self, pkg_list, api_obj=None, cats=None,
-            num_expected=None, patterns=misc.EmptyI,
-            pubs=misc.EmptyI, variants=False):
-
-                if not api_obj:
-                        api_obj = self.get_img_api_obj()
-
-                # Set of states exposed by the API.
-                exp_states = set([api.PackageInfo.FROZEN,
-                    api.PackageInfo.INCORPORATED, api.PackageInfo.EXCLUDES,
-                    api.PackageInfo.KNOWN, api.PackageInfo.INSTALLED,
-                    api.PackageInfo.UPGRADABLE, api.PackageInfo.OBSOLETE,
-                    api.PackageInfo.RENAMED])
-
-                # Get ordered list of all packages.
-                returned = []
-                for entry in api_obj.get_pkg_list(pkg_list, cats=cats,
-                    patterns=patterns, pubs=pubs, variants=variants):
-                        (pub, stem, ver), summ, pcats, raw_states, attrs = entry
-
-                        sver = ver.split(":", 1)[0]
-
-                        # Eliminate states not exposed by the api.
-                        states = raw_states.intersection(exp_states)
-                        returned.append(((pub, stem, ver), summ, pcats, states))
-                return returned
-
-        def __test_list(self, pkg_list, api_obj=None,
-            cats=None, num_expected=None, pubs=misc.EmptyI,
-            variants=False):
-
-                # Get package list.
-                returned = self.__get_returned(pkg_list, api_obj=api_obj,
-                    cats=cats, pubs=pubs, variants=variants)
-
-                # Now generate expected list.
-                expected = self.__get_expected(pkg_list, cats=cats,
-                    pubs=pubs, variants=variants)
-
-                # Compare returned and expected.
-                self.assertEqualDiff(expected, returned)
-
-                self.debug(pprint.pformat(returned))
-                if num_expected is not None:
-                        self.assertEqual(len(returned), num_expected)
-
-        def test_list_01_full(self):
-                """Verify the sort order and content of a full list and
-                combinations thereof."""
-
-                api_obj = self.get_img_api_obj()
-
-                # First check all variants case.
-                returned = self.__get_returned(api_obj.LIST_ALL,
-                    api_obj=api_obj, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 6, "apple",
-                        "1.2.1,5.11-1"),
-                    self.__get_exp_pub_entry("test1", 5, "apple",
-                        "1.2.1,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 4, "apple",
-                        "1.2.1,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 2, "apple", "1.1,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 1, "apple", "1.0,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 0, "apple", "1,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 6, "apple",
-                        "1.2.1,5.11-1"),
-                    self.__get_exp_pub_entry("test2", 5, "apple",
-                        "1.2.1,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 4, "apple",
-                        "1.2.1,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 3, "apple",
-                        "1.2.0,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 2, "apple", "1.1,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 1, "apple", "1.0,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 0, "apple", "1,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 10, "baz", "1.3,5.11"),
-                    self.__get_exp_pub_entry("test1", 9, "baz", "1.0.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 8, "baz", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 10, "baz", "1.3,5.11"),
-                    self.__get_exp_pub_entry("test2", 9, "baz", "1.0.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 8, "baz", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 11, "corge", "0.9,5.11"),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 11, "corge", "0.9,5.11"),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 13, "entire", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 18, "qux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11"),
-                    self.__get_exp_pub_entry("test2", 18, "qux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 17, "qux", "0.9,5.11"),
-                    self.__get_exp_pub_entry("test1", 20, "zoo", "2.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 20, "zoo", "2.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 46)
-
-                # Next, check no variants case (which has to be done
-                # programatically).
-                self.__test_list(api.ImageInterface.LIST_ALL, api_obj=api_obj,
-                    num_expected=38, variants=False)
-
-        def test_list_02_newest(self):
-                """Verify the sort order and content of a list excluding
-                packages not for the current image variant, and all but
-                the newest versions of each package for each publisher."""
-
-                self.__test_list(api.ImageInterface.LIST_NEWEST,
-                    num_expected=22, variants=False)
-
-                # Verify that LIST_NEWEST will allow version-specific
-                # patterns such that the newest version allowed by the
-                # pattern is what is listed.
-                api_obj = self.get_img_api_obj()
-
-                returned = self.__get_returned(api_obj.LIST_NEWEST,
-                    api_obj=api_obj, patterns=["baz@1.0", "bat/bar",
-                        "corge@1.0"], variants=True)
-                expected = [
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 9, "baz", "1.0.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 9, "baz", "1.0.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 6)
-
-                returned = self.__get_returned(api_obj.LIST_NEWEST,
-                    api_obj=api_obj, patterns=["apple@*", "bat/bar"],
-                    variants=True)
-                expected = [
-                    self.__get_exp_pub_entry("test1", 6, "apple",
-                        "1.2.1,5.11-1"),
-                    self.__get_exp_pub_entry("test2", 6, "apple",
-                        "1.2.1,5.11-1"),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0")
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 4)
-
-                returned = self.__get_returned(api_obj.LIST_NEWEST,
-                    api_obj=api_obj, patterns=["apple@1.2.0"],
-                    variants=True)
-                expected = [
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 3, "apple",
-                        "1.2.0,5.11-0")
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 2)
-
-        def test_list_03_cats(self):
-                """Verify the sort order and content of a list excluding
-                packages not for the current image variant, and packages
-                that don't match the specified scheme, category
-                combinations."""
-
-                combos = [
-                    ([
-                        ("", "fruit"),
-                        ("org.opensolaris.category.2008",
-                        "Applications/Sound and Video"),
-                        ("", "food"),
-                        ("org.opensolaris.category.2008",
-                        "Development/Python")
-                    ], 16),
-                    ([
-                        ("org.opensolaris.category.2008",
-                        "Development/Python")
-                    ], 2),
-                    ([
-                        ("org.opensolaris.category.2008",
-                        "Applications/Sound and Video"),
-                        ("", "food")
-                    ], 16),
-                    ([
-                        ("", "fruit")
-                    ], 14),
-                    ([
-                        ("", "food")
-                    ], 2),
-                    ([], 22) # Only packages with no category assigned.
-                ]
-
-                for combo, expected in combos:
-                        self.__test_list(api.ImageInterface.LIST_ALL,
-                            cats=combo, num_expected=expected, variants=False)
-
-        def test_list_04_pubs(self):
-                """Verify the sort order and content of list filtered using
-                various publisher and variant combinations."""
-
-                combos = [
-                    (["test1", "test2"], 38, False),
-                    (["test1", "test2"], 46, True),
-                    (["test2"], 19, False),
-                    (["test2"], 23, True),
-                    (["test1"], 19, False),
-                    (["test1"], 23, True),
-                    (["test3"], 0, False),
-                    (["test3"], 0, True),
-                    ([], 38, False),
-                    ([], 46, True)
-                ]
-
-                for combo, expected, variants in combos:
-                        self.__test_list(api.ImageInterface.LIST_ALL,
-                            num_expected=expected, pubs=combo,
-                            variants=variants)
-
-        def test_list_05_installed(self):
-                """Verify the sort order and content of a list containing
-                only installed packages and combinations thereof."""
-
-                api_obj = self.get_img_api_obj()
-
-                # Verify no installed packages case.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED,
-                    api_obj=api_obj)
-                self.assertEqual(len(returned), 0)
-
-                # Test results after installing packages and only listing the
-                # installed packages.  Note that the 'obsolete' and renamed packages
-                # won't be installed.
-                af = self.__get_pub_entry("test1", 3, "apple",
-                    "1.2.0,5.11-0")[0]
-                for pd in api_obj.gen_plan_install(
-                    ["entire", af.get_fmri(), "corge", "obsolete", "qux"]):
+                t, summ, pcats, states = self.__get_expected_entry(
+                    pub, stem, ver
+                )
+                if cats is not None:
+                    if not cats:
+                        if pcats:
+                            # Want packages with no
+                            # category.
+                            continue
+                    elif not [sc for sc in cats if sc in pcats]:
+                        # Doesn't match specified
+                        # categories.
                         continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                # Verify the results for LIST_INSTALLED.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED,
-                    api_obj=api_obj)
-                self.assertEqual(len(returned), 4)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0", installed=True),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11",
-                        installed=True)
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Verify the results for LIST_INSTALLED_NEWEST.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0", installed=True),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11", installed=False),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11", installed=False),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11", installed=False),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11", installed=False),
-                ]
-
-                self.assertEqual(len(returned), 16)
-                self.assertEqualDiff(expected, returned)
-
-                # Re-test, including variants.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0", installed=True),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 10, "baz", "1.3,5.11"),
-                    self.__get_exp_pub_entry("test2", 10, "baz", "1.3,5.11"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 20, "zoo", "2.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test2", 20, "zoo", "2.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11", installed=False),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11", installed=False),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11", installed=False),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11", installed=False),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Verify results of LIST_INSTALLED_NEWEST when not including
-                # the publisher of installed packages.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj, pubs=["test2"])
-
-                expected = [
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 12, "corge",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0", installed=True),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 19, "zoo",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Verify the results for LIST_INSTALLED_NEWEST after
-                # uninstalling 'quux' and 'qux'.
-                for pd in api_obj.gen_plan_uninstall(["quux"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0", installed=True),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11",
-                        installed=False),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Verify the results for LIST_INSTALLED_NEWEST after
-                # all packages have been uninstalled.
-                for pd in api_obj.gen_plan_uninstall(["*"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 6, "apple",
-                        "1.2.1,5.11-1"),
-                    self.__get_exp_pub_entry("test2", 6, "apple",
-                        "1.2.1,5.11-1"),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 13, "entire", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 18, "qux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 18, "qux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Re-test, including variants.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 6, "apple",
-                        "1.2.1,5.11-1"),
-                    self.__get_exp_pub_entry("test2", 6, "apple",
-                        "1.2.1,5.11-1"),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 10, "baz", "1.3,5.11"),
-                    self.__get_exp_pub_entry("test2", 10, "baz", "1.3,5.11"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 13, "entire",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 13, "entire", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 18, "qux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 18, "qux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 20, "zoo", "2.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 20, "zoo", "2.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Re-test, including only a specific package version, which
-                # should show the requested versions even though newer
-                # versions are available.  'baz' should be omitted because
-                # it doesn't apply to the current image variants; so should
-                # zoo@2.0.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj, patterns=["apple@1.0,5.11.0", "baz",
-                        "qux@0.9", "zoo@2.0"])
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 1, "apple", "1.0,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 1, "apple", "1.0,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11"),
-                    self.__get_exp_pub_entry("test2", 17, "qux", "0.9,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Re-test, including only a specific package version, which
-                # should show the requested versions even though newer
-                # versions are available, and all variants.  'baz' should be
-                # included this time; as should zoo@2.0.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj, patterns=["apple@1.0,5.11.0", "baz",
-                        "qux@0.9", "zoo@2.0"], variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 1, "apple", "1.0,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 1, "apple", "1.0,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 10, "baz", "1.3,5.11"),
-                    self.__get_exp_pub_entry("test2", 10, "baz", "1.3,5.11"),
-                    self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11"),
-                    self.__get_exp_pub_entry("test2", 17, "qux", "0.9,5.11"),
-                    self.__get_exp_pub_entry("test1", 20, "zoo", "2.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 20, "zoo", "2.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Test results after installing packages and only listing the
-                # installed packages.
-                af = self.__get_pub_entry("test1", 1, "apple", "1.0,5.11-0")[0]
-                for pd in api_obj.gen_plan_install(
-                    [af.get_fmri(), "qux@0.9", "corge@0.9"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                # Verify the results for LIST_INSTALLED and
-                # LIST_INSTALLED_NEWEST when future versions
-                # are renamed and current versions are not
-                # incorporated.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 1, "apple", "1.0,5.11-0",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 11, "corge", "0.9,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11",
-                        installed=True),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 3)
-
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 1, "apple", "1.0,5.11-0",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 11, "corge", "0.9,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 13, "entire", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Re-test last but specify patterns for versions newer than
-                # what is installed; nothing should be returned as
-                # LIST_INSTALLED_NEWEST is supposed to omit versions newer
-                # than what is installed, allowed by installed incorporations,
-                # or doesn't apply to image variants.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj, patterns=["apple@1.2.1,5.11-1",
-                        "corge@1.0", "qux@1.0"])
-                expected = []
-                self.assertEqualDiff(expected, returned)
-
-                # Remove corge, install grault, retest for
-                # LIST_INSTALLED_NEWEST.  corge, grault, qux, and
-                # quux should be listed since none of them are
-                # listed in an installed incorporation.
-                for pd in api_obj.gen_plan_uninstall(["corge"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                af = self.__get_pub_entry("test1", 1, "apple", "1.0,5.11-0")[0]
-                for pd in api_obj.gen_plan_install(["pkg://test2/grault"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 1, "apple", "1.0,5.11-0",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 13, "entire", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Now verify that publisher search order determines the entries
-                # that are listed when those entries are part of an installed
-                # incorporation.
-                for pd in api_obj.gen_plan_uninstall(["*"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                for pd in api_obj.gen_plan_install(["entire"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                # In this case, any packages present in an installed
-                # incorporation and that are not installed should be
-                # listed using the highest ranked publisher (test1).
-                # Only apple and quux are incorporated, and build
-                # 0 of apple should be listed here instead of build 1
-                # since the installed incorporation doesn't allow the
-                # build 1 version.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 5, "apple",
-                        "1.2.1,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Re-test, specifying versions older than the newest, with
-                # some older than that allowed by the incorporation (should
-                # be omitted) and with versions allowed by the incorporation
-                # (should be returned).
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj, patterns=["apple@1.2.0,5.11-0", "qux@0.9"])
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Re-test, specifying versions newer than that allowed by the
-                # incorporation.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj, patterns=["apple@1.2.1,5.11-1"])
-                self.assertEqual(len(returned), 0)
-
-                # Re-test, only including test1's packages.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj, pubs=["test1"])
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 5, "apple",
-                        "1.2.1,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Re-test, only including test2's packages.  Since none of
-                # the other packages are installed for test1, and they meet
-                # the requirements of the installed incorporations, this is
-                # the expected result.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj, pubs=["test2"])
-
-                expected = [
-                    self.__get_exp_pub_entry("test2", 5, "apple",
-                        "1.2.1,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Change test2 to be ranked higher than test1.
-                pub = api_obj.get_publisher(prefix="test2", duplicate=True)
-                api_obj.update_publisher(pub, search_before="test1")
-
-                # Re-test; test2 should now have its entries listed in place
-                # of test1's for the non-filtered case.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test2", 5, "apple",
-                        "1.2.1,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Now install one of the incorporated packages and check
-                # that test2 is still listed for the remaining package
-                # for the non-filtered case.
-                for pd in api_obj.gen_plan_install(["apple"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test2", 5, "apple",
-                        "1.2.1,5.11-0", installed=True),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Reset publisher search order and re-test.
-                pub = api_obj.get_publisher(prefix="test1", duplicate=True)
-                api_obj.update_publisher(pub, search_before="test2")
-
-                returned = self.__get_returned(api_obj.LIST_INSTALLED_NEWEST,
-                    api_obj=api_obj)
-
-                expected = [
-                    self.__get_exp_pub_entry("test2", 5, "apple",
-                        "1.2.1,5.11-0", installed=True),
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 21, "zzcowley",
-                        "1.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 22, "zzfenix",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Reset image state for following tests.
-                for pd in api_obj.gen_plan_uninstall(["*"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-        def test_list_06_upgradable(self):
-                """Verify the sort order and content of a list containing
-                only upgradable packages and combinations thereof."""
-
-                api_obj = self.get_img_api_obj()
-
-                # Verify no installed packages case.
-                returned = self.__get_returned(api_obj.LIST_UPGRADABLE,
-                    api_obj=api_obj)
-                self.assertEqual(len(returned), 0)
-
-                # Test results after installing packages and only listing the
-                # installed, upgradable packages.
-                af = self.__get_pub_entry("test1", 3, "apple",
-                    "1.2.0,5.11-0")[0]
-                for pd in api_obj.gen_plan_install(
-                    [af.get_fmri(), "bat/bar", "qux"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                # Verify the results for LIST_UPGRADABLE.
-                returned = self.__get_returned(api_obj.LIST_UPGRADABLE,
-                    api_obj=api_obj)
-                self.assertEqual(len(returned), 1)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0", installed=True),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Verify the results for LIST_UPGRADABLE when publisher
-                # repository no longer has installed package.
-                self.pkg("unset-publisher test2")
-                self.pkg("set-publisher -G '*' -g {0} test1".format(self.rurl4))
-                api_obj = self.get_img_api_obj()
-
-                returned = self.__get_returned(api_obj.LIST_UPGRADABLE,
-                    api_obj=api_obj)
-                self.assertEqualDiff([], returned)
-
-                # Reset image state for following tests.
-                self.pkg("set-publisher -G '*' -g " + self.rurl1 + " test1")
-                self.pkg("set-publisher -p " + self.rurl2)
-                for pd in api_obj.gen_plan_uninstall(["*"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-        def test_list_06b_removable(self):
-                """Verify the sort order and content of a list containing
-                only removable packages and combinations thereof."""
-
-                api_obj = self.get_img_api_obj()
-
-                # Verify no installed packages case.
-                returned = self.__get_returned(api_obj.LIST_REMOVABLE,
-                    api_obj=api_obj)
-                self.assertEqual(len(returned), 0)
-
-                # Test results after installing packages and only listing the
-                # installed, removable packages.
-                #
-                # qux was renamed to quux
-                # zzfenix depends on zzcowley
-                af = self.__get_pub_entry("test1", 3, "apple",
-                    "1.2.0,5.11-0")[0]
-                for pd in api_obj.gen_plan_install(
-                    [af.get_fmri(), "zzfenix", "qux"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-                # Verify what is installed.
-                returned = self.__get_returned(api_obj.LIST_INSTALLED,
-                    api_obj=api_obj)
-                self.assertEqual(len(returned), 4)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0", installed=True),
-                    self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11",
-                        installed=True),
-                    self.__get_exp_pub_entry("test1", 21, "zzcowley",
-                        "1.1,5.11", installed=True),
-                    self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11",
-                        installed=True),
-                ]
-                self.assertEqualDiff(expected, returned)
-
-                # Verify the results for LIST_REMOVABLE.
-                returned = self.__get_returned(api_obj.LIST_REMOVABLE,
-                    api_obj=api_obj)
-
-                # zzcowley is not removable
-                expected.pop(2)
-
-                self.assertEqual(len(returned), 3)
-                self.assertEqualDiff(expected, returned)
-
-                # Reset image state for following tests.
-                for pd in api_obj.gen_plan_uninstall(["*"]):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
-
-        def test_list_07_get_pkg_categories(self):
-                """Verify that get_pkg_categories returns expected results."""
-
-                api_obj = self.get_img_api_obj()
-
-                # Verify no installed packages case.
-                returned = api_obj.get_pkg_categories(installed=True)
-                self.assertEqual(len(returned), 0)
-
-                def get_pkg_cats(p):
-                        stem, ver = p.split("@")
-
-                        sver = version.Version(ver)
-                        sver = str(sver).split(":", 1)[0]
-                        raw_cats = self.__get_pkg_cats(stem, sver)
-
-                        pcats = []
-                        for e in raw_cats:
-                                if e and ":" in e:
-                                        scheme, cat = e.split(":", 1)
-                                else:
-                                        scheme = ""
-                                        cat = e
-                                pcats.append((scheme, cat))
-                        return pcats
-
-                # Verify all case.
-                returned = api_obj.get_pkg_categories()
-                all_pkgs = self.packages
-                all_cats = sorted(set(
-                    sc
-                    for p in all_pkgs
-                    for sc in get_pkg_cats(p)
-                ))
-                self.assertEqualDiff(all_cats, returned)
-
-                # Verify all case with a few different pub combos.
-                combos = [
-                    (["test1", "test2"], all_cats),
-                    (["test1"], all_cats),
-                    (["test2"], all_cats),
-                    (["test3"], []),
-                    ([], all_cats),
-                ]
-
-                for combo, expected in combos:
-                        returned = api_obj.get_pkg_categories(pubs=combo)
-                        self.assertEqualDiff(expected, returned)
-
-                # Now install different sets of packages and ensure the
-                # results match what is expected.
-                combos = [
-                    [
-                        self.dlist1[6], # "apple@1.2.1,5.11-1"
-                        self.dlist1[7], # "bar@1.2,5.11-0"
-                    ],
-                    [
-                        self.dlist1[12], # "corge@1.0"
-                        self.dlist1[14], # "grault@1.0"
-                    ],
-                    [
-                        self.dlist1[16], # "quux@1.0"
-                    ],
-                ]
-
-                for combo in combos:
-                        pkgs = [
-                            f.get_fmri(anarchy=True, include_scheme=False)
-                            for f in combo
-                        ]
-                        for pd in api_obj.gen_plan_install(pkgs):
-                                continue
-                        api_obj.prepare()
-                        api_obj.execute_plan()
-                        api_obj.reset()
-
-                        returned = api_obj.get_pkg_categories(installed=True)
-                        expected = sorted(set(
-                            sc
-                            for p in pkgs
-                            for sc in get_pkg_cats(p)
-                        ))
-                        self.assertEqualDiff(expected, returned)
-
-                        # Prepare for next test.
-                        # skip corge since it's renamed
-                        for pd in api_obj.gen_plan_uninstall([
-                                p
-                                for p in pkgs
-                                if not p.startswith("corge@1.0")
-                            ]):
-                                continue
-                        api_obj.prepare()
-                        api_obj.execute_plan()
-                        api_obj.reset()
-
-        def test_list_08_patterns(self):
-                """Verify that pattern filtering works as expected."""
-
-                api_obj = self.get_img_api_obj()
-
-                # First, check all variants, but with multiple patterns for the
-                # partial, exact, and wildcard match cases.
-                patterns = ["bar", "pkg:/baz", "*obs*"]
-                returned = self.__get_returned(api_obj.LIST_ALL,
-                    api_obj=api_obj, patterns=patterns, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test1", 10, "baz", "1.3,5.11"),
-                    self.__get_exp_pub_entry("test1", 9, "baz", "1.0.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 8, "baz", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 10, "baz", "1.3,5.11"),
-                    self.__get_exp_pub_entry("test2", 9, "baz", "1.0.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 8, "baz", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 10)
-
-                # Next, check all variants, but with exact and partial match.
-                patterns = ["pkg:/bar", "obsolete"]
-                returned = self.__get_returned(api_obj.LIST_ALL,
-                    api_obj=api_obj, patterns=patterns, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 15, "obsolete",
-                        "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 15, "obsolete",
-                        "1.0,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 2)
-
-                # Next, check all variants, but for publisher and exact
-                # match case only.
-                patterns = ["pkg://test2/bat/bar"]
-                returned = self.__get_returned(api_obj.LIST_ALL,
-                    api_obj=api_obj, patterns=patterns, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 1)
-
-                # Should return no matches.
-                patterns = ["pkg://test2/bar"]
-                returned = self.__get_returned(api_obj.LIST_ALL,
-                    api_obj=api_obj, patterns=patterns, variants=True)
-                expected = []
-                self.assertEqualDiff(expected, returned)
-
-                # Next, check all variants, but for exact match case only.
-                patterns = ["pkg:/bat/bar"]
-                returned = self.__get_returned(api_obj.LIST_ALL,
-                    api_obj=api_obj, patterns=patterns, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 7, "bat/bar",
-                        "1.2,5.11-0"),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 2)
-
-                # Next, check version matching for a single pattern.
-                patterns = ["apple@1.2.0"]
-                returned = self.__get_returned(api_obj.LIST_ALL,
-                    api_obj=api_obj, patterns=patterns, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 3, "apple",
-                        "1.2.0,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 3, "apple",
-                        "1.2.0,5.11-0"),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 2)
-
-                patterns = ["apple@1.0"]
-                returned = self.__get_returned(api_obj.LIST_ALL,
-                    api_obj=api_obj, patterns=patterns, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 1, "apple",
-                        "1.0,5.11-0"),
-                    self.__get_exp_pub_entry("test2", 1, "apple",
-                        "1.0,5.11-0"),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 2)
-
-                patterns = ["apple@*,*-1"]
-                returned = self.__get_returned(api_obj.LIST_ALL,
-                    api_obj=api_obj, patterns=patterns, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 6, "apple",
-                        "1.2.1,5.11-1"),
-                    self.__get_exp_pub_entry("test2", 6, "apple",
-                        "1.2.1,5.11-1"),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 2)
-
-                # Next, check version matching for multiple patterns.
-                patterns = ["baz@1.0", "pkg:/obsolete@1.1",
-                    "pkg://test1/qux@0.9"]
-                returned = self.__get_returned(api_obj.LIST_ALL,
-                    api_obj=api_obj, patterns=patterns, variants=True)
-
-                expected = [
-                    self.__get_exp_pub_entry("test1", 9, "baz", "1.0.1,5.11"),
-                    self.__get_exp_pub_entry("test1", 8, "baz", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test2", 9, "baz", "1.0.1,5.11"),
-                    self.__get_exp_pub_entry("test2", 8, "baz", "1.0,5.11"),
-                    self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11"),
-                ]
-                self.assertEqualDiff(expected, returned)
-                self.assertEqual(len(returned), 5)
-
-                # Finally, verify that specifying an illegal pattern will
-                # raise an InventoryException.
-                patterns = ["baz@1.*.a"]
-                expected = [
-                    version.IllegalVersion(
-                        "Bad Version: {0}".format(p.split("@", 1)[-1]))
-                    for p in patterns
-                ]
-                try:
-                        returned = self.__get_returned(api_obj.LIST_ALL,
-                            api_obj=api_obj, patterns=patterns, variants=True)
-                except api_errors.InventoryException as e:
-                        self.assertEqualDiff(expected, e.illegal)
+
+                expected.append((t, summ, pcats, states))
+
+        def pkg_list_order(a, b):
+            at = a[0]
+            bt = b[0]
+            return self.__tuple_order(at, bt)
+
+        expected.sort(key=cmp_to_key(pkg_list_order))
+        return expected
+
+    def __get_returned(
+        self,
+        pkg_list,
+        api_obj=None,
+        cats=None,
+        num_expected=None,
+        patterns=misc.EmptyI,
+        pubs=misc.EmptyI,
+        variants=False,
+    ):
+        if not api_obj:
+            api_obj = self.get_img_api_obj()
+
+        # Set of states exposed by the API.
+        exp_states = set(
+            [
+                api.PackageInfo.FROZEN,
+                api.PackageInfo.INCORPORATED,
+                api.PackageInfo.EXCLUDES,
+                api.PackageInfo.KNOWN,
+                api.PackageInfo.INSTALLED,
+                api.PackageInfo.UPGRADABLE,
+                api.PackageInfo.OBSOLETE,
+                api.PackageInfo.RENAMED,
+            ]
+        )
+
+        # Get ordered list of all packages.
+        returned = []
+        for entry in api_obj.get_pkg_list(
+            pkg_list, cats=cats, patterns=patterns, pubs=pubs, variants=variants
+        ):
+            (pub, stem, ver), summ, pcats, raw_states, attrs = entry
+
+            sver = ver.split(":", 1)[0]
+
+            # Eliminate states not exposed by the api.
+            states = raw_states.intersection(exp_states)
+            returned.append(((pub, stem, ver), summ, pcats, states))
+        return returned
+
+    def __test_list(
+        self,
+        pkg_list,
+        api_obj=None,
+        cats=None,
+        num_expected=None,
+        pubs=misc.EmptyI,
+        variants=False,
+    ):
+        # Get package list.
+        returned = self.__get_returned(
+            pkg_list, api_obj=api_obj, cats=cats, pubs=pubs, variants=variants
+        )
+
+        # Now generate expected list.
+        expected = self.__get_expected(
+            pkg_list, cats=cats, pubs=pubs, variants=variants
+        )
+
+        # Compare returned and expected.
+        self.assertEqualDiff(expected, returned)
+
+        self.debug(pprint.pformat(returned))
+        if num_expected is not None:
+            self.assertEqual(len(returned), num_expected)
+
+    def test_list_01_full(self):
+        """Verify the sort order and content of a full list and
+        combinations thereof."""
+
+        api_obj = self.get_img_api_obj()
+
+        # First check all variants case.
+        returned = self.__get_returned(
+            api_obj.LIST_ALL, api_obj=api_obj, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 6, "apple", "1.2.1,5.11-1"),
+            self.__get_exp_pub_entry("test1", 5, "apple", "1.2.1,5.11-0"),
+            self.__get_exp_pub_entry("test1", 4, "apple", "1.2.1,5.11-0"),
+            self.__get_exp_pub_entry("test1", 3, "apple", "1.2.0,5.11-0"),
+            self.__get_exp_pub_entry("test1", 2, "apple", "1.1,5.11-0"),
+            self.__get_exp_pub_entry("test1", 1, "apple", "1.0,5.11-0"),
+            self.__get_exp_pub_entry("test1", 0, "apple", "1,5.11-0"),
+            self.__get_exp_pub_entry("test2", 6, "apple", "1.2.1,5.11-1"),
+            self.__get_exp_pub_entry("test2", 5, "apple", "1.2.1,5.11-0"),
+            self.__get_exp_pub_entry("test2", 4, "apple", "1.2.1,5.11-0"),
+            self.__get_exp_pub_entry("test2", 3, "apple", "1.2.0,5.11-0"),
+            self.__get_exp_pub_entry("test2", 2, "apple", "1.1,5.11-0"),
+            self.__get_exp_pub_entry("test2", 1, "apple", "1.0,5.11-0"),
+            self.__get_exp_pub_entry("test2", 0, "apple", "1,5.11-0"),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 10, "baz", "1.3,5.11"),
+            self.__get_exp_pub_entry("test1", 9, "baz", "1.0.1,5.11"),
+            self.__get_exp_pub_entry("test1", 8, "baz", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 10, "baz", "1.3,5.11"),
+            self.__get_exp_pub_entry("test2", 9, "baz", "1.0.1,5.11"),
+            self.__get_exp_pub_entry("test2", 8, "baz", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 11, "corge", "0.9,5.11"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 11, "corge", "0.9,5.11"),
+            self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 13, "entire", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 18, "qux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11"),
+            self.__get_exp_pub_entry("test2", 18, "qux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 17, "qux", "0.9,5.11"),
+            self.__get_exp_pub_entry("test1", 20, "zoo", "2.0,5.11"),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 20, "zoo", "2.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 46)
+
+        # Next, check no variants case (which has to be done
+        # programatically).
+        self.__test_list(
+            api.ImageInterface.LIST_ALL,
+            api_obj=api_obj,
+            num_expected=38,
+            variants=False,
+        )
+
+    def test_list_02_newest(self):
+        """Verify the sort order and content of a list excluding
+        packages not for the current image variant, and all but
+        the newest versions of each package for each publisher."""
+
+        self.__test_list(
+            api.ImageInterface.LIST_NEWEST, num_expected=22, variants=False
+        )
+
+        # Verify that LIST_NEWEST will allow version-specific
+        # patterns such that the newest version allowed by the
+        # pattern is what is listed.
+        api_obj = self.get_img_api_obj()
+
+        returned = self.__get_returned(
+            api_obj.LIST_NEWEST,
+            api_obj=api_obj,
+            patterns=["baz@1.0", "bat/bar", "corge@1.0"],
+            variants=True,
+        )
+        expected = [
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 9, "baz", "1.0.1,5.11"),
+            self.__get_exp_pub_entry("test2", 9, "baz", "1.0.1,5.11"),
+            self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 6)
+
+        returned = self.__get_returned(
+            api_obj.LIST_NEWEST,
+            api_obj=api_obj,
+            patterns=["apple@*", "bat/bar"],
+            variants=True,
+        )
+        expected = [
+            self.__get_exp_pub_entry("test1", 6, "apple", "1.2.1,5.11-1"),
+            self.__get_exp_pub_entry("test2", 6, "apple", "1.2.1,5.11-1"),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 4)
+
+        returned = self.__get_returned(
+            api_obj.LIST_NEWEST,
+            api_obj=api_obj,
+            patterns=["apple@1.2.0"],
+            variants=True,
+        )
+        expected = [
+            self.__get_exp_pub_entry("test1", 3, "apple", "1.2.0,5.11-0"),
+            self.__get_exp_pub_entry("test2", 3, "apple", "1.2.0,5.11-0"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 2)
+
+    def test_list_03_cats(self):
+        """Verify the sort order and content of a list excluding
+        packages not for the current image variant, and packages
+        that don't match the specified scheme, category
+        combinations."""
+
+        combos = [
+            (
+                [
+                    ("", "fruit"),
+                    (
+                        "org.opensolaris.category.2008",
+                        "Applications/Sound and Video",
+                    ),
+                    ("", "food"),
+                    ("org.opensolaris.category.2008", "Development/Python"),
+                ],
+                16,
+            ),
+            ([("org.opensolaris.category.2008", "Development/Python")], 2),
+            (
+                [
+                    (
+                        "org.opensolaris.category.2008",
+                        "Applications/Sound and Video",
+                    ),
+                    ("", "food"),
+                ],
+                16,
+            ),
+            ([("", "fruit")], 14),
+            ([("", "food")], 2),
+            ([], 22),  # Only packages with no category assigned.
+        ]
+
+        for combo, expected in combos:
+            self.__test_list(
+                api.ImageInterface.LIST_ALL,
+                cats=combo,
+                num_expected=expected,
+                variants=False,
+            )
+
+    def test_list_04_pubs(self):
+        """Verify the sort order and content of list filtered using
+        various publisher and variant combinations."""
+
+        combos = [
+            (["test1", "test2"], 38, False),
+            (["test1", "test2"], 46, True),
+            (["test2"], 19, False),
+            (["test2"], 23, True),
+            (["test1"], 19, False),
+            (["test1"], 23, True),
+            (["test3"], 0, False),
+            (["test3"], 0, True),
+            ([], 38, False),
+            ([], 46, True),
+        ]
+
+        for combo, expected, variants in combos:
+            self.__test_list(
+                api.ImageInterface.LIST_ALL,
+                num_expected=expected,
+                pubs=combo,
+                variants=variants,
+            )
+
+    def test_list_05_installed(self):
+        """Verify the sort order and content of a list containing
+        only installed packages and combinations thereof."""
+
+        api_obj = self.get_img_api_obj()
+
+        # Verify no installed packages case.
+        returned = self.__get_returned(api_obj.LIST_INSTALLED, api_obj=api_obj)
+        self.assertEqual(len(returned), 0)
+
+        # Test results after installing packages and only listing the
+        # installed packages.  Note that the 'obsolete' and renamed packages
+        # won't be installed.
+        af = self.__get_pub_entry("test1", 3, "apple", "1.2.0,5.11-0")[0]
+        for pd in api_obj.gen_plan_install(
+            ["entire", af.get_fmri(), "corge", "obsolete", "qux"]
+        ):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        # Verify the results for LIST_INSTALLED.
+        returned = self.__get_returned(api_obj.LIST_INSTALLED, api_obj=api_obj)
+        self.assertEqual(len(returned), 4)
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test1", 3, "apple", "1.2.0,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 13, "entire", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 14, "grault", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 16, "quux", "1.0,5.11", installed=True
+            ),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Verify the results for LIST_INSTALLED_NEWEST.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj
+        )
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test1", 3, "apple", "1.2.0,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry(
+                "test1", 12, "corge", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test2", 12, "corge", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 13, "entire", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 14, "grault", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 16, "quux", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 19, "zoo", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test2", 19, "zoo", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 21, "zzcowley", "1.1,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test2", 21, "zzcowley", "1.1,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 22, "zzfenix", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test2", 22, "zzfenix", "1.0,5.11", installed=False
+            ),
+        ]
+
+        self.assertEqual(len(returned), 16)
+        self.assertEqualDiff(expected, returned)
+
+        # Re-test, including variants.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test1", 3, "apple", "1.2.0,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 10, "baz", "1.3,5.11"),
+            self.__get_exp_pub_entry("test2", 10, "baz", "1.3,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 12, "corge", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test2", 12, "corge", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 13, "entire", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 14, "grault", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 16, "quux", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 20, "zoo", "2.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test2", 20, "zoo", "2.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 21, "zzcowley", "1.1,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test2", 21, "zzcowley", "1.1,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 22, "zzfenix", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test2", 22, "zzfenix", "1.0,5.11", installed=False
+            ),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Verify results of LIST_INSTALLED_NEWEST when not including
+        # the publisher of installed packages.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj, pubs=["test2"]
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj
+        )
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test1", 3, "apple", "1.2.0,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry(
+                "test1", 12, "corge", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test2", 12, "corge", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 13, "entire", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 14, "grault", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 16, "quux", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Verify the results for LIST_INSTALLED_NEWEST after
+        # uninstalling 'quux' and 'qux'.
+        for pd in api_obj.gen_plan_uninstall(["quux"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj
+        )
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test1", 3, "apple", "1.2.0,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry(
+                "test1", 12, "corge", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test2", 12, "corge", "1.0,5.11", installed=False
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 13, "entire", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 14, "grault", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Verify the results for LIST_INSTALLED_NEWEST after
+        # all packages have been uninstalled.
+        for pd in api_obj.gen_plan_uninstall(["*"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 6, "apple", "1.2.1,5.11-1"),
+            self.__get_exp_pub_entry("test2", 6, "apple", "1.2.1,5.11-1"),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 13, "entire", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 18, "qux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 18, "qux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Re-test, including variants.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 6, "apple", "1.2.1,5.11-1"),
+            self.__get_exp_pub_entry("test2", 6, "apple", "1.2.1,5.11-1"),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 10, "baz", "1.3,5.11"),
+            self.__get_exp_pub_entry("test2", 10, "baz", "1.3,5.11"),
+            self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 13, "entire", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 18, "qux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 18, "qux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 20, "zoo", "2.0,5.11"),
+            self.__get_exp_pub_entry("test2", 20, "zoo", "2.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Re-test, including only a specific package version, which
+        # should show the requested versions even though newer
+        # versions are available.  'baz' should be omitted because
+        # it doesn't apply to the current image variants; so should
+        # zoo@2.0.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST,
+            api_obj=api_obj,
+            patterns=["apple@1.0,5.11.0", "baz", "qux@0.9", "zoo@2.0"],
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 1, "apple", "1.0,5.11-0"),
+            self.__get_exp_pub_entry("test2", 1, "apple", "1.0,5.11-0"),
+            self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11"),
+            self.__get_exp_pub_entry("test2", 17, "qux", "0.9,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Re-test, including only a specific package version, which
+        # should show the requested versions even though newer
+        # versions are available, and all variants.  'baz' should be
+        # included this time; as should zoo@2.0.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST,
+            api_obj=api_obj,
+            patterns=["apple@1.0,5.11.0", "baz", "qux@0.9", "zoo@2.0"],
+            variants=True,
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 1, "apple", "1.0,5.11-0"),
+            self.__get_exp_pub_entry("test2", 1, "apple", "1.0,5.11-0"),
+            self.__get_exp_pub_entry("test1", 10, "baz", "1.3,5.11"),
+            self.__get_exp_pub_entry("test2", 10, "baz", "1.3,5.11"),
+            self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11"),
+            self.__get_exp_pub_entry("test2", 17, "qux", "0.9,5.11"),
+            self.__get_exp_pub_entry("test1", 20, "zoo", "2.0,5.11"),
+            self.__get_exp_pub_entry("test2", 20, "zoo", "2.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Test results after installing packages and only listing the
+        # installed packages.
+        af = self.__get_pub_entry("test1", 1, "apple", "1.0,5.11-0")[0]
+        for pd in api_obj.gen_plan_install(
+            [af.get_fmri(), "qux@0.9", "corge@0.9"]
+        ):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        # Verify the results for LIST_INSTALLED and
+        # LIST_INSTALLED_NEWEST when future versions
+        # are renamed and current versions are not
+        # incorporated.
+        returned = self.__get_returned(api_obj.LIST_INSTALLED, api_obj=api_obj)
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test1", 1, "apple", "1.0,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 11, "corge", "0.9,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 17, "qux", "0.9,5.11", installed=True
+            ),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 3)
+
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj
+        )
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test1", 1, "apple", "1.0,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry(
+                "test1", 11, "corge", "0.9,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 13, "entire", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 17, "qux", "0.9,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Re-test last but specify patterns for versions newer than
+        # what is installed; nothing should be returned as
+        # LIST_INSTALLED_NEWEST is supposed to omit versions newer
+        # than what is installed, allowed by installed incorporations,
+        # or doesn't apply to image variants.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST,
+            api_obj=api_obj,
+            patterns=["apple@1.2.1,5.11-1", "corge@1.0", "qux@1.0"],
+        )
+        expected = []
+        self.assertEqualDiff(expected, returned)
+
+        # Remove corge, install grault, retest for
+        # LIST_INSTALLED_NEWEST.  corge, grault, qux, and
+        # quux should be listed since none of them are
+        # listed in an installed incorporation.
+        for pd in api_obj.gen_plan_uninstall(["corge"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        af = self.__get_pub_entry("test1", 1, "apple", "1.0,5.11-0")[0]
+        for pd in api_obj.gen_plan_install(["pkg://test2/grault"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj
+        )
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test1", 1, "apple", "1.0,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 13, "entire", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 13, "entire", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test2", 14, "grault", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 17, "qux", "0.9,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Now verify that publisher search order determines the entries
+        # that are listed when those entries are part of an installed
+        # incorporation.
+        for pd in api_obj.gen_plan_uninstall(["*"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        for pd in api_obj.gen_plan_install(["entire"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        # In this case, any packages present in an installed
+        # incorporation and that are not installed should be
+        # listed using the highest ranked publisher (test1).
+        # Only apple and quux are incorporated, and build
+        # 0 of apple should be listed here instead of build 1
+        # since the installed incorporation doesn't allow the
+        # build 1 version.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 5, "apple", "1.2.1,5.11-0"),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 13, "entire", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Re-test, specifying versions older than the newest, with
+        # some older than that allowed by the incorporation (should
+        # be omitted) and with versions allowed by the incorporation
+        # (should be returned).
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST,
+            api_obj=api_obj,
+            patterns=["apple@1.2.0,5.11-0", "qux@0.9"],
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 3, "apple", "1.2.0,5.11-0"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Re-test, specifying versions newer than that allowed by the
+        # incorporation.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST,
+            api_obj=api_obj,
+            patterns=["apple@1.2.1,5.11-1"],
+        )
+        self.assertEqual(len(returned), 0)
+
+        # Re-test, only including test1's packages.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj, pubs=["test1"]
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 5, "apple", "1.2.1,5.11-0"),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 13, "entire", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Re-test, only including test2's packages.  Since none of
+        # the other packages are installed for test1, and they meet
+        # the requirements of the installed incorporations, this is
+        # the expected result.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj, pubs=["test2"]
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test2", 5, "apple", "1.2.1,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Change test2 to be ranked higher than test1.
+        pub = api_obj.get_publisher(prefix="test2", duplicate=True)
+        api_obj.update_publisher(pub, search_before="test1")
+
+        # Re-test; test2 should now have its entries listed in place
+        # of test1's for the non-filtered case.
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test2", 5, "apple", "1.2.1,5.11-0"),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 13, "entire", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Now install one of the incorporated packages and check
+        # that test2 is still listed for the remaining package
+        # for the non-filtered case.
+        for pd in api_obj.gen_plan_install(["apple"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj
+        )
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test2", 5, "apple", "1.2.1,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 13, "entire", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Reset publisher search order and re-test.
+        pub = api_obj.get_publisher(prefix="test1", duplicate=True)
+        api_obj.update_publisher(pub, search_before="test2")
+
+        returned = self.__get_returned(
+            api_obj.LIST_INSTALLED_NEWEST, api_obj=api_obj
+        )
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test2", 5, "apple", "1.2.1,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 12, "corge", "1.0,5.11"),
+            self.__get_exp_pub_entry(
+                "test1", 13, "entire", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry("test1", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 14, "grault", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 16, "quux", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 19, "zoo", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test2", 21, "zzcowley", "1.1,5.11"),
+            self.__get_exp_pub_entry("test1", 22, "zzfenix", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 22, "zzfenix", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Reset image state for following tests.
+        for pd in api_obj.gen_plan_uninstall(["*"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+    def test_list_06_upgradable(self):
+        """Verify the sort order and content of a list containing
+        only upgradable packages and combinations thereof."""
+
+        api_obj = self.get_img_api_obj()
+
+        # Verify no installed packages case.
+        returned = self.__get_returned(api_obj.LIST_UPGRADABLE, api_obj=api_obj)
+        self.assertEqual(len(returned), 0)
+
+        # Test results after installing packages and only listing the
+        # installed, upgradable packages.
+        af = self.__get_pub_entry("test1", 3, "apple", "1.2.0,5.11-0")[0]
+        for pd in api_obj.gen_plan_install([af.get_fmri(), "bat/bar", "qux"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        # Verify the results for LIST_UPGRADABLE.
+        returned = self.__get_returned(api_obj.LIST_UPGRADABLE, api_obj=api_obj)
+        self.assertEqual(len(returned), 1)
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test1", 3, "apple", "1.2.0,5.11-0", installed=True
+            ),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Verify the results for LIST_UPGRADABLE when publisher
+        # repository no longer has installed package.
+        self.pkg("unset-publisher test2")
+        self.pkg("set-publisher -G '*' -g {0} test1".format(self.rurl4))
+        api_obj = self.get_img_api_obj()
+
+        returned = self.__get_returned(api_obj.LIST_UPGRADABLE, api_obj=api_obj)
+        self.assertEqualDiff([], returned)
+
+        # Reset image state for following tests.
+        self.pkg("set-publisher -G '*' -g " + self.rurl1 + " test1")
+        self.pkg("set-publisher -p " + self.rurl2)
+        for pd in api_obj.gen_plan_uninstall(["*"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+    def test_list_06b_removable(self):
+        """Verify the sort order and content of a list containing
+        only removable packages and combinations thereof."""
+
+        api_obj = self.get_img_api_obj()
+
+        # Verify no installed packages case.
+        returned = self.__get_returned(api_obj.LIST_REMOVABLE, api_obj=api_obj)
+        self.assertEqual(len(returned), 0)
+
+        # Test results after installing packages and only listing the
+        # installed, removable packages.
+        #
+        # qux was renamed to quux
+        # zzfenix depends on zzcowley
+        af = self.__get_pub_entry("test1", 3, "apple", "1.2.0,5.11-0")[0]
+        for pd in api_obj.gen_plan_install([af.get_fmri(), "zzfenix", "qux"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+        # Verify what is installed.
+        returned = self.__get_returned(api_obj.LIST_INSTALLED, api_obj=api_obj)
+        self.assertEqual(len(returned), 4)
+
+        expected = [
+            self.__get_exp_pub_entry(
+                "test1", 3, "apple", "1.2.0,5.11-0", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 16, "quux", "1.0,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 21, "zzcowley", "1.1,5.11", installed=True
+            ),
+            self.__get_exp_pub_entry(
+                "test1", 22, "zzfenix", "1.0,5.11", installed=True
+            ),
+        ]
+        self.assertEqualDiff(expected, returned)
+
+        # Verify the results for LIST_REMOVABLE.
+        returned = self.__get_returned(api_obj.LIST_REMOVABLE, api_obj=api_obj)
+
+        # zzcowley is not removable
+        expected.pop(2)
+
+        self.assertEqual(len(returned), 3)
+        self.assertEqualDiff(expected, returned)
+
+        # Reset image state for following tests.
+        for pd in api_obj.gen_plan_uninstall(["*"]):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
+
+    def test_list_07_get_pkg_categories(self):
+        """Verify that get_pkg_categories returns expected results."""
+
+        api_obj = self.get_img_api_obj()
+
+        # Verify no installed packages case.
+        returned = api_obj.get_pkg_categories(installed=True)
+        self.assertEqual(len(returned), 0)
+
+        def get_pkg_cats(p):
+            stem, ver = p.split("@")
+
+            sver = version.Version(ver)
+            sver = str(sver).split(":", 1)[0]
+            raw_cats = self.__get_pkg_cats(stem, sver)
+
+            pcats = []
+            for e in raw_cats:
+                if e and ":" in e:
+                    scheme, cat = e.split(":", 1)
                 else:
-                        raise RuntimeError("InventoryException not raised!")
+                    scheme = ""
+                    cat = e
+                pcats.append((scheme, cat))
+            return pcats
+
+        # Verify all case.
+        returned = api_obj.get_pkg_categories()
+        all_pkgs = self.packages
+        all_cats = sorted(set(sc for p in all_pkgs for sc in get_pkg_cats(p)))
+        self.assertEqualDiff(all_cats, returned)
+
+        # Verify all case with a few different pub combos.
+        combos = [
+            (["test1", "test2"], all_cats),
+            (["test1"], all_cats),
+            (["test2"], all_cats),
+            (["test3"], []),
+            ([], all_cats),
+        ]
+
+        for combo, expected in combos:
+            returned = api_obj.get_pkg_categories(pubs=combo)
+            self.assertEqualDiff(expected, returned)
+
+        # Now install different sets of packages and ensure the
+        # results match what is expected.
+        combos = [
+            [
+                self.dlist1[6],  # "apple@1.2.1,5.11-1"
+                self.dlist1[7],  # "bar@1.2,5.11-0"
+            ],
+            [
+                self.dlist1[12],  # "corge@1.0"
+                self.dlist1[14],  # "grault@1.0"
+            ],
+            [
+                self.dlist1[16],  # "quux@1.0"
+            ],
+        ]
+
+        for combo in combos:
+            pkgs = [
+                f.get_fmri(anarchy=True, include_scheme=False) for f in combo
+            ]
+            for pd in api_obj.gen_plan_install(pkgs):
+                continue
+            api_obj.prepare()
+            api_obj.execute_plan()
+            api_obj.reset()
+
+            returned = api_obj.get_pkg_categories(installed=True)
+            expected = sorted(set(sc for p in pkgs for sc in get_pkg_cats(p)))
+            self.assertEqualDiff(expected, returned)
+
+            # Prepare for next test.
+            # skip corge since it's renamed
+            for pd in api_obj.gen_plan_uninstall(
+                [p for p in pkgs if not p.startswith("corge@1.0")]
+            ):
+                continue
+            api_obj.prepare()
+            api_obj.execute_plan()
+            api_obj.reset()
+
+    def test_list_08_patterns(self):
+        """Verify that pattern filtering works as expected."""
+
+        api_obj = self.get_img_api_obj()
+
+        # First, check all variants, but with multiple patterns for the
+        # partial, exact, and wildcard match cases.
+        patterns = ["bar", "pkg:/baz", "*obs*"]
+        returned = self.__get_returned(
+            api_obj.LIST_ALL, api_obj=api_obj, patterns=patterns, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test1", 10, "baz", "1.3,5.11"),
+            self.__get_exp_pub_entry("test1", 9, "baz", "1.0.1,5.11"),
+            self.__get_exp_pub_entry("test1", 8, "baz", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 10, "baz", "1.3,5.11"),
+            self.__get_exp_pub_entry("test2", 9, "baz", "1.0.1,5.11"),
+            self.__get_exp_pub_entry("test2", 8, "baz", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 10)
+
+        # Next, check all variants, but with exact and partial match.
+        patterns = ["pkg:/bar", "obsolete"]
+        returned = self.__get_returned(
+            api_obj.LIST_ALL, api_obj=api_obj, patterns=patterns, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 15, "obsolete", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 15, "obsolete", "1.0,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 2)
+
+        # Next, check all variants, but for publisher and exact
+        # match case only.
+        patterns = ["pkg://test2/bat/bar"]
+        returned = self.__get_returned(
+            api_obj.LIST_ALL, api_obj=api_obj, patterns=patterns, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 1)
+
+        # Should return no matches.
+        patterns = ["pkg://test2/bar"]
+        returned = self.__get_returned(
+            api_obj.LIST_ALL, api_obj=api_obj, patterns=patterns, variants=True
+        )
+        expected = []
+        self.assertEqualDiff(expected, returned)
+
+        # Next, check all variants, but for exact match case only.
+        patterns = ["pkg:/bat/bar"]
+        returned = self.__get_returned(
+            api_obj.LIST_ALL, api_obj=api_obj, patterns=patterns, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 7, "bat/bar", "1.2,5.11-0"),
+            self.__get_exp_pub_entry("test2", 7, "bat/bar", "1.2,5.11-0"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 2)
+
+        # Next, check version matching for a single pattern.
+        patterns = ["apple@1.2.0"]
+        returned = self.__get_returned(
+            api_obj.LIST_ALL, api_obj=api_obj, patterns=patterns, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 3, "apple", "1.2.0,5.11-0"),
+            self.__get_exp_pub_entry("test2", 3, "apple", "1.2.0,5.11-0"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 2)
+
+        patterns = ["apple@1.0"]
+        returned = self.__get_returned(
+            api_obj.LIST_ALL, api_obj=api_obj, patterns=patterns, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 1, "apple", "1.0,5.11-0"),
+            self.__get_exp_pub_entry("test2", 1, "apple", "1.0,5.11-0"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 2)
+
+        patterns = ["apple@*,*-1"]
+        returned = self.__get_returned(
+            api_obj.LIST_ALL, api_obj=api_obj, patterns=patterns, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 6, "apple", "1.2.1,5.11-1"),
+            self.__get_exp_pub_entry("test2", 6, "apple", "1.2.1,5.11-1"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 2)
+
+        # Next, check version matching for multiple patterns.
+        patterns = ["baz@1.0", "pkg:/obsolete@1.1", "pkg://test1/qux@0.9"]
+        returned = self.__get_returned(
+            api_obj.LIST_ALL, api_obj=api_obj, patterns=patterns, variants=True
+        )
+
+        expected = [
+            self.__get_exp_pub_entry("test1", 9, "baz", "1.0.1,5.11"),
+            self.__get_exp_pub_entry("test1", 8, "baz", "1.0,5.11"),
+            self.__get_exp_pub_entry("test2", 9, "baz", "1.0.1,5.11"),
+            self.__get_exp_pub_entry("test2", 8, "baz", "1.0,5.11"),
+            self.__get_exp_pub_entry("test1", 17, "qux", "0.9,5.11"),
+        ]
+        self.assertEqualDiff(expected, returned)
+        self.assertEqual(len(returned), 5)
+
+        # Finally, verify that specifying an illegal pattern will
+        # raise an InventoryException.
+        patterns = ["baz@1.*.a"]
+        expected = [
+            version.IllegalVersion(
+                "Bad Version: {0}".format(p.split("@", 1)[-1])
+            )
+            for p in patterns
+        ]
+        try:
+            returned = self.__get_returned(
+                api_obj.LIST_ALL,
+                api_obj=api_obj,
+                patterns=patterns,
+                variants=True,
+            )
+        except api_errors.InventoryException as e:
+            self.assertEqualDiff(expected, e.illegal)
+        else:
+            raise RuntimeError("InventoryException not raised!")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_api_refresh.py
+++ b/src/tests/api/t_api_refresh.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -40,179 +41,182 @@ import pkg.client.publisher as publisher
 
 LIST_ALL = api.ImageInterface.LIST_ALL
 
+
 class TestApiRefresh(pkg5unittest.ManyDepotTestCase):
+    # restart depos for every test.
+    persistent_setup = False
 
-        # restart depos for every test.
-        persistent_setup = False
+    pubs = [
+        "test1",
+        "test1",
+    ]
 
-        pubs = [
-            "test1",
-            "test1",
-        ]
+    pkgs = [
+        "foo@1.0,5.11-0",
+        "bar@1.0,5.11-0",
+        "baz@1.0,5.11-0",
+    ]
 
-        pkgs = [
-            "foo@1.0,5.11-0",
-            "bar@1.0,5.11-0",
-            "baz@1.0,5.11-0",
-        ]
-
-        pkgs_data = {}
-        for i, pkg in enumerate(pkgs):
-                pkgs_data[i] = """
+    pkgs_data = {}
+    for i, pkg in enumerate(pkgs):
+        pkgs_data[
+            i
+        ] = """
                     open {pkg}
-                    close""".format(pkg=pkg)
+                    close""".format(
+            pkg=pkg
+        )
 
-        def setUp(self):
-                # we want two publishers with the same name
-                pkg5unittest.ManyDepotTestCase.setUp(self, self.pubs)
+    def setUp(self):
+        # we want two publishers with the same name
+        pkg5unittest.ManyDepotTestCase.setUp(self, self.pubs)
 
-                self.rurl = []
-                self.rurl.append(self.dcs[1].get_repo_url())
-                self.rurl.append(self.dcs[2].get_repo_url())
+        self.rurl = []
+        self.rurl.append(self.dcs[1].get_repo_url())
+        self.rurl.append(self.dcs[2].get_repo_url())
 
-        def test_stale_publisher_catalog(self):
-                """Verify that refresh updates the publisher catalog if it's
-                older than any of the origin catalogs."""
+    def test_stale_publisher_catalog(self):
+        """Verify that refresh updates the publisher catalog if it's
+        older than any of the origin catalogs."""
 
-                # create an image with one publisher (which has two origin)
-                origins = [self.rurl[0], self.rurl[1]]
-                api_obj = self.image_create(prefix=self.pubs[0],
-                    origins=origins)
+        # create an image with one publisher (which has two origin)
+        origins = [self.rurl[0], self.rurl[1]]
+        api_obj = self.image_create(prefix=self.pubs[0], origins=origins)
 
-                # make sure we don't see any packages
-                res = api_obj.get_pkg_list(LIST_ALL)
-                self.assertEqual(len(list(res)), 0)
+        # make sure we don't see any packages
+        res = api_obj.get_pkg_list(LIST_ALL)
+        self.assertEqual(len(list(res)), 0)
 
-                # get the publisher object
-                pub = api_obj.get_publishers()[0]
+        # get the publisher object
+        pub = api_obj.get_publishers()[0]
 
-                # note when the publisher catalog was last updated
-                ts1 = pub.catalog.last_modified
+        # note when the publisher catalog was last updated
+        ts1 = pub.catalog.last_modified
 
-                # create a copy of the publisher catalog
-                statedir = pub.catalog.meta_root
-                statedir_backup = statedir + ".backup"
-                shutil.copytree(statedir, statedir_backup)
+        # create a copy of the publisher catalog
+        statedir = pub.catalog.meta_root
+        statedir_backup = statedir + ".backup"
+        shutil.copytree(statedir, statedir_backup)
 
-                # force a delay so if the catalog is updated we'll notice.
-                time.sleep(1)
+        # force a delay so if the catalog is updated we'll notice.
+        time.sleep(1)
 
-                # publish a new package
-                self.pkgsend_bulk(self.rurl[0], self.pkgs_data[0])
+        # publish a new package
+        self.pkgsend_bulk(self.rurl[0], self.pkgs_data[0])
 
-                # refresh the image catalog
-                api_obj.refresh(immediate=True)
+        # refresh the image catalog
+        api_obj.refresh(immediate=True)
 
-                # make sure the publisher catalog was updated.
-                pub = api_obj.get_publishers()[0]
-                ts2 = pub.catalog.last_modified
-                self.assertNotEqual(ts1, ts2)
+        # make sure the publisher catalog was updated.
+        pub = api_obj.get_publishers()[0]
+        ts2 = pub.catalog.last_modified
+        self.assertNotEqual(ts1, ts2)
 
-                # overwrite the current publisher catalog with the old catalog
-                shutil.rmtree(statedir)
-                shutil.copytree(statedir_backup, statedir)
-                api_obj.reset()
+        # overwrite the current publisher catalog with the old catalog
+        shutil.rmtree(statedir)
+        shutil.copytree(statedir_backup, statedir)
+        api_obj.reset()
 
-                # make sure the publisher catalog is old
-                pub = api_obj.get_publishers()[0]
-                ts2 = pub.catalog.last_modified
-                self.assertEqual(ts1, ts2)
+        # make sure the publisher catalog is old
+        pub = api_obj.get_publishers()[0]
+        ts2 = pub.catalog.last_modified
+        self.assertEqual(ts1, ts2)
 
-                # refresh the image catalog
-                api_obj.refresh(immediate=True)
+        # refresh the image catalog
+        api_obj.refresh(immediate=True)
 
-                # make sure the publisher catalog was updated
-                pub = api_obj.get_publishers()[0]
-                ts2 = pub.catalog.last_modified
-                self.assertNotEqual(ts1, ts2)
+        # make sure the publisher catalog was updated
+        pub = api_obj.get_publishers()[0]
+        ts2 = pub.catalog.last_modified
+        self.assertNotEqual(ts1, ts2)
 
-        def test_stale_image_catalog(self):
-                """Verify that refresh updates the image catalog if it's
-                older than any of the publisher catalogs."""
+    def test_stale_image_catalog(self):
+        """Verify that refresh updates the image catalog if it's
+        older than any of the publisher catalogs."""
 
-                # create an image with one publisher (which has one origin)
-                origins = [self.rurl[0]]
-                api_obj = self.image_create(prefix=self.pubs[0],
-                    origins=origins)
+        # create an image with one publisher (which has one origin)
+        origins = [self.rurl[0]]
+        api_obj = self.image_create(prefix=self.pubs[0], origins=origins)
 
-                # make sure we don't see any packages
-                res = api_obj.get_pkg_list(LIST_ALL)
-                self.assertEqual(len(list(res)), 0)
+        # make sure we don't see any packages
+        res = api_obj.get_pkg_list(LIST_ALL)
+        self.assertEqual(len(list(res)), 0)
 
-                # create a copy of the image catalog
-                img_statedir = api_obj._img._statedir
-                img_statedir_backup = img_statedir + ".backup"
-                shutil.copytree(img_statedir, img_statedir_backup)
+        # create a copy of the image catalog
+        img_statedir = api_obj._img._statedir
+        img_statedir_backup = img_statedir + ".backup"
+        shutil.copytree(img_statedir, img_statedir_backup)
 
-                # publish a new package
-                self.pkgsend_bulk(self.rurl[0], self.pkgs_data[0])
+        # publish a new package
+        self.pkgsend_bulk(self.rurl[0], self.pkgs_data[0])
 
-                # refresh the image catalog
-                api_obj.refresh(immediate=True)
+        # refresh the image catalog
+        api_obj.refresh(immediate=True)
 
-                # make sure we see the new package
-                res = api_obj.get_pkg_list(LIST_ALL)
-                self.assertEqual(len(list(res)), 1)
+        # make sure we see the new package
+        res = api_obj.get_pkg_list(LIST_ALL)
+        self.assertEqual(len(list(res)), 1)
 
-                # overwrite the current image catalog with the old catalog
-                shutil.rmtree(img_statedir)
-                shutil.copytree(img_statedir_backup, img_statedir)
-                api_obj.reset()
+        # overwrite the current image catalog with the old catalog
+        shutil.rmtree(img_statedir)
+        shutil.copytree(img_statedir_backup, img_statedir)
+        api_obj.reset()
 
-                # refresh the image catalog
-                api_obj.refresh(immediate=True)
+        # refresh the image catalog
+        api_obj.refresh(immediate=True)
 
-                # make sure we see don't see the new package
-                res = api_obj.get_pkg_list(LIST_ALL)
-                self.assertEqual(len(list(res)), 0)
+        # make sure we see don't see the new package
+        res = api_obj.get_pkg_list(LIST_ALL)
+        self.assertEqual(len(list(res)), 0)
 
-                # trick the image into thinking that an update was interrupted
-                pathname = os.path.join(api_obj._img._statedir,
-                     "state_updating")
-                with open(pathname, "w"):
-                        os.chmod(pathname,
-                            stat.S_IRUSR|stat.S_IWUSR|stat.S_IRGRP|stat.S_IROTH)
+        # trick the image into thinking that an update was interrupted
+        pathname = os.path.join(api_obj._img._statedir, "state_updating")
+        with open(pathname, "w"):
+            os.chmod(
+                pathname,
+                stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH,
+            )
 
-                # make sure we see don't see the new package
-                res = api_obj.get_pkg_list(LIST_ALL)
-                self.assertEqual(len(list(res)), 0)
+        # make sure we see don't see the new package
+        res = api_obj.get_pkg_list(LIST_ALL)
+        self.assertEqual(len(list(res)), 0)
 
-                # refresh the image catalog
-                api_obj.refresh(immediate=True)
+        # refresh the image catalog
+        api_obj.refresh(immediate=True)
 
-                # make sure we see the new package
-                res = api_obj.get_pkg_list(LIST_ALL)
-                self.assertEqual(len(list(res)), 1)
+        # make sure we see the new package
+        res = api_obj.get_pkg_list(LIST_ALL)
+        self.assertEqual(len(list(res)), 1)
 
-        def test_no_origins_means_no_image_catalog_updates(self):
-                """Make sure we don't update the image catalog
-                unnecessarily."""
+    def test_no_origins_means_no_image_catalog_updates(self):
+        """Make sure we don't update the image catalog
+        unnecessarily."""
 
-                # create an image with no publishers
-                api_obj = self.image_create()
-                repo = publisher.Repository()
-                pub = publisher.Publisher(self.pubs[0], repository=repo)
-                api_obj.add_publisher(pub)
+        # create an image with no publishers
+        api_obj = self.image_create()
+        repo = publisher.Repository()
+        pub = publisher.Publisher(self.pubs[0], repository=repo)
+        api_obj.add_publisher(pub)
 
-                # make sure we've created a local catalog for this publisher
-                api_obj.refresh(immediate=True)
+        # make sure we've created a local catalog for this publisher
+        api_obj.refresh(immediate=True)
 
-                # get the image catalog timestamp
-                ts1 = api_obj._img.get_last_modified(string=True)
+        # get the image catalog timestamp
+        ts1 = api_obj._img.get_last_modified(string=True)
 
-                # force a delay so if the catalog is updated we'll notice.
-                time.sleep(1)
+        # force a delay so if the catalog is updated we'll notice.
+        time.sleep(1)
 
-                # refresh the image catalog (should be a noop)
-                api_obj.refresh(immediate=True)
+        # refresh the image catalog (should be a noop)
+        api_obj.refresh(immediate=True)
 
-                # make sure the image catalog wasn't updated
-                ts2 = api_obj._img.get_last_modified(string=True)
-                self.assertEqual(ts1, ts2)
+        # make sure the image catalog wasn't updated
+        ts2 = api_obj._img.get_last_modified(string=True)
+        self.assertEqual(ts1, ts2)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_api_search.py
+++ b/src/tests/api/t_api_search.py
@@ -24,8 +24,9 @@
 # Copyright 2018 OmniOS Community Edition (OmniOSce) Association.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import copy
@@ -49,10 +50,10 @@ from pkg.misc import force_str
 
 
 class TestApiSearchBasics(pkg5unittest.SingleDepotTestCase):
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        example_pkg10 = """
+    example_pkg10 = """
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
@@ -69,302 +70,576 @@ class TestApiSearchBasics(pkg5unittest.SingleDepotTestCase):
             add set name=org.opensolaris.smf.fmri value=svc:/milestone/multi-user-server:default
             close """
 
-        example_pkg11 = """
+    example_pkg11 = """
             open example_pkg@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path11
             close """
 
-        incorp_pkg10 = """
+    incorp_pkg10 = """
             open incorp_pkg@1.0,5.11-0
             add depend fmri=example_pkg@1.0,5.11-0 type=incorporate
             close """
 
-        incorp_pkg11 = """
+    incorp_pkg11 = """
             open incorp_pkg@1.1,5.11-0
             add depend fmri=example_pkg@1.1,5.11-0 type=incorporate
             close """
 
-        another_pkg10 = """
+    another_pkg10 = """
             open another_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bazbin
             close """
 
-        bad_pkg10 = """
+    bad_pkg10 = """
             open bad_pkg@1.0,5.11-0
             add dir path=badfoo/ mode=0755 owner=root group=bin
             close """
 
-        space_pkg10 = """
+    space_pkg10 = """
             open space_pkg@1.0,5.11-0
             add file tmp/example_file mode=0444 owner=nobody group=sys path='unique/with a space'
             add dir mode=0755 owner=root group=bin path=unique_dir
             close """
 
-        cat_pkg10 = """
+    cat_pkg10 = """
             open cat@1.0,5.11-0
             add set name=info.classification value=org.opensolaris.category.2008:System/Security value=org.random:Other/Category
             close """
 
-        cat2_pkg10 = """
+    cat2_pkg10 = """
             open cat2@1.0,5.11-0
             add set name=info.classification value="org.opensolaris.category.2008:Applications/Sound and Video" value=Developer/C
             close """
 
-        cat3_pkg10 = """
+    cat3_pkg10 = """
             open cat3@1.0,5.11-0
             add set name=info.classification value="org.opensolaris.category.2008:foo/bar/baz/bill/beam/asda"
             close """
 
-        bad_cat_pkg10 = """
+    bad_cat_pkg10 = """
             open badcat@1.0,5.11-0
             add set name=info.classification value="TestBad1/TestBad2"
             close """
 
-        bad_cat2_pkg10 = """
+    bad_cat2_pkg10 = """
             open badcat2@1.0,5.11-0
             add set name=info.classification value="org.opensolaris.category.2008:TestBad1:TestBad2"
             close """
 
-        fat_pkg10 = """
+    fat_pkg10 = """
 open fat@1.0,5.11-0
 add set name=variant.arch value=sparc value=i386
 add set name=description value="i386 variant" variant.arch=i386
 add set name=description value="sparc variant" variant.arch=sparc
 close """
 
-        bogus_pkg10 = """
+    bogus_pkg10 = """
 set name=pkg.fmri value=pkg:/bogus_pkg@1.0,5.11-0:20090326T233451Z
 set name=description value=""validation with simple chains of constraints ""
 set name=pkg.description value="pseudo-hashes as arrays tied to a "type" (list of fields)"
 depend fmri=XML-Atom-Entry
 set name=com.sun.service.incorporated_changes value="6556919 6627937"
 """
-        bogus_fmri = fmri.PkgFmri("bogus_pkg@1.0,5.11-0:20090326T233451Z")
+    bogus_fmri = fmri.PkgFmri("bogus_pkg@1.0,5.11-0:20090326T233451Z")
 
-        hierarchical_named_pkg = """
+    hierarchical_named_pkg = """
 open pa/pb/pc/pfoo@1.0,5.11-0
 close """
 
-        bug_8492_manf_1 = """
+    bug_8492_manf_1 = """
 open b1@1.0,5.11-0
 add set description="Image Packaging System"
 close """
 
-        bug_8492_manf_2 = """
+    bug_8492_manf_2 = """
 open b2@1.0,5.11-0
 add set description="Image Packaging System"
 close """
 
-        require_any_manf = """
+    require_any_manf = """
 open ra@1.0,5.11-0
 add depend type=require-any fmri=another_pkg@1.0,5.11-0 fmri=pkg:/space_pkg@1.0,5.11-0
 close
 """
 
-        res_8492_1 = set([('pkg:/b1@1.0-0', 'Image Packaging System', 'set name=description value="Image Packaging System"')])
-        res_8492_2 = set([('pkg:/b2@1.0-0', 'Image Packaging System', 'set name=description value="Image Packaging System"')])
+    res_8492_1 = set(
+        [
+            (
+                "pkg:/b1@1.0-0",
+                "Image Packaging System",
+                'set name=description value="Image Packaging System"',
+            )
+        ]
+    )
+    res_8492_2 = set(
+        [
+            (
+                "pkg:/b2@1.0-0",
+                "Image Packaging System",
+                'set name=description value="Image Packaging System"',
+            )
+        ]
+    )
 
-        remote_fmri_string = ('pkg:/example_pkg@1.0-0', 'test/example_pkg',
-            'set name=pkg.fmri value=pkg://test/example_pkg@1.0,5.11-0:')
+    remote_fmri_string = (
+        "pkg:/example_pkg@1.0-0",
+        "test/example_pkg",
+        "set name=pkg.fmri value=pkg://test/example_pkg@1.0,5.11-0:",
+    )
 
-        res_remote_pkg = set([
-            remote_fmri_string
-        ])
+    res_remote_pkg = set([remote_fmri_string])
 
-        res_remote_path = set([
-            ("pkg:/example_pkg@1.0-0", "basename","file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin mode=0555 owner=root path=bin/example_path pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12"),
-        ])
+    res_remote_path = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "basename",
+                "file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin mode=0555 owner=root path=bin/example_path pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12",
+            ),
+        ]
+    )
 
-        res_remote_path_of_example_path = set([
-            ("pkg:/example_pkg@1.0-0", "path","file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin mode=0555 owner=root path=bin/example_path pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12")
-        ])
+    res_remote_path_of_example_path = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "path",
+                "file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin mode=0555 owner=root path=bin/example_path pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12",
+            )
+        ]
+    )
 
-        res_remote_bin = set([
-            ("pkg:/example_pkg@1.0-0", "path", "dir group=bin mode=0755 owner=root path=bin")
-        ])
+    res_remote_bin = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "path",
+                "dir group=bin mode=0755 owner=root path=bin",
+            )
+        ]
+    )
 
-        res_remote_openssl = set([
-            ("pkg:/example_pkg@1.0-0", "basename", "dir group=bin mode=0755 owner=root path=usr/lib/python3.9/vendor-packages/OpenSSL")
-        ])
+    res_remote_openssl = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "basename",
+                "dir group=bin mode=0755 owner=root path=usr/lib/python3.9/vendor-packages/OpenSSL",
+            )
+        ]
+    )
 
-        res_remote_bug_id = set([
-            ("pkg:/example_pkg@1.0-0", "4851433", 'set name=com.sun.service.bug_ids value=4641790 value=4725245 value=4817791 value=4851433 value=4897491 value=4913776 value=6178339 value=6556919 value=6627937')
-        ])
+    res_remote_bug_id = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "4851433",
+                "set name=com.sun.service.bug_ids value=4641790 value=4725245 value=4817791 value=4851433 value=4897491 value=4913776 value=6178339 value=6556919 value=6627937",
+            )
+        ]
+    )
 
-        res_remote_bug_id_4725245 = set([
-            ("pkg:/example_pkg@1.0-0", "4725245", 'set name=com.sun.service.bug_ids value=4641790 value=4725245 value=4817791 value=4851433 value=4897491 value=4913776 value=6178339 value=6556919 value=6627937')
-        ])
+    res_remote_bug_id_4725245 = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "4725245",
+                "set name=com.sun.service.bug_ids value=4641790 value=4725245 value=4817791 value=4851433 value=4897491 value=4913776 value=6178339 value=6556919 value=6627937",
+            )
+        ]
+    )
 
+    res_remote_inc_changes = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "6556919 6627937",
+                'set name=com.sun.service.incorporated_changes value="6556919 6627937"',
+            ),
+            (
+                "pkg:/example_pkg@1.0-0",
+                "6556919",
+                "set name=com.sun.service.bug_ids value=4641790 value=4725245 value=4817791 value=4851433 value=4897491 value=4913776 value=6178339 value=6556919 value=6627937",
+            ),
+        ]
+    )
 
-        res_remote_inc_changes = set([
-            ("pkg:/example_pkg@1.0-0", "6556919 6627937", 'set name=com.sun.service.incorporated_changes value="6556919 6627937"'),
-            ("pkg:/example_pkg@1.0-0", "6556919", 'set name=com.sun.service.bug_ids value=4641790 value=4725245 value=4817791 value=4851433 value=4897491 value=4913776 value=6178339 value=6556919 value=6627937')
-        ])
+    res_remote_mediator = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "mediator",
+                "link mediator=example mediator-implementation=unladen-swallow mediator-version=7.0 path=bin/exlink target=/bin/example_path",
+            )
+        ]
+    )
 
-        res_remote_mediator = set([
-            ("pkg:/example_pkg@1.0-0", "mediator", "link mediator=example mediator-implementation=unladen-swallow mediator-version=7.0 path=bin/exlink target=/bin/example_path")
-        ])
+    res_remote_mediator_version = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "mediator-version",
+                "link mediator=example mediator-implementation=unladen-swallow mediator-version=7.0 path=bin/exlink target=/bin/example_path",
+            )
+        ]
+    )
 
-        res_remote_mediator_version = set([
-            ("pkg:/example_pkg@1.0-0", "mediator-version", "link mediator=example mediator-implementation=unladen-swallow mediator-version=7.0 path=bin/exlink target=/bin/example_path")
-        ])
+    res_remote_mediator_impl = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "mediator-implementation",
+                "link mediator=example mediator-implementation=unladen-swallow mediator-version=7.0 path=bin/exlink target=/bin/example_path",
+            )
+        ]
+    )
 
-        res_remote_mediator_impl = set([
-            ("pkg:/example_pkg@1.0-0", "mediator-implementation", "link mediator=example mediator-implementation=unladen-swallow mediator-version=7.0 path=bin/exlink target=/bin/example_path")
-        ])
+    res_remote_mediator_and_ver = res_remote_mediator.union(
+        res_remote_mediator_version
+    )
 
-        res_remote_mediator_and_ver = res_remote_mediator.union(
-            res_remote_mediator_version)
+    res_remote_mediator_and_ver_impl = res_remote_mediator.union(
+        res_remote_mediator_version
+    ).union(res_remote_mediator_impl)
 
-        res_remote_mediator_and_ver_impl = res_remote_mediator.union(
-            res_remote_mediator_version).union(res_remote_mediator_impl)
+    res_remote_random_test = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "42",
+                "set name=com.sun.service.random_test value=42 value=79",
+            )
+        ]
+    )
 
-        res_remote_random_test = set([
-            ("pkg:/example_pkg@1.0-0", "42", "set name=com.sun.service.random_test value=42 value=79")
-        ])
+    res_remote_random_test_79 = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "79",
+                "set name=com.sun.service.random_test value=42 value=79",
+            )
+        ]
+    )
 
-        res_remote_random_test_79 = set([
-            ("pkg:/example_pkg@1.0-0", "79", "set name=com.sun.service.random_test value=42 value=79")
-        ])
+    res_remote_keywords = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "sort null -n -m -t sort 0x86 separator",
+                'set name=com.sun.service.keywords value="sort null -n -m -t sort 0x86 separator"',
+            )
+        ]
+    )
 
-        res_remote_keywords = set([
-            ("pkg:/example_pkg@1.0-0", "sort null -n -m -t sort 0x86 separator", 'set name=com.sun.service.keywords value="sort null -n -m -t sort 0x86 separator"')
-        ])
+    res_remote_wildcard = res_remote_path.union(
+        set(
+            [
+                remote_fmri_string,
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "basename",
+                    "dir group=bin mode=0755 owner=root path=bin/example_dir",
+                ),
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "mediator",
+                    "link mediator=example mediator-implementation=unladen-swallow mediator-version=7.0 path=bin/exlink target=/bin/example_path",
+                ),
+            ]
+        )
+    )
 
-        res_remote_wildcard = res_remote_path.union(set([
-            remote_fmri_string,
-            ('pkg:/example_pkg@1.0-0', 'basename', 'dir group=bin mode=0755 owner=root path=bin/example_dir'),
-            ("pkg:/example_pkg@1.0-0", "mediator", "link mediator=example mediator-implementation=unladen-swallow mediator-version=7.0 path=bin/exlink target=/bin/example_path")
-        ]))
+    res_remote_glob = (
+        set(
+            [
+                remote_fmri_string,
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "path",
+                    "dir group=bin mode=0755 owner=root path=bin/example_dir",
+                ),
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "basename",
+                    "dir group=bin mode=0755 owner=root path=bin/example_dir",
+                ),
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "path",
+                    "file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin mode=0555 owner=root path=bin/example_path pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12",
+                ),
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "mediator",
+                    "link mediator=example mediator-implementation=unladen-swallow mediator-version=7.0 path=bin/exlink target=/bin/example_path",
+                ),
+            ]
+        )
+        | res_remote_path
+    )
 
-        res_remote_glob = set([
-            remote_fmri_string,
-            ('pkg:/example_pkg@1.0-0', 'path', 'dir group=bin mode=0755 owner=root path=bin/example_dir'),
-            ('pkg:/example_pkg@1.0-0', 'basename', 'dir group=bin mode=0755 owner=root path=bin/example_dir'),
-            ('pkg:/example_pkg@1.0-0', 'path', 'file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin mode=0555 owner=root path=bin/example_path pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12'),
-            ("pkg:/example_pkg@1.0-0", "mediator", "link mediator=example mediator-implementation=unladen-swallow mediator-version=7.0 path=bin/exlink target=/bin/example_path")
-        ]) | res_remote_path
+    res_remote_foo = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "FOOO bAr O OO OOO",
+                'set name=description value="FOOO bAr O OO OOO" value="whee fun"',
+            )
+        ]
+    )
 
-        res_remote_foo = set([
-            ('pkg:/example_pkg@1.0-0', 'FOOO bAr O OO OOO', 'set name=description value="FOOO bAr O OO OOO" value="whee fun"')
-        ])
+    res_remote_weird = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "] [ * ?",
+                'set name=weirdness value="] [ * ?"',
+            )
+        ]
+    )
 
-        res_remote_weird = set([
-            ('pkg:/example_pkg@1.0-0', '] [ * ?', 'set name=weirdness value="] [ * ?"')
-        ])
+    local_fmri_string = (
+        "pkg:/example_pkg@1.0-0",
+        "test/example_pkg",
+        "set name=pkg.fmri value=pkg://test/example_pkg@1.0,5.11-0:",
+    )
 
-        local_fmri_string = ('pkg:/example_pkg@1.0-0', 'test/example_pkg',
-            'set name=pkg.fmri value=pkg://test/example_pkg@1.0,5.11-0:')
+    res_local_pkg = set([local_fmri_string])
 
-        res_local_pkg = set([
-                local_fmri_string
-                ])
+    res_local_path = copy.copy(res_remote_path)
 
-        res_local_path = copy.copy(res_remote_path)
+    res_local_bin = copy.copy(res_remote_bin)
 
-        res_local_bin = copy.copy(res_remote_bin)
+    res_local_bug_id = copy.copy(res_remote_bug_id)
 
-        res_local_bug_id = copy.copy(res_remote_bug_id)
+    res_local_inc_changes = copy.copy(res_remote_inc_changes)
 
-        res_local_inc_changes = copy.copy(res_remote_inc_changes)
+    res_local_random_test = copy.copy(res_remote_random_test)
 
-        res_local_random_test = copy.copy(res_remote_random_test)
+    res_local_keywords = copy.copy(res_remote_keywords)
 
-        res_local_keywords = copy.copy(res_remote_keywords)
+    res_local_mediator = copy.copy(res_remote_mediator)
+    res_local_mediator_version = copy.copy(res_remote_mediator_version)
+    res_local_mediator_impl = copy.copy(res_remote_mediator_impl)
+    res_local_mediator_and_ver = copy.copy(res_remote_mediator_and_ver)
+    res_local_mediator_and_ver_impl = copy.copy(
+        res_remote_mediator_and_ver_impl
+    )
 
-        res_local_mediator = copy.copy(res_remote_mediator)
-        res_local_mediator_version = copy.copy(res_remote_mediator_version)
-        res_local_mediator_impl = copy.copy(res_remote_mediator_impl)
-        res_local_mediator_and_ver = copy.copy(res_remote_mediator_and_ver)
-        res_local_mediator_and_ver_impl = copy.copy(
-            res_remote_mediator_and_ver_impl)
+    res_local_wildcard = copy.copy(res_remote_wildcard)
+    res_local_wildcard.add(local_fmri_string)
 
-        res_local_wildcard = copy.copy(res_remote_wildcard)
-        res_local_wildcard.add(local_fmri_string)
+    res_local_glob = copy.copy(res_remote_glob)
+    res_local_glob.add(local_fmri_string)
 
-        res_local_glob = copy.copy(res_remote_glob)
-        res_local_glob.add(local_fmri_string)
+    res_local_foo = copy.copy(res_remote_foo)
 
-        res_local_foo = copy.copy(res_remote_foo)
+    res_local_openssl = copy.copy(res_remote_openssl)
 
-        res_local_openssl = copy.copy(res_remote_openssl)
+    res_local_path_example11 = set(
+        [
+            (
+                "pkg:/example_pkg@1.1-0",
+                "basename",
+                "file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin mode=0555 owner=root path=bin/example_path11 pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12",
+            )
+        ]
+    )
 
-        res_local_path_example11 = set([
-            ("pkg:/example_pkg@1.1-0", "basename", "file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin mode=0555 owner=root path=bin/example_path11 pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12")
-        ])
+    res_local_bin_example11 = set(
+        [
+            (
+                "pkg:/example_pkg@1.1-0",
+                "path",
+                "dir group=bin mode=0755 owner=root path=bin",
+            )
+        ]
+    )
 
-        res_local_bin_example11 = set([
-            ("pkg:/example_pkg@1.1-0", "path", "dir group=bin mode=0755 owner=root path=bin")
-        ])
+    res_local_pkg_example11 = set(
+        [
+            (
+                "pkg:/example_pkg@1.1-0",
+                "test/example_pkg",
+                "set name=pkg.fmri value=pkg://test/example_pkg@1.1,5.11-0:",
+            )
+        ]
+    )
 
-        res_local_pkg_example11 = set([
-            ("pkg:/example_pkg@1.1-0", "test/example_pkg", "set name=pkg.fmri value=pkg://test/example_pkg@1.1,5.11-0:")
-        ])
+    res_local_wildcard_example11 = set(
+        [
+            (
+                "pkg:/example_pkg@1.1-0",
+                "basename",
+                "file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin mode=0555 owner=root path=bin/example_path11 pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12",
+            ),
+        ]
+    ).union(res_local_pkg_example11)
 
-        res_local_wildcard_example11 = set([
-            ("pkg:/example_pkg@1.1-0", "basename", "file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin mode=0555 owner=root path=bin/example_path11 pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12"),
-        ]).union(res_local_pkg_example11)
+    res_cat_pkg10 = set(
+        [
+            (
+                "pkg:/cat@1.0-0",
+                "System/Security",
+                "set name=info.classification value=org.opensolaris.category.2008:System/Security value=org.random:Other/Category",
+            )
+        ]
+    )
 
-        res_cat_pkg10 = set([
-            ('pkg:/cat@1.0-0', 'System/Security', 'set name=info.classification value=org.opensolaris.category.2008:System/Security value=org.random:Other/Category')
-        ])
+    res_cat_pkg10_2 = set(
+        [
+            (
+                "pkg:/cat@1.0-0",
+                "Other/Category",
+                "set name=info.classification value=org.opensolaris.category.2008:System/Security value=org.random:Other/Category",
+            )
+        ]
+    )
 
-        res_cat_pkg10_2 = set([
-            ('pkg:/cat@1.0-0', 'Other/Category', 'set name=info.classification value=org.opensolaris.category.2008:System/Security value=org.random:Other/Category')
-        ])
+    res_cat2_pkg10 = set(
+        [
+            (
+                "pkg:/cat2@1.0-0",
+                "Applications/Sound and Video",
+                'set name=info.classification value="org.opensolaris.category.2008:Applications/Sound and Video" value=Developer/C',
+            )
+        ]
+    )
 
-        res_cat2_pkg10 = set([
-            ('pkg:/cat2@1.0-0', 'Applications/Sound and Video', 'set name=info.classification value="org.opensolaris.category.2008:Applications/Sound and Video" value=Developer/C')
-        ])
+    res_cat2_pkg10_2 = set(
+        [
+            (
+                "pkg:/cat2@1.0-0",
+                "Developer/C",
+                'set name=info.classification value="org.opensolaris.category.2008:Applications/Sound and Video" value=Developer/C',
+            )
+        ]
+    )
 
-        res_cat2_pkg10_2 = set([
-            ('pkg:/cat2@1.0-0', 'Developer/C', 'set name=info.classification value="org.opensolaris.category.2008:Applications/Sound and Video" value=Developer/C')
-        ])
+    res_cat3_pkg10 = set(
+        [
+            (
+                "pkg:/cat3@1.0-0",
+                "foo/bar/baz/bill/beam/asda",
+                "set name=info.classification value=org.opensolaris.category.2008:foo/bar/baz/bill/beam/asda",
+            )
+        ]
+    )
 
-        res_cat3_pkg10 = set([
-            ('pkg:/cat3@1.0-0', 'foo/bar/baz/bill/beam/asda', 'set name=info.classification value=org.opensolaris.category.2008:foo/bar/baz/bill/beam/asda')
-        ])
+    res_fat10_i386 = set(
+        [
+            (
+                "pkg:/fat@1.0-0",
+                "i386 variant",
+                'set name=description value="i386 variant" variant.arch=i386',
+            ),
+            (
+                "pkg:/fat@1.0-0",
+                "i386 variant",
+                'set name=description value="i386 variant" variant.arch=i386',
+            ),
+            (
+                "pkg:/fat@1.0-0",
+                "i386",
+                "set name=variant.arch value=sparc value=i386",
+            ),
+        ]
+    )
 
-        res_fat10_i386 = set([
-            ('pkg:/fat@1.0-0', 'i386 variant', 'set name=description value="i386 variant" variant.arch=i386'),
-            ('pkg:/fat@1.0-0', 'i386 variant', 'set name=description value="i386 variant" variant.arch=i386'),
-            ('pkg:/fat@1.0-0', 'i386', 'set name=variant.arch value=sparc value=i386'),
-        ])
+    res_fat10_sparc = set(
+        [
+            (
+                "pkg:/fat@1.0-0",
+                "sparc variant",
+                'set name=description value="sparc variant" variant.arch=sparc',
+            ),
+            (
+                "pkg:/fat@1.0-0",
+                "sparc",
+                "set name=variant.arch value=sparc value=i386",
+            ),
+        ]
+    )
 
-        res_fat10_sparc = set([
-            ('pkg:/fat@1.0-0', 'sparc variant', 'set name=description value="sparc variant" variant.arch=sparc'),
-            ('pkg:/fat@1.0-0', 'sparc', 'set name=variant.arch value=sparc value=i386')
-        ])
+    fat_10_fmri_string = set(
+        [
+            (
+                "pkg:/fat@1.0-0",
+                "test/fat",
+                "set name=pkg.fmri value=pkg://test/fat@1.0,5.11-0:",
+            )
+        ]
+    )
 
-        fat_10_fmri_string = set([('pkg:/fat@1.0-0', 'test/fat', 'set name=pkg.fmri value=pkg://test/fat@1.0,5.11-0:')])
+    res_remote_fat10_star = (
+        fat_10_fmri_string | res_fat10_sparc | res_fat10_i386
+    )
 
-        res_remote_fat10_star = fat_10_fmri_string | res_fat10_sparc | res_fat10_i386
+    res_local_fat10_i386_star = res_fat10_i386.union(
+        set(
+            [
+                (
+                    "pkg:/fat@1.0-0",
+                    "sparc",
+                    "set name=variant.arch value=sparc value=i386",
+                )
+            ]
+        )
+    ).union(fat_10_fmri_string)
 
-        res_local_fat10_i386_star = res_fat10_i386.union(set([
-            ('pkg:/fat@1.0-0', 'sparc', 'set name=variant.arch value=sparc value=i386')
-        ])).union(fat_10_fmri_string)
+    res_local_fat10_sparc_star = res_fat10_sparc.union(
+        set(
+            [
+                (
+                    "pkg:/fat@1.0-0",
+                    "i386",
+                    "set name=variant.arch value=sparc value=i386",
+                )
+            ]
+        )
+    ).union(fat_10_fmri_string)
 
-        res_local_fat10_sparc_star = res_fat10_sparc.union(set([
-            ('pkg:/fat@1.0-0', 'i386', 'set name=variant.arch value=sparc value=i386')
-        ])).union(fat_10_fmri_string)
+    res_space_with_star = set(
+        [
+            (
+                "pkg:/space_pkg@1.0-0",
+                "basename",
+                'file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=sys mode=0444 owner=nobody path="unique/with a space" pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12',
+            )
+        ]
+    )
 
-        res_space_with_star = set([
-            ('pkg:/space_pkg@1.0-0', 'basename', 'file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=sys mode=0444 owner=nobody path="unique/with a space" pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12')
-        ])
+    res_space_space_star = set(
+        [
+            (
+                "pkg:/space_pkg@1.0-0",
+                "basename",
+                'file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=sys mode=0444 owner=nobody path="unique/with a space" pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12',
+            ),
+            (
+                "pkg:/space_pkg@1.0-0",
+                "path",
+                'file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=sys mode=0444 owner=nobody path="unique/with a space" pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12',
+            ),
+        ]
+    )
 
-        res_space_space_star = set([
-            ('pkg:/space_pkg@1.0-0', 'basename', 'file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=sys mode=0444 owner=nobody path="unique/with a space" pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12'), ('pkg:/space_pkg@1.0-0', 'path', 'file a686473102ba73bd7920fc0ab1d97e00a24ed704 chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=sys mode=0444 owner=nobody path="unique/with a space" pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 pkg.csize=30 pkg.size=12')
-        ])
+    res_space_unique = set(
+        [
+            (
+                "pkg:/space_pkg@1.0-0",
+                "basename",
+                "dir group=bin mode=0755 owner=root path=unique_dir",
+            )
+        ]
+    )
 
-        res_space_unique = set([
-            ('pkg:/space_pkg@1.0-0', 'basename', 'dir group=bin mode=0755 owner=root path=unique_dir')
-        ])
-
-        # This is a copy of the 3.81%2C5.11-0.89%3A20080527T163123Z version of
-        # SUNWgmake from ipkg with the file and liscense actions changed so
-        # that they all take /tmp/example file when sending.
-        bug_983_manifest = """
+    # This is a copy of the 3.81%2C5.11-0.89%3A20080527T163123Z version of
+    # SUNWgmake from ipkg with the file and liscense actions changed so
+    # that they all take /tmp/example file when sending.
+    bug_983_manifest = """
 open SUNWgmake@3.81,5.11-0.89
 add dir group=sys mode=0755 owner=root path=usr
 add dir group=bin mode=0755 owner=root path=usr/bin
@@ -400,2414 +675,3258 @@ add legacy arch=i386 category=system desc="GNU make - A utility used to build so
 close
 """
 
-        res_bug_983 = set([
-            ("pkg:/SUNWgmake@3.81-0.89", "basename", "link path=usr/sfw/bin/gmake target=../../bin/gmake"),
-            ('pkg:/SUNWgmake@3.81-0.89', 'basename', 'file 038cc7a09940928aeac6966331a2f18bc40e7792 chash=a3e76bd1b97b715cddc93b2ad6502b41efa4d833 elfarch=i386 elfbits=32 elfhash=083308992c921537fd757548964f89452234dd11 group=bin mode=0555 owner=root path=usr/bin/gmake pkg.content-hash=gelf:sha512t_256:54f4cba7527ab9f78a85f7bb5a4e63315c8cae4a7e38f884e4bfd16bcab00821 pkg.content-hash=gelf.unsigned:sha512t_256:54f4cba7527ab9f78a85f7bb5a4e63315c8cae4a7e38f884e4bfd16bcab00821 pkg.content-hash=file:sha512t_256:2374db2dfb4968baad246ab37afc560cc9d278b6104a889a2727d9bcf6a20b17 pkg.content-hash=gzip:sha512t_256:17e38c279aad2c4877618246cb60cb4c795f6754880649c56d847e653fadd71c pkg.csize=1358 pkg.size=3948'),
-            ('pkg:/SUNWgmake@3.81-0.89', 'gmake - GNU make', 'set name=description value="gmake - GNU make"')
-        ])
+    res_bug_983 = set(
+        [
+            (
+                "pkg:/SUNWgmake@3.81-0.89",
+                "basename",
+                "link path=usr/sfw/bin/gmake target=../../bin/gmake",
+            ),
+            (
+                "pkg:/SUNWgmake@3.81-0.89",
+                "basename",
+                "file 038cc7a09940928aeac6966331a2f18bc40e7792 chash=a3e76bd1b97b715cddc93b2ad6502b41efa4d833 elfarch=i386 elfbits=32 elfhash=083308992c921537fd757548964f89452234dd11 group=bin mode=0555 owner=root path=usr/bin/gmake pkg.content-hash=gelf:sha512t_256:54f4cba7527ab9f78a85f7bb5a4e63315c8cae4a7e38f884e4bfd16bcab00821 pkg.content-hash=gelf.unsigned:sha512t_256:54f4cba7527ab9f78a85f7bb5a4e63315c8cae4a7e38f884e4bfd16bcab00821 pkg.content-hash=file:sha512t_256:2374db2dfb4968baad246ab37afc560cc9d278b6104a889a2727d9bcf6a20b17 pkg.content-hash=gzip:sha512t_256:17e38c279aad2c4877618246cb60cb4c795f6754880649c56d847e653fadd71c pkg.csize=1358 pkg.size=3948",
+            ),
+            (
+                "pkg:/SUNWgmake@3.81-0.89",
+                "gmake - GNU make",
+                'set name=description value="gmake - GNU make"',
+            ),
+        ]
+    )
 
-        res_983_csl_dependency = set([
-            ('pkg:/SUNWgmake@3.81-0.89', 'require', 'depend fmri=pkg:/SUNWcsl@0.5.11-0.89 type=require')
-        ])
+    res_983_csl_dependency = set(
+        [
+            (
+                "pkg:/SUNWgmake@3.81-0.89",
+                "require",
+                "depend fmri=pkg:/SUNWcsl@0.5.11-0.89 type=require",
+            )
+        ]
+    )
 
-        res_983_bar_dependency = set([
-            ('pkg:/SUNWgmake@3.81-0.89', 'require', 'depend fmri=SUNWtestbar@0.5.11-0.111 type=require')
-        ])
+    res_983_bar_dependency = set(
+        [
+            (
+                "pkg:/SUNWgmake@3.81-0.89",
+                "require",
+                "depend fmri=SUNWtestbar@0.5.11-0.111 type=require",
+            )
+        ]
+    )
 
-        res_983_foo_dependency = set([
-            ('pkg:/SUNWgmake@3.81-0.89', 'incorporate', 'depend fmri=SUNWtestfoo@0.5.11-0.111 type=incorporate')
-        ])
+    res_983_foo_dependency = set(
+        [
+            (
+                "pkg:/SUNWgmake@3.81-0.89",
+                "incorporate",
+                "depend fmri=SUNWtestfoo@0.5.11-0.111 type=incorporate",
+            )
+        ]
+    )
 
-        res_local_pkg_ret_pkg = set([
-            "pkg:/example_pkg@1.0-0"
-        ])
+    res_local_pkg_ret_pkg = set(["pkg:/example_pkg@1.0-0"])
 
-        res_remote_pkg_ret_pkg = set([
-            "pkg:/example_pkg@1.0-0"
-        ])
+    res_remote_pkg_ret_pkg = set(["pkg:/example_pkg@1.0-0"])
 
-        res_remote_file = set([
-            ("pkg:/example_pkg@1.0-0",
-             "path",
-             "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
-             "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
-             "mode=0555 owner=root path=bin/example_path "
-             "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
-             "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
-             "pkg.csize=30 "
-             "pkg.size=12"),
-            ("pkg:/example_pkg@1.0-0",
-             "a686473102ba73bd7920fc0ab1d97e00a24ed704",
-             "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
-             "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
-             "mode=0555 owner=root path=bin/example_path "
-             "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
-             "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
-             "pkg.csize=30 "
-             "pkg.size=12"),
-             ("pkg:/example_pkg@1.0-0",
-             "hash",
-             "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
-             "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
-             "mode=0555 owner=root path=bin/example_path "
-             "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
-             "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
-             "pkg.csize=30 "
-             "pkg.size=12"),
-            ("pkg:/example_pkg@1.0-0",
-             "pkg.content-hash",
-             "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
-             "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
-             "mode=0555 owner=root path=bin/example_path "
-             "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
-             "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
-             "pkg.csize=30 "
-             "pkg.size=12")
-        ]) | res_remote_path
+    res_remote_file = (
+        set(
+            [
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "path",
+                    "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
+                    "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
+                    "mode=0555 owner=root path=bin/example_path "
+                    "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
+                    "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
+                    "pkg.csize=30 "
+                    "pkg.size=12",
+                ),
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "a686473102ba73bd7920fc0ab1d97e00a24ed704",
+                    "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
+                    "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
+                    "mode=0555 owner=root path=bin/example_path "
+                    "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
+                    "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
+                    "pkg.csize=30 "
+                    "pkg.size=12",
+                ),
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "hash",
+                    "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
+                    "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
+                    "mode=0555 owner=root path=bin/example_path "
+                    "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
+                    "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
+                    "pkg.csize=30 "
+                    "pkg.size=12",
+                ),
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "pkg.content-hash",
+                    "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
+                    "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
+                    "mode=0555 owner=root path=bin/example_path "
+                    "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
+                    "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
+                    "pkg.csize=30 "
+                    "pkg.size=12",
+                ),
+            ]
+        )
+        | res_remote_path
+    )
 
-        res_remote_url = set([
-            ('pkg:/example_pkg@1.0-0',
-            'http://service.opensolaris.com/xml/pkg/SUNWcsu@0.5.11,5.11-1:20080514I120000Z',
-            'set name=com.sun.service.info_url value=http://service.opensolaris.com/xml/pkg/SUNWcsu@0.5.11,5.11-1:20080514I120000Z'),
-        ])
+    res_remote_url = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "http://service.opensolaris.com/xml/pkg/SUNWcsu@0.5.11,5.11-1:20080514I120000Z",
+                "set name=com.sun.service.info_url value=http://service.opensolaris.com/xml/pkg/SUNWcsu@0.5.11,5.11-1:20080514I120000Z",
+            ),
+        ]
+    )
 
-        res_remote_path_extra = set([
-            ("pkg:/example_pkg@1.0-0",
-             "basename",
-             "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
-             "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
-             "mode=0555 owner=root path=bin/example_path "
-             "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
-             "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
-             "pkg.csize=30 "
-             "pkg.size=12"),
-            ("pkg:/example_pkg@1.0-0",
-             "path",
-             "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
-             "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
-             "mode=0555 owner=root path=bin/example_path "
-             "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
-             "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
-             "pkg.csize=30 "
-             "pkg.size=12"),
-            ("pkg:/example_pkg@1.0-0",
-             "a686473102ba73bd7920fc0ab1d97e00a24ed704",
-             "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
-             "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
-             "mode=0555 owner=root path=bin/example_path "
-             "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
-             "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
-             "pkg.csize=30 "
-             "pkg.size=12"),
-            ("pkg:/example_pkg@1.0-0",
-            "hash",
-            "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
-            "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
-            "mode=0555 owner=root path=bin/example_path "
-            "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
-            "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
-            "pkg.csize=30 "
-            "pkg.size=12"),
-            ("pkg:/example_pkg@1.0-0",
-             "pkg.content-hash",
-             "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
-             "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
-             "mode=0555 owner=root path=bin/example_path "
-             "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
-             "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
-             "pkg.csize=30 "
-             "pkg.size=12")
-        ])
+    res_remote_path_extra = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "basename",
+                "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
+                "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
+                "mode=0555 owner=root path=bin/example_path "
+                "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
+                "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
+                "pkg.csize=30 "
+                "pkg.size=12",
+            ),
+            (
+                "pkg:/example_pkg@1.0-0",
+                "path",
+                "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
+                "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
+                "mode=0555 owner=root path=bin/example_path "
+                "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
+                "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
+                "pkg.csize=30 "
+                "pkg.size=12",
+            ),
+            (
+                "pkg:/example_pkg@1.0-0",
+                "a686473102ba73bd7920fc0ab1d97e00a24ed704",
+                "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
+                "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
+                "mode=0555 owner=root path=bin/example_path "
+                "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
+                "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
+                "pkg.csize=30 "
+                "pkg.size=12",
+            ),
+            (
+                "pkg:/example_pkg@1.0-0",
+                "hash",
+                "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
+                "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
+                "mode=0555 owner=root path=bin/example_path "
+                "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
+                "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
+                "pkg.csize=30 "
+                "pkg.size=12",
+            ),
+            (
+                "pkg:/example_pkg@1.0-0",
+                "pkg.content-hash",
+                "file a686473102ba73bd7920fc0ab1d97e00a24ed704 "
+                "chash=f88920ce1f61db185d127ccb32dc8cf401ae7a83 group=bin "
+                "mode=0555 owner=root path=bin/example_path "
+                "pkg.content-hash=file:sha512t_256:e4e6f08153d331ec9d342f9f52c512fcbb2c4b46d4b5e8de5640ae5fbe022011 "
+                "pkg.content-hash=gzip:sha512t_256:98026acb06f550ed66c22b4314c3ca48a92fce49735aa4c61c5cb4330bb83b81 "
+                "pkg.csize=30 "
+                "pkg.size=12",
+            ),
+        ]
+    )
 
-        res_bad_pkg = set([
-            ('pkg:/bad_pkg@1.0-0', 'basename',
-             'dir group=bin mode=0755 owner=root path=badfoo/')
-        ])
+    res_bad_pkg = set(
+        [
+            (
+                "pkg:/bad_pkg@1.0-0",
+                "basename",
+                "dir group=bin mode=0755 owner=root path=badfoo/",
+            )
+        ]
+    )
 
-        hierarchical_named_pkg_res = set([
-            ("pkg:/pa/pb/pc/pfoo@1.0-0", "test/pa/pb/pc/pfoo", "set name=pkg.fmri value=pkg://test/pa/pb/pc/pfoo@1.0,5.11-0:")
-        ])
+    hierarchical_named_pkg_res = set(
+        [
+            (
+                "pkg:/pa/pb/pc/pfoo@1.0-0",
+                "test/pa/pb/pc/pfoo",
+                "set name=pkg.fmri value=pkg://test/pa/pb/pc/pfoo@1.0,5.11-0:",
+            )
+        ]
+    )
 
-        fast_add_after_install = set([
+    fast_add_after_install = set(
+        ["VERSION: 2\n", "pkg22@1.0,5.11", "pkg21@1.0,5.11"]
+    )
+
+    fast_remove_after_install = set(
+        [
             "VERSION: 2\n",
-            "pkg22@1.0,5.11",
-            "pkg21@1.0,5.11"
-        ])
+        ]
+    )
 
-        fast_remove_after_install = set([
-            "VERSION: 2\n",
-        ])
-
-        fast_add_after_first_update = set([
+    fast_add_after_first_update = set(
+        [
             "VERSION: 2\n",
             "pkg0@2.0,5.11",
             "pkg22@1.0,5.11",
             "pkg21@1.0,5.11",
-            "pkg1@2.0,5.11"
-        ])
+            "pkg1@2.0,5.11",
+        ]
+    )
 
-        fast_remove_after_first_update = set([
-            "VERSION: 2\n",
-            "pkg0@1.0,5.11",
-            "pkg1@1.0,5.11"
-        ])
+    fast_remove_after_first_update = set(
+        ["VERSION: 2\n", "pkg0@1.0,5.11", "pkg1@1.0,5.11"]
+    )
 
-        res_smf_svc = set([
-            ('pkg:/example_pkg@1.0-0',
-            'svc:/milestone/multi-user-server:default',
-            'set name=org.opensolaris.smf.fmri value=svc:/milestone/multi-user-server:default')
-        ])
+    res_smf_svc = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "svc:/milestone/multi-user-server:default",
+                "set name=org.opensolaris.smf.fmri value=svc:/milestone/multi-user-server:default",
+            )
+        ]
+    )
 
-        res_dir = set([
-            ('pkg:/example_pkg@1.0-0', 'path',
-            'dir group=bin mode=0755 owner=root path=bin/example_dir')])
+    res_dir = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "path",
+                "dir group=bin mode=0755 owner=root path=bin/example_dir",
+            )
+        ]
+    )
 
-        fast_add_after_second_update = set(["VERSION: 2\n"])
+    fast_add_after_second_update = set(["VERSION: 2\n"])
 
-        fast_remove_after_second_update = set(["VERSION: 2\n"])
+    fast_remove_after_second_update = set(["VERSION: 2\n"])
 
-        debug_features = []
+    debug_features = []
 
-        # We wire the contents of the example file to a well known string
-        # so that the hash is also well known.
-        misc_files = { "tmp/example_file" : "magic banana" }
+    # We wire the contents of the example file to a well known string
+    # so that the hash is also well known.
+    misc_files = {"tmp/example_file": "magic banana"}
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self,
-                    debug_features=self.debug_features, start_depot=True)
-                self.testdata_dir = os.path.join(self.test_root,
-                    "search_results")
-                os.mkdir(self.testdata_dir)
-                self._dir_restore_functions = [self._restore_dir,
-                    self._restore_dir_preserve_hash]
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(
+            self, debug_features=self.debug_features, start_depot=True
+        )
+        self.testdata_dir = os.path.join(self.test_root, "search_results")
+        os.mkdir(self.testdata_dir)
+        self._dir_restore_functions = [
+            self._restore_dir,
+            self._restore_dir_preserve_hash,
+        ]
+        self.make_misc_files(self.misc_files)
 
-        def _check(self, proposed_answer, correct_answer):
-                if correct_answer == proposed_answer:
-                        return True
-                else:
-                        self.debug("Proposed Answer: " + str(proposed_answer))
-                        self.debug("Correct Answer : " + str(correct_answer))
-                        if isinstance(correct_answer, set) and \
-                            isinstance(proposed_answer, set):
-                                self.debug("Missing: " +
-                                    str(correct_answer - proposed_answer))
-                                self.debug("Extra  : " +
-                                    str(proposed_answer - correct_answer))
-                        self.assertEqualDiff(correct_answer, proposed_answer)
+    def _check(self, proposed_answer, correct_answer):
+        if correct_answer == proposed_answer:
+            return True
+        else:
+            self.debug("Proposed Answer: " + str(proposed_answer))
+            self.debug("Correct Answer : " + str(correct_answer))
+            if isinstance(correct_answer, set) and isinstance(
+                proposed_answer, set
+            ):
+                self.debug("Missing: " + str(correct_answer - proposed_answer))
+                self.debug("Extra  : " + str(proposed_answer - correct_answer))
+            self.assertEqualDiff(correct_answer, proposed_answer)
 
-        def _get_repo_index_dir(self):
-                depotpath = self.dc.get_repodir()
-                repo = self.dc.get_repo()
-                rstore = repo.get_pub_rstore("test")
-                return rstore.index_root
+    def _get_repo_index_dir(self):
+        depotpath = self.dc.get_repodir()
+        repo = self.dc.get_repo()
+        rstore = repo.get_pub_rstore("test")
+        return rstore.index_root
 
-        def _get_repo_writ_dir(self):
-                depotpath = self.dc.get_repodir()
-                repo = self.dc.get_repo()
-                rstore = repo.get_pub_rstore("test")
-                return rstore.writable_root
+    def _get_repo_writ_dir(self):
+        depotpath = self.dc.get_repodir()
+        repo = self.dc.get_repo()
+        rstore = repo.get_pub_rstore("test")
+        return rstore.writable_root
 
-        def _get_repo_catalog(self):
-                repo = self.dc.get_repo()
-                rstore = repo.get_pub_rstore("test")
-                return rstore.catalog
+    def _get_repo_catalog(self):
+        repo = self.dc.get_repo()
+        rstore = repo.get_pub_rstore("test")
+        return rstore.catalog
 
-        @staticmethod
-        def _replace_act(act):
-                if act.startswith('set name=pkg.fmri'):
-                        return act.strip().rsplit(":", 1)[0] + ":"
-                else:
-                        return act.strip()
+    @staticmethod
+    def _replace_act(act):
+        if act.startswith("set name=pkg.fmri"):
+            return act.strip().rsplit(":", 1)[0] + ":"
+        else:
+            return act.strip()
 
-        @staticmethod
-        def _extract_action_from_res(it):
-                return (
-                    (fmri.PkgFmri(str(pkg_name)).get_short_fmri(), piece,
-                    TestApiSearchBasics._replace_act(act))
-                    for query_num, auth, (version, return_type,
-                    (pkg_name, piece, act))
-                    in it
-                )
+    @staticmethod
+    def _extract_action_from_res(it):
+        return (
+            (
+                fmri.PkgFmri(str(pkg_name)).get_short_fmri(),
+                piece,
+                TestApiSearchBasics._replace_act(act),
+            )
+            for query_num, auth, (
+                version,
+                return_type,
+                (pkg_name, piece, act),
+            ) in it
+        )
 
-        @staticmethod
-        def _extract_package_from_res(it):
-                return (
-                    (fmri.PkgFmri(str(pkg_name)).get_short_fmri())
-                    for query_num, auth, (version, return_type, pkg_name)
-                    in it
-                )
+    @staticmethod
+    def _extract_package_from_res(it):
+        return (
+            (fmri.PkgFmri(str(pkg_name)).get_short_fmri())
+            for query_num, auth, (version, return_type, pkg_name) in it
+        )
 
-        @staticmethod
-        def _get_lines(fp):
-                with open(fp, "r") as fh:
-                        lines = fh.readlines()
-                return lines
+    @staticmethod
+    def _get_lines(fp):
+        with open(fp, "r") as fh:
+            lines = fh.readlines()
+        return lines
 
-        def _search_op(self, api_obj, remote, token, test_value,
-            case_sensitive=False, return_actions=True, num_to_return=None,
-            start_point=None, servers=None, prune_versions=True):
-                query = [api.Query(token, case_sensitive, return_actions,
-                    num_to_return, start_point)]
-                self._search_op_common(api_obj, remote, query, test_value,
-                    return_actions, servers, prune_versions)
+    def _search_op(
+        self,
+        api_obj,
+        remote,
+        token,
+        test_value,
+        case_sensitive=False,
+        return_actions=True,
+        num_to_return=None,
+        start_point=None,
+        servers=None,
+        prune_versions=True,
+    ):
+        query = [
+            api.Query(
+                token,
+                case_sensitive,
+                return_actions,
+                num_to_return,
+                start_point,
+            )
+        ]
+        self._search_op_common(
+            api_obj,
+            remote,
+            query,
+            test_value,
+            return_actions,
+            servers,
+            prune_versions,
+        )
 
-        def _search_op_multi(self, api_obj, remote, tokens, test_value,
-            case_sensitive=False, return_actions=True, num_to_return=None,
-            start_point=None, servers=None, prune_versions=True):
-                query = [api.Query(token, case_sensitive, return_actions,
-                    num_to_return, start_point) for token in tokens]
-                self._search_op_common(api_obj, remote, query, test_value,
-                    return_actions, servers, prune_versions)
+    def _search_op_multi(
+        self,
+        api_obj,
+        remote,
+        tokens,
+        test_value,
+        case_sensitive=False,
+        return_actions=True,
+        num_to_return=None,
+        start_point=None,
+        servers=None,
+        prune_versions=True,
+    ):
+        query = [
+            api.Query(
+                token,
+                case_sensitive,
+                return_actions,
+                num_to_return,
+                start_point,
+            )
+            for token in tokens
+        ]
+        self._search_op_common(
+            api_obj,
+            remote,
+            query,
+            test_value,
+            return_actions,
+            servers,
+            prune_versions,
+        )
 
-        def _search_op_common(self, api_obj, remote, query, test_value,
-            return_actions, servers, prune_versions):
-                self.debug("Search for: {0}".format(" ".join([str(q) for q in query])))
-                search_func = api_obj.local_search
-                if remote:
-                        search_func = lambda x: api_obj.remote_search(x,
-                            servers=servers, prune_versions=prune_versions)
-                init_time = time.time()
+    def _search_op_common(
+        self,
+        api_obj,
+        remote,
+        query,
+        test_value,
+        return_actions,
+        servers,
+        prune_versions,
+    ):
+        self.debug("Search for: {0}".format(" ".join([str(q) for q in query])))
+        search_func = api_obj.local_search
+        if remote:
+            search_func = lambda x: api_obj.remote_search(
+                x, servers=servers, prune_versions=prune_versions
+            )
+        init_time = time.time()
 
-                # servers may not be ready immediately - retry search
-                # operation for 5 seconds
+        # servers may not be ready immediately - retry search
+        # operation for 5 seconds
 
-                while (time.time() - init_time) < 5:
-                        try:
-                                res = search_func(query)
-                                if return_actions:
-                                        res = self._extract_action_from_res(res)
-                                else:
-                                        res = self._extract_package_from_res(res)
-                                res = set(res)
-                                break
-                        except api_errors.ProblematicSearchServers as e:
-                                pass
-
-                self._check(set(res), test_value)
-
-        def _search_op_slow(self, api_obj, remote, token, test_value,
-            case_sensitive=False, return_actions=True, num_to_return=None,
-            start_point=None):
-                query = [api.Query(token, case_sensitive, return_actions,
-                    num_to_return, start_point)]
-                self._search_op_slow_common(api_obj, query, test_value,
-                    return_actions)
-
-        def _search_op_slow_multi(self, api_obj, remote, tokens, test_value,
-            case_sensitive=False, return_actions=True, num_to_return=None,
-            start_point=None):
-                query = [api.Query(token, case_sensitive, return_actions,
-                    num_to_return, start_point) for token in tokens]
-                self._search_op_slow_common(api_obj, query, test_value,
-                    return_actions)
-
-        def _search_op_slow_common(self, api_obj, query, test_value,
-            return_actions):
-                search_func = api_obj.local_search
-                tmp = search_func(query)
-                res = []
-                ssu = False
-                try:
-                        for i in tmp:
-                                res.append(i)
-                except api_errors.SlowSearchUsed:
-                        ssu = True
-                self.assertTrue(ssu)
+        while (time.time() - init_time) < 5:
+            try:
+                res = search_func(query)
                 if return_actions:
-                        res = self._extract_action_from_res(res)
+                    res = self._extract_action_from_res(res)
                 else:
-                        res = self._extract_package_from_res(res)
+                    res = self._extract_package_from_res(res)
                 res = set(res)
-                self._check(set(res), test_value)
+                break
+            except api_errors.ProblematicSearchServers as e:
+                pass
 
-        def _run_full_remote_tests(self, api_obj):
-                self._search_op(api_obj, True, "example_pkg",
-                    self.res_remote_pkg)
-                self._search_op(api_obj, True, "example_path",
-                    self.res_remote_path)
-                self._search_op(api_obj, True, "(example_path)",
-                    self.res_remote_path)
-                self._search_op(api_obj, True, "<exam*:::>",
-                    self.res_remote_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, True, "::com.sun.service.info_url:",
-                    self.res_remote_url)
-                self._search_op(api_obj, True, ":::e* AND *path",
-                    self.res_remote_path)
-                self._search_op(api_obj, True, "e* AND *path",
-                    self.res_remote_path)
-                self._search_op(api_obj, True, "<e*>",
-                    self.res_remote_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, True, "<e*> AND <e*>",
-                    self.res_remote_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, True, "<e*> OR <e*>",
-                    self.res_remote_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, True, "<exam:::>",
-                    self.res_remote_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, True, "exam:::e*path",
-                    self.res_remote_path)
-                self._search_op(api_obj, True, "exam:::e*path AND e*:::",
-                    self.res_remote_path)
-                self._search_op(api_obj, True, "e*::: AND exam:::*path",
-                    self.res_remote_path_extra)
-                self._search_op(api_obj, True, "example*",
-                    self.res_remote_wildcard)
-                self._search_op(api_obj, True, "example",
-                    self.res_remote_mediator)
-                self._search_op(api_obj, True, "7.0",
-                    self.res_remote_mediator_version)
-                self._search_op(api_obj, True, "unladen-swallow",
-                    self.res_remote_mediator_impl)
-                self._search_op(api_obj, True, "::mediator-implementation:unladen*",
-                    self.res_remote_mediator_impl)
-                self._search_op(api_obj, True, ":link:mediator:example",
-                    self.res_remote_mediator)
-                self._search_op(api_obj, True, ":link:mediator:example OR :link:mediator-version:7.0",
-                    self.res_remote_mediator_and_ver)
-                self._search_op(api_obj, True, ":link:mediator:example OR :link:mediator-version:7.0 OR :link:mediator-implementation:unladen-swallow",
-                    self.res_remote_mediator_and_ver_impl)
-                self._search_op(api_obj, True, "/bin", self.res_remote_bin)
-                self._search_op(api_obj, True, "4851433",
-                    self.res_remote_bug_id)
-                self._search_op(api_obj, True, "<4851433> AND <4725245>",
-                    self.res_remote_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, True, "4851433 AND 4725245",
-                    self.res_remote_bug_id)
-                self._search_op(api_obj, True,
-                    "4851433 AND 4725245 OR example_path",
-                    self.res_remote_bug_id)
-                self._search_op(api_obj, True,
-                    "4851433 AND (4725245 OR example_path)",
-                    self.res_remote_bug_id)
-                self._search_op(api_obj, True,
-                    "(4851433 AND 4725245) OR example_path",
-                    self.res_remote_bug_id | self.res_remote_path)
-                self._search_op(api_obj, True, "4851433 OR 4725245",
-                    self.res_remote_bug_id | self.res_remote_bug_id_4725245)
-                self._search_op(api_obj, True, "6556919",
-                    self.res_remote_inc_changes)
-                self._search_op(api_obj, True, "6556?19",
-                    self.res_remote_inc_changes)
-                self._search_op(api_obj, True, "42",
-                    self.res_remote_random_test)
-                self._search_op(api_obj, True, "79",
-                    self.res_remote_random_test_79)
-                self._search_op(api_obj, True, "separator",
-                    self.res_remote_keywords)
-                self._search_op(api_obj, True, "\"sort 0x86\"",
-                    self.res_remote_keywords)
-                self._search_op(api_obj, True, "*example*",
-                    self.res_remote_glob)
-                self._search_op(api_obj, True, "fooo", self.res_remote_foo)
-                self._search_op(api_obj, True, "fo*", self.res_remote_foo)
-                self._search_op(api_obj, True, "bar", self.res_remote_foo)
-                self._search_op(api_obj, True, "openssl",
-                    self.res_remote_openssl)
-                self._search_op(api_obj, True, "OPENSSL",
-                    self.res_remote_openssl)
-                self._search_op(api_obj, True, "OpEnSsL",
-                    self.res_remote_openssl)
-                # Test for bug 11235, case insensitive phrase search, and bug
-                # 11354, mangled fields during phrase search.
-                self._search_op(api_obj, True, "'OpEnSsL'",
-                    self.res_remote_openssl)
-                self._search_op(api_obj, True, "OpEnS*",
-                    self.res_remote_openssl)
+        self._check(set(res), test_value)
 
-                # These tests are included because a specific bug
-                # was found during development. This prevents regression back
-                # to that bug. Exit status of 1 is expected because the
-                # token isn't in the packages.
-                self._search_op(api_obj, True, "a_non_existent_token", set())
+    def _search_op_slow(
+        self,
+        api_obj,
+        remote,
+        token,
+        test_value,
+        case_sensitive=False,
+        return_actions=True,
+        num_to_return=None,
+        start_point=None,
+    ):
+        query = [
+            api.Query(
+                token,
+                case_sensitive,
+                return_actions,
+                num_to_return,
+                start_point,
+            )
+        ]
+        self._search_op_slow_common(api_obj, query, test_value, return_actions)
 
-                self._search_op(api_obj, True, "42 AND 4641790", set())
-                self.assertRaises(api_errors.BooleanQueryException,
-                    self._search_op, api_obj, True, "<e*> AND e*", set())
-                self.assertRaises(api_errors.BooleanQueryException,
-                    self._search_op, api_obj, True, "e* AND <e*>", set())
-                self.assertRaises(api_errors.BooleanQueryException,
-                    self._search_op, api_obj, True, "<e*> OR e*", set())
-                self.assertRaises(api_errors.BooleanQueryException,
-                    self._search_op, api_obj, True, "e* OR <e*>", set())
-                # Test for bug 15284, \ not being treated as an escape character
-                # for : as well as testing that \: when used with field queries
-                # works as expected.
-                svc_name = "svc\\:/milestone/multi-user-server\\:default"
-                self._search_op(api_obj, True,
-                    svc_name,
-                    self.res_smf_svc)
-                self._search_op(api_obj, True,
-                    "example_pkg:set:org.opensolaris.smf.fmri:{0}".format(svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, True,
-                    "set:org.opensolaris.smf.fmri:{0}".format(svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, True,
-                    "org.opensolaris.smf.fmri:{0}".format(svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, True,
-                    ":set:org.opensolaris.smf.fmri:{0}".format(svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, True,
-                    "{0} *milestone*".format(svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, True,
-                    "example_pkg:set:org.opensolaris.smf.fmri:{0} {1}".format(svc_name, svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, True,
-                    "example_pkg:set:org.opensolaris.smf.fmri:{0} example_pkg:set:org.opensolaris.smf.fmri:{1}".format(
-                    svc_name, svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, True,
-                    "{0} example_pkg:set:org.opensolaris.smf.fmri:{1}".format(
-                    svc_name, svc_name),
-                    self.res_smf_svc)
-                # Test that a single escaped colon doesn't cause a traceback.
-                self._search_op(api_obj, True, "\\:", set())
+    def _search_op_slow_multi(
+        self,
+        api_obj,
+        remote,
+        tokens,
+        test_value,
+        case_sensitive=False,
+        return_actions=True,
+        num_to_return=None,
+        start_point=None,
+    ):
+        query = [
+            api.Query(
+                token,
+                case_sensitive,
+                return_actions,
+                num_to_return,
+                start_point,
+            )
+            for token in tokens
+        ]
+        self._search_op_slow_common(api_obj, query, test_value, return_actions)
 
-                # Test that doing a search restricted to dir actions works
-                # correctly.  This is a test for bug 17645.
-                self._search_op(api_obj, True, "dir::/bin/example_dir",
-                    self.res_dir)
+    def _search_op_slow_common(
+        self, api_obj, query, test_value, return_actions
+    ):
+        search_func = api_obj.local_search
+        tmp = search_func(query)
+        res = []
+        ssu = False
+        try:
+            for i in tmp:
+                res.append(i)
+        except api_errors.SlowSearchUsed:
+            ssu = True
+        self.assertTrue(ssu)
+        if return_actions:
+            res = self._extract_action_from_res(res)
+        else:
+            res = self._extract_package_from_res(res)
+        res = set(res)
+        self._check(set(res), test_value)
 
-        def _run_remote_tests(self, api_obj):
-                self._search_op(api_obj, True, "example_pkg",
-                    self.res_remote_pkg)
-                self._search_op(api_obj, True, "example_path",
-                    self.res_remote_path)
-                self._search_op(api_obj, True, "::com.sun.service.info_url:",
-                    self.res_remote_url)
-                self._search_op(api_obj, True, "<e*>",
-                    self.res_remote_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, True, "<exam:::>",
-                    self.res_remote_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, True, "exam:::e*path",
-                    self.res_remote_path)
-                self._search_op(api_obj, True, "example*",
-                    self.res_remote_wildcard)
-                self._search_op(api_obj, True, "/bin", self.res_remote_bin)
-                self._search_op(api_obj, True, "4851433",
-                    self.res_remote_bug_id)
-                self._search_op(api_obj, True, "4725245",
-                    self.res_remote_bug_id_4725245)
-                self._search_op(api_obj, True, "6556919",
-                    self.res_remote_inc_changes)
-                self._search_op(api_obj, True, "42",
-                    self.res_remote_random_test)
-                self._search_op(api_obj, True, "79",
-                    self.res_remote_random_test_79)
-                self._search_op(api_obj, True, "separator",
-                    self.res_remote_keywords)
-                self._search_op(api_obj, True, "\"sort 0x86\"",
-                    self.res_remote_keywords)
-                self._search_op(api_obj, True, "*example*",
-                    self.res_remote_glob)
-                self._search_op(api_obj, True, "fooo", self.res_remote_foo)
-                self._search_op(api_obj, True, "bar", self.res_remote_foo)
-                self._search_op(api_obj, True, "OpEnSsL",
-                    self.res_remote_openssl)
+    def _run_full_remote_tests(self, api_obj):
+        self._search_op(api_obj, True, "example_pkg", self.res_remote_pkg)
+        self._search_op(api_obj, True, "example_path", self.res_remote_path)
+        self._search_op(api_obj, True, "(example_path)", self.res_remote_path)
+        self._search_op(
+            api_obj,
+            True,
+            "<exam*:::>",
+            self.res_remote_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj, True, "::com.sun.service.info_url:", self.res_remote_url
+        )
+        self._search_op(api_obj, True, ":::e* AND *path", self.res_remote_path)
+        self._search_op(api_obj, True, "e* AND *path", self.res_remote_path)
+        self._search_op(
+            api_obj,
+            True,
+            "<e*>",
+            self.res_remote_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "<e*> AND <e*>",
+            self.res_remote_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "<e*> OR <e*>",
+            self.res_remote_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "<exam:::>",
+            self.res_remote_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(api_obj, True, "exam:::e*path", self.res_remote_path)
+        self._search_op(
+            api_obj, True, "exam:::e*path AND e*:::", self.res_remote_path
+        )
+        self._search_op(
+            api_obj, True, "e*::: AND exam:::*path", self.res_remote_path_extra
+        )
+        self._search_op(api_obj, True, "example*", self.res_remote_wildcard)
+        self._search_op(api_obj, True, "example", self.res_remote_mediator)
+        self._search_op(api_obj, True, "7.0", self.res_remote_mediator_version)
+        self._search_op(
+            api_obj, True, "unladen-swallow", self.res_remote_mediator_impl
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "::mediator-implementation:unladen*",
+            self.res_remote_mediator_impl,
+        )
+        self._search_op(
+            api_obj, True, ":link:mediator:example", self.res_remote_mediator
+        )
+        self._search_op(
+            api_obj,
+            True,
+            ":link:mediator:example OR :link:mediator-version:7.0",
+            self.res_remote_mediator_and_ver,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            ":link:mediator:example OR :link:mediator-version:7.0 OR :link:mediator-implementation:unladen-swallow",
+            self.res_remote_mediator_and_ver_impl,
+        )
+        self._search_op(api_obj, True, "/bin", self.res_remote_bin)
+        self._search_op(api_obj, True, "4851433", self.res_remote_bug_id)
+        self._search_op(
+            api_obj,
+            True,
+            "<4851433> AND <4725245>",
+            self.res_remote_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj, True, "4851433 AND 4725245", self.res_remote_bug_id
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "4851433 AND 4725245 OR example_path",
+            self.res_remote_bug_id,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "4851433 AND (4725245 OR example_path)",
+            self.res_remote_bug_id,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "(4851433 AND 4725245) OR example_path",
+            self.res_remote_bug_id | self.res_remote_path,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "4851433 OR 4725245",
+            self.res_remote_bug_id | self.res_remote_bug_id_4725245,
+        )
+        self._search_op(api_obj, True, "6556919", self.res_remote_inc_changes)
+        self._search_op(api_obj, True, "6556?19", self.res_remote_inc_changes)
+        self._search_op(api_obj, True, "42", self.res_remote_random_test)
+        self._search_op(api_obj, True, "79", self.res_remote_random_test_79)
+        self._search_op(api_obj, True, "separator", self.res_remote_keywords)
+        self._search_op(api_obj, True, '"sort 0x86"', self.res_remote_keywords)
+        self._search_op(api_obj, True, "*example*", self.res_remote_glob)
+        self._search_op(api_obj, True, "fooo", self.res_remote_foo)
+        self._search_op(api_obj, True, "fo*", self.res_remote_foo)
+        self._search_op(api_obj, True, "bar", self.res_remote_foo)
+        self._search_op(api_obj, True, "openssl", self.res_remote_openssl)
+        self._search_op(api_obj, True, "OPENSSL", self.res_remote_openssl)
+        self._search_op(api_obj, True, "OpEnSsL", self.res_remote_openssl)
+        # Test for bug 11235, case insensitive phrase search, and bug
+        # 11354, mangled fields during phrase search.
+        self._search_op(api_obj, True, "'OpEnSsL'", self.res_remote_openssl)
+        self._search_op(api_obj, True, "OpEnS*", self.res_remote_openssl)
 
-                # These tests are included because a specific bug
-                # was found during development. This prevents regression back
-                # to that bug.
-                self._search_op(api_obj, True, "a_non_existent_token", set())
+        # These tests are included because a specific bug
+        # was found during development. This prevents regression back
+        # to that bug. Exit status of 1 is expected because the
+        # token isn't in the packages.
+        self._search_op(api_obj, True, "a_non_existent_token", set())
 
-        def _run_full_local_tests(self, api_obj):
-                outfile = os.path.join(self.testdata_dir, "res")
+        self._search_op(api_obj, True, "42 AND 4641790", set())
+        self.assertRaises(
+            api_errors.BooleanQueryException,
+            self._search_op,
+            api_obj,
+            True,
+            "<e*> AND e*",
+            set(),
+        )
+        self.assertRaises(
+            api_errors.BooleanQueryException,
+            self._search_op,
+            api_obj,
+            True,
+            "e* AND <e*>",
+            set(),
+        )
+        self.assertRaises(
+            api_errors.BooleanQueryException,
+            self._search_op,
+            api_obj,
+            True,
+            "<e*> OR e*",
+            set(),
+        )
+        self.assertRaises(
+            api_errors.BooleanQueryException,
+            self._search_op,
+            api_obj,
+            True,
+            "e* OR <e*>",
+            set(),
+        )
+        # Test for bug 15284, \ not being treated as an escape character
+        # for : as well as testing that \: when used with field queries
+        # works as expected.
+        svc_name = "svc\\:/milestone/multi-user-server\\:default"
+        self._search_op(api_obj, True, svc_name, self.res_smf_svc)
+        self._search_op(
+            api_obj,
+            True,
+            "example_pkg:set:org.opensolaris.smf.fmri:{0}".format(svc_name),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "set:org.opensolaris.smf.fmri:{0}".format(svc_name),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "org.opensolaris.smf.fmri:{0}".format(svc_name),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            ":set:org.opensolaris.smf.fmri:{0}".format(svc_name),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj, True, "{0} *milestone*".format(svc_name), self.res_smf_svc
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "example_pkg:set:org.opensolaris.smf.fmri:{0} {1}".format(
+                svc_name, svc_name
+            ),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "example_pkg:set:org.opensolaris.smf.fmri:{0} example_pkg:set:org.opensolaris.smf.fmri:{1}".format(
+                svc_name, svc_name
+            ),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "{0} example_pkg:set:org.opensolaris.smf.fmri:{1}".format(
+                svc_name, svc_name
+            ),
+            self.res_smf_svc,
+        )
+        # Test that a single escaped colon doesn't cause a traceback.
+        self._search_op(api_obj, True, "\\:", set())
 
-                # This finds something because the client side
-                # manifest has had the name of the package inserted
-                # into it.
+        # Test that doing a search restricted to dir actions works
+        # correctly.  This is a test for bug 17645.
+        self._search_op(api_obj, True, "dir::/bin/example_dir", self.res_dir)
 
-                self._search_op(api_obj, False, "example_pkg",
-                    self.res_local_pkg)
-                self._search_op(api_obj, False, "example_path",
-                    self.res_local_path)
-                self._search_op(api_obj, False, "(example_path)",
-                    self.res_local_path)
-                self._search_op(api_obj, False, "<exam*:::>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, False, "::com.sun.service.info_url:",
-                    self.res_remote_url)
-                self._search_op(api_obj, False, ":::e* AND *path",
-                    self.res_local_path)
-                self._search_op(api_obj, False, "e* AND *path",
-                    self.res_local_path)
-                self._search_op(api_obj, False, "<e*>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, False, "<e*> AND <e*>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, False, "<e*> OR <e*>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, False, "<exam:::>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, False, "exam:::e*path",
-                    self.res_local_path)
-                self._search_op(api_obj, False, "exam:::e*path AND e*:::",
-                    self.res_local_path)
-                self._search_op(api_obj, False, "e*::: AND exam:::*path",
-                    self.res_remote_path_extra)
-                self._search_op(api_obj, False, "example*",
-                    self.res_local_wildcard)
-                self._search_op(api_obj, True, "example",
-                    self.res_local_mediator)
-                self._search_op(api_obj, True, "7.0",
-                    self.res_local_mediator_version)
-                self._search_op(api_obj, True, "unladen-swallow",
-                    self.res_local_mediator_impl)
-                self._search_op(api_obj, True, "::mediator-implementation:unladen*",
-                    self.res_local_mediator_impl)
-                self._search_op(api_obj, True, ":link:mediator:example",
-                    self.res_local_mediator)
-                self._search_op(api_obj, True, ":link:mediator:example OR :link:mediator-version:7.0",
-                    self.res_local_mediator_and_ver)
-                self._search_op(api_obj, True, ":link:mediator:example OR :link:mediator-version:7.0 OR :link:mediator-implementation:unladen-swallow",
-                    self.res_local_mediator_and_ver_impl)
-                self._search_op(api_obj, False, "/bin", self.res_local_bin)
-                self._search_op(api_obj, False, "4851433",
-                    self.res_local_bug_id)
-                self._search_op(api_obj, False, "<4851433> AND <4725245>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, False, "4851433 AND 4725245",
-                    self.res_local_bug_id)
-                self._search_op(api_obj, False,
-                    "4851433 AND 4725245 OR example_path",
-                    self.res_local_bug_id)
-                self._search_op(api_obj, False,
-                    "4851433 AND (4725245 OR example_path)",
-                    self.res_local_bug_id)
-                self._search_op(api_obj, False,
-                    "(4851433 AND 4725245) OR example_path",
-                    self.res_local_bug_id | self.res_local_path)
-                self._search_op(api_obj, False, "4851433 OR 4725245",
-                    self.res_local_bug_id | self.res_remote_bug_id_4725245)
-                self._search_op(api_obj, False, "6556919",
-                    self.res_local_inc_changes)
-                self._search_op(api_obj, False, "65569??",
-                    self.res_local_inc_changes)
-                self._search_op(api_obj, False, "42",
-                    self.res_local_random_test)
-                self._search_op(api_obj, False, "79",
-                    self.res_remote_random_test_79)
-                self._search_op(api_obj, False, "separator",
-                    self.res_local_keywords)
-                self._search_op(api_obj, False, "\"sort 0x86\"",
-                    self.res_remote_keywords)
-                self._search_op(api_obj, False, "*example*",
-                    self.res_local_glob)
-                self._search_op(api_obj, False, "fooo", self.res_local_foo)
-                self._search_op(api_obj, False, "fo*", self.res_local_foo)
-                self._search_op(api_obj, False, "bar", self.res_local_foo)
-                self._search_op(api_obj, False, "openssl",
-                    self.res_local_openssl)
-                self._search_op(api_obj, False, "OPENSSL",
-                    self.res_local_openssl)
-                self._search_op(api_obj, False, "OpEnSsL",
-                    self.res_local_openssl)
-                # Test for bug 11235, case insensitive phrase search, and bug
-                # 11354, mangled fields during phrase search.
-                self._search_op(api_obj, False, "'OpEnSsL'",
-                    self.res_remote_openssl)
-                self._search_op(api_obj, False, "OpEnS*",
-                    self.res_local_openssl)
-                # These tests are included because a specific bug
-                # was found during development. These tests prevent regression
-                # back to that bug. Exit status of 1 is expected because the
-                # token isn't in the packages.
-                self._search_op(api_obj, False, "a_non_existent_token", set())
-                self._search_op(api_obj, False, "42 AND 4641790", set())
-                self.assertRaises(api_errors.BooleanQueryException,
-                    self._search_op, api_obj, False, "<e*> AND e*", set())
-                self.assertRaises(api_errors.BooleanQueryException,
-                    self._search_op, api_obj, False, "e* AND <e*>", set())
-                self.assertRaises(api_errors.BooleanQueryException,
-                    self._search_op, api_obj, False, "<e*> OR e*", set())
-                self.assertRaises(api_errors.BooleanQueryException,
-                    self._search_op, api_obj, False, "e* OR <e*>", set())
-                # Test for bug 15284, \ not being treated as an escape character
-                # for : as well as testing that \: when used with field queries
-                # works as expected.
-                svc_name = "svc\\:/milestone/multi-user-server\\:default"
-                self._search_op(api_obj, False,
-                    svc_name,
-                    self.res_smf_svc)
-                self._search_op(api_obj, False,
-                    "example_pkg:set:org.opensolaris.smf.fmri:{0}".format(svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, False,
-                    "set:org.opensolaris.smf.fmri:{0}".format(svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, False,
-                    "org.opensolaris.smf.fmri:{0}".format(svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, False,
-                    ":set:org.opensolaris.smf.fmri:{0}".format(svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, False,
-                    "{0} *milestone*".format(svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, False,
-                    "example_pkg:set:org.opensolaris.smf.fmri:{0} {1}".format(svc_name, svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, False,
-                    "example_pkg:set:org.opensolaris.smf.fmri:{0} example_pkg:set:org.opensolaris.smf.fmri:{1}".format(
-                    svc_name, svc_name),
-                    self.res_smf_svc)
-                self._search_op(api_obj, False,
-                    "{0} example_pkg:set:org.opensolaris.smf.fmri:{1}".format(
-                    svc_name, svc_name),
-                    self.res_smf_svc)
-                # Test that a single escaped colon doesn't cause a traceback.
-                self._search_op(api_obj, True, "\\:", set())
+    def _run_remote_tests(self, api_obj):
+        self._search_op(api_obj, True, "example_pkg", self.res_remote_pkg)
+        self._search_op(api_obj, True, "example_path", self.res_remote_path)
+        self._search_op(
+            api_obj, True, "::com.sun.service.info_url:", self.res_remote_url
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "<e*>",
+            self.res_remote_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "<exam:::>",
+            self.res_remote_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(api_obj, True, "exam:::e*path", self.res_remote_path)
+        self._search_op(api_obj, True, "example*", self.res_remote_wildcard)
+        self._search_op(api_obj, True, "/bin", self.res_remote_bin)
+        self._search_op(api_obj, True, "4851433", self.res_remote_bug_id)
+        self._search_op(
+            api_obj, True, "4725245", self.res_remote_bug_id_4725245
+        )
+        self._search_op(api_obj, True, "6556919", self.res_remote_inc_changes)
+        self._search_op(api_obj, True, "42", self.res_remote_random_test)
+        self._search_op(api_obj, True, "79", self.res_remote_random_test_79)
+        self._search_op(api_obj, True, "separator", self.res_remote_keywords)
+        self._search_op(api_obj, True, '"sort 0x86"', self.res_remote_keywords)
+        self._search_op(api_obj, True, "*example*", self.res_remote_glob)
+        self._search_op(api_obj, True, "fooo", self.res_remote_foo)
+        self._search_op(api_obj, True, "bar", self.res_remote_foo)
+        self._search_op(api_obj, True, "OpEnSsL", self.res_remote_openssl)
 
-        def _run_local_tests(self, api_obj):
-                outfile = os.path.join(self.testdata_dir, "res")
+        # These tests are included because a specific bug
+        # was found during development. This prevents regression back
+        # to that bug.
+        self._search_op(api_obj, True, "a_non_existent_token", set())
 
-                # This finds something because the client side
-                # manifest has had the name of the package inserted
-                # into it.
+    def _run_full_local_tests(self, api_obj):
+        outfile = os.path.join(self.testdata_dir, "res")
 
-                self._search_op(api_obj, False, "example_pkg",
-                    self.res_local_pkg)
-                self._search_op(api_obj, False, "example_path",
-                    self.res_local_path)
-                self._search_op(api_obj, False, "::com.sun.service.info_url:",
-                    self.res_remote_url)
-                self._search_op(api_obj, False, "<e*>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, False, "<exam:::>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op(api_obj, False, "exam:::e*path",
-                    self.res_local_path)
-                self._search_op(api_obj, False, "example*",
-                    self.res_local_wildcard)
-                self._search_op(api_obj, False, "/bin", self.res_local_bin)
-                self._search_op(api_obj, False, "4851433",
-                    self.res_local_bug_id)
-                self._search_op(api_obj, False, "4725245",
-                    self.res_remote_bug_id_4725245)
-                self._search_op(api_obj, False, "6556919",
-                    self.res_local_inc_changes)
-                self._search_op(api_obj, False, "42",
-                    self.res_local_random_test)
-                self._search_op(api_obj, False, "79",
-                    self.res_remote_random_test_79)
-                self._search_op(api_obj, False, "separator",
-                    self.res_local_keywords)
-                self._search_op(api_obj, False, "\"sort 0x86\"",
-                    self.res_remote_keywords)
-                self._search_op(api_obj, False, "*example*",
-                    self.res_local_glob)
-                self._search_op(api_obj, False, "fooo", self.res_local_foo)
-                self._search_op(api_obj, False, "bar", self.res_local_foo)
-                self._search_op(api_obj, False, "OpEnSsL",
-                    self.res_local_openssl)
-                # These tests are included because a specific bug
-                # was found during development. These tests prevent regression
-                # back to that bug.
-                self._search_op(api_obj, False, "a_non_existent_token", set())
+        # This finds something because the client side
+        # manifest has had the name of the package inserted
+        # into it.
 
-                # Test that doing a search restricted to dir actions works
-                # correctly.  This is a test for bug 17645.
-                self._search_op(api_obj, False, "dir::/bin/example_dir",
-                    self.res_dir)
+        self._search_op(api_obj, False, "example_pkg", self.res_local_pkg)
+        self._search_op(api_obj, False, "example_path", self.res_local_path)
+        self._search_op(api_obj, False, "(example_path)", self.res_local_path)
+        self._search_op(
+            api_obj,
+            False,
+            "<exam*:::>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj, False, "::com.sun.service.info_url:", self.res_remote_url
+        )
+        self._search_op(api_obj, False, ":::e* AND *path", self.res_local_path)
+        self._search_op(api_obj, False, "e* AND *path", self.res_local_path)
+        self._search_op(
+            api_obj,
+            False,
+            "<e*>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "<e*> AND <e*>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "<e*> OR <e*>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "<exam:::>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(api_obj, False, "exam:::e*path", self.res_local_path)
+        self._search_op(
+            api_obj, False, "exam:::e*path AND e*:::", self.res_local_path
+        )
+        self._search_op(
+            api_obj, False, "e*::: AND exam:::*path", self.res_remote_path_extra
+        )
+        self._search_op(api_obj, False, "example*", self.res_local_wildcard)
+        self._search_op(api_obj, True, "example", self.res_local_mediator)
+        self._search_op(api_obj, True, "7.0", self.res_local_mediator_version)
+        self._search_op(
+            api_obj, True, "unladen-swallow", self.res_local_mediator_impl
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "::mediator-implementation:unladen*",
+            self.res_local_mediator_impl,
+        )
+        self._search_op(
+            api_obj, True, ":link:mediator:example", self.res_local_mediator
+        )
+        self._search_op(
+            api_obj,
+            True,
+            ":link:mediator:example OR :link:mediator-version:7.0",
+            self.res_local_mediator_and_ver,
+        )
+        self._search_op(
+            api_obj,
+            True,
+            ":link:mediator:example OR :link:mediator-version:7.0 OR :link:mediator-implementation:unladen-swallow",
+            self.res_local_mediator_and_ver_impl,
+        )
+        self._search_op(api_obj, False, "/bin", self.res_local_bin)
+        self._search_op(api_obj, False, "4851433", self.res_local_bug_id)
+        self._search_op(
+            api_obj,
+            False,
+            "<4851433> AND <4725245>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj, False, "4851433 AND 4725245", self.res_local_bug_id
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "4851433 AND 4725245 OR example_path",
+            self.res_local_bug_id,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "4851433 AND (4725245 OR example_path)",
+            self.res_local_bug_id,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "(4851433 AND 4725245) OR example_path",
+            self.res_local_bug_id | self.res_local_path,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "4851433 OR 4725245",
+            self.res_local_bug_id | self.res_remote_bug_id_4725245,
+        )
+        self._search_op(api_obj, False, "6556919", self.res_local_inc_changes)
+        self._search_op(api_obj, False, "65569??", self.res_local_inc_changes)
+        self._search_op(api_obj, False, "42", self.res_local_random_test)
+        self._search_op(api_obj, False, "79", self.res_remote_random_test_79)
+        self._search_op(api_obj, False, "separator", self.res_local_keywords)
+        self._search_op(api_obj, False, '"sort 0x86"', self.res_remote_keywords)
+        self._search_op(api_obj, False, "*example*", self.res_local_glob)
+        self._search_op(api_obj, False, "fooo", self.res_local_foo)
+        self._search_op(api_obj, False, "fo*", self.res_local_foo)
+        self._search_op(api_obj, False, "bar", self.res_local_foo)
+        self._search_op(api_obj, False, "openssl", self.res_local_openssl)
+        self._search_op(api_obj, False, "OPENSSL", self.res_local_openssl)
+        self._search_op(api_obj, False, "OpEnSsL", self.res_local_openssl)
+        # Test for bug 11235, case insensitive phrase search, and bug
+        # 11354, mangled fields during phrase search.
+        self._search_op(api_obj, False, "'OpEnSsL'", self.res_remote_openssl)
+        self._search_op(api_obj, False, "OpEnS*", self.res_local_openssl)
+        # These tests are included because a specific bug
+        # was found during development. These tests prevent regression
+        # back to that bug. Exit status of 1 is expected because the
+        # token isn't in the packages.
+        self._search_op(api_obj, False, "a_non_existent_token", set())
+        self._search_op(api_obj, False, "42 AND 4641790", set())
+        self.assertRaises(
+            api_errors.BooleanQueryException,
+            self._search_op,
+            api_obj,
+            False,
+            "<e*> AND e*",
+            set(),
+        )
+        self.assertRaises(
+            api_errors.BooleanQueryException,
+            self._search_op,
+            api_obj,
+            False,
+            "e* AND <e*>",
+            set(),
+        )
+        self.assertRaises(
+            api_errors.BooleanQueryException,
+            self._search_op,
+            api_obj,
+            False,
+            "<e*> OR e*",
+            set(),
+        )
+        self.assertRaises(
+            api_errors.BooleanQueryException,
+            self._search_op,
+            api_obj,
+            False,
+            "e* OR <e*>",
+            set(),
+        )
+        # Test for bug 15284, \ not being treated as an escape character
+        # for : as well as testing that \: when used with field queries
+        # works as expected.
+        svc_name = "svc\\:/milestone/multi-user-server\\:default"
+        self._search_op(api_obj, False, svc_name, self.res_smf_svc)
+        self._search_op(
+            api_obj,
+            False,
+            "example_pkg:set:org.opensolaris.smf.fmri:{0}".format(svc_name),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "set:org.opensolaris.smf.fmri:{0}".format(svc_name),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "org.opensolaris.smf.fmri:{0}".format(svc_name),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            ":set:org.opensolaris.smf.fmri:{0}".format(svc_name),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj, False, "{0} *milestone*".format(svc_name), self.res_smf_svc
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "example_pkg:set:org.opensolaris.smf.fmri:{0} {1}".format(
+                svc_name, svc_name
+            ),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "example_pkg:set:org.opensolaris.smf.fmri:{0} example_pkg:set:org.opensolaris.smf.fmri:{1}".format(
+                svc_name, svc_name
+            ),
+            self.res_smf_svc,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "{0} example_pkg:set:org.opensolaris.smf.fmri:{1}".format(
+                svc_name, svc_name
+            ),
+            self.res_smf_svc,
+        )
+        # Test that a single escaped colon doesn't cause a traceback.
+        self._search_op(api_obj, True, "\\:", set())
 
-        def _run_degraded_local_tests(self, api_obj):
-                outfile = os.path.join(self.testdata_dir, "res")
+    def _run_local_tests(self, api_obj):
+        outfile = os.path.join(self.testdata_dir, "res")
 
-                # This finds something because the client side
-                # manifest has had the name of the package inserted
-                # into it.
+        # This finds something because the client side
+        # manifest has had the name of the package inserted
+        # into it.
 
-                self._search_op_slow(api_obj, False, "example_pkg",
-                    self.res_local_pkg)
-                self._search_op_slow(api_obj, False, "example_path",
-                    self.res_local_path)
-                self._search_op_slow(api_obj, False, "(example_path)",
-                    self.res_local_path)
-                self._search_op_slow(api_obj, False, "<exam*:::>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op_slow(api_obj, False,
-                    "::com.sun.service.info_url:",
-                    self.res_remote_url)
-                self._search_op_slow(api_obj, False, ":::e* AND *path",
-                    self.res_local_path)
-                self._search_op_slow(api_obj, False, "e* AND *path",
-                    self.res_local_path)
-                self._search_op_slow(api_obj, False, "<e*>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op_slow(api_obj, False, "<e*> AND <e*>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op_slow(api_obj, False, "<e*> OR <e*>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op_slow(api_obj, False, "<exam:::>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op_slow(api_obj, False, "exam:::e*path",
-                    self.res_local_path)
-                self._search_op_slow(api_obj, False, "exam:::e*path AND e*:::",
-                    self.res_local_path)
-                self._search_op_slow(api_obj, False, "e*::: AND exam:::*path",
-                    self.res_remote_path_extra)
-                self._search_op_slow(api_obj, False, "example*",
-                    self.res_local_wildcard)
-                self._search_op_slow(api_obj, True, "example",
-                    self.res_local_mediator)
-                self._search_op_slow(api_obj, True, "7.0",
-                    self.res_local_mediator_version)
-                self._search_op_slow(api_obj, True, "unladen-swallow",
-                    self.res_local_mediator_impl)
-                self._search_op_slow(api_obj, True,
-                    "::mediator-implementation:unladen*",
-                    self.res_local_mediator_impl)
-                self._search_op_slow(api_obj, True, ":link:mediator:example",
-                    self.res_local_mediator)
-                self._search_op_slow(api_obj, True,
-                    ":link:mediator:example OR :link:mediator-version:7.0",
-                    self.res_local_mediator_and_ver)
-                self._search_op_slow(api_obj, True,
-                    ":link:mediator:example OR :link:mediator-version:7.0 OR :link:mediator-implementation:unladen-swallow",
-                    self.res_local_mediator_and_ver_impl)
-                self._search_op_slow(api_obj, False, "/bin", self.res_local_bin)
-                self._search_op_slow(api_obj, False, "4851433",
-                    self.res_local_bug_id)
-                self._search_op_slow(api_obj, False, "<4851433> AND <4725245>",
-                    self.res_local_pkg_ret_pkg, return_actions=False)
-                self._search_op_slow(api_obj, False, "4851433 AND 4725245",
-                    self.res_local_bug_id)
-                self._search_op_slow(api_obj, False,
-                    "4851433 AND 4725245 OR example_path",
-                    self.res_local_bug_id)
-                self._search_op_slow(api_obj, False,
-                    "4851433 AND (4725245 OR example_path)",
-                    self.res_local_bug_id)
-                self._search_op_slow(api_obj, False,
-                    "(4851433 AND 4725245) OR example_path",
-                    self.res_local_bug_id | self.res_local_path)
-                self._search_op_slow(api_obj, False, "4851433 OR 4725245",
-                    self.res_local_bug_id | self.res_remote_bug_id_4725245)
-                self._search_op_slow(api_obj, False, "6556919",
-                    self.res_local_inc_changes)
-                self._search_op_slow(api_obj, False, "65569??",
-                    self.res_local_inc_changes)
-                self._search_op_slow(api_obj, False, "42",
-                    self.res_local_random_test)
-                self._search_op_slow(api_obj, False, "79",
-                    self.res_remote_random_test_79)
-                self._search_op_slow(api_obj, False, "separator",
-                    self.res_local_keywords)
-                self._search_op_slow(api_obj, False, "\"sort 0x86\"",
-                    self.res_remote_keywords)
-                self._search_op_slow(api_obj, False, "*example*",
-                    self.res_local_glob)
-                self._search_op_slow(api_obj, False, "fooo", self.res_local_foo)
-                self._search_op_slow(api_obj, False, "fo*", self.res_local_foo)
-                self._search_op_slow(api_obj, False, "bar", self.res_local_foo)
-                self._search_op_slow(api_obj, False, "openssl",
-                    self.res_local_openssl)
-                self._search_op_slow(api_obj, False, "OPENSSL",
-                    self.res_local_openssl)
-                self._search_op_slow(api_obj, False, "OpEnSsL",
-                    self.res_local_openssl)
-                self._search_op_slow(api_obj, False, "OpEnS*",
-                    self.res_local_openssl)
-                # These tests are included because a specific bug
-                # was found during development. These tests prevent regression
-                # back to that bug. Exit status of 1 is expected because the
-                # token isn't in the packages.
-                self._search_op_slow(api_obj, False, "a_non_existent_token",
-                    set())
+        self._search_op(api_obj, False, "example_pkg", self.res_local_pkg)
+        self._search_op(api_obj, False, "example_path", self.res_local_path)
+        self._search_op(
+            api_obj, False, "::com.sun.service.info_url:", self.res_remote_url
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "<e*>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(
+            api_obj,
+            False,
+            "<exam:::>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op(api_obj, False, "exam:::e*path", self.res_local_path)
+        self._search_op(api_obj, False, "example*", self.res_local_wildcard)
+        self._search_op(api_obj, False, "/bin", self.res_local_bin)
+        self._search_op(api_obj, False, "4851433", self.res_local_bug_id)
+        self._search_op(
+            api_obj, False, "4725245", self.res_remote_bug_id_4725245
+        )
+        self._search_op(api_obj, False, "6556919", self.res_local_inc_changes)
+        self._search_op(api_obj, False, "42", self.res_local_random_test)
+        self._search_op(api_obj, False, "79", self.res_remote_random_test_79)
+        self._search_op(api_obj, False, "separator", self.res_local_keywords)
+        self._search_op(api_obj, False, '"sort 0x86"', self.res_remote_keywords)
+        self._search_op(api_obj, False, "*example*", self.res_local_glob)
+        self._search_op(api_obj, False, "fooo", self.res_local_foo)
+        self._search_op(api_obj, False, "bar", self.res_local_foo)
+        self._search_op(api_obj, False, "OpEnSsL", self.res_local_openssl)
+        # These tests are included because a specific bug
+        # was found during development. These tests prevent regression
+        # back to that bug.
+        self._search_op(api_obj, False, "a_non_existent_token", set())
 
-        def _run_remove_root_search(self, search_func, remote, api_obj, ip):
-                search_func(api_obj, remote, [ip + "example_pkg"], set())
-                search_func(api_obj, remote, [ip + "bin/example_path"],
-                    self.res_remote_path_of_example_path)
-                search_func(api_obj, remote, ["({0}bin/example_path)".format(ip)],
-                    self.res_remote_path_of_example_path)
-                search_func(api_obj, remote, ["<{0}exam*:::>".format(ip)],
-                    set(), return_actions=False)
-                search_func(api_obj, remote,
-                    ["::{0}com.sun.service.info_url:".format(ip)], set())
-                search_func(api_obj, remote,
-                    ["{0}bin/e* AND {1}*path".format(ip, ip)],
-                    self.res_remote_path_of_example_path)
-                search_func(api_obj, remote,
-                    ["(4851433 AND 4725245) OR :file::{0}bin/example_path".format(ip)],
-                    self.res_remote_bug_id |
-                    self.res_remote_path_of_example_path)
-                search_func(api_obj, remote,
-                    [":::{0}bin/example_path OR (4851433 AND 4725245)".format(ip)],
-                    self.res_remote_bug_id |
-                    self.res_remote_path_of_example_path)
-                search_func(api_obj, remote,
-                    ["{0}bin/example_path OR {1}bin/example_path".format(ip, ip)],
-                    self.res_remote_path_of_example_path)
-                search_func(api_obj, remote,
-                    ["<::path:{0}bin/example_path> OR <(a AND b)>".format(ip)],
-                    self.res_remote_pkg_ret_pkg, return_actions=False)
-                search_func(api_obj, remote,
-                    ["<(a AND b)> OR <{0}bin/example_path>".format(ip)],
-                    self.res_remote_pkg_ret_pkg, return_actions=False)
-                # The tests below here are for testing that multiple queries
-                # to search return the results from both queries (bug 10365)
-                search_func(api_obj, remote,
-                    ["<(a AND b)>",  "example_path"],
-                    self.res_remote_path)
-                search_func(api_obj, remote,
-                    ["example_path", "<(a AND b)>"],
-                    self.res_remote_path)
-                search_func(api_obj, remote,
-                    [":::{0}bin/example_path".format(ip), "(4851433 AND 4725245)"],
-                    self.res_remote_bug_id |
-                    self.res_remote_path_of_example_path)
-                search_func(api_obj, remote,
-                    ["(4851433 AND 4725245)", ":::{0}bin/example_path".format(ip)],
-                    self.res_remote_bug_id |
-                    self.res_remote_path_of_example_path)
+        # Test that doing a search restricted to dir actions works
+        # correctly.  This is a test for bug 17645.
+        self._search_op(api_obj, False, "dir::/bin/example_dir", self.res_dir)
 
-        def _run_local_tests_example11_installed(self, api_obj):
-                outfile = os.path.join(self.testdata_dir, "res")
+    def _run_degraded_local_tests(self, api_obj):
+        outfile = os.path.join(self.testdata_dir, "res")
 
-                # This finds something because the client side
-                # manifest has had the name of the package inserted
-                # into it.
+        # This finds something because the client side
+        # manifest has had the name of the package inserted
+        # into it.
 
-                self._search_op(api_obj, False, "example_pkg",
-                    self.res_local_pkg_example11)
-                self._search_op(api_obj, False, "example_path", set())
-                self._search_op(api_obj, False, "example_path11",
-                    self.res_local_path_example11)
-                self._search_op(api_obj, False, "example*",
-                    self.res_local_wildcard_example11)
-                self._search_op(api_obj, False, "/bin",
-                    self.res_local_bin_example11)
+        self._search_op_slow(api_obj, False, "example_pkg", self.res_local_pkg)
+        self._search_op_slow(
+            api_obj, False, "example_path", self.res_local_path
+        )
+        self._search_op_slow(
+            api_obj, False, "(example_path)", self.res_local_path
+        )
+        self._search_op_slow(
+            api_obj,
+            False,
+            "<exam*:::>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op_slow(
+            api_obj, False, "::com.sun.service.info_url:", self.res_remote_url
+        )
+        self._search_op_slow(
+            api_obj, False, ":::e* AND *path", self.res_local_path
+        )
+        self._search_op_slow(
+            api_obj, False, "e* AND *path", self.res_local_path
+        )
+        self._search_op_slow(
+            api_obj,
+            False,
+            "<e*>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op_slow(
+            api_obj,
+            False,
+            "<e*> AND <e*>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op_slow(
+            api_obj,
+            False,
+            "<e*> OR <e*>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op_slow(
+            api_obj,
+            False,
+            "<exam:::>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op_slow(
+            api_obj, False, "exam:::e*path", self.res_local_path
+        )
+        self._search_op_slow(
+            api_obj, False, "exam:::e*path AND e*:::", self.res_local_path
+        )
+        self._search_op_slow(
+            api_obj, False, "e*::: AND exam:::*path", self.res_remote_path_extra
+        )
+        self._search_op_slow(
+            api_obj, False, "example*", self.res_local_wildcard
+        )
+        self._search_op_slow(api_obj, True, "example", self.res_local_mediator)
+        self._search_op_slow(
+            api_obj, True, "7.0", self.res_local_mediator_version
+        )
+        self._search_op_slow(
+            api_obj, True, "unladen-swallow", self.res_local_mediator_impl
+        )
+        self._search_op_slow(
+            api_obj,
+            True,
+            "::mediator-implementation:unladen*",
+            self.res_local_mediator_impl,
+        )
+        self._search_op_slow(
+            api_obj, True, ":link:mediator:example", self.res_local_mediator
+        )
+        self._search_op_slow(
+            api_obj,
+            True,
+            ":link:mediator:example OR :link:mediator-version:7.0",
+            self.res_local_mediator_and_ver,
+        )
+        self._search_op_slow(
+            api_obj,
+            True,
+            ":link:mediator:example OR :link:mediator-version:7.0 OR :link:mediator-implementation:unladen-swallow",
+            self.res_local_mediator_and_ver_impl,
+        )
+        self._search_op_slow(api_obj, False, "/bin", self.res_local_bin)
+        self._search_op_slow(api_obj, False, "4851433", self.res_local_bug_id)
+        self._search_op_slow(
+            api_obj,
+            False,
+            "<4851433> AND <4725245>",
+            self.res_local_pkg_ret_pkg,
+            return_actions=False,
+        )
+        self._search_op_slow(
+            api_obj, False, "4851433 AND 4725245", self.res_local_bug_id
+        )
+        self._search_op_slow(
+            api_obj,
+            False,
+            "4851433 AND 4725245 OR example_path",
+            self.res_local_bug_id,
+        )
+        self._search_op_slow(
+            api_obj,
+            False,
+            "4851433 AND (4725245 OR example_path)",
+            self.res_local_bug_id,
+        )
+        self._search_op_slow(
+            api_obj,
+            False,
+            "(4851433 AND 4725245) OR example_path",
+            self.res_local_bug_id | self.res_local_path,
+        )
+        self._search_op_slow(
+            api_obj,
+            False,
+            "4851433 OR 4725245",
+            self.res_local_bug_id | self.res_remote_bug_id_4725245,
+        )
+        self._search_op_slow(
+            api_obj, False, "6556919", self.res_local_inc_changes
+        )
+        self._search_op_slow(
+            api_obj, False, "65569??", self.res_local_inc_changes
+        )
+        self._search_op_slow(api_obj, False, "42", self.res_local_random_test)
+        self._search_op_slow(
+            api_obj, False, "79", self.res_remote_random_test_79
+        )
+        self._search_op_slow(
+            api_obj, False, "separator", self.res_local_keywords
+        )
+        self._search_op_slow(
+            api_obj, False, '"sort 0x86"', self.res_remote_keywords
+        )
+        self._search_op_slow(api_obj, False, "*example*", self.res_local_glob)
+        self._search_op_slow(api_obj, False, "fooo", self.res_local_foo)
+        self._search_op_slow(api_obj, False, "fo*", self.res_local_foo)
+        self._search_op_slow(api_obj, False, "bar", self.res_local_foo)
+        self._search_op_slow(api_obj, False, "openssl", self.res_local_openssl)
+        self._search_op_slow(api_obj, False, "OPENSSL", self.res_local_openssl)
+        self._search_op_slow(api_obj, False, "OpEnSsL", self.res_local_openssl)
+        self._search_op_slow(api_obj, False, "OpEnS*", self.res_local_openssl)
+        # These tests are included because a specific bug
+        # was found during development. These tests prevent regression
+        # back to that bug. Exit status of 1 is expected because the
+        # token isn't in the packages.
+        self._search_op_slow(api_obj, False, "a_non_existent_token", set())
 
-        def _run_local_empty_tests(self, api_obj):
-                self._search_op(api_obj, False, "example_pkg", set())
-                self._search_op(api_obj, False, "example_path", set())
-                self._search_op(api_obj, False, "example*", set())
-                self._search_op(api_obj, False, "/bin", set())
+    def _run_remove_root_search(self, search_func, remote, api_obj, ip):
+        search_func(api_obj, remote, [ip + "example_pkg"], set())
+        search_func(
+            api_obj,
+            remote,
+            [ip + "bin/example_path"],
+            self.res_remote_path_of_example_path,
+        )
+        search_func(
+            api_obj,
+            remote,
+            ["({0}bin/example_path)".format(ip)],
+            self.res_remote_path_of_example_path,
+        )
+        search_func(
+            api_obj,
+            remote,
+            ["<{0}exam*:::>".format(ip)],
+            set(),
+            return_actions=False,
+        )
+        search_func(
+            api_obj,
+            remote,
+            ["::{0}com.sun.service.info_url:".format(ip)],
+            set(),
+        )
+        search_func(
+            api_obj,
+            remote,
+            ["{0}bin/e* AND {1}*path".format(ip, ip)],
+            self.res_remote_path_of_example_path,
+        )
+        search_func(
+            api_obj,
+            remote,
+            ["(4851433 AND 4725245) OR :file::{0}bin/example_path".format(ip)],
+            self.res_remote_bug_id | self.res_remote_path_of_example_path,
+        )
+        search_func(
+            api_obj,
+            remote,
+            [":::{0}bin/example_path OR (4851433 AND 4725245)".format(ip)],
+            self.res_remote_bug_id | self.res_remote_path_of_example_path,
+        )
+        search_func(
+            api_obj,
+            remote,
+            ["{0}bin/example_path OR {1}bin/example_path".format(ip, ip)],
+            self.res_remote_path_of_example_path,
+        )
+        search_func(
+            api_obj,
+            remote,
+            ["<::path:{0}bin/example_path> OR <(a AND b)>".format(ip)],
+            self.res_remote_pkg_ret_pkg,
+            return_actions=False,
+        )
+        search_func(
+            api_obj,
+            remote,
+            ["<(a AND b)> OR <{0}bin/example_path>".format(ip)],
+            self.res_remote_pkg_ret_pkg,
+            return_actions=False,
+        )
+        # The tests below here are for testing that multiple queries
+        # to search return the results from both queries (bug 10365)
+        search_func(
+            api_obj,
+            remote,
+            ["<(a AND b)>", "example_path"],
+            self.res_remote_path,
+        )
+        search_func(
+            api_obj,
+            remote,
+            ["example_path", "<(a AND b)>"],
+            self.res_remote_path,
+        )
+        search_func(
+            api_obj,
+            remote,
+            [":::{0}bin/example_path".format(ip), "(4851433 AND 4725245)"],
+            self.res_remote_bug_id | self.res_remote_path_of_example_path,
+        )
+        search_func(
+            api_obj,
+            remote,
+            ["(4851433 AND 4725245)", ":::{0}bin/example_path".format(ip)],
+            self.res_remote_bug_id | self.res_remote_path_of_example_path,
+        )
 
-        def _run_remote_empty_tests(self, api_obj):
-                self._search_op(api_obj, True, "example_pkg", set())
-                self._search_op(api_obj, True, "example_path", set())
-                self._search_op(api_obj, True, "example*", set())
-                self._search_op(api_obj, True, "/bin", set())
-                self._search_op(api_obj, True, "*unique*", set())
+    def _run_local_tests_example11_installed(self, api_obj):
+        outfile = os.path.join(self.testdata_dir, "res")
 
-        @staticmethod
-        def _restore_dir(index_dir, index_dir_tmp):
-                shutil.rmtree(index_dir)
-                shutil.move(index_dir_tmp, index_dir)
+        # This finds something because the client side
+        # manifest has had the name of the package inserted
+        # into it.
 
-        @staticmethod
-        def _restore_dir_preserve_hash(index_dir, index_dir_tmp):
-                tmp_file = "full_fmri_list.hash"
-                portable.remove(os.path.join(index_dir_tmp, tmp_file))
-                shutil.move(os.path.join(index_dir, tmp_file),
-                            index_dir_tmp)
-                fh = open(os.path.join(index_dir_tmp, ss.MAIN_FILE), "r")
-                fh.seek(0)
-                fh.seek(9)
-                ver = fh.read(1)
-                fh.close()
-                fh = open(os.path.join(index_dir_tmp, tmp_file), "r+")
-                fh.seek(0)
-                fh.seek(9)
-                # Overwrite the existing version number.
-                # By definition, the version 0 is never used.
-                fh.write("{0}".format(ver))
-                fh.close()
-                shutil.rmtree(index_dir)
-                shutil.move(index_dir_tmp, index_dir)
+        self._search_op(
+            api_obj, False, "example_pkg", self.res_local_pkg_example11
+        )
+        self._search_op(api_obj, False, "example_path", set())
+        self._search_op(
+            api_obj, False, "example_path11", self.res_local_path_example11
+        )
+        self._search_op(
+            api_obj, False, "example*", self.res_local_wildcard_example11
+        )
+        self._search_op(api_obj, False, "/bin", self.res_local_bin_example11)
 
-        def _get_index_dirs(self):
-                index_dir = os.path.join(self.img_path(), "var", "pkg",
-                    "cache", "index")
-                index_dir_tmp = index_dir + "TMP"
-                return index_dir, index_dir_tmp
+    def _run_local_empty_tests(self, api_obj):
+        self._search_op(api_obj, False, "example_pkg", set())
+        self._search_op(api_obj, False, "example_path", set())
+        self._search_op(api_obj, False, "example*", set())
+        self._search_op(api_obj, False, "/bin", set())
 
-        @staticmethod
-        def _overwrite_version_number(file_path):
-                fh = open(file_path, "r+")
-                fh.seek(0)
-                fh.seek(9)
-                # Overwrite the existing version number.
-                # By definition, the version 0 is never used.
-                fh.write("0")
-                fh.close()
+    def _run_remote_empty_tests(self, api_obj):
+        self._search_op(api_obj, True, "example_pkg", set())
+        self._search_op(api_obj, True, "example_path", set())
+        self._search_op(api_obj, True, "example*", set())
+        self._search_op(api_obj, True, "/bin", set())
+        self._search_op(api_obj, True, "*unique*", set())
 
-        @staticmethod
-        def _overwrite_on_disk_format_version_number(file_path):
-                fh = open(file_path, "r+")
-                fh.seek(0)
-                fh.seek(16)
-                # Overwrite the existing version number.
-                # By definition, the version 0 is never used.
-                fh.write("9")
-                fh.close()
+    @staticmethod
+    def _restore_dir(index_dir, index_dir_tmp):
+        shutil.rmtree(index_dir)
+        shutil.move(index_dir_tmp, index_dir)
 
-        @staticmethod
-        def _overwrite_on_disk_format_version_number_with_letter(file_path):
-                fh = open(file_path, "r+")
-                fh.seek(0)
-                fh.seek(16)
-                # Overwrite the existing version number.
-                # By definition, the version 0 is never used.
-                fh.write("a")
-                fh.close()
+    @staticmethod
+    def _restore_dir_preserve_hash(index_dir, index_dir_tmp):
+        tmp_file = "full_fmri_list.hash"
+        portable.remove(os.path.join(index_dir_tmp, tmp_file))
+        shutil.move(os.path.join(index_dir, tmp_file), index_dir_tmp)
+        fh = open(os.path.join(index_dir_tmp, ss.MAIN_FILE), "r")
+        fh.seek(0)
+        fh.seek(9)
+        ver = fh.read(1)
+        fh.close()
+        fh = open(os.path.join(index_dir_tmp, tmp_file), "r+")
+        fh.seek(0)
+        fh.seek(9)
+        # Overwrite the existing version number.
+        # By definition, the version 0 is never used.
+        fh.write("{0}".format(ver))
+        fh.close()
+        shutil.rmtree(index_dir)
+        shutil.move(index_dir_tmp, index_dir)
 
-        @staticmethod
-        def _replace_on_disk_format_version(dir):
-                file_path = os.path.join(dir, ss.BYTE_OFFSET_FILE)
-                fh = open(file_path, "r")
-                lst = fh.readlines()
-                fh.close()
-                fh = open(file_path, "w")
-                fh.write(lst[0])
-                for l in lst[2:]:
-                        fh.write(l)
-                fh.close()
+    def _get_index_dirs(self):
+        index_dir = os.path.join(
+            self.img_path(), "var", "pkg", "cache", "index"
+        )
+        index_dir_tmp = index_dir + "TMP"
+        return index_dir, index_dir_tmp
 
-        @staticmethod
-        def _overwrite_hash(ffh_path):
-                fd, tmp = tempfile.mkstemp()
-                portable.copyfile(ffh_path, tmp)
-                fh = open(tmp, "r+")
-                fh.seek(0)
-                fh.seek(20)
-                fh.write("*")
-                fh.close()
-                portable.rename(tmp, ffh_path)
+    @staticmethod
+    def _overwrite_version_number(file_path):
+        fh = open(file_path, "r+")
+        fh.seek(0)
+        fh.seek(9)
+        # Overwrite the existing version number.
+        # By definition, the version 0 is never used.
+        fh.write("0")
+        fh.close()
 
-        def _check_no_index(self):
-                ind_dir, ind_dir_tmp = self._get_index_dirs()
-                if os.listdir(ind_dir):
-                        self.assertTrue(0)
-                if os.path.exists(ind_dir_tmp):
-                        self.assertTrue(0)
+    @staticmethod
+    def _overwrite_on_disk_format_version_number(file_path):
+        fh = open(file_path, "r+")
+        fh.seek(0)
+        fh.seek(16)
+        # Overwrite the existing version number.
+        # By definition, the version 0 is never used.
+        fh.write("9")
+        fh.close()
 
-        @staticmethod
-        def validateAssertRaises(ex_type, validate_func, func, *args, **kwargs):
-                try:
-                        func(*args, **kwargs)
-                except ex_type as e:
-                        validate_func(e)
-                else:
-                        raise RuntimeError("Didn't raise expected exception.")
+    @staticmethod
+    def _overwrite_on_disk_format_version_number_with_letter(file_path):
+        fh = open(file_path, "r+")
+        fh.seek(0)
+        fh.seek(16)
+        # Overwrite the existing version number.
+        # By definition, the version 0 is never used.
+        fh.write("a")
+        fh.close()
 
-        @staticmethod
-        def _check_err(e, expected_str, expected_code):
-                err = force_str(e.read())
-                if expected_code != e.code:
-                        raise RuntimeError("Got wrong code, expected {0} got "
-                            "{1}".format(expected_code, e.code))
-                if expected_str not in err:
-                        raise RuntimeError("Got unexpected error message of:\n"
-                            "{0}".format(err))
+    @staticmethod
+    def _replace_on_disk_format_version(dir):
+        file_path = os.path.join(dir, ss.BYTE_OFFSET_FILE)
+        fh = open(file_path, "r")
+        lst = fh.readlines()
+        fh.close()
+        fh = open(file_path, "w")
+        fh.write(lst[0])
+        for l in lst[2:]:
+            fh.write(l)
+        fh.close()
+
+    @staticmethod
+    def _overwrite_hash(ffh_path):
+        fd, tmp = tempfile.mkstemp()
+        portable.copyfile(ffh_path, tmp)
+        fh = open(tmp, "r+")
+        fh.seek(0)
+        fh.seek(20)
+        fh.write("*")
+        fh.close()
+        portable.rename(tmp, ffh_path)
+
+    def _check_no_index(self):
+        ind_dir, ind_dir_tmp = self._get_index_dirs()
+        if os.listdir(ind_dir):
+            self.assertTrue(0)
+        if os.path.exists(ind_dir_tmp):
+            self.assertTrue(0)
+
+    @staticmethod
+    def validateAssertRaises(ex_type, validate_func, func, *args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except ex_type as e:
+            validate_func(e)
+        else:
+            raise RuntimeError("Didn't raise expected exception.")
+
+    @staticmethod
+    def _check_err(e, expected_str, expected_code):
+        err = force_str(e.read())
+        if expected_code != e.code:
+            raise RuntimeError(
+                "Got wrong code, expected {0} got "
+                "{1}".format(expected_code, e.code)
+            )
+        if expected_str not in err:
+            raise RuntimeError(
+                "Got unexpected error message of:\n" "{0}".format(err)
+            )
 
 
 class TestApiSearchBasicsP(TestApiSearchBasics):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        def __init__(self, *args, **kwargs):
-                TestApiSearchBasics.__init__(self, *args, **kwargs)
-                self.sent_pkgs = set()
+    def __init__(self, *args, **kwargs):
+        TestApiSearchBasics.__init__(self, *args, **kwargs)
+        self.sent_pkgs = set()
 
-        def pkgsend_bulk(self, durl, pkg, optional=True):
-                if pkg not in self.sent_pkgs or optional is False:
-                        self.sent_pkgs.add(pkg)
-                        # Ensures indexing is done for every pkgsend.
-                        TestApiSearchBasics.pkgsend_bulk(self, durl, pkg,
-                            refresh_index=True)
-                        self.wait_repo(self.dc.get_repodir())
+    def pkgsend_bulk(self, durl, pkg, optional=True):
+        if pkg not in self.sent_pkgs or optional is False:
+            self.sent_pkgs.add(pkg)
+            # Ensures indexing is done for every pkgsend.
+            TestApiSearchBasics.pkgsend_bulk(
+                self, durl, pkg, refresh_index=True
+            )
+            self.wait_repo(self.dc.get_repodir())
 
-        def setUp(self):
-                TestApiSearchBasics.setUp(self)
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, (self.example_pkg10, self.fat_pkg10,
-                    self.another_pkg10))
+    def setUp(self):
+        TestApiSearchBasics.setUp(self)
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(
+            durl, (self.example_pkg10, self.fat_pkg10, self.another_pkg10)
+        )
 
-        def test_010_remote(self):
-                """Test remote search."""
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
-                # This should be a full test to test all functionality.
-                self._run_full_remote_tests(api_obj)
-                self._search_op(api_obj, True, ":file::", self.res_remote_file)
+    def test_010_remote(self):
+        """Test remote search."""
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
+        # This should be a full test to test all functionality.
+        self._run_full_remote_tests(api_obj)
+        self._search_op(api_obj, True, ":file::", self.res_remote_file)
 
-        def test_020_local_0(self):
-                """Install one package, and run the search suite."""
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
+    def test_020_local_0(self):
+        """Install one package, and run the search suite."""
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
 
-                self._api_install(api_obj, ["example_pkg"])
+        self._api_install(api_obj, ["example_pkg"])
 
-                self._run_full_local_tests(api_obj)
+        self._run_full_local_tests(api_obj)
 
-        def test_030_degraded_local(self):
-                """Install one package, and run the search suite."""
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
+    def test_030_degraded_local(self):
+        """Install one package, and run the search suite."""
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
 
-                self._api_install(api_obj, ["example_pkg@1.0"])
+        self._api_install(api_obj, ["example_pkg@1.0"])
 
-                index_dir = os.path.join(self.img_path(), "var", "pkg",
-                    "cache", "index")
-                shutil.rmtree(index_dir)
+        index_dir = os.path.join(
+            self.img_path(), "var", "pkg", "cache", "index"
+        )
+        shutil.rmtree(index_dir)
 
-                self._run_degraded_local_tests(api_obj)
+        self._run_degraded_local_tests(api_obj)
 
-        def test_040_repeated_install_uninstall(self):
-                """Install and uninstall a package. Checking search both
-                after each change to the image."""
-                # During development, the index could become corrupted by
-                # repeated installing and uninstalling a package. This
-                # tests if that has been fixed.
-                repeat = 3
+    def test_040_repeated_install_uninstall(self):
+        """Install and uninstall a package. Checking search both
+        after each change to the image."""
+        # During development, the index could become corrupted by
+        # repeated installing and uninstalling a package. This
+        # tests if that has been fixed.
+        repeat = 3
 
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
 
-                self._api_install(api_obj, ["example_pkg@1.0"])
-                self._api_uninstall(api_obj, ["example_pkg"])
+        self._api_install(api_obj, ["example_pkg@1.0"])
+        self._api_uninstall(api_obj, ["example_pkg"])
 
-                for i in range(1, repeat):
-                        self._api_install(api_obj, ["example_pkg"])
-                        self._run_local_tests(api_obj)
-                        self._api_uninstall(api_obj, ["example_pkg"])
-                        api_obj.reset()
-                        self._run_local_empty_tests(api_obj)
+        for i in range(1, repeat):
+            self._api_install(api_obj, ["example_pkg"])
+            self._run_local_tests(api_obj)
+            self._api_uninstall(api_obj, ["example_pkg"])
+            api_obj.reset()
+            self._run_local_empty_tests(api_obj)
 
-        def test_050_local_case_sensitive(self):
-                """Test local case sensitive search"""
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
+    def test_050_local_case_sensitive(self):
+        """Test local case sensitive search"""
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
 
-                self._api_install(api_obj, ["example_pkg@1.0"])
-                self._search_op(api_obj, False, "fooo", set(), True)
-                self._search_op(api_obj, False, "fo*", set(), True)
-                self._search_op(api_obj, False, "bar", set(), True)
-                self._search_op(api_obj, False, "FOOO", self.res_local_foo,
-                    True)
-                self._search_op(api_obj, False, "bAr", self.res_local_foo, True)
+        self._api_install(api_obj, ["example_pkg@1.0"])
+        self._search_op(api_obj, False, "fooo", set(), True)
+        self._search_op(api_obj, False, "fo*", set(), True)
+        self._search_op(api_obj, False, "bar", set(), True)
+        self._search_op(api_obj, False, "FOOO", self.res_local_foo, True)
+        self._search_op(api_obj, False, "bAr", self.res_local_foo, True)
 
-        def test_060_missing_files(self):
-                """Test to check for stack trace when files missing.
-                Bug 2753"""
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
+    def test_060_missing_files(self):
+        """Test to check for stack trace when files missing.
+        Bug 2753"""
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
 
-                self._api_install(api_obj, ["example_pkg@1.0"])
+        self._api_install(api_obj, ["example_pkg@1.0"])
 
-                index_dir = os.path.join(self.img_path(), "var", "pkg",
-                    "cache", "index")
-                self._search_op(api_obj, False, "fooo", set(), True)
+        index_dir = os.path.join(
+            self.img_path(), "var", "pkg", "cache", "index"
+        )
+        self._search_op(api_obj, False, "fooo", set(), True)
 
-                first = True
+        first = True
 
-                for d in query_parser.TermQuery._get_gdd(index_dir).values():
-                        orig_fn = d.get_file_name()
-                        orig_path = os.path.join(index_dir, orig_fn)
-                        dest_fn = orig_fn + "TMP"
-                        dest_path = os.path.join(index_dir, dest_fn)
-                        portable.rename(orig_path, dest_path)
-                        self.assertRaises(api_errors.InconsistentIndexException,
-                            self._search_op, api_obj, False,
-                            "exam:::example_pkg", [])
-                        if first:
-                                # Run the shell version once to check that no
-                                # stack trace happens.
-                                self.pkg("search -l 'exam:::example_pkg'",
-                                    exit=1)
-                                first = False
-                        portable.rename(dest_path, orig_path)
-                        self._search_op(api_obj, False, "exam:::example_pkg",
-                            self.res_local_pkg)
-
-        def test_070_mismatched_versions(self):
-                """Test to check for stack trace when files missing.
-                Bug 2753"""
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
-                self._api_install(api_obj, ["example_pkg@1.0"])
-
-                index_dir = os.path.join(self.img_path(), "var", "pkg",
-                    "cache", "index")
-                self._search_op(api_obj, False, "fooo", set(), True)
-
-                first = True
-
-                for d in query_parser.TermQuery._get_gdd(index_dir).values():
-                        orig_fn = d.get_file_name()
-                        orig_path = os.path.join(index_dir, orig_fn)
-                        dest_fn = orig_fn + "TMP"
-                        dest_path = os.path.join(index_dir, dest_fn)
-                        shutil.copy(orig_path, dest_path)
-                        self._overwrite_version_number(orig_path)
-                        api_obj.reset()
-                        self.assertRaises(api_errors.InconsistentIndexException,
-                            self._search_op, api_obj, False,
-                            "exam:::example_pkg", [])
-                        if first:
-                                # Run the shell version once to check that no
-                                # stack trace happens.
-                                self.pkg("search -l 'exam:::example_pkg'",
-                                    exit=1)
-                                first = False
-                        portable.rename(dest_path, orig_path)
-                        self._search_op(api_obj, False, "example_pkg",
-                            self.res_local_pkg)
-                        self._overwrite_version_number(orig_path)
-                        self.assertRaises(
-                            api_errors.WrapSuccessfulIndexingException,
-                            self._api_uninstall, api_obj, ["example_pkg"],
-                            catch_wsie=False)
-                        api_obj.reset()
-                        self._search_op(api_obj, False, "example_pkg", set())
-                        self._overwrite_version_number(orig_path)
-                        self.assertRaises(
-                            api_errors.WrapSuccessfulIndexingException,
-                            self._api_install, api_obj, ["example_pkg"],
-                            catch_wsie=False)
-                        api_obj.reset()
-                        self._search_op(api_obj, False, "example_pkg",
-                            self.res_local_pkg)
-
-                ffh = ss.IndexStoreSetHash(ss.FULL_FMRI_HASH_FILE)
-                ffh_path = os.path.join(index_dir, ffh.get_file_name())
-                dest_fh, dest_path = tempfile.mkstemp()
-                shutil.copy(ffh_path, dest_path)
-                self._overwrite_hash(ffh_path)
-                self.assertRaises(api_errors.IncorrectIndexFileHash,
-                    self._search_op, api_obj, False, "example_pkg", set())
-                # Run the shell version of the test to check for a stack trace.
+        for d in query_parser.TermQuery._get_gdd(index_dir).values():
+            orig_fn = d.get_file_name()
+            orig_path = os.path.join(index_dir, orig_fn)
+            dest_fn = orig_fn + "TMP"
+            dest_path = os.path.join(index_dir, dest_fn)
+            portable.rename(orig_path, dest_path)
+            self.assertRaises(
+                api_errors.InconsistentIndexException,
+                self._search_op,
+                api_obj,
+                False,
+                "exam:::example_pkg",
+                [],
+            )
+            if first:
+                # Run the shell version once to check that no
+                # stack trace happens.
                 self.pkg("search -l 'exam:::example_pkg'", exit=1)
-                portable.rename(dest_path, ffh_path)
-                self._search_op(api_obj, False, "example_pkg",
-                    self.res_local_pkg)
-                self._overwrite_hash(ffh_path)
-                self.assertRaises(api_errors.WrapSuccessfulIndexingException,
-                    self._api_uninstall, api_obj, ["example_pkg"],
-                    catch_wsie=False)
-                self._search_op(api_obj, False, "example_pkg", set())
-
-        def test_080_weird_patterns(self):
-                """Test strange patterns to ensure they're handled correctly"""
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
-
-                self._search_op(api_obj, True, "[*]", self.res_remote_weird)
-                self._search_op(api_obj, True, "[?]", self.res_remote_weird)
-                self._search_op(api_obj, True, "[[]", self.res_remote_weird)
-                self._search_op(api_obj, True, "[]]", self.res_remote_weird)
-                self._search_op(api_obj, True, "FO[O]O", self.res_remote_foo)
-                self._search_op(api_obj, True, "FO[?O]O", self.res_remote_foo)
-                self._search_op(api_obj, True, "FO[*O]O", self.res_remote_foo)
-                self._search_op(api_obj, True, "FO[]O]O", self.res_remote_foo)
-
-        def test_090_bug_7660(self):
-                """Test that installing a package doesn't prevent searching on
-                package names from working on previously installed packages."""
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
-
-                tmp_dir = os.path.join(self.img_path(), "var", "pkg",
-                    "cache", "index", "TMP")
-                self._api_install(api_obj, ["example_pkg"])
-                api_obj.rebuild_search_index()
-                self._api_install(api_obj, ["fat"])
-                self.assertTrue(not os.path.exists(tmp_dir))
-                self._run_local_tests(api_obj)
-
-        def test_100_bug_6712_i386(self):
-                """Install one package, and run the search suite."""
-                durl = self.dc.get_depot_url()
-
-                variants = { "variant.arch": "i386" }
-                api_obj = self.image_create(durl, variants=variants)
-                remote = True
-
-                self._search_op(api_obj, remote, "fat:::*",
-                    self.res_remote_fat10_star)
-                self._api_install(api_obj, ["fat"])
-                remote = False
-                self._search_op(api_obj, remote, "fat:::*",
-                    self.res_local_fat10_i386_star)
-
-        def test_110_bug_6712_sparc(self):
-                """Install one package, and run the search suite."""
-                durl = self.dc.get_depot_url()
-
-                variants = { "variant.arch": "sparc" }
-                api_obj = self.image_create(durl, variants=variants)
-                remote = True
-
-                self._search_op(api_obj, remote, "fat:::*",
-                    self.res_remote_fat10_star)
-                self._api_install(api_obj, ["fat"])
-                remote = False
-                self._search_op(api_obj, remote, "fat:::*",
-                    self.res_local_fat10_sparc_star)
-
-        def test_120_bug_3046(self):
-                """Checks if directories ending in / break the indexer."""
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.bad_pkg10)
-                api_obj = self.image_create(durl)
-
-                self._search_op(api_obj, True, "foo", set())
-                self._search_op(api_obj, True, "/", set())
-
-        def test_130_bug_1059(self):
-                """Checks whether the fallback of removing the image root works.
-                Also tests whether multiple queries submitted via the api work.
-                """
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
-
-                ip = self.get_img_path()
-                if not ip.endswith("/"):
-                        ip += "/"
-
-                # Do remote searches
-                self._run_remove_root_search(self._search_op_multi, True,
-                    api_obj, ip)
-
-                self._api_install(api_obj, ["example_pkg"])
-                # Do local searches
-                self._run_remove_root_search(self._search_op_multi, False,
-                    api_obj, ip)
-
-                index_dir = os.path.join(self.img_path(), "var", "pkg",
-                    "cache", "index")
-                shutil.rmtree(index_dir)
-                # Do slow local searches
-                self._run_remove_root_search(self._search_op_slow_multi, False,
-                    api_obj, ip)
-
-        def test_bug_2849(self):
-                """Checks if things with spaces break the indexer."""
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.space_pkg10)
-                api_obj = self.image_create(durl)
-
-                self._api_install(api_obj, ["space_pkg"])
-
-                self.pkgsend_bulk(durl, self.space_pkg10, optional=False)
-                api_obj.refresh(immediate=True)
-
-                self._api_install(api_obj, ["space_pkg"])
-
-                remote = False
-                self._search_op(api_obj, remote, 'with', set())
-                self._search_op(api_obj, remote, 'with*',
-                    self.res_space_with_star)
-                self._search_op(api_obj, remote, '*space',
-                    self.res_space_space_star)
-                self._search_op(api_obj, remote, 'space', set())
-                self._search_op(api_obj, remote, 'unique_dir',
-                    self.res_space_unique)
-                remote = True
-                self._search_op(api_obj, remote, 'with', set())
-                self._search_op(api_obj, remote, 'with*',
-                    self.res_space_with_star)
-                self._search_op(api_obj, remote, '*space',
-                    self.res_space_space_star)
-                self._search_op(api_obj, remote, 'space', set())
-                self.pkgsend_bulk(durl, self.space_pkg10, optional=False)
-                # Need to add install of subsequent package and
-                # local side search as well as remote
-                self._search_op(api_obj, remote, 'with', set())
-                self._search_op(api_obj, remote, 'with*',
-                    self.res_space_with_star)
-                self._search_op(api_obj, remote, '*space',
-                    self.res_space_space_star)
-                self._search_op(api_obj, remote, 'space', set())
-                self._search_op(api_obj, remote, 'unique_dir',
-                    self.res_space_unique)
-
-        def test_bug_2863(self):
-                """Check that disabling indexing works as expected"""
-                durl = self.dc.get_depot_url()
-                api_obj = self.image_create(durl)
-
-                self._check_no_index()
-                self._api_install(api_obj, ["example_pkg"], update_index=False)
-                self._check_no_index()
-                api_obj.rebuild_search_index()
-                self._run_local_tests(api_obj)
-                self._api_uninstall(api_obj, ["example_pkg"], update_index=False)
-                # Running empty test because search will notice the index
-                # does not match the installed packages and complain.
-                self.assertRaises(api_errors.IncorrectIndexFileHash,
-                    self._search_op, api_obj, False, "example_pkg", set())
-                api_obj.rebuild_search_index()
-                self._run_local_empty_tests(api_obj)
-                self._api_install(api_obj, ["example_pkg"])
-                self._run_local_tests(api_obj)
-                self.pkgsend_bulk(durl, self.example_pkg11)
-                api_obj.refresh(immediate=True)
-                self._api_update(api_obj, update_index=False)
-                # Running empty test because search will notice the index
-                # does not match the installed packages and complain.
-                self.assertRaises(api_errors.IncorrectIndexFileHash,
-                    self._search_op, api_obj, False, "example_pkg", set())
-                api_obj.rebuild_search_index()
-                self._run_local_tests_example11_installed(api_obj)
-                self._api_uninstall(api_obj, ["example_pkg"],
-                    update_index=False)
-                # Running empty test because search will notice the index
-                # does not match the installed packages and complain.
-                self.assertRaises(api_errors.IncorrectIndexFileHash,
-                    self._search_op, api_obj, False, "example_pkg", set())
-                api_obj.rebuild_search_index()
-                self._run_local_empty_tests(api_obj)
-
-        def test_bug_2989_1(self):
-                durl = self.dc.get_depot_url()
-
-                for f in self._dir_restore_functions:
-                        api_obj = self.image_create(durl)
-
-                        api_obj.rebuild_search_index()
-
-                        index_dir, index_dir_tmp = self._get_index_dirs()
-
-                        shutil.copytree(index_dir, index_dir_tmp)
-
-                        self._api_install(api_obj, ["example_pkg"])
-
-                        f(index_dir, index_dir_tmp)
-
-                        self.assertRaises(
-                            api_errors.WrapSuccessfulIndexingException,
-                            self._api_uninstall, api_obj, ["example_pkg"],
-                            catch_wsie=False)
-
-                        self.image_destroy()
-
-        def test_bug_2989_2(self):
-                durl = self.dc.get_depot_url()
-
-                for f in self._dir_restore_functions:
-                        api_obj = self.image_create(durl)
-
-                        self._api_install(api_obj, ["example_pkg"])
-
-                        index_dir, index_dir_tmp = self._get_index_dirs()
-
-                        shutil.copytree(index_dir, index_dir_tmp)
-
-                        self._api_install(api_obj, ["another_pkg"])
-
-                        f(index_dir, index_dir_tmp)
-
-                        self.assertRaises(
-                            api_errors.WrapSuccessfulIndexingException,
-                            self._api_uninstall, api_obj, ["another_pkg"],
-                            catch_wsie=False)
-
-                        self.image_destroy()
-
-        def test_bug_2989_3(self):
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.example_pkg11)
-
-                for f in self._dir_restore_functions:
-                        api_obj = self.image_create(durl)
-
-                        self._api_install(api_obj, ["example_pkg@1.0,5.11-0"])
-
-                        index_dir, index_dir_tmp = self._get_index_dirs()
-
-                        shutil.copytree(index_dir, index_dir_tmp)
-
-                        self._api_install(api_obj, ["example_pkg"])
-
-                        f(index_dir, index_dir_tmp)
-
-                        self.assertRaises(
-                            api_errors.WrapSuccessfulIndexingException,
-                            self._api_uninstall, api_obj, ["example_pkg"],
-                            catch_wsie=False)
-
-                        self.image_destroy()
-
-        def test_bug_2989_4(self):
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.example_pkg11)
-
-                for f in self._dir_restore_functions:
-                        api_obj = self.image_create(durl)
-
-                        self._api_install(api_obj, ["another_pkg"])
-
-                        index_dir, index_dir_tmp = self._get_index_dirs()
-
-                        shutil.copytree(index_dir, index_dir_tmp)
-
-                        self._api_install(api_obj, ["example_pkg@1.0,5.11-0"])
-
-                        f(index_dir, index_dir_tmp)
-
-                        self.assertRaises(
-                            api_errors.WrapSuccessfulIndexingException,
-                            self._api_update, api_obj, catch_wsie=False)
-
-                        self.image_destroy()
-
-        def test_bug_4239(self):
-                """Tests whether categories are indexed and searched for
-                correctly."""
-
-                def _run_cat_tests(self, remote):
-                        self._search_op(api_obj, remote, "System",
-                            self.res_cat_pkg10, case_sensitive=False)
-                        self._search_op(api_obj, remote, "Security",
-                            self.res_cat_pkg10, case_sensitive=False)
-                        self._search_op(api_obj, remote, "System/Security",
-                            self.res_cat_pkg10, case_sensitive=False)
-                        self._search_op(api_obj, remote, "Other/Category",
-                            self.res_cat_pkg10_2, case_sensitive=False)
-                        self._search_op(api_obj, remote, "Other",
-                            self.res_cat_pkg10_2, case_sensitive=False)
-                        self._search_op(api_obj, remote, "Category",
-                            self.res_cat_pkg10_2, case_sensitive=False)
-
-                def _run_cat2_tests(self, remote):
-                        self._search_op(api_obj, remote, "Applications",
-                            self.res_cat2_pkg10, case_sensitive=False)
-                        self._search_op(api_obj, True, "Sound",
-                            self.res_cat2_pkg10, case_sensitive=False)
-                        self._search_op(api_obj, remote, "Sound and Video",
-                            self.res_cat2_pkg10, case_sensitive=False)
-                        self._search_op(api_obj, remote, "Sound*",
-                            self.res_cat2_pkg10, case_sensitive=False)
-                        self._search_op(api_obj, remote, "*Video",
-                            self.res_cat2_pkg10, case_sensitive=False)
-                        self._search_op(api_obj, remote,
-                            "'Applications/Sound and Video'",
-                            self.res_cat2_pkg10, case_sensitive=False)
-                        # This is a test for bug 11002 which ensures that the
-                        # unquoting is being performed correctly.
-                        self._search_op(api_obj, remote,
-                            "'Applications/Sound%20and%20Video'",
-                            set(), case_sensitive=False)
-                        self._search_op(api_obj, remote, "Developer/C",
-                            self.res_cat2_pkg10_2, case_sensitive=False)
-                        self._search_op(api_obj, remote, "Developer",
-                            self.res_cat2_pkg10_2, case_sensitive=False)
-                        self._search_op(api_obj, remote, "C",
-                            self.res_cat2_pkg10_2, case_sensitive=False)
-
-                def _run_cat3_tests(self, remote):
-                        self._search_op(api_obj, remote, "foo",
-                            self.res_cat3_pkg10,case_sensitive=False)
-                        self._search_op(api_obj, remote, "baz",
-                            self.res_cat3_pkg10, case_sensitive=False)
-                        self._search_op(api_obj, remote, "asda",
-                            self.res_cat3_pkg10, case_sensitive=False)
-                        self._search_op(api_obj, remote,
-                            "foo/bar/baz/bill/beam/asda", self.res_cat3_pkg10,
-                            case_sensitive=False)
-
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, (self.cat_pkg10, self.cat2_pkg10,
-                    self.cat3_pkg10, self.bad_cat_pkg10, self.bad_cat2_pkg10))
-                api_obj = self.image_create(durl)
-
-                remote = True
-                _run_cat_tests(self, remote)
-                _run_cat2_tests(self, remote)
-                _run_cat3_tests(self, remote)
-
-                remote = False
-                self._api_install(api_obj, ["cat"])
-                _run_cat_tests(self, remote)
-
-                self._api_install(api_obj, ["cat2"])
-                _run_cat2_tests(self, remote)
-
-                self._api_install(api_obj, ["cat3"])
-                _run_cat3_tests(self, remote)
-
-                self._api_install(api_obj, ["badcat"])
-                self._api_install(api_obj, ["badcat2"])
-                _run_cat_tests(self, remote)
-                _run_cat2_tests(self, remote)
-                _run_cat3_tests(self, remote)
-
-        def test_bug_7628(self):
-                """Checks whether incremental update generates wrong
-                additional lines."""
-                durl = self.dc.get_depot_url()
-                ind_dir = self._get_repo_index_dir()
-                tok_file = os.path.join(ind_dir, ss.BYTE_OFFSET_FILE)
-                main_file = os.path.join(ind_dir, ss.MAIN_FILE)
-
-                self.pkgsend_bulk(durl, self.example_pkg10)
-                fh = open(tok_file)
-                tok_1 = fh.readlines()
-                tok_len = len(tok_1)
-                fh.close()
-
-                fh = open(main_file)
-                main_1 = fh.readlines()
-                main_len = len(main_1)
-                fh.close()
-
-                self.pkgsend_bulk(durl, self.example_pkg10, optional=False)
-                fh = open(tok_file)
-                tok_2 = fh.readlines()
-                new_tok_len = len(tok_2)
-                fh.close()
-
-                fh = open(main_file)
-                main_2 = fh.readlines()
-                new_main_len = len(main_2)
-                fh.close()
-
-                # Since the server now adds a set action for the FMRI to
-                # manifests during publication, there should be one
-                # additional line for the token file.
-                self.assertEqual(new_tok_len, tok_len + 1)
-                self.assertEqual(new_main_len, main_len + 1)
-
-        def test_bug_983(self):
-                """Test for known bug 983."""
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.bug_983_manifest)
-                api_obj = self.image_create(durl)
-
-                self._search_op(api_obj, True, "gmake", self.res_bug_983)
-                self._search_op(api_obj, True, "SUNWcsl@0.5.11-0.89",
-                    self.res_983_csl_dependency)
-                self._search_op(api_obj, True, "SUNWcsl",
-                    self.res_983_csl_dependency)
-                self._search_op(api_obj, True, "SUNWtestbar@0.5.11-0.111",
-                    self.res_983_bar_dependency)
-                self._search_op(api_obj, True, "SUNWtestbar",
-                    self.res_983_bar_dependency)
-                self._search_op(api_obj, True, "SUNWtestfoo@0.5.11-0.111",
-                    self.res_983_foo_dependency)
-                self._search_op(api_obj, True, "SUNWtestfoo",
-                    self.res_983_foo_dependency)
-                self._search_op(api_obj, True, "depend:require:",
-                    self.res_983_csl_dependency | self.res_983_bar_dependency)
-                self._search_op(api_obj, True, "depend:incorporate:",
-                    self.res_983_foo_dependency)
-                self._search_op(api_obj, True, "depend::",
-                    self.res_983_csl_dependency | self.res_983_bar_dependency |
-                    self.res_983_foo_dependency)
-
-        def test_bug_7534(self):
-                """Tests that an automatic reindexing is detected by the test
-                suite."""
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.example_pkg10)
-                api_obj = self.image_create(durl)
-
-                index_dir = os.path.join(self.img_path(), "var", "pkg",
-                    "cache", "index")
-                api_obj.rebuild_search_index()
-                self._search_op(api_obj, False, 'example', set())
-
-                orig_fn = os.path.join(index_dir,
-                    list(query_parser.TermQuery._get_gdd(index_dir).values())[0].\
-                    get_file_name())
-                dest_fn = orig_fn + "TMP"
-
-                self._api_install(api_obj, ["example_pkg"])
-                api_obj.rebuild_search_index()
-
-                portable.rename(orig_fn, dest_fn)
-                self.assertRaises(api_errors.WrapSuccessfulIndexingException,
-                    self._api_uninstall, api_obj, ["example_pkg"],
-                    catch_wsie=False)
-
-        def test_bug_8492(self):
-                """Tests that field queries and phrase queries work together.
-                """
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, (self.bug_8492_manf_1,
-                    self.bug_8492_manf_2))
-                api_obj = self.image_create(durl)
-
-                self._search_op(api_obj, True, "set::'image packaging'",
-                    self.res_8492_1 | self.res_8492_2)
-                self._search_op(api_obj, True, "b1:set::'image packaging'",
-                    self.res_8492_1)
-
-                self._api_install(api_obj, ["b1", "b2"])
-
-                self._search_op(api_obj, False, "set::'image packaging'",
-                    self.res_8492_1 | self.res_8492_2)
-                self._search_op(api_obj, False, "b2:set::'image packaging'",
-                    self.res_8492_2)
-
-                api_obj.rebuild_search_index()
-
-                self._search_op(api_obj, True, "set::'image packaging'",
-                    self.res_8492_1 | self.res_8492_2)
-                self._search_op(api_obj, True, "b1:set::'image packaging'",
-                    self.res_8492_1)
-
-        def test_bug_9845_01(self):
-                """Test that a corrupt query doesn't break the server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("A query is expected to have five fields: "
-                    "case sensitivity, return type, number of results to "
-                    "return, the number at which to start returning results, "
-                    "and the text of the query.  The query provided lacked at "
-                    "least one of those fields:")
-                expected_code = 404
-                q_str = "foo"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_9845_02(self):
-                """Test that a corrupt case_sensitive value doesn't break the "
-                server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("{name} had a bad value of '{bv}'").format(
-                    name="case_sensitive",
-                    bv="FAlse"
-               )
-                expected_code = 404
-                q_str = "FAlse_2_None_None_foo"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_9845_03(self):
-                """Test that a corrupt return_type value doesn't break the "
-                server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("{name} had a bad value of '{bv}'").format(
-                    name="return_type",
-                    bv="3"
-               )
-                expected_code = 404
-                q_str = "False_3_None_None_foo"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_9845_04(self):
-                """Test that a corrupt return_type value doesn't break the "
-                server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("{name} had a bad value of '{bv}'").format(
-                    name="return_type",
-                    bv="A"
-               )
-                expected_code = 404
-                q_str = "False_A_None_None_foo"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_9845_05(self):
-                """Test that a corrupt num_to_return value doesn't break the "
-                server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("{name} had a bad value of '{bv}'").format(
-                    name="num_to_return",
-                    bv="NOne"
-               )
-                expected_code = 404
-                q_str = "False_2_NOne_None_foo"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_9845_06(self):
-                """Test that a corrupt start_point value doesn't break the "
-                server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("{name} had a bad value of '{bv}'").format(
-                    name="start_point",
-                    bv="NOne"
-               )
-                expected_code = 404
-                q_str = "False_2_None_NOne_foo"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_9845_07(self):
-                """Test that a corrupt case_sensitive value doesn't break the "
-                server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("{name} had a bad value of '{bv}'").format(
-                    name="case_sensitive",
-                    bv=""
-               )
-                expected_code = 404
-                q_str = "_2_None_None_foo"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_9845_08(self):
-                """Test that a missing return_type value doesn't break the "
-                server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("{name} had a bad value of '{bv}'").format(
-                    name="return_type",
-                    bv=""
-               )
-                expected_code = 404
-                q_str = "False__None_None_foo"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_9845_09(self):
-                """Test that a missing num_to_return value doesn't break the "
-                server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("{name} had a bad value of '{bv}'").format(
-                    name="num_to_return",
-                    bv=""
-               )
-                expected_code = 404
-                q_str = "False_2__None_foo"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_9845_10(self):
-                """Test that a missing start_point value doesn't break the "
-                server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("{name} had a bad value of '{bv}'").format(
-                    name="start_point",
-                    bv=""
-               )
-                expected_code = 404
-                q_str = "False_2_None__foo"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_9845_11(self):
-                """Test that missing query text doesn't break the server."""
-                durl = self.dc.get_depot_url()
-                expected_string = _("Could not parse query.")
-                expected_code = 400
-                q_str = "False_2_None_None_"
-                self.validateAssertRaises(HTTPError,
-                    lambda x: self._check_err(x, expected_string,
-                        expected_code),
-                    urlopen, durl + "/search/1/" + q_str)
-
-        def test_bug_14177(self):
-                def run_tests(api_obj, remote):
-                        self._search_op(api_obj, remote, "pfoo",
-                            self.hierarchical_named_pkg_res,
-                            case_sensitive=False)
-                        self._search_op(api_obj, remote, "pc/pfoo",
-                            self.hierarchical_named_pkg_res,
-                            case_sensitive=False)
-                        self._search_op(api_obj, remote, "pb/pc/pfoo",
-                            self.hierarchical_named_pkg_res,
-                            case_sensitive=False)
-                        self._search_op(api_obj, remote, "pa/pb/pc/pfoo",
-                            self.hierarchical_named_pkg_res,
-                            case_sensitive=False)
-                        self._search_op(api_obj, remote, "test/pa/pb/pc/pfoo",
-                            self.hierarchical_named_pkg_res,
-                            case_sensitive=False)
-
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.hierarchical_named_pkg)
-                api_obj = self.image_create(durl)
-
-                remote = True
-                run_tests(api_obj, remote)
-                self._api_install(api_obj, ["pfoo"])
-                remote = False
-                run_tests(api_obj, remote)
-                api_obj.rebuild_search_index()
-                api_obj.reset()
-                run_tests(api_obj, remote)
+                first = False
+            portable.rename(dest_path, orig_path)
+            self._search_op(
+                api_obj, False, "exam:::example_pkg", self.res_local_pkg
+            )
+
+    def test_070_mismatched_versions(self):
+        """Test to check for stack trace when files missing.
+        Bug 2753"""
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
+        self._api_install(api_obj, ["example_pkg@1.0"])
+
+        index_dir = os.path.join(
+            self.img_path(), "var", "pkg", "cache", "index"
+        )
+        self._search_op(api_obj, False, "fooo", set(), True)
+
+        first = True
+
+        for d in query_parser.TermQuery._get_gdd(index_dir).values():
+            orig_fn = d.get_file_name()
+            orig_path = os.path.join(index_dir, orig_fn)
+            dest_fn = orig_fn + "TMP"
+            dest_path = os.path.join(index_dir, dest_fn)
+            shutil.copy(orig_path, dest_path)
+            self._overwrite_version_number(orig_path)
+            api_obj.reset()
+            self.assertRaises(
+                api_errors.InconsistentIndexException,
+                self._search_op,
+                api_obj,
+                False,
+                "exam:::example_pkg",
+                [],
+            )
+            if first:
+                # Run the shell version once to check that no
+                # stack trace happens.
+                self.pkg("search -l 'exam:::example_pkg'", exit=1)
+                first = False
+            portable.rename(dest_path, orig_path)
+            self._search_op(api_obj, False, "example_pkg", self.res_local_pkg)
+            self._overwrite_version_number(orig_path)
+            self.assertRaises(
+                api_errors.WrapSuccessfulIndexingException,
+                self._api_uninstall,
+                api_obj,
+                ["example_pkg"],
+                catch_wsie=False,
+            )
+            api_obj.reset()
+            self._search_op(api_obj, False, "example_pkg", set())
+            self._overwrite_version_number(orig_path)
+            self.assertRaises(
+                api_errors.WrapSuccessfulIndexingException,
+                self._api_install,
+                api_obj,
+                ["example_pkg"],
+                catch_wsie=False,
+            )
+            api_obj.reset()
+            self._search_op(api_obj, False, "example_pkg", self.res_local_pkg)
+
+        ffh = ss.IndexStoreSetHash(ss.FULL_FMRI_HASH_FILE)
+        ffh_path = os.path.join(index_dir, ffh.get_file_name())
+        dest_fh, dest_path = tempfile.mkstemp()
+        shutil.copy(ffh_path, dest_path)
+        self._overwrite_hash(ffh_path)
+        self.assertRaises(
+            api_errors.IncorrectIndexFileHash,
+            self._search_op,
+            api_obj,
+            False,
+            "example_pkg",
+            set(),
+        )
+        # Run the shell version of the test to check for a stack trace.
+        self.pkg("search -l 'exam:::example_pkg'", exit=1)
+        portable.rename(dest_path, ffh_path)
+        self._search_op(api_obj, False, "example_pkg", self.res_local_pkg)
+        self._overwrite_hash(ffh_path)
+        self.assertRaises(
+            api_errors.WrapSuccessfulIndexingException,
+            self._api_uninstall,
+            api_obj,
+            ["example_pkg"],
+            catch_wsie=False,
+        )
+        self._search_op(api_obj, False, "example_pkg", set())
+
+    def test_080_weird_patterns(self):
+        """Test strange patterns to ensure they're handled correctly"""
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
+
+        self._search_op(api_obj, True, "[*]", self.res_remote_weird)
+        self._search_op(api_obj, True, "[?]", self.res_remote_weird)
+        self._search_op(api_obj, True, "[[]", self.res_remote_weird)
+        self._search_op(api_obj, True, "[]]", self.res_remote_weird)
+        self._search_op(api_obj, True, "FO[O]O", self.res_remote_foo)
+        self._search_op(api_obj, True, "FO[?O]O", self.res_remote_foo)
+        self._search_op(api_obj, True, "FO[*O]O", self.res_remote_foo)
+        self._search_op(api_obj, True, "FO[]O]O", self.res_remote_foo)
+
+    def test_090_bug_7660(self):
+        """Test that installing a package doesn't prevent searching on
+        package names from working on previously installed packages."""
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
+
+        tmp_dir = os.path.join(
+            self.img_path(), "var", "pkg", "cache", "index", "TMP"
+        )
+        self._api_install(api_obj, ["example_pkg"])
+        api_obj.rebuild_search_index()
+        self._api_install(api_obj, ["fat"])
+        self.assertTrue(not os.path.exists(tmp_dir))
+        self._run_local_tests(api_obj)
+
+    def test_100_bug_6712_i386(self):
+        """Install one package, and run the search suite."""
+        durl = self.dc.get_depot_url()
+
+        variants = {"variant.arch": "i386"}
+        api_obj = self.image_create(durl, variants=variants)
+        remote = True
+
+        self._search_op(api_obj, remote, "fat:::*", self.res_remote_fat10_star)
+        self._api_install(api_obj, ["fat"])
+        remote = False
+        self._search_op(
+            api_obj, remote, "fat:::*", self.res_local_fat10_i386_star
+        )
+
+    def test_110_bug_6712_sparc(self):
+        """Install one package, and run the search suite."""
+        durl = self.dc.get_depot_url()
+
+        variants = {"variant.arch": "sparc"}
+        api_obj = self.image_create(durl, variants=variants)
+        remote = True
+
+        self._search_op(api_obj, remote, "fat:::*", self.res_remote_fat10_star)
+        self._api_install(api_obj, ["fat"])
+        remote = False
+        self._search_op(
+            api_obj, remote, "fat:::*", self.res_local_fat10_sparc_star
+        )
+
+    def test_120_bug_3046(self):
+        """Checks if directories ending in / break the indexer."""
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.bad_pkg10)
+        api_obj = self.image_create(durl)
+
+        self._search_op(api_obj, True, "foo", set())
+        self._search_op(api_obj, True, "/", set())
+
+    def test_130_bug_1059(self):
+        """Checks whether the fallback of removing the image root works.
+        Also tests whether multiple queries submitted via the api work.
+        """
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
+
+        ip = self.get_img_path()
+        if not ip.endswith("/"):
+            ip += "/"
+
+        # Do remote searches
+        self._run_remove_root_search(self._search_op_multi, True, api_obj, ip)
+
+        self._api_install(api_obj, ["example_pkg"])
+        # Do local searches
+        self._run_remove_root_search(self._search_op_multi, False, api_obj, ip)
+
+        index_dir = os.path.join(
+            self.img_path(), "var", "pkg", "cache", "index"
+        )
+        shutil.rmtree(index_dir)
+        # Do slow local searches
+        self._run_remove_root_search(
+            self._search_op_slow_multi, False, api_obj, ip
+        )
+
+    def test_bug_2849(self):
+        """Checks if things with spaces break the indexer."""
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.space_pkg10)
+        api_obj = self.image_create(durl)
+
+        self._api_install(api_obj, ["space_pkg"])
+
+        self.pkgsend_bulk(durl, self.space_pkg10, optional=False)
+        api_obj.refresh(immediate=True)
+
+        self._api_install(api_obj, ["space_pkg"])
+
+        remote = False
+        self._search_op(api_obj, remote, "with", set())
+        self._search_op(api_obj, remote, "with*", self.res_space_with_star)
+        self._search_op(api_obj, remote, "*space", self.res_space_space_star)
+        self._search_op(api_obj, remote, "space", set())
+        self._search_op(api_obj, remote, "unique_dir", self.res_space_unique)
+        remote = True
+        self._search_op(api_obj, remote, "with", set())
+        self._search_op(api_obj, remote, "with*", self.res_space_with_star)
+        self._search_op(api_obj, remote, "*space", self.res_space_space_star)
+        self._search_op(api_obj, remote, "space", set())
+        self.pkgsend_bulk(durl, self.space_pkg10, optional=False)
+        # Need to add install of subsequent package and
+        # local side search as well as remote
+        self._search_op(api_obj, remote, "with", set())
+        self._search_op(api_obj, remote, "with*", self.res_space_with_star)
+        self._search_op(api_obj, remote, "*space", self.res_space_space_star)
+        self._search_op(api_obj, remote, "space", set())
+        self._search_op(api_obj, remote, "unique_dir", self.res_space_unique)
+
+    def test_bug_2863(self):
+        """Check that disabling indexing works as expected"""
+        durl = self.dc.get_depot_url()
+        api_obj = self.image_create(durl)
+
+        self._check_no_index()
+        self._api_install(api_obj, ["example_pkg"], update_index=False)
+        self._check_no_index()
+        api_obj.rebuild_search_index()
+        self._run_local_tests(api_obj)
+        self._api_uninstall(api_obj, ["example_pkg"], update_index=False)
+        # Running empty test because search will notice the index
+        # does not match the installed packages and complain.
+        self.assertRaises(
+            api_errors.IncorrectIndexFileHash,
+            self._search_op,
+            api_obj,
+            False,
+            "example_pkg",
+            set(),
+        )
+        api_obj.rebuild_search_index()
+        self._run_local_empty_tests(api_obj)
+        self._api_install(api_obj, ["example_pkg"])
+        self._run_local_tests(api_obj)
+        self.pkgsend_bulk(durl, self.example_pkg11)
+        api_obj.refresh(immediate=True)
+        self._api_update(api_obj, update_index=False)
+        # Running empty test because search will notice the index
+        # does not match the installed packages and complain.
+        self.assertRaises(
+            api_errors.IncorrectIndexFileHash,
+            self._search_op,
+            api_obj,
+            False,
+            "example_pkg",
+            set(),
+        )
+        api_obj.rebuild_search_index()
+        self._run_local_tests_example11_installed(api_obj)
+        self._api_uninstall(api_obj, ["example_pkg"], update_index=False)
+        # Running empty test because search will notice the index
+        # does not match the installed packages and complain.
+        self.assertRaises(
+            api_errors.IncorrectIndexFileHash,
+            self._search_op,
+            api_obj,
+            False,
+            "example_pkg",
+            set(),
+        )
+        api_obj.rebuild_search_index()
+        self._run_local_empty_tests(api_obj)
+
+    def test_bug_2989_1(self):
+        durl = self.dc.get_depot_url()
+
+        for f in self._dir_restore_functions:
+            api_obj = self.image_create(durl)
+
+            api_obj.rebuild_search_index()
+
+            index_dir, index_dir_tmp = self._get_index_dirs()
+
+            shutil.copytree(index_dir, index_dir_tmp)
+
+            self._api_install(api_obj, ["example_pkg"])
+
+            f(index_dir, index_dir_tmp)
+
+            self.assertRaises(
+                api_errors.WrapSuccessfulIndexingException,
+                self._api_uninstall,
+                api_obj,
+                ["example_pkg"],
+                catch_wsie=False,
+            )
+
+            self.image_destroy()
+
+    def test_bug_2989_2(self):
+        durl = self.dc.get_depot_url()
+
+        for f in self._dir_restore_functions:
+            api_obj = self.image_create(durl)
+
+            self._api_install(api_obj, ["example_pkg"])
+
+            index_dir, index_dir_tmp = self._get_index_dirs()
+
+            shutil.copytree(index_dir, index_dir_tmp)
+
+            self._api_install(api_obj, ["another_pkg"])
+
+            f(index_dir, index_dir_tmp)
+
+            self.assertRaises(
+                api_errors.WrapSuccessfulIndexingException,
+                self._api_uninstall,
+                api_obj,
+                ["another_pkg"],
+                catch_wsie=False,
+            )
+
+            self.image_destroy()
+
+    def test_bug_2989_3(self):
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.example_pkg11)
+
+        for f in self._dir_restore_functions:
+            api_obj = self.image_create(durl)
+
+            self._api_install(api_obj, ["example_pkg@1.0,5.11-0"])
+
+            index_dir, index_dir_tmp = self._get_index_dirs()
+
+            shutil.copytree(index_dir, index_dir_tmp)
+
+            self._api_install(api_obj, ["example_pkg"])
+
+            f(index_dir, index_dir_tmp)
+
+            self.assertRaises(
+                api_errors.WrapSuccessfulIndexingException,
+                self._api_uninstall,
+                api_obj,
+                ["example_pkg"],
+                catch_wsie=False,
+            )
+
+            self.image_destroy()
+
+    def test_bug_2989_4(self):
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.example_pkg11)
+
+        for f in self._dir_restore_functions:
+            api_obj = self.image_create(durl)
+
+            self._api_install(api_obj, ["another_pkg"])
+
+            index_dir, index_dir_tmp = self._get_index_dirs()
+
+            shutil.copytree(index_dir, index_dir_tmp)
+
+            self._api_install(api_obj, ["example_pkg@1.0,5.11-0"])
+
+            f(index_dir, index_dir_tmp)
+
+            self.assertRaises(
+                api_errors.WrapSuccessfulIndexingException,
+                self._api_update,
+                api_obj,
+                catch_wsie=False,
+            )
+
+            self.image_destroy()
+
+    def test_bug_4239(self):
+        """Tests whether categories are indexed and searched for
+        correctly."""
+
+        def _run_cat_tests(self, remote):
+            self._search_op(
+                api_obj,
+                remote,
+                "System",
+                self.res_cat_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "Security",
+                self.res_cat_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "System/Security",
+                self.res_cat_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "Other/Category",
+                self.res_cat_pkg10_2,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "Other",
+                self.res_cat_pkg10_2,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "Category",
+                self.res_cat_pkg10_2,
+                case_sensitive=False,
+            )
+
+        def _run_cat2_tests(self, remote):
+            self._search_op(
+                api_obj,
+                remote,
+                "Applications",
+                self.res_cat2_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                True,
+                "Sound",
+                self.res_cat2_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "Sound and Video",
+                self.res_cat2_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "Sound*",
+                self.res_cat2_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "*Video",
+                self.res_cat2_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "'Applications/Sound and Video'",
+                self.res_cat2_pkg10,
+                case_sensitive=False,
+            )
+            # This is a test for bug 11002 which ensures that the
+            # unquoting is being performed correctly.
+            self._search_op(
+                api_obj,
+                remote,
+                "'Applications/Sound%20and%20Video'",
+                set(),
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "Developer/C",
+                self.res_cat2_pkg10_2,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "Developer",
+                self.res_cat2_pkg10_2,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "C",
+                self.res_cat2_pkg10_2,
+                case_sensitive=False,
+            )
+
+        def _run_cat3_tests(self, remote):
+            self._search_op(
+                api_obj,
+                remote,
+                "foo",
+                self.res_cat3_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "baz",
+                self.res_cat3_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "asda",
+                self.res_cat3_pkg10,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "foo/bar/baz/bill/beam/asda",
+                self.res_cat3_pkg10,
+                case_sensitive=False,
+            )
+
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(
+            durl,
+            (
+                self.cat_pkg10,
+                self.cat2_pkg10,
+                self.cat3_pkg10,
+                self.bad_cat_pkg10,
+                self.bad_cat2_pkg10,
+            ),
+        )
+        api_obj = self.image_create(durl)
+
+        remote = True
+        _run_cat_tests(self, remote)
+        _run_cat2_tests(self, remote)
+        _run_cat3_tests(self, remote)
+
+        remote = False
+        self._api_install(api_obj, ["cat"])
+        _run_cat_tests(self, remote)
+
+        self._api_install(api_obj, ["cat2"])
+        _run_cat2_tests(self, remote)
+
+        self._api_install(api_obj, ["cat3"])
+        _run_cat3_tests(self, remote)
+
+        self._api_install(api_obj, ["badcat"])
+        self._api_install(api_obj, ["badcat2"])
+        _run_cat_tests(self, remote)
+        _run_cat2_tests(self, remote)
+        _run_cat3_tests(self, remote)
+
+    def test_bug_7628(self):
+        """Checks whether incremental update generates wrong
+        additional lines."""
+        durl = self.dc.get_depot_url()
+        ind_dir = self._get_repo_index_dir()
+        tok_file = os.path.join(ind_dir, ss.BYTE_OFFSET_FILE)
+        main_file = os.path.join(ind_dir, ss.MAIN_FILE)
+
+        self.pkgsend_bulk(durl, self.example_pkg10)
+        fh = open(tok_file)
+        tok_1 = fh.readlines()
+        tok_len = len(tok_1)
+        fh.close()
+
+        fh = open(main_file)
+        main_1 = fh.readlines()
+        main_len = len(main_1)
+        fh.close()
+
+        self.pkgsend_bulk(durl, self.example_pkg10, optional=False)
+        fh = open(tok_file)
+        tok_2 = fh.readlines()
+        new_tok_len = len(tok_2)
+        fh.close()
+
+        fh = open(main_file)
+        main_2 = fh.readlines()
+        new_main_len = len(main_2)
+        fh.close()
+
+        # Since the server now adds a set action for the FMRI to
+        # manifests during publication, there should be one
+        # additional line for the token file.
+        self.assertEqual(new_tok_len, tok_len + 1)
+        self.assertEqual(new_main_len, main_len + 1)
+
+    def test_bug_983(self):
+        """Test for known bug 983."""
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.bug_983_manifest)
+        api_obj = self.image_create(durl)
+
+        self._search_op(api_obj, True, "gmake", self.res_bug_983)
+        self._search_op(
+            api_obj, True, "SUNWcsl@0.5.11-0.89", self.res_983_csl_dependency
+        )
+        self._search_op(api_obj, True, "SUNWcsl", self.res_983_csl_dependency)
+        self._search_op(
+            api_obj,
+            True,
+            "SUNWtestbar@0.5.11-0.111",
+            self.res_983_bar_dependency,
+        )
+        self._search_op(
+            api_obj, True, "SUNWtestbar", self.res_983_bar_dependency
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "SUNWtestfoo@0.5.11-0.111",
+            self.res_983_foo_dependency,
+        )
+        self._search_op(
+            api_obj, True, "SUNWtestfoo", self.res_983_foo_dependency
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "depend:require:",
+            self.res_983_csl_dependency | self.res_983_bar_dependency,
+        )
+        self._search_op(
+            api_obj, True, "depend:incorporate:", self.res_983_foo_dependency
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "depend::",
+            self.res_983_csl_dependency
+            | self.res_983_bar_dependency
+            | self.res_983_foo_dependency,
+        )
+
+    def test_bug_7534(self):
+        """Tests that an automatic reindexing is detected by the test
+        suite."""
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.example_pkg10)
+        api_obj = self.image_create(durl)
+
+        index_dir = os.path.join(
+            self.img_path(), "var", "pkg", "cache", "index"
+        )
+        api_obj.rebuild_search_index()
+        self._search_op(api_obj, False, "example", set())
+
+        orig_fn = os.path.join(
+            index_dir,
+            list(query_parser.TermQuery._get_gdd(index_dir).values())[
+                0
+            ].get_file_name(),
+        )
+        dest_fn = orig_fn + "TMP"
+
+        self._api_install(api_obj, ["example_pkg"])
+        api_obj.rebuild_search_index()
+
+        portable.rename(orig_fn, dest_fn)
+        self.assertRaises(
+            api_errors.WrapSuccessfulIndexingException,
+            self._api_uninstall,
+            api_obj,
+            ["example_pkg"],
+            catch_wsie=False,
+        )
+
+    def test_bug_8492(self):
+        """Tests that field queries and phrase queries work together."""
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, (self.bug_8492_manf_1, self.bug_8492_manf_2))
+        api_obj = self.image_create(durl)
+
+        self._search_op(
+            api_obj,
+            True,
+            "set::'image packaging'",
+            self.res_8492_1 | self.res_8492_2,
+        )
+        self._search_op(
+            api_obj, True, "b1:set::'image packaging'", self.res_8492_1
+        )
+
+        self._api_install(api_obj, ["b1", "b2"])
+
+        self._search_op(
+            api_obj,
+            False,
+            "set::'image packaging'",
+            self.res_8492_1 | self.res_8492_2,
+        )
+        self._search_op(
+            api_obj, False, "b2:set::'image packaging'", self.res_8492_2
+        )
+
+        api_obj.rebuild_search_index()
+
+        self._search_op(
+            api_obj,
+            True,
+            "set::'image packaging'",
+            self.res_8492_1 | self.res_8492_2,
+        )
+        self._search_op(
+            api_obj, True, "b1:set::'image packaging'", self.res_8492_1
+        )
+
+    def test_bug_9845_01(self):
+        """Test that a corrupt query doesn't break the server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _(
+            "A query is expected to have five fields: "
+            "case sensitivity, return type, number of results to "
+            "return, the number at which to start returning results, "
+            "and the text of the query.  The query provided lacked at "
+            "least one of those fields:"
+        )
+        expected_code = 404
+        q_str = "foo"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_9845_02(self):
+        """Test that a corrupt case_sensitive value doesn't break the "
+        server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _("{name} had a bad value of '{bv}'").format(
+            name="case_sensitive", bv="FAlse"
+        )
+        expected_code = 404
+        q_str = "FAlse_2_None_None_foo"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_9845_03(self):
+        """Test that a corrupt return_type value doesn't break the "
+        server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _("{name} had a bad value of '{bv}'").format(
+            name="return_type", bv="3"
+        )
+        expected_code = 404
+        q_str = "False_3_None_None_foo"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_9845_04(self):
+        """Test that a corrupt return_type value doesn't break the "
+        server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _("{name} had a bad value of '{bv}'").format(
+            name="return_type", bv="A"
+        )
+        expected_code = 404
+        q_str = "False_A_None_None_foo"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_9845_05(self):
+        """Test that a corrupt num_to_return value doesn't break the "
+        server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _("{name} had a bad value of '{bv}'").format(
+            name="num_to_return", bv="NOne"
+        )
+        expected_code = 404
+        q_str = "False_2_NOne_None_foo"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_9845_06(self):
+        """Test that a corrupt start_point value doesn't break the "
+        server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _("{name} had a bad value of '{bv}'").format(
+            name="start_point", bv="NOne"
+        )
+        expected_code = 404
+        q_str = "False_2_None_NOne_foo"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_9845_07(self):
+        """Test that a corrupt case_sensitive value doesn't break the "
+        server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _("{name} had a bad value of '{bv}'").format(
+            name="case_sensitive", bv=""
+        )
+        expected_code = 404
+        q_str = "_2_None_None_foo"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_9845_08(self):
+        """Test that a missing return_type value doesn't break the "
+        server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _("{name} had a bad value of '{bv}'").format(
+            name="return_type", bv=""
+        )
+        expected_code = 404
+        q_str = "False__None_None_foo"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_9845_09(self):
+        """Test that a missing num_to_return value doesn't break the "
+        server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _("{name} had a bad value of '{bv}'").format(
+            name="num_to_return", bv=""
+        )
+        expected_code = 404
+        q_str = "False_2__None_foo"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_9845_10(self):
+        """Test that a missing start_point value doesn't break the "
+        server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _("{name} had a bad value of '{bv}'").format(
+            name="start_point", bv=""
+        )
+        expected_code = 404
+        q_str = "False_2_None__foo"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_9845_11(self):
+        """Test that missing query text doesn't break the server."""
+        durl = self.dc.get_depot_url()
+        expected_string = _("Could not parse query.")
+        expected_code = 400
+        q_str = "False_2_None_None_"
+        self.validateAssertRaises(
+            HTTPError,
+            lambda x: self._check_err(x, expected_string, expected_code),
+            urlopen,
+            durl + "/search/1/" + q_str,
+        )
+
+    def test_bug_14177(self):
+        def run_tests(api_obj, remote):
+            self._search_op(
+                api_obj,
+                remote,
+                "pfoo",
+                self.hierarchical_named_pkg_res,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "pc/pfoo",
+                self.hierarchical_named_pkg_res,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "pb/pc/pfoo",
+                self.hierarchical_named_pkg_res,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "pa/pb/pc/pfoo",
+                self.hierarchical_named_pkg_res,
+                case_sensitive=False,
+            )
+            self._search_op(
+                api_obj,
+                remote,
+                "test/pa/pb/pc/pfoo",
+                self.hierarchical_named_pkg_res,
+                case_sensitive=False,
+            )
+
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.hierarchical_named_pkg)
+        api_obj = self.image_create(durl)
+
+        remote = True
+        run_tests(api_obj, remote)
+        self._api_install(api_obj, ["pfoo"])
+        remote = False
+        run_tests(api_obj, remote)
+        api_obj.rebuild_search_index()
+        api_obj.reset()
+        run_tests(api_obj, remote)
 
 
 class TestApiSearchBasics_nonP(TestApiSearchBasics):
-        def setUp(self):
-                self.debug_features = ["headers"]
-                TestApiSearchBasics.setUp(self)
+    def setUp(self):
+        self.debug_features = ["headers"]
+        TestApiSearchBasics.setUp(self)
 
-        def pkgsend_bulk(self, durl, pkg):
-                # Ensures indexing is done for every pkgsend.
-                TestApiSearchBasics.pkgsend_bulk(self, durl, pkg,
-                    refresh_index=True)
-                self.wait_repo(self.dc.get_repodir())
+    def pkgsend_bulk(self, durl, pkg):
+        # Ensures indexing is done for every pkgsend.
+        TestApiSearchBasics.pkgsend_bulk(self, durl, pkg, refresh_index=True)
+        self.wait_repo(self.dc.get_repodir())
 
-        def test_local_image_update(self):
-                """Test that the index gets updated by update and
-                that rebuilding the index works after updating the
-                image. Specifically, this tests that rebuilding indexes with
-                gaps in them works correctly."""
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.example_pkg10)
-                api_obj = self.image_create(durl)
+    def test_local_image_update(self):
+        """Test that the index gets updated by update and
+        that rebuilding the index works after updating the
+        image. Specifically, this tests that rebuilding indexes with
+        gaps in them works correctly."""
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.example_pkg10)
+        api_obj = self.image_create(durl)
 
-                self._api_install(api_obj, ["example_pkg"])
+        self._api_install(api_obj, ["example_pkg"])
 
-                self.pkgsend_bulk(durl, self.example_pkg11)
-                api_obj.refresh(immediate=True)
+        self.pkgsend_bulk(durl, self.example_pkg11)
+        api_obj.refresh(immediate=True)
 
-                self._api_update(api_obj)
+        self._api_update(api_obj)
 
-                self._run_local_tests_example11_installed(api_obj)
+        self._run_local_tests_example11_installed(api_obj)
 
-                api_obj.rebuild_search_index()
+        api_obj.rebuild_search_index()
 
-                self._run_local_tests_example11_installed(api_obj)
+        self._run_local_tests_example11_installed(api_obj)
 
-        def test_bug_6177(self):
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, (self.example_pkg10, self.example_pkg11,
-                    self.incorp_pkg10, self.incorp_pkg11))
-                api_obj = self.image_create(durl)
+    def test_bug_6177(self):
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(
+            durl,
+            (
+                self.example_pkg10,
+                self.example_pkg11,
+                self.incorp_pkg10,
+                self.incorp_pkg11,
+            ),
+        )
+        api_obj = self.image_create(durl)
 
-                res_both_actions = set([
-                    ('pkg:/example_pkg@1.1-0', 'path',
-                        'dir group=bin mode=0755 owner=root path=bin'),
-                    ('pkg:/example_pkg@1.0-0', 'path',
-                        'dir group=bin mode=0755 owner=root path=bin')
-                ])
-
-                res_10_action = set([
-                    ('pkg:/example_pkg@1.0-0', 'path',
-                        'dir group=bin mode=0755 owner=root path=bin')
-                ])
-
-                res_11_action = set([
-                    ('pkg:/example_pkg@1.1-0', 'path',
-                        'dir group=bin mode=0755 owner=root path=bin')
-                ])
-
-                res_both_packages = set([
+        res_both_actions = set(
+            [
+                (
                     "pkg:/example_pkg@1.1-0",
-                    "pkg:/example_pkg@1.0-0"
-                ])
+                    "path",
+                    "dir group=bin mode=0755 owner=root path=bin",
+                ),
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "path",
+                    "dir group=bin mode=0755 owner=root path=bin",
+                ),
+            ]
+        )
 
-                res_10_package = set([
-                    "pkg:/example_pkg@1.0-0"
-                ])
+        res_10_action = set(
+            [
+                (
+                    "pkg:/example_pkg@1.0-0",
+                    "path",
+                    "dir group=bin mode=0755 owner=root path=bin",
+                )
+            ]
+        )
 
-                res_11_package = set([
-                    "pkg:/example_pkg@1.1-0"
-                ])
+        res_11_action = set(
+            [
+                (
+                    "pkg:/example_pkg@1.1-0",
+                    "path",
+                    "dir group=bin mode=0755 owner=root path=bin",
+                )
+            ]
+        )
 
-                self._search_op(api_obj, True, "/bin", res_both_actions)
+        res_both_packages = set(
+            ["pkg:/example_pkg@1.1-0", "pkg:/example_pkg@1.0-0"]
+        )
 
-                # Test that if a package is installed, its version and newer
-                # versions are shown.
-                self._api_install(api_obj, ["example_pkg@1.0"])
-                self._search_op(api_obj, True, "/bin", res_both_actions)
-                self._search_op(api_obj, True, "/bin", res_both_actions,
-                    prune_versions=False)
+        res_10_package = set(["pkg:/example_pkg@1.0-0"])
 
-                # Check that after uninstall, back to returning all versions.
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self._search_op(api_obj, True, "/bin", res_both_actions)
-                self._search_op(api_obj, True, "/bin", res_both_packages,
-                    return_actions=False)
+        res_11_package = set(["pkg:/example_pkg@1.1-0"])
 
-                # Test that if a package is installed, its version and newer
-                # versions are shown.  Older versions should not be shown.
-                self._api_install(api_obj, ["example_pkg@1.1"])
-                self._search_op(api_obj, True, "/bin", res_11_action)
-                self._search_op(api_obj, True, "</bin>", res_11_package,
-                    return_actions=False)
-                self._search_op(api_obj, True, "/bin", res_both_actions,
-                    prune_versions=False)
-                self._search_op(api_obj, True, "</bin>", res_both_packages,
-                    return_actions=False, prune_versions=False)
+        self._search_op(api_obj, True, "/bin", res_both_actions)
 
-                # Check that after uninstall, back to returning all versions.
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self._search_op(api_obj, True, "/bin", res_both_actions)
+        # Test that if a package is installed, its version and newer
+        # versions are shown.
+        self._api_install(api_obj, ["example_pkg@1.0"])
+        self._search_op(api_obj, True, "/bin", res_both_actions)
+        self._search_op(
+            api_obj, True, "/bin", res_both_actions, prune_versions=False
+        )
 
-                # Check that only the incorporated package is returned.
-                self._api_install(api_obj, ["incorp_pkg@1.0"])
-                self._search_op(api_obj, True, "/bin", res_10_action)
-                self._search_op(api_obj, True, "/bin", res_10_package,
-                    return_actions=False)
-                self._search_op(api_obj, True, "/bin", res_both_actions,
-                    prune_versions=False)
-                self._search_op(api_obj, True, "/bin", res_both_packages,
-                    return_actions=False, prune_versions=False)
+        # Check that after uninstall, back to returning all versions.
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self._search_op(api_obj, True, "/bin", res_both_actions)
+        self._search_op(
+            api_obj, True, "/bin", res_both_packages, return_actions=False
+        )
 
-                # Should now show the 1.1 version of example_pkg since the
-                # version has been upgraded.
-                self._api_install(api_obj, ["incorp_pkg"])
-                self._search_op(api_obj, True, "/bin", res_11_action)
-                self._search_op(api_obj, True, "</bin>", res_11_package,
-                    return_actions=False)
-                self._search_op(api_obj, True, "/bin", res_both_actions,
-                    prune_versions=False)
-                self._search_op(api_obj, True, "</bin>", res_both_packages,
-                    return_actions=False, prune_versions=False)
+        # Test that if a package is installed, its version and newer
+        # versions are shown.  Older versions should not be shown.
+        self._api_install(api_obj, ["example_pkg@1.1"])
+        self._search_op(api_obj, True, "/bin", res_11_action)
+        self._search_op(
+            api_obj, True, "</bin>", res_11_package, return_actions=False
+        )
+        self._search_op(
+            api_obj, True, "/bin", res_both_actions, prune_versions=False
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "</bin>",
+            res_both_packages,
+            return_actions=False,
+            prune_versions=False,
+        )
 
-                # Should now show both again since the incorporation has been
-                # removed.
-                self._api_uninstall(api_obj, ["incorp_pkg"])
-                self._search_op(api_obj, True, "/bin", res_both_actions)
+        # Check that after uninstall, back to returning all versions.
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self._search_op(api_obj, True, "/bin", res_both_actions)
 
-                # Check that installed and incorporated work correctly together.
-                self._api_install(api_obj,
-                    ["incorp_pkg@1.0", "example_pkg@1.0"])
-                self._search_op(api_obj, True, "/bin", res_10_action)
-                self._search_op(api_obj, True, "</bin>", res_10_package,
-                    return_actions=False)
-                self._search_op(api_obj, True, "/bin", res_both_actions,
-                    prune_versions=False)
-                self._search_op(api_obj, True, "</bin>", res_both_packages,
-                    return_actions=False, prune_versions=False)
+        # Check that only the incorporated package is returned.
+        self._api_install(api_obj, ["incorp_pkg@1.0"])
+        self._search_op(api_obj, True, "/bin", res_10_action)
+        self._search_op(
+            api_obj, True, "/bin", res_10_package, return_actions=False
+        )
+        self._search_op(
+            api_obj, True, "/bin", res_both_actions, prune_versions=False
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "/bin",
+            res_both_packages,
+            return_actions=False,
+            prune_versions=False,
+        )
 
-                # And that it works after the incorporation has been changed.
-                self._api_install(api_obj, ["incorp_pkg"])
-                self._search_op(api_obj, True, "/bin", res_11_action)
-                self._search_op(api_obj, True, "</bin>", res_11_package,
-                    return_actions=False)
-                self._search_op(api_obj, True, "/bin", res_both_actions,
-                    prune_versions=False)
-                self._search_op(api_obj, True, "</bin>", res_both_packages,
-                    return_actions=False, prune_versions=False)
+        # Should now show the 1.1 version of example_pkg since the
+        # version has been upgraded.
+        self._api_install(api_obj, ["incorp_pkg"])
+        self._search_op(api_obj, True, "/bin", res_11_action)
+        self._search_op(
+            api_obj, True, "</bin>", res_11_package, return_actions=False
+        )
+        self._search_op(
+            api_obj, True, "/bin", res_both_actions, prune_versions=False
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "</bin>",
+            res_both_packages,
+            return_actions=False,
+            prune_versions=False,
+        )
 
-        def __corrupt_depot(self, root):
-                self.dc.stop()
-                for entry in os.walk(root):
-                        dirpath, dirnames, fnames = entry
-                        if ss.MAIN_FILE in fnames:
-                                src = os.path.join(dirpath, ss.MAIN_FILE)
-                                dest = os.path.join(dirpath,
-                                    "main_dict.ascii.v1")
-                                self.debug("moving {0} to {1}".format(src, dest))
-                                shutil.move(src, dest)
-                self.dc.start()
+        # Should now show both again since the incorporation has been
+        # removed.
+        self._api_uninstall(api_obj, ["incorp_pkg"])
+        self._search_op(api_obj, True, "/bin", res_both_actions)
 
-        def test_bug_7358_1(self):
-                """Move files so that an inconsistent index is created and
-                check that the server rebuilds the index when possible, and
-                doesn't stack trace when it can't write to the directory."""
+        # Check that installed and incorporated work correctly together.
+        self._api_install(api_obj, ["incorp_pkg@1.0", "example_pkg@1.0"])
+        self._search_op(api_obj, True, "/bin", res_10_action)
+        self._search_op(
+            api_obj, True, "</bin>", res_10_package, return_actions=False
+        )
+        self._search_op(
+            api_obj, True, "/bin", res_both_actions, prune_versions=False
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "</bin>",
+            res_both_packages,
+            return_actions=False,
+            prune_versions=False,
+        )
 
-                durl = self.dc.get_depot_url()
-                repo_path = self.dc.get_repodir()
+        # And that it works after the incorporation has been changed.
+        self._api_install(api_obj, ["incorp_pkg"])
+        self._search_op(api_obj, True, "/bin", res_11_action)
+        self._search_op(
+            api_obj, True, "</bin>", res_11_package, return_actions=False
+        )
+        self._search_op(
+            api_obj, True, "/bin", res_both_actions, prune_versions=False
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "</bin>",
+            res_both_packages,
+            return_actions=False,
+            prune_versions=False,
+        )
 
-                api_obj = self.image_create(durl)
-                # Check when depot is empty.
-                self.__corrupt_depot(repo_path)
-                repo = self.dc.get_repo() # Every time to ensure current state.
-                repo.refresh_index()
-                # Since the depot is empty, should return no results but
-                # not error.
-                self._search_op(api_obj, True, 'e*', set())
+    def __corrupt_depot(self, root):
+        self.dc.stop()
+        for entry in os.walk(root):
+            dirpath, dirnames, fnames = entry
+            if ss.MAIN_FILE in fnames:
+                src = os.path.join(dirpath, ss.MAIN_FILE)
+                dest = os.path.join(dirpath, "main_dict.ascii.v1")
+                self.debug("moving {0} to {1}".format(src, dest))
+                shutil.move(src, dest)
+        self.dc.start()
 
-                self.pkgsend_bulk(durl, self.example_pkg10)
-                repo = self.dc.get_repo() # Every time to ensure current state.
-                repo.refresh_index()
-                self.dc.refresh()
+    def test_bug_7358_1(self):
+        """Move files so that an inconsistent index is created and
+        check that the server rebuilds the index when possible, and
+        doesn't stack trace when it can't write to the directory."""
 
-                # Check when depot contains a package.
-                self.__corrupt_depot(repo_path)
-                repo = self.dc.get_repo() # Every time to ensure current state.
-                repo.refresh_index()
-                self._run_remote_tests(api_obj)
+        durl = self.dc.get_depot_url()
+        repo_path = self.dc.get_repodir()
 
-        def test_bug_7358_2(self):
-                """Does same check as 7358_1 except it checks for interactions
-                with writable root."""
+        api_obj = self.image_create(durl)
+        # Check when depot is empty.
+        self.__corrupt_depot(repo_path)
+        repo = self.dc.get_repo()  # Every time to ensure current state.
+        repo.refresh_index()
+        # Since the depot is empty, should return no results but
+        # not error.
+        self._search_op(api_obj, True, "e*", set())
 
-                durl = self.dc.get_depot_url()
-                repo_path = self.dc.get_repodir()
-                ind_dir = self._get_repo_index_dir()
-                if os.path.exists(ind_dir):
-                        shutil.rmtree(ind_dir)
-                writable_root = os.path.join(self.test_root,
-                    "writ_root")
-                self.dc.set_writable_root(writable_root)
+        self.pkgsend_bulk(durl, self.example_pkg10)
+        repo = self.dc.get_repo()  # Every time to ensure current state.
+        repo.refresh_index()
+        self.dc.refresh()
 
-                api_obj = self.image_create(durl)
+        # Check when depot contains a package.
+        self.__corrupt_depot(repo_path)
+        repo = self.dc.get_repo()  # Every time to ensure current state.
+        repo.refresh_index()
+        self._run_remote_tests(api_obj)
 
-                # Check when depot is empty.
-                writ_dir = self._get_repo_writ_dir()
-                self.__corrupt_depot(writ_dir)
-                # Since the depot is empty, should return no results but
-                # not error.
-                self.assertTrue(not os.path.isdir(ind_dir))
-                self._search_op(api_obj, True, 'e*', set())
+    def test_bug_7358_2(self):
+        """Does same check as 7358_1 except it checks for interactions
+        with writable root."""
 
-                self.pkgsend_bulk(durl, self.example_pkg10)
+        durl = self.dc.get_depot_url()
+        repo_path = self.dc.get_repodir()
+        ind_dir = self._get_repo_index_dir()
+        if os.path.exists(ind_dir):
+            shutil.rmtree(ind_dir)
+        writable_root = os.path.join(self.test_root, "writ_root")
+        self.dc.set_writable_root(writable_root)
 
-                # Check when depot contains a package.
-                self.__corrupt_depot(writ_dir)
-                self.assertTrue(not os.path.isdir(ind_dir))
-                self._run_remote_tests(api_obj)
+        api_obj = self.image_create(durl)
 
-        def test_bug_8318(self):
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.example_pkg10)
-                api_obj = self.image_create(durl)
-                uuids = []
-                for p in api_obj.img.gen_publishers():
-                        uuids.append(p.client_uuid)
+        # Check when depot is empty.
+        writ_dir = self._get_repo_writ_dir()
+        self.__corrupt_depot(writ_dir)
+        # Since the depot is empty, should return no results but
+        # not error.
+        self.assertTrue(not os.path.isdir(ind_dir))
+        self._search_op(api_obj, True, "e*", set())
 
-                self._search_op(api_obj, True, "example_path",
-                    self.res_remote_path)
-                self._search_op(api_obj, True, "example_path",
-                    self.res_remote_path, servers=[{"origin": durl}])
-                lfh = open(self.dc.get_logpath(), "r")
-                found = 0
-                num_expected = 7
-                for line in lfh:
-                        if "X-IPKG-UUID:" in line:
-                                tmp = line.split()
-                                s_uuid = tmp[1]
-                                if s_uuid not in uuids:
-                                        raise RuntimeError("Uuid found:{0} not "
-                                            "found in list of possible "
-                                            "uuids:{1}".format(s_uuid, uuids))
-                                found += 1
-                lfh.close()
-                if found != num_expected:
-                        raise RuntimeError(("Found {0} instances of a "
-                            "client uuid, expected to find {1}.").format(
-                            found, num_expected))
+        self.pkgsend_bulk(durl, self.example_pkg10)
 
-        def test_bug_9729_1(self):
-                """Test that installing more than
-                indexer.MAX_FAST_INDEXED_PKGS packages at a time doesn't
-                cause any type of indexing error."""
-                durl = self.dc.get_depot_url()
-                pkg_list = []
-                for i in range(0, indexer.MAX_FAST_INDEXED_PKGS + 1):
-                        self.pkgsend_bulk(durl,
-                            "open pkg{0}@1.0,5.11-0\nclose\n".format(i))
-                        pkg_list.append("pkg{0}".format(i))
-                api_obj = self.image_create(durl)
-                self._api_install(api_obj, pkg_list)
+        # Check when depot contains a package.
+        self.__corrupt_depot(writ_dir)
+        self.assertTrue(not os.path.isdir(ind_dir))
+        self._run_remote_tests(api_obj)
 
-        def test_bug_9729_2(self):
-                """Test that installing more than
-                indexer.MAX_FAST_INDEXED_PKGS packages one after another
-                doesn't cause any type of indexing error."""
-                def _remove_extra_info(v):
-                        return v.split("-")[0]
-                durl = self.dc.get_depot_url()
-                pkg_list = []
-                for i in range(0, indexer.MAX_FAST_INDEXED_PKGS + 3):
-                        self.pkgsend_bulk(durl,
-                            "open pkg{0}@1.0,5.11-0\nclose\n".format(i))
-                        pkg_list.append("pkg{0}".format(i))
-                api_obj = self.image_create(durl)
-                fast_add_loc = os.path.join(self._get_index_dirs()[0],
-                    "fast_add.v1")
-                fast_remove_loc = os.path.join(self._get_index_dirs()[0],
-                    "fast_remove.v1")
-                api_obj.rebuild_search_index()
-                for p in pkg_list:
-                        self._api_install(api_obj, [p])
-                # Test for bug 11104. The fast_add.v1 file was not being updated
-                # correctly by install or image update, it was growing with
-                # each modification.
-                self._check(set((
-                    _remove_extra_info(v)
-                    for v in self._get_lines(fast_add_loc)
-                    )), self.fast_add_after_install)
-                self._check(set((
+    def test_bug_8318(self):
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.example_pkg10)
+        api_obj = self.image_create(durl)
+        uuids = []
+        for p in api_obj.img.gen_publishers():
+            uuids.append(p.client_uuid)
+
+        self._search_op(api_obj, True, "example_path", self.res_remote_path)
+        self._search_op(
+            api_obj,
+            True,
+            "example_path",
+            self.res_remote_path,
+            servers=[{"origin": durl}],
+        )
+        lfh = open(self.dc.get_logpath(), "r")
+        found = 0
+        num_expected = 7
+        for line in lfh:
+            if "X-IPKG-UUID:" in line:
+                tmp = line.split()
+                s_uuid = tmp[1]
+                if s_uuid not in uuids:
+                    raise RuntimeError(
+                        "Uuid found:{0} not "
+                        "found in list of possible "
+                        "uuids:{1}".format(s_uuid, uuids)
+                    )
+                found += 1
+        lfh.close()
+        if found != num_expected:
+            raise RuntimeError(
+                (
+                    "Found {0} instances of a "
+                    "client uuid, expected to find {1}."
+                ).format(found, num_expected)
+            )
+
+    def test_bug_9729_1(self):
+        """Test that installing more than
+        indexer.MAX_FAST_INDEXED_PKGS packages at a time doesn't
+        cause any type of indexing error."""
+        durl = self.dc.get_depot_url()
+        pkg_list = []
+        for i in range(0, indexer.MAX_FAST_INDEXED_PKGS + 1):
+            self.pkgsend_bulk(durl, "open pkg{0}@1.0,5.11-0\nclose\n".format(i))
+            pkg_list.append("pkg{0}".format(i))
+        api_obj = self.image_create(durl)
+        self._api_install(api_obj, pkg_list)
+
+    def test_bug_9729_2(self):
+        """Test that installing more than
+        indexer.MAX_FAST_INDEXED_PKGS packages one after another
+        doesn't cause any type of indexing error."""
+
+        def _remove_extra_info(v):
+            return v.split("-")[0]
+
+        durl = self.dc.get_depot_url()
+        pkg_list = []
+        for i in range(0, indexer.MAX_FAST_INDEXED_PKGS + 3):
+            self.pkgsend_bulk(durl, "open pkg{0}@1.0,5.11-0\nclose\n".format(i))
+            pkg_list.append("pkg{0}".format(i))
+        api_obj = self.image_create(durl)
+        fast_add_loc = os.path.join(self._get_index_dirs()[0], "fast_add.v1")
+        fast_remove_loc = os.path.join(
+            self._get_index_dirs()[0], "fast_remove.v1"
+        )
+        api_obj.rebuild_search_index()
+        for p in pkg_list:
+            self._api_install(api_obj, [p])
+        # Test for bug 11104. The fast_add.v1 file was not being updated
+        # correctly by install or image update, it was growing with
+        # each modification.
+        self._check(
+            set((_remove_extra_info(v) for v in self._get_lines(fast_add_loc))),
+            self.fast_add_after_install,
+        )
+        self._check(
+            set(
+                (
                     _remove_extra_info(v)
                     for v in self._get_lines(fast_remove_loc)
-                    )), self.fast_remove_after_install)
-                # Now check that image update also handles fast_add
-                # appropriately when a small number of packages have changed.
-                for i in range(0, 2):
-                        self.pkgsend_bulk(durl,
-                            "open pkg{0}@2.0,5.11-0\nclose\n".format(i))
-                        pkg_list.append("pkg{0}".format(i))
-                api_obj.refresh(immediate=True)
-                self._api_update(api_obj)
-                self._check(set((
-                    _remove_extra_info(v)
-                    for v in self._get_lines(fast_add_loc)
-                    )), self.fast_add_after_first_update)
+                )
+            ),
+            self.fast_remove_after_install,
+        )
+        # Now check that image update also handles fast_add
+        # appropriately when a small number of packages have changed.
+        for i in range(0, 2):
+            self.pkgsend_bulk(durl, "open pkg{0}@2.0,5.11-0\nclose\n".format(i))
+            pkg_list.append("pkg{0}".format(i))
+        api_obj.refresh(immediate=True)
+        self._api_update(api_obj)
+        self._check(
+            set((_remove_extra_info(v) for v in self._get_lines(fast_add_loc))),
+            self.fast_add_after_first_update,
+        )
 
-                self._check(set((
-                    _remove_extra_info(v)
-                    for v in self._get_lines(fast_remove_loc)
-                    )), self.fast_remove_after_first_update)
-                # Check that a local search actually works.
-                test_value = 'pkg:/pkg{0}@2.0-0', 'test/pkg{0}', \
-                    'set name=pkg.fmri value=pkg://test/pkg{0}@2.0,5.11-0:'
-                for n in range(0, 2):
-                        tv = set([tuple(v.format(n) for v in test_value)])
-                        self._search_op(api_obj, remote=False,
-                            token="pkg{0}".format(n), test_value=tv)
-
-                # Now check that image update also handles fast_add
-                # appropriately when a large number of packages have changed.
-                for i in range(3, indexer.MAX_FAST_INDEXED_PKGS + 3):
-                        self.pkgsend_bulk(durl,
-                            "open pkg{0}@2.0,5.11-0\nclose\n".format(i))
-                        pkg_list.append("pkg{0}".format(i))
-                api_obj.refresh(immediate=True)
-                self._api_update(api_obj)
-                self._check(set((
-                    _remove_extra_info(v)
-                    for v in self._get_lines(fast_add_loc)
-                    )), self.fast_add_after_second_update)
-                self._check(set((
+        self._check(
+            set(
+                (
                     _remove_extra_info(v)
                     for v in self._get_lines(fast_remove_loc)
-                    )), self.fast_remove_after_second_update)
-                # Check that a local search actually works.
-                for n in range(3, indexer.MAX_FAST_INDEXED_PKGS + 3):
-                        tv = set([tuple(v.format(n) for v in test_value)])
-                        self._search_op(api_obj, remote=False,
-                            token="pkg{0}".format(n), test_value=tv)
+                )
+            ),
+            self.fast_remove_after_first_update,
+        )
+        # Check that a local search actually works.
+        test_value = (
+            "pkg:/pkg{0}@2.0-0",
+            "test/pkg{0}",
+            "set name=pkg.fmri value=pkg://test/pkg{0}@2.0,5.11-0:",
+        )
+        for n in range(0, 2):
+            tv = set([tuple(v.format(n) for v in test_value)])
+            self._search_op(
+                api_obj, remote=False, token="pkg{0}".format(n), test_value=tv
+            )
 
-        def test_bug_13485(self):
-                """Test that indexer.Indexer's check_for_updates function works
-                as excepted. This needs to be a separate test because other
-                tests are likely to conintue working while reindexing more
-                frequently than they should."""
+        # Now check that image update also handles fast_add
+        # appropriately when a large number of packages have changed.
+        for i in range(3, indexer.MAX_FAST_INDEXED_PKGS + 3):
+            self.pkgsend_bulk(durl, "open pkg{0}@2.0,5.11-0\nclose\n".format(i))
+            pkg_list.append("pkg{0}".format(i))
+        api_obj.refresh(immediate=True)
+        self._api_update(api_obj)
+        self._check(
+            set((_remove_extra_info(v) for v in self._get_lines(fast_add_loc))),
+            self.fast_add_after_second_update,
+        )
+        self._check(
+            set(
+                (
+                    _remove_extra_info(v)
+                    for v in self._get_lines(fast_remove_loc)
+                )
+            ),
+            self.fast_remove_after_second_update,
+        )
+        # Check that a local search actually works.
+        for n in range(3, indexer.MAX_FAST_INDEXED_PKGS + 3):
+            tv = set([tuple(v.format(n) for v in test_value)])
+            self._search_op(
+                api_obj, remote=False, token="pkg{0}".format(n), test_value=tv
+            )
 
-                durl = self.dc.get_depot_url()
-                ind_dir = self._get_repo_index_dir()
+    def test_bug_13485(self):
+        """Test that indexer.Indexer's check_for_updates function works
+        as excepted. This needs to be a separate test because other
+        tests are likely to conintue working while reindexing more
+        frequently than they should."""
 
-                # Check that an empty index works correctly.
-                fmris = indexer.Indexer.check_for_updates(ind_dir,
-                    self._get_repo_catalog())
-                self.assertEqual(set(), fmris)
+        durl = self.dc.get_depot_url()
+        ind_dir = self._get_repo_index_dir()
 
-                self.pkgsend_bulk(durl, self.example_pkg10)
-                cat = self._get_repo_catalog()
-                self.assertEqual(len(set(cat.fmris())), 1)
-                # Check that after publishing one package, no packages need
-                # indexing.
-                fmris = indexer.Indexer.check_for_updates(ind_dir,
-                    self._get_repo_catalog())
-                self.assertEqual(set(), fmris)
+        # Check that an empty index works correctly.
+        fmris = indexer.Indexer.check_for_updates(
+            ind_dir, self._get_repo_catalog()
+        )
+        self.assertEqual(set(), fmris)
 
-                back_dir = ind_dir + ".BACKUP"
-                shutil.copytree(ind_dir, back_dir)
-                self.pkgsend_bulk(durl, self.example_pkg10)
-                cat = self._get_repo_catalog()
-                self.assertEqual(len(set(cat.fmris())), 2)
-                # Check that publishing a second package also works.
-                fmris = indexer.Indexer.check_for_updates(ind_dir,
-                    self._get_repo_catalog())
-                self.assertEqual(set(), fmris)
+        self.pkgsend_bulk(durl, self.example_pkg10)
+        cat = self._get_repo_catalog()
+        self.assertEqual(len(set(cat.fmris())), 1)
+        # Check that after publishing one package, no packages need
+        # indexing.
+        fmris = indexer.Indexer.check_for_updates(
+            ind_dir, self._get_repo_catalog()
+        )
+        self.assertEqual(set(), fmris)
 
-                # Check that a package that was publisher but not index is
-                # reported.
-                fmris = indexer.Indexer.check_for_updates(back_dir,
-                    self._get_repo_catalog())
-                self.assertEqual(len(fmris), 1)
+        back_dir = ind_dir + ".BACKUP"
+        shutil.copytree(ind_dir, back_dir)
+        self.pkgsend_bulk(durl, self.example_pkg10)
+        cat = self._get_repo_catalog()
+        self.assertEqual(len(set(cat.fmris())), 2)
+        # Check that publishing a second package also works.
+        fmris = indexer.Indexer.check_for_updates(
+            ind_dir, self._get_repo_catalog()
+        )
+        self.assertEqual(set(), fmris)
 
-        def test_bug_17672(self):
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, (self.another_pkg10, self.space_pkg10,
-                    self.require_any_manf))
-                repo = self.dc.get_repo()
-                repo.rebuild(build_catalog=False, build_index=True)
-                api_obj = self.image_create(durl)
-                expected_result = set([
-                    ('pkg:/ra@1.0-0', 'require-any',
-                    'depend fmri=another_pkg@1.0,5.11-0 ' +
-                    'fmri=pkg:/space_pkg@1.0,5.11-0 type=require-any')
-                ])
-                self._search_op(api_obj, True, "depend::", expected_result)
-                self._api_install(api_obj, ["ra"])
-                self._search_op(api_obj, False, "depend::", expected_result)
-                api_obj.rebuild_search_index()
-                self._search_op(api_obj, False, "depend::", expected_result)
-                self._search_op(api_obj, False, "depend::another_pkg",
-                    expected_result)
-                self._search_op(api_obj, False, "depend::space_pkg",
-                    expected_result)
+        # Check that a package that was publisher but not index is
+        # reported.
+        fmris = indexer.Indexer.check_for_updates(
+            back_dir, self._get_repo_catalog()
+        )
+        self.assertEqual(len(fmris), 1)
+
+    def test_bug_17672(self):
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(
+            durl, (self.another_pkg10, self.space_pkg10, self.require_any_manf)
+        )
+        repo = self.dc.get_repo()
+        repo.rebuild(build_catalog=False, build_index=True)
+        api_obj = self.image_create(durl)
+        expected_result = set(
+            [
+                (
+                    "pkg:/ra@1.0-0",
+                    "require-any",
+                    "depend fmri=another_pkg@1.0,5.11-0 "
+                    + "fmri=pkg:/space_pkg@1.0,5.11-0 type=require-any",
+                )
+            ]
+        )
+        self._search_op(api_obj, True, "depend::", expected_result)
+        self._api_install(api_obj, ["ra"])
+        self._search_op(api_obj, False, "depend::", expected_result)
+        api_obj.rebuild_search_index()
+        self._search_op(api_obj, False, "depend::", expected_result)
+        self._search_op(api_obj, False, "depend::another_pkg", expected_result)
+        self._search_op(api_obj, False, "depend::space_pkg", expected_result)
 
 
 class TestApiSearchMulti(pkg5unittest.ManyDepotTestCase):
-
-        example_pkg10 = """
+    example_pkg10 = """
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
             close """
 
-        res_alternate_server_local = set([
-            ('pkg:/example_pkg@1.0-0', 'test2/example_pkg',
-            'set name=pkg.fmri value=pkg://test2/example_pkg@1.0,5.11-0:')
-        ])
+    res_alternate_server_local = set(
+        [
+            (
+                "pkg:/example_pkg@1.0-0",
+                "test2/example_pkg",
+                "set name=pkg.fmri value=pkg://test2/example_pkg@1.0,5.11-0:",
+            )
+        ]
+    )
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test3"], debug_features=["headers"], start_depots=True)
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self,
+            ["test1", "test2", "test3"],
+            debug_features=["headers"],
+            start_depots=True,
+        )
 
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.durl3 = self.dcs[3].get_depot_url()
-                self.pkgsend_bulk(self.durl2, self.example_pkg10,
-                    refresh_index=True)
-                self.wait_repo(self.dcs[2].get_repodir())
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.durl3 = self.dcs[3].get_depot_url()
+        self.pkgsend_bulk(self.durl2, self.example_pkg10, refresh_index=True)
+        self.wait_repo(self.dcs[2].get_repodir())
 
-                self.image_create(self.durl1, prefix="test1")
-                self.pkg("set-publisher -O " + self.durl2 + " test2")
+        self.image_create(self.durl1, prefix="test1")
+        self.pkg("set-publisher -O " + self.durl2 + " test2")
 
-        def _check(self, proposed_answer, correct_answer):
-                if correct_answer == proposed_answer:
-                        return True
-                else:
-                        self.debug("Proposed Answer: " + str(proposed_answer))
-                        self.debug("Correct Answer : " + str(correct_answer))
-                        if isinstance(correct_answer, set) and \
-                            isinstance(proposed_answer, set):
-                                self.debug("Missing: " +
-                                    str(correct_answer - proposed_answer))
-                                self.debug("Extra  : " +
-                                    str(proposed_answer - correct_answer))
-                        self.assertEqual(correct_answer, proposed_answer)
+    def _check(self, proposed_answer, correct_answer):
+        if correct_answer == proposed_answer:
+            return True
+        else:
+            self.debug("Proposed Answer: " + str(proposed_answer))
+            self.debug("Correct Answer : " + str(correct_answer))
+            if isinstance(correct_answer, set) and isinstance(
+                proposed_answer, set
+            ):
+                self.debug("Missing: " + str(correct_answer - proposed_answer))
+                self.debug("Extra  : " + str(proposed_answer - correct_answer))
+            self.assertEqual(correct_answer, proposed_answer)
 
-        @staticmethod
-        def _extract_action_from_res(it, err):
-                res = []
-                if err:
-                        try:
-                                for query_num, auth, (version, return_type,
-                                    (pkg_name, piece, act)) in it:
-                                        res.append((fmri.PkgFmri(str(
-                                            pkg_name)).get_short_fmri(), piece,
-                                            TestApiSearchBasics._replace_act(
-                                            act)),)
-                        except err as e:
-                                return res
-                        else:
-                                raise RuntimeError(
-                                    "Didn't get expected error:{0}".format(err))
-                else:
-                        return TestApiSearchBasics._extract_action_from_res(it)
+    @staticmethod
+    def _extract_action_from_res(it, err):
+        res = []
+        if err:
+            try:
+                for (
+                    query_num,
+                    auth,
+                    (version, return_type, (pkg_name, piece, act)),
+                ) in it:
+                    res.append(
+                        (
+                            fmri.PkgFmri(str(pkg_name)).get_short_fmri(),
+                            piece,
+                            TestApiSearchBasics._replace_act(act),
+                        ),
+                    )
+            except err as e:
+                return res
+            else:
+                raise RuntimeError("Didn't get expected error:{0}".format(err))
+        else:
+            return TestApiSearchBasics._extract_action_from_res(it)
 
+    def _search_op(
+        self,
+        api_obj,
+        remote,
+        token,
+        test_value,
+        case_sensitive=False,
+        return_actions=True,
+        num_to_return=None,
+        start_point=None,
+        servers=None,
+        expected_err=None,
+    ):
+        search_func = api_obj.local_search
+        query = api.Query(
+            token, case_sensitive, return_actions, num_to_return, start_point
+        )
+        if remote:
+            search_func = api_obj.remote_search
+            res = set(
+                self._extract_action_from_res(
+                    search_func([query], servers=servers), expected_err
+                )
+            )
+        else:
+            res = set(
+                TestApiSearchBasics._extract_action_from_res(
+                    search_func([query])
+                )
+            )
+        self._check(set(res), test_value)
 
-        def _search_op(self, api_obj, remote, token, test_value,
-            case_sensitive=False, return_actions=True, num_to_return=None,
-            start_point=None, servers=None, expected_err=None):
-                search_func = api_obj.local_search
-                query = api.Query(token, case_sensitive, return_actions,
-                    num_to_return, start_point)
-                if remote:
-                        search_func = api_obj.remote_search
-                        res = set(self._extract_action_from_res(
-                            search_func([query], servers=servers),
-                            expected_err))
-                else:
-                        res = set(TestApiSearchBasics._extract_action_from_res(
-                            search_func([query])))
-                self._check(set(res), test_value)
+    def test_bug_2955(self):
+        """See http://defect.opensolaris.org/bz/show_bug.cgi?id=2955"""
 
-        def test_bug_2955(self):
-                """See http://defect.opensolaris.org/bz/show_bug.cgi?id=2955"""
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
 
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
+        # Test for bug 10690 by checking whether the fmri names
+        # for packages installed from the non-preferred publisher
+        # are parsed correctly. Specifically, test whether the name
+        # alone is searchable, as well as the publisher/name
+        # combination.
+        self._search_op(
+            api_obj,
+            False,
+            "set::test2/example_pkg",
+            self.res_alternate_server_local,
+        )
+        self._search_op(
+            api_obj, False, "set::example_pkg", self.res_alternate_server_local
+        )
+        self._search_op(
+            api_obj, False, "set::test2/*", self.res_alternate_server_local
+        )
+        api_obj.rebuild_search_index()
+        self._search_op(
+            api_obj,
+            False,
+            "set::test2/example_pkg",
+            self.res_alternate_server_local,
+        )
+        self._search_op(
+            api_obj, False, "set::example_pkg", self.res_alternate_server_local
+        )
+        self._search_op(
+            api_obj, False, "set::test2/*", self.res_alternate_server_local
+        )
+        self._api_uninstall(api_obj, ["example_pkg"])
 
-                # Test for bug 10690 by checking whether the fmri names
-                # for packages installed from the non-preferred publisher
-                # are parsed correctly. Specifically, test whether the name
-                # alone is searchable, as well as the publisher/name
-                # combination.
-                self._search_op(api_obj, False, "set::test2/example_pkg",
-                    self.res_alternate_server_local)
-                self._search_op(api_obj, False, "set::example_pkg",
-                    self.res_alternate_server_local)
-                self._search_op(api_obj, False, "set::test2/*",
-                    self.res_alternate_server_local)
-                api_obj.rebuild_search_index()
-                self._search_op(api_obj, False, "set::test2/example_pkg",
-                    self.res_alternate_server_local)
-                self._search_op(api_obj, False, "set::example_pkg",
-                    self.res_alternate_server_local)
-                self._search_op(api_obj, False, "set::test2/*",
-                    self.res_alternate_server_local)
-                self._api_uninstall(api_obj, ["example_pkg"])
+    def test_bug_8318(self):
+        api_obj = self.get_img_api_obj()
+        self._search_op(api_obj, True, "this_should_not_match_any_token", set())
+        self._search_op(
+            api_obj,
+            True,
+            "example_path",
+            set(),
+            servers=[{"origin": self.durl1}],
+        )
+        self._search_op(
+            api_obj,
+            True,
+            "example_path",
+            set(),
+            servers=[{"origin": self.durl3}],
+        )
+        num_expected = {1: 6, 2: 8, 3: 0}
+        for d in range(1, (len(self.dcs) + 1)):
+            try:
+                pub = api_obj.img.get_publisher(
+                    origin=self.dcs[d].get_depot_url()
+                )
+                c_uuid = pub.client_uuid
+            except api_errors.UnknownPublisher:
+                c_uuid = None
+            lfh = open(self.dcs[d].get_logpath(), "r")
+            found = 0
+            for line in lfh:
+                if "X-IPKG-UUID:" in line:
+                    tmp = line.split()
+                    s_uuid = tmp[1]
+                    if s_uuid != c_uuid:
+                        raise RuntimeError(
+                            "Found uuid:{0} doesn't "
+                            "match expected uuid:{1}, "
+                            "d:{2}, durl:{3}".format(
+                                s_uuid, c_uuid, d, self.dcs[d].get_depot_url()
+                            )
+                        )
+                    found += 1
+            lfh.close()
+            # With python 3, entries can take a short while to
+            # appear in the log file. This test intermittently
+            # fails as a result. Just check for at least one
+            # UUID in the log.
+            if six.PY3 and num_expected[d] > 0 and found > 0:
+                pass
+            elif found != num_expected[d]:
+                raise RuntimeError(
+                    "d:{0}, found {1} instances of"
+                    " a client uuid, expected to find {2}.".format(
+                        d, found, num_expected[d]
+                    )
+                )
 
-        def test_bug_8318(self):
-
-                api_obj = self.get_img_api_obj()
-                self._search_op(api_obj, True,
-                    "this_should_not_match_any_token", set())
-                self._search_op(api_obj, True, "example_path",
-                    set(), servers=[{"origin": self.durl1}])
-                self._search_op(api_obj, True, "example_path",
-                    set(), servers=[{"origin": self.durl3}])
-                num_expected = { 1: 6, 2: 8, 3: 0 }
-                for d in range(1,(len(self.dcs) + 1)):
-                        try:
-                                pub = api_obj.img.get_publisher(
-                                    origin=self.dcs[d].get_depot_url())
-                                c_uuid = pub.client_uuid
-                        except api_errors.UnknownPublisher:
-                                c_uuid = None
-                        lfh = open(self.dcs[d].get_logpath(), "r")
-                        found = 0
-                        for line in lfh:
-                                if "X-IPKG-UUID:" in line:
-                                        tmp = line.split()
-                                        s_uuid = tmp[1]
-                                        if s_uuid != c_uuid:
-                                                raise RuntimeError(
-                                                    "Found uuid:{0} doesn't "
-                                                    "match expected uuid:{1}, "
-                                                    "d:{2}, durl:{3}".format(
-                                                    s_uuid, c_uuid, d,
-                                                    self.dcs[d].get_depot_url()))
-                                        found += 1
-                        lfh.close()
-                        # With python 3, entries can take a short while to
-                        # appear in the log file. This test intermittently
-                        # fails as a result. Just check for at least one
-                        # UUID in the log.
-                        if six.PY3 and num_expected[d] > 0 and found > 0:
-                                pass
-                        elif found != num_expected[d]:
-                                raise RuntimeError("d:{0}, found {1} instances of"
-                                    " a client uuid, expected to find {2}.".format(
-                                    d, found, num_expected[d]))
-
-        def test_bug_12739(self):
-
-                api_obj = self.get_img_api_obj()
-                self._search_op(api_obj, True, "example_dir",
-                    set([("pkg:/example_pkg@1.0-0", "basename",
+    def test_bug_12739(self):
+        api_obj = self.get_img_api_obj()
+        self._search_op(
+            api_obj,
+            True,
+            "example_dir",
+            set(
+                [
+                    (
+                        "pkg:/example_pkg@1.0-0",
+                        "basename",
                         "dir group=bin mode=0755 owner=root "
-                        "path=bin/example_dir")]))
-                self.dcs[1].stop()
-                self._search_op(api_obj, True, "example_dir",
-                    set([("pkg:/example_pkg@1.0-0", "basename",
+                        "path=bin/example_dir",
+                    )
+                ]
+            ),
+        )
+        self.dcs[1].stop()
+        self._search_op(
+            api_obj,
+            True,
+            "example_dir",
+            set(
+                [
+                    (
+                        "pkg:/example_pkg@1.0-0",
+                        "basename",
                         "dir group=bin mode=0755 owner=root "
-                        "path=bin/example_dir")]),
-                        expected_err=api_errors.ProblematicSearchServers)
-                self.pkg("search example_dir", exit=3)
+                        "path=bin/example_dir",
+                    )
+                ]
+            ),
+            expected_err=api_errors.ProblematicSearchServers,
+        )
+        self.pkg("search example_dir", exit=3)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_async_rpc.py
+++ b/src/tests/api/t_async_rpc.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import multiprocessing
@@ -45,217 +46,231 @@ import pkg.pipeutils
 from pkg.client.debugvalues import DebugValues
 from pkg.misc import AsyncCall, AsyncCallException
 
+
 class TestAsyncRPC(pkg5unittest.Pkg5TestCase):
+    @staticmethod
+    def __nop():
+        pass
 
-        @staticmethod
-        def __nop():
-                pass
+    @staticmethod
+    def __add(x, y):
+        return x + y
 
-        @staticmethod
-        def __add(x, y):
-                return x + y
+    @staticmethod
+    def __raise_ex():
+        raise Exception("raise_ex()")
 
-        @staticmethod
-        def __raise_ex():
-                raise Exception("raise_ex()")
+    @staticmethod
+    def __sleep(n):
+        time.sleep(n)
 
-        @staticmethod
-        def __sleep(n):
-                time.sleep(n)
+    def test_async_basics(self):
+        # test a simple async call with no parameters
+        ac = AsyncCall()
+        ac.start(self.__nop)
+        ac.result()
 
-        def test_async_basics(self):
-                # test a simple async call with no parameters
-                ac = AsyncCall()
-                ac.start(self.__nop)
-                ac.result()
+        # test a simple async call with positional parameters
+        ac = AsyncCall()
+        ac.start(self.__add, 1, 2)
+        rv = ac.result()
+        self.assertEqual(rv, 3)
 
-                # test a simple async call with positional parameters
-                ac = AsyncCall()
-                ac.start(self.__add, 1, 2)
-                rv = ac.result()
-                self.assertEqual(rv, 3)
+        # test a simple async call with keyword parameters
+        ac = AsyncCall()
+        ac.start(self.__add, x=1, y=2)
+        rv = ac.result()
+        self.assertEqual(rv, 3)
 
-                # test a simple async call with keyword parameters
-                ac = AsyncCall()
-                ac.start(self.__add, x=1, y=2)
-                rv = ac.result()
-                self.assertEqual(rv, 3)
+        # test async call with invalid arguments
+        ac = AsyncCall()
+        ac.start(self.__add, 1, 2, 3)
+        if six.PY2:
+            self.assertRaisesRegexp(
+                AsyncCallException, "takes exactly 2 arguments", ac.result
+            )
+        else:
+            self.assertRaisesRegexp(
+                AsyncCallException, "takes 2 positional arguments", ac.result
+            )
+        ac = AsyncCall()
+        ac.start(self.__add, x=1, y=2, z=3)
+        self.assertRaisesRegexp(
+            AsyncCallException, "got an unexpected keyword argument", ac.result
+        )
+        ac = AsyncCall()
+        ac.start(self.__add, y=2, z=3)
+        self.assertRaisesRegexp(
+            AsyncCallException, "got an unexpected keyword argument", ac.result
+        )
 
-                # test async call with invalid arguments
-                ac = AsyncCall()
-                ac.start(self.__add, 1, 2, 3)
-                if six.PY2:
-                        self.assertRaisesRegexp(AsyncCallException,
-                            "takes exactly 2 arguments",
-                            ac.result)
-                else:
-                        self.assertRaisesRegexp(AsyncCallException,
-                            "takes 2 positional arguments",
-                            ac.result)
-                ac = AsyncCall()
-                ac.start(self.__add, x=1, y=2, z=3)
-                self.assertRaisesRegexp(AsyncCallException,
-                    "got an unexpected keyword argument",
-                    ac.result)
-                ac = AsyncCall()
-                ac.start(self.__add, y=2, z=3)
-                self.assertRaisesRegexp(AsyncCallException,
-                    "got an unexpected keyword argument",
-                    ac.result)
+    def test_async_thread_errors(self):
+        # test exceptions raised in the AsyncCall class
+        DebugValues["async_thread_error"] = 1
+        ac = AsyncCall()
+        ac.start(self.__nop)
+        self.assertRaisesRegexp(
+            AsyncCallException, "async_thread_error", ac.result
+        )
 
-        def test_async_thread_errors(self):
-                # test exceptions raised in the AsyncCall class
-                DebugValues["async_thread_error"] = 1
-                ac = AsyncCall()
-                ac.start(self.__nop)
-                self.assertRaisesRegexp(AsyncCallException,
-                    "async_thread_error",
-                    ac.result)
+    def __server(self, client_pipefd, server_pipefd, http_enc=True):
+        """Setup RPC Server."""
 
-        def __server(self, client_pipefd, server_pipefd, http_enc=True):
-                """Setup RPC Server."""
+        os.close(client_pipefd)
+        server = pkg.pipeutils.PipedRPCServer(server_pipefd, http_enc=http_enc)
+        server.register_introspection_functions()
+        server.register_function(self.__nop, "nop")
+        server.register_function(self.__add, "add")
+        server.register_function(self.__raise_ex, "raise_ex")
+        server.register_function(self.__sleep, "sleep")
+        server.serve_forever()
 
-                os.close(client_pipefd)
-                server = pkg.pipeutils.PipedRPCServer(server_pipefd,
-                    http_enc=http_enc)
-                server.register_introspection_functions()
-                server.register_function(self.__nop, "nop")
-                server.register_function(self.__add, "add")
-                server.register_function(self.__raise_ex, "raise_ex")
-                server.register_function(self.__sleep, "sleep")
-                server.serve_forever()
+    def __server_setup(self, http_enc=True, use_proc=True):
+        """Setup an rpc server."""
 
-        def __server_setup(self, http_enc=True, use_proc=True):
-                """Setup an rpc server."""
+        # create a pipe to communicate between the client and server
+        client_pipefd, server_pipefd = os.pipe()
 
-                # create a pipe to communicate between the client and server
-                client_pipefd, server_pipefd = os.pipe()
+        # check if the server should be a process or thread
+        alloc_server = multiprocessing.Process
+        if not use_proc:
+            threading.Thread
 
-                # check if the server should be a process or thread
-                alloc_server = multiprocessing.Process
-                if not use_proc:
-                        threading.Thread
+        # fork off and start server process/thread
+        server_proc = alloc_server(
+            target=self.__server,
+            args=(client_pipefd, server_pipefd),
+            kwargs={"http_enc": http_enc},
+        )
+        server_proc.daemon = True
+        server_proc.start()
+        os.close(server_pipefd)
 
-                # fork off and start server process/thread
-                server_proc = alloc_server(
-                    target=self.__server,
-                    args=(client_pipefd, server_pipefd),
-                    kwargs={ "http_enc": http_enc })
-                server_proc.daemon = True
-                server_proc.start()
-                os.close(server_pipefd)
+        # Setup ourselves as the client
+        client_rpc = pkg.pipeutils.PipedServerProxy(
+            client_pipefd, http_enc=http_enc
+        )
 
-                # Setup ourselves as the client
-                client_rpc = pkg.pipeutils.PipedServerProxy(client_pipefd,
-                    http_enc=http_enc)
+        return (server_proc, client_rpc)
 
-                return (server_proc, client_rpc)
+    def __server_setup_and_call(
+        self, method, http_enc=True, use_proc=True, **kwargs
+    ):
+        """Setup an rpc server and make a call to it.
+        All calls are made asynchronously."""
 
-        def __server_setup_and_call(self, method, http_enc=True,
-            use_proc=True, **kwargs):
-                """Setup an rpc server and make a call to it.
-                All calls are made asynchronously."""
+        server_proc, client_rpc = self.__server_setup(
+            http_enc=http_enc, use_proc=use_proc
+        )
+        method_cb = getattr(client_rpc, method)
+        ac = AsyncCall()
+        ac.start(method_cb, **kwargs)
 
-                server_proc, client_rpc = self.__server_setup(
-                    http_enc=http_enc, use_proc=use_proc)
-                method_cb = getattr(client_rpc, method)
-                ac = AsyncCall()
-                ac.start(method_cb, **kwargs)
+        # Destroying all references to the client object should close
+        # the client end of our pipe to the server, which in turn
+        # should cause the server to cleanly exit.  If we hang waiting
+        # for the server to exist then that's a bug.
+        del method_cb, client_rpc
 
-                # Destroying all references to the client object should close
-                # the client end of our pipe to the server, which in turn
-                # should cause the server to cleanly exit.  If we hang waiting
-                # for the server to exist then that's a bug.
-                del method_cb, client_rpc
+        try:
+            rv = ac.result()
+        except AsyncCallException as ex:
+            # we explicity delete the client rpc object to try and
+            # ensure that any connection to the server process
+            # gets closed (so that the server process exits).
+            server_proc.join()
+            raise
 
-                try:
-                        rv = ac.result()
-                except AsyncCallException as ex:
-                        # we explicity delete the client rpc object to try and
-                        # ensure that any connection to the server process
-                        # gets closed (so that the server process exits).
-                        server_proc.join()
-                        raise
+        server_proc.join()
+        return rv
 
-                server_proc.join()
-                return rv
+    def __test_rpc_basics(self, http_enc=True, use_proc=True):
+        # our rpc server only support keyword parameters
 
-        def __test_rpc_basics(self, http_enc=True, use_proc=True):
+        # test rpc call with no arguments
+        rv = self.__server_setup_and_call(
+            "nop", http_enc=http_enc, use_proc=use_proc
+        )
+        self.assertEqual(rv, None)
 
-                # our rpc server only support keyword parameters
+        # test rpc call with two arguments
+        rv = self.__server_setup_and_call(
+            "add", x=1, y=2, http_enc=http_enc, use_proc=use_proc
+        )
+        self.assertEqual(rv, 3)
 
-                # test rpc call with no arguments
-                rv = self.__server_setup_and_call("nop",
-                    http_enc=http_enc, use_proc=use_proc)
-                self.assertEqual(rv, None)
+        # test rpc call with an invalid number of arguments
+        self.assertRaisesRegexp(
+            AsyncCallException,
+            "Invalid parameters.",
+            self.__server_setup_and_call,
+            "add",
+            x=1,
+            y=2,
+            z=3,
+            http_enc=http_enc,
+            use_proc=use_proc,
+        )
 
-                # test rpc call with two arguments
-                rv = self.__server_setup_and_call("add", x=1, y=2,
-                    http_enc=http_enc, use_proc=use_proc)
-                self.assertEqual(rv, 3)
+        # test rpc call of a non-existant method
+        self.assertRaisesRegexp(
+            AsyncCallException,
+            "Method foo not supported.",
+            self.__server_setup_and_call,
+            "foo",
+            http_enc=http_enc,
+            use_proc=use_proc,
+        )
 
-                # test rpc call with an invalid number of arguments
-                self.assertRaisesRegexp(AsyncCallException,
-                    "Invalid parameters.",
-                    self.__server_setup_and_call,
-                    "add", x=1, y=2, z=3,
-                    http_enc=http_enc, use_proc=use_proc)
+        # test rpc call of a server function that raises an exception
+        self.assertRaisesRegexp(
+            AsyncCallException,
+            "Server error: .* Exception: raise_ex()",
+            self.__server_setup_and_call,
+            "raise_ex",
+            http_enc=http_enc,
+            use_proc=use_proc,
+        )
 
-                # test rpc call of a non-existant method
-                self.assertRaisesRegexp(AsyncCallException,
-                    "Method foo not supported.",
-                    self.__server_setup_and_call,
-                    "foo",
-                    http_enc=http_enc, use_proc=use_proc)
+    def __test_rpc_interruptions(self, http_enc):
+        # sanity check rpc sleep call
+        rv = self.__server_setup_and_call("sleep", n=0, http_enc=http_enc)
 
-                # test rpc call of a server function that raises an exception
-                self.assertRaisesRegexp(AsyncCallException,
-                    "Server error: .* Exception: raise_ex()",
-                    self.__server_setup_and_call,
-                    "raise_ex",
-                    http_enc=http_enc, use_proc=use_proc)
+        # test interrupted rpc calls by killing the server
+        for i in range(10):
+            server_proc, client_rpc = self.__server_setup(http_enc=http_enc)
+            ac = AsyncCall()
 
-        def __test_rpc_interruptions(self, http_enc):
+            method = getattr(client_rpc, "sleep")
+            ac.start(method, n=10000)
+            del method, client_rpc
 
-                # sanity check rpc sleep call
-                rv = self.__server_setup_and_call("sleep", n=0,
-                    http_enc=http_enc)
+            # add optional one second delay so that we can try
+            # kill before and after the call has been started.
+            time.sleep(random.randint(0, 1))
 
-                # test interrupted rpc calls by killing the server
-                for i in range(10):
-                        server_proc, client_rpc = self.__server_setup(
-                            http_enc=http_enc)
-                        ac = AsyncCall()
+            # vary how we kill the target
+            if random.randint(0, 1) == 1:
+                server_proc.terminate()
+            else:
+                os.kill(server_proc.pid, signal.SIGKILL)
 
-                        method = getattr(client_rpc, "sleep")
-                        ac.start(method, n=10000)
-                        del method, client_rpc
+            self.assertRaises(AsyncCallException, ac.result)
+            server_proc.join()
 
-                        # add optional one second delay so that we can try
-                        # kill before and after the call has been started.
-                        time.sleep(random.randint(0, 1))
+    def test_rpc_basics(self):
+        # tests rpc calls to another process
+        self.__test_rpc_basics()
+        self.__test_rpc_basics(http_enc=False)
 
-                        # vary how we kill the target
-                        if random.randint(0, 1) == 1:
-                                server_proc.terminate()
-                        else:
-                                os.kill(server_proc.pid, signal.SIGKILL)
+        # tests rpc calls to another thread
+        self.__test_rpc_basics(use_proc=False)
+        self.__test_rpc_basics(http_enc=False, use_proc=False)
 
-                        self.assertRaises(AsyncCallException, ac.result)
-                        server_proc.join()
+    def test_rpc_interruptions(self):
+        self.__test_rpc_interruptions(http_enc=True)
+        self.__test_rpc_interruptions(http_enc=False)
 
-        def test_rpc_basics(self):
-                # tests rpc calls to another process
-                self.__test_rpc_basics()
-                self.__test_rpc_basics(http_enc=False)
-
-                # tests rpc calls to another thread
-                self.__test_rpc_basics(use_proc=False)
-                self.__test_rpc_basics(http_enc=False, use_proc=False)
-
-        def test_rpc_interruptions(self):
-                self.__test_rpc_interruptions(http_enc=True)
-                self.__test_rpc_interruptions(http_enc=False)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_bootenv.py
+++ b/src/tests/api/t_bootenv.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -32,64 +33,68 @@ import os
 import sys
 import pkg.client.bootenv as bootenv
 
+
 class TestBootEnv(pkg5unittest.Pkg5TestCase):
+    def test_api_consistency(self):
+        """Make sure every public method in BootEnv exists in
+        BootEnvNull and the other way around.
+        """
 
-        def test_api_consistency(self):
-                """Make sure every public method in BootEnv exists in
-                BootEnvNull and the other way around.
-                """
+        nullm = set(
+            d for d in dir(bootenv.BootEnvNull) if not d.startswith("_")
+        )
+        bem = set(d for d in dir(bootenv.BootEnv) if not d.startswith("_"))
 
-                nullm = set(d for d in dir(bootenv.BootEnvNull)
-                    if not d.startswith("_"))
-                bem = set(d for d in dir(bootenv.BootEnv)
-                    if not d.startswith("_"))
+        be_missing = nullm - bem
+        null_missing = bem - nullm
 
-                be_missing = nullm - bem
-                null_missing = bem - nullm
+        estr = ""
+        if be_missing:
+            estr += (
+                "The following methods were missing from "
+                "BootEnv:\n" + "\n".join("\t{0}".format(s) for s in be_missing)
+            )
+        if null_missing:
+            estr += (
+                "The following methods were missing from "
+                "BootEnvNull:\n"
+                + "\n".join("\t{0}".format(s) for s in null_missing)
+            )
+        self.assertTrue(not estr, estr)
 
-                estr = ""
-                if be_missing:
-                        estr += "The following methods were missing from " \
-                            "BootEnv:\n" + \
-                            "\n".join("\t{0}".format(s) for s in be_missing)
-                if null_missing:
-                        estr += "The following methods were missing from " \
-                            "BootEnvNull:\n" + \
-                            "\n".join("\t{0}".format(s) for s in null_missing)
-                self.assertTrue(not estr, estr)
+    def test_bootenv(self):
+        """All other test suite tests test the BootEnv class with,
+        PKG_NO_LIVE_ROOT set in the environment, see the run() and
+        env_santize(..) methods in Pkg5TestSuite.  That environment
+        variable means that BootEnv.get_be_list will always return an
+        empty list.  While we want to generally avoid touching the live
+        image root at all, making an exception here seems the best
+        reasonable way to test some of the non-modifying BootEnv code.
+        To that end, this test clears the relevant environment variable.
+        """
 
-        def test_bootenv(self):
-                """All other test suite tests test the BootEnv class with,
-                PKG_NO_LIVE_ROOT set in the environment, see the run() and
-                env_santize(..) methods in Pkg5TestSuite.  That environment
-                variable means that BootEnv.get_be_list will always return an
-                empty list.  While we want to generally avoid touching the live
-                image root at all, making an exception here seems the best
-                reasonable way to test some of the non-modifying BootEnv code.
-                To that end, this test clears the relevant environment variable.
-                """
+        del os.environ["PKG_NO_LIVE_ROOT"]
+        self.assertTrue(bootenv.BootEnv.libbe_exists())
+        self.assertTrue(bootenv.BootEnv.check_verify())
+        self.assertTrue(
+            isinstance(bootenv.BootEnv.get_be_list(raise_error=False), list)
+        )
+        self.assertTrue(
+            isinstance(bootenv.BootEnv.get_be_list(raise_error=True), list)
+        )
 
-                del os.environ["PKG_NO_LIVE_ROOT"]
-                self.assertTrue(bootenv.BootEnv.libbe_exists())
-                self.assertTrue(bootenv.BootEnv.check_verify())
-                self.assertTrue(isinstance(
-                    bootenv.BootEnv.get_be_list(raise_error=False), list))
-                self.assertTrue(isinstance(
-                    bootenv.BootEnv.get_be_list(raise_error=True), list))
-
-                bootenv.BootEnv.get_be_name("/")
-                self.assertTrue(
-                    isinstance(bootenv.BootEnv.get_uuid_be_dic(), dict))
-                bootenv.BootEnv.get_activated_be_name()
-                bootenv.BootEnv.get_activated_be_name(bootnext=True)
-                bootenv.BootEnv.get_active_be_name()
-                # This assumes that a1b2c3d4e5f6g7h8i9j0 is highly unlikely to
-                # be an existing BE on the system.
-                bootenv.BootEnv.check_be_name("a1b2c3d4e5f6g7h8i9j0")
+        bootenv.BootEnv.get_be_name("/")
+        self.assertTrue(isinstance(bootenv.BootEnv.get_uuid_be_dic(), dict))
+        bootenv.BootEnv.get_activated_be_name()
+        bootenv.BootEnv.get_activated_be_name(bootnext=True)
+        bootenv.BootEnv.get_active_be_name()
+        # This assumes that a1b2c3d4e5f6g7h8i9j0 is highly unlikely to
+        # be an existing BE on the system.
+        bootenv.BootEnv.check_be_name("a1b2c3d4e5f6g7h8i9j0")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_catalog.py
+++ b/src/tests/api/t_catalog.py
@@ -26,8 +26,9 @@
 
 from __future__ import print_function
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -50,1295 +51,1376 @@ import pkg.variant as variant
 
 
 class TestCatalog(pkg5unittest.Pkg5TestCase):
-        """Tests for all catalog functionality."""
-        maxDiff = None
+    """Tests for all catalog functionality."""
 
-        def setUp(self):
-                pkg5unittest.Pkg5TestCase.setUp(self)
+    maxDiff = None
 
-                self.paths = [self.test_root]
-                self.c = catalog.Catalog(log_updates=True)
-                self.nversions = 0
+    def setUp(self):
+        pkg5unittest.Pkg5TestCase.setUp(self)
 
-                stems = {}
-                for f in [
-                    fmri.PkgFmri("pkg:/test@1.0,5.11-1:20000101T120000Z"),
-                    fmri.PkgFmri("pkg:/test@1.0,5.11-1:20000101T120010Z"),
-                    fmri.PkgFmri("pkg:/test@1.0,5.11-1.1:20000101T120020Z"),
-                    fmri.PkgFmri("pkg:/test@1.0,5.11-1.2:20000101T120030Z"),
-                    fmri.PkgFmri("pkg:/test@1.0,5.11-2:20000101T120040Z"),
-                    fmri.PkgFmri("pkg:/test@1.1,5.11-1:20000101T120040Z"),
-                    fmri.PkgFmri("pkg:/test@3.2.1,5.11-1:20000101T120050Z"),
-                    fmri.PkgFmri("pkg:/test@3.2.1,5.11-1.2:20000101T120051Z"),
-                    fmri.PkgFmri("pkg:/test@3.2.1,5.11-1.2.3:20000101T120052Z"),
-                    fmri.PkgFmri("pkg:/apkg@1.0,5.11-1:20000101T120040Z"),
-                    fmri.PkgFmri("pkg:/zpkg@1.0,5.11-1:20000101T120040Z"),
-                    fmri.PkgFmri("pkg:/zpkg@1.0,5.11-1:20000101T120014Z")
-                ]:
-                        if f.pkg_name == "apkg":
-                                f.set_publisher("extra")
-                        elif f.pkg_name == "zpkg":
-                                f.set_publisher("contrib.opensolaris.org")
-                        else:
-                                f.set_publisher("opensolaris.org")
-                        self.c.add_package(f)
-                        self.nversions += 1
-                        stems[f.get_pkg_stem()] = None
+        self.paths = [self.test_root]
+        self.c = catalog.Catalog(log_updates=True)
+        self.nversions = 0
 
-                # And for good measure, ensure that one of the publishers has
-                # a package with the exact same name and version as another
-                # publisher's package.
-                f = fmri.PkgFmri("pkg://extra/zpkg@1.0,5.11-1:20000101T120040Z")
-                stems[f.get_pkg_stem()] = None
-                self.c.add_package(f)
-                self.nversions += 1
+        stems = {}
+        for f in [
+            fmri.PkgFmri("pkg:/test@1.0,5.11-1:20000101T120000Z"),
+            fmri.PkgFmri("pkg:/test@1.0,5.11-1:20000101T120010Z"),
+            fmri.PkgFmri("pkg:/test@1.0,5.11-1.1:20000101T120020Z"),
+            fmri.PkgFmri("pkg:/test@1.0,5.11-1.2:20000101T120030Z"),
+            fmri.PkgFmri("pkg:/test@1.0,5.11-2:20000101T120040Z"),
+            fmri.PkgFmri("pkg:/test@1.1,5.11-1:20000101T120040Z"),
+            fmri.PkgFmri("pkg:/test@3.2.1,5.11-1:20000101T120050Z"),
+            fmri.PkgFmri("pkg:/test@3.2.1,5.11-1.2:20000101T120051Z"),
+            fmri.PkgFmri("pkg:/test@3.2.1,5.11-1.2.3:20000101T120052Z"),
+            fmri.PkgFmri("pkg:/apkg@1.0,5.11-1:20000101T120040Z"),
+            fmri.PkgFmri("pkg:/zpkg@1.0,5.11-1:20000101T120040Z"),
+            fmri.PkgFmri("pkg:/zpkg@1.0,5.11-1:20000101T120014Z"),
+        ]:
+            if f.pkg_name == "apkg":
+                f.set_publisher("extra")
+            elif f.pkg_name == "zpkg":
+                f.set_publisher("contrib.opensolaris.org")
+            else:
+                f.set_publisher("opensolaris.org")
+            self.c.add_package(f)
+            self.nversions += 1
+            stems[f.get_pkg_stem()] = None
 
-                self.npkgs = len(stems)
+        # And for good measure, ensure that one of the publishers has
+        # a package with the exact same name and version as another
+        # publisher's package.
+        f = fmri.PkgFmri("pkg://extra/zpkg@1.0,5.11-1:20000101T120040Z")
+        stems[f.get_pkg_stem()] = None
+        self.c.add_package(f)
+        self.nversions += 1
 
-        def create_test_dir(self, name):
-                """Creates a temporary directory with the specified name for
-                test usage and returns its absolute path."""
+        self.npkgs = len(stems)
 
-                target = os.path.join(self.test_root, name)
-                try:
-                        os.makedirs(target, misc.PKG_DIR_MODE)
-                except OSError as e:
-                        if e.errno != errno.EEXIST:
-                                raise e
-                return os.path.abspath(target)
+    def create_test_dir(self, name):
+        """Creates a temporary directory with the specified name for
+        test usage and returns its absolute path."""
 
-        def __gen_manifest(self, f):
+        target = os.path.join(self.test_root, name)
+        try:
+            os.makedirs(target, misc.PKG_DIR_MODE)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise e
+        return os.path.abspath(target)
+
+    def __gen_manifest(self, f):
+        m = manifest.Manifest()
+        lines = misc.force_text(
+            "depend fmri=foo@1.0 type=require\n"
+            "set name=facet.devel value=true\n"
+            "set name=info.classification "
+            """value="Desktop (GNOME)/Application" """
+            """value="org.opensolaris.category.2009:GNOME (Desktop)"\n"""
+            "set name=info.classification "
+            """value="Sparc Application" variant.arch=sparc\n"""
+            "set name=info.classification "
+            """value="i386 Application" variant.arch=i386\n"""
+            "set name=variant.arch value=i386 value=sparc\n"
+            'set name=pkg.fmri value="{0}"\n'
+            'set name=pkg.summary value="Summary {1}"\n'
+            'set name=pkg.summary value="Sparc Summary {2}"'
+            " variant.arch=sparc\n"
+            'set name=pkg.summary:th value="ซอฟต์แวร์ {3}"\n'
+            'set name=pkg.description value="Desc {4}"\n'
+        ).format(f, f, f, f, f)
+
+        if f.pkg_name == "zpkg":
+            lines += "set name=pkg.depend.install-hold value=test\n"
+            lines += "set name=pkg.renamed value=true\n"
+        else:
+            lines += "set name=pkg.obsolete value=true\n"
+        m.set_content(lines, signatures=True)
+
+        return m
+
+    def __test_catalog_actions(self, nc, pkg_src_list):
+        def expected_dependency(f):
+            expected = [
+                "depend fmri=foo@1.0 type=require",
+                "set name=facet.devel value=true",
+                "set name=variant.arch value=i386 value=sparc",
+            ]
+
+            if f.pkg_name == "zpkg":
+                expected.append(
+                    "set name=pkg.depend.install-hold " "value=test"
+                )
+                expected.append("set name=pkg.renamed " "value=true")
+            else:
+                expected.append("set name=pkg.obsolete " "value=true")
+            return expected
+
+        def expected_summary(f):
+            return [
+                (
+                    "set name=info.classification "
+                    'value="Desktop (GNOME)/Application" '
+                    'value="org.opensolaris.category.2009:GNOME (Desktop)"'
+                ),
+                (
+                    "set name=info.classification "
+                    """value="i386 Application" variant.arch=i386"""
+                ),
+                'set name=pkg.summary value="Summary {0}"'.format(f),
+                'set name=pkg.description value="Desc {0}"'.format(f),
+            ]
+
+        def expected_all_variant_summary(f):
+            return [
+                (
+                    "set name=info.classification "
+                    'value="Desktop (GNOME)/Application" '
+                    'value="org.opensolaris.category.2009:GNOME (Desktop)"'
+                ),
+                (
+                    "set name=info.classification "
+                    """value="Sparc Application" variant.arch=sparc"""
+                ),
+                (
+                    "set name=info.classification "
+                    """value="i386 Application" variant.arch=i386"""
+                ),
+                'set name=pkg.summary value="Summary {0}"'.format(f),
+                (
+                    'set name=pkg.summary value="Sparc Summary {0}"'
+                    " variant.arch=sparc".format(f)
+                ),
+                'set name=pkg.description value="Desc {0}"'.format(f),
+            ]
+
+        def expected_all_locale_summary(f):
+            # The comparison has to be sorted for this case.
+            return sorted(
+                [
+                    'set name=pkg.summary value="Summary {0}"'.format(f),
+                    'set name=pkg.description value="Desc {0}"'.format(f),
+                    'set name=pkg.summary:th value="ซอฟต์แวร์ {0}"'.format(f),
+                    (
+                        "set name=info.classification "
+                        'value="Desktop (GNOME)/Application" '
+                        'value="org.opensolaris.category.2009:GNOME (Desktop)"'
+                    ),
+                    (
+                        "set name=info.classification "
+                        """value="i386 Application" variant.arch=i386"""
+                    ),
+                ]
+            )
+
+        def expected_categories(f):
+            # The comparison has to be sorted for this case.
+            return set(
+                [
+                    ("", "Desktop (GNOME)/Application"),
+                    ("org.opensolaris.category.2009", "GNOME (Desktop)"),
+                    ("", "i386 Application"),
+                ]
+            )
+
+        def expected_all_variant_categories(f):
+            # The comparison has to be sorted for this case.
+            return set(
+                [
+                    ("", "Desktop (GNOME)/Application"),
+                    ("org.opensolaris.category.2009", "GNOME (Desktop)"),
+                    ("", "i386 Application"),
+                    ("", "Sparc Application"),
+                ]
+            )
+
+        # Next, ensure its populated.
+        def ordered(a, b):
+            rval = misc.cmp(a.pkg_name, b.pkg_name)
+            if rval != 0:
+                return rval
+            rval = misc.cmp(a.publisher, b.publisher)
+            if rval != 0:
+                return rval
+            return misc.cmp(a.version, b.version) * -1
+
+        self.assertEqual(
+            [f for f in nc.fmris(ordered=True)],
+            sorted(pkg_src_list, key=cmp_to_key(ordered)),
+        )
+
+        # This case should raise an AssertionError.
+        try:
+            for f, actions in nc.actions([]):
+                break
+        except AssertionError:
+            pass
+        else:
+            raise RuntimeError("actions() did not raise expected " "exception")
+
+        variants = variant.Variants()
+        variants["variant.arch"] = "i386"
+        excludes = [variants.allow_action]
+        locales = set(("C", "th"))
+
+        # This case should only return the dependency-related actions.
+        def validate_dep(f, actions):
+            returned = []
+            for a in actions:
+                self.assertTrue(isinstance(a, pkg.actions.generic.Action))
+                returned.append(str(a))
+
+            var = nc.get_entry_variants(f, "variant.arch")
+            vars = nc.get_entry_all_variants(f)
+            if f.pkg_name == "apkg":
+                # No actions should be returned for this case,
+                # as the callback will return an empty manifest.
+                self.assertEqual(returned, [])
+                self.assertEqual(var, None)
+                self.assertEqual([v for v in vars], [])
+                return
+
+            expected = expected_dependency(f)
+            self.assertEqual(returned, expected)
+            self.assertEqual(var, ["i386", "sparc"])
+            self.assertEqual(
+                [(n, vs) for n, vs in vars],
+                [("variant.arch", ["i386", "sparc"])],
+            )
+
+        for f, actions in nc.actions([nc.DEPENDENCY]):
+            validate_dep(f, actions)
+
+        latest = [f for f in nc.fmris(last=True)]
+        for f, actions in nc.actions([nc.DEPENDENCY], last=True):
+            self.assertTrue(f in latest)
+            validate_dep(f, actions)
+
+        latest = [(pub, stem, ver) for pub, stem, ver in nc.tuples(last=True)]
+        for (pub, stem, ver), entry, actions in nc.entry_actions(
+            [nc.DEPENDENCY], last=True
+        ):
+            self.assertTrue((pub, stem, ver) in latest)
+            f = fmri.PkgFmri("{0}@{1}".format(stem, ver), publisher=pub)
+            validate_dep(f, actions)
+
+        # This case should only return the summary-related actions (but
+        # for all variants).
+        for f, actions in nc.actions([nc.SUMMARY]):
+            returned = []
+            for a in actions:
+                self.assertTrue(isinstance(a, pkg.actions.generic.Action))
+                returned.append(str(a))
+
+            if f.pkg_name == "apkg":
+                # No actions should be returned for this case,
+                # as the callback will return an empty manifest.
+                self.assertEqual(returned, [])
+                continue
+
+            expected = expected_all_variant_summary(f)
+            self.assertEqual(returned, expected)
+
+        # This case should only return the summary-related actions (but
+        # for 'C' and 'th' locales and without sparc variants).
+        for f, actions in nc.actions(
+            [nc.SUMMARY], excludes=excludes, locales=locales
+        ):
+            returned = []
+            for a in actions:
+                self.assertTrue(isinstance(a, pkg.actions.generic.Action))
+                returned.append(str(a))
+
+            if f.pkg_name == "apkg":
+                # No actions should be returned for this case,
+                # as the callback will return an empty manifest.
+                self.assertEqual(returned, [])
+                continue
+
+            returned.sort()
+            expected = expected_all_locale_summary(f)
+            self.assertEqual(returned, expected)
+
+        # This case should only return the summary-related actions (but
+        # without sparc variants).
+        for f, actions in nc.actions([nc.SUMMARY], excludes=excludes):
+            returned = []
+            for a in actions:
+                self.assertTrue(isinstance(a, pkg.actions.generic.Action))
+                returned.append(str(a))
+
+            if f.pkg_name == "apkg":
+                # No actions should be returned for this case,
+                # as the callback will return an empty manifest.
+                self.assertEqual(returned, [])
+                continue
+
+            expected = expected_summary(f)
+            self.assertEqual(returned, expected)
+
+        # Verify that retrieving a single entry's actions works as well.
+        f = pkg_src_list[0]
+        try:
+            for a in nc.get_entry_actions(f, []):
+                break
+        except AssertionError:
+            pass
+        else:
+            raise RuntimeError(
+                "get_entry_actions() did not raise " "expected exception"
+            )
+
+        # This case should only return the dependency-related actions.
+        returned = [str(a) for a in nc.get_entry_actions(f, [nc.DEPENDENCY])]
+        expected = expected_dependency(f)
+        self.assertEqual(returned, expected)
+
+        # This case should only return the summary-related actions (but
+        # for all variants).
+        returned = [str(a) for a in nc.get_entry_actions(f, [nc.SUMMARY])]
+        expected = expected_all_variant_summary(f)
+        self.assertEqual(returned, expected)
+
+        # This case should only return the summary-related actions (but
+        # for 'C' and 'th' locales and without sparc variants).
+        returned = sorted(
+            [
+                str(a)
+                for a in nc.get_entry_actions(
+                    f, [nc.SUMMARY], excludes=excludes, locales=locales
+                )
+            ]
+        )
+        expected = expected_all_locale_summary(f)
+        self.assertEqual(returned, expected)
+
+        # This case should only return the summary-related actions (but
+        # without sparc variants).
+        returned = [
+            str(a)
+            for a in nc.get_entry_actions(f, [nc.SUMMARY], excludes=excludes)
+        ]
+        expected = expected_summary(f)
+        self.assertEqual(returned, expected)
+
+        # This case should return the categories used (but without sparc
+        # variants).
+        returned = nc.categories(excludes=excludes)
+        expected = expected_categories(f)
+        self.assertEqual(returned, expected)
+
+    def test_01_attrs(self):
+        self.assertEqual(self.npkgs, self.c.package_count)
+        self.assertEqual(self.nversions, self.c.package_version_count)
+
+    def test_02_gen_packages(self):
+        """Verify that the filtering logic provided by
+        gen_packages works as expected."""
+
+        f = "pkg:/test@1.0,5.11-1:20000101T120000Z"
+        cl = list(self.c.gen_packages(patterns=[f]))
+        self.assertEqual(len(cl), 1)
+
+        f = "pkg:/test@1.0"
+        cl = list(self.c.gen_packages(patterns=[f]))
+        self.assertEqual(len(cl), 5)
+
+        f = "pkg:/test@1.0"
+        cl = list(self.c.gen_packages(patterns=[f], pubs=["foobar"]))
+        self.assertEqual(len(cl), 0)
+
+        # zpkg exists in contrib.opensolaris.org (2 fmris) and extra (1)
+        f = "zpkg"
+        cl = list(self.c.gen_packages(patterns=[f]))
+        self.assertEqual(len(cl), 3)
+        cl = list(self.c.gen_packages(patterns=[f], pubs=["extra"]))
+        self.assertEqual(len(cl), 1)
+
+        patterns = ["pkg:/test@1.0", "willnotmatch"]
+        unmatched = set()
+        matched = set()
+        cl = list(
+            self.c.gen_packages(
+                patterns=patterns, matched=matched, unmatched=unmatched
+            )
+        )
+        self.assertEqual(unmatched, set(["willnotmatch"]))
+        self.assertEqual(matched, set(["pkg:/test@1.0"]))
+
+    def test_03_permissions(self):
+        """Verify that new catalogs are created with a mode of 644 and
+        that old catalogs will have their mode forcibly changed, unless
+        read_only is specified, in which case an exception is raised.
+        See bug 5603 for a documented case."""
+
+        # Catalog files should have this mode.
+        mode = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+        # Windows doesn't have group or other permissions, so they
+        # are set to be the same as for the owner
+        if portable.ostype == "windows":
+            mode |= stat.S_IWGRP | stat.S_IWOTH
+
+        # Catalog files should not have this mode.
+        bad_mode = stat.S_IRUSR | stat.S_IWUSR
+
+        # Test new catalog case.
+        cpath = self.create_test_dir("test-04")
+        c = catalog.Catalog(meta_root=cpath, log_updates=True)
+        c.add_package(
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/test@1.0,5.11-1:20000101T120000Z"
+            )
+        )
+        c.save()
+
+        for fname in c.signatures:
+            fn = os.path.join(c.meta_root, fname)
+            portable.assert_mode(fn, mode)
+
+        # Now test old catalog case.
+        for fname in c.signatures:
+            os.chmod(os.path.join(c.meta_root, fname), bad_mode)
+        c = catalog.Catalog(meta_root=cpath, log_updates=True)
+        for fname in c.signatures:
+            fn = os.path.join(c.meta_root, fname)
+            portable.assert_mode(fn, mode)
+
+        # Need to add an fmri to it and then re-test the permissions
+        # since this causes the catalog file to be re-created.
+        c.add_package(
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/test@2.0,5.11-1:20000101T120000Z"
+            )
+        )
+        c.save()
+
+        for fname in c.signatures:
+            fn = os.path.join(c.meta_root, fname)
+            portable.assert_mode(fn, mode)
+
+        # Finally, test read_only old catalog case.
+        for fname in c.signatures:
+            os.chmod(os.path.join(c.meta_root, fname), bad_mode)
+
+        self.assertRaises(
+            api_errors.BadCatalogPermissions,
+            catalog.Catalog,
+            meta_root=c.meta_root,
+            read_only=True,
+        )
+
+    def test_04_store_and_validate(self):
+        """Test catalog storage, retrieval, and validation."""
+
+        cpath = self.create_test_dir("test-05")
+        c = catalog.Catalog(meta_root=cpath, log_updates=True)
+
+        # Verify that a newly created catalog has no signature data.
+        for sigs in six.itervalues(c.signatures):
+            self.assertEqual(len(sigs), 0)
+
+        # Verify that a newly created catalog will validate since no
+        # signature data is present.
+        c.validate()
+
+        # Verify catalog storage and retrieval works.
+        c.add_package(
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/" "test@2.0,5.11-1:20000101T120000Z"
+            )
+        )
+        c.save()
+
+        # Get a copy of the signature data.
+        old_sigs = c.signatures
+
+        # Verify that a catalog will have signature data after save().
+        self.assertTrue(len(old_sigs) >= 1)
+
+        # Verify that expected entries are present.
+        self.assertTrue("catalog.attrs" in old_sigs)
+        self.assertTrue("catalog.base.C" in old_sigs)
+
+        updates = 0
+        for fname, sigs in six.iteritems(old_sigs):
+            self.assertTrue(len(sigs) >= 1)
+
+            if fname.startswith("update."):
+                updates += 1
+
+        # Only one updatelog should exist.
+        self.assertEqual(updates, 1)
+
+        # Verify that the newly saved catalog will validate.
+        c.validate()
+
+        # Next, retrieve the stored catalog.
+        c = catalog.Catalog(meta_root=cpath, log_updates=True)
+        pkg_list = [f for f in c.fmris()]
+        self.assertEqual(
+            pkg_list,
+            [
+                fmri.PkgFmri(
+                    "pkg://opensolaris.org/test@2.0,5.11-1:20000101T120000Z"
+                )
+            ],
+        )
+
+        # Verify that a stored catalog will validate, and that its
+        # current signatures match its previous signatures.
+        c.validate()
+        self.assertEqual(old_sigs, c.signatures)
+
+        # Finally, test that a catalog created with sign=False won't
+        # have any signature data after being saved.
+        c = catalog.Catalog(sign=False)
+        c.save()
+        self.assertEqual(c.signatures, {"catalog.attrs": {}})
+
+    def test_05_retrieval(self):
+        """Verify that various catalog retrieval methods work as
+        expected."""
+
+        vers = {}
+        fmris = {}
+        for f in self.c.fmris():
+            vers.setdefault(f.pkg_name, [])
+            vers[f.pkg_name].append(f.version)
+
+            fmris.setdefault(f.pkg_name, {})
+            fmris[f.pkg_name].setdefault(str(f.version), [])
+            fmris[f.pkg_name][str(f.version)].append(f)
+
+        # test names()
+        self.assertEqual(self.c.names(), set(["apkg", "test", "zpkg"]))
+        self.assertEqual(
+            self.c.names(pubs=["extra", "opensolaris.org"]),
+            set(["apkg", "test", "zpkg"]),
+        )
+        self.assertEqual(
+            self.c.names(pubs=["extra", "contrib.opensolaris.org"]),
+            set(["apkg", "zpkg"]),
+        )
+        self.assertEqual(self.c.names(pubs=["opensolaris.org"]), set(["test"]))
+
+        # test pkg_names()
+        expected = [
+            ("extra", "apkg"),
+            ("opensolaris.org", "test"),
+            ("contrib.opensolaris.org", "zpkg"),
+            ("extra", "zpkg"),
+        ]
+
+        for pubs in ([], ["extra", "opensolaris.org"], ["extra"], ["bobcat"]):
+            elist = [e for e in expected if not pubs or e[0] in pubs]
+            rlist = [e for e in self.c.pkg_names(pubs=pubs)]
+            self.assertEqual(rlist, elist)
+
+        def fmri_order(a, b):
+            rval = misc.cmp(a.pkg_name, b.pkg_name)
+            if rval != 0:
+                return rval
+            rval = misc.cmp(a.publisher, b.publisher)
+            if rval != 0:
+                return rval
+            return misc.cmp(a.version, b.version) * -1
+
+        def tuple_order(a, b):
+            apub, astem, aver = a
+            bpub, bstem, bver = b
+            rval = misc.cmp(astem, bstem)
+            if rval != 0:
+                return rval
+            rval = misc.cmp(apub, bpub)
+            if rval != 0:
+                return rval
+            aver = version.Version(aver)
+            bver = version.Version(bver)
+            return misc.cmp(aver, bver) * -1
+
+        def tuple_entry_order(a, b):
+            (apub, astem, aver), entry = a
+            (bpub, bstem, bver), entry = b
+            rval = misc.cmp(astem, bstem)
+            if rval != 0:
+                return rval
+            rval = misc.cmp(apub, bpub)
+            if rval != 0:
+                return rval
+            aver = version.Version(aver)
+            bver = version.Version(bver)
+            return misc.cmp(aver, bver) * -1
+
+        # test fmris()
+        for pubs in ([], ["extra", "opensolaris.org"], ["extra"], ["bobcat"]):
+            # Check base functionality.
+            elist = [
+                f for f in self.c.fmris() if not pubs or f.publisher in pubs
+            ]
+            rlist = [e for e in self.c.fmris(pubs=pubs)]
+            self.assertEqual(rlist, elist)
+
+            # Check last functionality.
+            elist = {}
+            for f in self.c.fmris(pubs=pubs):
+                if (
+                    f.get_pkg_stem() not in elist
+                    or f.version > elist[f.get_pkg_stem()].version
+                ):
+                    elist[f.get_pkg_stem()] = f
+            elist = sorted(elist.values())
+
+            rlist = sorted([f for f in self.c.fmris(last=True, pubs=pubs)])
+            self.assertEqual(rlist, elist)
+
+            # Check ordered functionality.
+            elist.sort(key=cmp_to_key(fmri_order))
+
+            rlist = [
+                f for f in self.c.fmris(last=True, ordered=True, pubs=pubs)
+            ]
+            self.assertEqual(rlist, elist)
+
+        # test entries(), tuple_entries()
+        for pubs in ([], ["extra", "opensolaris.org"], ["extra"], ["bobcat"]):
+            # Check base functionality.
+            elist = [(f, {}) for f in self.c.fmris(pubs=pubs)]
+            rlist = [e for e in self.c.entries(pubs=pubs)]
+            self.assertEqual(rlist, elist)
+
+            # Check last functionality.
+            elist = {}
+            for f in self.c.fmris(pubs=pubs):
+                if (
+                    f.get_pkg_stem() not in elist
+                    or f.version > elist[f.get_pkg_stem()].version
+                ):
+                    elist[f.get_pkg_stem()] = f
+            elist = [
+                (f, {})
+                for f in sorted(elist.values(), key=cmp_to_key(fmri_order))
+            ]
+            rlist = [
+                e for e in self.c.entries(last=True, ordered=True, pubs=pubs)
+            ]
+            self.assertEqual(rlist, elist)
+
+            # Check base functionality.
+            elist = []
+            for f in self.c.fmris(pubs=pubs):
+                pub, stem, ver = f.tuple()
+                ver = str(ver)
+                elist.append(((pub, stem, ver), {}))
+            rlist = [e for e in self.c.tuple_entries(pubs=pubs)]
+            self.assertEqual(rlist, elist)
+
+            # Check last functionality.
+            elist = {}
+            for f in self.c.fmris(pubs=pubs):
+                if (
+                    f.get_pkg_stem() not in elist
+                    or f.version > elist[f.get_pkg_stem()].version
+                ):
+                    elist[f.get_pkg_stem()] = f
+
+            nlist = []
+            for f in sorted(elist.values()):
+                pub, stem, ver = f.tuple()
+                ver = str(ver)
+                nlist.append(((pub, stem, ver), {}))
+            elist = sorted(nlist, key=cmp_to_key(tuple_entry_order))
+            nlist = None
+            rlist = [
+                e
+                for e in self.c.tuple_entries(
+                    last=True, ordered=True, pubs=pubs
+                )
+            ]
+            self.assertEqual(rlist, elist)
+
+        # test entries_by_version() and fmris_by_version()
+        for pubs in ([], ["extra", "opensolaris.org"], ["extra"]):
+            for name in fmris:
+                for ver, entries in self.c.entries_by_version(name, pubs=pubs):
+                    flist = [
+                        f[1]
+                        for f in entries
+                        if not pubs or f[0].publisher in pubs
+                    ]
+                    elist = [
+                        {}
+                        for f in entries
+                        if not pubs or f[0].publisher in pubs
+                    ]
+                    self.assertEqual(flist, elist)
+
+                for ver, pfmris in self.c.fmris_by_version(name, pubs=pubs):
+                    elist = [
+                        f
+                        for f in fmris[name][str(ver)]
+                        if not pubs or f.publisher in pubs
+                    ]
+                    self.assertEqual(pfmris, elist)
+
+    def test_06_operations(self):
+        """Verify that catalog operations work as expected."""
+
+        # Three sample packages used to verify that catalog data
+        # is populated as expected:
+        p1_fmri = fmri.PkgFmri(
+            "pkg://opensolaris.org/" "base@1.0,5.11-1:20000101T120000Z"
+        )
+        p1_man = manifest.Manifest(p1_fmri)
+        p1_man.set_content("", signatures=True)
+
+        p2_fmri = fmri.PkgFmri(
+            "pkg://opensolaris.org/" "dependency@1.0,5.11-1:20000101T130000Z"
+        )
+        p2_man = manifest.Manifest(p2_fmri)
+        p2_man.set_content(
+            "set name=fmri value={0}\n"
+            "depend type=require fmri=base@1.0\n".format(p2_fmri.get_fmri()),
+            signatures=True,
+        )
+
+        p3_fmri = fmri.PkgFmri(
+            "pkg://opensolaris.org/" "summary@1.0,5.11-1:20000101T140000Z"
+        )
+        p3_man = manifest.Manifest(p3_fmri)
+        p3_man.set_content(
+            "set name=fmri value={0}\n"
+            'set description="Example Description"\n'
+            'set pkg.description="Example pkg.Description"\n'
+            'set summary="Example Summary"\n'
+            'set pkg.summary="Example pkg.Summary"\n'
+            'set name=info.classification value="org.opensolaris.'
+            'category.2008:Applications/Sound and Video"\n'.format(
+                p3_fmri.get_fmri()
+            ),
+            signatures=True,
+        )
+
+        # Create and prep an empty catalog.
+        cpath = self.create_test_dir("test-06")
+        cat = catalog.Catalog(meta_root=cpath, log_updates=True)
+
+        # Populate the catalog and then verify the Manifest signatures
+        # for each entry are correct.
+        cat.add_package(p1_fmri, manifest=p1_man)
+        sigs = p1_man.signatures
+        cat_sigs = dict((s, v) for s, v in cat.get_entry_signatures(p1_fmri))
+        self.assertEqual(sigs, cat_sigs)
+
+        cat.add_package(p2_fmri, manifest=p2_man)
+        sigs = p2_man.signatures
+        cat_sigs = dict((s, v) for s, v in cat.get_entry_signatures(p2_fmri))
+        self.assertEqual(sigs, cat_sigs)
+
+        cat.add_package(p3_fmri, manifest=p3_man)
+        sigs = p3_man.signatures
+        cat_sigs = dict((s, v) for s, v in cat.get_entry_signatures(p3_fmri))
+        self.assertEqual(sigs, cat_sigs)
+
+        # Check that get_matching_fmris returns the right unmatched
+        # pattern.
+        pdict, references, unmatched = cat.get_matching_fmris(["xyzzy", "base"])
+        self.assertEqual(set(["xyzzy"]), unmatched)
+
+        # Next, verify that removal of an FMRI not in the catalog will
+        # raise the expected exception.  Do this by removing an FMRI
+        # and then attempting to remove it again.
+        cat.remove_package(p3_fmri)
+        self.assertRaises(
+            api_errors.UnknownCatalogEntry, cat.remove_package, p3_fmri
+        )
+
+        # Verify that update_entry will update base metadata and update
+        # the last_modified timestamp of the catalog and base part.
+        base = cat.get_part("catalog.base.C")
+        orig_cat_lm = cat.last_modified
+        orig_base_lm = base.last_modified
+
+        # Update logging has to be disabled for this to work.
+        cat.log_updates = False
+
+        cat.update_entry({"foo": True}, pfmri=p2_fmri)
+
+        entry = cat.get_entry(p2_fmri)
+        self.assertEqual(entry["metadata"], {"foo": True})
+
+        self.assertTrue(cat.last_modified > orig_cat_lm)
+        self.assertTrue(base.last_modified > orig_base_lm)
+
+        part_lm = cat.parts[base.name]["last-modified"]
+        self.assertTrue(base.last_modified == part_lm)
+
+    def test_07_updates(self):
+        """Verify that catalog updates are applied as expected."""
+
+        # First, start by creating and populating the original catalog.
+        cpath = self.create_test_dir("test-07-orig")
+        orig = catalog.Catalog(meta_root=cpath, log_updates=True)
+        orig.save()
+
+        # Next, duplicate the original for testing, and load it.
+        dup1_path = os.path.join(self.test_root, "test-07-dup1")
+        shutil.copytree(cpath, dup1_path)
+        dup1 = catalog.Catalog(meta_root=dup1_path)
+        dup1.validate()
+
+        # No catalog updates should be needed.
+        self.assertEqual(dup1.get_updates_needed(orig.meta_root), None)
+
+        # Add some packages to the original.
+        pkg_src_list = [
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/" "test@1.0,5.11-1:20000101T120000Z"
+            ),
+        ]
+
+        for f in pkg_src_list:
+            orig.add_package(f)
+        orig.save()
+
+        # Check the expected number of package versions in each catalog.
+        self.assertEqual(orig.package_version_count, 1)
+        self.assertEqual(dup1.package_version_count, 0)
+
+        # Only the new catalog parts should be listed as updates.
+        updates = dup1.get_updates_needed(orig.meta_root)
+        self.assertEqual(updates, set(["catalog.base.C"]))
+
+        # Now copy the existing catalog so that a baseline exists for
+        # incremental update testing.
+        shutil.rmtree(dup1_path)
+        shutil.copytree(cpath, dup1_path)
+
+        def apply_updates(src, dest):
+            # Next, determine the updates that could be made to the
+            # duplicate based on the original.
+            updates = dest.get_updates_needed(src.meta_root)
+
+            # Verify that the updates available to the original
+            # catalog are the same as the updated needed to update
+            # the duplicate.
+            self.assertEqual(list(src.updates.keys()), updates)
+
+            # Apply original catalog's updates to the duplicate.
+            dest.apply_updates(src.meta_root)
+
+            # Verify the contents.
+            self.assertEqual(
+                dest.package_version_count, src.package_version_count
+            )
+            self.assertEqual(
+                [f for f in dest.fmris()], [f for f in src.fmris()]
+            )
+
+        # Add some packages to the original.
+        pkg_src_list = [
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/" "test@1.0,5.11-1:20000101T120010Z"
+            ),
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/" "test@1.0,5.11-1.1:20000101T120020Z"
+            ),
+        ]
+
+        for f in pkg_src_list:
+            orig.add_package(f)
+        orig.save()
+
+        # Load the duplicate and ensure it contains the expected data.
+        dup1 = catalog.Catalog(meta_root=dup1_path)
+        self.assertEqual(dup1.package_version_count, 1)
+        dup1.validate()
+
+        # Apply the updates and verify.
+        apply_updates(orig, dup1)
+
+        # Now remove the packages that were added during the last
+        # update.
+        for f in pkg_src_list:
+            orig.remove_package(f)
+        orig.save()
+
+        # Apply the updates and verify.
+        self.assertEqual(orig.package_version_count, 1)
+        apply_updates(orig, dup1)
+
+        # Now add back one of the packages removed.
+        for f in pkg_src_list:
+            orig.add_package(f)
+            break
+        orig.save()
+
+        # Apply the updates and verify.
+        self.assertEqual(orig.package_version_count, 2)
+        apply_updates(orig, dup1)
+
+        # Now remove the package we just added and add back both
+        # packages we first removed and attempt to update.
+        for f in pkg_src_list:
+            orig.remove_package(f)
+            break
+        for f in pkg_src_list:
+            orig.add_package(f)
+        orig.save()
+
+        # Apply the updates and verify.
+        self.assertEqual(orig.package_version_count, 3)
+        apply_updates(orig, dup1)
+
+    def test_08_append(self):
+        """Verify that append functionality works as expected."""
+
+        # First, populate a new catalog with the entries from the test
+        # base one using synthesized manifest data.
+        c = catalog.Catalog()
+        for f in self.c.fmris():
+            c.add_package(f, manifest=self.__gen_manifest(f))
+
+        # Next, test that basic append functionality works.
+        nc = catalog.Catalog()
+        nc.append(c)
+        nc.finalize(pfmris=set([f for f in c.fmris()]))
+
+        self.assertEqual(
+            sorted([f for f in c.fmris()]), sorted([f for f in nc.fmris()])
+        )
+        self.assertEqual(c.package_version_count, nc.package_version_count)
+
+        for f, entry in nc.entries(
+            info_needed=[nc.DEPENDENCY, nc.SUMMARY], locales=set(("C", "th"))
+        ):
+            self.assertTrue("metadata" not in entry)
+
+            m = self.__gen_manifest(f)
+            expected = sorted(
+                s.strip()
+                for s in m.as_lines()
+                if not s.startswith("set name=pkg.fmri")
+            )
+            returned = sorted(entry["actions"])
+            self.assertEqual(expected, returned)
+
+        # Next, test that callbacks work as expected.
+        pkg_list = []
+        for f in c.fmris():
+            if f.pkg_name == "apkg":
+                continue
+            pkg_list.append(f)
+
+        def append_cb(cat, f, entry):
+            if f.pkg_name == "apkg":
+                return False, None
+            return True, {"states": []}
+
+        nc = catalog.Catalog()
+        nc.append(c, cb=append_cb)
+        nc.finalize()
+
+        for f, entry in nc.entries():
+            self.assertNotEqual(f.pkg_name, "apkg")
+            self.assertTrue("states" in entry["metadata"])
+
+        # Next, check that an append for a single FMRI works with a
+        # callback.
+        def cb_true(x, y, z):
+            return True, None
+
+        def cb_false(x, y, z):
+            return False, None
+
+        for f in c.fmris():
+            if f.pkg_name == "apkg":
+                nc.append(c, cb=cb_false, pfmri=f)
+                break
+        nc.finalize()
+
+        for f, entry in nc.entries():
+            self.assertNotEqual(f.pkg_name, "apkg")
+            self.assertTrue("states" in entry["metadata"])
+
+        for f in c.fmris():
+            if f.pkg_name == "apkg":
+                nc.append(c, cb=cb_true, pfmri=f)
+                break
+        nc.finalize()
+
+        self.assertEqual(
+            sorted([f for f in c.fmris()]), sorted([f for f in nc.fmris()])
+        )
+        self.assertEqual(c.package_version_count, nc.package_version_count)
+
+    def test_09_actions(self):
+        """Verify that the actions-related catalog functions work as
+        expected."""
+
+        pkg_src_list = [
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/" "test@1.0,5.11-1:20000101T120010Z"
+            ),
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/" "test@1.0,5.11-1.1:20000101T120020Z"
+            ),
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/" "apkg@1.0,5.11-1:20000101T120040Z"
+            ),
+            fmri.PkgFmri("pkg://extra/" "apkg@1.0,5.11-1:20000101T120040Z"),
+            fmri.PkgFmri("pkg://extra/zpkg@1.0,5.11-1:20000101T120040Z"),
+        ]
+
+        def manifest_cb(cat, f):
+            if f.pkg_name == "apkg":
                 m = manifest.Manifest()
-                lines = misc.force_text(
-                    "depend fmri=foo@1.0 type=require\n"
-                    "set name=facet.devel value=true\n"
-                    "set name=info.classification "
-                    """value="Desktop (GNOME)/Application" """
-                    """value="org.opensolaris.category.2009:GNOME (Desktop)"\n"""
-                    "set name=info.classification "
-                    """value="Sparc Application" variant.arch=sparc\n"""
-                    "set name=info.classification "
-                    """value="i386 Application" variant.arch=i386\n"""
-                    "set name=variant.arch value=i386 value=sparc\n"
-                    "set name=pkg.fmri value=\"{0}\"\n"
-                    "set name=pkg.summary value=\"Summary {1}\"\n"
-                    "set name=pkg.summary value=\"Sparc Summary {2}\""
-                    " variant.arch=sparc\n"
-                    "set name=pkg.summary:th value=\"ซอฟต์แวร์ {3}\"\n"
-                    "set name=pkg.description value=\"Desc {4}\"\n").format(
-                    f, f, f, f, f)
-
-                if f.pkg_name == "zpkg":
-                        lines += "set name=pkg.depend.install-hold value=test\n"
-                        lines += "set name=pkg.renamed value=true\n"
-                else:
-                        lines += "set name=pkg.obsolete value=true\n"
-                m.set_content(lines, signatures=True)
-
+                m.set_content("", signatures=True)
                 return m
-
-        def __test_catalog_actions(self, nc, pkg_src_list):
-                def expected_dependency(f):
-                        expected = [
-                            "depend fmri=foo@1.0 type=require",
-                            "set name=facet.devel value=true",
-                            "set name=variant.arch value=i386 value=sparc",
-                        ]
-
-                        if f.pkg_name == "zpkg":
-                                expected.append("set name=pkg.depend.install-hold "
-                                    "value=test")
-                                expected.append("set name=pkg.renamed "
-                                    "value=true")
-                        else:
-                                expected.append("set name=pkg.obsolete "
-                                    "value=true")
-                        return expected
-
-                def expected_summary(f):
-                        return [
-                            ('set name=info.classification '
-                            'value="Desktop (GNOME)/Application" '
-                            'value="org.opensolaris.category.2009:GNOME (Desktop)"'),
-                            ("set name=info.classification "
-                            """value="i386 Application" variant.arch=i386"""),
-                            "set name=pkg.summary value=\"Summary {0}\"".format(f),
-                            "set name=pkg.description value=\"Desc {0}\"".format(f),
-                        ]
-
-                def expected_all_variant_summary(f):
-                        return [
-                            ('set name=info.classification '
-                            'value="Desktop (GNOME)/Application" '
-                            'value="org.opensolaris.category.2009:GNOME (Desktop)"'),
-                            ("set name=info.classification "
-                            """value="Sparc Application" variant.arch=sparc"""),
-                            ("set name=info.classification "
-                            """value="i386 Application" variant.arch=i386"""),
-                            "set name=pkg.summary value=\"Summary {0}\"".format(f),
-                            ("set name=pkg.summary value=\"Sparc Summary {0}\""
-                            " variant.arch=sparc".format(f)),
-                            "set name=pkg.description value=\"Desc {0}\"".format(f),
-                        ]
-
-                def expected_all_locale_summary(f):
-                        # The comparison has to be sorted for this case.
-                        return sorted([
-                            "set name=pkg.summary value=\"Summary {0}\"".format(f),
-                            "set name=pkg.description value=\"Desc {0}\"".format(f),
-                            "set name=pkg.summary:th value=\"ซอฟต์แวร์ {0}\"".format(f),
-                            ('set name=info.classification '
-                            'value="Desktop (GNOME)/Application" '
-                            'value="org.opensolaris.category.2009:GNOME (Desktop)"'),
-                            ("set name=info.classification "
-                            """value="i386 Application" variant.arch=i386"""),
-                        ])
-
-                def expected_categories(f):
-                        # The comparison has to be sorted for this case.
-                        return set([
-                            ("", "Desktop (GNOME)/Application"),
-                            ("org.opensolaris.category.2009", "GNOME (Desktop)"),
-                            ("", "i386 Application"),
-                        ])
-
-                def expected_all_variant_categories(f):
-                        # The comparison has to be sorted for this case.
-                        return set([
-                            ("", "Desktop (GNOME)/Application"),
-                            ("org.opensolaris.category.2009", "GNOME (Desktop)"),
-                            ("", "i386 Application"),
-                            ("", "Sparc Application"),
-                        ])
-
-                # Next, ensure its populated.
-                def ordered(a, b):
-                        rval = misc.cmp(a.pkg_name, b.pkg_name)
-                        if rval != 0:
-                                return rval
-                        rval = misc.cmp(a.publisher, b.publisher)
-                        if rval != 0:
-                                return rval
-                        return misc.cmp(a.version, b.version) * -1
-                self.assertEqual([f for f in nc.fmris(ordered=True)],
-                    sorted(pkg_src_list, key=cmp_to_key(ordered)))
-
-                # This case should raise an AssertionError.
-                try:
-                        for f, actions in nc.actions([]):
-                                break
-                except AssertionError:
-                        pass
-                else:
-                        raise RuntimeError("actions() did not raise expected "
-                            "exception")
-
-                variants = variant.Variants()
-                variants["variant.arch"] = "i386"
-                excludes = [variants.allow_action]
-                locales = set(("C", "th"))
-
-                # This case should only return the dependency-related actions.
-                def validate_dep(f, actions):
-                        returned = []
-                        for a in actions:
-                                self.assertTrue(isinstance(a,
-                                    pkg.actions.generic.Action))
-                                returned.append(str(a))
-
-                        var = nc.get_entry_variants(f, "variant.arch")
-                        vars = nc.get_entry_all_variants(f)
-                        if f.pkg_name == "apkg":
-                                # No actions should be returned for this case,
-                                # as the callback will return an empty manifest.
-                                self.assertEqual(returned, [])
-                                self.assertEqual(var, None)
-                                self.assertEqual([v for v in vars], [])
-                                return
-
-                        expected = expected_dependency(f)
-                        self.assertEqual(returned, expected)
-                        self.assertEqual(var, ["i386", "sparc"])
-                        self.assertEqual([(n, vs) for n, vs in vars],
-                            [("variant.arch", ["i386", "sparc"])])
-
-                for f, actions in nc.actions([nc.DEPENDENCY]):
-                        validate_dep(f, actions)
-
-                latest = [f for f in nc.fmris(last=True)]
-                for f, actions in nc.actions([nc.DEPENDENCY], last=True):
-                        self.assertTrue(f in latest)
-                        validate_dep(f, actions)
-
-                latest = [
-                    (pub, stem, ver)
-                    for pub, stem, ver in nc.tuples(last=True)
-                ]
-                for (pub, stem, ver), entry, actions in nc.entry_actions(
-                    [nc.DEPENDENCY], last=True):
-                        self.assertTrue((pub, stem, ver) in latest)
-                        f = fmri.PkgFmri("{0}@{1}".format(stem, ver), publisher=pub)
-                        validate_dep(f, actions)
-
-                # This case should only return the summary-related actions (but
-                # for all variants).
-                for f, actions in nc.actions([nc.SUMMARY]):
-                        returned = []
-                        for a in actions:
-                                self.assertTrue(isinstance(a,
-                                    pkg.actions.generic.Action))
-                                returned.append(str(a))
-
-                        if f.pkg_name == "apkg":
-                                # No actions should be returned for this case,
-                                # as the callback will return an empty manifest.
-                                self.assertEqual(returned, [])
-                                continue
-
-                        expected = expected_all_variant_summary(f)
-                        self.assertEqual(returned, expected)
-
-                # This case should only return the summary-related actions (but
-                # for 'C' and 'th' locales and without sparc variants).
-                for f, actions in nc.actions([nc.SUMMARY], excludes=excludes,
-                    locales=locales):
-                        returned = []
-                        for a in actions:
-                                self.assertTrue(isinstance(a,
-                                    pkg.actions.generic.Action))
-                                returned.append(str(a))
-
-                        if f.pkg_name == "apkg":
-                                # No actions should be returned for this case,
-                                # as the callback will return an empty manifest.
-                                self.assertEqual(returned, [])
-                                continue
-
-                        returned.sort()
-                        expected = expected_all_locale_summary(f)
-                        self.assertEqual(returned, expected)
-
-                # This case should only return the summary-related actions (but
-                # without sparc variants).
-                for f, actions in nc.actions([nc.SUMMARY], excludes=excludes):
-                        returned = []
-                        for a in actions:
-                                self.assertTrue(isinstance(a,
-                                    pkg.actions.generic.Action))
-                                returned.append(str(a))
-
-                        if f.pkg_name == "apkg":
-                                # No actions should be returned for this case,
-                                # as the callback will return an empty manifest.
-                                self.assertEqual(returned, [])
-                                continue
-
-                        expected = expected_summary(f)
-                        self.assertEqual(returned, expected)
-
-                # Verify that retrieving a single entry's actions works as well.
-                f = pkg_src_list[0]
-                try:
-                        for a in nc.get_entry_actions(f, []):
-                                break
-                except AssertionError:
-                        pass
-                else:
-                        raise RuntimeError("get_entry_actions() did not raise "
-                            "expected exception")
-
-                # This case should only return the dependency-related actions.
-                returned = [
-                    str(a)
-                    for a in nc.get_entry_actions(f, [nc.DEPENDENCY])
-                ]
-                expected = expected_dependency(f)
-                self.assertEqual(returned, expected)
-
-                # This case should only return the summary-related actions (but
-                # for all variants).
-                returned = [
-                    str(a)
-                    for a in nc.get_entry_actions(f, [nc.SUMMARY])
-                ]
-                expected = expected_all_variant_summary(f)
-                self.assertEqual(returned, expected)
-
-                # This case should only return the summary-related actions (but
-                # for 'C' and 'th' locales and without sparc variants).
-                returned = sorted([
-                    str(a)
-                    for a in nc.get_entry_actions(f, [nc.SUMMARY],
-                    excludes=excludes, locales=locales)
-                ])
-                expected = expected_all_locale_summary(f)
-                self.assertEqual(returned, expected)
-
-                # This case should only return the summary-related actions (but
-                # without sparc variants).
-                returned = [
-                    str(a)
-                    for a in nc.get_entry_actions(f, [nc.SUMMARY],
-                    excludes=excludes)
-                ]
-                expected = expected_summary(f)
-                self.assertEqual(returned, expected)
-
-                # This case should return the categories used (but without sparc
-                # variants).
-                returned = nc.categories(excludes=excludes)
-                expected = expected_categories(f)
-                self.assertEqual(returned, expected)
-
-        def test_01_attrs(self):
-                self.assertEqual(self.npkgs, self.c.package_count)
-                self.assertEqual(self.nversions, self.c.package_version_count)
-
-        def test_02_gen_packages(self):
-                """Verify that the filtering logic provided by
-                gen_packages works as expected."""
-
-                f = "pkg:/test@1.0,5.11-1:20000101T120000Z"
-                cl = list(self.c.gen_packages(patterns=[f]))
-                self.assertEqual(len(cl), 1)
-
-                f = "pkg:/test@1.0"
-                cl = list(self.c.gen_packages(patterns=[f]))
-                self.assertEqual(len(cl), 5)
-
-                f = "pkg:/test@1.0"
-                cl = list(self.c.gen_packages(patterns=[f], pubs=["foobar"]))
-                self.assertEqual(len(cl), 0)
-
-                # zpkg exists in contrib.opensolaris.org (2 fmris) and extra (1)
-                f = "zpkg"
-                cl = list(self.c.gen_packages(patterns=[f]))
-                self.assertEqual(len(cl), 3)
-                cl = list(self.c.gen_packages(patterns=[f], pubs=["extra"]))
-                self.assertEqual(len(cl), 1)
-
-                patterns = ["pkg:/test@1.0", "willnotmatch"]
-                unmatched = set()
-                matched = set()
-                cl = list(self.c.gen_packages(patterns=patterns,
-                    matched=matched, unmatched=unmatched))
-                self.assertEqual(unmatched, set(["willnotmatch"]))
-                self.assertEqual(matched, set(["pkg:/test@1.0"]))
-
-        def test_03_permissions(self):
-                """Verify that new catalogs are created with a mode of 644 and
-                that old catalogs will have their mode forcibly changed, unless
-                read_only is specified, in which case an exception is raised.
-                See bug 5603 for a documented case."""
-
-                # Catalog files should have this mode.
-                mode = stat.S_IRUSR|stat.S_IWUSR|stat.S_IRGRP|stat.S_IROTH
-                # Windows doesn't have group or other permissions, so they
-                # are set to be the same as for the owner
-                if portable.ostype == "windows":
-                        mode |= stat.S_IWGRP|stat.S_IWOTH
-
-                # Catalog files should not have this mode.
-                bad_mode = stat.S_IRUSR|stat.S_IWUSR
-
-                # Test new catalog case.
-                cpath = self.create_test_dir("test-04")
-                c = catalog.Catalog(meta_root=cpath, log_updates=True)
-                c.add_package(fmri.PkgFmri(
-                    "pkg://opensolaris.org/test@1.0,5.11-1:20000101T120000Z"))
-                c.save()
-
-                for fname in c.signatures:
-                        fn = os.path.join(c.meta_root, fname)
-                        portable.assert_mode(fn, mode)
-
-                # Now test old catalog case.
-                for fname in c.signatures:
-                        os.chmod(os.path.join(c.meta_root, fname), bad_mode)
-                c = catalog.Catalog(meta_root=cpath, log_updates=True)
-                for fname in c.signatures:
-                        fn = os.path.join(c.meta_root, fname)
-                        portable.assert_mode(fn, mode)
-
-                # Need to add an fmri to it and then re-test the permissions
-                # since this causes the catalog file to be re-created.
-                c.add_package(fmri.PkgFmri(
-                    "pkg://opensolaris.org/test@2.0,5.11-1:20000101T120000Z"))
-                c.save()
-
-                for fname in c.signatures:
-                        fn = os.path.join(c.meta_root, fname)
-                        portable.assert_mode(fn, mode)
-
-                # Finally, test read_only old catalog case.
-                for fname in c.signatures:
-                        os.chmod(os.path.join(c.meta_root, fname), bad_mode)
-
-                self.assertRaises(api_errors.BadCatalogPermissions,
-                        catalog.Catalog, meta_root=c.meta_root, read_only=True)
-
-        def test_04_store_and_validate(self):
-                """Test catalog storage, retrieval, and validation."""
-
-                cpath = self.create_test_dir("test-05")
-                c = catalog.Catalog(meta_root=cpath, log_updates=True)
-
-                # Verify that a newly created catalog has no signature data.
-                for sigs in six.itervalues(c.signatures):
-                        self.assertEqual(len(sigs), 0)
-
-                # Verify that a newly created catalog will validate since no
-                # signature data is present.
-                c.validate()
-
-                # Verify catalog storage and retrieval works.
-                c.add_package(fmri.PkgFmri("pkg://opensolaris.org/"
-                    "test@2.0,5.11-1:20000101T120000Z"))
-                c.save()
-
-                # Get a copy of the signature data.
-                old_sigs = c.signatures
-
-                # Verify that a catalog will have signature data after save().
-                self.assertTrue(len(old_sigs) >= 1)
-
-                # Verify that expected entries are present.
-                self.assertTrue("catalog.attrs" in old_sigs)
-                self.assertTrue("catalog.base.C" in old_sigs)
-
-                updates = 0
-                for fname, sigs in six.iteritems(old_sigs):
-                        self.assertTrue(len(sigs) >= 1)
-
-                        if fname.startswith("update."):
-                                updates += 1
-
-                # Only one updatelog should exist.
-                self.assertEqual(updates, 1)
-
-                # Verify that the newly saved catalog will validate.
-                c.validate()
-
-                # Next, retrieve the stored catalog.
-                c = catalog.Catalog(meta_root=cpath, log_updates=True)
-                pkg_list = [f for f in c.fmris()]
-                self.assertEqual(pkg_list, [fmri.PkgFmri(
-                    "pkg://opensolaris.org/test@2.0,5.11-1:20000101T120000Z")])
-
-                # Verify that a stored catalog will validate, and that its
-                # current signatures match its previous signatures.
-                c.validate()
-                self.assertEqual(old_sigs, c.signatures)
-
-                # Finally, test that a catalog created with sign=False won't
-                # have any signature data after being saved.
-                c = catalog.Catalog(sign=False)
-                c.save()
-                self.assertEqual(c.signatures, { "catalog.attrs": {} })
-
-        def test_05_retrieval(self):
-                """Verify that various catalog retrieval methods work as
-                expected."""
-
-                vers = {}
-                fmris = {}
-                for f in self.c.fmris():
-                        vers.setdefault(f.pkg_name, [])
-                        vers[f.pkg_name].append(f.version)
-
-                        fmris.setdefault(f.pkg_name, {})
-                        fmris[f.pkg_name].setdefault(str(f.version), [])
-                        fmris[f.pkg_name][str(f.version)].append(f)
-
-                # test names()
-                self.assertEqual(self.c.names(), set(["apkg", "test", "zpkg"]))
-                self.assertEqual(self.c.names(pubs=["extra",
-                    "opensolaris.org"]), set(["apkg", "test", "zpkg"]))
-                self.assertEqual(self.c.names(pubs=["extra",
-                    "contrib.opensolaris.org"]), set(["apkg", "zpkg"]))
-                self.assertEqual(self.c.names(pubs=["opensolaris.org"]),
-                    set(["test"]))
-
-                # test pkg_names()
-                expected = [
-                    ("extra", "apkg"),
-                    ("opensolaris.org", "test"),
-                    ("contrib.opensolaris.org", "zpkg"),
-                    ("extra", "zpkg"),
-                ]
-
-                for pubs in ([], ["extra", "opensolaris.org"], ["extra"],
-                    ["bobcat"]):
-                        elist = [
-                            e for e in expected
-                            if not pubs or e[0] in pubs
-                        ]
-                        rlist = [e for e in self.c.pkg_names(pubs=pubs)]
-                        self.assertEqual(rlist, elist)
-
-                def fmri_order(a, b):
-                        rval = misc.cmp(a.pkg_name, b.pkg_name)
-                        if rval != 0:
-                                return rval
-                        rval = misc.cmp(a.publisher, b.publisher)
-                        if rval != 0:
-                                return rval
-                        return misc.cmp(a.version, b.version) * -1
-
-                def tuple_order(a, b):
-                        apub, astem, aver = a
-                        bpub, bstem, bver = b
-                        rval = misc.cmp(astem, bstem)
-                        if rval != 0:
-                                return rval
-                        rval = misc.cmp(apub, bpub)
-                        if rval != 0:
-                                return rval
-                        aver = version.Version(aver)
-                        bver = version.Version(bver)
-                        return misc.cmp(aver, bver) * -1
-
-                def tuple_entry_order(a, b):
-                        (apub, astem, aver), entry = a
-                        (bpub, bstem, bver), entry = b
-                        rval = misc.cmp(astem, bstem)
-                        if rval != 0:
-                                return rval
-                        rval = misc.cmp(apub, bpub)
-                        if rval != 0:
-                                return rval
-                        aver = version.Version(aver)
-                        bver = version.Version(bver)
-                        return misc.cmp(aver, bver) * -1
-
-                # test fmris()
-                for pubs in ([], ["extra", "opensolaris.org"], ["extra"],
-                    ["bobcat"]):
-                        # Check base functionality.
-                        elist = [
-                            f for f in self.c.fmris()
-                            if not pubs or f.publisher in pubs
-                        ]
-                        rlist = [e for e in self.c.fmris(pubs=pubs)]
-                        self.assertEqual(rlist, elist)
-
-                        # Check last functionality.
-                        elist = {}
-                        for f in self.c.fmris(pubs=pubs):
-                                if f.get_pkg_stem() not in elist or \
-                                    f.version > elist[f.get_pkg_stem()].version:
-                                        elist[f.get_pkg_stem()] = f
-                        elist = sorted(elist.values())
-
-                        rlist = sorted([f for f in self.c.fmris(last=True,
-                            pubs=pubs)])
-                        self.assertEqual(rlist, elist)
-
-                        # Check ordered functionality.
-                        elist.sort(key=cmp_to_key(fmri_order))
-
-                        rlist = [f for f in self.c.fmris(last=True,
-                            ordered=True, pubs=pubs)]
-                        self.assertEqual(rlist, elist)
-
-                # test entries(), tuple_entries()
-                for pubs in ([], ["extra", "opensolaris.org"], ["extra"],
-                    ["bobcat"]):
-                        # Check base functionality.
-                        elist = [(f, {}) for f in self.c.fmris(pubs=pubs)]
-                        rlist = [e for e in self.c.entries(pubs=pubs)]
-                        self.assertEqual(rlist, elist)
-
-                        # Check last functionality.
-                        elist = {}
-                        for f in self.c.fmris(pubs=pubs):
-                                if f.get_pkg_stem() not in elist or \
-                                    f.version > elist[f.get_pkg_stem()].version:
-                                        elist[f.get_pkg_stem()] = f
-                        elist = [(f, {}) for f in sorted(elist.values(),
-                            key=cmp_to_key(fmri_order))]
-                        rlist = [e for e in self.c.entries(last=True,
-                            ordered=True, pubs=pubs)]
-                        self.assertEqual(rlist, elist)
-
-                        # Check base functionality.
-                        elist = []
-                        for f in self.c.fmris(pubs=pubs):
-                                pub, stem, ver = f.tuple()
-                                ver = str(ver)
-                                elist.append(((pub, stem, ver), {}))
-                        rlist = [e for e in self.c.tuple_entries(pubs=pubs)]
-                        self.assertEqual(rlist, elist)
-
-                        # Check last functionality.
-                        elist = {}
-                        for f in self.c.fmris(pubs=pubs):
-                                if f.get_pkg_stem() not in elist or \
-                                    f.version > elist[f.get_pkg_stem()].version:
-                                        elist[f.get_pkg_stem()] = f
-
-                        nlist = []
-                        for f in sorted(elist.values()):
-                                pub, stem, ver = f.tuple()
-                                ver = str(ver)
-                                nlist.append(((pub, stem, ver), {}))
-                        elist = sorted(nlist, key=cmp_to_key(tuple_entry_order))
-                        nlist = None
-                        rlist = [e for e in self.c.tuple_entries(last=True,
-                            ordered=True, pubs=pubs)]
-                        self.assertEqual(rlist, elist)
-
-                # test entries_by_version() and fmris_by_version()
-                for pubs in ([], ["extra", "opensolaris.org"], ["extra"]):
-                        for name in fmris:
-                                for ver, entries in self.c.entries_by_version(
-                                    name, pubs=pubs):
-                                        flist = [
-                                            f[1] for f in entries
-                                            if not pubs or f[0].publisher in pubs
-                                        ]
-                                        elist = [
-                                            {} for f in entries
-                                            if not pubs or f[0].publisher in pubs
-                                        ]
-                                        self.assertEqual(flist, elist)
-
-                                for ver, pfmris in self.c.fmris_by_version(name,
-                                    pubs=pubs):
-                                        elist = [
-                                            f for f in fmris[name][str(ver)]
-                                            if not pubs or f.publisher in pubs
-                                        ]
-                                        self.assertEqual(pfmris, elist)
-
-        def test_06_operations(self):
-                """Verify that catalog operations work as expected."""
-
-                # Three sample packages used to verify that catalog data
-                # is populated as expected:
-                p1_fmri = fmri.PkgFmri("pkg://opensolaris.org/"
-                        "base@1.0,5.11-1:20000101T120000Z")
-                p1_man = manifest.Manifest(p1_fmri)
-                p1_man.set_content("", signatures=True)
-
-                p2_fmri = fmri.PkgFmri("pkg://opensolaris.org/"
-                        "dependency@1.0,5.11-1:20000101T130000Z")
-                p2_man = manifest.Manifest(p2_fmri)
-                p2_man.set_content("set name=fmri value={0}\n"
-                    "depend type=require fmri=base@1.0\n".format(
-                    p2_fmri.get_fmri()), signatures=True)
-
-                p3_fmri = fmri.PkgFmri("pkg://opensolaris.org/"
-                        "summary@1.0,5.11-1:20000101T140000Z")
-                p3_man = manifest.Manifest(p3_fmri)
-                p3_man.set_content("set name=fmri value={0}\n"
-                    "set description=\"Example Description\"\n"
-                    "set pkg.description=\"Example pkg.Description\"\n"
-                    "set summary=\"Example Summary\"\n"
-                    "set pkg.summary=\"Example pkg.Summary\"\n"
-                    "set name=info.classification value=\"org.opensolaris."
-                    "category.2008:Applications/Sound and Video\"\n".format(
-                    p3_fmri.get_fmri()), signatures=True)
-
-                # Create and prep an empty catalog.
-                cpath = self.create_test_dir("test-06")
-                cat = catalog.Catalog(meta_root=cpath, log_updates=True)
-
-                # Populate the catalog and then verify the Manifest signatures
-                # for each entry are correct.
-                cat.add_package(p1_fmri, manifest=p1_man)
-                sigs = p1_man.signatures
-                cat_sigs = dict(
-                    (s, v)
-                    for s, v in cat.get_entry_signatures(p1_fmri)
-                )
-                self.assertEqual(sigs, cat_sigs)
-
-                cat.add_package(p2_fmri, manifest=p2_man)
-                sigs = p2_man.signatures
-                cat_sigs = dict(
-                    (s, v)
-                    for s, v in cat.get_entry_signatures(p2_fmri)
-                )
-                self.assertEqual(sigs, cat_sigs)
-
-                cat.add_package(p3_fmri, manifest=p3_man)
-                sigs = p3_man.signatures
-                cat_sigs = dict(
-                    (s, v)
-                    for s, v in cat.get_entry_signatures(p3_fmri)
-                )
-                self.assertEqual(sigs, cat_sigs)
-
-                # Check that get_matching_fmris returns the right unmatched
-                # pattern.
-                pdict, references, unmatched = cat.get_matching_fmris(
-                    ["xyzzy", "base"])
-                self.assertEqual(set(["xyzzy"]), unmatched)
-
-                # Next, verify that removal of an FMRI not in the catalog will
-                # raise the expected exception.  Do this by removing an FMRI
-                # and then attempting to remove it again.
-                cat.remove_package(p3_fmri)
-                self.assertRaises(api_errors.UnknownCatalogEntry,
-                        cat.remove_package, p3_fmri)
-
-                # Verify that update_entry will update base metadata and update
-                # the last_modified timestamp of the catalog and base part.
-                base = cat.get_part("catalog.base.C")
-                orig_cat_lm = cat.last_modified
-                orig_base_lm = base.last_modified
-
-                # Update logging has to be disabled for this to work.
-                cat.log_updates = False
-
-                cat.update_entry({ "foo": True }, pfmri=p2_fmri)
-
-                entry = cat.get_entry(p2_fmri)
-                self.assertEqual(entry["metadata"], { "foo": True })
-
-                self.assertTrue(cat.last_modified > orig_cat_lm)
-                self.assertTrue(base.last_modified > orig_base_lm)
-
-                part_lm = cat.parts[base.name]["last-modified"]
-                self.assertTrue(base.last_modified == part_lm)
-
-        def test_07_updates(self):
-                """Verify that catalog updates are applied as expected."""
-
-                # First, start by creating and populating the original catalog.
-                cpath = self.create_test_dir("test-07-orig")
-                orig = catalog.Catalog(meta_root=cpath, log_updates=True)
-                orig.save()
-
-                # Next, duplicate the original for testing, and load it.
-                dup1_path = os.path.join(self.test_root, "test-07-dup1")
-                shutil.copytree(cpath, dup1_path)
-                dup1 = catalog.Catalog(meta_root=dup1_path)
-                dup1.validate()
-
-                # No catalog updates should be needed.
-                self.assertEqual(dup1.get_updates_needed(orig.meta_root), None)
-
-                # Add some packages to the original.
-                pkg_src_list = [
-                    fmri.PkgFmri("pkg://opensolaris.org/"
-                        "test@1.0,5.11-1:20000101T120000Z"),
-                ]
-
-                for f in pkg_src_list:
-                        orig.add_package(f)
-                orig.save()
-
-                # Check the expected number of package versions in each catalog.
-                self.assertEqual(orig.package_version_count, 1)
-                self.assertEqual(dup1.package_version_count, 0)
-
-                # Only the new catalog parts should be listed as updates.
-                updates = dup1.get_updates_needed(orig.meta_root)
-                self.assertEqual(updates, set(["catalog.base.C"]))
-
-                # Now copy the existing catalog so that a baseline exists for
-                # incremental update testing.
-                shutil.rmtree(dup1_path)
-                shutil.copytree(cpath, dup1_path)
-
-                def apply_updates(src, dest):
-                        # Next, determine the updates that could be made to the
-                        # duplicate based on the original.
-                        updates = dest.get_updates_needed(src.meta_root)
-
-                        # Verify that the updates available to the original
-                        # catalog are the same as the updated needed to update
-                        # the duplicate.
-                        self.assertEqual(list(src.updates.keys()), updates)
-
-                        # Apply original catalog's updates to the duplicate.
-                        dest.apply_updates(src.meta_root)
-
-                        # Verify the contents.
-                        self.assertEqual(dest.package_version_count,
-                            src.package_version_count)
-                        self.assertEqual([f for f in dest.fmris()],
-                            [f for f in src.fmris()])
-
-                # Add some packages to the original.
-                pkg_src_list = [
-                    fmri.PkgFmri("pkg://opensolaris.org/"
-                        "test@1.0,5.11-1:20000101T120010Z"),
-                    fmri.PkgFmri("pkg://opensolaris.org/"
-                        "test@1.0,5.11-1.1:20000101T120020Z"),
-                ]
-
-                for f in pkg_src_list:
-                        orig.add_package(f)
-                orig.save()
-
-                # Load the duplicate and ensure it contains the expected data.
-                dup1 = catalog.Catalog(meta_root=dup1_path)
-                self.assertEqual(dup1.package_version_count, 1)
-                dup1.validate()
-
-                # Apply the updates and verify.
-                apply_updates(orig, dup1)
-
-                # Now remove the packages that were added during the last
-                # update.
-                for f in pkg_src_list:
-                        orig.remove_package(f)
-                orig.save()
-
-                # Apply the updates and verify.
-                self.assertEqual(orig.package_version_count, 1)
-                apply_updates(orig, dup1)
-
-                # Now add back one of the packages removed.
-                for f in pkg_src_list:
-                        orig.add_package(f)
-                        break
-                orig.save()
-
-                # Apply the updates and verify.
-                self.assertEqual(orig.package_version_count, 2)
-                apply_updates(orig, dup1)
-
-                # Now remove the package we just added and add back both
-                # packages we first removed and attempt to update.
-                for f in pkg_src_list:
-                        orig.remove_package(f)
-                        break
-                for f in pkg_src_list:
-                        orig.add_package(f)
-                orig.save()
-
-                # Apply the updates and verify.
-                self.assertEqual(orig.package_version_count, 3)
-                apply_updates(orig, dup1)
-
-        def test_08_append(self):
-                """Verify that append functionality works as expected."""
-
-                # First, populate a new catalog with the entries from the test
-                # base one using synthesized manifest data.
-                c = catalog.Catalog()
-                for f in self.c.fmris():
-                        c.add_package(f, manifest=self.__gen_manifest(f))
-
-                # Next, test that basic append functionality works.
-                nc = catalog.Catalog()
-                nc.append(c)
-                nc.finalize(pfmris=set([f for f in c.fmris()]))
-
-                self.assertEqual(sorted([f for f in c.fmris()]),
-                    sorted([f for f in nc.fmris()]))
-                self.assertEqual(c.package_version_count,
-                    nc.package_version_count)
-
-                for f, entry in nc.entries(info_needed=[nc.DEPENDENCY,
-                    nc.SUMMARY], locales=set(("C", "th"))):
-                        self.assertTrue("metadata" not in entry)
-
-                        m = self.__gen_manifest(f)
-                        expected = sorted(
-                            s.strip() for s in m.as_lines()
-                            if not s.startswith("set name=pkg.fmri")
-                        )
-                        returned = sorted(entry["actions"])
-                        self.assertEqual(expected, returned)
-
-                # Next, test that callbacks work as expected.
-                pkg_list = []
-                for f in c.fmris():
-                        if f.pkg_name == "apkg":
-                                continue
-                        pkg_list.append(f)
-
-                def append_cb(cat, f, entry):
-                        if f.pkg_name == "apkg":
-                                return False, None
-                        return True, { "states": [] }
-
-                nc = catalog.Catalog()
-                nc.append(c, cb=append_cb)
-                nc.finalize()
-
-                for f, entry in nc.entries():
-                        self.assertNotEqual(f.pkg_name, "apkg")
-                        self.assertTrue("states" in entry["metadata"])
-
-                # Next, check that an append for a single FMRI works with a
-                # callback.
-                def cb_true(x, y, z):
-                        return True, None
-
-                def cb_false(x, y, z):
-                        return False, None
-
-                for f in c.fmris():
-                        if f.pkg_name == "apkg":
-                                nc.append(c, cb=cb_false, pfmri=f)
-                                break
-                nc.finalize()
-
-                for f, entry in nc.entries():
-                        self.assertNotEqual(f.pkg_name, "apkg")
-                        self.assertTrue("states" in entry["metadata"])
-
-                for f in c.fmris():
-                        if f.pkg_name == "apkg":
-                                nc.append(c, cb=cb_true, pfmri=f)
-                                break
-                nc.finalize()
-
-                self.assertEqual(sorted([f for f in c.fmris()]),
-                    sorted([f for f in nc.fmris()]))
-                self.assertEqual(c.package_version_count,
-                    nc.package_version_count)
-
-        def test_09_actions(self):
-                """Verify that the actions-related catalog functions work as
-                expected."""
-
-                pkg_src_list = [
-                    fmri.PkgFmri("pkg://opensolaris.org/"
-                        "test@1.0,5.11-1:20000101T120010Z"),
-                    fmri.PkgFmri("pkg://opensolaris.org/"
-                        "test@1.0,5.11-1.1:20000101T120020Z"),
-                    fmri.PkgFmri("pkg://opensolaris.org/"
-                        "apkg@1.0,5.11-1:20000101T120040Z"),
-                    fmri.PkgFmri("pkg://extra/"
-                        "apkg@1.0,5.11-1:20000101T120040Z"),
-                    fmri.PkgFmri("pkg://extra/zpkg@1.0,5.11-1:20000101T120040Z")
-                ]
-
-                def manifest_cb(cat, f):
-                        if f.pkg_name == "apkg":
-                                m = manifest.Manifest()
-                                m.set_content("", signatures=True)
-                                return m
-                        return self.__gen_manifest(f)
-
-                def ret_man(f):
-                        return manifest_cb(None, f)
-
-                # First, create a catalog (with callback) and populate it
-                # using only FMRIs.
-                nc = catalog.Catalog(manifest_cb=manifest_cb)
-                for f in pkg_src_list:
-                        nc.add_package(f)
-                self.__test_catalog_actions(nc, pkg_src_list)
-
-                # Second, create a catalog (without callback) and populate it
-                # using FMRIs and Manifests.
-                nc = catalog.Catalog()
-                for f in pkg_src_list:
-                        nc.add_package(f, manifest=ret_man(f))
-                self.__test_catalog_actions(nc, pkg_src_list)
-
-                # Third, create a catalog (with callback), but populate it
-                # using FMRIs and Manifests.
-                nc = catalog.Catalog(manifest_cb=manifest_cb)
-                for f in pkg_src_list:
-                        nc.add_package(f, manifest=ret_man(f))
-                self.__test_catalog_actions(nc, pkg_src_list)
-
-                # Fourth, create a catalog (no callback) and populate it
-                # using only FMRIs.
-                nc = catalog.Catalog()
-                for f in pkg_src_list:
-                        nc.add_package(f)
-
-                # These cases should not return any actions.
-                for f, actions in nc.actions([nc.DEPENDENCY]):
-                        returned = [a for a in actions]
-                        self.assertEqual(returned, [])
-
-                returned = nc.get_entry_actions(f, [nc.DEPENDENCY])
-                self.assertEqual(list(returned), [])
-
-        def test_10_destroy(self):
-
-                pkg_src_list = [
-                    fmri.PkgFmri("pkg://opensolaris.org/"
-                        "test@1.0,5.11-1:20000101T120010Z"),
-                    fmri.PkgFmri("pkg://opensolaris.org/"
-                        "test@1.0,5.11-1.1:20000101T120020Z"),
-                    fmri.PkgFmri("pkg://opensolaris.org/"
-                        "apkg@1.0,5.11-1:20000101T120040Z"),
-                    fmri.PkgFmri("pkg://extra/"
-                        "apkg@1.0,5.11-1:20000101T120040Z"),
-                    fmri.PkgFmri("pkg://extra/zpkg@1.0,5.11-1:20000101T120040Z")
-                ]
-
-                def manifest_cb(cat, f):
-                        if f.pkg_name == "apkg":
-                                m = manifest.Manifest()
-                                m.set_content("", signatures=True)
-                                return m
-                        return self.__gen_manifest(f)
-
-                def ret_man(f):
-                        return manifest_cb(None, f)
-
-                # First, create a catalog (with callback) and populate it
-                # using only FMRIs.
-                cpath = self.create_test_dir("test-10")
-                nc = catalog.Catalog(meta_root=cpath)
-                for f in pkg_src_list:
-                        nc.add_package(f, manifest=ret_man(f))
-
-                # Now verify that destroy really destroys the catalog.
-                nc.destroy()
-
-                # Verify that destroy actually emptied the catalog.
-                self.assertEqual(nc.package_count, 0)
-                self.assertEqual(list(nc.fmris()), [])
-                self.assertEqual(nc.parts, {})
-                self.assertEqual(nc.updates, {})
-                self.assertEqual(nc.signatures, { "catalog.attrs": {} })
-
-                # Next, re-create the catalog and then delete a few arbitrary
-                # parts (specifically, the attrs file).
-                cpath = self.create_test_dir("test-10")
-                nc = catalog.Catalog(manifest_cb=manifest_cb, meta_root=cpath)
-                for f in pkg_src_list:
-                        nc.add_package(f, manifest=ret_man(f))
-                nc.save()
-
-                # Now remove arbitrary files.
-                for fname in ("catalog.attrs", "catalog.dependency.C",
-                    "catalog.summary.C"):
-                        pname = os.path.join(nc.meta_root, fname)
-                        portable.remove(pname)
-
-                # Verify that destroy actually removes the files.
-                nc = catalog.Catalog(meta_root=cpath)
-                nc.destroy()
-
-                for fname in os.listdir(nc.meta_root):
-                        self.assertFalse(fname.startswith("catalog.") or \
-                            fname.startswith("update."))
-
-        def test_legacy_description(self):
-                """Test that gen_packages does not traceback when a package
-                uses the legacy style of declaring package description metadata."""
-
+            return self.__gen_manifest(f)
+
+        def ret_man(f):
+            return manifest_cb(None, f)
+
+        # First, create a catalog (with callback) and populate it
+        # using only FMRIs.
+        nc = catalog.Catalog(manifest_cb=manifest_cb)
+        for f in pkg_src_list:
+            nc.add_package(f)
+        self.__test_catalog_actions(nc, pkg_src_list)
+
+        # Second, create a catalog (without callback) and populate it
+        # using FMRIs and Manifests.
+        nc = catalog.Catalog()
+        for f in pkg_src_list:
+            nc.add_package(f, manifest=ret_man(f))
+        self.__test_catalog_actions(nc, pkg_src_list)
+
+        # Third, create a catalog (with callback), but populate it
+        # using FMRIs and Manifests.
+        nc = catalog.Catalog(manifest_cb=manifest_cb)
+        for f in pkg_src_list:
+            nc.add_package(f, manifest=ret_man(f))
+        self.__test_catalog_actions(nc, pkg_src_list)
+
+        # Fourth, create a catalog (no callback) and populate it
+        # using only FMRIs.
+        nc = catalog.Catalog()
+        for f in pkg_src_list:
+            nc.add_package(f)
+
+        # These cases should not return any actions.
+        for f, actions in nc.actions([nc.DEPENDENCY]):
+            returned = [a for a in actions]
+            self.assertEqual(returned, [])
+
+        returned = nc.get_entry_actions(f, [nc.DEPENDENCY])
+        self.assertEqual(list(returned), [])
+
+    def test_10_destroy(self):
+        pkg_src_list = [
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/" "test@1.0,5.11-1:20000101T120010Z"
+            ),
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/" "test@1.0,5.11-1.1:20000101T120020Z"
+            ),
+            fmri.PkgFmri(
+                "pkg://opensolaris.org/" "apkg@1.0,5.11-1:20000101T120040Z"
+            ),
+            fmri.PkgFmri("pkg://extra/" "apkg@1.0,5.11-1:20000101T120040Z"),
+            fmri.PkgFmri("pkg://extra/zpkg@1.0,5.11-1:20000101T120040Z"),
+        ]
+
+        def manifest_cb(cat, f):
+            if f.pkg_name == "apkg":
                 m = manifest.Manifest()
-                contents = misc.force_text(
-                    "set name=description "
-                    """value="legacy pkg description" """
-                )
-                m.set_content(contents, signatures=True)
-                f = fmri.PkgFmri("pkg://opensolaris.org/"
-                        "legacy@1.0,5.11-1:20000101T120000Z")
-                nc = catalog.Catalog()
-                nc.add_package(f, manifest=m)
-                cl = list(nc.gen_packages(patterns=[str(f)], collect_attrs=True))
-                self.assertEqual(len(cl), 1)
-                self.assertEqual(cl[0][2]['pkg.summary'][frozenset([])],
-                    ["legacy pkg description"])
+                m.set_content("", signatures=True)
+                return m
+            return self.__gen_manifest(f)
+
+        def ret_man(f):
+            return manifest_cb(None, f)
+
+        # First, create a catalog (with callback) and populate it
+        # using only FMRIs.
+        cpath = self.create_test_dir("test-10")
+        nc = catalog.Catalog(meta_root=cpath)
+        for f in pkg_src_list:
+            nc.add_package(f, manifest=ret_man(f))
+
+        # Now verify that destroy really destroys the catalog.
+        nc.destroy()
+
+        # Verify that destroy actually emptied the catalog.
+        self.assertEqual(nc.package_count, 0)
+        self.assertEqual(list(nc.fmris()), [])
+        self.assertEqual(nc.parts, {})
+        self.assertEqual(nc.updates, {})
+        self.assertEqual(nc.signatures, {"catalog.attrs": {}})
+
+        # Next, re-create the catalog and then delete a few arbitrary
+        # parts (specifically, the attrs file).
+        cpath = self.create_test_dir("test-10")
+        nc = catalog.Catalog(manifest_cb=manifest_cb, meta_root=cpath)
+        for f in pkg_src_list:
+            nc.add_package(f, manifest=ret_man(f))
+        nc.save()
+
+        # Now remove arbitrary files.
+        for fname in (
+            "catalog.attrs",
+            "catalog.dependency.C",
+            "catalog.summary.C",
+        ):
+            pname = os.path.join(nc.meta_root, fname)
+            portable.remove(pname)
+
+        # Verify that destroy actually removes the files.
+        nc = catalog.Catalog(meta_root=cpath)
+        nc.destroy()
+
+        for fname in os.listdir(nc.meta_root):
+            self.assertFalse(
+                fname.startswith("catalog.") or fname.startswith("update.")
+            )
+
+    def test_legacy_description(self):
+        """Test that gen_packages does not traceback when a package
+        uses the legacy style of declaring package description metadata."""
+
+        m = manifest.Manifest()
+        contents = misc.force_text(
+            "set name=description " """value="legacy pkg description" """
+        )
+        m.set_content(contents, signatures=True)
+        f = fmri.PkgFmri(
+            "pkg://opensolaris.org/" "legacy@1.0,5.11-1:20000101T120000Z"
+        )
+        nc = catalog.Catalog()
+        nc.add_package(f, manifest=m)
+        cl = list(nc.gen_packages(patterns=[str(f)], collect_attrs=True))
+        self.assertEqual(len(cl), 1)
+        self.assertEqual(
+            cl[0][2]["pkg.summary"][frozenset([])], ["legacy pkg description"]
+        )
 
 
 class TestEmptyCatalog(pkg5unittest.Pkg5TestCase):
-        """Basic functionality tests for empty catalogs."""
+    """Basic functionality tests for empty catalogs."""
 
-        def setUp(self):
-                self.c = catalog.Catalog()
+    def setUp(self):
+        self.c = catalog.Catalog()
 
-        def test_01_attrs(self):
-                self.assertEqual(self.c.package_count, 0)
-                self.assertEqual(self.c.package_version_count, 0)
+    def test_01_attrs(self):
+        self.assertEqual(self.c.package_count, 0)
+        self.assertEqual(self.c.package_version_count, 0)
 
-        def test_02_gen_packages(self):
-                cf = fmri.PkgFmri("pkg:/test@1.0,5.11-1:20070101T120000Z")
-                fmris = [str(s) for s in self.c.fmris()]
-                cl = list(self.c.gen_packages(patterns=fmris))
-                self.assertEqual(len(cl), 0)
+    def test_02_gen_packages(self):
+        cf = fmri.PkgFmri("pkg:/test@1.0,5.11-1:20070101T120000Z")
+        fmris = [str(s) for s in self.c.fmris()]
+        cl = list(self.c.gen_packages(patterns=fmris))
+        self.assertEqual(len(cl), 0)
 
-        def test_03_actions(self):
-                returned = [
-                    (f, actions)
-                    for f, actions in self.c.actions([self.c.DEPENDENCY])
-                ]
-                self.assertEqual(returned, [])
+    def test_03_actions(self):
+        returned = [
+            (f, actions) for f, actions in self.c.actions([self.c.DEPENDENCY])
+        ]
+        self.assertEqual(returned, [])
+
 
 class TestCatalogueFormats(pkg5unittest.Pkg5TestCase):
+    def test_catalogue_ascii_hex(self):
+        # Check that an ascii-encoded unicode point containing hex
+        # digits is properly encoded. simplejson uses lower case
+        # hex digits and the switch to rapidjson started using
+        # upper-case. This test confirms that the JSON serialiser
+        # is using lower case (or the checksum will not match)
+        c = catalog.Catalog(meta_root=self.test_root)
+        f = fmri.PkgFmri("pkg:/test@1.0,5.11-1:20070101T120000Z")
+        f.set_publisher("opensolaris.org")
+        m = manifest.Manifest()
+        m.set_content(
+            "set name=pkg.fmri value={}\n"
+            'set name=pkg.summary value="Jon K\u00F6gl"\n'.format(f),
+            signatures=True,
+        )
+        c.add_package(f, manifest=m)
+        c.save(fmt="ascii")
+        self.assertEqual(
+            c.signatures["catalog.summary.C"],
+            {"sha-1": "4991afea14ad5e4c990a05a3d3f287eacc62f37c"},
+        )
 
-        def test_catalogue_ascii_hex(self):
-                # Check that an ascii-encoded unicode point containing hex
-                # digits is properly encoded. simplejson uses lower case
-                # hex digits and the switch to rapidjson started using
-                # upper-case. This test confirms that the JSON serialiser
-                # is using lower case (or the checksum will not match)
-                c = catalog.Catalog(meta_root=self.test_root)
-                f = fmri.PkgFmri("pkg:/test@1.0,5.11-1:20070101T120000Z")
-                f.set_publisher("opensolaris.org")
-                m = manifest.Manifest()
-                m.set_content(
-                    "set name=pkg.fmri value={}\n"
-                    "set name=pkg.summary value=\"Jon K\u00F6gl\"\n"
-                    .format(f), signatures=True)
-                c.add_package(f, manifest=m)
-                c.save(fmt='ascii')
-                self.assertEqual(c.signatures['catalog.summary.C'],
-                    {'sha-1': '4991afea14ad5e4c990a05a3d3f287eacc62f37c'})
+    def test_catalogue_formats(self):
+        # Create catalogue
+        c = catalog.Catalog(meta_root=self.test_root)
+        c.save()
 
-        def test_catalogue_formats(self):
-                # Create catalogue
-                c = catalog.Catalog(meta_root=self.test_root)
-                c.save()
+        f = fmri.PkgFmri("pkg:/test@1.0,5.11-1:20070101T120000Z")
+        f.set_publisher("opensolaris.org")
+        m = manifest.Manifest()
+        m.set_content(
+            "set name=pkg.fmri value={}\n"
+            'set name=pkg.summary value="Testing \u2212 package"\n'.format(f),
+            signatures=True,
+        )
+        # Expected signature for ascii encoding
+        asig = "7bbaa64f40ac015c0fb08b17cef62568854a5928"
+        # Expected signature for UTF-8
+        bsig = "af21a62d87bbd223eb09e228737b7d985af590d8"
 
-                f = fmri.PkgFmri("pkg:/test@1.0,5.11-1:20070101T120000Z")
-                f.set_publisher("opensolaris.org")
-                m = manifest.Manifest()
-                m.set_content(
-                    "set name=pkg.fmri value={}\n"
-                    "set name=pkg.summary value=\"Testing \u2212 package\"\n"
-                    .format(f), signatures=True)
-                # Expected signature for ascii encoding
-                asig = '7bbaa64f40ac015c0fb08b17cef62568854a5928'
-                # Expected signature for UTF-8
-                bsig = 'af21a62d87bbd223eb09e228737b7d985af590d8'
+        c.add_package(f, manifest=m)
+        c.save(fmt="ascii")
 
-                c.add_package(f, manifest=m)
-                c.save(fmt='ascii')
+        self.assertEqual(c.signatures["catalog.summary.C"], {"sha-1": asig})
+        self.assertEqual(c._attrs.features, [])
 
-                self.assertEqual(c.signatures['catalog.summary.C'],
-                    {'sha-1': asig})
-                self.assertEqual(c._attrs.features, [])
+        # Check that the catalogue can be loaded and verified
 
-                # Check that the catalogue can be loaded and verified
+        cc = catalog.Catalog(meta_root=self.test_root)
+        self.assertEqual(cc.signatures["catalog.summary.C"], {"sha-1": asig})
 
-                cc = catalog.Catalog(meta_root=self.test_root)
-                self.assertEqual(cc.signatures['catalog.summary.C'],
-                    {'sha-1': asig})
+        # Confirm that saving the catalogue changes the hashes to the
+        # UTF-8 one.
+        c.save()
 
-                # Confirm that saving the catalogue changes the hashes to the
-                # UTF-8 one.
-                c.save()
+        self.assertEqual(c.signatures["catalog.summary.C"], {"sha-1": bsig})
+        self.assertEqual(c._attrs.features, ["ooce:utf8"])
 
-                self.assertEqual(c.signatures['catalog.summary.C'],
-                    {'sha-1': bsig})
-                self.assertEqual(c._attrs.features, ['ooce:utf8'])
+        # Check that the catalogue can be loaded and verified
 
-                # Check that the catalogue can be loaded and verified
-
-                cc = catalog.Catalog(meta_root=self.test_root)
-                self.assertEqual(cc.signatures['catalog.summary.C'],
-                    {'sha-1': bsig})
+        cc = catalog.Catalog(meta_root=self.test_root)
+        self.assertEqual(cc.signatures["catalog.summary.C"], {"sha-1": bsig})
 
 
 class TestCorruptCatalog(pkg5unittest.Pkg5TestCase):
-        """Tests against various forms of corrupted catalogs."""
+    """Tests against various forms of corrupted catalogs."""
 
-        def test_corrupt_attrs1(self):
-                """Raise InvalidCatalogFile for a catalog.attrs w/ bogus JSON"""
-                f = open(os.path.join(self.test_root, "catalog.attrs"), "w")
-                f.write('{"valid json": "but not a catalog"}')
-                f.close()
-                self.assertRaises(api_errors.InvalidCatalogFile,
-                    catalog.Catalog, meta_root=self.test_root)
+    def test_corrupt_attrs1(self):
+        """Raise InvalidCatalogFile for a catalog.attrs w/ bogus JSON"""
+        f = open(os.path.join(self.test_root, "catalog.attrs"), "w")
+        f.write('{"valid json": "but not a catalog"}')
+        f.close()
+        self.assertRaises(
+            api_errors.InvalidCatalogFile,
+            catalog.Catalog,
+            meta_root=self.test_root,
+        )
 
-        def test_corrupt_attrs2(self):
-                """Raise InvalidCatalogFile for a catalog.attrs w/ garbage"""
-                f = open(os.path.join(self.test_root, "catalog.attrs"), "w")
-                print('garbage', file=f)
-                f.close()
-                self.assertRaises(api_errors.InvalidCatalogFile,
-                    catalog.Catalog, meta_root=self.test_root)
+    def test_corrupt_attrs2(self):
+        """Raise InvalidCatalogFile for a catalog.attrs w/ garbage"""
+        f = open(os.path.join(self.test_root, "catalog.attrs"), "w")
+        print("garbage", file=f)
+        f.close()
+        self.assertRaises(
+            api_errors.InvalidCatalogFile,
+            catalog.Catalog,
+            meta_root=self.test_root,
+        )
 
-        def test_corrupt_attrs3(self):
-                """Raise InvalidCatalogFile for a catalog.attrs missing an
-                element"""
-                # make catalog
-                c = catalog.Catalog(meta_root=self.test_root)
-                c.save()
+    def test_corrupt_attrs3(self):
+        """Raise InvalidCatalogFile for a catalog.attrs missing an
+        element"""
+        # make catalog
+        c = catalog.Catalog(meta_root=self.test_root)
+        c.save()
 
-                # corrupt it
-                fname = os.path.join(self.test_root, "catalog.attrs")
-                f = open(fname, "r")
-                struct = json.load(f)
-                f.close()
-                del struct["parts"]
-                f = open(fname, "w")
-                print(json.dumps(struct), file=f)
-                f.close()
+        # corrupt it
+        fname = os.path.join(self.test_root, "catalog.attrs")
+        f = open(fname, "r")
+        struct = json.load(f)
+        f.close()
+        del struct["parts"]
+        f = open(fname, "w")
+        print(json.dumps(struct), file=f)
+        f.close()
 
-                self.assertRaises(api_errors.InvalidCatalogFile,
-                    catalog.Catalog, meta_root=self.test_root)
+        self.assertRaises(
+            api_errors.InvalidCatalogFile,
+            catalog.Catalog,
+            meta_root=self.test_root,
+        )
 
-        def test_corrupt_attrs4(self):
-                """Raise BadCatalogSignatures for a catalog.attrs with
-                corrupted _SIGNATURE"""
-                # make catalog
-                c = catalog.Catalog(meta_root=self.test_root)
-                c.save()
+    def test_corrupt_attrs4(self):
+        """Raise BadCatalogSignatures for a catalog.attrs with
+        corrupted _SIGNATURE"""
+        # make catalog
+        c = catalog.Catalog(meta_root=self.test_root)
+        c.save()
 
-                # corrupt it
-                fname = os.path.join(self.test_root, "catalog.attrs")
-                f = open(fname, "r")
-                struct = json.load(f)
-                f.close()
-                # corrupt signature by one digit
-                sig = int(struct["_SIGNATURE"]["sha-1"], 16)
-                struct["_SIGNATURE"]["sha-1"] = "{0:x}".format(sig + 1)
-                f = open(fname, "w")
-                print(json.dumps(struct), file=f)
-                f.close()
+        # corrupt it
+        fname = os.path.join(self.test_root, "catalog.attrs")
+        f = open(fname, "r")
+        struct = json.load(f)
+        f.close()
+        # corrupt signature by one digit
+        sig = int(struct["_SIGNATURE"]["sha-1"], 16)
+        struct["_SIGNATURE"]["sha-1"] = "{0:x}".format(sig + 1)
+        f = open(fname, "w")
+        print(json.dumps(struct), file=f)
+        f.close()
 
-                c = catalog.Catalog(meta_root=self.test_root)
-                self.assertRaises(api_errors.BadCatalogSignatures, c.validate,
-                    require_signatures=True)
-                self.assertRaises(api_errors.BadCatalogSignatures, c.validate,
-                    require_signatures=False)
+        c = catalog.Catalog(meta_root=self.test_root)
+        self.assertRaises(
+            api_errors.BadCatalogSignatures, c.validate, require_signatures=True
+        )
+        self.assertRaises(
+            api_errors.BadCatalogSignatures,
+            c.validate,
+            require_signatures=False,
+        )
 
-        def test_corrupt_attrs5(self):
-                """Raise BadCatalogSignatures for a catalog.attrs with
-                missing _SIGNATURE"""
-                # make catalog
-                c = catalog.Catalog(meta_root=self.test_root)
-                c.save()
+    def test_corrupt_attrs5(self):
+        """Raise BadCatalogSignatures for a catalog.attrs with
+        missing _SIGNATURE"""
+        # make catalog
+        c = catalog.Catalog(meta_root=self.test_root)
+        c.save()
 
-                # corrupt it by removing _SIGNATURE
-                fname = os.path.join(self.test_root, "catalog.attrs")
-                f = open(fname, "r")
-                struct = json.load(f)
-                f.close()
-                del struct["_SIGNATURE"]
-                f = open(fname, "w")
-                print(json.dumps(struct), file=f)
-                f.close()
+        # corrupt it by removing _SIGNATURE
+        fname = os.path.join(self.test_root, "catalog.attrs")
+        f = open(fname, "r")
+        struct = json.load(f)
+        f.close()
+        del struct["_SIGNATURE"]
+        f = open(fname, "w")
+        print(json.dumps(struct), file=f)
+        f.close()
 
-                c = catalog.Catalog(meta_root=self.test_root)
-                # Catalog should validate unless require_signatures=True
-                c.validate()
-                self.assertRaises(api_errors.BadCatalogSignatures, c.validate,
-                    require_signatures=True)
+        c = catalog.Catalog(meta_root=self.test_root)
+        # Catalog should validate unless require_signatures=True
+        c.validate()
+        self.assertRaises(
+            api_errors.BadCatalogSignatures, c.validate, require_signatures=True
+        )
 
-        def test_corrupt_attrs6(self):
-                """Raise UnrecognizedCatalogPart for a catalog.attrs{parts}
-                with bogus subpart."""
-                # make catalog
-                c = catalog.Catalog(meta_root=self.test_root)
-                c.save()
+    def test_corrupt_attrs6(self):
+        """Raise UnrecognizedCatalogPart for a catalog.attrs{parts}
+        with bogus subpart."""
+        # make catalog
+        c = catalog.Catalog(meta_root=self.test_root)
+        c.save()
 
-                # corrupt it by adding a bad name to the set of parts.
-                fname = os.path.join(self.test_root, "catalog.attrs")
-                f = open(fname, "r")
-                struct = json.load(f)
-                f.close()
-                struct["parts"]["/badpartname/"] = {}
-                f = open(fname, "w")
-                print(json.dumps(struct), file=f)
-                f.close()
+        # corrupt it by adding a bad name to the set of parts.
+        fname = os.path.join(self.test_root, "catalog.attrs")
+        f = open(fname, "r")
+        struct = json.load(f)
+        f.close()
+        struct["parts"]["/badpartname/"] = {}
+        f = open(fname, "w")
+        print(json.dumps(struct), file=f)
+        f.close()
 
-                # Catalog constructor should reject busted 'parts'
-                self.assertRaises(api_errors.UnrecognizedCatalogPart,
-                    catalog.Catalog, meta_root=self.test_root)
+        # Catalog constructor should reject busted 'parts'
+        self.assertRaises(
+            api_errors.UnrecognizedCatalogPart,
+            catalog.Catalog,
+            meta_root=self.test_root,
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_client.py
+++ b/src/tests/api/t_client.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import logging
@@ -36,70 +37,72 @@ import sys
 import unittest
 
 from pkg.client import global_settings
+
 logger = global_settings.logger
 
-class _LogFilter(logging.Filter):
-        def __init__(self, max_level=logging.CRITICAL):
-                logging.Filter.__init__(self)
-                self.max_level = max_level
 
-        def filter(self, record):
-                return record.levelno <= self.max_level
+class _LogFilter(logging.Filter):
+    def __init__(self, max_level=logging.CRITICAL):
+        logging.Filter.__init__(self)
+        self.max_level = max_level
+
+    def filter(self, record):
+        return record.levelno <= self.max_level
+
 
 class TestSettings(pkg5unittest.Pkg5TestCase):
+    def test_logging(self):
+        global_settings.client_name = "TestSettings"
 
-        def test_logging(self):
-                global_settings.client_name = "TestSettings"
+        info_out = six.StringIO()
+        error_out = six.StringIO()
 
-                info_out = six.StringIO()
-                error_out = six.StringIO()
+        log_fmt = logging.Formatter()
 
-                log_fmt = logging.Formatter()
+        # Enforce maximum logging level for informational messages.
+        info_h = logging.StreamHandler(info_out)
+        info_t = _LogFilter(logging.INFO)
+        info_h.addFilter(info_t)
+        info_h.setFormatter(log_fmt)
+        info_h.setLevel(logging.INFO)
 
-                # Enforce maximum logging level for informational messages.
-                info_h = logging.StreamHandler(info_out)
-                info_t = _LogFilter(logging.INFO)
-                info_h.addFilter(info_t)
-                info_h.setFormatter(log_fmt)
-                info_h.setLevel(logging.INFO)
+        # Log all warnings and above to stderr.
+        error_h = logging.StreamHandler(error_out)
+        error_h.setFormatter(log_fmt)
+        error_h.setLevel(logging.WARNING)
 
-                # Log all warnings and above to stderr.
-                error_h = logging.StreamHandler(error_out)
-                error_h.setFormatter(log_fmt)
-                error_h.setLevel(logging.WARNING)
+        global_settings.info_log_handler = info_h
+        global_settings.error_log_handler = error_h
 
-                global_settings.info_log_handler = info_h
-                global_settings.error_log_handler = error_h
+        # Log some messages.
+        logger.debug("DEBUG")
+        logger.info("INFO")
+        logger.warning("WARNING")
+        logger.error("ERROR")
+        logger.critical("CRITICAL")
 
-                # Log some messages.
-                logger.debug("DEBUG")
-                logger.info("INFO")
-                logger.warning("WARNING")
-                logger.error("ERROR")
-                logger.critical("CRITICAL")
+        # Now verify that the expected output was received (DEBUG
+        # shouldn't be here due to log level).
+        self.assertEqual(info_out.getvalue(), "INFO\n")
+        self.assertEqual(error_out.getvalue(), "WARNING\nERROR\nCRITICAL\n")
 
-                # Now verify that the expected output was received (DEBUG
-                # shouldn't be here due to log level).
-                self.assertEqual(info_out.getvalue(), "INFO\n")
-                self.assertEqual(error_out.getvalue(),
-                    "WARNING\nERROR\nCRITICAL\n")
+        # DEBUG should now be present in the info output.
+        info_out.seek(0)
+        info_h.setLevel(logging.DEBUG)
+        logger.debug("DEBUG")
+        self.assertEqual(info_out.getvalue(), "DEBUG\n")
 
-                # DEBUG should now be present in the info output.
-                info_out.seek(0)
-                info_h.setLevel(logging.DEBUG)
-                logger.debug("DEBUG")
-                self.assertEqual(info_out.getvalue(), "DEBUG\n")
+        # Reset logging and verify info_out, error_out are no longer
+        # set to receive messagse.
+        global_settings.reset_logging()
+        self.assertNotEqual(global_settings.info_log_handler, info_h)
+        self.assertNotEqual(global_settings.error_log_handler, error_h)
 
-                # Reset logging and verify info_out, error_out are no longer
-                # set to receive messagse.
-                global_settings.reset_logging()
-                self.assertNotEqual(global_settings.info_log_handler, info_h)
-                self.assertNotEqual(global_settings.error_log_handler, error_h)
+        logging.shutdown()
 
-                logging.shutdown()
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_config.py
+++ b/src/tests/api/t_config.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import copy
@@ -47,1136 +48,1348 @@ import pkg.config as cfg
 import pkg.portable as portable
 
 # The Thai word for package.
-TH_PACKAGE = u'บรรจุภัณฑ์'
+TH_PACKAGE = "บรรจุภัณฑ์"
 
 
 class TestProperty(pkg5unittest.Pkg5TestCase):
-        """Class to test the functionality of the pkg.config Property classes.
+    """Class to test the functionality of the pkg.config Property classes."""
+
+    def __verify_init(self, propcls, propname, glist, blist):
+        # 'glist' contains the list of good values to try.
+        for defval, expval in glist:
+            # Check init.
+            p = propcls(propname, default=defval)
+            self.assertEqual(p.value, expval)
+
+            # Check set.
+            p = propcls(propname)
+            p.value = defval
+            self.assertEqual(p.value, expval)
+
+        # 'blist' contains the list of bad values to try.
+        for badval in blist:
+            # Check init.
+            self.assertRaises(
+                cfg.InvalidPropertyValueError, propcls, propname, default=badval
+            )
+
+            # Check set.
+            p = cfg.PropBool(propname)
+            self.assertRaises(
+                cfg.InvalidPropertyValueError, setattr, p, "value", badval
+            )
+
+    def __verify_equality(self, propcls, eqlist, nelist):
+        # Check eq.
+        for entry in eqlist:
+            (p1name, p1def), (p2name, p2def) = entry
+            p1 = propcls(p1name, default=p1def)
+            p2 = propcls(p2name, default=p2def)
+            # This ensures that both __eq__ and __ne__ are tested
+            # properly.
+            self.assertTrue(p1 == p2)
+            self.assertFalse(p1 != p2)
+
+        # Check ne.
+        for entry in nelist:
+            (p1name, p1def), (p2name, p2def) = entry
+            p1 = propcls(p1name, default=p1def)
+            p2 = propcls(p2name, default=p2def)
+            # This ensures that both __eq__ and __ne__ are tested
+            # properly.
+            self.assertTrue(p1 != p2)
+            self.assertFalse(p1 == p2)
+
+    def __verify_stringify(self, propcls, propname, explist, debug=False):
+        for val, expstr in explist:
+            # Verify that the stringified form of the property's
+            # value matches what is expected.
+            p1 = propcls(propname, default=val)
+            self.assertEqual(six.text_type(p1), expstr)
+            if six.PY2:
+                self.assertEqual(str(p1), expstr.encode("utf-8"))
+            else:
+                # str() call in Python 3 must return str (unicode).
+                self.assertEqual(str(p1), expstr)
+
+            # Verify that a property value's stringified form
+            # provides can be parsed into an exact equivalent
+            # in native form (e.g. list -> string -> list).
+            p2 = propcls(propname)
+            p2.value = six.text_type(p1)
+            self.assertEqual(p1.value, p2.value)
+            self.assertEqualDiff(str(p1), str(p2))
+
+            p2.value = str(p1)
+            self.assertEqual(p1.value, p2.value)
+            self.assertEqualDiff(str(p1), str(p2))
+
+    def __verify_ex_stringify(self, ex):
+        encs = str(ex)
+        self.assertNotEqual(len(encs), 0)
+        unis = six.text_type(ex)
+        self.assertNotEqual(len(unis), 0)
+        if six.PY2:
+            self.assertEqualDiff(encs, unis.encode("utf-8"))
+        else:
+            self.assertEqualDiff(encs, unis)
+
+    def test_base(self):
+        """Verify base property functionality works as expected."""
+
+        propcls = cfg.Property
+
+        # Verify invalid names aren't permitted.
+        for n in (
+            "contains\na new line",
+            "contains\ttab",
+            "contains/slash",
+            "contains\rcarriage return",
+            "contains\fform feed",
+            "contains\vvertical tab",
+            "contains\\backslash",
+            "",
+            TH_PACKAGE,
+        ):
+            self.assertRaises(cfg.InvalidPropertyNameError, propcls, n)
+
+        # Verify spaces are permitted.
+        propcls("has space")
+
+        # Verify property objects are sorted by name and that other
+        # objects are sorted after.
+        plist = [propcls(n) for n in ("c", "d", "a", "b")]
+        plist.extend(["g", "e", "f"])
+        plist.sort()
+        self.assertEqual(
+            [getattr(p, "name", p) for p in plist],
+            ["a", "b", "c", "d", "e", "f", "g"],
+        )
+
+        # Verify equality is always False when comparing a property
+        # object to a different object and that objects that are not
+        # properties don't cause a traceback.
+        p1 = propcls("property")
+        self.assertFalse(p1 == "property")
+        self.assertTrue(p1 != "property")
+        self.assertFalse(p1 == None)
+        self.assertTrue(p1 != None)
+
+        # Verify that all expected values are accepted at init and
+        # during set and that the value is set as expected.  Also
+        # verify that bad values are rejected both during init and
+        # set.
+        glist = [
+            (None, ""),
+            ("", ""),
+            ("foo", "foo"),
+            (123, "123"),
+            (False, "False"),
+            (TH_PACKAGE, TH_PACKAGE),
+        ]
+        blist = [
+            [],  #
+            {},  # Expect strings; not objects.
+            object(),  #
+        ]
+        self.__verify_init(propcls, "def", glist, blist)
+
+        glist = [
+            (None, ""),  # None should become "".
+            ("", ""),  # "" should equal "".
+            ("foo", "foo"),  # simple strings should match.
+            (123, "123"),  # int should become str.
+            (False, "False"),  # boolean should become str.
+            (TH_PACKAGE, TH_PACKAGE),  # UTF-8 data.
+            ("\xfe", "\xfe")  # Passthrough of 8-bit data.
+            # (That is not valid UTF-8.)
+        ]
+        blist = [
+            [],  #
+            {},  # Other data types or objects not expected.
+            object(),  #
+        ]
+        self.__verify_init(propcls, "def", glist, blist)
+
+        # Verify equality works as expected.
+        eqlist = [
+            # Equal because property names and values match.
+            (("def", ""), ("def", None)),
+            (("def", "bob cat"), ("def", "bob cat")),
+            (("def", TH_PACKAGE), ("def", TH_PACKAGE)),
+        ]
+        nelist = [
+            # Not equal because property names and/or values do not
+            # match.
+            (("def", "bob cat"), ("str2", "bob cat")),
+            (("def", "lynx"), ("str2", "bob cat")),
+            (("def", "ซ"), ("str2", TH_PACKAGE)),
+        ]
+        self.__verify_equality(propcls, eqlist, nelist)
+
+        # Verify base stringify works as expected.
+        self.__verify_stringify(
+            propcls,
+            "property",
+            [(None, ""), ("", ""), (TH_PACKAGE, TH_PACKAGE)],
+        )
+
+        # Verify base copy works as expected.
+        p1 = propcls("p1", "v1")
+        p2 = copy.copy(p1)
+        self.assertEqual(p1.name, p2.name)
+        self.assertEqual(p1.value, p2.value)
+        self.assertNotEqual(id(p1), id(p2))
+
+    def test_bool(self):
+        """Verify boolean properties work as expected."""
+
+        # Verify default if no initial value provided.
+        propcls = cfg.PropBool
+        p = propcls("bool")
+        self.assertEqual(p.value, False)
+
+        # Verify that all expected values are accepted at init and
+        # during set and that the value is set as expected.  Also
+        # verify that bad values are rejected both during init and
+        # set.
+        glist = [
+            (None, False),
+            ("", False),
+            (False, False),
+            ("False", False),
+            ("True", True),
+        ]
+        blist = [("bogus", 123, "-true-", "\n")]
+        self.__verify_init(propcls, "bool", glist, blist)
+
+        # Verify equality works as expected.
+        eqlist = [
+            # Equal because property names and values match.
+            (("bool", True), ("bool", True)),
+            (("bool", "True"), ("bool", True)),
+            (("bool", "true"), ("bool", True)),
+            (("bool", "TrUE"), ("bool", True)),
+            (("bool", False), ("bool", False)),
+            (("bool", "False"), ("bool", False)),
+            (("bool", "false"), ("bool", False)),
+            (("bool", "FaLsE"), ("bool", False)),
+        ]
+        nelist = [
+            # Not equal because property names and/or values do not
+            # match.
+            (("bool", True), ("bool2", True)),
+            (("bool", True), ("bool", False)),
+        ]
+        self.__verify_equality(propcls, eqlist, nelist)
+
+        # Verify stringified form.
+        self.__verify_stringify(
+            propcls, "bool", [(True, "True"), (False, "False")]
+        )
+
+    def test_defined(self):
+        """Verify defined properties work as expected."""
+
+        # Verify default if no initial value provided.
+        propcls = cfg.PropDefined
+        p = propcls("def")
+        self.assertEqual(p.value, "")
+
+        # Verify stringified form.
+        self.__verify_stringify(
+            propcls,
+            "def",
+            [("", ""), ("bob cat", "bob cat"), (TH_PACKAGE, TH_PACKAGE)],
+        )
+
+        # Verify allowed value functionality permits expected values.
+        p = propcls(
+            "def", allowed=["", "<pathname>", "<exec:pathname>", "<smffmri>"]
+        )
+        for v in (
+            "/abs/path",
+            "exec:/my/binary",
+            "svc:/application/pkg/server:default",
+            "",
+        ):
+            p.value = v
+
+        # Verify allowed value functionality denies unexpected values.
+        p = propcls("def", allowed=["<abspathname>"], default="/abs/path")
+        for v in ("not/abs/path", "../also/not/not/abs", ""):
+            self.debug("p: {0}".format(v))
+            self.assertRaises(
+                cfg.InvalidPropertyValueError, setattr, p, "value", v
+            )
+
+    def test_int(self):
+        """Verify integer properties work as expected."""
+
+        # Verify default if no initial value provided.
+        propcls = cfg.PropInt
+        p = propcls("int")
+        self.assertEqual(p.value, 0)
+
+        # Verify that all expected values are accepted at init and
+        # during set and that the value is set as expected.  Also
+        # verify that bad values are rejected both during init and
+        # set.
+        glist = [(None, 0), ("", 0), (1, 1), ("16384", 16384)]
+        blist = [("bogus", "-true-", "\n")]
+        self.__verify_init(propcls, "int", glist, blist)
+
+        # Verify equality works as expected.
+        eqlist = [
+            # Equal because property names and values match.
+            (("int", 0), ("int", 0)),
+            (("int", "16384"), ("int", 16384)),
+        ]
+        nelist = [
+            # Not equal because property names and/or values do not
+            # match.
+            (("int", 256), ("int2", 256)),
+            (("int", 0), ("int", 256)),
+        ]
+        self.__verify_equality(propcls, eqlist, nelist)
+
+        # Verify minimum works as expected.
+        p = propcls("int", minimum=-1)
+        self.assertEqual(p.minimum, -1)
+        self.assertRaises(
+            cfg.InvalidPropertyValueError, setattr, p, "value", -100
+        )
+        p.value = 4294967295
+        self.assertEqual(p.value, 4294967295)
+
+        # Verify maximum works as expected.
+        p = propcls("int", maximum=65535)
+        self.assertEqual(p.maximum, 65535)
+        self.assertRaises(
+            cfg.InvalidPropertyValueError, setattr, p, "value", 42944967295
+        )
+        p.value = 65535
+        self.assertEqual(p.value, 65535)
+
+        # Verify maximum and minimum work together.
+        p = propcls("int", maximum=1, minimum=-1)
+        self.assertRaises(
+            cfg.InvalidPropertyValueError, setattr, p, "value", -2
+        )
+        self.assertRaises(cfg.InvalidPropertyValueError, setattr, p, "value", 2)
+
+        # Verify maximum and minimum are copied when object is.
+        np = copy.copy(p)
+        self.assertEqual(np.maximum, 1)
+        self.assertEqual(np.minimum, -1)
+        self.assertRaises(
+            cfg.InvalidPropertyValueError, setattr, np, "value", -2
+        )
+        self.assertRaises(
+            cfg.InvalidPropertyValueError, setattr, np, "value", 2
+        )
+
+        # Verify stringified form.
+        self.__verify_stringify(
+            propcls, "int", [(0, "0"), (4294967296, "4294967296")]
+        )
+
+    def test_exceptions(self):
+        """Verify that exception classes can be initialized as expected,
+        and when stringified return a non-zero-length string.
         """
 
-        def __verify_init(self, propcls, propname, glist, blist):
-                # 'glist' contains the list of good values to try.
-                for defval, expval in glist:
-                        # Check init.
-                        p = propcls(propname, default=defval)
-                        self.assertEqual(p.value, expval)
-
-                        # Check set.
-                        p = propcls(propname)
-                        p.value = defval
-                        self.assertEqual(p.value, expval)
-
-                # 'blist' contains the list of bad values to try.
-                for badval in blist:
-                        # Check init.
-                        self.assertRaises(cfg.InvalidPropertyValueError,
-                            propcls, propname, default=badval)
-
-                        # Check set.
-                        p = cfg.PropBool(propname)
-                        self.assertRaises(cfg.InvalidPropertyValueError,
-                            setattr, p, "value", badval)
-
-        def __verify_equality(self, propcls, eqlist, nelist):
-                # Check eq.
-                for entry in eqlist:
-                        (p1name, p1def), (p2name, p2def) = entry
-                        p1 = propcls(p1name, default=p1def)
-                        p2 = propcls(p2name, default=p2def)
-                        # This ensures that both __eq__ and __ne__ are tested
-                        # properly.
-                        self.assertTrue(p1 == p2)
-                        self.assertFalse(p1 != p2)
-
-                # Check ne.
-                for entry in nelist:
-                        (p1name, p1def), (p2name, p2def) = entry
-                        p1 = propcls(p1name, default=p1def)
-                        p2 = propcls(p2name, default=p2def)
-                        # This ensures that both __eq__ and __ne__ are tested
-                        # properly.
-                        self.assertTrue(p1 != p2)
-                        self.assertFalse(p1 == p2)
-
-        def __verify_stringify(self, propcls, propname, explist, debug=False):
-                for val, expstr in explist:
-                        # Verify that the stringified form of the property's
-                        # value matches what is expected.
-                        p1 = propcls(propname, default=val)
-                        self.assertEqual(six.text_type(p1), expstr)
-                        if six.PY2:
-                                self.assertEqual(str(p1), expstr.encode("utf-8"))
-                        else:
-                                # str() call in Python 3 must return str (unicode).
-                                self.assertEqual(str(p1), expstr)
-
-                        # Verify that a property value's stringified form
-                        # provides can be parsed into an exact equivalent
-                        # in native form (e.g. list -> string -> list).
-                        p2 = propcls(propname)
-                        p2.value = six.text_type(p1)
-                        self.assertEqual(p1.value, p2.value)
-                        self.assertEqualDiff(str(p1), str(p2))
-
-                        p2.value = str(p1)
-                        self.assertEqual(p1.value, p2.value)
-                        self.assertEqualDiff(str(p1), str(p2))
-
-        def __verify_ex_stringify(self, ex):
-                encs = str(ex)
-                self.assertNotEqual(len(encs), 0)
-                unis = six.text_type(ex)
-                self.assertNotEqual(len(unis), 0)
-                if six.PY2:
-                        self.assertEqualDiff(encs, unis.encode("utf-8"))
-                else:
-                        self.assertEqualDiff(encs, unis)
-
-        def test_base(self):
-                """Verify base property functionality works as expected."""
-
-                propcls = cfg.Property
-
-                # Verify invalid names aren't permitted.
-                for n in ("contains\na new line", "contains\ttab",
-                    "contains/slash", "contains\rcarriage return",
-                    "contains\fform feed", "contains\vvertical tab",
-                    "contains\\backslash", "", TH_PACKAGE):
-                        self.assertRaises(cfg.InvalidPropertyNameError,
-                            propcls, n)
-
-                # Verify spaces are permitted.
-                propcls("has space")
-
-                # Verify property objects are sorted by name and that other
-                # objects are sorted after.
-                plist = [propcls(n) for n in ("c", "d", "a", "b")]
-                plist.extend(["g", "e", "f"])
-                plist.sort()
-                self.assertEqual(
-                    [getattr(p, "name", p) for p in plist],
-                    ["a", "b", "c", "d", "e", "f", "g"]
-                )
-
-                # Verify equality is always False when comparing a property
-                # object to a different object and that objects that are not
-                # properties don't cause a traceback.
-                p1 = propcls("property")
-                self.assertFalse(p1 == "property")
-                self.assertTrue(p1 != "property")
-                self.assertFalse(p1 == None)
-                self.assertTrue(p1 != None)
-
-                # Verify that all expected values are accepted at init and
-                # during set and that the value is set as expected.  Also
-                # verify that bad values are rejected both during init and
-                # set.
-                glist = [(None, ""), ("", ""), ("foo", "foo"), (123, "123"),
-                    (False, "False"), (TH_PACKAGE, TH_PACKAGE)]
-                blist = [
-                    [],         # 
-                    {},         # Expect strings; not objects.
-                    object(),   #
-                ]
-                self.__verify_init(propcls, "def", glist, blist)
-
-                glist = [
-                    (None, ""),                 # None should become "".
-                    ("", ""),                   # "" should equal "".
-                    ("foo", "foo"),             # simple strings should match.
-                    (123, "123"),               # int should become str.
-                    (False, "False"),           # boolean should become str.
-                    (TH_PACKAGE, TH_PACKAGE),   # UTF-8 data.
-                    ("\xfe", "\xfe")            # Passthrough of 8-bit data.
-                                                # (That is not valid UTF-8.)
-                ]
-                blist = [
-                    [],         #
-                    {},         # Other data types or objects not expected.
-                    object()    #       
-                ]
-                self.__verify_init(propcls, "def", glist, blist)
-
-                # Verify equality works as expected.
-                eqlist = [
-                    # Equal because property names and values match.
-                    (("def", ""), ("def", None)),
-                    (("def", "bob cat"), ("def", "bob cat")),
-                    (("def", TH_PACKAGE), ("def", TH_PACKAGE)),
-                ]
-                nelist = [
-                    # Not equal because property names and/or values do not
-                    # match.
-                    (("def", "bob cat"), ("str2", "bob cat")),
-                    (("def", "lynx"), ("str2", "bob cat")),
-                    (("def", u'ซ'), ("str2", TH_PACKAGE)),
-                ]
-                self.__verify_equality(propcls, eqlist, nelist)
-
-
-                # Verify base stringify works as expected.
-                self.__verify_stringify(propcls, "property", [(None, ""),
-                    ("", ""), (TH_PACKAGE, TH_PACKAGE)])
-
-                # Verify base copy works as expected.
-                p1 = propcls("p1", "v1")
-                p2 = copy.copy(p1)
-                self.assertEqual(p1.name, p2.name)
-                self.assertEqual(p1.value, p2.value)
-                self.assertNotEqual(id(p1), id(p2))
-
-        def test_bool(self):
-                """Verify boolean properties work as expected."""
-
-                # Verify default if no initial value provided.
-                propcls = cfg.PropBool
-                p = propcls("bool")
-                self.assertEqual(p.value, False)
-
-                # Verify that all expected values are accepted at init and
-                # during set and that the value is set as expected.  Also
-                # verify that bad values are rejected both during init and
-                # set.
-                glist = [(None, False), ("", False), (False, False),
-                    ("False", False), ("True", True)]
-                blist = [("bogus", 123, "-true-", "\n")]
-                self.__verify_init(propcls, "bool", glist, blist)
-
-                # Verify equality works as expected.
-                eqlist = [
-                    # Equal because property names and values match.
-                    (("bool", True), ("bool", True)),
-                    (("bool", "True"), ("bool", True)),
-                    (("bool", "true"), ("bool", True)),
-                    (("bool", "TrUE"), ("bool", True)),
-                    (("bool", False), ("bool", False)),
-                    (("bool", "False"), ("bool", False)),
-                    (("bool", "false"), ("bool", False)),
-                    (("bool", "FaLsE"), ("bool", False)),
-                ]
-                nelist = [
-                    # Not equal because property names and/or values do not
-                    # match.
-                    (("bool", True), ("bool2", True)),
-                    (("bool", True), ("bool", False)),
-                ]
-                self.__verify_equality(propcls, eqlist, nelist)
-
-                # Verify stringified form.
-                self.__verify_stringify(propcls, "bool", [(True, "True"),
-                    (False, "False")])
-
-        def test_defined(self):
-                """Verify defined properties work as expected."""
-
-                # Verify default if no initial value provided.
-                propcls = cfg.PropDefined
-                p = propcls("def")
-                self.assertEqual(p.value, "")
-
-                # Verify stringified form.
-                self.__verify_stringify(propcls, "def", [("", ""),
-                    ("bob cat", "bob cat"), (TH_PACKAGE, TH_PACKAGE)])
-
-                # Verify allowed value functionality permits expected values.
-                p = propcls("def", allowed=["", "<pathname>", "<exec:pathname>",
-                    "<smffmri>"])
-                for v in ("/abs/path", "exec:/my/binary",
-                    "svc:/application/pkg/server:default", ""):
-                        p.value = v
-
-                # Verify allowed value functionality denies unexpected values.
-                p = propcls("def", allowed=["<abspathname>"],
-                    default="/abs/path")
-                for v in ("not/abs/path", "../also/not/not/abs", ""):
-                        self.debug("p: {0}".format(v))
-                        self.assertRaises(cfg.InvalidPropertyValueError,
-                            setattr, p, "value", v)
-
-        def test_int(self):
-                """Verify integer properties work as expected."""
-
-                # Verify default if no initial value provided.
-                propcls = cfg.PropInt
-                p = propcls("int")
-                self.assertEqual(p.value, 0)
-
-                # Verify that all expected values are accepted at init and
-                # during set and that the value is set as expected.  Also
-                # verify that bad values are rejected both during init and
-                # set.
-                glist = [(None, 0), ("", 0), (1, 1),
-                    ("16384", 16384)]
-                blist = [("bogus", "-true-", "\n")]
-                self.__verify_init(propcls, "int", glist, blist)
-
-                # Verify equality works as expected.
-                eqlist = [
-                    # Equal because property names and values match.
-                    (("int", 0), ("int", 0)),
-                    (("int", "16384"), ("int", 16384)),
-                ]
-                nelist = [
-                    # Not equal because property names and/or values do not
-                    # match.
-                    (("int", 256), ("int2", 256)),
-                    (("int", 0), ("int", 256)),
-                ]
-                self.__verify_equality(propcls, eqlist, nelist)
-
-                # Verify minimum works as expected.
-                p = propcls("int", minimum=-1)
-                self.assertEqual(p.minimum, -1)
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    setattr, p, "value", -100)
-                p.value = 4294967295
-                self.assertEqual(p.value, 4294967295)
-
-                # Verify maximum works as expected.
-                p = propcls("int", maximum=65535)
-                self.assertEqual(p.maximum, 65535)
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    setattr, p, "value", 42944967295)
-                p.value = 65535
-                self.assertEqual(p.value, 65535)
-
-                # Verify maximum and minimum work together.
-                p = propcls("int", maximum=1, minimum=-1)
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    setattr, p, "value", -2)
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    setattr, p, "value", 2)
-
-                # Verify maximum and minimum are copied when object is.
-                np = copy.copy(p)
-                self.assertEqual(np.maximum, 1)
-                self.assertEqual(np.minimum, -1)
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    setattr, np, "value", -2)
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    setattr, np, "value", 2)
-
-                # Verify stringified form.
-                self.__verify_stringify(propcls, "int", [(0, "0"),
-                    (4294967296, "4294967296")])
-
-        def test_exceptions(self):
-                """Verify that exception classes can be initialized as expected,
-                and when stringified return a non-zero-length string.
-                """
-
-                # Verify the expected behavior of all ConfigError classes.
-                for excls in (cfg.PropertyConfigError,
-                    cfg.PropertyMultiValueError,
-                    cfg.InvalidPropertyValueError, cfg.UnknownPropertyError,
-                    cfg.UnknownPropertyValueError, cfg.UnknownSectionError):
-                        # Verify that exception can't be created without
-                        # specifying section or property.
-                        self.assertRaises(AssertionError, excls)
-
-                        # Verify that exception can be created with just
-                        # section or property, or both, and that expected
-                        # value is set.  In addition, verify that the
-                        # stringified form or unicode object is equal
-                        # and not zero-length.
-                        ex1 = excls(section="section")
-                        self.assertEqual(ex1.section, "section")
-
-                        ex2 = excls(prop="property")
-                        self.assertEqual(ex2.prop, "property")
-
-                        ex3 = excls(section="section", prop="property")
-                        self.assertEqual(ex3.section, "section")
-                        self.assertEqual(ex3.prop, "property")
-
-                        if excls == cfg.PropertyConfigError:
-                                # Can't stringify base class.
-                                continue
-                        list(map(self.__verify_ex_stringify, (ex1, ex2, ex3)))
-
-                        if excls != cfg.UnknownPropertyValueError:
-                                continue
-
-                        ex4 = excls(section="section", prop="property",
-                            value="value")
-                        self.assertEqual(ex4.section, "section")
-                        self.assertEqual(ex4.prop, "property")
-                        self.assertEqual(ex4.value, "value")
-                        self.__verify_ex_stringify(ex4)
-
-                for excls in (cfg.InvalidSectionNameError,
-                    cfg.InvalidSectionTemplateNameError):
-                        # Verify that exception can't be created without
-                        # specifying section.
-                        self.assertRaises(AssertionError, excls, None)
-
-                        # Verify that exception can be created with just section
-                        # and that expected value is set.  In addition, verify
-                        # that the stringified form or unicode object is equal
-                        # and not zero-length.
-                        ex1 = excls("section")
-                        self.assertEqual(ex1.section, "section")
-                        self.__verify_ex_stringify(ex1)
-
-                for excls in (cfg.InvalidPropertyNameError,
-                    cfg.InvalidPropertyTemplateNameError):
-                        # Verify that exception can't be created without
-                        # specifying prop.
-                        self.assertRaises(AssertionError, excls, None)
-
-                        # Verify that exception can be created with just prop
-                        # and that expected value is set.  In addition, verify
-                        # that the stringified form or unicode object is equal
-                        # and not zero-length.
-                        ex1 = excls("prop")
-                        self.assertEqual(ex1.prop, "prop")
-                        self.__verify_ex_stringify(ex1)
-
-        def test_list(self):
-                """Verify list properties work as expected."""
-
-                # Verify default if no initial value provided.
-                propcls = cfg.PropList
-                p = propcls("list")
-                self.assertEqual(p.value, [])
-
-                # Verify that all expected values are accepted at init and
-                # during set and that the value is set as expected.  Also
-                # verify that bad values are rejected both during init and
-                # set.
-                glist = [
-                    ([1, 2, None], ["1", "2", ""]),
-                    ([TH_PACKAGE, "bob cat", "profit"], [TH_PACKAGE, "bob cat",
-                        "profit"]),
-                    ([1, "???", "profit"], ["1", "???", "profit"]),
-                    ([False, True, "false"], ["False", "True", "false"]),
-                    ([TH_PACKAGE, "profit"], [TH_PACKAGE, "profit"]),
-                    (["\xfe", "bob cat"], ["\xfe", "bob cat"]),
-                ]
-                blist = [[[]], [{}], [object()], '[__import__("sys").exit(-1)]',
-                    '{}', 123]
-                self.__verify_init(propcls, "list", glist, blist)
-
-                # Verify equality works as expected.
-                eqlist = [
-                    # Equal because property names and values match.
-                    (("list", [None]), ("list", [""])),
-                    (("list", ["box", "cat"]), ("list", ["box", "cat"])),
-                    (("list", [TH_PACKAGE, "profit"]),
-                        ("list", [TH_PACKAGE, "profit"])),
-                ]
-                nelist = [
-                    # Not equal because property names and/or values do not
-                    # match.
-                    (("list", ["bob cat"]), ("list2", ["bob cat"])),
-                    (("list", ["lynx"]), ("list2", ["bob cat"])),
-                    (("list", [TH_PACKAGE]),
-                        ("list", [TH_PACKAGE, "profit"])),
-                ]
-                self.__verify_equality(propcls, eqlist, nelist)
-
-                # Verify stringified form and that stringified form can be used
-                # to set value.
-                if six.PY2:
-                        self.__verify_stringify(propcls, "list", [
-                            ([""], "['']"),
-                            (["box", "cat"], "['box', 'cat']"),
-                            # List literal form uses unicode_escape.
-                            ([TH_PACKAGE, "profit"],
-                                u"[u'{0}', 'profit']".format(
-                                TH_PACKAGE.encode("unicode_escape"))),
-                            (["\xfe", "bob cat"], "['\\xfe', 'bob cat']"),
-                        ])
-                else:
-                        # unicode representation in Python 3 is not using
-                        # escape sequence
-                        self.__verify_stringify(propcls, "list", [
-                            ([""], "['']"),
-                            (["box", "cat"], "['box', 'cat']"),
-                            ([TH_PACKAGE, "profit"],
-                                "['{0}', 'profit']".format(
-                                TH_PACKAGE)),
-                            (["þ", "bob cat"], "['þ', 'bob cat']"),
-                        ])
-
-                # Verify allowed value functionality permits expected values.
-                p = propcls("list", allowed=["", "<pathname>",
-                    "<exec:pathname>", "<smffmri>"])
-                p.value = ["/abs/path", "exec:/my/binary",
-                    "svc:/application/pkg/server:default", ""]
-
-                # Verify allowed value functionality denies unexpected values.
-                p = propcls("list", allowed=["<pathname>"],
-                    default=["/export/repo"])
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    setattr, p, "value", ["exec:/binary", "svc:/application",
-                        ""])
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    setattr, p, "value", [])
-
-                # Verify that any iterable can be used to assign the property's
-                # value and the result will still be a list.
-                p = propcls("list")
-                expected = ["bob cat", "lynx", "tiger"]
-
-                # List.
-                p.value = ["bob cat", "lynx", "tiger"]
-                self.assertEqual(p.value, expected)
-
-                # Set.
-                p.value = set(("bob cat", "lynx", "tiger"))
-                self.assertEqual(p.value, list(set(expected)))
-
-                # Tuple.
-                p.value = ("bob cat", "lynx", "tiger")
-                self.assertEqual(p.value, expected)
-
-                # Generator.
-                p.value = (v for v in expected)
-                self.assertEqual(p.value, expected)
-
-        def test_publisher(self):
-                """Verify publisher properties work as expected."""
-
-                # Verify default if no initial value provided.
-                propcls = cfg.PropPublisher
-                p = propcls("pub")
-                self.assertEqual(p.value, "")
-
-                # Verify that all expected values are accepted at init and
-                # during set and that the value is set as expected.  Also
-                # verify that bad values are rejected both during init and
-                # set.
-                glist = [(None, ""), ("", ""), ("example.com", "example.com"),
-                    ("sub.sub.Example.Com", "sub.sub.Example.Com"),
-                    ("bob-cat", "bob-cat")]
-                blist = [(".startperiod", "!@&*#$&*(@badchars", "\n", object())]
-                self.__verify_init(propcls, "pub", glist, blist)
-
-                # Verify equality works as expected.
-                eqlist = [
-                    # Equal because property names and values match.
-                    (("pub", ""), ("pub", None)),
-                    (("pub", "bobcat"), ("pub", "bobcat")),
-                ]
-                nelist = [
-                    # Not equal because property names and/or values do not
-                    # match.
-                    (("pub", "bobcat"), ("pub2", "bobcat")),
-                    (("pub", "lynx"), ("pub2", "bobcat")),
-                ]
-                self.__verify_equality(propcls, eqlist, nelist)
-
-                # Verify stringified form.
-                self.__verify_stringify(propcls, "int", [("", ""),
-                    ("bobcat", "bobcat")])
-
-        def test_simple_list(self):
-                """Verify simple list properties work as expected."""
-
-                # Verify default if no initial value provided.
-                propcls = cfg.PropSimpleList
-                p = propcls("slist")
-                self.assertEqual(p.value, [])
-
-                # Verify that all expected values are accepted at init and
-                # during set and that the value is set as expected.  Also
-                # verify that bad values are rejected both during init and
-                # set.
-                glist = [
-                    ([1, 2, None], ["1", "2", ""]),
-                    ([TH_PACKAGE, "bob cat", "profit"],
-                        [TH_PACKAGE, "bob cat", "profit"]),
-                    ([1, "???", "profit"], ["1", "???", "profit"]),
-                    ([False, True, "false"], ["False", "True", "false"]),
-                    ([TH_PACKAGE, "profit"], [TH_PACKAGE, "profit"]),
-                ]
-                blist = [
-                    [[]], [{}], [object()], # Objects not expected.
-                    123,                    # Numbers not expected.
-                    [b"\xfe"],              # Arbitrary 8-bit data is not
-                    b"\xfe",                # supported.
-                ]
-
-                self.__verify_init(propcls, "slist", glist, blist)
-
-                # Verify equality works as expected.
-                eqlist = [
-                    # Equal because property names and values match.
-                    (("slist", [None]), ("slist", [""])),
-                    (("slist", ["box", "cat"]), ("slist", ["box", "cat"])),
-                    (("slist", [TH_PACKAGE, "profit"]),
-                        ("slist", [TH_PACKAGE, "profit"])),
-                ]
-                nelist = [
-                    # Not equal because property names and/or values do not
-                    # match.
-                    (("slist", ["bob cat"]), ("slist2", ["bob cat"])),
-                    (("slist", ["lynx"]), ("slist2", ["bob cat"])),
-                    (("slist", [TH_PACKAGE]),
-                        ("slist", [TH_PACKAGE, "profit"])),
-                ]
-                self.__verify_equality(propcls, eqlist, nelist)
-
-                # Verify stringified form (note that a simple list isn't able to
-                # preserve zero-length string values whenever it is the only
-                # value in the list).
-                self.__verify_stringify(propcls, "slist", [
-                    (["box", "cat"], "box,cat"),
-                    ([TH_PACKAGE, "profit"], u'บรรจุภัณฑ์,profit'),
-                ], debug=True)
-
-        def test_puburi(self):
-                """Verify publisher URI properties work as expected."""
-
-                # Verify default if no initial value provided.
-                propcls = cfg.PropPubURI
-                p = propcls("uri")
-                self.assertEqual(p.value, "")
-
-                # Verify that all expected values are accepted at init and
-                # during set and that the value is set as expected.  Also
-                # verify that bad values are rejected both during init and
-                # set.
-                glist = [(None, ""), ("", ""), ("http://example.com/",
-                    "http://example.com/"), ("file:/abspath", "file:/abspath")]
-                blist = ["bogus://", {}, object(), 123, "http://@&*#($badchars",
-                    "http:/baduri", "example.com", {}, []]
-                self.__verify_init(propcls, "str", glist, blist)
-
-                # Verify equality works as expected.
-                eqlist = [
-                    # Equal because property names and values match.
-                    (("uri", ""), ("uri", None)),
-                    (("uri", "http://example.com"),
-                        ("uri", "http://example.com")),
-                ]
-                nelist = [
-                    # Not equal because property names and/or values do not
-                    # match.
-                    (("uri", "http://example.com"),
-                        ("uri2", "http://example.com")),
-                    (("uri", "http://example.org/"),
-                        ("uri", "http://example.net/")),
-                ]
-                self.__verify_equality(propcls, eqlist, nelist)
-
-                # Verify stringified form.
-                self.__verify_stringify(propcls, "uri", [("", ""),
-                    ("http://example.com", "http://example.com"),
-                    ("http://example.org/", "http://example.org/")])
-
-        def test_puburi_list(self):
-                """Verify publisher URI list properties work as expected."""
-
-                propcls = cfg.PropPubURIList
-
-                # Verify default if no initial value provided.
-                p = propcls("uri_list")
-                self.assertEqual(p.value, [])
-
-                # Verify that all expected values are accepted at init and
-                # during set and that the value is set as expected.  Also
-                # verify that bad values are rejected both during init and
-                # set.
-                glist = [(None, []), ("", []), ("['http://example.com/']",
-                    ["http://example.com/"]), (["file:/abspath"],
-                    ["file:/abspath"])]
-                blist = [["bogus://"], [{}], [object()], [123],
-                    ["http://@&*#($badchars"], ["http:/baduri"],
-                    ["example.com"]]
-                self.__verify_init(propcls, "uri_list", glist, blist)
-
-                # Verify equality works as expected.
-                eqlist = [
-                    # Equal because property names and values match.
-                    (("uri_list", ""), ("uri_list", [])),
-                    (("uri_list", ["http://example.com", "file:/abspath"]),
-                        ("uri_list", ["http://example.com", "file:/abspath"])),
-                ]
-                nelist = [
-                    # Not equal because property names and/or values do not
-                    # match.
-                    (("uri_list", ["http://example.com", "file:/abspath"]),
-                        ("uri_list2", ["http://example.com", "file:/abspath"])),
-                    (("uri_list", ["http://example.com", "file:/abspath"]),
-                        ("uri_list", ["http://example.net/"])),
-                ]
-                self.__verify_equality(propcls, eqlist, nelist)
-
-                # Verify stringified form.
-                self.__verify_stringify(propcls, "uri", [("", "[]"),
-                    (["http://example.com", "file:/abspath"],
-                        "['http://example.com', 'file:/abspath']"),
-                    (["file:/abspath"], "['file:/abspath']")])
-
-        def test_simple_puburi_list(self):
-                """Verify publisher URI list properties work as expected."""
-
-                propcls = cfg.PropSimplePubURIList
-
-                # Verify default if no initial value provided.
-                p = propcls("uri_list")
-                self.assertEqual(p.value, [])
-
-                # Verify that all expected values are accepted at init and
-                # during set and that the value is set as expected.  Also
-                # verify that bad values are rejected both during init and
-                # set.
-                glist = [(None, []), ("", []), ("http://example.com/",
-                    ["http://example.com/"]), (["file:/abspath"],
-                    ["file:/abspath"])]
-                blist = [["bogus://"], [{}], [object()], [123],
-                    ["http://@&*#($badchars"], ["http:/baduri"],
-                    ["example.com"]]
-                self.__verify_init(propcls, "uri_list", glist, blist)
-
-                # Verify equality works as expected.
-                eqlist = [
-                    # Equal because property names and values match.
-                    (("uri_list", ""), ("uri_list", [])),
-                    (("uri_list", ["http://example.com", "file:/abspath"]),
-                        ("uri_list", ["http://example.com", "file:/abspath"])),
-                ]
-                nelist = [
-                    # Not equal because property names and/or values do not
-                    # match.
-                    (("uri_list", ["http://example.com", "file:/abspath"]),
-                        ("uri_list2", ["http://example.com", "file:/abspath"])),
-                    (("uri_list", ["http://example.com", "file:/abspath"]),
-                        ("uri_list", ["http://example.net/"])),
-                ]
-                self.__verify_equality(propcls, eqlist, nelist)
-
-                # Verify stringified form.
-                self.__verify_stringify(propcls, "uri", [("", ""),
-                    (["http://example.com", "file:/abspath"],
-                        "http://example.com,file:/abspath"),
-                    (["file:/abspath"], "file:/abspath")])
-
-        def test_uuid(self):
-                """Verify UUID properties work as expected."""
-
-                # Verify default if no initial value provided.
-                propcls = cfg.PropUUID
-                p = propcls("uuid")
-                self.assertEqual(p.value, "")
-
-                # Verify that all expected values are accepted at init and
-                # during set and that the value is set as expected.  Also
-                # verify that bad values are rejected both during init and
-                # set.
-                glist = [(None, ""), ("", ""),
-                    ("16fd2706-8baf-433b-82eb-8c7fada847da",
-                    "16fd2706-8baf-433b-82eb-8c7fada847da")]
-                blist = [[], {}, object(), "16fd2706-8baf-433b-82eb", "123",
-                    "badvalue"]
-                self.__verify_init(propcls, "uuid", glist, blist)
-
-                # Verify equality works as expected.
-                eqlist = [
-                    # Equal because property names and values match.
-                    (("uuid", ""), ("uuid", None)),
-                    (("uuid", "16fd2706-8baf-433b-82eb-8c7fada847da"),
-                        ("uuid", "16fd2706-8baf-433b-82eb-8c7fada847da")),
-                ]
-                nelist = [
-                    # Not equal because property names and/or values do not
-                    # match.
-                    (("uuid", ""), ("uuid2", None)),
-                    (("uuid", "16fd2706-8baf-433b-82eb-8c7fada847da"),
-                        ("uuid", "5a912a99-86dd-cb06-8ff0-b6bdfb74d0f6")),
-                ]
-                self.__verify_equality(propcls, eqlist, nelist)
-
-                # Verify stringified form.
-                self.__verify_stringify(propcls, "str", [("", ""),
-                    ("16fd2706-8baf-433b-82eb-8c7fada847da",
-                    "16fd2706-8baf-433b-82eb-8c7fada847da")])
+        # Verify the expected behavior of all ConfigError classes.
+        for excls in (
+            cfg.PropertyConfigError,
+            cfg.PropertyMultiValueError,
+            cfg.InvalidPropertyValueError,
+            cfg.UnknownPropertyError,
+            cfg.UnknownPropertyValueError,
+            cfg.UnknownSectionError,
+        ):
+            # Verify that exception can't be created without
+            # specifying section or property.
+            self.assertRaises(AssertionError, excls)
+
+            # Verify that exception can be created with just
+            # section or property, or both, and that expected
+            # value is set.  In addition, verify that the
+            # stringified form or unicode object is equal
+            # and not zero-length.
+            ex1 = excls(section="section")
+            self.assertEqual(ex1.section, "section")
+
+            ex2 = excls(prop="property")
+            self.assertEqual(ex2.prop, "property")
+
+            ex3 = excls(section="section", prop="property")
+            self.assertEqual(ex3.section, "section")
+            self.assertEqual(ex3.prop, "property")
+
+            if excls == cfg.PropertyConfigError:
+                # Can't stringify base class.
+                continue
+            list(map(self.__verify_ex_stringify, (ex1, ex2, ex3)))
+
+            if excls != cfg.UnknownPropertyValueError:
+                continue
+
+            ex4 = excls(section="section", prop="property", value="value")
+            self.assertEqual(ex4.section, "section")
+            self.assertEqual(ex4.prop, "property")
+            self.assertEqual(ex4.value, "value")
+            self.__verify_ex_stringify(ex4)
+
+        for excls in (
+            cfg.InvalidSectionNameError,
+            cfg.InvalidSectionTemplateNameError,
+        ):
+            # Verify that exception can't be created without
+            # specifying section.
+            self.assertRaises(AssertionError, excls, None)
+
+            # Verify that exception can be created with just section
+            # and that expected value is set.  In addition, verify
+            # that the stringified form or unicode object is equal
+            # and not zero-length.
+            ex1 = excls("section")
+            self.assertEqual(ex1.section, "section")
+            self.__verify_ex_stringify(ex1)
+
+        for excls in (
+            cfg.InvalidPropertyNameError,
+            cfg.InvalidPropertyTemplateNameError,
+        ):
+            # Verify that exception can't be created without
+            # specifying prop.
+            self.assertRaises(AssertionError, excls, None)
+
+            # Verify that exception can be created with just prop
+            # and that expected value is set.  In addition, verify
+            # that the stringified form or unicode object is equal
+            # and not zero-length.
+            ex1 = excls("prop")
+            self.assertEqual(ex1.prop, "prop")
+            self.__verify_ex_stringify(ex1)
+
+    def test_list(self):
+        """Verify list properties work as expected."""
+
+        # Verify default if no initial value provided.
+        propcls = cfg.PropList
+        p = propcls("list")
+        self.assertEqual(p.value, [])
+
+        # Verify that all expected values are accepted at init and
+        # during set and that the value is set as expected.  Also
+        # verify that bad values are rejected both during init and
+        # set.
+        glist = [
+            ([1, 2, None], ["1", "2", ""]),
+            (
+                [TH_PACKAGE, "bob cat", "profit"],
+                [TH_PACKAGE, "bob cat", "profit"],
+            ),
+            ([1, "???", "profit"], ["1", "???", "profit"]),
+            ([False, True, "false"], ["False", "True", "false"]),
+            ([TH_PACKAGE, "profit"], [TH_PACKAGE, "profit"]),
+            (["\xfe", "bob cat"], ["\xfe", "bob cat"]),
+        ]
+        blist = [
+            [[]],
+            [{}],
+            [object()],
+            '[__import__("sys").exit(-1)]',
+            "{}",
+            123,
+        ]
+        self.__verify_init(propcls, "list", glist, blist)
+
+        # Verify equality works as expected.
+        eqlist = [
+            # Equal because property names and values match.
+            (("list", [None]), ("list", [""])),
+            (("list", ["box", "cat"]), ("list", ["box", "cat"])),
+            (
+                ("list", [TH_PACKAGE, "profit"]),
+                ("list", [TH_PACKAGE, "profit"]),
+            ),
+        ]
+        nelist = [
+            # Not equal because property names and/or values do not
+            # match.
+            (("list", ["bob cat"]), ("list2", ["bob cat"])),
+            (("list", ["lynx"]), ("list2", ["bob cat"])),
+            (("list", [TH_PACKAGE]), ("list", [TH_PACKAGE, "profit"])),
+        ]
+        self.__verify_equality(propcls, eqlist, nelist)
+
+        # Verify stringified form and that stringified form can be used
+        # to set value.
+        if six.PY2:
+            self.__verify_stringify(
+                propcls,
+                "list",
+                [
+                    ([""], "['']"),
+                    (["box", "cat"], "['box', 'cat']"),
+                    # List literal form uses unicode_escape.
+                    (
+                        [TH_PACKAGE, "profit"],
+                        "[u'{0}', 'profit']".format(
+                            TH_PACKAGE.encode("unicode_escape")
+                        ),
+                    ),
+                    (["\xfe", "bob cat"], "['\\xfe', 'bob cat']"),
+                ],
+            )
+        else:
+            # unicode representation in Python 3 is not using
+            # escape sequence
+            self.__verify_stringify(
+                propcls,
+                "list",
+                [
+                    ([""], "['']"),
+                    (["box", "cat"], "['box', 'cat']"),
+                    (
+                        [TH_PACKAGE, "profit"],
+                        "['{0}', 'profit']".format(TH_PACKAGE),
+                    ),
+                    (["þ", "bob cat"], "['þ', 'bob cat']"),
+                ],
+            )
+
+        # Verify allowed value functionality permits expected values.
+        p = propcls(
+            "list", allowed=["", "<pathname>", "<exec:pathname>", "<smffmri>"]
+        )
+        p.value = [
+            "/abs/path",
+            "exec:/my/binary",
+            "svc:/application/pkg/server:default",
+            "",
+        ]
+
+        # Verify allowed value functionality denies unexpected values.
+        p = propcls("list", allowed=["<pathname>"], default=["/export/repo"])
+        self.assertRaises(
+            cfg.InvalidPropertyValueError,
+            setattr,
+            p,
+            "value",
+            ["exec:/binary", "svc:/application", ""],
+        )
+        self.assertRaises(
+            cfg.InvalidPropertyValueError, setattr, p, "value", []
+        )
+
+        # Verify that any iterable can be used to assign the property's
+        # value and the result will still be a list.
+        p = propcls("list")
+        expected = ["bob cat", "lynx", "tiger"]
+
+        # List.
+        p.value = ["bob cat", "lynx", "tiger"]
+        self.assertEqual(p.value, expected)
+
+        # Set.
+        p.value = set(("bob cat", "lynx", "tiger"))
+        self.assertEqual(p.value, list(set(expected)))
+
+        # Tuple.
+        p.value = ("bob cat", "lynx", "tiger")
+        self.assertEqual(p.value, expected)
+
+        # Generator.
+        p.value = (v for v in expected)
+        self.assertEqual(p.value, expected)
+
+    def test_publisher(self):
+        """Verify publisher properties work as expected."""
+
+        # Verify default if no initial value provided.
+        propcls = cfg.PropPublisher
+        p = propcls("pub")
+        self.assertEqual(p.value, "")
+
+        # Verify that all expected values are accepted at init and
+        # during set and that the value is set as expected.  Also
+        # verify that bad values are rejected both during init and
+        # set.
+        glist = [
+            (None, ""),
+            ("", ""),
+            ("example.com", "example.com"),
+            ("sub.sub.Example.Com", "sub.sub.Example.Com"),
+            ("bob-cat", "bob-cat"),
+        ]
+        blist = [(".startperiod", "!@&*#$&*(@badchars", "\n", object())]
+        self.__verify_init(propcls, "pub", glist, blist)
+
+        # Verify equality works as expected.
+        eqlist = [
+            # Equal because property names and values match.
+            (("pub", ""), ("pub", None)),
+            (("pub", "bobcat"), ("pub", "bobcat")),
+        ]
+        nelist = [
+            # Not equal because property names and/or values do not
+            # match.
+            (("pub", "bobcat"), ("pub2", "bobcat")),
+            (("pub", "lynx"), ("pub2", "bobcat")),
+        ]
+        self.__verify_equality(propcls, eqlist, nelist)
+
+        # Verify stringified form.
+        self.__verify_stringify(
+            propcls, "int", [("", ""), ("bobcat", "bobcat")]
+        )
+
+    def test_simple_list(self):
+        """Verify simple list properties work as expected."""
+
+        # Verify default if no initial value provided.
+        propcls = cfg.PropSimpleList
+        p = propcls("slist")
+        self.assertEqual(p.value, [])
+
+        # Verify that all expected values are accepted at init and
+        # during set and that the value is set as expected.  Also
+        # verify that bad values are rejected both during init and
+        # set.
+        glist = [
+            ([1, 2, None], ["1", "2", ""]),
+            (
+                [TH_PACKAGE, "bob cat", "profit"],
+                [TH_PACKAGE, "bob cat", "profit"],
+            ),
+            ([1, "???", "profit"], ["1", "???", "profit"]),
+            ([False, True, "false"], ["False", "True", "false"]),
+            ([TH_PACKAGE, "profit"], [TH_PACKAGE, "profit"]),
+        ]
+        blist = [
+            [[]],
+            [{}],
+            [object()],  # Objects not expected.
+            123,  # Numbers not expected.
+            [b"\xfe"],  # Arbitrary 8-bit data is not
+            b"\xfe",  # supported.
+        ]
+
+        self.__verify_init(propcls, "slist", glist, blist)
+
+        # Verify equality works as expected.
+        eqlist = [
+            # Equal because property names and values match.
+            (("slist", [None]), ("slist", [""])),
+            (("slist", ["box", "cat"]), ("slist", ["box", "cat"])),
+            (
+                ("slist", [TH_PACKAGE, "profit"]),
+                ("slist", [TH_PACKAGE, "profit"]),
+            ),
+        ]
+        nelist = [
+            # Not equal because property names and/or values do not
+            # match.
+            (("slist", ["bob cat"]), ("slist2", ["bob cat"])),
+            (("slist", ["lynx"]), ("slist2", ["bob cat"])),
+            (("slist", [TH_PACKAGE]), ("slist", [TH_PACKAGE, "profit"])),
+        ]
+        self.__verify_equality(propcls, eqlist, nelist)
+
+        # Verify stringified form (note that a simple list isn't able to
+        # preserve zero-length string values whenever it is the only
+        # value in the list).
+        self.__verify_stringify(
+            propcls,
+            "slist",
+            [
+                (["box", "cat"], "box,cat"),
+                ([TH_PACKAGE, "profit"], "บรรจุภัณฑ์,profit"),
+            ],
+            debug=True,
+        )
+
+    def test_puburi(self):
+        """Verify publisher URI properties work as expected."""
+
+        # Verify default if no initial value provided.
+        propcls = cfg.PropPubURI
+        p = propcls("uri")
+        self.assertEqual(p.value, "")
+
+        # Verify that all expected values are accepted at init and
+        # during set and that the value is set as expected.  Also
+        # verify that bad values are rejected both during init and
+        # set.
+        glist = [
+            (None, ""),
+            ("", ""),
+            ("http://example.com/", "http://example.com/"),
+            ("file:/abspath", "file:/abspath"),
+        ]
+        blist = [
+            "bogus://",
+            {},
+            object(),
+            123,
+            "http://@&*#($badchars",
+            "http:/baduri",
+            "example.com",
+            {},
+            [],
+        ]
+        self.__verify_init(propcls, "str", glist, blist)
+
+        # Verify equality works as expected.
+        eqlist = [
+            # Equal because property names and values match.
+            (("uri", ""), ("uri", None)),
+            (("uri", "http://example.com"), ("uri", "http://example.com")),
+        ]
+        nelist = [
+            # Not equal because property names and/or values do not
+            # match.
+            (("uri", "http://example.com"), ("uri2", "http://example.com")),
+            (("uri", "http://example.org/"), ("uri", "http://example.net/")),
+        ]
+        self.__verify_equality(propcls, eqlist, nelist)
+
+        # Verify stringified form.
+        self.__verify_stringify(
+            propcls,
+            "uri",
+            [
+                ("", ""),
+                ("http://example.com", "http://example.com"),
+                ("http://example.org/", "http://example.org/"),
+            ],
+        )
+
+    def test_puburi_list(self):
+        """Verify publisher URI list properties work as expected."""
+
+        propcls = cfg.PropPubURIList
+
+        # Verify default if no initial value provided.
+        p = propcls("uri_list")
+        self.assertEqual(p.value, [])
+
+        # Verify that all expected values are accepted at init and
+        # during set and that the value is set as expected.  Also
+        # verify that bad values are rejected both during init and
+        # set.
+        glist = [
+            (None, []),
+            ("", []),
+            ("['http://example.com/']", ["http://example.com/"]),
+            (["file:/abspath"], ["file:/abspath"]),
+        ]
+        blist = [
+            ["bogus://"],
+            [{}],
+            [object()],
+            [123],
+            ["http://@&*#($badchars"],
+            ["http:/baduri"],
+            ["example.com"],
+        ]
+        self.__verify_init(propcls, "uri_list", glist, blist)
+
+        # Verify equality works as expected.
+        eqlist = [
+            # Equal because property names and values match.
+            (("uri_list", ""), ("uri_list", [])),
+            (
+                ("uri_list", ["http://example.com", "file:/abspath"]),
+                ("uri_list", ["http://example.com", "file:/abspath"]),
+            ),
+        ]
+        nelist = [
+            # Not equal because property names and/or values do not
+            # match.
+            (
+                ("uri_list", ["http://example.com", "file:/abspath"]),
+                ("uri_list2", ["http://example.com", "file:/abspath"]),
+            ),
+            (
+                ("uri_list", ["http://example.com", "file:/abspath"]),
+                ("uri_list", ["http://example.net/"]),
+            ),
+        ]
+        self.__verify_equality(propcls, eqlist, nelist)
+
+        # Verify stringified form.
+        self.__verify_stringify(
+            propcls,
+            "uri",
+            [
+                ("", "[]"),
+                (
+                    ["http://example.com", "file:/abspath"],
+                    "['http://example.com', 'file:/abspath']",
+                ),
+                (["file:/abspath"], "['file:/abspath']"),
+            ],
+        )
+
+    def test_simple_puburi_list(self):
+        """Verify publisher URI list properties work as expected."""
+
+        propcls = cfg.PropSimplePubURIList
+
+        # Verify default if no initial value provided.
+        p = propcls("uri_list")
+        self.assertEqual(p.value, [])
+
+        # Verify that all expected values are accepted at init and
+        # during set and that the value is set as expected.  Also
+        # verify that bad values are rejected both during init and
+        # set.
+        glist = [
+            (None, []),
+            ("", []),
+            ("http://example.com/", ["http://example.com/"]),
+            (["file:/abspath"], ["file:/abspath"]),
+        ]
+        blist = [
+            ["bogus://"],
+            [{}],
+            [object()],
+            [123],
+            ["http://@&*#($badchars"],
+            ["http:/baduri"],
+            ["example.com"],
+        ]
+        self.__verify_init(propcls, "uri_list", glist, blist)
+
+        # Verify equality works as expected.
+        eqlist = [
+            # Equal because property names and values match.
+            (("uri_list", ""), ("uri_list", [])),
+            (
+                ("uri_list", ["http://example.com", "file:/abspath"]),
+                ("uri_list", ["http://example.com", "file:/abspath"]),
+            ),
+        ]
+        nelist = [
+            # Not equal because property names and/or values do not
+            # match.
+            (
+                ("uri_list", ["http://example.com", "file:/abspath"]),
+                ("uri_list2", ["http://example.com", "file:/abspath"]),
+            ),
+            (
+                ("uri_list", ["http://example.com", "file:/abspath"]),
+                ("uri_list", ["http://example.net/"]),
+            ),
+        ]
+        self.__verify_equality(propcls, eqlist, nelist)
+
+        # Verify stringified form.
+        self.__verify_stringify(
+            propcls,
+            "uri",
+            [
+                ("", ""),
+                (
+                    ["http://example.com", "file:/abspath"],
+                    "http://example.com,file:/abspath",
+                ),
+                (["file:/abspath"], "file:/abspath"),
+            ],
+        )
+
+    def test_uuid(self):
+        """Verify UUID properties work as expected."""
+
+        # Verify default if no initial value provided.
+        propcls = cfg.PropUUID
+        p = propcls("uuid")
+        self.assertEqual(p.value, "")
+
+        # Verify that all expected values are accepted at init and
+        # during set and that the value is set as expected.  Also
+        # verify that bad values are rejected both during init and
+        # set.
+        glist = [
+            (None, ""),
+            ("", ""),
+            (
+                "16fd2706-8baf-433b-82eb-8c7fada847da",
+                "16fd2706-8baf-433b-82eb-8c7fada847da",
+            ),
+        ]
+        blist = [[], {}, object(), "16fd2706-8baf-433b-82eb", "123", "badvalue"]
+        self.__verify_init(propcls, "uuid", glist, blist)
+
+        # Verify equality works as expected.
+        eqlist = [
+            # Equal because property names and values match.
+            (("uuid", ""), ("uuid", None)),
+            (
+                ("uuid", "16fd2706-8baf-433b-82eb-8c7fada847da"),
+                ("uuid", "16fd2706-8baf-433b-82eb-8c7fada847da"),
+            ),
+        ]
+        nelist = [
+            # Not equal because property names and/or values do not
+            # match.
+            (("uuid", ""), ("uuid2", None)),
+            (
+                ("uuid", "16fd2706-8baf-433b-82eb-8c7fada847da"),
+                ("uuid", "5a912a99-86dd-cb06-8ff0-b6bdfb74d0f6"),
+            ),
+        ]
+        self.__verify_equality(propcls, eqlist, nelist)
+
+        # Verify stringified form.
+        self.__verify_stringify(
+            propcls,
+            "str",
+            [
+                ("", ""),
+                (
+                    "16fd2706-8baf-433b-82eb-8c7fada847da",
+                    "16fd2706-8baf-433b-82eb-8c7fada847da",
+                ),
+            ],
+        )
 
 
 class TestPropertyTemplate(pkg5unittest.Pkg5TestCase):
-        """Class to test the functionality of the pkg.config PropertyTemplate
-        class.
+    """Class to test the functionality of the pkg.config PropertyTemplate
+    class.
+    """
+
+    def test_base(self):
+        """Verify base property template functionality works as
+        expected.
         """
 
-        def test_base(self):
-                """Verify base property template functionality works as
-                expected.
-                """
+        propcls = cfg.PropertyTemplate
 
-                propcls = cfg.PropertyTemplate
+        # Verify invalid names aren't permitted.
+        for n in ("", re.compile("^$"), "foo.*("):
+            self.assertRaises(cfg.InvalidPropertyTemplateNameError, propcls, n)
 
-                # Verify invalid names aren't permitted.
-                for n in ("", re.compile("^$"), "foo.*("):
-                        self.assertRaises(cfg.InvalidPropertyTemplateNameError,
-                            propcls, n)
+        prop = propcls("^facet\\..*$")
+        self.assertEqual(prop.name, "^facet\\..*$")
 
-                prop = propcls("^facet\\..*$")
-                self.assertEqual(prop.name, "^facet\\..*$")
+    def test_create_match(self):
+        """Verify that create and match operations work as expected."""
 
-        def test_create_match(self):
-                """Verify that create and match operations work as expected."""
+        proptemp = cfg.PropertyTemplate("^facet\\..*$")
 
-                proptemp = cfg.PropertyTemplate("^facet\\..*$")
+        # Verify match will match patterns as expected.
+        self.assertEqual(proptemp.match("facet.devel"), True)
+        self.assertEqual(proptemp.match("facet"), False)
 
-                # Verify match will match patterns as expected.
-                self.assertEqual(proptemp.match("facet.devel"), True)
-                self.assertEqual(proptemp.match("facet"), False)
+        # Verify create raises an assert if name doesn't match
+        # template pattern.
+        self.assertRaises(AssertionError, proptemp.create, "notallowed")
 
-                # Verify create raises an assert if name doesn't match
-                # template pattern.
-                self.assertRaises(AssertionError, proptemp.create, "notallowed")
+        # Verify create returns expected property.
+        expected_props = [
+            ({}, {"value": ""}),
+            (
+                {"prop_type": cfg.Property, "value_map": {"None": None}},
+                {"value": ""},
+            ),
+            ({"default": True, "prop_type": cfg.PropBool}, {"value": True}),
+            (
+                {
+                    "allowed": ["always", "never"],
+                    "default": "never",
+                    "prop_type": cfg.PropDefined,
+                },
+                {"allowed": ["always", "never"], "value": "never"},
+            ),
+        ]
+        for args, exp_attrs in expected_props:
+            proptemp = cfg.PropertyTemplate("name", **args)
+            extype = args.get("prop_type", cfg.Property)
 
-                # Verify create returns expected property.
-                expected_props = [
-                    ({}, { "value": "" }),
-                    ({ "prop_type": cfg.Property, "value_map": { "None": None }
-                        }, { "value": "" } ),
-                    ({ "default": True, "prop_type": cfg.PropBool},
-                        { "value": True }),
-                    ({ "allowed": ["always", "never"], "default": "never",
-                        "prop_type": cfg.PropDefined },
-                        { "allowed": ["always", "never"], "value": "never" }),
-                ]
-                for args, exp_attrs in expected_props:
-                        proptemp = cfg.PropertyTemplate("name", **args)
-                        extype = args.get("prop_type", cfg.Property)
+            prop = proptemp.create("name")
+            self.assertTrue(isinstance(prop, extype))
 
-                        prop = proptemp.create("name")
-                        self.assertTrue(isinstance(prop, extype))
-
-                        for attr in exp_attrs:
-                                self.assertEqual(getattr(prop, attr),
-                                    exp_attrs[attr])
+            for attr in exp_attrs:
+                self.assertEqual(getattr(prop, attr), exp_attrs[attr])
 
 
 class TestPropertySection(pkg5unittest.Pkg5TestCase):
-        """Class to test the functionality of the pkg.config PropertySection
-        classes.
+    """Class to test the functionality of the pkg.config PropertySection
+    classes.
+    """
+
+    def __verify_stringify(self, cls, explist):
+        for val, expstr in explist:
+            self.assertEqual(six.text_type(cls(val)), expstr)
+            if six.PY2:
+                self.assertEqual(str(cls(val)), expstr.encode("utf-8"))
+            else:
+                # str() call in Python 3 must return str (unicode).
+                self.assertEqual(str(cls(val)), expstr)
+
+    def test_base(self):
+        """Verify base section functionality works as expected."""
+
+        seccls = cfg.PropertySection
+
+        # Verify invalid names aren't permitted.
+        for n in (
+            "contains\na new line",
+            "contains\ttab",
+            "contains/slash",
+            "contains\rcarriage return",
+            "contains\fform feed",
+            "contains\vvertical tab",
+            "contains\\backslash",
+            "",
+            TH_PACKAGE,
+            "CONFIGURATION",
+        ):
+            self.assertRaises(cfg.InvalidSectionNameError, seccls, n)
+
+        # Verify spaces are permitted.
+        seccls("has space")
+
+        # Verify section objects are sorted by name and that other
+        # objects are sorted after.
+        slist = [seccls(n) for n in ("c", "d", "a", "b")]
+        slist.extend(["g", "e", "f"])
+        slist.sort()
+        self.assertEqual(
+            [getattr(s, "name", s) for s in slist],
+            ["a", "b", "c", "d", "e", "f", "g"],
+        )
+
+        # Verify equality is always False when comparing a section
+        # object to a different object and that objects that are not
+        # sections don't cause a traceback.
+        s1 = seccls("section")
+        self.assertFalse(s1 == "section")
+        self.assertTrue(s1 != "section")
+        self.assertFalse(s1 == None)
+        self.assertTrue(s1 != None)
+
+        # Verify base stringify works as expected.
+        self.__verify_stringify(seccls, [("section", "section")])
+
+        # Verify base copy works as expected.
+        s1 = seccls("s1")
+        s2 = copy.copy(s1)
+        self.assertEqual(s1.name, s2.name)
+        self.assertNotEqual(id(s1), id(s2))
+
+    def test_add_get_remove_props(self):
+        """Verify add_property, get_property, get_index, get_properties,
+        and remove_property works as expected.
         """
 
-        def __verify_stringify(self, cls, explist):
-                for val, expstr in explist:
-                        self.assertEqual(six.text_type(cls(val)), expstr)
-                        if six.PY2:
-                                self.assertEqual(str(cls(val)), expstr.encode(
-                                    "utf-8"))
-                        else:
-                                # str() call in Python 3 must return str (unicode).
-                                self.assertEqual(str(cls(val)), expstr)
+        propcls = cfg.Property
+        sec = cfg.PropertySection("section")
 
-        def test_base(self):
-                """Verify base section functionality works as expected."""
+        # Verify that attempting to retrieve an unknown property
+        # raises an exception.
+        self.assertRaises(cfg.UnknownPropertyError, sec.get_property, "p1")
 
-                seccls = cfg.PropertySection
+        # Verify that attempting to remove an unknown property raises
+        # an exception.
+        self.assertRaises(cfg.UnknownPropertyError, sec.remove_property, "p1")
 
-                # Verify invalid names aren't permitted.
-                for n in ("contains\na new line", "contains\ttab",
-                    "contains/slash", "contains\rcarriage return",
-                    "contains\fform feed", "contains\vvertical tab",
-                    "contains\\backslash", "", TH_PACKAGE,
-                    "CONFIGURATION"):
-                        self.assertRaises(cfg.InvalidSectionNameError,
-                            seccls, n)
+        # Verify that a property cannot be added twice.
+        p1 = propcls("p1", default="1")
+        sec.add_property(p1)
+        self.assertRaises(AssertionError, sec.add_property, p1)
 
-                # Verify spaces are permitted.
-                seccls("has space")
+        # Verify that get_properties returns expected value.
+        p2 = propcls("p2", default="2")
+        sec.add_property(p2)
+        p3 = propcls("p3", default="3")
+        sec.add_property(p3)
 
-                # Verify section objects are sorted by name and that other
-                # objects are sorted after.
-                slist = [seccls(n) for n in ("c", "d", "a", "b")]
-                slist.extend(["g", "e", "f"])
-                slist.sort()
-                self.assertEqual(
-                    [getattr(s, "name", s) for s in slist],
-                    ["a", "b", "c", "d", "e", "f", "g"]
-                )
+        returned = sorted((p.name, p.value) for p in sec.get_properties())
+        expected = [("p1", "1"), ("p2", "2"), ("p3", "3")]
+        self.assertEqualDiff(returned, expected)
 
-                # Verify equality is always False when comparing a section
-                # object to a different object and that objects that are not
-                # sections don't cause a traceback.
-                s1 = seccls("section")
-                self.assertFalse(s1 == "section")
-                self.assertTrue(s1 != "section")
-                self.assertFalse(s1 == None)
-                self.assertTrue(s1 != None)
-
-                # Verify base stringify works as expected.
-                self.__verify_stringify(seccls, [("section", "section")])
-
-                # Verify base copy works as expected.
-                s1 = seccls("s1")
-                s2 = copy.copy(s1)
-                self.assertEqual(s1.name, s2.name)
-                self.assertNotEqual(id(s1), id(s2))
-
-        def test_add_get_remove_props(self):
-                """Verify add_property, get_property, get_index, get_properties,
-                and remove_property works as expected.
-                """
-
-                propcls = cfg.Property
-                sec = cfg.PropertySection("section")
-
-                # Verify that attempting to retrieve an unknown property
-                # raises an exception.
-                self.assertRaises(cfg.UnknownPropertyError,
-                    sec.get_property, "p1")
-
-                # Verify that attempting to remove an unknown property raises
-                # an exception.
-                self.assertRaises(cfg.UnknownPropertyError,
-                    sec.remove_property, "p1")
-
-                # Verify that a property cannot be added twice.
-                p1 = propcls("p1", default="1")
-                sec.add_property(p1)
-                self.assertRaises(AssertionError, sec.add_property, p1)
-
-                # Verify that get_properties returns expected value.
-                p2 = propcls("p2", default="2")
-                sec.add_property(p2)
-                p3 = propcls("p3", default="3")
-                sec.add_property(p3)
-
-                returned = sorted(
-                    (p.name, p.value)
-                    for p in sec.get_properties()
-                )
-                expected = [("p1", "1"), ("p2", "2"), ("p3", "3")]
-                self.assertEqualDiff(returned, expected)
-
-                # Verify that get_index returns expected value.
-                exp_idx = {
-                    "p1": "1",
-                    "p2": "2",
-                    "p3": "3",
-                }
-                self.assertEqual(sec.get_index(), exp_idx)
+        # Verify that get_index returns expected value.
+        exp_idx = {
+            "p1": "1",
+            "p2": "2",
+            "p3": "3",
+        }
+        self.assertEqual(sec.get_index(), exp_idx)
 
 
 class TestPropertySectionTemplate(pkg5unittest.Pkg5TestCase):
-        """Class to test the functionality of the pkg.config PropertyTemplate
-        class.
+    """Class to test the functionality of the pkg.config PropertyTemplate
+    class.
+    """
+
+    def test_base(self):
+        """Verify base property section template functionality works as
+        expected.
         """
 
-        def test_base(self):
-                """Verify base property section template functionality works as
-                expected.
-                """
+        seccls = cfg.PropertySectionTemplate
 
-                seccls = cfg.PropertySectionTemplate
+        # Verify invalid names aren't permitted.
+        for n in ("", re.compile("^$"), "foo.*("):
+            self.assertRaises(cfg.InvalidSectionTemplateNameError, seccls, n)
 
-                # Verify invalid names aren't permitted.
-                for n in ("", re.compile("^$"), "foo.*("):
-                        self.assertRaises(cfg.InvalidSectionTemplateNameError,
-                            seccls, n)
+        sec = seccls("^authority_.*$")
+        self.assertEqual(sec.name, "^authority_.*$")
 
-                sec = seccls("^authority_.*$")
-                self.assertEqual(sec.name, "^authority_.*$")
+    def test_create_match(self):
+        """Verify that create and match operations work as expected."""
 
-        def test_create_match(self):
-                """Verify that create and match operations work as expected."""
+        sectemp = cfg.PropertySectionTemplate("^authority_.*$")
 
-                sectemp = cfg.PropertySectionTemplate("^authority_.*$")
+        # Verify match will match patterns as expected.
+        self.assertEqual(sectemp.match("authority_example.com"), True)
+        self.assertEqual(sectemp.match("authority"), False)
 
-                # Verify match will match patterns as expected.
-                self.assertEqual(sectemp.match("authority_example.com"), True)
-                self.assertEqual(sectemp.match("authority"), False)
+        # Verify create raises an assert if name doesn't match
+        # template pattern.
+        self.assertRaises(AssertionError, sectemp.create, "notallowed")
 
-                # Verify create raises an assert if name doesn't match
-                # template pattern.
-                self.assertRaises(AssertionError, sectemp.create, "notallowed")
+        # Verify create returns expected section.
+        exp_props = [
+            cfg.Property("prop"),
+            cfg.PropBool("bool"),
+            cfg.PropList("list"),
+            cfg.PropertyTemplate("multi_value", prop_type=cfg.PropList),
+        ]
+        sectemp = cfg.PropertySectionTemplate("name", properties=exp_props)
+        sec = sectemp.create("name")
+        self.assertTrue(isinstance(sec, cfg.PropertySection))
 
-                # Verify create returns expected section.
-                exp_props = [
-                    cfg.Property("prop"),
-                    cfg.PropBool("bool"),
-                    cfg.PropList("list"),
-                    cfg.PropertyTemplate("multi_value", prop_type=cfg.PropList),
-                ]
-                sectemp = cfg.PropertySectionTemplate("name",
-                    properties=exp_props)
-                sec = sectemp.create("name")
-                self.assertTrue(isinstance(sec, cfg.PropertySection))
-
-                expected = sorted([
-                    (p.name, type(p)) for p in exp_props
-                ])
-                returned = sorted([
-                    (p.name, type(p)) for p in sec.get_properties()
-                ])
-                self.assertEqualDiff(expected, returned)
+        expected = sorted([(p.name, type(p)) for p in exp_props])
+        returned = sorted([(p.name, type(p)) for p in sec.get_properties()])
+        self.assertEqualDiff(expected, returned)
 
 
 class _TestConfigBase(pkg5unittest.Pkg5TestCase):
-
-        _defs = {
-            0: [cfg.PropertySection("first_section", properties=[
+    _defs = {
+        0: [
+            cfg.PropertySection(
+                "first_section",
+                properties=[
                     cfg.PropBool("bool_basic"),
                     cfg.PropBool("bool_default", default=True),
                     cfg.PropInt("int_basic"),
                     cfg.PropInt("int_default", default=14400),
                     cfg.PropPublisher("publisher_basic"),
-                    cfg.PropPublisher("publisher_default",
-                        default="example.com"),
+                    cfg.PropPublisher(
+                        "publisher_default", default="example.com"
+                    ),
                     cfg.Property("str_basic"),
-                    cfg.Property("str_escape", default=";, &, (, ), |, ^, <, "
-                        ">, nl\n, sp , tab\t, bs\\, ', \", `"),
+                    cfg.Property(
+                        "str_escape",
+                        default=";, &, (, ), |, ^, <, "
+                        ">, nl\n, sp , tab\t, bs\\, ', \", `",
+                    ),
                     cfg.Property("str_default", default=TH_PACKAGE),
-                    cfg.PropDefined("str_allowed", allowed=["<pathname>",
-                        "<exec:pathname>", "<smffmri>", "builtin"],
-                        default="builtin"),
+                    cfg.PropDefined(
+                        "str_allowed",
+                        allowed=[
+                            "<pathname>",
+                            "<exec:pathname>",
+                            "<smffmri>",
+                            "builtin",
+                        ],
+                        default="builtin",
+                    ),
                     cfg.PropDefined("str_noneallowed", allowed=["", "bob cat"]),
                     cfg.PropList("list_basic"),
-                    cfg.PropList("list_default", default=[TH_PACKAGE, "bob cat",
-                        "profit"]),
-                    cfg.PropList("list_allowed", allowed=["<pathname>",
-                        "builtin"], default=["builtin"]),
-                    cfg.PropList("list_noneallowed", allowed=["", "always",
-                        "never"]),
-                ]),
-                cfg.PropertySection("second_section", properties=[
-                    cfg.PropSimpleList("simple_list_basic"),
-                    cfg.PropSimpleList("simple_list_default", default=["bar",
-                        "foo", TH_PACKAGE]),
-                    cfg.PropSimpleList("simple_list_allowed",
+                    cfg.PropList(
+                        "list_default",
+                        default=[TH_PACKAGE, "bob cat", "profit"],
+                    ),
+                    cfg.PropList(
+                        "list_allowed",
                         allowed=["<pathname>", "builtin"],
-                        default=["builtin"]),
-                    cfg.PropSimpleList("simple_list_noneallowed",
-                        allowed=["", "<pathname>", "builtin"]),
+                        default=["builtin"],
+                    ),
+                    cfg.PropList(
+                        "list_noneallowed", allowed=["", "always", "never"]
+                    ),
+                ],
+            ),
+            cfg.PropertySection(
+                "second_section",
+                properties=[
+                    cfg.PropSimpleList("simple_list_basic"),
+                    cfg.PropSimpleList(
+                        "simple_list_default",
+                        default=["bar", "foo", TH_PACKAGE],
+                    ),
+                    cfg.PropSimpleList(
+                        "simple_list_allowed",
+                        allowed=["<pathname>", "builtin"],
+                        default=["builtin"],
+                    ),
+                    cfg.PropSimpleList(
+                        "simple_list_noneallowed",
+                        allowed=["", "<pathname>", "builtin"],
+                    ),
                     cfg.PropPubURI("uri_basic"),
-                    cfg.PropPubURI("uri_default",
-                        default="http://example.com/"),
+                    cfg.PropPubURI(
+                        "uri_default", default="http://example.com/"
+                    ),
                     cfg.PropSimplePubURIList("urilist_basic"),
-                    cfg.PropSimplePubURIList("urilist_default",
-                        default=["http://example.com/", "file:/example/path"]),
+                    cfg.PropSimplePubURIList(
+                        "urilist_default",
+                        default=["http://example.com/", "file:/example/path"],
+                    ),
                     cfg.PropUUID("uuid_basic"),
-                    cfg.PropUUID("uuid_default",
-                        default="16fd2706-8baf-433b-82eb-8c7fada847da"),
-                ]),
-            ],
-            1: [cfg.PropertySection("first_section", properties=[
+                    cfg.PropUUID(
+                        "uuid_default",
+                        default="16fd2706-8baf-433b-82eb-8c7fada847da",
+                    ),
+                ],
+            ),
+        ],
+        1: [
+            cfg.PropertySection(
+                "first_section",
+                properties=[
                     cfg.PropBool("bool_basic"),
                     cfg.Property("str_basic"),
-                ]),
-            ],
-        }
+                ],
+            ),
+        ],
+    }
 
-        _templated_defs = {
-            0: [cfg.PropertySection("facet", properties=[
+    _templated_defs = {
+        0: [
+            cfg.PropertySection(
+                "facet",
+                properties=[
                     cfg.PropertyTemplate("^facet\\..*", prop_type=cfg.PropBool)
-                ]),
-            ],
-            1: [cfg.PropertySectionTemplate("^authority_.*", properties=[
-                    cfg.PropPublisher("prefix")
-                ])
-            ],
-        }
+                ],
+            ),
+        ],
+        1: [
+            cfg.PropertySectionTemplate(
+                "^authority_.*", properties=[cfg.PropPublisher("prefix")]
+            )
+        ],
+    }
 
-        _initial_state = {
-            0: {
-                "first_section": {
-                    "bool_basic": False,
-                    "bool_default": True,
-                    "int_basic": 0,
-                    "int_default": 14400,
-                    "publisher_basic": "",
-                    "publisher_default": "example.com",
-                    "str_basic": "",
-                    "str_escape": ";, &, (, ), |, ^, <, >, nl\n, sp , tab\t, " \
-                        "bs\\, ', \", `",
-                    "str_default": TH_PACKAGE,
-                    "str_allowed": "builtin",
-                    "str_noneallowed": "",
-                    "list_basic": [],
-                    "list_default": [TH_PACKAGE, "bob cat", "profit"],
-                    "list_allowed": ["builtin"],
-                    "list_noneallowed": [],
-                },
-                "second_section": {
-                    "simple_list_basic": [],
-                    "simple_list_default": ["bar", "foo", TH_PACKAGE],
-                    "simple_list_allowed": ["builtin"],
-                    "simple_list_noneallowed": [],
-                    "uri_basic": "",
-                    "uri_default": "http://example.com/",
-                    "urilist_basic": [],
-                    "urilist_default": ["http://example.com/",
-                        "file:/example/path"],
-                    "uuid_basic": "",
-                    "uuid_default": "16fd2706-8baf-433b-82eb-8c7fada847da",
-                },
+    _initial_state = {
+        0: {
+            "first_section": {
+                "bool_basic": False,
+                "bool_default": True,
+                "int_basic": 0,
+                "int_default": 14400,
+                "publisher_basic": "",
+                "publisher_default": "example.com",
+                "str_basic": "",
+                "str_escape": ";, &, (, ), |, ^, <, >, nl\n, sp , tab\t, "
+                "bs\\, ', \", `",
+                "str_default": TH_PACKAGE,
+                "str_allowed": "builtin",
+                "str_noneallowed": "",
+                "list_basic": [],
+                "list_default": [TH_PACKAGE, "bob cat", "profit"],
+                "list_allowed": ["builtin"],
+                "list_noneallowed": [],
             },
-            1: {
-                "first_section": {
-                    "bool_basic": False,
-                    "str_basic": "",
-                },
+            "second_section": {
+                "simple_list_basic": [],
+                "simple_list_default": ["bar", "foo", TH_PACKAGE],
+                "simple_list_allowed": ["builtin"],
+                "simple_list_noneallowed": [],
+                "uri_basic": "",
+                "uri_default": "http://example.com/",
+                "urilist_basic": [],
+                "urilist_default": [
+                    "http://example.com/",
+                    "file:/example/path",
+                ],
+                "uuid_basic": "",
+                "uuid_default": "16fd2706-8baf-433b-82eb-8c7fada847da",
             },
-        }
+        },
+        1: {
+            "first_section": {
+                "bool_basic": False,
+                "str_basic": "",
+            },
+        },
+    }
 
-        def _verify_initial_state(self, conf, exp_version, ver_defs=None,
-            exp_state=None):
-                if ver_defs is None:
-                        try:
-                                ver_defs = self._defs[exp_version]
-                        except:
-                                raise RuntimeError("Version not found in "
-                                    "definitions.")
-                if exp_state is None:
-                        exp_state = self._initial_state[exp_version]
+    def _verify_initial_state(
+        self, conf, exp_version, ver_defs=None, exp_state=None
+    ):
+        if ver_defs is None:
+            try:
+                ver_defs = self._defs[exp_version]
+            except:
+                raise RuntimeError("Version not found in " "definitions.")
+        if exp_state is None:
+            exp_state = self._initial_state[exp_version]
 
-                conf_idx = conf.get_index()
-                self.assertEqual(conf.version, exp_version)
-                self.assertEqualDiff(exp_state, conf_idx)
+        conf_idx = conf.get_index()
+        self.assertEqual(conf.version, exp_version)
+        self.assertEqualDiff(exp_state, conf_idx)
 
-                # Map out the type of each section and property returned and
-                # verify that if it exists in the definition that the type
-                # matches.
-                def iter_section(parent, spath):
-                        # Yield any properties for this section.
-                        for prop in parent.get_properties():
-                                yield spath, type(parent), prop.name, type(prop)
+        # Map out the type of each section and property returned and
+        # verify that if it exists in the definition that the type
+        # matches.
+        def iter_section(parent, spath):
+            # Yield any properties for this section.
+            for prop in parent.get_properties():
+                yield spath, type(parent), prop.name, type(prop)
 
-                        if not hasattr(parent, "get_sections"):
-                                # Class doesn't support subsections.
-                                return
+            if not hasattr(parent, "get_sections"):
+                # Class doesn't support subsections.
+                return
 
-                        # Yield subsections.
-                        for secobj in parent.get_sections():
-                                for rval in iter_section(secobj,
-                                    "/".join((spath, secobj.name))):
-                                        yield rval
+            # Yield subsections.
+            for secobj in parent.get_sections():
+                for rval in iter_section(
+                    secobj, "/".join((spath, secobj.name))
+                ):
+                    yield rval
 
-                def map_types(slist):
-                        tmap = {}
-                        for secobj in slist:
-                                for spath, stype, pname, ptype in iter_section(
-                                    secobj, secobj.name):
-                                        tmap.setdefault(spath, {
-                                            "type": stype,
-                                            "props": {},
-                                        })
-                                        tmap[spath]["props"][pname] = ptype
-                        return tmap
+        def map_types(slist):
+            tmap = {}
+            for secobj in slist:
+                for spath, stype, pname, ptype in iter_section(
+                    secobj, secobj.name
+                ):
+                    tmap.setdefault(
+                        spath,
+                        {
+                            "type": stype,
+                            "props": {},
+                        },
+                    )
+                    tmap[spath]["props"][pname] = ptype
+            return tmap
 
-                if not ver_defs:
-                        # No version definitions to compare.
-                        return
+        if not ver_defs:
+            # No version definitions to compare.
+            return
 
-                exp_types = map_types(ver_defs)
-                act_types = map_types(conf.get_sections())
-                self.assertEqualDiff(exp_types, act_types)
+        exp_types = map_types(ver_defs)
+        act_types = map_types(conf.get_sections())
+        self.assertEqualDiff(exp_types, act_types)
+
 
 class TestConfig(_TestConfigBase):
-        """Class to test the functionality of the pkg.config 'flat'
-        configuration classes.
-        """
+    """Class to test the functionality of the pkg.config 'flat'
+    configuration classes.
+    """
 
-        _initial_files = {
-            0: u"""\
+    _initial_files = {
+        0: """\
 [CONFIGURATION]
 version = 0
 
@@ -1207,529 +1420,613 @@ urilist_basic =
 urilist_default = http://example.com/,file:/example/path
 uuid_basic = 
 uuid_default = 16fd2706-8baf-433b-82eb-8c7fada847da
-""".format(uni_escape=TH_PACKAGE.encode("unicode_escape") if six.PY2 else TH_PACKAGE,
-    uni_txt=TH_PACKAGE),
-            1: """\
+""".format(
+            uni_escape=TH_PACKAGE.encode("unicode_escape")
+            if six.PY2
+            else TH_PACKAGE,
+            uni_txt=TH_PACKAGE,
+        ),
+        1: """\
 [CONFIGURATION]
 version = 1
 
 [first_section]
 bool_basic = False
 str_basic =
-"""
+""",
+    }
+
+    def test_base(self):
+        """Verify that the base Config class functionality works as
+        expected.
+        """
+
+        # Verify that write() doesn't raise an error for base Config
+        # class (it should be a no-op).
+        conf = cfg.Config()
+        conf.set_property("section", "property", "value")
+        conf.write()
+
+        #
+        # Verify initial state of Config object.
+        #
+
+        # Verify no definitions, overrides, or version.
+        conf = cfg.Config()
+        self._verify_initial_state(conf, 0, {}, exp_state={})
+
+        # Same as above, but with version.
+        conf = cfg.Config(version=1)
+        self._verify_initial_state(conf, 1, {}, exp_state={})
+
+        # Verify no definitions with overrides.
+        overrides = {
+            "first_section": {
+                "bool_basic": "False",
+            },
         }
+        conf = cfg.Config(overrides=overrides)
+        self._verify_initial_state(conf, 0, {}, exp_state=overrides)
 
-        def test_base(self):
-                """Verify that the base Config class functionality works as
-                expected.
-                """
+        # Verify with no overrides and no version (max version found in
+        # _defs should be used).
+        conf = cfg.Config(definitions=self._defs)
+        self._verify_initial_state(conf, 1)
 
-                # Verify that write() doesn't raise an error for base Config
-                # class (it should be a no-op).
-                conf = cfg.Config()
-                conf.set_property("section", "property", "value")
-                conf.write()
+        # Verify with no overrides and with version.
+        conf = cfg.Config(definitions=self._defs, version=0)
+        self._verify_initial_state(conf, 0)
 
-                #
-                # Verify initial state of Config object.
-                #
+        # Verify with overrides using native values (as opposed to
+        # string values) and with version.
+        overrides = {
+            "first_section": {
+                "bool_basic": True,
+                "int_basic": 14400,
+            },
+            "second_section": {
+                "uri_basic": "http://example.net/",
+            },
+        }
+        conf = cfg.Config(
+            definitions=self._defs, overrides=overrides, version=0
+        )
+        exp_state = copy.deepcopy(self._initial_state[0])
+        for sname, props in six.iteritems(overrides):
+            for pname, value in six.iteritems(props):
+                exp_state[sname][pname] = value
+        self._verify_initial_state(conf, 0, exp_state=exp_state)
 
-                # Verify no definitions, overrides, or version.
-                conf = cfg.Config()
-                self._verify_initial_state(conf, 0, {},
-                    exp_state={})
+        #
+        # Verify stringify behaviour.
+        #
 
-                # Same as above, but with version.
-                conf = cfg.Config(version=1)
-                self._verify_initial_state(conf, 1, {},
-                    exp_state={})
-
-                # Verify no definitions with overrides.
-                overrides = {
-                    "first_section": {
-                        "bool_basic": "False",
-                    },
-                }
-                conf = cfg.Config(overrides=overrides)
-                self._verify_initial_state(conf, 0, {},
-                    exp_state=overrides)
-
-                # Verify with no overrides and no version (max version found in
-                # _defs should be used).
-                conf = cfg.Config(definitions=self._defs)
-                self._verify_initial_state(conf, 1)
-
-                # Verify with no overrides and with version.
-                conf = cfg.Config(definitions=self._defs, version=0)
-                self._verify_initial_state(conf, 0)
-
-                # Verify with overrides using native values (as opposed to
-                # string values) and with version.
-                overrides = {
-                    "first_section": {
-                        "bool_basic": True,
-                        "int_basic": 14400,
-                    },
-                    "second_section": {
-                        "uri_basic": "http://example.net/",
-                    },
-                }
-                conf = cfg.Config(definitions=self._defs, overrides=overrides,
-                    version=0)
-                exp_state = copy.deepcopy(self._initial_state[0])
-                for sname, props in six.iteritems(overrides):
-                        for pname, value in six.iteritems(props):
-                                exp_state[sname][pname] = value
-                self._verify_initial_state(conf, 0, exp_state=exp_state)
-
-                #
-                # Verify stringify behaviour.
-                #
-
-                #
-                # Test str case with and without unicode data.
-                #
-                conf = cfg.Config(definitions=self._defs, version=1)
-                self.assertEqualDiff("""\
+        #
+        # Test str case with and without unicode data.
+        #
+        conf = cfg.Config(definitions=self._defs, version=1)
+        self.assertEqualDiff(
+            """\
 [first_section]
 bool_basic = False
 str_basic = 
 
-""", str(conf))
+""",
+            str(conf),
+        )
 
-                conf.set_property("first_section", "str_basic", TH_PACKAGE)
-                if six.PY2:
-                        self.assertEqualDiff("""\
+        conf.set_property("first_section", "str_basic", TH_PACKAGE)
+        if six.PY2:
+            self.assertEqualDiff(
+                """\
 [first_section]
 bool_basic = False
 str_basic = {0}
 
-""".format(TH_PACKAGE.encode("utf-8")), str(conf))
-                else:
-                        # str() must return str (unicode) in Python 3.
-                        self.assertEqualDiff("""\
+""".format(
+                    TH_PACKAGE.encode("utf-8")
+                ),
+                str(conf),
+            )
+        else:
+            # str() must return str (unicode) in Python 3.
+            self.assertEqualDiff(
+                """\
 [first_section]
 bool_basic = False
 str_basic = {0}
 
-""".format(TH_PACKAGE), str(conf))
+""".format(
+                    TH_PACKAGE
+                ),
+                str(conf),
+            )
 
-                #
-                # Test unicode case with and without unicode data.
-                #
-                conf = cfg.Config(definitions=self._defs, version=1)
-                self.assertEqualDiff(u"""\
+        #
+        # Test unicode case with and without unicode data.
+        #
+        conf = cfg.Config(definitions=self._defs, version=1)
+        self.assertEqualDiff(
+            """\
 [first_section]
 bool_basic = False
 str_basic = 
 
-""", six.text_type(conf))
+""",
+            six.text_type(conf),
+        )
 
-                conf.set_property("first_section", "str_basic", TH_PACKAGE)
-                self.assertEqualDiff(u"""\
+        conf.set_property("first_section", "str_basic", TH_PACKAGE)
+        self.assertEqualDiff(
+            """\
 [first_section]
 bool_basic = False
 str_basic = {0}
 
-""".format(TH_PACKAGE), six.text_type(conf))
-        
-                # Verify target is None.
-                self.assertEqual(conf.target, None)
+""".format(
+                TH_PACKAGE
+            ),
+            six.text_type(conf),
+        )
 
-        def test_add_get_remove_sections(self):
-                """Verify that add_section, get_section, get_sections, and
-                get_index work as expected.
-                """
+        # Verify target is None.
+        self.assertEqual(conf.target, None)
 
-                propcls = cfg.Property
-                conf = cfg.Config()
+    def test_add_get_remove_sections(self):
+        """Verify that add_section, get_section, get_sections, and
+        get_index work as expected.
+        """
 
-                # Verify that attempting to retrieve an unknown section raises
-                # an exception.
-                self.assertRaises(cfg.UnknownSectionError, conf.get_section,
-                    "s1")
+        propcls = cfg.Property
+        conf = cfg.Config()
 
-                # Verify that attempting to remove an unknown section raises
-                # an exception.
-                self.assertRaises(cfg.UnknownSectionError, conf.remove_section,
-                    "s1")
+        # Verify that attempting to retrieve an unknown section raises
+        # an exception.
+        self.assertRaises(cfg.UnknownSectionError, conf.get_section, "s1")
 
-                # Verify that a section cannot be added twice.
-                seccls = cfg.PropertySection
-                s1 = seccls("s1", properties=[
-                   propcls("1p1", "11"),
-                   propcls("1p2", "12"),
-                   propcls("1p3", "13"),
-                ])
-                conf.add_section(s1)
-                self.assertRaises(AssertionError, conf.add_section, s1)
-                self.assertEqual(id(s1), id(conf.get_section(s1.name)))
+        # Verify that attempting to remove an unknown section raises
+        # an exception.
+        self.assertRaises(cfg.UnknownSectionError, conf.remove_section, "s1")
 
-                # Verify that get_sections returns expected value.
-                s2 = seccls("s2", properties=[
-                   propcls("2p1", "21"),
-                   propcls("2p2", "22"),
-                   propcls("2p3", "23"),
-                ])
-                conf.add_section(s2)
+        # Verify that a section cannot be added twice.
+        seccls = cfg.PropertySection
+        s1 = seccls(
+            "s1",
+            properties=[
+                propcls("1p1", "11"),
+                propcls("1p2", "12"),
+                propcls("1p3", "13"),
+            ],
+        )
+        conf.add_section(s1)
+        self.assertRaises(AssertionError, conf.add_section, s1)
+        self.assertEqual(id(s1), id(conf.get_section(s1.name)))
 
-                s3 = seccls("s3", properties=[
-                   propcls("3p1", "31"),
-                   propcls("3p2", "32"),
-                   propcls("3p3", "33"),
-                ])
-                conf.add_section(s3)
+        # Verify that get_sections returns expected value.
+        s2 = seccls(
+            "s2",
+            properties=[
+                propcls("2p1", "21"),
+                propcls("2p2", "22"),
+                propcls("2p3", "23"),
+            ],
+        )
+        conf.add_section(s2)
 
-                returned = sorted(s.name for s in conf.get_sections())
-                expected = ["s1", "s2", "s3"]
-                self.assertEqualDiff(returned, expected)
+        s3 = seccls(
+            "s3",
+            properties=[
+                propcls("3p1", "31"),
+                propcls("3p2", "32"),
+                propcls("3p3", "33"),
+            ],
+        )
+        conf.add_section(s3)
 
-                # Verify that get_index returns expected value.
-                exp_idx = {
-                    "s1": {
-                        "1p1": "11",
-                        "1p2": "12",
-                        "1p3": "13",
-                    },
-                    "s2": {
-                        "2p1": "21",
-                        "2p2": "22",
-                        "2p3": "23",
-                    },
-                    "s3": {
-                        "3p1": "31",
-                        "3p2": "32",
-                        "3p3": "33",
-                    },
-                }
-                self.assertEqual(conf.get_index(), exp_idx)
+        returned = sorted(s.name for s in conf.get_sections())
+        expected = ["s1", "s2", "s3"]
+        self.assertEqualDiff(returned, expected)
 
-        def test_file_read_write(self):
-                """Verify that read and write works as expected for
-                FileConfig.
-                """
+        # Verify that get_index returns expected value.
+        exp_idx = {
+            "s1": {
+                "1p1": "11",
+                "1p2": "12",
+                "1p3": "13",
+            },
+            "s2": {
+                "2p1": "21",
+                "2p2": "22",
+                "2p3": "23",
+            },
+            "s3": {
+                "3p1": "31",
+                "3p2": "32",
+                "3p3": "33",
+            },
+        }
+        self.assertEqual(conf.get_index(), exp_idx)
 
-                # Verify configuration files missing state can still be loaded.
-                content = """\
+    def test_file_read_write(self):
+        """Verify that read and write works as expected for
+        FileConfig.
+        """
+
+        # Verify configuration files missing state can still be loaded.
+        content = """\
 [first_section]
 str_basic = bob cat
 """
-                scpath = self.make_misc_files({ "cfg_cache": content })[0]
-                conf = cfg.FileConfig(scpath, definitions=self._defs)
+        scpath = self.make_misc_files({"cfg_cache": content})[0]
+        conf = cfg.FileConfig(scpath, definitions=self._defs)
 
-                # Verify target matches specified path.
-                self.assertEqual(conf.target, scpath)
+        # Verify target matches specified path.
+        self.assertEqual(conf.target, scpath)
 
-                self.assertEqual(conf.version, 1) # Newest version assumed.
-                self.assertEqual(conf.get_property("first_section",
-                    "str_basic"), "bob cat")
-                portable.remove(scpath)
+        self.assertEqual(conf.version, 1)  # Newest version assumed.
+        self.assertEqual(
+            conf.get_property("first_section", "str_basic"), "bob cat"
+        )
+        portable.remove(scpath)
 
-                # Verify configuration files with unknown sections or properties
-                # can still be loaded.
-                content = u"""\
+        # Verify configuration files with unknown sections or properties
+        # can still be loaded.
+        content = """\
 [CONFIGURATION]
 version = 0
 
 [unknown_section]
 unknown_property = {0}
-""".format(TH_PACKAGE)
-                scpath = self.make_misc_files({ "cfg_cache": content })[0]
-                conf = cfg.FileConfig(scpath, definitions=self._defs)
-                self.assertEqual(conf.version, 0)
-                self.assertEqual(conf.get_property("unknown_section",
-                    "unknown_property"), TH_PACKAGE)
-                portable.remove(scpath)
+""".format(
+            TH_PACKAGE
+        )
+        scpath = self.make_misc_files({"cfg_cache": content})[0]
+        conf = cfg.FileConfig(scpath, definitions=self._defs)
+        self.assertEqual(conf.version, 0)
+        self.assertEqual(
+            conf.get_property("unknown_section", "unknown_property"), TH_PACKAGE
+        )
+        portable.remove(scpath)
 
-                # Verify configuration files with unknown versions can still be
-                # loaded.
-                content = u"""\
+        # Verify configuration files with unknown versions can still be
+        # loaded.
+        content = """\
 [CONFIGURATION]
 version = 2
 
 [new_section]
 new_property = {0}
-""".format(TH_PACKAGE)
-                scpath = self.make_misc_files({ "cfg_cache": content })[0]
-                conf = cfg.FileConfig(scpath, definitions=self._defs)
-                self.assertEqual(conf.version, 2)
-                self.assertEqual(conf.get_property("new_section",
-                    "new_property"), TH_PACKAGE)
-                portable.remove(scpath)
+""".format(
+            TH_PACKAGE
+        )
+        scpath = self.make_misc_files({"cfg_cache": content})[0]
+        conf = cfg.FileConfig(scpath, definitions=self._defs)
+        self.assertEqual(conf.version, 2)
+        self.assertEqual(
+            conf.get_property("new_section", "new_property"), TH_PACKAGE
+        )
+        portable.remove(scpath)
 
-                # Verify read and write of sample files.
-                for ver, content in six.iteritems(self._initial_files):
-                        scpath = self.make_misc_files({
-                            "cfg_cache": content })[0]
+        # Verify read and write of sample files.
+        for ver, content in six.iteritems(self._initial_files):
+            scpath = self.make_misc_files({"cfg_cache": content})[0]
 
-                        # Verify verison of content is auto detected and that
-                        # initial state matches file.
-                        conf = cfg.FileConfig(scpath, definitions=self._defs)
-                        self._verify_initial_state(conf, ver)
+            # Verify verison of content is auto detected and that
+            # initial state matches file.
+            conf = cfg.FileConfig(scpath, definitions=self._defs)
+            self._verify_initial_state(conf, ver)
 
-                        # Cleanup.
-                        portable.remove(scpath)
+            # Cleanup.
+            portable.remove(scpath)
 
-                # Verify that write only happens when needed and that perms are
-                # retained on existing configuration files.
-                scpath = self.make_misc_files({ "cfg_cache": "" })[0]
-                portable.remove(scpath)
+        # Verify that write only happens when needed and that perms are
+        # retained on existing configuration files.
+        scpath = self.make_misc_files({"cfg_cache": ""})[0]
+        portable.remove(scpath)
 
-                # Verify that configuration files that do not already exist will
-                # be created if the file doesn't exist, even if nothing has
-                # changed since init.
-                conf = cfg.FileConfig(scpath, definitions=self._defs, version=0)
-                self.assertTrue(not os.path.isfile(scpath))
-                conf.write()
+        # Verify that configuration files that do not already exist will
+        # be created if the file doesn't exist, even if nothing has
+        # changed since init.
+        conf = cfg.FileConfig(scpath, definitions=self._defs, version=0)
+        self.assertTrue(not os.path.isfile(scpath))
+        conf.write()
 
-                # Now the file should exist and have specific perms.
-                bstat = os.stat(scpath)
-                self.assertEqual(stat.S_IMODE(bstat.st_mode),
-                    misc.PKG_FILE_MODE)
+        # Now the file should exist and have specific perms.
+        bstat = os.stat(scpath)
+        self.assertEqual(stat.S_IMODE(bstat.st_mode), misc.PKG_FILE_MODE)
 
-                # Calling write again shouldn't do anything since nothing
-                # has changed since the last write.
-                conf.write()
-                astat = os.stat(scpath)
-                self.assertEqual(bstat.st_mtime, astat.st_mtime)
+        # Calling write again shouldn't do anything since nothing
+        # has changed since the last write.
+        conf.write()
+        astat = os.stat(scpath)
+        self.assertEqual(bstat.st_mtime, astat.st_mtime)
 
-                # Calling write after init shouldn't do anything since
-                # nothing has changed since init.
-                conf = cfg.FileConfig(scpath, definitions=self._defs)
-                astat = os.stat(scpath)
-                self.assertEqual(bstat.st_mtime, astat.st_mtime)
+        # Calling write after init shouldn't do anything since
+        # nothing has changed since init.
+        conf = cfg.FileConfig(scpath, definitions=self._defs)
+        astat = os.stat(scpath)
+        self.assertEqual(bstat.st_mtime, astat.st_mtime)
 
-                # Set a property; write should happen this time.
-                conf.set_property("first_section", "int_basic", 255)
-                conf.write()
-                astat = os.stat(scpath)
-                self.assertNotEqual(bstat.st_mtime, astat.st_mtime)
-                bstat = astat
+        # Set a property; write should happen this time.
+        conf.set_property("first_section", "int_basic", 255)
+        conf.write()
+        astat = os.stat(scpath)
+        self.assertNotEqual(bstat.st_mtime, astat.st_mtime)
+        bstat = astat
 
-                # Verify that set value was written along with the rest
-                # of the initial state.
-                conf = cfg.FileConfig(scpath, definitions=self._defs)
-                exp_state = copy.deepcopy(self._initial_state[0])
-                exp_state["first_section"]["int_basic"] = 255
-                self._verify_initial_state(conf, 0, exp_state=exp_state)
+        # Verify that set value was written along with the rest
+        # of the initial state.
+        conf = cfg.FileConfig(scpath, definitions=self._defs)
+        exp_state = copy.deepcopy(self._initial_state[0])
+        exp_state["first_section"]["int_basic"] = 255
+        self._verify_initial_state(conf, 0, exp_state=exp_state)
 
-                # If overrides are set during init, the file should get
-                # written.
-                overrides = {
-                    "first_section": {
-                        "int_basic": 0,
-                    },
-                }
-                conf = cfg.FileConfig(scpath, definitions=self._defs,
-                    overrides=overrides)
-                conf.write()
-                astat = os.stat(scpath)
-                self.assertNotEqual(bstat.st_mtime, astat.st_mtime)
-                bstat = astat
+        # If overrides are set during init, the file should get
+        # written.
+        overrides = {
+            "first_section": {
+                "int_basic": 0,
+            },
+        }
+        conf = cfg.FileConfig(
+            scpath, definitions=self._defs, overrides=overrides
+        )
+        conf.write()
+        astat = os.stat(scpath)
+        self.assertNotEqual(bstat.st_mtime, astat.st_mtime)
+        bstat = astat
 
-                # Verify overrides were written.
-                conf = cfg.FileConfig(scpath, definitions=self._defs,
-                    overrides=overrides)
-                exp_state = copy.deepcopy(self._initial_state[0])
-                exp_state["first_section"]["int_basic"] = 0
-                self._verify_initial_state(conf, 0, exp_state=exp_state)
+        # Verify overrides were written.
+        conf = cfg.FileConfig(
+            scpath, definitions=self._defs, overrides=overrides
+        )
+        exp_state = copy.deepcopy(self._initial_state[0])
+        exp_state["first_section"]["int_basic"] = 0
+        self._verify_initial_state(conf, 0, exp_state=exp_state)
 
-                # Verify that user-specified permissions are retained.
-                os.chmod(scpath, 0o777)
-                conf.set_property("first_section", "int_basic", 16384)
-                conf.write()
-                astat = os.stat(scpath)
-                self.assertEqual(stat.S_IMODE(astat.st_mode), 0o777)
-                self.assertNotEqual(bstat.st_mtime, astat.st_mtime)
-                bstat = astat
+        # Verify that user-specified permissions are retained.
+        os.chmod(scpath, 0o777)
+        conf.set_property("first_section", "int_basic", 16384)
+        conf.write()
+        astat = os.stat(scpath)
+        self.assertEqual(stat.S_IMODE(astat.st_mode), 0o777)
+        self.assertNotEqual(bstat.st_mtime, astat.st_mtime)
+        bstat = astat
 
-                if portable.util.get_canonical_os_type() != "unix":
-                        return
+        if portable.util.get_canonical_os_type() != "unix":
+            return
 
-                portable.chown(scpath, 65534, 65534)
-                conf.set_property("first_section", "int_basic", 0)
-                conf.write()
-                astat = os.stat(scpath)
-                self.assertEqual(astat.st_uid, 65534)
-                self.assertEqual(astat.st_gid, 65534)
+        portable.chown(scpath, 65534, 65534)
+        conf.set_property("first_section", "int_basic", 0)
+        conf.write()
+        astat = os.stat(scpath)
+        self.assertEqual(astat.st_uid, 65534)
+        self.assertEqual(astat.st_gid, 65534)
 
-        def test_get_modify_properties(self):
-                """Verify that get_property, set_property, get_properties,
-                set_properties, add_property_value, remove_property_value,
-                and remove_property work as expected.
-                """
+    def test_get_modify_properties(self):
+        """Verify that get_property, set_property, get_properties,
+        set_properties, add_property_value, remove_property_value,
+        and remove_property work as expected.
+        """
 
-                # Verify no definitions, overrides, or version.
-                conf = cfg.Config()
+        # Verify no definitions, overrides, or version.
+        conf = cfg.Config()
 
-                # Verify unknown section causes exception.
-                self.assertRaises(cfg.UnknownSectionError,
-                    conf.get_section, "section")
-                self.assertRaises(cfg.UnknownPropertyError,
-                    conf.get_property, "section", "property")
+        # Verify unknown section causes exception.
+        self.assertRaises(cfg.UnknownSectionError, conf.get_section, "section")
+        self.assertRaises(
+            cfg.UnknownPropertyError, conf.get_property, "section", "property"
+        )
 
-                # Verify set automatically creates unknown sections and
-                # properties.
-                conf.set_property("section", "bool_prop", False)
+        # Verify set automatically creates unknown sections and
+        # properties.
+        conf.set_property("section", "bool_prop", False)
 
-                secobj = conf.get_section("section")
-                self.assertEqual(secobj.name, "section")
-                self.assertTrue(isinstance(secobj, cfg.PropertySection))
+        secobj = conf.get_section("section")
+        self.assertEqual(secobj.name, "section")
+        self.assertTrue(isinstance(secobj, cfg.PropertySection))
 
-                conf.set_properties({
-                    "section": {
-                        "int_prop": 16384,
-                        "str_prop": "bob cat",
-                    },
-                })
+        conf.set_properties(
+            {
+                "section": {
+                    "int_prop": 16384,
+                    "str_prop": "bob cat",
+                },
+            }
+        )
 
-                # Unknown properties when set are assumed to be a string
-                # and forcibly cast as one if they are int, bool, etc.
-                self.assertEqual(conf.get_property("section", "bool_prop"),
-                    "False")
-                self.assertEqual(conf.get_property("section", "int_prop"),
-                    "16384")
-                self.assertEqual(conf.get_property("section", "str_prop"),
-                    "bob cat")
+        # Unknown properties when set are assumed to be a string
+        # and forcibly cast as one if they are int, bool, etc.
+        self.assertEqual(conf.get_property("section", "bool_prop"), "False")
+        self.assertEqual(conf.get_property("section", "int_prop"), "16384")
+        self.assertEqual(conf.get_property("section", "str_prop"), "bob cat")
 
-                # Verify that get_properties returns expected value.
-                secobj = conf.get_section("section")
-                props = [
-                    secobj.get_property(p)
-                    for p in sorted(["bool_prop", "str_prop", "int_prop"])
-                ]
-                expected = [(secobj, props)]
-                returned = []
-                for sec, secprops in conf.get_properties():
-                        returned.append((sec, [p for p in secprops]))
-                self.assertEqual(expected, returned)
+        # Verify that get_properties returns expected value.
+        secobj = conf.get_section("section")
+        props = [
+            secobj.get_property(p)
+            for p in sorted(["bool_prop", "str_prop", "int_prop"])
+        ]
+        expected = [(secobj, props)]
+        returned = []
+        for sec, secprops in conf.get_properties():
+            returned.append((sec, [p for p in secprops]))
+        self.assertEqual(expected, returned)
 
-                # Verify unknown property causes exception.
-                self.assertRaises(cfg.UnknownPropertyError,
-                    conf.get_property, "section", "property")
+        # Verify unknown property causes exception.
+        self.assertRaises(
+            cfg.UnknownPropertyError, conf.get_property, "section", "property"
+        )
 
-                # Verify with no overrides and with version.
-                conf = cfg.Config(definitions=self._defs, version=0)
+        # Verify with no overrides and with version.
+        conf = cfg.Config(definitions=self._defs, version=0)
 
-                # Verify that get returns set value when defaults are present.
-                self.assertEqual(conf.get_property("first_section",
-                    "str_default"), TH_PACKAGE)
-                conf.set_property("first_section", "str_default", "lynx")
-                self.assertEqual(conf.get_property("first_section",
-                    "str_default"), "lynx")
+        # Verify that get returns set value when defaults are present.
+        self.assertEqual(
+            conf.get_property("first_section", "str_default"), TH_PACKAGE
+        )
+        conf.set_property("first_section", "str_default", "lynx")
+        self.assertEqual(
+            conf.get_property("first_section", "str_default"), "lynx"
+        )
 
-                # Verify that Config's set_property passes through the expected
-                # exception when the value given is not valid for the property.
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    conf.set_property, "first_section", "int_basic", "badval")
+        # Verify that Config's set_property passes through the expected
+        # exception when the value given is not valid for the property.
+        self.assertRaises(
+            cfg.InvalidPropertyValueError,
+            conf.set_property,
+            "first_section",
+            "int_basic",
+            "badval",
+        )
 
-                # Verify that setting a property that doesn't currently exist,
-                # but for which there is a matching definition, will be created
-                # using the definition.
-                conf = cfg.Config(definitions=self._defs, version=0)
+        # Verify that setting a property that doesn't currently exist,
+        # but for which there is a matching definition, will be created
+        # using the definition.
+        conf = cfg.Config(definitions=self._defs, version=0)
 
-                # If the section is removed, then setting any property for
-                # that section should cause all properties defined for that
-                # section to be set with their default values using the
-                # types from the definition.
-                conf.remove_section("first_section")
-                conf.set_property("first_section", "bool_basic", False)
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    conf.set_property, "first_section", "bool_basic", 255)
+        # If the section is removed, then setting any property for
+        # that section should cause all properties defined for that
+        # section to be set with their default values using the
+        # types from the definition.
+        conf.remove_section("first_section")
+        conf.set_property("first_section", "bool_basic", False)
+        self.assertRaises(
+            cfg.InvalidPropertyValueError,
+            conf.set_property,
+            "first_section",
+            "bool_basic",
+            255,
+        )
 
-                conf.set_property("first_section", "list_basic", [])
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    conf.set_property, "first_section", "list_basic", 255)
+        conf.set_property("first_section", "list_basic", [])
+        self.assertRaises(
+            cfg.InvalidPropertyValueError,
+            conf.set_property,
+            "first_section",
+            "list_basic",
+            255,
+        )
 
-                self.assertEqualDiff(
-                    sorted(conf.get_index()["first_section"].keys()),
-                    sorted(self._initial_state[0]["first_section"].keys()))
+        self.assertEqualDiff(
+            sorted(conf.get_index()["first_section"].keys()),
+            sorted(self._initial_state[0]["first_section"].keys()),
+        )
 
-                # Verify that add_property_value and remove_property_value
-                # raise exceptions when used with non-list properties.
-                self.assertRaises(cfg.PropertyMultiValueError,
-                    conf.add_property_value, "first_section", "bool_basic",
-                    True)
-                self.assertRaises(cfg.PropertyMultiValueError,
-                    conf.remove_property_value, "first_section", "bool_basic",
-                    True)
-        
-                # Verify that add_property_value and remove_property_value
-                # work as expected for list properties.
-                conf.add_property_value("first_section", "list_noneallowed",
-                    "always")
-                self.assertEqual(conf.get_property("first_section",
-                    "list_noneallowed"), ["always"])
+        # Verify that add_property_value and remove_property_value
+        # raise exceptions when used with non-list properties.
+        self.assertRaises(
+            cfg.PropertyMultiValueError,
+            conf.add_property_value,
+            "first_section",
+            "bool_basic",
+            True,
+        )
+        self.assertRaises(
+            cfg.PropertyMultiValueError,
+            conf.remove_property_value,
+            "first_section",
+            "bool_basic",
+            True,
+        )
 
-                conf.remove_property_value("first_section", "list_noneallowed",
-                    "always")
-                self.assertEqual(conf.get_property("first_section",
-                    "list_noneallowed"), [])
+        # Verify that add_property_value and remove_property_value
+        # work as expected for list properties.
+        conf.add_property_value("first_section", "list_noneallowed", "always")
+        self.assertEqual(
+            conf.get_property("first_section", "list_noneallowed"), ["always"]
+        )
 
-                # Verify that remove_property_value will raise expected error
-                # if property value doesn't exist.
-                self.assertRaises(cfg.UnknownPropertyValueError,
-                    conf.remove_property_value, "first_section",
-                    "list_noneallowed", "nosuchvalue")
+        conf.remove_property_value(
+            "first_section", "list_noneallowed", "always"
+        )
+        self.assertEqual(
+            conf.get_property("first_section", "list_noneallowed"), []
+        )
 
-                # Remove the property for following tests.
-                conf.remove_property("first_section", "list_noneallowed")
+        # Verify that remove_property_value will raise expected error
+        # if property value doesn't exist.
+        self.assertRaises(
+            cfg.UnknownPropertyValueError,
+            conf.remove_property_value,
+            "first_section",
+            "list_noneallowed",
+            "nosuchvalue",
+        )
 
-                # Verify that attempting to remove a property that doesn't exist
-                # will raise the expected exception.
-                self.assertRaises(cfg.UnknownPropertyError,
-                    conf.remove_property, "first_section", "list_noneallowed")
+        # Remove the property for following tests.
+        conf.remove_property("first_section", "list_noneallowed")
 
-                # Verify that add_property_value will automatically create
-                # properties, just as set_property does, if needed.
-                conf.add_property_value("first_section", "list_noneallowed",
-                    "always")
-                self.assertEqual(conf.get_property("first_section",
-                    "list_noneallowed"), ["always"])
+        # Verify that attempting to remove a property that doesn't exist
+        # will raise the expected exception.
+        self.assertRaises(
+            cfg.UnknownPropertyError,
+            conf.remove_property,
+            "first_section",
+            "list_noneallowed",
+        )
 
-                # Verify that add_property_value will reject invalid values
-                # just as set_property does.
-                self.assertRaises(cfg.InvalidPropertyValueError,
-                    conf.add_property_value, "first_section",
-                        "list_noneallowed", "notallowed")
+        # Verify that add_property_value will automatically create
+        # properties, just as set_property does, if needed.
+        conf.add_property_value("first_section", "list_noneallowed", "always")
+        self.assertEqual(
+            conf.get_property("first_section", "list_noneallowed"), ["always"]
+        )
 
-                # Verify that attempting to remove a property in a section that
-                # doesn't exist fails as expected.
-                conf.remove_section("first_section")
-                self.assertRaises(cfg.UnknownPropertyError,
-                    conf.remove_property, "first_section", "list_noneallowed")
+        # Verify that add_property_value will reject invalid values
+        # just as set_property does.
+        self.assertRaises(
+            cfg.InvalidPropertyValueError,
+            conf.add_property_value,
+            "first_section",
+            "list_noneallowed",
+            "notallowed",
+        )
 
-                # Verify that attempting to remove a property value in for a
-                # property in a section that doesn't exist fails as expected.
-                self.assertRaises(cfg.UnknownPropertyError,
-                    conf.remove_property_value, "first_section",
-                    "list_noneallowed", "always")
+        # Verify that attempting to remove a property in a section that
+        # doesn't exist fails as expected.
+        conf.remove_section("first_section")
+        self.assertRaises(
+            cfg.UnknownPropertyError,
+            conf.remove_property,
+            "first_section",
+            "list_noneallowed",
+        )
 
-                # Verify that setting a property for which a property section
-                # template exists, but an instance of the section does not yet
-                # exist, works as expected.
-                conf = cfg.Config(definitions=self._templated_defs, version=0)
-                conf.remove_section("facet")
-                conf.set_property("facet", "facet.devel", True)
-                self.assertEqual(conf.get_property("facet", "facet.devel"),
-                    True)
+        # Verify that attempting to remove a property value in for a
+        # property in a section that doesn't exist fails as expected.
+        self.assertRaises(
+            cfg.UnknownPropertyError,
+            conf.remove_property_value,
+            "first_section",
+            "list_noneallowed",
+            "always",
+        )
 
-                conf = cfg.Config(definitions=self._templated_defs, version=1)
-                self.assertEqualDiff([], list(conf.get_index().keys()))
+        # Verify that setting a property for which a property section
+        # template exists, but an instance of the section does not yet
+        # exist, works as expected.
+        conf = cfg.Config(definitions=self._templated_defs, version=0)
+        conf.remove_section("facet")
+        conf.set_property("facet", "facet.devel", True)
+        self.assertEqual(conf.get_property("facet", "facet.devel"), True)
 
-                conf.set_property("authority_example.com", "prefix",
-                    "example.com")
-                self.assertEqual(conf.get_property("authority_example.com",
-                    "prefix"), "example.com")
+        conf = cfg.Config(definitions=self._templated_defs, version=1)
+        self.assertEqualDiff([], list(conf.get_index().keys()))
+
+        conf.set_property("authority_example.com", "prefix", "example.com")
+        self.assertEqual(
+            conf.get_property("authority_example.com", "prefix"), "example.com"
+        )
 
 
 class TestSMFConfig(_TestConfigBase):
-        """Class to test the functionality of the pkg.config SMF
-        configuration classes.
-        """
+    """Class to test the functionality of the pkg.config SMF
+    configuration classes.
+    """
 
-        _initial_files = {
-            0: u"""\
+    _initial_files = {
+        0: """\
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name=':pkg-config'>
@@ -1791,8 +2088,10 @@ class TestSMFConfig(_TestConfigBase):
         <stability value='Unstable' />
 </service>
 </service_bundle>
-""".format(uni_txt=TH_PACKAGE),
-            1: """\
+""".format(
+            uni_txt=TH_PACKAGE
+        ),
+        1: """\
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name=':pkg-config'>
@@ -1808,10 +2107,10 @@ class TestSMFConfig(_TestConfigBase):
 </service>
 </service_bundle>
 """,
-        }
+    }
 
-        # Manifest and state data for testing unknown sections and properties.
-        __undef_mfst = """\
+    # Manifest and state data for testing unknown sections and properties.
+    __undef_mfst = """\
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name=':pkg-config'>
@@ -1831,20 +2130,20 @@ class TestSMFConfig(_TestConfigBase):
 </service>
 </service_bundle>
 """
-        __undef_state = {
-            "unknown_section1": {
-                "unknown_prop11": "foo11",
-                "unknown_prop12": "foo12",
-            },
-            "unknown_section2": {
-                "unknown_prop21": "foo21",
-                "unknown_prop22": "foo22",
-            },
-        }
+    __undef_state = {
+        "unknown_section1": {
+            "unknown_prop11": "foo11",
+            "unknown_prop12": "foo12",
+        },
+        "unknown_section2": {
+            "unknown_prop21": "foo21",
+            "unknown_prop22": "foo22",
+        },
+    }
 
-        # "Calgon, take me away!"
-        # Torture data for SMFConfig parsing of values that require escaping.
-        __escape_mfst = """\
+    # "Calgon, take me away!"
+    # Torture data for SMFConfig parsing of values that require escaping.
+    __escape_mfst = """\
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name=':pkg-config'>
@@ -1875,8 +2174,11 @@ class TestSMFConfig(_TestConfigBase):
 </service_bundle>
 """
 
-        __escape_defs = {
-            3: [cfg.PropertySection("escaped", properties=[
+    __escape_defs = {
+        3: [
+            cfg.PropertySection(
+                "escaped",
+                properties=[
                     cfg.Property("one_slash", default="\\"),
                     cfg.Property("two_slash", default="\\\\"),
                     cfg.Property("one_slash_embed", default="\\\n\\"),
@@ -1884,275 +2186,298 @@ class TestSMFConfig(_TestConfigBase):
                     cfg.Property("end_embed_one_slash", default="foo\\\n\\"),
                     cfg.Property("end_one_slash", default="foo\\"),
                     cfg.Property("end_two_slash", default="foo\\\\"),
-                    cfg.Property("end_embed_two_slash", default="foo\\\\\n\\\\"),
+                    cfg.Property(
+                        "end_embed_two_slash", default="foo\\\\\n\\\\"
+                    ),
                     cfg.Property("multi_line", default="foo\\\n\n\\\n\n\\\n\\"),
-                    cfg.PropList("list_multi_line", default=[
-                        "foo\\\n\n\\\n\n\\\n\\",
-                        ";, &, (, ), |, ^, <, >, nl\n, sp , tab\t, bs\\, ', \", `",
-                        "Eat at Joe's!\n\tReally; eat at Joe's please."
-                    ])
-            ])]
-        }
-
-        __escape_state = {
-            "escaped": {
-                "one_slash": "\\",
-                "two_slash": "\\\\",
-                "one_slash_embed": "\\\n\\",
-                "two_slash_embed": "\\\\\n\\\\",
-                "end_embed_one_slash": "foo\\\n\\",
-                "end_one_slash": "foo\\",
-                "end_two_slash": "foo\\\\",
-                "end_embed_two_slash": "foo\\\\\n\\\\",
-                "multi_line": "foo\\\n\n\\\n\n\\\n\\",
-                "list_multi_line": [
-                    "foo\\\n\n\\\n\n\\\n\\",
-                    ";, &, (, ), |, ^, <, >, nl\n, sp , tab\t, bs\\, ', \", `",
-                    "Eat at Joe's!\n\tReally; eat at Joe's please."
+                    cfg.PropList(
+                        "list_multi_line",
+                        default=[
+                            "foo\\\n\n\\\n\n\\\n\\",
+                            ";, &, (, ), |, ^, <, >, nl\n, sp , tab\t, bs\\, ', \", `",
+                            "Eat at Joe's!\n\tReally; eat at Joe's please.",
+                        ],
+                    ),
                 ],
-            }
+            )
+        ]
+    }
+
+    __escape_state = {
+        "escaped": {
+            "one_slash": "\\",
+            "two_slash": "\\\\",
+            "one_slash_embed": "\\\n\\",
+            "two_slash_embed": "\\\\\n\\\\",
+            "end_embed_one_slash": "foo\\\n\\",
+            "end_one_slash": "foo\\",
+            "end_two_slash": "foo\\\\",
+            "end_embed_two_slash": "foo\\\\\n\\\\",
+            "multi_line": "foo\\\n\n\\\n\n\\\n\\",
+            "list_multi_line": [
+                "foo\\\n\n\\\n\n\\\n\\",
+                ";, &, (, ), |, ^, <, >, nl\n, sp , tab\t, bs\\, ', \", `",
+                "Eat at Joe's!\n\tReally; eat at Joe's please.",
+            ],
         }
+    }
 
-        def setUp(self):
-                """Prepare the tests."""
-                _TestConfigBase.setUp(self)
-                self.__configd = None
+    def setUp(self):
+        """Prepare the tests."""
+        _TestConfigBase.setUp(self)
+        self.__configd = None
 
-        def __create_smf_repo(self, manifest):
-                """Create a new SMF repository importing only the specified
-                manifest file."""
+    def __create_smf_repo(self, manifest):
+        """Create a new SMF repository importing only the specified
+        manifest file."""
 
-                SVCCFG_PATH = "/usr/sbin/svccfg"
+        SVCCFG_PATH = "/usr/sbin/svccfg"
 
-                rdbname = tempfile.mktemp(prefix="repo-", suffix=".db", dir="")
-                sc_repo_filename = self.make_misc_files({ rdbname: '' })[0]
-                portable.remove(sc_repo_filename)
+        rdbname = tempfile.mktemp(prefix="repo-", suffix=".db", dir="")
+        sc_repo_filename = self.make_misc_files({rdbname: ""})[0]
+        portable.remove(sc_repo_filename)
 
-                pdir = os.path.dirname(sc_repo_filename)
-                hndl = self.cmdline_run(
-                    "SVCCFG_REPOSITORY={sc_repo_filename} "
-                    "{SVCCFG_PATH} import {manifest}".format(**locals()),
-                    coverage=False, handle=True)
-                assert hndl is not None
-                hndl.wait()
+        pdir = os.path.dirname(sc_repo_filename)
+        hndl = self.cmdline_run(
+            "SVCCFG_REPOSITORY={sc_repo_filename} "
+            "{SVCCFG_PATH} import {manifest}".format(**locals()),
+            coverage=False,
+            handle=True,
+        )
+        assert hndl is not None
+        hndl.wait()
 
-                return sc_repo_filename
+        return sc_repo_filename
 
-        def __poll_process(self, hndl, pfile):
-                try:
-                        begintime = time.time()
+    def __poll_process(self, hndl, pfile):
+        try:
+            begintime = time.time()
 
-                        sleeptime = 0.0
-                        check_interval = 0.20
-                        contact = False
-                        while (time.time() - begintime) <= 10.0:
-                                hndl.poll()
-                                time.sleep(check_interval)
-                                # The door file will exist but will fail
-                                # os.path.isfile() check if the process
-                                # has launched.
-                                if os.path.exists(pfile) and \
-                                    not os.path.isfile(pfile):
-                                        contact = True
-                                        break
+            sleeptime = 0.0
+            check_interval = 0.20
+            contact = False
+            while (time.time() - begintime) <= 10.0:
+                hndl.poll()
+                time.sleep(check_interval)
+                # The door file will exist but will fail
+                # os.path.isfile() check if the process
+                # has launched.
+                if os.path.exists(pfile) and not os.path.isfile(pfile):
+                    contact = True
+                    break
 
-                        if contact == False:
-                                raise RuntimeError("Process did not launch "
-                                    "successfully.")
-                except (KeyboardInterrupt, RuntimeError) as e:
-                        try:
-                                hndl.kill()
-                        finally:
-                                self.debug(str(e))
-                        raise
+            if contact == False:
+                raise RuntimeError("Process did not launch " "successfully.")
+        except (KeyboardInterrupt, RuntimeError) as e:
+            try:
+                hndl.kill()
+            finally:
+                self.debug(str(e))
+            raise
 
-        def __start_configd(self, sc_repo_filename):
-                """Start svc.configd for the specified SMF repository."""
+    def __start_configd(self, sc_repo_filename):
+        """Start svc.configd for the specified SMF repository."""
 
-                assert not self.__configd
+        assert not self.__configd
 
-                SC_REPO_SERVER = "/lib/svc/bin/svc.configd"
+        SC_REPO_SERVER = "/lib/svc/bin/svc.configd"
 
-                doorname = tempfile.mktemp(prefix="repo-door-", dir="")
-                sc_repo_doorpath = self.make_misc_files({ doorname: "" })[0]
-                os.chmod(sc_repo_doorpath, 0o600)
+        doorname = tempfile.mktemp(prefix="repo-door-", dir="")
+        sc_repo_doorpath = self.make_misc_files({doorname: ""})[0]
+        os.chmod(sc_repo_doorpath, 0o600)
 
-                hndl = self.cmdline_run("{SC_REPO_SERVER} "
-                    "-d {sc_repo_doorpath} -r {sc_repo_filename}".format(
-                    **locals()), coverage=False, handle=True)
-                assert hndl is not None
-                self.__configd = hndl
-                self.__poll_process(hndl, sc_repo_doorpath)
-                self.__starttime = time.time()
-                return sc_repo_doorpath
+        hndl = self.cmdline_run(
+            "{SC_REPO_SERVER} "
+            "-d {sc_repo_doorpath} -r {sc_repo_filename}".format(**locals()),
+            coverage=False,
+            handle=True,
+        )
+        assert hndl is not None
+        self.__configd = hndl
+        self.__poll_process(hndl, sc_repo_doorpath)
+        self.__starttime = time.time()
+        return sc_repo_doorpath
 
-        def __verify_ex_stringify(self, ex):
-                encs = str(ex)
-                self.assertNotEqual(len(encs), 0)
-                unis = six.text_type(ex)
-                self.assertNotEqual(len(unis), 0)
-                if six.PY2:
-                        self.assertEqualDiff(encs, unis.encode("utf-8"))
-                else:
-                        self.assertEqualDiff(encs, unis)
+    def __verify_ex_stringify(self, ex):
+        encs = str(ex)
+        self.assertNotEqual(len(encs), 0)
+        unis = six.text_type(ex)
+        self.assertNotEqual(len(unis), 0)
+        if six.PY2:
+            self.assertEqualDiff(encs, unis.encode("utf-8"))
+        else:
+            self.assertEqualDiff(encs, unis)
 
-        def test_exceptions(self):
-                """Verify that exception classes can be initialized as expected,
-                and when stringified return a non-zero-length string.
-                """
+    def test_exceptions(self):
+        """Verify that exception classes can be initialized as expected,
+        and when stringified return a non-zero-length string.
+        """
 
-                # Verify the expected behavior of all SMF exception classes.
-                for excls in (cfg.SMFReadError, cfg.SMFWriteError):
-                        # Verify that exception can't be created without
-                        # specifying svc_fmri and errmsg.
-                        self.assertRaises(AssertionError, excls,
-                            None, None)
+        # Verify the expected behavior of all SMF exception classes.
+        for excls in (cfg.SMFReadError, cfg.SMFWriteError):
+            # Verify that exception can't be created without
+            # specifying svc_fmri and errmsg.
+            self.assertRaises(AssertionError, excls, None, None)
 
-                        # Verify that the properties specified at init can
-                        # be accessed.
-                        svc_fmri = "svc:/application/pkg/configuration"
-                        errmsg = "error message"
-                        ex = excls(svc_fmri, errmsg)
-                        self.assertEqual(ex.fmri, svc_fmri)
-                        self.assertEqual(ex.errmsg, errmsg)
-                        self.__verify_ex_stringify(ex)
+            # Verify that the properties specified at init can
+            # be accessed.
+            svc_fmri = "svc:/application/pkg/configuration"
+            errmsg = "error message"
+            ex = excls(svc_fmri, errmsg)
+            self.assertEqual(ex.fmri, svc_fmri)
+            self.assertEqual(ex.errmsg, errmsg)
+            self.__verify_ex_stringify(ex)
 
-                # Verify that exception can't be created without specifying
-                # section.
-                excls = cfg.SMFInvalidSectionNameError
-                self.assertRaises(AssertionError, excls, None)
+        # Verify that exception can't be created without specifying
+        # section.
+        excls = cfg.SMFInvalidSectionNameError
+        self.assertRaises(AssertionError, excls, None)
 
-                # Verify that exception can be created with just section and
-                # that expected value is set.  In addition, verify that the
-                # stringified form or unicode object is equal and not zero-
-                # length.
-                ex1 = excls("section")
-                self.assertEqual(ex1.section, "section")
-                self.__verify_ex_stringify(ex1)
+        # Verify that exception can be created with just section and
+        # that expected value is set.  In addition, verify that the
+        # stringified form or unicode object is equal and not zero-
+        # length.
+        ex1 = excls("section")
+        self.assertEqual(ex1.section, "section")
+        self.__verify_ex_stringify(ex1)
 
-                # Verify that exception can't be created without specifying
-                # prop.
-                excls = cfg.SMFInvalidPropertyNameError
-                self.assertRaises(AssertionError, excls, None)
+        # Verify that exception can't be created without specifying
+        # prop.
+        excls = cfg.SMFInvalidPropertyNameError
+        self.assertRaises(AssertionError, excls, None)
 
-                # Verify that exception can be created with just prop and that 
-                # expected value is set.  In addition, verify that the
-                # stringified form or unicode object is equal and not zero-
-                # length.
-                ex1 = excls("prop")
-                self.assertEqual(ex1.prop, "prop")
-                self.__verify_ex_stringify(ex1)
+        # Verify that exception can be created with just prop and that
+        # expected value is set.  In addition, verify that the
+        # stringified form or unicode object is equal and not zero-
+        # length.
+        ex1 = excls("prop")
+        self.assertEqual(ex1.prop, "prop")
+        self.__verify_ex_stringify(ex1)
 
-        def test_add_set_property(self):
-                """Verify that add_section and set_property works as expected.
-                (SMFConfig enforces additional restrictions on naming.)
-                """
+    def test_add_set_property(self):
+        """Verify that add_section and set_property works as expected.
+        (SMFConfig enforces additional restrictions on naming.)
+        """
 
-                svc_fmri = "svc:/application/pkg/configuration"
+        svc_fmri = "svc:/application/pkg/configuration"
 
-                rfiles = []
-                mname = "smf-manifest-naming.xml"
-                mpath = self.make_misc_files({ mname: self.__undef_mfst })[0]
-                rfiles.append(mpath)
+        rfiles = []
+        mname = "smf-manifest-naming.xml"
+        mpath = self.make_misc_files({mname: self.__undef_mfst})[0]
+        rfiles.append(mpath)
 
-                rpath = self.__create_smf_repo(mpath)
-                rfiles.append(rpath)
+        rpath = self.__create_smf_repo(mpath)
+        rfiles.append(rpath)
 
-                dpath = self.__start_configd(rpath)
-                rfiles.append(dpath)
+        dpath = self.__start_configd(rpath)
+        rfiles.append(dpath)
 
-                # Retrieve configuration data from SMF.
-                try:
-                        conf = cfg.SMFConfig(svc_fmri,
-                            doorpath=dpath)
-                finally:
-                        # Removing the files stops configd.
-                        self.__configd = None
-                        while rfiles:
-                                portable.remove(rfiles[-1])
-                                rfiles.pop()
+        # Retrieve configuration data from SMF.
+        try:
+            conf = cfg.SMFConfig(svc_fmri, doorpath=dpath)
+        finally:
+            # Removing the files stops configd.
+            self.__configd = None
+            while rfiles:
+                portable.remove(rfiles[-1])
+                rfiles.pop()
 
-                # Verify that SMFConfig's add_section passes through the
-                # expected exception when the name of the property section
-                # is not valid for SMF.
-                invalid_names = ("1startnum", "has.stopnocomma",
-                    " startspace")
-                for sname in invalid_names:
-                        section = cfg.PropertySection(sname)
-                        self.assertRaises(cfg.SMFInvalidSectionNameError,
-                            conf.add_section, section)
+        # Verify that SMFConfig's add_section passes through the
+        # expected exception when the name of the property section
+        # is not valid for SMF.
+        invalid_names = ("1startnum", "has.stopnocomma", " startspace")
+        for sname in invalid_names:
+            section = cfg.PropertySection(sname)
+            self.assertRaises(
+                cfg.SMFInvalidSectionNameError, conf.add_section, section
+            )
 
-                # Verify that SMFConfig's set_property passes through the
-                # expected exception when the name of the property is not
-                # valid for SMF.
-                for pname in invalid_names:
-                        self.assertRaises(cfg.SMFInvalidPropertyNameError,
-                            conf.set_property, "section", pname, "value")
+        # Verify that SMFConfig's set_property passes through the
+        # expected exception when the name of the property is not
+        # valid for SMF.
+        for pname in invalid_names:
+            self.assertRaises(
+                cfg.SMFInvalidPropertyNameError,
+                conf.set_property,
+                "section",
+                pname,
+                "value",
+            )
 
-        def test_read(self):
-                """Verify that read works as expected for SMFConfig."""
+    def test_read(self):
+        """Verify that read works as expected for SMFConfig."""
 
-                # Verify read and write of sample configuration.
-                svc_fmri = "svc:/application/pkg/configuration"
+        # Verify read and write of sample configuration.
+        svc_fmri = "svc:/application/pkg/configuration"
 
-                def cleanup():
-                        self.__configd = None
-                        while rfiles:
-                                portable.remove(rfiles[-1])
-                                rfiles.pop()
+        def cleanup():
+            self.__configd = None
+            while rfiles:
+                portable.remove(rfiles[-1])
+                rfiles.pop()
 
-                rfiles = []
-                def test_mfst(svc_fmri, ver, mfst_content, defs,
-                    exp_state=None):
-                        mname = "smf-manifest-{0:d}.xml".format(ver)
-                        mpath = self.make_misc_files({ mname: mfst_content })[0]
-                        rfiles.append(mpath)
+        rfiles = []
 
-                        rpath = self.__create_smf_repo(mpath)
-                        rfiles.append(rpath)
+        def test_mfst(svc_fmri, ver, mfst_content, defs, exp_state=None):
+            mname = "smf-manifest-{0:d}.xml".format(ver)
+            mpath = self.make_misc_files({mname: mfst_content})[0]
+            rfiles.append(mpath)
 
-                        dpath = self.__start_configd(rpath)
-                        rfiles.append(dpath)
+            rpath = self.__create_smf_repo(mpath)
+            rfiles.append(rpath)
 
-                        # Retrieve configuration data from SMF.
-                        try:
-                                conf = cfg.SMFConfig(svc_fmri,
-                                    definitions=defs,
-                                    doorpath=dpath,
-                                    version=ver)
-                        finally:
-                                cleanup()
+            dpath = self.__start_configd(rpath)
+            rfiles.append(dpath)
 
-                        # Verify initial state matches expected.
-                        ver_defs = defs.get(ver, {})
-                        self._verify_initial_state(conf, ver, ver_defs,
-                            exp_state=exp_state)
+            # Retrieve configuration data from SMF.
+            try:
+                conf = cfg.SMFConfig(
+                    svc_fmri, definitions=defs, doorpath=dpath, version=ver
+                )
+            finally:
+                cleanup()
 
-                        # Verify SMFConfig raises exception if write() is
-                        # attempted (not currently supported).
-                        self.assertRaises(cfg.SMFWriteError, conf.write)
+            # Verify initial state matches expected.
+            ver_defs = defs.get(ver, {})
+            self._verify_initial_state(conf, ver, ver_defs, exp_state=exp_state)
 
-                for ver, mfst_content in six.iteritems(self._initial_files):
-                        test_mfst(svc_fmri, ver, mfst_content, self._defs)
+            # Verify SMFConfig raises exception if write() is
+            # attempted (not currently supported).
+            self.assertRaises(cfg.SMFWriteError, conf.write)
 
-                # Verify configuration data with unknown sections or properties
-                # can be loaded.
-                test_mfst(svc_fmri, 2, self.__undef_mfst, {},
-                    exp_state=self.__undef_state)
+        for ver, mfst_content in six.iteritems(self._initial_files):
+            test_mfst(svc_fmri, ver, mfst_content, self._defs)
 
-                # Verify configuration data that requires extensive escaping
-                # during parsing can be loaded.
-                test_mfst(svc_fmri, 3, self.__escape_mfst, self.__escape_defs,
-                    exp_state=self.__escape_state)
+        # Verify configuration data with unknown sections or properties
+        # can be loaded.
+        test_mfst(
+            svc_fmri, 2, self.__undef_mfst, {}, exp_state=self.__undef_state
+        )
 
-                # Verify that an SMFReadError is raised if the configuration
-                # data cannot be read from SMF.  (This should fail since 
-                self.assertRaises(cfg.SMFReadError, test_mfst,
-                    "svc:/nosuchservice", 4, self.__escape_mfst, {})
+        # Verify configuration data that requires extensive escaping
+        # during parsing can be loaded.
+        test_mfst(
+            svc_fmri,
+            3,
+            self.__escape_mfst,
+            self.__escape_defs,
+            exp_state=self.__escape_state,
+        )
+
+        # Verify that an SMFReadError is raised if the configuration
+        # data cannot be read from SMF.  (This should fail since
+        self.assertRaises(
+            cfg.SMFReadError,
+            test_mfst,
+            "svc:/nosuchservice",
+            4,
+            self.__escape_mfst,
+            {},
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_dependencies.py
+++ b/src/tests/api/t_dependencies.py
@@ -25,8 +25,9 @@
 
 from __future__ import print_function
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -57,13 +58,21 @@ import pkg.updatelog as updatelog
 # using from importlib.machinery import EXTENSION_SUFFIXES).
 py_ver_default = "3.11"
 py_ver_lib = "311"
-py_ver_lib_list = ["{0}.abi3.so",
-                   "{0}.cpython-{1}.so".format("{0}", py_ver_lib),
-                   "64/{0}.abi3.so",
-                   "64/{0}.cpython-{1}.so".format("{0}", py_ver_lib)]
+py_ver_lib_list = [
+    "{0}.abi3.so",
+    "{0}.cpython-{1}.so".format("{0}", py_ver_lib),
+    "64/{0}.abi3.so",
+    "64/{0}.cpython-{1}.so".format("{0}", py_ver_lib),
+]
 
-mod_pats = ["{0}/__init__.py", "{0}.py", "{0}.pyc", "{0}.pyo",
-            "{0}.so", "64/{0}.so"] + py_ver_lib_list
+mod_pats = [
+    "{0}/__init__.py",
+    "{0}.py",
+    "{0}.pyc",
+    "{0}.pyo",
+    "{0}.so",
+    "64/{0}.so",
+] + py_ver_lib_list
 
 # This is a second version of python used because the python dependency checker
 # has two code paths, one that uses the native module importer and one that
@@ -71,132 +80,167 @@ mod_pats = ["{0}/__init__.py", "{0}.py", "{0}.pyc", "{0}.pyo",
 # output from both code paths.
 py_ver_other = "2.7"
 
+
 class TestDependencyAnalyzer(pkg5unittest.Pkg5TestCase):
+    paths = {
+        "authlog_path": "var/log/authlog",
+        "curses_path": "usr/xpg4/lib/libcurses.so.1",
+        "indexer_path": "usr/lib/python{0}/vendor-packages/pkg_test/client/indexer.py".format(
+            py_ver_default
+        ),
+        "ksh_path": "usr/bin/ksh",
+        "libc_path": "lib/libc.so.1",
+        "pkg_path": "usr/lib/python{0}/vendor-packages/pkg_test/client/__init__.py".format(
+            py_ver_default
+        ),
+        "bypass_path": "pkgdep_test/file.py",
+        "relative_dependee": "usr/lib/python{0}/vendor-packages/pkg_test/client/bar.py".format(
+            py_ver_default
+        ),
+        "relative_depender": "usr/lib/python{0}/vendor-packages/pkg_test/client/foo.py".format(
+            py_ver_default
+        ),
+        "runpath_mod_path": "opt/pkgdep_runpath/__init__.py",
+        "runpath_mod_test_path": "opt/pkgdep_runpath/pdtest.py",
+        "script_path": "lib/svc/method/svc-pkg-depot",
+        "syslog_path": "var/log/syslog",
+        "py_mod_path": "usr/lib/python{0}/vendor-packages/cProfile.py".format(
+            py_ver_default
+        ),
+        "py_mod_path_alt": "usr/lib/python{0}/vendor-packages/cProfile.py".format(
+            py_ver_other
+        ),
+    }
 
-        paths = {
-            "authlog_path": "var/log/authlog",
-            "curses_path": "usr/xpg4/lib/libcurses.so.1",
-            "indexer_path":
-                "usr/lib/python{0}/vendor-packages/pkg_test/client/indexer.py".format(py_ver_default),
-            "ksh_path": "usr/bin/ksh",
-            "libc_path": "lib/libc.so.1",
-            "pkg_path":
-                "usr/lib/python{0}/vendor-packages/pkg_test/client/__init__.py".format(py_ver_default),
-            "bypass_path": "pkgdep_test/file.py",
-            "relative_dependee":
-                "usr/lib/python{0}/vendor-packages/pkg_test/client/bar.py".format(py_ver_default),
-            "relative_depender":
-                "usr/lib/python{0}/vendor-packages/pkg_test/client/foo.py".format(py_ver_default),
-            "runpath_mod_path": "opt/pkgdep_runpath/__init__.py",
-            "runpath_mod_test_path": "opt/pkgdep_runpath/pdtest.py",
-            "script_path": "lib/svc/method/svc-pkg-depot",
-            "syslog_path": "var/log/syslog",
-            "py_mod_path": "usr/lib/python{0}/vendor-packages/cProfile.py".format(py_ver_default),
-            "py_mod_path_alt": "usr/lib/python{0}/vendor-packages/cProfile.py".format(py_ver_other)
-        }
+    smf_paths = {
+        "broken": "var/svc/manifest/broken-service.xml",
+        "delete": "var/svc/manifest/delete-service.xml",
+        "delivered_many_nodeps": "var/svc/manifest/delivered-many-nodeps.xml",
+        "delivered_many_nodeps_alt": "var/svc/manifest/delivered-many-nodeps-alt.xml",
+        "foreign_many_nodeps": "var/svc/manifest/foreign-many-nodeps.xml",
+        "foreign_single_nodeps": "var/svc/manifest/foreign-single-nodeps.xml",
+        "service_general": "var/svc/manifest/service-general.xml",
+        "service_many": "var/svc/manifest/service-many.xml",
+        "service_single": "var/svc/manifest/service-single.xml",
+        "service_single_specific": "var/svc/manifest/service-specific.xml",
+        "service_unknown": "var/svc/manifest/service-single-unknown.xml",
+    }
 
-        smf_paths = {
-            "broken":
-                "var/svc/manifest/broken-service.xml",
-            "delete": "var/svc/manifest/delete-service.xml",
-            "delivered_many_nodeps":
-                "var/svc/manifest/delivered-many-nodeps.xml",
-            "delivered_many_nodeps_alt":
-                "var/svc/manifest/delivered-many-nodeps-alt.xml",
-            "foreign_many_nodeps":
-                "var/svc/manifest/foreign-many-nodeps.xml",
-            "foreign_single_nodeps":
-                "var/svc/manifest/foreign-single-nodeps.xml",
-            "service_general": "var/svc/manifest/service-general.xml",
-            "service_many": "var/svc/manifest/service-many.xml",
-            "service_single": "var/svc/manifest/service-single.xml",
-            "service_single_specific": "var/svc/manifest/service-specific.xml",
-            "service_unknown": "var/svc/manifest/service-single-unknown.xml"
-        }
+    paths.update(smf_paths)
 
-        paths.update(smf_paths)
-
-        ext_hardlink_manf = """ \
+    ext_hardlink_manf = """ \
 hardlink path=usr/foo target=../{syslog_path}
 hardlink path=usr/bar target=../{syslog_path}
 hardlink path=baz target={authlog_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        int_hardlink_manf = """ \
+    int_hardlink_manf = """ \
 hardlink path=usr/foo target=../{syslog_path}
 file NOHASH group=sys mode=0644 owner=root path={syslog_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        int_hardlink_manf_test_symlink = """ \
+    int_hardlink_manf_test_symlink = """ \
 hardlink path=usr/foo target=../{syslog_path}
 file NOHASH group=sys mode=0644 owner=root path=bar/syslog
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        ext_script_manf = """ \
+    ext_script_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={script_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        int_script_manf = """ \
+    int_script_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={script_path}
 file NOHASH group=bin mode=0755 owner=root path={ksh_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        ext_elf_manf = """ \
+    ext_elf_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={curses_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        int_elf_manf = """ \
+    int_elf_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={libc_path}
 file NOHASH group=bin mode=0755 owner=root path={curses_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        ext_python_manf = """ \
+    ext_python_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={indexer_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        ext_python_pkg_manf = """ \
+    ext_python_pkg_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={pkg_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        python_mod_manf = """ \
+    python_mod_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={py_mod_path}
 file NOHASH group=bin mode=0755 owner=root path={py_mod_path_alt}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        relative_ext_depender_manf = """ \
+    relative_ext_depender_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={relative_depender}
-""".format(**paths)
-        relative_int_manf = """ \
+""".format(
+        **paths
+    )
+    relative_int_manf = """ \
 file NOHASH group=bin mode=0755 owner=root path={relative_dependee}
 file NOHASH group=bin mode=0755 owner=root path={relative_depender}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        variant_manf_1 = """ \
+    variant_manf_1 = """ \
 set name=variant.arch value=foo value=bar value=baz
 file NOHASH group=bin mode=0755 owner=root path={script_path}
 file NOHASH group=bin mode=0755 owner=root path={ksh_path} variant.arch=foo
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        variant_manf_2 = """ \
+    variant_manf_2 = """ \
 set name=variant.arch value=foo value=bar value=baz
 file NOHASH group=bin mode=0755 owner=root path={script_path} variant.arch=foo
 file NOHASH group=bin mode=0755 owner=root path={ksh_path} variant.arch=foo
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        variant_manf_3 = """ \
+    variant_manf_3 = """ \
 set name=variant.arch value=foo value=bar value=baz
 file NOHASH group=bin mode=0755 owner=root path={script_path} variant.arch=bar
 file NOHASH group=bin mode=0755 owner=root path={ksh_path} variant.arch=foo
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        variant_manf_4 = """ \
+    variant_manf_4 = """ \
 set name=variant.arch value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
 file NOHASH group=bin mode=0755 owner=root path={script_path} variant.opensolaris.zone=global
 file NOHASH group=bin mode=0755 owner=root path={ksh_path} variant.opensolaris.zone=global
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        python_abs_text = """\
+    python_abs_text = """\
 #!/usr/bin/python
 
 from __future__ import absolute_import
@@ -209,7 +253,7 @@ import xml.dom.minidom
 from ..misc_test import EmptyI
 """
 
-        python_text = """\
+    python_text = """\
 #!/usr/bin/python
 
 import os
@@ -219,9 +263,9 @@ import pkg.search_storage as ss
 import xml.dom.minidom
 from pkg_test.misc_test import EmptyI
 """
-        # a python module that causes slightly different behaviour in
-        # modulefinder.py
-        python_module_text = """\
+    # a python module that causes slightly different behaviour in
+    # modulefinder.py
+    python_module_text = """\
 #! /usr/bin/python
 
 class Foo(object):
@@ -229,21 +273,25 @@ class Foo(object):
                 import __main__
 """
 
-        smf_fmris = {}
-        smf_known_deps = {}
+    smf_fmris = {}
+    smf_known_deps = {}
 
-        smf_fmris["service_single"] = [
-            "svc:/application/pkg5test/service-default",
-            "svc:/application/pkg5test/service-default:default"]
+    smf_fmris["service_single"] = [
+        "svc:/application/pkg5test/service-default",
+        "svc:/application/pkg5test/service-default:default",
+    ]
 
-        smf_known_deps["svc:/application/pkg5test/service-default"] = \
-            ["svc:/application/pkg5test/delivered-many:nodeps"]
-        smf_known_deps["svc:/application/pkg5test/service-default:default"] = \
-            ["svc:/application/pkg5test/delivered-many:nodeps"]
+    smf_known_deps["svc:/application/pkg5test/service-default"] = [
+        "svc:/application/pkg5test/delivered-many:nodeps"
+    ]
+    smf_known_deps["svc:/application/pkg5test/service-default:default"] = [
+        "svc:/application/pkg5test/delivered-many:nodeps"
+    ]
 
-        smf_manifest_text = {}
-        smf_manifest_text["service_single"] = \
-"""<?xml version="1.0"?>
+    smf_manifest_text = {}
+    smf_manifest_text[
+        "service_single"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='service-default'>
 
@@ -299,19 +347,23 @@ class Foo(object):
 </service_bundle>
 """
 
-        smf_fmris["service_single_specific"] = [
-            "svc:/application/pkg5test/service-specific",
-            "svc:/application/pkg5test/service-specific:default"]
+    smf_fmris["service_single_specific"] = [
+        "svc:/application/pkg5test/service-specific",
+        "svc:/application/pkg5test/service-specific:default",
+    ]
 
-        smf_known_deps["svc:/application/pkg5test/service-specific"] = \
-            ["svc:/application/pkg5test/delivered-many:nodeps",
-            "svc:/application/pkg5test/delivered-many:nodeps2"]
-        smf_known_deps["svc:/application/pkg5test/service-specific:default"] = \
-            ["svc:/application/pkg5test/delivered-many:nodeps",
-            "svc:/application/pkg5test/delivered-many:nodeps2"]
+    smf_known_deps["svc:/application/pkg5test/service-specific"] = [
+        "svc:/application/pkg5test/delivered-many:nodeps",
+        "svc:/application/pkg5test/delivered-many:nodeps2",
+    ]
+    smf_known_deps["svc:/application/pkg5test/service-specific:default"] = [
+        "svc:/application/pkg5test/delivered-many:nodeps",
+        "svc:/application/pkg5test/delivered-many:nodeps2",
+    ]
 
-        smf_manifest_text["service_single_specific"] = \
-"""<?xml version="1.0"?>
+    smf_manifest_text[
+        "service_single_specific"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='service-default'>
 
@@ -373,17 +425,21 @@ class Foo(object):
 </service_bundle>
 """
 
-        smf_fmris["service_general"] = [
-            "svc:/application/pkg5test/service-general",
-            "svc:/application/pkg5test/service-general:default"]
+    smf_fmris["service_general"] = [
+        "svc:/application/pkg5test/service-general",
+        "svc:/application/pkg5test/service-general:default",
+    ]
 
-        smf_known_deps["svc:/application/pkg5test/service-general"] = \
-            ["svc:/application/pkg5test/delivered-many"]
-        smf_known_deps["svc:/application/pkg5test/service-general:default"] = \
-            ["svc:/application/pkg5test/delivered-many"]
+    smf_known_deps["svc:/application/pkg5test/service-general"] = [
+        "svc:/application/pkg5test/delivered-many"
+    ]
+    smf_known_deps["svc:/application/pkg5test/service-general:default"] = [
+        "svc:/application/pkg5test/delivered-many"
+    ]
 
-        smf_manifest_text["service_general"] = \
-"""<?xml version="1.0"?>
+    smf_manifest_text[
+        "service_general"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='service-general'>
 
@@ -439,24 +495,30 @@ class Foo(object):
 </service_bundle>
 """
 
-        smf_fmris["service_many"] = [
-            "svc:/application/pkg5test/service-many",
-            "svc:/application/pkg5test/service-many:default",
-            "svc:/application/pkg5test/service-many:one",
-            "svc:/application/pkg5test/service-many:two"]
+    smf_fmris["service_many"] = [
+        "svc:/application/pkg5test/service-many",
+        "svc:/application/pkg5test/service-many:default",
+        "svc:/application/pkg5test/service-many:one",
+        "svc:/application/pkg5test/service-many:two",
+    ]
 
-        smf_known_deps["svc:/application/pkg5test/service-many"] = \
-            ["svc:/application/pkg5test/foreign-many"]
-        smf_known_deps["svc:/application/pkg5test/service-many:default"] = \
-            ["svc:/application/pkg5test/foreign-many"]
-        smf_known_deps["svc:/application/pkg5test/service-many:one"] = \
-            ["svc:/application/pkg5test/foreign-many",
-            "svc:/application/pkg5test/foreign-many:default"]
-        smf_known_deps["svc:/application/pkg5test/service-many:two"] = \
-            ["svc:/application/pkg5test/foreign-many"]
+    smf_known_deps["svc:/application/pkg5test/service-many"] = [
+        "svc:/application/pkg5test/foreign-many"
+    ]
+    smf_known_deps["svc:/application/pkg5test/service-many:default"] = [
+        "svc:/application/pkg5test/foreign-many"
+    ]
+    smf_known_deps["svc:/application/pkg5test/service-many:one"] = [
+        "svc:/application/pkg5test/foreign-many",
+        "svc:/application/pkg5test/foreign-many:default",
+    ]
+    smf_known_deps["svc:/application/pkg5test/service-many:two"] = [
+        "svc:/application/pkg5test/foreign-many"
+    ]
 
-        smf_manifest_text["service_many"] = \
-"""<?xml version="1.0"?>
+    smf_manifest_text[
+        "service_many"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='pkg5test-many-instances'>
 
@@ -529,24 +591,29 @@ class Foo(object):
 </service_bundle>
 """
 
-        smf_fmris["service_unknown"] = [
-            "svc:/application/pkg5test/service-unknown",
-            "svc:/application/pkg5test/service-unknown:default",
-            "svc:/application/pkg5test/service-unknown:one"]
+    smf_fmris["service_unknown"] = [
+        "svc:/application/pkg5test/service-unknown",
+        "svc:/application/pkg5test/service-unknown:default",
+        "svc:/application/pkg5test/service-unknown:one",
+    ]
 
-        smf_known_deps["svc:/application/pkg5test/service-unknown"] = \
-            ["svc:/application/pkg5test/delivered-many:nodeps",
-            "svc:/application/pkg5test/unknown-service"]
-        smf_known_deps["svc:/application/pkg5test/service-unknown:default"] = \
-            ["svc:/application/pkg5test/delivered-many:nodeps",
-            "svc:/application/pkg5test/unknown-service"]
-        smf_known_deps["svc:/application/pkg5test/service-unknown:one"] = \
-            ["svc:/application/pkg5test/delivered-many:nodeps",
-            "svc:/application/pkg5test/unknown-service",
-            "svc:/application/pkg5test/another-unknown:default"]
+    smf_known_deps["svc:/application/pkg5test/service-unknown"] = [
+        "svc:/application/pkg5test/delivered-many:nodeps",
+        "svc:/application/pkg5test/unknown-service",
+    ]
+    smf_known_deps["svc:/application/pkg5test/service-unknown:default"] = [
+        "svc:/application/pkg5test/delivered-many:nodeps",
+        "svc:/application/pkg5test/unknown-service",
+    ]
+    smf_known_deps["svc:/application/pkg5test/service-unknown:one"] = [
+        "svc:/application/pkg5test/delivered-many:nodeps",
+        "svc:/application/pkg5test/unknown-service",
+        "svc:/application/pkg5test/another-unknown:default",
+    ]
 
-        smf_manifest_text["service_unknown"] = \
-"""<?xml version="1.0"?>
+    smf_manifest_text[
+        "service_unknown"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='service-unknown'>
 
@@ -623,17 +690,19 @@ class Foo(object):
 </service_bundle>
 """
 
-        smf_fmris["delivered_many_nodeps"] = [
-            "svc:/application/pkg5test/delivered-many",
-            "svc:/application/pkg5test/delivered-many:nodeps",
-            "svc:/application/pkg5test/delivered-many:nodeps1"]
+    smf_fmris["delivered_many_nodeps"] = [
+        "svc:/application/pkg5test/delivered-many",
+        "svc:/application/pkg5test/delivered-many:nodeps",
+        "svc:/application/pkg5test/delivered-many:nodeps1",
+    ]
 
-        smf_known_deps["svc:/application/pkg5test/delivered-many"] = []
-        smf_known_deps["svc:/application/pkg5test/delivered-many:nodeps"] = []
-        smf_known_deps["svc:/application/pkg5test/delivered-many:nodeps1"] = []
+    smf_known_deps["svc:/application/pkg5test/delivered-many"] = []
+    smf_known_deps["svc:/application/pkg5test/delivered-many:nodeps"] = []
+    smf_known_deps["svc:/application/pkg5test/delivered-many:nodeps1"] = []
 
-        smf_manifest_text["delivered_many_nodeps"] = \
-"""<?xml version="1.0"?>
+    smf_manifest_text[
+        "delivered_many_nodeps"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='default-service-many'>
 <!-- we deliver
@@ -678,12 +747,13 @@ None of these services or instances declare any dependencies.
 </service_bundle>
 """
 
-        smf_known_deps["svc:/application/pkg5test/delivered-many"] = []
-        smf_known_deps["svc:/application/pkg5test/delivered-many:nodeps2"] = []
-        smf_known_deps["svc:/application/pkg5test/delivered-many:nodeps3"] = []
+    smf_known_deps["svc:/application/pkg5test/delivered-many"] = []
+    smf_known_deps["svc:/application/pkg5test/delivered-many:nodeps2"] = []
+    smf_known_deps["svc:/application/pkg5test/delivered-many:nodeps3"] = []
 
-        smf_manifest_text["delivered_many_nodeps_alt"] = \
-"""<?xml version="1.0"?>
+    smf_manifest_text[
+        "delivered_many_nodeps_alt"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='default-service-many'>
 <!-- we deliver alternative instances of the "delivered-many" service.
@@ -728,15 +798,17 @@ None of these services or instances declare any dependencies.
 </service_bundle>
 """
 
-        smf_fmris["foreign_single_nodeps"] = [
-            "svc:/application/pkg5test/foreign-single",
-            "svc:/application/pkg5test/foreign-single:nodeps"]
+    smf_fmris["foreign_single_nodeps"] = [
+        "svc:/application/pkg5test/foreign-single",
+        "svc:/application/pkg5test/foreign-single:nodeps",
+    ]
 
-        smf_known_deps["svc:/application/pkg5test/foreign-single"] = []
-        smf_known_deps["svc:/application/pkg5test/foreign-single:nodeps"] = []
+    smf_known_deps["svc:/application/pkg5test/foreign-single"] = []
+    smf_known_deps["svc:/application/pkg5test/foreign-single:nodeps"] = []
 
-        smf_manifest_text["foreign_single_nodeps"] = \
-"""<?xml version="1.0"?>
+    smf_manifest_text[
+        "foreign_single_nodeps"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='SUNWcsr:cron'>
 
@@ -778,21 +850,23 @@ None of these services or instances declare any dependencies.
 </service_bundle>
 """
 
-        smf_fmris["foreign_many_nodeps"] = [
-            "svc:/application/pkg5test/foreign-many",
-            "svc:/application/pkg5test/foreign-many:default",
-            "svc:/application/pkg5test/foreign-many:nodeps",
-            "svc:/application/pkg5test/foreign-opt",
-            "svc:/application/pkg5test/foreign-opt:nodeps"]
+    smf_fmris["foreign_many_nodeps"] = [
+        "svc:/application/pkg5test/foreign-many",
+        "svc:/application/pkg5test/foreign-many:default",
+        "svc:/application/pkg5test/foreign-many:nodeps",
+        "svc:/application/pkg5test/foreign-opt",
+        "svc:/application/pkg5test/foreign-opt:nodeps",
+    ]
 
-        smf_known_deps["svc:/application/pkg5test/foreign-many"] = []
-        smf_known_deps["svc:/application/pkg5test/foreign-many:default"] = []
-        smf_known_deps["svc:/application/pkg5test/foreign-many:nodeps"] = []
-        smf_known_deps["svc:/application/pkg5test/foreign-opt"] = []
-        smf_known_deps["svc:/application/pkg5test/foreign-opt:nodeps"] = []
+    smf_known_deps["svc:/application/pkg5test/foreign-many"] = []
+    smf_known_deps["svc:/application/pkg5test/foreign-many:default"] = []
+    smf_known_deps["svc:/application/pkg5test/foreign-many:nodeps"] = []
+    smf_known_deps["svc:/application/pkg5test/foreign-opt"] = []
+    smf_known_deps["svc:/application/pkg5test/foreign-opt:nodeps"] = []
 
-        smf_manifest_text["foreign_many_nodeps"] = \
-"""<?xml version="1.0"?>
+    smf_manifest_text[
+        "foreign_many_nodeps"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='foreign-many-instances'>
 
@@ -873,8 +947,9 @@ None of these services or instances declare any dependencies.
 </service_bundle>
 """
 
-        smf_manifest_text["broken"] = \
-"""<?xml version="1.0"?>
+    smf_manifest_text[
+        "broken"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='broken-service'>
 
@@ -902,13 +977,15 @@ None of these services or instances declare any dependencies.
 </service>
 </service_bundle>
 """
-        smf_fmris["delete"] = [
-            "svc:/application/pkg5test/deleteservice",
-            "svc:/application/pkg5test/deleteservice:default"]
-        smf_known_deps["svc:/application/pkg5test/deleteservice"] = []
-        smf_known_deps["svc:/application/pkg5test/deleteservice:default"] = []
-        smf_manifest_text["delete"] = \
-"""<?xml version="1.0"?>
+    smf_fmris["delete"] = [
+        "svc:/application/pkg5test/deleteservice",
+        "svc:/application/pkg5test/deleteservice:default",
+    ]
+    smf_known_deps["svc:/application/pkg5test/deleteservice"] = []
+    smf_known_deps["svc:/application/pkg5test/deleteservice:default"] = []
+    smf_manifest_text[
+        "delete"
+    ] = """<?xml version="1.0"?>
 <!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
 <service_bundle type='manifest' name='delete-service'>
 
@@ -935,150 +1012,186 @@ None of these services or instances declare any dependencies.
 </service_bundle>
 """
 
-        int_smf_manf = """\
+    int_smf_manf = """\
 file NOHASH group=sys mode=0644 owner=root path={service_single}
 file NOHASH group=sys mode=0644 owner=root path={delivered_many_nodeps}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # service_general depends on a service, instances of which are delivered
-        # by both of the other SMF manifests
-        int_req_svc_smf_manf = """\
+    # service_general depends on a service, instances of which are delivered
+    # by both of the other SMF manifests
+    int_req_svc_smf_manf = """\
 file NOHASH group=sys mode=0644 owner=root path={service_general}
 file NOHASH group=sys mode=0644 owner=root path={delivered_many_nodeps_alt}
 file NOHASH group=sys mode=0644 owner=root path={delivered_many_nodeps}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a bypassed version of the above, to ensure that the use of
-        # full_paths by SMFManifestDependency when multiple files are
-        # depended on still works.
-        bypassed_int_req_svc_smf_manf = """\
+    # a bypassed version of the above, to ensure that the use of
+    # full_paths by SMFManifestDependency when multiple files are
+    # depended on still works.
+    bypassed_int_req_svc_smf_manf = """\
 file NOHASH group=sys mode=0644 owner=root path={service_general} \
     pkg.depend.bypass-generate=.*var/svc/manifest/delivered-many-nodeps-alt.xml
 file NOHASH group=sys mode=0644 owner=root path={delivered_many_nodeps_alt}
 file NOHASH group=sys mode=0644 owner=root path={delivered_many_nodeps}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # service_specific depends on instances delivered by both of the
-        # other SMF manifests
-        int_req_inst_smf_manf = """\
+    # service_specific depends on instances delivered by both of the
+    # other SMF manifests
+    int_req_inst_smf_manf = """\
 file NOHASH group=sys mode=0644 owner=root path={service_single_specific}
 file NOHASH group=sys mode=0644 owner=root path={delivered_many_nodeps_alt}
 file NOHASH group=sys mode=0644 owner=root path={delivered_many_nodeps}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        ext_smf_manf = """\
+    ext_smf_manf = """\
 file NOHASH group=sys mode=0644 owner=root path={service_many}
 file NOHASH group=sys mode=0644 owner=root path={foreign_single_nodeps}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        broken_smf_manf = """\
+    broken_smf_manf = """\
 file NOHASH group=sys mode=0644 owner=root path={broken}
 file NOHASH group=sys mode=0644 owner=root path={delivered_many_nodeps}
 file NOHASH group=sys mode=0644 owner=root path={service_single}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        delete_smf_manf = """\
+    delete_smf_manf = """\
 file NOHASH group=sys mode=0644 owner=root path={delete}
 file NOHASH group=sys mode=0644 owner=root path={foreign_single_nodeps}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        faildeps_smf_manf = """\
+    faildeps_smf_manf = """\
 file NOHASH group=sys mode=0644 owner=root path={delivered_many_nodeps}
 file NOHASH group=sys mode=0644 owner=root path={service_single}
 file NOHASH group=sys mode=0644 owner=root path={service_unknown}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        script_text = "#!/usr/bin/ksh -p\n"
+    script_text = "#!/usr/bin/ksh -p\n"
 
-        # the following scripts and manifests are used to test pkgdepend
-        # runpath and bypass
-        python_bypass_text = """\
+    # the following scripts and manifests are used to test pkgdepend
+    # runpath and bypass
+    python_bypass_text = """\
 #!/usr/bin/python{0}
 # This python script has an import used to test pkgdepend runpath and bypass
 # functionality. pdtest is installed in a non-standard location and generates
 # dependencies on multiple files (pdtest.py, pdtest.pyc, pdtest.pyo, etc.)
 import pkgdep_runpath.pdtest
-""".format(py_ver_default)
+""".format(
+        py_ver_default
+    )
 
-        # standard use of a runpath attribute
-        python_runpath_manf = """\
+    # standard use of a runpath attribute
+    python_runpath_manf = """\
 file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.runpath=opt:$PKGDEPEND_RUNPATH:dummy_directory
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path}
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a manifest which has an empty runpath (which is zany) - we will
-        # throw an error here and want to test for it
-        python_empty_runpath_manf = """
+    # a manifest which has an empty runpath (which is zany) - we will
+    # throw an error here and want to test for it
+    python_empty_runpath_manf = """
 file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.runpath=""
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path}
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a manifest which has a broken runpath
-        python_invalid_runpath_manf = """
+    # a manifest which has a broken runpath
+    python_invalid_runpath_manf = """
 file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.runpath=foo pkg.depend.runpath=bar pkg.depend.runpath=opt
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path}
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a manifest which needs a runpath in order to generate deps properly
-        python_invalid_runpath2_manf = """
+    # a manifest which needs a runpath in order to generate deps properly
+    python_invalid_runpath2_manf = """
 file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.runpath=$PKGDEPEND_RUNPATH:foo:$PKGDEPEND_RUNPATH
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path}
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a manifest that bypasses two files and sets a runpath
-        python_bypass_manf = """
+    # a manifest that bypasses two files and sets a runpath
+    python_bypass_manf = """
 file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.bypass-generate=opt/pkgdep_runpath/pdtest.py \
     pkg.depend.bypass-generate=usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so \
     pkg.depend.runpath=opt:$PKGDEPEND_RUNPATH
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path}
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
-""".format(py_ver_default, py_ver_lib, **paths)
+""".format(
+        py_ver_default, py_ver_lib, **paths
+    )
 
-        # a manifest that generates a single dependency, which we want to
-        # bypass
-        ksh_bypass_manf = """
+    # a manifest that generates a single dependency, which we want to
+    # bypass
+    ksh_bypass_manf = """
 file NOHASH group=sys mode=055 owner=root path={script_path} \
     pkg.depend.bypass-generate=usr/bin/ksh
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a manifest that generates a single dependency, which we want to
-        # bypass.  Specifying just the filename means we should bypass all
-        # paths to that filename (we implicitly add ".*/")
-        ksh_bypass_filename_manf = """
+    # a manifest that generates a single dependency, which we want to
+    # bypass.  Specifying just the filename means we should bypass all
+    # paths to that filename (we implicitly add ".*/")
+    ksh_bypass_filename_manf = """
 file NOHASH group=sys mode=055 owner=root path={script_path} \
     pkg.depend.bypass-generate=ksh
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a manifest that generates a single dependency, which we want to
-        # bypass, duplicating the value
-        ksh_bypass_dup_manf = """
+    # a manifest that generates a single dependency, which we want to
+    # bypass, duplicating the value
+    ksh_bypass_dup_manf = """
 file NOHASH group=sys mode=055 owner=root path={script_path} \
     pkg.depend.bypass-generate=usr/bin/ksh \
     pkg.depend.bypass-generate=usr/bin/ksh
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a manifest that declares bypasses, none of which match the
-        # dependences we generate
-        python_bypass_nomatch_manf = """
+    # a manifest that declares bypasses, none of which match the
+    # dependences we generate
+    python_bypass_nomatch_manf = """
 file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.bypass-generate=cats \
     pkg.depend.bypass-generate=dogs \
     pkg.depend.runpath=$PKGDEPEND_RUNPATH:opt
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path}
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a manifest which uses a wildcard to bypass all dependency generation
-        python_wildcard_bypass_manf = """
+    # a manifest which uses a wildcard to bypass all dependency generation
+    python_wildcard_bypass_manf = """
 file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.bypass-generate=.* \
     pkg.depend.runpath=$PKGDEPEND_RUNPATH:opt
@@ -1088,19 +1201,23 @@ file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path} \
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path} \
     pkg.depend.bypass-generate=.* \
     pkg.depend.runpath=$PKGDEPEND_RUNPATH:opt
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a manifest which uses a file wildcard to bypass generation
-        python_wildcard_file_bypass_manf = """
+    # a manifest which uses a file wildcard to bypass generation
+    python_wildcard_file_bypass_manf = """
 file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.bypass-generate=opt/pkgdep_runpath/.* \
     pkg.depend.runpath=$PKGDEPEND_RUNPATH:opt
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path}
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
-""".format(**paths)
+""".format(
+        **paths
+    )
 
-        # a manifest which uses a dir wildcard to bypass generation
-        python_wildcard_dir_bypass_manf = """
+    # a manifest which uses a dir wildcard to bypass generation
+    python_wildcard_dir_bypass_manf = """
 file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.bypass-generate=pdtest.py \
     pkg.depend.bypass-generate=pdtest.pyc \
@@ -1110,11 +1227,13 @@ file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.runpath=$PKGDEPEND_RUNPATH:opt
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path}
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
-""".format(py_ver_lib, **paths)
+""".format(
+        py_ver_lib, **paths
+    )
 
-        # a manifest which uses a combination of directory, file and normal
-        # bypass entries
-        python_wildcard_combo_bypass_manf = """
+    # a manifest which uses a combination of directory, file and normal
+    # bypass entries
+    python_wildcard_combo_bypass_manf = """
 file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.bypass-generate=pdtest.py \
     pkg.depend.bypass-generate=usr/lib/python{0}/vendor-packages/.* \
@@ -1122,1701 +1241,2276 @@ file NOHASH group=sys mode=0755 owner=root path={bypass_path} \
     pkg.depend.runpath=$PKGDEPEND_RUNPATH:opt
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_path}
 file NOHASH group=sys mode=0755 owner=root path={runpath_mod_test_path}
-""".format(py_ver_default, py_ver_lib, **paths)
+""".format(
+        py_ver_default, py_ver_lib, **paths
+    )
 
-        def glfilter(self, s):
-                return set([x for x in s if not re.match(r'usr/gcc/\d+/', x)])
+    def glfilter(self, s):
+        return set([x for x in s if not re.match(r"usr/gcc/\d+/", x)])
 
-        def tpfilter(self, s):
-                _p, _d = s
-                _d = tuple([x for x in _d
-                    if not re.match(r'^usr/gcc/\d+/lib$', x)])
-                return (_p, _d)
+    def tpfilter(self, s):
+        _p, _d = s
+        _d = tuple([x for x in _d if not re.match(r"^usr/gcc/\d+/lib$", x)])
+        return (_p, _d)
 
-        def setUp(self):
-                pkg5unittest.Pkg5TestCase.setUp(self)
+    def setUp(self):
+        pkg5unittest.Pkg5TestCase.setUp(self)
 
-                self.proto_dir = os.path.join(self.test_root, "proto")
-                os.makedirs(self.proto_dir)
+        self.proto_dir = os.path.join(self.test_root, "proto")
+        os.makedirs(self.proto_dir)
 
-        def make_proto_text_file(self, path, contents=""):
-                self.make_misc_files({path: contents}, prefix="proto")
+    def make_proto_text_file(self, path, contents=""):
+        self.make_misc_files({path: contents}, prefix="proto")
 
-        def make_python_test_files(self, py_version):
-                pdir = "usr/lib/python{0}/vendor-packages".format(py_version)
-                self.make_proto_text_file("{0}/pkg_test/__init__.py".format(pdir),
-                    "#!/usr/bin/python\n")
-                self.make_proto_text_file(
-                    "{0}/pkg_test/indexer_test/__init__.py".format(pdir),
-                    "#!/usr/bin/python")
-                self.make_proto_text_file("{0}/cProfile.py".format(pdir),
-                    self.python_module_text)
-                self.make_proto_text_file("{0}/pkg_test/client/foo.py".format(pdir),
-                    "#!/usr/bin/python\nimport bar")
-                self.make_proto_text_file("{0}/pkg_test/client/bar.py".format(pdir),
-                    "#!/usr/bin/python\n")
-                # install these in non-sys.path locations
-                self.make_proto_text_file(self.paths["bypass_path"],
-                    self.python_bypass_text)
-                self.make_proto_text_file(self.paths["runpath_mod_path"],
-                    "#!/usr/bin/python{0}".format(py_ver_default))
-                self.make_proto_text_file(self.paths["runpath_mod_test_path"],
-                    "#!/usr/bin/python{0}".format(py_ver_default))
+    def make_python_test_files(self, py_version):
+        pdir = "usr/lib/python{0}/vendor-packages".format(py_version)
+        self.make_proto_text_file(
+            "{0}/pkg_test/__init__.py".format(pdir), "#!/usr/bin/python\n"
+        )
+        self.make_proto_text_file(
+            "{0}/pkg_test/indexer_test/__init__.py".format(pdir),
+            "#!/usr/bin/python",
+        )
+        self.make_proto_text_file(
+            "{0}/cProfile.py".format(pdir), self.python_module_text
+        )
+        self.make_proto_text_file(
+            "{0}/pkg_test/client/foo.py".format(pdir),
+            "#!/usr/bin/python\nimport bar",
+        )
+        self.make_proto_text_file(
+            "{0}/pkg_test/client/bar.py".format(pdir), "#!/usr/bin/python\n"
+        )
+        # install these in non-sys.path locations
+        self.make_proto_text_file(
+            self.paths["bypass_path"], self.python_bypass_text
+        )
+        self.make_proto_text_file(
+            self.paths["runpath_mod_path"],
+            "#!/usr/bin/python{0}".format(py_ver_default),
+        )
+        self.make_proto_text_file(
+            self.paths["runpath_mod_test_path"],
+            "#!/usr/bin/python{0}".format(py_ver_default),
+        )
 
-        def make_broken_python_test_file(self, py_version):
-                pdir = "usr/lib/python{0}/vendor-packages".format(py_version)
-                self.make_proto_text_file("{0}/cProfile.py".format(pdir),
-                    "#!/usr/bin/python\n\\1" + self.python_module_text)
+    def make_broken_python_test_file(self, py_version):
+        pdir = "usr/lib/python{0}/vendor-packages".format(py_version)
+        self.make_proto_text_file(
+            "{0}/cProfile.py".format(pdir),
+            "#!/usr/bin/python\n\\1" + self.python_module_text,
+        )
 
-        def make_smf_test_files(self):
-                for manifest in self.smf_paths.keys():
-                        self.make_proto_text_file(self.paths[manifest],
-                            self.smf_manifest_text[manifest])
+    def make_smf_test_files(self):
+        for manifest in self.smf_paths.keys():
+            self.make_proto_text_file(
+                self.paths[manifest], self.smf_manifest_text[manifest]
+            )
 
-        def make_elf(self, final_path, static=False):
-                out_file = os.path.join(self.proto_dir, final_path)
+    def make_elf(self, final_path, static=False):
+        out_file = os.path.join(self.proto_dir, final_path)
 
-                opts = []
-                # In some cases we want to generate an elf binary with no
-                # dependencies of its own.  We use -c (suppress linking) for
-                # this purpose.
-                if static:
-                        opts.extend(["-c"])
-                self.c_compile("int main(){}\n", opts, out_file)
+        opts = []
+        # In some cases we want to generate an elf binary with no
+        # dependencies of its own.  We use -c (suppress linking) for
+        # this purpose.
+        if static:
+            opts.extend(["-c"])
+        self.c_compile("int main(){}\n", opts, out_file)
 
-                return out_file[len(self.proto_dir)+1:]
+        return out_file[len(self.proto_dir) + 1 :]
 
-        def __path_to_key(self, path):
-                if path == self.paths["libc_path"]:
-                        return ((os.path.basename(path),), tuple([
-                            p.lstrip("/") for p in elf.default_run_paths
-                        ]))
-                return ((os.path.basename(path),), (os.path.dirname(path),))
+    def __path_to_key(self, path):
+        if path == self.paths["libc_path"]:
+            return (
+                (os.path.basename(path),),
+                tuple([p.lstrip("/") for p in elf.default_run_paths]),
+            )
+        return ((os.path.basename(path),), (os.path.dirname(path),))
 
-        def test_ext_hardlink(self):
-                """Check that a hardlink with a target outside the package is
-                reported as a dependency."""
+    def test_ext_hardlink(self):
+        """Check that a hardlink with a target outside the package is
+        reported as a dependency."""
 
-                def _check_results(res):
-                        ds, es, ws, ms, pkg_attrs = res
-                        if es != []:
-                                raise RuntimeError("Got errors in results:" +
-                                    "\n".join([str(s) for s in es]))
-                        self.assertEqual(ms, {})
-                        self.assertTrue(len(ds) == 3)
-                        ans = set(["usr/foo", "usr/bar"])
-                        for d in ds:
-                                self.assertTrue(d.dep_vars.is_satisfied())
-                                self.assertTrue(d.is_error())
-                                if d.dep_key() == self.__path_to_key(
-                                    self.paths["syslog_path"]):
-                                        self.assertTrue(
-                                            d.action.attrs["path"] in ans)
-                                        ans.remove(d.action.attrs["path"])
-                                else:
-                                        self.assertEqual(d.dep_key(),
-                                            self.__path_to_key(
-                                                self.paths["authlog_path"]))
-                                        self.assertEqual(
-                                            d.action.attrs["path"], "baz")
-                t_path = self.make_manifest(self.ext_hardlink_manf)
-                _check_results(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False))
-                _check_results(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [],
-                    remove_internal_deps=False, convert=False))
-
-        def test_int_hardlink(self):
-                """Check that a hardlink with a target inside the package is
-                not reported as a dependency, unless the flag to show internal
-                dependencies is set."""
-
-                t_path = self.make_manifest(self.int_hardlink_manf)
-                self.make_proto_text_file(self.paths["syslog_path"])
-                ds, es, ws, ms, pkg_attrs = \
-                    dependencies.list_implicit_deps(t_path, [self.proto_dir],
-                        {}, [], convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertTrue(len(ms) == 1)
-                self.assertTrue(len(ds) == 0)
-
-                # Check that internal dependencies are as expected.
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(len(ms), 1)
-                self.assertEqual(len(ds), 1)
-                d = ds[0]
+        def _check_results(res):
+            ds, es, ws, ms, pkg_attrs = res
+            if es != []:
+                raise RuntimeError(
+                    "Got errors in results:" + "\n".join([str(s) for s in es])
+                )
+            self.assertEqual(ms, {})
+            self.assertTrue(len(ds) == 3)
+            ans = set(["usr/foo", "usr/bar"])
+            for d in ds:
                 self.assertTrue(d.dep_vars.is_satisfied())
                 self.assertTrue(d.is_error())
-                self.assertEqual(d.dep_key(), self.__path_to_key(
-                    self.paths["syslog_path"]))
-                self.assertEqual(d.action.attrs["path"], "usr/foo")
-                self.assertTrue(dependencies.is_file_dependency(d))
+                if d.dep_key() == self.__path_to_key(self.paths["syslog_path"]):
+                    self.assertTrue(d.action.attrs["path"] in ans)
+                    ans.remove(d.action.attrs["path"])
+                else:
+                    self.assertEqual(
+                        d.dep_key(),
+                        self.__path_to_key(self.paths["authlog_path"]),
+                    )
+                    self.assertEqual(d.action.attrs["path"], "baz")
 
-        def test_ext_script(self):
-                """Check that a file that starts with #! and references a file
-                outside its package is reported as a dependency."""
+        t_path = self.make_manifest(self.ext_hardlink_manf)
+        _check_results(
+            dependencies.list_implicit_deps(
+                t_path, [self.proto_dir], {}, [], convert=False
+            )
+        )
+        _check_results(
+            dependencies.list_implicit_deps(
+                t_path,
+                [self.proto_dir],
+                {},
+                [],
+                remove_internal_deps=False,
+                convert=False,
+            )
+        )
 
-                def _check_res(res):
-                        ds, es, ws, ms, pkg_attrs = res
-                        if es != []:
-                                raise RuntimeError("Got errors in results:" +
-                                    "\n".join([str(s) for s in es]))
-                        self.assertEqual(ms, {})
-                        self.assertTrue(len(ds) == 1)
-                        d = ds[0]
-                        self.assertTrue(d.is_error())
-                        self.assertTrue(d.dep_vars.is_satisfied())
-                        self.assertEqual(d.dep_key(),
-                            self.__path_to_key(self.paths["ksh_path"]))
-                        self.assertEqual(d.action.attrs["path"],
-                            self.paths["script_path"])
-                t_path = self.make_manifest(self.ext_script_manf)
-                self.make_proto_text_file(self.paths["script_path"],
-                    self.script_text)
-                _check_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False))
-                _check_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False))
+    def test_int_hardlink(self):
+        """Check that a hardlink with a target inside the package is
+        not reported as a dependency, unless the flag to show internal
+        dependencies is set."""
 
-        def test_int_script(self):
-                """Check that a file that starts with #! and references a file
-                inside its package is not reported as a dependency unless
-                the flag to show internal dependencies is set."""
+        t_path = self.make_manifest(self.int_hardlink_manf)
+        self.make_proto_text_file(self.paths["syslog_path"])
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertTrue(len(ms) == 1)
+        self.assertTrue(len(ds) == 0)
 
-                t_path = self.make_manifest(self.int_script_manf)
-                self.make_elf(self.paths["ksh_path"])
-                self.make_proto_text_file(self.paths["script_path"],
-                    self.script_text)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertTrue(len(ds) == 1)
-                d = ds[0]
+        # Check that internal dependencies are as expected.
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(len(ms), 1)
+        self.assertEqual(len(ds), 1)
+        d = ds[0]
+        self.assertTrue(d.dep_vars.is_satisfied())
+        self.assertTrue(d.is_error())
+        self.assertEqual(
+            d.dep_key(), self.__path_to_key(self.paths["syslog_path"])
+        )
+        self.assertEqual(d.action.attrs["path"], "usr/foo")
+        self.assertTrue(dependencies.is_file_dependency(d))
+
+    def test_ext_script(self):
+        """Check that a file that starts with #! and references a file
+        outside its package is reported as a dependency."""
+
+        def _check_res(res):
+            ds, es, ws, ms, pkg_attrs = res
+            if es != []:
+                raise RuntimeError(
+                    "Got errors in results:" + "\n".join([str(s) for s in es])
+                )
+            self.assertEqual(ms, {})
+            self.assertTrue(len(ds) == 1)
+            d = ds[0]
+            self.assertTrue(d.is_error())
+            self.assertTrue(d.dep_vars.is_satisfied())
+            self.assertEqual(
+                d.dep_key(), self.__path_to_key(self.paths["ksh_path"])
+            )
+            self.assertEqual(d.action.attrs["path"], self.paths["script_path"])
+
+        t_path = self.make_manifest(self.ext_script_manf)
+        self.make_proto_text_file(self.paths["script_path"], self.script_text)
+        _check_res(
+            dependencies.list_implicit_deps(
+                t_path, [self.proto_dir], {}, [], convert=False
+            )
+        )
+        _check_res(
+            dependencies.list_implicit_deps(
+                t_path,
+                [self.proto_dir],
+                {},
+                [],
+                remove_internal_deps=False,
+                convert=False,
+            )
+        )
+
+    def test_int_script(self):
+        """Check that a file that starts with #! and references a file
+        inside its package is not reported as a dependency unless
+        the flag to show internal dependencies is set."""
+
+        t_path = self.make_manifest(self.int_script_manf)
+        self.make_elf(self.paths["ksh_path"])
+        self.make_proto_text_file(self.paths["script_path"], self.script_text)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertTrue(len(ds) == 1)
+        d = ds[0]
+        self.assertTrue(d.is_error())
+        self.assertTrue(d.dep_vars.is_satisfied())
+        self.assertEqual(d.base_names[0], "libc.so.1")
+        self.assertEqual(
+            self.glfilter(set(d.run_paths)), set(["lib", "usr/lib"])
+        )
+
+        # Check that internal dependencies are as expected.
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertEqual(len(ds), 2)
+        for d in ds:
+            self.assertTrue(d.is_error())
+            self.assertTrue(d.dep_vars.is_satisfied())
+            self.assertTrue(dependencies.is_file_dependency(d))
+            if d.dep_key() == self.__path_to_key(self.paths["ksh_path"]):
+                self.assertEqual(
+                    d.action.attrs["path"], self.paths["script_path"]
+                )
+            elif self.tpfilter(d.dep_key()) == self.__path_to_key(
+                self.paths["libc_path"]
+            ):
+                self.assertEqual(d.action.attrs["path"], self.paths["ksh_path"])
+            else:
+                raise RuntimeError(
+                    "Unexpected " "dependency path:{0}".format(d)
+                )
+
+    def test_ext_elf(self):
+        """Check that an elf file that requires a library outside its
+        package is reported as a dependency."""
+
+        def _check_res(res):
+            ds, es, ws, ms, pkg_attrs = res
+            if es != []:
+                raise RuntimeError(
+                    "Got errors in results:" + "\n".join([str(s) for s in es])
+                )
+            self.assertEqual(ms, {})
+            self.assertTrue(len(ds) == 1)
+            d = ds[0]
+            self.assertTrue(d.is_error())
+            self.assertTrue(d.dep_vars.is_satisfied())
+            self.assertEqual(d.base_names[0], "libc.so.1")
+            self.assertEqual(
+                self.glfilter(set(d.run_paths)), set(["lib", "usr/lib"])
+            )
+            self.assertEqual(
+                self.tpfilter(d.dep_key()),
+                self.__path_to_key(self.paths["libc_path"]),
+            )
+            self.assertEqual(d.action.attrs["path"], self.paths["curses_path"])
+            self.assertTrue(dependencies.is_file_dependency(d))
+
+        t_path = self.make_manifest(self.ext_elf_manf)
+        self.make_elf(self.paths["curses_path"])
+        _check_res(
+            dependencies.list_implicit_deps(
+                t_path, [self.proto_dir], {}, [], convert=False
+            )
+        )
+        _check_res(
+            dependencies.list_implicit_deps(
+                t_path,
+                [self.proto_dir],
+                {},
+                [],
+                remove_internal_deps=False,
+                convert=False,
+            )
+        )
+
+    def test_int_elf(self):
+        """Check that an elf file that requires a library inside its
+        package is not reported as a dependency unless the flag to show
+        internal dependencies is set."""
+
+        def _check_all_res(res):
+            ds, es, ws, ms, pkg_attrs = res
+            if es != []:
+                raise RuntimeError(
+                    "Got errors in results:" + "\n".join([str(s) for s in es])
+                )
+            self.assertEqual(ms, {})
+            self.assertEqual(len(ds), 1)
+            d = ds[0]
+            self.assertTrue(d.is_error())
+            self.assertTrue(d.dep_vars.is_satisfied())
+            self.assertEqual(d.base_names[0], "libc.so.1")
+            self.assertEqual(
+                self.glfilter(set(d.run_paths)), set(["lib", "usr/lib"])
+            )
+            self.assertEqual(
+                self.tpfilter(d.dep_key()),
+                self.__path_to_key(self.paths["libc_path"]),
+            )
+            self.assertEqual(d.action.attrs["path"], self.paths["curses_path"])
+            self.assertTrue(dependencies.is_file_dependency(d))
+
+        t_path = self.make_manifest(self.int_elf_manf)
+        self.make_elf(self.paths["curses_path"])
+        self.make_elf(self.paths["libc_path"], static=True)
+        d_map, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertTrue(len(d_map) == 0)
+
+        # Check that internal dependencies are as expected.
+        _check_all_res(
+            dependencies.list_implicit_deps(
+                t_path,
+                [self.proto_dir],
+                {},
+                [],
+                remove_internal_deps=False,
+                convert=False,
+            )
+        )
+
+    def test_ext_python_dep(self):
+        """Check that a python file that imports a module outside its
+        package is reported as a dependency."""
+
+        def _check_all_res(res):
+            ds, es, ws, ms, pkg_attrs = res
+            mod_names = [
+                "foobar",
+                "misc_test",
+                "os",
+                "search_storage",
+                "minidom",
+            ]
+            pkg_names = ["indexer_test", "pkg", "pkg_test", "xml", "dom"]
+            expected_deps = set(
+                [("python",)]
+                + [
+                    tuple(sorted([pat.format(n) for pat in mod_pats]))
+                    for n in mod_names
+                ]
+                + [("{0}/__init__.py".format(n),) for n in pkg_names]
+            )
+            if es != []:
+                raise RuntimeError(
+                    "Got errors in results:" + "\n".join([str(s) for s in es])
+                )
+
+            self.assertEqual(ms, {})
+            for d in ds:
                 self.assertTrue(d.is_error())
+                if d.dep_vars is None:
+                    raise RuntimeError(
+                        "This dep had " "depvars of None:{0}".format(d)
+                    )
                 self.assertTrue(d.dep_vars.is_satisfied())
-                self.assertEqual(d.base_names[0], "libc.so.1")
-                self.assertEqual(self.glfilter(set(d.run_paths)),
-                    set(["lib", "usr/lib"]))
+                if not d.dep_key()[0] in expected_deps:
+                    raise RuntimeError(
+                        "Got this "
+                        "unexpected dep:{0}\n\nd:{1}".format(d.dep_key()[0], d)
+                    )
+                expected_deps.remove(d.dep_key()[0])
+                self.assertEqual(
+                    d.action.attrs["path"], self.paths["indexer_path"]
+                )
+            if expected_deps:
+                raise RuntimeError(
+                    "Couldn't find these "
+                    "dependencies:\n"
+                    + "\n".join([str(s) for s in sorted(expected_deps)])
+                )
 
-                # Check that internal dependencies are as expected.
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                self.assertEqual(len(ds), 2)
-                for d in ds:
-                        self.assertTrue(d.is_error())
-                        self.assertTrue(d.dep_vars.is_satisfied())
-                        self.assertTrue(dependencies.is_file_dependency(d))
-                        if d.dep_key() == self.__path_to_key(
-                            self.paths["ksh_path"]):
-                                self.assertEqual(d.action.attrs["path"],
-                                    self.paths["script_path"])
-                        elif self.tpfilter(d.dep_key()) == self.__path_to_key(
-                            self.paths["libc_path"]):
-                                self.assertEqual(d.action.attrs["path"],
-                                    self.paths["ksh_path"])
-                        else:
-                                raise RuntimeError("Unexpected "
-                                    "dependency path:{0}".format(d))
+        self.__debug = True
+        t_path = self.make_manifest(self.ext_python_manf)
+        self.make_python_test_files(py_ver_default)
+        self.make_proto_text_file(self.paths["indexer_path"], self.python_text)
+        _check_all_res(
+            dependencies.list_implicit_deps(
+                t_path, [self.proto_dir], {}, [], convert=False
+            )
+        )
+        _check_all_res(
+            dependencies.list_implicit_deps(
+                t_path,
+                [self.proto_dir],
+                {},
+                [],
+                remove_internal_deps=False,
+                convert=False,
+            )
+        )
 
-        def test_ext_elf(self):
-                """Check that an elf file that requires a library outside its
-                package is reported as a dependency."""
+    def test_ext_python_abs_import_dep(self):
+        """Check that a python file that uses absolute imports a module
+        is handled correctly."""
 
-                def _check_res(res):
-                        ds, es, ws, ms, pkg_attrs = res
-                        if es != []:
-                                raise RuntimeError("Got errors in results:" +
-                                    "\n".join([str(s) for s in es]))
-                        self.assertEqual(ms, {})
-                        self.assertTrue(len(ds) == 1)
-                        d = ds[0]
-                        self.assertTrue(d.is_error())
-                        self.assertTrue(d.dep_vars.is_satisfied())
-                        self.assertEqual(d.base_names[0], "libc.so.1")
-                        self.assertEqual(self.glfilter(set(d.run_paths)),
-                            set(["lib", "usr/lib"]))
-                        self.assertEqual(self.tpfilter(d.dep_key()),
-                            self.__path_to_key(self.paths["libc_path"]))
-                        self.assertEqual(
-                                d.action.attrs["path"],
-                                self.paths["curses_path"])
-                        self.assertTrue(dependencies.is_file_dependency(d))
+        def _check_all_res(res):
+            ds, es, ws, ms, pkg_attrs = res
+            mod_names = ["foobar", "os", "search_storage", "minidom"]
+            pkg_names = ["indexer_test", "pkg", "pkg_test", "xml", "dom"]
+            expected_deps = set(
+                [("python",)]
+                + [
+                    tuple(sorted([pat.format(n) for pat in mod_pats]))
+                    for n in mod_names
+                ]
+                + [("{0}/__init__.py".format(n),) for n in pkg_names]
+            )
+            if len(es) != 1:
+                raise RuntimeError(
+                    "Expected exactly 1 error, "
+                    "got:%\n" + "\n".join([str(s) for s in es])
+                )
+            if es[0].name != "misc_test":
+                raise RuntimeError(
+                    "Didn't get the expected "
+                    "error. Error found was:{0}".format(es[0])
+                )
 
-                t_path = self.make_manifest(self.ext_elf_manf)
-                self.make_elf(self.paths["curses_path"])
-                _check_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False))
-                _check_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False))
-
-        def test_int_elf(self):
-                """Check that an elf file that requires a library inside its
-                package is not reported as a dependency unless the flag to show
-                internal dependencies is set."""
-
-                def _check_all_res(res):
-                        ds, es, ws, ms, pkg_attrs = res
-                        if es != []:
-                                raise RuntimeError("Got errors in results:" +
-                                    "\n".join([str(s) for s in es]))
-                        self.assertEqual(ms, {})
-                        self.assertEqual(len(ds), 1)
-                        d = ds[0]
-                        self.assertTrue(d.is_error())
-                        self.assertTrue(d.dep_vars.is_satisfied())
-                        self.assertEqual(d.base_names[0], "libc.so.1")
-                        self.assertEqual(self.glfilter(set(d.run_paths)),
-                            set(["lib", "usr/lib"]))
-                        self.assertEqual(self.tpfilter(d.dep_key()),
-                            self.__path_to_key(self.paths["libc_path"]))
-                        self.assertEqual(d.action.attrs["path"],
-                            self.paths["curses_path"])
-                        self.assertTrue(dependencies.is_file_dependency(d))
-
-                t_path = self.make_manifest(self.int_elf_manf)
-                self.make_elf(self.paths["curses_path"])
-                self.make_elf(self.paths["libc_path"], static=True)
-                d_map, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    t_path, [self.proto_dir], {}, [], convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertTrue(len(d_map) == 0)
-
-                # Check that internal dependencies are as expected.
-                _check_all_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False))
-
-        def test_ext_python_dep(self):
-                """Check that a python file that imports a module outside its
-                package is reported as a dependency."""
-
-                def _check_all_res(res):
-                        ds, es, ws, ms, pkg_attrs = res
-                        mod_names = ["foobar", "misc_test", "os",
-                            "search_storage", "minidom"]
-                        pkg_names = ["indexer_test", "pkg", "pkg_test", "xml",
-                            "dom"]
-                        expected_deps = set([("python",)] +
-                            [tuple(sorted([
-                                pat.format(n) for pat in mod_pats
-                            ]))
-                            for n in mod_names] +
-                            [("{0}/__init__.py".format(n),) for n in pkg_names])
-                        if es != []:
-                                raise RuntimeError("Got errors in results:" +
-                                    "\n".join([str(s) for s in es]))
-
-                        self.assertEqual(ms, {})
-                        for d in ds:
-                                self.assertTrue(d.is_error())
-                                if d.dep_vars is None:
-                                        raise RuntimeError("This dep had "
-                                            "depvars of None:{0}".format(d))
-                                self.assertTrue(d.dep_vars.is_satisfied())
-                                if not d.dep_key()[0] in expected_deps:
-                                        raise RuntimeError("Got this "
-                                            "unexpected dep:{0}\n\nd:{1}".format(
-                                            d.dep_key()[0], d))
-                                expected_deps.remove(d.dep_key()[0])
-                                self.assertEqual(d.action.attrs["path"],
-                                        self.paths["indexer_path"])
-                        if expected_deps:
-                                raise RuntimeError("Couldn't find these "
-                                    "dependencies:\n" + "\n".join(
-                                    [str(s) for s in sorted(expected_deps)]))
-                self.__debug = True
-                t_path = self.make_manifest(self.ext_python_manf)
-                self.make_python_test_files(py_ver_default)
-                self.make_proto_text_file(self.paths["indexer_path"],
-                    self.python_text)
-                _check_all_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False))
-                _check_all_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False))
-
-        def test_ext_python_abs_import_dep(self):
-                """Check that a python file that uses absolute imports a module
-                is handled correctly."""
-
-                def _check_all_res(res):
-                        ds, es, ws, ms, pkg_attrs = res
-                        mod_names = ["foobar", "os", "search_storage",
-                            "minidom"]
-                        pkg_names = ["indexer_test", "pkg", "pkg_test", "xml",
-                            "dom"]
-                        expected_deps = set([("python",)] +
-                            [tuple(sorted([
-                                pat.format(n) for pat in mod_pats
-                            ]))
-                            for n in mod_names] +
-                            [("{0}/__init__.py".format(n),) for n in pkg_names])
-                        if len(es) != 1:
-                                raise RuntimeError("Expected exactly 1 error, "
-                                    "got:%\n" + "\n".join([str(s) for s in es]))
-                        if es[0].name != "misc_test":
-                                raise RuntimeError("Didn't get the expected "
-                                    "error. Error found was:{0}".format(es[0]))
-
-                        self.assertEqual(ms, {})
-                        for d in ds:
-                                self.assertTrue(d.is_error())
-                                if d.dep_vars is None:
-                                        raise RuntimeError("This dep had "
-                                            "depvars of None:{0}".format(d))
-                                self.assertTrue(d.dep_vars.is_satisfied())
-                                if not d.dep_key()[0] in expected_deps:
-                                        raise RuntimeError("Got this "
-                                            "unexpected dep:{0}\n\nd:{1}".format(
-                                            d.dep_key()[0], d))
-                                expected_deps.remove(d.dep_key()[0])
-                                self.assertEqual(d.action.attrs["path"],
-                                        self.paths["indexer_path"])
-                        if expected_deps:
-                                raise RuntimeError("Couldn't find these "
-                                    "dependencies:\n" + "\n".join(
-                                    [str(s) for s in sorted(expected_deps)]))
-                self.__debug = True
-                t_path = self.make_manifest(self.ext_python_manf)
-                self.make_python_test_files(py_ver_default)
-                # Check that absolute imports still work.
-                self.make_proto_text_file(self.paths["indexer_path"],
-                    self.python_abs_text)
-                _check_all_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False))
-                _check_all_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False))
-
-        def test_ext_python_pkg_dep(self):
-                """Check that a python file that is the __init__.py file for a
-                package is handled correctly."""
-
-                def _check_all_res(res):
-                        ds, es, ws, ms, pkg_attrs = res
-                        mod_names = ["foobar", "misc_test", "os",
-                            "search_storage", "minidom"]
-                        pkg_names = ["indexer_test", "pkg", "pkg_test",
-                            "xml", "dom"]
-
-                        # for a multi-level import, we should have the correct
-                        # dir suffixes generated for the pkg.debug.depend.paths
-                        path_suffixes = {"minidom.py": "xml/dom",
-                            "dom/__init__.py": "xml"}
-
-                        expected_deps = set([("python",)] +
-                            [tuple(sorted([
-                                pat.format(n) for pat in mod_pats
-                            ]))
-                            for n in mod_names] +
-                            [("{0}/__init__.py".format(n),) for n in pkg_names])
-                        if es != []:
-                                raise RuntimeError("Got errors in results:" +
-                                    "\n".join([str(s) for s in es]))
-
-                        self.assertEqual(ms, {})
-                        for d in ds:
-                                self.assertTrue(d.is_error())
-                                if d.dep_vars is None:
-                                        raise RuntimeError("This dep had "
-                                            "depvars of None:{0}".format(d))
-                                self.assertTrue(d.dep_vars.is_satisfied())
-                                if not d.dep_key()[0] in expected_deps:
-                                        raise RuntimeError("Got this "
-                                            "unexpected dep:{0}\n\nd:{1}".format(
-                                            d.dep_key()[0], d))
-
-                                # check the suffixes generated in our
-                                # pkg.debug.depend.path
-                                for bn in d.base_names:
-                                        if bn not in path_suffixes:
-                                                continue
-
-                                        suffix = path_suffixes[bn]
-                                        for p in d.run_paths:
-                                                self.assertTrue(
-                                                    p.endswith(suffix) or
-                                                    p == os.path.dirname(
-                                                    self.paths["pkg_path"]),
-                                                    "suffix {0} not found in "
-                                                    "paths for {1}: {2}".format(
-                                                    suffix, bn, " ".join(
-                                                    d.run_paths)))
-
-                                expected_deps.remove(d.dep_key()[0])
-                                self.assertEqual(d.action.attrs["path"],
-                                        self.paths["pkg_path"])
-                        if expected_deps:
-                                raise RuntimeError("Couldn't find these "
-                                    "dependencies:\n" + "\n".join(
-                                    [str(s) for s in sorted(expected_deps)]))
-                self.__debug = True
-                t_path = self.make_manifest(self.ext_python_pkg_manf)
-                self.make_python_test_files(py_ver_default)
-                self.make_proto_text_file(self.paths["pkg_path"],
-                    self.python_text)
-                _check_all_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False))
-                _check_all_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False))
-
-        def test_python_imp_main(self):
-                """Ensure we can generate a dependency from a python module
-                known to cause different behaviour in modulefinder, where
-                we try to import __main__"""
-
-                t_path = self.make_manifest(self.python_mod_manf)
-                # Two versions are used because the python dependency checker
-                # has two code paths, one that uses the native module importer
-                # and one that fires off a subprocess (depthlimited.py). So
-                # there is a need to verify the output from both code paths.
-                self.make_python_test_files(py_ver_other)
-                self.make_python_test_files(py_ver_default)
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False)
-                # No errors detected.
-                self.assertTrue(len(es) == 0, "Unexpected errors reported: {0}".format(es))
-                # Two for python and two for the __main__ dependency.
-                self.assertTrue(len(ds) == 4, "Unexpected deps reported: {0}".format(ds))
-                for d in ds:
-                        self.assertTrue(d.base_names == ["python"] or
-                                        "__main__.abi3.so" in d.base_names or
-                                        "__main__module.so" in d.base_names,
-                                        "Bad dependency generated: {0}".format(ds))
-
-        def test_python_relative_import_generation(self):
-                """This is a test for bug 14094.  It ensures that a python
-                dependency's paths include the directory into which the file
-                will be delivered."""
-
-                t_path = self.make_manifest(
-                    self.relative_ext_depender_manf)
-                self.make_python_test_files(py_ver_default)
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=True,
-                    convert=False)
-
-                pddt = "pkg.debug.depend.type"
-                pddp = "pkg.debug.depend.path"
-                pddf = "pkg.debug.depend.file"
-
-                expected_deps = set([pat.format("bar") for pat in mod_pats])
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertEqual(len(ds), 2)
-                got_relative_import = False
-                for d in ds:
-                        if d.attrs[pddt] == "script":
-                                continue
-                        self.assertEqual(d.attrs[pddt], "python")
-                        self.assertEqualDiff(expected_deps, set(d.attrs[pddf]))
-                        ep = os.path.dirname(self.paths["relative_depender"])
-                        if ep not in d.attrs[pddp]:
-                                raise RuntimeError("Expected {0} to be in the "
-                                    "list of pkg.debug.depend.path attribute "
-                                    "values, but it wasn't seen.".format(ep))
-
-                t_path = self.make_manifest(
-                    self.relative_int_manf)
-                self.assertTrue(os.path.exists(os.path.join(self.proto_dir,
-                    self.paths["relative_dependee"])))
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=True,
-                    convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertEqual(len(ds), 2, "Expected two dependencies, "
-                    "got:\n{0}".format("\n".join([str(d) for d in ds])))
-                for d in ds:
-                        self.assertEqual(d.attrs[pddt], "script", "Got this "
-                            "dependency which wasn't of the expected type:{0}".format(
-                            d))
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertEqual(len(ds), 3)
-                got_relative_import = False
-                for d in ds:
-                        if d.attrs[pddt] == "script":
-                                continue
-                        self.assertEqual(d.attrs[pddt], "python")
-                        self.assertEqualDiff(expected_deps, set(d.attrs[pddf]))
-                        ep = os.path.dirname(self.paths["relative_depender"])
-                        if ep not in d.attrs[pddp]:
-                                raise RuntimeError("Expected {0} to be in the "
-                                    "list of pkg.debug.depend.path attribute "
-                                    "values, but it wasn't seen.".format(ep))
-
-        def test_bug_18031(self):
-                """Test that an python file which python cannot import due to a
-                syntax error doesn't cause a traceback."""
-
-                t_path = self.make_manifest(self.python_mod_manf)
-                # Two versions are used because the python dependency checker
-                # has two code paths, one that uses the native module importer
-                # and one that fires off a subprocess (depthlimited.py). So
-                # there is a need to verify the output from both code paths.
-                self.make_broken_python_test_file(py_ver_other)
-                self.make_broken_python_test_file(py_ver_default)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False)
-                # One error for each python version.
-                self.assertTrue(len(es) == 2, "Unexpected errors reported: {0}".format(es))
-                for e in es:
-                        self.debug(str(e))
-                        self.assertTrue("but contains a syntax error that" in str(e))
-                # should be two dependencies (both on python)
-                self.assertTrue(len(ds) == 2, "Unexpected deps reported: {0}".format(ds))
-                for d in ds:
-                        self.assertTrue(d.base_names == ["python"],
-                                        "Unexpected dependency: {0}".format(ds))
-
-        def test_variants_1(self):
-                """Test that a file which satisfies a dependency only under a
-                certain set of variants results in the dependency being reported
-                for the other set of variants."""
-
-                t_path = self.make_manifest(self.variant_manf_1)
-                self.make_proto_text_file(self.paths["script_path"],
-                    self.script_text)
-                self.make_elf(self.paths["ksh_path"])
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertTrue(len(ds) == 2)
-                for d in ds:
-                        self.assertTrue(d.is_error())
-                        if d.dep_key() == self.__path_to_key(
-                            self.paths["ksh_path"]):
-                                self.assertEqual(d.action.attrs["path"],
-                                    self.paths["script_path"])
-                                expected_not_sat = set([
-                                    frozenset([("variant.arch", "bar")]),
-                                    frozenset([("variant.arch", "baz")])])
-                                expected_sat = set([
-                                    frozenset([("variant.arch", "foo")])])
-                                self.assertEqual(expected_sat,
-                                    d.dep_vars.sat_set)
-                                self.assertEqual(expected_not_sat,
-                                    d.dep_vars.not_sat_set)
-                        elif self.tpfilter(d.dep_key()) == self.__path_to_key(
-                            self.paths["libc_path"]):
-                                self.assertEqual(
-                                    d.action.attrs["path"],
-                                    self.paths["ksh_path"])
-                                expected_not_sat = set([
-                                    frozenset([("variant.arch", "foo")])])
-                                expected_sat = set()
-                                self.assertEqual(expected_sat,
-                                    d.dep_vars.sat_set)
-                                self.assertEqual(expected_not_sat,
-                                    d.dep_vars.not_sat_set)
-                        else:
-                                raise RuntimeError("Unexpected "
-                                    "dependency path:{0}".format(d.dep_key()))
-
-        def test_variants_2(self):
-                """Test that when the variants of the action with the dependency
-                and the action satisfying the dependency share the same
-                dependency, an external dependency is not reported."""
-
-                t_path = self.make_manifest(self.variant_manf_2)
-                self.make_proto_text_file(self.paths["script_path"],
-                    self.script_text)
-                self.make_elf(self.paths["ksh_path"])
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertTrue(len(ds) == 1)
-                d = ds[0]
+            self.assertEqual(ms, {})
+            for d in ds:
                 self.assertTrue(d.is_error())
+                if d.dep_vars is None:
+                    raise RuntimeError(
+                        "This dep had " "depvars of None:{0}".format(d)
+                    )
+                self.assertTrue(d.dep_vars.is_satisfied())
+                if not d.dep_key()[0] in expected_deps:
+                    raise RuntimeError(
+                        "Got this "
+                        "unexpected dep:{0}\n\nd:{1}".format(d.dep_key()[0], d)
+                    )
+                expected_deps.remove(d.dep_key()[0])
+                self.assertEqual(
+                    d.action.attrs["path"], self.paths["indexer_path"]
+                )
+            if expected_deps:
+                raise RuntimeError(
+                    "Couldn't find these "
+                    "dependencies:\n"
+                    + "\n".join([str(s) for s in sorted(expected_deps)])
+                )
+
+        self.__debug = True
+        t_path = self.make_manifest(self.ext_python_manf)
+        self.make_python_test_files(py_ver_default)
+        # Check that absolute imports still work.
+        self.make_proto_text_file(
+            self.paths["indexer_path"], self.python_abs_text
+        )
+        _check_all_res(
+            dependencies.list_implicit_deps(
+                t_path, [self.proto_dir], {}, [], convert=False
+            )
+        )
+        _check_all_res(
+            dependencies.list_implicit_deps(
+                t_path,
+                [self.proto_dir],
+                {},
+                [],
+                remove_internal_deps=False,
+                convert=False,
+            )
+        )
+
+    def test_ext_python_pkg_dep(self):
+        """Check that a python file that is the __init__.py file for a
+        package is handled correctly."""
+
+        def _check_all_res(res):
+            ds, es, ws, ms, pkg_attrs = res
+            mod_names = [
+                "foobar",
+                "misc_test",
+                "os",
+                "search_storage",
+                "minidom",
+            ]
+            pkg_names = ["indexer_test", "pkg", "pkg_test", "xml", "dom"]
+
+            # for a multi-level import, we should have the correct
+            # dir suffixes generated for the pkg.debug.depend.paths
+            path_suffixes = {"minidom.py": "xml/dom", "dom/__init__.py": "xml"}
+
+            expected_deps = set(
+                [("python",)]
+                + [
+                    tuple(sorted([pat.format(n) for pat in mod_pats]))
+                    for n in mod_names
+                ]
+                + [("{0}/__init__.py".format(n),) for n in pkg_names]
+            )
+            if es != []:
+                raise RuntimeError(
+                    "Got errors in results:" + "\n".join([str(s) for s in es])
+                )
+
+            self.assertEqual(ms, {})
+            for d in ds:
+                self.assertTrue(d.is_error())
+                if d.dep_vars is None:
+                    raise RuntimeError(
+                        "This dep had " "depvars of None:{0}".format(d)
+                    )
+                self.assertTrue(d.dep_vars.is_satisfied())
+                if not d.dep_key()[0] in expected_deps:
+                    raise RuntimeError(
+                        "Got this "
+                        "unexpected dep:{0}\n\nd:{1}".format(d.dep_key()[0], d)
+                    )
+
+                # check the suffixes generated in our
+                # pkg.debug.depend.path
+                for bn in d.base_names:
+                    if bn not in path_suffixes:
+                        continue
+
+                    suffix = path_suffixes[bn]
+                    for p in d.run_paths:
+                        self.assertTrue(
+                            p.endswith(suffix)
+                            or p == os.path.dirname(self.paths["pkg_path"]),
+                            "suffix {0} not found in "
+                            "paths for {1}: {2}".format(
+                                suffix, bn, " ".join(d.run_paths)
+                            ),
+                        )
+
+                expected_deps.remove(d.dep_key()[0])
+                self.assertEqual(d.action.attrs["path"], self.paths["pkg_path"])
+            if expected_deps:
+                raise RuntimeError(
+                    "Couldn't find these "
+                    "dependencies:\n"
+                    + "\n".join([str(s) for s in sorted(expected_deps)])
+                )
+
+        self.__debug = True
+        t_path = self.make_manifest(self.ext_python_pkg_manf)
+        self.make_python_test_files(py_ver_default)
+        self.make_proto_text_file(self.paths["pkg_path"], self.python_text)
+        _check_all_res(
+            dependencies.list_implicit_deps(
+                t_path, [self.proto_dir], {}, [], convert=False
+            )
+        )
+        _check_all_res(
+            dependencies.list_implicit_deps(
+                t_path,
+                [self.proto_dir],
+                {},
+                [],
+                remove_internal_deps=False,
+                convert=False,
+            )
+        )
+
+    def test_python_imp_main(self):
+        """Ensure we can generate a dependency from a python module
+        known to cause different behaviour in modulefinder, where
+        we try to import __main__"""
+
+        t_path = self.make_manifest(self.python_mod_manf)
+        # Two versions are used because the python dependency checker
+        # has two code paths, one that uses the native module importer
+        # and one that fires off a subprocess (depthlimited.py). So
+        # there is a need to verify the output from both code paths.
+        self.make_python_test_files(py_ver_other)
+        self.make_python_test_files(py_ver_default)
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        # No errors detected.
+        self.assertTrue(
+            len(es) == 0, "Unexpected errors reported: {0}".format(es)
+        )
+        # Two for python and two for the __main__ dependency.
+        self.assertTrue(
+            len(ds) == 4, "Unexpected deps reported: {0}".format(ds)
+        )
+        for d in ds:
+            self.assertTrue(
+                d.base_names == ["python"]
+                or "__main__.abi3.so" in d.base_names
+                or "__main__module.so" in d.base_names,
+                "Bad dependency generated: {0}".format(ds),
+            )
+
+    def test_python_relative_import_generation(self):
+        """This is a test for bug 14094.  It ensures that a python
+        dependency's paths include the directory into which the file
+        will be delivered."""
+
+        t_path = self.make_manifest(self.relative_ext_depender_manf)
+        self.make_python_test_files(py_ver_default)
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=True,
+            convert=False,
+        )
+
+        pddt = "pkg.debug.depend.type"
+        pddp = "pkg.debug.depend.path"
+        pddf = "pkg.debug.depend.file"
+
+        expected_deps = set([pat.format("bar") for pat in mod_pats])
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertEqual(len(ds), 2)
+        got_relative_import = False
+        for d in ds:
+            if d.attrs[pddt] == "script":
+                continue
+            self.assertEqual(d.attrs[pddt], "python")
+            self.assertEqualDiff(expected_deps, set(d.attrs[pddf]))
+            ep = os.path.dirname(self.paths["relative_depender"])
+            if ep not in d.attrs[pddp]:
+                raise RuntimeError(
+                    "Expected {0} to be in the "
+                    "list of pkg.debug.depend.path attribute "
+                    "values, but it wasn't seen.".format(ep)
+                )
+
+        t_path = self.make_manifest(self.relative_int_manf)
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(self.proto_dir, self.paths["relative_dependee"])
+            )
+        )
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=True,
+            convert=False,
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertEqual(
+            len(ds),
+            2,
+            "Expected two dependencies, "
+            "got:\n{0}".format("\n".join([str(d) for d in ds])),
+        )
+        for d in ds:
+            self.assertEqual(
+                d.attrs[pddt],
+                "script",
+                "Got this "
+                "dependency which wasn't of the expected type:{0}".format(d),
+            )
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertEqual(len(ds), 3)
+        got_relative_import = False
+        for d in ds:
+            if d.attrs[pddt] == "script":
+                continue
+            self.assertEqual(d.attrs[pddt], "python")
+            self.assertEqualDiff(expected_deps, set(d.attrs[pddf]))
+            ep = os.path.dirname(self.paths["relative_depender"])
+            if ep not in d.attrs[pddp]:
+                raise RuntimeError(
+                    "Expected {0} to be in the "
+                    "list of pkg.debug.depend.path attribute "
+                    "values, but it wasn't seen.".format(ep)
+                )
+
+    def test_bug_18031(self):
+        """Test that an python file which python cannot import due to a
+        syntax error doesn't cause a traceback."""
+
+        t_path = self.make_manifest(self.python_mod_manf)
+        # Two versions are used because the python dependency checker
+        # has two code paths, one that uses the native module importer
+        # and one that fires off a subprocess (depthlimited.py). So
+        # there is a need to verify the output from both code paths.
+        self.make_broken_python_test_file(py_ver_other)
+        self.make_broken_python_test_file(py_ver_default)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        # One error for each python version.
+        self.assertTrue(
+            len(es) == 2, "Unexpected errors reported: {0}".format(es)
+        )
+        for e in es:
+            self.debug(str(e))
+            self.assertTrue("but contains a syntax error that" in str(e))
+        # should be two dependencies (both on python)
+        self.assertTrue(
+            len(ds) == 2, "Unexpected deps reported: {0}".format(ds)
+        )
+        for d in ds:
+            self.assertTrue(
+                d.base_names == ["python"],
+                "Unexpected dependency: {0}".format(ds),
+            )
+
+    def test_variants_1(self):
+        """Test that a file which satisfies a dependency only under a
+        certain set of variants results in the dependency being reported
+        for the other set of variants."""
+
+        t_path = self.make_manifest(self.variant_manf_1)
+        self.make_proto_text_file(self.paths["script_path"], self.script_text)
+        self.make_elf(self.paths["ksh_path"])
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertTrue(len(ds) == 2)
+        for d in ds:
+            self.assertTrue(d.is_error())
+            if d.dep_key() == self.__path_to_key(self.paths["ksh_path"]):
+                self.assertEqual(
+                    d.action.attrs["path"], self.paths["script_path"]
+                )
+                expected_not_sat = set(
+                    [
+                        frozenset([("variant.arch", "bar")]),
+                        frozenset([("variant.arch", "baz")]),
+                    ]
+                )
+                expected_sat = set([frozenset([("variant.arch", "foo")])])
+                self.assertEqual(expected_sat, d.dep_vars.sat_set)
+                self.assertEqual(expected_not_sat, d.dep_vars.not_sat_set)
+            elif self.tpfilter(d.dep_key()) == self.__path_to_key(
+                self.paths["libc_path"]
+            ):
+                self.assertEqual(d.action.attrs["path"], self.paths["ksh_path"])
                 expected_not_sat = set([frozenset([("variant.arch", "foo")])])
                 expected_sat = set()
                 self.assertEqual(expected_sat, d.dep_vars.sat_set)
                 self.assertEqual(expected_not_sat, d.dep_vars.not_sat_set)
-                self.assertEqual(d.base_names[0], "libc.so.1")
-                self.assertEqual(self.glfilter(set(d.run_paths)),
-                    set(["lib", "usr/lib"]))
+            else:
+                raise RuntimeError(
+                    "Unexpected " "dependency path:{0}".format(d.dep_key())
+                )
 
-                # Check that internal dependencies are as expected.
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertTrue(len(ds) == 2)
-                for d in ds:
-                        self.assertTrue(d.is_error())
-                        # Because not removing internal dependencies means that
-                        # no resolution of their variants happens, both
-                        # dependencies have their variants as unsatisfied.
-                        expected_not_sat = set([
-                            frozenset([("variant.arch", "foo")])])
-                        expected_sat = set()
-                        self.assertEqual(expected_sat, d.dep_vars.sat_set)
-                        self.assertEqual(expected_not_sat,
-                            d.dep_vars.not_sat_set)
-                        if d.dep_key() == self.__path_to_key(
-                            self.paths["ksh_path"]):
-                                self.assertEqual(d.action.attrs["path"],
-                                    self.paths["script_path"])
-                        elif self.tpfilter(d.dep_key()) == self.__path_to_key(
-                            self.paths["libc_path"]):
-                                self.assertEqual(d.action.attrs["path"],
-                                    self.paths["ksh_path"])
-                        else:
-                                raise RuntimeError(
-                                    "Unexpected dependency path:{0}".format(
-                                    d.dep_key()))
+    def test_variants_2(self):
+        """Test that when the variants of the action with the dependency
+        and the action satisfying the dependency share the same
+        dependency, an external dependency is not reported."""
 
-        def test_variants_3(self):
-                """Test that when the action with the dependency is tagged with
-                a different variant than the action which could satisfy it, it's
-                reported as an external dependency."""
+        t_path = self.make_manifest(self.variant_manf_2)
+        self.make_proto_text_file(self.paths["script_path"], self.script_text)
+        self.make_elf(self.paths["ksh_path"])
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertTrue(len(ds) == 1)
+        d = ds[0]
+        self.assertTrue(d.is_error())
+        expected_not_sat = set([frozenset([("variant.arch", "foo")])])
+        expected_sat = set()
+        self.assertEqual(expected_sat, d.dep_vars.sat_set)
+        self.assertEqual(expected_not_sat, d.dep_vars.not_sat_set)
+        self.assertEqual(d.base_names[0], "libc.so.1")
+        self.assertEqual(
+            self.glfilter(set(d.run_paths)), set(["lib", "usr/lib"])
+        )
 
-                t_path = self.make_manifest(self.variant_manf_3)
-                self.make_proto_text_file(self.paths["script_path"],
-                    self.script_text)
-                self.make_elf(self.paths["ksh_path"])
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertTrue(len(ds) == 2)
-                for d in ds:
-                        self.assertTrue(d.is_error())
-                        if d.dep_key() == self.__path_to_key(
-                            self.paths["ksh_path"]):
-                                self.assertEqual(d.action.attrs["path"],
-                                    self.paths["script_path"])
-                                expected_not_sat = set([
-                                    frozenset([("variant.arch", "bar")])])
-                                expected_sat = set()
-                                self.assertEqual(expected_sat,
-                                    d.dep_vars.sat_set)
-                                self.assertEqual(expected_not_sat,
-                                    d.dep_vars.not_sat_set)
-                        elif self.tpfilter(d.dep_key()) == self.__path_to_key(
-                            self.paths["libc_path"]):
-                                self.assertEqual(d.action.attrs["path"],
-                                    self.paths["ksh_path"])
-                                expected_not_sat = set([
-                                    frozenset([("variant.arch", "foo")])])
-                                expected_sat = set()
-                                self.assertEqual(expected_sat,
-                                    d.dep_vars.sat_set)
-                                self.assertEqual(expected_not_sat,
-                                    d.dep_vars.not_sat_set)
-                        else:
-                                raise RuntimeError("Unexpected "
-                                    "dependency path:{0}".format(d.dep_key()))
+        # Check that internal dependencies are as expected.
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertTrue(len(ds) == 2)
+        for d in ds:
+            self.assertTrue(d.is_error())
+            # Because not removing internal dependencies means that
+            # no resolution of their variants happens, both
+            # dependencies have their variants as unsatisfied.
+            expected_not_sat = set([frozenset([("variant.arch", "foo")])])
+            expected_sat = set()
+            self.assertEqual(expected_sat, d.dep_vars.sat_set)
+            self.assertEqual(expected_not_sat, d.dep_vars.not_sat_set)
+            if d.dep_key() == self.__path_to_key(self.paths["ksh_path"]):
+                self.assertEqual(
+                    d.action.attrs["path"], self.paths["script_path"]
+                )
+            elif self.tpfilter(d.dep_key()) == self.__path_to_key(
+                self.paths["libc_path"]
+            ):
+                self.assertEqual(d.action.attrs["path"], self.paths["ksh_path"])
+            else:
+                raise RuntimeError(
+                    "Unexpected dependency path:{0}".format(d.dep_key())
+                )
 
-        def test_variants_4(self):
-                """Test that an action with a variant that depends on a
-                delivered action also tagged with that variant, but not with a
-                package-level variant is reported as an internal dependency, not
-                an external one."""
+    def test_variants_3(self):
+        """Test that when the action with the dependency is tagged with
+        a different variant than the action which could satisfy it, it's
+        reported as an external dependency."""
 
-                t_path = self.make_manifest(self.variant_manf_4)
-                self.make_proto_text_file(self.paths["script_path"],
-                    self.script_text)
-                self.make_elf(self.paths["ksh_path"])
-
-                # Check that we only report a single external dependency
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertTrue(len(ds) == 1)
-                d = ds[0]
-
-                self.assertTrue(d.is_error())
-                expected_not_sat = set([frozenset([
-                    ("variant.opensolaris.zone", "global")])])
+        t_path = self.make_manifest(self.variant_manf_3)
+        self.make_proto_text_file(self.paths["script_path"], self.script_text)
+        self.make_elf(self.paths["ksh_path"])
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertTrue(len(ds) == 2)
+        for d in ds:
+            self.assertTrue(d.is_error())
+            if d.dep_key() == self.__path_to_key(self.paths["ksh_path"]):
+                self.assertEqual(
+                    d.action.attrs["path"], self.paths["script_path"]
+                )
+                expected_not_sat = set([frozenset([("variant.arch", "bar")])])
                 expected_sat = set()
-                self.assertEqualDiff(expected_sat, d.dep_vars.sat_set)
-                self.assertEqualDiff(expected_not_sat, d.dep_vars.not_sat_set)
+                self.assertEqual(expected_sat, d.dep_vars.sat_set)
+                self.assertEqual(expected_not_sat, d.dep_vars.not_sat_set)
+            elif self.tpfilter(d.dep_key()) == self.__path_to_key(
+                self.paths["libc_path"]
+            ):
+                self.assertEqual(d.action.attrs["path"], self.paths["ksh_path"])
+                expected_not_sat = set([frozenset([("variant.arch", "foo")])])
+                expected_sat = set()
+                self.assertEqual(expected_sat, d.dep_vars.sat_set)
+                self.assertEqual(expected_not_sat, d.dep_vars.not_sat_set)
+            else:
+                raise RuntimeError(
+                    "Unexpected " "dependency path:{0}".format(d.dep_key())
+                )
 
-                self.assertEqual(d.base_names[0], "libc.so.1")
-                self.assertEqual(self.glfilter(set(d.run_paths)),
-                    set(["lib", "usr/lib"]))
+    def test_variants_4(self):
+        """Test that an action with a variant that depends on a
+        delivered action also tagged with that variant, but not with a
+        package-level variant is reported as an internal dependency, not
+        an external one."""
 
-                # Check that internal dependencies are as expected.
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertEqual(pkg_attrs, {})
-                self.assertTrue(len(ds) == 2)
-                for d in ds:
-                        self.assertTrue(d.is_error())
-                        # Because not removing internal dependencies means that
-                        # no resolution of their variants happens, both
-                        # dependencies have their variants as unsatisfied.
-                        expected_not_sat = set([frozenset([
+        t_path = self.make_manifest(self.variant_manf_4)
+        self.make_proto_text_file(self.paths["script_path"], self.script_text)
+        self.make_elf(self.paths["ksh_path"])
+
+        # Check that we only report a single external dependency
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertTrue(len(ds) == 1)
+        d = ds[0]
+
+        self.assertTrue(d.is_error())
+        expected_not_sat = set(
+            [frozenset([("variant.opensolaris.zone", "global")])]
+        )
+        expected_sat = set()
+        self.assertEqualDiff(expected_sat, d.dep_vars.sat_set)
+        self.assertEqualDiff(expected_not_sat, d.dep_vars.not_sat_set)
+
+        self.assertEqual(d.base_names[0], "libc.so.1")
+        self.assertEqual(
+            self.glfilter(set(d.run_paths)), set(["lib", "usr/lib"])
+        )
+
+        # Check that internal dependencies are as expected.
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertEqual(pkg_attrs, {})
+        self.assertTrue(len(ds) == 2)
+        for d in ds:
+            self.assertTrue(d.is_error())
+            # Because not removing internal dependencies means that
+            # no resolution of their variants happens, both
+            # dependencies have their variants as unsatisfied.
+            expected_not_sat = set(
+                [
+                    frozenset(
+                        [
                             ("variant.arch", "foo"),
-                            ("variant.opensolaris.zone", "global")])])
-                        expected_sat = set()
-                        self.assertEqual(expected_sat, d.dep_vars.sat_set)
-                        self.assertEqual(expected_not_sat,
-                            d.dep_vars.not_sat_set)
-
-                        if d.dep_key() == self.__path_to_key(
-                            self.paths["ksh_path"]):
-                                self.assertEqual(d.action.attrs["path"],
-                                    self.paths["script_path"])
-                        elif self.tpfilter(d.dep_key()) == self.__path_to_key(
-                            self.paths["libc_path"]):
-                                self.assertEqual(d.action.attrs["path"],
-                                    self.paths["ksh_path"])
-                        else:
-                                raise RuntimeError(
-                                    "Unexpected dependency path:{0}".format(
-                                    d.dep_key()))
-
-        def test_symlinks(self):
-                """Test that a file is recognized as delivered when a symlink
-                is involved."""
-
-                usr_path = os.path.join(self.proto_dir, "usr")
-                hardlink_path = os.path.join(usr_path, "foo")
-                bar_path = os.path.join(self.proto_dir, "bar")
-                file_path = os.path.join(bar_path, "syslog")
-                var_path = os.path.join(self.proto_dir, "var")
-                symlink_loc = os.path.join(var_path, "log")
-                hardlink_target = os.path.join(usr_path,
-                    "../var/log/syslog")
-                os.mkdir(usr_path)
-                os.mkdir(bar_path)
-                os.mkdir(var_path)
-                fh = open(file_path, "w")
-                fh.close()
-                os.symlink(bar_path, symlink_loc)
-                os.link(hardlink_target, hardlink_path)
-
-                t_path = self.make_manifest(
-                    self.int_hardlink_manf_test_symlink)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False)
-
-        def test_str_methods(self):
-                """Test the str methods of objects in the flavor space."""
-
-                str(base.MissingFile("fp"))
-                str(elf.BadElfFile("fp", "ex"))
-                str(elf.UnsupportedDynamicToken("/proto_path", "/install",
-                    "run_path", "tok"))
-                str(py.PythonModuleMissingPath("foo", "bar"))
-                str(py.PythonMismatchedVersion(py_ver_default, py_ver_other, "foo", "bar"))
-                str(py.PythonSubprocessError(2, "foo", "bar"))
-                str(py.PythonSubprocessBadLine("cmd", ["l1", "l2"]))
-                mi = dlmf.ModuleInfo("name", ["/d1", "/d2"])
-                str(mi)
-                mi.make_package()
-                str(mi)
-
-        def test_multi_proto_dirs(self):
-                """Check that analysis works correctly when multiple proto_dirs
-                are given."""
-
-                def _check_all_res(res):
-                        ds, es, ms = res
-                        if es != []:
-                                raise RuntimeError("Got errors in results:" +
-                                    "\n".join([str(s) for s in es]))
-                        self.assertEqual(ms, {})
-                        self.assertEqual(len(ds), 1)
-                        d = ds[0]
-                        self.assertTrue(d.is_error())
-                        self.assertTrue(d.dep_vars.is_satisfied())
-                        self.assertEqual(d.base_names[0], "libc.so.1")
-                        self.assertEqual(set(d.run_paths),
-                            set(["lib", "usr/lib"]))
-                        self.assertEqual(d.dep_key(),
-                            self.__path_to_key(self.paths["libc_path"]))
-                        self.assertEqual(d.action.attrs["path"],
-                            self.paths["curses_path"])
-                        self.assertTrue(dependencies.is_file_dependency(d))
-
-                t_path = self.make_manifest(self.int_elf_manf)
-                self.make_elf(os.path.join("foo", self.paths["curses_path"]))
-                self.make_elf(self.paths["libc_path"], static=True)
-
-                # This should fail because the "foo" directory is not given
-                # as a proto_dir.
-                d_map, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    t_path, [self.proto_dir], {}, [], convert=False)
-                if len(es) != 1:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                if es[0].file_path != self.paths["curses_path"]:
-                        raise RuntimeError("Wrong file was found missing:\n{0}".format(
-                            es[0]))
-                self.assertEqual(es[0].dirs, [self.proto_dir])
-                self.assertEqual(ms, {})
-                self.assertTrue(len(d_map) == 0)
-
-                # This should work since the "foo" directory has been added to
-                # the list of proto_dirs to use.
-                d_map, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    t_path, [self.proto_dir,
-                    os.path.join(self.proto_dir, "foo")], {}, [], convert=False)
-                if es:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertTrue(len(d_map) == 0)
-
-                # This should be different because the empty text file
-                # is found before the binary file.
-                self.make_proto_text_file(self.paths["curses_path"])
-                d_map, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    t_path, [self.proto_dir,
-                    os.path.join(self.proto_dir, "foo")], {}, [],
-                    remove_internal_deps=False, convert=False)
-                if es:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                if len(ms) != 1:
-                        raise RuntimeError("Didn't get expected types of "
-                            "missing files:\n{0}".format(ms))
-                self.assertEqual(list(ms.keys())[0], portable.EMPTYFILE)
-                self.assertTrue(len(d_map) == 0)
-
-                # This should find the binary file first and thus produce
-                # a depend action.
-                d_map, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    t_path, [os.path.join(self.proto_dir, "foo"),
-                    self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                if es:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertEqual(ms, {})
-                self.assertTrue(len(d_map) == 1)
-
-                # Check alternative proto_dirs with hardlinks.
-                t_path = self.make_manifest(self.int_hardlink_manf)
-                self.make_proto_text_file(os.path.join("foo",
-                    self.paths["syslog_path"]))
-                # This test should fail because "foo" is not included in the
-                # list of proto_dirs.
-                ds, es, ws, ms, pkg_attrs = \
-                    dependencies.list_implicit_deps(t_path, [self.proto_dir],
-                        {}, [], convert=False)
-                if len(es) != 1:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                if es[0].file_path != self.paths["syslog_path"]:
-                        raise RuntimeError("Wrong file was found missing:\n{0}".format(
-                            es[0]))
-                self.assertEqual(es[0].dirs, [self.proto_dir])
-                self.assertTrue(len(ms) == 0)
-                self.assertTrue(len(ds) == 1)
-
-                # This test should pass because the needed directory has been
-                # added to the list of proto_dirs.
-                ds, es, ws, ms, pkg_attrs = \
-                    dependencies.list_implicit_deps(t_path,
-                        [self.proto_dir, os.path.join(self.proto_dir, "foo")],
-                        {}, [], convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                self.assertTrue(len(ms) == 1)
-                self.assertTrue(len(ds) == 0)
-
-                # Check alternative proto_dirs work with python files and
-                # scripts.
-
-                def _py_check_all_res(res):
-                        ds, es, ws, ms, pkg_attrs = res
-                        mod_names = ["foobar", "misc_test", "os",
-                            "search_storage", "minidom"]
-                        pkg_names = ["indexer_test", "pkg", "pkg_test",
-                            "xml", "dom"]
-                        expected_deps = set([("python",)] +
-                            [tuple(sorted([
-                                pat.format(n) for pat in mod_pats
-                            ]))
-                            for n in mod_names] +
-                            [("{0}/__init__.py".format(n),) for n in pkg_names])
-                        if es != []:
-                                raise RuntimeError("Got errors in results:" +
-                                    "\n".join([str(s) for s in es]))
-
-                        self.assertEqual(ms, {})
-                        for d in ds:
-                                self.assertTrue(d.is_error())
-                                if d.dep_vars is None:
-                                        raise RuntimeError("This dep had "
-                                            "depvars of None:{0}".format(d))
-                                self.assertTrue(d.dep_vars.is_satisfied())
-                                if not d.dep_key()[0] in expected_deps:
-                                        raise RuntimeError("Got this "
-                                            "unexpected dep:{0}\n\nd:{1}".format(
-                                            d.dep_key()[0], d))
-                                expected_deps.remove(d.dep_key()[0])
-                                self.assertEqual(d.action.attrs["path"],
-                                        self.paths["indexer_path"])
-                        if expected_deps:
-                                raise RuntimeError("Couldn't find these "
-                                    "dependencies:\n" + "\n".join(
-                                    [str(s) for s in sorted(expected_deps)]))
-                self.__debug = True
-                t_path = self.make_manifest(self.ext_python_manf)
-
-                self.make_proto_text_file(
-                    os.path.join("d5", self.paths["indexer_path"]),
-                    self.python_text)
-                # This should have an error because it cannot find the file
-                # needed.
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], convert=False)
-                if len(es) != 1:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-                if es[0].file_path != self.paths["indexer_path"]:
-                        raise RuntimeError("Wrong file was found missing:\n{0}".format(
-                            es[0]))
-                self.assertEqual(es[0].dirs, [self.proto_dir])
-                self.assertEqual(len(ds), 0)
-                self.assertEqual(len(ms), 0)
-
-                # Because d5 is in the list of proto dirs, this test should work
-                # normally.
-                _py_check_all_res(dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir, os.path.join(self.proto_dir, "d5")], {},
-                    [], convert=False))
-
-        def test_smf_manifest_parse(self):
-                """ We parse valid SMF manifests returning instance
-                and dependency info."""
-
-                for manifest in self.smf_paths.keys():
-                        self.make_proto_text_file(self.paths[manifest],
-                            self.smf_manifest_text[manifest])
-
-                        # This should not parse, returning empty lists
-                        if manifest == "broken":
-                                instances, deps = smf.parse_smf_manifest(
-                                    self.proto_dir + "/" + self.paths[manifest])
-                                self.assertEqual(instances, None)
-                                self.assertEqual(deps, None)
-                                continue
-
-                        # Ensuring each manifest can be parsed
-                        # and we detect declared dependencies and
-                        # FMRIs according to those hardcoded in the test
-                        instances, deps = smf.parse_smf_manifest(
-                            self.proto_dir + "/" + self.paths[manifest])
-                        for fmri in instances:
-
-                                for dep in self.smf_known_deps[fmri]:
-                                        if dep not in deps[fmri]:
-                                                self.assertTrue(False,
-                                                    "{0} not found in "
-                                                    "dependencies for {1}".format(
-                                                    dep, manifest))
-                                expected = len(self.smf_known_deps[fmri])
-                                actual = len(deps[fmri])
-
-                                self.assertEqual(expected, actual,
-                                    "expected number of deps ({0}) != "
-                                    "actual ({1}) for {2}"
-                                   .format(expected, actual, fmri))
-
-        def check_smf_fmris(self, pkg_attrs, expected, manifest_name):
-                """ Given a list of expected SMF FMRIs, verify that each is
-                present in the provided pkg_attrs dictionary. Errors are
-                reported in an assertion message that includes manifest_name."""
-
-                self.assertTrue("org.opensolaris.smf.fmri" in pkg_attrs,
-                    "Missing org.opensolaris.smf.fmri key for {0}".format(
-                    manifest_name))
-
-                found = len(pkg_attrs["org.opensolaris.smf.fmri"])
-                self.assertEqual(found, len(expected),
-                    "Wrong no. of SMF instances/services found for {0}: expected"
-                    " {1} got {2}".format(manifest_name, len(expected), found))
-
-                for fmri in expected:
-                            self.assertTrue(
-                                fmri in pkg_attrs["org.opensolaris.smf.fmri"],
-                                "{0} not in list of SMF instances/services "
-                                "from {1}".format(fmri, manifest_name))
-
-        def print_deps(self, deps):
-                for dep in deps:
-                        print(dep.base_names)
-
-        def test_int_smf_manifest(self):
-                """We identify SMF dependencies delivered in the same package"""
-
-                t_path = self.make_manifest(self.int_smf_manf)
-                self.make_smf_test_files()
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-
-                self.assertTrue(len(ds) == 1, "Expected 1 dependency, got {0}".format(
-                    len(ds)))
-                d = ds[0]
-
-                # verify we have identified the one internal file we depend on
-                actual = d.manifest.replace(self.proto_dir + "/", "")
-                expected = self.paths["delivered_many_nodeps"]
-                self.assertEqual(actual, expected,
-                    "Expected dependency path {0}, got {1}".format(actual, expected))
-
-                self.check_smf_fmris(pkg_attrs,
-                    self.smf_fmris["service_single"] +
-                    self.smf_fmris["delivered_many_nodeps"],
-                    "int_smf_manf")
-
-                # verify that removing internal dependencies works as expected
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=True,
-                    convert=False)
-                self.assertTrue(len(ds) == 0, "Expected 0 dependencies, got {0}".format(
-                    len(ds)))
-                self.assertTrue(dependencies.is_file_dependency(d))
-
-        def test_ext_smf_manifest(self):
-                """We identify SMF dependencies delivered in a different
-                package"""
-
-                t_path = self.make_manifest(self.ext_smf_manf)
-                self.make_smf_test_files()
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-
-                self.assertTrue(len(ds) == 1, "Expected 1 dependency, got {0}".format(
-                    len(ds)))
-
-                # verify we have identified the one external file we depend on
-                actual = ds[0].manifest.replace(self.proto_dir + "/", "")
-                expected = self.paths["foreign_many_nodeps"]
-                self.assertEqual(actual, expected,
-                    "Expected dependency path {0}, got {1}".format(actual, expected))
-
-                self.check_smf_fmris(pkg_attrs,
-                    self.smf_fmris["service_many"] +
-                    self.smf_fmris["foreign_single_nodeps"],
-                    "ext_smf_manf")
-
-        def test_broken_manifest(self):
-                """We report errors when dealing with a broken SMF manifest."""
-
-                # as it happens, file(1) isn't good at spotting broken
-                # XML documents, it only sniffs the header - so this file
-                # gets reported as an XMLDOC despite it being invalid
-                # XML.
-                t_path = self.make_manifest(self.broken_smf_manf)
-                self.make_smf_test_files()
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-
-                self.assertEqual(len(ms), 1, "No unknown files reported during "
-                    "analysis")
-
-                if portable.XMLDOC not in ms:
-                        self.assertTrue(False, "Broken SMF manifest file not"
-                            " declared")
-
-                broken_path = os.path.join(self.proto_dir, self.paths["broken"])
-                self.assertEqual(ms[portable.XMLDOC], broken_path,
-                    "Did not detect broken SMF manifest file: {0} != {1}".format(
-                    broken_path, ms[portable.XMLDOC]))
-
-                # We should still be able to resolve the other dependencies
-                # though and it's important to check that the one broken SMF
-                # manifest file didn't break the rest of the SMF manifest
-                # backend.  This has been implicitly tested in other tests,
-                # as the broken file is always installed in the manifest
-                # location.
-                if es != []:
-                        raise RuntimeError("Got errors in results:" +
-                            "\n".join([str(s) for s in es]))
-
-                # our dependency comes from service_single depending on
-                # delivered_many
-                self.assertTrue(len(ds) == 1, "Expected 1 dependency, got {0}".format(
-                    len(ds)))
-                d = ds[0]
-
-                # verify we have identified the one internal file we depend on
-                actual = d.manifest.replace(self.proto_dir + "/", "")
-                expected = self.paths["delivered_many_nodeps"]
-                self.assertEqual(actual, expected,
-                    "Expected dependency path {0}, got {1}".format(actual, expected))
-
-                self.check_smf_fmris(pkg_attrs,
-                    self.smf_fmris["service_single"] +
-                    self.smf_fmris["delivered_many_nodeps"],
-                    "broken_smf_manf")
-
-        def test_faildeps_smf_manifest(self):
-                """We report failed attempts to resolve dependencies"""
-
-                t_path = self.make_manifest(self.faildeps_smf_manf)
-                self.make_smf_test_files()
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-
-                self.assertTrue(len(es) == 3,
-                    "Detected {0} error(s), expected 3".format(len(es)))
-
-                # our two dependencies come from:
-                # service_single depending on delivered_many_nodeps
-                # service_unknown depending on delivered_many_nodeps
-                self.assertTrue(len(ds) == 2, "Expected 2 dependencies, got {0}".format(
-                    len(ds)))
-
-                for d in ds:
-                        actual = d.manifest.replace(self.proto_dir + "/", "")
-                        expected = self.paths["delivered_many_nodeps"]
-                        self.assertEqual(actual, expected,
-                            "Expected dependency path {0}, got {1}".format(
-                            actual, expected))
-
-                self.check_smf_fmris(pkg_attrs,
-                    self.smf_fmris["service_single"] +
-                    self.smf_fmris["delivered_many_nodeps"] +
-                    self.smf_fmris["service_unknown"],
-                    "faildeps_smf_manf")
-
-        def test_delete_smf_manifest(self):
-                """We don't create any SMF dependencies where a manifest
-                specifies a 'delete' attribute in its dependency."""
-
-                t_path = self.make_manifest(self.delete_smf_manf)
-                self.make_smf_test_files()
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-
-                self.assertTrue(len(es) == 0,
-                    "Detected {0} error(s), expected 0".format(len(es)))
-                self.assertTrue(len(ds) == 0, "Expected 0 dependencies, got {0}".format(
-                    len(ds)))
-                self.check_smf_fmris(pkg_attrs, self.smf_fmris["delete"] +
-                    self.smf_fmris["foreign_single_nodeps"], "delete")
-
-        def test_req_any_smf_manifest(self):
-                """We can generate dependencies that can be turned into
-                require-any dependencies.
-
-                In this test, we generate dependencies on three different SMF
-                manifests:
-
-                The first has a single service-level dependency that is
-                satisfied by two instances, delivered by two separate SMF
-                manifests, generating a single dependency that can be turned
-                into a require-any depend action.
-
-                The second has two instance-level dependencies that are also
-                delivered by two separate SMF manifests, and should generate two
-                require dependencies (because we're being specific about which
-                instances we depend on, rather than depending on any instance
-                of that service, as in the first case, above)
-
-                The last is a version of the first, with a bypass attribute, to
-                ensure that we correctly process bypasses when generating
-                multiple dependencies. (SMFManifestDependency doesn't use
-                base_names/run_paths when multiple SMF manifests are found as
-                dependencies, but instead specifies full_paths directly, which
-                are modified by the bypass-generation code)
-                """
-
-                self.make_smf_test_files()
-
-                # Test the first case: service dependencies satisfied by
-                # multiple SMF manifests.
-                t_path = self.make_manifest(self.int_req_svc_smf_manf)
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    t_path, [self.proto_dir], {}, [],
-                    remove_internal_deps=False, convert=False)
-                self.assertTrue(len(es) == 0, "Detected {0} error(s), expected 0".format(
-                    len(es)))
-                self.assertTrue(len(ds) == 1, "Expected 1 dependency when "
-                    "depending on a service, got {0}".format(len(ds)))
-                # ensure the dependencies are correct.
-                self.assertTrue(set(ds[0].full_paths) == set([
+                            ("variant.opensolaris.zone", "global"),
+                        ]
+                    )
+                ]
+            )
+            expected_sat = set()
+            self.assertEqual(expected_sat, d.dep_vars.sat_set)
+            self.assertEqual(expected_not_sat, d.dep_vars.not_sat_set)
+
+            if d.dep_key() == self.__path_to_key(self.paths["ksh_path"]):
+                self.assertEqual(
+                    d.action.attrs["path"], self.paths["script_path"]
+                )
+            elif self.tpfilter(d.dep_key()) == self.__path_to_key(
+                self.paths["libc_path"]
+            ):
+                self.assertEqual(d.action.attrs["path"], self.paths["ksh_path"])
+            else:
+                raise RuntimeError(
+                    "Unexpected dependency path:{0}".format(d.dep_key())
+                )
+
+    def test_symlinks(self):
+        """Test that a file is recognized as delivered when a symlink
+        is involved."""
+
+        usr_path = os.path.join(self.proto_dir, "usr")
+        hardlink_path = os.path.join(usr_path, "foo")
+        bar_path = os.path.join(self.proto_dir, "bar")
+        file_path = os.path.join(bar_path, "syslog")
+        var_path = os.path.join(self.proto_dir, "var")
+        symlink_loc = os.path.join(var_path, "log")
+        hardlink_target = os.path.join(usr_path, "../var/log/syslog")
+        os.mkdir(usr_path)
+        os.mkdir(bar_path)
+        os.mkdir(var_path)
+        fh = open(file_path, "w")
+        fh.close()
+        os.symlink(bar_path, symlink_loc)
+        os.link(hardlink_target, hardlink_path)
+
+        t_path = self.make_manifest(self.int_hardlink_manf_test_symlink)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+
+    def test_str_methods(self):
+        """Test the str methods of objects in the flavor space."""
+
+        str(base.MissingFile("fp"))
+        str(elf.BadElfFile("fp", "ex"))
+        str(
+            elf.UnsupportedDynamicToken(
+                "/proto_path", "/install", "run_path", "tok"
+            )
+        )
+        str(py.PythonModuleMissingPath("foo", "bar"))
+        str(
+            py.PythonMismatchedVersion(
+                py_ver_default, py_ver_other, "foo", "bar"
+            )
+        )
+        str(py.PythonSubprocessError(2, "foo", "bar"))
+        str(py.PythonSubprocessBadLine("cmd", ["l1", "l2"]))
+        mi = dlmf.ModuleInfo("name", ["/d1", "/d2"])
+        str(mi)
+        mi.make_package()
+        str(mi)
+
+    def test_multi_proto_dirs(self):
+        """Check that analysis works correctly when multiple proto_dirs
+        are given."""
+
+        def _check_all_res(res):
+            ds, es, ms = res
+            if es != []:
+                raise RuntimeError(
+                    "Got errors in results:" + "\n".join([str(s) for s in es])
+                )
+            self.assertEqual(ms, {})
+            self.assertEqual(len(ds), 1)
+            d = ds[0]
+            self.assertTrue(d.is_error())
+            self.assertTrue(d.dep_vars.is_satisfied())
+            self.assertEqual(d.base_names[0], "libc.so.1")
+            self.assertEqual(set(d.run_paths), set(["lib", "usr/lib"]))
+            self.assertEqual(
+                d.dep_key(), self.__path_to_key(self.paths["libc_path"])
+            )
+            self.assertEqual(d.action.attrs["path"], self.paths["curses_path"])
+            self.assertTrue(dependencies.is_file_dependency(d))
+
+        t_path = self.make_manifest(self.int_elf_manf)
+        self.make_elf(os.path.join("foo", self.paths["curses_path"]))
+        self.make_elf(self.paths["libc_path"], static=True)
+
+        # This should fail because the "foo" directory is not given
+        # as a proto_dir.
+        d_map, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        if len(es) != 1:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        if es[0].file_path != self.paths["curses_path"]:
+            raise RuntimeError(
+                "Wrong file was found missing:\n{0}".format(es[0])
+            )
+        self.assertEqual(es[0].dirs, [self.proto_dir])
+        self.assertEqual(ms, {})
+        self.assertTrue(len(d_map) == 0)
+
+        # This should work since the "foo" directory has been added to
+        # the list of proto_dirs to use.
+        d_map, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir, os.path.join(self.proto_dir, "foo")],
+            {},
+            [],
+            convert=False,
+        )
+        if es:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertTrue(len(d_map) == 0)
+
+        # This should be different because the empty text file
+        # is found before the binary file.
+        self.make_proto_text_file(self.paths["curses_path"])
+        d_map, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir, os.path.join(self.proto_dir, "foo")],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        if es:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        if len(ms) != 1:
+            raise RuntimeError(
+                "Didn't get expected types of " "missing files:\n{0}".format(ms)
+            )
+        self.assertEqual(list(ms.keys())[0], portable.EMPTYFILE)
+        self.assertTrue(len(d_map) == 0)
+
+        # This should find the binary file first and thus produce
+        # a depend action.
+        d_map, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [os.path.join(self.proto_dir, "foo"), self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        if es:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertEqual(ms, {})
+        self.assertTrue(len(d_map) == 1)
+
+        # Check alternative proto_dirs with hardlinks.
+        t_path = self.make_manifest(self.int_hardlink_manf)
+        self.make_proto_text_file(
+            os.path.join("foo", self.paths["syslog_path"])
+        )
+        # This test should fail because "foo" is not included in the
+        # list of proto_dirs.
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        if len(es) != 1:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        if es[0].file_path != self.paths["syslog_path"]:
+            raise RuntimeError(
+                "Wrong file was found missing:\n{0}".format(es[0])
+            )
+        self.assertEqual(es[0].dirs, [self.proto_dir])
+        self.assertTrue(len(ms) == 0)
+        self.assertTrue(len(ds) == 1)
+
+        # This test should pass because the needed directory has been
+        # added to the list of proto_dirs.
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir, os.path.join(self.proto_dir, "foo")],
+            {},
+            [],
+            convert=False,
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        self.assertTrue(len(ms) == 1)
+        self.assertTrue(len(ds) == 0)
+
+        # Check alternative proto_dirs work with python files and
+        # scripts.
+
+        def _py_check_all_res(res):
+            ds, es, ws, ms, pkg_attrs = res
+            mod_names = [
+                "foobar",
+                "misc_test",
+                "os",
+                "search_storage",
+                "minidom",
+            ]
+            pkg_names = ["indexer_test", "pkg", "pkg_test", "xml", "dom"]
+            expected_deps = set(
+                [("python",)]
+                + [
+                    tuple(sorted([pat.format(n) for pat in mod_pats]))
+                    for n in mod_names
+                ]
+                + [("{0}/__init__.py".format(n),) for n in pkg_names]
+            )
+            if es != []:
+                raise RuntimeError(
+                    "Got errors in results:" + "\n".join([str(s) for s in es])
+                )
+
+            self.assertEqual(ms, {})
+            for d in ds:
+                self.assertTrue(d.is_error())
+                if d.dep_vars is None:
+                    raise RuntimeError(
+                        "This dep had " "depvars of None:{0}".format(d)
+                    )
+                self.assertTrue(d.dep_vars.is_satisfied())
+                if not d.dep_key()[0] in expected_deps:
+                    raise RuntimeError(
+                        "Got this "
+                        "unexpected dep:{0}\n\nd:{1}".format(d.dep_key()[0], d)
+                    )
+                expected_deps.remove(d.dep_key()[0])
+                self.assertEqual(
+                    d.action.attrs["path"], self.paths["indexer_path"]
+                )
+            if expected_deps:
+                raise RuntimeError(
+                    "Couldn't find these "
+                    "dependencies:\n"
+                    + "\n".join([str(s) for s in sorted(expected_deps)])
+                )
+
+        self.__debug = True
+        t_path = self.make_manifest(self.ext_python_manf)
+
+        self.make_proto_text_file(
+            os.path.join("d5", self.paths["indexer_path"]), self.python_text
+        )
+        # This should have an error because it cannot find the file
+        # needed.
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path, [self.proto_dir], {}, [], convert=False
+        )
+        if len(es) != 1:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+        if es[0].file_path != self.paths["indexer_path"]:
+            raise RuntimeError(
+                "Wrong file was found missing:\n{0}".format(es[0])
+            )
+        self.assertEqual(es[0].dirs, [self.proto_dir])
+        self.assertEqual(len(ds), 0)
+        self.assertEqual(len(ms), 0)
+
+        # Because d5 is in the list of proto dirs, this test should work
+        # normally.
+        _py_check_all_res(
+            dependencies.list_implicit_deps(
+                t_path,
+                [self.proto_dir, os.path.join(self.proto_dir, "d5")],
+                {},
+                [],
+                convert=False,
+            )
+        )
+
+    def test_smf_manifest_parse(self):
+        """We parse valid SMF manifests returning instance
+        and dependency info."""
+
+        for manifest in self.smf_paths.keys():
+            self.make_proto_text_file(
+                self.paths[manifest], self.smf_manifest_text[manifest]
+            )
+
+            # This should not parse, returning empty lists
+            if manifest == "broken":
+                instances, deps = smf.parse_smf_manifest(
+                    self.proto_dir + "/" + self.paths[manifest]
+                )
+                self.assertEqual(instances, None)
+                self.assertEqual(deps, None)
+                continue
+
+            # Ensuring each manifest can be parsed
+            # and we detect declared dependencies and
+            # FMRIs according to those hardcoded in the test
+            instances, deps = smf.parse_smf_manifest(
+                self.proto_dir + "/" + self.paths[manifest]
+            )
+            for fmri in instances:
+                for dep in self.smf_known_deps[fmri]:
+                    if dep not in deps[fmri]:
+                        self.assertTrue(
+                            False,
+                            "{0} not found in "
+                            "dependencies for {1}".format(dep, manifest),
+                        )
+                expected = len(self.smf_known_deps[fmri])
+                actual = len(deps[fmri])
+
+                self.assertEqual(
+                    expected,
+                    actual,
+                    "expected number of deps ({0}) != "
+                    "actual ({1}) for {2}".format(expected, actual, fmri),
+                )
+
+    def check_smf_fmris(self, pkg_attrs, expected, manifest_name):
+        """Given a list of expected SMF FMRIs, verify that each is
+        present in the provided pkg_attrs dictionary. Errors are
+        reported in an assertion message that includes manifest_name."""
+
+        self.assertTrue(
+            "org.opensolaris.smf.fmri" in pkg_attrs,
+            "Missing org.opensolaris.smf.fmri key for {0}".format(
+                manifest_name
+            ),
+        )
+
+        found = len(pkg_attrs["org.opensolaris.smf.fmri"])
+        self.assertEqual(
+            found,
+            len(expected),
+            "Wrong no. of SMF instances/services found for {0}: expected"
+            " {1} got {2}".format(manifest_name, len(expected), found),
+        )
+
+        for fmri in expected:
+            self.assertTrue(
+                fmri in pkg_attrs["org.opensolaris.smf.fmri"],
+                "{0} not in list of SMF instances/services "
+                "from {1}".format(fmri, manifest_name),
+            )
+
+    def print_deps(self, deps):
+        for dep in deps:
+            print(dep.base_names)
+
+    def test_int_smf_manifest(self):
+        """We identify SMF dependencies delivered in the same package"""
+
+        t_path = self.make_manifest(self.int_smf_manf)
+        self.make_smf_test_files()
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+
+        self.assertTrue(
+            len(ds) == 1, "Expected 1 dependency, got {0}".format(len(ds))
+        )
+        d = ds[0]
+
+        # verify we have identified the one internal file we depend on
+        actual = d.manifest.replace(self.proto_dir + "/", "")
+        expected = self.paths["delivered_many_nodeps"]
+        self.assertEqual(
+            actual,
+            expected,
+            "Expected dependency path {0}, got {1}".format(actual, expected),
+        )
+
+        self.check_smf_fmris(
+            pkg_attrs,
+            self.smf_fmris["service_single"]
+            + self.smf_fmris["delivered_many_nodeps"],
+            "int_smf_manf",
+        )
+
+        # verify that removing internal dependencies works as expected
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=True,
+            convert=False,
+        )
+        self.assertTrue(
+            len(ds) == 0, "Expected 0 dependencies, got {0}".format(len(ds))
+        )
+        self.assertTrue(dependencies.is_file_dependency(d))
+
+    def test_ext_smf_manifest(self):
+        """We identify SMF dependencies delivered in a different
+        package"""
+
+        t_path = self.make_manifest(self.ext_smf_manf)
+        self.make_smf_test_files()
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+
+        self.assertTrue(
+            len(ds) == 1, "Expected 1 dependency, got {0}".format(len(ds))
+        )
+
+        # verify we have identified the one external file we depend on
+        actual = ds[0].manifest.replace(self.proto_dir + "/", "")
+        expected = self.paths["foreign_many_nodeps"]
+        self.assertEqual(
+            actual,
+            expected,
+            "Expected dependency path {0}, got {1}".format(actual, expected),
+        )
+
+        self.check_smf_fmris(
+            pkg_attrs,
+            self.smf_fmris["service_many"]
+            + self.smf_fmris["foreign_single_nodeps"],
+            "ext_smf_manf",
+        )
+
+    def test_broken_manifest(self):
+        """We report errors when dealing with a broken SMF manifest."""
+
+        # as it happens, file(1) isn't good at spotting broken
+        # XML documents, it only sniffs the header - so this file
+        # gets reported as an XMLDOC despite it being invalid
+        # XML.
+        t_path = self.make_manifest(self.broken_smf_manf)
+        self.make_smf_test_files()
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+
+        self.assertEqual(
+            len(ms), 1, "No unknown files reported during " "analysis"
+        )
+
+        if portable.XMLDOC not in ms:
+            self.assertTrue(False, "Broken SMF manifest file not" " declared")
+
+        broken_path = os.path.join(self.proto_dir, self.paths["broken"])
+        self.assertEqual(
+            ms[portable.XMLDOC],
+            broken_path,
+            "Did not detect broken SMF manifest file: {0} != {1}".format(
+                broken_path, ms[portable.XMLDOC]
+            ),
+        )
+
+        # We should still be able to resolve the other dependencies
+        # though and it's important to check that the one broken SMF
+        # manifest file didn't break the rest of the SMF manifest
+        # backend.  This has been implicitly tested in other tests,
+        # as the broken file is always installed in the manifest
+        # location.
+        if es != []:
+            raise RuntimeError(
+                "Got errors in results:" + "\n".join([str(s) for s in es])
+            )
+
+        # our dependency comes from service_single depending on
+        # delivered_many
+        self.assertTrue(
+            len(ds) == 1, "Expected 1 dependency, got {0}".format(len(ds))
+        )
+        d = ds[0]
+
+        # verify we have identified the one internal file we depend on
+        actual = d.manifest.replace(self.proto_dir + "/", "")
+        expected = self.paths["delivered_many_nodeps"]
+        self.assertEqual(
+            actual,
+            expected,
+            "Expected dependency path {0}, got {1}".format(actual, expected),
+        )
+
+        self.check_smf_fmris(
+            pkg_attrs,
+            self.smf_fmris["service_single"]
+            + self.smf_fmris["delivered_many_nodeps"],
+            "broken_smf_manf",
+        )
+
+    def test_faildeps_smf_manifest(self):
+        """We report failed attempts to resolve dependencies"""
+
+        t_path = self.make_manifest(self.faildeps_smf_manf)
+        self.make_smf_test_files()
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+
+        self.assertTrue(
+            len(es) == 3, "Detected {0} error(s), expected 3".format(len(es))
+        )
+
+        # our two dependencies come from:
+        # service_single depending on delivered_many_nodeps
+        # service_unknown depending on delivered_many_nodeps
+        self.assertTrue(
+            len(ds) == 2, "Expected 2 dependencies, got {0}".format(len(ds))
+        )
+
+        for d in ds:
+            actual = d.manifest.replace(self.proto_dir + "/", "")
+            expected = self.paths["delivered_many_nodeps"]
+            self.assertEqual(
+                actual,
+                expected,
+                "Expected dependency path {0}, got {1}".format(
+                    actual, expected
+                ),
+            )
+
+        self.check_smf_fmris(
+            pkg_attrs,
+            self.smf_fmris["service_single"]
+            + self.smf_fmris["delivered_many_nodeps"]
+            + self.smf_fmris["service_unknown"],
+            "faildeps_smf_manf",
+        )
+
+    def test_delete_smf_manifest(self):
+        """We don't create any SMF dependencies where a manifest
+        specifies a 'delete' attribute in its dependency."""
+
+        t_path = self.make_manifest(self.delete_smf_manf)
+        self.make_smf_test_files()
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+
+        self.assertTrue(
+            len(es) == 0, "Detected {0} error(s), expected 0".format(len(es))
+        )
+        self.assertTrue(
+            len(ds) == 0, "Expected 0 dependencies, got {0}".format(len(ds))
+        )
+        self.check_smf_fmris(
+            pkg_attrs,
+            self.smf_fmris["delete"] + self.smf_fmris["foreign_single_nodeps"],
+            "delete",
+        )
+
+    def test_req_any_smf_manifest(self):
+        """We can generate dependencies that can be turned into
+        require-any dependencies.
+
+        In this test, we generate dependencies on three different SMF
+        manifests:
+
+        The first has a single service-level dependency that is
+        satisfied by two instances, delivered by two separate SMF
+        manifests, generating a single dependency that can be turned
+        into a require-any depend action.
+
+        The second has two instance-level dependencies that are also
+        delivered by two separate SMF manifests, and should generate two
+        require dependencies (because we're being specific about which
+        instances we depend on, rather than depending on any instance
+        of that service, as in the first case, above)
+
+        The last is a version of the first, with a bypass attribute, to
+        ensure that we correctly process bypasses when generating
+        multiple dependencies. (SMFManifestDependency doesn't use
+        base_names/run_paths when multiple SMF manifests are found as
+        dependencies, but instead specifies full_paths directly, which
+        are modified by the bypass-generation code)
+        """
+
+        self.make_smf_test_files()
+
+        # Test the first case: service dependencies satisfied by
+        # multiple SMF manifests.
+        t_path = self.make_manifest(self.int_req_svc_smf_manf)
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertTrue(
+            len(es) == 0, "Detected {0} error(s), expected 0".format(len(es))
+        )
+        self.assertTrue(
+            len(ds) == 1,
+            "Expected 1 dependency when "
+            "depending on a service, got {0}".format(len(ds)),
+        )
+        # ensure the dependencies are correct.
+        self.assertTrue(
+            set(ds[0].full_paths)
+            == set(
+                [
                     self.paths["delivered_many_nodeps"],
-                    self.paths["delivered_many_nodeps_alt"]]),
-                    "Expected two separate full_path entries, got {0}".format(
-                    ds[0].full_paths))
+                    self.paths["delivered_many_nodeps_alt"],
+                ]
+            ),
+            "Expected two separate full_path entries, got {0}".format(
+                ds[0].full_paths
+            ),
+        )
 
-                # for SMF dependencies on services that are satisfied by
-                # multiple instances in separate files, we should have no
-                # run_paths or base_names
-                self.assertTrue(ds[0].run_paths == [])
-                self.assertTrue(ds[0].base_names == [])
+        # for SMF dependencies on services that are satisfied by
+        # multiple instances in separate files, we should have no
+        # run_paths or base_names
+        self.assertTrue(ds[0].run_paths == [])
+        self.assertTrue(ds[0].base_names == [])
 
-                # Test the second case: specific dependencies on instances
-                # satisfied by multiple (different) SMF manifests.
-                t_path = self.make_manifest(self.int_req_inst_smf_manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    t_path, [self.proto_dir], {}, [],
-                    remove_internal_deps=False, convert=False)
-                self.assertTrue(len(es) == 0, "Detected {0} error(s), expected 0".format(
-                    len(es)))
-                self.assertTrue(len(ds) == 2, "Expected 2 dependencies, got {0}".format(
-                    len(ds)))
+        # Test the second case: specific dependencies on instances
+        # satisfied by multiple (different) SMF manifests.
+        t_path = self.make_manifest(self.int_req_inst_smf_manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertTrue(
+            len(es) == 0, "Detected {0} error(s), expected 0".format(len(es))
+        )
+        self.assertTrue(
+            len(ds) == 2, "Expected 2 dependencies, got {0}".format(len(ds))
+        )
 
-                seen_nodeps3 = False
-                seen_nodeps = False
-                for d in ds:
-                        # ensure the dependencies are correct.
-                        actual = d.manifest.replace(self.proto_dir + "/", "")
-                        if actual == self.paths["delivered_many_nodeps"]:
-                                seen_nodeps = True
-                        elif actual == self.paths["delivered_many_nodeps_alt"]:
-                                seen_nodeps3 = True
-                        self.assertTrue(d.run_paths, "Expected a directory path "
-                            "for {0}: {1}".format(d, d.run_paths))
-                        self.assertTrue(d.full_paths == [], "Expected an empty "
-                            "list for full_paths, got {0}".format(d.full_paths))
+        seen_nodeps3 = False
+        seen_nodeps = False
+        for d in ds:
+            # ensure the dependencies are correct.
+            actual = d.manifest.replace(self.proto_dir + "/", "")
+            if actual == self.paths["delivered_many_nodeps"]:
+                seen_nodeps = True
+            elif actual == self.paths["delivered_many_nodeps_alt"]:
+                seen_nodeps3 = True
+            self.assertTrue(
+                d.run_paths,
+                "Expected a directory path "
+                "for {0}: {1}".format(d, d.run_paths),
+            )
+            self.assertTrue(
+                d.full_paths == [],
+                "Expected an empty "
+                "list for full_paths, got {0}".format(d.full_paths),
+            )
 
-                self.assertTrue(seen_nodeps3 and seen_nodeps, "Expected "
-                    "dependencies were not generated when several SMF "
-                    "instances were listed as 'require_all' dependencies.")
+        self.assertTrue(
+            seen_nodeps3 and seen_nodeps,
+            "Expected "
+            "dependencies were not generated when several SMF "
+            "instances were listed as 'require_all' dependencies.",
+        )
 
-                # Test the third case: service dependencies satisfied by
-                # multiple SMF manifests, but with one bypassed.
-                t_path = self.make_manifest(self.bypassed_int_req_svc_smf_manf)
+        # Test the third case: service dependencies satisfied by
+        # multiple SMF manifests, but with one bypassed.
+        t_path = self.make_manifest(self.bypassed_int_req_svc_smf_manf)
 
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    t_path, [self.proto_dir], {}, [],
-                    remove_internal_deps=False, convert=False)
-                self.assertTrue(len(es) == 0, "Detected {0} error(s), expected 0".format(
-                    len(es)))
-                self.assertTrue(len(ds) == 1, "Expected 1 dependency, got {0}".format(
-                    len(ds)))
-                # ensure the dependencies are correct.
-                self.assertTrue(ds[0].full_paths ==
-                    [self.paths["delivered_many_nodeps"]],
-                    "d.full_paths entry was incorrect, got {0}".format(
-                    ds[0].full_paths))
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertTrue(
+            len(es) == 0, "Detected {0} error(s), expected 0".format(len(es))
+        )
+        self.assertTrue(
+            len(ds) == 1, "Expected 1 dependency, got {0}".format(len(ds))
+        )
+        # ensure the dependencies are correct.
+        self.assertTrue(
+            ds[0].full_paths == [self.paths["delivered_many_nodeps"]],
+            "d.full_paths entry was incorrect, got {0}".format(
+                ds[0].full_paths
+            ),
+        )
 
-                # since we've bypassed a dependency, we should not have
-                # run_paths or base_names
-                self.assertTrue(ds[0].run_paths == [])
-                self.assertTrue(ds[0].base_names == [])
+        # since we've bypassed a dependency, we should not have
+        # run_paths or base_names
+        self.assertTrue(ds[0].run_paths == [])
+        self.assertTrue(ds[0].base_names == [])
 
-        def test_runpath_1(self):
-                """Test basic functionality of runpaths."""
+    def test_runpath_1(self):
+        """Test basic functionality of runpaths."""
 
-                t_path = self.make_manifest(self.python_runpath_manf)
-                self.make_python_test_files(py_ver_default)
+        t_path = self.make_manifest(self.python_runpath_manf)
+        self.make_python_test_files(py_ver_default)
 
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                self.assertTrue(es == [], "Unexpected errors reported: {0}".format(es))
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertTrue(es == [], "Unexpected errors reported: {0}".format(es))
 
-                for dep in ds:
-                        # only interested in seeing that our runpath was changed
-                        if "pdtest.py" in dep.attrs["pkg.debug.depend.file"]:
-                                self.assertTrue("opt/pkgdep_runpath" in
-                                    dep.attrs["pkg.debug.depend.path"])
-                                self.assertTrue("usr/lib/python{0}/pkgdep_runpath".format(py_ver_default)
-                                    in dep.attrs["pkg.debug.depend.path"])
-                                # ensure this dependency was indeed generated
-                                # as a result of our test file
-                                self.assertTrue("pkgdep_test/file.py" in
-                                    dep.attrs["pkg.debug.depend.reason"])
-                        self.assertTrue(dependencies.is_file_dependency(dep))
+        for dep in ds:
+            # only interested in seeing that our runpath was changed
+            if "pdtest.py" in dep.attrs["pkg.debug.depend.file"]:
+                self.assertTrue(
+                    "opt/pkgdep_runpath" in dep.attrs["pkg.debug.depend.path"]
+                )
+                self.assertTrue(
+                    "usr/lib/python{0}/pkgdep_runpath".format(py_ver_default)
+                    in dep.attrs["pkg.debug.depend.path"]
+                )
+                # ensure this dependency was indeed generated
+                # as a result of our test file
+                self.assertTrue(
+                    "pkgdep_test/file.py"
+                    in dep.attrs["pkg.debug.depend.reason"]
+                )
+            self.assertTrue(dependencies.is_file_dependency(dep))
 
-        def test_runpath_2(self):
-                """Test invalid runpath attributes."""
+    def test_runpath_2(self):
+        """Test invalid runpath attributes."""
 
-                self.make_python_test_files(py_ver_default)
+        self.make_python_test_files(py_ver_default)
 
-                # test a runpath with multiple values
-                t_path = self.make_manifest(self.python_invalid_runpath_manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                self.assertTrue(es != [], "No errors reported for broken runpath")
+        # test a runpath with multiple values
+        t_path = self.make_manifest(self.python_invalid_runpath_manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertTrue(es != [], "No errors reported for broken runpath")
 
-                # test a runpath with multiple $PD_DEFAULT_RUNPATH components
-                t_path = self.make_manifest(self.python_invalid_runpath2_manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                self.assertTrue(es != [], "No errors reported for broken runpath")
+        # test a runpath with multiple $PD_DEFAULT_RUNPATH components
+        t_path = self.make_manifest(self.python_invalid_runpath2_manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertTrue(es != [], "No errors reported for broken runpath")
 
-        def test_runpath_3(self):
-                """Test setting an empty runpath attribute"""
+    def test_runpath_3(self):
+        """Test setting an empty runpath attribute"""
 
-                t_path = self.make_manifest(self.python_empty_runpath_manf)
-                self.make_python_test_files(py_ver_default)
+        t_path = self.make_manifest(self.python_empty_runpath_manf)
+        self.make_python_test_files(py_ver_default)
 
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                self.assertTrue(es != [], "No errors reported for empty runpath")
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertTrue(es != [], "No errors reported for empty runpath")
 
-        def validate_bypass_dep(self, dep):
-                """Given a dependency which may be bypassed, if it has been,
-                it should have been expanded into a dependency containing just
-                pkg.debug.depend.fullpath entries.
-                """
-                self.assertTrue(dependencies.is_file_dependency(dep))
+    def validate_bypass_dep(self, dep):
+        """Given a dependency which may be bypassed, if it has been,
+        it should have been expanded into a dependency containing just
+        pkg.debug.depend.fullpath entries.
+        """
+        self.assertTrue(dependencies.is_file_dependency(dep))
 
-                if dep.attrs.get("pkg.debug.depend.fullpath", None):
-                        for val in ["path", "file"]:
-                                self.assertTrue("pkg.debug.depend.{0}".format(val)
-                                    not in dep.attrs, "We should not see a {0} "
-                                    "entry in this dependency: {1}".format(
-                                    val, dep))
-                                self.assertTrue(not dep.run_paths,
-                                    "Unexpected run_paths: {0}".format(dep))
-                                self.assertTrue(not dep.base_names,
-                                    "Unexpected base_names: {0}".format(dep))
-                else:
-                        self.assertTrue("pkg.debug.depend.fullpath" not in
-                            dep.attrs, "We should not see a fullpath "
-                            "entry in this dependency: {0}".format(dep))
-                        self.assertTrue(not dep.full_paths,
-                            "Unexpected full_paths: {0}".format(dep))
+        if dep.attrs.get("pkg.debug.depend.fullpath", None):
+            for val in ["path", "file"]:
+                self.assertTrue(
+                    "pkg.debug.depend.{0}".format(val) not in dep.attrs,
+                    "We should not see a {0} "
+                    "entry in this dependency: {1}".format(val, dep),
+                )
+                self.assertTrue(
+                    not dep.run_paths, "Unexpected run_paths: {0}".format(dep)
+                )
+                self.assertTrue(
+                    not dep.base_names, "Unexpected base_names: {0}".format(dep)
+                )
+        else:
+            self.assertTrue(
+                "pkg.debug.depend.fullpath" not in dep.attrs,
+                "We should not see a fullpath "
+                "entry in this dependency: {0}".format(dep),
+            )
+            self.assertTrue(
+                not dep.full_paths, "Unexpected full_paths: {0}".format(dep)
+            )
 
-        def verify_bypass(self, ds, es, bypass):
-                """Given a list of dependencies, and a list of bypass paths,
-                verify that we have not generated a dependency on any of the
-                items in the bypass list.
+    def verify_bypass(self, ds, es, bypass):
+        """Given a list of dependencies, and a list of bypass paths,
+        verify that we have not generated a dependency on any of the
+        items in the bypass list.
 
-                If a bypass has been performed, the dependency will have been
-                expanded to contain pkg.debug.depend.fullpath values,
-                otherwise we should have p.d.d.path and p.d.d.file items.
-                We should never have all three attributes set.
-                """
+        If a bypass has been performed, the dependency will have been
+        expanded to contain pkg.debug.depend.fullpath values,
+        otherwise we should have p.d.d.path and p.d.d.file items.
+        We should never have all three attributes set.
+        """
 
-                self.assertTrue(len(es) == 0, "Errors reported during bypass: {0}".format(
-                    es))
+        self.assertTrue(
+            len(es) == 0, "Errors reported during bypass: {0}".format(es)
+        )
 
-                for dep in ds:
-                        # generate all possible paths this dep could represent
-                        dep_paths = set()
-                        self.validate_bypass_dep(dep)
-                        if dep.attrs.get("pkg.debug.depend.fullpath", None):
-                                dep_paths.update(
-                                    dep.attrs["pkg.debug.depend.fullpath"])
-                        else:
-                                for filename in dep.base_names:
-                                        dep_paths.update([os.path.join(dir,
-                                            filename)
-                                            for dir in dep.run_paths])
+        for dep in ds:
+            # generate all possible paths this dep could represent
+            dep_paths = set()
+            self.validate_bypass_dep(dep)
+            if dep.attrs.get("pkg.debug.depend.fullpath", None):
+                dep_paths.update(dep.attrs["pkg.debug.depend.fullpath"])
+            else:
+                for filename in dep.base_names:
+                    dep_paths.update(
+                        [os.path.join(dir, filename) for dir in dep.run_paths]
+                    )
 
-                        self.assertTrue(dependencies.is_file_dependency(dep))
+            self.assertTrue(dependencies.is_file_dependency(dep))
 
-                        # finally, check the dependencies
-                        if dep_paths.intersection(set(bypass)):
-                                self.debug("Some items were not bypassed: {0}".format(
-                                    "\n".join(sorted(list(
-                                    dep_paths.intersection(set(bypass)))))))
-                                return False
-                return True
+            # finally, check the dependencies
+            if dep_paths.intersection(set(bypass)):
+                self.debug(
+                    "Some items were not bypassed: {0}".format(
+                        "\n".join(
+                            sorted(list(dep_paths.intersection(set(bypass))))
+                        )
+                    )
+                )
+                return False
+        return True
 
-        def verify_dep_generation(self, ds, expected):
-                """Verifies that we have generated dependencies on the given
-                files"""
-                dep_paths = set()
-                for dep in ds:
-                        self.debug(dep)
-                        self.validate_bypass_dep(dep)
-                        if dep.attrs.get("pkg.debug.depend.fullpath", None):
-                                dep_paths.update(
-                                    dep.attrs["pkg.debug.depend.fullpath"])
-                        else:
-                                # generate all paths this dep could represent
-                                for filename in dep.base_names:
-                                        dep_paths.update([
-                                            os.path.join(dir, filename)
-                                            for dir in dep.run_paths])
-                for item in expected:
-                        if item not in dep_paths:
-                                self.debug("Expected to see dependency on {0}".format(
-                                    item))
-                                return False
-                return True
+    def verify_dep_generation(self, ds, expected):
+        """Verifies that we have generated dependencies on the given
+        files"""
+        dep_paths = set()
+        for dep in ds:
+            self.debug(dep)
+            self.validate_bypass_dep(dep)
+            if dep.attrs.get("pkg.debug.depend.fullpath", None):
+                dep_paths.update(dep.attrs["pkg.debug.depend.fullpath"])
+            else:
+                # generate all paths this dep could represent
+                for filename in dep.base_names:
+                    dep_paths.update(
+                        [os.path.join(dir, filename) for dir in dep.run_paths]
+                    )
+        for item in expected:
+            if item not in dep_paths:
+                self.debug("Expected to see dependency on {0}".format(item))
+                return False
+        return True
 
-        def test_bypass_1(self):
-                """Ensure we can bypass dependency generation on a given file,
-                or set of files
-                """
-                # this manifest should result in multiple dependencies
-                t_path = self.make_manifest(self.python_bypass_manf)
-                self.make_python_test_files(py_ver_default)
+    def test_bypass_1(self):
+        """Ensure we can bypass dependency generation on a given file,
+        or set of files
+        """
+        # this manifest should result in multiple dependencies
+        t_path = self.make_manifest(self.python_bypass_manf)
+        self.make_python_test_files(py_ver_default)
 
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                self.assertTrue(self.verify_bypass(ds, es, [
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertTrue(
+            self.verify_bypass(
+                ds,
+                es,
+                [
                     "opt/pkgdep_runpath/pdtest.py",
-                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so".format(py_ver_default, py_ver_lib)]),
-                    "Python script was not bypassed")
-                # now check we depend on some files which should not have been
-                # bypassed
-                self.assertTrue(self.verify_dep_generation(ds,
-                    ["usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.so".format(py_ver_default),
-                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.py".format(py_ver_default),
-                    "opt/pkgdep_runpath/pdtest.pyc"]))
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so".format(
+                        py_ver_default, py_ver_lib
+                    ),
+                ],
+            ),
+            "Python script was not bypassed",
+        )
+        # now check we depend on some files which should not have been
+        # bypassed
+        self.assertTrue(
+            self.verify_dep_generation(
+                ds,
+                [
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.so".format(
+                        py_ver_default
+                    ),
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.py".format(
+                        py_ver_default
+                    ),
+                    "opt/pkgdep_runpath/pdtest.pyc",
+                ],
+            )
+        )
 
-                # now run this again as a control, this time skipping bypass
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False, ignore_bypass=True)
-                # the first two items in the list were previously bypassed
-                self.assertTrue(self.verify_dep_generation(ds,
-                    ["opt/pkgdep_runpath/pdtest.py",
-                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so".format(py_ver_default, py_ver_lib),
-                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.so".format(py_ver_default),
-                    "opt/pkgdep_runpath/pdtest.pyc"]),
-                    "Python script did not generate a dependency on bypassed")
+        # now run this again as a control, this time skipping bypass
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+            ignore_bypass=True,
+        )
+        # the first two items in the list were previously bypassed
+        self.assertTrue(
+            self.verify_dep_generation(
+                ds,
+                [
+                    "opt/pkgdep_runpath/pdtest.py",
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so".format(
+                        py_ver_default, py_ver_lib
+                    ),
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.so".format(
+                        py_ver_default
+                    ),
+                    "opt/pkgdep_runpath/pdtest.pyc",
+                ],
+            ),
+            "Python script did not generate a dependency on bypassed",
+        )
 
-                self.make_proto_text_file(self.paths["script_path"],
-                    self.script_text)
+        self.make_proto_text_file(self.paths["script_path"], self.script_text)
 
-                # these manifests should only generate 1 dependency
-                # we also test that duplicated bypass entries are ignored
-                for manifest in [self.ksh_bypass_manf,
-                    self.ksh_bypass_dup_manf, self.ksh_bypass_filename_manf]:
-                        t_path = self.make_manifest(manifest)
+        # these manifests should only generate 1 dependency
+        # we also test that duplicated bypass entries are ignored
+        for manifest in [
+            self.ksh_bypass_manf,
+            self.ksh_bypass_dup_manf,
+            self.ksh_bypass_filename_manf,
+        ]:
+            t_path = self.make_manifest(manifest)
 
-                        ds, es, ws, ms, pkg_attrs = \
-                            dependencies.list_implicit_deps(t_path,
-                            [self.proto_dir], {}, [],
-                            remove_internal_deps=False, convert=False)
-                        self.assertTrue(len(ds) == 0,
-                            "Did not generate exactly 0 dependencies")
-                        self.assertTrue(self.verify_bypass(ds, es,
-                            ["usr/bin/ksh"]), "Ksh script was not bypassed")
+            ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+                t_path,
+                [self.proto_dir],
+                {},
+                [],
+                remove_internal_deps=False,
+                convert=False,
+            )
+            self.assertTrue(
+                len(ds) == 0, "Did not generate exactly 0 dependencies"
+            )
+            self.assertTrue(
+                self.verify_bypass(ds, es, ["usr/bin/ksh"]),
+                "Ksh script was not bypassed",
+            )
 
-                        # don't perform bypass
-                        ds, es, ws, ms, pkg_attrs = \
-                            dependencies.list_implicit_deps(t_path,
-                            [self.proto_dir], {}, [],
-                            remove_internal_deps=False, convert=False,
-                            ignore_bypass=True)
-                        self.assertTrue(len(ds) == 1,
-                            "Did not generate exactly 1 dependency on ksh")
-                        self.assertTrue(self.verify_dep_generation(
-                            ds, ["usr/bin/ksh"]),
-                            "Ksh script did not generate a dependency on ksh")
+            # don't perform bypass
+            ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+                t_path,
+                [self.proto_dir],
+                {},
+                [],
+                remove_internal_deps=False,
+                convert=False,
+                ignore_bypass=True,
+            )
+            self.assertTrue(
+                len(ds) == 1, "Did not generate exactly 1 dependency on ksh"
+            )
+            self.assertTrue(
+                self.verify_dep_generation(ds, ["usr/bin/ksh"]),
+                "Ksh script did not generate a dependency on ksh",
+            )
 
-        def test_bypass_2(self):
-                """Ensure that bypasses containing wildcards work"""
-                t_path = self.make_manifest(self.python_wildcard_bypass_manf)
-                self.make_python_test_files(py_ver_default)
+    def test_bypass_2(self):
+        """Ensure that bypasses containing wildcards work"""
+        t_path = self.make_manifest(self.python_wildcard_bypass_manf)
+        self.make_python_test_files(py_ver_default)
 
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
 
-                self.assertTrue(len(es) == 0, "Errors reported during bypass: {0}".format(
-                    es))
+        self.assertTrue(
+            len(es) == 0, "Errors reported during bypass: {0}".format(es)
+        )
 
-                # we should have bypassed all dependency generation on all files
-                self.assertTrue(len(ds) == 0, "Generated dependencies despite "
-                    "request to bypass all dependency generation.")
+        # we should have bypassed all dependency generation on all files
+        self.assertTrue(
+            len(ds) == 0,
+            "Generated dependencies despite "
+            "request to bypass all dependency generation.",
+        )
 
-                t_path = self.make_manifest(
-                    self.python_wildcard_dir_bypass_manf)
+        t_path = self.make_manifest(self.python_wildcard_dir_bypass_manf)
 
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
 
-                self.assertTrue(self.verify_bypass(ds, es, [
-                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.pyo".format(py_ver_default),
-                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so".format(py_ver_default, py_ver_lib)]),
-                    "Directory bypass wildcard failed")
-                self.assertTrue(self.verify_dep_generation(ds, [
-                    "usr/lib/python{0}/pkgdep_runpath/__init__.py".format(py_ver_default),
-                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/__init__.py".format(py_ver_default)]),
-                    "Failed to generate dependencies, despite dir-wildcards")
+        self.assertTrue(
+            self.verify_bypass(
+                ds,
+                es,
+                [
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.pyo".format(
+                        py_ver_default
+                    ),
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so".format(
+                        py_ver_default, py_ver_lib
+                    ),
+                ],
+            ),
+            "Directory bypass wildcard failed",
+        )
+        self.assertTrue(
+            self.verify_dep_generation(
+                ds,
+                [
+                    "usr/lib/python{0}/pkgdep_runpath/__init__.py".format(
+                        py_ver_default
+                    ),
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/__init__.py".format(
+                        py_ver_default
+                    ),
+                ],
+            ),
+            "Failed to generate dependencies, despite dir-wildcards",
+        )
 
-                t_path = self.make_manifest(
-                    self.python_wildcard_file_bypass_manf)
+        t_path = self.make_manifest(self.python_wildcard_file_bypass_manf)
 
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                self.assertTrue(self.verify_bypass(ds, es, [
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertTrue(
+            self.verify_bypass(
+                ds,
+                es,
+                [
                     "opt/pkgdep_runpath/pdtest.pyo",
-                    "opt/pkgdep_runpath/pdtest.cpython-{0}.so".format(py_ver_lib)]),
-                    "Failed to bypass some paths despite use of file-wildcard")
-                # we should still have dependencies on these
-                self.assertTrue(self.verify_dep_generation(ds, [
-                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.pyo".format(py_ver_default),
-                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so".format(py_ver_default, py_ver_lib)]),
-                    "Failed to generate dependencies, despite file-wildcards")
+                    "opt/pkgdep_runpath/pdtest.cpython-{0}.so".format(
+                        py_ver_lib
+                    ),
+                ],
+            ),
+            "Failed to bypass some paths despite use of file-wildcard",
+        )
+        # we should still have dependencies on these
+        self.assertTrue(
+            self.verify_dep_generation(
+                ds,
+                [
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.pyo".format(
+                        py_ver_default
+                    ),
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so".format(
+                        py_ver_default, py_ver_lib
+                    ),
+                ],
+            ),
+            "Failed to generate dependencies, despite file-wildcards",
+        )
 
-                # finally, test a combination of the above, we have:
-                # pkg.depend.bypass-generate=.*/pdtest.py \
-                # pkg.depend.bypass-generate=usr/lib/python3.x/vendor-packages/.* \
-                # pkg.depend.bypass-generate=usr/lib/python3.x/site-packages/pkgdep_runpath/pdtest.cpython-3x.so
-                t_path = self.make_manifest(
-                    self.python_wildcard_combo_bypass_manf)
+        # finally, test a combination of the above, we have:
+        # pkg.depend.bypass-generate=.*/pdtest.py \
+        # pkg.depend.bypass-generate=usr/lib/python3.x/vendor-packages/.* \
+        # pkg.depend.bypass-generate=usr/lib/python3.x/site-packages/pkgdep_runpath/pdtest.cpython-3x.so
+        t_path = self.make_manifest(self.python_wildcard_combo_bypass_manf)
 
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
-                self.assertTrue(self.verify_bypass(ds, es, [
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
+        self.assertTrue(
+            self.verify_bypass(
+                ds,
+                es,
+                [
                     "opt/pkgdep_runpath/pdtest.py",
-                    "usr/lib/python{0}/vendor-packages/pkgdep_runpath/pdtest.py".format(py_ver_default),
-                    "usr/lib/python{0}/site-packages/pkgdep_runpath/pdtest.py".format(py_ver_default),
-                    "usr/lib/python{0}/site-packages/pkgdep_runpath/pdtest.cpython-{1}.so".format(py_ver_default, py_ver_lib)]),
-                    "Failed to bypass some paths despite use of combo-wildcard")
-                # we should still have dependencies on these
-                self.assertTrue(self.verify_dep_generation(ds, [
-                    "usr/lib/python{0}/site-packages/pkgdep_runpath/pdtest.pyc".format(py_ver_default),
-                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so".format(py_ver_default, py_ver_lib)]),
-                    "Failed to generate dependencies, despite file-wildcards")
+                    "usr/lib/python{0}/vendor-packages/pkgdep_runpath/pdtest.py".format(
+                        py_ver_default
+                    ),
+                    "usr/lib/python{0}/site-packages/pkgdep_runpath/pdtest.py".format(
+                        py_ver_default
+                    ),
+                    "usr/lib/python{0}/site-packages/pkgdep_runpath/pdtest.cpython-{1}.so".format(
+                        py_ver_default, py_ver_lib
+                    ),
+                ],
+            ),
+            "Failed to bypass some paths despite use of combo-wildcard",
+        )
+        # we should still have dependencies on these
+        self.assertTrue(
+            self.verify_dep_generation(
+                ds,
+                [
+                    "usr/lib/python{0}/site-packages/pkgdep_runpath/pdtest.pyc".format(
+                        py_ver_default
+                    ),
+                    "usr/lib/python{0}/lib-dynload/pkgdep_runpath/pdtest.cpython-{1}.so".format(
+                        py_ver_default, py_ver_lib
+                    ),
+                ],
+            ),
+            "Failed to generate dependencies, despite file-wildcards",
+        )
 
-        def test_bypass_3(self):
-                """Ensure that bypasses which don't match any dependencies have
-                no effect on the computed dependencies."""
-                t_path = self.make_manifest(self.python_bypass_nomatch_manf)
-                self.make_python_test_files(py_ver_default)
+    def test_bypass_3(self):
+        """Ensure that bypasses which don't match any dependencies have
+        no effect on the computed dependencies."""
+        t_path = self.make_manifest(self.python_bypass_nomatch_manf)
+        self.make_python_test_files(py_ver_default)
 
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
 
-                for dep in ds:
-                        # we expect that there are only file/path attributes
-                        # since no bypasses have been performed
-                        self.assertTrue("pkg.debug.depend.file" in dep.attrs)
-                        self.assertTrue("pkg.debug.depend.path" in dep.attrs)
-                        self.assertTrue("pkg.debug.depend.fullpath"
-                            not in dep.attrs)
+        for dep in ds:
+            # we expect that there are only file/path attributes
+            # since no bypasses have been performed
+            self.assertTrue("pkg.debug.depend.file" in dep.attrs)
+            self.assertTrue("pkg.debug.depend.path" in dep.attrs)
+            self.assertTrue("pkg.debug.depend.fullpath" not in dep.attrs)
 
-                def all_paths(ds):
-                        """Return all paths this list of dependencies could
-                        generate"""
-                        dep_paths = set()
-                        for dep in ds:
-                                # generate all paths this dep could represent
-                                dep_paths = set()
-                                for filename in dep.base_names + ["*"]:
-                                        dep_paths.update(os.path.join(dir, filename)
-                                            for dir in dep.run_paths + ["*"])
-                                dep_paths.remove("*/*")
-                        return dep_paths
+        def all_paths(ds):
+            """Return all paths this list of dependencies could
+            generate"""
+            dep_paths = set()
+            for dep in ds:
+                # generate all paths this dep could represent
+                dep_paths = set()
+                for filename in dep.base_names + ["*"]:
+                    dep_paths.update(
+                        os.path.join(dir, filename)
+                        for dir in dep.run_paths + ["*"]
+                    )
+                dep_paths.remove("*/*")
+            return dep_paths
 
-                gen_paths = all_paths(ds)
+        gen_paths = all_paths(ds)
 
-                # now run again, without trying to perform dependency bypass
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False, ignore_bypass=True)
+        # now run again, without trying to perform dependency bypass
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+            ignore_bypass=True,
+        )
 
-                self.assertTrue(gen_paths == all_paths(ds),
-                    "generating dependencies with non-matching bypass entries "
-                    "changed the returned dependencies")
+        self.assertTrue(
+            gen_paths == all_paths(ds),
+            "generating dependencies with non-matching bypass entries "
+            "changed the returned dependencies",
+        )
 
-        def test_symlinked_proto(self):
-                """Ensure that the behavior when using a symlink to a proto dir
-                is identical to the behavior when using that proto dir for all
-                flavors."""
+    def test_symlinked_proto(self):
+        """Ensure that the behavior when using a symlink to a proto dir
+        is identical to the behavior when using that proto dir for all
+        flavors."""
 
-                multi_flavor_manf = (self.ext_hardlink_manf +
-                     self.ext_script_manf + self.ext_elf_manf +
-                     self.ext_python_manf + self.ext_smf_manf +
-                     self.relative_int_manf)
-                t_path = self.make_manifest(multi_flavor_manf)
+        multi_flavor_manf = (
+            self.ext_hardlink_manf
+            + self.ext_script_manf
+            + self.ext_elf_manf
+            + self.ext_python_manf
+            + self.ext_smf_manf
+            + self.relative_int_manf
+        )
+        t_path = self.make_manifest(multi_flavor_manf)
 
-                linked_proto = os.path.join(self.test_root, "linked_proto")
-                os.symlink(self.proto_dir, linked_proto)
+        linked_proto = os.path.join(self.test_root, "linked_proto")
+        os.symlink(self.proto_dir, linked_proto)
 
-                self.make_proto_text_file(self.paths["script_path"],
-                    self.script_text)
-                self.make_smf_test_files()
-                self.make_python_test_files(py_ver_default)
-                self.make_elf(self.paths["curses_path"])
+        self.make_proto_text_file(self.paths["script_path"], self.script_text)
+        self.make_smf_test_files()
+        self.make_python_test_files(py_ver_default)
+        self.make_elf(self.paths["curses_path"])
 
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(t_path,
-                    [self.proto_dir], {}, [], remove_internal_deps=False,
-                    convert=False)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            t_path,
+            [self.proto_dir],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
 
-                smf.SMFManifestDependency._clear_cache()
+        smf.SMFManifestDependency._clear_cache()
 
-                # now run the same function, this time using our symlinked dir
-                dsl, esl, wsl, msl, pkg_attrsl = dependencies.list_implicit_deps(
-                    t_path, [linked_proto], {}, [],
-                    remove_internal_deps=False, convert=False)
+        # now run the same function, this time using our symlinked dir
+        dsl, esl, wsl, msl, pkg_attrsl = dependencies.list_implicit_deps(
+            t_path,
+            [linked_proto],
+            {},
+            [],
+            remove_internal_deps=False,
+            convert=False,
+        )
 
-                for a, b in [(ds, dsl), (pkg_attrs, pkg_attrsl)]:
-                            self.assertTrue(a == b, "Differences found comparing "
-                                "proto_dir with symlinked proto_dir: {0} vs. {1}"
-                               .format(a, b))
+        for a, b in [(ds, dsl), (pkg_attrs, pkg_attrsl)]:
+            self.assertTrue(
+                a == b,
+                "Differences found comparing "
+                "proto_dir with symlinked proto_dir: {0} vs. {1}".format(a, b),
+            )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_elf.py
+++ b/src/tests/api/t_elf.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2017, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -33,127 +34,129 @@ import os
 import re
 import pkg.portable
 
-class TestElf(pkg5unittest.Pkg5TestCase):
-        need_ro_data = True
 
-        # If something in this list does not exist, the test_valid_elf
-        # tests may fail.  At some point if someone moves paths around in
-        # ON, this might fail.  Sorry!
-        elf_paths = [
-            "/usr/bin/mdb",
-            "/usr/bin/__ARCH__/mdb",
-            "/usr/lib/libc.so",
-            "/usr/lib/__ARCH__/libc.so",
-            "/usr/lib/crti.o",
-            "/usr/lib/__ARCH__/crti.o",
-            "/kernel/drv/__ARCH__/sd",
-            "/kernel/fs/__ARCH__/zfs",
-            "/usr/kernel/drv/__ARCH__/ksyms",
+class TestElf(pkg5unittest.Pkg5TestCase):
+    need_ro_data = True
+
+    # If something in this list does not exist, the test_valid_elf
+    # tests may fail.  At some point if someone moves paths around in
+    # ON, this might fail.  Sorry!
+    elf_paths = [
+        "/usr/bin/mdb",
+        "/usr/bin/__ARCH__/mdb",
+        "/usr/lib/libc.so",
+        "/usr/lib/__ARCH__/libc.so",
+        "/usr/lib/crti.o",
+        "/usr/lib/__ARCH__/crti.o",
+        "/kernel/drv/__ARCH__/sd",
+        "/kernel/fs/__ARCH__/zfs",
+        "/usr/kernel/drv/__ARCH__/ksyms",
+    ]
+
+    def test_non_elf(self):
+        """Test that elf routines gracefully handle non-elf objects."""
+
+        p = "this-is-not-an-elf-file.so"
+        self.make_misc_files({p: "this is only a test"})
+        os.chdir(self.test_root)
+        self.assertEqual(elf.is_elf_object(p), False)
+        self.assertRaises(elf.ElfError, elf.get_dynamic, p)
+        self.assertRaises(elf.ElfError, elf.get_hashes, p)
+        self.assertRaises(elf.ElfError, elf.get_info, p)
+
+    def test_non_existent(self):
+        """Test that elf routines gracefully handle ENOENT."""
+
+        os.chdir(self.test_root)
+        p = "does/not/exist"
+        self.assertRaises(OSError, elf.is_elf_object, p)
+        self.assertRaises(OSError, elf.get_dynamic, p)
+        self.assertRaises(OSError, elf.get_hashes, p)
+        self.assertRaises(OSError, elf.get_info, p)
+
+    def test_valid_elf(self):
+        """Test that elf routines work on a small set of objects."""
+        arch = pkg.portable.get_isainfo()[0]
+        for p in self.elf_paths:
+            p = re.sub("__ARCH__", arch, p)
+            self.debug("testing elf file {0}".format(p))
+            self.assertTrue(os.path.exists(p), "{0} does not exist".format(p))
+            self.assertEqual(elf.is_elf_object(p), True)
+            elf.get_dynamic(p)
+            elf.get_hashes(p)
+            self.debug("elf.get_info {0}".format(elf.get_info(p)))
+
+    def test_valid_elf_hash(self):
+        """Test that the elf routines generate the expected hash"""
+
+        o = os.path.join(self.test_root, "ro_data/elftest.so.1")
+        d = elf.get_hashes(o, elfhash=True, sha256=True, sha512t_256=True)
+
+        expected = [
+            "gelf:sha256:7c4f1f347b6d6e65e7542ffb21a05471728a80a5449fddd715186c6cbfdba4b0",
+            "gelf.unsigned:sha256:7c4f1f347b6d6e65e7542ffb21a05471728a80a5449fddd715186c6cbfdba4b0",
+            "gelf:sha512t_256:54f4cba7527ab9f78a85f7bb5a4e63315c8cae4a7e38f884e4bfd16bcab00821",
+            "gelf.unsigned:sha512t_256:54f4cba7527ab9f78a85f7bb5a4e63315c8cae4a7e38f884e4bfd16bcab00821",
         ]
 
-        def test_non_elf(self):
-                """Test that elf routines gracefully handle non-elf objects."""
+        import pprint
 
-                p = "this-is-not-an-elf-file.so"
-                self.make_misc_files({p: "this is only a test"})
-                os.chdir(self.test_root)
-                self.assertEqual(elf.is_elf_object(p), False)
-                self.assertRaises(elf.ElfError, elf.get_dynamic, p)
-                self.assertRaises(elf.ElfError, elf.get_hashes, p)
-                self.assertRaises(elf.ElfError, elf.get_info, p)
+        pprint.pprint(d)
 
-        def test_non_existent(self):
-                """Test that elf routines gracefully handle ENOENT."""
+        self.assertEqual(
+            d["elfhash"], "083308992c921537fd757548964f89452234dd11"
+        )
+        for hash in expected:
+            self.assertTrue(hash in d["pkg.content-hash"])
 
-                os.chdir(self.test_root)
-                p = "does/not/exist"
-                self.assertRaises(OSError, elf.is_elf_object, p)
-                self.assertRaises(OSError, elf.get_dynamic, p)
-                self.assertRaises(OSError, elf.get_hashes, p)
-                self.assertRaises(OSError, elf.get_info, p)
+    def test_get_hashes_params(self):
+        """Test that get_hashes(..) returns checksums according to the
+        parameters passed to the method."""
 
-        def test_valid_elf(self):
-                """Test that elf routines work on a small set of objects."""
-                arch = pkg.portable.get_isainfo()[0]
-                for p in self.elf_paths:
-                        p = re.sub("__ARCH__", arch, p)
-                        self.debug("testing elf file {0}".format(p))
-                        self.assertTrue(os.path.exists(p), "{0} does not exist".format(p))
-                        self.assertEqual(elf.is_elf_object(p), True)
-                        elf.get_dynamic(p)
-                        elf.get_hashes(p)
-                        self.debug("elf.get_info {0}".format(elf.get_info(p)))
+        # Check that the hashes generated have the correct length
+        # depending on the algorithm used to generated.
+        sha1_len = 40
+        sha256_len = 64
 
-        def test_valid_elf_hash(self):
-                """Test that the elf routines generate the expected hash"""
+        # the default is to return both the SHA-1 elfhash and
+        # the SHA-256 pkg.content-hash
+        d = elf.get_hashes(self.elf_paths[0])
+        self.assertTrue(len(d["elfhash"]) == sha1_len)
+        self.assertTrue("pkg.content-hash" in d)
+        self.assertTrue(len(d["pkg.content-hash"]) == 2)
+        for h in range(2):
+            v = d["pkg.content-hash"][h].split(":")
+            self.assertTrue(len(v) == 3)
+            self.assertTrue(v[1] == "sha256")
+            self.assertTrue(len(v[2]) == sha256_len)
 
-                o = os.path.join(self.test_root, "ro_data/elftest.so.1")
-                d = elf.get_hashes(o, elfhash=True, sha256=True,
-                    sha512t_256=True)
+        d = elf.get_hashes(self.elf_paths[0], elfhash=False, sha512t_256=True)
+        self.assertTrue("elfhash" not in d)
+        self.assertTrue("pkg.content-hash" in d)
+        self.assertTrue(len(d["pkg.content-hash"]) == 4)
+        sha256_count = 0
+        sha512t_256_count = 0
+        unsigned_count = 0
+        for h in range(4):
+            v = d["pkg.content-hash"][h].split(":")
+            self.assertTrue(len(v) == 3)
+            self.assertTrue(len(v[2]) == sha256_len)
+            if v[0].endswith(".unsigned"):
+                unsigned_count += 1
+            if v[1] == "sha256":
+                sha256_count += 1
+            elif v[1] == "sha512t_256":
+                sha512t_256_count += 1
+        self.assertTrue(sha256_count == 2)
+        self.assertTrue(sha512t_256_count == 2)
+        self.assertTrue(unsigned_count == 2)
 
-                expected = [
-'gelf:sha256:7c4f1f347b6d6e65e7542ffb21a05471728a80a5449fddd715186c6cbfdba4b0',
-'gelf.unsigned:sha256:7c4f1f347b6d6e65e7542ffb21a05471728a80a5449fddd715186c6cbfdba4b0',
-'gelf:sha512t_256:54f4cba7527ab9f78a85f7bb5a4e63315c8cae4a7e38f884e4bfd16bcab00821',
-'gelf.unsigned:sha512t_256:54f4cba7527ab9f78a85f7bb5a4e63315c8cae4a7e38f884e4bfd16bcab00821',
-                ]
+        d = elf.get_hashes(self.elf_paths[0], elfhash=False, sha256=False)
+        self.assertTrue(len(d) == 0)
 
-                import pprint; pprint.pprint(d)
-
-                self.assertEqual(d['elfhash'],
-                    '083308992c921537fd757548964f89452234dd11');
-                for hash in expected:
-                        self.assertTrue(hash in d['pkg.content-hash'])
-
-        def test_get_hashes_params(self):
-                """Test that get_hashes(..) returns checksums according to the
-                parameters passed to the method."""
-
-                # Check that the hashes generated have the correct length
-                # depending on the algorithm used to generated.
-                sha1_len = 40
-                sha256_len = 64
-
-                # the default is to return both the SHA-1 elfhash and
-                # the SHA-256 pkg.content-hash
-                d = elf.get_hashes(self.elf_paths[0])
-                self.assertTrue(len(d["elfhash"]) == sha1_len)
-                self.assertTrue("pkg.content-hash" in d)
-                self.assertTrue(len(d["pkg.content-hash"]) == 2)
-                for h in range(2):
-                        v = d["pkg.content-hash"][h].split(":")
-                        self.assertTrue(len(v) == 3)
-                        self.assertTrue(v[1] == "sha256")
-                        self.assertTrue(len(v[2]) == sha256_len)
-
-                d = elf.get_hashes(self.elf_paths[0],
-                    elfhash=False, sha512t_256=True)
-                self.assertTrue("elfhash" not in d)
-                self.assertTrue("pkg.content-hash" in d)
-                self.assertTrue(len(d["pkg.content-hash"]) == 4)
-                sha256_count = 0
-                sha512t_256_count = 0
-                unsigned_count = 0
-                for h in range(4):
-                        v = d["pkg.content-hash"][h].split(":")
-                        self.assertTrue(len(v) == 3)
-                        self.assertTrue(len(v[2]) == sha256_len)
-                        if v[0].endswith(".unsigned"):
-                                unsigned_count += 1
-                        if v[1] == "sha256":
-                                sha256_count += 1
-                        elif v[1] == "sha512t_256":
-                                sha512t_256_count += 1
-                self.assertTrue(sha256_count == 2)
-                self.assertTrue(sha512t_256_count == 2)
-                self.assertTrue(unsigned_count == 2)
-
-                d = elf.get_hashes(self.elf_paths[0], elfhash=False,
-                    sha256=False)
-                self.assertTrue(len(d) == 0)
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_file_manager.py
+++ b/src/tests/api/t_file_manager.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -40,300 +41,321 @@ import pkg.misc as misc
 import pkg.file_layout.file_manager as file_manager
 import pkg.file_layout.layout as layout
 
+
 class TestFileManager(pkg5unittest.Pkg5TestCase):
+    @staticmethod
+    def old_hash(s):
+        return os.path.join(s[0:2], s[2:8], s)
 
-        @staticmethod
-        def old_hash(s):
-                return os.path.join(s[0:2], s[2:8], s)
+    def touch_old_file(self, s, data=None):
+        if data is None:
+            data = s
+        p = os.path.join(self.base_dir, self.old_hash(s))
+        if not os.path.exists(os.path.dirname(p)):
+            os.makedirs(os.path.dirname(p))
+        fh = open(p, "wb")
+        fh.write(misc.force_bytes(data))
+        fh.close()
+        return p
 
-        def touch_old_file(self, s, data=None):
-                if data is None:
-                        data = s
-                p = os.path.join(self.base_dir, self.old_hash(s))
-                if not os.path.exists(os.path.dirname(p)):
-                        os.makedirs(os.path.dirname(p))
-                fh = open(p, "wb")
-                fh.write(misc.force_bytes(data))
-                fh.close()
-                return p
+    @staticmethod
+    def check_exception(func, ex, str_bits, *args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except ex as e:
+            s = str(e)
+            for b in str_bits:
+                if b not in s:
+                    raise RuntimeError(
+                        "Expected to find " "{0} in {1}".format(b, s)
+                    )
+        else:
+            raise RuntimeError("Didn't raise expected exception")
 
-        @staticmethod
-        def check_exception(func, ex, str_bits, *args, **kwargs):
-                try:
-                        func(*args, **kwargs)
-                except ex as e:
-                        s = str(e)
-                        for b in str_bits:
-                                if b not in s:
-                                        raise RuntimeError("Expected to find "
-                                            "{0} in {1}".format(b, s))
-                else:
-                        raise RuntimeError("Didn't raise expected exception")
+    def check_readonly(self, fm, unmoved, p):
+        self.assertTrue(os.path.isfile(p))
+        self.assertEqual(fm.lookup(unmoved), p)
+        fh = fm.lookup(unmoved, opener=True)
+        try:
+            self.assertEqual(fh.read(), misc.force_bytes(unmoved))
+        finally:
+            fh.close()
+        self.assertTrue(os.path.isfile(p))
 
-        def check_readonly(self, fm, unmoved, p):
-                self.assertTrue(os.path.isfile(p))
-                self.assertEqual(fm.lookup(unmoved), p)
-                fh = fm.lookup(unmoved, opener=True)
-                try:
-                        self.assertEqual(fh.read(), misc.force_bytes(unmoved))
-                finally:
-                        fh.close()
-                self.assertTrue(os.path.isfile(p))
+        self.check_exception(
+            fm.insert,
+            file_manager.NeedToModifyReadOnlyFileManager,
+            ["create", unmoved],
+            unmoved,
+            p,
+        )
+        self.assertTrue(os.path.isfile(p))
+        self.check_exception(
+            fm.remove,
+            file_manager.NeedToModifyReadOnlyFileManager,
+            ["remove", unmoved],
+            unmoved,
+        )
+        self.assertTrue(os.path.isfile(p))
 
-                self.check_exception(fm.insert,
-                    file_manager.NeedToModifyReadOnlyFileManager,
-                    ["create", unmoved], unmoved, p)
-                self.assertTrue(os.path.isfile(p))
-                self.check_exception(fm.remove,
-                    file_manager.NeedToModifyReadOnlyFileManager,
-                    ["remove", unmoved], unmoved)
-                self.assertTrue(os.path.isfile(p))
+    def setUp(self):
+        pkg5unittest.Pkg5TestCase.setUp(self)
+        # Move base_dir down one level so that the tests don't assume
+        # sole control over the contents of self.test_root.
+        self.base_dir = os.path.join(self.test_root, "fm")
+        os.mkdir(self.base_dir)
 
-        def setUp(self):
-                pkg5unittest.Pkg5TestCase.setUp(self)
-                # Move base_dir down one level so that the tests don't assume
-                # sole control over the contents of self.test_root.
-                self.base_dir = os.path.join(self.test_root, "fm")
-                os.mkdir(self.base_dir)
+    def test_1(self):
+        """Verify base functionality works as expected."""
 
-        def test_1(self):
-                """Verify base functionality works as expected."""
+        t = tempfile.gettempdir()
+        no_dir = os.path.join(t, "not_exist")
 
-                t = tempfile.gettempdir()
-                no_dir = os.path.join(t, "not_exist")
+        # Test that a read only FileManager won't modify the file
+        # system.
+        fm = file_manager.FileManager(self.base_dir, readonly=True)
+        self.assertEqual(os.listdir(self.base_dir), [])
 
-                # Test that a read only FileManager won't modify the file
-                # system.
-                fm = file_manager.FileManager(self.base_dir, readonly=True)
-                self.assertEqual(os.listdir(self.base_dir), [])
+        unmoved = "4b7c923af3a047d4685a39ad7bc9b0382ccde671"
 
-                unmoved = "4b7c923af3a047d4685a39ad7bc9b0382ccde671"
+        p = self.touch_old_file(unmoved)
+        self.check_readonly(fm, unmoved, p)
 
-                p = self.touch_old_file(unmoved)
-                self.check_readonly(fm, unmoved, p)
+        self.assertEqual(set(fm.walk()), set([unmoved]))
 
-                self.assertEqual(set(fm.walk()),
-                    set([unmoved]))
+        # Test a FileManager that can write to the file system.
+        fm = file_manager.FileManager(self.base_dir, False)
 
-                # Test a FileManager that can write to the file system.
-                fm = file_manager.FileManager(self.base_dir, False)
+        hash1 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cb"
+        hash2 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
+        hash3 = "994b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
+        hash4 = "cc1f76cdad188714d1c3b92a4eebb4ec7d646166"
 
-                hash1 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cb"
-                hash2 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
-                hash3 = "994b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
-                hash4 = "cc1f76cdad188714d1c3b92a4eebb4ec7d646166"
+        l = layout.V1Layout()
 
-                l = layout.V1Layout()
+        self.assertEqual(
+            l.lookup(hash1), "58/584b6ab7d7eb446938a02e57101c3a2fecbfb3cb"
+        )
 
-                self.assertEqual(l.lookup(hash1),
-                    "58/584b6ab7d7eb446938a02e57101c3a2fecbfb3cb")
+        # Test that looking up a file stored under the old system gets
+        # moved to the correct location, that the new location is
+        # correctly returned, and that the old location's parent
+        # directory no longer exists as only a single file existed
+        # there.  Finally, remove it for the next test if successful.
+        p1 = self.touch_old_file(hash1)
+        self.assertTrue(os.path.isfile(p1))
+        self.assertTrue(os.path.isdir(os.path.dirname(p1)))
+        self.assertEqual(
+            fm.lookup(hash1), os.path.join(self.base_dir, l.lookup(hash1))
+        )
+        self.assertTrue(not os.path.exists(p1))
+        self.assertTrue(not os.path.exists(os.path.dirname(p1)))
+        fm.remove(hash1)
 
-                # Test that looking up a file stored under the old system gets
-                # moved to the correct location, that the new location is
-                # correctly returned, and that the old location's parent
-                # directory no longer exists as only a single file existed
-                # there.  Finally, remove it for the next test if successful.
-                p1 = self.touch_old_file(hash1)
-                self.assertTrue(os.path.isfile(p1))
-                self.assertTrue(os.path.isdir(os.path.dirname(p1)))
-                self.assertEqual(fm.lookup(hash1),
-                    os.path.join(self.base_dir, l.lookup(hash1)))
-                self.assertTrue(not os.path.exists(p1))
-                self.assertTrue(not os.path.exists(os.path.dirname(p1)))
-                fm.remove(hash1)
+        # Test that looking up a file stored under the old system gets
+        # moved to the correct location, that the new location is
+        # correctly returned, and that the old location's parent
+        # directory still exists as multiple files were stored there.
+        # Finally, remove file stored in the old location for the next
+        # few tests.
+        p1 = self.touch_old_file(hash1)
+        self.touch_old_file(hash2)
+        self.assertTrue(os.path.isfile(p1))
+        self.assertTrue(os.path.isdir(os.path.dirname(p1)))
+        self.assertEqual(
+            fm.lookup(hash1), os.path.join(self.base_dir, l.lookup(hash1))
+        )
+        self.assertTrue(not os.path.exists(p1))
+        self.assertTrue(os.path.exists(os.path.dirname(p1)))
+        fm.remove(hash2)
 
-                # Test that looking up a file stored under the old system gets
-                # moved to the correct location, that the new location is
-                # correctly returned, and that the old location's parent
-                # directory still exists as multiple files were stored there.
-                # Finally, remove file stored in the old location for the next
-                # few tests.
-                p1 = self.touch_old_file(hash1)
-                self.touch_old_file(hash2)
-                self.assertTrue(os.path.isfile(p1))
-                self.assertTrue(os.path.isdir(os.path.dirname(p1)))
-                self.assertEqual(fm.lookup(hash1),
-                    os.path.join(self.base_dir, l.lookup(hash1)))
-                self.assertTrue(not os.path.exists(p1))
-                self.assertTrue(os.path.exists(os.path.dirname(p1)))
-                fm.remove(hash2)
+        # Test that looking up a file stored under the old system gets
+        # moved and that it returns a file handle with the correct
+        # contents.
+        p4 = self.touch_old_file(hash4)
+        self.assertTrue(os.path.isfile(p4))
+        self.assertTrue(os.path.isdir(os.path.dirname(p4)))
+        fh = fm.lookup(hash4, opener=True)
+        try:
+            self.assertEqual(fh.read(), misc.force_bytes(hash4))
+        finally:
+            fh.close()
+        self.assertTrue(not os.path.exists(p4))
+        self.assertTrue(not os.path.exists(os.path.dirname(p4)))
 
-                # Test that looking up a file stored under the old system gets
-                # moved and that it returns a file handle with the correct
-                # contents.
-                p4 = self.touch_old_file(hash4)
-                self.assertTrue(os.path.isfile(p4))
-                self.assertTrue(os.path.isdir(os.path.dirname(p4)))
-                fh = fm.lookup(hash4, opener=True)
-                try:
-                        self.assertEqual(fh.read(), misc.force_bytes(hash4))
-                finally:
-                        fh.close()
-                self.assertTrue(not os.path.exists(p4))
-                self.assertTrue(not os.path.exists(os.path.dirname(p4)))
+        p3 = self.touch_old_file(hash3)
+        self.assertTrue(os.path.isfile(p3))
+        self.assertTrue(os.path.isdir(os.path.dirname(p3)))
+        fm.insert(hash3, p3)
 
-                p3 = self.touch_old_file(hash3)
-                self.assertTrue(os.path.isfile(p3))
-                self.assertTrue(os.path.isdir(os.path.dirname(p3)))
-                fm.insert(hash3, p3)
+        self.assertTrue(not os.path.exists(p3))
+        self.assertTrue(not os.path.exists(os.path.dirname(p3)))
 
-                self.assertTrue(not os.path.exists(p3))
-                self.assertTrue(not os.path.exists(os.path.dirname(p3)))
+        fh = fm.lookup(hash3, opener=True)
+        try:
+            self.assertEqual(fh.read(), misc.force_bytes(hash3))
+        finally:
+            fh.close()
 
-                fh = fm.lookup(hash3, opener=True)
-                try:
-                        self.assertEqual(fh.read(), misc.force_bytes(hash3))
-                finally:
-                        fh.close()
+        # Test that walk returns the expected values.
+        self.assertEqual(set(fm.walk()), set([unmoved, hash1, hash4, hash3]))
 
-                # Test that walk returns the expected values.
-                self.assertEqual(set(fm.walk()),
-                    set([unmoved, hash1, hash4, hash3]))
+        # Test that walking with a different set of layouts works as
+        # expected.
+        fm2 = file_manager.FileManager(
+            self.base_dir,
+            readonly=True,
+            layouts=[layout.get_preferred_layout()],
+        )
 
-                # Test that walking with a different set of layouts works as
-                # expected.
-                fm2 = file_manager.FileManager(self.base_dir, readonly=True,
-                    layouts=[layout.get_preferred_layout()])
+        fs = set([hash1, hash4, hash3])
+        try:
+            for i in fm2.walk():
+                fs.remove(i)
+        except file_manager.UnrecognizedFilePaths as e:
+            self.assertEqual(e.fps, [p[len(self.base_dir) + 1 :]])
+        self.assertEqual(fs, set())
 
-                fs = set([hash1, hash4, hash3])
-                try:
-                        for i in fm2.walk():
-                                fs.remove(i)
-                except file_manager.UnrecognizedFilePaths as e:
-                        self.assertEqual(e.fps, [p[len(self.base_dir) + 1:]])
-                self.assertEqual(fs, set())
+        # Test removing a file works and removes the containing
+        # directory and that remove removes all instances of a hash
+        # from the file manager.
+        hash3_loc = os.path.join(self.base_dir, l.lookup(hash3))
+        v0_hash3_loc = self.touch_old_file(hash3)
 
-                # Test removing a file works and removes the containing
-                # directory and that remove removes all instances of a hash
-                # from the file manager.
-                hash3_loc = os.path.join(self.base_dir, l.lookup(hash3))
-                v0_hash3_loc = self.touch_old_file(hash3)
+        self.assertTrue(os.path.isfile(hash3_loc))
+        self.assertTrue(os.path.isfile(v0_hash3_loc))
+        fm.remove(hash3)
+        self.assertEqual(fm.lookup(hash3), None)
+        self.assertTrue(not os.path.exists(hash3_loc))
+        self.assertTrue(not os.path.exists(os.path.dirname(hash3_loc)))
+        self.assertTrue(not os.path.exists(v0_hash3_loc))
+        self.assertTrue(not os.path.exists(os.path.dirname(v0_hash3_loc)))
+        self.assertTrue(os.path.isfile(fm.lookup(hash1)))
 
-                self.assertTrue(os.path.isfile(hash3_loc))
-                self.assertTrue(os.path.isfile(v0_hash3_loc))
-                fm.remove(hash3)
-                self.assertEqual(fm.lookup(hash3), None)
-                self.assertTrue(not os.path.exists(hash3_loc))
-                self.assertTrue(not os.path.exists(os.path.dirname(hash3_loc)))
-                self.assertTrue(not os.path.exists(v0_hash3_loc))
-                self.assertTrue(not os.path.exists(os.path.dirname(v0_hash3_loc)))
-                self.assertTrue(os.path.isfile(fm.lookup(hash1)))
+        rh2_fd, raw_hash_2_loc = tempfile.mkstemp(dir=self.base_dir)
+        rh2_fh = os.fdopen(rh2_fd, "w")
+        rh2_fh.write(hash2)
+        rh2_fh.close()
 
-                rh2_fd, raw_hash_2_loc = tempfile.mkstemp(dir=self.base_dir)
-                rh2_fh = os.fdopen(rh2_fd, "w")
-                rh2_fh.write(hash2)
-                rh2_fh.close()
+        fm.insert(hash2, raw_hash_2_loc)
+        h2_loc = fm.lookup(hash2)
+        self.assertTrue(os.path.isfile(fm.lookup(hash2)))
+        # Test that the directory has two files in it as expected.
+        self.assertEqual(
+            set(os.listdir(os.path.dirname(fm.lookup(hash2)))),
+            set([hash1, hash2]),
+        )
+        # Test removing one of the two files doesn't remove the other.
+        fm.remove(hash1)
+        self.assertTrue(os.path.isfile(h2_loc))
+        self.assertEqual(fm.lookup(hash2), h2_loc)
+        self.assertEqual(fm.lookup(hash1), None)
+        # Test that removing the second file works and removes the
+        # containing directory as well.
+        fm.remove(hash2)
+        self.assertTrue(not os.path.exists(h2_loc))
+        self.assertTrue(not os.path.exists(os.path.dirname(h2_loc)))
 
-                fm.insert(hash2, raw_hash_2_loc)
-                h2_loc = fm.lookup(hash2)
-                self.assertTrue(os.path.isfile(fm.lookup(hash2)))
-                # Test that the directory has two files in it as expected.
-                self.assertEqual(set(os.listdir(
-                    os.path.dirname(fm.lookup(hash2)))),
-                    set([hash1, hash2]))
-                # Test removing one of the two files doesn't remove the other.
-                fm.remove(hash1)
-                self.assertTrue(os.path.isfile(h2_loc))
-                self.assertEqual(fm.lookup(hash2), h2_loc)
-                self.assertEqual(fm.lookup(hash1), None)
-                # Test that removing the second file works and removes the
-                # containing directory as well.
-                fm.remove(hash2)
-                self.assertTrue(not os.path.exists(h2_loc))
-                self.assertTrue(not os.path.exists(os.path.dirname(h2_loc)))
+        # Test that setting the read_only property works and that none
+        # of the activities has effected the location where unmoved has
+        # been stored.
+        fm.set_read_only()
+        self.check_readonly(fm, unmoved, p)
 
-                # Test that setting the read_only property works and that none
-                # of the activities has effected the location where unmoved has
-                # been stored.
-                fm.set_read_only()
-                self.check_readonly(fm, unmoved, p)
+    def test_2_reverse(self):
+        """Verify that reverse layout migration works as expected."""
 
-        def test_2_reverse(self):
-                """Verify that reverse layout migration works as expected."""
+        # Verify that reverse layout migration works as expected.
+        hash1 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cb"
+        hash2 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
+        hash3 = "994b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
+        hash4 = "cc1f76cdad188714d1c3b92a4eebb4ec7d646166"
 
-                # Verify that reverse layout migration works as expected.
-                hash1 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cb"
-                hash2 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
-                hash3 = "994b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
-                hash4 = "cc1f76cdad188714d1c3b92a4eebb4ec7d646166"
+        l0 = layout.V0Layout()
+        l1 = layout.V1Layout()
 
-                l0 = layout.V0Layout()
-                l1 = layout.V1Layout()
+        # Populate the managed location using the v0 layout.
+        for fhash in (hash1, hash2, hash3, hash4):
+            self.touch_old_file(fhash)
 
-                # Populate the managed location using the v0 layout.
-                for fhash in (hash1, hash2, hash3, hash4):
-                        self.touch_old_file(fhash)
+        # Migrate it to the v1 layout.
+        fm = file_manager.FileManager(self.base_dir, False)
+        for fhash in fm.walk():
+            self.assertEqual(
+                fm.lookup(fhash), os.path.join(self.base_dir, l1.lookup(fhash))
+            )
 
-                # Migrate it to the v1 layout.
-                fm = file_manager.FileManager(self.base_dir, False)
-                for fhash in fm.walk():
-                        self.assertEqual(fm.lookup(fhash),
-                            os.path.join(self.base_dir, l1.lookup(fhash)))
+        # After migration verify that no v0 parent directories remain.
+        for fhash in fm.walk():
+            self.assertFalse(
+                os.path.exists(
+                    os.path.dirname(
+                        os.path.join(self.base_dir, l0.lookup(fhash))
+                    )
+                )
+            )
 
-                # After migration verify that no v0 parent directories remain.
-                for fhash in fm.walk():
-                        self.assertFalse(os.path.exists(os.path.dirname(
-                            os.path.join(self.base_dir, l0.lookup(fhash)))))
+        # Re-create the FileManager using v0 as the preferred layout.
+        fm = file_manager.FileManager(self.base_dir, False, layouts=[l0, l1])
 
-                # Re-create the FileManager using v0 as the preferred layout.
-                fm = file_manager.FileManager(self.base_dir, False,
-                    layouts=[l0, l1])
+        # Test that looking up a file stored under the v1 layout is
+        # correctly moved to the v0 layout.
+        for fhash in fm.walk():
+            self.assertEqual(
+                fm.lookup(fhash), os.path.join(self.base_dir, l0.lookup(fhash))
+            )
 
-                # Test that looking up a file stored under the v1 layout is
-                # correctly moved to the v0 layout.
-                for fhash in fm.walk():
-                        self.assertEqual(fm.lookup(fhash),
-                            os.path.join(self.base_dir, l0.lookup(fhash)))
+    def test_3_replace(self):
+        """Verify that insert will replace an existing file even though
+        the hashval is the same."""
 
-        def test_3_replace(self):
-                """Verify that insert will replace an existing file even though
-                the hashval is the same."""
+        # Verify that reverse layout migration works as expected.
+        hash1 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cb"
+        hash2 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
+        hash3 = "994b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
+        hash4 = "cc1f76cdad188714d1c3b92a4eebb4ec7d646166"
 
-                # Verify that reverse layout migration works as expected.
-                hash1 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cb"
-                hash2 = "584b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
-                hash3 = "994b6ab7d7eb446938a02e57101c3a2fecbfb3cc"
-                hash4 = "cc1f76cdad188714d1c3b92a4eebb4ec7d646166"
+        l1 = layout.V1Layout()
 
-                l1 = layout.V1Layout()
+        # Populate the managed location using the v0 layout.
+        for fhash in (hash1, hash2, hash3, hash4):
+            self.touch_old_file(fhash, data="old-{0}".format(fhash))
 
-                # Populate the managed location using the v0 layout.
-                for fhash in (hash1, hash2, hash3, hash4):
-                        self.touch_old_file(fhash, data="old-{0}".format(fhash))
+        # Migrate it to the v1 layout and verify that each
+        # file contains the expected data.
+        fm = file_manager.FileManager(self.base_dir, False)
+        for fhash in fm.walk():
+            loc = fm.lookup(fhash)
+            self.assertEqual(loc, os.path.join(self.base_dir, l1.lookup(fhash)))
 
-                # Migrate it to the v1 layout and verify that each
-                # file contains the expected data.
-                fm = file_manager.FileManager(self.base_dir, False)
-                for fhash in fm.walk():
-                        loc = fm.lookup(fhash)
-                        self.assertEqual(loc, os.path.join(self.base_dir,
-                            l1.lookup(fhash)))
+            f = open(loc, "rb")
+            self.assertEqual(
+                f.read(), misc.force_bytes("old-{0}".format(fhash))
+            )
+            f.close()
 
-                        f = open(loc, "rb")
-                        self.assertEqual(f.read(), misc.force_bytes(
-                            "old-{0}".format(fhash)))
-                        f.close()
+        # Now replace each file using the old hashnames and verify
+        # that the each contains the expected data.
+        for fhash in fm.walk():
+            loc = os.path.join(self.base_dir, l1.lookup(fhash))
+            self.assertTrue(os.path.exists(loc))
 
-                # Now replace each file using the old hashnames and verify
-                # that the each contains the expected data.
-                for fhash in fm.walk():
-                        loc = os.path.join(self.base_dir, l1.lookup(fhash))
-                        self.assertTrue(os.path.exists(loc))
+            npath = os.path.join(self.base_dir, "new-{0}".format(fhash))
+            nfile = open(npath, "wb")
+            nfile.write(misc.force_bytes("new-{0}".format(fhash)))
+            nfile.close()
+            fm.insert(fhash, npath)
 
-                        npath = os.path.join(self.base_dir, "new-{0}".format(fhash))
-                        nfile = open(npath, "wb")
-                        nfile.write(misc.force_bytes("new-{0}".format(fhash)))
-                        nfile.close()
-                        fm.insert(fhash, npath)
+            loc = fm.lookup(fhash)
+            f = open(loc, "rb")
+            self.assertEqual(
+                f.read(), misc.force_bytes("new-{0}".format(fhash))
+            )
+            f.close()
 
-                        loc = fm.lookup(fhash)
-                        f = open(loc, "rb")
-                        self.assertEqual(f.read(), misc.force_bytes(
-                            "new-{0}".format(fhash)))
-                        f.close()
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_fmri.py
+++ b/src/tests/api/t_fmri.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -35,278 +36,301 @@ import pkg.fmri as fmri
 import os
 import sys
 
+
 class TestFMRI(pkg5unittest.Pkg5TestCase):
+    pkg_name_valid_chars = {
+        "never": ' `~!@#$%^&*()=[{]}\\|;:",<>?',
+        "always": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        + "0123456789",
+        "after-first": "_-.+",
+    }
 
-        pkg_name_valid_chars = {
-            "never": " `~!@#$%^&*()=[{]}\\|;:\",<>?",
-            "always": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" +
-                "0123456789",
-            "after-first": "_-.+",
-        }
+    def setUp(self):
+        self.n1 = fmri.PkgFmri("pkg://pion/sunos/coreutils")
+        self.n2 = fmri.PkgFmri("sunos/coreutils")
+        self.n3 = fmri.PkgFmri("sunos/coreutils@5.10")
+        self.n4 = fmri.PkgFmri("sunos/coreutils@6.7,5.10-2:20070710T164744Z")
+        self.n5 = fmri.PkgFmri("sunos/coreutils@6.6,5.10-2:20070710T164744Z")
+        self.n6 = fmri.PkgFmri("coreutils")
+        self.n7 = fmri.PkgFmri(
+            "pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z"
+        )
+        self.n8 = fmri.PkgFmri(
+            "pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070922T153047Z"
+        )
+        self.n9 = fmri.PkgFmri(
+            "sunos/coreutils@6.8,5.11-0", publisher="opensolaris.org"
+        )
+        self.n10 = fmri.PkgFmri(
+            "pkg://origin2/SUNWxwssu@0.5.11,5.11-0.72:20070922T153047Z"
+        )
+        # same as n10
+        self.n11 = fmri.PkgFmri(
+            "pkg://origin2/SUNWxwssu@0.5.11,5.11-0.72:20070922T153047Z"
+        )
 
-        def setUp(self):
-                self.n1 = fmri.PkgFmri("pkg://pion/sunos/coreutils")
-                self.n2 = fmri.PkgFmri("sunos/coreutils")
-                self.n3 = fmri.PkgFmri("sunos/coreutils@5.10")
-                self.n4 = fmri.PkgFmri(
-                    "sunos/coreutils@6.7,5.10-2:20070710T164744Z")
-                self.n5 = fmri.PkgFmri(
-                    "sunos/coreutils@6.6,5.10-2:20070710T164744Z")
-                self.n6 = fmri.PkgFmri("coreutils")
-                self.n7 = fmri.PkgFmri(
-                    "pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
-                self.n8 = fmri.PkgFmri(
-                    "pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070922T153047Z")
-                self.n9 = fmri.PkgFmri("sunos/coreutils@6.8,5.11-0",
-                    publisher = "opensolaris.org")
-                self.n10 = fmri.PkgFmri(
-                    "pkg://origin2/SUNWxwssu@0.5.11,5.11-0.72:20070922T153047Z")
-                # same as n10
-                self.n11 = fmri.PkgFmri(
-                    "pkg://origin2/SUNWxwssu@0.5.11,5.11-0.72:20070922T153047Z")
+    def testfmricmp1(self):
+        self.assertTrue(self.n3.__eq__(self.n3))
 
-        def testfmricmp1(self):
-                self.assertTrue(self.n3.__eq__(self.n3))
+    def testfmricmp2(self):
+        self.assertTrue(self.n3.__lt__(self.n4))
 
-        def testfmricmp2(self):
-                self.assertTrue(self.n3.__lt__(self.n4))
+    def testfmricmp3(self):
+        self.assertTrue(self.n5.__gt__(self.n3))
 
-        def testfmricmp3(self):
-                self.assertTrue(self.n5.__gt__(self.n3))
+    def testfmrisuccessor1(self):
+        self.assertTrue(self.n8.is_successor(self.n7))
 
-        def testfmrisuccessor1(self):
-                self.assertTrue(self.n8.is_successor(self.n7))
+    def testfmrisuccessor2(self):
+        self.assertTrue(self.n1.is_successor(self.n2))
 
-        def testfmrisuccessor2(self):
-                self.assertTrue(self.n1.is_successor(self.n2))
+    def testfmrisuccessor3(self):
+        self.assertTrue(self.n4.is_successor(self.n3))
 
-        def testfmrisuccessor3(self):
-                self.assertTrue(self.n4.is_successor(self.n3))
+    def testfmrisuccessor4(self):
+        self.assertTrue(not self.n5.is_successor(self.n4))
 
-        def testfmrisuccessor4(self):
-                self.assertTrue(not self.n5.is_successor(self.n4))
+    def testfmrisuccessor5(self):
+        """is_successor should return true on equality"""
+        self.assertTrue(self.n5.is_successor(self.n5))
 
-        def testfmrisuccessor5(self):
-                """is_successor should return true on equality"""
-                self.assertTrue(self.n5.is_successor(self.n5))
+    def testfmrisuccessor6(self):
+        """fmris have different versions and different authorities"""
+        self.assertTrue(self.n10.is_successor(self.n7))
 
-        def testfmrisuccessor6(self):
-                """fmris have different versions and different authorities"""
-                self.assertTrue(self.n10.is_successor(self.n7))
+    def testfmrisimilar1(self):
+        self.assertTrue(self.n4.is_similar(self.n2))
 
-        def testfmrisimilar1(self):
-                self.assertTrue(self.n4.is_similar(self.n2))
+    def testfmrisimilar2(self):
+        self.assertTrue(self.n1.is_similar(self.n2))
 
-        def testfmrisimilar2(self):
-                self.assertTrue(self.n1.is_similar(self.n2))
+    def testfmrisimilar3(self):
+        self.assertTrue(not self.n1.is_similar(self.n6))
 
-        def testfmrisimilar3(self):
-                self.assertTrue(not self.n1.is_similar(self.n6))
+    def testfmrihaspublisher(self):
+        self.assertTrue(self.n1.has_publisher() == True)
+        self.assertTrue(self.n2.has_publisher() == False)
+        self.assertTrue(self.n3.has_publisher() == False)
+        self.assertTrue(self.n4.has_publisher() == False)
+        self.assertTrue(self.n5.has_publisher() == False)
+        self.assertTrue(self.n6.has_publisher() == False)
+        self.assertTrue(self.n7.has_publisher() == True)
+        self.assertTrue(self.n8.has_publisher() == True)
 
-        def testfmrihaspublisher(self):
-                self.assertTrue(self.n1.has_publisher() == True)
-                self.assertTrue(self.n2.has_publisher() == False)
-                self.assertTrue(self.n3.has_publisher() == False)
-                self.assertTrue(self.n4.has_publisher() == False)
-                self.assertTrue(self.n5.has_publisher() == False)
-                self.assertTrue(self.n6.has_publisher() == False)
-                self.assertTrue(self.n7.has_publisher() == True)
-                self.assertTrue(self.n8.has_publisher() == True)
+    def testfmrihasversion(self):
+        self.assertTrue(self.n1.has_version() == False)
+        self.assertTrue(self.n2.has_version() == False)
+        self.assertTrue(self.n3.has_version() == True)
+        self.assertTrue(self.n4.has_version() == True)
+        self.assertTrue(self.n5.has_version() == True)
+        self.assertTrue(self.n6.has_version() == False)
 
-        def testfmrihasversion(self):
-                self.assertTrue(self.n1.has_version() == False)
-                self.assertTrue(self.n2.has_version() == False)
-                self.assertTrue(self.n3.has_version() == True)
-                self.assertTrue(self.n4.has_version() == True)
-                self.assertTrue(self.n5.has_version() == True)
-                self.assertTrue(self.n6.has_version() == False)
+    def testfmriissamepkg(self):
+        self.assertTrue(self.n7.is_same_pkg(self.n8))
+        self.assertTrue(self.n7.is_same_pkg(self.n10))
+        self.assertTrue(not self.n7.is_same_pkg(self.n6))
 
-        def testfmriissamepkg(self):
-                self.assertTrue(self.n7.is_same_pkg(self.n8))
-                self.assertTrue(self.n7.is_same_pkg(self.n10))
-                self.assertTrue(not self.n7.is_same_pkg(self.n6))
+    def testbadfmri1(self):
+        # no 31st day in february
+        self.assertRaises(
+            fmri.IllegalFmri,
+            fmri.PkgFmri,
+            "pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070231T203926Z",
+        )
 
-        def testbadfmri1(self):
-                # no 31st day in february
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070231T203926Z")
+    def testbadfmri2(self):
+        # missing version
+        self.assertRaises(
+            fmri.IllegalFmri, fmri.PkgFmri, "pkg://origin/SUNWxwssu@"
+        )
 
-        def testbadfmri2(self):
-                # missing version
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "pkg://origin/SUNWxwssu@")
+    #
+    # The next assertions are for various bogus fmris
+    #
+    def testbadfmri3(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "")
 
-        #
-        # The next assertions are for various bogus fmris
-        #
-        def testbadfmri3(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "")
+    def testbadfmri4(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "@")
 
-        def testbadfmri4(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "@")
+    def testbadfmri5(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "@1,1-1")
 
-        def testbadfmri5(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "@1,1-1")
+    def testbadfmri6(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg:")
 
-        def testbadfmri6(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg:")
+    def testbadfmri7(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg://")
 
-        def testbadfmri7(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg://")
+    def testbadfmri8(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg://foo")
 
-        def testbadfmri8(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg://foo")
+    def testbadfmri9(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg://foo/")
 
-        def testbadfmri9(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg://foo/")
+    def testbadfmri10(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg:/")
 
-        def testbadfmri10(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg:/")
+    def testbadfmri11(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg://@")
 
-        def testbadfmri11(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg://@")
+    def testbadfmri12(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg:/@")
 
-        def testbadfmri12(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg:/@")
+    def testbadfmri13(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg:/pkg:")
 
-        def testbadfmri13(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg:/pkg:")
+    def testbadfmri14(self):
+        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, "pkg://foo/pkg:")
 
-        def testbadfmri14(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "pkg://foo/pkg:")
+    def testbadfmri15(self):
+        # Truncated time
+        self.assertRaises(
+            fmri.IllegalFmri,
+            fmri.PkgFmri,
+            "pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070231T203",
+        )
 
-        def testbadfmri15(self):
-                # Truncated time
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070231T203")
+    def testbadfmri16(self):
+        # Truncated time
+        self.assertRaises(
+            fmri.IllegalFmri,
+            fmri.PkgFmri,
+            "pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:200702",
+        )
 
-        def testbadfmri16(self):
-                # Truncated time
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:200702")
+    def testbadfmri17(self):
+        # Dangling Branch with Time
+        self.assertRaises(
+            fmri.IllegalFmri,
+            fmri.PkgFmri,
+            "pkg://origin/SUNWxwssu@0.5.11,5.11-:20070922T153047Z",
+        )
 
-        def testbadfmri17(self):
-                # Dangling Branch with Time
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "pkg://origin/SUNWxwssu@0.5.11,5.11-:20070922T153047Z")
+    def testbadfmri18(self):
+        # Dangling Branch
+        self.assertRaises(
+            fmri.IllegalFmri,
+            fmri.PkgFmri,
+            "pkg://origin/SUNWxwssu@0.5.11,5.11-",
+        )
 
-        def testbadfmri18(self):
-                # Dangling Branch
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "pkg://origin/SUNWxwssu@0.5.11,5.11-")
+    def test_pkgname_grammar(self):
+        for char in self.pkg_name_valid_chars["never"]:
+            invalid_name = "invalid{0}pkg@1.0,5.11-0".format(char)
+            self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, invalid_name)
 
-        def test_pkgname_grammar(self):
-                for char in self.pkg_name_valid_chars["never"]:
-                        invalid_name = "invalid{0}pkg@1.0,5.11-0".format(char)
-                        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                            invalid_name)
+        for char in self.pkg_name_valid_chars["after-first"]:
+            invalid_name = "{0}invalidpkg@1.0,5.11-0".format(char)
+            self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, invalid_name)
 
-                for char in self.pkg_name_valid_chars["after-first"]:
-                        invalid_name = "{0}invalidpkg@1.0,5.11-0".format(char)
-                        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                            invalid_name)
+        for char in self.pkg_name_valid_chars["after-first"]:
+            invalid_name = "test/{0}pkg@1.0,5.11-0".format(char)
+            self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri, invalid_name)
 
-                for char in self.pkg_name_valid_chars["after-first"]:
-                        invalid_name = "test/{0}pkg@1.0,5.11-0".format(char)
-                        self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                            invalid_name)
+        # Some positive tests
+        for char in self.pkg_name_valid_chars["always"]:
+            for char2 in self.pkg_name_valid_chars["after-first"]:
+                valid_name = "{0}{1}test@1.0,5.11-0".format(char, char2)
+                fmri.PkgFmri(valid_name)
 
-                # Some positive tests
-                for char in self.pkg_name_valid_chars["always"]:
-                        for char2 in self.pkg_name_valid_chars["after-first"]:
-                                valid_name = "{0}{1}test@1.0,5.11-0".format(
-                                    char, char2)
-                                fmri.PkgFmri(valid_name)
+        # Test '/' == 'pkg:/'; '//' == 'pkg://'.
+        for vn in ("/test@1.0,5.11-0", "//publisher/test@1.0,5.11-0"):
+            pfmri = fmri.PkgFmri(vn)
+            self.assertEqual(pfmri.pkg_name, "test")
+            if vn.startswith("//"):
+                self.assertEqual(pfmri.publisher, "publisher")
+            else:
+                self.assertEqual(pfmri.publisher, None)
 
-                # Test '/' == 'pkg:/'; '//' == 'pkg://'.
-                for vn in ("/test@1.0,5.11-0", "//publisher/test@1.0,5.11-0"):
-                        pfmri = fmri.PkgFmri(vn)
-                        self.assertEqual(pfmri.pkg_name, "test")
-                        if vn.startswith("//"):
-                                self.assertEqual(pfmri.publisher, "publisher")
-                        else:
-                                self.assertEqual(pfmri.publisher, None)
+    def testbadfmri_pkgname(self):
+        self.assertRaises(
+            fmri.IllegalFmri,
+            fmri.PkgFmri,
+            "application//office@0.5.11,5.11-0.96",
+        )
+        self.assertRaises(
+            fmri.IllegalFmri,
+            fmri.PkgFmri,
+            "application/office/@0.5.11,5.11-0.96",
+        )
+        self.assertRaises(
+            fmri.IllegalFmri, fmri.PkgFmri, "app/.cool@0.5.11,5.11-0.96"
+        )
 
-        def testbadfmri_pkgname(self):
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "application//office@0.5.11,5.11-0.96")
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "application/office/@0.5.11,5.11-0.96")
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "app/.cool@0.5.11,5.11-0.96")
+    def testgoodfmris_dots(self):
+        fmri.PkgFmri("a.b")
+        fmri.PkgFmri("a.b@1.0")
 
-        def testgoodfmris_dots(self):
-                fmri.PkgFmri("a.b")
-                fmri.PkgFmri("a.b@1.0")
+    def testgoodfmris_slashes(self):
+        fmri.PkgFmri("a/b")
+        fmri.PkgFmri("a/b/c")
 
-        def testgoodfmris_slashes(self):
-                fmri.PkgFmri("a/b")
-                fmri.PkgFmri("a/b/c")
+    def testgoodfmris_dashes(self):
+        fmri.PkgFmri("a--b---")
 
-        def testgoodfmris_dashes(self):
-                fmri.PkgFmri("a--b---")
+    def testgoodfmris_unders(self):
+        fmri.PkgFmri("a___b__")
 
-        def testgoodfmris_unders(self):
-                fmri.PkgFmri("a___b__")
+    def testgoodfmris_pluses(self):
+        fmri.PkgFmri("a+++b+++")
 
-        def testgoodfmris_pluses(self):
-                fmri.PkgFmri("a+++b+++")
+    def testgoodfmris_(self):
+        fmri.PkgFmri("pkg:/abcdef01234.-+_/GHIJK@1.0")
+        fmri.PkgFmri("pkg:/a/b/c/d/e/f/g/H/I/J/0/1/2")
 
-        def testgoodfmris_(self):
-                fmri.PkgFmri("pkg:/abcdef01234.-+_/GHIJK@1.0")
-                fmri.PkgFmri("pkg:/a/b/c/d/e/f/g/H/I/J/0/1/2")
+    def testfmrihash(self):
+        """FMRIs override __hash__.  Test that this is working
+        properly."""
+        a = {}
+        a[self.n10] = 1
+        self.assertTrue(a[self.n11] == 1)
 
-        def testfmrihash(self):
-                """FMRIs override __hash__.  Test that this is working
-                properly."""
-                a = {}
-                a[self.n10] = 1
-                self.assertTrue(a[self.n11] == 1)
+    def testpartial(self):
+        """Verify that supported operations on a partial FMRI
+        function properly."""
 
-        def testpartial(self):
-                """Verify that supported operations on a partial FMRI
-                function properly."""
+        pfmri = "pkg:/BRCMbnx"
 
-                pfmri = "pkg:/BRCMbnx"
+        f = fmri.PkgFmri(pfmri)
+        self.assertEqual(f.get_short_fmri(), pfmri)
+        self.assertEqual(f.get_pkg_stem(), pfmri)
+        self.assertEqual(f.get_fmri(), pfmri)
+        self.assertFalse(f.has_version())
+        self.assertFalse(f.has_publisher())
 
-                f = fmri.PkgFmri(pfmri)
-                self.assertEqual(f.get_short_fmri(), pfmri)
-                self.assertEqual(f.get_pkg_stem(), pfmri)
-                self.assertEqual(f.get_fmri(), pfmri)
-                self.assertFalse(f.has_version())
-                self.assertFalse(f.has_publisher())
+    def testpublisher(self):
+        """Verify that different ways of specifying the publisher
+        information in an FMRI produce the same results."""
 
-        def testpublisher(self):
-                """Verify that different ways of specifying the publisher
-                information in an FMRI produce the same results."""
+        for s in ("pkg:///name", "pkg:/name", "///name", "/name"):
+            f = fmri.PkgFmri(s)
+            self.assertEqual(f.publisher, None)
 
-                for s in ("pkg:///name", "pkg:/name", "///name", "/name"):
-                        f = fmri.PkgFmri(s)
-                        self.assertEqual(f.publisher, None)
+        for s in ("pkg://test/name", "//test/name"):
+            f = fmri.PkgFmri(s)
+            self.assertEqual(f.publisher, "test")
 
-                for s in ("pkg://test/name", "//test/name"):
-                        f = fmri.PkgFmri(s)
-                        self.assertEqual(f.publisher, "test")
+    def testunsupported(self):
+        """Verify that unsupported operations on a partial FMRI raise
+        the correct exceptions."""
 
-        def testunsupported(self):
-                """Verify that unsupported operations on a partial FMRI raise
-                the correct exceptions."""
+        f = fmri.PkgFmri("BRCMbnx")
+        self.assertRaises(fmri.MissingVersionError, f.get_dir_path)
+        self.assertRaises(fmri.MissingVersionError, f.get_link_path)
+        self.assertRaises(fmri.MissingVersionError, f.get_url_path)
 
-                f = fmri.PkgFmri("BRCMbnx")
-                self.assertRaises(fmri.MissingVersionError, f.get_dir_path)
-                self.assertRaises(fmri.MissingVersionError, f.get_link_path)
-                self.assertRaises(fmri.MissingVersionError, f.get_url_path)
+    def testbadversionexception(self):
+        """Verify that a bad version in an FMRI still only raises an
+        FMRI exception."""
 
-        def testbadversionexception(self):
-                """Verify that a bad version in an FMRI still only raises an
-                FMRI exception."""
+        self.assertRaises(
+            fmri.IllegalFmri, fmri.PkgFmri, "BRCMbnx@0.5.aa,5.aa-0.aa"
+        )
 
-                self.assertRaises(fmri.IllegalFmri, fmri.PkgFmri,
-                    "BRCMbnx@0.5.aa,5.aa-0.aa")
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_history.py
+++ b/src/tests/api/t_history.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -43,338 +44,324 @@ import pkg.client.history as history
 import pkg.misc as misc
 import pkg.portable as portable
 
+
 class TestHistory(pkg5unittest.Pkg5TestCase):
-        # This is to prevent setup() being called for each test.
-        persistent_setup = True
+    # This is to prevent setup() being called for each test.
+    persistent_setup = True
 
-        __scratch_dir = None
+    __scratch_dir = None
 
-        __ip_before = """UNEVALUATED:
+    __ip_before = """UNEVALUATED:
             +pkg:/SUNWgcc@3.4.3,5.11-0.95:20080807T162946Z"""
 
-        __ip_after = \
-            """None -> pkg:/SUNWgcc@3.4.3,5.11-0.95:20080807T162946Z
+    __ip_after = """None -> pkg:/SUNWgcc@3.4.3,5.11-0.95:20080807T162946Z
             None -> pkg:/SUNWbinutils@2.15,5.11-0.95:20080807T153728Z
             None"""
 
-        __errors = [
-            "Error 1",
-            "Error 2",
-            "Error 3"
-        ]
+    __errors = ["Error 1", "Error 2", "Error 3"]
 
-        # Used to store the name of a history file across tests.
-        __filename = None
+    # Used to store the name of a history file across tests.
+    __filename = None
 
-        def setUp(self):
-                """Prepare the test for execution.
-                """
-                pkg5unittest.Pkg5TestCase.setUp(self)
+    def setUp(self):
+        """Prepare the test for execution."""
+        pkg5unittest.Pkg5TestCase.setUp(self)
 
-                self.__scratch_dir = tempfile.mkdtemp(dir=self.test_root)
-                # Explicitly convert these to strings as they will be
-                # converted by history to deal with minidom issues.
-                self.__userid = str(portable.get_userid())
-                self.__username = str(portable.get_username())
-                self.__h = history.History(root_dir=self.__scratch_dir)
-                self.__h.client_name = "pkg-test"
+        self.__scratch_dir = tempfile.mkdtemp(dir=self.test_root)
+        # Explicitly convert these to strings as they will be
+        # converted by history to deal with minidom issues.
+        self.__userid = str(portable.get_userid())
+        self.__username = str(portable.get_username())
+        self.__h = history.History(root_dir=self.__scratch_dir)
+        self.__h.client_name = "pkg-test"
 
-        def test_00_valid_operation(self):
-                """Verify that operation information can be stored and
-                retrieved.
-                """
-                h = self.__h
-                self.assertEqual(os.path.join(self.__scratch_dir, "history"),
-                    h.path)
+    def test_00_valid_operation(self):
+        """Verify that operation information can be stored and
+        retrieved.
+        """
+        h = self.__h
+        self.assertEqual(os.path.join(self.__scratch_dir, "history"), h.path)
 
-                h.log_operation_start("install")
-                self.__class__.__filename = os.path.basename(h.pathname)
+        h.log_operation_start("install")
+        self.__class__.__filename = os.path.basename(h.pathname)
 
-                # Verify that a valid start time was set.
-                misc.timestamp_to_time(h.operation_start_time)
+        # Verify that a valid start time was set.
+        misc.timestamp_to_time(h.operation_start_time)
 
-                self.assertEqual("install", h.operation_name)
-                self.assertEqual(self.__username, h.operation_username)
-                self.assertEqual(self.__userid, h.operation_userid)
+        self.assertEqual("install", h.operation_name)
+        self.assertEqual(self.__username, h.operation_username)
+        self.assertEqual(self.__userid, h.operation_userid)
 
-                h.operation_start_state = self.__ip_before
-                self.assertEqual(self.__ip_before, h.operation_start_state)
+        h.operation_start_state = self.__ip_before
+        self.assertEqual(self.__ip_before, h.operation_start_state)
 
-                h.operation_end_state = self.__ip_after
-                self.assertEqual(self.__ip_after, h.operation_end_state)
+        h.operation_end_state = self.__ip_after
+        self.assertEqual(self.__ip_after, h.operation_end_state)
 
-                h.operation_errors.extend(self.__errors)
-                self.assertEqual(self.__errors, h.operation_errors)
+        h.operation_errors.extend(self.__errors)
+        self.assertEqual(self.__errors, h.operation_errors)
 
-                h.log_operation_end()
+        h.log_operation_end()
 
-        def test_01_client_info(self):
-                """Verify that the client information can be retrieved.
-                """
-                h = self.__h
-                self.assertEqual("pkg-test", h.client_name)
-                self.assertEqual(pkg.VERSION, h.client_version)
-                # The contents can't really be verified (due to possible
-                # platform differences for the first element), but there
-                # should be something returned.
-                self.assertTrue(h.client_args)
+    def test_01_client_info(self):
+        """Verify that the client information can be retrieved."""
+        h = self.__h
+        self.assertEqual("pkg-test", h.client_name)
+        self.assertEqual(pkg.VERSION, h.client_version)
+        # The contents can't really be verified (due to possible
+        # platform differences for the first element), but there
+        # should be something returned.
+        self.assertTrue(h.client_args)
 
-        def test_02_clear(self):
-                """Verify that clear actually resets all transient values.
-                """
-                h = self.__h
-                h.clear()
-                self.assertEqual(None, h.client_name)
-                self.assertEqual(None, h.client_version)
-                self.assertFalse(h.client_args)
-                self.assertEqual(None, h.operation_name)
-                self.assertEqual(None, h.operation_username)
-                self.assertEqual(None, h.operation_userid)
-                self.assertEqual(None, h.operation_result)
-                self.assertEqual(None, h.operation_start_time)
-                self.assertEqual(None, h.operation_end_time)
-                self.assertEqual(None, h.operation_start_state)
-                self.assertEqual(None, h.operation_end_state)
-                self.assertEqual(None, h.operation_errors)
-                self.assertEqual(None, h.pathname)
+    def test_02_clear(self):
+        """Verify that clear actually resets all transient values."""
+        h = self.__h
+        h.clear()
+        self.assertEqual(None, h.client_name)
+        self.assertEqual(None, h.client_version)
+        self.assertFalse(h.client_args)
+        self.assertEqual(None, h.operation_name)
+        self.assertEqual(None, h.operation_username)
+        self.assertEqual(None, h.operation_userid)
+        self.assertEqual(None, h.operation_result)
+        self.assertEqual(None, h.operation_start_time)
+        self.assertEqual(None, h.operation_end_time)
+        self.assertEqual(None, h.operation_start_state)
+        self.assertEqual(None, h.operation_end_state)
+        self.assertEqual(None, h.operation_errors)
+        self.assertEqual(None, h.pathname)
 
-        def test_03_client_load(self):
-                """Verify that the saved history can be retrieved properly.
-                """
-                h = history.History(root_dir=self.__scratch_dir,
-                    filename=self.__filename)
-                # Verify that a valid start time and end time was set.
-                misc.timestamp_to_time(h.operation_start_time)
-                misc.timestamp_to_time(h.operation_end_time)
+    def test_03_client_load(self):
+        """Verify that the saved history can be retrieved properly."""
+        h = history.History(
+            root_dir=self.__scratch_dir, filename=self.__filename
+        )
+        # Verify that a valid start time and end time was set.
+        misc.timestamp_to_time(h.operation_start_time)
+        misc.timestamp_to_time(h.operation_end_time)
 
-                self.assertEqual("install", h.operation_name)
-                self.assertEqual(self.__username, h.operation_username)
-                self.assertEqual(self.__userid, h.operation_userid)
-                self.assertEqual(self.__ip_before, h.operation_start_state)
-                self.assertEqual(self.__ip_after, h.operation_end_state)
-                self.assertEqual(self.__errors, h.operation_errors)
-                self.assertEqual(history.RESULT_SUCCEEDED, h.operation_result)
+        self.assertEqual("install", h.operation_name)
+        self.assertEqual(self.__username, h.operation_username)
+        self.assertEqual(self.__userid, h.operation_userid)
+        self.assertEqual(self.__ip_before, h.operation_start_state)
+        self.assertEqual(self.__ip_after, h.operation_end_state)
+        self.assertEqual(self.__errors, h.operation_errors)
+        self.assertEqual(history.RESULT_SUCCEEDED, h.operation_result)
 
-        def test_04_stacked_operations(self):
-                """Verify that multiple operations can be stacked properly (in
-                other words, that storage and retrieval works as expected).
-                """
+    def test_04_stacked_operations(self):
+        """Verify that multiple operations can be stacked properly (in
+        other words, that storage and retrieval works as expected).
+        """
 
-                op_stack = {
-                    "operation-1": {
-                        "start_state": "op-1-start",
-                        "end_state": "op-1-end",
-                        "result": history.RESULT_SUCCEEDED,
-                    },
-                    "operation-2": {
-                        "start_state": "op-2-start",
-                        "end_state": "op-2-end",
-                        "result": history.RESULT_FAILED_UNKNOWN,
-                    },
-                    "operation-3": {
-                        "start_state": "op-3-start",
-                        "end_state": "op-3-end",
-                        "result": history.RESULT_CANCELED,
-                    },
-                }
-                h = self.__h
-                h.client_name = "pkg-test"
+        op_stack = {
+            "operation-1": {
+                "start_state": "op-1-start",
+                "end_state": "op-1-end",
+                "result": history.RESULT_SUCCEEDED,
+            },
+            "operation-2": {
+                "start_state": "op-2-start",
+                "end_state": "op-2-end",
+                "result": history.RESULT_FAILED_UNKNOWN,
+            },
+            "operation-3": {
+                "start_state": "op-3-start",
+                "end_state": "op-3-end",
+                "result": history.RESULT_CANCELED,
+            },
+        }
+        h = self.__h
+        h.client_name = "pkg-test"
 
-                for op_name in sorted(op_stack.keys()):
-                        h.log_operation_start(op_name)
+        for op_name in sorted(op_stack.keys()):
+            h.log_operation_start(op_name)
 
-                for op_name in sorted(op_stack.keys(), reverse=True):
-                        op_data = op_stack[op_name]
-                        h.operation_start_state = op_data["start_state"]
-                        h.operation_end_state = op_data["end_state"]
-                        h.log_operation_end(result=op_data["result"])
+        for op_name in sorted(op_stack.keys(), reverse=True):
+            op_data = op_stack[op_name]
+            h.operation_start_state = op_data["start_state"]
+            h.operation_end_state = op_data["end_state"]
+            h.log_operation_end(result=op_data["result"])
 
-                # Now load all operation data that's been saved during testing
-                # for comparison.
-                loaded_ops = {}
-                for entry in sorted(os.listdir(h.path)):
-                        # Load the history entry.
-                        he = history.History(root_dir=h.root_dir,
-                            filename=entry)
+        # Now load all operation data that's been saved during testing
+        # for comparison.
+        loaded_ops = {}
+        for entry in sorted(os.listdir(h.path)):
+            # Load the history entry.
+            he = history.History(root_dir=h.root_dir, filename=entry)
 
-                        loaded_ops[he.operation_name] = {
-                                "start_state": he.operation_start_state,
-                                "end_state": he.operation_end_state,
-                                "result": he.operation_result
-                        }
+            loaded_ops[he.operation_name] = {
+                "start_state": he.operation_start_state,
+                "end_state": he.operation_end_state,
+                "result": he.operation_result,
+            }
 
-                # Now verify that each operation was saved in the stack and
-                # that the correct data was written for each one.
-                for op_name in op_stack.keys():
-                        op_data = op_stack[op_name]
-                        loaded_data = loaded_ops[op_name]
-                        self.assertEqual(op_data, loaded_data)
+        # Now verify that each operation was saved in the stack and
+        # that the correct data was written for each one.
+        for op_name in op_stack.keys():
+            op_data = op_stack[op_name]
+            loaded_data = loaded_ops[op_name]
+            self.assertEqual(op_data, loaded_data)
 
-        def test_05_discarded_operations(self):
-                """Verify that discarded operations are not saved.
-                """
+    def test_05_discarded_operations(self):
+        """Verify that discarded operations are not saved."""
 
-                h = self.__h
-                h.client_name = "pkg-test"
+        h = self.__h
+        h.client_name = "pkg-test"
 
-                for op_name in sorted(history.DISCARDED_OPERATIONS):
-                        h.log_operation_start(op_name)
-                        h.log_operation_end(history.RESULT_NOTHING_TO_DO)
+        for op_name in sorted(history.DISCARDED_OPERATIONS):
+            h.log_operation_start(op_name)
+            h.log_operation_end(history.RESULT_NOTHING_TO_DO)
 
-                # Now load all operation data that's been saved during testing
-                # for comparison.
-                loaded_ops = []
-                for entry in sorted(os.listdir(h.path)):
-                        # Load the history entry.
-                        he = history.History(root_dir=h.root_dir,
-                            filename=entry)
-                        loaded_ops.append(he.operation_name)
+        # Now load all operation data that's been saved during testing
+        # for comparison.
+        loaded_ops = []
+        for entry in sorted(os.listdir(h.path)):
+            # Load the history entry.
+            he = history.History(root_dir=h.root_dir, filename=entry)
+            loaded_ops.append(he.operation_name)
 
-                # Now verify that none of the saved operations are one that
-                # should have been discarded.
-                for op_name in sorted(history.DISCARDED_OPERATIONS):
-                        self.assertTrue(op_name not in loaded_ops)
+        # Now verify that none of the saved operations are one that
+        # should have been discarded.
+        for op_name in sorted(history.DISCARDED_OPERATIONS):
+            self.assertTrue(op_name not in loaded_ops)
 
-        def test_06_purge_history(self):
-                """Verify that purge() removes all history and creates a new
-                history entry.
-                """
-                h = self.__h
-                h.clear()
-                h.client_name = "pkg-test"
-                h.purge()
+    def test_06_purge_history(self):
+        """Verify that purge() removes all history and creates a new
+        history entry.
+        """
+        h = self.__h
+        h.clear()
+        h.client_name = "pkg-test"
+        h.purge()
 
-                expected_ops = [["purge-history", history.RESULT_SUCCEEDED]]
+        expected_ops = [["purge-history", history.RESULT_SUCCEEDED]]
 
-                # Now load all operation data to verify that only an entry
-                # for purge-history remains and that it was successful.
-                loaded_ops = []
-                for entry in sorted(os.listdir(h.path)):
-                        # Load the history entry.
-                        he = history.History(root_dir=h.root_dir,
-                            filename=entry)
-                        loaded_ops.append([he.operation_name, he.operation_result])
+        # Now load all operation data to verify that only an entry
+        # for purge-history remains and that it was successful.
+        loaded_ops = []
+        for entry in sorted(os.listdir(h.path)):
+            # Load the history entry.
+            he = history.History(root_dir=h.root_dir, filename=entry)
+            loaded_ops.append([he.operation_name, he.operation_result])
 
-                self.assertTrue(loaded_ops == expected_ops)
+        self.assertTrue(loaded_ops == expected_ops)
 
-        def test_07_aborted_operations(self):
-                """Verify that aborted operations are saved properly."""
+    def test_07_aborted_operations(self):
+        """Verify that aborted operations are saved properly."""
 
-                h = self.__h
-                h.client_name = "pkg-test"
+        h = self.__h
+        h.client_name = "pkg-test"
 
-                for i in range(1, 4):
-                        h.log_operation_start("operation-{0:d}".format(i))
+        for i in range(1, 4):
+            h.log_operation_start("operation-{0:d}".format(i))
 
-                h.abort(history.RESULT_FAILED_BAD_REQUEST)
+        h.abort(history.RESULT_FAILED_BAD_REQUEST)
 
-                # Now load all operation data that's been saved during testing
-                # for comparison and verify the expected result was set for
-                # each.
-                loaded_ops = []
-                for entry in sorted(os.listdir(h.path)):
-                        # Load the history entry.
-                        he = history.History(root_dir=h.root_dir,
-                            filename=entry)
+        # Now load all operation data that's been saved during testing
+        # for comparison and verify the expected result was set for
+        # each.
+        loaded_ops = []
+        for entry in sorted(os.listdir(h.path)):
+            # Load the history entry.
+            he = history.History(root_dir=h.root_dir, filename=entry)
 
-                        if he.operation_name != "purge-history":
-                                loaded_ops.append([he.operation_name,
-                                    he.operation_result])
+            if he.operation_name != "purge-history":
+                loaded_ops.append([he.operation_name, he.operation_result])
 
-                # There should be three operations: operation-1, operation-2,
-                # and operation-3.
-                self.assertTrue(len(loaded_ops) == 3)
+        # There should be three operations: operation-1, operation-2,
+        # and operation-3.
+        self.assertTrue(len(loaded_ops) == 3)
 
-                for op in loaded_ops:
-                        op_name, op_result = op
-                        self.assertTrue(re.match("operation-[123]", op_name))
-                        self.assertEqual(op_result,
-                            history.RESULT_FAILED_BAD_REQUEST)
+        for op in loaded_ops:
+            op_name, op_result = op
+            self.assertTrue(re.match("operation-[123]", op_name))
+            self.assertEqual(op_result, history.RESULT_FAILED_BAD_REQUEST)
 
-        def test_08_bug_3540(self):
-                """Ensure that corrupt History files raise a
-                HistoryLoadException with parse_failure set to True.
-                """
+    def test_08_bug_3540(self):
+        """Ensure that corrupt History files raise a
+        HistoryLoadException with parse_failure set to True.
+        """
 
-                # Overwrite first entry with bad data.
-                h = self.__h
-                entry = sorted(os.listdir(h.path))[0]
-                f = open(os.path.join(h.path, entry), "w")
-                f.write("<Invalid>")
-                f.close()
+        # Overwrite first entry with bad data.
+        h = self.__h
+        entry = sorted(os.listdir(h.path))[0]
+        f = open(os.path.join(h.path, entry), "w")
+        f.write("<Invalid>")
+        f.close()
 
-                try:
-                        he = history.History(root_dir=h.root_dir,
-                            filename=entry)
-                except apx.HistoryLoadException as e:
-                        if not e.parse_failure:
-                                raise
-                        pass
+        try:
+            he = history.History(root_dir=h.root_dir, filename=entry)
+        except apx.HistoryLoadException as e:
+            if not e.parse_failure:
+                raise
+            pass
 
-        def test_09_bug_5153(self):
-                """Verify that purge will not raise an exception if the History
-                directory doesn't already exist as it will be re-created anyway.
-                """
-                h = self.__h
-                shutil.rmtree(h.path)
-                h.purge()
+    def test_09_bug_5153(self):
+        """Verify that purge will not raise an exception if the History
+        directory doesn't already exist as it will be re-created anyway.
+        """
+        h = self.__h
+        shutil.rmtree(h.path)
+        h.purge()
 
-        def test_10_snapshots(self):
-                """Verify that snapshot methods work as expected."""
+    def test_10_snapshots(self):
+        """Verify that snapshot methods work as expected."""
 
-                h = self.__h
-                h.client_name = "Schrodinger"
-                h.log_operation_start("start-bobcat-experiment")
-                h.operation_start_state = "bobcat-alive-plus-poison-in-box"
+        h = self.__h
+        h.client_name = "Schrodinger"
+        h.log_operation_start("start-bobcat-experiment")
+        h.operation_start_state = "bobcat-alive-plus-poison-in-box"
 
-                # Brought to you by Mr. Fusion.
-                h.create_snapshot()
+        # Brought to you by Mr. Fusion.
+        h.create_snapshot()
 
-                # Is it alive, dead, or both after this error?  Only quantum
-                # mechanics knows the answer for certain, but let us assume the
-                # outcome isn't good.
-                h.log_operation_error("radiation-detected")
-                h.operation_end_state = "bobcat-dead"
+        # Is it alive, dead, or both after this error?  Only quantum
+        # mechanics knows the answer for certain, but let us assume the
+        # outcome isn't good.
+        h.log_operation_error("radiation-detected")
+        h.operation_end_state = "bobcat-dead"
 
-                self.assertEqual(h.operation_start_state,
-                    "bobcat-alive-plus-poison-in-box")
+        self.assertEqual(
+            h.operation_start_state, "bobcat-alive-plus-poison-in-box"
+        )
 
-                # Since log_operation_error will automatically combine the error
-                # with a stacktrace, the last line of the logged error has to be
-                # checked for the error text instead.
-                error = ("".join(h.operation_errors[0])).splitlines()
-                self.assertEqual(error[-1], "radiation-detected")
-                self.assertEqual(h.operation_end_state, "bobcat-dead")
+        # Since log_operation_error will automatically combine the error
+        # with a stacktrace, the last line of the logged error has to be
+        # checked for the error text instead.
+        error = ("".join(h.operation_errors[0])).splitlines()
+        self.assertEqual(error[-1], "radiation-detected")
+        self.assertEqual(h.operation_end_state, "bobcat-dead")
 
-                # No animals were permanently harmed during this experiment.
-                h.restore_snapshot()
+        # No animals were permanently harmed during this experiment.
+        h.restore_snapshot()
 
-                self.assertEqual(h.operation_start_state,
-                    "bobcat-alive-plus-poison-in-box")
+        self.assertEqual(
+            h.operation_start_state, "bobcat-alive-plus-poison-in-box"
+        )
 
-                # Mysteriously, no radiation was detected...
-                self.assertEqual(h.operation_errors, [])
+        # Mysteriously, no radiation was detected...
+        self.assertEqual(h.operation_errors, [])
 
-                # The experiment isn't over yet.
-                self.assertEqual(h.operation_end_state, None)
+        # The experiment isn't over yet.
+        self.assertEqual(h.operation_end_state, None)
 
-                # Success!
-                h.operation_end_state = "bobcat-alive"
+        # Success!
+        h.operation_end_state = "bobcat-alive"
 
-                # Discard our last snapshot.
-                h.discard_snapshot()
+        # Discard our last snapshot.
+        h.discard_snapshot()
 
-                # Attempt to restore, which should have no effect.
-                h.restore_snapshot()
-                self.assertEqual(h.operation_end_state, "bobcat-alive")
+        # Attempt to restore, which should have no effect.
+        h.restore_snapshot()
+        self.assertEqual(h.operation_end_state, "bobcat-alive")
 
-                h.log_operation_end()
+        h.log_operation_end()
 
-        def test_11_bug_8072(self):
-                """Verify that a history file with unexpected start state, end
-                state, and error data won't cause an exception."""
+    def test_11_bug_8072(self):
+        """Verify that a history file with unexpected start state, end
+        state, and error data won't cause an exception."""
 
-                bad_hist = b"""<?xml version="1.0" encoding="ascii"?>
+        bad_hist = b"""<?xml version="1.0" encoding="ascii"?>
 <history>
   <client name="pkg" version="e827313523d8+">
     <args>
@@ -396,68 +383,67 @@ class TestHistory(pkg5unittest.Pkg5TestCase):
   </operation>
 </history>"""
 
-                (fd1, path1) = tempfile.mkstemp(dir=self.__scratch_dir)
-                os.write(fd1, bad_hist)
+        (fd1, path1) = tempfile.mkstemp(dir=self.__scratch_dir)
+        os.write(fd1, bad_hist)
 
-                # Load the history entry.
-                he = history.History(root_dir=self.__scratch_dir,
-                    filename=path1)
+        # Load the history entry.
+        he = history.History(root_dir=self.__scratch_dir, filename=path1)
 
-                self.assertEqual(he.operation_start_state, "None")
-                self.assertEqual(he.operation_end_state, "None")
-                self.assertEqual(he.operation_errors, [])
+        self.assertEqual(he.operation_start_state, "None")
+        self.assertEqual(he.operation_end_state, "None")
+        self.assertEqual(he.operation_errors, [])
 
-        def test_12_bug_9287(self):
-                """Verify that the current exception stack won't be logged
-                unless it is for the same exception the operation ended
-                with."""
+    def test_12_bug_9287(self):
+        """Verify that the current exception stack won't be logged
+        unless it is for the same exception the operation ended
+        with."""
 
-                h = self.__h
+        h = self.__h
 
-                # Test that an exception that occurs before an operation
-                # starts won't be recorded if it is not the same exception
-                # the operation ended with.
+        # Test that an exception that occurs before an operation
+        # starts won't be recorded if it is not the same exception
+        # the operation ended with.
 
-                # Clear history completely.
-                h.purge()
-                shutil.rmtree(h.path)
+        # Clear history completely.
+        h.purge()
+        shutil.rmtree(h.path)
 
-                # Populate the exception stack.
-                try:
-                        d = {}
-                        d['nosuchkey']
-                except KeyError:
-                        pass
+        # Populate the exception stack.
+        try:
+            d = {}
+            d["nosuchkey"]
+        except KeyError:
+            pass
 
-                h.log_operation_start("test-exceptions")
-                e = AssertionError()
-                h.log_operation_end(error=e)
+        h.log_operation_start("test-exceptions")
+        e = AssertionError()
+        h.log_operation_end(error=e)
 
-                for entry in sorted(os.listdir(h.path)):
-                        # Load the history entry.
-                        he = history.History(root_dir=h.root_dir,
-                            filename=entry)
+        for entry in sorted(os.listdir(h.path)):
+            # Load the history entry.
+            he = history.History(root_dir=h.root_dir, filename=entry)
 
-                        # Verify that the right exception was logged.
-                        for e in he.operation_errors:
-                                self.assertNotEqual(e.find("AssertionError"),
-                                    -1)
+            # Verify that the right exception was logged.
+            for e in he.operation_errors:
+                self.assertNotEqual(e.find("AssertionError"), -1)
 
-        def test_13_bug_11735(self):
-                """Ensure that history files are created with appropriate
-                permissions"""
+    def test_13_bug_11735(self):
+        """Ensure that history files are created with appropriate
+        permissions"""
 
-                h = self.__h
-                self.assertEqual(stat.S_IMODE(os.stat(h.path).st_mode),
-                                 misc.PKG_DIR_MODE)
+        h = self.__h
+        self.assertEqual(
+            stat.S_IMODE(os.stat(h.path).st_mode), misc.PKG_DIR_MODE
+        )
 
-                entry = os.path.join(h.path, os.listdir(h.path)[0])
-                self.assertEqual(stat.S_IMODE(os.stat(entry).st_mode),
-                                 misc.PKG_FILE_MODE)
+        entry = os.path.join(h.path, os.listdir(h.path)[0])
+        self.assertEqual(
+            stat.S_IMODE(os.stat(entry).st_mode), misc.PKG_FILE_MODE
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_imageconfig.py
+++ b/src/tests/api/t_imageconfig.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -39,8 +40,8 @@ import pkg.portable as portable
 
 
 class TestImageConfig(pkg5unittest.Pkg5TestCase):
-
-        misc_files = { imageconfig.CFG_FILE : """\
+    misc_files = {
+        imageconfig.CFG_FILE: """\
 [policy]
 Display-Copyrights: False
 
@@ -63,55 +64,64 @@ repo.registered: True
 repo.registration_uri: http://zruty.sfbay:10001/reg.html
 repo.related_uris:
 sort_policy: priority
-""" }
+"""
+    }
 
-        def setUp(self):
-                pkg5unittest.Pkg5TestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.ic = imageconfig.ImageConfig(os.path.join(self.test_root,
-                    "cfg_cache"), self.test_root)
+    def setUp(self):
+        pkg5unittest.Pkg5TestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.ic = imageconfig.ImageConfig(
+            os.path.join(self.test_root, "cfg_cache"), self.test_root
+        )
 
-        def test_0_read(self):
-                """Verify that read works and that values are read properly."""
+    def test_0_read(self):
+        """Verify that read works and that values are read properly."""
 
-                pub = self.ic.publishers["sfbay.sun.com"]
-                self.assertEqual(pub.alias, "zruty")
-                repo = pub.repository
-                origin = repo.origins[0]
-                self.assertEqual(origin.uri, "http://zruty.sfbay:10001/")
-                self.assertEqual(origin.ssl_key, None)
-                self.assertEqual(origin.ssl_cert, None)
-                self.assertEqual(repo.collection_type, "supplemental")
-                self.assertEqual(repo.description,
-                    "Lots of development packages here.")
-                self.assertEqual([u.uri for u in repo.legal_uris],
-                    ["http://zruty.sfbay:10001/legal.html",
-                    "http://zruty.sfbay:10001/tos.html"])
-                self.assertEqual(repo.name, "zruty development repository")
-                self.assertEqual(repo.refresh_seconds, 86400)
-                self.assertEqual(repo.registered, True)
-                self.assertEqual(repo.registration_uri, "http://zruty.sfbay:10001/reg.html")
-                self.assertEqual(repo.related_uris, [])
-                self.assertEqual(repo.sort_policy, "priority")
-                # uuid should have been set even though it wasn't in the file
-                self.assertNotEqual(pub.client_uuid, None)
+        pub = self.ic.publishers["sfbay.sun.com"]
+        self.assertEqual(pub.alias, "zruty")
+        repo = pub.repository
+        origin = repo.origins[0]
+        self.assertEqual(origin.uri, "http://zruty.sfbay:10001/")
+        self.assertEqual(origin.ssl_key, None)
+        self.assertEqual(origin.ssl_cert, None)
+        self.assertEqual(repo.collection_type, "supplemental")
+        self.assertEqual(repo.description, "Lots of development packages here.")
+        self.assertEqual(
+            [u.uri for u in repo.legal_uris],
+            [
+                "http://zruty.sfbay:10001/legal.html",
+                "http://zruty.sfbay:10001/tos.html",
+            ],
+        )
+        self.assertEqual(repo.name, "zruty development repository")
+        self.assertEqual(repo.refresh_seconds, 86400)
+        self.assertEqual(repo.registered, True)
+        self.assertEqual(
+            repo.registration_uri, "http://zruty.sfbay:10001/reg.html"
+        )
+        self.assertEqual(repo.related_uris, [])
+        self.assertEqual(repo.sort_policy, "priority")
+        # uuid should have been set even though it wasn't in the file
+        self.assertNotEqual(pub.client_uuid, None)
 
-        def test_1_reread(self):
-                """Verify that the uuid determined during the first read is the
-                same as the uuid in the second read."""
-                self.ic = imageconfig.ImageConfig(os.path.join(self.test_root,
-                    "cfg_cache"), self.test_root)
-                pub = self.ic.publishers["sfbay.sun.com"]
-                uuid = pub.client_uuid
+    def test_1_reread(self):
+        """Verify that the uuid determined during the first read is the
+        same as the uuid in the second read."""
+        self.ic = imageconfig.ImageConfig(
+            os.path.join(self.test_root, "cfg_cache"), self.test_root
+        )
+        pub = self.ic.publishers["sfbay.sun.com"]
+        uuid = pub.client_uuid
 
-                ic2 = imageconfig.ImageConfig(os.path.join(self.test_root,
-                    "cfg_cache"), self.test_root)
-                pub2 = ic2.publishers["sfbay.sun.com"]
-                self.assertEqual(pub2.client_uuid, uuid)
+        ic2 = imageconfig.ImageConfig(
+            os.path.join(self.test_root, "cfg_cache"), self.test_root
+        )
+        pub2 = ic2.publishers["sfbay.sun.com"]
+        self.assertEqual(pub2.client_uuid, uuid)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_indexer.py
+++ b/src/tests/api/t_indexer.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -37,79 +38,93 @@ import tempfile
 import stat
 import shutil
 
+
 class TestIndexer(pkg5unittest.Pkg5TestCase):
+    def __prep_indexer(self, limit):
+        ind = indexer.Indexer(
+            self.test_root, None, None, sort_file_max_size=limit
+        )
 
-        def __prep_indexer(self, limit):
-                ind = indexer.Indexer(self.test_root, None, None,
-                        sort_file_max_size=limit)
+        os.mkdir(ind._tmp_dir)
 
-                os.mkdir(ind._tmp_dir)
+        ind._sort_fh = open(
+            os.path.join(
+                ind._tmp_dir, indexer.SORT_FILE_PREFIX + str(ind._sort_file_num)
+            ),
+            "w",
+        )
 
-                ind._sort_fh = open(os.path.join(ind._tmp_dir,
-                        indexer.SORT_FILE_PREFIX +
-                        str(ind._sort_file_num)), "w")
+        ind._sort_file_num += 1
 
-                ind._sort_file_num += 1
+        d1 = {
+            ("test1/optional", "set", "pkg.fmri", "test1/optional"): [0],
+            ("optional", "set", "pkg.fmri", "test1/optional"): [0],
+            ("5.11", "set", "pkg.fmri", "test1/optional"): [0],
+            ("20091105T190147Z", "set", "pkg.fmri", "test1/optional"): [0],
+            ("1.0", "set", "pkg.fmri", "test1/optional"): [0],
+        }
 
-                d1 = {
-                    ('test1/optional', 'set', 'pkg.fmri', 'test1/optional'): [0], 
-                    ('optional', 'set', 'pkg.fmri', 'test1/optional'): [0], 
-                    ('5.11', 'set', 'pkg.fmri', 'test1/optional'): [0], 
-                    ('20091105T190147Z', 'set', 'pkg.fmri', 'test1/optional'): [0], 
-                    ('1.0', 'set', 'pkg.fmri', 'test1/optional'): [0]
-                }
+        d2 = {
+            ("20091105T190153Z", "set", "pkg.fmri", "test1/core"): [0],
+            ("test1/core", "set", "pkg.fmri", "test1/core"): [0],
+            ("1.0", "set", "pkg.fmri", "test1/core"): [0],
+            ("corge", "set", "pkg.fmri", "test1/core"): [0],
+            ("5.11", "set", "pkg.fmri", "test1/core"): [0],
+        }
 
-                d2 = {
-                    ('20091105T190153Z', 'set', 'pkg.fmri', 'test1/core'): [0],
-                    ('test1/core', 'set', 'pkg.fmri', 'test1/core'): [0],
-                    ('1.0', 'set', 'pkg.fmri', 'test1/core'): [0],
-                    ('corge', 'set', 'pkg.fmri', 'test1/core'): [0],
-                    ('5.11', 'set', 'pkg.fmri', 'test1/core'): [0]
-                }
+        fmri1 = "pkg://test1/optional@1.0,5.11-0:20091105T190147Z"
+        fmri2 = "pkg://test1/core@1.0,5.11-0:20091105T190153Z"
 
-                fmri1 = "pkg://test1/optional@1.0,5.11-0:20091105T190147Z"
-                fmri2 = "pkg://test1/core@1.0,5.11-0:20091105T190153Z"
+        ind._add_terms(fmri1, d1)
+        ind._add_terms(fmri2, d2)
 
-                ind._add_terms(fmri1, d1)
-                ind._add_terms(fmri2, d2)
+        return ind
 
-                return ind
+    def test_indexworkingsize(self):
+        """Verify indexer sort_file_max_size works as expected."""
 
-        def test_indexworkingsize(self):
-                """Verify indexer sort_file_max_size works as expected."""
+        # Verify that a max size of 0 raises an exception.
+        self.assertRaises(
+            se.IndexingException,
+            indexer.Indexer,
+            self.test_root,
+            None,
+            None,
+            sort_file_max_size=0,
+        )
 
-                # Verify that a max size of 0 raises an exception.
-                self.assertRaises(se.IndexingException, indexer.Indexer,
-                    self.test_root, None, None, sort_file_max_size=0)
+        # Verify a number larger than total number of records expected
+        # works...
+        ind = self.__prep_indexer(200)
 
-                # Verify a number larger than total number of records expected
-                # works...
-                ind = self.__prep_indexer(200)
+        # Each file should be under the limit.
+        for file in os.listdir(ind._tmp_dir):
+            fs = os.stat(os.path.join(ind._tmp_dir, file))
+            self.assertTrue(fs.st_size <= 200)
+        shutil.rmtree(ind._tmp_dir)
 
-                # Each file should be under the limit.
-                for file in os.listdir(ind._tmp_dir):
-                        fs = os.stat(os.path.join(ind._tmp_dir, file))
-                        self.assertTrue(fs.st_size <= 200)
-                shutil.rmtree(ind._tmp_dir)
+        # ...and that a number that matches the smallest atomic unit
+        # that the indexer can write works.
+        ind = self.__prep_indexer(1)
 
-                # ...and that a number that matches the smallest atomic unit
-                # that the indexer can write works.
-                ind = self.__prep_indexer(1)
+        # The first file is already opened by us, so it will fail the
+        # <= 0 test by indexer, and indexer will create a new one.
+        # Hence, sort.0 will be of size 0
+        self.assertTrue(
+            os.stat(os.path.join(ind._tmp_dir, "sort.0")).st_size == 0
+        )
 
-                # The first file is already opened by us, so it will fail the
-                # <= 0 test by indexer, and indexer will create a new one.
-                # Hence, sort.0 will be of size 0
-                self.assertTrue(os.stat(os.path.join(ind._tmp_dir , "sort.0")).st_size == 0)
+        # Since sort_file_max_size is a soft limit, the indexer can't
+        # actually limit each file to 1 byte, but there should be at
+        # most one line in each file.
+        for file in os.listdir(ind._tmp_dir):
+            self.assertTrue(
+                len(open(os.path.join(ind._tmp_dir, file)).readlines()) <= 1
+            )
 
-                # Since sort_file_max_size is a soft limit, the indexer can't
-                # actually limit each file to 1 byte, but there should be at
-                # most one line in each file.
-                for file in os.listdir(ind._tmp_dir):
-                        self.assertTrue(len(open(os.path.join(ind._tmp_dir,
-                            file)).readlines()) <= 1)
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_linked_image.py
+++ b/src/tests/api/t_linked_image.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -49,276 +50,314 @@ from pkg.client.pkgdefs import *
 
 p_update_index = 0
 
+
 def pkg_err_verify(string, fmri):
-        # Ignore package version as how it's displayed can change.
-        substring = fmri.split("@", 1)[0]
-        if string.find(substring) == -1:
-                raise RuntimeError("""
+    # Ignore package version as how it's displayed can change.
+    substring = fmri.split("@", 1)[0]
+    if string.find(substring) == -1:
+        raise RuntimeError(
+            """
 Expected "{0}" to be contained in:
 {1}
-""".format(substring, string))
+""".format(
+                substring, string
+            )
+        )
+
 
 def apx_verify(e, e_type, e_member=None):
-
-        if e == None:
-                raise RuntimeError("""
+    if e == None:
+        raise RuntimeError(
+            """
 Expected {0} exception.
 Didn't get any exception.
-""".format(str(e_type)))
+""".format(
+                str(e_type)
+            )
+        )
 
-        if type(e) != e_type:
-                raise RuntimeError("""
+    if type(e) != e_type:
+        raise RuntimeError(
+            """
 Expected {0} exception.
 Got a {1} exception:
 
 {2}
-""".format(str(e_type), str(type(e)), traceback.format_exc()))
+""".format(
+                str(e_type), str(type(e)), traceback.format_exc()
+            )
+        )
 
-        if e_member == None:
-                return
+    if e_member == None:
+        return
 
-        if getattr(e, e_member, None) is None:
-                raise RuntimeError("""
+    if getattr(e, e_member, None) is None:
+        raise RuntimeError(
+            """
 Expected {0} exception of type "{1}".
 Got a {2} exception with a differnt type:
 
 {3}
-""".format(str(e_type), e_member, str(type(e)), traceback.format_exc()))
+""".format(
+                str(e_type), e_member, str(type(e)), traceback.format_exc()
+            )
+        )
+
 
 def assertRaises(validate_cb, func, *args, **kwargs):
-        (validate_func, validate_args) = validate_cb
+    (validate_func, validate_args) = validate_cb
 
-        e = None
-        try:
-                func(*args, **kwargs)
-        except:
-                e_type, e, e_tb = sys.exc_info()
-                pass
-        validate_func(e, **validate_args)
-        return e
+    e = None
+    try:
+        func(*args, **kwargs)
+    except:
+        e_type, e, e_tb = sys.exc_info()
+        pass
+    validate_func(e, **validate_args)
+    return e
 
 
 class TestLinkedImageName(pkg5unittest.Pkg5TestCase):
+    def test_linked_name(self):
+        # setup bad linked image names
+        bad_name = []
+        bad_name.append("")
+        bad_name.append("too:many:colons")
+        bad_name.append("notenoughcolons")
+        bad_name.append(":img2")  # no type
+        bad_name.append("system:")  # no name
+        bad_name.append("badtype:img4")
 
-        def test_linked_name(self):
+        good_name = ["system:img1", "zone:img1"]
 
-                # setup bad linked image names
-                bad_name = []
-                bad_name.append("")
-                bad_name.append("too:many:colons")
-                bad_name.append("notenoughcolons")
-                bad_name.append(":img2")   # no type
-                bad_name.append("system:")   # no name
-                bad_name.append("badtype:img4")
-
-                good_name = ["system:img1", "zone:img1"]
-
-                for name in bad_name:
-                        assertRaises(
-                            (apx_verify, {
-                                "e_type": apx.LinkedImageException,
-                                "e_member": "lin_malformed"}),
-                                li.LinkedImageName, name)
-
-                for name in good_name:
-                       li.LinkedImageName(name)
-
-        def test_linked_zone_binaries(self):
-                DebugValues["bin_zonename"] = "/bin/false"
-                assertRaises(
-                    (apx_verify, {
+        for name in bad_name:
+            assertRaises(
+                (
+                    apx_verify,
+                    {
                         "e_type": apx.LinkedImageException,
-                        "e_member": "cmd_failed"}),
-                        li.zone._zonename)
+                        "e_member": "lin_malformed",
+                    },
+                ),
+                li.LinkedImageName,
+                name,
+            )
 
-                DebugValues["bin_zoneadm"] = "/bin/false"
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.LinkedImageException,
-                        "e_member": "cmd_failed"}),
-                        li.zone._zonename)
+        for name in good_name:
+            li.LinkedImageName(name)
 
-                DebugValues["bin_zonename"] = "/bin/true"
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.LinkedImageException,
-                        "e_member": "cmd_output_invalid"}),
-                        li.zone._zonename)
+    def test_linked_zone_binaries(self):
+        DebugValues["bin_zonename"] = "/bin/false"
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.LinkedImageException, "e_member": "cmd_failed"},
+            ),
+            li.zone._zonename,
+        )
+
+        DebugValues["bin_zoneadm"] = "/bin/false"
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.LinkedImageException, "e_member": "cmd_failed"},
+            ),
+            li.zone._zonename,
+        )
+
+        DebugValues["bin_zonename"] = "/bin/true"
+        assertRaises(
+            (
+                apx_verify,
+                {
+                    "e_type": apx.LinkedImageException,
+                    "e_member": "cmd_output_invalid",
+                },
+            ),
+            li.zone._zonename,
+        )
+
 
 class TestApiLinked(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        pub1 = "bobcat"
-        pub2 = "lolcat"
-        pub3 = "pussycat"
+    pub1 = "bobcat"
+    pub2 = "lolcat"
+    pub3 = "pussycat"
 
-        p_all = []
-        vers = [
-            "@1.2,5.11-145:19700101T000001Z",
-            "@1.2,5.11-145:19700101T000000Z", # old time
-            "@1.1,5.11-145:19700101T000000Z", # old ver
-            "@1.1,5.11-144:19700101T000000Z", # old build
-            "@1.0,5.11-144:19700101T000000Z", # oldest
-        ]
-        p_files1 = [
-            "tmp/bar",
-            "tmp/baz",
-            "tmp/dricon2_da",
-            "tmp/dricon_n2m",
-        ]
+    p_all = []
+    vers = [
+        "@1.2,5.11-145:19700101T000001Z",
+        "@1.2,5.11-145:19700101T000000Z",  # old time
+        "@1.1,5.11-145:19700101T000000Z",  # old ver
+        "@1.1,5.11-144:19700101T000000Z",  # old build
+        "@1.0,5.11-144:19700101T000000Z",  # oldest
+    ]
+    p_files1 = [
+        "tmp/bar",
+        "tmp/baz",
+        "tmp/dricon2_da",
+        "tmp/dricon_n2m",
+    ]
 
-        p_files2 = {
-            "tmp/passwd": """\
+    p_files2 = {
+        "tmp/passwd": """\
 root:x:0:0::/root:/usr/bin/bash
 """,
-            "tmp/shadow": """\
+        "tmp/shadow": """\
 root:9EIfTNBp9elws:13817::::::
 """,
-            "tmp/group":
-"""
+        "tmp/group": """
 root::0:
 sys::3:root
 adm::4:root
 """,
-            "foo/license.txt": """
+        "foo/license.txt": """
 This is a license.
 """,
-        }
+    }
 
-        # generate packages that don't need to be synced
-        p_foo1_name_gen = "foo1"
-        p_foo1_name = dict()
-        for i, v in zip(range(len(vers)), vers):
-                p_foo1_name[i] = p_foo1_name_gen + v
-                p_data = "open {0}\n".format(p_foo1_name[i])
-                p_data += """
+    # generate packages that don't need to be synced
+    p_foo1_name_gen = "foo1"
+    p_foo1_name = dict()
+    for i, v in zip(range(len(vers)), vers):
+        p_foo1_name[i] = p_foo1_name_gen + v
+        p_data = "open {0}\n".format(p_foo1_name[i])
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     add file tmp/bar mode=0555 owner=root group=bin path=foo1_bar variant.foo=bar
                     add file tmp/baz mode=0555 owner=root group=bin path=foo1_baz variant.foo=baz
                     close\n"""
-                p_all.append(p_data)
+        p_all.append(p_data)
 
-        # generate packages that don't need to be synced
-        p_foo2_name_gen = "foo2"
-        p_foo2_name = dict()
-        for i, v in zip(range(len(vers)), vers):
-                p_foo2_name[i] = p_foo2_name_gen + v
-                p_data = "open {0}\n".format(p_foo2_name[i])
-                p_data += """
+    # generate packages that don't need to be synced
+    p_foo2_name_gen = "foo2"
+    p_foo2_name = dict()
+    for i, v in zip(range(len(vers)), vers):
+        p_foo2_name[i] = p_foo2_name_gen + v
+        p_data = "open {0}\n".format(p_foo2_name[i])
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     add file tmp/bar mode=0555 owner=root group=bin path=foo2_bar variant.foo=bar
                     add file tmp/baz mode=0555 owner=root group=bin path=foo2_baz variant.foo=baz
                     close\n"""
-                p_all.append(p_data)
+        p_all.append(p_data)
 
-        p_foo_incorp_name_gen = "foo-incorp"
-        p_foo_incorp_name = dict()
-        for i, v in zip(range(len(vers)), vers):
-                p_foo_incorp_name[i] = p_foo_incorp_name_gen + v
-                p_data = "open {0}\n".format(p_foo_incorp_name[i])
-                p_data += "add depend type=incorporate fmri={0}\n".format(
-                    p_foo1_name[i])
-                p_data += "add depend type=incorporate fmri={0}\n".format(
-                    p_foo2_name[i])
-                p_data += """
+    p_foo_incorp_name_gen = "foo-incorp"
+    p_foo_incorp_name = dict()
+    for i, v in zip(range(len(vers)), vers):
+        p_foo_incorp_name[i] = p_foo_incorp_name_gen + v
+        p_data = "open {0}\n".format(p_foo_incorp_name[i])
+        p_data += "add depend type=incorporate fmri={0}\n".format(
+            p_foo1_name[i]
+        )
+        p_data += "add depend type=incorporate fmri={0}\n".format(
+            p_foo2_name[i]
+        )
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     close\n"""
-                p_all.append(p_data)
+        p_all.append(p_data)
 
-        # generate packages that do need to be synced
-        p_sync1_name_gen = "sync1"
-        p_sync1_name = dict()
-        for i, v in zip(range(len(vers)), vers):
-                p_sync1_name[i] = p_sync1_name_gen + v
-                p_data = "open {0}\n".format(p_sync1_name[i])
-                p_data += "add depend type=parent fmri={0}".format(
-                    pkg.actions.depend.DEPEND_SELF)
-                p_data += """
+    # generate packages that do need to be synced
+    p_sync1_name_gen = "sync1"
+    p_sync1_name = dict()
+    for i, v in zip(range(len(vers)), vers):
+        p_sync1_name[i] = p_sync1_name_gen + v
+        p_data = "open {0}\n".format(p_sync1_name[i])
+        p_data += "add depend type=parent fmri={0}".format(
+            pkg.actions.depend.DEPEND_SELF
+        )
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     add file tmp/bar mode=0555 owner=root group=bin path=sync1_bar variant.foo=bar
                     add file tmp/baz mode=0555 owner=root group=bin path=sync1_baz variant.foo=baz
                     close\n"""
-                p_all.append(p_data)
+        p_all.append(p_data)
 
-        # generate packages that do need to be synced
-        p_sync2_name_gen = "sync2"
-        p_sync2_name = dict()
-        for i, v in zip(range(len(vers)), vers):
-                p_sync2_name[i] = p_sync2_name_gen + v
-                p_data = "open {0}\n".format(p_sync2_name[i])
-                p_data += "add depend type=parent fmri={0}".format(
-                    pkg.actions.depend.DEPEND_SELF)
-                p_data += """
+    # generate packages that do need to be synced
+    p_sync2_name_gen = "sync2"
+    p_sync2_name = dict()
+    for i, v in zip(range(len(vers)), vers):
+        p_sync2_name[i] = p_sync2_name_gen + v
+        p_data = "open {0}\n".format(p_sync2_name[i])
+        p_data += "add depend type=parent fmri={0}".format(
+            pkg.actions.depend.DEPEND_SELF
+        )
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     add file tmp/bar mode=0555 owner=root group=bin path=sync2_bar variant.foo=bar
                     add file tmp/baz mode=0555 owner=root group=bin path=sync2_baz variant.foo=baz
                     close\n"""
-                p_all.append(p_data)
+        p_all.append(p_data)
 
-        # generate packages that do need to be synced
-        p_sync3_name_gen = "sync3"
-        p_sync3_name = dict()
-        for i, v in zip(range(len(vers)), vers):
-                p_sync3_name[i] = p_sync3_name_gen + v
-                p_data = "open {0}\n".format(p_sync3_name[i])
-                p_data += "add depend type=parent fmri={0}".format(
-                    pkg.actions.depend.DEPEND_SELF)
-                p_data += """
+    # generate packages that do need to be synced
+    p_sync3_name_gen = "sync3"
+    p_sync3_name = dict()
+    for i, v in zip(range(len(vers)), vers):
+        p_sync3_name[i] = p_sync3_name_gen + v
+        p_data = "open {0}\n".format(p_sync3_name[i])
+        p_data += "add depend type=parent fmri={0}".format(
+            pkg.actions.depend.DEPEND_SELF
+        )
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     add file tmp/bar mode=0555 owner=root group=bin path=sync3_bar variant.foo=bar
                     add file tmp/baz mode=0555 owner=root group=bin path=sync3_baz variant.foo=baz
                     close\n"""
-                p_all.append(p_data)
+        p_all.append(p_data)
 
-        # generate packages that do need to be synced
-        p_sync4_name_gen = "sync4"
-        p_sync4_name = dict()
-        for i, v in zip(range(len(vers)), vers):
-                p_sync4_name[i] = p_sync4_name_gen + v
-                p_data = "open {0}\n".format(p_sync4_name[i])
-                p_data += "add depend type=parent fmri={0}".format(
-                    pkg.actions.depend.DEPEND_SELF)
-                p_data += """
+    # generate packages that do need to be synced
+    p_sync4_name_gen = "sync4"
+    p_sync4_name = dict()
+    for i, v in zip(range(len(vers)), vers):
+        p_sync4_name[i] = p_sync4_name_gen + v
+        p_data = "open {0}\n".format(p_sync4_name[i])
+        p_data += "add depend type=parent fmri={0}".format(
+            pkg.actions.depend.DEPEND_SELF
+        )
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     add file tmp/bar mode=0555 owner=root group=bin path=sync4_bar variant.foo=bar
                     add file tmp/baz mode=0555 owner=root group=bin path=sync4_baz variant.foo=baz
                     close\n"""
-                p_all.append(p_data)
-
-        # create a fake zones package
-        p_zones_name = "system/zones@0.5.11,5.11-0.169"
-        p_data = "open {0}\n".format(p_zones_name)
-        p_data += """
-            add dir mode=0755 owner=root group=bin path=etc
-            close\n"""
         p_all.append(p_data)
 
-        # generate packages that do need to be synced
-        p_sync5_name_gen = "sync5"
-        p_sync5_name = dict()
-        for i, v in zip(range(len(vers)), vers):
-                p_sync5_name[i] = p_sync5_name_gen + v
-                p_data = "open {0}\n".format(p_sync5_name[i])
-                p_data += "add depend type=parent fmri={0}\n".format(
-                    pkg.actions.depend.DEPEND_SELF)
+    # create a fake zones package
+    p_zones_name = "system/zones@0.5.11,5.11-0.169"
+    p_data = "open {0}\n".format(p_zones_name)
+    p_data += """
+            add dir mode=0755 owner=root group=bin path=etc
+            close\n"""
+    p_all.append(p_data)
 
-                p_data += """
+    # generate packages that do need to be synced
+    p_sync5_name_gen = "sync5"
+    p_sync5_name = dict()
+    for i, v in zip(range(len(vers)), vers):
+        p_sync5_name[i] = p_sync5_name_gen + v
+        p_data = "open {0}\n".format(p_sync5_name[i])
+        p_data += "add depend type=parent fmri={0}\n".format(
+            pkg.actions.depend.DEPEND_SELF
+        )
+
+        p_data += """
                     add dir path=etc mode=0755 owner=root group=root
                     add file tmp/group path=etc/group mode=0644 owner=root group=sys preserve=true
                     add file tmp/passwd path=etc/passwd mode=0644 owner=root group=sys preserve=true
                     add file tmp/shadow path=etc/shadow mode=0600 owner=root group=sys preserve=true
                     """
 
-                if i != 1:
-                        p_data += """
+        if i != 1:
+            p_data += """
                             close\n"""
-                        p_all.append(p_data)
-                        continue
+            p_all.append(p_data)
+            continue
 
-                # package 1 should contain one of every action type
-                # (we already have a dependency action)
-                p_data += """
+        # package 1 should contain one of every action type
+        # (we already have a dependency action)
+        p_data += """
                     add set name=variant.arch value=i386 value=sparc
                     add dir path=var mode=0755 owner=root group=root
                     add link path=var/run target=../system/volatile
@@ -335,1006 +374,1184 @@ This is a license.
                     add user username=Kermit group=adm home-dir=/export/home/Kermit
                     add license license="Foo" path=foo/license.txt must-display=True must-accept=True
                     close\n"""
-                p_all.append(p_data)
+        p_all.append(p_data)
 
-        def setUp(self):
-                self.i_count = 5
-                pkg5unittest.ManyDepotTestCase.setUp(self,
-                    [self.pub1, self.pub2, self.pub3],
-                    image_count=self.i_count)
+    def setUp(self):
+        self.i_count = 5
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, [self.pub1, self.pub2, self.pub3], image_count=self.i_count
+        )
 
-                # create files that go in packages
-                self.make_misc_files(self.p_files1)
-                self.make_misc_files(self.p_files2)
+        # create files that go in packages
+        self.make_misc_files(self.p_files1)
+        self.make_misc_files(self.p_files2)
 
-                # get repo urls
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.rurl3 = self.dcs[3].get_repo_url()
+        # get repo urls
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.rurl3 = self.dcs[3].get_repo_url()
 
-                # populate repositories
-                self.pkgsend_bulk(self.rurl1, self.p_all)
+        # populate repositories
+        self.pkgsend_bulk(self.rurl1, self.p_all)
 
-                # setup image names and paths
-                self.i_path = []
-                self.i_lin = []
-                self.i_lin2index = {}
-                for i in range(self.i_count):
-                        lin = li.LinkedImageName("system:img{0:d}".format(i))
-                        self.i_lin.insert(i, lin)
-                        self.i_lin2index[lin] = i
-                        self.set_image(i)
-                        self.i_path.insert(i, self.img_path())
-                self.set_image(0)
+        # setup image names and paths
+        self.i_path = []
+        self.i_lin = []
+        self.i_lin2index = {}
+        for i in range(self.i_count):
+            lin = li.LinkedImageName("system:img{0:d}".format(i))
+            self.i_lin.insert(i, lin)
+            self.i_lin2index[lin] = i
+            self.set_image(i)
+            self.i_path.insert(i, self.img_path())
+        self.set_image(0)
 
-        def _cat_update(self):
-                global p_update_index
-                p_update_name = "update@{0:d}.0,5.11-143:19700101T000000Z".format(
-                    p_update_index)
-                p_update_index += 1
+    def _cat_update(self):
+        global p_update_index
+        p_update_name = "update@{0:d}.0,5.11-143:19700101T000000Z".format(
+            p_update_index
+        )
+        p_update_index += 1
 
-                p_data = "open {0}\n".format(p_update_name)
-                p_data += """
+        p_data = "open {0}\n".format(p_update_name)
+        p_data += """
                     close\n"""
 
-                self.pkgsend_bulk(self.rurl1, [p_data])
+        self.pkgsend_bulk(self.rurl1, [p_data])
 
-        def _list_inst_packages(self, apio):
-                pkg_list = apio.get_pkg_list(api.ImageInterface.LIST_INSTALLED)
-                return set(sorted([
-                        "pkg://{0}/{1}@{2}".format(pfmri[0], pfmri[1], pfmri[2])
-                        for pfmri, summ, cats, states, attrs in pkg_list
-                ]))
+    def _list_inst_packages(self, apio):
+        pkg_list = apio.get_pkg_list(api.ImageInterface.LIST_INSTALLED)
+        return set(
+            sorted(
+                [
+                    "pkg://{0}/{1}@{2}".format(pfmri[0], pfmri[1], pfmri[2])
+                    for pfmri, summ, cats, states, attrs in pkg_list
+                ]
+            )
+        )
 
-        def _list_all_packages(self, apio):
-                pkg_list = apio.get_pkg_list(api.ImageInterface.LIST_ALL)
-                return set(sorted([
-                        "pkg://{0}/{1}@{2}".format(pfmri[0], pfmri[1], pfmri[2])
-                        for pfmri, summ, cats, states, attrs in pkg_list
-                ]))
+    def _list_all_packages(self, apio):
+        pkg_list = apio.get_pkg_list(api.ImageInterface.LIST_ALL)
+        return set(
+            sorted(
+                [
+                    "pkg://{0}/{1}@{2}".format(pfmri[0], pfmri[1], pfmri[2])
+                    for pfmri, summ, cats, states, attrs in pkg_list
+                ]
+            )
+        )
 
-        # utility functions for use by test cases
-        def _imgs_create(self, limit, variants=None, **ic_opts):
-                if variants == None:
-                        variants = {
-                            "variant.foo": "bar",
-                            "variant.opensolaris.zone": "nonglobal",
-                        }
+    # utility functions for use by test cases
+    def _imgs_create(self, limit, variants=None, **ic_opts):
+        if variants == None:
+            variants = {
+                "variant.foo": "bar",
+                "variant.opensolaris.zone": "nonglobal",
+            }
 
-                rv = []
+        rv = []
 
-                for i in range(0, limit):
-                        self.set_image(i)
-                        api_obj = self.image_create(self.rurl1,
-                            prefix=self.pub1, variants=variants, **ic_opts)
-                        rv.insert(i, api_obj)
+        for i in range(0, limit):
+            self.set_image(i)
+            api_obj = self.image_create(
+                self.rurl1, prefix=self.pub1, variants=variants, **ic_opts
+            )
+            rv.insert(i, api_obj)
 
-                for i in range(limit, self.i_count):
-                        self.set_image(i)
-                        self.image_destroy()
+        for i in range(limit, self.i_count):
+            self.set_image(i)
+            self.image_destroy()
 
-                self.set_image(0)
-                self.api_objs = rv
-                return rv
+        self.set_image(0)
+        self.api_objs = rv
+        return rv
 
-        def _parent_attach(self, i, cl, **args):
-                assert i not in cl
+    def _parent_attach(self, i, cl, **args):
+        assert i not in cl
 
-                for c in cl:
-                        self._api_attach(self.api_objs[c],
-                            lin=self.i_lin[i], li_path=self.i_path[i], **args)
+        for c in cl:
+            self._api_attach(
+                self.api_objs[c],
+                lin=self.i_lin[i],
+                li_path=self.i_path[i],
+                **args,
+            )
 
-        def _children_attach(self, i, cl, rv=None, rvdict=None, **args):
-                assert i not in cl
-                assert rvdict == None or type(rvdict) == dict
-                assert rv == None or rvdict == None
+    def _children_attach(self, i, cl, rv=None, rvdict=None, **args):
+        assert i not in cl
+        assert rvdict == None or type(rvdict) == dict
+        assert rv == None or rvdict == None
 
-                if rv == None:
-                        rv = EXIT_OK
-                if rvdict == None:
-                        rvdict = {}
-                        for c in cl:
-                                rvdict[c] = rv
-                assert (set(rvdict) | set(cl)) == set(cl)
+        if rv == None:
+            rv = EXIT_OK
+        if rvdict == None:
+            rvdict = {}
+            for c in cl:
+                rvdict[c] = rv
+        assert (set(rvdict) | set(cl)) == set(cl)
 
-                # attach each child to parent
-                for c in cl:
-                        rv = rvdict.get(c, EXIT_OK)
-                        (c_rv, c_err, p_dict) = \
-                            self.api_objs[i].attach_linked_child(
-                            lin=self.i_lin[c], li_path=self.i_path[c], **args)
-                        self.assertEqual(rv, c_rv, """
+        # attach each child to parent
+        for c in cl:
+            rv = rvdict.get(c, EXIT_OK)
+            (c_rv, c_err, p_dict) = self.api_objs[i].attach_linked_child(
+                lin=self.i_lin[c], li_path=self.i_path[c], **args
+            )
+            self.assertEqual(
+                rv,
+                c_rv,
+                """
 Child attach returned unexpected error code.  Expected {0:d}, got: {1:d}.
 Error output:
-{2}""".format(rv, c_rv, str(c_err)))
-                        self.api_objs[c].reset()
+{2}""".format(
+                    rv, c_rv, str(c_err)
+                ),
+            )
+            self.api_objs[c].reset()
 
-        def _children_op(self, i, cl, op, rv=None, rvdict=None, **args):
-                assert i not in cl
-                assert type(op) == str
-                assert rv == None or type(rv) == int
-                assert rvdict == None or type(rvdict) == dict
-                assert rv == None or rvdict == None
+    def _children_op(self, i, cl, op, rv=None, rvdict=None, **args):
+        assert i not in cl
+        assert type(op) == str
+        assert rv == None or type(rv) == int
+        assert rvdict == None or type(rvdict) == dict
+        assert rv == None or rvdict == None
 
-                if rv == None:
-                        rv = EXIT_OK
-                if rvdict == None:
-                        rvdict = {}
-                        for c in cl:
-                                rvdict[c] = rv
+        if rv == None:
+            rv = EXIT_OK
+        if rvdict == None:
+            rvdict = {}
+            for c in cl:
+                rvdict[c] = rv
 
-                # sync each child from parent
-                li_list = [self.i_lin[c] for c in cl]
+        # sync each child from parent
+        li_list = [self.i_lin[c] for c in cl]
 
-                # get a pointer to the function we're invoking
-                func = getattr(self.api_objs[i], op)
-                c_rvdict = func(li_list=li_list, **args)
+        # get a pointer to the function we're invoking
+        func = getattr(self.api_objs[i], op)
+        c_rvdict = func(li_list=li_list, **args)
 
-                # check that the actual return values match up with expected
-                # return values in rvdict
-                for c_lin, (c_rv, c_err, p_dict) in c_rvdict.items():
-                        rv = rvdict.get(self.i_lin2index[c_lin], EXIT_OK)
-                        self.assertEqual(c_rv, rv)
+        # check that the actual return values match up with expected
+        # return values in rvdict
+        for c_lin, (c_rv, c_err, p_dict) in c_rvdict.items():
+            rv = rvdict.get(self.i_lin2index[c_lin], EXIT_OK)
+            self.assertEqual(c_rv, rv)
 
-                if rvdict:
-                        # make sure that we actually got a return value for
-                        # each image that we're expecting a return value from
-                        c_i = [self.i_lin2index[c_lin] for c_lin in c_rvdict]
-                        self.assertEqual(sorted(c_i), sorted(rvdict))
+        if rvdict:
+            # make sure that we actually got a return value for
+            # each image that we're expecting a return value from
+            c_i = [self.i_lin2index[c_lin] for c_lin in c_rvdict]
+            self.assertEqual(sorted(c_i), sorted(rvdict))
 
-        def _verify_pkg(self, api_objs, i, pfmri):
-                apio = api_objs[i]
-                progtrack = progress.NullProgressTracker()
+    def _verify_pkg(self, api_objs, i, pfmri):
+        apio = api_objs[i]
+        progtrack = progress.NullProgressTracker()
 
-                for act, err, warn, pinfo in apio.img.verify(pfmri, progtrack,
-                    verbose=True):
-                        self.assertEqual(len(err), 0, """
+        for act, err, warn, pinfo in apio.img.verify(
+            pfmri, progtrack, verbose=True
+        ):
+            self.assertEqual(
+                len(err),
+                0,
+                """
 unexpected verification error for pkg: {0}
 action: {1}
 error: {2}
 warning: {3}
-pinfo: {4}""".format(pfmri, str(act), str(err), str(warn), str(pinfo)))
+pinfo: {4}""".format(
+                    pfmri, str(act), str(err), str(warn), str(pinfo)
+                ),
+            )
 
+    def assertKnownPkgCount(self, api_objs, i, pl_init, offset=0):
+        apio = api_objs[i]
+        pl = self._list_all_packages(apio)
 
-        def assertKnownPkgCount(self, api_objs, i, pl_init, offset=0):
-                apio = api_objs[i]
-                pl = self._list_all_packages(apio)
+        pl_removed = pl_init - pl
+        pl_added = pl - pl_init
 
-                pl_removed = pl_init - pl
-                pl_added = pl - pl_init
-
-                self.assertEqual(len(pl_init), len(pl) - offset, """
+        self.assertEqual(
+            len(pl_init),
+            len(pl) - offset,
+            """
 unexpected packages known in image[{0:d}]: {1}
 packages removed:
     {2}
 packages added:
     {3}
 packages known:
-    {4}""".format(i, self.i_path[i], "\n    ".join(pl_removed),
-                    "\n    ".join(pl_added), "\n    ".join(pl)))
+    {4}""".format(
+                i,
+                self.i_path[i],
+                "\n    ".join(pl_removed),
+                "\n    ".join(pl_added),
+                "\n    ".join(pl),
+            ),
+        )
 
-        def test_linked_p2c_recurse_flags_1_no_refresh_via_attach(self):
-                """test no-refresh option when no catalog is present"""
+    def test_linked_p2c_recurse_flags_1_no_refresh_via_attach(self):
+        """test no-refresh option when no catalog is present"""
 
-                # create images but don't cache any catalogs
-                api_objs = self._imgs_create(3, refresh_allowed=False)
+        # create images but don't cache any catalogs
+        api_objs = self._imgs_create(3, refresh_allowed=False)
 
-                # Attach p2c, 0 -> 1
-                api_objs[0].attach_linked_child(
-                    lin=self.i_lin[1], li_path=self.i_path[1],
-                    refresh_catalogs=False)
+        # Attach p2c, 0 -> 1
+        api_objs[0].attach_linked_child(
+            lin=self.i_lin[1], li_path=self.i_path[1], refresh_catalogs=False
+        )
 
-                # Attach c2p, 2 -> 0
-                self._api_attach(api_objs[2],
-                    lin=self.i_lin[2], li_path=self.i_path[0],
-                    refresh_catalogs=False)
+        # Attach c2p, 2 -> 0
+        self._api_attach(
+            api_objs[2],
+            lin=self.i_lin[2],
+            li_path=self.i_path[0],
+            refresh_catalogs=False,
+        )
 
-                for i in range(3):
-                        api_objs[i].reset()
+        for i in range(3):
+            api_objs[i].reset()
 
-                # make sure the parent didn't refresh
-                # the parent doesn't know about any packages
-                # the child only knows about the constraints package
-                for i in range(3):
-                        self.assertKnownPkgCount(api_objs, i, set())
+        # make sure the parent didn't refresh
+        # the parent doesn't know about any packages
+        # the child only knows about the constraints package
+        for i in range(3):
+            self.assertKnownPkgCount(api_objs, i, set())
 
-        def test_linked_p2c_recurse_flags_1_no_refresh_via_sync(self):
-                """test no-refresh option when no catalog is present"""
+    def test_linked_p2c_recurse_flags_1_no_refresh_via_sync(self):
+        """test no-refresh option when no catalog is present"""
 
-                # create images but don't cache any catalogs
-                api_objs = self._imgs_create(3, refresh_allowed=False)
+        # create images but don't cache any catalogs
+        api_objs = self._imgs_create(3, refresh_allowed=False)
 
-                # Attach p2c, 0 -> 1
-                api_objs[0].attach_linked_child(
-                    lin=self.i_lin[1], li_path=self.i_path[1],
-                    refresh_catalogs=False, li_md_only=True)
+        # Attach p2c, 0 -> 1
+        api_objs[0].attach_linked_child(
+            lin=self.i_lin[1],
+            li_path=self.i_path[1],
+            refresh_catalogs=False,
+            li_md_only=True,
+        )
 
-                # Attach c2p, 2 -> 0
-                self._api_attach(api_objs[2],
-                    lin=self.i_lin[2], li_path=self.i_path[0],
-                    refresh_catalogs=False, li_md_only=True)
+        # Attach c2p, 2 -> 0
+        self._api_attach(
+            api_objs[2],
+            lin=self.i_lin[2],
+            li_path=self.i_path[0],
+            refresh_catalogs=False,
+            li_md_only=True,
+        )
 
-                for i in range(3):
-                        api_objs[i].reset()
+        for i in range(3):
+            api_objs[i].reset()
 
-                # Sync 1
-                api_objs[0].sync_linked_children(li_list=[],
-                    refresh_catalogs=False)
+        # Sync 1
+        api_objs[0].sync_linked_children(li_list=[], refresh_catalogs=False)
 
-                # Sync 2
-                self._api_sync(api_objs[2],
-                    refresh_catalogs=False)
+        # Sync 2
+        self._api_sync(api_objs[2], refresh_catalogs=False)
 
-                for i in range(3):
-                        api_objs[i].reset()
+        for i in range(3):
+            api_objs[i].reset()
 
-                # make sure the parent didn't refresh
-                # the parent doesn't know about any packages
-                # the child only knows about the constraints package
-                for i in range(3):
-                        self.assertKnownPkgCount(api_objs, i, set())
+        # make sure the parent didn't refresh
+        # the parent doesn't know about any packages
+        # the child only knows about the constraints package
+        for i in range(3):
+            self.assertKnownPkgCount(api_objs, i, set())
 
-        def test_linked_p2c_recurse_flags_2_no_refresh_via_attach(self):
-                """test no-refresh option when catalog is updated"""
+    def test_linked_p2c_recurse_flags_2_no_refresh_via_attach(self):
+        """test no-refresh option when catalog is updated"""
 
-                # create images
-                api_objs = self._imgs_create(3)
+        # create images
+        api_objs = self._imgs_create(3)
 
-                # get a list of all known packages
-                pl_init = dict()
-                for i in range(3):
-                        pl_init[i] = self._list_all_packages(api_objs[i])
+        # get a list of all known packages
+        pl_init = dict()
+        for i in range(3):
+            pl_init[i] = self._list_all_packages(api_objs[i])
 
-                # update the catalog with a new package
-                self._cat_update()
+        # update the catalog with a new package
+        self._cat_update()
 
-                # Attach p2c, 0 -> 1
-                api_objs[0].attach_linked_child(
-                    lin=self.i_lin[1], li_path=self.i_path[1],
-                    refresh_catalogs=False)
+        # Attach p2c, 0 -> 1
+        api_objs[0].attach_linked_child(
+            lin=self.i_lin[1], li_path=self.i_path[1], refresh_catalogs=False
+        )
 
-                # Attach c2p, 2 -> 0
-                self._api_attach(api_objs[2],
-                    lin=self.i_lin[2], li_path=self.i_path[0],
-                    refresh_catalogs=False)
+        # Attach c2p, 2 -> 0
+        self._api_attach(
+            api_objs[2],
+            lin=self.i_lin[2],
+            li_path=self.i_path[0],
+            refresh_catalogs=False,
+        )
 
-                for i in range(3):
-                        api_objs[i].reset()
+        for i in range(3):
+            api_objs[i].reset()
 
-                # make sure the parent didn't refresh
-                # the parent doesn't know about any packages
-                # the child only knows about the constraints package
-                for i in range(3):
-                        self.assertKnownPkgCount(api_objs, i, pl_init[i])
+        # make sure the parent didn't refresh
+        # the parent doesn't know about any packages
+        # the child only knows about the constraints package
+        for i in range(3):
+            self.assertKnownPkgCount(api_objs, i, pl_init[i])
 
-                return (api_objs, pl_init)
+        return (api_objs, pl_init)
 
-        def test_linked_p2c_recurse_flags_2_no_refresh_via_other(self):
-                """test no-refresh option when catalog is updated"""
+    def test_linked_p2c_recurse_flags_2_no_refresh_via_other(self):
+        """test no-refresh option when catalog is updated"""
 
-                # don't need to test uninstall and change-varcets since
-                # they don't accept the refresh_catalogs option
+        # don't need to test uninstall and change-varcets since
+        # they don't accept the refresh_catalogs option
 
-                # create images
-                api_objs = self._imgs_create(3)
+        # create images
+        api_objs = self._imgs_create(3)
 
-                # install different synced packages into each image
-                for i in [0, 1, 2]:
-                        self._api_install(api_objs[i],
-                            [self.p_sync1_name[i + 2]])
+        # install different synced packages into each image
+        for i in [0, 1, 2]:
+            self._api_install(api_objs[i], [self.p_sync1_name[i + 2]])
 
-                # Attach p2c, 0 -> 1
-                api_objs[0].attach_linked_child(
-                    lin=self.i_lin[1], li_path=self.i_path[1],
-                    li_md_only=True)
+        # Attach p2c, 0 -> 1
+        api_objs[0].attach_linked_child(
+            lin=self.i_lin[1], li_path=self.i_path[1], li_md_only=True
+        )
 
-                # Attach c2p, 2 -> 0
-                self._api_attach(api_objs[2],
-                    lin=self.i_lin[2], li_path=self.i_path[0],
-                    li_md_only=True)
+        # Attach c2p, 2 -> 0
+        self._api_attach(
+            api_objs[2],
+            lin=self.i_lin[2],
+            li_path=self.i_path[0],
+            li_md_only=True,
+        )
 
-                for i in range(3):
-                        api_objs[i].reset()
+        for i in range(3):
+            api_objs[i].reset()
 
-                # get a list of all known packages
-                pl_init = dict()
-                for i in range(3):
-                        pl_init[i] = self._list_all_packages(api_objs[i])
+        # get a list of all known packages
+        pl_init = dict()
+        for i in range(3):
+            pl_init[i] = self._list_all_packages(api_objs[i])
 
-                # update the catalog with a new package
-                self._cat_update()
+        # update the catalog with a new package
+        self._cat_update()
 
-                # Sync 1
-                api_objs[0].sync_linked_children(li_list=[],
-                    refresh_catalogs=False)
+        # Sync 1
+        api_objs[0].sync_linked_children(li_list=[], refresh_catalogs=False)
 
-                # Sync 2
-                self._api_sync(api_objs[2],
-                    refresh_catalogs=False)
+        # Sync 2
+        self._api_sync(api_objs[2], refresh_catalogs=False)
 
-                for i in range(3):
-                        api_objs[i].reset()
+        for i in range(3):
+            api_objs[i].reset()
 
-                # make sure all the images are unaware of new packages
-                for i in range(3):
-                        self.assertKnownPkgCount(api_objs, i, pl_init[i])
+        # make sure all the images are unaware of new packages
+        for i in range(3):
+            self.assertKnownPkgCount(api_objs, i, pl_init[i])
 
-                # Install newer package in 0 and 1
-                self._api_install(api_objs[0], [self.p_sync1_name[1]],
-                    refresh_catalogs=False)
+        # Install newer package in 0 and 1
+        self._api_install(
+            api_objs[0], [self.p_sync1_name[1]], refresh_catalogs=False
+        )
 
-                # Install newer package in 2
-                self._api_install(api_objs[2], [self.p_sync1_name[1]],
-                    refresh_catalogs=False)
+        # Install newer package in 2
+        self._api_install(
+            api_objs[2], [self.p_sync1_name[1]], refresh_catalogs=False
+        )
 
-                for i in range(3):
-                        api_objs[i].reset()
+        for i in range(3):
+            api_objs[i].reset()
 
-                # make sure all the images are unaware of new packages
-                for i in range(3):
-                        self.assertKnownPkgCount(api_objs, i, pl_init[i])
+        # make sure all the images are unaware of new packages
+        for i in range(3):
+            self.assertKnownPkgCount(api_objs, i, pl_init[i])
 
-                # Update to newest package in 0 and 1
-                self._api_update(api_objs[0], refresh_catalogs=False)
+        # Update to newest package in 0 and 1
+        self._api_update(api_objs[0], refresh_catalogs=False)
 
-                # Update to newest package in 2
-                self._api_update(api_objs[2], refresh_catalogs=False)
+        # Update to newest package in 2
+        self._api_update(api_objs[2], refresh_catalogs=False)
 
-                for i in range(3):
-                        api_objs[i].reset()
+        for i in range(3):
+            api_objs[i].reset()
 
-                # make sure all the images are unaware of new packages
-                for i in range(3):
-                        self.assertKnownPkgCount(api_objs, i, pl_init[i])
+        # make sure all the images are unaware of new packages
+        for i in range(3):
+            self.assertKnownPkgCount(api_objs, i, pl_init[i])
 
-                # change variant in 0
-                self._api_change_varcets(api_objs[0],
-                    variants={"variant.foo": "baz"},
-                    refresh_catalogs=False)
+        # change variant in 0
+        self._api_change_varcets(
+            api_objs[0], variants={"variant.foo": "baz"}, refresh_catalogs=False
+        )
 
-                # change variant in 2
-                self._api_change_varcets(api_objs[2],
-                    variants={"variant.foo": "baz"},
-                    refresh_catalogs=False)
+        # change variant in 2
+        self._api_change_varcets(
+            api_objs[2], variants={"variant.foo": "baz"}, refresh_catalogs=False
+        )
 
-                for i in range(3):
-                        api_objs[i].reset()
+        for i in range(3):
+            api_objs[i].reset()
 
-                # make sure all the images are unaware of new packages
-                for i in range(3):
-                        self.assertKnownPkgCount(api_objs, i, pl_init[i])
+        # make sure all the images are unaware of new packages
+        for i in range(3):
+            self.assertKnownPkgCount(api_objs, i, pl_init[i])
 
-        def test_err_toxic_pkg(self):
-                # create images
-                api_objs = self._imgs_create(2)
+    def test_err_toxic_pkg(self):
+        # create images
+        api_objs = self._imgs_create(2)
 
-                # install a synced package into 1
-                self._api_install(api_objs[1], [self.p_sync1_name[1]])
+        # install a synced package into 1
+        self._api_install(api_objs[1], [self.p_sync1_name[1]])
 
-                # Attach c2p, 1 -> 0
-                self._api_attach(api_objs[1],
-                    lin=self.i_lin[1], li_path=self.i_path[0],
-                    li_md_only=True)
+        # Attach c2p, 1 -> 0
+        self._api_attach(
+            api_objs[1],
+            lin=self.i_lin[1],
+            li_path=self.i_path[0],
+            li_md_only=True,
+        )
 
-                # try to modify sycned packages.
-                # no version of synced package is in the parent
-                assertRaises(
-                    (apx_verify, {
+        # try to modify sycned packages.
+        # no version of synced package is in the parent
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.PlanCreationException, "e_member": "no_version"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_update(*args, **kwargs)
+            ),
+        )
+
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.PlanCreationException, "e_member": "no_version"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_sync(*args, **kwargs)
+            ),
+        )
+
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.PlanCreationException, "e_member": "no_version"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_install(*args, **kwargs)
+            ),
+            [self.p_sync1_name[0]],
+        )
+
+        # but change variant is allowed since it's not taking us
+        # further out of sync
+        api_objs[1].gen_plan_change_varcets(variants={"variant.foo": "baz"})
+
+        # install a synced package into 0
+        self._api_install(api_objs[0], [self.p_sync1_name[2]], li_ignore=[])
+
+        # try to modify image.
+        # an older version of synced package is in the parent
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.PlanCreationException, "e_member": "no_version"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_update(*args, **kwargs)
+            ),
+        )
+
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.PlanCreationException, "e_member": "no_version"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_sync(*args, **kwargs)
+            ),
+        )
+
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.PlanCreationException, "e_member": "no_version"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_install(*args, **kwargs)
+            ),
+            [self.p_sync1_name[0]],
+        )
+
+        # but change variant is allowed since it's not taking us
+        # further out of sync
+        api_objs[1].gen_plan_change_varcets(variants={"variant.foo": "baz"})
+
+    def test_err_pubcheck(self):
+        """Verify the linked image publisher sync check."""
+
+        def configure_pubs1(self):
+            """change the publishers config in our images."""
+
+            # add pub 2 to image 0
+            self.api_objs[0].add_publisher(self.po2)
+
+            # add pubs 2 and 3 to image 1
+            self.api_objs[1].add_publisher(self.po2)
+            self.api_objs[1].add_publisher(self.po3)
+
+            # leave image 2 alone
+
+            # add pub 2 to image 3 and reverse the search order
+            self.api_objs[3].add_publisher(self.po2, search_before=self.po1)
+
+            # add pub 2 to image 4 as non-sticky
+            self.api_objs[4].add_publisher(self.po4)
+
+        # setup publisher objects
+        repouri = publisher.RepositoryURI(self.rurl1)
+        repo1 = publisher.Repository(origins=[repouri])
+        self.po1 = publisher.Publisher(self.pub1, repository=repo1)
+
+        repouri = publisher.RepositoryURI(self.rurl2)
+        repo2 = publisher.Repository(origins=[repouri])
+        self.po2 = publisher.Publisher(self.pub2, repository=repo2)
+
+        repouri = publisher.RepositoryURI(self.rurl3)
+        repo3 = publisher.Repository(origins=[repouri])
+        self.po3 = publisher.Publisher(self.pub3, repository=repo3)
+
+        self.po4 = publisher.Publisher(self.pub2, repository=repo2)
+        self.po4.sticky = False
+
+        # create images and update publishers
+        api_objs = self._imgs_create(5)
+        configure_pubs1(self)
+
+        # Attach p2c, 0 -> 1 (sync ok)
+        api_objs[0].attach_linked_child(
+            lin=self.i_lin[1], li_path=self.i_path[1]
+        )
+        api_objs[0].detach_linked_children(li_list=[self.i_lin[1]])
+        api_objs[1].reset()
+
+        # Attach p2c, 0 -> 2 (sync error)
+        (rv, err, p_dict) = api_objs[0].attach_linked_child(
+            lin=self.i_lin[2], li_path=self.i_path[2]
+        )
+        self.assertEqual(rv, EXIT_OOPS)
+
+        # Attach p2c, 0 -> 3 (sync error)
+        (rv, err, p_dict) = api_objs[0].attach_linked_child(
+            lin=self.i_lin[3], li_path=self.i_path[3]
+        )
+        self.assertEqual(rv, EXIT_OOPS)
+
+        # Attach p2c, 0 -> 4 (sync error)
+        (rv, err, p_dict) = api_objs[0].attach_linked_child(
+            lin=self.i_lin[4], li_path=self.i_path[4]
+        )
+        self.assertEqual(rv, EXIT_OOPS)
+
+        # Attach c2p, 1 -> 0 (sync ok)
+        for pd in api_objs[1].gen_plan_attach(
+            lin=self.i_lin[0], li_path=self.i_path[0], noexecute=True
+        ):
+            continue
+
+        # Attach c2p, [2, 3, 4] -> 0 (sync error)
+        for c in [2, 3, 4]:
+            assertRaises(
+                (
+                    apx_verify,
+                    {
                         "e_type": apx.PlanCreationException,
-                        "e_member": "no_version"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_update(*args, **kwargs)))
+                        "e_member": "linked_pub_error",
+                    },
+                ),
+                lambda *args, **kwargs: list(
+                    api_objs[c].gen_plan_attach(*args, **kwargs)
+                ),
+                lin=self.i_lin[0],
+                li_path=self.i_path[0],
+                noexecute=True,
+            )
 
-                assertRaises(
-                    (apx_verify, {
+        # create images, attach one child (p2c), and update publishers
+        api_objs = self._imgs_create(5)
+        self._children_attach(0, [2])
+        configure_pubs1(self)
+
+        # test recursive parent operations
+        assertRaises(
+            (
+                apx_verify,
+                {
+                    "e_type": apx.LinkedImageException,
+                    "e_member": "pkg_op_failed",
+                },
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[0].gen_plan_install(*args, **kwargs)
+            ),
+            [self.p_sync1_name[0]],
+        )
+        assertRaises(
+            (
+                apx_verify,
+                {
+                    "e_type": apx.LinkedImageException,
+                    "e_member": "pkg_op_failed",
+                },
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[0].gen_plan_update(*args, **kwargs)
+            ),
+        )
+        assertRaises(
+            (
+                apx_verify,
+                {
+                    "e_type": apx.LinkedImageException,
+                    "e_member": "pkg_op_failed",
+                },
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[0].gen_plan_change_varcets(*args, **kwargs)
+            ),
+            variants={"variant.foo": "baz"},
+        )
+        assertRaises(
+            (
+                apx_verify,
+                {
+                    "e_type": apx.LinkedImageException,
+                    "e_member": "pkg_op_failed",
+                },
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[0].gen_plan_uninstall(*args, **kwargs)
+            ),
+            [self.p_sync1_name_gen],
+        )
+
+        # create images, attach children (p2c), and update publishers
+        api_objs = self._imgs_create(5)
+        self._children_attach(0, [1, 2, 3, 4])
+        configure_pubs1(self)
+
+        # test recursive parent operations
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.LinkedImageException, "e_member": "lix_bundle"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[0].gen_plan_install(*args, **kwargs)
+            ),
+            [self.p_sync1_name[0]],
+        )
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.LinkedImageException, "e_member": "lix_bundle"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[0].gen_plan_update(*args, **kwargs)
+            ),
+        )
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.LinkedImageException, "e_member": "lix_bundle"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[0].gen_plan_change_varcets(*args, **kwargs)
+            ),
+            variants={"variant.foo": "baz"},
+        )
+        assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.LinkedImageException, "e_member": "lix_bundle"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[0].gen_plan_uninstall(*args, **kwargs)
+            ),
+            [self.p_sync1_name_gen],
+        )
+
+        # test operations on child nodes
+        rvdict = {1: EXIT_OK, 2: EXIT_OOPS, 3: EXIT_OOPS, 4: EXIT_OOPS}
+        self._children_op(0, [], "sync_linked_children", rvdict=rvdict)
+        rvdict = {1: EXIT_NOP, 2: EXIT_OOPS, 3: EXIT_OOPS, 4: EXIT_OOPS}
+        self._children_op(
+            0, [1, 2, 3, 4], "sync_linked_children", rvdict=rvdict
+        )
+
+        # no pub check during detach
+        self._children_op(0, [], "detach_linked_children")
+
+        # create images, attach children (c2p), and update publishers
+        api_objs = self._imgs_create(5)
+        self._parent_attach(0, [1, 2, 3, 4])
+        configure_pubs1(self)
+
+        # test sync
+        self._api_sync(api_objs[1])
+        for c in [2, 3, 4]:
+            assertRaises(
+                (
+                    apx_verify,
+                    {
                         "e_type": apx.PlanCreationException,
-                        "e_member": "no_version"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_sync(*args, **kwargs)))
+                        "e_member": "linked_pub_error",
+                    },
+                ),
+                lambda *args, **kwargs: list(
+                    api_objs[c].gen_plan_sync(*args, **kwargs)
+                ),
+            )
 
-                assertRaises(
-                    (apx_verify, {
+        # test install
+        self._api_install(api_objs[1], [self.p_foo1_name[1]])
+        for c in [2, 3, 4]:
+            assertRaises(
+                (
+                    apx_verify,
+                    {
                         "e_type": apx.PlanCreationException,
-                        "e_member": "no_version"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_install(*args, **kwargs)),
-                        [self.p_sync1_name[0]])
+                        "e_member": "linked_pub_error",
+                    },
+                ),
+                lambda *args, **kwargs: list(
+                    api_objs[c].gen_plan_install(*args, **kwargs)
+                ),
+                [self.p_foo1_name[1]],
+            )
 
-                # but change variant is allowed since it's not taking us
-                # further out of sync
-                api_objs[1].gen_plan_change_varcets(
-                    variants={"variant.foo": "baz"})
-
-                # install a synced package into 0
-                self._api_install(api_objs[0], [self.p_sync1_name[2]],
-                    li_ignore=[])
-
-                # try to modify image.
-                # an older version of synced package is in the parent
-                assertRaises(
-                    (apx_verify, {
+        # test update
+        self._api_update(api_objs[1])
+        for c in [2, 3, 4]:
+            assertRaises(
+                (
+                    apx_verify,
+                    {
                         "e_type": apx.PlanCreationException,
-                        "e_member": "no_version"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_update(*args, **kwargs)))
+                        "e_member": "linked_pub_error",
+                    },
+                ),
+                lambda *args, **kwargs: list(
+                    api_objs[c].gen_plan_update(*args, **kwargs)
+                ),
+            )
 
-                assertRaises(
-                    (apx_verify, {
+        # test change varcets
+        self._api_change_varcets(api_objs[1], variants={"variant.foo": "baz"})
+        for c in [2, 3, 4]:
+            assertRaises(
+                (
+                    apx_verify,
+                    {
                         "e_type": apx.PlanCreationException,
-                        "e_member": "no_version"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_sync(*args, **kwargs)))
+                        "e_member": "linked_pub_error",
+                    },
+                ),
+                lambda *args, **kwargs: list(
+                    api_objs[c].gen_plan_change_varcets(*args, **kwargs)
+                ),
+                variants={"variant.foo": "baz"},
+            )
 
-                assertRaises(
-                    (apx_verify, {
+        # test uninstall
+        self._api_uninstall(api_objs[1], [self.p_foo1_name_gen])
+        for c in [2, 3, 4]:
+            assertRaises(
+                (
+                    apx_verify,
+                    {
                         "e_type": apx.PlanCreationException,
-                        "e_member": "no_version"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_install(*args, **kwargs)),
-                        [self.p_sync1_name[0]])
+                        "e_member": "linked_pub_error",
+                    },
+                ),
+                lambda *args, **kwargs: list(
+                    api_objs[c].gen_plan_uninstall(*args, **kwargs)
+                ),
+                [self.p_foo1_name_gen],
+            )
 
-                # but change variant is allowed since it's not taking us
-                # further out of sync
-                api_objs[1].gen_plan_change_varcets(
-                    variants={"variant.foo": "baz"})
+        # no pub check during detach
+        for c in [1, 2, 3, 4]:
+            self._api_detach(api_objs[c])
 
-        def test_err_pubcheck(self):
-                """Verify the linked image publisher sync check."""
+    def test_linked_hfo_cleanup(self):
+        """test linked hotfix origin cleanup."""
 
-                def configure_pubs1(self):
-                        """change the publishers config in our images."""
+        api_objs = self._imgs_create(2, refresh_allowed=False)
 
-                        # add pub 2 to image 0
-                        self.api_objs[0].add_publisher(self.po2)
+        # Attach p2c, 0 -> 1
+        api_objs[0].attach_linked_child(
+            lin=self.i_lin[1], li_path=self.i_path[1], refresh_catalogs=False
+        )
 
-                        # add pubs 2 and 3 to image 1
-                        self.api_objs[1].add_publisher(self.po2)
-                        self.api_objs[1].add_publisher(self.po3)
+        for i in range(2):
+            api_objs[i].reset()
 
-                        # leave image 2 alone
+        api_objs[0].hotfix_origin_cleanup()
 
-                        # add pub 2 to image 3 and reverse the search order
-                        self.api_objs[3].add_publisher(self.po2,
-                            search_before=self.po1)
+        hfurl = "file:///pkg_hfa_test.p5p"
+        repouri = publisher.RepositoryURI(self.rurl2)
+        hfuri = publisher.RepositoryURI(hfurl)
 
-                        # add pub 2 to image 4 as non-sticky
-                        self.api_objs[4].add_publisher(self.po4)
+        repo = publisher.Repository(origins=[repouri, hfuri])
+        po = publisher.Publisher(self.pub2, repository=repo)
 
-                # setup publisher objects
-                repouri = publisher.RepositoryURI(self.rurl1)
-                repo1 = publisher.Repository(origins=[repouri])
-                self.po1 = publisher.Publisher(self.pub1, repository=repo1)
+        api_objs[0].add_publisher(po, refresh_allowed=False)
+        api_objs[1].add_publisher(po, refresh_allowed=False)
 
-                repouri = publisher.RepositoryURI(self.rurl2)
-                repo2 = publisher.Repository(origins=[repouri])
-                self.po2 = publisher.Publisher(self.pub2, repository=repo2)
+        for i in range(2):
+            pub = api_objs[i].get_publisher(prefix="lolcat")
+            origins = [o.uri.rstrip("/") for o in pub.repository.origins]
+            self.assertEqual(sorted(origins), [hfurl, self.rurl2])
 
-                repouri = publisher.RepositoryURI(self.rurl3)
-                repo3 = publisher.Repository(origins=[repouri])
-                self.po3 = publisher.Publisher(self.pub3, repository=repo3)
+        api_objs[0].hotfix_origin_cleanup()
 
-                self.po4 = publisher.Publisher(self.pub2, repository=repo2)
-                self.po4.sticky = False
+        for i in range(2):
+            pub = api_objs[i].get_publisher(prefix="lolcat")
+            origins = [o.uri.rstrip("/") for o in pub.repository.origins]
+            self.assertEqual(origins, [self.rurl2])
 
-                # create images and update publishers
-                api_objs = self._imgs_create(5)
-                configure_pubs1(self)
+    def test_solver_err_aggregation(self):
+        """Verify that when the solver reports errors on packages that
+        can't be installed, those errors include information about
+        all the proposed packages (and not a subset of the proposed
+        packages)."""
 
-                # Attach p2c, 0 -> 1 (sync ok)
-                api_objs[0].attach_linked_child(
-                    lin=self.i_lin[1], li_path=self.i_path[1])
-                api_objs[0].detach_linked_children(li_list=[self.i_lin[1]])
-                api_objs[1].reset()
+        api_objs = self._imgs_create(2)
+        self._parent_attach(0, [1])
 
-                # Attach p2c, 0 -> 2 (sync error)
-                (rv, err, p_dict) = api_objs[0].attach_linked_child(
-                    lin=self.i_lin[2], li_path=self.i_path[2])
-                self.assertEqual(rv, EXIT_OOPS)
+        # since we're check the default output of the solver, disable
+        # the collection of extended solver dependency errors.
+        if "plan" in DebugValues:
+            del DebugValues["plan"]
 
-                # Attach p2c, 0 -> 3 (sync error)
-                (rv, err, p_dict) = api_objs[0].attach_linked_child(
-                    lin=self.i_lin[3], li_path=self.i_path[3])
-                self.assertEqual(rv, EXIT_OOPS)
+        # install synced packages in the parent
+        self._api_install(
+            api_objs[0], [self.p_sync3_name[1], self.p_sync4_name[1]]
+        )
 
-                # Attach p2c, 0 -> 4 (sync error)
-                (rv, err, p_dict) = api_objs[0].attach_linked_child(
-                    lin=self.i_lin[4], li_path=self.i_path[4])
-                self.assertEqual(rv, EXIT_OOPS)
+        # install synced packages and an incorporation which
+        # constrains the foo* packages in the child
+        self._api_install(
+            api_objs[1],
+            [
+                self.p_foo_incorp_name[1],
+                self.p_sync3_name[1],
+                self.p_sync4_name[1],
+            ],
+        )
 
-                # Attach c2p, 1 -> 0 (sync ok)
-                for pd in api_objs[1].gen_plan_attach(
-                    lin=self.i_lin[0], li_path=self.i_path[0],
-                    noexecute=True):
-                        continue
+        # try to install packages that can't be installed
+        e = assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.PlanCreationException, "e_member": "no_version"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_install(*args, **kwargs)
+            ),
+            [self.p_foo1_name[0], self.p_foo2_name[0]],
+        )
 
-                # Attach c2p, [2, 3, 4] -> 0 (sync error)
-                for c in [2, 3, 4]:
-                        assertRaises(
-                            (apx_verify, {
-                                "e_type": apx.PlanCreationException,
-                                "e_member": "linked_pub_error"}),
-                            lambda *args, **kwargs: list(
-                                api_objs[c].gen_plan_attach(*args, **kwargs)),
-                                lin=self.i_lin[0], li_path=self.i_path[0],
-                                noexecute=True)
+        # make sure the error message mentions both packages.
+        pkg_err_verify(str(e), self.p_foo1_name[0])
+        pkg_err_verify(str(e), self.p_foo2_name[0])
 
-                # create images, attach one child (p2c), and update publishers
-                api_objs = self._imgs_create(5)
-                self._children_attach(0, [2])
-                configure_pubs1(self)
+        # try to install packages with missing parent dependencies
+        e = assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.PlanCreationException, "e_member": "no_version"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_install(*args, **kwargs)
+            ),
+            [self.p_sync1_name[0], self.p_sync2_name[0]],
+        )
 
-                # test recursive parent operations
-                assertRaises(
-                    (apx_verify, {
+        # make sure the error message mentions both packages.
+        pkg_err_verify(str(e), self.p_sync1_name[0])
+        pkg_err_verify(str(e), self.p_sync2_name[0])
+
+        # uninstall synced packages in the parent
+        self._api_uninstall(
+            api_objs[0], [self.p_sync3_name[1], self.p_sync4_name[1]]
+        )
+
+        # try to update
+        e = assertRaises(
+            (
+                apx_verify,
+                {"e_type": apx.PlanCreationException, "e_member": "no_version"},
+            ),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_update(*args, **kwargs)
+            ),
+        )
+
+        # make sure the error message mentions both synced packages.
+        pkg_err_verify(str(e), self.p_sync3_name[1])
+        pkg_err_verify(str(e), self.p_sync4_name[1])
+
+    def test_sync_nosolver(self):
+        """Verify that the solver is not invoked when syncing in-sync
+        images."""
+
+        api_objs = self._imgs_create(2)
+
+        # install a synced package into the images
+        self._api_install(api_objs[0], [self.p_sync1_name[1]])
+        self._api_install(api_objs[1], [self.p_sync1_name[1]])
+
+        # install a random package into the image
+        self._api_install(api_objs[1], [self.p_foo1_name[1]])
+
+        # link the images
+        self._parent_attach(0, [1])
+
+        # raise an exception of the solver is invoked
+        DebugValues["no_solver"] = 1
+
+        # the child is in sync and we're not rejecting an installed
+        # package, so a sync shound not invoke the solver.
+        self._api_sync(api_objs[1])
+        self._api_sync(api_objs[1], reject_list=[self.p_foo2_name[1]])
+
+        # the child is in sync, but we're rejecting an installed
+        # package, so a sync must invoke the solver.
+        assertRaises(
+            (apx_verify, {"e_type": RuntimeError}),
+            self._api_sync,
+            api_objs[1],
+            reject_list=[self.p_sync1_name[1]],
+        )
+        assertRaises(
+            (apx_verify, {"e_type": RuntimeError}),
+            self._api_sync,
+            api_objs[1],
+            reject_list=[self.p_sync1_name[1], self.p_foo2_name[1]],
+        )
+
+    def test_corrupt_zone_metadata(self):
+        """Verify that some corrupt zone metadata states are
+        handled reasonably."""
+
+        def __do_tests(li_count):
+            # if /etc/zones doesn't exists we don't have zones
+            # children and we don't run the zone commands.
+            api_objs[0].reset()
+            linked = api_objs[0].list_linked()
+            assert len(linked) == li_count
+
+            #
+            # Fail the zone list operation by making a fake zoneadm.
+            #
+            DebugValues["bin_zoneadm"] = "/bin/false"
+            #
+            # Setup the following directory in order to trigger the
+            # zone list operation.
+            #
+            os.mkdir(os.path.join(self.img_path(), "etc/zones"), 0o755)
+            api_objs[0].reset()
+            assertRaises(
+                (
+                    apx_verify,
+                    {
                         "e_type": apx.LinkedImageException,
-                        "e_member": "pkg_op_failed"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[0].gen_plan_install(*args, **kwargs)),
-                        [self.p_sync1_name[0]])
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.LinkedImageException,
-                        "e_member": "pkg_op_failed"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[0].gen_plan_update(*args, **kwargs)))
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.LinkedImageException,
-                        "e_member": "pkg_op_failed"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[0].gen_plan_change_varcets(*args, **kwargs)),
-                        variants={"variant.foo": "baz"})
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.LinkedImageException,
-                        "e_member": "pkg_op_failed"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[0].gen_plan_uninstall(*args, **kwargs)),
-                        [self.p_sync1_name_gen])
-
-                # create images, attach children (p2c), and update publishers
-                api_objs = self._imgs_create(5)
-                self._children_attach(0, [1, 2, 3, 4])
-                configure_pubs1(self)
-
-                # test recursive parent operations
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.LinkedImageException,
-                        "e_member": "lix_bundle"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[0].gen_plan_install(*args, **kwargs)),
-                        [self.p_sync1_name[0]])
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.LinkedImageException,
-                        "e_member": "lix_bundle"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[0].gen_plan_update(*args, **kwargs)))
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.LinkedImageException,
-                        "e_member": "lix_bundle"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[0].gen_plan_change_varcets(*args, **kwargs)),
-                        variants={"variant.foo": "baz"})
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.LinkedImageException,
-                        "e_member": "lix_bundle"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[0].gen_plan_uninstall(*args, **kwargs)),
-                        [self.p_sync1_name_gen])
-
-                # test operations on child nodes
-                rvdict = {1: EXIT_OK, 2: EXIT_OOPS, 3: EXIT_OOPS,
-                    4: EXIT_OOPS}
-                self._children_op(0, [], "sync_linked_children",
-                    rvdict=rvdict)
-                rvdict = {1: EXIT_NOP, 2: EXIT_OOPS, 3: EXIT_OOPS,
-                    4: EXIT_OOPS}
-                self._children_op(0, [1, 2, 3, 4], "sync_linked_children",
-                    rvdict=rvdict)
-
-                # no pub check during detach
-                self._children_op(0, [], "detach_linked_children")
-
-                # create images, attach children (c2p), and update publishers
-                api_objs = self._imgs_create(5)
-                self._parent_attach(0, [1, 2, 3, 4])
-                configure_pubs1(self)
-
-                # test sync
-                self._api_sync(api_objs[1])
-                for c in [2, 3, 4]:
-                        assertRaises(
-                            (apx_verify, {
-                                "e_type": apx.PlanCreationException,
-                                "e_member": "linked_pub_error"}),
-                            lambda *args, **kwargs: list(
-                                api_objs[c].gen_plan_sync(*args, **kwargs)))
-
-                # test install
-                self._api_install(api_objs[1], [self.p_foo1_name[1]])
-                for c in [2, 3, 4]:
-                        assertRaises(
-                            (apx_verify, {
-                                "e_type": apx.PlanCreationException,
-                                "e_member": "linked_pub_error"}),
-                            lambda *args, **kwargs: list(
-                                api_objs[c].gen_plan_install(*args, **kwargs)),
-                                [self.p_foo1_name[1]])
-
-                # test update
-                self._api_update(api_objs[1])
-                for c in [2, 3, 4]:
-                        assertRaises(
-                            (apx_verify, {
-                                "e_type": apx.PlanCreationException,
-                                "e_member": "linked_pub_error"}),
-                            lambda *args, **kwargs: list(
-                                api_objs[c].gen_plan_update(*args, **kwargs)))
-
-                # test change varcets
-                self._api_change_varcets(api_objs[1],
-                    variants={"variant.foo": "baz"})
-                for c in [2, 3, 4]:
-                        assertRaises(
-                            (apx_verify, {
-                                "e_type": apx.PlanCreationException,
-                                "e_member": "linked_pub_error"}),
-                            lambda *args, **kwargs: list(
-                                api_objs[c].gen_plan_change_varcets(*args,
-                                    **kwargs)),
-                                variants={"variant.foo": "baz"})
-
-                # test uninstall
-                self._api_uninstall(api_objs[1], [self.p_foo1_name_gen])
-                for c in [2, 3, 4]:
-                        assertRaises(
-                            (apx_verify, {
-                                "e_type": apx.PlanCreationException,
-                                "e_member": "linked_pub_error"}),
-                            lambda *args, **kwargs: list(
-                                api_objs[c].gen_plan_uninstall(*args,
-                                    **kwargs)),
-                                [self.p_foo1_name_gen])
-
-                # no pub check during detach
-                for c in [1, 2, 3, 4]:
-                        self._api_detach(api_objs[c])
-
-        def test_linked_hfo_cleanup(self):
-                """test linked hotfix origin cleanup."""
-
-                api_objs = self._imgs_create(2, refresh_allowed=False)
-
-                # Attach p2c, 0 -> 1
-                api_objs[0].attach_linked_child(
-                    lin=self.i_lin[1], li_path=self.i_path[1],
-                    refresh_catalogs=False)
-
-                for i in range(2):
-                        api_objs[i].reset()
-
-                api_objs[0].hotfix_origin_cleanup()
-
-                hfurl = 'file:///pkg_hfa_test.p5p'
-                repouri = publisher.RepositoryURI(self.rurl2)
-                hfuri = publisher.RepositoryURI(hfurl)
-
-                repo = publisher.Repository(origins=[repouri, hfuri])
-                po = publisher.Publisher(self.pub2, repository=repo)
-
-                api_objs[0].add_publisher(po, refresh_allowed=False)
-                api_objs[1].add_publisher(po, refresh_allowed=False)
-
-                for i in range(2):
-                        pub = api_objs[i].get_publisher(prefix='lolcat')
-                        origins = [ o.uri.rstrip('/')
-                            for o in pub.repository.origins ]
-                        self.assertEqual(sorted(origins), [hfurl, self.rurl2])
-
-                api_objs[0].hotfix_origin_cleanup()
-
-                for i in range(2):
-                        pub = api_objs[i].get_publisher(prefix='lolcat')
-                        origins = [ o.uri.rstrip('/')
-                            for o in pub.repository.origins ]
-                        self.assertEqual(origins, [self.rurl2])
-
-        def test_solver_err_aggregation(self):
-                """Verify that when the solver reports errors on packages that
-                can't be installed, those errors include information about
-                all the proposed packages (and not a subset of the proposed
-                packages)."""
-
-                api_objs = self._imgs_create(2)
-                self._parent_attach(0, [1])
-
-                # since we're check the default output of the solver, disable
-                # the collection of extended solver dependency errors.
-                if "plan" in DebugValues:
-                        del DebugValues["plan"]
-
-                # install synced packages in the parent
-                self._api_install(api_objs[0], [
-                    self.p_sync3_name[1], self.p_sync4_name[1]])
-
-                # install synced packages and an incorporation which
-                # constrains the foo* packages in the child
-                self._api_install(api_objs[1], [self.p_foo_incorp_name[1],
-                    self.p_sync3_name[1], self.p_sync4_name[1]])
-
-                # try to install packages that can't be installed
-                e = assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.PlanCreationException,
-                        "e_member": "no_version"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_install(*args, **kwargs)),
-                        [self.p_foo1_name[0], self.p_foo2_name[0]])
-
-                # make sure the error message mentions both packages.
-                pkg_err_verify(str(e), self.p_foo1_name[0])
-                pkg_err_verify(str(e), self.p_foo2_name[0])
-
-                # try to install packages with missing parent dependencies
-                e = assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.PlanCreationException,
-                        "e_member": "no_version"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_install(*args, **kwargs)),
-                        [self.p_sync1_name[0], self.p_sync2_name[0]])
-
-                # make sure the error message mentions both packages.
-                pkg_err_verify(str(e), self.p_sync1_name[0])
-                pkg_err_verify(str(e), self.p_sync2_name[0])
-
-                # uninstall synced packages in the parent
-                self._api_uninstall(api_objs[0], [
-                    self.p_sync3_name[1], self.p_sync4_name[1]])
-
-                # try to update
-                e = assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.PlanCreationException,
-                        "e_member": "no_version"}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_update(*args, **kwargs)))
-
-                # make sure the error message mentions both synced packages.
-                pkg_err_verify(str(e), self.p_sync3_name[1])
-                pkg_err_verify(str(e), self.p_sync4_name[1])
-
-
-        def test_sync_nosolver(self):
-                """Verify that the solver is not invoked when syncing in-sync
-                images."""
-
-                api_objs = self._imgs_create(2)
-
-                # install a synced package into the images
-                self._api_install(api_objs[0], [self.p_sync1_name[1]])
-                self._api_install(api_objs[1], [self.p_sync1_name[1]])
-
-                # install a random package into the image
-                self._api_install(api_objs[1], [self.p_foo1_name[1]])
-
-                # link the images
-                self._parent_attach(0, [1])
-
-                # raise an exception of the solver is invoked
-                DebugValues["no_solver"] = 1
-
-                # the child is in sync and we're not rejecting an installed
-                # package, so a sync shound not invoke the solver.
-                self._api_sync(api_objs[1])
-                self._api_sync(api_objs[1], reject_list=[self.p_foo2_name[1]])
-
-                # the child is in sync, but we're rejecting an installed
-                # package, so a sync must invoke the solver.
-                assertRaises(
-                    (apx_verify, {"e_type": RuntimeError}),
-                    self._api_sync, api_objs[1],
-                    reject_list=[self.p_sync1_name[1]])
-                assertRaises(
-                    (apx_verify, {"e_type": RuntimeError}),
-                    self._api_sync, api_objs[1],
-                    reject_list=[self.p_sync1_name[1], self.p_foo2_name[1]])
-
-        def test_corrupt_zone_metadata(self):
-                """Verify that some corrupt zone metadata states are
-                handled reasonably."""
-
-                def __do_tests(li_count):
-                        # if /etc/zones doesn't exists we don't have zones
-                        # children and we don't run the zone commands.
-                        api_objs[0].reset()
-                        linked = api_objs[0].list_linked()
-                        assert len(linked) == li_count
-
-                        #
-                        # Fail the zone list operation by making a fake zoneadm.
-                        #
-                        DebugValues["bin_zoneadm"] = "/bin/false"
-                        #
-                        # Setup the following directory in order to trigger the
-                        # zone list operation.
-                        #
-                        os.mkdir(os.path.join(self.img_path(), "etc/zones"),
-                            0o755)
-                        api_objs[0].reset()
-                        assertRaises(
-                            (apx_verify, {
-                                "e_type": apx.LinkedImageException,
-                                "e_member": "cmd_failed"}),
-                            api_objs[0].list_linked)
-
-                        # ignoring all linked children should allow the
-                        # operation to succeed.
-                        linked = api_objs[0].list_linked(li_ignore=[])
-                        assert len(linked) == 0
-
-                        # reset the image
-                        os.rmdir(os.path.join(self.img_path(), "etc/zones"))
-
-                #
-                # create a global zone image and install a fake zones package
-                # within the image.  this makes the linked image zones plugin
-                # think it's dealing with an image that could have zone
-                # children so it will invoke the zone tools on the image to
-                # try and discover zones installed in the image.
-                #
-                api_objs = self._imgs_create(2)
-                self._api_change_varcets(api_objs[0],
-                    variants={"variant.opensolaris.zone": "global"})
-                self._api_install(api_objs[0], [self.p_zones_name])
-
-                # run tests
-                __do_tests(0)
-
-                # link a system image child to the image and run tests
-                self._children_attach(0, [1])
-                __do_tests(2)
-
-                # remove linked image metadata from the parent and run tests
-                shutil.rmtree(os.path.join(self.img_path(), "var/pkg/linked"))
-                __do_tests(2)
-
-        def test_attach_reject(self):
-                """Verify that we can reject packages during attach."""
-
-                api_objs = self._imgs_create(3)
-
-                # install a random package into the image
-                pkg = self.p_foo1_name_gen
-                self._api_install(api_objs[1], [pkg])
-                self._api_install(api_objs[2], [pkg])
-
-                # attach c2p
-                assert len(self._list_inst_packages(api_objs[1])) == 1
-                self._parent_attach(0, [1], reject_list=[pkg])
-                assert len(self._list_inst_packages(api_objs[1])) == 0
-
-                # attach p2c
-                assert len(self._list_inst_packages(api_objs[2])) == 1
-                self._children_attach(0, [2], reject_list=[pkg])
-                assert len(self._list_inst_packages(api_objs[2])) == 0
-
-        def test_action_serialization(self):
-                """Verify that all actions can be serialized to disk and
-                reloaded successfully when updating a child image."""
-
-                api_objs = self._imgs_create(2)
-
-                # install an empty synced package into the images
-                self._api_install(api_objs[0], [self.p_sync5_name[2]])
-                self._api_install(api_objs[1], [self.p_sync5_name[2]])
-
-                # link the images
-                self._children_attach(0, [1])
-                # update the synced package in the parent so it delivers some
-                # content.  this will cause us to implicitly recurse into the
-                # child and serialize the child update plans to disk, which
-                # should serialize out all the new actions to disk (there by
-                # verifying that they get serialized and re-loaded correctly.)
-                self._api_install(api_objs[0], [self.p_sync5_name[1]],
-                    show_licenses=True, accept_licenses=True)
-
-                # update the synced package in the parent again so it delivers
-                # no content.
-                self._api_install(api_objs[0], [self.p_sync5_name[0]])
-
-        def test_unsynced_image_operations(self):
-                """Verify that package operations which modify unsynced
-                packages can be performed on an out of sync image."""
-
-                api_objs = self._imgs_create(2)
-
-                # install synced package into the images
-                # make sure the child has a newer synced package
-                self._api_install(api_objs[0], [self.p_sync1_name[2],
-                   self.p_sync2_name[2], self.p_sync3_name[0],
-                   self.p_sync4_name[2]])
-                self._api_install(api_objs[0], [self.p_sync1_name[2]])
-                self._api_install(api_objs[1], [self.p_sync1_name[1],
-                    self.p_sync2_name[1], self.p_sync3_name[1],
-                    self.p_sync4_name[1]])
-
-                # link the images
-                self._children_attach(0, [1], li_md_only=True)
-
-                # verify that our image is out of sync
-                lin = api_objs[1].get_linked_name()
-                rvdict = api_objs[1].audit_linked()
-                self.assertEqual(rvdict[lin].rvt_rv, EXIT_DIVERGED)
-
-                # verify that we can install an unsynced package
-                self._api_install(api_objs[1], [self.p_foo1_name[2]])
-
-                # verify that we can update an unsynced package
-                self._api_update(api_objs[1], pkgs_update=[self.p_foo1_name[1]])
-
-                # verify that we can downgrade an unsynced package
-                self._api_update(api_objs[1], pkgs_update=[self.p_foo1_name[2]])
-
-                # verify that we can bring a package into sync via downgrade
-                self._api_update(api_objs[1],
-                    pkgs_update=[self.p_sync2_name[2]])
-
-                # verify that we can bring a package into sync via upgrade
-                self._api_update(api_objs[1],
-                    pkgs_update=[self.p_sync3_name[0]])
-
-                # verify that we can uninstall an out of sync package
-                self._api_uninstall(api_objs[1], [self.p_sync4_name[1]])
-
-                # verify that we can install an in sync package.
-                self._api_install(api_objs[1], [self.p_sync4_name[2]])
-
-                # verify that we can uninstall an in sync package.
-                self._api_uninstall(api_objs[1], [self.p_sync4_name[2]])
-
-                # verify that a sync fails (parent has older package)
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.PlanCreationException}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_sync(*args, **kwargs)))
-
-                # verify that we can't install a new out of sync package
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.PlanCreationException}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_install(*args, **kwargs)),
-                        [self.p_sync4_name[0]])
-
-                # verify that we can't update an installed out of sync package
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.PlanCreationException}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_install(*args, **kwargs)),
-                        [self.p_sync1_name[0]])
-
-                # verify that we can't do a general update
-                assertRaises(
-                    (apx_verify, {
-                        "e_type": apx.PlanCreationException}),
-                    lambda *args, **kwargs: list(
-                        api_objs[1].gen_plan_update(*args, **kwargs)))
-
-                # verify that our image is still out of sync
-                lin = api_objs[1].get_linked_name()
-                rvdict = api_objs[1].audit_linked()
-                self.assertEqual(rvdict[lin].rvt_rv, EXIT_DIVERGED)
+                        "e_member": "cmd_failed",
+                    },
+                ),
+                api_objs[0].list_linked,
+            )
+
+            # ignoring all linked children should allow the
+            # operation to succeed.
+            linked = api_objs[0].list_linked(li_ignore=[])
+            assert len(linked) == 0
+
+            # reset the image
+            os.rmdir(os.path.join(self.img_path(), "etc/zones"))
+
+        #
+        # create a global zone image and install a fake zones package
+        # within the image.  this makes the linked image zones plugin
+        # think it's dealing with an image that could have zone
+        # children so it will invoke the zone tools on the image to
+        # try and discover zones installed in the image.
+        #
+        api_objs = self._imgs_create(2)
+        self._api_change_varcets(
+            api_objs[0], variants={"variant.opensolaris.zone": "global"}
+        )
+        self._api_install(api_objs[0], [self.p_zones_name])
+
+        # run tests
+        __do_tests(0)
+
+        # link a system image child to the image and run tests
+        self._children_attach(0, [1])
+        __do_tests(2)
+
+        # remove linked image metadata from the parent and run tests
+        shutil.rmtree(os.path.join(self.img_path(), "var/pkg/linked"))
+        __do_tests(2)
+
+    def test_attach_reject(self):
+        """Verify that we can reject packages during attach."""
+
+        api_objs = self._imgs_create(3)
+
+        # install a random package into the image
+        pkg = self.p_foo1_name_gen
+        self._api_install(api_objs[1], [pkg])
+        self._api_install(api_objs[2], [pkg])
+
+        # attach c2p
+        assert len(self._list_inst_packages(api_objs[1])) == 1
+        self._parent_attach(0, [1], reject_list=[pkg])
+        assert len(self._list_inst_packages(api_objs[1])) == 0
+
+        # attach p2c
+        assert len(self._list_inst_packages(api_objs[2])) == 1
+        self._children_attach(0, [2], reject_list=[pkg])
+        assert len(self._list_inst_packages(api_objs[2])) == 0
+
+    def test_action_serialization(self):
+        """Verify that all actions can be serialized to disk and
+        reloaded successfully when updating a child image."""
+
+        api_objs = self._imgs_create(2)
+
+        # install an empty synced package into the images
+        self._api_install(api_objs[0], [self.p_sync5_name[2]])
+        self._api_install(api_objs[1], [self.p_sync5_name[2]])
+
+        # link the images
+        self._children_attach(0, [1])
+        # update the synced package in the parent so it delivers some
+        # content.  this will cause us to implicitly recurse into the
+        # child and serialize the child update plans to disk, which
+        # should serialize out all the new actions to disk (there by
+        # verifying that they get serialized and re-loaded correctly.)
+        self._api_install(
+            api_objs[0],
+            [self.p_sync5_name[1]],
+            show_licenses=True,
+            accept_licenses=True,
+        )
+
+        # update the synced package in the parent again so it delivers
+        # no content.
+        self._api_install(api_objs[0], [self.p_sync5_name[0]])
+
+    def test_unsynced_image_operations(self):
+        """Verify that package operations which modify unsynced
+        packages can be performed on an out of sync image."""
+
+        api_objs = self._imgs_create(2)
+
+        # install synced package into the images
+        # make sure the child has a newer synced package
+        self._api_install(
+            api_objs[0],
+            [
+                self.p_sync1_name[2],
+                self.p_sync2_name[2],
+                self.p_sync3_name[0],
+                self.p_sync4_name[2],
+            ],
+        )
+        self._api_install(api_objs[0], [self.p_sync1_name[2]])
+        self._api_install(
+            api_objs[1],
+            [
+                self.p_sync1_name[1],
+                self.p_sync2_name[1],
+                self.p_sync3_name[1],
+                self.p_sync4_name[1],
+            ],
+        )
+
+        # link the images
+        self._children_attach(0, [1], li_md_only=True)
+
+        # verify that our image is out of sync
+        lin = api_objs[1].get_linked_name()
+        rvdict = api_objs[1].audit_linked()
+        self.assertEqual(rvdict[lin].rvt_rv, EXIT_DIVERGED)
+
+        # verify that we can install an unsynced package
+        self._api_install(api_objs[1], [self.p_foo1_name[2]])
+
+        # verify that we can update an unsynced package
+        self._api_update(api_objs[1], pkgs_update=[self.p_foo1_name[1]])
+
+        # verify that we can downgrade an unsynced package
+        self._api_update(api_objs[1], pkgs_update=[self.p_foo1_name[2]])
+
+        # verify that we can bring a package into sync via downgrade
+        self._api_update(api_objs[1], pkgs_update=[self.p_sync2_name[2]])
+
+        # verify that we can bring a package into sync via upgrade
+        self._api_update(api_objs[1], pkgs_update=[self.p_sync3_name[0]])
+
+        # verify that we can uninstall an out of sync package
+        self._api_uninstall(api_objs[1], [self.p_sync4_name[1]])
+
+        # verify that we can install an in sync package.
+        self._api_install(api_objs[1], [self.p_sync4_name[2]])
+
+        # verify that we can uninstall an in sync package.
+        self._api_uninstall(api_objs[1], [self.p_sync4_name[2]])
+
+        # verify that a sync fails (parent has older package)
+        assertRaises(
+            (apx_verify, {"e_type": apx.PlanCreationException}),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_sync(*args, **kwargs)
+            ),
+        )
+
+        # verify that we can't install a new out of sync package
+        assertRaises(
+            (apx_verify, {"e_type": apx.PlanCreationException}),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_install(*args, **kwargs)
+            ),
+            [self.p_sync4_name[0]],
+        )
+
+        # verify that we can't update an installed out of sync package
+        assertRaises(
+            (apx_verify, {"e_type": apx.PlanCreationException}),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_install(*args, **kwargs)
+            ),
+            [self.p_sync1_name[0]],
+        )
+
+        # verify that we can't do a general update
+        assertRaises(
+            (apx_verify, {"e_type": apx.PlanCreationException}),
+            lambda *args, **kwargs: list(
+                api_objs[1].gen_plan_update(*args, **kwargs)
+            ),
+        )
+
+        # verify that our image is still out of sync
+        lin = api_objs[1].get_linked_name()
+        rvdict = api_objs[1].audit_linked()
+        self.assertEqual(rvdict[lin].rvt_rv, EXIT_DIVERGED)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_manifest.py
+++ b/src/tests/api/t_manifest.py
@@ -24,8 +24,9 @@
 # Copyright (c) 2008, 2022, Oracle and/or its affiliates.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -47,19 +48,19 @@ import pkg.portable as portable
 import pkg.facet as facet
 import pkg.variant as variant
 
+
 class TestManifest(pkg5unittest.Pkg5TestCase):
+    def setUp(self):
+        pkg5unittest.Pkg5TestCase.setUp(self)
 
-        def setUp(self):
-                pkg5unittest.Pkg5TestCase.setUp(self)
-
-                self.m1 = manifest.Manifest()
-                self.m1_contents = """\
+        self.m1 = manifest.Manifest()
+        self.m1_contents = """\
 set com.sun,test=true
 depend type=require fmri=pkg:/library/libc
 file fff555fff mode=0555 owner=sch group=staff path=/usr/bin/i386/sort isa=i386
 """
-                self.m2 = manifest.Manifest()
-                self.m2_contents = """\
+        self.m2 = manifest.Manifest()
+        self.m2_contents = """\
 set com.sun,test=false
 set com.sun,data=true
 depend type=require fmri=pkg:/library/libc
@@ -72,15 +73,15 @@ file ff555ffe mode=0555 owner=root group=bin path=/kernel/drv/amd64/foo isa=amd6
 file ff555ffd mode=0644 owner=root group=bin path=/kernel/drv/foo.conf
 """
 
-                self.m2_signatures = {
-                    "sha-1": "7272cb2461a8a4ccf958b7a7f13f3ae20cbb0212"
-                }
+        self.m2_signatures = {
+            "sha-1": "7272cb2461a8a4ccf958b7a7f13f3ae20cbb0212"
+        }
 
-                #
-                # Try to keep this up to date with one of
-                # every action type.
-                #
-                self.diverse_contents = """\
+        #
+        # Try to keep this up to date with one of
+        # every action type.
+        #
+        self.diverse_contents = """\
 set com.sun,test=false
 set name=pkg.description value="The Z Shell (zsh) is a Bourne-like shell " \\
     "designed for interactive use, although it is also a powerful scripting " \\
@@ -99,7 +100,7 @@ hardlink path=usr/bin/amd64/rksh93 target=ksh93 variant.opensolaris.zone=global
 group groupname=testgroup gid=10
 """
 
-                self.m4_contents = """\
+        self.m4_contents = """\
 set com.sun,test=false
 set com.sun,data=true
 depend type=require fmri=pkg:/library/libc
@@ -107,55 +108,56 @@ file fff555ff9 mode=0555 owner=sch group=staff path=/usr/bin/i386/sort \\
 isa=i386
 """
 
-                self.m5_contents = """\
+        self.m5_contents = """\
 set com.sun,test=false
 set com.sun,data=true
 depend type=optional fmri=pkg:/library/libc
 file fff555ff9 mode=0555 owner=sch group=staff path=/usr/bin/i386/sort isa=i386
 """
 
-        def test_set_content1(self):
-                """ ASSERT: manifest string repr reflects its construction """
+    def test_set_content1(self):
+        """ASSERT: manifest string repr reflects its construction"""
 
-                self.m1.set_content(self.m1_contents)
+        self.m1.set_content(self.m1_contents)
 
-                # It would be nice if we could just see if the string
-                # representation of the manifest matched the input, but the
-                # order of individual fields seems to change.  Instead we look
-                # for useful substrings.
+        # It would be nice if we could just see if the string
+        # representation of the manifest matched the input, but the
+        # order of individual fields seems to change.  Instead we look
+        # for useful substrings.
 
-                # Index raises an exception if the substring isn't found;
-                # if that were to happen, the test case would then fail.
-                mstr = str(self.m1)
-                mstr.index("fmri=pkg:/library/libc")
-                mstr.index("owner=sch")
-                mstr.index("group=staff")
-                mstr.index("isa=i386")
+        # Index raises an exception if the substring isn't found;
+        # if that were to happen, the test case would then fail.
+        mstr = str(self.m1)
+        mstr.index("fmri=pkg:/library/libc")
+        mstr.index("owner=sch")
+        mstr.index("group=staff")
+        mstr.index("isa=i386")
 
-                # Verify set_content with a byte string with unicode data
-                # works.
-                bstr = "set name=pkg.summary:th value=\"ซอฟต์แวร์ \""
-                m = manifest.Manifest()
-                m.set_content(bstr)
-                output = list(m.as_lines())[0].rstrip()
-                self.assertEqual(bstr, output)
-                self.assertTrue(isinstance(output, str))
+        # Verify set_content with a byte string with unicode data
+        # works.
+        bstr = 'set name=pkg.summary:th value="ซอฟต์แวร์ "'
+        m = manifest.Manifest()
+        m.set_content(bstr)
+        output = list(m.as_lines())[0].rstrip()
+        self.assertEqual(bstr, output)
+        self.assertTrue(isinstance(output, str))
 
-                # Verify set_content with a Unicode string works.
-                m = manifest.Manifest()
-                if six.PY2:
-                        m.set_content(six.text_type(bstr, "utf-8"))
-                else:
-                        m.set_content(bstr)
-                output = list(m.as_lines())[0].rstrip()
-                self.assertEqual(bstr, output)
-                self.assertTrue(isinstance(output, str))
+        # Verify set_content with a Unicode string works.
+        m = manifest.Manifest()
+        if six.PY2:
+            m.set_content(six.text_type(bstr, "utf-8"))
+        else:
+            m.set_content(bstr)
+        output = list(m.as_lines())[0].rstrip()
+        self.assertEqual(bstr, output)
+        self.assertTrue(isinstance(output, str))
 
-                # Verify Manifests using line continuation '\' are parsed as
-                # expected.
-                m = manifest.Manifest()
-                m.set_content(self.diverse_contents)
-                expected = sorted('''\
+        # Verify Manifests using line continuation '\' are parsed as
+        # expected.
+        m = manifest.Manifest()
+        m.set_content(self.diverse_contents)
+        expected = sorted(
+            """\
 set name=com.sun,test value=false
 set name=pkg.description value="The Z Shell (zsh) is a Bourne-like shell designed for interactive use, although it is also a powerful scripting language.  Many of the useful features of bash, ksh, and tcsh were incorporated into zsh, but many original features were added."
 depend fmri=pkg:/library/libc type=require
@@ -166,258 +168,283 @@ dir group=bin mode=0755 owner=root path=usr/bin variant.arch=i386 variant.arch=s
 file fff555ff9 group=staff isa=i386 mode=0555 owner=sch path=usr/bin/i386/sort
 hardlink path=usr/bin/amd64/rksh93 target=ksh93 variant.opensolaris.zone=global
 link path=usr/lib/amd64/libjpeg.so target=libjpeg.so.62.0.0
-'''.splitlines())
-                actual = sorted(l.strip() for l in m.as_lines())
+""".splitlines()
+        )
+        actual = sorted(l.strip() for l in m.as_lines())
 
-                self.assertEqualDiff(expected, actual)
+        self.assertEqualDiff(expected, actual)
 
-        def test_diffs1(self):
-                """ humanized_differences runs to completion """
+    def test_diffs1(self):
+        """humanized_differences runs to completion"""
 
-                # humanized_differences is for now, at least, just a
-                # useful diagnostic
-                self.m1.set_content(self.m1_contents)
-                self.m2.set_content(self.m2_contents)
-                self.m2.humanized_differences(self.m1)
+        # humanized_differences is for now, at least, just a
+        # useful diagnostic
+        self.m1.set_content(self.m1_contents)
+        self.m2.set_content(self.m2_contents)
+        self.m2.humanized_differences(self.m1)
 
-        def test_diffs2(self):
-                self.m1.set_content(self.m1_contents)
-                self.m2.set_content(self.m2_contents)
-                diffs = self.m2.combined_difference(self.m1)
+    def test_diffs2(self):
+        self.m1.set_content(self.m1_contents)
+        self.m2.set_content(self.m2_contents)
+        diffs = self.m2.combined_difference(self.m1)
 
+    #
+    # Do the most obvious thing: build two manifests
+    # from the same string, and then diff the results
+    #
+    def test_diffs3(self):
+        """ASSERT: building m1(c) and m2(c) should yield no diffs"""
+        self.m1.set_content(self.diverse_contents)
+        self.m2.set_content(self.diverse_contents)
+
+        diffs = self.m2.combined_difference(self.m1)
+        self.assertEqual(len(diffs), 0)
+
+        diffs = self.m1.combined_difference(self.m2)
+        self.assertEqual(len(diffs), 0)
+
+    def test_diffs4(self):
+        """ASSERT: Building m' from diff(m, null) should yield m"""
+
+        self.m2.set_content(self.m2_contents)
+        diffs = self.m2.combined_difference(manifest.null)
+
+        new_contents = ""
+        for d in diffs:
+            new_contents += str(d[1]) + "\n"
+
+        mtmp = manifest.Manifest()
+        # print(new_contents)
+        mtmp.set_content(new_contents)
+
+        diffs = self.m2.combined_difference(mtmp)
+        self.assertEqual(len(diffs), 0)
+
+    def test_diffs5(self):
+        """detect an attribute change"""
+
+        self.m1.set_content(self.m4_contents)
+        self.m2.set_content(self.m5_contents)
+
+        # print(self.m2.display_differences(self.m1))
+
+        diffs = self.m2.combined_difference(self.m1)
+        self.assertEqual(len(diffs), 1)
+
+    def test_diffs6(self):
+        """ASSERT: changes in action work"""
+
+        self.m1.set_content("dir mode=0755 owner=root group=sys path=/bin/foo")
+        self.m2.set_content(
+            "file 12345 mode=0755 owner=root group=sys path=/bin"
+        )
+
+        diffs = self.m2.combined_difference(self.m1)
         #
-        # Do the most obvious thing: build two manifests
-        # from the same string, and then diff the results
+        # Expect to see a directory going away, and a file being
+        # added
         #
-        def test_diffs3(self):
-                """ ASSERT: building m1(c) and m2(c) should yield no diffs """
-                self.m1.set_content(self.diverse_contents)
-                self.m2.set_content(self.diverse_contents)
+        for d in diffs:
+            if type(d[0]) == type(None):
+                self.assertEqual(type(d[1]), pkg.actions.file.FileAction)
+            if type(d[1]) == type(None):
+                self.assertEqual(
+                    type(d[0]), pkg.actions.directory.DirectoryAction
+                )
 
-                diffs = self.m2.combined_difference(self.m1)
-                self.assertEqual(len(diffs), 0)
+        self.assertEqual(len(diffs), 2)
 
-                diffs = self.m1.combined_difference(self.m2)
-                self.assertEqual(len(diffs), 0)
+    def test_diffs7(self):
+        """ASSERT: changes in attributes are detected"""
 
-        def test_diffs4(self):
-                """ ASSERT: Building m' from diff(m, null) should yield m """
-
-                self.m2.set_content(self.m2_contents)
-                diffs = self.m2.combined_difference(manifest.null)
-
-                new_contents = ""
-                for d in diffs:
-                        new_contents += str(d[1]) + "\n"
-
-                mtmp = manifest.Manifest()
-                #print(new_contents)
-                mtmp.set_content(new_contents)
-
-                diffs = self.m2.combined_difference(mtmp)
-                self.assertEqual(len(diffs), 0)
-
-        def test_diffs5(self):
-                """ detect an attribute change """
-
-                self.m1.set_content(self.m4_contents)
-                self.m2.set_content(self.m5_contents)
-
-                #print(self.m2.display_differences(self.m1))
-
-                diffs = self.m2.combined_difference(self.m1)
-                self.assertEqual(len(diffs), 1)
-
-        def test_diffs6(self):
-                """ ASSERT: changes in action work """
-
-                self.m1.set_content(
-                    "dir mode=0755 owner=root group=sys path=/bin/foo")
-                self.m2.set_content(
-                    "file 12345 mode=0755 owner=root group=sys path=/bin")
-
-                diffs = self.m2.combined_difference(self.m1)
-                #
-                # Expect to see a directory going away, and a file being
-                # added
-                #
-                for d in diffs:
-                        if type(d[0]) == type(None):
-                                self.assertEqual(type(d[1]),
-                                    pkg.actions.file.FileAction)
-                        if type(d[1]) == type(None):
-                                self.assertEqual(type(d[0]),
-                                    pkg.actions.directory.DirectoryAction)
-
-                self.assertEqual(len(diffs), 2)
-
-        def test_diffs7(self):
-                """ ASSERT: changes in attributes are detected """
-
-                self.m1.set_content("""
+        self.m1.set_content(
+            """
             dir mode=0755 owner=root group=sys path=bin
             dir mode=0755 owner=root group=sys path=bin/foo
             file 00000000 mode=0644 owner=root group=sys path=a
             link path=bin/change-link target=change variant.opensolaris.zone=global
-                    """)
+                    """
+        )
 
-                self.m2.set_content("""
+        self.m2.set_content(
+            """
             dir mode=0755 owner=root group=sys path=bin
             dir mode=0555 owner=root group=sys path=bin/foo
             file 00000000 mode=0444 owner=root group=sys path=a
             link path=bin/change-link target=change variant.opensolaris.zone=nonglobal
-                    """)
+                    """
+        )
 
-                diffs = self.m2.combined_difference(self.m1)
-                #
-                # Expect to see a directory -> directory, file -> file, etc.
-                # 3 of the 4 things above should have changed.
-                #
-                self.assertEqual(len(diffs), 3)
-                for d in diffs:
-                        self.assertEqual(type(d[0]), type(d[1]))
+        diffs = self.m2.combined_difference(self.m1)
+        #
+        # Expect to see a directory -> directory, file -> file, etc.
+        # 3 of the 4 things above should have changed.
+        #
+        self.assertEqual(len(diffs), 3)
+        for d in diffs:
+            self.assertEqual(type(d[0]), type(d[1]))
 
+    def test_diffs8(self):
+        """ASSERT: changes in checksum are detected"""
 
-        def test_diffs8(self):
-                """ ASSERT: changes in checksum are detected """
-
-                self.m1.set_content("""
+        self.m1.set_content(
+            """
                     file 00000000 mode=0444 owner=root group=sys path=a
                     file 00000001 mode=0444 owner=root group=sys path=b
-                    """)
-                self.m2.set_content("""
+                    """
+        )
+        self.m2.set_content(
+            """
                     file 00000000 mode=0444 owner=root group=sys path=a
                     file 00000002 mode=0444 owner=root group=sys path=b
-                    """)
+                    """
+        )
 
-                diffs = self.m2.combined_difference(self.m1)
-                #
-                # Expect to see b change.
-                #
-                self.assertEqual(len(diffs), 1)
-                for d in diffs:
-                        self.assertEqual(type(d[0]), type(d[1]))
-                        self.assertEqual(d[0].attrs["path"], "b")
+        diffs = self.m2.combined_difference(self.m1)
+        #
+        # Expect to see b change.
+        #
+        self.assertEqual(len(diffs), 1)
+        for d in diffs:
+            self.assertEqual(type(d[0]), type(d[1]))
+            self.assertEqual(d[0].attrs["path"], "b")
 
-        def test_diffs9(self):
-                """ ASSERT: addition and removal are detected """
+    def test_diffs9(self):
+        """ASSERT: addition and removal are detected"""
 
-                self.m1.set_content(self.diverse_contents)
-                self.m2.set_content("")
+        self.m1.set_content(self.diverse_contents)
+        self.m2.set_content("")
 
-                diffs = self.m2.combined_difference(self.m1)
-                diffs2 = self.m1.combined_difference(self.m2)
+        diffs = self.m2.combined_difference(self.m1)
+        diffs2 = self.m1.combined_difference(self.m2)
 
-                #
-                # Expect to see something -> None differences
-                #
-                self.assertEqual(len(diffs), 10)
-                for d in diffs:
-                        self.assertEqual(type(d[1]), type(None))
+        #
+        # Expect to see something -> None differences
+        #
+        self.assertEqual(len(diffs), 10)
+        for d in diffs:
+            self.assertEqual(type(d[1]), type(None))
 
-                #
-                # Expect to see None -> something differences
-                #
-                self.assertEqual(len(diffs2), 10)
-                for d in diffs2:
-                        self.assertEqual(type(d[0]), type(None))
-                        self.assertNotEqual(type(d[1]), type(None))
+        #
+        # Expect to see None -> something differences
+        #
+        self.assertEqual(len(diffs2), 10)
+        for d in diffs2:
+            self.assertEqual(type(d[0]), type(None))
+            self.assertNotEqual(type(d[1]), type(None))
 
-        def test_diffs10(self):
-                """ ASSERT: changes in target are detected """
+    def test_diffs10(self):
+        """ASSERT: changes in target are detected"""
 
-                self.m1.set_content("""
+        self.m1.set_content(
+            """
                     link target=old path=a
                     hardlink target=old path=b
-                    """)
-                self.m2.set_content("""
+                    """
+        )
+        self.m2.set_content(
+            """
                     link target=new path=a
                     hardlink target=new path=b
-                    """)
+                    """
+        )
 
-                diffs = self.m2.combined_difference(self.m1)
-                #
-                # Expect to see differences in which "target" flips from "old"
-                # to "new"
-                #
-                self.assertEqual(len(diffs), 2)
-                for d in diffs:
-                        self.assertEqual(type(d[0]), type(d[1]))
-                        self.assertEqual(d[0].attrs["target"], "old")
-                        self.assertEqual(d[1].attrs["target"], "new")
+        diffs = self.m2.combined_difference(self.m1)
+        #
+        # Expect to see differences in which "target" flips from "old"
+        # to "new"
+        #
+        self.assertEqual(len(diffs), 2)
+        for d in diffs:
+            self.assertEqual(type(d[0]), type(d[1]))
+            self.assertEqual(d[0].attrs["target"], "old")
+            self.assertEqual(d[1].attrs["target"], "new")
 
+    def test_dups1(self):
+        """Test the duplicate search.  /bin shouldn't show up, since
+        they're identical actions, but /usr should show up three
+        times."""
 
-        def test_dups1(self):
-                """ Test the duplicate search.  /bin shouldn't show up, since
-                    they're identical actions, but /usr should show up three
-                    times."""
+        # XXX dp: "duplicates" is an odd name for this routine.
 
-                # XXX dp: "duplicates" is an odd name for this routine.
-
-                self.m1.set_content("""\
+        self.m1.set_content(
+            """\
 dir mode=0755 owner=root group=sys path=bin
 dir mode=0755 owner=root group=sys path=bin
 dir mode=0755 owner=root group=sys path=bin
 dir mode=0755 owner=root group=sys path=usr
 dir mode=0755 owner=root group=root path=usr
 dir mode=0755 owner=bin group=sys path=usr
-                        """)
+                        """
+        )
 
-                acount = 0
-                for kv, actions in self.m1.duplicates():
-                        self.assertEqual(kv, ('dir', 'usr'))
-                        for a in actions:
-                                acount += 1
-                                #print(" {0} {1}".format(kv, a))
-                self.assertEqual(acount, 3)
+        acount = 0
+        for kv, actions in self.m1.duplicates():
+            self.assertEqual(kv, ("dir", "usr"))
+            for a in actions:
+                acount += 1
+                # print(" {0} {1}".format(kv, a))
+        self.assertEqual(acount, 3)
 
-        def test_errors(self):
-                """Test that a variety of bogus manifests raise
-                InvalidPackageErrors.
-                """
-                self.assertRaises(api_errors.InvalidPackageErrors,
-                    self.m1.set_content, "foobar 1234 owner=root")
+    def test_errors(self):
+        """Test that a variety of bogus manifests raise
+        InvalidPackageErrors.
+        """
+        self.assertRaises(
+            api_errors.InvalidPackageErrors,
+            self.m1.set_content,
+            "foobar 1234 owner=root",
+        )
 
-                self.assertRaises(api_errors.InvalidPackageErrors,
-                    self.m1.set_content, "file 1234 path=foo bar")
+        self.assertRaises(
+            api_errors.InvalidPackageErrors,
+            self.m1.set_content,
+            "file 1234 path=foo bar",
+        )
 
-                self.assertRaises(api_errors.InvalidPackageErrors,
-                    self.m1.set_content, "file 1234 path=\"foo bar")
+        self.assertRaises(
+            api_errors.InvalidPackageErrors,
+            self.m1.set_content,
+            'file 1234 path="foo bar',
+        )
 
-                self.assertRaises(api_errors.InvalidPackageErrors,
-                    self.m1.set_content, "file 1234 =")
+        self.assertRaises(
+            api_errors.InvalidPackageErrors, self.m1.set_content, "file 1234 ="
+        )
 
-        def test_validate(self):
-                """Verifies that Manifest validation works as expected."""
+    def test_validate(self):
+        """Verifies that Manifest validation works as expected."""
 
-                self.m2.set_content(self.m2_contents, signatures=True)
-                self.m2.validate(signatures=self.m2_signatures)
+        self.m2.set_content(self.m2_contents, signatures=True)
+        self.m2.validate(signatures=self.m2_signatures)
 
-                self.m2.set_content(self.diverse_contents, signatures=True)
-                self.assertRaises(api_errors.BadManifestSignatures,
-                    self.m2.validate, signatures=self.m2_signatures)
+        self.m2.set_content(self.diverse_contents, signatures=True)
+        self.assertRaises(
+            api_errors.BadManifestSignatures,
+            self.m2.validate,
+            signatures=self.m2_signatures,
+        )
 
-                # Verify a manifest that has its content set using a byte string
-                # has the same signature as that of one set with a Unicode
-                # string when the content is the same.
-                bstr = "set name=pkg.summary:th value=\"ซอฟต์แวร์ \""
-                m1 = manifest.Manifest()
-                m1.set_content(bstr, signatures=True)
-                output1 = "".join(m1.as_lines())
+        # Verify a manifest that has its content set using a byte string
+        # has the same signature as that of one set with a Unicode
+        # string when the content is the same.
+        bstr = 'set name=pkg.summary:th value="ซอฟต์แวร์ "'
+        m1 = manifest.Manifest()
+        m1.set_content(bstr, signatures=True)
+        output1 = "".join(m1.as_lines())
 
-                m2 = manifest.Manifest()
-                if six.PY2:
-                        m2.set_content(six.text_type(bstr, "utf-8"), signatures=True)
-                else:
-                        m2.set_content(bstr, signatures=True)
-                output2 = "".join(m2.as_lines())
-                self.assertEqualDiff(output1, output2)
-                self.assertEqualDiff(m1.signatures, m2.signatures)
+        m2 = manifest.Manifest()
+        if six.PY2:
+            m2.set_content(six.text_type(bstr, "utf-8"), signatures=True)
+        else:
+            m2.set_content(bstr, signatures=True)
+        output2 = "".join(m2.as_lines())
+        self.assertEqualDiff(output1, output2)
+        self.assertEqualDiff(m1.signatures, m2.signatures)
 
 
 class TestFactoredManifest(pkg5unittest.Pkg5TestCase):
-
-        foo_content = """\
+    foo_content = """\
 set name=pkg.fmri value=pkg:/foo-content@1.0
 dir owner=root path=usr/bin group=bin mode=0755 variant.arch=i386
 dir owner=root path="opt/dir with spaces in value" group=bin mode=0755
@@ -435,172 +462,183 @@ dir owner=root path=fm group=bin mode=0755 facet.multi=true \\
     facet.multi=false
 """
 
-        def setUp(self):
-                pkg5unittest.Pkg5TestCase.setUp(self)
-                self.cache_dir = tempfile.mkdtemp(dir=self.test_root)
-                self.foo_content_p5m = self.make_misc_files(
-                    { "foo_content.p5m": self.foo_content })[0]
+    def setUp(self):
+        pkg5unittest.Pkg5TestCase.setUp(self)
+        self.cache_dir = tempfile.mkdtemp(dir=self.test_root)
+        self.foo_content_p5m = self.make_misc_files(
+            {"foo_content.p5m": self.foo_content}
+        )[0]
 
-        def test_cached_gen_actions_by_type(self):
-                """Test that when a factored manifest generates actions by type
-                from its cached source, it takes the excluded content into
-                account."""
+    def test_cached_gen_actions_by_type(self):
+        """Test that when a factored manifest generates actions by type
+        from its cached source, it takes the excluded content into
+        account."""
 
-                contents = """\
+        contents = """\
                     set name=pkg.fmri value=pkg:/bar@1
                     set name=variant.foo value=one value=two
                     dir path=one group=sys owner=root variant.foo=one
                     dir path=two group=sys owner=root variant.foo=two
                 """
-                m1 = manifest.FactoredManifest("bar@1", self.cache_dir,
-                    contents=contents)
-                self.assertEqual(len(list(m1.gen_actions_by_type("dir"))), 2)
-                v = variant.Variants({"variant.foo":"one"})
-                m1.exclude_content([v.allow_action, lambda x, publisher: True])
-                self.assertEqual(len(list(m1.gen_actions_by_type("dir"))), 1)
+        m1 = manifest.FactoredManifest(
+            "bar@1", self.cache_dir, contents=contents
+        )
+        self.assertEqual(len(list(m1.gen_actions_by_type("dir"))), 2)
+        v = variant.Variants({"variant.foo": "one"})
+        m1.exclude_content([v.allow_action, lambda x, publisher: True])
+        self.assertEqual(len(list(m1.gen_actions_by_type("dir"))), 1)
 
-        def test_store_to_disk(self):
-                """Verfies that a FactoredManifest gets force-loaded before it
-                gets stored to disk."""
+    def test_store_to_disk(self):
+        """Verfies that a FactoredManifest gets force-loaded before it
+        gets stored to disk."""
 
-                m1 = manifest.FactoredManifest("foo-content@1.0", self.cache_dir,
-                    pathname=self.foo_content_p5m)
+        m1 = manifest.FactoredManifest(
+            "foo-content@1.0", self.cache_dir, pathname=self.foo_content_p5m
+        )
 
-                tmpdir = tempfile.mkdtemp(dir=self.test_root)
-                path = os.path.join(tmpdir, "manifest.p5m")
-                m1.store(path)
-                self.assertEqual(misc.get_data_digest(path,
-                    hash_func=digest.DEFAULT_HASH_FUNC),
-                    misc.get_data_digest(self.foo_content_p5m,
-                    hash_func=digest.DEFAULT_HASH_FUNC))
+        tmpdir = tempfile.mkdtemp(dir=self.test_root)
+        path = os.path.join(tmpdir, "manifest.p5m")
+        m1.store(path)
+        self.assertEqual(
+            misc.get_data_digest(path, hash_func=digest.DEFAULT_HASH_FUNC),
+            misc.get_data_digest(
+                self.foo_content_p5m, hash_func=digest.DEFAULT_HASH_FUNC
+            ),
+        )
 
-        def test_get_directories(self):
-                """Verifies that get_directories() works as expected."""
+    def test_get_directories(self):
+        """Verifies that get_directories() works as expected."""
 
-                v = variant.Variants({ "variant.arch": "sparc" })
-                vexcludes = [v.allow_action, lambda x, publisher: True]
+        v = variant.Variants({"variant.arch": "sparc"})
+        vexcludes = [v.allow_action, lambda x, publisher: True]
 
-                f = facet.Facets({ "facet.test": False })
-                fexcludes = [lambda x, publisher: True, f.allow_action]
+        f = facet.Facets({"facet.test": False})
+        fexcludes = [lambda x, publisher: True, f.allow_action]
 
-                m1 = manifest.FactoredManifest("foo-content@1.0", self.cache_dir,
-                    pathname=self.foo_content_p5m)
+        m1 = manifest.FactoredManifest(
+            "foo-content@1.0", self.cache_dir, pathname=self.foo_content_p5m
+        )
 
-                all_expected = [
-                    "fdm",
-                    "fm",
-                    "vdo",
-                    "vo",
-                    "test",
-                    "opt/dir with spaces in value",
-                    "opt",
-                    "usr/bin",
-                    "opt/dir with whitespaces   in value",
-                    "usr"
-                ]
+        all_expected = [
+            "fdm",
+            "fm",
+            "vdo",
+            "vo",
+            "test",
+            "opt/dir with spaces in value",
+            "opt",
+            "usr/bin",
+            "opt/dir with whitespaces   in value",
+            "usr",
+        ]
 
-                var_expected = [
-                    "fdm",
-                    "fm",
-                    "opt/dir with spaces in value",
-                    "opt",
-                    "test"
-                ]
+        var_expected = [
+            "fdm",
+            "fm",
+            "opt/dir with spaces in value",
+            "opt",
+            "test",
+        ]
 
-                facet_expected = [
-                    "vdo",
-                    "vo",
-                    "opt/dir with spaces in value",
-                    "opt",
-                    "usr/bin",
-                    "opt/dir with whitespaces   in value",
-                    "usr"
-                ]
+        facet_expected = [
+            "vdo",
+            "vo",
+            "opt/dir with spaces in value",
+            "opt",
+            "usr/bin",
+            "opt/dir with whitespaces   in value",
+            "usr",
+        ]
 
-                def do_get_dirs():
-                        actual = m1.get_directories([])
-                        self.assertEqualDiff(sorted(all_expected), sorted(actual))
+        def do_get_dirs():
+            actual = m1.get_directories([])
+            self.assertEqualDiff(sorted(all_expected), sorted(actual))
 
-                        actual = m1.get_directories(vexcludes)
-                        self.assertEqualDiff(sorted(var_expected), sorted(actual))
+            actual = m1.get_directories(vexcludes)
+            self.assertEqualDiff(sorted(var_expected), sorted(actual))
 
-                        actual = m1.get_directories(fexcludes)
-                        self.assertEqualDiff(sorted(facet_expected), sorted(actual))
+            actual = m1.get_directories(fexcludes)
+            self.assertEqualDiff(sorted(facet_expected), sorted(actual))
 
-                # Verify get_directories works for initial load.
-                do_get_dirs()
+        # Verify get_directories works for initial load.
+        do_get_dirs()
 
-                # Now repeat experiment using "cached" FactoredManifest.
-                cfile_path = os.path.join(self.cache_dir, "manifest.dircache")
-                self.assertTrue(os.path.isfile(cfile_path))
-                m1 = manifest.FactoredManifest("foo-content@1.0", self.cache_dir,
-                    pathname=self.foo_content_p5m)
+        # Now repeat experiment using "cached" FactoredManifest.
+        cfile_path = os.path.join(self.cache_dir, "manifest.dircache")
+        self.assertTrue(os.path.isfile(cfile_path))
+        m1 = manifest.FactoredManifest(
+            "foo-content@1.0", self.cache_dir, pathname=self.foo_content_p5m
+        )
 
-                do_get_dirs()
+        do_get_dirs()
 
-                # Now rewrite the dircache so that it contains actions with
-                # paths that are not properly quoted to simulate older, broken
-                # behaviour and verify that the cache will be removed and that
-                # get_directories() still works as expected.
-                m1 = manifest.FactoredManifest("foo-content@1.0", self.cache_dir,
-                    pathname=self.foo_content_p5m)
+        # Now rewrite the dircache so that it contains actions with
+        # paths that are not properly quoted to simulate older, broken
+        # behaviour and verify that the cache will be removed and that
+        # get_directories() still works as expected.
+        m1 = manifest.FactoredManifest(
+            "foo-content@1.0", self.cache_dir, pathname=self.foo_content_p5m
+        )
 
-                with open(cfile_path, "w") as f:
-                        for a in m1.gen_actions_by_type("dir"):
-                                f.write(
-                                    "dir path={0} {1}\n".format(a.attrs["path"],
-                                        " ".join(
-                                            "{0}={1}".format(attr, a.attrs[attr])
-                                            for attr in itertools.chain(
-                                                *a.get_varcet_keys())
-                                        )
-                                ))
+        with open(cfile_path, "w") as f:
+            for a in m1.gen_actions_by_type("dir"):
+                f.write(
+                    "dir path={0} {1}\n".format(
+                        a.attrs["path"],
+                        " ".join(
+                            "{0}={1}".format(attr, a.attrs[attr])
+                            for attr in itertools.chain(*a.get_varcet_keys())
+                        ),
+                    )
+                )
 
-                # Repeat tests again.
-                do_get_dirs()
+        # Repeat tests again.
+        do_get_dirs()
 
-                # Verify cache file was removed (presumably because we
-                # detected it was malformed).
-                self.assertTrue(not os.path.exists(cfile_path))
+        # Verify cache file was removed (presumably because we
+        # detected it was malformed).
+        self.assertTrue(not os.path.exists(cfile_path))
 
-                # Repeat tests again, verifying cache file is recreated.
-                m1 = manifest.FactoredManifest("foo-content@1.0", self.cache_dir,
-                    pathname=self.foo_content_p5m)
-                do_get_dirs()
-                self.assertTrue(os.path.isfile(cfile_path))
+        # Repeat tests again, verifying cache file is recreated.
+        m1 = manifest.FactoredManifest(
+            "foo-content@1.0", self.cache_dir, pathname=self.foo_content_p5m
+        )
+        do_get_dirs()
+        self.assertTrue(os.path.isfile(cfile_path))
 
-        def test_clear_cache(self):
-                """Verify that FactoredManifest.clear_cache() works as
-                expected."""
+    def test_clear_cache(self):
+        """Verify that FactoredManifest.clear_cache() works as
+        expected."""
 
-                # Create FactoredManifest.
-                cache_dir = tempfile.mkdtemp(dir=self.test_root)
-                m1 = manifest.FactoredManifest("foo-content@1.0", cache_dir,
-                    pathname=self.foo_content_p5m)
+        # Create FactoredManifest.
+        cache_dir = tempfile.mkdtemp(dir=self.test_root)
+        m1 = manifest.FactoredManifest(
+            "foo-content@1.0", cache_dir, pathname=self.foo_content_p5m
+        )
 
-                # Verify cache was created.
-                cfile_path = os.path.join(cache_dir, "manifest.dircache")
-                self.assertTrue(os.path.isfile(cfile_path))
+        # Verify cache was created.
+        cfile_path = os.path.join(cache_dir, "manifest.dircache")
+        self.assertTrue(os.path.isfile(cfile_path))
 
-                # Create random file in cache_dir.
-                rfile_path = os.path.join(cache_dir, "junk")
-                self.make_file(rfile_path, "junk")
+        # Create random file in cache_dir.
+        rfile_path = os.path.join(cache_dir, "junk")
+        self.make_file(rfile_path, "junk")
 
-                # Verify that clear_cache() removes all known files from
-                # cache_dir and will not remove directory if unknown are
-                # present.
-                m1.clear_cache(cache_dir)
-                for name in os.listdir(cache_dir):
-                        self.assertEqualDiff(name, os.path.basename(rfile_path))
+        # Verify that clear_cache() removes all known files from
+        # cache_dir and will not remove directory if unknown are
+        # present.
+        m1.clear_cache(cache_dir)
+        for name in os.listdir(cache_dir):
+            self.assertEqualDiff(name, os.path.basename(rfile_path))
 
-                # Verify that clear_cache() removes cache_dir if empty.
-                portable.remove(rfile_path)
-                m1.clear_cache(cache_dir)
-                self.assertTrue(not os.path.exists(cache_dir))
+        # Verify that clear_cache() removes cache_dir if empty.
+        portable.remove(rfile_path)
+        m1.clear_cache(cache_dir)
+        self.assertTrue(not os.path.exists(cache_dir))
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_misc.py
+++ b/src/tests/api/t_misc.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import ctypes
@@ -43,92 +44,89 @@ import pkg.misc as misc
 import pkg.actions as action
 from pkg.actions.generic import Action
 
+
 class TestMisc(pkg5unittest.Pkg5TestCase):
+    def testMakedirs(self):
+        tmpdir = tempfile.mkdtemp()
+        # make the parent directory read-write
+        os.chmod(tmpdir, stat.S_IRWXU)
+        fpath = os.path.join(tmpdir, "f")
+        fopath = os.path.join(fpath, "o")
+        foopath = os.path.join(fopath, "o")
 
-        def testMakedirs(self):
-                tmpdir = tempfile.mkdtemp()
-                # make the parent directory read-write
-                os.chmod(tmpdir, stat.S_IRWXU)
-                fpath = os.path.join(tmpdir, "f")
-                fopath = os.path.join(fpath, "o")
-                foopath = os.path.join(fopath, "o")
+        # make the leaf, and ONLY the leaf read-only
+        act = action.fromstr("dir path={0}".format(foopath))
+        act.makedirs(foopath, mode=stat.S_IREAD)
 
-                # make the leaf, and ONLY the leaf read-only
-                act = action.fromstr("dir path={0}".format(foopath))
-                act.makedirs(foopath, mode = stat.S_IREAD)
+        # Now make sure the directories leading up the leaf
+        # are read-write, and the leaf is readonly.
+        assert os.stat(tmpdir).st_mode & (stat.S_IREAD | stat.S_IWRITE) != 0
+        assert os.stat(fpath).st_mode & (stat.S_IREAD | stat.S_IWRITE) != 0
+        assert os.stat(fopath).st_mode & (stat.S_IREAD | stat.S_IWRITE) != 0
+        assert os.stat(foopath).st_mode & stat.S_IREAD != 0
+        assert os.stat(foopath).st_mode & stat.S_IWRITE == 0
 
-                # Now make sure the directories leading up the leaf
-                # are read-write, and the leaf is readonly.
-                assert(os.stat(tmpdir).st_mode & (stat.S_IREAD | stat.S_IWRITE) != 0)
-                assert(os.stat(fpath).st_mode & (stat.S_IREAD | stat.S_IWRITE) != 0)
-                assert(os.stat(fopath).st_mode & (stat.S_IREAD | stat.S_IWRITE) != 0)
-                assert(os.stat(foopath).st_mode & stat.S_IREAD != 0)
-                assert(os.stat(foopath).st_mode & stat.S_IWRITE == 0)
+        # change it back to read/write so we can delete it
+        os.chmod(foopath, stat.S_IRWXU)
+        shutil.rmtree(tmpdir)
 
-                # change it back to read/write so we can delete it
-                os.chmod(foopath, stat.S_IRWXU)
-                shutil.rmtree(tmpdir)
+    def test_pub_prefix(self):
+        """Verify that misc.valid_pub_prefix returns True or False as
+        expected."""
 
-        def test_pub_prefix(self):
-                """Verify that misc.valid_pub_prefix returns True or False as
-                expected."""
+        self.assertFalse(misc.valid_pub_prefix(None))
+        self.assertFalse(misc.valid_pub_prefix(""))
+        self.assertFalse(misc.valid_pub_prefix("!@#$%^&*(*)"))
+        self.assertTrue(misc.valid_pub_prefix("a0bc.def-ghi"))
 
-                self.assertFalse(misc.valid_pub_prefix(None))
-                self.assertFalse(misc.valid_pub_prefix(""))
-                self.assertFalse(misc.valid_pub_prefix("!@#$%^&*(*)"))
-                self.assertTrue(misc.valid_pub_prefix(
-                    "a0bc.def-ghi"))
+    def test_pub_url(self):
+        """Verify that misc.valid_pub_url returns True or False as
+        expected."""
 
-        def test_pub_url(self):
-                """Verify that misc.valid_pub_url returns True or False as
-                expected."""
+        self.assertFalse(misc.valid_pub_url(None))
+        self.assertFalse(misc.valid_pub_url(""))
+        self.assertFalse(misc.valid_pub_url("!@#$%^&*(*)"))
+        self.assertTrue(misc.valid_pub_url("http://pkg.opensolaris.org/dev"))
 
-                self.assertFalse(misc.valid_pub_url(None))
-                self.assertFalse(misc.valid_pub_url(""))
-                self.assertFalse(misc.valid_pub_url("!@#$%^&*(*)"))
-                self.assertTrue(misc.valid_pub_url(
-                    "http://pkg.opensolaris.org/dev"))
+    def test_out_of_memory(self):
+        """Verify that misc.out_of_memory doesn't raise an exception
+        and displays the amount of memory that was in use."""
 
-        def test_out_of_memory(self):
-                """Verify that misc.out_of_memory doesn't raise an exception
-                and displays the amount of memory that was in use."""
+        self.assertRegexp(misc.out_of_memory(), "virtual memory was in use")
 
-                self.assertRegexp(misc.out_of_memory(),
-                    "virtual memory was in use")
+    def test_psinfo(self):
+        """Verify that psinfo gets us some reasonable data."""
 
-        def test_psinfo(self):
-                """Verify that psinfo gets us some reasonable data."""
+        psinfo = misc.ProcFS.psinfo()
 
-                psinfo = misc.ProcFS.psinfo()
+        # verify pids
+        self.assertEqual(psinfo.pr_pid, os.getpid())
+        self.assertEqual(psinfo.pr_ppid, os.getppid())
 
-                # verify pids
-                self.assertEqual(psinfo.pr_pid, os.getpid())
-                self.assertEqual(psinfo.pr_ppid, os.getppid())
+        # verify user/group ids
+        self.assertEqual(psinfo.pr_uid, os.getuid())
+        self.assertEqual(psinfo.pr_euid, os.geteuid())
+        self.assertEqual(psinfo.pr_gid, os.getgid())
+        self.assertEqual(psinfo.pr_egid, os.getegid())
 
-                # verify user/group ids
-                self.assertEqual(psinfo.pr_uid, os.getuid())
-                self.assertEqual(psinfo.pr_euid, os.geteuid())
-                self.assertEqual(psinfo.pr_gid, os.getgid())
-                self.assertEqual(psinfo.pr_egid, os.getegid())
+        # verify zoneid (it's near the end of the structure so if it
+        # is right then we likely got most the stuff inbetween decoded
+        # correctly).
+        libc = ctypes.CDLL("libc.so")
+        self.assertEqual(psinfo.pr_zoneid, libc.getzoneid())
 
-                # verify zoneid (it's near the end of the structure so if it
-                # is right then we likely got most the stuff inbetween decoded
-                # correctly).
-                libc = ctypes.CDLL('libc.so')
-                self.assertEqual(psinfo.pr_zoneid, libc.getzoneid())
+    def test_memory_limit(self):
+        """Verify that set_memory_limit works."""
 
-        def test_memory_limit(self):
-                """Verify that set_memory_limit works."""
+        # memory limit to test, keep small to avoid test slowdown
+        mem_cap = 100 * 1024 * 1024
+        # measured process resources. Note, that we have a static
+        # overhead in waste.py for the forking of ps, so while 20M seems
+        # large compared to a 100M limit, in a real world example with
+        # 8G limit it's fairly small.
+        mem_tol = 20 * 1024 * 1024
 
-                # memory limit to test, keep small to avoid test slowdown
-                mem_cap = 100 * 1024 * 1024
-                # measured process resources. Note, that we have a static
-                # overhead in waste.py for the forking of ps, so while 20M seems
-                # large compared to a 100M limit, in a real world example with
-                # 8G limit it's fairly small.
-                mem_tol = 20 * 1024 * 1024
-
-                waste_mem_py = """
+        waste_mem_py = """
 import os
 import resource
 import subprocess
@@ -147,60 +145,67 @@ except MemoryError:
         misc.set_memory_limit({0} * 3, allow_override=False)
         print(subprocess.check_output(['ps', '-o', 'rss=', '-p',
             str(os.getpid())], universal_newlines=True).strip())
-""".format(str(mem_cap))
+""".format(
+            str(mem_cap)
+        )
 
-                # Re-setting limits which are higher than original limit can
-                # only be done by root.
-                self.assertTrue(os.geteuid() == 0,
-                    "must be root to run this test")
+        # Re-setting limits which are higher than original limit can
+        # only be done by root.
+        self.assertTrue(os.geteuid() == 0, "must be root to run this test")
 
-                tmpdir = tempfile.mkdtemp(dir=self.test_root)
-                tmpfile = os.path.join(tmpdir, 'waste.py')
-                with open(tmpfile, 'w') as f:
-                        f.write(waste_mem_py)
+        tmpdir = tempfile.mkdtemp(dir=self.test_root)
+        tmpfile = os.path.join(tmpdir, "waste.py")
+        with open(tmpfile, "w") as f:
+            f.write(waste_mem_py)
 
-                pyv = '.'.join(platform.python_version_tuple()[:2])
+        pyv = ".".join(platform.python_version_tuple()[:2])
 
-                res = int(subprocess.check_output([f'python{pyv}', tmpfile]))
-                # convert from kB to bytes
-                res *= 1024
+        res = int(subprocess.check_output([f"python{pyv}", tmpfile]))
+        # convert from kB to bytes
+        res *= 1024
 
-                self.debug("mem_cap:   " + str(mem_cap))
-                self.debug("proc size: " + str(res))
+        self.debug("mem_cap:   " + str(mem_cap))
+        self.debug("proc size: " + str(res))
 
-                self.assertTrue(res < mem_cap + mem_tol,
-                    "process mem consumption too high")
-                self.assertTrue(res > mem_cap - mem_tol,
-                    "process mem consumption too low")
+        self.assertTrue(
+            res < mem_cap + mem_tol, "process mem consumption too high"
+        )
+        self.assertTrue(
+            res > mem_cap - mem_tol, "process mem consumption too low"
+        )
 
-                # test if env var works
-                os.environ["PKG_CLIENT_MAX_PROCESS_SIZE"] = str(mem_cap * 2)
-                res = int(subprocess.check_output([f'python{pyv}', tmpfile]))
-                res *= 1024
+        # test if env var works
+        os.environ["PKG_CLIENT_MAX_PROCESS_SIZE"] = str(mem_cap * 2)
+        res = int(subprocess.check_output([f"python{pyv}", tmpfile]))
+        res *= 1024
 
-                self.debug("mem_cap:   " + str(mem_cap))
-                self.debug("proc size: " + str(res))
+        self.debug("mem_cap:   " + str(mem_cap))
+        self.debug("proc size: " + str(res))
 
-                self.assertTrue(res < mem_cap * 2 + mem_tol,
-                    "process mem consumption too high")
-                #self.assertTrue(res > mem_cap * 2 - mem_tol,
-                #    "process mem consumption too low")
+        self.assertTrue(
+            res < mem_cap * 2 + mem_tol, "process mem consumption too high"
+        )
+        # self.assertTrue(res > mem_cap * 2 - mem_tol,
+        #    "process mem consumption too low")
 
-                # test if invalid env var is handled correctly
-                os.environ["PKG_CLIENT_MAX_PROCESS_SIZE"] = "octopus"
-                res = int(subprocess.check_output([f'python{pyv}', tmpfile]))
-                res *= 1024
+        # test if invalid env var is handled correctly
+        os.environ["PKG_CLIENT_MAX_PROCESS_SIZE"] = "octopus"
+        res = int(subprocess.check_output([f"python{pyv}", tmpfile]))
+        res *= 1024
 
-                self.debug("mem_cap:   " + str(mem_cap))
-                self.debug("proc size: " + str(res))
+        self.debug("mem_cap:   " + str(mem_cap))
+        self.debug("proc size: " + str(res))
 
-                self.assertTrue(res < mem_cap + mem_tol,
-                    "process mem consumption too high")
-                self.assertTrue(res > mem_cap - mem_tol,
-                    "process mem consumption too low")
+        self.assertTrue(
+            res < mem_cap + mem_tol, "process mem consumption too high"
+        )
+        self.assertTrue(
+            res > mem_cap - mem_tol, "process mem consumption too low"
+        )
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_p5i.py
+++ b/src/tests/api/t_p5i.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -45,15 +46,16 @@ from six.moves import cStringIO
 from six.moves.urllib.parse import urlparse, urlunparse
 from six.moves.urllib.request import pathname2url
 
-class TestP5I(pkg5unittest.Pkg5TestCase):
-        """Class to test the functionality of the pkg.p5i module."""
 
-        #
-        # Whitespace (or lack thereof) at the ends of some lines in the below is
-        # significant. It's also a function of which json version you're
-        # running/using.
-        #
-        p5i_bobcat = """{
+class TestP5I(pkg5unittest.Pkg5TestCase):
+    """Class to test the functionality of the pkg.p5i module."""
+
+    #
+    # Whitespace (or lack thereof) at the ends of some lines in the below is
+    # significant. It's also a function of which json version you're
+    # running/using.
+    #
+    p5i_bobcat = """{
   "packages": [
     "pkg:/bar@1.0,5.11-0",
     "baz"
@@ -88,132 +90,136 @@ class TestP5I(pkg5unittest.Pkg5TestCase):
 }
 """
 
-        misc_files = [ "libc.so.1" ]
+    misc_files = ["libc.so.1"]
 
-        def setUp(self):
-                pkg5unittest.Pkg5TestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.Pkg5TestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-        def __get_bobcat_pub(self, omit_repo=False):
-                # First build a publisher object matching our expected data.
-                repo = None
-                if not omit_repo:
-                        repo = publisher.Repository(description="xkcd.net/325",
-                            legal_uris=["http://xkcd.com/license.html"],
-                            name="source", origins=["http://localhost:12001/"],
-                            refresh_seconds=43200)
-                pub = publisher.Publisher("bobcat", alias="cat",
-                    repository=repo)
+    def __get_bobcat_pub(self, omit_repo=False):
+        # First build a publisher object matching our expected data.
+        repo = None
+        if not omit_repo:
+            repo = publisher.Repository(
+                description="xkcd.net/325",
+                legal_uris=["http://xkcd.com/license.html"],
+                name="source",
+                origins=["http://localhost:12001/"],
+                refresh_seconds=43200,
+            )
+        pub = publisher.Publisher("bobcat", alias="cat", repository=repo)
 
-                return pub
+        return pub
 
-        def test_parse_write(self):
-                """Verify that the p5i parsing and writing works as expected."""
+    def test_parse_write(self):
+        """Verify that the p5i parsing and writing works as expected."""
 
-                # Verify that p5i export and parse works as expected.
-                pub = self.__get_bobcat_pub()
+        # Verify that p5i export and parse works as expected.
+        pub = self.__get_bobcat_pub()
 
-                # First, Ensure that PkgFmri and strings are supported properly.
-                # Build a simple list of packages.
-                fmri_foo = fmri.PkgFmri("pkg:/foo@1.0,5.11-0")
-                pnames = {
-                    "bobcat": [fmri_foo],
-                    "": ["pkg:/bar@1.0,5.11-0", "baz"],
-                }
+        # First, Ensure that PkgFmri and strings are supported properly.
+        # Build a simple list of packages.
+        fmri_foo = fmri.PkgFmri("pkg:/foo@1.0,5.11-0")
+        pnames = {
+            "bobcat": [fmri_foo],
+            "": ["pkg:/bar@1.0,5.11-0", "baz"],
+        }
 
-                # Dump the p5i data.
-                fobj = cStringIO()
-                p5i.write(fobj, [pub], pkg_names=pnames)
+        # Dump the p5i data.
+        fobj = cStringIO()
+        p5i.write(fobj, [pub], pkg_names=pnames)
 
-                # Verify that the p5i data ends with a terminating newline.
-                # In Python 3, StringIO doesn't support non-zero relative seek.
-                fobj.seek(0, os.SEEK_END)
-                fobj.seek(fobj.tell() - 1)
-                self.assertEqual(fobj.read(), "\n")
+        # Verify that the p5i data ends with a terminating newline.
+        # In Python 3, StringIO doesn't support non-zero relative seek.
+        fobj.seek(0, os.SEEK_END)
+        fobj.seek(fobj.tell() - 1)
+        self.assertEqual(fobj.read(), "\n")
 
-                # Verify that output matches expected output.
-                fobj.seek(0)
-                output = fobj.read()
-                self.assertEqualJSON(self.p5i_bobcat, output)
+        # Verify that output matches expected output.
+        fobj.seek(0)
+        output = fobj.read()
+        self.assertEqualJSON(self.p5i_bobcat, output)
 
-                def validate_results(results):
-                        # First result should be 'bobcat' publisher and its
-                        # pkg_names.
-                        pub, pkg_names = results[0]
+        def validate_results(results):
+            # First result should be 'bobcat' publisher and its
+            # pkg_names.
+            pub, pkg_names = results[0]
 
-                        self.assertEqual(pub.prefix, "bobcat")
-                        self.assertEqual(pub.alias, "cat")
-                        repo = pub.repository
-                        self.assertEqual(repo.name, "source")
-                        self.assertEqual(repo.description, "xkcd.net/325")
-                        self.assertEqual(repo.legal_uris[0],
-                            "http://xkcd.com/license.html")
-                        self.assertEqual(repo.refresh_seconds, 43200)
-                        self.assertEqual(pkg_names, [str(fmri_foo)])
+            self.assertEqual(pub.prefix, "bobcat")
+            self.assertEqual(pub.alias, "cat")
+            repo = pub.repository
+            self.assertEqual(repo.name, "source")
+            self.assertEqual(repo.description, "xkcd.net/325")
+            self.assertEqual(repo.legal_uris[0], "http://xkcd.com/license.html")
+            self.assertEqual(repo.refresh_seconds, 43200)
+            self.assertEqual(pkg_names, [str(fmri_foo)])
 
-                        # Last result should be no publisher and a list of
-                        # pkg_names.
-                        pub, pkg_names = results[1]
-                        self.assertEqual(pub, None)
-                        self.assertEqual(pkg_names, ["pkg:/bar@1.0,5.11-0",
-                            "baz"])
+            # Last result should be no publisher and a list of
+            # pkg_names.
+            pub, pkg_names = results[1]
+            self.assertEqual(pub, None)
+            self.assertEqual(pkg_names, ["pkg:/bar@1.0,5.11-0", "baz"])
 
-                # Verify that parse returns the expected object and information
-                # when provided a fileobj.
-                fobj.seek(0)
-                validate_results(p5i.parse(fileobj=fobj))
+        # Verify that parse returns the expected object and information
+        # when provided a fileobj.
+        fobj.seek(0)
+        validate_results(p5i.parse(fileobj=fobj))
 
-                # Verify that parse returns the expected object and information
-                # when provided a file path.
-                fobj.seek(0)
-                (fd1, path1) = tempfile.mkstemp(dir=self.test_root)
-                # tempfile.mkstemp open the file in binary mode
-                os.write(fd1, misc.force_bytes(fobj.read()))
-                os.close(fd1)
-                validate_results(p5i.parse(location=path1))
+        # Verify that parse returns the expected object and information
+        # when provided a file path.
+        fobj.seek(0)
+        (fd1, path1) = tempfile.mkstemp(dir=self.test_root)
+        # tempfile.mkstemp open the file in binary mode
+        os.write(fd1, misc.force_bytes(fobj.read()))
+        os.close(fd1)
+        validate_results(p5i.parse(location=path1))
 
-                # Verify that parse returns the expected object and information
-                # when provided a file URI.
-                location = os.path.abspath(path1)
-                location = urlunparse(("file", "",
-                    pathname2url(location), "", "", ""))
-                validate_results(p5i.parse(location=location))
-                fobj.close()
-                fobj = None
+        # Verify that parse returns the expected object and information
+        # when provided a file URI.
+        location = os.path.abspath(path1)
+        location = urlunparse(("file", "", pathname2url(location), "", "", ""))
+        validate_results(p5i.parse(location=location))
+        fobj.close()
+        fobj = None
 
-                # Verify that appropriate exceptions are raised for p5i
-                # information that can't be retrieved (doesn't exist).
-                nefpath = os.path.join(self.test_root, "non-existent")
-                self.assertRaises(api_errors.RetrievalError,
-                    p5i.parse, location="file://{0}".format(nefpath))
+        # Verify that appropriate exceptions are raised for p5i
+        # information that can't be retrieved (doesn't exist).
+        nefpath = os.path.join(self.test_root, "non-existent")
+        self.assertRaises(
+            api_errors.RetrievalError,
+            p5i.parse,
+            location="file://{0}".format(nefpath),
+        )
 
-                self.assertRaises(api_errors.RetrievalError,
-                    p5i.parse, location=nefpath)
+        self.assertRaises(
+            api_errors.RetrievalError, p5i.parse, location=nefpath
+        )
 
-                # Verify that appropriate exceptions are raised for invalid
-                # p5i information.
-                lcpath = os.path.join(self.test_root, "libc.so.1")
-                location = os.path.abspath(lcpath)
-                location = urlunparse(("file", "",
-                    pathname2url(location), "", "", ""))
+        # Verify that appropriate exceptions are raised for invalid
+        # p5i information.
+        lcpath = os.path.join(self.test_root, "libc.so.1")
+        location = os.path.abspath(lcpath)
+        location = urlunparse(("file", "", pathname2url(location), "", "", ""))
 
-                # First, test as a file:// URI.
-                self.assertRaises(api_errors.InvalidP5IFile, p5i.parse,
-                    location=location)
+        # First, test as a file:// URI.
+        self.assertRaises(
+            api_errors.InvalidP5IFile, p5i.parse, location=location
+        )
 
-                # Last, test as a pathname.
-                self.assertRaises(api_errors.InvalidP5IFile, p5i.parse,
-                    location=location)
+        # Last, test as a pathname.
+        self.assertRaises(
+            api_errors.InvalidP5IFile, p5i.parse, location=location
+        )
 
-        def test_parse_write_partial(self):
-                """Verify that a p5i file with various parts of a publisher's
-                repository configuration omitted will still parse and write
-                as expected."""
+    def test_parse_write_partial(self):
+        """Verify that a p5i file with various parts of a publisher's
+        repository configuration omitted will still parse and write
+        as expected."""
 
-                # First, test the no repository case.
-                # NOTE:        Spaces, or lack thereof, at the end of a line, are
-                #        important.
-                expected = """{
+        # First, test the no repository case.
+        # NOTE:        Spaces, or lack thereof, at the end of a line, are
+        #        important.
+        expected = """{
   "packages": [],
   "publishers": [
     {
@@ -227,26 +233,26 @@ class TestP5I(pkg5unittest.Pkg5TestCase):
 }
 """
 
-                pub = self.__get_bobcat_pub(omit_repo=True)
+        pub = self.__get_bobcat_pub(omit_repo=True)
 
-                # Dump the p5i data.
-                fobj = cStringIO()
-                p5i.write(fobj, [pub])
+        # Dump the p5i data.
+        fobj = cStringIO()
+        p5i.write(fobj, [pub])
 
-                # Verify that output matches expected output.
-                fobj.seek(0)
-                output = fobj.read()
-                self.assertEqualJSON(expected, output)
+        # Verify that output matches expected output.
+        fobj.seek(0)
+        output = fobj.read()
+        self.assertEqualJSON(expected, output)
 
-                # Now parse the result and verify no repositories are defined.
-                pub, pkg_names = p5i.parse(data=output)[0]
-                self.assertTrue(not pub.repository)
+        # Now parse the result and verify no repositories are defined.
+        pub, pkg_names = p5i.parse(data=output)[0]
+        self.assertTrue(not pub.repository)
 
-                # Next, test the partial repository configuration case.  No
-                # origin is provided, but everything else is.
-                # NOTE:        Spaces, or lack thereof, at the end of a line, are
-                #        important.
-                expected = """{
+        # Next, test the partial repository configuration case.  No
+        # origin is provided, but everything else is.
+        # NOTE:        Spaces, or lack thereof, at the end of a line, are
+        #        important.
+        expected = """{
   "packages": [],
   "publishers": [
     {
@@ -273,28 +279,28 @@ class TestP5I(pkg5unittest.Pkg5TestCase):
   "version": 1
 }
 """
-                pub = self.__get_bobcat_pub()
+        pub = self.__get_bobcat_pub()
 
-                # Nuke the origin data.
-                pub.repository.reset_origins()
+        # Nuke the origin data.
+        pub.repository.reset_origins()
 
-                # Dump the p5i data.
-                fobj = cStringIO()
-                p5i.write(fobj, [pub])
+        # Dump the p5i data.
+        fobj = cStringIO()
+        p5i.write(fobj, [pub])
 
-                # Verify that output matches expected output.
-                fobj.seek(0)
-                output = fobj.read()
-                self.assertEqualJSON(expected, output)
+        # Verify that output matches expected output.
+        fobj.seek(0)
+        output = fobj.read()
+        self.assertEqualJSON(expected, output)
 
-                # Now parse the result and verify that there is a repository,
-                # but without origins information.
-                pub, pkg_names = p5i.parse(data=output)[0]
-                self.assertEqualDiff([], pub.repository.origins)
+        # Now parse the result and verify that there is a repository,
+        # but without origins information.
+        pub, pkg_names = p5i.parse(data=output)[0]
+        self.assertEqualDiff([], pub.repository.origins)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_p5p.py
+++ b/src/tests/api/t_p5p.py
@@ -26,8 +26,9 @@
 
 from __future__ import division
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -50,14 +51,14 @@ import tempfile
 
 
 class TestP5P(pkg5unittest.SingleDepotTestCase):
-        """Class to test the functionality of the pkg.p5p module."""
+    """Class to test the functionality of the pkg.p5p module."""
 
-        # Don't recreate repository and publish packages for every test.
-        persistent_setup = True
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Don't recreate repository and publish packages for every test.
+    persistent_setup = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        pkgs = """
+    pkgs = """
             open pkg://test/foo@1.0
             add set name=pkg.summary value="Example package foo."
             add dir mode=0755 owner=root group=bin path=lib
@@ -88,941 +89,993 @@ class TestP5P(pkg5unittest.SingleDepotTestCase):
             add file tmp/quux mode=0755 owner=root group=bin path=usr/bin/quux
             close """
 
-        misc_files = ["tmp/foo", "tmp/libfoo.so.1", "tmp/foo.1", "tmp/README",
-            "tmp/LICENSE", "tmp/quux"]
+    misc_files = [
+        "tmp/foo",
+        "tmp/libfoo.so.1",
+        "tmp/foo.1",
+        "tmp/README",
+        "tmp/LICENSE",
+        "tmp/quux",
+    ]
 
-        def seed_ta_dir(self, certs, dest_dir=None):
-                if isinstance(certs, six.string_types):
-                        certs = [certs]
-                if not dest_dir:
-                        dest_dir = self.ta_dir
-                self.assertTrue(dest_dir)
-                self.assertTrue(self.raw_trust_anchor_dir)
-                for c in certs:
-                        name = "{0}_cert.pem".format(c)
-                        portable.copyfile(
-                            os.path.join(self.raw_trust_anchor_dir, name),
-                            os.path.join(dest_dir, name))
+    def seed_ta_dir(self, certs, dest_dir=None):
+        if isinstance(certs, six.string_types):
+            certs = [certs]
+        if not dest_dir:
+            dest_dir = self.ta_dir
+        self.assertTrue(dest_dir)
+        self.assertTrue(self.raw_trust_anchor_dir)
+        for c in certs:
+            name = "{0}_cert.pem".format(c)
+            portable.copyfile(
+                os.path.join(self.raw_trust_anchor_dir, name),
+                os.path.join(dest_dir, name),
+            )
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-                # Publish packages needed for tests.
-                plist = self.pkgsend_bulk(self.rurl, self.pkgs)
+        # Publish packages needed for tests.
+        plist = self.pkgsend_bulk(self.rurl, self.pkgs)
 
-                # Stash published package FMRIs away for easy access by tests.
-                self.foo = pkg.fmri.PkgFmri(plist[0])
-                self.signed = pkg.fmri.PkgFmri(plist[1])
-                self.quux = pkg.fmri.PkgFmri(plist[2])
+        # Stash published package FMRIs away for easy access by tests.
+        self.foo = pkg.fmri.PkgFmri(plist[0])
+        self.signed = pkg.fmri.PkgFmri(plist[1])
+        self.quux = pkg.fmri.PkgFmri(plist[2])
 
-                # Sign the 'signed' package.
-                r = self.get_repo(self.dcs[1].get_repodir())
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} -i {i6} {pkg}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                    cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                    i1=os.path.join(self.chain_certs_dir,
-                        "ch1_ta1_cert.pem"),
-                    i2=os.path.join(self.chain_certs_dir,
-                        "ch2_ta1_cert.pem"),
-                    i3=os.path.join(self.chain_certs_dir,
-                        "ch3_ta1_cert.pem"),
-                    i4=os.path.join(self.chain_certs_dir,
-                        "ch4_ta1_cert.pem"),
-                    i5=os.path.join(self.chain_certs_dir,
-                        "ch5_ta1_cert.pem"),
-                    i6=os.path.join(self.chain_certs_dir,
-                        "ch1_ta3_cert.pem"),
-                    pkg=self.signed
-                )
-                self.pkgsign(self.rurl, sign_args)
+        # Sign the 'signed' package.
+        r = self.get_repo(self.dcs[1].get_repodir())
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} -i {i6} {pkg}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                i1=os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
+                i2=os.path.join(self.chain_certs_dir, "ch2_ta1_cert.pem"),
+                i3=os.path.join(self.chain_certs_dir, "ch3_ta1_cert.pem"),
+                i4=os.path.join(self.chain_certs_dir, "ch4_ta1_cert.pem"),
+                i5=os.path.join(self.chain_certs_dir, "ch5_ta1_cert.pem"),
+                i6=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+                pkg=self.signed,
+            )
+        )
+        self.pkgsign(self.rurl, sign_args)
 
-                # This is just a test assertion to verify that the package
-                # was signed as expected.
-                self.image_create(self.rurl)
-                self.seed_ta_dir("ta1")
-                self.pkg("set-property signature-policy verify")
-                self.pkg("install signed")
-                self.image_destroy()
+        # This is just a test assertion to verify that the package
+        # was signed as expected.
+        self.image_create(self.rurl)
+        self.seed_ta_dir("ta1")
+        self.pkg("set-property signature-policy verify")
+        self.pkg("install signed")
+        self.image_destroy()
 
-                # Expected list of archive members for archive containing foo.
-                self.foo_expected = [
-                    "pkg5.index.0.gz",
-                    "publisher",
-                    "publisher/test",
-                    "publisher/test/pkg",
-                    "publisher/test/pkg/foo",
-                    "publisher/test/pkg/{0}".format(self.foo.get_dir_path()),
-                    "publisher/test/file",
-                    "publisher/test/file/b2",
-                    "publisher/test/file/b2/b265f2ec87c4a55eb2b6b4c926e7c65f7247a27e",
-                    "publisher/test/file/a2",
-                    "publisher/test/file/a2/a285ada5f3cae14ea00e97a8d99bd3e357cb0dca",
-                    "publisher/test/file/0a",
-                    "publisher/test/file/0a/0acf1107d31f3bab406f8611b21b8fade78ac874",
-                    "publisher/test/file/dc",
-                    "publisher/test/file/dc/dc84bd4b606fe43fc892eb245d9602b67f8cba38",
-                    "pkg5.repository",
-                ]
+        # Expected list of archive members for archive containing foo.
+        self.foo_expected = [
+            "pkg5.index.0.gz",
+            "publisher",
+            "publisher/test",
+            "publisher/test/pkg",
+            "publisher/test/pkg/foo",
+            "publisher/test/pkg/{0}".format(self.foo.get_dir_path()),
+            "publisher/test/file",
+            "publisher/test/file/b2",
+            "publisher/test/file/b2/b265f2ec87c4a55eb2b6b4c926e7c65f7247a27e",
+            "publisher/test/file/a2",
+            "publisher/test/file/a2/a285ada5f3cae14ea00e97a8d99bd3e357cb0dca",
+            "publisher/test/file/0a",
+            "publisher/test/file/0a/0acf1107d31f3bab406f8611b21b8fade78ac874",
+            "publisher/test/file/dc",
+            "publisher/test/file/dc/dc84bd4b606fe43fc892eb245d9602b67f8cba38",
+            "pkg5.repository",
+        ]
 
-                # Expected list of archive members for archive containing foo
-                # and quux (sorted).
-                self.multi_expected = [
-                    "pkg5.index.0.gz",
-                    "pkg5.repository",
-                    "publisher",
-                    "publisher/test",
-                    "publisher/test/file",
-                    "publisher/test/file/0a",
-                    "publisher/test/file/0a/0acf1107d31f3bab406f8611b21b8fade78ac874",
-                    "publisher/test/file/a2",
-                    "publisher/test/file/a2/a285ada5f3cae14ea00e97a8d99bd3e357cb0dca",
-                    "publisher/test/file/b2",
-                    "publisher/test/file/b2/b265f2ec87c4a55eb2b6b4c926e7c65f7247a27e",
-                    "publisher/test/file/dc",
-                    "publisher/test/file/dc/dc84bd4b606fe43fc892eb245d9602b67f8cba38",
-                    "publisher/test/pkg",
-                    "publisher/test/pkg/foo",
-                    "publisher/test/pkg/{0}".format(self.foo.get_dir_path()),
-                    "publisher/test/pkg/signed",
-                    "publisher/test/pkg/{0}".format(self.signed.get_dir_path()),
-                    "publisher/test2",
-                    "publisher/test2/file",
-                    "publisher/test2/file/80",
-                    "publisher/test2/file/80/801eebbfe8c526bf092d98741d4228e4d0fc99ae",
-                    "publisher/test2/pkg",
-                    "publisher/test2/pkg/quux",
-                    "publisher/test2/pkg/{0}".format(self.quux.get_dir_path()),
-                ]
+        # Expected list of archive members for archive containing foo
+        # and quux (sorted).
+        self.multi_expected = [
+            "pkg5.index.0.gz",
+            "pkg5.repository",
+            "publisher",
+            "publisher/test",
+            "publisher/test/file",
+            "publisher/test/file/0a",
+            "publisher/test/file/0a/0acf1107d31f3bab406f8611b21b8fade78ac874",
+            "publisher/test/file/a2",
+            "publisher/test/file/a2/a285ada5f3cae14ea00e97a8d99bd3e357cb0dca",
+            "publisher/test/file/b2",
+            "publisher/test/file/b2/b265f2ec87c4a55eb2b6b4c926e7c65f7247a27e",
+            "publisher/test/file/dc",
+            "publisher/test/file/dc/dc84bd4b606fe43fc892eb245d9602b67f8cba38",
+            "publisher/test/pkg",
+            "publisher/test/pkg/foo",
+            "publisher/test/pkg/{0}".format(self.foo.get_dir_path()),
+            "publisher/test/pkg/signed",
+            "publisher/test/pkg/{0}".format(self.signed.get_dir_path()),
+            "publisher/test2",
+            "publisher/test2/file",
+            "publisher/test2/file/80",
+            "publisher/test2/file/80/801eebbfe8c526bf092d98741d4228e4d0fc99ae",
+            "publisher/test2/pkg",
+            "publisher/test2/pkg/quux",
+            "publisher/test2/pkg/{0}".format(self.quux.get_dir_path()),
+        ]
 
-        def test_00_create(self):
-                """Verify that archive creation works as expected."""
+    def test_00_create(self):
+        """Verify that archive creation works as expected."""
 
-                # Verify that an empty package archive can be created and that
-                # the resulting archive is of the correct type.
-                arc_path = os.path.join(self.test_root, "empty.p5p")
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                self.assertEqual(arc.pathname, arc_path)
-                arc.close()
+        # Verify that an empty package archive can be created and that
+        # the resulting archive is of the correct type.
+        arc_path = os.path.join(self.test_root, "empty.p5p")
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        self.assertEqual(arc.pathname, arc_path)
+        arc.close()
 
-                # Verify archive exists and use the tarfile module to read the
-                # archive so that the implementation can be verified.
-                assert os.path.exists(arc_path)
-                arc = ptf.PkgTarFile(name=arc_path, mode="r")
-                fm = arc.firstmember
-                self.assertEqual(fm.name, "pkg5.index.0.gz")
-                comment = fm.pax_headers.get("comment", "")
+        # Verify archive exists and use the tarfile module to read the
+        # archive so that the implementation can be verified.
+        assert os.path.exists(arc_path)
+        arc = ptf.PkgTarFile(name=arc_path, mode="r")
+        fm = arc.firstmember
+        self.assertEqual(fm.name, "pkg5.index.0.gz")
+        comment = fm.pax_headers.get("comment", "")
+        self.assertEqual(comment, "pkg5.archive.version.0")
+
+        # Verify basic expected content exists.
+        expected = ["pkg5.index.0.gz", "publisher", "pkg5.repository"]
+        actual = [m.name for m in arc.getmembers()]
+        self.assertEqualDiff(expected, actual)
+
+        # Destroy the archive.
+        os.unlink(arc_path)
+
+    def test_01_add(self):
+        """Verify that add() works as expected."""
+
+        # Prep the archive.
+        arc_path = os.path.join(self.test_root, "add.p5p")
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+
+        # add() permits addition of arbitrary files (intentionally);
+        # it is also the routine that higher-level functions to add
+        # package content use internally.  Because of that, this
+        # function does not strictly need standalone testing, but it
+        # helps ensure all code paths for add() are tested.
+        arc.add(self.test_root)
+        tmp_root = os.path.join(self.test_root, "tmp")
+        arc.add(tmp_root)
+
+        for f in self.misc_files:
+            src = os.path.join(self.test_root, f)
+
+            # Ensure files are read-only mode so that file perm
+            # normalization can be tested.
+            os.chmod(src, pkg.misc.PKG_RO_FILE_MODE)
+            arc.add(src)
+
+        # Write out archive.
+        arc.close()
+
+        # Now open the archive and iterate through its contents and
+        # verify that each member has the expected characteristics.
+        arc = ptf.PkgTarFile(name=arc_path, mode="r")
+
+        members = [m for m in arc.getmembers()]
+
+        # Should be 11 files including package archive index and three
+        # directories.
+        actual = [m.name for m in members]
+        self.assertEqual(len(actual), 11)
+        expected = [
+            "pkg5.index.0.gz",
+            "publisher",
+            pkg.misc.relpath(self.test_root, "/"),
+            pkg.misc.relpath(tmp_root, "/"),
+        ]
+        expected.extend(
+            pkg.misc.relpath(os.path.join(self.test_root, e), "/")
+            for e in self.misc_files
+        )
+        expected.append("pkg5.repository")
+        self.assertEqualDiff(expected, actual)
+
+        for member in members:
+            # All archive members should be a file or directory.
+            self.assertTrue(member.isreg() or member.isdir())
+
+            if member.name == "pkg5.index.0.gz":
+                assert member.isreg()
+                comment = member.pax_headers.get("comment", "")
                 self.assertEqual(comment, "pkg5.archive.version.0")
-
-                # Verify basic expected content exists.
-                expected = ["pkg5.index.0.gz", "publisher", "pkg5.repository"]
-                actual = [m.name for m in arc.getmembers()]
-                self.assertEqualDiff(expected, actual)
-
-                # Destroy the archive.
-                os.unlink(arc_path)
-
-        def test_01_add(self):
-                """Verify that add() works as expected."""
-
-                # Prep the archive.
-                arc_path = os.path.join(self.test_root, "add.p5p")
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-
-                # add() permits addition of arbitrary files (intentionally);
-                # it is also the routine that higher-level functions to add
-                # package content use internally.  Because of that, this
-                # function does not strictly need standalone testing, but it
-                # helps ensure all code paths for add() are tested.
-                arc.add(self.test_root)
-                tmp_root = os.path.join(self.test_root, "tmp")
-                arc.add(tmp_root)
-
-                for f in self.misc_files:
-                        src = os.path.join(self.test_root, f)
-
-                        # Ensure files are read-only mode so that file perm
-                        # normalization can be tested.
-                        os.chmod(src, pkg.misc.PKG_RO_FILE_MODE)
-                        arc.add(src)
-
-                # Write out archive.
-                arc.close()
-
-                # Now open the archive and iterate through its contents and
-                # verify that each member has the expected characteristics.
-                arc = ptf.PkgTarFile(name=arc_path, mode="r")
-
-                members = [m for m in arc.getmembers()]
-
-                # Should be 11 files including package archive index and three
-                # directories.
-                actual = [m.name for m in members]
-                self.assertEqual(len(actual), 11)
-                expected = ["pkg5.index.0.gz", "publisher",
-                    pkg.misc.relpath(self.test_root, "/"),
-                    pkg.misc.relpath(tmp_root, "/")
-                ]
-                expected.extend(
-                    pkg.misc.relpath(os.path.join(self.test_root, e), "/")
-                    for e in self.misc_files
-                )
-                expected.append("pkg5.repository")
-                self.assertEqualDiff(expected, actual)
-
-                for member in members:
-                        # All archive members should be a file or directory.
-                        self.assertTrue(member.isreg() or member.isdir())
-
-                        if member.name == "pkg5.index.0.gz":
-                                assert member.isreg()
-                                comment = member.pax_headers.get("comment", "")
-                                self.assertEqual(comment,
-                                    "pkg5.archive.version.0")
-                                continue
-
-                        if member.isdir():
-                                # Verify directories were added with expected
-                                # mode.
-                                self.assertEqual(oct(member.mode),
-                                    oct(pkg.misc.PKG_DIR_MODE))
-                        elif member.isfile():
-                                # Verify files were added with expected mode.
-                                self.assertEqual(oct(member.mode),
-                                    oct(pkg.misc.PKG_FILE_MODE))
-
-                        # Verify files and directories have expected ownership.
-                        self.assertEqual(member.uname, "root")
-                        self.assertEqual(member.gname, "root")
-                        self.assertEqual(member.uid, 0)
-                        self.assertEqual(member.gid, 0)
-
-                os.unlink(arc_path)
-
-        def test_02_add_package(self):
-                """Verify that pkg(7) archive creation using add_package() works
-                as expected.
-                """
-
-                # Get repository.
-                repo = self.get_repo(self.dc.get_repodir())
-
-                # Create a directory and copy package files from repository to
-                # it (this is how pkgrecv stores content during republication
-                # or when using --raw).
-                dfroot = os.path.join(self.test_root, "pfiles")
-                os.mkdir(dfroot, pkg.misc.PKG_DIR_MODE)
-
-                foo_path = os.path.join(dfroot, "foo.p5m")
-                portable.copyfile(repo.manifest(self.foo), foo_path)
-
-                signed_path = os.path.join(dfroot, "signed.p5m")
-                portable.copyfile(repo.manifest(self.signed), signed_path)
-
-                quux_path = os.path.join(dfroot, "quux.p5m")
-                portable.copyfile(repo.manifest(self.quux), quux_path)
-
-                for rstore in repo.rstores:
-                        for dirpath, dirnames, filenames in os.walk(
-                            rstore.file_root):
-                                if not filenames:
-                                        continue
-                                for f in filenames:
-                                        portable.copyfile(
-                                            os.path.join(dirpath, f),
-                                            os.path.join(dfroot, f))
-
-                # Prep the archive.
-                progtrack = pkg.client.progress.QuietProgressTracker()
-                arc_path = os.path.join(self.test_root, "add_package.p5p")
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-
-                # Create an archive with just one package.
-                arc.add_package(self.foo, foo_path, dfroot)
-                arc.close(progtrack=progtrack)
-
-                # Verify the result.
-                arc = ptf.PkgTarFile(name=arc_path, mode="r")
-                expected = self.foo_expected
-                actual = [m.name for m in arc.getmembers()]
-                self.assertEqualDiff(expected, actual)
-
-                # Prep a new archive.
-                os.unlink(arc_path)
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-
-                # Create an archive with multiple packages.
-                # (Don't use progtrack this time.)
-                arc.add_package(self.foo, foo_path, dfroot)
-                arc.add_package(self.signed, signed_path, dfroot)
-                arc.add_package(self.quux, quux_path, dfroot)
-                arc.close()
-
-                # Verify the result.
-                arc = ptf.PkgTarFile(name=arc_path, mode="r")
-                expected = self.multi_expected[:]
-                action_certs = [self.calc_pem_hash(t) for t in (
-                    os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch2_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch3_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch4_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch5_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
-                )]
-                for hsh in action_certs:
-                        d = "publisher/test/file/{0}".format(hsh[0:2])
-                        f = "{0}/{1}".format(d, hsh)
-                        expected.append(d)
-                        expected.append(f)
-
-                actual = sorted(m.name for m in arc.getmembers())
-                self.assertEqualDiff(sorted(set(expected)), actual)
-
-                os.unlink(arc_path)
-                os.unlink(foo_path)
-                os.unlink(quux_path)
-                os.unlink(signed_path)
-
-        def test_03_add_repo_package(self):
-                """Verify that pkg(7) archive creation using add_repo_package()
-                works as expected.
-                """
-
-                progtrack = pkg.client.progress.QuietProgressTracker()
-
-                # Get repository.
-                repo = self.get_repo(self.dc.get_repodir())
-
-                # Create an archive with just one package.
-                arc_path = os.path.join(self.test_root, "add_repo_package.p5p")
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                arc.add_repo_package(self.foo, repo)
-                arc.close(progtrack=progtrack)
-
-                # Verify the result.
-                arc = ptf.PkgTarFile(name=arc_path, mode="r")
-                expected = self.foo_expected
-                actual = [m.name for m in arc.getmembers()]
-                self.assertEqualDiff(expected, actual)
-
-                # Prep a new archive.
-                os.unlink(arc_path)
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-
-                # Create an archive with multiple packages.
-                # (Don't use progtrack this time.)
-                arc.add_repo_package(self.foo, repo)
-                arc.add_repo_package(self.signed, repo)
-                arc.add_repo_package(self.quux, repo)
-                arc.close()
-
-                # Verify the result.
-                arc = ptf.PkgTarFile(name=arc_path, mode="r")
-                # Add in the p5i file since this is an archive with signed
-                # packages created from a repo.
-                expected = sorted(self.multi_expected +
-                    ["publisher/test/pub.p5i"])
-                action_certs = [self.calc_pem_hash(t) for t in (
-                    os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch2_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch3_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch4_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch5_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
-                )]
-                for hsh in action_certs:
-                        d = "publisher/test/file/{0}".format(hsh[0:2])
-                        f = "{0}/{1}".format(d, hsh)
-                        expected.append(d)
-                        expected.append(f)
-                actual = sorted(m.name for m in arc.getmembers())
-                self.assertEqualDiff(sorted(set(expected)), actual)
-
-                os.unlink(arc_path)
-
-        def __verify_manifest_sig(self, repo, pfmri, content):
-                """Helper method to verify that the given manifest signature
-                data matches that of the corresponding manifest in a repository.
-                """
-
-                sm = pkg.manifest.Manifest(pfmri=pfmri)
-                sm.set_content(pathname=repo.manifest(pfmri), signatures=True)
-
-                # p5p archive extraction file return bytes
-                if isinstance(content, bytes):
-                        content = pkg.misc.force_str(content)
-                if isinstance(content, six.string_types):
-                        dm = pkg.manifest.Manifest()
-                        dm.set_content(content=content, signatures=True)
-                else:
-                        dm = content
-                self.assertEqualDiff(sm.signatures, dm.signatures)
-
-        def __verify_manifest_file_sig(self, repo, pfmri, target):
-                """Helper method to verify that target manifest's signature data
-                matches that of the corresponding manifest in a repository.
-                """
-
-                sm = pkg.manifest.Manifest(pfmri=pfmri)
-                sm.set_content(pathname=repo.manifest(pfmri), signatures=True)
-
-                dm = pkg.manifest.Manifest()
-                dm.set_content(pathname=target, signatures=True)
-                self.assertEqualDiff(sm.signatures, dm.signatures)
-
-        def __verify_extract(self, repo, arc_path, hashes, ext_dir,
-            archive_index=None):
-                """Helper method to test extraction and retrieval functionality.
-                """
-
-                arc = pkg.p5p.Archive(arc_path, mode="r",
-                    archive_index=archive_index)
-
-                #
-                # Verify behaviour of extract_package_manifest().
-                #
-
-                # Test bad FMRI.
-                self.assertRaises(pkg.fmri.IllegalFmri,
-                    arc.extract_package_manifest, "pkg:/^boguspkg@1.0,5.11",
-                    ext_dir)
-
-                # Test unqualified (no publisher) FMRI.
-                self.assertRaises(AssertionError,
-                    arc.extract_package_manifest, "pkg:/unknown@1.0,5.11",
-                    ext_dir)
-
-                # Test unknown FMRI.
-                self.assertRaisesStringify(pkg.p5p.UnknownPackageManifest,
-                    arc.extract_package_manifest, "pkg://test/unknown@1.0,5.11",
-                    ext_dir)
-
-                # Test extraction when not specifying filename.
-                fpath = os.path.join(ext_dir, self.foo.get_dir_path())
-                arc.extract_package_manifest(self.foo, ext_dir)
-                self.__verify_manifest_file_sig(repo, self.foo, fpath)
-
-                # Test extraction specifying directory that does not exist.
-                shutil.rmtree(ext_dir)
-                arc.extract_package_manifest(self.foo, ext_dir,
-                    filename="foo.p5m")
-                self.__verify_manifest_file_sig(repo, self.foo,
-                    os.path.join(ext_dir, "foo.p5m"))
-
-                # Test extraction specifying directory that already exists.
-                arc.extract_package_manifest(self.quux, ext_dir,
-                    filename="quux.p5m")
-                self.__verify_manifest_file_sig(repo, self.quux,
-                    os.path.join(ext_dir, "quux.p5m"))
-
-                # Test extraction in the case that manifest already exists.
-                arc.extract_package_manifest(self.quux, ext_dir,
-                    filename="quux.p5m")
-                self.__verify_manifest_file_sig(repo, self.quux,
-                    os.path.join(ext_dir, "quux.p5m"))
-
-                #
-                # Verify behaviour of extract_package_files().
-                #
-                arc.close()
-                arc = pkg.p5p.Archive(arc_path, mode="r",
-                    archive_index=archive_index)
-                shutil.rmtree(ext_dir)
-
-                # Test unknown hashes.
-                self.assertRaisesStringify(pkg.p5p.UnknownArchiveFiles,
-                    arc.extract_package_files, ["a", "b", "c"], ext_dir)
-
-                # Test extraction specifying directory that does not exist.
-                arc.extract_package_files(hashes["all"], ext_dir)
-                for h in hashes["all"]:
-                        fpath = os.path.join(ext_dir, h)
-                        assert os.path.exists(fpath)
-
-                        # Now change mode to readonly.
-                        os.chmod(fpath, pkg.misc.PKG_RO_FILE_MODE)
-
-                # Test extraction in the case that files already exist
-                # (and those files are readonly).
-                arc.extract_package_files(hashes["all"], ext_dir)
-                for h in hashes["all"]:
-                        assert os.path.exists(os.path.join(ext_dir, h))
-
-                # Test extraction when publisher is specified.
-                shutil.rmtree(ext_dir)
-                arc.extract_package_files(hashes["test"], ext_dir, pub="test")
-                for h in hashes["test"]:
-                        assert os.path.exists(os.path.join(ext_dir, h))
-
-                #
-                # Verify behaviour of extract_to().
-                #
-                arc.close()
-                arc = pkg.p5p.Archive(arc_path, mode="r",
-                    archive_index=archive_index)
-                shutil.rmtree(ext_dir)
-
-                # Test unknown file.
-                self.assertRaisesStringify(pkg.p5p.UnknownArchiveFiles,
-                    arc.extract_to, "no/such/file", ext_dir)
-
-                # Test extraction when not specifying filename (archive
-                # member should be extracted into target directory using
-                # full path in archive; that is, the target dir is pre-
-                # pended).
-                for pub in hashes:
-                        if pub == "all":
-                                continue
-                        for h in hashes[pub]:
-                                arcname = os.path.join("publisher", pub, "file",
-                                    h[:2], h)
-                                arc.extract_to(arcname, ext_dir)
-
-                                fpath = os.path.join(ext_dir, arcname)
-                                assert os.path.exists(fpath)
-
-                # Test extraction specifying directory that does not exist.
-                shutil.rmtree(ext_dir)
-                for pub in hashes:
-                        if pub == "all":
-                                continue
-                        for h in hashes[pub]:
-                                arcname = os.path.join("publisher", pub, "file",
-                                    h[:2], h)
-                                arc.extract_to(arcname, ext_dir, filename=h)
-
-                                fpath = os.path.join(ext_dir, h)
-                                assert os.path.exists(fpath)
-
-                                # Now change mode to readonly.
-                                os.chmod(fpath, pkg.misc.PKG_RO_FILE_MODE)
-
-                # Test extraction in the case that files already exist
-                # (and those files are readonly).
-                for pub in hashes:
-                        if pub == "all":
-                                continue
-                        for h in hashes[pub]:
-                                arcname = os.path.join("publisher", pub, "file",
-                                    h[:2], h)
-                                arc.extract_to(arcname, ext_dir, filename=h)
-
-                                fpath = os.path.join(ext_dir, h)
-                                assert os.path.exists(fpath)
-
-                #
-                # Verify behaviour of get_file().
-                #
-                arc.close()
-                arc = pkg.p5p.Archive(arc_path, mode="r",
-                     archive_index=archive_index)
-
-                # Test behaviour for non-existent file.
-                self.assertRaisesStringify(pkg.p5p.UnknownArchiveFiles,
-                    arc.get_file, "no/such/file")
-
-                # Test that archived content retrieved is identical.
-                arcname = os.path.join("publisher", self.foo.publisher, "pkg",
-                    self.foo.get_dir_path())
-                fobj = arc.get_file(arcname)
-                self.__verify_manifest_sig(repo, self.foo, fobj.read())
-                fobj.close()
-
-                #
-                # Verify behaviour of get_package_file().
-                #
-                arc.close()
-                arc = pkg.p5p.Archive(arc_path, mode="r",
-                    archive_index=archive_index)
-
-                # We always store content using the least_preferred hash, so
-                # determine what that is so that we can verify it using
-                # gunzip_from_stream.
-                hash_func = digest.get_least_preferred_hash(None)[2]
-
-                # Test behaviour when specifying publisher.
-                nullf = open(os.devnull, "wb")
-                for h in hashes["test"]:
-                        fobj = arc.get_package_file(h, pub="test")
-                        uchash = pkg.misc.gunzip_from_stream(fobj, nullf,
-                            hash_func=hash_func)
-                        self.assertEqual(uchash, h)
-                        fobj.close()
-
-                # Test behaviour when not specifying publisher.
-                for h in hashes["test"]:
-                        fobj = arc.get_package_file(h)
-                        uchash = pkg.misc.gunzip_from_stream(fobj, nullf,
-                            hash_func=hash_func)
-                        self.assertEqual(uchash, h)
-                        fobj.close()
-                nullf.close()
-
-                #
-                # Verify behaviour of get_package_manifest().
-                #
-                arc.close()
-                arc = pkg.p5p.Archive(arc_path, mode="r",
-                    archive_index=archive_index)
-
-                # Test bad FMRI.
-                self.assertRaises(pkg.fmri.IllegalFmri,
-                    arc.get_package_manifest, "pkg:/^boguspkg@1.0,5.11")
-
-                # Test unqualified (no publisher) FMRI.
-                self.assertRaises(AssertionError,
-                    arc.get_package_manifest, "pkg:/unknown@1.0,5.11")
-
-                # Test unknown FMRI.
-                self.assertRaisesStringify(pkg.p5p.UnknownPackageManifest,
-                    arc.get_package_manifest, "pkg://test/unknown@1.0,5.11")
-
-                # Test that archived content retrieved is identical.
-                mobj = arc.get_package_manifest(self.foo)
-                self.__verify_manifest_sig(repo, self.foo, mobj)
-
-                mobj = arc.get_package_manifest(self.signed)
-                self.__verify_manifest_sig(repo, self.signed, mobj)
-
-                #
-                # Verify behaviour of extract_catalog1().
-                #
-                arc.close()
-                arc = pkg.p5p.Archive(arc_path, mode="r",
-                    archive_index=archive_index)
-                ext_tmp_dir = tempfile.mkdtemp(dir=self.test_root)
-                def verify_catalog(pub, pfmris):
-                        for pname in ("catalog.attrs", "catalog.base.C",
-                            "catalog.dependency.C", "catalog.summary.C"):
-                                expected = os.path.join(ext_tmp_dir, pname)
-                                try:
-                                        arc.extract_catalog1(pname, ext_tmp_dir,
-                                            pub=pub)
-                                except pkg.p5p.UnknownArchiveFiles:
-                                        if pname == "catalog.dependency.C":
-                                                # No dependencies, so exeception
-                                                # is only expected for this.
-                                                continue
-                                        raise
-
-                                assert os.path.exists(expected)
-
-                        cat = pkg.catalog.Catalog(meta_root=ext_tmp_dir)
-                        self.assertEqual(sorted([f for f in cat.fmris()]),
-                            sorted(pfmris))
-
-                verify_catalog("test", [self.foo, self.signed])
-                shutil.rmtree(ext_tmp_dir)
-                os.mkdir(ext_tmp_dir)
-
-                verify_catalog("test2", [self.quux])
-                shutil.rmtree(ext_tmp_dir)
-                return arc
-
-        def test_04_extract(self):
-                """Verify that pkg(7) archive extraction methods work as
-                expected.
-                """
-
-                # Get repository.
-                repo = self.get_repo(self.dc.get_repodir())
-
-                # Create an archive with a few packages.
-                arc_path = os.path.join(self.test_root, "retrieve.p5p")
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                arc.add_repo_package(self.foo, repo)
-                arc.add_repo_package(self.signed, repo)
-                arc.add_repo_package(self.quux, repo)
-                arc.close()
-
-                # Get list of file hashes. These will be the "least-preferred"
-                # hash for the actions being stored.
-                hashes = { "all": set() }
-                for rstore in repo.rstores:
-                        for dirpath, dirnames, filenames in os.walk(
-                            rstore.file_root):
-                                if not filenames:
-                                        continue
-                                hashes["all"].update(filenames)
-                                hashes.setdefault(rstore.publisher,
-                                    set()).update(filenames)
-
-                # Extraction directory for testing.
-                ext_dir = os.path.join(self.test_root, "extracted")
-
-                # First, verify behaviour using archive created using
-                # pkg(7) archive class.
-                arc = self.__verify_extract(repo, arc_path, hashes, ext_dir)
-                arc.close()
-
-                # Now extract everything from the archive and create
-                # a new archive using the tarfile class, and verify
-                # that the pkg(7) archive class can still extract
-                # and access the contents as expected even though
-                # the index file isn't marked with the appropriate
-                # pax headers (and so should be ignored since it's
-                # also invalid).
-                shutil.rmtree(ext_dir)
-
-                # Extract all of the existing content.
-                arc = ptf.PkgTarFile(name=arc_path, mode="r")
-                arc.extractall(ext_dir)
-                arc.close()
-
-                # Create a new archive.
-                os.unlink(arc_path)
-                arc = ptf.PkgTarFile(name=arc_path, mode="w")
-
-                def add_entry(src):
-                        fpath = os.path.join(dirpath, src)
-                        arcname = pkg.misc.relpath(fpath, ext_dir)
-                        arc.add(name=fpath, arcname=arcname,
-                            recursive=False)
-
-                for dirpath, dirnames, filenames in os.walk(ext_dir):
-                        list(map(add_entry, filenames))
-                        list(map(add_entry, dirnames))
-                arc.close()
-
-                # Verify that archive has expected contents.
-                arc = ptf.PkgTarFile(name=arc_path, mode="r")
-                # Add in the p5i file since this is an archive with signed
-                # packages created from a repo.
-                expected = sorted(self.multi_expected +
-                    ["publisher/test/pub.p5i"])
-                action_certs = [self.calc_pem_hash(t) for t in (
-                    os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch2_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch3_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch4_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch5_ta1_cert.pem"),
-                    os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
-                )]
-                for hsh in action_certs:
-                        d = "publisher/test/file/{0}".format(hsh[0:2])
-                        f = "{0}/{1}".format(d, hsh)
-                        expected.append(d)
-                        expected.append(f)
-                actual = sorted(m.name for m in arc.getmembers())
-                self.assertEqualDiff(sorted(set(expected)), actual)
-                arc.close()
-
-                # Verify pkg(7) archive class extraction behaviour using
-                # the new archive.
-                arc = self.__verify_extract(repo, arc_path, hashes, ext_dir)
-                arc.close()
-
-                # Extract all of the existing content.
-                arc = ptf.PkgTarFile(name=arc_path, mode="r")
-                arc.extractall(ext_dir)
-                arc.close()
-
-                # Now verify archive can still be used when index file
-                # is omitted.
-                os.unlink(arc_path)
-                arc = ptf.PkgTarFile(name=arc_path, mode="w")
-                for dirpath, dirnames, filenames in os.walk(ext_dir):
-                        list(map(add_entry,
-                            [f for f in filenames if f != "pkg5.index.0.gz"]))
-                        list(map(add_entry, dirnames))
-                arc.close()
-
-                # Verify pkg(7) archive class extraction behaviour using
-                # the new archive.
-                arc = self.__verify_extract(repo, arc_path, hashes, ext_dir)
-                arc.close()
-
-                # Save an index for later.
-                arc = pkg.p5p.Archive(arc_path, mode="r")
-                saved_index = arc.get_index()
-                arc.close()
-
-                # Verify we can extract the archive reusing an index.
-                arc = self.__verify_extract(repo, arc_path, hashes, ext_dir,
-                    archive_index=saved_index)
-                arc.close()
-
-                # Verify we throw an assert when opening a p5p in write mode.
-                self.assertRaisesStringify(AssertionError, pkg.p5p.Archive,
-                    arc_path, mode="w", archive_index=saved_index)
-
-                # Verify we can't extract archive members using a corrupted
-                # index.
-                arc = pkg.p5p.Archive(arc_path, mode="r",
-                    archive_index={"cats": 1234})
-                self.assertRaisesStringify(pkg.p5p.ArchiveErrors,
-                    arc.extract_catalog1, "catalog.attrs", ext_dir)
-                self.assertRaisesStringify(pkg.p5p.ArchiveErrors,
-                    arc.extract_package_files, hashes, ext_dir)
-                arc.close()
-
-        def test_05_invalid(self):
-                """Verify that pkg(7) archive class handles broken archives
-                and items that aren't archives as expected."""
-
-                arc_path = os.path.join(self.test_root, "nosucharchive.p5p")
-
-                #
-                # Check that no archive is handled.
-                #
-                self.assertRaisesStringify(pkg.p5p.InvalidArchive,
-                    pkg.p5p.Archive, arc_path, mode="r")
-
-                #
-                # Check that empty archive file is handled.
-                #
-                arc_path = os.path.join(self.test_root, "retrieve.p5p")
-                open(arc_path, "wb").close()
-                self.assertRaisesStringify(pkg.p5p.InvalidArchive,
-                    pkg.p5p.Archive, arc_path, mode="r")
-                os.unlink(arc_path)
-
-                #
-                # Check that invalid archive file is handled.
-                #
-                with open(arc_path, "w") as f:
-                        f.write("not_a_valid_archive")
-                self.assertRaisesStringify(pkg.p5p.InvalidArchive,
-                    pkg.p5p.Archive, arc_path, mode="r")
-                os.unlink(arc_path)
-
-                #
-                # Check that a truncated archive is handled.
-                #
-                repo = self.get_repo(self.dc.get_repodir())
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                arc.add_repo_package(self.foo, repo)
-                arc.add_repo_package(self.signed, repo)
-                arc.add_repo_package(self.quux, repo)
-                arc.close()
-
-                #
-                # Check that truncated archives, or archives with invalid
-                # indexes are handled as expected.
-                #
-
-                # Determine where to truncate archive by looking for specific
-                # package file and then setting truncate location to halfway
-                # through data for file.
-                arc = ptf.PkgTarFile(name=arc_path, mode="r")
-                idx_data_offset = 0
-                src_offset = 0
-                src_bytes = 0
-                dest_offset = 0
-                trunc_sz = 0
-                src_fhash = "b265f2ec87c4a55eb2b6b4c926e7c65f7247a27e"
-                dest_fhash = "801eebbfe8c526bf092d98741d4228e4d0fc99ae"
-                for m in arc.getmembers():
-                        if m.name.endswith("/" + dest_fhash):
-                                dest_offset = m.offset
-                                trunc_sz = m.offset_data + int(m.size // 2)
-                        elif m.name.endswith("pkg5.index.0.gz"):
-                                idx_data_offset = m.offset_data
-                        elif m.name.endswith("/" + src_fhash):
-                                # Calculate size of source entry.
-                                src_bytes = m.offset_data - m.offset
-                                blocks, rem = divmod(m.size, tf.BLOCKSIZE)
-                                if rem > 0:
-                                        blocks += 1
-                                src_bytes += blocks * tf.BLOCKSIZE
-                                src_offset = m.offset
-
-                arc.close()
-
-                # Test truncated archive case.
-                bad_arc_path = os.path.join(self.test_root, "bad_arc.p5p")
-                portable.copyfile(arc_path, bad_arc_path)
-
-                self.debug("{0} size: {1:d} truncate: {2:d}".format(arc_path,
-                    os.stat(arc_path).st_size, trunc_sz))
-                with open(bad_arc_path, "ab+") as f:
-                        f.truncate(trunc_sz)
-
-                ext_dir = os.path.join(self.test_root, "extracted")
-                shutil.rmtree(ext_dir, True)
-                arc = pkg.p5p.Archive(bad_arc_path, mode="r")
-                self.assertRaisesStringify(pkg.p5p.InvalidArchive,
-                    arc.extract_package_files, [dest_fhash], ext_dir,
-                    pub="test2")
-                arc.close()
-
-                # Test archive with invalid index; do this by writing some bogus
-                # bytes into the data area for the index.
-                portable.copyfile(arc_path, bad_arc_path)
-                with open(bad_arc_path, "ab+") as dest:
-                        dest.seek(idx_data_offset)
-                        dest.truncate()
-                        with open(arc_path, "rb") as src:
-                                bogus_data = b"invalid_index_data"
-                                dest.write(bogus_data)
-                                src.seek(idx_data_offset + len(bogus_data))
-                                dest.write(src.read())
-
-                shutil.rmtree(ext_dir, True)
-                self.assertRaisesStringify(pkg.p5p.InvalidArchive,
-                    pkg.p5p.Archive, bad_arc_path, mode="r")
-
-                # Test archive with invalid index offsets; do this by truncating
-                # an existing archive at the offset of one of its files and then
-                # appending the data for a different archive member in its
-                # place.
-                portable.copyfile(arc_path, bad_arc_path)
-                with open(bad_arc_path, "ab+") as dest:
-                        dest.seek(dest_offset)
-                        dest.truncate()
-                        with open(arc_path, "rb") as src:
-                                src.seek(src_offset)
-                                dest.write(src.read(src_bytes))
-
-                shutil.rmtree(ext_dir, True)
-                arc = pkg.p5p.Archive(bad_arc_path, mode="r")
-                self.assertRaisesStringify(pkg.p5p.InvalidArchive,
-                    arc.extract_package_files, [dest_fhash], ext_dir,
-                    pub="test2")
-                arc.close()
-
-                os.unlink(arc_path)
-                os.unlink(bad_arc_path)
-
-                #
-                # Check that directory where archive expected is handled.
-                #
-                os.mkdir(arc_path)
-                self.assertRaisesStringify(pkg.p5p.InvalidArchive,
-                    pkg.p5p.Archive, arc_path, mode="r")
-                os.rmdir(arc_path)
-
-                # Temporarily change the current archive version and create a
-                # a new archive, and then verify that the expected exception is
-                # raised when an attempt to read it is made.
-                orig_ver = pkg.p5p.Archive.CURRENT_VERSION
+                continue
+
+            if member.isdir():
+                # Verify directories were added with expected
+                # mode.
+                self.assertEqual(oct(member.mode), oct(pkg.misc.PKG_DIR_MODE))
+            elif member.isfile():
+                # Verify files were added with expected mode.
+                self.assertEqual(oct(member.mode), oct(pkg.misc.PKG_FILE_MODE))
+
+            # Verify files and directories have expected ownership.
+            self.assertEqual(member.uname, "root")
+            self.assertEqual(member.gname, "root")
+            self.assertEqual(member.uid, 0)
+            self.assertEqual(member.gid, 0)
+
+        os.unlink(arc_path)
+
+    def test_02_add_package(self):
+        """Verify that pkg(7) archive creation using add_package() works
+        as expected.
+        """
+
+        # Get repository.
+        repo = self.get_repo(self.dc.get_repodir())
+
+        # Create a directory and copy package files from repository to
+        # it (this is how pkgrecv stores content during republication
+        # or when using --raw).
+        dfroot = os.path.join(self.test_root, "pfiles")
+        os.mkdir(dfroot, pkg.misc.PKG_DIR_MODE)
+
+        foo_path = os.path.join(dfroot, "foo.p5m")
+        portable.copyfile(repo.manifest(self.foo), foo_path)
+
+        signed_path = os.path.join(dfroot, "signed.p5m")
+        portable.copyfile(repo.manifest(self.signed), signed_path)
+
+        quux_path = os.path.join(dfroot, "quux.p5m")
+        portable.copyfile(repo.manifest(self.quux), quux_path)
+
+        for rstore in repo.rstores:
+            for dirpath, dirnames, filenames in os.walk(rstore.file_root):
+                if not filenames:
+                    continue
+                for f in filenames:
+                    portable.copyfile(
+                        os.path.join(dirpath, f), os.path.join(dfroot, f)
+                    )
+
+        # Prep the archive.
+        progtrack = pkg.client.progress.QuietProgressTracker()
+        arc_path = os.path.join(self.test_root, "add_package.p5p")
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+
+        # Create an archive with just one package.
+        arc.add_package(self.foo, foo_path, dfroot)
+        arc.close(progtrack=progtrack)
+
+        # Verify the result.
+        arc = ptf.PkgTarFile(name=arc_path, mode="r")
+        expected = self.foo_expected
+        actual = [m.name for m in arc.getmembers()]
+        self.assertEqualDiff(expected, actual)
+
+        # Prep a new archive.
+        os.unlink(arc_path)
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+
+        # Create an archive with multiple packages.
+        # (Don't use progtrack this time.)
+        arc.add_package(self.foo, foo_path, dfroot)
+        arc.add_package(self.signed, signed_path, dfroot)
+        arc.add_package(self.quux, quux_path, dfroot)
+        arc.close()
+
+        # Verify the result.
+        arc = ptf.PkgTarFile(name=arc_path, mode="r")
+        expected = self.multi_expected[:]
+        action_certs = [
+            self.calc_pem_hash(t)
+            for t in (
+                os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch2_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch3_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch4_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch5_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+            )
+        ]
+        for hsh in action_certs:
+            d = "publisher/test/file/{0}".format(hsh[0:2])
+            f = "{0}/{1}".format(d, hsh)
+            expected.append(d)
+            expected.append(f)
+
+        actual = sorted(m.name for m in arc.getmembers())
+        self.assertEqualDiff(sorted(set(expected)), actual)
+
+        os.unlink(arc_path)
+        os.unlink(foo_path)
+        os.unlink(quux_path)
+        os.unlink(signed_path)
+
+    def test_03_add_repo_package(self):
+        """Verify that pkg(7) archive creation using add_repo_package()
+        works as expected.
+        """
+
+        progtrack = pkg.client.progress.QuietProgressTracker()
+
+        # Get repository.
+        repo = self.get_repo(self.dc.get_repodir())
+
+        # Create an archive with just one package.
+        arc_path = os.path.join(self.test_root, "add_repo_package.p5p")
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        arc.add_repo_package(self.foo, repo)
+        arc.close(progtrack=progtrack)
+
+        # Verify the result.
+        arc = ptf.PkgTarFile(name=arc_path, mode="r")
+        expected = self.foo_expected
+        actual = [m.name for m in arc.getmembers()]
+        self.assertEqualDiff(expected, actual)
+
+        # Prep a new archive.
+        os.unlink(arc_path)
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+
+        # Create an archive with multiple packages.
+        # (Don't use progtrack this time.)
+        arc.add_repo_package(self.foo, repo)
+        arc.add_repo_package(self.signed, repo)
+        arc.add_repo_package(self.quux, repo)
+        arc.close()
+
+        # Verify the result.
+        arc = ptf.PkgTarFile(name=arc_path, mode="r")
+        # Add in the p5i file since this is an archive with signed
+        # packages created from a repo.
+        expected = sorted(self.multi_expected + ["publisher/test/pub.p5i"])
+        action_certs = [
+            self.calc_pem_hash(t)
+            for t in (
+                os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch2_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch3_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch4_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch5_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+            )
+        ]
+        for hsh in action_certs:
+            d = "publisher/test/file/{0}".format(hsh[0:2])
+            f = "{0}/{1}".format(d, hsh)
+            expected.append(d)
+            expected.append(f)
+        actual = sorted(m.name for m in arc.getmembers())
+        self.assertEqualDiff(sorted(set(expected)), actual)
+
+        os.unlink(arc_path)
+
+    def __verify_manifest_sig(self, repo, pfmri, content):
+        """Helper method to verify that the given manifest signature
+        data matches that of the corresponding manifest in a repository.
+        """
+
+        sm = pkg.manifest.Manifest(pfmri=pfmri)
+        sm.set_content(pathname=repo.manifest(pfmri), signatures=True)
+
+        # p5p archive extraction file return bytes
+        if isinstance(content, bytes):
+            content = pkg.misc.force_str(content)
+        if isinstance(content, six.string_types):
+            dm = pkg.manifest.Manifest()
+            dm.set_content(content=content, signatures=True)
+        else:
+            dm = content
+        self.assertEqualDiff(sm.signatures, dm.signatures)
+
+    def __verify_manifest_file_sig(self, repo, pfmri, target):
+        """Helper method to verify that target manifest's signature data
+        matches that of the corresponding manifest in a repository.
+        """
+
+        sm = pkg.manifest.Manifest(pfmri=pfmri)
+        sm.set_content(pathname=repo.manifest(pfmri), signatures=True)
+
+        dm = pkg.manifest.Manifest()
+        dm.set_content(pathname=target, signatures=True)
+        self.assertEqualDiff(sm.signatures, dm.signatures)
+
+    def __verify_extract(
+        self, repo, arc_path, hashes, ext_dir, archive_index=None
+    ):
+        """Helper method to test extraction and retrieval functionality."""
+
+        arc = pkg.p5p.Archive(arc_path, mode="r", archive_index=archive_index)
+
+        #
+        # Verify behaviour of extract_package_manifest().
+        #
+
+        # Test bad FMRI.
+        self.assertRaises(
+            pkg.fmri.IllegalFmri,
+            arc.extract_package_manifest,
+            "pkg:/^boguspkg@1.0,5.11",
+            ext_dir,
+        )
+
+        # Test unqualified (no publisher) FMRI.
+        self.assertRaises(
+            AssertionError,
+            arc.extract_package_manifest,
+            "pkg:/unknown@1.0,5.11",
+            ext_dir,
+        )
+
+        # Test unknown FMRI.
+        self.assertRaisesStringify(
+            pkg.p5p.UnknownPackageManifest,
+            arc.extract_package_manifest,
+            "pkg://test/unknown@1.0,5.11",
+            ext_dir,
+        )
+
+        # Test extraction when not specifying filename.
+        fpath = os.path.join(ext_dir, self.foo.get_dir_path())
+        arc.extract_package_manifest(self.foo, ext_dir)
+        self.__verify_manifest_file_sig(repo, self.foo, fpath)
+
+        # Test extraction specifying directory that does not exist.
+        shutil.rmtree(ext_dir)
+        arc.extract_package_manifest(self.foo, ext_dir, filename="foo.p5m")
+        self.__verify_manifest_file_sig(
+            repo, self.foo, os.path.join(ext_dir, "foo.p5m")
+        )
+
+        # Test extraction specifying directory that already exists.
+        arc.extract_package_manifest(self.quux, ext_dir, filename="quux.p5m")
+        self.__verify_manifest_file_sig(
+            repo, self.quux, os.path.join(ext_dir, "quux.p5m")
+        )
+
+        # Test extraction in the case that manifest already exists.
+        arc.extract_package_manifest(self.quux, ext_dir, filename="quux.p5m")
+        self.__verify_manifest_file_sig(
+            repo, self.quux, os.path.join(ext_dir, "quux.p5m")
+        )
+
+        #
+        # Verify behaviour of extract_package_files().
+        #
+        arc.close()
+        arc = pkg.p5p.Archive(arc_path, mode="r", archive_index=archive_index)
+        shutil.rmtree(ext_dir)
+
+        # Test unknown hashes.
+        self.assertRaisesStringify(
+            pkg.p5p.UnknownArchiveFiles,
+            arc.extract_package_files,
+            ["a", "b", "c"],
+            ext_dir,
+        )
+
+        # Test extraction specifying directory that does not exist.
+        arc.extract_package_files(hashes["all"], ext_dir)
+        for h in hashes["all"]:
+            fpath = os.path.join(ext_dir, h)
+            assert os.path.exists(fpath)
+
+            # Now change mode to readonly.
+            os.chmod(fpath, pkg.misc.PKG_RO_FILE_MODE)
+
+        # Test extraction in the case that files already exist
+        # (and those files are readonly).
+        arc.extract_package_files(hashes["all"], ext_dir)
+        for h in hashes["all"]:
+            assert os.path.exists(os.path.join(ext_dir, h))
+
+        # Test extraction when publisher is specified.
+        shutil.rmtree(ext_dir)
+        arc.extract_package_files(hashes["test"], ext_dir, pub="test")
+        for h in hashes["test"]:
+            assert os.path.exists(os.path.join(ext_dir, h))
+
+        #
+        # Verify behaviour of extract_to().
+        #
+        arc.close()
+        arc = pkg.p5p.Archive(arc_path, mode="r", archive_index=archive_index)
+        shutil.rmtree(ext_dir)
+
+        # Test unknown file.
+        self.assertRaisesStringify(
+            pkg.p5p.UnknownArchiveFiles, arc.extract_to, "no/such/file", ext_dir
+        )
+
+        # Test extraction when not specifying filename (archive
+        # member should be extracted into target directory using
+        # full path in archive; that is, the target dir is pre-
+        # pended).
+        for pub in hashes:
+            if pub == "all":
+                continue
+            for h in hashes[pub]:
+                arcname = os.path.join("publisher", pub, "file", h[:2], h)
+                arc.extract_to(arcname, ext_dir)
+
+                fpath = os.path.join(ext_dir, arcname)
+                assert os.path.exists(fpath)
+
+        # Test extraction specifying directory that does not exist.
+        shutil.rmtree(ext_dir)
+        for pub in hashes:
+            if pub == "all":
+                continue
+            for h in hashes[pub]:
+                arcname = os.path.join("publisher", pub, "file", h[:2], h)
+                arc.extract_to(arcname, ext_dir, filename=h)
+
+                fpath = os.path.join(ext_dir, h)
+                assert os.path.exists(fpath)
+
+                # Now change mode to readonly.
+                os.chmod(fpath, pkg.misc.PKG_RO_FILE_MODE)
+
+        # Test extraction in the case that files already exist
+        # (and those files are readonly).
+        for pub in hashes:
+            if pub == "all":
+                continue
+            for h in hashes[pub]:
+                arcname = os.path.join("publisher", pub, "file", h[:2], h)
+                arc.extract_to(arcname, ext_dir, filename=h)
+
+                fpath = os.path.join(ext_dir, h)
+                assert os.path.exists(fpath)
+
+        #
+        # Verify behaviour of get_file().
+        #
+        arc.close()
+        arc = pkg.p5p.Archive(arc_path, mode="r", archive_index=archive_index)
+
+        # Test behaviour for non-existent file.
+        self.assertRaisesStringify(
+            pkg.p5p.UnknownArchiveFiles, arc.get_file, "no/such/file"
+        )
+
+        # Test that archived content retrieved is identical.
+        arcname = os.path.join(
+            "publisher", self.foo.publisher, "pkg", self.foo.get_dir_path()
+        )
+        fobj = arc.get_file(arcname)
+        self.__verify_manifest_sig(repo, self.foo, fobj.read())
+        fobj.close()
+
+        #
+        # Verify behaviour of get_package_file().
+        #
+        arc.close()
+        arc = pkg.p5p.Archive(arc_path, mode="r", archive_index=archive_index)
+
+        # We always store content using the least_preferred hash, so
+        # determine what that is so that we can verify it using
+        # gunzip_from_stream.
+        hash_func = digest.get_least_preferred_hash(None)[2]
+
+        # Test behaviour when specifying publisher.
+        nullf = open(os.devnull, "wb")
+        for h in hashes["test"]:
+            fobj = arc.get_package_file(h, pub="test")
+            uchash = pkg.misc.gunzip_from_stream(
+                fobj, nullf, hash_func=hash_func
+            )
+            self.assertEqual(uchash, h)
+            fobj.close()
+
+        # Test behaviour when not specifying publisher.
+        for h in hashes["test"]:
+            fobj = arc.get_package_file(h)
+            uchash = pkg.misc.gunzip_from_stream(
+                fobj, nullf, hash_func=hash_func
+            )
+            self.assertEqual(uchash, h)
+            fobj.close()
+        nullf.close()
+
+        #
+        # Verify behaviour of get_package_manifest().
+        #
+        arc.close()
+        arc = pkg.p5p.Archive(arc_path, mode="r", archive_index=archive_index)
+
+        # Test bad FMRI.
+        self.assertRaises(
+            pkg.fmri.IllegalFmri,
+            arc.get_package_manifest,
+            "pkg:/^boguspkg@1.0,5.11",
+        )
+
+        # Test unqualified (no publisher) FMRI.
+        self.assertRaises(
+            AssertionError, arc.get_package_manifest, "pkg:/unknown@1.0,5.11"
+        )
+
+        # Test unknown FMRI.
+        self.assertRaisesStringify(
+            pkg.p5p.UnknownPackageManifest,
+            arc.get_package_manifest,
+            "pkg://test/unknown@1.0,5.11",
+        )
+
+        # Test that archived content retrieved is identical.
+        mobj = arc.get_package_manifest(self.foo)
+        self.__verify_manifest_sig(repo, self.foo, mobj)
+
+        mobj = arc.get_package_manifest(self.signed)
+        self.__verify_manifest_sig(repo, self.signed, mobj)
+
+        #
+        # Verify behaviour of extract_catalog1().
+        #
+        arc.close()
+        arc = pkg.p5p.Archive(arc_path, mode="r", archive_index=archive_index)
+        ext_tmp_dir = tempfile.mkdtemp(dir=self.test_root)
+
+        def verify_catalog(pub, pfmris):
+            for pname in (
+                "catalog.attrs",
+                "catalog.base.C",
+                "catalog.dependency.C",
+                "catalog.summary.C",
+            ):
+                expected = os.path.join(ext_tmp_dir, pname)
                 try:
-                        pkg.p5p.Archive.CURRENT_VERSION = 99 # EVIL
-                        arc = pkg.p5p.Archive(arc_path, mode="w")
-                        arc.close()
-                finally:
-                        # Ensure this is reset to the right value.
-                        pkg.p5p.Archive.CURRENT_VERSION = orig_ver
+                    arc.extract_catalog1(pname, ext_tmp_dir, pub=pub)
+                except pkg.p5p.UnknownArchiveFiles:
+                    if pname == "catalog.dependency.C":
+                        # No dependencies, so exeception
+                        # is only expected for this.
+                        continue
+                    raise
 
-                self.assertRaisesStringify(pkg.p5p.InvalidArchive,
-                    pkg.p5p.Archive, arc_path, mode="r")
-                os.unlink(arc_path)
+                assert os.path.exists(expected)
 
-        def test_06_get_index(self):
-                """Verify we can't retrieve an index from an archive opened
-                in write-mode."""
-                arc_path = os.path.join(self.test_root, "index.p5p")
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                self.assertRaisesStringify(AssertionError, arc.get_index)
-                arc.close()
-                os.unlink(arc_path)
+            cat = pkg.catalog.Catalog(meta_root=ext_tmp_dir)
+            self.assertEqual(sorted([f for f in cat.fmris()]), sorted(pfmris))
+
+        verify_catalog("test", [self.foo, self.signed])
+        shutil.rmtree(ext_tmp_dir)
+        os.mkdir(ext_tmp_dir)
+
+        verify_catalog("test2", [self.quux])
+        shutil.rmtree(ext_tmp_dir)
+        return arc
+
+    def test_04_extract(self):
+        """Verify that pkg(7) archive extraction methods work as
+        expected.
+        """
+
+        # Get repository.
+        repo = self.get_repo(self.dc.get_repodir())
+
+        # Create an archive with a few packages.
+        arc_path = os.path.join(self.test_root, "retrieve.p5p")
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        arc.add_repo_package(self.foo, repo)
+        arc.add_repo_package(self.signed, repo)
+        arc.add_repo_package(self.quux, repo)
+        arc.close()
+
+        # Get list of file hashes. These will be the "least-preferred"
+        # hash for the actions being stored.
+        hashes = {"all": set()}
+        for rstore in repo.rstores:
+            for dirpath, dirnames, filenames in os.walk(rstore.file_root):
+                if not filenames:
+                    continue
+                hashes["all"].update(filenames)
+                hashes.setdefault(rstore.publisher, set()).update(filenames)
+
+        # Extraction directory for testing.
+        ext_dir = os.path.join(self.test_root, "extracted")
+
+        # First, verify behaviour using archive created using
+        # pkg(7) archive class.
+        arc = self.__verify_extract(repo, arc_path, hashes, ext_dir)
+        arc.close()
+
+        # Now extract everything from the archive and create
+        # a new archive using the tarfile class, and verify
+        # that the pkg(7) archive class can still extract
+        # and access the contents as expected even though
+        # the index file isn't marked with the appropriate
+        # pax headers (and so should be ignored since it's
+        # also invalid).
+        shutil.rmtree(ext_dir)
+
+        # Extract all of the existing content.
+        arc = ptf.PkgTarFile(name=arc_path, mode="r")
+        arc.extractall(ext_dir)
+        arc.close()
+
+        # Create a new archive.
+        os.unlink(arc_path)
+        arc = ptf.PkgTarFile(name=arc_path, mode="w")
+
+        def add_entry(src):
+            fpath = os.path.join(dirpath, src)
+            arcname = pkg.misc.relpath(fpath, ext_dir)
+            arc.add(name=fpath, arcname=arcname, recursive=False)
+
+        for dirpath, dirnames, filenames in os.walk(ext_dir):
+            list(map(add_entry, filenames))
+            list(map(add_entry, dirnames))
+        arc.close()
+
+        # Verify that archive has expected contents.
+        arc = ptf.PkgTarFile(name=arc_path, mode="r")
+        # Add in the p5i file since this is an archive with signed
+        # packages created from a repo.
+        expected = sorted(self.multi_expected + ["publisher/test/pub.p5i"])
+        action_certs = [
+            self.calc_pem_hash(t)
+            for t in (
+                os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch2_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch3_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch4_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch5_ta1_cert.pem"),
+                os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+            )
+        ]
+        for hsh in action_certs:
+            d = "publisher/test/file/{0}".format(hsh[0:2])
+            f = "{0}/{1}".format(d, hsh)
+            expected.append(d)
+            expected.append(f)
+        actual = sorted(m.name for m in arc.getmembers())
+        self.assertEqualDiff(sorted(set(expected)), actual)
+        arc.close()
+
+        # Verify pkg(7) archive class extraction behaviour using
+        # the new archive.
+        arc = self.__verify_extract(repo, arc_path, hashes, ext_dir)
+        arc.close()
+
+        # Extract all of the existing content.
+        arc = ptf.PkgTarFile(name=arc_path, mode="r")
+        arc.extractall(ext_dir)
+        arc.close()
+
+        # Now verify archive can still be used when index file
+        # is omitted.
+        os.unlink(arc_path)
+        arc = ptf.PkgTarFile(name=arc_path, mode="w")
+        for dirpath, dirnames, filenames in os.walk(ext_dir):
+            list(
+                map(add_entry, [f for f in filenames if f != "pkg5.index.0.gz"])
+            )
+            list(map(add_entry, dirnames))
+        arc.close()
+
+        # Verify pkg(7) archive class extraction behaviour using
+        # the new archive.
+        arc = self.__verify_extract(repo, arc_path, hashes, ext_dir)
+        arc.close()
+
+        # Save an index for later.
+        arc = pkg.p5p.Archive(arc_path, mode="r")
+        saved_index = arc.get_index()
+        arc.close()
+
+        # Verify we can extract the archive reusing an index.
+        arc = self.__verify_extract(
+            repo, arc_path, hashes, ext_dir, archive_index=saved_index
+        )
+        arc.close()
+
+        # Verify we throw an assert when opening a p5p in write mode.
+        self.assertRaisesStringify(
+            AssertionError,
+            pkg.p5p.Archive,
+            arc_path,
+            mode="w",
+            archive_index=saved_index,
+        )
+
+        # Verify we can't extract archive members using a corrupted
+        # index.
+        arc = pkg.p5p.Archive(arc_path, mode="r", archive_index={"cats": 1234})
+        self.assertRaisesStringify(
+            pkg.p5p.ArchiveErrors,
+            arc.extract_catalog1,
+            "catalog.attrs",
+            ext_dir,
+        )
+        self.assertRaisesStringify(
+            pkg.p5p.ArchiveErrors, arc.extract_package_files, hashes, ext_dir
+        )
+        arc.close()
+
+    def test_05_invalid(self):
+        """Verify that pkg(7) archive class handles broken archives
+        and items that aren't archives as expected."""
+
+        arc_path = os.path.join(self.test_root, "nosucharchive.p5p")
+
+        #
+        # Check that no archive is handled.
+        #
+        self.assertRaisesStringify(
+            pkg.p5p.InvalidArchive, pkg.p5p.Archive, arc_path, mode="r"
+        )
+
+        #
+        # Check that empty archive file is handled.
+        #
+        arc_path = os.path.join(self.test_root, "retrieve.p5p")
+        open(arc_path, "wb").close()
+        self.assertRaisesStringify(
+            pkg.p5p.InvalidArchive, pkg.p5p.Archive, arc_path, mode="r"
+        )
+        os.unlink(arc_path)
+
+        #
+        # Check that invalid archive file is handled.
+        #
+        with open(arc_path, "w") as f:
+            f.write("not_a_valid_archive")
+        self.assertRaisesStringify(
+            pkg.p5p.InvalidArchive, pkg.p5p.Archive, arc_path, mode="r"
+        )
+        os.unlink(arc_path)
+
+        #
+        # Check that a truncated archive is handled.
+        #
+        repo = self.get_repo(self.dc.get_repodir())
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        arc.add_repo_package(self.foo, repo)
+        arc.add_repo_package(self.signed, repo)
+        arc.add_repo_package(self.quux, repo)
+        arc.close()
+
+        #
+        # Check that truncated archives, or archives with invalid
+        # indexes are handled as expected.
+        #
+
+        # Determine where to truncate archive by looking for specific
+        # package file and then setting truncate location to halfway
+        # through data for file.
+        arc = ptf.PkgTarFile(name=arc_path, mode="r")
+        idx_data_offset = 0
+        src_offset = 0
+        src_bytes = 0
+        dest_offset = 0
+        trunc_sz = 0
+        src_fhash = "b265f2ec87c4a55eb2b6b4c926e7c65f7247a27e"
+        dest_fhash = "801eebbfe8c526bf092d98741d4228e4d0fc99ae"
+        for m in arc.getmembers():
+            if m.name.endswith("/" + dest_fhash):
+                dest_offset = m.offset
+                trunc_sz = m.offset_data + int(m.size // 2)
+            elif m.name.endswith("pkg5.index.0.gz"):
+                idx_data_offset = m.offset_data
+            elif m.name.endswith("/" + src_fhash):
+                # Calculate size of source entry.
+                src_bytes = m.offset_data - m.offset
+                blocks, rem = divmod(m.size, tf.BLOCKSIZE)
+                if rem > 0:
+                    blocks += 1
+                src_bytes += blocks * tf.BLOCKSIZE
+                src_offset = m.offset
+
+        arc.close()
+
+        # Test truncated archive case.
+        bad_arc_path = os.path.join(self.test_root, "bad_arc.p5p")
+        portable.copyfile(arc_path, bad_arc_path)
+
+        self.debug(
+            "{0} size: {1:d} truncate: {2:d}".format(
+                arc_path, os.stat(arc_path).st_size, trunc_sz
+            )
+        )
+        with open(bad_arc_path, "ab+") as f:
+            f.truncate(trunc_sz)
+
+        ext_dir = os.path.join(self.test_root, "extracted")
+        shutil.rmtree(ext_dir, True)
+        arc = pkg.p5p.Archive(bad_arc_path, mode="r")
+        self.assertRaisesStringify(
+            pkg.p5p.InvalidArchive,
+            arc.extract_package_files,
+            [dest_fhash],
+            ext_dir,
+            pub="test2",
+        )
+        arc.close()
+
+        # Test archive with invalid index; do this by writing some bogus
+        # bytes into the data area for the index.
+        portable.copyfile(arc_path, bad_arc_path)
+        with open(bad_arc_path, "ab+") as dest:
+            dest.seek(idx_data_offset)
+            dest.truncate()
+            with open(arc_path, "rb") as src:
+                bogus_data = b"invalid_index_data"
+                dest.write(bogus_data)
+                src.seek(idx_data_offset + len(bogus_data))
+                dest.write(src.read())
+
+        shutil.rmtree(ext_dir, True)
+        self.assertRaisesStringify(
+            pkg.p5p.InvalidArchive, pkg.p5p.Archive, bad_arc_path, mode="r"
+        )
+
+        # Test archive with invalid index offsets; do this by truncating
+        # an existing archive at the offset of one of its files and then
+        # appending the data for a different archive member in its
+        # place.
+        portable.copyfile(arc_path, bad_arc_path)
+        with open(bad_arc_path, "ab+") as dest:
+            dest.seek(dest_offset)
+            dest.truncate()
+            with open(arc_path, "rb") as src:
+                src.seek(src_offset)
+                dest.write(src.read(src_bytes))
+
+        shutil.rmtree(ext_dir, True)
+        arc = pkg.p5p.Archive(bad_arc_path, mode="r")
+        self.assertRaisesStringify(
+            pkg.p5p.InvalidArchive,
+            arc.extract_package_files,
+            [dest_fhash],
+            ext_dir,
+            pub="test2",
+        )
+        arc.close()
+
+        os.unlink(arc_path)
+        os.unlink(bad_arc_path)
+
+        #
+        # Check that directory where archive expected is handled.
+        #
+        os.mkdir(arc_path)
+        self.assertRaisesStringify(
+            pkg.p5p.InvalidArchive, pkg.p5p.Archive, arc_path, mode="r"
+        )
+        os.rmdir(arc_path)
+
+        # Temporarily change the current archive version and create a
+        # a new archive, and then verify that the expected exception is
+        # raised when an attempt to read it is made.
+        orig_ver = pkg.p5p.Archive.CURRENT_VERSION
+        try:
+            pkg.p5p.Archive.CURRENT_VERSION = 99  # EVIL
+            arc = pkg.p5p.Archive(arc_path, mode="w")
+            arc.close()
+        finally:
+            # Ensure this is reset to the right value.
+            pkg.p5p.Archive.CURRENT_VERSION = orig_ver
+
+        self.assertRaisesStringify(
+            pkg.p5p.InvalidArchive, pkg.p5p.Archive, arc_path, mode="r"
+        )
+        os.unlink(arc_path)
+
+    def test_06_get_index(self):
+        """Verify we can't retrieve an index from an archive opened
+        in write-mode."""
+        arc_path = os.path.join(self.test_root, "index.p5p")
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        self.assertRaisesStringify(AssertionError, arc.get_index)
+        arc.close()
+        os.unlink(arc_path)
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_pkg_api_fix.py
+++ b/src/tests/api/t_pkg_api_fix.py
@@ -25,51 +25,58 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import pkg.client.api_errors as api_errors
 
-class TestPkgApiFix(pkg5unittest.SingleDepotTestCase):
 
-        amber10 = """
+class TestPkgApiFix(pkg5unittest.SingleDepotTestCase):
+    amber10 = """
             open amber@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add file amber1 mode=0644 owner=root group=bin path=etc/amber1
             close """
 
-        misc_files = ["amber1"]
+    misc_files = ["amber1"]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.pkgsend_bulk(self.rurl, self.amber10)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.pkgsend_bulk(self.rurl, self.amber10)
 
-        def test_01_basic(self):
+    def test_01_basic(self):
+        api_inst = self.image_create(self.rurl)
 
-                api_inst = self.image_create(self.rurl)
+        self._api_install(api_inst, ["amber"])
+        victim = "etc/amber1"
+        # Corrupt the file
+        self.file_append(victim, "foobar")
 
-                self._api_install(api_inst, ["amber"])
-                victim = "etc/amber1"
-                # Corrupt the file
-                self.file_append(victim, "foobar")
+        self._api_fix(api_inst)
+        self.pkg("verify")
 
-                self._api_fix(api_inst)
-                self.pkg("verify")
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            lambda *args, **kwargs: list(
+                api_inst.gen_plan_fix(*args, **kwargs)
+            ),
+            ["foo", "bar"],
+        )
 
-                self.assertRaises(api_errors.PlanCreationException,
-                    lambda *args, **kwargs: list(
-                        api_inst.gen_plan_fix(*args, **kwargs)),
-                    ["foo", "bar"])
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            lambda *args, **kwargs: list(
+                api_inst.gen_plan_fix(*args, **kwargs)
+            ),
+            ["amber@-1.0"],
+        )
 
-                self.assertRaises(api_errors.PlanCreationException,
-                    lambda *args, **kwargs: list(
-                        api_inst.gen_plan_fix(*args, **kwargs)),
-                    ["amber@-1.0"])
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_pkg_api_hydrate.py
+++ b/src/tests/api/t_pkg_api_hydrate.py
@@ -25,16 +25,16 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import pkg.client.api_errors as api_errors
 
 
 class TestPkgApiHydrate(pkg5unittest.SingleDepotTestCase):
-
-        dev10 = """
+    dev10 = """
             open dev@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=dev
             add dir mode=0755 owner=root group=bin path=dev/cfg
@@ -45,50 +45,60 @@ class TestPkgApiHydrate(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        misc_files = ["dev/cfg/bar", "dev/cfg/bar1", "dev/cfg/bar2",
-            "dev/cfg/bar2.hlink"]
+    misc_files = [
+        "dev/cfg/bar",
+        "dev/cfg/bar1",
+        "dev/cfg/bar2",
+        "dev/cfg/bar2.hlink",
+    ]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.pkgsend_bulk(self.rurl, self.dev10)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.pkgsend_bulk(self.rurl, self.dev10)
 
-        def test_01_basic(self):
-                api_inst = self.image_create(self.rurl)
-                self._api_install(api_inst, ["dev"])
+    def test_01_basic(self):
+        api_inst = self.image_create(self.rurl)
+        self._api_install(api_inst, ["dev"])
 
-                self._api_dehydrate(api_inst)
+        self._api_dehydrate(api_inst)
 
-                # Verify that files are deleted or remained as expected.
-                self.file_exists("dev/cfg/bar")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.file_exists("dev/cfg/bar2")
-                self.file_doesnt_exist("dev/cfg/bar2.hlink")
+        # Verify that files are deleted or remained as expected.
+        self.file_exists("dev/cfg/bar")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.file_exists("dev/cfg/bar2")
+        self.file_doesnt_exist("dev/cfg/bar2.hlink")
 
-                self._api_rehydrate(api_inst)
-                self.pkg("verify")
+        self._api_rehydrate(api_inst)
+        self.pkg("verify")
 
-        def test_bad_publishers(self):
-                api_inst = self.image_create(self.rurl)
-                self._api_install(api_inst, ["dev"])
+    def test_bad_publishers(self):
+        api_inst = self.image_create(self.rurl)
+        self._api_install(api_inst, ["dev"])
 
-                # Test that dehydrate will raise a PlanCreationException when
-                # encountering bad publishers.
-                self.assertRaises(api_errors.PlanCreationException,
-                    lambda *args, **kwargs: list(
-                        api_inst.gen_plan_dehydrate(*args, **kwargs)),
-                    ["-p nosuch", "-p unknown", "-p test"])
+        # Test that dehydrate will raise a PlanCreationException when
+        # encountering bad publishers.
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            lambda *args, **kwargs: list(
+                api_inst.gen_plan_dehydrate(*args, **kwargs)
+            ),
+            ["-p nosuch", "-p unknown", "-p test"],
+        )
 
-                # Test that rehydrate will raise a PlanCreationException when
-                # encountering bad publishers.
-                self.assertRaises(api_errors.PlanCreationException,
-                    lambda *args, **kwargs: list(
-                        api_inst.gen_plan_rehydrate(*args, **kwargs)),
-                    ["-p nosuch", "-p unknown", "-p test"])
+        # Test that rehydrate will raise a PlanCreationException when
+        # encountering bad publishers.
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            lambda *args, **kwargs: list(
+                api_inst.gen_plan_rehydrate(*args, **kwargs)
+            ),
+            ["-p nosuch", "-p unknown", "-p test"],
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_pkg_api_install.py
+++ b/src/tests/api/t_pkg_api_install.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -50,121 +51,122 @@ from six.moves.urllib.request import pathname2url
 
 PKG_CLIENT_NAME = "pkg"
 
-class TestPkgApiInstall(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = False
 
-        foo10 = """
+class TestPkgApiInstall(pkg5unittest.SingleDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = False
+
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1 timestamp="20080731T024051Z"
             close """
-        foo11_timestamp = 1217472051
+    foo11_timestamp = 1217472051
 
-        foo12 = """
+    foo12 = """
             open foo@1.2,5.11-0
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
             close """
 
-        bar09 = """
+    bar09 = """
             open bar@0.9,5.11-0
             add depend type=require fmri=pkg:/foo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0550 owner=root group=bin path=/bin/cat
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             add depend type=require fmri=pkg:/foo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        bar11 = """
+    bar11 = """
             open bar@1.1,5.11-0
             add depend type=require fmri=pkg:/foo@1.2
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        xfoo10 = """
+    xfoo10 = """
             open xfoo@1.0,5.11-0
             close """
 
-        xbar10 = """
+    xbar10 = """
             open xbar@1.0,5.11-0
             add depend type=require fmri=pkg:/xfoo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        xbar11 = """
+    xbar11 = """
             open xbar@1.1,5.11-0
             add depend type=require fmri=pkg:/xfoo@1.2
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        bar12 = """
+    bar12 = """
             open bar@1.2,5.11-0
             add depend type=require fmri=pkg:/foo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             add depend type=require fmri=pkg:/foo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/baz mode=0555 owner=root group=bin path=/bin/baz
             close """
 
-        deep10 = """
+    deep10 = """
             open deep@1.0,5.11-0
             add depend type=require fmri=pkg:/bar@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        xdeep10 = """
+    xdeep10 = """
             open xdeep@1.0,5.11-0
             add depend type=require fmri=pkg:/xbar@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        ydeep10 = """
+    ydeep10 = """
             open ydeep@1.0,5.11-0
             add depend type=require fmri=pkg:/ybar@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        badfile10 = """
+    badfile10 = """
             open badfile@1.0,5.11-0
             add file tmp/baz mode=644 owner=root group=bin path=/foo/baz-file
             close """
 
-        baddir10 = """
+    baddir10 = """
             open baddir@1.0,5.11-0
             add dir mode=755 owner=root group=bin path=/foo/baz-dir
             close """
 
-        moving10 = """
+    moving10 = """
             open moving@1.0,5.11-0
             add file tmp/baz mode=644 owner=root group=bin path=baz preserve=true
             close """
 
-        moving20 = """
+    moving20 = """
             open moving@2.0,5.11-0
             add file tmp/baz mode=644 owner=root group=bin path=quux original_name="moving:baz" preserve=true
             close """
 
-        corepkgs = """
+    corepkgs = """
             open consolidation/ips/ips-incorporation@1.0,5.11-0
             add depend type=incorporate fmri=package/pkg@1
             close
@@ -193,7 +195,7 @@ class TestPkgApiInstall(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        carriage = """
+    carriage = """
             open carriage@1.0
             add depend type=require fmri=horse@1.0
             add depend type=exclude fmri=horse@2.0
@@ -203,13 +205,13 @@ class TestPkgApiInstall(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        horse = """
+    horse = """
             open horse@1.0
             close
             open horse@2.0
             close """
 
-        foo = """
+    foo = """
             open foo@1.0
             add file tmp/motd mode=0444 owner=root group=bin path=etc/motd
             close
@@ -217,1362 +219,1513 @@ class TestPkgApiInstall(pkg5unittest.SingleDepotTestCase):
             add file tmp/motd mode=0644 owner=root group=bin path=etc/motd
             close"""
 
-        misc_files = [ "tmp/libc.so.1", "tmp/cat", "tmp/baz", "tmp/motd" ]
+    misc_files = ["tmp/libc.so.1", "tmp/cat", "tmp/baz", "tmp/motd"]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-        @staticmethod
-        def __do_install(api_obj, fmris):
-                api_obj.reset()
-                for pd in api_obj.gen_plan_install(fmris):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
+    @staticmethod
+    def __do_install(api_obj, fmris):
+        api_obj.reset()
+        for pd in api_obj.gen_plan_install(fmris):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
 
-        @staticmethod
-        def __do_update(api_obj, fmris):
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update(fmris):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
+    @staticmethod
+    def __do_update(api_obj, fmris):
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update(fmris):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
 
-        @staticmethod
-        def __do_uninstall(api_obj, fmris):
-                api_obj.reset()
-                for pd in api_obj.gen_plan_uninstall(fmris):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
+    @staticmethod
+    def __do_uninstall(api_obj, fmris):
+        api_obj.reset()
+        for pd in api_obj.gen_plan_uninstall(fmris):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
 
-        def test_needsdata(self):
-                """Ensure graceful failure or successful retrieval if preserved
-                files are modified after image planning or a small number of
-                files are missing."""
+    def test_needsdata(self):
+        """Ensure graceful failure or successful retrieval if preserved
+        files are modified after image planning or a small number of
+        files are missing."""
 
-                self.dc.start()
-                self.pkgsend_bulk(self.durl, self.foo)
-                api_obj = self.image_create(self.durl)
+        self.dc.start()
+        self.pkgsend_bulk(self.durl, self.foo)
+        api_obj = self.image_create(self.durl)
 
-                # Install foo@1.0
-                self.__do_install(api_obj, ["foo@1.0"])
+        # Install foo@1.0
+        self.__do_install(api_obj, ["foo@1.0"])
 
-                # Now plan an upgrade to foo@2.0 in which only the mode changes,
-                # but the content has not...
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update(["foo"]):
-                        continue
-                api_obj.prepare()
+        # Now plan an upgrade to foo@2.0 in which only the mode changes,
+        # but the content has not...
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update(["foo"]):
+            continue
+        api_obj.prepare()
 
-                # Now remove the file before we execute the plan to simulate bad
-                # administrative change for a misbehaving program and verify we
-                # do a one-off retrieval of the file and won't fail.
-                self.file_remove("etc/motd")
-                api_obj.execute_plan()
+        # Now remove the file before we execute the plan to simulate bad
+        # administrative change for a misbehaving program and verify we
+        # do a one-off retrieval of the file and won't fail.
+        self.file_remove("etc/motd")
+        api_obj.execute_plan()
 
-                self.__do_uninstall(api_obj, ["foo"])
-                self.__do_install(api_obj, ["foo@1.0"])
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update(["foo"]):
-                        continue
-                api_obj.prepare()
+        self.__do_uninstall(api_obj, ["foo"])
+        self.__do_install(api_obj, ["foo@1.0"])
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update(["foo"]):
+            continue
+        api_obj.prepare()
 
-                DebugValues['max-plan-execute-retrievals'] = 1
-                self.file_remove("etc/motd")
-                # Test that we raise an exception if we have to retrieve too
-                # many files.
-                self.assertRaises(api_errors.PlanExecutionError,
-                    lambda *args, **kwargs: api_obj.execute_plan())
+        DebugValues["max-plan-execute-retrievals"] = 1
+        self.file_remove("etc/motd")
+        # Test that we raise an exception if we have to retrieve too
+        # many files.
+        self.assertRaises(
+            api_errors.PlanExecutionError,
+            lambda *args, **kwargs: api_obj.execute_plan(),
+        )
 
-        def test_basics_1(self):
-                """ Send empty package foo@1.0, install and uninstall """
+    def test_basics_1(self):
+        """Send empty package foo@1.0, install and uninstall"""
 
-                self.pkgsend_bulk(self.rurl, self.foo10)
-                api_obj = self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, self.foo10)
+        api_obj = self.image_create(self.rurl)
 
-                self.pkg("list -a")
-                self.pkg("list", exit=1)
+        self.pkg("list -a")
+        self.pkg("list", exit=1)
 
-                self.__do_install(api_obj, ["foo"])
+        self.__do_install(api_obj, ["foo"])
 
-                self.pkg("list")
-                self.pkg("verify")
+        self.pkg("list")
+        self.pkg("verify")
 
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["foo"])
-                self.pkg("verify")
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["foo"])
+        self.pkg("verify")
 
-        def test_basics_2(self):
-                """ Send package foo@1.1, containing a directory and a file,
-                    install, search, and uninstall. """
+    def test_basics_2(self):
+        """Send package foo@1.1, containing a directory and a file,
+        install, search, and uninstall."""
 
-                plist = self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11),
-                    refresh_index=True)
-                api_obj = self.image_create(self.rurl)
+        plist = self.pkgsend_bulk(
+            self.rurl, (self.foo10, self.foo11), refresh_index=True
+        )
+        api_obj = self.image_create(self.rurl)
 
-                self.pkg("list -a")
-                self.__do_install(api_obj, ["foo"])
+        self.pkg("list -a")
+        self.__do_install(api_obj, ["foo"])
 
-                self.pkg("verify")
-                self.pkg("list")
+        self.pkg("verify")
+        self.pkg("list")
 
-                self.pkg("search -l /lib/libc.so.1")
-                self.pkg("search -r /lib/libc.so.1")
-                self.pkg("search -l blah", exit=1)
-                self.pkg("search -r blah", exit=1)
+        self.pkg("search -l /lib/libc.so.1")
+        self.pkg("search -r /lib/libc.so.1")
+        self.pkg("search -l blah", exit=1)
+        self.pkg("search -r blah", exit=1)
 
-                # check to make sure timestamp was set to correct value
-                libc_path = os.path.join(self.get_img_path(), "lib/libc.so.1")
-                fstat = os.stat(libc_path)
+        # check to make sure timestamp was set to correct value
+        libc_path = os.path.join(self.get_img_path(), "lib/libc.so.1")
+        fstat = os.stat(libc_path)
 
-                self.assertTrue(fstat[stat.ST_MTIME] == self.foo11_timestamp)
+        self.assertTrue(fstat[stat.ST_MTIME] == self.foo11_timestamp)
 
-                # check that verify finds changes
-                now = time.time()
-                os.utime(libc_path, (now, now))
-                self.pkg("verify", exit=1)
+        # check that verify finds changes
+        now = time.time()
+        os.utime(libc_path, (now, now))
+        self.pkg("verify", exit=1)
 
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["foo"])
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["foo"])
 
-                self.pkg("verify")
-                self.pkg("list -a")
-                self.pkg("verify")
+        self.pkg("verify")
+        self.pkg("list -a")
+        self.pkg("verify")
 
-        def test_basics_3(self):
-                """ Install foo@1.0, upgrade to foo@1.1, update foo@1.0,
-                and then uninstall. """
+    def test_basics_3(self):
+        """Install foo@1.0, upgrade to foo@1.1, update foo@1.0,
+        and then uninstall."""
 
-                self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11))
-                api_obj = self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11))
+        api_obj = self.image_create(self.rurl)
 
-                self.__do_install(api_obj, ["foo@1.0"])
+        self.__do_install(api_obj, ["foo@1.0"])
 
-                self.pkg("list foo@1.0")
-                self.pkg("list foo@1.1", exit=1)
+        self.pkg("list foo@1.0")
+        self.pkg("list foo@1.1", exit=1)
 
-                api_obj.reset()
-                self.__do_install(api_obj, ["foo@1.1"])
-                self.pkg("list foo@1.1")
-                self.pkg("list foo@1.0", exit=1)
-                self.pkg("list foo@1")
-                self.pkg("verify")
+        api_obj.reset()
+        self.__do_install(api_obj, ["foo@1.1"])
+        self.pkg("list foo@1.1")
+        self.pkg("list foo@1.0", exit=1)
+        self.pkg("list foo@1")
+        self.pkg("verify")
 
-                api_obj.reset()
-                self.__do_update(api_obj, ["foo@1.0"])
-                self.pkg("list foo@1.0")
-                self.pkg("list foo@1.1", exit=1)
-                self.pkg("verify")
+        api_obj.reset()
+        self.__do_update(api_obj, ["foo@1.0"])
+        self.pkg("list foo@1.0")
+        self.pkg("list foo@1.1", exit=1)
+        self.pkg("verify")
 
-                api_obj.reset()
-                self.__do_update(api_obj, ["foo@1.1"])
-                self.pkg("list foo@1.1")
-                self.pkg("list foo@1.0", exit=1)
-                self.pkg("verify")
+        api_obj.reset()
+        self.__do_update(api_obj, ["foo@1.1"])
+        self.pkg("list foo@1.1")
+        self.pkg("list foo@1.0", exit=1)
+        self.pkg("verify")
 
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["foo"])
-                self.pkg("list -a")
-                self.pkg("verify")
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["foo"])
+        self.pkg("list -a")
+        self.pkg("verify")
 
-        def test_basics_4(self):
-                """ Add bar@1.0, dependent on foo@1.0, install, uninstall. """
+    def test_basics_4(self):
+        """Add bar@1.0, dependent on foo@1.0, install, uninstall."""
 
-                self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11,
-                    self.bar10))
-                api_obj = self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11, self.bar10))
+        api_obj = self.image_create(self.rurl)
 
-                self.pkg("list -a")
-                api_obj.reset()
-                self.__do_install(api_obj, ["bar@1.0"])
+        self.pkg("list -a")
+        api_obj.reset()
+        self.__do_install(api_obj, ["bar@1.0"])
 
-                self.pkg("list")
-                self.pkg("verify")
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["bar", "foo"])
+        self.pkg("list")
+        self.pkg("verify")
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["bar", "foo"])
 
-                # foo and bar should not be installed at this point
-                self.pkg("list bar", exit=1)
-                self.pkg("list foo", exit=1)
-                self.pkg("verify")
+        # foo and bar should not be installed at this point
+        self.pkg("list bar", exit=1)
+        self.pkg("list foo", exit=1)
+        self.pkg("verify")
 
-        def test_update_backwards(self):
-                """ Publish horse and carriage, verify update won't downgrade
-                packages not specified for operation. """
+    def test_update_backwards(self):
+        """Publish horse and carriage, verify update won't downgrade
+        packages not specified for operation."""
 
-                self.pkgsend_bulk(self.rurl, (self.carriage, self.horse))
-                api_obj = self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (self.carriage, self.horse))
+        api_obj = self.image_create(self.rurl)
 
-                self.__do_install(api_obj, ["carriage@2"])
+        self.__do_install(api_obj, ["carriage@2"])
 
-                # Attempting to update carriage should result in nothing to do.
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update(["carriage"]):
-                        continue
-                self.assertTrue(api_obj.planned_nothingtodo())
+        # Attempting to update carriage should result in nothing to do.
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update(["carriage"]):
+            continue
+        self.assertTrue(api_obj.planned_nothingtodo())
 
-                # Downgrading to carriage@1.0 would force a downgrade to
-                # horse@1.0 and so should raise an exception...
-                api_obj.reset()
-                self.assertRaises(api_errors.PlanCreationException,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_update(*args, **kwargs)),
-                    ["carriage@1"])
+        # Downgrading to carriage@1.0 would force a downgrade to
+        # horse@1.0 and so should raise an exception...
+        api_obj.reset()
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_update(*args, **kwargs)
+            ),
+            ["carriage@1"],
+        )
 
-                api_obj.reset()
-                self.assertRaises(api_errors.PlanCreationException,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_update(*args, **kwargs)),
-                    ["carriage@1", "horse"])
+        api_obj.reset()
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_update(*args, **kwargs)
+            ),
+            ["carriage@1", "horse"],
+        )
 
-                # ...unless horse is explicitly downgraded as well.
-                api_obj.reset()
-                self.__do_update(api_obj, ["carriage@1", "horse@1"])
-                self.pkg("list carriage@1 horse@1")
+        # ...unless horse is explicitly downgraded as well.
+        api_obj.reset()
+        self.__do_update(api_obj, ["carriage@1", "horse@1"])
+        self.pkg("list carriage@1 horse@1")
 
-                # Update carriage again.
-                self.__do_update(api_obj, ["carriage"])
-                self.pkg("list carriage@2 horse@2")
+        # Update carriage again.
+        self.__do_update(api_obj, ["carriage"])
+        self.pkg("list carriage@2 horse@2")
 
-                # Publish a new version of carriage.
-                self.pkgsend_bulk(self.rurl, """
+        # Publish a new version of carriage.
+        self.pkgsend_bulk(
+            self.rurl,
+            """
                     open carriage@3.0
                     add depend type=require fmri=horse@1.0
                     add depend type=exclude fmri=horse@2.0
-                    close """)
-                api_obj.reset()
-                api_obj.refresh()
-
-                # Upgrading implicitly to carriage@3.0 would force a downgrade
-                # to horse@1.0 so should be ignored as a possibility by
-                # the solver.
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update(["carriage"]):
-                        continue
-                self.assertTrue(api_obj.planned_nothingtodo())
-
-                # Upgrading explicitly to carriage@3.0 would force a downgrade
-                # to horse@1.0 and so should raise an exception...
-                api_obj.reset()
-                self.assertRaises(api_errors.PlanCreationException,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_update(*args, **kwargs)),
-                    ["carriage@3", "horse"])
-
-                # ...unless horse is explicitly downgraded as well.
-                api_obj.reset()
-                self.__do_update(api_obj, ["carriage@3", "horse@1"])
-                self.pkg("list carriage@3 horse@1")
-
-                # Now verify an implicit update to carriage@3.0 will work
-                # if horse is explicitly downgraded to 1.0.
-                api_obj.reset()
-                self.__do_update(api_obj, ["carriage@2", "horse@2"])
-                self.pkg("list carriage@2 horse@2")
-
-                api_obj.reset()
-                self.__do_update(api_obj, ["carriage", "horse@1"])
-                self.pkg("list carriage@3 horse@1")
-
-        def test_multi_publisher(self):
-                """ Verify that package install works as expected when multiple
-                publishers share the same repository. """
-
-                # Publish a package for 'test'.
-                self.pkgsend_bulk(self.rurl, self.bar10)
-
-                # Now change the default publisher to 'test2' and publish
-                # another package.
-                self.pkgrepo("set -s {0} publisher/prefix=test2".format(self.rurl))
-                self.pkgsend_bulk(self.rurl, self.foo10)
-
-                # Finally, create an image and verify that packages from
-                # both publishers may be installed.
-                api_obj = self.image_create(self.rurl, prefix=None)
-                self.__do_install(api_obj, ["pkg://test/bar@1.0",
-                    "pkg://test2/foo@1.0"])
-
-        def test_pkg_file_errors(self):
-                """ Verify that package install and uninstall works as expected
-                when files or directories are missing. """
-
-                self.pkgsend_bulk(self.rurl, (self.bar09, self.bar10,
-                    self.bar11, self.foo10, self.foo12, self.moving10,
-                    self.moving20))
-                api_obj = self.image_create(self.rurl)
-
-                # Verify that missing files will be replaced during upgrade if
-                # the file action has changed (even if the content hasn't),
-                # such as when the mode changes.
-                self.__do_install(api_obj, ["bar@0.9"])
-                file_path = os.path.join(self.get_img_path(), "bin", "cat")
-                portable.remove(file_path)
-                self.assertTrue(not os.path.isfile(file_path))
-                self.__do_install(api_obj, ["bar@1.0"])
-                self.assertTrue(os.path.isfile(file_path))
-
-                # Verify that if the directory containing a missing file is also
-                # missing that upgrade will still work as expected for the file.
-                self.__do_uninstall(api_obj, ["bar@1.0"])
-                self.__do_install(api_obj, ["bar@0.9"])
-                dir_path = os.path.dirname(file_path)
-                shutil.rmtree(dir_path)
-                self.assertTrue(not os.path.isdir(dir_path))
-                self.__do_install(api_obj, ["bar@1.0"])
-                self.assertTrue(os.path.isfile(file_path))
-
-                # Verify that missing files won't cause uninstall failure.
-                portable.remove(file_path)
-                self.assertTrue(not os.path.isfile(file_path))
-                self.__do_uninstall(api_obj, ["bar@1.0"])
-
-                # Verify that missing directories won't cause uninstall failure.
-                self.__do_install(api_obj, ["bar@1.0"])
-                shutil.rmtree(dir_path)
-                self.assertTrue(not os.path.isdir(dir_path))
-                self.__do_uninstall(api_obj, ["bar@1.0"])
-
-                # Verify that missing files won't cause update failure if
-                # original_name is set.
-                self.__do_install(api_obj, ["moving@1.0"])
-                file_path = os.path.join(self.get_img_path(), "baz")
-                portable.remove(file_path)
-                self.__do_install(api_obj, ["moving@2.0"])
-                file_path = os.path.join(self.get_img_path(), "quux")
-
-                # Verify that missing files won't cause uninstall failure if
-                # original_name is set.
-                self.assertTrue(os.path.isfile(file_path))
-                portable.remove(file_path)
-                self.__do_uninstall(api_obj, ["moving@2.0"])
-
-        def test_image_upgrade(self):
-                """ Send package bar@1.1, dependent on foo@1.2.  Install
-                    bar@1.0.  List all packages.  Upgrade image. """
-
-                self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11,
-                    self.bar10))
-                api_obj = self.image_create(self.rurl)
-
-                self.__do_install(api_obj, ["bar@1.0"])
-
-                self.pkgsend_bulk(self.rurl, (self.foo12, self.bar11))
-
-                self.pkg("contents -H")
-                self.pkg("list")
-                api_obj.refresh(immediate=True)
-
-                self.pkg("list")
-                self.pkg("verify")
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-                self.pkg("verify")
-
-                self.pkg("list foo@1.2")
-                self.pkg("list bar@1.1")
-
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["bar", "foo"])
-                self.pkg("verify")
-
-        def test_ipkg_out_of_date(self):
-                """Make sure that packaging system out-of-date testing works."""
-
-                self.pkgsend_bulk(self.rurl, (self.foo10, self.foo12,
-                    self.corepkgs))
-                self.image_create(self.rurl)
-
-                api_obj = self.get_img_api_obj()
-
-                # Update when it doesn't appear to be an opensolaris image
-                # shouldn't have any issues.
-                self.__do_install(api_obj, ["foo@1.0"])
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        continue
-
-                # Even though SUNWipkg is on the system, it won't appear as an
-                # opensolaris system.
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["*"])
-                api_obj.reset()
-                self.__do_install(api_obj, ["foo@1.0", "SUNWipkg@1.0"])
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        continue
-
-                # Same for package/pkg
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["*"])
-                api_obj.reset()
-                self.__do_install(api_obj, ["foo@1.0", "package/pkg@1.0"])
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        continue
-
-                # Same for SUNWcs
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["*"])
-                api_obj.reset()
-                self.__do_install(api_obj, ["foo@1.0", "SUNWcs"])
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        continue
-
-                # There are still no problems if the packaging system is up to
-                # date.  We can't test with SUNWipkg installed instead, because
-                # we're making the assumption in the code that we always want to
-                # update package/pkg, given that this revision of the code will
-                # only run on systems where the packaging system is in that
-                # package.
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["*"])
-                api_obj.reset()
-                self.__do_install(api_obj, ["foo@1.0", "SUNWcs", "package/pkg@1.1"])
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        continue
-
-                # We should run into a problem if pkg(7) is out of date.
-                # api_obj.reset()
-                # self.__do_uninstall(api_obj, ["*"])
-                # api_obj.reset()
-                # self.__do_install(api_obj,
-                #     ["foo@1.0", "SUNWcs", "package/pkg@1.0"])
-                # api_obj.reset()
-                # self.assertRaises(api_errors.IpkgOutOfDateException,
-                #     lambda *args, **kwargs: list(
-                #         api_obj.gen_plan_update(*args, **kwargs)))
-
-                # Use the metadata on release/name to determine it's an
-                # opensolaris system.
-                # api_obj.reset()
-                # self.__do_uninstall(api_obj, ["*"])
-                # api_obj.reset()
-                # self.__do_install(api_obj,
-                #     ["foo@1.0", "release/name@2.0", "package/pkg@1.0"])
-                # api_obj.reset()
-                # self.assertRaises(api_errors.IpkgOutOfDateException,
-                #     lambda *args, **kwargs: list(
-                #         api_obj.gen_plan_update(*args, **kwargs)))
-
-                # An older release/name which doesn't have the metadata should
-                # cause us to skip the check.
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["*"])
-                api_obj.reset()
-                self.__do_install(api_obj,
-                    ["foo@1.0", "release/name@1.0", "package/pkg@1.0"])
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        continue
-
-                # Verify that if a newer version of package/pkg is available
-                # but not allowed by the currently installed ips-incorporation
-                # that the client up-to-date check succeeds.
-                self.__do_uninstall(api_obj, ["*"])
-                self.__do_install(api_obj, ["release/name@2.0", "package/pkg@1.1"])
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        pass
-
-                # Verify that if the image pkg is executed from has a client
-                # with a newer version installed than what is available in the
-                # image being operated on that the update check will not fail.
-                self.__do_update(api_obj, ["ips-incorporation@1.0", "pkg@1.0"])
-
-                idir = os.path.join(self.test_root, "pkg-mismatch")
-                self.pkg("image-create -F -p {0} {1}".format(self.rurl, idir))
-
-                mis_api_obj = self.get_img_api_obj(img_path=idir)
-                self.__do_install(mis_api_obj, ["release/name@2.0", "package/pkg@2.0"])
-                # The version found in the image pkg is being executed from must
-                # not be available in the image being operated on.  Removing the
-                # publisher is the easiest way to accomplish that.
-                self.pkg("-R {0} unset-publisher test".format(idir))
-
-                mis_api_obj.reset()
-                #self.assertRaises(api_errors.IpkgOutOfDateException,
-                #    lambda *args, **kwargs: list(
-                #        mis_api_obj.gen_plan_update(*args, **kwargs)))
-
-                # Verify that if the installed version of pkg is from an
-                # unconfigured publisher and is newer than what is available
-                # that the update check will not fail.
-
-                # First, install package/pkg again.
-                self.__do_install(api_obj,
-                    ["foo@1.0", "SUNWcs", "package/pkg@1.1"])
-
-                # Next, create a repository with an older version of pkg,
-                # and a newer version of foo.
-                new_repo_dir = os.path.join(self.test_root, "test2")
-                new_repo_uri = urlunparse(("file", "",
-                    pathname2url(new_repo_dir), "", "", ""))
-
-                self.create_repo(new_repo_dir,
-                    properties={ "publisher": { "prefix": "test2" } })
-                self.pkgsend_bulk(new_repo_uri, ("""
-                    open package/pkg@1.0,5.11-0
-                    close""", self.foo11))
-
-                # Now add the new publisher and remove the old one.
-                api_obj.reset()
-                npub = publisher.Publisher("test2",
-                    repository=publisher.Repository(origins=[new_repo_uri]))
-                api_obj.add_publisher(npub, search_first=True)
-                api_obj.reset()
-                api_obj.remove_publisher(prefix="test")
-
-                # Now verify that plan_update succeeds still since the
-                # version of pkg installed is newer than the versions that
-                # are offered by the current publishers.
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        continue
-
-        def test_basics_5(self):
-                """ Add bar@1.1, install bar@1.0. """
-
-                self.pkgsend_bulk(self.rurl, self.xbar11)
-                api_obj = self.image_create(self.rurl)
-
-                self.assertRaises(api_errors.PlanCreationException,
-                    self.__do_install, api_obj, ["xbar@1.0"])
-
-        def test_bug_1338(self):
-                """ Add bar@1.1, dependent on foo@1.2, install bar@1.1. """
-
-                self.pkgsend_bulk(self.rurl, self.bar11)
-                api_obj = self.image_create(self.rurl)
-
-                self.pkg("list -a")
-
-                self.assertRaises(api_errors.PlanCreationException,
-                    self.__do_install, api_obj, ["bar@1.1"])
-
-        def test_bug_1338_2(self):
-                """ Add bar@1.1, dependent on foo@1.2, and baz@1.0, dependent
-                    on foo@1.0, install baz@1.0 and bar@1.1. """
-
-                self.pkgsend_bulk(self.rurl, (self.bar11, self.baz10))
-                api_obj = self.image_create(self.rurl)
-
-                self.assertRaises(api_errors.PlanCreationException,
-                    self.__do_install, api_obj, ["baz@1.0", "bar@1.1"])
-
-        def test_bug_1338_3(self):
-                """ Add xdeep@1.0, xbar@1.0. xDeep@1.0 depends on xbar@1.0 which
-                    depends on xfoo@1.0, install xdeep@1.0. """
-
-                self.pkgsend_bulk(self.rurl, (self.xbar10, self.xdeep10))
-                api_obj = self.image_create(self.rurl)
-
-                self.assertRaises(api_errors.PlanCreationException,
-                    self.__do_install, api_obj, ["xdeep@1.0"])
-
-        def test_bug_1338_4(self):
-                """ Add ydeep@1.0. yDeep@1.0 depends on ybar@1.0 which depends
-                on xfoo@1.0, install ydeep@1.0. """
-
-                self.pkgsend_bulk(self.rurl, self.ydeep10)
-                api_obj = self.image_create(self.rurl)
-
-                self.assertRaises(api_errors.PlanCreationException,
-                    self.__do_install, api_obj, ["ydeep@1.0"])
-
-        def test_bug_2795(self):
-                """ Try to install two versions of the same package """
-
-                self.pkgsend_bulk(self.rurl, (self.foo11, self.foo12))
-                api_obj = self.image_create(self.rurl)
-
-                self.assertRaises(api_errors.PlanCreationException,
-                    self.__do_install, api_obj, ["foo@1.1", "foo@1.2"])
-
-                self.pkg("list foo", exit=1)
-
-                self.assertRaises(api_errors.PlanCreationException,
-                    self.__do_install, api_obj, ["foo@1.1", "foo@1.2"])
-
-                self.pkg("list foo", exit=1)
-
-        def test_install_matching(self):
-                """ Try to [un]install packages matching a pattern """
-
-                self.pkgsend_bulk(self.rurl, (self.foo10, self.bar10,
-                    self.baz10))
-                api_obj = self.image_create(self.rurl)
-
-                self.__do_install(api_obj, ['ba*'])
-                self.pkg("list foo@1.0", exit=0)
-                self.pkg("list bar@1.0", exit=0)
-                self.pkg("list baz@1.0", exit=0)
-
-                self.__do_uninstall(api_obj, ['ba*'])
-                self.pkg("list foo@1.0", exit=0)
-                self.pkg("list bar@1.0", exit=1)
-                self.pkg("list baz@1.0", exit=1)
-
-        def test_bad_fmris(self):
-                """ Test passing problematic fmris into the api """
-
-                api_obj = self.image_create(self.rurl)
-
-                def check_unfound(e):
-                        return e.unmatched_fmris
-
-                def check_illegal(e):
-                        return e.illegal
-
-                def check_missing(e):
-                        return e.missing_matches
-
-                pkg5unittest.eval_assert_raises(api_errors.PlanCreationException,
-                    check_unfound,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_install(*args, **kwargs)),
-                    ["foo"])
-
-                api_obj.reset()
-                pkg5unittest.eval_assert_raises(api_errors.PlanCreationException,
-                    check_missing,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_uninstall(*args, **kwargs)),
-                    ["foo"], False)
-
-                api_obj.reset()
-                pkg5unittest.eval_assert_raises(api_errors.PlanCreationException,
-                    check_illegal,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_install(*args, **kwargs)),
-                    ["@/foo"])
-
-                api_obj.reset()
-                pkg5unittest.eval_assert_raises(api_errors.PlanCreationException,
-                    check_illegal,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_uninstall(*args, **kwargs)),
-                    ["_foo"], False)
-
-                self.pkgsend_bulk(self.rurl, self.foo10)
-
-                api_obj.refresh(False)
-                pkg5unittest.eval_assert_raises(api_errors.PlanCreationException,
-                    check_missing,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_uninstall(*args, **kwargs)),
-                    ["foo"], False)
-
-                api_obj.reset()
-                pkg5unittest.eval_assert_raises(api_errors.PlanCreationException,
-                    check_illegal,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_uninstall(*args, **kwargs)),
-                    ["_foo"], False)
-
-                api_obj.reset()
-                pkg5unittest.eval_assert_raises(api_errors.PlanCreationException,
-                    check_missing,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_update(*args, **kwargs)),
-                    ["foo"])
-
-                api_obj.reset()
-                api_obj.refresh(True)
-                self.__do_install(api_obj, ["foo"])
-
-                # Verify update plan has nothing to do result for installed
-                # package that can't be updated.
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update(["foo"]):
-                        continue
-                self.assertTrue(api_obj.planned_nothingtodo())
-
-                self.__do_uninstall(api_obj, ["foo"])
-
-                api_obj.reset()
-                pkg5unittest.eval_assert_raises(api_errors.PlanCreationException,
-                    check_missing,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_uninstall(*args, **kwargs)),
-                    ["foo"], False)
-
-        def test_bug_4109(self):
-
-                api_obj = self.image_create(self.rurl)
-
-                def check_illegal(e):
-                        return e.illegal
-
-                api_obj.reset()
-                pkg5unittest.eval_assert_raises(api_errors.PlanCreationException,
-                    check_illegal,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_install(*args, **kwargs)),
-                    ["_foo"])
-
-        def test_catalog_v0(self):
-                """Test install from a publisher's repository that only supports
-                catalog v0, and then the transition from v0 to v1."""
-
-                # Actual depot required for this test due to v0 repository
-                # operation usage.
-                self.dc.set_disable_ops(["catalog/1"])
-                self.dc.start()
-
-                self.pkgsend_bulk(self.durl, self.foo10)
-                api_obj = self.image_create(self.durl)
-
-                self.__do_install(api_obj, ["foo"])
-
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["foo"])
-
-                api_obj.reset()
-                self.__do_install(api_obj, ["pkg://test/foo"])
-
-                self.pkgsend_bulk(self.durl, self.bar10)
-                self.dc.stop()
-                self.dc.unset_disable_ops()
-                self.dc.start()
-
-                api_obj.reset()
-                api_obj.refresh(immediate=True)
-
-                api_obj.reset()
-                self.__do_install(api_obj, ["pkg://test/bar@1.0"])
-                self.dc.stop()
-
-        def test_bad_package_actions(self):
-                """Test the install of packages that have actions that are
-                invalid."""
-
-                # XXX This test is not yet comprehensive.
-
-                # First, publish the package that will be corrupted and create
-                # an image for testing.
-                plist = self.pkgsend_bulk(self.rurl, (self.badfile10,
-                    self.baddir10))
-                api_obj = self.image_create(self.rurl)
-
-                # This should succeed and cause the manifest to be cached.
-                self.__do_install(api_obj, plist)
-
-                # Now attempt to corrupt the client's copy of the manifest by
-                # adding malformed actions or invalidating existing ones.
-                for p in plist:
-                        pfmri = fmri.PkgFmri(p)
-                        mdata = self.get_img_manifest(pfmri)
-                        if mdata.find("dir") != -1:
-                                src_mode = "mode=755"
-                        else:
-                                src_mode = "mode=644"
-
-                        # Remove the package so corrupt case can be tested.
-                        self.__do_uninstall(api_obj, [pfmri.pkg_name])
-
-                        for bad_mode in ("", 'mode=""', "mode=???"):
-                                self.debug("Testing with bad mode "
-                                    "'{0}'.".format(bad_mode))
-
-                                bad_mdata = mdata.replace(src_mode, bad_mode)
-                                self.write_img_manifest(pfmri, bad_mdata)
-                                DebugValues["manifest_validate"] = "Never"
-                                self.assertRaises(api_errors.InvalidPackageErrors,
-                                    self.__do_install, api_obj,
-                                    [pfmri.pkg_name])
-
-                        for bad_owner in ("", 'owner=""', "owner=invaliduser"):
-                                self.debug("Testing with bad owner "
-                                    "'{0}'.".format(bad_owner))
-
-                                bad_mdata = mdata.replace("owner=root",
-                                    bad_owner)
-                                self.write_img_manifest(pfmri, bad_mdata)
-                                self.assertRaises(api_errors.InvalidPackageErrors,
-                                    self.__do_install, api_obj,
-                                    [pfmri.pkg_name])
-
-                        for bad_group in ("", 'group=""', "group=invalidgroup"):
-                                self.debug("Testing with bad group "
-                                    "'{0}'.".format(bad_group))
-
-                                bad_mdata = mdata.replace("group=bin",
-                                    bad_group)
-                                self.write_img_manifest(pfmri, bad_mdata)
-                                self.assertRaises(api_errors.InvalidPackageErrors,
-                                    self.__do_install, api_obj,
-                                    [pfmri.pkg_name])
-
-                        for bad_act in (
-                            'set name=description value="" \" my desc  ""',
-                            "set name=com.sun.service.escalations value="):
-                                self.debug("Testing with bad action "
-                                    "'{0}'.".format(bad_act))
-
-                                bad_mdata = mdata + "{0}\n".format(bad_act)
-                                self.write_img_manifest(pfmri, bad_mdata)
-                                self.assertRaises(api_errors.InvalidPackageErrors,
-                                    self.__do_install, api_obj,
-                                    [pfmri.pkg_name])
-
-        def test_freeze_basics_1(self):
-                """Test that installing a package which has been frozen at a
-                particular version works, that installing a version which
-                doesn't match fails, that upgrading doesn't move the package
-                forward, and that unfreezing a package lets it move once more.
+                    close """,
+        )
+        api_obj.reset()
+        api_obj.refresh()
+
+        # Upgrading implicitly to carriage@3.0 would force a downgrade
+        # to horse@1.0 so should be ignored as a possibility by
+        # the solver.
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update(["carriage"]):
+            continue
+        self.assertTrue(api_obj.planned_nothingtodo())
+
+        # Upgrading explicitly to carriage@3.0 would force a downgrade
+        # to horse@1.0 and so should raise an exception...
+        api_obj.reset()
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_update(*args, **kwargs)
+            ),
+            ["carriage@3", "horse"],
+        )
+
+        # ...unless horse is explicitly downgraded as well.
+        api_obj.reset()
+        self.__do_update(api_obj, ["carriage@3", "horse@1"])
+        self.pkg("list carriage@3 horse@1")
+
+        # Now verify an implicit update to carriage@3.0 will work
+        # if horse is explicitly downgraded to 1.0.
+        api_obj.reset()
+        self.__do_update(api_obj, ["carriage@2", "horse@2"])
+        self.pkg("list carriage@2 horse@2")
+
+        api_obj.reset()
+        self.__do_update(api_obj, ["carriage", "horse@1"])
+        self.pkg("list carriage@3 horse@1")
+
+    def test_multi_publisher(self):
+        """Verify that package install works as expected when multiple
+        publishers share the same repository."""
+
+        # Publish a package for 'test'.
+        self.pkgsend_bulk(self.rurl, self.bar10)
+
+        # Now change the default publisher to 'test2' and publish
+        # another package.
+        self.pkgrepo("set -s {0} publisher/prefix=test2".format(self.rurl))
+        self.pkgsend_bulk(self.rurl, self.foo10)
+
+        # Finally, create an image and verify that packages from
+        # both publishers may be installed.
+        api_obj = self.image_create(self.rurl, prefix=None)
+        self.__do_install(
+            api_obj, ["pkg://test/bar@1.0", "pkg://test2/foo@1.0"]
+        )
+
+    def test_pkg_file_errors(self):
+        """Verify that package install and uninstall works as expected
+        when files or directories are missing."""
+
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.bar09,
+                self.bar10,
+                self.bar11,
+                self.foo10,
+                self.foo12,
+                self.moving10,
+                self.moving20,
+            ),
+        )
+        api_obj = self.image_create(self.rurl)
+
+        # Verify that missing files will be replaced during upgrade if
+        # the file action has changed (even if the content hasn't),
+        # such as when the mode changes.
+        self.__do_install(api_obj, ["bar@0.9"])
+        file_path = os.path.join(self.get_img_path(), "bin", "cat")
+        portable.remove(file_path)
+        self.assertTrue(not os.path.isfile(file_path))
+        self.__do_install(api_obj, ["bar@1.0"])
+        self.assertTrue(os.path.isfile(file_path))
+
+        # Verify that if the directory containing a missing file is also
+        # missing that upgrade will still work as expected for the file.
+        self.__do_uninstall(api_obj, ["bar@1.0"])
+        self.__do_install(api_obj, ["bar@0.9"])
+        dir_path = os.path.dirname(file_path)
+        shutil.rmtree(dir_path)
+        self.assertTrue(not os.path.isdir(dir_path))
+        self.__do_install(api_obj, ["bar@1.0"])
+        self.assertTrue(os.path.isfile(file_path))
+
+        # Verify that missing files won't cause uninstall failure.
+        portable.remove(file_path)
+        self.assertTrue(not os.path.isfile(file_path))
+        self.__do_uninstall(api_obj, ["bar@1.0"])
+
+        # Verify that missing directories won't cause uninstall failure.
+        self.__do_install(api_obj, ["bar@1.0"])
+        shutil.rmtree(dir_path)
+        self.assertTrue(not os.path.isdir(dir_path))
+        self.__do_uninstall(api_obj, ["bar@1.0"])
+
+        # Verify that missing files won't cause update failure if
+        # original_name is set.
+        self.__do_install(api_obj, ["moving@1.0"])
+        file_path = os.path.join(self.get_img_path(), "baz")
+        portable.remove(file_path)
+        self.__do_install(api_obj, ["moving@2.0"])
+        file_path = os.path.join(self.get_img_path(), "quux")
+
+        # Verify that missing files won't cause uninstall failure if
+        # original_name is set.
+        self.assertTrue(os.path.isfile(file_path))
+        portable.remove(file_path)
+        self.__do_uninstall(api_obj, ["moving@2.0"])
+
+    def test_image_upgrade(self):
+        """Send package bar@1.1, dependent on foo@1.2.  Install
+        bar@1.0.  List all packages.  Upgrade image."""
+
+        self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11, self.bar10))
+        api_obj = self.image_create(self.rurl)
+
+        self.__do_install(api_obj, ["bar@1.0"])
+
+        self.pkgsend_bulk(self.rurl, (self.foo12, self.bar11))
+
+        self.pkg("contents -H")
+        self.pkg("list")
+        api_obj.refresh(immediate=True)
+
+        self.pkg("list")
+        self.pkg("verify")
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
+        self.pkg("verify")
+
+        self.pkg("list foo@1.2")
+        self.pkg("list bar@1.1")
+
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["bar", "foo"])
+        self.pkg("verify")
+
+    def test_ipkg_out_of_date(self):
+        """Make sure that packaging system out-of-date testing works."""
+
+        self.pkgsend_bulk(self.rurl, (self.foo10, self.foo12, self.corepkgs))
+        self.image_create(self.rurl)
+
+        api_obj = self.get_img_api_obj()
+
+        # Update when it doesn't appear to be an opensolaris image
+        # shouldn't have any issues.
+        self.__do_install(api_obj, ["foo@1.0"])
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            continue
+
+        # Even though SUNWipkg is on the system, it won't appear as an
+        # opensolaris system.
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["*"])
+        api_obj.reset()
+        self.__do_install(api_obj, ["foo@1.0", "SUNWipkg@1.0"])
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            continue
+
+        # Same for package/pkg
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["*"])
+        api_obj.reset()
+        self.__do_install(api_obj, ["foo@1.0", "package/pkg@1.0"])
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            continue
+
+        # Same for SUNWcs
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["*"])
+        api_obj.reset()
+        self.__do_install(api_obj, ["foo@1.0", "SUNWcs"])
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            continue
+
+        # There are still no problems if the packaging system is up to
+        # date.  We can't test with SUNWipkg installed instead, because
+        # we're making the assumption in the code that we always want to
+        # update package/pkg, given that this revision of the code will
+        # only run on systems where the packaging system is in that
+        # package.
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["*"])
+        api_obj.reset()
+        self.__do_install(api_obj, ["foo@1.0", "SUNWcs", "package/pkg@1.1"])
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            continue
+
+        # We should run into a problem if pkg(7) is out of date.
+        # api_obj.reset()
+        # self.__do_uninstall(api_obj, ["*"])
+        # api_obj.reset()
+        # self.__do_install(api_obj,
+        #     ["foo@1.0", "SUNWcs", "package/pkg@1.0"])
+        # api_obj.reset()
+        # self.assertRaises(api_errors.IpkgOutOfDateException,
+        #     lambda *args, **kwargs: list(
+        #         api_obj.gen_plan_update(*args, **kwargs)))
+
+        # Use the metadata on release/name to determine it's an
+        # opensolaris system.
+        # api_obj.reset()
+        # self.__do_uninstall(api_obj, ["*"])
+        # api_obj.reset()
+        # self.__do_install(api_obj,
+        #     ["foo@1.0", "release/name@2.0", "package/pkg@1.0"])
+        # api_obj.reset()
+        # self.assertRaises(api_errors.IpkgOutOfDateException,
+        #     lambda *args, **kwargs: list(
+        #         api_obj.gen_plan_update(*args, **kwargs)))
+
+        # An older release/name which doesn't have the metadata should
+        # cause us to skip the check.
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["*"])
+        api_obj.reset()
+        self.__do_install(
+            api_obj, ["foo@1.0", "release/name@1.0", "package/pkg@1.0"]
+        )
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            continue
+
+        # Verify that if a newer version of package/pkg is available
+        # but not allowed by the currently installed ips-incorporation
+        # that the client up-to-date check succeeds.
+        self.__do_uninstall(api_obj, ["*"])
+        self.__do_install(api_obj, ["release/name@2.0", "package/pkg@1.1"])
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            pass
+
+        # Verify that if the image pkg is executed from has a client
+        # with a newer version installed than what is available in the
+        # image being operated on that the update check will not fail.
+        self.__do_update(api_obj, ["ips-incorporation@1.0", "pkg@1.0"])
+
+        idir = os.path.join(self.test_root, "pkg-mismatch")
+        self.pkg("image-create -F -p {0} {1}".format(self.rurl, idir))
+
+        mis_api_obj = self.get_img_api_obj(img_path=idir)
+        self.__do_install(mis_api_obj, ["release/name@2.0", "package/pkg@2.0"])
+        # The version found in the image pkg is being executed from must
+        # not be available in the image being operated on.  Removing the
+        # publisher is the easiest way to accomplish that.
+        self.pkg("-R {0} unset-publisher test".format(idir))
+
+        mis_api_obj.reset()
+        # self.assertRaises(api_errors.IpkgOutOfDateException,
+        #    lambda *args, **kwargs: list(
+        #        mis_api_obj.gen_plan_update(*args, **kwargs)))
+
+        # Verify that if the installed version of pkg is from an
+        # unconfigured publisher and is newer than what is available
+        # that the update check will not fail.
+
+        # First, install package/pkg again.
+        self.__do_install(api_obj, ["foo@1.0", "SUNWcs", "package/pkg@1.1"])
+
+        # Next, create a repository with an older version of pkg,
+        # and a newer version of foo.
+        new_repo_dir = os.path.join(self.test_root, "test2")
+        new_repo_uri = urlunparse(
+            ("file", "", pathname2url(new_repo_dir), "", "", "")
+        )
+
+        self.create_repo(
+            new_repo_dir, properties={"publisher": {"prefix": "test2"}}
+        )
+        self.pkgsend_bulk(
+            new_repo_uri,
+            (
                 """
+                    open package/pkg@1.0,5.11-0
+                    close""",
+                self.foo11,
+            ),
+        )
 
-                plist = self.pkgsend_bulk(self.rurl, [self.foo10, self.foo11,
-                    self.foo12])
-                api_obj = self.image_create(self.rurl)
+        # Now add the new publisher and remove the old one.
+        api_obj.reset()
+        npub = publisher.Publisher(
+            "test2", repository=publisher.Repository(origins=[new_repo_uri])
+        )
+        api_obj.add_publisher(npub, search_first=True)
+        api_obj.reset()
+        api_obj.remove_publisher(prefix="test")
 
-                api_obj.freeze_pkgs(["foo@1.1"])
-                api_obj.reset()
-                self.assertRaises(api_errors.PlanCreationException,
-                    self._api_install, api_obj, ["foo@1.0"])
-                self.assertRaises(api_errors.PlanCreationException,
-                    self._api_install, api_obj, ["foo@1.2"])
-                self._api_install(api_obj, ["foo"])
+        # Now verify that plan_update succeeds still since the
+        # version of pkg installed is newer than the versions that
+        # are offered by the current publishers.
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            continue
 
-                # Test that update won't move foo to 1.2 until it's unfrozen.
-                self.pkg("update", exit=4)
-                self.pkg("update foo@1.2", exit=1)
-                api_obj.freeze_pkgs(["foo"], unfreeze=True)
-                self.pkg("update -n")
-                self._api_update(api_obj, ["foo@1.2"])
+    def test_basics_5(self):
+        """Add bar@1.1, install bar@1.0."""
 
-                # Check that freezing an installed package at a different
-                # version fails.
-                self.assertRaises(api_errors.FreezePkgsException,
-                    api_obj.freeze_pkgs, ["foo@1.1"])
-                api_obj.reset()
+        self.pkgsend_bulk(self.rurl, self.xbar11)
+        api_obj = self.image_create(self.rurl)
 
-                # Check that freeze survives uninstalls.
-                self._api_uninstall(api_obj, ["foo"])
-                api_obj.freeze_pkgs(["foo@1.1"])
-                api_obj.reset()
-                self._api_install(api_obj, ["foo"])
-                self.pkg("list foo@1.2", exit=1)
-                self.pkg("list foo@1.1")
-                self._api_uninstall(api_obj, ["foo"])
-                self._api_install(api_obj, ["foo"])
-                self.pkg("list foo@1.2", exit=1)
-                self.pkg("list foo@1.1")
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            self.__do_install,
+            api_obj,
+            ["xbar@1.0"],
+        )
 
-                # Check that freeze only freezes what it should.
-                api_obj.freeze_pkgs(["foo@1"])
-                api_obj.reset()
-                self._api_update(api_obj, [])
-                self.pkg("list foo@1.1", exit=1)
-                self.pkg("list foo@1.2")
+    def test_bug_1338(self):
+        """Add bar@1.1, dependent on foo@1.2, install bar@1.1."""
 
-        def test_flag_basics_1(self):
-                """Test that the package flag API works"""
+        self.pkgsend_bulk(self.rurl, self.bar11)
+        api_obj = self.image_create(self.rurl)
 
-                plist = self.pkgsend_bulk(self.rurl, [self.foo10, self.bar10])
-                api_obj = self.image_create(self.rurl)
+        self.pkg("list -a")
 
-                self.pkg("install foo bar")
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            self.__do_install,
+            api_obj,
+            ["bar@1.1"],
+        )
 
-                expected = self.reduceSpaces(
-                    "bar    1.0-0    im-\n"
-                    "foo    1.0-0    im-\n"
+    def test_bug_1338_2(self):
+        """Add bar@1.1, dependent on foo@1.2, and baz@1.0, dependent
+        on foo@1.0, install baz@1.0 and bar@1.1."""
+
+        self.pkgsend_bulk(self.rurl, (self.bar11, self.baz10))
+        api_obj = self.image_create(self.rurl)
+
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            self.__do_install,
+            api_obj,
+            ["baz@1.0", "bar@1.1"],
+        )
+
+    def test_bug_1338_3(self):
+        """Add xdeep@1.0, xbar@1.0. xDeep@1.0 depends on xbar@1.0 which
+        depends on xfoo@1.0, install xdeep@1.0."""
+
+        self.pkgsend_bulk(self.rurl, (self.xbar10, self.xdeep10))
+        api_obj = self.image_create(self.rurl)
+
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            self.__do_install,
+            api_obj,
+            ["xdeep@1.0"],
+        )
+
+    def test_bug_1338_4(self):
+        """Add ydeep@1.0. yDeep@1.0 depends on ybar@1.0 which depends
+        on xfoo@1.0, install ydeep@1.0."""
+
+        self.pkgsend_bulk(self.rurl, self.ydeep10)
+        api_obj = self.image_create(self.rurl)
+
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            self.__do_install,
+            api_obj,
+            ["ydeep@1.0"],
+        )
+
+    def test_bug_2795(self):
+        """Try to install two versions of the same package"""
+
+        self.pkgsend_bulk(self.rurl, (self.foo11, self.foo12))
+        api_obj = self.image_create(self.rurl)
+
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            self.__do_install,
+            api_obj,
+            ["foo@1.1", "foo@1.2"],
+        )
+
+        self.pkg("list foo", exit=1)
+
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            self.__do_install,
+            api_obj,
+            ["foo@1.1", "foo@1.2"],
+        )
+
+        self.pkg("list foo", exit=1)
+
+    def test_install_matching(self):
+        """Try to [un]install packages matching a pattern"""
+
+        self.pkgsend_bulk(self.rurl, (self.foo10, self.bar10, self.baz10))
+        api_obj = self.image_create(self.rurl)
+
+        self.__do_install(api_obj, ["ba*"])
+        self.pkg("list foo@1.0", exit=0)
+        self.pkg("list bar@1.0", exit=0)
+        self.pkg("list baz@1.0", exit=0)
+
+        self.__do_uninstall(api_obj, ["ba*"])
+        self.pkg("list foo@1.0", exit=0)
+        self.pkg("list bar@1.0", exit=1)
+        self.pkg("list baz@1.0", exit=1)
+
+    def test_bad_fmris(self):
+        """Test passing problematic fmris into the api"""
+
+        api_obj = self.image_create(self.rurl)
+
+        def check_unfound(e):
+            return e.unmatched_fmris
+
+        def check_illegal(e):
+            return e.illegal
+
+        def check_missing(e):
+            return e.missing_matches
+
+        pkg5unittest.eval_assert_raises(
+            api_errors.PlanCreationException,
+            check_unfound,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_install(*args, **kwargs)
+            ),
+            ["foo"],
+        )
+
+        api_obj.reset()
+        pkg5unittest.eval_assert_raises(
+            api_errors.PlanCreationException,
+            check_missing,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_uninstall(*args, **kwargs)
+            ),
+            ["foo"],
+            False,
+        )
+
+        api_obj.reset()
+        pkg5unittest.eval_assert_raises(
+            api_errors.PlanCreationException,
+            check_illegal,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_install(*args, **kwargs)
+            ),
+            ["@/foo"],
+        )
+
+        api_obj.reset()
+        pkg5unittest.eval_assert_raises(
+            api_errors.PlanCreationException,
+            check_illegal,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_uninstall(*args, **kwargs)
+            ),
+            ["_foo"],
+            False,
+        )
+
+        self.pkgsend_bulk(self.rurl, self.foo10)
+
+        api_obj.refresh(False)
+        pkg5unittest.eval_assert_raises(
+            api_errors.PlanCreationException,
+            check_missing,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_uninstall(*args, **kwargs)
+            ),
+            ["foo"],
+            False,
+        )
+
+        api_obj.reset()
+        pkg5unittest.eval_assert_raises(
+            api_errors.PlanCreationException,
+            check_illegal,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_uninstall(*args, **kwargs)
+            ),
+            ["_foo"],
+            False,
+        )
+
+        api_obj.reset()
+        pkg5unittest.eval_assert_raises(
+            api_errors.PlanCreationException,
+            check_missing,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_update(*args, **kwargs)
+            ),
+            ["foo"],
+        )
+
+        api_obj.reset()
+        api_obj.refresh(True)
+        self.__do_install(api_obj, ["foo"])
+
+        # Verify update plan has nothing to do result for installed
+        # package that can't be updated.
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update(["foo"]):
+            continue
+        self.assertTrue(api_obj.planned_nothingtodo())
+
+        self.__do_uninstall(api_obj, ["foo"])
+
+        api_obj.reset()
+        pkg5unittest.eval_assert_raises(
+            api_errors.PlanCreationException,
+            check_missing,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_uninstall(*args, **kwargs)
+            ),
+            ["foo"],
+            False,
+        )
+
+    def test_bug_4109(self):
+        api_obj = self.image_create(self.rurl)
+
+        def check_illegal(e):
+            return e.illegal
+
+        api_obj.reset()
+        pkg5unittest.eval_assert_raises(
+            api_errors.PlanCreationException,
+            check_illegal,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_install(*args, **kwargs)
+            ),
+            ["_foo"],
+        )
+
+    def test_catalog_v0(self):
+        """Test install from a publisher's repository that only supports
+        catalog v0, and then the transition from v0 to v1."""
+
+        # Actual depot required for this test due to v0 repository
+        # operation usage.
+        self.dc.set_disable_ops(["catalog/1"])
+        self.dc.start()
+
+        self.pkgsend_bulk(self.durl, self.foo10)
+        api_obj = self.image_create(self.durl)
+
+        self.__do_install(api_obj, ["foo"])
+
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["foo"])
+
+        api_obj.reset()
+        self.__do_install(api_obj, ["pkg://test/foo"])
+
+        self.pkgsend_bulk(self.durl, self.bar10)
+        self.dc.stop()
+        self.dc.unset_disable_ops()
+        self.dc.start()
+
+        api_obj.reset()
+        api_obj.refresh(immediate=True)
+
+        api_obj.reset()
+        self.__do_install(api_obj, ["pkg://test/bar@1.0"])
+        self.dc.stop()
+
+    def test_bad_package_actions(self):
+        """Test the install of packages that have actions that are
+        invalid."""
+
+        # XXX This test is not yet comprehensive.
+
+        # First, publish the package that will be corrupted and create
+        # an image for testing.
+        plist = self.pkgsend_bulk(self.rurl, (self.badfile10, self.baddir10))
+        api_obj = self.image_create(self.rurl)
+
+        # This should succeed and cause the manifest to be cached.
+        self.__do_install(api_obj, plist)
+
+        # Now attempt to corrupt the client's copy of the manifest by
+        # adding malformed actions or invalidating existing ones.
+        for p in plist:
+            pfmri = fmri.PkgFmri(p)
+            mdata = self.get_img_manifest(pfmri)
+            if mdata.find("dir") != -1:
+                src_mode = "mode=755"
+            else:
+                src_mode = "mode=644"
+
+            # Remove the package so corrupt case can be tested.
+            self.__do_uninstall(api_obj, [pfmri.pkg_name])
+
+            for bad_mode in ("", 'mode=""', "mode=???"):
+                self.debug("Testing with bad mode " "'{0}'.".format(bad_mode))
+
+                bad_mdata = mdata.replace(src_mode, bad_mode)
+                self.write_img_manifest(pfmri, bad_mdata)
+                DebugValues["manifest_validate"] = "Never"
+                self.assertRaises(
+                    api_errors.InvalidPackageErrors,
+                    self.__do_install,
+                    api_obj,
+                    [pfmri.pkg_name],
                 )
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
 
-                api_obj.flag_pkgs(["foo"], flag="manual", value=False)
+            for bad_owner in ("", 'owner=""', "owner=invaliduser"):
+                self.debug("Testing with bad owner " "'{0}'.".format(bad_owner))
 
-                expected = self.reduceSpaces(
-                    "bar    1.0-0    im-\n"
-                    "foo    1.0-0    i--\n"
+                bad_mdata = mdata.replace("owner=root", bad_owner)
+                self.write_img_manifest(pfmri, bad_mdata)
+                self.assertRaises(
+                    api_errors.InvalidPackageErrors,
+                    self.__do_install,
+                    api_obj,
+                    [pfmri.pkg_name],
                 )
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
 
-                api_obj.flag_pkgs(["*"], flag="manual", value=True)
+            for bad_group in ("", 'group=""', "group=invalidgroup"):
+                self.debug("Testing with bad group " "'{0}'.".format(bad_group))
 
-                expected = self.reduceSpaces(
-                    "bar    1.0-0    im-\n"
-                    "foo    1.0-0    im-\n"
+                bad_mdata = mdata.replace("group=bin", bad_group)
+                self.write_img_manifest(pfmri, bad_mdata)
+                self.assertRaises(
+                    api_errors.InvalidPackageErrors,
+                    self.__do_install,
+                    api_obj,
+                    [pfmri.pkg_name],
                 )
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
 
-        def test_pkg_mancache(self):
-                """Verify that client manifest cache is managed as expected."""
+            for bad_act in (
+                'set name=description value="" " my desc  ""',
+                "set name=com.sun.service.escalations value=",
+            ):
+                self.debug("Testing with bad action " "'{0}'.".format(bad_act))
 
-                plist = self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11),
-                    refresh_index=True)
-                api_obj = self.image_create(self.rurl)
+                bad_mdata = mdata + "{0}\n".format(bad_act)
+                self.write_img_manifest(pfmri, bad_mdata)
+                self.assertRaises(
+                    api_errors.InvalidPackageErrors,
+                    self.__do_install,
+                    api_obj,
+                    [pfmri.pkg_name],
+                )
 
-                self.pkg("list -af")
-                self.__do_install(api_obj, ["foo@1.0"])
+    def test_freeze_basics_1(self):
+        """Test that installing a package which has been frozen at a
+        particular version works, that installing a version which
+        doesn't match fails, that upgrading doesn't move the package
+        forward, and that unfreezing a package lets it move once more.
+        """
 
-                # Verify that manifest file exists after install.
-                pfmri = fmri.PkgFmri(plist[0])
-                mpath = self.get_img_manifest_path(pfmri)
-                mdir = os.path.dirname(mpath)
-                assert os.path.exists(mpath)
+        plist = self.pkgsend_bulk(
+            self.rurl, [self.foo10, self.foo11, self.foo12]
+        )
+        api_obj = self.image_create(self.rurl)
 
-                # Verify that manifest cache file exists after install.
-                mcdir = self.get_img_manifest_cache_dir(pfmri)
-                mcpath = os.path.join(mcdir, "manifest.set")
-                assert os.path.exists(mcpath)
+        api_obj.freeze_pkgs(["foo@1.1"])
+        api_obj.reset()
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            self._api_install,
+            api_obj,
+            ["foo@1.0"],
+        )
+        self.assertRaises(
+            api_errors.PlanCreationException,
+            self._api_install,
+            api_obj,
+            ["foo@1.2"],
+        )
+        self._api_install(api_obj, ["foo"])
 
-                # Verify that manifest cache file and directories do not exist
-                # after uninstall.
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["foo"])
-                assert not os.path.exists(mcpath), \
-                    "manifest cache file '{0}' exists!".format(mcpath)
-                assert not os.path.exists(mcdir), \
-                    "manifest cache file directory exists!"
-                assert not os.path.exists(os.path.dirname(mcdir)), \
-                    "manifest cache parent directory '{0}' exists!".format(
-                    os.path.dirname(mcdir))
+        # Test that update won't move foo to 1.2 until it's unfrozen.
+        self.pkg("update", exit=4)
+        self.pkg("update foo@1.2", exit=1)
+        api_obj.freeze_pkgs(["foo"], unfreeze=True)
+        self.pkg("update -n")
+        self._api_update(api_obj, ["foo@1.2"])
 
-                # Verify that manifest file and directories do not exist after
-                # uninstall.
-                assert not os.path.exists(mpath), \
-                    "manifest file '{0}' exists!".format(mpath)
-                assert not os.path.exists(mdir), \
-                    "manifest directory '{0}' exists!".format(mdir)
+        # Check that freezing an installed package at a different
+        # version fails.
+        self.assertRaises(
+            api_errors.FreezePkgsException, api_obj.freeze_pkgs, ["foo@1.1"]
+        )
+        api_obj.reset()
 
-                # Install foo@1.0, then update package to foo@1.1 and verify
-                # that old manifest is removed, but new remains.
-                self.__do_install(api_obj, ["foo@1.0"])
-                assert os.path.exists(mpath)
-                assert os.path.exists(mcpath)
-                self.__do_update(api_obj, ["foo@1.1"])
+        # Check that freeze survives uninstalls.
+        self._api_uninstall(api_obj, ["foo"])
+        api_obj.freeze_pkgs(["foo@1.1"])
+        api_obj.reset()
+        self._api_install(api_obj, ["foo"])
+        self.pkg("list foo@1.2", exit=1)
+        self.pkg("list foo@1.1")
+        self._api_uninstall(api_obj, ["foo"])
+        self._api_install(api_obj, ["foo"])
+        self.pkg("list foo@1.2", exit=1)
+        self.pkg("list foo@1.1")
 
-                # Verify that old version of package manifest file and directory
-                # do not exist after update.
-                assert not os.path.exists(mcpath), \
-                    "old manifest cache file '{0}' exists!".format(mcpath)
-                assert not os.path.exists(mcdir), \
-                    "old manifest cache file directory exists!"
+        # Check that freeze only freezes what it should.
+        api_obj.freeze_pkgs(["foo@1"])
+        api_obj.reset()
+        self._api_update(api_obj, [])
+        self.pkg("list foo@1.1", exit=1)
+        self.pkg("list foo@1.2")
 
-                # Verify that new version of package manifest file and directory
-                # do exist after update.
-                pfmri = fmri.PkgFmri(plist[1])
-                mpath = self.get_img_manifest_path(pfmri)
-                mdir = os.path.dirname(mpath)
-                mcdir = self.get_img_manifest_cache_dir(pfmri)
-                mcpath = os.path.join(mcdir, "manifest.set")
+    def test_flag_basics_1(self):
+        """Test that the package flag API works"""
 
-                # Install foo again, then remove manifest cache files and then
-                # verify uninstall doesn't fail.
-                api_obj.reset()
-                self.__do_install(api_obj, ["foo"])
-                pkg_dir = os.path.join(mcdir, "..", "..")
-                shutil.rmtree(os.path.dirname(mcdir))
-                assert not os.path.exists(os.path.dirname(mcdir)), \
-                    "manifest cache parent directory '{0}' exists!".format(
-                    os.path.dirname(mcdir))
-                api_obj.reset()
-                self.__do_uninstall(api_obj, ["foo"])
+        plist = self.pkgsend_bulk(self.rurl, [self.foo10, self.bar10])
+        api_obj = self.image_create(self.rurl)
 
-                # Verify that manifest file and directories do not exist after
-                # uninstall.
-                assert not os.path.exists(mpath), \
-                    "manifest file '{0}' exists!".format(mpath)
-                assert not os.path.exists(mdir), \
-                    "manifest directory '{0}' exists!".format(mdir)
+        self.pkg("install foo bar")
+
+        expected = self.reduceSpaces(
+            "bar    1.0-0    im-\n" "foo    1.0-0    im-\n"
+        )
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        api_obj.flag_pkgs(["foo"], flag="manual", value=False)
+
+        expected = self.reduceSpaces(
+            "bar    1.0-0    im-\n" "foo    1.0-0    i--\n"
+        )
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        api_obj.flag_pkgs(["*"], flag="manual", value=True)
+
+        expected = self.reduceSpaces(
+            "bar    1.0-0    im-\n" "foo    1.0-0    im-\n"
+        )
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+    def test_pkg_mancache(self):
+        """Verify that client manifest cache is managed as expected."""
+
+        plist = self.pkgsend_bulk(
+            self.rurl, (self.foo10, self.foo11), refresh_index=True
+        )
+        api_obj = self.image_create(self.rurl)
+
+        self.pkg("list -af")
+        self.__do_install(api_obj, ["foo@1.0"])
+
+        # Verify that manifest file exists after install.
+        pfmri = fmri.PkgFmri(plist[0])
+        mpath = self.get_img_manifest_path(pfmri)
+        mdir = os.path.dirname(mpath)
+        assert os.path.exists(mpath)
+
+        # Verify that manifest cache file exists after install.
+        mcdir = self.get_img_manifest_cache_dir(pfmri)
+        mcpath = os.path.join(mcdir, "manifest.set")
+        assert os.path.exists(mcpath)
+
+        # Verify that manifest cache file and directories do not exist
+        # after uninstall.
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["foo"])
+        assert not os.path.exists(
+            mcpath
+        ), "manifest cache file '{0}' exists!".format(mcpath)
+        assert not os.path.exists(
+            mcdir
+        ), "manifest cache file directory exists!"
+        assert not os.path.exists(
+            os.path.dirname(mcdir)
+        ), "manifest cache parent directory '{0}' exists!".format(
+            os.path.dirname(mcdir)
+        )
+
+        # Verify that manifest file and directories do not exist after
+        # uninstall.
+        assert not os.path.exists(mpath), "manifest file '{0}' exists!".format(
+            mpath
+        )
+        assert not os.path.exists(
+            mdir
+        ), "manifest directory '{0}' exists!".format(mdir)
+
+        # Install foo@1.0, then update package to foo@1.1 and verify
+        # that old manifest is removed, but new remains.
+        self.__do_install(api_obj, ["foo@1.0"])
+        assert os.path.exists(mpath)
+        assert os.path.exists(mcpath)
+        self.__do_update(api_obj, ["foo@1.1"])
+
+        # Verify that old version of package manifest file and directory
+        # do not exist after update.
+        assert not os.path.exists(
+            mcpath
+        ), "old manifest cache file '{0}' exists!".format(mcpath)
+        assert not os.path.exists(
+            mcdir
+        ), "old manifest cache file directory exists!"
+
+        # Verify that new version of package manifest file and directory
+        # do exist after update.
+        pfmri = fmri.PkgFmri(plist[1])
+        mpath = self.get_img_manifest_path(pfmri)
+        mdir = os.path.dirname(mpath)
+        mcdir = self.get_img_manifest_cache_dir(pfmri)
+        mcpath = os.path.join(mcdir, "manifest.set")
+
+        # Install foo again, then remove manifest cache files and then
+        # verify uninstall doesn't fail.
+        api_obj.reset()
+        self.__do_install(api_obj, ["foo"])
+        pkg_dir = os.path.join(mcdir, "..", "..")
+        shutil.rmtree(os.path.dirname(mcdir))
+        assert not os.path.exists(
+            os.path.dirname(mcdir)
+        ), "manifest cache parent directory '{0}' exists!".format(
+            os.path.dirname(mcdir)
+        )
+        api_obj.reset()
+        self.__do_uninstall(api_obj, ["foo"])
+
+        # Verify that manifest file and directories do not exist after
+        # uninstall.
+        assert not os.path.exists(mpath), "manifest file '{0}' exists!".format(
+            mpath
+        )
+        assert not os.path.exists(
+            mdir
+        ), "manifest directory '{0}' exists!".format(mdir)
 
 
 class TestActionExecutionErrors(pkg5unittest.SingleDepotTestCase):
-        """This set of tests is intended to verify that the client API will
-        handle image state errors gracefully during install or uninstall
-        operations."""
+    """This set of tests is intended to verify that the client API will
+    handle image state errors gracefully during install or uninstall
+    operations."""
 
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        dir10 = """
+    dir10 = """
             open dir@1.0,5.11-0
             add dir path=dir mode=755 owner=root group=bin
             close """
 
-        file10 = """
+    file10 = """
             open file@1.0,5.11-0
             add file tmp/file path=file mode=755 owner=root group=bin
             close """
 
-        # Purposefully omits depend on dir@1.0.
-        filesub10 = """
+    # Purposefully omits depend on dir@1.0.
+    filesub10 = """
             open filesub@1.0,5.11-0
             add file tmp/file path=dir/file mode=755 owner=root group=bin
             close """
 
-        # Purposefully omits depend on dir@1.0.
-        link10 = """
+    # Purposefully omits depend on dir@1.0.
+    link10 = """
             open link@1.0,5.11-0
             add link path=link target=dir
             close """
 
-        link20 = """
+    link20 = """
             open link@2.0,5.11-0
             add depend type=require fmri=file@1.0,5.11-0
             add link path=dir/link target=file
             close """
 
-        # Purposefully omits depend on file@1.0.
-        hardlink10 = """
+    # Purposefully omits depend on file@1.0.
+    hardlink10 = """
             open hardlink@1.0,5.11-0
             add hardlink path=hardlink target=file
             close """
 
-        # Purposefully omits depend on dir@1.0.
-        hardlink20 = """
+    # Purposefully omits depend on dir@1.0.
+    hardlink20 = """
             open hardlink@2.0,5.11-0
             add depend type=require fmri=file@1.0,5.11-0
             add hardlink path=dir/hardlink target=file
             close """
 
-        misc_files = ["tmp/file"]
+    misc_files = ["tmp/file"]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                plist = self.pkgsend_bulk(self.rurl, (self.dir10, self.file10,
-                    self.filesub10, self.link10, self.link20, self.hardlink10,
-                    self.hardlink20))
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        plist = self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.dir10,
+                self.file10,
+                self.filesub10,
+                self.link10,
+                self.link20,
+                self.hardlink10,
+                self.hardlink20,
+            ),
+        )
 
-                self.plist = {}
-                for p in plist:
-                        pfmri = fmri.PkgFmri(p)
-                        self.plist.setdefault(pfmri.pkg_name, []).append(pfmri)
+        self.plist = {}
+        for p in plist:
+            pfmri = fmri.PkgFmri(p)
+            self.plist.setdefault(pfmri.pkg_name, []).append(pfmri)
 
-        @staticmethod
-        def __do_install(api_obj, fmris):
-                fmris = [str(f) for f in fmris]
-                api_obj.reset()
-                for pd in api_obj.gen_plan_install(fmris):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
+    @staticmethod
+    def __do_install(api_obj, fmris):
+        fmris = [str(f) for f in fmris]
+        api_obj.reset()
+        for pd in api_obj.gen_plan_install(fmris):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
 
-        @staticmethod
-        def __do_verify(api_obj, pfmri):
-                img = api_obj.img
-                progtrack = progress.NullProgressTracker()
-                progtrack.plan_start(progtrack.PLAN_PKG_VERIFY, goal=1)
-                for act, errors, warnings, pinfo in img.verify(pfmri, progtrack,
-                    forever=True):
-                        raise AssertionError("Action {0} in package {1} failed "
-                            "verification: {2}, {3}".format(act, pfmri, errors,
-                            warnings))
+    @staticmethod
+    def __do_verify(api_obj, pfmri):
+        img = api_obj.img
+        progtrack = progress.NullProgressTracker()
+        progtrack.plan_start(progtrack.PLAN_PKG_VERIFY, goal=1)
+        for act, errors, warnings, pinfo in img.verify(
+            pfmri, progtrack, forever=True
+        ):
+            raise AssertionError(
+                "Action {0} in package {1} failed "
+                "verification: {2}, {3}".format(act, pfmri, errors, warnings)
+            )
 
-        @staticmethod
-        def __do_uninstall(api_obj, fmris):
-                fmris = [str(f) for f in fmris]
-                api_obj.reset()
-                for pd in api_obj.gen_plan_uninstall(fmris):
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
+    @staticmethod
+    def __do_uninstall(api_obj, fmris):
+        fmris = [str(f) for f in fmris]
+        api_obj.reset()
+        for pd in api_obj.gen_plan_uninstall(fmris):
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
 
-        @staticmethod
-        def __write_empty_file(target, mode=misc.PKG_FILE_MODE, owner="root",
-            group="bin"):
-                f = open(target, "wb")
-                f.write(b"\n")
-                f.close()
-                os.chmod(target, mode)
-                owner = portable.get_user_by_name(owner, "/", True)
-                group = portable.get_group_by_name(group, "/", True)
-                os.chown(target, owner, group)
+    @staticmethod
+    def __write_empty_file(
+        target, mode=misc.PKG_FILE_MODE, owner="root", group="bin"
+    ):
+        f = open(target, "wb")
+        f.write(b"\n")
+        f.close()
+        os.chmod(target, mode)
+        owner = portable.get_user_by_name(owner, "/", True)
+        group = portable.get_group_by_name(group, "/", True)
+        os.chown(target, owner, group)
 
-        def test_00_directory(self):
-                """Verify that directory install and removal works as expected
-                when directory is already present before install or has been
-                replaced with a file or link during install or removal."""
+    def test_00_directory(self):
+        """Verify that directory install and removal works as expected
+        when directory is already present before install or has been
+        replaced with a file or link during install or removal."""
 
-                api_obj = self.image_create(self.rurl)
+        api_obj = self.image_create(self.rurl)
 
-                # The dest_dir's installed path.
-                dest_dir_name = "dir"
-                dir10_pfmri = self.plist[dest_dir_name][0]
-                dest_dir = os.path.join(self.get_img_path(), dest_dir_name)
+        # The dest_dir's installed path.
+        dest_dir_name = "dir"
+        dir10_pfmri = self.plist[dest_dir_name][0]
+        dest_dir = os.path.join(self.get_img_path(), dest_dir_name)
 
-                # First, verify that install won't fail if the dest_dir already
-                # exists, and that it will set the correct owner, group, and
-                # mode for the dest_dir even though it already exists and has
-                # the wrong mode.
-                os.mkdir(dest_dir, misc.PKG_FILE_MODE) # Intentionally wrong.
-                os.chown(dest_dir, 0, 0)
-                self.__do_install(api_obj, [dir10_pfmri])
-                self.__do_verify(api_obj, dir10_pfmri)
+        # First, verify that install won't fail if the dest_dir already
+        # exists, and that it will set the correct owner, group, and
+        # mode for the dest_dir even though it already exists and has
+        # the wrong mode.
+        os.mkdir(dest_dir, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        os.chown(dest_dir, 0, 0)
+        self.__do_install(api_obj, [dir10_pfmri])
+        self.__do_verify(api_obj, dir10_pfmri)
 
-                self.__do_uninstall(api_obj, [dir10_pfmri])
+        self.__do_uninstall(api_obj, [dir10_pfmri])
 
-                # Next, verify that install and uninstall won't fail if the
-                # dest_dir exists, but not as the expected type.  Also check
-                # that the correct mode, owner, group, etc. is set for the
-                # dest_dir.
+        # Next, verify that install and uninstall won't fail if the
+        # dest_dir exists, but not as the expected type.  Also check
+        # that the correct mode, owner, group, etc. is set for the
+        # dest_dir.
 
-                # Directory replaced with a file.
-                self.__write_empty_file(dest_dir)
-                self.__do_install(api_obj, [dir10_pfmri])
-                self.__do_verify(api_obj, dir10_pfmri)
+        # Directory replaced with a file.
+        self.__write_empty_file(dest_dir)
+        self.__do_install(api_obj, [dir10_pfmri])
+        self.__do_verify(api_obj, dir10_pfmri)
 
-                shutil.rmtree(dest_dir)
-                self.__write_empty_file(dest_dir)
-                self.__do_uninstall(api_obj, [dir10_pfmri])
+        shutil.rmtree(dest_dir)
+        self.__write_empty_file(dest_dir)
+        self.__do_uninstall(api_obj, [dir10_pfmri])
 
-                # Directory replaced with a link (fails for install).
-                self.__write_empty_file(dest_dir + ".src")
-                os.symlink(dest_dir + ".src", dest_dir)
-                self.assertRaises(api_errors.ActionExecutionError,
-                    self.__do_install, api_obj, [dir10_pfmri])
-                os.unlink(dest_dir)
+        # Directory replaced with a link (fails for install).
+        self.__write_empty_file(dest_dir + ".src")
+        os.symlink(dest_dir + ".src", dest_dir)
+        self.assertRaises(
+            api_errors.ActionExecutionError,
+            self.__do_install,
+            api_obj,
+            [dir10_pfmri],
+        )
+        os.unlink(dest_dir)
 
-                # Directory replaced with a link (succeeds for uninstall).
-                self.__do_install(api_obj, [dir10_pfmri])
-                shutil.rmtree(dest_dir)
-                os.symlink(dest_dir + ".src", dest_dir)
-                self.__do_uninstall(api_obj, [dir10_pfmri])
-                os.unlink(dest_dir + ".src")
+        # Directory replaced with a link (succeeds for uninstall).
+        self.__do_install(api_obj, [dir10_pfmri])
+        shutil.rmtree(dest_dir)
+        os.symlink(dest_dir + ".src", dest_dir)
+        self.__do_uninstall(api_obj, [dir10_pfmri])
+        os.unlink(dest_dir + ".src")
 
-        def test_01_file(self):
-                """Verify that file install and removal works as expected when
-                file is: already present before install, has been replaced
-                with a directory or link during install or removal, or an
-                install is attempted when its parent directory has been
-                replaced with a link."""
+    def test_01_file(self):
+        """Verify that file install and removal works as expected when
+        file is: already present before install, has been replaced
+        with a directory or link during install or removal, or an
+        install is attempted when its parent directory has been
+        replaced with a link."""
 
-                api_obj = self.image_create(self.rurl)
+        api_obj = self.image_create(self.rurl)
 
-                # The dest_file's installed path.
-                dest_file_name = "file"
-                file10_pfmri = self.plist[dest_file_name][0]
-                dest_file = os.path.join(self.get_img_path(), dest_file_name)
-                src = os.path.join(self.get_img_path(), "dir")
+        # The dest_file's installed path.
+        dest_file_name = "file"
+        file10_pfmri = self.plist[dest_file_name][0]
+        dest_file = os.path.join(self.get_img_path(), dest_file_name)
+        src = os.path.join(self.get_img_path(), "dir")
 
-                # First, verify that install won't fail if the dest_file already
-                # exists, and that it will set the correct owner, group, and
-                # mode for the dest_file even though it already exists.
-                self.__write_empty_file(dest_file, mode=misc.PKG_DIR_MODE,
-                    owner="root", group="root")
-                self.__do_install(api_obj, [file10_pfmri])
-                self.__do_verify(api_obj, file10_pfmri)
-                self.__do_uninstall(api_obj, [file10_pfmri])
+        # First, verify that install won't fail if the dest_file already
+        # exists, and that it will set the correct owner, group, and
+        # mode for the dest_file even though it already exists.
+        self.__write_empty_file(
+            dest_file, mode=misc.PKG_DIR_MODE, owner="root", group="root"
+        )
+        self.__do_install(api_obj, [file10_pfmri])
+        self.__do_verify(api_obj, file10_pfmri)
+        self.__do_uninstall(api_obj, [file10_pfmri])
 
-                # Next, verify that install and uninstall won't fail if the
-                # dest_file exists, but not as the expected type.  Also check
-                # that the correct mode, owner, group, etc. is set for the
-                # dest_file.
+        # Next, verify that install and uninstall won't fail if the
+        # dest_file exists, but not as the expected type.  Also check
+        # that the correct mode, owner, group, etc. is set for the
+        # dest_file.
 
-                # File replaced with a directory.
-                os.mkdir(dest_file, misc.PKG_FILE_MODE) # Intentionally wrong.
-                self.__do_install(api_obj, [file10_pfmri])
-                self.__do_verify(api_obj, file10_pfmri)
+        # File replaced with a directory.
+        os.mkdir(dest_file, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        self.__do_install(api_obj, [file10_pfmri])
+        self.__do_verify(api_obj, file10_pfmri)
 
-                os.unlink(dest_file)
-                os.mkdir(dest_file, misc.PKG_FILE_MODE) # Intentionally wrong.
-                self.__do_uninstall(api_obj, [file10_pfmri])
+        os.unlink(dest_file)
+        os.mkdir(dest_file, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        self.__do_uninstall(api_obj, [file10_pfmri])
 
-                # File replaced with a non-empty directory.
-                os.mkdir(dest_file, misc.PKG_FILE_MODE) # Intentionally wrong.
-                open(os.path.join(dest_file, "foobar"), "wb").close()
-                self.assertTrue(os.path.isfile(os.path.join(dest_file, "foobar")))
-                self.__do_install(api_obj, [file10_pfmri])
-                self.__do_verify(api_obj, file10_pfmri)
+        # File replaced with a non-empty directory.
+        os.mkdir(dest_file, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        open(os.path.join(dest_file, "foobar"), "wb").close()
+        self.assertTrue(os.path.isfile(os.path.join(dest_file, "foobar")))
+        self.__do_install(api_obj, [file10_pfmri])
+        self.__do_verify(api_obj, file10_pfmri)
 
-                os.unlink(dest_file)
-                os.mkdir(dest_file, misc.PKG_FILE_MODE) # Intentionally wrong.
-                open(os.path.join(dest_file, "foobar"), "wb").close()
-                self.assertTrue(os.path.exists(os.path.join(dest_file, "foobar")))
-                self.__do_uninstall(api_obj, [file10_pfmri])
+        os.unlink(dest_file)
+        os.mkdir(dest_file, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        open(os.path.join(dest_file, "foobar"), "wb").close()
+        self.assertTrue(os.path.exists(os.path.join(dest_file, "foobar")))
+        self.__do_uninstall(api_obj, [file10_pfmri])
 
-                # File replaced with a link.
-                self.__do_install(api_obj, ["dir"])
-                os.symlink(src, dest_file)
-                self.__do_install(api_obj, [file10_pfmri])
-                self.__do_verify(api_obj, file10_pfmri)
+        # File replaced with a link.
+        self.__do_install(api_obj, ["dir"])
+        os.symlink(src, dest_file)
+        self.__do_install(api_obj, [file10_pfmri])
+        self.__do_verify(api_obj, file10_pfmri)
 
-                os.unlink(dest_file)
-                os.symlink(src, dest_file)
-                self.__do_uninstall(api_obj, [file10_pfmri])
+        os.unlink(dest_file)
+        os.symlink(src, dest_file)
+        self.__do_uninstall(api_obj, [file10_pfmri])
 
-                # File's parent directory replaced with a link.
-                filesub10_pfmri = self.plist["filesub"][0]
-                os.mkdir(os.path.join(self.get_img_path(), "export"))
-                new_src = os.path.join(os.path.dirname(src), "export", "dir")
-                shutil.move(src, os.path.dirname(new_src))
-                os.symlink(new_src, src)
-                self.assertRaises(api_errors.ActionExecutionError,
-                    self.__do_install, api_obj, [filesub10_pfmri])
+        # File's parent directory replaced with a link.
+        filesub10_pfmri = self.plist["filesub"][0]
+        os.mkdir(os.path.join(self.get_img_path(), "export"))
+        new_src = os.path.join(os.path.dirname(src), "export", "dir")
+        shutil.move(src, os.path.dirname(new_src))
+        os.symlink(new_src, src)
+        self.assertRaises(
+            api_errors.ActionExecutionError,
+            self.__do_install,
+            api_obj,
+            [filesub10_pfmri],
+        )
 
-        def test_01_file_parent(self):
+    def test_01_file_parent(self):
+        api_obj = self.image_create(self.rurl)
 
-                api_obj = self.image_create(self.rurl)
+        # File's parent directory replaced with a file
+        self.__do_install(api_obj, ["filesub", "dir"])
+        dirpath = os.path.join(self.get_img_path(), "dir")
+        filepath = os.path.join(dirpath, "file")
+        os.unlink(filepath)
+        os.rmdir(dirpath)
+        open(dirpath, "wb").close()
+        self.assertRaises(
+            api_errors.ActionExecutionError,
+            self.__do_uninstall,
+            api_obj,
+            ["filesub"],
+        )
 
-                # File's parent directory replaced with a file
-                self.__do_install(api_obj, ['filesub', 'dir'])
-                dirpath = os.path.join(self.get_img_path(), "dir")
-                filepath = os.path.join(dirpath, "file")
-                os.unlink(filepath)
-                os.rmdir(dirpath)
-                open(dirpath, "wb").close()
-                self.assertRaises(api_errors.ActionExecutionError,
-                    self.__do_uninstall, api_obj, ['filesub'])
+    def test_02_link(self):
+        """Verify that link install and removal works as expected when
+        link is already present before install or has been replaced
+        with a directory or file during install or removal."""
 
-        def test_02_link(self):
-                """Verify that link install and removal works as expected when
-                link is already present before install or has been replaced
-                with a directory or file during install or removal."""
+        api_obj = self.image_create(self.rurl)
 
-                api_obj = self.image_create(self.rurl)
+        # The dest_link's installed path.
+        dest_link_name = "link"
+        link10_pfmri = self.plist[dest_link_name][0]
+        link20_pfmri = self.plist[dest_link_name][1]
+        dest_link = os.path.join(self.get_img_path(), dest_link_name)
 
-                # The dest_link's installed path.
-                dest_link_name = "link"
-                link10_pfmri = self.plist[dest_link_name][0]
-                link20_pfmri = self.plist[dest_link_name][1]
-                dest_link = os.path.join(self.get_img_path(), dest_link_name)
+        # First, verify that install won't fail if the dest_link already
+        # exists.
+        self.__do_install(api_obj, ["dir"])
+        os.symlink("dir", dest_link)
+        self.__do_install(api_obj, [link10_pfmri])
+        self.__do_verify(api_obj, link10_pfmri)
+        self.__do_uninstall(api_obj, [link10_pfmri])
 
-                # First, verify that install won't fail if the dest_link already
-                # exists.
-                self.__do_install(api_obj, ["dir"])
-                os.symlink("dir", dest_link)
-                self.__do_install(api_obj, [link10_pfmri])
-                self.__do_verify(api_obj, link10_pfmri)
-                self.__do_uninstall(api_obj, [link10_pfmri])
+        # Next, verify that install and uninstall won't fail if the
+        # dest_link exists, but not as the expected type.  Also check
+        # that the correct mode, owner, group, etc. is set for the
+        # dest_link.
 
-                # Next, verify that install and uninstall won't fail if the
-                # dest_link exists, but not as the expected type.  Also check
-                # that the correct mode, owner, group, etc. is set for the
-                # dest_link.
+        # Link replaced with a directory.
+        os.mkdir(dest_link, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        self.__do_install(api_obj, [link10_pfmri])
+        self.__do_verify(api_obj, link10_pfmri)
 
-                # Link replaced with a directory.
-                os.mkdir(dest_link, misc.PKG_FILE_MODE) # Intentionally wrong.
-                self.__do_install(api_obj, [link10_pfmri])
-                self.__do_verify(api_obj, link10_pfmri)
+        os.unlink(dest_link)
+        os.mkdir(dest_link, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        self.__do_uninstall(api_obj, [link10_pfmri])
 
-                os.unlink(dest_link)
-                os.mkdir(dest_link, misc.PKG_FILE_MODE) # Intentionally wrong.
-                self.__do_uninstall(api_obj, [link10_pfmri])
+        # Link replaced with a non-empty directory.
+        os.mkdir(dest_link, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        open(os.path.join(dest_link, "foobar"), "wb").close()
+        self.assertTrue(os.path.isfile(os.path.join(dest_link, "foobar")))
+        self.__do_install(api_obj, [link10_pfmri])
+        self.__do_verify(api_obj, link10_pfmri)
 
-                # Link replaced with a non-empty directory.
-                os.mkdir(dest_link, misc.PKG_FILE_MODE) # Intentionally wrong.
-                open(os.path.join(dest_link, "foobar"), "wb").close()
-                self.assertTrue(os.path.isfile(os.path.join(dest_link, "foobar")))
-                self.__do_install(api_obj, [link10_pfmri])
-                self.__do_verify(api_obj, link10_pfmri)
+        os.unlink(dest_link)
+        os.mkdir(dest_link, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        open(os.path.join(dest_link, "foobar"), "wb").close()
+        self.assertTrue(os.path.exists(os.path.join(dest_link, "foobar")))
+        self.__do_uninstall(api_obj, [link10_pfmri])
 
-                os.unlink(dest_link)
-                os.mkdir(dest_link, misc.PKG_FILE_MODE) # Intentionally wrong.
-                open(os.path.join(dest_link, "foobar"), "wb").close()
-                self.assertTrue(os.path.exists(os.path.join(dest_link, "foobar")))
-                self.__do_uninstall(api_obj, [link10_pfmri])
+        # Link replaced with a file.
+        self.__write_empty_file(dest_link)
+        self.__do_install(api_obj, [link10_pfmri])
+        self.__do_verify(api_obj, link10_pfmri)
 
-                # Link replaced with a file.
-                self.__write_empty_file(dest_link)
-                self.__do_install(api_obj, [link10_pfmri])
-                self.__do_verify(api_obj, link10_pfmri)
+        os.unlink(dest_link)
+        self.__write_empty_file(dest_link)
+        self.__do_uninstall(api_obj, [link10_pfmri])
 
-                os.unlink(dest_link)
-                self.__write_empty_file(dest_link)
-                self.__do_uninstall(api_obj, [link10_pfmri])
+        # Link's parent directory replaced with a link.
+        os.mkdir(os.path.join(self.get_img_path(), "export"))
+        src = os.path.join(self.get_img_path(), "dir")
+        new_src = os.path.join(os.path.dirname(src), "export", "dir")
+        self.__do_install(api_obj, ["dir"])
+        shutil.move(src, os.path.dirname(new_src))
+        os.symlink(new_src, src)
+        self.assertRaises(
+            api_errors.ActionExecutionError,
+            self.__do_install,
+            api_obj,
+            [link20_pfmri],
+        )
 
-                # Link's parent directory replaced with a link.
-                os.mkdir(os.path.join(self.get_img_path(), "export"))
-                src = os.path.join(self.get_img_path(), "dir")
-                new_src = os.path.join(os.path.dirname(src), "export", "dir")
-                self.__do_install(api_obj, ["dir"])
-                shutil.move(src, os.path.dirname(new_src))
-                os.symlink(new_src, src)
-                self.assertRaises(api_errors.ActionExecutionError,
-                    self.__do_install, api_obj, [link20_pfmri])
+    def test_03_hardlink(self):
+        """Verify that hard link install and removal works as expected
+        when the link is already present before install or has been
+        replaced with a directory or link during install or removal."""
 
-        def test_03_hardlink(self):
-                """Verify that hard link install and removal works as expected
-                when the link is already present before install or has been
-                replaced with a directory or link during install or removal."""
+        api_obj = self.image_create(self.rurl)
 
-                api_obj = self.image_create(self.rurl)
+        # The dest_hlink's installed path.
+        dest_hlink_name = "hardlink"
+        hlink10_pfmri = self.plist[dest_hlink_name][0]
+        hlink20_pfmri = self.plist[dest_hlink_name][1]
+        dest_hlink = os.path.join(self.get_img_path(), dest_hlink_name)
+        src = os.path.join(self.get_img_path(), "file")
 
-                # The dest_hlink's installed path.
-                dest_hlink_name = "hardlink"
-                hlink10_pfmri = self.plist[dest_hlink_name][0]
-                hlink20_pfmri = self.plist[dest_hlink_name][1]
-                dest_hlink = os.path.join(self.get_img_path(), dest_hlink_name)
-                src = os.path.join(self.get_img_path(), "file")
+        # First, verify that install won't fail if the dest_hlink
+        # already exists, and that it will set the correct owner, group,
+        # and mode for the dest_hlink even though it already exists.
+        self.__do_install(api_obj, ["file"])
+        os.link(src, dest_hlink)
+        self.__do_install(api_obj, [hlink10_pfmri])
+        self.__do_verify(api_obj, hlink10_pfmri)
+        self.__do_uninstall(api_obj, [hlink10_pfmri])
 
-                # First, verify that install won't fail if the dest_hlink
-                # already exists, and that it will set the correct owner, group,
-                # and mode for the dest_hlink even though it already exists.
-                self.__do_install(api_obj, ["file"])
-                os.link(src, dest_hlink)
-                self.__do_install(api_obj, [hlink10_pfmri])
-                self.__do_verify(api_obj, hlink10_pfmri)
-                self.__do_uninstall(api_obj, [hlink10_pfmri])
+        # Next, verify that install and uninstall won't fail if the
+        # dest_hlink exists, but not as the expected type.  Also check
+        # that the correct mode, owner, group, etc. is set for the
+        # dest_hlink.
 
-                # Next, verify that install and uninstall won't fail if the
-                # dest_hlink exists, but not as the expected type.  Also check
-                # that the correct mode, owner, group, etc. is set for the
-                # dest_hlink.
+        # Hard link replaced with a directory.
+        os.mkdir(dest_hlink, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        self.__do_install(api_obj, [hlink10_pfmri])
+        self.__do_verify(api_obj, hlink10_pfmri)
 
-                # Hard link replaced with a directory.
-                os.mkdir(dest_hlink, misc.PKG_FILE_MODE) # Intentionally wrong.
-                self.__do_install(api_obj, [hlink10_pfmri])
-                self.__do_verify(api_obj, hlink10_pfmri)
+        os.unlink(dest_hlink)
+        os.mkdir(dest_hlink, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        self.__do_uninstall(api_obj, [hlink10_pfmri])
 
-                os.unlink(dest_hlink)
-                os.mkdir(dest_hlink, misc.PKG_FILE_MODE) # Intentionally wrong.
-                self.__do_uninstall(api_obj, [hlink10_pfmri])
+        # Hard link replaced with a non-empty directory.
+        os.mkdir(dest_hlink, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        open(os.path.join(dest_hlink, "foobar"), "wb").close()
+        self.assertTrue(os.path.isfile(os.path.join(dest_hlink, "foobar")))
+        self.__do_install(api_obj, [hlink10_pfmri])
+        self.__do_verify(api_obj, hlink10_pfmri)
 
-                # Hard link replaced with a non-empty directory.
-                os.mkdir(dest_hlink, misc.PKG_FILE_MODE) # Intentionally wrong.
-                open(os.path.join(dest_hlink, "foobar"), "wb").close()
-                self.assertTrue(os.path.isfile(os.path.join(dest_hlink, "foobar")))
-                self.__do_install(api_obj, [hlink10_pfmri])
-                self.__do_verify(api_obj, hlink10_pfmri)
+        os.unlink(dest_hlink)
+        os.mkdir(dest_hlink, misc.PKG_FILE_MODE)  # Intentionally wrong.
+        open(os.path.join(dest_hlink, "foobar"), "wb").close()
+        self.assertTrue(os.path.exists(os.path.join(dest_hlink, "foobar")))
+        self.__do_uninstall(api_obj, [hlink10_pfmri])
 
-                os.unlink(dest_hlink)
-                os.mkdir(dest_hlink, misc.PKG_FILE_MODE) # Intentionally wrong.
-                open(os.path.join(dest_hlink, "foobar"), "wb").close()
-                self.assertTrue(os.path.exists(os.path.join(dest_hlink, "foobar")))
-                self.__do_uninstall(api_obj, [hlink10_pfmri])
+        # Hard link replaced with a link.
+        os.symlink(src, dest_hlink)
+        self.__do_install(api_obj, [hlink10_pfmri])
+        self.__do_verify(api_obj, hlink10_pfmri)
 
-                # Hard link replaced with a link.
-                os.symlink(src, dest_hlink)
-                self.__do_install(api_obj, [hlink10_pfmri])
-                self.__do_verify(api_obj, hlink10_pfmri)
+        os.unlink(dest_hlink)
+        os.symlink(src, dest_hlink)
+        self.__do_uninstall(api_obj, [hlink10_pfmri])
 
-                os.unlink(dest_hlink)
-                os.symlink(src, dest_hlink)
-                self.__do_uninstall(api_obj, [hlink10_pfmri])
+        # Hard link target is missing (failure expected).
+        self.__do_uninstall(api_obj, ["file"])
+        self.assertRaises(
+            api_errors.ActionExecutionError,
+            self.__do_install,
+            api_obj,
+            [hlink10_pfmri],
+        )
 
-                # Hard link target is missing (failure expected).
-                self.__do_uninstall(api_obj, ["file"])
-                self.assertRaises(api_errors.ActionExecutionError,
-                    self.__do_install, api_obj, [hlink10_pfmri])
-
-                # Hard link's parent directory replaced with a link.
-                os.mkdir(os.path.join(self.get_img_path(), "export"))
-                src = os.path.join(self.get_img_path(), "dir")
-                new_src = os.path.join(os.path.dirname(src), "export", "dir")
-                self.__do_install(api_obj, ["dir"])
-                shutil.move(src, os.path.dirname(new_src))
-                os.symlink(new_src, src)
-                self.assertRaises(api_errors.ActionExecutionError,
-                    self.__do_install, api_obj, [hlink20_pfmri])
+        # Hard link's parent directory replaced with a link.
+        os.mkdir(os.path.join(self.get_img_path(), "export"))
+        src = os.path.join(self.get_img_path(), "dir")
+        new_src = os.path.join(os.path.dirname(src), "export", "dir")
+        self.__do_install(api_obj, ["dir"])
+        shutil.move(src, os.path.dirname(new_src))
+        os.symlink(new_src, src)
+        self.assertRaises(
+            api_errors.ActionExecutionError,
+            self.__do_install,
+            api_obj,
+            [hlink20_pfmri],
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_pkg_api_revert.py
+++ b/src/tests/api/t_pkg_api_revert.py
@@ -25,16 +25,17 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 
 class TestPkgApiRevert(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        pkgs = """
+    pkgs = """
             open A@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add file etc/file1 mode=0555 owner=root group=bin path=etc/file1
@@ -46,45 +47,45 @@ class TestPkgApiRevert(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        misc_files = ["etc/file1", "etc/file2", "etc/file3"]
+    misc_files = ["etc/file1", "etc/file2", "etc/file3"]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.plist = self.pkgsend_bulk(self.rurl, self.pkgs)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.plist = self.pkgsend_bulk(self.rurl, self.pkgs)
 
-        def test_changed_packages(self):
-                """Verify that pkg revert correctly marks changed packages."""
+    def test_changed_packages(self):
+        """Verify that pkg revert correctly marks changed packages."""
 
-                api_inst = self.image_create(self.rurl)
+        api_inst = self.image_create(self.rurl)
 
-                # try reverting non-editable files
-                self._api_install(api_inst, ["A@1.0", "B@1.0"])
+        # try reverting non-editable files
+        self._api_install(api_inst, ["A@1.0", "B@1.0"])
 
-                # remove a files from pkg A only
-                self.file_remove("etc/file2")
+        # remove a files from pkg A only
+        self.file_remove("etc/file2")
 
-                # make sure we broke only pkg A
-                self.pkg("verify A", exit=1)
-                self.pkg("verify B")
+        # make sure we broke only pkg A
+        self.pkg("verify A", exit=1)
+        self.pkg("verify B")
 
-                # now see if revert when files in both packages are named only
-                # marks pkg A as changed
-                self._api_revert(api_inst, ["/etc/file2"], noexecute=True)
-                plan = api_inst.describe()
-                pfmri = self.plist[0]
-                self.assertEqualDiff([(pfmri, pfmri)], [
-                    (str(entry[0]), str(entry[1]))
-                    for entry in plan.plan_desc
-                ])
+        # now see if revert when files in both packages are named only
+        # marks pkg A as changed
+        self._api_revert(api_inst, ["/etc/file2"], noexecute=True)
+        plan = api_inst.describe()
+        pfmri = self.plist[0]
+        self.assertEqualDiff(
+            [(pfmri, pfmri)],
+            [(str(entry[0]), str(entry[1])) for entry in plan.plan_desc],
+        )
 
-                # actually execute it, then check verify passes
-                self._api_revert(api_inst, ["/etc/file2", "/etc/file3"])
-                self.pkg("verify")
+        # actually execute it, then check verify passes
+        self._api_revert(api_inst, ["/etc/file2", "/etc/file3"])
+        self.pkg("verify")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_pkglint.py
+++ b/src/tests/api/t_pkglint.py
@@ -24,8 +24,9 @@
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os.path
@@ -43,28 +44,39 @@ from pkg.lint.engine import lint_fmri_successor
 from pkg.lint.base import linted, DuplicateLintedAttrException
 
 import logging
+
 log_fmt_string = "{asctime} - {levelname} - {message}"
 
 logger = logging.getLogger("pkglint")
 if not logger.handlers:
-        logger.setLevel(logging.WARNING)
-        ch = logging.StreamHandler()
-        formatter = logging.Formatter(log_fmt_string, style='{')
-        ch.setFormatter(formatter)
-        ch.setLevel(logging.WARNING)
-        logger.addHandler(ch)
+    logger.setLevel(logging.WARNING)
+    ch = logging.StreamHandler()
+    formatter = logging.Formatter(log_fmt_string, style="{")
+    ch.setFormatter(formatter)
+    ch.setLevel(logging.WARNING)
+    logger.addHandler(ch)
 
-pkglintrcfile = "{0}/usr/share/lib/pkg/pkglintrc".format(pkg5unittest.g_pkg_path)
+pkglintrcfile = "{0}/usr/share/lib/pkg/pkglintrc".format(
+    pkg5unittest.g_pkg_path
+)
 broken_manifests = {}
 expected_failures = {}
 
-expected_failures["unusual_perms.mf"] = ["pkglint.action002.2",
-    "pkglint.action002.1", "pkglint.action002.4", "pkglint.action002.4",
+expected_failures["unusual_perms.mf"] = [
+    "pkglint.action002.2",
+    "pkglint.action002.1",
+    "pkglint.action002.4",
+    "pkglint.action002.4",
     # 5 errors corresponding to the broken group checks above
-    "pkglint.action002.3", "pkglint.action009", "pkglint.action009",
-    "pkglint.action009", "pkglint.action009"]
-broken_manifests["unusual_perms.mf"] = \
-"""
+    "pkglint.action002.3",
+    "pkglint.action009",
+    "pkglint.action009",
+    "pkglint.action009",
+    "pkglint.action009",
+]
+broken_manifests[
+    "unusual_perms.mf"
+] = """
 #
 #
 # We deliver prtdiag as a link on one platform, as a file on another, which is
@@ -93,10 +105,13 @@ file NOHASH path=usr/foo/bar mode=01 owner=root group=staff
 # ERROR pkglint.dupaction001.2      path usr/sbin/prtdiag is a duplicate delivered by
 #                                   pkg://opensolaris.org/system/kernel@0.5.11,5.11-0.141
 #                                   declaring overlapping variants variant.arch
-expected_failures["combo_variants_broken.mf"] = ["pkglint.dupaction008",
-    "pkglint.dupaction001.2"]
-broken_manifests["combo_variants_broken.mf"] = \
-"""
+expected_failures["combo_variants_broken.mf"] = [
+    "pkglint.dupaction008",
+    "pkglint.dupaction001.2",
+]
+broken_manifests[
+    "combo_variants_broken.mf"
+] = """
 #
 #
 # We deliver prtdiag as a dir on one platform, as a file on another
@@ -113,24 +128,27 @@ file 1d5eac1aab628317f9c088d21e4afda9c754bb76 chash=43dbb3e0bc142f399b61d171f926
 """
 
 
-
-#ERROR pkglint.dupaction008        path usr/sbin/prtdiag is delivered by multiple
+# ERROR pkglint.dupaction008        path usr/sbin/prtdiag is delivered by multiple
 #                                  action types across
 #                                  pkg://opensolaris.org/system/kernel@0.5.11,5.11-0.141:20100603T215050Z
-#ERROR pkglint.dupaction010.2      path usr/sbin/prtdiag has missing mediator
+# ERROR pkglint.dupaction010.2      path usr/sbin/prtdiag has missing mediator
 #                                  attributes across actions in
 #                                  pkg://opensolaris.org/system/kernel@0.5.11,5.11-0.141:20100603T215050Z
-#ERROR pkglint.dupaction010.1      path usr/sbin/prtdiag uses multiple action
+# ERROR pkglint.dupaction010.1      path usr/sbin/prtdiag uses multiple action
 #                                  types for potentially mediated links across
 #                                  actions in pkg://opensolaris.org/system/kernel@0.5.11,5.11-0.141:20100603T215050Z
-#ERROR pkglint.dupaction001.2      path usr/sbin/prtdiag is a duplicate delivered
+# ERROR pkglint.dupaction001.2      path usr/sbin/prtdiag is a duplicate delivered
 #                                  by pkg://opensolaris.org/system/kernel@0.5.11,5.11-0.141:20100603T215050Z
 #                                  declaring overlapping variants variant.arch=sparc
 
-expected_failures["combo_variants_broken_links.mf"] = ["pkglint.dupaction008",
-    "pkglint.dupaction001.2", "pkglint.dupaction010.1"]
-broken_manifests["combo_variants_broken_links.mf"] = \
-"""
+expected_failures["combo_variants_broken_links.mf"] = [
+    "pkglint.dupaction008",
+    "pkglint.dupaction001.2",
+    "pkglint.dupaction010.1",
+]
+broken_manifests[
+    "combo_variants_broken_links.mf"
+] = """
 #
 #
 # We deliver prtdiag as a link on one platform, as a file on another
@@ -150,8 +168,9 @@ file 1d5eac1aab628317f9c088d21e4afda9c754bb76 chash=43dbb3e0bc142f399b61d171f926
 """
 
 expected_failures["dup-clashing-vars.mf"] = ["pkglint.dupaction001.1"]
-broken_manifests["dup-clashing-vars.mf"] = \
-"""
+broken_manifests[
+    "dup-clashing-vars.mf"
+] = """
 #
 # we try to deliver usr/sbin/fsadmin twice with the same variant value
 #
@@ -173,11 +192,15 @@ file nohash group=sys mode=0444 owner=root path=var/svc/manifest/application/x11
 file nohash elfarch=i386 elfbits=64 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fcdb1e group=bin mode=0755 owner=root path=usr/bin/xfs pkg.csize=68397 pkg.size=177700 variant.arch=i386
 """
 
-expected_failures["dup-depend-vars.mf"] = ["pkglint.manifest005.2",
-    "pkglint.action005.1", "pkglint.action005.1",
-    "pkglint.action005.1"]
-broken_manifests["dup-depend-vars.mf"] = \
-"""
+expected_failures["dup-depend-vars.mf"] = [
+    "pkglint.manifest005.2",
+    "pkglint.action005.1",
+    "pkglint.action005.1",
+    "pkglint.action005.1",
+]
+broken_manifests[
+    "dup-depend-vars.mf"
+] = """
 #
 # we declare dependencies on the same package name twice, with variants
 #
@@ -197,8 +220,9 @@ depend fmri=shell/zsh/redherring@4.3.9-0.133 type=require variant.foo=bar
 """
 
 expected_failures["dup-depend-incorp.mf"] = ["pkglint.action005.1"]
-broken_manifests["dup-depend-incorp.mf"] = \
-"""
+broken_manifests[
+    "dup-depend-incorp.mf"
+] = """
 #
 # There are 2 dependencies on sfw-incorporation, but only one is a require
 # incorporation, so this should not generate errors, other than us not being
@@ -216,10 +240,14 @@ depend fmri=consolidation/sfw/sfw-incorporation type=require
 depend fmri=consolidation/sfw/sfw-incorporation@0.5.11-0.145 type=incorporate
 """
 
-expected_failures["dup-depend-versions.mf"] = ["pkglint.action005.1",
-    "pkglint.action005.1", "pkglint.action005.1"]
-broken_manifests["dup-depend-versions.mf"] = \
-"""
+expected_failures["dup-depend-versions.mf"] = [
+    "pkglint.action005.1",
+    "pkglint.action005.1",
+    "pkglint.action005.1",
+]
+broken_manifests[
+    "dup-depend-versions.mf"
+] = """
 #
 # as we're declaring complimentary variants, we shouldn't report errors,
 # other than the 3 lint warnings for the missing dependencies
@@ -239,10 +267,13 @@ depend fmri=consolidation/sfw/sfw-incorporation type=require
 depend fmri=shell/zsh@4.3.9-0.134 type=require variant.foo=baz
 """
 
-expected_failures["dup-depend-linted.mf"] = ["pkglint.action005.1",
-    "pkglint.action008"]
-broken_manifests["dup-depend-linted.mf"] = \
-"""
+expected_failures["dup-depend-linted.mf"] = [
+    "pkglint.action005.1",
+    "pkglint.action008",
+]
+broken_manifests[
+    "dup-depend-linted.mf"
+] = """
 #
 # We deliver duplicate dependencies, one coming from a require-any dep
 #
@@ -256,10 +287,13 @@ depend fmri=foo/bar type=require pkg.linted.pkglint.manifest005.2=True
 depend fmri=foo/bar fmri=foo/baz type=require-any
 """
 
-expected_failures["dup-depend-require-any_1.mf"] = ["pkglint.manifest005.2",
-    "pkglint.action005.1"]
-broken_manifests["dup-depend-require-any_1.mf"] = \
-"""
+expected_failures["dup-depend-require-any_1.mf"] = [
+    "pkglint.manifest005.2",
+    "pkglint.action005.1",
+]
+broken_manifests[
+    "dup-depend-require-any_1.mf"
+] = """
 #
 # We deliver duplicate dependencies, one coming from a require-any dep
 #
@@ -274,8 +308,9 @@ depend fmri=foo/bar fmri=foo/baz type=require-any
 """
 
 expected_failures["dup-depend-require-any_2.mf"] = ["pkglint.manifest005.2"]
-broken_manifests["dup-depend-require-any_2.mf"] = \
-"""
+broken_manifests[
+    "dup-depend-require-any_2.mf"
+] = """
 #
 # Should use all values of fmri attribute for duplicate depends check
 #
@@ -290,8 +325,9 @@ depend fmri=foo/gcc-c++-runtime fmri=foo/gcc-3-runtime type=require-any
 """
 
 expected_failures["dup-depend-group-any_1.mf"] = []
-broken_manifests["dup-depend-group-any_1.mf"] = \
-"""
+broken_manifests[
+    "dup-depend-group-any_1.mf"
+] = """
 #
 # Should use all values of fmri attribute for duplicate depends check
 #
@@ -306,8 +342,9 @@ depend fmri=foo/gcc-c-runtime fmri=foo/gcc-3-runtime type=group-any
 """
 
 expected_failures["dup-depend-group-any_2.mf"] = ["pkglint.manifest005.2"]
-broken_manifests["dup-depend-group-any_2.mf"] = \
-"""
+broken_manifests[
+    "dup-depend-group-any_2.mf"
+] = """
 #
 # Should use all values of fmri attribute for duplicate depends check
 #
@@ -321,9 +358,12 @@ depend fmri=foo/gcc-c++-runtime fmri=foo/gcc-3-runtime type=group-any
 depend fmri=foo/gcc-c++-runtime fmri=foo/gcc-3-runtime type=group-any
 """
 
-expected_failures["dup-depend-group-any_require-any_1.mf"] = ["pkglint.manifest005.2"]
-broken_manifests["dup-depend-group-any_require-any_1.mf"] = \
-"""
+expected_failures["dup-depend-group-any_require-any_1.mf"] = [
+    "pkglint.manifest005.2"
+]
+broken_manifests[
+    "dup-depend-group-any_require-any_1.mf"
+] = """
 #
 # Should use all values of fmri attribute for duplicate depends check
 #
@@ -338,8 +378,9 @@ depend fmri=foo/gcc-c-runtime fmri=foo/gcc-3-runtime type=group-any
 """
 
 expected_failures["dup-depend-group-any_require-any_2.mf"] = []
-broken_manifests["dup-depend-group-any_require-any_2.mf"] = \
-"""
+broken_manifests[
+    "dup-depend-group-any_require-any_2.mf"
+] = """
 #
 # Should use all values of fmri attribute for duplicate depends check
 #
@@ -354,8 +395,9 @@ depend fmri=foo/gcc-c++-runtime fmri=foo/gcc-3-runtime type=group-any
 """
 
 expected_failures["bug-17337432.mf"] = []
-broken_manifests["bug-17337432.mf"] = \
-"""
+broken_manifests[
+    "bug-17337432.mf"
+] = """
 #
 # Should use all values of fmri attribute for duplicate depends check
 #
@@ -370,8 +412,9 @@ depend fmri=foo/gcc-c-runtime fmri=foo/gcc-3-runtime type=require-any
 """
 
 expected_failures["license-has-path.mf"] = ["pkglint.action007"]
-broken_manifests["license-has-path.mf"] = \
-"""
+broken_manifests[
+    "license-has-path.mf"
+] = """
 #
 # We deliver a license action that also specifies a path
 #
@@ -385,8 +428,9 @@ license license="Foo" path=usr/share/lib/legalese.txt
 """
 
 expected_failures["license-duplicate.mf"] = ["pkglint.manifest016"]
-broken_manifests["license-duplicate.mf"] = \
-"""
+broken_manifests[
+    "license-duplicate.mf"
+] = """
 #
 # We deliver two license actions with the same license
 #
@@ -401,8 +445,9 @@ license usr/foo/file license="Foo"
 """
 
 expected_failures["dup-no-vars.mf"] = ["pkglint.dupaction001.1"]
-broken_manifests["dup-no-vars.mf"] = \
-"""
+broken_manifests[
+    "dup-no-vars.mf"
+] = """
 #
 # We try to deliver usr/sbin/fsadmin twice without specifying any variants
 #
@@ -427,8 +472,9 @@ file nohash elfarch=i386 elfbits=64 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fc
 """
 
 expected_failures["dup-refcount-diff-attrs.mf"] = ["pkglint.dupaction007"]
-broken_manifests["dup-refcount-diff-attrs.mf"] = \
-"""
+broken_manifests[
+    "dup-refcount-diff-attrs.mf"
+] = """
 #
 # we deliver some duplicate ref-counted actions (dir, link, hardlink) with differing
 # attributes
@@ -447,10 +493,13 @@ dir group=bin mode=0755 alt=foo owner=root path=usr/lib/X11/fs
 dir group=sys mode=0755 owner=root path=/usr/lib/X11
 """
 
-expected_failures["dup-refcount-diff-types.mf"] = ["pkglint.dupaction008",
-    "pkglint.dupaction010.1"]
-broken_manifests["dup-refcount-diff-types.mf"] = \
-"""
+expected_failures["dup-refcount-diff-types.mf"] = [
+    "pkglint.dupaction008",
+    "pkglint.dupaction010.1",
+]
+broken_manifests[
+    "dup-refcount-diff-types.mf"
+] = """
 #
 # we deliver some duplicate ref-counted actions (dir, link, hardlink) with differing
 # types
@@ -469,8 +518,9 @@ hardlink path=usr/bin/gcc target=bar/gcc-bin1
 """
 
 expected_failures["dup-refcount-legacy.mf"] = ["pkglint.dupaction015.1"]
-broken_manifests["dup-refcount-legacy.mf"] = \
-"""
+broken_manifests[
+    "dup-refcount-legacy.mf"
+] = """
 #
 # we deliver two legacy actions with mismatched attributes
 #
@@ -496,10 +546,13 @@ legacy category=system desc="The Apache HTTP Server (usr components)" \
 # 3 errors get reported for this manifest:
 # usr/sbin/fsadmin is delivered by multiple action types across ['pkg://opensolaris.org/pkglint/test@1.1.0,5.11-0.141:20100604T143737Z']
 # usr/sbin/fsadmin delivered by [<pkg.fmri.PkgFmri 'pkg://opensolaris.org/pkglint/test@1.1.0,5.11-0.141:20100604T143737Z' at 0x8733e2c>] is a duplicate, declaring overlapping variants ['variant.other']
-expected_failures["dup-types-clashing-vars.mf"] = ["pkglint.dupaction008",
-    "pkglint.dupaction001.1"]
-broken_manifests["dup-types-clashing-vars.mf"] = \
-"""
+expected_failures["dup-types-clashing-vars.mf"] = [
+    "pkglint.dupaction008",
+    "pkglint.dupaction001.1",
+]
+broken_manifests[
+    "dup-types-clashing-vars.mf"
+] = """
 #
 # we try to deliver usr/sbin/fsadmin with different action types, declaring a
 # variant on both.
@@ -522,10 +575,13 @@ file nohash group=sys mode=0444 owner=root path=var/svc/manifest/application/x11
 file nohash elfarch=i386 elfbits=64 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fcdb1e group=bin mode=0755 owner=root path=usr/bin/xfs pkg.csize=68397 pkg.size=177700 variant.arch=i386
 """
 
-expected_failures["dup-types.mf"] = ["pkglint.dupaction008",
-    "pkglint.dupaction010.1"]
-broken_manifests["dup-types.mf"] = \
-"""
+expected_failures["dup-types.mf"] = [
+    "pkglint.dupaction008",
+    "pkglint.dupaction010.1",
+]
+broken_manifests[
+    "dup-types.mf"
+] = """
 #
 # we deliver usr/lib/X11/fs as several action types
 #
@@ -547,8 +603,9 @@ file nohash elfarch=i386 elfbits=64 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fc
 """
 
 expected_failures["duplicate_sets.mf"] = ["pkglint.manifest006"]
-broken_manifests["duplicate_sets.mf"] = \
-"""
+broken_manifests[
+    "duplicate_sets.mf"
+] = """
 #
 # We try to deliver the same set action twice
 #
@@ -563,8 +620,9 @@ set name=test value=i386
 """
 
 expected_failures["duplicate_sets_allowed_vars.mf"] = []
-broken_manifests["duplicate_sets_allowed_vars.mf"] = \
-"""
+broken_manifests[
+    "duplicate_sets_allowed_vars.mf"
+] = """
 #
 # We try to deliver the same set action twice, with different variants
 #
@@ -579,8 +637,9 @@ set name=test value=i386 variant.arch=i386
 """
 
 expected_failures["duplicate_sets_variants.mf"] = ["pkglint.manifest006"]
-broken_manifests["duplicate_sets_variants.mf"] = \
-"""
+broken_manifests[
+    "duplicate_sets_variants.mf"
+] = """
 #
 # We try to deliver the same set action twice, with variants
 #
@@ -594,10 +653,13 @@ set name=test value=i386 variant.arch=sparc
 set name=test value=i386 variant.arch=sparc
 """
 
-expected_failures["duplicate_sets-linted.mf"] = ["pkglint.manifest006",
-    "pkglint.action008"]
-broken_manifests["duplicate_sets-linted.mf"] = \
-"""
+expected_failures["duplicate_sets-linted.mf"] = [
+    "pkglint.manifest006",
+    "pkglint.action008",
+]
+broken_manifests[
+    "duplicate_sets-linted.mf"
+] = """
 #
 # We try to deliver the same set action twice, the second time we do this,
 # we mark one of the actions as linted
@@ -615,10 +677,13 @@ set name=foo value=bar
 """
 
 
-expected_failures["duplicate_sets-not-enough-lint.mf"] = ["pkglint.manifest006",
-    "pkglint.action008"]
-broken_manifests["duplicate_sets-not-enough-lint.mf"] = \
-"""
+expected_failures["duplicate_sets-not-enough-lint.mf"] = [
+    "pkglint.manifest006",
+    "pkglint.action008",
+]
+broken_manifests[
+    "duplicate_sets-not-enough-lint.mf"
+] = """
 #
 # We try to deliver the same set action twice, the second time we do this,
 # we mark one of the actions as linted, but still should have a broken manifest
@@ -636,8 +701,9 @@ set name=foo value=bar
 """
 
 expected_failures["info_class_valid.mf"] = []
-broken_manifests["info_class_valid.mf"] = \
-"""
+broken_manifests[
+    "info_class_valid.mf"
+] = """
 #
 # A perfectly valid manifest with a correct info.classification key
 #
@@ -652,8 +718,9 @@ set name=variant.arch value=i386 value=sparc
 """
 
 expected_failures["info_class_missing.mf"] = ["opensolaris.manifest001.1"]
-broken_manifests["info_class_missing.mf"] = \
-"""
+broken_manifests[
+    "info_class_missing.mf"
+] = """
 #
 # we deliver package with no info.classification key
 #
@@ -667,8 +734,9 @@ set name=variant.arch value=i386 value=sparc
 """
 
 expected_failures["silly_description.mf"] = ["pkglint.manifest009.2"]
-broken_manifests["silly_description.mf"] = \
-"""
+broken_manifests[
+    "silly_description.mf"
+] = """
 #
 # we deliver package where the description is the same as the summary
 #
@@ -682,8 +750,9 @@ set name=variant.arch value=i386 value=sparc
 """
 
 expected_failures["empty_description.mf"] = ["pkglint.manifest009.1"]
-broken_manifests["empty_description.mf"] = \
-"""
+broken_manifests[
+    "empty_description.mf"
+] = """
 #
 # we deliver package where the description is empty
 #
@@ -697,8 +766,9 @@ set name=variant.arch value=i386 value=sparc
 """
 
 expected_failures["empty_summary.mf"] = ["pkglint.manifest009.3"]
-broken_manifests["empty_summary.mf"] = \
-"""
+broken_manifests[
+    "empty_summary.mf"
+] = """
 #
 # we deliver package where the summary is empty
 #
@@ -712,8 +782,9 @@ set name=variant.arch value=i386 value=sparc
 """
 
 expected_failures["info_class_many_values.mf"] = ["pkglint.manifest008.6"]
-broken_manifests["info_class_many_values.mf"] = \
-"""
+broken_manifests[
+    "info_class_many_values.mf"
+] = """
 #
 # we deliver a directory with multiple info.classification keys, one of which
 # is wrong
@@ -729,8 +800,9 @@ set name=variant.arch value=i386 value=sparc
 """
 
 expected_failures["info_class_wrong_prefix.mf"] = ["pkglint.manifest008.2"]
-broken_manifests["info_class_wrong_prefix.mf"] = \
-"""
+broken_manifests[
+    "info_class_wrong_prefix.mf"
+] = """
 #
 # we deliver a directory with an incorrect info.classification key
 #
@@ -745,8 +817,9 @@ set name=variant.arch value=i386 value=sparc
 """
 
 expected_failures["info_class_no_category.mf"] = ["pkglint.manifest008.3"]
-broken_manifests["info_class_no_category.mf"] = \
-"""
+broken_manifests[
+    "info_class_no_category.mf"
+] = """
 #
 # we deliver a directory with an incorrect info.classification key,
 # with no category value
@@ -762,8 +835,9 @@ set name=variant.arch value=i386 value=sparc
 """
 
 expected_failures["info_class_wrong_category.mf"] = ["pkglint.manifest008.4"]
-broken_manifests["info_class_wrong_category.mf"] = \
-"""
+broken_manifests[
+    "info_class_wrong_category.mf"
+] = """
 #
 # we deliver a directory with incorrect info.classification section/category
 #
@@ -777,10 +851,15 @@ set name=pkg.summary value="Pkglint test package"
 set name=variant.arch value=i386 value=sparc
 """
 
-expected_failures["invalid_fmri.mf"] = ["pkglint.action006",
-    "pkglint.action006", "pkglint.action009", "pkglint.action009"]
-broken_manifests["invalid_fmri.mf"] = \
-"""
+expected_failures["invalid_fmri.mf"] = [
+    "pkglint.action006",
+    "pkglint.action006",
+    "pkglint.action009",
+    "pkglint.action009",
+]
+broken_manifests[
+    "invalid_fmri.mf"
+] = """
 #
 # We deliver some broken fmri values
 #
@@ -794,11 +873,18 @@ depend fmri=foo/bar@@134 type=require
 depend fmri=foo/bar fmri="" type=require-any
 """
 
-expected_failures["invalid_linted.mf"] = ["pkglint.action006",
-    "pkglint.action006", "pkglint001.6", "pkglint001.6", "pkglint.manifest007",
-    "pkglint.action009", "pkglint.action009"]
-broken_manifests["invalid_linted.mf"] = \
-"""
+expected_failures["invalid_linted.mf"] = [
+    "pkglint.action006",
+    "pkglint.action006",
+    "pkglint001.6",
+    "pkglint001.6",
+    "pkglint.manifest007",
+    "pkglint.action009",
+    "pkglint.action009",
+]
+broken_manifests[
+    "invalid_linted.mf"
+] = """
 #
 # We have a broken pkg.linted action, so we report both broken depend actions
 # due to the corrupt FMRI values.  We also report two failed attempts
@@ -816,11 +902,16 @@ depend fmri=foo/bar@@134 type=require
 depend fmri=foo/bar fmri="" type=require-any
 """
 
-expected_failures["invalid_usernames.mf"] = ["pkglint.action010.4",
-    "pkglint.action010.2", "pkglint.action010.3", "pkglint.action010.1",
-    "pkglint.action010.3"]
-broken_manifests["invalid_usernames.mf"] = \
-"""
+expected_failures["invalid_usernames.mf"] = [
+    "pkglint.action010.4",
+    "pkglint.action010.2",
+    "pkglint.action010.3",
+    "pkglint.action010.1",
+    "pkglint.action010.3",
+]
+broken_manifests[
+    "invalid_usernames.mf"
+] = """
 #
 # We try to deliver a series of invalid usernames, some result in multiple
 # lint messages
@@ -842,12 +933,21 @@ user gcos-field="pkg(7) server UID" group=pkg5srv uid=101 username=pkg5-_.
 # 5 saying that we've found pkg.linted attributes in these actions, and 2
 # for the errors that would be thrown were they not marked as linted.
 #
-expected_failures["linted-action.mf"] = ["pkglint.action001.2",
-    "pkglint.dupaction003.1", "pkglint.dupaction007",
-    "pkglint.action008", "pkglint.action008", "pkglint.action008",
-    "pkglint.action008", "pkglint.action008", "pkglint001.5", "pkglint001.5"]
-broken_manifests["linted-action.mf"] = \
-"""
+expected_failures["linted-action.mf"] = [
+    "pkglint.action001.2",
+    "pkglint.dupaction003.1",
+    "pkglint.dupaction007",
+    "pkglint.action008",
+    "pkglint.action008",
+    "pkglint.action008",
+    "pkglint.action008",
+    "pkglint.action008",
+    "pkglint001.5",
+    "pkglint001.5",
+]
+broken_manifests[
+    "linted-action.mf"
+] = """
 #
 # we deliver some duplicate ref-counted actions (dir, link, hardlink) with
 # differing attributes, but since they're marked as linted, we should get no
@@ -892,10 +992,13 @@ user ftpuser=false gcos-field="Network Configuration Admin" group=netadm uid=19 
 # - the default log handler used by the pkglint CLI only marks
 # a failure if it's > level.INFO, but for testing, we record all
 # messages
-expected_failures["linted-manifest.mf"] = ["pkglint001.5",
-    "pkglint.manifest007"]
-broken_manifests["linted-manifest.mf"] = \
-"""
+expected_failures["linted-manifest.mf"] = [
+    "pkglint001.5",
+    "pkglint.manifest007",
+]
+broken_manifests[
+    "linted-manifest.mf"
+] = """
 #
 # This manifest is marked as pkg.linted, and should not have manifest
 # checks run on it.  In particular, we should not complain about the lack
@@ -918,10 +1021,14 @@ user ftpuser=false gcos-field="Network Configuration Admin" group=netadm uid=17 
 user ftpuser=false gcos-field="Network Configuration Admin" group=netadm uid=19 username=netcfg
 """
 
-expected_failures["linted-manifest-check.mf"] = ["pkglint001.5",
-    "pkglint.manifest007", "pkglint.action008"]
-broken_manifests["linted-manifest-check.mf"] = \
-"""
+expected_failures["linted-manifest-check.mf"] = [
+    "pkglint001.5",
+    "pkglint.manifest007",
+    "pkglint.action008",
+]
+broken_manifests[
+    "linted-manifest-check.mf"
+] = """
 #
 # This manifest is delivers a weird info.classification value
 #
@@ -938,10 +1045,16 @@ set name=pkg.linted value=True
 dir group=bin mode=0755 owner=root path=usr/lib/X11
 """
 
-expected_failures["linted-manifest-check2.mf"] = ["pkglint001.5",
-    "pkglint001.5", "pkglint001.5", "pkglint.manifest007", "pkglint.action008"]
-broken_manifests["linted-manifest-check2.mf"] = \
-"""
+expected_failures["linted-manifest-check2.mf"] = [
+    "pkglint001.5",
+    "pkglint001.5",
+    "pkglint001.5",
+    "pkglint.manifest007",
+    "pkglint.action008",
+]
+broken_manifests[
+    "linted-manifest-check2.mf"
+] = """
 #
 # This manifest delivers actions with underscores in attribute names
 # and values, but they're all marked linted because we have a manifest-level
@@ -968,11 +1081,17 @@ set name=pkg.summary value="Pkglint test package" foo_name=bar
 dir group=bin mode=0755 owner=root path=usr/lib/X11 bar=has_underscore
 """
 
-expected_failures["linted-manifest-check3.mf"] = ["pkglint.action008",
-    "pkglint.manifest007", "pkglint.action001.1", "pkglint.action001.1",
-    "pkglint001.5", "pkglint001.5"]
-broken_manifests["linted-manifest-check3.mf"] = \
-"""
+expected_failures["linted-manifest-check3.mf"] = [
+    "pkglint.action008",
+    "pkglint.manifest007",
+    "pkglint.action001.1",
+    "pkglint.action001.1",
+    "pkglint001.5",
+    "pkglint001.5",
+]
+broken_manifests[
+    "linted-manifest-check3.mf"
+] = """
 #
 # This manifest delivers lots of actions with underscores in attribute names
 # and values, but we have a manifest-level check that bypasses only one
@@ -993,10 +1112,13 @@ set name=foo_bar value=baz
 dir group=bin mode=0755 owner=root path=usr/lib/X11 bar=has_underscore
 """
 
-expected_failures["linted-missing-summary.mf"] = ["pkglint001.5",
-    "pkglint.manifest007"]
-broken_manifests["linted-missing-summary.mf"] = \
-"""
+expected_failures["linted-missing-summary.mf"] = [
+    "pkglint001.5",
+    "pkglint.manifest007",
+]
+broken_manifests[
+    "linted-missing-summary.mf"
+] = """
 # We don't care we don't have a summary
 #
 set name=pkg.fmri value=pkg://opensolaris.org/pkglint/TIMFtest@1.1.0,5.11-0.141:20100604T143737Z
@@ -1008,9 +1130,13 @@ set name=pkg.description value="Description of pkglint test package"
 set name=info.classification value=org.opensolaris.category.2008:System/Packaging
 """
 
-expected_failures["linted-desc-match-summary.mf"] = ["pkglint001.5", "pkglint.action008"]
-broken_manifests["linted-desc-match-summary.mf"] = \
-"""
+expected_failures["linted-desc-match-summary.mf"] = [
+    "pkglint001.5",
+    "pkglint.action008",
+]
+broken_manifests[
+    "linted-desc-match-summary.mf"
+] = """
 # We don't care that the description matches the summary
 #
 set name=pkg.fmri value=pkg://opensolaris.org/pkglint/TIMFtest@1.1.0,5.11-0.141:20100604T143737Z
@@ -1022,10 +1148,14 @@ set name=info.classification value=org.opensolaris.category.2008:System/Packagin
 set name=pkg.summary value="Description of pkglint test package" pkg.linted.pkglint.manifest009.2=True
 """
 
-expected_failures["linted-dup-path-types.mf"] = ["pkglint.dupaction001.1",
-    "pkglint.action008", "pkglint.manifest007"]
-broken_manifests["linted-dup-path-types.mf"] = \
-"""
+expected_failures["linted-dup-path-types.mf"] = [
+    "pkglint.dupaction001.1",
+    "pkglint.action008",
+    "pkglint.manifest007",
+]
+broken_manifests[
+    "linted-dup-path-types.mf"
+] = """
 # We don't care that usr/bin/ls is a different type across two actions, but
 # make sure we still complain about the duplicate path attribute
 #
@@ -1042,10 +1172,14 @@ dir path=usr/bin/ls owner=root group=staff mode=755
 
 # three messages: saying we're linting the duplicate attribute path, that we've
 # got a manifest with linted attributes, and an action with a linted attribute.
-expected_failures["linted-dup-attrs.mf"] = ["pkglint001.5", "pkglint.action008",
-    "pkglint.manifest007"]
-broken_manifests["linted-dup-attrs.mf"] = \
-"""
+expected_failures["linted-dup-attrs.mf"] = [
+    "pkglint001.5",
+    "pkglint.action008",
+    "pkglint.manifest007",
+]
+broken_manifests[
+    "linted-dup-attrs.mf"
+] = """
 # We don't care that usr/bin/ls is a duplicate path
 #
 set name=pkg.fmri value=pkg://opensolaris.org/pkglint/TIMFtest@1.1.0,5.11-0.141:20100604T143737Z
@@ -1059,10 +1193,13 @@ file path=usr/bin/ls owner=root group=staff mode=755 pkg.linted.pkglint.dupactio
 file path=usr/bin/ls owner=root group=staff mode=755
 """
 
-expected_failures["linted-dup-refcount.mf"] = ["pkglint.action008",
-    "pkglint.action008"]
-broken_manifests["linted-dup-refcount.mf"] = \
-"""
+expected_failures["linted-dup-refcount.mf"] = [
+    "pkglint.action008",
+    "pkglint.action008",
+]
+broken_manifests[
+    "linted-dup-refcount.mf"
+] = """
 # We don't care that usr/bin/ls are duplicate links, the only output here
 # should be pkglint.action008, reporting on the use of each linted action.
 # Despite avoiding pkglint(1) errors here, pkg(1) will still refuse to
@@ -1080,8 +1217,9 @@ link path=usr/bin/ls target=foo pkg.linted.pkglint.dupaction010.2=true
 """
 
 expected_failures["no_desc-legacy.mf"] = ["pkglint.action003.1"]
-broken_manifests["no_desc-legacy.mf"] = \
-"""
+broken_manifests[
+    "no_desc-legacy.mf"
+] = """
 #
 # We deliver a legacy actions without a required attribute, "desc". Since we
 # can't find the package pointed to by the legacy 'pkg' attribute, we should
@@ -1098,8 +1236,9 @@ legacy variant.arch=sparc arch=sparc category=system desc="core kernel software 
 """
 
 expected_failures["no_dup-allowed-vars.mf"] = []
-broken_manifests["no_dup-allowed-vars.mf"] = \
-"""
+broken_manifests[
+    "no_dup-allowed-vars.mf"
+] = """
 #
 # we try to deliver usr/sbin/fsadmin twice with the same variant value
 #
@@ -1122,8 +1261,9 @@ file nohash elfarch=i386 elfbits=64 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fc
 """
 
 expected_failures["no_dup-types-different-vars.mf"] = []
-broken_manifests["no_dup-types-different-vars.mf"] = \
-"""
+broken_manifests[
+    "no_dup-types-different-vars.mf"
+] = """
 #
 # we declare allowed variants for usr/lib/X11/fs, despite them
 # delivering to the same path name.  Ref-counted actions, but
@@ -1153,10 +1293,14 @@ file nohash elfarch=i386 elfbits=64 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fc
 
 # our obsolete depend lint check should complain about not being able to find
 # manifests, but we shouldn't trigger the duplicate dependency error
-expected_failures["nodup-depend-okvars.mf"] = ["pkglint.action005.1",
-    "pkglint.action005.1", "pkglint.action005.1"]
-broken_manifests["nodup-depend-okvars.mf"] = \
-"""
+expected_failures["nodup-depend-okvars.mf"] = [
+    "pkglint.action005.1",
+    "pkglint.action005.1",
+    "pkglint.action005.1",
+]
+broken_manifests[
+    "nodup-depend-okvars.mf"
+] = """
 #
 # as we're declaring complimentary variants, we shouldn't report errors
 #
@@ -1175,10 +1319,14 @@ depend fmri=consolidation/sfw/sfw-incorporation type=require
 depend fmri=shell/zsh@4.3.9-0.134 type=require variant.foo=baz
 """
 
-expected_failures["novariant_arch.mf"] = ["pkglint.manifest003.3",
-    "pkglint.action005.1", "pkglint.action005.1"]
-broken_manifests["novariant_arch.mf"] = \
-"""
+expected_failures["novariant_arch.mf"] = [
+    "pkglint.manifest003.3",
+    "pkglint.action005.1",
+    "pkglint.action005.1",
+]
+broken_manifests[
+    "novariant_arch.mf"
+] = """
 #
 # we don't have a variant.arch attribute set, and are delivering a file with
 # an elfarch attribute
@@ -1198,8 +1346,9 @@ file nohash elfarch=i386 elfbits=64 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fc
 """
 
 expected_failures["obsolete-has-description.mf"] = ["pkglint.manifest001.1"]
-broken_manifests["obsolete-has-description.mf"] = \
-"""
+broken_manifests[
+    "obsolete-has-description.mf"
+] = """
 #
 # We deliver an obsolete package that has a pkg.description
 #
@@ -1211,8 +1360,9 @@ set name=variant.arch value=i386
 """
 
 expected_failures["obsolete-more-actions.mf"] = ["pkglint.manifest001.2"]
-broken_manifests["obsolete-more-actions.mf"] = \
-"""
+broken_manifests[
+    "obsolete-more-actions.mf"
+] = """
 #
 # We deliver an obsolete package that has actions other than 'set'.
 # (bogus signature on this manifest, just for testing)
@@ -1226,8 +1376,9 @@ signature algorithm=sha256 value=75b662e14a4ea8f0fa0507d40133b0347a36bc1f6311248
 """
 
 expected_failures["obsolete.mf"] = []
-broken_manifests["obsolete.mf"] = \
-"""
+broken_manifests[
+    "obsolete.mf"
+] = """
 #
 # This is a perfectly valid example of an obsolete package
 #
@@ -1238,9 +1389,13 @@ set name=variant.arch value=i386
 signature algorithm=sha256 value=75b662e14a4ea8f0fa0507d40133b0347a36bc1f63112487f4738073edf4455d version=0
 """
 
-expected_failures["obsolete-has-description-linted.mf"] = ["pkglint001.5", "pkglint.action008"]
-broken_manifests["obsolete-has-description-linted.mf"] = \
-"""
+expected_failures["obsolete-has-description-linted.mf"] = [
+    "pkglint001.5",
+    "pkglint.action008",
+]
+broken_manifests[
+    "obsolete-has-description-linted.mf"
+] = """
 #
 # We deliver an obsolete package that has a pkg.description
 #
@@ -1251,9 +1406,13 @@ set name=variant.opensolaris.zone value=global value=nonglobal variant.arch=i386
 set name=variant.arch value=i386
 """
 
-expected_failures["obsolete-more-actions-linted.mf"] = ["pkglint.manifest001.2","pkglint.action008"]
-broken_manifests["obsolete-more-actions-linted.mf"] = \
-"""
+expected_failures["obsolete-more-actions-linted.mf"] = [
+    "pkglint.manifest001.2",
+    "pkglint.action008",
+]
+broken_manifests[
+    "obsolete-more-actions-linted.mf"
+] = """
 #
 # We deliver an obsolete package that has actions other than 'set'.
 # (bogus signature on this manifest, just for testing)
@@ -1267,8 +1426,9 @@ signature algorithm=sha256 value=75b662e14a4ea8f0fa0507d40133b0347a36bc1f6311248
 """
 
 expected_failures["overlay-valid-many-overlays-valid-mismatch.mf"] = []
-broken_manifests["overlay-valid-many-overlays-valid-mismatch.mf"] = \
-"""
+broken_manifests[
+    "overlay-valid-many-overlays-valid-mismatch.mf"
+] = """
 #
 # This manifest declares multiple overlay=true action, each under a different
 # variant, and multiple overlay=allow actions, one of our variants declares a
@@ -1290,8 +1450,9 @@ file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=tru
 """
 
 expected_failures["overlay-valid-many-overlays.mf"] = []
-broken_manifests["overlay-valid-many-overlays.mf"] = \
-"""
+broken_manifests[
+    "overlay-valid-many-overlays.mf"
+] = """
 #
 # This manifest declares multiple overlay=true action, each under a different
 # variant, and multiple overlay=allow actions.
@@ -1312,8 +1473,9 @@ file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=tru
 """
 
 expected_failures["overlay-valid-no-allow-overlay-variant.mf"] = []
-broken_manifests["overlay-valid-no-allow-overlay-variant.mf"] = \
-"""
+broken_manifests[
+    "overlay-valid-no-allow-overlay-variant.mf"
+] = """
 #
 # We have an overlay attribute, but no overlay=allow attribute on the 2nd
 # action, but since we use use variants, the first action never needs to overlay
@@ -1333,8 +1495,9 @@ file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=tru
 """
 
 expected_failures["overlay-valid-simple-no-overlay.mf"] = []
-broken_manifests["overlay-valid-simple-no-overlay.mf"] = \
-"""
+broken_manifests[
+    "overlay-valid-simple-no-overlay.mf"
+] = """
 #
 # A valid manifest which declares two overlay=allow actions across different
 # variants.
@@ -1352,8 +1515,9 @@ file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=tru
 """
 
 expected_failures["overlay-valid-simple-overlay-true.mf"] = []
-broken_manifests["overlay-valid-simple-overlay-true.mf"] = \
-"""
+broken_manifests[
+    "overlay-valid-simple-overlay-true.mf"
+] = """
 #
 # A valid manifest which just declares an overlay=true action
 #
@@ -1368,8 +1532,9 @@ file NOHASH group=staff mode=0644 overlay=true owner=timf path=foo variant.arch=
 """
 
 expected_failures["overlay-valid-simple-overlay.mf"] = []
-broken_manifests["overlay-valid-simple-overlay.mf"] = \
-"""
+broken_manifests[
+    "overlay-valid-simple-overlay.mf"
+] = """
 #
 # A basic valid manifest that uses overlays
 #
@@ -1386,8 +1551,9 @@ file NOHASH group=staff mode=0644 overlay=allow preserve=true owner=timf path=fo
 """
 
 expected_failures["overlay-valid-triple-allowed.mf"] = []
-broken_manifests["overlay-valid-triple-allowed.mf"] = \
-"""
+broken_manifests[
+    "overlay-valid-triple-allowed.mf"
+] = """
 #
 # A valid manifest which has a single overlay=true action, and multiple
 # overlay=allow actions, each in a different variant.
@@ -1408,8 +1574,9 @@ file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=tru
 """
 
 expected_failures["overlay-valid-triple-true.mf"] = []
-broken_manifests["overlay-valid-triple-true.mf"] = \
-"""
+broken_manifests[
+    "overlay-valid-triple-true.mf"
+] = """
 #
 # This manifest declares multiple overlay=true attributes, each under a
 # different variant.
@@ -1429,8 +1596,9 @@ file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=tru
 """
 
 expected_failures["overlay-valid-mismatch-attrs.mf"] = []
-broken_manifests["overlay-valid-mismatch-attrs.mf"] = \
-"""
+broken_manifests[
+    "overlay-valid-mismatch-attrs.mf"
+] = """
 #
 # We declare overlays, but have mismatching attributes between them
 # blah=foo differs, but shouldn't matter.
@@ -1447,9 +1615,12 @@ file NOHASH group=staff mode=0755 overlay=allow owner=timf path=foo preserve=ren
 """
 
 # more overlay checks
-expected_failures["overlay-invalid-broken-attrs.mf"] = ["pkglint.dupaction009.6"]
-broken_manifests["overlay-invalid-broken-attrs.mf"] = \
-"""
+expected_failures["overlay-invalid-broken-attrs.mf"] = [
+    "pkglint.dupaction009.6"
+]
+broken_manifests[
+    "overlay-invalid-broken-attrs.mf"
+] = """
 #
 # We declare overlays, but have mismatching attributes between them
 #
@@ -1464,10 +1635,12 @@ file NOHASH group=staff mode=0755 overlay=true owner=timf path=foo variant.arch=
 file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=rename variant.arch=ppc variant.timf=foo
 """
 
-expected_failures["overlay-invalid-duplicate-allows.mf"] = \
-    ["pkglint.dupaction009.3"]
-broken_manifests["overlay-invalid-duplicate-allows.mf"] = \
-"""
+expected_failures["overlay-invalid-duplicate-allows.mf"] = [
+    "pkglint.dupaction009.3"
+]
+broken_manifests[
+    "overlay-invalid-duplicate-allows.mf"
+] = """
 #
 # Duplicate overlay=allow actions, with no overlay=true action.
 #
@@ -1482,10 +1655,12 @@ file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=ren
 file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=rename variant.arch=ppc
 """
 
-expected_failures["overlay-invalid-duplicate-overlays.mf"] = \
-    ["pkglint.dupaction009.2"]
-broken_manifests["overlay-invalid-duplicate-overlays.mf"] = \
-"""
+expected_failures["overlay-invalid-duplicate-overlays.mf"] = [
+    "pkglint.dupaction009.2"
+]
+broken_manifests[
+    "overlay-invalid-duplicate-overlays.mf"
+] = """
 # We have duplicate overlay actions
 
 set name=pkg.fmri value=bar
@@ -1500,10 +1675,13 @@ file NOHASH group=staff mode=0644 overlay=true owner=timf path=foo variant.arch=
 file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=rename variant.arch=ppc
 """
 
-expected_failures["overlay-invalid-duplicate-pairs.mf"] = \
-    ["pkglint.dupaction009.4", "pkglint.dupaction009.2"]
-broken_manifests["overlay-invalid-duplicate-pairs.mf"] = \
-"""
+expected_failures["overlay-invalid-duplicate-pairs.mf"] = [
+    "pkglint.dupaction009.4",
+    "pkglint.dupaction009.2",
+]
+broken_manifests[
+    "overlay-invalid-duplicate-pairs.mf"
+] = """
 # ensure that depite complimentary pairs of overlay actions,
 # we still catch the duplicate one
 
@@ -1520,11 +1698,14 @@ file NOHASH group=staff mode=0644 overlay=true owner=timf path=foo variant.arch=
 file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=rename variant.arch=ppc
 """
 
-expected_failures["overlay-invalid-no-allow-overlay.mf"] = \
-    ["pkglint.dupaction001.2", "pkglint.dupaction009.7",
-    "pkglint.dupaction009.5"]
-broken_manifests["overlay-invalid-no-allow-overlay.mf"] = \
-"""
+expected_failures["overlay-invalid-no-allow-overlay.mf"] = [
+    "pkglint.dupaction001.2",
+    "pkglint.dupaction009.7",
+    "pkglint.dupaction009.5",
+]
+broken_manifests[
+    "overlay-invalid-no-allow-overlay.mf"
+] = """
 # we have an overlay attribute, but no overlay=allow attribute
 # on the 2nd action
 set name=pkg.fmri value=foo
@@ -1539,11 +1720,14 @@ file NOHASH group=staff mode=0644 overlay=true owner=timf path=foo variant.arch=
 file NOHASH group=staff mode=0644 owner=timf path=foo preserve=true variant.arch=i386
 """
 
-expected_failures["overlay-invalid-no-overlay-allow.mf"] = \
-    ["pkglint.dupaction001.1", "pkglint.dupaction009.7",
-    "pkglint.dupaction009.5"]
-broken_manifests["overlay-invalid-no-overlay-allow.mf"] = \
-"""
+expected_failures["overlay-invalid-no-overlay-allow.mf"] = [
+    "pkglint.dupaction001.1",
+    "pkglint.dupaction009.7",
+    "pkglint.dupaction009.5",
+]
+broken_manifests[
+    "overlay-invalid-no-overlay-allow.mf"
+] = """
 set name=pkg.fmri value=bar
 set name=pkg.summary value="Image Packaging System"
 set name=info.classification value=org.opensolaris.category.2008:System/Packaging
@@ -1554,10 +1738,13 @@ file NOHASH group=staff mode=0644 overlay=true owner=timf path=foo
 file NOHASH group=staff mode=0644 owner=timf path=foo preserve=rename
 """
 
-expected_failures["overlay-invalid-no-overlay-preserve.mf"] = \
-    ["pkglint.dupaction009.1", "pkglint.dupaction009.5"]
-broken_manifests["overlay-invalid-no-overlay-preserve.mf"] = \
-"""
+expected_failures["overlay-invalid-no-overlay-preserve.mf"] = [
+    "pkglint.dupaction009.1",
+    "pkglint.dupaction009.5",
+]
+broken_manifests[
+    "overlay-invalid-no-overlay-preserve.mf"
+] = """
 # we don't delcare a 'preserve' attribute on our overlay=allow action
 #
 set name=pkg.fmri value=bar
@@ -1570,10 +1757,13 @@ file NOHASH group=staff mode=0644 overlay=true owner=timf path=foo
 file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo
 """
 
-expected_failures["overlay-invalid-no-overlay-true.mf"] = \
-    ["pkglint.dupaction001.1", "pkglint.dupaction009.7"]
-broken_manifests["overlay-invalid-no-overlay-true.mf"] = \
-"""
+expected_failures["overlay-invalid-no-overlay-true.mf"] = [
+    "pkglint.dupaction001.1",
+    "pkglint.dupaction009.7",
+]
+broken_manifests[
+    "overlay-invalid-no-overlay-true.mf"
+] = """
 # we're missing an overlay=true action, resulting in a duplicate
 set name=pkg.fmri value=bar
 set name=pkg.summary value="Image Packaging System"
@@ -1585,10 +1775,12 @@ file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=tru
 file NOHASH group=staff mode=0644 owner=timf path=foo preserve=rename
 """
 
-expected_failures["overlay-invalid-triple-broken-variants.mf"] = \
-    ["pkglint.dupaction009.4"]
-broken_manifests["overlay-invalid-triple-broken-variants.mf"] = \
-"""
+expected_failures["overlay-invalid-triple-broken-variants.mf"] = [
+    "pkglint.dupaction009.4"
+]
+broken_manifests[
+    "overlay-invalid-triple-broken-variants.mf"
+] = """
 # this package declares overlay actions, but we have duplicate
 # overlay='allow' attributes for variant.foo=foo1
 
@@ -1608,10 +1800,12 @@ file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=tru
 file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=true variant.arch=i386 variant.bar=new variant.foo=foo1
 """
 
-expected_failures["overlay-invalid-triple-broken.mf"] = \
-    ["pkglint.dupaction009.4"]
-broken_manifests["overlay-invalid-triple-broken.mf"] = \
-"""
+expected_failures["overlay-invalid-triple-broken.mf"] = [
+    "pkglint.dupaction009.4"
+]
+broken_manifests[
+    "overlay-invalid-triple-broken.mf"
+] = """
 # this manifest has multiple overlay=allow variants, but the last is
 # duplicated across variant.bar variants
 set name=pkg.fmri value=foo
@@ -1629,8 +1823,9 @@ file NOHASH group=staff mode=0644 overlay=allow owner=timf path=foo preserve=tru
 """
 
 expected_failures["parent_is_not_dir.mf"] = ["pkglint.dupaction011"]
-broken_manifests["parent_is_not_dir.mf"] = \
-"""
+broken_manifests[
+    "parent_is_not_dir.mf"
+] = """
 # This manifest delivers /usr/bin as a symlink to /bin, but tries to install
 # a file through that symlink.
 #
@@ -1646,8 +1841,9 @@ file /etc/motd group=sys mode=0644 owner=root path=usr/bin/foo
 """
 
 expected_failures["parent_is_not_dir_variants.mf"] = []
-broken_manifests["parent_is_not_dir_variants.mf"] = \
-"""
+broken_manifests[
+    "parent_is_not_dir_variants.mf"
+] = """
 # This manifest delivers /usr/bin as a symlink to /bin, but tries to install
 # a file through that symlink.  However, since the symlink and the file are
 # delivered under different variants, this is acceptable
@@ -1664,10 +1860,13 @@ link target=../bin path=usr/bin group=sys owner=root variant.bar=other
 file /etc/motd group=sys mode=0644 owner=root path=usr/bin/foo variant.bar=new
 """
 
-expected_failures["renamed-more-actions.mf"] = ["pkglint.manifest002.1",
-    "pkglint.manifest002.3"]
-broken_manifests["renamed-more-actions.mf"] = \
-"""
+expected_failures["renamed-more-actions.mf"] = [
+    "pkglint.manifest002.1",
+    "pkglint.manifest002.3",
+]
+broken_manifests[
+    "renamed-more-actions.mf"
+] = """
 #
 # We've reported a package as having been renamed, yet try to deliver
 # actions other than 'set' and 'depend'
@@ -1684,10 +1883,14 @@ dir mode=0555 owner=root group=sys path=/usr/bin
 signature algorithm=sha256 value=75b662e14a4ea8f0fa0507d40133b0347a36bc1f63112487f4738073edf4455d version=0
 """
 
-expected_failures["renamed-more-actions-linted.mf"] = ["pkglint.manifest002.3",
-    "pkglint.action008", "pkglint001.5"]
-broken_manifests["renamed-more-actions-linted.mf"] = \
-"""
+expected_failures["renamed-more-actions-linted.mf"] = [
+    "pkglint.manifest002.3",
+    "pkglint.action008",
+    "pkglint001.5",
+]
+broken_manifests[
+    "renamed-more-actions-linted.mf"
+] = """
 #
 # We've reported a package as having been renamed, yet try to deliver
 # actions other than 'set' and 'depend'.  The additional actions are marked
@@ -1705,10 +1908,14 @@ dir mode=0555 owner=root group=sys path=/usr/bin pkg.linted.pkglint.manifest002.
 signature algorithm=sha256 value=75b662e14a4ea8f0fa0507d40133b0347a36bc1f63112487f4738073edf4455d version=0
 """
 
-expected_failures["renamed-more-actions-not-all-linted.mf"] = \
-    ["pkglint.manifest002.1", "pkglint.manifest002.3", "pkglint.action008"]
-broken_manifests["renamed-more-actions-not-all-linted.mf"] = \
-"""
+expected_failures["renamed-more-actions-not-all-linted.mf"] = [
+    "pkglint.manifest002.1",
+    "pkglint.manifest002.3",
+    "pkglint.action008",
+]
+broken_manifests[
+    "renamed-more-actions-not-all-linted.mf"
+] = """
 #
 # We've reported a package as having been renamed, yet try to deliver
 # actions other than 'set' and 'depend'.  One of these additional actions
@@ -1728,8 +1935,9 @@ signature algorithm=sha256 value=75b662e14a4ea8f0fa0507d40133b0347a36bc1f6311248
 """
 
 expected_failures["renamed.mf"] = ["pkglint.manifest002.3"]
-broken_manifests["renamed.mf"] = \
-"""
+broken_manifests[
+    "renamed.mf"
+] = """
 #
 # This is a perfectly valid example of a renamed package
 # (bogus signature on this manifest, just for testing)
@@ -1745,7 +1953,9 @@ signature algorithm=sha256 value=75b662e14a4ea8f0fa0507d40133b0347a36bc1f6311248
 """
 
 expected_failures["renamed-self.mf"] = ["pkglint.manifest002.4"]
-broken_manifests["renamed-self.mf"] = """
+broken_manifests[
+    "renamed-self.mf"
+] = """
 #
 # We try to rename to ourself.
 #
@@ -1760,7 +1970,9 @@ depend fmri=renamed-ancestor-new type=require
 """
 
 expected_failures["smf-manifest.mf"] = []
-broken_manifests["smf-manifest.mf"] = """
+broken_manifests[
+    "smf-manifest.mf"
+] = """
 #
 # We deliver SMF manifests, with correct org.opensolaris.smf.fmri tags
 #
@@ -1777,7 +1989,9 @@ file path=var/svc/manifest/application/file.xml owner=root group=sys mode=644
 """
 
 expected_failures["smf-manifest_broken.mf"] = ["pkglint.manifest011"]
-broken_manifests["smf-manifest_broken.mf"] = """
+broken_manifests[
+    "smf-manifest_broken.mf"
+] = """
 #
 # We deliver SMF manifests, but don't declare an org.opensolaris.smf.fmri tag
 # We should get one warning, rather than one per-SMF-manifest
@@ -1796,10 +2010,15 @@ file path=lib/svc/manifest/README owner=root group=sys mode=644
 file path=var/svc/manifest/sample.db owner=root group=sys mode=644
 """
 
-expected_failures["underscores.mf"] = ["pkglint.action001.1",
-    "pkglint.action001.3", "pkglint.action001.2", "pkglint.action001.1"]
-broken_manifests["underscores.mf"] = \
-"""
+expected_failures["underscores.mf"] = [
+    "pkglint.action001.1",
+    "pkglint.action001.3",
+    "pkglint.action001.2",
+    "pkglint.action001.1",
+]
+broken_manifests[
+    "underscores.mf"
+] = """
 #
 # We try to deliver attributes with underscores.
 #
@@ -1817,8 +2036,9 @@ dir group=bin mode=0755 owner=root path=usr/lib/X11 reboot_needed=False
 """
 
 expected_failures["undescribed-variant.mf"] = ["pkglint.manifest003.1"]
-broken_manifests["undescribed-variant.mf"] = \
-"""
+broken_manifests[
+    "undescribed-variant.mf"
+] = """
 #
 # we try to set a variant we've never described in the manifest
 #
@@ -1838,8 +2058,9 @@ file nohash elfarch=i386 elfbits=64 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fc
 """
 
 expected_failures["unknown-variant.mf"] = ["pkglint.manifest003.2"]
-broken_manifests["unknown-variant.mf"] = \
-"""
+broken_manifests[
+    "unknown-variant.mf"
+] = """
 #
 # we try to deliver an action with a variant value we haven't described
 #
@@ -1859,8 +2080,9 @@ file nohash elfarch=i386 elfbits=64 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fc
 """
 
 expected_failures["ignorable-variant.mf"] = []
-broken_manifests["ignorable-variant.mf"] = \
-"""
+broken_manifests[
+    "ignorable-variant.mf"
+] = """
 #
 # we deliver an undefined, but ignorable variant
 #
@@ -1880,8 +2102,9 @@ file nohash variant.debug.osnet=True elfarch=i386 elfbits=64 elfhash=2d5abc9b99e
 """
 
 expected_failures["ignorable-unknown-variant.mf"] = ["pkglint.manifest003.2"]
-broken_manifests["ignorable-unknown-variant.mf"] = \
-"""
+broken_manifests[
+    "ignorable-unknown-variant.mf"
+] = """
 #
 # we try to deliver an action with a variant value we haven't described,
 # as well as an ignorable variant - we should still get an error
@@ -1902,8 +2125,9 @@ file nohash variant.debug.osnet=True elfarch=i386 elfbits=64 elfhash=2d5abc9b99e
 """
 
 expected_failures["unknown.mf"] = ["pkglint.action004"]
-broken_manifests["unknown.mf"] = \
-"""
+broken_manifests[
+    "unknown.mf"
+] = """
 #
 # We try to deliver an 'unknown' action
 #
@@ -1916,10 +2140,13 @@ set name=org.opensolaris.consolidation value=osnet
 unknown name="no idea"
 """
 
-expected_failures["unusual_mode_noexecdir.mf"] = ["pkglint.action002.1",
-    "pkglint.action002.4"]
-broken_manifests["unusual_mode_noexecdir.mf"] = \
-"""
+expected_failures["unusual_mode_noexecdir.mf"] = [
+    "pkglint.action002.1",
+    "pkglint.action002.4",
+]
+broken_manifests[
+    "unusual_mode_noexecdir.mf"
+] = """
 #
 # we deliver a directory with an unexecutable mode 0422
 #
@@ -1939,9 +2166,10 @@ file nohash group=sys mode=0444 owner=root path=var/svc/manifest/application/x11
 file nohash elfarch=i386 elfbits=64 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fcdb1e group=bin mode=0755 owner=root path=usr/bin/xfs pkg.csize=68397 pkg.size=177700 variant.arch=i386
 """
 
-expected_failures["action_validation.mf" ] = ["pkglint.action009"]
-broken_manifests["action_validation.mf" ] = \
-"""
+expected_failures["action_validation.mf"] = ["pkglint.action009"]
+broken_manifests[
+    "action_validation.mf"
+] = """
 #
 # We deliver an intentionally broken file action
 #
@@ -1956,8 +2184,9 @@ file nohash path=/dev/null
 """
 
 expected_failures["whitelist_action_missing_dep.mf"] = []
-broken_manifests["whitelist_action_missing_dep.mf"] = \
-"""
+broken_manifests[
+    "whitelist_action_missing_dep.mf"
+] = """
 #
 #
 # We declare a pkg.lint.pkglint.action005.1 parameter to a depend action that
@@ -1974,8 +2203,9 @@ depend type=require fmri=test/package pkg.lint.pkglint.action005.1.missing-deps=
 """
 
 expected_failures["whitelist_mf_missing_dep.mf"] = []
-broken_manifests["whitelist_mf_missing_dep.mf"] = \
-"""
+broken_manifests[
+    "whitelist_mf_missing_dep.mf"
+] = """
 #
 # We declare a pkg.lint.pkglint.action005.1 parameter that tells the check to
 # ignore any missing dependencies, as part of its package obsoletion test
@@ -1991,8 +2221,9 @@ depend type=require fmri=test/package
 """
 
 expected_failures["okay_underscores.mf"] = []
-broken_manifests["okay_underscores.mf"] = \
-"""
+broken_manifests[
+    "okay_underscores.mf"
+] = """
 #
 # Underscores in attribute names generate warnings, except for a few that are
 # grandfathered in, locale facets, which have locale names in them, and
@@ -2014,9 +2245,10 @@ link path=usr/bin/foo6 target=bar clone_perms="* 0666 root root"
 link path=usr/bin/foo7 target=bar original_name=SUNWcar:usr/bin/wazaap
 """
 
-expected_failures["mediated_links.mf" ] = []
-broken_manifests["mediated_links.mf" ] = \
-"""
+expected_failures["mediated_links.mf"] = []
+broken_manifests[
+    "mediated_links.mf"
+] = """
 #
 # A perfectly valid manifest that uses mediated links
 #
@@ -2033,9 +2265,10 @@ file path=usr/perl5/5.6/bin/perl owner=root group=sys mode=0755
 file path=usr/perl5/5.12/bin/perl owner=root group=sys mode=0755
 """
 
-expected_failures["mediated_links-dup_file.mf" ] = ["pkglint.dupaction010.1"]
-broken_manifests["mediated_links-dup_file.mf" ] = \
-"""
+expected_failures["mediated_links-dup_file.mf"] = ["pkglint.dupaction010.1"]
+broken_manifests[
+    "mediated_links-dup_file.mf"
+] = """
 #
 # We use mediated links, but also try to deliver a file using the same path as
 # that mediated link
@@ -2054,9 +2287,10 @@ file path=usr/perl5/5.12/bin/perl owner=root group=sys mode=0755
 file path=usr/bin/perl owner=root group=sys mode=0755
 """
 
-expected_failures["mediated_links-types.mf" ] = ["pkglint.dupaction010.1"]
-broken_manifests["mediated_links-types.mf" ] = \
-"""
+expected_failures["mediated_links-types.mf"] = ["pkglint.dupaction010.1"]
+broken_manifests[
+    "mediated_links-types.mf"
+] = """
 #
 # We use mediated links, but then also try to deliver a directory over that link
 # this is similar to the last test, but ensures that reference-counted
@@ -2076,9 +2310,10 @@ file path=usr/perl5/5.12/bin/perl owner=root group=sys mode=0755
 dir path=usr/bin/perl owner=root group=sys mode=0755
 """
 
-expected_failures["mediated_links-variants.mf" ] = []
-broken_manifests["mediated_links-variants.mf" ] = \
-"""
+expected_failures["mediated_links-variants.mf"] = []
+broken_manifests[
+    "mediated_links-variants.mf"
+] = """
 #
 # We use mediated links, but only in the nonglobal zone, with a file
 # in the global zone
@@ -2097,9 +2332,12 @@ file path=usr/perl5/5.12/bin/perl owner=root group=sys mode=0755
 file path=usr/bin/perl owner=root group=sys mode=0755 variant.opensolaris.zone=global
 """
 
-expected_failures["mediated_links-missing-mediator.mf" ] = ["pkglint.dupaction010.2"]
-broken_manifests["mediated_links-missing-mediator.mf" ] = \
-"""
+expected_failures["mediated_links-missing-mediator.mf"] = [
+    "pkglint.dupaction010.2"
+]
+broken_manifests[
+    "mediated_links-missing-mediator.mf"
+] = """
 #
 # We're missing mediated link attributes on one of our links
 #
@@ -2116,9 +2354,10 @@ file path=usr/perl5/5.6/bin/perl owner=root group=sys mode=0755
 file path=usr/perl5/5.12/bin/perl owner=root group=sys mode=0755
 """
 
-expected_failures["mediated_links-namespaces.mf" ] = ["pkglint.dupaction010.3"]
-broken_manifests["mediated_links-namespaces.mf" ] = \
-"""
+expected_failures["mediated_links-namespaces.mf"] = ["pkglint.dupaction010.3"]
+broken_manifests[
+    "mediated_links-namespaces.mf"
+] = """
 #
 # Our mediated links deliver the same path to different namespaces
 #
@@ -2135,9 +2374,10 @@ file path=usr/perl5/5.6/bin/perl owner=root group=sys mode=0755
 file path=usr/perl5/5.12/bin/perl owner=root group=sys mode=0755
 """
 
-expected_failures["mediated_links-missing-attrs.mf" ] = ["pkglint.action009"]
-broken_manifests["mediated_links-missing-attrs.mf" ] = \
-"""
+expected_failures["mediated_links-missing-attrs.mf"] = ["pkglint.action009"]
+broken_manifests[
+    "mediated_links-missing-attrs.mf"
+] = """
 #
 # One of our mediated links is missing mediator-version/impl, causing a
 # general action validation error.
@@ -2155,9 +2395,10 @@ file path=usr/perl5/5.6/bin/perl owner=root group=sys mode=0755
 file path=usr/perl5/5.12/bin/perl owner=root group=sys mode=0755
 """
 
-expected_failures["noversion-incorp.mf" ] = ["pkglint.action011"]
-broken_manifests["noversion-incorp.mf" ] = \
-"""
+expected_failures["noversion-incorp.mf"] = ["pkglint.action011"]
+broken_manifests[
+    "noversion-incorp.mf"
+] = """
 #
 # We deliver an 'incorporate' dependency without specifying the version.
 #
@@ -2171,9 +2412,10 @@ set name=info.classification value=org.opensolaris.category.2008:System/Packagin
 depend type=incorporate fmri=pkg:/some/package
 """
 
-expected_failures["facetvalue-invalid.mf" ] = ["pkglint.action012"]
-broken_manifests["facetvalue-invalid.mf" ] = \
-"""
+expected_failures["facetvalue-invalid.mf"] = ["pkglint.action012"]
+broken_manifests[
+    "facetvalue-invalid.mf"
+] = """
 #
 # Intentionally set facet into a value other than 'true', 'false' or 'all'
 #
@@ -2191,8 +2433,9 @@ file path=usr/perl5/5.12/bin/perl owner=root group=sys mode=0755
 """
 
 expected_failures["file-elfbits32.mf"] = ["pkglint.action014.1"]
-broken_manifests["file-elfbits32.mf"] = \
-"""
+broken_manifests[
+    "file-elfbits32.mf"
+] = """
 #
 # One of the file has elfbits=32, causing an elfbits validation error.
 #
@@ -2207,8 +2450,9 @@ file nohash elfarch=i386 elfbits=32 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fc
 """
 
 expected_failures["so-elfbits32.mf"] = []
-broken_manifests["so-elfbits32.mf"] = \
-"""
+broken_manifests[
+    "so-elfbits32.mf"
+] = """
 #
 # Should not cause validation error if an so file has elfbits=32.
 #
@@ -2223,8 +2467,9 @@ file nohash elfarch=i386 elfbits=32 elfhash=2d5abc9b99e65c52c1afde443e9c5da7a6fc
 """
 
 expected_failures["valid_usernames.mf"] = []
-broken_manifests["valid_usernames.mf"] = \
-"""
+broken_manifests[
+    "valid_usernames.mf"
+] = """
 #
 # Usernames are allowed to contain digit zero.
 #
@@ -2237,146 +2482,173 @@ set name=variant.arch value=i386 value=sparc
 user gcos-field="pkg(7) server UID" group=pkg5srv uid=97 username="pkg5s0v"
 """
 
+
 class TestLogFormatter(log.LogFormatter):
-        """Records log messages to a buffer"""
-        def __init__(self):
-                self.messages = []
-                self.ids = []
-                super(TestLogFormatter, self).__init__()
+    """Records log messages to a buffer"""
 
-        def format(self, msg, ignore_linted=False):
-                if isinstance(msg, log.LintMessage):
-                        linted_flag = False
-                        try:
-                                linted_flag = linted(action=self.action,
-                                    manifest=self.manifest, lint_id=msg.msgid)
-                        except DuplicateLintedAttrException as err:
-                                self.messages.append("{0}\t{1}".format(
-                                    "pkglint001.6", "Logging error: {0}".format(err)))
-                                self.ids.append("pkglint001.6")
+    def __init__(self):
+        self.messages = []
+        self.ids = []
+        super(TestLogFormatter, self).__init__()
 
-                        if linted_flag and not ignore_linted:
-                                linted_msg = (
-                                    "Linted message: {id}  {msg}").format(
-                                    id=msg.msgid, msg=msg)
-                                self.messages.append("{0}\t{1}".format(
-                                        "pkglint001.5", linted_msg))
-                                self.ids.append("pkglint001.5")
-                                return
+    def format(self, msg, ignore_linted=False):
+        if isinstance(msg, log.LintMessage):
+            linted_flag = False
+            try:
+                linted_flag = linted(
+                    action=self.action,
+                    manifest=self.manifest,
+                    lint_id=msg.msgid,
+                )
+            except DuplicateLintedAttrException as err:
+                self.messages.append(
+                    "{0}\t{1}".format(
+                        "pkglint001.6", "Logging error: {0}".format(err)
+                    )
+                )
+                self.ids.append("pkglint001.6")
 
-                        if msg.level >= self.level:
-                                self.messages.append("{0}\t{1}".format(
-                                    msg.msgid, str(msg)))
-                                self.ids.append(msg.msgid)
+            if linted_flag and not ignore_linted:
+                linted_msg = ("Linted message: {id}  {msg}").format(
+                    id=msg.msgid, msg=msg
+                )
+                self.messages.append(
+                    "{0}\t{1}".format("pkglint001.5", linted_msg)
+                )
+                self.ids.append("pkglint001.5")
+                return
 
-        def close(self):
-                self.messages = []
-                self.ids = []
+            if msg.level >= self.level:
+                self.messages.append("{0}\t{1}".format(msg.msgid, str(msg)))
+                self.ids.append(msg.msgid)
+
+    def close(self):
+        self.messages = []
+        self.ids = []
+
 
 class TestLintEngine(pkg5unittest.Pkg5TestCase):
+    def test_lint_checks(self):
+        """Ensure that lint checks are functioning."""
 
-        def test_lint_checks(self):
-                """Ensure that lint checks are functioning."""
+        paths = self.make_misc_files(broken_manifests)
+        paths.sort()
 
-                paths = self.make_misc_files(broken_manifests)
-                paths.sort()
+        for manifest in paths:
+            self.debug("running lint checks on {0}".format(manifest))
+            basename = os.path.basename(manifest)
+            lint_logger = TestLogFormatter()
+            lint_engine = engine.LintEngine(
+                lint_logger,
+                config_file=os.path.join(self.test_root, "pkglintrc"),
+                use_tracker=False,
+            )
 
-                for manifest in paths:
-                        self.debug("running lint checks on {0}".format(manifest))
-                        basename = os.path.basename(manifest)
-                        lint_logger = TestLogFormatter()
-                        lint_engine = engine.LintEngine(lint_logger,
-                            config_file=os.path.join(self.test_root,
-                            "pkglintrc"), use_tracker=False)
+            manifests = read_manifests([manifest], lint_logger)
+            lint_engine.setup(lint_manifests=manifests)
 
-                        manifests = read_manifests([manifest], lint_logger)
-                        lint_engine.setup(lint_manifests=manifests)
+            lint_engine.execute()
+            lint_engine.teardown()
 
-                        lint_engine.execute()
-                        lint_engine.teardown()
+            # look for pkglint001.3 in the output, regardless
+            # of whether we marked that as linted, since it
+            # indicates we caught an exception in one of the
+            # Checker methods.
+            for message in lint_logger.messages:
+                self.assertTrue(
+                    "pkglint001.3" not in message,
+                    "Checker exception thrown for {0}: {1}".format(
+                        basename, message
+                    ),
+                )
 
-                        # look for pkglint001.3 in the output, regardless
-                        # of whether we marked that as linted, since it
-                        # indicates we caught an exception in one of the
-                        # Checker methods.
-                        for message in lint_logger.messages:
-                                self.assertTrue("pkglint001.3" not in message,
-                                    "Checker exception thrown for {0}: {1}".format(
-                                    basename, message))
+            expected = len(expected_failures[basename])
+            actual = len(lint_logger.messages)
+            if actual != expected:
+                self.debug("\n".join(lint_logger.messages))
+                self.assertTrue(
+                    actual == expected,
+                    "Expected {0} failures for {1}, got {2}: {3}".format(
+                        expected,
+                        basename,
+                        actual,
+                        "\n".join(lint_logger.messages),
+                    ),
+                )
+            else:
+                reported = lint_logger.ids
+                known = expected_failures[basename]
+                reported.sort()
+                known.sort()
+                for i in range(0, len(reported)):
+                    self.assertTrue(
+                        reported[i] == known[i],
+                        "Differences in reported vs. "
+                        "expected lint ids for {0}: "
+                        "{1} vs. {2}\n{3}".format(
+                            basename,
+                            str(reported),
+                            str(known),
+                            "\n".join(lint_logger.messages),
+                        ),
+                    )
+            lint_logger.close()
 
-                        expected = len(expected_failures[basename])
-                        actual = len(lint_logger.messages)
-                        if (actual != expected):
-                                self.debug("\n".join(lint_logger.messages))
-                                self.assertTrue(actual == expected,
-                                    "Expected {0} failures for {1}, got {2}: {3}".format(
-                                    expected, basename, actual,
-                                    "\n".join(lint_logger.messages)))
-                        else:
-                                reported = lint_logger.ids
-                                known = expected_failures[basename]
-                                reported.sort()
-                                known.sort()
-                                for i in range(0, len(reported)):
-                                        self.assertTrue(reported[i] == known[i],
-                                            "Differences in reported vs. "
-                                            "expected lint ids for {0}: "
-                                            "{1} vs. {2}\n{3}".format(
-                                            basename, str(reported),
-                                            str(known),
-                                            "\n".join(lint_logger.messages)))
-                        lint_logger.close()
+    def test_info_classification_data(self):
+        """info.classification check can deal with bad data files."""
 
-        def test_info_classification_data(self):
-                """info.classification check can deal with bad data files."""
+        paths = self.make_misc_files(
+            {"info_class_valid.mf": broken_manifests["info_class_valid.mf"]}
+        )
 
-                paths = self.make_misc_files(
-                    {"info_class_valid.mf":
-                    broken_manifests["info_class_valid.mf"]})
+        empty_file = "{0}/empty_file".format(self.test_root)
+        open(empty_file, "w").close()
 
-                empty_file = "{0}/empty_file".format(self.test_root)
-                open(empty_file, "w").close()
+        bad_file = "{0}/bad_file".format(self.test_root)
+        f = open(bad_file, "w")
+        f.write("nothing here")
+        f.close()
 
-                bad_file = "{0}/bad_file".format(self.test_root)
-                f = open(bad_file, "w")
-                f.write("nothing here")
-                f.close()
+        mf_path = paths.pop()
 
-                mf_path = paths.pop()
+        lint_logger = TestLogFormatter()
+        manifests = read_manifests([mf_path], lint_logger)
 
-                lint_logger = TestLogFormatter()
-                manifests = read_manifests([mf_path], lint_logger)
+        for classification_path in ["/dev/null", "/", empty_file, bad_file]:
+            rcfile = self.configure_rcfile(
+                os.path.join(self.test_root, "pkglintrc"),
+                {"info_classification_path": classification_path},
+                self.test_root,
+                section="pkglint",
+                suffix=".tmp",
+            )
 
-                for classification_path in ["/dev/null", "/", empty_file,
-                    bad_file]:
+            lint_engine = engine.LintEngine(
+                lint_logger, config_file=rcfile, use_tracker=False
+            )
 
-                        rcfile = self.configure_rcfile(
-                            os.path.join(self.test_root, "pkglintrc"),
-                            {"info_classification_path": classification_path},
-                            self.test_root, section="pkglint", suffix=".tmp")
-
-                        lint_engine = engine.LintEngine(lint_logger,
-                            config_file=rcfile,
-                            use_tracker=False)
-
-                        lint_engine.setup(lint_manifests=manifests)
-                        lint_engine.execute()
-                        self.assertTrue(
-                            lint_logger.ids == ["pkglint.manifest008.1"],
-                            "Unexpected errors encountered: {0}".format(
-                            lint_logger.messages))
-                        lint_logger.close()
+            lint_engine.setup(lint_manifests=manifests)
+            lint_engine.execute()
+            self.assertTrue(
+                lint_logger.ids == ["pkglint.manifest008.1"],
+                "Unexpected errors encountered: {0}".format(
+                    lint_logger.messages
+                ),
+            )
+            lint_logger.close()
 
 
 class TestLintEngineDepot(pkg5unittest.ManyDepotTestCase):
-        """Tests that exercise reference vs. lint repository checks
-        and test linting of multiple packages at once."""
+    """Tests that exercise reference vs. lint repository checks
+    and test linting of multiple packages at once."""
 
-        persistent_setup = True
+    persistent_setup = True
 
-        ref_mf = {}
+    ref_mf = {}
 
-        ref_mf["ref-ancient-sample1.mf"] = """
+    ref_mf[
+        "ref-ancient-sample1.mf"
+    ] = """
 #
 # A sample package which delivers several actions, to an earlier release than
 # 0.140. This manifest has an intentional error, which we should detect when
@@ -2393,7 +2665,9 @@ file /etc/passwd path=etc/passwd group=sys mode=0644 owner=root preserve=true
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        ref_mf["ref-old-sample1.mf"] = """
+    ref_mf[
+        "ref-old-sample1.mf"
+    ] = """
 #
 # A sample package which delivers several actions, to an earlier release than
 # 0.141
@@ -2407,7 +2681,9 @@ set name=variant.arch value=i386 value=sparc
 file /etc/passwd path=etc/passwd group=sys mode=0644 owner=root preserve=true
 dir group=sys mode=0755 owner=root path=etc
 """
-        ref_mf["ref-sample1.mf"] = """
+    ref_mf[
+        "ref-sample1.mf"
+    ] = """
 #
 # A sample package which delivers several actions, to 0.141
 #
@@ -2421,7 +2697,9 @@ file /etc/passwd path=etc/passwd group=sys mode=0644 owner=root preserve=true
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        ref_mf["ref-sample2.mf"] = """
+    ref_mf[
+        "ref-sample2.mf"
+    ] = """
 #
 # A sample package which delivers several actions
 #
@@ -2436,7 +2714,9 @@ dir group=sys mode=0755 owner=root path=etc
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        ref_mf["ref-sample3.mf"] = """
+    ref_mf[
+        "ref-sample3.mf"
+    ] = """
 #
 # A sample package which delivers several actions
 #
@@ -2450,7 +2730,9 @@ file /etc/group group=sys mode=0644 owner=root path=etc/group
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        ref_mf["ref-sample4-not-obsolete"] = """
+    ref_mf[
+        "ref-sample4-not-obsolete"
+    ] = """
 #
 # This is not an obsolete package - used to check versioning
 #
@@ -2459,7 +2741,9 @@ set name=variant.opensolaris.zone value=global value=nonglobal variant.arch=i386
 set name=variant.arch value=i386
 """
 
-        ref_mf["ref-sample4-obsolete"] = """
+    ref_mf[
+        "ref-sample4-obsolete"
+    ] = """
 #
 # This is a perfectly valid example of an obsolete package
 #
@@ -2469,7 +2753,9 @@ set name=variant.opensolaris.zone value=global value=nonglobal variant.arch=i386
 set name=variant.arch value=i386
 """
 
-        ref_mf["dummy-ancestor.mf"] = """
+    ref_mf[
+        "dummy-ancestor.mf"
+    ] = """
 #
 # This is a dummy package designed trip a lint of no-ancestor-legacy.mf
 # we don't declare a dependency on the package delivering the legacy action.
@@ -2484,7 +2770,9 @@ set name=variant.arch value=i386 value=sparc
 depend fmri=system/more type=require
 """
 
-        ref_mf["twovar.mf"] = """
+    ref_mf[
+        "twovar.mf"
+    ] = """
 #
 # This package shares the kernel/strmod path with onevar.mf but has a different
 # set of variants for both the action and the package.  This should not cause
@@ -2499,7 +2787,9 @@ set name=variant.opensolaris.zone value=global value=nonglobal
 set name=pkg.fmri value=pkg://opensolaris.org/variant/twovar@0.5.11,5.11-0.148:20100910T211706Z
 dir group=sys mode=0755 owner=root path=kernel/strmod variant.opensolaris.zone=global
 """
-        ref_mf["no_rename-dummy-ancestor.mf"] = """
+    ref_mf[
+        "no_rename-dummy-ancestor.mf"
+    ] = """
 #
 # This is a dummy package designed trip a lint of no-ancestor-legacy.mf
 # we don't declare a dependency on the FMRI delivered by it.
@@ -2513,7 +2803,9 @@ set name=variant.arch value=i386 value=sparc
 depend fmri=system/kernel type=require
 """
 
-        ref_mf["legacy-uses-renamed-ancestor.mf"] = """
+    ref_mf[
+        "legacy-uses-renamed-ancestor.mf"
+    ] = """
 #
 # A package with a legacy action that points to a renamed ancestor
 #
@@ -2526,7 +2818,9 @@ set name=variant.arch value=i386 value=sparc
 legacy pkg="renamed-ancestor-old" desc="core kernel software for a specific instruction-set architecture" arch=i386 category=system hotline="Please contact your local service provider" name="Core Solaris Kernel (Root)" vendor="Sun Microsystems, Inc." version=11.11,REV=2009.11.11
 """
 
-        ref_mf["renamed-ancestor-old.mf"] = """
+    ref_mf[
+        "renamed-ancestor-old.mf"
+    ] = """
 #
 # The ancestor referred to above, but we've renamed it
 #
@@ -2539,7 +2833,9 @@ set name=variant.arch value=i386 value=sparc
 set name=pkg.renamed value=true
 depend fmri=renamed-ancestor-new type=require
 """
-        ref_mf["renamed-ancestor-new.mf"] = """
+    ref_mf[
+        "renamed-ancestor-new.mf"
+    ] = """
 #
 # The renamed legacy ancestor - this correctly depends on the latest
 # named version
@@ -2554,7 +2850,9 @@ set name=pkg.renamed value=true
 depend fmri=legacy-uses-renamed-ancestor type=require
 """
 
-        ref_mf["compat-renamed-ancestor-old.mf"] = """
+    ref_mf[
+        "compat-renamed-ancestor-old.mf"
+    ] = """
 #
 # A package with a legacy action that points to a package name that has the
 # leaf name that matches the 'pkg' attribute of the legacy action that it
@@ -2577,7 +2875,9 @@ set name=variant.arch value=i386 value=sparc
 legacy pkg="renamed-ancestor-old" desc="core kernel software for a specific instruction-set architecture" arch=i386 category=system hotline="Please contact your local service provider" name="Core Solaris Kernel (Root)" vendor="Sun Microsystems, Inc." version=11.11,REV=2009.11.11
 """
 
-        ref_mf["depend-possibly-obsolete.mf"] = """
+    ref_mf[
+        "depend-possibly-obsolete.mf"
+    ] = """
 #
 # We declare a dependency on a package that we intend to make obsolete
 # in the lint repository, though this package itself is perfectly valid.
@@ -2593,16 +2893,20 @@ set name=variant.arch value=i386 value=sparc
 depend fmri=system/obsolete-this type=require
 """
 
-        # A set of manifests to be linted. Note that these are all self
-        # consistent, passing all lint checks on their own.
-        # Errors are designed to show up when linted against the ref_*
-        # manifests, as imported to our reference repository.
-        lint_mf = {}
-        expected_failures = {}
+    # A set of manifests to be linted. Note that these are all self
+    # consistent, passing all lint checks on their own.
+    # Errors are designed to show up when linted against the ref_*
+    # manifests, as imported to our reference repository.
+    lint_mf = {}
+    expected_failures = {}
 
-        expected_failures["deliver-old-sample1.mf"] = ["pkglint.dupaction001.1",
-            "pkglint.manifest004"]
-        lint_mf["deliver-old-sample1.mf"] = """
+    expected_failures["deliver-old-sample1.mf"] = [
+        "pkglint.dupaction001.1",
+        "pkglint.manifest004",
+    ]
+    lint_mf[
+        "deliver-old-sample1.mf"
+    ] = """
 #
 # We deliver something a package older version than our ref_repo has,
 # 0.140 instead of 0.141, this should cause errors unless we're
@@ -2621,8 +2925,10 @@ file /etc/passwd path=etc/passwd group=sys mode=0644 owner=root preserve=true
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        expected_failures["deliver-new-sample1.mf"] = []
-        lint_mf["deliver-new-sample1.mf"] = """
+    expected_failures["deliver-new-sample1.mf"] = []
+    lint_mf[
+        "deliver-new-sample1.mf"
+    ] = """
 #
 # We deliver a newer version than our reference repo has
 #
@@ -2636,9 +2942,12 @@ file /etc/passwd path=etc/passwd group=sys mode=0644 owner=root preserve=true
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        expected_failures["deliver-new-sample1-duplicate.mf"] = \
-            ["pkglint.dupaction001.1"]
-        lint_mf["deliver-new-sample1-duplicate.mf"] = """
+    expected_failures["deliver-new-sample1-duplicate.mf"] = [
+        "pkglint.dupaction001.1"
+    ]
+    lint_mf[
+        "deliver-new-sample1-duplicate.mf"
+    ] = """
 #
 # We deliver a newer version than our reference repo has, intentionally
 # duplicating a file our reference repository has in sample3
@@ -2654,9 +2963,10 @@ file /etc/group path=etc/group group=sys mode=0644 owner=root preserve=true
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        expected_failures["no-ancestor-legacy.mf"] = ["pkglint.action003.2"]
-        lint_mf["no-ancestor-legacy.mf"] = \
-"""
+    expected_failures["no-ancestor-legacy.mf"] = ["pkglint.action003.2"]
+    lint_mf[
+        "no-ancestor-legacy.mf"
+    ] = """
 #
 # We deliver a legacy action, but declare a package in the legacy action pkg=
 # field from the ref repo which doesn't depend on us.  Only one failure,
@@ -2672,8 +2982,10 @@ legacy arch=i386 category=system desc="core kernel software for a specific instr
 legacy arch=sparc category=system desc="core kernel software for a specific instruction-set architecture" hotline="Please contact your local service provider" name="Core Solaris Kernel (Root)" pkg=SUNWthisdoesnotexist variant.arch=sparc vendor="Sun Microsystems, Inc." version=11.11,REV=2009.11.11
 """
 
-        expected_failures["unversioned-dep-obsolete.mf"] = ["pkglint.action005"]
-        lint_mf["unversioned-dep-obsolete.mf"] = """
+    expected_failures["unversioned-dep-obsolete.mf"] = ["pkglint.action005"]
+    lint_mf[
+        "unversioned-dep-obsolete.mf"
+    ] = """
 #
 # We declare a dependency without a version number, on an obsolete package
 # this should result in a lint error
@@ -2687,8 +2999,10 @@ set name=variant.arch value=i386 value=sparc
 depend fmri=pkg:/system/obsolete type=require
         """
 
-        expected_failures["versioned-dep-obsolete.mf"] = ["pkglint.action005"]
-        lint_mf["versioned-dep-obsolete.mf"] = """
+    expected_failures["versioned-dep-obsolete.mf"] = ["pkglint.action005"]
+    lint_mf[
+        "versioned-dep-obsolete.mf"
+    ] = """
 #
 # We declare a dependency on a version known to be obsolete
 #
@@ -2701,8 +3015,10 @@ set name=variant.arch value=i386 value=sparc
 depend fmri=pkg://opensolaris.org/system/obsolete@0.5.11,5.11-0.141 type=require
         """
 
-        expected_failures["versioned-older-obsolete.mf"] = ["pkglint.action005"]
-        lint_mf["versioned-older-obsolete.mf"] = """
+    expected_failures["versioned-older-obsolete.mf"] = ["pkglint.action005"]
+    lint_mf[
+        "versioned-older-obsolete.mf"
+    ] = """
 #
 # We have dependency on an older version of the packages which was recently
 # made obsolete. Even though we declared the dependency on the non-obsolete
@@ -2718,8 +3034,10 @@ set name=variant.arch value=i386 value=sparc
 depend fmri=system/obsolete@0.5.11-0.140 type=require
         """
 
-        expected_failures["onevar.mf"] = []
-        lint_mf["onevar.mf"] = """
+    expected_failures["onevar.mf"] = []
+    lint_mf[
+        "onevar.mf"
+    ] = """
 #
 # Test that a package which is only published against one variant value doesn't
 # cause an assertion failure when it shares an action with another package.
@@ -2736,9 +3054,12 @@ set name=pkg.description value="A package published against only one variant val
 dir group=sys mode=0755 owner=root path=kernel/strmod variant.arch=i386 variant.opensolaris.zone=global
 """
 
-        expected_failures["broken-renamed-ancestor-new.mf"] = \
-            ["pkglint.manifest002.3"]
-        lint_mf["broken-renamed-ancestor-new.mf"] = """
+    expected_failures["broken-renamed-ancestor-new.mf"] = [
+        "pkglint.manifest002.3"
+    ]
+    lint_mf[
+        "broken-renamed-ancestor-new.mf"
+    ] = """
 #
 # A new version of one of the packages in the rename chain for
 # legacy-has-renamed-ancestor, which should result in an error.
@@ -2757,8 +3078,12 @@ set name=pkg.renamed value=true
 depend fmri=renamed-ancestor-missing type=require
 """
 
-        expected_failures["self-depend-renamed-ancestor-new.mf"] = ["pkglint.manifest002.4"]
-        lint_mf["self-depend-renamed-ancestor-new.mf"] = """
+    expected_failures["self-depend-renamed-ancestor-new.mf"] = [
+        "pkglint.manifest002.4"
+    ]
+    lint_mf[
+        "self-depend-renamed-ancestor-new.mf"
+    ] = """
 #
 # A new version of one of the packages in the rename chain for
 # legacy-has-renamed-ancestor, which should result in an error.
@@ -2777,8 +3102,10 @@ set name=pkg.renamed value=true
 depend fmri=renamed-ancestor-new type=require
 """
 
-        expected_failures["renamed-obsolete.mf"] = ["pkglint.manifest002.5"]
-        lint_mf["renamed-obsolete.mf"] = """
+    expected_failures["renamed-obsolete.mf"] = ["pkglint.manifest002.5"]
+    lint_mf[
+        "renamed-obsolete.mf"
+    ] = """
 #
 # We try to rename ourselves to an obsolete package.
 #
@@ -2792,8 +3119,10 @@ set name=pkg.renamed value=true
 depend fmri=system/obsolete type=require
 """
 
-        expected_failures["obsolete-this.mf"] = ["pkglint.manifest001.3"]
-        lint_mf["obsolete-this.mf"] = """
+    expected_failures["obsolete-this.mf"] = ["pkglint.manifest001.3"]
+    lint_mf[
+        "obsolete-this.mf"
+    ] = """
 #
 # Make this package obsolete.  Since it has a dependency in the ref_repository,
 # we should get a warning, but only when linting against that repo.
@@ -2804,8 +3133,10 @@ set name=variant.opensolaris.zone value=global value=nonglobal variant.arch=i386
 set name=variant.arch value=i386
 """
 
-        lint_move_mf = {}
-        lint_move_mf["move-sample1.mf"] = """
+    lint_move_mf = {}
+    lint_move_mf[
+        "move-sample1.mf"
+    ] = """
 #
 # A sample package which delivers several actions, to 0.161. We no longer
 # deliver etc/passwd, moving that to the package in move-sample2.mf below.
@@ -2819,7 +3150,9 @@ set name=variant.arch value=i386 value=sparc
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        lint_move_mf["move-sample2.mf"] = """
+    lint_move_mf[
+        "move-sample2.mf"
+    ] = """
 #
 # A sample package which delivers several actions, we now deliver etc/passwd
 # also.
@@ -2836,8 +3169,10 @@ dir group=sys mode=0755 owner=root path=etc
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        lint_license_mf = {}
-        lint_license_mf["pkg1.mf"] = """
+    lint_license_mf = {}
+    lint_license_mf[
+        "pkg1.mf"
+    ] = """
 set name=variant.arch value=i386 value=sparc
 set name=pkg.fmri value=pkg://opensolaris.org/pkg1@0.5.11,5.11-0.141:20100603T215050Z
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -2847,7 +3182,9 @@ set name=pkg.summary value="license test"
 license usr/share/lib/legalese.txt license="Foo"
 """
 
-        lint_license_mf["pkg2.mf"] = """
+    lint_license_mf[
+        "pkg2.mf"
+    ] = """
 set name=variant.arch value=i386 value=sparc
 set name=pkg.fmri value=pkg://opensolaris.org/pkg2@0.5.11,5.11-0.141:20100603T215050Z
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -2857,501 +3194,615 @@ set name=pkg.summary value="license test"
 license usr/foo/file license="Foo"
 """
 
-        def setUp(self):
-
-                pkg5unittest.ManyDepotTestCase.setUp(self,
-                    ["opensolaris.org", "opensolaris.org", "opensolaris.org"],
-                    start_depots=True)
-
-                self.ref_uri = self.dcs[1].get_depot_url()
-                self.lint_uri = self.dcs[2].get_depot_url()
-                self.empty_lint_uri = self.dcs[3].get_depot_url()
-                self.cache_dir = tempfile.mkdtemp("pkglint-cache", "",
-                    self.test_root)
-
-                paths = self.make_misc_files(self.ref_mf)
-
-                for item in paths:
-                        self.pkgsend(depot_url=self.ref_uri,
-                            command="publish {0}".format(item))
-                self.pkgsend(depot_url=self.ref_uri,
-                            command="refresh-index")
-
-                paths = self.make_misc_files(self.lint_mf)
-                for item in paths:
-                        self.pkgsend(depot_url=self.lint_uri,
-                            command="publish {0}".format(item))
-                self.pkgsend(depot_url=self.lint_uri,
-                            command="refresh-index")
-                # we should sign the repositories for additional coverage
-                self.pkgsign(self.lint_uri, "'*'")
-                self.pkgsign(self.ref_uri, "'*'")
-
-        def test_lint_repo_basics(self):
-                """Test basic handling of repo URIs with the lint engine,
-                reference repo is error free, cache dir torn down appropriately.
-                """
-                if not os.path.exists(self.cache_dir):
-                        os.makedirs(self.cache_dir)
-
-                lint_logger = TestLogFormatter()
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=os.path.join(self.test_root, "pkglintrc"))
-
-                lint_engine.setup(cache=self.cache_dir,
-                    lint_uris=[self.ref_uri])
-                lint_engine.execute()
-
-                lint_msgs = []
-                # prune out the missing dependency warnings
-                for msg in lint_logger.messages:
-                        if ("pkglint.action005.1" not in msg
-                            and "pkglint.dupaction015.1" not in msg):
-                                lint_msgs.append(msg)
-
-                self.assertTrue(len(lint_msgs) == 0,
-                    "Unexpected lint errors messages reported against "
-                    "reference repo: {0}".format(
-                    "\n".join(lint_msgs)))
-                lint_logger.close()
-
-                lint_engine.teardown()
-                self.assertTrue(os.path.exists(self.cache_dir),
-                    "Cache dir does not exist after teardown!")
-                self.assertTrue(os.path.exists(
-                    os.path.join(self.cache_dir, "lint_image")),
-                    "lint image dir still existed after teardown!")
-
-                # This shouldn't appear when we're not using a reference repo
-                self.assertFalse(os.path.exists(
-                    os.path.join(self.cache_dir, "ref_image")),
-                    "ref image dir existed!")
-                lint_engine.teardown(clear_cache=True)
-                self.assertFalse(os.path.exists(self.cache_dir),
-                    "Cache dir was not torn down as expected")
-
-        def test_empty_lint_repo(self):
-                """Ensure we can lint an empty repository"""
-
-                paths = self.make_misc_files(self.lint_mf)
-                if not os.path.exists(self.cache_dir):
-                        os.makedirs(self.cache_dir)
-
-                lint_logger = TestLogFormatter()
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                        config_file=os.path.join(self.test_root, "pkglintrc"))
-
-                lint_engine.setup(cache=self.cache_dir,
-                    lint_uris=[self.ref_uri])
-                lint_engine.execute()
-
-                lint_msgs = []
-                # prune out the missing dependency warnings
-                for msg in lint_logger.messages:
-                        if ("pkglint.action005.1" not in msg
-                            and "pkglint.dupaction015.1" not in msg):
-                                lint_msgs.append(msg)
-
-                self.assertFalse(lint_msgs,
-                    "Lint messages reported from a clean reference repository.")
-                lint_engine.teardown(clear_cache=True)
-
-                # this should be an empty test: we have no packages in the
-                # lint repository, so we end up doing nothing
-                lint_logger = TestLogFormatter()
-                lint_engine.setup(cache=self.cache_dir,
-                    lint_uris=[self.empty_lint_uri])
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-                self.assertFalse(lint_logger.messages,
-                    "Lint messages reported from a empty lint repository.")
-
-        def test_versioning(self):
-                """Package version handling during lint runs.
-                In particular, it verifies that packages for linting are merged
-                correctly into pkglint's view of what the ref repository would
-                look like, were the lint package to be published to the
-                reference repository."""
-
-                paths = self.make_misc_files(self.lint_mf)
-                paths.sort()
-
-                for manifest in paths:
-                        self.debug("running lint checks on {0}".format(manifest))
-                        basename = os.path.basename(manifest)
-                        lint_logger = TestLogFormatter()
-                        lint_engine = engine.LintEngine(lint_logger,
-                            use_tracker=False,
-                            config_file=os.path.join(self.test_root,
-                            "pkglintrc"))
-
-                        manifests = read_manifests([manifest], lint_logger)
-                        lint_engine.setup(cache=self.cache_dir,
-                            ref_uris=[self.ref_uri],
-                            lint_manifests=manifests)
-
-                        lint_engine.execute()
-                        lint_engine.teardown(clear_cache=True)
-
-                        expected = len(self.expected_failures[basename])
-                        actual = len(lint_logger.messages)
-                        if (actual != expected):
-                                self.debug("\n".join(lint_logger.messages))
-                                self.assertTrue(actual == expected,
-                                    "Expected {0} failures for {1}, got {2}: {3}".format(
-                                    expected, basename, actual,
-                                    "\n".join(lint_logger.messages)))
-                        else:
-                                reported = lint_logger.ids
-                                known = self.expected_failures[basename]
-                                reported.sort()
-                                known.sort()
-                                for i in range(0, len(reported)):
-                                        self.assertTrue(reported[i] == known[i],
-                                            "Differences in reported vs. expected"
-                                            " lint ids for {0}: {1} vs. {2}".format(
-                                            basename, str(reported),
-                                            str(known)))
-                        lint_logger.close()
-
-                # this manifest should report duplicates when
-                # linted against a 0.141 repository, but none
-                # when linted against a 0.140 repository. The duplicates
-                # were tested when 'deliver-old-sample1.mf' was linted
-                # above - this time, we lint against 0.140 and expect
-                # no errors.
-                lint_logger = TestLogFormatter()
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=os.path.join(self.test_root, "pkglintrc"))
-
-                path = os.path.join(self.test_root, "deliver-old-sample1.mf")
-                manifests = read_manifests([path], lint_logger)
-
-                lint_engine.setup(cache=self.cache_dir,
-                    ref_uris=[self.ref_uri],
-                    lint_manifests=manifests, release="140")
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-
-                self.assertFalse(lint_logger.messages,
-                    "Unexpected lint messages when linting against old "
-                    "version of reference repo: {0}".format(
-                    "\n".join(lint_logger.messages)))
-
-                # ensure we detect the error when linting against the reference
-                # 0.139 repository
-                lint_logger = TestLogFormatter()
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=os.path.join(self.test_root, "pkglintrc"))
-                lint_engine.setup(cache=self.cache_dir,
-                    ref_uris=[self.ref_uri],
-                    lint_uris=[self.ref_uri], release="139")
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-
-                if not lint_logger.ids:
-                        self.assertTrue(False,
-                            "No lint messages produced when linting the "
-                            "contents of an old repository")
-                elif len(lint_logger.ids) != 1:
-                        self.assertTrue(False,
-                            "Expected exactly 1 lint message when linting the "
-                            "contents of an old repository, got {0}".format(
-                            len(lint_logger.ids)))
-                elif lint_logger.ids[0] != "pkglint.dupaction001.1":
-                        self.assertTrue(False,
-                            "Expected pkglint.dupaction001.1 message when "
-                            "linting the contents of an old repository, got "
-                            "{0}".format(lint_logger.ids[0]))
-
-
-        def test_lint_mf_baseline(self):
-                """The lint manifests in this test class should be lint-clean
-                themselves - they should only report errors when linting against
-                our reference repository."""
-
-                paths = self.make_misc_files(self.lint_mf)
-                paths.sort()
-
-                for manifest in paths:
-                        basename = os.path.basename(manifest)
-                        lint_logger = TestLogFormatter()
-                        lint_engine = engine.LintEngine(lint_logger,
-                            use_tracker=False,
-                            config_file=os.path.join(self.test_root,
-                            "pkglintrc"))
-
-                        manifests = read_manifests([manifest], lint_logger)
-                        lint_engine.setup(lint_manifests=manifests)
-
-                        lint_engine.execute()
-                        lint_engine.teardown()
-
-                        # prune missing dependency and missing rename warnings
-                        lint_msgs = []
-                        for msg in lint_logger.messages:
-                                if "pkglint.manifest002.3" in msg or \
-                                    "pkglint.manifest002.4" in msg or \
-                                    "pkglint.action005.1" in msg:
-                                        pass
-                                else:
-                                        lint_msgs.append(msg)
-
-                        self.assertFalse(lint_msgs,
-                            "Unexpected lint messages when linting individual "
-                            "manifests that should contain no errors: {0} {1}".format(
-                            basename, "\n".join(lint_msgs)))
-
-        def test_broken_legacy_rename(self):
-                """Tests that linting a package where we break the renaming
-                of a legacy package, we'll get an error."""
-
-                paths = self.make_misc_files(self.lint_mf)
-                paths.extend(self.make_misc_files(self.ref_mf))
-                rcfile = os.path.join(self.test_root, "pkglintrc")
-
-                legacy = os.path.join(self.test_root,
-                    "legacy-uses-renamed-ancestor.mf")
-                renamed_new = os.path.join(self.test_root,
-                    "broken-renamed-ancestor-new.mf")
-                renamed_old = os.path.join(self.test_root,
-                    "renamed-ancestor-old.mf")
-                renamed_self_depend = os.path.join(self.test_root,
-                    "self-depend-renamed-ancestor-new.mf")
-                compat_legacy = os.path.join(self.test_root,
-                    "compat-renamed-ancestor-old.mf")
-
-                # look for a rename that didn't ultimately resolve to the
-                # package that contained the legacy action
-                lint_logger = TestLogFormatter()
-                manifests = read_manifests([legacy, renamed_new], lint_logger)
-
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=rcfile)
-                lint_engine.setup(cache=self.cache_dir,
-                    ref_uris=[self.ref_uri], lint_manifests=manifests)
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-
-                lint_msgs = []
-                for msg in lint_logger.messages:
-                        if ("pkglint.action005.1" not in msg
-                            and "pkglint.dupaction015.1" not in msg):
-                                lint_msgs.append(msg)
-
-                self.assertTrue(len(lint_msgs) == 2, "Unexpected lint messages "
-                    "{0} produced when linting broken renaming with legacy "
-                    "pkgs".format(lint_msgs))
-
-                seen_2_3 = False
-                seen_3_4 = False
-                for i in lint_logger.ids:
-                        if i == "pkglint.manifest002.3":
-                                seen_2_3 = True
-                        if i == "pkglint.action003.4":
-                                seen_3_4 = True
-
-                self.assertTrue(seen_2_3 and seen_3_4,
-                    "Missing expected broken renaming legacy errors, "
-                    "got {0}".format(lint_msgs))
-
-                # make sure we spot renames that depend upon themselves
-                lint_logger = TestLogFormatter()
-                manifests = read_manifests([legacy, renamed_self_depend],
-                    lint_logger)
-
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=rcfile)
-                lint_engine.setup(cache=self.cache_dir,
-                    ref_uris=[self.ref_uri], lint_manifests=manifests)
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-
-                lint_msgs = []
-                for msg in lint_logger.messages:
-                        lint_msgs.append(msg)
-
-                self.debug(lint_msgs)
-                self.assertTrue(len(lint_msgs) == 3, "Unexpected lint messages "
-                    "produced when linting broken self-dependent renaming with "
-                    "legacy pkgs")
-                seen_2_4 = False
-                seen_3_5 = False
-                for i in lint_logger.ids:
-                        if i == "pkglint.manifest002.4":
-                                seen_2_4 = True
-                        if i == "pkglint.action003.5":
-                                seen_3_5 = True
-                self.assertTrue(seen_2_3 and seen_3_4,
-                    "Missing expected broken renaming self-dependent errors "
-                    "with legacy pkgs. Got {0}".format(lint_msgs))
-
-                # make sure we can deal with compatibility packages.  We include
-                # the 'renamed_old' package as well as the 'compat_legacy'
-                # to ensure that pkglint is satisfied by the compatability
-                # package, rather that trying to follow renames from the
-                # 'renamed_old' package. (otherwise, if a package pointed to by
-                # the legacy 'pkg' attribute doesn't exist, pkglint wouldn't
-                # complain)
-                lint_logger = TestLogFormatter()
-                manifests = read_manifests([renamed_old, compat_legacy],
-                    lint_logger)
-
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=rcfile)
-                lint_engine.setup(cache=self.cache_dir,
-                    ref_uris=[self.ref_uri], lint_manifests=manifests)
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-
-                lint_msgs = []
-                for msg in lint_logger.messages:
-                        lint_msgs.append(msg)
-
-                self.debug(lint_msgs)
-                self.assertTrue(len(lint_msgs) == 1, "Unexpected lint messages "
-                    "produced when linting a compatibility legacy package")
-
-                # the 'legacy' package includes a legacy action which should
-                # also be satisfied by the compat_legacy being installed.
-                lint_logger = TestLogFormatter()
-                manifests = read_manifests([legacy, compat_legacy],
-                    lint_logger)
-
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=rcfile)
-                lint_engine.setup(cache=self.cache_dir,
-                    ref_uris=[self.ref_uri], lint_manifests=manifests)
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-
-                lint_msgs = []
-                for msg in lint_logger.messages:
-                        lint_msgs.append(msg)
-
-                self.assertTrue(len(lint_msgs) == 1, "Unexpected lint messages "
-                    "produced when linting a compatibility legacy package")
-
-        def test_relative_path(self):
-                """The engine can start with a relative path to its cache."""
-                lint_logger = TestLogFormatter()
-                lint_engine = engine.LintEngine(lint_logger,
-                    use_tracker=False,
-                    config_file=os.path.join(self.test_root,
-                    "pkglintrc"))
-
-                lint_engine.setup(cache=self.cache_dir,
-                    lint_uris=[self.ref_uri])
-
-                lint_engine.execute()
-                lint_engine.teardown()
-
-                relative = os.path.join("..", os.path.basename(self.cache_dir))
-                cache = os.path.join(self.cache_dir, relative)
-                lint_engine.setup(cache=cache)
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-
-        def test_ref_file_move(self):
-                """The dupaction checks can cope with a file that moves between
-                packages, where the old package was delivered in our reference
-                repository and we're linting both new packages: the package
-                from which the file was moved, as well as the package to which
-                the file is moving.
-
-                It should report an error when we only lint the new version
-                of the package to which the file is moving, but not the new
-                version of package from which the file was moved."""
-
-                paths = self.make_misc_files(self.lint_move_mf)
-                paths.sort()
-                rcfile = os.path.join(self.test_root, "pkglintrc")
-
-                move_src = os.path.join(self.test_root, "move-sample1.mf")
-                move_dst = os.path.join(self.test_root, "move-sample2.mf")
-
-                lint_logger = TestLogFormatter()
-
-                # first check that file moves work properly, that is,
-                # we should report no errors here.
-                manifests = read_manifests([move_src, move_dst], lint_logger)
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=rcfile)
-                lint_engine.setup(cache=self.cache_dir,
-                    ref_uris=[self.ref_uri], lint_manifests=manifests)
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-
-                lint_msgs = []
-                for msg in lint_logger.messages:
-                        lint_msgs.append(msg)
-
-                self.assertTrue(lint_msgs == [], "Unexpected errors during file "
-                    "movement between packages: {0}".format("\n".join(lint_msgs)))
-
-                # next check that when delivering only the moved-to package,
-                # we report a duplicate error.
-                manifests = read_manifests([move_dst], lint_logger)
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=rcfile)
-                lint_engine.setup(cache=self.cache_dir,
-                    ref_uris=[self.ref_uri], lint_manifests=manifests)
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-
-                lint_msgs = []
-                for msg in lint_logger.messages:
-                        lint_msgs.append(msg)
-
-                self.assertTrue(len(lint_msgs) == 1, "Expected duplicate path "
-                    "error not seen when moving file between packages, but "
-                    "omitting new source package: {0}".format("\n".join(lint_msgs)))
-                self.assertTrue(lint_logger.ids[0] == "pkglint.dupaction001.1",
-                    "Expected pkglint.dupaction001.1, got {0}".format(
-                    lint_logger.ids[0]))
-
-        def test_license_pkg_dup(self):
-                """This test checks that license actions across packages do not
-                have to be unique. """
-
-                paths = self.make_misc_files(self.lint_license_mf)
-                paths.sort()
-                rcfile = os.path.join(self.test_root, "pkglintrc")
-
-                pkg1 = os.path.join(self.test_root, "pkg1.mf")
-                pkg2 = os.path.join(self.test_root, "pkg2.mf")
-
-                lint_logger = TestLogFormatter()
-
-                manifests = read_manifests([pkg1, pkg2], lint_logger)
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=rcfile)
-                lint_engine.setup(cache=self.cache_dir,
-                    ref_uris=[self.ref_uri], lint_manifests=manifests)
-                lint_engine.execute()
-                lint_engine.teardown(clear_cache=True)
-
-                lint_msgs = []
-                for msg in lint_logger.messages:
-                        lint_msgs.append(msg)
-
-                self.assertTrue(lint_msgs == [],
-                    "Unexpected errors from duplicate licenses: {}"
-                    .format("\n".join(lint_msgs)))
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self,
+            ["opensolaris.org", "opensolaris.org", "opensolaris.org"],
+            start_depots=True,
+        )
+
+        self.ref_uri = self.dcs[1].get_depot_url()
+        self.lint_uri = self.dcs[2].get_depot_url()
+        self.empty_lint_uri = self.dcs[3].get_depot_url()
+        self.cache_dir = tempfile.mkdtemp("pkglint-cache", "", self.test_root)
+
+        paths = self.make_misc_files(self.ref_mf)
+
+        for item in paths:
+            self.pkgsend(
+                depot_url=self.ref_uri, command="publish {0}".format(item)
+            )
+        self.pkgsend(depot_url=self.ref_uri, command="refresh-index")
+
+        paths = self.make_misc_files(self.lint_mf)
+        for item in paths:
+            self.pkgsend(
+                depot_url=self.lint_uri, command="publish {0}".format(item)
+            )
+        self.pkgsend(depot_url=self.lint_uri, command="refresh-index")
+        # we should sign the repositories for additional coverage
+        self.pkgsign(self.lint_uri, "'*'")
+        self.pkgsign(self.ref_uri, "'*'")
+
+    def test_lint_repo_basics(self):
+        """Test basic handling of repo URIs with the lint engine,
+        reference repo is error free, cache dir torn down appropriately.
+        """
+        if not os.path.exists(self.cache_dir):
+            os.makedirs(self.cache_dir)
+
+        lint_logger = TestLogFormatter()
+        lint_engine = engine.LintEngine(
+            lint_logger,
+            use_tracker=False,
+            config_file=os.path.join(self.test_root, "pkglintrc"),
+        )
+
+        lint_engine.setup(cache=self.cache_dir, lint_uris=[self.ref_uri])
+        lint_engine.execute()
+
+        lint_msgs = []
+        # prune out the missing dependency warnings
+        for msg in lint_logger.messages:
+            if (
+                "pkglint.action005.1" not in msg
+                and "pkglint.dupaction015.1" not in msg
+            ):
+                lint_msgs.append(msg)
+
+        self.assertTrue(
+            len(lint_msgs) == 0,
+            "Unexpected lint errors messages reported against "
+            "reference repo: {0}".format("\n".join(lint_msgs)),
+        )
+        lint_logger.close()
+
+        lint_engine.teardown()
+        self.assertTrue(
+            os.path.exists(self.cache_dir),
+            "Cache dir does not exist after teardown!",
+        )
+        self.assertTrue(
+            os.path.exists(os.path.join(self.cache_dir, "lint_image")),
+            "lint image dir still existed after teardown!",
+        )
+
+        # This shouldn't appear when we're not using a reference repo
+        self.assertFalse(
+            os.path.exists(os.path.join(self.cache_dir, "ref_image")),
+            "ref image dir existed!",
+        )
+        lint_engine.teardown(clear_cache=True)
+        self.assertFalse(
+            os.path.exists(self.cache_dir),
+            "Cache dir was not torn down as expected",
+        )
+
+    def test_empty_lint_repo(self):
+        """Ensure we can lint an empty repository"""
+
+        paths = self.make_misc_files(self.lint_mf)
+        if not os.path.exists(self.cache_dir):
+            os.makedirs(self.cache_dir)
+
+        lint_logger = TestLogFormatter()
+        lint_engine = engine.LintEngine(
+            lint_logger,
+            use_tracker=False,
+            config_file=os.path.join(self.test_root, "pkglintrc"),
+        )
+
+        lint_engine.setup(cache=self.cache_dir, lint_uris=[self.ref_uri])
+        lint_engine.execute()
+
+        lint_msgs = []
+        # prune out the missing dependency warnings
+        for msg in lint_logger.messages:
+            if (
+                "pkglint.action005.1" not in msg
+                and "pkglint.dupaction015.1" not in msg
+            ):
+                lint_msgs.append(msg)
+
+        self.assertFalse(
+            lint_msgs,
+            "Lint messages reported from a clean reference repository.",
+        )
+        lint_engine.teardown(clear_cache=True)
+
+        # this should be an empty test: we have no packages in the
+        # lint repository, so we end up doing nothing
+        lint_logger = TestLogFormatter()
+        lint_engine.setup(cache=self.cache_dir, lint_uris=[self.empty_lint_uri])
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+        self.assertFalse(
+            lint_logger.messages,
+            "Lint messages reported from a empty lint repository.",
+        )
+
+    def test_versioning(self):
+        """Package version handling during lint runs.
+        In particular, it verifies that packages for linting are merged
+        correctly into pkglint's view of what the ref repository would
+        look like, were the lint package to be published to the
+        reference repository."""
+
+        paths = self.make_misc_files(self.lint_mf)
+        paths.sort()
+
+        for manifest in paths:
+            self.debug("running lint checks on {0}".format(manifest))
+            basename = os.path.basename(manifest)
+            lint_logger = TestLogFormatter()
+            lint_engine = engine.LintEngine(
+                lint_logger,
+                use_tracker=False,
+                config_file=os.path.join(self.test_root, "pkglintrc"),
+            )
+
+            manifests = read_manifests([manifest], lint_logger)
+            lint_engine.setup(
+                cache=self.cache_dir,
+                ref_uris=[self.ref_uri],
+                lint_manifests=manifests,
+            )
+
+            lint_engine.execute()
+            lint_engine.teardown(clear_cache=True)
+
+            expected = len(self.expected_failures[basename])
+            actual = len(lint_logger.messages)
+            if actual != expected:
+                self.debug("\n".join(lint_logger.messages))
+                self.assertTrue(
+                    actual == expected,
+                    "Expected {0} failures for {1}, got {2}: {3}".format(
+                        expected,
+                        basename,
+                        actual,
+                        "\n".join(lint_logger.messages),
+                    ),
+                )
+            else:
+                reported = lint_logger.ids
+                known = self.expected_failures[basename]
+                reported.sort()
+                known.sort()
+                for i in range(0, len(reported)):
+                    self.assertTrue(
+                        reported[i] == known[i],
+                        "Differences in reported vs. expected"
+                        " lint ids for {0}: {1} vs. {2}".format(
+                            basename, str(reported), str(known)
+                        ),
+                    )
+            lint_logger.close()
+
+        # this manifest should report duplicates when
+        # linted against a 0.141 repository, but none
+        # when linted against a 0.140 repository. The duplicates
+        # were tested when 'deliver-old-sample1.mf' was linted
+        # above - this time, we lint against 0.140 and expect
+        # no errors.
+        lint_logger = TestLogFormatter()
+        lint_engine = engine.LintEngine(
+            lint_logger,
+            use_tracker=False,
+            config_file=os.path.join(self.test_root, "pkglintrc"),
+        )
+
+        path = os.path.join(self.test_root, "deliver-old-sample1.mf")
+        manifests = read_manifests([path], lint_logger)
+
+        lint_engine.setup(
+            cache=self.cache_dir,
+            ref_uris=[self.ref_uri],
+            lint_manifests=manifests,
+            release="140",
+        )
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+
+        self.assertFalse(
+            lint_logger.messages,
+            "Unexpected lint messages when linting against old "
+            "version of reference repo: {0}".format(
+                "\n".join(lint_logger.messages)
+            ),
+        )
+
+        # ensure we detect the error when linting against the reference
+        # 0.139 repository
+        lint_logger = TestLogFormatter()
+        lint_engine = engine.LintEngine(
+            lint_logger,
+            use_tracker=False,
+            config_file=os.path.join(self.test_root, "pkglintrc"),
+        )
+        lint_engine.setup(
+            cache=self.cache_dir,
+            ref_uris=[self.ref_uri],
+            lint_uris=[self.ref_uri],
+            release="139",
+        )
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+
+        if not lint_logger.ids:
+            self.assertTrue(
+                False,
+                "No lint messages produced when linting the "
+                "contents of an old repository",
+            )
+        elif len(lint_logger.ids) != 1:
+            self.assertTrue(
+                False,
+                "Expected exactly 1 lint message when linting the "
+                "contents of an old repository, got {0}".format(
+                    len(lint_logger.ids)
+                ),
+            )
+        elif lint_logger.ids[0] != "pkglint.dupaction001.1":
+            self.assertTrue(
+                False,
+                "Expected pkglint.dupaction001.1 message when "
+                "linting the contents of an old repository, got "
+                "{0}".format(lint_logger.ids[0]),
+            )
+
+    def test_lint_mf_baseline(self):
+        """The lint manifests in this test class should be lint-clean
+        themselves - they should only report errors when linting against
+        our reference repository."""
+
+        paths = self.make_misc_files(self.lint_mf)
+        paths.sort()
+
+        for manifest in paths:
+            basename = os.path.basename(manifest)
+            lint_logger = TestLogFormatter()
+            lint_engine = engine.LintEngine(
+                lint_logger,
+                use_tracker=False,
+                config_file=os.path.join(self.test_root, "pkglintrc"),
+            )
+
+            manifests = read_manifests([manifest], lint_logger)
+            lint_engine.setup(lint_manifests=manifests)
+
+            lint_engine.execute()
+            lint_engine.teardown()
+
+            # prune missing dependency and missing rename warnings
+            lint_msgs = []
+            for msg in lint_logger.messages:
+                if (
+                    "pkglint.manifest002.3" in msg
+                    or "pkglint.manifest002.4" in msg
+                    or "pkglint.action005.1" in msg
+                ):
+                    pass
+                else:
+                    lint_msgs.append(msg)
+
+            self.assertFalse(
+                lint_msgs,
+                "Unexpected lint messages when linting individual "
+                "manifests that should contain no errors: {0} {1}".format(
+                    basename, "\n".join(lint_msgs)
+                ),
+            )
+
+    def test_broken_legacy_rename(self):
+        """Tests that linting a package where we break the renaming
+        of a legacy package, we'll get an error."""
+
+        paths = self.make_misc_files(self.lint_mf)
+        paths.extend(self.make_misc_files(self.ref_mf))
+        rcfile = os.path.join(self.test_root, "pkglintrc")
+
+        legacy = os.path.join(self.test_root, "legacy-uses-renamed-ancestor.mf")
+        renamed_new = os.path.join(
+            self.test_root, "broken-renamed-ancestor-new.mf"
+        )
+        renamed_old = os.path.join(self.test_root, "renamed-ancestor-old.mf")
+        renamed_self_depend = os.path.join(
+            self.test_root, "self-depend-renamed-ancestor-new.mf"
+        )
+        compat_legacy = os.path.join(
+            self.test_root, "compat-renamed-ancestor-old.mf"
+        )
+
+        # look for a rename that didn't ultimately resolve to the
+        # package that contained the legacy action
+        lint_logger = TestLogFormatter()
+        manifests = read_manifests([legacy, renamed_new], lint_logger)
+
+        lint_engine = engine.LintEngine(
+            lint_logger, use_tracker=False, config_file=rcfile
+        )
+        lint_engine.setup(
+            cache=self.cache_dir,
+            ref_uris=[self.ref_uri],
+            lint_manifests=manifests,
+        )
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+
+        lint_msgs = []
+        for msg in lint_logger.messages:
+            if (
+                "pkglint.action005.1" not in msg
+                and "pkglint.dupaction015.1" not in msg
+            ):
+                lint_msgs.append(msg)
+
+        self.assertTrue(
+            len(lint_msgs) == 2,
+            "Unexpected lint messages "
+            "{0} produced when linting broken renaming with legacy "
+            "pkgs".format(lint_msgs),
+        )
+
+        seen_2_3 = False
+        seen_3_4 = False
+        for i in lint_logger.ids:
+            if i == "pkglint.manifest002.3":
+                seen_2_3 = True
+            if i == "pkglint.action003.4":
+                seen_3_4 = True
+
+        self.assertTrue(
+            seen_2_3 and seen_3_4,
+            "Missing expected broken renaming legacy errors, "
+            "got {0}".format(lint_msgs),
+        )
+
+        # make sure we spot renames that depend upon themselves
+        lint_logger = TestLogFormatter()
+        manifests = read_manifests([legacy, renamed_self_depend], lint_logger)
+
+        lint_engine = engine.LintEngine(
+            lint_logger, use_tracker=False, config_file=rcfile
+        )
+        lint_engine.setup(
+            cache=self.cache_dir,
+            ref_uris=[self.ref_uri],
+            lint_manifests=manifests,
+        )
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+
+        lint_msgs = []
+        for msg in lint_logger.messages:
+            lint_msgs.append(msg)
+
+        self.debug(lint_msgs)
+        self.assertTrue(
+            len(lint_msgs) == 3,
+            "Unexpected lint messages "
+            "produced when linting broken self-dependent renaming with "
+            "legacy pkgs",
+        )
+        seen_2_4 = False
+        seen_3_5 = False
+        for i in lint_logger.ids:
+            if i == "pkglint.manifest002.4":
+                seen_2_4 = True
+            if i == "pkglint.action003.5":
+                seen_3_5 = True
+        self.assertTrue(
+            seen_2_3 and seen_3_4,
+            "Missing expected broken renaming self-dependent errors "
+            "with legacy pkgs. Got {0}".format(lint_msgs),
+        )
+
+        # make sure we can deal with compatibility packages.  We include
+        # the 'renamed_old' package as well as the 'compat_legacy'
+        # to ensure that pkglint is satisfied by the compatability
+        # package, rather that trying to follow renames from the
+        # 'renamed_old' package. (otherwise, if a package pointed to by
+        # the legacy 'pkg' attribute doesn't exist, pkglint wouldn't
+        # complain)
+        lint_logger = TestLogFormatter()
+        manifests = read_manifests([renamed_old, compat_legacy], lint_logger)
+
+        lint_engine = engine.LintEngine(
+            lint_logger, use_tracker=False, config_file=rcfile
+        )
+        lint_engine.setup(
+            cache=self.cache_dir,
+            ref_uris=[self.ref_uri],
+            lint_manifests=manifests,
+        )
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+
+        lint_msgs = []
+        for msg in lint_logger.messages:
+            lint_msgs.append(msg)
+
+        self.debug(lint_msgs)
+        self.assertTrue(
+            len(lint_msgs) == 1,
+            "Unexpected lint messages "
+            "produced when linting a compatibility legacy package",
+        )
+
+        # the 'legacy' package includes a legacy action which should
+        # also be satisfied by the compat_legacy being installed.
+        lint_logger = TestLogFormatter()
+        manifests = read_manifests([legacy, compat_legacy], lint_logger)
+
+        lint_engine = engine.LintEngine(
+            lint_logger, use_tracker=False, config_file=rcfile
+        )
+        lint_engine.setup(
+            cache=self.cache_dir,
+            ref_uris=[self.ref_uri],
+            lint_manifests=manifests,
+        )
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+
+        lint_msgs = []
+        for msg in lint_logger.messages:
+            lint_msgs.append(msg)
+
+        self.assertTrue(
+            len(lint_msgs) == 1,
+            "Unexpected lint messages "
+            "produced when linting a compatibility legacy package",
+        )
+
+    def test_relative_path(self):
+        """The engine can start with a relative path to its cache."""
+        lint_logger = TestLogFormatter()
+        lint_engine = engine.LintEngine(
+            lint_logger,
+            use_tracker=False,
+            config_file=os.path.join(self.test_root, "pkglintrc"),
+        )
+
+        lint_engine.setup(cache=self.cache_dir, lint_uris=[self.ref_uri])
+
+        lint_engine.execute()
+        lint_engine.teardown()
+
+        relative = os.path.join("..", os.path.basename(self.cache_dir))
+        cache = os.path.join(self.cache_dir, relative)
+        lint_engine.setup(cache=cache)
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+
+    def test_ref_file_move(self):
+        """The dupaction checks can cope with a file that moves between
+        packages, where the old package was delivered in our reference
+        repository and we're linting both new packages: the package
+        from which the file was moved, as well as the package to which
+        the file is moving.
+
+        It should report an error when we only lint the new version
+        of the package to which the file is moving, but not the new
+        version of package from which the file was moved."""
+
+        paths = self.make_misc_files(self.lint_move_mf)
+        paths.sort()
+        rcfile = os.path.join(self.test_root, "pkglintrc")
+
+        move_src = os.path.join(self.test_root, "move-sample1.mf")
+        move_dst = os.path.join(self.test_root, "move-sample2.mf")
+
+        lint_logger = TestLogFormatter()
+
+        # first check that file moves work properly, that is,
+        # we should report no errors here.
+        manifests = read_manifests([move_src, move_dst], lint_logger)
+        lint_engine = engine.LintEngine(
+            lint_logger, use_tracker=False, config_file=rcfile
+        )
+        lint_engine.setup(
+            cache=self.cache_dir,
+            ref_uris=[self.ref_uri],
+            lint_manifests=manifests,
+        )
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+
+        lint_msgs = []
+        for msg in lint_logger.messages:
+            lint_msgs.append(msg)
+
+        self.assertTrue(
+            lint_msgs == [],
+            "Unexpected errors during file "
+            "movement between packages: {0}".format("\n".join(lint_msgs)),
+        )
+
+        # next check that when delivering only the moved-to package,
+        # we report a duplicate error.
+        manifests = read_manifests([move_dst], lint_logger)
+        lint_engine = engine.LintEngine(
+            lint_logger, use_tracker=False, config_file=rcfile
+        )
+        lint_engine.setup(
+            cache=self.cache_dir,
+            ref_uris=[self.ref_uri],
+            lint_manifests=manifests,
+        )
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+
+        lint_msgs = []
+        for msg in lint_logger.messages:
+            lint_msgs.append(msg)
+
+        self.assertTrue(
+            len(lint_msgs) == 1,
+            "Expected duplicate path "
+            "error not seen when moving file between packages, but "
+            "omitting new source package: {0}".format("\n".join(lint_msgs)),
+        )
+        self.assertTrue(
+            lint_logger.ids[0] == "pkglint.dupaction001.1",
+            "Expected pkglint.dupaction001.1, got {0}".format(
+                lint_logger.ids[0]
+            ),
+        )
+
+    def test_license_pkg_dup(self):
+        """This test checks that license actions across packages do not
+        have to be unique."""
+
+        paths = self.make_misc_files(self.lint_license_mf)
+        paths.sort()
+        rcfile = os.path.join(self.test_root, "pkglintrc")
+
+        pkg1 = os.path.join(self.test_root, "pkg1.mf")
+        pkg2 = os.path.join(self.test_root, "pkg2.mf")
+
+        lint_logger = TestLogFormatter()
+
+        manifests = read_manifests([pkg1, pkg2], lint_logger)
+        lint_engine = engine.LintEngine(
+            lint_logger, use_tracker=False, config_file=rcfile
+        )
+        lint_engine.setup(
+            cache=self.cache_dir,
+            ref_uris=[self.ref_uri],
+            lint_manifests=manifests,
+        )
+        lint_engine.execute()
+        lint_engine.teardown(clear_cache=True)
+
+        lint_msgs = []
+        for msg in lint_logger.messages:
+            lint_msgs.append(msg)
+
+        self.assertTrue(
+            lint_msgs == [],
+            "Unexpected errors from duplicate licenses: {}".format(
+                "\n".join(lint_msgs)
+            ),
+        )
+
 
 class TestVolatileLintEngineDepot(pkg5unittest.ManyDepotTestCase):
-        """Tests that exercise reference vs. lint repository checks and tests
-        linting of multiple packages at once, similar to TestLintEngineDepot,
-        but with less overhead during setUp (this test class is not marked
-        as persistent_setup = True, so test methods are responsible for their
-        own setup)"""
+    """Tests that exercise reference vs. lint repository checks and tests
+    linting of multiple packages at once, similar to TestLintEngineDepot,
+    but with less overhead during setUp (this test class is not marked
+    as persistent_setup = True, so test methods are responsible for their
+    own setup)"""
 
-        # used by test_get_manifest(..)
-        get_manifest_data = {}
-# The following two manifests check that given a package in the lint repository,
-# that we can access the latest version of that package from the reference
-# repository using LintEngine.get_manifest(.., reference=True)
-        get_manifest_data["get-manifest-ref.mf"] = """
+    # used by test_get_manifest(..)
+    get_manifest_data = {}
+    # The following two manifests check that given a package in the lint repository,
+    # that we can access the latest version of that package from the reference
+    # repository using LintEngine.get_manifest(.., reference=True)
+    get_manifest_data[
+        "get-manifest-ref.mf"
+    ] = """
 set name=pkg.fmri value=pkg://opensolaris.org/check/parent@0.5.11,5.11-0.100:20100603T215050Z
 set name=variant.arch value=i386 value=sparc
 set name=pkg.summary value="additional content"
@@ -3359,7 +3810,9 @@ set name=pkg.description value="core kernel software for a specific instruction-
 set name=org.opensolaris.consolidation value=osnet
 set name=info.classification value=org.opensolaris.category.2008:System/Core
 """
-        get_manifest_data["get-manifest-oldref.mf"] = """
+    get_manifest_data[
+        "get-manifest-oldref.mf"
+    ] = """
 set name=pkg.fmri value=pkg://opensolaris.org/check/parent@0.5.11,5.11-0.99:20100603T215050Z
 set name=variant.arch value=i386 value=sparc
 set name=pkg.summary value="additional content"
@@ -3367,7 +3820,9 @@ set name=pkg.description value="core kernel software for a specific instruction-
 set name=org.opensolaris.consolidation value=osnet
 set name=info.classification value=org.opensolaris.category.2008:System/Core
 """
-        get_manifest_data["get-manifest-lint.mf"] = """
+    get_manifest_data[
+        "get-manifest-lint.mf"
+    ] = """
 #
 # This is the manifest that should appear in the lint repository.
 #
@@ -3379,357 +3834,440 @@ set name=org.opensolaris.consolidation value=osnet
 set name=info.classification value=org.opensolaris.category.2008:System/Core
 """
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self,
-                    ["opensolaris.org", "opensolaris.org"],
-                    start_depots=True)
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["opensolaris.org", "opensolaris.org"], start_depots=True
+        )
 
-                self.ref_uri = self.dcs[1].get_depot_url()
-                self.lint_uri = self.dcs[2].get_depot_url()
-                self.cache_dir = tempfile.mkdtemp("pkglint-cache", "",
-                    self.test_root)
+        self.ref_uri = self.dcs[1].get_depot_url()
+        self.lint_uri = self.dcs[2].get_depot_url()
+        self.cache_dir = tempfile.mkdtemp("pkglint-cache", "", self.test_root)
 
-        def test_get_manifest(self):
-                """Check that <LintEngine>.get_manifest works ensuring
-                it returns appropriate manifests for the lint and reference
-                repositories."""
+    def test_get_manifest(self):
+        """Check that <LintEngine>.get_manifest works ensuring
+        it returns appropriate manifests for the lint and reference
+        repositories."""
 
-                paths = self.make_misc_files(self.get_manifest_data)
-                rcfile = os.path.join(self.test_root, "pkglintrc")
-                lint_mf = os.path.join(self.test_root, "get-manifest-lint.mf")
-                old_ref_mf = os.path.join(self.test_root,
-                    "get-manifest-oldref.mf")
-                ref_mf = os.path.join(self.test_root, "get-manifest-ref.mf")
-                ret, ref_fmri =  self.pkgsend(self.ref_uri, "publish {0}".format(
-                    ref_mf))
-                ret, oldref_fmri =  self.pkgsend(self.ref_uri, "publish {0}".format(
-                    old_ref_mf))
-                ret, lint_fmri =  self.pkgsend(self.lint_uri, "publish {0}".format(
-                    lint_mf))
+        paths = self.make_misc_files(self.get_manifest_data)
+        rcfile = os.path.join(self.test_root, "pkglintrc")
+        lint_mf = os.path.join(self.test_root, "get-manifest-lint.mf")
+        old_ref_mf = os.path.join(self.test_root, "get-manifest-oldref.mf")
+        ref_mf = os.path.join(self.test_root, "get-manifest-ref.mf")
+        ret, ref_fmri = self.pkgsend(self.ref_uri, "publish {0}".format(ref_mf))
+        ret, oldref_fmri = self.pkgsend(
+            self.ref_uri, "publish {0}".format(old_ref_mf)
+        )
+        ret, lint_fmri = self.pkgsend(
+            self.lint_uri, "publish {0}".format(lint_mf)
+        )
 
-                lint_logger = TestLogFormatter()
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=rcfile)
-                manifests = read_manifests([lint_mf], lint_logger)
-                lint_engine.setup(cache=self.cache_dir,
-                    ref_uris=[self.ref_uri], lint_uris=[self.lint_uri])
+        lint_logger = TestLogFormatter()
+        lint_engine = engine.LintEngine(
+            lint_logger, use_tracker=False, config_file=rcfile
+        )
+        manifests = read_manifests([lint_mf], lint_logger)
+        lint_engine.setup(
+            cache=self.cache_dir,
+            ref_uris=[self.ref_uri],
+            lint_uris=[self.lint_uri],
+        )
 
-                # try retrieving a few names that should match our lint manifest
-                for name in ["check/parent", "pkg:/check/parent",
-                    "pkg://opensolaris.org/check/parent@0.5.10"]:
-                        mf = lint_engine.get_manifest(
-                            name, search_type=lint_engine.LATEST_SUCCESSOR)
-                        self.assertTrue(str(mf.fmri) == lint_fmri)
+        # try retrieving a few names that should match our lint manifest
+        for name in [
+            "check/parent",
+            "pkg:/check/parent",
+            "pkg://opensolaris.org/check/parent@0.5.10",
+        ]:
+            mf = lint_engine.get_manifest(
+                name, search_type=lint_engine.LATEST_SUCCESSOR
+            )
+            self.assertTrue(str(mf.fmri) == lint_fmri)
 
-                # try retrieving a few names that should match our parent
-                # manifest when using LATEST_SUCCESSOR mode
-                for name in ["check/parent", "pkg:/check/parent",
-                    "pkg://opensolaris.org/check/parent@0.5.10"]:
-                        mf = lint_engine.get_manifest(
-                            name, search_type=lint_engine.LATEST_SUCCESSOR,
-                            reference=True)
-                        self.assertTrue(str(mf.fmri) == ref_fmri)
+        # try retrieving a few names that should match our parent
+        # manifest when using LATEST_SUCCESSOR mode
+        for name in [
+            "check/parent",
+            "pkg:/check/parent",
+            "pkg://opensolaris.org/check/parent@0.5.10",
+        ]:
+            mf = lint_engine.get_manifest(
+                name, search_type=lint_engine.LATEST_SUCCESSOR, reference=True
+            )
+            self.assertTrue(str(mf.fmri) == ref_fmri)
 
-                # try retrieving a few names that should not match when using
-                # EXACT mode.
-                for name in ["check/parent@1.0",
-                    "pkg://opensolaris.org/check/parent@0.5.10"]:
-                        mf = lint_engine.get_manifest(
-                            name, search_type=lint_engine.EXACT)
-                        self.assertTrue(mf == None)
+        # try retrieving a few names that should not match when using
+        # EXACT mode.
+        for name in [
+            "check/parent@1.0",
+            "pkg://opensolaris.org/check/parent@0.5.10",
+        ]:
+            mf = lint_engine.get_manifest(name, search_type=lint_engine.EXACT)
+            self.assertTrue(mf == None)
 
-                # try retrieving a specific version of the manifest from the
-                # reference repository.
-                mf = lint_engine.get_manifest(
-                    "pkg://opensolaris.org/check/parent@0.5.11,5.11-0.99",
-                    search_type=lint_engine.EXACT, reference=True)
-                self.assertTrue(str(mf.fmri) == oldref_fmri)
+        # try retrieving a specific version of the manifest from the
+        # reference repository.
+        mf = lint_engine.get_manifest(
+            "pkg://opensolaris.org/check/parent@0.5.11,5.11-0.99",
+            search_type=lint_engine.EXACT,
+            reference=True,
+        )
+        self.assertTrue(str(mf.fmri) == oldref_fmri)
 
-                # test that we raise an exception when no reference repo is
-                # configured, but that searches for a non-existent package from
-                # the lint manifests do still return None.
-                shutil.rmtree(os.path.join(self.cache_dir, "ref_image"))
-                lint_engine = engine.LintEngine(lint_logger, use_tracker=False,
-                    config_file=rcfile)
-                lint_engine.setup(cache=self.cache_dir,
-                    lint_manifests=manifests)
-                mf = lint_engine.get_manifest("example/package")
-                self.assertTrue(mf == None)
-                self.assertRaises(base.LintException, lint_engine.get_manifest,
-                    "example/package", reference=True)
+        # test that we raise an exception when no reference repo is
+        # configured, but that searches for a non-existent package from
+        # the lint manifests do still return None.
+        shutil.rmtree(os.path.join(self.cache_dir, "ref_image"))
+        lint_engine = engine.LintEngine(
+            lint_logger, use_tracker=False, config_file=rcfile
+        )
+        lint_engine.setup(cache=self.cache_dir, lint_manifests=manifests)
+        mf = lint_engine.get_manifest("example/package")
+        self.assertTrue(mf == None)
+        self.assertRaises(
+            base.LintException,
+            lint_engine.get_manifest,
+            "example/package",
+            reference=True,
+        )
 
 
 class TestLintEngineInternals(pkg5unittest.Pkg5TestCase):
+    def test_lint_fmri_successor(self):
+        """lint_fmri_successor reports lint successors correctly.
 
-        def test_lint_fmri_successor(self):
-            """lint_fmri_successor reports lint successors correctly.
+        The lint fmri_successor check has a biase for new FMRIs  and
+        acts differently to the pkg.fmri.PkgFmri is_successor check,
+        favouring the new fmri if it is missing information not present
+        in the old fmri.
 
-            The lint fmri_successor check has a biase for new FMRIs  and
-            acts differently to the pkg.fmri.PkgFmri is_successor check,
-            favouring the new fmri if it is missing information not present
-            in the old fmri.
+        We also include some tests for the standard is_successor
+        check, which is used in the implementation of
+        lint_fmri_successor."""
 
-            We also include some tests for the standard is_successor
-            check, which is used in the implementation of
-            lint_fmri_successor."""
+        class FmriPair:
+            def __init__(self, new, old):
+                self.new = new
+                self.old = old
 
-            class FmriPair():
-                    def __init__(self, new, old):
-                            self.new = new
-                            self.old = old
+            def __repr__(self):
+                return "FmriPair({0}, {1}) ".format(self.new, self.old)
 
-                    def __repr__(self):
-                            return "FmriPair({0}, {1}) ".format(self.new, self.old)
+        def is_successor(pair):
+            """baseline the standard fmri.is_successor check"""
+            new = fmri.PkgFmri(pair.new)
+            old = fmri.PkgFmri(pair.old)
+            return new.is_successor(old)
 
-            def is_successor(pair):
-                    """baseline the standard fmri.is_successor check"""
-                    new = fmri.PkgFmri(pair.new)
-                    old = fmri.PkgFmri(pair.old)
-                    return new.is_successor(old)
+        def commutative(pair, ignore_pubs=True):
+            """test that new succeeds old and old succeeds new."""
+            new = fmri.PkgFmri(pair.new)
+            old = fmri.PkgFmri(pair.old)
+            return lint_fmri_successor(
+                new, old, ignore_pubs=ignore_pubs
+            ) and lint_fmri_successor(old, new, ignore_pubs=ignore_pubs)
 
-            def commutative(pair, ignore_pubs=True):
-                    """test that new succeeds old and old succeeds new."""
-                    new = fmri.PkgFmri(pair.new)
-                    old = fmri.PkgFmri(pair.old)
-                    return lint_fmri_successor(new, old,
-                        ignore_pubs=ignore_pubs) and \
-                        lint_fmri_successor(old, new, ignore_pubs=ignore_pubs)
+        def newer(pair, ignore_pubs=True, ignore_timestamps=True):
+            """test that new succeeds old, but old does not succeed new"""
+            new = fmri.PkgFmri(pair.new)
+            old = fmri.PkgFmri(pair.old)
+            return lint_fmri_successor(
+                new,
+                old,
+                ignore_pubs=ignore_pubs,
+                ignore_timestamps=ignore_timestamps,
+            ) and not lint_fmri_successor(
+                old,
+                new,
+                ignore_pubs=ignore_pubs,
+                ignore_timestamps=ignore_timestamps,
+            )
 
-            def newer(pair, ignore_pubs=True, ignore_timestamps=True):
-                    """test that new succeeds old, but old does not succeed new"""
-                    new = fmri.PkgFmri(pair.new)
-                    old = fmri.PkgFmri(pair.old)
-                    return lint_fmri_successor(new, old,
-                        ignore_pubs=ignore_pubs,
-                        ignore_timestamps=ignore_timestamps) and \
-                        not lint_fmri_successor(old, new,
-                        ignore_pubs=ignore_pubs,
-                        ignore_timestamps=ignore_timestamps)
+        # messages used in assertions
+        fail_msg = "{0} do not pass {1} check"
+        fail_msg_pubs = "{0} do not pass {1} check, ignoring publishers"
+        fail_msg_ts = "{0} do not pass {1} check, ignoring timestamps"
 
-            # messages used in assertions
-            fail_msg = "{0} do not pass {1} check"
-            fail_msg_pubs = "{0} do not pass {1} check, ignoring publishers"
-            fail_msg_ts = "{0} do not pass {1} check, ignoring timestamps"
+        fail_comm = fail_msg.format("{0}", "commutative")
+        fail_comm_pubs = fail_msg_pubs.format("{0}", "commutative")
+        fail_newer = fail_msg.format("{0}", "newer")
+        fail_newer_pubs = fail_msg_pubs.format("{0}", "newer")
+        fail_newer_ts = fail_msg_ts.format("{0}", "newer timestamp-sensitive")
+        fail_successor = fail_msg.format("{0}", "is_successor")
 
-            fail_comm = fail_msg.format("{0}", "commutative")
-            fail_comm_pubs = fail_msg_pubs.format("{0}", "commutative")
-            fail_newer = fail_msg.format("{0}", "newer")
-            fail_newer_pubs = fail_msg_pubs.format("{0}", "newer")
-            fail_newer_ts = fail_msg_ts.format("{0}", "newer timestamp-sensitive")
-            fail_successor = fail_msg.format("{0}", "is_successor")
+        # 1 identical everything
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
+            "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
+        )
+        self.assertTrue(commutative(pair), fail_comm.format(pair))
+        self.assertTrue(
+            commutative(pair, ignore_pubs=False), fail_comm_pubs.format(pair)
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
-            # 1 identical everything
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
-                "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z")
-            self.assertTrue(commutative(pair), fail_comm.format(pair))
-            self.assertTrue(commutative(pair, ignore_pubs=False),
-                fail_comm_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
+        # 2 identical versions
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.120",
+            "pkg://foo.org/tst@1.0,5.11-0.120",
+        )
+        self.assertTrue(commutative(pair), fail_comm.format(pair))
+        self.assertTrue(
+            commutative(pair, ignore_pubs=False), fail_comm_pubs.format(pair)
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
-            # 2 identical versions
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.120",
-                "pkg://foo.org/tst@1.0,5.11-0.120")
-            self.assertTrue(commutative(pair), fail_comm.format(pair))
-            self.assertTrue(commutative(pair, ignore_pubs=False),
-                fail_comm_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
+        # 3 identical names
+        pair = FmriPair("pkg://foo.org/tst", "pkg://foo.org/tst")
+        self.assertTrue(commutative(pair), fail_comm.format(pair))
+        self.assertTrue(
+            commutative(pair, ignore_pubs=False), fail_comm_pubs.format(pair)
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
+        # 4 differing timestamps, same version (identical, in pkglint's view)
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
+            "pkg://foo.org/tst@1.0,5.11-0.120:20311003T222559Z",
+        )
+        self.assertTrue(commutative(pair), fail_comm.format(pair))
+        self.assertTrue(
+            commutative(pair, ignore_pubs=False), fail_comm_pubs.format(pair)
+        )
+        self.assertTrue(not is_successor(pair), fail_successor.format(pair))
+        self.assertTrue(
+            not newer(pair, ignore_timestamps=False), fail_newer_ts.format(pair)
+        )
 
-            # 3 identical names
-            pair = FmriPair("pkg://foo.org/tst",
-                "pkg://foo.org/tst")
-            self.assertTrue(commutative(pair), fail_comm.format(pair))
-            self.assertTrue(commutative(pair, ignore_pubs=False),
-                fail_comm_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
+        # 5 missing timestamps, same version
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.120",
+            "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
+        )
+        self.assertTrue(commutative(pair), fail_comm.format(pair))
+        self.assertTrue(
+            commutative(pair, ignore_pubs=False), fail_comm_pubs.format(pair)
+        )
 
+        # 6 missing timestamps, different version
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.121",
+            "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
+        )
+        self.assertTrue(newer(pair), fail_newer.format(pair))
+        self.assertTrue(
+            newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
 
-            # 4 differing timestamps, same version (identical, in pkglint's view)
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
-                "pkg://foo.org/tst@1.0,5.11-0.120:20311003T222559Z")
-            self.assertTrue(commutative(pair), fail_comm.format(pair))
-            self.assertTrue(commutative(pair, ignore_pubs=False),
-                fail_comm_pubs.format(pair))
-            self.assertTrue(not is_successor(pair), fail_successor.format(pair))
-            self.assertTrue(not newer(pair, ignore_timestamps=False),
-                fail_newer_ts.format(pair))
+        # 7 different versions
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.121:20101003T222523Z",
+            "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
+        )
+        self.assertTrue(newer(pair), fail_newer.format(pair))
+        self.assertTrue(
+            newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
 
-            # 5 missing timestamps, same version
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.120",
-                "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z")
-            self.assertTrue(commutative(pair), fail_comm.format(pair))
-            self.assertTrue(commutative(pair, ignore_pubs=False),
-                fail_comm_pubs.format(pair))
+        # 8 different versions (where string comparisons won't work since
+        # with string comparisons, '0.133' < '0.99' which is not desired
+        pair = FmriPair(
+            "pkg://opensolaris.org/SUNWfcsm@0.5.11,5.11-0.133:20100216T065435Z",
+            "pkg://opensolaris.org/SUNWfcsm@0.5.11,5.11-0.99:20100216T065435Z",
+        )
+        self.assertTrue(newer(pair), fail_newer.format(pair))
+        self.assertTrue(
+            newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
 
-            # 6 missing timestamps, different version
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.121",
-                "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z")
-            self.assertTrue(newer(pair), fail_newer.format(pair))
-            self.assertTrue(newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
+        #  Now the same set of tests, this time with different publishers
+        # 1.1 identical everything
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
+            "pkg://bar.org/tst@1.0,5.11-0.120:20101003T222523Z",
+        )
+        self.assertTrue(commutative(pair), fail_comm.format(pair))
+        self.assertTrue(
+            not newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
-            # 7 different versions
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.121:20101003T222523Z",
-                "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z")
-            self.assertTrue(newer(pair), fail_newer.format(pair))
-            self.assertTrue(newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
+        # 2.1 identical versions
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.120",
+            "pkg://bar.org/tst@1.0,5.11-0.120",
+        )
+        self.assertTrue(commutative(pair), fail_comm.format(pair))
+        self.assertTrue(
+            not commutative(pair, ignore_pubs=False),
+            fail_comm_pubs.format(pair),
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
-            # 8 different versions (where string comparisons won't work since
-            # with string comparisons, '0.133' < '0.99' which is not desired
-            pair = FmriPair("pkg://opensolaris.org/SUNWfcsm@0.5.11,5.11-0.133:20100216T065435Z",
-            "pkg://opensolaris.org/SUNWfcsm@0.5.11,5.11-0.99:20100216T065435Z")
-            self.assertTrue(newer(pair), fail_newer.format(pair))
-            self.assertTrue(newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
+        # 3.1 identical names
+        pair = FmriPair("pkg://foo.org/tst", "pkg://bar.org/tst")
+        self.assertTrue(commutative(pair), fail_comm.format(pair))
+        self.assertTrue(
+            not commutative(pair, ignore_pubs=False),
+            fail_comm_pubs.format(pair),
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
-            #  Now the same set of tests, this time with different publishers
-            # 1.1 identical everything
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
-                "pkg://bar.org/tst@1.0,5.11-0.120:20101003T222523Z")
-            self.assertTrue(commutative(pair), fail_comm.format(pair))
-            self.assertTrue(not newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
+        # 4.1 differing timestamps, same version (identical, in pkglint's
+        # view unless we specifically look at the timestamp)
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
+            "pkg://bar.org/tst@1.0,5.11-0.120:20311003T222559Z",
+        )
+        self.assertTrue(commutative(pair), fail_comm.format(pair))
+        self.assertTrue(
+            not commutative(pair, ignore_pubs=False),
+            fail_comm_pubs.format(pair),
+        )
+        self.assertTrue(not is_successor(pair), fail_successor.format(pair))
+        self.assertTrue(
+            not newer(pair, ignore_timestamps=False), fail_newer_ts.format(pair)
+        )
 
-             # 2.1 identical versions
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.120",
-                "pkg://bar.org/tst@1.0,5.11-0.120")
-            self.assertTrue(commutative(pair), fail_comm.format(pair))
-            self.assertTrue(not commutative(pair, ignore_pubs=False),
-                fail_comm_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
+        # 5.1 missing timestamps, same version
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.120",
+            "pkg://bar.org/tst@1.0,5.11-0.120:20101003T222523Z",
+        )
+        self.assertTrue(commutative(pair), fail_comm.format(pair))
+        self.assertTrue(
+            not commutative(pair, ignore_pubs=False),
+            fail_comm_pubs.format(pair),
+        )
+        self.assertTrue(not is_successor(pair), fail_successor.format(pair))
 
-            # 3.1 identical names
-            pair = FmriPair("pkg://foo.org/tst",
-                "pkg://bar.org/tst")
-            self.assertTrue(commutative(pair), fail_comm.format(pair))
-            self.assertTrue(not commutative(pair, ignore_pubs=False),
-                fail_comm_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
+        # 6.1 missing timestamps, different version
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.121",
+            "pkg://bar.org/tst@1.0,5.11-0.120:20101003T222523Z",
+        )
+        self.assertTrue(newer(pair), fail_newer.format(pair))
+        self.assertTrue(
+            not newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
-            # 4.1 differing timestamps, same version (identical, in pkglint's
-            # view unless we specifically look at the timestamp)
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.120:20101003T222523Z",
-                "pkg://bar.org/tst@1.0,5.11-0.120:20311003T222559Z")
-            self.assertTrue(commutative(pair), fail_comm.format(pair))
-            self.assertTrue(not commutative(pair, ignore_pubs=False),
-                fail_comm_pubs.format(pair))
-            self.assertTrue(not is_successor(pair), fail_successor.format(pair))
-            self.assertTrue(not newer(pair, ignore_timestamps=False),
-                fail_newer_ts.format(pair))
+        # 7.1 different versions
+        pair = FmriPair(
+            "pkg://foo.org/tst@1.0,5.11-0.121:20101003T222523Z",
+            "pkg://bar.org/tst@1.0,5.11-0.120:20101003T222523Z",
+        )
+        self.assertTrue(newer(pair), fail_newer.format(pair))
+        self.assertTrue(
+            not newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
-            # 5.1 missing timestamps, same version
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.120",
-                "pkg://bar.org/tst@1.0,5.11-0.120:20101003T222523Z")
-            self.assertTrue(commutative(pair), fail_comm.format(pair))
-            self.assertTrue(not commutative(pair, ignore_pubs=False),
-                fail_comm_pubs.format(pair))
-            self.assertTrue(not is_successor(pair), fail_successor.format(pair))
+        # 8.1 different versions (where string comparisons won't work
+        # with string comparisons, '0.133' < '0.99' which is not desired
+        pair = FmriPair(
+            "pkg://opensolaris.org/SUNWfcsm@0.5.11,5.11-0.133:20100216T065435Z",
+            "pkg://solaris/SUNWfcsm@0.5.11,5.11-0.99:20100216T065435Z",
+        )
+        self.assertTrue(newer(pair), fail_newer.format(pair))
+        self.assertTrue(
+            not newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
 
-            # 6.1 missing timestamps, different version
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.121",
-                "pkg://bar.org/tst@1.0,5.11-0.120:20101003T222523Z")
-            self.assertTrue(newer(pair), fail_newer.format(pair))
-            self.assertTrue(not newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
+        # missing publishers
+        pair = FmriPair("pkg:/tst", "pkg://foo.org/tst")
+        self.assertTrue(commutative(pair), fail_newer.format(pair))
+        self.assertTrue(
+            not newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
-            # 7.1 different versions
-            pair = FmriPair("pkg://foo.org/tst@1.0,5.11-0.121:20101003T222523Z",
-                "pkg://bar.org/tst@1.0,5.11-0.120:20101003T222523Z")
-            self.assertTrue(newer(pair), fail_newer.format(pair))
-            self.assertTrue(not newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
+        # different publishers
+        pair = FmriPair("pkg://bar.org/tst", "pkg://foo.org/tst")
+        self.assertTrue(commutative(pair), fail_newer.format(pair))
+        self.assertTrue(
+            not newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
-            # 8.1 different versions (where string comparisons won't work
-            # with string comparisons, '0.133' < '0.99' which is not desired
-            pair = FmriPair("pkg://opensolaris.org/SUNWfcsm@0.5.11,5.11-0.133:20100216T065435Z",
-            "pkg://solaris/SUNWfcsm@0.5.11,5.11-0.99:20100216T065435Z")
-            self.assertTrue(newer(pair), fail_newer.format(pair))
-            self.assertTrue(not newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
+        # different publishers, missing timestmap, same version
+        pair = FmriPair(
+            "pkg://bar.org/tst@1.0,5.11-0.121",
+            "pkg://foo.org/tst@1.0,5.11-0.121:20101003T222523Z",
+        )
+        self.assertTrue(commutative(pair), fail_newer.format(pair))
+        self.assertTrue(
+            not newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
+        self.assertTrue(not is_successor(pair), fail_successor.format(pair))
 
-            # missing publishers
-            pair = FmriPair("pkg:/tst", "pkg://foo.org/tst")
-            self.assertTrue(commutative(pair), fail_newer.format(pair))
-            self.assertTrue(not newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
+        # different publishers, missing timestmap
+        pair = FmriPair(
+            "pkg://bar.org/tst@1.0,5.11-0.122",
+            "pkg://foo.org/tst@1.0,5.11-0.121:20101003T222523Z",
+        )
+        self.assertTrue(newer(pair), fail_newer.format(pair))
+        self.assertTrue(
+            not newer(pair, ignore_pubs=False), fail_newer_pubs.format(pair)
+        )
+        self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
-            # different publishers
-            pair = FmriPair("pkg://bar.org/tst", "pkg://foo.org/tst")
-            self.assertTrue(commutative(pair), fail_newer.format(pair))
-            self.assertTrue(not newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
-
-            # different publishers, missing timestmap, same version
-            pair = FmriPair("pkg://bar.org/tst@1.0,5.11-0.121",
-                "pkg://foo.org/tst@1.0,5.11-0.121:20101003T222523Z")
-            self.assertTrue(commutative(pair), fail_newer.format(pair))
-            self.assertTrue(not newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
-            self.assertTrue(not is_successor(pair), fail_successor.format(pair))
-
-            # different publishers, missing timestmap
-            pair = FmriPair("pkg://bar.org/tst@1.0,5.11-0.122",
-                "pkg://foo.org/tst@1.0,5.11-0.121:20101003T222523Z")
-            self.assertTrue(newer(pair), fail_newer.format(pair))
-            self.assertTrue(not newer(pair, ignore_pubs=False),
-                fail_newer_pubs.format(pair))
-            self.assertTrue(is_successor(pair), fail_successor.format(pair))
 
 def read_manifests(names, lint_logger):
-        "Read a list of filenames, return a list of Manifest objects"
-        manifests = []
-        for filename in names:
-                data = None
-                # borrowed code from publish.py
-                lines = []      # giant string of all input lines
-                linecnts = []   # tuples of starting line no., ending line no
-                linecounter = 0 # running total
-                try:
-                        data = open(filename).read()
-                except IOError as e:
-                        lint_logger.error("Unable to read manifest file {0}".format(
-                            filename, msgid="lint.manifest001"))
-                        continue
-                lines.append(data)
-                linecnt = len(data.splitlines())
-                linecnts.append((linecounter, linecounter + linecnt))
-                linecounter += linecnt
+    "Read a list of filenames, return a list of Manifest objects"
+    manifests = []
+    for filename in names:
+        data = None
+        # borrowed code from publish.py
+        lines = []  # giant string of all input lines
+        linecnts = []  # tuples of starting line no., ending line no
+        linecounter = 0  # running total
+        try:
+            data = open(filename).read()
+        except IOError as e:
+            lint_logger.error(
+                "Unable to read manifest file {0}".format(
+                    filename, msgid="lint.manifest001"
+                )
+            )
+            continue
+        lines.append(data)
+        linecnt = len(data.splitlines())
+        linecnts.append((linecounter, linecounter + linecnt))
+        linecounter += linecnt
 
-                manifest = pkg.manifest.Manifest()
-                try:
-                        manifest.set_content("\n".join(lines))
-                except pkg.actions.ActionError as e:
-                        lineno = e.lineno
-                        for i, tup in enumerate(linecnts):
-                                if lineno > tup[0] and lineno <= tup[1]:
-                                        lineno -= tup[0]
-                                        break;
-                        else:
-                                lineno = "???"
+        manifest = pkg.manifest.Manifest()
+        try:
+            manifest.set_content("\n".join(lines))
+        except pkg.actions.ActionError as e:
+            lineno = e.lineno
+            for i, tup in enumerate(linecnts):
+                if lineno > tup[0] and lineno <= tup[1]:
+                    lineno -= tup[0]
+                    break
+            else:
+                lineno = "???"
 
-                        lint_logger.error(
-                            "Problem reading manifest {0} line: {1}: {2} ".format(
-                            filename, lineno, e), "lint.manifest002")
-                        continue
+            lint_logger.error(
+                "Problem reading manifest {0} line: {1}: {2} ".format(
+                    filename, lineno, e
+                ),
+                "lint.manifest002",
+            )
+            continue
 
-                if "pkg.fmri" in manifest:
-                        manifest.fmri = fmri.PkgFmri(
-                            manifest["pkg.fmri"])
-                        manifests.append(manifest)
-                else:
-                        lint_logger.error(
-                            "Manifest {0} does not declare fmri.".format(filename),
-                            "lint.manifest003")
-        return manifests
+        if "pkg.fmri" in manifest:
+            manifest.fmri = fmri.PkgFmri(manifest["pkg.fmri"])
+            manifests.append(manifest)
+        else:
+            lint_logger.error(
+                "Manifest {0} does not declare fmri.".format(filename),
+                "lint.manifest003",
+            )
+    return manifests
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_pkgtarfile.py
+++ b/src/tests/api/t_pkgtarfile.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -38,50 +39,52 @@ import tarfile
 import pkg.portable as portable
 import pkg.pkgtarfile as pkgtarfile
 
+
 class TestPkgTarFile(pkg5unittest.Pkg5TestCase):
+    def setUp(self):
+        pkg5unittest.Pkg5TestCase.setUp(self)
+        self.tpath = tempfile.mkdtemp(dir=self.test_root)
 
-        def setUp(self):
-                pkg5unittest.Pkg5TestCase.setUp(self)
-                self.tpath = tempfile.mkdtemp(dir=self.test_root)
+        cpath = tempfile.mkdtemp(dir=self.test_root)
+        filepath = os.path.join(cpath, "foo/bar")
+        filename = "baz"
+        create_path = os.path.join(filepath, filename)
+        os.makedirs(filepath)
+        wfp = open(create_path, "wb")
+        buf = os.urandom(8192)
+        wfp.write(buf)
+        wfp.close()
 
-                cpath = tempfile.mkdtemp(dir=self.test_root)
-                filepath = os.path.join(cpath, "foo/bar")
-                filename = "baz"
-                create_path = os.path.join(filepath, filename)
-                os.makedirs(filepath)
-                wfp = open(create_path, "wb")
-                buf = os.urandom(8192)
-                wfp.write(buf)
-                wfp.close()
+        self.tarfile = os.path.join(self.tpath, "test.tar")
 
-                self.tarfile = os.path.join(self.tpath, "test.tar")
+        tarfp = tarfile.open(self.tarfile, "w")
+        tarfp.add(create_path, "foo/bar/baz")
+        tarfp.close()
+        shutil.rmtree(cpath)
 
-                tarfp = tarfile.open(self.tarfile, 'w')
-                tarfp.add(create_path, "foo/bar/baz")
-                tarfp.close()
-                shutil.rmtree(cpath)
+    def testerrorlevelIsCorrect(self):
+        p = pkgtarfile.PkgTarFile(self.tarfile, "r")
 
-        def testerrorlevelIsCorrect(self):
-                p = pkgtarfile.PkgTarFile(self.tarfile, 'r')
+        # "read-only" folders on Windows are not actually read-only so
+        # the test below doesn't cause the exception to be raised
+        if (
+            portable.is_admin()
+            or portable.util.get_canonical_os_type() == "windows"
+        ):
+            self.assertTrue(p.errorlevel == 2)
+            p.close()
+            return
 
-                # "read-only" folders on Windows are not actually read-only so
-                # the test below doesn't cause the exception to be raised
-                if portable.is_admin() or portable.util.get_canonical_os_type() == "windows":
-                        self.assertTrue(p.errorlevel == 2)
-                        p.close()
-                        return
-
-                extractpath = os.path.join(self.tpath, "foo/bar")
-                os.makedirs(extractpath)
-                os.chmod(extractpath, 0o555)
-                self.assertRaises(IOError, p.extract, "foo/bar/baz",
-                    self.tpath)
-                p.close()
-                os.chmod(extractpath, 0o777)
+        extractpath = os.path.join(self.tpath, "foo/bar")
+        os.makedirs(extractpath)
+        os.chmod(extractpath, 0o555)
+        self.assertRaises(IOError, p.extract, "foo/bar/baz", self.tpath)
+        p.close()
+        os.chmod(extractpath, 0o777)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_plat.py
+++ b/src/tests/api/t_plat.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -38,128 +39,148 @@ import pkg.client.image as image
 import pkg.portable.util as util
 import pkg.portable as portable
 
+
 class TestPlat(pkg5unittest.Pkg5TestCase):
-                
-        def testbasic(self):
-                portable.get_isainfo()
-                portable.get_release()
-                portable.get_platform()
+    def testbasic(self):
+        portable.get_isainfo()
+        portable.get_release()
+        portable.get_platform()
+
+    def testAdmin(self):
+        if os.name == "posix" and os.getuid() == 0:
+            self.assertTrue(portable.is_admin())
+        if os.name == "posix" and os.getuid() != 0:
+            self.assertTrue(not portable.is_admin())
+
+    def testUtils(self):
+        self.assertNotEqual("unknown", util.get_canonical_os_type())
+        self.assertNotEqual("unknown", util.get_canonical_os_name())
+
+    def testRelease(self):
+        rel = util.get_os_release()
+        # make sure it can be used in an fmri
+        test_fmri = fmri.PkgFmri("testpkg", build_release=rel)
+
+    def testForcibleRename(self):
+        # rename a file on top of another file which already exists
+        (fd1, path1) = tempfile.mkstemp()
+        os.write(fd1, b"foo")
+        (fd2, path2) = tempfile.mkstemp()
+        os.write(fd2, b"bar")
+        os.close(fd1)
+        os.close(fd2)
+        portable.rename(path1, path2)
+        self.assertFalse(os.path.exists(path1))
+        self.assertTrue(os.path.exists(path2))
+        fd2 = os.open(path2, os.O_RDONLY)
+        self.assertEqual(os.read(fd2, 3), b"foo")
+        os.close(fd2)
+        os.unlink(path2)
+
+    def testRenameOfRunningExecutable(self):
+        if util.get_canonical_os_type() != "windows":
+            return
+        import pkg.portable.os_windows as os_windows
+
+        cwd = os.getcwdu()
+        exefilesrc = "C:\\Windows\\system32\\more.com"
+        self.assertTrue(os.path.exists(exefilesrc))
+
+        # create an image, copy an executable into it,
+        # run the executable, replace the executable
+        tdir1 = tempfile.mkdtemp()
+        img1 = image.Image(
+            tdir1,
+            imgtype=image.IMG_USER,
+            should_exist=False,
+            user_provided_dir=True,
+        )
+        img1.history.client_name = "pkg-test"
+        img1.set_attrs(
+            False,
+            "test",
+            origins=["http://localhost:10000"],
+            refresh_allowed=False,
+        )
+        exefile = os.path.join(tdir1, "less.com")
+        shutil.copyfile(exefilesrc, exefile)
+        proc = subprocess.Popen([exefile], stdin=subprocess.PIPE)
+        self.assertRaises(OSError, os.unlink, exefile)
+        fd1, path1 = tempfile.mkstemp(dir=tdir1)
+        os.write(fd1, b"foo")
+        os.close(fd1)
+        portable.rename(path1, exefile)
+        fd2 = os.open(exefile, os.O_RDONLY)
+        self.assertEqual(os.read(fd2, 3), "foo")
+        os.close(fd2)
+        proc.communicate()
+
+        # Make sure that the moved executable gets deleted
+        # This is a white-box test
+        # To simulate running another process, we delete the cache
+        # and call get_trashdir as if another file was being moved
+        # to the trash.
+        os_windows.cached_image_info = []
+        os_windows.get_trashdir(exefile)
+        self.assertTrue(
+            not os.path.exists(os.path.join(img1.imgdir, os_windows.trashname))
+        )
+
+        # cleanup
+        os.chdir(cwd)
+        shutil.rmtree(tdir1)
+
+    def testRemoveOfRunningExecutable(self):
+        if util.get_canonical_os_type() != "windows":
+            return
+        import pkg.portable.os_windows as os_windows
+
+        cwd = os.getcwdu()
+        exefilesrc = "C:\\Windows\\system32\\more.com"
+        self.assertTrue(os.path.exists(exefilesrc))
+
+        # create an image, copy an executable into it,
+        # run the executable, remove the executable
+        tdir1 = tempfile.mkdtemp()
+        img1 = image.Image(
+            tdir1,
+            imgtype=image.IMG_USER,
+            should_exist=False,
+            user_provided_dir=True,
+        )
+        img1.history.client_name = "pkg-test"
+        img1.set_attrs(
+            False,
+            "test",
+            origins=["http://localhost:10000"],
+            refresh_allowed=False,
+        )
+        exefile = os.path.join(tdir1, "less.com")
+        shutil.copyfile(exefilesrc, exefile)
+        proc = subprocess.Popen([exefile], stdin=subprocess.PIPE)
+        self.assertRaises(OSError, os.unlink, exefile)
+        portable.remove(exefile)
+        self.assertTrue(not os.path.exists(exefile))
+        proc.communicate()
+
+        # Make sure that the moved executable gets deleted
+        # This is a white-box test
+        # To simulate running another process, we delete the cache
+        # and call get_trashdir as if another file was being moved
+        # to the trash.
+        os_windows.cached_image_info = []
+        os_windows.get_trashdir(exefile)
+        self.assertTrue(
+            not os.path.exists(os.path.join(img1.imgdir, os_windows.trashname))
+        )
+
+        # cleanup
+        os.chdir(cwd)
+        shutil.rmtree(tdir1)
 
 
-        def testAdmin(self):
-                if os.name == 'posix' and os.getuid() == 0:
-                        self.assertTrue(portable.is_admin())
-                if os.name == 'posix' and os.getuid() != 0:
-                        self.assertTrue(not portable.is_admin())
-
-        def testUtils(self):
-                self.assertNotEqual("unknown", util.get_canonical_os_type())
-                self.assertNotEqual("unknown", util.get_canonical_os_name())
-
-        def testRelease(self):
-                rel = util.get_os_release()
-                # make sure it can be used in an fmri
-                test_fmri = fmri.PkgFmri("testpkg", build_release = rel)
-
-        def testForcibleRename(self):
-                # rename a file on top of another file which already exists
-                (fd1, path1) = tempfile.mkstemp()
-                os.write(fd1, b"foo")
-                (fd2, path2) = tempfile.mkstemp()
-                os.write(fd2, b"bar")
-                os.close(fd1)
-                os.close(fd2)
-                portable.rename(path1, path2)
-                self.assertFalse(os.path.exists(path1))
-                self.assertTrue(os.path.exists(path2))
-                fd2 = os.open(path2, os.O_RDONLY)
-                self.assertEqual(os.read(fd2, 3), b"foo")
-                os.close(fd2)
-                os.unlink(path2)
-
-        def testRenameOfRunningExecutable(self):
-                if util.get_canonical_os_type() != 'windows':
-                        return
-                import pkg.portable.os_windows as os_windows
-                cwd = os.getcwdu()
-                exefilesrc = 'C:\\Windows\\system32\\more.com'
-                self.assertTrue(os.path.exists(exefilesrc))
-
-                # create an image, copy an executable into it, 
-                # run the executable, replace the executable
-                tdir1 = tempfile.mkdtemp()
-                img1 = image.Image(tdir1, imgtype=image.IMG_USER,
-                    should_exist=False, user_provided_dir=True)
-                img1.history.client_name = "pkg-test"
-                img1.set_attrs(False, "test",
-                    origins=["http://localhost:10000"], refresh_allowed=False)
-                exefile = os.path.join(tdir1, 'less.com')
-                shutil.copyfile(exefilesrc, exefile)
-                proc = subprocess.Popen([exefile], stdin = subprocess.PIPE)
-                self.assertRaises(OSError, os.unlink, exefile)
-                fd1, path1 = tempfile.mkstemp(dir = tdir1)
-                os.write(fd1, b"foo")
-                os.close(fd1)
-                portable.rename(path1, exefile)
-                fd2 = os.open(exefile, os.O_RDONLY)
-                self.assertEqual(os.read(fd2, 3), "foo")
-                os.close(fd2)
-                proc.communicate()
-
-                # Make sure that the moved executable gets deleted
-                # This is a white-box test
-                # To simulate running another process, we delete the cache
-                # and call get_trashdir as if another file was being moved
-                # to the trash.
-                os_windows.cached_image_info = []
-                os_windows.get_trashdir(exefile)
-                self.assertTrue(not os.path.exists(os.path.join(img1.imgdir, 
-                    os_windows.trashname)))
-
-                # cleanup
-                os.chdir(cwd)
-                shutil.rmtree(tdir1)
-
-        def testRemoveOfRunningExecutable(self):
-                if util.get_canonical_os_type() != 'windows':
-                        return
-                import pkg.portable.os_windows as os_windows
-                cwd = os.getcwdu()
-                exefilesrc = 'C:\\Windows\\system32\\more.com'
-                self.assertTrue(os.path.exists(exefilesrc))
-
-                # create an image, copy an executable into it, 
-                # run the executable, remove the executable
-                tdir1 = tempfile.mkdtemp()
-                img1 = image.Image(tdir1, imgtype=image.IMG_USER,
-                    should_exist=False, user_provided_dir=True)
-                img1.history.client_name = "pkg-test"
-                img1.set_attrs(False, "test",
-                    origins=["http://localhost:10000"], refresh_allowed=False)
-                exefile = os.path.join(tdir1, 'less.com')
-                shutil.copyfile(exefilesrc, exefile)
-                proc = subprocess.Popen([exefile], stdin = subprocess.PIPE)
-                self.assertRaises(OSError, os.unlink, exefile)
-                portable.remove(exefile)
-                self.assertTrue(not os.path.exists(exefile))
-                proc.communicate()
-
-                # Make sure that the moved executable gets deleted
-                # This is a white-box test
-                # To simulate running another process, we delete the cache
-                # and call get_trashdir as if another file was being moved
-                # to the trash.
-                os_windows.cached_image_info = []
-                os_windows.get_trashdir(exefile)
-                self.assertTrue(not os.path.exists(os.path.join(img1.imgdir,
-                    os_windows.trashname)))
-
-                # cleanup
-                os.chdir(cwd)
-                shutil.rmtree(tdir1)
-            
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_printengine.py
+++ b/src/tests/api/t_printengine.py
@@ -24,8 +24,9 @@
 
 from __future__ import print_function
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -37,67 +38,78 @@ import threading
 
 import pkg.client.printengine as printengine
 
+
 class TestPrintEngine(pkg5unittest.Pkg5TestCase):
-        def test_posix_printengine_tty(self):
-                """Test POSIX print engine tty mode."""
-                sio = six.StringIO()
-                def __drain(masterf):
-                        """Drain data from masterf and discard until eof."""
-                        while True:
-                                termdata = masterf.read(1024)
-                                if len(termdata) < 1024:
-                                        if len(termdata) > 0:
-                                                print (termdata, file=sio)
-                                        break
-                                print(termdata, file=sio)
+    def test_posix_printengine_tty(self):
+        """Test POSIX print engine tty mode."""
+        sio = six.StringIO()
 
-                #
-                # - Allocate a pty
-                # - Create a thread to drain off the master side; without
-                #   this, the slave side will block when trying to write.
-                # - Connect the printengine to the slave side
-                # - Set it running
-                #
-                (master, slave) = pty.openpty()
-                slavef = os.fdopen(slave, "w")
-                masterf = os.fdopen(master, "r")
+        def __drain(masterf):
+            """Drain data from masterf and discard until eof."""
+            while True:
+                termdata = masterf.read(1024)
+                if len(termdata) < 1024:
+                    if len(termdata) > 0:
+                        print(termdata, file=sio)
+                    break
+                print(termdata, file=sio)
 
-                t = threading.Thread(target=__drain, args=(masterf,))
-                t.start()
+        #
+        # - Allocate a pty
+        # - Create a thread to drain off the master side; without
+        #   this, the slave side will block when trying to write.
+        # - Connect the printengine to the slave side
+        # - Set it running
+        #
+        (master, slave) = pty.openpty()
+        slavef = os.fdopen(slave, "w")
+        masterf = os.fdopen(master, "r")
 
-                printengine.test_posix_printengine(slavef, True)
-                slavef.close()
+        t = threading.Thread(target=__drain, args=(masterf,))
+        t.start()
 
-                t.join()
-                masterf.close()
-                self.assertTrue(len(sio.getvalue()) > 0)
+        printengine.test_posix_printengine(slavef, True)
+        slavef.close()
 
-        def test_posix_printengine_badtty(self):
-                """Try to make ttymode POSIX print engines on non-ttys."""
-                f = six.StringIO()
-                self.assertRaises(printengine.PrintEngineException,
-                    printengine.POSIXPrintEngine, f, True)
+        t.join()
+        masterf.close()
+        self.assertTrue(len(sio.getvalue()) > 0)
 
-                tpath = self.make_misc_files("testfile")
-                f = open(tpath[0], "w")
-                self.assertRaises(printengine.PrintEngineException,
-                    printengine.POSIXPrintEngine, f, True)
-                f.close()
+    def test_posix_printengine_badtty(self):
+        """Try to make ttymode POSIX print engines on non-ttys."""
+        f = six.StringIO()
+        self.assertRaises(
+            printengine.PrintEngineException,
+            printengine.POSIXPrintEngine,
+            f,
+            True,
+        )
 
-        def test_posix_printengine_notty(self):
-                """Smoke test POSIX print engine non-tty mode."""
-                sio = six.StringIO()
-                printengine.test_posix_printengine(sio, False)
-                self.assertTrue(len(sio.getvalue()) > 0)
+        tpath = self.make_misc_files("testfile")
+        f = open(tpath[0], "w")
+        self.assertRaises(
+            printengine.PrintEngineException,
+            printengine.POSIXPrintEngine,
+            f,
+            True,
+        )
+        f.close()
 
-        def test_logging_printengine(self):
-                """Smoke test logging print engine."""
-                sio = six.StringIO()
-                printengine.test_logging_printengine(sio)
-                self.assertTrue(len(sio.getvalue()) > 0)
+    def test_posix_printengine_notty(self):
+        """Smoke test POSIX print engine non-tty mode."""
+        sio = six.StringIO()
+        printengine.test_posix_printengine(sio, False)
+        self.assertTrue(len(sio.getvalue()) > 0)
+
+    def test_logging_printengine(self):
+        """Smoke test logging print engine."""
+        sio = six.StringIO()
+        printengine.test_logging_printengine(sio)
+        self.assertTrue(len(sio.getvalue()) > 0)
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_progress.py
+++ b/src/tests/api/t_progress.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -43,374 +44,402 @@ import pkg.client.printengine as printengine
 
 
 class TestTrackerItem(pkg5unittest.Pkg5TestCase):
-        def test_reset(self):
-                """Test reset of a TrackerItem."""
-                pi = progress.TrackerItem("testitem")
-                pi.items = 10
-                pi.reset()
-                self.assertTrue(pi.items == 0)
+    def test_reset(self):
+        """Test reset of a TrackerItem."""
+        pi = progress.TrackerItem("testitem")
+        pi.items = 10
+        pi.reset()
+        self.assertTrue(pi.items == 0)
 
-        def test_str(self):
-                """Test str() of a TrackerItem."""
-                pi = progress.TrackerItem("testitem")
-                pi.items = 10
-                str(pi)
+    def test_str(self):
+        """Test str() of a TrackerItem."""
+        pi = progress.TrackerItem("testitem")
+        pi.items = 10
+        str(pi)
 
-        def test_elapsed(self):
-                """Test TrackerItem elapsed() functionality."""
-                pi = progress.TrackerItem("testitem")
-                # special case before items is set
-                self.assertTrue(pi.elapsed() == 0.0)
-                pi.items = 100
-                time.sleep(0.20)
-                # should work before done()
-                self.assertTrue(pi.elapsed() >= 0.10)
-                pi.done()
-                # should work after done()
-                self.assertTrue(pi.elapsed() >= 0.10)
+    def test_elapsed(self):
+        """Test TrackerItem elapsed() functionality."""
+        pi = progress.TrackerItem("testitem")
+        # special case before items is set
+        self.assertTrue(pi.elapsed() == 0.0)
+        pi.items = 100
+        time.sleep(0.20)
+        # should work before done()
+        self.assertTrue(pi.elapsed() >= 0.10)
+        pi.done()
+        # should work after done()
+        self.assertTrue(pi.elapsed() >= 0.10)
 
 
 class TestGoalTrackerItem(pkg5unittest.Pkg5TestCase):
-        def test_item_before_goal(self):
-                """Items must not be able to be set before goal is set."""
-                def doit():
-                        pi.items = 3
-                pi = progress.GoalTrackerItem("testitem")
-                # check can't set items before goal is set
-                self.assertRaises(RuntimeError, doit)
-                pi.goalitems = 100
-                pi.items = 10
-                pi.reset()
-                self.assertRaises(RuntimeError, doit)
+    def test_item_before_goal(self):
+        """Items must not be able to be set before goal is set."""
 
-        def test_elapsed(self):
-                """Test GoalTrackerItem elapsed() functionality."""
-                pi = progress.GoalTrackerItem("testitem")
-                # special case before goal is set
-                self.assertTrue(pi.elapsed() == 0.0)
-                pi.goalitems = 100
-                self.assertTrue(pi.elapsed() == 0.0)
-                pi.items = 100
-                time.sleep(0.20)
-                # should work before done()
-                self.assertTrue(pi.elapsed() >= 0.10)
-                pi.done()
-                # should work after done()
-                self.assertTrue(pi.elapsed() >= 0.10)
+        def doit():
+            pi.items = 3
 
-        def test_pair(self):
-                """Test that pair() gives proper results."""
-                pi = progress.GoalTrackerItem("testitem")
-                # special case before goal is set
-                self.assertEqual(pi.pair(), "0/0")
-                pi.goalitems = 100
-                self.assertEqual(pi.pair(), "  0/100")
-                pi.items = 100
-                self.assertEqual(pi.pair(), "100/100")
-                pi.done()
-                # should work after done()
-                self.assertEqual(pi.pair(), "100/100")
+        pi = progress.GoalTrackerItem("testitem")
+        # check can't set items before goal is set
+        self.assertRaises(RuntimeError, doit)
+        pi.goalitems = 100
+        pi.items = 10
+        pi.reset()
+        self.assertRaises(RuntimeError, doit)
 
-        def test_pairplus1(self):
-                """Test that pairplus1() gives proper results."""
-                pi = progress.GoalTrackerItem("testitem")
-                # special case before goal is set
-                self.assertEqual(pi.pairplus1(), "1/1")
-                pi.goalitems = 100
-                self.assertEqual(pi.pairplus1(), "  1/100")
-                pi.items = 100
-                self.assertEqual(pi.pairplus1(), "100/100")
-                pi.done()
-                # should work after done()
-                self.assertEqual(pi.pairplus1(), "100/100")
+    def test_elapsed(self):
+        """Test GoalTrackerItem elapsed() functionality."""
+        pi = progress.GoalTrackerItem("testitem")
+        # special case before goal is set
+        self.assertTrue(pi.elapsed() == 0.0)
+        pi.goalitems = 100
+        self.assertTrue(pi.elapsed() == 0.0)
+        pi.items = 100
+        time.sleep(0.20)
+        # should work before done()
+        self.assertTrue(pi.elapsed() >= 0.10)
+        pi.done()
+        # should work after done()
+        self.assertTrue(pi.elapsed() >= 0.10)
 
-        def test_pctdone(self):
-                """Test that pctdone() returns correct values."""
-                pi = progress.GoalTrackerItem("testitem")
-                # special case before goal is set
-                self.assertEqual(pi.pctdone(), 0)
-                pi.goalitems = 100
-                self.assertEqual(pi.pctdone(), 0)
-                pi.items = 50
-                self.assertEqual(int(pi.pctdone()), 50)
-                pi.items = 100
-                self.assertEqual(int(pi.pctdone()), 100)
-                pi.done()
-                # should work after done()
-                self.assertEqual(int(pi.pctdone()), 100)
+    def test_pair(self):
+        """Test that pair() gives proper results."""
+        pi = progress.GoalTrackerItem("testitem")
+        # special case before goal is set
+        self.assertEqual(pi.pair(), "0/0")
+        pi.goalitems = 100
+        self.assertEqual(pi.pair(), "  0/100")
+        pi.items = 100
+        self.assertEqual(pi.pair(), "100/100")
+        pi.done()
+        # should work after done()
+        self.assertEqual(pi.pair(), "100/100")
 
-        def test_metgoal(self):
-                """Test that metgoal() works properly."""
-                pi = progress.GoalTrackerItem("testitem")
-                self.assertEqual(pi.metgoal(), True)
-                pi.goalitems = 1
-                self.assertEqual(pi.metgoal(), False)
-                pi.items += 1
-                self.assertEqual(pi.metgoal(), True)
-                pi.done()
-                # should work after done()
-                self.assertEqual(pi.metgoal(), True)
+    def test_pairplus1(self):
+        """Test that pairplus1() gives proper results."""
+        pi = progress.GoalTrackerItem("testitem")
+        # special case before goal is set
+        self.assertEqual(pi.pairplus1(), "1/1")
+        pi.goalitems = 100
+        self.assertEqual(pi.pairplus1(), "  1/100")
+        pi.items = 100
+        self.assertEqual(pi.pairplus1(), "100/100")
+        pi.done()
+        # should work after done()
+        self.assertEqual(pi.pairplus1(), "100/100")
 
-        def test_done(self):
-                """Test that done() works properly."""
-                pi = progress.GoalTrackerItem("testitem")
-                pi.goalitems = 1
-                self.assertRaises(AssertionError, pi.done)
-                pi.done(goalcheck=False)
+    def test_pctdone(self):
+        """Test that pctdone() returns correct values."""
+        pi = progress.GoalTrackerItem("testitem")
+        # special case before goal is set
+        self.assertEqual(pi.pctdone(), 0)
+        pi.goalitems = 100
+        self.assertEqual(pi.pctdone(), 0)
+        pi.items = 50
+        self.assertEqual(int(pi.pctdone()), 50)
+        pi.items = 100
+        self.assertEqual(int(pi.pctdone()), 100)
+        pi.done()
+        # should work after done()
+        self.assertEqual(int(pi.pctdone()), 100)
+
+    def test_metgoal(self):
+        """Test that metgoal() works properly."""
+        pi = progress.GoalTrackerItem("testitem")
+        self.assertEqual(pi.metgoal(), True)
+        pi.goalitems = 1
+        self.assertEqual(pi.metgoal(), False)
+        pi.items += 1
+        self.assertEqual(pi.metgoal(), True)
+        pi.done()
+        # should work after done()
+        self.assertEqual(pi.metgoal(), True)
+
+    def test_done(self):
+        """Test that done() works properly."""
+        pi = progress.GoalTrackerItem("testitem")
+        pi.goalitems = 1
+        self.assertRaises(AssertionError, pi.done)
+        pi.done(goalcheck=False)
 
 
 class TestSpeedEstimator(pkg5unittest.Pkg5TestCase):
+    def test_basic(self):
+        """Basic test of Speed Estimator functionality."""
 
-        def test_basic(self):
-                """Basic test of Speed Estimator functionality."""
+        # make sure that we test all of the interval handling logic
+        interval = progress.SpeedEstimator(0).INTERVAL
+        time_to_test = interval * 2.5
+        hunkspersec = 30
+        hunktime = 1.0 / hunkspersec
+        hunk = 1024
+        goalbytes = time_to_test * hunkspersec * hunk
 
-                # make sure that we test all of the interval handling logic
-                interval = progress.SpeedEstimator(0).INTERVAL
-                time_to_test = interval * 2.5
-                hunkspersec = 30
-                hunktime = 1.0 / hunkspersec
-                hunk = 1024
-                goalbytes = time_to_test * hunkspersec * hunk
+        #
+        # Test that estimator won't give out estimates when constructed
+        #
+        sp = progress.SpeedEstimator(goalbytes)
+        self.assertTrue(sp.get_speed_estimate() == None)
+        self.assertTrue(sp.elapsed() == None)
+        self.assertTrue(sp.get_final_speed() == None)
 
-                #
-                # Test that estimator won't give out estimates when constructed
-                #
-                sp = progress.SpeedEstimator(goalbytes)
-                self.assertTrue(sp.get_speed_estimate() == None)
-                self.assertTrue(sp.elapsed() == None)
-                self.assertTrue(sp.get_final_speed() == None)
+        timestamp = 1000.0
 
-                timestamp = 1000.0
+        #
+        # Test again after starting, but before adding data
+        #
+        sp.start(timestamp)
+        self.assertTrue(sp.get_speed_estimate() == None)
+        self.assertTrue(sp.elapsed() == None)
+        self.assertTrue(sp.get_final_speed() == None)
 
-                #
-                # Test again after starting, but before adding data
-                #
-                sp.start(timestamp)
-                self.assertTrue(sp.get_speed_estimate() == None)
-                self.assertTrue(sp.elapsed() == None)
-                self.assertTrue(sp.get_final_speed() == None)
+        #
+        # We record transactions of one hunk each until there
+        # are no more transactions left, and we claim that each
+        # transaction took 0.01 second.  Therefore, the final speed
+        # should be 100 * hunksize/second.
+        #
+        while goalbytes > 0:
+            est = sp.get_speed_estimate()
+            self.assertTrue(est is None or est > 0)
+            sp.newdata(hunk, timestamp)
+            goalbytes -= hunk
+            timestamp += hunktime
 
-                #
-                # We record transactions of one hunk each until there
-                # are no more transactions left, and we claim that each
-                # transaction took 0.01 second.  Therefore, the final speed
-                # should be 100 * hunksize/second.
-                #
-                while goalbytes > 0:
-                        est = sp.get_speed_estimate()
-                        self.assertTrue(est is None or est > 0)
-                        sp.newdata(hunk, timestamp)
-                        goalbytes -= hunk
-                        timestamp += hunktime
+        self.assertTrue(sp.get_final_speed() is None)
+        sp.done(timestamp)
+        self.debug("-- final speed: {0:f}".format(sp.get_final_speed()))
+        self.debug("-- expected final speed: {0:f}".format(hunk * hunkspersec))
+        self.debug(str(sp))
+        self.assertTrue(int(sp.get_final_speed()) == hunk * hunkspersec)
 
-                self.assertTrue(sp.get_final_speed() is None)
-                sp.done(timestamp)
-                self.debug("-- final speed: {0:f}".format(sp.get_final_speed()))
-                self.debug("-- expected final speed: {0:f}".format(hunk * hunkspersec))
-                self.debug(str(sp))
-                self.assertTrue(int(sp.get_final_speed()) == hunk * hunkspersec)
+    def test_stall(self):
+        """Test that the ProgressTracker correctly diagnoses a
+        "stall" in the download process."""
+        hunk = 1024
+        timestamp = 1000.0
+        goalbytes = 10 * hunk * hunk
 
-        def test_stall(self):
-                """Test that the ProgressTracker correctly diagnoses a
-                "stall" in the download process."""
-                hunk = 1024
-                timestamp = 1000.0
-                goalbytes = 10 * hunk * hunk
+        #
+        # Play records at the estimator until it starts giving out
+        # estimates.
+        #
+        sp = progress.SpeedEstimator(goalbytes)
+        sp.start(timestamp)
+        while sp.get_speed_estimate() == None:
+            sp.newdata(hunk, timestamp)
+            timestamp += 0.01
 
-                #
-                # Play records at the estimator until it starts giving out
-                # estimates.
-                #
-                sp = progress.SpeedEstimator(goalbytes)
-                sp.start(timestamp)
-                while sp.get_speed_estimate() == None:
-                        sp.newdata(hunk, timestamp)
-                        timestamp += 0.01
+        #
+        # Now jump the timestamp forward by a lot-- 1000 seconds-- much
+        # longer than the interval inside the estimator.  We should see
+        # it stop giving us estimates.
+        #
+        timestamp = 2000.0
+        sp.newdata(hunk, timestamp)
+        self.assertTrue(sp.get_speed_estimate() == None)
 
-                #
-                # Now jump the timestamp forward by a lot-- 1000 seconds-- much
-                # longer than the interval inside the estimator.  We should see
-                # it stop giving us estimates.
-                #
-                timestamp = 2000.0
-                sp.newdata(hunk, timestamp)
-                self.assertTrue(sp.get_speed_estimate() == None)
+    def test_format_speed(self):
+        """Test that format_speed works as expected."""
+        hunk = 1024
+        goalbytes = 10 * hunk * hunk
+        sp = progress.SpeedEstimator(goalbytes)
 
-        def test_format_speed(self):
-                """Test that format_speed works as expected."""
-                hunk = 1024
-                goalbytes = 10 * hunk * hunk
-                sp = progress.SpeedEstimator(goalbytes)
+        testdata = {
+            0: "0B/s",
+            999: "999B/s",
+            1000: "1000B/s",
+            1024: "1.0k/s",
+            10 * 1024: "10.0k/s",
+            999 * 1024: "999k/s",
+            1001 * 1024: "1001k/s",
+            1024 * 1024: "1.0M/s",
+        }
 
-                testdata = {
-                    0:           "0B/s",
-                    999:         "999B/s",
-                    1000:        "1000B/s",
-                    1024:        "1.0k/s",
-                    10 * 1024:   "10.0k/s",
-                    999 * 1024:  "999k/s",
-                    1001 * 1024: "1001k/s",
-                    1024 * 1024: "1.0M/s"
-                }
-
-                for (val, expected) in testdata.items():
-                        str = sp.format_speed(val)
-                        self.assertTrue(len(str) <= 7)
-                        self.assertTrue(str == expected)
+        for val, expected in testdata.items():
+            str = sp.format_speed(val)
+            self.assertTrue(len(str) <= 7)
+            self.assertTrue(str == expected)
 
 
 class TestFormatPair(pkg5unittest.Pkg5TestCase):
-
-        def test_format_pair(self):
-                """Test that format_pair works as expected."""
-                testdata = [
-                    ["{0:d}", 0, 0, {},                   "0/0"],
-                    ["{0:d}", 0, 1, {},                   "0/1"],
-                    ["{0:d}", 1, 100, {},                 "  1/100"],
-                    ["{0:d}", 1000, 1000, {},             "1000/1000"],
-                    ["{0:.1f}", 0, 1000, {},              "   0.0/1000.0"],
-                    ["{0:.1f}", 1000, 1000, {},           "1000.0/1000.0"],
-                    ["{0:.1f}", 1012.512, 2000.912, {},   "1012.5/2000.9"],
-                    ["{0:.1f}", 20.32, 1000.23,
-                        {"targetwidth": 6, "format2": "{0:d}"},
-                                                            "  20.3/1000.2"],
-                    ["{0:.1f}", 20.322, 1000.23,
-                        {"targetwidth": 5, "format2": "{0:d}"},
-                                                            "  20/1000"],
-                    ["{0:.1f}", 20.322, 1000.23,
-                        {"targetwidth": 4, "format2": "{0:d}"},
-                                                            "  20/1000"],
-                    ["{0:.1f}", 20.322, 99.23,
-                        {"targetwidth": 5, "format2": "{0:d}"},
-                                                            "20.3/99.2"],
-                    ["{0:.1f}", 2032, 9923,
-                        {"targetwidth": 5, "format2": "{0:d}", "scale": 100},
-                                                            "20.3/99.2"],
-                ]
-                for (formatstr, item, goal, kwargs, expresult) in testdata:
-                        result = progress.format_pair(formatstr, item,
-                            goal, **kwargs)
-                        self.assertEqual(result, expresult,
-                            "expected: {0} != result: {1}".format(expresult, result))
+    def test_format_pair(self):
+        """Test that format_pair works as expected."""
+        testdata = [
+            ["{0:d}", 0, 0, {}, "0/0"],
+            ["{0:d}", 0, 1, {}, "0/1"],
+            ["{0:d}", 1, 100, {}, "  1/100"],
+            ["{0:d}", 1000, 1000, {}, "1000/1000"],
+            ["{0:.1f}", 0, 1000, {}, "   0.0/1000.0"],
+            ["{0:.1f}", 1000, 1000, {}, "1000.0/1000.0"],
+            ["{0:.1f}", 1012.512, 2000.912, {}, "1012.5/2000.9"],
+            [
+                "{0:.1f}",
+                20.32,
+                1000.23,
+                {"targetwidth": 6, "format2": "{0:d}"},
+                "  20.3/1000.2",
+            ],
+            [
+                "{0:.1f}",
+                20.322,
+                1000.23,
+                {"targetwidth": 5, "format2": "{0:d}"},
+                "  20/1000",
+            ],
+            [
+                "{0:.1f}",
+                20.322,
+                1000.23,
+                {"targetwidth": 4, "format2": "{0:d}"},
+                "  20/1000",
+            ],
+            [
+                "{0:.1f}",
+                20.322,
+                99.23,
+                {"targetwidth": 5, "format2": "{0:d}"},
+                "20.3/99.2",
+            ],
+            [
+                "{0:.1f}",
+                2032,
+                9923,
+                {"targetwidth": 5, "format2": "{0:d}", "scale": 100},
+                "20.3/99.2",
+            ],
+        ]
+        for formatstr, item, goal, kwargs, expresult in testdata:
+            result = progress.format_pair(formatstr, item, goal, **kwargs)
+            self.assertEqual(
+                result,
+                expresult,
+                "expected: {0} != result: {1}".format(expresult, result),
+            )
 
 
 class TestProgressTrackers(pkg5unittest.Pkg5TestCase):
+    def test_basic_trackers(self):
+        """Basic testing of all trackers; reset, and then retest."""
+        sio_c = six.StringIO()
+        sio_c2 = six.StringIO()
+        sio_f = six.StringIO()
+        sio_d = six.StringIO()
 
-        def test_basic_trackers(self):
-                """Basic testing of all trackers; reset, and then retest."""
-                sio_c = six.StringIO()
-                sio_c2 = six.StringIO()
-                sio_f = six.StringIO()
-                sio_d = six.StringIO()
+        tc = progress.CommandLineProgressTracker(output_file=sio_c)
+        tc2 = progress.CommandLineProgressTracker(
+            output_file=sio_c2, term_delay=1
+        )
+        tf = progress.FunctionProgressTracker(output_file=sio_f)
+        td = progress.DotProgressTracker(output_file=sio_d)
+        tq = progress.QuietProgressTracker()
 
-                tc = progress.CommandLineProgressTracker(output_file=sio_c)
-                tc2 = progress.CommandLineProgressTracker(output_file=sio_c2,
-                    term_delay=1)
-                tf = progress.FunctionProgressTracker(output_file=sio_f)
-                td = progress.DotProgressTracker(output_file=sio_d)
-                tq = progress.QuietProgressTracker()
+        mt = progress.MultiProgressTracker([tc, tc2, tf, tq, td])
 
-                mt = progress.MultiProgressTracker([tc, tc2, tf, tq, td])
+        # run everything twice; this exercises that after a
+        # reset(), everything still works correctly.
+        for x in [1, 2]:
+            progress.test_progress_tracker(mt, gofast=True)
 
-                # run everything twice; this exercises that after a
-                # reset(), everything still works correctly.
-                for x in [1, 2]:
-                        progress.test_progress_tracker(mt, gofast=True)
+            self.assertTrue(len(sio_c.getvalue()) > 100)
+            self.assertTrue(len(sio_c2.getvalue()) > 100)
+            self.assertTrue(len(sio_f.getvalue()) > 100)
+            self.assertTrue(len(sio_d.getvalue()) > 1)
+            # check that dot only printed dots
+            self.assertTrue(len(sio_d.getvalue()) * "." == sio_d.getvalue())
 
-                        self.assertTrue(len(sio_c.getvalue()) > 100)
-                        self.assertTrue(len(sio_c2.getvalue()) > 100)
-                        self.assertTrue(len(sio_f.getvalue()) > 100)
-                        self.assertTrue(len(sio_d.getvalue()) > 1)
-                        # check that dot only printed dots
-                        self.assertTrue(
-                            len(sio_d.getvalue()) * "." == sio_d.getvalue())
+            for f in [sio_c, sio_c2, sio_f, sio_d]:
+                f.seek(0)
+                f.truncate(0)
 
-                        for f in [sio_c, sio_c2, sio_f, sio_d]:
-                                f.seek(0)
-                                f.truncate(0)
+            # Reset them all, and go again, as a test of reset().
+            mt.flush()
+            mt.reset()
 
-                        # Reset them all, and go again, as a test of reset().
-                        mt.flush()
-                        mt.reset()
+    def __t_pty_tracker(self, trackerclass, **kwargs):
+        def __drain(masterf):
+            while True:
+                termdata = masterf.read(1024)
+                if len(termdata) < 1024:
+                    break
 
-        def __t_pty_tracker(self, trackerclass, **kwargs):
-                def __drain(masterf):
-                        while True:
-                                termdata = masterf.read(1024)
-                                if len(termdata) < 1024:
-                                        break
+        #
+        # - Allocate a pty
+        # - Create a thread to drain off the master side; without
+        #   this, the slave side will block when trying to write.
+        # - Connect the prog tracker to the slave side
+        # - Set it running
+        #
+        (master, slave) = pty.openpty()
+        slavef = os.fdopen(slave, "w")
+        masterf = os.fdopen(master, "rb")
 
-                #
-                # - Allocate a pty
-                # - Create a thread to drain off the master side; without
-                #   this, the slave side will block when trying to write.
-                # - Connect the prog tracker to the slave side
-                # - Set it running
-                #
-                (master, slave) = pty.openpty()
-                slavef = os.fdopen(slave, "w")
-                masterf = os.fdopen(master, "rb")
+        t = threading.Thread(target=__drain, args=(masterf,))
+        t.start()
 
-                t = threading.Thread(target=__drain, args=(masterf,))
-                t.start()
+        p = trackerclass(output_file=slavef, **kwargs)
+        progress.test_progress_tracker(p, gofast=True)
+        slavef.close()
 
-                p = trackerclass(output_file=slavef, **kwargs)
-                progress.test_progress_tracker(p, gofast=True)
-                slavef.close()
+        t.join()
+        masterf.close()
 
-                t.join()
-                masterf.close()
+    def test_fancy_unix_tracker(self):
+        """Test the terminal-based tracker we have on a pty."""
+        self.__t_pty_tracker(progress.FancyUNIXProgressTracker)
 
-        def test_fancy_unix_tracker(self):
-                """Test the terminal-based tracker we have on a pty."""
-                self.__t_pty_tracker(progress.FancyUNIXProgressTracker)
+    def test_fancy_unix_tracker_bad_tty(self):
+        """Try to make a terminal-based tracker on non-terminals."""
+        f = six.StringIO()
+        self.assertRaises(
+            progress.ProgressTrackerException,
+            progress.FancyUNIXProgressTracker,
+            f,
+        )
 
-        def test_fancy_unix_tracker_bad_tty(self):
-                """Try to make a terminal-based tracker on non-terminals."""
-                f = six.StringIO()
-                self.assertRaises(progress.ProgressTrackerException,
-                    progress.FancyUNIXProgressTracker, f)
+        tpath = self.make_misc_files("testfile")
+        f = open(tpath[0], "w")
+        self.assertRaises(
+            progress.ProgressTrackerException,
+            progress.FancyUNIXProgressTracker,
+            f,
+        )
+        f.close()
 
-                tpath = self.make_misc_files("testfile")
-                f = open(tpath[0], "w")
-                self.assertRaises(progress.ProgressTrackerException,
-                    progress.FancyUNIXProgressTracker, f)
-                f.close()
-
-        def test_fancy_unix_tracker_termdelay(self):
-                """Test the fancy tracker with term_delay customized."""
-                self.__t_pty_tracker(progress.FancyUNIXProgressTracker,
-                    term_delay=0.20)
+    def test_fancy_unix_tracker_termdelay(self):
+        """Test the fancy tracker with term_delay customized."""
+        self.__t_pty_tracker(progress.FancyUNIXProgressTracker, term_delay=0.20)
 
 
 class TestMultiProgressTracker(pkg5unittest.Pkg5TestCase):
-        def test_multi(self):
-                """Test basic multi functionality."""
-                sio1 = six.StringIO()
-                sio2 = six.StringIO()
+    def test_multi(self):
+        """Test basic multi functionality."""
+        sio1 = six.StringIO()
+        sio2 = six.StringIO()
 
-                #
-                # The FunctionProgressTracker is used here because its
-                # output doesn't contain any timing information.  The
-                # output of the two Function progress trackers can thus
-                # be tested for equality.
-                #
-                t1 = progress.FunctionProgressTracker(output_file=sio1)
-                t2 = progress.FunctionProgressTracker(output_file=sio2)
-                mt = progress.MultiProgressTracker([t1, t2])
-                progress.test_progress_tracker(mt, gofast=True)
+        #
+        # The FunctionProgressTracker is used here because its
+        # output doesn't contain any timing information.  The
+        # output of the two Function progress trackers can thus
+        # be tested for equality.
+        #
+        t1 = progress.FunctionProgressTracker(output_file=sio1)
+        t2 = progress.FunctionProgressTracker(output_file=sio2)
+        mt = progress.MultiProgressTracker([t1, t2])
+        progress.test_progress_tracker(mt, gofast=True)
 
-                self.assertTrue(len(sio1.getvalue()) > 100)
-                self.assertTrue(len(sio2.getvalue()) > 100)
-                self.assertEqual(sio1.getvalue(), sio2.getvalue())
+        self.assertTrue(len(sio1.getvalue()) > 100)
+        self.assertTrue(len(sio2.getvalue()) > 100)
+        self.assertEqual(sio1.getvalue(), sio2.getvalue())
 
-        def test_multi_init(self):
-                """Can't construct a Multi with zero subsidiary trackers."""
-                self.assertRaises(progress.ProgressTrackerException,
-                    progress.MultiProgressTracker, [])
+    def test_multi_init(self):
+        """Can't construct a Multi with zero subsidiary trackers."""
+        self.assertRaises(
+            progress.ProgressTrackerException, progress.MultiProgressTracker, []
+        )
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_publisher.py
+++ b/src/tests/api/t_publisher.py
@@ -26,8 +26,9 @@
 
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import copy
@@ -44,449 +45,536 @@ import pkg.misc as misc
 
 
 class TestPublisher(pkg5unittest.Pkg5TestCase):
-        """Class to test the functionality of the pkg.client.publisher module.
-        """
+    """Class to test the functionality of the pkg.client.publisher module."""
 
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        misc_files = [ "test.cert", "test.key", "test2.cert", "test2.key" ]
+    misc_files = ["test.cert", "test.key", "test2.cert", "test2.key"]
 
-        def setUp(self):
-                pkg5unittest.Pkg5TestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.Pkg5TestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-        def test_01_repository_uri(self):
-                """Verify that a RepositoryURI object can be created, copied,
-                modified, and used as expected."""
+    def test_01_repository_uri(self):
+        """Verify that a RepositoryURI object can be created, copied,
+        modified, and used as expected."""
 
-                nsfile = os.path.join(self.test_root, "nosuchfile")
-                tcert = os.path.join(self.test_root, "test.cert")
-                tkey = os.path.join(self.test_root, "test.key")
+        nsfile = os.path.join(self.test_root, "nosuchfile")
+        tcert = os.path.join(self.test_root, "test.cert")
+        tkey = os.path.join(self.test_root, "test.key")
 
-                uprops = {
-                    "priority": 1,
-                    "ssl_cert": tcert,
-                    "ssl_key": tkey,
-                    "trailing_slash": False,
-                }
+        uprops = {
+            "priority": 1,
+            "ssl_cert": tcert,
+            "ssl_key": tkey,
+            "trailing_slash": False,
+        }
 
-                # Check that all properties can be set at construction time.
-                uobj = publisher.RepositoryURI("https://example.com", **uprops)
+        # Check that all properties can be set at construction time.
+        uobj = publisher.RepositoryURI("https://example.com", **uprops)
 
-                # Verify that all properties provided at construction time were
-                # set as expected.
-                self.assertEqual(uobj.uri, "https://example.com")
-                for p in uprops:
-                        self.assertEqual(uprops[p], getattr(uobj, p))
+        # Verify that all properties provided at construction time were
+        # set as expected.
+        self.assertEqual(uobj.uri, "https://example.com")
+        for p in uprops:
+            self.assertEqual(uprops[p], getattr(uobj, p))
 
-                # Verify that scheme matches provided URI.
-                self.assertEqual(uobj.scheme, "https")
+        # Verify that scheme matches provided URI.
+        self.assertEqual(uobj.scheme, "https")
 
-                # Verify that a copy matches its original.
-                cuobj = copy.copy(uobj)
-                self.assertEqual(uobj.uri, cuobj.uri)
-                for p in uprops:
-                        self.assertEqual(getattr(uobj, p), getattr(cuobj, p))
-                cuobj = None
+        # Verify that a copy matches its original.
+        cuobj = copy.copy(uobj)
+        self.assertEqual(uobj.uri, cuobj.uri)
+        for p in uprops:
+            self.assertEqual(getattr(uobj, p), getattr(cuobj, p))
+        cuobj = None
 
-                # Verify that setting invalid property values raises the
-                # expected exception.
-                self.assertRaises(api_errors.BadRepositoryURI, setattr, uobj,
-                    "uri", None)
-                self.assertRaises(api_errors.UnsupportedRepositoryURI, setattr,
-                    uobj, "uri", ":/notvalid")
-                # this value is valid only for ProxyURI objects, not
-                # RepositoryURI objects
-                self.assertRaises(api_errors.BadRepositoryURI, setattr, uobj,
-                    "uri", "http://user:password@server")
-                self.assertRaises(api_errors.BadRepositoryURIPriority,
-                    setattr, uobj, "priority", "foo")
-                self.assertRaises(api_errors.BadRepositoryAttributeValue,
-                    setattr, uobj, "ssl_cert", -1)
-                self.assertRaises(api_errors.BadRepositoryAttributeValue,
-                    setattr, uobj, "ssl_key", -1)
+        # Verify that setting invalid property values raises the
+        # expected exception.
+        self.assertRaises(
+            api_errors.BadRepositoryURI, setattr, uobj, "uri", None
+        )
+        self.assertRaises(
+            api_errors.UnsupportedRepositoryURI,
+            setattr,
+            uobj,
+            "uri",
+            ":/notvalid",
+        )
+        # this value is valid only for ProxyURI objects, not
+        # RepositoryURI objects
+        self.assertRaises(
+            api_errors.BadRepositoryURI,
+            setattr,
+            uobj,
+            "uri",
+            "http://user:password@server",
+        )
+        self.assertRaises(
+            api_errors.BadRepositoryURIPriority,
+            setattr,
+            uobj,
+            "priority",
+            "foo",
+        )
+        self.assertRaises(
+            api_errors.BadRepositoryAttributeValue,
+            setattr,
+            uobj,
+            "ssl_cert",
+            -1,
+        )
+        self.assertRaises(
+            api_errors.BadRepositoryAttributeValue, setattr, uobj, "ssl_key", -1
+        )
 
-                # Verify that changing the URI scheme will null properties that
-                # no longer apply.
-                uobj.uri = "http://example.com"
-                self.assertEqual(uobj.ssl_cert, None)
-                self.assertEqual(uobj.ssl_key, None)
+        # Verify that changing the URI scheme will null properties that
+        # no longer apply.
+        uobj.uri = "http://example.com"
+        self.assertEqual(uobj.ssl_cert, None)
+        self.assertEqual(uobj.ssl_key, None)
 
-                # Verify that scheme matches provided URI.
-                self.assertEqual(uobj.scheme, "http")
+        # Verify that scheme matches provided URI.
+        self.assertEqual(uobj.scheme, "http")
 
-                # Verify that attempting to set properties not valid for the
-                # current URI scheme raises the expected exception.
-                self.assertRaises(api_errors.UnsupportedRepositoryURIAttribute,
-                    setattr, uobj, "ssl_cert", tcert)
-                self.assertRaises(api_errors.UnsupportedRepositoryURIAttribute,
-                    setattr, uobj, "ssl_key", tkey)
+        # Verify that attempting to set properties not valid for the
+        # current URI scheme raises the expected exception.
+        self.assertRaises(
+            api_errors.UnsupportedRepositoryURIAttribute,
+            setattr,
+            uobj,
+            "ssl_cert",
+            tcert,
+        )
+        self.assertRaises(
+            api_errors.UnsupportedRepositoryURIAttribute,
+            setattr,
+            uobj,
+            "ssl_key",
+            tkey,
+        )
 
-                # Verify that individual properties can be set.
-                uobj = publisher.RepositoryURI("https://example.com/")
-                for p in uprops:
-                        setattr(uobj, p, uprops[p])
-                        self.assertEqual(getattr(uobj, p), uprops[p])
+        # Verify that individual properties can be set.
+        uobj = publisher.RepositoryURI("https://example.com/")
+        for p in uprops:
+            setattr(uobj, p, uprops[p])
+            self.assertEqual(getattr(uobj, p), uprops[p])
 
-                # Finally, verify all properties (except URI and trailing_slash)
-                # can be set to None.
-                for p in ("priority", "ssl_cert", "ssl_key"):
-                        setattr(uobj, p, None)
-                        self.assertEqual(getattr(uobj, p), None)
+        # Finally, verify all properties (except URI and trailing_slash)
+        # can be set to None.
+        for p in ("priority", "ssl_cert", "ssl_key"):
+            setattr(uobj, p, None)
+            self.assertEqual(getattr(uobj, p), None)
 
-                # Verify that proxies are set properly
-                uobj = publisher.RepositoryURI("https://example.com",
-                    proxies=[])
-                uobj = publisher.RepositoryURI("https://example.com",
-                    proxies=[publisher.ProxyURI("http://foo.com")])
+        # Verify that proxies are set properly
+        uobj = publisher.RepositoryURI("https://example.com", proxies=[])
+        uobj = publisher.RepositoryURI(
+            "https://example.com",
+            proxies=[publisher.ProxyURI("http://foo.com")],
+        )
 
-                self.assertTrue(uobj.proxies == [publisher.ProxyURI(
-                    "http://foo.com")])
-                uobj.proxies = []
-                self.assertTrue(uobj.proxies == [])
+        self.assertTrue(uobj.proxies == [publisher.ProxyURI("http://foo.com")])
+        uobj.proxies = []
+        self.assertTrue(uobj.proxies == [])
 
-                # Verify that proxies and proxy are linked
-                uobj.proxies = [publisher.ProxyURI("http://foo.com")]
-                self.assertTrue(uobj.proxy == "http://foo.com")
-                uobj.proxy = "http://bar"
-                self.assertTrue(uobj.proxies == [publisher.ProxyURI("http://bar")])
+        # Verify that proxies and proxy are linked
+        uobj.proxies = [publisher.ProxyURI("http://foo.com")]
+        self.assertTrue(uobj.proxy == "http://foo.com")
+        uobj.proxy = "http://bar"
+        self.assertTrue(uobj.proxies == [publisher.ProxyURI("http://bar")])
 
-                try:
-                        raised = False
-                        publisher.RepositoryURI("http://foo", proxies=[
-                            publisher.ProxyURI("http://bar")],
-                            proxy="http://foo")
-                except api_errors.PublisherError:
-                        raised = True
-                finally:
-                        self.assertTrue(raised, "No exception raised when "
-                            "creating a RepositoryURI obj with proxies & proxy")
+        try:
+            raised = False
+            publisher.RepositoryURI(
+                "http://foo",
+                proxies=[publisher.ProxyURI("http://bar")],
+                proxy="http://foo",
+            )
+        except api_errors.PublisherError:
+            raised = True
+        finally:
+            self.assertTrue(
+                raised,
+                "No exception raised when "
+                "creating a RepositoryURI obj with proxies & proxy",
+            )
 
-                # Check that we detect bad values for proxies
-                self.assertRaises(api_errors.BadRepositoryAttributeValue,
-                    setattr, uobj, "proxies", "foo")
-                self.assertRaises(api_errors.BadRepositoryAttributeValue,
-                    setattr, uobj, "proxies", [None])
-                # we only support a single proxy per RepositoryURI
-                self.assertRaises(api_errors.BadRepositoryAttributeValue,
-                    setattr, uobj, "proxies", [
-                    publisher.ProxyURI("http://foo.com"),
-                    publisher.ProxyURI("http://bar.com")])
+        # Check that we detect bad values for proxies
+        self.assertRaises(
+            api_errors.BadRepositoryAttributeValue,
+            setattr,
+            uobj,
+            "proxies",
+            "foo",
+        )
+        self.assertRaises(
+            api_errors.BadRepositoryAttributeValue,
+            setattr,
+            uobj,
+            "proxies",
+            [None],
+        )
+        # we only support a single proxy per RepositoryURI
+        self.assertRaises(
+            api_errors.BadRepositoryAttributeValue,
+            setattr,
+            uobj,
+            "proxies",
+            [
+                publisher.ProxyURI("http://foo.com"),
+                publisher.ProxyURI("http://bar.com"),
+            ],
+        )
 
+    def test_02_repository(self):
+        """Verify that a Repository object can be created, copied,
+        modified, and used as expected."""
 
-        def test_02_repository(self):
-                """Verify that a Repository object can be created, copied,
-                modified, and used as expected."""
+        tcert = os.path.join(self.test_root, "test.cert")
+        tkey = os.path.join(self.test_root, "test.key")
 
-                tcert = os.path.join(self.test_root, "test.cert")
-                tkey = os.path.join(self.test_root, "test.key")
+        t2cert = os.path.join(self.test_root, "test2.cert")
+        t2key = os.path.join(self.test_root, "test2.key")
 
-                t2cert = os.path.join(self.test_root, "test2.cert")
-                t2key = os.path.join(self.test_root, "test2.key")
+        rprops = {
+            "collection_type": publisher.REPO_CTYPE_SUPPLEMENTAL,
+            "description": "Provides only the best BobCat packages!",
+            "legal_uris": [
+                "http://legal1.example.com",
+                "http://legal2.example.com",
+            ],
+            "mirrors": [
+                "http://mirror1.example.com/",
+                "http://mirror2.example.com/",
+            ],
+            "name": "BobCat Repository",
+            "origins": [
+                "http://origin1.example.com/",
+                "http://origin2.example.com/",
+            ],
+            "refresh_seconds": 70000,
+            "registered": True,
+            "registration_uri": "http://register.example.com/",
+            "related_uris": [
+                "http://related1.example.com",
+                "http://related2.example.com",
+            ],
+            "sort_policy": publisher.URI_SORT_PRIORITY,
+        }
 
-                rprops = {
-                    "collection_type": publisher.REPO_CTYPE_SUPPLEMENTAL,
-                    "description": "Provides only the best BobCat packages!",
-                    "legal_uris": [
-                        "http://legal1.example.com",
-                        "http://legal2.example.com"
-                    ],
-                    "mirrors": [
-                        "http://mirror1.example.com/",
-                        "http://mirror2.example.com/"
-                    ],
-                    "name": "BobCat Repository",
-                    "origins": [
-                        "http://origin1.example.com/",
-                        "http://origin2.example.com/"
-                    ],
-                    "refresh_seconds": 70000,
-                    "registered": True,
-                    "registration_uri": "http://register.example.com/",
-                    "related_uris": [
-                        "http://related1.example.com",
-                        "http://related2.example.com"
-                    ],
-                    "sort_policy": publisher.URI_SORT_PRIORITY,
-                }
+        # Check that all properties can be set at construction time.
+        robj = publisher.Repository(**rprops)
 
-                # Check that all properties can be set at construction time.
-                robj = publisher.Repository(**rprops)
+        # Verify that all properties provided at construction time were
+        # set as expected.
+        for p in rprops:
+            self.assertEqual(rprops[p], getattr(robj, p))
 
-                # Verify that all properties provided at construction time were
-                # set as expected.
-                for p in rprops:
-                        self.assertEqual(rprops[p], getattr(robj, p))
+        # Verify that a copy matches its original.
+        crobj = copy.copy(robj)
+        for p in rprops:
+            self.assertEqual(getattr(robj, p), getattr(crobj, p))
+        crobj = None
 
-                # Verify that a copy matches its original.
-                crobj = copy.copy(robj)
-                for p in rprops:
-                        self.assertEqual(getattr(robj, p), getattr(crobj, p))
-                crobj = None
+        # New set of rprops for testing (all the URI use https so that
+        # setting ssl_key and ssl_cert can be tested).
+        rprops = {
+            "collection_type": publisher.REPO_CTYPE_SUPPLEMENTAL,
+            "description": "Provides only the best BobCat packages!",
+            "legal_uris": [
+                "https://legal1.example.com",
+                "https://legal2.example.com",
+            ],
+            "mirrors": [
+                "https://mirror1.example.com/",
+                "https://mirror2.example.com/",
+            ],
+            "name": "BobCat Repository",
+            "origins": [
+                "https://origin1.example.com/",
+                "https://origin2.example.com/",
+            ],
+            "refresh_seconds": 70000,
+            "registered": True,
+            "registration_uri": "https://register.example.com/",
+            "related_uris": [
+                "https://related1.example.com",
+                "https://related2.example.com",
+            ],
+            "sort_policy": publisher.URI_SORT_PRIORITY,
+        }
 
-                # New set of rprops for testing (all the URI use https so that
-                # setting ssl_key and ssl_cert can be tested).
-                rprops = {
-                    "collection_type": publisher.REPO_CTYPE_SUPPLEMENTAL,
-                    "description": "Provides only the best BobCat packages!",
-                    "legal_uris": [
-                        "https://legal1.example.com",
-                        "https://legal2.example.com"
-                    ],
-                    "mirrors": [
-                        "https://mirror1.example.com/",
-                        "https://mirror2.example.com/"
-                    ],
-                    "name": "BobCat Repository",
-                    "origins": [
-                        "https://origin1.example.com/",
-                        "https://origin2.example.com/"
-                    ],
-                    "refresh_seconds": 70000,
-                    "registered": True,
-                    "registration_uri": "https://register.example.com/",
-                    "related_uris": [
-                        "https://related1.example.com",
-                        "https://related2.example.com"
-                    ],
-                    "sort_policy": publisher.URI_SORT_PRIORITY,
-                }
+        # Verify that individual properties can be set.
+        robj = publisher.Repository()
+        for p in rprops:
+            setattr(robj, p, rprops[p])
+            self.assertEqual(getattr(robj, p), rprops[p])
 
-                # Verify that individual properties can be set.
-                robj = publisher.Repository()
-                for p in rprops:
-                        setattr(robj, p, rprops[p])
-                        self.assertEqual(getattr(robj, p), rprops[p])
+        # Verify that setting invalid property values raises the
+        # expected exception.
+        self.assertRaises(
+            api_errors.BadRepositoryCollectionType,
+            setattr,
+            robj,
+            "collection_type",
+            -1,
+        )
+        self.assertRaises(
+            api_errors.BadRepositoryAttributeValue,
+            setattr,
+            robj,
+            "refresh_seconds",
+            -1,
+        )
+        self.assertRaises(
+            api_errors.BadRepositoryURISortPolicy,
+            setattr,
+            robj,
+            "sort_policy",
+            -1,
+        )
 
-                # Verify that setting invalid property values raises the
-                # expected exception.
-                self.assertRaises(api_errors.BadRepositoryCollectionType,
-                    setattr, robj, "collection_type", -1)
-                self.assertRaises(api_errors.BadRepositoryAttributeValue,
-                    setattr, robj, "refresh_seconds", -1)
-                self.assertRaises(api_errors.BadRepositoryURISortPolicy,
-                    setattr, robj, "sort_policy", -1)
+        # Verify that add functions work as expected.
+        robj = publisher.Repository()
+        for utype in ("legal_uri", "mirror", "origin", "related_uri"):
+            prop = utype + "s"
+            for u in rprops[prop]:
+                method = getattr(robj, "add_{0}".format(utype))
+                method(u, priority=1, ssl_cert=tcert, ssl_key=tkey)
 
-                # Verify that add functions work as expected.
-                robj = publisher.Repository()
-                for utype in ("legal_uri", "mirror", "origin", "related_uri"):
-                        prop = utype + "s"
-                        for u in rprops[prop]:
-                                method = getattr(robj, "add_{0}".format(utype))
-                                method(u, priority=1, ssl_cert=tcert,
-                                    ssl_key=tkey)
+        # Verify that has and get functions work as expected.
+        for utype in ("mirror", "origin"):
+            prop = utype + "s"
+            for u in rprops[prop]:
+                method = getattr(robj, "has_{0}".format(utype))
+                self.assertTrue(method(u))
 
-                # Verify that has and get functions work as expected.
-                for utype in ("mirror", "origin"):
-                        prop = utype + "s"
-                        for u in rprops[prop]:
-                                method = getattr(robj, "has_{0}".format(utype))
-                                self.assertTrue(method(u))
-
-                                method = getattr(robj, "get_{0}".format(utype))
-                                cu = publisher.RepositoryURI(u, priority=1,
-                                    ssl_cert=tcert, ssl_key=tkey,
-                                    trailing_slash=True)
-                                ou = method(u)
-
-                                # This verifies that the expected URI object is
-                                # returned and that all of the properties match
-                                # exactly as they were added.
-                                for uprop in ("uri", "priority", "ssl_cert",
-                                    "ssl_key", "trailing_slash"):
-                                        self.assertEqual(getattr(cu, uprop),
-                                            getattr(ou, uprop))
-
-                # Verify that remove functions work as expected.
-                for utype in ("legal_uri", "mirror", "origin", "related_uri"):
-                        prop = utype + "s"
-
-                        # Remove only the first URI for each property.
-                        u = rprops[prop][0]
-                        method = getattr(robj, "remove_{0}".format(utype))
-                        method(u)
-                        self.assertTrue(u not in getattr(robj, prop))
-                        self.assertEqual(len(getattr(robj, prop)), 1)
-
-                # Verify that update functions work as expected.
-                for utype in ("mirror", "origin"):
-                        prop = utype + "s"
-
-                        # Update only the last entry for each property.
-                        u = rprops[prop][-1]
-
-                        method = getattr(robj, "update_{0}".format(utype))
-                        method(u, priority=2, ssl_cert=t2cert, ssl_key=t2key)
-
-                        method = getattr(robj, "get_{0}".format(utype))
-                        ou = method(u)
-
-                        # This verifies that the expected URI object is
-                        # returned and that all of the properties match
-                        # exactly as specified to the update method.
-                        cu = publisher.RepositoryURI(u, priority=2,
-                            ssl_cert=t2cert, ssl_key=t2key)
-                        for uprop in ("uri", "priority", "ssl_cert",
-                            "ssl_key", "trailing_slash"):
-                                self.assertEqual(getattr(cu, uprop),
-                                    getattr(ou, uprop))
-
-                # Verify that reset functions work as expected.
-                for prop in ("mirrors", "origins"):
-                        method = getattr(robj, "reset_{0}".format(prop))
-                        method()
-                        self.assertEqual(getattr(robj, prop), [])
-
-        def test_03_publisher(self):
-                """Verify that a Repository object can be created, copied,
-                modified, and used as expected."""
-
-                robj = publisher.Repository(
-                    collection_type=publisher.REPO_CTYPE_SUPPLEMENTAL,
-                    description="Provides only the best BobCat packages!",
-                    legal_uris=[
-                        "http://legal1.example.com",
-                        "http://legal2.example.com"
-                    ],
-                    mirrors=[
-                        "http://mirror1.example.com/",
-                        "http://mirror2.example.com/"
-                    ],
-                    name="First Repository",
-                    origins=[
-                        "http://origin1.example.com/",
-                        "http://origin2.example.com/"
-                    ],
-                    refresh_seconds=70000,
-                    registered=True,
-                    registration_uri="http://register.example.com/",
-                    related_uris=[
-                        "http://related1.example.com",
-                        "http://related2.example.com"
-                    ],
-                    sort_policy=publisher.URI_SORT_PRIORITY,
+                method = getattr(robj, "get_{0}".format(utype))
+                cu = publisher.RepositoryURI(
+                    u,
+                    priority=1,
+                    ssl_cert=tcert,
+                    ssl_key=tkey,
+                    trailing_slash=True,
                 )
+                ou = method(u)
 
-                r2obj = copy.copy(robj)
-                r2obj.origins = ["http://origin3.example.com"]
-                r2obj.name = "Second Repository"
-                r2obj.reset_mirrors()
+                # This verifies that the expected URI object is
+                # returned and that all of the properties match
+                # exactly as they were added.
+                for uprop in (
+                    "uri",
+                    "priority",
+                    "ssl_cert",
+                    "ssl_key",
+                    "trailing_slash",
+                ):
+                    self.assertEqual(getattr(cu, uprop), getattr(ou, uprop))
 
-                pprops = {
-                    "alias": "cat",
-                    "client_uuid": "2c6a8ff8-20e5-11de-a818-001fd0979039",
-                    "client_uuid_time": "Wed Dec 20 13:24:40 2017",
-                    "disabled": True,
-                    "meta_root": os.path.join(self.test_root, "bobcat"),
-                    "repository": r2obj,
-                }
+        # Verify that remove functions work as expected.
+        for utype in ("legal_uri", "mirror", "origin", "related_uri"):
+            prop = utype + "s"
 
-                # Check that all properties can be set at construction time.
-                pobj = publisher.Publisher("bobcat", **pprops)
+            # Remove only the first URI for each property.
+            u = rprops[prop][0]
+            method = getattr(robj, "remove_{0}".format(utype))
+            method(u)
+            self.assertTrue(u not in getattr(robj, prop))
+            self.assertEqual(len(getattr(robj, prop)), 1)
 
-                # Verify that all properties provided at construction time were
-                # set as expected.
-                for p in pprops:
-                        self.assertEqual(pprops[p], getattr(pobj, p))
+        # Verify that update functions work as expected.
+        for utype in ("mirror", "origin"):
+            prop = utype + "s"
 
-                # Verify that a copy matches its original.
-                cpobj = copy.copy(pobj)
-                for p in pprops:
-                        if p == "repository":
-                                # These attributes can't be directly compared.
-                                continue
-                        self.assertEqual(getattr(pobj, p), getattr(cpobj, p))
+            # Update only the last entry for each property.
+            u = rprops[prop][-1]
 
-                # Assume that if the origins match, we have the right selected
-                # repository.
-                self.assertEqual(cpobj.repository.origins,
-                    r2obj.origins)
+            method = getattr(robj, "update_{0}".format(utype))
+            method(u, priority=2, ssl_cert=t2cert, ssl_key=t2key)
 
-                # Compare the source_object_id of the copied repository object
-                # with the id of the source repository object.
-                self.assertEqual(id(pobj), cpobj._source_object_id)
+            method = getattr(robj, "get_{0}".format(utype))
+            ou = method(u)
 
-                cpobj = None
+            # This verifies that the expected URI object is
+            # returned and that all of the properties match
+            # exactly as specified to the update method.
+            cu = publisher.RepositoryURI(
+                u, priority=2, ssl_cert=t2cert, ssl_key=t2key
+            )
+            for uprop in (
+                "uri",
+                "priority",
+                "ssl_cert",
+                "ssl_key",
+                "trailing_slash",
+            ):
+                self.assertEqual(getattr(cu, uprop), getattr(ou, uprop))
 
-                # Verify that individual properties can be set.
-                pobj = publisher.Publisher("tomcat")
-                pobj.prefix = "bobcat"
-                self.assertEqual(pobj.prefix, "bobcat")
+        # Verify that reset functions work as expected.
+        for prop in ("mirrors", "origins"):
+            method = getattr(robj, "reset_{0}".format(prop))
+            method()
+            self.assertEqual(getattr(robj, prop), [])
 
-                for p in pprops:
-                        if p == "repositories":
-                                for r in pprops[p]:
-                                        pobj.add_repository(r)
-                        else:
-                                setattr(pobj, p, pprops[p])
-                        self.assertEqual(getattr(pobj, p), pprops[p])
+    def test_03_publisher(self):
+        """Verify that a Repository object can be created, copied,
+        modified, and used as expected."""
 
-                pobj.repository = robj
-                self.assertEqual(pobj.repository, robj)
+        robj = publisher.Repository(
+            collection_type=publisher.REPO_CTYPE_SUPPLEMENTAL,
+            description="Provides only the best BobCat packages!",
+            legal_uris=[
+                "http://legal1.example.com",
+                "http://legal2.example.com",
+            ],
+            mirrors=[
+                "http://mirror1.example.com/",
+                "http://mirror2.example.com/",
+            ],
+            name="First Repository",
+            origins=[
+                "http://origin1.example.com/",
+                "http://origin2.example.com/",
+            ],
+            refresh_seconds=70000,
+            registered=True,
+            registration_uri="http://register.example.com/",
+            related_uris=[
+                "http://related1.example.com",
+                "http://related2.example.com",
+            ],
+            sort_policy=publisher.URI_SORT_PRIORITY,
+        )
 
-                # An invalid value shouldn't be allowed.
-                self.assertRaises(api_errors.UnknownRepository, setattr,
-                    pobj, "repository", -1)
+        r2obj = copy.copy(robj)
+        r2obj.origins = ["http://origin3.example.com"]
+        r2obj.name = "Second Repository"
+        r2obj.reset_mirrors()
 
-                pobj.reset_client_uuid()
-                self.assertNotEqual(pobj.client_uuid, None)
-                self.assertNotEqual(pobj.client_uuid, pprops["client_uuid"])
+        pprops = {
+            "alias": "cat",
+            "client_uuid": "2c6a8ff8-20e5-11de-a818-001fd0979039",
+            "client_uuid_time": "Wed Dec 20 13:24:40 2017",
+            "disabled": True,
+            "meta_root": os.path.join(self.test_root, "bobcat"),
+            "repository": r2obj,
+        }
 
-                pobj.create_meta_root()
-                self.assertTrue(os.path.exists(pobj.meta_root))
+        # Check that all properties can be set at construction time.
+        pobj = publisher.Publisher("bobcat", **pprops)
 
-                pobj.remove_meta_root()
-                self.assertFalse(os.path.exists(pobj.meta_root))
+        # Verify that all properties provided at construction time were
+        # set as expected.
+        for p in pprops:
+            self.assertEqual(pprops[p], getattr(pobj, p))
 
-        def test_04_proxy_uri(self):
-                """Verify that a ProxyURI object can be created, copied,
-                modified, and used as expected."""
+        # Verify that a copy matches its original.
+        cpobj = copy.copy(pobj)
+        for p in pprops:
+            if p == "repository":
+                # These attributes can't be directly compared.
+                continue
+            self.assertEqual(getattr(pobj, p), getattr(cpobj, p))
 
-                pobj = publisher.ProxyURI("http://example.com")
-                self.assertTrue(pobj.uri == "http://example.com")
+        # Assume that if the origins match, we have the right selected
+        # repository.
+        self.assertEqual(cpobj.repository.origins, r2obj.origins)
 
-                tcert = os.path.join(self.test_root, "test.cert")
-                tkey = os.path.join(self.test_root, "test.key")
-                # check that we can't set several RepositoryURI attributes
-                bad_props = {
-                    "priority": 1,
-                    "ssl_cert": tcert,
-                    "ssl_key": tkey,
-                    "trailing_slash": False
-                }
+        # Compare the source_object_id of the copied repository object
+        # with the id of the source repository object.
+        self.assertEqual(id(pobj), cpobj._source_object_id)
 
-                pobj = publisher.ProxyURI("http://example.com")
-                for prop in bad_props:
-                        self.assertRaises(ValueError,
-                            setattr, pobj, prop, bad_props[prop])
+        cpobj = None
 
-                # check bad values for system
-                self.assertRaises(api_errors.BadRepositoryAttributeValue,
-                    setattr, pobj, "system", "Carrots")
-                self.assertRaises(api_errors.BadRepositoryAttributeValue,
-                    setattr, pobj, "system", None)
+        # Verify that individual properties can be set.
+        pobj = publisher.Publisher("tomcat")
+        pobj.prefix = "bobcat"
+        self.assertEqual(pobj.prefix, "bobcat")
 
-                # check that we can set URI values that RespositoryURI would
-                # choke on
-                uri = "http://user:pass@server"
-                pobj.uri = uri
-                self.assertTrue(pobj.uri == uri)
+        for p in pprops:
+            if p == "repositories":
+                for r in pprops[p]:
+                    pobj.add_repository(r)
+            else:
+                setattr(pobj, p, pprops[p])
+            self.assertEqual(getattr(pobj, p), pprops[p])
 
-                # check that setting system results in uri being overridden
-                pobj.system = True
-                self.assertTrue(pobj.system == True)
-                self.assertTrue(pobj.uri == publisher.SYSREPO_PROXY)
+        pobj.repository = robj
+        self.assertEqual(pobj.repository, robj)
 
-                # check that clearing system also clears uri
-                pobj.system = False
-                self.assertTrue(pobj.system == False)
-                self.assertTrue(pobj.uri == None)
+        # An invalid value shouldn't be allowed.
+        self.assertRaises(
+            api_errors.UnknownRepository, setattr, pobj, "repository", -1
+        )
+
+        pobj.reset_client_uuid()
+        self.assertNotEqual(pobj.client_uuid, None)
+        self.assertNotEqual(pobj.client_uuid, pprops["client_uuid"])
+
+        pobj.create_meta_root()
+        self.assertTrue(os.path.exists(pobj.meta_root))
+
+        pobj.remove_meta_root()
+        self.assertFalse(os.path.exists(pobj.meta_root))
+
+    def test_04_proxy_uri(self):
+        """Verify that a ProxyURI object can be created, copied,
+        modified, and used as expected."""
+
+        pobj = publisher.ProxyURI("http://example.com")
+        self.assertTrue(pobj.uri == "http://example.com")
+
+        tcert = os.path.join(self.test_root, "test.cert")
+        tkey = os.path.join(self.test_root, "test.key")
+        # check that we can't set several RepositoryURI attributes
+        bad_props = {
+            "priority": 1,
+            "ssl_cert": tcert,
+            "ssl_key": tkey,
+            "trailing_slash": False,
+        }
+
+        pobj = publisher.ProxyURI("http://example.com")
+        for prop in bad_props:
+            self.assertRaises(ValueError, setattr, pobj, prop, bad_props[prop])
+
+        # check bad values for system
+        self.assertRaises(
+            api_errors.BadRepositoryAttributeValue,
+            setattr,
+            pobj,
+            "system",
+            "Carrots",
+        )
+        self.assertRaises(
+            api_errors.BadRepositoryAttributeValue,
+            setattr,
+            pobj,
+            "system",
+            None,
+        )
+
+        # check that we can set URI values that RespositoryURI would
+        # choke on
+        uri = "http://user:pass@server"
+        pobj.uri = uri
+        self.assertTrue(pobj.uri == uri)
+
+        # check that setting system results in uri being overridden
+        pobj.system = True
+        self.assertTrue(pobj.system == True)
+        self.assertTrue(pobj.uri == publisher.SYSREPO_PROXY)
+
+        # check that clearing system also clears uri
+        pobj.system = False
+        self.assertTrue(pobj.system == False)
+        self.assertTrue(pobj.uri == None)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_sha512_t.py
+++ b/src/tests/api/t_sha512_t.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-# 
+#
 # CDDL HEADER START
 #
 # The contents of this file are subject to the terms of the
@@ -27,8 +27,9 @@
 
 from __future__ import unicode_literals
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import six
@@ -36,124 +37,137 @@ import unittest
 from six.moves import range
 
 try:
-        import pkg.sha512_t as sha512_t
-        sha512_supported = True
+    import pkg.sha512_t as sha512_t
+
+    sha512_supported = True
 except ImportError:
-        sha512_supported = False
+    sha512_supported = False
+
 
 class TestPkgSha(pkg5unittest.Pkg5TestCase):
-        """A class tests the sha512_t module."""
+    """A class tests the sha512_t module."""
 
-        def test_basic(self):
-                if not sha512_supported:
-                        return
+    def test_basic(self):
+        if not sha512_supported:
+            return
 
-                # The expected values are from the examples:
-                # http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_224.pdf
-                # http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_256.pdf
+        # The expected values are from the examples:
+        # http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_224.pdf
+        # http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512_256.pdf
 
-                # Test SHA512/256
-                # Test hexdigest()
-                a = sha512_t.SHA512_t()
-                a.update(b"abc")
-                expected = "53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23"
-                output = a.hexdigest()
-                self.assertEqualDiff(expected, output)
+        # Test SHA512/256
+        # Test hexdigest()
+        a = sha512_t.SHA512_t()
+        a.update(b"abc")
+        expected = (
+            "53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23"
+        )
+        output = a.hexdigest()
+        self.assertEqualDiff(expected, output)
 
-                a = sha512_t.SHA512_t(b"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")
-                expected = "3928e184fb8690f840da3988121d31be65cb9d3ef83ee6146feac861e19b563a"
-                output = a.hexdigest()
-                self.assertEqualDiff(expected, output)
+        a = sha512_t.SHA512_t(
+            b"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
+        )
+        expected = (
+            "3928e184fb8690f840da3988121d31be65cb9d3ef83ee6146feac861e19b563a"
+        )
+        output = a.hexdigest()
+        self.assertEqualDiff(expected, output)
 
-                # Test the length of the output of hexdigest()
-                output = len(sha512_t.SHA512_t(b"0.861687995815").hexdigest())
-                self.assertEqualDiff(64, output)
-                output = len(sha512_t.SHA512_t(b"0.861687995815", 224).hexdigest())
-                self.assertEqualDiff(56, output)
+        # Test the length of the output of hexdigest()
+        output = len(sha512_t.SHA512_t(b"0.861687995815").hexdigest())
+        self.assertEqualDiff(64, output)
+        output = len(sha512_t.SHA512_t(b"0.861687995815", 224).hexdigest())
+        self.assertEqualDiff(56, output)
 
-                # Test digest()
-                a = sha512_t.SHA512_t()
-                a.update(b"abc")
-                expected = b"S\x04\x8e&\x81\x94\x1e\xf9\x9b.)\xb7kL}\xab\xe4\xc2\xd0\xc64\xfcmF\xe0\xe2\xf11\x07\xe7\xaf#"
-                output = a.digest()
-                self.assertEqualDiff(expected, output)
+        # Test digest()
+        a = sha512_t.SHA512_t()
+        a.update(b"abc")
+        expected = b"S\x04\x8e&\x81\x94\x1e\xf9\x9b.)\xb7kL}\xab\xe4\xc2\xd0\xc64\xfcmF\xe0\xe2\xf11\x07\xe7\xaf#"
+        output = a.digest()
+        self.assertEqualDiff(expected, output)
 
-                # Test the length of the output of digest()
-                output = len(sha512_t.SHA512_t(b"0.861687995815").digest())
-                self.assertEqualDiff(32, output)
-                output = len(sha512_t.SHA512_t(b"0.861687995815", 224).digest())
-                self.assertEqualDiff(28, output)
+        # Test the length of the output of digest()
+        output = len(sha512_t.SHA512_t(b"0.861687995815").digest())
+        self.assertEqualDiff(32, output)
+        output = len(sha512_t.SHA512_t(b"0.861687995815", 224).digest())
+        self.assertEqualDiff(28, output)
 
-                # Test update()
-                a = sha512_t.SHA512_t(b"a")
-                a.update(b"bc")
-                expected = "53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23"
-                output = a.hexdigest()
-                self.assertEqualDiff(expected, output)
+        # Test update()
+        a = sha512_t.SHA512_t(b"a")
+        a.update(b"bc")
+        expected = (
+            "53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23"
+        )
+        output = a.hexdigest()
+        self.assertEqualDiff(expected, output)
 
-                a = sha512_t.SHA512_t(b"a")
-                a.hexdigest()
-                a.digest()
-                a.update(b"b")
-                a.hexdigest()
-                a.update(b"c")
-                output = a.hexdigest()
-                self.assertEqualDiff(expected, output)
+        a = sha512_t.SHA512_t(b"a")
+        a.hexdigest()
+        a.digest()
+        a.update(b"b")
+        a.hexdigest()
+        a.update(b"c")
+        output = a.hexdigest()
+        self.assertEqualDiff(expected, output)
 
-                # Test hash_size
-                a = sha512_t.SHA512_t()
-                self.assertEqualDiff("256", a.hash_size)
+        # Test hash_size
+        a = sha512_t.SHA512_t()
+        self.assertEqualDiff("256", a.hash_size)
 
-                # Test SHA512/224
-                a = sha512_t.SHA512_t(t=224)
-                a.update(b"abc")
-                expected = "4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa"
-                output = a.hexdigest()
-                self.assertEqualDiff(expected, output)
+        # Test SHA512/224
+        a = sha512_t.SHA512_t(t=224)
+        a.update(b"abc")
+        expected = "4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa"
+        output = a.hexdigest()
+        self.assertEqualDiff(expected, output)
 
-                a = sha512_t.SHA512_t(b"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu", t=224)
-                expected = "23fec5bb94d60b23308192640b0c453335d664734fe40e7268674af9"
-                output = a.hexdigest()
-                self.assertEqualDiff(expected, output)
+        a = sha512_t.SHA512_t(
+            b"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu",
+            t=224,
+        )
+        expected = "23fec5bb94d60b23308192640b0c453335d664734fe40e7268674af9"
+        output = a.hexdigest()
+        self.assertEqualDiff(expected, output)
 
-                # Test positional arguments
-                a = sha512_t.SHA512_t(b"abc", 224)
-                expected = "4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa"
-                output = a.hexdigest()
-                self.assertEqualDiff(expected, output)
+        # Test positional arguments
+        a = sha512_t.SHA512_t(b"abc", 224)
+        expected = "4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa"
+        output = a.hexdigest()
+        self.assertEqualDiff(expected, output)
 
-                # Test keyword arguments
-                a = sha512_t.SHA512_t(message=b"abc", t=224)
-                expected = "4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa"
-                output = a.hexdigest()
-                self.assertEqualDiff(expected, output)
+        # Test keyword arguments
+        a = sha512_t.SHA512_t(message=b"abc", t=224)
+        expected = "4634270f707b6a54daae7530460842e20e37ed265ceee9a43e8924aa"
+        output = a.hexdigest()
+        self.assertEqualDiff(expected, output)
 
-                # Test scalability
-                a = sha512_t.SHA512_t()
-                for i in range(1000000):
-                        a.update(b"abc")
-                a.hexdigest()
+        # Test scalability
+        a = sha512_t.SHA512_t()
+        for i in range(1000000):
+            a.update(b"abc")
+        a.hexdigest()
 
-                # Test bad input
-                self.assertRaises(TypeError, sha512_t.SHA512_t, 8)
-                self.assertRaises(ValueError, sha512_t.SHA512_t, t=160)
-                self.assertRaises(TypeError, sha512_t.SHA512_t.update, 8)
+        # Test bad input
+        self.assertRaises(TypeError, sha512_t.SHA512_t, 8)
+        self.assertRaises(ValueError, sha512_t.SHA512_t, t=160)
+        self.assertRaises(TypeError, sha512_t.SHA512_t.update, 8)
 
-                if six.PY2:
-                        # We allow unicode in Python 2 as hashlib does
-                        a = sha512_t.SHA512_t(u"abc")
-                        expected = "53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23"
-                        output = a.hexdigest()
-                        self.assertEqualDiff(expected, output)
-                        # Test special unicode character
-                        a = sha512_t.SHA512_t("α♭¢")
-                        a.hexdigest()
-                        a.update("ρ⑂☂♄øη")
-                        a.hexdigest()
-                else:
-                        # We don't allow unicode in Python 3 as hashlib does
-                        self.assertRaises(TypeError, sha512_t.SHA512_t, "str")
+        if six.PY2:
+            # We allow unicode in Python 2 as hashlib does
+            a = sha512_t.SHA512_t("abc")
+            expected = "53048e2681941ef99b2e29b76b4c7dabe4c2d0c634fc6d46e0e2f13107e7af23"
+            output = a.hexdigest()
+            self.assertEqualDiff(expected, output)
+            # Test special unicode character
+            a = sha512_t.SHA512_t("α♭¢")
+            a.hexdigest()
+            a.update("ρ⑂☂♄øη")
+            a.hexdigest()
+        else:
+            # We don't allow unicode in Python 3 as hashlib does
+            self.assertRaises(TypeError, sha512_t.SHA512_t, "str")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()

--- a/src/tests/api/t_smf.py
+++ b/src/tests/api/t_smf.py
@@ -24,8 +24,9 @@
 
 from __future__ import print_function
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 
 import os
 import pkg5unittest
@@ -35,12 +36,13 @@ import pkg.smf as smf
 
 from pkg.client.debugvalues import DebugValues
 
-class TestSMF(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
 
-        smf_cmds = { \
-            "usr/bin/svcprop" : """\
+class TestSMF(pkg5unittest.SingleDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+
+    smf_cmds = {
+        "usr/bin/svcprop": """\
 #!/usr/bin/python
 
 import getopt
@@ -77,13 +79,11 @@ if __name__ == "__main__":
         print(s)
         sys.exit(0)
 """,
-                "usr/sbin/svcadm" : \
-"""#!/bin/sh
+        "usr/sbin/svcadm": """#!/bin/sh
 echo $0 "$@" >> $PKG_TEST_DIR/svcadm_arguments
 exit $PKG_SVCADM_EXIT_CODE
 """,
-                "usr/bin/svcs" : \
-"""#!/bin/sh
+        "usr/bin/svcs": """#!/bin/sh
 
 # called from pkg.client.actuator using 'svcs -H -o fmri <string>'
 # so $4 is the FMRI pattern that we're interested in resolving
@@ -117,16 +117,14 @@ esac
 echo $FMRI
 exit $RETURN
 """,
-                "bin_zlogin" : \
-"""#!/bin/ksh
+        "bin_zlogin": """#!/bin/ksh
 zone_name=$1
 shift
 echo "zlogin $zone_name" >> $PKG_TEST_DIR/zlogin_arguments
 ($*)""",
-}
-        misc_files = { \
-                "svcprop_enabled" :
-"""general/enabled boolean true
+    }
+    misc_files = {
+        "svcprop_enabled": """general/enabled boolean true
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 4172
@@ -155,9 +153,7 @@ start/type astring method
 stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method""",
-
-                "svcprop_disabled" :
-"""general/enabled boolean false
+        "svcprop_disabled": """general/enabled boolean false
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 4172
@@ -186,9 +182,7 @@ start/type astring method
 stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method""",
-
-                "svcprop_temp_enabled" :
-"""general/enabled boolean false
+        "svcprop_temp_enabled": """general/enabled boolean false
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 7816
@@ -218,9 +212,7 @@ start/type astring method
 stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method""",
-
-                "svcprop_temp_enabled2" :
-"""general/enabled boolean true
+        "svcprop_temp_enabled2": """general/enabled boolean true
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 7816
@@ -250,9 +242,7 @@ start/type astring method
 stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method""",
-
-                "svcprop_temp_disabled" :
-"""general/enabled boolean true
+        "svcprop_temp_disabled": """general/enabled boolean true
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 7816
@@ -282,9 +272,7 @@ start/type astring method
 stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method""",
-
-                "svcprop_temp_disabled2" :
-"""general/enabled boolean false
+        "svcprop_temp_disabled2": """general/enabled boolean false
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 7816
@@ -314,9 +302,7 @@ start/type astring method
 stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method""",
-
-                "svcprop_maintenance":
-"""general/enabled boolean true
+        "svcprop_maintenance": """general/enabled boolean true
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 4172
@@ -345,287 +331,318 @@ start/type astring method
 stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method""",
+        "empty": "",
+    }
 
-                "empty": "",
-}
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files, prefix="testdata")
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files, prefix="testdata")
+    def test_smf(self):
+        """Test that the smf interface performs as expected."""
 
-        def test_smf(self):
-                """Test that the smf interface performs as expected."""
+        testdata_dir = os.path.join(self.test_root, "testdata")
+        svcadm_output = os.path.join(testdata_dir, "svcadm_arguments")
+        os.environ["PKG_TEST_DIR"] = testdata_dir
+        os.environ["PKG_SVCADM_EXIT_CODE"] = "0"
+        os.environ["PKG_SVCPROP_EXIT_CODE"] = "0"
 
-                testdata_dir = os.path.join(self.test_root, "testdata")
-                svcadm_output = os.path.join(testdata_dir,
-                    "svcadm_arguments")
-                os.environ["PKG_TEST_DIR"] = testdata_dir
-                os.environ["PKG_SVCADM_EXIT_CODE"] = "0"
-                os.environ["PKG_SVCPROP_EXIT_CODE"] = "0"
+        smf.restart("svc:/system/test_restart_svc:default")
+        self.file_contains(
+            svcadm_output, "svcadm restart svc:/system/test_restart_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                smf.restart("svc:/system/test_restart_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm restart svc:/system/test_restart_svc:default")
-                os.unlink(svcadm_output)
+        smf.restart("svc:/system/test_restart_svc:default", sync_timeout=0)
+        self.file_contains(
+            svcadm_output, "svcadm restart svc:/system/test_restart_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                smf.restart("svc:/system/test_restart_svc:default",
-                    sync_timeout=0)
-                self.file_contains(svcadm_output,
-                    "svcadm restart svc:/system/test_restart_svc:default")
-                os.unlink(svcadm_output)
+        smf.restart("svc:/system/test_restart_svc:default", sync_timeout=-1)
+        self.file_contains(
+            svcadm_output,
+            "svcadm restart -s svc:/system/test_restart_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.restart("svc:/system/test_restart_svc:default",
-                    sync_timeout=-1)
-                self.file_contains(svcadm_output,
-                    "svcadm restart -s svc:/system/test_restart_svc:default")
-                os.unlink(svcadm_output)
+        smf.restart("svc:/system/test_restart_svc:default", sync_timeout=10)
+        self.file_contains(
+            svcadm_output,
+            "svcadm restart -s svc:/system/test_restart_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.restart("svc:/system/test_restart_svc:default",
-                    sync_timeout=10)
-                self.file_contains(svcadm_output,
-                    "svcadm restart -s svc:/system/test_restart_svc:default")
-                os.unlink(svcadm_output)
+        smf.refresh("svc:/system/test_refresh_svc:default")
+        self.file_contains(
+            svcadm_output, "svcadm refresh svc:/system/test_refresh_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                smf.refresh("svc:/system/test_refresh_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm refresh svc:/system/test_refresh_svc:default")
-                os.unlink(svcadm_output)
+        smf.refresh("svc:/system/test_refresh_svc:default", sync_timeout=0)
+        self.file_contains(
+            svcadm_output, "svcadm refresh svc:/system/test_refresh_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                smf.refresh("svc:/system/test_refresh_svc:default",
-                    sync_timeout=0)
-                self.file_contains(svcadm_output,
-                    "svcadm refresh svc:/system/test_refresh_svc:default")
-                os.unlink(svcadm_output)
+        smf.refresh("svc:/system/test_refresh_svc:default", sync_timeout=-1)
+        self.file_contains(
+            svcadm_output,
+            "svcadm refresh -s svc:/system/test_refresh_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.refresh("svc:/system/test_refresh_svc:default",
-                    sync_timeout=-1)
-                self.file_contains(svcadm_output,
-                    "svcadm refresh -s svc:/system/test_refresh_svc:default")
-                os.unlink(svcadm_output)
+        smf.refresh("svc:/system/test_refresh_svc:default", sync_timeout=10)
+        self.file_contains(
+            svcadm_output,
+            "svcadm refresh -s svc:/system/test_refresh_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.refresh("svc:/system/test_refresh_svc:default",
-                    sync_timeout=10)
-                self.file_contains(svcadm_output,
-                    "svcadm refresh -s svc:/system/test_refresh_svc:default")
-                os.unlink(svcadm_output)
+        smf.mark("maintenance", "svc:/system/test_mark_svc:default")
+        self.file_contains(
+            svcadm_output,
+            "svcadm mark maintenance svc:/system/test_mark_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.mark("maintenance", "svc:/system/test_mark_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm mark maintenance svc:/system/test_mark_svc:default")
-                os.unlink(svcadm_output)
+        smf.mark("degraded", "svc:/system/test_mark_svc:default")
+        self.file_contains(
+            svcadm_output,
+            "svcadm mark degraded svc:/system/test_mark_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.mark("degraded", "svc:/system/test_mark_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm mark degraded svc:/system/test_mark_svc:default")
-                os.unlink(svcadm_output)
+        smf.disable("svc:/system/test_disable_svc:default")
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s svc:/system/test_disable_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.disable("svc:/system/test_disable_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s svc:/system/test_disable_svc:default")
-                os.unlink(svcadm_output)
+        smf.disable("svc:/system/test_disable_svc:default", temporary=True)
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s -t svc:/system/test_disable_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.disable("svc:/system/test_disable_svc:default",
-                    temporary=True)
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s -t svc:/system/test_disable_svc:default")
-                os.unlink(svcadm_output)
+        smf.enable("svc:/system/test_enable_svc:default")
+        self.file_contains(
+            svcadm_output, "svcadm enable svc:/system/test_enable_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                smf.enable("svc:/system/test_enable_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm enable svc:/system/test_enable_svc:default")
-                os.unlink(svcadm_output)
+        smf.enable("svc:/system/test_enable_svc:default", temporary=True)
+        self.file_contains(
+            svcadm_output,
+            "svcadm enable -t svc:/system/test_enable_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.enable("svc:/system/test_enable_svc:default",
-                    temporary=True)
-                self.file_contains(svcadm_output,
-                    "svcadm enable -t svc:/system/test_enable_svc:default")
-                os.unlink(svcadm_output)
+        smf.enable("svc:/system/test_enable_svc:default", sync_timeout=-1)
+        self.file_contains(
+            svcadm_output,
+            "svcadm enable -s svc:/system/test_enable_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.enable("svc:/system/test_enable_svc:default",
-                    sync_timeout=-1)
-                self.file_contains(svcadm_output,
-                    "svcadm enable -s svc:/system/test_enable_svc:default")
-                os.unlink(svcadm_output)
+        smf.enable("svc:/system/test_enable_svc:default", sync_timeout=0)
+        self.file_contains(
+            svcadm_output, "svcadm enable svc:/system/test_enable_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                smf.enable("svc:/system/test_enable_svc:default",
-                    sync_timeout=0)
-                self.file_contains(svcadm_output,
-                    "svcadm enable svc:/system/test_enable_svc:default")
-                os.unlink(svcadm_output)
+        smf.enable("svc:/system/test_enable_svc:default", sync_timeout=10)
+        self.file_contains(
+            svcadm_output,
+            "svcadm enable -s svc:/system/test_enable_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.enable("svc:/system/test_enable_svc:default",
-                    sync_timeout=10)
-                self.file_contains(svcadm_output,
-                    "svcadm enable -s svc:/system/test_enable_svc:default")
-                os.unlink(svcadm_output)
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
+        self.assertEqual(smf.get_prop("foo", "start/timeout_seconds"), "0")
+        self.assertEqual(smf.get_prop("foo", "stop/exec"), ":true")
 
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
-                self.assertEqual(smf.get_prop("foo", "start/timeout_seconds"),
-                    "0")
-                self.assertEqual(smf.get_prop("foo", "stop/exec"), ":true")
+        p = smf.get_props("foo")
+        self.assertTrue("start/timeout_seconds" in p)
+        self.assertTrue("0" in p["start/timeout_seconds"])
+        self.assertTrue("stop/exec" in p)
+        self.assertTrue("true" in p["stop/exec"])
 
-                p = smf.get_props("foo")
-                self.assertTrue("start/timeout_seconds" in p)
-                self.assertTrue("0" in p["start/timeout_seconds"])
-                self.assertTrue("stop/exec" in p)
-                self.assertTrue("true" in p["stop/exec"])
+        # "a" should be removed from the list of fmris since it's not
+        # an instance.
+        fmris = smf.check_fmris("foo", set(["a"]))
+        self.assertEqual(fmris, set([]))
 
-                # "a" should be removed from the list of fmris since it's not
-                # an instance.
-                fmris = smf.check_fmris("foo", set(["a"]))
-                self.assertEqual(fmris, set([]))
+        fmris = smf.check_fmris("foo", set(["test_disable_svc:default"]))
+        self.assertEqual(fmris, set(["test_disable_svc:default"]))
 
-                fmris = smf.check_fmris("foo",
-                    set(["test_disable_svc:default"]))
-                self.assertEqual(fmris, set(["test_disable_svc:default"]))
+        fmris = smf.check_fmris("foo", set(["test_disable_svc*"]))
+        self.assertEqual(fmris, set(["svc:/system/test_disable_svc:default"]))
 
-                fmris = smf.check_fmris("foo", set(["test_disable_svc*"]))
-                self.assertEqual(fmris,
-                    set(["svc:/system/test_disable_svc:default"]))
+        self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_ENABLED)
+        self.assertTrue(not smf.is_disabled("foo"))
 
-                self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_ENABLED)
-                self.assertTrue(not smf.is_disabled("foo"))
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_disabled"
+        self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_DISABLED)
+        self.assertTrue(smf.is_disabled("foo"))
 
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_disabled"
-                self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_DISABLED)
-                self.assertTrue(smf.is_disabled("foo"))
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_temp_enabled"
+        self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_TMP_ENABLED)
+        self.assertTrue(not smf.is_disabled("foo"))
 
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_temp_enabled"
-                self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_TMP_ENABLED)
-                self.assertTrue(not smf.is_disabled("foo"))
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_temp_enabled2"
+        self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_TMP_ENABLED)
+        self.assertTrue(not smf.is_disabled("foo"))
 
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_temp_enabled2"
-                self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_TMP_ENABLED)
-                self.assertTrue(not smf.is_disabled("foo"))
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_temp_disabled"
+        self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_TMP_DISABLED)
+        self.assertTrue(smf.is_disabled("foo"))
 
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_temp_disabled"
-                self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_TMP_DISABLED)
-                self.assertTrue(smf.is_disabled("foo"))
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_temp_disabled2"
+        self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_TMP_DISABLED)
+        self.assertTrue(smf.is_disabled("foo"))
 
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_temp_disabled2"
-                self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_TMP_DISABLED)
-                self.assertTrue(smf.is_disabled("foo"))
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_maintenance"
+        self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_MAINTENANCE)
+        self.assertTrue(smf.is_disabled("foo"))
 
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_maintenance"
-                self.assertEqual(smf.get_state("foo"), smf.SMF_SVC_MAINTENANCE)
-                self.assertTrue(smf.is_disabled("foo"))
+        # test if supplying tuples and lists as arguments works
+        smf.enable(["svc:/system/test_enable_svc:default", "foo"])
+        self.file_contains(
+            svcadm_output,
+            "svcadm enable svc:/system/test_enable_svc:default foo",
+        )
+        os.unlink(svcadm_output)
+        smf.enable(("svc:/system/test_enable_svc:default", "foo"))
+        self.file_contains(
+            svcadm_output,
+            "svcadm enable svc:/system/test_enable_svc:default foo",
+        )
+        os.unlink(svcadm_output)
 
-                # test if supplying tuples and lists as arguments works
-                smf.enable(["svc:/system/test_enable_svc:default", "foo"])
-                self.file_contains(svcadm_output,
-                    "svcadm enable svc:/system/test_enable_svc:default foo")
-                os.unlink(svcadm_output)
-                smf.enable(("svc:/system/test_enable_svc:default", "foo"))
-                self.file_contains(svcadm_output,
-                    "svcadm enable svc:/system/test_enable_svc:default foo")
-                os.unlink(svcadm_output)
+        smf.disable(["svc:/system/test_enable_svc:default", "foo"])
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s svc:/system/test_enable_svc:default foo",
+        )
+        os.unlink(svcadm_output)
+        smf.disable(("svc:/system/test_enable_svc:default", "foo"))
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s svc:/system/test_enable_svc:default foo",
+        )
+        os.unlink(svcadm_output)
 
-                smf.disable(["svc:/system/test_enable_svc:default", "foo"])
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s svc:/system/test_enable_svc:default foo")
-                os.unlink(svcadm_output)
-                smf.disable(("svc:/system/test_enable_svc:default", "foo"))
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s svc:/system/test_enable_svc:default foo")
-                os.unlink(svcadm_output)
+        smf.refresh(["svc:/system/test_enable_svc:default", "foo"])
+        self.file_contains(
+            svcadm_output,
+            "svcadm refresh svc:/system/test_enable_svc:default foo",
+        )
+        os.unlink(svcadm_output)
+        smf.refresh(("svc:/system/test_enable_svc:default", "foo"))
+        self.file_contains(
+            svcadm_output,
+            "svcadm refresh svc:/system/test_enable_svc:default foo",
+        )
+        os.unlink(svcadm_output)
 
-                smf.refresh(["svc:/system/test_enable_svc:default", "foo"])
-                self.file_contains(svcadm_output,
-                    "svcadm refresh svc:/system/test_enable_svc:default foo")
-                os.unlink(svcadm_output)
-                smf.refresh(("svc:/system/test_enable_svc:default", "foo"))
-                self.file_contains(svcadm_output,
-                    "svcadm refresh svc:/system/test_enable_svc:default foo")
-                os.unlink(svcadm_output)
+        smf.restart(["svc:/system/test_enable_svc:default", "foo"])
+        self.file_contains(
+            svcadm_output,
+            "svcadm restart svc:/system/test_enable_svc:default foo",
+        )
+        os.unlink(svcadm_output)
+        smf.restart(("svc:/system/test_enable_svc:default", "foo"))
+        self.file_contains(
+            svcadm_output,
+            "svcadm restart svc:/system/test_enable_svc:default foo",
+        )
+        os.unlink(svcadm_output)
 
-                smf.restart(["svc:/system/test_enable_svc:default", "foo"])
-                self.file_contains(svcadm_output,
-                    "svcadm restart svc:/system/test_enable_svc:default foo")
-                os.unlink(svcadm_output)
-                smf.restart(("svc:/system/test_enable_svc:default", "foo"))
-                self.file_contains(svcadm_output,
-                    "svcadm restart svc:/system/test_enable_svc:default foo")
-                os.unlink(svcadm_output)
+        smf.mark("degraded", ["svc:/system/test_enable_svc:default", "foo"])
+        self.file_contains(
+            svcadm_output,
+            "svcadm mark degraded svc:/system/test_enable_svc:default foo",
+        )
+        os.unlink(svcadm_output)
+        smf.mark("degraded", ("svc:/system/test_enable_svc:default", "foo"))
+        self.file_contains(
+            svcadm_output,
+            "svcadm mark degraded svc:/system/test_enable_svc:default foo",
+        )
+        os.unlink(svcadm_output)
 
-                smf.mark("degraded", ["svc:/system/test_enable_svc:default", "foo"])
-                self.file_contains(svcadm_output,
-                    "svcadm mark degraded svc:/system/test_enable_svc:default foo")
-                os.unlink(svcadm_output)
-                smf.mark("degraded", ("svc:/system/test_enable_svc:default", "foo"))
-                self.file_contains(svcadm_output,
-                    "svcadm mark degraded svc:/system/test_enable_svc:default foo")
-                os.unlink(svcadm_output)
+    def test_zone_actuators(self):
+        """Test that the smf interface for zones performs as
+        expected."""
 
-        def test_zone_actuators(self):
-                """Test that the smf interface for zones performs as
-                expected."""
+        testdata_dir = os.path.join(self.test_root, "testdata")
+        svcadm_output = os.path.join(testdata_dir, "svcadm_arguments")
+        zlogin_output = os.path.join(testdata_dir, "zlogin_arguments")
+        os.environ["PKG_TEST_DIR"] = testdata_dir
+        DebugValues["bin_zlogin"] = os.path.join(
+            self.test_root, "smf_cmds", "bin_zlogin"
+        )
 
-                testdata_dir = os.path.join(self.test_root, "testdata")
-                svcadm_output = os.path.join(testdata_dir,
-                    "svcadm_arguments")
-                zlogin_output = os.path.join(testdata_dir,
-                    "zlogin_arguments")
-                os.environ["PKG_TEST_DIR"] = testdata_dir
-                DebugValues["bin_zlogin"] = os.path.join(self.test_root,
-                    "smf_cmds", "bin_zlogin")
+        zone = "z1"
 
-                zone = "z1"
+        smf.restart("svc:/system/test_restart_svc:default", zone=zone)
+        self.file_contains(zlogin_output, "zlogin " + zone)
+        os.unlink(zlogin_output)
+        self.file_contains(
+            svcadm_output, "svcadm restart svc:/system/test_restart_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                smf.restart("svc:/system/test_restart_svc:default", zone=zone)
-                self.file_contains(zlogin_output,
-                    "zlogin "+zone)
-                os.unlink(zlogin_output)
-                self.file_contains(svcadm_output,
-                    "svcadm restart svc:/system/test_restart_svc:default")
-                os.unlink(svcadm_output)
+        smf.refresh("svc:/system/test_refresh_svc:default", zone=zone)
+        self.file_contains(zlogin_output, "zlogin " + zone)
+        os.unlink(zlogin_output)
+        self.file_contains(
+            svcadm_output, "svcadm refresh svc:/system/test_refresh_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                smf.refresh("svc:/system/test_refresh_svc:default", zone=zone)
-                self.file_contains(zlogin_output,
-                    "zlogin "+zone)
-                os.unlink(zlogin_output)
-                self.file_contains(svcadm_output,
-                    "svcadm refresh svc:/system/test_refresh_svc:default")
-                os.unlink(svcadm_output)
+        smf.mark("maintenance", "svc:/system/test_mark_svc:default", zone=zone)
+        self.file_contains(zlogin_output, "zlogin " + zone)
+        os.unlink(zlogin_output)
+        self.file_contains(
+            svcadm_output,
+            "svcadm mark maintenance svc:/system/test_mark_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.mark("maintenance", "svc:/system/test_mark_svc:default", zone=zone)
-                self.file_contains(zlogin_output,
-                    "zlogin "+zone)
-                os.unlink(zlogin_output)
-                self.file_contains(svcadm_output,
-                    "svcadm mark maintenance svc:/system/test_mark_svc:default")
-                os.unlink(svcadm_output)
+        smf.enable("svc:/system/test_enable_svc:default", zone=zone)
+        self.file_contains(zlogin_output, "zlogin " + zone)
+        os.unlink(zlogin_output)
+        self.file_contains(
+            svcadm_output, "svcadm enable svc:/system/test_enable_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                smf.enable("svc:/system/test_enable_svc:default", zone=zone)
-                self.file_contains(zlogin_output,
-                    "zlogin "+zone)
-                os.unlink(zlogin_output)
-                self.file_contains(svcadm_output,
-                    "svcadm enable svc:/system/test_enable_svc:default")
-                os.unlink(svcadm_output)
+        smf.disable("svc:/system/test_disable_svc:default", zone=zone)
+        self.file_contains(zlogin_output, "zlogin " + zone)
+        os.unlink(zlogin_output)
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s svc:/system/test_disable_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                smf.disable("svc:/system/test_disable_svc:default", zone=zone)
-                self.file_contains(zlogin_output,
-                    "zlogin "+zone)
-                os.unlink(zlogin_output)
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s svc:/system/test_disable_svc:default")
-                os.unlink(svcadm_output)
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
+        smf.get_prop("foo", "start/timeout_seconds", zone=zone)
+        self.file_contains(zlogin_output, "zlogin " + zone)
+        os.unlink(zlogin_output)
 
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
-                smf.get_prop("foo", "start/timeout_seconds", zone=zone)
-                self.file_contains(zlogin_output,
-                    "zlogin "+zone)
-                os.unlink(zlogin_output)
+        smf.is_disabled("foo", zone=zone)
+        self.file_contains(zlogin_output, "zlogin " + zone)
+        os.unlink(zlogin_output)
 
-                smf.is_disabled("foo", zone=zone)
-                self.file_contains(zlogin_output,
-                    "zlogin "+zone)
-                os.unlink(zlogin_output)
+        smf.get_state("foo", zone=zone)
+        self.file_contains(zlogin_output, "zlogin " + zone)
+        os.unlink(zlogin_output)
 
-                smf.get_state("foo", zone=zone)
-                self.file_contains(zlogin_output,
-                    "zlogin "+zone)
-                os.unlink(zlogin_output)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_solver.py
+++ b/src/tests/api/t_solver.py
@@ -25,37 +25,39 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 
 import pkg5unittest
 import pkg.solver as solver
 import os
 import sys
 
+
 class TestSolver(pkg5unittest.Pkg5TestCase):
+    def test_no_solution(self):
+        cnf_test(failing_test_case.splitlines())
 
-        def test_no_solution(self):
-                cnf_test(failing_test_case.splitlines())
+    def test_solution(self):
+        cnf_test(working_test_case.splitlines())
 
-        def test_solution(self):
-                cnf_test(working_test_case.splitlines())
 
 def cnf_test(lines):
-        s = solver.msat_solver()
-        
-        for l in lines:
-                if l and l[0] in 'pc%0':
-                        pass # comment
-                else:
-                        # skip trailing 0
-                        cl = [int(i) for i in l.split()[0:-1]]
-                        if cl and not s.add_clause(cl):
-                                return False
-        # create new copy of solver instance to test copy code
-        n = solver.msat_solver(s)
-        del s # force gc of old solver instance
-        return n.solve([])
+    s = solver.msat_solver()
+
+    for l in lines:
+        if l and l[0] in "pc%0":
+            pass  # comment
+        else:
+            # skip trailing 0
+            cl = [int(i) for i in l.split()[0:-1]]
+            if cl and not s.add_clause(cl):
+                return False
+    # create new copy of solver instance to test copy code
+    n = solver.msat_solver(s)
+    del s  # force gc of old solver instance
+    return n.solve([])
 
 
 failing_test_case = """
@@ -2214,7 +2216,7 @@ p cnf 250  1065
 """
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_sysattr.py
+++ b/src/tests/api/t_sysattr.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import pkg.portable as portable
@@ -33,130 +34,125 @@ import re
 import tempfile
 import unittest
 
+
 class TestSysattr(pkg5unittest.Pkg5TestCase):
+    def __check_sysattrs(self, path, expected=[]):
+        """Use ls -/ to check if sysattrs specified by expected are
+        set."""
 
-        def __check_sysattrs(self, path, expected=[]):
-                """Use ls -/ to check if sysattrs specified by expected are
-                   set."""
+        p_re = re.compile("{(?P<attrs>.*)}")
 
-                p_re = re.compile("{(?P<attrs>.*)}")
+        self.cmdline_run("/usr/bin/ls -/ v {0}".format(path), coverage=False)
+        m = re.search(p_re, self.output)
 
-                self.cmdline_run("/usr/bin/ls -/ v {0}".format(path), coverage=False)
-                m = re.search(p_re, self.output)
+        self.assertTrue(m is not None)
 
-                self.assertTrue(m is not None)
+        attrs = m.groupdict()["attrs"].split(",")
+        for e in expected:
+            self.assertTrue(e in attrs)
 
-                attrs = m.groupdict()["attrs"].split(",")
-                for e in expected:
-                        self.assertTrue(e in attrs)
+    def __reset_file(self):
+        """Remove and recreate test file to clear sys attrs."""
+        portable.remove(self.test_fn)
+        self.test_fh, self.test_fn = tempfile.mkstemp(dir=self.test_path)
 
-        def __reset_file(self):
-                """Remove and recreate test file to clear sys attrs."""
-                portable.remove(self.test_fn)
-                self.test_fh, self.test_fn = tempfile.mkstemp(
-                    dir=self.test_path)
+    def __get_supported(self):
+        supported = portable.get_sysattr_dict()
+        # remove "immutable" and "nounlink"
+        # We can't unset system attributes and we can't use chmod
+        # for unsetting them due to the missing sys_linkdir privilege
+        # which gets removed in run.py.
+        del supported["immutable"]
+        del supported["nounlink"]
 
-        def __get_supported(self):
-                supported = portable.get_sysattr_dict()
-                # remove "immutable" and "nounlink"
-                # We can't unset system attributes and we can't use chmod
-                # for unsetting them due to the missing sys_linkdir privilege
-                # which gets removed in run.py.
-                del supported["immutable"]
-                del supported["nounlink"]
+        return supported
 
-                return supported
+    def setUp(self):
+        if portable.osname != "sunos":
+            raise pkg5unittest.TestSkippedException(
+                "System attributes unsupported on this platform."
+            )
 
-        def setUp(self):
-                if portable.osname != "sunos":
-                        raise pkg5unittest.TestSkippedException(
-                            "System attributes unsupported on this platform.")
+        self.test_path = tempfile.mkdtemp(prefix="test-suite", dir="/var/tmp")
+        self.test_fh, self.test_fn = tempfile.mkstemp(dir=self.test_path)
+        self.unsup_test_path = tempfile.mkdtemp(prefix="test-suite", dir="/tmp")
+        self.test_fh2, self.test_fn2 = tempfile.mkstemp(
+            dir=self.unsup_test_path
+        )
 
-                self.test_path = tempfile.mkdtemp(prefix="test-suite",
-                    dir="/var/tmp")
-                self.test_fh, self.test_fn = tempfile.mkstemp(
-                    dir=self.test_path)
-                self.unsup_test_path = tempfile.mkdtemp(prefix="test-suite",
-                    dir="/tmp")
-                self.test_fh2, self.test_fn2 = tempfile.mkstemp(
-                    dir=self.unsup_test_path)
+    def tearDown(self):
+        portable.remove(self.test_fn)
+        portable.remove(self.test_fn2)
+        os.rmdir(self.test_path)
+        os.rmdir(self.unsup_test_path)
 
-        def tearDown(self):
-                portable.remove(self.test_fn)
-                portable.remove(self.test_fn2)
-                os.rmdir(self.test_path)
-                os.rmdir(self.unsup_test_path)
+    def test_0_bad_input(self):
+        # fsetattr
+        self.assertRaises(TypeError, portable.fsetattr, self.test_fn, None)
+        self.assertRaises(
+            ValueError, portable.fsetattr, self.test_fn, ["octopus"]
+        )
+        self.assertRaises(ValueError, portable.fsetattr, self.test_fn, "xyz")
+        self.assertRaises(OSError, portable.fsetattr, "/nofile", "H")
+        # FS does not support system attributes.
+        self.assertRaises(OSError, portable.fsetattr, self.test_fn2, "H")
 
-        def test_0_bad_input(self):
-                # fsetattr
-                self.assertRaises(TypeError, portable.fsetattr, self.test_fn,
-                    None)
-                self.assertRaises(ValueError, portable.fsetattr, self.test_fn,
-                    ["octopus"])
-                self.assertRaises(ValueError, portable.fsetattr, self.test_fn,
-                    "xyz")
-                self.assertRaises(OSError, portable.fsetattr, "/nofile",
-                    "H")
-                # FS does not support system attributes.
-                self.assertRaises(OSError, portable.fsetattr, self.test_fn2,
-                    "H")
+        # fgetattr
+        self.assertRaises(OSError, portable.fgetattr, "/nofile")
 
-                # fgetattr
-                self.assertRaises(OSError, portable.fgetattr, "/nofile")
+    def test_1_supported_dict(self):
+        """Check if the supported sys attr dictionary can be retrieved
+        and contains some attributes."""
 
-        def test_1_supported_dict(self):
-                """Check if the supported sys attr dictionary can be retrieved
-                   and contains some attributes."""
+        supported = portable.get_sysattr_dict()
+        self.assertTrue(len(supported))
 
-                supported = portable.get_sysattr_dict()
-                self.assertTrue(len(supported))
+    def test_2_fsetattr(self):
+        """Check if the fsetattr works with all supported attrs."""
+        supported = self.__get_supported()
 
-        def test_2_fsetattr(self):
-                """Check if the fsetattr works with all supported attrs."""
-                supported = self.__get_supported()
+        # try to set all supported verbose attrs
+        for a in supported:
+            portable.fsetattr(self.test_fn, [a])
+            self.__check_sysattrs(self.test_fn, [a])
+            self.__reset_file()
 
-                # try to set all supported verbose attrs
-                for a in supported:
-                        portable.fsetattr(self.test_fn, [a])
-                        self.__check_sysattrs(self.test_fn, [a])
-                        self.__reset_file()
+        # try to set all supported compact attrs
+        for a in supported:
+            portable.fsetattr(self.test_fn, supported[a])
+            self.__check_sysattrs(self.test_fn, [a])
+            self.__reset_file()
 
-                # try to set all supported compact attrs
-                for a in supported:
-                        portable.fsetattr(self.test_fn, supported[a])
-                        self.__check_sysattrs(self.test_fn, [a])
-                        self.__reset_file()
+        # set all at once using verbose
+        portable.fsetattr(self.test_fn, supported)
+        self.__check_sysattrs(self.test_fn, supported)
+        self.__reset_file()
 
-                # set all at once using verbose
-                portable.fsetattr(self.test_fn, supported)
-                self.__check_sysattrs(self.test_fn, supported)
-                self.__reset_file()
+        # set all at once using compact
+        cattrs = ""
+        for a in supported:
+            cattrs += supported[a]
+        portable.fsetattr(self.test_fn, cattrs)
+        self.__check_sysattrs(self.test_fn, supported)
+        self.__reset_file()
 
-                # set all at once using compact
-                cattrs = ""
-                for a in supported:
-                        cattrs += supported[a]
-                portable.fsetattr(self.test_fn, cattrs)
-                self.__check_sysattrs(self.test_fn, supported)
-                self.__reset_file()
-
-        def test_3_fgetattr(self):
-                """Check if the fgetattr works with all supported attrs.""" 
-                supported = self.__get_supported()
-                for a in supported:
-                        # av_quarantined file becomes unreadable, skip
-                        if a == "av_quarantined":
-                                continue
-                        portable.fsetattr(self.test_fn, [a])
-                        vattrs = portable.fgetattr(self.test_fn, compact=False)
-                        cattrs = portable.fgetattr(self.test_fn, compact=True)
-                        self.assertTrue(a in vattrs)
-                        self.assertTrue(supported[a] in cattrs)
-                        self.__reset_file()
+    def test_3_fgetattr(self):
+        """Check if the fgetattr works with all supported attrs."""
+        supported = self.__get_supported()
+        for a in supported:
+            # av_quarantined file becomes unreadable, skip
+            if a == "av_quarantined":
+                continue
+            portable.fsetattr(self.test_fn, [a])
+            vattrs = portable.fgetattr(self.test_fn, compact=False)
+            cattrs = portable.fgetattr(self.test_fn, compact=True)
+            self.assertTrue(a in vattrs)
+            self.assertTrue(supported[a] in cattrs)
+            self.__reset_file()
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_unix_usergrp.py
+++ b/src/tests/api/t_unix_usergrp.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -36,19 +37,19 @@ import sys
 import tempfile
 import pkg.portable as portable
 
+
 class TestUserGroup(pkg5unittest.Pkg5TestCase):
+    def setUp(self):
+        pkg5unittest.Pkg5TestCase.setUp(self)
+        os.makedirs(os.path.join(self.test_root, "etc"))
 
-        def setUp(self):
-                pkg5unittest.Pkg5TestCase.setUp(self)
-                os.makedirs(os.path.join(self.test_root, "etc"))
+    def testGroup1(self):
+        if not os.path.exists("/etc/group"):
+            return
 
-        def testGroup1(self):
-                if not os.path.exists("/etc/group"):
-                        return
-
-                grpfile = open(os.path.join(self.test_root, "etc", "group"), "w")
-                grpfile.write( \
-"""root::0:
+        grpfile = open(os.path.join(self.test_root, "etc", "group"), "w")
+        grpfile.write(
+            """root::0:
 gk::0:
 other::1:root
 bin::2:root,daemon
@@ -56,43 +57,58 @@ sys::3:root,bin,adm
 adm::4:root,daemon
 uucp::5:root
 mail::6:root
-tty::7:root,adm""")
-                grpfile.close()
+tty::7:root,adm"""
+        )
+        grpfile.close()
 
-                self.assertRaises(KeyError, portable.get_group_by_name,
-                    "ThisShouldNotExist", self.test_root, True)
+        self.assertRaises(
+            KeyError,
+            portable.get_group_by_name,
+            "ThisShouldNotExist",
+            self.test_root,
+            True,
+        )
 
-                self.assertTrue(0 == \
-                    portable.get_group_by_name("root", self.test_root, True))
-                self.assertTrue(0 == \
-                    portable.get_group_by_name("gk", self.test_root, True))
+        self.assertTrue(
+            0 == portable.get_group_by_name("root", self.test_root, True)
+        )
+        self.assertTrue(
+            0 == portable.get_group_by_name("gk", self.test_root, True)
+        )
 
-                self.assertRaises(KeyError, portable.get_name_by_gid,
-                    12345, self.test_root, True)
+        self.assertRaises(
+            KeyError, portable.get_name_by_gid, 12345, self.test_root, True
+        )
 
-        def testGroup2(self):
-                """ Test with a missing group file """
-                if not os.path.exists("/etc/group"):
-                        return
+    def testGroup2(self):
+        """Test with a missing group file"""
+        if not os.path.exists("/etc/group"):
+            return
 
-                self.assertRaises(KeyError, portable.get_group_by_name,
-                    "ThisShouldNotExist", self.test_root, True)
+        self.assertRaises(
+            KeyError,
+            portable.get_group_by_name,
+            "ThisShouldNotExist",
+            self.test_root,
+            True,
+        )
 
-                # This should work on unix systems, since we'll "bootstrap"
-                # out to the OS's version.  And AFAIK all unix systems have
-                # a group with gid 0.
-                grpname = portable.get_name_by_gid(0, self.test_root, True)
-                self.assertTrue(0 == \
-                    portable.get_group_by_name(grpname, self.test_root, True))
+        # This should work on unix systems, since we'll "bootstrap"
+        # out to the OS's version.  And AFAIK all unix systems have
+        # a group with gid 0.
+        grpname = portable.get_name_by_gid(0, self.test_root, True)
+        self.assertTrue(
+            0 == portable.get_group_by_name(grpname, self.test_root, True)
+        )
 
-        def testGroup3(self):
-                """ Test with corrupt/oddball group file """
-                if not os.path.exists("/etc/group"):
-                        return
+    def testGroup3(self):
+        """Test with corrupt/oddball group file"""
+        if not os.path.exists("/etc/group"):
+            return
 
-                grpfile = open(os.path.join(self.test_root, "etc", "group"), "w")
-                grpfile.write( \
-"""root::0:
+        grpfile = open(os.path.join(self.test_root, "etc", "group"), "w")
+        grpfile.write(
+            """root::0:
 blorg
 bin::2:root,daemon
 
@@ -102,35 +118,51 @@ uucp::5:root
 mail::6:root
 tty::7:root,adm
 gk::0:
-+""")
-                grpfile.close()
-                self.assertTrue("root" == \
-                    portable.get_name_by_gid(0, self.test_root, True))
-                self.assertTrue(0 == \
-                    portable.get_group_by_name("root", self.test_root, True))
-                self.assertTrue(0 == \
-                    portable.get_group_by_name("gk", self.test_root, True))
-                self.assertTrue(7 == \
-                    portable.get_group_by_name("tty", self.test_root, True))
++"""
+        )
+        grpfile.close()
+        self.assertTrue(
+            "root" == portable.get_name_by_gid(0, self.test_root, True)
+        )
+        self.assertTrue(
+            0 == portable.get_group_by_name("root", self.test_root, True)
+        )
+        self.assertTrue(
+            0 == portable.get_group_by_name("gk", self.test_root, True)
+        )
+        self.assertTrue(
+            7 == portable.get_group_by_name("tty", self.test_root, True)
+        )
 
-                self.assertRaises(KeyError, portable.get_group_by_name,
-                    "ThisShouldNotExist", self.test_root, True)
+        self.assertRaises(
+            KeyError,
+            portable.get_group_by_name,
+            "ThisShouldNotExist",
+            self.test_root,
+            True,
+        )
 
-                self.assertRaises(KeyError, portable.get_group_by_name,
-                    "corrupt", self.test_root, True)
+        self.assertRaises(
+            KeyError,
+            portable.get_group_by_name,
+            "corrupt",
+            self.test_root,
+            True,
+        )
 
-                self.assertRaises(KeyError, portable.get_group_by_name,
-                    570, self.test_root, True)
+        self.assertRaises(
+            KeyError, portable.get_group_by_name, 570, self.test_root, True
+        )
 
-        def testGroup4(self):
-                """ Test with a group name line in the group file that
-                starts with a "+". (See bug #4470 for more details). """
-                if not os.path.exists("/etc/group"):
-                        return
+    def testGroup4(self):
+        """Test with a group name line in the group file that
+        starts with a "+". (See bug #4470 for more details)."""
+        if not os.path.exists("/etc/group"):
+            return
 
-                grpfile = open(os.path.join(self.test_root, "etc", "group"), "w")
-                grpfile.write( \
-"""root::0:
+        grpfile = open(os.path.join(self.test_root, "etc", "group"), "w")
+        grpfile.write(
+            """root::0:
 gk::0:
 bin::2:root,daemon
 +plusgrp
@@ -138,28 +170,37 @@ adm::4:root,daemon
 uucp::5:root
 mail::6:root
 tty::7:root,adm
-+""")
-                grpfile.close()
-                self.assertTrue("root" == \
-                    portable.get_name_by_gid(0, self.test_root, True))
-                self.assertTrue(0 == \
-                    portable.get_group_by_name("root", self.test_root, True))
-                self.assertTrue(0 == \
-                    portable.get_group_by_name("gk", self.test_root, True))
-                self.assertTrue(7 == \
-                    portable.get_group_by_name("tty", self.test_root, True))
++"""
+        )
+        grpfile.close()
+        self.assertTrue(
+            "root" == portable.get_name_by_gid(0, self.test_root, True)
+        )
+        self.assertTrue(
+            0 == portable.get_group_by_name("root", self.test_root, True)
+        )
+        self.assertTrue(
+            0 == portable.get_group_by_name("gk", self.test_root, True)
+        )
+        self.assertTrue(
+            7 == portable.get_group_by_name("tty", self.test_root, True)
+        )
 
-                self.assertRaises(KeyError, portable.get_group_by_name,
-                    "plusgrp", self.test_root, True)
+        self.assertRaises(
+            KeyError,
+            portable.get_group_by_name,
+            "plusgrp",
+            self.test_root,
+            True,
+        )
 
+    def testUser1(self):
+        if not os.path.exists("/etc/passwd"):
+            return
 
-        def testUser1(self):
-                if not os.path.exists("/etc/passwd"):
-                        return
-
-                passwd = open(os.path.join(self.test_root, "etc", "passwd"), "w")
-                passwd.write( \
-"""root:x:0:0::/root:/usr/bin/bash
+        passwd = open(os.path.join(self.test_root, "etc", "passwd"), "w")
+        passwd.write(
+            """root:x:0:0::/root:/usr/bin/bash
 gk:x:0:0::/root:/usr/bin/bash
 daemon:x:1:1::/:
 bin:x:2:2::/usr/bin:
@@ -167,47 +208,62 @@ sys:x:3:3::/:
 adm:x:4:4:Admin:/var/adm:
 lp:x:71:8:Line Printer Admin:/usr/spool/lp:
 uucp:x:5:5:uucp Admin:/usr/lib/uucp:
-moop:x:999:999:moop:/usr/moop:""")
-                passwd.close()
+moop:x:999:999:moop:/usr/moop:"""
+        )
+        passwd.close()
 
-                self.assertRaises(KeyError, portable.get_user_by_name,
-                    "ThisShouldNotExist", self.test_root, True)
+        self.assertRaises(
+            KeyError,
+            portable.get_user_by_name,
+            "ThisShouldNotExist",
+            self.test_root,
+            True,
+        )
 
-                self.assertTrue(0 == \
-                    portable.get_user_by_name("root", self.test_root, True))
-                self.assertTrue(0 == \
-                    portable.get_user_by_name("gk", self.test_root, True))
-                self.assertTrue(999 == \
-                    portable.get_user_by_name("moop", self.test_root, True))
+        self.assertTrue(
+            0 == portable.get_user_by_name("root", self.test_root, True)
+        )
+        self.assertTrue(
+            0 == portable.get_user_by_name("gk", self.test_root, True)
+        )
+        self.assertTrue(
+            999 == portable.get_user_by_name("moop", self.test_root, True)
+        )
 
-                self.assertRaises(KeyError, portable.get_name_by_uid,
-                    12345, self.test_root, True)
+        self.assertRaises(
+            KeyError, portable.get_name_by_uid, 12345, self.test_root, True
+        )
 
+    def testUser2(self):
+        """Test with a missing passwd file"""
+        if not os.path.exists("/etc/passwd"):
+            return
 
-        def testUser2(self):
-                """ Test with a missing passwd file """
-                if not os.path.exists("/etc/passwd"):
-                        return
+        self.assertRaises(
+            KeyError,
+            portable.get_user_by_name,
+            "ThisShouldNotExist",
+            self.test_root,
+            True,
+        )
 
-                self.assertRaises(KeyError, portable.get_user_by_name,
-                    "ThisShouldNotExist", self.test_root, True)
+        # This should work on unix systems, since we'll "bootstrap"
+        # out to the OS's version.
+        self.assertTrue(
+            0 == portable.get_user_by_name("root", self.test_root, True)
+        )
+        self.assertTrue(
+            "root" == portable.get_name_by_uid(0, self.test_root, True)
+        )
 
-                # This should work on unix systems, since we'll "bootstrap"
-                # out to the OS's version.
-                self.assertTrue(0 == \
-                    portable.get_user_by_name("root", self.test_root, True))
-                self.assertTrue("root" == \
-                    portable.get_name_by_uid(0, self.test_root, True))
+    def testUser3(self):
+        """Test with an oddball/corrupt passwd file"""
+        if not os.path.exists("/etc/passwd"):
+            return
 
-
-        def testUser3(self):
-                """ Test with an oddball/corrupt passwd file """
-                if not os.path.exists("/etc/passwd"):
-                        return
-
-                passwd = open(os.path.join(self.test_root, "etc", "passwd"), "w")
-                passwd.write( \
-"""root:x:0:0::/root:/usr/bin/bash
+        passwd = open(os.path.join(self.test_root, "etc", "passwd"), "w")
+        passwd.write(
+            """root:x:0:0::/root:/usr/bin/bash
 daemon:x:1:1::/:
 bin:x:2:2::/usr/bin:
 sys:x:3:3::/:
@@ -219,33 +275,44 @@ gk:x:0:0::/root:/usr/bin/bash
 adm:x:4:4:Admin:/var/adm:
 lp:x:71:8:Line Printer Admin:/usr/spool/lp:
 uucp:x:5:5:uucp Admin:/usr/lib/uucp:
-+""")
-                passwd.close()
-                self.assertTrue(0 == \
-                    portable.get_user_by_name("root", self.test_root, True))
-                self.assertTrue(0 == \
-                    portable.get_user_by_name("gk", self.test_root, True))
-                self.assertTrue("uucp" == \
-                    portable.get_name_by_uid(5, self.test_root, True))
++"""
+        )
+        passwd.close()
+        self.assertTrue(
+            0 == portable.get_user_by_name("root", self.test_root, True)
+        )
+        self.assertTrue(
+            0 == portable.get_user_by_name("gk", self.test_root, True)
+        )
+        self.assertTrue(
+            "uucp" == portable.get_name_by_uid(5, self.test_root, True)
+        )
 
-                self.assertRaises(KeyError, portable.get_user_by_name,
-                    "ThisShouldNotExist", self.test_root, True)
+        self.assertRaises(
+            KeyError,
+            portable.get_user_by_name,
+            "ThisShouldNotExist",
+            self.test_root,
+            True,
+        )
 
-                self.assertRaises(KeyError, portable.get_user_by_name,
-                    "corrupt", self.test_root, True)
+        self.assertRaises(
+            KeyError, portable.get_user_by_name, "corrupt", self.test_root, True
+        )
 
-                self.assertRaises(KeyError, portable.get_user_by_name,
-                    999, self.test_root, True)
+        self.assertRaises(
+            KeyError, portable.get_user_by_name, 999, self.test_root, True
+        )
 
-        def testUser4(self):
-                """ Test with a user name line in the passwd file that
-                starts with a "+". (See bug #4470 for more details). """
-                if not os.path.exists("/etc/passwd"):
-                        return
+    def testUser4(self):
+        """Test with a user name line in the passwd file that
+        starts with a "+". (See bug #4470 for more details)."""
+        if not os.path.exists("/etc/passwd"):
+            return
 
-                passwd = open(os.path.join(self.test_root, "etc", "passwd"), "w")
-                passwd.write( \
-"""root:x:0:0::/root:/usr/bin/bash
+        passwd = open(os.path.join(self.test_root, "etc", "passwd"), "w")
+        passwd.write(
+            """root:x:0:0::/root:/usr/bin/bash
 gk:x:0:0::/root:/usr/bin/bash
 daemon:x:1:1::/:
 bin:x:2:2::/usr/bin:
@@ -254,23 +321,33 @@ sys:x:3:3::/:
 adm:x:4:4:Admin:/var/adm:
 lp:x:71:8:Line Printer Admin:/usr/spool/lp:
 uucp:x:5:5:uucp Admin:/usr/lib/uucp:
-+""")
-                passwd.close()
-                self.assertTrue(0 == \
-                    portable.get_user_by_name("root", self.test_root, True))
-                self.assertTrue(0 == \
-                    portable.get_user_by_name("gk", self.test_root, True))
-                self.assertTrue("root" == \
-                    portable.get_name_by_uid(0, self.test_root, True))
-                self.assertTrue("uucp" == \
-                    portable.get_name_by_uid(5, self.test_root, True))
++"""
+        )
+        passwd.close()
+        self.assertTrue(
+            0 == portable.get_user_by_name("root", self.test_root, True)
+        )
+        self.assertTrue(
+            0 == portable.get_user_by_name("gk", self.test_root, True)
+        )
+        self.assertTrue(
+            "root" == portable.get_name_by_uid(0, self.test_root, True)
+        )
+        self.assertTrue(
+            "uucp" == portable.get_name_by_uid(5, self.test_root, True)
+        )
 
-                self.assertRaises(KeyError, portable.get_user_by_name,
-                    "plususer", self.test_root, True)
+        self.assertRaises(
+            KeyError,
+            portable.get_user_by_name,
+            "plususer",
+            self.test_root,
+            True,
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_variant.py
+++ b/src/tests/api/t_variant.py
@@ -26,157 +26,164 @@
 
 import copy
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
 import pkg.variant as variant
 
+
 class TestVariants(pkg5unittest.Pkg5TestCase):
+    def __check_equal(self, v1, v2):
+        self.assertEqual(sorted(v1.keys()), sorted(v2.keys()))
+        for k in v1:
+            self.assertEqual(sorted(v1[k]), sorted(v2[k]))
 
-        def __check_equal(self, v1, v2):
-                self.assertEqual(sorted(v1.keys()), sorted(v2.keys()))
-                for k in v1:
-                        self.assertEqual(sorted(v1[k]), sorted(v2[k]))
+    def test_vct(self):
+        """Test functionality of VariantCombinationTemplates."""
 
+        vct_1 = variant.VariantCombinationTemplate(
+            dict([(1, ["a", "b", "c"]), (2, ["z", "y", "x"])])
+        )
+        self.assertEqual(vct_1[1], set(["a", "b", "c"]))
+        self.assertTrue(vct_1.issubset(vct_1))
+        self.assertEqual(str(vct_1), ' 1="a","b","c" 2="x","y","z"')
 
-        def test_vct(self):
-                """Test functionality of VariantCombinationTemplates."""
+        vct_2 = variant.VariantCombinationTemplate(
+            dict([(1, ["a", "b"]), (2, ["z", "y"])])
+        )
+        self.assertTrue(vct_2.issubset(vct_1))
+        self.assertTrue(not vct_1.issubset(vct_2))
+        vct_2.merge_unknown(vct_1)
+        self.assertEqual(vct_2[1], set(["a", "b"]))
+        self.assertEqual(vct_2[2], set(["z", "y"]))
 
-                vct_1 = variant.VariantCombinationTemplate(
-                    dict([(1, ["a", "b", "c"]), (2, ["z", "y", "x"])]))
-                self.assertEqual(vct_1[1], set(["a", "b", "c"]))
-                self.assertTrue(vct_1.issubset(vct_1))
-                self.assertEqual(str(vct_1), ' 1="a","b","c" 2="x","y","z"')
+        vct_3 = variant.VariantCombinationTemplate(dict([(1, ["a", "b", "c"])]))
+        self.assertTrue(vct_3.issubset(vct_1))
+        self.assertTrue(not vct_1.issubset(vct_3))
+        vct_3.merge_unknown(vct_1)
+        self.assertEqual(vct_1, vct_3)
 
-                vct_2 = variant.VariantCombinationTemplate(
-                    dict([(1, ["a", "b"]), (2, ["z", "y"])]))
-                self.assertTrue(vct_2.issubset(vct_1))
-                self.assertTrue(not vct_1.issubset(vct_2))
-                vct_2.merge_unknown(vct_1)
-                self.assertEqual(vct_2[1], set(["a", "b"]))
-                self.assertEqual(vct_2[2], set(["z", "y"]))
+        vct_3 = variant.VariantCombinationTemplate(dict([(1, ["a", "b", "c"])]))
+        vct_m = variant.VariantCombinationTemplate(set([]))
+        vct_m.merge_values(vct_3)
+        self.assertEqual(vct_m, vct_3)
+        vct_m.merge_values(vct_2)
+        self.assertEqual(vct_m[1], set(["a", "b", "c"]))
+        self.assertEqual(vct_m[2], set(["z", "y"]))
+        self.assertEqual(vct_3[1], set(["a", "b", "c"]))
+        self.assertTrue(2 not in vct_3)
+        vct_m.merge_values(vct_1)
+        self.assertEqual(str(vct_m), ' 1="a","b","c" 2="x","y","z"')
+        self.assertEqual(vct_2[1], set(["a", "b"]))
+        self.assertEqual(vct_2[2], set(["z", "y"]))
+        vct_m.merge_values(vct_2)
+        self.assertEqual(str(vct_m), ' 1="a","b","c" 2="x","y","z"')
 
-                vct_3 = variant.VariantCombinationTemplate(
-                    dict([(1, ["a", "b", "c"])]))
-                self.assertTrue(vct_3.issubset(vct_1))
-                self.assertTrue(not vct_1.issubset(vct_3))
-                vct_3.merge_unknown(vct_1)
-                self.assertEqual(vct_1, vct_3)
+    def test_variant_combinations(self):
+        """Test functionality of VariantCombinations."""
 
-                vct_3 = variant.VariantCombinationTemplate(
-                    dict([(1, ["a", "b", "c"])]))
-                vct_m = variant.VariantCombinationTemplate(set([]))
-                vct_m.merge_values(vct_3)
-                self.assertEqual(vct_m, vct_3)
-                vct_m.merge_values(vct_2)
-                self.assertEqual(vct_m[1], set(["a", "b", "c"]))
-                self.assertEqual(vct_m[2], set(["z", "y"]))
-                self.assertEqual(vct_3[1], set(["a", "b", "c"]))
-                self.assertTrue(2 not in vct_3)
-                vct_m.merge_values(vct_1)
-                self.assertEqual(str(vct_m), ' 1="a","b","c" 2="x","y","z"')
-                self.assertEqual(vct_2[1], set(["a", "b"]))
-                self.assertEqual(vct_2[2], set(["z", "y"]))
-                vct_m.merge_values(vct_2)
-                self.assertEqual(str(vct_m), ' 1="a","b","c" 2="x","y","z"')
+        vct_1 = variant.VariantCombinationTemplate(
+            dict([(1, ["a", "b", "c"]), (2, ["z", "y", "x"])])
+        )
+        vct_2 = variant.VariantCombinationTemplate(
+            dict([(10, ["l", "m", "n"]), (20, ["p", "q", "r"])])
+        )
+        vct_3 = variant.VariantCombinationTemplate(
+            dict([(1, ["a"]), (2, ["z"])])
+        )
+        vct_4 = variant.VariantCombinationTemplate(
+            dict([(1, ["a", "b", "d"]), (2, ["z", "y", "x"])])
+        )
+        set_combo = set(
+            [
+                frozenset([(1, "a"), (2, "z")]),
+                frozenset([(1, "a"), (2, "y")]),
+                frozenset([(1, "a"), (2, "x")]),
+                frozenset([(1, "b"), (2, "z")]),
+                frozenset([(1, "b"), (2, "y")]),
+                frozenset([(1, "b"), (2, "x")]),
+                frozenset([(1, "c"), (2, "z")]),
+                frozenset([(1, "c"), (2, "y")]),
+                frozenset([(1, "c"), (2, "x")]),
+            ]
+        )
+        vc1_s = variant.VariantCombinations(vct_1, True)
+        self.assertEqual(vc1_s.sat_set, set_combo)
+        self.assertEqual(vc1_s.not_sat_set, set())
+        self.assertTrue(not vc1_s.is_empty())
 
-        def test_variant_combinations(self):
-                """Test functionality of VariantCombinations."""
+        vc1_ns = variant.VariantCombinations(vct_1, False)
+        self.assertEqual(vc1_ns.not_sat_set, set_combo)
+        self.assertEqual(vc1_ns.sat_set, set())
+        self.assertTrue(not vc1_ns.is_empty())
 
-                vct_1 = variant.VariantCombinationTemplate(
-                    dict([(1, ["a", "b", "c"]), (2, ["z", "y", "x"])]))
-                vct_2 = variant.VariantCombinationTemplate(
-                    dict([(10, ["l", "m", "n"]), (20, ["p", "q", "r"])]))
-                vct_3 = variant.VariantCombinationTemplate(
-                    dict([(1, ["a"]), (2, ["z"])]))
-                vct_4 = variant.VariantCombinationTemplate(
-                    dict([(1, ["a", "b", "d"]), (2, ["z", "y", "x"])]))
-                set_combo = set([
-                    frozenset([(1, "a"), (2, "z")]),
-                    frozenset([(1, "a"), (2, "y")]),
-                    frozenset([(1, "a"), (2, "x")]),
-                    frozenset([(1, "b"), (2, "z")]),
-                    frozenset([(1, "b"), (2, "y")]),
-                    frozenset([(1, "b"), (2, "x")]),
-                    frozenset([(1, "c"), (2, "z")]),
-                    frozenset([(1, "c"), (2, "y")]),
-                    frozenset([(1, "c"), (2, "x")])])
-                vc1_s = variant.VariantCombinations(vct_1, True)
-                self.assertEqual(vc1_s.sat_set, set_combo)
-                self.assertEqual(vc1_s.not_sat_set, set())
-                self.assertTrue(not vc1_s.is_empty())
-                
-                vc1_ns = variant.VariantCombinations(vct_1, False)
-                self.assertEqual(vc1_ns.not_sat_set, set_combo)
-                self.assertEqual(vc1_ns.sat_set, set())
-                self.assertTrue(not vc1_ns.is_empty())
+        self.assertRaises(AssertionError, vc1_ns.simplify, vct_2)
+        self.assertEqual(vc1_ns.not_sat_set, set_combo)
+        self.assertEqual(vc1_ns.sat_set, set())
+        self.assertTrue(not vc1_ns.is_empty())
 
-                self.assertRaises(AssertionError, vc1_ns.simplify, vct_2)
-                self.assertEqual(vc1_ns.not_sat_set, set_combo)
-                self.assertEqual(vc1_ns.sat_set, set())
-                self.assertTrue(not vc1_ns.is_empty())
+        self.assertRaises(AssertionError, vc1_ns.simplify, vct_4)
+        self.assertEqual(vc1_ns.not_sat_set, set_combo)
+        self.assertEqual(vc1_ns.sat_set, set())
+        self.assertTrue(not vc1_ns.is_empty())
 
-                self.assertRaises(AssertionError, vc1_ns.simplify, vct_4)
-                self.assertEqual(vc1_ns.not_sat_set, set_combo)
-                self.assertEqual(vc1_ns.sat_set, set())
-                self.assertTrue(not vc1_ns.is_empty())
+        vc1_tmp = copy.copy(vc1_ns)
+        self.assertTrue(not vc1_tmp.is_satisfied())
+        vc1_tmp.mark_all_as_satisfied()
+        self.assertTrue(vc1_tmp.is_satisfied())
+        self.assertEqual(vc1_tmp.sat_set, set_combo)
 
-                vc1_tmp = copy.copy(vc1_ns)
-                self.assertTrue(not vc1_tmp.is_satisfied())
-                vc1_tmp.mark_all_as_satisfied()
-                self.assertTrue(vc1_tmp.is_satisfied())
-                self.assertEqual(vc1_tmp.sat_set, set_combo)
+        vct3_set_combo = set([frozenset([(1, "a"), (2, "z")])])
+        vc3_ns = variant.VariantCombinations(vct_3, False)
+        self.assertEqual(vc3_ns.not_sat_set, vct3_set_combo)
+        self.assertTrue(vc3_ns.issubset(vc1_ns, False))
+        self.assertTrue(not vc1_ns.issubset(vc3_ns, False))
+        self.assertTrue(vc1_ns.issubset(vc3_ns, True))
+        self.assertTrue(not vc1_s.issubset(vc3_ns, True))
 
-                vct3_set_combo = set([frozenset([(1, "a"), (2, "z")])])
-                vc3_ns = variant.VariantCombinations(vct_3, False)
-                self.assertEqual(vc3_ns.not_sat_set, vct3_set_combo)
-                self.assertTrue(vc3_ns.issubset(vc1_ns, False))
-                self.assertTrue(not vc1_ns.issubset(vc3_ns, False))
-                self.assertTrue(vc1_ns.issubset(vc3_ns, True))
-                self.assertTrue(not vc1_s.issubset(vc3_ns, True))
+        vc3_s = variant.VariantCombinations(vct_3, True)
+        vc2_s = variant.VariantCombinations(vct_2, True)
+        self.assertTrue(vc3_s.intersects(vc1_s))
+        self.assertTrue(vc3_ns.intersects(vc1_s))
+        self.assertTrue(not vc3_ns.intersects(vc2_s))
+        self.assertTrue(not vc3_s.intersects(vc2_s))
+        self.assertTrue(vc1_s.intersects(vc3_s))
+        intersect = vc3_s.intersection(vc1_s)
+        self.assertEqual(intersect.sat_set, vct3_set_combo)
+        self.assertEqual(intersect.not_sat_set, set())
 
-                vc3_s = variant.VariantCombinations(vct_3, True)
-                vc2_s = variant.VariantCombinations(vct_2, True)
-                self.assertTrue(vc3_s.intersects(vc1_s))
-                self.assertTrue(vc3_ns.intersects(vc1_s))
-                self.assertTrue(not vc3_ns.intersects(vc2_s))
-                self.assertTrue(not vc3_s.intersects(vc2_s))
-                self.assertTrue(vc1_s.intersects(vc3_s))
-                intersect = vc3_s.intersection(vc1_s)
-                self.assertEqual(intersect.sat_set, vct3_set_combo)
-                self.assertEqual(intersect.not_sat_set, set())
+        # Test that modifing the original does not modify the copy.
+        vc3_ns_copy = copy.copy(vc3_ns)
+        vc3_ns.mark_all_as_satisfied()
+        self.assertEqual(vc3_ns_copy.not_sat_set, vct3_set_combo)
+        self.assertEqual(vc3_ns.not_sat_set, set())
+        self.assertEqual(vc3_ns.sat_set, vct3_set_combo)
 
-                # Test that modifing the original does not modify the copy.
-                vc3_ns_copy = copy.copy(vc3_ns)
-                vc3_ns.mark_all_as_satisfied()
-                self.assertEqual(vc3_ns_copy.not_sat_set, vct3_set_combo)
-                self.assertEqual(vc3_ns.not_sat_set, set())
-                self.assertEqual(vc3_ns.sat_set, vct3_set_combo)
-                
-                vct_empty = variant.VariantCombinationTemplate(dict([]))
-                vc_empty = variant.VariantCombinations(vct_empty, True)
-                self.assertTrue(vc_empty.is_empty())
-                self.assertTrue(vc_empty.intersects(vc1_ns))
-                self.assertTrue(vc1_ns.intersects(vc_empty))
+        vct_empty = variant.VariantCombinationTemplate(dict([]))
+        vc_empty = variant.VariantCombinations(vct_empty, True)
+        self.assertTrue(vc_empty.is_empty())
+        self.assertTrue(vc_empty.intersects(vc1_ns))
+        self.assertTrue(vc1_ns.intersects(vc_empty))
 
-                vc1_ns.mark_as_satisfied(vc3_s)
-                self.assertEqual(vc1_ns.sat_set, vct3_set_combo)
-                self.assertEqual(vc1_ns.not_sat_set, set_combo - vct3_set_combo)
+        vc1_ns.mark_as_satisfied(vc3_s)
+        self.assertEqual(vc1_ns.sat_set, vct3_set_combo)
+        self.assertEqual(vc1_ns.not_sat_set, set_combo - vct3_set_combo)
 
-                vc1_s.simplify(vct_1)
-                self.assertEqual(vc1_s.sat_set, set())
-                self.assertEqual(vc1_s.not_sat_set, set())
+        vc1_s.simplify(vct_1)
+        self.assertEqual(vc1_s.sat_set, set())
+        self.assertEqual(vc1_s.not_sat_set, set())
 
-                vc1_ns_simp = variant.VariantCombinations(vct_1, False)
-                vc1_ns_simp.simplify(vct_1)
-                self.assertEqual(vc1_ns_simp.sat_set, set())
-                self.assertEqual(vc1_ns_simp.not_sat_set, set())
+        vc1_ns_simp = variant.VariantCombinations(vct_1, False)
+        vc1_ns_simp.simplify(vct_1)
+        self.assertEqual(vc1_ns_simp.sat_set, set())
+        self.assertEqual(vc1_ns_simp.not_sat_set, set())
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/t_version.py
+++ b/src/tests/api/t_version.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -35,353 +36,396 @@ import datetime
 import os
 import sys
 
+
 class TestVersion(pkg5unittest.Pkg5TestCase):
-        def setUp(self):
-                self.d1 = version.DotSequence("1.1.3")
-                self.d2 = version.DotSequence("1.1.3")
-                self.d3 = version.DotSequence("5.4")
-                self.d4 = version.DotSequence("5.6")
-                self.d5 = version.DotSequence("5.4.1")
-                self.d6 = version.DotSequence("5.5.1")
-                self.d7 = version.DotSequence("6.5.1")
+    def setUp(self):
+        self.d1 = version.DotSequence("1.1.3")
+        self.d2 = version.DotSequence("1.1.3")
+        self.d3 = version.DotSequence("5.4")
+        self.d4 = version.DotSequence("5.6")
+        self.d5 = version.DotSequence("5.4.1")
+        self.d6 = version.DotSequence("5.5.1")
+        self.d7 = version.DotSequence("6.5.1")
 
-                self.v1 = version.Version("5.5.1-10:20051122T000000Z", "5.5.1")
-                self.v2 = version.Version("5.5.1-10:20070318T123456Z", "5.5.1")
-                self.v3 = version.Version("5.5.1-10", "5.5")
-                self.v4 = version.Version("5.5.1-6", "5.4")
-                self.v5 = version.Version("5.6,1", "5.4")
-                self.v6 = version.Version("5.7", "5.4")
-                self.v7 = version.Version("5.10", "5.5.1")
-                self.v8 = version.Version("5.10.1", "5.5.1")
-                self.v9 = version.Version("5.11", "5.5.1")
-                self.v9same = version.Version("5.11", "5.5.1")
-                self.v10 = version.Version("0.1,5.11-1", None)
-                self.v11 = version.Version("0.1,5.11-1:20070710T120000Z", None)
-                self.v12 = version.Version("5.11-0.72:20070921T211008Z",
-                    "0.5.11")
-                self.v13 = version.Version("5.11-0.72:20070922T160226Z",
-                    "0.5.11")
-                self.v14 = version.Version("0.1,5.11", None)
-                self.v15 = version.Version("0.1,5.11:20071014T234545Z", None)
-                self.v16 = version.Version("0.2,5.11", None)
-                self.v17 = version.Version("0.2,5.11-1:20071029T131519Z", None)
-                self.v18 = version.Version("5", "5")
+        self.v1 = version.Version("5.5.1-10:20051122T000000Z", "5.5.1")
+        self.v2 = version.Version("5.5.1-10:20070318T123456Z", "5.5.1")
+        self.v3 = version.Version("5.5.1-10", "5.5")
+        self.v4 = version.Version("5.5.1-6", "5.4")
+        self.v5 = version.Version("5.6,1", "5.4")
+        self.v6 = version.Version("5.7", "5.4")
+        self.v7 = version.Version("5.10", "5.5.1")
+        self.v8 = version.Version("5.10.1", "5.5.1")
+        self.v9 = version.Version("5.11", "5.5.1")
+        self.v9same = version.Version("5.11", "5.5.1")
+        self.v10 = version.Version("0.1,5.11-1", None)
+        self.v11 = version.Version("0.1,5.11-1:20070710T120000Z", None)
+        self.v12 = version.Version("5.11-0.72:20070921T211008Z", "0.5.11")
+        self.v13 = version.Version("5.11-0.72:20070922T160226Z", "0.5.11")
+        self.v14 = version.Version("0.1,5.11", None)
+        self.v15 = version.Version("0.1,5.11:20071014T234545Z", None)
+        self.v16 = version.Version("0.2,5.11", None)
+        self.v17 = version.Version("0.2,5.11-1:20071029T131519Z", None)
+        self.v18 = version.Version("5", "5")
 
-        def testbogusdotsequence(self):
-                self.assertRaises(version.IllegalDotSequence,
-                    version.DotSequence, "x.y")
-                self.assertRaises(version.IllegalDotSequence,
-                    version.DotSequence, "")
-                self.assertRaises(version.IllegalDotSequence,
-                    version.DotSequence, "@")
-                self.assertRaises(version.IllegalDotSequence,
-                    version.DotSequence, "1.@")
+    def testbogusdotsequence(self):
+        self.assertRaises(
+            version.IllegalDotSequence, version.DotSequence, "x.y"
+        )
+        self.assertRaises(version.IllegalDotSequence, version.DotSequence, "")
+        self.assertRaises(version.IllegalDotSequence, version.DotSequence, "@")
+        self.assertRaises(
+            version.IllegalDotSequence, version.DotSequence, "1.@"
+        )
 
-        def testdotsequencecomparison(self):
-                self.assertTrue(self.d3 < self.d4)
-                self.assertTrue(self.d4 > self.d3)
-                self.assertTrue(not self.d1 < self.d2)
-                self.assertTrue(not self.d1 > self.d2)
-                self.assertTrue(not None == self.d1)
-                self.assertTrue(None != self.d1)
-                self.assertTrue(self.d1 != self.d3)
-                self.assertTrue(self.d1 == self.d2)
-                self.assertTrue(self.d1.is_same_major(self.d2))
-                self.assertTrue(self.d3.is_same_major(self.d4))
-                self.assertTrue(self.d1.is_same_minor(self.d2))
-                self.assertTrue(not self.d1.is_same_minor(self.d5))
-                self.assertTrue(not self.d3.is_same_minor(self.d4))
-                self.assertTrue(not self.d6.is_same_minor(self.d7))
-                self.assertTrue(self.d3.is_subsequence(self.d5))
-                self.assertTrue(not self.d3.is_subsequence(self.d6))
-                self.assertTrue(not self.d1.is_subsequence(self.d6))
-                self.assertTrue(not self.d6.is_subsequence(self.d1))
-                self.assertTrue(not self.d5.is_subsequence(self.d3))
+    def testdotsequencecomparison(self):
+        self.assertTrue(self.d3 < self.d4)
+        self.assertTrue(self.d4 > self.d3)
+        self.assertTrue(not self.d1 < self.d2)
+        self.assertTrue(not self.d1 > self.d2)
+        self.assertTrue(not None == self.d1)
+        self.assertTrue(None != self.d1)
+        self.assertTrue(self.d1 != self.d3)
+        self.assertTrue(self.d1 == self.d2)
+        self.assertTrue(self.d1.is_same_major(self.d2))
+        self.assertTrue(self.d3.is_same_major(self.d4))
+        self.assertTrue(self.d1.is_same_minor(self.d2))
+        self.assertTrue(not self.d1.is_same_minor(self.d5))
+        self.assertTrue(not self.d3.is_same_minor(self.d4))
+        self.assertTrue(not self.d6.is_same_minor(self.d7))
+        self.assertTrue(self.d3.is_subsequence(self.d5))
+        self.assertTrue(not self.d3.is_subsequence(self.d6))
+        self.assertTrue(not self.d1.is_subsequence(self.d6))
+        self.assertTrue(not self.d6.is_subsequence(self.d1))
+        self.assertTrue(not self.d5.is_subsequence(self.d3))
 
-        def teststr(self):
-                self.assertTrue(str(self.v1) == "5.5.1,5.5.1-10:20051122T000000Z")
-                self.assertTrue(str(self.v2) == "5.5.1,5.5.1-10:20070318T123456Z")
-                self.assertTrue(str(self.v3) == "5.5.1,5.5-10")
-                self.assertTrue(str(self.v4) == "5.5.1,5.4-6")
-                self.assertTrue(str(self.v5) == "5.6,1")
-                self.assertTrue(str(self.v6) == "5.7,5.4")
-                self.assertTrue(str(self.v7) == "5.10,5.5.1")
-                self.assertTrue(str(self.v8) == "5.10.1,5.5.1")
-                self.assertTrue(str(self.v9) == "5.11,5.5.1")
-                self.assertTrue(str(self.v10) == "0.1,5.11-1")
-                self.assertTrue(str(self.v11) == "0.1,5.11-1:20070710T120000Z")
-                self.assertTrue(
-                    str(self.v12) == "5.11,0.5.11-0.72:20070921T211008Z")
-                self.assertTrue(
-                    str(self.v13) == "5.11,0.5.11-0.72:20070922T160226Z")
-                self.assertTrue(str(self.v14) == "0.1,5.11")
-                self.assertTrue(str(self.v15) == "0.1,5.11:20071014T234545Z")
-                self.assertTrue(str(self.v16) == "0.2,5.11")
-                self.assertTrue(str(self.v17) == "0.2,5.11-1:20071029T131519Z")
-                self.assertTrue(str(self.v18) == "5,5")
+    def teststr(self):
+        self.assertTrue(str(self.v1) == "5.5.1,5.5.1-10:20051122T000000Z")
+        self.assertTrue(str(self.v2) == "5.5.1,5.5.1-10:20070318T123456Z")
+        self.assertTrue(str(self.v3) == "5.5.1,5.5-10")
+        self.assertTrue(str(self.v4) == "5.5.1,5.4-6")
+        self.assertTrue(str(self.v5) == "5.6,1")
+        self.assertTrue(str(self.v6) == "5.7,5.4")
+        self.assertTrue(str(self.v7) == "5.10,5.5.1")
+        self.assertTrue(str(self.v8) == "5.10.1,5.5.1")
+        self.assertTrue(str(self.v9) == "5.11,5.5.1")
+        self.assertTrue(str(self.v10) == "0.1,5.11-1")
+        self.assertTrue(str(self.v11) == "0.1,5.11-1:20070710T120000Z")
+        self.assertTrue(str(self.v12) == "5.11,0.5.11-0.72:20070921T211008Z")
+        self.assertTrue(str(self.v13) == "5.11,0.5.11-0.72:20070922T160226Z")
+        self.assertTrue(str(self.v14) == "0.1,5.11")
+        self.assertTrue(str(self.v15) == "0.1,5.11:20071014T234545Z")
+        self.assertTrue(str(self.v16) == "0.2,5.11")
+        self.assertTrue(str(self.v17) == "0.2,5.11-1:20071029T131519Z")
+        self.assertTrue(str(self.v18) == "5,5")
 
-        def testbogusversion1(self):
-                """ Test empty elements """
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, ".", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, ",", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "-", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, ":", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "@", "5.11")
+    def testbogusversion1(self):
+        """Test empty elements"""
+        self.assertRaises(version.IllegalVersion, version.Version, "", "5.11")
+        self.assertRaises(version.IllegalVersion, version.Version, ".", "5.11")
+        self.assertRaises(version.IllegalVersion, version.Version, ",", "5.11")
+        self.assertRaises(version.IllegalVersion, version.Version, "-", "5.11")
+        self.assertRaises(version.IllegalVersion, version.Version, ":", "5.11")
+        self.assertRaises(version.IllegalVersion, version.Version, "@", "5.11")
 
-        def testbogusversion2(self):
-                """ Test bad release strings """
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "x.y", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.y", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "-3", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.@", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.", None)
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, ".1", None)
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1..1", None)
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0001", "5.11")
+    def testbogusversion2(self):
+        """Test bad release strings"""
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "x.y", "5.11"
+        )
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.y", "5.11"
+        )
+        self.assertRaises(version.IllegalVersion, version.Version, "-3", "5.11")
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.@", "5.11"
+        )
+        self.assertRaises(version.IllegalVersion, version.Version, "1.", None)
+        self.assertRaises(version.IllegalVersion, version.Version, ".1", None)
+        self.assertRaises(version.IllegalVersion, version.Version, "1..1", None)
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.0,", "5.11"
+        )
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.0001", "5.11"
+        )
 
-        def testbogusversion3(self):
-                """ Test bad build strings """
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,-1.0", None)
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,,,,,-2.0", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,1.-0", None)
+    def testbogusversion3(self):
+        """Test bad build strings"""
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.0,-1.0", None
+        )
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.0,,,,,-2.0", "5.11"
+        )
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.0,1.-0", None
+        )
 
-        def testbogusversion4(self):
-                """ Test bad branch strings """
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,1-.0", None)
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,2----2.0", "5.11")
+    def testbogusversion4(self):
+        """Test bad branch strings"""
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.0,1-.0", None
+        )
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.0,2----2.0", "5.11"
+        )
 
-        def testbogusversion5(self):
-                # dangling branch
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,1.0-", None)
-                # dangling branch with timestamp
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,1.0-:19760113T111111Z", None)
-                # empty time
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,1.0-1.0:", "5.11")
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,-1.0:19760113T111111Z", None)
-                # dangling build
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,", None)
-                # dangling build with timestamp
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "1.0,:19760113T111111Z", None)
+    def testbogusversion5(self):
+        # dangling branch
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.0,1.0-", None
+        )
+        # dangling branch with timestamp
+        self.assertRaises(
+            version.IllegalVersion,
+            version.Version,
+            "1.0,1.0-:19760113T111111Z",
+            None,
+        )
+        # empty time
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "1.0,1.0-1.0:", "5.11"
+        )
+        self.assertRaises(
+            version.IllegalVersion,
+            version.Version,
+            "1.0,-1.0:19760113T111111Z",
+            None,
+        )
+        # dangling build
+        self.assertRaises(version.IllegalVersion, version.Version, "1.0,", None)
+        # dangling build with timestamp
+        self.assertRaises(
+            version.IllegalVersion,
+            version.Version,
+            "1.0,:19760113T111111Z",
+            None,
+        )
 
-        def testbogusversion6(self):
-                """ insert a bad char at (almost) every position in a version"""
-                v = "12.34.56-78:19760113T111111Z"
-                # Check that v is valid
-                version.Version(v)
-                badchars = [ "T", "Z", "@", "-", ".", ",", ":" ]
-                becareful = [".", ",", "-"]
-                for b in badchars:
-                        for x in range(0, len(v)):
-                                vlist = list(v)
-                                if b in becareful and vlist[x] in becareful:
-                                        continue
-                                if vlist[x] == b:
-                                        continue
-                                vlist[x] = b
-                                vv = "".join(vlist)
-                                self.assertRaises(version.IllegalVersion,
-                                    version.Version, vv, "5.11")
+    def testbogusversion6(self):
+        """insert a bad char at (almost) every position in a version"""
+        v = "12.34.56-78:19760113T111111Z"
+        # Check that v is valid
+        version.Version(v)
+        badchars = ["T", "Z", "@", "-", ".", ",", ":"]
+        becareful = [".", ",", "-"]
+        for b in badchars:
+            for x in range(0, len(v)):
+                vlist = list(v)
+                if b in becareful and vlist[x] in becareful:
+                    continue
+                if vlist[x] == b:
+                    continue
+                vlist[x] = b
+                vv = "".join(vlist)
+                self.assertRaises(
+                    version.IllegalVersion, version.Version, vv, "5.11"
+                )
 
-        def testversionlt(self):
-                self.assertTrue(self.v1 < self.v2)
+    def testversionlt(self):
+        self.assertTrue(self.v1 < self.v2)
 
-        def testversionlt2(self):
-                self.assertTrue(self.v4 < self.v3)
+    def testversionlt2(self):
+        self.assertTrue(self.v4 < self.v3)
 
-        def testversionlt3(self):
-                self.assertTrue(self.v4 < self.v5)
+    def testversionlt3(self):
+        self.assertTrue(self.v4 < self.v5)
 
-        def testversionlt4(self):
-                self.assertTrue(self.v7 < self.v8)
+    def testversionlt4(self):
+        self.assertTrue(self.v7 < self.v8)
 
-        def testversionlt5(self):
-                self.assertTrue(not self.v7 < None)
+    def testversionlt5(self):
+        self.assertTrue(not self.v7 < None)
 
-        def testversionlt6(self):
-                self.assertTrue(not self.v7 < self.v7)
+    def testversionlt6(self):
+        self.assertTrue(not self.v7 < self.v7)
 
-        def testversiongt1(self):
-                self.assertTrue(self.v6 > self.v5)
+    def testversiongt1(self):
+        self.assertTrue(self.v6 > self.v5)
 
-        def testversiongt2(self):
-                self.assertTrue(self.v9 > self.v8)
+    def testversiongt2(self):
+        self.assertTrue(self.v9 > self.v8)
 
-        def testversiongt3(self):
-                self.assertTrue(self.v11 > self.v10)
+    def testversiongt3(self):
+        self.assertTrue(self.v11 > self.v10)
 
-        def testversiongt4(self):
-                self.assertTrue(self.v13 > self.v12)
+    def testversiongt4(self):
+        self.assertTrue(self.v13 > self.v12)
 
-        def testversiongt5(self):
-                self.assertTrue(self.v7 > None)
+    def testversiongt5(self):
+        self.assertTrue(self.v7 > None)
 
-        def testversiongt6(self):
-                self.assertTrue(not self.v7 > self.v7)
+    def testversiongt6(self):
+        self.assertTrue(not self.v7 > self.v7)
 
-        def testversioneq(self):
-                self.assertTrue(not self.v9 == self.v8)
-                self.assertTrue(not self.v9 == None)
-                self.assertTrue(not None == self.v9)
-                self.assertTrue(self.v9 == self.v9same)
+    def testversioneq(self):
+        self.assertTrue(not self.v9 == self.v8)
+        self.assertTrue(not self.v9 == None)
+        self.assertTrue(not None == self.v9)
+        self.assertTrue(self.v9 == self.v9same)
 
-        def testversionne(self):
-                self.assertTrue(self.v9 != self.v8)
-                self.assertTrue(self.v9 != None)
-                self.assertTrue(None != self.v9)
-                self.assertTrue(not self.v9 != self.v9same)
+    def testversionne(self):
+        self.assertTrue(self.v9 != self.v8)
+        self.assertTrue(self.v9 != None)
+        self.assertTrue(None != self.v9)
+        self.assertTrue(not self.v9 != self.v9same)
 
-        def testversionsuccessor1(self):
-                self.assertTrue(self.v13.is_successor(self.v12,
-                    version.CONSTRAINT_BRANCH))
+    def testversionsuccessor1(self):
+        self.assertTrue(
+            self.v13.is_successor(self.v12, version.CONSTRAINT_BRANCH)
+        )
 
-        def testversionsuccessor2(self):
-                self.assertTrue(self.v2.is_successor(self.v1,
-                    version.CONSTRAINT_BRANCH))
+    def testversionsuccessor2(self):
+        self.assertTrue(
+            self.v2.is_successor(self.v1, version.CONSTRAINT_BRANCH)
+        )
 
-        def testversionsuccessor3(self):
-                self.assertTrue(self.v4.is_successor(self.v2,
-                    version.CONSTRAINT_RELEASE))
+    def testversionsuccessor3(self):
+        self.assertTrue(
+            self.v4.is_successor(self.v2, version.CONSTRAINT_RELEASE)
+        )
 
-        def testversionsuccessor4(self):
-                self.assertTrue(self.v6.is_successor(self.v5,
-                    version.CONSTRAINT_RELEASE_MAJOR))
+    def testversionsuccessor4(self):
+        self.assertTrue(
+            self.v6.is_successor(self.v5, version.CONSTRAINT_RELEASE_MAJOR)
+        )
 
-        def testversionsuccessor5(self):
-                self.assertTrue(self.v8.is_successor(self.v7,
-                    version.CONSTRAINT_RELEASE_MAJOR))
+    def testversionsuccessor5(self):
+        self.assertTrue(
+            self.v8.is_successor(self.v7, version.CONSTRAINT_RELEASE_MAJOR)
+        )
 
-        def testversionsuccessor6(self):
-                self.assertTrue(self.v10.is_successor(self.v14,
-                    version.CONSTRAINT_AUTO))
+    def testversionsuccessor6(self):
+        self.assertTrue(
+            self.v10.is_successor(self.v14, version.CONSTRAINT_AUTO)
+        )
 
-        def testversionsuccessor7(self):
-                self.assertTrue(self.v15.is_successor(self.v14,
-                    version.CONSTRAINT_AUTO))
+    def testversionsuccessor7(self):
+        self.assertTrue(
+            self.v15.is_successor(self.v14, version.CONSTRAINT_AUTO)
+        )
 
-        def testversionsuccessor8(self):
-                self.assertTrue(not self.v16.is_successor(self.v14,
-                    version.CONSTRAINT_AUTO))
+    def testversionsuccessor8(self):
+        self.assertTrue(
+            not self.v16.is_successor(self.v14, version.CONSTRAINT_AUTO)
+        )
 
-        def testversionsuccessor9(self):
-                self.assertTrue(not self.v17.is_successor(self.v14,
-                    version.CONSTRAINT_AUTO))
+    def testversionsuccessor9(self):
+        self.assertTrue(
+            not self.v17.is_successor(self.v14, version.CONSTRAINT_AUTO)
+        )
 
-        def testversionbadversion(self):
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "", None)
+    def testversionbadversion(self):
+        self.assertRaises(version.IllegalVersion, version.Version, "", None)
 
-        def testversionbaddots(self):
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "0.2.q.4,5.11-1", None)
+    def testversionbaddots(self):
+        self.assertRaises(
+            version.IllegalVersion, version.Version, "0.2.q.4,5.11-1", None
+        )
 
-        def testversionbadtime1(self):
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "0.2,5.11-1:moomoomoomoomooZ", None)
+    def testversionbadtime1(self):
+        self.assertRaises(
+            version.IllegalVersion,
+            version.Version,
+            "0.2,5.11-1:moomoomoomoomooZ",
+            None,
+        )
 
-        def testversionbadtime2(self):
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "0.2,5.11-1:20070113T131519Q", None)
+    def testversionbadtime2(self):
+        self.assertRaises(
+            version.IllegalVersion,
+            version.Version,
+            "0.2,5.11-1:20070113T131519Q",
+            None,
+        )
 
-        def testversionbadtime3(self):
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "0.2,5.11-1:29T131519Z", None)
+    def testversionbadtime3(self):
+        self.assertRaises(
+            version.IllegalVersion,
+            version.Version,
+            "0.2,5.11-1:29T131519Z",
+            None,
+        )
 
-        def testversionbadtime4(self):
-                #bad month
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "0.2,5.11-1:20070013T112233Z", None)
+    def testversionbadtime4(self):
+        # bad month
+        self.assertRaises(
+            version.IllegalVersion,
+            version.Version,
+            "0.2,5.11-1:20070013T112233Z",
+            None,
+        )
 
-        def testversionbadtime5(self):
-                #bad day; no day 31 in feb
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "0.2,5.11-1:20070231T112233Z", None)
+    def testversionbadtime5(self):
+        # bad day; no day 31 in feb
+        self.assertRaises(
+            version.IllegalVersion,
+            version.Version,
+            "0.2,5.11-1:20070231T112233Z",
+            None,
+        )
 
-        def testversionbadtime6(self):
-                #bad second
-                self.assertRaises(version.IllegalVersion,
-                    version.Version, "0.2,5.11-1:20070113T131672Z", None)
+    def testversionbadtime6(self):
+        # bad second
+        self.assertRaises(
+            version.IllegalVersion,
+            version.Version,
+            "0.2,5.11-1:20070113T131672Z",
+            None,
+        )
 
-        def testversiongettime(self):
-                self.assertTrue(self.v1.get_timestamp().year == 2005)
-                self.assertTrue(self.v1.get_timestamp().hour == 0)
-                self.assertTrue(self.v1.get_timestamp().hour == 0)
-                self.assertTrue(self.v1.get_timestamp().tzname() == None)
-                self.assertTrue(self.v3.get_timestamp() == None)
+    def testversiongettime(self):
+        self.assertTrue(self.v1.get_timestamp().year == 2005)
+        self.assertTrue(self.v1.get_timestamp().hour == 0)
+        self.assertTrue(self.v1.get_timestamp().hour == 0)
+        self.assertTrue(self.v1.get_timestamp().tzname() == None)
+        self.assertTrue(self.v3.get_timestamp() == None)
 
-        def testversionsettime(self):
-                d = datetime.datetime.utcnow()
-                # 'd' includes microseconds, so we trim those off.
-                d = d.replace(microsecond=0)
-                self.v1.set_timestamp(d)
-                self.assertTrue(self.v1.get_timestamp() == d)
+    def testversionsettime(self):
+        d = datetime.datetime.utcnow()
+        # 'd' includes microseconds, so we trim those off.
+        d = d.replace(microsecond=0)
+        self.v1.set_timestamp(d)
+        self.assertTrue(self.v1.get_timestamp() == d)
 
-        def testsplit(self):
-                """Verify that split() works as expected."""
+    def testsplit(self):
+        """Verify that split() works as expected."""
 
-                sver = "1.0,5.11-0.156:20101231T161351Z"
-                expected = (("1.0", "5.11", "0.156", "20101231T161351Z"),
-                    "1.0-0.156")
-                self.assertEqualDiff(expected, version.Version.split(sver)) 
+        sver = "1.0,5.11-0.156:20101231T161351Z"
+        expected = (("1.0", "5.11", "0.156", "20101231T161351Z"), "1.0-0.156")
+        self.assertEqualDiff(expected, version.Version.split(sver))
 
-                sver = "1.0:20101231T161351Z"
-                expected = (("1.0", "", None, "20101231T161351Z"), "1.0")
-                self.assertEqualDiff(expected, version.Version.split(sver)) 
+        sver = "1.0:20101231T161351Z"
+        expected = (("1.0", "", None, "20101231T161351Z"), "1.0")
+        self.assertEqualDiff(expected, version.Version.split(sver))
 
-                sver = ":20101231T161351Z"
-                expected = (("", "", None, "20101231T161351Z"), "")
-                self.assertEqualDiff(expected, version.Version.split(sver)) 
+        sver = ":20101231T161351Z"
+        expected = (("", "", None, "20101231T161351Z"), "")
+        self.assertEqualDiff(expected, version.Version.split(sver))
 
-                sver = "1.0,5.11-0.156"
-                expected = (("1.0", "5.11", "0.156", None), "1.0-0.156")
-                self.assertEqualDiff(expected, version.Version.split(sver)) 
+        sver = "1.0,5.11-0.156"
+        expected = (("1.0", "5.11", "0.156", None), "1.0-0.156")
+        self.assertEqualDiff(expected, version.Version.split(sver))
 
-                sver = "-0.156"
-                expected = (("", "", "0.156", None), "-0.156")
-                self.assertEqualDiff(expected, version.Version.split(sver)) 
+        sver = "-0.156"
+        expected = (("", "", "0.156", None), "-0.156")
+        self.assertEqualDiff(expected, version.Version.split(sver))
 
-                sver = "1.0,5.11"
-                expected = (("1.0", "5.11", None, None), "1.0")
-                self.assertEqualDiff(expected, version.Version.split(sver)) 
+        sver = "1.0,5.11"
+        expected = (("1.0", "5.11", None, None), "1.0")
+        self.assertEqualDiff(expected, version.Version.split(sver))
 
-                sver = ",5.11"
-                expected = (("", "5.11", None, None), "")
-                self.assertEqualDiff(expected, version.Version.split(sver)) 
+        sver = ",5.11"
+        expected = (("", "5.11", None, None), "")
+        self.assertEqualDiff(expected, version.Version.split(sver))
 
-                sver = "1.0"
-                expected = (("1.0", "", None, None), "1.0")
-                self.assertEqualDiff(expected, version.Version.split(sver)) 
+        sver = "1.0"
+        expected = (("1.0", "", None, None), "1.0")
+        self.assertEqualDiff(expected, version.Version.split(sver))
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/api/testutils.py
+++ b/src/tests/api/testutils.py
@@ -29,12 +29,14 @@ import sys
 # Set the path so that modules can be found
 path_to_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if path_to_parent not in sys.path:
-        sys.path.insert(0, path_to_parent)
+    sys.path.insert(0, path_to_parent)
 
 import pkg5testenv
 
+
 def setup_environment(proto):
-        pkg5testenv.setup_environment(proto)
+    pkg5testenv.setup_environment(proto)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/baseline.py
+++ b/src/tests/baseline.py
@@ -29,130 +29,139 @@ import os
 import sys
 import unittest
 
-BASELINE_MATCH=0
-BASELINE_MISMATCH=1
+BASELINE_MATCH = 0
+BASELINE_MISMATCH = 1
+
 
 class BaseLine(object):
-        """Test result baseline recording and checking. """
-        sep1 = '=' * 70
-        sep2 = '-' * 70
+    """Test result baseline recording and checking."""
 
-        def __init__(self, filename="baseline.txt", generate=False):
+    sep1 = "=" * 70
+    sep2 = "-" * 70
 
-                # filename from which to get or store baseline results
-                self.__filename = filename
-                # 'generating' keeps track of whether we are currently
-                # generating a baseline or not: if either the baseline doesn't
-                # exist or the "-g" option is specified on the commandline.
-                self.__generating = generate
-                # List of tuples (name, result) for failed tests
-                self.__failed_list = []
-                # dict of "test name" -> "result"
-                self.__results = {}
+    def __init__(self, filename="baseline.txt", generate=False):
+        # filename from which to get or store baseline results
+        self.__filename = filename
+        # 'generating' keeps track of whether we are currently
+        # generating a baseline or not: if either the baseline doesn't
+        # exist or the "-g" option is specified on the commandline.
+        self.__generating = generate
+        # List of tuples (name, result) for failed tests
+        self.__failed_list = []
+        # dict of "test name" -> "result"
+        self.__results = {}
 
-        def handleresult(self, name, actualresult):
-                """Add a result if we're generating the baseline file,
-                otherwise check it against the current result set.
-                Returns a value to indicate whether the result matched
-                the baseline."""
+    def handleresult(self, name, actualresult):
+        """Add a result if we're generating the baseline file,
+        otherwise check it against the current result set.
+        Returns a value to indicate whether the result matched
+        the baseline."""
 
-                if self.__generating:
-                        self.__results[name] = actualresult
-                        return BASELINE_MATCH
+        if self.__generating:
+            self.__results[name] = actualresult
+            return BASELINE_MATCH
 
-                if self.expectedresult(name) != actualresult:
-                        self.__failed_list.append((name, actualresult))
-                        return BASELINE_MISMATCH
-                return BASELINE_MATCH
+        if self.expectedresult(name) != actualresult:
+            self.__failed_list.append((name, actualresult))
+            return BASELINE_MISMATCH
+        return BASELINE_MATCH
 
-        def expectedresult(self, name):
-                # The assumption if we're generating, or if we don't
-                # have a result in baseline, is that the test should pass.
-                if self.__generating:
-                        return "pass"
-                return self.__results.get(name, "pass")
+    def expectedresult(self, name):
+        # The assumption if we're generating, or if we don't
+        # have a result in baseline, is that the test should pass.
+        if self.__generating:
+            return "pass"
+        return self.__results.get(name, "pass")
 
-        def getfailures(self):
-                """Return the list of failed tests."""
-                return self.__failed_list
+    def getfailures(self):
+        """Return the list of failed tests."""
+        return self.__failed_list
 
-        def reportfailures(self, file='failures'):
-                """Display all test cases that failed to match the baseline
-                and their result.
-                """
-                lst = self.getfailures()
+    def reportfailures(self, file="failures"):
+        """Display all test cases that failed to match the baseline
+        and their result.
+        """
+        lst = self.getfailures()
 
-                def op_baseline(stream):
-                        print("", file=stream)
-                        print(self.sep1, file=stream)
-                        if lst:
-                                print("BASELINE MISMATCH: The following "
-                                    "results didn't match the baseline.",
-                                    file=stream)
-                                print(self.sep2, file=stream)
-                                for name, result in lst:
-                                        print("{0}: {1}".format(name, result),
-                                            file=stream)
-                        else:
-                                print("BASELINE MATCH", file=stream)
-                        print(self.sep1, file=stream)
-                        print("", file=stream)
+        def op_baseline(stream):
+            print("", file=stream)
+            print(self.sep1, file=stream)
+            if lst:
+                print(
+                    "BASELINE MISMATCH: The following "
+                    "results didn't match the baseline.",
+                    file=stream,
+                )
+                print(self.sep2, file=stream)
+                for name, result in lst:
+                    print("{0}: {1}".format(name, result), file=stream)
+            else:
+                print("BASELINE MATCH", file=stream)
+            print(self.sep1, file=stream)
+            print("", file=stream)
 
-                op_baseline(sys.stderr)
-                if file != None:
-                        try:
-                                with open(file, 'w') as out:
-                                        op_baseline(out)
-                        except:
-                                pass
+        op_baseline(sys.stderr)
+        if file != None:
+            try:
+                with open(file, "w") as out:
+                    op_baseline(out)
+            except:
+                pass
 
-        def store(self):
-                """Store the result set."""
-                # Only store the result set if we're generating a baseline
-                if not self.__generating:
-                        return
-                try:
-                        f = open(self.__filename, "w")
-                except IOError as xxx_todo_changeme:
-                        (err, msg) = xxx_todo_changeme.args
-                        print("ERROR: storing baseline:", file=sys.stderr)
-                        print("Failed to open {0}: {1}".format(
-                            self.__filename, msg), file=sys.stderr)
-                        return
+    def store(self):
+        """Store the result set."""
+        # Only store the result set if we're generating a baseline
+        if not self.__generating:
+            return
+        try:
+            f = open(self.__filename, "w")
+        except IOError as xxx_todo_changeme:
+            (err, msg) = xxx_todo_changeme.args
+            print("ERROR: storing baseline:", file=sys.stderr)
+            print(
+                "Failed to open {0}: {1}".format(self.__filename, msg),
+                file=sys.stderr,
+            )
+            return
 
-                # Sort the results to make baseline diffs easier
-                results_sorted = list(self.__results.keys())
-                results_sorted.sort()
-                print("# Writing baseline to {0}.".format(self.__filename),
-                    file=sys.stderr)
-                for s in results_sorted:
-                        f.write("{0}|{1}{2}".format(
-                            s, self.__results[s], os.linesep))
-                f.flush()
-                f.close()
+        # Sort the results to make baseline diffs easier
+        results_sorted = list(self.__results.keys())
+        results_sorted.sort()
+        print(
+            "# Writing baseline to {0}.".format(self.__filename),
+            file=sys.stderr,
+        )
+        for s in results_sorted:
+            f.write("{0}|{1}{2}".format(s, self.__results[s], os.linesep))
+        f.flush()
+        f.close()
 
-        def load(self):
-                """Load the result set."""
-                if not os.path.exists(self.__filename):
-                        self.__generating = True
-                        return
+    def load(self):
+        """Load the result set."""
+        if not os.path.exists(self.__filename):
+            self.__generating = True
+            return
 
-                try:
-                        f = open(self.__filename, "r")
-                except IOError as xxx_todo_changeme1:
-                        (err, msg) = xxx_todo_changeme1.args
-                        print("ERROR: loading baseline:", file=sys.stderr)
-                        print("Failed to open {0}: {1}".format(
-                            self.__filename, msg), file=sys.stderr)
-                        return
-                for line in f.readlines():
-                        n, r = line.split('|')
-                        self.__results[n] = r.rstrip('\n')
-                f.close()
+        try:
+            f = open(self.__filename, "r")
+        except IOError as xxx_todo_changeme1:
+            (err, msg) = xxx_todo_changeme1.args
+            print("ERROR: loading baseline:", file=sys.stderr)
+            print(
+                "Failed to open {0}: {1}".format(self.__filename, msg),
+                file=sys.stderr,
+            )
+            return
+        for line in f.readlines():
+            n, r = line.split("|")
+            self.__results[n] = r.rstrip("\n")
+        f.close()
+
 
 class ReadOnlyBaseLine(BaseLine):
-        def store(self):
-                raise NotImplementedError()
+    def store(self):
+        raise NotImplementedError()
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/certgenerator.py
+++ b/src/tests/certgenerator.py
@@ -27,235 +27,341 @@
 import os
 import subprocess
 
+
 class CertGenerator(object):
-        """A class which creates certificates."""
+    """A class which creates certificates."""
 
-        def __init__(self, base_dir="."):
-                # Allow relative path, but convert it to absolute path first.
-                self.base_dir = os.path.abspath(base_dir)
+    def __init__(self, base_dir="."):
+        # Allow relative path, but convert it to absolute path first.
+        self.base_dir = os.path.abspath(base_dir)
 
-                conf_dict = {"base_dir": self.base_dir}
-                self.cnf_file = os.path.join(self.base_dir, "openssl.cnf")
-                with open(self.cnf_file, "w") as fh:
-                        fh.write(self.openssl_conf.format(**conf_dict))
+        conf_dict = {"base_dir": self.base_dir}
+        self.cnf_file = os.path.join(self.base_dir, "openssl.cnf")
+        with open(self.cnf_file, "w") as fh:
+            fh.write(self.openssl_conf.format(**conf_dict))
 
-                # Set up the needed files.
-                fh = open(os.path.join(self.base_dir, "index"), "w")
-                fh.close()
+        # Set up the needed files.
+        fh = open(os.path.join(self.base_dir, "index"), "w")
+        fh.close()
 
-                fh = open(os.path.join(self.base_dir, "serial"), "w")
-                fh.write("01\n")
-                fh.close()
+        fh = open(os.path.join(self.base_dir, "serial"), "w")
+        fh.write("01\n")
+        fh.close()
 
-                # Set up the names of the needed directories.
-                self.keys_loc = "keys"
-                self.cs_loc = "code_signing_certs"
-                self.chain_certs_loc = "chain_certs"
-                self.trust_anchors_loc = "trust_anchors"
-                self.crl_loc = "crl"
+        # Set up the names of the needed directories.
+        self.keys_loc = "keys"
+        self.cs_loc = "code_signing_certs"
+        self.chain_certs_loc = "chain_certs"
+        self.trust_anchors_loc = "trust_anchors"
+        self.crl_loc = "crl"
 
-                # Set up the paths to the certificates that will be needed.
-                self.keys_dir = os.path.join(self.base_dir, self.keys_loc)
-                self.cs_dir = os.path.join(self.base_dir, self.cs_loc)
-                self.chain_certs_dir = os.path.join(self.base_dir,
-                    self.chain_certs_loc)
-                self.raw_trust_anchor_dir = os.path.join(self.base_dir,
-                    self.trust_anchors_loc)
-                self.crl_dir = os.path.join(self.base_dir, self.crl_loc)
+        # Set up the paths to the certificates that will be needed.
+        self.keys_dir = os.path.join(self.base_dir, self.keys_loc)
+        self.cs_dir = os.path.join(self.base_dir, self.cs_loc)
+        self.chain_certs_dir = os.path.join(self.base_dir, self.chain_certs_loc)
+        self.raw_trust_anchor_dir = os.path.join(
+            self.base_dir, self.trust_anchors_loc
+        )
+        self.crl_dir = os.path.join(self.base_dir, self.crl_loc)
 
-                os.mkdir(self.keys_dir)
-                os.mkdir(self.cs_dir)
-                os.mkdir(self.chain_certs_dir)
-                os.mkdir(self.raw_trust_anchor_dir)
-                os.mkdir(self.crl_dir)
+        os.mkdir(self.keys_dir)
+        os.mkdir(self.cs_dir)
+        os.mkdir(self.chain_certs_dir)
+        os.mkdir(self.raw_trust_anchor_dir)
+        os.mkdir(self.crl_dir)
 
-        def convert_pem_to_text(self, tmp_pth, out_pth, kind="x509"):
-                """Convert a pem file to a human friendly text file."""
+    def convert_pem_to_text(self, tmp_pth, out_pth, kind="x509"):
+        """Convert a pem file to a human friendly text file."""
 
-                assert not os.path.exists(out_pth)
+        assert not os.path.exists(out_pth)
 
-                cmd = ["openssl", kind, "-in", tmp_pth,
-                    "-text"]
+        cmd = ["openssl", kind, "-in", tmp_pth, "-text"]
 
-                fh = open(out_pth, "w")
-                p = subprocess.Popen(cmd, stdout=fh)
-                assert p.wait() == 0
-                fh.close()
+        fh = open(out_pth, "w")
+        p = subprocess.Popen(cmd, stdout=fh)
+        assert p.wait() == 0
+        fh.close()
 
-        def make_ca_cert(self, new_name, parent_name, parent_loc=None,
-            ext="v3_ca", ta_path=None, expired=False, future=False, https=False):
-                """Create a new CA cert."""
+    def make_ca_cert(
+        self,
+        new_name,
+        parent_name,
+        parent_loc=None,
+        ext="v3_ca",
+        ta_path=None,
+        expired=False,
+        future=False,
+        https=False,
+    ):
+        """Create a new CA cert."""
 
-                if not parent_loc:
-                        parent_loc = self.trust_anchors_loc
-                if not ta_path:
-                        ta_path = self.base_dir
-                subj_str_to_use = self.subj_str
-                if https:
-                        subj_str_to_use = self.https_subj_str
-                cmd = ["openssl", "req", "-new", "-nodes",
-                    "-keyout", "{0}/{1}_key.pem".format(self.keys_dir, new_name),
-                    "-out", "{0}/{1}.csr".format(self.chain_certs_dir, new_name),
-                    "-sha256", "-subj", subj_str_to_use.format(new_name, new_name)]
-                p = subprocess.Popen(cmd)
-                assert p.wait() == 0
+        if not parent_loc:
+            parent_loc = self.trust_anchors_loc
+        if not ta_path:
+            ta_path = self.base_dir
+        subj_str_to_use = self.subj_str
+        if https:
+            subj_str_to_use = self.https_subj_str
+        cmd = [
+            "openssl",
+            "req",
+            "-new",
+            "-nodes",
+            "-keyout",
+            "{0}/{1}_key.pem".format(self.keys_dir, new_name),
+            "-out",
+            "{0}/{1}.csr".format(self.chain_certs_dir, new_name),
+            "-sha256",
+            "-subj",
+            subj_str_to_use.format(new_name, new_name),
+        ]
+        p = subprocess.Popen(cmd)
+        assert p.wait() == 0
 
-                cmd = ["openssl", "ca", "-policy", "policy_anything",
-                    "-extensions", ext,
-                    "-out", "{0}/{1}_cert.pem".format(self.chain_certs_dir,
-                        new_name),
-                    "-in", "{0}/{1}.csr".format(self.chain_certs_dir, new_name),
-                    "-cert", "{0}/{1}/{2}_cert.pem".format(ta_path, parent_loc,
-                        parent_name),
-                    "-outdir", "{0}".format(self.chain_certs_dir),
-                    "-keyfile", "{0}/{1}/{2}_key.pem".format(ta_path, self.keys_loc,
-                        parent_name),
-                    "-config", self.cnf_file,
-                    "-batch"]
-                if expired:
-                        cmd.append("-startdate")
-                        cmd.append("090101010101Z")
-                        cmd.append("-enddate")
-                        cmd.append("090102010101Z")
-                elif future:
-                        cmd.append("-startdate")
-                        cmd.append("350101010101Z")
-                        cmd.append("-enddate")
-                        cmd.append("350102010101Z")
-                else:
-                        cmd.append("-days")
-                        cmd.append("1000")
-                p = subprocess.Popen(cmd)
-                assert p.wait() == 0
+        cmd = [
+            "openssl",
+            "ca",
+            "-policy",
+            "policy_anything",
+            "-extensions",
+            ext,
+            "-out",
+            "{0}/{1}_cert.pem".format(self.chain_certs_dir, new_name),
+            "-in",
+            "{0}/{1}.csr".format(self.chain_certs_dir, new_name),
+            "-cert",
+            "{0}/{1}/{2}_cert.pem".format(ta_path, parent_loc, parent_name),
+            "-outdir",
+            "{0}".format(self.chain_certs_dir),
+            "-keyfile",
+            "{0}/{1}/{2}_key.pem".format(ta_path, self.keys_loc, parent_name),
+            "-config",
+            self.cnf_file,
+            "-batch",
+        ]
+        if expired:
+            cmd.append("-startdate")
+            cmd.append("090101010101Z")
+            cmd.append("-enddate")
+            cmd.append("090102010101Z")
+        elif future:
+            cmd.append("-startdate")
+            cmd.append("350101010101Z")
+            cmd.append("-enddate")
+            cmd.append("350102010101Z")
+        else:
+            cmd.append("-days")
+            cmd.append("1000")
+        p = subprocess.Popen(cmd)
+        assert p.wait() == 0
 
-        def make_cs_cert(self, new_name, parent_name, parent_loc=None,
-                ext="v3_req", ca_path=None, expiring=False, expired=False,
-                    future=False, https=False, passphrase=None):
-                """Create a new code signing cert."""
+    def make_cs_cert(
+        self,
+        new_name,
+        parent_name,
+        parent_loc=None,
+        ext="v3_req",
+        ca_path=None,
+        expiring=False,
+        expired=False,
+        future=False,
+        https=False,
+        passphrase=None,
+    ):
+        """Create a new code signing cert."""
 
-                if not parent_loc:
-                        parent_loc = self.trust_anchors_loc
-                if not ca_path:
-                        ca_path = self.base_dir
-                subj_str_to_use = self.subj_str
-                if https:
-                        subj_str_to_use = self.https_subj_str
-                cmd = ["openssl", "genrsa", "-out", "{0}/{1}_key.pem".format(
-                    self.keys_dir, new_name), "2048"]
-                p = subprocess.Popen(cmd)
-                assert p.wait() == 0
+        if not parent_loc:
+            parent_loc = self.trust_anchors_loc
+        if not ca_path:
+            ca_path = self.base_dir
+        subj_str_to_use = self.subj_str
+        if https:
+            subj_str_to_use = self.https_subj_str
+        cmd = [
+            "openssl",
+            "genrsa",
+            "-out",
+            "{0}/{1}_key.pem".format(self.keys_dir, new_name),
+            "2048",
+        ]
+        p = subprocess.Popen(cmd)
+        assert p.wait() == 0
 
-                cmd = ["openssl", "req", "-new", "-nodes",
-                    "-key", "{0}/{1}_key.pem".format(self.keys_dir, new_name),
-                    "-out", "{0}/{1}.csr".format(self.cs_dir, new_name),
-                    "-sha256", "-subj", subj_str_to_use.format(new_name, new_name)]
-                p = subprocess.Popen(cmd)
-                assert p.wait() == 0
+        cmd = [
+            "openssl",
+            "req",
+            "-new",
+            "-nodes",
+            "-key",
+            "{0}/{1}_key.pem".format(self.keys_dir, new_name),
+            "-out",
+            "{0}/{1}.csr".format(self.cs_dir, new_name),
+            "-sha256",
+            "-subj",
+            subj_str_to_use.format(new_name, new_name),
+        ]
+        p = subprocess.Popen(cmd)
+        assert p.wait() == 0
 
-                if passphrase:
-                        # Add a passphrase to the key just created using a new filename.
-                        cmd = ["openssl", "rsa", "-des3",
-                            "-in", "{0}/{1}_key.pem".format(self.keys_dir, new_name),
-                            "-out", "{0}/{1}_reqpass_key.pem".format(self.keys_dir,
-                                new_name),
-                            "-passout", "pass:{0}".format(passphrase)]
-                        p = subprocess.Popen(cmd)
-                        assert p.wait() == 0
+        if passphrase:
+            # Add a passphrase to the key just created using a new filename.
+            cmd = [
+                "openssl",
+                "rsa",
+                "-des3",
+                "-in",
+                "{0}/{1}_key.pem".format(self.keys_dir, new_name),
+                "-out",
+                "{0}/{1}_reqpass_key.pem".format(self.keys_dir, new_name),
+                "-passout",
+                "pass:{0}".format(passphrase),
+            ]
+            p = subprocess.Popen(cmd)
+            assert p.wait() == 0
 
-                cmd = ["openssl", "ca", "-policy", "policy_anything",
-                    "-extensions", ext,
-                    "-out", "{0}/{1}_cert.pem".format(self.cs_dir, new_name),
-                    "-in", "{0}/{1}.csr".format(self.cs_dir, new_name),
-                    "-cert", "{0}/{1}/{2}_cert.pem".format(ca_path, parent_loc,
-                        parent_name),
-                    "-outdir", "{0}".format(self.cs_dir),
-                    "-keyfile", "{0}/{1}/{2}_key.pem".format(ca_path, self.keys_loc,
-                        parent_name),
-                    "-config", self.cnf_file,
-                    "-batch"]
-                if expired:
-                        cmd.append("-startdate")
-                        cmd.append("090101010101Z")
-                        cmd.append("-enddate")
-                        cmd.append("090102010101Z")
-                elif future:
-                        cmd.append("-startdate")
-                        cmd.append("350101010101Z")
-                        cmd.append("-enddate")
-                        cmd.append("350102010101Z")
-                elif expiring:
-                        cmd.append("-days")
-                        cmd.append("27")
-                else:
-                        cmd.append("-days")
-                        cmd.append("1000")
-                p = subprocess.Popen(cmd)
-                assert p.wait() == 0
+        cmd = [
+            "openssl",
+            "ca",
+            "-policy",
+            "policy_anything",
+            "-extensions",
+            ext,
+            "-out",
+            "{0}/{1}_cert.pem".format(self.cs_dir, new_name),
+            "-in",
+            "{0}/{1}.csr".format(self.cs_dir, new_name),
+            "-cert",
+            "{0}/{1}/{2}_cert.pem".format(ca_path, parent_loc, parent_name),
+            "-outdir",
+            "{0}".format(self.cs_dir),
+            "-keyfile",
+            "{0}/{1}/{2}_key.pem".format(ca_path, self.keys_loc, parent_name),
+            "-config",
+            self.cnf_file,
+            "-batch",
+        ]
+        if expired:
+            cmd.append("-startdate")
+            cmd.append("090101010101Z")
+            cmd.append("-enddate")
+            cmd.append("090102010101Z")
+        elif future:
+            cmd.append("-startdate")
+            cmd.append("350101010101Z")
+            cmd.append("-enddate")
+            cmd.append("350102010101Z")
+        elif expiring:
+            cmd.append("-days")
+            cmd.append("27")
+        else:
+            cmd.append("-days")
+            cmd.append("1000")
+        p = subprocess.Popen(cmd)
+        assert p.wait() == 0
 
-        def make_trust_anchor(self, name, https=False):
-                """Make a new trust anchor."""
+    def make_trust_anchor(self, name, https=False):
+        """Make a new trust anchor."""
 
-                subj_str_to_use = self.subj_str
-                if https:
-                        subj_str_to_use = self.https_subj_str
-                cmd = ["openssl", "req", "-new", "-x509", "-nodes",
-                    "-keyout", "{0}/{1}_key.pem".format(self.keys_dir, name),
-                    "-subj", subj_str_to_use.format(name, name),
-                    "-out", "{0}/{1}/{2}_cert.tmp".format(self.base_dir, name, name),
-                    "-days", "1000",
-                    "-sha256"]
+        subj_str_to_use = self.subj_str
+        if https:
+            subj_str_to_use = self.https_subj_str
+        cmd = [
+            "openssl",
+            "req",
+            "-new",
+            "-x509",
+            "-nodes",
+            "-keyout",
+            "{0}/{1}_key.pem".format(self.keys_dir, name),
+            "-subj",
+            subj_str_to_use.format(name, name),
+            "-out",
+            "{0}/{1}/{2}_cert.tmp".format(self.base_dir, name, name),
+            "-days",
+            "1000",
+            "-sha256",
+        ]
 
-                os.mkdir("{0}/{1}".format(self.base_dir, name))
+        os.mkdir("{0}/{1}".format(self.base_dir, name))
 
-                p = subprocess.Popen(cmd)
-                assert p.wait() == 0
-                self.convert_pem_to_text("{0}/{1}/{2}_cert.tmp".format(self.base_dir,
-                    name, name), "{0}/{1}/{2}_cert.pem".format(self.base_dir, name,
-                        name))
+        p = subprocess.Popen(cmd)
+        assert p.wait() == 0
+        self.convert_pem_to_text(
+            "{0}/{1}/{2}_cert.tmp".format(self.base_dir, name, name),
+            "{0}/{1}/{2}_cert.pem".format(self.base_dir, name, name),
+        )
 
-                try:
-                        os.link("{0}/{1}/{2}_cert.pem".format(self.base_dir, name, name),
-                            "{0}/{1}_cert.pem".format(self.raw_trust_anchor_dir, name))
-                except:
-                        shutil.copy("{0}/{1}/{2}_cert.pem".format(self.base_dir, name,
-                            name), "{0}/{1}_cert.pem".format(self.raw_trust_anchor_dir,
-                                name))
+        try:
+            os.link(
+                "{0}/{1}/{2}_cert.pem".format(self.base_dir, name, name),
+                "{0}/{1}_cert.pem".format(self.raw_trust_anchor_dir, name),
+            )
+        except:
+            shutil.copy(
+                "{0}/{1}/{2}_cert.pem".format(self.base_dir, name, name),
+                "{0}/{1}_cert.pem".format(self.raw_trust_anchor_dir, name),
+            )
 
-        def revoke_cert(self, ca, revoked_cert, ca_dir=None, cert_dir=None,
-                ca_path=None):
-                """Revoke a certificate using the CA given."""
+    def revoke_cert(
+        self, ca, revoked_cert, ca_dir=None, cert_dir=None, ca_path=None
+    ):
+        """Revoke a certificate using the CA given."""
 
-                if not ca_dir:
-                        ca_dir = ca
-                if not cert_dir:
-                        cert_dir = self.cs_loc
-                if not ca_path:
-                        ca_path = self.base_dir
-                cmd = ["openssl", "ca", "-keyfile", "{0}/{1}/{2}_key.pem".format(
-                    ca_path, self.keys_loc, ca),
-                    "-cert", "{0}/{1}/{2}_cert.pem".format(ca_path, ca_dir, ca),
-                    "-config", self.cnf_file,
-                    "-revoke", "{0}/{1}/{2}_cert.pem".format(self.base_dir, cert_dir,
-                    revoked_cert)]
-                p = subprocess.Popen(cmd)
-                assert p.wait() == 0
+        if not ca_dir:
+            ca_dir = ca
+        if not cert_dir:
+            cert_dir = self.cs_loc
+        if not ca_path:
+            ca_path = self.base_dir
+        cmd = [
+            "openssl",
+            "ca",
+            "-keyfile",
+            "{0}/{1}/{2}_key.pem".format(ca_path, self.keys_loc, ca),
+            "-cert",
+            "{0}/{1}/{2}_cert.pem".format(ca_path, ca_dir, ca),
+            "-config",
+            self.cnf_file,
+            "-revoke",
+            "{0}/{1}/{2}_cert.pem".format(
+                self.base_dir, cert_dir, revoked_cert
+            ),
+        ]
+        p = subprocess.Popen(cmd)
+        assert p.wait() == 0
 
-                cmd = ["openssl", "ca", "-gencrl",
-                    "-keyfile", "{0}/{1}/{2}_key.pem".format(ca_path, self.keys_loc, ca),
-                    "-cert", "{0}/{1}/{2}_cert.pem".format(ca_path, ca_dir, ca),
-                    "-config", self.cnf_file,
-                    "-out", "{0}/{1}_crl.tmp".format(self.crl_dir, ca),
-                    "-crldays", "1000"]
-                p = subprocess.Popen(cmd)
-                assert p.wait() == 0
-                self.convert_pem_to_text("{0}/{1}_crl.tmp".format(self.crl_dir, ca),
-                    "{0}/{1}_crl.pem".format(self.crl_dir, ca), kind="crl")
+        cmd = [
+            "openssl",
+            "ca",
+            "-gencrl",
+            "-keyfile",
+            "{0}/{1}/{2}_key.pem".format(ca_path, self.keys_loc, ca),
+            "-cert",
+            "{0}/{1}/{2}_cert.pem".format(ca_path, ca_dir, ca),
+            "-config",
+            self.cnf_file,
+            "-out",
+            "{0}/{1}_crl.tmp".format(self.crl_dir, ca),
+            "-crldays",
+            "1000",
+        ]
+        p = subprocess.Popen(cmd)
+        assert p.wait() == 0
+        self.convert_pem_to_text(
+            "{0}/{1}_crl.tmp".format(self.crl_dir, ca),
+            "{0}/{1}_crl.pem".format(self.crl_dir, ca),
+            kind="crl",
+        )
 
-        subj_str = "/C=US/ST=California/L=Santa Clara/O=pkg5/CN={0}/emailAddress={1}"
-        https_subj_str = "/C=US/ST=California/L=Santa Clara/O=pkg5/OU={0}/" \
-            "CN=localhost/emailAddress={1}"
+    subj_str = (
+        "/C=US/ST=California/L=Santa Clara/O=pkg5/CN={0}/emailAddress={1}"
+    )
+    https_subj_str = (
+        "/C=US/ST=California/L=Santa Clara/O=pkg5/OU={0}/"
+        "CN=localhost/emailAddress={1}"
+    )
 
-        openssl_conf = """\
+    openssl_conf = """\
 HOME                    = .
 RANDFILE                = $ENV::HOME/.rnd
 
@@ -519,6 +625,5 @@ crlDistributionPoints = URI:foo://bar/baz
 """
 
 
-
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/__init__.py
+++ b/src/tests/cli/__init__.py
@@ -25,4 +25,4 @@
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_actuators.py
+++ b/src/tests/cli/t_actuators.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2020, Oracle and/or its affiliates.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 
 import os
 import six
@@ -34,23 +35,21 @@ import stat
 from io import open
 from pkg.misc import force_text
 
-class TestPkgSMFActuators(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
 
-        smf_cmds = { \
-                "usr/bin/svcprop" :
-"""#!/bin/sh
+class TestPkgSMFActuators(pkg5unittest.SingleDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+
+    smf_cmds = {
+        "usr/bin/svcprop": """#!/bin/sh
 cat $PKG_TEST_DIR/$PKG_SVCPROP_OUTPUT
 exit $PKG_SVCPROP_EXIT_CODE
 """,
-                "usr/sbin/svcadm" : \
-"""#!/bin/sh
+        "usr/sbin/svcadm": """#!/bin/sh
 echo $0 "$@" >> $PKG_TEST_DIR/svcadm_arguments
 exit $PKG_SVCADM_EXIT_CODE
 """,
-                "usr/bin/svcs" : \
-"""#!/bin/sh
+        "usr/bin/svcs": """#!/bin/sh
 
 # called from pkg.client.actuator using 'svcs -H -o fmri <string>'
 # so $4 is the FMRI pattern that we're interested in resolving
@@ -83,26 +82,22 @@ esac
 echo $FMRI
 exit $RETURN
 """,
-                "bin_zlogin" : \
-"""#!/bin/sh
+        "bin_zlogin": """#!/bin/sh
 # print full cmd line, then execute in gz what zlogin would execute in ngz
 echo $0 "$@" >> $PKG_TEST_DIR/zlogin_arguments
 shift
 ($*)
 """,
-                "bin_zoneadm" : \
-"""#!/bin/sh
+        "bin_zoneadm": """#!/bin/sh
 cat <<-EOF
 0:global:running:/::solaris:shared:-:none:
 1:z1:running:$PKG_TZR1::solaris:excl:-::
 2:z2:installed:$PKG_TZR2::solaris:excl:-::
 EOF
-exit 0"""
-
-}
-        misc_files = { \
-                "svcprop_enabled" :
-"""general/enabled boolean true
+exit 0""",
+    }
+    misc_files = {
+        "svcprop_enabled": """general/enabled boolean true
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 4172
@@ -132,9 +127,7 @@ stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method
 """,
-
-                "svcprop_disabled" :
-"""general/enabled boolean false
+        "svcprop_disabled": """general/enabled boolean false
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 4172
@@ -164,9 +157,7 @@ stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method
 """,
-
-                "svcprop_temp_enabled" :
-"""general/enabled boolean false
+        "svcprop_temp_enabled": """general/enabled boolean false
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 7816
@@ -197,8 +188,7 @@ stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method
 """,
-                "svcprop_temp_disabled" :
-"""general/enabled boolean true
+        "svcprop_temp_disabled": """general/enabled boolean true
 general/entity_stability astring Unstable
 general/single_instance boolean true
 restarter/start_pid count 7816
@@ -229,582 +219,672 @@ stop/exec astring :true
 stop/timeout_seconds count 0
 stop/type astring method
 """,
+        "empty": "",
+    }
 
-                "empty": "",
-}
+    testdata_dir = None
 
-        testdata_dir = None
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.testdata_dir = os.path.join(self.test_root, "testdata")
+        os.mkdir(self.testdata_dir)
 
-        def setUp(self):
+        self.pkg_list = []
 
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.testdata_dir = os.path.join(self.test_root, "testdata")
-                os.mkdir(self.testdata_dir)
-
-                self.pkg_list = []
-
-                self.pkg_list+= ["""
+        self.pkg_list += [
+            """
                     open basics@1.0,5.11-0
                     add file testdata/empty mode=0644 owner=root group=sys path=/test_restart restart_fmri=svc:/system/test_restart_svc:default
-                    close """]
+                    close """
+        ]
 
-                self.pkg_list+= ["""
+        self.pkg_list += [
+            """
                     open basics@1.1,5.11-0
                     add file testdata/empty mode=0655 owner=root group=sys path=/test_restart restart_fmri=svc:/system/test_restart_svc:default
-                    close """]
+                    close """
+        ]
 
-                self.pkg_list+= ["""
+        self.pkg_list += [
+            """
                     open basics@1.2,5.11-0
                     add file testdata/empty mode=0646 owner=root group=sys path=/test_restart restart_fmri=svc:/system/test_restart_svc:default
-                    close """]
+                    close """
+        ]
 
-                self.pkg_list+= ["""
+        self.pkg_list += [
+            """
                     open basics@1.3,5.11-0
                     add file testdata/empty mode=0657 owner=root group=sys path=/test_restart refresh_fmri=svc:/system/test_refresh_svc:default
-                    close """]
+                    close """
+        ]
 
-                self.pkg_list+= ["""
+        self.pkg_list += [
+            """
                     open basics@1.4,5.11-0
                     add file testdata/empty mode=0667 owner=root group=sys path=/test_restart suspend_fmri=svc:/system/test_suspend_svc:default
-                    close """]
+                    close """
+        ]
 
-                self.pkg_list+= ["""
+        self.pkg_list += [
+            """
                     open basics@1.5,5.11-0
                     add file testdata/empty mode=0677 owner=root group=sys path=/test_restart suspend_fmri=svc:/system/test_suspend_svc:default disable_fmri=svc:/system/test_disable_svc:default
-                    close """]
+                    close """
+        ]
 
-                # no fully specified FMRIs here
-                self.pkg_list+= ["""
+        # no fully specified FMRIs here
+        self.pkg_list += [
+            """
                     open basics@1.6,5.11-0
                     add file testdata/empty mode=0677 owner=root group=sys path=/test_restart restart_fmri=svc:/system/test_restart_svc suspend_fmri=svc:/system/test_suspend_svc disable_fmri=svc:/system/test_disable_svc
-                    close """]
+                    close """
+        ]
 
-                # multiple FMRIs, some with globbing characters
-                self.pkg_list+= ["""
+        # multiple FMRIs, some with globbing characters
+        self.pkg_list += [
+            """
                     open basics@1.7,5.11-0
                     add file testdata/empty mode=0677 owner=root group=sys path=/test_restart refresh_fmri=svc:/system/test_refresh_svc:default restart_fmri=svc:/system/test_restart_svc* suspend_fmri=svc:/sy*t?st_suspend_svc:def* disable_fmri=*test_disable_svc*
-                    close """]
+                    close """
+        ]
 
-                self.pkg_list += ["""
+        self.pkg_list += [
+            """
                     open basics@1.8,5.11-0
                     add file testdata/empty mode=0677 owner=root group=sys path=/test_restart restart_fmri=svc:/system/test_multi_svc1:default restart_fmri=svc:/system/test_multi_svc2:default
-                    close """]
+                    close """
+        ]
 
-                self.pkg_list += ["""
+        self.pkg_list += [
+            """
                     open basics@1.9,5.11-0
                     add file testdata/empty mode=0677 owner=root group=sys path=/test_restart disable_fmri=svc:/system/test_multi_svc1:default disable_fmri=svc:/system/test_multi_svc2:default
-                    close """]
+                    close """
+        ]
 
-                self.make_misc_files(self.misc_files, prefix="testdata",
-                     mode=0o755)
+        self.make_misc_files(self.misc_files, prefix="testdata", mode=0o755)
 
-        def test_actuators(self):
-                """test actuators"""
+    def test_actuators(self):
+        """test actuators"""
 
-                rurl = self.dc.get_repo_url()
-                plist = self.pkgsend_bulk(rurl, self.pkg_list)
-                self.image_create(rurl)
-                os.environ["PKG_TEST_DIR"] = self.testdata_dir
-                os.environ["PKG_SVCADM_EXIT_CODE"] = "0"
-                os.environ["PKG_SVCPROP_EXIT_CODE"] = "0"
+        rurl = self.dc.get_repo_url()
+        plist = self.pkgsend_bulk(rurl, self.pkg_list)
+        self.image_create(rurl)
+        os.environ["PKG_TEST_DIR"] = self.testdata_dir
+        os.environ["PKG_SVCADM_EXIT_CODE"] = "0"
+        os.environ["PKG_SVCPROP_EXIT_CODE"] = "0"
 
-                svcadm_output = os.path.join(self.testdata_dir,
-                    "svcadm_arguments")
+        svcadm_output = os.path.join(self.testdata_dir, "svcadm_arguments")
 
-                # make it look like our test service is enabled
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
+        # make it look like our test service is enabled
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
 
-                # test to see if our test service is restarted on install
-                self.pkg("install --parsable=0 basics@1.0")
-                self.assertEqualParsable(self.output, add_packages=[plist[0]],
-                    affect_services=[["restart_fmri",
-                        "svc:/system/test_restart_svc:default"]
-                    ])
-                self.pkg("verify")
+        # test to see if our test service is restarted on install
+        self.pkg("install --parsable=0 basics@1.0")
+        self.assertEqualParsable(
+            self.output,
+            add_packages=[plist[0]],
+            affect_services=[
+                ["restart_fmri", "svc:/system/test_restart_svc:default"]
+            ],
+        )
+        self.pkg("verify")
 
-                self.file_contains(svcadm_output,
-                    "svcadm restart svc:/system/test_restart_svc:default")
-                os.unlink(svcadm_output)
+        self.file_contains(
+            svcadm_output, "svcadm restart svc:/system/test_restart_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                # test to see if our test service is restarted on upgrade
-                self.pkg("install basics@1.1")
-                self.pkg("verify")
-                self.file_contains(svcadm_output,
-                    "svcadm restart svc:/system/test_restart_svc:default")
-                os.unlink(svcadm_output)
+        # test to see if our test service is restarted on upgrade
+        self.pkg("install basics@1.1")
+        self.pkg("verify")
+        self.file_contains(
+            svcadm_output, "svcadm restart svc:/system/test_restart_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                # test to see if our test service is restarted on uninstall
-                self.pkg("uninstall basics")
-                self.pkg("verify")
-                self.file_contains(svcadm_output,
-                    "svcadm restart svc:/system/test_restart_svc:default")
-                os.unlink(svcadm_output)
+        # test to see if our test service is restarted on uninstall
+        self.pkg("uninstall basics")
+        self.pkg("verify")
+        self.file_contains(
+            svcadm_output, "svcadm restart svc:/system/test_restart_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                # make it look like our test service is not enabled
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_disabled"
+        # make it look like our test service is not enabled
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_disabled"
 
-                # test to see to make sure we don't restart disabled service
-                self.pkg("install basics@1.2")
-                self.pkg("verify")
-                self.file_doesnt_exist(svcadm_output)
+        # test to see to make sure we don't restart disabled service
+        self.pkg("install basics@1.2")
+        self.pkg("verify")
+        self.file_doesnt_exist(svcadm_output)
 
-                # test to see if services that aren't installed are ignored
-                os.environ["PKG_SVCPROP_EXIT_CODE"] = "1"
-                self.pkg("uninstall basics")
-                self.pkg("verify")
-                self.pkg("install basics@1.2")
-                self.pkg("verify")
-                self.file_doesnt_exist(svcadm_output)
-                os.environ["PKG_SVCPROP_EXIT_CODE"] = "0"
+        # test to see if services that aren't installed are ignored
+        os.environ["PKG_SVCPROP_EXIT_CODE"] = "1"
+        self.pkg("uninstall basics")
+        self.pkg("verify")
+        self.pkg("install basics@1.2")
+        self.pkg("verify")
+        self.file_doesnt_exist(svcadm_output)
+        os.environ["PKG_SVCPROP_EXIT_CODE"] = "0"
 
-                # make it look like our test service(s) is/are enabled
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
+        # make it look like our test service(s) is/are enabled
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
 
-                # test to see if refresh works as designed, along w/ restart
-                self.pkg("install basics@1.3")
-                self.pkg("verify")
-                self.file_contains(svcadm_output,
-                    "svcadm restart svc:/system/test_restart_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm refresh svc:/system/test_refresh_svc:default")
-                os.unlink(svcadm_output)
+        # test to see if refresh works as designed, along w/ restart
+        self.pkg("install basics@1.3")
+        self.pkg("verify")
+        self.file_contains(
+            svcadm_output, "svcadm restart svc:/system/test_restart_svc:default"
+        )
+        self.file_contains(
+            svcadm_output, "svcadm refresh svc:/system/test_refresh_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                # test if suspend works
-                self.pkg("install basics@1.4")
-                self.pkg("verify")
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s -t svc:/system/test_suspend_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm enable svc:/system/test_suspend_svc:default")
-                os.unlink(svcadm_output)
+        # test if suspend works
+        self.pkg("install basics@1.4")
+        self.pkg("verify")
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s -t svc:/system/test_suspend_svc:default",
+        )
+        self.file_contains(
+            svcadm_output, "svcadm enable svc:/system/test_suspend_svc:default"
+        )
+        os.unlink(svcadm_output)
 
-                # test if suspend works properly w/ temp. enabled service
-                # make it look like our test service(s) is/are temp enabled
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_temp_enabled"
-                self.pkg("install basics@1.5")
-                self.pkg("verify")
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s -t svc:/system/test_suspend_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm enable -t svc:/system/test_suspend_svc:default")
-                os.unlink(svcadm_output)
+        # test if suspend works properly w/ temp. enabled service
+        # make it look like our test service(s) is/are temp enabled
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_temp_enabled"
+        self.pkg("install basics@1.5")
+        self.pkg("verify")
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s -t svc:/system/test_suspend_svc:default",
+        )
+        self.file_contains(
+            svcadm_output,
+            "svcadm enable -t svc:/system/test_suspend_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                # test if service is disabled on uninstall
-                self.pkg("uninstall basics")
-                self.pkg("verify")
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s svc:/system/test_disable_svc:default")
-                os.unlink(svcadm_output)
+        # test if service is disabled on uninstall
+        self.pkg("uninstall basics")
+        self.pkg("verify")
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s svc:/system/test_disable_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                # make it look like our test service(s) is/are enabled
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
-                os.environ["PKG_SVCPROP_EXIT_CODE"] = "0"
+        # make it look like our test service(s) is/are enabled
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
+        os.environ["PKG_SVCPROP_EXIT_CODE"] = "0"
 
-                # test that we do nothing for FMRIs with no instance specified
-                self.pkg("install basics@1.6")
-                self.pkg("verify")
-                self.file_doesnt_exist(svcadm_output)
-                self.pkg("uninstall basics")
-                self.file_doesnt_exist(svcadm_output)
+        # test that we do nothing for FMRIs with no instance specified
+        self.pkg("install basics@1.6")
+        self.pkg("verify")
+        self.file_doesnt_exist(svcadm_output)
+        self.pkg("uninstall basics")
+        self.file_doesnt_exist(svcadm_output)
 
-                # test that we do the right thing for multiple FMRIs with
-                # globbing chars
-                self.pkg("install basics@1.6")
-                self.pkg("install basics@1.7")
-                self.pkg("verify")
+        # test that we do the right thing for multiple FMRIs with
+        # globbing chars
+        self.pkg("install basics@1.6")
+        self.pkg("install basics@1.7")
+        self.pkg("verify")
 
-                for text in [ "svcadm refresh svc:/system/test_refresh_svc:default",
-                   "svcadm refresh svc:/system/test_refresh_svc:default",
-                   "svcadm restart svc:/system/test_restart_svc:default",
-                   "svcadm disable -s -t svc:/system/test_suspend_svc:default",
-                   "svcadm enable svc:/system/test_suspend_svc:default" ]:
-                           self.file_contains(svcadm_output, text)
+        for text in [
+            "svcadm refresh svc:/system/test_refresh_svc:default",
+            "svcadm refresh svc:/system/test_refresh_svc:default",
+            "svcadm restart svc:/system/test_restart_svc:default",
+            "svcadm disable -s -t svc:/system/test_suspend_svc:default",
+            "svcadm enable svc:/system/test_suspend_svc:default",
+        ]:
+            self.file_contains(svcadm_output, text)
 
-                # Next test will get muddled if prior actuators get
-                # run too, so we test removal here.
-                self.pkg("uninstall basics")
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s svc:/system/test_disable_svc:default")
-                os.unlink(svcadm_output)
+        # Next test will get muddled if prior actuators get
+        # run too, so we test removal here.
+        self.pkg("uninstall basics")
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s svc:/system/test_disable_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                # Test with multi-valued actuators
-                self.pkg("install basics@1.8")
-                self.pkg("verify")
-                if six.PY2:
-                        self.file_contains(svcadm_output,
-                            "svcadm restart svc:/system/test_multi_svc1:default "
-                            "svc:/system/test_multi_svc2:default")
-                else:
-                        # output order is not stable in Python 3
-                        self.file_contains(svcadm_output, ["svcadm restart",
-                            "svc:/system/test_multi_svc1:default",
-                            "svc:/system/test_multi_svc2:default"])
+        # Test with multi-valued actuators
+        self.pkg("install basics@1.8")
+        self.pkg("verify")
+        if six.PY2:
+            self.file_contains(
+                svcadm_output,
+                "svcadm restart svc:/system/test_multi_svc1:default "
+                "svc:/system/test_multi_svc2:default",
+            )
+        else:
+            # output order is not stable in Python 3
+            self.file_contains(
+                svcadm_output,
+                [
+                    "svcadm restart",
+                    "svc:/system/test_multi_svc1:default",
+                    "svc:/system/test_multi_svc2:default",
+                ],
+            )
 
-                # Test synchronous options
-                # synchronous restart
-                self.pkg("uninstall basics")
-                self.pkg("install --sync-actuators basics@1.1")
-                self.pkg("verify")
-                self.file_contains(svcadm_output,
-                    "svcadm restart -s svc:/system/test_restart_svc:default")
-                os.unlink(svcadm_output)
+        # Test synchronous options
+        # synchronous restart
+        self.pkg("uninstall basics")
+        self.pkg("install --sync-actuators basics@1.1")
+        self.pkg("verify")
+        self.file_contains(
+            svcadm_output,
+            "svcadm restart -s svc:/system/test_restart_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                # synchronous restart with timeout
-                self.pkg("uninstall basics")
-                self.pkg("install --sync-actuators --sync-actuators-timeout 20 basics@1.1")
-                self.pkg("verify")
-                self.file_contains(svcadm_output,
-                    "svcadm restart -s svc:/system/test_restart_svc:default")
-                os.unlink(svcadm_output)
+        # synchronous restart with timeout
+        self.pkg("uninstall basics")
+        self.pkg(
+            "install --sync-actuators --sync-actuators-timeout 20 basics@1.1"
+        )
+        self.pkg("verify")
+        self.file_contains(
+            svcadm_output,
+            "svcadm restart -s svc:/system/test_restart_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                # synchronous suspend
-                self.pkg("install --sync-actuators basics@1.4")
-                self.pkg("verify")
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s -t svc:/system/test_suspend_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm enable -s svc:/system/test_suspend_svc:default")
-                os.unlink(svcadm_output)
+        # synchronous suspend
+        self.pkg("install --sync-actuators basics@1.4")
+        self.pkg("verify")
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s -t svc:/system/test_suspend_svc:default",
+        )
+        self.file_contains(
+            svcadm_output,
+            "svcadm enable -s svc:/system/test_suspend_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                # synchronous suspend with timeout
-                self.pkg("uninstall basics")
-                self.pkg("install basics@1.1")
-                self.pkg("install --sync-actuators --sync-actuators-timeout 10 basics@1.4")
-                self.pkg("verify")
-                self.file_contains(svcadm_output,
-                    "svcadm disable -s -t svc:/system/test_suspend_svc:default")
-                self.file_contains(svcadm_output,
-                    "svcadm enable -s svc:/system/test_suspend_svc:default")
-                os.unlink(svcadm_output)
+        # synchronous suspend with timeout
+        self.pkg("uninstall basics")
+        self.pkg("install basics@1.1")
+        self.pkg(
+            "install --sync-actuators --sync-actuators-timeout 10 basics@1.4"
+        )
+        self.pkg("verify")
+        self.file_contains(
+            svcadm_output,
+            "svcadm disable -s -t svc:/system/test_suspend_svc:default",
+        )
+        self.file_contains(
+            svcadm_output,
+            "svcadm enable -s svc:/system/test_suspend_svc:default",
+        )
+        os.unlink(svcadm_output)
 
-                # make it look like our test service is enabled
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
+        # make it look like our test service is enabled
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
 
-                self.pkg("install basics@1.9")
-                self.pkg("verify")
-                self.pkg("uninstall basics")
-                if six.PY2:
-                        self.file_contains(svcadm_output,
-                            "svcadm disable -s svc:/system/test_multi_svc1:default "
-                            "svc:/system/test_multi_svc2:default")
-                else:
-                        # output order is not stable in Python 3
-                        self.file_contains(svcadm_output, ["svcadm disable -s",
-                            "svc:/system/test_multi_svc1:default",
-                            "svc:/system/test_multi_svc2:default"])
-                os.unlink(svcadm_output)
+        self.pkg("install basics@1.9")
+        self.pkg("verify")
+        self.pkg("uninstall basics")
+        if six.PY2:
+            self.file_contains(
+                svcadm_output,
+                "svcadm disable -s svc:/system/test_multi_svc1:default "
+                "svc:/system/test_multi_svc2:default",
+            )
+        else:
+            # output order is not stable in Python 3
+            self.file_contains(
+                svcadm_output,
+                [
+                    "svcadm disable -s",
+                    "svc:/system/test_multi_svc1:default",
+                    "svc:/system/test_multi_svc2:default",
+                ],
+            )
+        os.unlink(svcadm_output)
 
-        def test_actuator_plan_display(self):
-                """Test that the actuators are correct in plan display for different
-                pkg operations."""
+    def test_actuator_plan_display(self):
+        """Test that the actuators are correct in plan display for different
+        pkg operations."""
 
-                rurl = self.dc.get_repo_url()
-                plist = self.pkgsend_bulk(rurl, self.pkg_list)
-                self.image_create(rurl)
+        rurl = self.dc.get_repo_url()
+        plist = self.pkgsend_bulk(rurl, self.pkg_list)
+        self.image_create(rurl)
 
-                self.pkg("install -v basics@1.0")
-                self.assertTrue("restart_fmri" in self.output)
+        self.pkg("install -v basics@1.0")
+        self.assertTrue("restart_fmri" in self.output)
 
-                self.pkg("update -v basics@1.5")
-                self.assertTrue("suspend_fmri" in self.output
-                    and "disable_fmri" not in self.output)
+        self.pkg("update -v basics@1.5")
+        self.assertTrue(
+            "suspend_fmri" in self.output and "disable_fmri" not in self.output
+        )
 
-                self.pkg("uninstall -v basics")
-                self.assertTrue("suspend_fmri" not in self.output
-                    and "disable_fmri" in self.output)
+        self.pkg("uninstall -v basics")
+        self.assertTrue(
+            "suspend_fmri" not in self.output and "disable_fmri" in self.output
+        )
 
-                self.pkg("install -v basics@1.5")
-                self.assertTrue("suspend_fmri" not in self.output and
-                    "disable_fmri" not in self.output)
-                self.pkg("uninstall basics")
+        self.pkg("install -v basics@1.5")
+        self.assertTrue(
+            "suspend_fmri" not in self.output
+            and "disable_fmri" not in self.output
+        )
+        self.pkg("uninstall basics")
 
-                self.pkg("install -v basics@1.7")
-                self.assertTrue("restart_fmri" in self.output and
-                    "refresh_fmri" in self.output and
-                    "suspend_fmri" not in self.output and
-                    "disable_fmri" not in self.output)
+        self.pkg("install -v basics@1.7")
+        self.assertTrue(
+            "restart_fmri" in self.output
+            and "refresh_fmri" in self.output
+            and "suspend_fmri" not in self.output
+            and "disable_fmri" not in self.output
+        )
 
-        def __create_zone(self, zname, rurl):
-                """Create a fake zone linked image and attach to parent."""
+    def __create_zone(self, zname, rurl):
+        """Create a fake zone linked image and attach to parent."""
 
-                zone_path = os.path.join(self.img_path(0), zname)
-                os.mkdir(zone_path)
-                # zone images are rooted at <zonepath>/root
-                zimg_path = os.path.join(zone_path, "root")
-                self.image_create(repourl=rurl, img_path=zimg_path)
-                self.pkg("-R {0} attach-linked -c system:{1} {2}".format(
-                    self.img_path(0), zname, zimg_path))
+        zone_path = os.path.join(self.img_path(0), zname)
+        os.mkdir(zone_path)
+        # zone images are rooted at <zonepath>/root
+        zimg_path = os.path.join(zone_path, "root")
+        self.image_create(repourl=rurl, img_path=zimg_path)
+        self.pkg(
+            "-R {0} attach-linked -c system:{1} {2}".format(
+                self.img_path(0), zname, zimg_path
+            )
+        )
 
-                return zone_path
+        return zone_path
 
-        def test_zone_actuators(self):
-                """test zone actuators"""
+    def test_zone_actuators(self):
+        """test zone actuators"""
 
-                rurl = self.dc.get_repo_url()
-                plist = self.pkgsend_bulk(rurl, self.pkg_list)
-                self.image_create(rurl)
+        rurl = self.dc.get_repo_url()
+        plist = self.pkgsend_bulk(rurl, self.pkg_list)
+        self.image_create(rurl)
 
-                # Create fake zone images.
-                # We have one "running" zone (z1) and one "installed" zone (z2).
-                # The zone actuators should only be run in the running zone.
+        # Create fake zone images.
+        # We have one "running" zone (z1) and one "installed" zone (z2).
+        # The zone actuators should only be run in the running zone.
 
-                # set env variable for fake zoneadm to print correct zonepaths
-                os.environ["PKG_TZR1"] = self.__create_zone("z1", rurl)
-                os.environ["PKG_TZR2"] = self.__create_zone("z2", rurl)
+        # set env variable for fake zoneadm to print correct zonepaths
+        os.environ["PKG_TZR1"] = self.__create_zone("z1", rurl)
+        os.environ["PKG_TZR2"] = self.__create_zone("z2", rurl)
 
-                os.environ["PKG_TEST_DIR"] = self.testdata_dir
-                os.environ["PKG_SVCADM_EXIT_CODE"] = "0"
-                os.environ["PKG_SVCPROP_EXIT_CODE"] = "0"
+        os.environ["PKG_TEST_DIR"] = self.testdata_dir
+        os.environ["PKG_SVCADM_EXIT_CODE"] = "0"
+        os.environ["PKG_SVCPROP_EXIT_CODE"] = "0"
 
-                # Prepare fake zone and smf cmds.
-                svcadm_output = os.path.join(self.testdata_dir,
-                    "svcadm_arguments")
-                zlogin_output = os.path.join(self.testdata_dir,
-                    "zlogin_arguments")
-                bin_zlogin = os.path.join(self.test_root,
-                    "smf_cmds", "bin_zlogin")
-                bin_zoneadm = os.path.join(self.test_root,
-                    "smf_cmds", "bin_zoneadm")
+        # Prepare fake zone and smf cmds.
+        svcadm_output = os.path.join(self.testdata_dir, "svcadm_arguments")
+        zlogin_output = os.path.join(self.testdata_dir, "zlogin_arguments")
+        bin_zlogin = os.path.join(self.test_root, "smf_cmds", "bin_zlogin")
+        bin_zoneadm = os.path.join(self.test_root, "smf_cmds", "bin_zoneadm")
 
-                # make it look like our test service is enabled
-                os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
+        # make it look like our test service is enabled
+        os.environ["PKG_SVCPROP_OUTPUT"] = "svcprop_enabled"
 
-                # test to see if our test service is restarted on install
-                self.pkg("--debug bin_zoneadm='{0}' "
-                    "--debug bin_zlogin='{1}' "
-                    "install -rv basics@1.0".format(bin_zoneadm, bin_zlogin))
-                # test that actuator in global zone and z2 is run
-                self.file_contains(svcadm_output,
-                    "svcadm restart svc:/system/test_restart_svc:default",
-                    appearances=2)
-                os.unlink(svcadm_output)
-                # test that actuator in non-global zone is run
-                self.file_contains(zlogin_output,
-                    "zlogin z1")
-                self.file_doesnt_contain(zlogin_output,
-                    "zlogin z2")
-                self.file_contains(zlogin_output,
-                    "svcadm restart svc:/system/test_restart_svc:default")
-                os.unlink(zlogin_output)
+        # test to see if our test service is restarted on install
+        self.pkg(
+            "--debug bin_zoneadm='{0}' "
+            "--debug bin_zlogin='{1}' "
+            "install -rv basics@1.0".format(bin_zoneadm, bin_zlogin)
+        )
+        # test that actuator in global zone and z2 is run
+        self.file_contains(
+            svcadm_output,
+            "svcadm restart svc:/system/test_restart_svc:default",
+            appearances=2,
+        )
+        os.unlink(svcadm_output)
+        # test that actuator in non-global zone is run
+        self.file_contains(zlogin_output, "zlogin z1")
+        self.file_doesnt_contain(zlogin_output, "zlogin z2")
+        self.file_contains(
+            zlogin_output, "svcadm restart svc:/system/test_restart_svc:default"
+        )
+        os.unlink(zlogin_output)
+
 
 class TestPkgReleaseNotes(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             add file tmp/release-note-1 mode=0644 owner=root group=bin path=/usr/share/doc/release-notes/release-note-1 release-note=feature/pkg/self@0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             add file tmp/release-note-2 mode=0644 owner=root group=root path=/usr/share/doc/release-notes/release-note-2 release-note=feature/pkg/self@1.0.1
             close """
 
-        foo12 = """
+    foo12 = """
             open foo@1.2,5.11-0
             add file tmp/release-note-3 mode=0644 owner=root group=root path=/usr/share/doc/release-notes/release-note-3 release-note=feature/pkg/self@1.1.1 must-display=true
             close """
 
-        foo13 = """
+    foo13 = """
             open foo@1.3,5.11-0
             add file tmp/release-note-4 mode=0644 owner=root group=root path=/usr/share/doc/release-notes/release-note-4 release-note=feature/pkg/self@1.1
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             add dir path=/usr mode=0755 owner=root group=root release-note=feature/pkg/self@0
             close """
 
-        bar11 = """
+    bar11 = """
             open bar@1.1,5.11-0
             close """
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             add file tmp/release-note-5 mode=0644 owner=root group=root path=/usr/share/doc/release-notes/release-note-5 release-note=bar@1.1
             close """
 
-        hovercraft = """
+    hovercraft = """
             open hovercraft@1.0,5.10-0
             add file tmp/release-note-6 mode=0644 owner=root group=root path=/usr/share/doc/release-notes/release-note-6 release-note=feature/pkg/self@0
             close """
 
-        badencoding10 = """
+    badencoding10 = """
             open badencoding@1.0,5.11-0
             add file tmp/release-note-7 mode=0644 owner=root group=bin path=/usr/share/doc/release-notes/release-note-7 release-note=feature/pkg/self@0
             close """
 
+    multi_unicode = "Eels are best smoked\nМоё судно на воздушной подушке полно угрей\nHovercraft can be smoked, too.\n"
+    multi_ascii = (
+        "multi-line release notes\nshould work too,\nwe'll see if they do.\n"
+    )
+    misc_files = {
+        "tmp/release-note-1": "bobcats are fun!",
+        "tmp/release-note-2": "wombats are fun!",
+        "tmp/release-note-3": "no animals were hurt...",
+        "tmp/release-note-4": "no vegetables were hurt...",
+        "tmp/release-note-5": multi_ascii,
+        "tmp/release-note-6": multi_unicode,
+    }
 
-        multi_unicode = u"Eels are best smoked\nМоё судно на воздушной подушке полно угрей\nHovercraft can be smoked, too.\n"
-        multi_ascii = "multi-line release notes\nshould work too,\nwe'll see if they do.\n"
-        misc_files = {
-                "tmp/release-note-1":"bobcats are fun!",
-                "tmp/release-note-2":"wombats are fun!",
-                "tmp/release-note-3":"no animals were hurt...",
-                "tmp/release-note-4":"no vegetables were hurt...",
-                "tmp/release-note-5":multi_ascii,
-                "tmp/release-note-6":multi_unicode
-                }
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        badenc_relnote = os.path.join(self.ro_data_root, "badencoding.relnote")
+        self.make_misc_files({"tmp/release-note-7": badenc_relnote}, copy=True)
+        self.pkgsend_bulk(
+            self.rurl,
+            self.foo10
+            + self.foo11
+            + self.foo12
+            + self.foo13
+            + self.bar10
+            + self.bar11
+            + self.baz10
+            + self.hovercraft
+            + self.badencoding10,
+        )
+        self.image_create(self.rurl)
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                badenc_relnote = os.path.join(self.ro_data_root,
-                                                   "badencoding.relnote")
-                self.make_misc_files({"tmp/release-note-7": badenc_relnote},
-                                     copy=True)
-                self.pkgsend_bulk(self.rurl, self.foo10 + self.foo11 +
-                    self.foo12 + self.foo13 + self.bar10 + self.bar11 +
-                    self.baz10 + self.hovercraft + self.badencoding10)
-                self.image_create(self.rurl)
+    def test_release_note_1(self):
+        # make sure release note gets printed on original install
+        self.pkg("install -v foo@1.0")
+        self.output.index("bobcats are fun!")
+        # check update case
+        self.pkg("update -v foo@1.1")
+        self.output.index("wombats are fun!")
+        # check must display case
+        self.pkg("update foo@1.2")
+        self.output.index("no animals")
+        # check that no output is seen w/o must-display and -v,
+        # but that user is prompted that notes are available.
+        self.pkg("update foo@1.3")
+        assert self.output.find("no vegetables") == -1
+        self.pkg("uninstall '*'")
 
-        def test_release_note_1(self):
-                # make sure release note gets printed on original install
-                self.pkg("install -v foo@1.0")
-                self.output.index("bobcats are fun!")
-                # check update case
-                self.pkg("update -v foo@1.1")
-                self.output.index("wombats are fun!")
-                # check must display case
-                self.pkg("update foo@1.2")
-                self.output.index("no animals")
-                # check that no output is seen w/o must-display and -v,
-                # but that user is prompted that notes are available.
-                self.pkg("update foo@1.3")
-                assert self.output.find("no vegetables") == -1
-                self.pkg("uninstall '*'")
+    def test_release_note_2(self):
+        # check that release notes are printed with just -n
+        self.pkg("install -vn foo@1.0")
+        self.output.index("bobcats are fun!")
+        # retrieve release notes with pkg history after actual install
+        self.pkg("install foo@1.0")
+        # make sure we note that release notes are available
+        self.output.index("Release notes")
+        # check that we list them in the -l output
+        self.pkg("history -n 1 -l")
+        self.output.index("Release Notes")
+        # retrieve notes and look for felines
+        self.pkg("history -n 1 -N")
+        self.output.index("bobcats are fun!")
+        # check that we say yes that release notes are available
+        self.pkg("history -Hn 1 -o release_notes")
+        self.output.index("Yes")
+        self.pkg("uninstall '*'")
 
-        def test_release_note_2(self):
-                # check that release notes are printed with just -n
-                self.pkg("install -vn foo@1.0")
-                self.output.index("bobcats are fun!")
-                # retrieve release notes with pkg history after actual install
-                self.pkg("install foo@1.0")
-                # make sure we note that release notes are available
-                self.output.index("Release notes")
-                # check that we list them in the -l output
-                self.pkg("history -n 1 -l")
-                self.output.index("Release Notes")
-                # retrieve notes and look for felines
-                self.pkg("history -n 1 -N")
-                self.output.index("bobcats are fun!")
-                # check that we say yes that release notes are available
-                self.pkg("history -Hn 1 -o release_notes")
-                self.output.index("Yes")
-                self.pkg("uninstall '*'")
+    def test_release_note_3(self):
+        # check that release notes are printed properly
+        # when needed and dependency is on other pkg
+        self.pkg("install bar@1.0")
+        self.pkg("install -v baz@1.0")
+        self.output.index("multi-line release notes")
+        self.output.index("should work too,")
+        self.output.index("we'll see if they do.")
+        # should not see notes again
+        self.pkg("update -v bar")
+        assert self.output.find("Release notes") == -1
+        self.pkg("uninstall '*'")
+        # no output expected here since baz@1.0 isn't part of original image.
+        self.pkg("install bar@1.0 baz@1.0")
+        assert self.output.find("multi-line release notes") == -1
+        self.pkg("uninstall '*'")
 
-        def test_release_note_3(self):
-                # check that release notes are printed properly
-                # when needed and dependency is on other pkg
-                self.pkg("install bar@1.0")
-                self.pkg("install -v baz@1.0")
-                self.output.index("multi-line release notes")
-                self.output.index("should work too,")
-                self.output.index("we'll see if they do.")
-                # should not see notes again
-                self.pkg("update -v bar")
-                assert self.output.find("Release notes") == -1
-                self.pkg("uninstall '*'")
-                # no output expected here since baz@1.0 isn't part of original image.
-                self.pkg("install bar@1.0 baz@1.0")
-                assert self.output.find("multi-line release notes") == -1
-                self.pkg("uninstall '*'")
+    def test_release_note_4(self):
+        # make sure that parseable option works properly
+        self.pkg("install bar@1.0")
+        self.pkg("install --parsable 0 baz@1.0")
+        self.output.index("multi-line release notes")
+        self.output.index("should work too,")
+        self.output.index("we'll see if they do.")
+        self.pkg("uninstall '*'")
 
-        def test_release_note_4(self):
-                # make sure that parseable option works properly
-                self.pkg("install bar@1.0")
-                self.pkg("install --parsable 0 baz@1.0")
-                self.output.index("multi-line release notes")
-                self.output.index("should work too,")
-                self.output.index("we'll see if they do.")
-                self.pkg("uninstall '*'")
+    def test_release_note_5(self):
+        # test unicode character in release notes
+        self.pkg("install -n hovercraft@1.0")
+        force_text(self.output, "utf-8").index(
+            "Моё судно на воздушной подушке полно угрей"
+        )
+        force_text(self.output, "utf-8").index("Eels are best smoked")
+        self.pkg("install -v hovercraft@1.0")
+        force_text(self.output, "utf-8").index(
+            "Моё судно на воздушной подушке полно угрей"
+        )
+        force_text(self.output, "utf-8").index("Eels are best smoked")
+        self.pkg("uninstall '*'")
 
-        def test_release_note_5(self):
-                # test unicode character in release notes
-                self.pkg("install -n hovercraft@1.0")
-                force_text(self.output, "utf-8").index(u"Моё судно на воздушной подушке полно угрей")
-                force_text(self.output, "utf-8").index(u"Eels are best smoked")
-                self.pkg("install -v hovercraft@1.0")
-                force_text(self.output, "utf-8").index(u"Моё судно на воздушной подушке полно угрей")
-                force_text(self.output, "utf-8").index(u"Eels are best smoked")
-                self.pkg("uninstall '*'")
+    def test_release_note_6(self):
+        # test parsable unicode
+        self.pkg("install --parsable 0 hovercraft@1.0")
+        self.pkg("history -n 1 -N")
+        force_text(self.output, "utf-8").index(
+            "Моё судно на воздушной подушке полно угрей"
+        )
+        force_text(self.output, "utf-8").index("Eels are best smoked")
+        self.pkg("uninstall '*'")
 
-        def test_release_note_6(self):
-                # test parsable unicode
-                self.pkg("install --parsable 0 hovercraft@1.0")
-                self.pkg("history -n 1 -N")
-                force_text(self.output, "utf-8").index(u"Моё судно на воздушной подушке полно угрей")
-                force_text(self.output, "utf-8").index(u"Eels are best smoked")
-                self.pkg("uninstall '*'")
+    def test_release_note_7(self):
+        # check that multiple release notes are composited properly
+        self.pkg("install bar@1.0")
+        self.pkg("install -v hovercraft@1.0 baz@1.0")
+        uni_out = force_text(self.output, "utf-8")
+        # we indent the release notes for readability, so a strict
+        # index or compare won't work unless we remove indenting
+        # this works for our test cases since they have no leading
+        # spaces
 
-        def test_release_note_7(self):
-                # check that multiple release notes are composited properly
-                self.pkg("install bar@1.0")
-                self.pkg("install -v hovercraft@1.0 baz@1.0")
-                uni_out = force_text(self.output, "utf-8")
-                # we indent the release notes for readability, so a strict
-                # index or compare won't work unless we remove indenting
-                # this works for our test cases since they have no leading
-                # spaces
+        # removing indent
+        uni_out = "\n".join((n.lstrip() for n in uni_out.split("\n")))
 
-                # removing indent
-                uni_out = "\n".join((n.lstrip() for n in uni_out.split("\n")))
+        uni_out.index(self.multi_unicode)
+        uni_out.index(self.multi_ascii)
 
-                uni_out.index(self.multi_unicode)
-                uni_out.index(self.multi_ascii)
+        # repeat test using history to make sure everything is there.
+        # do as unpriv. user
 
-                # repeat test using history to make sure everything is there.
-                # do as unpriv. user
+        self.pkg("history -n 1 -HN", su_wrap=True)
+        uni_out = force_text(self.output, "utf-8")
+        # we indent the release notes for readability, so a strict
+        # index or compare won't work unless we remove indenting
+        # this works for our test cases since they have no leading
+        # spaces
 
-                self.pkg("history -n 1 -HN", su_wrap=True)
-                uni_out = force_text(self.output, "utf-8")
-                # we indent the release notes for readability, so a strict
-                # index or compare won't work unless we remove indenting
-                # this works for our test cases since they have no leading
-                # spaces
+        # removing indent
+        uni_out = "\n".join((n.lstrip() for n in uni_out.split("\n")))
 
-                # removing indent
-                uni_out = "\n".join((n.lstrip() for n in uni_out.split("\n")))
+        uni_out.index(self.multi_unicode)
+        uni_out.index(self.multi_ascii)
+        self.pkg("uninstall '*'")
 
-                uni_out.index(self.multi_unicode)
-                uni_out.index(self.multi_ascii)
-                self.pkg("uninstall '*'")
+    def test_release_note_8(self):
+        # verify that temporary file is correctly written with /n characters
+        self.pkg("-D GenerateNotesFile=1 install hovercraft@1.0")
+        # find name of file containing release notes in output.
+        for field in force_text(self.output, "utf-8").split(" "):
+            try:
+                if field.index("release-note"):
+                    break
+            except:
+                pass
+        else:
+            assert "output file not found" == 0
 
-        def test_release_note_8(self):
-                # verify that temporary file is correctly written with /n characters
-                self.pkg("-D GenerateNotesFile=1 install hovercraft@1.0")
-                # find name of file containing release notes in output.
-                for field in force_text(self.output, "utf-8").split(u" "):
-                        try:
-                                if field.index(u"release-note"):
-                                        break
-                        except:
-                                pass
-                else:
-                        assert "output file not found" == 0
+        # make sure file is readable by everyone
+        assert stat.S_IMODE(os.stat(field).st_mode) == 0o644
 
-                # make sure file is readable by everyone
-                assert(stat.S_IMODE(os.stat(field).st_mode) == 0o644)
+        # read release note file and check to make sure
+        # entire contents are there verbatim
+        with open(field, encoding="utf-8") as f:
+            release_note = force_text(f.read())
 
-                # read release note file and check to make sure
-                # entire contents are there verbatim
-                with open(field, encoding="utf-8") as f:
-                        release_note = force_text(f.read())
+        assert self.multi_unicode == release_note
 
-                assert self.multi_unicode == release_note
+        self.pkg("uninstall '*'")
 
-                self.pkg("uninstall '*'")
-
-        def test_release_note_bad_encoding(self):
-                self.pkg("install -v badencoding@1.0")
-                self.pkg("uninstall '*'")
+    def test_release_note_bad_encoding(self):
+        self.pkg("install -v badencoding@1.0")
+        self.pkg("uninstall '*'")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_change_facet.py
+++ b/src/tests/cli/t_change_facet.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -34,10 +35,10 @@ import unittest
 
 
 class TestPkgChangeFacet(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        pkg_A = """
+    pkg_A = """
         open pkg_A@1.0,5.11-0
         add file tmp/facets_0 mode=0555 owner=root group=bin path=0
         add file tmp/facets_1 mode=0555 owner=root group=bin path=1 facet.locale.fr=True
@@ -52,15 +53,15 @@ class TestPkgChangeFacet(pkg5unittest.SingleDepotTestCase):
         add link path=test target=1
         close"""
 
-        pkg_B1 = """
+    pkg_B1 = """
         open pkg_B@1.0,5.11-0
         close"""
-        pkg_B2 = """
+    pkg_B2 = """
         open pkg_B@2.0,5.11-0
         close"""
 
-        # All 'all's must be true AND any 'true's true.
-        pkg_top_level = """
+    # All 'all's must be true AND any 'true's true.
+    pkg_top_level = """
         open pkg_top_level@1.0,5.11-0
         add file tmp/facets_0 mode=0555 owner=root group=bin path=top0 facet.devel=all
         add file tmp/facets_1 mode=0555 owner=root group=bin path=top1 facet.doc=all
@@ -73,557 +74,614 @@ class TestPkgChangeFacet(pkg5unittest.SingleDepotTestCase):
         add file tmp/facets_8 mode=0555 owner=root group=bin path=optional_fr.doc facet.optional.doc=all facet.doc=all facet.locale.fr_CA=true
         close"""
 
-        misc_files = [
-            "tmp/facets_0", "tmp/facets_1", "tmp/facets_2", "tmp/facets_3",
-            "tmp/facets_4", "tmp/facets_5", "tmp/facets_6", "tmp/facets_7",
-            "tmp/facets_8", "tmp/facets_9"
-        ]
+    misc_files = [
+        "tmp/facets_0",
+        "tmp/facets_1",
+        "tmp/facets_2",
+        "tmp/facets_3",
+        "tmp/facets_4",
+        "tmp/facets_5",
+        "tmp/facets_6",
+        "tmp/facets_7",
+        "tmp/facets_8",
+        "tmp/facets_9",
+    ]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.plist = self.pkgsend_bulk(self.rurl, (self.pkg_A,
-                    self.pkg_top_level))
-                self.plist_B = self.pkgsend_bulk(self.rurl,
-                    [self.pkg_B1, self.pkg_B2])
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.plist = self.pkgsend_bulk(
+            self.rurl, (self.pkg_A, self.pkg_top_level)
+        )
+        self.plist_B = self.pkgsend_bulk(self.rurl, [self.pkg_B1, self.pkg_B2])
 
-        def test_01_facets(self):
-                # create an image w/ locales set
-                ic_args = "";
-                ic_args += " --facet 'facet.locale*=False' "
-                ic_args += " --facet 'facet.locale.fr*=True' "
-                ic_args += " --facet 'facet.locale.fr_CA=False' "
+    def test_01_facets(self):
+        # create an image w/ locales set
+        ic_args = ""
+        ic_args += " --facet 'facet.locale*=False' "
+        ic_args += " --facet 'facet.locale.fr*=True' "
+        ic_args += " --facet 'facet.locale.fr_CA=False' "
 
-                self.pkg_image_create(self.rurl, additional_args=ic_args)
-                self.pkg("facet")
-                self.pkg("facet -H -F tsv 'facet.locale*' | egrep False")
+        self.pkg_image_create(self.rurl, additional_args=ic_args)
+        self.pkg("facet")
+        self.pkg("facet -H -F tsv 'facet.locale*' | egrep False")
 
-                # install a package and verify
-                alist = [self.plist[0]]
-                self.pkg("install --parsable=0 pkg_A")
-                self.assertEqualParsable(self.output, add_packages=alist)
-                self.pkg("verify")
-                self.pkg("facet")
+        # install a package and verify
+        alist = [self.plist[0]]
+        self.pkg("install --parsable=0 pkg_A")
+        self.assertEqualParsable(self.output, add_packages=alist)
+        self.pkg("verify")
+        self.pkg("facet")
 
-                # make sure it delivers its files as appropriate
-                self.assert_file_exists("0")
-                self.assert_file_exists("1")
-                self.assert_file_exists("2")
-                self.assert_file_exists("3", negate=True)
-                self.assert_file_exists("4", negate=True)
-                self.assert_file_exists("5", negate=True)
-                self.assert_file_exists("6", negate=True)
-                self.assert_file_exists("7", negate=True)
-                self.assert_file_exists("8")
-                self.assert_file_exists("debug", negate=True)
+        # make sure it delivers its files as appropriate
+        self.assert_file_exists("0")
+        self.assert_file_exists("1")
+        self.assert_file_exists("2")
+        self.assert_file_exists("3", negate=True)
+        self.assert_file_exists("4", negate=True)
+        self.assert_file_exists("5", negate=True)
+        self.assert_file_exists("6", negate=True)
+        self.assert_file_exists("7", negate=True)
+        self.assert_file_exists("8")
+        self.assert_file_exists("debug", negate=True)
 
-                # Verify that effective value is shown for facets that are
-                # always implicity false such as debug / optional.
-                self.pkg("facet -H -F tsv debug.top optional.doc")
-                self.assertEqual(
-                    "facet.debug.top\tFalse\tsystem\n"
-                    "facet.optional.doc\tFalse\tsystem\n",
-                    self.output
-                )
+        # Verify that effective value is shown for facets that are
+        # always implicity false such as debug / optional.
+        self.pkg("facet -H -F tsv debug.top optional.doc")
+        self.assertEqual(
+            "facet.debug.top\tFalse\tsystem\n"
+            "facet.optional.doc\tFalse\tsystem\n",
+            self.output,
+        )
 
-                # notice that a file should not exist according to its facet
-                open(os.path.join(self.get_img_path(), "3"), "w").close()
-                self.pkg("verify", exit=1)
-                os.remove(os.path.join(self.get_img_path(), "3"))
+        # notice that a file should not exist according to its facet
+        open(os.path.join(self.get_img_path(), "3"), "w").close()
+        self.pkg("verify", exit=1)
+        os.remove(os.path.join(self.get_img_path(), "3"))
 
-                # verify that a non-existent facet can be set when other facets
-                # are in effect
-                self.pkg("change-facet -n --parsable=0 wombat=false")
-                self.assertEqualParsable(self.output,
-                    affect_packages=[],
-                    change_facets=[["facet.wombat", False, None, 'local',
-                       False, False]])
+        # verify that a non-existent facet can be set when other facets
+        # are in effect
+        self.pkg("change-facet -n --parsable=0 wombat=false")
+        self.assertEqualParsable(
+            self.output,
+            affect_packages=[],
+            change_facets=[
+                ["facet.wombat", False, None, "local", False, False]
+            ],
+        )
 
-                # Again, but this time after removing the publisher cache data
-                # and as an unprivileged user to verify that cached manifest
-                # data doesn't affect operation.
-                cache_dir = os.path.join(self.get_img_api_obj().img.imgdir,
-                    "cache", "publisher")
-                shutil.rmtree(cache_dir)
-                self.pkg("change-facet --no-refresh -n --parsable=0 "
-                    "wombat=false", su_wrap=True)
-                self.assertEqualParsable(self.output,
-                    affect_packages=[],
-                    change_facets=[["facet.wombat", False, None, 'local',
-                        False, False]])
+        # Again, but this time after removing the publisher cache data
+        # and as an unprivileged user to verify that cached manifest
+        # data doesn't affect operation.
+        cache_dir = os.path.join(
+            self.get_img_api_obj().img.imgdir, "cache", "publisher"
+        )
+        shutil.rmtree(cache_dir)
+        self.pkg(
+            "change-facet --no-refresh -n --parsable=0 " "wombat=false",
+            su_wrap=True,
+        )
+        self.assertEqualParsable(
+            self.output,
+            affect_packages=[],
+            change_facets=[
+                ["facet.wombat", False, None, "local", False, False]
+            ],
+        )
 
-                # Again, but this time after removing the cache directory
-                # entirely.
-                cache_dir = os.path.join(self.get_img_api_obj().img.imgdir,
-                    "cache")
-                shutil.rmtree(cache_dir)
-                self.pkg("change-facet --no-refresh -n --parsable=0 "
-                    "wombat=false", su_wrap=True)
-                self.assertEqualParsable(self.output,
-                    affect_packages=[],
-                    change_facets=[["facet.wombat", False, None, 'local',
-                        False, False]])
+        # Again, but this time after removing the cache directory
+        # entirely.
+        cache_dir = os.path.join(self.get_img_api_obj().img.imgdir, "cache")
+        shutil.rmtree(cache_dir)
+        self.pkg(
+            "change-facet --no-refresh -n --parsable=0 " "wombat=false",
+            su_wrap=True,
+        )
+        self.assertEqualParsable(
+            self.output,
+            affect_packages=[],
+            change_facets=[
+                ["facet.wombat", False, None, "local", False, False]
+            ],
+        )
 
-                # change to pick up another file w/ two tags and test the
-                # parsable output
-                self.pkg("change-facet --parsable=0 facet.locale.nl_ZA=True")
-                self.assertEqualParsable(self.output,
-                    affect_packages=alist,
-                    change_facets=[["facet.locale.nl_ZA", True, None, 'local',
-                        False, False]])
-                self.pkg("verify")
-                self.pkg("facet")
+        # change to pick up another file w/ two tags and test the
+        # parsable output
+        self.pkg("change-facet --parsable=0 facet.locale.nl_ZA=True")
+        self.assertEqualParsable(
+            self.output,
+            affect_packages=alist,
+            change_facets=[
+                ["facet.locale.nl_ZA", True, None, "local", False, False]
+            ],
+        )
+        self.pkg("verify")
+        self.pkg("facet")
 
-                self.assert_file_exists("0")
-                self.assert_file_exists("1")
-                self.assert_file_exists("2")
-                self.assert_file_exists("3", negate=True)
-                self.assert_file_exists("4")
-                self.assert_file_exists("5", negate=True)
-                self.assert_file_exists("6", negate=True)
-                self.assert_file_exists("7")
-                self.assert_file_exists("8")
-                self.assert_file_exists("debug", negate=True)
+        self.assert_file_exists("0")
+        self.assert_file_exists("1")
+        self.assert_file_exists("2")
+        self.assert_file_exists("3", negate=True)
+        self.assert_file_exists("4")
+        self.assert_file_exists("5", negate=True)
+        self.assert_file_exists("6", negate=True)
+        self.assert_file_exists("7")
+        self.assert_file_exists("8")
+        self.assert_file_exists("debug", negate=True)
 
-                # remove all the facets
-                self.pkg("change-facet --parsable=0 facet.locale*=None "
-                    "'facet.locale.fr*'=None facet.locale.fr_CA=None")
-                self.assertEqualParsable(self.output,
-                    affect_packages=alist,
-                    change_facets=[
-                        ["facet.locale*", None, False, 'local', False, False],
-                        ["facet.locale.fr*", None, True, 'local', False,
-                            False],
-                        ["facet.locale.fr_CA", None, False, 'local', False,
-                            False]
-                    ])
-                self.pkg("verify")
+        # remove all the facets
+        self.pkg(
+            "change-facet --parsable=0 facet.locale*=None "
+            "'facet.locale.fr*'=None facet.locale.fr_CA=None"
+        )
+        self.assertEqualParsable(
+            self.output,
+            affect_packages=alist,
+            change_facets=[
+                ["facet.locale*", None, False, "local", False, False],
+                ["facet.locale.fr*", None, True, "local", False, False],
+                ["facet.locale.fr_CA", None, False, "local", False, False],
+            ],
+        )
+        self.pkg("verify")
 
-                for i in range(8):
-                        self.assert_file_exists("{0:d}".format(i))
+        for i in range(8):
+            self.assert_file_exists("{0:d}".format(i))
 
-                # zap all the locales
-                self.pkg("change-facet -v facet.locale*=False facet.locale.nl_ZA=None")
-                self.pkg("verify")
-                self.pkg("facet")
+        # zap all the locales
+        self.pkg("change-facet -v facet.locale*=False facet.locale.nl_ZA=None")
+        self.pkg("verify")
+        self.pkg("facet")
 
-                for i in range(8):
-                        self.assert_file_exists("{0:d}".format(i), negate=(i != 0))
+        for i in range(8):
+            self.assert_file_exists("{0:d}".format(i), negate=(i != 0))
 
-                # Verify that effective value is shown for facets that are
-                # implicity false due to wildcards whether they're known to the
-                # system through packages or not.
-                self.pkg("facet -H -F tsv facet.locale.fr facet.locale.nl_ZA")
-                self.assertEqual(
-                    "facet.locale.fr\tFalse\tlocal\n"
-                    "facet.locale.nl_ZA\tFalse\tlocal\n",
-                    self.output
-                )
+        # Verify that effective value is shown for facets that are
+        # implicity false due to wildcards whether they're known to the
+        # system through packages or not.
+        self.pkg("facet -H -F tsv facet.locale.fr facet.locale.nl_ZA")
+        self.assertEqual(
+            "facet.locale.fr\tFalse\tlocal\n"
+            "facet.locale.nl_ZA\tFalse\tlocal\n",
+            self.output,
+        )
 
-                # Verify that an action with multiple facets will be installed
-                # if at least one is implicitly true even when the first facet
-                # evaluated matches an explicit wildcard facet set to false.
+        # Verify that an action with multiple facets will be installed
+        # if at least one is implicitly true even when the first facet
+        # evaluated matches an explicit wildcard facet set to false.
 
-                # This test relies on Python iterating over the action
-                # attributes dictionary such that facet.locale.nl_ZA is
-                # evaluated first.  (There's no way to influence that and the
-                # order seems 100% consistent for now.)
-                self.pkg("change-facet --parsable=0 'facet.locale*=None' "
-                    "'facet.locale.*=false' facet.locale.fr_CA=true");
-                self.assertEqualParsable(self.output,
-                    affect_packages=alist,
-                    change_facets=[
-                        ["facet.locale*", None, False, 'local', False, False],
-                        ["facet.locale.*", False, None, 'local', False, False],
-                        ["facet.locale.fr_CA", True, None, 'local', False,
-                            False]
-                    ])
-                self.assert_file_exists("4")
+        # This test relies on Python iterating over the action
+        # attributes dictionary such that facet.locale.nl_ZA is
+        # evaluated first.  (There's no way to influence that and the
+        # order seems 100% consistent for now.)
+        self.pkg(
+            "change-facet --parsable=0 'facet.locale*=None' "
+            "'facet.locale.*=false' facet.locale.fr_CA=true"
+        )
+        self.assertEqualParsable(
+            self.output,
+            affect_packages=alist,
+            change_facets=[
+                ["facet.locale*", None, False, "local", False, False],
+                ["facet.locale.*", False, None, "local", False, False],
+                ["facet.locale.fr_CA", True, None, "local", False, False],
+            ],
+        )
+        self.assert_file_exists("4")
 
-                # This test is merely here so that if the evaluation order is
-                # reversed for some reason that expected results are still seen.
-                self.pkg("change-facet --parsable=0 'facet.locale.*=None' "
-                    "facet.locale.fr_*=false facet.locale.fr_CA=None");
-                self.assertEqualParsable(self.output,
-                    affect_packages=alist,
-                    change_facets=[
-                        ["facet.locale.*", None, False, 'local', False, False],
-                        ["facet.locale.fr_*", False, None, 'local', False,
-                            False],
-                        ["facet.locale.fr_CA", None, True, 'local', False,
-                            False]
-                    ])
-                self.assert_file_exists("4")
+        # This test is merely here so that if the evaluation order is
+        # reversed for some reason that expected results are still seen.
+        self.pkg(
+            "change-facet --parsable=0 'facet.locale.*=None' "
+            "facet.locale.fr_*=false facet.locale.fr_CA=None"
+        )
+        self.assertEqualParsable(
+            self.output,
+            affect_packages=alist,
+            change_facets=[
+                ["facet.locale.*", None, False, "local", False, False],
+                ["facet.locale.fr_*", False, None, "local", False, False],
+                ["facet.locale.fr_CA", None, True, "local", False, False],
+            ],
+        )
+        self.assert_file_exists("4")
 
-        def test_02_removing_facets(self):
-                self.image_create(self.rurl)
-                # Test that setting an unset, non-existent facet to None works.
-                self.pkg("change-facet foo=None", exit=4)
+    def test_02_removing_facets(self):
+        self.image_create(self.rurl)
+        # Test that setting an unset, non-existent facet to None works.
+        self.pkg("change-facet foo=None", exit=4)
 
-                # Test that setting a non-existent facet to True then removing
-                # it works.
-                self.pkg("change-facet -v foo=True")
-                self.pkg("facet -H -F tsv")
-                self.assertEqual("facet.foo\tTrue\tlocal\n", self.output)
-                self.pkg("change-facet --parsable=0 foo=None")
-                self.assertEqualParsable(self.output, change_facets=[
-                    ["facet.foo", None, True, 'local', False, False]])
-                self.pkg("facet -H")
-                self.assertEqual("", self.output)
+        # Test that setting a non-existent facet to True then removing
+        # it works.
+        self.pkg("change-facet -v foo=True")
+        self.pkg("facet -H -F tsv")
+        self.assertEqual("facet.foo\tTrue\tlocal\n", self.output)
+        self.pkg("change-facet --parsable=0 foo=None")
+        self.assertEqualParsable(
+            self.output,
+            change_facets=[["facet.foo", None, True, "local", False, False]],
+        )
+        self.pkg("facet -H")
+        self.assertEqual("", self.output)
 
-                self.pkg("change-facet -v foo=None", exit=4)
+        self.pkg("change-facet -v foo=None", exit=4)
 
-                # Test that setting a facet at the same time as removing a facet
-                # sees both as changing.
+        # Test that setting a facet at the same time as removing a facet
+        # sees both as changing.
 
-                # First, install faceted package.
-                self.pkg("install pkg_A")
-                for i in range(9):
-                        self.assert_file_exists(i)
+        # First, install faceted package.
+        self.pkg("install pkg_A")
+        for i in range(9):
+            self.assert_file_exists(i)
 
-                # Next, set general locale.*=False, but locale.fr=True.
-                self.pkg("change-facet 'locale.*=False' 'locale.fr=True'")
+        # Next, set general locale.*=False, but locale.fr=True.
+        self.pkg("change-facet 'locale.*=False' 'locale.fr=True'")
 
-                # General 0 file, locale.fr file, and has slashes file should be
-                # there.
-                for i in (0, 1, 8):
-                        self.assert_file_exists(i)
+        # General 0 file, locale.fr file, and has slashes file should be
+        # there.
+        for i in (0, 1, 8):
+            self.assert_file_exists(i)
 
-                # No other locale files should be present.
-                for i in (2, 3, 4, 5, 6, 7):
-                        self.assert_file_exists(i, negate=True)
+        # No other locale files should be present.
+        for i in (2, 3, 4, 5, 6, 7):
+            self.assert_file_exists(i, negate=True)
 
-                # Now set wombat=False and unset locale.fr.
-                self.pkg("change-facet -vv locale.fr=None wombat=False")
-                self.assert_file_exists(0) # general 0 file exists
-                self.assert_file_exists(1, negate=True) # locale.fr file gone
+        # Now set wombat=False and unset locale.fr.
+        self.pkg("change-facet -vv locale.fr=None wombat=False")
+        self.assert_file_exists(0)  # general 0 file exists
+        self.assert_file_exists(1, negate=True)  # locale.fr file gone
 
-        def test_03_slashed_facets(self):
-                self.pkg_image_create(self.rurl)
-                self.pkg("install pkg_A")
-                self.pkg("verify")
+    def test_03_slashed_facets(self):
+        self.pkg_image_create(self.rurl)
+        self.pkg("install pkg_A")
+        self.pkg("verify")
 
-                self.assert_file_exists("8")
-                self.pkg("change-facet -v facet.has/some/slashes=False")
-                self.assert_file_exists("8", negate=True)
-                self.pkg("verify")
-                self.pkg("change-facet -v facet.has/some/slashes=True")
-                self.assert_file_exists("8")
-                self.pkg("verify")
+        self.assert_file_exists("8")
+        self.pkg("change-facet -v facet.has/some/slashes=False")
+        self.assert_file_exists("8", negate=True)
+        self.pkg("verify")
+        self.pkg("change-facet -v facet.has/some/slashes=True")
+        self.assert_file_exists("8")
+        self.pkg("verify")
 
-        def test_04_no_accidental_changes(self):
-                """Verify that non-facet related packaging operation don't
-                accidentally change facets."""
+    def test_04_no_accidental_changes(self):
+        """Verify that non-facet related packaging operation don't
+        accidentally change facets."""
 
-                rurl = self.dc.get_repo_url()
+        rurl = self.dc.get_repo_url()
 
-                # create an image w/ two facets set.
-                ic_args = ""
-                ic_args += " --facet 'locale.fr=False' "
-                ic_args += " --facet 'locale.fr_FR=False' "
-                self.pkg_image_create(rurl, additional_args=ic_args)
-                self.pkg("install pkg_A")
+        # create an image w/ two facets set.
+        ic_args = ""
+        ic_args += " --facet 'locale.fr=False' "
+        ic_args += " --facet 'locale.fr_FR=False' "
+        self.pkg_image_create(rurl, additional_args=ic_args)
+        self.pkg("install pkg_A")
 
-                # install a random package and make sure we don't accidentally
-                # change facets.
-                self.pkg("install pkg_B@1.0")
-                self.pkg("facet -H -F tsv")
-                expected = (
-                    "facet.locale.fr\tFalse\tlocal\n"
-                    "facet.locale.fr_FR\tFalse\tlocal\n")
-                self.assertEqualDiff(expected, self.output)
-                for i in [ 0, 3, 4, 5, 6, 7 ]:
-                        self.assert_file_exists(str(i))
-                for i in [ 1, 2 ]:
-                        self.assert_file_exists(str(i), negate=True)
-                self.pkg("verify")
+        # install a random package and make sure we don't accidentally
+        # change facets.
+        self.pkg("install pkg_B@1.0")
+        self.pkg("facet -H -F tsv")
+        expected = (
+            "facet.locale.fr\tFalse\tlocal\n"
+            "facet.locale.fr_FR\tFalse\tlocal\n"
+        )
+        self.assertEqualDiff(expected, self.output)
+        for i in [0, 3, 4, 5, 6, 7]:
+            self.assert_file_exists(str(i))
+        for i in [1, 2]:
+            self.assert_file_exists(str(i), negate=True)
+        self.pkg("verify")
 
-                # update an image and make sure we don't accidentally change
-                # facets.
-                self.pkg("update")
-                self.pkg("facet -H -F tsv")
-                expected = (
-                    "facet.locale.fr\tFalse\tlocal\n"
-                    "facet.locale.fr_FR\tFalse\tlocal\n")
-                self.assertEqualDiff(expected, self.output)
-                for i in [ 0, 3, 4, 5, 6, 7 ]:
-                        self.assert_file_exists(str(i))
-                for i in [ 1, 2 ]:
-                        self.assert_file_exists(str(i), negate=True)
-                self.pkg("verify")
+        # update an image and make sure we don't accidentally change
+        # facets.
+        self.pkg("update")
+        self.pkg("facet -H -F tsv")
+        expected = (
+            "facet.locale.fr\tFalse\tlocal\n"
+            "facet.locale.fr_FR\tFalse\tlocal\n"
+        )
+        self.assertEqualDiff(expected, self.output)
+        for i in [0, 3, 4, 5, 6, 7]:
+            self.assert_file_exists(str(i))
+        for i in [1, 2]:
+            self.assert_file_exists(str(i), negate=True)
+        self.pkg("verify")
 
-        def test_05_reset_facet(self):
-                """Verify that resetting a Facet explicitly set to false
-                restores/removes delivered content."""
+    def test_05_reset_facet(self):
+        """Verify that resetting a Facet explicitly set to false
+        restores/removes delivered content."""
 
-                # create an image with pkg_A and no facets
-                self.pkg_image_create(self.rurl)
-                self.pkg("install pkg_A")
-                self.pkg("facet -H")
-                self.assertEqualDiff("", self.output)
-                for i in range(8):
-                        self.assert_file_exists(str(i))
-                self.assert_file_exists("debug", negate=True)
-                self.pkg("verify")
+        # create an image with pkg_A and no facets
+        self.pkg_image_create(self.rurl)
+        self.pkg("install pkg_A")
+        self.pkg("facet -H")
+        self.assertEqualDiff("", self.output)
+        for i in range(8):
+            self.assert_file_exists(str(i))
+        self.assert_file_exists("debug", negate=True)
+        self.pkg("verify")
 
-                # set a facet on an image with no facets
-                self.pkg("change-facet -v locale.fr=False")
-                self.pkg("facet -H -F tsv")
-                output = self.reduceSpaces(self.output)
-                expected = (
-                    "facet.locale.fr\tFalse\tlocal\n")
-                self.assertEqualDiff(expected, output)
-                for i in [ 0, 2, 3, 4, 5, 6, 7 ]:
-                        self.assert_file_exists(str(i))
-                for i in [ 1 ]:
-                        self.assert_file_exists(str(i), negate=True)
-                self.pkg("verify")
+        # set a facet on an image with no facets
+        self.pkg("change-facet -v locale.fr=False")
+        self.pkg("facet -H -F tsv")
+        output = self.reduceSpaces(self.output)
+        expected = "facet.locale.fr\tFalse\tlocal\n"
+        self.assertEqualDiff(expected, output)
+        for i in [0, 2, 3, 4, 5, 6, 7]:
+            self.assert_file_exists(str(i))
+        for i in [1]:
+            self.assert_file_exists(str(i), negate=True)
+        self.pkg("verify")
 
-                # set a facet on an image with existing facets
-                self.pkg("change-facet -v locale.fr_FR=False")
-                self.pkg("facet -H -F tsv")
-                expected = (
-                    "facet.locale.fr\tFalse\tlocal\n"
-                    "facet.locale.fr_FR\tFalse\tlocal\n")
-                self.assertEqualDiff(expected, self.output)
-                for i in [ 0, 3, 4, 5, 6, 7 ]:
-                        self.assert_file_exists(str(i))
-                for i in [ 1, 2 ]:
-                        self.assert_file_exists(str(i), negate=True)
-                self.pkg("verify")
+        # set a facet on an image with existing facets
+        self.pkg("change-facet -v locale.fr_FR=False")
+        self.pkg("facet -H -F tsv")
+        expected = (
+            "facet.locale.fr\tFalse\tlocal\n"
+            "facet.locale.fr_FR\tFalse\tlocal\n"
+        )
+        self.assertEqualDiff(expected, self.output)
+        for i in [0, 3, 4, 5, 6, 7]:
+            self.assert_file_exists(str(i))
+        for i in [1, 2]:
+            self.assert_file_exists(str(i), negate=True)
+        self.pkg("verify")
 
-                # clear a facet while setting a facet on an image with other
-                # facets that aren't being changed
-                self.pkg("change-facet -v locale.fr=None locale.nl=False")
-                self.pkg("facet -H -F tsv")
-                output = self.reduceSpaces(self.output)
-                expected = (
-                    "facet.locale.fr_FR\tFalse\tlocal\n"
-                    "facet.locale.nl\tFalse\tlocal\n")
-                self.assertEqualDiff(expected, output)
-                for i in [ 0, 1, 3, 4, 6, 7 ]:
-                        self.assert_file_exists(str(i))
-                for i in [ 2, 5 ]:
-                        self.assert_file_exists(str(i), negate=True)
-                self.pkg("verify")
+        # clear a facet while setting a facet on an image with other
+        # facets that aren't being changed
+        self.pkg("change-facet -v locale.fr=None locale.nl=False")
+        self.pkg("facet -H -F tsv")
+        output = self.reduceSpaces(self.output)
+        expected = (
+            "facet.locale.fr_FR\tFalse\tlocal\n"
+            "facet.locale.nl\tFalse\tlocal\n"
+        )
+        self.assertEqualDiff(expected, output)
+        for i in [0, 1, 3, 4, 6, 7]:
+            self.assert_file_exists(str(i))
+        for i in [2, 5]:
+            self.assert_file_exists(str(i), negate=True)
+        self.pkg("verify")
 
-                # clear a facet on an image with other facets that aren't
-                # being changed
-                self.pkg("change-facet -v locale.nl=None")
-                self.pkg("facet -H -F tsv")
-                output = self.reduceSpaces(self.output)
-                expected = (
-                    "facet.locale.fr_FR\tFalse\tlocal\n")
-                self.assertEqualDiff(expected, output)
-                for i in [ 0, 1, 3, 4, 5, 6, 7 ]:
-                        self.assert_file_exists(str(i))
-                for i in [ 2 ]:
-                        self.assert_file_exists(str(i), negate=True)
-                self.pkg("verify")
+        # clear a facet on an image with other facets that aren't
+        # being changed
+        self.pkg("change-facet -v locale.nl=None")
+        self.pkg("facet -H -F tsv")
+        output = self.reduceSpaces(self.output)
+        expected = "facet.locale.fr_FR\tFalse\tlocal\n"
+        self.assertEqualDiff(expected, output)
+        for i in [0, 1, 3, 4, 5, 6, 7]:
+            self.assert_file_exists(str(i))
+        for i in [2]:
+            self.assert_file_exists(str(i), negate=True)
+        self.pkg("verify")
 
-                # clear the only facet on an image
-                self.pkg("change-facet -v locale.fr_FR=None")
-                self.pkg("facet -H -F tsv")
-                self.assertEqualDiff("", self.output)
-                for i in range(8):
-                        self.assert_file_exists(str(i))
-                self.pkg("verify")
+        # clear the only facet on an image
+        self.pkg("change-facet -v locale.fr_FR=None")
+        self.pkg("facet -H -F tsv")
+        self.assertEqualDiff("", self.output)
+        for i in range(8):
+            self.assert_file_exists(str(i))
+        self.pkg("verify")
 
-                # verify debug content removed when debug facet reset
-                self.pkg("change-facet -v debug.foo=True")
-                self.pkg("facet -H -F tsv")
-                output = self.reduceSpaces(self.output)
-                expected = (
-                    "facet.debug.foo\tTrue\tlocal\n")
-                self.assertEqualDiff(expected, output)
-                self.assert_file_exists("debug")
+        # verify debug content removed when debug facet reset
+        self.pkg("change-facet -v debug.foo=True")
+        self.pkg("facet -H -F tsv")
+        output = self.reduceSpaces(self.output)
+        expected = "facet.debug.foo\tTrue\tlocal\n"
+        self.assertEqualDiff(expected, output)
+        self.assert_file_exists("debug")
 
-                self.pkg("change-facet -v debug.foo=None")
-                self.pkg("facet -H -F tsv")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff("", self.output)
-                self.assert_file_exists("debug", negate=True)
+        self.pkg("change-facet -v debug.foo=None")
+        self.pkg("facet -H -F tsv")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff("", self.output)
+        self.assert_file_exists("debug", negate=True)
 
-        def test_06_facet_all(self):
-                """Verify that the 'all' value for facets is handled as
-                expected."""
+    def test_06_facet_all(self):
+        """Verify that the 'all' value for facets is handled as
+        expected."""
 
-                self.pkg_image_create(self.rurl)
+        self.pkg_image_create(self.rurl)
 
-                # All faceted files except debug/optional should be installed.
-                self.pkg("install pkg_top_level")
-                self.assert_files_exist((
-                    ("top0", True),
-                    ("top0.debug", False),
-                    ("top1", True),
-                    ("top2", True),
-                    ("top3", True),
-                    ("top4", True),
-                    ("top5", True),
-                    ("optional.doc", False),
-                    ("optional_fr.doc", False),
-                ))
+        # All faceted files except debug/optional should be installed.
+        self.pkg("install pkg_top_level")
+        self.assert_files_exist(
+            (
+                ("top0", True),
+                ("top0.debug", False),
+                ("top1", True),
+                ("top2", True),
+                ("top3", True),
+                ("top4", True),
+                ("top5", True),
+                ("optional.doc", False),
+                ("optional_fr.doc", False),
+            )
+        )
 
-                # All faceted files should be installed.
-                self.pkg("change-facet -v debug.top=true optional.doc=true")
-                self.assert_files_exist((
-                    ("top0", True),
-                    ("top0.debug", True),
-                    ("top1", True),
-                    ("top2", True),
-                    ("top3", True),
-                    ("top4", True),
-                    ("top5", True),
-                    ("optional.doc", True),
-                    ("optional_fr.doc", True),
-                ))
+        # All faceted files should be installed.
+        self.pkg("change-facet -v debug.top=true optional.doc=true")
+        self.assert_files_exist(
+            (
+                ("top0", True),
+                ("top0.debug", True),
+                ("top1", True),
+                ("top2", True),
+                ("top3", True),
+                ("top4", True),
+                ("top5", True),
+                ("optional.doc", True),
+                ("optional_fr.doc", True),
+            )
+        )
 
-                # Only top0[.debug] should be installed.
-                self.pkg('change-facet -v doc=false')
-                self.assert_files_exist((
-                    ("top0", True),
-                    ("top0.debug", True),
-                    ("top1", False),
-                    ("top2", False),
-                    ("top3", False),
-                    ("top4", False),
-                    ("top5", False),
-                    ("optional.doc", False),
-                    ("optional_fr.doc", False),
-                ))
+        # Only top0[.debug] should be installed.
+        self.pkg("change-facet -v doc=false")
+        self.assert_files_exist(
+            (
+                ("top0", True),
+                ("top0.debug", True),
+                ("top1", False),
+                ("top2", False),
+                ("top3", False),
+                ("top4", False),
+                ("top5", False),
+                ("optional.doc", False),
+                ("optional_fr.doc", False),
+            )
+        )
 
-                # No faceted files should be installed.
-                self.pkg('change-facet -v devel=false optional.doc=false')
-                self.assert_files_exist((
-                    ("top0", False),
-                    ("top0.debug", False),
-                    ("top1", False),
-                    ("top2", False),
-                    ("top3", False),
-                    ("top4", False),
-                    ("top5", False),
-                    ("optional.doc", False),
-                    ("optional_fr.doc", False),
-                ))
+        # No faceted files should be installed.
+        self.pkg("change-facet -v devel=false optional.doc=false")
+        self.assert_files_exist(
+            (
+                ("top0", False),
+                ("top0.debug", False),
+                ("top1", False),
+                ("top2", False),
+                ("top3", False),
+                ("top4", False),
+                ("top5", False),
+                ("optional.doc", False),
+                ("optional_fr.doc", False),
+            )
+        )
 
-                # Only top1, top3, top4, optional.doc, and optional_fr.doc
-                # should be installed.
-                self.pkg('change-facet -v doc=true optional.doc=true')
-                self.assert_files_exist((
-                    ("top0", False),
-                    ("top0.debug", False),
-                    ("top1", True),
-                    ("top2", False),
-                    ("top3", True),
-                    ("top4", True),
-                    ("top5", False),
-                    ("optional.doc", True),
-                    ("optional_fr.doc", True),
-                ))
+        # Only top1, top3, top4, optional.doc, and optional_fr.doc
+        # should be installed.
+        self.pkg("change-facet -v doc=true optional.doc=true")
+        self.assert_files_exist(
+            (
+                ("top0", False),
+                ("top0.debug", False),
+                ("top1", True),
+                ("top2", False),
+                ("top3", True),
+                ("top4", True),
+                ("top5", False),
+                ("optional.doc", True),
+                ("optional_fr.doc", True),
+            )
+        )
 
-                # All faceted files should be installed.
-                self.pkg("change-facet -v devel=true optional.doc=true")
-                self.assert_files_exist((
-                    ("top0", True),
-                    ("top0.debug", True),
-                    ("top1", True),
-                    ("top2", True),
-                    ("top3", True),
-                    ("top4", True),
-                    ("top5", True),
-                    ("optional.doc", True),
-                    ("optional_fr.doc", True),
-                ))
+        # All faceted files should be installed.
+        self.pkg("change-facet -v devel=true optional.doc=true")
+        self.assert_files_exist(
+            (
+                ("top0", True),
+                ("top0.debug", True),
+                ("top1", True),
+                ("top2", True),
+                ("top3", True),
+                ("top4", True),
+                ("top5", True),
+                ("optional.doc", True),
+                ("optional_fr.doc", True),
+            )
+        )
 
-                # Only top0[.debug], top1, top2, top4, top5, and optional.doc
-                # should be installed.
-                self.pkg("change-facet -v locale.fr_CA=false")
-                self.assert_files_exist((
-                    ("top0", True),
-                    ("top0.debug", True),
-                    ("top1", True),
-                    ("top2", True),
-                    ("top3", False),
-                    ("top4", True),
-                    ("top5", True),
-                    ("optional.doc", True),
-                    ("optional_fr.doc", False),
-                ))
+        # Only top0[.debug], top1, top2, top4, top5, and optional.doc
+        # should be installed.
+        self.pkg("change-facet -v locale.fr_CA=false")
+        self.assert_files_exist(
+            (
+                ("top0", True),
+                ("top0.debug", True),
+                ("top1", True),
+                ("top2", True),
+                ("top3", False),
+                ("top4", True),
+                ("top5", True),
+                ("optional.doc", True),
+                ("optional_fr.doc", False),
+            )
+        )
 
-                # Only top0[.debug], top1, top2, and optional.doc should be
-                # installed.
-                self.pkg("change-facet -v locale.nl_ZA=false")
-                self.assert_files_exist((
-                    ("top0", True),
-                    ("top0.debug", True),
-                    ("top1", True),
-                    ("top2", True),
-                    ("top3", False),
-                    ("top4", False),
-                    ("top5", False),
-                    ("optional.doc", True),
-                    ("optional_fr.doc", False),
-                ))
+        # Only top0[.debug], top1, top2, and optional.doc should be
+        # installed.
+        self.pkg("change-facet -v locale.nl_ZA=false")
+        self.assert_files_exist(
+            (
+                ("top0", True),
+                ("top0.debug", True),
+                ("top1", True),
+                ("top2", True),
+                ("top3", False),
+                ("top4", False),
+                ("top5", False),
+                ("optional.doc", True),
+                ("optional_fr.doc", False),
+            )
+        )
 
-                # Reset all facets and verify all files except optional/debug
-                # are installed.
-                self.pkg("change-facet -vvv devel=None doc=None locale.fr_CA=None "
-                    "locale.nl_ZA=None optional.doc=None debug.top=None")
-                self.assert_files_exist((
-                    ("top0", True),
-                    ("top0.debug", False),
-                    ("top1", True),
-                    ("top2", True),
-                    ("top3", True),
-                    ("top4", True),
-                    ("top5", True),
-                    ("optional.doc", False),
-                    ("optional_fr.doc", False),
-                ))
+        # Reset all facets and verify all files except optional/debug
+        # are installed.
+        self.pkg(
+            "change-facet -vvv devel=None doc=None locale.fr_CA=None "
+            "locale.nl_ZA=None optional.doc=None debug.top=None"
+        )
+        self.assert_files_exist(
+            (
+                ("top0", True),
+                ("top0.debug", False),
+                ("top1", True),
+                ("top2", True),
+                ("top3", True),
+                ("top4", True),
+                ("top5", True),
+                ("optional.doc", False),
+                ("optional_fr.doc", False),
+            )
+        )
 
-                # Set a false wildcard for the 'devel' and 'doc' facets.  No
-                # files should be installed.
-                self.pkg("change-facet -v 'facet.d*=False' optional.*=true "
-                    "debug.*=true")
-                self.assert_files_exist((
-                    ("top0", False),
-                    ("top0.debug", False),
-                    ("top1", False),
-                    ("top2", False),
-                    ("top3", False),
-                    ("top4", False),
-                    ("top5", False),
-                    ("optional.doc", False),
-                    ("optional_fr.doc", False),
-                ))
+        # Set a false wildcard for the 'devel' and 'doc' facets.  No
+        # files should be installed.
+        self.pkg(
+            "change-facet -v 'facet.d*=False' optional.*=true " "debug.*=true"
+        )
+        self.assert_files_exist(
+            (
+                ("top0", False),
+                ("top0.debug", False),
+                ("top1", False),
+                ("top2", False),
+                ("top3", False),
+                ("top4", False),
+                ("top5", False),
+                ("optional.doc", False),
+                ("optional_fr.doc", False),
+            )
+        )
 
-                # Set the devel facet True and the debug.top facet true and
-                # verify that explicit sets trump wildcard matching.  Only
-                # top0[.debug] should be installed.
-                self.pkg("change-facet -v devel=True debug.top=True")
-                self.assert_files_exist((
-                    ("top0", True),
-                    ("top0.debug", True),
-                    ("top1", False),
-                    ("top2", False),
-                    ("top3", False),
-                    ("top4", False),
-                    ("top5", False),
-                    ("optional.doc", False),
-                    ("optional_fr.doc", False),
-                ))
+        # Set the devel facet True and the debug.top facet true and
+        # verify that explicit sets trump wildcard matching.  Only
+        # top0[.debug] should be installed.
+        self.pkg("change-facet -v devel=True debug.top=True")
+        self.assert_files_exist(
+            (
+                ("top0", True),
+                ("top0.debug", True),
+                ("top1", False),
+                ("top2", False),
+                ("top3", False),
+                ("top4", False),
+                ("top5", False),
+                ("optional.doc", False),
+                ("optional_fr.doc", False),
+            )
+        )
 
-        def test_07_invalid_facet_name(self):
-                """Test that invalid facet names are handled appropriately"""
+    def test_07_invalid_facet_name(self):
+        """Test that invalid facet names are handled appropriately"""
 
-                self.image_create(self.rurl)
-                self.pkg("change-facet --no-refresh "
-                    "facet.foo\\ bar=false", exit=1)
-                self.assertTrue("facet.foo bar" in self.errout)
+        self.image_create(self.rurl)
+        self.pkg("change-facet --no-refresh " "facet.foo\\ bar=false", exit=1)
+        self.assertTrue("facet.foo bar" in self.errout)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_client_api.py
+++ b/src/tests/cli/t_client_api.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -39,46 +40,46 @@ from pkg.client import global_settings
 
 
 class TestClientApi(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        foo1 = """
+    foo1 = """
             open foo@1,5.11-0
             close """
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             close """
 
-        foo12 = """
+    foo12 = """
             open foo@1.2,5.11-0
             close """
 
-        foo121 = """
+    foo121 = """
             open foo@1.2.1,5.11-0
             close """
 
-        food12 = """
+    food12 = """
             open food@1.2,5.11-0
             close """
 
-        newpkg10 = """
+    newpkg10 = """
             open newpkg@1.0
             close """
 
-        newpkg210 = """
+    newpkg210 = """
             open newpkg2@1.0
             close """
 
-        hierfoo10 = """
+    hierfoo10 = """
             open hier/foo@1.0,5.11-0
             close """
 
-        verifypkg10 = """
+    verifypkg10 = """
             open verifypkg@1.0,5.11-0:20160302T054916Z
             add dir mode=0755 owner=root group=sys path=/etc
             add dir mode=0755 owner=root group=sys path=/etc/security
@@ -97,1076 +98,1124 @@ class TestClientApi(pkg5unittest.ManyDepotTestCase):
             close
             """
 
-        misc_files = {
-           "bobcat": "",
-           "dricon_da": """zigit "pci8086,1234"\n""",
-           "dricon_maj": """zigit 103\n""",
-           "dricon_cls": """\n""",
-           "dricon_mp": """\n""",
-           "dricon_dp": """\n""",
-           "dricon_ep": """\n""",
-           "permission": ""
+    misc_files = {
+        "bobcat": "",
+        "dricon_da": """zigit "pci8086,1234"\n""",
+        "dricon_maj": """zigit 103\n""",
+        "dricon_cls": """\n""",
+        "dricon_mp": """\n""",
+        "dricon_dp": """\n""",
+        "dricon_ep": """\n""",
+        "permission": "",
+    }
+
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2", "test2"])
+        self.make_misc_files(self.misc_files)
+
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.pkgsend_bulk(
+            self.rurl1,
+            (
+                self.foo1,
+                self.foo10,
+                self.foo11,
+                self.foo12,
+                self.foo121,
+                self.food12,
+                self.hierfoo10,
+                self.newpkg10,
+                self.newpkg210,
+                self.verifypkg10,
+            ),
+        )
+
+        # Ensure that the second repo's packages have exactly the same
+        # timestamps as those in the first ... by copying the repo over.
+        # If the repos need to have some contents which are different,
+        # send those changes after restarting depot 2.
+        d1dir = self.dcs[1].get_repodir()
+        d2dir = self.dcs[2].get_repodir()
+        self.copy_repository(d1dir, d2dir, {"test1": "test2"})
+
+        # The new repository won't have a catalog, so rebuild it.
+        self.dcs[2].get_repo(auto_create=True).rebuild()
+
+        # The third repository should remain empty and not be
+        # published to.
+
+        # Next, create the image and configure publishers.
+        self.image_create(self.rurl1, prefix="test1")
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.pkg("set-publisher -O " + self.rurl2 + " test2")
+
+        self.rurl3 = self.dcs[3].get_repo_url()
+
+    def __call_cmd(self, subcommand, args, opts):
+        retjson = cli_api._pkg_invoke(
+            subcommand=subcommand,
+            pargs_json=json.dumps(args),
+            opts_json=json.dumps(opts),
+        )
+        return retjson
+
+    def test_01_invalid_pkg_invoke_args(self):
+        """Test invalid pkg_invoke args is handled correctly."""
+
+        pkgs = ["foo"]
+        opts = {"list_installed_newest": True, "list_all": True}
+        os.environ["PKG_IMAGE"] = self.img_path()
+        retjson = self.__call_cmd(None, pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue("Sub-command" in retjson["errors"][0]["reason"])
+
+        invalidpargs = {"invalid": -1}
+        retjson = self.__call_cmd("list", invalidpargs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "pargs_json is invalid" in retjson["errors"][0]["reason"]
+        )
+
+        invalidpargs = {"invalid": -1}
+        retjson = self.__call_cmd("publisher", invalidpargs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "pargs_json is invalid" in retjson["errors"][0]["reason"]
+        )
+
+        invalidpargs = "+1+1random"
+        retjson = cli_api._pkg_invoke(
+            subcommand="list",
+            pargs_json=invalidpargs,
+            opts_json=json.dumps(opts),
+        )
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "pargs_json is invalid" in retjson["errors"][0]["reason"]
+        )
+
+        invalidopts = "+1+1random"
+        retjson = cli_api._pkg_invoke(
+            subcommand="list", pargs_json=json.dumps([]), opts_json=invalidopts
+        )
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "opts_json is invalid" in retjson["errors"][0]["reason"]
+        )
+
+    def test_02_valid_pkg_invoke_args(self):
+        """Test valid arguments for pkg json."""
+
+        self.image_create(self.rurl1, prefix="test1")
+        os.environ["PKG_IMAGE"] = self.img_path()
+        pkgs = ["foo"]
+        opts = {"list_newest": True}
+
+        self.pkg("install pkg://test1/foo")
+        retjson = cli_api._pkg_invoke(
+            subcommand="list", pargs_json=None, opts_json=json.dumps(opts)
+        )
+        self.assertTrue("errors" not in retjson)
+
+        retjson = cli_api._pkg_invoke(
+            subcommand="list", pargs_json=json.dumps(["foo"]), opts_json=None
+        )
+        self.assertTrue("errors" not in retjson)
+
+        retjson = self.__call_cmd("list", pkgs, opts)
+        self.assertTrue("errors" not in retjson)
+
+    def __schema_validation(self, input, schema):
+        """Test if the input is valid against the schema."""
+
+        try:
+            json.validate(input, schema)
+            return True
+        except Exception as e:
+            return False
+
+    def test_03_list_json_args_opts(self):
+        """Test json args or opts for list command."""
+
+        self.image_create(self.rurl1, prefix="test1")
+        pkgs = [1, 2, 3]
+        opts = {"list_installed_newest": True, "list_all": True}
+        os.environ["PKG_IMAGE"] = self.img_path()
+        retjson = self.__call_cmd("list", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'string'" in retjson["errors"][0]["reason"]
+        )
+
+        pkgs = [None]
+        retjson = self.__call_cmd("list", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'string'" in retjson["errors"][0]["reason"]
+        )
+
+        pkgs = []
+        opts = {"list_installed_newest": 1}
+        retjson = self.__call_cmd("list", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'boolean'" in retjson["errors"][0]["reason"]
+        )
+
+        opts = {"origins": 1}
+        retjson = self.__call_cmd("list", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'array'" in retjson["errors"][0]["reason"]
+        )
+
+        opts = {"random": 1}
+        retjson = self.__call_cmd("list", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue("invalid option" in retjson["errors"][0]["reason"])
+
+        # Test args and opts directly against schema.
+        pargs = "pargs_json"
+        list_schema = cli_api._get_pkg_input_schema("list")
+        list_input = {pargs: [], "opts_json": {}}
+        self.assertTrue(self.__schema_validation(list_input, list_schema))
+
+        list_input = {pargs: [12], "opts_json": {}}
+        self.assertTrue(not self.__schema_validation(list_input, list_schema))
+
+        list_input = {pargs: [], "opts_json": {"list_upgradable": "string"}}
+        self.assertTrue(not self.__schema_validation(list_input, list_schema))
+
+        list_input = {pargs: [], "opts_json": {"list_upgradable": False}}
+        self.assertTrue(self.__schema_validation(list_input, list_schema))
+
+        list_input = {pargs: [], "opts_json": {"origins": False}}
+        self.assertTrue(not self.__schema_validation(list_input, list_schema))
+
+        list_input = {pargs: [], "opts_json": {"origins": []}}
+        self.assertTrue(self.__schema_validation(list_input, list_schema))
+
+    def test_04_install_json_args_opts(self):
+        """Test json args or opts for install command."""
+
+        # Test invalid pkg name.
+        self.image_create(self.rurl1, prefix="test1")
+        os.environ["PKG_IMAGE"] = self.img_path()
+        pkgs = [1, 2, 3]
+        opts = {"backup_be": True}
+        retjson = self.__call_cmd("install", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'string'" in retjson["errors"][0]["reason"]
+        )
+
+        pkgs = [None]
+        opts = {"backup_be": True}
+        os.environ["PKG_IMAGE"] = self.img_path()
+        retjson = self.__call_cmd("install", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'string'" in retjson["errors"][0]["reason"]
+        )
+
+        # Test unknown option was reported.
+        pkgs = ["newpkg@1.0"]
+        opts = {"unknown": "solaris"}
+        retjson = self.__call_cmd("install", pkgs, opts)
+        self.assertTrue("invalid option" in retjson["errors"][0]["reason"])
+
+        # Test without pkg specified.
+        pkgs = []
+        opts = {"verbose": 3}
+        retjson = self.__call_cmd("install", pkgs, opts)
+        self.assertTrue(
+            "at least one package" in retjson["errors"][0]["reason"]
+        )
+
+        # Run through pkg install.
+        pkgs = ["newpkg@1.0"]
+        opts = {"parsable_version": 0}
+        global_settings.client_output_quiet = True
+        retjson = self.__call_cmd("install", pkgs, opts)
+        global_settings.client_output_quiet = False
+
+        # Test input directly against schema.
+        pargs = "pargs_json"
+        install_schema = cli_api._get_pkg_input_schema("install")
+        install_input = {pargs: [], "opts_json": {}}
+        self.assertTrue(self.__schema_validation(install_input, install_schema))
+
+        install_input = {pargs: [12], "opts_json": {}}
+        self.assertTrue(
+            not self.__schema_validation(install_input, install_schema)
+        )
+
+        install_input = {pargs: ["pkg"], "opts_json": {}}
+        self.assertTrue(self.__schema_validation(install_input, install_schema))
+
+        install_input = {
+            pargs: ["pkg"],
+            "opts_json": {"parsable_version": "string"},
         }
+        self.assertTrue(
+            not self.__schema_validation(install_input, install_schema)
+        )
+
+        install_input = {pargs: ["pkg"], "opts_json": {"parsable_version": 3}}
+        self.assertTrue(
+            not self.__schema_validation(install_input, install_schema)
+        )
+
+        install_input = {
+            pargs: ["pkg"],
+            "opts_json": {"parsable_version": None},
+        }
+        self.assertTrue(self.__schema_validation(install_input, install_schema))
+
+        install_input = {pargs: ["pkg"], "opts_json": {"reject_pats": False}}
+        self.assertTrue(
+            not self.__schema_validation(install_input, install_schema)
+        )
+
+        install_input = {pargs: ["pkg"], "opts_json": {"reject_pats": []}}
+        self.assertTrue(self.__schema_validation(install_input, install_schema))
+
+        install_input = {pargs: ["pkg"], "opts_json": {"accept": "str"}}
+        self.assertTrue(
+            not self.__schema_validation(install_input, install_schema)
+        )
+
+        install_input = {pargs: ["pkg"], "opts_json": {"accept": False}}
+        self.assertTrue(self.__schema_validation(install_input, install_schema))
+
+        install_input = {pargs: ["pkg"], "opts_json": {"act_timeout": 1.2}}
+        self.assertTrue(
+            not self.__schema_validation(install_input, install_schema)
+        )
+
+        install_input = {pargs: ["pkg"], "opts_json": {"act_timeout": -1}}
+        self.assertTrue(
+            not self.__schema_validation(install_input, install_schema)
+        )
+
+        install_input = {
+            pargs: ["pkg"],
+            "opts_json": {"li_erecurse_list": [None, None]},
+        }
+        self.assertTrue(
+            not self.__schema_validation(install_input, install_schema)
+        )
+
+        install_input = {pargs: [None], "opts_json": {"li_erecurse_list": []}}
+        self.assertTrue(
+            not self.__schema_validation(install_input, install_schema)
+        )
+
+    def test_05_update_json_args_opts(self):
+        """Test json args or opts for update command."""
+
+        global_settings.client_output_quiet = True
+        self.image_create(self.rurl1, prefix="test1")
+        os.environ["PKG_IMAGE"] = self.img_path()
+        # Test invalid pkg name.
+        pkgs = [1, 2, 3]
+        opts = {"backup_be": True}
+        retjson = self.__call_cmd("update", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'string'" in retjson["errors"][0]["reason"]
+        )
+
+        pkgs = [None]
+        opts = {"backup_be": True}
+        os.environ["PKG_IMAGE"] = self.img_path()
+        retjson = self.__call_cmd("update", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'string'" in retjson["errors"][0]["reason"]
+        )
+
+        # Test unknown option was reported.
+        pkgs = ["newpkg@1.0"]
+        opts = {"unknown": "solaris"}
+        retjson = self.__call_cmd("update", pkgs, opts)
+        self.assertTrue("invalid option" in retjson["errors"][0]["reason"])
+
+        # Test without pkg specified.
+        pkgs = []
+        opts = {"verbose": 3}
+        retjson = self.__call_cmd("update", pkgs, opts)
+        self.assertTrue(retjson["status"] == 4)
+
+        # Run through pkg update.
+        self.pkg("install pkg://test1/foo@1.0")
+        pkgs = ["foo@1.1"]
+        opts = {"parsable_version": 0}
+
+        retjson = self.__call_cmd("update", pkgs, opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+
+        pkgs = []
+        retjson = self.__call_cmd("update", pkgs, opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+        global_settings.client_output_quiet = False
+
+        # Test input directly against schema.
+        pargs = "pargs_json"
+        update_schema = cli_api._get_pkg_input_schema("update")
+        update_input = {pargs: [], "opts_json": {}}
+        self.assertTrue(self.__schema_validation(update_input, update_schema))
+
+        update_input = {pargs: [None], "opts_json": {}}
+        self.assertTrue(
+            not self.__schema_validation(update_input, update_schema)
+        )
+
+        update_input = {pargs: None, "opts_json": {}}
+        self.assertTrue(
+            not self.__schema_validation(update_input, update_schema)
+        )
+
+        update_input = {pargs: [1, 2], "opts_json": {}}
+        self.assertTrue(
+            not self.__schema_validation(update_input, update_schema)
+        )
+
+        update_input = {pargs: [], "opts_json": {"force": True}}
+        self.assertTrue(self.__schema_validation(update_input, update_schema))
+
+        update_input = {pargs: [], "opts_json": {"ignore_missing": True}}
+        self.assertTrue(self.__schema_validation(update_input, update_schema))
+
+    def test_06_uninstall_args_opts(self):
+        """Test json args or opts for update command."""
+
+        global_settings.client_output_quiet = True
+        self.image_create(self.rurl1, prefix="test1")
+        os.environ["PKG_IMAGE"] = self.img_path()
+        # Test invalid pkg name.
+        pkgs = [1, 2, 3]
+        opts = {}
+        retjson = self.__call_cmd("uninstall", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'string'" in retjson["errors"][0]["reason"]
+        )
+
+        pkgs = [None]
+        opts = {}
+        os.environ["PKG_IMAGE"] = self.img_path()
+        retjson = self.__call_cmd("uninstall", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'string'" in retjson["errors"][0]["reason"]
+        )
+
+        # Test unknown option was reported.
+        pkgs = ["newpkg@1.0"]
+        opts = {"unknown": "solaris"}
+        retjson = self.__call_cmd("uninstall", pkgs, opts)
+        self.assertTrue("invalid option" in retjson["errors"][0]["reason"])
+
+        # Test without pkg specified.
+        pkgs = []
+        opts = {"verbose": 3}
+        retjson = self.__call_cmd("uninstall", pkgs, opts)
+        self.assertTrue(
+            "at least one package" in retjson["errors"][0]["reason"]
+        )
+
+        # Run through pkg uninstall.
+        self.pkg("install pkg://test1/foo@1.0")
+        pkgs = ["foo"]
+        opts = {"parsable_version": 0}
+
+        retjson = self.__call_cmd("uninstall", pkgs, opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+        global_settings.client_output_quiet = False
+
+        # Test input directly against schema.
+        pargs = "pargs_json"
+        uninstall_schema = cli_api._get_pkg_input_schema("uninstall")
+        uninstall_input = {pargs: ["pkg"], "opts_json": {}}
+        self.assertTrue(
+            self.__schema_validation(uninstall_input, uninstall_schema)
+        )
+
+        uninstall_input = {pargs: None, "opts_json": {}}
+        self.assertTrue(
+            not self.__schema_validation(uninstall_input, uninstall_schema)
+        )
+
+        uninstall_input = {pargs: [], "opts_json": {"ignore_missing": True}}
+        self.assertTrue(
+            self.__schema_validation(uninstall_input, uninstall_schema)
+        )
+
+    def test_07_set_publisher_args_opts(self):
+        """Test json args or opts for update command."""
+
+        global_settings.client_output_quiet = True
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.image_create(self.rurl1)
+        os.environ["PKG_IMAGE"] = self.img_path()
+        # Test invalid pkg name.
+        pubs = ["test1"]
+        opts = {"origin_uri": self.rurl1}
+        retjson = self.__call_cmd("set-publisher", pubs, opts)
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+
+        retjson = self.__call_cmd("unset-publisher", pubs, {})
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+
+        opts = {"add_origins": [self.rurl1]}
+        retjson = self.__call_cmd("set-publisher", pubs, opts)
+        self.assertTrue("errors" not in retjson)
+
+        pkgs = ["newpkg@1.0"]
+        opts = {"parsable_version": 0}
+        retjson = self.__call_cmd("install", pkgs, opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+
+        pkgs = ["newpkg"]
+        opts = {"parsable_version": 0}
+        retjson = self.__call_cmd("uninstall", pkgs, opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+
+        self.pkg("set-publisher -O " + self.rurl2 + " test2")
+        retjson = cli_api._pkg_invoke(
+            subcommand="unset-publisher",
+            pargs_json=json.dumps(["test2"]),
+            opts_json=None,
+        )
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+
+        retjson = self.__call_cmd("unset-publisher", pubs, {})
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+
+        opts = {"repo_uri": self.rurl1}
+        retjson = self.__call_cmd("set-publisher", [], opts)
+        self.assertTrue(retjson["data"]["added"] == ["test1"])
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+
+        retjson = self.__call_cmd("set-publisher", [], opts)
+        self.assertTrue(retjson["data"]["updated"] == ["test1"])
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+
+        pkgs = ["pkg://test1/foo@1"]
+        opts = {"parsable_version": 0}
+        retjson = self.__call_cmd("install", pkgs, opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+
+        opts = {
+            "repo_uri": self.rurl2,
+            "set_props": ["prop1=here", "prop2=there"],
+        }
+        retjson = self.__call_cmd("set-publisher", [], opts)
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+
+        opts = {"repo_uri": self.rurl2, "unset_props": ["prop1", "prop2"]}
+        retjson = self.__call_cmd("set-publisher", [], opts)
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+
+        opts = {
+            "repo_uri": self.rurl2,
+            "search_before": "a",
+            "search_after": "b",
+        }
+        retjson = self.__call_cmd("set-publisher", [], opts)
+        self.assertTrue(retjson["status"] == 2)
+        self.assertTrue("errors" in retjson)
+
+        opts = {"repo_uri": self.rurl2, "add_origins": ["a"]}
+        retjson = self.__call_cmd("set-publisher", [], opts)
+        self.assertTrue(retjson["status"] == 2)
+        self.assertTrue("errors" in retjson)
+
+        opts = {"repo_uri": self.rurl2, "refresh_allowed": False}
+        retjson = self.__call_cmd("set-publisher", [], opts)
+        self.assertTrue(retjson["status"] == 2)
+        self.assertTrue("combined" in retjson["errors"][0]["reason"])
+
+        opts = {"proxy_uri": self.rurl2}
+        retjson = self.__call_cmd("set-publisher", [], opts)
+        self.assertTrue(retjson["status"] == 2)
+        self.assertTrue("only be used" in retjson["errors"][0]["reason"])
+        global_settings.client_output_quiet = False
+
+        # Test input directly against schema.
+        pargs = "pargs_json"
+        schema = cli_api._get_pkg_input_schema("set-publisher")
+
+        test_input = {pargs: ["test1"], "opts_json": {"enable": True}}
+        self.assertTrue(self.__schema_validation(test_input, schema))
+
+        test_input = {pargs: None, "opts_json": {"enable": True}}
+        self.assertTrue(not self.__schema_validation(test_input, schema))
+
+        test_input = {pargs: [], "opts_json": {"repo_uri": "test"}}
+        self.assertTrue(self.__schema_validation(test_input, schema))
+
+        schema = cli_api._get_pkg_input_schema("unset-publisher")
+        test_input = {pargs: [], "opts_json": {}}
+        self.assertTrue(self.__schema_validation(test_input, schema))
+
+    def test_08_publisher_args_opts(self):
+        global_settings.client_output_quiet = True
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.image_create(self.rurl1)
+        os.environ["PKG_IMAGE"] = self.img_path()
+        opts = {"repo_uri": self.rurl1}
+        retjson = self.__call_cmd("set-publisher", [], opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+        # Test unset pub name.
+        pubs = ["no_pub"]
+        opts = {}
+        retjson = self.__call_cmd("publisher", pubs, opts)
+        self.assertTrue(retjson["status"] == 1)
+        self.assertTrue("Unknown publisher" in retjson["errors"][0]["reason"])
+
+        pubs = []
+        opts = {"omit_headers": True}
+        retjson = self.__call_cmd("publisher", pubs, opts)
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("data" in retjson)
+        self.assertTrue("headers" not in retjson["data"])
+
+        pubs = []
+        opts = {"output_format": "tsv"}
+        retjson = self.__call_cmd("publisher", pubs, opts)
+        self.assertTrue(len(retjson["data"]["headers"]) == 8)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+
+        pubs = []
+        opts = {"output_format": "invalid"}
+        retjson = self.__call_cmd("publisher", pubs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        pubs = []
+        opts = {"output_format": ["invalid"]}
+        retjson = self.__call_cmd("publisher", pubs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        pubs = []
+        opts = {"output_format": None}
+        retjson = self.__call_cmd("publisher", pubs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        pubs = []
+        opts = {"inc_disabled": False}
+        retjson = self.__call_cmd("publisher", pubs, opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+
+        pubs = []
+        opts = {"inc_disabled": "False"}
+        retjson = self.__call_cmd("publisher", pubs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        pubs = ["test1"]
+        opts = {}
+        retjson = self.__call_cmd("publisher", pubs, opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("publisher_details" in retjson["data"])
+        self.assertTrue(len(retjson["data"]["publisher_details"]) == 1)
+
+    def test_09_info_args_opts(self):
+        global_settings.client_output_quiet = True
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.image_create(self.rurl1)
+        os.environ["PKG_IMAGE"] = self.img_path()
+        opts = {"repo_uri": self.rurl1}
+        retjson = self.__call_cmd("set-publisher", [], opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+
+        self.pkg("install pkg://test1/foo@1.0")
+        pkgs = ["foo"]
+        opts = {"origins": [self.rurl1]}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue("package_attrs" in retjson["data"])
+        self.assertTrue(len(retjson["data"]["package_attrs"]) == 2)
+
+        pkgs = []
+        opts = {"origins": [self.rurl1]}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        pkgs = []
+        opts = {"origins": [None]}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        pkgs = []
+        opts = {"origins": None}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        opts = {"origins": "single"}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        pkgs = ["foo"]
+        opts = {"origins": [self.rurl1], "quiet": "True"}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue("data" not in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        pkgs = ["foo"]
+        opts = {"origins": [self.rurl1], "quiet": True}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue("data" not in retjson)
+        self.assertTrue(retjson["status"] == 0)
+
+        pkgs = []
+        opts = {"origins": [self.rurl1], "quiet": True}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue("data" not in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        pkgs = ["foo"]
+        opts = {}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue(len(retjson["data"]["package_attrs"]) == 1)
+        self.assertTrue(
+            retjson["data"]["package_attrs"][0][2][1][0]
+            == "Installed (Manually installed)"
+        )
+        self.assertTrue(retjson["status"] == 0)
+
+        pkgs = []
+        opts = {"origins": [self.rurl1], "quiet": True}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue("data" not in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        pkgs = []
+        opts = {"info_local": True, "info_remote": True}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue("data" not in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+        # Test with wrong value type.
+        pkgs = []
+        opts = {"info_local": "true"}
+        retjson = self.__call_cmd("info", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue("data" not in retjson)
+        self.assertTrue(retjson["status"] == 2)
+
+    def test_10_exact_install_json_args_opts(self):
+        """Test json args or opts for exact-install command."""
+
+        # Test invalid pkg name.
+        self.image_create(self.rurl1, prefix="test1")
+        os.environ["PKG_IMAGE"] = self.img_path()
+        pkgs = [1, 2, 3]
+        opts = {"backup_be": True}
+        retjson = self.__call_cmd("exact-install", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'string'" in retjson["errors"][0]["reason"]
+        )
+
+        pkgs = [None]
+        opts = {"backup_be": True}
+        os.environ["PKG_IMAGE"] = self.img_path()
+        retjson = self.__call_cmd("exact-install", pkgs, opts)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue(
+            "is not of type 'string'" in retjson["errors"][0]["reason"]
+        )
+
+        # Test unknown option was reported.
+        pkgs = ["newpkg@1.0"]
+        opts = {"unknown": "solaris"}
+        retjson = self.__call_cmd("exact-install", pkgs, opts)
+        self.assertTrue("invalid option" in retjson["errors"][0]["reason"])
+
+        # Test without pkg specified.
+        pkgs = []
+        opts = {"verbose": 3}
+        retjson = self.__call_cmd("exact-install", pkgs, opts)
+        self.assertTrue(
+            "at least one package" in retjson["errors"][0]["reason"]
+        )
+
+        # Run through pkg install.
+        pkgs = ["newpkg@1.0"]
+        opts = {"parsable_version": 0}
+        global_settings.client_output_quiet = True
+        retjson = self.__call_cmd("exact-install", pkgs, opts)
+        global_settings.client_output_quiet = False
+
+        # Test input directly against schema.
+        pargs = "pargs_json"
+        einstall_schema = cli_api._get_pkg_input_schema("exact-install")
+        einstall_input = {pargs: [], "opts_json": {}}
+        self.assertTrue(
+            self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {pargs: [12], "opts_json": {}}
+        self.assertTrue(
+            not self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {pargs: ["pkg"], "opts_json": {}}
+        self.assertTrue(
+            self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {
+            pargs: ["pkg"],
+            "opts_json": {"parsable_version": "string"},
+        }
+        self.assertTrue(
+            not self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {pargs: ["pkg"], "opts_json": {"parsable_version": 3}}
+        self.assertTrue(
+            not self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {
+            pargs: ["pkg"],
+            "opts_json": {"parsable_version": None},
+        }
+        self.assertTrue(
+            self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {pargs: ["pkg"], "opts_json": {"reject_pats": False}}
+        self.assertTrue(
+            not self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {pargs: ["pkg"], "opts_json": {"reject_pats": []}}
+        self.assertTrue(
+            self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {pargs: ["pkg"], "opts_json": {"accept": "str"}}
+        self.assertTrue(
+            not self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {pargs: ["pkg"], "opts_json": {"accept": False}}
+        self.assertTrue(
+            self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {
+            pargs: ["pkg"],
+            "opts_json": {"reject_pats": [None, None]},
+        }
+        self.assertTrue(
+            not self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+        einstall_input = {pargs: [None], "opts_json": {"reject_pats": []}}
+        self.assertTrue(
+            not self.__schema_validation(einstall_input, einstall_schema)
+        )
+
+    def test_11_verify_json_args_opts(self):
+        """Test json args or opts for verify command."""
+
+        self.image_create(self.rurl1, prefix="test1")
+        os.environ["PKG_IMAGE"] = self.img_path()
+        pkgs = ["verifypkg@1.0"]
+        opts = {"parsable_version": 0}
+        global_settings.client_output_quiet = True
+        retjson = self.__call_cmd("install", pkgs, opts)
+        global_settings.client_output_quiet = False
+
+        # Test invalid options.
+        pkgs = ["verifypkg"]
+        opts = {"omit_headers": True, "parsable_version": 0}
+        retjson = self.__call_cmd("verify", pkgs, opts)
+        self.assertTrue(retjson["status"] == 2)
+        self.assertTrue("combined" in retjson["errors"][0]["reason"])
+
+        pkgs = ["verifypkg"]
+        opts = {"fake_opt": True}
+        retjson = self.__call_cmd("verify", pkgs, opts)
+        self.assertTrue(retjson["status"] == 2)
+        self.assertTrue("invalid" in retjson["errors"][0]["reason"])
+
+        pkgs = ["verifypkg"]
+        opts = {"parsable_version": "wrongValueType"}
+        retjson = self.__call_cmd("verify", pkgs, opts)
+        self.assertTrue(retjson["status"] == 2)
+
+        pkgs = ["verifypkg"]
+        opts = {"parsable_version": 1}
+        retjson = self.__call_cmd("verify", pkgs, opts)
+        self.assertTrue(retjson["status"] == 2)
+
+        pkgs = ["verifypkg"]
+        opts = {"unpackaged_only": True}
+        retjson = self.__call_cmd("verify", pkgs, opts)
+        self.assertTrue(retjson["status"] == 2)
+
+        pkgs = ["verifypkg"]
+        opts = {"unpackaged": True}
+        retjson = self.__call_cmd("verify", pkgs, opts)
+        self.assertTrue(retjson["status"] == 0)
+
+        # Run through verify.
+        pkgs = ["verifypkg"]
+        opts = {"parsable_version": 0}
+        retjson = self.__call_cmd("verify", pkgs, opts)
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue(retjson["data"]["plan"]["item-messages"])
+        reslist = retjson["data"]["plan"]["item-messages"]
+        self.assertTrue(
+            len(reslist) == 1
+            and reslist["pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z"][
+                "messages"
+            ][0]["msg_level"]
+            == "info"
+        )
+        verify_outschema = cli_api._get_pkg_output_schema("verify")
+        self.assertTrue(self.__schema_validation(retjson, verify_outschema))
+
+        pkgs = []
+        opts = {"unpackaged": True, "parsable_version": 0}
+        retjson = self.__call_cmd("verify", pkgs, opts)
+
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue(retjson["data"]["plan"]["item-messages"])
+        reslist = retjson["data"]["plan"]["item-messages"]["unpackaged"]
+
+        # /var is unpackaged
+        self.assertTrue(
+            len(reslist) == 1
+            and list(reslist.values())[0][0]["msg_level"] == "info"
+        )
+        # Also check if the packaged content is still there.
+        reslist = retjson["data"]["plan"]["item-messages"]
+        self.assertTrue(
+            len(reslist) == 2
+            and reslist["pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z"][
+                "messages"
+            ][0]["msg_level"]
+            == "info"
+        )
+        self.assertTrue(self.__schema_validation(retjson, verify_outschema))
+
+        pkgs = []
+        opts = {"unpackaged_only": True, "parsable_version": 0}
+        retjson = self.__call_cmd("verify", pkgs, opts)
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue(retjson["data"]["plan"]["item-messages"])
+        reslist = retjson["data"]["plan"]["item-messages"]["unpackaged"]
+
+        self.assertTrue(
+            len(reslist) == 1
+            and list(reslist.values())[0][0]["msg_level"] == "info"
+        )
+        # Also check if the packaged content is gone.
+        reslist = retjson["data"]["plan"]["item-messages"]
+        self.assertTrue(
+            len(reslist) == 1
+            and "pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z"
+            not in reslist
+        )
+        self.assertTrue(self.__schema_validation(retjson, verify_outschema))
+
+        # Test input directly against schema.
+        pargs = "pargs_json"
+        verify_schema = cli_api._get_pkg_input_schema("verify")
+        verify_input = {pargs: [], "opts_json": {}}
+        self.assertTrue(self.__schema_validation(verify_input, verify_schema))
+
+        verify_input = {
+            pargs: [],
+            "opts_json": {"unpackaged": "wrongValueType"},
+        }
+        self.assertTrue(
+            not self.__schema_validation(verify_input, verify_schema)
+        )
+
+    def test_12_fix_json_args_opts(self):
+        """Test json args or opts for fix command."""
+
+        self.image_create(self.rurl1, prefix="test1")
+        os.environ["PKG_IMAGE"] = self.img_path()
+        pkgs = ["verifypkg@1.0"]
+        opts = {"parsable_version": 0}
+        global_settings.client_output_quiet = True
+        retjson = self.__call_cmd("install", pkgs, opts)
+        global_settings.client_output_quiet = False
+
+        # Test invalid options.
+        pkgs = ["verifypkg"]
+        opts = {"omit_headers": True, "parsable_version": 0}
+        retjson = self.__call_cmd("fix", pkgs, opts)
+        self.assertTrue(retjson["status"] == 2)
+        self.assertTrue("combined" in retjson["errors"][0]["reason"])
+
+        pkgs = ["verifypkg"]
+        opts = {"fake_opt": True}
+        retjson = self.__call_cmd("fix", pkgs, opts)
+        self.assertTrue(retjson["status"] == 2)
+        self.assertTrue("invalid" in retjson["errors"][0]["reason"])
+
+        pkgs = ["verifypkg"]
+        opts = {"parsable_version": "wrongValueType"}
+        retjson = self.__call_cmd("fix", pkgs, opts)
+        self.assertTrue(retjson["status"] == 2)
+
+        opts = {"unpackaged": True}
+        retjson = self.__call_cmd("fix", pkgs, opts)
+        self.assertTrue(retjson["status"] == 4)
+
+        pkgs = []
+        opts = {"unpackaged": True}
+        retjson = self.__call_cmd("fix", pkgs, opts)
+        self.assertTrue(retjson["status"] == 4)
+
+        pkgs = []
+        opts = {"unpackaged_only": True}
+        retjson = self.__call_cmd("fix", pkgs, opts)
+        self.assertTrue(retjson["status"] == 2)
+
+        # Run through fix.
+        pkgs = ["verifypkg"]
+        opts = {"parsable_version": 0}
+        retjson = self.__call_cmd("fix", pkgs, opts)
+        self.assertTrue(retjson["status"] == 4)
+
+        # Modify file
+        self.file_append("usr/bin/bobcat", "foobar")
+        retjson = self.__call_cmd("fix", pkgs, opts)
+
+        self.assertTrue(retjson["data"]["plan"]["item-messages"])
+        reslist = retjson["data"]["plan"]["item-messages"]
+        self.assertTrue(
+            len(reslist) == 1
+            and reslist["pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z"][
+                "messages"
+            ][0]["msg_level"]
+            == "error"
+        )
+        fix_outschema = cli_api._get_pkg_output_schema("fix")
+        self.assertTrue(self.__schema_validation(retjson, fix_outschema))
+        # Test input directly against schema.
+        pargs = "pargs_json"
+        fix_schema = cli_api._get_pkg_input_schema("fix")
+        fix_input = {pargs: [], "opts_json": {}}
+        self.assertTrue(self.__schema_validation(fix_input, fix_schema))
+
+        pargs = "pargs_json"
+        fix_schema = cli_api._get_pkg_input_schema("fix")
+        fix_input = {pargs: [], "opts_json": {"verbose": "WrongType"}}
+        self.assertTrue(not self.__schema_validation(fix_input, fix_schema))
+
+    def test_13_ClientInterface(self):
+        """Test the clientInterface class."""
+        pt = progress.QuietProgressTracker()
+        cli_inst = cli_api.ClientInterface(
+            pkg_image=self.img_path(),
+            prog_tracker=pt,
+            opts_mapping={"be_name": "boot_env"},
+        )
+        opts = {"repo_uri": self.rurl1}
+        retjson = cli_inst.publisher_set(json.dumps([]), json.dumps(opts))
+        epset_schema_in = cli_inst.get_pkg_input_schema("set-publisher")
+        epset_schema_out = cli_inst.get_pkg_output_schema("set-publisher")
+        epset_input = {"pargs_json": [], "opts_json": opts}
+        self.assertTrue(self.__schema_validation(epset_input, epset_schema_in))
+        self.assertTrue(self.__schema_validation(retjson, epset_schema_out))
+
+        # Test uninstalling an not installed pkg.
+        opts = {}
+        args = ["no_install"]
+        retjson = cli_inst.uninstall(json.dumps(args), json.dumps(opts))
+        self.assertTrue(retjson["status"] == 1)
+        self.assertTrue("errors" in retjson)
+        eunins_schema_in = cli_inst.get_pkg_input_schema("uninstall")
+        # Test input schema was replaced by an mapped option name.
+        self.assertTrue("boot_env" in json.dumps(eunins_schema_in))
+        eunins_schema_out = cli_inst.get_pkg_output_schema("uninstall")
+        eunins_input = {"pargs_json": args, "opts_json": opts}
+        self.assertTrue(
+            self.__schema_validation(eunins_input, eunins_schema_in)
+        )
+        self.assertTrue(self.__schema_validation(retjson, eunins_schema_out))
+
+        # Test be related exception does not crash the system.
+        opts = {"boot_env": "s12"}
+        args = ["no_install"]
+        retjson = cli_inst.uninstall(json.dumps(args), json.dumps(opts))
+        self.assertTrue(retjson["status"] == 1)
+        self.assertTrue("errors" in retjson)
+        self.assertTrue("boot_env" not in json.dumps(retjson))
+
+        retjson = cli_inst.uninstall(json.dumps(["newpkg2"]), json.dumps({}))
+        self.assertTrue(retjson["status"] == 1)
+        self.assertTrue("errors" in retjson)
+
+        opts = {"parsable_version": 0}
+        args = ["newpkg2@1.0"]
+        retjson = cli_inst.install(json.dumps(args), json.dumps(opts))
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+        eins_schema_in = cli_inst.get_pkg_input_schema("install")
+        eins_schema_out = cli_inst.get_pkg_output_schema("install")
+        eins_input = {"pargs_json": args, "opts_json": opts}
+        self.assertTrue(self.__schema_validation(eins_input, eins_schema_in))
+        self.assertTrue(self.__schema_validation(retjson, eins_schema_out))
+
+        retjson = cli_inst.list_inventory()
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+        self.assertTrue("newpkg2" in json.dumps(retjson))
+
+        retjson = cli_inst.uninstall(json.dumps(args), json.dumps(opts))
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
+
+        retjson = cli_inst.publisher_set(json.dumps(["test1"]))
+        self.assertTrue(retjson["status"] == 0)
+        self.assertTrue("errors" not in retjson)
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test2"])
-                self.make_misc_files(self.misc_files)
-
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.pkgsend_bulk(self.rurl1, (self.foo1, self.foo10,
-                    self.foo11, self.foo12, self.foo121, self.food12,
-                    self.hierfoo10, self.newpkg10, self.newpkg210,
-                    self.verifypkg10))
-
-                # Ensure that the second repo's packages have exactly the same
-                # timestamps as those in the first ... by copying the repo over.
-                # If the repos need to have some contents which are different,
-                # send those changes after restarting depot 2.
-                d1dir = self.dcs[1].get_repodir()
-                d2dir = self.dcs[2].get_repodir()
-                self.copy_repository(d1dir, d2dir, { "test1": "test2" })
-
-                # The new repository won't have a catalog, so rebuild it.
-                self.dcs[2].get_repo(auto_create=True).rebuild()
-
-                # The third repository should remain empty and not be
-                # published to.
-
-                # Next, create the image and configure publishers.
-                self.image_create(self.rurl1, prefix="test1")
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.pkg("set-publisher -O " + self.rurl2 + " test2")
-
-                self.rurl3 = self.dcs[3].get_repo_url()
-
-        def __call_cmd(self, subcommand, args, opts):
-                retjson = cli_api._pkg_invoke(subcommand=subcommand,
-                    pargs_json=json.dumps(args), opts_json=json.dumps(opts))
-                return retjson
-
-        def test_01_invalid_pkg_invoke_args(self):
-                """Test invalid pkg_invoke args is handled correctly."""
-
-                pkgs = ["foo"]
-                opts = {"list_installed_newest": True, "list_all": True}
-                os.environ["PKG_IMAGE"] = self.img_path()
-                retjson = self.__call_cmd(None, pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("Sub-command"
-                    in retjson["errors"][0]["reason"])
-
-                invalidpargs = {"invalid": -1}
-                retjson = self.__call_cmd("list", invalidpargs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("pargs_json is invalid"
-                    in retjson["errors"][0]["reason"])
-
-                invalidpargs = {"invalid": -1}
-                retjson = self.__call_cmd("publisher", invalidpargs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("pargs_json is invalid"
-                    in retjson["errors"][0]["reason"])
-
-                invalidpargs = "+1+1random"
-                retjson = cli_api._pkg_invoke(subcommand="list",
-                    pargs_json=invalidpargs,
-                    opts_json=json.dumps(opts))
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("pargs_json is invalid"
-                    in retjson["errors"][0]["reason"])
-
-                invalidopts = "+1+1random"
-                retjson = cli_api._pkg_invoke(subcommand="list",
-                    pargs_json=json.dumps([]),
-                    opts_json=invalidopts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("opts_json is invalid"
-                    in retjson["errors"][0]["reason"])
-
-        def test_02_valid_pkg_invoke_args(self):
-                """Test valid arguments for pkg json."""
-
-                self.image_create(self.rurl1, prefix="test1")
-                os.environ["PKG_IMAGE"] = self.img_path()
-                pkgs = ["foo"]
-                opts = {"list_newest": True}
-
-                self.pkg("install pkg://test1/foo")
-                retjson = cli_api._pkg_invoke(subcommand="list", pargs_json=None,
-                    opts_json=json.dumps(opts))
-                self.assertTrue("errors" not in retjson)
-
-                retjson = cli_api._pkg_invoke(subcommand="list",
-                    pargs_json=json.dumps(["foo"]),
-                    opts_json=None)
-                self.assertTrue("errors" not in retjson)
-
-                retjson = self.__call_cmd("list", pkgs, opts)
-                self.assertTrue("errors" not in retjson)
-
-        def __schema_validation(self, input, schema):
-                """Test if the input is valid against the schema."""
-
-                try:
-                        json.validate(input, schema)
-                        return True
-                except Exception as e:
-                        return False
-
-        def test_03_list_json_args_opts(self):
-                """Test json args or opts for list command."""
-
-                self.image_create(self.rurl1, prefix="test1")
-                pkgs = [1, 2, 3]
-                opts = {"list_installed_newest": True, "list_all": True}
-                os.environ["PKG_IMAGE"] = self.img_path()
-                retjson = self.__call_cmd("list", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'string'" in
-                    retjson["errors"][0]["reason"])
-
-                pkgs = [None]
-                retjson = self.__call_cmd("list", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'string'" in
-                    retjson["errors"][0]["reason"])
-
-                pkgs = []
-                opts = {"list_installed_newest": 1}
-                retjson = self.__call_cmd("list", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'boolean'" in
-                    retjson["errors"][0]["reason"])
-
-                opts = {"origins": 1}
-                retjson = self.__call_cmd("list", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'array'" in
-                    retjson["errors"][0]["reason"])
-
-                opts = {"random": 1}
-                retjson = self.__call_cmd("list", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("invalid option" in \
-                    retjson["errors"][0]["reason"])
-
-                # Test args and opts directly against schema.
-                pargs = "pargs_json"
-                list_schema = cli_api._get_pkg_input_schema("list")
-                list_input = {pargs: [], "opts_json": {}}
-                self.assertTrue(self.__schema_validation(list_input, list_schema))
-
-                list_input = {pargs: [12], "opts_json": {}}
-                self.assertTrue(not self.__schema_validation(list_input,
-                    list_schema))
-
-                list_input = {pargs: [],
-                    "opts_json": {"list_upgradable": "string"}}
-                self.assertTrue(not self.__schema_validation(list_input,
-                    list_schema))
-
-                list_input = {pargs: [], "opts_json": {"list_upgradable":
-                    False}}
-                self.assertTrue(self.__schema_validation(list_input,
-                    list_schema))
-
-                list_input = {pargs: [], "opts_json": {"origins": False}}
-                self.assertTrue(not self.__schema_validation(list_input,
-                    list_schema))
-
-                list_input = {pargs: [], "opts_json": {"origins": []}}
-                self.assertTrue(self.__schema_validation(list_input,
-                    list_schema))
-
-        def test_04_install_json_args_opts(self):
-                """Test json args or opts for install command."""
-
-                # Test invalid pkg name.
-                self.image_create(self.rurl1, prefix="test1")
-                os.environ["PKG_IMAGE"] = self.img_path()
-                pkgs = [1, 2, 3]
-                opts = {"backup_be": True}
-                retjson = self.__call_cmd("install", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'string'" in
-                    retjson["errors"][0]["reason"])
-
-                pkgs = [None]
-                opts = {"backup_be": True}
-                os.environ["PKG_IMAGE"] = self.img_path()
-                retjson = self.__call_cmd("install", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'string'" in
-                    retjson["errors"][0]["reason"])
-
-                # Test unknown option was reported.
-                pkgs = ["newpkg@1.0"]
-                opts = {"unknown": "solaris"}
-                retjson = self.__call_cmd("install", pkgs, opts)
-                self.assertTrue("invalid option" in
-                    retjson["errors"][0]["reason"])
-
-                # Test without pkg specified.
-                pkgs = []
-                opts = {"verbose": 3}
-                retjson = self.__call_cmd("install", pkgs, opts)
-                self.assertTrue("at least one package" in
-                    retjson["errors"][0]["reason"])
-
-                # Run through pkg install.
-                pkgs = ["newpkg@1.0"]
-                opts = {"parsable_version": 0}
-                global_settings.client_output_quiet = True
-                retjson = self.__call_cmd("install", pkgs, opts)
-                global_settings.client_output_quiet = False
-
-                # Test input directly against schema.
-                pargs = "pargs_json"
-                install_schema = cli_api._get_pkg_input_schema("install")
-                install_input = {pargs : [], "opts_json": {}}
-                self.assertTrue(self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: [12], "opts_json": {}}
-                self.assertTrue(not self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = { pargs: ["pkg"], "opts_json": {}}
-                self.assertTrue(self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs : ["pkg"], "opts_json":
-                    {"parsable_version": "string"}}
-                self.assertTrue(not self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: ["pkg"], "opts_json":
-                    {"parsable_version": 3}}
-                self.assertTrue(not self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: ["pkg"], "opts_json":
-                    {"parsable_version": None}}
-                self.assertTrue(self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: ["pkg"], "opts_json": {"reject_pats":
-                    False}}
-                self.assertTrue(not self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: ["pkg"], "opts_json": {"reject_pats":
-                    []}}
-                self.assertTrue(self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: ["pkg"], "opts_json": {"accept": "str"}}
-                self.assertTrue(not self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: ["pkg"], "opts_json": {"accept": False}}
-                self.assertTrue(self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: ["pkg"], "opts_json":
-                    {"act_timeout": 1.2}}
-                self.assertTrue(not self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: ["pkg"], "opts_json":
-                    {"act_timeout": -1}}
-                self.assertTrue(not self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: ["pkg"], "opts_json":
-                    {"li_erecurse_list": [None, None]}}
-                self.assertTrue(not self.__schema_validation(install_input,
-                    install_schema))
-
-                install_input = {pargs: [None], "opts_json":
-                    {"li_erecurse_list": []}}
-                self.assertTrue(not self.__schema_validation(install_input,
-                    install_schema))
-
-        def test_05_update_json_args_opts(self):
-                """Test json args or opts for update command."""
-
-                global_settings.client_output_quiet = True
-                self.image_create(self.rurl1, prefix="test1")
-                os.environ["PKG_IMAGE"] = self.img_path()
-                # Test invalid pkg name.
-                pkgs = [1, 2, 3]
-                opts = {"backup_be": True}
-                retjson = self.__call_cmd("update", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'string'" in
-                    retjson["errors"][0]["reason"])
-
-                pkgs = [None]
-                opts = {"backup_be": True}
-                os.environ["PKG_IMAGE"] = self.img_path()
-                retjson = self.__call_cmd("update", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'string'" in
-                    retjson["errors"][0]["reason"])
-
-                # Test unknown option was reported.
-                pkgs = ["newpkg@1.0"]
-                opts = {"unknown": "solaris"}
-                retjson = self.__call_cmd("update", pkgs, opts)
-                self.assertTrue("invalid option" in
-                    retjson["errors"][0]["reason"])
-
-                # Test without pkg specified.
-                pkgs = []
-                opts = {"verbose": 3}
-                retjson = self.__call_cmd("update", pkgs, opts)
-                self.assertTrue(retjson["status"] == 4)
-
-                # Run through pkg update.
-                self.pkg("install pkg://test1/foo@1.0")
-                pkgs = ["foo@1.1"]
-                opts = {"parsable_version": 0}
-
-                retjson = self.__call_cmd("update", pkgs, opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-
-                pkgs=[]
-                retjson = self.__call_cmd("update", pkgs, opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-                global_settings.client_output_quiet = False
-
-                # Test input directly against schema.
-                pargs = "pargs_json"
-                update_schema = cli_api._get_pkg_input_schema("update")
-                update_input = {pargs: [], "opts_json": {}}
-                self.assertTrue(self.__schema_validation(update_input,
-                    update_schema))
-
-                update_input = {pargs: [None], "opts_json": {}}
-                self.assertTrue(not self.__schema_validation(update_input,
-                    update_schema))
-
-                update_input = {pargs: None, "opts_json": {}}
-                self.assertTrue(not self.__schema_validation(update_input,
-                    update_schema))
-
-                update_input = {pargs: [1, 2], "opts_json": {}}
-                self.assertTrue(not self.__schema_validation(update_input,
-                    update_schema))
-
-                update_input = {pargs: [], "opts_json": {"force": True}}
-                self.assertTrue(self.__schema_validation(update_input,
-                    update_schema))
-
-                update_input = {pargs: [], "opts_json": {"ignore_missing":
-                    True}}
-                self.assertTrue(self.__schema_validation(update_input,
-                    update_schema))
-
-        def test_06_uninstall_args_opts(self):
-                """Test json args or opts for update command."""
-
-                global_settings.client_output_quiet = True
-                self.image_create(self.rurl1, prefix="test1")
-                os.environ["PKG_IMAGE"] = self.img_path()
-                # Test invalid pkg name.
-                pkgs = [1, 2, 3]
-                opts = {}
-                retjson = self.__call_cmd("uninstall", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'string'" in
-                    retjson["errors"][0]["reason"])
-
-                pkgs = [None]
-                opts = {}
-                os.environ["PKG_IMAGE"] = self.img_path()
-                retjson = self.__call_cmd("uninstall", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'string'" in
-                    retjson["errors"][0]["reason"])
-
-                # Test unknown option was reported.
-                pkgs = ["newpkg@1.0"]
-                opts = {"unknown": "solaris"}
-                retjson = self.__call_cmd("uninstall", pkgs, opts)
-                self.assertTrue("invalid option" in
-                    retjson["errors"][0]["reason"])
-
-                # Test without pkg specified.
-                pkgs = []
-                opts = {"verbose": 3}
-                retjson = self.__call_cmd("uninstall", pkgs, opts)
-                self.assertTrue("at least one package" in
-                    retjson["errors"][0]["reason"])
-
-                # Run through pkg uninstall.
-                self.pkg("install pkg://test1/foo@1.0")
-                pkgs = ["foo"]
-                opts = {"parsable_version": 0}
-
-                retjson = self.__call_cmd("uninstall", pkgs, opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-                global_settings.client_output_quiet = False
-
-                # Test input directly against schema.
-                pargs = "pargs_json"
-                uninstall_schema = cli_api._get_pkg_input_schema("uninstall")
-                uninstall_input = {pargs: ["pkg"], "opts_json": {}}
-                self.assertTrue(self.__schema_validation(uninstall_input,
-                    uninstall_schema))
-
-                uninstall_input = {pargs: None, "opts_json": {}}
-                self.assertTrue(not self.__schema_validation(uninstall_input,
-                    uninstall_schema))
-
-                uninstall_input = {pargs: [], "opts_json": {"ignore_missing":
-                    True}}
-                self.assertTrue(self.__schema_validation(uninstall_input,
-                    uninstall_schema))
-
-        def test_07_set_publisher_args_opts(self):
-                """Test json args or opts for update command."""
-
-                global_settings.client_output_quiet = True
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.image_create(self.rurl1)
-                os.environ["PKG_IMAGE"] = self.img_path()
-                # Test invalid pkg name.
-                pubs = ["test1"]
-                opts = {"origin_uri": self.rurl1}
-                retjson = self.__call_cmd("set-publisher", pubs, opts)
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-
-                retjson = self.__call_cmd("unset-publisher", pubs, {})
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-
-                opts = {"add_origins": [self.rurl1]}
-                retjson = self.__call_cmd("set-publisher", pubs, opts)
-                self.assertTrue("errors" not in retjson)
-
-                pkgs = ["newpkg@1.0"]
-                opts = {"parsable_version": 0}
-                retjson = self.__call_cmd("install", pkgs, opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-
-                pkgs = ["newpkg"]
-                opts = {"parsable_version": 0}
-                retjson = self.__call_cmd("uninstall", pkgs, opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-
-                self.pkg("set-publisher -O " + self.rurl2 + " test2")
-                retjson = cli_api._pkg_invoke(
-                    subcommand="unset-publisher",
-                    pargs_json=json.dumps(["test2"]),
-                    opts_json=None)
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-
-                retjson = self.__call_cmd("unset-publisher", pubs, {})
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-
-                opts = {"repo_uri": self.rurl1}
-                retjson = self.__call_cmd("set-publisher", [], opts)
-                self.assertTrue(retjson["data"]["added"] == ["test1"])
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-
-                retjson = self.__call_cmd("set-publisher", [], opts)
-                self.assertTrue(retjson["data"]["updated"] == ["test1"])
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-
-                pkgs = ["pkg://test1/foo@1"]
-                opts = {"parsable_version": 0}
-                retjson = self.__call_cmd("install", pkgs, opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-
-                opts = {"repo_uri": self.rurl2, "set_props": ["prop1=here",
-                    "prop2=there"]}
-                retjson = self.__call_cmd("set-publisher", [], opts)
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-
-                opts = {"repo_uri": self.rurl2, "unset_props": ["prop1",
-                    "prop2"]}
-                retjson = self.__call_cmd("set-publisher", [], opts)
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-
-                opts = {"repo_uri": self.rurl2, "search_before": "a",
-                    "search_after": "b"}
-                retjson = self.__call_cmd("set-publisher", [], opts)
-                self.assertTrue(retjson["status"] == 2)
-                self.assertTrue("errors" in retjson)
-
-                opts = {"repo_uri": self.rurl2, "add_origins": ["a"]}
-                retjson = self.__call_cmd("set-publisher", [], opts)
-                self.assertTrue(retjson["status"] == 2)
-                self.assertTrue("errors" in retjson)
-
-                opts = {"repo_uri": self.rurl2, "refresh_allowed": False}
-                retjson = self.__call_cmd("set-publisher", [], opts)
-                self.assertTrue(retjson["status"] == 2)
-                self.assertTrue("combined" in retjson["errors"][0]["reason"])
-
-                opts = {"proxy_uri": self.rurl2}
-                retjson = self.__call_cmd("set-publisher", [], opts)
-                self.assertTrue(retjson["status"] == 2)
-                self.assertTrue("only be used" in retjson["errors"][0]["reason"])
-                global_settings.client_output_quiet = False
-
-                # Test input directly against schema.
-                pargs = "pargs_json"
-                schema = cli_api._get_pkg_input_schema("set-publisher")
-
-                test_input = {pargs: ["test1"], "opts_json": {"enable": True}}
-                self.assertTrue(self.__schema_validation(test_input,
-                    schema))
-
-                test_input = {pargs: None, "opts_json": {"enable": True}}
-                self.assertTrue(not self.__schema_validation(test_input,
-                    schema))
-
-                test_input = {pargs: [], "opts_json": {"repo_uri": "test"}}
-                self.assertTrue(self.__schema_validation(test_input,
-                    schema))
-
-                schema = cli_api._get_pkg_input_schema("unset-publisher")
-                test_input = {pargs: [], "opts_json": {}}
-                self.assertTrue(self.__schema_validation(test_input,
-                    schema))
-
-        def test_08_publisher_args_opts(self):
-                global_settings.client_output_quiet = True
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.image_create(self.rurl1)
-                os.environ["PKG_IMAGE"] = self.img_path()
-                opts = {"repo_uri": self.rurl1}
-                retjson = self.__call_cmd("set-publisher", [], opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-                # Test unset pub name.
-                pubs = ["no_pub"]
-                opts = {}
-                retjson = self.__call_cmd("publisher", pubs, opts)
-                self.assertTrue(retjson["status"] == 1)
-                self.assertTrue("Unknown publisher" in \
-                    retjson["errors"][0]["reason"])
-
-                pubs = []
-                opts = {"omit_headers": True}
-                retjson = self.__call_cmd("publisher", pubs, opts)
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("data" in retjson)
-                self.assertTrue("headers" not in retjson["data"])
-
-                pubs = []
-                opts = {"output_format": "tsv"}
-                retjson = self.__call_cmd("publisher", pubs, opts)
-                self.assertTrue(len(retjson["data"]["headers"]) == 8)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-
-                pubs = []
-                opts = {"output_format": "invalid"}
-                retjson = self.__call_cmd("publisher", pubs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                pubs = []
-                opts = {"output_format": ["invalid"]}
-                retjson = self.__call_cmd("publisher", pubs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                pubs = []
-                opts = {"output_format": None}
-                retjson = self.__call_cmd("publisher", pubs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                pubs = []
-                opts = {"inc_disabled": False}
-                retjson = self.__call_cmd("publisher", pubs, opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-
-                pubs = []
-                opts = {"inc_disabled": "False"}
-                retjson = self.__call_cmd("publisher", pubs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                pubs = ["test1"]
-                opts = {}
-                retjson = self.__call_cmd("publisher", pubs, opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("publisher_details" in retjson["data"])
-                self.assertTrue(len(retjson["data"]["publisher_details"]) == 1)
-
-        def test_09_info_args_opts(self):
-                global_settings.client_output_quiet = True
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.image_create(self.rurl1)
-                os.environ["PKG_IMAGE"] = self.img_path()
-                opts = {"repo_uri": self.rurl1}
-                retjson = self.__call_cmd("set-publisher", [], opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-
-                self.pkg("install pkg://test1/foo@1.0")
-                pkgs = ["foo"]
-                opts = {"origins": [self.rurl1]}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue("package_attrs" in retjson["data"])
-                self.assertTrue(len(retjson["data"]["package_attrs"]) == 2)
-
-                pkgs = []
-                opts = {"origins": [self.rurl1]}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                pkgs = []
-                opts = {"origins": [None]}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                pkgs = []
-                opts = {"origins": None}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                opts = {"origins": "single"}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                pkgs = ["foo"]
-                opts = {"origins": [self.rurl1], "quiet": "True"}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("data" not in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                pkgs = ["foo"]
-                opts = {"origins": [self.rurl1], "quiet": True}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue("data" not in retjson)
-                self.assertTrue(retjson["status"] == 0)
-
-                pkgs = []
-                opts = {"origins": [self.rurl1], "quiet": True}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("data" not in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                pkgs = ["foo"]
-                opts = {}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue(len(retjson["data"]["package_attrs"]) == 1)
-                self.assertTrue(retjson["data"]["package_attrs"][0][2][1][0] \
-                    == "Installed (Manually installed)")
-                self.assertTrue(retjson["status"] == 0)
-
-                pkgs = []
-                opts = {"origins": [self.rurl1], "quiet": True}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("data" not in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                pkgs = []
-                opts = {"info_local": True, "info_remote": True}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("data" not in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-                # Test with wrong value type.
-                pkgs = []
-                opts = {"info_local": "true"}
-                retjson = self.__call_cmd("info", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("data" not in retjson)
-                self.assertTrue(retjson["status"] == 2)
-
-        def test_10_exact_install_json_args_opts(self):
-                """Test json args or opts for exact-install command."""
-
-                # Test invalid pkg name.
-                self.image_create(self.rurl1, prefix="test1")
-                os.environ["PKG_IMAGE"] = self.img_path()
-                pkgs = [1, 2, 3]
-                opts = {"backup_be": True}
-                retjson = self.__call_cmd("exact-install", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'string'" in
-                    retjson["errors"][0]["reason"])
-
-                pkgs = [None]
-                opts = {"backup_be": True}
-                os.environ["PKG_IMAGE"] = self.img_path()
-                retjson = self.__call_cmd("exact-install", pkgs, opts)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("is not of type 'string'" in
-                    retjson["errors"][0]["reason"])
-
-                # Test unknown option was reported.
-                pkgs = ["newpkg@1.0"]
-                opts = {"unknown": "solaris"}
-                retjson = self.__call_cmd("exact-install", pkgs, opts)
-                self.assertTrue("invalid option" in
-                    retjson["errors"][0]["reason"])
-
-                # Test without pkg specified.
-                pkgs = []
-                opts = {"verbose": 3}
-                retjson = self.__call_cmd("exact-install", pkgs, opts)
-                self.assertTrue("at least one package" in
-                    retjson["errors"][0]["reason"])
-
-                # Run through pkg install.
-                pkgs = ["newpkg@1.0"]
-                opts = {"parsable_version": 0}
-                global_settings.client_output_quiet = True
-                retjson = self.__call_cmd("exact-install", pkgs, opts)
-                global_settings.client_output_quiet = False
-
-                # Test input directly against schema.
-                pargs = "pargs_json"
-                einstall_schema = cli_api._get_pkg_input_schema("exact-install")
-                einstall_input = {pargs : [], "opts_json": {}}
-                self.assertTrue(self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = {pargs: [12], "opts_json": {}}
-                self.assertTrue(not self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = { pargs: ["pkg"], "opts_json": {}}
-                self.assertTrue(self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = {pargs : ["pkg"], "opts_json":
-                    {"parsable_version": "string"}}
-                self.assertTrue(not self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = {pargs: ["pkg"], "opts_json":
-                    {"parsable_version": 3}}
-                self.assertTrue(not self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = {pargs: ["pkg"], "opts_json":
-                    {"parsable_version": None}}
-                self.assertTrue(self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = {pargs: ["pkg"], "opts_json": {"reject_pats":
-                    False}}
-                self.assertTrue(not self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = {pargs: ["pkg"], "opts_json": {"reject_pats":
-                    []}}
-                self.assertTrue(self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = {pargs: ["pkg"], "opts_json": {"accept":
-                    "str"}}
-                self.assertTrue(not self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = {pargs: ["pkg"], "opts_json": {"accept":
-                    False}}
-                self.assertTrue(self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = {pargs: ["pkg"], "opts_json":
-                    {"reject_pats": [None, None]}}
-                self.assertTrue(not self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-                einstall_input = {pargs: [None], "opts_json":
-                    {"reject_pats": []}}
-                self.assertTrue(not self.__schema_validation(einstall_input,
-                    einstall_schema))
-
-        def test_11_verify_json_args_opts(self):
-                """Test json args or opts for verify command."""
-
-                self.image_create(self.rurl1, prefix="test1")
-                os.environ["PKG_IMAGE"] = self.img_path()
-                pkgs = ["verifypkg@1.0"]
-                opts = {"parsable_version": 0}
-                global_settings.client_output_quiet = True
-                retjson = self.__call_cmd("install", pkgs, opts)
-                global_settings.client_output_quiet = False
-
-                # Test invalid options.
-                pkgs = ["verifypkg"]
-                opts = {"omit_headers": True, "parsable_version": 0}
-                retjson = self.__call_cmd("verify", pkgs, opts)
-                self.assertTrue(retjson["status"] == 2)
-                self.assertTrue("combined" in retjson["errors"][0]["reason"])
-
-                pkgs = ["verifypkg"]
-                opts = {"fake_opt": True}
-                retjson = self.__call_cmd("verify", pkgs, opts)
-                self.assertTrue(retjson["status"] == 2)
-                self.assertTrue("invalid" in retjson["errors"][0]["reason"])
-
-                pkgs = ["verifypkg"]
-                opts = {"parsable_version": "wrongValueType"}
-                retjson = self.__call_cmd("verify", pkgs, opts)
-                self.assertTrue(retjson["status"] == 2)
-
-                pkgs = ["verifypkg"]
-                opts = {"parsable_version": 1}
-                retjson = self.__call_cmd("verify", pkgs, opts)
-                self.assertTrue(retjson["status"] == 2)
-
-                pkgs = ["verifypkg"]
-                opts = {"unpackaged_only": True}
-                retjson = self.__call_cmd("verify", pkgs, opts)
-                self.assertTrue(retjson["status"] == 2)
-
-                pkgs = ["verifypkg"]
-                opts = {"unpackaged": True}
-                retjson = self.__call_cmd("verify", pkgs, opts)
-                self.assertTrue(retjson["status"] == 0)
-
-                # Run through verify.
-                pkgs = ["verifypkg"]
-                opts = {"parsable_version": 0}
-                retjson = self.__call_cmd("verify", pkgs, opts)
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue(retjson["data"]["plan"]["item-messages"])
-                reslist = retjson["data"]["plan"]["item-messages"]
-                self.assertTrue(len(reslist) == 1 and
-                    reslist['pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z']
-                    ["messages"][0]["msg_level"] == "info")
-                verify_outschema = cli_api._get_pkg_output_schema("verify")
-                self.assertTrue(self.__schema_validation(retjson,
-                    verify_outschema))
-
-                pkgs = []
-                opts = {"unpackaged": True, "parsable_version": 0}
-                retjson = self.__call_cmd("verify", pkgs, opts)
-
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue(retjson["data"]["plan"]
-                    ["item-messages"])
-                reslist = retjson["data"]["plan"]["item-messages"]["unpackaged"]
-
-                # /var is unpackaged
-                self.assertTrue(len(reslist) == 1
-                    and list(reslist.values())[0][0]["msg_level"] == "info")
-                # Also check if the packaged content is still there.
-                reslist = retjson["data"]["plan"]["item-messages"]
-                self.assertTrue(len(reslist) == 2 and
-                    reslist['pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z']
-                    ["messages"][0]["msg_level"] == "info")
-                self.assertTrue(self.__schema_validation(retjson,
-                    verify_outschema))
-
-                pkgs = []
-                opts = {"unpackaged_only": True, "parsable_version": 0}
-                retjson = self.__call_cmd("verify", pkgs, opts)
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue(retjson["data"]["plan"]
-                    ["item-messages"])
-                reslist = retjson["data"]["plan"]["item-messages"]["unpackaged"]
-
-                self.assertTrue(len(reslist) == 1
-                    and list(reslist.values())[0][0]["msg_level"] == "info")
-                # Also check if the packaged content is gone.
-                reslist = retjson["data"]["plan"]["item-messages"]
-                self.assertTrue(len(reslist) == 1 and
-                    'pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z'
-                    not in reslist)
-                self.assertTrue(self.__schema_validation(retjson,
-                    verify_outschema))
-
-                # Test input directly against schema.
-                pargs = "pargs_json"
-                verify_schema = cli_api._get_pkg_input_schema("verify")
-                verify_input = {pargs : [], "opts_json": {}}
-                self.assertTrue(self.__schema_validation(verify_input,
-                    verify_schema))
-
-                verify_input = {pargs : [], "opts_json": {"unpackaged":
-                    "wrongValueType"}}
-                self.assertTrue(not self.__schema_validation(verify_input,
-                    verify_schema))
-
-        def test_12_fix_json_args_opts(self):
-                """Test json args or opts for fix command."""
-
-                self.image_create(self.rurl1, prefix="test1")
-                os.environ["PKG_IMAGE"] = self.img_path()
-                pkgs = ["verifypkg@1.0"]
-                opts = {"parsable_version": 0}
-                global_settings.client_output_quiet = True
-                retjson = self.__call_cmd("install", pkgs, opts)
-                global_settings.client_output_quiet = False
-
-                # Test invalid options.
-                pkgs = ["verifypkg"]
-                opts = {"omit_headers": True, "parsable_version": 0}
-                retjson = self.__call_cmd("fix", pkgs, opts)
-                self.assertTrue(retjson["status"] == 2)
-                self.assertTrue("combined" in retjson["errors"][0]["reason"])
-
-                pkgs = ["verifypkg"]
-                opts = {"fake_opt": True}
-                retjson = self.__call_cmd("fix", pkgs, opts)
-                self.assertTrue(retjson["status"] == 2)
-                self.assertTrue("invalid" in retjson["errors"][0]["reason"])
-
-                pkgs = ["verifypkg"]
-                opts = {"parsable_version": "wrongValueType"}
-                retjson = self.__call_cmd("fix", pkgs, opts)
-                self.assertTrue(retjson["status"] == 2)
-
-                opts = {"unpackaged": True}
-                retjson = self.__call_cmd("fix", pkgs, opts)
-                self.assertTrue(retjson["status"] == 4)
-
-                pkgs = []
-                opts = {"unpackaged": True}
-                retjson = self.__call_cmd("fix", pkgs, opts)
-                self.assertTrue(retjson["status"] == 4)
-
-                pkgs = []
-                opts = {"unpackaged_only": True}
-                retjson = self.__call_cmd("fix", pkgs, opts)
-                self.assertTrue(retjson["status"] == 2)
-
-                # Run through fix.
-                pkgs = ["verifypkg"]
-                opts = {"parsable_version": 0}
-                retjson = self.__call_cmd("fix", pkgs, opts)
-                self.assertTrue(retjson["status"] == 4)
-
-                # Modify file
-                self.file_append("usr/bin/bobcat", "foobar")
-                retjson = self.__call_cmd("fix", pkgs, opts)
-
-                self.assertTrue(retjson["data"]["plan"]["item-messages"])
-                reslist = retjson["data"]["plan"]["item-messages"]
-                self.assertTrue(len(reslist) == 1 and
-                    reslist['pkg://test1/verifypkg@1.0,5.11-0:20160302T054916Z']
-                    ["messages"][0]["msg_level"] == "error")
-                fix_outschema = cli_api._get_pkg_output_schema("fix")
-                self.assertTrue(self.__schema_validation(retjson,
-                    fix_outschema))
-                # Test input directly against schema.
-                pargs = "pargs_json"
-                fix_schema = cli_api._get_pkg_input_schema("fix")
-                fix_input = {pargs : [], "opts_json": {}}
-                self.assertTrue(self.__schema_validation(fix_input,
-                    fix_schema))
-
-                pargs = "pargs_json"
-                fix_schema = cli_api._get_pkg_input_schema("fix")
-                fix_input = {pargs : [], "opts_json": {"verbose": "WrongType"}}
-                self.assertTrue(not self.__schema_validation(fix_input,
-                    fix_schema))
-
-        def test_13_ClientInterface(self):
-                """Test the clientInterface class."""
-                pt = progress.QuietProgressTracker()
-                cli_inst = cli_api.ClientInterface(pkg_image=self.img_path(),
-                    prog_tracker=pt, opts_mapping={"be_name": "boot_env"})
-                opts = {"repo_uri": self.rurl1}
-                retjson = cli_inst.publisher_set(json.dumps([]),
-                    json.dumps(opts))
-                epset_schema_in = cli_inst.get_pkg_input_schema(
-                    "set-publisher")
-                epset_schema_out = cli_inst.get_pkg_output_schema(
-                    "set-publisher")
-                epset_input = {"pargs_json": [], "opts_json": opts}
-                self.assertTrue(self.__schema_validation(epset_input,
-                    epset_schema_in))
-                self.assertTrue(self.__schema_validation(retjson,
-                    epset_schema_out))
-
-                # Test uninstalling an not installed pkg.
-                opts = {}
-                args = ["no_install"]
-                retjson = cli_inst.uninstall(json.dumps(args), json.dumps(opts))
-                self.assertTrue(retjson["status"] == 1)
-                self.assertTrue("errors" in retjson)
-                eunins_schema_in = cli_inst.get_pkg_input_schema("uninstall")
-                # Test input schema was replaced by an mapped option name.
-                self.assertTrue("boot_env" in json.dumps(eunins_schema_in))
-                eunins_schema_out = cli_inst.get_pkg_output_schema("uninstall")
-                eunins_input = {"pargs_json": args, "opts_json": opts}
-                self.assertTrue(self.__schema_validation(eunins_input,
-                    eunins_schema_in))
-                self.assertTrue(self.__schema_validation(retjson,
-                    eunins_schema_out))
-
-                # Test be related exception does not crash the system.
-                opts = {"boot_env": "s12"}
-                args = ["no_install"]
-                retjson = cli_inst.uninstall(json.dumps(args),
-                    json.dumps(opts))
-                self.assertTrue(retjson["status"] == 1)
-                self.assertTrue("errors" in retjson)
-                self.assertTrue("boot_env" not in json.dumps(retjson))
-
-                retjson = cli_inst.uninstall(json.dumps(["newpkg2"]),
-                    json.dumps({}))
-                self.assertTrue(retjson["status"] == 1)
-                self.assertTrue("errors" in retjson)
-
-                opts = {"parsable_version": 0}
-                args = ["newpkg2@1.0"]
-                retjson = cli_inst.install(json.dumps(args), json.dumps(opts))
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-                eins_schema_in = cli_inst.get_pkg_input_schema("install")
-                eins_schema_out = cli_inst.get_pkg_output_schema("install")
-                eins_input = {"pargs_json": args, "opts_json": opts}
-                self.assertTrue(self.__schema_validation(eins_input,
-                    eins_schema_in))
-                self.assertTrue(self.__schema_validation(retjson,
-                    eins_schema_out))
-
-                retjson = cli_inst.list_inventory()
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-                self.assertTrue("newpkg2" in json.dumps(retjson))
-
-                retjson = cli_inst.uninstall(json.dumps(args), json.dumps(opts))
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
-
-                retjson = cli_inst.publisher_set(json.dumps(["test1"]))
-                self.assertTrue(retjson["status"] == 0)
-                self.assertTrue("errors" not in retjson)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_colliding_links.py
+++ b/src/tests/cli/t_colliding_links.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -32,69 +33,68 @@ import unittest
 
 
 class TestPkgCollidingLinks(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        pkg_A = """
+    pkg_A = """
         open pkg_A@1.0,5.11-0
         add file tmp/link_target_0 mode=0555 owner=root group=bin path=link_target_0
         add file tmp/link_target_1 mode=0555 owner=root group=bin path=link_target_1
         add file tmp/link_target_2 mode=0555 owner=root group=bin path=link_target_2
         close"""
 
-        pkg_B = """
+    pkg_B = """
         open pkg_B@1.0,5.11-0
         add link path=0 target=./link_target_0
         add link path=1 target=./link_target_1
         add link path=2 target=./link_target_2
         close"""
 
-        pkg_C = """
+    pkg_C = """
         open pkg_C@1.0,5.11-0
         add link path=0 target=./link_target_0
         add link path=1 target=./link_target_1
         add link path=/2 target=./link_target_2
         close"""
 
+    misc_files = [p for p in pkg_A.split() if "tmp/link_target" in p]
 
-        misc_files = [p for p in pkg_A.split() if "tmp/link_target" in p]
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.pkgsend_bulk(self.rurl, (self.pkg_A, self.pkg_B, self.pkg_C))
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.pkgsend_bulk(self.rurl, (self.pkg_A, self.pkg_B,
-                    self.pkg_C))
+    def test_1(self):
+        """Verify symlinks are correctly reference counted
+        during installation & removal of packages"""
+        # create an image
+        self.image_create(self.rurl)
+        # install packages and verify
 
-        def test_1(self):
-                """Verify symlinks are correctly reference counted
-                during installation & removal of packages"""
-                # create an image 
-                self.image_create(self.rurl)
-                # install packages and verify
+        self.pkg("install pkg_A pkg_B")
+        self.pkg("verify")
 
-                self.pkg("install pkg_A pkg_B")
-                self.pkg("verify")
+        # add a pkg w/ duplicate links
+        self.pkg("install pkg_C")
+        self.pkg("verify")
 
-                # add a pkg w/ duplicate links
-                self.pkg("install pkg_C")
-                self.pkg("verify")
+        # cause trouble.
+        self.pkg("uninstall pkg_C")
+        self.pkg("verify")
 
-                # cause trouble.
-                self.pkg("uninstall pkg_C")
-                self.pkg("verify")
+        # readd a pkg w/ duplicate links
+        self.pkg("install pkg_C")
+        self.pkg("verify")
 
-                # readd a pkg w/ duplicate links
-                self.pkg("install pkg_C")
-                self.pkg("verify")
+        self.pkg("uninstall pkg_B pkg_C")
+        self.pkg("verify")
 
-                self.pkg("uninstall pkg_B pkg_C")
-                self.pkg("verify")
 
 class TestPkgCollidingHardLinks(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        pkg_A = """
+    pkg_A = """
         open pkg_A@1.0,5.11-0
         add file tmp/link_target_0 mode=0555 owner=root group=bin path=link_target_0
         add file tmp/link_target_1 mode=0555 owner=root group=bin path=link_target_1
@@ -106,7 +106,7 @@ class TestPkgCollidingHardLinks(pkg5unittest.SingleDepotTestCase):
         add file tmp/link_target_5 mode=0555 owner=root group=bin path=link_target_2
         close"""
 
-        pkg_B = """
+    pkg_B = """
         open pkg_B@1.0,5.11-0
         add hardlink path=0 target=./link_target_0
         add hardlink path=1 target=./link_target_1
@@ -114,7 +114,7 @@ class TestPkgCollidingHardLinks(pkg5unittest.SingleDepotTestCase):
         add depend type=require fmri=pkg_A@1.0,5.11-0
         close"""
 
-        pkg_C = """
+    pkg_C = """
         open pkg_C@1.0,5.11-0
         add hardlink path=0 target=./link_target_0
         add hardlink path=1 target=./link_target_1
@@ -122,61 +122,60 @@ class TestPkgCollidingHardLinks(pkg5unittest.SingleDepotTestCase):
         add depend type=require fmri=pkg_A@1.0,5.11-0
         close"""
 
+    misc_files = [p for p in pkg_A.split() if "tmp/link_target" in p]
 
-        misc_files = [p for p in pkg_A.split() if "tmp/link_target" in p]
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.pkgsend_bulk(self.rurl, (self.pkg_A, self.pkg_B, self.pkg_C))
+
+    def check_link_count(self, n):
+        """Make sure link count is what we think it should be"""
+        for f in ("link_target_{0:d}".format(i) for i in range(3)):
+            self.assertEqual(
+                os.stat(os.path.join(self.get_img_path(), f)).st_nlink, n
+            )
+
+    def test_1(self):
+        """Verify hardlinks are correctly reference counted
+        during installation & removal of packages"""
+        # create an image
+        self.image_create(self.rurl)
+        # install packages and verify
+
+        self.pkg("install pkg_A@1.0")
+        self.check_link_count(1)
+
+        self.pkg("install pkg_B")
+        self.pkg("verify")
+        self.check_link_count(2)
+
+        # add a pkg w/ duplicate links
+        self.pkg("install pkg_C")
+        self.pkg("verify")
+        self.check_link_count(2)
+
+        # cause trouble.
+        self.pkg("uninstall pkg_C")
+        self.pkg("verify")
+        self.check_link_count(2)
+
+        # readd a pkg w/ duplicate links
+        self.pkg("install pkg_C")
+        self.pkg("verify")
+        self.check_link_count(2)
+
+        # update the files the links all point to
+        self.pkg("install pkg_A@2.0")
+        self.pkg("verify")
+
+        self.pkg("uninstall pkg_B pkg_C")
+        self.pkg("verify")
+        self.check_link_count(1)
 
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.pkgsend_bulk(self.rurl, (self.pkg_A, self.pkg_B,
-                    self.pkg_C))
-
-        def check_link_count(self, n):
-                """ Make sure link count is what we think it should be"""
-                for f in ("link_target_{0:d}".format(i) for i in range(3)):
-                        self.assertEqual(os.stat(os.path.join(self.get_img_path(), 
-                            f)).st_nlink, n)
- 
-        def test_1(self):
-                """Verify hardlinks are correctly reference counted
-                during installation & removal of packages"""
-                # create an image 
-                self.image_create(self.rurl)
-                # install packages and verify
-
-                self.pkg("install pkg_A@1.0")
-                self.check_link_count(1)
-
-                self.pkg("install pkg_B")
-                self.pkg("verify")
-                self.check_link_count(2)
-
-                # add a pkg w/ duplicate links
-                self.pkg("install pkg_C")
-                self.pkg("verify")
-                self.check_link_count(2)
-
-                # cause trouble.
-                self.pkg("uninstall pkg_C")
-                self.pkg("verify")
-                self.check_link_count(2)
-
-                # readd a pkg w/ duplicate links
-                self.pkg("install pkg_C")
-                self.pkg("verify")
-                self.check_link_count(2)
-
-                # update the files the links all point to
-                self.pkg("install pkg_A@2.0")
-                self.pkg("verify")
-
-                self.pkg("uninstall pkg_B pkg_C")
-                self.pkg("verify")
-                self.check_link_count(1)
-                
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_depot_config.py
+++ b/src/tests/cli/t_depot_config.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import copy
@@ -49,65 +50,64 @@ HTTPDEPOT_USER = "pkg5srv"
 
 
 class _Apache(object):
-        # An array that can be used to build our svcs(1) wrapper.
-        default_svcs_conf = [
-            # FMRI                                   STATE
-            ["svc:/application/pkg/server:default",  "online" ],
-            ["svc:/application/pkg/server:usr",      "online" ],
-            # an instance which we have a writable_root for
-            ["svc:/application/pkg/server:windex",   "online" ],
-            # repositories that we will not serve
-            ["svc:/application/pkg/server:off",      "offline"],
-            ["svc:/application/pkg/server:writable", "online" ],
-            ["svc:/application/pkg/server:solitary", "offline"]
-        ]
+    # An array that can be used to build our svcs(1) wrapper.
+    default_svcs_conf = [
+        # FMRI                                   STATE
+        ["svc:/application/pkg/server:default", "online"],
+        ["svc:/application/pkg/server:usr", "online"],
+        # an instance which we have a writable_root for
+        ["svc:/application/pkg/server:windex", "online"],
+        # repositories that we will not serve
+        ["svc:/application/pkg/server:off", "offline"],
+        ["svc:/application/pkg/server:writable", "online"],
+        ["svc:/application/pkg/server:solitary", "offline"],
+    ]
 
-        # An array that can be used to build our svcprop(1)
-        # wrapper in conjunction with svcs_conf.  This array
-        # must be in the same order as svcs_conf and the rows
-        # must correspond.
-        default_svcprop_conf = [
-            # inst_root           readonly  standalone  writable_root
-            ["{rdir1}",         "true",   "false",    "\"\""],
-            ["{rdir2}",         "true",   "false",    "\"\""],
-            ["{rdir3}",         "true",   "false",    "{index_dir}"],
-            # we intentionally use non-existent repository
-            # paths in these services, and check they aren't
-            # present in the httpd.conf later.
-            ["/pkg5/there/aint", "true",    "false",    "\"\""],
-            ["/pkg5/nobody/here", "false",  "false",    "\"\""],
-            ["/pkg5/but/us/chickens", "true", "true",   "\"\""],
-        ]
+    # An array that can be used to build our svcprop(1)
+    # wrapper in conjunction with svcs_conf.  This array
+    # must be in the same order as svcs_conf and the rows
+    # must correspond.
+    default_svcprop_conf = [
+        # inst_root           readonly  standalone  writable_root
+        ["{rdir1}", "true", "false", '""'],
+        ["{rdir2}", "true", "false", '""'],
+        ["{rdir3}", "true", "false", "{index_dir}"],
+        # we intentionally use non-existent repository
+        # paths in these services, and check they aren't
+        # present in the httpd.conf later.
+        ["/pkg5/there/aint", "true", "false", '""'],
+        ["/pkg5/nobody/here", "false", "false", '""'],
+        ["/pkg5/but/us/chickens", "true", "true", '""'],
+    ]
 
-        sample_pkg = """
+    sample_pkg = """
             open sample@1.0,5.11-0
             add file tmp/sample mode=0444 owner=root group=bin path=/usr/bin/sample
             close"""
 
-        sample_pkg_11 = """
+    sample_pkg_11 = """
             open sample@1.1,5.11-0
             add file tmp/updated mode=0444 owner=root group=bin path=/usr/bin/sample
             close"""
 
-        new_pkg = """
+    new_pkg = """
             open new@1.0,5.11-0
             add file tmp/new mode=0444 owner=root group=bin path=/usr/bin/new
             close"""
 
-        another_pkg = """
+    another_pkg = """
             open another@1.0,5.11-0
             add file tmp/another mode=0444 owner=root group=bin path=/usr/bin/another
             close"""
 
-        carrots_pkg = """
+    carrots_pkg = """
             open pkg://carrots/carrots@1.0,5.11-0
             add file tmp/another mode=0444 owner=root group=bin path=/usr/bin/carrots
             close"""
 
-        misc_files = ["tmp/sample", "tmp/updated", "tmp/another", "tmp/new"]
+    misc_files = ["tmp/sample", "tmp/updated", "tmp/another", "tmp/new"]
 
-        _svcs_template = \
-"""#!/usr/bin/ksh93
+    _svcs_template = """#!/usr/bin/ksh93
 #
 # This script produces false svcs(1) output, using
 # a list of space separated strings, with each string
@@ -149,8 +149,7 @@ for service in $SERVICE_STATUS ; do
 done
 """
 
-        _svcprop_template = \
-"""#!/usr/bin/ksh93
+    _svcprop_template = """#!/usr/bin/ksh93
 #
 # This script produces false svcprop(1) output, using
 # a list of space separated strings, with each string
@@ -206,12 +205,11 @@ case $3 in
 esac
 """
 
-        # A very minimal httpd.conf, which contains an Include directive
-        # that we will use to reference our pkg5 depot-config.conf file. We leave
-        # an Alias pointing to /server-status to make this server distinctive
-        # for this test case.
-        _default_httpd_conf = \
-"""ServerRoot "/usr/apache2/2.2"
+    # A very minimal httpd.conf, which contains an Include directive
+    # that we will use to reference our pkg5 depot-config.conf file. We leave
+    # an Alias pointing to /server-status to make this server distinctive
+    # for this test case.
+    _default_httpd_conf = """ServerRoot "/usr/apache2/2.2"
 PidFile "{runtime_dir}/default_httpd.pid"
 Listen {port}
 <IfDefine 64bit>
@@ -252,999 +250,1184 @@ SSLRandomSeed connect builtin
 </Location>
 """
 
-        def setUp(self):
-                self.sc = None
-                pkg5unittest.ApacheDepotTestCase.setUp(self, ["test1",
-                    "test2", "test3"])
-                self.rdir1 = self.dcs[1].get_repodir()
-                self.rdir2 = self.dcs[2].get_repodir()
-                self.rdir3 = self.dcs[3].get_repodir()
+    def setUp(self):
+        self.sc = None
+        pkg5unittest.ApacheDepotTestCase.setUp(
+            self, ["test1", "test2", "test3"]
+        )
+        self.rdir1 = self.dcs[1].get_repodir()
+        self.rdir2 = self.dcs[2].get_repodir()
+        self.rdir3 = self.dcs[3].get_repodir()
 
-                self.index_dir = os.path.join(self.test_root,
-                    "depot_writable_root")
-                self.default_depot_runtime = os.path.join(self.test_root,
-                    "depot_runtime")
-                self.default_depot_conf = os.path.join(
-                    self.default_depot_runtime, "depot_httpd.conf")
-                self.depot_conf_fragment = os.path.join(
-                    self.default_depot_runtime, "depot.conf")
+        self.index_dir = os.path.join(self.test_root, "depot_writable_root")
+        self.default_depot_runtime = os.path.join(
+            self.test_root, "depot_runtime"
+        )
+        self.default_depot_conf = os.path.join(
+            self.default_depot_runtime, "depot_httpd.conf"
+        )
+        self.depot_conf_fragment = os.path.join(
+            self.default_depot_runtime, "depot.conf"
+        )
 
-                self.depot_port = self.next_free_port
-                self.next_free_port += 1
-                self.make_misc_files(self.misc_files)
-                self._set_smf_state()
+        self.depot_port = self.next_free_port
+        self.next_free_port += 1
+        self.make_misc_files(self.misc_files)
+        self._set_smf_state()
 
-        def _set_smf_state(self, svcs_conf=default_svcs_conf,
-            svcprop_conf=default_svcprop_conf):
-                """Create wrapper scripts for svcprop and svcs based on the
-                arrays of arrays passed in as arguments. By default, the
-                following responses are configured using the class variables
-                svcs_conf and svcprop_conf:
+    def _set_smf_state(
+        self, svcs_conf=default_svcs_conf, svcprop_conf=default_svcprop_conf
+    ):
+        """Create wrapper scripts for svcprop and svcs based on the
+        arrays of arrays passed in as arguments. By default, the
+        following responses are configured using the class variables
+        svcs_conf and svcprop_conf:
 
-                pkg/server:default and pkg/server:usr can be served by the
-                depot-config as they are marked readonly=true, standalone=false.
+        pkg/server:default and pkg/server:usr can be served by the
+        depot-config as they are marked readonly=true, standalone=false.
 
-                pkg/server:off is ineligible, because it is reported as being
-                offline for these tests.
-                pkg/server:writable and pkg/server:solitary are both not
-                eligible to be served by the depot, the former, because it
-                is not marked as readonly, the latter because it is marked
-                as standalone.
-                """
+        pkg/server:off is ineligible, because it is reported as being
+        offline for these tests.
+        pkg/server:writable and pkg/server:solitary are both not
+        eligible to be served by the depot, the former, because it
+        is not marked as readonly, the latter because it is marked
+        as standalone.
+        """
 
-                # we don't want to modify our arguments
-                _svcs_conf = copy.deepcopy(svcs_conf)
-                _svcprop_conf = copy.deepcopy(svcprop_conf)
+        # we don't want to modify our arguments
+        _svcs_conf = copy.deepcopy(svcs_conf)
+        _svcprop_conf = copy.deepcopy(svcprop_conf)
 
-                # ensure the arrays are the same length.
-                self.assertTrue(len(_svcs_conf) == len(_svcprop_conf))
+        # ensure the arrays are the same length.
+        self.assertTrue(len(_svcs_conf) == len(_svcprop_conf))
 
-                for index, conf in enumerate(_svcs_conf):
-                        fmri = conf[0]
-                        state = conf[1]
-                        _svcprop_conf[index].insert(0, fmri)
-                        _svcprop_conf[index].insert(1, state)
+        for index, conf in enumerate(_svcs_conf):
+            fmri = conf[0]
+            state = conf[1]
+            _svcprop_conf[index].insert(0, fmri)
+            _svcprop_conf[index].insert(1, state)
 
-                rdirs = {"rdir1": self.rdir1, "rdir2": self.rdir2,
-                    "rdir3": self.rdir3, "index_dir": self.index_dir}
+        rdirs = {
+            "rdir1": self.rdir1,
+            "rdir2": self.rdir2,
+            "rdir3": self.rdir3,
+            "index_dir": self.index_dir,
+        }
 
-                # construct two strings we can use as parameters to our
-                # __svc*_template values
-                _svcs_conf = " ".join(["%".join([value for value in item])
-                    for item in _svcs_conf])
-                _svcprop_conf = " ".join(["%".join(
-                    [value.format(**rdirs) for value in item])
-                    for item in _svcprop_conf])
+        # construct two strings we can use as parameters to our
+        # __svc*_template values
+        _svcs_conf = " ".join(
+            ["%".join([value for value in item]) for item in _svcs_conf]
+        )
+        _svcprop_conf = " ".join(
+            [
+                "%".join([value.format(**rdirs) for value in item])
+                for item in _svcprop_conf
+            ]
+        )
 
-                self.smf_cmds = {
-                    "usr/bin/svcs": self._svcs_template.format(_svcs_conf),
-                    "usr/bin/svcprop": self._svcprop_template.format(_svcprop_conf)
-                }
-                self.make_misc_files(self.smf_cmds, "smf_cmds", mode=0o755)
+        self.smf_cmds = {
+            "usr/bin/svcs": self._svcs_template.format(_svcs_conf),
+            "usr/bin/svcprop": self._svcprop_template.format(_svcprop_conf),
+        }
+        self.make_misc_files(self.smf_cmds, "smf_cmds", mode=0o755)
 
-        def start_depot(self, build_indexes=True):
-                hc = pkg5unittest.HttpDepotController(
-                    self.default_depot_conf, self.depot_port,
-                    self.default_depot_runtime, testcase=self)
-                self.register_apache_controller("depot", hc)
-                self.ac.start()
-                if build_indexes:
-                        # we won't return until indexes are built
-                        u = urlopen(
-                            "{0}/depot/depot-wait-refresh".format(hc.url)).close()
+    def start_depot(self, build_indexes=True):
+        hc = pkg5unittest.HttpDepotController(
+            self.default_depot_conf,
+            self.depot_port,
+            self.default_depot_runtime,
+            testcase=self,
+        )
+        self.register_apache_controller("depot", hc)
+        self.ac.start()
+        if build_indexes:
+            # we won't return until indexes are built
+            u = urlopen("{0}/depot/depot-wait-refresh".format(hc.url)).close()
 
 
 class TestHttpDepot(_Apache, pkg5unittest.ApacheDepotTestCase):
-        """Tests that exercise the pkg.depot-config CLI as well as checking the
-        functionality of the depot-config itself for configuring http service.
-        This test class will fail if not run as root, since many of the tests
-        use 'pkg.depot-config -a' which will attempt to chown a directory to
-        pkg5srv:pkg5srv.
+    """Tests that exercise the pkg.depot-config CLI as well as checking the
+    functionality of the depot-config itself for configuring http service.
+    This test class will fail if not run as root, since many of the tests
+    use 'pkg.depot-config -a' which will attempt to chown a directory to
+    pkg5srv:pkg5srv.
 
-        The default_svcs_conf having an instance name of 'usr' is not a
-        coincidence: we use it there so that we catch RewriteRules that
-        mistakenly try to serve content from the root filesystem ('/') rather
-        than from beneath our DocumentRoot (assuming that test systems always
-        have a /usr directory)
-        """
+    The default_svcs_conf having an instance name of 'usr' is not a
+    coincidence: we use it there so that we catch RewriteRules that
+    mistakenly try to serve content from the root filesystem ('/') rather
+    than from beneath our DocumentRoot (assuming that test systems always
+    have a /usr directory)
+    """
 
-        def test_0_htdepot(self):
-                """A basic test to see that we can start the depot,
-                as part of this, by starting the depot, ApacheController will
-                ping the "/ URI of the server."""
+    def test_0_htdepot(self):
+        """A basic test to see that we can start the depot,
+        as part of this, by starting the depot, ApacheController will
+        ping the "/ URI of the server."""
 
-                # ensure we fail when not supplying the required argument
-                self.depotconfig("", exit=2, fill_missing_args=False)
-                self.depotconfig("")
-                self.start_depot()
+        # ensure we fail when not supplying the required argument
+        self.depotconfig("", exit=2, fill_missing_args=False)
+        self.depotconfig("")
+        self.start_depot()
 
-                # the httpd.conf should reference our repositories
-                self.file_contains(self.ac.conf, [self.rdir1, self.rdir2,
-                    self.rdir3, self.index_dir])
-                # it should not reference the repositories that we have
-                # marked as offline, writable or standalone
-                self.file_doesnt_contain(self.ac.conf, ["/pkg5/there/aint",
-                    "/pkg5/nobody/here", "/pkg5/but/us/chickens"])
+        # the httpd.conf should reference our repositories
+        self.file_contains(
+            self.ac.conf, [self.rdir1, self.rdir2, self.rdir3, self.index_dir]
+        )
+        # it should not reference the repositories that we have
+        # marked as offline, writable or standalone
+        self.file_doesnt_contain(
+            self.ac.conf,
+            ["/pkg5/there/aint", "/pkg5/nobody/here", "/pkg5/but/us/chickens"],
+        )
 
-        def test_1_htdepot_usage(self):
-                """Tests that we show a usage message."""
+    def test_1_htdepot_usage(self):
+        """Tests that we show a usage message."""
 
-                ret, output = self.depotconfig("", fill_missing_args=False,
-                    out=True, exit=2)
-                self.assertTrue("Usage:" in output,
-                    "No usage string printed: {0}".format(output))
-                ret, output = self.depotconfig("--help", out=True, exit=2)
-                self.assertTrue("Usage:" in output,
-                    "No usage string printed: {0}".format(output))
+        ret, output = self.depotconfig(
+            "", fill_missing_args=False, out=True, exit=2
+        )
+        self.assertTrue(
+            "Usage:" in output, "No usage string printed: {0}".format(output)
+        )
+        ret, output = self.depotconfig("--help", out=True, exit=2)
+        self.assertTrue(
+            "Usage:" in output, "No usage string printed: {0}".format(output)
+        )
 
-        def test_2_htinvalid_root(self):
-                """We return an error given an invalid image root"""
+    def test_2_htinvalid_root(self):
+        """We return an error given an invalid image root"""
 
-                # check for incorrectly-formed -d options
-                self.depotconfig("-d usr -F -r /dev/null", exit=2)
+        # check for incorrectly-formed -d options
+        self.depotconfig("-d usr -F -r /dev/null", exit=2)
 
-                # ensure we pick up invalid -d directories
-                for invalid_root in ["usr=/dev/null",
-                    "foo=/etc/passwd", "alt=/proc"]:
-                        ret, output, err = self.depotconfig(
-                            "-d {0} -F".format(invalid_root), out=True, stderr=True,
-                            exit=1)
-                        expected = invalid_root.split("=")[1]
-                        self.assertTrue(expected in err,
-                            "error message did not contain {0}: {1}".format(
-                            expected, err))
+        # ensure we pick up invalid -d directories
+        for invalid_root in ["usr=/dev/null", "foo=/etc/passwd", "alt=/proc"]:
+            ret, output, err = self.depotconfig(
+                "-d {0} -F".format(invalid_root), out=True, stderr=True, exit=1
+            )
+            expected = invalid_root.split("=")[1]
+            self.assertTrue(
+                expected in err,
+                "error message did not contain {0}: {1}".format(expected, err),
+            )
 
-                # ensure we also catch invalid SMF inst_roots
-                svcs_conf = [["svc:/application/pkg/server:default", "online" ]]
-                svcprop_conf = [["/tmp", "true", "false"]]
-                self._set_smf_state(svcs_conf, svcprop_conf)
-                ret, output, err = self.depotconfig("", out=True, stderr=True,
-                    exit=1)
-                self.assertTrue("/tmp" in err, "error message did not contain "
-                    "/tmp")
+        # ensure we also catch invalid SMF inst_roots
+        svcs_conf = [["svc:/application/pkg/server:default", "online"]]
+        svcprop_conf = [["/tmp", "true", "false"]]
+        self._set_smf_state(svcs_conf, svcprop_conf)
+        ret, output, err = self.depotconfig("", out=True, stderr=True, exit=1)
+        self.assertTrue("/tmp" in err, "error message did not contain " "/tmp")
 
-                # ensure we pick up invalid writable_root directories
-                ret, output, err = self.depotconfig("-d blah={0}=/dev/null".format(
-                    self.rdir1), out=True, stderr=True, exit=1)
+        # ensure we pick up invalid writable_root directories
+        ret, output, err = self.depotconfig(
+            "-d blah={0}=/dev/null".format(self.rdir1),
+            out=True,
+            stderr=True,
+            exit=1,
+        )
 
-                # but check that we allow valid writeable_roots
-                ret, output, err = self.depotconfig("-d blah={0}={1}".format(
-                    self.rdir1, self.index_dir), out=True, stderr=True)
-                self.file_contains(self.default_depot_conf,
-                    "PKG5_WRITABLE_ROOT_blah {0}".format(self.index_dir))
+        # but check that we allow valid writeable_roots
+        ret, output, err = self.depotconfig(
+            "-d blah={0}={1}".format(self.rdir1, self.index_dir),
+            out=True,
+            stderr=True,
+        )
+        self.file_contains(
+            self.default_depot_conf,
+            "PKG5_WRITABLE_ROOT_blah {0}".format(self.index_dir),
+        )
 
-        def test_3_invalid_htcache_dir(self):
-                """We return an error given an invalid cache_dir"""
+    def test_3_invalid_htcache_dir(self):
+        """We return an error given an invalid cache_dir"""
 
-                for invalid_cache in ["/dev/null", "/etc/passwd"]:
-                        ret, output, err = self.depotconfig("-c {0}".format(
-                            invalid_cache), out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_cache in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_cache, err))
+        for invalid_cache in ["/dev/null", "/etc/passwd"]:
+            ret, output, err = self.depotconfig(
+                "-c {0}".format(invalid_cache), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_cache in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_cache, err),
+            )
 
-        def test_4_invalid_hthostname(self):
-                """We return an error given an invalid hostname"""
+    def test_4_invalid_hthostname(self):
+        """We return an error given an invalid hostname"""
 
-                for invalid_host in ["1.2.3.4.5.6", "pkgsysrepotestname", "."]:
-                        ret, output, err = self.depotconfig("-h {0}".format(
-                            invalid_host), out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_host in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_host, err))
+        for invalid_host in ["1.2.3.4.5.6", "pkgsysrepotestname", "."]:
+            ret, output, err = self.depotconfig(
+                "-h {0}".format(invalid_host), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_host in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_host, err),
+            )
 
-        def test_5_invalid_htlogs_dir(self):
-                """We return an error given an invalid logs_dir"""
+    def test_5_invalid_htlogs_dir(self):
+        """We return an error given an invalid logs_dir"""
 
-                for invalid_log in ["/dev/null", "/etc/passwd"]:
-                        ret, output, err = self.depotconfig("-l {0}".format(invalid_log),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_log in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_log, err))
+        for invalid_log in ["/dev/null", "/etc/passwd"]:
+            ret, output, err = self.depotconfig(
+                "-l {0}".format(invalid_log), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_log in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_log, err),
+            )
 
-                for invalid_log in ["/proc"]:
-                        port = self.next_free_port
-                        self.depotconfig("-l {0} -p {1}".format(invalid_log, port),
-                            exit=0)
-                        self.assertRaises(pkg5unittest.ApacheStateException,
-                            self.start_depot)
+        for invalid_log in ["/proc"]:
+            port = self.next_free_port
+            self.depotconfig("-l {0} -p {1}".format(invalid_log, port), exit=0)
+            self.assertRaises(
+                pkg5unittest.ApacheStateException, self.start_depot
+            )
 
-        def test_6_invalid_htport(self):
-                """We return an error given an invalid port"""
+    def test_6_invalid_htport(self):
+        """We return an error given an invalid port"""
 
-                for invalid_port in [999999, "bobcat", "-1234"]:
-                        ret, output, err = self.depotconfig("-p {0}".format(invalid_port),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue(str(invalid_port) in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_port, err))
+        for invalid_port in [999999, "bobcat", "-1234"]:
+            ret, output, err = self.depotconfig(
+                "-p {0}".format(invalid_port), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                str(invalid_port) in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_port, err),
+            )
 
-        def test_7_invalid_htruntime_dir(self):
-                """We return an error given an invalid runtime_dir"""
+    def test_7_invalid_htruntime_dir(self):
+        """We return an error given an invalid runtime_dir"""
 
-                for invalid_runtime in ["/dev/null", "/etc/passwd", "/proc"]:
-                        ret, output, err = self.depotconfig("-r {0}".format(
-                            invalid_runtime), out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_runtime in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_runtime, err))
+        for invalid_runtime in ["/dev/null", "/etc/passwd", "/proc"]:
+            ret, output, err = self.depotconfig(
+                "-r {0}".format(invalid_runtime), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_runtime in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_runtime, err),
+            )
 
-        def test_8_invalid_htcache_size(self):
-                """We return an error given an invalid cache_size"""
+    def test_8_invalid_htcache_size(self):
+        """We return an error given an invalid cache_size"""
 
-                for invalid_csize in ["cats", "-1234"]:
-                        ret, output, err = self.depotconfig(
-                            "-s {0}".format(invalid_csize), out=True, stderr=True,
-                            exit=1)
-                        self.assertTrue(str(invalid_csize) in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_csize, err))
+        for invalid_csize in ["cats", "-1234"]:
+            ret, output, err = self.depotconfig(
+                "-s {0}".format(invalid_csize), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                str(invalid_csize) in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_csize, err),
+            )
 
-        def test_9_invalid_httemplates_dir(self):
-                """We return an error given an invalid templates_dir"""
+    def test_9_invalid_httemplates_dir(self):
+        """We return an error given an invalid templates_dir"""
 
-                for invalid_tmp in ["/dev/null", "/etc/passwd", "/proc"]:
-                        ret, output, err = self.depotconfig("-T {0}".format(invalid_tmp),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_tmp in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_tmp, err))
+        for invalid_tmp in ["/dev/null", "/etc/passwd", "/proc"]:
+            ret, output, err = self.depotconfig(
+                "-T {0}".format(invalid_tmp), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_tmp in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_tmp, err),
+            )
 
-        def test_10_httype(self):
-                """We return an error given an invalid type option."""
+    def test_10_httype(self):
+        """We return an error given an invalid type option."""
 
-                invalid_type = "weblogic"
-                ret, output, err = self.depotconfig("-t {0}".format(invalid_type),
-                    out=True, stderr=True, exit=2)
-                self.assertTrue(invalid_type in err, "error message "
-                    "did not contain {0}: {1}".format(invalid_type, err))
-                # ensure we work with the supported type
-                self.depotconfig("-t apache2")
+        invalid_type = "weblogic"
+        ret, output, err = self.depotconfig(
+            "-t {0}".format(invalid_type), out=True, stderr=True, exit=2
+        )
+        self.assertTrue(
+            invalid_type in err,
+            "error message "
+            "did not contain {0}: {1}".format(invalid_type, err),
+        )
+        # ensure we work with the supported type
+        self.depotconfig("-t apache2")
 
-        def test_11_htbui(self):
-                """We can perform a series of HTTP requests against the BUI."""
+    def test_11_htbui(self):
+        """We can perform a series of HTTP requests against the BUI."""
 
-                fmris = self.pkgsend_bulk(self.dcs[1].get_repo_url(),
-                    self.new_pkg)
-                r2_fmris = self.pkgsend_bulk(self.dcs[2].get_repo_url(),
-                    self.sample_pkg)
-                self.depotconfig("")
-                self.start_depot()
+        fmris = self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.new_pkg)
+        r2_fmris = self.pkgsend_bulk(
+            self.dcs[2].get_repo_url(), self.sample_pkg
+        )
+        self.depotconfig("")
+        self.start_depot()
 
-                fmri = pkg.fmri.PkgFmri(fmris[0])
-                esc_full_fmri = fmri.get_url_path()
+        fmri = pkg.fmri.PkgFmri(fmris[0])
+        esc_full_fmri = fmri.get_url_path()
 
-                conf = {"prefix": "default",
-                    "esc_full_fmri": esc_full_fmri}
+        conf = {"prefix": "default", "esc_full_fmri": esc_full_fmri}
 
-                # a series of BUI paths we should be able to access
-                paths = [
-                        "/",
-                        "/default/test1",
-                        "/default/en",
-                        "/default/en/index.shtml",
-                        "/default/en/catalog.shtml",
-                        "/default/p5i/0/new.p5i",
-                        "/default/info/0/{esc_full_fmri}",
-                        "/default/test1/info/0/{esc_full_fmri}",
-                        "/default/manifest/0/{esc_full_fmri}",
-                        "/default/en/search.shtml",
-                        "/usr/test2/en/catalog.shtml",
-                        "/depot/default/en/search.shtml?token=pkg&action=Search"
-                ]
+        # a series of BUI paths we should be able to access
+        paths = [
+            "/",
+            "/default/test1",
+            "/default/en",
+            "/default/en/index.shtml",
+            "/default/en/catalog.shtml",
+            "/default/p5i/0/new.p5i",
+            "/default/info/0/{esc_full_fmri}",
+            "/default/test1/info/0/{esc_full_fmri}",
+            "/default/manifest/0/{esc_full_fmri}",
+            "/default/en/search.shtml",
+            "/usr/test2/en/catalog.shtml",
+            "/depot/default/en/search.shtml?token=pkg&action=Search",
+        ]
 
-                def get_url(url_path):
-                        try:
-                                url_obj = urlopen(url_path, timeout=10)
-                                self.assertTrue(url_obj.code == 200,
-                                    "Failed to open {0}: {1}".format(url_path,
-                                    url_obj.code))
-                                url_obj.close()
-                        except HTTPError as e:
-                                self.debug("Failed to open {0}: {1}".format(
-                                    url_path, e))
-                                raise
-
-                for p in paths:
-                        get_url("{0}{1}".format(self.ac.url, p.format(**conf)))
-
-                self.ac.stop()
-
-                # test that pkg.depot-config detects missing repos
-                broken_rdir = self.rdir2 + "foo"
-                os.rename(self.rdir2, broken_rdir)
-                self.depotconfig("", exit=1)
-
-                # test that when we break one of the repositories we're
-                # serving, the remaining repositories are still accessible
-                # from the bui. We need to fix the repo dir before rebuilding
-                # the configuration, then break it once the depot has started.
-                os.rename(broken_rdir, self.rdir2)
-                self.depotconfig("")
-                os.rename(self.rdir2, broken_rdir)
-                self.start_depot(build_indexes=False)
-
-                # check the first request to the BUI works as expected
-                get_url(self.ac.url)
-
-                # and check that we get a 404 for the missing repo
-                bad_url = "{0}/usr/test2/en/catalog.shtml".format(self.ac.url)
-                raised_404 = False
-                try:
-                        url_obj = urlopen(bad_url, timeout=10)
-                        url_obj.close()
-                except HTTPError as e:
-                        if e.code == 404:
-                                raised_404 = True
-                self.assertTrue(raised_404, "Didn't get a 404 opening {0}".format(
-                    bad_url))
-
-                # check that we can still reach other valid paths
-                paths = [
-                        "/",
-                        "/default/test1",
-                        "/default/en",
-                        "/default/en/index.shtml",
-                        "/default/en/catalog.shtml",
-                        "/default/p5i/0/new.p5i",
-                        "/default/info/0/{esc_full_fmri}",
-                        "/default/test1/info/0/{esc_full_fmri}",
-                        "/default/manifest/0/{esc_full_fmri}",
-                        "/default/en/search.shtml",
-                ]
-                for p in paths:
-                        self.debug(p)
-                        get_url("{0}{1}".format(self.ac.url, p.format(**conf)))
-                os.rename(broken_rdir, self.rdir2)
-
-        def test_12_htpkgclient(self):
-                """A depot-config can act as a repository server for pkg(1)
-                clients, with all functionality supported."""
-
-                # publish some sample packages to our repositories
-                for dc_num in self.dcs:
-                        rurl = self.dcs[dc_num].get_repo_url()
-                        self.pkgsend_bulk(rurl, self.sample_pkg)
-                        self.pkgsend_bulk(rurl, self.sample_pkg_11)
-                self.pkgsend_bulk(self.dcs[2].get_repo_url(), self.new_pkg)
-                self.pkgrepo("-s {0} refresh".format(self.dcs[2].get_repo_url()))
-
-                self.depotconfig("")
-                self.image_create()
-                self.start_depot()
-                # test that we can access the default publisher
-                self.pkg("set-publisher -p {0}/default".format(self.ac.url))
-                self.pkg("publisher")
-                self.pkg("install sample@1.0")
-                self.file_contains("usr/bin/sample", "tmp/sample")
-                self.pkg("update")
-                self.file_contains("usr/bin/sample", "tmp/updated")
-
-                # test that we can access specific publishers, this time from
-                # a different repository, served by the same depot-config.
-                self.pkg("set-publisher -p {0}/usr/test2".format(self.ac.url))
-                self.pkg("contents -r new")
-                self.pkg("set-publisher -G '*' test2")
-                ret, output = self.pkg(
-                    "search -o action.raw -s {0}/usr new".format(self.ac.url),
-                    out=True)
-                self.assertTrue("path=usr/bin/new" in output)
-
-                # publish a new package, and ensure we can install it
-                self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.another_pkg)
-                self.pkg("install another")
-                self.file_contains("usr/bin/another", "tmp/another")
-
-                # add a new publisher to an existing repository and ensure it
-                # is visible from the repository
-                self.ac.stop()
-                self.pkgrepo("-s {0} add-publisher carrots".format(self.rdir1))
-                self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.carrots_pkg)
-                self.depotconfig("")
-                self.start_depot()
-
-                self.pkg("set-publisher -g {0}/default/carrots carrots".format(
-                    self.ac.url))
-
-        def test_13_htpkgrecv(self):
-                """A depot-config can act as a repository server for pkgrecv(1)
-                clients."""
-
-                rurl = self.dcs[1].get_repo_url()
-                first = self.pkgsend_bulk(rurl, self.sample_pkg)
-                second = self.pkgsend_bulk(rurl, self.sample_pkg_11)
-                self.pkgsend_bulk(self.dcs[2].get_repo_url(), self.new_pkg)
-
-                # gather the FMRIs we published and the URL-quoted version
-                first_fmri = pkg.fmri.PkgFmri(first[0])
-                second_fmri = pkg.fmri.PkgFmri(second[0])
-                first_ver = quote(str(first_fmri.version))
-                second_ver = quote(str(second_fmri.version))
-
-                self.depotconfig("")
-                self.image_create()
-                self.start_depot()
-
-                ret, output = self.pkgrecv(command="-s {0}/default --newest".format(
-                    self.ac.url), out=True)
-                sec_fmri_nobuild = pkg.fmri.PkgFmri(second[0]).get_fmri(
-                    include_build=False)
-                self.assertTrue(sec_fmri_nobuild in output)
-                dest = os.path.join(self.test_root, "test_13_hgpkgrecv")
-                os.mkdir(dest)
-
-                # pull down raw package contents
-                self.pkgrecv(command="-s {0}/default -m all-versions --raw "
-                    "-d {1} '*'".format(self.ac.url, dest))
-
-                # Quickly sanity check the contents
-                self.assertTrue(os.listdir(dest) == ["sample"])
+        def get_url(url_path):
+            try:
+                url_obj = urlopen(url_path, timeout=10)
                 self.assertTrue(
-                    set(os.listdir(os.path.join(dest, "sample"))) ==
-                    set([first_ver, second_ver]))
+                    url_obj.code == 200,
+                    "Failed to open {0}: {1}".format(url_path, url_obj.code),
+                )
+                url_obj.close()
+            except HTTPError as e:
+                self.debug("Failed to open {0}: {1}".format(url_path, e))
+                raise
 
-                # grab one of the manifests we just downloaded, and check that
-                # the file content is present and correct.
-                mf_path = os.path.sep.join([dest, "sample", second_ver])
-                mf = pkg.manifest.Manifest()
-                mf.set_content(pathname=os.path.join(mf_path, "manifest.file"))
-                f_ac = mf.actions[0]
-                self.assertTrue(f_ac.attrs["path"] == "usr/bin/sample")
-                f_path = os.path.join(mf_path, f_ac.hash)
-                os.path.exists(f_path)
-                self.file_contains(f_path, "tmp/updated")
+        for p in paths:
+            get_url("{0}{1}".format(self.ac.url, p.format(**conf)))
 
-        def test_14_htpkgrepo(self):
-                """Test that only the 'pkgrepo refresh' command works with the
-                depot-config only when the -A flag is enabled and only on
-                the repository that has a writable root. Test that the index
-                does indeed get updated when a refresh is performed and that
-                new package contents are visible."""
+        self.ac.stop()
 
-                rurl = self.dcs[1].get_repo_url()
-                nosearch_rurl = self.dcs[2].get_repo_url()
-                writable_rurl = self.dcs[3].get_repo_url()
+        # test that pkg.depot-config detects missing repos
+        broken_rdir = self.rdir2 + "foo"
+        os.rename(self.rdir2, broken_rdir)
+        self.depotconfig("", exit=1)
 
-                self.pkgsend_bulk(rurl, self.sample_pkg)
-                # we have a search index on rurl
-                self.pkgrepo("-s {0} refresh".format(rurl))
-                self.pkgsend_bulk(writable_rurl, self.sample_pkg)
+        # test that when we break one of the repositories we're
+        # serving, the remaining repositories are still accessible
+        # from the bui. We need to fix the repo dir before rebuilding
+        # the configuration, then break it once the depot has started.
+        os.rename(broken_rdir, self.rdir2)
+        self.depotconfig("")
+        os.rename(self.rdir2, broken_rdir)
+        self.start_depot(build_indexes=False)
 
-                # we have no search index on nosearch_rurl
-                self.pkgsend_bulk(nosearch_rurl, self.sample_pkg)
+        # check the first request to the BUI works as expected
+        get_url(self.ac.url)
 
-                # allow index refreshes for repositories that support them
-                # (ie. have a writable root)
-                self.depotconfig("-A")
-                self.start_depot()
-                self.image_create()
+        # and check that we get a 404 for the missing repo
+        bad_url = "{0}/usr/test2/en/catalog.shtml".format(self.ac.url)
+        raised_404 = False
+        try:
+            url_obj = urlopen(bad_url, timeout=10)
+            url_obj.close()
+        except HTTPError as e:
+            if e.code == 404:
+                raised_404 = True
+        self.assertTrue(
+            raised_404, "Didn't get a 404 opening {0}".format(bad_url)
+        )
 
-                depot_url = "{0}/default".format(self.ac.url)
-                windex_url = "{0}/windex".format(self.ac.url)
-                nosearch_url = "{0}/usr".format(self.ac.url)
+        # check that we can still reach other valid paths
+        paths = [
+            "/",
+            "/default/test1",
+            "/default/en",
+            "/default/en/index.shtml",
+            "/default/en/catalog.shtml",
+            "/default/p5i/0/new.p5i",
+            "/default/info/0/{esc_full_fmri}",
+            "/default/test1/info/0/{esc_full_fmri}",
+            "/default/manifest/0/{esc_full_fmri}",
+            "/default/en/search.shtml",
+        ]
+        for p in paths:
+            self.debug(p)
+            get_url("{0}{1}".format(self.ac.url, p.format(**conf)))
+        os.rename(broken_rdir, self.rdir2)
 
-                # verify that list commands work
-                ret, output = self.pkgrepo("-s {0} list -F tsv".format(depot_url),
-                    out=True)
-                self.assertTrue("pkg://test1/sample@1.0" in output)
-                self.assertTrue("pkg://test1/new@1.0" not in output)
+    def test_12_htpkgclient(self):
+        """A depot-config can act as a repository server for pkg(1)
+        clients, with all functionality supported."""
 
-                # rebuild, remove and set commands should fail, the latter two
-                # with exit code 2
-                self.pkgrepo("-s {0} rebuild".format(depot_url), exit=1)
-                self.pkgrepo("-s {0} remove sample".format(depot_url), exit=2)
-                self.pkgrepo("-s {0} set -p test1 foo/bar=baz".format(depot_url),
-                    exit=2)
+        # publish some sample packages to our repositories
+        for dc_num in self.dcs:
+            rurl = self.dcs[dc_num].get_repo_url()
+            self.pkgsend_bulk(rurl, self.sample_pkg)
+            self.pkgsend_bulk(rurl, self.sample_pkg_11)
+        self.pkgsend_bulk(self.dcs[2].get_repo_url(), self.new_pkg)
+        self.pkgrepo("-s {0} refresh".format(self.dcs[2].get_repo_url()))
 
-                # verify that status works
-                self.pkgrepo("-s {0} info".format(depot_url))
-                self.assertTrue("test1 1 online" in self.reduceSpaces(self.output))
+        self.depotconfig("")
+        self.image_create()
+        self.start_depot()
+        # test that we can access the default publisher
+        self.pkg("set-publisher -p {0}/default".format(self.ac.url))
+        self.pkg("publisher")
+        self.pkg("install sample@1.0")
+        self.file_contains("usr/bin/sample", "tmp/sample")
+        self.pkg("update")
+        self.file_contains("usr/bin/sample", "tmp/updated")
 
-                # verify search works for packages in the repository
-                self.pkg("set-publisher -p {0}".format(depot_url))
-                self.pkg("search -s {0} msgsh".format("{0}".format(depot_url)),
-                    exit=1)
-                self.pkg("search -s {0} /usr/bin/sample".format(depot_url))
+        # test that we can access specific publishers, this time from
+        # a different repository, served by the same depot-config.
+        self.pkg("set-publisher -p {0}/usr/test2".format(self.ac.url))
+        self.pkg("contents -r new")
+        self.pkg("set-publisher -G '*' test2")
+        ret, output = self.pkg(
+            "search -o action.raw -s {0}/usr new".format(self.ac.url), out=True
+        )
+        self.assertTrue("path=usr/bin/new" in output)
 
-                # Can't refresh this repo since it doesn't have a writable root
-                self.pkgrepo("-s {0} refresh".format(depot_url), exit=1)
+        # publish a new package, and ensure we can install it
+        self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.another_pkg)
+        self.pkg("install another")
+        self.file_contains("usr/bin/another", "tmp/another")
 
-                # verify that search fails for repositories that don't have
-                # a pre-existing search index in the repository
-                self.pkg("search -s {0} /usr/bin/sample".format(nosearch_url), exit=1)
+        # add a new publisher to an existing repository and ensure it
+        # is visible from the repository
+        self.ac.stop()
+        self.pkgrepo("-s {0} add-publisher carrots".format(self.rdir1))
+        self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.carrots_pkg)
+        self.depotconfig("")
+        self.start_depot()
 
-                # publish a new package, and verify it doesn't appear in the
-                # search results for the repo with the writable_root
-                self.pkgsend_bulk(writable_rurl, self.new_pkg)
-                self.pkg("search -s {0} /usr/bin/new".format(windex_url), exit=1)
+        self.pkg(
+            "set-publisher -g {0}/default/carrots carrots".format(self.ac.url)
+        )
 
-                # now refresh the index
-                self.pkgrepo("-s {0} refresh".format(windex_url))
+    def test_13_htpkgrecv(self):
+        """A depot-config can act as a repository server for pkgrecv(1)
+        clients."""
 
-                # there isn't a synchronous option to pkgrepo, so wait a bit
-                # then make sure we do see this new package.
-                time.sleep(3)
+        rurl = self.dcs[1].get_repo_url()
+        first = self.pkgsend_bulk(rurl, self.sample_pkg)
+        second = self.pkgsend_bulk(rurl, self.sample_pkg_11)
+        self.pkgsend_bulk(self.dcs[2].get_repo_url(), self.new_pkg)
 
-                # we should now get search results for that new package
-                ret, output = self.pkg("search -s {0} /usr/bin/new".format(windex_url),
-                    out=True)
-                self.assertTrue("usr/bin/new" in output)
-                ret, output = self.pkgrepo("-s {0} list -F tsv".format(windex_url),
-                    out=True)
-                self.assertTrue("pkg://test3/sample@1.0" in output)
-                self.assertTrue("pkg://test3/new@1.0" in output)
+        # gather the FMRIs we published and the URL-quoted version
+        first_fmri = pkg.fmri.PkgFmri(first[0])
+        second_fmri = pkg.fmri.PkgFmri(second[0])
+        first_ver = quote(str(first_fmri.version))
+        second_ver = quote(str(second_fmri.version))
 
-                # ensure that refresh --no-catalog works, but refresh --no-index
-                # does not.
-                self.pkgrepo("-s {0} refresh --no-catalog".format(windex_url))
-                self.pkgrepo("-s {0} refresh --no-index".format(windex_url), exit=1)
+        self.depotconfig("")
+        self.image_create()
+        self.start_depot()
 
-                # check that when we start the depot without -A, we cannot
-                # issue refresh commands.
-                self.depotconfig("")
-                self.start_depot()
-                self.pkgrepo("-s {0} refresh".format(windex_url), exit=1)
+        ret, output = self.pkgrecv(
+            command="-s {0}/default --newest".format(self.ac.url), out=True
+        )
+        sec_fmri_nobuild = pkg.fmri.PkgFmri(second[0]).get_fmri(
+            include_build=False
+        )
+        self.assertTrue(sec_fmri_nobuild in output)
+        dest = os.path.join(self.test_root, "test_13_hgpkgrecv")
+        os.mkdir(dest)
 
-        def test_15_htheaders(self):
-                """Test that the correct Content-Type and Cache-control headers
-                are sent from the depot for the responses that we care about."""
+        # pull down raw package contents
+        self.pkgrecv(
+            command="-s {0}/default -m all-versions --raw "
+            "-d {1} '*'".format(self.ac.url, dest)
+        )
 
-                fmris = self.pkgsend_bulk(self.dcs[1].get_repo_url(),
-                    self.sample_pkg)
-                self.pkgrepo("-s {0} refresh".format(self.dcs[1].get_repo_url()))
-                self.depotconfig("")
-                self.start_depot()
+        # Quickly sanity check the contents
+        self.assertTrue(os.listdir(dest) == ["sample"])
+        self.assertTrue(
+            set(os.listdir(os.path.join(dest, "sample")))
+            == set([first_ver, second_ver])
+        )
 
-                # Create an image so we have something to search with.
-                # This technically isn't necessary anymore, but the test suite
-                # runs with some debug flags to make it (intentionally)
-                # difficult to mess with the root image of the test system
-                # (even though calling 'pkg search -s' would never actually
-                # modify it) Creating an image is just the easier thing to do
-                # here.
-                self.image_create()
-                ret, output = self.pkg("search -s {0}/default -H -o action.hash "
-                     "-r /usr/bin/sample".format(self.ac.url), out=True)
-                file_hash = output.strip()
+        # grab one of the manifests we just downloaded, and check that
+        # the file content is present and correct.
+        mf_path = os.path.sep.join([dest, "sample", second_ver])
+        mf = pkg.manifest.Manifest()
+        mf.set_content(pathname=os.path.join(mf_path, "manifest.file"))
+        f_ac = mf.actions[0]
+        self.assertTrue(f_ac.attrs["path"] == "usr/bin/sample")
+        f_path = os.path.join(mf_path, f_ac.hash)
+        os.path.exists(f_path)
+        self.file_contains(f_path, "tmp/updated")
 
-                fmri = pkg.fmri.PkgFmri(fmris[0])
-                esc_short_fmri = fmri.get_fmri(anarchy=True).replace(
-                    "pkg:/", "")
-                esc_short_fmri = esc_short_fmri.replace(",", "%2C")
-                esc_short_fmri = esc_short_fmri.replace(":", "%3A")
+    def test_14_htpkgrepo(self):
+        """Test that only the 'pkgrepo refresh' command works with the
+        depot-config only when the -A flag is enabled and only on
+        the repository that has a writable root. Test that the index
+        does indeed get updated when a refresh is performed and that
+        new package contents are visible."""
 
-                # a dictionary of paths we should be able to access, along with
-                # expected header (name,value) pairs for each
-                paths = {
-                    "/default/p5i/0/sample.p5i":
-                    [("Content-Type", "application/vnd.pkg5.info")],
-                    "/default/catalog/1/catalog.attrs":
-                    [("Cache-Control", "no-cache")],
-                    "/default/manifest/0/{0}".format(esc_short_fmri):
-                    [("Cache-Control",
-                    "must-revalidate, no-transform, max-age=31536000"),
-                    ("Content-Type", "text/plain;charset=utf-8")],
-                    "/default/search/1/False_2_None_None_%3a%3a%3asample":
-                    [("Cache-Control", "no-cache"),
-                    ("Content-Type", "text/plain;charset=utf-8")],
-                    "/default/file/1/{0}".format(file_hash):
-                    [("Cache-Control",
-                    "must-revalidate, no-transform, max-age=31536000"),
-                    ("Content-Type", "application/data")]
-                }
+        rurl = self.dcs[1].get_repo_url()
+        nosearch_rurl = self.dcs[2].get_repo_url()
+        writable_rurl = self.dcs[3].get_repo_url()
 
-                def header_contains(url, header, value):
-                        """Check that HTTP 'header' from 'url' contains an
-                        expected value 'value'."""
-                        ret = False
-                        try:
-                                u = urlopen(url)
-                                if six.PY2:
-                                        h = u.headers.get(header, "")
-                                else:
-                                        # HTTPMessage inherits from
-                                        # email.Message in Python 3 so that it
-                                        # has a different method
-                                        h = u.headers.get_all(header, "")
-                                if value in h:
-                                        return True
-                        except Exception as e:
-                                self.assertTrue(False, "Error opening {0}: {1}".format(
-                                    url, e))
-                        return ret
+        self.pkgsend_bulk(rurl, self.sample_pkg)
+        # we have a search index on rurl
+        self.pkgrepo("-s {0} refresh".format(rurl))
+        self.pkgsend_bulk(writable_rurl, self.sample_pkg)
 
-                for path in paths:
-                        for headers in paths[path]:
-                                name, value = headers
-                                url = "{0}{1}".format(self.ac.url, path)
-                                self.assertTrue(header_contains(url, name, value),
-                                    "{0} did not contain the header {1}={2}".format(
-                                    url, name, value))
+        # we have no search index on nosearch_rurl
+        self.pkgsend_bulk(nosearch_rurl, self.sample_pkg)
 
-        def test_16_htfragment(self):
-                """Test that the fragment httpd.conf generated by pkg.depot-config
-                can be used in a standard Apache configuration, but that
-                pkg(1) admin and search operations fail."""
+        # allow index refreshes for repositories that support them
+        # (ie. have a writable root)
+        self.depotconfig("-A")
+        self.start_depot()
+        self.image_create()
 
-                self.pkgsend_bulk(self.dcs[1].get_repo_url(),
-                    self.sample_pkg)
-                self.pkgrepo("-s {0} add-publisher carrots".format(
-                    self.dcs[1].get_repo_url()))
-                self.pkgsend_bulk(self.dcs[1].get_repo_url(),
-                    self.carrots_pkg)
-                self.pkgsend_bulk(self.dcs[2].get_repo_url(),
-                    self.new_pkg)
+        depot_url = "{0}/default".format(self.ac.url)
+        windex_url = "{0}/windex".format(self.ac.url)
+        nosearch_url = "{0}/usr".format(self.ac.url)
 
-                # We shouldn't be able to supply a writable root when running
-                # in fragment mode
-                self.depotconfig("-l {0} -F -d usr={1} -d spaghetti={2}={3} "
-                    "-P testpkg5".format(
-                    self.default_depot_runtime, self.rdir1, self.rdir2,
-                    self.index_dir), exit=2)
-                self.depotconfig("-l {0} -F -d usr={1} -d spaghetti={2} "
-                    "-P testpkg5".format(
-                    self.default_depot_runtime, self.rdir1, self.rdir2))
+        # verify that list commands work
+        ret, output = self.pkgrepo(
+            "-s {0} list -F tsv".format(depot_url), out=True
+        )
+        self.assertTrue("pkg://test1/sample@1.0" in output)
+        self.assertTrue("pkg://test1/new@1.0" not in output)
 
-                default_httpd_conf_path = os.path.join(self.test_root,
-                    "default_httpd.conf")
-                httpd_conf = open(default_httpd_conf_path, "w")
-                httpd_conf.write(self._default_httpd_conf.format(
-                    port=self.depot_port,
-                    depot_conf=self.depot_conf_fragment,
-                    runtime_dir=self.default_depot_runtime))
-                httpd_conf.close()
+        # rebuild, remove and set commands should fail, the latter two
+        # with exit code 2
+        self.pkgrepo("-s {0} rebuild".format(depot_url), exit=1)
+        self.pkgrepo("-s {0} remove sample".format(depot_url), exit=2)
+        self.pkgrepo(
+            "-s {0} set -p test1 foo/bar=baz".format(depot_url), exit=2
+        )
 
-                # Start an Apache instance
-                ac = pkg5unittest.ApacheController(default_httpd_conf_path,
-                    self.depot_port, self.default_depot_runtime, testcase=self)
-                self.register_apache_controller("depot", ac)
-                ac.start()
+        # verify that status works
+        self.pkgrepo("-s {0} info".format(depot_url))
+        self.assertTrue("test1 1 online" in self.reduceSpaces(self.output))
 
-                # verify the instance is definitely the one using our custom
-                # httpd.conf
-                u = urlopen("{0}/pkg5test-server-status".format(self.ac.url))
-                self.assertTrue(u.code == http_client.OK,
-                    "Error getting pkg5-server-status")
+        # verify search works for packages in the repository
+        self.pkg("set-publisher -p {0}".format(depot_url))
+        self.pkg("search -s {0} msgsh".format("{0}".format(depot_url)), exit=1)
+        self.pkg("search -s {0} /usr/bin/sample".format(depot_url))
 
-                self.image_create()
-                # add publishers for the two repositories being served by this
-                # Apache instance
-                self.pkg("set-publisher -p {0}/testpkg5/usr".format(self.ac.url))
-                self.pkg("set-publisher -p {0}/testpkg5/spaghetti".format(self.ac.url))
-                # install packages from the two different publishers in the
-                # first repository
-                self.pkg("install sample")
-                self.pkg("install carrots")
-                # install a package from the second repository
-                self.pkg("install new")
-                # we can't perform remote search or admin operations, since
-                # we've no supporting mod_wsgi process.
-                self.pkg("search -r new", exit=1)
-                self.pkgrepo("-s {0}/testpkg5/usr refresh".format(
-                    self.ac.url), exit=1)
+        # Can't refresh this repo since it doesn't have a writable root
+        self.pkgrepo("-s {0} refresh".format(depot_url), exit=1)
+
+        # verify that search fails for repositories that don't have
+        # a pre-existing search index in the repository
+        self.pkg("search -s {0} /usr/bin/sample".format(nosearch_url), exit=1)
+
+        # publish a new package, and verify it doesn't appear in the
+        # search results for the repo with the writable_root
+        self.pkgsend_bulk(writable_rurl, self.new_pkg)
+        self.pkg("search -s {0} /usr/bin/new".format(windex_url), exit=1)
+
+        # now refresh the index
+        self.pkgrepo("-s {0} refresh".format(windex_url))
+
+        # there isn't a synchronous option to pkgrepo, so wait a bit
+        # then make sure we do see this new package.
+        time.sleep(3)
+
+        # we should now get search results for that new package
+        ret, output = self.pkg(
+            "search -s {0} /usr/bin/new".format(windex_url), out=True
+        )
+        self.assertTrue("usr/bin/new" in output)
+        ret, output = self.pkgrepo(
+            "-s {0} list -F tsv".format(windex_url), out=True
+        )
+        self.assertTrue("pkg://test3/sample@1.0" in output)
+        self.assertTrue("pkg://test3/new@1.0" in output)
+
+        # ensure that refresh --no-catalog works, but refresh --no-index
+        # does not.
+        self.pkgrepo("-s {0} refresh --no-catalog".format(windex_url))
+        self.pkgrepo("-s {0} refresh --no-index".format(windex_url), exit=1)
+
+        # check that when we start the depot without -A, we cannot
+        # issue refresh commands.
+        self.depotconfig("")
+        self.start_depot()
+        self.pkgrepo("-s {0} refresh".format(windex_url), exit=1)
+
+    def test_15_htheaders(self):
+        """Test that the correct Content-Type and Cache-control headers
+        are sent from the depot for the responses that we care about."""
+
+        fmris = self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.sample_pkg)
+        self.pkgrepo("-s {0} refresh".format(self.dcs[1].get_repo_url()))
+        self.depotconfig("")
+        self.start_depot()
+
+        # Create an image so we have something to search with.
+        # This technically isn't necessary anymore, but the test suite
+        # runs with some debug flags to make it (intentionally)
+        # difficult to mess with the root image of the test system
+        # (even though calling 'pkg search -s' would never actually
+        # modify it) Creating an image is just the easier thing to do
+        # here.
+        self.image_create()
+        ret, output = self.pkg(
+            "search -s {0}/default -H -o action.hash "
+            "-r /usr/bin/sample".format(self.ac.url),
+            out=True,
+        )
+        file_hash = output.strip()
+
+        fmri = pkg.fmri.PkgFmri(fmris[0])
+        esc_short_fmri = fmri.get_fmri(anarchy=True).replace("pkg:/", "")
+        esc_short_fmri = esc_short_fmri.replace(",", "%2C")
+        esc_short_fmri = esc_short_fmri.replace(":", "%3A")
+
+        # a dictionary of paths we should be able to access, along with
+        # expected header (name,value) pairs for each
+        paths = {
+            "/default/p5i/0/sample.p5i": [
+                ("Content-Type", "application/vnd.pkg5.info")
+            ],
+            "/default/catalog/1/catalog.attrs": [("Cache-Control", "no-cache")],
+            "/default/manifest/0/{0}".format(esc_short_fmri): [
+                (
+                    "Cache-Control",
+                    "must-revalidate, no-transform, max-age=31536000",
+                ),
+                ("Content-Type", "text/plain;charset=utf-8"),
+            ],
+            "/default/search/1/False_2_None_None_%3a%3a%3asample": [
+                ("Cache-Control", "no-cache"),
+                ("Content-Type", "text/plain;charset=utf-8"),
+            ],
+            "/default/file/1/{0}".format(file_hash): [
+                (
+                    "Cache-Control",
+                    "must-revalidate, no-transform, max-age=31536000",
+                ),
+                ("Content-Type", "application/data"),
+            ],
+        }
+
+        def header_contains(url, header, value):
+            """Check that HTTP 'header' from 'url' contains an
+            expected value 'value'."""
+            ret = False
+            try:
+                u = urlopen(url)
+                if six.PY2:
+                    h = u.headers.get(header, "")
+                else:
+                    # HTTPMessage inherits from
+                    # email.Message in Python 3 so that it
+                    # has a different method
+                    h = u.headers.get_all(header, "")
+                if value in h:
+                    return True
+            except Exception as e:
+                self.assertTrue(False, "Error opening {0}: {1}".format(url, e))
+            return ret
+
+        for path in paths:
+            for headers in paths[path]:
+                name, value = headers
+                url = "{0}{1}".format(self.ac.url, path)
+                self.assertTrue(
+                    header_contains(url, name, value),
+                    "{0} did not contain the header {1}={2}".format(
+                        url, name, value
+                    ),
+                )
+
+    def test_16_htfragment(self):
+        """Test that the fragment httpd.conf generated by pkg.depot-config
+        can be used in a standard Apache configuration, but that
+        pkg(1) admin and search operations fail."""
+
+        self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.sample_pkg)
+        self.pkgrepo(
+            "-s {0} add-publisher carrots".format(self.dcs[1].get_repo_url())
+        )
+        self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.carrots_pkg)
+        self.pkgsend_bulk(self.dcs[2].get_repo_url(), self.new_pkg)
+
+        # We shouldn't be able to supply a writable root when running
+        # in fragment mode
+        self.depotconfig(
+            "-l {0} -F -d usr={1} -d spaghetti={2}={3} "
+            "-P testpkg5".format(
+                self.default_depot_runtime,
+                self.rdir1,
+                self.rdir2,
+                self.index_dir,
+            ),
+            exit=2,
+        )
+        self.depotconfig(
+            "-l {0} -F -d usr={1} -d spaghetti={2} "
+            "-P testpkg5".format(
+                self.default_depot_runtime, self.rdir1, self.rdir2
+            )
+        )
+
+        default_httpd_conf_path = os.path.join(
+            self.test_root, "default_httpd.conf"
+        )
+        httpd_conf = open(default_httpd_conf_path, "w")
+        httpd_conf.write(
+            self._default_httpd_conf.format(
+                port=self.depot_port,
+                depot_conf=self.depot_conf_fragment,
+                runtime_dir=self.default_depot_runtime,
+            )
+        )
+        httpd_conf.close()
+
+        # Start an Apache instance
+        ac = pkg5unittest.ApacheController(
+            default_httpd_conf_path,
+            self.depot_port,
+            self.default_depot_runtime,
+            testcase=self,
+        )
+        self.register_apache_controller("depot", ac)
+        ac.start()
+
+        # verify the instance is definitely the one using our custom
+        # httpd.conf
+        u = urlopen("{0}/pkg5test-server-status".format(self.ac.url))
+        self.assertTrue(
+            u.code == http_client.OK, "Error getting pkg5-server-status"
+        )
+
+        self.image_create()
+        # add publishers for the two repositories being served by this
+        # Apache instance
+        self.pkg("set-publisher -p {0}/testpkg5/usr".format(self.ac.url))
+        self.pkg("set-publisher -p {0}/testpkg5/spaghetti".format(self.ac.url))
+        # install packages from the two different publishers in the
+        # first repository
+        self.pkg("install sample")
+        self.pkg("install carrots")
+        # install a package from the second repository
+        self.pkg("install new")
+        # we can't perform remote search or admin operations, since
+        # we've no supporting mod_wsgi process.
+        self.pkg("search -r new", exit=1)
+        self.pkgrepo("-s {0}/testpkg5/usr refresh".format(self.ac.url), exit=1)
 
 
 class TestHttpsDepot(_Apache, pkg5unittest.HTTPSTestClass):
-        """Tests that exercise the pkg.depot-config CLI as well as checking the
-        functionality of the depot-config itself for configuring https service.
-        This test class will fail if not run as root, since many of the tests
-        use 'pkg.depot-config -a' which will attempt to chown a directory to
-        pkg5srv:pkg5srv.
-        """
+    """Tests that exercise the pkg.depot-config CLI as well as checking the
+    functionality of the depot-config itself for configuring https service.
+    This test class will fail if not run as root, since many of the tests
+    use 'pkg.depot-config -a' which will attempt to chown a directory to
+    pkg5srv:pkg5srv.
+    """
 
-        def test_0_invalid_option_combo(self):
-                """We return an error given an invalid option combo."""
+    def test_0_invalid_option_combo(self):
+        """We return an error given an invalid option combo."""
 
-                cert = os.path.join(self.test_root, "tmp",
-                    "ido_exist_cert")
-                key = os.path.join(self.test_root, "tmp",
-                    "ido_exist_key")
-                self.make_misc_files(["tmp/ido_exist_cert",
-                    "tmp/ido_exist_key"])
+        cert = os.path.join(self.test_root, "tmp", "ido_exist_cert")
+        key = os.path.join(self.test_root, "tmp", "ido_exist_key")
+        self.make_misc_files(["tmp/ido_exist_cert", "tmp/ido_exist_key"])
 
-                # Test that without --https, providing certs or keys will fail.
-                dummy_ret, dummy_output, err = self.depotconfig(
-                    "--cert {0} --key {1}".format(cert, key),
-                    out=True, stderr=True, exit=2)
-                self.assertTrue(len(err), "error message: Without --https, "
-                            "providing cert or key should fail but succeeded "
-                            "instead.")
+        # Test that without --https, providing certs or keys will fail.
+        dummy_ret, dummy_output, err = self.depotconfig(
+            "--cert {0} --key {1}".format(cert, key),
+            out=True,
+            stderr=True,
+            exit=2,
+        )
+        self.assertTrue(
+            len(err),
+            "error message: Without --https, "
+            "providing cert or key should fail but succeeded "
+            "instead.",
+        )
 
-                dummy_ret, dummy_output, err = self.depotconfig(
-                    "--ca-cert {0} --ca-key {1}".format(cert, key),
-                    out=True, stderr=True, exit=2)
-                self.assertTrue(len(err), "error message: Without --https, "
-                            "providing cert or key should fail but succeeded "
-                            "instead.")
+        dummy_ret, dummy_output, err = self.depotconfig(
+            "--ca-cert {0} --ca-key {1}".format(cert, key),
+            out=True,
+            stderr=True,
+            exit=2,
+        )
+        self.assertTrue(
+            len(err),
+            "error message: Without --https, "
+            "providing cert or key should fail but succeeded "
+            "instead.",
+        )
 
-                dummy_ret, dummy_output, err = self.depotconfig(
-                    "--cert-chain {0}".format(cert), out=True, stderr=True, exit=2)
-                self.assertTrue(len(err), "error message: Without --https, "
-                            "providing cert or key should fail but succeeded "
-                            "instead.")
+        dummy_ret, dummy_output, err = self.depotconfig(
+            "--cert-chain {0}".format(cert), out=True, stderr=True, exit=2
+        )
+        self.assertTrue(
+            len(err),
+            "error message: Without --https, "
+            "providing cert or key should fail but succeeded "
+            "instead.",
+        )
 
-                # Checking that HTTPS is not supported in fragment mode.
-                dummy_ret, dummy_output, err = self.depotconfig(
-                    "--https -F", out=True, stderr=True, exit=2)
-                self.assertTrue(len(err), "error message: Without --https, "
-                            "providing cert or key should fail but succeeded "
-                            "instead.")
+        # Checking that HTTPS is not supported in fragment mode.
+        dummy_ret, dummy_output, err = self.depotconfig(
+            "--https -F", out=True, stderr=True, exit=2
+        )
+        self.assertTrue(
+            len(err),
+            "error message: Without --https, "
+            "providing cert or key should fail but succeeded "
+            "instead.",
+        )
 
-        def test_1_missing_combo_options(self):
-                """We return errors if the option in a combo is not specified
-                at the same time."""
+    def test_1_missing_combo_options(self):
+        """We return errors if the option in a combo is not specified
+        at the same time."""
 
-                cert = os.path.join(self.test_root, "tmp",
-                    "ido_exist_cert")
-                key = os.path.join(self.test_root, "tmp",
-                    "ido_exist_key")
-                self.make_misc_files(["tmp/ido_exist_cert",
-                    "tmp/ido_exist_key"])
+        cert = os.path.join(self.test_root, "tmp", "ido_exist_cert")
+        key = os.path.join(self.test_root, "tmp", "ido_exist_key")
+        self.make_misc_files(["tmp/ido_exist_cert", "tmp/ido_exist_key"])
 
-                self.depotconfig("--https --cert {0}".format(cert), exit=2)
-                self.depotconfig("--https --key {0}".format(key), exit=2)
-                self.depotconfig("--https --ca-cert {0}".format(cert), exit=2)
-                self.depotconfig("--https --ca-key {0}".format(key), exit=2)
-                self.depotconfig("--https --cert-chain {0}".format(cert), exit=2)
+        self.depotconfig("--https --cert {0}".format(cert), exit=2)
+        self.depotconfig("--https --key {0}".format(key), exit=2)
+        self.depotconfig("--https --ca-cert {0}".format(cert), exit=2)
+        self.depotconfig("--https --ca-key {0}".format(key), exit=2)
+        self.depotconfig("--https --cert-chain {0}".format(cert), exit=2)
 
-        def test_2_invalid_cert_key_dir(self):
-                """We return an error given an invalid cer_key_dir."""
+    def test_2_invalid_cert_key_dir(self):
+        """We return an error given an invalid cer_key_dir."""
 
-                for invalid_certkey_dir in ["/dev/null", "/etc/passwd"]:
-                        ret, output, err = self.depotconfig("--https "
-                            "--cert-key-dir {0}".format(
-                            invalid_certkey_dir), out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_certkey_dir in err, "error message "
-                           "did not contain {0}: {1}".format(invalid_certkey_dir, err))
+        for invalid_certkey_dir in ["/dev/null", "/etc/passwd"]:
+            ret, output, err = self.depotconfig(
+                "--https " "--cert-key-dir {0}".format(invalid_certkey_dir),
+                out=True,
+                stderr=True,
+                exit=1,
+            )
+            self.assertTrue(
+                invalid_certkey_dir in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_certkey_dir, err),
+            )
 
-        def test_3_non_exist_cert_key(self):
-                """We return an error given an non-exist cert or key."""
+    def test_3_non_exist_cert_key(self):
+        """We return an error given an non-exist cert or key."""
 
-                non_exist_cert = os.path.join(self.test_root,
-                    "idonot_exist_cert")
-                non_exist_key = os.path.join(self.test_root,
-                    "idonot_exist_key")
-                exist_cert = os.path.join(self.test_root, "tmp",
-                    "ido_exist_cert")
-                exist_key = os.path.join(self.test_root, "tmp",
-                    "ido_exist_key")
-                self.make_misc_files(["tmp/ido_exist_cert",
-                    "tmp/ido_exist_key"])
+        non_exist_cert = os.path.join(self.test_root, "idonot_exist_cert")
+        non_exist_key = os.path.join(self.test_root, "idonot_exist_key")
+        exist_cert = os.path.join(self.test_root, "tmp", "ido_exist_cert")
+        exist_key = os.path.join(self.test_root, "tmp", "ido_exist_key")
+        self.make_misc_files(["tmp/ido_exist_cert", "tmp/ido_exist_key"])
 
-                # Test checking user provided server cert works.
-                dummy_ret, dummy_output, err = self.depotconfig("--https "
-                    "--cert {0} --key {1}".format(non_exist_cert, exist_key),
-                    out=True, stderr=True, exit=1)
-                self.assertTrue(non_exist_cert in err, "error message "
-                    "did not contain {0}: {1}".format(non_exist_cert, err))
+        # Test checking user provided server cert works.
+        dummy_ret, dummy_output, err = self.depotconfig(
+            "--https " "--cert {0} --key {1}".format(non_exist_cert, exist_key),
+            out=True,
+            stderr=True,
+            exit=1,
+        )
+        self.assertTrue(
+            non_exist_cert in err,
+            "error message "
+            "did not contain {0}: {1}".format(non_exist_cert, err),
+        )
 
-                # Test checking user provided server key works.
-                dummy_ret, dummy_output, err = self.depotconfig("--https "
-                    "--cert {0} --key {1}".format(exist_cert, non_exist_key),
-                    out=True, stderr=True, exit=1)
-                self.assertTrue(non_exist_key in err, "error message "
-                    "did not contain {0}: {1}".format(non_exist_key, err))
+        # Test checking user provided server key works.
+        dummy_ret, dummy_output, err = self.depotconfig(
+            "--https " "--cert {0} --key {1}".format(exist_cert, non_exist_key),
+            out=True,
+            stderr=True,
+            exit=1,
+        )
+        self.assertTrue(
+            non_exist_key in err,
+            "error message "
+            "did not contain {0}: {1}".format(non_exist_key, err),
+        )
 
-                # Test checking user provided cert chain file works.
-                dummy_ret, dummy_output, err = self.depotconfig("--https "
-                    "--cert {0} --key {1} --cert-chain {2}".format(
-                    exist_cert, exist_key, non_exist_cert),
-                    out=True, stderr=True, exit=1)
-                self.assertTrue(non_exist_cert in err, "error message "
-                    "did not contain {0}: {1}".format(non_exist_cert, err))
+        # Test checking user provided cert chain file works.
+        dummy_ret, dummy_output, err = self.depotconfig(
+            "--https "
+            "--cert {0} --key {1} --cert-chain {2}".format(
+                exist_cert, exist_key, non_exist_cert
+            ),
+            out=True,
+            stderr=True,
+            exit=1,
+        )
+        self.assertTrue(
+            non_exist_cert in err,
+            "error message "
+            "did not contain {0}: {1}".format(non_exist_cert, err),
+        )
 
-                # Test checking user provided CA cert file works.
-                tmp_dir = os.path.join(self.test_root, "tmp")
-                dummy_ret, dummy_output, err = self.depotconfig("--https "
-                    "--ca-cert {0} --ca-key {1} --cert-key-dir {2}".format(
-                    non_exist_cert, exist_key, tmp_dir),
-                    out=True, stderr=True, exit=1)
-                self.assertTrue(non_exist_cert in err, "error message "
-                    "did not contain {0}: {1}".format(non_exist_cert, err))
+        # Test checking user provided CA cert file works.
+        tmp_dir = os.path.join(self.test_root, "tmp")
+        dummy_ret, dummy_output, err = self.depotconfig(
+            "--https "
+            "--ca-cert {0} --ca-key {1} --cert-key-dir {2}".format(
+                non_exist_cert, exist_key, tmp_dir
+            ),
+            out=True,
+            stderr=True,
+            exit=1,
+        )
+        self.assertTrue(
+            non_exist_cert in err,
+            "error message "
+            "did not contain {0}: {1}".format(non_exist_cert, err),
+        )
 
-                # Test checking user provided CA key file works.
-                dummy_ret, dummy_output, err = self.depotconfig("--https "
-                    "--ca-cert {0} --ca-key {1} --cert-key-dir {2}".format(
-                    exist_cert, non_exist_key, tmp_dir),
-                    out=True, stderr=True, exit=1)
-                self.assertTrue(non_exist_key in err, "error message "
-                    "did not contain {0}: {1}".format(non_exist_key, err))
+        # Test checking user provided CA key file works.
+        dummy_ret, dummy_output, err = self.depotconfig(
+            "--https "
+            "--ca-cert {0} --ca-key {1} --cert-key-dir {2}".format(
+                exist_cert, non_exist_key, tmp_dir
+            ),
+            out=True,
+            stderr=True,
+            exit=1,
+        )
+        self.assertTrue(
+            non_exist_key in err,
+            "error message "
+            "did not contain {0}: {1}".format(non_exist_key, err),
+        )
 
-        def test_4_invalid_smf_fmri(self):
-                """We return an error given an invalid pkg/depot smf fmri."""
+    def test_4_invalid_smf_fmri(self):
+        """We return an error given an invalid pkg/depot smf fmri."""
 
-                some_fake_file = os.path.join(self.test_root, "tmp",
-                    "some_fake_file")
-                self.make_misc_files(["tmp/some_fake_file"])
-                tmp_dir = os.path.join(self.test_root, "tmp")
-                # Test with invalid fmri.
-                for invalid_fmri in ["svc:", "svc://notexist", some_fake_file]:
-                        dummy_ret, dummy_output, err = self.depotconfig(
-                            "--https --cert-key-dir {0} --smf-fmri {1}".format(
-                            tmp_dir, invalid_fmri), out=True, stderr=True)
-                        self.assertTrue(len(err), "error message: SMF FMRI "
-                            "setting should fail but succeeded instead.")
+        some_fake_file = os.path.join(self.test_root, "tmp", "some_fake_file")
+        self.make_misc_files(["tmp/some_fake_file"])
+        tmp_dir = os.path.join(self.test_root, "tmp")
+        # Test with invalid fmri.
+        for invalid_fmri in ["svc:", "svc://notexist", some_fake_file]:
+            dummy_ret, dummy_output, err = self.depotconfig(
+                "--https --cert-key-dir {0} --smf-fmri {1}".format(
+                    tmp_dir, invalid_fmri
+                ),
+                out=True,
+                stderr=True,
+            )
+            self.assertTrue(
+                len(err),
+                "error message: SMF FMRI "
+                "setting should fail but succeeded instead.",
+            )
 
-                # Test with wrong fmri.
-                wrong_fmri = "pkg/server:default"
-                dummy_ret, dummy_output, err = self.depotconfig(
-                    "--https --cert-key-dir {0} --smf-fmri {1}".format(
-                    tmp_dir, wrong_fmri), out=True, stderr=True, exit=1)
-                self.assertTrue(len(err), "error message: SMF FMRI "
-                    "setting should fail but succeeded instead.")
+        # Test with wrong fmri.
+        wrong_fmri = "pkg/server:default"
+        dummy_ret, dummy_output, err = self.depotconfig(
+            "--https --cert-key-dir {0} --smf-fmri {1}".format(
+                tmp_dir, wrong_fmri
+            ),
+            out=True,
+            stderr=True,
+            exit=1,
+        )
+        self.assertTrue(
+            len(err),
+            "error message: SMF FMRI "
+            "setting should fail but succeeded instead.",
+        )
 
-        def test_5_https_gen_cert(self):
-                """Test that https functionality works as expected."""
+    def test_5_https_gen_cert(self):
+        """Test that https functionality works as expected."""
 
-                self.pkgsend_bulk(self.dcs[1].get_repo_url(),
-                    self.sample_pkg)
-                self.pkgrepo("-s {0} add-publisher carrots".format(
-                    self.dcs[1].get_repo_url()))
-                self.pkgsend_bulk(self.dcs[1].get_repo_url(),
-                    self.carrots_pkg)
-                self.pkgsend_bulk(self.dcs[2].get_repo_url(),
-                    self.new_pkg)
+        self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.sample_pkg)
+        self.pkgrepo(
+            "-s {0} add-publisher carrots".format(self.dcs[1].get_repo_url())
+        )
+        self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.carrots_pkg)
+        self.pkgsend_bulk(self.dcs[2].get_repo_url(), self.new_pkg)
 
-                cert_key_dir = os.path.join(self.default_depot_runtime,
-                    "cert_key")
-                if os.path.isdir(cert_key_dir):
-                        shutil.rmtree(cert_key_dir)
+        cert_key_dir = os.path.join(self.default_depot_runtime, "cert_key")
+        if os.path.isdir(cert_key_dir):
+            shutil.rmtree(cert_key_dir)
 
-                cache_dir = os.path.join(self.test_root, "cache_test_dir")
-                self.depotconfig("-l {0} -r {1} -c {2} -d usr={3} -d spa={4} -p {5} "
-                    "--https -T {6} -h localhost --cert-key-dir {7}".format(
-                    self.default_depot_runtime, self.default_depot_runtime,
-                    cache_dir, self.rdir1, self.rdir2, self.depot_port,
-                    self.depot_template_dir, cert_key_dir))
-                server_id = "localhost_{0}".format(self.depot_port)
-                ca_cert_file = os.path.join(cert_key_dir, "ca_{0}_cert.pem".format(
-                    server_id))
-                DebugValues["ssl_ca_file"] = ca_cert_file
+        cache_dir = os.path.join(self.test_root, "cache_test_dir")
+        self.depotconfig(
+            "-l {0} -r {1} -c {2} -d usr={3} -d spa={4} -p {5} "
+            "--https -T {6} -h localhost --cert-key-dir {7}".format(
+                self.default_depot_runtime,
+                self.default_depot_runtime,
+                cache_dir,
+                self.rdir1,
+                self.rdir2,
+                self.depot_port,
+                self.depot_template_dir,
+                cert_key_dir,
+            )
+        )
+        server_id = "localhost_{0}".format(self.depot_port)
+        ca_cert_file = os.path.join(
+            cert_key_dir, "ca_{0}_cert.pem".format(server_id)
+        )
+        DebugValues["ssl_ca_file"] = ca_cert_file
 
-                # Start an Apache instance
-                self.default_depot_conf = os.path.join(
-                    self.default_depot_runtime, "depot_httpd.conf")
-                ac = pkg5unittest.HttpDepotController(self.default_depot_conf,
-                    self.depot_port, self.default_depot_runtime, testcase=self,
-                    https=True)
-                self.register_apache_controller("depot", ac)
-                ac.start()
-                self.image_create()
+        # Start an Apache instance
+        self.default_depot_conf = os.path.join(
+            self.default_depot_runtime, "depot_httpd.conf"
+        )
+        ac = pkg5unittest.HttpDepotController(
+            self.default_depot_conf,
+            self.depot_port,
+            self.default_depot_runtime,
+            testcase=self,
+            https=True,
+        )
+        self.register_apache_controller("depot", ac)
+        ac.start()
+        self.image_create()
 
-                # add publishers for the two repositories being served by this
-                # Apache instance.
-                self.pkg("set-publisher -p {0}/usr".format(self.ac.url))
-                self.pkg("set-publisher -p {0}/spa".format(self.ac.url))
-                # install packages from the two different publishers in the
-                # first repository
-                self.pkg("install sample")
-                self.pkg("install carrots")
-                # install a package from the second repository
-                self.pkg("install new")
-                # we can't perform remote search or admin operations, since
-                # we've no supporting mod_wsgi process.
-                self.pkg("search -r new", exit=1)
-                self.pkgrepo("-s {0}/testpkg5/usr refresh".format(
-                    self.ac.url), exit=1)
+        # add publishers for the two repositories being served by this
+        # Apache instance.
+        self.pkg("set-publisher -p {0}/usr".format(self.ac.url))
+        self.pkg("set-publisher -p {0}/spa".format(self.ac.url))
+        # install packages from the two different publishers in the
+        # first repository
+        self.pkg("install sample")
+        self.pkg("install carrots")
+        # install a package from the second repository
+        self.pkg("install new")
+        # we can't perform remote search or admin operations, since
+        # we've no supporting mod_wsgi process.
+        self.pkg("search -r new", exit=1)
+        self.pkgrepo("-s {0}/testpkg5/usr refresh".format(self.ac.url), exit=1)
 
-        def test_6_https_cert_chain(self):
-                """Test that https functionality with cert chain works as
-                expected."""
+    def test_6_https_cert_chain(self):
+        """Test that https functionality with cert chain works as
+        expected."""
 
-                self.pkgsend_bulk(self.dcs[1].get_repo_url(),
-                    self.sample_pkg)
-                self.pkgrepo("-s {0} add-publisher carrots".format(
-                    self.dcs[1].get_repo_url()))
-                self.pkgsend_bulk(self.dcs[1].get_repo_url(),
-                    self.carrots_pkg)
-                self.pkgsend_bulk(self.dcs[2].get_repo_url(),
-                    self.new_pkg)
+        self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.sample_pkg)
+        self.pkgrepo(
+            "-s {0} add-publisher carrots".format(self.dcs[1].get_repo_url())
+        )
+        self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.carrots_pkg)
+        self.pkgsend_bulk(self.dcs[2].get_repo_url(), self.new_pkg)
 
-                cert_key_dir = os.path.join(self.default_depot_runtime,
-                    "cert_key_dir")
-                if os.path.isdir(cert_key_dir):
-                        shutil.rmtree(cert_key_dir)
-                os.makedirs(cert_key_dir)
-                cg = certgenerator.CertGenerator(base_dir=cert_key_dir)
-                cg.make_trust_anchor("ta", https=True)
-                cg.make_ca_cert("ca_ta", "ta", https=True)
-                cg.make_cs_cert("cs_ta", "ca_ta", parent_loc="chain_certs",
-                    https=True)
+        cert_key_dir = os.path.join(self.default_depot_runtime, "cert_key_dir")
+        if os.path.isdir(cert_key_dir):
+            shutil.rmtree(cert_key_dir)
+        os.makedirs(cert_key_dir)
+        cg = certgenerator.CertGenerator(base_dir=cert_key_dir)
+        cg.make_trust_anchor("ta", https=True)
+        cg.make_ca_cert("ca_ta", "ta", https=True)
+        cg.make_cs_cert("cs_ta", "ca_ta", parent_loc="chain_certs", https=True)
 
-                ta_cert_file = os.path.join(cg.raw_trust_anchor_dir,
-                    "ta_cert.pem")
-                ca_cert_file = os.path.join(cg.chain_certs_dir,
-                    "ca_ta_cert.pem")
-                cs_cert_file = os.path.join(cg.cs_dir, "cs_ta_cert.pem")
-                cs_key_file = os.path.join(cg.keys_dir, "cs_ta_key.pem")
+        ta_cert_file = os.path.join(cg.raw_trust_anchor_dir, "ta_cert.pem")
+        ca_cert_file = os.path.join(cg.chain_certs_dir, "ca_ta_cert.pem")
+        cs_cert_file = os.path.join(cg.cs_dir, "cs_ta_cert.pem")
+        cs_key_file = os.path.join(cg.keys_dir, "cs_ta_key.pem")
 
-                cache_dir = os.path.join(self.test_root, "cache_test_dir")
-                self.depotconfig("-l {0} -r {1} -c {2} -d usr={3} -d spa={4} -p {5} "
-                    "--https -T {6} -h localhost --cert {7} --key {8} "
-                    "--cert-chain {9}".format(
-                    self.default_depot_runtime, self.default_depot_runtime,
-                    cache_dir, self.rdir1, self.rdir2, self.depot_port,
-                    self.depot_template_dir, cs_cert_file, cs_key_file,
-                    ca_cert_file))
+        cache_dir = os.path.join(self.test_root, "cache_test_dir")
+        self.depotconfig(
+            "-l {0} -r {1} -c {2} -d usr={3} -d spa={4} -p {5} "
+            "--https -T {6} -h localhost --cert {7} --key {8} "
+            "--cert-chain {9}".format(
+                self.default_depot_runtime,
+                self.default_depot_runtime,
+                cache_dir,
+                self.rdir1,
+                self.rdir2,
+                self.depot_port,
+                self.depot_template_dir,
+                cs_cert_file,
+                cs_key_file,
+                ca_cert_file,
+            )
+        )
 
-                DebugValues["ssl_ca_file"] = ta_cert_file
+        DebugValues["ssl_ca_file"] = ta_cert_file
 
-                # Start an Apache instance
-                self.default_depot_conf = os.path.join(
-                    self.default_depot_runtime, "depot_httpd.conf")
-                ac = pkg5unittest.HttpDepotController(self.default_depot_conf,
-                    self.depot_port, self.default_depot_runtime, testcase=self,
-                    https=True)
-                self.register_apache_controller("depot", ac)
-                ac.start()
-                self.image_create()
+        # Start an Apache instance
+        self.default_depot_conf = os.path.join(
+            self.default_depot_runtime, "depot_httpd.conf"
+        )
+        ac = pkg5unittest.HttpDepotController(
+            self.default_depot_conf,
+            self.depot_port,
+            self.default_depot_runtime,
+            testcase=self,
+            https=True,
+        )
+        self.register_apache_controller("depot", ac)
+        ac.start()
+        self.image_create()
 
-                # add publishers for the two repositories being served by this
-                # Apache instance.
-                self.pkg("set-publisher -p {0}/usr".format(self.ac.url))
-                self.pkg("set-publisher -p {0}/spa".format(self.ac.url))
-                # install packages from the two different publishers in the
-                # first repository
-                self.pkg("install sample")
-                self.pkg("install carrots")
-                # install a package from the second repository
-                self.pkg("install new")
+        # add publishers for the two repositories being served by this
+        # Apache instance.
+        self.pkg("set-publisher -p {0}/usr".format(self.ac.url))
+        self.pkg("set-publisher -p {0}/spa".format(self.ac.url))
+        # install packages from the two different publishers in the
+        # first repository
+        self.pkg("install sample")
+        self.pkg("install carrots")
+        # install a package from the second repository
+        self.pkg("install new")
 
-        def test_7_https_provided_ca(self):
-                """Test that pkg.depot-config functionality with provided
-                ca certificate and key works as expected."""
+    def test_7_https_provided_ca(self):
+        """Test that pkg.depot-config functionality with provided
+        ca certificate and key works as expected."""
 
-                self.pkgsend_bulk(self.dcs[1].get_repo_url(),
-                    self.sample_pkg)
-                self.pkgrepo("-s {0} add-publisher carrots".format(
-                    self.dcs[1].get_repo_url()))
-                self.pkgsend_bulk(self.dcs[1].get_repo_url(),
-                    self.carrots_pkg)
-                self.pkgsend_bulk(self.dcs[2].get_repo_url(),
-                    self.new_pkg)
+        self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.sample_pkg)
+        self.pkgrepo(
+            "-s {0} add-publisher carrots".format(self.dcs[1].get_repo_url())
+        )
+        self.pkgsend_bulk(self.dcs[1].get_repo_url(), self.carrots_pkg)
+        self.pkgsend_bulk(self.dcs[2].get_repo_url(), self.new_pkg)
 
-                cert_key_dir = os.path.join(self.default_depot_runtime,
-                    "cert_key_dir")
-                if os.path.isdir(cert_key_dir):
-                        shutil.rmtree(cert_key_dir)
-                os.makedirs(cert_key_dir)
+        cert_key_dir = os.path.join(self.default_depot_runtime, "cert_key_dir")
+        if os.path.isdir(cert_key_dir):
+            shutil.rmtree(cert_key_dir)
+        os.makedirs(cert_key_dir)
 
-                cg = certgenerator.CertGenerator(base_dir=cert_key_dir)
-                cg.make_trust_anchor("ta", https=True)
+        cg = certgenerator.CertGenerator(base_dir=cert_key_dir)
+        cg.make_trust_anchor("ta", https=True)
 
-                ta_cert_file = os.path.join(cg.raw_trust_anchor_dir,
-                    "ta_cert.pem")
-                ta_key_file = os.path.join(cg.keys_dir, "ta_key.pem")
+        ta_cert_file = os.path.join(cg.raw_trust_anchor_dir, "ta_cert.pem")
+        ta_key_file = os.path.join(cg.keys_dir, "ta_key.pem")
 
-                cache_dir = os.path.join(self.test_root, "cache_test_dir")
-                self.depotconfig("-l {0} -r {1} -c {2} -d usr={3} -d spa={4} -p {5} "
-                    "--https -T {6} -h localhost --ca-cert {7} --ca-key {8} "
-                    "--cert-key-dir {9}".format(
-                    self.default_depot_runtime, self.default_depot_runtime,
-                    cache_dir, self.rdir1, self.rdir2, self.depot_port,
-                    self.depot_template_dir, ta_cert_file, ta_key_file,
-                    cert_key_dir))
+        cache_dir = os.path.join(self.test_root, "cache_test_dir")
+        self.depotconfig(
+            "-l {0} -r {1} -c {2} -d usr={3} -d spa={4} -p {5} "
+            "--https -T {6} -h localhost --ca-cert {7} --ca-key {8} "
+            "--cert-key-dir {9}".format(
+                self.default_depot_runtime,
+                self.default_depot_runtime,
+                cache_dir,
+                self.rdir1,
+                self.rdir2,
+                self.depot_port,
+                self.depot_template_dir,
+                ta_cert_file,
+                ta_key_file,
+                cert_key_dir,
+            )
+        )
 
-                DebugValues["ssl_ca_file"] = ta_cert_file
+        DebugValues["ssl_ca_file"] = ta_cert_file
 
-                # Start an Apache instance
-                self.default_depot_conf = os.path.join(
-                    self.default_depot_runtime, "depot_httpd.conf")
-                ac = pkg5unittest.HttpDepotController(self.default_depot_conf,
-                    self.depot_port, self.default_depot_runtime, testcase=self,
-                    https=True)
-                self.register_apache_controller("depot", ac)
-                ac.start()
-                self.image_create()
+        # Start an Apache instance
+        self.default_depot_conf = os.path.join(
+            self.default_depot_runtime, "depot_httpd.conf"
+        )
+        ac = pkg5unittest.HttpDepotController(
+            self.default_depot_conf,
+            self.depot_port,
+            self.default_depot_runtime,
+            testcase=self,
+            https=True,
+        )
+        self.register_apache_controller("depot", ac)
+        ac.start()
+        self.image_create()
 
-                # add publishers for the two repositories being served by this
-                # Apache instance.
-                self.pkg("set-publisher -p {0}/usr".format(self.ac.url))
-                self.pkg("set-publisher -p {0}/spa".format(self.ac.url))
-                # install packages from the two different publishers in the
-                # first repository
-                self.pkg("install sample")
-                self.pkg("install carrots")
-                # install a package from the second repository
-                self.pkg("install new")
+        # add publishers for the two repositories being served by this
+        # Apache instance.
+        self.pkg("set-publisher -p {0}/usr".format(self.ac.url))
+        self.pkg("set-publisher -p {0}/spa".format(self.ac.url))
+        # install packages from the two different publishers in the
+        # first repository
+        self.pkg("install sample")
+        self.pkg("install carrots")
+        # install a package from the second repository
+        self.pkg("install new")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_fix.py
+++ b/src/tests/cli/t_fix.py
@@ -24,8 +24,9 @@
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -40,14 +41,14 @@ import unittest
 
 import pkg.json as json
 
+
 class TestFix(pkg5unittest.SingleDepotTestCase):
+    # Don't need to restart depot for every test.
+    persistent_setup = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        # Don't need to restart depot for every test.
-        persistent_setup = True
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
-
-        amber10 = """
+    amber10 = """
             open amber@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add file amber1 mode=0644 owner=root group=bin path=etc/amber1
@@ -56,57 +57,57 @@ class TestFix(pkg5unittest.SingleDepotTestCase):
             add hardlink path=etc/amber.hardlink target=/etc/amber1
             close """
 
-        licensed13 = """
+    licensed13 = """
             open licensed@1.3,5.11-0
             add file libc.so.1 mode=0555 owner=root group=bin path=lib/libc.so.1
             add license copyright.licensed license=copyright.licensed must-display=True
             add license license.licensed license=license.licensed must-accept=True
             close """
 
-        dir10 = """
+    dir10 = """
             open dir@1.0,5.11-0
             add dir path=etc mode=0755 owner=root group=bin
             close """
 
-        pkg_dupfile = """
+    pkg_dupfile = """
             open dupfile@0,5.11-0
             add file tmp/file1 path=dir/pathname mode=0755 owner=root group=bin preserve=renameold overlay=allow
             close
         """
-        pkg_duplink = """
+    pkg_duplink = """
             open duplink@0,5.11-0
             add link path=dir/pathname target=dir/other preserve=renameold overlay=true
             close
         """
 
-        # All of these purposefully omit dir dependency.
-        file10 = """
+    # All of these purposefully omit dir dependency.
+    file10 = """
             open file@1.0,5.11-0
             add file amber1 path=amber1 mode=0600 owner=root group=bin
             close """
 
-        preserve10 = """
+    preserve10 = """
             open preserve@1.0,5.11-0
             add file amber1 path=amber1 mode=755 owner=root group=bin preserve=true timestamp="20080731T001051Z"
             add file amber2 path=amber2 mode=755 owner=root group=bin preserve=true timestamp="20080731T001051Z"
             close """
 
-        preserve11 = """
+    preserve11 = """
             open preserve@1.1,5.11-0
             add file amber1 path=amber1 mode=755 owner=root group=bin preserve=renamenew timestamp="20090731T004051Z"
             close """
 
-        preserve12 = """
+    preserve12 = """
             open preserve@1.2,5.11-0
             add file amber1 path=amber1 mode=755 owner=root group=bin preserve=renameold timestamp="20100731T014051Z"
             close """
 
-        driver10 = """
+    driver10 = """
             open drv@1.0,5.11-0
             add driver name=whee alias=pci8186,4321
             close """
 
-        driver_prep10 = """
+    driver_prep10 = """
             open drv-prep@1.0,5.11-0
             add dir path=/tmp mode=755 owner=root group=root
             add dir mode=0755 owner=root group=root path=/var
@@ -121,37 +122,37 @@ class TestFix(pkg5unittest.SingleDepotTestCase):
             add file tmp/empty path=/etc/security/extra_privs mode=644 owner=root group=sys
             close """
 
-        sysattr = """
+    sysattr = """
             open sysattr@1.0-0
             add file amber1 mode=0555 owner=root group=bin sysattr=nodump preserve=true path=amber1 timestamp=20100731T014051Z overlay=allow
             add file amber2 mode=0555 owner=root group=bin sysattr=nodump path=amber2 timestamp=20100731T014051Z
             close"""
 
-        sysattr_no_overlay = """
+    sysattr_no_overlay = """
             open sysattr-no-overlay@1.0-0
             add file amber1 mode=0555 owner=root group=bin sysattr=archive preserve=true path=amber1
             add file amber2 mode=0555 owner=root group=bin sysattr=archive path=amber2
             close"""
 
-        sysattr_o = """
+    sysattr_o = """
             open sysattr_overlay@1.0-0
             add file mode=0555 owner=root group=bin sysattr=nodump preserve=true path=amber1 overlay=true
             close"""
 
-        gss = """
+    gss = """
             open gss@1.0-0
             add file mech_1 path=etc/gss/mech owner=root group=sys mode=0644 overlay=allow preserve=renameold
             add file mech_3 path=etc/gss/mech_1 owner=root group=sys mode=0644 overlay=allow preserve=renameold
             close """
 
-        krb = """
+    krb = """
             open krb5@1.0-0
             add file mech_2 path=etc/gss/mech owner=root group=sys mode=0644 overlay=true preserve=renameold
             add file mech_4 path=etc/gss/mech_1 owner=root group=sys mode=0644 overlay=true preserve=renameold
             close """
 
-        # Mismatched group attribute between file mech_1 and mech_2.
-        mismatched_attr = """
+    # Mismatched group attribute between file mech_1 and mech_2.
+    mismatched_attr = """
             open gss-no-attr@1.0-0
             add file mech_1 path=etc/gss/mech owner=root group=sys mode=0644 overlay=allow preserve=renameold
             add file mech_3 path=etc/gss/mech_1 owner=root group=sys mode=0644 overlay=allow preserve=renameold
@@ -176,7 +177,7 @@ class TestFix(pkg5unittest.SingleDepotTestCase):
             add file mech_4 path=etc/gss/mech_1 owner=root group=sys mode=0644 overlay=true preserve=renameold overlay-attributes=deny
             close"""
 
-        ftpd = """
+    ftpd = """
             open ftpd@1.0-0
             add dir path=etc mode=0755 owner=root group=sys
             add dir path=etc/ftpd mode=0755 owner=root group=sys
@@ -190,21 +191,27 @@ class TestFix(pkg5unittest.SingleDepotTestCase):
             add user username=daemon ftpuser=false gcos-field="" group=other home-dir=/ lastchg=6445 login-shell=/bin/sh password=NP uid=1 group-list=adm group-list=bin
             close"""
 
-        misc_files = [ "copyright.licensed", "license.licensed", "libc.so.1",
-            "license.licensed", "license.licensed.addendum", "amber1", "amber2",
-            "tmp/file1"]
+    misc_files = [
+        "copyright.licensed",
+        "license.licensed",
+        "libc.so.1",
+        "license.licensed",
+        "license.licensed.addendum",
+        "amber1",
+        "amber2",
+        "tmp/file1",
+    ]
 
-        misc_files2 = {
-            "tmp/empty": "",
-            "mech_1": """kerberos_v5 1.2.840.113554.1.2.2 mech_krb5.so kmech_krb5\n""",
-            "mech_2": """\n""",
-            "mech_3": """kerberos_v5 1.2.840.113554.1.2.2 mech_krb5.so kmech_krb5\n""",
-            "mech_4": """\n"""
-        }
+    misc_files2 = {
+        "tmp/empty": "",
+        "mech_1": """kerberos_v5 1.2.840.113554.1.2.2 mech_krb5.so kmech_krb5\n""",
+        "mech_2": """\n""",
+        "mech_3": """kerberos_v5 1.2.840.113554.1.2.2 mech_krb5.so kmech_krb5\n""",
+        "mech_4": """\n""",
+    }
 
-        misc_ftpfile = {
-                "ftpusers" :
-"""# ident      "@(#)ftpusers   1.6     06/11/21 SMI"
+    misc_ftpfile = {
+        "ftpusers": """# ident      "@(#)ftpusers   1.6     06/11/21 SMI"
 #
 # List of users denied access to the FTP server, see ftpusers(5).
 #
@@ -213,8 +220,7 @@ bin
 sys
 adm
 """,
-                "group" :
-"""root::0:
+        "group": """root::0:
 other::1:root
 bin::2:root,daemon
 sys::3:root,bin,adm
@@ -222,817 +228,921 @@ adm::4:root,daemon
 keepmembers::102:user1,user2
 +::::
 """,
-                "passwd" :
-"""root:x:0:0::/root:/usr/bin/bash
+        "passwd": """root:x:0:0::/root:/usr/bin/bash
 daemon:x:1:1::/:
 bin:x:2:2::/usr/bin:
 sys:x:3:3::/:
 adm:x:4:4:Admin:/var/adm:
 +::::::
 """,
-                "shadow" :
-"""root:NP::::::
+        "shadow": """root:NP::::::
 daemon:NP:6445::::::
 bin:NP:6445::::::
 sys:NP:6445::::::
 adm:NP:6445::::::
 +::::::::
-"""
-        }
-
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
-                self.make_misc_files(self.misc_files)
-                self.make_misc_files(self.misc_files2)
-                self.make_misc_files(self.misc_ftpfile)
-                # Grab a well known ELF file so it can be used for ELF tests.
-                portable.copyfile("/usr/bin/ls", os.path.join(self.test_root,
-                    "ls"))
-                self.plist = {}
-                for p in self.pkgsend_bulk(self.rurl, (self.amber10,
-                    self.licensed13, self.dir10, self.file10, self.preserve10,
-                    self.preserve11, self.preserve12, self.driver10,
-                    self.driver_prep10, self.sysattr, self.sysattr_no_overlay, self.sysattr_o, self.gss,
-                    self.krb, self.pkg_dupfile, self.pkg_duplink, self.mismatched_attr, self.ftpd)):
-                        pfmri = fmri.PkgFmri(p)
-                        old_publisher = pfmri.publisher
-                        pfmri.publisher = None
-                        sfmri = pfmri.get_short_fmri().replace("pkg:/", "")
-                        self.plist[sfmri] = pfmri
-                        pfmri.publisher = old_publisher
-
-        def test_01_basics(self):
-                """Basic fix test: install the amber package, modify one of the
-                files, and make sure it gets fixed.  """
-
-                self.image_create(self.rurl)
-                self.pkg("install amber@1.0")
-
-                # Test invalid option combo.
-                self.pkg("fix -v --parsable 0 foo", exit=2)
-                self.pkg("fix -H --parsable 0 foo", exit=2)
-                # Test invalid option value.
-                self.pkg("fix --parsable 1 foo", exit=2)
-
-                # Test parsable output.
-                self.pkg("fix --parsable 0 amber", exit=4)
-                out_json = json.loads(self.output)
-                item_id = list(out_json["item-messages"].keys())[0]
-                self.assertTrue(
-                    out_json["item-messages"][item_id]["messages"][0]["msg_level"]
-                    == "info")
-
-                # Test unpackaged option.
-                self.pkg("fix --unpackaged", exit=4)
-                self.pkg("fix --parsable 0 --unpackaged", exit=4)
-                out_json = json.loads(self.output)
-                subitem_id = list(out_json["item-messages"]["unpackaged"].keys())[0]
-                self.assertTrue(
-                    out_json["item-messages"]["unpackaged"][subitem_id][0]["msg_level"]
-                    == "info")
-
-                index_dir = self.get_img_api_obj().img.index_dir
-                index_file = os.path.join(index_dir, "main_dict.ascii.v2")
-                orig_mtime = os.stat(index_file).st_mtime
-                time.sleep(1)
-
-                victim = "etc/amber2"
-                # Initial size
-                size1 = self.file_size(victim)
-
-                # Corrupt the file
-                self.file_append(victim, "foobar")
-
-                # Make sure the size actually changed
-                size2 = self.file_size(victim)
-                self.assertNotEqual(size1, size2)
-
-                # Verify that unprivileged users are handled by fix.
-                self.pkg("fix amber", exit=1, su_wrap=True)
-
-                self.pkg("fix --unpackaged -nv amber")
-                self.assertTrue("----" in self.output and "UNPACKAGED" in
-                    self.output)
-
-                # Fix the package
-                self.pkg("fix amber")
-
-                # Make sure it's the same size as the original
-                size2 = self.file_size(victim)
-                self.assertEqual(size1, size2)
-
-                # check that we didn't reindex
-                new_mtime = os.stat(index_file).st_mtime
-                self.assertEqual(orig_mtime, new_mtime)
-
-                # Using the same methodology as above, verify that a corrupted
-                # ELF file can be fixed (the corruption being such that libelf
-                # fails on the file).
-                victim = "usr/bin/ls"
-                size1 = self.file_size(victim)
-                self.file_remove(victim)
-                self.file_append(victim, "This is not an ELF")
-                self.pkg("fix amber")
-                self.assertTrue("ELF failure:" in self.output)
-                size2 = self.file_size(victim)
-                self.assertEqual(size1, size2)
-
-                # Verify that text appended to an ELF file is fixed.
-                self.file_append(victim, "Extra text at end of file")
-                self.pkg("fix amber")
-                self.assertTrue("ERROR: Hash:" in self.output)
-                size2 = self.file_size(victim)
-                self.assertEqual(size1, size2)
-
-                # Verify that removing the publisher of a package that needs
-                # fixing results in graceful failure (not a traceback).
-                victim = "etc/amber2"
-                self.file_append(victim, "foobar")
-                self.pkg("set-publisher -P --no-refresh -g {0} foo".format(self.rurl))
-                self.pkg("unset-publisher test")
-                self.pkg("fix", exit=1)
-
-        def test_02_hardlinks(self):
-                """Hardlink test: make sure that a file getting fixed gets any
-                hardlinks that point to it updated"""
-
-                self.image_create(self.rurl)
-                self.pkg("install amber@1.0")
-
-                victim = "etc/amber1"
-                victimlink = "etc/amber.hardlink"
-
-                self.file_append(victim, "foobar")
-                self.pkg("fix amber")
-
-                # Get the inode of the orig file
-                i1 = self.file_inode(victim)
-                # Get the inode of the new hardlink
-                i2 = self.file_inode(victimlink)
-
-                # Make sure the inode of the link is now different
-                self.assertEqual(i1, i2)
-
-        def test_03_license(self):
-                """Verify that fix works with licenses that require acceptance
-                and/or display."""
-
-                self.image_create(self.rurl)
-                self.pkg("install --accept licensed@1.3")
-
-                victim = "lib/libc.so.1"
-
-                # Initial size
-                size1 = self.file_size(victim)
-
-                # Corrupt the file
-                self.file_append(victim, "foobar")
-
-                # Make sure the size actually changed
-                size2 = self.file_size(victim)
-                self.assertNotEqual(size1, size2)
-
-                # Verify that the fix will fail if the license file needs fixing
-                # since the license action requires acceptance.
-                img = self.get_img_api_obj().img
-                shutil.rmtree(os.path.join(img.imgdir, "license"))
-                self.pkg("fix licensed", exit=6)
-
-                # Verify that when the fix failed, it displayed the license
-                # that required display.
-                self.pkg("fix licensed | grep 'copyright.licensed'")
-                self.pkg("fix licensed | grep -v 'license.licensed'")
-
-                # Verify that fix will display all licenses when it fails,
-                # if provided the --licenses option.
-                self.pkg("fix --licenses licensed | grep 'license.licensed'")
-
-                # Finally, verify that fix will succeed when a package requires
-                # license acceptance if provided the --accept option.
-                self.pkg("fix --accept licensed")
-
-                # Make sure it's the same size as the original
-                size2 = self.file_size(victim)
-                self.assertEqual(size1, size2)
-
-        def __do_alter_verify(self, pfmri, verbose=False, quiet=False, exit=0,
-            parsable=False, validate=True):
-                # Alter the owner, group, mode, and timestamp of all files (and
-                # directories) to something different than the package declares.
-                m = manifest.Manifest()
-                m.set_content(self.get_img_manifest(pfmri))
-                ctime = time.time() - 1000
-                for a in m.gen_actions():
-                        if a.name not in ("file", "dir"):
-                                # Only want file or dir actions.
-                                continue
-
-                        ubin = portable.get_user_by_name("bin", None, False)
-                        groot = portable.get_group_by_name("root", None, False)
-
-                        fname = a.attrs["path"]
-                        fpath = os.path.join(self.get_img_path(), fname)
-                        os.chown(fpath, ubin, groot)
-                        os.chmod(fpath, misc.PKG_RO_FILE_MODE)
-                        os.utime(fpath, (ctime, ctime))
-
-                # Call pkg fix to fix them.
-                fix_cmd = "fix"
-                if verbose:
-                        fix_cmd += " -v"
-                if quiet:
-                        fix_cmd += " -q"
-                if parsable:
-                        fix_cmd += " --parsable=0"
-
-                self.pkg("{0} {1}".format(fix_cmd, pfmri), exit=exit)
-                if exit != 0:
-                        return exit
-
-                editables = []
-                # For actions being overlaid, the following logic will
-                # not report correct validation results because it is
-                # only against the overlaid fmri. So we just return.
-                if not validate:
-                        return
-
-                # Now verify that fix actually fixed them.
-                for a in m.gen_actions():
-                        if a.name not in ("file", "dir"):
-                                # Only want file or dir actions.
-                                continue
-
-                        # Validate standard attributes.
-                        self.validate_fsobj_attrs(a)
-
-                        # Now validate attributes that require special handling.
-                        fname = a.attrs["path"]
-                        fpath = os.path.join(self.get_img_path(), fname)
-                        lstat = os.lstat(fpath)
-
-                        # Verify that preserved files don't get renamed, and
-                        # the new ones are not installed if the file wasn't
-                        # missing already.
-                        preserve = a.attrs.get("preserve")
-                        if preserve == "renamenew":
-                                self.assertTrue(not os.path.exists(fpath + ".new"))
-                        elif preserve == "renameold":
-                                self.assertTrue(not os.path.exists(fpath + ".old"))
-
-                        if preserve:
-                                editables.append("{0}".format(a.attrs["path"]))
-
-                        # Verify timestamp (if applicable).
-                        ts = a.attrs.get("timestamp")
-                        if ts:
-                                expected = misc.timestamp_to_time(ts)
-                                actual = lstat.st_mtime
-                                if preserve:
-                                        self.assertNotEqual(expected, actual,
-                                            "timestamp expected {expected} == "
-                                            "actual {actual} for "
-                                            "{fname}".format(
-                                                expected=expected,
-                                                actual=actual, fname=fname))
-                                else:
-                                        self.assertEqual(expected, actual,
-                                            "timestamp expected {expected} != "
-                                            "actual {actual} for "
-                                            "{fname}".format(
-                                                expected=expected,
-                                                actual=actual, fname=fname))
-
-                # Verify the parsable output (if applicable).
-                if parsable:
-                        if editables:
-                                self.assertEqualParsable(self.output,
-                                    affect_packages=["{0}".format(pfmri)],
-                                    change_editables=[["updated", editables]])
-                        else:
-                                self.assertEqualParsable(self.output,
-                                    affect_packages=["{0}".format(pfmri)])
-
-        def test_04_permissions(self):
-                """Ensure that files and directories will have their owner,
-                group, and modes fixed."""
-
-                self.image_create(self.rurl)
-
-                # Because fix and install operations for directories and
-                # files can indirectly interact, each package must be
-                # tested separately and then together (by using a package
-                # with a mix of files and directories).
-                for p in ("dir@1.0-0", "file@1.0-0", "preserve@1.0-0",
-                    "preserve@1.1-0", "preserve@1.2-0", "amber@1.0-0"):
-                        pfmri = self.plist[p]
-                        self.pkg("install {0}".format(pfmri))
-                        self.__do_alter_verify(pfmri)
-                        self.pkg("verify {0}".format(pfmri))
-                        self.pkg("uninstall {0}".format(pfmri))
-
-        def test_05_driver(self):
-                """Verify that fixing a name collision for drivers doesn't
-                cause a stack trace. Bug 14948"""
-
-                self.image_create(self.rurl)
-
-                self.pkg("install drv-prep")
-                self.pkg("install drv")
-
-                fh = open(os.path.join(self.get_img_path(), "etc",
-                    "driver_aliases"), "w")
-                # Change the entry from whee to wqee.
-                fh.write('wqee "pci8186,4321"\n')
-                fh.close()
-
-                self.pkg("fix drv")
-                self.pkg("verify")
-
-        def test_06_download(self):
-                """Test that pkg fix won't try to download all data for
-                files that fail verification when the data is not going
-                to be used."""
-
-                # If only attributes are wrong and no local modification
-                # is on the file content, fix doesn't need to download the
-                # file data.
-
-                # Test the system attribute.
-                # Need to create an image in /var/tmp since sysattrs don't work
-                # in tmpfs.
-                old_img_path = self.img_path()
-                self.set_img_path(tempfile.mkdtemp(prefix="test-suite",
-                    dir="/var/tmp"))
-                self.image_create(self.durl)
-                self.pkg("install sysattr")
-                self.pkg("verify")
-                fpath = os.path.join(self.img_path(), "amber1")
-
-                # Need to get creative here to remove the system attributes
-                # since you need the sys_linkdir privilege which we don't have:
-                # see run.py:393
-                # So we re-create the file with correct owner and mode and the
-                # only thing missing are the sysattrs.
-                portable.remove(fpath)
-                portable.copyfile(os.path.join(self.test_root, "amber1"),
-                    fpath)
-                os.chmod(fpath, 0o555)
-                os.chown(fpath, -1, 2)
-                self.pkg("verify", exit=1)
-                # Make the repository offline.
-                self.dc.stop()
-                # If only attributes on a file are wrong, pkg fix still
-                # succeeds even if the repository is offline.
-                self.pkg("fix sysattr")
-                self.pkg("verify")
-                self.dc.start()
-                shutil.rmtree(self.img_path())
-
-                # Test other attributes: mode, owner, group and timestamp.
-                self.image_create(self.durl)
-                for p in ("file@1.0-0","preserve@1.0-0", "preserve@1.1-0",
-                        "preserve@1.2-0", "amber@1.0-0", "sysattr-no-overlay@1.0-0"):
-                        pfmri = self.plist[p]
-                        self.pkg("install {0}".format(pfmri))
-                        self.dc.stop()
-                        self.__do_alter_verify(pfmri, parsable=True)
-                        self.pkg("verify --parsable=0 {0}".format(pfmri))
-                        self.pkg("uninstall {0}".format(pfmri))
-                        self.dc.start()
-
-                # If modify the file content locally and its attributes, for the
-                # editable file delivered with preserve=true, fix doesn't need to
-                # download the file data.
-                pfmri = self.plist["preserve@1.0-0"]
-                self.pkg("install {0}".format(pfmri))
-                self.file_append("amber1", "junk")
-                self.dc.stop()
-                self.__do_alter_verify(pfmri, verbose=True)
-                self.pkg("uninstall {0}".format(pfmri))
-                self.dc.start()
-
-                # For editable files delivered with preserve=renamenew or
-                # preserve=renameold, and non-editable files, fix needs to
-                # download the file data.
-                for p in ("file@1.0-0", "preserve@1.1-0", "preserve@1.2-0"):
-                        pfmri = self.plist[p]
-                        self.pkg("install {0}".format(pfmri))
-                        self.file_append("amber1", "junk")
-                        self.dc.stop()
-                        self.__do_alter_verify(pfmri, verbose=True, exit=1)
-                        self.pkg("uninstall {0}".format(pfmri))
-                        self.dc.start()
-
-        def test_fix_changed_manifest(self):
-                """Test that running package fix won't change the manifest of an
-                installed package even if it has changed in the repository."""
-
-                self.image_create(self.rurl)
-                self.pkg("install file")
-
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("fix -v", exit=1)
-
-                # Specify location as filesystem path.
-                self.pkgsign_simple(self.dc.get_repodir(), "file")
-
-                self.pkg("fix", exit=1)
-                # Run it one more time to ensure that the manifest on disk
-                # wasn't changed.
-                self.pkg("fix", exit=1)
-
-        def test_fix_output(self):
-                """Test that the output and exit code works fine for pkg fix."""
-
-                self.image_create(self.rurl)
-                pfmri = self.plist["preserve@1.0-0"]
-                self.pkg("install {0}".format(pfmri))
-                info = "editable file has been changed"
-                # Test that the output is expected when the file has only info
-                # level mistakes.
-                self.file_append("amber1", "junk")
-                self.pkg("fix preserve", exit=4)
-                assert info not in self.output
-                self.pkg("fix -n preserve", exit=4)
-                assert info not in self.output
-
-                self.pkg("fix -v preserve", exit=4)
-                assert info in self.output
-                self.pkg("fix -nv preserve", exit=4)
-                assert info in self.output
-
-                self.pkg("fix -q preserve", exit=4)
-                assert(self.output == "")
-
-                # Test that the output is expected when the file has both info
-                # and error level mistakes.
-                self.__do_alter_verify(pfmri)
-                assert info not in self.output
-                self.__do_alter_verify(pfmri, verbose=True)
-                assert info in self.output
-                self.__do_alter_verify(pfmri, quiet=True)
-                assert(self.output == "")
-
-        def __do_alter_only_verify(self, pfmri, verbose=False, quiet=False, exit=0,
-            parsable=False, debug=""):
-                # Alter the owner, group, mode of all files (and
-                # directories) to something different than the package declares.
-                m = manifest.Manifest()
-                m.set_content(self.get_img_manifest(pfmri))
-                for a in m.gen_actions():
-                        if a.name not in ("file", "dir"):
-                                # Only want file or dir actions.
-                                continue
-
-                        ubin = portable.get_user_by_name("bin", None, False)
-                        groot = portable.get_group_by_name("root", None, False)
-
-                        fname = a.attrs["path"]
-                        fpath = os.path.join(self.get_img_path(), fname)
-                        os.chown(fpath, ubin, groot)
-                        os.chmod(fpath, misc.PKG_RO_FILE_MODE)
-
-                verify_cmd = "verify"
-                if verbose:
-                        verify_cmd += " -v"
-                if quiet:
-                        verify_cmd += " -q"
-                if parsable:
-                        verify_cmd += " --parsable=0"
-
-                self.pkg("{0}{1} {2}".format(debug, verify_cmd, pfmri),
-                    exit=exit)
-                if exit == 0:
-                        self.assertTrue("OK" in self.output and "ERROR" not
-                            in self.output)
-                return exit
-
-        def __check_overlay_attr_verify(self, pkg, exit=0, new_img=True, debug=""):
-                if new_img:
-                        self.image_create(self.rurl)
-                pfmri = self.plist[pkg]
-                self.pkg("-D broken-conflicting-action-handling=1 install {0}".format(pkg))
-                return self.__do_alter_only_verify(pfmri, exit=exit, verbose=True, debug=debug)
-
-        def __check_overlay_attr_fix(self, pkg, exit=0, new_img=True):
-                if new_img:
-                        self.image_create(self.rurl)
-                pfmri = self.plist[pkg]
-                self.pkg("-D broken-conflicting-action-handling=1 install {0}".format(pkg))
-                return self.__do_alter_verify(pfmri, exit=exit, verbose=True)
-
-        def test_verify_fix_overlay_attributes(self):
-                """Test verify/fix behaviour for overlay-attributes attribute."""
-
-                # Changing on-disk action attributes should always fail.
-                self.__check_overlay_attr_verify("gss@1.0-0", exit=1)
-                # Changing on-disk action attributes should always fail.
-                self.__check_overlay_attr_verify("krb5@1.0-0", exit=1,
-                    new_img=False)
-                self.assertTrue("(from " not in self.output)
-                file_path = "etc/gss/mech"
-                self.pkg("verify -v -p {0}".format(file_path), exit=1)
-                self.assertTrue("pkg://test/gss" in self.output)
-                self.assertTrue("pkg://test/krb5" in self.output)
-                self.assertTrue("ERROR: owner: 'bin (2)' should be 'root (0)'"
-                    in self.output)
-
-                # Verify overlaid package should turn into checking its
-                # overlaying action (the on-disk one), and fail.
-                self.__do_alter_only_verify(self.plist["gss@1.0-0"],
-                    verbose=True, exit=1)
-                self.assertTrue("(from pkg:/krb5" in self.output)
-                # Verify all packages.
-                self.pkg("verify -v", exit=1)
-
-                # Changing on-disk action attributes should always fail.
-                self.__check_overlay_attr_verify("gss-no-attr@1.0-0", exit=1)
-                # Changing on-disk action attributes should always fail.
-                self.__check_overlay_attr_verify("krb5-no-attr@1.0-0", exit=1,
-                    new_img=False)
-                # Verify overlaid package should turn into checking its
-                # overlaying action (the on-disk one), and fail.
-                self.__do_alter_only_verify(self.plist["gss-no-attr@1.0-0"],
-                    verbose=True, exit=1)
-                self.assertTrue("(from pkg:/krb5" in self.output)
-                self.assertTrue("Overlaid package: pkg://test/gss-no-attr"
-                    in self.output)
-                self.assertTrue("mode: 0664 does not match overlaid package mode: 0644"
-                    in self.output)
-                # Verify all packages.
-                self.pkg("verify -v", exit=1)
-                self.assertTrue("Overlaid package" in self.output)
-
-                self.pkg("verify -v -p {0}".format(file_path), exit=1)
-                self.assertTrue("pkg://test/krb5-no-attr" in self.output)
-                self.assertTrue("pkg://test/gss-no-attr" in self.output)
-                self.assertTrue("ERROR: owner: 'bin (2)' should be 'root (0)'"
-                    in self.output)
-
-                # Changing on-disk action attributes should always fail.
-                self.__check_overlay_attr_verify("gss-attr-allow@1.0-0", exit=1)
-
-                # Changing on-disk action attributes should always fail.
-                exit = self.__check_overlay_attr_verify("krb5-attr-allow@1.0-0",
-                    exit=1, new_img=False)
-                self.assertTrue(exit == 1)
-                self.assertTrue("(from " not in self.output)
-
-                # Verify overlaid package should still fail, because it
-                # turn into checking its overlaying action (the on-disk one).
-                self.__do_alter_only_verify(self.plist["gss-attr-allow@1.0-0"],
-                    verbose=True, exit=1)
-                self.assertTrue("(from pkg:/krb5" in self.output)
-                self.assertTrue("Overlaid package: pkg://test/gss-attr-allow"
-                    in self.output)
-                self.assertTrue("mode: 0664 does not match overlaid package mode: 0644"
-                    in self.output)
-                # Verify all packages.
-                self.pkg("verify -v", exit=1)
-                self.assertTrue("Overlaid package" in self.output)
-
-                # Changing on-disk action should always fail.
-                exit = self.__check_overlay_attr_verify("gss-attr-deny@1.0-0", exit=1)
-                self.assertTrue(exit == 1)
-                self.assertTrue("(from " not in self.output)
-
-                # Verify overlaid package should still fail, because it
-                # turn into checking its overlaying action (the on-disk one).
-                exit = self.__check_overlay_attr_verify("krb5-attr-deny@1.0-0",
-                    exit=1, new_img=False, debug="-D broken-conflicting-action-handling=1 ")
-                self.assertTrue("(from " not in self.output)
-                self.assertTrue(exit == 1)
-
-                # Verify overlaid package should turn into checking its
-                # overlaying action (the on-disk one), and fail.
-                self.__do_alter_only_verify(self.plist["gss-attr-deny@1.0-0"],
-                    verbose=True, exit=1, debug="-D broken-conflicting-action-handling=1 ")
-                self.assertTrue("(from pkg:/krb5" in self.output)
-                self.assertTrue("Overlaid package: pkg://test/gss-attr-deny"
-                    in self.output)
-                self.assertTrue("ERROR: mode: 0664 does not match overlaid package mode: 0644"
-                    in self.output)
-                # Verify all packages.
-                self.pkg("-D broken-conflicting-action-handling=1 verify -v", exit=1)
-                self.assertTrue("Overlaid package" in self.output)
-                self.assertTrue("ERROR: mode: 0664 does not match overlaid package mode: 0644"
-                    in self.output)
-
-                # Should be fixed, since on-disk actions should not be changed.
-                exit = self.__check_overlay_attr_fix("gss@1.0-0", exit=0)
-
-                # Should be fixed, since on-disk actions should not be changed.
-                self.__check_overlay_attr_fix("krb5@1.0-0")
-
-                # Should be fixed, since on-disk actions should not be changed.
-                exit = self.__check_overlay_attr_fix("gss-attr-allow@1.0-0", exit=0)
-                # Should be fixed, since on-disk actions should not be changed.
-                self.__check_overlay_attr_fix("krb5-attr-allow@1.0-0",
-                    exit=0, new_img=False)
-                # The on-disk overlaying action should be fixed.
-                self.__do_alter_verify(self.plist["gss-attr-allow@1.0-0"],
-                    exit=0, verbose=True, validate=False)
-                # Post verify the above has been fixed.
-                self.pkg("verify -v gss-attr-allow@1.0-0")
-                self.assertTrue("Overlaid package" in self.output)
-                self.pkg("verify krb5-attr-allow@1.0-0")
-
-                # Should be fixed, since on-disk actions should not be changed.
-                self.__check_overlay_attr_fix("gss-attr-deny@1.0-0")
-
-                # Should be fixed, since on-disk actions should not be changed.
-                self.__check_overlay_attr_fix("krb5-attr-deny@1.0-0")
-
-        def test_fix_overlay(self):
-                """Test that pkg verify / fix should tell the users to look at
-                the overlaying package in the error message if fix won't repair
-                the overlaid package."""
-
-                file_path = "etc/gss/mech"
-                file_path_1 = "etc/gss/mech_1"
-                self.image_create(self.rurl)
-                pfmri_gss = self.plist["gss@1.0-0"]
-                pfmri_krb = self.plist["krb5@1.0-0"]
-                pfmri_sysattr = self.plist["sysattr@1.0-0"]
-                pfmri_sysattr_o = self.plist["sysattr_overlay@1.0-0"]
-
-                # First, only install the package that has a file with
-                # attribute overlay=allow.
-                self.pkg("install gss")
-
-                # Path verification should report ok.
-                self.pkg("verify -v -p {0}".format(file_path))
-                self.assertTrue("OK" in self.output and file_path not in self.output
-                    and pfmri_gss.get_pkg_stem() in self.output)
-
-                self.file_exists(file_path)
-                self.file_remove(file_path)
-                self.file_doesnt_exist(file_path)
-
-                # Verify should report an error if the file is missing.
-                self.pkg("verify -v gss", exit=1)
-
-                # Path verification should report error.
-                self.pkg("verify -v -p {0}".format(file_path), exit=1)
-                self.assertTrue("OK" not in self.output and "ERROR" in self.output)
-                self.assertTrue(file_path in self.output and \
-                    pfmri_gss.get_pkg_stem() in self.output)
-
-                # Fix should be able to repair the file.
-                self.pkg("fix -v gss")
-                self.file_exists(file_path)
-                # On-disk action attributes should be changed and should be
-                # fixed.
-                self.__do_alter_verify(pfmri_gss, exit=0)
-
-                # Install the overlaying package.
-                self.pkg("install krb5")
-
-                # Path verification should report ok for both the overlaid package
-                # and the overlaying package.
-                self.pkg("verify -v -p {0}".format(file_path))
-                self.assertTrue(self.output.count("OK") == 2
-                    and "ERROR" not in self.output)
-                self.assertTrue(pfmri_krb.get_pkg_stem() in self.output
-                    and pfmri_gss.get_pkg_stem() in self.output)
-
-                self.pkg("verify -v -p {0} gss".format(file_path))
-                self.assertTrue(self.output.count("OK") == 2
-                    and "ERROR" not in self.output)
-                self.assertTrue(pfmri_krb.get_pkg_stem() in self.output
-                    and pfmri_gss.get_pkg_stem() in self.output)
-
-                self.file_exists(file_path)
-                self.file_remove(file_path)
-                self.file_doesnt_exist(file_path)
-
-                # Path verification should report error for both the overlaid package
-                # and the overlaying package.
-                self.pkg("verify -v -p {0}".format(file_path), exit=1)
-                self.assertTrue("OK" not in self.output
-                    and self.output.count("ERROR") == 4)
-                self.assertTrue(pfmri_krb.get_pkg_stem() in self.output
-                    and pfmri_gss.get_pkg_stem() in self.output)
-
-                self.pkg("verify -v -p {0} gss".format(file_path), exit=1)
-                self.assertTrue("OK" not in self.output
-                    and self.output.count("ERROR") == 4)
-                self.assertTrue(pfmri_krb.get_pkg_stem() in self.output
-                    and pfmri_gss.get_pkg_stem() in self.output)
-
-                # Now pkg verify should still report an error on the overlaid
-                # package and tell the users it is from the overlaying package.
-                self.pkg("verify gss", exit=1)
-                self.assertTrue("from {0}".format(
-                    pfmri_krb.get_pkg_stem(anarchy=True)) in self.output)
-                # Verify should report an error on the overlaying package.
-                self.pkg("verify krb5", exit=1)
-                # Fix will fix the overlaying action (from krb5) for gss
-                # directly.
-                self.pkg("fix gss")
-                self.file_exists(file_path)
-
-                # Fix has fixed that one before.
-                self.pkg("fix -v pkg:/krb5", exit=4)
-                self.pkg("verify gss")
-                self.file_exists(file_path)
-
-                # Test that multiple overlaid files are missing.
-                self.file_remove(file_path)
-                self.file_remove(file_path_1)
-                self.pkg("verify gss", exit=1)
-                self.pkg("fix krb5")
-
-                # Test the owner, group and mode change.
-                self.__do_alter_verify(pfmri_gss, verbose=True)
-                self.__do_alter_verify(pfmri_krb, verbose=True)
-
-                # Test that verify / fix on system wide could report / fix the
-                # error on the overlaid and overlaying packges.
-                self.file_remove(file_path)
-                self.pkg("verify", exit=1)
-                self.assertTrue("(from " in self.output)
-                self.pkg("fix")
-                self.assertTrue("(from " in self.output)
-                self.pkg("verify")
-                self.file_exists(file_path)
-
-                # Test different file types install. Since fix will repair the
-                # overlaid package in this case, we don't need to tell the users
-                # to look at the overlaying package.
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupfile duplink")
-                self.pkg("verify dupfile", exit=1)
-                self.pkg("fix dupfile")
-                self.pkg("verify dupfile")
-
-                # Test overlaid package that contains system attribute error.
-                self.set_img_path(tempfile.mkdtemp(prefix="test-suite",
-                    dir="/var/tmp"))
-                self.image_create(self.rurl)
-                self.pkg("install sysattr")
-                fpath = os.path.join(self.img_path(), "amber1")
-
-                # Install the overlaying package.
-                self.pkg("install sysattr_overlay")
-                portable.remove(fpath)
-                portable.copyfile(os.path.join(self.test_root, "amber1"),
-                    fpath)
-                os.chmod(fpath, 0o555)
-                os.chown(fpath, -1, 2)
-                self.pkg("verify sysattr", exit=1)
-                self.pkg("fix -v sysattr")
-                self.assertTrue("from {0}".format(
-                    pfmri_sysattr_o.get_pkg_stem(anarchy=True)) in self.output)
-                self.pkg("fix sysattr_overlay", exit=4)
-                self.pkg("verify sysattr")
-                self.image_destroy()
-
-        def test_fix_with_ftpuser(self):
-            """ Test to check pkg fix works fine for the package which
-            delivers ftpuser file"""
-
-            file_path = "etc/ftpd/ftpusers"
-            pfmri_ftpd = self.plist["ftpd@1.0-0"]
+""",
+    }
+
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
+        self.make_misc_files(self.misc_files)
+        self.make_misc_files(self.misc_files2)
+        self.make_misc_files(self.misc_ftpfile)
+        # Grab a well known ELF file so it can be used for ELF tests.
+        portable.copyfile("/usr/bin/ls", os.path.join(self.test_root, "ls"))
+        self.plist = {}
+        for p in self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.amber10,
+                self.licensed13,
+                self.dir10,
+                self.file10,
+                self.preserve10,
+                self.preserve11,
+                self.preserve12,
+                self.driver10,
+                self.driver_prep10,
+                self.sysattr,
+                self.sysattr_no_overlay,
+                self.sysattr_o,
+                self.gss,
+                self.krb,
+                self.pkg_dupfile,
+                self.pkg_duplink,
+                self.mismatched_attr,
+                self.ftpd,
+            ),
+        ):
+            pfmri = fmri.PkgFmri(p)
+            old_publisher = pfmri.publisher
+            pfmri.publisher = None
+            sfmri = pfmri.get_short_fmri().replace("pkg:/", "")
+            self.plist[sfmri] = pfmri
+            pfmri.publisher = old_publisher
+
+    def test_01_basics(self):
+        """Basic fix test: install the amber package, modify one of the
+        files, and make sure it gets fixed."""
+
+        self.image_create(self.rurl)
+        self.pkg("install amber@1.0")
+
+        # Test invalid option combo.
+        self.pkg("fix -v --parsable 0 foo", exit=2)
+        self.pkg("fix -H --parsable 0 foo", exit=2)
+        # Test invalid option value.
+        self.pkg("fix --parsable 1 foo", exit=2)
+
+        # Test parsable output.
+        self.pkg("fix --parsable 0 amber", exit=4)
+        out_json = json.loads(self.output)
+        item_id = list(out_json["item-messages"].keys())[0]
+        self.assertTrue(
+            out_json["item-messages"][item_id]["messages"][0]["msg_level"]
+            == "info"
+        )
+
+        # Test unpackaged option.
+        self.pkg("fix --unpackaged", exit=4)
+        self.pkg("fix --parsable 0 --unpackaged", exit=4)
+        out_json = json.loads(self.output)
+        subitem_id = list(out_json["item-messages"]["unpackaged"].keys())[0]
+        self.assertTrue(
+            out_json["item-messages"]["unpackaged"][subitem_id][0]["msg_level"]
+            == "info"
+        )
+
+        index_dir = self.get_img_api_obj().img.index_dir
+        index_file = os.path.join(index_dir, "main_dict.ascii.v2")
+        orig_mtime = os.stat(index_file).st_mtime
+        time.sleep(1)
+
+        victim = "etc/amber2"
+        # Initial size
+        size1 = self.file_size(victim)
+
+        # Corrupt the file
+        self.file_append(victim, "foobar")
+
+        # Make sure the size actually changed
+        size2 = self.file_size(victim)
+        self.assertNotEqual(size1, size2)
+
+        # Verify that unprivileged users are handled by fix.
+        self.pkg("fix amber", exit=1, su_wrap=True)
+
+        self.pkg("fix --unpackaged -nv amber")
+        self.assertTrue("----" in self.output and "UNPACKAGED" in self.output)
+
+        # Fix the package
+        self.pkg("fix amber")
+
+        # Make sure it's the same size as the original
+        size2 = self.file_size(victim)
+        self.assertEqual(size1, size2)
+
+        # check that we didn't reindex
+        new_mtime = os.stat(index_file).st_mtime
+        self.assertEqual(orig_mtime, new_mtime)
+
+        # Using the same methodology as above, verify that a corrupted
+        # ELF file can be fixed (the corruption being such that libelf
+        # fails on the file).
+        victim = "usr/bin/ls"
+        size1 = self.file_size(victim)
+        self.file_remove(victim)
+        self.file_append(victim, "This is not an ELF")
+        self.pkg("fix amber")
+        self.assertTrue("ELF failure:" in self.output)
+        size2 = self.file_size(victim)
+        self.assertEqual(size1, size2)
+
+        # Verify that text appended to an ELF file is fixed.
+        self.file_append(victim, "Extra text at end of file")
+        self.pkg("fix amber")
+        self.assertTrue("ERROR: Hash:" in self.output)
+        size2 = self.file_size(victim)
+        self.assertEqual(size1, size2)
+
+        # Verify that removing the publisher of a package that needs
+        # fixing results in graceful failure (not a traceback).
+        victim = "etc/amber2"
+        self.file_append(victim, "foobar")
+        self.pkg("set-publisher -P --no-refresh -g {0} foo".format(self.rurl))
+        self.pkg("unset-publisher test")
+        self.pkg("fix", exit=1)
+
+    def test_02_hardlinks(self):
+        """Hardlink test: make sure that a file getting fixed gets any
+        hardlinks that point to it updated"""
+
+        self.image_create(self.rurl)
+        self.pkg("install amber@1.0")
+
+        victim = "etc/amber1"
+        victimlink = "etc/amber.hardlink"
+
+        self.file_append(victim, "foobar")
+        self.pkg("fix amber")
+
+        # Get the inode of the orig file
+        i1 = self.file_inode(victim)
+        # Get the inode of the new hardlink
+        i2 = self.file_inode(victimlink)
+
+        # Make sure the inode of the link is now different
+        self.assertEqual(i1, i2)
+
+    def test_03_license(self):
+        """Verify that fix works with licenses that require acceptance
+        and/or display."""
+
+        self.image_create(self.rurl)
+        self.pkg("install --accept licensed@1.3")
+
+        victim = "lib/libc.so.1"
+
+        # Initial size
+        size1 = self.file_size(victim)
+
+        # Corrupt the file
+        self.file_append(victim, "foobar")
+
+        # Make sure the size actually changed
+        size2 = self.file_size(victim)
+        self.assertNotEqual(size1, size2)
+
+        # Verify that the fix will fail if the license file needs fixing
+        # since the license action requires acceptance.
+        img = self.get_img_api_obj().img
+        shutil.rmtree(os.path.join(img.imgdir, "license"))
+        self.pkg("fix licensed", exit=6)
+
+        # Verify that when the fix failed, it displayed the license
+        # that required display.
+        self.pkg("fix licensed | grep 'copyright.licensed'")
+        self.pkg("fix licensed | grep -v 'license.licensed'")
+
+        # Verify that fix will display all licenses when it fails,
+        # if provided the --licenses option.
+        self.pkg("fix --licenses licensed | grep 'license.licensed'")
+
+        # Finally, verify that fix will succeed when a package requires
+        # license acceptance if provided the --accept option.
+        self.pkg("fix --accept licensed")
+
+        # Make sure it's the same size as the original
+        size2 = self.file_size(victim)
+        self.assertEqual(size1, size2)
+
+    def __do_alter_verify(
+        self,
+        pfmri,
+        verbose=False,
+        quiet=False,
+        exit=0,
+        parsable=False,
+        validate=True,
+    ):
+        # Alter the owner, group, mode, and timestamp of all files (and
+        # directories) to something different than the package declares.
+        m = manifest.Manifest()
+        m.set_content(self.get_img_manifest(pfmri))
+        ctime = time.time() - 1000
+        for a in m.gen_actions():
+            if a.name not in ("file", "dir"):
+                # Only want file or dir actions.
+                continue
+
+            ubin = portable.get_user_by_name("bin", None, False)
+            groot = portable.get_group_by_name("root", None, False)
+
+            fname = a.attrs["path"]
+            fpath = os.path.join(self.get_img_path(), fname)
+            os.chown(fpath, ubin, groot)
+            os.chmod(fpath, misc.PKG_RO_FILE_MODE)
+            os.utime(fpath, (ctime, ctime))
+
+        # Call pkg fix to fix them.
+        fix_cmd = "fix"
+        if verbose:
+            fix_cmd += " -v"
+        if quiet:
+            fix_cmd += " -q"
+        if parsable:
+            fix_cmd += " --parsable=0"
+
+        self.pkg("{0} {1}".format(fix_cmd, pfmri), exit=exit)
+        if exit != 0:
+            return exit
+
+        editables = []
+        # For actions being overlaid, the following logic will
+        # not report correct validation results because it is
+        # only against the overlaid fmri. So we just return.
+        if not validate:
+            return
+
+        # Now verify that fix actually fixed them.
+        for a in m.gen_actions():
+            if a.name not in ("file", "dir"):
+                # Only want file or dir actions.
+                continue
+
+            # Validate standard attributes.
+            self.validate_fsobj_attrs(a)
+
+            # Now validate attributes that require special handling.
+            fname = a.attrs["path"]
+            fpath = os.path.join(self.get_img_path(), fname)
+            lstat = os.lstat(fpath)
+
+            # Verify that preserved files don't get renamed, and
+            # the new ones are not installed if the file wasn't
+            # missing already.
+            preserve = a.attrs.get("preserve")
+            if preserve == "renamenew":
+                self.assertTrue(not os.path.exists(fpath + ".new"))
+            elif preserve == "renameold":
+                self.assertTrue(not os.path.exists(fpath + ".old"))
+
+            if preserve:
+                editables.append("{0}".format(a.attrs["path"]))
+
+            # Verify timestamp (if applicable).
+            ts = a.attrs.get("timestamp")
+            if ts:
+                expected = misc.timestamp_to_time(ts)
+                actual = lstat.st_mtime
+                if preserve:
+                    self.assertNotEqual(
+                        expected,
+                        actual,
+                        "timestamp expected {expected} == "
+                        "actual {actual} for "
+                        "{fname}".format(
+                            expected=expected, actual=actual, fname=fname
+                        ),
+                    )
+                else:
+                    self.assertEqual(
+                        expected,
+                        actual,
+                        "timestamp expected {expected} != "
+                        "actual {actual} for "
+                        "{fname}".format(
+                            expected=expected, actual=actual, fname=fname
+                        ),
+                    )
+
+        # Verify the parsable output (if applicable).
+        if parsable:
+            if editables:
+                self.assertEqualParsable(
+                    self.output,
+                    affect_packages=["{0}".format(pfmri)],
+                    change_editables=[["updated", editables]],
+                )
+            else:
+                self.assertEqualParsable(
+                    self.output, affect_packages=["{0}".format(pfmri)]
+                )
+
+    def test_04_permissions(self):
+        """Ensure that files and directories will have their owner,
+        group, and modes fixed."""
+
+        self.image_create(self.rurl)
+
+        # Because fix and install operations for directories and
+        # files can indirectly interact, each package must be
+        # tested separately and then together (by using a package
+        # with a mix of files and directories).
+        for p in (
+            "dir@1.0-0",
+            "file@1.0-0",
+            "preserve@1.0-0",
+            "preserve@1.1-0",
+            "preserve@1.2-0",
+            "amber@1.0-0",
+        ):
+            pfmri = self.plist[p]
+            self.pkg("install {0}".format(pfmri))
+            self.__do_alter_verify(pfmri)
+            self.pkg("verify {0}".format(pfmri))
+            self.pkg("uninstall {0}".format(pfmri))
+
+    def test_05_driver(self):
+        """Verify that fixing a name collision for drivers doesn't
+        cause a stack trace. Bug 14948"""
+
+        self.image_create(self.rurl)
+
+        self.pkg("install drv-prep")
+        self.pkg("install drv")
+
+        fh = open(
+            os.path.join(self.get_img_path(), "etc", "driver_aliases"), "w"
+        )
+        # Change the entry from whee to wqee.
+        fh.write('wqee "pci8186,4321"\n')
+        fh.close()
+
+        self.pkg("fix drv")
+        self.pkg("verify")
+
+    def test_06_download(self):
+        """Test that pkg fix won't try to download all data for
+        files that fail verification when the data is not going
+        to be used."""
+
+        # If only attributes are wrong and no local modification
+        # is on the file content, fix doesn't need to download the
+        # file data.
+
+        # Test the system attribute.
+        # Need to create an image in /var/tmp since sysattrs don't work
+        # in tmpfs.
+        old_img_path = self.img_path()
+        self.set_img_path(tempfile.mkdtemp(prefix="test-suite", dir="/var/tmp"))
+        self.image_create(self.durl)
+        self.pkg("install sysattr")
+        self.pkg("verify")
+        fpath = os.path.join(self.img_path(), "amber1")
+
+        # Need to get creative here to remove the system attributes
+        # since you need the sys_linkdir privilege which we don't have:
+        # see run.py:393
+        # So we re-create the file with correct owner and mode and the
+        # only thing missing are the sysattrs.
+        portable.remove(fpath)
+        portable.copyfile(os.path.join(self.test_root, "amber1"), fpath)
+        os.chmod(fpath, 0o555)
+        os.chown(fpath, -1, 2)
+        self.pkg("verify", exit=1)
+        # Make the repository offline.
+        self.dc.stop()
+        # If only attributes on a file are wrong, pkg fix still
+        # succeeds even if the repository is offline.
+        self.pkg("fix sysattr")
+        self.pkg("verify")
+        self.dc.start()
+        shutil.rmtree(self.img_path())
+
+        # Test other attributes: mode, owner, group and timestamp.
+        self.image_create(self.durl)
+        for p in (
+            "file@1.0-0",
+            "preserve@1.0-0",
+            "preserve@1.1-0",
+            "preserve@1.2-0",
+            "amber@1.0-0",
+            "sysattr-no-overlay@1.0-0",
+        ):
+            pfmri = self.plist[p]
+            self.pkg("install {0}".format(pfmri))
+            self.dc.stop()
+            self.__do_alter_verify(pfmri, parsable=True)
+            self.pkg("verify --parsable=0 {0}".format(pfmri))
+            self.pkg("uninstall {0}".format(pfmri))
+            self.dc.start()
+
+        # If modify the file content locally and its attributes, for the
+        # editable file delivered with preserve=true, fix doesn't need to
+        # download the file data.
+        pfmri = self.plist["preserve@1.0-0"]
+        self.pkg("install {0}".format(pfmri))
+        self.file_append("amber1", "junk")
+        self.dc.stop()
+        self.__do_alter_verify(pfmri, verbose=True)
+        self.pkg("uninstall {0}".format(pfmri))
+        self.dc.start()
+
+        # For editable files delivered with preserve=renamenew or
+        # preserve=renameold, and non-editable files, fix needs to
+        # download the file data.
+        for p in ("file@1.0-0", "preserve@1.1-0", "preserve@1.2-0"):
+            pfmri = self.plist[p]
+            self.pkg("install {0}".format(pfmri))
+            self.file_append("amber1", "junk")
+            self.dc.stop()
+            self.__do_alter_verify(pfmri, verbose=True, exit=1)
+            self.pkg("uninstall {0}".format(pfmri))
+            self.dc.start()
+
+    def test_fix_changed_manifest(self):
+        """Test that running package fix won't change the manifest of an
+        installed package even if it has changed in the repository."""
+
+        self.image_create(self.rurl)
+        self.pkg("install file")
+
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("fix -v", exit=1)
+
+        # Specify location as filesystem path.
+        self.pkgsign_simple(self.dc.get_repodir(), "file")
+
+        self.pkg("fix", exit=1)
+        # Run it one more time to ensure that the manifest on disk
+        # wasn't changed.
+        self.pkg("fix", exit=1)
+
+    def test_fix_output(self):
+        """Test that the output and exit code works fine for pkg fix."""
+
+        self.image_create(self.rurl)
+        pfmri = self.plist["preserve@1.0-0"]
+        self.pkg("install {0}".format(pfmri))
+        info = "editable file has been changed"
+        # Test that the output is expected when the file has only info
+        # level mistakes.
+        self.file_append("amber1", "junk")
+        self.pkg("fix preserve", exit=4)
+        assert info not in self.output
+        self.pkg("fix -n preserve", exit=4)
+        assert info not in self.output
+
+        self.pkg("fix -v preserve", exit=4)
+        assert info in self.output
+        self.pkg("fix -nv preserve", exit=4)
+        assert info in self.output
+
+        self.pkg("fix -q preserve", exit=4)
+        assert self.output == ""
+
+        # Test that the output is expected when the file has both info
+        # and error level mistakes.
+        self.__do_alter_verify(pfmri)
+        assert info not in self.output
+        self.__do_alter_verify(pfmri, verbose=True)
+        assert info in self.output
+        self.__do_alter_verify(pfmri, quiet=True)
+        assert self.output == ""
+
+    def __do_alter_only_verify(
+        self,
+        pfmri,
+        verbose=False,
+        quiet=False,
+        exit=0,
+        parsable=False,
+        debug="",
+    ):
+        # Alter the owner, group, mode of all files (and
+        # directories) to something different than the package declares.
+        m = manifest.Manifest()
+        m.set_content(self.get_img_manifest(pfmri))
+        for a in m.gen_actions():
+            if a.name not in ("file", "dir"):
+                # Only want file or dir actions.
+                continue
+
+            ubin = portable.get_user_by_name("bin", None, False)
+            groot = portable.get_group_by_name("root", None, False)
+
+            fname = a.attrs["path"]
+            fpath = os.path.join(self.get_img_path(), fname)
+            os.chown(fpath, ubin, groot)
+            os.chmod(fpath, misc.PKG_RO_FILE_MODE)
+
+        verify_cmd = "verify"
+        if verbose:
+            verify_cmd += " -v"
+        if quiet:
+            verify_cmd += " -q"
+        if parsable:
+            verify_cmd += " --parsable=0"
+
+        self.pkg("{0}{1} {2}".format(debug, verify_cmd, pfmri), exit=exit)
+        if exit == 0:
+            self.assertTrue("OK" in self.output and "ERROR" not in self.output)
+        return exit
+
+    def __check_overlay_attr_verify(self, pkg, exit=0, new_img=True, debug=""):
+        if new_img:
             self.image_create(self.rurl)
+        pfmri = self.plist[pkg]
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install {0}".format(pkg)
+        )
+        return self.__do_alter_only_verify(
+            pfmri, exit=exit, verbose=True, debug=debug
+        )
 
-            # First, only install the package that has a file with
-            # the attribute ftpuser=true. Not to be confused with the
-            # user action attribute of ftpuser=false
-            self.pkg("install ftpd")
+    def __check_overlay_attr_fix(self, pkg, exit=0, new_img=True):
+        if new_img:
+            self.image_create(self.rurl)
+        pfmri = self.plist[pkg]
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install {0}".format(pkg)
+        )
+        return self.__do_alter_verify(pfmri, exit=exit, verbose=True)
 
-            # Path verification should report ok.
-            self.pkg("verify -v -p {0}".format(file_path))
-            self.assertTrue("OK" in self.output)
+    def test_verify_fix_overlay_attributes(self):
+        """Test verify/fix behaviour for overlay-attributes attribute."""
 
-            # Check whether the users are present in the file
-            self.file_contains(file_path,"root")
-            self.file_contains(file_path,"daemon")
-            self.file_exists(file_path)
-            # remove the file and check the same
-            self.file_remove(file_path)
-            self.file_doesnt_exist(file_path)
+        # Changing on-disk action attributes should always fail.
+        self.__check_overlay_attr_verify("gss@1.0-0", exit=1)
+        # Changing on-disk action attributes should always fail.
+        self.__check_overlay_attr_verify("krb5@1.0-0", exit=1, new_img=False)
+        self.assertTrue("(from " not in self.output)
+        file_path = "etc/gss/mech"
+        self.pkg("verify -v -p {0}".format(file_path), exit=1)
+        self.assertTrue("pkg://test/gss" in self.output)
+        self.assertTrue("pkg://test/krb5" in self.output)
+        self.assertTrue(
+            "ERROR: owner: 'bin (2)' should be 'root (0)'" in self.output
+        )
 
-            # Verify should report an error if the file is missing.
-            self.pkg("verify -v ftpd", exit=1)
+        # Verify overlaid package should turn into checking its
+        # overlaying action (the on-disk one), and fail.
+        self.__do_alter_only_verify(
+            self.plist["gss@1.0-0"], verbose=True, exit=1
+        )
+        self.assertTrue("(from pkg:/krb5" in self.output)
+        # Verify all packages.
+        self.pkg("verify -v", exit=1)
 
-            # Path verification should report error.
-            self.pkg("verify -v -p {0}".format(file_path), exit=1)
-            self.assertTrue("OK" not in self.output and
-                    "ERROR" in self.output)
-            self.assertTrue(file_path in self.output and
-                    pfmri_ftpd.get_pkg_stem() in self.output)
+        # Changing on-disk action attributes should always fail.
+        self.__check_overlay_attr_verify("gss-no-attr@1.0-0", exit=1)
+        # Changing on-disk action attributes should always fail.
+        self.__check_overlay_attr_verify(
+            "krb5-no-attr@1.0-0", exit=1, new_img=False
+        )
+        # Verify overlaid package should turn into checking its
+        # overlaying action (the on-disk one), and fail.
+        self.__do_alter_only_verify(
+            self.plist["gss-no-attr@1.0-0"], verbose=True, exit=1
+        )
+        self.assertTrue("(from pkg:/krb5" in self.output)
+        self.assertTrue(
+            "Overlaid package: pkg://test/gss-no-attr" in self.output
+        )
+        self.assertTrue(
+            "mode: 0664 does not match overlaid package mode: 0644"
+            in self.output
+        )
+        # Verify all packages.
+        self.pkg("verify -v", exit=1)
+        self.assertTrue("Overlaid package" in self.output)
 
-            # Fix should be able to repair the file.
-            self.pkg("fix -v ftpd")
-            self.file_exists(file_path)
-            self.file_contains(file_path, "root")
-            self.file_contains(file_path,"daemon")
-            self.__do_alter_verify(pfmri_ftpd, exit=0)
+        self.pkg("verify -v -p {0}".format(file_path), exit=1)
+        self.assertTrue("pkg://test/krb5-no-attr" in self.output)
+        self.assertTrue("pkg://test/gss-no-attr" in self.output)
+        self.assertTrue(
+            "ERROR: owner: 'bin (2)' should be 'root (0)'" in self.output
+        )
+
+        # Changing on-disk action attributes should always fail.
+        self.__check_overlay_attr_verify("gss-attr-allow@1.0-0", exit=1)
+
+        # Changing on-disk action attributes should always fail.
+        exit = self.__check_overlay_attr_verify(
+            "krb5-attr-allow@1.0-0", exit=1, new_img=False
+        )
+        self.assertTrue(exit == 1)
+        self.assertTrue("(from " not in self.output)
+
+        # Verify overlaid package should still fail, because it
+        # turn into checking its overlaying action (the on-disk one).
+        self.__do_alter_only_verify(
+            self.plist["gss-attr-allow@1.0-0"], verbose=True, exit=1
+        )
+        self.assertTrue("(from pkg:/krb5" in self.output)
+        self.assertTrue(
+            "Overlaid package: pkg://test/gss-attr-allow" in self.output
+        )
+        self.assertTrue(
+            "mode: 0664 does not match overlaid package mode: 0644"
+            in self.output
+        )
+        # Verify all packages.
+        self.pkg("verify -v", exit=1)
+        self.assertTrue("Overlaid package" in self.output)
+
+        # Changing on-disk action should always fail.
+        exit = self.__check_overlay_attr_verify("gss-attr-deny@1.0-0", exit=1)
+        self.assertTrue(exit == 1)
+        self.assertTrue("(from " not in self.output)
+
+        # Verify overlaid package should still fail, because it
+        # turn into checking its overlaying action (the on-disk one).
+        exit = self.__check_overlay_attr_verify(
+            "krb5-attr-deny@1.0-0",
+            exit=1,
+            new_img=False,
+            debug="-D broken-conflicting-action-handling=1 ",
+        )
+        self.assertTrue("(from " not in self.output)
+        self.assertTrue(exit == 1)
+
+        # Verify overlaid package should turn into checking its
+        # overlaying action (the on-disk one), and fail.
+        self.__do_alter_only_verify(
+            self.plist["gss-attr-deny@1.0-0"],
+            verbose=True,
+            exit=1,
+            debug="-D broken-conflicting-action-handling=1 ",
+        )
+        self.assertTrue("(from pkg:/krb5" in self.output)
+        self.assertTrue(
+            "Overlaid package: pkg://test/gss-attr-deny" in self.output
+        )
+        self.assertTrue(
+            "ERROR: mode: 0664 does not match overlaid package mode: 0644"
+            in self.output
+        )
+        # Verify all packages.
+        self.pkg("-D broken-conflicting-action-handling=1 verify -v", exit=1)
+        self.assertTrue("Overlaid package" in self.output)
+        self.assertTrue(
+            "ERROR: mode: 0664 does not match overlaid package mode: 0644"
+            in self.output
+        )
+
+        # Should be fixed, since on-disk actions should not be changed.
+        exit = self.__check_overlay_attr_fix("gss@1.0-0", exit=0)
+
+        # Should be fixed, since on-disk actions should not be changed.
+        self.__check_overlay_attr_fix("krb5@1.0-0")
+
+        # Should be fixed, since on-disk actions should not be changed.
+        exit = self.__check_overlay_attr_fix("gss-attr-allow@1.0-0", exit=0)
+        # Should be fixed, since on-disk actions should not be changed.
+        self.__check_overlay_attr_fix(
+            "krb5-attr-allow@1.0-0", exit=0, new_img=False
+        )
+        # The on-disk overlaying action should be fixed.
+        self.__do_alter_verify(
+            self.plist["gss-attr-allow@1.0-0"],
+            exit=0,
+            verbose=True,
+            validate=False,
+        )
+        # Post verify the above has been fixed.
+        self.pkg("verify -v gss-attr-allow@1.0-0")
+        self.assertTrue("Overlaid package" in self.output)
+        self.pkg("verify krb5-attr-allow@1.0-0")
+
+        # Should be fixed, since on-disk actions should not be changed.
+        self.__check_overlay_attr_fix("gss-attr-deny@1.0-0")
+
+        # Should be fixed, since on-disk actions should not be changed.
+        self.__check_overlay_attr_fix("krb5-attr-deny@1.0-0")
+
+    def test_fix_overlay(self):
+        """Test that pkg verify / fix should tell the users to look at
+        the overlaying package in the error message if fix won't repair
+        the overlaid package."""
+
+        file_path = "etc/gss/mech"
+        file_path_1 = "etc/gss/mech_1"
+        self.image_create(self.rurl)
+        pfmri_gss = self.plist["gss@1.0-0"]
+        pfmri_krb = self.plist["krb5@1.0-0"]
+        pfmri_sysattr = self.plist["sysattr@1.0-0"]
+        pfmri_sysattr_o = self.plist["sysattr_overlay@1.0-0"]
+
+        # First, only install the package that has a file with
+        # attribute overlay=allow.
+        self.pkg("install gss")
+
+        # Path verification should report ok.
+        self.pkg("verify -v -p {0}".format(file_path))
+        self.assertTrue(
+            "OK" in self.output
+            and file_path not in self.output
+            and pfmri_gss.get_pkg_stem() in self.output
+        )
+
+        self.file_exists(file_path)
+        self.file_remove(file_path)
+        self.file_doesnt_exist(file_path)
+
+        # Verify should report an error if the file is missing.
+        self.pkg("verify -v gss", exit=1)
+
+        # Path verification should report error.
+        self.pkg("verify -v -p {0}".format(file_path), exit=1)
+        self.assertTrue("OK" not in self.output and "ERROR" in self.output)
+        self.assertTrue(
+            file_path in self.output and pfmri_gss.get_pkg_stem() in self.output
+        )
+
+        # Fix should be able to repair the file.
+        self.pkg("fix -v gss")
+        self.file_exists(file_path)
+        # On-disk action attributes should be changed and should be
+        # fixed.
+        self.__do_alter_verify(pfmri_gss, exit=0)
+
+        # Install the overlaying package.
+        self.pkg("install krb5")
+
+        # Path verification should report ok for both the overlaid package
+        # and the overlaying package.
+        self.pkg("verify -v -p {0}".format(file_path))
+        self.assertTrue(
+            self.output.count("OK") == 2 and "ERROR" not in self.output
+        )
+        self.assertTrue(
+            pfmri_krb.get_pkg_stem() in self.output
+            and pfmri_gss.get_pkg_stem() in self.output
+        )
+
+        self.pkg("verify -v -p {0} gss".format(file_path))
+        self.assertTrue(
+            self.output.count("OK") == 2 and "ERROR" not in self.output
+        )
+        self.assertTrue(
+            pfmri_krb.get_pkg_stem() in self.output
+            and pfmri_gss.get_pkg_stem() in self.output
+        )
+
+        self.file_exists(file_path)
+        self.file_remove(file_path)
+        self.file_doesnt_exist(file_path)
+
+        # Path verification should report error for both the overlaid package
+        # and the overlaying package.
+        self.pkg("verify -v -p {0}".format(file_path), exit=1)
+        self.assertTrue(
+            "OK" not in self.output and self.output.count("ERROR") == 4
+        )
+        self.assertTrue(
+            pfmri_krb.get_pkg_stem() in self.output
+            and pfmri_gss.get_pkg_stem() in self.output
+        )
+
+        self.pkg("verify -v -p {0} gss".format(file_path), exit=1)
+        self.assertTrue(
+            "OK" not in self.output and self.output.count("ERROR") == 4
+        )
+        self.assertTrue(
+            pfmri_krb.get_pkg_stem() in self.output
+            and pfmri_gss.get_pkg_stem() in self.output
+        )
+
+        # Now pkg verify should still report an error on the overlaid
+        # package and tell the users it is from the overlaying package.
+        self.pkg("verify gss", exit=1)
+        self.assertTrue(
+            "from {0}".format(pfmri_krb.get_pkg_stem(anarchy=True))
+            in self.output
+        )
+        # Verify should report an error on the overlaying package.
+        self.pkg("verify krb5", exit=1)
+        # Fix will fix the overlaying action (from krb5) for gss
+        # directly.
+        self.pkg("fix gss")
+        self.file_exists(file_path)
+
+        # Fix has fixed that one before.
+        self.pkg("fix -v pkg:/krb5", exit=4)
+        self.pkg("verify gss")
+        self.file_exists(file_path)
+
+        # Test that multiple overlaid files are missing.
+        self.file_remove(file_path)
+        self.file_remove(file_path_1)
+        self.pkg("verify gss", exit=1)
+        self.pkg("fix krb5")
+
+        # Test the owner, group and mode change.
+        self.__do_alter_verify(pfmri_gss, verbose=True)
+        self.__do_alter_verify(pfmri_krb, verbose=True)
+
+        # Test that verify / fix on system wide could report / fix the
+        # error on the overlaid and overlaying packges.
+        self.file_remove(file_path)
+        self.pkg("verify", exit=1)
+        self.assertTrue("(from " in self.output)
+        self.pkg("fix")
+        self.assertTrue("(from " in self.output)
+        self.pkg("verify")
+        self.file_exists(file_path)
+
+        # Test different file types install. Since fix will repair the
+        # overlaid package in this case, we don't need to tell the users
+        # to look at the overlaying package.
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install " "dupfile duplink"
+        )
+        self.pkg("verify dupfile", exit=1)
+        self.pkg("fix dupfile")
+        self.pkg("verify dupfile")
+
+        # Test overlaid package that contains system attribute error.
+        self.set_img_path(tempfile.mkdtemp(prefix="test-suite", dir="/var/tmp"))
+        self.image_create(self.rurl)
+        self.pkg("install sysattr")
+        fpath = os.path.join(self.img_path(), "amber1")
+
+        # Install the overlaying package.
+        self.pkg("install sysattr_overlay")
+        portable.remove(fpath)
+        portable.copyfile(os.path.join(self.test_root, "amber1"), fpath)
+        os.chmod(fpath, 0o555)
+        os.chown(fpath, -1, 2)
+        self.pkg("verify sysattr", exit=1)
+        self.pkg("fix -v sysattr")
+        self.assertTrue(
+            "from {0}".format(pfmri_sysattr_o.get_pkg_stem(anarchy=True))
+            in self.output
+        )
+        self.pkg("fix sysattr_overlay", exit=4)
+        self.pkg("verify sysattr")
+        self.image_destroy()
+
+    def test_fix_with_ftpuser(self):
+        """Test to check pkg fix works fine for the package which
+        delivers ftpuser file"""
+
+        file_path = "etc/ftpd/ftpusers"
+        pfmri_ftpd = self.plist["ftpd@1.0-0"]
+        self.image_create(self.rurl)
+
+        # First, only install the package that has a file with
+        # the attribute ftpuser=true. Not to be confused with the
+        # user action attribute of ftpuser=false
+        self.pkg("install ftpd")
+
+        # Path verification should report ok.
+        self.pkg("verify -v -p {0}".format(file_path))
+        self.assertTrue("OK" in self.output)
+
+        # Check whether the users are present in the file
+        self.file_contains(file_path, "root")
+        self.file_contains(file_path, "daemon")
+        self.file_exists(file_path)
+        # remove the file and check the same
+        self.file_remove(file_path)
+        self.file_doesnt_exist(file_path)
+
+        # Verify should report an error if the file is missing.
+        self.pkg("verify -v ftpd", exit=1)
+
+        # Path verification should report error.
+        self.pkg("verify -v -p {0}".format(file_path), exit=1)
+        self.assertTrue("OK" not in self.output and "ERROR" in self.output)
+        self.assertTrue(
+            file_path in self.output
+            and pfmri_ftpd.get_pkg_stem() in self.output
+        )
+
+        # Fix should be able to repair the file.
+        self.pkg("fix -v ftpd")
+        self.file_exists(file_path)
+        self.file_contains(file_path, "root")
+        self.file_contains(file_path, "daemon")
+        self.__do_alter_verify(pfmri_ftpd, exit=0)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_https.py
+++ b/src/tests/cli/t_https.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import hashlib
@@ -44,382 +45,411 @@ from pkg.client.transport.exception import TransportFailures
 
 
 class TestHTTPS(pkg5unittest.HTTPSTestClass):
-
-        example_pkg10 = """
+    example_pkg10 = """
             open example_pkg@1.0,5.11-0
             add file tmp/example_file mode=0555 owner=root group=bin path=/usr/bin/example_path
             close"""
 
-        misc_files = ["tmp/example_file"]
+    misc_files = ["tmp/example_file"]
 
-        def setUp(self):
-                pub1_name = "test"
-                pub2_name = "tmp"
+    def setUp(self):
+        pub1_name = "test"
+        pub2_name = "tmp"
 
-                pkg5unittest.HTTPSTestClass.setUp(self, [pub1_name, pub2_name],
-                    start_depots=True)
-                
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.tmppub = pub2_name
+        pkg5unittest.HTTPSTestClass.setUp(
+            self, [pub1_name, pub2_name], start_depots=True
+        )
 
-                self.make_misc_files(self.misc_files)
-                self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                self.acurl1 = self.ac.url + "/{0}".format(pub1_name)
-                self.acurl2 = self.ac.url + "/{0}".format(pub2_name)
-                # Our proxy is served by the same Apache controller, but uses
-                # a different port.
-                self.proxyurl = self.ac.url.replace("https", "http")
-                self.proxyurl = self.proxyurl.replace(str(self.https_port),
-                    str(self.proxy_port))
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.tmppub = pub2_name
 
-        def test_01_basics(self):
-                """Test that adding a https publisher works and that a package
-                can be installed from that publisher."""
+        self.make_misc_files(self.misc_files)
+        self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        self.acurl1 = self.ac.url + "/{0}".format(pub1_name)
+        self.acurl2 = self.ac.url + "/{0}".format(pub2_name)
+        # Our proxy is served by the same Apache controller, but uses
+        # a different port.
+        self.proxyurl = self.ac.url.replace("https", "http")
+        self.proxyurl = self.proxyurl.replace(
+            str(self.https_port), str(self.proxy_port)
+        )
 
-                self.ac.start()
-                # Test that creating an image using a HTTPS repo without
-                # providing any keys or certificates fails.
-                self.assertRaises(TransportFailures, self.image_create,
-                    self.acurl1)
-                self.pkg_image_create(repourl=self.acurl1, exit=1)
-                api_obj = self.image_create()
+    def test_01_basics(self):
+        """Test that adding a https publisher works and that a package
+        can be installed from that publisher."""
 
-                # Test that adding a HTTPS repo fails if the image does not
-                # contain the trust anchor to verify the server's identity.
-                self.pkg("set-publisher -k {key} -c {cert} -p {url}".format(
-                    url=self.acurl1,
-                    cert=os.path.join(self.cs_dir, self.get_cli_cert("test")),
-                    key=os.path.join(self.keys_dir, self.get_cli_key("test")),
-                   ), exit=1)
+        self.ac.start()
+        # Test that creating an image using a HTTPS repo without
+        # providing any keys or certificates fails.
+        self.assertRaises(TransportFailures, self.image_create, self.acurl1)
+        self.pkg_image_create(repourl=self.acurl1, exit=1)
+        api_obj = self.image_create()
 
-                # Add the trust anchor needed to verify the server's identity to
-                # the image.
-                self.seed_ta_dir("ta7")
-                self.pkg("set-publisher -k {key} -c {cert} -p {url}".format(
-                    url=self.acurl1,
-                    cert=os.path.join(self.cs_dir, self.get_cli_cert("test")),
-                    key=os.path.join(self.keys_dir, self.get_cli_key("test")),
-                   ))
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
+        # Test that adding a HTTPS repo fails if the image does not
+        # contain the trust anchor to verify the server's identity.
+        self.pkg(
+            "set-publisher -k {key} -c {cert} -p {url}".format(
+                url=self.acurl1,
+                cert=os.path.join(self.cs_dir, self.get_cli_cert("test")),
+                key=os.path.join(self.keys_dir, self.get_cli_key("test")),
+            ),
+            exit=1,
+        )
 
-                # Verify that if the image location changes, SSL operations
-                # are still possible.  (The paths to key and cert should be
-                # updated on load.)
-                opath = self.img_path()
-                npath = opath.replace("image0", "new.image")
-                portable.rename(opath, npath)
-                odebug = DebugValues["ssl_ca_file"]
-                DebugValues["ssl_ca_file"] = odebug.replace("image0",
-                    "new.image")
-                self.pkg("-R {0} refresh --full test".format(npath))
+        # Add the trust anchor needed to verify the server's identity to
+        # the image.
+        self.seed_ta_dir("ta7")
+        self.pkg(
+            "set-publisher -k {key} -c {cert} -p {url}".format(
+                url=self.acurl1,
+                cert=os.path.join(self.cs_dir, self.get_cli_cert("test")),
+                key=os.path.join(self.keys_dir, self.get_cli_key("test")),
+            )
+        )
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
 
-                # Listing the test publisher causes its cert and key to be
-                # validated.
-                self.pkg("-R {0} publisher test".format(npath))
-                assert os.path.join("new.image", "var", "pkg", "ssl") in \
-                    self.output
+        # Verify that if the image location changes, SSL operations
+        # are still possible.  (The paths to key and cert should be
+        # updated on load.)
+        opath = self.img_path()
+        npath = opath.replace("image0", "new.image")
+        portable.rename(opath, npath)
+        odebug = DebugValues["ssl_ca_file"]
+        DebugValues["ssl_ca_file"] = odebug.replace("image0", "new.image")
+        self.pkg("-R {0} refresh --full test".format(npath))
 
-                # Restore image to original location.
-                portable.rename(npath, opath)
-                DebugValues["ssl_ca_file"] = odebug
+        # Listing the test publisher causes its cert and key to be
+        # validated.
+        self.pkg("-R {0} publisher test".format(npath))
+        assert os.path.join("new.image", "var", "pkg", "ssl") in self.output
 
-                # verify that we can reach the repository using a HTTPS-capable
-                # HTTP proxy.
-                self.image_create()
-                self.seed_ta_dir("ta7")
-                self.pkg("set-publisher --proxy {proxy} "
-                    "-k {key} -c {cert} -p {url}".format(
-                    url=self.acurl1,
-                    cert=os.path.join(self.cs_dir, self.get_cli_cert("test")),
-                    key=os.path.join(self.keys_dir, self.get_cli_key("test")),
-                    proxy=self.proxyurl))
-                self.pkg("install example_pkg")
+        # Restore image to original location.
+        portable.rename(npath, opath)
+        DebugValues["ssl_ca_file"] = odebug
 
-                # Now try to use the bad proxy, ensuring that we cannot set
-                # the publisher (and verifying that we were indeed using the
-                # proxy previously)
-                bad_proxyurl = self.proxyurl.replace(str(self.proxy_port),
-                    str(self.bad_proxy_port))
-                self.image_create()
-                self.seed_ta_dir("ta7")
-                self.pkg("set-publisher --proxy {proxy} "
-                    "-k {key} -c {cert} -p {url}".format(
-                    url=self.acurl1,
-                    cert=os.path.join(self.cs_dir, self.get_cli_cert("test")),
-                    key=os.path.join(self.keys_dir, self.get_cli_key("test")),
-                    proxy=bad_proxyurl), exit=1)
+        # verify that we can reach the repository using a HTTPS-capable
+        # HTTP proxy.
+        self.image_create()
+        self.seed_ta_dir("ta7")
+        self.pkg(
+            "set-publisher --proxy {proxy} "
+            "-k {key} -c {cert} -p {url}".format(
+                url=self.acurl1,
+                cert=os.path.join(self.cs_dir, self.get_cli_cert("test")),
+                key=os.path.join(self.keys_dir, self.get_cli_key("test")),
+                proxy=self.proxyurl,
+            )
+        )
+        self.pkg("install example_pkg")
 
-                # Set the bad proxy in the image, verify we can't refresh,
-                # then use an OS environment override to force the use of a
-                # good proxy.
-                self.pkg("set-publisher --no-refresh --proxy {proxy} "
-                    "-k {key} -c {cert} -g {url} test".format(
-                    url=self.acurl1,
-                    cert=os.path.join(self.cs_dir, self.get_cli_cert("test")),
-                    key=os.path.join(self.keys_dir, self.get_cli_key("test")),
-                    proxy=bad_proxyurl), exit=0)
-                self.pkg("refresh", exit=1)
-                proxy_env = {"https_proxy": self.proxyurl}
-                self.pkg("refresh", env_arg=proxy_env)
-                self.pkg("install example_pkg", env_arg=proxy_env)
+        # Now try to use the bad proxy, ensuring that we cannot set
+        # the publisher (and verifying that we were indeed using the
+        # proxy previously)
+        bad_proxyurl = self.proxyurl.replace(
+            str(self.proxy_port), str(self.bad_proxy_port)
+        )
+        self.image_create()
+        self.seed_ta_dir("ta7")
+        self.pkg(
+            "set-publisher --proxy {proxy} "
+            "-k {key} -c {cert} -p {url}".format(
+                url=self.acurl1,
+                cert=os.path.join(self.cs_dir, self.get_cli_cert("test")),
+                key=os.path.join(self.keys_dir, self.get_cli_key("test")),
+                proxy=bad_proxyurl,
+            ),
+            exit=1,
+        )
 
-        def test_correct_cert_validation(self):
-                """ Test that an expired cert for one publisher doesn't prevent
-                making changes to other publishers due to certifcate checks on
-                all configured publishers. (Bug 17018362)"""
+        # Set the bad proxy in the image, verify we can't refresh,
+        # then use an OS environment override to force the use of a
+        # good proxy.
+        self.pkg(
+            "set-publisher --no-refresh --proxy {proxy} "
+            "-k {key} -c {cert} -g {url} test".format(
+                url=self.acurl1,
+                cert=os.path.join(self.cs_dir, self.get_cli_cert("test")),
+                key=os.path.join(self.keys_dir, self.get_cli_key("test")),
+                proxy=bad_proxyurl,
+            ),
+            exit=0,
+        )
+        self.pkg("refresh", exit=1)
+        proxy_env = {"https_proxy": self.proxyurl}
+        self.pkg("refresh", env_arg=proxy_env)
+        self.pkg("install example_pkg", env_arg=proxy_env)
 
-                bad_cert_path = os.path.join(self.cs_dir,
-                    "cs3_ch1_ta3_cert.pem")
-                good_cert_path = os.path.join(self.cs_dir,
-                    self.get_cli_cert("test"))
-                self.ac.start()
-                self.image_create()
+    def test_correct_cert_validation(self):
+        """Test that an expired cert for one publisher doesn't prevent
+        making changes to other publishers due to certifcate checks on
+        all configured publishers. (Bug 17018362)"""
 
-                # Set https-based publisher with correct cert.
-                self.seed_ta_dir("ta7")
-                self.pkg("set-publisher -k {key} -c {cert} -p {url}".format(
-                    url=self.acurl1,
-                    cert=good_cert_path,
-                    key=os.path.join(self.keys_dir, self.get_cli_key("test")),
-                   ))
-                # Set a second publisher
-                self.pkg("set-publisher -p {url}".format(url=self.rurl2))
+        bad_cert_path = os.path.join(self.cs_dir, "cs3_ch1_ta3_cert.pem")
+        good_cert_path = os.path.join(self.cs_dir, self.get_cli_cert("test"))
+        self.ac.start()
+        self.image_create()
 
-                # Replace cert of first publisher with one that is expired.
-                # It doesn't need to match the key because we just want to
-                # test if the cert validation code works correctly so we are not
-                # actually using the cert.
+        # Set https-based publisher with correct cert.
+        self.seed_ta_dir("ta7")
+        self.pkg(
+            "set-publisher -k {key} -c {cert} -p {url}".format(
+                url=self.acurl1,
+                cert=good_cert_path,
+                key=os.path.join(self.keys_dir, self.get_cli_key("test")),
+            )
+        )
+        # Set a second publisher
+        self.pkg("set-publisher -p {url}".format(url=self.rurl2))
 
-                # Cert is stored by content hash in the pkg config of the image,
-                # which must be a SHA-1 hash for backwards compatibility.
-                ch = misc.get_data_digest(good_cert_path,
-                    hash_func=hashlib.sha1)[0]
-                pkg_cert_path = os.path.join(self.get_img_path(), "var", "pkg",
-                    "ssl", ch)
-                shutil.copy(bad_cert_path, pkg_cert_path)
+        # Replace cert of first publisher with one that is expired.
+        # It doesn't need to match the key because we just want to
+        # test if the cert validation code works correctly so we are not
+        # actually using the cert.
 
-                # Refreshing the second publisher should not try to validate
-                # the cert for the first publisher.
-                self.pkg("refresh {0}".format(self.tmppub))
+        # Cert is stored by content hash in the pkg config of the image,
+        # which must be a SHA-1 hash for backwards compatibility.
+        ch = misc.get_data_digest(good_cert_path, hash_func=hashlib.sha1)[0]
+        pkg_cert_path = os.path.join(
+            self.get_img_path(), "var", "pkg", "ssl", ch
+        )
+        shutil.copy(bad_cert_path, pkg_cert_path)
 
-        def test_expired_certs(self):
-                """ Test that certificate validation needs to validate all
-                certificates before raising an exception. (Bug 15507548)"""
+        # Refreshing the second publisher should not try to validate
+        # the cert for the first publisher.
+        self.pkg("refresh {0}".format(self.tmppub))
 
-                bad_cert_path = os.path.join(self.cs_dir,
-                    "cs3_ch1_ta3_cert.pem")
-                good_cert_path_1 = os.path.join(self.cs_dir,
-                    self.get_cli_cert("test"))
-                good_cert_path_2 = os.path.join(self.cs_dir,
-                    self.get_cli_cert("tmp"))
-                self.ac.start()
-                self.image_create()
+    def test_expired_certs(self):
+        """Test that certificate validation needs to validate all
+        certificates before raising an exception. (Bug 15507548)"""
 
-                # Set https-based publisher with correct cert.
-                self.seed_ta_dir("ta7")
-                self.pkg("set-publisher -k {key} -c {cert} -p {url}".format(
-                    url=self.acurl1,
-                    cert=good_cert_path_1,
-                    key=os.path.join(self.keys_dir, self.get_cli_key("test")),
-                   ))
-                # Set a second publisher
-                self.pkg("set-publisher -k {key} -c {cert} -p {url}".format(
-                    url=self.acurl2,
-                    cert=good_cert_path_2,
-                    key=os.path.join(self.keys_dir, self.get_cli_key("tmp")),
-                   ))
- 
-                # Replace cert of first publisher with one that is expired.
+        bad_cert_path = os.path.join(self.cs_dir, "cs3_ch1_ta3_cert.pem")
+        good_cert_path_1 = os.path.join(self.cs_dir, self.get_cli_cert("test"))
+        good_cert_path_2 = os.path.join(self.cs_dir, self.get_cli_cert("tmp"))
+        self.ac.start()
+        self.image_create()
 
-                # Cert is stored by content hash in the pkg config of the image,
-                # which must be a SHA-1 hash for backwards compatibility.
-                ch = misc.get_data_digest(good_cert_path_1,
-                    hash_func=hashlib.sha1)[0]
-                pkg_cert_path = os.path.join(self.get_img_path(), "var", "pkg",
-                    "ssl", ch)
-                shutil.copy(bad_cert_path, pkg_cert_path)
+        # Set https-based publisher with correct cert.
+        self.seed_ta_dir("ta7")
+        self.pkg(
+            "set-publisher -k {key} -c {cert} -p {url}".format(
+                url=self.acurl1,
+                cert=good_cert_path_1,
+                key=os.path.join(self.keys_dir, self.get_cli_key("test")),
+            )
+        )
+        # Set a second publisher
+        self.pkg(
+            "set-publisher -k {key} -c {cert} -p {url}".format(
+                url=self.acurl2,
+                cert=good_cert_path_2,
+                key=os.path.join(self.keys_dir, self.get_cli_key("tmp")),
+            )
+        )
 
-                # Replace the second certificate with one that is expired.
-                ch = misc.get_data_digest(good_cert_path_2,
-                    hash_func=hashlib.sha1)[0]
-                pkg_cert_path = os.path.join(self.get_img_path(), "var", "pkg",
-                    "ssl", ch)
-                shutil.copy(bad_cert_path, pkg_cert_path)
+        # Replace cert of first publisher with one that is expired.
 
-                # Refresh all publishers should try to validate all certs.
-                self.pkg("refresh", exit=1)
-                self.assertTrue("Publisher: tmp" in self.errout, self.errout)
-                self.assertTrue("Publisher: test" in self.errout, self.errout)
+        # Cert is stored by content hash in the pkg config of the image,
+        # which must be a SHA-1 hash for backwards compatibility.
+        ch = misc.get_data_digest(good_cert_path_1, hash_func=hashlib.sha1)[0]
+        pkg_cert_path = os.path.join(
+            self.get_img_path(), "var", "pkg", "ssl", ch
+        )
+        shutil.copy(bad_cert_path, pkg_cert_path)
 
-        def test_expiring_certs(self):
-                """Test that image-create will not raise exception for
-                expiring certificates. (Bug 17768096)"""
+        # Replace the second certificate with one that is expired.
+        ch = misc.get_data_digest(good_cert_path_2, hash_func=hashlib.sha1)[0]
+        pkg_cert_path = os.path.join(
+            self.get_img_path(), "var", "pkg", "ssl", ch
+        )
+        shutil.copy(bad_cert_path, pkg_cert_path)
 
-                tmp_dir = tempfile.mkdtemp(dir=self.test_root)
+        # Refresh all publishers should try to validate all certs.
+        self.pkg("refresh", exit=1)
+        self.assertTrue("Publisher: tmp" in self.errout, self.errout)
+        self.assertTrue("Publisher: test" in self.errout, self.errout)
 
-                # Retrive the correct CA and use it to generate a new cert.
-                test_ca = self.get_pub_ta("test")
-                test_cs = "cs1_{0}".format(test_ca)
+    def test_expiring_certs(self):
+        """Test that image-create will not raise exception for
+        expiring certificates. (Bug 17768096)"""
 
-                # Add a certificate to the length 2 chain that is going to
-                # expire in 27 days.
-                cg = certgenerator.CertGenerator(base_dir=tmp_dir)
-                cg.make_cs_cert(test_cs, test_ca, ca_path=self.path_to_certs,
-                    expiring=True, https=True)
-                self.ac.start()
-                self.image_create()
+        tmp_dir = tempfile.mkdtemp(dir=self.test_root)
 
-                # Set https-based publisher with expiring cert.
-                self.seed_ta_dir("ta7")
-                self.pkg("image-create -f --user -k {key} -c {cert} "
-                    "-p test={url} {path}/image".format(
-                    url=self.acurl1,
-                    cert=os.path.join(cg.cs_dir, "{0}_cert.pem".format(test_cs)),
-                    key=os.path.join(cg.keys_dir, "{0}_key.pem".format(test_cs)),
-                    path=tmp_dir
-                   ))
+        # Retrive the correct CA and use it to generate a new cert.
+        test_ca = self.get_pub_ta("test")
+        test_cs = "cs1_{0}".format(test_ca)
+
+        # Add a certificate to the length 2 chain that is going to
+        # expire in 27 days.
+        cg = certgenerator.CertGenerator(base_dir=tmp_dir)
+        cg.make_cs_cert(
+            test_cs,
+            test_ca,
+            ca_path=self.path_to_certs,
+            expiring=True,
+            https=True,
+        )
+        self.ac.start()
+        self.image_create()
+
+        # Set https-based publisher with expiring cert.
+        self.seed_ta_dir("ta7")
+        self.pkg(
+            "image-create -f --user -k {key} -c {cert} "
+            "-p test={url} {path}/image".format(
+                url=self.acurl1,
+                cert=os.path.join(cg.cs_dir, "{0}_cert.pem".format(test_cs)),
+                key=os.path.join(cg.keys_dir, "{0}_key.pem".format(test_cs)),
+                path=tmp_dir,
+            )
+        )
 
 
 class TestDepotHTTPS(pkg5unittest.SingleDepotTestCase):
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        example_pkg10 = """
+    example_pkg10 = """
             open example_pkg@1.0,5.11-0
             add file tmp/example_file mode=0555 owner=root group=bin path=/usr/bin/example_path
             close"""
 
-        misc_files = {
-            "tmp/example_file": "tmp/example_file",
-            "tmp/test_ssl_auth": """\
+    misc_files = {
+        "tmp/example_file": "tmp/example_file",
+        "tmp/test_ssl_auth": """\
 #!/usr/bin/sh
 reserved=$1
 port=$2
 echo "123"
 """,
-            "tmp/test_ssl_auth_bad": """\
+        "tmp/test_ssl_auth_bad": """\
 #!/usr/bin/sh
 reserved=$1
 port=$2
 echo "12345"
 """,
-        }
+    }
 
-        def pkg(self, command, *args, **kwargs):
-                # The value for ssl_ca_file is pulled from DebugValues because
-                # ssl_ca_file needs to be set there so the api object calls work
-                # as desired.
-                command = "--debug ssl_ca_file={0} {1}".format(
-                    DebugValues["ssl_ca_file"], command)
-                return pkg5unittest.SingleDepotTestCase.pkg(self, command,
-                    *args, **kwargs)
+    def pkg(self, command, *args, **kwargs):
+        # The value for ssl_ca_file is pulled from DebugValues because
+        # ssl_ca_file needs to be set there so the api object calls work
+        # as desired.
+        command = "--debug ssl_ca_file={0} {1}".format(
+            DebugValues["ssl_ca_file"], command
+        )
+        return pkg5unittest.SingleDepotTestCase.pkg(
+            self, command, *args, **kwargs
+        )
 
-        def seed_ta_dir(self, certs, dest_dir=None):
-                if isinstance(certs, six.string_types):
-                        certs = [certs]
-                if not dest_dir:
-                        dest_dir = self.ta_dir
-                for c in certs:
-                        name = "{0}_cert.pem".format(c)
-                        portable.copyfile(
-                            os.path.join(self.raw_trust_anchor_dir, name),
-                            os.path.join(dest_dir, name))
-                        DebugValues["ssl_ca_file"] = os.path.join(dest_dir,
-                            name)
+    def seed_ta_dir(self, certs, dest_dir=None):
+        if isinstance(certs, six.string_types):
+            certs = [certs]
+        if not dest_dir:
+            dest_dir = self.ta_dir
+        for c in certs:
+            name = "{0}_cert.pem".format(c)
+            portable.copyfile(
+                os.path.join(self.raw_trust_anchor_dir, name),
+                os.path.join(dest_dir, name),
+            )
+            DebugValues["ssl_ca_file"] = os.path.join(dest_dir, name)
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.testdata_dir = os.path.join(self.test_root, "testdata")
-                mpaths = self.make_misc_files(self.misc_files)
-                self.ssl_auth_script = mpaths[1]
-                self.ssl_auth_bad_script = mpaths[2]
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.testdata_dir = os.path.join(self.test_root, "testdata")
+        mpaths = self.make_misc_files(self.misc_files)
+        self.ssl_auth_script = mpaths[1]
+        self.ssl_auth_bad_script = mpaths[2]
 
-                # Make shell scripts executable.
-                os.chmod(self.ssl_auth_script, stat.S_IRWXU)
-                os.chmod(self.ssl_auth_bad_script, stat.S_IRWXU)
+        # Make shell scripts executable.
+        os.chmod(self.ssl_auth_script, stat.S_IRWXU)
+        os.chmod(self.ssl_auth_bad_script, stat.S_IRWXU)
 
-                # Set up the paths to the certificates that will be needed.
-                self.path_to_certs = os.path.join(self.ro_data_root,
-                    "signing_certs", "produced")
-                self.keys_dir = os.path.join(self.path_to_certs, "keys")
-                self.cs_dir = os.path.join(self.path_to_certs,
-                    "code_signing_certs")
-                self.chain_certs_dir = os.path.join(self.path_to_certs,
-                    "chain_certs")
-                self.pub_cas_dir = os.path.join(self.path_to_certs,
-                    "publisher_cas")
-                self.inter_certs_dir = os.path.join(self.path_to_certs,
-                    "inter_certs")
-                self.raw_trust_anchor_dir = os.path.join(self.path_to_certs,
-                    "trust_anchors")
-                self.crl_dir = os.path.join(self.path_to_certs, "crl")
+        # Set up the paths to the certificates that will be needed.
+        self.path_to_certs = os.path.join(
+            self.ro_data_root, "signing_certs", "produced"
+        )
+        self.keys_dir = os.path.join(self.path_to_certs, "keys")
+        self.cs_dir = os.path.join(self.path_to_certs, "code_signing_certs")
+        self.chain_certs_dir = os.path.join(self.path_to_certs, "chain_certs")
+        self.pub_cas_dir = os.path.join(self.path_to_certs, "publisher_cas")
+        self.inter_certs_dir = os.path.join(self.path_to_certs, "inter_certs")
+        self.raw_trust_anchor_dir = os.path.join(
+            self.path_to_certs, "trust_anchors"
+        )
+        self.crl_dir = os.path.join(self.path_to_certs, "crl")
 
-                self.pkgsend_bulk(self.rurl, self.example_pkg10)
+        self.pkgsend_bulk(self.rurl, self.example_pkg10)
 
-                self.server_ssl_cert = os.path.join(self.cs_dir,
-                    "cs1_ta7_cert.pem")
-                self.server_ssl_key = os.path.join(self.keys_dir,
-                    "cs1_ta7_key.pem")
-                self.server_ssl_reqpass_key = os.path.join(self.keys_dir,
-                    "cs1_ta7_reqpass_key.pem")
+        self.server_ssl_cert = os.path.join(self.cs_dir, "cs1_ta7_cert.pem")
+        self.server_ssl_key = os.path.join(self.keys_dir, "cs1_ta7_key.pem")
+        self.server_ssl_reqpass_key = os.path.join(
+            self.keys_dir, "cs1_ta7_reqpass_key.pem"
+        )
 
-        def test_01_basics(self):
-                """Test that adding an https publisher works and that a package
-                can be installed from that publisher."""
+    def test_01_basics(self):
+        """Test that adding an https publisher works and that a package
+        can be installed from that publisher."""
 
-                def test_ssl_settings(exit=0):
-                        # Image must be created first before seeding cert files.
-                        self.pkg_image_create()
-                        self.seed_ta_dir("ta7")
+        def test_ssl_settings(exit=0):
+            # Image must be created first before seeding cert files.
+            self.pkg_image_create()
+            self.seed_ta_dir("ta7")
 
-                        if exit != 0:
-                                self.dc.start_expected_fail(exit=exit)
-                                self.dc.disable_ssl()
-                                return
+            if exit != 0:
+                self.dc.start_expected_fail(exit=exit)
+                self.dc.disable_ssl()
+                return
 
-                        # Start depot *after* seeding certs.
-                        self.dc.start()
+            # Start depot *after* seeding certs.
+            self.dc.start()
 
-                        self.pkg("set-publisher -p {0}".format(self.durl))
-                        api_obj = self.get_img_api_obj()
-                        self._api_install(api_obj, ["example_pkg"])
+            self.pkg("set-publisher -p {0}".format(self.durl))
+            api_obj = self.get_img_api_obj()
+            self._api_install(api_obj, ["example_pkg"])
 
-                        self.dc.stop()
-                        self.dc.disable_ssl()
+            self.dc.stop()
+            self.dc.disable_ssl()
 
-                # Verify using 'builtin' ssl authentication for server with
-                # a key that has no passphrase.
-                self.dc.enable_ssl(key_path=self.server_ssl_key,
-                    cert_path=self.server_ssl_cert)
-                test_ssl_settings()
+        # Verify using 'builtin' ssl authentication for server with
+        # a key that has no passphrase.
+        self.dc.enable_ssl(
+            key_path=self.server_ssl_key, cert_path=self.server_ssl_cert
+        )
+        test_ssl_settings()
 
-                # Verify using 'exec' ssl authentication for server with a key
-                # that has no passphrase.
-                self.dc.enable_ssl(key_path=self.server_ssl_key,
-                    cert_path=self.server_ssl_cert,
-                    dialog="exec:{0}".format(self.ssl_auth_script))
-                test_ssl_settings()
+        # Verify using 'exec' ssl authentication for server with a key
+        # that has no passphrase.
+        self.dc.enable_ssl(
+            key_path=self.server_ssl_key,
+            cert_path=self.server_ssl_cert,
+            dialog="exec:{0}".format(self.ssl_auth_script),
+        )
+        test_ssl_settings()
 
-                # Verify using 'exec' ssl authentication for server with a key
-                # that has a passphrase of '123'.
-                self.dc.enable_ssl(key_path=self.server_ssl_reqpass_key,
-                    cert_path=self.server_ssl_cert,
-                    dialog="exec:{0}".format(self.ssl_auth_script))
-                test_ssl_settings()
+        # Verify using 'exec' ssl authentication for server with a key
+        # that has a passphrase of '123'.
+        self.dc.enable_ssl(
+            key_path=self.server_ssl_reqpass_key,
+            cert_path=self.server_ssl_cert,
+            dialog="exec:{0}".format(self.ssl_auth_script),
+        )
+        test_ssl_settings()
 
-                # Verify using 'exec' ssl authentication for server with a key
-                # that has a passphrase of 123' but the wrong passphrase is
-                # supplied.
-                self.dc.enable_ssl(key_path=self.server_ssl_reqpass_key,
-                    cert_path=self.server_ssl_cert,
-                    dialog="exec:{0}".format(self.ssl_auth_bad_script))
-                test_ssl_settings(exit=1)
+        # Verify using 'exec' ssl authentication for server with a key
+        # that has a passphrase of 123' but the wrong passphrase is
+        # supplied.
+        self.dc.enable_ssl(
+            key_path=self.server_ssl_reqpass_key,
+            cert_path=self.server_ssl_cert,
+            dialog="exec:{0}".format(self.ssl_auth_bad_script),
+        )
+        test_ssl_settings(exit=1)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_lock.py
+++ b/src/tests/cli/t_lock.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -38,162 +39,164 @@ import unittest
 
 
 class TestPkgApi(pkg5unittest.SingleDepotTestCase):
-        # restart the depot for every test
-        persistent_depot = False
+    # restart the depot for every test
+    persistent_depot = False
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             close """
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11))
-                self.image_create(self.rurl)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11))
+        self.image_create(self.rurl)
 
-        def test_api_locking(self):
-                """Verify that a locked image cannot be modified if it is
-                already locked and that the API will raise an appropriate
-                exception."""
+    def test_api_locking(self):
+        """Verify that a locked image cannot be modified if it is
+        already locked and that the API will raise an appropriate
+        exception."""
 
-                # Get an image object and tests its manual lock mechanism.
-                api_obj = self.get_img_api_obj()
-                img = api_obj.img
+        # Get an image object and tests its manual lock mechanism.
+        api_obj = self.get_img_api_obj()
+        img = api_obj.img
 
-                # Verify a lock file is created and is not zero size.
-                img.lock()
-                lfpath = os.path.join(img.imgdir, "lock")
-                self.assertTrue(os.path.exists(lfpath))
-                self.assertNotEqual(os.stat(lfpath).st_size, 0)
+        # Verify a lock file is created and is not zero size.
+        img.lock()
+        lfpath = os.path.join(img.imgdir, "lock")
+        self.assertTrue(os.path.exists(lfpath))
+        self.assertNotEqual(os.stat(lfpath).st_size, 0)
 
-                # Verify attempting to re-lock when locked fails.
-                self.assertRaises(nrlock.NRLockException, img.lock)
+        # Verify attempting to re-lock when locked fails.
+        self.assertRaises(nrlock.NRLockException, img.lock)
 
-                # Verify lock file still exists on failure.
-                self.assertTrue(os.path.exists(lfpath))
+        # Verify lock file still exists on failure.
+        self.assertTrue(os.path.exists(lfpath))
 
-                # Verify that an API function will fail the same way.
-                self.assertRaises(nrlock.NRLockException,
-                    lambda *args, **kwargs: list(
-                        api_obj.gen_plan_install(*args, **kwargs)),
-                    ["foo"])
-                api_obj.reset()
+        # Verify that an API function will fail the same way.
+        self.assertRaises(
+            nrlock.NRLockException,
+            lambda *args, **kwargs: list(
+                api_obj.gen_plan_install(*args, **kwargs)
+            ),
+            ["foo"],
+        )
+        api_obj.reset()
 
-                # Now verify that after unlocking the image that it will work.
-                img.unlock()
+        # Now verify that after unlocking the image that it will work.
+        img.unlock()
 
-                # Verify that after unlock, lock file still exists, but is
-                # zero size.
-                self.assertTrue(os.path.exists(lfpath))
-                self.assertEqual(os.stat(lfpath).st_size, 0)
+        # Verify that after unlock, lock file still exists, but is
+        # zero size.
+        self.assertTrue(os.path.exists(lfpath))
+        self.assertEqual(os.stat(lfpath).st_size, 0)
 
-                for pd in api_obj.gen_plan_install(["foo"]):
-                        continue
-                api_obj.reset()
+        for pd in api_obj.gen_plan_install(["foo"]):
+            continue
+        api_obj.reset()
 
-                # Verify that if a state change occurs at any point after
-                # planning before a plan successfully executes, that an
-                # InvalidPlanError will be raised.
-                api_obj2 = self.get_img_api_obj()
+        # Verify that if a state change occurs at any point after
+        # planning before a plan successfully executes, that an
+        # InvalidPlanError will be raised.
+        api_obj2 = self.get_img_api_obj()
 
-                # Both of these should succeed since no state change exists yet.
-                for pd in api_obj.gen_plan_install(["foo"]):
-                        continue
-                for pd in api_obj2.gen_plan_install(["foo"]):
-                        continue
+        # Both of these should succeed since no state change exists yet.
+        for pd in api_obj.gen_plan_install(["foo"]):
+            continue
+        for pd in api_obj2.gen_plan_install(["foo"]):
+            continue
 
-                # Execute the first plan.
-                api_obj.prepare()
-                api_obj.execute_plan()
-                api_obj.reset()
+        # Execute the first plan.
+        api_obj.prepare()
+        api_obj.execute_plan()
+        api_obj.reset()
 
-                # Now verify preparing second plan fails since first has changed
-                # the image state.
-                self.assertRaises(api_errors.InvalidPlanError, api_obj2.prepare)
+        # Now verify preparing second plan fails since first has changed
+        # the image state.
+        self.assertRaises(api_errors.InvalidPlanError, api_obj2.prepare)
 
-                # Restart plan process.
-                api_obj2.reset()
-                for pd in api_obj2.gen_plan_uninstall(["foo"]):
-                        continue
-                for pd in api_obj.gen_plan_uninstall(["foo"]):
-                        continue
+        # Restart plan process.
+        api_obj2.reset()
+        for pd in api_obj2.gen_plan_uninstall(["foo"]):
+            continue
+        for pd in api_obj.gen_plan_uninstall(["foo"]):
+            continue
 
-                # Prepare second and first plan.
-                api_obj2.prepare()
-                api_obj.prepare()
+        # Prepare second and first plan.
+        api_obj2.prepare()
+        api_obj.prepare()
 
-                # Execute second plan, which should mean that the first can't
-                # execute due to state change since plan was created.
-                api_obj2.execute_plan()
-                self.assertRaises(api_errors.InvalidPlanError,
-                    api_obj.execute_plan)
+        # Execute second plan, which should mean that the first can't
+        # execute due to state change since plan was created.
+        api_obj2.execute_plan()
+        self.assertRaises(api_errors.InvalidPlanError, api_obj.execute_plan)
 
-        def test_process_locking(self):
-                """Verify that image locking works across processes."""
+    def test_process_locking(self):
+        """Verify that image locking works across processes."""
 
-                # Get an image object and tests its manual lock mechanism.
-                api_obj = self.get_img_api_obj()
-                img = api_obj.img
+        # Get an image object and tests its manual lock mechanism.
+        api_obj = self.get_img_api_obj()
+        img = api_obj.img
 
-                # Verify a lock file is created.
-                img.lock()
-                lfpath = os.path.join(img.imgdir, "lock")
-                self.assertTrue(os.path.exists(lfpath))
+        # Verify a lock file is created.
+        img.lock()
+        lfpath = os.path.join(img.imgdir, "lock")
+        self.assertTrue(os.path.exists(lfpath))
 
-                # Verify attempting to re-lock when lock fails.
-                self.assertRaises(nrlock.NRLockException, img.lock)
+        # Verify attempting to re-lock when lock fails.
+        self.assertRaises(nrlock.NRLockException, img.lock)
 
-                # Verify that the pkg process will fail if the image is locked.
-                self.pkg("install foo", exit=7)
+        # Verify that the pkg process will fail if the image is locked.
+        self.pkg("install foo", exit=7)
 
-                # Now verify that after unlocking the image that it will work.
-                img.unlock()
-                self.pkg("install foo")
+        # Now verify that after unlocking the image that it will work.
+        img.unlock()
+        self.pkg("install foo")
 
-                # Now plan an uninstall using the API object.
-                api_obj.reset()
-                for pd in api_obj.gen_plan_uninstall(["foo"]):
-                        continue
-                api_obj.prepare()
+        # Now plan an uninstall using the API object.
+        api_obj.reset()
+        for pd in api_obj.gen_plan_uninstall(["foo"]):
+            continue
+        api_obj.prepare()
 
-                # Execute the client to actually uninstall the package, and then
-                # attempt to execute the plan which should fail since the image
-                # state has changed since the plan was created.
-                self.pkg("uninstall foo")
-                self.assertRaises(api_errors.InvalidPlanError,
-                    api_obj.execute_plan)
+        # Execute the client to actually uninstall the package, and then
+        # attempt to execute the plan which should fail since the image
+        # state has changed since the plan was created.
+        self.pkg("uninstall foo")
+        self.assertRaises(api_errors.InvalidPlanError, api_obj.execute_plan)
 
-        def test_symlink_lock(self):
-                """Verify that if a install/refresh operation is performed
-                on lock file, the lock file is not a symlink."""
+    def test_symlink_lock(self):
+        """Verify that if a install/refresh operation is performed
+        on lock file, the lock file is not a symlink."""
 
-                # Get an image object and tests its manual lock mechanism.
-                api_obj = self.get_img_api_obj()
-                img = api_obj.img
+        # Get an image object and tests its manual lock mechanism.
+        api_obj = self.get_img_api_obj()
+        img = api_obj.img
 
-                # Verify a lock file is created.
-                img.lock()
-                lfpath = os.path.join(img.imgdir, "lock")
-                self.assertTrue(os.path.exists(lfpath))
-                img.unlock()
-                os.remove(lfpath)
+        # Verify a lock file is created.
+        img.lock()
+        lfpath = os.path.join(img.imgdir, "lock")
+        self.assertTrue(os.path.exists(lfpath))
+        img.unlock()
+        os.remove(lfpath)
 
-                # Make lock file a symlink by pointing it to a random file .
-                tmp_file = os.path.join(img.imgdir, "test_symlink")
-                fo = open(tmp_file, 'wb+')
-                fo.close()
-                os.symlink(tmp_file, lfpath)
+        # Make lock file a symlink by pointing it to a random file .
+        tmp_file = os.path.join(img.imgdir, "test_symlink")
+        fo = open(tmp_file, "wb+")
+        fo.close()
+        os.symlink(tmp_file, lfpath)
 
-                # Verify that both pkg install and refresh generate an error
-                # if the lock file is a symlink.
-                self.pkg("install foo", su_wrap=True, exit=1)
-                self.assertTrue("contains a symlink" in self.errout)
+        # Verify that both pkg install and refresh generate an error
+        # if the lock file is a symlink.
+        self.pkg("install foo", su_wrap=True, exit=1)
+        self.assertTrue("contains a symlink" in self.errout)
 
-                self.pkg("refresh --full", su_wrap=True, exit=1)
-                self.assertTrue("contains a symlink" in self.errout)
+        self.pkg("refresh --full", su_wrap=True, exit=1)
+        self.assertTrue("contains a symlink" in self.errout)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_origin_fw.py
+++ b/src/tests/cli/t_origin_fw.py
@@ -23,8 +23,9 @@
 
 from __future__ import print_function
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 
 import os
 import pkg5unittest
@@ -32,13 +33,13 @@ import unittest
 
 import pkg.portable as portable
 
+
 class TestPkgFWDependencies(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
-        # leverage smf test infrastructure here
-        smf_cmds = {
-            "testdriver" :
-"""#!/usr/bin/python
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+    # leverage smf test infrastructure here
+    smf_cmds = {
+        "testdriver": """#!/usr/bin/python
 import os
 import resource
 import sys
@@ -71,87 +72,98 @@ if __name__ == "__main__":
         warnings.simplefilter('error')
 
         sys.exit(main())
-"""}
+"""
+    }
 
-        def setUp(self):
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
 
-                pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.pkg_list = []
 
-                self.pkg_list = []
-
-                for t in (
-                    ("1.0", "dwarf"),
-                    ("1.1", "elf"),
-                    ("1.2", "hobbit"),
-                    ("1.3", "wizard")
-                    ):
-                    self.pkg_list+= ["""
+        for t in (
+            ("1.0", "dwarf"),
+            ("1.1", "elf"),
+            ("1.2", "hobbit"),
+            ("1.3", "wizard"),
+        ):
+            self.pkg_list += [
+                """
                     open A@{0},5.11-0
                     add depend type=origin root-image=true fmri=pkg:/feature/firmware/testdriver minimum-version={1}
                     close
                     open B@{2},5.11-0
                     add depend type=origin root-image=true fmri=pkg:/feature/firmware/testdriver minimum-version={3}
-                    close """.format(*(t + t)) ]
+                    close """.format(
+                    *(t + t)
+                )
+            ]
 
-                self.pkg_list += ["""
+        self.pkg_list += [
+            """
                     open A@1.4,5.11-0
                     add depend type=origin root-image=true fmri=pkg:/feature/firmware/testdriver
-                    close """]
+                    close """
+        ]
 
-                self.pkg_list += ["""
+        self.pkg_list += [
+            """
                     open A@1.6,5.11-0
                     add depend type=origin root-image=true fmri=pkg:/feature/firmware/testdriver dump_core=1
-                    close"""]
+                    close"""
+        ]
 
-                self.pkg_list += ["""
+        self.pkg_list += [
+            """
                     open C@1.0,5.11-0
                     add depend type=origin root-image=true fmri=pkg:/feature/firmware/no-such-enumerator
-                    close"""]
+                    close"""
+        ]
 
-        def test_fw_dependency(self):
-                """test origin firmware dependency"""
-                """firmware test simulator uses alphabetic comparison"""
+    def test_fw_dependency(self):
+        """test origin firmware dependency"""
+        """firmware test simulator uses alphabetic comparison"""
 
-                if portable.osname != "sunos":
-                        raise pkg5unittest.TestSkippedException(
-                            "Firmware check unsupported on this platform.")
+        if portable.osname != "sunos":
+            raise pkg5unittest.TestSkippedException(
+                "Firmware check unsupported on this platform."
+            )
 
-                rurl = self.dc.get_repo_url()
-                plist = self.pkgsend_bulk(rurl, self.pkg_list)
-                self.image_create(rurl)
+        rurl = self.dc.get_repo_url()
+        plist = self.pkgsend_bulk(rurl, self.pkg_list)
+        self.image_create(rurl)
 
-                os.environ["PKG_INSTALLED_VERSION"] = "elf"
-                # trim some of the versions out; note that pkgs w/ firmware
-                # errors/problems are silently ignored.
-                self.pkg("install A B")
-                self.pkg("list")
-                self.pkg("verify A@1.1")
-                # test verify by changing device version
-                os.environ["PKG_INSTALLED_VERSION"] = "dwarf"
-                self.pkg("verify A@1.1", 1)
-                os.environ["PKG_INSTALLED_VERSION"] = "elf"
-                # exercise large number of devices code
-                os.environ["PKG_NUM_FAKE_DEVICES"] = "500"
-                self.pkg("install A@1.3", 1)
-                # exercise general error codes
-                self.pkg("install A@1.4", 1)
-                self.pkg("install A@1.6", 1)
-                # verify that upreving the firmware lets us install more
-                os.environ["PKG_INSTALLED_VERSION"] = "hobbit"
-                self.pkg("update")
-                self.pkg("verify A@1.2")
-                # simulate removing device
-                del os.environ["PKG_INSTALLED_VERSION"]
-                self.pkg("update")
-                self.pkg("list")
-                self.pkg("verify A@1.6")
-                # ok since we never drop core
-                # here as device
-                # doesn't exist.
+        os.environ["PKG_INSTALLED_VERSION"] = "elf"
+        # trim some of the versions out; note that pkgs w/ firmware
+        # errors/problems are silently ignored.
+        self.pkg("install A B")
+        self.pkg("list")
+        self.pkg("verify A@1.1")
+        # test verify by changing device version
+        os.environ["PKG_INSTALLED_VERSION"] = "dwarf"
+        self.pkg("verify A@1.1", 1)
+        os.environ["PKG_INSTALLED_VERSION"] = "elf"
+        # exercise large number of devices code
+        os.environ["PKG_NUM_FAKE_DEVICES"] = "500"
+        self.pkg("install A@1.3", 1)
+        # exercise general error codes
+        self.pkg("install A@1.4", 1)
+        self.pkg("install A@1.6", 1)
+        # verify that upreving the firmware lets us install more
+        os.environ["PKG_INSTALLED_VERSION"] = "hobbit"
+        self.pkg("update")
+        self.pkg("verify A@1.2")
+        # simulate removing device
+        del os.environ["PKG_INSTALLED_VERSION"]
+        self.pkg("update")
+        self.pkg("list")
+        self.pkg("verify A@1.6")
+        # ok since we never drop core
+        # here as device
+        # doesn't exist.
 
-                # check that we ignore dependencies w/ missing enumerators for now
-                self.pkg("install C@1.0")
+        # check that we ignore dependencies w/ missing enumerators for now
+        self.pkg("install C@1.0")
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_R_option.py
+++ b/src/tests/cli/t_pkg_R_option.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -33,106 +34,114 @@ import unittest
 
 
 class TestROption(pkg5unittest.SingleDepotTestCase):
-        # Cleanup after every test.
-        persistent_setup = False
+    # Cleanup after every test.
+    persistent_setup = False
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.pkgsend_bulk(self.rurl, self.foo10)
-                self.image_create(self.rurl)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.pkgsend_bulk(self.rurl, self.foo10)
+        self.image_create(self.rurl)
 
-        def test_bad_cli_options(self):
-                """Verify that pkg rejects invalid -R combos and values."""
+    def test_bad_cli_options(self):
+        """Verify that pkg rejects invalid -R combos and values."""
 
-                self.pkg("-@", exit=2)
-                self.pkg("-s status", exit=2)
-                self.pkg("-R status", exit=2)
-                self.pkg("-R / version", exit=2)
+        self.pkg("-@", exit=2)
+        self.pkg("-s status", exit=2)
+        self.pkg("-R status", exit=2)
+        self.pkg("-R / version", exit=2)
 
-        def test_1_explicit(self):
-                """Ensure that pkg explicit image specification works as
-                expected."""
+    def test_1_explicit(self):
+        """Ensure that pkg explicit image specification works as
+        expected."""
 
-                imgpath = self.img_path()
-                badpath = self.test_root
+        imgpath = self.img_path()
+        badpath = self.test_root
 
-                # Verify that bad paths cause exit and good paths succeed.
-                self.pkg("-R {0} list".format(badpath), exit=1)
-                self.pkg("-R {0} list".format(imgpath), exit=1)
+        # Verify that bad paths cause exit and good paths succeed.
+        self.pkg("-R {0} list".format(badpath), exit=1)
+        self.pkg("-R {0} list".format(imgpath), exit=1)
 
-                self.pkg("-R {0} install foo".format(badpath), exit=1)
-                self.pkg("-R {0} install foo".format(imgpath))
+        self.pkg("-R {0} install foo".format(badpath), exit=1)
+        self.pkg("-R {0} install foo".format(imgpath))
 
-                self.pkg("-R {0} list".format(badpath), exit=1)
-                self.pkg("-R {0} list".format(imgpath))
+        self.pkg("-R {0} list".format(badpath), exit=1)
+        self.pkg("-R {0} list".format(imgpath))
 
-                self.pkgsend_bulk(self.rurl, self.foo10)
-                self.pkg("-R {0} refresh".format(imgpath))
+        self.pkgsend_bulk(self.rurl, self.foo10)
+        self.pkg("-R {0} refresh".format(imgpath))
 
-                self.pkg("-R {0} update".format(badpath), exit=1)
-                self.pkg("-R {0} update --be-name NEWBENAME".format(imgpath), exit=1)
-                self.pkg("-R {0} update".format(imgpath))
+        self.pkg("-R {0} update".format(badpath), exit=1)
+        self.pkg("-R {0} update --be-name NEWBENAME".format(imgpath), exit=1)
+        self.pkg("-R {0} update".format(imgpath))
 
-                self.pkg("-R {0} uninstall foo".format(badpath), exit=1)
-                self.pkg("-R {0} install foo".format(imgpath), exit=4)
+        self.pkg("-R {0} uninstall foo".format(badpath), exit=1)
+        self.pkg("-R {0} install foo".format(imgpath), exit=4)
 
-                self.pkg("-R {0} info foo".format(badpath), exit=1)
-                self.pkg("-R {0} info foo".format(imgpath))
+        self.pkg("-R {0} info foo".format(badpath), exit=1)
+        self.pkg("-R {0} info foo".format(imgpath))
 
-        def test_2_implicit(self):
-                """Ensure that pkg implicit image finding works as expected."""
+    def test_2_implicit(self):
+        """Ensure that pkg implicit image finding works as expected."""
 
-                # Should fail because $PKG_IMAGE is set to test root by default,
-                # and default test behaviour to use -R self.img_path() was
-                # disabled.
-                self.pkg("install foo", exit=1, use_img_root=False)
+        # Should fail because $PKG_IMAGE is set to test root by default,
+        # and default test behaviour to use -R self.img_path() was
+        # disabled.
+        self.pkg("install foo", exit=1, use_img_root=False)
 
-                # Unset unit testing default bogus image dir.
-                del os.environ["PKG_IMAGE"]
-                os.chdir(self.img_path())
-                self.assertEqual(os.getcwd(), self.img_path())
+        # Unset unit testing default bogus image dir.
+        del os.environ["PKG_IMAGE"]
+        os.chdir(self.img_path())
+        self.assertEqual(os.getcwd(), self.img_path())
 
-                if portable.osname != "sunos":
-                        # For other platforms, first install a package using an
-                        # explicit root, and then verify that an implicit find
-                        # of the image results in the right image being found.
-                        self.pkg("install foo")
-                        self.pkg("info foo", use_img_root=False)
+        if portable.osname != "sunos":
+            # For other platforms, first install a package using an
+            # explicit root, and then verify that an implicit find
+            # of the image results in the right image being found.
+            self.pkg("install foo")
+            self.pkg("info foo", use_img_root=False)
 
-                        # Remaining tests are not valid on other platforms.
-                        return
+            # Remaining tests are not valid on other platforms.
+            return
 
-                # Should fail because live root is not an image (Solaris 10
-                # case), even though CWD contains a valid one since
-                # PKG_FIND_IMAGE was not set in environment.
-                bad_live_root = os.path.join(self.test_root, "test_2_implicit")
-                os.mkdir(bad_live_root)
-                self.pkg("-D simulate_live_root={0} install foo ".format(bad_live_root),
-                     use_img_root=False, exit=1)
+        # Should fail because live root is not an image (Solaris 10
+        # case), even though CWD contains a valid one since
+        # PKG_FIND_IMAGE was not set in environment.
+        bad_live_root = os.path.join(self.test_root, "test_2_implicit")
+        os.mkdir(bad_live_root)
+        self.pkg(
+            "-D simulate_live_root={0} install foo ".format(bad_live_root),
+            use_img_root=False,
+            exit=1,
+        )
 
-                # Should succeed because image is found at simulated live root,
-                # even though one does not exist in CWD.
-                os.chdir(self.test_root)
-                self.pkg("-D simulate_live_root={0} install foo".format(
-                    self.img_path()), use_img_root=False)
+        # Should succeed because image is found at simulated live root,
+        # even though one does not exist in CWD.
+        os.chdir(self.test_root)
+        self.pkg(
+            "-D simulate_live_root={0} install foo".format(self.img_path()),
+            use_img_root=False,
+        )
 
-                # Should succeed because image is found using CWD and
-                # PKG_FIND_IMAGE was set in environment, even though live root
-                # is not a valid image.
-                os.environ["PKG_FIND_IMAGE"] = "true"
-                os.chdir(self.img_path())
-                self.pkg("-D simulate_live_root={0} uninstall foo".format(
-                     bad_live_root, use_img_root=False))
-                del os.environ["PKG_FIND_IMAGE"]
-                os.chdir(self.test_root)
+        # Should succeed because image is found using CWD and
+        # PKG_FIND_IMAGE was set in environment, even though live root
+        # is not a valid image.
+        os.environ["PKG_FIND_IMAGE"] = "true"
+        os.chdir(self.img_path())
+        self.pkg(
+            "-D simulate_live_root={0} uninstall foo".format(
+                bad_live_root, use_img_root=False
+            )
+        )
+        del os.environ["PKG_FIND_IMAGE"]
+        os.chdir(self.test_root)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_autoremove.py
+++ b/src/tests/cli/t_pkg_autoremove.py
@@ -27,8 +27,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -56,109 +57,109 @@ import pkg.portable as portable
 
 from pkg.client.pkgdefs import EXIT_OOPS, EXIT_NOP, EXIT_BADOPT
 
-class TestPkgAutoremove(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
 
-        foo10 = """
+class TestPkgAutoremove(pkg5unittest.SingleDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        bar11 = """
+    bar11 = """
             open bar@1.1,5.11-0
             add depend type=require fmri=pkg:/foo
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        misc_files = [ "tmp/cat" ]
+    misc_files = ["tmp/cat"]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-        def test_cli_badoptions(self):
-                """Test bad cli options"""
+    def test_cli_badoptions(self):
+        """Test bad cli options"""
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                self.pkg("autoremove -@", exit=EXIT_BADOPT)
-                self.pkg("autoremove -vq foo", exit=EXIT_BADOPT)
-                self.pkg("autoremove foo@x.y", exit=EXIT_BADOPT)
-                self.pkg("autoremove pkg:/foo@bar.baz", exit=EXIT_BADOPT)
+        self.pkg("autoremove -@", exit=EXIT_BADOPT)
+        self.pkg("autoremove -vq foo", exit=EXIT_BADOPT)
+        self.pkg("autoremove foo@x.y", exit=EXIT_BADOPT)
+        self.pkg("autoremove pkg:/foo@bar.baz", exit=EXIT_BADOPT)
 
-        def test_autoremove_basics(self):
-                plist = self.pkgsend_bulk(self.rurl, self.foo10)
-                self.image_create(self.rurl)
+    def test_autoremove_basics(self):
+        plist = self.pkgsend_bulk(self.rurl, self.foo10)
+        self.image_create(self.rurl)
 
-                self.pkg("install --parsable=0 foo")
-                self.assertEqualParsable(self.output, add_packages=plist)
+        self.pkg("install --parsable=0 foo")
+        self.assertEqualParsable(self.output, add_packages=plist)
 
-                # autoremove should return NOP since there is nothing to do
-                self.pkg("autoremove", exit=EXIT_NOP)
+        # autoremove should return NOP since there is nothing to do
+        self.pkg("autoremove", exit=EXIT_NOP)
 
-                # Now unflag the package as manually installed
-                self.pkg("flag -M foo")
+        # Now unflag the package as manually installed
+        self.pkg("flag -M foo")
 
-                # Autoremove should now remove foo
-                self.pkg("autoremove --parsable=0")
-                self.assertEqualParsable(self.output, remove_packages=plist)
+        # Autoremove should now remove foo
+        self.pkg("autoremove --parsable=0")
+        self.assertEqualParsable(self.output, remove_packages=plist)
 
-        def test_autoremove_install_dep(self):
-                plist = self.pkgsend_bulk(self.rurl, [self.bar11, self.foo10])
-                self.image_create(self.rurl)
+    def test_autoremove_install_dep(self):
+        plist = self.pkgsend_bulk(self.rurl, [self.bar11, self.foo10])
+        self.image_create(self.rurl)
 
-                # bar depends on foo
-                self.pkg("install --parsable=0 bar")
-                self.assertEqualParsable(self.output, add_packages=plist)
+        # bar depends on foo
+        self.pkg("install --parsable=0 bar")
+        self.assertEqualParsable(self.output, add_packages=plist)
 
-                # autoremove should return NOP
-                self.pkg("autoremove", exit=EXIT_NOP)
+        # autoremove should return NOP
+        self.pkg("autoremove", exit=EXIT_NOP)
 
-                # Now remove bar
-                self.pkg("uninstall bar")
+        # Now remove bar
+        self.pkg("uninstall bar")
 
-                # Autoremove should now remove foo
-                self.pkg("autoremove --parsable=0")
-                self.assertEqualParsable(self.output,
-                    remove_packages=[plist[1]])
+        # Autoremove should now remove foo
+        self.pkg("autoremove --parsable=0")
+        self.assertEqualParsable(self.output, remove_packages=[plist[1]])
 
-        def test_autoremove_update(self):
-                plist = self.pkgsend_bulk(self.rurl,
-                    [self.bar10, self.bar11, self.foo10])
-                self.image_create(self.rurl)
+    def test_autoremove_update(self):
+        plist = self.pkgsend_bulk(
+            self.rurl, [self.bar10, self.bar11, self.foo10]
+        )
+        self.image_create(self.rurl)
 
-                # bar10 has no dependencies, bar@1.1 depends on foo
-                self.pkg("install --parsable=0 bar@1.0")
-                self.assertEqualParsable(self.output, add_packages=[plist[0]])
+        # bar10 has no dependencies, bar@1.1 depends on foo
+        self.pkg("install --parsable=0 bar@1.0")
+        self.assertEqualParsable(self.output, add_packages=[plist[0]])
 
-                # This update will pull in foo as a dependency
-                self.pkg("update bar")
+        # This update will pull in foo as a dependency
+        self.pkg("update bar")
 
-                # autoremove should return NOP since foo has a dependant
-                self.pkg("autoremove", exit=EXIT_NOP)
+        # autoremove should return NOP since foo has a dependant
+        self.pkg("autoremove", exit=EXIT_NOP)
 
-                # Now remove bar
-                self.pkg("uninstall bar")
+        # Now remove bar
+        self.pkg("uninstall bar")
 
-                # Autoremove should now remove foo
-                self.pkg("autoremove --parsable=0")
-                self.assertEqualParsable(self.output,
-                    remove_packages=[plist[2]])
+        # Autoremove should now remove foo
+        self.pkg("autoremove --parsable=0")
+        self.assertEqualParsable(self.output, remove_packages=[plist[2]])
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_avoid.py
+++ b/src/tests/cli/t_pkg_avoid.py
@@ -26,18 +26,20 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 import os
 
 import pkg.json as json
 
-class TestPkgAvoid(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
 
-        pkgs = """
+class TestPkgAvoid(pkg5unittest.SingleDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+
+    pkgs = """
             open A@1.0,5.11-0
             add depend type=require fmri=liveroot
             close
@@ -110,269 +112,280 @@ class TestPkgAvoid(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        def __get_avoid_set(self):
-                """Returns a tuple of (avoid, implicit_avoid, obsolete)
-                representing packages being avoided by image configuration or
-                due to package constraints (respectively)."""
+    def __get_avoid_set(self):
+        """Returns a tuple of (avoid, implicit_avoid, obsolete)
+        representing packages being avoided by image configuration or
+        due to package constraints (respectively)."""
 
-                fpath = self.get_img_file_path("var/pkg/state/avoid_set")
-                with open(fpath) as f:
-                        version, d = json.load(f)
+        fpath = self.get_img_file_path("var/pkg/state/avoid_set")
+        with open(fpath) as f:
+            version, d = json.load(f)
 
-                avoid = set()
-                implicit_avoid = set()
-                obsolete = set()
-                for stem in d:
-                        if d[stem] == "avoid":
-                                avoid.add(stem)
-                        elif d[stem] == "implicit-avoid":
-                                implicit_avoid.add(stem)
-                        elif d[stem] == "obsolete":
-                                obsolete.add(stem)
-                return avoid, implicit_avoid, obsolete
+        avoid = set()
+        implicit_avoid = set()
+        obsolete = set()
+        for stem in d:
+            if d[stem] == "avoid":
+                avoid.add(stem)
+            elif d[stem] == "implicit-avoid":
+                implicit_avoid.add(stem)
+            elif d[stem] == "obsolete":
+                obsolete.add(stem)
+        return avoid, implicit_avoid, obsolete
 
-        def __assertAvoids(self, avoid=frozenset(), implicit=frozenset(),
-            obsolete=frozenset()):
-                aavoid, aimplicit, aobsolete = self.__get_avoid_set()
-                self.assertEqualDiff(sorted(avoid), sorted(aavoid),
-                    msg="avoids")
-                self.assertEqualDiff(sorted(implicit), sorted(aimplicit),
-                    msg="implicit avoids")
-                self.assertEqualDiff(sorted(obsolete), sorted(aobsolete),
-                    msg="obsolete avoids")
+    def __assertAvoids(
+        self, avoid=frozenset(), implicit=frozenset(), obsolete=frozenset()
+    ):
+        aavoid, aimplicit, aobsolete = self.__get_avoid_set()
+        self.assertEqualDiff(sorted(avoid), sorted(aavoid), msg="avoids")
+        self.assertEqualDiff(
+            sorted(implicit), sorted(aimplicit), msg="implicit avoids"
+        )
+        self.assertEqualDiff(
+            sorted(obsolete), sorted(aobsolete), msg="obsolete avoids"
+        )
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files("tmp/liveroot")
-                self.pkgsend_bulk(self.rurl, self.pkgs)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files("tmp/liveroot")
+        self.pkgsend_bulk(self.rurl, self.pkgs)
 
-        def test_group_basics(self):
-                """Make sure group dependencies work"""
-                self.image_create(self.rurl)
-                # make sure that unavoiding a package which isn't avoided
-                # doesn't traceback.
-                self.pkg("unavoid C", exit=1)
+    def test_group_basics(self):
+        """Make sure group dependencies work"""
+        self.image_create(self.rurl)
+        # make sure that unavoiding a package which isn't avoided
+        # doesn't traceback.
+        self.pkg("unavoid C", exit=1)
 
-                # make sure group dependency brings in packages
-                self.pkg("install C")
-                self.pkg("verify A B C")
-                self.pkg("uninstall '*'")
-                # test that we don't avoid packages when we
-                # uninstall group at the same time
-                self.pkg("avoid")
-                assert self.output == ""
-                self.__assertAvoids()
+        # make sure group dependency brings in packages
+        self.pkg("install C")
+        self.pkg("verify A B C")
+        self.pkg("uninstall '*'")
+        # test that we don't avoid packages when we
+        # uninstall group at the same time
+        self.pkg("avoid")
+        assert self.output == ""
+        self.__assertAvoids()
 
-                # avoid a package
-                self.pkg("avoid 'B*'")
-                self.pkg("avoid")
-                assert " B" in self.output
-                assert "Bobcats" in self.output
-                self.__assertAvoids(avoid=frozenset(["B", "Bobcats"]))
-                self.pkg("unavoid Bobcats")
+        # avoid a package
+        self.pkg("avoid 'B*'")
+        self.pkg("avoid")
+        assert " B" in self.output
+        assert "Bobcats" in self.output
+        self.__assertAvoids(avoid=frozenset(["B", "Bobcats"]))
+        self.pkg("unavoid Bobcats")
 
-                # and then see if it gets brought in
-                self.pkg("install C")
-                self.pkg("verify A C")
-                self.pkg("list B", exit=1)
-                self.pkg("avoid")
-                # unavoiding it should fail because there
-                # is a group dependency on it...
-                self.pkg("unavoid B", exit=1)
+        # and then see if it gets brought in
+        self.pkg("install C")
+        self.pkg("verify A C")
+        self.pkg("list B", exit=1)
+        self.pkg("avoid")
+        # unavoiding it should fail because there
+        # is a group dependency on it...
+        self.pkg("unavoid B", exit=1)
 
-                # installing it should work
-                self.pkg("install B")
-                self.pkg("verify A B C")
+        # installing it should work
+        self.pkg("install B")
+        self.pkg("verify A B C")
 
-                # B should no longer be in avoid list
-                self.pkg("avoid")
-                assert "B" not in self.output
-                self.__assertAvoids()
+        # B should no longer be in avoid list
+        self.pkg("avoid")
+        assert "B" not in self.output
+        self.__assertAvoids()
 
-                # avoiding installed packages should fail
-                self.pkg("avoid C", exit=1)
-                self.pkg("uninstall '*'")
+        # avoiding installed packages should fail
+        self.pkg("avoid C", exit=1)
+        self.pkg("uninstall '*'")
 
-        def test_group_require(self):
-                """Show that require dependencies 'overpower' avoid state"""
-                self.image_create(self.rurl)
-                # test require dependencies w/ avoid
-                self.pkg("avoid A B")
-                self.pkg("install C D")
-                # D will have forced in B
-                self.pkg("verify C D B")
-                self.pkg("verify A", exit=1)
-                # check to make sure we're avoiding despite
-                # forced install of B
-                self.__assertAvoids(avoid=frozenset(["A", "B"]))
-                # Uninstall of D removes B as well
-                self.pkg("uninstall D")
-                self.pkg("verify A", exit=1)
-                self.pkg("verify D", exit=1)
-                self.pkg("verify B", exit=1)
-                self.pkg("uninstall '*'")
-                self.pkg("unavoid A B")
-                self.__assertAvoids()
+    def test_group_require(self):
+        """Show that require dependencies 'overpower' avoid state"""
+        self.image_create(self.rurl)
+        # test require dependencies w/ avoid
+        self.pkg("avoid A B")
+        self.pkg("install C D")
+        # D will have forced in B
+        self.pkg("verify C D B")
+        self.pkg("verify A", exit=1)
+        # check to make sure we're avoiding despite
+        # forced install of B
+        self.__assertAvoids(avoid=frozenset(["A", "B"]))
+        # Uninstall of D removes B as well
+        self.pkg("uninstall D")
+        self.pkg("verify A", exit=1)
+        self.pkg("verify D", exit=1)
+        self.pkg("verify B", exit=1)
+        self.pkg("uninstall '*'")
+        self.pkg("unavoid A B")
+        self.__assertAvoids()
 
-        def test_group_update(self):
-                """Test to make sure avoided packages
-                are removed when required dependency
-                goes away"""
-                self.image_create(self.rurl)
-                # examine upgrade behavior
-                self.pkg("avoid A B")
-                self.__assertAvoids(avoid=frozenset(["A", "B"]))
-                self.pkg("install E@1.0")
-                self.pkg("verify")
-                self.pkg("update E@2.0")
-                self.pkg("verify E@2.0 A")
-                self.pkg("verify B", exit=1)
-                self.pkg("update E@3.0")
-                self.pkg("verify E@3.0 B")
-                self.pkg("verify A", exit=1)
-                self.pkg("update E@4.0")
-                self.pkg("verify E@4.0")
-                self.pkg("verify A", exit=1)
-                self.pkg("verify B", exit=1)
-                self.pkg("update E@2.0")
-                self.pkg("verify E@2.0")
-                self.pkg("uninstall '*'")
-                self.__assertAvoids(avoid=frozenset(["A", "B"]))
+    def test_group_update(self):
+        """Test to make sure avoided packages
+        are removed when required dependency
+        goes away"""
+        self.image_create(self.rurl)
+        # examine upgrade behavior
+        self.pkg("avoid A B")
+        self.__assertAvoids(avoid=frozenset(["A", "B"]))
+        self.pkg("install E@1.0")
+        self.pkg("verify")
+        self.pkg("update E@2.0")
+        self.pkg("verify E@2.0 A")
+        self.pkg("verify B", exit=1)
+        self.pkg("update E@3.0")
+        self.pkg("verify E@3.0 B")
+        self.pkg("verify A", exit=1)
+        self.pkg("update E@4.0")
+        self.pkg("verify E@4.0")
+        self.pkg("verify A", exit=1)
+        self.pkg("verify B", exit=1)
+        self.pkg("update E@2.0")
+        self.pkg("verify E@2.0")
+        self.pkg("uninstall '*'")
+        self.__assertAvoids(avoid=frozenset(["A", "B"]))
 
-        def test_group_reject_1(self):
-                """test aspects of reject."""
-                self.image_create(self.rurl)
-                # make sure install w/ --reject
-                # places packages w/ group dependencies
-                # on avoid list
-                self.pkg("install --reject A F@1.0")
-                self.__assertAvoids(avoid=frozenset(["A"]))
-                # install A and see it removed from avoid list
-                self.pkg("install A")
-                self.__assertAvoids()
-                self.pkg("verify F@1.0 A")
-                # remove A and see it added to avoid list
-                self.pkg("uninstall A")
-                self.__assertAvoids(avoid=frozenset(["A"]))
-                # update F and see A kept out, but B added
-                self.pkg("update F@2")
-                self.pkg("verify F@2.0 B")
-                self.pkg("verify A", exit=1)
-                self.__assertAvoids(avoid=frozenset(["A"]))
-                self.pkg("update --reject B F@3.0")
-                self.__assertAvoids(avoid=frozenset(["A", "B"]))
-                self.pkg("verify F@3.0 C")
-                self.pkg("verify A", exit=1)
-                self.pkg("verify B", exit=1)
-                # update everything
-                self.pkg("update")
-                self.__assertAvoids(avoid=frozenset(["A", "B"]))
-                self.pkg("verify F@4.0 C D B")
-                self.pkg("verify A", exit=1)
-                # check 17264951
-                # break something so pkg fix will do some work
-                dpath = self.get_img_file_path("etc/breakable")
-                os.chmod(dpath, 0o700)
-                self.pkg("fix F")
-                self.__assertAvoids(avoid=frozenset(["A", "B"]))
-                self.pkg("verify")
+    def test_group_reject_1(self):
+        """test aspects of reject."""
+        self.image_create(self.rurl)
+        # make sure install w/ --reject
+        # places packages w/ group dependencies
+        # on avoid list
+        self.pkg("install --reject A F@1.0")
+        self.__assertAvoids(avoid=frozenset(["A"]))
+        # install A and see it removed from avoid list
+        self.pkg("install A")
+        self.__assertAvoids()
+        self.pkg("verify F@1.0 A")
+        # remove A and see it added to avoid list
+        self.pkg("uninstall A")
+        self.__assertAvoids(avoid=frozenset(["A"]))
+        # update F and see A kept out, but B added
+        self.pkg("update F@2")
+        self.pkg("verify F@2.0 B")
+        self.pkg("verify A", exit=1)
+        self.__assertAvoids(avoid=frozenset(["A"]))
+        self.pkg("update --reject B F@3.0")
+        self.__assertAvoids(avoid=frozenset(["A", "B"]))
+        self.pkg("verify F@3.0 C")
+        self.pkg("verify A", exit=1)
+        self.pkg("verify B", exit=1)
+        # update everything
+        self.pkg("update")
+        self.__assertAvoids(avoid=frozenset(["A", "B"]))
+        self.pkg("verify F@4.0 C D B")
+        self.pkg("verify A", exit=1)
+        # check 17264951
+        # break something so pkg fix will do some work
+        dpath = self.get_img_file_path("etc/breakable")
+        os.chmod(dpath, 0o700)
+        self.pkg("fix F")
+        self.__assertAvoids(avoid=frozenset(["A", "B"]))
+        self.pkg("verify")
 
-        def test_group_reject_2(self):
-                """Make sure --reject places packages
-                on avoid list; insure that multiple
-                group dependencies don't overcome
-                avoid list, and that require dependencies
-                do."""
-                self.image_create(self.rurl)
-                self.pkg("install F@1.0")
-                self.pkg("verify F@1.0 A")
-                self.pkg("update --reject B --reject A F@2.0")
-                self.pkg("verify F@2.0")
-                self.__assertAvoids(avoid=frozenset(["A", "B"]))
+    def test_group_reject_2(self):
+        """Make sure --reject places packages
+        on avoid list; insure that multiple
+        group dependencies don't overcome
+        avoid list, and that require dependencies
+        do."""
+        self.image_create(self.rurl)
+        self.pkg("install F@1.0")
+        self.pkg("verify F@1.0 A")
+        self.pkg("update --reject B --reject A F@2.0")
+        self.pkg("verify F@2.0")
+        self.__assertAvoids(avoid=frozenset(["A", "B"]))
 
-        def test_group_obsolete_ok(self):
-                """Make sure we're down w/ obsoletions, and that
-                they are automatically placed on the avoid list"""
-                self.image_create(self.rurl)
-                self.pkg("install I@1.0") # anchor version of G
-                self.pkg("install H")
-                self.pkg("verify G@1.0 H@1.0 I@1.0")
-                self.__assertAvoids()
-                # update I; this will force G to an obsolete
-                # version.  This should place it on the
-                # avoid list
-                self.pkg("update I@2.0")
-                self.pkg("list G", exit=1)
-                self.pkg("verify I@2.0 H@1.0")
-                self.__assertAvoids(obsolete=frozenset(["G"]))
-                # update I again; this should bring G back
-                # as it is no longer obsolete.
-                self.pkg("update I@3.0")
-                self.pkg("verify I@3.0 G@3.0 H@1.0")
-                self.__assertAvoids()
+    def test_group_obsolete_ok(self):
+        """Make sure we're down w/ obsoletions, and that
+        they are automatically placed on the avoid list"""
+        self.image_create(self.rurl)
+        self.pkg("install I@1.0")  # anchor version of G
+        self.pkg("install H")
+        self.pkg("verify G@1.0 H@1.0 I@1.0")
+        self.__assertAvoids()
+        # update I; this will force G to an obsolete
+        # version.  This should place it on the
+        # avoid list
+        self.pkg("update I@2.0")
+        self.pkg("list G", exit=1)
+        self.pkg("verify I@2.0 H@1.0")
+        self.__assertAvoids(obsolete=frozenset(["G"]))
+        # update I again; this should bring G back
+        # as it is no longer obsolete.
+        self.pkg("update I@3.0")
+        self.pkg("verify I@3.0 G@3.0 H@1.0")
+        self.__assertAvoids()
 
-        def test_unavoid(self):
-                """Make sure pkg unavoid should always allow installed packages
-                that are a target of group dependencies to be unavoided."""
+    def test_unavoid(self):
+        """Make sure pkg unavoid should always allow installed packages
+        that are a target of group dependencies to be unavoided."""
 
-                self.image_create(self.rurl)
-                # Avoid package liveroot to put it on the avoid list.
-                self.pkg("avoid liveroot")
-                self.__assertAvoids(avoid=frozenset(["liveroot"]))
+        self.image_create(self.rurl)
+        # Avoid package liveroot to put it on the avoid list.
+        self.pkg("avoid liveroot")
+        self.__assertAvoids(avoid=frozenset(["liveroot"]))
 
-                # A has require dependency on liveroot and B has group
-                # dependency on liveroot. Since require dependency 'overpower'
-                # avoid state, liveroot is required to be installed.
-                self.pkg("--debug simulate_live_root={0} install A B".format(
-                    self.get_img_path()))
-                self.pkg("list")
-                assert "liveroot" in self.output
+        # A has require dependency on liveroot and B has group
+        # dependency on liveroot. Since require dependency 'overpower'
+        # avoid state, liveroot is required to be installed.
+        self.pkg(
+            "--debug simulate_live_root={0} install A B".format(
+                self.get_img_path()
+            )
+        )
+        self.pkg("list")
+        assert "liveroot" in self.output
 
-                # Make sure liveroot is still on the avoid list.
-                self.__assertAvoids(avoid=frozenset(["liveroot"]))
+        # Make sure liveroot is still on the avoid list.
+        self.__assertAvoids(avoid=frozenset(["liveroot"]))
 
-                # Unable to uninstall A because the package system currently
-                # requires the avoided package liveroot to be uninstalled,
-                # which requires reboot.
-                self.pkg("--debug simulate_live_root={0} uninstall --deny-new-be A".format(
-                    self.get_img_path()), exit=5)
+        # Unable to uninstall A because the package system currently
+        # requires the avoided package liveroot to be uninstalled,
+        # which requires reboot.
+        self.pkg(
+            "--debug simulate_live_root={0} uninstall --deny-new-be A".format(
+                self.get_img_path()
+            ),
+            exit=5,
+        )
 
-                # We need to remove liveroot from the avoid list, and pkg unvoid
-                # should allow installed packages that are a target of group
-                # dependencies to be unavoided.
-                self.pkg("unavoid liveroot")
-                self.__assertAvoids()
+        # We need to remove liveroot from the avoid list, and pkg unvoid
+        # should allow installed packages that are a target of group
+        # dependencies to be unavoided.
+        self.pkg("unavoid liveroot")
+        self.__assertAvoids()
 
-                # Uninstall A should succeed now because liveroot is not on the
-                # avoid list.
-                self.pkg("--debug simulate_live_root={0} uninstall --deny-new-be A".format(
-                    self.get_img_path()))
+        # Uninstall A should succeed now because liveroot is not on the
+        # avoid list.
+        self.pkg(
+            "--debug simulate_live_root={0} uninstall --deny-new-be A".format(
+                self.get_img_path()
+            )
+        )
 
-        def test_corrupted_avoid_file(self):
-                self.image_create(self.rurl)
-                self.pkg("avoid A")
-                avoid_set_path = self.get_img_file_path("var/pkg/state/avoid_set")
+    def test_corrupted_avoid_file(self):
+        self.image_create(self.rurl)
+        self.pkg("avoid A")
+        avoid_set_path = self.get_img_file_path("var/pkg/state/avoid_set")
 
-                # test for empty avoid set file
-                with open(avoid_set_path, "w+") as f:
-                        f.truncate(0)
-                self.pkg("avoid B", exit=0)
-                self.__assertAvoids(avoid=frozenset(["B"]))
+        # test for empty avoid set file
+        with open(avoid_set_path, "w+") as f:
+            f.truncate(0)
+        self.pkg("avoid B", exit=0)
+        self.__assertAvoids(avoid=frozenset(["B"]))
 
-                # test avoid set file having junk values
-                with open(avoid_set_path, "w+") as f:
-                        f.write('Some junk value\n')
-                self.pkg("avoid C", exit=0)
-                self.__assertAvoids(avoid=frozenset(["C"]))
+        # test avoid set file having junk values
+        with open(avoid_set_path, "w+") as f:
+            f.write("Some junk value\n")
+        self.pkg("avoid C", exit=0)
+        self.__assertAvoids(avoid=frozenset(["C"]))
 
-        def test_group_trim(self):
-                """Verify that trimmed group dependencies are placed on the
-                correct avoid list."""
+    def test_group_trim(self):
+        """Verify that trimmed group dependencies are placed on the
+        correct avoid list."""
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                exclude_pkgs = \
-                    """open bar@1.0
+        exclude_pkgs = """open bar@1.0
                     add depend type=group fmri=foo
                     close
                     open baz@1.0
@@ -381,172 +394,164 @@ class TestPkgAvoid(pkg5unittest.SingleDepotTestCase):
                     open foo@1.0
                     close"""
 
-                pfmris = self.pkgsend_bulk(self.rurl, exclude_pkgs)
+        pfmris = self.pkgsend_bulk(self.rurl, exclude_pkgs)
 
-                # Install bar; foo should also be installed.
-                self.pkg("install --parsable=0 bar")
-                self.assertEqualParsable(self.output,
-                    add_packages=[pfmris[0], pfmris[2]]
-                )
-                self.__assertAvoids()
+        # Install bar; foo should also be installed.
+        self.pkg("install --parsable=0 bar")
+        self.assertEqualParsable(
+            self.output, add_packages=[pfmris[0], pfmris[2]]
+        )
+        self.__assertAvoids()
 
-                # Install baz; should fail since foo is installed and it is
-                # excluded.
-                self.pkg("install --parsable=0 baz", exit=1)
-                self.__assertAvoids()
+        # Install baz; should fail since foo is installed and it is
+        # excluded.
+        self.pkg("install --parsable=0 baz", exit=1)
+        self.__assertAvoids()
 
-                # Remove foo; foo should be placed on avoid list.
-                self.pkg("uninstall --parsable=0 foo")
-                self.assertEqualParsable(self.output,
-                    remove_packages=pfmris[-1:]
-                )
-                self.__assertAvoids(avoid=frozenset(["foo"]))
+        # Remove foo; foo should be placed on avoid list.
+        self.pkg("uninstall --parsable=0 foo")
+        self.assertEqualParsable(self.output, remove_packages=pfmris[-1:])
+        self.__assertAvoids(avoid=frozenset(["foo"]))
 
-                # Remove all packages.
-                self.pkg("uninstall --parsable=0 \\*")
-                self.assertEqualParsable(self.output,
-                    remove_packages=pfmris[0:1]
-                )
+        # Remove all packages.
+        self.pkg("uninstall --parsable=0 \\*")
+        self.assertEqualParsable(self.output, remove_packages=pfmris[0:1])
 
-                # Foo should still be on the avoid list.
-                self.__assertAvoids(avoid=frozenset(["foo"]))
-                self.pkg("unavoid foo")
+        # Foo should still be on the avoid list.
+        self.__assertAvoids(avoid=frozenset(["foo"]))
+        self.pkg("unavoid foo")
 
-                # Nothing should be installed.
-                self.pkg("list", exit=1)
+        # Nothing should be installed.
+        self.pkg("list", exit=1)
 
-                # Install baz...
-                self.pkg("install --parsable=0 baz")
-                self.assertEqualParsable(self.output,
-                    add_packages=pfmris[1:2]
-                )
-                self.__assertAvoids()
+        # Install baz...
+        self.pkg("install --parsable=0 baz")
+        self.assertEqualParsable(self.output, add_packages=pfmris[1:2])
+        self.__assertAvoids()
 
-                # ...and then try to install bar; it should fail because the
-                # installed 'baz' package has an 'exclude' dependency on foo.
-                # Currently, the solver only allows group dependencies to be
-                # satisfied if at least one fmri matches the group dependency or
-                # if the only matches are obsolete.
-                self.pkg("install --parsable=0 bar", exit=1)
+        # ...and then try to install bar; it should fail because the
+        # installed 'baz' package has an 'exclude' dependency on foo.
+        # Currently, the solver only allows group dependencies to be
+        # satisfied if at least one fmri matches the group dependency or
+        # if the only matches are obsolete.
+        self.pkg("install --parsable=0 bar", exit=1)
 
-        def test_group_any_trim(self):
-                """Verify that unused group-any dependencies are placed on the
-                implicit avoid list (invisible to administrator) and obsoletion
-                behavior."""
+    def test_group_any_trim(self):
+        """Verify that unused group-any dependencies are placed on the
+        implicit avoid list (invisible to administrator) and obsoletion
+        behavior."""
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                pkgs = [
-                    """open dbx@1.0
+        pkgs = [
+            """open dbx@1.0
                     add depend type=group fmri=dbx-python
                     close""",
-                    """open dbx-python@1.0
+            """open dbx-python@1.0
                     add depend type=group-any fmri=python-26 fmri=python-27
                     close""",
-                    """open python-26@2.6
+            """open python-26@2.6
                     close""",
-                    """open python-27@2.7
+            """open python-27@2.7
                     close""",
-                    """open python-26@2.6.1
+            """open python-26@2.6.1
                     add set name=pkg.obsolete value=true
                     close""",
-                    """open python-27@2.7.1
+            """open python-27@2.7.1
                     add set name=pkg.obsolete value=true
-                    close"""
-                ]
-                pfmris = self.pkgsend_bulk(self.rurl, pkgs[0])
+                    close""",
+        ]
+        pfmris = self.pkgsend_bulk(self.rurl, pkgs[0])
 
-                # Install dbx; should succeed even though no dbx-python is
-                # available.
-                self.pkg("install --parsable=0 dbx")
-                self.assertEqualParsable(self.output,
-                    add_packages=pfmris[0:1],
-                )
-                self.__assertAvoids(implicit=frozenset(["dbx-python"]))
-                self.pkg("verify")
+        # Install dbx; should succeed even though no dbx-python is
+        # available.
+        self.pkg("install --parsable=0 dbx")
+        self.assertEqualParsable(
+            self.output,
+            add_packages=pfmris[0:1],
+        )
+        self.__assertAvoids(implicit=frozenset(["dbx-python"]))
+        self.pkg("verify")
 
-                # Publish dbx-python; pkg verify should still succeed.
-                pfmris.extend(self.pkgsend_bulk(self.rurl, pkgs[1]))
-                self.__assertAvoids(implicit=frozenset(["dbx-python"]))
-                self.pkg("refresh")
-                self.pkg("verify")
+        # Publish dbx-python; pkg verify should still succeed.
+        pfmris.extend(self.pkgsend_bulk(self.rurl, pkgs[1]))
+        self.__assertAvoids(implicit=frozenset(["dbx-python"]))
+        self.pkg("refresh")
+        self.pkg("verify")
 
-                # Install dbx-python; should succeed even though no python-*
-                # package is available and should be removed from implicit avoid
-                # list automatically.
-                self.pkg("install --parsable=0 dbx-python")
-                self.assertEqualParsable(self.output,
-                    add_packages=pfmris[1:2],
-                )
-                self.__assertAvoids(implicit=frozenset(["python-26",
-                    "python-27"]))
-                self.pkg("verify")
+        # Install dbx-python; should succeed even though no python-*
+        # package is available and should be removed from implicit avoid
+        # list automatically.
+        self.pkg("install --parsable=0 dbx-python")
+        self.assertEqualParsable(
+            self.output,
+            add_packages=pfmris[1:2],
+        )
+        self.__assertAvoids(implicit=frozenset(["python-26", "python-27"]))
+        self.pkg("verify")
 
-                # Remove dbx-python; python-26 and python-27 should be removed
-                # from implicit avoid list.
-                self.pkg("uninstall --parsable=0 dbx-python")
-                self.assertEqualParsable(self.output,
-                    remove_packages=pfmris[1:2]
-                )
-                self.__assertAvoids(avoid=frozenset(["dbx-python"]))
-                self.pkg("verify")
+        # Remove dbx-python; python-26 and python-27 should be removed
+        # from implicit avoid list.
+        self.pkg("uninstall --parsable=0 dbx-python")
+        self.assertEqualParsable(self.output, remove_packages=pfmris[1:2])
+        self.__assertAvoids(avoid=frozenset(["dbx-python"]))
+        self.pkg("verify")
 
-                # Publish python-26; pkg verify should still
-                # succeed.
-                pfmris.extend(self.pkgsend_bulk(self.rurl, pkgs[2]))
-                self.pkg("refresh")
-                self.pkg("verify")
+        # Publish python-26; pkg verify should still
+        # succeed.
+        pfmris.extend(self.pkgsend_bulk(self.rurl, pkgs[2]))
+        self.pkg("refresh")
+        self.pkg("verify")
 
-                # Install dbx-python; python-26 should also be installed.
-                self.pkg("install --parsable=0 dbx-python")
-                self.assertEqualParsable(self.output,
-                    add_packages=pfmris[1:3],
-                )
-                self.__assertAvoids(implicit=frozenset(["python-27"]))
-                self.pkg("verify")
+        # Install dbx-python; python-26 should also be installed.
+        self.pkg("install --parsable=0 dbx-python")
+        self.assertEqualParsable(
+            self.output,
+            add_packages=pfmris[1:3],
+        )
+        self.__assertAvoids(implicit=frozenset(["python-27"]))
+        self.pkg("verify")
 
-                # Publish python-27; pkg verify should still succeed.
-                pfmris.extend(self.pkgsend_bulk(self.rurl, pkgs[3]))
-                self.pkg("refresh")
-                self.pkg("verify")
+        # Publish python-27; pkg verify should still succeed.
+        pfmris.extend(self.pkgsend_bulk(self.rurl, pkgs[3]))
+        self.pkg("refresh")
+        self.pkg("verify")
 
-                # pkg update should do nothing since optimal solution is to
-                # simply leave python-26 installed and not install python-27.
-                self.pkg("update", exit=4)
+        # pkg update should do nothing since optimal solution is to
+        # simply leave python-26 installed and not install python-27.
+        self.pkg("update", exit=4)
 
-                # Publish obsolete python-26; pkg verify should still succeed.
-                pfmris.extend(self.pkgsend_bulk(self.rurl, pkgs[4]))
-                self.pkg("refresh")
-                self.pkg("verify")
+        # Publish obsolete python-26; pkg verify should still succeed.
+        pfmris.extend(self.pkgsend_bulk(self.rurl, pkgs[4]))
+        self.pkg("refresh")
+        self.pkg("verify")
 
-                # pkg update should remove python-26 and place it on the
-                # obsolete list, and install python-27 as we prefer newer
-                # versions of packages whenever possible.
-                self.pkg("update --parsable=0")
-                self.assertEqualParsable(self.output,
-                    add_packages=pfmris[3:4],
-                    remove_packages=pfmris[2:3]
-                )
-                self.__assertAvoids(obsolete=frozenset(["python-26"]))
+        # pkg update should remove python-26 and place it on the
+        # obsolete list, and install python-27 as we prefer newer
+        # versions of packages whenever possible.
+        self.pkg("update --parsable=0")
+        self.assertEqualParsable(
+            self.output, add_packages=pfmris[3:4], remove_packages=pfmris[2:3]
+        )
+        self.__assertAvoids(obsolete=frozenset(["python-26"]))
 
-                # Publish obsolete python-27; pkg verify should still succeed.
-                pfmris.extend(self.pkgsend_bulk(self.rurl, pkgs[5]))
-                self.pkg("refresh")
-                self.pkg("verify")
+        # Publish obsolete python-27; pkg verify should still succeed.
+        pfmris.extend(self.pkgsend_bulk(self.rurl, pkgs[5]))
+        self.pkg("refresh")
+        self.pkg("verify")
 
-                # pkg update should remove python-27 and place it on the
-                # obsolete list as we prefer newer versions of packages whenever
-                # possible.
-                self.pkg("update --parsable=0")
-                self.assertEqualParsable(self.output,
-                    remove_packages=pfmris[3:4]
-                )
-                self.__assertAvoids(implicit=frozenset(["python-26"]),
-                    obsolete=frozenset(["python-27"]))
+        # pkg update should remove python-27 and place it on the
+        # obsolete list as we prefer newer versions of packages whenever
+        # possible.
+        self.pkg("update --parsable=0")
+        self.assertEqualParsable(self.output, remove_packages=pfmris[3:4])
+        self.__assertAvoids(
+            implicit=frozenset(["python-26"]), obsolete=frozenset(["python-27"])
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_composite.py
+++ b/src/tests/cli/t_pkg_composite.py
@@ -25,8 +25,9 @@
 
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import json
@@ -44,13 +45,12 @@ import unittest
 
 
 class TestPkgCompositePublishers(pkg5unittest.ManyDepotTestCase):
+    # Don't discard repository or setUp() every test.
+    persistent_setup = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        # Don't discard repository or setUp() every test.
-        persistent_setup = True
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
-
-        foo_pkg = """
+    foo_pkg = """
             open pkg://test/foo@1.0
             add set name=pkg.summary value="Example package foo."
             add dir mode=0755 owner=root group=bin path=lib
@@ -72,7 +72,7 @@ class TestPkgCompositePublishers(pkg5unittest.ManyDepotTestCase):
             add hardlink path=usr/local/bin/hard-foo target=/usr/bin/foo
             close """
 
-        incorp_pkg = """
+    incorp_pkg = """
             open pkg://test/incorp@1.0
             add set name=pkg.summary value="Incorporation"
             add depend type=incorporate fmri=quux@0.1,5.11-0.1
@@ -82,7 +82,7 @@ class TestPkgCompositePublishers(pkg5unittest.ManyDepotTestCase):
             add depend type=incorporate fmri=quux@1.0,5.11-0.2
             close """
 
-        signed_pkg = """
+    signed_pkg = """
             open pkg://test/signed@1.0
             add depend type=require fmri=foo@1.0
             add dir mode=0755 owner=root group=bin path=usr/bin
@@ -90,7 +90,7 @@ class TestPkgCompositePublishers(pkg5unittest.ManyDepotTestCase):
             add set name=authorized.species value=bobcat
             close """
 
-        quux_pkg = """
+    quux_pkg = """
             open pkg://test2/quux@0.1,5.11-0.1
             add set name=pkg.summary value="Example package quux."
             add depend type=require fmri=pkg:/incorp
@@ -103,279 +103,310 @@ class TestPkgCompositePublishers(pkg5unittest.ManyDepotTestCase):
             add file tmp/quux mode=0755 owner=root group=bin path=usr/bin/quux
             close """
 
-        misc_files = ["tmp/foo", "tmp/libfoo.so.1", "tmp/libfoo_debug.so.1",
-            "tmp/foo.1", "tmp/README", "tmp/LICENSE", "tmp/quux"]
+    misc_files = [
+        "tmp/foo",
+        "tmp/libfoo.so.1",
+        "tmp/libfoo_debug.so.1",
+        "tmp/foo.1",
+        "tmp/README",
+        "tmp/LICENSE",
+        "tmp/quux",
+    ]
 
-        def __seed_ta_dir(self, certs, dest_dir=None):
-                if isinstance(certs, six.string_types):
-                        certs = [certs]
-                if not dest_dir:
-                        dest_dir = self.ta_dir
-                self.assertTrue(dest_dir)
-                self.assertTrue(self.raw_trust_anchor_dir)
-                for c in certs:
-                        name = "{0}_cert.pem".format(c)
-                        portable.copyfile(
-                            os.path.join(self.raw_trust_anchor_dir, name),
-                            os.path.join(dest_dir, name))
+    def __seed_ta_dir(self, certs, dest_dir=None):
+        if isinstance(certs, six.string_types):
+            certs = [certs]
+        if not dest_dir:
+            dest_dir = self.ta_dir
+        self.assertTrue(dest_dir)
+        self.assertTrue(self.raw_trust_anchor_dir)
+        for c in certs:
+            name = "{0}_cert.pem".format(c)
+            portable.copyfile(
+                os.path.join(self.raw_trust_anchor_dir, name),
+                os.path.join(dest_dir, name),
+            )
 
-        def __publish_packages(self, rurl):
-                """Private helper function to publish packages needed for
-                testing.
-                """
+    def __publish_packages(self, rurl):
+        """Private helper function to publish packages needed for
+        testing.
+        """
 
-                pkgs = "".join([self.foo_pkg, self.incorp_pkg, self.signed_pkg,
-                    self.quux_pkg])
+        pkgs = "".join(
+            [self.foo_pkg, self.incorp_pkg, self.signed_pkg, self.quux_pkg]
+        )
 
-                # Publish packages needed for tests.
-                plist = self.pkgsend_bulk(rurl, pkgs)
+        # Publish packages needed for tests.
+        plist = self.pkgsend_bulk(rurl, pkgs)
 
-                # Sign the 'signed' package.
-                r = self.get_repo(self.dcs[1].get_repodir())
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} -i {i6} {pkg}".format(
-                      key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      i1=os.path.join(self.chain_certs_dir,
-                          "ch1_ta1_cert.pem"),
-                      i2=os.path.join(self.chain_certs_dir,
-                          "ch2_ta1_cert.pem"),
-                      i3=os.path.join(self.chain_certs_dir,
-                          "ch3_ta1_cert.pem"),
-                      i4=os.path.join(self.chain_certs_dir,
-                          "ch4_ta1_cert.pem"),
-                      i5=os.path.join(self.chain_certs_dir,
-                          "ch5_ta1_cert.pem"),
-                      i6=os.path.join(self.chain_certs_dir,
-                          "ch1_ta3_cert.pem"),
-                      pkg=plist[3]
-                    )
-                self.pkgsign(rurl, sign_args)
+        # Sign the 'signed' package.
+        r = self.get_repo(self.dcs[1].get_repodir())
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} -i {i6} {pkg}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                i1=os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
+                i2=os.path.join(self.chain_certs_dir, "ch2_ta1_cert.pem"),
+                i3=os.path.join(self.chain_certs_dir, "ch3_ta1_cert.pem"),
+                i4=os.path.join(self.chain_certs_dir, "ch4_ta1_cert.pem"),
+                i5=os.path.join(self.chain_certs_dir, "ch5_ta1_cert.pem"),
+                i6=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+                pkg=plist[3],
+            )
+        )
+        self.pkgsign(rurl, sign_args)
 
-                # This is just a test assertion to verify that the
-                # package was signed as expected.
-                self.image_create(rurl, prefix=None)
-                self.__seed_ta_dir("ta1")
-                self.pkg("set-property signature-policy verify")
-                self.pkg("install signed")
-                self.image_destroy()
+        # This is just a test assertion to verify that the
+        # package was signed as expected.
+        self.image_create(rurl, prefix=None)
+        self.__seed_ta_dir("ta1")
+        self.pkg("set-property signature-policy verify")
+        self.pkg("install signed")
+        self.image_destroy()
 
-                return [
-                    fmri.PkgFmri(sfmri)
-                    for sfmri in plist
-                ]
+        return [fmri.PkgFmri(sfmri) for sfmri in plist]
 
-        def __archive_packages(self, arc_name, repo, plist):
-                """Private helper function to archive packages needed for
-                testing.
-                """
+    def __archive_packages(self, arc_name, repo, plist):
+        """Private helper function to archive packages needed for
+        testing.
+        """
 
-                arc_path = os.path.join(self.test_root, arc_name)
-                assert not os.path.exists(arc_path)
+        arc_path = os.path.join(self.test_root, arc_name)
+        assert not os.path.exists(arc_path)
 
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                for pfmri in plist:
-                        arc.add_repo_package(pfmri, repo)
-                arc.close()
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        for pfmri in plist:
+            arc.add_repo_package(pfmri, repo)
+        arc.close()
 
-                return arc_path
+        return arc_path
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test", "test",
-                    "test", "empty", "void"])
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test", "test", "test", "empty", "void"]
+        )
+        self.make_misc_files(self.misc_files)
 
-                # First repository will contain all packages.
-                self.all_rurl = self.dcs[1].get_repo_url()
+        # First repository will contain all packages.
+        self.all_rurl = self.dcs[1].get_repo_url()
 
-                # Second repository will contain only foo.
-                self.foo_rurl = self.dcs[2].get_repo_url()
+        # Second repository will contain only foo.
+        self.foo_rurl = self.dcs[2].get_repo_url()
 
-                # Third repository will contain only signed.
-                self.signed_rurl = self.dcs[3].get_repo_url()
+        # Third repository will contain only signed.
+        self.signed_rurl = self.dcs[3].get_repo_url()
 
-                # Fourth will be empty.
-                self.empty_rurl = self.dcs[4].get_repo_url()
-                self.pkgrepo("refresh -s {0}".format(self.empty_rurl))
+        # Fourth will be empty.
+        self.empty_rurl = self.dcs[4].get_repo_url()
+        self.pkgrepo("refresh -s {0}".format(self.empty_rurl))
 
-                # Fifth will have a publisher named 'void', but no packages.
-                self.void_rurl = self.dcs[5].get_repo_url()
-                self.pkgrepo("refresh -s {0}".format(self.void_rurl))
+        # Fifth will have a publisher named 'void', but no packages.
+        self.void_rurl = self.dcs[5].get_repo_url()
+        self.pkgrepo("refresh -s {0}".format(self.void_rurl))
 
-                # Setup base test paths.
-                self.path_to_certs = os.path.join(self.ro_data_root,
-                    "signing_certs", "produced")
-                self.keys_dir = os.path.join(self.path_to_certs, "keys")
-                self.cs_dir = os.path.join(self.path_to_certs,
-                    "code_signing_certs")
-                self.chain_certs_dir = os.path.join(self.path_to_certs,
-                    "chain_certs")
-                self.pub_cas_dir = os.path.join(self.path_to_certs,
-                    "publisher_cas")
-                self.inter_certs_dir = os.path.join(self.path_to_certs,
-                    "inter_certs")
-                self.raw_trust_anchor_dir = os.path.join(self.path_to_certs,
-                    "trust_anchors")
-                self.crl_dir = os.path.join(self.path_to_certs, "crl")
+        # Setup base test paths.
+        self.path_to_certs = os.path.join(
+            self.ro_data_root, "signing_certs", "produced"
+        )
+        self.keys_dir = os.path.join(self.path_to_certs, "keys")
+        self.cs_dir = os.path.join(self.path_to_certs, "code_signing_certs")
+        self.chain_certs_dir = os.path.join(self.path_to_certs, "chain_certs")
+        self.pub_cas_dir = os.path.join(self.path_to_certs, "publisher_cas")
+        self.inter_certs_dir = os.path.join(self.path_to_certs, "inter_certs")
+        self.raw_trust_anchor_dir = os.path.join(
+            self.path_to_certs, "trust_anchors"
+        )
+        self.crl_dir = os.path.join(self.path_to_certs, "crl")
 
-                # Publish packages.
-                plist = self.__publish_packages(self.all_rurl)
-                self.pkgrepo("refresh -s {0}".format(self.all_rurl))
+        # Publish packages.
+        plist = self.__publish_packages(self.all_rurl)
+        self.pkgrepo("refresh -s {0}".format(self.all_rurl))
 
-                # Copy foo to second repository and build index.
-                self.pkgrecv(self.all_rurl, "-d {0} foo".format(self.foo_rurl))
-                self.pkgrepo("refresh -s {0}".format(self.foo_rurl))
+        # Copy foo to second repository and build index.
+        self.pkgrecv(self.all_rurl, "-d {0} foo".format(self.foo_rurl))
+        self.pkgrepo("refresh -s {0}".format(self.foo_rurl))
 
-                # Copy incorp and quux to third repository and build index.
-                self.pkgrecv(self.all_rurl, "-d {0} signed".format(self.signed_rurl))
-                self.pkgrepo("refresh -s {0}".format(self.signed_rurl))
+        # Copy incorp and quux to third repository and build index.
+        self.pkgrecv(self.all_rurl, "-d {0} signed".format(self.signed_rurl))
+        self.pkgrepo("refresh -s {0}".format(self.signed_rurl))
 
-                # Now create a package archive containing all packages, and
-                # then one for each.
-                repo = self.dcs[1].get_repo()
-                self.all_arc = self.__archive_packages("all_pkgs.p5p", repo,
-                    plist)
+        # Now create a package archive containing all packages, and
+        # then one for each.
+        repo = self.dcs[1].get_repo()
+        self.all_arc = self.__archive_packages("all_pkgs.p5p", repo, plist)
 
-                for alist in ([plist[0]], [plist[1], plist[2]], [plist[3]],
-                    [plist[4], plist[5]]):
-                        arc_path = self.__archive_packages(
-                            "{0}.p5p".format(alist[0].pkg_name), repo, alist)
-                        setattr(self, "{0}_arc".format(alist[0].pkg_name), arc_path)
+        for alist in (
+            [plist[0]],
+            [plist[1], plist[2]],
+            [plist[3]],
+            [plist[4], plist[5]],
+        ):
+            arc_path = self.__archive_packages(
+                "{0}.p5p".format(alist[0].pkg_name), repo, alist
+            )
+            setattr(self, "{0}_arc".format(alist[0].pkg_name), arc_path)
 
-                self.ta_dir = None
+        self.ta_dir = None
 
-                # Store FMRIs for later use.
-                self.foo10 = plist[0]
-                self.incorp10 = plist[1]
-                self.incorp20 = plist[2]
-                self.signed10 = plist[3]
-                self.quux01 = plist[4]
-                self.quux10 = plist[5]
+        # Store FMRIs for later use.
+        self.foo10 = plist[0]
+        self.incorp10 = plist[1]
+        self.incorp20 = plist[2]
+        self.signed10 = plist[3]
+        self.quux01 = plist[4]
+        self.quux10 = plist[5]
 
-        def test_00_list(self):
-                """Verify that the list operation works as expected when
-                compositing publishers.
-                """
+    def test_00_list(self):
+        """Verify that the list operation works as expected when
+        compositing publishers.
+        """
 
-                # Create an image and verify no packages are known.
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                self.pkg("list -a", exit=1)
+        # Create an image and verify no packages are known.
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        self.pkg("list -a", exit=1)
 
-                # Verify list output for multiple, disparate sources using
-                # different combinations of archives and repositories.
-                self.pkg("set-publisher -g {0} -g {1} test".format(self.signed_arc,
-                    self.foo_rurl))
-                self.pkg("list -afH")
-                expected = \
-                    ("foo (test) 1.0 ---\n"
-                    "signed (test) 1.0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify list output for multiple, disparate sources using
+        # different combinations of archives and repositories.
+        self.pkg(
+            "set-publisher -g {0} -g {1} test".format(
+                self.signed_arc, self.foo_rurl
+            )
+        )
+        self.pkg("list -afH")
+        expected = "foo (test) 1.0 ---\n" "signed (test) 1.0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify removing origins while others remain configured
-                # works as expected.
-                self.pkg("set-publisher -G {0} test".format(self.foo_rurl))
-                self.pkg("list -afH")
-                expected = "signed (test) 1.0 ---\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify removing origins while others remain configured
+        # works as expected.
+        self.pkg("set-publisher -G {0} test".format(self.foo_rurl))
+        self.pkg("list -afH")
+        expected = "signed (test) 1.0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify simply adding origins works as expected.
-                self.pkg("set-publisher -g {0} test".format(self.foo_arc))
-                self.pkg("set-publisher -g {0} test".format(self.incorp_arc))
-                self.pkg("set-publisher -g {0} test2".format(self.quux_arc))
-                self.pkg("list -afH")
-                expected = \
-                    ("foo (test) 1.0 ---\n"
-                    "incorp (test) 2.0 ---\n"
-                    "incorp (test) 1.0 ---\n"
-                    "quux (test2) 1.0-0.2 ---\n"
-                    "quux (test2) 0.1-0.1 ---\n"
-                    "signed (test) 1.0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify simply adding origins works as expected.
+        self.pkg("set-publisher -g {0} test".format(self.foo_arc))
+        self.pkg("set-publisher -g {0} test".format(self.incorp_arc))
+        self.pkg("set-publisher -g {0} test2".format(self.quux_arc))
+        self.pkg("list -afH")
+        expected = (
+            "foo (test) 1.0 ---\n"
+            "incorp (test) 2.0 ---\n"
+            "incorp (test) 1.0 ---\n"
+            "quux (test2) 1.0-0.2 ---\n"
+            "quux (test2) 0.1-0.1 ---\n"
+            "signed (test) 1.0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify removing and adding origins at the same time works as
-                # expected.
-                self.pkg("set-publisher -G {0} -g {1} test".format(self.foo_arc,
-                    self.foo_rurl))
-                self.pkg("list -afH")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify removing and adding origins at the same time works as
+        # expected.
+        self.pkg(
+            "set-publisher -G {0} -g {1} test".format(
+                self.foo_arc, self.foo_rurl
+            )
+        )
+        self.pkg("list -afH")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("set-publisher -G \\* -g {0} test".format(self.all_arc))
-                self.pkg("set-publisher -G {0} -g {1} -g {2} test2".format(
-                    self.quux_arc, self.all_arc, self.all_rurl))
-                self.pkg("list -afH -g {0} -g {1}".format(self.all_arc,
-                    self.all_rurl))
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg("set-publisher -G \\* -g {0} test".format(self.all_arc))
+        self.pkg(
+            "set-publisher -G {0} -g {1} -g {2} test2".format(
+                self.quux_arc, self.all_arc, self.all_rurl
+            )
+        )
+        self.pkg("list -afH -g {0} -g {1}".format(self.all_arc, self.all_rurl))
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify packages can be installed from disparate sources and
-                # show in default list output.
-                self.pkg("install incorp@1.0 quux signed")
-                self.pkg("list -H")
-                expected = \
-                    ("foo (test) 1.0 i--\n"
-                    "incorp (test) 1.0 im-\n"
-                    "quux (test2) 0.1-0.1 im-\n"
-                    "signed (test) 1.0 im-\n")
+        # Verify packages can be installed from disparate sources and
+        # show in default list output.
+        self.pkg("install incorp@1.0 quux signed")
+        self.pkg("list -H")
+        expected = (
+            "foo (test) 1.0 i--\n"
+            "incorp (test) 1.0 im-\n"
+            "quux (test2) 0.1-0.1 im-\n"
+            "signed (test) 1.0 im-\n"
+        )
 
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-        def test_01_info(self):
-                """Verify that the info operation works as expected when
-                compositing publishers.
-                """
-                # because we compare date strings we must run this in
-                # a consistent locale, which we made 'C'
+    def test_01_info(self):
+        """Verify that the info operation works as expected when
+        compositing publishers.
+        """
+        # because we compare date strings we must run this in
+        # a consistent locale, which we made 'C'
 
-                os.environ['LC_ALL'] = 'C'
+        os.environ["LC_ALL"] = "C"
 
-                # Create an image and verify no packages are known.
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("list -a", exit=1)
+        # Create an image and verify no packages are known.
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("list -a", exit=1)
 
-                # Verify info result for multiple disparate sources using
-                # different combinations of archives and repositories.
-                self.pkg("set-publisher -g {0} -g {1} test".format(self.signed_arc,
-                    self.foo_rurl))
-                self.pkg("info -r signed@1.0 foo@1.0")
+        # Verify info result for multiple disparate sources using
+        # different combinations of archives and repositories.
+        self.pkg(
+            "set-publisher -g {0} -g {1} test".format(
+                self.signed_arc, self.foo_rurl
+            )
+        )
+        self.pkg("info -r signed@1.0 foo@1.0")
 
-                self.pkg("set-publisher -G {0} -g {1} -g {2} test".format(
-                    self.foo_rurl, self.foo_arc, self.incorp_arc))
-                self.pkg("set-publisher -g {0} test2".format(self.quux_arc))
-                self.pkg("info -r foo@1.0 incorp@1.0 signed@1.0 quux@0.1")
+        self.pkg(
+            "set-publisher -G {0} -g {1} -g {2} test".format(
+                self.foo_rurl, self.foo_arc, self.incorp_arc
+            )
+        )
+        self.pkg("set-publisher -g {0} test2".format(self.quux_arc))
+        self.pkg("info -r foo@1.0 incorp@1.0 signed@1.0 quux@0.1")
 
-                self.pkg("set-publisher -G {0} -g {1} test".format(self.foo_arc,
-                    self.foo_rurl))
-                self.pkg("info -g {0} -g {1} -g {2} -g {3} foo@1.0 incorp@1.0 "
-                    "signed@1.0 quux@0.1".format(
-                    self.signed_arc, self.incorp_arc, self.quux_arc,
-                    self.foo_rurl))
+        self.pkg(
+            "set-publisher -G {0} -g {1} test".format(
+                self.foo_arc, self.foo_rurl
+            )
+        )
+        self.pkg(
+            "info -g {0} -g {1} -g {2} -g {3} foo@1.0 incorp@1.0 "
+            "signed@1.0 quux@0.1".format(
+                self.signed_arc, self.incorp_arc, self.quux_arc, self.foo_rurl
+            )
+        )
 
-                self.pkg("set-publisher -G \\* -g {0} -g {1} test".format(
-                    self.all_arc, self.all_rurl))
-                self.pkg("set-publisher -G \\* -g {0} -g {1} test2".format(
-                    self.all_arc, self.all_rurl))
-                self.pkg("info -r foo@1.0 incorp@2.0 signed@1.0 quux@1.0")
+        self.pkg(
+            "set-publisher -G \\* -g {0} -g {1} test".format(
+                self.all_arc, self.all_rurl
+            )
+        )
+        self.pkg(
+            "set-publisher -G \\* -g {0} -g {1} test2".format(
+                self.all_arc, self.all_rurl
+            )
+        )
+        self.pkg("info -r foo@1.0 incorp@2.0 signed@1.0 quux@1.0")
 
-                # Verify package installed from archive shows in default info
-                # output.
-                self.pkg("install foo@1.0")
-                self.pkg("info")
+        # Verify package installed from archive shows in default info
+        # output.
+        self.pkg("install foo@1.0")
+        self.pkg("info")
 
-                path = os.path.join(self.img_path(),
-                    "var/pkg/state/installed/catalog.base.C")
+        path = os.path.join(
+            self.img_path(), "var/pkg/state/installed/catalog.base.C"
+        )
 
-                entry = json.load(open(path))["test"]["foo"][0]
-                pkg_install = catalog.basic_ts_to_datetime(
-                    entry["metadata"]["last-install"]).strftime("%c")
-                expected = """\
+        entry = json.load(open(path))["test"]["foo"][0]
+        pkg_install = catalog.basic_ts_to_datetime(
+            entry["metadata"]["last-install"]
+        ).strftime("%c")
+        expected = """\
              Name: foo
           Summary: Example package foo.
             State: Installed (Manually installed)
@@ -386,215 +417,243 @@ class TestPkgCompositePublishers(pkg5unittest.ManyDepotTestCase):
 Last Install Time: {pkg_install}
              Size: 41.00 B
              FMRI: {pkg_fmri}
-""".format(pkg_date=self.foo10.version.get_timestamp().strftime("%c"),
-    pkg_fmri=self.foo10.get_fmri(include_build=False),
-    pkg_install=pkg_install)
-                self.assertEqualDiff(expected, self.output)
+""".format(
+            pkg_date=self.foo10.version.get_timestamp().strftime("%c"),
+            pkg_fmri=self.foo10.get_fmri(include_build=False),
+            pkg_install=pkg_install,
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                # Change locale back to 'UTF-8' to not affect other test cases.
-                if six.PY3:
-                        os.environ["LC_ALL"] = "en_US.UTF-8"
+        # Change locale back to 'UTF-8' to not affect other test cases.
+        if six.PY3:
+            os.environ["LC_ALL"] = "en_US.UTF-8"
 
-        def test_02_contents(self):
-                """Verify that the contents operation works as expected when
-                compositing publishers.
-                """
+    def test_02_contents(self):
+        """Verify that the contents operation works as expected when
+        compositing publishers.
+        """
 
-                # Create an image and verify no packages are known.
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("list -a", exit=1)
+        # Create an image and verify no packages are known.
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("list -a", exit=1)
 
-                # Verify contents result for multiple disparate sources using
-                # different combinations of archives and repositories.
-                self.pkg("set-publisher -g {0} -g {1} test".format(self.signed_arc,
-                    self.foo_rurl))
-                self.pkg("contents -r signed@1.0 foo@1.0")
+        # Verify contents result for multiple disparate sources using
+        # different combinations of archives and repositories.
+        self.pkg(
+            "set-publisher -g {0} -g {1} test".format(
+                self.signed_arc, self.foo_rurl
+            )
+        )
+        self.pkg("contents -r signed@1.0 foo@1.0")
 
-                self.pkg("set-publisher -G {0} -g {1} -g {2} test".format(
-                    self.foo_rurl, self.foo_arc, self.incorp_arc))
-                self.pkg("set-publisher -g {0} test2".format(self.quux_arc))
-                self.pkg("contents -r foo@1.0 incorp@1.0 signed@1.0 quux@0.1")
+        self.pkg(
+            "set-publisher -G {0} -g {1} -g {2} test".format(
+                self.foo_rurl, self.foo_arc, self.incorp_arc
+            )
+        )
+        self.pkg("set-publisher -g {0} test2".format(self.quux_arc))
+        self.pkg("contents -r foo@1.0 incorp@1.0 signed@1.0 quux@0.1")
 
-                self.pkg("set-publisher -G {0} -g {1} test".format(self.foo_arc,
-                    self.foo_rurl))
-                self.pkg("contents -r foo@1.0 incorp@1.0 signed@1.0 quux@0.1")
+        self.pkg(
+            "set-publisher -G {0} -g {1} test".format(
+                self.foo_arc, self.foo_rurl
+            )
+        )
+        self.pkg("contents -r foo@1.0 incorp@1.0 signed@1.0 quux@0.1")
 
-                self.pkg("set-publisher -G \\* -g {0} -g {1} test".format(
-                    self.all_arc, self.all_rurl))
-                self.pkg("set-publisher -G \\* -g {0} -g {1} test2".format(
-                    self.all_arc, self.all_rurl))
-                self.pkg("contents -r foo@1.0 incorp@2.0 signed@1.0 quux@1.0")
+        self.pkg(
+            "set-publisher -G \\* -g {0} -g {1} test".format(
+                self.all_arc, self.all_rurl
+            )
+        )
+        self.pkg(
+            "set-publisher -G \\* -g {0} -g {1} test2".format(
+                self.all_arc, self.all_rurl
+            )
+        )
+        self.pkg("contents -r foo@1.0 incorp@2.0 signed@1.0 quux@1.0")
 
-                # Verify package installed from archive can be used with
-                # contents.
-                self.pkg("install foo@1.0")
-                self.pkg("contents foo")
+        # Verify package installed from archive can be used with
+        # contents.
+        self.pkg("install foo@1.0")
+        self.pkg("contents foo")
 
-        def test_03_install_update(self):
-                """Verify that install and update work as expected when
-                compositing publishers.
-                """
+    def test_03_install_update(self):
+        """Verify that install and update work as expected when
+        compositing publishers.
+        """
 
-                #
-                # Create an image and verify no packages are known.
-                #
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                self.pkg("list -a", exit=1)
+        #
+        # Create an image and verify no packages are known.
+        #
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        self.pkg("list -a", exit=1)
 
-                # Verify that packages with dependencies can be installed when
-                # using multiple, disparate sources.
-                self.pkg("set-publisher -g {0} -g {1} test".format(self.foo_arc,
-                    self.signed_arc))
-                self.pkg("install signed")
-                self.pkg("list foo signed")
-                self.pkg("uninstall \\*")
+        # Verify that packages with dependencies can be installed when
+        # using multiple, disparate sources.
+        self.pkg(
+            "set-publisher -g {0} -g {1} test".format(
+                self.foo_arc, self.signed_arc
+            )
+        )
+        self.pkg("install signed")
+        self.pkg("list foo signed")
+        self.pkg("uninstall \\*")
 
-                # Verify publisher can be removed.
-                self.pkg("unset-publisher test")
+        # Verify publisher can be removed.
+        self.pkg("unset-publisher test")
 
-                #
-                # Create an image using the signed archive.
-                #
-                self.image_create(misc.parse_uri(self.signed_arc), prefix=None)
-                self.__seed_ta_dir("ta1")
+        #
+        # Create an image using the signed archive.
+        #
+        self.image_create(misc.parse_uri(self.signed_arc), prefix=None)
+        self.__seed_ta_dir("ta1")
 
-                # Verify that signed package can be installed and the archive
-                # configured for the publisher allows dependencies to be
-                # satisfied.
-                self.pkg("set-publisher -g {0} test".format(self.foo_arc))
-                self.pkg("set-property signature-policy verify")
-                self.pkg("publisher test")
-                self.pkg("install signed")
-                self.pkg("list foo signed")
+        # Verify that signed package can be installed and the archive
+        # configured for the publisher allows dependencies to be
+        # satisfied.
+        self.pkg("set-publisher -g {0} test".format(self.foo_arc))
+        self.pkg("set-property signature-policy verify")
+        self.pkg("publisher test")
+        self.pkg("install signed")
+        self.pkg("list foo signed")
 
-                # Verify that removing all packages and the signed archive as
-                # a source leaves only foo known.
-                self.pkg("uninstall \\*")
-                self.pkg("set-publisher -G {0} test".format(self.signed_arc))
-                self.pkg("list -aH")
-                expected = "foo 1.0 ---\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify that removing all packages and the signed archive as
+        # a source leaves only foo known.
+        self.pkg("uninstall \\*")
+        self.pkg("set-publisher -G {0} test".format(self.signed_arc))
+        self.pkg("list -aH")
+        expected = "foo 1.0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                #
-                # Create an image and verify no packages are known.
-                #
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("list -a", exit=1)
+        #
+        # Create an image and verify no packages are known.
+        #
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("list -a", exit=1)
 
-                # Install an older version of a known package.
-                self.pkg("set-publisher -g {0} test".format(self.all_arc))
-                self.pkg("set-publisher -g {0} test2".format(self.all_arc))
-                self.pkg("install quux@0.1")
-                self.pkg("list incorp@1.0 quux@0.1")
+        # Install an older version of a known package.
+        self.pkg("set-publisher -g {0} test".format(self.all_arc))
+        self.pkg("set-publisher -g {0} test2".format(self.all_arc))
+        self.pkg("install quux@0.1")
+        self.pkg("list incorp@1.0 quux@0.1")
 
-                # Verify that packages can be updated when using multiple,
-                # disparate sources (that have some overlap).
-                self.pkg("set-publisher -g {0} test".format(self.incorp_arc))
-                self.pkg("update")
-                self.pkg("list incorp@2.0 quux@1.0")
+        # Verify that packages can be updated when using multiple,
+        # disparate sources (that have some overlap).
+        self.pkg("set-publisher -g {0} test".format(self.incorp_arc))
+        self.pkg("update")
+        self.pkg("list incorp@2.0 quux@1.0")
 
-                #
-                # Create an image using the signed archive.
-                #
-                self.image_create(misc.parse_uri(self.signed_arc), prefix=None)
-                self.__seed_ta_dir("ta1")
+        #
+        # Create an image using the signed archive.
+        #
+        self.image_create(misc.parse_uri(self.signed_arc), prefix=None)
+        self.__seed_ta_dir("ta1")
 
-                # Add the incorp archive as a source.
-                self.pkg("set-publisher -g {0} test".format(self.incorp_arc))
+        # Add the incorp archive as a source.
+        self.pkg("set-publisher -g {0} test".format(self.incorp_arc))
 
-                # Now verify that temporary package sources can be used during
-                # package operations when multiple, disparate sources are
-                # already configured for the same publisher.
-                self.pkg("install -g {0} incorp signed".format(self.foo_rurl))
-                self.pkg("list incorp foo signed")
+        # Now verify that temporary package sources can be used during
+        # package operations when multiple, disparate sources are
+        # already configured for the same publisher.
+        self.pkg("install -g {0} incorp signed".format(self.foo_rurl))
+        self.pkg("list incorp foo signed")
 
-        def test_04_search(self):
-                """Verify that search works as expected when compositing
-                publishers.
-                """
+    def test_04_search(self):
+        """Verify that search works as expected when compositing
+        publishers.
+        """
 
-                #
-                # Create an image and verify no packages are known.
-                #
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("list -a", exit=1)
+        #
+        # Create an image and verify no packages are known.
+        #
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("list -a", exit=1)
 
-                # Add multiple, different sources.
-                self.pkg("set-publisher -g {0} -g {1} test".format(self.foo_rurl,
-                    self.signed_rurl))
+        # Add multiple, different sources.
+        self.pkg(
+            "set-publisher -g {0} -g {1} test".format(
+                self.foo_rurl, self.signed_rurl
+            )
+        )
 
-                # Verify a remote search that should only match one of the
-                # sources works as expected.
-                self.pkg("search -Hpr -o pkg.shortfmri /usr/bin/foo")
-                expected = "pkg:/foo@1.0\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify a remote search that should only match one of the
+        # sources works as expected.
+        self.pkg("search -Hpr -o pkg.shortfmri /usr/bin/foo")
+        expected = "pkg:/foo@1.0\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify a remote search for multiple terms that should match
-                # each source works as expected.
-                self.pkg("search -Hpr -o pkg.shortfmri /usr/bin/foo OR "
-                    "/usr/bin/quark")
-                expected = \
-                    ("pkg:/foo@1.0\n"
-                    "pkg:/signed@1.0\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify a remote search for multiple terms that should match
+        # each source works as expected.
+        self.pkg(
+            "search -Hpr -o pkg.shortfmri /usr/bin/foo OR " "/usr/bin/quark"
+        )
+        expected = "pkg:/foo@1.0\n" "pkg:/signed@1.0\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Add a source that partially overlaps with the existing ones
-                # (provides some of the same packages) and verify that some
-                # of the results are duplicated (since search across sources
-                # is a simple aggregation of all sources).
-                self.pkg("set-publisher -g {0} test".format(self.all_rurl))
-                self.pkg("search -Hpr -o pkg.shortfmri /usr/bin/foo OR "
-                    "/usr/bin/quark OR Incorporation")
-                expected = \
-                    ("pkg:/foo@1.0\n"
-                    "pkg:/incorp@1.0\n"
-                    "pkg:/incorp@2.0\n"
-                    "pkg:/signed@1.0\n"
-                    "pkg:/foo@1.0\n"
-                    "pkg:/signed@1.0\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Add a source that partially overlaps with the existing ones
+        # (provides some of the same packages) and verify that some
+        # of the results are duplicated (since search across sources
+        # is a simple aggregation of all sources).
+        self.pkg("set-publisher -g {0} test".format(self.all_rurl))
+        self.pkg(
+            "search -Hpr -o pkg.shortfmri /usr/bin/foo OR "
+            "/usr/bin/quark OR Incorporation"
+        )
+        expected = (
+            "pkg:/foo@1.0\n"
+            "pkg:/incorp@1.0\n"
+            "pkg:/incorp@2.0\n"
+            "pkg:/signed@1.0\n"
+            "pkg:/foo@1.0\n"
+            "pkg:/signed@1.0\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Add a publisher with no origins and verify output still
-                # matches expected.
-                self.pkg("set-publisher no-origins")
-                self.pkg("search -Hpr -o pkg.shortfmri /usr/bin/foo OR "
-                    "/usr/bin/quark OR Incorporation")
-                output = self.reduceSpaces(self.output)
+        # Add a publisher with no origins and verify output still
+        # matches expected.
+        self.pkg("set-publisher no-origins")
+        self.pkg(
+            "search -Hpr -o pkg.shortfmri /usr/bin/foo OR "
+            "/usr/bin/quark OR Incorporation"
+        )
+        output = self.reduceSpaces(self.output)
 
-                # Elide error output from client to verify that search
-                # results were returned despite error.
-                output = output[:output.find("pkg: ")] + "\n"
-                self.assertEqualDiff(expected, output)
+        # Elide error output from client to verify that search
+        # results were returned despite error.
+        output = output[: output.find("pkg: ")] + "\n"
+        self.assertEqualDiff(expected, output)
 
-        def test_05_empty(self):
-                """Verify empty repositories and repositories with a publisher,
-                but no packages, can be used with -g."""
+    def test_05_empty(self):
+        """Verify empty repositories and repositories with a publisher,
+        but no packages, can be used with -g."""
 
-                self.image_create(repourl=None, prefix=None)
+        self.image_create(repourl=None, prefix=None)
 
-                # Verify usage alone.
-                for uri in (self.empty_rurl, self.void_rurl):
-                        self.pkg("list -afH -g {0} '*'".format(uri), exit=1)
-                        self.pkg("contents -H -g {0} '*'".format(uri), exit=1)
+        # Verify usage alone.
+        for uri in (self.empty_rurl, self.void_rurl):
+            self.pkg("list -afH -g {0} '*'".format(uri), exit=1)
+            self.pkg("contents -H -g {0} '*'".format(uri), exit=1)
 
-                # Verify usage in combination with non-empty.
-                self.pkg("list -afH -g {0} -g {1} -g {2} '*'".format(self.empty_rurl,
-                    self.void_rurl, self.foo_rurl))
-                expected = \
-                    ("foo (test) 1.0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify usage in combination with non-empty.
+        self.pkg(
+            "list -afH -g {0} -g {1} -g {2} '*'".format(
+                self.empty_rurl, self.void_rurl, self.foo_rurl
+            )
+        )
+        expected = "foo (test) 1.0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_contents.py
+++ b/src/tests/cli/t_pkg_contents.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2022, Oracle and/or its affiliates.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -34,11 +35,12 @@ import pkg.fmri as pfmri
 
 from functools import reduce
 
-class TestPkgContentsBasics(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
 
-        bronze10 = """
+class TestPkgContentsBasics(pkg5unittest.SingleDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+
+    bronze10 = """
             open bronze@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/usr
             add dir mode=0755 owner=root group=bin path=/usr/bin
@@ -51,335 +53,358 @@ class TestPkgContentsBasics(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        nopathA10 = """
+    nopathA10 = """
             open nopathA@1.0,5.11-0
             add license tmp/copyright1 license=copyright
             close
         """
 
-        nopathB10 = """
+    nopathB10 = """
             open nopathB@1.0,5.11-0
             add license tmp/copyright1 license=copyright
             close
         """
 
-        # wire file contents to well known values so we're sure we
-        # know their hashes.
-        misc_files = {
-                "tmp/bronzeA1": "magic1",
-                "tmp/bronzeA2": "magic2",
-                "tmp/bronze1": "magic3",
-                "tmp/bronze2": "magic4",
-                "tmp/copyright1": "magic5",
-                "tmp/sh": "magic6",
-        }
+    # wire file contents to well known values so we're sure we
+    # know their hashes.
+    misc_files = {
+        "tmp/bronzeA1": "magic1",
+        "tmp/bronzeA2": "magic2",
+        "tmp/bronze1": "magic3",
+        "tmp/bronze2": "magic4",
+        "tmp/copyright1": "magic5",
+        "tmp/sh": "magic6",
+    }
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.plist = self.pkgsend_bulk(self.rurl, (self.bronze10,
-                    self.nopathA10, self.nopathB10))
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.plist = self.pkgsend_bulk(
+            self.rurl, (self.bronze10, self.nopathA10, self.nopathB10)
+        )
 
-        def test_contents_bad_opts(self):
-                """Verify that contents handles bad options as expected."""
+    def test_contents_bad_opts(self):
+        """Verify that contents handles bad options as expected."""
 
-                self.image_create(self.rurl)
-                self.pkg("contents -@", exit=2)
-                self.pkg("contents -m -r", exit=2)
-                self.pkg("contents -o", exit=2)
-                self.pkg("contents -s", exit=2)
-                self.pkg("contents -t", exit=2)
-                self.pkg("contents foo@x.y", exit=1)
-                self.pkg("contents -a foo", exit=2)
-                self.pkg("contents -m -o action.hash", exit=2)
-                self.pkg("contents -m -a path=usr/bin/sh", exit=2)
-                self.pkg("contents -m -s path", exit=2)
-                self.pkg("contents -m -t depend", exit=2)
+        self.image_create(self.rurl)
+        self.pkg("contents -@", exit=2)
+        self.pkg("contents -m -r", exit=2)
+        self.pkg("contents -o", exit=2)
+        self.pkg("contents -s", exit=2)
+        self.pkg("contents -t", exit=2)
+        self.pkg("contents foo@x.y", exit=1)
+        self.pkg("contents -a foo", exit=2)
+        self.pkg("contents -m -o action.hash", exit=2)
+        self.pkg("contents -m -a path=usr/bin/sh", exit=2)
+        self.pkg("contents -m -s path", exit=2)
+        self.pkg("contents -m -t depend", exit=2)
 
-        def test_contents_default_attrs(self):
-                """Verify that when -t is specified without -o, the default
-                attributes vary to match."""
+    def test_contents_default_attrs(self):
+        """Verify that when -t is specified without -o, the default
+        attributes vary to match."""
 
-                self.image_create(self.rurl)
-                self.pkg("install bronze")
+        self.image_create(self.rurl)
+        self.pkg("install bronze")
 
-                self.pkg("contents")
-                self.assertTrue("PATH" in self.output)
-                self.pkg("contents -t file")
-                self.assertTrue("PATH" in self.output)
-                self.pkg("contents -t file,set")
-                self.assertTrue("PATH" in self.output and "NAME" in self.output
-                    and "VALUE" in self.output)
-                self.pkg("contents -t set,license")
-                self.assertTrue("LICENSE" in self.output and "NAME" in self.output
-                    and "VALUE" in self.output)
-                self.pkg("contents -t falseaction", exit=2)
-                self.pkg("contents -t falseaction,file")
-                self.assertTrue("PATH" in self.output)
-                self.assertTrue("falseaction" in self.errout)
+        self.pkg("contents")
+        self.assertTrue("PATH" in self.output)
+        self.pkg("contents -t file")
+        self.assertTrue("PATH" in self.output)
+        self.pkg("contents -t file,set")
+        self.assertTrue(
+            "PATH" in self.output
+            and "NAME" in self.output
+            and "VALUE" in self.output
+        )
+        self.pkg("contents -t set,license")
+        self.assertTrue(
+            "LICENSE" in self.output
+            and "NAME" in self.output
+            and "VALUE" in self.output
+        )
+        self.pkg("contents -t falseaction", exit=2)
+        self.pkg("contents -t falseaction,file")
+        self.assertTrue("PATH" in self.output)
+        self.assertTrue("falseaction" in self.errout)
 
-        def test_contents_empty_image(self):
-                """local pkg contents should fail in an empty image; remote
-                should succeed on a match """
+    def test_contents_empty_image(self):
+        """local pkg contents should fail in an empty image; remote
+        should succeed on a match"""
 
-                self.image_create(self.rurl)
-                self.pkg("contents -m", exit=1)
-                self.pkg("contents -m -r bronze@1.0", exit=0)
+        self.image_create(self.rurl)
+        self.pkg("contents -m", exit=1)
+        self.pkg("contents -m -r bronze@1.0", exit=0)
 
-        def test_contents_1(self):
-                """get contents"""
+    def test_contents_1(self):
+        """get contents"""
 
-                self.image_create(self.rurl)
-                self.pkg("install bronze@1.0")
-                self.pkg("contents")
-                self.pkg("contents -m")
+        self.image_create(self.rurl)
+        self.pkg("install bronze@1.0")
+        self.pkg("contents")
+        self.pkg("contents -m")
 
-        def test_contents_2(self):
-                """test that local and remote contents are the same"""
+    def test_contents_2(self):
+        """test that local and remote contents are the same"""
 
-                self.image_create(self.rurl)
-                self.pkg("install bronze@1.0")
-                self.pkg("contents -m bronze@1.0")
-                x = sorted(self.output.splitlines())
-                x = "".join(x)
-                x = self.reduceSpaces(x)
-                self.pkg("contents -r -m bronze@1.0")
-                y = sorted(self.output.splitlines())
-                y = "".join(y)
-                y = self.reduceSpaces(y)
-                self.assertEqualDiff(x, y)
+        self.image_create(self.rurl)
+        self.pkg("install bronze@1.0")
+        self.pkg("contents -m bronze@1.0")
+        x = sorted(self.output.splitlines())
+        x = "".join(x)
+        x = self.reduceSpaces(x)
+        self.pkg("contents -r -m bronze@1.0")
+        y = sorted(self.output.splitlines())
+        y = "".join(y)
+        y = self.reduceSpaces(y)
+        self.assertEqualDiff(x, y)
 
-        def test_contents_3(self):
-                """ test matching """
+    def test_contents_3(self):
+        """test matching"""
 
-                self.image_create(self.rurl)
-                self.pkg("install bronze@1.0")
-                self.pkg("contents 'bro*'")
+        self.image_create(self.rurl)
+        self.pkg("install bronze@1.0")
+        self.pkg("contents 'bro*'")
 
-        def test_contents_failures(self):
-                """ attempt to get contents of non-existent packages """
+    def test_contents_failures(self):
+        """attempt to get contents of non-existent packages"""
 
-                self.image_create(self.rurl)
-                self.pkg("contents bad", exit=1)
-                self.pkg("contents -r bad", exit=1)
+        self.image_create(self.rurl)
+        self.pkg("contents bad", exit=1)
+        self.pkg("contents -r bad", exit=1)
 
-        def test_contents_dash_a(self):
-                """Test the -a option of contents"""
+    def test_contents_dash_a(self):
+        """Test the -a option of contents"""
 
-                self.image_create(self.rurl)
-                self.pkg("install bronze")
+        self.image_create(self.rurl)
+        self.pkg("install bronze")
 
-                # Basic -a
-                self.pkg("contents -H -o action.hash -a path=usr/bin/sh")
-                self.assertTrue(self.output.rstrip() ==
-                    "422bdb3eb2d613367933194e3f11220aebe56226")
+        # Basic -a
+        self.pkg("contents -H -o action.hash -a path=usr/bin/sh")
+        self.assertTrue(
+            self.output.rstrip() == "422bdb3eb2d613367933194e3f11220aebe56226"
+        )
 
-                # -a with a pattern
-                self.pkg("contents -H -o action.hash -a path=etc/bronze*")
-                self.assertTrue(self.output.splitlines() == [
-                    "02cdf31d12ccfb6d35e4b8eeff10535e22da3f7e",
-                    "b14e4cdfee720f1eab645bcbfb76eca153301715"])
+        # -a with a pattern
+        self.pkg("contents -H -o action.hash -a path=etc/bronze*")
+        self.assertTrue(
+            self.output.splitlines()
+            == [
+                "02cdf31d12ccfb6d35e4b8eeff10535e22da3f7e",
+                "b14e4cdfee720f1eab645bcbfb76eca153301715",
+            ]
+        )
 
-                # Multiple -a
-                self.pkg("contents -H -o action.hash -a path=etc/bronze1 "
-                    "-a mode=0555")
-                self.assertEqualDiff(self.output.splitlines(),[
-                    "02cdf31d12ccfb6d35e4b8eeff10535e22da3f7e",
-                    "422bdb3eb2d613367933194e3f11220aebe56226"])
+        # Multiple -a
+        self.pkg(
+            "contents -H -o action.hash -a path=etc/bronze1 " "-a mode=0555"
+        )
+        self.assertEqualDiff(
+            self.output.splitlines(),
+            [
+                "02cdf31d12ccfb6d35e4b8eeff10535e22da3f7e",
+                "422bdb3eb2d613367933194e3f11220aebe56226",
+            ],
+        )
 
-                # Non-matching pattern should exit 1
-                self.pkg("contents -a path=usr/bin/notthere", 1)
+        # Non-matching pattern should exit 1
+        self.pkg("contents -a path=usr/bin/notthere", 1)
 
-        def test_contents_dash_o(self):
-                """Test the -o option of contents. When pkg contents doesn't
-                find any actions that match the specified output columns, we
-                produce appropriate error messages."""
+    def test_contents_dash_o(self):
+        """Test the -o option of contents. When pkg contents doesn't
+        find any actions that match the specified output columns, we
+        produce appropriate error messages."""
 
-                self.image_create(self.rurl)
-                self.pkg("install nopathA")
-                self.pkg("install nopathB")
+        self.image_create(self.rurl)
+        self.pkg("install nopathA")
+        self.pkg("install nopathB")
 
-                # Test that the build_release is dropped from version string of
-                # pkg FMRIS for the special case '-o pkg.fmri'.(Bug 17659776)"""
-                self.pkg("contents -o pkg.fmri nopathA")
-                self.assertTrue(pfmri.PkgFmri(self.plist[1]).get_fmri(
-                    include_build=False) in self.output)
+        # Test that the build_release is dropped from version string of
+        # pkg FMRIS for the special case '-o pkg.fmri'.(Bug 17659776)"""
+        self.pkg("contents -o pkg.fmri nopathA")
+        self.assertTrue(
+            pfmri.PkgFmri(self.plist[1]).get_fmri(include_build=False)
+            in self.output
+        )
 
-                # part of the messages that result in running pkg contents
-                # when no output would result.  Note that pkg still returns 0
-                # at present in these cases.
-                # XXX Checking for a substring of an error message in a test case
-                # isn't ideal.
-                nopath = "This package delivers no filesystem content"
-                nopath_plural = "These packages deliver no filesystem content"
+        # part of the messages that result in running pkg contents
+        # when no output would result.  Note that pkg still returns 0
+        # at present in these cases.
+        # XXX Checking for a substring of an error message in a test case
+        # isn't ideal.
+        nopath = "This package delivers no filesystem content"
+        nopath_plural = "These packages deliver no filesystem content"
 
-                nofield = "This package contains no actions with the fields specified " \
-                    "using the -o"
-                nofield_plural = "These packages contain no actions with the fields " \
-                    "specified using the -o"
+        nofield = (
+            "This package contains no actions with the fields specified "
+            "using the -o"
+        )
+        nofield_plural = (
+            "These packages contain no actions with the fields "
+            "specified using the -o"
+        )
 
-                self.pkg("contents nopathA")
-                self.assertTrue(nopath in self.errout)
+        self.pkg("contents nopathA")
+        self.assertTrue(nopath in self.errout)
 
-                self.pkg("contents nopathA nopathB")
-                self.assertTrue(nopath_plural in self.errout)
+        self.pkg("contents nopathA nopathB")
+        self.assertTrue(nopath_plural in self.errout)
 
-                self.pkg("contents -o noodles nopathA")
-                self.assertTrue(nofield in self.errout)
+        self.pkg("contents -o noodles nopathA")
+        self.assertTrue(nofield in self.errout)
 
-                self.pkg("contents -o noodles -o mice nopathA nopathB")
-                self.assertTrue(nofield_plural in self.errout)
+        self.pkg("contents -o noodles -o mice nopathA nopathB")
+        self.assertTrue(nofield_plural in self.errout)
 
-        def test_contents_dash_t(self):
-                """Test the -t option of contents. When pkg contents doesn't
-                find any actions that match the specified action, we produce
-                appropriate error messages."""
+    def test_contents_dash_t(self):
+        """Test the -t option of contents. When pkg contents doesn't
+        find any actions that match the specified action, we produce
+        appropriate error messages."""
 
-                self.image_create(self.rurl)
-                self.pkg("install nopathA")
+        self.image_create(self.rurl)
+        self.pkg("install nopathA")
 
-                # Test that the pkg has a license action
-                self.pkg("contents -t license nopathA", exit=0)
+        # Test that the pkg has a license action
+        self.pkg("contents -t license nopathA", exit=0)
 
-                # Test that the pkg has a no depend action, and we produce
-                # appropriate error
-                self.pkg("contents -t depend nopathA")
-                self.assertFalse("contains no actions specified using the -t option"
-                    in self.output)
+        # Test that the pkg has a no depend action, and we produce
+        # appropriate error
+        self.pkg("contents -t depend nopathA")
+        self.assertFalse(
+            "contains no actions specified using the -t option" in self.output
+        )
 
-        def test_bug_4315(self):
-                """Test that when multiple manifests are given and -m is used,
-                their contents aren't comingled."""
+    def test_bug_4315(self):
+        """Test that when multiple manifests are given and -m is used,
+        their contents aren't comingled."""
 
-                self.image_create(self.rurl)
-                self.pkg("contents -r -m {0}".format(" ".join(self.plist)))
-                expected_res = reduce(lambda x, y: x + y,
-                    [
-                        self.get_img_manifest(pfmri.PkgFmri(s))
-                        for s in self.plist
-                    ], "")
+        self.image_create(self.rurl)
+        self.pkg("contents -r -m {0}".format(" ".join(self.plist)))
+        expected_res = reduce(
+            lambda x, y: x + y,
+            [self.get_img_manifest(pfmri.PkgFmri(s)) for s in self.plist],
+            "",
+        )
 
-                self.assertEqualDiff(expected_res, self.output)
+        self.assertEqualDiff(expected_res, self.output)
 
-        def test_ranked(self):
-                """Verify that pkg contents -r returns expected results
-                when multiple publishers provide the same package based
-                on publisher search order."""
+    def test_ranked(self):
+        """Verify that pkg contents -r returns expected results
+        when multiple publishers provide the same package based
+        on publisher search order."""
 
-                # Create an isolated repository for this test
-                repodir = os.path.join(self.test_root, "test-ranked")
-                self.create_repo(repodir)
-                self.pkgrepo("add-publisher -s {0} test".format(repodir))
-                self.pkgsend_bulk(repodir, self.bronze10)
+        # Create an isolated repository for this test
+        repodir = os.path.join(self.test_root, "test-ranked")
+        self.create_repo(repodir)
+        self.pkgrepo("add-publisher -s {0} test".format(repodir))
+        self.pkgsend_bulk(repodir, self.bronze10)
 
-                self.pkgrepo("add-publisher -s {0} test2".format(repodir))
-                self.pkgrepo("set -s {0} publisher/prefix=test2".format(repodir))
-                self.pkgsend_bulk(repodir, self.bronze10)
+        self.pkgrepo("add-publisher -s {0} test2".format(repodir))
+        self.pkgrepo("set -s {0} publisher/prefix=test2".format(repodir))
+        self.pkgsend_bulk(repodir, self.bronze10)
 
-                self.pkgrepo("add-publisher -s {0} test3".format(repodir))
-                self.pkgrepo("set -s {0} publisher/prefix=test3".format(repodir))
-                self.pkgsend_bulk(repodir, self.bronze10)
+        self.pkgrepo("add-publisher -s {0} test3".format(repodir))
+        self.pkgrepo("set -s {0} publisher/prefix=test3".format(repodir))
+        self.pkgsend_bulk(repodir, self.bronze10)
 
-                # Create a test image.
-                self.image_create()
-                self.pkg("set-publisher -p {0}".format(repodir))
+        # Create a test image.
+        self.image_create()
+        self.pkg("set-publisher -p {0}".format(repodir))
 
-                # Test should be higher ranked than test2 since the default
-                # for auto-configuration is to use lexical order when
-                # multiple publishers are found.  As such, info -r should
-                # return results for 'test' by default.
-                self.pkg("contents -H -r -t set -o pkg.fmri bronze")
-                self.assertTrue(self.output.startswith("pkg://test/bronze"))
-                self.assertTrue("pkg://test2/bronze" not in self.output)
-                self.assertTrue("pkg://test3/bronze" not in self.output)
+        # Test should be higher ranked than test2 since the default
+        # for auto-configuration is to use lexical order when
+        # multiple publishers are found.  As such, info -r should
+        # return results for 'test' by default.
+        self.pkg("contents -H -r -t set -o pkg.fmri bronze")
+        self.assertTrue(self.output.startswith("pkg://test/bronze"))
+        self.assertTrue("pkg://test2/bronze" not in self.output)
+        self.assertTrue("pkg://test3/bronze" not in self.output)
 
-                # Verify that if the publisher is specified, that is preferred
-                # over rank.
-                self.pkg("contents -H -r -t set -o pkg.fmri //test2/bronze")
-                self.assertTrue("pkg://test/bronze" not in self.output)
-                self.assertTrue(self.output.startswith("pkg://test2/bronze"))
-                self.assertTrue("pkg://test3/bronze" not in self.output)
+        # Verify that if the publisher is specified, that is preferred
+        # over rank.
+        self.pkg("contents -H -r -t set -o pkg.fmri //test2/bronze")
+        self.assertTrue("pkg://test/bronze" not in self.output)
+        self.assertTrue(self.output.startswith("pkg://test2/bronze"))
+        self.assertTrue("pkg://test3/bronze" not in self.output)
 
-                # Verify that if stem is specified with and without publisher,
-                # both matches are listed if the higher-ranked publisher differs
-                # from the publisher specified.
-                self.pkg("contents -H -r -t set -o pkg.fmri //test/bronze "
-                    "bronze")
-                self.assertTrue(self.output.startswith("pkg://test/bronze"))
-                self.assertTrue("pkg://test2/bronze" not in self.output)
-                self.assertTrue("pkg://test3/bronze" not in self.output)
+        # Verify that if stem is specified with and without publisher,
+        # both matches are listed if the higher-ranked publisher differs
+        # from the publisher specified.
+        self.pkg("contents -H -r -t set -o pkg.fmri //test/bronze " "bronze")
+        self.assertTrue(self.output.startswith("pkg://test/bronze"))
+        self.assertTrue("pkg://test2/bronze" not in self.output)
+        self.assertTrue("pkg://test3/bronze" not in self.output)
 
-                self.pkg("contents -H -r -t set -o pkg.fmri //test2/bronze "
-                    "bronze")
-                self.assertTrue(self.output.startswith("pkg://test/bronze"))
-                self.assertTrue("pkg://test2/bronze" in self.output)
-                self.assertTrue("pkg://test3/bronze" not in self.output)
+        self.pkg("contents -H -r -t set -o pkg.fmri //test2/bronze " "bronze")
+        self.assertTrue(self.output.startswith("pkg://test/bronze"))
+        self.assertTrue("pkg://test2/bronze" in self.output)
+        self.assertTrue("pkg://test3/bronze" not in self.output)
 
-                self.pkg("contents -H -r -t set -o pkg.fmri //test3/bronze "
-                    "//test2/bronze bronze")
-                self.assertTrue(self.output.startswith("pkg://test/bronze"))
-                self.assertTrue("pkg://test2/bronze" in self.output)
-                self.assertTrue("pkg://test3/bronze" in self.output)
+        self.pkg(
+            "contents -H -r -t set -o pkg.fmri //test3/bronze "
+            "//test2/bronze bronze"
+        )
+        self.assertTrue(self.output.startswith("pkg://test/bronze"))
+        self.assertTrue("pkg://test2/bronze" in self.output)
+        self.assertTrue("pkg://test3/bronze" in self.output)
 
 
 class TestPkgContentsPerTestRepo(pkg5unittest.SingleDepotTestCase):
-        """A separate test class is needed because these tests modify packages
-        after they've been published and need to avoid corrupting packages for
-        other tests."""
+    """A separate test class is needed because these tests modify packages
+    after they've been published and need to avoid corrupting packages for
+    other tests."""
 
-        persistent_setup = False
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    persistent_setup = False
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        nopathA10 = """
+    nopathA10 = """
             open nopathA@1.0,5.11-0
             add license tmp/copyright1 license=copyright
             close
         """
 
-        misc_files = ["tmp/copyright1"]
+    misc_files = ["tmp/copyright1"]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.plist = self.pkgsend_bulk(self.rurl, (self.nopathA10))
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.plist = self.pkgsend_bulk(self.rurl, (self.nopathA10))
 
+    def test_contents_installed_changed_manifest(self):
+        """Test that if an installed manifest has changed in the
+        repository the original manifest is used for pkg contents and
+        contents -r."""
 
-        def test_contents_installed_changed_manifest(self):
-                """Test that if an installed manifest has changed in the
-                repository the original manifest is used for pkg contents and
-                contents -r."""
+        self.image_create(self.rurl)
+        self.pkg("install nopathA")
 
-                self.image_create(self.rurl)
-                self.pkg("install nopathA")
+        # Specify location as filesystem path.
+        self.pkgsign_simple(self.dc.get_repodir(), "nopathA")
+        self.pkg("refresh --full")
 
-                # Specify location as filesystem path.
-                self.pkgsign_simple(self.dc.get_repodir(), "nopathA")
-                self.pkg("refresh --full")
+        self.pkg("contents -m nopathA")
+        self.assertTrue("signature" not in self.output)
+        self.pkg("contents -r -m nopathA")
+        self.assertTrue("signature" not in self.output)
 
-                self.pkg("contents -m nopathA")
-                self.assertTrue("signature" not in self.output)
-                self.pkg("contents -r -m nopathA")
-                self.assertTrue("signature" not in self.output)
+    def test_contents_uninstalled_changed_manifest(self):
+        """Test that if an uninstalled manifest has changed in the
+        repository but is cached locally, that the changed manifest is
+        reflected in contents -r."""
 
-        def test_contents_uninstalled_changed_manifest(self):
-                """Test that if an uninstalled manifest has changed in the
-                repository but is cached locally, that the changed manifest is
-                reflected in contents -r."""
+        self.image_create(self.rurl)
+        self.pkg("contents -r -m nopathA")
 
-                self.image_create(self.rurl)
-                self.pkg("contents -r -m nopathA")
+        # Specify location as filesystem path.
+        self.pkgsign_simple(self.dc.get_repodir(), "nopathA")
+        self.pkg("refresh")
 
-                # Specify location as filesystem path.
-                self.pkgsign_simple(self.dc.get_repodir(), "nopathA")
-                self.pkg("refresh")
-
-                self.pkg("contents -r -m nopathA")
-                self.assertTrue("signature" in self.output)
+        self.pkg("contents -r -m nopathA")
+        self.assertTrue("signature" in self.output)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_depotd.py
+++ b/src/tests/cli/t_pkg_depotd.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import datetime
@@ -53,52 +54,53 @@ import pkg.p5i as p5i
 import re
 import subprocess
 
-class TestPkgDepot(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
 
-        foo10 = """
+class TestPkgDepot(pkg5unittest.SingleDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+
+    foo10 = """
             open foo@1.0,5.11-0
             add dir path=foo/foo mode=0755 owner=root group=bin
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             add dir path=foo/bar mode=0755 owner=root group=bin
             close """
 
-        quux10 = """
+    quux10 = """
             open quux@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
             close """
 
-        info10 = """
+    info10 = """
             open info@1.0,5.11-0
             close """
 
-        update10 = """
+    update10 = """
             open update@1.0,5.11-0
             close """
 
-        update11 = """
+    update11 = """
             open update@1.1,5.11-0
             close """
 
-        system10 = """
+    system10 = """
             open system/libc@1.0,5.11-0
             add set name="description" value="Package to test package names with slashes"
             add dir path=tmp/foo mode=0755 owner=root group=bin
             add depend type=require fmri=pkg:/SUNWcsl
             close """
 
-        entire10 = """
+    entire10 = """
             open entire@1.0,5.11-0
             add depend type=incorporate fmri=pkg:/foo
             close """
 
-        info20 = """
+    info20 = """
             open info@2.0,5.11-0
             add set name="description" value="Test for checking info_0 consistency"
             add set name="pkg.human-version" value="test of human version"
@@ -107,1162 +109,1189 @@ class TestPkgDepot(pkg5unittest.SingleDepotTestCase):
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
             close"""
 
-        misc_files = [ "tmp/libc.so.1", "tmp/cat" ]
+    misc_files = ["tmp/libc.so.1", "tmp/cat"]
 
-        def setUp(self):
-                # test_info() parses dates,
-                # so set expected locale before starting depots
-                os.environ['LC_ALL'] = 'C'
+    def setUp(self):
+        # test_info() parses dates,
+        # so set expected locale before starting depots
+        os.environ["LC_ALL"] = "C"
 
-                # This suite, for obvious reasons, actually needs a depot.
-                pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
-                self.make_misc_files(self.misc_files)
+        # This suite, for obvious reasons, actually needs a depot.
+        pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
+        self.make_misc_files(self.misc_files)
 
-        def test_depot_ping(self):
-                """ Ping the depot several times """
+    def test_depot_ping(self):
+        """Ping the depot several times"""
 
-                self.assertTrue(self.dc.is_alive())
-                self.assertTrue(self.dc.is_alive())
-                self.assertTrue(self.dc.is_alive())
-                self.assertTrue(self.dc.is_alive())
+        self.assertTrue(self.dc.is_alive())
+        self.assertTrue(self.dc.is_alive())
+        self.assertTrue(self.dc.is_alive())
+        self.assertTrue(self.dc.is_alive())
 
-        def testStartStop(self):
-                """ Start and stop the depot several times """
-                self.dc.stop()
-                for i in range(0, 5):
-                        self.dc.start()
-                        self.assertTrue(self.dc.is_alive())
-                        self.dc.stop()
-                        self.assertTrue(not self.dc.is_alive())
+    def testStartStop(self):
+        """Start and stop the depot several times"""
+        self.dc.stop()
+        for i in range(0, 5):
+            self.dc.start()
+            self.assertTrue(self.dc.is_alive())
+            self.dc.stop()
+            self.assertTrue(not self.dc.is_alive())
 
-                self.dc.start()
+        self.dc.start()
 
-        def test_bug_1876(self):
-                """ Send package quux@1.0 an action at a time, restarting the
-                    depot server after each one is sent, to ensure that
-                    transactions work across depot restart. Then verify that
-                    the package was successfully added by performing some
-                    basic operations. """
+    def test_bug_1876(self):
+        """Send package quux@1.0 an action at a time, restarting the
+        depot server after each one is sent, to ensure that
+        transactions work across depot restart. Then verify that
+        the package was successfully added by performing some
+        basic operations."""
 
-                durl = self.dc.get_depot_url()
+        durl = self.dc.get_depot_url()
 
-                for line in self.quux10.split("\n"):
-                        line = line.strip()
-                        if line == "":
-                                continue
+        for line in self.quux10.split("\n"):
+            line = line.strip()
+            if line == "":
+                continue
 
-                        try:
-                                self.pkgsend(durl, line, exit = 0)
-                        except:
-                                self.pkgsend(durl, "close -A", exit = 0)
-                                raise
+            try:
+                self.pkgsend(durl, line, exit=0)
+            except:
+                self.pkgsend(durl, "close -A", exit=0)
+                raise
 
-                        if not line == "close":
-                                self.restart_depots()
+            if not line == "close":
+                self.restart_depots()
 
-                self.image_create(durl)
+        self.image_create(durl)
 
-                self.pkg("list -a")
-                self.pkg("list", exit=1)
+        self.pkg("list -a")
+        self.pkg("list", exit=1)
 
-                self.pkg("install quux")
+        self.pkg("install quux")
 
-                self.pkg("list")
-                self.pkg("verify")
+        self.pkg("list")
+        self.pkg("verify")
 
-                self.pkg("uninstall quux")
-                self.pkg("verify")
+        self.pkg("uninstall quux")
+        self.pkg("verify")
 
-        def test_bad_fmris(self):
-                durl = self.dc.get_depot_url()
-                self.pkgsend(durl, "open foo@", exit=1)
-                self.pkgsend(durl, "open foo@x.y", exit=1)
-                self.pkgsend(durl, "open foo@1.0,-2.0", exit=1)
+    def test_bad_fmris(self):
+        durl = self.dc.get_depot_url()
+        self.pkgsend(durl, "open foo@", exit=1)
+        self.pkgsend(durl, "open foo@x.y", exit=1)
+        self.pkgsend(durl, "open foo@1.0,-2.0", exit=1)
 
-        def test_bug_3365(self):
-                durl = self.dc.get_depot_url()
-                depotpath = self.dc.get_repodir()
+    def test_bug_3365(self):
+        durl = self.dc.get_depot_url()
+        depotpath = self.dc.get_repodir()
 
-                dir_file = os.path.join(depotpath, "search.dir")
-                pag_file = os.path.join(depotpath, "search.pag")
+        dir_file = os.path.join(depotpath, "search.dir")
+        pag_file = os.path.join(depotpath, "search.pag")
 
-                self.assertTrue(not os.path.exists(dir_file))
-                self.assertTrue(not os.path.exists(pag_file))
+        self.assertTrue(not os.path.exists(dir_file))
+        self.assertTrue(not os.path.exists(pag_file))
 
-                f = open(dir_file, "w")
-                f.close()
-                f = open(pag_file, "w")
-                f.close()
-                self.assertTrue(os.path.exists(dir_file))
-                self.assertTrue(os.path.exists(pag_file))
+        f = open(dir_file, "w")
+        f.close()
+        f = open(pag_file, "w")
+        f.close()
+        self.assertTrue(os.path.exists(dir_file))
+        self.assertTrue(os.path.exists(pag_file))
 
-                self.dc.stop()
-                self.dc.start()
-                self.pkgsend_bulk(durl, self.quux10)
-                self.assertTrue(not os.path.exists(dir_file))
-                self.assertTrue(not os.path.exists(pag_file))
+        self.dc.stop()
+        self.dc.start()
+        self.pkgsend_bulk(durl, self.quux10)
+        self.assertTrue(not os.path.exists(dir_file))
+        self.assertTrue(not os.path.exists(pag_file))
 
-        def test_bug_4489(self):
-                """Publish a package and then verify that the depot /info
-                operation doesn't fail."""
-                depot_url = self.dc.get_depot_url()
-                plist = self.pkgsend_bulk(depot_url, self.info10)
-                repourl = urljoin(depot_url, "info/0/{0}".format(plist[0]))
-                urlopen(repourl)
+    def test_bug_4489(self):
+        """Publish a package and then verify that the depot /info
+        operation doesn't fail."""
+        depot_url = self.dc.get_depot_url()
+        plist = self.pkgsend_bulk(depot_url, self.info10)
+        repourl = urljoin(depot_url, "info/0/{0}".format(plist[0]))
+        urlopen(repourl)
 
-        def test_bug_3739(self):
-                """Verify that a depot will return a 400 (Bad Request) error
-                whenever it is provided malformed FMRIs."""
+    def test_bug_3739(self):
+        """Verify that a depot will return a 400 (Bad Request) error
+        whenever it is provided malformed FMRIs."""
 
-                durl = self.dc.get_depot_url()
+        durl = self.dc.get_depot_url()
 
-                for operation in ("info", "manifest"):
-                        for entry in ("BRCMbnx", "BRCMbnx%40a",
-                            "BRCMbnx%400.5.11%2C5.11-0.101%3A20081119T231649a"):
-                                try:
-                                        urlopen("{0}/{1}/0/{2}".format(durl,
-                                            operation, entry))
-                                except HTTPError as e:
-                                        if e.code != http_client.BAD_REQUEST:
-                                                raise
-
-        def test_bug_5366(self):
-                """Publish a package with slashes in the name, and then verify
-                that the depot manifest and info operations work regardless of
-                the encoding."""
-                depot_url = self.dc.get_depot_url()
-                plist = self.pkgsend_bulk(depot_url, self.system10)
-                # First, try it un-encoded.
-                repourl = urljoin(depot_url, "info/0/{0}".format(plist[0]))
-                urlopen(repourl)
-                repourl = urljoin(depot_url, "manifest/0/{0}".format(
-                    plist[0]))
-                urlopen(repourl)
-                # Second, try it encoded.
-                repourl = urljoin(depot_url, "info/0/{0}".format(
-                    quote(plist[0])))
-                urlopen(repourl)
-                repourl = urljoin(depot_url, "manifest/0/{0}".format(
-                    quote(plist[0])))
-                urlopen(repourl)
-
-        def test_info(self):
-                """Testing information showed in /info/0."""
-
-                depot_url = self.dc.get_depot_url();
-                plist = self.pkgsend_bulk(depot_url, self.info20)
-
-                openurl = urljoin(depot_url, "info/0/{0}".format(plist[0]))
-                # urlopen.read return bytes
-                content = misc.force_str(urlopen(openurl).read())
-                # Get text from content.
-                lines = content.splitlines()
-                info_dic = {}
-                attr_list = [
-                    'Name',
-                    'Summary',
-                    'Publisher',
-                    'Version',
-                    'Build Release',
-                    'Branch',
-                    'Packaging Date',
-                    'Size',
-                    'Compressed Size',
-                    'FMRI'
-                ]
-
-                for line in lines:
-                        fields = misc.force_str(line).split(":", 1)
-                        attr = fields[0].strip()
-                        if attr == "License":
-                                break
-                        if attr in attr_list:
-                                if len(fields) == 2:
-                                        info_dic[attr] = fields[1].strip()
-                                else:
-                                        info_dic[attr] = ""
-
-                # Read manifest.
-                openurl = urljoin(depot_url, "manifest/0/{0}".format(plist[0]))
-                content = misc.force_str(urlopen(openurl).read())
-                manifest = man.Manifest()
-                manifest.set_content(content=content)
-                fmri_content = manifest.get("pkg.fmri", "")
-
-                # Check if FMRI is empty.
-                self.assertTrue(fmri_content)
-                pfmri = fmri.PkgFmri(fmri_content, None)
-                pub, name, ver = pfmri.tuple()
-                size, csize = manifest.get_size()
-
-                # Human version.
-                version = info_dic['Version']
-                hum_ver = ""
-                if '(' in version:
-                        start = version.find('(')
-                        end = version.rfind(')')
-                        hum_ver = version[start + 1 : end - len(version)]
-                        version = version[:start - len(version)]
-                        info_dic['Version'] = version.strip()
-
-                # Compare each attribute.
-                self.assertEqual(info_dic["Summary"], manifest.get("pkg.summary",
-                    manifest.get("description", "")))
-                self.assertEqual(info_dic["Version"], str(ver.release))
-                self.assertEqual(hum_ver, manifest.get("pkg.human-version",""))
-                self.assertEqual(info_dic["Name"], name)
-                self.assertEqual(info_dic["Publisher"], pub)
-                self.assertEqual(info_dic["Build Release"], str(ver.build_release))
-                timestamp = datetime.datetime.strptime(
-                    info_dic["Packaging Date"], "%a %b %d %H:%M:%S %Y")
-                self.assertEqual(timestamp, ver.get_timestamp())
-                self.assertEqual(info_dic["Size"], misc.bytes_to_str(size))
-                self.assertEqual(info_dic["Compressed Size"], misc.bytes_to_str(csize))
-                self.assertEqual(info_dic["FMRI"], fmri_content)
-                if six.PY3:
-                        os.environ["LC_ALL"] = "en_US.UTF-8"
-
-        def test_bug_5707(self):
-                """Testing depotcontroller.refresh()."""
-
-                depot_url = self.dc.get_depot_url()
-                self.pkgsend_bulk(depot_url, self.foo10)
-
-                self.image_create(depot_url)
-                self.pkg("install foo")
-                self.pkg("verify")
-
-                depot_file_url = "file://{0}".format(self.dc.get_repodir())
-                self.pkgsend_bulk(depot_url, self.bar10)
-                self.pkg("refresh")
-
-                self.pkg("install bar")
-                self.pkg("verify")
-
-                self.dc.refresh()
-                self.pkg("refresh")
-
-                self.pkg("install bar", exit=4) # nothing to do
-                self.pkg("verify")
-
-        def test_face_root(self):
-                """Verify that files outside of the package content web root
-                cannot be accessed, and that files inside can be."""
-                depot_url = self.dc.get_depot_url()
-                # Since /usr/share/lib/pkg/web/ is the content web root,
-                # any attempts to go outside that directory should fail
-                # with a 404 error.
+        for operation in ("info", "manifest"):
+            for entry in (
+                "BRCMbnx",
+                "BRCMbnx%40a",
+                "BRCMbnx%400.5.11%2C5.11-0.101%3A20081119T231649a",
+            ):
                 try:
-                        urlopen("{0}/../../../../bin/pkg".format(depot_url))
+                    urlopen("{0}/{1}/0/{2}".format(durl, operation, entry))
                 except HTTPError as e:
-                        if e.code != http_client.NOT_FOUND:
-                                raise
+                    if e.code != http_client.BAD_REQUEST:
+                        raise
 
-                f = urlopen("{0}/robots.txt".format(depot_url))
-                self.assertTrue(len(f.read()))
-                f.close()
+    def test_bug_5366(self):
+        """Publish a package with slashes in the name, and then verify
+        that the depot manifest and info operations work regardless of
+        the encoding."""
+        depot_url = self.dc.get_depot_url()
+        plist = self.pkgsend_bulk(depot_url, self.system10)
+        # First, try it un-encoded.
+        repourl = urljoin(depot_url, "info/0/{0}".format(plist[0]))
+        urlopen(repourl)
+        repourl = urljoin(depot_url, "manifest/0/{0}".format(plist[0]))
+        urlopen(repourl)
+        # Second, try it encoded.
+        repourl = urljoin(depot_url, "info/0/{0}".format(quote(plist[0])))
+        urlopen(repourl)
+        repourl = urljoin(depot_url, "manifest/0/{0}".format(quote(plist[0])))
+        urlopen(repourl)
 
-        def test_repo_create(self):
-                """Verify that starting a depot server in readonly mode with
-                a non-existent or empty repo_dir fails and that permissions
-                errors are handled correctly during creation.  Then verify
-                that starting a depot with the same directory in publishing
-                mode works and then a readonly depot again after that works.
-                """
+    def test_info(self):
+        """Testing information showed in /info/0."""
 
-                dpath = os.path.join(self.test_root, "repo_create")
+        depot_url = self.dc.get_depot_url()
+        plist = self.pkgsend_bulk(depot_url, self.info20)
 
-                opath = self.dc.get_repodir()
-                self.dc.set_repodir(dpath)
+        openurl = urljoin(depot_url, "info/0/{0}".format(plist[0]))
+        # urlopen.read return bytes
+        content = misc.force_str(urlopen(openurl).read())
+        # Get text from content.
+        lines = content.splitlines()
+        info_dic = {}
+        attr_list = [
+            "Name",
+            "Summary",
+            "Publisher",
+            "Version",
+            "Build Release",
+            "Branch",
+            "Packaging Date",
+            "Size",
+            "Compressed Size",
+            "FMRI",
+        ]
 
-                # First, test readonly mode with a repo_dir that doesn't exist.
-                self.dc.set_readonly()
-                self.dc.stop()
-                self.dc.start_expected_fail()
-                self.assertTrue(not self.dc.is_alive())
+        for line in lines:
+            fields = misc.force_str(line).split(":", 1)
+            attr = fields[0].strip()
+            if attr == "License":
+                break
+            if attr in attr_list:
+                if len(fields) == 2:
+                    info_dic[attr] = fields[1].strip()
+                else:
+                    info_dic[attr] = ""
 
-                # Next, test readonly mode with a repo_dir that is empty.
-                os.makedirs(dpath, misc.PKG_DIR_MODE)
-                self.dc.set_readonly()
-                self.dc.start_expected_fail()
-                self.assertTrue(not self.dc.is_alive())
+        # Read manifest.
+        openurl = urljoin(depot_url, "manifest/0/{0}".format(plist[0]))
+        content = misc.force_str(urlopen(openurl).read())
+        manifest = man.Manifest()
+        manifest.set_content(content=content)
+        fmri_content = manifest.get("pkg.fmri", "")
 
-                # Next, test readwrite (publishing) mode with a non-existent
-                # repo_dir.
-                shutil.rmtree(dpath)
-                self.dc.set_readwrite()
-                self.dc.start()
-                self.assertTrue(self.dc.is_alive())
-                self.dc.stop()
-                self.assertTrue(not self.dc.is_alive())
+        # Check if FMRI is empty.
+        self.assertTrue(fmri_content)
+        pfmri = fmri.PkgFmri(fmri_content, None)
+        pub, name, ver = pfmri.tuple()
+        size, csize = manifest.get_size()
 
-                # Next, test readwrite (publishing) mode with a non-existent
-                # repo_dir for an unprivileged user.
-                shutil.rmtree(dpath)
-                self.dc.set_readwrite()
-                wr_start, wr_end = self.dc.get_wrapper()
-                su_wrap, su_end = self.get_su_wrapper(su_wrap=True)
-                try:
-                        self.dc.set_wrapper([su_wrap], su_end)
-                        self.dc.start_expected_fail(exit=1)
-                finally:
-                        # Even if this test fails, this wrapper must be reset.
-                        self.dc.set_wrapper(wr_start, wr_end)
-                self.assertTrue(not self.dc.is_alive())
+        # Human version.
+        version = info_dic["Version"]
+        hum_ver = ""
+        if "(" in version:
+            start = version.find("(")
+            end = version.rfind(")")
+            hum_ver = version[start + 1 : end - len(version)]
+            version = version[: start - len(version)]
+            info_dic["Version"] = version.strip()
 
-                # Next, test readwrite (publishing) mode with an empty repo_dir.
-                os.makedirs(dpath, misc.PKG_DIR_MODE)
-                self.dc.set_readwrite()
-                self.dc.start()
-                self.assertTrue(self.dc.is_alive())
-                self.dc.stop()
-                self.assertTrue(not self.dc.is_alive())
+        # Compare each attribute.
+        self.assertEqual(
+            info_dic["Summary"],
+            manifest.get("pkg.summary", manifest.get("description", "")),
+        )
+        self.assertEqual(info_dic["Version"], str(ver.release))
+        self.assertEqual(hum_ver, manifest.get("pkg.human-version", ""))
+        self.assertEqual(info_dic["Name"], name)
+        self.assertEqual(info_dic["Publisher"], pub)
+        self.assertEqual(info_dic["Build Release"], str(ver.build_release))
+        timestamp = datetime.datetime.strptime(
+            info_dic["Packaging Date"], "%a %b %d %H:%M:%S %Y"
+        )
+        self.assertEqual(timestamp, ver.get_timestamp())
+        self.assertEqual(info_dic["Size"], misc.bytes_to_str(size))
+        self.assertEqual(info_dic["Compressed Size"], misc.bytes_to_str(csize))
+        self.assertEqual(info_dic["FMRI"], fmri_content)
+        if six.PY3:
+            os.environ["LC_ALL"] = "en_US.UTF-8"
 
-                # Finally, re-test readonly mode now that the repository has
-                # been created.
-                self.dc.set_readonly()
-                self.dc.start()
-                self.assertTrue(self.dc.is_alive())
-                self.dc.stop()
-                self.assertTrue(not self.dc.is_alive())
+    def test_bug_5707(self):
+        """Testing depotcontroller.refresh()."""
 
-                # Cleanup.
-                shutil.rmtree(dpath)
-                self.dc.set_repodir(opath)
+        depot_url = self.dc.get_depot_url()
+        self.pkgsend_bulk(depot_url, self.foo10)
 
-        def test_append_reopen(self):
-                """Test that if a depot has a partially finished append
-                transaction, that it reopens it correctly."""
+        self.image_create(depot_url)
+        self.pkg("install foo")
+        self.pkg("verify")
 
-                durl = self.dc.get_depot_url()
-                plist = self.pkgsend_bulk(durl, self.foo10)
-                self.pkgsend(durl, "append {0}".format(plist[0]))
-                self.dc.stop()
-                self.dc.start()
-                self.pkgsend(durl, "close")
+        depot_file_url = "file://{0}".format(self.dc.get_repodir())
+        self.pkgsend_bulk(depot_url, self.bar10)
+        self.pkg("refresh")
 
-        def test_nonsig_append(self):
-                """Test that sending a non-signature action to an append
-                transaction results in an error."""
+        self.pkg("install bar")
+        self.pkg("verify")
 
-                durl = self.dc.get_depot_url()
-                plist = self.pkgsend_bulk(durl, self.foo10)
-                self.pkgsend(durl, "append {0}".format(plist[0]))
-                self.pkgsend(durl, "add dir path=tmp/foo mode=0755 "
-                    "owner=root group=bin", exit=1)
+        self.dc.refresh()
+        self.pkg("refresh")
 
-        def test_root_link(self):
-                """Verify that the depot server accepts a link to a
-                directory as a repository root."""
+        self.pkg("install bar", exit=4)  # nothing to do
+        self.pkg("verify")
 
-                if self.dc.started:
-                        self.dc.stop()
+    def test_face_root(self):
+        """Verify that files outside of the package content web root
+        cannot be accessed, and that files inside can be."""
+        depot_url = self.dc.get_depot_url()
+        # Since /usr/share/lib/pkg/web/ is the content web root,
+        # any attempts to go outside that directory should fail
+        # with a 404 error.
+        try:
+            urlopen("{0}/../../../../bin/pkg".format(depot_url))
+        except HTTPError as e:
+            if e.code != http_client.NOT_FOUND:
+                raise
 
-                # Create a link to the repository and verify that
-                # the depot server allows it.
-                lsrc = self.dc.get_repodir()
-                ltarget = os.path.join(self.test_root, "depot_link")
-                os.symlink(lsrc, ltarget)
-                self.dc.set_repodir(ltarget)
-                self.dc.start()
+        f = urlopen("{0}/robots.txt".format(depot_url))
+        self.assertTrue(len(f.read()))
+        f.close()
 
-                # Reset for any tests that might execute afterwards.
-                os.unlink(ltarget)
-                self.dc.stop()
-                self.dc.set_repodir(lsrc)
-                self.dc.start()
+    def test_repo_create(self):
+        """Verify that starting a depot server in readonly mode with
+        a non-existent or empty repo_dir fails and that permissions
+        errors are handled correctly during creation.  Then verify
+        that starting a depot with the same directory in publishing
+        mode works and then a readonly depot again after that works.
+        """
 
-        def test_empty_incorp_depend(self):
-                """ Bug 16304629
-                Test that a version-less incorporate dependency in a package
-                doesn't cause a traceback and a 404 in the BUI.
-                """
-                depot_url = self.dc.get_depot_url()
-                self.pkgsend_bulk(depot_url, self.foo10)
-                self.pkgsend_bulk(depot_url, self.entire10)
+        dpath = os.path.join(self.test_root, "repo_create")
 
-                repourl = urljoin(depot_url,
-                    "/en/catalog.shtml?version={0}&action=Browse".format(
-                    quote("entire@1.0,5.11-0")))
+        opath = self.dc.get_repodir()
+        self.dc.set_repodir(dpath)
 
-                res = urlopen(repourl)
+        # First, test readonly mode with a repo_dir that doesn't exist.
+        self.dc.set_readonly()
+        self.dc.stop()
+        self.dc.start_expected_fail()
+        self.assertTrue(not self.dc.is_alive())
 
-        def test_publisher_prefix(self):
-                """Test that various publisher prefixes can be understood
-                by CherryPy's dispatcher."""
+        # Next, test readonly mode with a repo_dir that is empty.
+        os.makedirs(dpath, misc.PKG_DIR_MODE)
+        self.dc.set_readonly()
+        self.dc.start_expected_fail()
+        self.assertTrue(not self.dc.is_alive())
 
-                if self.dc.started:
-                        self.dc.stop()
+        # Next, test readwrite (publishing) mode with a non-existent
+        # repo_dir.
+        shutil.rmtree(dpath)
+        self.dc.set_readwrite()
+        self.dc.start()
+        self.assertTrue(self.dc.is_alive())
+        self.dc.stop()
+        self.assertTrue(not self.dc.is_alive())
 
-                depot_url = self.dc.get_depot_url()
-                repopath = os.path.join(self.test_root, "repo")
-                self.create_repo(repopath)
-                self.dc.set_repodir(repopath)
-                pubs = ["test-hyphen", "test.dot"]
-                for p in pubs:
-                        self.pkgrepo("-s {0} add-publisher {1}".format(
-                            repopath, p))
-                self.dc.start()
-                for p in pubs:
-                        # test that the catalog file can be found
-                        url = urljoin(depot_url,
-                            "{0}/catalog/1/catalog.attrs".format(p))
-                        urlopen(url)
+        # Next, test readwrite (publishing) mode with a non-existent
+        # repo_dir for an unprivileged user.
+        shutil.rmtree(dpath)
+        self.dc.set_readwrite()
+        wr_start, wr_end = self.dc.get_wrapper()
+        su_wrap, su_end = self.get_su_wrapper(su_wrap=True)
+        try:
+            self.dc.set_wrapper([su_wrap], su_end)
+            self.dc.start_expected_fail(exit=1)
+        finally:
+            # Even if this test fails, this wrapper must be reset.
+            self.dc.set_wrapper(wr_start, wr_end)
+        self.assertTrue(not self.dc.is_alive())
+
+        # Next, test readwrite (publishing) mode with an empty repo_dir.
+        os.makedirs(dpath, misc.PKG_DIR_MODE)
+        self.dc.set_readwrite()
+        self.dc.start()
+        self.assertTrue(self.dc.is_alive())
+        self.dc.stop()
+        self.assertTrue(not self.dc.is_alive())
+
+        # Finally, re-test readonly mode now that the repository has
+        # been created.
+        self.dc.set_readonly()
+        self.dc.start()
+        self.assertTrue(self.dc.is_alive())
+        self.dc.stop()
+        self.assertTrue(not self.dc.is_alive())
+
+        # Cleanup.
+        shutil.rmtree(dpath)
+        self.dc.set_repodir(opath)
+
+    def test_append_reopen(self):
+        """Test that if a depot has a partially finished append
+        transaction, that it reopens it correctly."""
+
+        durl = self.dc.get_depot_url()
+        plist = self.pkgsend_bulk(durl, self.foo10)
+        self.pkgsend(durl, "append {0}".format(plist[0]))
+        self.dc.stop()
+        self.dc.start()
+        self.pkgsend(durl, "close")
+
+    def test_nonsig_append(self):
+        """Test that sending a non-signature action to an append
+        transaction results in an error."""
+
+        durl = self.dc.get_depot_url()
+        plist = self.pkgsend_bulk(durl, self.foo10)
+        self.pkgsend(durl, "append {0}".format(plist[0]))
+        self.pkgsend(
+            durl,
+            "add dir path=tmp/foo mode=0755 " "owner=root group=bin",
+            exit=1,
+        )
+
+    def test_root_link(self):
+        """Verify that the depot server accepts a link to a
+        directory as a repository root."""
+
+        if self.dc.started:
+            self.dc.stop()
+
+        # Create a link to the repository and verify that
+        # the depot server allows it.
+        lsrc = self.dc.get_repodir()
+        ltarget = os.path.join(self.test_root, "depot_link")
+        os.symlink(lsrc, ltarget)
+        self.dc.set_repodir(ltarget)
+        self.dc.start()
+
+        # Reset for any tests that might execute afterwards.
+        os.unlink(ltarget)
+        self.dc.stop()
+        self.dc.set_repodir(lsrc)
+        self.dc.start()
+
+    def test_empty_incorp_depend(self):
+        """Bug 16304629
+        Test that a version-less incorporate dependency in a package
+        doesn't cause a traceback and a 404 in the BUI.
+        """
+        depot_url = self.dc.get_depot_url()
+        self.pkgsend_bulk(depot_url, self.foo10)
+        self.pkgsend_bulk(depot_url, self.entire10)
+
+        repourl = urljoin(
+            depot_url,
+            "/en/catalog.shtml?version={0}&action=Browse".format(
+                quote("entire@1.0,5.11-0")
+            ),
+        )
+
+        res = urlopen(repourl)
+
+    def test_publisher_prefix(self):
+        """Test that various publisher prefixes can be understood
+        by CherryPy's dispatcher."""
+
+        if self.dc.started:
+            self.dc.stop()
+
+        depot_url = self.dc.get_depot_url()
+        repopath = os.path.join(self.test_root, "repo")
+        self.create_repo(repopath)
+        self.dc.set_repodir(repopath)
+        pubs = ["test-hyphen", "test.dot"]
+        for p in pubs:
+            self.pkgrepo("-s {0} add-publisher {1}".format(repopath, p))
+        self.dc.start()
+        for p in pubs:
+            # test that the catalog file can be found
+            url = urljoin(depot_url, "{0}/catalog/1/catalog.attrs".format(p))
+            urlopen(url)
+
 
 class TestDepotController(pkg5unittest.CliTestCase):
+    def setUp(self):
+        pkg5unittest.CliTestCase.setUp(self)
 
-        def setUp(self):
-                pkg5unittest.CliTestCase.setUp(self)
+        self.__dc = dc.DepotController()
+        self.__pid = os.getpid()
+        self.__dc.set_property("publisher", "prefix", "test")
+        self.__dc.set_depotd_path(
+            pkg5unittest.g_pkg_path + "/usr/lib/pkg.depotd"
+        )
+        self.__dc.set_depotd_content_root(
+            pkg5unittest.g_pkg_path + "/usr/share/lib/pkg"
+        )
 
-                self.__dc = dc.DepotController()
-                self.__pid = os.getpid()
-                self.__dc.set_property("publisher", "prefix", "test")
-                self.__dc.set_depotd_path(pkg5unittest.g_pkg_path + \
-                    "/usr/lib/pkg.depotd")
-                self.__dc.set_depotd_content_root(pkg5unittest.g_pkg_path + \
-                    "/usr/share/lib/pkg")
+        repopath = os.path.join(self.test_root, "repo")
+        logpath = os.path.join(self.test_root, self.id())
+        self.create_repo(repopath, properties={"publisher": {"prefix": "test"}})
+        self.__dc.set_repodir(repopath)
+        self.__dc.set_logpath(logpath)
 
-                repopath = os.path.join(self.test_root, "repo")
-                logpath = os.path.join(self.test_root, self.id())
-                self.create_repo(repopath, properties={ "publisher": {
-                    "prefix": "test" }})
-                self.__dc.set_repodir(repopath)
-                self.__dc.set_logpath(logpath)
+    def _get_repo_index_dir(self):
+        depotpath = self.__dc.get_repodir()
+        repo = self.__dc.get_repo()
+        rstore = repo.get_pub_rstore("test")
+        return rstore.index_root
 
-        def _get_repo_index_dir(self):
-                depotpath = self.__dc.get_repodir()
-                repo = self.__dc.get_repo()
-                rstore = repo.get_pub_rstore("test")
-                return rstore.index_root
+    def _get_repo_writ_dir(self):
+        depotpath = self.__dc.get_repodir()
+        repo = self.__dc.get_repo()
+        rstore = repo.get_pub_rstore("test")
+        return rstore.writable_root
 
-        def _get_repo_writ_dir(self):
-                depotpath = self.__dc.get_repodir()
-                repo = self.__dc.get_repo()
-                rstore = repo.get_pub_rstore("test")
-                return rstore.writable_root
+    def tearDown(self):
+        pkg5unittest.CliTestCase.tearDown(self)
+        self.__dc.kill()
 
-        def tearDown(self):
-                pkg5unittest.CliTestCase.tearDown(self)
-                self.__dc.kill()
+    def testStartStop(self):
+        self.__dc.set_port(self.next_free_port)
+        for i in range(0, 5):
+            self.__dc.start()
+            self.assertTrue(self.__dc.is_alive())
+            self.__dc.stop()
+            self.assertTrue(not self.__dc.is_alive())
 
-        def testStartStop(self):
-                self.__dc.set_port(self.next_free_port)
-                for i in range(0, 5):
-                        self.__dc.start()
-                        self.assertTrue(self.__dc.is_alive())
-                        self.__dc.stop()
-                        self.assertTrue(not self.__dc.is_alive())
+    def test_cfg_file(self):
+        cfg_file = os.path.join(self.test_root, "cfg2")
+        fh = open(cfg_file, "w")
+        fh.close()
+        self.__dc.set_port(self.next_free_port)
+        self.__dc.set_cfg_file(cfg_file)
+        self.__dc.start()
 
-        def test_cfg_file(self):
-                cfg_file = os.path.join(self.test_root, "cfg2")
-                fh = open(cfg_file, "w")
-                fh.close()
-                self.__dc.set_port(self.next_free_port)
-                self.__dc.set_cfg_file(cfg_file)
-                self.__dc.start()
+    def test_writable_root(self):
+        """Tests whether the index and feed cache file are written to
+        the writable root parameter."""
 
-        def test_writable_root(self):
-                """Tests whether the index and feed cache file are written to
-                the writable root parameter."""
+        self.make_misc_files(TestPkgDepot.misc_files)
+        writable_root = os.path.join(self.test_root, "writ_root")
+        o_index_dir = os.path.join(self._get_repo_index_dir(), "index")
 
-                self.make_misc_files(TestPkgDepot.misc_files)
-                writable_root = os.path.join(self.test_root,
-                    "writ_root")
-                o_index_dir = os.path.join(self._get_repo_index_dir(), "index")
+        timeout = 10
 
-                timeout = 10
+        def check_state(check_feed):
+            index_dir = os.path.join(self._get_repo_writ_dir(), "index")
+            feed = os.path.join(writable_root, "publisher", "test", "feed.xml")
+            found = (
+                not os.path.exists(o_index_dir)
+                and os.path.isdir(index_dir)
+                and (not check_feed or os.path.isfile(feed))
+            )
+            start_time = time.time()
+            while not found and time.time() - start_time < timeout:
+                time.sleep(1)
+                found = (
+                    not os.path.exists(o_index_dir)
+                    and os.path.isdir(index_dir)
+                    and (not check_feed or os.path.isfile(feed))
+                )
 
-                def check_state(check_feed):
-                        index_dir = os.path.join(self._get_repo_writ_dir(),
-                            "index")
-                        feed = os.path.join(writable_root, "publisher", "test",
-                            "feed.xml")
-                        found = not os.path.exists(o_index_dir) and \
-                            os.path.isdir(index_dir) and \
-                            (not check_feed or os.path.isfile(feed))
-                        start_time = time.time()
-                        while not found and time.time() - start_time < timeout:
-                                time.sleep(1)
-                                found = not os.path.exists(o_index_dir) and \
-                                    os.path.isdir(index_dir) and \
-                                    (not check_feed or os.path.isfile(feed))
-
-                        self.assertTrue(not os.path.exists(o_index_dir))
-                        self.assertTrue(os.path.isdir(index_dir))
-                        if check_feed:
-                                try:
-                                        self.assertTrue(os.path.isfile(feed))
-                                except:
-                                        raise RuntimeError("Feed cache file "
-                                            "not found at '{0}'.".format(feed))
-                def get_feed(durl, pub=""):
-                        start_time = time.time()
-                        got = False
-                        while not got and (time.time() - start_time) < timeout:
-                                if pub:
-                                        pub = "{0}/".format(pub)
-                                try:
-                                        urlopen("{0}{1}/feed".format(durl,
-                                            pub))
-                                        got = True
-                                except HTTPError as e:
-                                        self.debug(str(e))
-                                        time.sleep(1)
-                        self.assertTrue(got)
-
-                self.__dc.set_port(self.next_free_port)
-                durl = self.__dc.get_depot_url()
-
-                repo = self.__dc.get_repo()
-                pub = repo.get_publisher("test")
-                pub_repo = pub.repository
-                if not pub_repo:
-                        pub_repo = publisher.Repository()
-                        pub.repository = pub_repo
-                pub_repo.origins = [durl]
-                repo.update_publisher(pub)
-
-                self.__dc.set_writable_root(writable_root)
-                self.__dc.set_property("publisher", "prefix", "test")
-                self.__dc.start()
-                check_state(False)
-                self.pkgsend_bulk(durl, TestPkgDepot.quux10, refresh_index=True)
-                get_feed(durl)
-                check_state(True)
-
-                self.image_create(durl)
-                self.pkg("search -r cat")
-                self.__dc.stop()
-                self.__dc.set_readonly()
-                shutil.rmtree(writable_root)
-                self.__dc.start()
-                get_feed(durl)
-                check_state(True)
-                self.pkg("search -r cat")
-                self.__dc.stop()
-                self.__dc.set_refresh_index()
-                shutil.rmtree(writable_root)
-                self.__dc.start()
-                check_state(False)
-                self.__dc.stop()
-                self.__dc.set_norefresh_index()
-                self.__dc.start()
-                get_feed(durl)
-                check_state(True)
-                self.pkg("search -r cat")
-
-        def testBadArgs(self):
-                self.__dc.set_port(self.next_free_port)
-                self.__dc.set_readonly()
-                self.__dc.set_rebuild()
-                self.__dc.set_norefresh_index()
-
-                self.assertTrue(self.__dc.start_expected_fail())
-
-                self.__dc.set_readonly()
-                self.__dc.set_norebuild()
-                self.__dc.set_refresh_index()
-
-                self.assertTrue(self.__dc.start_expected_fail())
-
-                self.__dc.set_readonly()
-                self.__dc.set_rebuild()
-                self.__dc.set_refresh_index()
-
-                self.assertTrue(self.__dc.start_expected_fail())
-
-                self.__dc.set_readwrite()
-                self.__dc.set_rebuild()
-                self.__dc.set_refresh_index()
-
-                self.assertTrue(self.__dc.start_expected_fail())
-
-                self.__dc.set_mirror()
-                self.__dc.set_rebuild()
-                self.__dc.set_norefresh_index()
-
-                self.assertTrue(self.__dc.start_expected_fail())
-
-                self.__dc.set_mirror()
-                self.__dc.set_norebuild()
-                self.__dc.set_refresh_index()
-
-                self.assertTrue(self.__dc.start_expected_fail())
-
-        def test_disable_ops(self):
-                """Verify that disable-ops works as expected."""
-
-                # For this disabled case, /catalog/1/ should return
-                # a NOT_FOUND error.
-                self.__dc.set_disable_ops(["catalog/1"])
-                self.__dc.set_port(self.next_free_port)
-                self.__dc.start()
-                durl = self.__dc.get_depot_url()
+            self.assertTrue(not os.path.exists(o_index_dir))
+            self.assertTrue(os.path.isdir(index_dir))
+            if check_feed:
                 try:
-                        urlopen("{0}/catalog/1/".format(durl))
-                except HTTPError as e:
-                        self.assertEqual(e.code, http_client.NOT_FOUND)
-                self.__dc.stop()
+                    self.assertTrue(os.path.isfile(feed))
+                except:
+                    raise RuntimeError(
+                        "Feed cache file " "not found at '{0}'.".format(feed)
+                    )
 
-                # For this disabled case, all /catalog/ operations should return
-                # a NOT_FOUND error.
-                self.__dc.set_disable_ops(["catalog"])
-                self.__dc.set_port(self.next_free_port)
-                self.__dc.start()
-                durl = self.__dc.get_depot_url()
-                for ver in (0, 1):
-                        try:
-                                urlopen("{0}/catalog/{1:d}/".format(durl, ver))
-                        except HTTPError as e:
-                                self.assertEqual(e.code, http_client.NOT_FOUND)
-                self.__dc.stop()
-
-                # In the normal case, /catalog/1/ should return
-                # a FORBIDDEN error.
-                self.__dc.unset_disable_ops()
-                self.__dc.start()
-                durl = self.__dc.get_depot_url()
+        def get_feed(durl, pub=""):
+            start_time = time.time()
+            got = False
+            while not got and (time.time() - start_time) < timeout:
+                if pub:
+                    pub = "{0}/".format(pub)
                 try:
-                        urlopen("{0}/catalog/1/".format(durl))
+                    urlopen("{0}{1}/feed".format(durl, pub))
+                    got = True
                 except HTTPError as e:
-                        self.assertEqual(e.code, http_client.FORBIDDEN)
-                self.__dc.stop()
+                    self.debug(str(e))
+                    time.sleep(1)
+            self.assertTrue(got)
 
-                # A bogus operation should prevent the depot from starting.
-                self.__dc.set_disable_ops(["no_such_op/0"])
-                self.__dc.start_expected_fail()
-                self.assertFalse(self.__dc.is_alive())
+        self.__dc.set_port(self.next_free_port)
+        durl = self.__dc.get_depot_url()
+
+        repo = self.__dc.get_repo()
+        pub = repo.get_publisher("test")
+        pub_repo = pub.repository
+        if not pub_repo:
+            pub_repo = publisher.Repository()
+            pub.repository = pub_repo
+        pub_repo.origins = [durl]
+        repo.update_publisher(pub)
+
+        self.__dc.set_writable_root(writable_root)
+        self.__dc.set_property("publisher", "prefix", "test")
+        self.__dc.start()
+        check_state(False)
+        self.pkgsend_bulk(durl, TestPkgDepot.quux10, refresh_index=True)
+        get_feed(durl)
+        check_state(True)
+
+        self.image_create(durl)
+        self.pkg("search -r cat")
+        self.__dc.stop()
+        self.__dc.set_readonly()
+        shutil.rmtree(writable_root)
+        self.__dc.start()
+        get_feed(durl)
+        check_state(True)
+        self.pkg("search -r cat")
+        self.__dc.stop()
+        self.__dc.set_refresh_index()
+        shutil.rmtree(writable_root)
+        self.__dc.start()
+        check_state(False)
+        self.__dc.stop()
+        self.__dc.set_norefresh_index()
+        self.__dc.start()
+        get_feed(durl)
+        check_state(True)
+        self.pkg("search -r cat")
+
+    def testBadArgs(self):
+        self.__dc.set_port(self.next_free_port)
+        self.__dc.set_readonly()
+        self.__dc.set_rebuild()
+        self.__dc.set_norefresh_index()
+
+        self.assertTrue(self.__dc.start_expected_fail())
+
+        self.__dc.set_readonly()
+        self.__dc.set_norebuild()
+        self.__dc.set_refresh_index()
+
+        self.assertTrue(self.__dc.start_expected_fail())
+
+        self.__dc.set_readonly()
+        self.__dc.set_rebuild()
+        self.__dc.set_refresh_index()
+
+        self.assertTrue(self.__dc.start_expected_fail())
+
+        self.__dc.set_readwrite()
+        self.__dc.set_rebuild()
+        self.__dc.set_refresh_index()
+
+        self.assertTrue(self.__dc.start_expected_fail())
+
+        self.__dc.set_mirror()
+        self.__dc.set_rebuild()
+        self.__dc.set_norefresh_index()
+
+        self.assertTrue(self.__dc.start_expected_fail())
+
+        self.__dc.set_mirror()
+        self.__dc.set_norebuild()
+        self.__dc.set_refresh_index()
+
+        self.assertTrue(self.__dc.start_expected_fail())
+
+    def test_disable_ops(self):
+        """Verify that disable-ops works as expected."""
+
+        # For this disabled case, /catalog/1/ should return
+        # a NOT_FOUND error.
+        self.__dc.set_disable_ops(["catalog/1"])
+        self.__dc.set_port(self.next_free_port)
+        self.__dc.start()
+        durl = self.__dc.get_depot_url()
+        try:
+            urlopen("{0}/catalog/1/".format(durl))
+        except HTTPError as e:
+            self.assertEqual(e.code, http_client.NOT_FOUND)
+        self.__dc.stop()
+
+        # For this disabled case, all /catalog/ operations should return
+        # a NOT_FOUND error.
+        self.__dc.set_disable_ops(["catalog"])
+        self.__dc.set_port(self.next_free_port)
+        self.__dc.start()
+        durl = self.__dc.get_depot_url()
+        for ver in (0, 1):
+            try:
+                urlopen("{0}/catalog/{1:d}/".format(durl, ver))
+            except HTTPError as e:
+                self.assertEqual(e.code, http_client.NOT_FOUND)
+        self.__dc.stop()
+
+        # In the normal case, /catalog/1/ should return
+        # a FORBIDDEN error.
+        self.__dc.unset_disable_ops()
+        self.__dc.start()
+        durl = self.__dc.get_depot_url()
+        try:
+            urlopen("{0}/catalog/1/".format(durl))
+        except HTTPError as e:
+            self.assertEqual(e.code, http_client.FORBIDDEN)
+        self.__dc.stop()
+
+        # A bogus operation should prevent the depot from starting.
+        self.__dc.set_disable_ops(["no_such_op/0"])
+        self.__dc.start_expected_fail()
+        self.assertFalse(self.__dc.is_alive())
 
 
 class TestDepotOutput(pkg5unittest.SingleDepotTestCase):
-        # Since these tests are output sensitive, the depots should be purged
-        # after each one is run.
-        persistent_setup = False
+    # Since these tests are output sensitive, the depots should be purged
+    # after each one is run.
+    persistent_setup = False
 
-        quux10 = """
+    quux10 = """
             open quux@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             close """
 
-        info10 = """
+    info10 = """
             open info@1.0,5.11-0
             close """
 
-        file10 = """
+    file10 = """
             open file@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/var
             add file tmp/file path=var/file mode=644 owner=root group=bin
             close """
 
-        system10 = """
+    system10 = """
             open system/libc@1.0,5.11-0
             add set name="description" value="Package to test package names with slashes"
             add dir path=tmp/foo mode=0755 owner=root group=bin
             add depend type=require fmri=pkg:/SUNWcsl
             close """
 
-        zfsextras10 = """
+    zfsextras10 = """
             open zfs-extras@1.0,5.11-0
             close """
 
-        zfsutils10 = """
+    zfsutils10 = """
             open zfs/utils@1.0,5.11-0
             close """
 
-        repo_cfg = {
-            "publisher": {
-                "prefix": "org.opensolaris.pending"
-            },
-        }
+    repo_cfg = {
+        "publisher": {"prefix": "org.opensolaris.pending"},
+    }
 
-        pub_repo_cfg = {
-            "collection_type": "supplemental",
-            "description":
-                "Development packages for the contrib repository.",
-            "legal_uris": [
-                "http://www.opensolaris.org/os/copyrights",
-                "http://www.opensolaris.org/os/tou",
-                "http://www.opensolaris.org/os/trademark"
-            ],
-            "mirrors": [],
-            "name": """"Pending" Repository""",
-            "origins": [],  # Has to be set during setUp for correct origin.
-            "refresh_seconds": 86400,
-            "registration_uri": "",
-            "related_uris": [
-                "http://jucr.opensolaris.org/contrib",
-                "http://jucr.opensolaris.org/pending",
-                "http://pkg.opensolaris.org/contrib",
-            ]
-        }
+    pub_repo_cfg = {
+        "collection_type": "supplemental",
+        "description": "Development packages for the contrib repository.",
+        "legal_uris": [
+            "http://www.opensolaris.org/os/copyrights",
+            "http://www.opensolaris.org/os/tou",
+            "http://www.opensolaris.org/os/trademark",
+        ],
+        "mirrors": [],
+        "name": """"Pending" Repository""",
+        "origins": [],  # Has to be set during setUp for correct origin.
+        "refresh_seconds": 86400,
+        "registration_uri": "",
+        "related_uris": [
+            "http://jucr.opensolaris.org/contrib",
+            "http://jucr.opensolaris.org/pending",
+            "http://pkg.opensolaris.org/contrib",
+        ],
+    }
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
 
-                # Prevent override of custom configuration;
-                # tests will set as needed.
-                self.dc.clear_property("publisher", "prefix")
+        # Prevent override of custom configuration;
+        # tests will set as needed.
+        self.dc.clear_property("publisher", "prefix")
 
-                self.tpath = tempfile.mkdtemp(prefix="tpath",
-                    dir=self.test_root)
+        self.tpath = tempfile.mkdtemp(prefix="tpath", dir=self.test_root)
 
-                self.make_misc_files("tmp/file")
+        self.make_misc_files("tmp/file")
 
-        def __depot_daemon_start(self, repopath, out_path, err_path):
-                """Helper function: start a depot daemon and return a handler
-                for its parent process and the port number it is running on.
-                The parent process is a ctrun process. It is the user's
-                responsibility to call depot_daemon_stop to stop the process.
-                ctrun is used to kill the depot daemon process after finishing
-                testing. It is needed because the double fork machanism of the
-                daemonizer make the daemonized depot server indenpendent from
-                its parent process.
+    def __depot_daemon_start(self, repopath, out_path, err_path):
+        """Helper function: start a depot daemon and return a handler
+        for its parent process and the port number it is running on.
+        The parent process is a ctrun process. It is the user's
+        responsibility to call depot_daemon_stop to stop the process.
+        ctrun is used to kill the depot daemon process after finishing
+        testing. It is needed because the double fork machanism of the
+        daemonizer make the daemonized depot server indenpendent from
+        its parent process.
 
-                repopath: The repository path that a depot daemon will run on.
+        repopath: The repository path that a depot daemon will run on.
 
-                out_path: The depot daemon stdout log file path.
+        out_path: The depot daemon stdout log file path.
 
-                err_path: The depot daemon stderr log file path."""
+        err_path: The depot daemon stderr log file path."""
 
-                # Make sure the PKGDEPOT_CONTROLLER is not set in the newenv.
-                newenv = os.environ.copy()
-                newenv.pop("PKGDEPOT_CONTROLLER", None)
+        # Make sure the PKGDEPOT_CONTROLLER is not set in the newenv.
+        newenv = os.environ.copy()
+        newenv.pop("PKGDEPOT_CONTROLLER", None)
 
-                cmdargs = [
-                    '/usr/bin/ctrun', '-o', 'noorphan',
-                    sys.executable,
-                    f'{pkg5unittest.g_pkg_path}/usr/lib/pkg.depotd',
-                    '-p', str(self.next_free_port),
-                    '-d', repopath,
-                    '--content-root',
-                        f'{pkg5unittest.g_pkg_path}/usr/share/lib/pkg',
-                    '--readonly',
-                    f'--log-access={out_path}',
-                    f'--log-errors={err_path}']
+        cmdargs = [
+            "/usr/bin/ctrun",
+            "-o",
+            "noorphan",
+            sys.executable,
+            f"{pkg5unittest.g_pkg_path}/usr/lib/pkg.depotd",
+            "-p",
+            str(self.next_free_port),
+            "-d",
+            repopath,
+            "--content-root",
+            f"{pkg5unittest.g_pkg_path}/usr/share/lib/pkg",
+            "--readonly",
+            f"--log-access={out_path}",
+            f"--log-errors={err_path}",
+        ]
 
-                curport = self.next_free_port
-                self.next_free_port += 1
+        curport = self.next_free_port
+        self.next_free_port += 1
 
-                # Start a depot daemon process.
+        # Start a depot daemon process.
+        try:
+            depot_handle = subprocess.Popen(
+                cmdargs, env=newenv, stdin=subprocess.DEVNULL
+            )
+
+            self.assertTrue(
+                depot_handle != None, msg="Could not " "start depot"
+            )
+            begintime = time.time()
+            check_interval = 0.20
+            daemon_started = False
+            durl = "http://localhost:{0}/en/index.shtml".format(curport)
+
+            while (time.time() - begintime) <= 40.0:
+                rc = depot_handle.poll()
+                self.assertTrue(rc is None, msg="Depot exited " "unexpectedly")
+
                 try:
-                        depot_handle = subprocess.Popen(cmdargs, env=newenv,
-                            stdin=subprocess.DEVNULL)
+                    f = urlopen(durl)
+                    daemon_started = True
+                    break
+                except URLError as e:
+                    time.sleep(check_interval)
 
-                        self.assertTrue(depot_handle != None, msg="Could not "
-                            "start depot")
-                        begintime = time.time()
-                        check_interval = 0.20
-                        daemon_started = False
-                        durl = "http://localhost:{0}/en/index.shtml".format(curport)
+            if not daemon_started:
+                if depot_handle:
+                    depot_handle.kill()
+                self.assertTrue(
+                    daemon_started, msg="Could not " "access depot daemon"
+                )
 
-                        while (time.time() - begintime) <= 40.0:
-                                rc = depot_handle.poll()
-                                self.assertTrue(rc is None, msg="Depot exited "
-                                    "unexpectedly")
+            # Read the msgs from the err log file to verify log
+            # msgs.
+            with open(err_path, "r") as read_err:
+                msgs = read_err.readlines()
+                self.assertTrue(
+                    msgs,
+                    "Log message is "
+                    "empty. Check if the previous "
+                    "ctrun process shut down "
+                    "properly",
+                )
+            return (depot_handle, curport)
+        except:
+            try:
+                if depot_handle:
+                    depot_handle.kill()
+            except:
+                pass
+            raise
 
-                                try:
-                                        f = urlopen(durl)
-                                        daemon_started = True
-                                        break
-                                except URLError as e:
-                                        time.sleep(check_interval)
+    def __depot_daemon_stop(self, depot_handle):
+        """Helper function: stop the depot daemon process by sending
+        signal to its handle."""
 
-                        if not daemon_started:
-                                if depot_handle:
-                                        depot_handle.kill()
-                                self.assertTrue(daemon_started, msg="Could not "
-                                    "access depot daemon")
+        if not depot_handle:
+            return
 
-                        # Read the msgs from the err log file to verify log
-                        # msgs.
-                        with open(err_path, "r") as read_err:
-                                msgs = read_err.readlines()
-                                self.assertTrue(msgs, "Log message is "
-                                    "empty. Check if the previous "
-                                    "ctrun process shut down "
-                                    "properly")
-                        return (depot_handle, curport)
-                except:
-                        try:
-                                if depot_handle:
-                                        depot_handle.kill()
-                        except:
-                                pass
-                        raise
+        # Terminate the depot daemon. If failed, kill it.
+        try:
+            i = 0
+            while i < 30:
+                depot_handle.terminate()
+                if depot_handle.returncode is not None:
+                    break
+                time.sleep(0.1)
+                i += 1
+            if depot_handle.returncode is None:
+                depot_handle.kill()
+        except:
+            try:
+                depot_handle.kill()
+            except:
+                pass
 
-        def __depot_daemon_stop(self, depot_handle):
-                """Helper function: stop the depot daemon process by sending
-                signal to its handle."""
+    def test_0_depot_bui_output(self):
+        """Verify that a non-error response and valid HTML is returned
+        for each known BUI page in every available depot mode."""
 
-                if not depot_handle:
-                        return
+        pub = "test"
+        self.dc.set_property("publisher", "prefix", pub)
 
-                # Terminate the depot daemon. If failed, kill it.
-                try:
-                        i = 0
-                        while i < 30:
-                                depot_handle.terminate()
-                                if depot_handle.returncode is not None:
-                                        break
-                                time.sleep(0.1)
-                                i += 1
-                        if depot_handle.returncode is None:
-                                depot_handle.kill()
-                except:
-                        try:
-                                depot_handle.kill()
-                        except:
-                                pass
+        # A list of tuples containing the name of the method used to set
+        # the mode, and then the method needed to unset that mode.
+        mode_methods = [
+            ("set_readwrite", None),
+            ("set_mirror", "unset_mirror"),
+            ("set_readonly", "set_readwrite"),
+        ]
 
-        def test_0_depot_bui_output(self):
-                """Verify that a non-error response and valid HTML is returned
-                for each known BUI page in every available depot mode."""
+        pages = [
+            "index.shtml",
+            "en/catalog.shtml",
+            "en/index.shtml",
+            "en/advanced_search.shtml",
+            "en/search.shtml",
+            "en/stats.shtml",
+        ]
 
-                pub = "test"
-                self.dc.set_property("publisher", "prefix", pub)
+        repodir = self.dc.get_repodir()
+        durl = self.dc.get_depot_url()
+        for with_packages in (False, True):
+            shutil.rmtree(repodir, ignore_errors=True)
 
-                # A list of tuples containing the name of the method used to set
-                # the mode, and then the method needed to unset that mode.
-                mode_methods = [
-                    ("set_readwrite", None),
-                    ("set_mirror", "unset_mirror"),
-                    ("set_readonly", "set_readwrite"),
-                ]
+            # Create repository and set publisher origins.
+            self.create_repo(self.dc.get_repodir())
+            self.pkgrepo(
+                "set -s {repodir} -p {pub} "
+                "repository/origins={durl}".format(**locals())
+            )
 
-                pages = [
-                    "index.shtml",
-                    "en/catalog.shtml",
-                    "en/index.shtml",
-                    "en/advanced_search.shtml",
-                    "en/search.shtml",
-                    "en/stats.shtml",
-                ]
-
-                repodir = self.dc.get_repodir()
-                durl = self.dc.get_depot_url()
-                for with_packages in (False, True):
-                        shutil.rmtree(repodir, ignore_errors=True)
-
-                        # Create repository and set publisher origins.
-                        self.create_repo(self.dc.get_repodir())
-                        self.pkgrepo("set -s {repodir} -p {pub} "
-                            "repository/origins={durl}".format(**locals()))
-
-                        if with_packages:
-                                self.dc.set_readwrite()
-                                self.dc.start()
-                                self.pkgsend_bulk(durl, (self.info10,
-                                    self.quux10, self.system10))
-                                self.dc.stop()
-
-                        for set_method, unset_method in mode_methods:
-                                if set_method:
-                                        getattr(self.dc, set_method)()
-
-                                self.dc.start()
-                                for path in pages:
-                                        # Any error responses will cause an
-                                        # exception.
-                                        response = urlopen(
-                                            "{0}/{1}".format(durl, path))
-
-                                        fd, fpath = tempfile.mkstemp(
-                                            suffix="html", dir=self.tpath)
-                                        fp = os.fdopen(fd, "wb")
-                                        fp.write(response.read())
-                                        fp.close()
-
-                                        # Because the 'role' attribute used for
-                                        # screen readers and other accessibility
-                                        # tools isn't part of the official XHTML
-                                        # 1.x standards, it has to be dropped
-                                        # for the document to be validated.
-                                        # Setting 'drop_prop_attrs' to True here
-                                        # does that while ensuring that the
-                                        # output of the depot is otherwise
-                                        # standards-compliant.
-                                        self.validate_html_file(fpath,
-                                            drop_prop_attrs=True)
-
-                                self.dc.stop()
-                                if unset_method:
-                                        getattr(self.dc, unset_method)()
-
-        def __update_repo_config(self):
-                """Helper function to generate test repository configuration."""
-                # Find and load the repository configuration.
-                rpath = self.dc.get_repodir()
-                assert os.path.isdir(rpath)
-                rcpath = os.path.join(rpath, "cfg_cache")
-
-                rc = sr.RepositoryConfig(target=rcpath)
-
-                # Update the configuration with our sample data.
-                cfgdata = self.repo_cfg
-                for section in cfgdata:
-                        for prop in cfgdata[section]:
-                                rc.set_property(section, prop,
-                                    cfgdata[section][prop])
-
-                # Save it.
-                rc.write()
-
-                # Apply publisher properties and update.
-                repo = self.dc.get_repo()
-                try:
-                        pub = repo.get_publisher("org.opensolaris.pending")
-                except sr.RepositoryUnknownPublisher:
-                        pub = publisher.Publisher("org.opensolaris.pending")
-                        repo.add_publisher(pub)
-
-                pub_repo = pub.repository
-                if not pub_repo:
-                        pub_repo = publisher.Repository()
-                        pub.repository = pub_repo
-
-                for attr, val in six.iteritems(self.pub_repo_cfg):
-                        setattr(pub_repo, attr, val)
-                repo.update_publisher(pub)
-
-        def test_1_depot_publisher(self):
-                """Verify the output of the depot /publisher operation."""
-
-                # Now update the repository configuration while the depot is
-                # stopped so changes won't be overwritten on exit.
-                self.__update_repo_config()
-
-                # Start the depot.
+            if with_packages:
+                self.dc.set_readwrite()
                 self.dc.start()
+                self.pkgsend_bulk(
+                    durl, (self.info10, self.quux10, self.system10)
+                )
+                self.dc.stop()
 
-                durl = self.dc.get_depot_url()
-                purl = urljoin(durl, "publisher/0")
-                entries = p5i.parse(location=purl)
-                # entries's order is unstable in Python 3, but it doesn't really
-                # matter as long as the prefix is in entries.
-                if entries[0][0].prefix == "test":
-                        index = -1
-                        assert entries[1][0].prefix == "org.opensolaris.pending"
-                else:
-                        index = 0
-                        assert entries[0][0].prefix == "org.opensolaris.pending"
-                        assert entries[1][0].prefix == "test"
+            for set_method, unset_method in mode_methods:
+                if set_method:
+                    getattr(self.dc, set_method)()
 
-
-                # Now verify that the parsed response has the expected data.
-                pub, pkglist = entries[index]
-                cfgdata = self.repo_cfg
-                for prop in cfgdata["publisher"]:
-                        self.assertEqual(getattr(pub, prop),
-                            cfgdata["publisher"][prop])
-
-                repo = pub.repository
-                for prop, expected in six.iteritems(self.pub_repo_cfg):
-                        returned = getattr(repo, prop)
-                        if prop.endswith("uris") or prop == "origins":
-                                uris = []
-                                for u in returned:
-                                        uri = u.uri
-                                        if uri.endswith("/"):
-                                                uri = uri[:-1]
-                                        uris.append(uri)
-                                returned = uris
-                        self.assertEqual(returned, expected)
-
-        def test_2_depot_p5i(self):
-                """Verify the output of the depot /p5i operation."""
-
-                # Now update the repository configuration while the depot is
-                # stopped so changes won't be overwritten on exit.
-                self.__update_repo_config()
-
-                # Start the depot.
                 self.dc.start()
+                for path in pages:
+                    # Any error responses will cause an
+                    # exception.
+                    response = urlopen("{0}/{1}".format(durl, path))
 
-                # Then, publish some packages we can abuse for testing.
-                durl = self.dc.get_depot_url()
-                plist = self.pkgsend_bulk(durl, (self.info10, self.quux10,
-                    self.system10, self.zfsextras10, self.zfsutils10))
+                    fd, fpath = tempfile.mkstemp(suffix="html", dir=self.tpath)
+                    fp = os.fdopen(fd, "wb")
+                    fp.write(response.read())
+                    fp.close()
 
-                # Now, for each published package, attempt to get a p5i file
-                # and then verify that the parsed response has the expected
-                # package information under the expected publisher.
-                for p in plist:
-                        purl = urljoin(durl, "p5i/0/{0}".format(p))
-                        pub, pkglist = p5i.parse(location=purl)[0]
+                    # Because the 'role' attribute used for
+                    # screen readers and other accessibility
+                    # tools isn't part of the official XHTML
+                    # 1.x standards, it has to be dropped
+                    # for the document to be validated.
+                    # Setting 'drop_prop_attrs' to True here
+                    # does that while ensuring that the
+                    # output of the depot is otherwise
+                    # standards-compliant.
+                    self.validate_html_file(fpath, drop_prop_attrs=True)
 
-                        # p5i files contain non-qualified FMRIs as the FMRIs
-                        # are already grouped by publisher.
-                        nq_p = fmri.PkgFmri(p).get_fmri(anarchy=True,
-                            include_scheme=False)
-                        self.assertEqual(pkglist, [nq_p])
+                self.dc.stop()
+                if unset_method:
+                    getattr(self.dc, unset_method)()
 
-                # Try again, but only using package stems.
-                for p in plist:
-                        stem = fmri.PkgFmri(p).pkg_name
-                        purl = urljoin(durl, "p5i/0/{0}".format(stem))
-                        pub, pkglist = p5i.parse(location=purl)[0]
-                        self.assertEqual(pkglist, [stem])
+    def __update_repo_config(self):
+        """Helper function to generate test repository configuration."""
+        # Find and load the repository configuration.
+        rpath = self.dc.get_repodir()
+        assert os.path.isdir(rpath)
+        rcpath = os.path.join(rpath, "cfg_cache")
 
-                # Try again, but using wildcards (which will return a list of
-                # matching package stems).
-                purl = urljoin(durl, "p5i/0/zfs*")
-                pub, pkglist = p5i.parse(location=purl)[0]
-                self.assertEqual(pkglist, ["zfs-extras", "zfs/utils"])
+        rc = sr.RepositoryConfig(target=rcpath)
 
-                # Finally, verify that a non-existent package will error out
-                # with a httplib.NOT_FOUND.
-                try:
-                        urlopen(urljoin(durl,
-                            "p5i/0/nosuchpackage"))
-                except HTTPError as e:
-                        if e.code != http_client.NOT_FOUND:
-                                raise
+        # Update the configuration with our sample data.
+        cfgdata = self.repo_cfg
+        for section in cfgdata:
+            for prop in cfgdata[section]:
+                rc.set_property(section, prop, cfgdata[section][prop])
 
-        def test_3_headers(self):
-                """Ensure expected headers are present for client operations
-                (excluding publication)."""
+        # Save it.
+        rc.write()
 
-                # Now update the repository configuration while the depot is
-                # stopped so changes won't be overwritten on exit.
-                self.__update_repo_config()
+        # Apply publisher properties and update.
+        repo = self.dc.get_repo()
+        try:
+            pub = repo.get_publisher("org.opensolaris.pending")
+        except sr.RepositoryUnknownPublisher:
+            pub = publisher.Publisher("org.opensolaris.pending")
+            repo.add_publisher(pub)
 
-                # Start the depot.
-                self.dc.start()
+        pub_repo = pub.repository
+        if not pub_repo:
+            pub_repo = publisher.Repository()
+            pub.repository = pub_repo
 
-                durl = self.dc.get_depot_url()
-                pfmri = fmri.PkgFmri(self.pkgsend_bulk(durl, self.file10,
-                    refresh_index=True)[0], "5.11")
+        for attr, val in six.iteritems(self.pub_repo_cfg):
+            setattr(pub_repo, attr, val)
+        repo.update_publisher(pub)
 
-                # Wait for search indexing to complete.
-                self.wait_repo(self.dc.get_repodir())
+    def test_1_depot_publisher(self):
+        """Verify the output of the depot /publisher operation."""
 
-                def get_headers(req_path):
-                        try:
-                                rinfo = urlopen(urljoin(durl,
-                                    req_path)).info()
-                                return list(rinfo.items())
-                        except HTTPError as e:
-                                return list(e.info().items())
-                        except Exception as e:
-                                raise RuntimeError("retrieval of {0} "
-                                    "failed: {1}".format(req_path, str(e)))
+        # Now update the repository configuration while the depot is
+        # stopped so changes won't be overwritten on exit.
+        self.__update_repo_config()
 
-                for req_path in ("publisher/0", 'search/0/%2Fvar%2Ffile',
-                    'search/1/False_2_None_None_%2Fvar%2Ffile',
-                    "versions/0", "manifest/0/{0}".format(pfmri.get_url_path()),
-                    "catalog/0", "catalog/1/catalog.attrs",
-                    "file/0/3aad0bca6f3a6f502c175700ebe90ef36e312d7e"):
-                        hdrs = dict(get_headers(req_path))
-                        if six.PY2:
-                                # Fields must be referenced in lowercase.
-                                cc = hdrs.get("cache-control", "")
-                                self.assertTrue(cc.startswith("must-revalidate, "
-                                    "no-transform, max-age="))
-                                exp = hdrs.get("expires", None)
-                        else:
-                                # Fields begin with uppercase.
-                                cc = hdrs.get("Cache-Control", "")
-                                self.assertTrue(cc.startswith("must-revalidate, "
-                                    "no-transform, max-age="))
-                                exp = hdrs.get("Expires", None)
-                        self.assertNotEqual(exp, None)
-                        self.assertTrue(exp.endswith(" GMT"))
+        # Start the depot.
+        self.dc.start()
 
-                for req_path in ("catalog/1/catalog.hatters",
-                    "file/0/3aad0bca6f3a6f502c175700ebe90ef36e312d7f"):
+        durl = self.dc.get_depot_url()
+        purl = urljoin(durl, "publisher/0")
+        entries = p5i.parse(location=purl)
+        # entries's order is unstable in Python 3, but it doesn't really
+        # matter as long as the prefix is in entries.
+        if entries[0][0].prefix == "test":
+            index = -1
+            assert entries[1][0].prefix == "org.opensolaris.pending"
+        else:
+            index = 0
+            assert entries[0][0].prefix == "org.opensolaris.pending"
+            assert entries[1][0].prefix == "test"
 
-                        hdrs = dict(get_headers(req_path))
-                        if six.PY2:
-                                cc = hdrs.get("cache-control", None)
-                                prg = hdrs.get("pragma", None)
-                        else:
-                                cc = hdrs.get("Cache-Control", None)
-                                prg = hdrs.get("Pragma", None)
-                        self.assertEqual(cc, None)
-                        self.assertEqual(prg, None)
+        # Now verify that the parsed response has the expected data.
+        pub, pkglist = entries[index]
+        cfgdata = self.repo_cfg
+        for prop in cfgdata["publisher"]:
+            self.assertEqual(getattr(pub, prop), cfgdata["publisher"][prop])
 
-        def test_bug_15482(self):
-                """Test to make sure BUI search doesn't trigger a traceback."""
+        repo = pub.repository
+        for prop, expected in six.iteritems(self.pub_repo_cfg):
+            returned = getattr(repo, prop)
+            if prop.endswith("uris") or prop == "origins":
+                uris = []
+                for u in returned:
+                    uri = u.uri
+                    if uri.endswith("/"):
+                        uri = uri[:-1]
+                    uris.append(uri)
+                returned = uris
+            self.assertEqual(returned, expected)
 
-                # Now update the repository configuration while the depot is
-                # stopped so changes won't be overwritten on exit.
-                self.__update_repo_config()
+    def test_2_depot_p5i(self):
+        """Verify the output of the depot /p5i operation."""
 
-                # Start the depot.
-                self.dc.start()
+        # Now update the repository configuration while the depot is
+        # stopped so changes won't be overwritten on exit.
+        self.__update_repo_config()
 
-                # Then, publish some packages we can abuse for testing.
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.quux10, refresh_index=True)
+        # Start the depot.
+        self.dc.start()
 
-                surl = urljoin(durl,
-                    "en/search.shtml?action=Search&token=*")
-                urlopen(surl).read()
-                surl = urljoin(durl,
-                    "en/advanced_search.shtml?action=Search&token=*")
-                urlopen(surl).read()
-                surl = urljoin(durl,
-                    "en/advanced_search.shtml?token=*&show=a&rpp=50&"
-                    "action=Advanced+Search")
-                urlopen(surl).read()
+        # Then, publish some packages we can abuse for testing.
+        durl = self.dc.get_depot_url()
+        plist = self.pkgsend_bulk(
+            durl,
+            (
+                self.info10,
+                self.quux10,
+                self.system10,
+                self.zfsextras10,
+                self.zfsutils10,
+            ),
+        )
 
-        def test_address(self):
-                """Verify that depot address can be set."""
+        # Now, for each published package, attempt to get a p5i file
+        # and then verify that the parsed response has the expected
+        # package information under the expected publisher.
+        for p in plist:
+            purl = urljoin(durl, "p5i/0/{0}".format(p))
+            pub, pkglist = p5i.parse(location=purl)[0]
 
-                # Check that IPv6 address can be used.
-                self.dc.set_address("::1")
-                self.dc.set_port(self.next_free_port)
-                self.dc.start()
-                self.assertTrue(self.dc.is_alive())
-                self.assertTrue(self.dc.is_alive())
-                self.assertTrue(self.dc.is_alive())
+            # p5i files contain non-qualified FMRIs as the FMRIs
+            # are already grouped by publisher.
+            nq_p = fmri.PkgFmri(p).get_fmri(anarchy=True, include_scheme=False)
+            self.assertEqual(pkglist, [nq_p])
 
-                # Check that we can retrieve something.
-                durl = self.dc.get_depot_url()
-                verdata = urlopen("{0}/versions/0/".format(durl))
+        # Try again, but only using package stems.
+        for p in plist:
+            stem = fmri.PkgFmri(p).pkg_name
+            purl = urljoin(durl, "p5i/0/{0}".format(stem))
+            pub, pkglist = p5i.parse(location=purl)[0]
+            self.assertEqual(pkglist, [stem])
 
-        def test_log_depot_daemon(self):
-                """Verify that depot daemon works properly and the error
-                 message is logged properly."""
+        # Try again, but using wildcards (which will return a list of
+        # matching package stems).
+        purl = urljoin(durl, "p5i/0/zfs*")
+        pub, pkglist = p5i.parse(location=purl)[0]
+        self.assertEqual(pkglist, ["zfs-extras", "zfs/utils"])
 
-                if self.dc.started:
-                        self.dc.stop()
+        # Finally, verify that a non-existent package will error out
+        # with a httplib.NOT_FOUND.
+        try:
+            urlopen(urljoin(durl, "p5i/0/nosuchpackage"))
+        except HTTPError as e:
+            if e.code != http_client.NOT_FOUND:
+                raise
 
-                # Create a test repo.
-                repopath = os.path.join(self.test_root, "repo_tmp_depot_log")
-                self.create_repo(repopath)
+    def test_3_headers(self):
+        """Ensure expected headers are present for client operations
+        (excluding publication)."""
 
-                out_path = os.path.join(self.test_root, "daemon_out_log")
-                err_path = os.path.join(self.test_root, "daemon_err_log")
+        # Now update the repository configuration while the depot is
+        # stopped so changes won't be overwritten on exit.
+        self.__update_repo_config()
 
-                depot_handle = None
-                try:
-                        depot_handle, curport = self.__depot_daemon_start(
-                            repopath, out_path, err_path)
+        # Start the depot.
+        self.dc.start()
 
-                        # Issue a bad request to trigger the server logging
-                        # the error msg.
-                        durl = "http://localhost:{0}/catalog/0".format(curport)
-                        try:
-                                urlopen(durl)
-                        except URLError as e:
-                                pass
-                        # Stop the depot daemon.
-                        self.__depot_daemon_stop(depot_handle)
+        durl = self.dc.get_depot_url()
+        pfmri = fmri.PkgFmri(
+            self.pkgsend_bulk(durl, self.file10, refresh_index=True)[0], "5.11"
+        )
 
-                        # Read the msgs from the err log file to verify log
-                        # msgs.
-                        with open(err_path, "r") as read_err:
-                                msgs = read_err.readlines()
-                        self.assertRegexp(msgs[-1],
-                            r"\[[\w:/]+\]  Request failed")
-                except:
-                        self.__depot_daemon_stop(depot_handle)
-                        raise
+        # Wait for search indexing to complete.
+        self.wait_repo(self.dc.get_repodir())
+
+        def get_headers(req_path):
+            try:
+                rinfo = urlopen(urljoin(durl, req_path)).info()
+                return list(rinfo.items())
+            except HTTPError as e:
+                return list(e.info().items())
+            except Exception as e:
+                raise RuntimeError(
+                    "retrieval of {0} " "failed: {1}".format(req_path, str(e))
+                )
+
+        for req_path in (
+            "publisher/0",
+            "search/0/%2Fvar%2Ffile",
+            "search/1/False_2_None_None_%2Fvar%2Ffile",
+            "versions/0",
+            "manifest/0/{0}".format(pfmri.get_url_path()),
+            "catalog/0",
+            "catalog/1/catalog.attrs",
+            "file/0/3aad0bca6f3a6f502c175700ebe90ef36e312d7e",
+        ):
+            hdrs = dict(get_headers(req_path))
+            if six.PY2:
+                # Fields must be referenced in lowercase.
+                cc = hdrs.get("cache-control", "")
+                self.assertTrue(
+                    cc.startswith("must-revalidate, " "no-transform, max-age=")
+                )
+                exp = hdrs.get("expires", None)
+            else:
+                # Fields begin with uppercase.
+                cc = hdrs.get("Cache-Control", "")
+                self.assertTrue(
+                    cc.startswith("must-revalidate, " "no-transform, max-age=")
+                )
+                exp = hdrs.get("Expires", None)
+            self.assertNotEqual(exp, None)
+            self.assertTrue(exp.endswith(" GMT"))
+
+        for req_path in (
+            "catalog/1/catalog.hatters",
+            "file/0/3aad0bca6f3a6f502c175700ebe90ef36e312d7f",
+        ):
+            hdrs = dict(get_headers(req_path))
+            if six.PY2:
+                cc = hdrs.get("cache-control", None)
+                prg = hdrs.get("pragma", None)
+            else:
+                cc = hdrs.get("Cache-Control", None)
+                prg = hdrs.get("Pragma", None)
+            self.assertEqual(cc, None)
+            self.assertEqual(prg, None)
+
+    def test_bug_15482(self):
+        """Test to make sure BUI search doesn't trigger a traceback."""
+
+        # Now update the repository configuration while the depot is
+        # stopped so changes won't be overwritten on exit.
+        self.__update_repo_config()
+
+        # Start the depot.
+        self.dc.start()
+
+        # Then, publish some packages we can abuse for testing.
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.quux10, refresh_index=True)
+
+        surl = urljoin(durl, "en/search.shtml?action=Search&token=*")
+        urlopen(surl).read()
+        surl = urljoin(durl, "en/advanced_search.shtml?action=Search&token=*")
+        urlopen(surl).read()
+        surl = urljoin(
+            durl,
+            "en/advanced_search.shtml?token=*&show=a&rpp=50&"
+            "action=Advanced+Search",
+        )
+        urlopen(surl).read()
+
+    def test_address(self):
+        """Verify that depot address can be set."""
+
+        # Check that IPv6 address can be used.
+        self.dc.set_address("::1")
+        self.dc.set_port(self.next_free_port)
+        self.dc.start()
+        self.assertTrue(self.dc.is_alive())
+        self.assertTrue(self.dc.is_alive())
+        self.assertTrue(self.dc.is_alive())
+
+        # Check that we can retrieve something.
+        durl = self.dc.get_depot_url()
+        verdata = urlopen("{0}/versions/0/".format(durl))
+
+    def test_log_depot_daemon(self):
+        """Verify that depot daemon works properly and the error
+        message is logged properly."""
+
+        if self.dc.started:
+            self.dc.stop()
+
+        # Create a test repo.
+        repopath = os.path.join(self.test_root, "repo_tmp_depot_log")
+        self.create_repo(repopath)
+
+        out_path = os.path.join(self.test_root, "daemon_out_log")
+        err_path = os.path.join(self.test_root, "daemon_err_log")
+
+        depot_handle = None
+        try:
+            depot_handle, curport = self.__depot_daemon_start(
+                repopath, out_path, err_path
+            )
+
+            # Issue a bad request to trigger the server logging
+            # the error msg.
+            durl = "http://localhost:{0}/catalog/0".format(curport)
+            try:
+                urlopen(durl)
+            except URLError as e:
+                pass
+            # Stop the depot daemon.
+            self.__depot_daemon_stop(depot_handle)
+
+            # Read the msgs from the err log file to verify log
+            # msgs.
+            with open(err_path, "r") as read_err:
+                msgs = read_err.readlines()
+            self.assertRegexp(msgs[-1], r"\[[\w:/]+\]  Request failed")
+        except:
+            self.__depot_daemon_stop(depot_handle)
+            raise
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_errors.py
+++ b/src/tests/cli/t_pkg_errors.py
@@ -26,56 +26,56 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
-class TestPkgSolverErrors(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
 
-        pkgs = (
-            """
+class TestPkgSolverErrors(pkg5unittest.SingleDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+
+    pkgs = (
+        """
             open entire@1.0
             add depend type=incorporate fmri=perl-516@1.0
             close """,
-
-            """
+        """
             open entire@1.1
             add depend type=incorporate fmri=perl-516@1.1
             close """,
-
-            """
+        """
             open osnet@1.0
             add depend type=require fmri=perl-516
             add depend type=incorporate fmri=baz@1.0
             close """,
-
-            """
+        """
             open perl-516@1.0
             add dir mode=0755 owner=root group=bin path=/perl516_1.1
             add depend type=require fmri=entire
             close """,
-
-            """
+        """
             open perl-516@1.1
             add set name=pkg.obsolete value=true
             add set name=pkg.summary value="A test package"
-            close """
-            )
+            close """,
+    )
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.pkgsend_bulk(self.rurl, self.pkgs)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.pkgsend_bulk(self.rurl, self.pkgs)
 
-        def test_incorporation_mixes(self):
-            self.image_create(self.rurl, prefix="")
+    def test_incorporation_mixes(self):
+        self.image_create(self.rurl, prefix="")
 
-            # install entire, osnet and perl
+        # install entire, osnet and perl
 
-            self.pkg("install perl-516 entire@1.0 osnet")
-            self.pkg("install entire@latest", exit=1)
-            self.assertFalse("No solution" in self.errout)
-            self.assertTrue("Package 'osnet' must be uninstalled"
-                " or upgraded if the requested operation is to be performed."
-                in self.errout)
+        self.pkg("install perl-516 entire@1.0 osnet")
+        self.pkg("install entire@latest", exit=1)
+        self.assertFalse("No solution" in self.errout)
+        self.assertTrue(
+            "Package 'osnet' must be uninstalled"
+            " or upgraded if the requested operation is to be performed."
+            in self.errout
+        )

--- a/src/tests/cli/t_pkg_flag.py
+++ b/src/tests/cli/t_pkg_flag.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -38,125 +39,124 @@ import pkg.client.api_errors as apx
 import pkg.json as json
 import pkg.fmri as fmri
 
-class TestPkgFlag(pkg5unittest.SingleDepotTestCase):
-        persistent_setup = True
 
-        foo10 = """
+class TestPkgFlag(pkg5unittest.SingleDepotTestCase):
+    persistent_setup = True
+
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             close """
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             close """
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.sent_pkgs = self.pkgsend_bulk(self.rurl,
-                    [self.foo10, self.bar10, self.baz10])
-                self.foo10_name = fmri.PkgFmri(self.sent_pkgs[0]).get_fmri(
-                    anarchy=True)
-                self.bar10_name = fmri.PkgFmri(self.sent_pkgs[1]).get_fmri(
-                    anarchy=True)
-                self.baz_name = fmri.PkgFmri(self.sent_pkgs[2]).get_fmri(
-                    anarchy=True)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.sent_pkgs = self.pkgsend_bulk(
+            self.rurl, [self.foo10, self.bar10, self.baz10]
+        )
+        self.foo10_name = fmri.PkgFmri(self.sent_pkgs[0]).get_fmri(anarchy=True)
+        self.bar10_name = fmri.PkgFmri(self.sent_pkgs[1]).get_fmri(anarchy=True)
+        self.baz_name = fmri.PkgFmri(self.sent_pkgs[2]).get_fmri(anarchy=True)
 
-        def test_bad_input(self):
-                """Test bad options to pkg flag."""
+    def test_bad_input(self):
+        """Test bad options to pkg flag."""
 
-                self.api_obj = self.image_create(self.rurl)
+        self.api_obj = self.image_create(self.rurl)
 
-                self.pkg("flag", exit=2)
-                # Unknown flag
-                self.pkg("flag -c", exit=2)
-                self.pkg("flag -c 'foo'", exit=2)
-                self.pkg("flag pkg://foo", exit=2)
-                # Cannot specify both -m and -M
-                self.pkg("flag -m -M foo", exit=1)
-                # Must specify at least one package
-                self.pkg("flag -m", exit=2)
+        self.pkg("flag", exit=2)
+        # Unknown flag
+        self.pkg("flag -c", exit=2)
+        self.pkg("flag -c 'foo'", exit=2)
+        self.pkg("flag pkg://foo", exit=2)
+        # Cannot specify both -m and -M
+        self.pkg("flag -m -M foo", exit=1)
+        # Must specify at least one package
+        self.pkg("flag -m", exit=2)
 
-        def test_flag_m(self):
-                """Test flag -m/M"""
+    def test_flag_m(self):
+        """Test flag -m/M"""
 
-                self.api_obj = self.image_create(self.rurl)
+        self.api_obj = self.image_create(self.rurl)
 
-                self._api_install(self.api_obj, ["bar", "baz"])
-                os.environ["PKG_AUTOINSTALL"] = "1"
-                self._api_install(self.api_obj, ["foo"])
-                del os.environ["PKG_AUTOINSTALL"]
+        self._api_install(self.api_obj, ["bar", "baz"])
+        os.environ["PKG_AUTOINSTALL"] = "1"
+        self._api_install(self.api_obj, ["foo"])
+        del os.environ["PKG_AUTOINSTALL"]
 
-                expected = self.reduceSpaces(
-                    "bar    1.0-0    im-\n"
-                    "baz    1.0-0    im-\n"
-                    "foo    1.0-0    i--\n"
-                )
+        expected = self.reduceSpaces(
+            "bar    1.0-0    im-\n"
+            "baz    1.0-0    im-\n"
+            "foo    1.0-0    i--\n"
+        )
 
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("flag -M bar")
-                expected = self.reduceSpaces(
-                    "bar    1.0-0    i--\n"
-                    "baz    1.0-0    im-\n"
-                    "foo    1.0-0    i--\n"
-                )
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg("flag -M bar")
+        expected = self.reduceSpaces(
+            "bar    1.0-0    i--\n"
+            "baz    1.0-0    im-\n"
+            "foo    1.0-0    i--\n"
+        )
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("flag -M '*'")
-                expected = self.reduceSpaces(
-                    "bar    1.0-0    i--\n"
-                    "baz    1.0-0    i--\n"
-                    "foo    1.0-0    i--\n"
-                )
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg("flag -M '*'")
+        expected = self.reduceSpaces(
+            "bar    1.0-0    i--\n"
+            "baz    1.0-0    i--\n"
+            "foo    1.0-0    i--\n"
+        )
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("flag -m foo")
-                expected = self.reduceSpaces(
-                    "bar    1.0-0    i--\n"
-                    "baz    1.0-0    i--\n"
-                    "foo    1.0-0    im-\n"
-                )
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg("flag -m foo")
+        expected = self.reduceSpaces(
+            "bar    1.0-0    i--\n"
+            "baz    1.0-0    i--\n"
+            "foo    1.0-0    im-\n"
+        )
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("flag -m '*'")
-                expected = self.reduceSpaces(
-                    "bar    1.0-0    im-\n"
-                    "baz    1.0-0    im-\n"
-                    "foo    1.0-0    im-\n"
-                )
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg("flag -m '*'")
+        expected = self.reduceSpaces(
+            "bar    1.0-0    im-\n"
+            "baz    1.0-0    im-\n"
+            "foo    1.0-0    im-\n"
+        )
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("uninstall bar");
-                expected = self.reduceSpaces(
-                    "baz    1.0-0    im-\n"
-                    "foo    1.0-0    im-\n"
-                )
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg("uninstall bar")
+        expected = self.reduceSpaces(
+            "baz    1.0-0    im-\n" "foo    1.0-0    im-\n"
+        )
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Check that the 'known' catalogue is still consistent
-                expected = self.reduceSpaces(
-                    "bar    1.0-0    ---\n"
-                    "baz    1.0-0    im-\n"
-                    "foo    1.0-0    im-\n"
-                )
-                self.pkg("list -Ha")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Check that the 'known' catalogue is still consistent
+        expected = self.reduceSpaces(
+            "bar    1.0-0    ---\n"
+            "baz    1.0-0    im-\n"
+            "foo    1.0-0    im-\n"
+        )
+        self.pkg("list -Ha")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_freeze.py
+++ b/src/tests/cli/t_pkg_freeze.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -38,72 +39,79 @@ import pkg.client.api_errors as apx
 import pkg.json as json
 import pkg.fmri as fmri
 
-class TestPkgFreeze(pkg5unittest.SingleDepotTestCase):
-        persistent_setup = True
 
-        foo10 = """
+class TestPkgFreeze(pkg5unittest.SingleDepotTestCase):
+    persistent_setup = True
+
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             close """
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             close """
 
-        pkg410 = """
+    pkg410 = """
             open pkg4@1.0,5.11-0
             close """
 
-        obsolete10 = """
+    obsolete10 = """
             open obso@1.0,5.11-0
             add set name=pkg.obsolete value=true
             close """
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.sent_pkgs = self.pkgsend_bulk(self.rurl, [self.foo10,
-                    self.foo11, self.baz10, self.bar10, self.pkg410,
-                    self.obsolete10])
-                self.foo10_name = fmri.PkgFmri(self.sent_pkgs[0]).get_fmri(
-                    anarchy=True)
-                self.foo11_name = fmri.PkgFmri(self.sent_pkgs[1]).get_fmri(
-                    anarchy=True)
-                self.bar10_name = fmri.PkgFmri(self.sent_pkgs[3]).get_fmri(
-                    anarchy=True)
-                self.pkg410_name = fmri.PkgFmri(self.sent_pkgs[4]).get_fmri(
-                    anarchy=True)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.sent_pkgs = self.pkgsend_bulk(
+            self.rurl,
+            [
+                self.foo10,
+                self.foo11,
+                self.baz10,
+                self.bar10,
+                self.pkg410,
+                self.obsolete10,
+            ],
+        )
+        self.foo10_name = fmri.PkgFmri(self.sent_pkgs[0]).get_fmri(anarchy=True)
+        self.foo11_name = fmri.PkgFmri(self.sent_pkgs[1]).get_fmri(anarchy=True)
+        self.bar10_name = fmri.PkgFmri(self.sent_pkgs[3]).get_fmri(anarchy=True)
+        self.pkg410_name = fmri.PkgFmri(self.sent_pkgs[4]).get_fmri(
+            anarchy=True
+        )
 
-        def test_bad_input(self):
-                """Test bad options to pkg freeze."""
+    def test_bad_input(self):
+        """Test bad options to pkg freeze."""
 
-                self.api_obj = self.image_create(self.rurl)
+        self.api_obj = self.image_create(self.rurl)
 
-                self.pkg("freeze -c", exit=2)
-                self.pkg("freeze -c 'foo'", exit=2)
-                self.pkg("freeze pkg://foo", exit=1)
-                self.pkg("unfreeze pkg://foo", exit=1)
-                self.pkg("freeze foo@1.2,4,4,4", exit=1)
-                self.pkg("freeze foo@1#%^", exit=1)
+        self.pkg("freeze -c", exit=2)
+        self.pkg("freeze -c 'foo'", exit=2)
+        self.pkg("freeze pkg://foo", exit=1)
+        self.pkg("unfreeze pkg://foo", exit=1)
+        self.pkg("freeze foo@1.2,4,4,4", exit=1)
+        self.pkg("freeze foo@1#%^", exit=1)
 
-                self.api_obj.reset()
-                self._api_install(self.api_obj, ["bar@1.0", "baz@1.0", "pkg4"])
-                # Test that if the user gives two arguments, and one's invalid,
-                # no packages are frozen.
-                self.assertRaises(apx.FreezePkgsException,
-                    self.api_obj.freeze_pkgs, ["bar", "foo"])
-                self.api_obj.reset()
-                self.assertEqualDiff([], self.api_obj.get_frozen_list())
-                # Test that printing a FreezePkgsException works.
-                self.pkg("freeze foo@1.2 foo@1.3 pkg4@1.2 'z*' 'b*@1.1' foo",
-                    exit=1)
-                expected = """\
+        self.api_obj.reset()
+        self._api_install(self.api_obj, ["bar@1.0", "baz@1.0", "pkg4"])
+        # Test that if the user gives two arguments, and one's invalid,
+        # no packages are frozen.
+        self.assertRaises(
+            apx.FreezePkgsException, self.api_obj.freeze_pkgs, ["bar", "foo"]
+        )
+        self.api_obj.reset()
+        self.assertEqualDiff([], self.api_obj.get_frozen_list())
+        # Test that printing a FreezePkgsException works.
+        self.pkg("freeze foo@1.2 foo@1.3 pkg4@1.2 'z*' 'b*@1.1' foo", exit=1)
+        expected = """\
 
 pkg freeze: The following packages were frozen at two different versions by
 the patterns provided.  The package stem and the versions it was frozen at are
@@ -123,286 +131,293 @@ contain no version information.  Uninstalled packages can only be frozen by
 providing a version at which to freeze them.
 	foo
 """
-                self.assertEqualDiff(expected, self.errout)
+        self.assertEqualDiff(expected, self.errout)
 
-        def test_cli_operations(self):
-                """Test that the pkg freeze and unfreeze cli handle exceptions
-                and provide the correct arguments to the api."""
+    def test_cli_operations(self):
+        """Test that the pkg freeze and unfreeze cli handle exceptions
+        and provide the correct arguments to the api."""
 
-                self.api_obj = self.image_create(self.rurl)
-                self.pkg("freeze")
-                # Test that unfreezing a package that isn't frozen gives an
-                # exitcode of 4.
-                self.pkg("unfreeze foo", exit=4)
-                self.pkg("unfreeze '*'", exit=4)
+        self.api_obj = self.image_create(self.rurl)
+        self.pkg("freeze")
+        # Test that unfreezing a package that isn't frozen gives an
+        # exitcode of 4.
+        self.pkg("unfreeze foo", exit=4)
+        self.pkg("unfreeze '*'", exit=4)
 
-                # This fails because bar isn't installed and no version is
-                # provided.
-                self.pkg("freeze bar", exit=1)
+        # This fails because bar isn't installed and no version is
+        # provided.
+        self.pkg("freeze bar", exit=1)
 
-                self.pkg("freeze foo@1.0")
+        self.pkg("freeze foo@1.0")
 
-                # Test that freeze and unfreeze both display the list of frozen
-                # packages when no arguments are given.
-                self.pkg("freeze -H")
-                tmp = self.output.split()
-                self.assertEqualDiff("foo", tmp[0])
-                self.assertEqualDiff("1.0", tmp[1])
-                self.assertTrue("None" in self.output)
-                self.pkg("unfreeze -H")
-                tmp = self.output.split()
-                self.assertEqualDiff("foo", tmp[0])
-                self.assertEqualDiff("1.0", tmp[1])
-                self.assertTrue("None" in self.output)
-                self.api_obj.reset()
-                self._api_install(self.api_obj, ["foo"])
-                # Test that a frozen package can't be updated.
-                self.pkg("update", exit=4)
-                # Check that -n with unfreeze works as expected.
-                self.pkg("unfreeze -n foo")
-                self.pkg("freeze -H")
-                tmp = self.output.split()
-                self.assertEqualDiff("foo", tmp[0])
-                self.assertEqualDiff("1.0", tmp[1])
-                self.assertTrue("None" in self.output)
-                self.pkg("info foo")
-                self.assertTrue("(Frozen," in self.output)
+        # Test that freeze and unfreeze both display the list of frozen
+        # packages when no arguments are given.
+        self.pkg("freeze -H")
+        tmp = self.output.split()
+        self.assertEqualDiff("foo", tmp[0])
+        self.assertEqualDiff("1.0", tmp[1])
+        self.assertTrue("None" in self.output)
+        self.pkg("unfreeze -H")
+        tmp = self.output.split()
+        self.assertEqualDiff("foo", tmp[0])
+        self.assertEqualDiff("1.0", tmp[1])
+        self.assertTrue("None" in self.output)
+        self.api_obj.reset()
+        self._api_install(self.api_obj, ["foo"])
+        # Test that a frozen package can't be updated.
+        self.pkg("update", exit=4)
+        # Check that -n with unfreeze works as expected.
+        self.pkg("unfreeze -n foo")
+        self.pkg("freeze -H")
+        tmp = self.output.split()
+        self.assertEqualDiff("foo", tmp[0])
+        self.assertEqualDiff("1.0", tmp[1])
+        self.assertTrue("None" in self.output)
+        self.pkg("info foo")
+        self.assertTrue("(Frozen," in self.output)
 
-                # Test that unfreezing a package allows it to move.
-                self.pkg("unfreeze foo")
-                self.pkg("update")
-                # Test that freezing a package at a different version than the
-                # installed version fails.
-                self.pkg("freeze foo@1.0", exit=1)
-                self.api_obj.reset()
-                self._api_uninstall(self.api_obj, ["foo"])
+        # Test that unfreezing a package allows it to move.
+        self.pkg("unfreeze foo")
+        self.pkg("update")
+        # Test that freezing a package at a different version than the
+        # installed version fails.
+        self.pkg("freeze foo@1.0", exit=1)
+        self.api_obj.reset()
+        self._api_uninstall(self.api_obj, ["foo"])
 
-                # Test -n
-                self.pkg("freeze -n foo@1.0")
-                self.pkg("freeze")
-                self.assertEqualDiff("", self.output)
-                self.api_obj.reset()
-                self._api_install(self.api_obj, ["foo@1.0"])
+        # Test -n
+        self.pkg("freeze -n foo@1.0")
+        self.pkg("freeze")
+        self.assertEqualDiff("", self.output)
+        self.api_obj.reset()
+        self._api_install(self.api_obj, ["foo@1.0"])
 
-                # Test that the -c option works and that reasons show up in the
-                # output when the solver can't produce a solution.  This also
-                # tests that wildcarding a package name with a specified version
-                # works as expected.
-                self.pkg("freeze -c '1.2 is broken' 'f*@1.0'")
-                self.pkg("freeze -H")
-                tmp = self.output.split()
-                self.assertEqualDiff("foo", tmp[0])
-                self.assertEqualDiff("1.0", tmp[1])
-                self.assertTrue("1.2 is broken" in self.output)
+        # Test that the -c option works and that reasons show up in the
+        # output when the solver can't produce a solution.  This also
+        # tests that wildcarding a package name with a specified version
+        # works as expected.
+        self.pkg("freeze -c '1.2 is broken' 'f*@1.0'")
+        self.pkg("freeze -H")
+        tmp = self.output.split()
+        self.assertEqualDiff("foo", tmp[0])
+        self.assertEqualDiff("1.0", tmp[1])
+        self.assertTrue("1.2 is broken" in self.output)
 
-                # Test that the reason a package was frozen is included in the
-                # output of a failed install.
-                self.pkg("install foo@1.1", exit=1)
-                self.assertTrue("1.2 is broken" in self.errout)
+        # Test that the reason a package was frozen is included in the
+        # output of a failed install.
+        self.pkg("install foo@1.1", exit=1)
+        self.assertTrue("1.2 is broken" in self.errout)
 
-                self.pkg("freeze obso@1.0")
-                self.pkg("info -r obso")
-                self.assertTrue("(Obsolete, Frozen)" in self.output)
+        self.pkg("freeze obso@1.0")
+        self.pkg("info -r obso")
+        self.assertTrue("(Obsolete, Frozen)" in self.output)
 
-        def test_unprived_operation(self):
-                """Test that pkg freeze and unfreeze display the frozen packages
-                without needing privs, and that they don't stack trace when run
-                without privs."""
+    def test_unprived_operation(self):
+        """Test that pkg freeze and unfreeze display the frozen packages
+        without needing privs, and that they don't stack trace when run
+        without privs."""
 
-                self.api_obj = self.image_create(self.rurl)
-                self.pkg("freeze", su_wrap=True)
-                self.pkg("freeze foo@1.0", su_wrap=True, exit=1)
-                self.pkg("unfreeze foo", su_wrap=True, exit=1)
-                self.pkg("freeze foo@1.0")
-                self.pkg("freeze -H", su_wrap=True)
-                tmp = self.output.split()
-                self.assertEqualDiff("foo", tmp[0])
-                self.assertEqualDiff("1.0", tmp[1])
-                self.assertTrue("None" in self.output)
-                self.pkg("unfreeze -H", su_wrap=True)
-                tmp = self.output.split()
-                self.assertEqualDiff("foo", tmp[0])
-                self.assertEqualDiff("1.0", tmp[1])
-                self.assertTrue("None" in self.output)
+        self.api_obj = self.image_create(self.rurl)
+        self.pkg("freeze", su_wrap=True)
+        self.pkg("freeze foo@1.0", su_wrap=True, exit=1)
+        self.pkg("unfreeze foo", su_wrap=True, exit=1)
+        self.pkg("freeze foo@1.0")
+        self.pkg("freeze -H", su_wrap=True)
+        tmp = self.output.split()
+        self.assertEqualDiff("foo", tmp[0])
+        self.assertEqualDiff("1.0", tmp[1])
+        self.assertTrue("None" in self.output)
+        self.pkg("unfreeze -H", su_wrap=True)
+        tmp = self.output.split()
+        self.assertEqualDiff("foo", tmp[0])
+        self.assertEqualDiff("1.0", tmp[1])
+        self.assertTrue("None" in self.output)
 
-                # Test that if the freeze file can't be read, we handle the
-                # exception appropriately.
-                pth = os.path.join(self.img_path(), "var", "pkg", "state",
-                    "frozen_dict")
-                mod = stat.S_IMODE(os.stat(pth)[stat.ST_MODE])
-                new_mod = mod & ~stat.S_IROTH
-                os.chmod(pth, new_mod)
-                self.pkg("freeze", exit=1, su_wrap=True)
-                self.pkg("unfreeze", exit=1, su_wrap=True)
-                os.chmod(pth, mod)
+        # Test that if the freeze file can't be read, we handle the
+        # exception appropriately.
+        pth = os.path.join(
+            self.img_path(), "var", "pkg", "state", "frozen_dict"
+        )
+        mod = stat.S_IMODE(os.stat(pth)[stat.ST_MODE])
+        new_mod = mod & ~stat.S_IROTH
+        os.chmod(pth, new_mod)
+        self.pkg("freeze", exit=1, su_wrap=True)
+        self.pkg("unfreeze", exit=1, su_wrap=True)
+        os.chmod(pth, mod)
 
-                # Make sure that we can read the file again.
-                self.pkg("freeze", su_wrap=True)
+        # Make sure that we can read the file again.
+        self.pkg("freeze", su_wrap=True)
 
-                # Test that we don't stack trace if the version is unexpected.
-                version, d = json.load(open(pth))
-                with open(pth, "w") as fh:
-                        json.dump((-1, d), fh)
-                self.pkg("freeze", exit=1)
-                self.pkg("unfreeze", exit=1)
+        # Test that we don't stack trace if the version is unexpected.
+        version, d = json.load(open(pth))
+        with open(pth, "w") as fh:
+            json.dump((-1, d), fh)
+        self.pkg("freeze", exit=1)
+        self.pkg("unfreeze", exit=1)
 
-        def test_timestamp_freezes(self):
-                """Test operations involving freezing and relaxing freezes down
-                to the timestamp level."""
+    def test_timestamp_freezes(self):
+        """Test operations involving freezing and relaxing freezes down
+        to the timestamp level."""
 
-                self.api_obj = self.image_create(self.rurl)
-                existing_foo = self.foo10_name
-                # Sleep for one second to ensure this new package has a
-                # different timestamp than the old one.
-                time.sleep(1)
-                new_foo = self.pkgsend_bulk(self.rurl, self.foo10)[0]
-                new_foo = fmri.PkgFmri(new_foo).get_fmri(anarchy=True)
+        self.api_obj = self.image_create(self.rurl)
+        existing_foo = self.foo10_name
+        # Sleep for one second to ensure this new package has a
+        # different timestamp than the old one.
+        time.sleep(1)
+        new_foo = self.pkgsend_bulk(self.rurl, self.foo10)[0]
+        new_foo = fmri.PkgFmri(new_foo).get_fmri(anarchy=True)
 
-                self.api_obj.refresh(full_refresh=True)
-                self.api_obj.reset()
-                self.api_obj.freeze_pkgs([existing_foo])
-                self.api_obj.reset()
-                # Test that dispaying a timestamp freeze works.
-                self.pkg("freeze")
-                # This should fail because new_foo isn't the version frozen.
-                self.assertRaises(apx.PlanCreationException, self._api_install,
-                    self.api_obj, [new_foo])
-                # Check that the output of pkg list is correct in terms of the F
-                # column.
-                self.pkg("list -Ha {0}".format(new_foo))
-                expected = "foo 1.0-0 ---\n"
-                self.assertEqualDiff(expected, self.reduceSpaces(self.output))
-                self.pkg("list -Ha {0}".format(existing_foo))
-                expected = "foo 1.0-0 -f-\n"
-                self.assertEqualDiff(expected, self.reduceSpaces(self.output))
-                # This should install the original foo@1.0 package.
-                self._api_install(self.api_obj, ["foo"])
-                # Relax the freeze so it doesn't include the timestamp.
-                self.api_obj.freeze_pkgs(["foo@1.0"])
-                self.api_obj.reset()
-                self.pkg("freeze")
+        self.api_obj.refresh(full_refresh=True)
+        self.api_obj.reset()
+        self.api_obj.freeze_pkgs([existing_foo])
+        self.api_obj.reset()
+        # Test that dispaying a timestamp freeze works.
+        self.pkg("freeze")
+        # This should fail because new_foo isn't the version frozen.
+        self.assertRaises(
+            apx.PlanCreationException,
+            self._api_install,
+            self.api_obj,
+            [new_foo],
+        )
+        # Check that the output of pkg list is correct in terms of the F
+        # column.
+        self.pkg("list -Ha {0}".format(new_foo))
+        expected = "foo 1.0-0 ---\n"
+        self.assertEqualDiff(expected, self.reduceSpaces(self.output))
+        self.pkg("list -Ha {0}".format(existing_foo))
+        expected = "foo 1.0-0 -f-\n"
+        self.assertEqualDiff(expected, self.reduceSpaces(self.output))
+        # This should install the original foo@1.0 package.
+        self._api_install(self.api_obj, ["foo"])
+        # Relax the freeze so it doesn't include the timestamp.
+        self.api_obj.freeze_pkgs(["foo@1.0"])
+        self.api_obj.reset()
+        self.pkg("freeze")
 
-                # Test that pkg list reflects the relaxed freeze.
-                self.pkg("list -H {0}".format(existing_foo))
-                expected = "foo 1.0-0 if-\n"
-                self.assertEqualDiff(expected, self.reduceSpaces(self.output))
-                self.pkg("list -Haf {0}".format(new_foo))
-                expected = "foo 1.0-0 -f-\n"
-                self.assertEqualDiff(expected, self.reduceSpaces(self.output))
-                # This should work and take foo to the foo@1.0 with the newer
-                # timestamp.
-                self.pkg("update {0}".format(new_foo))
+        # Test that pkg list reflects the relaxed freeze.
+        self.pkg("list -H {0}".format(existing_foo))
+        expected = "foo 1.0-0 if-\n"
+        self.assertEqualDiff(expected, self.reduceSpaces(self.output))
+        self.pkg("list -Haf {0}".format(new_foo))
+        expected = "foo 1.0-0 -f-\n"
+        self.assertEqualDiff(expected, self.reduceSpaces(self.output))
+        # This should work and take foo to the foo@1.0 with the newer
+        # timestamp.
+        self.pkg("update {0}".format(new_foo))
 
-                # Test that freezing using just the name freezes the installed
-                # package down to the timestamp.  This also tests that freezing
-                # the same package with a different version overrides the
-                # previous setting.
-                self.api_obj.reset()
-                self.api_obj.freeze_pkgs(["foo"])
-                self.api_obj.reset()
-                self.assertEqual(new_foo,
-                    str(self.api_obj.get_frozen_list()[0][0]))
-                self.api_obj.reset()
+        # Test that freezing using just the name freezes the installed
+        # package down to the timestamp.  This also tests that freezing
+        # the same package with a different version overrides the
+        # previous setting.
+        self.api_obj.reset()
+        self.api_obj.freeze_pkgs(["foo"])
+        self.api_obj.reset()
+        self.assertEqual(new_foo, str(self.api_obj.get_frozen_list()[0][0]))
+        self.api_obj.reset()
 
-                # Test that freezing '*' freezes all installed packages and only
-                # installed packages down to timestamp.
-                self._api_install(self.api_obj, ["bar", "pkg4"])
-                self.api_obj.freeze_pkgs(["*"])
-                self.api_obj.reset()
-                frzs = self.api_obj.get_frozen_list()
-                self.assertEqualDiff(
-                    set([new_foo, self.bar10_name, self.pkg410_name]),
-                    set([str(s) for s, r, t in frzs]))
-                # Test that unfreezeing '*' unfreezes all packages.
-                self.api_obj.freeze_pkgs(["*"], unfreeze=True)
-                self.api_obj.reset()
-                self.assertEqualDiff([], self.api_obj.get_frozen_list())
+        # Test that freezing '*' freezes all installed packages and only
+        # installed packages down to timestamp.
+        self._api_install(self.api_obj, ["bar", "pkg4"])
+        self.api_obj.freeze_pkgs(["*"])
+        self.api_obj.reset()
+        frzs = self.api_obj.get_frozen_list()
+        self.assertEqualDiff(
+            set([new_foo, self.bar10_name, self.pkg410_name]),
+            set([str(s) for s, r, t in frzs]),
+        )
+        # Test that unfreezeing '*' unfreezes all packages.
+        self.api_obj.freeze_pkgs(["*"], unfreeze=True)
+        self.api_obj.reset()
+        self.assertEqualDiff([], self.api_obj.get_frozen_list())
+
 
 class TestPkgFreezeDisplay(pkg5unittest.ManyDepotTestCase):
-
-        foo1 = """
+    foo1 = """
                 open foo@1.1,5.11-0
                 close """
 
-        foo2 = """
+    foo2 = """
                 open foo@1.2,5.12-0
                 close """
 
-        def setUp(self):
-                # This test suite needs actual depots.
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test1",
-		        "test1"], start_depots=True)
+    def setUp(self):
+        # This test suite needs actual depots.
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test1", "test1", "test1"], start_depots=True
+        )
 
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.pkgsend_bulk(self.durl1, self.foo1)
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.pkgsend_bulk(self.durl1, self.foo1)
 
-                self.image_create(self.durl1)
+        self.image_create(self.durl1)
 
-        def test_remove_origin_display(self):
-                """Test whether the frozen state is displayed for the installed
-                package when the configured origin is removed."""
+    def test_remove_origin_display(self):
+        """Test whether the frozen state is displayed for the installed
+        package when the configured origin is removed."""
 
-                self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl1))
-                self.pkg("install foo")
-                self.pkg("freeze foo")
-                self.pkg("list -H foo")
-                self.assertTrue("if" in self.output)
-                self.pkg("info foo")
-                self.assertTrue("Frozen" in self.output)
+        self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl1))
+        self.pkg("install foo")
+        self.pkg("freeze foo")
+        self.pkg("list -H foo")
+        self.assertTrue("if" in self.output)
+        self.pkg("info foo")
+        self.assertTrue("Frozen" in self.output)
 
-                self.pkg("set-publisher -G '*' test1")
-                self.pkg("list -H foo")
-                self.assertTrue("if" in self.output)
+        self.pkg("set-publisher -G '*' test1")
+        self.pkg("list -H foo")
+        self.assertTrue("if" in self.output)
 
-                self.pkg("unfreeze foo")
-                self.pkg("list -H foo")
-                self.assertTrue("if" not in self.output)
+        self.pkg("unfreeze foo")
+        self.pkg("list -H foo")
+        self.assertTrue("if" not in self.output)
 
-                self.pkg("freeze foo")
-                self.pkg("set-publisher -g {0} test1".format(self.durl1))
-                self.pkg("list -H foo")
-                self.assertTrue("if" in self.output)
+        self.pkg("freeze foo")
+        self.pkg("set-publisher -g {0} test1".format(self.durl1))
+        self.pkg("list -H foo")
+        self.assertTrue("if" in self.output)
 
-        def test_change_origin_display(self):
-                """Test whether the frozen state is displayed for the installed
-                package when the configured origin is changed and the new origin
-                also contains the package."""
+    def test_change_origin_display(self):
+        """Test whether the frozen state is displayed for the installed
+        package when the configured origin is changed and the new origin
+        also contains the package."""
 
-                self.pkgsend_bulk(self.durl2, self.foo1)
+        self.pkgsend_bulk(self.durl2, self.foo1)
 
-                self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl1))
-                self.pkg("install foo")
-                self.pkg("freeze foo@1.1,5.11-0")
+        self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl1))
+        self.pkg("install foo")
+        self.pkg("freeze foo@1.1,5.11-0")
 
-                self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl2))
-                self.pkg("list -H foo")
-                self.assertTrue("if" in self.output)
+        self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl2))
+        self.pkg("list -H foo")
+        self.assertTrue("if" in self.output)
 
-        def test_package_not_in_catalog_display(self):
-                """Test whether the frozen state is displayed for the installed
-                package when the frozen package is not in the catalog of the
-                new origin."""
+    def test_package_not_in_catalog_display(self):
+        """Test whether the frozen state is displayed for the installed
+        package when the frozen package is not in the catalog of the
+        new origin."""
 
-                self.pkgsend_bulk(self.durl2, self.foo2)
+        self.pkgsend_bulk(self.durl2, self.foo2)
 
-                self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl2))
-                self.pkg("install foo")
+        self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl2))
+        self.pkg("install foo")
 
-                # Test the frozen state is displayed when the configured origin of
-                # the publisher is changed and the package is not in the catalog
-                # of the new origin.
-                self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl1))
-                self.pkg("freeze foo")
-                self.pkg("list -H foo")
-                self.assertTrue("if" in self.output)
+        # Test the frozen state is displayed when the configured origin of
+        # the publisher is changed and the package is not in the catalog
+        # of the new origin.
+        self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl1))
+        self.pkg("freeze foo")
+        self.pkg("list -H foo")
+        self.assertTrue("if" in self.output)
 
-                # Test the frozen state is removed after the origin of the publisher
-                # is changed back and the package is unfrozen.
-                self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl2))
-                self.pkg("unfreeze foo")
-                self.pkg("list -H foo")
-                self.assertTrue("if" not in self.output)
+        # Test the frozen state is removed after the origin of the publisher
+        # is changed back and the package is unfrozen.
+        self.pkg("set-publisher -G '*' -g {0} test1".format(self.durl2))
+        self.pkg("unfreeze foo")
+        self.pkg("list -H foo")
+        self.assertTrue("if" not in self.output)
+
 
 # Vim hints
 # vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_help.py
+++ b/src/tests/cli/t_pkg_help.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import codecs
@@ -34,116 +35,146 @@ import six
 import unittest
 from pkg.misc import force_text
 
+
 class TestPkgHelp(pkg5unittest.CliTestCase):
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        def test_help(self):
-                """Verify that usage message works regardless of how it is
-                triggered."""
+    def test_help(self):
+        """Verify that usage message works regardless of how it is
+        triggered."""
 
-                def verify_help(msg, expected, unexpected=[]):
-                        """Verify a usage message contains output for each of
-                        the elements of a given array 'expected', and none
-                        of the items in the array 'unexpected'."""
+        def verify_help(msg, expected, unexpected=[]):
+            """Verify a usage message contains output for each of
+            the elements of a given array 'expected', and none
+            of the items in the array 'unexpected'."""
 
-                        for str in expected:
-                                if str not in msg:
-                                        self.assertTrue(False, "{0} not in {1}".format(
-                                            str, msg))
-                        for str in unexpected:
-                                if str in msg:
-                                        self.assertTrue(False, "{0} in {1}".format(
-                                            str, msg))
+            for str in expected:
+                if str not in msg:
+                    self.assertTrue(False, "{0} not in {1}".format(str, msg))
+            for str in unexpected:
+                if str in msg:
+                    self.assertTrue(False, "{0} in {1}".format(str, msg))
 
-                # Full list of subcommands, ensuring we exit 0
-                for option in ["-\\?", "--help", "help"]:
-                        ret, out, err = self.pkg(option, out=True, stderr=True)
-                        verify_help(err,
-                            ["pkg [options] command [cmd_options] [operands]",
-                            "For more info, run: pkg help <command>"])
-
-                # Full usage text, ensuring we exit 0
-                for option in ["help -v"]:
-                        ret, out, err = self.pkg(option, out=True, stderr=True)
-                        verify_help(err,
-                            ["pkg [options] command [cmd_options] [operands]",
-                            "pkg verify [-Hqv] [-p path]... [--parsable version]\n"
-                            "            [--unpackaged] [--unpackaged-only] [pkg_fmri_pattern ...]",
-                            "PKG_IMAGE", "Usage:"])
-
-                # Invalid subcommands, ensuring we exit 2
-                for option in ["-\\? bobcat", "--help bobcat", "help bobcat",
-                    "bobcat --help"]:
-                        ret, out, err = self.pkg("-\\? bobcat", exit=2, out=True,
-                            stderr=True)
-                        verify_help(err,
-                            ["pkg: unknown subcommand",
-                            "For a full list of subcommands, run: pkg help"])
-
-                # Unrequested usage
-                ret, out, err = self.pkg("", exit=2, out=True, stderr=True)
-                verify_help(err,
-                    ["pkg: no subcommand specified",
+        # Full list of subcommands, ensuring we exit 0
+        for option in ["-\\?", "--help", "help"]:
+            ret, out, err = self.pkg(option, out=True, stderr=True)
+            verify_help(
+                err,
+                [
                     "pkg [options] command [cmd_options] [operands]",
-                    "For more info, run: pkg help <command>"],
-                    unexpected = ["PKG_IMAGE"])
+                    "For more info, run: pkg help <command>",
+                ],
+            )
 
-                # help for a subcommand should only print that subcommand usage
-                for option in ["property --help", "--help property",
-                    "help property"]:
-                        ret, out, err = self.pkg(option, out=True, stderr=True)
-                        verify_help(err, ["pkg property [-H] [propname ...]",
-                            "Usage:"], unexpected=[
-                            "pkg [options] command [cmd_options] [operands]",
-                            "PKG_IMAGE"])
+        # Full usage text, ensuring we exit 0
+        for option in ["help -v"]:
+            ret, out, err = self.pkg(option, out=True, stderr=True)
+            verify_help(
+                err,
+                [
+                    "pkg [options] command [cmd_options] [operands]",
+                    "pkg verify [-Hqv] [-p path]... [--parsable version]\n"
+                    "            [--unpackaged] [--unpackaged-only] [pkg_fmri_pattern ...]",
+                    "PKG_IMAGE",
+                    "Usage:",
+                ],
+            )
 
-        def test_help_character_encoding(self):
-                """Verify help command output for ja_JP.eucJP locale.
-                Match against the expected output"""
+        # Invalid subcommands, ensuring we exit 2
+        for option in [
+            "-\\? bobcat",
+            "--help bobcat",
+            "help bobcat",
+            "bobcat --help",
+        ]:
+            ret, out, err = self.pkg(
+                "-\\? bobcat", exit=2, out=True, stderr=True
+            )
+            verify_help(
+                err,
+                [
+                    "pkg: unknown subcommand",
+                    "For a full list of subcommands, run: pkg help",
+                ],
+            )
 
-                # This is a test case for CR 7166082.
-                # It compares the output of "pkg --help" command against
-                # the expected output for ja_JP.eucJP locale.
-                # If first 4 lines of "pkg --help" command output modified
-                # in the future then this test case will also need to be
-                # modified.
+        # Unrequested usage
+        ret, out, err = self.pkg("", exit=2, out=True, stderr=True)
+        verify_help(
+            err,
+            [
+                "pkg: no subcommand specified",
+                "pkg [options] command [cmd_options] [operands]",
+                "For more info, run: pkg help <command>",
+            ],
+            unexpected=["PKG_IMAGE"],
+        )
 
-                ret, out = self.cmdline_run("/usr/bin/locale -a", out=True,
-                    coverage=False)
-                line = " ".join(out.split())
-                m = re.search(r"ja_JP.eucJP", line)
-                if not m:
-                        raise pkg5unittest.TestSkippedException("The "
-                            "test system must have the ja_JP.eucJP locale "
-                            "installed to run this test.")
+        # help for a subcommand should only print that subcommand usage
+        for option in ["property --help", "--help property", "help property"]:
+            ret, out, err = self.pkg(option, out=True, stderr=True)
+            verify_help(
+                err,
+                ["pkg property [-H] [propname ...]", "Usage:"],
+                unexpected=[
+                    "pkg [options] command [cmd_options] [operands]",
+                    "PKG_IMAGE",
+                ],
+            )
 
-                eucJP_encode_file = os.path.join(self.ro_data_root,
-                    "pkg.help.eucJP.expected.out")
-                f = codecs.open(eucJP_encode_file, encoding="eucJP")
+    def test_help_character_encoding(self):
+        """Verify help command output for ja_JP.eucJP locale.
+        Match against the expected output"""
 
-                locale_env = { "LC_ALL": "ja_JP.eucJP" }
-                ret, out, err = self.pkg("help -v", env_arg=locale_env,
-                    out=True, stderr=True)
-                cmd_out = force_text(err, encoding="eucJP")
-                # Take only 4 lines from "pkg --help" command output.
-                u_out = cmd_out.splitlines()[:4]
+        # This is a test case for CR 7166082.
+        # It compares the output of "pkg --help" command against
+        # the expected output for ja_JP.eucJP locale.
+        # If first 4 lines of "pkg --help" command output modified
+        # in the future then this test case will also need to be
+        # modified.
 
-                n = 0
-                # The expected output file contain 4 lines and command output
-                # is also 4 lines.
-                while n < 4:
-                        cmd_line = u_out[n]
-                        # Remove \n from readline()
-                        file_line = f.readline()[:-1]
+        ret, out = self.cmdline_run(
+            "/usr/bin/locale -a", out=True, coverage=False
+        )
+        line = " ".join(out.split())
+        m = re.search(r"ja_JP.eucJP", line)
+        if not m:
+            raise pkg5unittest.TestSkippedException(
+                "The "
+                "test system must have the ja_JP.eucJP locale "
+                "installed to run this test."
+            )
 
-                        self.assertEqual(cmd_line, file_line)
-                        n = n + 1
+        eucJP_encode_file = os.path.join(
+            self.ro_data_root, "pkg.help.eucJP.expected.out"
+        )
+        f = codecs.open(eucJP_encode_file, encoding="eucJP")
 
-                f.close()
+        locale_env = {"LC_ALL": "ja_JP.eucJP"}
+        ret, out, err = self.pkg(
+            "help -v", env_arg=locale_env, out=True, stderr=True
+        )
+        cmd_out = force_text(err, encoding="eucJP")
+        # Take only 4 lines from "pkg --help" command output.
+        u_out = cmd_out.splitlines()[:4]
+
+        n = 0
+        # The expected output file contain 4 lines and command output
+        # is also 4 lines.
+        while n < 4:
+            cmd_line = u_out[n]
+            # Remove \n from readline()
+            file_line = f.readline()[:-1]
+
+            self.assertEqual(cmd_line, file_line)
+            n = n + 1
+
+        f.close()
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_history.py
+++ b/src/tests/cli/t_pkg_history.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import datetime
@@ -41,557 +42,614 @@ import unittest
 import xml.etree.ElementTree
 from pkg.misc import force_str
 
-class TestPkgHistory(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
 
-        foo1 = """
+class TestPkgHistory(pkg5unittest.ManyDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+
+    foo1 = """
             open foo@1,5.11-0
             close """
 
-        foo2 = """
+    foo2 = """
             open foo@2,5.11-0
             close """
 
-        bar1 = """
+    bar1 = """
             open bar@1,5.11-0
             add depend type=incorporate fmri=pkg:/foo@1
             close """
 
-        baz = """
+    baz = """
             open baz@1,5.11-0
             add file tmp/baz mode=0555 owner=root group=bin path=/foo/baz
             close"""
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
-                misc_files = [ "tmp/baz" ]
-                self.make_misc_files(misc_files)
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
+        misc_files = ["tmp/baz"]
+        self.make_misc_files(misc_files)
 
-                rurl1 = self.dcs[1].get_repo_url()
-                self.pkgsend_bulk(rurl1, (self.foo1, self.foo2, self.baz))
+        rurl1 = self.dcs[1].get_repo_url()
+        self.pkgsend_bulk(rurl1, (self.foo1, self.foo2, self.baz))
 
-                # Ensure that the second repo's packages are exactly the same
-                # as those in the first ... by duplicating the repo.
-                d1dir = self.dcs[1].get_repodir()
-                d2dir = self.dcs[2].get_repodir()
-                self.copy_repository(d1dir, d2dir, { "test1": "test2" })
-                self.dcs[2].get_repo(auto_create=True).rebuild()
+        # Ensure that the second repo's packages are exactly the same
+        # as those in the first ... by duplicating the repo.
+        d1dir = self.dcs[1].get_repodir()
+        d2dir = self.dcs[2].get_repodir()
+        self.copy_repository(d1dir, d2dir, {"test1": "test2"})
+        self.dcs[2].get_repo(auto_create=True).rebuild()
 
-                self.image_create(rurl1, prefix="test1")
-                # add a few more entries to the history - we don't care
-                # that these fail
-                for item in ["cheese", "tomatoes", "bread", "pasta"]:
-                            self.pkg("install {0}".format(item), exit=1)
-                            time.sleep(1)
-                self.pkg("install baz")
-                self.pkg("refresh")
+        self.image_create(rurl1, prefix="test1")
+        # add a few more entries to the history - we don't care
+        # that these fail
+        for item in ["cheese", "tomatoes", "bread", "pasta"]:
+            self.pkg("install {0}".format(item), exit=1)
+            time.sleep(1)
+        self.pkg("install baz")
+        self.pkg("refresh")
 
-        def test_1_history_options(self):
-                """Verify all history options are accepted or rejected as
-                expected.
-                """
-                self.pkg("history")
-                self.pkg("history -l")
-                self.pkg("history -H")
-                self.pkg("history -n 5")
-                self.pkg("history -n foo", exit=2)
-                self.pkg("history -n -5", exit=2)
-                self.pkg("history -n 0", exit=2)
-                self.pkg("history -lH", exit=2)
-                self.pkg("history -t 2010-10-20T14:18:17 -n 1", exit=2)
-                self.pkg("history -t 2010-10-20T14:18:17,rubbish", exit=1)
-                self.pkg("history -t 'this is not a  time-stamp'", exit=1)
-                self.pkg("history -t northis", exit=1)
-                self.pkg("history -o time,command -l", exit=2)
-                self.pkg("history -o time,time", exit=2)
-                self.pkg("history -o unknow_column", exit=2)
-                self.pkg("history -o time,command,finish", exit=2)
-                self.pkg("history -o time,reason,finish", exit=2)
+    def test_1_history_options(self):
+        """Verify all history options are accepted or rejected as
+        expected.
+        """
+        self.pkg("history")
+        self.pkg("history -l")
+        self.pkg("history -H")
+        self.pkg("history -n 5")
+        self.pkg("history -n foo", exit=2)
+        self.pkg("history -n -5", exit=2)
+        self.pkg("history -n 0", exit=2)
+        self.pkg("history -lH", exit=2)
+        self.pkg("history -t 2010-10-20T14:18:17 -n 1", exit=2)
+        self.pkg("history -t 2010-10-20T14:18:17,rubbish", exit=1)
+        self.pkg("history -t 'this is not a  time-stamp'", exit=1)
+        self.pkg("history -t northis", exit=1)
+        self.pkg("history -o time,command -l", exit=2)
+        self.pkg("history -o time,time", exit=2)
+        self.pkg("history -o unknow_column", exit=2)
+        self.pkg("history -o time,command,finish", exit=2)
+        self.pkg("history -o time,reason,finish", exit=2)
 
-        def test_2_history_record(self):
-                """Verify that all image operations that change an image are
-                recorded as expected.
-                """
+    def test_2_history_record(self):
+        """Verify that all image operations that change an image are
+        recorded as expected.
+        """
 
-                rurl2 = self.dcs[2].get_repo_url()
-                commands = [
-                    ("install foo@1", 0),
-                    ("update", 0),
-                    ("uninstall foo", 0),
-                    ("set-publisher -O " + rurl2 + " test2", 0),
-                    ("set-publisher -P test1", 0),
-                    ("set-publisher -m " + rurl2 + " test1", 0),
-                    ("set-publisher -M " + rurl2 + " test1", 0),
-                    ("unset-publisher test2", 0),
-                    ("rebuild-index", 0),
-                    ("fix", 0)
-                ]
+        rurl2 = self.dcs[2].get_repo_url()
+        commands = [
+            ("install foo@1", 0),
+            ("update", 0),
+            ("uninstall foo", 0),
+            ("set-publisher -O " + rurl2 + " test2", 0),
+            ("set-publisher -P test1", 0),
+            ("set-publisher -m " + rurl2 + " test1", 0),
+            ("set-publisher -M " + rurl2 + " test1", 0),
+            ("unset-publisher test2", 0),
+            ("rebuild-index", 0),
+            ("fix", 0),
+        ]
 
-                operations = [
-                    "install",
-                    "update",
-                    "uninstall",
-                    "add-publisher",
-                    "update-publisher",
-                    "remove-publisher",
-                    "rebuild-index",
-                    "fix"
-                ]
+        operations = [
+            "install",
+            "update",
+            "uninstall",
+            "add-publisher",
+            "update-publisher",
+            "remove-publisher",
+            "rebuild-index",
+            "fix",
+        ]
 
-                # remove a file in the image which will cause pkg fix to do
-                # work, writing a history entry in the process
-                img_file = os.path.join(self.get_img_path(), "foo/baz")
-                os.remove(img_file)
+        # remove a file in the image which will cause pkg fix to do
+        # work, writing a history entry in the process
+        img_file = os.path.join(self.get_img_path(), "foo/baz")
+        os.remove(img_file)
 
-                for cmd, exit in commands:
-                        self.pkg(cmd, exit=exit)
+        for cmd, exit in commands:
+            self.pkg(cmd, exit=exit)
 
-                self.pkg("history -H")
-                o = self.output
+        self.pkg("history -H")
+        o = self.output
+        self.assertTrue(re.search(r"START\s+", o.splitlines()[0]) == None)
+
+        # Only the operation is listed in short format.
+        for op in operations:
+            # Verify that each operation was recorded.
+            if o.find(op) == -1:
+                raise RuntimeError(
+                    "Operation: {0} wasn't " "recorded, o:{1}".format(op, o)
+                )
+
+        self.pkg("history -o start,command")
+        o = self.output
+        for cmd, exit in commands:
+            # Verify that each of the commands was recorded.
+            if o.find(" {0}".format(cmd)) == -1:
+                raise RuntimeError(
+                    "Command: {0} wasn't recorded," " o:{1}".format(cmd, o)
+                )
+
+        # Verify that a successful operation with no effect won't
+        # be recorded.
+        self.pkg("purge-history")
+        self.pkg("refresh")
+        self.pkg("history -l")
+        self.assertTrue(" refresh" not in self.output)
+
+        self.pkg("refresh --full")
+        self.pkg("history -l")
+        self.assertTrue(" refresh" in self.output)
+
+    def test_3_purge_history(self):
+        """Verify that the purge-history command works as expected."""
+        self.pkg("purge-history")
+        self.pkg("history -H")
+        o = self.output
+        # Ensure that the first item in history output is now
+        # purge-history.
+        self.assertTrue(re.search("purge-history", o.splitlines()[0]) != None)
+
+    def test_4_bug_4639(self):
+        """Test that install and uninstall of non-existent packages
+        both make the same history entry.
+        """
+
+        self.pkg("purge-history")
+        self.pkg("uninstall doesnt_exist", exit=1)
+        self.pkg("install doesnt_exist", exit=1)
+        self.pkg("history -H -o start,operation,client,outcome,reason")
+        o = self.output
+        for l in o.splitlines():
+            tmp = l.split()
+            res = tmp[3]
+            reason = " ".join(tmp[4:])
+            if tmp[1] == "install" or tmp[1] == "uninstall":
+                self.assertTrue(reason == "Bad Request")
+            else:
                 self.assertTrue(
-                    re.search(r"START\s+", o.splitlines()[0]) == None)
+                    tmp[1] in ("purge-history", "refresh-publishers")
+                )
 
-                # Only the operation is listed in short format.
-                for op in operations:
-                        # Verify that each operation was recorded.
-                        if o.find(op) == -1:
-                                raise RuntimeError("Operation: {0} wasn't "
-                                    "recorded, o:{1}".format(op, o))
+    def test_5_bug_5024(self):
+        """Test that install and uninstall of non-existent packages
+        both make the same history entry.
+        """
 
-                self.pkg("history -o start,command")
-                o = self.output
-                for cmd, exit in commands:
-                        # Verify that each of the commands was recorded.
-                        if o.find(" {0}".format(cmd)) == -1:
-                                raise RuntimeError("Command: {0} wasn't recorded,"
-                                    " o:{1}".format(cmd, o))
-
-                # Verify that a successful operation with no effect won't
-                # be recorded.
-                self.pkg("purge-history")
-                self.pkg("refresh")
-                self.pkg("history -l")
-                self.assertTrue(" refresh" not in self.output)
-
-                self.pkg("refresh --full")
-                self.pkg("history -l")
-                self.assertTrue(" refresh" in self.output)
-
-        def test_3_purge_history(self):
-                """Verify that the purge-history command works as expected.
-                """
-                self.pkg("purge-history")
-                self.pkg("history -H")
-                o = self.output
-                # Ensure that the first item in history output is now
-                # purge-history.
+        rurl1 = self.dcs[1].get_repo_url()
+        self.pkgsend_bulk(rurl1, self.bar1)
+        self.pkg("refresh")
+        self.pkg("install bar")
+        self.pkg("install foo")
+        self.pkgsend_bulk(rurl1, self.foo2)
+        self.pkg("refresh")
+        self.pkg("purge-history")
+        self.pkg("install foo@2", exit=1)
+        self.pkg("history -H -o start,operation,client,outcome,reason")
+        o = self.output
+        for l in o.splitlines():
+            tmp = l.split()
+            ts = tmp[0]
+            res = tmp[3]
+            reason = " ".join(tmp[4:])
+            if tmp[1] == "install":
+                self.assertTrue(res == "Failed")
+                self.assertTrue(reason == "Constrained")
+            else:
                 self.assertTrue(
-                    re.search("purge-history", o.splitlines()[0]) != None)
+                    tmp[1] in ("purge-history", "refresh-publishers")
+                )
 
-        def test_4_bug_4639(self):
-                """Test that install and uninstall of non-existent packages
-                both make the same history entry.
-                """
+    def test_6_bug_3540(self):
+        """Verify that corrupt history entries won't cause the client to
+        exit abnormally.
+        """
+        # Overwrite first entry with bad data.
+        hist_path = self.get_img_api_obj().img.history.path
+        entry = sorted(os.listdir(hist_path))[0]
+        f = open(os.path.join(hist_path, entry), "w")
+        f.write("<Invalid>")
+        f.close()
+        self.pkg("history")
 
-                self.pkg("purge-history")
-                self.pkg("uninstall doesnt_exist", exit=1)
-                self.pkg("install doesnt_exist", exit=1)
-                self.pkg("history -H -o start,operation,client,outcome,reason")
-                o = self.output
-                for l in o.splitlines():
-                        tmp = l.split()
-                        res = tmp[3]
-                        reason = " ".join(tmp[4:])
-                        if tmp[1] == "install" or tmp[1] == "uninstall":
-                                self.assertTrue(reason == "Bad Request")
-                        else:
-                                self.assertTrue(tmp[1] in ("purge-history",
-                                    "refresh-publishers"))
+    def test_7_bug_5153(self):
+        """Verify that an absent History directory will not cause the
+        the client to exit with an error or traceback.
+        """
+        hist_path = self.get_img_api_obj().img.history.path
+        shutil.rmtree(hist_path)
+        self.pkg("history")
 
-        def test_5_bug_5024(self):
-                """Test that install and uninstall of non-existent packages
-                both make the same history entry.
-                """
+    def test_8_failed_record(self):
+        """Verify that all failed image operations that change an image
+        are recorded as expected.
+        """
 
-                rurl1 = self.dcs[1].get_repo_url()
-                self.pkgsend_bulk(rurl1, self.bar1)
-                self.pkg("refresh")
-                self.pkg("install bar")
-                self.pkg("install foo")
-                self.pkgsend_bulk(rurl1, self.foo2)
-                self.pkg("refresh")
-                self.pkg("purge-history")
-                self.pkg("install foo@2", exit=1)
-                self.pkg("history -H -o start,operation,client,outcome,reason")
-                o = self.output
-                for l in o.splitlines():
-                        tmp = l.split()
-                        ts = tmp[0]
-                        res = tmp[3]
-                        reason = " ".join(tmp[4:])
-                        if tmp[1] == "install":
-                                self.assertTrue(res == "Failed")
-                                self.assertTrue(reason == "Constrained")
-                        else:
-                                self.assertTrue(tmp[1] in ("purge-history",
-                                    "refresh-publishers"))
+        commands = [
+            "install nosuchpackage",
+            "uninstall nosuchpackage",
+            "set-publisher -O http://test.invalid2 test2",
+            "set-publisher -O http://test.invalid1 test1",
+            "unset-publisher test3",
+        ]
 
-        def test_6_bug_3540(self):
-                """Verify that corrupt history entries won't cause the client to
-                exit abnormally.
-                """
-                # Overwrite first entry with bad data.
-                hist_path = self.get_img_api_obj().img.history.path
-                entry = sorted(os.listdir(hist_path))[0]
-                f = open(os.path.join(hist_path, entry), "w")
-                f.write("<Invalid>")
-                f.close()
-                self.pkg("history")
+        operations = [
+            "install",
+            "uninstall",
+            "add-publisher",
+            "update-publisher",
+            "remove-publisher",
+        ]
 
-        def test_7_bug_5153(self):
-                """Verify that an absent History directory will not cause the
-                the client to exit with an error or traceback.
-                """
-                hist_path = self.get_img_api_obj().img.history.path
-                shutil.rmtree(hist_path)
-                self.pkg("history")
+        self.pkg("purge-history")
+        for cmd in commands:
+            self.pkg(cmd, exit=1)
 
-        def test_8_failed_record(self):
-                """Verify that all failed image operations that change an image
-                are recorded as expected.
-                """
+        self.pkg("history -H")
+        o = self.output
+        self.assertTrue(re.search(r"START\s+", o.splitlines()[0]) == None)
 
-                commands = [
-                    "install nosuchpackage",
-                    "uninstall nosuchpackage",
-                    "set-publisher -O http://test.invalid2 test2",
-                    "set-publisher -O http://test.invalid1 test1",
-                    "unset-publisher test3",
-                ]
+        # Only the operation is listed in short format.
+        for op in operations:
+            # Verify that each operation was recorded as failing.
+            found_op = False
+            for line in o.splitlines():
+                if line.find(op) == -1:
+                    continue
 
-                operations = [
-                    "install",
-                    "uninstall",
-                    "add-publisher",
-                    "update-publisher",
-                    "remove-publisher",
-                ]
+                found_op = True
+                if line.find("Failed") == -1:
+                    raise RuntimeError(
+                        "Operation: {0} "
+                        "wasn't recorded as failing, "
+                        "o:{0}".format(op, l)
+                    )
+                break
 
-                self.pkg("purge-history")
-                for cmd in commands:
-                        self.pkg(cmd, exit=1)
+            if not found_op:
+                raise RuntimeError(
+                    "Operation: {0} " "wasn't recorded, o:{1}".format(op, o)
+                )
 
-                self.pkg("history -H")
-                o = self.output
+        # The actual commands are only found in long format.
+        self.pkg("history -l")
+        o = self.output
+        for cmd in commands:
+            # Verify that each of the commands was recorded.
+            if o.find(" {0}".format(cmd)) == -1:
+                raise RuntimeError(
+                    "Command: {0} wasn't recorded," " o:{1}".format(cmd, o)
+                )
+
+    def test_9_history_limit(self):
+        """Verify limiting the number of records to output"""
+
+        #
+        # Make sure we have a nice number of entries with which to
+        # experiment.
+        #
+        for i in range(5):
+            self.pkg("install pkg{0:d}".format(i), exit=1)
+        self.pkg("history -Hn 3")
+        self.assertEqual(len(self.output.splitlines()), 3)
+
+        self.pkg("history -ln 3")
+        lines = self.output.splitlines()
+        nentries = len([l for l in lines if l.find("Operation:") >= 0])
+        self.assertEqual(nentries, 3)
+
+        hist_path = self.get_img_api_obj().img.history.path
+        count = len(os.listdir(hist_path))
+
+        # Asking for too many objects should return the full set
+        self.pkg("history -Hn {0:d}".format(count + 5))
+        self.assertEqual(len(self.output.splitlines()), count)
+
+    def test_10_history_columns(self):
+        """Verify the -o option"""
+
+        self.pkg("history -H -n 1")
+        # START OPERATION CLIENT OUTCOME
+        arr = self.output.split()
+        known = {}
+        known["start"] = arr[0]
+        known["operation"] = arr[1]
+        known["client"] = arr[2]
+        known["outcome"] = arr[3]
+
+        # Ensure we can obtain output for each column
+        cols = [
+            "be",
+            "be_uuid",
+            "client",
+            "client_ver",
+            "command",
+            "finish",
+            "id",
+            "new_be",
+            "new_be_uuid",
+            "operation",
+            "outcome",
+            "reason",
+            "snapshot",
+            "start",
+            "time",
+            "user",
+        ]
+        for col in cols:
+            self.pkg("history -H -n1 -o {0}".format(col))
+            self.assertTrue(self.output)
+            # if we've seen this column before, we can verify
+            # the -o output matches that field in the normal
+            # output.
+            if col in known:
                 self.assertTrue(
-                    re.search(r"START\s+", o.splitlines()[0]) == None)
+                    self.output.strip() == known[col],
+                    "{0} column output {1} does not match {2}".format(
+                        col, self.output, known[col]
+                    ),
+                )
 
-                # Only the operation is listed in short format.
-                for op in operations:
-                        # Verify that each operation was recorded as failing.
-                        found_op = False
-                        for line in o.splitlines():
-                                if line.find(op) == -1:
-                                        continue
+    def test_11_history_events(self):
+        """Verify the -t option, for discreet timestamps"""
 
-                                found_op = True
-                                if line.find("Failed") == -1:
-                                        raise RuntimeError("Operation: {0} "
-                                            "wasn't recorded as failing, "
-                                            "o:{0}".format(op, l))
-                                break
+        self.pkg("history -H")
+        output = self.output.splitlines()
 
-                        if not found_op:
-                                raise RuntimeError("Operation: {0} "
-                                    "wasn't recorded, o:{1}".format(op, o))
+        # create a dictionary of events, keyed by timestamp since we can
+        # get several events per timestamp.
+        events = {}
+        for line in output:
+            fields = line.split()
+            timestamp = fields[0].strip()
+            operation = fields[1].strip()
+            if timestamp in events:
+                events[timestamp].append(operation)
+            else:
+                events[timestamp] = [operation]
 
-                # The actual commands are only found in long format.
-                self.pkg("history -l")
-                o = self.output
-                for cmd in commands:
-                        # Verify that each of the commands was recorded.
-                        if o.find(" {0}".format(cmd)) == -1:
-                                raise RuntimeError("Command: {0} wasn't recorded,"
-                                    " o:{1}".format(cmd, o))
+        # verify we can retrieve each event
+        for timestamp in events:
+            operations = set(events[timestamp])
+            self.pkg("history -H -t {0} -o operation".format(timestamp))
+            arr = self.output.splitlines()
+            found = set()
+            for item in arr:
+                found.add(item.strip())
+            self.assertTrue(
+                found == operations,
+                "{0} does not equal {1} for {2}".format(
+                    found, operations, timestamp
+                ),
+            )
 
-        def test_9_history_limit(self):
-                """Verify limiting the number of records to output
-                """
+        # record timestamp and expected result for 3 random,
+        # unique timestamps.  Since each timestamp can result in
+        # multiple  events, we need to calculate how many events to
+        # expect
+        keys = events.keys()
 
-                #
-                # Make sure we have a nice number of entries with which to
-                # experiment.
-                #
-                for i in range(5):
-                        self.pkg("install pkg{0:d}".format(i), exit=1)
-                self.pkg("history -Hn 3")
-                self.assertEqual(len(self.output.splitlines()), 3)
+        comma_events = ""
+        expected_count = 0
 
-                self.pkg("history -ln 3")
-                lines = self.output.splitlines()
-                nentries = len([l for l in lines if l.find("Operation:") >= 0])
-                self.assertEqual(nentries, 3)
+        for ts in random.sample(list(keys), 3):
+            if not comma_events:
+                comma_events = ts
+            else:
+                comma_events = "{0},{1}".format(comma_events, ts)
+            expected_count = expected_count + len(events[ts])
 
-                hist_path = self.get_img_api_obj().img.history.path
-                count = len(os.listdir(hist_path))
+        self.pkg("history -H -t {0} -o start,operation".format(comma_events))
+        output = self.output.splitlines()
+        self.assertTrue(
+            len(output) == expected_count,
+            "Expected {0} events, got {1}".format(expected_count, len(output)),
+        )
 
-                # Asking for too many objects should return the full set
-                self.pkg("history -Hn {0:d}".format(count + 5))
-                self.assertEqual(len(self.output.splitlines()), count)
+        for line in output:
+            fields = line.split()
+            timestamp = fields[0].strip()
+            operation = fields[1].strip()
+            self.assertTrue(
+                timestamp in events,
+                "Missing {0} from {1}".format(timestamp, events),
+            )
+            expected = events[timestamp]
+            self.assertTrue(
+                operation in expected,
+                "Recorded operation {0} at {1} not in dictionary {2}".format(
+                    operation, timestamp, events
+                ),
+            )
 
-        def test_10_history_columns(self):
-                """Verify the -o option """
+        # verify that duplicate timestamps specified on command line
+        # only output history for one instance of each timestamp
+        multi_events = "{0},{1}".format(comma_events, comma_events)
+        self.pkg("history -H -t {0} -o start,operation".format(multi_events))
+        output = self.output.splitlines()
+        self.assertTrue(
+            len(output) == expected_count,
+            "Expected {0} events, got {1}".format(expected_count, len(output)),
+        )
 
-                self.pkg("history -H -n 1")
-                # START OPERATION CLIENT OUTCOME
-                arr = self.output.split()
-                known = {}
-                known["start"] = arr[0]
-                known["operation"] = arr[1]
-                known["client"] = arr[2]
-                known["outcome"] = arr[3]
+    def test_12_history_range(self):
+        """Verify the -t option for ranges of timestamps"""
 
-                # Ensure we can obtain output for each column
-                cols = ["be", "be_uuid", "client", "client_ver", "command",
-                    "finish", "id", "new_be", "new_be_uuid", "operation",
-                    "outcome", "reason", "snapshot", "start", "time", "user"]
-                for col in cols:
-                        self.pkg("history -H -n1 -o {0}".format(col))
-                        self.assertTrue(self.output)
-                        # if we've seen this column before, we can verify
-                        # the -o output matches that field in the normal
-                        # output.
-                        if col in known:
-                                self.assertTrue(self.output.strip() == known[col],
-                                    "{0} column output {1} does not match {2}".format(
-                                    col, self.output, known[col]))
+        self.pkg("history -H")
+        entire_output = self.output
 
-        def test_11_history_events(self):
-                """ Verify the -t option, for discreet timestamps """
+        # verify that printing a very wide history range is equal to
+        # printing all history entries. XXX we need to fix this in 2038
+        self.pkg("history -H " "-t 1970-01-01T00:00:00-2037-01-01T03:44:07")
+        self.assertTrue(
+            entire_output == self.output,
+            "large history range, {0} not equal to {1}".format(
+                entire_output, self.output
+            ),
+        )
 
-                self.pkg("history -H")
-                output = self.output.splitlines()
+        # checks to verify history ranges are tricky since one history
+        # timestamp can correspond to more than one history entry.
+        # To help with this, we build a dictionary keyed by timestamp
+        # of history output
+        entries = {}
+        for line in entire_output.splitlines():
+            timestamp = line.strip().split()[0]
+            if timestamp in entries:
+                entries[timestamp].append(line)
+            else:
+                entries[timestamp] = [line]
 
-                # create a dictionary of events, keyed by timestamp since we can
-                # get several events per timestamp.
-                events = {}
-                for line in output:
-                        fields = line.split()
-                        timestamp = fields[0].strip()
-                        operation = fields[1].strip()
-                        if timestamp in events:
-                                events[timestamp].append(operation)
-                        else:
-                                events[timestamp] = [operation]
+        single_ts = list(entries.keys())[random.randint(0, len(entries) - 1)]
 
-                # verify we can retrieve each event
-                for timestamp in events:
-                        operations = set(events[timestamp])
-                        self.pkg("history -H -t {0} -o operation".format(timestamp))
-                        arr = self.output.splitlines()
-                        found = set()
-                        for item in arr:
-                                found.add(item.strip())
-                        self.assertTrue(found == operations,
-                                    "{0} does not equal {1} for {2}".format(
-                                    found, operations, timestamp))
+        # verify a range specifying the same timestamp twice
+        # is the same as printing just that timestamp
+        self.pkg("history -H -t {0}".format(single_ts))
+        single_entry_output = self.output
+        self.pkg("history -H -t {0}-{1}".format(single_ts, single_ts))
+        self.assertTrue(
+            single_entry_output == self.output,
+            "{0} does not equal {1}".format(single_entry_output, self.output),
+        )
 
-                # record timestamp and expected result for 3 random,
-                # unique timestamps.  Since each timestamp can result in
-                # multiple  events, we need to calculate how many events to
-                # expect
-                keys = events.keys()
+        # verify a random range taken from the history is correct
+        timestamps = list(entries.keys())
+        timestamps.sort()
 
-                comma_events = ""
-                expected_count = 0
+        # get two random indices from our list of timestamps
+        start_ts = None
+        end_ts = None
+        attempts = 0
+        last_index = len(timestamps) - 1
 
-                for ts in random.sample(list(keys), 3):
-                        if not comma_events:
-                                comma_events = ts
-                        else:
-                                comma_events = "{0},{1}".format(comma_events, ts)
-                        expected_count = expected_count + len(events[ts])
+        while start_ts == end_ts and attempts < 10:
+            start_ts = timestamps[random.randint(0, last_index)]
+            end_ts = timestamps[
+                random.randint(timestamps.index(start_ts), last_index)
+            ]
+            attempts = attempts + 1
 
-                self.pkg("history -H -t {0} -o start,operation".format(comma_events))
-                output = self.output.splitlines()
-                self.assertTrue(len(output) == expected_count,
-                    "Expected {0} events, got {1}".format(expected_count,
-                    len(output)))
+        self.assertTrue(
+            start_ts != end_ts,
+            "Unable to test pkg history range, {0} == {1}".format(
+                start_ts, end_ts
+            ),
+        )
 
-                for line in output:
-                        fields = line.split()
-                        timestamp = fields[0].strip()
-                        operation = fields[1].strip()
-                        self.assertTrue(timestamp in events,
-                            "Missing {0} from {1}".format(timestamp, events))
-                        expected = events[timestamp]
-                        self.assertTrue(operation in expected,
-                            "Recorded operation {0} at {1} not in dictionary {2}".format(
-                            operation, timestamp, events))
+        self.pkg("history -H -t {0}-{1}".format(start_ts, end_ts))
+        range_lines = self.output.splitlines()
+        range_timestamps = []
 
-                # verify that duplicate timestamps specified on command line
-                # only output history for one instance of each timestamp
-                multi_events = "{0},{1}".format(comma_events, comma_events)
-                self.pkg("history -H -t {0} -o start,operation".format(multi_events))
-                output = self.output.splitlines()
-                self.assertTrue(len(output) == expected_count,
-                    "Expected {0} events, got {1}".format(expected_count,
-                    len(output)))
+        self.assertTrue(
+            len(range_lines) >= 1,
+            "No output from pkg history" " -t {0}-{1}".format(start_ts, end_ts),
+        )
 
-        def test_12_history_range(self):
-                """ Verify the -t option for ranges of timestamps """
+        # for each history line in the range output, ensure that it
+        # matches timestamps that we stored from the main history output
+        for line in range_lines:
+            ts = line.strip().split()[0]
+            self.assertTrue(
+                line in entries[ts],
+                "{0} does not appear in {1}".format(line, entries[ts]),
+            )
+            range_timestamps.append(ts)
 
-                self.pkg("history -H")
-                entire_output = self.output
+        # determine the reverse. That is, for each entry in the
+        # list of ranges we expect taken from the entire history output,
+        # verify that entry was printed as part of
+        # pkg history -t <range>
+        start_index = timestamps.index(start_ts)
+        end_index = timestamps.index(end_ts)
+        # ranges are inclusive
+        if end_index != len(timestamps):
+            end_index = end_index + 1
+        for ts in timestamps[start_index:end_index]:
+            for line in entries[ts]:
+                self.assertTrue(
+                    line in range_lines,
+                    "expected range history entry not found "
+                    "in output:\n"
+                    "Line: {0}\n"
+                    "Range output {1}\n"
+                    "Entire output {2}".format(
+                        line, "\n".join(range_lines), entire_output
+                    ),
+                )
 
-                # verify that printing a very wide history range is equal to
-                # printing all history entries. XXX we need to fix this in 2038
-                self.pkg("history -H "
-                    "-t 1970-01-01T00:00:00-2037-01-01T03:44:07")
-                self.assertTrue(entire_output == self.output,
-                    "large history range, {0} not equal to {1}".format(
-                    entire_output, self.output))
+        # now verify that each timestamp we collected does indeed fall
+        # within that range
+        for ts in range_timestamps:
+            self.assertTrue(
+                ts >= start_ts, "{0} is not >= {1}".format(ts, start_ts)
+            )
+            self.assertTrue(
+                ts <= end_ts, "{0} is not <= {1}".format(ts, end_ts)
+            )
 
-                # checks to verify history ranges are tricky since one history
-                # timestamp can correspond to more than one history entry.
-                # To help with this, we build a dictionary keyed by timestamp
-                # of history output
-                entries = {}
-                for line in entire_output.splitlines():
-                        timestamp = line.strip().split()[0]
-                        if timestamp in entries:
-                                entries[timestamp].append(line)
-                        else:
-                                entries[timestamp] = [line]
+    def test_13_bug_17418(self):
+        """Verify we can get history for an operation that ran for a
+        long time"""
 
-                single_ts = list(entries.keys())[
-                    random.randint(0, len(entries) - 1)]
+        image_path = self.get_img_path()
+        history_dir = os.path.sep.join([image_path, "var", "pkg", "history"])
+        dirlist = os.listdir(history_dir)
+        dirlist.sort()
 
-                # verify a range specifying the same timestamp twice
-                # is the same as printing just that timestamp
-                self.pkg("history -H -t {0}".format(single_ts))
-                single_entry_output = self.output
-                self.pkg("history -H -t {0}-{1}".format(single_ts, single_ts))
-                self.assertTrue(single_entry_output == self.output,
-                    "{0} does not equal {1}".format(single_entry_output, self.output))
+        # get the latest history file, and write another copy of it
+        # with an artificial start and end timestamp.
+        latest = os.path.join(history_dir, dirlist[-1])
 
-                # verify a random range taken from the history is correct
-                timestamps = list(entries.keys())
-                timestamps.sort()
+        tree = xml.etree.ElementTree.parse(latest)
+        root = tree.getroot()
+        operation = root.find("operation")
+        operation.attrib["start_time"] = datetime.datetime.utcfromtimestamp(
+            0
+        ).strftime("%Y%m%dT%H%M%SZ")
+        operation.attrib["end_time"] = "20120229T000000Z"
 
-                # get two random indices from our list of timestamps
-                start_ts = None
-                end_ts = None
-                attempts = 0
-                last_index = len(timestamps) - 1
+        new_file = re.sub(".xml", "99.xml", latest)
+        # xml.etree.ElementTree.tostring will generate a bytestring
+        # by default
+        outfile = open(os.path.join(history_dir, new_file), "wb")
+        outfile.write(xml.etree.ElementTree.tostring(root))
+        outfile.close()
 
-                while start_ts == end_ts and attempts < 10:
-                        start_ts = timestamps[random.randint(0, last_index)]
-                        end_ts = timestamps[
-                            random.randint(timestamps.index(start_ts),
-                            last_index)]
-                        attempts = attempts + 1
+        self.pkg("history -n 1 -o time")
+        self.assertTrue("369576:00:00" in self.output)
 
-                self.assertTrue(start_ts != end_ts,
-                    "Unable to test pkg history range, {0} == {1}".format(
-                    start_ts, end_ts))
+    def test_14_history_unicode_locale(self):
+        """Verify we can get history when unicode locale is set"""
 
-                self.pkg("history -H -t {0}-{1}".format(start_ts, end_ts))
-                range_lines = self.output.splitlines()
-                range_timestamps = []
+        # If pkg history run when below locales set, it fails.
+        unicode_locales = [
+            "fr_FR.UTF-8",
+            "zh_TW.UTF-8",
+            "zh_CN.UTF-8",
+            "ko_KR.UTF-8",
+            "ja_JP.UTF-8",
+        ]
+        p = subprocess.Popen(
+            ["/usr/bin/locale", "-a"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        lines = p.stdout.readlines()
+        # subprocess return bytes and we need str
+        locale_list = [force_str(i.rstrip()) for i in lines]
+        unicode_list = list(set(locale_list) & set(unicode_locales))
+        self.assertTrue(
+            unicode_list,
+            "You must have one of the "
+            " following locales installed for this test to succeed: "
+            + ", ".join(unicode_locales),
+        )
+        env = {"LC_ALL": unicode_list[0]}
+        self.pkg("history", env_arg=env)
 
-                self.assertTrue(len(range_lines) >= 1, "No output from pkg history"
-                    " -t {0}-{1}".format(start_ts, end_ts))
-
-                # for each history line in the range output, ensure that it
-                # matches timestamps that we stored from the main history output
-                for line in range_lines:
-                        ts = line.strip().split()[0]
-                        self.assertTrue(line in entries[ts],
-                            "{0} does not appear in {1}".format(line, entries[ts]))
-                        range_timestamps.append(ts)
-
-                # determine the reverse. That is, for each entry in the
-                # list of ranges we expect taken from the entire history output,
-                # verify that entry was printed as part of
-                # pkg history -t <range>
-                start_index = timestamps.index(start_ts)
-                end_index = timestamps.index(end_ts)
-                # ranges are inclusive
-                if end_index != len(timestamps):
-                        end_index = end_index + 1
-                for ts in timestamps[start_index:end_index]:
-                        for line in entries[ts]:
-                                self.assertTrue(line in range_lines,
-                                    "expected range history entry not found "
-                                    "in output:\n"
-                                    "Line: {0}\n"
-                                    "Range output {1}\n"
-                                    "Entire output {2}".format(
-                                    line, "\n".join(range_lines),
-                                    entire_output))
-
-                # now verify that each timestamp we collected does indeed fall
-                # within that range
-                for ts in range_timestamps:
-                        self.assertTrue(ts >= start_ts, "{0} is not >= {1}".format(
-                            ts, start_ts))
-                        self.assertTrue(ts <= end_ts, "{0} is not <= {1}".format(
-                            ts, end_ts))
-
-        def test_13_bug_17418(self):
-                """Verify we can get history for an operation that ran for a
-                long time"""
-
-                image_path = self.get_img_path()
-                history_dir = os.path.sep.join([image_path, "var", "pkg",
-                    "history"])
-                dirlist = os.listdir(history_dir)
-                dirlist.sort()
-
-                # get the latest history file, and write another copy of it
-                # with an artificial start and end timestamp.
-                latest = os.path.join(history_dir, dirlist[-1])
-
-                tree = xml.etree.ElementTree.parse(latest)
-                root = tree.getroot()
-                operation = root.find("operation")
-                operation.attrib["start_time"] = \
-                    datetime.datetime.utcfromtimestamp(0).strftime(
-                    "%Y%m%dT%H%M%SZ")
-                operation.attrib["end_time"] = "20120229T000000Z"
-
-                new_file = re.sub(".xml", "99.xml", latest)
-                # xml.etree.ElementTree.tostring will generate a bytestring
-                # by default
-                outfile = open(os.path.join(history_dir, new_file), "wb")
-                outfile.write(xml.etree.ElementTree.tostring(root))
-                outfile.close()
-
-                self.pkg("history -n 1 -o time")
-                self.assertTrue("369576:00:00" in self.output)
-
-        def test_14_history_unicode_locale(self):
-                """Verify we can get history when unicode locale is set"""
-
-                # If pkg history run when below locales set, it fails.
-                unicode_locales = ["fr_FR.UTF-8", "zh_TW.UTF-8", "zh_CN.UTF-8",
-                    "ko_KR.UTF-8", "ja_JP.UTF-8"]
-                p = subprocess.Popen(["/usr/bin/locale", "-a"],
-                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                lines = p.stdout.readlines()
-                # subprocess return bytes and we need str
-                locale_list = [force_str(i.rstrip()) for i in lines]
-                unicode_list = list(set(locale_list) & set(unicode_locales))
-                self.assertTrue(unicode_list, "You must have one of the "
-                    " following locales installed for this test to succeed: "
-                    + ", ".join(unicode_locales))
-                env = { "LC_ALL": unicode_list[0] }
-                self.pkg("history", env_arg=env)
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_hydrate.py
+++ b/src/tests/cli/t_pkg_hydrate.py
@@ -25,20 +25,22 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
 import pkg.misc as misc
 import time
 
-class TestPkgHydrate(pkg5unittest.ManyDepotTestCase):
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
 
-        # A set of packages that we publish with additional hash attributes
-        pkgs = """
+class TestPkgHydrate(pkg5unittest.ManyDepotTestCase):
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
+
+    # A set of packages that we publish with additional hash attributes
+    pkgs = """
             open dev@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=dev
             add dir mode=0755 owner=root group=bin path=dev/cfg
@@ -67,7 +69,7 @@ class TestPkgHydrate(pkg5unittest.ManyDepotTestCase):
             close
             """
 
-        pkgs2 = """
+    pkgs2 = """
             open etc@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add dir mode=0755 owner=root group=bin path=etc/cfg
@@ -84,7 +86,7 @@ class TestPkgHydrate(pkg5unittest.ManyDepotTestCase):
             close
             """
 
-        pkgs3 = """
+    pkgs3 = """
             open dba@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=dba
             add file dba/foo path=dba/foo mode=0555 owner=root group=bin
@@ -94,7 +96,7 @@ class TestPkgHydrate(pkg5unittest.ManyDepotTestCase):
             close
             """
 
-        pkgs4 = """
+    pkgs4 = """
             open cga@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=cga
             close
@@ -105,7 +107,7 @@ class TestPkgHydrate(pkg5unittest.ManyDepotTestCase):
             close
             """
 
-        zones = """
+    zones = """
             open zones@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc/zones
             add file path=etc/zones/index mode=0644 owner=root group=bin preserve=true
@@ -113,754 +115,789 @@ class TestPkgHydrate(pkg5unittest.ManyDepotTestCase):
             close
             """
 
-        misc_files = ["dev/cfg/bar", "dev/cfg/bar1", "dev/cfg/bar2", "dev/cfg/bar3",
-                "dev/cfg/bar1.slink", "usr/bin/vi", "dev/cfg/foo",
-                "dev/cfg/foo.hlink",
-                "etc/foo", "etc/cfg/foo", "etc/cfg/foo1", "etc/foo.slink",
-                "dba/foo", "dba/foo1", "dba/foo.slink", "dba/foo1.slink",
-                "dba/foo.hlink",
-                "mnt/mm", "mnt/nn"]
+    misc_files = [
+        "dev/cfg/bar",
+        "dev/cfg/bar1",
+        "dev/cfg/bar2",
+        "dev/cfg/bar3",
+        "dev/cfg/bar1.slink",
+        "usr/bin/vi",
+        "dev/cfg/foo",
+        "dev/cfg/foo.hlink",
+        "etc/foo",
+        "etc/cfg/foo",
+        "etc/cfg/foo1",
+        "etc/foo.slink",
+        "dba/foo",
+        "dba/foo1",
+        "dba/foo.slink",
+        "dba/foo1.slink",
+        "dba/foo.hlink",
+        "mnt/mm",
+        "mnt/nn",
+    ]
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test1", "test3"])
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test1", "test2", "test1", "test3"]
+        )
 
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.make_misc_files(self.misc_files)
-                self.plist = self.pkgsend_bulk(self.rurl1, self.pkgs)
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.pkgsend_bulk(self.rurl2, self.pkgs2)
-                self.rurl3 = self.dcs[3].get_repo_url()
-                self.pkgsend_bulk(self.rurl3, self.pkgs3)
-                self.rurl4 = self.dcs[4].get_repo_url()
-                self.pkgsend_bulk(self.rurl4, self.pkgs4)
-                self.pkgsign_simple(self.rurl1, "'*'")
-                self.pkgsign_simple(self.rurl2, "'*'")
-                self.pkgsign_simple(self.rurl3, "'*'")
-                self.pkgsign_simple(self.rurl4, "'*'")
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.make_misc_files(self.misc_files)
+        self.plist = self.pkgsend_bulk(self.rurl1, self.pkgs)
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.pkgsend_bulk(self.rurl2, self.pkgs2)
+        self.rurl3 = self.dcs[3].get_repo_url()
+        self.pkgsend_bulk(self.rurl3, self.pkgs3)
+        self.rurl4 = self.dcs[4].get_repo_url()
+        self.pkgsend_bulk(self.rurl4, self.pkgs4)
+        self.pkgsign_simple(self.rurl1, "'*'")
+        self.pkgsign_simple(self.rurl2, "'*'")
+        self.pkgsign_simple(self.rurl3, "'*'")
+        self.pkgsign_simple(self.rurl4, "'*'")
 
-        def test_01_basics(self):
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
+    def test_01_basics(self):
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
 
-                # Nothing to do when there are no packages installed under
-                # all publishers.
-                self.pkg("dehydrate", exit=4)
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated []\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("dehydrate -p test1", exit=4)
-                self.pkg("rehydrate", exit=4)
+        # Nothing to do when there are no packages installed under
+        # all publishers.
+        self.pkg("dehydrate", exit=4)
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated []\n"""
+        self.assertEqual(expected, self.output)
+        self.pkg("dehydrate -p test1", exit=4)
+        self.pkg("rehydrate", exit=4)
 
-                self.pkg("install dev@1.0 dev2")
-                # Rehydrate do nothing if the publisher has not been dehydrated.
-                self.pkg("rehydrate -p test1", exit=4)
- 
-                index_dir = self.get_img_api_obj().img.index_dir
-                index_file = os.path.join(index_dir, "main_dict.ascii.v2")
-                orig_mtime = os.stat(index_file).st_mtime
-                time.sleep(1)
- 
-                some_files = ["dev/xxx", "dev/yyy", "dev/zzz",
-                              "dev/dir1/aaaa", "dev/dir1/bbbb", "dev/dir2/cccc",
-                              "dev/cfg/ffff", "dev/cfg/gggg",
-                              "dev/cfg/dir3/iiii", "dev/cfg/dir3/jjjj"]
-                some_dirs = ["dev/dir1/", "dev/dir1/", "dev/dir2/", "dev/cfg/dir3/"]
-                self.create_some_files(some_dirs + some_files)
-                self.files_are_all_there(some_dirs + some_files)
-                removed = "dev/cfg/bar1"
-                size1 = self.file_size(removed)
- 
-                # Verify that unprivileged users are handled by dehydrate.
-                self.pkg("dehydrate", exit=1, su_wrap=True)
- 
-                # Verify that dehydrate fails gracefully,
-                # if any of the specified publishers does not have a configured
-                # package repository;
-                self.pkg("set-publisher -g " + self.rurl2 + " test2")
-                self.pkg("set-publisher -G '*' test2")
-                self.pkg("dehydrate -p test1 -p test2", exit=1)
-                # if any of the publishers specified does not exist;
-                self.pkg("dehydrate -p nosuch -p test1", exit=1)
-                # if all known publishers have no configured package repository.
-                self.pkg("set-publisher -G '*' test1")
-                self.pkg("dehydrate", exit=1)
-                self.pkg("dehydrate -p test1", exit=1)
+        self.pkg("install dev@1.0 dev2")
+        # Rehydrate do nothing if the publisher has not been dehydrated.
+        self.pkg("rehydrate -p test1", exit=4)
 
-                # If no publishers exist in the image,
-                self.pkg("unset-publisher test1 test2")
-                # dehydrate will default to do nothing;
-                self.pkg("dehydrate", exit=4)
-                # the specified publisher will be treated as not having a
-                # configured package repository.
-                self.pkg("dehydrate -p test1", exit=1)
- 
-                # Verify that dehydrate works as expected.
-                self.pkg("set-publisher -g " + self.rurl1 + " test1")
-                self.pkg("dehydrate -vvv -p test1")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1']\n"""
-                self.assertEqual(expected, self.output)
-                # Verify dehydrate would not touch unpackaged data.
-                self.files_are_all_there(some_dirs + some_files)
-                # Verify that files are deleted or remained as expected.
-                self.file_exists("dev/cfg/bar")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.file_exists("dev/cfg/bar2")
-                self.file_doesnt_exist("usr/bin/vi")
-                self.file_doesnt_exist("dev/cfg/foo.hlink")
-                self.file_doesnt_exist("dev/cfg/foo")
-  
-                # Dehydrate do nothing on dehydrated publishers.
-                self.pkg("dehydrate -vvv -p test1", exit=4)
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1']\n"""
-                self.assertEqual(expected, self.output)
-  
-                # Verify that rehydrate fails gracefully,
-                # if any of the specified publishers does not have a configured
-                # package repository;
-                self.pkg("set-publisher -g " + self.rurl2 + " test2")
-                self.pkg("set-publisher -G '*' test2")
-                self.pkg("rehydrate -p test2 -p test1", exit=1)
-                # if any of the publishers specified does not exist;
-                self.pkg("rehydrate -p nosuch -p test1", exit=1)
-                # if all known publishers have no configured package repository.
-                self.pkg("set-publisher -G '*' test1")
-                self.pkg("rehydrate", exit=1)
-                self.pkg("rehydrate -p test1", exit=1)
+        index_dir = self.get_img_api_obj().img.index_dir
+        index_file = os.path.join(index_dir, "main_dict.ascii.v2")
+        orig_mtime = os.stat(index_file).st_mtime
+        time.sleep(1)
 
-                # If no publishers exist in the image,
-                self.pkg("unset-publisher test1 test2")
-                # The dehydrated property will not be removed if the publisher
-                # is deleted.
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1']\n"""
-                self.assertEqual(expected, self.output)
-                # rehydrate will default to do nothing;
-                self.pkg("rehydrate", exit=4)
-                # the specified publisher will be treated as not having a
-                # configured package repository.
-                self.pkg("rehydrate -p test1", exit=1)
- 
-                # Verify that unprivileged users are handled by rehydrate.
-                self.pkg("rehydrate", exit=1, su_wrap=True)
- 
-                # Verify that rehydrate works as expected.
-                self.pkg("set-publisher -g " + self.rurl1 + " test1")
-                self.pkg("rehydrate -vvv -p test1")
-                self.pkg("verify")
-  
-                # Check that we didn't reindex.
-                new_mtime = os.stat(index_file).st_mtime
-                self.assertEqual(orig_mtime, new_mtime)
-  
-                # Make sure it's the same size as the original.
-                size2 = self.file_size(removed)
-                self.assertEqual(size1, size2)
-  
-                # Verify that rehydrate will not operate on rehydrated publishers.
-                self.pkg("rehydrate -p test1", exit=4)
+        some_files = [
+            "dev/xxx",
+            "dev/yyy",
+            "dev/zzz",
+            "dev/dir1/aaaa",
+            "dev/dir1/bbbb",
+            "dev/dir2/cccc",
+            "dev/cfg/ffff",
+            "dev/cfg/gggg",
+            "dev/cfg/dir3/iiii",
+            "dev/cfg/dir3/jjjj",
+        ]
+        some_dirs = ["dev/dir1/", "dev/dir1/", "dev/dir2/", "dev/cfg/dir3/"]
+        self.create_some_files(some_dirs + some_files)
+        self.files_are_all_there(some_dirs + some_files)
+        removed = "dev/cfg/bar1"
+        size1 = self.file_size(removed)
 
-                # Verify that the default behavior of dehydrate/rehydrate works
-                # as expected.
-                self.pkg("dehydrate")
-                self.pkg("rehydrate")
-                self.pkg("verify")
+        # Verify that unprivileged users are handled by dehydrate.
+        self.pkg("dehydrate", exit=1, su_wrap=True)
 
-                # Verify that dehydrate defaults to dehydrate on all publishers
-                # that have configured repositories, regardless of whether the
-                # publisher has installed packages or not.
-                self.pkg("set-publisher -g " + self.rurl2 + " test2")
-                self.pkg("dehydrate -vvv")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1', 'test2']\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("rehydrate -vvv")
-                self.pkg("verify")
+        # Verify that dehydrate fails gracefully,
+        # if any of the specified publishers does not have a configured
+        # package repository;
+        self.pkg("set-publisher -g " + self.rurl2 + " test2")
+        self.pkg("set-publisher -G '*' test2")
+        self.pkg("dehydrate -p test1 -p test2", exit=1)
+        # if any of the publishers specified does not exist;
+        self.pkg("dehydrate -p nosuch -p test1", exit=1)
+        # if all known publishers have no configured package repository.
+        self.pkg("set-publisher -G '*' test1")
+        self.pkg("dehydrate", exit=1)
+        self.pkg("dehydrate -p test1", exit=1)
 
-        def test_02_multiple_publishers(self):
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("set-publisher -g " + self.rurl2 + " test2")
-                self.pkg("install dev@1.0 dev2")
-                self.pkg("install etc@1.0")
+        # If no publishers exist in the image,
+        self.pkg("unset-publisher test1 test2")
+        # dehydrate will default to do nothing;
+        self.pkg("dehydrate", exit=4)
+        # the specified publisher will be treated as not having a
+        # configured package repository.
+        self.pkg("dehydrate -p test1", exit=1)
 
-                some_files = ["dev/cfg/bar1", "usr/bin/vi", "dev/cfg/foo",
-                "etc/foo", "etc/cfg/foo1"]
- 
-                # Verify that specifying publishers manually will work.
-                self.pkg("dehydrate -vvv -p test1 -p test2")
-                self.files_are_all_missing(some_files)
-                self.pkg("rehydrate -vvv -p test1 -p test2")
-                self.files_are_all_there(some_files)
-                self.pkg("verify")
- 
-                # Verify that dehydrate defaults to operate on all publishers
-                # with configured package repositories.
-                self.pkg("dehydrate -vvv")
-                self.files_are_all_missing(some_files)
-                self.pkg("rehydrate -vvv")
-                self.files_are_all_there(some_files)
-                self.pkg("verify")
- 
-                # Verify that multiple origins with the same publisher will work.
-                self.pkg("set-publisher -g " + self.rurl3 + " test1")
-                self.pkg("install dba")
-                self.pkg("dehydrate -vvv -p test1")
-                some_files = ["dev/cfg/bar1", "dev/cfg/foo", "dba/foo",
-                    "dba/foo.hlink"]
-                self.files_are_all_missing(some_files)
-                self.pkg("rehydrate -vvv")
-                self.files_are_all_there(some_files)
-                self.pkg("verify")
+        # Verify that dehydrate works as expected.
+        self.pkg("set-publisher -g " + self.rurl1 + " test1")
+        self.pkg("dehydrate -vvv -p test1")
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1']\n"""
+        self.assertEqual(expected, self.output)
+        # Verify dehydrate would not touch unpackaged data.
+        self.files_are_all_there(some_dirs + some_files)
+        # Verify that files are deleted or remained as expected.
+        self.file_exists("dev/cfg/bar")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.file_exists("dev/cfg/bar2")
+        self.file_doesnt_exist("usr/bin/vi")
+        self.file_doesnt_exist("dev/cfg/foo.hlink")
+        self.file_doesnt_exist("dev/cfg/foo")
 
-                # Verify that packages with nothing to dehydrate will work.
-                self.pkg("set-publisher -g " + self.rurl4 + " test3")
-                self.pkg("install cga")
-                self.pkg("dehydrate -vvv -p test1 -p test3")
-                self.pkg("rehydrate -vvv -p test1 -p test3")
-                self.pkg("verify")
- 
-                # More tests on the user behaviors.
-                self.pkg("dehydrate -vvv -p test1")
-                self.pkg("dehydrate -vvv -p test2")
-                self.pkg("rehydrate -vvv -p test1")
-                self.pkg("rehydrate -vvv -p test1", exit=4)
-                self.pkg("rehydrate -vvv -p test2")
-                self.pkg("verify")
+        # Dehydrate do nothing on dehydrated publishers.
+        self.pkg("dehydrate -vvv -p test1", exit=4)
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1']\n"""
+        self.assertEqual(expected, self.output)
 
-                # Test the dehydrated property will be set correctly.
-                self.pkg("install mnt")
-                self.pkg("dehydrate -p test1 -p test3")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1', 'test3']\n"""
-                self.assertEqual(expected, self.output)
+        # Verify that rehydrate fails gracefully,
+        # if any of the specified publishers does not have a configured
+        # package repository;
+        self.pkg("set-publisher -g " + self.rurl2 + " test2")
+        self.pkg("set-publisher -G '*' test2")
+        self.pkg("rehydrate -p test2 -p test1", exit=1)
+        # if any of the publishers specified does not exist;
+        self.pkg("rehydrate -p nosuch -p test1", exit=1)
+        # if all known publishers have no configured package repository.
+        self.pkg("set-publisher -G '*' test1")
+        self.pkg("rehydrate", exit=1)
+        self.pkg("rehydrate -p test1", exit=1)
 
-                self.pkg("dehydrate -p test1 -p test2 -p test3")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1', 'test2', 'test3']\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("rehydrate -p test3")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1', 'test2']\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("rehydrate")
-                # The dehydrated proerty should has no value after
-                # fully rehydrate.
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated []\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("verify")
+        # If no publishers exist in the image,
+        self.pkg("unset-publisher test1 test2")
+        # The dehydrated property will not be removed if the publisher
+        # is deleted.
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1']\n"""
+        self.assertEqual(expected, self.output)
+        # rehydrate will default to do nothing;
+        self.pkg("rehydrate", exit=4)
+        # the specified publisher will be treated as not having a
+        # configured package repository.
+        self.pkg("rehydrate -p test1", exit=1)
 
-                self.pkg("dehydrate")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1', 'test2', 'test3']\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("rehydrate")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated []\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("verify")
+        # Verify that unprivileged users are handled by rehydrate.
+        self.pkg("rehydrate", exit=1, su_wrap=True)
 
-        def test_03_hardlinks(self):
-                """Hardlink test: make sure that a file getting rehydrated gets
-                any hardlinks that point to it updated"""
+        # Verify that rehydrate works as expected.
+        self.pkg("set-publisher -g " + self.rurl1 + " test1")
+        self.pkg("rehydrate -vvv -p test1")
+        self.pkg("verify")
 
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("install dev@1.0")
+        # Check that we didn't reindex.
+        new_mtime = os.stat(index_file).st_mtime
+        self.assertEqual(orig_mtime, new_mtime)
 
-                victim = "dev/cfg/bar2"
-                victimlink = "usr/bin/vi"
+        # Make sure it's the same size as the original.
+        size2 = self.file_size(removed)
+        self.assertEqual(size1, size2)
 
-                self.pkg("dehydrate")
-                self.pkg("rehydrate")
+        # Verify that rehydrate will not operate on rehydrated publishers.
+        self.pkg("rehydrate -p test1", exit=4)
 
-                # Get the inode of the orig file.
-                i1 = self.file_inode(victim)
-                # Get the inode of the new hardlink.
-                i2 = self.file_inode(victimlink)
+        # Verify that the default behavior of dehydrate/rehydrate works
+        # as expected.
+        self.pkg("dehydrate")
+        self.pkg("rehydrate")
+        self.pkg("verify")
 
-                # Make sure the inode of the link is now same.
-                self.assertEqual(i1, i2)
+        # Verify that dehydrate defaults to dehydrate on all publishers
+        # that have configured repositories, regardless of whether the
+        # publisher has installed packages or not.
+        self.pkg("set-publisher -g " + self.rurl2 + " test2")
+        self.pkg("dehydrate -vvv")
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1', 'test2']\n"""
+        self.assertEqual(expected, self.output)
+        self.pkg("rehydrate -vvv")
+        self.pkg("verify")
 
-        def test_04_pkg_install(self):
-                """Test that pkg install will install packages dehydrated from
-                dehydrated publishers and install packages normally from normal
-                publishers."""
-                for install_cmd in ["install", "exact-install"]:
-                        self.base_04_pkg_install(install_cmd)
+    def test_02_multiple_publishers(self):
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("set-publisher -g " + self.rurl2 + " test2")
+        self.pkg("install dev@1.0 dev2")
+        self.pkg("install etc@1.0")
 
-        def base_04_pkg_install(self, install_cmd):
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("install dev@1.0")
-                self.pkg("dehydrate")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1']\n"""
-                self.assertEqual(expected, self.output)
-                # Verify that a package from a dehydrated publisher will be
-                # installed dehydrated on the image.
-                self.pkg("install -vvv dev2")
-                self.file_doesnt_exist("dev/cfg/foo")
-                self.file_doesnt_exist("dev/cfg/foo.hlink")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1']\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("dehydrate", exit=4)
-                self.pkg("rehydrate")
-                self.file_exists("dev/cfg/foo")
-                self.file_exists("dev/cfg/foo.hlink")
-                self.pkg("verify")
+        some_files = [
+            "dev/cfg/bar1",
+            "usr/bin/vi",
+            "dev/cfg/foo",
+            "etc/foo",
+            "etc/cfg/foo1",
+        ]
 
-                # Verify that if we dehydrate a publisher without any packages,
-                # installing packages for that publisher are dehydrated.
-                self.pkg("set-publisher -g " + self.rurl2 + " test2")
-                self.pkg("dehydrate -p test1 -p test2")
-                self.pkg("install etc@1.0")
-                self.file_doesnt_exist("etc/foo")
-                self.file_doesnt_exist("etc/cfg/foo1")
-                self.file_doesnt_exist("usr/bin/vi")
-                self.pkg("rehydrate")
-                self.pkg("verify")
+        # Verify that specifying publishers manually will work.
+        self.pkg("dehydrate -vvv -p test1 -p test2")
+        self.files_are_all_missing(some_files)
+        self.pkg("rehydrate -vvv -p test1 -p test2")
+        self.files_are_all_there(some_files)
+        self.pkg("verify")
 
-                # Verify that if users adds a new publisher and install packages
-                # from it, the package is installed normally.
-                self.pkg("dehydrate -p test1")
-                self.pkg("set-publisher -g " + self.rurl4 + " test3")
-                self.pkg("install mnt")
-                self.file_exists("mnt/mm")
-                self.file_exists("mnt/nn")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1']\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("rehydrate")
-                self.pkg("verify")
+        # Verify that dehydrate defaults to operate on all publishers
+        # with configured package repositories.
+        self.pkg("dehydrate -vvv")
+        self.files_are_all_missing(some_files)
+        self.pkg("rehydrate -vvv")
+        self.files_are_all_there(some_files)
+        self.pkg("verify")
 
-        def test_05_pkg_update(self):
-                """Test that pkg update will update packages dehydrated from
-                dehydrated publishers and update packages normally from normal
-                publishers."""
+        # Verify that multiple origins with the same publisher will work.
+        self.pkg("set-publisher -g " + self.rurl3 + " test1")
+        self.pkg("install dba")
+        self.pkg("dehydrate -vvv -p test1")
+        some_files = ["dev/cfg/bar1", "dev/cfg/foo", "dba/foo", "dba/foo.hlink"]
+        self.files_are_all_missing(some_files)
+        self.pkg("rehydrate -vvv")
+        self.files_are_all_there(some_files)
+        self.pkg("verify")
 
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                
-                # Verify that a package that is dilvered by a dehydrated publisher
-                # will be updated dehydrated on the image.
-                self.pkg("set-publisher -g " + self.rurl2 + " test2")
-                self.pkg("install dev@1.0 etc@1.0")
-                self.file_doesnt_exist("dev/cfg/bar3")
-                self.pkg("dehydrate -p test1")
-                self.file_doesnt_exist("dev/cfg/bar3")
-                self.pkg("update dev")
-                self.file_doesnt_exist("dev/cfg/bar3")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.pkg("rehydrate")
-                self.pkg("verify")
+        # Verify that packages with nothing to dehydrate will work.
+        self.pkg("set-publisher -g " + self.rurl4 + " test3")
+        self.pkg("install cga")
+        self.pkg("dehydrate -vvv -p test1 -p test3")
+        self.pkg("rehydrate -vvv -p test1 -p test3")
+        self.pkg("verify")
 
-                # Verify that a package that is not dilvered by a dehydrated
-                # publisher will be updated normally.
-                self.pkg("dehydrate -p test1")
-                self.pkg("update etc")
-                self.file_exists("etc/foo")
-                self.pkg("rehydrate")
-                self.pkg("verify")
+        # More tests on the user behaviors.
+        self.pkg("dehydrate -vvv -p test1")
+        self.pkg("dehydrate -vvv -p test2")
+        self.pkg("rehydrate -vvv -p test1")
+        self.pkg("rehydrate -vvv -p test1", exit=4)
+        self.pkg("rehydrate -vvv -p test2")
+        self.pkg("verify")
 
-                # Verify that update without pargs will work too.
-                self.pkg("update dev@1.0")
-                self.pkg("update etc@1.0")
-                self.pkg("dehydrate -p test1")
-                self.pkg("update")
-                self.file_doesnt_exist("dev/cfg/bar3")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.file_exists("etc/foo")
-                self.pkg("rehydrate")
-                self.pkg("verify")
+        # Test the dehydrated property will be set correctly.
+        self.pkg("install mnt")
+        self.pkg("dehydrate -p test1 -p test3")
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1', 'test3']\n"""
+        self.assertEqual(expected, self.output)
 
-        def test_06_pkg_uninstall(self):
-                """Test uninstall works fine."""
+        self.pkg("dehydrate -p test1 -p test2 -p test3")
+        self.pkg("property dehydrated")
+        expected = (
+            """PROPERTY   VALUE\ndehydrated ['test1', 'test2', 'test3']\n"""
+        )
+        self.assertEqual(expected, self.output)
+        self.pkg("rehydrate -p test3")
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1', 'test2']\n"""
+        self.assertEqual(expected, self.output)
+        self.pkg("rehydrate")
+        # The dehydrated proerty should has no value after
+        # fully rehydrate.
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated []\n"""
+        self.assertEqual(expected, self.output)
+        self.pkg("verify")
 
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                
-                # Verify that if we uninstall all packages under dehydrated
-                # publishers, no work to do in dehydrate and rehydrate, and
-                # the dehydrated property remains.
-                self.pkg("install dev@1.0")
-                self.pkg("dehydrate")
-                self.pkg("uninstall dev")
-                self.pkg("dehydrate", exit=4)
-                self.pkg("rehydrate", exit=4)
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1']\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("verify")
+        self.pkg("dehydrate")
+        self.pkg("property dehydrated")
+        expected = (
+            """PROPERTY   VALUE\ndehydrated ['test1', 'test2', 'test3']\n"""
+        )
+        self.assertEqual(expected, self.output)
+        self.pkg("rehydrate")
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated []\n"""
+        self.assertEqual(expected, self.output)
+        self.pkg("verify")
 
-                # Verify that uninstalling some packages under dehydrated
-                # publishers will not cause dehydrate to fail on other packages,
-                # and the dehydrated property is deleted after rehydrate.
-                self.pkg("unset-property dehydrated")
-                self.pkg("install dev@1.0 dev2")
-                self.pkg("dehydrate -p test1")
-                self.pkg("uninstall dev")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated ['test1']\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("dehydrate -p test1", exit=4)
-                self.pkg("rehydrate")
-                self.pkg("property dehydrated")
-                expected = \
-"""PROPERTY   VALUE\ndehydrated []\n"""
-                self.assertEqual(expected, self.output)
-                self.pkg("verify")
- 
-                # Verify that uninstalling some packages under a publisher
-                # will not cause dehydrate to fail on another publisher.
-                self.pkg("set-publisher -g " + self.rurl4 + " test3")
-                self.pkg("install mnt")
-                self.pkg("dehydrate -p test3")
-                self.pkg("uninstall mnt")
-                self.pkg("dehydrate -p test1")
-                self.pkg("rehydrate")
-                self.pkg("verify")
+    def test_03_hardlinks(self):
+        """Hardlink test: make sure that a file getting rehydrated gets
+        any hardlinks that point to it updated"""
 
-        def test_07_pkg_verify(self):
-                """Test that verify will only look at things that have not been
-                dehydrated."""
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("install dev@1.0")
 
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("install dev@1.0")
-                self.file_append("dev/cfg/bar", "junk")
-                self.pkg("dehydrate")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.file_contains("dev/cfg/bar", "junk")
-                self.pkg("verify -vvv")
-                # dev/cfg/bar1 is dehydrated, so verify will not look at it
-                self.assertTrue("dev/cfg/bar1" not in self.output)
-                self.pkg("verify -v")
-                self.output.index("editable file has been changed")
+        victim = "dev/cfg/bar2"
+        victimlink = "usr/bin/vi"
 
-        def test_08_pkg_fix(self):
-                """Test that fix will only fix things that have not been
-                dehydrated."""
+        self.pkg("dehydrate")
+        self.pkg("rehydrate")
 
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                
-                self.pkg("install dev@1.0")
-                self.file_append("dev/cfg/bar", "junk")
-                self.pkg("dehydrate")
-                # dev/cfg/bar1 is dehydrated, dev/cfg/bar is not
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.file_exists("dev/cfg/bar")
-                self.pkg("fix -vvv", exit=4)
-                self.file_doesnt_exist("dev/cfg/bar1")
-                # remove dev/cfg/bar to cause an error
-                self.file_remove("dev/cfg/bar")
-                self.pkg("fix")
+        # Get the inode of the orig file.
+        i1 = self.file_inode(victim)
+        # Get the inode of the new hardlink.
+        i2 = self.file_inode(victimlink)
 
-        def test_09_pkg_revert(self):
-                """Test that revert will only revert things that have not been
-                dehydrated."""
+        # Make sure the inode of the link is now same.
+        self.assertEqual(i1, i2)
 
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("install dev@1.0")
-                self.file_append("dev/cfg/bar", "junk")
-                self.pkg("dehydrate")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.file_contains("dev/cfg/bar", "junk")
-                # It will be treated as "not packaged" if revert by path-to-name.
-                self.pkg("revert dev/cfg/bar1", exit=1)
-                # Nothing to do if revert by tag-name.
-                self.pkg("revert --tagged bob", exit=4)
-                self.pkg("revert dev/cfg/bar")
-                self.pkg("verify")
+    def test_04_pkg_install(self):
+        """Test that pkg install will install packages dehydrated from
+        dehydrated publishers and install packages normally from normal
+        publishers."""
+        for install_cmd in ["install", "exact-install"]:
+            self.base_04_pkg_install(install_cmd)
 
-        def test_10_pkg_change_facet(self):
-                """Test that change-facet for dehydrated publishers will be
-                automatically dehydrated."""
+    def base_04_pkg_install(self, install_cmd):
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("install dev@1.0")
+        self.pkg("dehydrate")
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1']\n"""
+        self.assertEqual(expected, self.output)
+        # Verify that a package from a dehydrated publisher will be
+        # installed dehydrated on the image.
+        self.pkg("install -vvv dev2")
+        self.file_doesnt_exist("dev/cfg/foo")
+        self.file_doesnt_exist("dev/cfg/foo.hlink")
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1']\n"""
+        self.assertEqual(expected, self.output)
+        self.pkg("dehydrate", exit=4)
+        self.pkg("rehydrate")
+        self.file_exists("dev/cfg/foo")
+        self.file_exists("dev/cfg/foo.hlink")
+        self.pkg("verify")
 
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                
-                # Test that change-facet uninstalls files on dehydrated
-                # publishers.
-                self.pkg("install dev@1.0")
-                self.pkg("dehydrate")
-                self.file_exists("dev/cfg/bar")
-                self.pkg("change-facet facet.locale.fr=False")
-                self.file_doesnt_exist("dev/cfg/bar")
-                self.pkg("rehydrate")
-                self.file_doesnt_exist("dev/cfg/bar")
-                self.pkg("verify")
+        # Verify that if we dehydrate a publisher without any packages,
+        # installing packages for that publisher are dehydrated.
+        self.pkg("set-publisher -g " + self.rurl2 + " test2")
+        self.pkg("dehydrate -p test1 -p test2")
+        self.pkg("install etc@1.0")
+        self.file_doesnt_exist("etc/foo")
+        self.file_doesnt_exist("etc/cfg/foo1")
+        self.file_doesnt_exist("usr/bin/vi")
+        self.pkg("rehydrate")
+        self.pkg("verify")
 
-                # Verify that change-facet installs new files dehydrated on
-                # dehydrated publishers.
-                self.pkg("dehydrate")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.pkg("change-facet facet.locale.fr=True")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.pkg("rehydrate")
-                self.file_exists("dev/cfg/bar1")
-                self.pkg("verify")
+        # Verify that if users adds a new publisher and install packages
+        # from it, the package is installed normally.
+        self.pkg("dehydrate -p test1")
+        self.pkg("set-publisher -g " + self.rurl4 + " test3")
+        self.pkg("install mnt")
+        self.file_exists("mnt/mm")
+        self.file_exists("mnt/nn")
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1']\n"""
+        self.assertEqual(expected, self.output)
+        self.pkg("rehydrate")
+        self.pkg("verify")
 
-        def test_11_pkg_change_variant(self):
-                """Test that change-variant for dehydrated publishers will be
-                automatically dehydrated."""
+    def test_05_pkg_update(self):
+        """Test that pkg update will update packages dehydrated from
+        dehydrated publishers and update packages normally from normal
+        publishers."""
 
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                
-                # Test that change-variant uninstalls files on dehydrated
-                # publishers.
-                self.pkg("install dev@1.0")
-                self.pkg("dehydrate")
-                self.file_exists("dev/cfg/bar")
-                self.pkg("change-variant variant.opensolaris.zone=non-global")
-                self.file_doesnt_exist("dev/cfg/bar")
-                self.pkg("rehydrate")
-                # Rehydrate will be restricted by variants.
-                self.file_doesnt_exist("dev/cfg/bar")
-                self.pkg("verify")
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
 
-                # Verify that change-variant installs new files dehydrated on
-                # dehydrated publishers.
-                self.pkg("dehydrate")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.pkg("change-variant variant.opensolaris.zone=global")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.pkg("rehydrate")
-                self.file_exists("dev/cfg/bar1")
-                self.pkg("verify")
+        # Verify that a package that is dilvered by a dehydrated publisher
+        # will be updated dehydrated on the image.
+        self.pkg("set-publisher -g " + self.rurl2 + " test2")
+        self.pkg("install dev@1.0 etc@1.0")
+        self.file_doesnt_exist("dev/cfg/bar3")
+        self.pkg("dehydrate -p test1")
+        self.file_doesnt_exist("dev/cfg/bar3")
+        self.pkg("update dev")
+        self.file_doesnt_exist("dev/cfg/bar3")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.pkg("rehydrate")
+        self.pkg("verify")
 
-        def test_12_zone_files(self):
-                """Test that zone configuration files 'index' and 'SYSdefault.xml'
-                will not be removed in dehydrate."""
+        # Verify that a package that is not dilvered by a dehydrated
+        # publisher will be updated normally.
+        self.pkg("dehydrate -p test1")
+        self.pkg("update etc")
+        self.file_exists("etc/foo")
+        self.pkg("rehydrate")
+        self.pkg("verify")
 
-                self.image_create(self.rurl1)
-                self.make_misc_files(["etc/zones/index", "etc/zones/SYSdefault.xml"])
-                self.pkgsend_bulk(self.rurl1, self.zones)
-                self.pkgsign_simple(self.rurl1, "zones")
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("install zones dev@1.0")
-                self.pkg("dehydrate")
-                self.file_exists("etc/zones/index")
-                self.file_exists("etc/zones/SYSdefault.xml")
+        # Verify that update without pargs will work too.
+        self.pkg("update dev@1.0")
+        self.pkg("update etc@1.0")
+        self.pkg("dehydrate -p test1")
+        self.pkg("update")
+        self.file_doesnt_exist("dev/cfg/bar3")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.file_exists("etc/foo")
+        self.pkg("rehydrate")
+        self.pkg("verify")
 
-        def test_13_existing_file(self):
-                """Test that rehydrate will reinstall the file if it was created
-                manually at the same path."""
+    def test_06_pkg_uninstall(self):
+        """Test uninstall works fine."""
 
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("install dev@1.0")
-                self.pkg("dehydrate")
-                self.file_doesnt_exist("dev/cfg/bar1")
-                self.file_append("dev/cfg/bar1", "junk")
-                self.file_exists("dev/cfg/bar1")
-                self.pkg("rehydrate -vvv")
-                self.file_doesnt_contain("dev/cfg/bar1", "junk")
-                self.pkg("verify")
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
 
-        def test_14_mediator(self):
-                """Test that a warning emitted whenever dehydrated publishers
-                exist and 'pkg mediator' or 'pkg set-mediator' is executed, and
-                the correct mediation will be applied when the publishers are
-                rehydrated."""
+        # Verify that if we uninstall all packages under dehydrated
+        # publishers, no work to do in dehydrate and rehydrate, and
+        # the dehydrated property remains.
+        self.pkg("install dev@1.0")
+        self.pkg("dehydrate")
+        self.pkg("uninstall dev")
+        self.pkg("dehydrate", exit=4)
+        self.pkg("rehydrate", exit=4)
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1']\n"""
+        self.assertEqual(expected, self.output)
+        self.pkg("verify")
 
-                def get_link_path(*parts):
-                        return os.path.join(self.img_path(), *parts)
+        # Verify that uninstalling some packages under dehydrated
+        # publishers will not cause dehydrate to fail on other packages,
+        # and the dehydrated property is deleted after rehydrate.
+        self.pkg("unset-property dehydrated")
+        self.pkg("install dev@1.0 dev2")
+        self.pkg("dehydrate -p test1")
+        self.pkg("uninstall dev")
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated ['test1']\n"""
+        self.assertEqual(expected, self.output)
+        self.pkg("dehydrate -p test1", exit=4)
+        self.pkg("rehydrate")
+        self.pkg("property dehydrated")
+        expected = """PROPERTY   VALUE\ndehydrated []\n"""
+        self.assertEqual(expected, self.output)
+        self.pkg("verify")
 
-                def assert_target(link, target):
-                        self.assertEqual(os.stat(link).st_ino,
-                            os.stat(target).st_ino)
+        # Verify that uninstalling some packages under a publisher
+        # will not cause dehydrate to fail on another publisher.
+        self.pkg("set-publisher -g " + self.rurl4 + " test3")
+        self.pkg("install mnt")
+        self.pkg("dehydrate -p test3")
+        self.pkg("uninstall mnt")
+        self.pkg("dehydrate -p test1")
+        self.pkg("rehydrate")
+        self.pkg("verify")
 
-                def assert_mediation_matches(expected, mediators=misc.EmptyI):
-                        self.pkg("mediator -H -F tsv {0}".format(" ".join(mediators)))
-                        self.assertEqualDiff(expected, self.output)
+    def test_07_pkg_verify(self):
+        """Test that verify will only look at things that have not been
+        dehydrated."""
 
-                vi_path = get_link_path("usr", "bin", "vi")
-                dev_path = get_link_path("dev", "cfg", "bar2")
-                etc_path = get_link_path("etc", "foo")
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("install dev@1.0")
+        self.file_append("dev/cfg/bar", "junk")
+        self.pkg("dehydrate")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.file_contains("dev/cfg/bar", "junk")
+        self.pkg("verify -vvv")
+        # dev/cfg/bar1 is dehydrated, so verify will not look at it
+        self.assertTrue("dev/cfg/bar1" not in self.output)
+        self.pkg("verify -v")
+        self.output.index("editable file has been changed")
 
-                self.image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("set-publisher -g " + self.rurl2 + " test2")
-                self.pkg("install dev@1.0 etc@1.0")
-                assert_mediation_matches("""\
+    def test_08_pkg_fix(self):
+        """Test that fix will only fix things that have not been
+        dehydrated."""
+
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+
+        self.pkg("install dev@1.0")
+        self.file_append("dev/cfg/bar", "junk")
+        self.pkg("dehydrate")
+        # dev/cfg/bar1 is dehydrated, dev/cfg/bar is not
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.file_exists("dev/cfg/bar")
+        self.pkg("fix -vvv", exit=4)
+        self.file_doesnt_exist("dev/cfg/bar1")
+        # remove dev/cfg/bar to cause an error
+        self.file_remove("dev/cfg/bar")
+        self.pkg("fix")
+
+    def test_09_pkg_revert(self):
+        """Test that revert will only revert things that have not been
+        dehydrated."""
+
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("install dev@1.0")
+        self.file_append("dev/cfg/bar", "junk")
+        self.pkg("dehydrate")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.file_contains("dev/cfg/bar", "junk")
+        # It will be treated as "not packaged" if revert by path-to-name.
+        self.pkg("revert dev/cfg/bar1", exit=1)
+        # Nothing to do if revert by tag-name.
+        self.pkg("revert --tagged bob", exit=4)
+        self.pkg("revert dev/cfg/bar")
+        self.pkg("verify")
+
+    def test_10_pkg_change_facet(self):
+        """Test that change-facet for dehydrated publishers will be
+        automatically dehydrated."""
+
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+
+        # Test that change-facet uninstalls files on dehydrated
+        # publishers.
+        self.pkg("install dev@1.0")
+        self.pkg("dehydrate")
+        self.file_exists("dev/cfg/bar")
+        self.pkg("change-facet facet.locale.fr=False")
+        self.file_doesnt_exist("dev/cfg/bar")
+        self.pkg("rehydrate")
+        self.file_doesnt_exist("dev/cfg/bar")
+        self.pkg("verify")
+
+        # Verify that change-facet installs new files dehydrated on
+        # dehydrated publishers.
+        self.pkg("dehydrate")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.pkg("change-facet facet.locale.fr=True")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.pkg("rehydrate")
+        self.file_exists("dev/cfg/bar1")
+        self.pkg("verify")
+
+    def test_11_pkg_change_variant(self):
+        """Test that change-variant for dehydrated publishers will be
+        automatically dehydrated."""
+
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+
+        # Test that change-variant uninstalls files on dehydrated
+        # publishers.
+        self.pkg("install dev@1.0")
+        self.pkg("dehydrate")
+        self.file_exists("dev/cfg/bar")
+        self.pkg("change-variant variant.opensolaris.zone=non-global")
+        self.file_doesnt_exist("dev/cfg/bar")
+        self.pkg("rehydrate")
+        # Rehydrate will be restricted by variants.
+        self.file_doesnt_exist("dev/cfg/bar")
+        self.pkg("verify")
+
+        # Verify that change-variant installs new files dehydrated on
+        # dehydrated publishers.
+        self.pkg("dehydrate")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.pkg("change-variant variant.opensolaris.zone=global")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.pkg("rehydrate")
+        self.file_exists("dev/cfg/bar1")
+        self.pkg("verify")
+
+    def test_12_zone_files(self):
+        """Test that zone configuration files 'index' and 'SYSdefault.xml'
+        will not be removed in dehydrate."""
+
+        self.image_create(self.rurl1)
+        self.make_misc_files(["etc/zones/index", "etc/zones/SYSdefault.xml"])
+        self.pkgsend_bulk(self.rurl1, self.zones)
+        self.pkgsign_simple(self.rurl1, "zones")
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("install zones dev@1.0")
+        self.pkg("dehydrate")
+        self.file_exists("etc/zones/index")
+        self.file_exists("etc/zones/SYSdefault.xml")
+
+    def test_13_existing_file(self):
+        """Test that rehydrate will reinstall the file if it was created
+        manually at the same path."""
+
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("install dev@1.0")
+        self.pkg("dehydrate")
+        self.file_doesnt_exist("dev/cfg/bar1")
+        self.file_append("dev/cfg/bar1", "junk")
+        self.file_exists("dev/cfg/bar1")
+        self.pkg("rehydrate -vvv")
+        self.file_doesnt_contain("dev/cfg/bar1", "junk")
+        self.pkg("verify")
+
+    def test_14_mediator(self):
+        """Test that a warning emitted whenever dehydrated publishers
+        exist and 'pkg mediator' or 'pkg set-mediator' is executed, and
+        the correct mediation will be applied when the publishers are
+        rehydrated."""
+
+        def get_link_path(*parts):
+            return os.path.join(self.img_path(), *parts)
+
+        def assert_target(link, target):
+            self.assertEqual(os.stat(link).st_ino, os.stat(target).st_ino)
+
+        def assert_mediation_matches(expected, mediators=misc.EmptyI):
+            self.pkg("mediator -H -F tsv {0}".format(" ".join(mediators)))
+            self.assertEqualDiff(expected, self.output)
+
+        vi_path = get_link_path("usr", "bin", "vi")
+        dev_path = get_link_path("dev", "cfg", "bar2")
+        etc_path = get_link_path("etc", "foo")
+
+        self.image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("set-publisher -g " + self.rurl2 + " test2")
+        self.pkg("install dev@1.0 etc@1.0")
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tsystem\tdev\t
-""")
+"""
+        )
 
-                warning = """\
+        warning = """\
 WARNING: pkg mediators may not be accurately shown when one or more publishers have been dehydrated. The correct mediation will be applied when the publishers are rehydrated.
 """
- 
-                # If dehydrate all publishers that have the mediated hardlink
-                # to remove it and its target file exists.
-                self.pkg("dehydrate -p test1 -p test2")
-                self.file_doesnt_exist(vi_path)
-                self.file_exists(dev_path)
-                self.pkg("set-mediator -vvv -I dev vi")
-                self.file_doesnt_exist(vi_path)
-                self.assertTrue(warning in self.output, self.output)
-                self.pkg("mediator")
-                self.assertTrue(warning in self.output, self.output)
-                self.pkg("rehydrate")
-                assert_target(vi_path, dev_path)
-                assert_mediation_matches("""\
+
+        # If dehydrate all publishers that have the mediated hardlink
+        # to remove it and its target file exists.
+        self.pkg("dehydrate -p test1 -p test2")
+        self.file_doesnt_exist(vi_path)
+        self.file_exists(dev_path)
+        self.pkg("set-mediator -vvv -I dev vi")
+        self.file_doesnt_exist(vi_path)
+        self.assertTrue(warning in self.output, self.output)
+        self.pkg("mediator")
+        self.assertTrue(warning in self.output, self.output)
+        self.pkg("rehydrate")
+        assert_target(vi_path, dev_path)
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tlocal\tdev\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                self.pkg("dehydrate -p test1 -p test2")
-                self.file_doesnt_exist(vi_path)
-                self.pkg("unset-mediator -vvv vi")
-                self.file_doesnt_exist(vi_path)
-                self.pkg("rehydrate")
-                assert_target(vi_path, dev_path)
-                assert_mediation_matches("""\
+        self.pkg("dehydrate -p test1 -p test2")
+        self.file_doesnt_exist(vi_path)
+        self.pkg("unset-mediator -vvv vi")
+        self.file_doesnt_exist(vi_path)
+        self.pkg("rehydrate")
+        assert_target(vi_path, dev_path)
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tsystem\tdev\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # If dehydrate all publishers that have the mediated hardlink
-                # to remove it and its target file doesn't exist.
-                self.pkg("dehydrate -p test1 -p test2")
-                self.file_doesnt_exist(vi_path)
-                self.file_doesnt_exist(etc_path)
-                self.pkg("set-mediator -vvv -I etc vi")
-                self.file_doesnt_exist(vi_path)
-                self.file_doesnt_exist(etc_path)
-                self.pkg("rehydrate")
-                assert_target(vi_path, etc_path)
-                assert_mediation_matches("""\
+        # If dehydrate all publishers that have the mediated hardlink
+        # to remove it and its target file doesn't exist.
+        self.pkg("dehydrate -p test1 -p test2")
+        self.file_doesnt_exist(vi_path)
+        self.file_doesnt_exist(etc_path)
+        self.pkg("set-mediator -vvv -I etc vi")
+        self.file_doesnt_exist(vi_path)
+        self.file_doesnt_exist(etc_path)
+        self.pkg("rehydrate")
+        assert_target(vi_path, etc_path)
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tlocal\tetc\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                self.pkg("dehydrate -p test1 -p test2")
-                self.file_doesnt_exist(vi_path)
-                self.file_doesnt_exist(etc_path)
-                self.pkg("unset-mediator -vvv vi")
-                self.file_doesnt_exist(vi_path)
-                self.file_doesnt_exist(etc_path)
-                self.pkg("rehydrate")
-                assert_target(vi_path, dev_path)
-                assert_mediation_matches("""\
+        self.pkg("dehydrate -p test1 -p test2")
+        self.file_doesnt_exist(vi_path)
+        self.file_doesnt_exist(etc_path)
+        self.pkg("unset-mediator -vvv vi")
+        self.file_doesnt_exist(vi_path)
+        self.file_doesnt_exist(etc_path)
+        self.pkg("rehydrate")
+        assert_target(vi_path, dev_path)
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tsystem\tdev\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # If dehydrate only a publisher that has the mediated hardlink
-                # but the other publisher still deliver it and its target file
-                # exists.
-                self.pkg("dehydrate -vvv -p test2")
-                self.file_exists(vi_path)
-                self.file_exists(dev_path)
-                self.pkg("set-mediator -vvv -I dev vi")
-                self.pkg("rehydrate -vvv")
-                assert_target(vi_path, dev_path)
-                assert_mediation_matches("""\
+        # If dehydrate only a publisher that has the mediated hardlink
+        # but the other publisher still deliver it and its target file
+        # exists.
+        self.pkg("dehydrate -vvv -p test2")
+        self.file_exists(vi_path)
+        self.file_exists(dev_path)
+        self.pkg("set-mediator -vvv -I dev vi")
+        self.pkg("rehydrate -vvv")
+        assert_target(vi_path, dev_path)
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tlocal\tdev\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                self.pkg("dehydrate -p test2")
-                self.file_exists(vi_path)
-                self.file_exists(dev_path)
-                self.pkg("unset-mediator -vvv vi")
-                self.pkg("rehydrate")
-                assert_target(vi_path, dev_path)
-                assert_mediation_matches("""\
+        self.pkg("dehydrate -p test2")
+        self.file_exists(vi_path)
+        self.file_exists(dev_path)
+        self.pkg("unset-mediator -vvv vi")
+        self.pkg("rehydrate")
+        assert_target(vi_path, dev_path)
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tsystem\tdev\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                self.pkg("dehydrate -p test1")
-                self.file_exists(vi_path)
-                self.file_exists(dev_path)
-                self.pkg("set-mediator -vvv -I dev vi")
-                self.pkg("rehydrate")
-                assert_target(vi_path, dev_path)
-                assert_mediation_matches("""\
+        self.pkg("dehydrate -p test1")
+        self.file_exists(vi_path)
+        self.file_exists(dev_path)
+        self.pkg("set-mediator -vvv -I dev vi")
+        self.pkg("rehydrate")
+        assert_target(vi_path, dev_path)
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tlocal\tdev\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                self.pkg("dehydrate -p test1")
-                self.file_exists(vi_path)
-                self.file_exists(etc_path)
-                self.pkg("set-mediator -vvv -I etc vi")
-                self.pkg("rehydrate")
-                assert_target(vi_path, etc_path)
-                assert_mediation_matches("""\
+        self.pkg("dehydrate -p test1")
+        self.file_exists(vi_path)
+        self.file_exists(etc_path)
+        self.pkg("set-mediator -vvv -I etc vi")
+        self.pkg("rehydrate")
+        assert_target(vi_path, etc_path)
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tlocal\tetc\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                self.pkg("dehydrate -p test1")
-                self.file_exists(vi_path)
-                self.file_exists(etc_path)
-                self.pkg("unset-mediator -vvv vi")
-                self.pkg("rehydrate")
-                assert_target(vi_path, dev_path)
-                assert_mediation_matches("""\
+        self.pkg("dehydrate -p test1")
+        self.file_exists(vi_path)
+        self.file_exists(etc_path)
+        self.pkg("unset-mediator -vvv vi")
+        self.pkg("rehydrate")
+        assert_target(vi_path, dev_path)
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tsystem\tdev\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # If dehydrate only a publisher that has the mediated hardlink
-                # but the other publisher still deliver it and its target file
-                # doesn't exist.
-                self.pkg("dehydrate -p test2")
-                self.file_exists(vi_path)
-                self.file_doesnt_exist(etc_path)
-                self.pkg("set-mediator -vvv -I etc vi")
-                self.file_doesnt_exist(etc_path)
-                self.pkg("rehydrate")
-                assert_target(vi_path, etc_path)
-                assert_mediation_matches("""\
+        # If dehydrate only a publisher that has the mediated hardlink
+        # but the other publisher still deliver it and its target file
+        # doesn't exist.
+        self.pkg("dehydrate -p test2")
+        self.file_exists(vi_path)
+        self.file_doesnt_exist(etc_path)
+        self.pkg("set-mediator -vvv -I etc vi")
+        self.file_doesnt_exist(etc_path)
+        self.pkg("rehydrate")
+        assert_target(vi_path, etc_path)
+        assert_mediation_matches(
+            """\
 vi\tsystem\t\tlocal\tetc\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_image_create.py
+++ b/src/tests/cli/t_pkg_image_create.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -41,768 +42,866 @@ import unittest
 
 
 class TestPkgImageCreateBasics(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depots once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depots once (instead of for every test)
+    persistent_setup = True
 
-        def setUp(self):
-                # Extra instances of test1 are created so that a valid
-                # repository that is different than the actual test1
-                # repository can be used.
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test1", "test1", "nopubconfig"])
+    def setUp(self):
+        # Extra instances of test1 are created so that a valid
+        # repository that is different than the actual test1
+        # repository can be used.
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test1", "test2", "test1", "test1", "nopubconfig"]
+        )
 
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.rurl3 = self.dcs[3].get_repo_url()
-                self.rurl4 = self.dcs[4].get_repo_url()
-                self.durl5 = self.dcs[5].get_depot_url()
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.rurl3 = self.dcs[3].get_repo_url()
+        self.rurl4 = self.dcs[4].get_repo_url()
+        self.durl5 = self.dcs[5].get_depot_url()
 
-                self.rpath1 = self.dcs[1].get_repodir()
-                self.rpath3 = self.dcs[3].get_repodir()
-                self.rpath4 = self.dcs[4].get_repodir()
+        self.rpath1 = self.dcs[1].get_repodir()
+        self.rpath3 = self.dcs[3].get_repodir()
+        self.rpath4 = self.dcs[4].get_repodir()
 
-                # The fifth depot is purposefully one with the publisher
-                # operation disabled.
-                self.dcs[5].set_disable_ops(["publisher/0", "publisher/1"])
-                self.dcs[5].start()
+        # The fifth depot is purposefully one with the publisher
+        # operation disabled.
+        self.dcs[5].set_disable_ops(["publisher/0", "publisher/1"])
+        self.dcs[5].start()
 
-        def test_basic(self):
-                """ Create an image, verify it. """
+    def test_basic(self):
+        """Create an image, verify it."""
 
-                self.pkg_image_create(self.rurl1, prefix="test1")
-                self.pkg("verify")
+        self.pkg_image_create(self.rurl1, prefix="test1")
+        self.pkg("verify")
 
-        def test_image_create_bad_opts(self):
-                """Test some bad cli options."""
+    def test_image_create_bad_opts(self):
+        """Test some bad cli options."""
 
-                self.pkg("image-create -@", exit=2)
-                self.pkg("image-create --bozo", exit=2)
-                self.pkg("image-create", exit=2)
+        self.pkg("image-create -@", exit=2)
+        self.pkg("image-create --bozo", exit=2)
+        self.pkg("image-create", exit=2)
 
-                self.pkg("image-create --facet foo=NONE -p test1={0} {1}".format(
-                    self.rurl1, self.test_root), exit=2)
-                self.pkg("image-create --facet foo= -p test1={0} {1}".format(
-                    self.rurl1, self.test_root), exit=2)
-                self.pkg("image-create --facet foo -p test1={0} {1}".format(
-                    self.rurl1, self.test_root), exit=2)
+        self.pkg(
+            "image-create --facet foo=NONE -p test1={0} {1}".format(
+                self.rurl1, self.test_root
+            ),
+            exit=2,
+        )
+        self.pkg(
+            "image-create --facet foo= -p test1={0} {1}".format(
+                self.rurl1, self.test_root
+            ),
+            exit=2,
+        )
+        self.pkg(
+            "image-create --facet foo -p test1={0} {1}".format(
+                self.rurl1, self.test_root
+            ),
+            exit=2,
+        )
 
-                self.pkg("image-create --set-property foo -p test1={0} {1}".format(
-                    self.rurl1, self.test_root), exit=2)
-                self.pkg("image-create --set-property foo=bar --set-property "
-                    "foo=baz -p test1={0} {1}".format(self.rurl1, self.test_root),
-                    exit=2)
-                self.pkg("image-create -g {0} {1}".format(self.rurl1, self.test_root),
-                    exit=2)
-                self.pkg("image-create -m {0} {1}".format(self.rurl1, self.test_root),
-                    exit=2)
-                self.pkg("image-create -g {0} -m {1} {2}".format(self.rurl1,
-                    self.rurl1, self.test_root), exit=2)
+        self.pkg(
+            "image-create --set-property foo -p test1={0} {1}".format(
+                self.rurl1, self.test_root
+            ),
+            exit=2,
+        )
+        self.pkg(
+            "image-create --set-property foo=bar --set-property "
+            "foo=baz -p test1={0} {1}".format(self.rurl1, self.test_root),
+            exit=2,
+        )
+        self.pkg(
+            "image-create -g {0} {1}".format(self.rurl1, self.test_root), exit=2
+        )
+        self.pkg(
+            "image-create -m {0} {1}".format(self.rurl1, self.test_root), exit=2
+        )
+        self.pkg(
+            "image-create -g {0} -m {1} {2}".format(
+                self.rurl1, self.rurl1, self.test_root
+            ),
+            exit=2,
+        )
 
-        def __add_install_file(self, imgdir, fmri):
-                """Take an image path and fmri. Write a file to disk that
-                indicates that the package named by the fmri has been
-                installed.  Assumes package was installed from a preferred
-                publisher."""
+    def __add_install_file(self, imgdir, fmri):
+        """Take an image path and fmri. Write a file to disk that
+        indicates that the package named by the fmri has been
+        installed.  Assumes package was installed from a preferred
+        publisher."""
 
-                def install_file(fmri):
-                        return "{0}/pkg/{1}/installed".format(imgdir,
-                            fmri.get_dir_path())
+        def install_file(fmri):
+            return "{0}/pkg/{1}/installed".format(imgdir, fmri.get_dir_path())
 
-                f = open(install_file(fmri), "w")
-                f.writelines(["VERSION_1\n_PRE_", fmri.publisher])
-                f.close()
+        f = open(install_file(fmri), "w")
+        f.writelines(["VERSION_1\n_PRE_", fmri.publisher])
+        f.close()
 
-                fi = open("{0}/state/installed/{1}".format(imgdir,
-                    fmri.get_link_path()), "w")
-                fi.close()
+        fi = open(
+            "{0}/state/installed/{1}".format(imgdir, fmri.get_link_path()), "w"
+        )
+        fi.close()
 
-        @staticmethod
-        def __transform_v1_v0(v1_cat, v0_dest):
-                name = os.path.join(v0_dest, "attrs")
-                f = open(name, "wb")
-                f.write(misc.force_bytes("S "
-                    "Last-Modified: {0}\n".format(
-                     v1_cat.last_modified.isoformat())))
-                f.write(misc.force_bytes("S prefix: CRSV\n"))
-                f.write(misc.force_bytes(
-                        "S npkgs: {0}\n".format(v1_cat.package_version_count)))
-                f.close()
+    @staticmethod
+    def __transform_v1_v0(v1_cat, v0_dest):
+        name = os.path.join(v0_dest, "attrs")
+        f = open(name, "wb")
+        f.write(
+            misc.force_bytes(
+                "S "
+                "Last-Modified: {0}\n".format(v1_cat.last_modified.isoformat())
+            )
+        )
+        f.write(misc.force_bytes("S prefix: CRSV\n"))
+        f.write(
+            misc.force_bytes(
+                "S npkgs: {0}\n".format(v1_cat.package_version_count)
+            )
+        )
+        f.close()
 
-                name = os.path.join(v0_dest, "catalog")
-                f = open(name, "wb")
-                # Now write each FMRI in the catalog in the v0 format:
-                # V pkg:/SUNWdvdrw@5.21.4.10.8,5.11-0.86:20080426T173208Z
-                for pub, stem, ver in v1_cat.tuples():
-                        f.write(misc.force_bytes(
-                                "V pkg:/{0}@{1}\n".format(stem, ver)))
-                f.close()
+        name = os.path.join(v0_dest, "catalog")
+        f = open(name, "wb")
+        # Now write each FMRI in the catalog in the v0 format:
+        # V pkg:/SUNWdvdrw@5.21.4.10.8,5.11-0.86:20080426T173208Z
+        for pub, stem, ver in v1_cat.tuples():
+            f.write(misc.force_bytes("V pkg:/{0}@{1}\n".format(stem, ver)))
+        f.close()
 
-        def test_force(self):
-                """Ensure that image creation works as expected when an image
-                already exists."""
+    def test_force(self):
+        """Ensure that image creation works as expected when an image
+        already exists."""
 
-                # These tests are interdependent.
-                #
-                # Bug 3588: Make sure we can't create an image where one
-                # already exists
-                self.pkg("image-create -p test1={0} {1}/3588_image".format(
-                    self.rurl1, self.get_img_path()))
-                self.pkg("image-create -p test1={0} {1}/3588_image".format(
-                    self.rurl1, self.get_img_path()), exit=1)
+        # These tests are interdependent.
+        #
+        # Bug 3588: Make sure we can't create an image where one
+        # already exists
+        self.pkg(
+            "image-create -p test1={0} {1}/3588_image".format(
+                self.rurl1, self.get_img_path()
+            )
+        )
+        self.pkg(
+            "image-create -p test1={0} {1}/3588_image".format(
+                self.rurl1, self.get_img_path()
+            ),
+            exit=1,
+        )
 
-                # Make sure we can create an image where one
-                # already exists with the -f (force) flag
-                self.pkg("image-create -p test1={0} {1}/3588_image_1".format(
-                    self.rurl1, self.get_img_path()))
-                self.pkg("image-create -f -p test1={0} {1}/3588_image_1".format(
-                         self.rurl1, self.get_img_path()))
+        # Make sure we can create an image where one
+        # already exists with the -f (force) flag
+        self.pkg(
+            "image-create -p test1={0} {1}/3588_image_1".format(
+                self.rurl1, self.get_img_path()
+            )
+        )
+        self.pkg(
+            "image-create -f -p test1={0} {1}/3588_image_1".format(
+                self.rurl1, self.get_img_path()
+            )
+        )
 
-                # Bug 3588: Make sure we can't create an image where a
-                # non-empty directory exists
-                p = os.path.join(self.get_img_path(), "3588_2_image")
-                os.mkdir(p)
-                self.cmdline_run("touch {0}/{1}".format(p, "somefile"),
-                    coverage=False)
-                self.pkg("image-create -p test1={0} {1}".format(self.rurl1, p),
-                    exit=1)
-                self.pkg("image-create -f -p test1={0} {1}".format(self.rurl1, p))
+        # Bug 3588: Make sure we can't create an image where a
+        # non-empty directory exists
+        p = os.path.join(self.get_img_path(), "3588_2_image")
+        os.mkdir(p)
+        self.cmdline_run("touch {0}/{1}".format(p, "somefile"), coverage=False)
+        self.pkg("image-create -p test1={0} {1}".format(self.rurl1, p), exit=1)
+        self.pkg("image-create -f -p test1={0} {1}".format(self.rurl1, p))
 
-                # Bug 17680: Ensure ssl directory is preserved if it
-                # already exists when creating an image where one
-                # might already exist with the -f (force) flag.
-                shutil.rmtree(self.get_img_path())
-                self.pkg("image-create -p test1={0} {1}".format(self.rurl1,
-                    self.get_img_path()))
+        # Bug 17680: Ensure ssl directory is preserved if it
+        # already exists when creating an image where one
+        # might already exist with the -f (force) flag.
+        shutil.rmtree(self.get_img_path())
+        self.pkg(
+            "image-create -p test1={0} {1}".format(
+                self.rurl1, self.get_img_path()
+            )
+        )
 
-                img = self.get_img_api_obj().img
-                cert_path = os.path.join(img.imgdir, "ssl", "cert.file")
-                misc.makedirs(os.path.dirname(cert_path))
-                open(cert_path, "wb").close()
-                assert os.path.exists(cert_path)
-                self.pkg("image-create -f -p test1={0} {1}".format(self.rurl1,
-                    self.get_img_path()))
-                assert os.path.exists(cert_path)
+        img = self.get_img_api_obj().img
+        cert_path = os.path.join(img.imgdir, "ssl", "cert.file")
+        misc.makedirs(os.path.dirname(cert_path))
+        open(cert_path, "wb").close()
+        assert os.path.exists(cert_path)
+        self.pkg(
+            "image-create -f -p test1={0} {1}".format(
+                self.rurl1, self.get_img_path()
+            )
+        )
+        assert os.path.exists(cert_path)
 
-        def __verify_pub_cfg(self, img_path, prefix, pub_cfg):
-                """Private helper method to verify publisher configuration."""
+    def __verify_pub_cfg(self, img_path, prefix, pub_cfg):
+        """Private helper method to verify publisher configuration."""
 
-                # pretend like the Image object is being allocated from
-                # a pkg command run from within the target image.
-                cmdpath = os.path.join(self.get_img_path(), "pkg")
+        # pretend like the Image object is being allocated from
+        # a pkg command run from within the target image.
+        cmdpath = os.path.join(self.get_img_path(), "pkg")
 
-                img = image.Image(img_path, should_exist=True,
-                    user_provided_dir=True, cmdpath=cmdpath)
-                pub = img.get_publisher(prefix=prefix)
-                for section in pub_cfg:
-                        for prop, val in six.iteritems(pub_cfg[section]):
-                                if section == "publisher":
-                                        pub_val = getattr(pub, prop)
-                                else:
-                                        pub_val = getattr(
-                                            pub.repository, prop)
+        img = image.Image(
+            img_path, should_exist=True, user_provided_dir=True, cmdpath=cmdpath
+        )
+        pub = img.get_publisher(prefix=prefix)
+        for section in pub_cfg:
+            for prop, val in six.iteritems(pub_cfg[section]):
+                if section == "publisher":
+                    pub_val = getattr(pub, prop)
+                else:
+                    pub_val = getattr(pub.repository, prop)
 
-                                if prop in ("legal_uris", "mirrors", "origins",
-                                    "related_uris"):
-                                        # The publisher will have these as lists,
-                                        # so transform both sets of data first
-                                        # for reliable comparison.  Remove any
-                                        # trailing slashes so comparison can
-                                        # succeed.
-                                        if not val:
-                                                val = set()
-                                        else:
-                                                val = set(val.split(","))
-                                        new_pub_val = set()
-                                        for u in pub_val:
-                                                uri = u.uri
-                                                if uri.endswith("/"):
-                                                        uri = uri[:-1]
-                                                new_pub_val.add(uri)
-                                        pub_val = new_pub_val
-                                self.assertEqual(val, pub_val)
+                if prop in ("legal_uris", "mirrors", "origins", "related_uris"):
+                    # The publisher will have these as lists,
+                    # so transform both sets of data first
+                    # for reliable comparison.  Remove any
+                    # trailing slashes so comparison can
+                    # succeed.
+                    if not val:
+                        val = set()
+                    else:
+                        val = set(val.split(","))
+                    new_pub_val = set()
+                    for u in pub_val:
+                        uri = u.uri
+                        if uri.endswith("/"):
+                            uri = uri[:-1]
+                        new_pub_val.add(uri)
+                    pub_val = new_pub_val
+                self.assertEqual(val, pub_val)
 
-                # Loading an image changed the cwd, so change it back.
-                os.chdir(self.test_root)
+        # Loading an image changed the cwd, so change it back.
+        os.chdir(self.test_root)
 
-        def test_4_options(self):
-                """Verify that all of the options for specifying publisher
-                information work as expected for image-create."""
+    def test_4_options(self):
+        """Verify that all of the options for specifying publisher
+        information work as expected for image-create."""
 
-                img_path = os.path.join(self.test_root, "test_4_img")
-                for opt in ("-p", "--publisher"):
-                        self.pkg("image-create {0} test1={1} {2}".format(opt,
-                            self.rurl1, img_path))
-                        shutil.rmtree(img_path)
-
-                # Verify that specifying additional mirrors and origins works.
-                mirrors = " ".join(
-                    "-m {0}".format(u)
-                    for u in (self.rurl3, self.rurl4)
+        img_path = os.path.join(self.test_root, "test_4_img")
+        for opt in ("-p", "--publisher"):
+            self.pkg(
+                "image-create {0} test1={1} {2}".format(
+                    opt, self.rurl1, img_path
                 )
-                origins = " ".join(
-                    "-g {0}".format(u)
-                    for u in (self.rurl3, self.rurl4)
-                )
+            )
+            shutil.rmtree(img_path)
 
-                self.pkg("image-create -p test1={0} {1} {2} {3}".format(self.rurl1,
-                    mirrors, origins, img_path))
+        # Verify that specifying additional mirrors and origins works.
+        mirrors = " ".join("-m {0}".format(u) for u in (self.rurl3, self.rurl4))
+        origins = " ".join("-g {0}".format(u) for u in (self.rurl3, self.rurl4))
 
-                self.pkg("-R {0} publisher | grep origin.*{1}".format(img_path,
-                    self.rurl1))
-                for u in (self.rurl3, self.rurl4):
-                        self.pkg("-R {0} publisher | grep mirror.*{1}".format(
-                            img_path, u))
-                        self.pkg("-R {0} publisher | grep origin.*{1}".format(
-                            img_path, u))
-                shutil.rmtree(img_path, True)
+        self.pkg(
+            "image-create -p test1={0} {1} {2} {3}".format(
+                self.rurl1, mirrors, origins, img_path
+            )
+        )
 
-                # Verify that specifying --no-refresh when use-system-repo
-                # is set to true works.
-                saved_sysrepo_env = os.environ.get("PKG_SYSREPO_URL")
-                os.environ["PKG_SYSREPO_URL"] = "http://localhost:1"
-                self.pkg("image-create --no-refresh --set-property \
-                    use-system-repo=true {0}".format(img_path))
-                shutil.rmtree(img_path)
-                if saved_sysrepo_env:
-                        os.environ["PKG_SYSREPO_URL"] = saved_sysrepo_env
+        self.pkg(
+            "-R {0} publisher | grep origin.*{1}".format(img_path, self.rurl1)
+        )
+        for u in (self.rurl3, self.rurl4):
+            self.pkg("-R {0} publisher | grep mirror.*{1}".format(img_path, u))
+            self.pkg("-R {0} publisher | grep origin.*{1}".format(img_path, u))
+        shutil.rmtree(img_path, True)
 
+        # Verify that specifying --no-refresh when use-system-repo
+        # is set to true works.
+        saved_sysrepo_env = os.environ.get("PKG_SYSREPO_URL")
+        os.environ["PKG_SYSREPO_URL"] = "http://localhost:1"
+        self.pkg(
+            "image-create --no-refresh --set-property \
+                    use-system-repo=true {0}".format(
+                img_path
+            )
+        )
+        shutil.rmtree(img_path)
+        if saved_sysrepo_env:
+            os.environ["PKG_SYSREPO_URL"] = saved_sysrepo_env
 
-                # Verify that simple paths to file repositories can be used
-                # (not just file:// URIs).
-                mirrors = " ".join(
-                    "-m {0}".format(u)
-                    for u in (self.rpath3, self.rpath4)
-                )
-                origins = " ".join(
-                    "-g {0}".format(u)
-                    for u in (self.rpath3, self.rpath4)
-                )
+        # Verify that simple paths to file repositories can be used
+        # (not just file:// URIs).
+        mirrors = " ".join(
+            "-m {0}".format(u) for u in (self.rpath3, self.rpath4)
+        )
+        origins = " ".join(
+            "-g {0}".format(u) for u in (self.rpath3, self.rpath4)
+        )
 
-                self.pkg("image-create -p test1={0} {1} {2} {3}".format(self.rpath1,
-                    mirrors, origins, img_path))
+        self.pkg(
+            "image-create -p test1={0} {1} {2} {3}".format(
+                self.rpath1, mirrors, origins, img_path
+            )
+        )
 
-                self.pkg("-R {0} publisher | grep origin.*{1}".format(img_path,
-                    self.rurl1))
-                for u in (self.rurl3, self.rurl4):
-                        self.pkg("-R {0} publisher | grep mirror.*{1}".format(
-                            img_path, u))
-                        self.pkg("-R {0} publisher | grep origin.*{1}".format(
-                            img_path, u))
-                shutil.rmtree(img_path, True)
+        self.pkg(
+            "-R {0} publisher | grep origin.*{1}".format(img_path, self.rurl1)
+        )
+        for u in (self.rurl3, self.rurl4):
+            self.pkg("-R {0} publisher | grep mirror.*{1}".format(img_path, u))
+            self.pkg("-R {0} publisher | grep origin.*{1}".format(img_path, u))
+        shutil.rmtree(img_path, True)
 
-                # Verify that a v0 repo can be configured for a publisher.
-                # This should succeed as the API should fallback to manual
-                # configuration if auto-configuration isn't available.
-                self.pkg("image-create -p test5={0} {1}".format(self.durl5, img_path))
-                pub_cfg = {
-                    "publisher": { "prefix": "test5" },
-                    "repository": { "origins": self.durl5 }
-                }
-                self.__verify_pub_cfg(img_path, "test5", pub_cfg)
-                shutil.rmtree(img_path)
+        # Verify that a v0 repo can be configured for a publisher.
+        # This should succeed as the API should fallback to manual
+        # configuration if auto-configuration isn't available.
+        self.pkg("image-create -p test5={0} {1}".format(self.durl5, img_path))
+        pub_cfg = {
+            "publisher": {"prefix": "test5"},
+            "repository": {"origins": self.durl5},
+        }
+        self.__verify_pub_cfg(img_path, "test5", pub_cfg)
+        shutil.rmtree(img_path)
 
-                # Verify that -p auto-configuration works as expected for a
-                # a v1 repository when no prefix is provided.
-                self.pkg("image-create -p {0} {1}".format(self.rurl1, img_path))
-                pub_cfg = {
-                    "publisher": { "prefix": "test1" },
-                    "repository": { "origins": self.rurl1 }
-                }
-                self.__verify_pub_cfg(img_path, "test1", pub_cfg)
-                shutil.rmtree(img_path)
+        # Verify that -p auto-configuration works as expected for a
+        # a v1 repository when no prefix is provided.
+        self.pkg("image-create -p {0} {1}".format(self.rurl1, img_path))
+        pub_cfg = {
+            "publisher": {"prefix": "test1"},
+            "repository": {"origins": self.rurl1},
+        }
+        self.__verify_pub_cfg(img_path, "test1", pub_cfg)
+        shutil.rmtree(img_path)
 
-                # Verify that -p auto-configuration works as expected for a
-                # a v1 repository when a prefix is provided.
-                self.pkg("image-create -p test1={0} {1}".format(self.rurl1, img_path))
-                pub_cfg = {
-                    "publisher": { "prefix": "test1" },
-                    "repository": { "origins": self.rurl1 }
-                }
-                self.__verify_pub_cfg(img_path, "test1", pub_cfg)
-                shutil.rmtree(img_path)
+        # Verify that -p auto-configuration works as expected for a
+        # a v1 repository when a prefix is provided.
+        self.pkg("image-create -p test1={0} {1}".format(self.rurl1, img_path))
+        pub_cfg = {
+            "publisher": {"prefix": "test1"},
+            "repository": {"origins": self.rurl1},
+        }
+        self.__verify_pub_cfg(img_path, "test1", pub_cfg)
+        shutil.rmtree(img_path)
 
-                # Verify that -p auto-configuration works as expected for a
-                # a v1 repository with additional origins and mirrors.
-                self.pkg("image-create -p test1={0} -g {1} -m {2} {3}".format(
-                    self.rurl1, self.rurl3, self.durl5, img_path))
-                pub_cfg = {
-                    "publisher": { "prefix": "test1" },
-                    "repository": {
-                        "origins": "{0},{1}".format(self.rurl1,self.rurl3),
-                        "mirrors": self.durl5,
-                    },
-                }
-                self.__verify_pub_cfg(img_path, "test1", pub_cfg)
-                shutil.rmtree(img_path)
+        # Verify that -p auto-configuration works as expected for a
+        # a v1 repository with additional origins and mirrors.
+        self.pkg(
+            "image-create -p test1={0} -g {1} -m {2} {3}".format(
+                self.rurl1, self.rurl3, self.durl5, img_path
+            )
+        )
+        pub_cfg = {
+            "publisher": {"prefix": "test1"},
+            "repository": {
+                "origins": "{0},{1}".format(self.rurl1, self.rurl3),
+                "mirrors": self.durl5,
+            },
+        }
+        self.__verify_pub_cfg(img_path, "test1", pub_cfg)
+        shutil.rmtree(img_path)
 
-        def test_5_bad_values_no_image(self):
-                """Verify that an invalid publisher URI or other piece of
-                information provided to image-create will not result in an
-                empty image being created despite failure.  In addition,
-                test that omitting required information will also not result
-                in the creation of an image."""
+    def test_5_bad_values_no_image(self):
+        """Verify that an invalid publisher URI or other piece of
+        information provided to image-create will not result in an
+        empty image being created despite failure.  In addition,
+        test that omitting required information will also not result
+        in the creation of an image."""
 
-                p = os.path.join(self.get_img_path(), "test_5_image")
+        p = os.path.join(self.get_img_path(), "test_5_image")
 
-                # Invalid URIs should not result in the creation of an image.
-                self.pkg("image-create -p test=InvalidURI {0}".format(p), exit=1)
-                self.assertFalse(os.path.exists(p))
+        # Invalid URIs should not result in the creation of an image.
+        self.pkg("image-create -p test=InvalidURI {0}".format(p), exit=1)
+        self.assertFalse(os.path.exists(p))
 
-                self.pkg("image-create -p InvalidURI {0}".format(p), exit=1)
-                self.assertFalse(os.path.exists(p))
+        self.pkg("image-create -p InvalidURI {0}".format(p), exit=1)
+        self.assertFalse(os.path.exists(p))
 
-                # Valid URI but without prefix and with --no-refresh; auto-
-                # configuration isn't possible in this scenario and so
-                # an image should not be created.
-                self.pkg("image-create --no-refresh -p {0} {1}".format(self.rurl1, p),
-                    exit=2)
-                self.assertFalse(os.path.exists(p))
+        # Valid URI but without prefix and with --no-refresh; auto-
+        # configuration isn't possible in this scenario and so
+        # an image should not be created.
+        self.pkg(
+            "image-create --no-refresh -p {0} {1}".format(self.rurl1, p), exit=2
+        )
+        self.assertFalse(os.path.exists(p))
 
-                # Valid URI but with the wrong publisher prefix should
-                # not create an image.
-                self.pkg("image-create -p nosuchpub={0} {1}".format(self.rurl1, p),
-                    exit=1)
-                self.assertFalse(os.path.exists(p))
+        # Valid URI but with the wrong publisher prefix should
+        # not create an image.
+        self.pkg(
+            "image-create -p nosuchpub={0} {1}".format(self.rurl1, p), exit=1
+        )
+        self.assertFalse(os.path.exists(p))
 
-                # Valid URI, without a publisher prefix, but for a repository
-                # that doesn't provide publisher configuration should not
-                # create an image.
-                self.pkg("image-create -p {0} {1}".format(self.durl5, p),
-                    exit=1)
-                self.assertFalse(os.path.exists(p))
+        # Valid URI, without a publisher prefix, but for a repository
+        # that doesn't provide publisher configuration should not
+        # create an image.
+        self.pkg("image-create -p {0} {1}".format(self.durl5, p), exit=1)
+        self.assertFalse(os.path.exists(p))
 
-        def test_6_relative_root_create(self):
-                """Verify that an image with a relative path for the root is
-                created correctly."""
+    def test_6_relative_root_create(self):
+        """Verify that an image with a relative path for the root is
+        created correctly."""
 
-                pwd = os.getcwd()
-                img_path = "test_6_image"
-                abs_img_path = os.path.join(self.test_root, img_path)
+        pwd = os.getcwd()
+        img_path = "test_6_image"
+        abs_img_path = os.path.join(self.test_root, img_path)
 
-                # Now verify that the image root isn't duplicated within the
-                # specified image root if the specified root doesn't already
-                # exist.
-                os.chdir(self.test_root)
-                self.pkg("image-create -p test1={0} {1}".format(self.rurl1,
-                    img_path))
-                os.chdir(pwd)
-                self.assertFalse(os.path.exists(os.path.join(abs_img_path,
-                    img_path)))
-                shutil.rmtree(abs_img_path)
+        # Now verify that the image root isn't duplicated within the
+        # specified image root if the specified root doesn't already
+        # exist.
+        os.chdir(self.test_root)
+        self.pkg("image-create -p test1={0} {1}".format(self.rurl1, img_path))
+        os.chdir(pwd)
+        self.assertFalse(os.path.exists(os.path.join(abs_img_path, img_path)))
+        shutil.rmtree(abs_img_path)
 
-                # Now verify that the image root isn't duplicated within the
-                # specified image root if the specified root already exists.
-                os.chdir(self.test_root)
-                os.mkdir(img_path)
-                self.pkg("image-create -p test1={0} {1}".format(self.rurl1,
-                    img_path))
-                os.chdir(pwd)
-                self.assertFalse(os.path.exists(os.path.join(abs_img_path,
-                    img_path)))
-                shutil.rmtree(abs_img_path)
+        # Now verify that the image root isn't duplicated within the
+        # specified image root if the specified root already exists.
+        os.chdir(self.test_root)
+        os.mkdir(img_path)
+        self.pkg("image-create -p test1={0} {1}".format(self.rurl1, img_path))
+        os.chdir(pwd)
+        self.assertFalse(os.path.exists(os.path.join(abs_img_path, img_path)))
+        shutil.rmtree(abs_img_path)
 
-        def test_7_image_create_no_refresh(self):
-                """Verify that image-create --no-refresh works as expected.
-                See bug 8777 for related issue."""
+    def test_7_image_create_no_refresh(self):
+        """Verify that image-create --no-refresh works as expected.
+        See bug 8777 for related issue."""
 
-                pkgsend_data = """
+        pkgsend_data = """
                 open baz@0.0
                 close
                 """
-                self.pkgsend_bulk(self.rurl1, pkgsend_data)
+        self.pkgsend_bulk(self.rurl1, pkgsend_data)
 
-                # First, check to be certain that an image-create --no-refresh
-                # will succeed.
-                self.pkg_image_create(self.rurl2, prefix="test1",
-                    additional_args="--no-refresh")
-                self.pkg("list --no-refresh -a | grep baz", exit=1)
+        # First, check to be certain that an image-create --no-refresh
+        # will succeed.
+        self.pkg_image_create(
+            self.rurl2, prefix="test1", additional_args="--no-refresh"
+        )
+        self.pkg("list --no-refresh -a | grep baz", exit=1)
 
-                # Finally, verify that using set-publisher will cause a refresh
-                # which in turn should cause 'baz' to be listed *if* the origin
-                # has changed (setting it to the same value again won't work).
-                self.pkg("set-publisher -O {0} test1".format(self.rurl1))
-                self.pkg("list --no-refresh -a | grep baz")
+        # Finally, verify that using set-publisher will cause a refresh
+        # which in turn should cause 'baz' to be listed *if* the origin
+        # has changed (setting it to the same value again won't work).
+        self.pkg("set-publisher -O {0} test1".format(self.rurl1))
+        self.pkg("list --no-refresh -a | grep baz")
 
-        def test_8_image_upgrade(self):
-                """Verify that a version 2 or version 3 image can be used by a
-                client that creates version 4 images, and that it will be
-                upgraded correctly when a privileged user uses it."""
+    def test_8_image_upgrade(self):
+        """Verify that a version 2 or version 3 image can be used by a
+        client that creates version 4 images, and that it will be
+        upgraded correctly when a privileged user uses it."""
 
-                # Publish some sample packages (to separate repositories).
-                self.pkgsend_bulk(self.rurl1, "open quux@1.0\nclose")
-                self.pkgsend_bulk(self.rurl2, "open corge@1.0\nclose")
+        # Publish some sample packages (to separate repositories).
+        self.pkgsend_bulk(self.rurl1, "open quux@1.0\nclose")
+        self.pkgsend_bulk(self.rurl2, "open corge@1.0\nclose")
 
-                # First, create a new image.
-                self.pkg_image_create(self.rurl1, prefix="test1")
+        # First, create a new image.
+        self.pkg_image_create(self.rurl1, prefix="test1")
 
-                # Create a 'repo' directory in image directory so that we
-                # can verify that it survives the various upgrades.
-                rpath = os.path.join(self.get_img_path(), "repo")
-                self.pkgrepo("create {0}".format(rpath))
+        # Create a 'repo' directory in image directory so that we
+        # can verify that it survives the various upgrades.
+        rpath = os.path.join(self.get_img_path(), "repo")
+        self.pkgrepo("create {0}".format(rpath))
 
-                # Create an 'ssl' directory in image directory so that we
-                # can verify that it survives the various upgrades.
-                sslpath = os.path.join(self.get_img_path(), "ssl")
-                sslfile = os.path.join(sslpath, "my.cert")
-                os.mkdir(sslpath)
-                open(sslfile, "wb").close()
+        # Create an 'ssl' directory in image directory so that we
+        # can verify that it survives the various upgrades.
+        sslpath = os.path.join(self.get_img_path(), "ssl")
+        sslfile = os.path.join(sslpath, "my.cert")
+        os.mkdir(sslpath)
+        open(sslfile, "wb").close()
 
-                # Add the second repository.
-                self.pkg("set-publisher -O {0} test2".format(self.rurl2))
+        # Add the second repository.
+        self.pkg("set-publisher -O {0} test2".format(self.rurl2))
 
-                # Next, install the packages.
-                self.pkg("install quux")
-                self.pkg("set-publisher -P test2")
+        # Next, install the packages.
+        self.pkg("install quux")
+        self.pkg("set-publisher -P test2")
 
-                # This is necessary to ensure that packages installed from a
-                # previously preferred publisher also get the correct status.
-                self.pkg("install corge")
-                self.pkg("set-publisher -P test1")
+        # This is necessary to ensure that packages installed from a
+        # previously preferred publisher also get the correct status.
+        self.pkg("install corge")
+        self.pkg("set-publisher -P test1")
 
-                # Next, disable the second repository's publisher.
-                self.pkg("set-publisher -d test2")
+        # Next, disable the second repository's publisher.
+        self.pkg("set-publisher -d test2")
 
-                # Next, convert the v4 image to a v2 image.
-                img_root = os.path.join(self.get_img_path(), "var", "pkg")
+        # Next, convert the v4 image to a v2 image.
+        img_root = os.path.join(self.get_img_path(), "var", "pkg")
 
-                cat_path = os.path.join(img_root, "catalog")
-                pub_path = os.path.join(img_root, "publisher")
+        cat_path = os.path.join(img_root, "catalog")
+        pub_path = os.path.join(img_root, "publisher")
 
-                v1_cat = pkg.catalog.Catalog(meta_root=os.path.join(pub_path,
-                    "test1", "catalog"), read_only=True)
-                v0_cat_path = os.path.join(cat_path, "test1")
+        v1_cat = pkg.catalog.Catalog(
+            meta_root=os.path.join(pub_path, "test1", "catalog"), read_only=True
+        )
+        v0_cat_path = os.path.join(cat_path, "test1")
 
-                # For conversion, the v0 catalogs need to be generated in
-                # the v2 location.
-                os.makedirs(v0_cat_path)
-                self.__transform_v1_v0(v1_cat, v0_cat_path)
+        # For conversion, the v0 catalogs need to be generated in
+        # the v2 location.
+        os.makedirs(v0_cat_path)
+        self.__transform_v1_v0(v1_cat, v0_cat_path)
 
-                # Manifests have to be linked into their v2/v3 location.
-                def link_manifests():
-                        for pub in os.listdir(pub_path):
-                                pkg_root = os.path.join(pub_path, pub, "pkg")
-                                for stem in os.listdir(pkg_root):
-                                        stem_root = os.path.join(pkg_root, stem)
-                                        for ver in os.listdir(stem_root):
-                                                src = os.path.join(stem_root,
-                                                    ver)
-                                                dest = os.path.join(img_root,
-                                                    "pkg", stem, ver,
-                                                    "manifest")
-                                                misc.makedirs(
-                                                    os.path.dirname(dest))
-                                                os.link(src, dest)
-                link_manifests()
+        # Manifests have to be linked into their v2/v3 location.
+        def link_manifests():
+            for pub in os.listdir(pub_path):
+                pkg_root = os.path.join(pub_path, pub, "pkg")
+                for stem in os.listdir(pkg_root):
+                    stem_root = os.path.join(pkg_root, stem)
+                    for ver in os.listdir(stem_root):
+                        src = os.path.join(stem_root, ver)
+                        dest = os.path.join(
+                            img_root, "pkg", stem, ver, "manifest"
+                        )
+                        misc.makedirs(os.path.dirname(dest))
+                        os.link(src, dest)
 
-                # The existing installed state has to be converted to v2.
-                state_dir = os.path.join(img_root, "state")
-                inst_state_dir = os.path.join(state_dir, "installed")
-                cat = pkg.catalog.Catalog(meta_root=inst_state_dir)
-                for f in cat.fmris():
-                        self.__add_install_file(img_root, f)
-                cat = None
+        link_manifests()
 
-                # Now dump any v4 directories not found in v2 images.
-                shutil.rmtree(pub_path)
-                for entry in ("cache", "license", "ssl", "state/known"):
-                        shutil.rmtree(os.path.join(img_root, entry))
+        # The existing installed state has to be converted to v2.
+        state_dir = os.path.join(img_root, "state")
+        inst_state_dir = os.path.join(state_dir, "installed")
+        cat = pkg.catalog.Catalog(meta_root=inst_state_dir)
+        for f in cat.fmris():
+            self.__add_install_file(img_root, f)
+        cat = None
 
-                for fname in sorted(os.listdir(inst_state_dir)):
-                        if fname.startswith("catalog"):
-                                pkg.portable.remove(os.path.join(inst_state_dir,
-                                    fname))
+        # Now dump any v4 directories not found in v2 images.
+        shutil.rmtree(pub_path)
+        for entry in ("cache", "license", "ssl", "state/known"):
+            shutil.rmtree(os.path.join(img_root, entry))
 
-                # Finally, rename image configuration and revert it.
-                src = os.path.join(img_root, "pkg5.image")
-                dest = os.path.join(img_root, "cfg_cache")
-                newcfg = cfg.FileConfig(src)
-                newcfg._version = 2
-                newcfg.set_property("image", "version", 2)
+        for fname in sorted(os.listdir(inst_state_dir)):
+            if fname.startswith("catalog"):
+                pkg.portable.remove(os.path.join(inst_state_dir, fname))
 
-                # Older clients stored origin information in 'origin' instead of
-                # 'origins'.
-                for pfx in ("test1", "test2"):
-                        origin = newcfg.get_property("authority_{0}".format(pfx),
-                            "origins")[2:-2]
-                        newcfg.set_property("authority_{0}".format(pfx), "origin",
-                            origin)
+        # Finally, rename image configuration and revert it.
+        src = os.path.join(img_root, "pkg5.image")
+        dest = os.path.join(img_root, "cfg_cache")
+        newcfg = cfg.FileConfig(src)
+        newcfg._version = 2
+        newcfg.set_property("image", "version", 2)
 
-                # Older clients store disabled authorities in separate config
-                # file.
-                disabled_src = os.path.join(img_root, "disabled_auth")
-                discfg = cfg.FileConfig(disabled_src, version=2)
+        # Older clients stored origin information in 'origin' instead of
+        # 'origins'.
+        for pfx in ("test1", "test2"):
+            origin = newcfg.get_property(
+                "authority_{0}".format(pfx), "origins"
+            )[2:-2]
+            newcfg.set_property("authority_{0}".format(pfx), "origin", origin)
 
-                for p in ("publisher-search-order", "signature-required-names"):
-                        newcfg.remove_property("property", p)
-                for p in ("origins", "property.signature-required-names",
-                    "intermediate_certs", "approved_ca_certs",
-                    "revoked_ca_certs", "signing_ca_certs",
-                    "origin_info", "mirror_info"):
-                        newcfg.remove_property("authority_test1", p)
-                        newcfg.remove_property("authority_test2", p)
+        # Older clients store disabled authorities in separate config
+        # file.
+        disabled_src = os.path.join(img_root, "disabled_auth")
+        discfg = cfg.FileConfig(disabled_src, version=2)
 
-                discfg.add_section(newcfg.get_section("authority_test2"))
-                newcfg.remove_section("authority_test2")
-                newcfg.write()
-                pkg.portable.rename(src, dest)
-                discfg.write()
+        for p in ("publisher-search-order", "signature-required-names"):
+            newcfg.remove_property("property", p)
+        for p in (
+            "origins",
+            "property.signature-required-names",
+            "intermediate_certs",
+            "approved_ca_certs",
+            "revoked_ca_certs",
+            "signing_ca_certs",
+            "origin_info",
+            "mirror_info",
+        ):
+            newcfg.remove_property("authority_test1", p)
+            newcfg.remove_property("authority_test2", p)
 
-                # Next, verify that the new client can read v2 images as an
-                # an unprivileged user.  Each must be done with and without
-                # the publisher prefix to test that these are stripped and
-                # read properly (because of the publisher preferred prefix).
-                self.pkg("publisher", su_wrap=True)
-                self.pkg("info pkg://test1/quux corge", su_wrap=True)
-                self.pkg("info pkg://test2/corge quux", su_wrap=True)
-                self.pkg("update -nv --no-refresh", su_wrap=True, exit=4)
+        discfg.add_section(newcfg.get_section("authority_test2"))
+        newcfg.remove_section("authority_test2")
+        newcfg.write()
+        pkg.portable.rename(src, dest)
+        discfg.write()
 
-                # Verify pkg refresh fails when not simulating a live root
-                # since image needs format update.
-                self.pkg("refresh", exit=1)
+        # Next, verify that the new client can read v2 images as an
+        # an unprivileged user.  Each must be done with and without
+        # the publisher prefix to test that these are stripped and
+        # read properly (because of the publisher preferred prefix).
+        self.pkg("publisher", su_wrap=True)
+        self.pkg("info pkg://test1/quux corge", su_wrap=True)
+        self.pkg("info pkg://test2/corge quux", su_wrap=True)
+        self.pkg("update -nv --no-refresh", su_wrap=True, exit=4)
 
-                # Next, verify that the client won't automatically upgrade
-                # images unless the image is the liveroot.
-                self.pkg("--debug simulate_live_root={0} info quux "
-                    "pkg://test1/quux pkg://test2/corge".format(self.get_img_path()))
+        # Verify pkg refresh fails when not simulating a live root
+        # since image needs format update.
+        self.pkg("refresh", exit=1)
 
-                # Next, verify that the new client can upgrade v2 images to
-                # v4 images if the image is the liveroot.
-                self.pkg("info quux pkg://test1/quux pkg://test2/corge")
+        # Next, verify that the client won't automatically upgrade
+        # images unless the image is the liveroot.
+        self.pkg(
+            "--debug simulate_live_root={0} info quux "
+            "pkg://test1/quux pkg://test2/corge".format(self.get_img_path())
+        )
 
-                # Next, verify that the old structures and state information
-                # are gone and a part of the new structure is present.
-                self.assertFalse(os.path.exists(cat_path))
-                self.assertTrue(os.path.exists(pub_path))
+        # Next, verify that the new client can upgrade v2 images to
+        # v4 images if the image is the liveroot.
+        self.pkg("info quux pkg://test1/quux pkg://test2/corge")
 
-                for pl in sorted(os.listdir(inst_state_dir)):
-                        # If there any other files but catalog files here, then
-                        # the old state information didn't get properly removed.
-                        self.assertTrue(pl.startswith("catalog."))
+        # Next, verify that the old structures and state information
+        # are gone and a part of the new structure is present.
+        self.assertFalse(os.path.exists(cat_path))
+        self.assertTrue(os.path.exists(pub_path))
 
-                # Verify origin configuration is intact.
-                expected = """\
+        for pl in sorted(os.listdir(inst_state_dir)):
+            # If there any other files but catalog files here, then
+            # the old state information didn't get properly removed.
+            self.assertTrue(pl.startswith("catalog."))
+
+        # Verify origin configuration is intact.
+        expected = """\
 test1\ttrue\tfalse\ttrue\torigin\tonline\t{0}/\t-
 test2\ttrue\tfalse\ttrue\torigin\tonline\t{1}/\t-
-""".format(self.rurl1, self.rurl2)
-                self.pkg("publisher -HF tsv")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+""".format(
+            self.rurl1, self.rurl2
+        )
+        self.pkg("publisher -HF tsv")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify origin information matches expected if configuration
-                # changes are made.
-                expected = """\
+        # Verify origin information matches expected if configuration
+        # changes are made.
+        expected = """\
 test1\ttrue\tfalse\ttrue\torigin\tonline\t{0}/\t-
 test2\ttrue\tfalse\ttrue\torigin\tonline\t{1}/\t-
-""".format(self.rurl2, self.rurl2)
-                self.pkg("set-publisher --no-refresh -O {0} test1".format(self.rurl2))
-                self.pkg("publisher -HF tsv")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+""".format(
+            self.rurl2, self.rurl2
+        )
+        self.pkg("set-publisher --no-refresh -O {0} test1".format(self.rurl2))
+        self.pkg("publisher -HF tsv")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Reset configuration.
-                self.pkg("set-publisher --no-refresh -O {0} test1".format(self.rurl1))
+        # Reset configuration.
+        self.pkg("set-publisher --no-refresh -O {0} test1".format(self.rurl1))
 
-                # Now convert the v4 image to a v3 image.
-                link_manifests()
+        # Now convert the v4 image to a v3 image.
+        link_manifests()
 
-                # Dump any v4 directories not found in v3 images.
-                for entry in ("cache", "license", "ssl"):
-                        shutil.rmtree(os.path.join(img_root, entry))
+        # Dump any v4 directories not found in v3 images.
+        for entry in ("cache", "license", "ssl"):
+            shutil.rmtree(os.path.join(img_root, entry))
 
-                # Next, revert image configuration.
-                src = os.path.join(img_root, "pkg5.image")
-                newcfg = cfg.FileConfig(src)
-                newcfg._version = 3
-                newcfg.set_property("image", "version", 3)
-                newcfg.write()
-                newcfg.reset()
-                newcfg.write()
+        # Next, revert image configuration.
+        src = os.path.join(img_root, "pkg5.image")
+        newcfg = cfg.FileConfig(src)
+        newcfg._version = 3
+        newcfg.set_property("image", "version", 3)
+        newcfg.write()
+        newcfg.reset()
+        newcfg.write()
 
-                # Next, verify that the new client can read v3 images as an
-                # an unprivileged user.  Each must be done with and without
-                # the publisher prefix to test that these are stripped and
-                # read properly.
-                self.pkg("--debug simulate_live_root={0} publisher".format(
-                    self.get_img_path()), su_wrap=True)
-                self.pkg("--debug simulate_live_root={0} info "
-                    "pkg://test1/quux corge".format(self.get_img_path()),
-                    su_wrap=True)
-                self.pkg("--debug simulate_live_root={0} info "
-                    "pkg://test2/corge quux".format(self.get_img_path()),
-                    su_wrap=True)
-                self.pkg("--debug simulate_live_root={0} update -nv "
-                    "--no-refresh".format(self.get_img_path()), su_wrap=True, exit=4)
+        # Next, verify that the new client can read v3 images as an
+        # an unprivileged user.  Each must be done with and without
+        # the publisher prefix to test that these are stripped and
+        # read properly.
+        self.pkg(
+            "--debug simulate_live_root={0} publisher".format(
+                self.get_img_path()
+            ),
+            su_wrap=True,
+        )
+        self.pkg(
+            "--debug simulate_live_root={0} info "
+            "pkg://test1/quux corge".format(self.get_img_path()),
+            su_wrap=True,
+        )
+        self.pkg(
+            "--debug simulate_live_root={0} info "
+            "pkg://test2/corge quux".format(self.get_img_path()),
+            su_wrap=True,
+        )
+        self.pkg(
+            "--debug simulate_live_root={0} update -nv "
+            "--no-refresh".format(self.get_img_path()),
+            su_wrap=True,
+            exit=4,
+        )
 
-                # Next, verify that the new client can upgrade v3 images to
-                # v4 images.
-                self.pkg("--debug simulate_live_root={0} info quux "
-                    "pkg://test1/quux pkg://test2/corge".format(self.get_img_path()))
+        # Next, verify that the new client can upgrade v3 images to
+        # v4 images.
+        self.pkg(
+            "--debug simulate_live_root={0} info quux "
+            "pkg://test1/quux pkg://test2/corge".format(self.get_img_path())
+        )
 
-                # Next, verify that the old structures and state information
-                # are gone and a part of the new structure is present.
-                self.assertFalse(os.path.exists(
-                    os.path.join(img_root, "index")))
-                self.assertTrue(os.path.exists(
-                    os.path.join(img_root, "cache")))
+        # Next, verify that the old structures and state information
+        # are gone and a part of the new structure is present.
+        self.assertFalse(os.path.exists(os.path.join(img_root, "index")))
+        self.assertTrue(os.path.exists(os.path.join(img_root, "cache")))
 
-                # Now convert the v4 image to a v3 image again.
-                link_manifests()
+        # Now convert the v4 image to a v3 image again.
+        link_manifests()
 
-                # Dump any v4 directories not found in v3 images.
-                for entry in ("cache", "license", "ssl"):
-                        shutil.rmtree(os.path.join(img_root, entry))
+        # Dump any v4 directories not found in v3 images.
+        for entry in ("cache", "license", "ssl"):
+            shutil.rmtree(os.path.join(img_root, entry))
 
-                # Next, revert image configuration.
-                src = os.path.join(img_root, "pkg5.image")
-                newcfg = cfg.FileConfig(src)
-                newcfg._version = 3
-                newcfg.set_property("image", "version", 3)
-                newcfg.write()
-                newcfg.reset()
-                newcfg.write()
+        # Next, revert image configuration.
+        src = os.path.join(img_root, "pkg5.image")
+        newcfg = cfg.FileConfig(src)
+        newcfg._version = 3
+        newcfg.set_property("image", "version", 3)
+        newcfg.write()
+        newcfg.reset()
+        newcfg.write()
 
-                # Verify pkg update-format fails as an unprivileged user.
-                self.pkg("update-format", su_wrap=True, exit=1)
+        # Verify pkg update-format fails as an unprivileged user.
+        self.pkg("update-format", su_wrap=True, exit=1)
 
-                # Verify pkg refresh succeeds even when image needs format
-                # update for a v3 image.
-                self.pkg("refresh")
+        # Verify pkg refresh succeeds even when image needs format
+        # update for a v3 image.
+        self.pkg("refresh")
 
-                # Verify update-format will upgrade a v3 image to a v4 image.
-                self.pkg("update-format")
-                self.assertFalse(os.path.exists(
-                    os.path.join(img_root, "index")))
-                self.assertTrue(os.path.exists(
-                    os.path.join(img_root, "cache")))
-                self.pkg("verify")
+        # Verify update-format will upgrade a v3 image to a v4 image.
+        self.pkg("update-format")
+        self.assertFalse(os.path.exists(os.path.join(img_root, "index")))
+        self.assertTrue(os.path.exists(os.path.join(img_root, "cache")))
+        self.pkg("verify")
 
-                # Verify updated image works as expected.
-                self.pkg("publisher", su_wrap=True)
-                self.pkg("info pkg://test1/quux corge", su_wrap=True)
-                self.pkg("info pkg://test2/corge quux", su_wrap=True)
-                self.pkg("update -nv --no-refresh", su_wrap=True, exit=4)
+        # Verify updated image works as expected.
+        self.pkg("publisher", su_wrap=True)
+        self.pkg("info pkg://test1/quux corge", su_wrap=True)
+        self.pkg("info pkg://test2/corge quux", su_wrap=True)
+        self.pkg("update -nv --no-refresh", su_wrap=True, exit=4)
 
-                # Verify an already updated image will cause update-format to
-                # exit 4.
-                self.pkg("update-format", exit=4)
+        # Verify an already updated image will cause update-format to
+        # exit 4.
+        self.pkg("update-format", exit=4)
 
-                # Finally, check that repository and ssl data still exists
-                # through all the upgrades.
-                self.assertTrue(os.path.exists(os.path.join(rpath,
-                    "pkg5.repository")))
-                self.assertTrue(os.path.exists(sslfile))
+        # Finally, check that repository and ssl data still exists
+        # through all the upgrades.
+        self.assertTrue(os.path.exists(os.path.join(rpath, "pkg5.repository")))
+        self.assertTrue(os.path.exists(sslfile))
 
-        def test_9_bad_image_state(self):
-                """Verify that the pkg(1) command handles invalid image state
-                gracefully."""
+    def test_9_bad_image_state(self):
+        """Verify that the pkg(1) command handles invalid image state
+        gracefully."""
 
-                # Publish a package.
-                self.pkgsend_bulk(self.rurl1, """
+        # Publish a package.
+        self.pkgsend_bulk(
+            self.rurl1,
+            """
                 open foo@0.0
                 close
-                """)
+                """,
+        )
 
-                # First, create a new image.
-                self.pkg_image_create(self.rurl1, prefix="test1")
+        # First, create a new image.
+        self.pkg_image_create(self.rurl1, prefix="test1")
 
-                # Verify pkg info works as expected.
-                self.pkg("info -r foo")
+        # Verify pkg info works as expected.
+        self.pkg("info -r foo")
 
-                # Now invalidate the existing image data.
-                state_path = self.get_img_api_obj().img._statedir
-                kfile_path = os.path.join(state_path, "known", "catalog.attrs")
-                ifile_path = os.path.join(state_path, "installed",
-                    "catalog.attrs")
+        # Now invalidate the existing image data.
+        state_path = self.get_img_api_obj().img._statedir
+        kfile_path = os.path.join(state_path, "known", "catalog.attrs")
+        ifile_path = os.path.join(state_path, "installed", "catalog.attrs")
 
-                self.pkg("install foo")
+        self.pkg("install foo")
 
-                with open(kfile_path, "w") as f:
-                        f.write("InvalidCatalogFile")
-                        f.flush()
+        with open(kfile_path, "w") as f:
+            f.write("InvalidCatalogFile")
+            f.flush()
 
-                # Should work since known catalog file was corrupted, not the
-                # installed catalog file.
-                self.pkg("info foo")
+        # Should work since known catalog file was corrupted, not the
+        # installed catalog file.
+        self.pkg("info foo")
 
-                # These should all fail as they depend on the known catalog
-                # file.
-                self.pkg("list -a", exit=1)
-                self.pkg("install -nv foo", exit=1)
-                self.pkg("update -nv", exit=1)
-                self.pkg("info -r foo", exit=1)
+        # These should all fail as they depend on the known catalog
+        # file.
+        self.pkg("list -a", exit=1)
+        self.pkg("install -nv foo", exit=1)
+        self.pkg("update -nv", exit=1)
+        self.pkg("info -r foo", exit=1)
 
-                with open(ifile_path, "w") as f:
-                        f.write("InvalidCatalogFile")
-                        f.flush()
+        with open(ifile_path, "w") as f:
+            f.write("InvalidCatalogFile")
+            f.flush()
 
-                # Should fail since installed catalog file is corrupt.
-                self.pkg("info foo", exit=1)
-                self.pkg("list", exit=1)
+        # Should fail since installed catalog file is corrupt.
+        self.pkg("info foo", exit=1)
+        self.pkg("list", exit=1)
 
-        def test_10_unprivileged(self):
-                """Verify that pkg correctly handles permission errors during
-                image-create."""
+    def test_10_unprivileged(self):
+        """Verify that pkg correctly handles permission errors during
+        image-create."""
 
-                p = os.path.join(self.test_root, "unpriv_test_10")
-                os.mkdir(p)
+        p = os.path.join(self.test_root, "unpriv_test_10")
+        os.mkdir(p)
 
-                self.pkg("image-create -p test1={0} {1}/image".format(
-                    self.rurl1, p), su_wrap=True, exit=1)
+        self.pkg(
+            "image-create -p test1={0} {1}/image".format(self.rurl1, p),
+            su_wrap=True,
+            exit=1,
+        )
 
 
 class TestImageCreateNoDepot(pkg5unittest.CliTestCase):
-        persistent_setup = True
-        def test_bad_image_create(self):
-                """ Create image from non-existent server """
+    persistent_setup = True
 
-                #
-                # Currently port 4 is unassigned by IANA and we
-                # Can just hope that it never gets assigned.
-                # We choose localhost because, well, we think
-                # it will be universally able to be looked up.
-                #
-                durl = "http://localhost:4"
-                self.assertRaises(pkg5unittest.UnexpectedExitCodeException, \
-                    self.pkg_image_create, durl)
+    def test_bad_image_create(self):
+        """Create image from non-existent server"""
 
-        def test_765(self):
-                """Bug 765: malformed publisher URL."""
+        #
+        # Currently port 4 is unassigned by IANA and we
+        # Can just hope that it never gets assigned.
+        # We choose localhost because, well, we think
+        # it will be universally able to be looked up.
+        #
+        durl = "http://localhost:4"
+        self.assertRaises(
+            pkg5unittest.UnexpectedExitCodeException,
+            self.pkg_image_create,
+            durl,
+        )
 
-                durl = "bar=baz"
-                self.assertRaises(pkg5unittest.UnexpectedExitCodeException, \
-                    self.pkg_image_create, durl)
+    def test_765(self):
+        """Bug 765: malformed publisher URL."""
 
-        def test_763c(self):
-                """Bug 763, traceback 3: -p given to image-create, but no
-                publisher specified."""
+        durl = "bar=baz"
+        self.assertRaises(
+            pkg5unittest.UnexpectedExitCodeException,
+            self.pkg_image_create,
+            durl,
+        )
 
-                self.assertRaises(pkg5unittest.UnexpectedExitCodeException, \
-                    self.pkg, "image-create -p foo")
+    def test_763c(self):
+        """Bug 763, traceback 3: -p given to image-create, but no
+        publisher specified."""
 
-        def test_bad_publisher_options(self):
-                """More tests that abuse the publisher prefix and URL."""
+        self.assertRaises(
+            pkg5unittest.UnexpectedExitCodeException,
+            self.pkg,
+            "image-create -p foo",
+        )
 
-                self.assertRaises(pkg5unittest.UnexpectedExitCodeException, \
-                    self.pkg, "image-create -p $%^8" + ("=http://{0}1".format(
-                    self.bogus_url)))
+    def test_bad_publisher_options(self):
+        """More tests that abuse the publisher prefix and URL."""
 
-                self.assertRaises(pkg5unittest.UnexpectedExitCodeException, \
-                    self.pkg, "image-create -p test1=http://$%^8")
+        self.assertRaises(
+            pkg5unittest.UnexpectedExitCodeException,
+            self.pkg,
+            "image-create -p $%^8" + ("=http://{0}1".format(self.bogus_url)),
+        )
 
-                self.assertRaises(pkg5unittest.UnexpectedExitCodeException, \
-                    self.pkg, "image-create -p test1=http://{0}1:abcde".format(
-                    self.bogus_url))
+        self.assertRaises(
+            pkg5unittest.UnexpectedExitCodeException,
+            self.pkg,
+            "image-create -p test1=http://$%^8",
+        )
 
-                self.assertRaises(pkg5unittest.UnexpectedExitCodeException, \
-                    self.pkg, "image-create -p test1=ftp://{0}1".format(
-                    self.bogus_url))
+        self.assertRaises(
+            pkg5unittest.UnexpectedExitCodeException,
+            self.pkg,
+            "image-create -p test1=http://{0}1:abcde".format(self.bogus_url),
+        )
 
-                self.assertRaises(pkg5unittest.UnexpectedExitCodeException, \
-                    self.pkg, "image-create -p test1=ftp://{0}1 -p test2=http://{1}2:abc".format(
-                    self.bogus_url, self.bogus_url))
+        self.assertRaises(
+            pkg5unittest.UnexpectedExitCodeException,
+            self.pkg,
+            "image-create -p test1=ftp://{0}1".format(self.bogus_url),
+        )
+
+        self.assertRaises(
+            pkg5unittest.UnexpectedExitCodeException,
+            self.pkg,
+            "image-create -p test1=ftp://{0}1 -p test2=http://{1}2:abc".format(
+                self.bogus_url, self.bogus_url
+            ),
+        )
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_image_update.py
+++ b/src/tests/cli/t_pkg_image_update.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2022, Oracle and/or its affiliates.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 from pkg.client.pkgdefs import *
@@ -36,101 +37,102 @@ import unittest
 
 import pkg.misc as misc
 
-class NoTestImageUpdate(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
-        need_ro_data = True
 
-        foo10 = """
+class NoTestImageUpdate(pkg5unittest.ManyDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+    need_ro_data = True
+
+    foo10 = """
             open foo@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             close """
 
-        bar11 = """
+    bar11 = """
             open bar@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             close """
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             close """
 
-        baz11 = """
+    baz11 = """
             open baz@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             close """
 
-        qux10 = """
+    qux10 = """
             open qux@1.0,5.11-0
             add depend type=require fmri=pkg:/quux@1.0
             add dir mode=0755 owner=root group=bin path=/lib
             close """
 
-        qux11 = """
+    qux11 = """
             open qux@1.1,5.11-0
             add depend type=require fmri=pkg:/quux@1.1
             add dir mode=0755 owner=root group=bin path=/lib
             close """
 
-        quux10 = """
+    quux10 = """
             open quux@1.0,5.11-0
             add depend type=require fmri=pkg:/corge@1.0
             add dir mode=0755 owner=root group=bin path=/usr
             close """
 
-        quux11 = """
+    quux11 = """
             open quux@1.1,5.11-0
             add depend type=require fmri=pkg:/corge@1.1
             add dir mode=0755 owner=root group=bin path=/usr
             close """
 
-        corge10 = """
+    corge10 = """
             open corge@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             close """
 
-        corge11 = """
+    corge11 = """
             open corge@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             close """
 
-        incorp10 = """
+    incorp10 = """
             open incorp@1.0,5.11-0
             add depend type=incorporate fmri=foo@1.0
             add depend type=incorporate fmri=bar@1.0
             add set name=pkg.depend.install-hold value=test
             close """
 
-        incorp11 = """
+    incorp11 = """
             open incorp@1.1,5.11-0
             add depend type=incorporate fmri=foo@1.1
             add depend type=incorporate fmri=bar@1.1
             add set name=pkg.depend.install-hold value=test
             close """
 
-        elftest1 = """
+    elftest1 = """
             open elftest@1.0
             add file {0} mode=0755 owner=root group=bin path=/bin/true
             close """
 
-        elftest2 = """
+    elftest2 = """
             open elftest@2.0
             add file {0} mode=0755 owner=root group=bin path=/bin/true
             close """
 
-        # An example of dueling incorporations for an upgrade case.
-        dueling_inst = """
+    # An example of dueling incorporations for an upgrade case.
+    dueling_inst = """
             open entire@5.12-5.12.0.0.0.45.0
             add set name=pkg.depend.install-hold value=core-os
             add depend fmri=consolidation/java-7/java-7-incorporation type=require
@@ -156,7 +158,7 @@ class NoTestImageUpdate(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        dueling_latest = """
+    dueling_latest = """
             open consolidation/osnet/osnet-incorporation@5.12-5.12.0.0.0.46.25205
             add set name=pkg.depend.install-hold value=core-os.osnet
             add depend fmri=pkg:/system/resource-mgmt/dynamic-resource-pools@5.12,5.12-5.12.0.0.0.46.25205 type=incorporate
@@ -170,7 +172,7 @@ class NoTestImageUpdate(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        obsolete = """
+    obsolete = """
             open goingaway@1.0
             add dir mode=0755 owner=root group=bin path=/lib
             close
@@ -185,346 +187,377 @@ class NoTestImageUpdate(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        def setUp(self):
-                # Two repositories are created for test2.
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test2", "test4", "test5", "nightly"], image_count=2)
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.rurl3 = self.dcs[3].get_repo_url()
-                self.rurl4 = self.dcs[4].get_repo_url()
-                self.rurl5 = self.dcs[5].get_repo_url()
-                self.rurl6 = self.dcs[6].get_repo_url()
-                self.pkgsend_bulk(self.rurl1, (self.foo10, self.foo11,
-                    self.baz11, self.qux10, self.qux11, self.quux10,
-                    self.quux11, self.corge11, self.incorp10, self.incorp11,
-                    self.obsolete))
+    def setUp(self):
+        # Two repositories are created for test2.
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self,
+            ["test1", "test2", "test2", "test4", "test5", "nightly"],
+            image_count=2,
+        )
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.rurl3 = self.dcs[3].get_repo_url()
+        self.rurl4 = self.dcs[4].get_repo_url()
+        self.rurl5 = self.dcs[5].get_repo_url()
+        self.rurl6 = self.dcs[6].get_repo_url()
+        self.pkgsend_bulk(
+            self.rurl1,
+            (
+                self.foo10,
+                self.foo11,
+                self.baz11,
+                self.qux10,
+                self.qux11,
+                self.quux10,
+                self.quux11,
+                self.corge11,
+                self.incorp10,
+                self.incorp11,
+                self.obsolete,
+            ),
+        )
 
-                self.pkgsend_bulk(self.rurl2, (self.foo10, self.bar10,
-                    self.bar11, self.baz10, self.qux10, self.qux11,
-                    self.quux10, self.quux11, self.corge10))
+        self.pkgsend_bulk(
+            self.rurl2,
+            (
+                self.foo10,
+                self.bar10,
+                self.bar11,
+                self.baz10,
+                self.qux10,
+                self.qux11,
+                self.quux10,
+                self.quux11,
+                self.corge10,
+            ),
+        )
 
-                # Copy contents of repository 2 to repos 4 and 5.
-                for i in (4, 5):
-                        self.copy_repository(self.dcs[2].get_repodir(),
-                                self.dcs[i].get_repodir(),
-                                { "test1": "test{0:d}".format(i) })
-                        self.dcs[i].get_repo(auto_create=True).rebuild()
+        # Copy contents of repository 2 to repos 4 and 5.
+        for i in (4, 5):
+            self.copy_repository(
+                self.dcs[2].get_repodir(),
+                self.dcs[i].get_repodir(),
+                {"test1": "test{0:d}".format(i)},
+            )
+            self.dcs[i].get_repo(auto_create=True).rebuild()
 
-                self.pkgsend_bulk(self.rurl6, (self.dueling_inst,
-                    self.dueling_latest))
+        self.pkgsend_bulk(self.rurl6, (self.dueling_inst, self.dueling_latest))
 
-        def test_image_update_bad_opts(self):
-                """Test update with bad options."""
+    def test_image_update_bad_opts(self):
+        """Test update with bad options."""
 
-                self.image_create(self.rurl1, prefix="test1")
-                self.pkg("update -@", exit=2)
-                self.pkg("update -vq", exit=2)
+        self.image_create(self.rurl1, prefix="test1")
+        self.pkg("update -@", exit=2)
+        self.pkg("update -vq", exit=2)
 
-        def test_01_after_pub_removal(self):
-                """Install packages from multiple publishers, then verify that
-                removal of the second publisher will not prevent an
-                update."""
+    def test_01_after_pub_removal(self):
+        """Install packages from multiple publishers, then verify that
+        removal of the second publisher will not prevent an
+        update."""
 
-                self.image_create(self.rurl1, prefix="test1")
+        self.image_create(self.rurl1, prefix="test1")
 
-                # Install a package from the preferred publisher.
-                self.pkg("install foo@1.0")
+        # Install a package from the preferred publisher.
+        self.pkg("install foo@1.0")
 
-                # Install a package from a second publisher.
-                self.pkg("set-publisher -O {0} test2".format(self.rurl2))
-                self.pkg("install bar@1.0")
+        # Install a package from a second publisher.
+        self.pkg("set-publisher -O {0} test2".format(self.rurl2))
+        self.pkg("install bar@1.0")
 
-                # Remove the publisher of an installed package, then add the
-                # publisher back, but with an empty repository.  An update
-                # should still be possible.
-                self.pkg("unset-publisher test2")
-                self.pkg("set-publisher -O {0} test2".format(self.rurl3))
-                self.pkg("update -nv")
+        # Remove the publisher of an installed package, then add the
+        # publisher back, but with an empty repository.  An update
+        # should still be possible.
+        self.pkg("unset-publisher test2")
+        self.pkg("set-publisher -O {0} test2".format(self.rurl3))
+        self.pkg("update -nv")
 
-                # Add two publishers with the same packages as a removed one;
-                # an update should be possible despite the conflict (as
-                # the newer versions will simply be ignored).
-                self.pkg("unset-publisher test2")
-                self.pkg("set-publisher -O {0} test4".format(self.rurl4))
-                self.pkg("set-publisher -O {0} test5".format(self.rurl5))
-                self.pkg("update -nv")
+        # Add two publishers with the same packages as a removed one;
+        # an update should be possible despite the conflict (as
+        # the newer versions will simply be ignored).
+        self.pkg("unset-publisher test2")
+        self.pkg("set-publisher -O {0} test4".format(self.rurl4))
+        self.pkg("set-publisher -O {0} test5".format(self.rurl5))
+        self.pkg("update -nv")
 
-                # Remove one of the conflicting publishers. An update
-                # should still be possible even though the conflicts no longer
-                # exist and the original publisher is unknown (see bug 6856).
-                self.pkg("unset-publisher test4")
-                self.pkg("update -nv")
+        # Remove one of the conflicting publishers. An update
+        # should still be possible even though the conflicts no longer
+        # exist and the original publisher is unknown (see bug 6856).
+        self.pkg("unset-publisher test4")
+        self.pkg("update -nv")
 
-                # Remove the remaining test publisher.
-                self.pkg("unset-publisher test5")
+        # Remove the remaining test publisher.
+        self.pkg("unset-publisher test5")
 
-        def test_02_update_multi_publisher(self):
-                """Verify that updates work as expected when different
-                publishers offer the same package."""
+    def test_02_update_multi_publisher(self):
+        """Verify that updates work as expected when different
+        publishers offer the same package."""
 
-                self.image_create(self.rurl1, prefix="test1")
+        self.image_create(self.rurl1, prefix="test1")
 
-                # First, verify that the preferred status of a publisher will
-                # not affect which source is used for update when two
-                # publishers offer the same package and the package publisher
-                # was preferred at the time of install.
-                self.pkg("set-publisher -P -O {0} test2".format(self.rurl2))
-                self.pkg("install foo@1.0")
-                self.pkg("info foo@1.0 | grep test2")
-                self.pkg("set-publisher -P test1")
-                self.pkg("update -v", exit=4)
-                self.pkg("info foo@1.1 | grep test1", exit=1)
-                self.pkg("uninstall foo")
+        # First, verify that the preferred status of a publisher will
+        # not affect which source is used for update when two
+        # publishers offer the same package and the package publisher
+        # was preferred at the time of install.
+        self.pkg("set-publisher -P -O {0} test2".format(self.rurl2))
+        self.pkg("install foo@1.0")
+        self.pkg("info foo@1.0 | grep test2")
+        self.pkg("set-publisher -P test1")
+        self.pkg("update -v", exit=4)
+        self.pkg("info foo@1.1 | grep test1", exit=1)
+        self.pkg("uninstall foo")
 
-                # Next, verify that the preferred status of a publisher will
-                # not cause an upgrade of a package if the newer version is
-                # offered by the preferred publisher and the package publisher
-                # was not preferred at the time of isntall and was not used
-                # to install the package.
-                self.pkg("install baz@1.0")
-                self.pkg("info baz@1.0 | grep test2")
-                # Also verify that the client still accepts 'image-update'
-                # as a synonym for 'update' for compatibility.
-                self.pkg("image-update -v", exit=4)
-                self.pkg("info baz@1.0 | grep test2")
+        # Next, verify that the preferred status of a publisher will
+        # not cause an upgrade of a package if the newer version is
+        # offered by the preferred publisher and the package publisher
+        # was not preferred at the time of isntall and was not used
+        # to install the package.
+        self.pkg("install baz@1.0")
+        self.pkg("info baz@1.0 | grep test2")
+        # Also verify that the client still accepts 'image-update'
+        # as a synonym for 'update' for compatibility.
+        self.pkg("image-update -v", exit=4)
+        self.pkg("info baz@1.0 | grep test2")
 
-                # Finally, cleanup and verify no packages are installed.
-                self.pkg("uninstall '*'")
-                self.pkg("list", exit=1)
+        # Finally, cleanup and verify no packages are installed.
+        self.pkg("uninstall '*'")
+        self.pkg("list", exit=1)
 
-        def test_03_update_specific_packages(self):
-                """Verify that update only updates specified packages."""
+    def test_03_update_specific_packages(self):
+        """Verify that update only updates specified packages."""
 
-                self.image_create(self.rurl1, prefix="test1")
+        self.image_create(self.rurl1, prefix="test1")
 
-                # Install a package from the preferred publisher.
-                self.pkg("install foo@1.0")
+        # Install a package from the preferred publisher.
+        self.pkg("install foo@1.0")
 
-                # Install a package from a second publisher.
-                self.pkg("set-publisher -O {0} test2".format(self.rurl2))
-                self.pkg("install bar@1.0")
+        # Install a package from a second publisher.
+        self.pkg("set-publisher -O {0} test2".format(self.rurl2))
+        self.pkg("install bar@1.0")
 
-                # Update just bar, and then verify foo wasn't updated.
-                self.pkg("update bar")
-                self.pkg("info bar@1.1 foo@1.0")
+        # Update just bar, and then verify foo wasn't updated.
+        self.pkg("update bar")
+        self.pkg("info bar@1.1 foo@1.0")
 
-                # Now update bar back to 1.0 and then verify that update '*',
-                # update '*@*', or update without arguments will update all
-                # packages.
-                self.pkg("update bar@1.0")
-                self.pkg("install incorp@1.0")
+        # Now update bar back to 1.0 and then verify that update '*',
+        # update '*@*', or update without arguments will update all
+        # packages.
+        self.pkg("update bar@1.0")
+        self.pkg("install incorp@1.0")
 
-                self.pkg("update")
-                self.pkg("info bar@1.1 foo@1.1 incorp@1.1")
+        self.pkg("update")
+        self.pkg("info bar@1.1 foo@1.1 incorp@1.1")
 
-                self.pkg("update *@1.0")
-                self.pkg("info bar@1.0 foo@1.0 incorp@1.0")
+        self.pkg("update *@1.0")
+        self.pkg("info bar@1.0 foo@1.0 incorp@1.0")
 
-                self.pkg("update '*'")
-                self.pkg("info bar@1.1 foo@1.1 incorp@1.1")
+        self.pkg("update '*'")
+        self.pkg("info bar@1.1 foo@1.1 incorp@1.1")
 
-                self.pkg("update bar@1.0 foo@1.0 incorp@1.0")
-                self.pkg("info bar@1.0 foo@1.0 incorp@1.0")
+        self.pkg("update bar@1.0 foo@1.0 incorp@1.0")
+        self.pkg("info bar@1.0 foo@1.0 incorp@1.0")
 
-                self.pkg("update '*@*'")
-                self.pkg("info bar@1.1 foo@1.1 incorp@1.1")
+        self.pkg("update '*@*'")
+        self.pkg("info bar@1.1 foo@1.1 incorp@1.1")
 
-                # Now rollback everything to 1.0, and then verify that
-                # '@latest' will take everything to the latest version.
-                self.pkg("update '*@1.0'")
-                self.pkg("info bar@1.0 foo@1.0 incorp@1.0")
+        # Now rollback everything to 1.0, and then verify that
+        # '@latest' will take everything to the latest version.
+        self.pkg("update '*@1.0'")
+        self.pkg("info bar@1.0 foo@1.0 incorp@1.0")
 
-                self.pkg("update '*@latest'")
-                self.pkg("info bar@1.1 foo@1.1 incorp@1.1")
+        self.pkg("update '*@latest'")
+        self.pkg("info bar@1.1 foo@1.1 incorp@1.1")
 
-        def test_upgrade_sticky(self):
-                """Test that when a package specified on the command line can't
-                be upgraded because of a sticky publisher, the exception raised
-                is correct."""
+    def test_upgrade_sticky(self):
+        """Test that when a package specified on the command line can't
+        be upgraded because of a sticky publisher, the exception raised
+        is correct."""
 
-                self.image_create(self.rurl2)
-                self.pkg("install foo")
-                self.pkg("set-publisher -p {0}".format(self.rurl1))
-                self.pkg("update foo@1.1", exit=1)
-                self.assertTrue("test1" in self.errout)
+        self.image_create(self.rurl2)
+        self.pkg("install foo")
+        self.pkg("set-publisher -p {0}".format(self.rurl1))
+        self.pkg("update foo@1.1", exit=1)
+        self.assertTrue("test1" in self.errout)
 
-        def test_nothingtodo(self):
-                """Test that if we have multiple facets of equal length that
-                we don't accidentally report that there are image updates when
-                there are not."""
+    def test_nothingtodo(self):
+        """Test that if we have multiple facets of equal length that
+        we don't accidentally report that there are image updates when
+        there are not."""
 
-                facet_max = 1000
-                facet_fmt = "{{0:{0:d}d}}".format(len("{0:d}".format(facet_max)))
+        facet_max = 1000
+        facet_fmt = "{{0:{0:d}d}}".format(len("{0:d}".format(facet_max)))
 
-                facet_set = set()
-                random.seed()
-                self.image_create()
-                for i in range(15):
-                        facet = facet_fmt.format(random.randint(0, facet_max))
-                        if facet in facet_set:
-                                # skip dups
-                                continue
-                        facet_set.add(facet)
-                        self.pkg("change-facet {0}=False".format(facet))
-                        self.pkg("update -nv", exit=EXIT_NOP)
+        facet_set = set()
+        random.seed()
+        self.image_create()
+        for i in range(15):
+            facet = facet_fmt.format(random.randint(0, facet_max))
+            if facet in facet_set:
+                # skip dups
+                continue
+            facet_set.add(facet)
+            self.pkg("change-facet {0}=False".format(facet))
+            self.pkg("update -nv", exit=EXIT_NOP)
 
-        def test_ignore_missing(self):
-                """Test that update shows correct behavior w/ and w/o
-                   --ignore-missing."""
-                self.image_create(self.rurl1)
-                self.pkg("update missing", exit=1)
-                self.pkg("update --ignore-missing missing", exit=4)
+    def test_ignore_missing(self):
+        """Test that update shows correct behavior w/ and w/o
+        --ignore-missing."""
+        self.image_create(self.rurl1)
+        self.pkg("update missing", exit=1)
+        self.pkg("update --ignore-missing missing", exit=4)
 
-        def test_content_policy(self):
-                """ Test the content-update-policy property. When set to
-                'when-required' content should only be updated if the GELF content
-                hash has changed, if set to 'always' content should be updated
-                if there is any file change at all."""
+    def test_content_policy(self):
+        """Test the content-update-policy property. When set to
+        'when-required' content should only be updated if the GELF content
+        hash has changed, if set to 'always' content should be updated
+        if there is any file change at all."""
 
-                def get_test_sum(fname=None):
-                        """ Helper to get sha256 sum of installed test file."""
-                        if fname is None:
-                                fname = os.path.join(self.get_img_path(),
-                                    "bin/true")
-                        fsum , data = misc.get_data_digest(fname,
-                            hash_func=hashlib.sha256)
-                        return fsum
+        def get_test_sum(fname=None):
+            """Helper to get sha256 sum of installed test file."""
+            if fname is None:
+                fname = os.path.join(self.get_img_path(), "bin/true")
+            fsum, data = misc.get_data_digest(fname, hash_func=hashlib.sha256)
+            return fsum
 
-                # Elftest1 and elftest2 have the same content and the same size,
-                # just different entries in the comment section. The content
-                # hash for both is the same, however the file hash is different.
-                elftest1 = self.elftest1.format(os.path.join("ro_data",
-                    "elftest.so.1"))
-                elftest2 = self.elftest2.format(os.path.join("ro_data",
-                    "elftest.so.2"))
+        # Elftest1 and elftest2 have the same content and the same size,
+        # just different entries in the comment section. The content
+        # hash for both is the same, however the file hash is different.
+        elftest1 = self.elftest1.format(os.path.join("ro_data", "elftest.so.1"))
+        elftest2 = self.elftest2.format(os.path.join("ro_data", "elftest.so.2"))
 
-                # get the sha256 sums from the original files to distinguish
-                # what actually got installed
-                elf1sum = get_test_sum(fname=os.path.join(self.ro_data_root,
-                    "elftest.so.1"))
-                elf2sum = get_test_sum(fname=os.path.join(self.ro_data_root,
-                    "elftest.so.2"))
+        # get the sha256 sums from the original files to distinguish
+        # what actually got installed
+        elf1sum = get_test_sum(
+            fname=os.path.join(self.ro_data_root, "elftest.so.1")
+        )
+        elf2sum = get_test_sum(
+            fname=os.path.join(self.ro_data_root, "elftest.so.2")
+        )
 
-                elf1, elf2 = self.pkgsend_bulk(self.rurl1, (elftest1, elftest2))
+        elf1, elf2 = self.pkgsend_bulk(self.rurl1, (elftest1, elftest2))
 
-                # prepare image, install elftest@1.0 and verify
-                self.image_create(self.rurl1)
-                self.pkg("install -v {0}".format(elf1))
-                self.pkg("contents -m {0}".format(elf1))
-                self.assertEqual(elf1sum, get_test_sum())
+        # prepare image, install elftest@1.0 and verify
+        self.image_create(self.rurl1)
+        self.pkg("install -v {0}".format(elf1))
+        self.pkg("contents -m {0}".format(elf1))
+        self.assertEqual(elf1sum, get_test_sum())
 
-                # test default behavior (always update)
-                self.pkg("update -v elftest")
-                self.pkg("contents -m {0}".format(elf2))
-                self.assertEqual(elf2sum, get_test_sum())
-                # reset and start over
-                self.pkg("uninstall elftest")
-                self.pkg("install -v {0}".format(elf1))
+        # test default behavior (always update)
+        self.pkg("update -v elftest")
+        self.pkg("contents -m {0}".format(elf2))
+        self.assertEqual(elf2sum, get_test_sum())
+        # reset and start over
+        self.pkg("uninstall elftest")
+        self.pkg("install -v {0}".format(elf1))
 
-                # set policy to when-required, file shouldn't be updated
-                self.pkg("set-property content-update-policy when-required")
-                self.pkg("update -v elftest")
-                self.pkg("list {0}".format(elf2))
-                self.assertEqual(elf1sum, get_test_sum())
-                # reset and start over
-                self.pkg("uninstall elftest")
-                self.pkg("install -v {0}".format(elf1))
+        # set policy to when-required, file shouldn't be updated
+        self.pkg("set-property content-update-policy when-required")
+        self.pkg("update -v elftest")
+        self.pkg("list {0}".format(elf2))
+        self.assertEqual(elf1sum, get_test_sum())
+        # reset and start over
+        self.pkg("uninstall elftest")
+        self.pkg("install -v {0}".format(elf1))
 
-                # set policy to always, file should be updated now
-                self.pkg("set-property content-update-policy always")
-                self.pkg("update -v elftest")
-                self.pkg("list {0}".format(elf2))
-                self.assertEqual(elf2sum, get_test_sum())
+        # set policy to always, file should be updated now
+        self.pkg("set-property content-update-policy always")
+        self.pkg("update -v elftest")
+        self.pkg("list {0}".format(elf2))
+        self.assertEqual(elf2sum, get_test_sum())
 
-                # do tests again for downgrading, test file shouldn't change
-                self.pkg("set-property content-update-policy when-required")
-                self.pkg("update -v {0}".format(elf1))
-                self.pkg("list {0}".format(elf1))
-                self.assertEqual(elf2sum, get_test_sum())
-                # reset and start over
-                self.pkg("uninstall elftest")
-                self.pkg("install -v {0}".format(elf2))
+        # do tests again for downgrading, test file shouldn't change
+        self.pkg("set-property content-update-policy when-required")
+        self.pkg("update -v {0}".format(elf1))
+        self.pkg("list {0}".format(elf1))
+        self.assertEqual(elf2sum, get_test_sum())
+        # reset and start over
+        self.pkg("uninstall elftest")
+        self.pkg("install -v {0}".format(elf2))
 
-                # set policy to always, file should be updated now
-                self.pkg("set-property content-update-policy always")
-                self.pkg("update -v {0}".format(elf1))
-                self.pkg("list {0}".format(elf1))
-                self.assertEqual(elf1sum, get_test_sum())
+        # set policy to always, file should be updated now
+        self.pkg("set-property content-update-policy always")
+        self.pkg("update -v {0}".format(elf1))
+        self.pkg("list {0}".format(elf1))
+        self.assertEqual(elf1sum, get_test_sum())
 
-        def test_dueling_incs(self):
-                """Verify that dueling incorporations don't result in a 'no
-                solution' error in a case sometimes found with 'nightly'
-                upgrades."""
+    def test_dueling_incs(self):
+        """Verify that dueling incorporations don't result in a 'no
+        solution' error in a case sometimes found with 'nightly'
+        upgrades."""
 
-                self.image_create(self.rurl6)
-                self.image_clone(1)
-                self.pkg("change-facet "
-                    "version-lock.consolidation/osnet/osnet-incorporation=false")
-                self.pkg("install entire@5.12-5.12.0.0.0.45.0 "
-                    "osnet-incorporation@5.12-5.12.0.0.0.45.25345 "
-                    "system/resource-mgmt/dynamic-resource-pools@5.12-5.12.0.0.0.45.25345")
+        self.image_create(self.rurl6)
+        self.image_clone(1)
+        self.pkg(
+            "change-facet "
+            "version-lock.consolidation/osnet/osnet-incorporation=false"
+        )
+        self.pkg(
+            "install entire@5.12-5.12.0.0.0.45.0 "
+            "osnet-incorporation@5.12-5.12.0.0.0.45.25345 "
+            "system/resource-mgmt/dynamic-resource-pools@5.12-5.12.0.0.0.45.25345"
+        )
 
-                # Failure is expected for these cases because an installed
-                # incorporation prevents the upgrade of an installed dependency
-                # required by the new packages.
+        # Failure is expected for these cases because an installed
+        # incorporation prevents the upgrade of an installed dependency
+        # required by the new packages.
 
-                # Should fail and result in 'no solution' because user failed to
-                # specify any input. In this case we also get the constrained
-                # operation exit status.
-                self.pkg("update -nv", exit=9, assert_solution=False)
-                self.assertTrue("No solution" in self.errout)
+        # Should fail and result in 'no solution' because user failed to
+        # specify any input. In this case we also get the constrained
+        # operation exit status.
+        self.pkg("update -nv", exit=9, assert_solution=False)
+        self.assertTrue("No solution" in self.errout)
 
-                # Should fail, but not result in 'no solution' because user
-                # specified a particular package.
-                self.pkg("update -nv osnet-incorporation@latest", exit=1)
-                self.assertTrue("No matching version" in self.errout)
+        # Should fail, but not result in 'no solution' because user
+        # specified a particular package.
+        self.pkg("update -nv osnet-incorporation@latest", exit=1)
+        self.assertTrue("No matching version" in self.errout)
 
-                # Should exit with 'nothing to do' since update to new version
-                # of osnet-incorporation is not possible.
-                self.pkg("update -nv osnet-incorporation", exit=4)
+        # Should exit with 'nothing to do' since update to new version
+        # of osnet-incorporation is not possible.
+        self.pkg("update -nv osnet-incorporation", exit=4)
 
-                # With -vv, the message should always show the reason for
-                # the upgrade not being possible.
-                self.pkg("update -nvv", exit=1, assert_solution=False)
-                self.assertTrue("This version is excluded" in self.errout)
-                self.pkg("update -nvv osnet-incorporation@latest", exit=1)
-                self.assertTrue("This version is excluded" in self.errout)
-                self.pkg("update -nvv osnet-incorporation", exit=1)
-                self.assertTrue("This version is excluded" in self.errout)
+        # With -vv, the message should always show the reason for
+        # the upgrade not being possible.
+        self.pkg("update -nvv", exit=1, assert_solution=False)
+        self.assertTrue("This version is excluded" in self.errout)
+        self.pkg("update -nvv osnet-incorporation@latest", exit=1)
+        self.assertTrue("This version is excluded" in self.errout)
+        self.pkg("update -nvv osnet-incorporation", exit=1)
+        self.assertTrue("This version is excluded" in self.errout)
 
-                # A pkg update (with no arguments) should not fail if we are a
-                # linked image child because we're likely constrained by our
-                # parent dependencies.
-                self.pkg("attach-linked --linked-md-only -p system:foo "
-                    "{0}".format(self.img_path(1)))
-                self.pkg("update -nv", exit=4)
+        # A pkg update (with no arguments) should not fail if we are a
+        # linked image child because we're likely constrained by our
+        # parent dependencies.
+        self.pkg(
+            "attach-linked --linked-md-only -p system:foo "
+            "{0}".format(self.img_path(1))
+        )
+        self.pkg("update -nv", exit=4)
 
-        def test_display_removed_pkgs(self):
-            """Verify that the names of removed packages are displayed during
-            upgrade."""
+    def test_display_removed_pkgs(self):
+        """Verify that the names of removed packages are displayed during
+        upgrade."""
 
-            self.image_create(self.rurl1)
-            self.pkg("install foo@1.0 goingaway@1.0 moreoldstuff@1.0")
-            self.pkg("update", exit=0)
+        self.image_create(self.rurl1)
+        self.pkg("install foo@1.0 goingaway@1.0 moreoldstuff@1.0")
+        self.pkg("update", exit=0)
 
-            # Check the header and the package names without a version are
-            # present.
-            # Ensure that a package that has not been obsoleted is not included.
-            self.assertTrue("Removed Packages:" in self.output)
+        # Check the header and the package names without a version are
+        # present.
+        # Ensure that a package that has not been obsoleted is not included.
+        self.assertTrue("Removed Packages:" in self.output)
 
-            self.assertTrue("goingaway" in self.output)
-            self.assertFalse("goingaway@" in self.output)
-            self.assertTrue("moreoldstuff" in self.output)
-            self.assertFalse("moreoldstuff@" in self.output)
+        self.assertTrue("goingaway" in self.output)
+        self.assertFalse("goingaway@" in self.output)
+        self.assertTrue("moreoldstuff" in self.output)
+        self.assertFalse("moreoldstuff@" in self.output)
 
-            self.assertFalse("foo" in self.output)
+        self.assertFalse("foo" in self.output)
+
 
 class TestIDROps(pkg5unittest.SingleDepotTestCase):
+    need_ro_data = True
 
-        need_ro_data = True
-
-        idr_comb = """
+    idr_comb = """
             open pkg://test/management/em-sysmgmt-ecpc/em-oc-common@12.2.2.1103,5.11-0.1:20160225T115559Z 
             add set name=pkg.description value="test package"
             add dir path=foo/hello owner=root group=sys mode=555
@@ -554,163 +587,176 @@ class TestIDROps(pkg5unittest.SingleDepotTestCase):
             add depend type=incorporate fmri=management/em-sysmgmt-ecpc/em-oc-common@12.2.2.1103-0.1.1697.1
             close"""
 
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.pkgsend_bulk(self.rurl, self.idr_comb)
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.pkgsend_bulk(self.rurl, self.idr_comb)
+    def test_idr_application(self):
+        """Verify branch versioning that might that might lead to odd
+        ordering of the possible FMRIs will not be erroneously trimmed
+        during installation or removal."""
 
-        def test_idr_application(self):
-                """Verify branch versioning that might that might lead to odd
-                ordering of the possible FMRIs will not be erroneously trimmed
-                during installation or removal."""
-
-                self.image_create(self.rurl)
-                self.pkg("install opscenter-ecpc-incorporation")
-                self.pkg("list -afv em-oc-common")
-                # If branch versioning ordering is working correctly, the next
-                # two packages should be installable.
-                self.pkg("install pkg://test/management/em-sysmgmt-ecpc/em-oc-common@12.2.2.1103,5.11-0.1:20160225T115559Z")
-                self.pkg("install pkg://test/management/em-sysmgmt-ecpc/em-oc-common@12.2.2.1103,5.11-0.1:20160225T115616Z")
-                # If branch ordering is broken, only this package will be
-                # instalable.
-                self.pkg("install pkg://test/management/em-sysmgmt-ecpc/em-oc-common")
-                self.pkg("list -afv em-oc-common")
-                # If branch ordering is broken, the upgrade will fail because
-                # em-oc-common won't be installable despite removal of the idr.
-                self.pkg("update --reject pkg://test/idr1697@1 "
-                    "pkg://test/management/em-sysmgmt-ecpc/em-oc-common@12.2.2.1103,5.11-0.1:20160225T115616Z")
+        self.image_create(self.rurl)
+        self.pkg("install opscenter-ecpc-incorporation")
+        self.pkg("list -afv em-oc-common")
+        # If branch versioning ordering is working correctly, the next
+        # two packages should be installable.
+        self.pkg(
+            "install pkg://test/management/em-sysmgmt-ecpc/em-oc-common@12.2.2.1103,5.11-0.1:20160225T115559Z"
+        )
+        self.pkg(
+            "install pkg://test/management/em-sysmgmt-ecpc/em-oc-common@12.2.2.1103,5.11-0.1:20160225T115616Z"
+        )
+        # If branch ordering is broken, only this package will be
+        # instalable.
+        self.pkg("install pkg://test/management/em-sysmgmt-ecpc/em-oc-common")
+        self.pkg("list -afv em-oc-common")
+        # If branch ordering is broken, the upgrade will fail because
+        # em-oc-common won't be installable despite removal of the idr.
+        self.pkg(
+            "update --reject pkg://test/idr1697@1 "
+            "pkg://test/management/em-sysmgmt-ecpc/em-oc-common@12.2.2.1103,5.11-0.1:20160225T115616Z"
+        )
 
 
 class NoTestPkgUpdateOverlappingPatterns(pkg5unittest.SingleDepotTestCase):
-
-        a_1 = """
+    a_1 = """
             open a@1.0,5.11-0
             close """
 
-        pub2_a_1 = """
+    pub2_a_1 = """
             open pkg://pub2/a@1.0,5.11-0
             close """
 
-        a_11 = """
+    a_11 = """
             open a@1.1,5.11-0
             close """
 
-        a_2 = """
+    a_2 = """
             open a@2.0,5.11-0
             close """
 
-        pub2_a_2 = """
+    pub2_a_2 = """
             open pkg://pub2/a@2.0,5.11-0
             close """
 
-        a_3 = """
+    a_3 = """
             open a@3.0,5.11-0
             close """
 
-        aa_1 = """
+    aa_1 = """
             open aa@1.0,5.11-0
             close """
 
-        aa_2 = """
+    aa_2 = """
             open aa@2.0,5.11-0
             close """
 
-        afoo_1 = """
+    afoo_1 = """
             open a/foo@1.0,5.11-0
             close """
 
-        bfoo_1 = """
+    bfoo_1 = """
             open b/foo@1.0,5.11-0
             close """
 
-        fooa_1 = """
+    fooa_1 = """
             open foo/a@1.0,5.11-0
             close """
 
-        foob_1 = """
+    foob_1 = """
             open foo/b@1.0,5.11-0
             close """
 
-        def test_overlapping_patterns_one_stem_update(self):
-                self.pkgsend_bulk(self.rurl, self.a_1 + self.a_2 + self.a_11)
-                api_inst = self.image_create(self.rurl)
+    def test_overlapping_patterns_one_stem_update(self):
+        self.pkgsend_bulk(self.rurl, self.a_1 + self.a_2 + self.a_11)
+        api_inst = self.image_create(self.rurl)
 
-                self._api_install(api_inst, ["a@1.0"])
-                self._api_update(api_inst, pkgs_update=["a@latest", "a@2"],
-                    noexecute=True)
-                self.pkg("update a@1.1 a@2", exit=1)
+        self._api_install(api_inst, ["a@1.0"])
+        self._api_update(
+            api_inst, pkgs_update=["a@latest", "a@2"], noexecute=True
+        )
+        self.pkg("update a@1.1 a@2", exit=1)
 
-        def test_overlapping_patterns_multi_stems_update(self):
-                self.pkgsend_bulk(self.rurl, self.a_1 + self.a_11 + self.a_2 +
-                    self.aa_1 + self.aa_2)
-                api_inst = self.image_create(self.rurl)
+    def test_overlapping_patterns_multi_stems_update(self):
+        self.pkgsend_bulk(
+            self.rurl, self.a_1 + self.a_11 + self.a_2 + self.aa_1 + self.aa_2
+        )
+        api_inst = self.image_create(self.rurl)
 
-                self._api_install(api_inst, ["a@1.0", "aa@1.0"])
-                self._api_update(api_inst, pkgs_update=["*", "a@1.1"])
-                self.pkg("list aa@2.0 a@1.1")
-                self._api_uninstall(api_inst, ["*"])
+        self._api_install(api_inst, ["a@1.0", "aa@1.0"])
+        self._api_update(api_inst, pkgs_update=["*", "a@1.1"])
+        self.pkg("list aa@2.0 a@1.1")
+        self._api_uninstall(api_inst, ["*"])
 
-                self._api_install(api_inst, ["a@1.0", "aa@1.0"])
-                self._api_update(api_inst, pkgs_update=["*", "a@1.1", "a*@2"])
-                self.pkg("list aa@2.0 a@1.1")
-                self._api_uninstall(api_inst, ["*"])
+        self._api_install(api_inst, ["a@1.0", "aa@1.0"])
+        self._api_update(api_inst, pkgs_update=["*", "a@1.1", "a*@2"])
+        self.pkg("list aa@2.0 a@1.1")
+        self._api_uninstall(api_inst, ["*"])
 
-        def test_overlapping_patterns_multi_publisher_update(self):
-                self.pkgsend_bulk(self.rurl, self.a_1 + self.a_2 +
-                    self.aa_1 + self.aa_2 + self.pub2_a_1 + self.pub2_a_2)
-                api_inst = self.image_create(self.rurl)
-                self.pkg("set-publisher -P test")
+    def test_overlapping_patterns_multi_publisher_update(self):
+        self.pkgsend_bulk(
+            self.rurl,
+            self.a_1
+            + self.a_2
+            + self.aa_1
+            + self.aa_2
+            + self.pub2_a_1
+            + self.pub2_a_2,
+        )
+        api_inst = self.image_create(self.rurl)
+        self.pkg("set-publisher -P test")
 
-                # Test that naming a specific publisher and stem will override
-                # the general wildcard.
-                self._api_install(api_inst, ["a@1", "aa@1"])
-                self.pkg("update '*' 'pkg://pub2/a@1'")
-                self.pkg("list -Hv pkg://pub2/a@1 pkg://test/aa@2")
-                self._api_uninstall(api_inst, ["*"])
+        # Test that naming a specific publisher and stem will override
+        # the general wildcard.
+        self._api_install(api_inst, ["a@1", "aa@1"])
+        self.pkg("update '*' 'pkg://pub2/a@1'")
+        self.pkg("list -Hv pkg://pub2/a@1 pkg://test/aa@2")
+        self._api_uninstall(api_inst, ["*"])
 
-                # Test that naming a specific publisher will correctly change
-                # the publisher of the installed package.
-                self._api_install(api_inst, ["a@1", "aa@1"])
-                self.pkg("update 'pkg://pub2/*@1'")
-                self.pkg("list -Hv pkg://pub2/a@1 pkg://test/aa@1")
-                self._api_uninstall(api_inst, ["*"])
+        # Test that naming a specific publisher will correctly change
+        # the publisher of the installed package.
+        self._api_install(api_inst, ["a@1", "aa@1"])
+        self.pkg("update 'pkg://pub2/*@1'")
+        self.pkg("list -Hv pkg://pub2/a@1 pkg://test/aa@1")
+        self._api_uninstall(api_inst, ["*"])
 
-                # Test that a specific publisher and stem will override an
-                # unspecified publisher with a specific stem.
-                self._api_install(api_inst, ["a@1"])
-                self.pkg("update 'a@1' 'pkg://pub2/a@1'")
-                self.pkg("list -Hv pkg://pub2/a@1")
-                self.pkg("update 'a@2' '//test/a@2'")
-                self.pkg("list -Hv pkg://test/a@2")
-                self._api_uninstall(api_inst, ["*"])
+        # Test that a specific publisher and stem will override an
+        # unspecified publisher with a specific stem.
+        self._api_install(api_inst, ["a@1"])
+        self.pkg("update 'a@1' 'pkg://pub2/a@1'")
+        self.pkg("list -Hv pkg://pub2/a@1")
+        self.pkg("update 'a@2' '//test/a@2'")
+        self.pkg("list -Hv pkg://test/a@2")
+        self._api_uninstall(api_inst, ["*"])
 
-                self._api_install(api_inst, ["a@1"])
-                self.pkg("update 'a@1' 'pkg://pub2/a@2'", exit=1)
-                self._api_uninstall(api_inst, ["*"])
+        self._api_install(api_inst, ["a@1"])
+        self.pkg("update 'a@1' 'pkg://pub2/a@2'", exit=1)
+        self._api_uninstall(api_inst, ["*"])
 
-                # Test that a specific publisher with a wildcard will override a
-                # unspecified publisher with a wildcard.
-                self._api_install(api_inst, ["a@1", "aa@1"])
-                self.pkg("update '*' 'pkg://pub2/*@1'")
-                self.pkg("list -Hv pkg://pub2/a@1 pkg://test/aa@2")
-                self._api_uninstall(api_inst, ["*"])
+        # Test that a specific publisher with a wildcard will override a
+        # unspecified publisher with a wildcard.
+        self._api_install(api_inst, ["a@1", "aa@1"])
+        self.pkg("update '*' 'pkg://pub2/*@1'")
+        self.pkg("list -Hv pkg://pub2/a@1 pkg://test/aa@2")
+        self._api_uninstall(api_inst, ["*"])
 
-                # Test that a specific stem without a specific publisher
-                # overrides a specific publisher without a specific stem.
-                self._api_install(api_inst, ["a@1", "aa@1"])
-                self.pkg("update '*' 'pkg://pub2/*@1' 'a@2'")
-                self.pkg("list -Hv pkg://test/a@2 pkg://test/aa@2")
-                self._api_uninstall(api_inst, ["*"])
+        # Test that a specific stem without a specific publisher
+        # overrides a specific publisher without a specific stem.
+        self._api_install(api_inst, ["a@1", "aa@1"])
+        self.pkg("update '*' 'pkg://pub2/*@1' 'a@2'")
+        self.pkg("list -Hv pkg://test/a@2 pkg://test/aa@2")
+        self._api_uninstall(api_inst, ["*"])
 
-                # Test that conflicting publishers results in an error.
-                self._api_install(api_inst, ["a@1", "aa@1"])
-                self.pkg("update '*' 'pkg://pub2/a@1' 'pkg://test/a@2'", exit=1)
-                self.pkg("update '*' 'pkg://pub2/*@1' 'pkg://test/*@2'", exit=1)
-                self._api_uninstall(api_inst, ["*"])
+        # Test that conflicting publishers results in an error.
+        self._api_install(api_inst, ["a@1", "aa@1"])
+        self.pkg("update '*' 'pkg://pub2/a@1' 'pkg://test/a@2'", exit=1)
+        self.pkg("update '*' 'pkg://pub2/*@1' 'pkg://test/*@2'", exit=1)
+        self._api_uninstall(api_inst, ["*"])
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_info.py
+++ b/src/tests/cli/t_pkg_info.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import json
@@ -37,11 +38,12 @@ import pkg.catalog as catalog
 import pkg.actions as actions
 import pkg.fmri as fmri
 
-class TestPkgInfoBasics(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
 
-        bronze10 = """
+class TestPkgInfoBasics(pkg5unittest.SingleDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+
+    bronze10 = """
             open bronze@1.0,5.11-0:20110910T004546Z
             add dir mode=0755 owner=root group=bin path=/usr
             add dir mode=0755 owner=root group=bin path=/usr/bin
@@ -54,113 +56,126 @@ class TestPkgInfoBasics(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        bronze05 = """
+    bronze05 = """
             open bronze@0.5,5.11-0:20110908T004546Z
             add license tmp/copyright0 license=copyright
             close
         """
 
-        badfile10 = """
+    badfile10 = """
             open badfile@1.0,5.11-0
             add file tmp/baz mode=644 owner=root group=bin path=/tmp/baz-file
             close
         """
 
-        baddir10 = """
+    baddir10 = """
             open baddir@1.0,5.11-0
             add dir mode=755 owner=root group=bin path=/tmp/baz-dir
             close
         """
 
-        human = """
+    human = """
             open human@0.9.8.18,5.11-0:20110910T004546Z
             add set name=pkg.human-version value=0.9.8r
             close
         """
 
-        human2 = """
+    human2 = """
             open human2@0.9.8.18,5.11-0:20110908T004546Z
             add set name=pkg.human-version value=0.9.8.18
             close
         """
 
-        misc_files = [ "tmp/bronzeA1",  "tmp/bronzeA2", "tmp/bronze1",
-            "tmp/bronze2", "tmp/copyright1", "tmp/copyright0", "tmp/sh",
-            "tmp/baz"]
+    misc_files = [
+        "tmp/bronzeA1",
+        "tmp/bronzeA2",
+        "tmp/bronze1",
+        "tmp/bronze2",
+        "tmp/copyright1",
+        "tmp/copyright0",
+        "tmp/sh",
+        "tmp/baz",
+    ]
 
-        def __check_qoutput(self, errout=False):
-                self.assertEqualDiff(self.output, "")
-                if errout:
-                        self.assertTrue(self.errout != "",
-                            "-q must print fatal errors!")
-                else:
-                        self.assertTrue(self.errout == "",
-                            "-q should only print fatal errors!")
+    def __check_qoutput(self, errout=False):
+        self.assertEqualDiff(self.output, "")
+        if errout:
+            self.assertTrue(self.errout != "", "-q must print fatal errors!")
+        else:
+            self.assertTrue(
+                self.errout == "", "-q should only print fatal errors!"
+            )
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.plist = self.pkgsend_bulk(self.rurl, (self.badfile10,
-                    self.baddir10, self.bronze10, self.bronze05, self.human,
-                    self.human2))
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.plist = self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.badfile10,
+                self.baddir10,
+                self.bronze10,
+                self.bronze05,
+                self.human,
+                self.human2,
+            ),
+        )
 
-        def test_pkg_info_bad_fmri(self):
-                """Test bad frmi's with pkg info."""
+    def test_pkg_info_bad_fmri(self):
+        """Test bad frmi's with pkg info."""
 
-                pkg1 = """
+        pkg1 = """
                     open jade@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=/bin
                     close
                 """
-                self.pkgsend_bulk(self.rurl, pkg1)
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, pkg1)
+        self.image_create(self.rurl)
 
-                self.pkg("info foo@x.y", exit=1)
-                # Should only print fatal errors when using -q.
-                self.pkg("info -q foo@x.y", exit=1)
-                self.__check_qoutput(errout=True)
-                self.pkg("info pkg:/man@0.5.11,5.11-0.95:20080807T160129",
-                    exit=1)
-                self.pkg("info pkg:/man@0.5.11,5.11-0.95:20080807T1", exit=1)
-                self.pkg("info pkg:/man@0.5.11,5.11-0.95:", exit=1)
-                self.pkg("info pkg:/man@0.5.11,5.11-0.", exit=1)
-                self.pkg("info pkg:/man@0.5.11,5.11-", exit=1)
-                self.pkg("info pkg:/man@0.5.11,-", exit=1)
-                self.pkg("info pkg:/man@-", exit=1)
-                self.pkg("info pkg:/man@", exit=1)
+        self.pkg("info foo@x.y", exit=1)
+        # Should only print fatal errors when using -q.
+        self.pkg("info -q foo@x.y", exit=1)
+        self.__check_qoutput(errout=True)
+        self.pkg("info pkg:/man@0.5.11,5.11-0.95:20080807T160129", exit=1)
+        self.pkg("info pkg:/man@0.5.11,5.11-0.95:20080807T1", exit=1)
+        self.pkg("info pkg:/man@0.5.11,5.11-0.95:", exit=1)
+        self.pkg("info pkg:/man@0.5.11,5.11-0.", exit=1)
+        self.pkg("info pkg:/man@0.5.11,5.11-", exit=1)
+        self.pkg("info pkg:/man@0.5.11,-", exit=1)
+        self.pkg("info pkg:/man@-", exit=1)
+        self.pkg("info pkg:/man@", exit=1)
 
-                # Bug 4878
-                self.pkg("info -r _usr/bin/stunnel", exit=1)
-                self.pkg("info _usr/bin/stunnel", exit=1)
+        # Bug 4878
+        self.pkg("info -r _usr/bin/stunnel", exit=1)
+        self.pkg("info _usr/bin/stunnel", exit=1)
 
-                # bad version
-                self.pkg("install jade")
-                self.pkg("info pkg:/foo@bar.baz", exit=1)
-                self.pkg("info pkg:/foo@bar.baz jade", exit=1)
-                self.pkg("info -r pkg:/foo@bar.baz", exit=1)
+        # bad version
+        self.pkg("install jade")
+        self.pkg("info pkg:/foo@bar.baz", exit=1)
+        self.pkg("info pkg:/foo@bar.baz jade", exit=1)
+        self.pkg("info -r pkg:/foo@bar.baz", exit=1)
 
-                # bad time
-                self.pkg("info pkg:/foo@0.5.11,5.11-0.91:20080613T999999Z",
-                    exit=1)
+        # bad time
+        self.pkg("info pkg:/foo@0.5.11,5.11-0.91:20080613T999999Z", exit=1)
 
-        def test_info_empty_image(self):
-                """local pkg info should fail in an empty image; remote
-                should succeed on a match """
+    def test_info_empty_image(self):
+        """local pkg info should fail in an empty image; remote
+        should succeed on a match"""
 
-                self.image_create(self.rurl)
-                self.pkg("info", exit=1)
+        self.image_create(self.rurl)
+        self.pkg("info", exit=1)
 
-        def test_info_local_remote(self):
-                """pkg: check that info behaves for local and remote cases."""
+    def test_info_local_remote(self):
+        """pkg: check that info behaves for local and remote cases."""
 
-                pkg1 = """
+        pkg1 = """
                     open jade@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=/bin
                     add set name=info.classification value="org.opensolaris.category.2008:Applications/Sound and Video"
                     close
                 """
 
-                pkg2 = """
+        pkg2 = """
                     open turquoise@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=/bin
                     add set name=info.classification value=org.opensolaris.category.2008:System/Security/Foo/bar/Baz
@@ -168,176 +183,205 @@ class TestPkgInfoBasics(pkg5unittest.SingleDepotTestCase):
                     close
                 """
 
-                pkg3 = """
+        pkg3 = """
                     open copper@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=/bin
                     add set pkg.description="This package constrains package versions to those for build 123.  WARNING: Proper system update and correct package selection depend on the presence of this incorporation.  Removing this package will result in an unsupported system."
                     close
                 """
 
-                # This unit test needs an actual depot due to unprivileged user
-                # testing.
-                self.dc.start()
-                plist = self.pkgsend_bulk(self.durl, (pkg1, pkg2, pkg3))
-                self.image_create(self.durl)
+        # This unit test needs an actual depot due to unprivileged user
+        # testing.
+        self.dc.start()
+        plist = self.pkgsend_bulk(self.durl, (pkg1, pkg2, pkg3))
+        self.image_create(self.durl)
 
-                # Install one package and verify
-                self.pkg("install jade")
-                self.pkg("verify -v")
+        # Install one package and verify
+        self.pkg("install jade")
+        self.pkg("verify -v")
 
-                # Now remove the manifest and manifest cache for jade and retry
-                # the info for an unprivileged user both local and remote.
-                pfmri = fmri.PkgFmri(plist[0])
-                mdir = os.path.dirname(self.get_img_manifest_path(pfmri))
-                shutil.rmtree(mdir)
-                self.assertFalse(os.path.exists(mdir))
+        # Now remove the manifest and manifest cache for jade and retry
+        # the info for an unprivileged user both local and remote.
+        pfmri = fmri.PkgFmri(plist[0])
+        mdir = os.path.dirname(self.get_img_manifest_path(pfmri))
+        shutil.rmtree(mdir)
+        self.assertFalse(os.path.exists(mdir))
 
-                mcdir = self.get_img_manifest_cache_dir(pfmri)
-                shutil.rmtree(mcdir)
-                self.assertFalse(os.path.exists(mcdir))
+        mcdir = self.get_img_manifest_cache_dir(pfmri)
+        shutil.rmtree(mcdir)
+        self.assertFalse(os.path.exists(mcdir))
 
-                # A remote request should work even though local manifest is gone.
-                self.pkg("info -r jade", su_wrap=True)
+        # A remote request should work even though local manifest is gone.
+        self.pkg("info -r jade", su_wrap=True)
 
-                # A local request should succeed even though manifest is missing
-                # since we can still retrieve it from the publisher repository.
-                self.pkg("info jade", su_wrap=True)
+        # A local request should succeed even though manifest is missing
+        # since we can still retrieve it from the publisher repository.
+        self.pkg("info jade", su_wrap=True)
 
-                # Remove the publisher, and verify a remote or local request
-                # fails since the manifest isn't cached within the image and we
-                # can't retrieve it.
-                self.pkg("unset-publisher test")
-                self.pkg("info -r jade", su_wrap=True, exit=1)
-                self.assertTrue("no errors" not in self.errout, self.errout)
-                self.assertTrue("Unknown" not in self.errout, self.errout)
+        # Remove the publisher, and verify a remote or local request
+        # fails since the manifest isn't cached within the image and we
+        # can't retrieve it.
+        self.pkg("unset-publisher test")
+        self.pkg("info -r jade", su_wrap=True, exit=1)
+        self.assertTrue("no errors" not in self.errout, self.errout)
+        self.assertTrue("Unknown" not in self.errout, self.errout)
 
-                self.pkg("info jade", su_wrap=True, exit=1)
-                self.assertTrue("no errors" not in self.errout, self.errout)
-                self.assertTrue("Unknown" not in self.errout, self.errout)
+        self.pkg("info jade", su_wrap=True, exit=1)
+        self.assertTrue("no errors" not in self.errout, self.errout)
+        self.assertTrue("Unknown" not in self.errout, self.errout)
 
-                self.pkg("set-publisher test")
-                self.pkg("info -r jade", su_wrap=True, exit=1)
-                self.assertTrue("no errors" not in self.errout, self.errout)
-                self.assertTrue("Unknown" not in self.errout, self.errout)
+        self.pkg("set-publisher test")
+        self.pkg("info -r jade", su_wrap=True, exit=1)
+        self.assertTrue("no errors" not in self.errout, self.errout)
+        self.assertTrue("Unknown" not in self.errout, self.errout)
 
-                self.pkg("info jade", su_wrap=True, exit=1)
-                self.assertTrue("no errors" not in self.errout, self.errout)
-                self.assertTrue("Unknown" not in self.errout, self.errout)
+        self.pkg("info jade", su_wrap=True, exit=1)
+        self.assertTrue("no errors" not in self.errout, self.errout)
+        self.assertTrue("Unknown" not in self.errout, self.errout)
 
-                self.pkg("set-publisher -p {0} test".format(self.durl))
+        self.pkg("set-publisher -p {0} test".format(self.durl))
 
-                # Check local info
-                self.pkg("info jade | grep 'State: Installed'")
-                self.pkg("info jade | grep '      Category: Applications/Sound and Video'")
-                self.pkg("info jade | grep '      Category: Applications/Sound and Video (org.opensolaris.category.2008)'", exit=1)
-                self.pkg("info jade | grep 'Description:'", exit=1)
-                self.pkg("info turquoise 2>&1 | grep 'no packages matching'")
-                self.pkg("info emerald", exit=1)
-                self.pkg("info emerald 2>&1 | grep 'no packages matching'")
-                self.pkg("info 'j*'")
-                self.pkg("info '*a*'")
-                self.pkg("info jade", su_wrap=True)
-                # Should only print fatal errors when using -q.
-                self.pkg("info -q jade")
-                self.__check_qoutput(errout=False)
+        # Check local info
+        self.pkg("info jade | grep 'State: Installed'")
+        self.pkg(
+            "info jade | grep '      Category: Applications/Sound and Video'"
+        )
+        self.pkg(
+            "info jade | grep '      Category: Applications/Sound and Video (org.opensolaris.category.2008)'",
+            exit=1,
+        )
+        self.pkg("info jade | grep 'Description:'", exit=1)
+        self.pkg("info turquoise 2>&1 | grep 'no packages matching'")
+        self.pkg("info emerald", exit=1)
+        self.pkg("info emerald 2>&1 | grep 'no packages matching'")
+        self.pkg("info 'j*'")
+        self.pkg("info '*a*'")
+        self.pkg("info jade", su_wrap=True)
+        # Should only print fatal errors when using -q.
+        self.pkg("info -q jade")
+        self.__check_qoutput(errout=False)
 
-                # Check remote info
-                self.pkg("info -r jade | grep 'State: Installed'")
-                self.pkg("info -r jade | grep '      Category: Applications/Sound and Video'")
-                self.pkg("info -r jade | grep '      Category: Applications/Sound and Video (org.opensolaris.category.2008)'", exit=1)
-                self.pkg("info -r turquoise | grep 'State: Not installed'")
-                self.pkg("info -r turquoise | grep '      Category: System/Security/Foo/bar/Baz'")
-                self.pkg("info -r turquoise | grep '      Category: System/Security/Foo/bar/Baz (org.opensolaris.category.2008)'", exit=1)
-                self.pkg("info -r turquoise | grep '   Description: Short desc'")
-                # Should only print fatal errors when using -q.
-                self.pkg("info -qr turquoise")
-                self.__check_qoutput(errout=False)
-                self.pkg("info -r turquoise")
+        # Check remote info
+        self.pkg("info -r jade | grep 'State: Installed'")
+        self.pkg(
+            "info -r jade | grep '      Category: Applications/Sound and Video'"
+        )
+        self.pkg(
+            "info -r jade | grep '      Category: Applications/Sound and Video (org.opensolaris.category.2008)'",
+            exit=1,
+        )
+        self.pkg("info -r turquoise | grep 'State: Not installed'")
+        self.pkg(
+            "info -r turquoise | grep '      Category: System/Security/Foo/bar/Baz'"
+        )
+        self.pkg(
+            "info -r turquoise | grep '      Category: System/Security/Foo/bar/Baz (org.opensolaris.category.2008)'",
+            exit=1,
+        )
+        self.pkg("info -r turquoise | grep '   Description: Short desc'")
+        # Should only print fatal errors when using -q.
+        self.pkg("info -qr turquoise")
+        self.__check_qoutput(errout=False)
+        self.pkg("info -r turquoise")
 
-                # Now remove the manifest and manifest cache for turquoise and
-                # retry the info -r for an unprivileged user.
-                pfmri = fmri.PkgFmri(plist[1])
-                mdir = os.path.dirname(self.get_img_manifest_path(pfmri))
-                shutil.rmtree(mdir)
-                self.assertFalse(os.path.exists(mdir))
+        # Now remove the manifest and manifest cache for turquoise and
+        # retry the info -r for an unprivileged user.
+        pfmri = fmri.PkgFmri(plist[1])
+        mdir = os.path.dirname(self.get_img_manifest_path(pfmri))
+        shutil.rmtree(mdir)
+        self.assertFalse(os.path.exists(mdir))
 
-                mcdir = self.get_img_manifest_cache_dir(pfmri)
-                shutil.rmtree(mcdir)
-                self.assertFalse(os.path.exists(mcdir))
+        mcdir = self.get_img_manifest_cache_dir(pfmri)
+        shutil.rmtree(mcdir)
+        self.assertFalse(os.path.exists(mcdir))
 
-                self.pkg("info -r turquoise", su_wrap=True)
+        self.pkg("info -r turquoise", su_wrap=True)
 
-                # Verify output.
-                lines = self.output.split("\n")
-                self.assertEqual(lines[1], "   Description: Short desc")
-                self.assertEqual(lines[2],
-                    "      Category: System/Security/Foo/bar/Baz")
-                self.pkg("info -r copper")
-                lines = self.output.split("\n")
-                self.assertEqual(lines[1],
-                   "   Description: This package constrains package versions to those for build 123.")
+        # Verify output.
+        lines = self.output.split("\n")
+        self.assertEqual(lines[1], "   Description: Short desc")
+        self.assertEqual(
+            lines[2], "      Category: System/Security/Foo/bar/Baz"
+        )
+        self.pkg("info -r copper")
+        lines = self.output.split("\n")
+        self.assertEqual(
+            lines[1],
+            "   Description: This package constrains package versions to those for build 123.",
+        )
 
-                self.assertEqual(lines[2], "                WARNING: Proper system update and correct package selection")
-                self.assertEqual(lines[3], "                depend on the presence of this incorporation.  Removing this")
-                self.assertEqual(lines[4], "                package will result in an unsupported system.")
-                self.assertEqual(lines[5], "         State: Not installed")
-                # Should only print fatal errors when using -q.
-                self.pkg("info -qr turquoise")
-                self.__check_qoutput(errout=False)
-                # Now check for an unknown remote package.
-                self.pkg("info -r emerald", exit=1)
-                self.pkg("info -r emerald 2>&1 | grep 'no packages matching'")
-                # Should only print fatal errors when using -q.
-                self.pkg("info -qr emerald", exit=1)
-                self.__check_qoutput(errout=False)
+        self.assertEqual(
+            lines[2],
+            "                WARNING: Proper system update and correct package selection",
+        )
+        self.assertEqual(
+            lines[3],
+            "                depend on the presence of this incorporation.  Removing this",
+        )
+        self.assertEqual(
+            lines[4],
+            "                package will result in an unsupported system.",
+        )
+        self.assertEqual(lines[5], "         State: Not installed")
+        # Should only print fatal errors when using -q.
+        self.pkg("info -qr turquoise")
+        self.__check_qoutput(errout=False)
+        # Now check for an unknown remote package.
+        self.pkg("info -r emerald", exit=1)
+        self.pkg("info -r emerald 2>&1 | grep 'no packages matching'")
+        # Should only print fatal errors when using -q.
+        self.pkg("info -qr emerald", exit=1)
+        self.__check_qoutput(errout=False)
 
-                self.dc.stop()
+        self.dc.stop()
 
-        def test_bug_2274(self):
-                """Verify that a failure to retrieve license information, for
-                one or more packages specified, will result in an exit code of
-                1 (complete failure) or 3 (partial failure) and a printed
-                message.
-                """
+    def test_bug_2274(self):
+        """Verify that a failure to retrieve license information, for
+        one or more packages specified, will result in an exit code of
+        1 (complete failure) or 3 (partial failure) and a printed
+        message.
+        """
 
-                pkg1 = """
+        pkg1 = """
                     open silver@1.0,5.11-0
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, pkg1)
-                self.image_create(self.rurl)
-                self.pkg("info --license -r bronze")
-                self.pkg("info --license -r silver", exit=1)
-                # Should only print fatal errors when using -q.
-                self.pkg("info --license -qr silver", exit=1)
-                self.__check_qoutput(errout=False)
-                self.pkg("info --license -r bronze silver", exit=3)
-                self.pkg("info --license -r silver 2>&1 | grep 'no license information'")
+        self.pkgsend_bulk(self.rurl, pkg1)
+        self.image_create(self.rurl)
+        self.pkg("info --license -r bronze")
+        self.pkg("info --license -r silver", exit=1)
+        # Should only print fatal errors when using -q.
+        self.pkg("info --license -qr silver", exit=1)
+        self.__check_qoutput(errout=False)
+        self.pkg("info --license -r bronze silver", exit=3)
+        self.pkg(
+            "info --license -r silver 2>&1 | grep 'no license information'"
+        )
 
-                self.pkg("install bronze silver")
+        self.pkg("install bronze silver")
 
-                self.pkg("info --license bronze")
-                # Should only print fatal errors when using -q.
-                self.pkg("info --license -q bronze")
-                self.__check_qoutput(errout=False)
+        self.pkg("info --license bronze")
+        # Should only print fatal errors when using -q.
+        self.pkg("info --license -q bronze")
+        self.__check_qoutput(errout=False)
 
-                self.pkg("info --license silver", exit=1)
-                # Should only print fatal errors when using -q.
-                self.pkg("info --license -q silver", exit=1)
-                self.__check_qoutput(errout=False)
+        self.pkg("info --license silver", exit=1)
+        # Should only print fatal errors when using -q.
+        self.pkg("info --license -q silver", exit=1)
+        self.__check_qoutput(errout=False)
 
-                self.pkg("info --license bronze silver", exit=3)
-                # Should only print fatal errors when using -q.
-                self.pkg("info --license -q bronze silver", exit=3)
-                self.__check_qoutput(errout=False)
+        self.pkg("info --license bronze silver", exit=3)
+        # Should only print fatal errors when using -q.
+        self.pkg("info --license -q bronze silver", exit=3)
+        self.__check_qoutput(errout=False)
 
-                self.pkg("info --license silver 2>&1 | grep 'no license information'")
+        self.pkg("info --license silver 2>&1 | grep 'no license information'")
 
-        def test_info_attribute(self):
-                """Verify that 'pkg info' handles optional attributes as expected."""
+    def test_info_attribute(self):
+        """Verify that 'pkg info' handles optional attributes as expected."""
 
-                pkg1 = """
+        pkg1 = """
                     open jade@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=/bin
                     add set name=info.classification value="org.opensolaris.category.2008:Applications/Sound and Video"
@@ -348,14 +392,14 @@ class TestPkgInfoBasics(pkg5unittest.SingleDepotTestCase):
                     close
                 """
 
-                pkg2 = """
+        pkg2 = """
                     open turquoise@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=/bin
                     add set name=info.classification value=org.opensolaris.category.2008:System/Security/Foo/bar/Baz
                     add set pkg.description="Short desc"
                     close
                 """
-                pkg3 = """
+        pkg3 = """
                     open copper@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=/bin
                     add set pkg.description="This package constrains package versions to those for build 123.  WARNING: Proper system update and correct packagsudo ../run.py -dvo test_info_local_remote selection depend on the presence of this incorporation.  Removing this package will result in an unsupported system."
@@ -364,117 +408,117 @@ class TestPkgInfoBasics(pkg5unittest.SingleDepotTestCase):
                     close
                 """
 
-                plist = self.pkgsend_bulk(self.rurl, (pkg1,pkg2,pkg3))
-                self.image_create(self.rurl)
+        plist = self.pkgsend_bulk(self.rurl, (pkg1, pkg2, pkg3))
+        self.image_create(self.rurl)
 
-                # Install packages and verify
-                self.pkg("install jade")
-                self.pkg("install turquoise")
-                self.pkg("install copper")
-                self.pkg("verify -v")
- 
-                # grep for some attributes that are defined and they have
-                # single values
-                self.pkg("info jade")
-                self.assertTrue("Category" in self.output) 
-                
-                # grep for some attributes that are defined and they have
-                # multiple values
-                self.pkg("info jade")
-                self.assertTrue("Project Maintainer" in self.output) 
+        # Install packages and verify
+        self.pkg("install jade")
+        self.pkg("install turquoise")
+        self.pkg("install copper")
+        self.pkg("verify -v")
 
-                # grep for some attributes that are defined , with no value
-                self.pkg("info jade")
-                self.assertTrue("Project Maintainer URL" not in self.output) 
-                   
-                # grep for same attributes that are defined above in different
-                # packages, with some value 
-                self.pkg("info copper")
-                self.assertTrue("Project Maintainer URL" in self.output) 
+        # grep for some attributes that are defined and they have
+        # single values
+        self.pkg("info jade")
+        self.assertTrue("Category" in self.output)
 
-                # grep for attributes that are not defined
-                self.pkg("info jade")
-                self.assertTrue("info.foo" not in self.output) 
+        # grep for some attributes that are defined and they have
+        # multiple values
+        self.pkg("info jade")
+        self.assertTrue("Project Maintainer" in self.output)
 
-        def test_info_bad_packages(self):
-                """Verify that pkg info handles packages with invalid
-                metadata."""
+        # grep for some attributes that are defined , with no value
+        self.pkg("info jade")
+        self.assertTrue("Project Maintainer URL" not in self.output)
 
-                self.image_create(self.rurl)
+        # grep for same attributes that are defined above in different
+        # packages, with some value
+        self.pkg("info copper")
+        self.assertTrue("Project Maintainer URL" in self.output)
 
-                # Verify that no packages are installed.
-                self.pkg("list", exit=1)
-                plist = self.plist[:2]
+        # grep for attributes that are not defined
+        self.pkg("info jade")
+        self.assertTrue("info.foo" not in self.output)
 
-                # This should succeed and cause the manifests to be cached.
-                self.pkg("info -r {0}".format(" ".join(p for p in plist)))
+    def test_info_bad_packages(self):
+        """Verify that pkg info handles packages with invalid
+        metadata."""
 
-                # Now attempt to corrupt the client's copy of the manifest by
-                # adding malformed actions.
-                for p in plist:
-                        self.debug("Testing package {0} ...".format(p))
-                        pfmri = fmri.PkgFmri(p)
-                        mdata = self.get_img_manifest(pfmri)
-                        if mdata.find("dir") != -1:
-                                src_mode = "mode=755"
-                        else:
-                                src_mode = "mode=644"
+        self.image_create(self.rurl)
 
-                        for bad_act in (
-                            'set name=description value="" \" my desc \" ""',
-                            "set name=com.sun.service.escalations value="):
-                                self.debug("Testing with bad action "
-                                    "'{0}'.".format(bad_act))
-                                bad_mdata = mdata + "{0}\n".format(bad_act)
-                                self.write_img_manifest(pfmri, bad_mdata)
-                                self.pkg("info -r {0}".format(pfmri.pkg_name), exit=0)
+        # Verify that no packages are installed.
+        self.pkg("list", exit=1)
+        plist = self.plist[:2]
 
-        def test_human_version(self):
-                """Verify that info returns the expected output for packages
-                with a human-readable version defined. If it is the same as
-                version number, then only version number is displayed"""
+        # This should succeed and cause the manifests to be cached.
+        self.pkg("info -r {0}".format(" ".join(p for p in plist)))
 
-                self.image_create(self.rurl)
-                self.pkg("info -r human | grep 'Version: 0.9.8.18 (0.9.8r)'")
+        # Now attempt to corrupt the client's copy of the manifest by
+        # adding malformed actions.
+        for p in plist:
+            self.debug("Testing package {0} ...".format(p))
+            pfmri = fmri.PkgFmri(p)
+            mdata = self.get_img_manifest(pfmri)
+            if mdata.find("dir") != -1:
+                src_mode = "mode=755"
+            else:
+                src_mode = "mode=644"
 
-                # Verify that human version number should not be displayed
-                # if it is identical to the version number.
-                self.pkg("info -r human2 | grep 'Version: 0.9.8.18$'")
+            for bad_act in (
+                'set name=description value="" " my desc " ""',
+                "set name=com.sun.service.escalations value=",
+            ):
+                self.debug("Testing with bad action " "'{0}'.".format(bad_act))
+                bad_mdata = mdata + "{0}\n".format(bad_act)
+                self.write_img_manifest(pfmri, bad_mdata)
+                self.pkg("info -r {0}".format(pfmri.pkg_name), exit=0)
 
-        def test_ranked(self):
-                """Verify that pkg info -r returns expected results when
-                multiple publishers provide the same package based on
-                publisher search order."""
+    def test_human_version(self):
+        """Verify that info returns the expected output for packages
+        with a human-readable version defined. If it is the same as
+        version number, then only version number is displayed"""
 
-                # because we compare date strings we must run this in
-                # a consistent locale, which we made 'C'
+        self.image_create(self.rurl)
+        self.pkg("info -r human | grep 'Version: 0.9.8.18 (0.9.8r)'")
 
-                os.environ['LC_ALL'] = 'C'
+        # Verify that human version number should not be displayed
+        # if it is identical to the version number.
+        self.pkg("info -r human2 | grep 'Version: 0.9.8.18$'")
 
-                # Create an isolated repository for this test
-                repodir = os.path.join(self.test_root, "test-ranked")
-                self.create_repo(repodir)
-                self.pkgrepo("add-publisher -s {0} test".format(repodir))
-                self.pkgsend_bulk(repodir, (self.bronze10, self.human))
+    def test_ranked(self):
+        """Verify that pkg info -r returns expected results when
+        multiple publishers provide the same package based on
+        publisher search order."""
 
-                self.pkgrepo("add-publisher -s {0} test2".format(repodir))
-                self.pkgrepo("set -s {0} publisher/prefix=test2".format(repodir))
-                self.pkgsend_bulk(repodir, self.bronze10)
+        # because we compare date strings we must run this in
+        # a consistent locale, which we made 'C'
 
-                self.pkgrepo("add-publisher -s {0} test3".format(repodir))
-                self.pkgrepo("set -s {0} publisher/prefix=test3".format(repodir))
-                self.pkgsend_bulk(repodir, self.bronze10)
+        os.environ["LC_ALL"] = "C"
 
-                # Create a test image.
-                self.image_create()
-                self.pkg("set-publisher -p {0}".format(repodir))
+        # Create an isolated repository for this test
+        repodir = os.path.join(self.test_root, "test-ranked")
+        self.create_repo(repodir)
+        self.pkgrepo("add-publisher -s {0} test".format(repodir))
+        self.pkgsend_bulk(repodir, (self.bronze10, self.human))
 
-                # Test should be higher ranked than test2 since the default
-                # for auto-configuration is to use lexical order when
-                # multiple publishers are found.  As such, info -r should
-                # return results for 'test' by default.
-                self.pkg("info -r bronze human")
-                expected = """\
+        self.pkgrepo("add-publisher -s {0} test2".format(repodir))
+        self.pkgrepo("set -s {0} publisher/prefix=test2".format(repodir))
+        self.pkgsend_bulk(repodir, self.bronze10)
+
+        self.pkgrepo("add-publisher -s {0} test3".format(repodir))
+        self.pkgrepo("set -s {0} publisher/prefix=test3".format(repodir))
+        self.pkgsend_bulk(repodir, self.bronze10)
+
+        # Create a test image.
+        self.image_create()
+        self.pkg("set-publisher -p {0}".format(repodir))
+
+        # Test should be higher ranked than test2 since the default
+        # for auto-configuration is to use lexical order when
+        # multiple publishers are found.  As such, info -r should
+        # return results for 'test' by default.
+        self.pkg("info -r bronze human")
+        expected = """\
  Name: bronze
  State: Not installed
  Publisher: test
@@ -493,12 +537,12 @@ Packaging Date: Sat Sep 10 00:45:46 2011
  Size: 0.00 B
  FMRI: pkg://test/human@0.9.8.18-0:20110910T004546Z
 """
-                self.assertEqualDiff(expected, self.reduceSpaces(self.output))
+        self.assertEqualDiff(expected, self.reduceSpaces(self.output))
 
-                # Verify that if the publisher is specified, that is preferred
-                # over rank.
-                self.pkg("info -r //test2/bronze")
-                expected = """\
+        # Verify that if the publisher is specified, that is preferred
+        # over rank.
+        self.pkg("info -r //test2/bronze")
+        expected = """\
  Name: bronze
  State: Not installed
  Publisher: test2
@@ -508,13 +552,13 @@ Packaging Date: Sat Sep 10 00:45:46 2011
  Size: 54.00 B
  FMRI: pkg://test2/bronze@1.0-0:20110910T004546Z
 """
-                self.assertEqualDiff(expected, self.reduceSpaces(self.output))
+        self.assertEqualDiff(expected, self.reduceSpaces(self.output))
 
-                # Verify that if stem is specified with and without publisher,
-                # both matches are listed if the higher-ranked publisher differs
-                # from the publisher specified.
-                self.pkg("info -r //test/bronze bronze")
-                expected = """\
+        # Verify that if stem is specified with and without publisher,
+        # both matches are listed if the higher-ranked publisher differs
+        # from the publisher specified.
+        self.pkg("info -r //test/bronze bronze")
+        expected = """\
  Name: bronze
  State: Not installed
  Publisher: test
@@ -524,10 +568,10 @@ Packaging Date: Sat Sep 10 00:45:46 2011
  Size: 54.00 B
  FMRI: pkg://test/bronze@1.0-0:20110910T004546Z
 """
-                self.assertEqualDiff(expected, self.reduceSpaces(self.output))
+        self.assertEqualDiff(expected, self.reduceSpaces(self.output))
 
-                self.pkg("info -r //test2/bronze bronze")
-                expected = """\
+        self.pkg("info -r //test2/bronze bronze")
+        expected = """\
  Name: bronze
  State: Not installed
  Publisher: test
@@ -546,10 +590,10 @@ Packaging Date: Sat Sep 10 00:45:46 2011
  Size: 54.00 B
  FMRI: pkg://test2/bronze@1.0-0:20110910T004546Z
 """
-                self.assertEqualDiff(expected, self.reduceSpaces(self.output))
+        self.assertEqualDiff(expected, self.reduceSpaces(self.output))
 
-                self.pkg("info -r //test3/bronze //test2/bronze bronze")
-                expected = """\
+        self.pkg("info -r //test3/bronze //test2/bronze bronze")
+        expected = """\
  Name: bronze
  State: Not installed
  Publisher: test
@@ -577,26 +621,26 @@ Packaging Date: Sat Sep 10 00:45:46 2011
  Size: 54.00 B
  FMRI: pkg://test3/bronze@1.0-0:20110910T004546Z
 """
-                self.assertEqualDiff(expected, self.reduceSpaces(self.output))
+        self.assertEqualDiff(expected, self.reduceSpaces(self.output))
 
-                if six.PY3:
-                        os.environ["LC_ALL"] = "en_US.UTF-8"
+        if six.PY3:
+            os.environ["LC_ALL"] = "en_US.UTF-8"
 
-        def test_renamed_packages(self):
-                """Verify that info returns the expected output for renamed
-                packages."""
+    def test_renamed_packages(self):
+        """Verify that info returns the expected output for renamed
+        packages."""
 
-                # because we compare date strings we must run this in
-                # a consistent locale, which we made 'C'
-                os.environ['LC_ALL'] = 'C'
+        # because we compare date strings we must run this in
+        # a consistent locale, which we made 'C'
+        os.environ["LC_ALL"] = "C"
 
-                target10 = """
+        target10 = """
                     open target@1.0
                     close
                 """
 
-                # Renamed package for all variants, with correct dependencies.
-                ren_correct10 = """
+        # Renamed package for all variants, with correct dependencies.
+        ren_correct10 = """
                     open ren_correct@1.0
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=target@1.0 variant.cat=bobcat
@@ -604,48 +648,55 @@ Packaging Date: Sat Sep 10 00:45:46 2011
                     close
                 """
 
-                # Renamed package for other variant, with dependencies only for
-                # for other variant.
-                ren_op_variant10 = """
+        # Renamed package for other variant, with dependencies only for
+        # for other variant.
+        ren_op_variant10 = """
                     open ren_op_variant@1.0
                     add set name=pkg.renamed value=true variant.cat=lynx
                     add depend type=require fmri=target@1.0 variant.cat=lynx
                     close
                 """
 
-                # Renamed package for current image variant, with dependencies
-                # only for other variant.
-                ren_variant_missing10 = """
+        # Renamed package for current image variant, with dependencies
+        # only for other variant.
+        ren_variant_missing10 = """
                     open ren_variant_missing@1.0
                     add set name=pkg.renamed value=true variant.cat=bobcat
                     add depend type=require fmri=target@1.0 variant.cat=lynx
                     close
                 """
 
-                # Renamed package for multiple variants, with dependencies
-                # missing for one variant.
-                ren_partial_variant10 = """
+        # Renamed package for multiple variants, with dependencies
+        # missing for one variant.
+        ren_partial_variant10 = """
                     open ren_partial_variant@1.0
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=target@1.0 variant.cat=lynx
                     close
                 """
 
-                plist = self.pkgsend_bulk(self.rurl, (target10, ren_correct10,
-                    ren_op_variant10, ren_variant_missing10,
-                    ren_partial_variant10))
+        plist = self.pkgsend_bulk(
+            self.rurl,
+            (
+                target10,
+                ren_correct10,
+                ren_op_variant10,
+                ren_variant_missing10,
+                ren_partial_variant10,
+            ),
+        )
 
-                # Create an image.
-                variants = { "variant.cat": "bobcat" }
-                self.image_create(self.rurl, variants=variants)
+        # Create an image.
+        variants = {"variant.cat": "bobcat"}
+        self.image_create(self.rurl, variants=variants)
 
-                # First, verify that a renamed package (for all variants), and
-                # with the correct dependencies will provide the expected info.
-                self.pkg("info -r ren_correct")
-                actual = self.output
-                pfmri = fmri.PkgFmri(plist[1])
-                pkg_date = pfmri.version.get_timestamp().strftime("%c")
-                expected = """\
+        # First, verify that a renamed package (for all variants), and
+        # with the correct dependencies will provide the expected info.
+        self.pkg("info -r ren_correct")
+        actual = self.output
+        pfmri = fmri.PkgFmri(plist[1])
+        pkg_date = pfmri.version.get_timestamp().strftime("%c")
+        expected = """\
           Name: ren_correct
          State: Not installed (Renamed)
     Renamed to: target@1.0
@@ -655,19 +706,21 @@ Packaging Date: Sat Sep 10 00:45:46 2011
 Packaging Date: {pkg_date}
           Size: 0.00 B
           FMRI: {pkg_fmri}
-""".format(pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False))
-                self.assertEqualDiff(expected, actual)
+""".format(
+            pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False)
+        )
+        self.assertEqualDiff(expected, actual)
 
-                # Next, verify that a renamed package (for a variant not
-                # applicable to this image), and with dependencies that
-                # are only for that other variant will provide the expected
-                # info.  Ensure package isn't seen as renamed for current
-                # variant.
-                self.pkg("info -r ren_op_variant")
-                actual = self.output
-                pfmri = fmri.PkgFmri(plist[2])
-                pkg_date = pfmri.version.get_timestamp().strftime("%c")
-                expected = """\
+        # Next, verify that a renamed package (for a variant not
+        # applicable to this image), and with dependencies that
+        # are only for that other variant will provide the expected
+        # info.  Ensure package isn't seen as renamed for current
+        # variant.
+        self.pkg("info -r ren_op_variant")
+        actual = self.output
+        pfmri = fmri.PkgFmri(plist[2])
+        pkg_date = pfmri.version.get_timestamp().strftime("%c")
+        expected = """\
           Name: ren_op_variant
          State: Not installed
      Publisher: test
@@ -676,17 +729,19 @@ Packaging Date: {pkg_date}
 Packaging Date: {pkg_date}
           Size: 0.00 B
           FMRI: {pkg_fmri}
-""".format(pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False))
-                self.assertEqualDiff(expected, actual)
+""".format(
+            pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False)
+        )
+        self.assertEqualDiff(expected, actual)
 
-                # Next, verify that a renamed package (for a variant applicable
-                # to this image), and with dependencies that are only for that
-                # other variant will provide the expected info.
-                self.pkg("info -r ren_variant_missing")
-                actual = self.output
-                pfmri = fmri.PkgFmri(plist[3])
-                pkg_date = pfmri.version.get_timestamp().strftime("%c")
-                expected = """\
+        # Next, verify that a renamed package (for a variant applicable
+        # to this image), and with dependencies that are only for that
+        # other variant will provide the expected info.
+        self.pkg("info -r ren_variant_missing")
+        actual = self.output
+        pfmri = fmri.PkgFmri(plist[3])
+        pkg_date = pfmri.version.get_timestamp().strftime("%c")
+        expected = """\
           Name: ren_variant_missing
          State: Not installed (Renamed)
      Publisher: test
@@ -695,18 +750,19 @@ Packaging Date: {pkg_date}
 Packaging Date: {pkg_date}
           Size: 0.00 B
           FMRI: {pkg_fmri}
-""".format(pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False))
-                self.assertEqualDiff(expected, actual)
+""".format(
+            pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False)
+        )
+        self.assertEqualDiff(expected, actual)
 
-
-                # Next, verify that a renamed package (for all variants),
-                # but that is missing a dependency for the current variant
-                # will provide the expected info.
-                self.pkg("info -r ren_partial_variant")
-                actual = self.output
-                pfmri = fmri.PkgFmri(plist[4])
-                pkg_date = pfmri.version.get_timestamp().strftime("%c")
-                expected = """\
+        # Next, verify that a renamed package (for all variants),
+        # but that is missing a dependency for the current variant
+        # will provide the expected info.
+        self.pkg("info -r ren_partial_variant")
+        actual = self.output
+        pfmri = fmri.PkgFmri(plist[4])
+        pkg_date = pfmri.version.get_timestamp().strftime("%c")
+        expected = """\
           Name: ren_partial_variant
          State: Not installed (Renamed)
      Publisher: test
@@ -715,34 +771,36 @@ Packaging Date: {pkg_date}
 Packaging Date: {pkg_date}
           Size: 0.00 B
           FMRI: {pkg_fmri}
-""".format(pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False))
-                self.assertEqualDiff(expected, actual)
+""".format(
+            pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False)
+        )
+        self.assertEqualDiff(expected, actual)
 
-                if six.PY3:
-                        os.environ["LC_ALL"] = "en_US.UTF-8"
+        if six.PY3:
+            os.environ["LC_ALL"] = "en_US.UTF-8"
 
-        def test_legacy_packages(self):
-                """Verify that info returns the expected output for legacy
-                packages."""
+    def test_legacy_packages(self):
+        """Verify that info returns the expected output for legacy
+        packages."""
 
-                # because we compare date strings we must run this in
-                # a consistent locale, which we made 'C'
-                os.environ['LC_ALL'] = 'C'
+        # because we compare date strings we must run this in
+        # a consistent locale, which we made 'C'
+        os.environ["LC_ALL"] = "C"
 
-                target10 = """
+        target10 = """
                     open target@1.0
                     close
                 """
 
-                # Basic legacy package.
-                legacy_basic10 = """
+        # Basic legacy package.
+        legacy_basic10 = """
                     open legacy_basic@1.0
                     add set name=pkg.legacy value=true
                     close
                 """
 
-                # Legacy package which is also renamed.
-                legacy_renamed10 = """
+        # Legacy package which is also renamed.
+        legacy_renamed10 = """
                     open legacy_renamed@1.0
                     add set name=pkg.legacy value=true
                     add set name=pkg.renamed value=true
@@ -750,9 +808,9 @@ Packaging Date: {pkg_date}
                     close
                 """
 
-                # Another legacy & renamed package with
-                # a different order of attributes.
-                legacy_renamed20 = """
+        # Another legacy & renamed package with
+        # a different order of attributes.
+        legacy_renamed20 = """
                     open legacy_renamed@2.0
                     add set name=pkg.renamed value=true
                     add set name=pkg.legacy value=true
@@ -760,18 +818,20 @@ Packaging Date: {pkg_date}
                     close
                 """
 
-                plist = self.pkgsend_bulk(self.rurl, (target10, legacy_basic10,
-                    legacy_renamed10, legacy_renamed20))
+        plist = self.pkgsend_bulk(
+            self.rurl,
+            (target10, legacy_basic10, legacy_renamed10, legacy_renamed20),
+        )
 
-                # Create an image.
-                self.image_create(self.rurl)
+        # Create an image.
+        self.image_create(self.rurl)
 
-                # Verify that a legacy package will provide the expected info.
-                self.pkg("info -r legacy_basic")
-                actual = self.output
-                pfmri = fmri.PkgFmri(plist[1])
-                pkg_date = pfmri.version.get_timestamp().strftime("%c")
-                expected = """\
+        # Verify that a legacy package will provide the expected info.
+        self.pkg("info -r legacy_basic")
+        actual = self.output
+        pfmri = fmri.PkgFmri(plist[1])
+        pkg_date = pfmri.version.get_timestamp().strftime("%c")
+        expected = """\
           Name: legacy_basic
          State: Not installed (Legacy)
      Publisher: test
@@ -780,16 +840,18 @@ Packaging Date: {pkg_date}
 Packaging Date: {pkg_date}
           Size: 0.00 B
           FMRI: {pkg_fmri}
-""".format(pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False))
-                self.assertEqualDiff(expected, actual)
+""".format(
+            pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False)
+        )
+        self.assertEqualDiff(expected, actual)
 
-                # Next, verify that a legacy package, which is also renamed,
-                # will provide the expected info (rename takes precedence).
-                self.pkg("info -r legacy_renamed@1.0")
-                actual = self.output
-                pfmri = fmri.PkgFmri(plist[2])
-                pkg_date = pfmri.version.get_timestamp().strftime("%c")
-                expected = """\
+        # Next, verify that a legacy package, which is also renamed,
+        # will provide the expected info (rename takes precedence).
+        self.pkg("info -r legacy_renamed@1.0")
+        actual = self.output
+        pfmri = fmri.PkgFmri(plist[2])
+        pkg_date = pfmri.version.get_timestamp().strftime("%c")
+        expected = """\
           Name: legacy_renamed
          State: Not installed (Renamed)
     Renamed to: target@1.0
@@ -799,16 +861,18 @@ Packaging Date: {pkg_date}
 Packaging Date: {pkg_date}
           Size: 0.00 B
           FMRI: {pkg_fmri}
-""".format(pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False))
-                self.assertEqualDiff(expected, actual)
+""".format(
+            pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False)
+        )
+        self.assertEqualDiff(expected, actual)
 
-                # Next, verify that rename takes precedence no matter the
-                # order of attributes.
-                self.pkg("info -r legacy_renamed@2.0")
-                actual = self.output
-                pfmri = fmri.PkgFmri(plist[3])
-                pkg_date = pfmri.version.get_timestamp().strftime("%c")
-                expected = """\
+        # Next, verify that rename takes precedence no matter the
+        # order of attributes.
+        self.pkg("info -r legacy_renamed@2.0")
+        actual = self.output
+        pfmri = fmri.PkgFmri(plist[3])
+        pkg_date = pfmri.version.get_timestamp().strftime("%c")
+        expected = """\
           Name: legacy_renamed
          State: Not installed (Renamed)
     Renamed to: target@1.0
@@ -818,96 +882,125 @@ Packaging Date: {pkg_date}
 Packaging Date: {pkg_date}
           Size: 0.00 B
           FMRI: {pkg_fmri}
-""".format(pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False))
-                self.assertEqualDiff(expected, actual)
+""".format(
+            pkg_date=pkg_date, pkg_fmri=pfmri.get_fmri(include_build=False)
+        )
+        self.assertEqualDiff(expected, actual)
 
-                if six.PY3:
-                        os.environ["LC_ALL"] = "en_US.UTF-8"
+        if six.PY3:
+            os.environ["LC_ALL"] = "en_US.UTF-8"
 
-        def test_appropriate_license_files(self):
-                """Verify that the correct license file is displayed."""
+    def test_appropriate_license_files(self):
+        """Verify that the correct license file is displayed."""
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                self.pkg("info -r --license bronze")
-                self.assertEqual("tmp/copyright1\n", self.output)
-                self.pkg("info -r --license bronze@0.5")
-                self.assertEqual("tmp/copyright0\n", self.output)
+        self.pkg("info -r --license bronze")
+        self.assertEqual("tmp/copyright1\n", self.output)
+        self.pkg("info -r --license bronze@0.5")
+        self.assertEqual("tmp/copyright0\n", self.output)
 
-                self.pkg("install --licenses bronze@0.5")
-                self.assertTrue("tmp/copyright0" in self.output, "Expected "
-                    "tmp/copyright0 to be in the output of the install. Output "
-                    "was:\n{0}".format(self.output))
-                self.pkg("info -l --license bronze")
-                self.assertEqual("tmp/copyright0\n", self.output)
-                self.pkg("info -r --license bronze")
-                self.assertEqual("tmp/copyright1\n", self.output)
-                self.pkg("info -r --license bronze@1.0")
-                self.assertEqual("tmp/copyright1\n", self.output)
+        self.pkg("install --licenses bronze@0.5")
+        self.assertTrue(
+            "tmp/copyright0" in self.output,
+            "Expected "
+            "tmp/copyright0 to be in the output of the install. Output "
+            "was:\n{0}".format(self.output),
+        )
+        self.pkg("info -l --license bronze")
+        self.assertEqual("tmp/copyright0\n", self.output)
+        self.pkg("info -r --license bronze")
+        self.assertEqual("tmp/copyright1\n", self.output)
+        self.pkg("info -r --license bronze@1.0")
+        self.assertEqual("tmp/copyright1\n", self.output)
 
-                self.pkg("update --licenses bronze@1.0")
-                self.assertTrue("tmp/copyright1" in self.output, "Expected "
-                    "tmp/copyright1 to be in the output of the install. Output "
-                    "was:\n{0}".format(self.output))
-                self.pkg("info -r --license bronze")
-                self.assertEqual("tmp/copyright1\n", self.output)
-                self.pkg("info -l --license bronze")
-                self.assertEqual("tmp/copyright1\n", self.output)
-                self.pkg("info -r --license bronze@0.5")
-                self.assertEqual("tmp/copyright0\n", self.output)
+        self.pkg("update --licenses bronze@1.0")
+        self.assertTrue(
+            "tmp/copyright1" in self.output,
+            "Expected "
+            "tmp/copyright1 to be in the output of the install. Output "
+            "was:\n{0}".format(self.output),
+        )
+        self.pkg("info -r --license bronze")
+        self.assertEqual("tmp/copyright1\n", self.output)
+        self.pkg("info -l --license bronze")
+        self.assertEqual("tmp/copyright1\n", self.output)
+        self.pkg("info -r --license bronze@0.5")
+        self.assertEqual("tmp/copyright0\n", self.output)
 
-        def test_info_update_install(self):
-                """Test that pkg info will show last update and install time"""
+    def test_info_update_install(self):
+        """Test that pkg info will show last update and install time"""
 
-                os.environ["LC_ALL"] = "C"
-                self.image_create(self.rurl)
-                self.pkg("install bronze@0.5")
-                path = os.path.join(self.img_path(),
-                    "var/pkg/state/installed/catalog.base.C")
-                entry = json.load(open(path))["test"]["bronze"][0]["metadata"]
-                last_install = catalog.basic_ts_to_datetime(
-                    entry["last-install"]).strftime("%c")
-                self.pkg(("info bronze | grep 'Last Install Time: "
-                    "{0}'").format(last_install))
+        os.environ["LC_ALL"] = "C"
+        self.image_create(self.rurl)
+        self.pkg("install bronze@0.5")
+        path = os.path.join(
+            self.img_path(), "var/pkg/state/installed/catalog.base.C"
+        )
+        entry = json.load(open(path))["test"]["bronze"][0]["metadata"]
+        last_install = catalog.basic_ts_to_datetime(
+            entry["last-install"]
+        ).strftime("%c")
+        self.pkg(
+            ("info bronze | grep 'Last Install Time: " "{0}'").format(
+                last_install
+            )
+        )
 
-                # Now update the version.
-                self.pkg("install bronze@1.0")
-                entry = json.load(open(path))["test"]["bronze"][0]["metadata"]
-                last_install = catalog.basic_ts_to_datetime(
-                    entry["last-install"]).strftime("%c")
-                self.pkg(("info bronze | grep 'Last Install Time: "
-                    "{0}'").format(last_install))
+        # Now update the version.
+        self.pkg("install bronze@1.0")
+        entry = json.load(open(path))["test"]["bronze"][0]["metadata"]
+        last_install = catalog.basic_ts_to_datetime(
+            entry["last-install"]
+        ).strftime("%c")
+        self.pkg(
+            ("info bronze | grep 'Last Install Time: " "{0}'").format(
+                last_install
+            )
+        )
 
-                # Last update should be existed this time.
-                last_update = catalog.basic_ts_to_datetime(
-                    entry["last-update"]).strftime("%c")
-                self.pkg(("info bronze | grep 'Last Update Time: "
-                    "{0}'").format(last_update))
+        # Last update should be existed this time.
+        last_update = catalog.basic_ts_to_datetime(
+            entry["last-update"]
+        ).strftime("%c")
+        self.pkg(
+            ("info bronze | grep 'Last Update Time: " "{0}'").format(
+                last_update
+            )
+        )
 
-                # Perfrom a full refresh and ensure the last-update/install
-                # have been preserved.
-                self.pkg("refresh --full")
-                last_install = catalog.basic_ts_to_datetime(
-                    entry["last-install"]).strftime("%c")
-                self.pkg(("info bronze | grep 'Last Install Time: "
-                    "{0}'").format(last_install))
-                last_update = catalog.basic_ts_to_datetime(
-                    entry["last-update"]).strftime("%c")
-                self.pkg(("info bronze | grep 'Last Update Time: "
-                    "{0}'").format(last_update))
+        # Perfrom a full refresh and ensure the last-update/install
+        # have been preserved.
+        self.pkg("refresh --full")
+        last_install = catalog.basic_ts_to_datetime(
+            entry["last-install"]
+        ).strftime("%c")
+        self.pkg(
+            ("info bronze | grep 'Last Install Time: " "{0}'").format(
+                last_install
+            )
+        )
+        last_update = catalog.basic_ts_to_datetime(
+            entry["last-update"]
+        ).strftime("%c")
+        self.pkg(
+            ("info bronze | grep 'Last Update Time: " "{0}'").format(
+                last_update
+            )
+        )
 
-                if six.PY3:
-                        os.environ["LC_ALL"] = "en_US.UTF-8"
+        if six.PY3:
+            os.environ["LC_ALL"] = "en_US.UTF-8"
 
 
 class TestPkgInfoPerTestRepo(pkg5unittest.SingleDepotTestCase):
-        """A separate test class is needed because these tests modify packages
-        after they've been published and need to avoid corrupting packages for
-        other tests."""
+    """A separate test class is needed because these tests modify packages
+    after they've been published and need to avoid corrupting packages for
+    other tests."""
 
-        persistent_setup = False
+    persistent_setup = False
 
-        bronze10 = """
+    bronze10 = """
             open bronze@1.0,5.11-0:20110908T004546Z
             add dir mode=0755 owner=root group=bin path=/usr
             add dir mode=0755 owner=root group=bin path=/usr/bin
@@ -920,81 +1013,87 @@ class TestPkgInfoPerTestRepo(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        misc_files = [ "tmp/bronzeA1", "tmp/bronze1", "tmp/bronze2", "tmp/cat",
-            "tmp/copyright1", "tmp/sh"]
+    misc_files = [
+        "tmp/bronzeA1",
+        "tmp/bronze1",
+        "tmp/bronze2",
+        "tmp/cat",
+        "tmp/copyright1",
+        "tmp/sh",
+    ]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.plist = self.pkgsend_bulk(self.rurl, (self.bronze10))
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.plist = self.pkgsend_bulk(self.rurl, (self.bronze10))
 
-        def __mangle_license(self, fmri):
-                repo = self.dc.get_repo()
-                m_path = repo.manifest(fmri)
-                with open(m_path, "r") as fh:
-                        fmri_lines = fh.readlines()
-                with open(m_path, "w") as fh:
-                        a = None
-                        for l in fmri_lines:
-                                if "license=copyright" in l:
-                                        continue
-                                elif "path=etc/bronze1" in l:
-                                        a = actions.fromstr(l)
-                                fh.write(l)
-                        self.assertTrue(a)
-                        l = """\
+    def __mangle_license(self, fmri):
+        repo = self.dc.get_repo()
+        m_path = repo.manifest(fmri)
+        with open(m_path, "r") as fh:
+            fmri_lines = fh.readlines()
+        with open(m_path, "w") as fh:
+            a = None
+            for l in fmri_lines:
+                if "license=copyright" in l:
+                    continue
+                elif "path=etc/bronze1" in l:
+                    a = actions.fromstr(l)
+                fh.write(l)
+            self.assertTrue(a)
+            l = """\
 license {hash} license=foo chash={chash} pkg.csize={csize} \
 pkg.size={size}""".format(
-    hash=a.hash,
-    chash=a.attrs["chash"],
-    csize=a.attrs["pkg.csize"],
-    size=a.attrs["pkg.size"]
-)
-                        fh.write(l)
-                repo.rebuild()
+                hash=a.hash,
+                chash=a.attrs["chash"],
+                csize=a.attrs["pkg.csize"],
+                size=a.attrs["pkg.size"],
+            )
+            fh.write(l)
+        repo.rebuild()
 
-        def test_info_installed_changed_manifest(self):
-                """Test that if an installed manifest has changed in the
-                repository the original manifest is used for pkg info and info
-                -r."""
+    def test_info_installed_changed_manifest(self):
+        """Test that if an installed manifest has changed in the
+        repository the original manifest is used for pkg info and info
+        -r."""
 
-                self.image_create(self.rurl)
-                self.pkg("install bronze")
+        self.image_create(self.rurl)
+        self.pkg("install bronze")
 
-                self.pkg("info --license bronze")
-                self.assertTrue("tmp/copyright1" in self.output)
-                self.__mangle_license(self.plist[0])
+        self.pkg("info --license bronze")
+        self.assertTrue("tmp/copyright1" in self.output)
+        self.__mangle_license(self.plist[0])
 
-                self.pkg("refresh --full")
+        self.pkg("refresh --full")
 
-                self.pkg("info --license bronze")
-                self.assertTrue("tmp/bronze1" not in self.output)
-                self.assertTrue("tmp/copyright1" in self.output)
+        self.pkg("info --license bronze")
+        self.assertTrue("tmp/bronze1" not in self.output)
+        self.assertTrue("tmp/copyright1" in self.output)
 
-                self.pkg("info -r --license bronze")
-                self.assertTrue("tmp/bronze1" not in self.output)
-                self.assertTrue("tmp/copyright1" in self.output)
+        self.pkg("info -r --license bronze")
+        self.assertTrue("tmp/bronze1" not in self.output)
+        self.assertTrue("tmp/copyright1" in self.output)
 
-        def test_info_uninstalled_changed_manifest(self):
-                """Test that if an uninstalled manifest has changed in the
-                repository but is cached locally, that the changed manifest is
-                reflected in info -r."""
+    def test_info_uninstalled_changed_manifest(self):
+        """Test that if an uninstalled manifest has changed in the
+        repository but is cached locally, that the changed manifest is
+        reflected in info -r."""
 
-                # First test remote retrieval.
-                self.image_create(self.rurl)
+        # First test remote retrieval.
+        self.image_create(self.rurl)
 
-                self.pkg("info -r  --license bronze")
-                self.assertTrue("tmp/copyright1" in self.output)
-                self.__mangle_license(self.plist[0])
-                self.pkg("refresh --full")
+        self.pkg("info -r  --license bronze")
+        self.assertTrue("tmp/copyright1" in self.output)
+        self.__mangle_license(self.plist[0])
+        self.pkg("refresh --full")
 
-                self.pkg("info -r  --license bronze")
-                self.assertTrue("tmp/bronze1" in self.output)
-                self.assertTrue("tmp/copyright1" not in self.output)
+        self.pkg("info -r  --license bronze")
+        self.assertTrue("tmp/bronze1" in self.output)
+        self.assertTrue("tmp/copyright1" not in self.output)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_initinstall.py
+++ b/src/tests/cli/t_pkg_initinstall.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -35,10 +36,11 @@ import os
 import platform
 import unittest
 
-class TestPkgInitInstall(pkg5unittest.SingleDepotTestCase):
-        persistent_setup = True
 
-        core = """\
+class TestPkgInitInstall(pkg5unittest.SingleDepotTestCase):
+    persistent_setup = True
+
+    core = """\
         open core-os@1.0
         add set name=pkg.fmri value=pkg://solaris/system/core-os@1.0
         add set name=pkg.summary value="Core Solaris"
@@ -78,42 +80,49 @@ class TestPkgInitInstall(pkg5unittest.SingleDepotTestCase):
         add user username=webservd ftpuser=false gcos-field="WebServer Reserved UID" group=webservd home-dir=/ login-shell=/bin/sh password=*LK* uid=80
         close
 """
-        misc_files = { "etc/passwd":"", "etc/group":"", "etc/shadow":"", "etc/ftpd/ftpusers":"" }
+    misc_files = {
+        "etc/passwd": "",
+        "etc/group": "",
+        "etc/shadow": "",
+        "etc/ftpd/ftpusers": "",
+    }
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-        def file_in_image(self, path):
-                return open(os.path.join(self.get_img_path(), path))
+    def file_in_image(self, path):
+        return open(os.path.join(self.get_img_path(), path))
 
-        def file_is_sorted(self, path, column):
-                # make sure the ':' separated file is sorted in ascending order
-                # on the integer in the specified column
-                previous = None
-                for line in self.file_in_image(path):
-                        if previous is None:
-                                previous = int(line.split(":")[column])
-                        else:
-                                now = int(line.split(":")[column])
-                                self.assertTrue(now >= previous,
-                                    "{0} is not sorted by column {1}".format(
-                                    path, column))
+    def file_is_sorted(self, path, column):
+        # make sure the ':' separated file is sorted in ascending order
+        # on the integer in the specified column
+        previous = None
+        for line in self.file_in_image(path):
+            if previous is None:
+                previous = int(line.split(":")[column])
+            else:
+                now = int(line.split(":")[column])
+                self.assertTrue(
+                    now >= previous,
+                    "{0} is not sorted by column {1}".format(path, column),
+                )
 
-        def test_init_install(self):
-                """test initial install of stripped down core OS"""
+    def test_init_install(self):
+        """test initial install of stripped down core OS"""
 
-                plist = self.pkgsend_bulk(self.rurl, self.core)
-                self.image_create(self.rurl)
+        plist = self.pkgsend_bulk(self.rurl, self.core)
+        self.image_create(self.rurl)
 
-                self.pkg("install core-os")
-                self.pkg("verify")
+        self.pkg("install core-os")
+        self.pkg("verify")
 
-                # verify that /etc/passwd and /etc/group are in
-                # ascending [UG]ID order
+        # verify that /etc/passwd and /etc/group are in
+        # ascending [UG]ID order
 
-                self.file_is_sorted("etc/passwd", 2)
-                self.file_is_sorted("etc/group", 2)
+        self.file_is_sorted("etc/passwd", 2)
+        self.file_is_sorted("etc/group", 2)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_install.py
+++ b/src/tests/cli/t_pkg_install.py
@@ -27,8 +27,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -48,7 +49,12 @@ import unittest
 import locale
 from six.moves import range
 from six.moves.urllib.parse import quote
-from six.moves.urllib.request import urlopen, build_opener, ProxyHandler, Request
+from six.moves.urllib.request import (
+    urlopen,
+    build_opener,
+    ProxyHandler,
+    Request,
+)
 
 import pkg.actions
 import pkg.digest as digest
@@ -60,171 +66,171 @@ import pkg.portable as portable
 from pkg.client.pkgdefs import EXIT_OOPS
 
 try:
-        import pkg.sha512_t
-        sha512_supported = True
+    import pkg.sha512_t
+
+    sha512_supported = True
 except ImportError:
-        sha512_supported = False
+    sha512_supported = False
+
 
 class _TestHelper(object):
-        """Private helper class for shared functionality between test
-        classes."""
+    """Private helper class for shared functionality between test
+    classes."""
 
-        def _assertEditables(self, moved=[], removed=[], installed=[],
-            updated=[]):
-                """Private helper function that verifies that expected editables
-                are listed in parsable output.  If no editable of a given type
-                is specified, then no editable files are expected."""
+    def _assertEditables(self, moved=[], removed=[], installed=[], updated=[]):
+        """Private helper function that verifies that expected editables
+        are listed in parsable output.  If no editable of a given type
+        is specified, then no editable files are expected."""
 
-                changed = []
-                if moved:
-                        changed.append(['moved', moved])
-                if removed:
-                        changed.append(['removed', removed])
-                if installed:
-                        changed.append(['installed', installed])
-                if updated:
-                        changed.append(['updated', updated])
+        changed = []
+        if moved:
+            changed.append(["moved", moved])
+        if removed:
+            changed.append(["removed", removed])
+        if installed:
+            changed.append(["installed", installed])
+        if updated:
+            changed.append(["updated", updated])
 
-                self.assertEqualParsable(self.output,
-                        include=["change-editables"],
-                        change_editables=changed)
+        self.assertEqualParsable(
+            self.output, include=["change-editables"], change_editables=changed
+        )
 
 
 class TestPkgInstallBasics(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1 timestamp="20080731T024051Z"
             close """
-        foo11_timestamp = 1217472051
+    foo11_timestamp = 1217472051
 
-        foo12 = """
+    foo12 = """
             open foo@1.2,5.11-0
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
             close """
 
-        afoo10 = """
+    afoo10 = """
             open a/foo@1.0,5.11-0
             close """
 
-        boring10 = """
+    boring10 = """
             open boring@1.0,5.11-0
             close """
 
-        boring11 = """
+    boring11 = """
             open boring@1.1,5.11-0
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             add depend type=require fmri=pkg:/foo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        bar11 = """
+    bar11 = """
             open bar@1.1,5.11-0
             add depend type=require fmri=pkg:/foo@1.2
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        xfoo10 = """
+    xfoo10 = """
             open xfoo@1.0,5.11-0
             close """
 
-        xbar10 = """
+    xbar10 = """
             open xbar@1.0,5.11-0
             add depend type=require fmri=pkg:/xfoo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        xbar11 = """
+    xbar11 = """
             open xbar@1.1,5.11-0
             add depend type=require fmri=pkg:/xfoo@1.2
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-
-        bar12 = """
+    bar12 = """
             open bar@1.2,5.11-0
             add depend type=require fmri=pkg:/foo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             add depend type=require fmri=pkg:/foo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/baz mode=0555 owner=root group=bin path=/bin/baz
             close """
 
-        deep10 = """
+    deep10 = """
             open deep@1.0,5.11-0
             add depend type=require fmri=pkg:/bar@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        xdeep10 = """
+    xdeep10 = """
             open xdeep@1.0,5.11-0
             add depend type=require fmri=pkg:/xbar@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        ydeep10 = """
+    ydeep10 = """
             open ydeep@1.0,5.11-0
             add depend type=require fmri=pkg:/ybar@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        a6018_1 = """
+    a6018_1 = """
             open a6018@1.0,5.11-0
             close """
 
-        a6018_2 = """
+    a6018_2 = """
             open a6018@2.0,5.11-0
             close """
 
-        b6018_1 = """
+    b6018_1 = """
             open b6018@1.0,5.11-0
             add depend type=optional fmri=a6018@1
             close """
 
-        badfile10 = """
+    badfile10 = """
             open badfile@1.0,5.11-0
             add file tmp/baz mode=644 owner=root group=bin path=/foo/baz-file
             close """
 
-        baddir10 = """
+    baddir10 = """
             open baddir@1.0,5.11-0
             add dir mode=755 owner=root group=bin path=/foo/baz-dir
             close """
 
-        a16189 = """
+    a16189 = """
             open a16189@1.0,5.11-0
             add depend type=require fmri=pkg:/b16189@1.0
             close """
 
-        b16189 = """
+    b16189 = """
             open b16189@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        fuzzy = """
+    fuzzy = """
             open fuzzy@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path="opt/dir with white\tspace"
             add file tmp/cat mode=0644 owner=root group=bin path="opt/dir with white\tspace/cat in a hat"
@@ -235,67 +241,67 @@ class TestPkgInstallBasics(pkg5unittest.SingleDepotTestCase):
             add link path=etc/cat_link target="../opt/dir with white\tspace/cat in a hat"
             close """
 
-        ffoo10 = """
+    ffoo10 = """
             open ffoo@1.0,5.11-0
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
             close """
 
-        ffoo11 = """
+    ffoo11 = """
             open ffoo@1.1,5.11-0
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
             close """
 
-        fbar10 = """
+    fbar10 = """
             open fbar@1.0,5.11-0
             add depend type=require fmri=pkg:/ffoo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        fbar11 = """
+    fbar11 = """
             open fbar@1.1,5.11-0
             add depend type=require fmri=pkg:/ffoo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cät
             close """
 
-        secret1 = """
+    secret1 = """
             open secret1@1.0-0
             add dir mode=0755 owner=root group=bin path=/p1
             add file tmp/cat mode=0555 owner=root group=bin sysattr=SH path=/p1/cat
             close """
 
-        secret2 = """
+    secret2 = """
             open secret2@1.0-0
             add dir mode=0755 owner=root group=bin path=/p2
             add file tmp/cat mode=0555 owner=root group=bin sysattr=hidden,system path=/p2/cat
             close """
 
-        secret3 = """
+    secret3 = """
             open secret3@1.0-0
             add dir mode=0755 owner=root group=bin path=/p3
             add file tmp/cat mode=0555 owner=root group=bin sysattr=horst path=/p3/cat
             close """
 
-        secret4 = """
+    secret4 = """
             open secret4@1.0-0
             add dir mode=0755 owner=root group=bin path=/p3
             add file tmp/cat mode=0555 owner=root group=bin sysattr=hidden,horst path=/p3/cat
             close """
 
-        secret5 = """
+    secret5 = """
             open secret5@1.0-0
             add dir mode=0755 owner=root group=bin path=/p3
             add file tmp/cat mode=0555 owner=root group=bin sysattr=hidden sysattr=system path=/p3/cat
             close """
 
-        secret6 = """
+    secret6 = """
             open secret6@1.0-0
             add dir mode=0755 owner=root group=bin path=/p3
             add file tmp/cat mode=0555 owner=root group=bin sysattr=hidden,readonly sysattr=system path=/p4/cat
             close """
 
-        rofiles = """
+    rofiles = """
             open rofilesdir@1.0-0
             add dir mode=0755 owner=root group=bin path=rofdir
             close
@@ -303,2326 +309,2377 @@ class TestPkgInstallBasics(pkg5unittest.SingleDepotTestCase):
             add file tmp/cat mode=0444 owner=root group=bin path=rofdir/rofile
             close """
 
-        filemissing = """
+    filemissing = """
             open filemissing@1.0,5.11:20160426T084036Z
             add file tmp/truck1 path=opt/truck1 mode=755 owner=root group=bin
             close
         """
 
-        manimissing = """
+    manimissing = """
             open manimissing@1.0,5.11:20160426T084036Z
             add file tmp/truck2 path=opt/truck2 mode=755 owner=root group=bin
             close
         """
 
-        fhashes = {
-            "tmp/truck1": "c9e257b659ace6c3fbc4d334f49326b3889fd109",
-            "tmp/truck2": "c07fd27b5b57f8131f42e5f2c719a469d9fc71c5"
-        }
-
-        misc_files = [ "tmp/libc.so.1", "tmp/cat", "tmp/baz", "tmp/truck1",
-            "tmp/truck2" ]
-
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-
-        def __get_mf_path(self, fmri_str, pub=None):
-                """Given an FMRI, return the path to its manifest in our
-                repository."""
-
-                usepub = "test"
-                if pub:
-                        usepub = pub
-                path_comps = [self.dc.get_repodir(), "publisher",
-                    usepub, "pkg"]
-                pfmri = pkg.fmri.PkgFmri(fmri_str)
-                path_comps.append(pfmri.get_name())
-                path_comps.append(pfmri.get_link_path().split("@")[1])
-                return os.path.sep.join(path_comps)
-
-        def __get_file_path(self, path):
-                """Returns the path to a file in the repository. The path name
-                must be present in self.fhashes."""
-
-                fpath = os.path.sep.join([self.dc.get_repodir(), "publisher",
-                    "test", "file"])
-                fhash = self.fhashes[path]
-                return os.path.sep.join([fpath, fhash[0:2], fhash])
-
-        def __inject_nofile(self, path):
-                fpath = self.__get_file_path(path)
-                os.remove(fpath)
-                return fpath
-
-        def __inject_nomanifest(self, fmri_str):
-                mpath = self.__get_mf_path(fmri_str)
-                os.remove(mpath)
-
-        def test_cli(self):
-                """Test bad cli options"""
-
-                self.cli_helper("install")
-                self.cli_helper("exact-install")
-
-        def cli_helper(self, install_cmd):
-                self.image_create(self.rurl)
-
-                self.pkg("-@", exit=2)
-                self.pkg("-s status", exit=2)
-                self.pkg("-R status", exit=2)
-
-                self.pkg("{0} -@ foo".format(install_cmd), exit=2)
-                self.pkg("{0} -vq foo".format(install_cmd), exit=2)
-                self.pkg("{0}".format(install_cmd), exit=2)
-                self.pkg("{0} foo@x.y".format(install_cmd), exit=1)
-                self.pkg("{0} pkg:/foo@bar.baz".format(install_cmd), exit=1)
-
-        def test_basics_1_install(self):
-                """Send empty package foo@1.0, install and uninstall """
-
-                plist = self.pkgsend_bulk(self.rurl, self.foo10)
-                self.image_create(self.rurl)
-
-                self.pkg("list -a")
-                self.pkg("list", exit=1)
-
-                self.pkg("install --parsable=0 foo")
-                self.assertEqualParsable(self.output,
-                    add_packages=plist)
-
-                self.pkg("list")
-                self.pkg("verify")
-
-                self.pkg("uninstall --parsable=0 foo")
-                self.assertEqualParsable(self.output,
-                    remove_packages=plist)
-                self.pkg("verify")
-
-        def test_basics_1_exact_install(self):
-                """ Send empty package foo@1.0, exact-install and uninstall """
-
-                plist = self.pkgsend_bulk(self.rurl, self.foo10)
-                self.image_create(self.rurl)
-
-                self.pkg("list -a")
-                self.pkg("list", exit=1)
-
-                self.pkg("exact-install --parsable=0 foo")
-                self.assertEqualParsable(self.output,
-                    add_packages=plist)
-
-                # Exact-install the same version should do nothing.
-                self.pkg("exact-install foo", exit=4)
-                self.pkg("list")
-                self.pkg("verify")
-
-                self.pkg("uninstall --parsable=0 foo")
-                self.assertEqualParsable(self.output,
-                    remove_packages=plist)
-                self.pkg("verify")
-
-        def test_basics_2(self):
-                """ Send package foo@1.1, containing a directory and a file,
-                    install or exact-install, search, and uninstall. """
-
-                self.basics_2_helper("install")
-                self.basics_2_helper("exact-install")
-
-        def basics_2_helper(self, install_cmd):
-                # This test needs to use the depot to be able to test the
-                # download cache.
-                self.dc.start()
-
-                self.pkgsend_bulk(self.durl, (self.foo10, self.foo11),
-                    refresh_index=True)
-                self.image_create(self.durl)
-
-                self.pkg("list -a")
-                self.pkg("{0} foo".format(install_cmd))
-
-                # Verify that content cache is empty after successful install
-                # or exact-install.
-                api_inst = self.get_img_api_obj()
-                img_inst = api_inst.img
-                cache_dirs = []
-                for path, readonly, pub, layout in img_inst.get_cachedirs():
-                        if os.path.exists(path):
-                                cache_dirs.extend(os.listdir(path))
-                self.assertEqual(cache_dirs, [])
-
-                self.pkg("verify")
-                self.pkg("list")
-
-                self.pkg("search -l /lib/libc.so.1")
-                self.pkg("search -r /lib/libc.so.1")
-                self.pkg("search -l blah", exit=1)
-                self.pkg("search -r blah", exit=1)
-
-                # check to make sure timestamp was set to correct value
-                libc_path = os.path.join(self.get_img_path(), "lib/libc.so.1")
-                lstat = os.stat(libc_path)
-
-                assert (lstat[stat.ST_MTIME] == self.foo11_timestamp)
-
-                # check that verify finds changes
-                now = time.time()
-                os.utime(libc_path, (now, now))
-                self.pkg("verify", exit=1)
-
-                self.pkg("uninstall foo")
-                self.pkg("verify")
-                self.pkg("list -a")
-                self.pkg("verify")
-                self.dc.stop()
-
-        def test_basics_3(self):
-                """Exact-install or Install foo@1.0, upgrade to foo@1.1,
-                uninstall. """
-
-                self.basics_3_helper("install")
-                self.basics_3_helper("exact-install")
-
-        def basics_3_helper(self, installed_cmd):
-                # This test needs to use the depot to be able to test the
-                # download cache.
-                self.dc.start()
-
-                self.pkgsend_bulk(self.durl, (self.foo10, self.foo11))
-                self.image_create(self.durl)
-                self.pkg("set-property flush-content-cache-on-success False")
-
-                # Verify that content cache is empty before install or
-                # exact-install.
-                api_inst = self.get_img_api_obj()
-                img_inst = api_inst.img
-                cache_dirs = []
-                for path, readonly, pub, layout in img_inst.get_cachedirs():
-                        if os.path.exists(path):
-                                cache_dirs.extend(os.listdir(path))
-                self.assertEqual(cache_dirs, [])
-
-                self.pkg("{0} foo@1.0".format(installed_cmd))
-                self.pkg("list foo@1.0")
-                self.pkg("list foo@1.1", exit=1)
-
-                self.pkg("{0} foo@1.1".format(installed_cmd))
-
-                # Verify that content cache is not empty after successful
-                # install or exact_install (since
-                # flush-content-cache-on-success is True by default) for
-                # packages that have content.
-                cache_dirs = []
-                for path, readonly, pub, layout in img_inst.get_cachedirs():
-                        if os.path.exists(path):
-                                cache_dirs.extend(os.listdir(path))
-                self.assertNotEqual(cache_dirs, [])
-
-                # Verify that "pkg clean" flushes the cache
-                self.pkg("clean")
-                cache_dirs = []
-                for path, readonly, pub, layout in img_inst.get_cachedirs():
-                        if os.path.exists(path):
-                                cache_dirs.extend(os.listdir(path))
-                self.assertEqual(cache_dirs, [])
-
-                self.pkg("list foo@1.1")
-                self.pkg("list foo@1.0", exit=1)
-                self.pkg("list foo@1")
-                self.pkg("verify")
-
-                self.pkg("uninstall foo")
-                self.pkg("list -a")
-                self.pkg("verify")
-                self.dc.stop()
-
-        def test_basics_4(self):
-                """ Add bar@1.0, dependent on foo@1.0, exact-install or
-                install, uninstall. """
-
-                self.basics_4_helper("install")
-                self.basics_4_helper("exact-install")
-
-        def basics_4_helper(self, installed_cmd):
-                # This test needs to use the depot to be able to test the
-                # download cache.
-                self.dc.start()
-
-                self.pkgsend_bulk(self.durl, (self.foo10, self.foo11,
-                    self.bar10))
-                self.image_create(self.durl)
-
-                # Set content cache to not be flushed on success.
-                self.pkg("set-property flush-content-cache-on-success False")
-
-                # Verify that content cache is empty before install or
-                # exact-install.
-                api_inst = self.get_img_api_obj()
-                img_inst = api_inst.img
-                cache_dirs = []
-                for path, readonly, pub, layout in img_inst.get_cachedirs():
-                        if os.path.exists(path):
-                                cache_dirs.extend(os.listdir(path))
-                self.assertEqual(cache_dirs, [])
-
-                self.pkg("list -a")
-                self.pkg("{0} bar@1.0".format(installed_cmd))
-
-                # Verify that content cache is not empty after successful
-                # install or exact-install (since
-                # flush-content-cache-on-success is False)
-                # for packages that have content.
-                cache_dirs = []
-                for path, readonly, pub, layout in img_inst.get_cachedirs():
-                        if os.path.exists(path):
-                                cache_dirs.extend(os.listdir(path))
-                self.assertNotEqual(cache_dirs, [])
-
-                self.pkg("list")
-                self.pkg("verify")
-                self.pkg("uninstall -v bar foo")
-
-                # foo and bar should not be installed at this point
-                self.pkg("list bar", exit=1)
-                self.pkg("list foo", exit=1)
-                self.pkg("verify")
-                self.dc.stop()
-
-        def test_basics_5_install(self):
-                """Install bar@1.0, upgrade to bar@1.1,
-                downgrade to bar@1.0.
-
-                Boring should be left alone, while
-                foo gets upgraded as needed"""
-
-                self.pkgsend_bulk(self.rurl, (self.bar10, self.bar11,
-                    self.foo10, self.foo11, self.foo12, self.boring10,
-                    self.boring11))
-                self.image_create(self.rurl)
-
-                self.pkg("install foo@1.0 bar@1.0 boring@1.0")
-                self.pkg("list foo@1.0 boring@1.0 bar@1.0")
-                self.pkg("install -v bar@1.1") # upgrade bar
-                self.pkg("list bar@1.1 foo@1.2 boring@1.0")
-                self.pkg("install -v bar@1.0") # downgrade bar
-                self.pkg("list bar@1.0 foo@1.2 boring@1.0")
-
-        def test_basics_5_exact_install(self):
-                """exact-install bar@1.0, upgrade to bar@1.1.
-                Boring should be left alone, while
-                foo gets upgraded as needed"""
-
-                self.pkgsend_bulk(self.rurl, (self.bar10, self.bar11,
-                    self.foo10, self.foo11, self.foo12, self.boring10,
-                    self.boring11))
-                self.image_create(self.rurl)
-
-                self.pkg("exact-install foo@1.0 bar@1.0 boring@1.0")
-                self.pkg("list foo@1.0 boring@1.0 bar@1.0")
-                self.pkg("exact-install -v bar@1.1") # upgrade bar
-                self.pkg("list bar@1.1 foo@1.2")
-                self.pkg("list boring@1.0", exit=1)
-
-        def test_basics_6_install(self):
-                """Verify that '@latest' will install the latest version
-                of a package."""
-
-                # Create a repository for the test publisher.
-                t1dir = os.path.join(self.test_root, "test-repo")
-                self.create_repo(t1dir, properties={ "publisher": {
-                    "prefix": "test" } })
-                self.pkgsend_bulk(t1dir, (self.bar10,
-                    self.foo10, self.foo11, self.foo12, self.boring10,
-                    self.boring11))
-                self.image_create("file:{0}".format(t1dir))
-
-                # Create a repository for a different publisher for at
-                # least one of the packages so that we can verify that
-                # publisher search order is accounted for by @latest.
-                # The second publisher is called 'pub2' here so that
-                # it comes lexically before 'test' (see bug 18180) to
-                # ensure that latest version ordering works correctly
-                # when the same stem is provided by different publishers.
-                t2dir = os.path.join(self.test_root, "pub2-repo")
-                self.create_repo(t2dir, properties={ "publisher": {
-                    "prefix": "pub2" } })
-                self.pkgsend_bulk(t2dir, self.bar11)
-
-                self.pkg("set-publisher -p {0}".format(t2dir))
-                self.pkg("install '*@latest'")
-
-                # 1.0 of bar should be installed here since pub2 is a
-                # lower-ranked publisher.
-                self.pkg("list")
-                self.pkg("info bar@1.0 foo@1.2 boring@1.1")
-
-                self.pkg("set-publisher --non-sticky test")
-                self.pkg("set-publisher -P pub2 ")
-                self.pkg("install bar@latest")
-
-                # 1.1 of bar should be installed here since pub2 is a
-                # higher-ranked publisher and test is non-sticky.
-                self.pkg("list")
-                self.pkg("info bar@1.1")
-
-                # Cleanup.
-                shutil.rmtree(t1dir)
-                shutil.rmtree(t2dir)
-
-        def test_basics_6_exact_install(self):
-                """Verify that '@latest' will install the latest version
-                of a package."""
-
-                # Create a repository for the test publisher.
-                t1dir = os.path.join(self.test_root, "test-repo")
-                self.create_repo(t1dir, properties={ "publisher": {
-                    "prefix": "test" } })
-                self.pkgsend_bulk(t1dir, (self.bar10,
-                    self.foo10, self.foo11, self.foo12, self.boring10,
-                    self.boring11))
-                self.image_create("file:{0}".format(t1dir))
-
-                # Create a repository for a different publisher for at
-                # least one of the packages so that we can verify that
-                # publisher search order is accounted for by @latest.
-                # The second publisher is called 'pub2' here so that
-                # it comes lexically before 'test' (see bug 18180) to
-                # ensure that latest version ordering works correctly
-                # when the same stem is provided by different publishers.
-                t2dir = os.path.join(self.test_root, "pub2-repo")
-                self.create_repo(t2dir, properties={ "publisher": {
-                    "prefix": "pub2" } })
-                self.pkgsend_bulk(t2dir, self.bar11)
-
-                self.pkg("set-publisher -p {0}".format(t2dir))
-                self.pkg("exact-install '*@latest'")
-
-                # 1.0 of bar should be installed here since pub2 is a
-                # lower-ranked publisher.
-                self.pkg("list")
-                self.pkg("info bar@1.0 foo@1.2 boring@1.1")
-
-                self.pkg("set-publisher --non-sticky test")
-                self.pkg("set-publisher -P pub2 ")
-                self.pkg("exact-install bar@latest")
-
-                # 1.1 of bar should be installed here since pub2 is a
-                # higher-ranked publisher and test is non-sticky.
-                self.pkg("info bar@1.1")
-                self.pkg("list foo@1.2")
-                self.pkg("list boring@1.1", exit=1)
-
-                # Cleanup.
-                shutil.rmtree(t1dir)
-                shutil.rmtree(t2dir)
-
-        def test_basics_7_install(self):
-                """Add bar@1.1, install bar@1.0. """
-
-                self.pkgsend_bulk(self.rurl, self.xbar11)
-                self.image_create(self.rurl)
-                self.pkg("install xbar@1.0", exit=1)
-
-        def test_basics_7_exact_install(self):
-                """Add bar@1.1, exact-install bar@1.0."""
-
-                self.pkgsend_bulk(self.rurl, self.xbar11)
-                self.image_create(self.rurl)
-                self.pkg("exact-install xbar@1.0", exit=1)
-
-        def test_basics_8_exact_install(self):
-                """Try to exact-install two versions of the same package."""
-
-                self.pkgsend_bulk(self.rurl, (self.foo11, self.foo12))
-                self.image_create(self.rurl)
-
-                self.pkg("exact-install foo@1.1 foo@1.2", exit=1)
-
-        def test_basics_9_exact_install(self):
-                """Verify downgrade will work with exact-install."""
-
-                self.pkgsend_bulk(self.rurl, (self.bar10, self.bar11,
-                    self.foo10, self.foo12))
-                self.image_create(self.rurl)
-
-                self.pkg("install bar@1.1")
-                self.pkg("exact-install bar@1.0")
-                self.pkg("list bar@1.0")
-                self.pkg("list foo@1.2")
-
-        def test_freeze_exact_install(self):
-                """Verify frozen packages can be relaxed with exact_install.
-                Which means we can ignore the frozen list with exact_install.
-                """
-
-                self.pkgsend_bulk(self.rurl, (self.fbar10, self.ffoo10,
-                    self.fbar11, self.ffoo11))
-                self.image_create(self.rurl)
-
-                # Freeze bar@1.0.
-                self.pkg("install fbar@1.0")
-                self.pkg("freeze fbar@1.0")
-                self.pkg("exact-install fbar@1.1")
-                self.pkg("list fbar@1.1")
-                self.pkg("list ffoo@1.1")
-                self.pkg("uninstall '*'")
-
-                # Freeze both bar@1.0 and foo@1.0.
-                self.image_create(self.rurl)
-                self.pkg("install fbar@1.0 ffoo@1.0")
-                self.pkg("freeze fbar@1.0")
-                self.pkg("freeze ffoo@1.0")
-                self.pkg("exact-install fbar@1.1")
-                self.pkg("list fbar@1.1")
-                self.pkg("list ffoo@1.1")
-
-        def test_basics_mdns(self):
-                """ Send empty package foo@1.0, install and uninstall """
-
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
-
-                self.pkg("set-property mirror-discovery True")
-                self.pkg("list -a")
-                self.pkg("list", exit=1)
-
-                self.pkg("install foo")
-
-                self.pkg("list")
-                self.pkg("verify")
-
-                self.pkg("uninstall foo")
-                self.pkg("verify")
-
-        def test_basics_ipv6(self):
-                """Verify package operations can be performed using a depot
-                server being addressed via IPv6."""
-
-                # This test needs to use the depot to be able to test
-                # IPv6 connectivity.
-                self.dc.set_address("::1")
-                self.dc.start()
-
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, (self.foo10, self.foo12))
-                self.wait_repo(self.dc.get_repodir())
-                self.image_create(durl)
-
-                self.pkg("install foo@1.0")
-                self.pkg("info foo@1.0")
-
-                self.pkg("update")
-                self.pkg("list")
-                self.pkg("info foo@1.2")
-                self.pkg("uninstall '*'")
-                self.dc.stop()
-                self.dc.set_address(None)
-
-        def test_image_upgrade(self):
-                """ Send package bar@1.1, dependent on foo@1.2.  Install
-                or exact-install bar@1.0.  List all packages.  Upgrade image.
-                """
-
-                self.image_upgrade_helper("install")
-                self.image_upgrade_helper("exact-install")
-
-        def image_upgrade_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11,
-                    self.bar10))
-                self.image_create(self.rurl)
-
-                self.pkg("{0} bar@1.0".format(install_cmd))
-
-                self.pkgsend_bulk(self.rurl, (self.foo12, self.bar11))
-                self.pkg("refresh")
-
-                self.pkg("contents -H")
-                self.pkg("list")
-                self.pkg("refresh")
-
-                self.pkg("list")
-                self.pkg("verify")
-                self.pkg("update -v")
-                self.pkg("verify")
-
-                self.pkg("list foo@1.2")
-                self.pkg("list bar@1.1")
-
-                self.pkg("uninstall bar foo")
-                self.pkg("verify")
-
-        def test_dependent_uninstall(self):
-                """Trying to remove a package that's a dependency of another
-                package should fail since uninstall isn't recursive."""
-
-                self.pkgsend_bulk(self.rurl, (self.foo10, self.bar10))
-                self.image_create(self.rurl)
-
-                self.pkg("install bar@1.0")
-
-                self.pkg("uninstall -v foo", exit=1)
-                self.pkg("list bar")
-                self.pkg("list foo")
-
-        def test_bug_1338(self):
-                """ Add bar@1.1, dependent on foo@1.2, install bar@1.1. """
-
-                self.pkg("list -a")
-                self.pkgsend_bulk(self.rurl, self.bar11)
-                self.image_create(self.rurl)
-
-                self.pkg("install xbar@1.1", exit=1)
-
-        def test_bug_1338_2(self):
-                """ Add bar@1.1, dependent on foo@1.2, and baz@1.0, dependent
-                    on foo@1.0, install baz@1.0 and bar@1.1. """
-
-                self.pkgsend_bulk(self.rurl, (self.bar11, self.baz10))
-                self.image_create(self.rurl)
-                self.pkg("list -a")
-                self.pkg("install baz@1.0 bar@1.1")
-
-        def test_bug_1338_3(self):
-                """ Add xdeep@1.0, xbar@1.0. xDeep@1.0 depends on xbar@1.0 which
-                    depends on xfoo@1.0, install xdeep@1.0. """
-
-                self.pkgsend_bulk(self.rurl, (self.xbar10, self.xdeep10))
-                self.image_create(self.rurl)
-
-                self.pkg("install xdeep@1.0", exit=1)
-
-        def test_bug_1338_4(self):
-                """ Add ydeep@1.0. yDeep@1.0 depends on ybar@1.0 which depends
-                on xfoo@1.0, install ydeep@1.0. """
-
-                self.pkgsend_bulk(self.rurl, self.ydeep10)
-                self.image_create(self.rurl)
-
-                self.pkg("install ydeep@1.0", exit=1)
-
-        def test_bug_2795(self):
-                """ Try to install two versions of the same package """
-
-                self.pkgsend_bulk(self.rurl, (self.foo11, self.foo12))
-                self.image_create(self.rurl)
-
-                self.pkg("install foo@1.1 foo@1.2", exit=1)
-
-        def test_bug_6018(self):
-                """  From original comment in bug report:
-
-                Consider a repository that contains:
-
-                a@1 and a@2
-
-                b@1 that contains an optional dependency on package a@1
-
-                If a@1 and b@1 are installed in an image, the "pkg update" command
-                produces the following output:
-
-                $ pkg update
-                No updates available for this image.
-
-                However, "pkg install a@2" works.
-                """
-
-                plist = self.pkgsend_bulk(self.rurl, (self.a6018_1,
-                    self.a6018_2, self.b6018_1))
-                self.image_create(self.rurl)
-                self.pkg("install b6018@1 a6018@1")
-                # Test the parsable output of update.
-                self.pkg("update --parsable=0")
-                self.assertEqualParsable(self.output,
-                    change_packages=[[plist[0], plist[1]]])
-                self.pkg("list b6018@1 a6018@2")
-
-        def test_install_matching(self):
-                """ Try to [un]install or exact-install packages matching a
-                pattern """
-
-                self.install_matching_helper("install")
-                self.install_matching_helper("exact-install")
-
-        def install_matching_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.foo10, self.bar10,
-                    self.baz10))
-                self.image_create(self.rurl)
-                # don't specify versions here; we have many
-                # different versions of foo, bar & baz in repo
-                # when entire class is run w/ one repo instance.
-
-                # first case should fail since multiple patterns
-                # match the same pacakge
-                self.pkg("{0} 'ba*' 'b*'".format(install_cmd), exit=1)
-                self.pkg("{0} 'ba*'".format(install_cmd), exit=0)
-                self.pkg("list foo", exit=0)
-                self.pkg("list bar", exit=0)
-                self.pkg("list baz", exit=0)
-                self.pkg("uninstall 'b*' 'f*'")
-
-                # However, multiple forms of the same pattern should simply be
-                # coalesced and allowed.
-                self.pkg("{0} pkg:/foo /foo ///foo pkg:///foo".format(install_cmd))
-                self.pkg("list")
-                self.pkg("verify pkg:/foo /foo ///foo pkg:///foo")
-                self.pkg("uninstall pkg:/foo /foo ///foo "
-                    "pkg:///foo")
-
-        def test_bad_package_actions(self):
-                """Test the install of packages that have actions that are
-                invalid."""
-
-                self.bad_package_actions("install")
-                self.bad_package_actions("exact-install")
-
-        def bad_package_actions(self, install_cmd):
-                # First, publish the package that will be corrupted and create
-                # an image for testing.
-                plist = self.pkgsend_bulk(self.rurl, (self.badfile10,
-                    self.baddir10))
-                self.image_create(self.rurl)
-
-                # This should succeed and cause the manifest to be cached.
-                self.pkg("{0} {1}".format(install_cmd, " ".join(plist)))
-
-                # While the manifest is cached, get a copy of its contents.
-                for p in plist:
-                        pfmri = fmri.PkgFmri(p)
-                        mdata = self.get_img_manifest(pfmri)
-                        if mdata.find("dir") != -1:
-                                src_mode = "mode=755"
-                        else:
-                                src_mode = "mode=644"
-
-                        # Now remove the package so corrupt case can be tested.
-                        self.pkg("uninstall {0}".format(pfmri.pkg_name))
-
-                        # Now attempt to corrupt the client's copy of the
-                        # manifest in various ways to check if the client
-                        # handles missing mode and invalid mode cases for
-                        # file and directory actions.
-                        for bad_mode in ("", 'mode=""', "mode=???"):
-                                self.debug("Testing with bad mode "
-                                    "'{0}'.".format(bad_mode))
-                                bad_mdata = mdata.replace(src_mode, bad_mode)
-                                self.write_img_manifest(pfmri, bad_mdata)
-                                self.pkg("--debug manifest_validate=Never "
-                                    "{0} {1}".format(install_cmd, pfmri.pkg_name),
-                                    exit=1)
-
-                        # Now attempt to corrupt the client's copy of the
-                        # manifest in various ways to check if the client
-                        # handles missing or invalid owners and groups.
-                        for bad_owner in ("", 'owner=""', "owner=invaliduser"):
-                                self.debug("Testing with bad owner "
-                                    "'{0}'.".format(bad_owner))
-
-                                bad_mdata = mdata.replace("owner=root",
-                                    bad_owner)
-                                self.write_img_manifest(pfmri, bad_mdata)
-                                self.pkg("--debug manifest_validate=Never "
-                                    "{0} {1}".format(install_cmd, pfmri.pkg_name),
-                                    exit=1)
-
-                        for bad_group in ("", 'group=""', "group=invalidgroup"):
-                                self.debug("Testing with bad group "
-                                    "'{0}'.".format(bad_group))
-
-                                bad_mdata = mdata.replace("group=bin",
-                                    bad_group)
-                                self.write_img_manifest(pfmri, bad_mdata)
-                                self.pkg("--debug manifest_validate=Never "
-                                    "{0} {1}".format(install_cmd, pfmri.pkg_name),
-                                    exit=1)
-
-                        # Now attempt to corrupt the client's copy of the
-                        # manifest such that actions are malformed.
-                        for bad_act in (
-                            'set name=description value="" \" my desc  ""',
-                            "set name=com.sun.service.escalations value="):
-                                self.debug("Testing with bad action "
-                                    "'{0}'.".format(bad_act))
-                                bad_mdata = mdata + "{0}\n".format(bad_act)
-                                self.write_img_manifest(pfmri, bad_mdata)
-                                self.pkg("--debug manifest_validate=Never "
-                                    "{0} {1}".format(install_cmd, pfmri.pkg_name),
-                                    exit=1)
-
-        def test_bug_3770(self):
-                """ Try to install a package from a publisher with an
-                unavailable repository. """
-
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
-
-                # Depot hasn't been started, so client can't connect.
-                self.pkg("set-publisher --no-refresh -O {0} test".format(self.durl))
-                self.pkg("install foo@1.1", exit=1)
-
-        def test_bug_9929(self):
-                """Make sure that we can uninstall a package that already
-                has its contents on disk even when the repository isn't
-                accessible."""
-
-                # Depot required for this test since client doesn't cache
-                # files from a file repository by default.
-                self.dc.start()
-                self.pkgsend_bulk(self.durl, self.foo11)
-                self.image_create(self.durl)
-
-                self.pkg("install foo")
-
-                # Stop depot, so client can't connect.
-                self.dc.stop()
-                self.pkg("set-publisher --no-refresh -O {0} test".format(self.durl))
-                self.pkg("uninstall foo")
-
-        def test_bug_16189(self):
-                """Create a repository with a pair of manifests.  Have
-                pkg A depend upon pkg B.  Rename pkg B on the depot-side
-                and attempt to install. This should fail, but not traceback.
-                Then, modify the manifest on the serverside, ensuring that
-                the contents don't match the hash.  Then try the install again.
-                This should also fail, but not traceback."""
-
-                afmri = self.pkgsend_bulk(self.rurl, self.a16189)
-                bfmri = self.pkgsend_bulk(self.rurl, self.b16189)
-                self.image_create(self.rurl)
-
-                repo = self.dc.get_repo()
-
-                bpath = repo.manifest(bfmri[0])
-                old_dirname = os.path.basename(os.path.dirname(bpath))
-                old_dirpath = os.path.dirname(os.path.dirname(bpath))
-                new_dirname = "potato"
-                old_path = os.path.join(old_dirpath, old_dirname)
-                new_path = os.path.join(old_dirpath, new_dirname)
-                os.rename(old_path, new_path)
-                self.pkg("install a16189", exit=1)
-
-                os.rename(new_path, old_path)
-                self.image_destroy()
-                self.image_create(self.rurl)
-
-                apath = repo.manifest(afmri[0])
-                afobj = open(apath, "w")
-                afobj.write("set name=pkg.summary value=\"banana\"\n")
-                afobj.close()
-                self.pkg("install a16189", exit=1)
-
-        def test_install_fuzz(self):
-                """Verify that packages delivering files with whitespace in
-                their paths can be installed or exact-installed, updated, and
-                uninstalled."""
-
-                self.pkgsend_bulk(self.rurl, self.fuzzy)
-                self.image_create(self.rurl)
-
-                self.pkg("install fuzzy@1")
-                self.pkg("verify -v")
-                self.pkg("update -vvv fuzzy@2")
-                self.pkg("verify -v")
-
-                for name in (
-                    "opt/dir with white\tspace/cat in a hat",
-                    "etc/cat_link",
-                ):
-                        self.debug("fname: {0}".format(name))
-                        self.assertTrue(os.path.exists(os.path.join(self.get_img_path(),
-                            name)))
-
-                self.pkg("uninstall -vvv fuzzy")
-
-        def test_sysattrs(self):
-                """Test install with setting system attributes."""
-
-                if portable.osname != "sunos":
-                        raise pkg5unittest.TestSkippedException(
-                            "System attributes unsupported on this platform.")
-
-                plist = self.pkgsend_bulk(self.rurl, [self.secret1,
-                    self.secret2, self.secret3, self.secret4, self.secret5,
-                    self.secret6])
-
-                # Try to install in /tmp which does not support system
-                # attributes. Just make sure we fail gracefully.
-                self.image_create(self.rurl)
-                self.pkg("install secret1")
-                self.assertTrue("WARNING" in self.errout)
-
-                # Need to create an image in /var/tmp since sysattrs don't work
-                # in tmpfs.
-                self.debug(self.rurl)
-                old_img_path = self.img_path()
-                self.set_img_path(tempfile.mkdtemp(dir="/var/tmp"))
-
-                self.image_create(self.rurl)
-
-                # test without permission for setting sensitive system attribute
-                self.pkg("install secret1", su_wrap=True, exit=1)
-
-                # now some tests which should succeed
-                self.pkg("install secret1")
-                fpath = os.path.join(self.img_path(),"p1/cat")
-                p = subprocess.Popen(["/usr/bin/ls", "-/", "c", fpath],
-                    stdout=subprocess.PIPE)
-                out, err = p.communicate()
-                # sensitive attr is not in 11 FCS, so no closing }
-                expected = b"{AH-S---m----"
-                self.assertTrue(expected in out, out)
-
-                self.pkg("install secret2")
-                fpath = os.path.join(self.img_path(),"p2/cat")
-                p = subprocess.Popen(["/usr/bin/ls", "-/", "c", fpath],
-                    stdout=subprocess.PIPE)
-                out, err = p.communicate()
-                # sensitive attr is not in 11 FCS, so no closing }
-                expected = b"{AH-S---m----"
-                self.assertTrue(expected in out, out)
-
-                # test some packages with invalid sysattrs
-                self.pkg("install secret3")
-                self.pkg("uninstall secret3")
-                self.pkg("install secret4")
-                self.pkg("uninstall secret4")
-
-                # test package with a file action that has multiple sysattr tags
-                self.pkg("install secret5")
-                self.pkg("uninstall secret5")
-                self.pkg("install secret6")
-
-                shutil.rmtree(self.img_path())
-                self.set_img_path(old_img_path)
-
-        def test_readonly_files(self):
-                """Ensure that packages containing files found in a read-only
-                directory or read-only files can be uninstalled."""
-
-                self.pkgsend_bulk(self.rurl, self.rofiles)
-                self.image_create(self.rurl)
-
-                # First, install parent directory package.
-                self.pkg("install -vvv rofilesdir@1.0")
-                pdir = os.path.join(self.get_img_path(), "rofdir")
-
-                # Next, install the package.  Note that this test intentionally
-                # does not cover the case of *installing* files to a read-only
-                # directory.
-                self.pkg("install -vvv rofiles@1.0")
-
-                # chmod parent directory to read-only and then verify that the
-                # package can still be uninstalled
-                os.chmod(pdir, 0o555)
-                self.pkg("verify -vvv rofilesdir", exit=1)
-                self.pkg("uninstall -vvv rofiles@1.0")
-
-                # Finally, verify directory mode was restored to 555.
-                try:
-                        self.dir_exists("rofdir", mode=0o555)
-                finally:
-                        # Ensure directory can be cleaned up.
-                        os.chmod(pdir, 0o755)
-
-        def test_error_messages(self):
-                """Verify that error messages for installing a package with a
-                file or manifest that cannot be retrieved include the package
-                FMRI."""
-
-                repo_path = self.dc.get_repodir()
-                durl = self.dc.get_depot_url()
-                self.dc.start()
-                self.image_create(durl)
-                # publish a single package and break it
-                fmris = self.pkgsend_bulk(repo_path, (self.filemissing,
-                    self.manimissing))
-                self.__inject_nofile("tmp/truck1")
-                self.pkg("install filemissing", exit=1)
-                self.assertTrue("pkg://test/filemissing@1.0,5.11:20160426T084036Z"
-                    in self.errout)
-                self.image_create("file://" + repo_path)
-                self.pkg("install filemissing", exit=1)
-                self.assertTrue("pkg://test/filemissing@1.0,5.11:20160426T084036Z"
-                    in self.errout)
-                self.__inject_nomanifest(fmris[1])
-                self.pkg("install manimissing", exit=1)
-                self.assertTrue("pkg://test/manimissing@1.0,5.11:20160426T084036Z"
-                    in self.errout)
-                self.dc.stop()
-
-        def test_install_to_reserved_directories(self):
-                """Ensure installation of new actions will fail when the delivered
-                files target reserved filesystem locations."""
-
-                b1 = """
+    fhashes = {
+        "tmp/truck1": "c9e257b659ace6c3fbc4d334f49326b3889fd109",
+        "tmp/truck2": "c07fd27b5b57f8131f42e5f2c719a469d9fc71c5",
+    }
+
+    misc_files = [
+        "tmp/libc.so.1",
+        "tmp/cat",
+        "tmp/baz",
+        "tmp/truck1",
+        "tmp/truck2",
+    ]
+
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+
+    def __get_mf_path(self, fmri_str, pub=None):
+        """Given an FMRI, return the path to its manifest in our
+        repository."""
+
+        usepub = "test"
+        if pub:
+            usepub = pub
+        path_comps = [self.dc.get_repodir(), "publisher", usepub, "pkg"]
+        pfmri = pkg.fmri.PkgFmri(fmri_str)
+        path_comps.append(pfmri.get_name())
+        path_comps.append(pfmri.get_link_path().split("@")[1])
+        return os.path.sep.join(path_comps)
+
+    def __get_file_path(self, path):
+        """Returns the path to a file in the repository. The path name
+        must be present in self.fhashes."""
+
+        fpath = os.path.sep.join(
+            [self.dc.get_repodir(), "publisher", "test", "file"]
+        )
+        fhash = self.fhashes[path]
+        return os.path.sep.join([fpath, fhash[0:2], fhash])
+
+    def __inject_nofile(self, path):
+        fpath = self.__get_file_path(path)
+        os.remove(fpath)
+        return fpath
+
+    def __inject_nomanifest(self, fmri_str):
+        mpath = self.__get_mf_path(fmri_str)
+        os.remove(mpath)
+
+    def test_cli(self):
+        """Test bad cli options"""
+
+        self.cli_helper("install")
+        self.cli_helper("exact-install")
+
+    def cli_helper(self, install_cmd):
+        self.image_create(self.rurl)
+
+        self.pkg("-@", exit=2)
+        self.pkg("-s status", exit=2)
+        self.pkg("-R status", exit=2)
+
+        self.pkg("{0} -@ foo".format(install_cmd), exit=2)
+        self.pkg("{0} -vq foo".format(install_cmd), exit=2)
+        self.pkg("{0}".format(install_cmd), exit=2)
+        self.pkg("{0} foo@x.y".format(install_cmd), exit=1)
+        self.pkg("{0} pkg:/foo@bar.baz".format(install_cmd), exit=1)
+
+    def test_basics_1_install(self):
+        """Send empty package foo@1.0, install and uninstall"""
+
+        plist = self.pkgsend_bulk(self.rurl, self.foo10)
+        self.image_create(self.rurl)
+
+        self.pkg("list -a")
+        self.pkg("list", exit=1)
+
+        self.pkg("install --parsable=0 foo")
+        self.assertEqualParsable(self.output, add_packages=plist)
+
+        self.pkg("list")
+        self.pkg("verify")
+
+        self.pkg("uninstall --parsable=0 foo")
+        self.assertEqualParsable(self.output, remove_packages=plist)
+        self.pkg("verify")
+
+    def test_basics_1_exact_install(self):
+        """Send empty package foo@1.0, exact-install and uninstall"""
+
+        plist = self.pkgsend_bulk(self.rurl, self.foo10)
+        self.image_create(self.rurl)
+
+        self.pkg("list -a")
+        self.pkg("list", exit=1)
+
+        self.pkg("exact-install --parsable=0 foo")
+        self.assertEqualParsable(self.output, add_packages=plist)
+
+        # Exact-install the same version should do nothing.
+        self.pkg("exact-install foo", exit=4)
+        self.pkg("list")
+        self.pkg("verify")
+
+        self.pkg("uninstall --parsable=0 foo")
+        self.assertEqualParsable(self.output, remove_packages=plist)
+        self.pkg("verify")
+
+    def test_basics_2(self):
+        """Send package foo@1.1, containing a directory and a file,
+        install or exact-install, search, and uninstall."""
+
+        self.basics_2_helper("install")
+        self.basics_2_helper("exact-install")
+
+    def basics_2_helper(self, install_cmd):
+        # This test needs to use the depot to be able to test the
+        # download cache.
+        self.dc.start()
+
+        self.pkgsend_bulk(
+            self.durl, (self.foo10, self.foo11), refresh_index=True
+        )
+        self.image_create(self.durl)
+
+        self.pkg("list -a")
+        self.pkg("{0} foo".format(install_cmd))
+
+        # Verify that content cache is empty after successful install
+        # or exact-install.
+        api_inst = self.get_img_api_obj()
+        img_inst = api_inst.img
+        cache_dirs = []
+        for path, readonly, pub, layout in img_inst.get_cachedirs():
+            if os.path.exists(path):
+                cache_dirs.extend(os.listdir(path))
+        self.assertEqual(cache_dirs, [])
+
+        self.pkg("verify")
+        self.pkg("list")
+
+        self.pkg("search -l /lib/libc.so.1")
+        self.pkg("search -r /lib/libc.so.1")
+        self.pkg("search -l blah", exit=1)
+        self.pkg("search -r blah", exit=1)
+
+        # check to make sure timestamp was set to correct value
+        libc_path = os.path.join(self.get_img_path(), "lib/libc.so.1")
+        lstat = os.stat(libc_path)
+
+        assert lstat[stat.ST_MTIME] == self.foo11_timestamp
+
+        # check that verify finds changes
+        now = time.time()
+        os.utime(libc_path, (now, now))
+        self.pkg("verify", exit=1)
+
+        self.pkg("uninstall foo")
+        self.pkg("verify")
+        self.pkg("list -a")
+        self.pkg("verify")
+        self.dc.stop()
+
+    def test_basics_3(self):
+        """Exact-install or Install foo@1.0, upgrade to foo@1.1,
+        uninstall."""
+
+        self.basics_3_helper("install")
+        self.basics_3_helper("exact-install")
+
+    def basics_3_helper(self, installed_cmd):
+        # This test needs to use the depot to be able to test the
+        # download cache.
+        self.dc.start()
+
+        self.pkgsend_bulk(self.durl, (self.foo10, self.foo11))
+        self.image_create(self.durl)
+        self.pkg("set-property flush-content-cache-on-success False")
+
+        # Verify that content cache is empty before install or
+        # exact-install.
+        api_inst = self.get_img_api_obj()
+        img_inst = api_inst.img
+        cache_dirs = []
+        for path, readonly, pub, layout in img_inst.get_cachedirs():
+            if os.path.exists(path):
+                cache_dirs.extend(os.listdir(path))
+        self.assertEqual(cache_dirs, [])
+
+        self.pkg("{0} foo@1.0".format(installed_cmd))
+        self.pkg("list foo@1.0")
+        self.pkg("list foo@1.1", exit=1)
+
+        self.pkg("{0} foo@1.1".format(installed_cmd))
+
+        # Verify that content cache is not empty after successful
+        # install or exact_install (since
+        # flush-content-cache-on-success is True by default) for
+        # packages that have content.
+        cache_dirs = []
+        for path, readonly, pub, layout in img_inst.get_cachedirs():
+            if os.path.exists(path):
+                cache_dirs.extend(os.listdir(path))
+        self.assertNotEqual(cache_dirs, [])
+
+        # Verify that "pkg clean" flushes the cache
+        self.pkg("clean")
+        cache_dirs = []
+        for path, readonly, pub, layout in img_inst.get_cachedirs():
+            if os.path.exists(path):
+                cache_dirs.extend(os.listdir(path))
+        self.assertEqual(cache_dirs, [])
+
+        self.pkg("list foo@1.1")
+        self.pkg("list foo@1.0", exit=1)
+        self.pkg("list foo@1")
+        self.pkg("verify")
+
+        self.pkg("uninstall foo")
+        self.pkg("list -a")
+        self.pkg("verify")
+        self.dc.stop()
+
+    def test_basics_4(self):
+        """Add bar@1.0, dependent on foo@1.0, exact-install or
+        install, uninstall."""
+
+        self.basics_4_helper("install")
+        self.basics_4_helper("exact-install")
+
+    def basics_4_helper(self, installed_cmd):
+        # This test needs to use the depot to be able to test the
+        # download cache.
+        self.dc.start()
+
+        self.pkgsend_bulk(self.durl, (self.foo10, self.foo11, self.bar10))
+        self.image_create(self.durl)
+
+        # Set content cache to not be flushed on success.
+        self.pkg("set-property flush-content-cache-on-success False")
+
+        # Verify that content cache is empty before install or
+        # exact-install.
+        api_inst = self.get_img_api_obj()
+        img_inst = api_inst.img
+        cache_dirs = []
+        for path, readonly, pub, layout in img_inst.get_cachedirs():
+            if os.path.exists(path):
+                cache_dirs.extend(os.listdir(path))
+        self.assertEqual(cache_dirs, [])
+
+        self.pkg("list -a")
+        self.pkg("{0} bar@1.0".format(installed_cmd))
+
+        # Verify that content cache is not empty after successful
+        # install or exact-install (since
+        # flush-content-cache-on-success is False)
+        # for packages that have content.
+        cache_dirs = []
+        for path, readonly, pub, layout in img_inst.get_cachedirs():
+            if os.path.exists(path):
+                cache_dirs.extend(os.listdir(path))
+        self.assertNotEqual(cache_dirs, [])
+
+        self.pkg("list")
+        self.pkg("verify")
+        self.pkg("uninstall -v bar foo")
+
+        # foo and bar should not be installed at this point
+        self.pkg("list bar", exit=1)
+        self.pkg("list foo", exit=1)
+        self.pkg("verify")
+        self.dc.stop()
+
+    def test_basics_5_install(self):
+        """Install bar@1.0, upgrade to bar@1.1,
+        downgrade to bar@1.0.
+
+        Boring should be left alone, while
+        foo gets upgraded as needed"""
+
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.bar10,
+                self.bar11,
+                self.foo10,
+                self.foo11,
+                self.foo12,
+                self.boring10,
+                self.boring11,
+            ),
+        )
+        self.image_create(self.rurl)
+
+        self.pkg("install foo@1.0 bar@1.0 boring@1.0")
+        self.pkg("list foo@1.0 boring@1.0 bar@1.0")
+        self.pkg("install -v bar@1.1")  # upgrade bar
+        self.pkg("list bar@1.1 foo@1.2 boring@1.0")
+        self.pkg("install -v bar@1.0")  # downgrade bar
+        self.pkg("list bar@1.0 foo@1.2 boring@1.0")
+
+    def test_basics_5_exact_install(self):
+        """exact-install bar@1.0, upgrade to bar@1.1.
+        Boring should be left alone, while
+        foo gets upgraded as needed"""
+
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.bar10,
+                self.bar11,
+                self.foo10,
+                self.foo11,
+                self.foo12,
+                self.boring10,
+                self.boring11,
+            ),
+        )
+        self.image_create(self.rurl)
+
+        self.pkg("exact-install foo@1.0 bar@1.0 boring@1.0")
+        self.pkg("list foo@1.0 boring@1.0 bar@1.0")
+        self.pkg("exact-install -v bar@1.1")  # upgrade bar
+        self.pkg("list bar@1.1 foo@1.2")
+        self.pkg("list boring@1.0", exit=1)
+
+    def test_basics_6_install(self):
+        """Verify that '@latest' will install the latest version
+        of a package."""
+
+        # Create a repository for the test publisher.
+        t1dir = os.path.join(self.test_root, "test-repo")
+        self.create_repo(t1dir, properties={"publisher": {"prefix": "test"}})
+        self.pkgsend_bulk(
+            t1dir,
+            (
+                self.bar10,
+                self.foo10,
+                self.foo11,
+                self.foo12,
+                self.boring10,
+                self.boring11,
+            ),
+        )
+        self.image_create("file:{0}".format(t1dir))
+
+        # Create a repository for a different publisher for at
+        # least one of the packages so that we can verify that
+        # publisher search order is accounted for by @latest.
+        # The second publisher is called 'pub2' here so that
+        # it comes lexically before 'test' (see bug 18180) to
+        # ensure that latest version ordering works correctly
+        # when the same stem is provided by different publishers.
+        t2dir = os.path.join(self.test_root, "pub2-repo")
+        self.create_repo(t2dir, properties={"publisher": {"prefix": "pub2"}})
+        self.pkgsend_bulk(t2dir, self.bar11)
+
+        self.pkg("set-publisher -p {0}".format(t2dir))
+        self.pkg("install '*@latest'")
+
+        # 1.0 of bar should be installed here since pub2 is a
+        # lower-ranked publisher.
+        self.pkg("list")
+        self.pkg("info bar@1.0 foo@1.2 boring@1.1")
+
+        self.pkg("set-publisher --non-sticky test")
+        self.pkg("set-publisher -P pub2 ")
+        self.pkg("install bar@latest")
+
+        # 1.1 of bar should be installed here since pub2 is a
+        # higher-ranked publisher and test is non-sticky.
+        self.pkg("list")
+        self.pkg("info bar@1.1")
+
+        # Cleanup.
+        shutil.rmtree(t1dir)
+        shutil.rmtree(t2dir)
+
+    def test_basics_6_exact_install(self):
+        """Verify that '@latest' will install the latest version
+        of a package."""
+
+        # Create a repository for the test publisher.
+        t1dir = os.path.join(self.test_root, "test-repo")
+        self.create_repo(t1dir, properties={"publisher": {"prefix": "test"}})
+        self.pkgsend_bulk(
+            t1dir,
+            (
+                self.bar10,
+                self.foo10,
+                self.foo11,
+                self.foo12,
+                self.boring10,
+                self.boring11,
+            ),
+        )
+        self.image_create("file:{0}".format(t1dir))
+
+        # Create a repository for a different publisher for at
+        # least one of the packages so that we can verify that
+        # publisher search order is accounted for by @latest.
+        # The second publisher is called 'pub2' here so that
+        # it comes lexically before 'test' (see bug 18180) to
+        # ensure that latest version ordering works correctly
+        # when the same stem is provided by different publishers.
+        t2dir = os.path.join(self.test_root, "pub2-repo")
+        self.create_repo(t2dir, properties={"publisher": {"prefix": "pub2"}})
+        self.pkgsend_bulk(t2dir, self.bar11)
+
+        self.pkg("set-publisher -p {0}".format(t2dir))
+        self.pkg("exact-install '*@latest'")
+
+        # 1.0 of bar should be installed here since pub2 is a
+        # lower-ranked publisher.
+        self.pkg("list")
+        self.pkg("info bar@1.0 foo@1.2 boring@1.1")
+
+        self.pkg("set-publisher --non-sticky test")
+        self.pkg("set-publisher -P pub2 ")
+        self.pkg("exact-install bar@latest")
+
+        # 1.1 of bar should be installed here since pub2 is a
+        # higher-ranked publisher and test is non-sticky.
+        self.pkg("info bar@1.1")
+        self.pkg("list foo@1.2")
+        self.pkg("list boring@1.1", exit=1)
+
+        # Cleanup.
+        shutil.rmtree(t1dir)
+        shutil.rmtree(t2dir)
+
+    def test_basics_7_install(self):
+        """Add bar@1.1, install bar@1.0."""
+
+        self.pkgsend_bulk(self.rurl, self.xbar11)
+        self.image_create(self.rurl)
+        self.pkg("install xbar@1.0", exit=1)
+
+    def test_basics_7_exact_install(self):
+        """Add bar@1.1, exact-install bar@1.0."""
+
+        self.pkgsend_bulk(self.rurl, self.xbar11)
+        self.image_create(self.rurl)
+        self.pkg("exact-install xbar@1.0", exit=1)
+
+    def test_basics_8_exact_install(self):
+        """Try to exact-install two versions of the same package."""
+
+        self.pkgsend_bulk(self.rurl, (self.foo11, self.foo12))
+        self.image_create(self.rurl)
+
+        self.pkg("exact-install foo@1.1 foo@1.2", exit=1)
+
+    def test_basics_9_exact_install(self):
+        """Verify downgrade will work with exact-install."""
+
+        self.pkgsend_bulk(
+            self.rurl, (self.bar10, self.bar11, self.foo10, self.foo12)
+        )
+        self.image_create(self.rurl)
+
+        self.pkg("install bar@1.1")
+        self.pkg("exact-install bar@1.0")
+        self.pkg("list bar@1.0")
+        self.pkg("list foo@1.2")
+
+    def test_freeze_exact_install(self):
+        """Verify frozen packages can be relaxed with exact_install.
+        Which means we can ignore the frozen list with exact_install.
+        """
+
+        self.pkgsend_bulk(
+            self.rurl, (self.fbar10, self.ffoo10, self.fbar11, self.ffoo11)
+        )
+        self.image_create(self.rurl)
+
+        # Freeze bar@1.0.
+        self.pkg("install fbar@1.0")
+        self.pkg("freeze fbar@1.0")
+        self.pkg("exact-install fbar@1.1")
+        self.pkg("list fbar@1.1")
+        self.pkg("list ffoo@1.1")
+        self.pkg("uninstall '*'")
+
+        # Freeze both bar@1.0 and foo@1.0.
+        self.image_create(self.rurl)
+        self.pkg("install fbar@1.0 ffoo@1.0")
+        self.pkg("freeze fbar@1.0")
+        self.pkg("freeze ffoo@1.0")
+        self.pkg("exact-install fbar@1.1")
+        self.pkg("list fbar@1.1")
+        self.pkg("list ffoo@1.1")
+
+    def test_basics_mdns(self):
+        """Send empty package foo@1.0, install and uninstall"""
+
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
+
+        self.pkg("set-property mirror-discovery True")
+        self.pkg("list -a")
+        self.pkg("list", exit=1)
+
+        self.pkg("install foo")
+
+        self.pkg("list")
+        self.pkg("verify")
+
+        self.pkg("uninstall foo")
+        self.pkg("verify")
+
+    def test_basics_ipv6(self):
+        """Verify package operations can be performed using a depot
+        server being addressed via IPv6."""
+
+        # This test needs to use the depot to be able to test
+        # IPv6 connectivity.
+        self.dc.set_address("::1")
+        self.dc.start()
+
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, (self.foo10, self.foo12))
+        self.wait_repo(self.dc.get_repodir())
+        self.image_create(durl)
+
+        self.pkg("install foo@1.0")
+        self.pkg("info foo@1.0")
+
+        self.pkg("update")
+        self.pkg("list")
+        self.pkg("info foo@1.2")
+        self.pkg("uninstall '*'")
+        self.dc.stop()
+        self.dc.set_address(None)
+
+    def test_image_upgrade(self):
+        """Send package bar@1.1, dependent on foo@1.2.  Install
+        or exact-install bar@1.0.  List all packages.  Upgrade image.
+        """
+
+        self.image_upgrade_helper("install")
+        self.image_upgrade_helper("exact-install")
+
+    def image_upgrade_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, (self.foo10, self.foo11, self.bar10))
+        self.image_create(self.rurl)
+
+        self.pkg("{0} bar@1.0".format(install_cmd))
+
+        self.pkgsend_bulk(self.rurl, (self.foo12, self.bar11))
+        self.pkg("refresh")
+
+        self.pkg("contents -H")
+        self.pkg("list")
+        self.pkg("refresh")
+
+        self.pkg("list")
+        self.pkg("verify")
+        self.pkg("update -v")
+        self.pkg("verify")
+
+        self.pkg("list foo@1.2")
+        self.pkg("list bar@1.1")
+
+        self.pkg("uninstall bar foo")
+        self.pkg("verify")
+
+    def test_dependent_uninstall(self):
+        """Trying to remove a package that's a dependency of another
+        package should fail since uninstall isn't recursive."""
+
+        self.pkgsend_bulk(self.rurl, (self.foo10, self.bar10))
+        self.image_create(self.rurl)
+
+        self.pkg("install bar@1.0")
+
+        self.pkg("uninstall -v foo", exit=1)
+        self.pkg("list bar")
+        self.pkg("list foo")
+
+    def test_bug_1338(self):
+        """Add bar@1.1, dependent on foo@1.2, install bar@1.1."""
+
+        self.pkg("list -a")
+        self.pkgsend_bulk(self.rurl, self.bar11)
+        self.image_create(self.rurl)
+
+        self.pkg("install xbar@1.1", exit=1)
+
+    def test_bug_1338_2(self):
+        """Add bar@1.1, dependent on foo@1.2, and baz@1.0, dependent
+        on foo@1.0, install baz@1.0 and bar@1.1."""
+
+        self.pkgsend_bulk(self.rurl, (self.bar11, self.baz10))
+        self.image_create(self.rurl)
+        self.pkg("list -a")
+        self.pkg("install baz@1.0 bar@1.1")
+
+    def test_bug_1338_3(self):
+        """Add xdeep@1.0, xbar@1.0. xDeep@1.0 depends on xbar@1.0 which
+        depends on xfoo@1.0, install xdeep@1.0."""
+
+        self.pkgsend_bulk(self.rurl, (self.xbar10, self.xdeep10))
+        self.image_create(self.rurl)
+
+        self.pkg("install xdeep@1.0", exit=1)
+
+    def test_bug_1338_4(self):
+        """Add ydeep@1.0. yDeep@1.0 depends on ybar@1.0 which depends
+        on xfoo@1.0, install ydeep@1.0."""
+
+        self.pkgsend_bulk(self.rurl, self.ydeep10)
+        self.image_create(self.rurl)
+
+        self.pkg("install ydeep@1.0", exit=1)
+
+    def test_bug_2795(self):
+        """Try to install two versions of the same package"""
+
+        self.pkgsend_bulk(self.rurl, (self.foo11, self.foo12))
+        self.image_create(self.rurl)
+
+        self.pkg("install foo@1.1 foo@1.2", exit=1)
+
+    def test_bug_6018(self):
+        """From original comment in bug report:
+
+        Consider a repository that contains:
+
+        a@1 and a@2
+
+        b@1 that contains an optional dependency on package a@1
+
+        If a@1 and b@1 are installed in an image, the "pkg update" command
+        produces the following output:
+
+        $ pkg update
+        No updates available for this image.
+
+        However, "pkg install a@2" works.
+        """
+
+        plist = self.pkgsend_bulk(
+            self.rurl, (self.a6018_1, self.a6018_2, self.b6018_1)
+        )
+        self.image_create(self.rurl)
+        self.pkg("install b6018@1 a6018@1")
+        # Test the parsable output of update.
+        self.pkg("update --parsable=0")
+        self.assertEqualParsable(
+            self.output, change_packages=[[plist[0], plist[1]]]
+        )
+        self.pkg("list b6018@1 a6018@2")
+
+    def test_install_matching(self):
+        """Try to [un]install or exact-install packages matching a
+        pattern"""
+
+        self.install_matching_helper("install")
+        self.install_matching_helper("exact-install")
+
+    def install_matching_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, (self.foo10, self.bar10, self.baz10))
+        self.image_create(self.rurl)
+        # don't specify versions here; we have many
+        # different versions of foo, bar & baz in repo
+        # when entire class is run w/ one repo instance.
+
+        # first case should fail since multiple patterns
+        # match the same pacakge
+        self.pkg("{0} 'ba*' 'b*'".format(install_cmd), exit=1)
+        self.pkg("{0} 'ba*'".format(install_cmd), exit=0)
+        self.pkg("list foo", exit=0)
+        self.pkg("list bar", exit=0)
+        self.pkg("list baz", exit=0)
+        self.pkg("uninstall 'b*' 'f*'")
+
+        # However, multiple forms of the same pattern should simply be
+        # coalesced and allowed.
+        self.pkg("{0} pkg:/foo /foo ///foo pkg:///foo".format(install_cmd))
+        self.pkg("list")
+        self.pkg("verify pkg:/foo /foo ///foo pkg:///foo")
+        self.pkg("uninstall pkg:/foo /foo ///foo " "pkg:///foo")
+
+    def test_bad_package_actions(self):
+        """Test the install of packages that have actions that are
+        invalid."""
+
+        self.bad_package_actions("install")
+        self.bad_package_actions("exact-install")
+
+    def bad_package_actions(self, install_cmd):
+        # First, publish the package that will be corrupted and create
+        # an image for testing.
+        plist = self.pkgsend_bulk(self.rurl, (self.badfile10, self.baddir10))
+        self.image_create(self.rurl)
+
+        # This should succeed and cause the manifest to be cached.
+        self.pkg("{0} {1}".format(install_cmd, " ".join(plist)))
+
+        # While the manifest is cached, get a copy of its contents.
+        for p in plist:
+            pfmri = fmri.PkgFmri(p)
+            mdata = self.get_img_manifest(pfmri)
+            if mdata.find("dir") != -1:
+                src_mode = "mode=755"
+            else:
+                src_mode = "mode=644"
+
+            # Now remove the package so corrupt case can be tested.
+            self.pkg("uninstall {0}".format(pfmri.pkg_name))
+
+            # Now attempt to corrupt the client's copy of the
+            # manifest in various ways to check if the client
+            # handles missing mode and invalid mode cases for
+            # file and directory actions.
+            for bad_mode in ("", 'mode=""', "mode=???"):
+                self.debug("Testing with bad mode " "'{0}'.".format(bad_mode))
+                bad_mdata = mdata.replace(src_mode, bad_mode)
+                self.write_img_manifest(pfmri, bad_mdata)
+                self.pkg(
+                    "--debug manifest_validate=Never "
+                    "{0} {1}".format(install_cmd, pfmri.pkg_name),
+                    exit=1,
+                )
+
+            # Now attempt to corrupt the client's copy of the
+            # manifest in various ways to check if the client
+            # handles missing or invalid owners and groups.
+            for bad_owner in ("", 'owner=""', "owner=invaliduser"):
+                self.debug("Testing with bad owner " "'{0}'.".format(bad_owner))
+
+                bad_mdata = mdata.replace("owner=root", bad_owner)
+                self.write_img_manifest(pfmri, bad_mdata)
+                self.pkg(
+                    "--debug manifest_validate=Never "
+                    "{0} {1}".format(install_cmd, pfmri.pkg_name),
+                    exit=1,
+                )
+
+            for bad_group in ("", 'group=""', "group=invalidgroup"):
+                self.debug("Testing with bad group " "'{0}'.".format(bad_group))
+
+                bad_mdata = mdata.replace("group=bin", bad_group)
+                self.write_img_manifest(pfmri, bad_mdata)
+                self.pkg(
+                    "--debug manifest_validate=Never "
+                    "{0} {1}".format(install_cmd, pfmri.pkg_name),
+                    exit=1,
+                )
+
+            # Now attempt to corrupt the client's copy of the
+            # manifest such that actions are malformed.
+            for bad_act in (
+                'set name=description value="" " my desc  ""',
+                "set name=com.sun.service.escalations value=",
+            ):
+                self.debug("Testing with bad action " "'{0}'.".format(bad_act))
+                bad_mdata = mdata + "{0}\n".format(bad_act)
+                self.write_img_manifest(pfmri, bad_mdata)
+                self.pkg(
+                    "--debug manifest_validate=Never "
+                    "{0} {1}".format(install_cmd, pfmri.pkg_name),
+                    exit=1,
+                )
+
+    def test_bug_3770(self):
+        """Try to install a package from a publisher with an
+        unavailable repository."""
+
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
+
+        # Depot hasn't been started, so client can't connect.
+        self.pkg("set-publisher --no-refresh -O {0} test".format(self.durl))
+        self.pkg("install foo@1.1", exit=1)
+
+    def test_bug_9929(self):
+        """Make sure that we can uninstall a package that already
+        has its contents on disk even when the repository isn't
+        accessible."""
+
+        # Depot required for this test since client doesn't cache
+        # files from a file repository by default.
+        self.dc.start()
+        self.pkgsend_bulk(self.durl, self.foo11)
+        self.image_create(self.durl)
+
+        self.pkg("install foo")
+
+        # Stop depot, so client can't connect.
+        self.dc.stop()
+        self.pkg("set-publisher --no-refresh -O {0} test".format(self.durl))
+        self.pkg("uninstall foo")
+
+    def test_bug_16189(self):
+        """Create a repository with a pair of manifests.  Have
+        pkg A depend upon pkg B.  Rename pkg B on the depot-side
+        and attempt to install. This should fail, but not traceback.
+        Then, modify the manifest on the serverside, ensuring that
+        the contents don't match the hash.  Then try the install again.
+        This should also fail, but not traceback."""
+
+        afmri = self.pkgsend_bulk(self.rurl, self.a16189)
+        bfmri = self.pkgsend_bulk(self.rurl, self.b16189)
+        self.image_create(self.rurl)
+
+        repo = self.dc.get_repo()
+
+        bpath = repo.manifest(bfmri[0])
+        old_dirname = os.path.basename(os.path.dirname(bpath))
+        old_dirpath = os.path.dirname(os.path.dirname(bpath))
+        new_dirname = "potato"
+        old_path = os.path.join(old_dirpath, old_dirname)
+        new_path = os.path.join(old_dirpath, new_dirname)
+        os.rename(old_path, new_path)
+        self.pkg("install a16189", exit=1)
+
+        os.rename(new_path, old_path)
+        self.image_destroy()
+        self.image_create(self.rurl)
+
+        apath = repo.manifest(afmri[0])
+        afobj = open(apath, "w")
+        afobj.write('set name=pkg.summary value="banana"\n')
+        afobj.close()
+        self.pkg("install a16189", exit=1)
+
+    def test_install_fuzz(self):
+        """Verify that packages delivering files with whitespace in
+        their paths can be installed or exact-installed, updated, and
+        uninstalled."""
+
+        self.pkgsend_bulk(self.rurl, self.fuzzy)
+        self.image_create(self.rurl)
+
+        self.pkg("install fuzzy@1")
+        self.pkg("verify -v")
+        self.pkg("update -vvv fuzzy@2")
+        self.pkg("verify -v")
+
+        for name in (
+            "opt/dir with white\tspace/cat in a hat",
+            "etc/cat_link",
+        ):
+            self.debug("fname: {0}".format(name))
+            self.assertTrue(
+                os.path.exists(os.path.join(self.get_img_path(), name))
+            )
+
+        self.pkg("uninstall -vvv fuzzy")
+
+    def test_sysattrs(self):
+        """Test install with setting system attributes."""
+
+        if portable.osname != "sunos":
+            raise pkg5unittest.TestSkippedException(
+                "System attributes unsupported on this platform."
+            )
+
+        plist = self.pkgsend_bulk(
+            self.rurl,
+            [
+                self.secret1,
+                self.secret2,
+                self.secret3,
+                self.secret4,
+                self.secret5,
+                self.secret6,
+            ],
+        )
+
+        # Try to install in /tmp which does not support system
+        # attributes. Just make sure we fail gracefully.
+        self.image_create(self.rurl)
+        self.pkg("install secret1")
+        self.assertTrue("WARNING" in self.errout)
+
+        # Need to create an image in /var/tmp since sysattrs don't work
+        # in tmpfs.
+        self.debug(self.rurl)
+        old_img_path = self.img_path()
+        self.set_img_path(tempfile.mkdtemp(dir="/var/tmp"))
+
+        self.image_create(self.rurl)
+
+        # test without permission for setting sensitive system attribute
+        self.pkg("install secret1", su_wrap=True, exit=1)
+
+        # now some tests which should succeed
+        self.pkg("install secret1")
+        fpath = os.path.join(self.img_path(), "p1/cat")
+        p = subprocess.Popen(
+            ["/usr/bin/ls", "-/", "c", fpath], stdout=subprocess.PIPE
+        )
+        out, err = p.communicate()
+        # sensitive attr is not in 11 FCS, so no closing }
+        expected = b"{AH-S---m----"
+        self.assertTrue(expected in out, out)
+
+        self.pkg("install secret2")
+        fpath = os.path.join(self.img_path(), "p2/cat")
+        p = subprocess.Popen(
+            ["/usr/bin/ls", "-/", "c", fpath], stdout=subprocess.PIPE
+        )
+        out, err = p.communicate()
+        # sensitive attr is not in 11 FCS, so no closing }
+        expected = b"{AH-S---m----"
+        self.assertTrue(expected in out, out)
+
+        # test some packages with invalid sysattrs
+        self.pkg("install secret3")
+        self.pkg("uninstall secret3")
+        self.pkg("install secret4")
+        self.pkg("uninstall secret4")
+
+        # test package with a file action that has multiple sysattr tags
+        self.pkg("install secret5")
+        self.pkg("uninstall secret5")
+        self.pkg("install secret6")
+
+        shutil.rmtree(self.img_path())
+        self.set_img_path(old_img_path)
+
+    def test_readonly_files(self):
+        """Ensure that packages containing files found in a read-only
+        directory or read-only files can be uninstalled."""
+
+        self.pkgsend_bulk(self.rurl, self.rofiles)
+        self.image_create(self.rurl)
+
+        # First, install parent directory package.
+        self.pkg("install -vvv rofilesdir@1.0")
+        pdir = os.path.join(self.get_img_path(), "rofdir")
+
+        # Next, install the package.  Note that this test intentionally
+        # does not cover the case of *installing* files to a read-only
+        # directory.
+        self.pkg("install -vvv rofiles@1.0")
+
+        # chmod parent directory to read-only and then verify that the
+        # package can still be uninstalled
+        os.chmod(pdir, 0o555)
+        self.pkg("verify -vvv rofilesdir", exit=1)
+        self.pkg("uninstall -vvv rofiles@1.0")
+
+        # Finally, verify directory mode was restored to 555.
+        try:
+            self.dir_exists("rofdir", mode=0o555)
+        finally:
+            # Ensure directory can be cleaned up.
+            os.chmod(pdir, 0o755)
+
+    def test_error_messages(self):
+        """Verify that error messages for installing a package with a
+        file or manifest that cannot be retrieved include the package
+        FMRI."""
+
+        repo_path = self.dc.get_repodir()
+        durl = self.dc.get_depot_url()
+        self.dc.start()
+        self.image_create(durl)
+        # publish a single package and break it
+        fmris = self.pkgsend_bulk(
+            repo_path, (self.filemissing, self.manimissing)
+        )
+        self.__inject_nofile("tmp/truck1")
+        self.pkg("install filemissing", exit=1)
+        self.assertTrue(
+            "pkg://test/filemissing@1.0,5.11:20160426T084036Z" in self.errout
+        )
+        self.image_create("file://" + repo_path)
+        self.pkg("install filemissing", exit=1)
+        self.assertTrue(
+            "pkg://test/filemissing@1.0,5.11:20160426T084036Z" in self.errout
+        )
+        self.__inject_nomanifest(fmris[1])
+        self.pkg("install manimissing", exit=1)
+        self.assertTrue(
+            "pkg://test/manimissing@1.0,5.11:20160426T084036Z" in self.errout
+        )
+        self.dc.stop()
+
+    def test_install_to_reserved_directories(self):
+        """Ensure installation of new actions will fail when the delivered
+        files target reserved filesystem locations."""
+
+        b1 = """
                     open b1@1.0-0
                     add dir mode=0755 owner=root group=bin path=var/pkg/cache
                     close
                     """
-                b2 = """
+        b2 = """
                     open b2@1.0-0
                     add link path=var/pkg/pkg5.image target=tmp/cat
                     close
                     """
-                b3 = """
+        b3 = """
                     open b3@1.0-0
                     add dir mode=0755 owner=root group=bin path=var/pkg/config
                     close
                     """
-                b4 = """
+        b4 = """
                     open b4@1.0-0
                     add dir mode=0755 owner=root group=bin path=var/tmp/foo
                     close
                     """
-                b5 = """
+        b5 = """
                     open b5@1.0-0
                     add dir mode=0755 owner=root group=bin path=var/tmp/
                     close
                     """
 
-                self.image_create(self.rurl)
-                self.pkgsend_bulk(self.rurl, [b1, b2, b3, b4, b5])
+        self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, [b1, b2, b3, b4, b5])
 
-                self.pkg("install b1", exit=1)
-                self.pkg("install b2", exit=1)
-                # this should pass because var/pkg/config is not reserved
-                self.pkg("install b3", exit=0)
+        self.pkg("install b1", exit=1)
+        self.pkg("install b2", exit=1)
+        # this should pass because var/pkg/config is not reserved
+        self.pkg("install b3", exit=0)
 
-                if portable.osname != "sunos":
-                        return
-                self.pkg("install b4", exit=1)
-                # this should pass because we are packaging var/tmp but not delivering
-                self.pkg("install b5", exit=0)
+        if portable.osname != "sunos":
+            return
+        self.pkg("install b4", exit=1)
+        # this should pass because we are packaging var/tmp but not delivering
+        self.pkg("install b5", exit=0)
 
-        def test_update_to_reserved_directories(self):
-                """Ensure installation of new actions will fail when the delivered
-                files target reserved filesystem locations."""
+    def test_update_to_reserved_directories(self):
+        """Ensure installation of new actions will fail when the delivered
+        files target reserved filesystem locations."""
 
-                b1 = """
+        b1 = """
                     open b1@1.0-0
                     add file tmp/cat mode=0755 owner=root group=bin path=var/pkg/foo
                     close
                     """
-                b2 = """
+        b2 = """
                     open b1@2.0-0
                     add dir mode=0755 owner=root group=bin path=var/pkg/cache
                     close
                     """
-                b3 = """
+        b3 = """
                     open b1@3.0-0
                     add dir mode=0755 owner=root group=bin path=var/pkg/config
                     close
                     """
 
-                self.image_create(self.rurl)
-                self.pkgsend_bulk(self.rurl, [b1, b2, b3])
+        self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, [b1, b2, b3])
 
-                self.pkg("install b1@1.0-0", exit=0)
-                self.pkg("update b1@2.0-0", exit=1)
-                # this should pass because var/pkg/config is not reserved
-                self.pkg("update b1@3.0-0", exit=0)
+        self.pkg("install b1@1.0-0", exit=0)
+        self.pkg("update b1@2.0-0", exit=1)
+        # this should pass because var/pkg/config is not reserved
+        self.pkg("update b1@3.0-0", exit=0)
 
 
 class TestPkgInstallApache(pkg5unittest.ApacheDepotTestCase):
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
-
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1 timestamp="20080731T024051Z"
             close """
 
-        upgrade_np10 = """
+    upgrade_np10 = """
             open upgrade-np@1.0,5.11-0
             close"""
 
-        misc_files = [ "tmp/libc.so.1" ]
+    misc_files = ["tmp/libc.so.1"]
 
-        def setUp(self):
-                pkg5unittest.ApacheDepotTestCase.setUp(self, ["test1", "test2"],
-                    start_depots=True)
-                self.make_misc_files(self.misc_files)
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.pkgsend_bulk(self.durl1, self.foo11)
-                self.pkgsend_bulk(self.durl2, self.upgrade_np10)
+    def setUp(self):
+        pkg5unittest.ApacheDepotTestCase.setUp(
+            self, ["test1", "test2"], start_depots=True
+        )
+        self.make_misc_files(self.misc_files)
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.pkgsend_bulk(self.durl1, self.foo11)
+        self.pkgsend_bulk(self.durl2, self.upgrade_np10)
 
-        def test_corrupt_web_cache(self):
-                """Make sure the client can detect corrupt content being served
-                to it from a corrupt web cache, modifying its requests to
-                retrieve correct content."""
+    def test_corrupt_web_cache(self):
+        """Make sure the client can detect corrupt content being served
+        to it from a corrupt web cache, modifying its requests to
+        retrieve correct content."""
 
-                fmris = self.pkgsend_bulk(self.durl1, (self.foo11,
-                    self.upgrade_np10))
-                # we need to record just the version string of foo in order
-                # to properly quote it later.
-                foo_version = fmris[0].split("@")[1]
-                self.image_create(self.durl1)
+        fmris = self.pkgsend_bulk(self.durl1, (self.foo11, self.upgrade_np10))
+        # we need to record just the version string of foo in order
+        # to properly quote it later.
+        foo_version = fmris[0].split("@")[1]
+        self.image_create(self.durl1)
 
-                # we use the system repository as a convenient way to setup
-                # a caching proxy
-                self.sysrepo("")
-                sc_runtime_dir = os.path.join(self.test_root, "sysrepo_runtime")
-                sc_conf = os.path.join(sc_runtime_dir, "sysrepo_httpd.conf")
-                sc_cache = os.path.join(self.test_root, "sysrepo_cache")
+        # we use the system repository as a convenient way to setup
+        # a caching proxy
+        self.sysrepo("")
+        sc_runtime_dir = os.path.join(self.test_root, "sysrepo_runtime")
+        sc_conf = os.path.join(sc_runtime_dir, "sysrepo_httpd.conf")
+        sc_cache = os.path.join(self.test_root, "sysrepo_cache")
 
-                # ensure pkg5srv can write cache content
-                os.chmod(sc_cache, 0o777)
+        # ensure pkg5srv can write cache content
+        os.chmod(sc_cache, 0o777)
 
-                sysrepo_port = self.next_free_port
-                self.next_free_port += 1
-                sc = pkg5unittest.SysrepoController(sc_conf,
-                    sysrepo_port, sc_runtime_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
+        sysrepo_port = self.next_free_port
+        self.next_free_port += 1
+        sc = pkg5unittest.SysrepoController(
+            sc_conf, sysrepo_port, sc_runtime_dir, testcase=self
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
 
-                sysrepo_url = "http://localhost:{0}".format(sysrepo_port)
+        sysrepo_url = "http://localhost:{0}".format(sysrepo_port)
 
-                saved_pkg_sysrepo_env = os.environ.get("PKG_SYSREPO_URL")
-                os.environ["PKG_SYSREPO_URL"] = sysrepo_url
+        saved_pkg_sysrepo_env = os.environ.get("PKG_SYSREPO_URL")
+        os.environ["PKG_SYSREPO_URL"] = sysrepo_url
 
-                # create an image, installing a package, to warm up the webcache
-                self.image_create(props={"use-system-repo": True})
-                self.pkg("install foo@1.1")
-                self.pkg("uninstall foo")
+        # create an image, installing a package, to warm up the webcache
+        self.image_create(props={"use-system-repo": True})
+        self.pkg("install foo@1.1")
+        self.pkg("uninstall foo")
 
-                # now recreate the image.  image_create calls image_destroy,
-                # thereby cleaning any cached content in the image.
-                self.image_create(props={"use-system-repo": True})
+        # now recreate the image.  image_create calls image_destroy,
+        # thereby cleaning any cached content in the image.
+        self.image_create(props={"use-system-repo": True})
 
-                def corrupt_path(path, value="noodles\n", rename=False):
-                        """Given a path, corrupt its contents."""
-                        self.assertTrue(os.path.exists(path))
-                        if rename:
-                                os.rename(path, path + ".not-corrupt")
-                                with open(path, "w") as f:
-                                        f.write(value)
-                        else:
-                                df = open(path, "w")
-                                df.write(value)
-                                df.close()
+        def corrupt_path(path, value="noodles\n", rename=False):
+            """Given a path, corrupt its contents."""
+            self.assertTrue(os.path.exists(path))
+            if rename:
+                os.rename(path, path + ".not-corrupt")
+                with open(path, "w") as f:
+                    f.write(value)
+            else:
+                df = open(path, "w")
+                df.write(value)
+                df.close()
 
-                def corrupt_cache(cache_dir):
-                        """Given an apache cache, corrupt it's contents."""
+        def corrupt_cache(cache_dir):
+            """Given an apache cache, corrupt it's contents."""
 
-                        for dirpath, dirname, filenames in os.walk(cache_dir):
-                                for name in filenames:
-                                        if name.endswith(".header"):
-                                                data = name.replace(".header",
-                                                    ".data")
-                                                corrupt_path(os.path.join(
-                                                    dirpath, data))
-                # corrupt our web cache
-                corrupt_cache(sc_cache)
+            for dirpath, dirname, filenames in os.walk(cache_dir):
+                for name in filenames:
+                    if name.endswith(".header"):
+                        data = name.replace(".header", ".data")
+                        corrupt_path(os.path.join(dirpath, data))
 
-                urls = [
-                    # we need to quote the version carefully to use exactly the
-                    # format pkg(1) uses - two logically identical urls that
-                    # differ only by the way they're quoted are treated by
-                    # Apache as separate cacheable resources.
-                    "{0}/test1/manifest/0/foo@{1}".format(self.durl1, quote(
-                    foo_version)),
-                    "{0}/test1/file/1/8535c15c49cbe1e7cb1a0bf8ff87e512abed66f8".format(
-                    self.durl1),
-                ]
+        # corrupt our web cache
+        corrupt_cache(sc_cache)
 
-                proxy_handler = ProxyHandler({"http": sysrepo_url})
-                proxy_opener = build_opener(proxy_handler)
+        urls = [
+            # we need to quote the version carefully to use exactly the
+            # format pkg(1) uses - two logically identical urls that
+            # differ only by the way they're quoted are treated by
+            # Apache as separate cacheable resources.
+            "{0}/test1/manifest/0/foo@{1}".format(
+                self.durl1, quote(foo_version)
+            ),
+            "{0}/test1/file/1/8535c15c49cbe1e7cb1a0bf8ff87e512abed66f8".format(
+                self.durl1
+            ),
+        ]
 
-                # validate that our cache is returning corrupt urls.
-                for url in urls:
-                        self.debug("url:{0}".format(url))
-                        # we should get clean content when we don't use the
-                        # cache
-                        u = urlopen(url)
-                        content = u.readlines()
-                        # content from urlopen is bytes
-                        self.assertTrue(content != [b"noodles\n"],
-                            "Unexpected content from depot")
+        proxy_handler = ProxyHandler({"http": sysrepo_url})
+        proxy_opener = build_opener(proxy_handler)
 
-                        # get the corrupted version, and verify it is broken
-                        req = Request(url)
-                        u = proxy_opener.open(req)
-                        content = u.readlines()
+        # validate that our cache is returning corrupt urls.
+        for url in urls:
+            self.debug("url:{0}".format(url))
+            # we should get clean content when we don't use the
+            # cache
+            u = urlopen(url)
+            content = u.readlines()
+            # content from urlopen is bytes
+            self.assertTrue(
+                content != [b"noodles\n"], "Unexpected content from depot"
+            )
 
-                        self.assertTrue(content == [b"noodles\n"],
-                            "Expected noodles, got {0} for {1}".format(content, url))
+            # get the corrupted version, and verify it is broken
+            req = Request(url)
+            u = proxy_opener.open(req)
+            content = u.readlines()
 
-                # the following should work, as pkg should retry requests
-                # where it has detected corrupt contents with a
-                # "Cache-Control: no-cache" header.
-                self.pkg("refresh --full")
-                self.pkg("contents -rm foo@1.1")
-                self.pkg("install foo@1.1")
+            self.assertTrue(
+                content == [b"noodles\n"],
+                "Expected noodles, got {0} for {1}".format(content, url),
+            )
 
-                # since the cache has been refreshed, we should see valid
-                # contents when going through the proxy now.
-                for url in urls:
-                        req = Request(url)
-                        u = proxy_opener.open(req)
-                        content = u.readlines()
-                        self.assertTrue(content != ["noodles\n"],
-                            "Unexpected content from depot")
+        # the following should work, as pkg should retry requests
+        # where it has detected corrupt contents with a
+        # "Cache-Control: no-cache" header.
+        self.pkg("refresh --full")
+        self.pkg("contents -rm foo@1.1")
+        self.pkg("install foo@1.1")
 
-                # ensure that when we actually corrupt the repository
-                # as well as the cache, we do detect the errors properly.
-                corrupt_cache(sc_cache)
-                repodir = self.dcs[1].get_repodir()
+        # since the cache has been refreshed, we should see valid
+        # contents when going through the proxy now.
+        for url in urls:
+            req = Request(url)
+            u = proxy_opener.open(req)
+            content = u.readlines()
+            self.assertTrue(
+                content != ["noodles\n"], "Unexpected content from depot"
+            )
 
-                prefix = "publisher/test1"
-                self.image_create(props={"use-system-repo": True})
+        # ensure that when we actually corrupt the repository
+        # as well as the cache, we do detect the errors properly.
+        corrupt_cache(sc_cache)
+        repodir = self.dcs[1].get_repodir()
 
-                # When we corrupt the files in the repository, we intentionally
-                # corrupt them with different contents than the cache,
-                # allowing us to check the error messages being printed by the
-                # transport subsystem.
+        prefix = "publisher/test1"
+        self.image_create(props={"use-system-repo": True})
 
-                filepath = os.path.join(repodir,
-                    "{0}/file/85/8535c15c49cbe1e7cb1a0bf8ff87e512abed66f8".format(
-                    prefix))
-                mfpath = os.path.join(repodir, "{0}/pkg/foo/{1}".format(prefix,
-                    quote(foo_version)))
-                catpath = os.path.join(repodir, "{0}/catalog/catalog.base.C".format(
-                    prefix))
+        # When we corrupt the files in the repository, we intentionally
+        # corrupt them with different contents than the cache,
+        # allowing us to check the error messages being printed by the
+        # transport subsystem.
 
-                try:
-                        # first corrupt the file
-                        corrupt_path(filepath, value="spaghetti\n", rename=True)
-                        self.pkg("install foo@1.1", stderr=True, exit=1)
-                        os.rename(filepath + ".not-corrupt", filepath)
+        filepath = os.path.join(
+            repodir,
+            "{0}/file/85/8535c15c49cbe1e7cb1a0bf8ff87e512abed66f8".format(
+                prefix
+            ),
+        )
+        mfpath = os.path.join(
+            repodir, "{0}/pkg/foo/{1}".format(prefix, quote(foo_version))
+        )
+        catpath = os.path.join(
+            repodir, "{0}/catalog/catalog.base.C".format(prefix)
+        )
 
-                        # we should be getting two hash errors, one from the
-                        # cache, one from the repo. The one from the repo should
-                        # repeat
-                        self.assertTrue(
-                            "1: Invalid contentpath lib/libc.so.1: chash" in
-                            self.errout)
-                        self.assertTrue(
-                            "2: Invalid contentpath lib/libc.so.1: chash" in
-                            self.errout)
-                        self.assertTrue("(happened 3 times)" in self.errout)
+        try:
+            # first corrupt the file
+            corrupt_path(filepath, value="spaghetti\n", rename=True)
+            self.pkg("install foo@1.1", stderr=True, exit=1)
+            os.rename(filepath + ".not-corrupt", filepath)
 
-                        # now corrupt the manifest (we have to re-corrupt the
-                        # cache, since attempting to install foo above would
-                        # have caused the cache to refetch the valid manifest
-                        # from the repo) and remove the version of the manifest
-                        # cached in the image.
-                        corrupt_cache(sc_cache)
-                        corrupt_path(mfpath, value="spaghetti\n", rename=True)
-                        shutil.rmtree(os.path.join(self.img_path(),
-                            "var/pkg/publisher/test1/pkg"))
-                        self.pkg("contents -rm foo@1.1", stderr=True, exit=1)
-                        os.rename(mfpath + ".not-corrupt", mfpath)
+            # we should be getting two hash errors, one from the
+            # cache, one from the repo. The one from the repo should
+            # repeat
+            self.assertTrue(
+                "1: Invalid contentpath lib/libc.so.1: chash" in self.errout
+            )
+            self.assertTrue(
+                "2: Invalid contentpath lib/libc.so.1: chash" in self.errout
+            )
+            self.assertTrue("(happened 3 times)" in self.errout)
 
-                        # we should get two hash errors, one from the cache, one
-                        # from the repo - the one from the repo should repeat.
-                        self.assertTrue(
-                            "1: Invalid content: manifest hash failure" in
-                            self.errout)
-                        self.assertTrue("2: Invalid content: manifest hash failure"
-                            in self.errout)
-                        self.assertTrue("(happened 3 times)" in self.errout)
+            # now corrupt the manifest (we have to re-corrupt the
+            # cache, since attempting to install foo above would
+            # have caused the cache to refetch the valid manifest
+            # from the repo) and remove the version of the manifest
+            # cached in the image.
+            corrupt_cache(sc_cache)
+            corrupt_path(mfpath, value="spaghetti\n", rename=True)
+            shutil.rmtree(
+                os.path.join(self.img_path(), "var/pkg/publisher/test1/pkg")
+            )
+            self.pkg("contents -rm foo@1.1", stderr=True, exit=1)
+            os.rename(mfpath + ".not-corrupt", mfpath)
 
-                        # finally, corrupt the catalog. Given we've asked for a
-                        # full refresh, we retrieve the upstream version only.
-                        corrupt_path(catpath, value="spaghetti\n", rename=True)
-                        self.pkg("refresh --full", stderr=True, exit=1)
-                        self.assertTrue("catalog.base.C' is invalid." in
-                            self.errout)
-                        os.rename(catpath + ".not-corrupt", catpath)
+            # we should get two hash errors, one from the cache, one
+            # from the repo - the one from the repo should repeat.
+            self.assertTrue(
+                "1: Invalid content: manifest hash failure" in self.errout
+            )
+            self.assertTrue(
+                "2: Invalid content: manifest hash failure" in self.errout
+            )
+            self.assertTrue("(happened 3 times)" in self.errout)
 
-                finally:
-                        # make sure we clean up any corrupt repo contents.
-                        for path in [filepath, mfpath, catpath]:
-                                not_corrupt = path + ".not-corrupt"
-                                if os.path.exists(not_corrupt):
-                                        os.rename(not_corrupt, path)
+            # finally, corrupt the catalog. Given we've asked for a
+            # full refresh, we retrieve the upstream version only.
+            corrupt_path(catpath, value="spaghetti\n", rename=True)
+            self.pkg("refresh --full", stderr=True, exit=1)
+            self.assertTrue("catalog.base.C' is invalid." in self.errout)
+            os.rename(catpath + ".not-corrupt", catpath)
 
-                        if saved_pkg_sysrepo_env:
-                                os.environ["PKG_SYSREPO_URL"] = \
-                                    saved_pkg_sysrepo_env
+        finally:
+            # make sure we clean up any corrupt repo contents.
+            for path in [filepath, mfpath, catpath]:
+                not_corrupt = path + ".not-corrupt"
+                if os.path.exists(not_corrupt):
+                    os.rename(not_corrupt, path)
 
-        def test_granular_proxy(self):
-                """Tests that images can use the set-publisher --proxy argument
-                to selectively proxy requests."""
+            if saved_pkg_sysrepo_env:
+                os.environ["PKG_SYSREPO_URL"] = saved_pkg_sysrepo_env
 
-                # we use the system repository as a convenient way to setup
-                # a caching proxy.   Since the image doesn't have the property
-                # 'use-system-repo=True', the configuration of the sysrepo
-                # will remain static.
-                self.image_create(self.durl1)
-                self.sysrepo("")
-                sc_runtime_dir = os.path.join(self.test_root, "sysrepo_runtime")
-                sc_conf = os.path.join(sc_runtime_dir, "sysrepo_httpd.conf")
-                sc_cache = os.path.join(self.test_root, "sysrepo_cache")
+    def test_granular_proxy(self):
+        """Tests that images can use the set-publisher --proxy argument
+        to selectively proxy requests."""
 
-                # ensure pkg5srv can write cache content
-                os.chmod(sc_cache, 0o777)
+        # we use the system repository as a convenient way to setup
+        # a caching proxy.   Since the image doesn't have the property
+        # 'use-system-repo=True', the configuration of the sysrepo
+        # will remain static.
+        self.image_create(self.durl1)
+        self.sysrepo("")
+        sc_runtime_dir = os.path.join(self.test_root, "sysrepo_runtime")
+        sc_conf = os.path.join(sc_runtime_dir, "sysrepo_httpd.conf")
+        sc_cache = os.path.join(self.test_root, "sysrepo_cache")
 
-                sysrepo_port = self.next_free_port
-                self.next_free_port += 1
-                sc = pkg5unittest.SysrepoController(sc_conf,
-                    sysrepo_port, sc_runtime_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                sysrepo_url = "http://localhost:{0}".format(sysrepo_port)
+        # ensure pkg5srv can write cache content
+        os.chmod(sc_cache, 0o777)
 
-                self.image_create()
-                self.pkg("set-publisher -p {0} --proxy {1}".format(self.durl1,
-                    sysrepo_url))
-                self.pkg("install foo")
-                self.pkg("uninstall foo")
+        sysrepo_port = self.next_free_port
+        self.next_free_port += 1
+        sc = pkg5unittest.SysrepoController(
+            sc_conf, sysrepo_port, sc_runtime_dir, testcase=self
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        sysrepo_url = "http://localhost:{0}".format(sysrepo_port)
 
-                sc.stop()
-                # with our proxy offline, and with no other origins
-                # available, we should be unable to install
-                self.pkg("install --no-refresh foo", exit=1)
-                sc.start()
+        self.image_create()
+        self.pkg(
+            "set-publisher -p {0} --proxy {1}".format(self.durl1, sysrepo_url)
+        )
+        self.pkg("install foo")
+        self.pkg("uninstall foo")
 
-                # we cannot add another origin with the same url
-                self.pkg("set-publisher --no-refresh -g {0} test1".format(
-                    self.durl1), exit=1)
-                # we cannot add another proxied origin with that url
-                self.pkg("set-publisher --no-refresh -g {0} "
-                    "--proxy http://noodles test1".format(self.durl1),
-                    exit=1)
+        sc.stop()
+        # with our proxy offline, and with no other origins
+        # available, we should be unable to install
+        self.pkg("install --no-refresh foo", exit=1)
+        sc.start()
 
-                # Now add a second, unproxied publisher, ensuring we
-                # can install packages from there.  Since the proxy
-                # isn't configured to proxy that resource, this tests
-                # that the proxy for self.durl1 isn't being used.
-                self.pkg("set-publisher -g {0} test2".format(self.durl2))
-                self.pkg("install --no-refresh "
-                    "pkg://test2/upgrade-np@1.0")
-                self.pkg("uninstall pkg://test2/upgrade-np@1.0")
-                self.pkg("set-publisher -G {0} test2".format(self.durl2))
+        # we cannot add another origin with the same url
+        self.pkg(
+            "set-publisher --no-refresh -g {0} test1".format(self.durl1), exit=1
+        )
+        # we cannot add another proxied origin with that url
+        self.pkg(
+            "set-publisher --no-refresh -g {0} "
+            "--proxy http://noodles test1".format(self.durl1),
+            exit=1,
+        )
 
-                # check that runtime proxies are being used - we
-                # set a bogus proxy, then ensure our $http_proxy value
-                # gets used.
-                self.pkg("publisher")
-                self.pkg("set-publisher -G {0} test1".format(self.durl1))
-                self.pkg("set-publisher --no-refresh -g {0} "
-                    "--proxy http://noodles test1".format(self.durl1))
-                env = {"http_proxy": sysrepo_url}
-                self.pkg("refresh", env_arg=env)
-                self.pkg("install foo", env_arg=env)
-                self.pkg("uninstall foo", env_arg=env)
+        # Now add a second, unproxied publisher, ensuring we
+        # can install packages from there.  Since the proxy
+        # isn't configured to proxy that resource, this tests
+        # that the proxy for self.durl1 isn't being used.
+        self.pkg("set-publisher -g {0} test2".format(self.durl2))
+        self.pkg("install --no-refresh " "pkg://test2/upgrade-np@1.0")
+        self.pkg("uninstall pkg://test2/upgrade-np@1.0")
+        self.pkg("set-publisher -G {0} test2".format(self.durl2))
 
-                # check that $all_proxy works
-                env = {"all_proxy": sysrepo_url}
-                self.pkg("install foo", env_arg=env)
-                self.pkg("uninstall foo", env_arg=env)
+        # check that runtime proxies are being used - we
+        # set a bogus proxy, then ensure our $http_proxy value
+        # gets used.
+        self.pkg("publisher")
+        self.pkg("set-publisher -G {0} test1".format(self.durl1))
+        self.pkg(
+            "set-publisher --no-refresh -g {0} "
+            "--proxy http://noodles test1".format(self.durl1)
+        )
+        env = {"http_proxy": sysrepo_url}
+        self.pkg("refresh", env_arg=env)
+        self.pkg("install foo", env_arg=env)
+        self.pkg("uninstall foo", env_arg=env)
 
-                # now check that no_proxy works
-                env["no_proxy"] = "*"
-                self.pkg("install foo", env_arg=env)
-                self.pkg("refresh --full", env_arg=env)
+        # check that $all_proxy works
+        env = {"all_proxy": sysrepo_url}
+        self.pkg("install foo", env_arg=env)
+        self.pkg("uninstall foo", env_arg=env)
+
+        # now check that no_proxy works
+        env["no_proxy"] = "*"
+        self.pkg("install foo", env_arg=env)
+        self.pkg("refresh --full", env_arg=env)
 
 
 class TestPkgInstallRepoPerTest(pkg5unittest.SingleDepotTestCase):
-        persistent_setup = False
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    persistent_setup = False
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        disappear10 = """
+    disappear10 = """
             open disappear@1.0,5.11-0
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        disappear11 = """
+    disappear11 = """
             open disappear@1.1,5.11-0
             close """
 
-        misc_files = ["tmp/cat"]
+    misc_files = ["tmp/cat"]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-        def test_install_changed_manifest(self):
-                """Test that if a manifest that is being installed is cached
-                locally has been changed on the repo is updated, the new
-                manifest is used."""
+    def test_install_changed_manifest(self):
+        """Test that if a manifest that is being installed is cached
+        locally has been changed on the repo is updated, the new
+        manifest is used."""
 
-                plist = self.pkgsend_bulk(self.rurl, self.foo10)
+        plist = self.pkgsend_bulk(self.rurl, self.foo10)
 
-                self.image_create(self.rurl)
-                self.seed_ta_dir("ta3")
-                api_inst = self.get_img_api_obj()
+        self.image_create(self.rurl)
+        self.seed_ta_dir("ta3")
+        api_inst = self.get_img_api_obj()
 
-                # Use pkg contents to cache the manifest.
-                self.pkg("contents -r foo")
+        # Use pkg contents to cache the manifest.
+        self.pkg("contents -r foo")
 
-                # Specify location as filesystem path.
-                self.pkgsign_simple(self.dc.get_repodir(), plist[0])
+        # Specify location as filesystem path.
+        self.pkgsign_simple(self.dc.get_repodir(), plist[0])
 
-                # Ensure that the image requires signed manifests.
-                self.pkg("set-property signature-policy require-signatures")
-                api_inst.reset()
+        # Ensure that the image requires signed manifests.
+        self.pkg("set-property signature-policy require-signatures")
+        api_inst.reset()
 
-                # Install the package
-                self._api_install(api_inst, ["foo"])
+        # Install the package
+        self._api_install(api_inst, ["foo"])
 
-        def test_keep_installed_changed_manifest(self):
-                """Test that if a manifest that has been installed is changed on
-                the server is updated, the installed manifest is not changed."""
+    def test_keep_installed_changed_manifest(self):
+        """Test that if a manifest that has been installed is changed on
+        the server is updated, the installed manifest is not changed."""
 
-                pfmri = self.pkgsend_bulk(self.rurl, self.disappear10)[0]
+        pfmri = self.pkgsend_bulk(self.rurl, self.disappear10)[0]
 
-                self.image_create(self.rurl)
-                api_inst = self.get_img_api_obj()
+        self.image_create(self.rurl)
+        api_inst = self.get_img_api_obj()
 
-                # Install the package
-                self._api_install(api_inst, ["disappear"])
+        # Install the package
+        self._api_install(api_inst, ["disappear"])
 
-                self.assertTrue(os.path.isfile(os.path.join(
-                    self.img_path(), "bin", "cat")))
-                repo = self.dc.get_repo()
-                m_path = repo.manifest(pfmri)
-                with open(m_path, "r") as fh:
-                        fmri_lines = fh.readlines()
-                with open(m_path, "w") as fh:
-                        for l in fmri_lines:
-                                if "usr/bin/cat" in l:
-                                        continue
-                                fh.write(l)
-                repo.rebuild()
+        self.assertTrue(
+            os.path.isfile(os.path.join(self.img_path(), "bin", "cat"))
+        )
+        repo = self.dc.get_repo()
+        m_path = repo.manifest(pfmri)
+        with open(m_path, "r") as fh:
+            fmri_lines = fh.readlines()
+        with open(m_path, "w") as fh:
+            for l in fmri_lines:
+                if "usr/bin/cat" in l:
+                    continue
+                fh.write(l)
+        repo.rebuild()
 
-                pfmri = self.pkgsend_bulk(self.rurl, self.disappear11)[0]
-                self._api_update(api_inst)
-                self.assertTrue(not os.path.isfile(os.path.join(
-                    self.img_path(), "bin", "cat")))
+        pfmri = self.pkgsend_bulk(self.rurl, self.disappear11)[0]
+        self._api_update(api_inst)
+        self.assertTrue(
+            not os.path.isfile(os.path.join(self.img_path(), "bin", "cat"))
+        )
 
 
 class TestPkgActuators(pkg5unittest.SingleDepotTestCase):
-        """Test package actuators"""
-        persistent_setup = True
+    """Test package actuators"""
 
-        pkgs = (
-                """
+    persistent_setup = True
+
+    pkgs = (
+        """
                     open multimatch/A@1,5.11-0
                     close """,
-                """
+        """
                     open A@0.5,5.11-0
                     close """,
-                """
+        """
                     open A@1.0,5.11-0
                     close """,
-                """
+        """
                     open A@2.0,5.11-0
                     close """,
-                """
+        """
                     open B@1.0,5.11-0
                     close """,
-                """
+        """
                     open B@2.0,5.11-0
                     close """,
-                """
+        """
                     open C@1.0,5.11-0
                     add depend type=require fmri=trigger
                     close """,
-                """
+        """
                     open trigger@1.0,5.11-0
                     add set name=pkg.additional-update-on-uninstall value=A@2
                     close """,
-                """
+        """
                     open trigger@2.0,5.11-0
                     add set pkg.additional-update-on-uninstall=A@1
                     close """,
-                """
+        """
                     open trigger@3.0,5.11-0
                     add set name=pkg.additional-uninstall-on-uninstall value=A
                     close """,
-                """
+        """
                     open trigger@4.0,5.11-0
                     add set pkg.additional-uninstall-on-uninstall=A
                     close """,
-                """
+        """
                     open trigger@5.0,5.11-0
                     add set name=pkg.additional-uninstall-on-uninstall value=A@2 value=B@2
                     close """,
-                """
+        """
                     open trigger@6.0,5.11-0
                     add set name=pkg.additional-uninstall-on-uninstall value=A@1
                     close """,
-                """
+        """
                     open trigger@7.0,5.11-0
                     add set name=pkg.additional-uninstall-on-uninstall value=C
                     close """,
-                """
+        """
                     open evil@1.0,5.11-0
                     add set name=pkg.additional-update-on-uninstall value=evil@2
                     close """,
-                """
+        """
                     open evil@2.0,5.11-0
                     close """,
-                )
+    )
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.pkgsend_bulk(self.rurl, self.pkgs)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.pkgsend_bulk(self.rurl, self.pkgs)
 
-        def test_basics(self):
-                """Test that pkg actuators work as expected."""
-                # prepare image
-                self.image_create(self.rurl)
-                self.pkg("install /A@1")
-                self.pkg("install -v trigger@1")
-                self.pkg("list A@1 trigger@1")
+    def test_basics(self):
+        """Test that pkg actuators work as expected."""
+        # prepare image
+        self.image_create(self.rurl)
+        self.pkg("install /A@1")
+        self.pkg("install -v trigger@1")
+        self.pkg("list A@1 trigger@1")
 
-                # update on uninstall
-                self.pkg("uninstall -v trigger")
-                self.pkg("list A@2")
+        # update on uninstall
+        self.pkg("uninstall -v trigger")
+        self.pkg("list A@2")
 
-                self.pkg("install -v trigger@2")
-                self.pkg("uninstall -v trigger")
-                self.pkg("list A@1")
+        self.pkg("install -v trigger@2")
+        self.pkg("uninstall -v trigger")
+        self.pkg("list A@1")
 
-                # uninstall on uninstall
-                self.pkg("install -v trigger@3")
-                self.pkg("uninstall -v trigger")
-                self.pkg("list A", exit=1)
+        # uninstall on uninstall
+        self.pkg("install -v trigger@3")
+        self.pkg("uninstall -v trigger")
+        self.pkg("list A", exit=1)
 
-                # verify unversioned actuator triggers
-                self.pkg("install -v trigger@4 /A@1")
-                self.pkg("uninstall -v trigger")
-                self.pkg("list A", exit=1)
-                self.pkg("install -v trigger@4 /A@2")
-                self.pkg("uninstall -v trigger")
-                self.pkg("list A", exit=1)
+        # verify unversioned actuator triggers
+        self.pkg("install -v trigger@4 /A@1")
+        self.pkg("uninstall -v trigger")
+        self.pkg("list A", exit=1)
+        self.pkg("install -v trigger@4 /A@2")
+        self.pkg("uninstall -v trigger")
+        self.pkg("list A", exit=1)
 
-                # verify correct version is uninstalled
-                self.pkg("install -v trigger@6 /A@1")
-                self.pkg("uninstall -v trigger")
-                self.pkg("list A", exit=1)
+        # verify correct version is uninstalled
+        self.pkg("install -v trigger@6 /A@1")
+        self.pkg("uninstall -v trigger")
+        self.pkg("list A", exit=1)
 
-                # verify non-matching version is not installed
-                self.pkg("install -v trigger@6 /A@2")
-                self.pkg("uninstall -v trigger")
-                self.pkg("list A")
+        # verify non-matching version is not installed
+        self.pkg("install -v trigger@6 /A@2")
+        self.pkg("uninstall -v trigger")
+        self.pkg("list A")
 
-                # multiple values
-                self.pkg("install -v trigger@5 /A@2 B@2")
-                self.pkg("uninstall -v trigger")
-                self.pkg("list A B", exit=1)
+        # multiple values
+        self.pkg("install -v trigger@5 /A@2 B@2")
+        self.pkg("uninstall -v trigger")
+        self.pkg("list A B", exit=1)
 
-                # multiple values but at different versions
-                self.pkg("install -v trigger@5 /A@1 B@1")
-                self.pkg("uninstall -v trigger")
-                self.pkg("list A@1 B@1")
+        # multiple values but at different versions
+        self.pkg("install -v trigger@5 /A@1 B@1")
+        self.pkg("uninstall -v trigger")
+        self.pkg("list A@1 B@1")
 
-                # removal pkg depends on trigger
-                self.pkg("install -v trigger@7 C")
-                self.pkg("uninstall -v trigger")
-                self.pkg("list C", exit=1)
+        # removal pkg depends on trigger
+        self.pkg("install -v trigger@7 C")
+        self.pkg("uninstall -v trigger")
+        self.pkg("list C", exit=1)
 
-                # test that uninstall actuators also work when pkg is rejected
-                self.pkg("install -v /A@1 trigger@1")
-                self.pkg("list A@1")
-                # install with reject
-                self.pkg("install --reject trigger B@1")
-                self.pkg("list A@2")
-                # update with reject
-                self.pkg("install -v trigger@2")
-                self.pkg("update -v --reject trigger B@2")
-                self.pkg("list A@1")
+        # test that uninstall actuators also work when pkg is rejected
+        self.pkg("install -v /A@1 trigger@1")
+        self.pkg("list A@1")
+        # install with reject
+        self.pkg("install --reject trigger B@1")
+        self.pkg("list A@2")
+        # update with reject
+        self.pkg("install -v trigger@2")
+        self.pkg("update -v --reject trigger B@2")
+        self.pkg("list A@1")
 
-                # self-referencing (evil) pkgs
-                self.pkg("install -v evil@1")
-                # solver will complain about passing same pkg to reject and
-                # proposed dict
-                self.pkg("uninstall -v evil@1", exit=1)
-                # try workaround
-                self.pkg("-R {0} -D ignore-pkg-actuators=true "
-                    "uninstall -v evil@1".format(self.get_img_path()))
-                self.pkg("list evil", exit=1)
+        # self-referencing (evil) pkgs
+        self.pkg("install -v evil@1")
+        # solver will complain about passing same pkg to reject and
+        # proposed dict
+        self.pkg("uninstall -v evil@1", exit=1)
+        # try workaround
+        self.pkg(
+            "-R {0} -D ignore-pkg-actuators=true "
+            "uninstall -v evil@1".format(self.get_img_path())
+        )
+        self.pkg("list evil", exit=1)
 
-                # Test overlapping user and actuator pkg requests.
-                # Since actuators are treated like user requests, the solver
-                # will pick the latest one.
-                self.pkg("install -v /A@1 trigger@1")
-                # update with reject
-                self.pkg("update --parsable=0 --reject trigger /A@0.5")
-                self.pkg("list A@2")
+        # Test overlapping user and actuator pkg requests.
+        # Since actuators are treated like user requests, the solver
+        # will pick the latest one.
+        self.pkg("install -v /A@1 trigger@1")
+        # update with reject
+        self.pkg("update --parsable=0 --reject trigger /A@0.5")
+        self.pkg("list A@2")
 
-        def test_multimatch_reject(self):
-                """Ensure --reject works as expected when actuators are
-                applied."""
+    def test_multimatch_reject(self):
+        """Ensure --reject works as expected when actuators are
+        applied."""
 
-                self.image_create(self.rurl)
-                # verify that pkg actuators work as expected in the presence of
-                # multiple, installed packages that can be ambiguously matched
-                self.pkg("install -v /A /multimatch/A")
-                self.pkg("update -nv --reject /A")
+        self.image_create(self.rurl)
+        # verify that pkg actuators work as expected in the presence of
+        # multiple, installed packages that can be ambiguously matched
+        self.pkg("install -v /A /multimatch/A")
+        self.pkg("update -nv --reject /A")
 
-        def test_multimatch_trigger(self):
-                """Ensure actuator matches are exact and do not result in
-                multiple matches."""
+    def test_multimatch_trigger(self):
+        """Ensure actuator matches are exact and do not result in
+        multiple matches."""
 
-                self.image_create(self.rurl)
-                # Install two packages which can be ambiguously matched using
-                # the pattern 'A'.
-                self.pkg("install -v /A@1 /multimatch/A@1 trigger@6")
-                self.pkg("uninstall -v trigger@6")
-                self.pkg("list /A", exit=1)
+        self.image_create(self.rurl)
+        # Install two packages which can be ambiguously matched using
+        # the pattern 'A'.
+        self.pkg("install -v /A@1 /multimatch/A@1 trigger@6")
+        self.pkg("uninstall -v trigger@6")
+        self.pkg("list /A", exit=1)
 
 
 class TestPkgInstallUpdateReject(pkg5unittest.SingleDepotTestCase):
-        """Test --reject option to pkg update/install"""
-        persistent_setup = True
+    """Test --reject option to pkg update/install"""
 
-        pkgs = (
-                """
+    persistent_setup = True
+
+    pkgs = (
+        """
                     open A@1.0,5.11-0
                     add depend type=require-any fmri=pkg:/B@1.0 fmri=pkg:/C@1.0
                     close """,
-                """
+        """
                     open A@2.0,5.11-0
                     add depend type=require-any fmri=pkg:/B@1.0 fmri=pkg:/C@1.0
                     close """,
-
-                """
+        """
                     open B@1.0,5.11-0
                     add depend type=exclude fmri=pkg:/C
                     close """,
-
-                """
+        """
                     open C@1.0,5.11-0
                     add depend type=exclude fmri=pkg:/B
                     close """,
-
-                """
+        """
                     open kernel@1.0,5.11-0.1
                     add depend type=require fmri=pkg:/incorp
                     close """,
-
-                """
+        """
                     open kernelX@1.0,5.11-0.1
                     add depend type=require fmri=pkg:/incorp
                     close """,
-
-                """
+        """
                     open kernel@1.0,5.11-0.2
                     add depend type=require fmri=pkg:/incorp
                     close """,
-
-                """
+        """
                     open incorp@1.0,5.11-0.1
                     add depend type=incorporate fmri=kernel@1.0,5.11-0.1
                     close """,
-
-                 """
+        """
                     open incorp@1.0,5.11-0.2
                     add depend type=incorporate fmri=kernel@1.0,5.11-0.2
                     close """,
-
-                """
+        """
                     open kernel@1.0,5.11-0.1.1.0
                     add depend type=require fmri=pkg:/incorp
                     add depend type=require fmri=pkg:/idr1
                     close """,
-
-
-                """
+        """
                     open kernel@1.0,5.11-0.1.1.1
                     add depend type=require fmri=pkg:/incorp
                     add depend type=require fmri=pkg:/idr1
                     close """,
-
-                """
+        """
                     open kernel@1.0,5.11-0.1.2.0
                     add depend type=require fmri=pkg:/incorp
                     add depend type=require fmri=pkg:/idr2
                     close """,
-
-                """
+        """
                     open kernelX@1.0,5.11-0.1.1.0
                     add depend type=require fmri=pkg:/incorp
                     add depend type=require fmri=pkg:/idrX
                     close """,
-
-                """
+        """
                     open idr1@1.0,5.11-0.1.1.0
                     add depend type=incorporate fmri=kernel@1.0,5.11-0.1.1.0
                     add depend type=require fmri=idr1_entitlement
                     close """,
-
-                """
+        """
                     open idr1@1.0,5.11-0.1.1.1
                     add depend type=incorporate fmri=kernel@1.0,5.11-0.1.1.1
                     add depend type=require fmri=idr1_entitlement
                     close """,
-
-                """
+        """
                     open idr2@1.0,5.11-0.1.2.0
                     add depend type=incorporate fmri=kernel@1.0,5.11-0.1.2.0
                     add depend type=require fmri=idr2_entitlement
                     close """,
-
-                """
+        """
                     open idrX@1.0,5.11-0.1.1.0
                     add set name=pkg.additional-update-on-uninstall value=kernelX@1.0,5.11-0.1
                     add depend type=incorporate fmri=kernelX@1.0,5.11-0.1.1.0
                     add depend type=require fmri=idr1_entitlement
                     close """,
-
-                """
+        """
                     open idr1_entitlement@1.0,5.11-0
                     add depend type=exclude fmri=no-idrs
                     close """,
-
-                """
+        """
                     open idr2_entitlement@1.0,5.11-0
                     add depend type=exclude fmri=no-idrs
                     close """,
-
-                # hack to prevent idrs from being installed from repo...
-
-                """
+        # hack to prevent idrs from being installed from repo...
+        """
                     open no-idrs@1.0,5.11-0
                     close """,
-
-                """
+        """
                     open pkg://contrib/bogus@1.0,5.11-0
                     add depend type=exclude fmri=A
                     add depend type=require fmri=bogus1
                     add depend type=require fmri=bogus2
                     close """,
-
-                """
+        """
                     open pkg://contrib/bogus1@1.0,5.11-0
                     add depend type=exclude fmri=B
                     close """,
-
-                """
+        """
                     open pkg://contrib/bogus2@1.0,5.11-0
                     add depend type=exclude fmri=C
-                    close """
+                    close """,
+    )
 
-                )
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.pkgsend_bulk(self.rurl, self.pkgs)
 
+    def test_install(self):
+        self.image_create(self.rurl, prefix="")
+        # simple test of reject
+        self.pkg("install --reject B A")
+        self.pkg("list A C")
+        self.pkg("uninstall '*'")
+        self.pkg("install --reject C A")
+        self.pkg("list A B")
+        self.pkg("uninstall '*'")
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.pkgsend_bulk(self.rurl, self.pkgs)
+        # test swapping XOR'd pkgs B & C w/o uninstalling A
+        self.pkg("install B")
+        self.pkg("install A")
+        self.pkg("list A B")
+        self.pkg("install --reject B C")
+        self.pkg("list A C")
+        self.pkg("uninstall '*'")
 
-        def test_install(self):
-                self.image_create(self.rurl, prefix="")
-                # simple test of reject
-                self.pkg("install --reject B A")
-                self.pkg("list A C")
-                self.pkg("uninstall '*'")
-                self.pkg("install --reject C A")
-                self.pkg("list A B")
-                self.pkg("uninstall '*'")
+        # test that solver picks up on impossible cases
+        self.pkg("install -v --reject B --reject C A", exit=1)
 
-                # test swapping XOR'd pkgs B & C w/o uninstalling A
-                self.pkg("install B")
-                self.pkg("install A")
-                self.pkg("list A B")
-                self.pkg("install --reject B C")
-                self.pkg("list A C")
-                self.pkg("uninstall '*'")
+        # test that publisher matching works
+        self.pkg("install bogus")
+        self.pkg("list bogus")
+        self.pkg("install --reject B --reject 'pkg://contrib/*' A")
 
-                # test that solver picks up on impossible cases
-                self.pkg("install -v --reject B --reject C A", exit=1)
+        # verify that matching accounts for reject.
+        self.pkg("uninstall '*'")
+        self.pkg("install -v --reject A A", exit=1)
+        self.pkg(
+            "install -v --reject 'idr*' --reject 'bogus*' " "--reject B '*'"
+        )
+        self.pkg("list 'idr*' 'bogus*' B", exit=1)
+        self.pkg("list A C incorp kernel no-idrs")
 
-                # test that publisher matching works
-                self.pkg("install bogus")
-                self.pkg("list bogus")
-                self.pkg("install --reject B --reject 'pkg://contrib/*' A")
+    def test_exact_install(self):
+        """Test that the --reject option performs as expected."""
 
-                # verify that matching accounts for reject.
-                self.pkg("uninstall '*'")
-                self.pkg("install -v --reject A A", exit=1)
-                self.pkg("install -v --reject 'idr*' --reject 'bogus*' "
-                    "--reject B '*'")
-                self.pkg("list 'idr*' 'bogus*' B", exit=1)
-                self.pkg("list A C incorp kernel no-idrs")
+        self.image_create(self.rurl, prefix="")
 
-        def test_exact_install(self):
-                """Test that the --reject option performs as expected."""
+        # test basic usage of --reject
+        self.pkg("exact-install --reject B A")
+        self.pkg("list A C")
+        self.pkg("uninstall '*'")
 
-                self.image_create(self.rurl, prefix="")
+        # test swapping XOR'd pkgs B & C.
+        self.pkg("install B")
+        self.pkg("install A")
+        self.pkg("list A B")
+        self.pkg("exact-install --reject B A")
+        self.pkg("list A C")
+        self.pkg("list B", exit=1)
+        self.pkg("uninstall '*'")
 
-                # test basic usage of --reject
-                self.pkg("exact-install --reject B A")
-                self.pkg("list A C")
-                self.pkg("uninstall '*'")
+        # test that solver picks up on impossible cases fails
+        self.pkg("exact-install -v --reject B --reject C A", exit=1)
 
-                # test swapping XOR'd pkgs B & C.
-                self.pkg("install B")
-                self.pkg("install A")
-                self.pkg("list A B")
-                self.pkg("exact-install --reject B A")
-                self.pkg("list A C")
-                self.pkg("list B", exit=1)
-                self.pkg("uninstall '*'")
+        # test that publisher matching works.
+        self.pkg("install bogus")
+        self.pkg("list bogus")
+        self.pkg("exact-install --reject B --reject " "'pkg://contrib/*' A")
+        self.pkg("uninstall '*'")
 
-                # test that solver picks up on impossible cases fails
-                self.pkg("exact-install -v --reject B --reject C A", exit=1)
+        # verify that matching accounts for reject with --exact option.
+        self.pkg("exact-install -v --reject A A", exit=1)
+        self.pkg(
+            "exact-install -v --reject 'idr*' --reject 'bogus*' "
+            "--reject B '*'"
+        )
+        self.pkg("list 'idr*' 'bogus*' B", exit=1)
+        self.pkg("list A C incorp kernel no-idrs")
 
-                # test that publisher matching works.
-                self.pkg("install bogus")
-                self.pkg("list bogus")
-                self.pkg("exact-install --reject B --reject "
-                    "'pkg://contrib/*' A")
-                self.pkg("uninstall '*'")
+    def test_idr(self):
+        self.image_create(self.rurl)
+        # install kernel pkg; remember version so we can reinstall it later
+        self.pkg("install no-idrs")
+        self.pkg("install -v kernel@1.0,5.11-0.1")
+        self.pkg("list -Hv kernel@1.0,5.11-0.1 | /usr/bin/awk '{print $1}'")
+        kernel_fmri = self.output
+        # upgrade to next version w/o encountering idrs
+        self.pkg("update -v")
+        self.pkg("list kernel@1.0,5.11-0.2")
+        self.pkg("list")
 
-                # verify that matching accounts for reject with --exact option.
-                self.pkg("exact-install -v --reject A A", exit=1)
-                self.pkg("exact-install -v --reject 'idr*' --reject 'bogus*' "
-                    "--reject B '*'")
-                self.pkg("list 'idr*' 'bogus*' B", exit=1)
-                self.pkg("list A C incorp kernel no-idrs")
+        # try installing idr1; testing wild card support as well
+        self.pkg("uninstall no-idrs")
+        self.pkg("install --reject 'k*' --reject 'i*'  no-idrs")
+        self.pkg("install -v kernel@1.0,5.11-0.1")
+        self.pkg("install -v --reject no-idrs idr1_entitlement")
+        self.pkg("install -v idr1@1.0,5.11-0.1.1.0")
+        self.pkg("update -v --reject idr2")
+        self.pkg("list idr1@1.0,5.11-0.1.1.1")
 
-        def test_idr(self):
-                self.image_create(self.rurl)
-                # install kernel pkg; remember version so we can reinstall it later
-                self.pkg("install no-idrs")
-                self.pkg("install -v kernel@1.0,5.11-0.1")
-                self.pkg("list -Hv kernel@1.0,5.11-0.1 | /usr/bin/awk '{print $1}'")
-                kernel_fmri = self.output
-                # upgrade to next version w/o encountering idrs
-                self.pkg("update -v")
-                self.pkg("list kernel@1.0,5.11-0.2")
-                self.pkg("list")
+        # switch to idr2, which affects same package
+        self.pkg(
+            "install -v --reject idr1 --reject 'idr1_*' idr2 idr2_entitlement"
+        )
 
-                # try installing idr1; testing wild card support as well
-                self.pkg("uninstall no-idrs")
-                self.pkg("install --reject 'k*' --reject 'i*'  no-idrs")
-                self.pkg("install -v kernel@1.0,5.11-0.1")
-                self.pkg("install -v --reject no-idrs idr1_entitlement")
-                self.pkg("install -v idr1@1.0,5.11-0.1.1.0")
-                self.pkg("update -v --reject idr2")
-                self.pkg("list idr1@1.0,5.11-0.1.1.1")
+        # switch back to base version of kernel
+        self.pkg(
+            "update -v --reject idr2 --reject 'idr2_*' {0}".format(kernel_fmri)
+        )
 
-                # switch to idr2, which affects same package
-                self.pkg("install -v --reject idr1 --reject 'idr1_*' idr2 idr2_entitlement")
+        # reinstall idr1, then update to version 2 of base kernel
+        self.pkg("install -v idr1@1.0,5.11-0.1.1.0 idr1_entitlement")
+        self.pkg("list kernel@1.0,5.11-0.1.1.0")
+        # Wildcards are purposefully used here for both patterns to
+        # ensure pattern matching works as expected for update.
+        self.pkg("update -v --reject 'idr1*' '*incorp@1.0-0.2'")
+        self.pkg("list  kernel@1.0,5.11-0.2")
 
-                # switch back to base version of kernel
-                self.pkg("update -v --reject idr2 --reject 'idr2_*' {0}".format(kernel_fmri))
+    def test_idr_removal(self):
+        """IDR removal with pkg actuators."""
+        self.image_create(self.rurl)
+        self.pkg("install no-idrs")
+        self.pkg("install -v kernelX@1.0,5.11-0.1")
+        self.pkg("list kernelX@1.0,5.11-0.1")
 
-                # reinstall idr1, then update to version 2 of base kernel
-                self.pkg("install -v idr1@1.0,5.11-0.1.1.0 idr1_entitlement")
-                self.pkg("list kernel@1.0,5.11-0.1.1.0")
-                # Wildcards are purposefully used here for both patterns to
-                # ensure pattern matching works as expected for update.
-                self.pkg("update -v --reject 'idr1*' '*incorp@1.0-0.2'")
-                self.pkg("list  kernel@1.0,5.11-0.2")
+        # try installing idr
+        self.pkg("install -v --reject no-idrs idr1_entitlement")
+        self.pkg("install -v idrX@1.0,5.11-0.1.1.0")
+        # check if IDR pkgs got installed
+        self.pkg("list idrX@1.0,5.11-0.1.1.0")
+        self.pkg("list kernelX@1.0,5.11-0.1.1.0")
 
-        def test_idr_removal(self):
-                """IDR removal with pkg actuators."""
-                self.image_create(self.rurl)
-                self.pkg("install no-idrs")
-                self.pkg("install -v kernelX@1.0,5.11-0.1")
-                self.pkg("list kernelX@1.0,5.11-0.1")
+        # uninstall IDR
+        self.pkg("uninstall -v idrX@1.0,5.11-0.1.1.0")
+        self.pkg("list kernelX@1.0,5.11-0.1")
 
-                # try installing idr
-                self.pkg("install -v --reject no-idrs idr1_entitlement")
-                self.pkg("install -v idrX@1.0,5.11-0.1.1.0")
-                # check if IDR pkgs got installed
-                self.pkg("list idrX@1.0,5.11-0.1.1.0")
-                self.pkg("list kernelX@1.0,5.11-0.1.1.0")
+        # try with reject
+        self.pkg("install -v idrX@1.0,5.11-0.1.1.0")
+        self.pkg("list idrX@1.0,5.11-0.1.1.0")
+        self.pkg("list kernelX@1.0,5.11-0.1.1.0")
+        self.pkg("install --reject idrX B")
+        self.pkg("list kernelX@1.0,5.11-0.1")
 
-                # uninstall IDR
-                self.pkg("uninstall -v idrX@1.0,5.11-0.1.1.0")
-                self.pkg("list kernelX@1.0,5.11-0.1")
+    def test_update(self):
+        self.image_create(self.rurl)
+        # Test update reject without wildcards.
+        self.pkg("install  kernel@1.0,5.11-0.1.1.0 A@1.0,5.11-0")
+        self.pkg("update -v --reject A")
+        self.pkg("list A", exit=1)
+        self.pkg("verify")
 
-                # try with reject
-                self.pkg("install -v idrX@1.0,5.11-0.1.1.0")
-                self.pkg("list idrX@1.0,5.11-0.1.1.0")
-                self.pkg("list kernelX@1.0,5.11-0.1.1.0")
-                self.pkg("install --reject idrX B")
-                self.pkg("list kernelX@1.0,5.11-0.1")
-
-        def test_update(self):
-                self.image_create(self.rurl)
-                # Test update reject without wildcards.
-                self.pkg("install  kernel@1.0,5.11-0.1.1.0 A@1.0,5.11-0")
-                self.pkg("update -v --reject A")
-                self.pkg("list A", exit=1)
-                self.pkg("verify")
-
-                # Reinstall kernel package, install A, and test update again using
-                # wildcards.
-                self.pkg("uninstall '*'")
-                self.pkg("install kernel@1.0,5.11-0.1.1.0")
-                self.pkg("list kernel@1.0,5.11-0.1.1.0")
-                self.pkg("install A@1.0,5.11-0")
-                self.pkg("update -v --reject A '*'")
-                self.pkg("list A", exit=1)
-                self.pkg("list kernel@1.0,5.11-0.1.1.1")
-                self.pkg("verify")
+        # Reinstall kernel package, install A, and test update again using
+        # wildcards.
+        self.pkg("uninstall '*'")
+        self.pkg("install kernel@1.0,5.11-0.1.1.0")
+        self.pkg("list kernel@1.0,5.11-0.1.1.0")
+        self.pkg("install A@1.0,5.11-0")
+        self.pkg("update -v --reject A '*'")
+        self.pkg("list A", exit=1)
+        self.pkg("list kernel@1.0,5.11-0.1.1.1")
+        self.pkg("verify")
 
 
 class TestPkgInstallAmbiguousPatterns(pkg5unittest.SingleDepotTestCase):
+    # An "ambiguous" package name pattern is one which, because of the
+    # pattern matching rules, might refer to more than one package.  This
+    # may be as obvious as the pattern "SUNW*", but also like the pattern
+    # "foo", where "foo" and "a/foo" both exist in the catalog.
 
-        # An "ambiguous" package name pattern is one which, because of the
-        # pattern matching rules, might refer to more than one package.  This
-        # may be as obvious as the pattern "SUNW*", but also like the pattern
-        # "foo", where "foo" and "a/foo" both exist in the catalog.
-
-        afoo10 = """
+    afoo10 = """
             open a/foo@1.0,5.11-0
             close """
 
-        bfoo10 = """
+    bfoo10 = """
             open b/foo@1.0,5.11-0
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             close """
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             close """
 
-        anotherfoo11 = """
+    anotherfoo11 = """
             open another/foo@1.1,5.11-0
             close """
 
-        depender10 = """
+    depender10 = """
             open depender@1.0,5.11-0
             add depend type=require fmri=foo@1.0
             close """
 
-        depender11 = """
+    depender11 = """
             open depender@1.1,5.11-0
             add depend type=require fmri=foo@1.1
             close """
 
-        def test_bug_4204(self):
-                """Don't stack trace when printing a PlanCreationException with
-                "multiple_matches" populated (on uninstall)."""
+    def test_bug_4204(self):
+        """Don't stack trace when printing a PlanCreationException with
+        "multiple_matches" populated (on uninstall)."""
 
-                self.pkgsend_bulk(self.rurl, (self.afoo10, self.bfoo10,
-                    self.bar10))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (self.afoo10, self.bfoo10, self.bar10))
+        self.image_create(self.rurl)
 
-                self.pkg("install foo", exit=1)
-                self.pkg("install a/foo b/foo", exit=0)
-                self.pkg("list")
-                self.pkg("uninstall foo", exit=1)
-                self.pkg("uninstall a/foo b/foo", exit=0)
+        self.pkg("install foo", exit=1)
+        self.pkg("install a/foo b/foo", exit=0)
+        self.pkg("list")
+        self.pkg("uninstall foo", exit=1)
+        self.pkg("uninstall a/foo b/foo", exit=0)
 
-        def test_bug_6874(self):
-                """Don't stack trace when printing a PlanCreationException with
-                "multiple_matches" populated (on install and update)."""
+    def test_bug_6874(self):
+        """Don't stack trace when printing a PlanCreationException with
+        "multiple_matches" populated (on install and update)."""
 
-                self.pkgsend_bulk(self.rurl, (self.afoo10, self.bfoo10))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (self.afoo10, self.bfoo10))
+        self.image_create(self.rurl)
 
-                self.pkg("install foo", exit=1)
+        self.pkg("install foo", exit=1)
 
-        def test_ambiguous_pattern_install(self):
-                """An update should never get confused about an existing
-                package being part of an ambiguous set of package names."""
+    def test_ambiguous_pattern_install(self):
+        """An update should never get confused about an existing
+        package being part of an ambiguous set of package names."""
 
-                self.pkgsend_bulk(self.rurl, self.foo10)
+        self.pkgsend_bulk(self.rurl, self.foo10)
 
-                self.image_create(self.rurl)
-                self.pkg("install foo")
+        self.image_create(self.rurl)
+        self.pkg("install foo")
 
-                self.pkgsend_bulk(self.rurl, self.anotherfoo11)
-                self.pkg("refresh")
-                self.pkg("update -v", exit=4)
+        self.pkgsend_bulk(self.rurl, self.anotherfoo11)
+        self.pkg("refresh")
+        self.pkg("update -v", exit=4)
 
-        def test_ambiguous_pattern_depend(self):
-                """A dependency on a package should pull in an exact name
-                match."""
+    def test_ambiguous_pattern_depend(self):
+        """A dependency on a package should pull in an exact name
+        match."""
 
-                self.ambiguous_pattern_depend_helper("install")
-                self.ambiguous_pattern_depend_helper("exact-install")
+        self.ambiguous_pattern_depend_helper("install")
+        self.ambiguous_pattern_depend_helper("exact-install")
 
-        def ambiguous_pattern_depend_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.depender10, self.foo10))
+    def ambiguous_pattern_depend_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, (self.depender10, self.foo10))
 
-                self.image_create(self.rurl)
-                self.pkg("{0} depender".format(install_cmd))
+        self.image_create(self.rurl)
+        self.pkg("{0} depender".format(install_cmd))
 
-                self.pkgsend_bulk(self.rurl, (self.foo11, self.anotherfoo11,
-                    self.depender11))
-                self.pkg("refresh")
+        self.pkgsend_bulk(
+            self.rurl, (self.foo11, self.anotherfoo11, self.depender11)
+        )
+        self.pkg("refresh")
 
-                self.pkg("{0} depender".format(install_cmd))
+        self.pkg("{0} depender".format(install_cmd))
 
-                # Make sure that we didn't get other/foo from the dependency.
-                self.pkg("list another/foo", exit=1)
+        # Make sure that we didn't get other/foo from the dependency.
+        self.pkg("list another/foo", exit=1)
 
-        def test_non_ambiguous_fragment(self):
-                """We should be able to refer to a package by its "basename", if
-                that component is unique."""
+    def test_non_ambiguous_fragment(self):
+        """We should be able to refer to a package by its "basename", if
+        that component is unique."""
 
-                self.non_ambiguous_fragment_helper("install")
-                self.non_ambiguous_fragment_helper("exact-install")
+        self.non_ambiguous_fragment_helper("install")
+        self.non_ambiguous_fragment_helper("exact-install")
 
-        def non_ambiguous_fragment_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, self.anotherfoo11)
-                self.image_create(self.rurl)
+    def non_ambiguous_fragment_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, self.anotherfoo11)
+        self.image_create(self.rurl)
 
-                # Right now, this is not exact, but still unambiguous
-                self.pkg("{0} foo".format(install_cmd))
+        # Right now, this is not exact, but still unambiguous
+        self.pkg("{0} foo".format(install_cmd))
 
-                # Create ambiguity
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.pkg("refresh")
+        # Create ambiguity
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.pkg("refresh")
 
-                # This is unambiguous, should succeed
-                self.pkg("{0} pkg:/foo".format(install_cmd))
+        # This is unambiguous, should succeed
+        self.pkg("{0} pkg:/foo".format(install_cmd))
 
-                # This is now ambiguous, should fail
-                self.pkg("{0} foo".format(install_cmd), exit=1)
-                self.pkgrepo("remove -s {0} pkg:/foo@1.1".format(self.rurl ))
+        # This is now ambiguous, should fail
+        self.pkg("{0} foo".format(install_cmd), exit=1)
+        self.pkgrepo("remove -s {0} pkg:/foo@1.1".format(self.rurl))
 
 
 class TestPkgInstallOverlappingPatterns(pkg5unittest.SingleDepotTestCase):
-
-        a_1 = """
+    a_1 = """
             open a@1.0,5.11-0
             close """
 
-        pub2_a_1 = """
+    pub2_a_1 = """
             open pkg://pub2/a@1.0,5.11-0
             close """
 
-        a_11 = """
+    a_11 = """
             open a@1.1,5.11-0
             close """
 
-        a_2 = """
+    a_2 = """
             open a@2.0,5.11-0
             close """
 
-        pub2_a_2 = """
+    pub2_a_2 = """
             open pkg://pub2/a@2.0,5.11-0
             close """
 
-        a_3 = """
+    a_3 = """
             open a@3.0,5.11-0
             close """
 
-        aa_1 = """
+    aa_1 = """
             open aa@1.0,5.11-0
             close """
 
-        afoo_1 = """
+    afoo_1 = """
             open a/foo@1.0,5.11-0
             close """
 
-        bfoo_1 = """
+    bfoo_1 = """
             open b/foo@1.0,5.11-0
             close """
 
-        fooa_1 = """
+    fooa_1 = """
             open foo/a@1.0,5.11-0
             close """
 
-        foob_1 = """
+    foob_1 = """
             open foo/b@1.0,5.11-0
             close """
 
-        def test_overlapping_one_package_available(self):
-                self.pkgsend_bulk(self.rurl, self.a_1)
-                api_inst = self.image_create(self.rurl)
+    def test_overlapping_one_package_available(self):
+        self.pkgsend_bulk(self.rurl, self.a_1)
+        api_inst = self.image_create(self.rurl)
 
-                self._api_install(api_inst, ["a@1", "a@1"], noexecute=True)
-                self._api_install(api_inst, ["a@1", "a@1.0"], noexecute=True)
-                self._api_install(api_inst, ["a@1", "pkg://test/a@1"],
-                    noexecute=True)
-                self._api_install(api_inst, ["a*@1", "pkg:/*a@1"],
-                    noexecute=True)
-                self._api_install(api_inst, ["a*@1", "a@1"], noexecute=True)
-                self._api_install(api_inst, ["a@1", "pkg://test/a*@1"],
-                    noexecute=True)
-                # This fails because a*@2 matches no patterns on its own.
-                self.pkg("install -n 'a*@2' 'a@1'", exit=1)
+        self._api_install(api_inst, ["a@1", "a@1"], noexecute=True)
+        self._api_install(api_inst, ["a@1", "a@1.0"], noexecute=True)
+        self._api_install(api_inst, ["a@1", "pkg://test/a@1"], noexecute=True)
+        self._api_install(api_inst, ["a*@1", "pkg:/*a@1"], noexecute=True)
+        self._api_install(api_inst, ["a*@1", "a@1"], noexecute=True)
+        self._api_install(api_inst, ["a@1", "pkg://test/a*@1"], noexecute=True)
+        # This fails because a*@2 matches no patterns on its own.
+        self.pkg("install -n 'a*@2' 'a@1'", exit=1)
 
-        def test_overlapping_conflicting_versions_no_wildcard_match(self):
-                self.pkgsend_bulk(self.rurl, self.a_1 + self.a_2)
-                api_inst = self.image_create(self.rurl)
+    def test_overlapping_conflicting_versions_no_wildcard_match(self):
+        self.pkgsend_bulk(self.rurl, self.a_1 + self.a_2)
+        api_inst = self.image_create(self.rurl)
 
-                self.pkg("install -n a@1 a@2", exit=1)
-                self.pkg("install -n a@2 pkg://test/a@1", exit=1)
-                self.pkg("install -n 'a*@2' 'pkg:/*a@1'", exit=1)
+        self.pkg("install -n a@1 a@2", exit=1)
+        self.pkg("install -n a@2 pkg://test/a@1", exit=1)
+        self.pkg("install -n 'a*@2' 'pkg:/*a@1'", exit=1)
 
-                # This is allowed because a*@1 matches published packages, even
-                # though the packages it matches aren't installed in the image.
-                self._api_install(api_inst, ["a*@1", "a@2"])
-                self.pkg("list a@2")
-                self._api_uninstall(api_inst, ["a"])
+        # This is allowed because a*@1 matches published packages, even
+        # though the packages it matches aren't installed in the image.
+        self._api_install(api_inst, ["a*@1", "a@2"])
+        self.pkg("list a@2")
+        self._api_uninstall(api_inst, ["a"])
 
-                self._api_install(api_inst, ["a@1", "pkg://test/a*@2"])
-                self.pkg("list a@1")
-                self._api_uninstall(api_inst, ["a"])
+        self._api_install(api_inst, ["a@1", "pkg://test/a*@2"])
+        self.pkg("list a@1")
+        self._api_uninstall(api_inst, ["a"])
 
-                self.pkgsend_bulk(self.rurl, self.a_3)
-                self._api_install(api_inst, ["a*@1", "*a@2", "a@3"])
-                self.pkg("list a@3")
-                self._api_uninstall(api_inst, ["a"])
+        self.pkgsend_bulk(self.rurl, self.a_3)
+        self._api_install(api_inst, ["a*@1", "*a@2", "a@3"])
+        self.pkg("list a@3")
+        self._api_uninstall(api_inst, ["a"])
 
-                self._api_install(api_inst, ["a*@1", "*a@2", "a@latest"])
-                self.pkg("list a@3")
-                self._api_uninstall(api_inst, ["a"])
+        self._api_install(api_inst, ["a*@1", "*a@2", "a@latest"])
+        self.pkg("list a@3")
+        self._api_uninstall(api_inst, ["a"])
 
-                self.pkgsend_bulk(self.rurl, self.a_11)
-                self.pkg("install a@1.1 a@1.0", exit=1)
-                self._api_install(api_inst, ["a@1", "a@1.0", "a*@1.1"])
-                self.pkg("list a@1.0")
-                self._api_uninstall(api_inst, ["a"])
+        self.pkgsend_bulk(self.rurl, self.a_11)
+        self.pkg("install a@1.1 a@1.0", exit=1)
+        self._api_install(api_inst, ["a@1", "a@1.0", "a*@1.1"])
+        self.pkg("list a@1.0")
+        self._api_uninstall(api_inst, ["a"])
 
-                self._api_install(api_inst, ["*", "a@1.0"])
-                self.pkg("list a@1.0")
-                self._api_uninstall(api_inst, ["a"])
+        self._api_install(api_inst, ["*", "a@1.0"])
+        self.pkg("list a@1.0")
+        self._api_uninstall(api_inst, ["a"])
 
-        def test_overlapping_multiple_packages(self):
-                self.pkgsend_bulk(self.rurl, self.a_1 + self.a_2 + self.aa_1 +
-                    self.afoo_1 + self.bfoo_1 + self.fooa_1 + self.foob_1)
-                api_inst = self.image_create(self.rurl)
+    def test_overlapping_multiple_packages(self):
+        self.pkgsend_bulk(
+            self.rurl,
+            self.a_1
+            + self.a_2
+            + self.aa_1
+            + self.afoo_1
+            + self.bfoo_1
+            + self.fooa_1
+            + self.foob_1,
+        )
+        api_inst = self.image_create(self.rurl)
 
-                self.pkg("install '*a@1' 'a*@2'", exit=1)
+        self.pkg("install '*a@1' 'a*@2'", exit=1)
 
-                self._api_install(api_inst, ["a*@1", "a@2"])
-                self.pkg("list -Hv")
-                self.assertEqual(len(self.output.splitlines()), 3)
-                self.assertTrue("a@2" in self.output)
-                self._api_uninstall(api_inst, ["a", "aa", "a/foo"])
+        self._api_install(api_inst, ["a*@1", "a@2"])
+        self.pkg("list -Hv")
+        self.assertEqual(len(self.output.splitlines()), 3)
+        self.assertTrue("a@2" in self.output)
+        self._api_uninstall(api_inst, ["a", "aa", "a/foo"])
 
-                self._api_install(api_inst, ["/a@1", "a*@2", "*foo*@1"])
-                self.pkg("list -Hv")
-                self.assertEqual(len(self.output.splitlines()), 5)
-                self.assertTrue("a@1" in self.output)
-                self._api_uninstall(api_inst,
-                    ["/a", "a/foo", "b/foo", "foo/a", "foo/b"])
+        self._api_install(api_inst, ["/a@1", "a*@2", "*foo*@1"])
+        self.pkg("list -Hv")
+        self.assertEqual(len(self.output.splitlines()), 5)
+        self.assertTrue("a@1" in self.output)
+        self._api_uninstall(
+            api_inst, ["/a", "a/foo", "b/foo", "foo/a", "foo/b"]
+        )
 
-        def test_overlapping_multiple_publishers(self):
-                self.pkgsend_bulk(self.rurl, self.a_1 + self.pub2_a_2)
-                api_inst = self.image_create(self.rurl)
+    def test_overlapping_multiple_publishers(self):
+        self.pkgsend_bulk(self.rurl, self.a_1 + self.pub2_a_2)
+        api_inst = self.image_create(self.rurl)
 
-                self._api_install(api_inst, ["a*@1", "pkg://pub2/a@2"],
-                    noexecute=True)
-                self._api_install(api_inst, ["a@1", "pkg://pub2/a*@2"],
-                    noexecute=True)
-                self._api_install(api_inst, ["a@1", "pkg://pub2/*@2"],
-                    noexecute=True)
-                self.pkg("install -n 'pkg://test/a*@1' 'pkg://pub2/*a@2'",
-                    exit=1)
-                self.pkg("install -n 'pkg://test/a@1' 'pkg://pub2/a@2'",
-                    exit=1)
-                self.pkg("install -n 'a@1' 'pkg://pub2/a@2'", exit=1)
+        self._api_install(api_inst, ["a*@1", "pkg://pub2/a@2"], noexecute=True)
+        self._api_install(api_inst, ["a@1", "pkg://pub2/a*@2"], noexecute=True)
+        self._api_install(api_inst, ["a@1", "pkg://pub2/*@2"], noexecute=True)
+        self.pkg("install -n 'pkg://test/a*@1' 'pkg://pub2/*a@2'", exit=1)
+        self.pkg("install -n 'pkg://test/a@1' 'pkg://pub2/a@2'", exit=1)
+        self.pkg("install -n 'a@1' 'pkg://pub2/a@2'", exit=1)
 
-                self.pkgsend_bulk(self.rurl, self.pub2_a_1)
-                self._api_install(api_inst, ["a@1", "pkg://pub2/a@1"])
-                self.pkg("list -Hv 'pkg://pub2/*'")
-                self.assertEqual(len(self.output.splitlines()), 1)
-                self.assertTrue("a@1" in self.output)
-                self._api_uninstall(api_inst, ["a"])
+        self.pkgsend_bulk(self.rurl, self.pub2_a_1)
+        self._api_install(api_inst, ["a@1", "pkg://pub2/a@1"])
+        self.pkg("list -Hv 'pkg://pub2/*'")
+        self.assertEqual(len(self.output.splitlines()), 1)
+        self.assertTrue("a@1" in self.output)
+        self._api_uninstall(api_inst, ["a"])
 
-                self._api_install(api_inst, ["a@1", "pkg://test/a@1"])
-                self.pkg("list -Hv 'pkg://test/*'")
-                self.assertEqual(len(self.output.splitlines()), 1)
-                self.assertTrue("a@1" in self.output)
-                self._api_uninstall(api_inst, ["a"])
+        self._api_install(api_inst, ["a@1", "pkg://test/a@1"])
+        self.pkg("list -Hv 'pkg://test/*'")
+        self.assertEqual(len(self.output.splitlines()), 1)
+        self.assertTrue("a@1" in self.output)
+        self._api_uninstall(api_inst, ["a"])
 
-                self._api_install(api_inst, ["a*@1", "pkg://pub2/*@2"])
-                self.pkg("list -Hv 'pkg://pub2/*'")
-                self.assertEqual(len(self.output.splitlines()), 1)
-                self.assertTrue("a@2" in self.output)
-                self._api_uninstall(api_inst, ["a"])
+        self._api_install(api_inst, ["a*@1", "pkg://pub2/*@2"])
+        self.pkg("list -Hv 'pkg://pub2/*'")
+        self.assertEqual(len(self.output.splitlines()), 1)
+        self.assertTrue("a@2" in self.output)
+        self._api_uninstall(api_inst, ["a"])
 
-                self._api_install(api_inst,
-                    ["pkg://test/a@1", "pkg://pub2/*@2"])
-                self.pkg("list -Hv 'pkg://test/*'")
-                self.assertEqual(len(self.output.splitlines()), 1)
-                self.assertTrue("a@1" in self.output)
-                self._api_uninstall(api_inst, ["a"])
+        self._api_install(api_inst, ["pkg://test/a@1", "pkg://pub2/*@2"])
+        self.pkg("list -Hv 'pkg://test/*'")
+        self.assertEqual(len(self.output.splitlines()), 1)
+        self.assertTrue("a@1" in self.output)
+        self._api_uninstall(api_inst, ["a"])
 
-                # This intentionally doesn't use api_install to check for
-                # special handling of '*' in client.py.
-                self.pkg("install '*' 'pkg://pub2/*@2'")
-                self.pkg("list -Hv 'pkg://pub2/*'")
-                self.assertEqual(len(self.output.splitlines()), 1)
-                self.assertTrue("a@2" in self.output)
-                self._api_uninstall(api_inst, ["a"])
+        # This intentionally doesn't use api_install to check for
+        # special handling of '*' in client.py.
+        self.pkg("install '*' 'pkg://pub2/*@2'")
+        self.pkg("list -Hv 'pkg://pub2/*'")
+        self.assertEqual(len(self.output.splitlines()), 1)
+        self.assertTrue("a@2" in self.output)
+        self._api_uninstall(api_inst, ["a"])
 
 
 class TestPkgInstallCircularDependencies(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        pkg10 = """
+    pkg10 = """
             open pkg1@1.0,5.11-0
             add depend type=require fmri=pkg:/pkg2
             close
         """
 
-        pkg20 = """
+    pkg20 = """
             open pkg2@1.0,5.11-0
             add depend type=require fmri=pkg:/pkg3
             close
         """
 
-        pkg30 = """
+    pkg30 = """
             open pkg3@1.0,5.11-0
             add depend type=require fmri=pkg:/pkg1
             close
         """
 
-
-        pkg11 = """
+    pkg11 = """
             open pkg1@1.1,5.11-0
             add depend type=require fmri=pkg:/pkg2@1.1
             close
         """
 
-        pkg21 = """
+    pkg21 = """
             open pkg2@1.1,5.11-0
             add depend type=require fmri=pkg:/pkg3@1.1
             close
         """
 
-        pkg31 = """
+    pkg31 = """
             open pkg3@1.1,5.11-0
             add depend type=require fmri=pkg:/pkg1@1.1
             close
         """
 
-        def test_unanchored_circular_dependencies(self):
-                """ check to make sure we can install or exact-install
-                circular dependencies w/o versions
-                """
+    def test_unanchored_circular_dependencies(self):
+        """check to make sure we can install or exact-install
+        circular dependencies w/o versions
+        """
 
-                self.unanchored_circular_dependencies_helper("install")
-                self.unanchored_circular_dependencies_helper("exact-install")
+        self.unanchored_circular_dependencies_helper("install")
+        self.unanchored_circular_dependencies_helper("exact-install")
 
-        def unanchored_circular_dependencies_helper(self, install_cmd):
-                # Send 1.0 versions of packages.
-                self.pkgsend_bulk(self.rurl, (self.pkg10, self.pkg20,
-                    self.pkg30))
+    def unanchored_circular_dependencies_helper(self, install_cmd):
+        # Send 1.0 versions of packages.
+        self.pkgsend_bulk(self.rurl, (self.pkg10, self.pkg20, self.pkg30))
 
-                self.image_create(self.rurl)
-                self.pkg("{0} pkg1".format(install_cmd))
-                self.pkg("list")
-                self.pkg("verify -v")
+        self.image_create(self.rurl)
+        self.pkg("{0} pkg1".format(install_cmd))
+        self.pkg("list")
+        self.pkg("verify -v")
 
-        def test_anchored_circular_dependencies(self):
-                """ check to make sure we can install or exact-install
-                circular dependencies w/ versions
-                """
+    def test_anchored_circular_dependencies(self):
+        """check to make sure we can install or exact-install
+        circular dependencies w/ versions
+        """
 
-                self.anchored_circular_dependencies_helper("install")
-                self.unanchored_circular_dependencies_helper("exact-install")
+        self.anchored_circular_dependencies_helper("install")
+        self.unanchored_circular_dependencies_helper("exact-install")
 
-        def anchored_circular_dependencies_helper(self, install_cmd):
-                # Send 1.1 versions of packages.
-                self.pkgsend_bulk(self.rurl, (self.pkg11, self.pkg21,
-                    self.pkg31))
+    def anchored_circular_dependencies_helper(self, install_cmd):
+        # Send 1.1 versions of packages.
+        self.pkgsend_bulk(self.rurl, (self.pkg11, self.pkg21, self.pkg31))
 
-                self.image_create(self.rurl)
-                self.pkg("{0} pkg1".format(install_cmd))
-                self.pkg("list")
-                self.pkg("verify -v")
+        self.image_create(self.rurl)
+        self.pkg("{0} pkg1".format(install_cmd))
+        self.pkg("list")
+        self.pkg("verify -v")
 
 
 class TestPkgInstallUpdateSolverOutput(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        octo10 = """
+    octo10 = """
             open octo@1.0,5.11-0
             close
         """
 
-        octo20 = """
+    octo20 = """
             open octo@2.0,5.11-0
             close
         """
 
-        incorp = """
+    incorp = """
             open incorp@1.0,5.11-0
             add depend type=incorporate fmri=pkg:/octo@2.0
             close
         """
 
-        def test_output_two_issues(self):
-                """ ^^^ hard to find a good name for this, it tests for bug
-                21130996.
-                In case one pkg triggers two or more issues, one of which is not
-                considered print-worthy, we wouldn't print anything at all."""
+    def test_output_two_issues(self):
+        """^^^ hard to find a good name for this, it tests for bug
+        21130996.
+        In case one pkg triggers two or more issues, one of which is not
+        considered print-worthy, we wouldn't print anything at all."""
 
-                self.pkgsend_bulk(self.rurl,
-                    (self.incorp, self.octo10, self.octo20))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (self.incorp, self.octo10, self.octo20))
+        self.image_create(self.rurl)
 
-                self.pkg("install incorp octo@2")
-                self.pkg("install -v octo@1", exit=1)
+        self.pkg("install incorp octo@2")
+        self.pkg("install -v octo@1", exit=1)
 
-                # Check that the root cause for the issue is shown;
-                # the incorporation does not allow the older version.
-                self.assertTrue("incorp@1.0" in self.errout,
-                    "Excluding incorporation not shown in solver error.")
-                # Check that the notice about a newer version already installed
-                # is ommited (it's not relevant).
-                self.assertFalse("octo@2.0" in self.errout,
-                    "Newer version should not be shown in solver error.")
+        # Check that the root cause for the issue is shown;
+        # the incorporation does not allow the older version.
+        self.assertTrue(
+            "incorp@1.0" in self.errout,
+            "Excluding incorporation not shown in solver error.",
+        )
+        # Check that the notice about a newer version already installed
+        # is ommited (it's not relevant).
+        self.assertFalse(
+            "octo@2.0" in self.errout,
+            "Newer version should not be shown in solver error.",
+        )
 
 
 class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
-        need_ro_data = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+    need_ro_data = True
 
-        incorp10 = """
+    incorp10 = """
             open incorp@1.0,5.11-0
             add depend type=incorporate fmri=pkg:/amber@1.0
             add depend type=incorporate fmri=pkg:/bronze@1.0
             close
         """
 
-        incorp20 = """
+    incorp20 = """
             open incorp@2.0,5.11-0
             add depend type=incorporate fmri=pkg:/amber@2.0
             add depend type=incorporate fmri=pkg:/bronze@2.0
             close
         """
 
-        incorp30 = """
+    incorp30 = """
             open incorp@3.0,5.11-0
             add depend type=incorporate fmri=pkg:/amber@2.0
             close
         """
 
-        incorpA = """
+    incorpA = """
             open incorpA@1.0,5.11-0
             add depend type=incorporate fmri=pkg:/amber@1.0
             add depend type=incorporate fmri=pkg:/bronze@1.0
             close
         """
 
-        incorpB =  """
+    incorpB = """
             open incorpB@1.0,5.11-0
             add depend type=incorporate fmri=pkg:/amber@2.0
             add depend type=incorporate fmri=pkg:/bronze@2.0
             close
         """
 
-        iridium10 = """
+    iridium10 = """
             open iridium@1.0,5.11-0
             add depend fmri=pkg:/amber@2.0 type=require
             close
         """
-        amber10 = """
+    amber10 = """
             open amber@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             add dir mode=0755 owner=root group=bin path=/etc
@@ -2635,13 +2692,13 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        brass10 = """
+    brass10 = """
             open brass@1.0,5.11-0
             add depend fmri=pkg:/bronze type=require
             close
         """
 
-        bronze10 = """
+    bronze10 = """
             open bronze@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/usr
             add dir mode=0755 owner=root group=bin path=/usr/bin
@@ -2656,7 +2713,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        amber20 = """
+    amber20 = """
             open amber@2.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/usr
             add dir mode=0755 owner=root group=bin path=/usr/bin
@@ -2671,7 +2728,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        bronze20 = """
+    bronze20 = """
             open bronze@2.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/etc
             add dir mode=0755 owner=root group=bin path=/lib
@@ -2687,7 +2744,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        bronze30 = """
+    bronze30 = """
             open bronze@3.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/etc
             add dir mode=0755 owner=root group=bin path=/lib
@@ -2703,8 +2760,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-
-        gold10 = """
+    gold10 = """
             open gold@1.0,5.11-0
             add file tmp/gold-passwd1 mode=0644 owner=root group=bin path=etc/passwd preserve=true
             add file tmp/gold-group mode=0644 owner=root group=bin path=etc/group preserve=true
@@ -2715,34 +2771,34 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        gold20 = """
+    gold20 = """
             open gold@2.0,5.11-0
             add file tmp/config2 mode=0644 owner=root group=bin path=etc/config2 original_name="gold:etc/passwd" preserve=true
             close
         """
 
-        gold30 = """
+    gold30 = """
             open gold@3.0,5.11-0
             close
         """
 
-        golduser10 = """
+    golduser10 = """
             open golduser@1.0
             add user username=Kermit group=adm home-dir=/export/home/Kermit
             close
         """
 
-        golduser20 = """
+    golduser20 = """
             open golduser@2.0
             close
         """
 
-        silver10  = """
+    silver10 = """
             open silver@1.0,5.11-0
             close
         """
 
-        silver20  = """
+    silver20 = """
             open silver@2.0,5.11-0
             add file tmp/gold-passwd2 mode=0644 owner=root group=bin path=etc/passwd original_name="gold:etc/passwd" preserve=true
             add file tmp/gold-group mode=0644 owner=root group=bin path=etc/group original_name="gold:etc/group" preserve=true
@@ -2752,20 +2808,19 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             add file tmp/silver-silly mode=0644 owner=root group=bin path=etc/silly2
             close
         """
-        silver30  = """
+    silver30 = """
             open silver@3.0,5.11-0
             add file tmp/config2 mode=0644 owner=root group=bin path=etc/config2 original_name="gold:etc/passwd" preserve=true
             close
         """
 
-        silveruser = """
+    silveruser = """
             open silveruser@1.0
             add user username=Kermit group=adm home-dir=/export/home/Kermit
             close
         """
 
-
-        iron10 = """
+    iron10 = """
             open iron@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add file tmp/config1 mode=0644 owner=root group=bin path=etc/foo
@@ -2773,7 +2828,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             add license tmp/copyright1 license=copyright
             close
         """
-        iron20 = """
+    iron20 = """
             open iron@2.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add file tmp/config2 mode=0644 owner=root group=bin path=etc/foo
@@ -2782,14 +2837,14 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        concorp10 = """
+    concorp10 = """
             open concorp@1.0,5.11-0
             add depend type=incorporate fmri=pkg:/amber@2.0
             add depend type=incorporate fmri=pkg:/bronze@2.0
             close
         """
 
-        dricon1 = """
+    dricon1 = """
             open dricon@1
             add dir path=var mode=755 owner=root group=root
             add dir path=var/run mode=755 owner=root group=root
@@ -2802,7 +2857,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        dricon2 = """
+    dricon2 = """
             open dricon@2
             add dir path=var mode=755 owner=root group=root
             add dir path=var/run mode=755 owner=root group=root
@@ -2816,7 +2871,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        dricon3 = """
+    dricon3 = """
             open dricon@3
             add dir path=var mode=755 owner=root group=root
             add dir path=var/run mode=755 owner=root group=root
@@ -2829,7 +2884,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        dripol1 = """
+    dripol1 = """
             open dripol@1
             add dir path=var mode=755 owner=root group=root
             add dir path=var/run mode=755 owner=root group=root
@@ -2845,7 +2900,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        dripol2 = """
+    dripol2 = """
             open dripol@2
             add dir path=var mode=755 owner=root group=root
             add dir path=var/run mode=755 owner=root group=root
@@ -2861,140 +2916,140 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        liveroot10 = """
+    liveroot10 = """
             open liveroot@1.0
             add dir path=/etc mode=755 owner=root group=root
             add file tmp/liveroot1 path=/etc/liveroot mode=644 owner=root group=sys reboot-needed=true
             close
         """
-        liveroot20 = """
+    liveroot20 = """
             open liveroot@2.0
             add dir path=/etc mode=755 owner=root group=root
             add file tmp/liveroot2 path=/etc/liveroot mode=644 owner=root group=sys reboot-needed=true
             close
         """
 
-        release_name = """
+    release_name = """
             open release/name@1.0
             add file tmp/liveroot1 path=/etc/liveroot mode=644 owner=root group=sys reboot-needed=true
             close
         """
 
-        renameold1 = """
+    renameold1 = """
             open renold@1.0
             add file tmp/renold1 path=testme mode=0644 owner=root group=root preserve=renameold
             close
         """
 
-        renameold2 = """
+    renameold2 = """
             open renold@2.0
             add file tmp/renold1 path=testme mode=0640 owner=root group=root preserve=renameold
             close
         """
 
-        renameold3 = """
+    renameold3 = """
             open renold@3.0
             add file tmp/renold3 path=testme mode=0644 owner=root group=root preserve=renameold
             close
         """
 
-        renamenew1 = """
+    renamenew1 = """
             open rennew@1.0
             add file tmp/rennew1 path=testme mode=0644 owner=root group=root preserve=renamenew
             close
         """
 
-        renamenew2 = """
+    renamenew2 = """
             open rennew@2.0
             add file tmp/rennew1 path=testme mode=0640 owner=root group=root preserve=renamenew
             close
         """
 
-        renamenew3 = """
+    renamenew3 = """
             open rennew@3.0
             add file tmp/rennew3 path=testme mode=0644 owner=root group=root preserve=renamenew
             close
         """
 
-        preserve1 = """
+    preserve1 = """
             open preserve@1.0
             add file tmp/preserve1 path=testme mode=0644 owner=root group=root preserve=true
             close
         """
 
-        preserve2 = """
+    preserve2 = """
             open preserve@2.0
             add file tmp/preserve1 path=testme mode=0640 owner=root group=root preserve=true
             close
         """
 
-        preserve3 = """
+    preserve3 = """
             open preserve@3.0
             add file tmp/preserve3 path=testme mode=0644 owner=root group=root preserve=true
             close
         """
 
-        preserve_version_4 = """
+    preserve_version_4 = """
             open preserve_version@4.0
             add file tmp/preserve_version_4 path=testme mode=0644 owner=root group=root preserve=true preserve-version=1.0
             close
         """
 
-        preserve_version_3 = """
+    preserve_version_3 = """
             open preserve_version@3.0
             add file tmp/preserve_version_3 path=testme mode=0644 owner=root group=root preserve=true preserve-version=0.1
             close
         """
 
-        preserve_version_2 = """
+    preserve_version_2 = """
             open preserve_version@2.0
             add file tmp/preserve_version_2 path=testme mode=0644 owner=root group=root preserve=true preserve-version=1.0
             close
         """
 
-        preserve_version_1 = """
+    preserve_version_1 = """
             open preserve_version@1.0
             add file tmp/preserve_version_1 path=testme mode=0644 owner=root group=root preserve=true preserve-version=2.0 overlay=allow
             close
         """
 
-        no_pres_ver_2 = """
+    no_pres_ver_2 = """
             open no_pres_ver@2.0
             add file tmp/no_pres_ver_2 path=testme mode=0644 owner=root group=root preserve=true
             close
         """
 
-        no_pres_ver_1 = """
+    no_pres_ver_1 = """
             open no_pres_ver@1.0
             add file tmp/no_pres_ver_1 path=testme mode=0644 owner=root group=root preserve=true preserve-version=1.0
             close
         """
 
-        add_pres_ver_2 = """
+    add_pres_ver_2 = """
             open add_pres_ver@2.0
             add file tmp/add_pres_ver_2 path=testme mode=0644 owner=root group=root preserve=true preserve-version=1.0
             close
         """
 
-        add_pres_ver_1 = """
+    add_pres_ver_1 = """
             open add_pres_ver@1.0
             add file tmp/add_pres_ver_1 path=testme mode=0644 owner=root group=root preserve=true
             close
         """
 
-        pres_ver_overlay_1 = """
+    pres_ver_overlay_1 = """
             open pres_ver_overlay@1.0
             add file tmp/pres_ver_overlay_1 path=testme mode=0644 owner=root group=root overlay=true
             close
         """
 
-        pres_ver_overlay_2 = """
+    pres_ver_overlay_2 = """
             open pres_ver_overlay@2.0
             add file tmp/pres_ver_overlay_2 path=testme mode=0644 owner=root group=root overlay=true preserve=true preserve-version=1.0
             close
         """
 
-        preslegacy = """
+    preslegacy = """
             open preslegacy@1.0
             add file tmp/preserve1 path=testme mode=0644 owner=root group=root preserve=true
             close
@@ -3006,7 +3061,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        renpreslegacy = """
+    renpreslegacy = """
             open orig_preslegacy@1.0
             add file tmp/preserve1 path=testme mode=0644 owner=root group=root preserve=true
             close
@@ -3019,7 +3074,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        presabandon = """
+    presabandon = """
             open presabandon@1.0
             add file tmp/preserve1 path=testme mode=0444 owner=root group=root preserve=true
             close
@@ -3034,7 +3089,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        presinstallonly = """
+    presinstallonly = """
             open presinstallonly@0.0
             close
             open presinstallonly@1.0
@@ -3051,7 +3106,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        preslink = """
+    preslink = """
             open preslink@0.0
             close
             open preslink@1.0
@@ -3074,7 +3129,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        renpreserve = """
+    renpreserve = """
             open orig_pkg@1.0
             add file tmp/preserve1 path=foo1 mode=0644 owner=root group=root preserve=true
             add file tmp/bronze1 path=bronze1 mode=0644 owner=root group=root preserve=true
@@ -3089,7 +3144,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        linkpreserve = """
+    linkpreserve = """
             open linkpreserve@1.0
             add file tmp/preserve1 path=etc/ssh/sshd_config mode=0644 owner=root group=root preserve=true
             close
@@ -3098,7 +3153,7 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             add link path=etc/ssh/sshd_config target=../sunssh/sshd_config
             close """
 
-        salvage = """
+    salvage = """
             open salvage@1.0
             add dir path=var mode=755 owner=root group=root
             add dir path=var/mail mode=755 owner=root group=root
@@ -3123,13 +3178,13 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        salvage_special = """
+    salvage_special = """
             open salvage-special@1.0
             add dir path=salvage mode=755 owner=root group=root
             close
         """
 
-        salvage_nested = """
+    salvage_nested = """
             open salvage-nested@1.0
             add dir path=var mode=755 owner=root group=root
             add dir path=var/mail mode=755 owner=root group=root
@@ -3175,87 +3230,112 @@ class TestPkgInstallUpgrade(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        dumdir10 = """
+    dumdir10 = """
             open dumdir@1.0
             add dir path=etc mode=0755 owner=root group=bin
             add file tmp/amber1 mode=0755 owner=root group=bin path=etc/amber1
             close
         """
 
-        dumdir20 = """
+    dumdir20 = """
             open dumdir@2.0
             add dir path=etc mode=0700 owner=root group=bin
             add file tmp/amber1 mode=0444 owner=root group=bin path=etc/amber1
             close
         """
 
-        dumdir30 = """
+    dumdir30 = """
             open dumdir@3.0
             add dir path=etc mode=0700 owner=bin group=bin
             add file tmp/amber1 mode=0400 owner=root group=bin path=etc/amber1
             close
         """
 
-        elfhash10 = """
+    elfhash10 = """
             open elfhash@1.0
             add file ro_data/elftest.so.1 mode=0755 owner=root group=bin path=bin/true
             close
         """
 
-        elfhash20 = """
+    elfhash20 = """
             open elfhash@2.0
             add file ro_data/elftest.so.1 mode=0755 owner=root group=bin path=bin/true
             close
         """
 
-        misc_files1 = [
-            "tmp/amber1", "tmp/amber2", "tmp/bronzeA1",  "tmp/bronzeA2",
-            "tmp/bronze1", "tmp/bronze2",
-            "tmp/copyright1", "tmp/copyright2",
-            "tmp/copyright3", "tmp/copyright4",
-            "tmp/libc.so.1", "tmp/sh", "tmp/config1", "tmp/config2",
-            "tmp/gold-passwd1", "tmp/gold-passwd2", "tmp/gold-group",
-            "tmp/gold-shadow", "tmp/gold-ftpusers", "tmp/gold-silly",
-            "tmp/silver-silly", "tmp/preserve1", "tmp/preserve2",
-            "tmp/preserve3",
-            "tmp/preserve_version_1", "tmp/preserve_version_2",
-            "tmp/preserve_version_3", "tmp/preserve_version_4",
-            "tmp/no_pres_ver_1", "tmp/no_pres_ver_2",
-            "tmp/add_pres_ver_1", "tmp/add_pres_ver_2",
-            "tmp/pres_ver_overlay_1", "tmp/pres_ver_overlay_2",
-            "tmp/renold1", "tmp/renold3", "tmp/rennew1",
-            "tmp/rennew3", "tmp/liveroot1", "tmp/liveroot2", "tmp/foo2",
-            "tmp/auth1"
-        ]
+    misc_files1 = [
+        "tmp/amber1",
+        "tmp/amber2",
+        "tmp/bronzeA1",
+        "tmp/bronzeA2",
+        "tmp/bronze1",
+        "tmp/bronze2",
+        "tmp/copyright1",
+        "tmp/copyright2",
+        "tmp/copyright3",
+        "tmp/copyright4",
+        "tmp/libc.so.1",
+        "tmp/sh",
+        "tmp/config1",
+        "tmp/config2",
+        "tmp/gold-passwd1",
+        "tmp/gold-passwd2",
+        "tmp/gold-group",
+        "tmp/gold-shadow",
+        "tmp/gold-ftpusers",
+        "tmp/gold-silly",
+        "tmp/silver-silly",
+        "tmp/preserve1",
+        "tmp/preserve2",
+        "tmp/preserve3",
+        "tmp/preserve_version_1",
+        "tmp/preserve_version_2",
+        "tmp/preserve_version_3",
+        "tmp/preserve_version_4",
+        "tmp/no_pres_ver_1",
+        "tmp/no_pres_ver_2",
+        "tmp/add_pres_ver_1",
+        "tmp/add_pres_ver_2",
+        "tmp/pres_ver_overlay_1",
+        "tmp/pres_ver_overlay_2",
+        "tmp/renold1",
+        "tmp/renold3",
+        "tmp/rennew1",
+        "tmp/rennew3",
+        "tmp/liveroot1",
+        "tmp/liveroot2",
+        "tmp/foo2",
+        "tmp/auth1",
+    ]
 
-        misc_files2 = {
-            "tmp/dricon_da": """\
+    misc_files2 = {
+        "tmp/dricon_da": """\
 wigit "pci8086,1234"
 wigit "pci8086,4321"
 # someother "pci8086,1234"
 foobar "pci8086,9999"
 """,
-            "tmp/dricon2_da": """\
+        "tmp/dricon2_da": """\
 zigit "pci8086,1234"
 wigit "pci8086,4321"
 # someother "pci8086,1234"
 foobar "pci8086,9999"
 """,
-            "tmp/dricon_n2m": """\
+        "tmp/dricon_n2m": """\
 wigit 1
 foobar 2
 """,
-            "tmp/dripol1_dp": """\
+        "tmp/dripol1_dp": """\
 *               read_priv_set=none              write_priv_set=none
 """,
-            "tmp/gold-passwd1": """\
+        "tmp/gold-passwd1": """\
 root:x:0:0::/root:/usr/bin/bash
 daemon:x:1:1::/:
 bin:x:2:2::/usr/bin:
 sys:x:3:3::/:
 adm:x:4:4:Admin:/var/adm:
 """,
-            "tmp/gold-passwd2": """\
+        "tmp/gold-passwd2": """\
 root:x:0:0::/root:/usr/bin/bash
 daemon:x:1:1::/:
 bin:x:2:2::/usr/bin:
@@ -3263,2159 +3343,2219 @@ sys:x:3:3::/:
 adm:x:4:4:Admin:/var/adm:
 bogus:x:10001:10001:Bogus User:/:
 """,
-            "tmp/gold-group": """\
+        "tmp/gold-group": """\
 root::0:
 other::1:root
 bin::2:root,daemon
 sys::3:root,bin,adm
 adm::4:root,daemon
 """,
-            "tmp/gold-shadow": """\
+        "tmp/gold-shadow": """\
 root:9EIfTNBp9elws:13817::::::
 daemon:NP:6445::::::
 bin:NP:6445::::::
 sys:NP:6445::::::
 adm:NP:6445::::::
 """,
-            "tmp/gold-ftpusers": """\
+        "tmp/gold-ftpusers": """\
 root
 bin
 sys
 adm
 """,
-        }
+    }
 
-        cat_data = " "
+    cat_data = " "
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        only_attr10 = """
+    only_attr10 = """
             open only_attr@1.0,5.11-0
             add set name=foo value=bar
             close """
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files1)
-                self.make_misc_files(self.misc_files2)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files1)
+        self.make_misc_files(self.misc_files2)
 
-        def __salvage_file_contains(self, sroot, fprefix, entry):
-                salvaged = [
-                    n for n in os.listdir(sroot)
-                    if n.startswith(fprefix + "-")
+    def __salvage_file_contains(self, sroot, fprefix, entry):
+        salvaged = [n for n in os.listdir(sroot) if n.startswith(fprefix + "-")]
+
+        sfile = os.path.join(sroot, salvaged[0])
+        with open(sfile, "r") as f:
+            found = [l.strip() for l in f if entry in l]
+            self.assertEqual(found, [entry])
+
+    def test_incorp_install(self):
+        """Make sure we don't round up packages we specify on
+        install"""
+
+        first_bronze = self.pkgsend_bulk(self.rurl, self.bronze20)[0]
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.incorp20,
+                self.amber10,
+                self.bronze10,
+                self.amber20,
+                self.bronze20,
+            ),
+        )
+
+        # create image
+        self.image_create(self.rurl)
+        # install incorp2
+        self.pkg("install incorp@2.0")
+        # try to install version 1
+        self.pkg("install bronze@1.0", exit=1)
+        # install earliest version bronze@2.0
+        self.pkg("install {0}".format(first_bronze))
+        self.pkg("list -v {0}".format(first_bronze))
+        self.pkg("install bronze@2.0")
+
+    def test_content_hash_install(self):
+        """Test that pkg install/upgrade works fine for files with
+        content-hash attributes."""
+
+        plist = self.pkgsend_bulk(self.rurl, (self.elfhash10, self.elfhash20))
+        elf1 = plist[0]
+        elf2 = plist[1]
+        f1 = fmri.PkgFmri(elf1, None)
+        f2 = fmri.PkgFmri(elf2, None)
+        repo = self.get_repo(self.dc.get_repodir())
+        mpath1 = repo.manifest(f1)
+        mpath2 = repo.manifest(f2)
+
+        # load manifest, change content-hash attr and store back
+        # to disk
+        mani = manifest.Manifest()
+        mani.set_content(pathname=mpath1)
+        mani2 = manifest.Manifest()
+        mani2.set_content(pathname=mpath2)
+
+        # Upgrade case: action that doesn't use pkg.content-hash upgrade
+        # to action that uses pkg.content-hash.
+        for a in mani.gen_actions():
+            if "bin/true" in str(a):
+                tmp = a.attrs["pkg.content-hash"]
+                del a.attrs["pkg.content-hash"]
+        mani.store(mpath1)
+        # rebuild repo catalog since manifest digest changed
+        repo.rebuild()
+
+        self.image_create(self.rurl)
+        self.pkg("install -v elfhash@1.0")
+        # should not see pkg.content-hash
+        self.pkg("contents -m elfhash | grep pkg.content-hash", exit=1)
+        self.pkg("update -vvv elfhash")
+        # should update to the new hash attr name
+        self.pkg("contents -m elfhash | grep pkg.content-hash")
+        self.pkg("uninstall elfhash")
+
+        # Upgrade case: action that uses SHA-2 hash upgrade to action
+        # that uses SHA-3 hash.
+        for a in mani.gen_actions():
+            if "bin/true" in str(a):
+                a.attrs["pkg.content-hash"] = tmp
+        mani.store(mpath1)
+        repo.rebuild()
+
+        for a in mani2.gen_actions():
+            if "bin/true" in str(a):
+                a.attrs["pkg.content-hash"] = [
+                    "file:sha3_384:abcd",
+                    "gelf:sha3_384:wxyz",
+                    "gelf.unsigned:sha3_384:wxyz",
+                ]
+        mani2.store(mpath2)
+        repo.rebuild()
+
+        self.pkg("install -v elfhash@1.0")
+        self.pkg("contents -m elfhash | grep gelf:sha512t_256")
+        self.pkg("update -vvv elfhash")
+        self.pkg("contents -m elfhash | grep gelf:sha512t_256", exit=1)
+        self.pkg("contents -m elfhash | grep gelf:sha3_384")
+        self.pkg("uninstall elfhash")
+
+        # Redo the test again with upgrading to action that uses both
+        # hashes.
+        for a in mani2.gen_actions():
+            if "bin/true" in str(a):
+                a.attrs["pkg.content-hash"] = [
+                    "gelf:sha512t_256:abcd",
+                    "gelf:sha3_384:wxyz",
                 ]
 
-                sfile = os.path.join(sroot, salvaged[0])
-                with open(sfile, "r") as f:
-                        found = [l.strip() for l in f if entry in l]
-                        self.assertEqual(found, [entry])
-
-        def test_incorp_install(self):
-                """Make sure we don't round up packages we specify on
-                install"""
-
-                first_bronze = self.pkgsend_bulk(self.rurl, self.bronze20)[0]
-                self.pkgsend_bulk(self.rurl, (self.incorp20, self.amber10,
-                    self.bronze10, self.amber20, self.bronze20))
-
-                # create image
-                self.image_create(self.rurl)
-                # install incorp2
-                self.pkg("install incorp@2.0")
-                # try to install version 1
-                self.pkg("install bronze@1.0", exit=1)
-                # install earliest version bronze@2.0
-                self.pkg("install {0}".format(first_bronze))
-                self.pkg("list -v {0}".format(first_bronze))
-                self.pkg("install bronze@2.0")
-
-        def test_content_hash_install(self):
-                """Test that pkg install/upgrade works fine for files with
-                content-hash attributes."""
-
-                plist = self.pkgsend_bulk(self.rurl, (self.elfhash10,
-                    self.elfhash20))
-                elf1 = plist[0]
-                elf2 = plist[1]
-                f1 = fmri.PkgFmri(elf1, None)
-                f2 = fmri.PkgFmri(elf2, None)
-                repo = self.get_repo(self.dc.get_repodir())
-                mpath1 = repo.manifest(f1)
-                mpath2 = repo.manifest(f2)
-
-                # load manifest, change content-hash attr and store back
-                # to disk
-                mani = manifest.Manifest()
-                mani.set_content(pathname=mpath1)
-                mani2 = manifest.Manifest()
-                mani2.set_content(pathname=mpath2)
-
-                # Upgrade case: action that doesn't use pkg.content-hash upgrade
-                # to action that uses pkg.content-hash.
-                for a in mani.gen_actions():
-                        if "bin/true" in str(a):
-                                tmp = a.attrs["pkg.content-hash"]
-                                del a.attrs["pkg.content-hash"]
-                mani.store(mpath1)
-                # rebuild repo catalog since manifest digest changed
-                repo.rebuild()
-
-                self.image_create(self.rurl)
-                self.pkg("install -v elfhash@1.0")
-                # should not see pkg.content-hash
-                self.pkg("contents -m elfhash | grep pkg.content-hash", exit=1)
-                self.pkg("update -vvv elfhash")
-                # should update to the new hash attr name
-                self.pkg("contents -m elfhash | grep pkg.content-hash")
-                self.pkg("uninstall elfhash")
-
-                # Upgrade case: action that uses SHA-2 hash upgrade to action
-                # that uses SHA-3 hash.
-                for a in mani.gen_actions():
-                        if "bin/true" in str(a):
-                                a.attrs["pkg.content-hash"] = tmp
-                mani.store(mpath1)
-                repo.rebuild()
-
-                for a in mani2.gen_actions():
-                        if "bin/true" in str(a):
-                                a.attrs["pkg.content-hash"] = \
-                                    ["file:sha3_384:abcd", "gelf:sha3_384:wxyz", "gelf.unsigned:sha3_384:wxyz"]
-                mani2.store(mpath2)
-                repo.rebuild()
-
-                self.pkg("install -v elfhash@1.0")
-                self.pkg("contents -m elfhash | grep gelf:sha512t_256")
-                self.pkg("update -vvv elfhash")
-                self.pkg("contents -m elfhash | grep gelf:sha512t_256", exit=1)
-                self.pkg("contents -m elfhash | grep gelf:sha3_384")
-                self.pkg("uninstall elfhash")
-
-                # Redo the test again with upgrading to action that uses both
-                # hashes.
-                for a in mani2.gen_actions():
-                        if "bin/true" in str(a):
-                                a.attrs["pkg.content-hash"] = \
-                                    ["gelf:sha512t_256:abcd", "gelf:sha3_384:wxyz"]
-
-                mani2.store(mpath2)
-                repo.rebuild()
-
-                self.pkg("install -v elfhash@1.0")
-                self.pkg("contents -m elfhash | grep gelf:sha512t_256")
-                self.pkg("update -vvv elfhash")
-                self.pkg("contents -m elfhash | grep gelf:sha512t_256")
-                self.pkg("contents -m elfhash | grep gelf:sha3_384")
-                self.pkg("uninstall elfhash")
-
-                # Upgrade case: action that uses gelf and file extraction method
-                # upgrade to action that only uses file extraction method.
-                for a in mani2.gen_actions():
-                        if "bin/true" in str(a):
-                                a.attrs["pkg.content-hash"] = \
-                                    ["file:sha512t_256:2374db2dfb4968baad246ab37afc560cc9d278b6104a889a2727d9bcf6a20b17"]
-
-                mani2.store(mpath2)
-                repo.rebuild()
-
-                self.pkg("install -v elfhash@1.0")
-                self.pkg("contents -m elfhash | grep gelf")
-                self.pkg("update -vvv elfhash")
-                self.pkg("contents -m elfhash | grep gelf", exit=1)
-                self.pkg("contents -m elfhash | grep file")
-                self.pkg("uninstall elfhash")
-
-                # Redo the test again with upgrading to action uses both
-                # methods.
-                for a in mani2.gen_actions():
-                        if "bin/true" in str(a):
-                                a.attrs["pkg.content-hash"] = \
-                                    ["gelf:sha512t_256:abcd", "file:sha512t_256:2374db2dfb4968baad246ab37afc560cc9d278b6104a889a2727d9bcf6a20b17"]
-
-                mani2.store(mpath2)
-                repo.rebuild()
-
-                self.pkg("install -v elfhash@1.0")
-                self.pkg("contents -m elfhash | grep gelf")
-                self.pkg("update -vvv elfhash")
-                # we update the file's content-hash attributes.
-                self.pkg("contents -m elfhash | grep gelf")
-                self.pkg("contents -m elfhash | grep file")
-                self.pkg("uninstall elfhash")
-
-        def test_upgrade1(self):
-
-                """ Upgrade torture test.
-                    Send package amber@1.0, bronze1.0; install bronze1.0, which
-                    should cause amber to also install.
-                    Send 2.0 versions of packages which contains a lot of
-                    complex transactions between amber and bronze, then do
-                    an update, and try to check the results.
-                """
-
-                # Send 1.0 versions of packages.
-                self.pkgsend_bulk(self.rurl, (self.incorp10, self.amber10,
-                    self.bronze10))
-
-                #
-                # In version 2.0, several things happen:
-                #
-                # Amber and Bronze swap a file with each other in both
-                # directions.  The dependency flips over (Amber now depends
-                # on Bronze).  Amber and Bronze swap ownership of various
-                # directories.
-                #
-                # Bronze's 1.0 hardlink to amber's libc goes away and is
-                # replaced with a file of the same name.  Amber hardlinks
-                # to that.
-                #
-                self.pkgsend_bulk(self.rurl, (self.incorp20, self.amber20,
-                    self.bronze20))
-
-                # create image and install version 1
-                self.image_create(self.rurl)
-                self.pkg("install incorp@1.0")
-                # self.file_exists(".SELF-ASSEMBLY-REQUIRED")
-                self.pkg("install bronze")
-
-                self.pkg("list amber@1.0 bronze@1.0")
-                self.pkg("verify -v")
-
-                # demonstrate that incorp@1.0 prevents package movement
-                self.pkg("install bronze@2.0 amber@2.0", exit=1)
-
-                # ...again, but using @latest.
-                self.pkg("install bronze@latest amber@latest", exit=1)
-                self.pkg("update bronze@latest amber@latest", exit=1)
-
-                # Now update to get new versions of amber and bronze
-                # self.file_remove(".SELF-ASSEMBLY-REQUIRED")
-                self.pkg("update")
-                # self.file_exists(".SELF-ASSEMBLY-REQUIRED")
-
-                # Try to verify that it worked.
-                self.pkg("list amber@2.0 bronze@2.0")
-                self.pkg("verify -v")
-                # make sure old implicit directories for bronzeA1 were removed
-                self.assertTrue(not os.path.isdir(os.path.join(self.get_img_path(),
-                    "A")))
-                # Remove packages
-                self.pkg("uninstall amber bronze")
-                self.pkg("verify -v")
-
-                # Make sure all directories are gone save /var in test image.
-                self.assertEqual(set(os.listdir(self.get_img_path())),
-                    set(["var"]))
-
-        def test_upgrade2(self):
-                """ test incorporations:
-                        1) install files that conflict w/ existing incorps
-                        2) install package w/ dependencies that violate incorps
-                        3) install incorp that violates existing incorp
-                        4) install incorp that would force package backwards
-                        """
-
-                # Send all pkgs
-                plist = self.pkgsend_bulk(self.rurl, (self.incorp10,
-                    self.incorp20, self.incorp30, self.iridium10,
-                    self.concorp10, self.amber10, self.amber20, self.bronze10,
-                    self.bronze20, self.bronze30, self.brass10))
-
-                self.image_create(self.rurl)
-
-                self.pkg("install incorp@1.0")
-                # install files that conflict w/ existing incorps
-                self.pkg("install bronze@2.0", exit=1)
-                # install package w/ dependencies that violate incorps
-                self.pkg("install iridium@1.0", exit=1)
-                # install package w/ unspecified dependency that pulls
-                # in bronze
-                self.pkg("install brass")
-                self.pkg("verify brass@1.0 bronze@1.0")
-                # attempt to install conflicting incorporation
-                self.pkg("install concorp@1.0", exit=1)
-
-                # attempt to force downgrade of package w/ older incorp
-                self.pkg("install incorp@2.0")
-                self.pkg("uninstall incorp@2.0")
-                self.pkg("install incorp@1.0")
-
-                # upgrade pkg that loses incorp. deps. in new version
-                self.pkg("install -vvv incorp@2.0")
-
-                # perform explicit update of incorp; should not update bronze
-                self.pkg("update --parsable=0 -n incorp@3")
-                self.assertEqualParsable(self.output, change_packages=[
-                    [plist[1], plist[2]] # incorp 2.0 -> 3.0
-                ])
-                self.pkg("update --parsable=0 -n incorp")
-                self.assertEqualParsable(self.output, change_packages=[
-                    [plist[1], plist[2]] # incorp 2.0 -> 3.0
-                ])
-
-                # perform a general update; should upgrade incorp and bronze
-                self.pkg("update --parsable=0 -n")
-                self.assertEqualParsable(self.output, change_packages=[
-                    [plist[8], plist[9]],  # bronze 2.0 -> 3.0
-                    [plist[1], plist[2]] # incorp 2.0 -> 3.0
-                ])
-
-        def test_upgrade3(self):
-                """Test for editable files moving between packages or locations
-                or both."""
-
-                install_cmd = "install"
-                self.pkgsend_bulk(self.rurl, (self.silver10, self.silver20,
-                    self.silver30, self.gold10, self.gold20, self.gold30,
-                    self.golduser10, self.golduser20, self.silveruser))
-
-                self.image_create(self.rurl)
-
-                # test 1: move an editable file between packages
-                self.pkg("{0} --parsable=0 gold@1.0 silver@1.0".format(install_cmd))
-                self._assertEditables(
-                    installed=[
-                        'etc/ftpd/ftpusers',
-                        'etc/group',
-                        'etc/passwd',
-                        'etc/shadow',
-                    ]
-                )
-                self.pkg("verify -v")
-
-                # modify config file
-                test_str = "this file has been modified 1"
-                file_path = "etc/passwd"
-                self.file_append(file_path, test_str)
-
-                # make sure /etc/passwd contains correct string
-                self.file_contains(file_path, test_str)
-
-                # update packages
-                self.pkg("{0} -nvv gold@3.0 silver@2.0".format(install_cmd))
-                self.pkg("{0} --parsable=0 gold@3.0 silver@2.0".format(install_cmd))
-                self._assertEditables()
-                self.pkg("verify -v")
-
-                # make sure /etc/passwd contains still correct string
-                self.file_contains(file_path, test_str)
-
-                self.pkg("uninstall --parsable=0 silver gold")
-                self._assertEditables(
-                    removed=[
-                        'etc/ftpd/ftpusers',
-                        'etc/group',
-                        'etc/passwd',
-                        'etc/shadow',
-                    ],
-                )
-
-
-                # test 2: change an editable file's path within a package
-                self.pkg("{0} --parsable=0 gold@1.0".format(install_cmd))
-                self.pkg("verify -v")
-
-                # modify config file
-                test_str = "this file has been modified test 2"
-                file_path = "etc/passwd"
-                self.file_append(file_path, test_str)
-
-                self.pkg("{0} --parsable=0 gold@2.0".format(install_cmd))
-                self._assertEditables(
-                    moved=[['etc/passwd', 'etc/config2']],
-                    removed=[
-                        'etc/ftpd/ftpusers',
-                        'etc/group',
-                        'etc/shadow',
-                    ],
-                )
-                self.pkg("verify -v")
-
-                # make sure /etc/config2 contains correct string
-                file_path = "etc/config2"
-                self.file_contains(file_path, test_str)
-
-                self.pkg("uninstall --parsable=0 gold")
-                self._assertEditables(
-                    removed=['etc/config2'],
-                )
-                self.pkg("verify -v")
-
-
-                # test 3: move an editable file between packages and change its path
-                self.pkg("{0} --parsable=0 gold@1.0 silver@1.0".format(install_cmd))
-                self.pkg("verify -v")
-
-                # modify config file
-                file_path = "etc/passwd"
-                test_str = "this file has been modified test 3"
-                self.file_append(file_path, test_str)
-
-                self.file_contains(file_path, test_str)
-
-                self.pkg("{0} --parsable=0 gold@3.0 silver@3.0".format(install_cmd))
-                self._assertEditables(
-                    moved=[['etc/passwd', 'etc/config2']],
-                    removed=[
-                        'etc/ftpd/ftpusers',
-                        'etc/group',
-                        'etc/shadow',
-                    ],
-                )
-                self.pkg("verify -v")
-
-                # make sure /etc/config2 now contains correct string
-                file_path = "etc/config2"
-                self.file_contains(file_path, test_str)
-
-                self.pkg("uninstall --parsable=0 gold silver")
-
-
-                # test 4: move /etc/passwd between packages and ensure that we
-                # can still uninstall a user at the same time.
-                self.pkg("{0} --parsable=0 gold@1.0 silver@1.0".format(install_cmd))
-                self.pkg("verify -v")
-
-                # add a user
-                self.pkg("install golduser@1.0")
-
-                # make local changes to the user
-                pwdpath = os.path.join(self.get_img_path(), "etc/passwd")
-
-                pwdfile = open(pwdpath, "r+")
-                lines = pwdfile.readlines()
-                for i, l in enumerate(lines):
-                        if l.startswith("Kermit"):
-                                lines[i] = lines[i].replace("& User",
-                                    "Kermit loves Miss Piggy")
-                pwdfile.seek(0)
-                pwdfile.writelines(lines)
-                pwdfile.close()
-
-                silly_path = os.path.join(self.get_img_path(), "etc/silly")
-                silly_inode = os.stat(silly_path).st_ino
-
-                # update packages
-                self.pkg("{0} --parsable=0 gold@3.0 silver@2.0 golduser@2.0 "
-                    "silveruser".format(install_cmd))
-                self._assertEditables()
-
-                # make sure Kermie is still installed and still has our local
-                # changes
-                self.file_contains("etc/passwd",
-                    "Kermit:x:5:4:Kermit loves Miss Piggy:/export/home/Kermit:")
-
-                # also make sure that /etc/silly hasn't been removed and added
-                # again, even though it wasn't marked specially
-                self.assertEqual(os.stat(silly_path).st_ino, silly_inode)
-
-        def test_upgrade4(self):
-                """Test to make sure hardlinks are correctly restored when file
-                they point to is updated."""
-
-                self.pkgsend_bulk(self.rurl, (self.iron10, self.iron20))
-                self.image_create(self.rurl)
-
-                self.pkg("install iron@1.0")
-                self.pkg("verify -v")
-
-                self.pkg("install iron@2.0")
-                self.pkg("verify -v")
-
-        def test_upgrade5(self):
-                """Test manually removed directory and files will be restored
-                 during update, if mode are different."""
-
-                self.pkgsend_bulk(self.rurl, (self.dumdir10, self.dumdir20,
-                    self.dumdir30))
-                self.image_create(self.rurl)
-
-                self.pkg("install -vvv dumdir@1.0")
-                self.pkg("verify -v")
-                dirpath = os.path.join(self.test_root, "image0", "etc")
-                shutil.rmtree(dirpath)
-
-                self.pkg("update -vvv dumdir@2.0")
-                self.pkg("verify -v")
-                shutil.rmtree(dirpath)
-
-                self.pkg("update -vvv dumdir@3.0")
-                self.pkg("verify -v")
-
-        def test_newbe_liveroot(self):
-                """Test to verify the command output, when modifying a live
-                image has the correct initial information for the user."""
-
-                self.pkgsend_bulk(self.rurl, (self.release_name))
-                self.image_create(self.rurl)
-
-                # Verify the name of the boot environment is printed
-                # on install. The installation will fail because creating
-                # a BE name is not permitted on a non-live root and
-                # simulate_live_root does not override that.
-                self.pkg("--debug simulate_live_root={0} install "
-                    " --be-name=livetest release/name@1.0".format(
-                    self.get_img_path()), exit=1)
-                self.assertTrue("environment: livetest" in self.output)
-
-                # Install the package (no new BE)
-                self.pkg("--debug simulate_live_root={0} install "
-                    "release/name@1.0".format(
-                    self.get_img_path()))
-
-                # Ensure that the uninstall case prints a create
-                # boot environment message. The command will fail due
-                # to test framework limitations.
-                self.pkg("--debug simulate_live_root={0} uninstall "
-                    "release/name@1.0".format(self.get_img_path()), exit=1)
-                self.assertTrue("Create boot environment: Yes" in self.output)
-                # Ensure the failure is for the correct reason.
-                self.assertTrue(
-                    "pkg: Unable to clone the current boot environment" in
-                    self.errout)
-
-        def test_upgrade_liveroot(self):
-                """Test to make sure upgrade of package fails if on live root
-                and reboot is needed."""
-
-                self.upgrade_liveroot_helper("install")
-                self.upgrade_liveroot_helper("exact-install")
-
-        def upgrade_liveroot_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.liveroot10, self.liveroot20))
-                self.image_create(self.rurl)
-
-                self.pkg("--debug simulate_live_root={0} {1} liveroot@1.0".format(
-                    self.get_img_path(), install_cmd))
-                self.pkg("verify -v")
-                self.pkg("--debug simulate_live_root={0} {1} --deny-new-be "
-                    "liveroot@2.0".format(self.get_img_path(),  install_cmd),
-                    exit=5)
-                self.pkg("--debug simulate_live_root={0} uninstall "
-                    "--deny-new-be liveroot".format(self.get_img_path()), exit=5)
-                # "break" liveroot@1
-                self.file_append("etc/liveroot", "this file has been changed")
-                self.pkg("--debug simulate_live_root={0} fix --deny-new-be "
-                    "liveroot".format(self.get_img_path()), exit=5)
-
-        def test_upgrade_driver_conflicts(self):
-                """Test to make sure driver_aliases conflicts don't cause
-                add_drv to fail."""
-
-                self.upgrade_driver_conflicts_helper("install")
-                self.upgrade_driver_conflicts_helper("exact-install")
-
-        def upgrade_driver_conflicts_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.dricon1, self.dricon2,
-                    self.dricon3))
-
-                self.image_create(self.rurl)
-
-                self.pkg("list -afv")
-                self.pkg("{0} dricon@1".format(install_cmd))
-                # This one should comment out the wigit entry in driver_aliases
-                self.pkg("{0} dricon@2".format(install_cmd))
-                with open(os.path.join(self.get_img_path(),
-                    "etc/driver_aliases")) as f:
-                        da_contents = f.readlines()
-                self.assertTrue("# pkg(7): wigit \"pci8086,1234\"\n" in da_contents)
-                self.assertTrue("wigit \"pci8086,1234\"\n" not in da_contents)
-                self.assertTrue("wigit \"pci8086,4321\"\n" in da_contents)
-                self.assertTrue("zigit \"pci8086,1234\"\n" in da_contents)
-                # This one should fail
-                self.pkg("{0} dricon@3".format(install_cmd), exit=1)
-
-        def test_driver_policy_removal(self):
-                """Test for bug #9568 - that removing a policy for a
-                driver where there is no minor node associated with it,
-                works successfully.
-                """
-
-                self.driver_policy_removal_helper("install")
-                self.driver_policy_removal_helper("exact-install")
-
-        def driver_policy_removal_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.dripol1, self.dripol2))
-
-                self.image_create(self.rurl)
-
-                self.pkg("list -afv")
-
-                # Should install the frigit driver with a policy.
-                self.pkg("{0} dripol@1".format(install_cmd))
-
-                # Check that there is a policy entry for this
-                # device in /etc/security/device_policy
-                with open(os.path.join(self.get_img_path(),
-                    "etc/security/device_policy")) as f:
-                        dp_contents = f.readlines()
-                self.assertTrue("frigit:*\tread_priv_set=net_rawaccess\t"
-                    "write_priv_set=net_rawaccess\n"
-                    in dp_contents)
-
-                # Should reinstall the frigit driver without a policy.
-                self.pkg("{0} dripol@2".format(install_cmd))
-
-                # Check that there is no longer a policy entry for this
-                # device in /etc/security/device_policy
-                with open(os.path.join(self.get_img_path(),
-                    "etc/security/device_policy")) as f:
-                        dp_contents = f.readlines()
-                self.assertTrue("frigit:*\tread_priv_set=net_rawaccess\t"
-                    "write_priv_set=net_rawaccess\n"
-                    not in dp_contents)
-
-                #self.pkg("update dripol@3")
-                #with open(os.path.join(self.get_img_path(),
-                #    "etc/security/device_policy")) as f:
-                #        dp_contents = f.readlines()
-                #self.assertTrue("frigit:*\ttpd_member=true\n"
-                #    in dp_contents)
-
-                #self.pkg("update dripol@5")
-                #with open(os.path.join(self.get_img_path(),
-                #    "etc/security/device_policy")) as f:
-                #        dp_contents = f.readlines()
-                #self.assertTrue("frigit:node1\tread_priv_set=all"
-                #    "\twrite_priv_set=all\ttpd_member=true\n"
-                #    in dp_contents)
-
-                #self.pkg("update dripol@4")
-                #with open(os.path.join(self.get_img_path(),
-                #    "etc/security/device_policy")) as f:
-                #        dp_contents = f.readlines()
-                #self.assertTrue("frigit:node1" not in dp_contents)
-
-        def test_file_preserve(self):
-                """Verify that file preserve=true works as expected during
-                package install, update, upgrade, and removal."""
-
-                install_cmd = "install"
-                self.pkgsend_bulk(self.rurl, (self.preserve1, self.preserve2,
-                    self.preserve3, self.renpreserve))
-                self.image_create(self.rurl)
-
-                # If there are no local modifications, no preservation should be
-                # done.  First with no content change ...
-                self.pkg("{0} --parsable=0 preserve@1".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.pkg("{0} --parsable=0 preserve@2".format(install_cmd))
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", "preserve1")
-                self.pkg("verify preserve")
-
-                self.pkg("update --parsable=0 preserve@1")
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", "preserve1")
-                self.pkg("verify preserve")
-
-                self.pkg("uninstall --parsable=0 preserve")
-
-                # ... and again with content change.
-                self.pkg("install --parsable=0 preserve@1")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.pkg("install --parsable=0 preserve@3")
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", "preserve3")
-
-                self.pkg("update --parsable=0 preserve@1")
-                self._assertEditables()
-
-                # ... on downgrade leave the existing configuration intact.
-                self.file_contains("testme", "preserve3")
-
-                self.pkg("verify preserve")
-                self.pkg("uninstall --parsable=0 preserve")
-
-                # Modify the file locally and update to a version where the
-                # content changes.
-                self.pkg("{0} --parsable=0 preserve@1".format(install_cmd))
-                self.file_append("testme", "junk")
-                self.file_contains("testme", "preserve1")
-                self.pkg("{0} --parsable=0 preserve@3".format(install_cmd))
-                self._assertEditables()
-                self.file_contains("testme", ["preserve1", "junk"])
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.pkg("verify preserve")
-                self.pkg("uninstall --parsable=0 preserve")
-
-                # Modify the file locally and verify that on downgrade the
-                # content remains unchanged.
-                self.pkg("{0} --parsable=0 preserve@3".format(install_cmd))
-                self.file_append("testme", "junk")
-                self.file_contains("testme", "preserve3")
-                self.pkg("update --parsable=0 preserve@1")
-                self._assertEditables()
-                self.file_contains("testme", ["preserve3", "junk"])
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.update")
-                self.pkg("verify preserve")
-                self.pkg("uninstall --parsable=0 preserve")
-
-                # Modify the file locally and update to a version where just the
-                # mode changes.
-                self.pkg("{0} --parsable=0 preserve@1".format(install_cmd))
-                self.file_append("testme", "junk")
-
-                self.pkg("{0} --parsable=0 preserve@2".format(install_cmd))
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", ["preserve1", "junk"])
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-
-                self.pkg("update --parsable=0 preserve@1")
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", ["preserve1", "junk"])
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.update")
-
-                self.pkg("{0} --parsable=0 preserve@2".format(install_cmd))
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-
-                # Remove the file locally and update the package; this should
-                # simply replace the missing file.
-                self.file_remove("testme")
-                self.pkg("{0} --parsable=0 preserve@3".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.pkg("verify preserve")
-                self.file_exists("testme")
-
-                # Remove the file locally and downgrade the package; this should
-                # simply replace the missing file.
-                self.file_remove("testme")
-                self.pkg("update --parsable=0 preserve@2")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.pkg("verify preserve")
-                self.file_exists("testme")
-                self.pkg("uninstall preserve@2")
-
-                # Verify preserved files will have their mode changed on update.
-                self.pkg("{0} --parsable=0 preserve@1".format(install_cmd))
-                self.pkg("{0} --parsable=0 preserve@2".format(install_cmd))
-                self.pkg("verify preserve")
-
-                # Verify that a package with a missing file that is marked with
-                # the preserve=true won't cause uninstall failure.
-                self.file_remove("testme")
-                self.file_doesnt_exist("testme")
-                self.pkg("uninstall --parsable=0 preserve")
-
-                # Verify preserve works across package rename with and without
-                # original_name use and even when the original file is missing.
-                self.pkg("{0} --parsable=0 orig_pkg@1.0".format(install_cmd))
-                foo1_path = os.path.join(self.get_img_path(), "foo1")
-                self.assertTrue(os.path.isfile(foo1_path))
-                bronze1_path = os.path.join(self.get_img_path(), "bronze1")
-                self.assertTrue(os.path.isfile(bronze1_path))
-
-                # Update across the rename boundary, then verify that the files
-                # were installed with their new name and the old ones were
-                # removed.
-                self.pkg("update -nvv orig_pkg")
-                self.pkg("update --parsable=0 orig_pkg")
-                self._assertEditables(
-                    moved=[['foo1', 'foo2']],
-                )
-
-                foo2_path = os.path.join(self.get_img_path(), "foo2")
-                self.assertTrue(not os.path.exists(foo1_path))
-                self.assertTrue(os.path.isfile(foo2_path))
-                self.assertTrue(os.path.isfile(bronze1_path))
-                self.pkg("uninstall --parsable=0 \\*")
-
-                # Update across the rename boundary, then truncate each of the
-                # preserved files.  They should remain empty even though one is
-                # changing names and the other is simply being preserved across
-                # a package rename.
-                self.pkg("{0} --parsable=0 orig_pkg@1.0".format(install_cmd))
-                open(foo1_path, "wb").close()
-                open(bronze1_path, "wb").close()
-                self.pkg("update --parsable=0 orig_pkg")
-                self._assertEditables(
-                    moved=[['foo1', 'foo2']],
-                )
-                self.assertTrue(not os.path.exists(foo1_path))
-                self.assertTrue(os.path.isfile(foo2_path))
-                self.assertEqual(os.stat(foo2_path).st_size, 0)
-                self.assertTrue(os.path.isfile(bronze1_path))
-                self.assertEqual(os.stat(bronze1_path).st_size, 0)
-                self.pkg("uninstall --parsable=0 \\*")
-                self._assertEditables(
-                    removed=['bronze1', 'foo2'],
-                )
-
-                # Update across the rename boundary, then verify that a change
-                # in file name will cause re-delivery of preserved files, but
-                # unchanged, preserved files will not be re-delivered.
-                self.pkg("{0} --parsable=0 orig_pkg@1.0".format(install_cmd))
-                os.unlink(foo1_path)
-                os.unlink(bronze1_path)
-                self.pkg("update --parsable=0 orig_pkg")
-                self._assertEditables(
-                    moved=[['foo1', 'foo2']],
-                )
-                self.assertTrue(not os.path.exists(foo1_path))
-                self.assertTrue(os.path.isfile(foo2_path))
-                self.assertTrue(not os.path.exists(bronze1_path))
-                self.pkg("uninstall --parsable=0 \\*")
-
-                # Ensure directory is empty before testing.
-                api_inst = self.get_img_api_obj()
-                img_inst = api_inst.img
-                sroot = os.path.join(img_inst.imgdir, "lost+found")
-                shutil.rmtree(sroot)
-
-                # Verify that unmodified, preserved files will not be salvaged
-                # on uninstall.
-                self.pkg("{0} --parsable=0 preserve@1.0".format(install_cmd))
-                self.file_contains("testme", "preserve1")
-                self.pkg("uninstall --parsable=0 preserve")
-                salvaged = [
-                    n for n in os.listdir(sroot)
-                    if n.startswith("testme-")
+        mani2.store(mpath2)
+        repo.rebuild()
+
+        self.pkg("install -v elfhash@1.0")
+        self.pkg("contents -m elfhash | grep gelf:sha512t_256")
+        self.pkg("update -vvv elfhash")
+        self.pkg("contents -m elfhash | grep gelf:sha512t_256")
+        self.pkg("contents -m elfhash | grep gelf:sha3_384")
+        self.pkg("uninstall elfhash")
+
+        # Upgrade case: action that uses gelf and file extraction method
+        # upgrade to action that only uses file extraction method.
+        for a in mani2.gen_actions():
+            if "bin/true" in str(a):
+                a.attrs["pkg.content-hash"] = [
+                    "file:sha512t_256:2374db2dfb4968baad246ab37afc560cc9d278b6104a889a2727d9bcf6a20b17"
                 ]
-                self.assertEqual(salvaged, [])
-
-                # Verify that modified, preserved files will be salvaged
-                # on uninstall.
-                self.pkg("{0} --parsable=0 preserve@1.0".format(install_cmd))
-                self.file_contains("testme", "preserve1")
-                self.file_append("testme", "junk")
-                self.pkg("uninstall --parsable=0 preserve")
-                self.__salvage_file_contains(sroot, "testme", "junk")
-
-        def test_file_preserve_renameold(self):
-                """Make sure that file upgrade with preserve=renameold works."""
-
-                install_cmd = "install"
-                plist = self.pkgsend_bulk(self.rurl, (self.renameold1,
-                    self.renameold2, self.renameold3))
-                self.image_create(self.rurl)
-
-                # If there are no local modifications, no preservation should be
-                # done.  First with no content change ...
-                self.pkg("{0} renold@1".format(install_cmd))
-                self.pkg("{0} renold@2".format(install_cmd))
-                self.file_contains("testme", "renold1")
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.pkg("verify renold")
-                self.pkg("uninstall renold")
-
-                # ... and again with content change.
-                self.pkg("{0} renold@1".format(install_cmd))
-                self.pkg("{0} renold@3".format(install_cmd))
-                self.file_contains("testme", "renold3")
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.pkg("verify renold")
-                self.pkg("uninstall renold")
-
-                # Modify the file locally and update to a version where the
-                # content changes.
-                self.pkg("{0} renold@1".format(install_cmd))
-                self.file_append("testme", "junk")
-                self.pkg("{0} --parsable=0 renold@3".format(install_cmd))
-                self._assertEditables(
-                    moved=[['testme', 'testme.old']],
-                    installed=['testme'],
-                )
-                self.file_contains("testme.old", "junk")
-                self.file_doesnt_contain("testme", "junk")
-                self.file_contains("testme", "renold3")
-                self.dest_file_valid(plist, "renold@3.0", "testme", "testme")
-                self.file_doesnt_exist("testme.new")
-                self.pkg("verify renold")
-                self.pkg("uninstall renold")
-
-                # Modify the file locally and update to a version where just the
-                # mode changes.
-                self.pkg("{0} renold@1".format(install_cmd))
-                self.file_append("testme", "junk")
-                self.pkg("{0} --parsable=0 renold@2".format(install_cmd))
-                self._assertEditables(
-                    moved=[['testme', 'testme.old']],
-                    installed=['testme'],
-                )
-                self.file_contains("testme.old", "junk")
-                self.file_doesnt_contain("testme", "junk")
-                self.file_contains("testme", "renold1")
-                self.file_doesnt_exist("testme.new")
-                self.pkg("verify renold")
-                self.pkg("uninstall renold")
-
-                # Remove the file locally and update the package; this should
-                # simply replace the missing file.
-                self.pkg("{0} renold@1".format(install_cmd))
-                self.file_remove("testme")
-                self.pkg("{0} --parsable=0 renold@2".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.pkg("verify renold")
-                self.pkg("uninstall renold")
-
-        def test_file_preserve_renamenew(self):
-                """Make sure that file ugprade with preserve=renamenew works."""
-
-                install_cmd = "install"
-                plist = self.pkgsend_bulk(self.rurl, (self.renamenew1,
-                    self.renamenew2, self.renamenew3))
-                self.image_create(self.rurl)
-
-                # If there are no local modifications, no preservation should be
-                # done.  First with no content change ...
-                self.pkg("{0} rennew@1".format(install_cmd))
-                self.pkg("{0} --parsable=0 rennew@2".format(install_cmd))
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", "rennew1")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.old")
-                self.pkg("verify rennew")
-                self.pkg("uninstall rennew")
-
-                # ... and again with content change
-                self.pkg("{0} rennew@1".format(install_cmd))
-                self.pkg("{0} --parsable=0 rennew@3".format(install_cmd))
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", "rennew3")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.old")
-                self.pkg("verify rennew")
-                self.pkg("uninstall rennew")
-
-                # Modify the file locally and update to a version where the
-                # content changes.
-                self.pkg("{0} rennew@1".format(install_cmd))
-                self.file_append("testme", "junk")
-                self.pkg("{0} --parsable=0 rennew@3".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme.new'],
-                )
-                self.file_contains("testme", "junk")
-                self.file_doesnt_contain("testme.new", "junk")
-                self.file_contains("testme.new", "rennew3")
-                self.dest_file_valid(plist, "rennew@3.0", "testme",
-                    "testme.new")
-                self.file_doesnt_exist("testme.old")
-                self.pkg("verify rennew")
-                self.pkg("uninstall rennew")
-
-                # Modify the file locally and update to a version where just the
-                # mode changes.
-                self.pkg("{0} rennew@1".format(install_cmd))
-                self.file_append("testme", "junk")
-                self.pkg("{0} --parsable=0 rennew@2".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme.new'],
-                )
-                self.file_contains("testme", "junk")
-                self.file_doesnt_contain("testme.new", "junk")
-                self.file_contains("testme.new", "rennew1")
-                self.file_doesnt_exist("testme.old")
-
-                # The original file won't be touched on update, so verify fails.
-                self.pkg("verify rennew", exit=1)
-
-                # Ensure that after fixing mode, verify passes.
-                self.file_chmod("testme", 0o640)
-                self.pkg("verify rennew")
-                self.pkg("uninstall rennew")
-                self.file_remove("testme.new")
-
-                # Remove the file locally and update the package; this should
-                # simply replace the missing file.
-                self.pkg("{0} rennew@1".format(install_cmd))
-                self.file_remove("testme")
-                self.pkg("{0} --parsable=0 rennew@2".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.old")
-                self.pkg("verify rennew")
-                self.pkg("uninstall rennew")
-
-        def test_file_preserve_legacy(self):
-                """Verify that preserve=legacy works as expected."""
-
-                install_cmd = "install"
-                self.pkgsend_bulk(self.rurl, (self.preslegacy,
-                    self.renpreslegacy))
-                self.image_create(self.rurl)
-
-                # Ensure directory is empty before testing.
-                api_inst = self.get_img_api_obj()
-                img_inst = api_inst.img
-                sroot = os.path.join(img_inst.imgdir, "lost+found")
-                shutil.rmtree(sroot)
-
-                # Verify that unpackaged files will be salvaged on initial
-                # install if a package being installed delivers the same file
-                # and that the new file will be installed.
-                self.file_append("testme", "unpackaged")
-                self.pkg("{0} --parsable=0 preslegacy@1.0".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_contains("testme", "preserve1")
-                self.__salvage_file_contains(sroot, "testme", "unpackaged")
-                shutil.rmtree(sroot)
-
-                # Verify that a package transitioning to preserve=legacy from
-                # some other state will have the existing file renamed using
-                # .legacy as an extension.
-                self.pkg("update --parsable=0 preslegacy@2.0")
-                self._assertEditables(
-                    moved=[['testme', 'testme.legacy']],
-                    installed=['testme'],
-                )
-                self.file_contains("testme.legacy", "preserve1")
-                self.file_contains("testme", "preserve2")
-
-                # Verify that if an action with preserve=legacy is upgraded
-                # and its payload changes that the new payload is delivered
-                # but the old .legacy file is not modified.
-                self.pkg("update --parsable=0 preslegacy@3.0")
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme.legacy", "preserve1")
-                self.file_contains("testme", "preserve3")
-
-                # Verify that if the file for an action marked with
-                # preserve=legacy is removed that the package still
-                # verifies.
-                self.file_remove("testme")
-                self.pkg("verify -v preslegacy")
-
-                # Verify that a file removed for an action marked with
-                # preserve=legacy can be reverted.
-                self.pkg("revert testme")
-                self.file_contains("testme", "preserve3")
-
-                # Verify that an initial install of an action with
-                # preserve=legacy will not install the payload of the action.
-                self.pkg("uninstall preslegacy")
-                self.pkg("{0} --parsable=0 preslegacy@3.0".format(install_cmd))
-                self._assertEditables()
-                self.file_doesnt_exist("testme")
-
-                # Verify that if the original preserved file is missing during
-                # a transition to preserve=legacy from some other state that
-                # the new action is still delivered and the operation succeeds.
-                self.pkg("uninstall preslegacy")
-                self.pkg("{0} --parsable=0 preslegacy@1.0".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_remove("testme")
-                self.pkg("update --parsable=0")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_contains("testme", "preserve3")
-
-                # Verify that a preserved file can be moved from one package to
-                # another and transition to preserve=legacy at the same time.
-                self.pkg("uninstall preslegacy")
-                self.pkg("{0} --parsable=0 orig_preslegacy@1.0".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_exists("testme")
-                self.pkg("update --parsable=0")
-                self._assertEditables(
-                    moved=[['testme', 'newme.legacy']],
-                    installed=['newme'],
-                )
-                self.file_contains("testme.legacy", "preserve1")
-                self.file_contains("newme", "preserve2")
-
-        def test_file_preserve_abandon(self):
-                """Verify that preserve=abandon works as expected."""
-
-                install_cmd = "install"
-                self.pkgsend_bulk(self.rurl, self.presabandon)
-                self.image_create(self.rurl)
-
-                # Ensure directory is empty before testing.
-                api_inst = self.get_img_api_obj()
-                img_inst = api_inst.img
-                sroot = os.path.join(img_inst.imgdir, "lost+found")
-                shutil.rmtree(sroot)
-
-                # Verify that unpackaged files will not be salvaged on initial
-                # install if a package being installed delivers the same file
-                # and that the new file will not be installed.
-                self.file_append("testme", "unpackaged")
-                self.pkg("{0} --parsable=0 presabandon@2".format(install_cmd))
-                self._assertEditables()
-                self.file_contains("testme", "unpackaged")
-                self.assertTrue(not os.path.exists(os.path.join(sroot, "testme")))
-                self.file_remove("testme")
-                self.pkg("uninstall presabandon")
-
-                # Verify that an initial install of an action with
-                # preserve=abandon will not install the payload of the action.
-                self.pkg("{0} --parsable=0 presabandon@2".format(install_cmd))
-                self._assertEditables()
-                self.file_doesnt_exist("testme")
-                self.pkg("uninstall presabandon")
-
-                # If an action delivered by the upgraded version of the package
-                # has a preserve=abandon, the new file will not be installed and
-                # the existing file will not be modified.
-
-                # First with no content change ...
-                self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.pkg("update --parsable=0 presabandon@2")
-                self._assertEditables()
-                self.file_contains("testme", "preserve1")
-                # The currently installed version of the package has a preserve
-                # value of abandon, so the file will not be removed.
-                self.pkg("uninstall --parsable=0 presabandon")
-                self._assertEditables()
-                self.file_exists("testme")
-
-                # If an action delivered by the downgraded version of the package
-                # has a preserve=abandon, the new file will not be installed and
-                # the existing file will not be modified.
-                self.pkg("{0} --parsable=0 presabandon@4".format(install_cmd))
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_contains("testme", "preserve3")
-                self.pkg("verify presabandon")
-                self.pkg("update --parsable=0 presabandon@3")
-                self._assertEditables()
-                self.file_contains("testme", "preserve3")
-                self.pkg("verify presabandon")
-                self.pkg("uninstall --parsable=0 presabandon")
-                self.file_remove("testme")
-
-                # ... and again with content change.
-                self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
-                self.pkg("{0} --parsable=0 presabandon@3".format(install_cmd))
-                self._assertEditables()
-                self.file_contains("testme", "preserve1")
-                self.pkg("uninstall --parsable=0 presabandon")
-
-                self.pkg("install --parsable=0 presabandon@4")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_contains("testme", "preserve3")
-                self.pkg("update --parsable=0 presabandon@2")
-                self._assertEditables()
-                self.file_contains("testme", "preserve3")
-                self.pkg("verify presabandon")
-                self.pkg("uninstall --parsable=0 presabandon")
-                self.file_remove("testme")
-
-                # Modify the file locally and upgrade to a version where the
-                # file has a preserve=abandon attribute and the content changes.
-                self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
-                self.file_append("testme", "junk")
-                self.pkg("{0} --parsable=0 presabandon@3".format(install_cmd))
-                self._assertEditables()
-                self.file_contains("testme", "preserve1")
-                self.file_contains("testme", "junk")
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.pkg("uninstall --parsable=0 presabandon")
-                self.file_remove("testme")
-
-                # Modify the file locally and downgrade to a version where the
-                # file has a preserve=abandon attribute and the content changes.
-                self.pkg("{0} --parsable=0 presabandon@4".format(install_cmd))
-                self.file_append("testme", "junk")
-                self.file_contains("testme", "preserve3")
-                self.pkg("update --parsable=0 presabandon@2")
-                self._assertEditables()
-                self.file_contains("testme", "preserve3")
-                self.file_contains("testme", "junk")
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.update")
-                self.pkg("verify presabandon")
-                self.pkg("uninstall --parsable=0 presabandon")
-                self.file_remove("testme")
-
-                # Modify the file locally and upgrade to a version where the
-                # file has a preserve=abandon attribute and just the mode changes.
-                self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
-                self.file_append("testme", "junk")
-                self.pkg("{0} --parsable=0 presabandon@2".format(install_cmd))
-                self._assertEditables()
-                self.file_contains("testme", "preserve1")
-                self.file_contains("testme", "junk")
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.pkg("verify presabandon")
-                self.pkg("uninstall --parsable=0 presabandon")
-                self.file_remove("testme")
-
-                # Modify the file locally and downgrade to a version where the
-                # file has a preserve=abandon attribute and just the mode changes.
-                self.pkg("{0} --parsable=0 presabandon@4".format(install_cmd))
-                self.file_append("testme", "junk")
-                self.pkg("update --parsable=0 presabandon@3")
-                self._assertEditables()
-                self.file_contains("testme", "preserve3")
-                self.file_contains("testme", "junk")
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.update")
-                self.pkg("verify presabandon")
-                self.pkg("uninstall --parsable=0 presabandon")
-                self.file_remove("testme")
-
-                # Remove the file locally and update the package where the
-                # file has a preserve=abandon attribute; this will not replace
-                # the missing file.
-                self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
-                self.file_remove("testme")
-                self.pkg("{0} --parsable=0 presabandon@2".format(install_cmd))
-                self._assertEditables()
-                self.file_doesnt_exist("testme")
-                self.pkg("uninstall --parsable=0 presabandon")
-
-                # Remove the file locally and downgrade the package where the
-                # file has a preserve=abandon attribute; this will not replace
-                # the missing file.
-                self.pkg("{0} --parsable=0 presabandon@4".format(install_cmd))
-                self.file_remove("testme")
-                self.pkg("update --parsable=0 presabandon@3")
-                self._assertEditables()
-
-                # Verify that a package with a missing file that is marked with
-                # the preserve=abandon won't cause uninstall failure.
-                self.file_doesnt_exist("testme")
-                self.pkg("uninstall --parsable=0 presabandon")
-
-                # Verify that if the file for an action marked with
-                # preserve=abandon is removed that the package still
-                # verifies.
-                self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
-                self.pkg("{0} --parsable=0 presabandon@2".format(install_cmd))
-                self.file_remove("testme")
-                self.pkg("verify -v presabandon")
-
-                # Verify that a file removed for an action marked with
-                # preserve=abandon can be reverted.
-                #self.pkg("revert testme")
-                #self.file_contains("testme", "preserve1")
-
-        def test_file_preserve_install_only(self):
-                """Verify that preserve=install-only works as expected."""
-
-                self.pkgsend_bulk(self.rurl, self.presinstallonly)
-                self.image_create(self.rurl)
-
-                # Ensure directory is empty before testing.
-                api_inst = self.get_img_api_obj()
-                img_inst = api_inst.img
-                sroot = os.path.join(img_inst.imgdir, "lost+found")
-                shutil.rmtree(sroot)
-
-                # Verify that unpackaged files will not be modified or salvaged
-                # on initial install if a package being installed delivers the
-                # same file and that the new file will not be installed.
-                self.file_append("testme", "unpackaged")
-                self.pkg("install --parsable=0 presinstallonly@2")
-                self._assertEditables()
-                self.file_contains("testme", "unpackaged")
-                self.assertTrue(not os.path.exists(os.path.join(sroot, "testme")))
-                # Verify uninstall of the package will not remove the file.
-                self.pkg("uninstall presinstallonly")
-                self.file_exists("testme")
-                self.file_remove("testme")
-
-                # Verify that an initial install of an action with
-                # preserve=install-only will install the payload of the action
-                # if the file does not already exist.
-                self.file_doesnt_exist("testme")
-                self.pkg("install --parsable=0 presinstallonly@2")
-                self._assertEditables(
-                    installed=['testme']
-                )
-                self.file_exists("testme")
-                self.pkg("uninstall presinstallonly")
-                self.file_remove("testme")
-
-                # Verify that an upgrade that initially delivers the action will
-                # install it.
-                self.pkg("install --parsable=0 presinstallonly@0")
-                self._assertEditables()
-                self.file_doesnt_exist("testme")
-                self.pkg("install --parsable=0 presinstallonly@2")
-                self._assertEditables(
-                    installed=['testme']
-                )
-                self.file_exists("testme")
-                self.pkg("uninstall presinstallonly")
-                self.file_remove("testme")
-
-                # If an action delivered by the upgraded version of the package
-                # has a preserve=install-only, the new file will not be
-                # installed and the existing file will not have its content
-                # modified (the mode is being updated though).
-
-                # First with no content change ...
-                self.pkg("install --parsable=0 presinstallonly@1")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.pkg("update --parsable=0 presinstallonly@2")
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", "preserve1")
-                # The currently installed version of the package has a preserve
-                # value of install-only, so the file will not be removed.
-                self.pkg("uninstall --parsable=0 presinstallonly")
-                self._assertEditables()
-                self.file_exists("testme")
-                self.file_remove("testme")
-
-                # If an action delivered by the downgraded version of the
-                # package has a preserve=install-only, the new file will not be
-                # installed and the existing file will not be modified.
-                self.pkg("install --parsable=0 presinstallonly@4")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_contains("testme", "preserve3")
-                self.pkg("verify presinstallonly")
-                self.pkg("update --parsable=0 presinstallonly@3")
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", "preserve3")
-                self.pkg("verify presinstallonly")
-                self.pkg("uninstall --parsable=0 presinstallonly")
-                self.file_remove("testme")
-
-                # ... and again with content change.
-                self.pkg("install --parsable=0 presinstallonly@1")
-                self.pkg("install --parsable=0 presinstallonly@3")
-                self._assertEditables()
-                self.file_contains("testme", "preserve1")
-                self.pkg("uninstall --parsable=0 presinstallonly")
-                self.file_remove("testme")
-
-                self.pkg("install --parsable=0 presinstallonly@4")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_contains("testme", "preserve3")
-                self.pkg("update --parsable=0 presinstallonly@2")
-                self._assertEditables()
-                self.file_contains("testme", "preserve3")
-                self.pkg("verify presinstallonly")
-                self.pkg("uninstall --parsable=0 presinstallonly")
-                self.file_remove("testme")
-
-                # Modify the file locally and upgrade to a version where the
-                # file has a preserve=install-only attribute and the content
-                # changes; it should not be modified.
-                self.pkg("install --parsable=0 presinstallonly@1")
-                self.file_append("testme", "junk")
-                self.pkg("install --parsable=0 presinstallonly@3")
-                self._assertEditables()
-                self.file_contains("testme", "preserve1")
-                self.file_contains("testme", "junk")
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.pkg("uninstall --parsable=0 presinstallonly")
-                self.file_remove("testme")
-
-                # Modify the file locally and downgrade to a version where the
-                # file has a preserve=install-only attribute and the content
-                # changes.
-                self.pkg("install --parsable=0 presinstallonly@4")
-                self.file_append("testme", "junk")
-                self.pkg("update --parsable=0 presinstallonly@2")
-                self._assertEditables()
-                self.file_contains("testme", "preserve3")
-                self.file_contains("testme", "junk")
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.update")
-                self.pkg("verify presinstallonly")
-                self.pkg("uninstall --parsable=0 presinstallonly")
-                self.file_remove("testme")
-
-                # Modify the file locally and upgrade to a version where the
-                # file has a preserve=install-only attribute and just the mode
-                # changes.
-                self.pkg("install --parsable=0 presinstallonly@1")
-                self.file_append("testme", "junk")
-                self.pkg("install --parsable=0 presinstallonly@2")
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", "preserve1")
-                self.file_contains("testme", "junk")
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.pkg("verify presinstallonly")
-                self.pkg("uninstall --parsable=0 presinstallonly")
-                self.file_remove("testme")
-
-                # Modify the file locally and downgrade to a version where the
-                # file has a preserve=install-only attribute and just the mode
-                # changes.
-                self.pkg("install --parsable=0 presinstallonly@4")
-                self.file_append("testme", "junk")
-                self.pkg("update --parsable=0 presinstallonly@3")
-                self._assertEditables(
-                    updated=['testme'],
-                )
-                self.file_contains("testme", "preserve3")
-                self.file_contains("testme", "junk")
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.update")
-                self.pkg("verify presinstallonly")
-                self.pkg("uninstall --parsable=0 presinstallonly")
-                self.file_remove("testme")
-
-                # Remove the file locally and update the package where the file
-                # has a preserve=install-only attribute; this will not replace
-                # the missing file.
-                self.pkg("install --parsable=0 presinstallonly@1")
-                self.file_remove("testme")
-                self.pkg("install --parsable=0 presinstallonly@2")
-                self._assertEditables()
-                self.file_doesnt_exist("testme")
-                self.pkg("uninstall --parsable=0 presinstallonly")
-
-                # Remove the file locally and downgrade the package where the
-                # file has a preserve=install-only attribute; this will not
-                # replace the missing file.
-                self.pkg("install --parsable=0 presinstallonly@4")
-                self.file_remove("testme")
-                self.pkg("update --parsable=0 presinstallonly@3")
-                self._assertEditables()
-                self.file_doesnt_exist("testme")
-
-                # Verify that a package with a missing file that is marked with
-                # the preserve=install-only won't cause uninstall failure.
-                self.file_doesnt_exist("testme")
-                self.pkg("uninstall --parsable=0 presinstallonly")
-
-                # Verify that if the file for an action marked with
-                # preserve=install-only is removed that the package fails
-                # verify.
-                self.pkg("install --parsable=0 presinstallonly@1")
-                self.pkg("install --parsable=0 presinstallonly@2")
-                self.file_remove("testme")
-                self.pkg("verify -v presinstallonly", exit=1)
-
-                # Verify that fix will restore it.
-                self.pkg("fix -v presinstallonly")
-                self.file_contains("testme", "preserve1")
-
-                # Verify that a file removed for an action marked with
-                # preserve=install-only can be reverted.
-                self.file_remove("testme")
-                self.pkg("revert testme")
-                self.file_contains("testme", "preserve1")
-
-        def test_file_preserve_version(self):
-                """Verify that file preserve-version works as expected
-                during pkg install, update, upgrade, and removal."""
-
-                self.pkgsend_bulk(self.rurl, (self.preserve_version_1,
-                    self.preserve_version_2, self.preserve_version_3,
-                    self.preserve_version_4))
-                self.image_create(self.rurl)
-
-                # If file preserve_version is less than the
-                # installed preserve_version, the installed file
-                # will be renamed with '.update' and the proposed file
-                # will be installed.
-                # (orig_preserve_ver = 1.0, preserve_ver = 0.1)
-                self.pkg("install --parsable=0 preserve_version@4")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_append("testme", "junk")
-                self.pkg("install --parsable=0 preserve_version@3")
-                self._assertEditables(
-                    moved=[['testme', 'testme.update']],
-                    installed=['testme'],
-                )
-
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_exists("testme.update")
-
-                self.file_contains("testme.update", "preserve_version_4")
-                self.file_contains("testme.update", "junk")
-
-                self.file_contains("testme", "preserve_version_3")
-                self.file_doesnt_contain("testme", "junk")
-
-                self.file_remove("testme.update")
-
-                self.pkg("verify preserve_version")
-
-                self.pkg("uninstall --parsable=0 preserve_version")
-
-                # If file preserve_version is equal to the
-                # proposed preserve_version, the installed file
-                # content is not modified (but the owner, group, and
-                # permissions are updated).
-                # (orig_preserve_ver = 1.0, preserve_ver = 1.0)
-                self.pkg("install --parsable=0 preserve_version@4")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_chmod("testme", 0o777)
-                self.file_chown("testme", "nobody", "nobody")
-                self.file_append("testme", "junk")
-                self.pkg("install --parsable=0 preserve_version@2")
-                self._assertEditables()
-
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.update")
-                self.file_exists("testme", 0o644, "root", "root")
-
-                self.file_contains("testme", "preserve_version_4")
-                self.file_contains("testme", "junk")
-
-                self.pkg("verify preserve_version")
-
-                self.pkg("uninstall --parsable=0 preserve_version")
-
-                # If file preserve_version is greater than the
-                # installed preserve_version, the installed file
-                # content is not modified (but the owner, group, and
-                # permissions are updated).
-                # (orig_preserve_ver = 1.0, preserve_ver = 2.0)
-                self.pkg("install --parsable=0 preserve_version@4")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_chmod("testme", 0o777)
-                self.file_chown("testme", "nobody", "nobody")
-                self.file_append("testme", "junk")
-                self.pkg("install --parsable=0 preserve_version@1")
-                self._assertEditables()
-
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.update")
-                self.file_exists("testme", 0o644, "root", "root")
-
-                self.file_contains("testme", "preserve_version_4")
-                self.file_contains("testme", "junk")
-
-                self.pkg("verify preserve_version")
-
-                self.pkg("uninstall --parsable=0 preserve_version")
-
-        def test_file_preserve_version_defined(self):
-                """Verify that file preserve-version works as expected
-                during pkg install, update, upgrade, and removal for a file
-                that did not initially define a preserve-version."""
-
-                self.pkgsend_bulk(self.rurl, (self.no_pres_ver_1,
-                    self.no_pres_ver_2))
-                self.image_create(self.rurl)
-
-                self.pkg("install --parsable=0 no_pres_ver@2")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_append("testme", "junk")
-                self.pkg("install --parsable=0 no_pres_ver@1")
-                self._assertEditables()
-
-                self.file_contains("testme", "no_pres_ver_2")
-                self.file_contains("testme", "junk")
-
-                self.pkg("verify no_pres_ver")
-
-                self.pkg("uninstall --parsable=0 no_pres_ver")
-
-        def test_file_preserve_version_undefined(self):
-                """Verify that file preserve-version works as expected
-                during pkg install, update, upgrade, and removal for a file
-                that no longer defines a preserve-version."""
-
-                self.pkgsend_bulk(self.rurl, (self.add_pres_ver_1,
-                    self.add_pres_ver_2))
-                self.image_create(self.rurl)
-
-                self.pkg("install --parsable=0 add_pres_ver@2")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_append("testme", "junk")
-                self.pkg("install --parsable=0 add_pres_ver@1")
-                self._assertEditables(
-                    moved=[['testme', 'testme.update']],
-                    installed=['testme'],
-                )
-
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_exists("testme.update")
-
-                self.file_contains("testme.update", "add_pres_ver_2")
-                self.file_contains("testme.update", "junk")
-
-                self.file_contains("testme", "add_pres_ver_1")
-                self.file_doesnt_contain("testme", "junk")
-
-                self.pkg("verify add_pres_ver")
-
-                self.pkg("uninstall --parsable=0 add_pres_ver")
-
-        def test_file_preserve_version_overlay(self):
-                """Verify that file preserve-version works as expected
-                when the file specifies overlay=allow."""
-
-                self.pkgsend_bulk(self.rurl, (self.preserve_version_1,
-                    self.pres_ver_overlay_1, self.pres_ver_overlay_2))
-                self.image_create(self.rurl)
-
-                # Install an overlaying package that does not specify a
-                # preserve-version and verify that the file gets replaced
-                # as expected.
-                # (orig_preserve_ver = 2.0, preserve_ver = 0)
-                self.pkg("install --parsable=0 preserve_version@1")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.pkg("install --parsable=0 pres_ver_overlay@1")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.update")
-
-                self.file_contains("testme", "pres_ver_overlay_1")
-                self.file_doesnt_contain("testme", "preserve_version")
-
-                self.pkg("verify preserve_version")
-
-                self.pkg("uninstall --parsable=0 preserve_version")
-                self.pkg("uninstall --parsable=0 pres_ver_overlay")
-
-                # Install an overlaying package that specifies a downgraded
-                # preserve-version and verify that the file gets replaced
-                # as expected.
-                # (orig_preserve_ver = 2.0, preserve_ver = 1.0)
-                self.pkg("install --parsable=0 preserve_version@1")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.pkg("install --parsable=0 pres_ver_overlay@2")
-                self._assertEditables(
-                    installed=['testme'],
-                )
-                self.file_doesnt_exist("testme.old")
-                self.file_doesnt_exist("testme.new")
-                self.file_doesnt_exist("testme.update")
-
-                self.file_contains("testme", "pres_ver_overlay_2")
-                self.file_doesnt_contain("testme", "preserve_version")
-
-                self.pkg("verify preserve_version")
-
-                self.pkg("uninstall --parsable=0 preserve_version")
-                self.pkg("uninstall --parsable=0 pres_ver_overlay")
-
-        def test_link_preserve_true(self):
-                """Verify that preserve=true for a link works as expected."""
-
-                self.pkgsend_bulk(self.rurl, self.preslink)
-                self.image_create(self.rurl)
-
-                # Install the package
-                self.pkg("install --parsable=0 preslink@1")
-                #self.image_walk()
-                self.link_exists("testlink", target="test1")
-                self.link_exists("link", target="test1")
-                self.pkg("verify preslink")
-
-                # Check that if no changes are made to the installed link
-                # which has preserve=true, then it will be updated on package
-                # update when its target changes.
-                self.pkg("update --parsable=0 preslink@3")
-                self.link_exists("testlink", target="test2")
-
-                self.pkg("uninstall --parsable=0 preslink")
-                self.pkg("install --parsable=0 preslink@1")
-
-                # Remove the link and test that an upgrade does not restore it
-                # where the link action has not changed in the package.
-                self.file_remove("testlink")
-                self.pkg("update --parsable=0 preslink@2")
-                self.file_doesnt_exist("testlink")
-                # that a verify succeeds
-                self.pkg("verify preslink")
-                # and that a fix does not restore the link
-                # (exit status 4 is nothing-to-do)
-                self.pkg("fix preslink", exit=4)
-                self.file_doesnt_exist("testlink")
-
-                # and where the link action has changed
-                self.file_remove("link")
-                self.pkg("update --parsable=0 preslink@3")
-                self.file_doesnt_exist("testlink")
-                # but 'link' should have come back
-                self.link_exists("link", target="test2")
-                # that a verify succeeds
-                self.pkg("verify preslink")
-                # and that a fix does not restore the link
-                self.pkg("fix preslink", exit=4)
-                self.file_doesnt_exist("testlink")
-
-                self.pkg("uninstall preslink")
-
-                # Test that a preserved link which has been changed is not
-                # replaced during upgrade
-                self.pkg("install preslink@1")
-                # Change the link
-                self.file_remove("testlink")
-                os.symlink(f'bobcat', f'{self.get_img_path()}/testlink')
-                self.link_exists("testlink", target="bobcat")
-                # a verify should still succeed
-                self.pkg("verify preslink")
-                # and a fix should not restore the link
-                self.pkg("fix preslink", exit=4)
-                self.link_exists("testlink", target="bobcat")
-
-                # Upgrade to a package with the same link action
-                self.pkg("update --parsable=0 preslink@2")
-                self.link_exists("testlink", target="bobcat")
-                # that a verify succeeds
-                self.pkg("verify preslink")
-                # and that a fix does not restore the link
-                self.pkg("fix preslink", exit=4)
-                self.link_exists("testlink", target="bobcat")
-
-                # and to one which changes the action
-                self.file_remove("link")
-                os.symlink(f'bobcat', f'{self.get_img_path()}/link')
-                self.link_exists("link", target="bobcat")
-                self.pkg("update --parsable=0 preslink@3")
-                self.link_exists("testlink", target="bobcat")
-                self.link_exists("link", target="test2")
-                # that a verify succeeds
-                self.pkg("verify preslink")
-                # and that a fix does not restore the link
-                self.pkg("fix preslink", exit=4)
-                self.link_exists("testlink", target="bobcat")
-
-                # verify that an uninstall removes the link
-                self.pkg("uninstall --parsable=0 preslink")
-                self.file_doesnt_exist("testlink")
-                self.file_doesnt_exist("link")
-
-        def test_directory_salvage(self):
-                """Make sure basic directory salvage works as expected"""
-
-                self.pkgsend_bulk(self.rurl, self.salvage)
-                self.image_create(self.rurl)
-                self.pkg("install salvage@1.0")
-                self.file_append("var/mail/foo", "foo's mail")
-                self.file_append("var/mail/bar", "bar's mail")
-                self.file_append("var/mail/baz", "baz's mail")
-                self.pkg("update salvage")
-                self.file_exists("var/.migrate-to-shared/mail/foo")
-                self.file_exists("var/.migrate-to-shared/mail/bar")
-                self.file_exists("var/.migrate-to-shared/mail/baz")
-
-        def test_directory_salvage_persistent(self):
-                """Make sure directory salvage works as expected when salvaging
-                content to an existing packaged directory."""
-
-                # we salvage content from two directories,
-                # var/noodles and var/spaghetti each of which disappear over
-                # subsequent updates.
-                self.pkgsend_bulk(self.rurl, self.salvage)
-                self.image_create(self.rurl)
-                self.pkg("install salvage@1.0")
-                self.file_append("var/mail/foo", "foo's mail")
-                self.file_append("var/noodles/noodles.txt", "yum")
-                self.pkg("update salvage@2.0")
-                self.file_exists("var/.migrate-to-shared/mail/foo")
-                self.file_exists("var/persistent/noodles.txt")
-                self.file_append("var/spaghetti/spaghetti.txt", "yum")
-                self.pkg("update")
-                self.file_exists("var/persistent/noodles.txt")
-                self.file_exists("var/persistent/spaghetti.txt")
-
-                # ensure that we can jump from 1.0 to 3.0 directly.
-                self.image_create(self.rurl)
-                self.pkg("install salvage@1.0")
-                self.file_append("var/noodles/noodles.txt", "yum")
-                self.pkg("update  salvage@3.0")
-                self.file_exists("var/persistent/noodles.txt")
-
-        def test_special_salvage(self):
-                """Make sure salvaging directories with special files works as
-                expected."""
-
-                self.pkgsend_bulk(self.rurl, self.salvage_special)
-                self.image_create(self.rurl, destroy=True, fs=("var",))
-
-                self.pkg("install salvage-special")
-
-                os.mkfifo(os.path.join(self.img_path(), "salvage", "fifo"))
-                sock = socket.socket(socket.AF_UNIX)
-                sock.bind(os.path.join(self.img_path(), "salvage", "socket"))
-                sock.close()
-
-                # This could hang reading fifo, or keel over reading socket.
-                self.pkg("uninstall salvage-special")
-
-        def test_salvage_nested(self):
-                """Make sure salvaging from nested packaged directories
-                works as expected. We test four scenarios, abandoning an
-                editable file (since that's a scenario ON will use for
-                23743369), a direct upgrade with no user edits,
-                salvaging all unpackaged contents despite nested dirs
-                not being delivered to var/.migrate, and splitting the
-                salvaged contents of a previously delivered directory to
-                two new directories."""
-
-                # We salvage to several places as part of the upgrade
-                # operation.
-                self.pkgsend_bulk(self.rurl, self.salvage_nested)
-                self.image_create(self.rurl)
-                self.pkg("install salvage-nested@1.0")
-                # add some unpackaged directories & contents
-                self.file_append("var/mail/foo", "foo's mail")
-                os.makedirs(
-                    os.path.join(self.get_img_path(),
-                    "var", "user", "webui", "timf"))
-                self.file_append("var/user/webui/user-pref.conf", "ook")
-                self.file_append("var/user/webui/timf/blah.conf", "moo")
-                self.file_append("var/user/evsuser/.ssh/config", "bar")
-
-                # modify a packaged editable file
-                self.file_append(
-                    "var/user/evsuser/.ssh/authorized_keys", "foo")
-
-                # abandon our editable file
-                self.pkg("update salvage-nested@1.1")
-                self.file_exists("var/user/evsuser/.ssh/authorized_keys")
-
-                self.pkg("update salvage-nested@2.0")
-                # Check negative cases first. This first location was where
-                # files would get salvaged to incorrectly prior to the fix
-                # for 23739095
-                self.file_doesnt_exist("var/.migrate/user/authorized_keys")
-                # these weren't known failures, but let's check anyway,
-                # since this is a useful safety net.
-                self.file_doesnt_exist("var/.migrate/authorized_keys")
-                self.file_doesnt_exist(
-                    "var/.migrate/user/evsuser/authorized_keys")
-                self.file_doesnt_exist("var/.migrate/user/evsuser/config")
-                self.file_doesnt_exist("var/.migrate/blah.conf")
-                self.file_doesnt_exist("var/.migrate/user/blah.conf")
-                self.file_doesnt_exist("var/.migrate/user/webui/blah.conf")
-
-                # now verify we salvaged everything correctly
-                self.file_contains("var/.migrate/mail/foo", "foo's mail")
-                self.file_contains(
-                    "var/.migrate/user/evsuser/.ssh/authorized_keys",
-                    "foo")
-                self.file_contains(
-                    "var/.migrate/user/evsuser/.ssh/config", "bar")
-                self.file_contains(
-                    "var/.migrate/user/webui/user-pref.conf", "ook")
-                self.file_contains(
-                    "var/.migrate/user/webui/timf/blah.conf", "moo")
-
-                # now try without the initial non-editable file
-                self.image_create(self.rurl)
-                self.pkg("install salvage-nested@1.1")
-                # an abandoned file shouldn't be installed
-                self.file_doesnt_exist("var/user/evsuser/.ssh/authorized_keys")
-                self.file_append(
-                    "var/user/evsuser/.ssh/authorized_keys", "ook")
-                self.pkg("update salvage-nested@2.0")
-                self.file_contains(
-                    "var/.migrate/user/evsuser/.ssh/authorized_keys",
-                    "ook")
-
-                # now try with no user edits
-                self.image_create(self.rurl)
-                self.pkg("install salvage-nested@1.1")
-                self.pkg("update salvage-nested@2.0")
-                self.file_doesnt_exist(
-                    "var/.migrate/user/evsuser/.ssh/authorized_keys")
-                self.dir_exists("var/.migrate/user/evsuser/.ssh")
-
-                # Now try without delivering the evsuser dir and subdirs
-                # in the updated package
-                self.image_create(self.rurl)
-                self.pkg("install salvage-nested@1.1")
-                os.makedirs(
-                    os.path.join(self.get_img_path(),
-                    "var", "user", "webui", "timf"))
-                os.makedirs(
-                    os.path.join(self.get_img_path(),
-                    "var", "user", "noodles"))
-                self.file_append("var/user/webui/timf/user-pref.conf", "ook")
-                self.file_append("var/user/noodles/blah.conf", "moo")
-                self.file_append("var/user/evsuser/.ssh/config", "bar")
-                self.pkg("update salvage-nested@3.0")
-                self.file_contains(
-                    "var/.migrate/user/evsuser/.ssh/config", "bar")
-                self.file_contains(
-                    "var/.migrate/user/webui/timf/user-pref.conf", "ook")
-                self.file_contains(
-                    "var/.migrate/user/noodles/blah.conf", "moo")
-
-                # Finally try splitting the salvaged contents from a
-                # previously delivered directory into two new directories.
-                self.image_create(self.rurl)
-                self.pkg("install salvage-nested@1.1")
-                os.makedirs(
-                    os.path.join(self.get_img_path(),
-                    "var", "user", "webui", "timf"))
-                os.makedirs(
-                    os.path.join(self.get_img_path(),
-                    "var", "user", "noodles"))
-                self.file_append("var/user/webui/timf/user-pref.conf", "ook")
-                self.file_append("var/user/noodles/blah.conf", "moo")
-                self.file_append("var/user/evsuser/.ssh/config", "bar")
-                self.pkg("update salvage-nested@4.0")
-                self.file_contains(
-                    "var/.migrate/evsuser/.ssh/config", "bar")
-                self.file_contains(
-                    "var/.migrate/user/webui/timf/user-pref.conf", "ook")
-                self.file_contains(
-                    "var/.migrate/user/noodles/blah.conf", "moo")
-
-
-        def dest_file_valid(self, plist, pkg, src, dest):
-                """Used to verify that the dest item's mode, attrs, timestamp,
-                etc. match the src items's matching action as expected."""
-
-                for p in plist:
-                        pfmri = fmri.PkgFmri(p)
-                        pfmri.publisher = None
-                        sfmri = pfmri.get_short_fmri().replace("pkg:/", "")
-
-                        if pkg != sfmri:
-                                continue
-
-                        m = manifest.Manifest()
-                        m.set_content(self.get_img_manifest(pfmri))
-                        for a in m.gen_actions():
-                                if a.name != "file":
-                                        # Only want file actions that have
-                                        # preserve attribute.
-                                        continue
-                                if a.attrs["path"] != src:
-                                        # Only want actions with matching path.
-                                        continue
-                                self.validate_fsobj_attrs(a, target=dest)
-
-        def test_link_preserve(self):
-                """Ensure that files transitioning to a link still follow
-                original_name preservation rules."""
-
-                self.pkgsend_bulk(self.rurl, (self.linkpreserve))
-                self.image_create(self.rurl, destroy=True, fs=("var",))
-
-                # Install package with original config file location.
-                self.pkg("install --parsable=0 linkpreserve@1.0")
-                cfg_path = os.path.join("etc", "ssh", "sshd_config")
-                abs_path = os.path.join(self.get_img_path(), cfg_path)
-
-                self.file_exists(cfg_path)
-                self.assertTrue(not os.path.islink(abs_path))
-
-                # Modify the file.
-                self.file_append(cfg_path, "modified")
-
-                # Install new package version, verify file replaced with link
-                # and modified version was moved to new location.
-                new_cfg_path = os.path.join("etc", "sunssh", "sshd_config")
-                self.pkg("update --parsable=0 linkpreserve@2.0")
-                self._assertEditables(
-                    moved=[['etc/ssh/sshd_config', 'etc/sunssh/sshd_config']]
-                )
-                self.assertTrue(os.path.islink(abs_path))
-                self.file_exists(new_cfg_path)
-                self.file_contains(new_cfg_path, "modified")
-
-                # Uninstall, then install original version again.
-                self.pkg("uninstall linkpreserve")
-                self.pkg("install linkpreserve@1.0")
-                self.file_contains(cfg_path, "preserve1")
-
-                # Install new package version and verify that unmodified file is
-                # replaced with new configuration file.
-                self.pkg("update --parsable=0 linkpreserve@2.0")
-                self._assertEditables(
-                    moved=[['etc/ssh/sshd_config', 'etc/sunssh/sshd_config']]
-                )
-                self.file_contains(new_cfg_path, "preserve2")
-
-        def test_many_hashalgs(self):
-                """Test that when upgrading actions where the new action
-                contains more hash attributes than the old action, that the
-                upgrade works."""
-
-                self.many_hashalgs_helper("install", "sha256")
-                self.many_hashalgs_helper("exact-install", "sha256")
-                if sha512_supported:
-                        self.many_hashalgs_helper("install", "sha512t_256")
-                        self.many_hashalgs_helper("exact-install", "sha512t_256")
-
-        def many_hashalgs_helper(self, install_cmd, hash_alg):
-                self.pkgsend_bulk(self.rurl, self.iron10, debug_hash="sha1")
-                self.image_create(self.rurl, destroy=True)
-                self.pkg("install iron@1.0")
-                self.pkg("contents -m iron")
-                # We have not enabled SHA2 hash publication yet.
-                self.assertTrue(("pkg.content-hash=file:{0}".format(hash_alg) not in self.output))
-
-                # publish with SHA1 and SHA2 hashes
-                self.pkgsend_bulk(self.rurl, self.iron20,
-                    debug_hash="sha1+{0}".format(hash_alg))
-
-                # verify that a non-SHA2 aware client can install these bits
-                self.pkg("-D hash=sha1 update")
-                self.image_create(self.rurl, destroy=True)
-
-                # This also tests package retrieval: we always retrieve packages
-                # with the least-preferred hash, but verify with the
-                # most-preferred hash.
-                self.pkg("install iron@2.0")
-                self.pkg("contents -m iron")
-                self.assertTrue("pkg.content-hash=file:{0}".format(hash_alg) in self.output)
-
-                # publish with only SHA-2 hashes
-                self.pkgsend_bulk(self.rurl, self.iron20,
-                    debug_hash="{0}".format(hash_alg))
-
-                # verify that a non-SHA2 aware client cannot install these bits
-                # since there are no SHA1 hashes present
-                self.pkg("-D hash=sha1 update", exit=1)
-                self.assertTrue(
-                    "No file could be found for the specified hash name: "
-                    "'NOHASH'" in self.errout)
-
-                # Make sure we've been publishing only with SHA2 by removing
-                # those known attributes, then checking for the presence of
-                # the SHA-1 attributes.
-                self.pkg("-D hash={0} update".format(hash_alg))
-                self.pkg("contents -m iron")
-                for attr in ["pkg.chash.{0}".format(hash_alg), "pkg.content-hash"]:
-                        self.output = self.output.replace(attr, "")
-                self.assertTrue("hash" not in self.output)
-                self.assertTrue("chash" not in self.output)
-
-        def test_content_hash_ignore(self):
-                """Test that pkgs with gelf content-hash attributes are ignored
-                for install and verify by default if file hash matches."""
-
-                elfpkg_1 = """
+
+        mani2.store(mpath2)
+        repo.rebuild()
+
+        self.pkg("install -v elfhash@1.0")
+        self.pkg("contents -m elfhash | grep gelf")
+        self.pkg("update -vvv elfhash")
+        self.pkg("contents -m elfhash | grep gelf", exit=1)
+        self.pkg("contents -m elfhash | grep file")
+        self.pkg("uninstall elfhash")
+
+        # Redo the test again with upgrading to action uses both
+        # methods.
+        for a in mani2.gen_actions():
+            if "bin/true" in str(a):
+                a.attrs["pkg.content-hash"] = [
+                    "gelf:sha512t_256:abcd",
+                    "file:sha512t_256:2374db2dfb4968baad246ab37afc560cc9d278b6104a889a2727d9bcf6a20b17",
+                ]
+
+        mani2.store(mpath2)
+        repo.rebuild()
+
+        self.pkg("install -v elfhash@1.0")
+        self.pkg("contents -m elfhash | grep gelf")
+        self.pkg("update -vvv elfhash")
+        # we update the file's content-hash attributes.
+        self.pkg("contents -m elfhash | grep gelf")
+        self.pkg("contents -m elfhash | grep file")
+        self.pkg("uninstall elfhash")
+
+    def test_upgrade1(self):
+        """Upgrade torture test.
+        Send package amber@1.0, bronze1.0; install bronze1.0, which
+        should cause amber to also install.
+        Send 2.0 versions of packages which contains a lot of
+        complex transactions between amber and bronze, then do
+        an update, and try to check the results.
+        """
+
+        # Send 1.0 versions of packages.
+        self.pkgsend_bulk(
+            self.rurl, (self.incorp10, self.amber10, self.bronze10)
+        )
+
+        #
+        # In version 2.0, several things happen:
+        #
+        # Amber and Bronze swap a file with each other in both
+        # directions.  The dependency flips over (Amber now depends
+        # on Bronze).  Amber and Bronze swap ownership of various
+        # directories.
+        #
+        # Bronze's 1.0 hardlink to amber's libc goes away and is
+        # replaced with a file of the same name.  Amber hardlinks
+        # to that.
+        #
+        self.pkgsend_bulk(
+            self.rurl, (self.incorp20, self.amber20, self.bronze20)
+        )
+
+        # create image and install version 1
+        self.image_create(self.rurl)
+        self.pkg("install incorp@1.0")
+        # self.file_exists(".SELF-ASSEMBLY-REQUIRED")
+        self.pkg("install bronze")
+
+        self.pkg("list amber@1.0 bronze@1.0")
+        self.pkg("verify -v")
+
+        # demonstrate that incorp@1.0 prevents package movement
+        self.pkg("install bronze@2.0 amber@2.0", exit=1)
+
+        # ...again, but using @latest.
+        self.pkg("install bronze@latest amber@latest", exit=1)
+        self.pkg("update bronze@latest amber@latest", exit=1)
+
+        # Now update to get new versions of amber and bronze
+        # self.file_remove(".SELF-ASSEMBLY-REQUIRED")
+        self.pkg("update")
+        # self.file_exists(".SELF-ASSEMBLY-REQUIRED")
+
+        # Try to verify that it worked.
+        self.pkg("list amber@2.0 bronze@2.0")
+        self.pkg("verify -v")
+        # make sure old implicit directories for bronzeA1 were removed
+        self.assertTrue(
+            not os.path.isdir(os.path.join(self.get_img_path(), "A"))
+        )
+        # Remove packages
+        self.pkg("uninstall amber bronze")
+        self.pkg("verify -v")
+
+        # Make sure all directories are gone save /var in test image.
+        self.assertEqual(set(os.listdir(self.get_img_path())), set(["var"]))
+
+    def test_upgrade2(self):
+        """test incorporations:
+        1) install files that conflict w/ existing incorps
+        2) install package w/ dependencies that violate incorps
+        3) install incorp that violates existing incorp
+        4) install incorp that would force package backwards
+        """
+
+        # Send all pkgs
+        plist = self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.incorp10,
+                self.incorp20,
+                self.incorp30,
+                self.iridium10,
+                self.concorp10,
+                self.amber10,
+                self.amber20,
+                self.bronze10,
+                self.bronze20,
+                self.bronze30,
+                self.brass10,
+            ),
+        )
+
+        self.image_create(self.rurl)
+
+        self.pkg("install incorp@1.0")
+        # install files that conflict w/ existing incorps
+        self.pkg("install bronze@2.0", exit=1)
+        # install package w/ dependencies that violate incorps
+        self.pkg("install iridium@1.0", exit=1)
+        # install package w/ unspecified dependency that pulls
+        # in bronze
+        self.pkg("install brass")
+        self.pkg("verify brass@1.0 bronze@1.0")
+        # attempt to install conflicting incorporation
+        self.pkg("install concorp@1.0", exit=1)
+
+        # attempt to force downgrade of package w/ older incorp
+        self.pkg("install incorp@2.0")
+        self.pkg("uninstall incorp@2.0")
+        self.pkg("install incorp@1.0")
+
+        # upgrade pkg that loses incorp. deps. in new version
+        self.pkg("install -vvv incorp@2.0")
+
+        # perform explicit update of incorp; should not update bronze
+        self.pkg("update --parsable=0 -n incorp@3")
+        self.assertEqualParsable(
+            self.output,
+            change_packages=[[plist[1], plist[2]]],  # incorp 2.0 -> 3.0
+        )
+        self.pkg("update --parsable=0 -n incorp")
+        self.assertEqualParsable(
+            self.output,
+            change_packages=[[plist[1], plist[2]]],  # incorp 2.0 -> 3.0
+        )
+
+        # perform a general update; should upgrade incorp and bronze
+        self.pkg("update --parsable=0 -n")
+        self.assertEqualParsable(
+            self.output,
+            change_packages=[
+                [plist[8], plist[9]],  # bronze 2.0 -> 3.0
+                [plist[1], plist[2]],  # incorp 2.0 -> 3.0
+            ],
+        )
+
+    def test_upgrade3(self):
+        """Test for editable files moving between packages or locations
+        or both."""
+
+        install_cmd = "install"
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.silver10,
+                self.silver20,
+                self.silver30,
+                self.gold10,
+                self.gold20,
+                self.gold30,
+                self.golduser10,
+                self.golduser20,
+                self.silveruser,
+            ),
+        )
+
+        self.image_create(self.rurl)
+
+        # test 1: move an editable file between packages
+        self.pkg("{0} --parsable=0 gold@1.0 silver@1.0".format(install_cmd))
+        self._assertEditables(
+            installed=[
+                "etc/ftpd/ftpusers",
+                "etc/group",
+                "etc/passwd",
+                "etc/shadow",
+            ]
+        )
+        self.pkg("verify -v")
+
+        # modify config file
+        test_str = "this file has been modified 1"
+        file_path = "etc/passwd"
+        self.file_append(file_path, test_str)
+
+        # make sure /etc/passwd contains correct string
+        self.file_contains(file_path, test_str)
+
+        # update packages
+        self.pkg("{0} -nvv gold@3.0 silver@2.0".format(install_cmd))
+        self.pkg("{0} --parsable=0 gold@3.0 silver@2.0".format(install_cmd))
+        self._assertEditables()
+        self.pkg("verify -v")
+
+        # make sure /etc/passwd contains still correct string
+        self.file_contains(file_path, test_str)
+
+        self.pkg("uninstall --parsable=0 silver gold")
+        self._assertEditables(
+            removed=[
+                "etc/ftpd/ftpusers",
+                "etc/group",
+                "etc/passwd",
+                "etc/shadow",
+            ],
+        )
+
+        # test 2: change an editable file's path within a package
+        self.pkg("{0} --parsable=0 gold@1.0".format(install_cmd))
+        self.pkg("verify -v")
+
+        # modify config file
+        test_str = "this file has been modified test 2"
+        file_path = "etc/passwd"
+        self.file_append(file_path, test_str)
+
+        self.pkg("{0} --parsable=0 gold@2.0".format(install_cmd))
+        self._assertEditables(
+            moved=[["etc/passwd", "etc/config2"]],
+            removed=[
+                "etc/ftpd/ftpusers",
+                "etc/group",
+                "etc/shadow",
+            ],
+        )
+        self.pkg("verify -v")
+
+        # make sure /etc/config2 contains correct string
+        file_path = "etc/config2"
+        self.file_contains(file_path, test_str)
+
+        self.pkg("uninstall --parsable=0 gold")
+        self._assertEditables(
+            removed=["etc/config2"],
+        )
+        self.pkg("verify -v")
+
+        # test 3: move an editable file between packages and change its path
+        self.pkg("{0} --parsable=0 gold@1.0 silver@1.0".format(install_cmd))
+        self.pkg("verify -v")
+
+        # modify config file
+        file_path = "etc/passwd"
+        test_str = "this file has been modified test 3"
+        self.file_append(file_path, test_str)
+
+        self.file_contains(file_path, test_str)
+
+        self.pkg("{0} --parsable=0 gold@3.0 silver@3.0".format(install_cmd))
+        self._assertEditables(
+            moved=[["etc/passwd", "etc/config2"]],
+            removed=[
+                "etc/ftpd/ftpusers",
+                "etc/group",
+                "etc/shadow",
+            ],
+        )
+        self.pkg("verify -v")
+
+        # make sure /etc/config2 now contains correct string
+        file_path = "etc/config2"
+        self.file_contains(file_path, test_str)
+
+        self.pkg("uninstall --parsable=0 gold silver")
+
+        # test 4: move /etc/passwd between packages and ensure that we
+        # can still uninstall a user at the same time.
+        self.pkg("{0} --parsable=0 gold@1.0 silver@1.0".format(install_cmd))
+        self.pkg("verify -v")
+
+        # add a user
+        self.pkg("install golduser@1.0")
+
+        # make local changes to the user
+        pwdpath = os.path.join(self.get_img_path(), "etc/passwd")
+
+        pwdfile = open(pwdpath, "r+")
+        lines = pwdfile.readlines()
+        for i, l in enumerate(lines):
+            if l.startswith("Kermit"):
+                lines[i] = lines[i].replace("& User", "Kermit loves Miss Piggy")
+        pwdfile.seek(0)
+        pwdfile.writelines(lines)
+        pwdfile.close()
+
+        silly_path = os.path.join(self.get_img_path(), "etc/silly")
+        silly_inode = os.stat(silly_path).st_ino
+
+        # update packages
+        self.pkg(
+            "{0} --parsable=0 gold@3.0 silver@2.0 golduser@2.0 "
+            "silveruser".format(install_cmd)
+        )
+        self._assertEditables()
+
+        # make sure Kermie is still installed and still has our local
+        # changes
+        self.file_contains(
+            "etc/passwd",
+            "Kermit:x:5:4:Kermit loves Miss Piggy:/export/home/Kermit:",
+        )
+
+        # also make sure that /etc/silly hasn't been removed and added
+        # again, even though it wasn't marked specially
+        self.assertEqual(os.stat(silly_path).st_ino, silly_inode)
+
+    def test_upgrade4(self):
+        """Test to make sure hardlinks are correctly restored when file
+        they point to is updated."""
+
+        self.pkgsend_bulk(self.rurl, (self.iron10, self.iron20))
+        self.image_create(self.rurl)
+
+        self.pkg("install iron@1.0")
+        self.pkg("verify -v")
+
+        self.pkg("install iron@2.0")
+        self.pkg("verify -v")
+
+    def test_upgrade5(self):
+        """Test manually removed directory and files will be restored
+        during update, if mode are different."""
+
+        self.pkgsend_bulk(
+            self.rurl, (self.dumdir10, self.dumdir20, self.dumdir30)
+        )
+        self.image_create(self.rurl)
+
+        self.pkg("install -vvv dumdir@1.0")
+        self.pkg("verify -v")
+        dirpath = os.path.join(self.test_root, "image0", "etc")
+        shutil.rmtree(dirpath)
+
+        self.pkg("update -vvv dumdir@2.0")
+        self.pkg("verify -v")
+        shutil.rmtree(dirpath)
+
+        self.pkg("update -vvv dumdir@3.0")
+        self.pkg("verify -v")
+
+    def test_newbe_liveroot(self):
+        """Test to verify the command output, when modifying a live
+        image has the correct initial information for the user."""
+
+        self.pkgsend_bulk(self.rurl, (self.release_name))
+        self.image_create(self.rurl)
+
+        # Verify the name of the boot environment is printed
+        # on install. The installation will fail because creating
+        # a BE name is not permitted on a non-live root and
+        # simulate_live_root does not override that.
+        self.pkg(
+            "--debug simulate_live_root={0} install "
+            " --be-name=livetest release/name@1.0".format(self.get_img_path()),
+            exit=1,
+        )
+        self.assertTrue("environment: livetest" in self.output)
+
+        # Install the package (no new BE)
+        self.pkg(
+            "--debug simulate_live_root={0} install "
+            "release/name@1.0".format(self.get_img_path())
+        )
+
+        # Ensure that the uninstall case prints a create
+        # boot environment message. The command will fail due
+        # to test framework limitations.
+        self.pkg(
+            "--debug simulate_live_root={0} uninstall "
+            "release/name@1.0".format(self.get_img_path()),
+            exit=1,
+        )
+        self.assertTrue("Create boot environment: Yes" in self.output)
+        # Ensure the failure is for the correct reason.
+        self.assertTrue(
+            "pkg: Unable to clone the current boot environment" in self.errout
+        )
+
+    def test_upgrade_liveroot(self):
+        """Test to make sure upgrade of package fails if on live root
+        and reboot is needed."""
+
+        self.upgrade_liveroot_helper("install")
+        self.upgrade_liveroot_helper("exact-install")
+
+    def upgrade_liveroot_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, (self.liveroot10, self.liveroot20))
+        self.image_create(self.rurl)
+
+        self.pkg(
+            "--debug simulate_live_root={0} {1} liveroot@1.0".format(
+                self.get_img_path(), install_cmd
+            )
+        )
+        self.pkg("verify -v")
+        self.pkg(
+            "--debug simulate_live_root={0} {1} --deny-new-be "
+            "liveroot@2.0".format(self.get_img_path(), install_cmd),
+            exit=5,
+        )
+        self.pkg(
+            "--debug simulate_live_root={0} uninstall "
+            "--deny-new-be liveroot".format(self.get_img_path()),
+            exit=5,
+        )
+        # "break" liveroot@1
+        self.file_append("etc/liveroot", "this file has been changed")
+        self.pkg(
+            "--debug simulate_live_root={0} fix --deny-new-be "
+            "liveroot".format(self.get_img_path()),
+            exit=5,
+        )
+
+    def test_upgrade_driver_conflicts(self):
+        """Test to make sure driver_aliases conflicts don't cause
+        add_drv to fail."""
+
+        self.upgrade_driver_conflicts_helper("install")
+        self.upgrade_driver_conflicts_helper("exact-install")
+
+    def upgrade_driver_conflicts_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, (self.dricon1, self.dricon2, self.dricon3))
+
+        self.image_create(self.rurl)
+
+        self.pkg("list -afv")
+        self.pkg("{0} dricon@1".format(install_cmd))
+        # This one should comment out the wigit entry in driver_aliases
+        self.pkg("{0} dricon@2".format(install_cmd))
+        with open(os.path.join(self.get_img_path(), "etc/driver_aliases")) as f:
+            da_contents = f.readlines()
+        self.assertTrue('# pkg(7): wigit "pci8086,1234"\n' in da_contents)
+        self.assertTrue('wigit "pci8086,1234"\n' not in da_contents)
+        self.assertTrue('wigit "pci8086,4321"\n' in da_contents)
+        self.assertTrue('zigit "pci8086,1234"\n' in da_contents)
+        # This one should fail
+        self.pkg("{0} dricon@3".format(install_cmd), exit=1)
+
+    def test_driver_policy_removal(self):
+        """Test for bug #9568 - that removing a policy for a
+        driver where there is no minor node associated with it,
+        works successfully.
+        """
+
+        self.driver_policy_removal_helper("install")
+        self.driver_policy_removal_helper("exact-install")
+
+    def driver_policy_removal_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, (self.dripol1, self.dripol2))
+
+        self.image_create(self.rurl)
+
+        self.pkg("list -afv")
+
+        # Should install the frigit driver with a policy.
+        self.pkg("{0} dripol@1".format(install_cmd))
+
+        # Check that there is a policy entry for this
+        # device in /etc/security/device_policy
+        with open(
+            os.path.join(self.get_img_path(), "etc/security/device_policy")
+        ) as f:
+            dp_contents = f.readlines()
+        self.assertTrue(
+            "frigit:*\tread_priv_set=net_rawaccess\t"
+            "write_priv_set=net_rawaccess\n" in dp_contents
+        )
+
+        # Should reinstall the frigit driver without a policy.
+        self.pkg("{0} dripol@2".format(install_cmd))
+
+        # Check that there is no longer a policy entry for this
+        # device in /etc/security/device_policy
+        with open(
+            os.path.join(self.get_img_path(), "etc/security/device_policy")
+        ) as f:
+            dp_contents = f.readlines()
+        self.assertTrue(
+            "frigit:*\tread_priv_set=net_rawaccess\t"
+            "write_priv_set=net_rawaccess\n" not in dp_contents
+        )
+
+        # self.pkg("update dripol@3")
+        # with open(os.path.join(self.get_img_path(),
+        #    "etc/security/device_policy")) as f:
+        #        dp_contents = f.readlines()
+        # self.assertTrue("frigit:*\ttpd_member=true\n"
+        #    in dp_contents)
+
+        # self.pkg("update dripol@5")
+        # with open(os.path.join(self.get_img_path(),
+        #    "etc/security/device_policy")) as f:
+        #        dp_contents = f.readlines()
+        # self.assertTrue("frigit:node1\tread_priv_set=all"
+        #    "\twrite_priv_set=all\ttpd_member=true\n"
+        #    in dp_contents)
+
+        # self.pkg("update dripol@4")
+        # with open(os.path.join(self.get_img_path(),
+        #    "etc/security/device_policy")) as f:
+        #        dp_contents = f.readlines()
+        # self.assertTrue("frigit:node1" not in dp_contents)
+
+    def test_file_preserve(self):
+        """Verify that file preserve=true works as expected during
+        package install, update, upgrade, and removal."""
+
+        install_cmd = "install"
+        self.pkgsend_bulk(
+            self.rurl,
+            (self.preserve1, self.preserve2, self.preserve3, self.renpreserve),
+        )
+        self.image_create(self.rurl)
+
+        # If there are no local modifications, no preservation should be
+        # done.  First with no content change ...
+        self.pkg("{0} --parsable=0 preserve@1".format(install_cmd))
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.pkg("{0} --parsable=0 preserve@2".format(install_cmd))
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", "preserve1")
+        self.pkg("verify preserve")
+
+        self.pkg("update --parsable=0 preserve@1")
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", "preserve1")
+        self.pkg("verify preserve")
+
+        self.pkg("uninstall --parsable=0 preserve")
+
+        # ... and again with content change.
+        self.pkg("install --parsable=0 preserve@1")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.pkg("install --parsable=0 preserve@3")
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", "preserve3")
+
+        self.pkg("update --parsable=0 preserve@1")
+        self._assertEditables()
+
+        # ... on downgrade leave the existing configuration intact.
+        self.file_contains("testme", "preserve3")
+
+        self.pkg("verify preserve")
+        self.pkg("uninstall --parsable=0 preserve")
+
+        # Modify the file locally and update to a version where the
+        # content changes.
+        self.pkg("{0} --parsable=0 preserve@1".format(install_cmd))
+        self.file_append("testme", "junk")
+        self.file_contains("testme", "preserve1")
+        self.pkg("{0} --parsable=0 preserve@3".format(install_cmd))
+        self._assertEditables()
+        self.file_contains("testme", ["preserve1", "junk"])
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.pkg("verify preserve")
+        self.pkg("uninstall --parsable=0 preserve")
+
+        # Modify the file locally and verify that on downgrade the
+        # content remains unchanged.
+        self.pkg("{0} --parsable=0 preserve@3".format(install_cmd))
+        self.file_append("testme", "junk")
+        self.file_contains("testme", "preserve3")
+        self.pkg("update --parsable=0 preserve@1")
+        self._assertEditables()
+        self.file_contains("testme", ["preserve3", "junk"])
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.update")
+        self.pkg("verify preserve")
+        self.pkg("uninstall --parsable=0 preserve")
+
+        # Modify the file locally and update to a version where just the
+        # mode changes.
+        self.pkg("{0} --parsable=0 preserve@1".format(install_cmd))
+        self.file_append("testme", "junk")
+
+        self.pkg("{0} --parsable=0 preserve@2".format(install_cmd))
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", ["preserve1", "junk"])
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+
+        self.pkg("update --parsable=0 preserve@1")
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", ["preserve1", "junk"])
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.update")
+
+        self.pkg("{0} --parsable=0 preserve@2".format(install_cmd))
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+
+        # Remove the file locally and update the package; this should
+        # simply replace the missing file.
+        self.file_remove("testme")
+        self.pkg("{0} --parsable=0 preserve@3".format(install_cmd))
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.pkg("verify preserve")
+        self.file_exists("testme")
+
+        # Remove the file locally and downgrade the package; this should
+        # simply replace the missing file.
+        self.file_remove("testme")
+        self.pkg("update --parsable=0 preserve@2")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.pkg("verify preserve")
+        self.file_exists("testme")
+        self.pkg("uninstall preserve@2")
+
+        # Verify preserved files will have their mode changed on update.
+        self.pkg("{0} --parsable=0 preserve@1".format(install_cmd))
+        self.pkg("{0} --parsable=0 preserve@2".format(install_cmd))
+        self.pkg("verify preserve")
+
+        # Verify that a package with a missing file that is marked with
+        # the preserve=true won't cause uninstall failure.
+        self.file_remove("testme")
+        self.file_doesnt_exist("testme")
+        self.pkg("uninstall --parsable=0 preserve")
+
+        # Verify preserve works across package rename with and without
+        # original_name use and even when the original file is missing.
+        self.pkg("{0} --parsable=0 orig_pkg@1.0".format(install_cmd))
+        foo1_path = os.path.join(self.get_img_path(), "foo1")
+        self.assertTrue(os.path.isfile(foo1_path))
+        bronze1_path = os.path.join(self.get_img_path(), "bronze1")
+        self.assertTrue(os.path.isfile(bronze1_path))
+
+        # Update across the rename boundary, then verify that the files
+        # were installed with their new name and the old ones were
+        # removed.
+        self.pkg("update -nvv orig_pkg")
+        self.pkg("update --parsable=0 orig_pkg")
+        self._assertEditables(
+            moved=[["foo1", "foo2"]],
+        )
+
+        foo2_path = os.path.join(self.get_img_path(), "foo2")
+        self.assertTrue(not os.path.exists(foo1_path))
+        self.assertTrue(os.path.isfile(foo2_path))
+        self.assertTrue(os.path.isfile(bronze1_path))
+        self.pkg("uninstall --parsable=0 \\*")
+
+        # Update across the rename boundary, then truncate each of the
+        # preserved files.  They should remain empty even though one is
+        # changing names and the other is simply being preserved across
+        # a package rename.
+        self.pkg("{0} --parsable=0 orig_pkg@1.0".format(install_cmd))
+        open(foo1_path, "wb").close()
+        open(bronze1_path, "wb").close()
+        self.pkg("update --parsable=0 orig_pkg")
+        self._assertEditables(
+            moved=[["foo1", "foo2"]],
+        )
+        self.assertTrue(not os.path.exists(foo1_path))
+        self.assertTrue(os.path.isfile(foo2_path))
+        self.assertEqual(os.stat(foo2_path).st_size, 0)
+        self.assertTrue(os.path.isfile(bronze1_path))
+        self.assertEqual(os.stat(bronze1_path).st_size, 0)
+        self.pkg("uninstall --parsable=0 \\*")
+        self._assertEditables(
+            removed=["bronze1", "foo2"],
+        )
+
+        # Update across the rename boundary, then verify that a change
+        # in file name will cause re-delivery of preserved files, but
+        # unchanged, preserved files will not be re-delivered.
+        self.pkg("{0} --parsable=0 orig_pkg@1.0".format(install_cmd))
+        os.unlink(foo1_path)
+        os.unlink(bronze1_path)
+        self.pkg("update --parsable=0 orig_pkg")
+        self._assertEditables(
+            moved=[["foo1", "foo2"]],
+        )
+        self.assertTrue(not os.path.exists(foo1_path))
+        self.assertTrue(os.path.isfile(foo2_path))
+        self.assertTrue(not os.path.exists(bronze1_path))
+        self.pkg("uninstall --parsable=0 \\*")
+
+        # Ensure directory is empty before testing.
+        api_inst = self.get_img_api_obj()
+        img_inst = api_inst.img
+        sroot = os.path.join(img_inst.imgdir, "lost+found")
+        shutil.rmtree(sroot)
+
+        # Verify that unmodified, preserved files will not be salvaged
+        # on uninstall.
+        self.pkg("{0} --parsable=0 preserve@1.0".format(install_cmd))
+        self.file_contains("testme", "preserve1")
+        self.pkg("uninstall --parsable=0 preserve")
+        salvaged = [n for n in os.listdir(sroot) if n.startswith("testme-")]
+        self.assertEqual(salvaged, [])
+
+        # Verify that modified, preserved files will be salvaged
+        # on uninstall.
+        self.pkg("{0} --parsable=0 preserve@1.0".format(install_cmd))
+        self.file_contains("testme", "preserve1")
+        self.file_append("testme", "junk")
+        self.pkg("uninstall --parsable=0 preserve")
+        self.__salvage_file_contains(sroot, "testme", "junk")
+
+    def test_file_preserve_renameold(self):
+        """Make sure that file upgrade with preserve=renameold works."""
+
+        install_cmd = "install"
+        plist = self.pkgsend_bulk(
+            self.rurl, (self.renameold1, self.renameold2, self.renameold3)
+        )
+        self.image_create(self.rurl)
+
+        # If there are no local modifications, no preservation should be
+        # done.  First with no content change ...
+        self.pkg("{0} renold@1".format(install_cmd))
+        self.pkg("{0} renold@2".format(install_cmd))
+        self.file_contains("testme", "renold1")
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.pkg("verify renold")
+        self.pkg("uninstall renold")
+
+        # ... and again with content change.
+        self.pkg("{0} renold@1".format(install_cmd))
+        self.pkg("{0} renold@3".format(install_cmd))
+        self.file_contains("testme", "renold3")
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.pkg("verify renold")
+        self.pkg("uninstall renold")
+
+        # Modify the file locally and update to a version where the
+        # content changes.
+        self.pkg("{0} renold@1".format(install_cmd))
+        self.file_append("testme", "junk")
+        self.pkg("{0} --parsable=0 renold@3".format(install_cmd))
+        self._assertEditables(
+            moved=[["testme", "testme.old"]],
+            installed=["testme"],
+        )
+        self.file_contains("testme.old", "junk")
+        self.file_doesnt_contain("testme", "junk")
+        self.file_contains("testme", "renold3")
+        self.dest_file_valid(plist, "renold@3.0", "testme", "testme")
+        self.file_doesnt_exist("testme.new")
+        self.pkg("verify renold")
+        self.pkg("uninstall renold")
+
+        # Modify the file locally and update to a version where just the
+        # mode changes.
+        self.pkg("{0} renold@1".format(install_cmd))
+        self.file_append("testme", "junk")
+        self.pkg("{0} --parsable=0 renold@2".format(install_cmd))
+        self._assertEditables(
+            moved=[["testme", "testme.old"]],
+            installed=["testme"],
+        )
+        self.file_contains("testme.old", "junk")
+        self.file_doesnt_contain("testme", "junk")
+        self.file_contains("testme", "renold1")
+        self.file_doesnt_exist("testme.new")
+        self.pkg("verify renold")
+        self.pkg("uninstall renold")
+
+        # Remove the file locally and update the package; this should
+        # simply replace the missing file.
+        self.pkg("{0} renold@1".format(install_cmd))
+        self.file_remove("testme")
+        self.pkg("{0} --parsable=0 renold@2".format(install_cmd))
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.pkg("verify renold")
+        self.pkg("uninstall renold")
+
+    def test_file_preserve_renamenew(self):
+        """Make sure that file ugprade with preserve=renamenew works."""
+
+        install_cmd = "install"
+        plist = self.pkgsend_bulk(
+            self.rurl, (self.renamenew1, self.renamenew2, self.renamenew3)
+        )
+        self.image_create(self.rurl)
+
+        # If there are no local modifications, no preservation should be
+        # done.  First with no content change ...
+        self.pkg("{0} rennew@1".format(install_cmd))
+        self.pkg("{0} --parsable=0 rennew@2".format(install_cmd))
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", "rennew1")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.old")
+        self.pkg("verify rennew")
+        self.pkg("uninstall rennew")
+
+        # ... and again with content change
+        self.pkg("{0} rennew@1".format(install_cmd))
+        self.pkg("{0} --parsable=0 rennew@3".format(install_cmd))
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", "rennew3")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.old")
+        self.pkg("verify rennew")
+        self.pkg("uninstall rennew")
+
+        # Modify the file locally and update to a version where the
+        # content changes.
+        self.pkg("{0} rennew@1".format(install_cmd))
+        self.file_append("testme", "junk")
+        self.pkg("{0} --parsable=0 rennew@3".format(install_cmd))
+        self._assertEditables(
+            installed=["testme.new"],
+        )
+        self.file_contains("testme", "junk")
+        self.file_doesnt_contain("testme.new", "junk")
+        self.file_contains("testme.new", "rennew3")
+        self.dest_file_valid(plist, "rennew@3.0", "testme", "testme.new")
+        self.file_doesnt_exist("testme.old")
+        self.pkg("verify rennew")
+        self.pkg("uninstall rennew")
+
+        # Modify the file locally and update to a version where just the
+        # mode changes.
+        self.pkg("{0} rennew@1".format(install_cmd))
+        self.file_append("testme", "junk")
+        self.pkg("{0} --parsable=0 rennew@2".format(install_cmd))
+        self._assertEditables(
+            installed=["testme.new"],
+        )
+        self.file_contains("testme", "junk")
+        self.file_doesnt_contain("testme.new", "junk")
+        self.file_contains("testme.new", "rennew1")
+        self.file_doesnt_exist("testme.old")
+
+        # The original file won't be touched on update, so verify fails.
+        self.pkg("verify rennew", exit=1)
+
+        # Ensure that after fixing mode, verify passes.
+        self.file_chmod("testme", 0o640)
+        self.pkg("verify rennew")
+        self.pkg("uninstall rennew")
+        self.file_remove("testme.new")
+
+        # Remove the file locally and update the package; this should
+        # simply replace the missing file.
+        self.pkg("{0} rennew@1".format(install_cmd))
+        self.file_remove("testme")
+        self.pkg("{0} --parsable=0 rennew@2".format(install_cmd))
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.old")
+        self.pkg("verify rennew")
+        self.pkg("uninstall rennew")
+
+    def test_file_preserve_legacy(self):
+        """Verify that preserve=legacy works as expected."""
+
+        install_cmd = "install"
+        self.pkgsend_bulk(self.rurl, (self.preslegacy, self.renpreslegacy))
+        self.image_create(self.rurl)
+
+        # Ensure directory is empty before testing.
+        api_inst = self.get_img_api_obj()
+        img_inst = api_inst.img
+        sroot = os.path.join(img_inst.imgdir, "lost+found")
+        shutil.rmtree(sroot)
+
+        # Verify that unpackaged files will be salvaged on initial
+        # install if a package being installed delivers the same file
+        # and that the new file will be installed.
+        self.file_append("testme", "unpackaged")
+        self.pkg("{0} --parsable=0 preslegacy@1.0".format(install_cmd))
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_contains("testme", "preserve1")
+        self.__salvage_file_contains(sroot, "testme", "unpackaged")
+        shutil.rmtree(sroot)
+
+        # Verify that a package transitioning to preserve=legacy from
+        # some other state will have the existing file renamed using
+        # .legacy as an extension.
+        self.pkg("update --parsable=0 preslegacy@2.0")
+        self._assertEditables(
+            moved=[["testme", "testme.legacy"]],
+            installed=["testme"],
+        )
+        self.file_contains("testme.legacy", "preserve1")
+        self.file_contains("testme", "preserve2")
+
+        # Verify that if an action with preserve=legacy is upgraded
+        # and its payload changes that the new payload is delivered
+        # but the old .legacy file is not modified.
+        self.pkg("update --parsable=0 preslegacy@3.0")
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme.legacy", "preserve1")
+        self.file_contains("testme", "preserve3")
+
+        # Verify that if the file for an action marked with
+        # preserve=legacy is removed that the package still
+        # verifies.
+        self.file_remove("testme")
+        self.pkg("verify -v preslegacy")
+
+        # Verify that a file removed for an action marked with
+        # preserve=legacy can be reverted.
+        self.pkg("revert testme")
+        self.file_contains("testme", "preserve3")
+
+        # Verify that an initial install of an action with
+        # preserve=legacy will not install the payload of the action.
+        self.pkg("uninstall preslegacy")
+        self.pkg("{0} --parsable=0 preslegacy@3.0".format(install_cmd))
+        self._assertEditables()
+        self.file_doesnt_exist("testme")
+
+        # Verify that if the original preserved file is missing during
+        # a transition to preserve=legacy from some other state that
+        # the new action is still delivered and the operation succeeds.
+        self.pkg("uninstall preslegacy")
+        self.pkg("{0} --parsable=0 preslegacy@1.0".format(install_cmd))
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_remove("testme")
+        self.pkg("update --parsable=0")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_contains("testme", "preserve3")
+
+        # Verify that a preserved file can be moved from one package to
+        # another and transition to preserve=legacy at the same time.
+        self.pkg("uninstall preslegacy")
+        self.pkg("{0} --parsable=0 orig_preslegacy@1.0".format(install_cmd))
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_exists("testme")
+        self.pkg("update --parsable=0")
+        self._assertEditables(
+            moved=[["testme", "newme.legacy"]],
+            installed=["newme"],
+        )
+        self.file_contains("testme.legacy", "preserve1")
+        self.file_contains("newme", "preserve2")
+
+    def test_file_preserve_abandon(self):
+        """Verify that preserve=abandon works as expected."""
+
+        install_cmd = "install"
+        self.pkgsend_bulk(self.rurl, self.presabandon)
+        self.image_create(self.rurl)
+
+        # Ensure directory is empty before testing.
+        api_inst = self.get_img_api_obj()
+        img_inst = api_inst.img
+        sroot = os.path.join(img_inst.imgdir, "lost+found")
+        shutil.rmtree(sroot)
+
+        # Verify that unpackaged files will not be salvaged on initial
+        # install if a package being installed delivers the same file
+        # and that the new file will not be installed.
+        self.file_append("testme", "unpackaged")
+        self.pkg("{0} --parsable=0 presabandon@2".format(install_cmd))
+        self._assertEditables()
+        self.file_contains("testme", "unpackaged")
+        self.assertTrue(not os.path.exists(os.path.join(sroot, "testme")))
+        self.file_remove("testme")
+        self.pkg("uninstall presabandon")
+
+        # Verify that an initial install of an action with
+        # preserve=abandon will not install the payload of the action.
+        self.pkg("{0} --parsable=0 presabandon@2".format(install_cmd))
+        self._assertEditables()
+        self.file_doesnt_exist("testme")
+        self.pkg("uninstall presabandon")
+
+        # If an action delivered by the upgraded version of the package
+        # has a preserve=abandon, the new file will not be installed and
+        # the existing file will not be modified.
+
+        # First with no content change ...
+        self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.pkg("update --parsable=0 presabandon@2")
+        self._assertEditables()
+        self.file_contains("testme", "preserve1")
+        # The currently installed version of the package has a preserve
+        # value of abandon, so the file will not be removed.
+        self.pkg("uninstall --parsable=0 presabandon")
+        self._assertEditables()
+        self.file_exists("testme")
+
+        # If an action delivered by the downgraded version of the package
+        # has a preserve=abandon, the new file will not be installed and
+        # the existing file will not be modified.
+        self.pkg("{0} --parsable=0 presabandon@4".format(install_cmd))
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_contains("testme", "preserve3")
+        self.pkg("verify presabandon")
+        self.pkg("update --parsable=0 presabandon@3")
+        self._assertEditables()
+        self.file_contains("testme", "preserve3")
+        self.pkg("verify presabandon")
+        self.pkg("uninstall --parsable=0 presabandon")
+        self.file_remove("testme")
+
+        # ... and again with content change.
+        self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
+        self.pkg("{0} --parsable=0 presabandon@3".format(install_cmd))
+        self._assertEditables()
+        self.file_contains("testme", "preserve1")
+        self.pkg("uninstall --parsable=0 presabandon")
+
+        self.pkg("install --parsable=0 presabandon@4")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_contains("testme", "preserve3")
+        self.pkg("update --parsable=0 presabandon@2")
+        self._assertEditables()
+        self.file_contains("testme", "preserve3")
+        self.pkg("verify presabandon")
+        self.pkg("uninstall --parsable=0 presabandon")
+        self.file_remove("testme")
+
+        # Modify the file locally and upgrade to a version where the
+        # file has a preserve=abandon attribute and the content changes.
+        self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
+        self.file_append("testme", "junk")
+        self.pkg("{0} --parsable=0 presabandon@3".format(install_cmd))
+        self._assertEditables()
+        self.file_contains("testme", "preserve1")
+        self.file_contains("testme", "junk")
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.pkg("uninstall --parsable=0 presabandon")
+        self.file_remove("testme")
+
+        # Modify the file locally and downgrade to a version where the
+        # file has a preserve=abandon attribute and the content changes.
+        self.pkg("{0} --parsable=0 presabandon@4".format(install_cmd))
+        self.file_append("testme", "junk")
+        self.file_contains("testme", "preserve3")
+        self.pkg("update --parsable=0 presabandon@2")
+        self._assertEditables()
+        self.file_contains("testme", "preserve3")
+        self.file_contains("testme", "junk")
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.update")
+        self.pkg("verify presabandon")
+        self.pkg("uninstall --parsable=0 presabandon")
+        self.file_remove("testme")
+
+        # Modify the file locally and upgrade to a version where the
+        # file has a preserve=abandon attribute and just the mode changes.
+        self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
+        self.file_append("testme", "junk")
+        self.pkg("{0} --parsable=0 presabandon@2".format(install_cmd))
+        self._assertEditables()
+        self.file_contains("testme", "preserve1")
+        self.file_contains("testme", "junk")
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.pkg("verify presabandon")
+        self.pkg("uninstall --parsable=0 presabandon")
+        self.file_remove("testme")
+
+        # Modify the file locally and downgrade to a version where the
+        # file has a preserve=abandon attribute and just the mode changes.
+        self.pkg("{0} --parsable=0 presabandon@4".format(install_cmd))
+        self.file_append("testme", "junk")
+        self.pkg("update --parsable=0 presabandon@3")
+        self._assertEditables()
+        self.file_contains("testme", "preserve3")
+        self.file_contains("testme", "junk")
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.update")
+        self.pkg("verify presabandon")
+        self.pkg("uninstall --parsable=0 presabandon")
+        self.file_remove("testme")
+
+        # Remove the file locally and update the package where the
+        # file has a preserve=abandon attribute; this will not replace
+        # the missing file.
+        self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
+        self.file_remove("testme")
+        self.pkg("{0} --parsable=0 presabandon@2".format(install_cmd))
+        self._assertEditables()
+        self.file_doesnt_exist("testme")
+        self.pkg("uninstall --parsable=0 presabandon")
+
+        # Remove the file locally and downgrade the package where the
+        # file has a preserve=abandon attribute; this will not replace
+        # the missing file.
+        self.pkg("{0} --parsable=0 presabandon@4".format(install_cmd))
+        self.file_remove("testme")
+        self.pkg("update --parsable=0 presabandon@3")
+        self._assertEditables()
+
+        # Verify that a package with a missing file that is marked with
+        # the preserve=abandon won't cause uninstall failure.
+        self.file_doesnt_exist("testme")
+        self.pkg("uninstall --parsable=0 presabandon")
+
+        # Verify that if the file for an action marked with
+        # preserve=abandon is removed that the package still
+        # verifies.
+        self.pkg("{0} --parsable=0 presabandon@1".format(install_cmd))
+        self.pkg("{0} --parsable=0 presabandon@2".format(install_cmd))
+        self.file_remove("testme")
+        self.pkg("verify -v presabandon")
+
+        # Verify that a file removed for an action marked with
+        # preserve=abandon can be reverted.
+        # self.pkg("revert testme")
+        # self.file_contains("testme", "preserve1")
+
+    def test_file_preserve_install_only(self):
+        """Verify that preserve=install-only works as expected."""
+
+        self.pkgsend_bulk(self.rurl, self.presinstallonly)
+        self.image_create(self.rurl)
+
+        # Ensure directory is empty before testing.
+        api_inst = self.get_img_api_obj()
+        img_inst = api_inst.img
+        sroot = os.path.join(img_inst.imgdir, "lost+found")
+        shutil.rmtree(sroot)
+
+        # Verify that unpackaged files will not be modified or salvaged
+        # on initial install if a package being installed delivers the
+        # same file and that the new file will not be installed.
+        self.file_append("testme", "unpackaged")
+        self.pkg("install --parsable=0 presinstallonly@2")
+        self._assertEditables()
+        self.file_contains("testme", "unpackaged")
+        self.assertTrue(not os.path.exists(os.path.join(sroot, "testme")))
+        # Verify uninstall of the package will not remove the file.
+        self.pkg("uninstall presinstallonly")
+        self.file_exists("testme")
+        self.file_remove("testme")
+
+        # Verify that an initial install of an action with
+        # preserve=install-only will install the payload of the action
+        # if the file does not already exist.
+        self.file_doesnt_exist("testme")
+        self.pkg("install --parsable=0 presinstallonly@2")
+        self._assertEditables(installed=["testme"])
+        self.file_exists("testme")
+        self.pkg("uninstall presinstallonly")
+        self.file_remove("testme")
+
+        # Verify that an upgrade that initially delivers the action will
+        # install it.
+        self.pkg("install --parsable=0 presinstallonly@0")
+        self._assertEditables()
+        self.file_doesnt_exist("testme")
+        self.pkg("install --parsable=0 presinstallonly@2")
+        self._assertEditables(installed=["testme"])
+        self.file_exists("testme")
+        self.pkg("uninstall presinstallonly")
+        self.file_remove("testme")
+
+        # If an action delivered by the upgraded version of the package
+        # has a preserve=install-only, the new file will not be
+        # installed and the existing file will not have its content
+        # modified (the mode is being updated though).
+
+        # First with no content change ...
+        self.pkg("install --parsable=0 presinstallonly@1")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.pkg("update --parsable=0 presinstallonly@2")
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", "preserve1")
+        # The currently installed version of the package has a preserve
+        # value of install-only, so the file will not be removed.
+        self.pkg("uninstall --parsable=0 presinstallonly")
+        self._assertEditables()
+        self.file_exists("testme")
+        self.file_remove("testme")
+
+        # If an action delivered by the downgraded version of the
+        # package has a preserve=install-only, the new file will not be
+        # installed and the existing file will not be modified.
+        self.pkg("install --parsable=0 presinstallonly@4")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_contains("testme", "preserve3")
+        self.pkg("verify presinstallonly")
+        self.pkg("update --parsable=0 presinstallonly@3")
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", "preserve3")
+        self.pkg("verify presinstallonly")
+        self.pkg("uninstall --parsable=0 presinstallonly")
+        self.file_remove("testme")
+
+        # ... and again with content change.
+        self.pkg("install --parsable=0 presinstallonly@1")
+        self.pkg("install --parsable=0 presinstallonly@3")
+        self._assertEditables()
+        self.file_contains("testme", "preserve1")
+        self.pkg("uninstall --parsable=0 presinstallonly")
+        self.file_remove("testme")
+
+        self.pkg("install --parsable=0 presinstallonly@4")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_contains("testme", "preserve3")
+        self.pkg("update --parsable=0 presinstallonly@2")
+        self._assertEditables()
+        self.file_contains("testme", "preserve3")
+        self.pkg("verify presinstallonly")
+        self.pkg("uninstall --parsable=0 presinstallonly")
+        self.file_remove("testme")
+
+        # Modify the file locally and upgrade to a version where the
+        # file has a preserve=install-only attribute and the content
+        # changes; it should not be modified.
+        self.pkg("install --parsable=0 presinstallonly@1")
+        self.file_append("testme", "junk")
+        self.pkg("install --parsable=0 presinstallonly@3")
+        self._assertEditables()
+        self.file_contains("testme", "preserve1")
+        self.file_contains("testme", "junk")
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.pkg("uninstall --parsable=0 presinstallonly")
+        self.file_remove("testme")
+
+        # Modify the file locally and downgrade to a version where the
+        # file has a preserve=install-only attribute and the content
+        # changes.
+        self.pkg("install --parsable=0 presinstallonly@4")
+        self.file_append("testme", "junk")
+        self.pkg("update --parsable=0 presinstallonly@2")
+        self._assertEditables()
+        self.file_contains("testme", "preserve3")
+        self.file_contains("testme", "junk")
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.update")
+        self.pkg("verify presinstallonly")
+        self.pkg("uninstall --parsable=0 presinstallonly")
+        self.file_remove("testme")
+
+        # Modify the file locally and upgrade to a version where the
+        # file has a preserve=install-only attribute and just the mode
+        # changes.
+        self.pkg("install --parsable=0 presinstallonly@1")
+        self.file_append("testme", "junk")
+        self.pkg("install --parsable=0 presinstallonly@2")
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", "preserve1")
+        self.file_contains("testme", "junk")
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.pkg("verify presinstallonly")
+        self.pkg("uninstall --parsable=0 presinstallonly")
+        self.file_remove("testme")
+
+        # Modify the file locally and downgrade to a version where the
+        # file has a preserve=install-only attribute and just the mode
+        # changes.
+        self.pkg("install --parsable=0 presinstallonly@4")
+        self.file_append("testme", "junk")
+        self.pkg("update --parsable=0 presinstallonly@3")
+        self._assertEditables(
+            updated=["testme"],
+        )
+        self.file_contains("testme", "preserve3")
+        self.file_contains("testme", "junk")
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.update")
+        self.pkg("verify presinstallonly")
+        self.pkg("uninstall --parsable=0 presinstallonly")
+        self.file_remove("testme")
+
+        # Remove the file locally and update the package where the file
+        # has a preserve=install-only attribute; this will not replace
+        # the missing file.
+        self.pkg("install --parsable=0 presinstallonly@1")
+        self.file_remove("testme")
+        self.pkg("install --parsable=0 presinstallonly@2")
+        self._assertEditables()
+        self.file_doesnt_exist("testme")
+        self.pkg("uninstall --parsable=0 presinstallonly")
+
+        # Remove the file locally and downgrade the package where the
+        # file has a preserve=install-only attribute; this will not
+        # replace the missing file.
+        self.pkg("install --parsable=0 presinstallonly@4")
+        self.file_remove("testme")
+        self.pkg("update --parsable=0 presinstallonly@3")
+        self._assertEditables()
+        self.file_doesnt_exist("testme")
+
+        # Verify that a package with a missing file that is marked with
+        # the preserve=install-only won't cause uninstall failure.
+        self.file_doesnt_exist("testme")
+        self.pkg("uninstall --parsable=0 presinstallonly")
+
+        # Verify that if the file for an action marked with
+        # preserve=install-only is removed that the package fails
+        # verify.
+        self.pkg("install --parsable=0 presinstallonly@1")
+        self.pkg("install --parsable=0 presinstallonly@2")
+        self.file_remove("testme")
+        self.pkg("verify -v presinstallonly", exit=1)
+
+        # Verify that fix will restore it.
+        self.pkg("fix -v presinstallonly")
+        self.file_contains("testme", "preserve1")
+
+        # Verify that a file removed for an action marked with
+        # preserve=install-only can be reverted.
+        self.file_remove("testme")
+        self.pkg("revert testme")
+        self.file_contains("testme", "preserve1")
+
+    def test_file_preserve_version(self):
+        """Verify that file preserve-version works as expected
+        during pkg install, update, upgrade, and removal."""
+
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.preserve_version_1,
+                self.preserve_version_2,
+                self.preserve_version_3,
+                self.preserve_version_4,
+            ),
+        )
+        self.image_create(self.rurl)
+
+        # If file preserve_version is less than the
+        # installed preserve_version, the installed file
+        # will be renamed with '.update' and the proposed file
+        # will be installed.
+        # (orig_preserve_ver = 1.0, preserve_ver = 0.1)
+        self.pkg("install --parsable=0 preserve_version@4")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_append("testme", "junk")
+        self.pkg("install --parsable=0 preserve_version@3")
+        self._assertEditables(
+            moved=[["testme", "testme.update"]],
+            installed=["testme"],
+        )
+
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_exists("testme.update")
+
+        self.file_contains("testme.update", "preserve_version_4")
+        self.file_contains("testme.update", "junk")
+
+        self.file_contains("testme", "preserve_version_3")
+        self.file_doesnt_contain("testme", "junk")
+
+        self.file_remove("testme.update")
+
+        self.pkg("verify preserve_version")
+
+        self.pkg("uninstall --parsable=0 preserve_version")
+
+        # If file preserve_version is equal to the
+        # proposed preserve_version, the installed file
+        # content is not modified (but the owner, group, and
+        # permissions are updated).
+        # (orig_preserve_ver = 1.0, preserve_ver = 1.0)
+        self.pkg("install --parsable=0 preserve_version@4")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_chmod("testme", 0o777)
+        self.file_chown("testme", "nobody", "nobody")
+        self.file_append("testme", "junk")
+        self.pkg("install --parsable=0 preserve_version@2")
+        self._assertEditables()
+
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.update")
+        self.file_exists("testme", 0o644, "root", "root")
+
+        self.file_contains("testme", "preserve_version_4")
+        self.file_contains("testme", "junk")
+
+        self.pkg("verify preserve_version")
+
+        self.pkg("uninstall --parsable=0 preserve_version")
+
+        # If file preserve_version is greater than the
+        # installed preserve_version, the installed file
+        # content is not modified (but the owner, group, and
+        # permissions are updated).
+        # (orig_preserve_ver = 1.0, preserve_ver = 2.0)
+        self.pkg("install --parsable=0 preserve_version@4")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_chmod("testme", 0o777)
+        self.file_chown("testme", "nobody", "nobody")
+        self.file_append("testme", "junk")
+        self.pkg("install --parsable=0 preserve_version@1")
+        self._assertEditables()
+
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.update")
+        self.file_exists("testme", 0o644, "root", "root")
+
+        self.file_contains("testme", "preserve_version_4")
+        self.file_contains("testme", "junk")
+
+        self.pkg("verify preserve_version")
+
+        self.pkg("uninstall --parsable=0 preserve_version")
+
+    def test_file_preserve_version_defined(self):
+        """Verify that file preserve-version works as expected
+        during pkg install, update, upgrade, and removal for a file
+        that did not initially define a preserve-version."""
+
+        self.pkgsend_bulk(self.rurl, (self.no_pres_ver_1, self.no_pres_ver_2))
+        self.image_create(self.rurl)
+
+        self.pkg("install --parsable=0 no_pres_ver@2")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_append("testme", "junk")
+        self.pkg("install --parsable=0 no_pres_ver@1")
+        self._assertEditables()
+
+        self.file_contains("testme", "no_pres_ver_2")
+        self.file_contains("testme", "junk")
+
+        self.pkg("verify no_pres_ver")
+
+        self.pkg("uninstall --parsable=0 no_pres_ver")
+
+    def test_file_preserve_version_undefined(self):
+        """Verify that file preserve-version works as expected
+        during pkg install, update, upgrade, and removal for a file
+        that no longer defines a preserve-version."""
+
+        self.pkgsend_bulk(self.rurl, (self.add_pres_ver_1, self.add_pres_ver_2))
+        self.image_create(self.rurl)
+
+        self.pkg("install --parsable=0 add_pres_ver@2")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_append("testme", "junk")
+        self.pkg("install --parsable=0 add_pres_ver@1")
+        self._assertEditables(
+            moved=[["testme", "testme.update"]],
+            installed=["testme"],
+        )
+
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_exists("testme.update")
+
+        self.file_contains("testme.update", "add_pres_ver_2")
+        self.file_contains("testme.update", "junk")
+
+        self.file_contains("testme", "add_pres_ver_1")
+        self.file_doesnt_contain("testme", "junk")
+
+        self.pkg("verify add_pres_ver")
+
+        self.pkg("uninstall --parsable=0 add_pres_ver")
+
+    def test_file_preserve_version_overlay(self):
+        """Verify that file preserve-version works as expected
+        when the file specifies overlay=allow."""
+
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.preserve_version_1,
+                self.pres_ver_overlay_1,
+                self.pres_ver_overlay_2,
+            ),
+        )
+        self.image_create(self.rurl)
+
+        # Install an overlaying package that does not specify a
+        # preserve-version and verify that the file gets replaced
+        # as expected.
+        # (orig_preserve_ver = 2.0, preserve_ver = 0)
+        self.pkg("install --parsable=0 preserve_version@1")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.pkg("install --parsable=0 pres_ver_overlay@1")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.update")
+
+        self.file_contains("testme", "pres_ver_overlay_1")
+        self.file_doesnt_contain("testme", "preserve_version")
+
+        self.pkg("verify preserve_version")
+
+        self.pkg("uninstall --parsable=0 preserve_version")
+        self.pkg("uninstall --parsable=0 pres_ver_overlay")
+
+        # Install an overlaying package that specifies a downgraded
+        # preserve-version and verify that the file gets replaced
+        # as expected.
+        # (orig_preserve_ver = 2.0, preserve_ver = 1.0)
+        self.pkg("install --parsable=0 preserve_version@1")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.pkg("install --parsable=0 pres_ver_overlay@2")
+        self._assertEditables(
+            installed=["testme"],
+        )
+        self.file_doesnt_exist("testme.old")
+        self.file_doesnt_exist("testme.new")
+        self.file_doesnt_exist("testme.update")
+
+        self.file_contains("testme", "pres_ver_overlay_2")
+        self.file_doesnt_contain("testme", "preserve_version")
+
+        self.pkg("verify preserve_version")
+
+        self.pkg("uninstall --parsable=0 preserve_version")
+        self.pkg("uninstall --parsable=0 pres_ver_overlay")
+
+    def test_link_preserve_true(self):
+        """Verify that preserve=true for a link works as expected."""
+
+        self.pkgsend_bulk(self.rurl, self.preslink)
+        self.image_create(self.rurl)
+
+        # Install the package
+        self.pkg("install --parsable=0 preslink@1")
+        # self.image_walk()
+        self.link_exists("testlink", target="test1")
+        self.link_exists("link", target="test1")
+        self.pkg("verify preslink")
+
+        # Check that if no changes are made to the installed link
+        # which has preserve=true, then it will be updated on package
+        # update when its target changes.
+        self.pkg("update --parsable=0 preslink@3")
+        self.link_exists("testlink", target="test2")
+
+        self.pkg("uninstall --parsable=0 preslink")
+        self.pkg("install --parsable=0 preslink@1")
+
+        # Remove the link and test that an upgrade does not restore it
+        # where the link action has not changed in the package.
+        self.file_remove("testlink")
+        self.pkg("update --parsable=0 preslink@2")
+        self.file_doesnt_exist("testlink")
+        # that a verify succeeds
+        self.pkg("verify preslink")
+        # and that a fix does not restore the link
+        # (exit status 4 is nothing-to-do)
+        self.pkg("fix preslink", exit=4)
+        self.file_doesnt_exist("testlink")
+
+        # and where the link action has changed
+        self.file_remove("link")
+        self.pkg("update --parsable=0 preslink@3")
+        self.file_doesnt_exist("testlink")
+        # but 'link' should have come back
+        self.link_exists("link", target="test2")
+        # that a verify succeeds
+        self.pkg("verify preslink")
+        # and that a fix does not restore the link
+        self.pkg("fix preslink", exit=4)
+        self.file_doesnt_exist("testlink")
+
+        self.pkg("uninstall preslink")
+
+        # Test that a preserved link which has been changed is not
+        # replaced during upgrade
+        self.pkg("install preslink@1")
+        # Change the link
+        self.file_remove("testlink")
+        os.symlink(f"bobcat", f"{self.get_img_path()}/testlink")
+        self.link_exists("testlink", target="bobcat")
+        # a verify should still succeed
+        self.pkg("verify preslink")
+        # and a fix should not restore the link
+        self.pkg("fix preslink", exit=4)
+        self.link_exists("testlink", target="bobcat")
+
+        # Upgrade to a package with the same link action
+        self.pkg("update --parsable=0 preslink@2")
+        self.link_exists("testlink", target="bobcat")
+        # that a verify succeeds
+        self.pkg("verify preslink")
+        # and that a fix does not restore the link
+        self.pkg("fix preslink", exit=4)
+        self.link_exists("testlink", target="bobcat")
+
+        # and to one which changes the action
+        self.file_remove("link")
+        os.symlink(f"bobcat", f"{self.get_img_path()}/link")
+        self.link_exists("link", target="bobcat")
+        self.pkg("update --parsable=0 preslink@3")
+        self.link_exists("testlink", target="bobcat")
+        self.link_exists("link", target="test2")
+        # that a verify succeeds
+        self.pkg("verify preslink")
+        # and that a fix does not restore the link
+        self.pkg("fix preslink", exit=4)
+        self.link_exists("testlink", target="bobcat")
+
+        # verify that an uninstall removes the link
+        self.pkg("uninstall --parsable=0 preslink")
+        self.file_doesnt_exist("testlink")
+        self.file_doesnt_exist("link")
+
+    def test_directory_salvage(self):
+        """Make sure basic directory salvage works as expected"""
+
+        self.pkgsend_bulk(self.rurl, self.salvage)
+        self.image_create(self.rurl)
+        self.pkg("install salvage@1.0")
+        self.file_append("var/mail/foo", "foo's mail")
+        self.file_append("var/mail/bar", "bar's mail")
+        self.file_append("var/mail/baz", "baz's mail")
+        self.pkg("update salvage")
+        self.file_exists("var/.migrate-to-shared/mail/foo")
+        self.file_exists("var/.migrate-to-shared/mail/bar")
+        self.file_exists("var/.migrate-to-shared/mail/baz")
+
+    def test_directory_salvage_persistent(self):
+        """Make sure directory salvage works as expected when salvaging
+        content to an existing packaged directory."""
+
+        # we salvage content from two directories,
+        # var/noodles and var/spaghetti each of which disappear over
+        # subsequent updates.
+        self.pkgsend_bulk(self.rurl, self.salvage)
+        self.image_create(self.rurl)
+        self.pkg("install salvage@1.0")
+        self.file_append("var/mail/foo", "foo's mail")
+        self.file_append("var/noodles/noodles.txt", "yum")
+        self.pkg("update salvage@2.0")
+        self.file_exists("var/.migrate-to-shared/mail/foo")
+        self.file_exists("var/persistent/noodles.txt")
+        self.file_append("var/spaghetti/spaghetti.txt", "yum")
+        self.pkg("update")
+        self.file_exists("var/persistent/noodles.txt")
+        self.file_exists("var/persistent/spaghetti.txt")
+
+        # ensure that we can jump from 1.0 to 3.0 directly.
+        self.image_create(self.rurl)
+        self.pkg("install salvage@1.0")
+        self.file_append("var/noodles/noodles.txt", "yum")
+        self.pkg("update  salvage@3.0")
+        self.file_exists("var/persistent/noodles.txt")
+
+    def test_special_salvage(self):
+        """Make sure salvaging directories with special files works as
+        expected."""
+
+        self.pkgsend_bulk(self.rurl, self.salvage_special)
+        self.image_create(self.rurl, destroy=True, fs=("var",))
+
+        self.pkg("install salvage-special")
+
+        os.mkfifo(os.path.join(self.img_path(), "salvage", "fifo"))
+        sock = socket.socket(socket.AF_UNIX)
+        sock.bind(os.path.join(self.img_path(), "salvage", "socket"))
+        sock.close()
+
+        # This could hang reading fifo, or keel over reading socket.
+        self.pkg("uninstall salvage-special")
+
+    def test_salvage_nested(self):
+        """Make sure salvaging from nested packaged directories
+        works as expected. We test four scenarios, abandoning an
+        editable file (since that's a scenario ON will use for
+        23743369), a direct upgrade with no user edits,
+        salvaging all unpackaged contents despite nested dirs
+        not being delivered to var/.migrate, and splitting the
+        salvaged contents of a previously delivered directory to
+        two new directories."""
+
+        # We salvage to several places as part of the upgrade
+        # operation.
+        self.pkgsend_bulk(self.rurl, self.salvage_nested)
+        self.image_create(self.rurl)
+        self.pkg("install salvage-nested@1.0")
+        # add some unpackaged directories & contents
+        self.file_append("var/mail/foo", "foo's mail")
+        os.makedirs(
+            os.path.join(self.get_img_path(), "var", "user", "webui", "timf")
+        )
+        self.file_append("var/user/webui/user-pref.conf", "ook")
+        self.file_append("var/user/webui/timf/blah.conf", "moo")
+        self.file_append("var/user/evsuser/.ssh/config", "bar")
+
+        # modify a packaged editable file
+        self.file_append("var/user/evsuser/.ssh/authorized_keys", "foo")
+
+        # abandon our editable file
+        self.pkg("update salvage-nested@1.1")
+        self.file_exists("var/user/evsuser/.ssh/authorized_keys")
+
+        self.pkg("update salvage-nested@2.0")
+        # Check negative cases first. This first location was where
+        # files would get salvaged to incorrectly prior to the fix
+        # for 23739095
+        self.file_doesnt_exist("var/.migrate/user/authorized_keys")
+        # these weren't known failures, but let's check anyway,
+        # since this is a useful safety net.
+        self.file_doesnt_exist("var/.migrate/authorized_keys")
+        self.file_doesnt_exist("var/.migrate/user/evsuser/authorized_keys")
+        self.file_doesnt_exist("var/.migrate/user/evsuser/config")
+        self.file_doesnt_exist("var/.migrate/blah.conf")
+        self.file_doesnt_exist("var/.migrate/user/blah.conf")
+        self.file_doesnt_exist("var/.migrate/user/webui/blah.conf")
+
+        # now verify we salvaged everything correctly
+        self.file_contains("var/.migrate/mail/foo", "foo's mail")
+        self.file_contains(
+            "var/.migrate/user/evsuser/.ssh/authorized_keys", "foo"
+        )
+        self.file_contains("var/.migrate/user/evsuser/.ssh/config", "bar")
+        self.file_contains("var/.migrate/user/webui/user-pref.conf", "ook")
+        self.file_contains("var/.migrate/user/webui/timf/blah.conf", "moo")
+
+        # now try without the initial non-editable file
+        self.image_create(self.rurl)
+        self.pkg("install salvage-nested@1.1")
+        # an abandoned file shouldn't be installed
+        self.file_doesnt_exist("var/user/evsuser/.ssh/authorized_keys")
+        self.file_append("var/user/evsuser/.ssh/authorized_keys", "ook")
+        self.pkg("update salvage-nested@2.0")
+        self.file_contains(
+            "var/.migrate/user/evsuser/.ssh/authorized_keys", "ook"
+        )
+
+        # now try with no user edits
+        self.image_create(self.rurl)
+        self.pkg("install salvage-nested@1.1")
+        self.pkg("update salvage-nested@2.0")
+        self.file_doesnt_exist("var/.migrate/user/evsuser/.ssh/authorized_keys")
+        self.dir_exists("var/.migrate/user/evsuser/.ssh")
+
+        # Now try without delivering the evsuser dir and subdirs
+        # in the updated package
+        self.image_create(self.rurl)
+        self.pkg("install salvage-nested@1.1")
+        os.makedirs(
+            os.path.join(self.get_img_path(), "var", "user", "webui", "timf")
+        )
+        os.makedirs(os.path.join(self.get_img_path(), "var", "user", "noodles"))
+        self.file_append("var/user/webui/timf/user-pref.conf", "ook")
+        self.file_append("var/user/noodles/blah.conf", "moo")
+        self.file_append("var/user/evsuser/.ssh/config", "bar")
+        self.pkg("update salvage-nested@3.0")
+        self.file_contains("var/.migrate/user/evsuser/.ssh/config", "bar")
+        self.file_contains("var/.migrate/user/webui/timf/user-pref.conf", "ook")
+        self.file_contains("var/.migrate/user/noodles/blah.conf", "moo")
+
+        # Finally try splitting the salvaged contents from a
+        # previously delivered directory into two new directories.
+        self.image_create(self.rurl)
+        self.pkg("install salvage-nested@1.1")
+        os.makedirs(
+            os.path.join(self.get_img_path(), "var", "user", "webui", "timf")
+        )
+        os.makedirs(os.path.join(self.get_img_path(), "var", "user", "noodles"))
+        self.file_append("var/user/webui/timf/user-pref.conf", "ook")
+        self.file_append("var/user/noodles/blah.conf", "moo")
+        self.file_append("var/user/evsuser/.ssh/config", "bar")
+        self.pkg("update salvage-nested@4.0")
+        self.file_contains("var/.migrate/evsuser/.ssh/config", "bar")
+        self.file_contains("var/.migrate/user/webui/timf/user-pref.conf", "ook")
+        self.file_contains("var/.migrate/user/noodles/blah.conf", "moo")
+
+    def dest_file_valid(self, plist, pkg, src, dest):
+        """Used to verify that the dest item's mode, attrs, timestamp,
+        etc. match the src items's matching action as expected."""
+
+        for p in plist:
+            pfmri = fmri.PkgFmri(p)
+            pfmri.publisher = None
+            sfmri = pfmri.get_short_fmri().replace("pkg:/", "")
+
+            if pkg != sfmri:
+                continue
+
+            m = manifest.Manifest()
+            m.set_content(self.get_img_manifest(pfmri))
+            for a in m.gen_actions():
+                if a.name != "file":
+                    # Only want file actions that have
+                    # preserve attribute.
+                    continue
+                if a.attrs["path"] != src:
+                    # Only want actions with matching path.
+                    continue
+                self.validate_fsobj_attrs(a, target=dest)
+
+    def test_link_preserve(self):
+        """Ensure that files transitioning to a link still follow
+        original_name preservation rules."""
+
+        self.pkgsend_bulk(self.rurl, (self.linkpreserve))
+        self.image_create(self.rurl, destroy=True, fs=("var",))
+
+        # Install package with original config file location.
+        self.pkg("install --parsable=0 linkpreserve@1.0")
+        cfg_path = os.path.join("etc", "ssh", "sshd_config")
+        abs_path = os.path.join(self.get_img_path(), cfg_path)
+
+        self.file_exists(cfg_path)
+        self.assertTrue(not os.path.islink(abs_path))
+
+        # Modify the file.
+        self.file_append(cfg_path, "modified")
+
+        # Install new package version, verify file replaced with link
+        # and modified version was moved to new location.
+        new_cfg_path = os.path.join("etc", "sunssh", "sshd_config")
+        self.pkg("update --parsable=0 linkpreserve@2.0")
+        self._assertEditables(
+            moved=[["etc/ssh/sshd_config", "etc/sunssh/sshd_config"]]
+        )
+        self.assertTrue(os.path.islink(abs_path))
+        self.file_exists(new_cfg_path)
+        self.file_contains(new_cfg_path, "modified")
+
+        # Uninstall, then install original version again.
+        self.pkg("uninstall linkpreserve")
+        self.pkg("install linkpreserve@1.0")
+        self.file_contains(cfg_path, "preserve1")
+
+        # Install new package version and verify that unmodified file is
+        # replaced with new configuration file.
+        self.pkg("update --parsable=0 linkpreserve@2.0")
+        self._assertEditables(
+            moved=[["etc/ssh/sshd_config", "etc/sunssh/sshd_config"]]
+        )
+        self.file_contains(new_cfg_path, "preserve2")
+
+    def test_many_hashalgs(self):
+        """Test that when upgrading actions where the new action
+        contains more hash attributes than the old action, that the
+        upgrade works."""
+
+        self.many_hashalgs_helper("install", "sha256")
+        self.many_hashalgs_helper("exact-install", "sha256")
+        if sha512_supported:
+            self.many_hashalgs_helper("install", "sha512t_256")
+            self.many_hashalgs_helper("exact-install", "sha512t_256")
+
+    def many_hashalgs_helper(self, install_cmd, hash_alg):
+        self.pkgsend_bulk(self.rurl, self.iron10, debug_hash="sha1")
+        self.image_create(self.rurl, destroy=True)
+        self.pkg("install iron@1.0")
+        self.pkg("contents -m iron")
+        # We have not enabled SHA2 hash publication yet.
+        self.assertTrue(
+            ("pkg.content-hash=file:{0}".format(hash_alg) not in self.output)
+        )
+
+        # publish with SHA1 and SHA2 hashes
+        self.pkgsend_bulk(
+            self.rurl, self.iron20, debug_hash="sha1+{0}".format(hash_alg)
+        )
+
+        # verify that a non-SHA2 aware client can install these bits
+        self.pkg("-D hash=sha1 update")
+        self.image_create(self.rurl, destroy=True)
+
+        # This also tests package retrieval: we always retrieve packages
+        # with the least-preferred hash, but verify with the
+        # most-preferred hash.
+        self.pkg("install iron@2.0")
+        self.pkg("contents -m iron")
+        self.assertTrue(
+            "pkg.content-hash=file:{0}".format(hash_alg) in self.output
+        )
+
+        # publish with only SHA-2 hashes
+        self.pkgsend_bulk(
+            self.rurl, self.iron20, debug_hash="{0}".format(hash_alg)
+        )
+
+        # verify that a non-SHA2 aware client cannot install these bits
+        # since there are no SHA1 hashes present
+        self.pkg("-D hash=sha1 update", exit=1)
+        self.assertTrue(
+            "No file could be found for the specified hash name: "
+            "'NOHASH'" in self.errout
+        )
+
+        # Make sure we've been publishing only with SHA2 by removing
+        # those known attributes, then checking for the presence of
+        # the SHA-1 attributes.
+        self.pkg("-D hash={0} update".format(hash_alg))
+        self.pkg("contents -m iron")
+        for attr in ["pkg.chash.{0}".format(hash_alg), "pkg.content-hash"]:
+            self.output = self.output.replace(attr, "")
+        self.assertTrue("hash" not in self.output)
+        self.assertTrue("chash" not in self.output)
+
+    def test_content_hash_ignore(self):
+        """Test that pkgs with gelf content-hash attributes are ignored
+        for install and verify by default if file hash matches."""
+
+        elfpkg_1 = """
                     open elftest@1.0
                     add file {0} mode=0755 owner=root group=bin path=/bin/true
                     close """
-                elfpkg = elfpkg_1.format(os.path.join("ro_data", "elftest.so.1"))
-                elf1 = self.pkgsend_bulk(self.rurl, (elfpkg,))[0]
+        elfpkg = elfpkg_1.format(os.path.join("ro_data", "elftest.so.1"))
+        elf1 = self.pkgsend_bulk(self.rurl, (elfpkg,))[0]
 
-                repo_dir = self.dcs[1].get_repodir()
-                f = fmri.PkgFmri(elf1, None)
-                repo = self.get_repo(repo_dir)
-                mpath = repo.manifest(f)
-                # load manifest, add content-hash attr and store back to disk
-                mani = manifest.Manifest()
-                mani.set_content(pathname=mpath)
-                for a in mani.gen_actions():
-                        if "bin/true" in str(a):
-                                a.attrs["pkg.content-hash"] = "gelf:sha512t_256:foo"
-                mani.store(mpath)
-                # rebuild repo catalog since manifest digest changed
-                repo.rebuild()
+        repo_dir = self.dcs[1].get_repodir()
+        f = fmri.PkgFmri(elf1, None)
+        repo = self.get_repo(repo_dir)
+        mpath = repo.manifest(f)
+        # load manifest, add content-hash attr and store back to disk
+        mani = manifest.Manifest()
+        mani.set_content(pathname=mpath)
+        for a in mani.gen_actions():
+            if "bin/true" in str(a):
+                a.attrs["pkg.content-hash"] = "gelf:sha512t_256:foo"
+        mani.store(mpath)
+        # rebuild repo catalog since manifest digest changed
+        repo.rebuild()
 
-                # Test that pkgrecv, pkgrepo verify, pkg install and pkg verify
-                # do not complain about unknown gelf content-hash.
-                self.pkgrecv("{0} -a -d {1} '*'".format(repo_dir,
-                    os.path.join(self.test_root, "x.p5p")))
-                self.pkgrepo("verify -s {0}".format(repo_dir))
-                self.image_create(self.rurl, destroy=True)
-                self.pkg("install -v {0}".format(elf1))
-                # Note that we pass verification if any of the hashes match, but
-                # we require by default that the content hash matches.
-                self.pkg("verify")
+        # Test that pkgrecv, pkgrepo verify, pkg install and pkg verify
+        # do not complain about unknown gelf content-hash.
+        self.pkgrecv(
+            "{0} -a -d {1} '*'".format(
+                repo_dir, os.path.join(self.test_root, "x.p5p")
+            )
+        )
+        self.pkgrepo("verify -s {0}".format(repo_dir))
+        self.image_create(self.rurl, destroy=True)
+        self.pkg("install -v {0}".format(elf1))
+        # Note that we pass verification if any of the hashes match, but
+        # we require by default that the content hash matches.
+        self.pkg("verify")
 
-                for a in mani.gen_actions():
-                        if "bin/true" in str(a):
-                                a.attrs["pkg.content-hash"] = "file:sha512t_256:foo"
-                mani.store(mpath)
-                # rebuild repo catalog since manifest digest changed
-                repo.rebuild()
-                # Test that pkgrecv, pkgrepo verify, pkg install complains about
-                # the unknown file hash.
-                self.pkgrecv("{0} -a -d {1} '*'".format(repo_dir,
-                    os.path.join(self.test_root, "y.p5p")))
-                self.pkgrepo("verify -s {0}".format(repo_dir), exit=1)
-                self.image_create(self.rurl, destroy=True)
-                self.pkg("install -v {0}".format(elf1), exit=1)
-                # We pass verification if any of the hashes match.
-                self.pkg("verify")
+        for a in mani.gen_actions():
+            if "bin/true" in str(a):
+                a.attrs["pkg.content-hash"] = "file:sha512t_256:foo"
+        mani.store(mpath)
+        # rebuild repo catalog since manifest digest changed
+        repo.rebuild()
+        # Test that pkgrecv, pkgrepo verify, pkg install complains about
+        # the unknown file hash.
+        self.pkgrecv(
+            "{0} -a -d {1} '*'".format(
+                repo_dir, os.path.join(self.test_root, "y.p5p")
+            )
+        )
+        self.pkgrepo("verify -s {0}".format(repo_dir), exit=1)
+        self.image_create(self.rurl, destroy=True)
+        self.pkg("install -v {0}".format(elf1), exit=1)
+        # We pass verification if any of the hashes match.
+        self.pkg("verify")
 
 
 class TestPkgInstallActions(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        misc_files = {
-                "ftpusers" :
-"""# ident      "@(#)ftpusers   1.6     06/11/21 SMI"
+    misc_files = {
+        "ftpusers": """# ident      "@(#)ftpusers   1.6     06/11/21 SMI"
 #
 # List of users denied access to the FTP server, see ftpusers(5).
 #
@@ -5424,8 +5564,7 @@ bin
 sys
 adm
 """,
-                "group" :
-"""root::0:
+        "group": """root::0:
 other::1:root
 bin::2:root,daemon
 sys::3:root,bin,adm
@@ -5433,146 +5572,142 @@ adm::4:root,daemon
 keepmembers::102:user1,user2
 +::::
 """,
-                "passwd" :
-"""root:x:0:0::/root:/usr/bin/bash
+        "passwd": """root:x:0:0::/root:/usr/bin/bash
 daemon:x:1:1::/:
 bin:x:2:2::/usr/bin:
 sys:x:3:3::/:
 adm:x:4:4:Admin:/var/adm:
 +::::::
 """,
-                "shadow" :
-"""root:9EIfTNBp9elws:13817::::::
+        "shadow": """root:9EIfTNBp9elws:13817::::::
 daemon:NP:6445::::::
 bin:NP:6445::::::
 sys:NP:6445::::::
 adm:NP:6445::::::
 +::::::::
 """,
-                "cat" : " ",
-                "empty" : ""
-        }
+        "cat": " ",
+        "empty": "",
+    }
 
-
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        only_attr10 = """
+    only_attr10 = """
             open only_attr@1.0,5.11-0
             add set name=foo value=bar
             close """
 
-        only_depend10 = """
+    only_depend10 = """
             open only_depend@1.0,5.11-0
             add depend type=require fmri=foo@1.0,5.11-0
             close """
 
-        only_directory10 = """
+    only_directory10 = """
             open only_dir@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             close """
 
-        only_driver10 = """
+    only_driver10 = """
             open only_driver@1.0,5.11-0
             add driver name=zerg devlink="type=ddi_pseudo;name=zerg\\t\\D"
             close """
 
-        only_group10 = """
+    only_group10 = """
             open only_group@1.0,5.11-0
             add group groupname=Kermit gid=28
             close """
 
-        only_group_file10 = """
+    only_group_file10 = """
             open only_group_file@1.0,5.11-0
             add dir mode=0755 owner=root group=Kermit path=/export/home/Kermit
             close """
 
-        only_hardlink10 = """
+    only_hardlink10 = """
             open only_hardlink@1.0,5.11-0
             add hardlink path=/cat.hardlink target=/cat
             close """
 
-        only_legacy10 = """
+    only_legacy10 = """
             open only_legacy@1.0,5.11-0
             add legacy category=system desc="GNU make - A utility used to build software (gmake) 3.81" hotline="Please contact your local service provider" name="gmake - GNU make" pkg=SUNWgmake vendor="Sun Microsystems, Inc." version=11.11.0,REV=2008.04.29.02.08
             close """
 
-        only_link10 = """
+    only_link10 = """
             open only_link@1.0,5.11-0
             add link path=/link target=/tmp/cat
             close """
 
-        only_user10 = """
+    only_user10 = """
             open only_user@1.0,5.11-0
             add user username=Kermit group=adm home-dir=/export/home/Kermit
             close """
 
-        only_user_file10 = """
+    only_user_file10 = """
             open only_user_file@1.0,5.11-0
             add dir mode=0755 owner=Kermit group=adm path=/export/home/Kermit
             close """
 
-        csu1 = """
+    csu1 = """
             open csu1@1.0,5.11-0
             add legacy category=system desc="core software for a specific instruction-set architecture" hotline="Please contact your local service provider" name="Core Solaris, (Usr)" pkg=SUNWcsu vendor="Oracle Corporation" version=11.11,REV=2009.11.11
             close
         """
 
-        csu1_2 = """
+    csu1_2 = """
             open csu1@2.0,5.11-0
             add legacy category=system desc="core software for a specific instruction-set architecture" hotline="Please contact your local service provider" name="Core Solaris, (Usr)" pkg=SUNWcsu vendor="Oracle Corporation" version=11.11,REV=2010.11.11
             close
         """
 
-        csu2 = """
+    csu2 = """
             open csu2@1.0,5.11-0
             add legacy category=system desc="core software for a specific instruction-set architecture" hotline="Please contact your local service provider" name="Core Solaris, (Usr)" pkg=SUNWcsu vendor="Oracle Corporation" version=11.11,REV=2009.11.11
             close
         """
 
-        csu2_2 = """
+    csu2_2 = """
             open csu2@2.0,5.11-0
             add legacy category=system desc="core software for a specific instruction-set architecture" hotline="Please contact your local service provider" name="Core Solaris, (Usr)" pkg=SUNWcsu vendor="Oracle Corporation" version=11.11,REV=2010.11.11
             close
         """
 
-        csu3 = """
+    csu3 = """
             open csu3@1.0,5.11-0
             add legacy category=system desc="core software for a specific instruction-set architecture" hotline="Please contact your local service provider" name="Core Solaris, (Usr)" pkg=SUNWcsu vendor="Oracle Corporation" version=11.11,REV=2009.11.11
             close
         """
 
-        csu3_2 = """
+    csu3_2 = """
             open csu3@2.0,5.11-0
             add legacy category=system desc="core software for a specific instruction-set architecture" hotline="Please contact your local service provider" name="Core Solaris, (Usr)" pkg=SUNWcsu vendor="Oracle Corporation" version=11.11,REV=2010.11.11
             close
         """
 
-        # some of these are subsets-- "always" and "at-end"-- for performance;
-        # we assume that e.g. if a and z work, that bcdef, etc. will too.
-        pkg_name_valid_chars = {
-            "never": " `~!@#$%^&*()=[{]}\\|;:\",<>?",
-            "always": "09azAZ",
-            "after-first": "_-.+",
-            "at-end": "09azAZ_-.+",
-        }
+    # some of these are subsets-- "always" and "at-end"-- for performance;
+    # we assume that e.g. if a and z work, that bcdef, etc. will too.
+    pkg_name_valid_chars = {
+        "never": ' `~!@#$%^&*()=[{]}\\|;:",<>?',
+        "always": "09azAZ",
+        "after-first": "_-.+",
+        "at-end": "09azAZ_-.+",
+    }
 
-        def setUp(self):
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
 
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-
-                self.only_file10 = """
+        self.only_file10 = """
                     open only_file@1.0,5.11-0
                     add file cat mode=0555 owner=root group=bin path=/cat
                     close """
 
-                self.only_license10 = """
+        self.only_license10 = """
                     open only_license@1.0,5.11-0
                     add license cat license=copyright
                     close """
 
-                self.baseuser = """
+        self.baseuser = """
                     open system/action/user@0,5.11
                     add dir path=etc mode=0755 owner=root group=sys
                     add dir path=etc/ftpd mode=0755 owner=root group=sys
@@ -5586,14 +5721,14 @@ adm:NP:6445::::::
                     add file empty path=etc/user_attr mode=0644 owner=root group=sys preserve=true
                     close """
 
-                self.singleuser = """
+        self.singleuser = """
                     open singleuser@0,5.11
                     add user group=fozzie uid=16 username=fozzie
                     add group groupname=fozzie gid=16
                     close
                 """
 
-                self.basics0 = """
+        self.basics0 = """
                     open basics@1.0,5.11-0
                     add file passwd mode=0644 owner=root group=sys path=etc/passwd preserve=true
                     add file shadow mode=0400 owner=root group=sys path=etc/shadow preserve=true
@@ -5603,7 +5738,7 @@ adm:NP:6445::::::
                     add dir mode=0755 owner=root group=sys path=etc/ftpd
                     close """
 
-                self.basics1 = """
+        self.basics1 = """
                     open basics1@1.0,5.11-0
                     add dir mode=0755 owner=root group=bin path=lib
                     add dir mode=0755 owner=root group=sys path=var
@@ -5613,7 +5748,7 @@ adm:NP:6445::::::
                     add dir mode=0755 owner=root group=bin path=usr/local
                     close """
 
-                self.grouptest = """
+        self.grouptest = """
                     open grouptest@1.0,5.11-0
                     add dir mode=0755 owner=root group=Kermit path=/usr/Kermit
                     add file empty mode=0755 owner=root group=Kermit path=/usr/local/bin/do_group_nothing
@@ -5623,7 +5758,7 @@ adm:NP:6445::::::
                     add depend fmri=pkg:/basics@1.0 type=require
                     close """
 
-                self.usertest10 = """
+        self.usertest10 = """
                     open usertest@1.0,5.11-0
                     add dir mode=0755 owner=Kermit group=Kermit path=/export/home/Kermit
                     add file empty mode=0755 owner=Kermit group=Kermit path=/usr/local/bin/do_user_nothing
@@ -5633,7 +5768,7 @@ adm:NP:6445::::::
                     add depend fmri=pkg:/basics@1.0 type=require
                     close """
 
-                self.usertest11 = """
+        self.usertest11 = """
                     open usertest@1.1,5.11-0
                     add dir mode=0755 owner=Kermit group=Kermit path=/export/home/Kermit
                     add file empty mode=0755 owner=Kermit group=Kermit path=/usr/local/bin/do_user_nothing
@@ -5643,19 +5778,19 @@ adm:NP:6445::::::
                     add depend fmri=pkg:/basics@1.0 type=require
                     close """
 
-                self.ugidtest = """
+        self.ugidtest = """
                     open ugidtest@1.0,5.11-0
                     add user username=dummy group=root
                     add group groupname=dummy
                     close """
 
-                self.silver10 = """
+        self.silver10 = """
                     open silver@1.0,5.11-0
                     add file empty mode=0755 owner=root group=root path=/usr/local/bin/silver
                     add depend fmri=pkg:/basics@1.0 type=require
                     add depend fmri=pkg:/basics1@1.0 type=require
                     close """
-                self.silver20 = """
+        self.silver20 = """
                     open silver@2.0,5.11-0
                     add file empty mode=0755 owner=Kermit group=Kermit path=/usr/local/bin/silver
                     add user username=Kermit group=Kermit home-dir=/export/home/Kermit group-list=lp group-list=staff
@@ -5664,7 +5799,7 @@ adm:NP:6445::::::
                     add depend fmri=pkg:/grouptest@1.0 type=require
                     close """
 
-                self.devicebase = """
+        self.devicebase = """
                     open devicebase@1.0,5.11-0
                     add dir mode=0755 owner=root group=sys path=/var
                     add dir mode=0755 owner=root group=sys path=/var/run
@@ -5683,7 +5818,7 @@ adm:NP:6445::::::
                     close
                 """
 
-                self.devlink10 = """
+        self.devlink10 = """
                     open devlinktest@1.0,5.11-0
                     add driver name=zerg devlink="type=ddi_pseudo;name=zerg\\t\\D"
                     add driver name=borg devlink="type=ddi_pseudo;name=borg\\t\\D" devlink="type=ddi_pseudo;name=warg\\t\\D"
@@ -5691,7 +5826,7 @@ adm:NP:6445::::::
                     close
                 """
 
-                self.devlink20 = """
+        self.devlink20 = """
                     open devlinktest@2.0,5.11-0
                     add driver name=zerg devlink="type=ddi_pseudo;name=zerg2\\t\\D" devlink="type=ddi_pseudo;name=zorg\\t\\D"
                     add driver name=borg devlink="type=ddi_pseudo;name=borg\\t\\D" devlink="type=ddi_pseudo;name=zork\\t\\D"
@@ -5699,45 +5834,45 @@ adm:NP:6445::::::
                     close
                 """
 
-                self.devalias10 = """
+        self.devalias10 = """
                     open devalias@1,5.11
                     add driver name=zerg alias=pci8086,1234 alias=pci8086,4321
                     close
                 """
 
-                self.devalias20 = """
+        self.devalias20 = """
                     open devalias@2,5.11
                     add driver name=zerg alias=pci8086,5555
                     close
                 """
 
-                self.devaliasmove10 = """
+        self.devaliasmove10 = """
                     open devaliasmove@1,5.11
                     add driver name=zerg alias=pci8086,5555
                     close
                 """
 
-                self.devaliasmove20 = """
+        self.devaliasmove20 = """
                     open devaliasmove@2,5.11
                     add driver name=zerg
                     add driver name=borg alias=pci8086,5555
                     close
                 """
 
-                self.badhardlink1 = """
+        self.badhardlink1 = """
                     open badhardlink1@1.0,5.11-0
                     add hardlink path=foo target=bar
                     close
                 """
 
-                self.badhardlink2 = """
+        self.badhardlink2 = """
                     open badhardlink2@1.0,5.11-0
                     add file cat mode=0555 owner=root group=bin path=/etc/motd
                     add hardlink path=foo target=/etc/motd
                     close
                 """
 
-                self.hardlink_chain = """
+        self.hardlink_chain = """
                     open hardlink_chain@1.0,5.11-0
                     add file cat mode=0555 owner=root group=bin path=file
                     add hardlink path=hardlink1 target=hardlink2
@@ -5747,242 +5882,245 @@ adm:NP:6445::::::
                     close
                 """
 
-                self.make_misc_files(self.misc_files)
+        self.make_misc_files(self.misc_files)
 
-        def test_basics_0_install(self):
-                """Send basic infrastructure, install and uninstall."""
+    def test_basics_0_install(self):
+        """Send basic infrastructure, install and uninstall."""
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.basics1))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (self.basics0, self.basics1))
+        self.image_create(self.rurl)
 
-                self.pkg("list -a")
-                self.pkg("list", exit=1)
+        self.pkg("list -a")
+        self.pkg("list", exit=1)
 
-                self.pkg("install basics")
-                self.pkg("install basics1")
+        self.pkg("install basics")
+        self.pkg("install basics1")
 
-                self.pkg("list")
-                self.pkg("verify")
+        self.pkg("list")
+        self.pkg("verify")
 
-                self.pkg("uninstall basics basics1")
-                self.pkg("verify")
+        self.pkg("uninstall basics basics1")
+        self.pkg("verify")
 
-        def test_basics_0_exact_install(self):
-                """Send basic infrastructure, exact-install and uninstall."""
+    def test_basics_0_exact_install(self):
+        """Send basic infrastructure, exact-install and uninstall."""
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.basics1))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (self.basics0, self.basics1))
+        self.image_create(self.rurl)
 
-                self.pkg("list -a")
-                self.pkg("list", exit=1)
+        self.pkg("list -a")
+        self.pkg("list", exit=1)
 
-                self.pkg("exact-install basics basics1")
+        self.pkg("exact-install basics basics1")
 
-                self.pkg("list")
-                self.pkg("verify")
+        self.pkg("list")
+        self.pkg("verify")
 
-                self.pkg("uninstall basics basics1")
-                self.pkg("verify")
+        self.pkg("uninstall basics basics1")
+        self.pkg("verify")
 
-        def test_grouptest_install(self):
+    def test_grouptest_install(self):
+        self.pkgsend_bulk(
+            self.rurl, (self.basics0, self.basics1, self.grouptest)
+        )
+        self.image_create(self.rurl)
+        self.pkg("install basics")
+        self.file_doesnt_contain("etc/group", ["lp", "staff", "Kermit"])
+        self.pkg("install basics1")
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.basics1,
-                    self.grouptest))
-                self.image_create(self.rurl)
-                self.pkg("install basics")
-                self.file_doesnt_contain("etc/group", ["lp", "staff", "Kermit"])
-                self.pkg("install basics1")
+        self.pkg("install grouptest")
+        self.pkg("verify -v")
+        self.file_contains("etc/group", ["lp", "staff", "Kermit"])
+        self.pkg("uninstall -vvv grouptest")
+        self.pkg("verify -v")
+        self.file_doesnt_contain("etc/group", ["lp", "staff", "Kermit"])
 
-                self.pkg("install grouptest")
-                self.pkg("verify -v")
-                self.file_contains("etc/group", ["lp", "staff", "Kermit"])
-                self.pkg("uninstall -vvv grouptest")
-                self.pkg("verify -v")
-                self.file_doesnt_contain("etc/group", ["lp", "staff", "Kermit"])
+    def test_grouptest_exact_install(self):
+        self.pkgsend_bulk(
+            self.rurl, (self.basics0, self.basics1, self.grouptest)
+        )
+        self.image_create(self.rurl)
+        self.pkg("exact-install basics basics1")
+        self.file_doesnt_contain("etc/group", ["lp", "staff", "Kermit"])
 
-        def test_grouptest_exact_install(self):
+        self.pkg("exact-install grouptest")
+        self.pkg("verify")
+        self.file_contains("etc/group", ["lp", "staff", "Kermit"])
+        self.pkg("list basics1", exit=1)
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.basics1,
-                    self.grouptest))
-                self.image_create(self.rurl)
-                self.pkg("exact-install basics basics1")
-                self.file_doesnt_contain("etc/group", ["lp", "staff", "Kermit"])
+        self.pkg("uninstall grouptest")
+        self.pkg("verify")
+        self.file_doesnt_contain("etc/group", ["lp", "staff", "Kermit"])
 
-                self.pkg("exact-install grouptest")
-                self.pkg("verify")
-                self.file_contains("etc/group", ["lp", "staff", "Kermit"])
-                self.pkg("list basics1", exit=1)
+    def test_usertest_install(self):
+        self.pkgsend_bulk(
+            self.rurl,
+            (self.basics0, self.basics1, self.grouptest, self.usertest10),
+        )
+        self.image_create(self.rurl)
+        self.pkg("install basics")
+        self.pkg("install basics1")
+        self.file_doesnt_contain("etc/passwd", "Kermit")
+        self.file_doesnt_contain("etc/shadow", "Kermit")
 
-                self.pkg("uninstall grouptest")
-                self.pkg("verify")
-                self.file_doesnt_contain("etc/group", ["lp", "staff", "Kermit"])
+        self.pkg("install usertest")
+        self.pkg("verify")
+        self.file_contains("etc/passwd", "Kermit")
+        self.file_contains("etc/shadow", "Kermit")
+        self.pkg("contents -m usertest")
 
-        def test_usertest_install(self):
+        self.pkgsend_bulk(self.rurl, self.usertest11)
+        self.pkg("refresh")
+        self.pkg("install usertest")
+        self.pkg("verify")
+        self.pkg("contents -m usertest")
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.basics1,
-                    self.grouptest, self.usertest10))
-                self.image_create(self.rurl)
-                self.pkg("install basics")
-                self.pkg("install basics1")
-                self.file_doesnt_contain("etc/passwd", "Kermit")
-                self.file_doesnt_contain("etc/shadow", "Kermit")
+        self.pkg("uninstall usertest")
+        self.pkg("verify")
+        self.file_doesnt_contain("etc/passwd", "Kermit")
+        self.file_doesnt_contain("etc/shadow", "Kermit")
 
-                self.pkg("install usertest")
-                self.pkg("verify")
-                self.file_contains("etc/passwd", "Kermit")
-                self.file_contains("etc/shadow", "Kermit")
-                self.pkg("contents -m usertest")
+    def test_usertest_exact_install(self):
+        self.pkgsend_bulk(
+            self.rurl,
+            (self.basics0, self.basics1, self.grouptest, self.usertest10),
+        )
+        self.image_create(self.rurl)
+        self.pkg("exact-install basics basics1")
+        self.file_doesnt_contain("etc/passwd", "Kermit")
+        self.file_doesnt_contain("etc/shadow", "Kermit")
 
-                self.pkgsend_bulk(self.rurl, self.usertest11)
-                self.pkg("refresh")
-                self.pkg("install usertest")
-                self.pkg("verify")
-                self.pkg("contents -m usertest")
+        self.pkg("exact-install usertest")
+        self.pkg("verify")
+        self.pkg("list basics1", exit=1)
+        self.pkg("contents -m usertest")
+        self.file_contains("etc/passwd", "Kermit")
+        self.file_contains("etc/shadow", "Kermit")
 
-                self.pkg("uninstall usertest")
-                self.pkg("verify")
-                self.file_doesnt_contain("etc/passwd", "Kermit")
-                self.file_doesnt_contain("etc/shadow", "Kermit")
+        self.pkgsend_bulk(self.rurl, self.usertest11)
+        self.pkg("refresh")
+        self.pkg("exact-install usertest")
+        self.pkg("verify")
+        self.pkg("contents -m usertest")
 
-        def test_usertest_exact_install(self):
+        self.pkg("uninstall usertest")
+        self.pkg("verify")
+        self.file_doesnt_contain("etc/passwd", "Kermit")
+        self.file_doesnt_contain("etc/shadow", "Kermit")
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.basics1,
-                    self.grouptest, self.usertest10))
-                self.image_create(self.rurl)
-                self.pkg("exact-install basics basics1")
-                self.file_doesnt_contain("etc/passwd", "Kermit")
-                self.file_doesnt_contain("etc/shadow", "Kermit")
+    def test_primordial_usergroup_install(self):
+        """Ensure that we can install user and group actions in the same
+        transaction as /etc/passwd, /etc/group, etc."""
 
-                self.pkg("exact-install usertest")
-                self.pkg("verify")
-                self.pkg("list basics1", exit=1)
-                self.pkg("contents -m usertest")
-                self.file_contains("etc/passwd", "Kermit")
-                self.file_contains("etc/shadow", "Kermit")
+        self.pkgsend_bulk(self.rurl, [self.baseuser, self.singleuser])
 
-                self.pkgsend_bulk(self.rurl, self.usertest11)
-                self.pkg("refresh")
-                self.pkg("exact-install usertest")
-                self.pkg("verify")
-                self.pkg("contents -m usertest")
+        self.image_create(self.rurl)
+        self.pkg("install system/action/user")
+        self.pkg("verify")
 
-                self.pkg("uninstall usertest")
-                self.pkg("verify")
-                self.file_doesnt_contain("etc/passwd", "Kermit")
-                self.file_doesnt_contain("etc/shadow", "Kermit")
+        self.image_destroy()
+        self.image_create(self.rurl)
+        self.pkg("install singleuser", exit=1)
 
-        def test_primordial_usergroup_install(self):
-                """Ensure that we can install user and group actions in the same
-                transaction as /etc/passwd, /etc/group, etc."""
+    def test_primordial_usergroup_exact_install(self):
+        """Ensure that we can exact-install user and group actions in
+        the same transaction as /etc/passwd, /etc/group, etc."""
 
-                self.pkgsend_bulk(self.rurl, [self.baseuser, self.singleuser])
+        self.pkgsend_bulk(self.rurl, [self.basics0, self.singleuser])
 
-                self.image_create(self.rurl)
-                self.pkg("install system/action/user")
-                self.pkg("verify")
+        self.image_create(self.rurl)
+        self.pkg("exact-install basics")
+        self.pkg("verify")
 
-                self.image_destroy()
-                self.image_create(self.rurl)
-                self.pkg("install singleuser", exit=1)
+        self.image_destroy()
+        self.image_create(self.rurl)
+        self.pkg("exact-install  basics singleuser")
 
-        def test_primordial_usergroup_exact_install(self):
-                """Ensure that we can exact-install user and group actions in
-                the same transaction as /etc/passwd, /etc/group, etc."""
+    def test_ftpuser_install(self):
+        """Make sure we correctly handle /etc/ftpd/ftpusers."""
 
-                self.pkgsend_bulk(self.rurl, [self.basics0, self.singleuser])
-
-                self.image_create(self.rurl)
-                self.pkg("exact-install basics")
-                self.pkg("verify")
-
-                self.image_destroy()
-                self.image_create(self.rurl)
-                self.pkg("exact-install  basics singleuser")
-
-        def test_ftpuser_install(self):
-                """Make sure we correctly handle /etc/ftpd/ftpusers."""
-
-                notftpuser = """
+        notftpuser = """
                 open notftpuser@1
                 add user username=animal group=root ftpuser=false
                 close"""
 
-                ftpuserexp = """
+        ftpuserexp = """
                 open ftpuserexp@1
                 add user username=fozzie group=root ftpuser=true
                 close"""
 
-                ftpuserimp = """
+        ftpuserimp = """
                 open ftpuserimp@1
                 add user username=gonzo group=root
                 close"""
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, notftpuser,
-                    ftpuserexp, ftpuserimp))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(
+            self.rurl, (self.basics0, notftpuser, ftpuserexp, ftpuserimp)
+        )
+        self.image_create(self.rurl)
 
-                self.pkg("install basics")
+        self.pkg("install basics")
 
-                # Add a user with ftpuser=false.  Make sure the user is added to
-                # the file, and that the user verifies.
-                self.pkg("install notftpuser")
-                fpath = self.get_img_path() + "/etc/ftpd/ftpusers"
-                with open(fpath) as f:
-                        self.assertTrue("animal\n" in f.readlines())
-                self.pkg("verify notftpuser")
+        # Add a user with ftpuser=false.  Make sure the user is added to
+        # the file, and that the user verifies.
+        self.pkg("install notftpuser")
+        fpath = self.get_img_path() + "/etc/ftpd/ftpusers"
+        with open(fpath) as f:
+            self.assertTrue("animal\n" in f.readlines())
+        self.pkg("verify notftpuser")
 
-                # Add a user with an explicit ftpuser=true.  Make sure the user
-                # is not added to the file, and that the user verifies.
-                self.pkg("install ftpuserexp")
-                with open(fpath) as f:
-                        self.assertTrue("fozzie\n" not in f.readlines())
-                self.pkg("verify ftpuserexp")
+        # Add a user with an explicit ftpuser=true.  Make sure the user
+        # is not added to the file, and that the user verifies.
+        self.pkg("install ftpuserexp")
+        with open(fpath) as f:
+            self.assertTrue("fozzie\n" not in f.readlines())
+        self.pkg("verify ftpuserexp")
 
-                # Add a user with an implicit ftpuser=true.  Make sure the user
-                # is not added to the file, and that the user verifies.
-                self.pkg("install ftpuserimp")
-                with open(fpath) as f:
-                        self.assertTrue("gonzo\n" not in f.readlines())
-                self.pkg("verify ftpuserimp")
+        # Add a user with an implicit ftpuser=true.  Make sure the user
+        # is not added to the file, and that the user verifies.
+        self.pkg("install ftpuserimp")
+        with open(fpath) as f:
+            self.assertTrue("gonzo\n" not in f.readlines())
+        self.pkg("verify ftpuserimp")
 
-                # Put a user into the ftpusers file as shipped, then add that
-                # user, with ftpuser=false.  Make sure the user remains in the
-                # file, and that the user verifies.
-                self.pkg("uninstall notftpuser")
-                with open(fpath, "a") as f:
-                        f.write("animal\n")
-                self.pkg("install notftpuser")
-                with open(fpath) as f:
-                        self.assertTrue("animal\n" in f.readlines())
-                self.pkg("verify notftpuser")
+        # Put a user into the ftpusers file as shipped, then add that
+        # user, with ftpuser=false.  Make sure the user remains in the
+        # file, and that the user verifies.
+        self.pkg("uninstall notftpuser")
+        with open(fpath, "a") as f:
+            f.write("animal\n")
+        self.pkg("install notftpuser")
+        with open(fpath) as f:
+            self.assertTrue("animal\n" in f.readlines())
+        self.pkg("verify notftpuser")
 
-                # Put a user into the ftpusers file as shipped, then add that
-                # user, with an explicit ftpuser=true.  Make sure the user is
-                # stripped from the file, and that the user verifies.
-                self.pkg("uninstall ftpuserexp")
-                with open(fpath, "a") as f:
-                        f.write("fozzie\n")
-                self.pkg("install ftpuserexp")
-                with open(fpath) as f:
-                        self.assertTrue("fozzie\n" not in f.readlines())
-                self.pkg("verify ftpuserexp")
+        # Put a user into the ftpusers file as shipped, then add that
+        # user, with an explicit ftpuser=true.  Make sure the user is
+        # stripped from the file, and that the user verifies.
+        self.pkg("uninstall ftpuserexp")
+        with open(fpath, "a") as f:
+            f.write("fozzie\n")
+        self.pkg("install ftpuserexp")
+        with open(fpath) as f:
+            self.assertTrue("fozzie\n" not in f.readlines())
+        self.pkg("verify ftpuserexp")
 
-                # Put a user into the ftpusers file as shipped, then add that
-                # user, with an implicit ftpuser=true.  Make sure the user is
-                # stripped from the file, and that the user verifies.
-                self.pkg("uninstall ftpuserimp")
-                with open(fpath, "a") as f:
-                        f.write("gonzo\n")
-                self.pkg("install ftpuserimp")
-                with open(fpath) as f:
-                        self.assertTrue("gonzo\n" not in f.readlines())
-                self.pkg("verify ftpuserimp")
+        # Put a user into the ftpusers file as shipped, then add that
+        # user, with an implicit ftpuser=true.  Make sure the user is
+        # stripped from the file, and that the user verifies.
+        self.pkg("uninstall ftpuserimp")
+        with open(fpath, "a") as f:
+            f.write("gonzo\n")
+        self.pkg("install ftpuserimp")
+        with open(fpath) as f:
+            self.assertTrue("gonzo\n" not in f.readlines())
+        self.pkg("verify ftpuserimp")
 
-        def test_groupverify_install(self):
-                """Make sure we correctly verify group actions when users have
-                been added."""
+    def test_groupverify_install(self):
+        """Make sure we correctly verify group actions when users have
+        been added."""
 
-                simplegroups = """
+        simplegroups = """
                 open simplegroup@1
                 add group groupname=muppets gid=100
                 close
@@ -5990,41 +6128,41 @@ adm:NP:6445::::::
                 add group groupname=muppets2 gid=101
                 close"""
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, simplegroups))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (self.basics0, simplegroups))
+        self.image_create(self.rurl)
 
-                self.pkg("install basics")
-                self.pkg("install simplegroup")
-                self.pkg("verify simplegroup")
-                self.file_contains("etc/group", "muppets")
+        self.pkg("install basics")
+        self.pkg("install simplegroup")
+        self.pkg("verify simplegroup")
+        self.file_contains("etc/group", "muppets")
 
-                # add additional members to group & verify
-                gpath = self.get_img_file_path("etc/group")
-                with open(gpath) as f:
-                        gdata = f.readlines()
-                gdata[-1] = gdata[-1].rstrip() + "kermit,misspiggy\n"
-                with open(gpath, "w") as f:
-                        f.writelines(gdata)
-                self.pkg("verify simplegroup")
-                self.pkg("uninstall simplegroup")
-                self.pkg("verify")
-                self.file_doesnt_contain("etc/group", "muppets")
+        # add additional members to group & verify
+        gpath = self.get_img_file_path("etc/group")
+        with open(gpath) as f:
+            gdata = f.readlines()
+        gdata[-1] = gdata[-1].rstrip() + "kermit,misspiggy\n"
+        with open(gpath, "w") as f:
+            f.writelines(gdata)
+        self.pkg("verify simplegroup")
+        self.pkg("uninstall simplegroup")
+        self.pkg("verify")
+        self.file_doesnt_contain("etc/group", "muppets")
 
-                # verify that groups appear in gid order.
-                self.pkg("install simplegroup simplegroup2")
-                self.pkg("verify")
-                with open(gpath) as f:
-                        gdata = f.readlines()
-                self.assertTrue(gdata[-1].find("muppets2") == 0)
-                self.pkg("uninstall simple*")
-                self.pkg("install simplegroup2 simplegroup")
-                with open(gpath) as f:
-                        gdata = f.readlines()
-                self.assertTrue(gdata[-1].find("muppets2") == 0)
+        # verify that groups appear in gid order.
+        self.pkg("install simplegroup simplegroup2")
+        self.pkg("verify")
+        with open(gpath) as f:
+            gdata = f.readlines()
+        self.assertTrue(gdata[-1].find("muppets2") == 0)
+        self.pkg("uninstall simple*")
+        self.pkg("install simplegroup2 simplegroup")
+        with open(gpath) as f:
+            gdata = f.readlines()
+        self.assertTrue(gdata[-1].find("muppets2") == 0)
 
-        def test_preexisting_group_install(self):
-                """Make sure we correct any errors in pre-existing group actions"""
-                simplegroup = """
+    def test_preexisting_group_install(self):
+        """Make sure we correct any errors in pre-existing group actions"""
+        simplegroup = """
                 open simplegroup@0
                 add group groupname=muppets
                 close
@@ -6038,42 +6176,41 @@ adm:NP:6445::::::
                 add group groupname=keepmembers gid=102
                 close"""
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, simplegroup))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (self.basics0, simplegroup))
+        self.image_create(self.rurl)
 
-                self.pkg("install basics")
-                gpath = self.get_img_file_path("etc/group")
-                with open(gpath) as f:
-                        gdata = f.readlines()
-                gdata = ["muppets::1010:\n"] + gdata
-                with open(gpath, "w") as f:
-                        f.writelines(gdata)
-                self.pkg("verify")
-                # properly install group w/o a gid
-                self.pkg("install simplegroup@0")
-                self.pkg("verify simplegroup")
-                # install w/ different gid
-                self.pkg("install simplegroup@1")
-                self.pkg("verify simplegroup")
-                # check # lines beginning w/ 'muppets' in group file
-                with open(gpath) as f:
-                        gdata = f.readlines()
-                self.assertTrue(
-                    len([a for a in gdata if a.find("muppets") == 0]) == 1)
+        self.pkg("install basics")
+        gpath = self.get_img_file_path("etc/group")
+        with open(gpath) as f:
+            gdata = f.readlines()
+        gdata = ["muppets::1010:\n"] + gdata
+        with open(gpath, "w") as f:
+            f.writelines(gdata)
+        self.pkg("verify")
+        # properly install group w/o a gid
+        self.pkg("install simplegroup@0")
+        self.pkg("verify simplegroup")
+        # install w/ different gid
+        self.pkg("install simplegroup@1")
+        self.pkg("verify simplegroup")
+        # check # lines beginning w/ 'muppets' in group file
+        with open(gpath) as f:
+            gdata = f.readlines()
+        self.assertTrue(len([a for a in gdata if a.find("muppets") == 0]) == 1)
 
-                # make sure we can add new version of same package
-                self.pkg("update simplegroup")
-                self.pkg("verify simplegroup")
+        # make sure we can add new version of same package
+        self.pkg("update simplegroup")
+        self.pkg("verify simplegroup")
 
-                # verify that pre-existing members are preserved on upgrade
-                self.pkg("uninstall simple*")
-                self.pkg("install keepmembers")
-                self.pkg("verify")
-                self.file_contains("etc/group", "keepmembers::102:user1,user2")
+        # verify that pre-existing members are preserved on upgrade
+        self.pkg("uninstall simple*")
+        self.pkg("install keepmembers")
+        self.pkg("verify")
+        self.file_contains("etc/group", "keepmembers::102:user1,user2")
 
-        def test_missing_ownergroup_install(self):
-                """test what happens when a owner or group is missing"""
-                missing = """
+    def test_missing_ownergroup_install(self):
+        """test what happens when a owner or group is missing"""
+        missing = """
                 open missing_group@1
                 add dir path=etc/muppet1 owner=root group=muppets mode=755
                 close
@@ -6091,52 +6228,52 @@ adm:NP:6445::::::
                 close
                 """
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, missing))
-                self.image_create(self.rurl)
-                self.pkg("install basics")
+        self.pkgsend_bulk(self.rurl, (self.basics0, missing))
+        self.image_create(self.rurl)
+        self.pkg("install basics")
 
-                # try installing directory w/ a non-existing group
-                self.pkg("install missing_group@1", exit=1)
-                # try installing directory w/ a non-existing owner
-                self.pkg("install missing_owner@1", exit=1)
-                # try installing user w/ unknown group
-                self.pkg("install muppetsuser@1", exit=1)
-                # install group
-                self.pkg("install muppetsgroup")
-                # install working user & see if it all works.
-                self.pkg("install muppetsuser@2")
-                self.pkg("install missing_group@1")
-                self.pkg("install missing_owner@1")
-                self.pkg("verify")
-                # edit group file to remove muppets group
-                gpath = self.get_img_file_path("etc/group")
-                with open(gpath) as f:
-                        gdata = f.readlines()
-                with open(gpath, "w") as f:
-                        f.writelines(gdata[0:-1])
+        # try installing directory w/ a non-existing group
+        self.pkg("install missing_group@1", exit=1)
+        # try installing directory w/ a non-existing owner
+        self.pkg("install missing_owner@1", exit=1)
+        # try installing user w/ unknown group
+        self.pkg("install muppetsuser@1", exit=1)
+        # install group
+        self.pkg("install muppetsgroup")
+        # install working user & see if it all works.
+        self.pkg("install muppetsuser@2")
+        self.pkg("install missing_group@1")
+        self.pkg("install missing_owner@1")
+        self.pkg("verify")
+        # edit group file to remove muppets group
+        gpath = self.get_img_file_path("etc/group")
+        with open(gpath) as f:
+            gdata = f.readlines()
+        with open(gpath, "w") as f:
+            f.writelines(gdata[0:-1])
 
-                # verify that we catch missing group
-                # in both group and user actions
-                self.pkg("verify muppetsgroup", 1)
-                self.pkg("verify muppetsuser", 1)
-                self.pkg("fix muppetsgroup", 0)
-                self.pkg("verify muppetsgroup muppetsuser missing*")
-                self.pkg("uninstall missing*")
-                # try installing w/ broken group
+        # verify that we catch missing group
+        # in both group and user actions
+        self.pkg("verify muppetsgroup", 1)
+        self.pkg("verify muppetsuser", 1)
+        self.pkg("fix muppetsgroup", 0)
+        self.pkg("verify muppetsgroup muppetsuser missing*")
+        self.pkg("uninstall missing*")
+        # try installing w/ broken group
 
-                with open(gpath, "w") as f:
-                        f.writelines(gdata[0:-1])
-                self.pkg("install missing_group@1", 1)
-                self.pkg("fix muppetsgroup")
-                self.pkg("install missing_group@1")
-                self.pkg("install missing_owner@1")
-                self.pkg("verify muppetsgroup muppetsuser missing*")
+        with open(gpath, "w") as f:
+            f.writelines(gdata[0:-1])
+        self.pkg("install missing_group@1", 1)
+        self.pkg("fix muppetsgroup")
+        self.pkg("install missing_group@1")
+        self.pkg("install missing_owner@1")
+        self.pkg("verify muppetsgroup muppetsuser missing*")
 
-        def test_userverify_install(self):
-                """Make sure we correctly verify user actions when the on-disk
-                databases have been modified."""
+    def test_userverify_install(self):
+        """Make sure we correctly verify user actions when the on-disk
+        databases have been modified."""
 
-                simpleusers = """
+        simpleusers = """
                 open simpleuser@1
                 add user username=misspiggy group=root gcos-field="& loves Kermie" login-shell=/bin/sh uid=5
                 close
@@ -6152,786 +6289,823 @@ adm:NP:6445::::::
                 add user username=wombat group=root gcos-field="& has explict password" login-shell=/bin/bash uid=99 password=$5$C6451mtT$PDg63UKGtFr7FHkMSxUhdTcd0XBtHTnKXNN7RpJe/h1 shell-change-ok=true
                 close"""
 
+        self.pkgsend_bulk(self.rurl, (self.basics0, simpleusers))
+        self.image_create(self.rurl)
 
-                self.pkgsend_bulk(self.rurl, (self.basics0, simpleusers))
-                self.image_create(self.rurl)
+        self.pkg("install basics")
+        self.pkg("install simpleuser")
+        self.pkg("verify simpleuser")
 
-                self.pkg("install basics")
-                self.pkg("install simpleuser")
-                self.pkg("verify simpleuser")
+        ppath = self.get_img_path() + "/etc/passwd"
+        with open(ppath) as f:
+            pdata = f.readlines()
+        spath = self.get_img_path() + "/etc/shadow"
+        with open(spath) as f:
+            sdata = f.readlines()
 
-                ppath = self.get_img_path() + "/etc/passwd"
-                with open(ppath) as f:
-                        pdata = f.readlines()
-                spath = self.get_img_path() + "/etc/shadow"
-                with open(spath) as f:
-                        sdata = f.readlines()
+        def finderr(err):
+            self.assertTrue("\t\tERROR: " + err in self.output)
 
-                def finderr(err):
-                        self.assertTrue("\t\tERROR: " + err in self.output)
+        # change a provided, empty-default field to something else
+        pdata[-1] = "misspiggy:x:5:0:& loves Kermie:/:/bin/zsh"
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        self.pkg("verify simpleuser", exit=1)
+        finderr("login-shell: '/bin/zsh' should be '/bin/sh'")
+        self.pkg("fix simpleuser")
+        self.pkg("verify simpleuser")
 
-                # change a provided, empty-default field to something else
-                pdata[-1] = "misspiggy:x:5:0:& loves Kermie:/:/bin/zsh"
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                self.pkg("verify simpleuser", exit=1)
-                finderr("login-shell: '/bin/zsh' should be '/bin/sh'")
-                self.pkg("fix simpleuser")
-                self.pkg("verify simpleuser")
+        # change a provided, non-empty-default field to the default
+        pdata[-1] = "misspiggy:x:5:0:& User:/:/bin/sh"
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        self.pkg("verify simpleuser", exit=1)
+        finderr("gcos-field: '& User' should be '& loves Kermie'")
+        self.pkg("fix simpleuser")
+        self.pkg("verify simpleuser")
 
-                # change a provided, non-empty-default field to the default
-                pdata[-1] = "misspiggy:x:5:0:& User:/:/bin/sh"
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                self.pkg("verify simpleuser", exit=1)
-                finderr("gcos-field: '& User' should be '& loves Kermie'")
-                self.pkg("fix simpleuser")
-                self.pkg("verify simpleuser")
+        # change a non-provided, non-empty-default field to something
+        # other than the default
+        pdata[-1] = "misspiggy:x:5:0:& loves Kermie:/misspiggy:/bin/sh"
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        self.pkg("verify simpleuser", exit=1)
+        finderr("home-dir: '/misspiggy' should be '/'")
+        self.pkg("fix simpleuser")
+        self.pkg("verify simpleuser")
 
-                # change a non-provided, non-empty-default field to something
-                # other than the default
-                pdata[-1] = "misspiggy:x:5:0:& loves Kermie:/misspiggy:/bin/sh"
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                self.pkg("verify simpleuser", exit=1)
-                finderr("home-dir: '/misspiggy' should be '/'")
-                self.pkg("fix simpleuser")
-                self.pkg("verify simpleuser")
+        # add a non-provided, empty-default field
+        pdata[-1] = "misspiggy:x:5:0:& loves Kermie:/:/bin/sh"
+        sdata[-1] = "misspiggy:*LK*:14579:7:::::"
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        os.chmod(spath, stat.S_IMODE(os.stat(spath).st_mode) | stat.S_IWUSR)
+        with open(spath, "w") as f:
+            f.writelines(sdata)
+        self.pkg("verify simpleuser", exit=1)
+        finderr("min: '7' should be '<empty>'")
+        # we now fix entries w/ non-mutable passwords
+        self.pkg("fix simpleuser")
+        self.pkg("verify simpleuser")
 
-                # add a non-provided, empty-default field
-                pdata[-1] = "misspiggy:x:5:0:& loves Kermie:/:/bin/sh"
-                sdata[-1] = "misspiggy:*LK*:14579:7:::::"
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                os.chmod(spath,
-                    stat.S_IMODE(os.stat(spath).st_mode)|stat.S_IWUSR)
-                with open(spath, "w") as f:
-                        f.writelines(sdata)
-                self.pkg("verify simpleuser", exit=1)
-                finderr("min: '7' should be '<empty>'")
-                # we now fix entries w/ non-mutable passwords
-                self.pkg("fix simpleuser")
-                self.pkg("verify simpleuser")
+        # remove a non-provided, non-empty-default field
+        pdata[-1] = "misspiggy:x:5:0:& loves Kermie::/bin/sh"
+        sdata[-1] = "misspiggy:*LK*:14579::::::"
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        with open(spath, "w") as f:
+            f.writelines(sdata)
+        self.pkg("verify simpleuser", exit=1)
+        finderr("home-dir: '' should be '/'")
+        self.pkg("fix simpleuser")
+        self.pkg("verify simpleuser")
 
-                # remove a non-provided, non-empty-default field
-                pdata[-1] = "misspiggy:x:5:0:& loves Kermie::/bin/sh"
-                sdata[-1] = "misspiggy:*LK*:14579::::::"
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                with open(spath, "w") as f:
-                        f.writelines(sdata)
-                self.pkg("verify simpleuser", exit=1)
-                finderr("home-dir: '' should be '/'")
-                self.pkg("fix simpleuser")
-                self.pkg("verify simpleuser")
+        # remove a provided, non-empty-default field
+        pdata[-1] = "misspiggy:x:5:0::/:/bin/sh"
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        self.pkg("verify simpleuser", exit=1)
+        finderr("gcos-field: '' should be '& loves Kermie'")
+        self.pkg("fix simpleuser")
+        self.pkg("verify simpleuser")
 
-                # remove a provided, non-empty-default field
-                pdata[-1] = "misspiggy:x:5:0::/:/bin/sh"
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                self.pkg("verify simpleuser", exit=1)
-                finderr("gcos-field: '' should be '& loves Kermie'")
-                self.pkg("fix simpleuser")
-                self.pkg("verify simpleuser")
+        # remove a provided, empty-default field
+        pdata[-1] = "misspiggy:x:5:0:& loves Kermie:/:"
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        self.pkg("verify simpleuser", exit=1)
+        finderr("login-shell: '' should be '/bin/sh'")
+        self.pkg("fix simpleuser")
+        self.pkg("verify simpleuser")
 
-                # remove a provided, empty-default field
-                pdata[-1] = "misspiggy:x:5:0:& loves Kermie:/:"
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                self.pkg("verify simpleuser", exit=1)
-                finderr("login-shell: '' should be '/bin/sh'")
-                self.pkg("fix simpleuser")
-                self.pkg("verify simpleuser")
+        # remove the user from /etc/passwd
+        pdata[-1] = "misswiggy:x:5:0:& loves Kermie:/:"
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        self.pkg("verify simpleuser", exit=1)
+        finderr("login-shell: '<missing>' should be '/bin/sh'")
+        finderr("gcos-field: '<missing>' should be '& loves Kermie'")
+        finderr("group: '<missing>' should be 'root'")
+        self.pkg("fix simpleuser")
+        self.pkg("verify simpleuser")
 
-                # remove the user from /etc/passwd
-                pdata[-1] = "misswiggy:x:5:0:& loves Kermie:/:"
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                self.pkg("verify simpleuser", exit=1)
-                finderr("login-shell: '<missing>' should be '/bin/sh'")
-                finderr("gcos-field: '<missing>' should be '& loves Kermie'")
-                finderr("group: '<missing>' should be 'root'")
-                self.pkg("fix simpleuser")
-                self.pkg("verify simpleuser")
+        # remove the user completely
+        pdata[-1] = "misswiggy:x:5:0:& loves Kermie:/:"
+        sdata[-1] = "misswiggy:*LK*:14579::::::"
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        with open(spath, "w") as f:
+            f.writelines(sdata)
+        self.pkg("verify simpleuser", exit=1)
+        finderr("username: '<missing>' should be 'misspiggy'")
+        self.pkg("fix simpleuser")
+        self.pkg("verify simpleuser")
 
-                # remove the user completely
-                pdata[-1] = "misswiggy:x:5:0:& loves Kermie:/:"
-                sdata[-1] = "misswiggy:*LK*:14579::::::"
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                with open(spath, "w") as f:
-                        f.writelines(sdata)
-                self.pkg("verify simpleuser", exit=1)
-                finderr("username: '<missing>' should be 'misspiggy'")
-                self.pkg("fix simpleuser")
-                self.pkg("verify simpleuser")
+        # change the password and show an error
+        self.pkg("verify simpleuser")
+        sdata[-1] = "misspiggy:NP:14579::::::"
+        with open(spath, "w") as f:
+            f.writelines(sdata)
+        self.pkg("verify simpleuser", exit=1)
+        finderr("password: 'NP' should be '*LK*'")
+        self.pkg("fix simpleuser")
+        self.pkg("verify simpleuser")
 
-                # change the password and show an error
-                self.pkg("verify simpleuser")
-                sdata[-1] = "misspiggy:NP:14579::::::"
-                with open(spath, "w") as f:
-                        f.writelines(sdata)
-                self.pkg("verify simpleuser", exit=1)
-                finderr("password: 'NP' should be '*LK*'")
-                self.pkg("fix simpleuser")
-                self.pkg("verify simpleuser")
+        # verify that passwords set to UP
+        # do not cause verify errors if changed.
+        self.pkg("install --reject simpleuser simpleuser2@1")
+        self.pkg("verify simpleuser2")
+        with open(ppath) as f:
+            pdata = f.readlines()
+        with open(spath) as f:
+            sdata = f.readlines()
+        sdata[
+            -1
+        ] = "kermit:$5$pWPEsjm2$GXjBRTjGeeWmJ81ytw3q1ah7QTaI7yJeRYZeyvB.Rp1:14579:3:10::::1234"
+        with open(spath, "w") as f:
+            f.writelines(sdata)
+        self.pkg("verify simpleuser2")
+        # verify that upgrading package to version that implicitly
+        # uses *LK* default causes password to change and that it
+        # verifies correctly
+        self.pkg("update simpleuser2@2")
+        self.pkg("verify simpleuser2")
+        with open(spath) as f:
+            sdata = f.readlines()
+        sdata[-1].index("*LK*")
 
-                # verify that passwords set to UP
-                # do not cause verify errors if changed.
-                self.pkg("install --reject simpleuser simpleuser2@1")
-                self.pkg("verify simpleuser2")
-                with open(ppath) as f:
-                        pdata = f.readlines()
-                with open(spath) as f:
-                        sdata = f.readlines()
-                sdata[-1] = "kermit:$5$pWPEsjm2$GXjBRTjGeeWmJ81ytw3q1ah7QTaI7yJeRYZeyvB.Rp1:14579:3:10::::1234"
-                with open(spath, "w") as f:
-                        f.writelines(sdata)
-                self.pkg("verify simpleuser2")
-                # verify that upgrading package to version that implicitly
-                # uses *LK* default causes password to change and that it
-                # verifies correctly
-                self.pkg("update simpleuser2@2")
-                self.pkg("verify simpleuser2")
-                with open(spath) as f:
-                        sdata = f.readlines()
-                sdata[-1].index("*LK*")
+        # ascertain that users are added in uid order when
+        # installed at the same time.
+        self.pkg("uninstall simpleuser2")
+        self.pkg("install simpleuser simpleuser2")
 
-                # ascertain that users are added in uid order when
-                # installed at the same time.
-                self.pkg("uninstall simpleuser2")
-                self.pkg("install simpleuser simpleuser2")
+        with open(ppath) as f:
+            pdata = f.readlines()
+        pdata[-1].index("kermit")
 
-                with open(ppath) as f:
-                        pdata = f.readlines()
-                pdata[-1].index("kermit")
+        self.pkg("uninstall simpleuser simpleuser2")
+        self.pkg("install simpleuser2 simpleuser")
 
-                self.pkg("uninstall simpleuser simpleuser2")
-                self.pkg("install simpleuser2 simpleuser")
+        with open(ppath) as f:
+            pdata = f.readlines()
+        pdata[-1].index("kermit")
 
-                with open(ppath) as f:
-                        pdata = f.readlines()
-                pdata[-1].index("kermit")
+        # verify that entry w/ explicit password fails verify when that entry is changed
+        self.pkg("install simpleuser3@1")
+        self.pkg("verify simpleuser3")
+        with open(spath) as f:
+            sdata = f.readlines()
+        splits = sdata[-1].split(":")
+        saved_password = splits[1]
+        splits[1] = "$5$TaoLBw9p$dbeliOK0AMQlgMtozei/IPgM1ncBdDVgzdv7HTk.bu0"
+        sdata[-1] = ":".join(splits)
+        with open(spath, "w") as f:
+            f.writelines(sdata)
+        self.pkg("verify simpleuser3", exit=1)
+        # restore password
+        splits[1] = saved_password
+        sdata[-1] = ":".join(splits)
+        with open(spath, "w") as f:
+            f.writelines(sdata)
+        self.pkg("verify simpleuser3")
 
-                # verify that entry w/ explicit password fails verify when that entry is changed
-                self.pkg("install simpleuser3@1")
-                self.pkg("verify simpleuser3")
-                with open(spath) as f:
-                        sdata = f.readlines()
-                splits = sdata[-1].split(":")
-                saved_password = splits[1]
-                splits[1] = "$5$TaoLBw9p$dbeliOK0AMQlgMtozei/IPgM1ncBdDVgzdv7HTk.bu0"
-                sdata[-1] = ":".join(splits)
-                with open(spath, "w") as f:
-                        f.writelines(sdata)
-                self.pkg("verify simpleuser3", exit=1)
-                # restore password
-                splits[1] = saved_password
-                sdata[-1] = ":".join(splits)
-                with open(spath, "w") as f:
-                        f.writelines(sdata)
-                self.pkg("verify simpleuser3")
+        # change shell and make sure error occurs
+        with open(ppath) as f:
+            pdata = f.readlines()
+        pdata[-1].index("wombat")
+        splits = pdata[-1].split(":")
+        splits[6] = "/bin/zsh"
+        pdata[-1] = ":".join(splits)
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        self.pkg("verify simpleuser3", exit=1)
+        finderr("login-shell")
+        # upgrade pkg so shell change is ok
+        self.pkg("update simpleuser3")
+        with open(ppath) as f:
+            pdata = f.readlines()
+        splits = pdata[-1].split(":")
+        splits[6] = "/bin/zsh"
+        pdata[-1] = ":".join(splits)
+        with open(ppath, "w") as f:
+            f.writelines(pdata)
+        self.pkg("verify simpleuser3")
 
-                # change shell and make sure error occurs
-                with open(ppath) as f:
-                        pdata = f.readlines()
-                pdata[-1].index("wombat")
-                splits = pdata[-1].split(":")
-                splits[6] = "/bin/zsh"
-                pdata[-1] = ":".join(splits)
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                self.pkg("verify simpleuser3", exit=1)
-                finderr("login-shell")
-                # upgrade pkg so shell change is ok
-                self.pkg("update simpleuser3")
-                with open(ppath) as f:
-                        pdata = f.readlines()
-                splits = pdata[-1].split(":")
-                splits[6] = "/bin/zsh"
-                pdata[-1] = ":".join(splits)
-                with open(ppath, "w") as f:
-                        f.writelines(pdata)
-                self.pkg("verify simpleuser3")
+    def test_minugid(self):
+        """Ensure that an unspecified uid/gid results in the first
+        unused."""
 
-        def test_minugid(self):
-                """Ensure that an unspecified uid/gid results in the first
-                unused."""
+        self.minugid_helper("install")
+        self.minugid_helper("exact-install")
 
-                self.minugid_helper("install")
-                self.minugid_helper("exact-install")
+    def minugid_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, (self.basics0, self.ugidtest))
+        self.image_create(self.rurl)
 
-        def minugid_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.ugidtest))
-                self.image_create(self.rurl)
+        # This will lay down the sample passwd file, group file, etc.
+        self.pkg("install basics")
+        if install_cmd == "install":
+            self.pkg("install ugidtest")
+        else:
+            self.pkg("exact-install basics ugidtest")
+        passwd_file = open(os.path.join(self.get_img_path(), "/etc/passwd"))
+        for line in passwd_file:
+            if line.startswith("dummy"):
+                self.assertTrue(line.startswith("dummy:x:5:"))
+        passwd_file.close()
+        group_file = open(os.path.join(self.get_img_path(), "/etc/group"))
+        for line in group_file:
+            if line.startswith("dummy"):
+                self.assertTrue(line.startswith("dummy::5:"))
+        group_file.close()
 
-                # This will lay down the sample passwd file, group file, etc.
-                self.pkg("install basics")
-                if install_cmd == "install":
-                        self.pkg("install ugidtest")
+    def test_upgrade_with_user(self):
+        """Ensure that we can add a user and change file ownership to
+        that user in the same delta (mysql tripped over this early on
+        in IPS development)."""
+
+        self.upgrade_with_user_helper("install")
+        self.upgrade_with_user_helper("exact-install")
+
+    def upgrade_with_user_helper(self, install_cmd):
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.basics0,
+                self.basics1,
+                self.silver10,
+                self.silver20,
+                self.grouptest,
+            ),
+        )
+        self.image_create(self.rurl)
+        self.pkg("install basics@1.0")
+        self.pkg("{0} basics1@1.0".format(install_cmd))
+        self.pkg("{0} silver@1.0".format(install_cmd))
+        self.pkg("list silver@1.0")
+        self.pkg("verify -v")
+        self.pkg("{0} silver@2.0".format(install_cmd))
+        self.pkg("verify -v")
+
+    def test_upgrade_garbage_passwd(self):
+        self.upgrade_garbage_passwd_helper("install")
+        self.upgrade_garbage_passwd_helper("exact-install")
+
+    def upgrade_garbage_passwd_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, (self.basics0, self.singleuser))
+        self.image_create(self.rurl)
+        pwd_path = os.path.join(self.get_img_path(), "etc/passwd")
+        # Put a garbage line in /etc/passwd, and make sure we can
+        # install or exact-install, uninstall a user, and preserve the
+        # garbage line.  Once with a blank line in the middle, once
+        # with a non-blank line with too few fields, once with a
+        # non-blank line with too many fields, and once with a blank
+        # line at the end.
+        for lineno, garbage in (
+            (3, ""),
+            (3, "garbage"),
+            (3, ":::::::::"),
+            (100, ""),
+        ):
+            garbage += "\n"
+            self.pkg("install basics")
+            with open(pwd_path, "r+") as pwd_file:
+                lines = pwd_file.readlines()
+                lines[lineno:lineno] = garbage
+                pwd_file.truncate(0)
+                pwd_file.seek(0)
+                pwd_file.writelines(lines)
+            if install_cmd == "install":
+                self.pkg("{0} singleuser".format(install_cmd))
+            else:
+                self.pkg("{0} basics singleuser".format(install_cmd))
+            with open(pwd_path) as pwd_file:
+                lines = pwd_file.readlines()
+                self.assertTrue(garbage in lines)
+            self.pkg("uninstall singleuser")
+            with open(pwd_path) as pwd_file:
+                lines = pwd_file.readlines()
+                self.assertTrue(garbage in lines)
+
+            self.pkg("uninstall '*'")
+
+    def test_user_in_grouplist(self):
+        """If a user is present in a secondary group list when the user
+        is installed, the client shouldn't crash."""
+
+        self.user_in_grouplist_helper("install")
+        self.user_in_grouplist_helper("exact-install")
+
+    def user_in_grouplist_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, (self.basics0, self.only_user10))
+        self.image_create(self.rurl)
+        self.pkg("install basics@1.0")
+        group_path = os.path.join(self.get_img_path(), "etc/group")
+        with open(group_path, "r+") as group_file:
+            lines = group_file.readlines()
+            lines[0] = lines[0][:-1] + "Kermit" + "\n"
+            group_file.truncate(0)
+            group_file.seek(0)
+            group_file.writelines(lines)
+        if install_cmd == "install":
+            self.pkg("install only_user@1.0")
+        else:
+            self.pkg("exact-install basics@1.0 only_user@1.0")
+
+    def test_invalid_open(self):
+        """Send invalid package definitions (invalid fmris); expect
+        failure."""
+
+        for char in self.pkg_name_valid_chars["never"]:
+            invalid_name = "invalid{0}pkg@1.0,5.11-0".format(char)
+            self.pkgsend(self.rurl, "open '{0}'".format(invalid_name), exit=1)
+
+        for char in self.pkg_name_valid_chars["after-first"]:
+            invalid_name = "{0}invalidpkg@1.0,5.11-0".format(char)
+            if char == "-":
+                cmd = "open -- '{0}'".format(invalid_name)
+            else:
+                cmd = "open '{0}'".format(invalid_name)
+            self.pkgsend(self.rurl, cmd, exit=1)
+
+            invalid_name = "invalid/{0}pkg@1.0,5.11-0".format(char)
+            cmd = "open '{0}'".format(invalid_name)
+            self.pkgsend(self.rurl, cmd, exit=1)
+
+    def test_valid_open(self):
+        """Send a series of valid packages; expect success."""
+
+        for char in self.pkg_name_valid_chars["always"]:
+            valid_name = "{0}valid{1}/{2}pkg{3}@1.0,5.11-0".format(
+                char, char, char, char
+            )
+            self.pkgsend(self.rurl, "open '{0}'".format(valid_name))
+            self.pkgsend(self.rurl, "close -A")
+
+        for char in self.pkg_name_valid_chars["after-first"]:
+            valid_name = "v{0}alid{1}pkg@1.0,5.11-0".format(char, char)
+            self.pkgsend(self.rurl, "open '{0}'".format(valid_name))
+            self.pkgsend(self.rurl, "close -A")
+
+        for char in self.pkg_name_valid_chars["at-end"]:
+            valid_name = "validpkg{0}@1.0,5.11-0".format(char)
+            self.pkgsend(self.rurl, "open '{0}'".format(valid_name))
+            self.pkgsend(self.rurl, "close -A")
+
+    def test_devlink(self):
+        self.devlink_helper("install")
+        self.devlink_helper("exact-install")
+
+    def devlink_helper(self, install_cmd):
+        # driver actions are not valid except on OpenSolaris
+        if portable.util.get_canonical_os_name() != "sunos":
+            return
+
+        self.pkgsend_bulk(
+            self.rurl, (self.devicebase, self.devlink10, self.devlink20)
+        )
+        self.image_create(self.rurl)
+
+        def readfile():
+            dlf = open(os.path.join(self.get_img_path(), "etc/devlink.tab"))
+            dllines = dlf.readlines()
+            dlf.close()
+            return dllines
+
+        def writefile(dllines):
+            dlf = open(
+                os.path.join(self.get_img_path(), "etc/devlink.tab"), "w"
+            )
+            dlf.writelines(dllines)
+            dlf.close()
+
+        def assertContents(dllines, contents):
+            actual = re.findall(r"name=([^\t;]*)", "\n".join(dllines), re.M)
+            self.assertTrue(set(actual) == set(contents))
+
+        # Install
+        self.pkg("install devlinktest@1.0")
+        self.pkg("verify -v")
+
+        dllines = readfile()
+
+        # Verify that three entries got added
+        self.assertTrue(len(dllines) == 3)
+
+        # Verify that the tab character got written correctly
+        self.assertTrue(dllines[0].find("\t") > 0)
+
+        # Upgrade
+        self.pkg("{0} devlinktest@2.0".format(install_cmd))
+        self.pkg("verify -v")
+
+        dllines = readfile()
+
+        # Verify that there are four entries now
+        self.assertTrue(len(dllines) == 4)
+
+        # Verify they are what they should be
+        assertContents(dllines, ["zerg2", "zorg", "borg", "zork"])
+
+        # Remove
+        self.pkg("uninstall devlinktest")
+        self.pkg("verify -v")
+
+        # Install again
+        self.pkg("install devlinktest@1.0")
+
+        # Diddle with it
+        dllines = readfile()
+        for i, line in enumerate(dllines):
+            if line.find("zerg") != -1:
+                dllines[i] = "type=ddi_pseudo;name=zippy\t\\D\n"
+        writefile(dllines)
+
+        # Upgrade
+        self.pkg("{0} devlinktest@2.0".format(install_cmd))
+
+        # Verify that we spewed a message on upgrade
+        self.assertTrue(self.output.find("not found") != -1)
+        self.assertTrue(self.output.find("name=zerg") != -1)
+
+        # Verify the new set
+        dllines = readfile()
+        self.assertTrue(len(dllines) == 5)
+        assertContents(dllines, ["zerg2", "zorg", "borg", "zork", "zippy"])
+
+        self.pkg("uninstall devlinktest")
+
+        # Null out the "zippy" entry
+        writefile([])
+
+        # Install again
+        self.pkg("install devlinktest@1.0")
+
+        # Diddle with it
+        dllines = readfile()
+        for i, line in enumerate(dllines):
+            if line.find("zerg") != -1:
+                dllines[i] = "type=ddi_pseudo;name=zippy\t\\D\n"
+        writefile(dllines)
+
+        # Remove
+        self.pkg("uninstall devlinktest")
+
+        # Verify that we spewed a message on removal
+        self.assertTrue(self.output.find("not found") != -1)
+        self.assertTrue(self.output.find("name=zerg") != -1)
+
+        # Verify that the one left behind was the one we overwrote.
+        dllines = readfile()
+        self.assertTrue(len(dllines) == 1)
+        assertContents(dllines, ["zippy"])
+
+        # Null out the "zippy" entry, but add the "zerg" entry
+        writefile(["type=ddi_pseudo;name=zerg\t\\D\n"])
+
+        # Install ... again
+        self.pkg("install devlinktest@1.0")
+
+        # Make sure we didn't get a second zerg line
+        dllines = readfile()
+        self.assertTrue(len(dllines) == 3, msg=dllines)
+        assertContents(dllines, ["zerg", "borg", "warg"])
+
+        # Now for the same test on upgrade
+        dllines.append("type=ddi_pseudo;name=zorg\t\\D\n")
+        writefile(dllines)
+
+        self.pkg("{0} devlinktest@2.0".format(install_cmd))
+        dllines = readfile()
+        self.assertTrue(len(dllines) == 4, msg=dllines)
+        assertContents(dllines, ["zerg2", "zorg", "borg", "zork"])
+
+    def test_driver_aliases_upgrade(self):
+        """Make sure that aliases properly appear and disappear on
+        upgrade.  This is the result of a bug in update_drv, but it's
+        not a bad idea to test some of this ourselves."""
+
+        self.driver_aliases_upgrade_helper("install")
+        self.driver_aliases_upgrade_helper("exact-install")
+
+    def driver_aliases_upgrade_helper(self, install_cmd):
+        # driver actions are not valid except on OpenSolaris
+        if portable.util.get_canonical_os_name() != "sunos":
+            return
+
+        self.pkgsend_bulk(
+            self.rurl, [self.devicebase, self.devalias10, self.devalias20]
+        )
+
+        self.image_create(self.rurl)
+        self.pkg("{0} devicebase devalias@1".format(install_cmd))
+        self.pkg("update devalias")
+        self.pkg("verify devalias")
+
+        daf = open(os.path.join(self.get_img_path(), "etc/driver_aliases"))
+        dalines = daf.readlines()
+        daf.close()
+
+        self.assertTrue(len(dalines) == 1, msg=dalines)
+        self.assertTrue(",1234" not in dalines[0])
+        self.assertTrue(",4321" not in dalines[0])
+        self.assertTrue(",5555" in dalines[0])
+
+    def test_driver_aliases_move(self):
+        """Make sure that an alias can be moved from one driver action
+        to another."""
+
+        self.driver_aliases_move_helper("install")
+        self.driver_aliases_move_helper("exact-install")
+
+    def driver_aliases_move_helper(self, install_cmd):
+        self.pkgsend_bulk(
+            self.rurl,
+            [self.devicebase, self.devaliasmove10, self.devaliasmove20],
+        )
+
+        self.image_create(self.rurl)
+        self.pkg("{0} devicebase devaliasmove@1".format(install_cmd))
+        self.pkg("update devaliasmove")
+        self.assertTrue("pci8086,5555" not in self.output)
+
+    def test_uninstall_without_perms(self):
+        """Verify uninstall fails as expected for unprivileged users."""
+
+        pkg_list = [
+            self.foo10,
+            self.only_attr10,
+            self.only_depend10,
+            self.only_directory10,
+            self.only_file10,
+            self.only_group10,
+            self.only_hardlink10,
+            self.only_legacy10,
+            self.only_license10,
+            self.only_link10,
+            self.only_user10,
+        ]
+
+        # driver actions are not valid except on OpenSolaris
+        if portable.util.get_canonical_os_name() == "sunos":
+            pkg_list += [self.only_driver10]
+
+        self.pkgsend_bulk(
+            self.rurl,
+            pkg_list + [self.devicebase + self.basics0 + self.basics1],
+        )
+
+        self.image_create(self.rurl)
+
+        name_pat = re.compile(r"^\s+open\s+(\S+)\@.*$")
+
+        def __manually_check_deps(name, install=True, exit=0):
+            cmd = ["install", "--no-refresh"]
+            if not install:
+                cmd = ["uninstall"]
+            if name == "only_depend" and not install:
+                self.pkg(cmd + ["foo"], exit=exit)
+            elif name == "only_driver":
+                self.pkg(cmd + ["devicebase"], exit=exit)
+            elif name == "only_group":
+                self.pkg(cmd + ["basics"], exit=exit)
+            elif name == "only_hardlink":
+                self.pkg(cmd + ["only_file"], exit=exit)
+            elif name == "only_user":
+                if install:
+                    self.pkg(cmd + ["basics"], exit=exit)
+                    self.pkg(cmd + ["only_group"], exit=exit)
                 else:
-                        self.pkg("exact-install basics ugidtest")
-                passwd_file = open(os.path.join(self.get_img_path(),
-                    "/etc/passwd"))
-                for line in passwd_file:
-                        if line.startswith("dummy"):
-                                self.assertTrue(line.startswith("dummy:x:5:"))
-                passwd_file.close()
-                group_file = open(os.path.join(self.get_img_path(),
-                    "/etc/group"))
-                for line in group_file:
-                        if line.startswith("dummy"):
-                                self.assertTrue(line.startswith("dummy::5:"))
-                group_file.close()
-
-        def test_upgrade_with_user(self):
-                """Ensure that we can add a user and change file ownership to
-                that user in the same delta (mysql tripped over this early on
-                in IPS development)."""
-
-                self.upgrade_with_user_helper("install")
-                self.upgrade_with_user_helper("exact-install")
-
-        def upgrade_with_user_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.basics1,
-                    self.silver10, self.silver20, self.grouptest))
-                self.image_create(self.rurl)
-                self.pkg("install basics@1.0")
-                self.pkg("{0} basics1@1.0".format(install_cmd))
-                self.pkg("{0} silver@1.0".format(install_cmd))
-                self.pkg("list silver@1.0")
-                self.pkg("verify -v")
-                self.pkg("{0} silver@2.0".format(install_cmd))
-                self.pkg("verify -v")
-
-        def test_upgrade_garbage_passwd(self):
-                self.upgrade_garbage_passwd_helper("install")
-                self.upgrade_garbage_passwd_helper("exact-install")
-
-        def upgrade_garbage_passwd_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.singleuser))
-                self.image_create(self.rurl)
-                pwd_path = os.path.join(self.get_img_path(), "etc/passwd")
-                # Put a garbage line in /etc/passwd, and make sure we can
-                # install or exact-install, uninstall a user, and preserve the
-                # garbage line.  Once with a blank line in the middle, once
-                # with a non-blank line with too few fields, once with a
-                # non-blank line with too many fields, and once with a blank
-                # line at the end.
-                for lineno, garbage in ((3, ""), (3, "garbage"),
-                    (3, ":::::::::"), (100, "")):
-                        garbage += "\n"
-                        self.pkg("install basics")
-                        with open(pwd_path, "r+") as pwd_file:
-                                lines = pwd_file.readlines()
-                                lines[lineno:lineno] = garbage
-                                pwd_file.truncate(0)
-                                pwd_file.seek(0)
-                                pwd_file.writelines(lines)
-                        if install_cmd == "install":
-                                self.pkg("{0} singleuser".format(install_cmd))
-                        else:
-                                self.pkg("{0} basics singleuser".format(install_cmd))
-                        with open(pwd_path) as pwd_file:
-                                lines = pwd_file.readlines()
-                                self.assertTrue(garbage in lines)
-                        self.pkg("uninstall singleuser")
-                        with open(pwd_path) as pwd_file:
-                                lines = pwd_file.readlines()
-                                self.assertTrue(garbage in lines)
-
-                        self.pkg("uninstall '*'")
-
-        def test_user_in_grouplist(self):
-                """If a user is present in a secondary group list when the user
-                is installed, the client shouldn't crash."""
-
-                self.user_in_grouplist_helper("install")
-                self.user_in_grouplist_helper("exact-install")
-
-        def user_in_grouplist_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.only_user10))
-                self.image_create(self.rurl)
-                self.pkg("install basics@1.0")
-                group_path = os.path.join(self.get_img_path(), "etc/group")
-                with open(group_path, "r+") as group_file:
-                        lines = group_file.readlines()
-                        lines[0] = lines[0][:-1] + "Kermit" + "\n"
-                        group_file.truncate(0)
-                        group_file.seek(0)
-                        group_file.writelines(lines)
-                if install_cmd == "install":
-                        self.pkg("install only_user@1.0")
-                else:
-                        self.pkg("exact-install basics@1.0 only_user@1.0")
-
-        def test_invalid_open(self):
-                """Send invalid package definitions (invalid fmris); expect
-                failure."""
-
-                for char in self.pkg_name_valid_chars["never"]:
-                        invalid_name = "invalid{0}pkg@1.0,5.11-0".format(char)
-                        self.pkgsend(self.rurl, "open '{0}'".format(invalid_name),
-                            exit=1)
-
-                for char in self.pkg_name_valid_chars["after-first"]:
-                        invalid_name = "{0}invalidpkg@1.0,5.11-0".format(char)
-                        if char == "-":
-                                cmd = "open -- '{0}'".format(invalid_name)
-                        else:
-                                cmd = "open '{0}'".format(invalid_name)
-                        self.pkgsend(self.rurl, cmd, exit=1)
-
-                        invalid_name = "invalid/{0}pkg@1.0,5.11-0".format(char)
-                        cmd = "open '{0}'".format(invalid_name)
-                        self.pkgsend(self.rurl, cmd, exit=1)
-
-        def test_valid_open(self):
-                """Send a series of valid packages; expect success."""
-
-                for char in self.pkg_name_valid_chars["always"]:
-                        valid_name = "{0}valid{1}/{2}pkg{3}@1.0,5.11-0".format(char,
-                            char, char, char)
-                        self.pkgsend(self.rurl, "open '{0}'".format(valid_name))
-                        self.pkgsend(self.rurl, "close -A")
-
-                for char in self.pkg_name_valid_chars["after-first"]:
-                        valid_name = "v{0}alid{1}pkg@1.0,5.11-0".format(char, char)
-                        self.pkgsend(self.rurl, "open '{0}'".format(valid_name))
-                        self.pkgsend(self.rurl, "close -A")
-
-                for char in self.pkg_name_valid_chars["at-end"]:
-                        valid_name = "validpkg{0}@1.0,5.11-0".format(char)
-                        self.pkgsend(self.rurl, "open '{0}'".format(valid_name))
-                        self.pkgsend(self.rurl, "close -A")
-
-        def test_devlink(self):
-                self.devlink_helper("install")
-                self.devlink_helper("exact-install")
-
-        def devlink_helper(self, install_cmd):
-                # driver actions are not valid except on OpenSolaris
-                if portable.util.get_canonical_os_name() != "sunos":
-                        return
-
-                self.pkgsend_bulk(self.rurl, (self.devicebase, self.devlink10,
-                    self.devlink20))
-                self.image_create(self.rurl)
-
-                def readfile():
-                        dlf = open(os.path.join(self.get_img_path(),
-                            "etc/devlink.tab"))
-                        dllines = dlf.readlines()
-                        dlf.close()
-                        return dllines
-
-                def writefile(dllines):
-                        dlf = open(os.path.join(self.get_img_path(),
-                            "etc/devlink.tab"), "w")
-                        dlf.writelines(dllines)
-                        dlf.close()
-
-                def assertContents(dllines, contents):
-                        actual = re.findall(r"name=([^\t;]*)",
-                            "\n".join(dllines), re.M)
-                        self.assertTrue(set(actual) == set(contents))
-
-                # Install
-                self.pkg("install devlinktest@1.0")
-                self.pkg("verify -v")
-
-                dllines = readfile()
-
-                # Verify that three entries got added
-                self.assertTrue(len(dllines) == 3)
-
-                # Verify that the tab character got written correctly
-                self.assertTrue(dllines[0].find("\t") > 0)
-
-                # Upgrade
-                self.pkg("{0} devlinktest@2.0".format(install_cmd))
-                self.pkg("verify -v")
-
-                dllines = readfile()
-
-                # Verify that there are four entries now
-                self.assertTrue(len(dllines) == 4)
-
-                # Verify they are what they should be
-                assertContents(dllines, ["zerg2", "zorg", "borg", "zork"])
-
-                # Remove
-                self.pkg("uninstall devlinktest")
-                self.pkg("verify -v")
-
-                # Install again
-                self.pkg("install devlinktest@1.0")
-
-                # Diddle with it
-                dllines = readfile()
-                for i, line in enumerate(dllines):
-                        if line.find("zerg") != -1:
-                                dllines[i] = "type=ddi_pseudo;name=zippy\t\\D\n"
-                writefile(dllines)
-
-                # Upgrade
-                self.pkg("{0} devlinktest@2.0".format(install_cmd))
-
-                # Verify that we spewed a message on upgrade
-                self.assertTrue(self.output.find("not found") != -1)
-                self.assertTrue(self.output.find("name=zerg") != -1)
-
-                # Verify the new set
-                dllines = readfile()
-                self.assertTrue(len(dllines) == 5)
-                assertContents(dllines,
-                    ["zerg2", "zorg", "borg", "zork", "zippy"])
-
-                self.pkg("uninstall devlinktest")
-
-                # Null out the "zippy" entry
-                writefile([])
-
-                # Install again
-                self.pkg("install devlinktest@1.0")
-
-                # Diddle with it
-                dllines = readfile()
-                for i, line in enumerate(dllines):
-                        if line.find("zerg") != -1:
-                                dllines[i] = "type=ddi_pseudo;name=zippy\t\\D\n"
-                writefile(dllines)
-
-                # Remove
-                self.pkg("uninstall devlinktest")
-
-                # Verify that we spewed a message on removal
-                self.assertTrue(self.output.find("not found") != -1)
-                self.assertTrue(self.output.find("name=zerg") != -1)
-
-                # Verify that the one left behind was the one we overwrote.
-                dllines = readfile()
-                self.assertTrue(len(dllines) == 1)
-                assertContents(dllines, ["zippy"])
-
-                # Null out the "zippy" entry, but add the "zerg" entry
-                writefile(["type=ddi_pseudo;name=zerg\t\\D\n"])
-
-                # Install ... again
-                self.pkg("install devlinktest@1.0")
-
-                # Make sure we didn't get a second zerg line
-                dllines = readfile()
-                self.assertTrue(len(dllines) == 3, msg=dllines)
-                assertContents(dllines, ["zerg", "borg", "warg"])
-
-                # Now for the same test on upgrade
-                dllines.append("type=ddi_pseudo;name=zorg\t\\D\n")
-                writefile(dllines)
-
-                self.pkg("{0} devlinktest@2.0".format(install_cmd))
-                dllines = readfile()
-                self.assertTrue(len(dllines) == 4, msg=dllines)
-                assertContents(dllines, ["zerg2", "zorg", "borg", "zork"])
-
-        def test_driver_aliases_upgrade(self):
-                """Make sure that aliases properly appear and disappear on
-                upgrade.  This is the result of a bug in update_drv, but it's
-                not a bad idea to test some of this ourselves."""
-
-                self.driver_aliases_upgrade_helper("install")
-                self.driver_aliases_upgrade_helper("exact-install")
-
-        def driver_aliases_upgrade_helper(self, install_cmd):
-                # driver actions are not valid except on OpenSolaris
-                if portable.util.get_canonical_os_name() != "sunos":
-                        return
-
-                self.pkgsend_bulk(self.rurl, [self.devicebase, self.devalias10,
-                    self.devalias20])
-
-                self.image_create(self.rurl)
-                self.pkg("{0} devicebase devalias@1".format(install_cmd))
-                self.pkg("update devalias")
-                self.pkg("verify devalias")
-
-                daf = open(os.path.join(self.get_img_path(),
-                    "etc/driver_aliases"))
-                dalines = daf.readlines()
-                daf.close()
-
-                self.assertTrue(len(dalines) == 1, msg=dalines)
-                self.assertTrue(",1234" not in dalines[0])
-                self.assertTrue(",4321" not in dalines[0])
-                self.assertTrue(",5555" in dalines[0])
-
-        def test_driver_aliases_move(self):
-                """Make sure that an alias can be moved from one driver action
-                to another."""
-
-                self.driver_aliases_move_helper("install")
-                self.driver_aliases_move_helper("exact-install")
-
-        def driver_aliases_move_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, [self.devicebase,
-                    self.devaliasmove10, self.devaliasmove20])
-
-                self.image_create(self.rurl)
-                self.pkg("{0} devicebase devaliasmove@1".format(install_cmd))
-                self.pkg("update devaliasmove")
-                self.assertTrue("pci8086,5555" not in self.output)
-
-        def test_uninstall_without_perms(self):
-                """Verify uninstall fails as expected for unprivileged users."""
-
-                pkg_list = [self.foo10, self.only_attr10, self.only_depend10,
-                    self.only_directory10, self.only_file10,
-                    self.only_group10, self.only_hardlink10, self.only_legacy10,
-                    self.only_license10, self.only_link10, self.only_user10]
-
-                # driver actions are not valid except on OpenSolaris
-                if portable.util.get_canonical_os_name() == 'sunos':
-                        pkg_list += [self.only_driver10]
-
-                self.pkgsend_bulk(self.rurl, pkg_list + [
-                    self.devicebase + self.basics0 + self.basics1])
-
-                self.image_create(self.rurl)
-
-                name_pat = re.compile(r"^\s+open\s+(\S+)\@.*$")
-
-                def __manually_check_deps(name, install=True, exit=0):
-                        cmd = ["install", "--no-refresh"]
-                        if not install:
-                                cmd = ["uninstall"]
-                        if name == "only_depend" and not install:
-                                self.pkg(cmd + ["foo"], exit=exit)
-                        elif name == "only_driver":
-                                self.pkg(cmd + ["devicebase"], exit=exit)
-                        elif name == "only_group":
-                                self.pkg(cmd + ["basics"], exit=exit)
-                        elif name == "only_hardlink":
-                                self.pkg(cmd + ["only_file"], exit=exit)
-                        elif name == "only_user":
-                                if install:
-                                        self.pkg(cmd + ["basics"], exit=exit)
-                                        self.pkg(cmd + ["only_group"],
-                                            exit=exit)
-                                else:
-                                        self.pkg(cmd + ["only_group"],
-                                            exit=exit)
-                                        self.pkg(cmd + ["basics"], exit=exit)
-                for p in pkg_list:
-                        name_mat = name_pat.match(p.splitlines()[1])
-                        pname = name_mat.group(1)
-                        __manually_check_deps(pname, exit=[0, 4])
-                        self.pkg(["install", "--no-refresh", pname],
-                            su_wrap=True, exit=1)
-                        self.pkg(["install", pname], su_wrap=True,
-                            exit=1)
-                        self.pkg(["install", "--no-refresh", pname])
-                        self.pkg(["uninstall", pname], su_wrap=True,
-                            exit=1)
-                        self.pkg(["uninstall", pname])
-                        __manually_check_deps(pname, install=False)
-
-                for p in pkg_list:
-                        name_mat = name_pat.match(p.splitlines()[1])
-                        pname = name_mat.group(1)
-                        __manually_check_deps(pname, exit=[0, 4])
-                        self.pkg(["install", "--no-refresh", pname])
-
-                for p in pkg_list:
-                        self.pkgsend_bulk(self.rurl, p)
-                self.pkgsend_bulk(self.rurl, (self.devicebase, self.basics0,
-                    self.basics1))
-
-                # Modifying operations require permissions needed to create and
-                # manage lock files.
-                self.pkg(["update", "--no-refresh"], su_wrap=True, exit=1)
-
-                self.pkg(["refresh"])
-                self.pkg(["update"], su_wrap=True, exit=1)
-                # Should fail since user doesn't have permission to refresh
-                # publisher metadata.
-                self.pkg(["refresh", "--full"], su_wrap=True, exit=1)
-                self.pkg(["refresh", "--full"])
-                self.pkg(["update", "--no-refresh"], su_wrap=True,
-                    exit=1)
-                self.pkg(["update"])
-
-        def test_bug_3222(self):
-                """ Verify that a timestamp of '0' for a passwd file will not
-                    cause further package operations to fail.  This can happen
-                    when there are time synchronization issues within a virtual
-                    environment or in other cases. """
-
-                self.pkgsend_bulk(self.rurl, (self.basics0, self.only_user10,
-                    self.only_user_file10, self.only_group10,
-                    self.only_group_file10, self.grouptest, self.usertest10))
-                self.image_create(self.rurl)
-                fname = os.path.join(self.get_img_path(), "etc", "passwd")
-                self.pkg("install basics")
-
-                # This should work regardless of whether a user is installed
-                # at the same time as the file in a package, or if the user is
-                # installed first and then files owned by that user are
-                # installed.
-                plists = [["grouptest", "usertest"],
-                    ["only_user", "only_user_file"],
-                    ["only_group", "only_group_file"]]
-                for plist in plists:
-                        for pname in plist:
-                                os.utime(fname, (0, 0))
-                                self.pkg("install {0}".format(pname))
-                                self.pkg("verify")
-
-                        for pname in reversed(plist):
-                                os.utime(fname, (0, 0))
-                                self.pkg("uninstall {0}".format(pname))
-                                self.pkg("verify")
-
-        def test_bad_hardlinks(self):
-                """A couple of bogus hard link target tests."""
-
-                self.bad_hardlinks_helper("install")
-                self.bad_hardlinks_helper("exact-install")
-
-        def bad_hardlinks_helper(self, install_cmd):
-                self.pkgsend_bulk(self.rurl, (self.badhardlink1,
-                    self.badhardlink2))
-                self.image_create(self.rurl)
-
-                # A package which tries to install a hard link to a target that
-                # doesn't exist shouldn't stack trace, but exit sanely.
-                self.pkg("{0} badhardlink1".format(install_cmd), exit=1)
-
-                # A package which tries to install a hard link to a target
-                # specified as an absolute path should install that link
-                # relative to the image root.
-                self.pkg("{0} badhardlink2".format(install_cmd))
-                ino1 = os.stat(os.path.join(self.get_img_path(), "foo")).st_ino
-                ino2 = os.stat(os.path.join(self.get_img_path(), "etc/motd")).st_ino
-                self.assertTrue(ino1 == ino2)
-
-        def test_hardlink_chain(self):
-                self.pkgsend_bulk(self.rurl, (self.hardlink_chain))
-                self.image_create(self.rurl)
-
-                # A package which tries to install a hard link to another
-                # hardlink should install them in the correct order.
-                self.pkg("{0} hardlink_chain".format("install"))
-
-        def test_legacy(self):
-                self.pkgsend_bulk(self.rurl,
-                    (self.csu1, self.csu1_2, self.csu2, self.csu2_2,
-                    self.csu3, self.csu3_2))
-                self.image_create(self.rurl)
-
-                self.pkg("install csu1@1 csu2@1 csu3@1")
-
-                # Make sure we installed one and only one pkginfo file, and with
-                # the correct information.
-                vsp = self.get_img_file_path("var/sadm/pkg")
-                pi = os.path.join(vsp, "SUNWcsu/pkginfo")
-                pi2 = os.path.join(vsp, "SUNWcsu/pkginfo.2")
-                pi3 = os.path.join(vsp, "SUNWcsu/pkginfo.3")
-                self.assertTrue(os.path.exists(pi), "pkginfo doesn't exist")
-                self.file_contains(pi, "VERSION=11.11,REV=2009.11.11")
-                self.assertTrue(not os.path.exists(pi2), "pkginfo.2 exists")
-                self.assertTrue(not os.path.exists(pi3), "pkginfo.3 exists")
-                # Create the hardlinks as we'd have for the old refcounting
-                # system.
-                os.link(pi, pi2)
-                os.link(pi, pi3)
-
-                # Make sure that upgrading the actions modifies the pkginfo file
-                # correctly, and that the hardlinks go away.
-                self.pkg("update")
-                self.file_contains(pi, "VERSION=11.11,REV=2010.11.11")
-                self.assertTrue(not os.path.exists(pi2), "pkginfo.2 exists")
-                self.assertTrue(not os.path.exists(pi3), "pkginfo.3 exists")
-
-                # Start over, but this time "break" the hardlinks.
-                self.pkg("uninstall -vvv \\*")
-                self.pkg("install csu1@1 csu2@1 csu3@1")
-                shutil.copy(pi, pi2)
-                shutil.copy(pi, pi3)
-                self.pkg("update")
-                self.file_contains(pi, "VERSION=11.11,REV=2010.11.11")
-                self.assertTrue(not os.path.exists(pi2), "pkginfo.2 exists")
-                self.assertTrue(not os.path.exists(pi3), "pkginfo.3 exists")
+                    self.pkg(cmd + ["only_group"], exit=exit)
+                    self.pkg(cmd + ["basics"], exit=exit)
+
+        for p in pkg_list:
+            name_mat = name_pat.match(p.splitlines()[1])
+            pname = name_mat.group(1)
+            __manually_check_deps(pname, exit=[0, 4])
+            self.pkg(["install", "--no-refresh", pname], su_wrap=True, exit=1)
+            self.pkg(["install", pname], su_wrap=True, exit=1)
+            self.pkg(["install", "--no-refresh", pname])
+            self.pkg(["uninstall", pname], su_wrap=True, exit=1)
+            self.pkg(["uninstall", pname])
+            __manually_check_deps(pname, install=False)
+
+        for p in pkg_list:
+            name_mat = name_pat.match(p.splitlines()[1])
+            pname = name_mat.group(1)
+            __manually_check_deps(pname, exit=[0, 4])
+            self.pkg(["install", "--no-refresh", pname])
+
+        for p in pkg_list:
+            self.pkgsend_bulk(self.rurl, p)
+        self.pkgsend_bulk(
+            self.rurl, (self.devicebase, self.basics0, self.basics1)
+        )
+
+        # Modifying operations require permissions needed to create and
+        # manage lock files.
+        self.pkg(["update", "--no-refresh"], su_wrap=True, exit=1)
+
+        self.pkg(["refresh"])
+        self.pkg(["update"], su_wrap=True, exit=1)
+        # Should fail since user doesn't have permission to refresh
+        # publisher metadata.
+        self.pkg(["refresh", "--full"], su_wrap=True, exit=1)
+        self.pkg(["refresh", "--full"])
+        self.pkg(["update", "--no-refresh"], su_wrap=True, exit=1)
+        self.pkg(["update"])
+
+    def test_bug_3222(self):
+        """Verify that a timestamp of '0' for a passwd file will not
+        cause further package operations to fail.  This can happen
+        when there are time synchronization issues within a virtual
+        environment or in other cases."""
+
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.basics0,
+                self.only_user10,
+                self.only_user_file10,
+                self.only_group10,
+                self.only_group_file10,
+                self.grouptest,
+                self.usertest10,
+            ),
+        )
+        self.image_create(self.rurl)
+        fname = os.path.join(self.get_img_path(), "etc", "passwd")
+        self.pkg("install basics")
+
+        # This should work regardless of whether a user is installed
+        # at the same time as the file in a package, or if the user is
+        # installed first and then files owned by that user are
+        # installed.
+        plists = [
+            ["grouptest", "usertest"],
+            ["only_user", "only_user_file"],
+            ["only_group", "only_group_file"],
+        ]
+        for plist in plists:
+            for pname in plist:
+                os.utime(fname, (0, 0))
+                self.pkg("install {0}".format(pname))
+                self.pkg("verify")
+
+            for pname in reversed(plist):
+                os.utime(fname, (0, 0))
+                self.pkg("uninstall {0}".format(pname))
+                self.pkg("verify")
+
+    def test_bad_hardlinks(self):
+        """A couple of bogus hard link target tests."""
+
+        self.bad_hardlinks_helper("install")
+        self.bad_hardlinks_helper("exact-install")
+
+    def bad_hardlinks_helper(self, install_cmd):
+        self.pkgsend_bulk(self.rurl, (self.badhardlink1, self.badhardlink2))
+        self.image_create(self.rurl)
+
+        # A package which tries to install a hard link to a target that
+        # doesn't exist shouldn't stack trace, but exit sanely.
+        self.pkg("{0} badhardlink1".format(install_cmd), exit=1)
+
+        # A package which tries to install a hard link to a target
+        # specified as an absolute path should install that link
+        # relative to the image root.
+        self.pkg("{0} badhardlink2".format(install_cmd))
+        ino1 = os.stat(os.path.join(self.get_img_path(), "foo")).st_ino
+        ino2 = os.stat(os.path.join(self.get_img_path(), "etc/motd")).st_ino
+        self.assertTrue(ino1 == ino2)
+
+    def test_hardlink_chain(self):
+        self.pkgsend_bulk(self.rurl, (self.hardlink_chain))
+        self.image_create(self.rurl)
+
+        # A package which tries to install a hard link to another
+        # hardlink should install them in the correct order.
+        self.pkg("{0} hardlink_chain".format("install"))
+
+    def test_legacy(self):
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.csu1,
+                self.csu1_2,
+                self.csu2,
+                self.csu2_2,
+                self.csu3,
+                self.csu3_2,
+            ),
+        )
+        self.image_create(self.rurl)
+
+        self.pkg("install csu1@1 csu2@1 csu3@1")
+
+        # Make sure we installed one and only one pkginfo file, and with
+        # the correct information.
+        vsp = self.get_img_file_path("var/sadm/pkg")
+        pi = os.path.join(vsp, "SUNWcsu/pkginfo")
+        pi2 = os.path.join(vsp, "SUNWcsu/pkginfo.2")
+        pi3 = os.path.join(vsp, "SUNWcsu/pkginfo.3")
+        self.assertTrue(os.path.exists(pi), "pkginfo doesn't exist")
+        self.file_contains(pi, "VERSION=11.11,REV=2009.11.11")
+        self.assertTrue(not os.path.exists(pi2), "pkginfo.2 exists")
+        self.assertTrue(not os.path.exists(pi3), "pkginfo.3 exists")
+        # Create the hardlinks as we'd have for the old refcounting
+        # system.
+        os.link(pi, pi2)
+        os.link(pi, pi3)
+
+        # Make sure that upgrading the actions modifies the pkginfo file
+        # correctly, and that the hardlinks go away.
+        self.pkg("update")
+        self.file_contains(pi, "VERSION=11.11,REV=2010.11.11")
+        self.assertTrue(not os.path.exists(pi2), "pkginfo.2 exists")
+        self.assertTrue(not os.path.exists(pi3), "pkginfo.3 exists")
+
+        # Start over, but this time "break" the hardlinks.
+        self.pkg("uninstall -vvv \\*")
+        self.pkg("install csu1@1 csu2@1 csu3@1")
+        shutil.copy(pi, pi2)
+        shutil.copy(pi, pi3)
+        self.pkg("update")
+        self.file_contains(pi, "VERSION=11.11,REV=2010.11.11")
+        self.assertTrue(not os.path.exists(pi2), "pkginfo.2 exists")
+        self.assertTrue(not os.path.exists(pi3), "pkginfo.3 exists")
+
 
 class TestDependencies(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        pkg10 = """
+    pkg10 = """
             open pkg1@1.0,5.11-0
             add depend type=optional fmri=pkg:/pkg2
             close
         """
 
-        pkg20 = """
+    pkg20 = """
             open pkg2@1.0,5.11-0
             close
         """
 
-        pkg11 = """
+    pkg11 = """
             open pkg1@1.1,5.11-0
             add depend type=optional fmri=pkg:/pkg2@1.1
             close
         """
 
-        pkg21 = """
+    pkg21 = """
             open pkg2@1.1,5.11-0
             close
         """
 
-        pkg30 = """
+    pkg30 = """
             open pkg3@1.0,5.11-0
             add depend type=require fmri=pkg:/pkg1@1.1
             close
         """
 
-        pkg40 = """
+    pkg40 = """
             open pkg4@1.0,5.11-0
             add depend type=exclude fmri=pkg:/pkg1@1.1
             close
         """
 
-        pkg50 = """
+    pkg50 = """
             open pkg5@1.0,5.11-0
             add depend type=exclude fmri=pkg:/pkg1@1.1
             add depend type=require fmri=pkg:/pkg1@1.0
             close
         """
 
-        pkg505 = """
+    pkg505 = """
             open pkg5@1.0.5,5.11-0
             add depend type=exclude fmri=pkg:/pkg1@1.1
             add depend type=require fmri=pkg:/pkg1@1.0
             close
         """
-        pkg51 = """
+    pkg51 = """
             open pkg5@1.1,5.11-0
             add depend type=exclude fmri=pkg:/pkg1@1.1
             add depend type=exclude fmri=pkg:/pkg2
             add depend type=require fmri=pkg:/pkg1@1.0
             close
         """
-        pkg60 = """
+    pkg60 = """
             open pkg6@1.0,5.11-0
             add depend type=exclude fmri=pkg:/pkg1@1.1
             close
         """
 
-        pkg61 = """
+    pkg61 = """
             open pkg6@1.1,5.11-0
             close
         """
 
-        bug_18653 = """
+    bug_18653 = """
             open entire@1.0,5.11-0
             add depend type=incorporate fmri=osnet-incorporation@1.0
             close
@@ -6964,108 +7138,111 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        pkg70 = """
+    pkg70 = """
             open pkg7@1.0,5.11-0
             add depend type=conditional predicate=pkg:/pkg2@1.1 fmri=pkg:/pkg6@1.1
             close
         """
 
-        pkg71 = """
+    pkg71 = """
             open pkg7@1.1,5.11-0
             add depend type=conditional predicate=pkg:/pkg2@1.1 fmri=pkg:/nonsuch
             close
         """
 
-        pkg80 = """
+    pkg80 = """
             open pkg8@1.0,5.11-0
             add depend type=require-any fmri=pkg:/pkg9@1.0 fmri=pkg:/pkg2@1.1 fmri=pkg:/nonsuch
             close
         """
 
-        pkg81 = """
+    pkg81 = """
             open pkg8@1.1,5.11-0
             add depend type=require-any fmri=pkg:/pkg9@1.1 fmri=pkg:/pkg2@1.1 fmri=pkg:/nonsuch
             close
         """
 
-        pkg90 = """
+    pkg90 = """
             open pkg9@1.0,5.11-0
             close
         """
 
-        pkg91 = """
+    pkg91 = """
             open pkg9@1.1,5.11-0
             close
         """
 
-        pkg100 = """
+    pkg100 = """
             open pkg10@1.0,5.11-0
             close
         """
 
-        pkg101 = """
+    pkg101 = """
             open pkg10@1.1,5.11-0
             close
         """
 
-        pkg102 = """
+    pkg102 = """
             open pkg10@1.2,5.11-0
             add depend type=origin fmri=pkg10@1.1,5.11-0
             close
         """
 
-        pkg110 = """
+    pkg110 = """
             open pkg11@1.0,5.11-0
             add depend type=origin root-image=true fmri=SUNWcs@0.5.11-0.75
             close
         """
-        pkg111 = """
+    pkg111 = """
             open pkg11@1.1,5.11-0
             add depend type=origin root-image=true fmri=SUNWcs@0.5.11-1.0
             close
         """
 
-        pkg121 = """
+    pkg121 = """
             open pkg12@1.1,5.11-0
         """
-        pkg121 += "add depend type=parent fmri={0}".format(
-            pkg.actions.depend.DEPEND_SELF)
-        pkg121 += """
+    pkg121 += "add depend type=parent fmri={0}".format(
+        pkg.actions.depend.DEPEND_SELF
+    )
+    pkg121 += """
             close
         """
 
-        pkg122 = """
+    pkg122 = """
             open pkg12@1.2,5.11-0
         """
-        pkg122 += "add depend type=parent fmri={0}".format(
-            pkg.actions.depend.DEPEND_SELF)
-        pkg122 += """
+    pkg122 += "add depend type=parent fmri={0}".format(
+        pkg.actions.depend.DEPEND_SELF
+    )
+    pkg122 += """
             close
         """
 
-        pkg123 = """
+    pkg123 = """
             open pkg12@1.3,5.11-0
         """
-        pkg123 += "add depend type=parent fmri={0}".format(
-            pkg.actions.depend.DEPEND_SELF)
-        pkg123 += """
+    pkg123 += "add depend type=parent fmri={0}".format(
+        pkg.actions.depend.DEPEND_SELF
+    )
+    pkg123 += """
             close
         """
 
-        pkg132 = """
+    pkg132 = """
             open pkg13@1.2,5.11-0
             add depend type=parent fmri=pkg12@1.2,5.11-0
             close
         """
 
-        pkg142 = """
+    pkg142 = """
             open pkg14@1.2,5.11-0
             add depend type=parent fmri=pkg12@1.2,5.11-0
             add depend type=parent fmri=pkg13@1.2,5.11-0
             close
         """
 
-        pkg_nosol = """
+    pkg_nosol = """
             open pkg-nosol-A@1.0,5.11-0
             add depend type=require-any fmri=pkg:/pkg-nosol-B fmri=pkg:/pkg-nosol-C
             add depend type=require fmri=pkg:/pkg-nosol-D
@@ -7085,7 +7262,7 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        pkg_renames = """
+    pkg_renames = """
             open pkg_need_rename@1.0,5.11-0
             add depend type=require fmri=pkg_rename
             close
@@ -7103,61 +7280,55 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        pkgSUNWcs075 = """
+    pkgSUNWcs075 = """
             open SUNWcs@0.5.11-0.75
             close
         """
 
-        leaf_template = """
+    leaf_template = """
             open pkg{0}{1}@{2},5.11-0
             add depend type=require fmri=pkg:/{3}_incorp{4}
             close
         """
-        install_hold = "add set name=pkg.depend.install-hold value=test"
+    install_hold = "add set name=pkg.depend.install-hold value=test"
 
-        leaf_expansion = [
-                ("A","_0", "1.0", "A", ""),
-                ("A","_1", "1.0", "A", ""),
-                ("A","_2", "1.0", "A", ""),
-                ("A","_3", "1.0", "A", ""),
+    leaf_expansion = [
+        ("A", "_0", "1.0", "A", ""),
+        ("A", "_1", "1.0", "A", ""),
+        ("A", "_2", "1.0", "A", ""),
+        ("A", "_3", "1.0", "A", ""),
+        ("B", "_0", "1.0", "B", ""),
+        ("B", "_1", "1.0", "B", ""),
+        ("B", "_2", "1.0", "B", ""),
+        ("B", "_3", "1.0", "B", ""),
+        ("A", "_0", "1.1", "A", "@1.1"),
+        ("A", "_1", "1.1", "A", "@1.1"),
+        ("A", "_2", "1.1", "A", "@1.1"),
+        ("A", "_3", "1.1", "A", "@1.1"),
+        ("B", "_0", "1.1", "B", "@1.1"),
+        ("B", "_1", "1.1", "B", "@1.1"),
+        ("B", "_2", "1.1", "B", "@1.1"),
+        ("B", "_3", "1.1", "B", "@1.1"),
+        ("A", "_0", "1.2", "A", "@1.2"),
+        ("A", "_1", "1.2", "A", "@1.2"),
+        ("A", "_2", "1.2", "A", "@1.2"),
+        ("A", "_3", "1.2", "A", "@1.2"),
+        ("B", "_0", "1.2", "B", "@1.2"),
+        ("B", "_1", "1.2", "B", "@1.2"),
+        ("B", "_2", "1.2", "B", "@1.2"),
+        ("B", "_3", "1.2", "B", "@1.2"),
+        ("A", "_0", "1.3", "A", ""),
+        ("A", "_1", "1.3", "A", ""),
+        ("A", "_2", "1.3", "A", ""),
+        ("A", "_3", "1.3", "A", ""),
+        ("B", "_0", "1.3", "B", ""),
+        ("B", "_1", "1.3", "B", ""),
+        ("B", "_2", "1.3", "B", ""),
+        ("B", "_3", "1.3", "B", ""),
+    ]
 
-                ("B","_0", "1.0", "B", ""),
-                ("B","_1", "1.0", "B", ""),
-                ("B","_2", "1.0", "B", ""),
-                ("B","_3", "1.0", "B", ""),
-
-                ("A","_0", "1.1", "A", "@1.1"),
-                ("A","_1", "1.1", "A", "@1.1"),
-                ("A","_2", "1.1", "A", "@1.1"),
-                ("A","_3", "1.1", "A", "@1.1"),
-
-                ("B","_0", "1.1", "B", "@1.1"),
-                ("B","_1", "1.1", "B", "@1.1"),
-                ("B","_2", "1.1", "B", "@1.1"),
-                ("B","_3", "1.1", "B", "@1.1"),
-
-                ("A","_0", "1.2", "A", "@1.2"),
-                ("A","_1", "1.2", "A", "@1.2"),
-                ("A","_2", "1.2", "A", "@1.2"),
-                ("A","_3", "1.2", "A", "@1.2"),
-
-                ("B","_0", "1.2", "B", "@1.2"),
-                ("B","_1", "1.2", "B", "@1.2"),
-                ("B","_2", "1.2", "B", "@1.2"),
-                ("B","_3", "1.2", "B", "@1.2"),
-
-                ("A","_0", "1.3", "A", ""),
-                ("A","_1", "1.3", "A", ""),
-                ("A","_2", "1.3", "A", ""),
-                ("A","_3", "1.3", "A", ""),
-
-                ("B","_0", "1.3", "B", ""),
-                ("B","_1", "1.3", "B", ""),
-                ("B","_2", "1.3", "B", ""),
-                ("B","_3", "1.3", "B", "")
-                ]
-
-        incorps = [ """
+    incorps = [
+        """
             open A_incorp@1.0,5.11-0
             add depend type=incorporate fmri=pkg:/pkgA_0@1.0
             add depend type=incorporate fmri=pkg:/pkgA_1@1.0
@@ -7165,7 +7336,6 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add depend type=incorporate fmri=pkg:/pkgA_3@1.0
             close
         """,
-
         """
             open B_incorp@1.0,5.11-0
             add depend type=incorporate fmri=pkg:/pkgB_0@1.0
@@ -7174,7 +7344,6 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add depend type=incorporate fmri=pkg:/pkgB_3@1.0
             close
         """,
-
         """
             open A_incorp@1.1,5.11-0
             add depend type=incorporate fmri=pkg:/pkgA_0@1.1
@@ -7184,7 +7353,6 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add set name=pkg.depend.install-hold value=test
             close
         """,
-
         """
             open B_incorp@1.1,5.11-0
             add depend type=incorporate fmri=pkg:/pkgB_0@1.1
@@ -7194,7 +7362,6 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add set name=pkg.depend.install-hold value=test
             close
         """,
-
         """
             open A_incorp@1.2,5.11-0
             add depend type=incorporate fmri=pkg:/pkgA_0@1.2
@@ -7204,7 +7371,6 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add set name=pkg.depend.install-hold value=test.A
             close
         """,
-
         """
             open B_incorp@1.2,5.11-0
             add depend type=incorporate fmri=pkg:/pkgB_0@1.2
@@ -7214,7 +7380,6 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add set name=pkg.depend.install-hold value=test.B
             close
         """,
-
         """
             open A_incorp@1.3,5.11-0
             add depend type=incorporate fmri=pkg:/pkgA_0@1.3
@@ -7224,7 +7389,6 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add set name=pkg.depend.install-hold value=test.A
             close
         """,
-
         """
             open B_incorp@1.3,5.11-0
             add depend type=incorporate fmri=pkg:/pkgB_0@1.3
@@ -7234,7 +7398,6 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add set name=pkg.depend.install-hold value=test.B
             close
         """,
-
         """
             open incorp@1.0,5.11-0
             add depend type=incorporate fmri=pkg:/A_incorp@1.0
@@ -7242,7 +7405,6 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add set name=pkg.depend.install-hold value=test
             close
         """,
-
         """
             open incorp@1.1,5.11-0
             add depend type=incorporate fmri=pkg:/A_incorp@1.1
@@ -7250,7 +7412,6 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add set name=pkg.depend.install-hold value=test
             close
         """,
-
         """
             open incorp@1.2,5.11-0
             add depend type=incorporate fmri=pkg:/A_incorp@1.2
@@ -7264,16 +7425,16 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             add depend type=exclude fmri=pkg:/pkgB_0
             add set name=pkg.depend.install-hold value=test
             close
-        """
-        ]
+        """,
+    ]
 
-        bug_7394_incorp = """
+    bug_7394_incorp = """
             open bug_7394_incorp@1.0,5.11-0
             add depend type=incorporate fmri=pkg:/pkg1@2.0
             close
         """
 
-        exclude_group = """
+    exclude_group = """
             open network/rsync@1.0
             close
             open gold-server@1.0
@@ -7284,7 +7445,7 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        optional_group = """
+    optional_group = """
             open consolidation/desktop/desktop-incorporation@0.5.11-0.175.3.0.0.28.0
             add depend type=incorporate fmri=communication/im/pidgin@2.10.11-0.175.3.0.0.26.0
             close
@@ -7302,2380 +7463,2488 @@ class TestDependencies(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self, image_count=2)
-                self.pkgsend_bulk(self.rurl, (self.pkg10, self.pkg20,
-                    self.pkg11, self.pkg21, self.pkg30, self.pkg40, self.pkg50,
-                    self.pkg505, self.pkg51, self.pkg60, self.pkg61,
-                    self.bug_18653,
-                    self.pkg70, self.pkg71, self.pkg80, self.pkg81,
-                    self.pkg90, self.pkg91, self.bug_7394_incorp, self.pkg100,
-                    self.pkg101, self.pkg102, self.pkg110, self.pkg111,
-                    self.pkg121, self.pkg122, self.pkg123, self.pkg132,
-                    self.pkg142, self.pkg_nosol, self.pkg_renames,
-                    self.pkgSUNWcs075, self.exclude_group,
-                    self.optional_group))
-
-                self.leaf_pkgs = []
-                for t in self.leaf_expansion:
-                        self.leaf_pkgs.extend(self.pkgsend_bulk(self.rurl,
-                            self.leaf_template.format(*t)))
-
-                self.incorp_pkgs = []
-                for i in self.incorps:
-                        self.incorp_pkgs.extend(self.pkgsend_bulk(self.rurl, i))
-
-        def test_rename_matching(self):
-                """Verify install or exact-install won't fail with a multiple
-                match error for a renamed package that shares a common
-                basename."""
-
-                self.rename_matching("install")
-                self.rename_matching("exact-install")
-
-        def rename_matching(self, install_cmd):
-                self.image_create(self.rurl)
-                self.pkg("{0} trusted".format(install_cmd))
-                self.pkg("info system/trusted")
-
-        def test_require_dependencies(self):
-                """ exercise require dependencies """
-
-                self.require_dependencies_helper("install")
-                self.require_dependencies_helper("exact-install")
-
-        def require_dependencies_helper(self, install_cmd):
-                self.image_create(self.rurl)
-                self.pkg("install pkg1@1.0")
-                self.pkg("verify  pkg1@1.0")
-                self.pkg("{0} pkg3@1.0".format(install_cmd))
-                self.pkg("verify  pkg3@1.0 pkg1@1.1")
-
-        def test_exclude_group_install(self):
-                """Verify that a simultaneous exclude and group dependency on
-                the same package is handled gracefully."""
-
-                self.image_create(self.rurl)
-
-                # These should fail (gracefully) because my-rsync packages
-                # excludes network/rsync which is a group dependency of
-                # gold-server package.
-                self.pkg("install network/rsync gold-server my-rsync", exit=1)
-
-                self.pkg("install network/rsync")
-                self.pkg("install gold-server my-rsync", exit=1)
-                self.pkg("uninstall '*'")
-
-                # This should succeed because network/rsync dependency is not
-                # installed.
-                self.pkg("avoid network/rsync")
-                self.pkg("install -nv gold-server my-rsync")
-
-                # This will install network/rsync and remove it from the avoid
-                # list.
-                self.pkg("install network/rsync")
-
-                # This should succeed because network/rsync will be removed and
-                # placed on avoid list as part of operation.
-                self.pkg("install --reject network/rsync gold-server my-rsync")
-
-                # Now remove gold-server and then verify install will fail.
-                self.pkg("uninstall gold-server")
-                self.pkg("unavoid network/rsync")
-
-                # This should fail as there's no installed constraining package
-                # and user didn't provide sufficient input.
-                self.pkg("install gold-server", exit=1)
-
-        def test_exclude_dependencies_install(self):
-                """ exercise exclude dependencies """
-
-                self.image_create(self.rurl)
-                # install pkg w/ exclude dep.
-                self.pkg("install pkg4@1.0")
-                self.pkg("verify  pkg4@1.0")
-                # install pkg that is allowed by dep
-                self.pkg("install pkg1@1.0")
-                self.pkg("verify  pkg1@1.0")
-                # try to install disallowed pkg
-                self.pkg("install pkg1@1.1", exit=1)
-                self.pkg("uninstall '*'")
-                # install pkg
-                self.pkg("install pkg1@1.1")
-                # try to install pkg exclude dep on already
-                # installed pkg
-                self.pkg("install pkg4@1.0", exit=1)
-                self.pkg("uninstall '*'")
-                # install a package w/ both exclude
-                # and require dependencies
-                self.pkg("install pkg5")
-                self.pkg("verify pkg5@1.1 pkg1@1.0 ")
-                self.pkg("uninstall '*'")
-                # pick pkg to install that fits constraint
-                # of already installed pkg
-                self.pkg("install pkg2")
-                self.pkg("install pkg5")
-                self.pkg("verify pkg5@1.0.5 pkg1@1.0 pkg2")
-                self.pkg("uninstall '*'")
-                # install a package that requires updating
-                # existing package to avoid exclude
-                # dependency
-                self.pkg("install pkg6@1.0")
-                self.pkg("install pkg1@1.1")
-                self.pkg("verify pkg1@1.1 pkg6@1.1")
-                self.pkg("uninstall '*'")
-                # try to install two incompatible pkgs
-                self.pkg("install pkg1@1.1 pkg4@1.0", exit=1)
-
-        def test_exclude_dependencies_exact_install(self):
-                """ exercise exclude dependencies """
-
-                self.image_create(self.rurl)
-                # Install pkg w/ exclude dep.
-                self.pkg("install pkg4@1.0")
-                self.pkg("verify  pkg4@1.0")
-
-                # Exact-install should ignore exclude dependencies,
-                # except user specifies both pkg name in command line.
-                self.pkg("exact-install pkg1@1.1")
-                self.pkg("uninstall '*'")
-
-                # Exact-install a package w/ both exclude
-                # and require dependencies.
-                self.pkg("exact-install pkg5")
-                self.pkg("verify pkg5@1.1 pkg1@1.0 ")
-                self.pkg("uninstall '*'")
-                # pick pkg to exact-install that fits constraint.
-                self.pkg("exact-install pkg2 pkg5")
-                self.pkg("verify pkg5@1.0.5 pkg1@1.0 pkg2")
-                self.pkg("uninstall '*'")
-                # Exact- install two packages with proper version selected for
-                # one package based on the version of the other package.
-                self.pkg("exact-install pkg6 pkg1@1.1")
-                self.pkg("verify pkg1@1.1 pkg6@1.1")
-                self.pkg("uninstall '*'")
-                # try to exact-install two incompatible pkgs
-                self.pkg("exact-install pkg1@1.1 pkg4@1.0", exit=1)
-
-        def test_optional_dependencies_install(self):
-                """ check to make sure that optional dependencies are enforced
-                """
-
-                self.image_create(self.rurl)
-                self.pkg("install pkg1@1.0")
-
-                # pkg2 is optional, it should not have been installed
-                self.pkg("list pkg2", exit=1)
-
-                self.pkg("install pkg2@1.0")
-
-                # this should install pkg1@1.1 and upgrade pkg2 to pkg2@1.1
-                self.pkg("install pkg1")
-                self.pkg("list pkg2@1.1")
-
-                self.pkg("uninstall pkg2")
-                self.pkg("list pkg2", exit=1)
-                # this should not install pkg2@1.0 because of the optional
-                # dependency in pkg1
-                self.pkg("list pkg1@1.1")
-                self.pkg("install pkg2@1.0", exit=1)
-
-        def test_optional_dependencies_exact_install(self):
-                """ check to make sure that optional dependencies are enforced
-                """
-
-                self.image_create(self.rurl)
-                self.pkg("exact-install pkg1@1.0")
-
-                # pkg2 is optional, it should not have been installed
-                self.pkg("list pkg2", exit=1)
-
-                self.pkg("install pkg2@1.1")
-
-                # Verify with exact-install, the optional dependency package
-                # should be removed.
-                self.pkg("exact-install pkg1")
-                self.pkg("list pkg2@1.1", exit=1)
-                self.pkg("list pkg1@1.1")
-
-                # Verify exact-install pkg2@1.0 should succeed and pkg1 should
-                # be removed.
-                self.pkg("exact-install pkg2@1.0")
-                self.pkg("list pkg1", exit=1)
-
-        def test_incorporation_dependencies_install(self):
-                """ shake out incorporation dependencies """
-
-                self.image_create(self.rurl)
-                # simple pkg requiring controlling incorp
-                # should control pkgA_1 as well
-                self.pkg("install -v pkgA_0@1.0 pkgA_1")
-                self.pkg("list")
-                self.pkg("verify pkgA_0@1.0 pkgA_1@1.0 A_incorp@1.0")
-                self.pkg("install A_incorp@1.1")
-                self.pkg("list pkgA_0@1.1 pkgA_1@1.1 A_incorp@1.1")
-                self.pkg("uninstall '*'")
-                # try nested incorporations
-                self.pkg("install -v incorp@1.0 pkgA_0 pkgB_0")
-                self.pkg("list")
-                self.pkg("list incorp@1.0 pkgA_0@1.0 pkgB_0@1.0 A_incorp@1.0 B_incorp@1.0")
-                # try to break incorporation
-                self.pkg("install -v A_incorp@1.1", exit=1) # fixed by incorp@1.0
-                # try update (using '*' which also checks that the update all
-                # path is used when '*' is specified)
-                self.pkg("update -v '*'")
-                self.pkg("list incorp@1.2")
-                self.pkg("list pkgA_0@1.2")
-                self.pkg("list pkgB_0@1.2")
-                self.pkg("list A_incorp@1.2")
-                self.pkg("list B_incorp@1.2")
-                self.pkg("uninstall '*'")
-                # what happens when incorporation specified
-                # a package that isn't in the catalog
-                self.pkg("install bug_7394_incorp")
-                self.pkg("install pkg1", exit=1)
-                self.pkg("uninstall '*'")
-                # test pkg.depend.install-hold feature
-                self.pkg("install -v A_incorp@1.1  pkgA_1")
-                self.pkg("list pkgA_1@1.1")
-                self.pkg("list A_incorp@1.1")
-                # next attempt will fail because incorporations prevent motion
-                # even though explicit dependency exists from pkg to
-                # incorporation.
-                self.pkg("install pkgA_1@1.2", exit=1)
-                # test to see if we could install both; presence of incorp
-                # causes relaxation of pkg.depend.install-hold and also test
-                # that parsable output works when -n is used
-                self.pkg("install -n --parsable=0 A_incorp@1.2 pkgA_1@1.2")
-                self.assertEqualParsable(self.output, change_packages=[
-                    [self.incorp_pkgs[2], self.incorp_pkgs[4]],
-                    [self.leaf_pkgs[9], self.leaf_pkgs[17]]])
-                # this attempt also succeeds because pkg.depend.install-hold is
-                # relaxed since A_incorp is on command line
-                self.pkg("install A_incorp@1.2")
-                self.pkg("list pkgA_1@1.2")
-                self.pkg("list A_incorp@1.2")
-                # now demonstrate w/ version 1.2 subincorps that master incorp
-                # prevents upgrade since pkg.depend.install-hold of master != other incorps
-                self.pkg("install incorp@1.2")
-                self.pkg("install A_incorp@1.3", exit=1)
-                self.pkg("install incorp@1.3")
-                self.pkg("list pkgA_1@1.3")
-                self.pkg("list A_incorp@1.3")
-
-        def test_incorporation_dependencies_exact_install(self):
-                """ shake out incorporation dependencies """
-
-                self.image_create(self.rurl)
-                # Simple pkg requiring controlling incorp
-                # should control pkgA_1 as well.
-                self.pkg("exact-install -v pkgA_0@1.0 pkgA_1")
-                self.pkg("list")
-                self.pkg("verify pkgA_0@1.0 pkgA_1@1.0 A_incorp@1.0")
-
-                # Verify exact-install will upgrade pkgA_0 and A_incorp to 1.1
-                #, and uninstall pkgA_1.
-                self.pkg("exact-install pkgA_0@1.1")
-                self.pkg("list pkgA_0@1.1 A_incorp@1.1")
-                self.pkg("uninstall '*'")
-
-                # Try nested incorporations.
-                self.pkg("exact-install -v incorp@1.0 pkgA_0 pkgB_0")
-                self.pkg("list incorp@1.0 pkgA_0@1.0 pkgB_0@1.0 A_incorp@1.0 B_incorp@1.0")
-                # Try to break incorporation.
-                self.pkg("exact-install -v incorp@1.0 A_incorp@1.1", exit=1) # fixed by incorp@1.0
-
-                # Only specify A_incorp@1.1 should succeed. install holds
-                # should be ignored.
-                self.pkg("exact-install -v A_incorp@1.1")
-                self.pkg("list A_incorp@1.1")
-                self.pkg("uninstall '*'")
-                # what happens when incorporation specified
-                # a package that isn't in the catalog.
-                self.pkg("exact-install pkg1 bug_7394_incorp", exit=1)
-                # test pkg.depend.install-hold feature.
-                self.pkg("exact-install -v A_incorp@1.1  pkgA_1")
-                self.pkg("list pkgA_1@1.1")
-                self.pkg("list A_incorp@1.1")
-
-        def test_conditional_dependencies_install(self):
-                """Get conditional dependencies working"""
-                self.image_create(self.rurl)
-                self.pkg("install pkg7@1.0")
-                self.pkg("verify")
-                self.pkg("list pkg6@1.1", exit=1) # should not be here
-                self.pkg("install -v pkg2@1.0")      # older version...
-                self.pkg("verify")
-                self.pkg("list pkg6@1.1", exit=1)
-                self.pkg("install -v pkg2@1.1")      # this triggers conditional dependency
-                self.pkg("verify")
-                self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0") # everyone is present
-                self.pkg("uninstall '*'")
-
-                self.pkg("install pkg2@1.1")  # install trigger
-                self.pkg("verify")
-                self.pkg("install pkg7@1.0")  # install pkg
-                self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0") # all here again
-                self.pkg("verify")
-                self.pkg("uninstall '*'")
-
-                # Test bug 18653
-                self.pkg("install osnet-incorporation@1.0 sun-solaris "
-                    "perl-510 sun-solaris-510")
-                # Uninstall should fail because sun-solaris conditional
-                # dependency requires sun-solaris-510.
-                self.pkg("uninstall sun-solaris-510", exit=1)
-                # Uninstalling both the predicate and the target of the
-                # conditional dependency should work.
-                self.pkg("uninstall perl-510 sun-solaris-510")
-                self.pkg("install perl-510")
-                # Check that reject also works.
-                self.pkg("update --reject perl-510 --reject sun-solaris-510")
-                self.pkg("uninstall '*'")
-
-                # Verify that if the predicate of a conditional can be
-                # installed, but the consequent cannot, the package delivering
-                # the conditional dependency can still be installed.
-                self.pkg("install -v entire osnet-incorporation@1.1 "
-                    "sun-solaris")
-
-                # Verify that the package incorporating a package that delivers
-                # a conditional for a consequent that cannot be installed can be
-                # removed.
-                self.pkg("uninstall -v entire")
-
-        def test_cond_depend_nonexist(self):
-
-                # pkg7@1.0 has conditional - install pkg6@1.1 if pkg2@1.1
-                # pkg7@1.1 has conditional on non-existent package if pkg2@1.1
-
-                self.image_create(self.rurl)
-
-                # installing pkg7@1.1 should work since the conditional
-                # requirement is predicated on pkg2, which is not installed
-                self.pkg('install pkg7@1.1')
-                self.pkg("uninstall '*'")
-
-                self.pkg("install pkg7@1.0 pkg2@1.0")
-                self.pkg("verify")
-                self.pkg("list pkg7@1.0 pkg2@1.0")
-                # pkg6 should not be installed
-                self.pkg("list pkg6", exit=1)
-
-                # upgrading to pkg7@1.1 should work fine since the non-existent
-                # package is only required if pkg2 is at 1.1 or above
-                self.pkg("update pkg7@1.1")
-                self.pkg("verify")
-                self.pkg("list pkg7@1.1")
-
-                # Installing pkg2@1.1 should fail as the conditionally required
-                # package does not exist
-                self.pkg("install pkg2@1.1", exit=1, assert_solution=False)
-
-        def test_cond_depend_uninstall(self):
-
-                # pkg7@1.0 has conditional - install pkg6@1.1 if pkg2@1.1
-
-                self.image_create(self.rurl)
-                self.pkg("install pkg7@1.0 pkg2@1.1")
-                self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")
-                self.pkg("verify")
-
-                # It should not be possible to uninstall pkg6@1.1
-                self.pkg("uninstall pkg6@1.1", exit=1)
-
-                # Uninstall pkg2 and then pkg6 should become uninstallable
-                self.pkg("uninstall pkg2")
-                self.pkg("uninstall pkg6")
-
-                # Install pkg2 again (which will trigger pkg6)
-                self.pkg("install pkg2@1.1")
-                self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")
-
-                # uninstall both together
-                self.pkg("uninstall pkg2 pkg6")
-
-                # Try unversioned pkg2
-                self.pkg("install -v pkg2")
-                self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")
-
-                # Downgrade pkg2 and pkg6 should become uninstallable
-                self.pkg("update pkg2@1.0")
-                self.pkg("uninstall pkg6")
-
-                # Upgrade pkg2 again and pkg6 should be re-installed
-                self.pkg("update pkg2")
-                self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")
-
-        def test_conditional_dependencies_exact_install(self):
-                """Get conditional dependencies working."""
-
-                self.image_create(self.rurl)
-                # Presenting pkg7@1.0 and pkg2@1.1 in the command line should
-                # trigger conditional dependency.
-                self.pkg("exact-install -v pkg7@1.0 pkg2@1.1")
-                self.pkg("verify")
-                self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")
-                self.pkg("uninstall '*'")
-
-                # If  only pkg7@1.0 present in the command line, pkg2@1.1
-                # should be removed and pkg6@1.1 should not be installed.
-                self.pkg("install pkg2@1.1")
-                self.pkg("verify")
-                self.pkg("exact-install pkg7@1.0")
-                self.pkg("list pkg7@1.0")
-                self.pkg("list pkg2@1.1", exit=1)
-                self.pkg("list pkg6@1.1", exit=1)
-                self.pkg("verify")
-                self.pkg("uninstall '*'")
-
-        def test_require_any_dependencies_install(self):
-                """Get require-any dependencies working"""
-                self.image_create(self.rurl)
-
-                # test to see if solver will fail gracefully when no solution is
-                # possible and a require-any dependency is involved
-                self.pkg("install -vvv pkg-nosol-A pkg-nosol-E",
-                    assert_solution=False, exit=9)
-
-                # test to see if solver will pick one
-                self.pkg("install pkg8@1.0")  # install pkg
-                self.pkg("verify")
-                self.pkg("list pkg8@1.0 pkg9@1.0 pkg2@1.1", exit=3)
-                self.pkg("uninstall '*'")
-
-                # test to see if solver will be happy w/ renamed packages,
-                # already installed dependencies.
-                self.pkg("install pkg:/pkg2@1.1")
-                self.pkg("install pkg_need_rename")
-                self.pkg("install pkg8@1.0")
-                self.pkg("verify")
-                self.pkg("list pkg8@1.0 pkg2@1.1")
-                self.pkg("uninstall '*'")
-
-                # test to see if solver will install new verion of existing
-                # package rather than add new package
-                self.pkg("install pkg8@1.0 pkg9@1.0")  # install pkg
-                self.pkg("verify")
-                self.pkg("list pkg8@1.0 pkg9@1.0")
-                self.pkg("list pkg2@1.1", exit=1)
-                self.pkg("install pkg8 pkg9") # will fail w/o pkg9 on list
-                self.pkg("verify")
-                self.pkg("list pkg8@1.1 pkg9@1.1")
-                self.pkg("uninstall '*'")
-
-                # see if update works the same way
-                self.pkg("install pkg8@1.0 pkg9@1.0")  # install pkg
-                self.pkg("image-update")
-                self.pkg("list pkg8@1.1 pkg9@1.1")
-                self.pkg("uninstall '*'")
-
-                # test to see if uninstall is clever enough
-                self.pkg("install pkg8@1.0 pkg9@1.0")  # install pkg
-                self.pkg("verify")
-                self.pkg("list pkg8@1.0 pkg9@1.0")
-                self.pkg("uninstall pkg9@1.0")
-                self.pkg("list pkg2@1.1")
-                self.pkg("verify")
-
-        def test_require_any_dependencies_exact_install(self):
-                """Get require-any dependencies working"""
-                self.image_create(self.rurl)
-
-                # Test to see if solver will fail gracefully when no solution is
-                # possible and a require-any dependency is involved.
-                self.pkg("exact-install -v pkg-nosol-A pkg-nosol-E",
-                    assert_solution=False, exit=9)
-
-                # Test to see if solver will pick one.
-                self.pkg("exact-install pkg8@1.0")
-                self.pkg("verify")
-                self.pkg("list pkg8@1.0 pkg9@1.0 pkg2@1.1", exit=3)
-                self.pkg("uninstall '*'")
-
-                # Test to see if solver will be happy w/ renamed packages,
-                # already installed dependencies.
-                self.pkg("exact-install pkg:/pkg2@1.1 pkg_need_rename "
-                    "pkg8@1.0")
-                self.pkg("verify")
-                self.pkg("list pkg8@1.0 pkg2@1.1")
-                self.pkg("uninstall '*'")
-
-                # test to see if solver will install new verion of existing
-                # package rather than add new package
-                self.pkg("exact-install pkg8@1.0 pkg9@1.0")  # install pkg
-                self.pkg("verify")
-                self.pkg("list pkg8@1.0 pkg9@1.0")
-                self.pkg("list pkg2@1.1", exit=1)
-                self.pkg("exact-install pkg8 pkg9")
-                self.pkg("verify")
-                self.pkg("list pkg8@1.1 pkg9@1.1")
-                self.pkg("list pkg2@1.1", exit=1)
-                self.pkg("uninstall '*'")
-
-        def test_origin_dependencies(self):
-                """Get origin dependencies working"""
-
-                self.origin_dependencies_helper("install")
-                self.origin_dependencies_helper("exact-install")
-
-        def origin_dependencies_helper(self, install_cmd):
-                self.set_image(0)
-                self.image_create(self.rurl)
-                self.set_image(1)
-                self.image_create(self.rurl)
-                self.set_image(0)
-                # check install or exact-install behavior
-                self.pkg("{0} pkg10@1.0".format(install_cmd))
-                self.pkg("{0} pkg10".format(install_cmd))
-                self.pkg("list pkg10@1.1")
-                self.pkg("{0} pkg10".format(install_cmd))
-                self.pkg("list pkg10@1.2")
-                self.pkg("uninstall '*'")
-                # check image-update behavior
-                self.pkg("install pkg10@1.0")
-                self.pkg("image-update")
-                self.pkg("list pkg10@1.1")
-                self.pkg("image-update")
-                self.pkg("list pkg10@1.2")
-                self.pkg("uninstall '*'")
-                # check that dependencies are ignored if
-                # dependency not present
-                self.pkg("{0} pkg10@1.2".format(install_cmd))
-                self.pkg("uninstall '*'")
-                # make sure attempts to force install don't work
-                self.pkg("{0} pkg10@1.0".format(install_cmd))
-                self.pkg("{0} pkg10@1.2".format(install_cmd), exit=1)
-                self.pkg("{0} pkg10@1.1".format(install_cmd))
-                self.pkg("{0} pkg10@1.2".format(install_cmd))
-                self.pkg("uninstall '*'")
-                # check origin root-image=true dependencies
-                # relies on SUNWcs in root image; make image 1 the root image
-                self.set_image(1)
-                self.pkg("{0} SUNWcs@0.5.11-0.75".format(install_cmd))
-                self.set_image(0)
-                live_root = self.img_path(1)
-                self.pkg("-D simulate_live_root={0} {1} pkg11@1.0".format(
-                    live_root, install_cmd))
-                self.pkg("-D simulate_live_root={0} {1} pkg11@1.1".format(
-                    live_root, install_cmd), exit=1)
-                self.pkg("uninstall '*'")
-
-        def test_parent_dependencies(self):
-                self.parent_dependencies_helper("install")
-                self.parent_dependencies_helper("exact-install")
-
-        def parent_dependencies_helper(self, install_cmd):
-                self.set_image(0)
-                self.image_create(self.rurl)
-                self.set_image(1)
-                self.image_create(self.rurl)
-
-                # attach c2p 1 -> 0.
-                self.pkg("attach-linked -p system:img1 {0}".format(self.img_path(0)))
-
-                # try to install or exact-install packages that have unmet
-                # parent dependencies.
-                self.pkg("{0} pkg12@1.2".format(install_cmd), exit=EXIT_OOPS)
-                self.pkg("{0} pkg13@1.2".format(install_cmd), exit=EXIT_OOPS)
-                self.pkg("{0} pkg14@1.2".format(install_cmd), exit=EXIT_OOPS)
-
-                # install or exact-install packages in parent.
-                self.set_image(0)
-                self.pkg("install pkg12@1.1")
-                self.set_image(1)
-
-                # try to install or exact-install packages that have unmet
-                # parent dependencies.
-                self.pkg("{0} pkg12@1.2".format(install_cmd), exit=EXIT_OOPS)
-                self.pkg("{0} pkg13@1.2".format(install_cmd), exit=EXIT_OOPS)
-                self.pkg("{0} pkg14@1.2".format(install_cmd), exit=EXIT_OOPS)
-
-                # install or exact-install packages in parent.
-                self.set_image(0)
-                self.pkg("{0} pkg12@1.3".format(install_cmd))
-                self.set_image(1)
-
-                # try to install or exact-install packages that have unmet
-                # parent dependencies.
-                self.pkg("{0} pkg12@1.2".format(install_cmd), exit=EXIT_OOPS)
-                self.pkg("{0} pkg14@1.2".format(install_cmd), exit=EXIT_OOPS)
-
-                # update packages in parent
-                self.set_image(0)
-                self.pkg("update pkg12@1.2")
-                self.set_image(1)
-
-                # try to install or exact-install packages that have unmet parent dependencies.
-                self.pkg("{0} pkg14@1.2".format(install_cmd), exit=EXIT_OOPS)
-
-                # try to install or exact-install packages that have satisfied parent deps.
-                self.pkg("{0} pkg12@1.2".format(install_cmd))
-                self.pkg("verify")
-                self.pkg("uninstall pkg12@1.2")
-                self.pkg("{0} pkg13@1.2".format(install_cmd))
-                self.pkg("verify")
-                self.pkg("uninstall pkg13@1.2")
-
-                # install or exact-install packages in parent.
-                self.set_image(0)
-                if install_cmd == "install":
-                        self.pkg("install pkg13@1.2")
-                else:
-                        self.pkg("exact-install pkg12@1.2 pkg13@1.2")
-                self.set_image(1)
-
-                # try to install or exact-install packages that have satisfied.
-                # parent deps.
-                self.pkg("{0} pkg14@1.2".format(install_cmd))
-                self.pkg("verify")
-                self.pkg("uninstall pkg14@1.2")
-
-                # update packages in parent
-                self.set_image(0)
-                self.pkg("update pkg12@1.3")
-                self.set_image(1)
-
-                # try to install or exact-install packages that have satisfied parent deps.
-                self.pkg("{0} pkg13@1.2".format(install_cmd))
-                self.pkg("verify")
-                self.pkg("uninstall pkg13@1.2")
-
-        def test_optional_nosolution(self):
-                """Ensure useful error messages are produced when an optional
-                dependency in a proposed package cannot be satisfied due to
-                another proposed package."""
-
-                self.image_create(self.rurl)
-                self.pkg("install desktop-incorporation")
-                self.pkg("install -n multi-user-desktop@latest libotr@latest "
-                    "desktop-incorporation@latest", exit=1)
-                self.assertFalse("No solution" in self.errout)
-                # desktop-incorporation should not be listed as a rejected
-                # package; rejected packages are always listed with full FMRI
-                # and scheme
-                self.assertFalse("pkg://test/consolidation/desktop/desktop-incorporation" in self.errout)
-                # all of these should show up as rejected packages
-                self.assertTrue("pkg://test/communication/im/libotr" in self.errout)
-                self.assertTrue("pkg://test/group/feature/multi-user-desktop" in self.errout)
-                # reason for rejection should reference optional dependency type
-                self.assertTrue("optional" in self.errout)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self, image_count=2)
+        self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.pkg10,
+                self.pkg20,
+                self.pkg11,
+                self.pkg21,
+                self.pkg30,
+                self.pkg40,
+                self.pkg50,
+                self.pkg505,
+                self.pkg51,
+                self.pkg60,
+                self.pkg61,
+                self.bug_18653,
+                self.pkg70,
+                self.pkg71,
+                self.pkg80,
+                self.pkg81,
+                self.pkg90,
+                self.pkg91,
+                self.bug_7394_incorp,
+                self.pkg100,
+                self.pkg101,
+                self.pkg102,
+                self.pkg110,
+                self.pkg111,
+                self.pkg121,
+                self.pkg122,
+                self.pkg123,
+                self.pkg132,
+                self.pkg142,
+                self.pkg_nosol,
+                self.pkg_renames,
+                self.pkgSUNWcs075,
+                self.exclude_group,
+                self.optional_group,
+            ),
+        )
+
+        self.leaf_pkgs = []
+        for t in self.leaf_expansion:
+            self.leaf_pkgs.extend(
+                self.pkgsend_bulk(self.rurl, self.leaf_template.format(*t))
+            )
+
+        self.incorp_pkgs = []
+        for i in self.incorps:
+            self.incorp_pkgs.extend(self.pkgsend_bulk(self.rurl, i))
+
+    def test_rename_matching(self):
+        """Verify install or exact-install won't fail with a multiple
+        match error for a renamed package that shares a common
+        basename."""
+
+        self.rename_matching("install")
+        self.rename_matching("exact-install")
+
+    def rename_matching(self, install_cmd):
+        self.image_create(self.rurl)
+        self.pkg("{0} trusted".format(install_cmd))
+        self.pkg("info system/trusted")
+
+    def test_require_dependencies(self):
+        """exercise require dependencies"""
+
+        self.require_dependencies_helper("install")
+        self.require_dependencies_helper("exact-install")
+
+    def require_dependencies_helper(self, install_cmd):
+        self.image_create(self.rurl)
+        self.pkg("install pkg1@1.0")
+        self.pkg("verify  pkg1@1.0")
+        self.pkg("{0} pkg3@1.0".format(install_cmd))
+        self.pkg("verify  pkg3@1.0 pkg1@1.1")
+
+    def test_exclude_group_install(self):
+        """Verify that a simultaneous exclude and group dependency on
+        the same package is handled gracefully."""
+
+        self.image_create(self.rurl)
+
+        # These should fail (gracefully) because my-rsync packages
+        # excludes network/rsync which is a group dependency of
+        # gold-server package.
+        self.pkg("install network/rsync gold-server my-rsync", exit=1)
+
+        self.pkg("install network/rsync")
+        self.pkg("install gold-server my-rsync", exit=1)
+        self.pkg("uninstall '*'")
+
+        # This should succeed because network/rsync dependency is not
+        # installed.
+        self.pkg("avoid network/rsync")
+        self.pkg("install -nv gold-server my-rsync")
+
+        # This will install network/rsync and remove it from the avoid
+        # list.
+        self.pkg("install network/rsync")
+
+        # This should succeed because network/rsync will be removed and
+        # placed on avoid list as part of operation.
+        self.pkg("install --reject network/rsync gold-server my-rsync")
+
+        # Now remove gold-server and then verify install will fail.
+        self.pkg("uninstall gold-server")
+        self.pkg("unavoid network/rsync")
+
+        # This should fail as there's no installed constraining package
+        # and user didn't provide sufficient input.
+        self.pkg("install gold-server", exit=1)
+
+    def test_exclude_dependencies_install(self):
+        """exercise exclude dependencies"""
+
+        self.image_create(self.rurl)
+        # install pkg w/ exclude dep.
+        self.pkg("install pkg4@1.0")
+        self.pkg("verify  pkg4@1.0")
+        # install pkg that is allowed by dep
+        self.pkg("install pkg1@1.0")
+        self.pkg("verify  pkg1@1.0")
+        # try to install disallowed pkg
+        self.pkg("install pkg1@1.1", exit=1)
+        self.pkg("uninstall '*'")
+        # install pkg
+        self.pkg("install pkg1@1.1")
+        # try to install pkg exclude dep on already
+        # installed pkg
+        self.pkg("install pkg4@1.0", exit=1)
+        self.pkg("uninstall '*'")
+        # install a package w/ both exclude
+        # and require dependencies
+        self.pkg("install pkg5")
+        self.pkg("verify pkg5@1.1 pkg1@1.0 ")
+        self.pkg("uninstall '*'")
+        # pick pkg to install that fits constraint
+        # of already installed pkg
+        self.pkg("install pkg2")
+        self.pkg("install pkg5")
+        self.pkg("verify pkg5@1.0.5 pkg1@1.0 pkg2")
+        self.pkg("uninstall '*'")
+        # install a package that requires updating
+        # existing package to avoid exclude
+        # dependency
+        self.pkg("install pkg6@1.0")
+        self.pkg("install pkg1@1.1")
+        self.pkg("verify pkg1@1.1 pkg6@1.1")
+        self.pkg("uninstall '*'")
+        # try to install two incompatible pkgs
+        self.pkg("install pkg1@1.1 pkg4@1.0", exit=1)
+
+    def test_exclude_dependencies_exact_install(self):
+        """exercise exclude dependencies"""
+
+        self.image_create(self.rurl)
+        # Install pkg w/ exclude dep.
+        self.pkg("install pkg4@1.0")
+        self.pkg("verify  pkg4@1.0")
+
+        # Exact-install should ignore exclude dependencies,
+        # except user specifies both pkg name in command line.
+        self.pkg("exact-install pkg1@1.1")
+        self.pkg("uninstall '*'")
+
+        # Exact-install a package w/ both exclude
+        # and require dependencies.
+        self.pkg("exact-install pkg5")
+        self.pkg("verify pkg5@1.1 pkg1@1.0 ")
+        self.pkg("uninstall '*'")
+        # pick pkg to exact-install that fits constraint.
+        self.pkg("exact-install pkg2 pkg5")
+        self.pkg("verify pkg5@1.0.5 pkg1@1.0 pkg2")
+        self.pkg("uninstall '*'")
+        # Exact- install two packages with proper version selected for
+        # one package based on the version of the other package.
+        self.pkg("exact-install pkg6 pkg1@1.1")
+        self.pkg("verify pkg1@1.1 pkg6@1.1")
+        self.pkg("uninstall '*'")
+        # try to exact-install two incompatible pkgs
+        self.pkg("exact-install pkg1@1.1 pkg4@1.0", exit=1)
+
+    def test_optional_dependencies_install(self):
+        """check to make sure that optional dependencies are enforced"""
+
+        self.image_create(self.rurl)
+        self.pkg("install pkg1@1.0")
+
+        # pkg2 is optional, it should not have been installed
+        self.pkg("list pkg2", exit=1)
+
+        self.pkg("install pkg2@1.0")
+
+        # this should install pkg1@1.1 and upgrade pkg2 to pkg2@1.1
+        self.pkg("install pkg1")
+        self.pkg("list pkg2@1.1")
+
+        self.pkg("uninstall pkg2")
+        self.pkg("list pkg2", exit=1)
+        # this should not install pkg2@1.0 because of the optional
+        # dependency in pkg1
+        self.pkg("list pkg1@1.1")
+        self.pkg("install pkg2@1.0", exit=1)
+
+    def test_optional_dependencies_exact_install(self):
+        """check to make sure that optional dependencies are enforced"""
+
+        self.image_create(self.rurl)
+        self.pkg("exact-install pkg1@1.0")
+
+        # pkg2 is optional, it should not have been installed
+        self.pkg("list pkg2", exit=1)
+
+        self.pkg("install pkg2@1.1")
+
+        # Verify with exact-install, the optional dependency package
+        # should be removed.
+        self.pkg("exact-install pkg1")
+        self.pkg("list pkg2@1.1", exit=1)
+        self.pkg("list pkg1@1.1")
+
+        # Verify exact-install pkg2@1.0 should succeed and pkg1 should
+        # be removed.
+        self.pkg("exact-install pkg2@1.0")
+        self.pkg("list pkg1", exit=1)
+
+    def test_incorporation_dependencies_install(self):
+        """shake out incorporation dependencies"""
+
+        self.image_create(self.rurl)
+        # simple pkg requiring controlling incorp
+        # should control pkgA_1 as well
+        self.pkg("install -v pkgA_0@1.0 pkgA_1")
+        self.pkg("list")
+        self.pkg("verify pkgA_0@1.0 pkgA_1@1.0 A_incorp@1.0")
+        self.pkg("install A_incorp@1.1")
+        self.pkg("list pkgA_0@1.1 pkgA_1@1.1 A_incorp@1.1")
+        self.pkg("uninstall '*'")
+        # try nested incorporations
+        self.pkg("install -v incorp@1.0 pkgA_0 pkgB_0")
+        self.pkg("list")
+        self.pkg(
+            "list incorp@1.0 pkgA_0@1.0 pkgB_0@1.0 A_incorp@1.0 B_incorp@1.0"
+        )
+        # try to break incorporation
+        self.pkg("install -v A_incorp@1.1", exit=1)  # fixed by incorp@1.0
+        # try update (using '*' which also checks that the update all
+        # path is used when '*' is specified)
+        self.pkg("update -v '*'")
+        self.pkg("list incorp@1.2")
+        self.pkg("list pkgA_0@1.2")
+        self.pkg("list pkgB_0@1.2")
+        self.pkg("list A_incorp@1.2")
+        self.pkg("list B_incorp@1.2")
+        self.pkg("uninstall '*'")
+        # what happens when incorporation specified
+        # a package that isn't in the catalog
+        self.pkg("install bug_7394_incorp")
+        self.pkg("install pkg1", exit=1)
+        self.pkg("uninstall '*'")
+        # test pkg.depend.install-hold feature
+        self.pkg("install -v A_incorp@1.1  pkgA_1")
+        self.pkg("list pkgA_1@1.1")
+        self.pkg("list A_incorp@1.1")
+        # next attempt will fail because incorporations prevent motion
+        # even though explicit dependency exists from pkg to
+        # incorporation.
+        self.pkg("install pkgA_1@1.2", exit=1)
+        # test to see if we could install both; presence of incorp
+        # causes relaxation of pkg.depend.install-hold and also test
+        # that parsable output works when -n is used
+        self.pkg("install -n --parsable=0 A_incorp@1.2 pkgA_1@1.2")
+        self.assertEqualParsable(
+            self.output,
+            change_packages=[
+                [self.incorp_pkgs[2], self.incorp_pkgs[4]],
+                [self.leaf_pkgs[9], self.leaf_pkgs[17]],
+            ],
+        )
+        # this attempt also succeeds because pkg.depend.install-hold is
+        # relaxed since A_incorp is on command line
+        self.pkg("install A_incorp@1.2")
+        self.pkg("list pkgA_1@1.2")
+        self.pkg("list A_incorp@1.2")
+        # now demonstrate w/ version 1.2 subincorps that master incorp
+        # prevents upgrade since pkg.depend.install-hold of master != other incorps
+        self.pkg("install incorp@1.2")
+        self.pkg("install A_incorp@1.3", exit=1)
+        self.pkg("install incorp@1.3")
+        self.pkg("list pkgA_1@1.3")
+        self.pkg("list A_incorp@1.3")
+
+    def test_incorporation_dependencies_exact_install(self):
+        """shake out incorporation dependencies"""
+
+        self.image_create(self.rurl)
+        # Simple pkg requiring controlling incorp
+        # should control pkgA_1 as well.
+        self.pkg("exact-install -v pkgA_0@1.0 pkgA_1")
+        self.pkg("list")
+        self.pkg("verify pkgA_0@1.0 pkgA_1@1.0 A_incorp@1.0")
+
+        # Verify exact-install will upgrade pkgA_0 and A_incorp to 1.1
+        # , and uninstall pkgA_1.
+        self.pkg("exact-install pkgA_0@1.1")
+        self.pkg("list pkgA_0@1.1 A_incorp@1.1")
+        self.pkg("uninstall '*'")
+
+        # Try nested incorporations.
+        self.pkg("exact-install -v incorp@1.0 pkgA_0 pkgB_0")
+        self.pkg(
+            "list incorp@1.0 pkgA_0@1.0 pkgB_0@1.0 A_incorp@1.0 B_incorp@1.0"
+        )
+        # Try to break incorporation.
+        self.pkg(
+            "exact-install -v incorp@1.0 A_incorp@1.1", exit=1
+        )  # fixed by incorp@1.0
+
+        # Only specify A_incorp@1.1 should succeed. install holds
+        # should be ignored.
+        self.pkg("exact-install -v A_incorp@1.1")
+        self.pkg("list A_incorp@1.1")
+        self.pkg("uninstall '*'")
+        # what happens when incorporation specified
+        # a package that isn't in the catalog.
+        self.pkg("exact-install pkg1 bug_7394_incorp", exit=1)
+        # test pkg.depend.install-hold feature.
+        self.pkg("exact-install -v A_incorp@1.1  pkgA_1")
+        self.pkg("list pkgA_1@1.1")
+        self.pkg("list A_incorp@1.1")
+
+    def test_conditional_dependencies_install(self):
+        """Get conditional dependencies working"""
+        self.image_create(self.rurl)
+        self.pkg("install pkg7@1.0")
+        self.pkg("verify")
+        self.pkg("list pkg6@1.1", exit=1)  # should not be here
+        self.pkg("install -v pkg2@1.0")  # older version...
+        self.pkg("verify")
+        self.pkg("list pkg6@1.1", exit=1)
+        self.pkg("install -v pkg2@1.1")  # this triggers conditional dependency
+        self.pkg("verify")
+        self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")  # everyone is present
+        self.pkg("uninstall '*'")
+
+        self.pkg("install pkg2@1.1")  # install trigger
+        self.pkg("verify")
+        self.pkg("install pkg7@1.0")  # install pkg
+        self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")  # all here again
+        self.pkg("verify")
+        self.pkg("uninstall '*'")
+
+        # Test bug 18653
+        self.pkg(
+            "install osnet-incorporation@1.0 sun-solaris "
+            "perl-510 sun-solaris-510"
+        )
+        # Uninstall should fail because sun-solaris conditional
+        # dependency requires sun-solaris-510.
+        self.pkg("uninstall sun-solaris-510", exit=1)
+        # Uninstalling both the predicate and the target of the
+        # conditional dependency should work.
+        self.pkg("uninstall perl-510 sun-solaris-510")
+        self.pkg("install perl-510")
+        # Check that reject also works.
+        self.pkg("update --reject perl-510 --reject sun-solaris-510")
+        self.pkg("uninstall '*'")
+
+        # Verify that if the predicate of a conditional can be
+        # installed, but the consequent cannot, the package delivering
+        # the conditional dependency can still be installed.
+        self.pkg("install -v entire osnet-incorporation@1.1 " "sun-solaris")
+
+        # Verify that the package incorporating a package that delivers
+        # a conditional for a consequent that cannot be installed can be
+        # removed.
+        self.pkg("uninstall -v entire")
+
+    def test_cond_depend_nonexist(self):
+        # pkg7@1.0 has conditional - install pkg6@1.1 if pkg2@1.1
+        # pkg7@1.1 has conditional on non-existent package if pkg2@1.1
+
+        self.image_create(self.rurl)
+
+        # installing pkg7@1.1 should work since the conditional
+        # requirement is predicated on pkg2, which is not installed
+        self.pkg("install pkg7@1.1")
+        self.pkg("uninstall '*'")
+
+        self.pkg("install pkg7@1.0 pkg2@1.0")
+        self.pkg("verify")
+        self.pkg("list pkg7@1.0 pkg2@1.0")
+        # pkg6 should not be installed
+        self.pkg("list pkg6", exit=1)
+
+        # upgrading to pkg7@1.1 should work fine since the non-existent
+        # package is only required if pkg2 is at 1.1 or above
+        self.pkg("update pkg7@1.1")
+        self.pkg("verify")
+        self.pkg("list pkg7@1.1")
+
+        # Installing pkg2@1.1 should fail as the conditionally required
+        # package does not exist
+        self.pkg("install pkg2@1.1", exit=1, assert_solution=False)
+
+    def test_cond_depend_uninstall(self):
+        # pkg7@1.0 has conditional - install pkg6@1.1 if pkg2@1.1
+
+        self.image_create(self.rurl)
+        self.pkg("install pkg7@1.0 pkg2@1.1")
+        self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")
+        self.pkg("verify")
+
+        # It should not be possible to uninstall pkg6@1.1
+        self.pkg("uninstall pkg6@1.1", exit=1)
+
+        # Uninstall pkg2 and then pkg6 should become uninstallable
+        self.pkg("uninstall pkg2")
+        self.pkg("uninstall pkg6")
+
+        # Install pkg2 again (which will trigger pkg6)
+        self.pkg("install pkg2@1.1")
+        self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")
+
+        # uninstall both together
+        self.pkg("uninstall pkg2 pkg6")
+
+        # Try unversioned pkg2
+        self.pkg("install -v pkg2")
+        self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")
+
+        # Downgrade pkg2 and pkg6 should become uninstallable
+        self.pkg("update pkg2@1.0")
+        self.pkg("uninstall pkg6")
+
+        # Upgrade pkg2 again and pkg6 should be re-installed
+        self.pkg("update pkg2")
+        self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")
+
+    def test_conditional_dependencies_exact_install(self):
+        """Get conditional dependencies working."""
+
+        self.image_create(self.rurl)
+        # Presenting pkg7@1.0 and pkg2@1.1 in the command line should
+        # trigger conditional dependency.
+        self.pkg("exact-install -v pkg7@1.0 pkg2@1.1")
+        self.pkg("verify")
+        self.pkg("list pkg6@1.1 pkg2@1.1 pkg7@1.0")
+        self.pkg("uninstall '*'")
+
+        # If  only pkg7@1.0 present in the command line, pkg2@1.1
+        # should be removed and pkg6@1.1 should not be installed.
+        self.pkg("install pkg2@1.1")
+        self.pkg("verify")
+        self.pkg("exact-install pkg7@1.0")
+        self.pkg("list pkg7@1.0")
+        self.pkg("list pkg2@1.1", exit=1)
+        self.pkg("list pkg6@1.1", exit=1)
+        self.pkg("verify")
+        self.pkg("uninstall '*'")
+
+    def test_require_any_dependencies_install(self):
+        """Get require-any dependencies working"""
+        self.image_create(self.rurl)
+
+        # test to see if solver will fail gracefully when no solution is
+        # possible and a require-any dependency is involved
+        self.pkg(
+            "install -vvv pkg-nosol-A pkg-nosol-E",
+            assert_solution=False,
+            exit=9,
+        )
+
+        # test to see if solver will pick one
+        self.pkg("install pkg8@1.0")  # install pkg
+        self.pkg("verify")
+        self.pkg("list pkg8@1.0 pkg9@1.0 pkg2@1.1", exit=3)
+        self.pkg("uninstall '*'")
+
+        # test to see if solver will be happy w/ renamed packages,
+        # already installed dependencies.
+        self.pkg("install pkg:/pkg2@1.1")
+        self.pkg("install pkg_need_rename")
+        self.pkg("install pkg8@1.0")
+        self.pkg("verify")
+        self.pkg("list pkg8@1.0 pkg2@1.1")
+        self.pkg("uninstall '*'")
+
+        # test to see if solver will install new verion of existing
+        # package rather than add new package
+        self.pkg("install pkg8@1.0 pkg9@1.0")  # install pkg
+        self.pkg("verify")
+        self.pkg("list pkg8@1.0 pkg9@1.0")
+        self.pkg("list pkg2@1.1", exit=1)
+        self.pkg("install pkg8 pkg9")  # will fail w/o pkg9 on list
+        self.pkg("verify")
+        self.pkg("list pkg8@1.1 pkg9@1.1")
+        self.pkg("uninstall '*'")
+
+        # see if update works the same way
+        self.pkg("install pkg8@1.0 pkg9@1.0")  # install pkg
+        self.pkg("image-update")
+        self.pkg("list pkg8@1.1 pkg9@1.1")
+        self.pkg("uninstall '*'")
+
+        # test to see if uninstall is clever enough
+        self.pkg("install pkg8@1.0 pkg9@1.0")  # install pkg
+        self.pkg("verify")
+        self.pkg("list pkg8@1.0 pkg9@1.0")
+        self.pkg("uninstall pkg9@1.0")
+        self.pkg("list pkg2@1.1")
+        self.pkg("verify")
+
+    def test_require_any_dependencies_exact_install(self):
+        """Get require-any dependencies working"""
+        self.image_create(self.rurl)
+
+        # Test to see if solver will fail gracefully when no solution is
+        # possible and a require-any dependency is involved.
+        self.pkg(
+            "exact-install -v pkg-nosol-A pkg-nosol-E",
+            assert_solution=False,
+            exit=9,
+        )
+
+        # Test to see if solver will pick one.
+        self.pkg("exact-install pkg8@1.0")
+        self.pkg("verify")
+        self.pkg("list pkg8@1.0 pkg9@1.0 pkg2@1.1", exit=3)
+        self.pkg("uninstall '*'")
+
+        # Test to see if solver will be happy w/ renamed packages,
+        # already installed dependencies.
+        self.pkg("exact-install pkg:/pkg2@1.1 pkg_need_rename " "pkg8@1.0")
+        self.pkg("verify")
+        self.pkg("list pkg8@1.0 pkg2@1.1")
+        self.pkg("uninstall '*'")
+
+        # test to see if solver will install new verion of existing
+        # package rather than add new package
+        self.pkg("exact-install pkg8@1.0 pkg9@1.0")  # install pkg
+        self.pkg("verify")
+        self.pkg("list pkg8@1.0 pkg9@1.0")
+        self.pkg("list pkg2@1.1", exit=1)
+        self.pkg("exact-install pkg8 pkg9")
+        self.pkg("verify")
+        self.pkg("list pkg8@1.1 pkg9@1.1")
+        self.pkg("list pkg2@1.1", exit=1)
+        self.pkg("uninstall '*'")
+
+    def test_origin_dependencies(self):
+        """Get origin dependencies working"""
+
+        self.origin_dependencies_helper("install")
+        self.origin_dependencies_helper("exact-install")
+
+    def origin_dependencies_helper(self, install_cmd):
+        self.set_image(0)
+        self.image_create(self.rurl)
+        self.set_image(1)
+        self.image_create(self.rurl)
+        self.set_image(0)
+        # check install or exact-install behavior
+        self.pkg("{0} pkg10@1.0".format(install_cmd))
+        self.pkg("{0} pkg10".format(install_cmd))
+        self.pkg("list pkg10@1.1")
+        self.pkg("{0} pkg10".format(install_cmd))
+        self.pkg("list pkg10@1.2")
+        self.pkg("uninstall '*'")
+        # check image-update behavior
+        self.pkg("install pkg10@1.0")
+        self.pkg("image-update")
+        self.pkg("list pkg10@1.1")
+        self.pkg("image-update")
+        self.pkg("list pkg10@1.2")
+        self.pkg("uninstall '*'")
+        # check that dependencies are ignored if
+        # dependency not present
+        self.pkg("{0} pkg10@1.2".format(install_cmd))
+        self.pkg("uninstall '*'")
+        # make sure attempts to force install don't work
+        self.pkg("{0} pkg10@1.0".format(install_cmd))
+        self.pkg("{0} pkg10@1.2".format(install_cmd), exit=1)
+        self.pkg("{0} pkg10@1.1".format(install_cmd))
+        self.pkg("{0} pkg10@1.2".format(install_cmd))
+        self.pkg("uninstall '*'")
+        # check origin root-image=true dependencies
+        # relies on SUNWcs in root image; make image 1 the root image
+        self.set_image(1)
+        self.pkg("{0} SUNWcs@0.5.11-0.75".format(install_cmd))
+        self.set_image(0)
+        live_root = self.img_path(1)
+        self.pkg(
+            "-D simulate_live_root={0} {1} pkg11@1.0".format(
+                live_root, install_cmd
+            )
+        )
+        self.pkg(
+            "-D simulate_live_root={0} {1} pkg11@1.1".format(
+                live_root, install_cmd
+            ),
+            exit=1,
+        )
+        self.pkg("uninstall '*'")
+
+    def test_parent_dependencies(self):
+        self.parent_dependencies_helper("install")
+        self.parent_dependencies_helper("exact-install")
+
+    def parent_dependencies_helper(self, install_cmd):
+        self.set_image(0)
+        self.image_create(self.rurl)
+        self.set_image(1)
+        self.image_create(self.rurl)
+
+        # attach c2p 1 -> 0.
+        self.pkg("attach-linked -p system:img1 {0}".format(self.img_path(0)))
+
+        # try to install or exact-install packages that have unmet
+        # parent dependencies.
+        self.pkg("{0} pkg12@1.2".format(install_cmd), exit=EXIT_OOPS)
+        self.pkg("{0} pkg13@1.2".format(install_cmd), exit=EXIT_OOPS)
+        self.pkg("{0} pkg14@1.2".format(install_cmd), exit=EXIT_OOPS)
+
+        # install or exact-install packages in parent.
+        self.set_image(0)
+        self.pkg("install pkg12@1.1")
+        self.set_image(1)
+
+        # try to install or exact-install packages that have unmet
+        # parent dependencies.
+        self.pkg("{0} pkg12@1.2".format(install_cmd), exit=EXIT_OOPS)
+        self.pkg("{0} pkg13@1.2".format(install_cmd), exit=EXIT_OOPS)
+        self.pkg("{0} pkg14@1.2".format(install_cmd), exit=EXIT_OOPS)
+
+        # install or exact-install packages in parent.
+        self.set_image(0)
+        self.pkg("{0} pkg12@1.3".format(install_cmd))
+        self.set_image(1)
+
+        # try to install or exact-install packages that have unmet
+        # parent dependencies.
+        self.pkg("{0} pkg12@1.2".format(install_cmd), exit=EXIT_OOPS)
+        self.pkg("{0} pkg14@1.2".format(install_cmd), exit=EXIT_OOPS)
+
+        # update packages in parent
+        self.set_image(0)
+        self.pkg("update pkg12@1.2")
+        self.set_image(1)
+
+        # try to install or exact-install packages that have unmet parent dependencies.
+        self.pkg("{0} pkg14@1.2".format(install_cmd), exit=EXIT_OOPS)
+
+        # try to install or exact-install packages that have satisfied parent deps.
+        self.pkg("{0} pkg12@1.2".format(install_cmd))
+        self.pkg("verify")
+        self.pkg("uninstall pkg12@1.2")
+        self.pkg("{0} pkg13@1.2".format(install_cmd))
+        self.pkg("verify")
+        self.pkg("uninstall pkg13@1.2")
+
+        # install or exact-install packages in parent.
+        self.set_image(0)
+        if install_cmd == "install":
+            self.pkg("install pkg13@1.2")
+        else:
+            self.pkg("exact-install pkg12@1.2 pkg13@1.2")
+        self.set_image(1)
+
+        # try to install or exact-install packages that have satisfied.
+        # parent deps.
+        self.pkg("{0} pkg14@1.2".format(install_cmd))
+        self.pkg("verify")
+        self.pkg("uninstall pkg14@1.2")
+
+        # update packages in parent
+        self.set_image(0)
+        self.pkg("update pkg12@1.3")
+        self.set_image(1)
+
+        # try to install or exact-install packages that have satisfied parent deps.
+        self.pkg("{0} pkg13@1.2".format(install_cmd))
+        self.pkg("verify")
+        self.pkg("uninstall pkg13@1.2")
+
+    def test_optional_nosolution(self):
+        """Ensure useful error messages are produced when an optional
+        dependency in a proposed package cannot be satisfied due to
+        another proposed package."""
+
+        self.image_create(self.rurl)
+        self.pkg("install desktop-incorporation")
+        self.pkg(
+            "install -n multi-user-desktop@latest libotr@latest "
+            "desktop-incorporation@latest",
+            exit=1,
+        )
+        self.assertFalse("No solution" in self.errout)
+        # desktop-incorporation should not be listed as a rejected
+        # package; rejected packages are always listed with full FMRI
+        # and scheme
+        self.assertFalse(
+            "pkg://test/consolidation/desktop/desktop-incorporation"
+            in self.errout
+        )
+        # all of these should show up as rejected packages
+        self.assertTrue("pkg://test/communication/im/libotr" in self.errout)
+        self.assertTrue(
+            "pkg://test/group/feature/multi-user-desktop" in self.errout
+        )
+        # reason for rejection should reference optional dependency type
+        self.assertTrue("optional" in self.errout)
 
 
 class TestMultipleDepots(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close"""
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             close"""
 
-        moo10 = """
+    moo10 = """
             open moo@1.0,5.11-0
             close"""
 
-        quux10 = """
+    quux10 = """
             open quux@1.0,5.11-0
             add depend type=optional fmri=optional@1.0
             close"""
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             add depend type=require fmri=corge@1.0
             close"""
 
-        corge10 = """
+    corge10 = """
             open corge@1.0,5.11-0
             close"""
 
-        optional10 = """
+    optional10 = """
             open optional@1.0,5.11-0
             close"""
 
-        upgrade_p10 = """
+    upgrade_p10 = """
             open upgrade-p@1.0,5.11-0
             close"""
 
-        upgrade_p11 = """
+    upgrade_p11 = """
             open upgrade-p@1.1,5.11-0
             close"""
 
-        upgrade_np10 = """
+    upgrade_np10 = """
             open upgrade-np@1.0,5.11-0
             close"""
 
-        upgrade_np11 = """
+    upgrade_np11 = """
             open upgrade-np@1.1,5.11-0
             close"""
 
-        incorp_p10 = """
+    incorp_p10 = """
             open incorp-p@1.0,5.11-0
             add depend type=incorporate fmri=upgrade-p@1.0
             close"""
 
-        incorp_p11 = """
+    incorp_p11 = """
             open incorp-p@1.1,5.11-0
             add depend type=incorporate fmri=upgrade-p@1.1
             close"""
 
-        incorp_np10 = """
+    incorp_np10 = """
             open incorp-np@1.0,5.11-0
             add depend type=incorporate fmri=upgrade-np@1.0
             close"""
 
-        incorp_np11 = """
+    incorp_np11 = """
             open incorp-np@1.1,5.11-0
             add depend type=incorporate fmri=upgrade-np@1.1
             close"""
 
-        def setUp(self):
-                """ depot 1 gets foo and moo, depot 2 gets foo and bar,
-                    depot 3 is empty, depot 4 gets upgrade_np@1.1
-                    depot 5 gets corge10, depot6 is empty
-                    depot7 is a copy of test1's repository for test3
-                    depot1 is mapped to publisher test1 (preferred)
-                    depot2 is mapped to publisher test2
-                    depot3 is not mapped during setUp
-                    depot4 is not mapped during setUp
-                    depot5 is not mapped during setUp
-                    depot6 is not mapped during setUp"""
-
-                # Two depots are intentionally started for some publishers.
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test3", "test2", "test4", "test1", "test3"])
-
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.pkgsend_bulk(self.rurl1, (self.foo10, self.moo10,
-                    self.quux10, self.optional10, self.upgrade_p10,
-                    self.upgrade_np11, self.incorp_p10, self.incorp_p11,
-                    self.incorp_np10, self.incorp_np11, self.baz10,
-                    self.corge10))
-
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.pkgsend_bulk(self.rurl2, (self.foo10, self.bar10,
-                    self.upgrade_p11, self.upgrade_np10, self.corge10))
-
-                self.rurl3 = self.dcs[3].get_repo_url()
-
-                self.rurl4 = self.dcs[4].get_repo_url()
-                self.pkgsend_bulk(self.rurl4, self.upgrade_np11)
-
-                self.rurl5 = self.dcs[5].get_repo_url()
-                self.pkgsend_bulk(self.rurl5, self.corge10)
-
-                self.rurl6 = self.dcs[6].get_repo_url()
-                self.rurl7 = self.dcs[7].get_repo_url()
-
-                # Copy contents of test1's repo to a repo for test3.
-                d1dir = self.dcs[1].get_repodir()
-                d2dir = self.dcs[7].get_repodir()
-                self.copy_repository(d1dir, d2dir, { "test1": "test3" })
-                self.dcs[7].get_repo(auto_create=True).rebuild()
-
-                # Create image and hence primary publisher
-                self.image_create(self.rurl1, prefix="test1")
-
-                # Create second publisher using depot #2
-                self.pkg("set-publisher -O " + self.rurl2 + " test2")
-
-        def test_01_basics(self):
-                self.pkg("list -a")
-
-                # Install and uninstall moo (which is unique to depot 1)
-                self.pkg("install moo")
-
-                self.pkg("list")
-                self.pkg("uninstall moo")
-
-                # Install and uninstall bar (which is unique to depot 2)
-                self.pkg("install bar")
-
-                self.pkg("list")
-
-                self.pkg("uninstall bar")
-
-                # Install and uninstall foo (which is in both depots)
-                # In this case, we should select foo from depot 1, since
-                # it is preferred.
-                self.pkg("install foo")
-
-                self.pkg("list pkg://test1/foo")
-
-                self.pkg("uninstall foo")
-
-        def test_02_basics(self):
-                """ Test install from an explicit preferred publisher """
-                self.pkg("install pkg://test1/foo")
-                self.pkg("list foo")
-                self.pkg("list pkg://test1/foo")
-                self.pkg("uninstall foo")
-
-        def test_03_basics(self):
-                """ Test install from an explicit non-preferred publisher """
-                self.pkg("install pkg://test2/foo")
-                self.pkg("list foo")
-                self.pkg("list pkg://test2/foo")
-                self.pkg("uninstall foo")
-
-        def test_04_upgrade_preferred_to_non_preferred(self):
-                """Install a package from the preferred publisher, and then
-                upgrade it, failing to implicitly switching to a non-preferred
-                publisher and then managing it explicitly"""
-                self.pkg("list -a upgrade-p")
-                self.pkg("install upgrade-p@1.0")
-                self.pkg("install upgrade-p@1.1", exit=1)
-                self.pkg("install pkg://test2/upgrade-p@1.1")
-                self.pkg("uninstall upgrade-p")
-
-        def test_05_upgrade_non_preferred_to_preferred(self):
-                """Install a package from a non-preferred publisher, and then
-                try to upgrade it, failing to implicitly switch to the preferred
-                publisher and then succeed doing it explicitly."""
-                self.pkg("list -a upgrade-np")
-                self.pkg("install upgrade-np@1.0")
-                self.pkg("install upgrade-np@1.1", exit=1)
-                self.pkg("install pkg://test1/upgrade-np@1.1")
-                self.pkg("uninstall upgrade-np")
-
-        def test_06_upgrade_preferred_to_non_preferred_incorporated(self):
-                """Install a package from the preferred publisher, and then
-                upgrade it, failing to implicitly switch to a non-preferred
-                publisher, when the package is constrained by an
-                incorporation, and then succeed when doing so explicitly"""
-
-                self.pkg("list -a upgrade-p incorp-p")
-                self.pkg("install incorp-p@1.0")
-                self.pkg("install upgrade-p")
-                self.pkg("install incorp-p@1.1", exit=1)
-                self.pkg("install incorp-p@1.1 pkg://test2/upgrade-p@1.1")
-                self.pkg("list upgrade-p@1.1")
-                self.pkg("uninstall '*'")
-
-        def test_07_upgrade_non_preferred_to_preferred_incorporated(self):
-                """Install a package from the preferred publisher, and then
-                upgrade it, implicitly switching to a non-preferred
-                publisher, when the package is constrained by an
-                incorporation."""
-                self.pkg("list", exit=1)
-                self.pkg("list -a upgrade-np incorp-np")
-                self.pkg("install incorp-np@1.0")
-                self.pkg("install upgrade-np", exit=1)
-                self.pkg("uninstall '*'")
-
-        def test_08_install_repository_access(self):
-                """Verify that packages can still be installed from a repository
-                even when any of the other repositories are not reachable and
-                --no-refresh is used."""
-
-                # Change the second publisher to point to an unreachable URI.
-                self.pkg("set-publisher --no-refresh -O http://test.invalid7 "
-                    "test2")
-
-                # Verify that no packages are installed.
-                self.pkg("list", exit=1)
-
-                # Verify moo can be installed (as only depot1 has it) even
-                # though test2 cannot be reached (and needs a refresh).
-                self.pkg("install moo")
-                self.pkg("uninstall moo")
-
-                # Verify moo can be installed (as only depot1 has it) even
-                # though test2 cannot be reached (and needs a refresh) if
-                # --no-refresh is used.
-                self.pkg("install --no-refresh moo")
-
-                self.pkg("uninstall moo")
-
-                # Reset the test2 publisher.
-                self.pkg("set-publisher -O {0} test2".format(self.rurl2))
-
-                # Install v1.0 of upgrade-np from test2 to prepare for
-                # update.
-                self.pkg("install upgrade-np@1.0")
-
-                # Set test1 to point to an unreachable URI.
-                self.pkg("set-publisher --no-refresh -O http://test.invalid7 "
-                    "test1")
-
-                # Set test2 so that upgrade-np has a new version available
-                # even though test1's repository is not accessible.
-                self.pkg("set-publisher -O {0} test2".format(self.rurl4))
-
-                # Verify update works even though test1 is unreachable
-                # since upgrade-np@1.1 is available from test2 if --no-refresh
-                # is used.
-                self.pkg("update --no-refresh")
-
-                # Now reset everything for the next test.
-                self.pkg("uninstall upgrade-np")
-                self.pkg("set-publisher --no-refresh -O {0} test1".format(self.rurl1))
-                self.pkg("set-publisher -O {0} test2".format(self.rurl2))
-
-        def test_09_uninstall_from_wrong_publisher(self):
-                """Install a package from a publisher and try to remove it
-                using a different publisher name; this should fail."""
-                self.pkg("install foo")
-                self.pkg("uninstall pkg://test2/foo", exit=1)
-                # Check to make sure that uninstalling using the explicit
-                # publisher works
-                self.pkg("uninstall pkg://test1/foo")
-
-        def test_10_install_after_publisher_removal(self):
-                """Install a package from a publisher that has an optional
-                dependency; then change the preferred publisher and remove the
-                original publisher and then verify that installing the package
-                again succeeds since it is essentially a no-op."""
-                self.pkg("install quux@1.0")
-                self.pkg("set-publisher -P test2")
-                self.pkg("unset-publisher test1")
-                self.pkg("list -avf")
-
-                # Attempting to install an already installed package should
-                # be a no-op even if the corresponding publisher no longer
-                # exists.
-                self.pkg("install quux@1.0", exit=4)
-
-                # Update should work if we don't see the optional
-                # dependency.
-                self.pkg("update", exit=4)
-
-                # Add back the installed package's publisher, but using a
-                # a repository with an empty catalog.  After that, attempt to
-                # install the package again, which should succeed even though
-                # the fmri is no longer in the publisher's catalog.
-                self.pkg("set-publisher -O {0} test1".format(self.rurl6))
-                self.pkg("install quux@1.0", exit=4)
-                self.pkg("info quux@1.0")
-                self.pkg("unset-publisher test1")
-
-                # Add a new publisher, with the same packages as the installed
-                # publisher.  Then, add back the installed package's publisher,
-                # but using an empty repository.  After that, attempt to install
-                # the package again, which should succeed since at least one
-                # publisher has the package in its catalog.
-                self.pkg("set-publisher -O {0} test3".format(self.rurl7))
-                self.pkg("set-publisher -O {0} test1".format(self.rurl6))
-                self.pkg("info -r pkg://test3/quux@1.0")
-                self.pkg("install quux@1.0", exit=4)
-                self.pkg("unset-publisher test1")
-                self.pkg("unset-publisher test3")
-
-                self.pkg("set-publisher -O {0} test1".format(self.rurl1))
-                self.pkg("info -r pkg://test1/quux@1.0")
-                self.pkg("unset-publisher test1")
-
-                # Add a new publisher, using the installed package publisher's
-                # repository.  After that, attempt to install the package again,
-                # which should simply result in a 'no updates necessary' exit
-                # code since the removed publisher's package is already the
-                # newest version available.
-                #
-                self.pkg("set-publisher -O {0} test3".format(self.rurl7))
-                self.pkg("install quux@1.0", exit=4)
-                self.pkg("unset-publisher test3")
-
-                # Change the image metadata back to where it was, in preparation
-                # for subsequent tests.
-                self.pkg("set-publisher -O {0} -P test1".format(self.rurl1))
-
-                # Remove the installed packages.
-                self.pkg("uninstall quux")
-
-        def test_11_uninstall_after_preferred_publisher_change(self):
-                """Install a package from the preferred publisher, change the
-                preferred publisher, and attempt to remove the package."""
-                self.pkg("install foo@1.0")
-                self.pkg("set-publisher -P test2")
-                self.pkg("uninstall foo")
-                # Change the image metadata back to where it was, in preparation
-                # for the next test.
-                self.pkg("set-publisher -P test1")
-
-        def test_12_uninstall_after_publisher_removal(self):
-                """Install a package from the preferred publisher, remove the
-                preferred publisher, and then evaluate whether an uninstall
-                would succeed regardless of whether its publisher still exists
-                or another publisher has the same fmri in its catalog."""
-                self.pkg("install foo@1.0")
-                self.pkg("set-publisher -P test2")
-                self.pkg("unset-publisher test1")
-
-                # Attempting to uninstall should work even if the corresponding
-                # publisher no longer exists.
-                self.pkg("uninstall -nv foo")
-
-                # Add back the installed package's publisher, but using a
-                # a repository with an empty catalog.  After that, attempt to
-                # uninstall the package again, which should succeed even though
-                # the fmri is no longer in the publisher's catalog.
-                self.pkg("set-publisher -O {0} test1".format(self.rurl6))
-                self.pkg("uninstall -nv foo")
-                self.pkg("unset-publisher test1")
-
-                # Add a new publisher, with a repository with the same packages
-                # as the installed publisher.  Then, add back the installed
-                # package's publisher using an empty repository.  After that,
-                # attempt to uninstall the package again, which should succeed
-                # even though the package's installed publisher is known, but
-                # doesn't have the package's fmri in its catalog, but the
-                # package's fmri is in a different publisher's catalog.
-                self.pkg("set-publisher -O {0} test3".format(self.rurl7))
-                self.pkg("set-publisher -O {0} test1".format(self.rurl6))
-                self.pkg("uninstall -nv foo")
-                self.pkg("unset-publisher test1")
-                self.pkg("unset-publisher test3")
-
-                # Add a new publisher, with a repository with the same packages
-                # as the installed publisher.  After that, attempt to uninstall
-                # the package again, which should succeed even though the fmri
-                # is only in a different publisher's catalog.
-                self.pkg("set-publisher -O {0} test3".format(self.rurl7))
-                self.pkg("uninstall -nv foo")
-                self.pkg("unset-publisher test3")
-
-                # Finally, actually remove the package.
-                self.pkg("uninstall -v foo")
-
-                # Change the image metadata back to where it was, in preparation
-                # for subsequent tests.
-                self.pkg("set-publisher -O {0} -P test1".format(self.rurl1))
-
-        def test_13_non_preferred_multimatch(self):
-                """Verify that when multiple non-preferred publishers offer the
-                same package that the expected install behaviour occurs."""
-
-                self.pkg("set-publisher -P -O {0} test3".format(self.rurl3))
-
-                # make sure we look here first; tests rely on that
-                self.pkg("set-publisher --search-before=test2 test1")
-                self.pkg("publisher")
-                # First, verify that installing a package from a non-preferred
-                # publisher will cause its dependencies to be installed from the
-                # same publisher if the preferred publisher does not offer them.
-                self.pkg("list -a")
-                self.pkg("install pkg://test1/baz")
-                self.pkg("list")
-                self.pkg("info baz | grep test1")
-                self.pkg("info corge | grep test1")
-                self.pkg("uninstall baz corge")
-
-                # Next, verify that naming the specific publishers for a package
-                # and all of its dependencies will install the package from the
-                # specified sources instead of the same publisher the package is a
-                # dependency of.
-                self.pkg("install pkg://test1/baz pkg://test2/corge")
-                self.pkg("info baz | grep test1")
-                self.pkg("info corge | grep test2")
-                self.pkg("uninstall baz corge")
-
-                # Finally, cleanup for the next test.
-                self.pkg("set-publisher -P test1")
-                self.pkg("unset-publisher test3")
-
-        def test_14_nonsticky_publisher(self):
-                """Test various aspects of the stick/non-sticky
-                behavior of publishers"""
-
-                # For ease of debugging
-                self.pkg("list -a")
-                # install from non-preferred repo explicitly
-                self.pkg("install pkg://test2/upgrade-np@1.0")
-                # Demonstrate that perferred publisher is not
-                # acceptable, since test2 is sticky by default
-                self.pkg("install upgrade-np@1.1", exit=1) # not right repo
-                # Check that we can proceed once test2 is not sticky
-                self.pkg("set-publisher --non-sticky test2")
-                self.pkg("install upgrade-np@1.1") # should work now
-                # Restore to pristine
-                self.pkg("set-publisher --sticky test2")
-                self.pkg("uninstall upgrade-np")
-                # Repeat the test w/ preferred
-                self.pkg("install upgrade-p")
-                self.pkg("set-publisher -P test2")
-                self.pkg("install upgrade-p@1.1", exit=1) #orig pub is sticky
-                self.pkg("set-publisher --non-sticky test1")  #not anymore
-                self.pkg("install upgrade-p@1.1")
-                self.pkg("set-publisher -P --sticky test1") # restore
-                self.pkg("uninstall '*'")
-                # Check  that search order can be overridden w/ explicit
-                # version specification...
-                self.pkg("install upgrade-p")
-                self.pkg("install upgrade-p@1.1", exit=1)
-                self.pkg("set-publisher --non-sticky test1")
-                self.pkg("install upgrade-p@1.1") # find match later on
-                self.pkg("set-publisher --sticky test1")
-                self.pkg("uninstall '*'")
-
-        def test_15_nonsticky_update(self):
-                """Test to make sure update follows the same
-                publisher selection mechanisms as pkg install"""
-
-                # try update
-                self.pkg("install pkg://test2/upgrade-np@1.0")
-                self.pkg("update", exit=4)
-                self.pkg("list upgrade-np@1.0")
-                self.pkg("set-publisher --non-sticky test2")
-                self.pkg("publisher")
-                self.pkg("list -a upgrade-np")
-                self.pkg("update '*@*'")
-                self.pkg("list upgrade-np@1.1")
-                self.pkg("set-publisher --sticky test2")
-                self.pkg("uninstall '*'")
-
-        def test_16_disabled_nonsticky(self):
-                """Test to make sure disabled publishers are
-                automatically made non-sticky, and after
-                being enabled keep their previous value
-                of stickiness"""
-
-                # For ease of debugging
-                self.pkg("list -a")
-                # install from non-preferred repo explicitly
-                self.pkg("install pkg://test2/upgrade-np@1.0")
-                # Demonstrate that perferred publisher is not
-                # acceptable, since test2 is sticky by default
-                self.pkg("install upgrade-np@1.1", exit=1) # not right repo
-                # Disable test2 and then we should be able to proceed
-                self.pkg("set-publisher --disable test2")
-                self.pkg("install upgrade-np@1.1")
-                self.pkg("publisher")
-                self.pkg("set-publisher --enable test2")
-                self.pkg("publisher")
-                self.pkg("publisher | egrep sticky", exit=1 )
-
-        def test_17_dependency_is_from_deleted_publisher(self):
-                """Verify that packages installed from a publisher that has
-                been removed can still satisfy dependencies."""
-
-                self.pkg("set-publisher -O {0} test4".format(self.rurl5))
-                self.pkg("install pkg://test4/corge")
-                self.pkg("set-publisher --disable test2")
-                self.pkg("set-publisher --disable test4")
-                self.pkg("list -af")
-                self.pkg("publisher")
-                # this should work, since dependency is already installed
-                # even though it is from a disabled publisher
-                self.pkg("install baz@1.0")
-
-        def test_18_upgrade_across_publishers(self):
-                """Verify that an install/update of specific packages when
-                there is a newer package version available works as expected.
-                """
-
-                # Ensure a new image is created.
-                self.image_create(self.rurl1, prefix="test1", destroy=True)
-
-                # Add second publisher using repository #2.
-                self.pkg("set-publisher -O " + self.rurl2 + " test2")
-
-                # Install older version of package from test1.
-                self.pkg("install pkg://test1/upgrade-p@1.0")
-
-                # Verify update of all packages results in nothing to do even
-                # after test2 is set as preferred.
-                self.pkg("set-publisher -P test2")
-                self.pkg("update -v", exit=4)
-
-                # Verify setting test1 as non-sticky would result in update.
-                self.pkg("set-publisher --non-sticky test1")
-                self.pkg("update -n")
-
-                # Verify update of 'upgrade-p' package will result in upgrade
-                # from 1.0 -> 1.1.
-                self.pkg("update upgrade-p")
-                self.pkg("info pkg://test2/upgrade-p@1.1")
-
-                # Revert to 1.0 and verify install behaves the same.
-                self.pkg("update pkg://test1/upgrade-p@1.0")
-                self.pkg("install upgrade-p")
-                self.pkg("info pkg://test2/upgrade-p@1.1")
-
-        def test_19_refresh_failure(self):
-                """Test that pkg client returns with exit code 1 when only one
-                publisher is specified and it's not reachable (bug 7176158)."""
-
-                # Create private image for this test.
-                self.image_create(self.rurl1, prefix="test1")
-                # Set origin to an invalid repo.
-                self.pkg("set-publisher --no-refresh -O http://test.invalid7 "
-                    "test1")
-
-                # Check if install -n returns with exit code 1
-                self.pkg("install -n moo", exit=1)
+    def setUp(self):
+        """depot 1 gets foo and moo, depot 2 gets foo and bar,
+        depot 3 is empty, depot 4 gets upgrade_np@1.1
+        depot 5 gets corge10, depot6 is empty
+        depot7 is a copy of test1's repository for test3
+        depot1 is mapped to publisher test1 (preferred)
+        depot2 is mapped to publisher test2
+        depot3 is not mapped during setUp
+        depot4 is not mapped during setUp
+        depot5 is not mapped during setUp
+        depot6 is not mapped during setUp"""
+
+        # Two depots are intentionally started for some publishers.
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self,
+            ["test1", "test2", "test3", "test2", "test4", "test1", "test3"],
+        )
+
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.pkgsend_bulk(
+            self.rurl1,
+            (
+                self.foo10,
+                self.moo10,
+                self.quux10,
+                self.optional10,
+                self.upgrade_p10,
+                self.upgrade_np11,
+                self.incorp_p10,
+                self.incorp_p11,
+                self.incorp_np10,
+                self.incorp_np11,
+                self.baz10,
+                self.corge10,
+            ),
+        )
+
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.pkgsend_bulk(
+            self.rurl2,
+            (
+                self.foo10,
+                self.bar10,
+                self.upgrade_p11,
+                self.upgrade_np10,
+                self.corge10,
+            ),
+        )
+
+        self.rurl3 = self.dcs[3].get_repo_url()
+
+        self.rurl4 = self.dcs[4].get_repo_url()
+        self.pkgsend_bulk(self.rurl4, self.upgrade_np11)
+
+        self.rurl5 = self.dcs[5].get_repo_url()
+        self.pkgsend_bulk(self.rurl5, self.corge10)
+
+        self.rurl6 = self.dcs[6].get_repo_url()
+        self.rurl7 = self.dcs[7].get_repo_url()
+
+        # Copy contents of test1's repo to a repo for test3.
+        d1dir = self.dcs[1].get_repodir()
+        d2dir = self.dcs[7].get_repodir()
+        self.copy_repository(d1dir, d2dir, {"test1": "test3"})
+        self.dcs[7].get_repo(auto_create=True).rebuild()
+
+        # Create image and hence primary publisher
+        self.image_create(self.rurl1, prefix="test1")
+
+        # Create second publisher using depot #2
+        self.pkg("set-publisher -O " + self.rurl2 + " test2")
+
+    def test_01_basics(self):
+        self.pkg("list -a")
+
+        # Install and uninstall moo (which is unique to depot 1)
+        self.pkg("install moo")
+
+        self.pkg("list")
+        self.pkg("uninstall moo")
+
+        # Install and uninstall bar (which is unique to depot 2)
+        self.pkg("install bar")
+
+        self.pkg("list")
+
+        self.pkg("uninstall bar")
+
+        # Install and uninstall foo (which is in both depots)
+        # In this case, we should select foo from depot 1, since
+        # it is preferred.
+        self.pkg("install foo")
+
+        self.pkg("list pkg://test1/foo")
+
+        self.pkg("uninstall foo")
+
+    def test_02_basics(self):
+        """Test install from an explicit preferred publisher"""
+        self.pkg("install pkg://test1/foo")
+        self.pkg("list foo")
+        self.pkg("list pkg://test1/foo")
+        self.pkg("uninstall foo")
+
+    def test_03_basics(self):
+        """Test install from an explicit non-preferred publisher"""
+        self.pkg("install pkg://test2/foo")
+        self.pkg("list foo")
+        self.pkg("list pkg://test2/foo")
+        self.pkg("uninstall foo")
+
+    def test_04_upgrade_preferred_to_non_preferred(self):
+        """Install a package from the preferred publisher, and then
+        upgrade it, failing to implicitly switching to a non-preferred
+        publisher and then managing it explicitly"""
+        self.pkg("list -a upgrade-p")
+        self.pkg("install upgrade-p@1.0")
+        self.pkg("install upgrade-p@1.1", exit=1)
+        self.pkg("install pkg://test2/upgrade-p@1.1")
+        self.pkg("uninstall upgrade-p")
+
+    def test_05_upgrade_non_preferred_to_preferred(self):
+        """Install a package from a non-preferred publisher, and then
+        try to upgrade it, failing to implicitly switch to the preferred
+        publisher and then succeed doing it explicitly."""
+        self.pkg("list -a upgrade-np")
+        self.pkg("install upgrade-np@1.0")
+        self.pkg("install upgrade-np@1.1", exit=1)
+        self.pkg("install pkg://test1/upgrade-np@1.1")
+        self.pkg("uninstall upgrade-np")
+
+    def test_06_upgrade_preferred_to_non_preferred_incorporated(self):
+        """Install a package from the preferred publisher, and then
+        upgrade it, failing to implicitly switch to a non-preferred
+        publisher, when the package is constrained by an
+        incorporation, and then succeed when doing so explicitly"""
+
+        self.pkg("list -a upgrade-p incorp-p")
+        self.pkg("install incorp-p@1.0")
+        self.pkg("install upgrade-p")
+        self.pkg("install incorp-p@1.1", exit=1)
+        self.pkg("install incorp-p@1.1 pkg://test2/upgrade-p@1.1")
+        self.pkg("list upgrade-p@1.1")
+        self.pkg("uninstall '*'")
+
+    def test_07_upgrade_non_preferred_to_preferred_incorporated(self):
+        """Install a package from the preferred publisher, and then
+        upgrade it, implicitly switching to a non-preferred
+        publisher, when the package is constrained by an
+        incorporation."""
+        self.pkg("list", exit=1)
+        self.pkg("list -a upgrade-np incorp-np")
+        self.pkg("install incorp-np@1.0")
+        self.pkg("install upgrade-np", exit=1)
+        self.pkg("uninstall '*'")
+
+    def test_08_install_repository_access(self):
+        """Verify that packages can still be installed from a repository
+        even when any of the other repositories are not reachable and
+        --no-refresh is used."""
+
+        # Change the second publisher to point to an unreachable URI.
+        self.pkg("set-publisher --no-refresh -O http://test.invalid7 " "test2")
+
+        # Verify that no packages are installed.
+        self.pkg("list", exit=1)
+
+        # Verify moo can be installed (as only depot1 has it) even
+        # though test2 cannot be reached (and needs a refresh).
+        self.pkg("install moo")
+        self.pkg("uninstall moo")
+
+        # Verify moo can be installed (as only depot1 has it) even
+        # though test2 cannot be reached (and needs a refresh) if
+        # --no-refresh is used.
+        self.pkg("install --no-refresh moo")
+
+        self.pkg("uninstall moo")
+
+        # Reset the test2 publisher.
+        self.pkg("set-publisher -O {0} test2".format(self.rurl2))
+
+        # Install v1.0 of upgrade-np from test2 to prepare for
+        # update.
+        self.pkg("install upgrade-np@1.0")
+
+        # Set test1 to point to an unreachable URI.
+        self.pkg("set-publisher --no-refresh -O http://test.invalid7 " "test1")
+
+        # Set test2 so that upgrade-np has a new version available
+        # even though test1's repository is not accessible.
+        self.pkg("set-publisher -O {0} test2".format(self.rurl4))
+
+        # Verify update works even though test1 is unreachable
+        # since upgrade-np@1.1 is available from test2 if --no-refresh
+        # is used.
+        self.pkg("update --no-refresh")
+
+        # Now reset everything for the next test.
+        self.pkg("uninstall upgrade-np")
+        self.pkg("set-publisher --no-refresh -O {0} test1".format(self.rurl1))
+        self.pkg("set-publisher -O {0} test2".format(self.rurl2))
+
+    def test_09_uninstall_from_wrong_publisher(self):
+        """Install a package from a publisher and try to remove it
+        using a different publisher name; this should fail."""
+        self.pkg("install foo")
+        self.pkg("uninstall pkg://test2/foo", exit=1)
+        # Check to make sure that uninstalling using the explicit
+        # publisher works
+        self.pkg("uninstall pkg://test1/foo")
+
+    def test_10_install_after_publisher_removal(self):
+        """Install a package from a publisher that has an optional
+        dependency; then change the preferred publisher and remove the
+        original publisher and then verify that installing the package
+        again succeeds since it is essentially a no-op."""
+        self.pkg("install quux@1.0")
+        self.pkg("set-publisher -P test2")
+        self.pkg("unset-publisher test1")
+        self.pkg("list -avf")
+
+        # Attempting to install an already installed package should
+        # be a no-op even if the corresponding publisher no longer
+        # exists.
+        self.pkg("install quux@1.0", exit=4)
+
+        # Update should work if we don't see the optional
+        # dependency.
+        self.pkg("update", exit=4)
+
+        # Add back the installed package's publisher, but using a
+        # a repository with an empty catalog.  After that, attempt to
+        # install the package again, which should succeed even though
+        # the fmri is no longer in the publisher's catalog.
+        self.pkg("set-publisher -O {0} test1".format(self.rurl6))
+        self.pkg("install quux@1.0", exit=4)
+        self.pkg("info quux@1.0")
+        self.pkg("unset-publisher test1")
+
+        # Add a new publisher, with the same packages as the installed
+        # publisher.  Then, add back the installed package's publisher,
+        # but using an empty repository.  After that, attempt to install
+        # the package again, which should succeed since at least one
+        # publisher has the package in its catalog.
+        self.pkg("set-publisher -O {0} test3".format(self.rurl7))
+        self.pkg("set-publisher -O {0} test1".format(self.rurl6))
+        self.pkg("info -r pkg://test3/quux@1.0")
+        self.pkg("install quux@1.0", exit=4)
+        self.pkg("unset-publisher test1")
+        self.pkg("unset-publisher test3")
+
+        self.pkg("set-publisher -O {0} test1".format(self.rurl1))
+        self.pkg("info -r pkg://test1/quux@1.0")
+        self.pkg("unset-publisher test1")
+
+        # Add a new publisher, using the installed package publisher's
+        # repository.  After that, attempt to install the package again,
+        # which should simply result in a 'no updates necessary' exit
+        # code since the removed publisher's package is already the
+        # newest version available.
+        #
+        self.pkg("set-publisher -O {0} test3".format(self.rurl7))
+        self.pkg("install quux@1.0", exit=4)
+        self.pkg("unset-publisher test3")
+
+        # Change the image metadata back to where it was, in preparation
+        # for subsequent tests.
+        self.pkg("set-publisher -O {0} -P test1".format(self.rurl1))
+
+        # Remove the installed packages.
+        self.pkg("uninstall quux")
+
+    def test_11_uninstall_after_preferred_publisher_change(self):
+        """Install a package from the preferred publisher, change the
+        preferred publisher, and attempt to remove the package."""
+        self.pkg("install foo@1.0")
+        self.pkg("set-publisher -P test2")
+        self.pkg("uninstall foo")
+        # Change the image metadata back to where it was, in preparation
+        # for the next test.
+        self.pkg("set-publisher -P test1")
+
+    def test_12_uninstall_after_publisher_removal(self):
+        """Install a package from the preferred publisher, remove the
+        preferred publisher, and then evaluate whether an uninstall
+        would succeed regardless of whether its publisher still exists
+        or another publisher has the same fmri in its catalog."""
+        self.pkg("install foo@1.0")
+        self.pkg("set-publisher -P test2")
+        self.pkg("unset-publisher test1")
+
+        # Attempting to uninstall should work even if the corresponding
+        # publisher no longer exists.
+        self.pkg("uninstall -nv foo")
+
+        # Add back the installed package's publisher, but using a
+        # a repository with an empty catalog.  After that, attempt to
+        # uninstall the package again, which should succeed even though
+        # the fmri is no longer in the publisher's catalog.
+        self.pkg("set-publisher -O {0} test1".format(self.rurl6))
+        self.pkg("uninstall -nv foo")
+        self.pkg("unset-publisher test1")
+
+        # Add a new publisher, with a repository with the same packages
+        # as the installed publisher.  Then, add back the installed
+        # package's publisher using an empty repository.  After that,
+        # attempt to uninstall the package again, which should succeed
+        # even though the package's installed publisher is known, but
+        # doesn't have the package's fmri in its catalog, but the
+        # package's fmri is in a different publisher's catalog.
+        self.pkg("set-publisher -O {0} test3".format(self.rurl7))
+        self.pkg("set-publisher -O {0} test1".format(self.rurl6))
+        self.pkg("uninstall -nv foo")
+        self.pkg("unset-publisher test1")
+        self.pkg("unset-publisher test3")
+
+        # Add a new publisher, with a repository with the same packages
+        # as the installed publisher.  After that, attempt to uninstall
+        # the package again, which should succeed even though the fmri
+        # is only in a different publisher's catalog.
+        self.pkg("set-publisher -O {0} test3".format(self.rurl7))
+        self.pkg("uninstall -nv foo")
+        self.pkg("unset-publisher test3")
+
+        # Finally, actually remove the package.
+        self.pkg("uninstall -v foo")
+
+        # Change the image metadata back to where it was, in preparation
+        # for subsequent tests.
+        self.pkg("set-publisher -O {0} -P test1".format(self.rurl1))
+
+    def test_13_non_preferred_multimatch(self):
+        """Verify that when multiple non-preferred publishers offer the
+        same package that the expected install behaviour occurs."""
+
+        self.pkg("set-publisher -P -O {0} test3".format(self.rurl3))
+
+        # make sure we look here first; tests rely on that
+        self.pkg("set-publisher --search-before=test2 test1")
+        self.pkg("publisher")
+        # First, verify that installing a package from a non-preferred
+        # publisher will cause its dependencies to be installed from the
+        # same publisher if the preferred publisher does not offer them.
+        self.pkg("list -a")
+        self.pkg("install pkg://test1/baz")
+        self.pkg("list")
+        self.pkg("info baz | grep test1")
+        self.pkg("info corge | grep test1")
+        self.pkg("uninstall baz corge")
+
+        # Next, verify that naming the specific publishers for a package
+        # and all of its dependencies will install the package from the
+        # specified sources instead of the same publisher the package is a
+        # dependency of.
+        self.pkg("install pkg://test1/baz pkg://test2/corge")
+        self.pkg("info baz | grep test1")
+        self.pkg("info corge | grep test2")
+        self.pkg("uninstall baz corge")
+
+        # Finally, cleanup for the next test.
+        self.pkg("set-publisher -P test1")
+        self.pkg("unset-publisher test3")
+
+    def test_14_nonsticky_publisher(self):
+        """Test various aspects of the stick/non-sticky
+        behavior of publishers"""
+
+        # For ease of debugging
+        self.pkg("list -a")
+        # install from non-preferred repo explicitly
+        self.pkg("install pkg://test2/upgrade-np@1.0")
+        # Demonstrate that perferred publisher is not
+        # acceptable, since test2 is sticky by default
+        self.pkg("install upgrade-np@1.1", exit=1)  # not right repo
+        # Check that we can proceed once test2 is not sticky
+        self.pkg("set-publisher --non-sticky test2")
+        self.pkg("install upgrade-np@1.1")  # should work now
+        # Restore to pristine
+        self.pkg("set-publisher --sticky test2")
+        self.pkg("uninstall upgrade-np")
+        # Repeat the test w/ preferred
+        self.pkg("install upgrade-p")
+        self.pkg("set-publisher -P test2")
+        self.pkg("install upgrade-p@1.1", exit=1)  # orig pub is sticky
+        self.pkg("set-publisher --non-sticky test1")  # not anymore
+        self.pkg("install upgrade-p@1.1")
+        self.pkg("set-publisher -P --sticky test1")  # restore
+        self.pkg("uninstall '*'")
+        # Check  that search order can be overridden w/ explicit
+        # version specification...
+        self.pkg("install upgrade-p")
+        self.pkg("install upgrade-p@1.1", exit=1)
+        self.pkg("set-publisher --non-sticky test1")
+        self.pkg("install upgrade-p@1.1")  # find match later on
+        self.pkg("set-publisher --sticky test1")
+        self.pkg("uninstall '*'")
+
+    def test_15_nonsticky_update(self):
+        """Test to make sure update follows the same
+        publisher selection mechanisms as pkg install"""
+
+        # try update
+        self.pkg("install pkg://test2/upgrade-np@1.0")
+        self.pkg("update", exit=4)
+        self.pkg("list upgrade-np@1.0")
+        self.pkg("set-publisher --non-sticky test2")
+        self.pkg("publisher")
+        self.pkg("list -a upgrade-np")
+        self.pkg("update '*@*'")
+        self.pkg("list upgrade-np@1.1")
+        self.pkg("set-publisher --sticky test2")
+        self.pkg("uninstall '*'")
+
+    def test_16_disabled_nonsticky(self):
+        """Test to make sure disabled publishers are
+        automatically made non-sticky, and after
+        being enabled keep their previous value
+        of stickiness"""
+
+        # For ease of debugging
+        self.pkg("list -a")
+        # install from non-preferred repo explicitly
+        self.pkg("install pkg://test2/upgrade-np@1.0")
+        # Demonstrate that perferred publisher is not
+        # acceptable, since test2 is sticky by default
+        self.pkg("install upgrade-np@1.1", exit=1)  # not right repo
+        # Disable test2 and then we should be able to proceed
+        self.pkg("set-publisher --disable test2")
+        self.pkg("install upgrade-np@1.1")
+        self.pkg("publisher")
+        self.pkg("set-publisher --enable test2")
+        self.pkg("publisher")
+        self.pkg("publisher | egrep sticky", exit=1)
+
+    def test_17_dependency_is_from_deleted_publisher(self):
+        """Verify that packages installed from a publisher that has
+        been removed can still satisfy dependencies."""
+
+        self.pkg("set-publisher -O {0} test4".format(self.rurl5))
+        self.pkg("install pkg://test4/corge")
+        self.pkg("set-publisher --disable test2")
+        self.pkg("set-publisher --disable test4")
+        self.pkg("list -af")
+        self.pkg("publisher")
+        # this should work, since dependency is already installed
+        # even though it is from a disabled publisher
+        self.pkg("install baz@1.0")
+
+    def test_18_upgrade_across_publishers(self):
+        """Verify that an install/update of specific packages when
+        there is a newer package version available works as expected.
+        """
+
+        # Ensure a new image is created.
+        self.image_create(self.rurl1, prefix="test1", destroy=True)
+
+        # Add second publisher using repository #2.
+        self.pkg("set-publisher -O " + self.rurl2 + " test2")
+
+        # Install older version of package from test1.
+        self.pkg("install pkg://test1/upgrade-p@1.0")
+
+        # Verify update of all packages results in nothing to do even
+        # after test2 is set as preferred.
+        self.pkg("set-publisher -P test2")
+        self.pkg("update -v", exit=4)
+
+        # Verify setting test1 as non-sticky would result in update.
+        self.pkg("set-publisher --non-sticky test1")
+        self.pkg("update -n")
+
+        # Verify update of 'upgrade-p' package will result in upgrade
+        # from 1.0 -> 1.1.
+        self.pkg("update upgrade-p")
+        self.pkg("info pkg://test2/upgrade-p@1.1")
+
+        # Revert to 1.0 and verify install behaves the same.
+        self.pkg("update pkg://test1/upgrade-p@1.0")
+        self.pkg("install upgrade-p")
+        self.pkg("info pkg://test2/upgrade-p@1.1")
+
+    def test_19_refresh_failure(self):
+        """Test that pkg client returns with exit code 1 when only one
+        publisher is specified and it's not reachable (bug 7176158)."""
+
+        # Create private image for this test.
+        self.image_create(self.rurl1, prefix="test1")
+        # Set origin to an invalid repo.
+        self.pkg("set-publisher --no-refresh -O http://test.invalid7 " "test1")
+
+        # Check if install -n returns with exit code 1
+        self.pkg("install -n moo", exit=1)
 
 
 class TestImageCreateCorruptImage(pkg5unittest.SingleDepotTestCaseCorruptImage):
-        """
-        If a new essential directory is added to the format of an image it will
-        be necessary to update this test suite. To update this test suite,
-        decide in what ways it is necessary to corrupt the image (removing the
-        new directory or file, or removing the some or all of contents of the
-        new directory for example). Make the necessary changes in
-        pkg5unittest.SingleDepotTestCaseCorruptImage to allow the needed
-        corruptions, then add new tests to the suite below. Be sure to add
-        tests for both Full and User images, and perhaps Partial images if
-        situations are found where these behave differently than Full or User
-        images.
-        """
+    """
+    If a new essential directory is added to the format of an image it will
+    be necessary to update this test suite. To update this test suite,
+    decide in what ways it is necessary to corrupt the image (removing the
+    new directory or file, or removing the some or all of contents of the
+    new directory for example). Make the necessary changes in
+    pkg5unittest.SingleDepotTestCaseCorruptImage to allow the needed
+    corruptions, then add new tests to the suite below. Be sure to add
+    tests for both Full and User images, and perhaps Partial images if
+    situations are found where these behave differently than Full or User
+    images.
+    """
 
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
             close """
 
-        misc_files = [ "tmp/libc.so.1" ]
+    misc_files = ["tmp/libc.so.1"]
 
-        PREFIX = "unset PKG_IMAGE; cd {0};"
+    PREFIX = "unset PKG_IMAGE; cd {0};"
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCaseCorruptImage.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCaseCorruptImage.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-        def pkg(self, command, exit=0, comment="", use_img_root=True):
-                pkg5unittest.SingleDepotTestCaseCorruptImage.pkg(self, command,
-                    exit=exit, comment=comment, prefix=self.PREFIX.format(self.dir),
-                    use_img_root=use_img_root)
+    def pkg(self, command, exit=0, comment="", use_img_root=True):
+        pkg5unittest.SingleDepotTestCaseCorruptImage.pkg(
+            self,
+            command,
+            exit=exit,
+            comment=comment,
+            prefix=self.PREFIX.format(self.dir),
+            use_img_root=use_img_root,
+        )
+
+    # For each test:
+    # A good image is created at $basedir/image
+    # A corrupted image is created at $basedir/image/bad (called bad_dir
+    #     in subsequent notes) in verious ways
+    # The $basedir/image/bad/final directory is created and PKG_IMAGE
+    #     is set to that dirctory.
 
-        # For each test:
-        # A good image is created at $basedir/image
-        # A corrupted image is created at $basedir/image/bad (called bad_dir
-        #     in subsequent notes) in verious ways
-        # The $basedir/image/bad/final directory is created and PKG_IMAGE
-        #     is set to that dirctory.
+    # Tests simulating a corrupted Full Image
 
-        # Tests simulating a corrupted Full Image
+    def test_empty_var_pkg(self):
+        """Creates an empty bad_dir."""
 
-        def test_empty_var_pkg(self):
-                """ Creates an empty bad_dir. """
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.dir = self.corrupt_image_create(
+            self.rurl,
+            set(["publisher", "cfg_cache", "file", "pkg", "index"]),
+            ["var/pkg"],
+        )
 
-                self.dir = self.corrupt_image_create(self.rurl,
-                    set(["publisher", "cfg_cache", "file", "pkg", "index"]),
-                    ["var/pkg"])
+        self.pkg("install foo@1.1")
 
-                self.pkg("install foo@1.1")
+    def test_var_pkg_missing_publisher(self):
+        """Creates bad_dir with only the publisher and known/state
+        dir missing."""
 
-        def test_var_pkg_missing_publisher(self):
-                """ Creates bad_dir with only the publisher and known/state
-                dir missing. """
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.dir = self.corrupt_image_create(
+            self.rurl, set(["publisher_absent", "known_absent"]), ["var/pkg"]
+        )
 
-                self.dir = self.corrupt_image_create(self.rurl,
-                    set(["publisher_absent", "known_absent"]),
-                    ["var/pkg"])
+        self.pkg("install foo@1.1")
 
-                self.pkg("install foo@1.1")
+    def test_var_pkg_missing_cfg_cache(self):
+        """Creates bad_dir with only the cfg_cache file missing."""
 
-        def test_var_pkg_missing_cfg_cache(self):
-                """ Creates bad_dir with only the cfg_cache file missing. """
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.dir = self.corrupt_image_create(
+            self.rurl, set(["cfg_cache_absent"]), ["var/pkg"]
+        )
 
-                self.dir = self.corrupt_image_create(self.rurl,
-                    set(["cfg_cache_absent"]), ["var/pkg"])
+        self.pkg(
+            "-D simulate_live_root={0} install foo@1.1".format(
+                self.backup_img_path()
+            ),
+            use_img_root=False,
+        )
 
-                self.pkg("-D simulate_live_root={0} install foo@1.1".format(
-                    self.backup_img_path()), use_img_root=False)
+    def test_var_pkg_missing_index(self):
+        """Creates bad_dir with only the index dir missing."""
 
-        def test_var_pkg_missing_index(self):
-                """ Creates bad_dir with only the index dir missing. """
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.dir = self.corrupt_image_create(
+            self.rurl, set(["index_absent"]), ["var/pkg"]
+        )
 
-                self.dir = self.corrupt_image_create(self.rurl, set(
-                    ["index_absent"]), ["var/pkg"])
+        self.pkg("install foo@1.1")
 
-                self.pkg("install foo@1.1")
+    def test_var_pkg_missing_publisher_empty(self):
+        """Creates bad_dir with all dirs and files present, but
+        with an empty publisher and state/known dir.
+        """
 
-        def test_var_pkg_missing_publisher_empty(self):
-                """ Creates bad_dir with all dirs and files present, but
-                with an empty publisher and state/known dir.
-                """
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.dir = self.corrupt_image_create(
+            self.rurl, set(["publisher_empty", "known_empty"]), ["var/pkg"]
+        )
 
-                self.dir = self.corrupt_image_create(self.rurl,
-                    set(["publisher_empty", "known_empty"]), ["var/pkg"])
+        # This is expected to fail because it will see an empty
+        # publisher directory and not rebuild the files as needed
+        self.pkg("install --no-refresh foo@1.1", exit=1)
+        self.pkg("install foo@1.1")
 
-                # This is expected to fail because it will see an empty
-                # publisher directory and not rebuild the files as needed
-                self.pkg("install --no-refresh foo@1.1", exit=1)
-                self.pkg("install foo@1.1")
+    def test_var_pkg_missing_publisher_empty_hit_then_refreshed_then_hit(self):
+        """Creates bad_dir with all dirs and files present, but with an
+        with an empty publisher and state/known dir. This is to ensure
+        that refresh will work, and that an install after the refresh
+        also works.
+        """
 
-        def test_var_pkg_missing_publisher_empty_hit_then_refreshed_then_hit(
-            self):
-                """ Creates bad_dir with all dirs and files present, but with an
-                with an empty publisher and state/known dir. This is to ensure
-                that refresh will work, and that an install after the refresh
-                also works.
-                """
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.dir = self.corrupt_image_create(
+            self.rurl, set(["publisher_empty", "known_empty"]), ["var/pkg"]
+        )
 
-                self.dir = self.corrupt_image_create(self.rurl,
-                    set(["publisher_empty", "known_empty"]), ["var/pkg"])
+        self.pkg("install --no-refresh foo@1.1", exit=1)
+        self.pkg("refresh")
+        self.pkg("install foo@1.1")
 
-                self.pkg("install --no-refresh foo@1.1", exit=1)
-                self.pkg("refresh")
-                self.pkg("install foo@1.1")
+    def test_var_pkg_left_alone(self):
+        """Sanity check to ensure that the code for creating
+        a bad_dir creates a good copy other than what's specified
+        to be wrong."""
 
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-        def test_var_pkg_left_alone(self):
-                """ Sanity check to ensure that the code for creating
-                a bad_dir creates a good copy other than what's specified
-                to be wrong. """
+        self.dir = self.corrupt_image_create(self.rurl, set(), ["var/pkg"])
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.pkg("install foo@1.1")
 
-                self.dir = self.corrupt_image_create(self.rurl, set(), ["var/pkg"])
+    # Tests simulating a corrupted User Image
 
-                self.pkg("install foo@1.1")
+    # These tests are duplicates of those above but instead of creating
+    # a corrupt full image, they create a corrupt User image.
 
-        # Tests simulating a corrupted User Image
+    def test_empty_ospkg(self):
+        """Creates a corrupted image at bad_dir by creating empty
+        bad_dir."""
 
-        # These tests are duplicates of those above but instead of creating
-        # a corrupt full image, they create a corrupt User image.
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-        def test_empty_ospkg(self):
-                """ Creates a corrupted image at bad_dir by creating empty
-                bad_dir.  """
+        self.dir = self.corrupt_image_create(
+            self.rurl,
+            set(["publisher", "cfg_cache", "file", "pkg", "index"]),
+            [".org.opensolaris,pkg"],
+        )
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.pkg("install foo@1.1")
 
-                self.dir = self.corrupt_image_create(self.rurl,
-                    set(["publisher", "cfg_cache", "file", "pkg", "index"]),
-                    [".org.opensolaris,pkg"])
+    def test_ospkg_missing_publisher(self):
+        """Creates a corrupted image at bad_dir by creating bad_dir
+        with only the publisher and known/state dir missing."""
 
-                self.pkg("install foo@1.1")
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-        def test_ospkg_missing_publisher(self):
-                """ Creates a corrupted image at bad_dir by creating bad_dir
-                with only the publisher and known/state dir missing. """
+        self.dir = self.corrupt_image_create(
+            self.rurl,
+            set(["publisher_absent", "known_absent"]),
+            [".org.opensolaris,pkg"],
+        )
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.pkg("install foo@1.1")
 
-                self.dir = self.corrupt_image_create(self.rurl,
-                    set(["publisher_absent", "known_absent"]),
-                        [".org.opensolaris,pkg"])
+    def test_ospkg_missing_cfg_cache(self):
+        """Creates a corrupted image at bad_dir by creating
+        bad_dir with only the cfg_cache file missing."""
 
-                self.pkg("install foo@1.1")
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-        def test_ospkg_missing_cfg_cache(self):
-                """ Creates a corrupted image at bad_dir by creating
-                bad_dir with only the cfg_cache file missing.  """
+        self.dir = self.corrupt_image_create(
+            self.rurl, set(["cfg_cache_absent"]), [".org.opensolaris,pkg"]
+        )
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.pkg(
+            "-D simulate_live_root={0} install foo@1.1".format(
+                self.backup_img_path()
+            ),
+            use_img_root=False,
+        )
 
-                self.dir = self.corrupt_image_create(self.rurl,
-                    set(["cfg_cache_absent"]), [".org.opensolaris,pkg"])
+    def test_ospkg_missing_index(self):
+        """Creates a corrupted image at bad_dir by creating
+        bad_dir with only the index dir missing."""
 
-                self.pkg("-D simulate_live_root={0} install foo@1.1".format(
-                    self.backup_img_path()), use_img_root=False)
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-        def test_ospkg_missing_index(self):
-                """ Creates a corrupted image at bad_dir by creating
-                bad_dir with only the index dir missing. """
+        self.dir = self.corrupt_image_create(
+            self.rurl, set(["index_absent"]), [".org.opensolaris,pkg"]
+        )
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.pkg("install foo@1.1")
 
-                self.dir = self.corrupt_image_create(self.rurl, set(["index_absent"]),
-                    [".org.opensolaris,pkg"])
+    def test_ospkg_missing_publisher_empty(self):
+        """Creates a corrupted image at bad_dir by creating bad_dir
+        with all dirs and files present, but with an empty publisher
+        and known/state dir."""
 
-                self.pkg("install foo@1.1")
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-        def test_ospkg_missing_publisher_empty(self):
-                """ Creates a corrupted image at bad_dir by creating bad_dir
-                with all dirs and files present, but with an empty publisher
-                and known/state dir. """
+        self.dir = self.corrupt_image_create(
+            self.rurl,
+            set(["publisher_empty", "known_empty"]),
+            [".org.opensolaris,pkg"],
+        )
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.pkg("install --no-refresh foo@1.1", exit=1)
 
-                self.dir = self.corrupt_image_create(self.rurl,
-                    set(["publisher_empty", "known_empty"]),
-                    [".org.opensolaris,pkg"])
+    def test_ospkg_missing_publisher_empty_hit_then_refreshed_then_hit(self):
+        """Creates bad_dir with all dirs and files present, but with
+        an empty publisher and known/state dir. This is to ensure that
+        refresh will work, and that an install after the refresh also
+        works.
+        """
 
-                self.pkg("install --no-refresh foo@1.1", exit=1)
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-        def test_ospkg_missing_publisher_empty_hit_then_refreshed_then_hit(self):
-                """ Creates bad_dir with all dirs and files present, but with
-                an empty publisher and known/state dir. This is to ensure that
-                refresh will work, and that an install after the refresh also
-                works.
-                """
+        self.dir = self.corrupt_image_create(
+            self.rurl,
+            set(["publisher_empty", "known_empty"]),
+            [".org.opensolaris,pkg"],
+        )
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
+        self.pkg("install --no-refresh foo@1.1", exit=1)
+        self.pkg("refresh")
+        self.pkg("install foo@1.1")
 
-                self.dir = self.corrupt_image_create(self.rurl,
-                    set(["publisher_empty", "known_empty"]),
-                    [".org.opensolaris,pkg"])
+    def test_ospkg_left_alone(self):
+        """Sanity check to ensure that the code for creating
+        a bad_dir creates a good copy other than what's specified
+        to be wrong."""
 
-                self.pkg("install --no-refresh foo@1.1", exit=1)
-                self.pkg("refresh")
-                self.pkg("install foo@1.1")
+        self.pkgsend_bulk(self.rurl, self.foo11)
+        self.image_create(self.rurl)
 
-        def test_ospkg_left_alone(self):
-                """ Sanity check to ensure that the code for creating
-                a bad_dir creates a good copy other than what's specified
-                to be wrong. """
+        self.dir = self.corrupt_image_create(
+            self.rurl, set(), [".org.opensolaris,pkg"]
+        )
 
-                self.pkgsend_bulk(self.rurl, self.foo11)
-                self.image_create(self.rurl)
-
-                self.dir = self.corrupt_image_create(self.rurl, set(),
-                    [".org.opensolaris,pkg"])
-
-                self.pkg("install foo@1.1")
+        self.pkg("install foo@1.1")
 
 
 class TestPkgInstallObsolete(pkg5unittest.SingleDepotTestCase):
-        """Test cases for obsolete packages."""
+    """Test cases for obsolete packages."""
 
-        persistent_setup = True
-        def test_basic_install(self):
-                foo1 = """
+    persistent_setup = True
+
+    def test_basic_install(self):
+        foo1 = """
                     open foo@1
                     add dir path=usr mode=0755 owner=root group=root
                     close
                 """
-                # Obsolete packages can have metadata
-                foo2 = """
+        # Obsolete packages can have metadata
+        foo2 = """
                     open foo@2
                     add set name=pkg.obsolete value=true
                     add set name=pkg.summary value="A test package"
                     close
                 """
 
-                fbar = """
+        fbar = """
                     open fbar@1
                     add depend type=require fmri=foo@2
                     close
                 """
 
-                qbar = """
+        qbar = """
                     open qbar@1
                     add depend type=require fmri=qux@2
                     close
                 """
 
-                qux1 = """
+        qux1 = """
                     open qux@1
                     add dir path=usr mode=0755 owner=root group=root
                     close
                 """
 
-                qux2 = """
+        qux2 = """
                     open qux@2
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=foo@1
                     close
                 """
 
-                fred1 = """
+        fred1 = """
                     open fred@1
                     add depend type=require fmri=foo
                     close
                 """
-                fred2 = """
+        fred2 = """
                     open fred@2
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (foo1, foo2, fbar, qbar, qux1,
-                    qux2, fred1))
+        self.pkgsend_bulk(
+            self.rurl, (foo1, foo2, fbar, qbar, qux1, qux2, fred1)
+        )
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                # First install the non-obsolete version of foo
-                self.pkg("install foo@1")
-                self.pkg("list foo@1")
+        # First install the non-obsolete version of foo
+        self.pkg("install foo@1")
+        self.pkg("list foo@1")
 
-                # Now install the obsolete version, and ensure it disappears (5)
-                self.pkg("install foo")
-                self.pkg("list foo", exit=1)
+        # Now install the obsolete version, and ensure it disappears (5)
+        self.pkg("install foo")
+        self.pkg("list foo", exit=1)
 
-                # Explicitly installing an obsolete package succeeds, but
-                # results in nothing on the system. (1)
-                self.pkg("install foo@2", exit=4)
-                self.pkg("list foo", exit=1)
+        # Explicitly installing an obsolete package succeeds, but
+        # results in nothing on the system. (1)
+        self.pkg("install foo@2", exit=4)
+        self.pkg("list foo", exit=1)
 
-                # Installing a package with a dependency on an obsolete package
-                # fails. (2)
-                self.pkg("install fbar", exit=1)
+        # Installing a package with a dependency on an obsolete package
+        # fails. (2)
+        self.pkg("install fbar", exit=1)
 
-                # Installing a package with a dependency on a renamed package
-                # succeeds, leaving the first package and the renamed package on
-                # the system, as well as the empty, pre-renamed package. (3)
-                self.pkg("install qbar")
-                self.pkg("list qbar")
-                self.pkg("list foo@1")
-                self.pkg("list qux | grep -- i-r")
-                self.pkg("uninstall '*'") #clean up for next test
-                # A simple rename test: First install the pre-renamed version of
-                # qux.  Then install the renamed version, and see that the new
-                # package is installed, and the renamed package is installed,
-                # but marked renamed.  (4)
-                self.pkg("install qux@1")
-                self.pkg("install qux") # upgrades qux
-                self.pkg("list foo@1")
-                self.pkg("list qux", exit=1)
-                self.pkg("uninstall '*'") #clean up for next test
+        # Installing a package with a dependency on a renamed package
+        # succeeds, leaving the first package and the renamed package on
+        # the system, as well as the empty, pre-renamed package. (3)
+        self.pkg("install qbar")
+        self.pkg("list qbar")
+        self.pkg("list foo@1")
+        self.pkg("list qux | grep -- i-r")
+        self.pkg("uninstall '*'")  # clean up for next test
+        # A simple rename test: First install the pre-renamed version of
+        # qux.  Then install the renamed version, and see that the new
+        # package is installed, and the renamed package is installed,
+        # but marked renamed.  (4)
+        self.pkg("install qux@1")
+        self.pkg("install qux")  # upgrades qux
+        self.pkg("list foo@1")
+        self.pkg("list qux", exit=1)
+        self.pkg("uninstall '*'")  # clean up for next test
 
-                # Install a package that's going to be obsoleted and a package
-                # that depends on it.  Update the package to its obsolete
-                # version and see that it fails.  (6, sorta)
-                self.pkg("install foo@1 fred@1")
-                self.pkg("install foo@2", exit=1)
-                # now add a version of fred that doesn't require foo, and
-                # show that update works
-                self.pkgsend_bulk(self.rurl, fred2)
-                self.pkg("refresh")
-                self.pkg("install foo@2")
-                self.pkg("uninstall '*'") #clean up for next test
-                # test fix for bug 12898
-                self.pkg("install qux@1")
-                self.pkg("install fred@2")
-                self.pkg("list foo@1", exit=1) # should not be installed
-                self.pkg("install qux") #update
-                self.pkg("list foo@1")
-                self.pkgrepo("remove -s {0} fred@2".format(self.rurl))
+        # Install a package that's going to be obsoleted and a package
+        # that depends on it.  Update the package to its obsolete
+        # version and see that it fails.  (6, sorta)
+        self.pkg("install foo@1 fred@1")
+        self.pkg("install foo@2", exit=1)
+        # now add a version of fred that doesn't require foo, and
+        # show that update works
+        self.pkgsend_bulk(self.rurl, fred2)
+        self.pkg("refresh")
+        self.pkg("install foo@2")
+        self.pkg("uninstall '*'")  # clean up for next test
+        # test fix for bug 12898
+        self.pkg("install qux@1")
+        self.pkg("install fred@2")
+        self.pkg("list foo@1", exit=1)  # should not be installed
+        self.pkg("install qux")  # update
+        self.pkg("list foo@1")
+        self.pkgrepo("remove -s {0} fred@2".format(self.rurl))
 
-        def test_basic_exact_install(self):
-                foo1 = """
+    def test_basic_exact_install(self):
+        foo1 = """
                     open foo@1
                     add dir path=usr mode=0755 owner=root group=root
                     close
                 """
-                # Obsolete packages can have metadata
-                foo2 = """
+        # Obsolete packages can have metadata
+        foo2 = """
                     open foo@2
                     add set name=pkg.obsolete value=true
                     add set name=pkg.summary value="A test package"
                     close
                 """
 
-                fbar = """
+        fbar = """
                     open fbar@1
                     add depend type=require fmri=foo@2
                     close
                 """
 
-                qbar = """
+        qbar = """
                     open qbar@1
                     add depend type=require fmri=qux@2
                     close
                 """
 
-                qux1 = """
+        qux1 = """
                     open qux@1
                     add dir path=usr mode=0755 owner=root group=root
                     close
                 """
 
-                qux2 = """
+        qux2 = """
                     open qux@2
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=foo@1
                     close
                 """
 
-                fred1 = """
+        fred1 = """
                     open fred@1
                     add depend type=require fmri=foo
                     close
                 """
-                fred2 = """
+        fred2 = """
                     open fred@2
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (foo1, foo2, fbar, qbar, qux1,
-                    qux2, fred1))
+        self.pkgsend_bulk(
+            self.rurl, (foo1, foo2, fbar, qbar, qux1, qux2, fred1)
+        )
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                # First exact-install the non-obsolete version of foo
-                self.pkg("exact-install foo@1")
-                self.pkg("list foo@1")
+        # First exact-install the non-obsolete version of foo
+        self.pkg("exact-install foo@1")
+        self.pkg("list foo@1")
 
-                # Now exact-install the obsolete version, and ensure it disappears
-                # (5).
-                self.pkg("exact-install foo")
-                self.pkg("list foo", exit=1)
+        # Now exact-install the obsolete version, and ensure it disappears
+        # (5).
+        self.pkg("exact-install foo")
+        self.pkg("list foo", exit=1)
 
-                # Explicitly exact-installing an obsolete package succeeds, but
-                # results in nothing on the system. (1)
-                self.pkg("exact-install foo@2", exit=4)
-                self.pkg("list foo", exit=1)
+        # Explicitly exact-installing an obsolete package succeeds, but
+        # results in nothing on the system. (1)
+        self.pkg("exact-install foo@2", exit=4)
+        self.pkg("list foo", exit=1)
 
-                # Exact-installing a package with a dependency on an obsolete
-                # package fails. (2)
-                self.pkg("exact-install fbar", exit=1)
+        # Exact-installing a package with a dependency on an obsolete
+        # package fails. (2)
+        self.pkg("exact-install fbar", exit=1)
 
-                # Exact-installing a package with a dependency on a renamed
-                # package succeeds, leaving the first package and the renamed
-                # package on the system, as well as the empty, pre-renamed
-                # package. (3)
-                self.pkg("exact-install qbar")
-                self.pkg("list qbar")
-                self.pkg("list foo@1")
-                self.pkg("list qux | grep -- i-r")
-                self.pkg("uninstall '*'") #clean up for next test
-                # A simple rename test: First exact-install the pre-renamed
-                # version of qux.  Then install the renamed version, and see
-                # that the new package is installed, and the renamed package
-                # is installed, but marked renamed.  (4)
-                self.pkg("exact-install qux@1")
-                self.pkg("exact-install qux") # upgrades qux
-                self.pkg("list foo@1")
-                self.pkg("list qux", exit=1)
-                self.pkg("uninstall '*'") #clean up for next test
+        # Exact-installing a package with a dependency on a renamed
+        # package succeeds, leaving the first package and the renamed
+        # package on the system, as well as the empty, pre-renamed
+        # package. (3)
+        self.pkg("exact-install qbar")
+        self.pkg("list qbar")
+        self.pkg("list foo@1")
+        self.pkg("list qux | grep -- i-r")
+        self.pkg("uninstall '*'")  # clean up for next test
+        # A simple rename test: First exact-install the pre-renamed
+        # version of qux.  Then install the renamed version, and see
+        # that the new package is installed, and the renamed package
+        # is installed, but marked renamed.  (4)
+        self.pkg("exact-install qux@1")
+        self.pkg("exact-install qux")  # upgrades qux
+        self.pkg("list foo@1")
+        self.pkg("list qux", exit=1)
+        self.pkg("uninstall '*'")  # clean up for next test
 
-                # Exact-install a package that's going to be obsoleted and a
-                # package that depends on it.  Update the package to its
-                # obsolete version and see that it fails.  (6, sorta)
-                self.pkg("exact-install foo@1 fred@1")
-                self.pkg("exact-install foo@2 fred@1", exit=1)
+        # Exact-install a package that's going to be obsoleted and a
+        # package that depends on it.  Update the package to its
+        # obsolete version and see that it fails.  (6, sorta)
+        self.pkg("exact-install foo@1 fred@1")
+        self.pkg("exact-install foo@2 fred@1", exit=1)
 
-                # If fred is not in the command line, we should ignore its
-                # restriction and install foo@2.
-                self.pkg("exact-install foo@2")
-                # now add a version of fred that doesn't require foo, and
-                # show that update works
-                self.pkgsend_bulk(self.rurl, fred2)
-                self.pkg("refresh")
-                self.pkg("exact-install foo@2 fred")
-                self.pkg("uninstall '*'") #clean up for next test
-                self.pkgrepo("remove -s {0} fred@2".format(self.rurl))
+        # If fred is not in the command line, we should ignore its
+        # restriction and install foo@2.
+        self.pkg("exact-install foo@2")
+        # now add a version of fred that doesn't require foo, and
+        # show that update works
+        self.pkgsend_bulk(self.rurl, fred2)
+        self.pkg("refresh")
+        self.pkg("exact-install foo@2 fred")
+        self.pkg("uninstall '*'")  # clean up for next test
+        self.pkgrepo("remove -s {0} fred@2".format(self.rurl))
 
-        def test_basic_7a(self):
-                """Upgrade a package to a version with a dependency on a renamed
-                package.  A => A' (-> Br (-> C))"""
+    def test_basic_7a(self):
+        """Upgrade a package to a version with a dependency on a renamed
+        package.  A => A' (-> Br (-> C))"""
 
-                t7ap1_1 = """
+        t7ap1_1 = """
                     open t7ap1@1
                     close
                 """
 
-                t7ap1_2 = """
+        t7ap1_2 = """
                     open t7ap1@2
                     add depend type=require fmri=t7ap2
                     close
                 """
 
-                t7ap2_1 = """
+        t7ap2_1 = """
                     open t7ap2@1
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=t7ap3
                     close
                 """
 
-                t7ap3_1 = """
+        t7ap3_1 = """
                     open t7ap3@1
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, t7ap1_1)
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, t7ap1_1)
+        self.image_create(self.rurl)
 
-                self.pkg("install t7ap1")
+        self.pkg("install t7ap1")
 
-                self.pkgsend_bulk(self.rurl, (t7ap1_2, t7ap2_1, t7ap3_1))
+        self.pkgsend_bulk(self.rurl, (t7ap1_2, t7ap2_1, t7ap3_1))
 
-                self.pkg("refresh")
-                self.pkg("update")
-                self.pkg("list -af")
-                self.pkg("list t7ap2 | grep -- i-r")
-                self.pkg("list t7ap3")
+        self.pkg("refresh")
+        self.pkg("update")
+        self.pkg("list -af")
+        self.pkg("list t7ap2 | grep -- i-r")
+        self.pkg("list t7ap3")
 
-        def test_basic_7b(self):
-                """Upgrade a package to a version with a dependency on a renamed
-                package.  Like 7a except package A starts off depending on B.
+    def test_basic_7b(self):
+        """Upgrade a package to a version with a dependency on a renamed
+        package.  Like 7a except package A starts off depending on B.
 
-                A (-> B) => A' (-> Br (-> C))"""
+        A (-> B) => A' (-> Br (-> C))"""
 
-                t7bp1_1 = """
+        t7bp1_1 = """
                     open t7bp1@1
                     add depend type=require fmri=t7bp2
                     close
                 """
 
-                t7bp1_2 = """
+        t7bp1_2 = """
                     open t7bp1@2
                     add depend type=require fmri=t7bp2
                     close
                 """
 
-                t7bp2_1 = """
+        t7bp2_1 = """
                     open t7bp2@1
                     close
                 """
 
-                t7bp2_2 = """
+        t7bp2_2 = """
                     open t7bp2@1
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=t7bp3
                     close
                 """
 
-                t7bp3_1 = """
+        t7bp3_1 = """
                     open t7bp3@1
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (t7bp1_1, t7bp2_1))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (t7bp1_1, t7bp2_1))
+        self.image_create(self.rurl)
 
-                self.pkg("install t7bp1")
+        self.pkg("install t7bp1")
 
-                self.pkgsend_bulk(self.rurl, (t7bp1_2, t7bp2_2, t7bp3_1))
+        self.pkgsend_bulk(self.rurl, (t7bp1_2, t7bp2_2, t7bp3_1))
 
-                self.pkg("refresh")
-                self.pkg("update")
-                self.pkg("list t7bp2 | grep -- i-r")
-                self.pkg("list t7bp3")
+        self.pkg("refresh")
+        self.pkg("update")
+        self.pkg("list t7bp2 | grep -- i-r")
+        self.pkg("list t7bp3")
 
-        def test_basic_7c(self):
-                """Upgrade a package to a version with a dependency on a renamed
-                package.  Like 7b, except package A doesn't change.
+    def test_basic_7c(self):
+        """Upgrade a package to a version with a dependency on a renamed
+        package.  Like 7b, except package A doesn't change.
 
-                A (-> B) => A (-> Br (-> C))"""
+        A (-> B) => A (-> Br (-> C))"""
 
-                t7cp1_1 = """
+        t7cp1_1 = """
                     open t7cp1@1
                     add depend type=require fmri=t7cp2
                     close
                 """
 
-                t7cp2_1 = """
+        t7cp2_1 = """
                     open t7cp2@1
                     close
                 """
 
-                t7cp2_2 = """
+        t7cp2_2 = """
                     open t7cp2@2
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=t7cp3
                     close
                 """
 
-                t7cp3_1 = """
+        t7cp3_1 = """
                     open t7cp3@1
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (t7cp1_1, t7cp2_1))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (t7cp1_1, t7cp2_1))
+        self.image_create(self.rurl)
 
-                self.pkg("install t7cp1")
+        self.pkg("install t7cp1")
 
-                self.pkgsend_bulk(self.rurl, (t7cp2_2, t7cp3_1))
+        self.pkgsend_bulk(self.rurl, (t7cp2_2, t7cp3_1))
 
-                self.pkg("refresh")
-                self.pkg("update")
+        self.pkg("refresh")
+        self.pkg("update")
 
-                self.pkg("list t7cp2 | grep -- i-r")
-                self.pkg("list t7cp3")
+        self.pkg("list t7cp2 | grep -- i-r")
+        self.pkg("list t7cp3")
 
-        def test_basic_6a(self):
-                """Upgrade a package to a version with a dependency on an
-                obsolete package.  This version is unlikely to happen in real
-                life."""
+    def test_basic_6a(self):
+        """Upgrade a package to a version with a dependency on an
+        obsolete package.  This version is unlikely to happen in real
+        life."""
 
-                t6ap1_1 = """
+        t6ap1_1 = """
                     open t6ap1@1
                     close
                 """
 
-                t6ap1_2 = """
+        t6ap1_2 = """
                     open t6ap1@2
                     add depend type=require fmri=t6ap2
                     close
                 """
 
-                t6ap2_1 = """
+        t6ap2_1 = """
                     open t6ap2@1
                     add set name=pkg.obsolete value=true
                     close
                 """
 
+        self.pkgsend_bulk(self.rurl, t6ap1_1)
+        self.image_create(self.rurl)
 
-                self.pkgsend_bulk(self.rurl, t6ap1_1)
-                self.image_create(self.rurl)
+        self.pkg("install t6ap1")
 
-                self.pkg("install t6ap1")
+        self.pkgsend_bulk(self.rurl, (t6ap1_2, t6ap2_1))
 
-                self.pkgsend_bulk(self.rurl, (t6ap1_2, t6ap2_1))
+        self.pkg("refresh")
+        self.pkg("update", exit=4)  # does nothing
+        self.pkg("list t6ap1")
 
-                self.pkg("refresh")
-                self.pkg("update", exit=4) # does nothing
-                self.pkg("list t6ap1")
+    def test_basic_6b(self):
+        """Install a package with a dependency, and update after
+        publishing updated packages for both, but where the dependency
+        has become obsolete."""
 
-        def test_basic_6b(self):
-                """Install a package with a dependency, and update after
-                publishing updated packages for both, but where the dependency
-                has become obsolete."""
-
-                t6ap1_1 = """
+        t6ap1_1 = """
                     open t6ap1@1
                     add depend type=require fmri=t6ap2
                     close
                 """
 
-                t6ap1_2 = """
+        t6ap1_2 = """
                     open t6ap1@2
                     add depend type=require fmri=t6ap2
                     close
                 """
 
-                t6ap2_1 = """
+        t6ap2_1 = """
                     open t6ap2@1
                     close
                 """
 
-                t6ap2_2 = """
+        t6ap2_2 = """
                     open t6ap2@2
                     add set name=pkg.obsolete value=true
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (t6ap1_1, t6ap2_1))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (t6ap1_1, t6ap2_1))
+        self.image_create(self.rurl)
 
-                self.pkg("install t6ap1")
-                self.pkg("list")
+        self.pkg("install t6ap1")
+        self.pkg("list")
 
-                self.pkgsend_bulk(self.rurl, (t6ap1_2, t6ap2_2))
+        self.pkgsend_bulk(self.rurl, (t6ap1_2, t6ap2_2))
 
-                self.pkg("refresh")
-                self.pkg("update")
-                self.pkg("list t6ap1@2 t6ap2@1")
+        self.pkg("refresh")
+        self.pkg("update")
+        self.pkg("list t6ap1@2 t6ap2@1")
 
-        def test_basic_8a(self):
-                """Upgrade a package to an obsolete leaf version when another
-                depends on it."""
+    def test_basic_8a(self):
+        """Upgrade a package to an obsolete leaf version when another
+        depends on it."""
 
-                t8ap1_1 = """
+        t8ap1_1 = """
                     open t8ap1@1
                     close
                 """
 
-                t8ap1_2 = """
+        t8ap1_2 = """
                     open t8ap1@2
                     add set name=pkg.obsolete value=true
                     close
                 """
 
-                t8ap2_1 = """
+        t8ap2_1 = """
                     open t8ap2@1
                     add depend type=require fmri=t8ap1
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (t8ap1_1, t8ap2_1))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (t8ap1_1, t8ap2_1))
+        self.image_create(self.rurl)
 
-                self.pkg("install t8ap2")
+        self.pkg("install t8ap2")
 
-                self.pkgsend_bulk(self.rurl, t8ap1_2)
+        self.pkgsend_bulk(self.rurl, t8ap1_2)
 
-                self.pkg("refresh")
-                self.pkg("update", exit=4) # does nothing
-                self.pkg("list  t8ap2@1")
+        self.pkg("refresh")
+        self.pkg("update", exit=4)  # does nothing
+        self.pkg("list  t8ap2@1")
 
-        def test_basic_13a(self):
-                """Publish an package with a dependency, then publish both as
-                obsolete, update, and see that both packages have gotten
-                removed."""
+    def test_basic_13a(self):
+        """Publish an package with a dependency, then publish both as
+        obsolete, update, and see that both packages have gotten
+        removed."""
 
-                t13ap1_1 = """
+        t13ap1_1 = """
                     open t13ap1@1
                     add depend type=require fmri=t13ap2
                     close
                 """
 
-                t13ap1_2 = """
+        t13ap1_2 = """
                     open t13ap1@2
                     add set name=pkg.obsolete value=true
                     close
                 """
 
-                t13ap2_1 = """
+        t13ap2_1 = """
                     open t13ap2@1
                     close
                 """
 
-                t13ap2_2 = """
+        t13ap2_2 = """
                     open t13ap2@2
                     add set name=pkg.obsolete value=true
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (t13ap1_1, t13ap2_1))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (t13ap1_1, t13ap2_1))
+        self.image_create(self.rurl)
 
-                self.pkg("install t13ap1")
+        self.pkg("install t13ap1")
 
-                self.pkgsend_bulk(self.rurl, (t13ap1_2, t13ap2_2))
+        self.pkgsend_bulk(self.rurl, (t13ap1_2, t13ap2_2))
 
-                self.pkg("refresh")
-                self.pkg("update")
-                self.pkg("list", exit=1)
+        self.pkg("refresh")
+        self.pkg("update")
+        self.pkg("list", exit=1)
 
-        def test_basic_11(self):
-                """Install or exact-install a package with an ambiguous name,
-                where only one match is non-obsolete."""
+    def test_basic_11(self):
+        """Install or exact-install a package with an ambiguous name,
+        where only one match is non-obsolete."""
 
-                self.basic_11_helper("install")
-                self.basic_11_helper("exact-install")
+        self.basic_11_helper("install")
+        self.basic_11_helper("exact-install")
 
-        def basic_11_helper(self, install_cmd):
-                t11p1 = """
+    def basic_11_helper(self, install_cmd):
+        t11p1 = """
                     open netbeans@1
                     add set name=pkg.obsolete value=true
                     close
                 """
 
-                t11p2 = """
+        t11p2 = """
                     open developer/netbeans@1
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (t11p1, t11p2))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (t11p1, t11p2))
+        self.image_create(self.rurl)
 
-                self.pkg("{0} netbeans".format(install_cmd))
-                self.pkg("list pkg:/developer/netbeans")
-                self.pkg("list pkg:/netbeans", exit=1)
+        self.pkg("{0} netbeans".format(install_cmd))
+        self.pkg("list pkg:/developer/netbeans")
+        self.pkg("list pkg:/netbeans", exit=1)
 
-        def test_basic_11a(self):
-                """Install or exact-install a package using an ambiguous name
-                where pkg is renamed to another package, but not the
-                conflicting one"""
+    def test_basic_11a(self):
+        """Install or exact-install a package using an ambiguous name
+        where pkg is renamed to another package, but not the
+        conflicting one"""
 
-                self.basic_11a_helper("install")
-                self.basic_11a_helper("exact-install")
+        self.basic_11a_helper("install")
+        self.basic_11a_helper("exact-install")
 
-        def basic_11a_helper(self, install_cmd):
-                t11p1 = """
+    def basic_11a_helper(self, install_cmd):
+        t11p1 = """
                     open netbonze@1
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=SUNWnetbonze
                     close
                 """
 
-                t11p2 = """
+        t11p2 = """
                     open developer/netbonze@1
                     close
                 """
 
-                t11p3 = """
+        t11p3 = """
                     open SUNWnetbonze@1
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (t11p1, t11p2, t11p3))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (t11p1, t11p2, t11p3))
+        self.image_create(self.rurl)
 
-                self.pkg("{0} netbonze".format(install_cmd), exit=1)
+        self.pkg("{0} netbonze".format(install_cmd), exit=1)
 
-        def test_basic_11b(self):
-                """Install or exact-install a package using an ambiguous name
-                where only one match is non-renamed, and the renamed match
-                is renamed to the other."""
+    def test_basic_11b(self):
+        """Install or exact-install a package using an ambiguous name
+        where only one match is non-renamed, and the renamed match
+        is renamed to the other."""
 
-                self.basic_11b_helper("install")
-                self.basic_11b_helper("exact-install")
+        self.basic_11b_helper("install")
+        self.basic_11b_helper("exact-install")
 
-        def basic_11b_helper(self, install_cmd):
-                t11p1 = """
+    def basic_11b_helper(self, install_cmd):
+        t11p1 = """
                     open netbooze@1
                     close
                 """
 
-                t11p2 = """
+        t11p2 = """
                     open netbooze@2
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=developer/netbooze
                     close
                 """
 
-                t11p3 = """
+        t11p3 = """
                     open developer/netbooze@2
                     close
                 """
 
-                t11p4 = """
+        t11p4 = """
                     open developer/netbooze@3
                     add depend type=require fmri=developer/missing
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (t11p1, t11p2, t11p3, t11p4))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (t11p1, t11p2, t11p3, t11p4))
+        self.image_create(self.rurl)
 
-                self.pkg("{0} netbooze".format(install_cmd))
-                self.pkg("list pkg:/developer/netbooze")
-                self.pkg("list pkg:/netbooze", exit=1)
+        self.pkg("{0} netbooze".format(install_cmd))
+        self.pkg("list pkg:/developer/netbooze")
+        self.pkg("list pkg:/netbooze", exit=1)
 
+    def test_basic_12(self):
+        """Upgrade a package across a rename to an ambiguous name."""
 
-        def test_basic_12(self):
-                """Upgrade a package across a rename to an ambiguous name."""
-
-                t12p1_1 = """
+        t12p1_1 = """
                     open netbeenz@1
                     close
                 """
 
-                t12p1_2 = """
+        t12p1_2 = """
                     open netbeenz@2
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=pkg:/developer/netbeenz
                     close
                 """
 
-                t12p2_1 = """
+        t12p2_1 = """
                     open developer/netbeenz@1
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, t12p1_1)
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, t12p1_1)
+        self.image_create(self.rurl)
 
-                self.pkg("install netbeenz")
+        self.pkg("install netbeenz")
 
-                self.pkgsend_bulk(self.rurl, (t12p1_2, t12p2_1))
+        self.pkgsend_bulk(self.rurl, (t12p1_2, t12p2_1))
 
-                self.pkg("refresh")
-                self.pkg("update -v")
-                self.pkg("list pkg:/developer/netbeenz | grep -- i--")
-                self.pkg("list pkg:/netbeenz", exit=1)
+        self.pkg("refresh")
+        self.pkg("update -v")
+        self.pkg("list pkg:/developer/netbeenz | grep -- i--")
+        self.pkg("list pkg:/netbeenz", exit=1)
 
-        def test_remove_renamed(self):
-                """If a renamed package has nothing depending on it, it should
-                be removed."""
+    def test_remove_renamed(self):
+        """If a renamed package has nothing depending on it, it should
+        be removed."""
 
-                p1_1 = """
+        p1_1 = """
                     open remrenA@1
                     close
                 """
 
-                p1_2 = """
+        p1_2 = """
                     open remrenA@2
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=pkg:/remrenB
                     close
                 """
 
-                p2_1 = """
+        p2_1 = """
                     open remrenB@1
                     close
                 """
 
-                p3_1 = """
+        p3_1 = """
                     open remrenC@1
                     add depend type=require fmri=pkg:/remrenA
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, p1_1)
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, p1_1)
+        self.image_create(self.rurl)
 
-                self.pkg("install remrenA")
+        self.pkg("install remrenA")
 
-                self.pkgsend_bulk(self.rurl, (p1_2, p2_1, p3_1))
+        self.pkgsend_bulk(self.rurl, (p1_2, p2_1, p3_1))
 
-                self.pkg("refresh")
-                self.pkg("update")
-                self.pkg("list remrenA", exit=1)
+        self.pkg("refresh")
+        self.pkg("update")
+        self.pkg("list remrenA", exit=1)
 
-                # But if there is something depending on the renamed package, it
-                # can't be removed.
-                self.pkg("uninstall remrenB")
+        # But if there is something depending on the renamed package, it
+        # can't be removed.
+        self.pkg("uninstall remrenB")
 
-                self.pkg("install remrenA@1 remrenC")
-                self.pkg("update")
-                self.pkg("list remrenA")
+        self.pkg("install remrenA@1 remrenC")
+        self.pkg("update")
+        self.pkg("list remrenA")
 
-        def test_chained_renames(self):
-                """If there are multiple renames, make sure we delete as much
-                as possible, but no more."""
+    def test_chained_renames(self):
+        """If there are multiple renames, make sure we delete as much
+        as possible, but no more."""
 
-                A1 = """
+        A1 = """
                     open chained_A@1
                     close
                 """
 
-                A2 = """
+        A2 = """
                     open chained_A@2
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=pkg:/chained_B@2
                     close
                 """
 
-                B2 = """
+        B2 = """
                     open chained_B@2
                     add set name=pkg.renamed value=true
                     add depend type=require fmri=pkg:/chained_C@2
                     close
                 """
 
-                C2 = """
+        C2 = """
                     open chained_C@2
                     close
                 """
 
-                X = """
+        X = """
                     open chained_X@1
                     add depend type=require fmri=pkg:/chained_A
                     close
                 """
 
-                Y = """
+        Y = """
                     open chained_Y@1
                     add depend type=require fmri=pkg:/chained_B
                     close
                 """
 
-                Z = """
+        Z = """
                     open chained_Z@1
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (A1, A2, B2, C2, X, Y, Z))
+        self.pkgsend_bulk(self.rurl, (A1, A2, B2, C2, X, Y, Z))
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                self.pkg("install chained_A@1 chained_X chained_Z")
-                for p in ["chained_A@1", "chained_X@1"]:
-                        self.pkg("list {0}".format(p))
-                self.pkg("update")
+        self.pkg("install chained_A@1 chained_X chained_Z")
+        for p in ["chained_A@1", "chained_X@1"]:
+            self.pkg("list {0}".format(p))
+        self.pkg("update")
 
-                for p in ["chained_A@2", "chained_X@1", "chained_B@2",
-                    "chained_C@2", "chained_Z"]:
-                        self.pkg("list {0}".format(p))
+        for p in [
+            "chained_A@2",
+            "chained_X@1",
+            "chained_B@2",
+            "chained_C@2",
+            "chained_Z",
+        ]:
+            self.pkg("list {0}".format(p))
 
-                self.pkg("uninstall chained_X")
+        self.pkg("uninstall chained_X")
 
-                for p in ["chained_C@2", "chained_Z"]:
-                        self.pkg("list {0}".format(p))
+        for p in ["chained_C@2", "chained_Z"]:
+            self.pkg("list {0}".format(p))
 
-                # make sure renamed pkgs no longer needed are uninstalled
-                for p in ["chained_A@2", "chained_B@2"]:
-                        self.pkg("list {0}".format(p), exit=1)
+        # make sure renamed pkgs no longer needed are uninstalled
+        for p in ["chained_A@2", "chained_B@2"]:
+            self.pkg("list {0}".format(p), exit=1)
 
-        def test_unobsoleted(self):
-                """Ensure that the existence of an obsolete package version
-                does not prevent the system from upgrading to or installing
-                a resurrected version."""
+    def test_unobsoleted(self):
+        """Ensure that the existence of an obsolete package version
+        does not prevent the system from upgrading to or installing
+        a resurrected version."""
 
-                self.unobsoleted_helper("install")
-                self.unobsoleted_helper("exact-install")
+        self.unobsoleted_helper("install")
+        self.unobsoleted_helper("exact-install")
 
-        def unobsoleted_helper(self, install_cmd):
-                pA_1 = """
+    def unobsoleted_helper(self, install_cmd):
+        pA_1 = """
                     open reintroA@1
                     close
                 """
 
-                pA_2 = """
+        pA_2 = """
                     open reintroA@2
                     add set name=pkg.obsolete value=true
                     close
                 """
 
-                pA_3 = """
+        pA_3 = """
                     open reintroA@3
                     close
                 """
 
-                pB_1 = """
+        pB_1 = """
                     open reintroB@1
                     add depend type=require fmri=pkg:/reintroA@1
                     close
                 """
 
-                pB_2 = """
+        pB_2 = """
                     open reintroB@2
                     close
                 """
 
-                pB_3 = """
+        pB_3 = """
                     open reintroB@3
                     add depend type=require fmri=pkg:/reintroA@3
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (pA_1, pA_2, pA_3, pB_1, pB_2,
-                    pB_3))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (pA_1, pA_2, pA_3, pB_1, pB_2, pB_3))
+        self.image_create(self.rurl)
 
-                # Check installation of an unobsoleted package with no
-                # dependencies.
+        # Check installation of an unobsoleted package with no
+        # dependencies.
 
-                # Testing reintroA@1 -> reintroA@3 with update
-                self.pkg("install reintroA@1")
-                self.pkg("refresh")
-                self.pkg("update")
-                self.pkg("list reintroA@3")
-                self.pkg("uninstall reintroA")
+        # Testing reintroA@1 -> reintroA@3 with update
+        self.pkg("install reintroA@1")
+        self.pkg("refresh")
+        self.pkg("update")
+        self.pkg("list reintroA@3")
+        self.pkg("uninstall reintroA")
 
-                # Testing reintroA@1 -> reintroA@3 with install or
-                # exact-install.
-                self.pkg("{0} reintroA@1".format(install_cmd))
-                self.pkg("{0} reintroA@3".format(install_cmd))
-                self.pkg("list reintroA@3")
-                self.pkg("uninstall reintroA")
+        # Testing reintroA@1 -> reintroA@3 with install or
+        # exact-install.
+        self.pkg("{0} reintroA@1".format(install_cmd))
+        self.pkg("{0} reintroA@3".format(install_cmd))
+        self.pkg("list reintroA@3")
+        self.pkg("uninstall reintroA")
 
-                # Testing empty image -> reintroA@3 with install or
-                # exact-install.
-                self.pkg("{0} reintroA@3".format(install_cmd))
-                self.pkg("list reintroA@3")
-                self.pkg("uninstall reintroA")
+        # Testing empty image -> reintroA@3 with install or
+        # exact-install.
+        self.pkg("{0} reintroA@3".format(install_cmd))
+        self.pkg("list reintroA@3")
+        self.pkg("uninstall reintroA")
 
-                # Testing reintroA@1 -> reintroA@2 -> reintroA@3 with install
-                # or exact-install.
-                self.pkg("{0} reintroA@1".format(install_cmd))
-                self.pkg("{0} reintroA@2".format(install_cmd))
-                self.pkg("{0} reintroA@3".format(install_cmd))
-                self.pkg("list reintroA@3")
-                self.pkg("uninstall reintroA")
+        # Testing reintroA@1 -> reintroA@2 -> reintroA@3 with install
+        # or exact-install.
+        self.pkg("{0} reintroA@1".format(install_cmd))
+        self.pkg("{0} reintroA@2".format(install_cmd))
+        self.pkg("{0} reintroA@3".format(install_cmd))
+        self.pkg("list reintroA@3")
+        self.pkg("uninstall reintroA")
 
-                # Check installation of a package with an unobsoleted
-                # dependency.
+        # Check installation of a package with an unobsoleted
+        # dependency.
 
-                # Testing reintroB@1 -> reintroB@3 with update
-                self.pkg("install reintroB@1")
-                self.pkg("refresh")
-                self.pkg("update")
-                self.pkg("list reintroB@3")
-                self.pkg("list reintroA@3")
-                self.pkg("uninstall reintroB reintroA")
+        # Testing reintroB@1 -> reintroB@3 with update
+        self.pkg("install reintroB@1")
+        self.pkg("refresh")
+        self.pkg("update")
+        self.pkg("list reintroB@3")
+        self.pkg("list reintroA@3")
+        self.pkg("uninstall reintroB reintroA")
 
-                # Testing reintroB@1 -> reintroB@3 with install or
-                # exact-install
-                self.pkg("{0} reintroB@1".format(install_cmd))
-                self.pkg("{0} reintroB@3".format(install_cmd))
-                self.pkg("list reintroB@3")
-                self.pkg("list reintroA@3")
-                self.pkg("uninstall reintroB reintroA")
+        # Testing reintroB@1 -> reintroB@3 with install or
+        # exact-install
+        self.pkg("{0} reintroB@1".format(install_cmd))
+        self.pkg("{0} reintroB@3".format(install_cmd))
+        self.pkg("list reintroB@3")
+        self.pkg("list reintroA@3")
+        self.pkg("uninstall reintroB reintroA")
 
-                # Testing empty image -> reintroB@3 with install or
-                # exact-install
-                self.pkg("{0} reintroB@3".format(install_cmd))
-                self.pkg("list reintroB@3")
-                self.pkg("list reintroA@3")
-                self.pkg("uninstall reintroB reintroA")
+        # Testing empty image -> reintroB@3 with install or
+        # exact-install
+        self.pkg("{0} reintroB@3".format(install_cmd))
+        self.pkg("list reintroB@3")
+        self.pkg("list reintroA@3")
+        self.pkg("uninstall reintroB reintroA")
 
-                # Testing reintroB@1 -> reintroB@2 -> reintroB@3 with install
-                # or exact-install
-                self.pkg("{0} reintroB@1".format(install_cmd))
-                self.pkg("{0} reintroB@2".format(install_cmd))
-                self.pkg("{0} reintroB@3".format(install_cmd))
-                self.pkg("list reintroB@3")
-                self.pkg("list reintroA@3")
-                self.pkg("uninstall reintroB reintroA")
+        # Testing reintroB@1 -> reintroB@2 -> reintroB@3 with install
+        # or exact-install
+        self.pkg("{0} reintroB@1".format(install_cmd))
+        self.pkg("{0} reintroB@2".format(install_cmd))
+        self.pkg("{0} reintroB@3".format(install_cmd))
+        self.pkg("list reintroB@3")
+        self.pkg("list reintroA@3")
+        self.pkg("uninstall reintroB reintroA")
 
-        def test_incorp_1(self):
-                """We should be able to incorporate an obsolete package."""
+    def test_incorp_1(self):
+        """We should be able to incorporate an obsolete package."""
 
-                self.incorp_1_helper("install")
-                self.incorp_1_helper("exact-install")
+        self.incorp_1_helper("install")
+        self.incorp_1_helper("exact-install")
 
-        def incorp_1_helper(self, install_cmd):
-                p1_1 = """
+    def incorp_1_helper(self, install_cmd):
+        p1_1 = """
                     open inc1p1@1
                     add depend type=incorporate fmri=inc1p2@1
                     close
                 """
 
-                p2_1 = """
+        p2_1 = """
                     open inc1p2@1
                     add set name=pkg.obsolete value=true
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (p1_1, p2_1))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (p1_1, p2_1))
+        self.image_create(self.rurl)
 
-                if install_cmd == "install":
-                        self.pkg("install inc1p1")
-                        self.pkg("install inc1p2", exit=4)
+        if install_cmd == "install":
+            self.pkg("install inc1p1")
+            self.pkg("install inc1p2", exit=4)
 
-                        self.pkg("list inc1p2", exit=1)
-                else:
-                        self.pkg("exact-install inc1p1")
+            self.pkg("list inc1p2", exit=1)
+        else:
+            self.pkg("exact-install inc1p1")
 
-        def test_incorp_2(self):
-                """We should be able to continue incorporating a package when it
-                becomes obsolete on upgrade."""
+    def test_incorp_2(self):
+        """We should be able to continue incorporating a package when it
+        becomes obsolete on upgrade."""
 
-                p1_1 = """
+        p1_1 = """
                     open inc2p1@1
                     add depend type=incorporate fmri=inc2p2@1
                     close
                 """
 
-                p1_2 = """
+        p1_2 = """
                     open inc2p1@2
                     add depend type=incorporate fmri=inc2p2@2
                     close
                 """
 
-                p2_1 = """
+        p2_1 = """
                     open inc2p2@1
                     close
                 """
 
-                p2_2 = """
+        p2_2 = """
                     open inc2p2@2
                     add set name=pkg.obsolete value=true
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl, (p1_1, p2_1))
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, (p1_1, p2_1))
+        self.image_create(self.rurl)
 
-                self.pkg("install inc2p1 inc2p2")
+        self.pkg("install inc2p1 inc2p2")
 
-                self.pkgsend_bulk(self.rurl, (p1_2, p2_2))
+        self.pkgsend_bulk(self.rurl, (p1_2, p2_2))
 
-                self.pkg("refresh")
-                self.pkg("list -afv")
-                self.pkg("update -v")
-                self.pkg("list inc2p2", exit=1)
+        self.pkg("refresh")
+        self.pkg("list -afv")
+        self.pkg("update -v")
+        self.pkg("list inc2p2", exit=1)
 
 
 class TestObsoletionNestedIncorporations(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
+    # Only start/stop the depot once (instead of for every test)
 
-        persistent_setup = True
+    persistent_setup = True
 
-        bug_15713570 = """
+    bug_15713570 = """
             open oldcompiler@1.0,5.11-0
             add depend type=require fmri=oldperl@1.0
             close
@@ -9711,32 +9980,32 @@ class TestObsoletionNestedIncorporations(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        def test_15713570(self):
-                """If an unincorporated package has its dependency obsoleted
-                by a doubly nested incorporation with multiple levels of
-                incorporation, there is no useful error message generated"""
+    def test_15713570(self):
+        """If an unincorporated package has its dependency obsoleted
+        by a doubly nested incorporation with multiple levels of
+        incorporation, there is no useful error message generated"""
 
-                self.pkgsend_bulk(self.rurl, self.bug_15713570)
-                self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, self.bug_15713570)
+        self.image_create(self.rurl)
 
-                self.pkg("install -v entire@1.0 oldcompiler")
-                self.pkg("list")
-                self.pkg("verify")
-                self.pkg("update -v entire", exit=4)
-                self.pkg("list")
-                self.pkg("verify")
-                self.pkg("update -v entire@2", exit=1)
+        self.pkg("install -v entire@1.0 oldcompiler")
+        self.pkg("list")
+        self.pkg("verify")
+        self.pkg("update -v entire", exit=4)
+        self.pkg("list")
+        self.pkg("verify")
+        self.pkg("update -v entire@2", exit=1)
 
-                self.assertTrue("oldcompiler" in self.errout and
-                    "oldperl" in self.errout,
-                    "error message does not mention oldcompiler and oldperl packages")
+        self.assertTrue(
+            "oldcompiler" in self.errout and "oldperl" in self.errout,
+            "error message does not mention oldcompiler and oldperl packages",
+        )
 
 
 class TestNotInstalledIncorp(pkg5unittest.SingleDepotTestCase):
+    persistent_setup = True
 
-        persistent_setup = True
-
-        bug_31762523 = """
+    bug_31762523 = """
             open topinc@1.0.0
             add depend type=incorporate fmri=osnet-inc@1.0.0
             add depend type=require fmri=osnet-inc
@@ -9773,112 +10042,114 @@ class TestNotInstalledIncorp(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
 
-        def test_31762523(self):
-            """ Test to ensure that an uninstalled incorporation is not considered
-                as part of the packaging solution. """
-            self.pkgsend_bulk(self.rurl, self.bug_31762523)
-            self.image_create(self.rurl)
+    def test_31762523(self):
+        """Test to ensure that an uninstalled incorporation is not considered
+        as part of the packaging solution."""
+        self.pkgsend_bulk(self.rurl, self.bug_31762523)
+        self.image_create(self.rurl)
 
-            # Install the base packages and then the basepkg
-            self.pkg("install topinc@1.0.0 osnet-inc@1.0.0 test-os basepkg@1.1.0")
+        # Install the base packages and then the basepkg
+        self.pkg("install topinc@1.0.0 osnet-inc@1.0.0 test-os basepkg@1.1.0")
 
-            # Verify the installed packages can be updated
-            # without involving the not-installed incorporation (testinc)
-            self.pkg("update -nv topinc@1.0.1")
+        # Verify the installed packages can be updated
+        # without involving the not-installed incorporation (testinc)
+        self.pkg("update -nv topinc@1.0.1")
 
-            # This will cause the basepkg to be downgraded
-            self.pkg("install -v topinc@1.0.1 testinc")
-            self.pkg("list basepkg@1.0.1")
+        # This will cause the basepkg to be downgraded
+        self.pkg("install -v topinc@1.0.1 testinc")
+        self.pkg("list basepkg@1.0.1")
 
 
 class TestPkgInstallMultiObsolete(pkg5unittest.ManyDepotTestCase):
-        """Tests involving obsolete packages and multiple publishers."""
+    """Tests involving obsolete packages and multiple publishers."""
 
-        obs = """
+    obs = """
             open stem@1
             add set name=pkg.obsolete value=true
             close
         """
 
-        nonobs = """
+    nonobs = """
             open stem@1
             close
         """
 
-        persistent_setup = True
+    persistent_setup = True
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
 
-        def test_01(self):
-                """If an obsolete package is found in a preferred publisher and
-                a non-obsolete package of the same name is found in a
-                non-preferred publisher, pick the preferred pub as usual """
+    def test_01(self):
+        """If an obsolete package is found in a preferred publisher and
+        a non-obsolete package of the same name is found in a
+        non-preferred publisher, pick the preferred pub as usual"""
 
-                self.helper_01("install")
-                self.helper_01("exact-install")
+        self.helper_01("install")
+        self.helper_01("exact-install")
 
-        def helper_01(self, install_cmd):
-                self.pkgsend_bulk(self.rurl1, self.obs)
-                self.pkgsend_bulk(self.rurl2, self.nonobs)
+    def helper_01(self, install_cmd):
+        self.pkgsend_bulk(self.rurl1, self.obs)
+        self.pkgsend_bulk(self.rurl2, self.nonobs)
 
-                self.image_create(self.rurl1, prefix="test1")
-                self.pkg("set-publisher -O " + self.rurl2 + " test2")
-                self.pkg("list -a")
+        self.image_create(self.rurl1, prefix="test1")
+        self.pkg("set-publisher -O " + self.rurl2 + " test2")
+        self.pkg("list -a")
 
-                self.pkg("{0} stem".format(install_cmd), exit=4) # noting to do since it's obs
-                # We should choose the obsolete package, which means nothing
-                # gets installed.
-                self.pkg("list", exit=1)
+        self.pkg(
+            "{0} stem".format(install_cmd), exit=4
+        )  # noting to do since it's obs
+        # We should choose the obsolete package, which means nothing
+        # gets installed.
+        self.pkg("list", exit=1)
 
-        def test_02(self):
-                """Same as test_01, but now we have ambiguity in the package
-                names.  While at first blush we might follow the same rule as in
-                test_01 (choose the preferred publisher), in this case, we can't
-                figure out which package from the preferred publisher we want,
-                so the choice already isn't as straightforward, so we choose the
-                non-obsolete package."""
+    def test_02(self):
+        """Same as test_01, but now we have ambiguity in the package
+        names.  While at first blush we might follow the same rule as in
+        test_01 (choose the preferred publisher), in this case, we can't
+        figure out which package from the preferred publisher we want,
+        so the choice already isn't as straightforward, so we choose the
+        non-obsolete package."""
 
-                self.helper_02("install")
-                self.helper_02("exact-install")
+        self.helper_02("install")
+        self.helper_02("exact-install")
 
-        def helper_02(self, install_cmd):
-                lobs = """
+    def helper_02(self, install_cmd):
+        lobs = """
                     open some/stem@1
                     add set name=pkg.obsolete value=true
                     close
                 """
 
-                self.pkgsend_bulk(self.rurl1, (self.obs, lobs))
-                self.pkgsend_bulk(self.rurl2, (self.nonobs, lobs))
+        self.pkgsend_bulk(self.rurl1, (self.obs, lobs))
+        self.pkgsend_bulk(self.rurl2, (self.nonobs, lobs))
 
-                self.image_create(self.rurl1, prefix="test1")
-                self.pkg("set-publisher -O " + self.rurl2 + " test2")
+        self.image_create(self.rurl1, prefix="test1")
+        self.pkg("set-publisher -O " + self.rurl2 + " test2")
 
-                self.pkg("{0} stem".format(install_cmd), exit=1)
+        self.pkg("{0} stem".format(install_cmd), exit=1)
 
 
 class TestPkgInstallMultiIncorp(pkg5unittest.ManyDepotTestCase):
-        """Tests involving incorporations and multiple publishers."""
+    """Tests involving incorporations and multiple publishers."""
 
-        incorporated_latest = """
+    incorporated_latest = """
             open vim@7.4.233-5.12.0.0.0.44.1
             close
             open vim@7.4.232-5.12.0.0.0.44.1
             close"""
 
-        incorporated = """
+    incorporated = """
             open vim@7.4.1-5.12.0.0.0.45.0
             close
             open vim@7.4.1-5.12.0.0.0.44.1
             close """
 
-        incorporates = """
+    incorporates = """
             open userland-incorporation@0.5.12-5.12.0.0.0.44.1
             add depend type=incorporate fmri=vim@7.4-5.12.0.0.0.44.1
             close
@@ -9886,78 +10157,79 @@ class TestPkgInstallMultiIncorp(pkg5unittest.ManyDepotTestCase):
             add depend type=incorporate fmri=vim@7.4.1-5.12.0.0.0.44.1
             close"""
 
-        persistent_setup = True
+    persistent_setup = True
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
 
-        def test_1_incorp_latest_older(self):
-                """Ensure that if the newest release version of a package is
-                available for an older branch that incorporate dependencies work
-                as expected."""
+    def test_1_incorp_latest_older(self):
+        """Ensure that if the newest release version of a package is
+        available for an older branch that incorporate dependencies work
+        as expected."""
 
-                self.image_create(self.rurl1)
-                self.pkgsend_bulk(self.rurl1, (self.incorporates,
-                    self.incorporated, self.incorporated_latest))
+        self.image_create(self.rurl1)
+        self.pkgsend_bulk(
+            self.rurl1,
+            (self.incorporates, self.incorporated, self.incorporated_latest),
+        )
 
-                # First, install two incorporations that intersect such that
-                # only the version before the latest branch can be installed.
-                self.pkg("install userland-incorporation vim-incorporation")
+        # First, install two incorporations that intersect such that
+        # only the version before the latest branch can be installed.
+        self.pkg("install userland-incorporation vim-incorporation")
 
-                # Then, attempt to install vim; this should succeed even though
-                # the newest version available is for an older branch.
-                self.pkg("install vim@7.4")
+        # Then, attempt to install vim; this should succeed even though
+        # the newest version available is for an older branch.
+        self.pkg("install vim@7.4")
 
-        def test_2_incorp_multi_pub(self):
-                """Ensure that if another publisher offers newer packages that
-                satisfy an incorporate dependency, but are rejected because of
-                publisher selection, that the preferred publisher's package can
-                still satisfy the incorporate."""
+    def test_2_incorp_multi_pub(self):
+        """Ensure that if another publisher offers newer packages that
+        satisfy an incorporate dependency, but are rejected because of
+        publisher selection, that the preferred publisher's package can
+        still satisfy the incorporate."""
 
-                self.image_create(self.rurl1)
-                self.pkgsend_bulk(self.rurl1, (self.incorporates,
-                    self.incorporated))
-                self.pkgsend_bulk(self.rurl2, self.incorporated_latest)
+        self.image_create(self.rurl1)
+        self.pkgsend_bulk(self.rurl1, (self.incorporates, self.incorporated))
+        self.pkgsend_bulk(self.rurl2, self.incorporated_latest)
 
-                # First, install the incorporation.
-                self.pkg("install userland-incorporation")
+        # First, install the incorporation.
+        self.pkg("install userland-incorporation")
 
-                # Next, add the second publisher.
-                self.pkg("set-publisher -p {0}".format(self.rurl2))
+        # Next, add the second publisher.
+        self.pkg("set-publisher -p {0}".format(self.rurl2))
 
-                # Next, verify that first publisher's incorporated package can
-                # be installed since it satisfies incorporate dependencies even
-                # though second publisher's versions will be rejected.
-                self.pkg("install //test1/vim")
+        # Next, verify that first publisher's incorporated package can
+        # be installed since it satisfies incorporate dependencies even
+        # though second publisher's versions will be rejected.
+        self.pkg("install //test1/vim")
 
 
 class TestPkgInstallLicense(pkg5unittest.SingleDepotTestCase):
-        """Tests involving one or more packages that require license acceptance
-        or display."""
+    """Tests involving one or more packages that require license acceptance
+    or display."""
 
-        maxDiff = None
-        persistent_depot = True
+    maxDiff = None
+    persistent_depot = True
 
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             add license copyright.baz license=copyright.baz
             close """
 
-        # First iteration has just a copyright.
-        licensed10 = """
+    # First iteration has just a copyright.
+    licensed10 = """
             open licensed@1.0,5.11-0
             add depend type=require fmri=baz@1.0
             add license copyright.licensed license=copyright.licensed
             close """
 
-        # Second iteration has copyright that must-display and a new license
-        # that doesn't require acceptance.
-        licensed12 = """
+    # Second iteration has copyright that must-display and a new license
+    # that doesn't require acceptance.
+    licensed12 = """
             open licensed@1.2,5.11-0
             add depend type=require fmri=baz@1.0
             add file libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
@@ -9965,8 +10237,8 @@ class TestPkgInstallLicense(pkg5unittest.SingleDepotTestCase):
             add license license.licensed license=license.licensed
             close """
 
-        # Third iteration now requires acceptance of license.
-        licensed13 = """
+    # Third iteration now requires acceptance of license.
+    licensed13 = """
             open licensed@1.3,5.11-0
             add depend type=require fmri=baz@1.0
             add file libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
@@ -9974,464 +10246,535 @@ class TestPkgInstallLicense(pkg5unittest.SingleDepotTestCase):
             add license license.licensed license=license.licensed must-accept=True
             close """
 
-        misc_files = ["copyright.baz", "copyright.licensed", "libc.so.1",
-            "license.licensed", "license.licensed.addendum"]
+    misc_files = [
+        "copyright.baz",
+        "copyright.licensed",
+        "libc.so.1",
+        "license.licensed",
+        "license.licensed.addendum",
+    ]
 
-        # Packages with copyright in non-ascii character
-        nonascii10 = """
+    # Packages with copyright in non-ascii character
+    nonascii10 = """
             open nonascii@1.0,5.11-0
             add license 88591enc.copyright license=88591enc.copyright
             close """
 
-        # Packages with copyright in non-ascii character
-        utf8enc10 = """
+    # Packages with copyright in non-ascii character
+    utf8enc10 = """
             open utf8enc@1.0,5.11-0
             add license utf8enc.copyright license=utf8enc.copyright
             close """
 
-        # Packages with copyright in unsupported character set
-        unsupported10 = """
+    # Packages with copyright in unsupported character set
+    unsupported10 = """
             open unsupported@1.0,5.11-0
             add license unsupported.copyright license=unsupported.copyright
             close """
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self, publisher="bobcat")
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self, publisher="bobcat")
+        self.make_misc_files(self.misc_files)
 
-                # Use license with latin1 i.e 88591 encoding
-                n_copyright = os.path.join(self.ro_data_root,
-                                           "88591enc.copyright")
-                self.make_misc_files({"88591enc.copyright": n_copyright},
-                                     copy=True)
+        # Use license with latin1 i.e 88591 encoding
+        n_copyright = os.path.join(self.ro_data_root, "88591enc.copyright")
+        self.make_misc_files({"88591enc.copyright": n_copyright}, copy=True)
 
-                # Use utf-8 encoding license
-                utf_copyright = os.path.join(self.ro_data_root,
-                                             "utf8enc.copyright")
-                self.make_misc_files({"utf8enc.copyright": utf_copyright},
-                                     copy=True)
+        # Use utf-8 encoding license
+        utf_copyright = os.path.join(self.ro_data_root, "utf8enc.copyright")
+        self.make_misc_files({"utf8enc.copyright": utf_copyright}, copy=True)
 
-                # Use unsupported license
-                u_copyright = os.path.join(self.ro_data_root,
-                                           "unsupported.copyright")
-                self.make_misc_files({"unsupported.copyright": u_copyright},
-                                     copy=True)
+        # Use unsupported license
+        u_copyright = os.path.join(self.ro_data_root, "unsupported.copyright")
+        self.make_misc_files({"unsupported.copyright": u_copyright}, copy=True)
 
-                self.plist = self.pkgsend_bulk(self.rurl, (self.licensed10,
-                    self.licensed12, self.licensed13, self.baz10,
-                    self.nonascii10, self.utf8enc10, self.unsupported10))
+        self.plist = self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.licensed10,
+                self.licensed12,
+                self.licensed13,
+                self.baz10,
+                self.nonascii10,
+                self.utf8enc10,
+                self.unsupported10,
+            ),
+        )
 
+    def test_01_install_update(self):
+        """Verifies that install and update handle license
+        acceptance and display."""
 
-        def test_01_install_update(self):
-                """Verifies that install and update handle license
-                acceptance and display."""
+        self.image_create(self.rurl, prefix="bobcat")
 
-                self.image_create(self.rurl, prefix="bobcat")
+        # First, test the basic install case to see if a license that
+        # does not require viewing or acceptance will be installed.
+        self.pkg("install --parsable=0 licensed@1.0")
+        self.assertEqualParsable(
+            self.output,
+            add_packages=[self.plist[3], self.plist[0]],
+            licenses=[
+                [
+                    self.plist[3],
+                    [],
+                    [
+                        self.plist[3],
+                        "copyright.baz",
+                        "copyright.baz",
+                        False,
+                        False,
+                    ],
+                ],
+                [
+                    self.plist[0],
+                    [],
+                    [
+                        self.plist[0],
+                        "copyright.licensed",
+                        "copyright.licensed",
+                        False,
+                        False,
+                    ],
+                ],
+            ],
+        )
+        self.pkg("list")
+        self.pkg("info licensed@1.0 baz@1.0")
 
-                # First, test the basic install case to see if a license that
-                # does not require viewing or acceptance will be installed.
-                self.pkg("install --parsable=0 licensed@1.0")
-                self.assertEqualParsable(self.output,
-                    add_packages=[self.plist[3], self.plist[0]], licenses=[
-                        [self.plist[3], [],
-                            [self.plist[3], "copyright.baz", "copyright.baz",
-                            False, False]],
-                        [self.plist[0], [],
-                            [self.plist[0], "copyright.licensed",
-                            "copyright.licensed", False, False]
-                        ]])
-                self.pkg("list")
-                self.pkg("info licensed@1.0 baz@1.0")
+        # Verify that --licenses include the license in output.
+        self.pkg(
+            "install -n --licenses licensed@1.2 | " "grep 'license.licensed'"
+        )
 
-                # Verify that --licenses include the license in output.
-                self.pkg("install -n --licenses licensed@1.2 | "
-                    "grep 'license.licensed'")
+        # Verify that licenses that require display are included in
+        # -n output even if --licenses is not provided.
+        self.pkg("install -n licensed@1.2 | grep 'copyright.licensed'")
 
-                # Verify that licenses that require display are included in
-                # -n output even if --licenses is not provided.
-                self.pkg("install -n licensed@1.2 | grep 'copyright.licensed'")
+        # Next, check that an upgrade succeeds when a license requires
+        # display and that the license will be displayed.
+        self.pkg("install --parsable=0 licensed@1.2")
+        self.assertEqualParsable(
+            self.output,
+            change_packages=[[self.plist[0], self.plist[1]]],
+            licenses=[
+                [
+                    self.plist[1],
+                    [],
+                    [
+                        self.plist[1],
+                        "license.licensed",
+                        "license.licensed",
+                        False,
+                        False,
+                    ],
+                ],
+                [
+                    self.plist[1],
+                    [
+                        self.plist[0],
+                        "copyright.licensed",
+                        "copyright.licensed",
+                        False,
+                        False,
+                    ],
+                    [
+                        self.plist[1],
+                        "copyright.licensed",
+                        "copyright.licensed",
+                        False,
+                        True,
+                    ],
+                ],
+            ],
+        )
 
-                # Next, check that an upgrade succeeds when a license requires
-                # display and that the license will be displayed.
-                self.pkg("install --parsable=0 licensed@1.2")
-                self.assertEqualParsable(self.output,
-                    change_packages=[[self.plist[0], self.plist[1]]], licenses=[
-                        [self.plist[1],
-                            [],
-                            [self.plist[1], "license.licensed",
-                            "license.licensed", False, False]],
-                        [self.plist[1],
-                            [self.plist[0], "copyright.licensed",
-                            "copyright.licensed", False, False],
-                            [self.plist[1], "copyright.licensed",
-                            "copyright.licensed", False, True]]])
+        # Next, check that an update fails if the user has not
+        # specified --accept and a license requires acceptance.
+        self.pkg("update -v", exit=6)
+        # Check that asking for parsable output doesn't change this
+        # requirement.
+        self.pkg("update --parsable=0", exit=6)
 
-                # Next, check that an update fails if the user has not
-                # specified --accept and a license requires acceptance.
-                self.pkg("update -v", exit=6)
-                # Check that asking for parsable output doesn't change this
-                # requirement.
-                self.pkg("update --parsable=0", exit=6)
+        # Verify that licenses are not included in -n output if
+        # --licenses is not provided.
+        self.pkg("update -n | grep 'copyright.licensed", exit=1)
 
-                # Verify that licenses are not included in -n output if
-                # --licenses is not provided.
-                self.pkg("update -n | grep 'copyright.licensed", exit=1)
+        # Verify that --licenses include the license in output.
+        self.pkg("update -n --licenses | " "grep 'license.licensed'")
 
-                # Verify that --licenses include the license in output.
-                self.pkg("update -n --licenses | "
-                    "grep 'license.licensed'")
+        # Next, check that an update succeeds if the user has
+        # specified --accept and a license requires acceptance.
+        self.pkg("update --parsable=0 --accept")
+        self.assertEqualParsable(
+            self.output,
+            change_packages=[[self.plist[1], self.plist[2]]],
+            licenses=[
+                [
+                    self.plist[2],
+                    [
+                        self.plist[1],
+                        "license.licensed",
+                        "license.licensed",
+                        False,
+                        False,
+                    ],
+                    [
+                        self.plist[2],
+                        "license.licensed",
+                        "license.licensed",
+                        True,
+                        False,
+                    ],
+                ]
+            ],
+        )
+        self.pkg("info licensed@1.3")
 
-                # Next, check that an update succeeds if the user has
-                # specified --accept and a license requires acceptance.
-                self.pkg("update --parsable=0 --accept")
-                self.assertEqualParsable(self.output,
-                    change_packages=[[self.plist[1], self.plist[2]]], licenses=[
-                        [self.plist[2],
-                            [self.plist[1], "license.licensed",
-                            "license.licensed", False, False],
-                            [self.plist[2], "license.licensed",
-                            "license.licensed", True, False]]])
-                self.pkg("info licensed@1.3")
+    def test_02_bug_7127117_C(self):
+        """Verifies that install with --parsable handles licenses
+        with non-ascii & non UTF locale"""
 
-        def test_02_bug_7127117_C(self):
-                """Verifies that install with --parsable handles licenses
-                with non-ascii & non UTF locale"""
+        os.environ["LC_ALL"] = "C"
+        self.image_create(self.rurl, prefix="bobcat")
+        self.pkg("install --parsable=0 utf8enc@1.0")
+        self.pkg("install --parsable=0 nonascii@1.0")
+        self.pkg("install --parsable=0 unsupported@1.0")
+        self.image_destroy()
 
-                os.environ["LC_ALL"] = "C"
-                self.image_create(self.rurl, prefix="bobcat")
-                self.pkg("install --parsable=0 utf8enc@1.0")
-                self.pkg("install --parsable=0 nonascii@1.0")
-                self.pkg("install --parsable=0 unsupported@1.0")
-                self.image_destroy()
+    def test_02_bug_7127117_ISO8859(self):
+        """Verifies that install with --parsable handles licenses
+        with non-ascii & non UTF locale"""
 
-        def test_02_bug_7127117_ISO8859(self):
-                """Verifies that install with --parsable handles licenses
-                with non-ascii & non UTF locale"""
+        os.environ["LC_ALL"] = "en_US.ISO8859-1"
+        self.image_create(self.rurl, prefix="bobcat")
+        self.pkg("install --parsable=0 utf8enc@1.0")
+        self.pkg("install --parsable=0 nonascii@1.0")
+        self.pkg("install --parsable=0 unsupported@1.0")
+        self.image_destroy()
 
-                os.environ["LC_ALL"] = "en_US.ISO8859-1"
-                self.image_create(self.rurl, prefix="bobcat")
-                self.pkg("install --parsable=0 utf8enc@1.0")
-                self.pkg("install --parsable=0 nonascii@1.0")
-                self.pkg("install --parsable=0 unsupported@1.0")
-                self.image_destroy()
+    def test_02_bug_7127117_UTF8(self):
+        """Verifies that install with --parsable handles licenses
+        with non-ascii & non UTF locale"""
 
-        def test_02_bug_7127117_UTF8(self):
-                """Verifies that install with --parsable handles licenses
-                with non-ascii & non UTF locale"""
-
-                os.environ["LC_ALL"] = "en_US.UTF-8"
-                self.image_create(self.rurl, prefix="bobcat")
-                self.pkg("install --parsable=0 utf8enc@1.0")
-                self.pkg("install --parsable=0 nonascii@1.0")
-                self.pkg("install --parsable=0 unsupported@1.0")
-                self.image_destroy()
+        os.environ["LC_ALL"] = "en_US.UTF-8"
+        self.image_create(self.rurl, prefix="bobcat")
+        self.pkg("install --parsable=0 utf8enc@1.0")
+        self.pkg("install --parsable=0 nonascii@1.0")
+        self.pkg("install --parsable=0 unsupported@1.0")
+        self.image_destroy()
 
 
 class TestActionErrors(pkg5unittest.SingleDepotTestCase):
-        """This set of tests is intended to verify that the client will handle
-        image state and action errors gracefully during install or uninstall
-        operations.  Unlike the client API version of these tests, the CLI only
-        needs to be tested for failure cases since it uses the client API."""
+    """This set of tests is intended to verify that the client will handle
+    image state and action errors gracefully during install or uninstall
+    operations.  Unlike the client API version of these tests, the CLI only
+    needs to be tested for failure cases since it uses the client API."""
 
-        # Teardown the test root every time.
-        persistent_setup = False
+    # Teardown the test root every time.
+    persistent_setup = False
 
-        dir10 = """
+    dir10 = """
             open dir@1.0,5.11-0
             add dir path=dir mode=755 owner=root group=bin
             close """
 
-        dir11 = """
+    dir11 = """
             open dir@1.1,5.11-0
             add dir path=dir mode=750 owner=root group=bin
             close """
 
-        # Purposefully omits depend on dir@1.0.
-        filesub10 = """
+    # Purposefully omits depend on dir@1.0.
+    filesub10 = """
             open filesub@1.0,5.11-0
             add file tmp/file path=dir/file mode=755 owner=root group=bin
             close """
 
-        filesub11 = """
+    filesub11 = """
             open filesub@1.1,5.11-0
             add file tmp/file path=dir/file mode=444 owner=root group=bin
             close """
 
-        # Dependency providing file intentionally omitted.
-        hardlink10 = """
+    # Dependency providing file intentionally omitted.
+    hardlink10 = """
             open hardlink@1.0,5.11-0
             add hardlink path=hardlink target=file
             close """
 
-        # Empty packages suitable for corruption testing.
-        foo10 = """
+    # Empty packages suitable for corruption testing.
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        unsupp10 = """
+    unsupp10 = """
             open unsupported@1.0
             add depend type=require fmri=foo@1.0
             close """
 
-        misc_files = ["tmp/file"]
+    misc_files = ["tmp/file"]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-                plist = self.pkgsend_bulk(self.rurl, (self.dir10, self.dir11,
-                    self.filesub10, self.filesub11, self.hardlink10))
+        plist = self.pkgsend_bulk(
+            self.rurl,
+            (
+                self.dir10,
+                self.dir11,
+                self.filesub10,
+                self.filesub11,
+                self.hardlink10,
+            ),
+        )
 
-                self.plist = {}
-                for p in plist:
-                        pfmri = fmri.PkgFmri(p)
-                        self.plist[pfmri.pkg_name] = pfmri
+        self.plist = {}
+        for p in plist:
+            pfmri = fmri.PkgFmri(p)
+            self.plist[pfmri.pkg_name] = pfmri
 
-        @staticmethod
-        def __write_empty_file(target, mode=644, owner="root", group="bin"):
-                f = open(target, "w")
-                f.write("\n")
-                f.close()
-                os.chmod(target, mode)
-                owner = portable.get_user_by_name(owner, "/", True)
-                group = portable.get_group_by_name(group, "/", True)
-                os.chown(target, owner, group)
+    @staticmethod
+    def __write_empty_file(target, mode=644, owner="root", group="bin"):
+        f = open(target, "w")
+        f.write("\n")
+        f.close()
+        os.chmod(target, mode)
+        owner = portable.get_user_by_name(owner, "/", True)
+        group = portable.get_group_by_name(group, "/", True)
+        os.chown(target, owner, group)
 
-        def test_00_directory(self):
-                """Verify that directory install fails as expected when it has
-                been replaced with a link prior to install."""
+    def test_00_directory(self):
+        """Verify that directory install fails as expected when it has
+        been replaced with a link prior to install."""
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                # The dest_dir's installed path.
-                dest_dir_name = "dir"
-                dest_dir = os.path.join(self.get_img_path(), dest_dir_name)
+        # The dest_dir's installed path.
+        dest_dir_name = "dir"
+        dest_dir = os.path.join(self.get_img_path(), dest_dir_name)
 
-                # Directory replaced with a link (fails for install).
-                self.__write_empty_file(dest_dir + ".src")
-                os.symlink(dest_dir + ".src", dest_dir)
-                self.pkg("install {0}".format(dest_dir_name), exit=1)
+        # Directory replaced with a link (fails for install).
+        self.__write_empty_file(dest_dir + ".src")
+        os.symlink(dest_dir + ".src", dest_dir)
+        self.pkg("install {0}".format(dest_dir_name), exit=1)
 
-        def test_01_file(self):
-                """Verify that file install works as expected when its parent
-                directory has been replaced with a link."""
+    def test_01_file(self):
+        """Verify that file install works as expected when its parent
+        directory has been replaced with a link."""
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                # File's parent directory replaced with a link.
-                self.pkg("install dir")
-                src = os.path.join(self.get_img_path(), "dir")
-                os.mkdir(os.path.join(self.get_img_path(), "export"))
-                new_src = os.path.join(os.path.dirname(src), "export", "dir")
-                shutil.move(src, os.path.dirname(new_src))
-                os.symlink(new_src, src)
-                self.pkg("install filesub@1.0", exit=1)
+        # File's parent directory replaced with a link.
+        self.pkg("install dir")
+        src = os.path.join(self.get_img_path(), "dir")
+        os.mkdir(os.path.join(self.get_img_path(), "export"))
+        new_src = os.path.join(os.path.dirname(src), "export", "dir")
+        shutil.move(src, os.path.dirname(new_src))
+        os.symlink(new_src, src)
+        self.pkg("install filesub@1.0", exit=1)
 
-        def test_02_hardlink(self):
-                """Verify that hardlink install fails as expected when
-                hardlink target is missing."""
+    def test_02_hardlink(self):
+        """Verify that hardlink install fails as expected when
+        hardlink target is missing."""
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                # Hard link target is missing (failure expected).
-                self.pkg("install hardlink", exit=1)
+        # Hard link target is missing (failure expected).
+        self.pkg("install hardlink", exit=1)
 
-        def __populate_repo(self, unsupp_content=None):
-                # Publish a package and then add some unsupported action data
-                # to the repository's copy of the manifest and catalog.
-                sfmri = self.pkgsend_bulk(self.rurl, self.unsupp10)[0]
+    def __populate_repo(self, unsupp_content=None):
+        # Publish a package and then add some unsupported action data
+        # to the repository's copy of the manifest and catalog.
+        sfmri = self.pkgsend_bulk(self.rurl, self.unsupp10)[0]
 
-                if unsupp_content is None:
-                        # No manipulation required.
-                        return
+        if unsupp_content is None:
+            # No manipulation required.
+            return
 
-                pfmri = fmri.PkgFmri(sfmri)
-                repo = self.get_repo(self.dcs[1].get_repodir())
-                mpath = repo.manifest(pfmri)
-                with open(mpath, "a+") as mfile:
-                        mfile.write(unsupp_content + "\n")
+        pfmri = fmri.PkgFmri(sfmri)
+        repo = self.get_repo(self.dcs[1].get_repodir())
+        mpath = repo.manifest(pfmri)
+        with open(mpath, "a+") as mfile:
+            mfile.write(unsupp_content + "\n")
 
-                mcontent = None
-                with open(mpath, "r") as mfile:
-                        mcontent = mfile.read()
+        mcontent = None
+        with open(mpath, "r") as mfile:
+            mcontent = mfile.read()
 
-                cat = repo.get_catalog("test")
-                cat.log_updates = False
+        cat = repo.get_catalog("test")
+        cat.log_updates = False
 
-                # Update the catalog signature.
-                entry = cat.get_entry(pfmri)
-                entry["signature-sha-1"] = manifest.Manifest.hash_create(
-                    mcontent)
+        # Update the catalog signature.
+        entry = cat.get_entry(pfmri)
+        entry["signature-sha-1"] = manifest.Manifest.hash_create(mcontent)
 
-                # Update the catalog actions.
-                dpart = cat.get_part("catalog.dependency.C", must_exist=True)
-                entry = dpart.get_entry(pfmri)
-                entry["actions"].append(unsupp_content)
+        # Update the catalog actions.
+        dpart = cat.get_part("catalog.dependency.C", must_exist=True)
+        entry = dpart.get_entry(pfmri)
+        entry["actions"].append(unsupp_content)
 
-                # Write out the new catalog.
-                cat.save()
+        # Write out the new catalog.
+        cat.save()
 
-        def test_03_unsupported(self):
-                """Verify that packages with invalid or unsupported actions are
-                handled gracefully.
-                """
+    def test_03_unsupported(self):
+        """Verify that packages with invalid or unsupported actions are
+        handled gracefully.
+        """
 
-                # Base package needed for tests.
-                self.pkgsend_bulk(self.rurl, self.foo10)
+        # Base package needed for tests.
+        self.pkgsend_bulk(self.rurl, self.foo10)
 
-                # Verify that a package with unsupported content doesn't cause
-                # a problem.
-                newact = "depend type=new-type fmri=foo@1.1"
+        # Verify that a package with unsupported content doesn't cause
+        # a problem.
+        newact = "depend type=new-type fmri=foo@1.1"
 
-                # Now create a new image and verify that pkg install will fail
-                # for the unsupported package, but succeed for the supported
-                # one.
-                self.__populate_repo(newact)
-                self.image_create(self.rurl)
-                self.pkg("install foo@1.0")
-                self.pkg("install unsupported@1.0", exit=1)
-                self.pkg("uninstall foo")
-                self.pkg("install foo@1.0 unsupported@1.0", exit=1)
+        # Now create a new image and verify that pkg install will fail
+        # for the unsupported package, but succeed for the supported
+        # one.
+        self.__populate_repo(newact)
+        self.image_create(self.rurl)
+        self.pkg("install foo@1.0")
+        self.pkg("install unsupported@1.0", exit=1)
+        self.pkg("uninstall foo")
+        self.pkg("install foo@1.0 unsupported@1.0", exit=1)
 
-                # Verify that a package with invalid content behaves the same.
-                newact = "depend notvalid"
-                self.__populate_repo(newact)
-                self.pkg("refresh --full")
-                self.pkg("install foo@1.0")
-                self.pkg("install unsupported@1.0", exit=1)
-                self.pkg("uninstall foo")
+        # Verify that a package with invalid content behaves the same.
+        newact = "depend notvalid"
+        self.__populate_repo(newact)
+        self.pkg("refresh --full")
+        self.pkg("install foo@1.0")
+        self.pkg("install unsupported@1.0", exit=1)
+        self.pkg("uninstall foo")
 
-                # Now verify that if a newer version of the unsupported package
-                # is found that is supported, it can be installed.
-                self.__populate_repo()
-                self.pkg("refresh --full")
-                self.pkg("install foo@1.0 unsupported@1.0")
-                self.pkg("uninstall foo unsupported")
+        # Now verify that if a newer version of the unsupported package
+        # is found that is supported, it can be installed.
+        self.__populate_repo()
+        self.pkg("refresh --full")
+        self.pkg("install foo@1.0 unsupported@1.0")
+        self.pkg("uninstall foo unsupported")
 
-        def test_04_loop(self):
-                """Verify that if a directory or file is replaced with a link
-                that targets itself (resulting in ELOOP) pkg fails gracefully.
-                """
+    def test_04_loop(self):
+        """Verify that if a directory or file is replaced with a link
+        that targets itself (resulting in ELOOP) pkg fails gracefully.
+        """
 
-                # Create an image and install a package delivering a file.
-                self.image_create(self.rurl)
-                self.pkg("install dir@1.0 filesub@1.0")
+        # Create an image and install a package delivering a file.
+        self.image_create(self.rurl)
+        self.pkg("install dir@1.0 filesub@1.0")
 
-                # Now replace the file with a link that points to itself.
-                def create_link_loop(fpath):
-                        if os.path.isfile(fpath):
-                                portable.remove(fpath)
-                        else:
-                                shutil.rmtree(fpath)
-                        cwd = os.getcwd()
-                        os.chdir(os.path.dirname(fpath))
-                        os.symlink(os.path.basename(fpath),
-                            os.path.basename(fpath))
-                        os.chdir(cwd)
+        # Now replace the file with a link that points to itself.
+        def create_link_loop(fpath):
+            if os.path.isfile(fpath):
+                portable.remove(fpath)
+            else:
+                shutil.rmtree(fpath)
+            cwd = os.getcwd()
+            os.chdir(os.path.dirname(fpath))
+            os.symlink(os.path.basename(fpath), os.path.basename(fpath))
+            os.chdir(cwd)
 
-                fpath = self.get_img_file_path("dir/file")
-                create_link_loop(fpath)
+        fpath = self.get_img_file_path("dir/file")
+        create_link_loop(fpath)
 
-                # Verify that pkg verify gracefully fails if traversing a
-                # link targeting itself.
-                self.pkg("verify", exit=1)
+        # Verify that pkg verify gracefully fails if traversing a
+        # link targeting itself.
+        self.pkg("verify", exit=1)
 
-                # Verify that pkg succeeds if attempting to update a
-                # package containing a file replaced with a link loop.
-                self.pkg("update filesub")
-                self.pkg("verify")
+        # Verify that pkg succeeds if attempting to update a
+        # package containing a file replaced with a link loop.
+        self.pkg("update filesub")
+        self.pkg("verify")
 
-                # Now remove the package delivering the file and replace the
-                # directory with a link loop.
-                self.pkg("uninstall filesub")
-                fpath = self.get_img_file_path("dir")
-                create_link_loop(fpath)
+        # Now remove the package delivering the file and replace the
+        # directory with a link loop.
+        self.pkg("uninstall filesub")
+        fpath = self.get_img_file_path("dir")
+        create_link_loop(fpath)
 
-                # Verify that pkg verify gracefully fails if traversing a
-                # link targeting itself.
-                self.pkg("verify", exit=1)
+        # Verify that pkg verify gracefully fails if traversing a
+        # link targeting itself.
+        self.pkg("verify", exit=1)
 
-                # Verify that pkg gracefully fails if attempting to update
-                # a package containing a directory replace with a link loop.
-                self.pkg("update", exit=1)
+        # Verify that pkg gracefully fails if attempting to update
+        # a package containing a directory replace with a link loop.
+        self.pkg("update", exit=1)
 
 
 class TestConflictingActions(_TestHelper, pkg5unittest.SingleDepotTestCase):
-        """This set of tests verifies that packages which deliver conflicting
-        actions into the same name in a namespace cannot be installed
-        simultaneously."""
+    """This set of tests verifies that packages which deliver conflicting
+    actions into the same name in a namespace cannot be installed
+    simultaneously."""
 
-        pkg_boring10 = """
+    pkg_boring10 = """
             open boring@1.0,5.11-0
             close """
 
-        pkg_dupfiles = """
+    pkg_dupfiles = """
             open dupfiles@0,5.11-0
             add file tmp/file1 path=dir/pathname mode=0755 owner=root group=bin
             add file tmp/file2 path=dir/pathname mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupfilesp1 = """
+    pkg_dupfilesp1 = """
             open dupfilesp1@0,5.11-0
             add file tmp/file1 path=dir/pathname mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupfilesp2 = """
+    pkg_dupfilesp2 = """
             open dupfilesp2@0,5.11-0
             add file tmp/file2 path=dir/pathname mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupfilesp2v2 = """
+    pkg_dupfilesp2v2 = """
             open dupfilesp2@2,5.11-0
             close
         """
 
-        pkg_dupfilesp3 = """
+    pkg_dupfilesp3 = """
             open dupfilesp3@0,5.11-0
             add file tmp/file2 path=dir/pathname mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupfilesp4 = """
+    pkg_dupfilesp4 = """
             open dupfilesp4@0,5.11-0
             add file tmp/file3 path=dir/pathname mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupotherfilesp1 = """
+    pkg_dupotherfilesp1 = """
             open dupotherfilesp1@0,5.11-0
             add file tmp/file1 path=dir/namepath mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupotherfilesp2 = """
+    pkg_dupotherfilesp2 = """
             open dupotherfilesp2@0,5.11-0
             add file tmp/file2 path=dir/namepath mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupotherfilesp2v2 = """
+    pkg_dupotherfilesp2v2 = """
             open dupotherfilesp2@2,5.11-0
             close
         """
 
-        pkg_dupotherfilesp3 = """
+    pkg_dupotherfilesp3 = """
             open dupotherfilesp3@0,5.11-0
             add file tmp/file3 path=dir/namepath mode=0755 owner=root group=bin
             close
         """
 
-        pkg_identicalfiles = """
+    pkg_identicalfiles = """
             open identicalfiles@0,5.11-0
             add file tmp/file1 path=dir/pathname mode=0755 owner=root group=bin
             add file tmp/file1 path=dir/pathname mode=0755 owner=root group=bin
             close
         """
 
-        pkg_overlaid = """
+    pkg_overlaid = """
             open overlaid@0,5.11-0
             add dir path=etc mode=0755 owner=root group=root
             add file tmp/file1 path=etc/pam.conf mode=644 owner=root group=sys preserve=true overlay=allow
@@ -10468,7 +10811,7 @@ class TestConflictingActions(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        pkg_overlaid_attr = """
+    pkg_overlaid_attr = """
             open overlaid-no-attr@0,5.11-0
             add dir path=etc mode=0755 owner=root group=root
             add file tmp/file1 path=etc/pam.conf mode=644 owner=root group=sys preserve=true overlay=allow
@@ -10483,20 +10826,20 @@ class TestConflictingActions(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        # 'overlay' is ignored unless 'preserve' is also set.
-        pkg_invalid_overlaid = """
+    # 'overlay' is ignored unless 'preserve' is also set.
+    pkg_invalid_overlaid = """
             open invalid-overlaid@0,5.11-0
             add file tmp/file1 path=etc/pam.conf mode=644 owner=root group=sys overlay=allow
             close
         """
 
-        pkg_overlayer = """
+    pkg_overlayer = """
             open overlayer@0,5.11-0
             add file tmp/file2 path=etc/pam.conf mode=644 owner=root group=sys preserve=true overlay=true
             close
         """
 
-        pkg_overlayer_move = """
+    pkg_overlayer_move = """
             open overlayer-move@0,5.11-0
             add file tmp/file2 path=etc/pam.conf mode=644 owner=root group=sys preserve=true overlay=true
             close
@@ -10505,7 +10848,7 @@ class TestConflictingActions(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        pkg_overlayer_update = """
+    pkg_overlayer_update = """
             open overlayer-update@0,5.11-0
             add file tmp/file1 path=etc/pam.conf mode=644 owner=root group=sys overlay=true
             close
@@ -10520,80 +10863,80 @@ class TestConflictingActions(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        pkg_multi_overlayer = """
+    pkg_multi_overlayer = """
             open multi-overlayer@0,5.11-0
             add file tmp/file2 path=etc/pam.conf mode=644 owner=root group=sys preserve=true overlay=true
             close
         """
 
-        pkg_mismatch_overlayer = """
+    pkg_mismatch_overlayer = """
             open mismatch-overlayer@0,5.11-0
             add file tmp/file2 path=etc/pam.conf mode=640 owner=root group=bin preserve=true overlay=true
             close
         """
 
-        pkg_mismatch_overlayer2 = """
+    pkg_mismatch_overlayer2 = """
             open mismatch-overlayer-deny@0,5.11-0
             add file tmp/file2 path=etc/pam.conf mode=640 owner=root group=bin preserve=true overlay=true overlay-attributes=deny
             close
         """
 
-        # overlaying file is treated as conflicting file if overlay-attribute is
-        # set to false or its mode, owner, and group attributes don't match the
-        # action being overlaid.
-        pkg_mismatch_overlayer3 = """
+    # overlaying file is treated as conflicting file if overlay-attribute is
+    # set to false or its mode, owner, and group attributes don't match the
+    # action being overlaid.
+    pkg_mismatch_overlayer3 = """
             open mismatch-overlayer-allow@0,5.11-0
             add file tmp/file2 path=etc/pam.conf mode=640 owner=root group=bin preserve=true overlay=true overlay-attributes=allow
             close
         """
 
-        # overlaying file is treated as conflicting file if it doesn't set overlay=true
-        # even if file being overlaid allows overlay.
-        pkg_invalid_overlayer = """
+    # overlaying file is treated as conflicting file if it doesn't set overlay=true
+    # even if file being overlaid allows overlay.
+    pkg_invalid_overlayer = """
             open invalid-overlayer@0,5.11-0
             add file tmp/file2 path=etc/pam.conf mode=644 owner=root group=sys preserve=true
             close
         """
 
-        pkg_unpreserved_overlayer = """
+    pkg_unpreserved_overlayer = """
             open unpreserved-overlayer@0,5.11-0
             add file tmp/unpreserved path=etc/pam.conf mode=644 owner=root group=sys overlay=true
             close
         """
 
-        pkgremote_pkg1 = """
+    pkgremote_pkg1 = """
             open pkg1@0,5.11-0
             add file tmp/file1 path=remote mode=644 owner=root group=sys
             close
         """
 
-        pkgremote_pkg2 = """
+    pkgremote_pkg2 = """
             open pkg2@0,5.11-0
             add file tmp/file2 path=remote mode=644 owner=root group=sys
             close
         """
 
-        pkg_dupfilesv1 = """
+    pkg_dupfilesv1 = """
             open dupfilesv1@0,5.11-0
             add set name=variant.arch value=sparc value=i386
             add dir path=dir/pathname mode=0755 owner=root group=bin variant.arch=i386
             close
         """
 
-        pkg_dupfilesv2 = """
+    pkg_dupfilesv2 = """
             open dupfilesv2@0,5.11-0
             add dir path=dir/pathname mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupfilesv3 = """
+    pkg_dupfilesv3 = """
             open dupfilesv3@0,5.11-0
             add set name=variant.arch value=sparc value=i386
             add dir path=dir/pathname mode=0777 owner=root group=bin variant.arch=sparc
             close
         """
 
-        pkg_dupfilesv4 = """
+    pkg_dupfilesv4 = """
             open dupfilesv4@0,5.11-0
             add set name=variant.arch value=sparc value=i386
             add file tmp/file1 path=dir/pathname mode=0777 owner=root group=bin variant.arch=sparc
@@ -10602,58 +10945,58 @@ class TestConflictingActions(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        pkg_dupfilesv5 = """
+    pkg_dupfilesv5 = """
             open dupfilesv5@0,5.11-0
             add set name=variant.opensolaris.zone value=global value=nonglobal
             add file tmp/file1 path=dir/pathname mode=0777 owner=root group=bin variant.opensolaris.zone=nonglobal
             close
         """
 
-        pkg_dupfilesv6 = """
+    pkg_dupfilesv6 = """
             open dupfilesv6@0,5.11-0
             add file tmp/file2 path=dir/pathname mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupfilesf1 = """
+    pkg_dupfilesf1 = """
             open dupfilesf1@0,5.11-0
             add dir path=dir/pathname mode=0755 owner=root group=bin facet.devel=true
             close
         """
 
-        pkg_dupfilesf2 = """
+    pkg_dupfilesf2 = """
             open dupfilesf2@0,5.11-0
             add dir path=dir/pathname mode=0755 owner=root group=bin facet.devel=false
             close
         """
 
-        pkg_dupfilesf3 = """
+    pkg_dupfilesf3 = """
             open dupfilesf3@0,5.11-0
             add dir path=dir/pathname mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupfilesf4 = """
+    pkg_dupfilesf4 = """
             open dupfilesf4@0,5.11-0
             add file tmp/file1 path=dir/pumpkin mode=0755 owner=root group=bin
             add file tmp/file2 path=dir/pumpkin mode=0755 owner=root group=bin facet.devel=true
             close
         """
 
-        pkg_duppathfilelink = """
+    pkg_duppathfilelink = """
             open duppath-filelink@0,5.11-0
             add file tmp/file1 path=dir/pathname mode=0755 owner=root group=bin
             add link path=dir/pathname target=dir/other
             close
         """
 
-        pkg_duplink = """
+    pkg_duplink = """
             open duplink@0,5.11-0
             add link path=dir/pathname target=dir/other
             close
         """
 
-        pkg_dupmultitypes1 = """
+    pkg_dupmultitypes1 = """
             open dupmultitypes@1,5.11-0
             add link path=multitypepath target=dir/other
             add file tmp/file1 path=multitypepath mode=0644 owner=root group=bin
@@ -10661,210 +11004,210 @@ class TestConflictingActions(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        pkg_dupmultitypes2 = """
+    pkg_dupmultitypes2 = """
             open dupmultitypes@2,5.11-0
             add dir path=multitypepath mode=0755 owner=root group=bin
             close
         """
 
-        pkg_dupmultitypes3_0 = """
+    pkg_dupmultitypes3_0 = """
             open dupmultitypes3@0,5.11-0
             add link path=multitypepath target=blah
             add link path=multitypepath target=blah
             close
         """
 
-        pkg_dupmultitypes3_1 = """
+    pkg_dupmultitypes3_1 = """
             open dupmultitypes3@1,5.11-0
             add dir path=multitypepath mode=0755 owner=root group=bin
             add dir path=multitypepath mode=0755 owner=root group=bin
             close
         """
 
-        pkg_duppathnonidenticallinks = """
+    pkg_duppathnonidenticallinks = """
             open duppath-nonidenticallinks@0,5.11-0
             add link path=dir/pathname target=dir/something
             add link path=dir/pathname target=dir/other
             close
         """
 
-        pkg_duppathnonidenticallinksp1 = """
+    pkg_duppathnonidenticallinksp1 = """
             open duppath-nonidenticallinksp1@0,5.11-0
             add link path=dir/pathname target=dir/something
             close
         """
 
-        pkg_duppathnonidenticallinksp2 = """
+    pkg_duppathnonidenticallinksp2 = """
             open duppath-nonidenticallinksp2@0,5.11-0
             add link path=dir/pathname target=dir/other
             close
         """
 
-        pkg_duppathnonidenticallinksp2v1 = """
+    pkg_duppathnonidenticallinksp2v1 = """
             open duppath-nonidenticallinksp2@1,5.11-0
             close
         """
 
-        pkg_duppathnonidenticaldirs = """
+    pkg_duppathnonidenticaldirs = """
             open duppath-nonidenticaldirs@0,5.11-0
             add dir path=dir/pathname owner=root group=root mode=0755
             add dir path=dir/pathname owner=root group=bin mode=0711
             close
         """
 
-        pkg_duppathalmostidenticaldirs = """
+    pkg_duppathalmostidenticaldirs = """
             open duppath-almostidenticaldirs@0,5.11-0
             add dir path=dir/pathname owner=root group=root mode=0755
             add dir path=dir/pathname owner=root group=root mode=755
             close
         """
 
-        pkg_implicitdirs = """
+    pkg_implicitdirs = """
             open implicitdirs@0,5.11-0
             add file tmp/file1 path=usr/bin/something mode=0755 owner=root group=bin
             add file tmp/file2 path=usr/bin mode=0755 owner=root group=bin
             close
         """
 
-        pkg_implicitdirs2 = """
+    pkg_implicitdirs2 = """
             open implicitdirs2@0,5.11-0
             add file tmp/file1 path=usr/bin/something mode=0755 owner=root group=bin
             add dir path=usr/bin mode=0700 owner=root group=bin
             close
         """
 
-        pkg_implicitdirs3 = """
+    pkg_implicitdirs3 = """
             open implicitdirs3@0,5.11-0
             add file tmp/file1 path=usr/bin/other mode=0755 owner=root group=bin
             close
         """
 
-        pkg_implicitdirs4 = """
+    pkg_implicitdirs4 = """
             open implicitdirs4@0,5.11-0
             add file tmp/file1 path=usr/bin/something mode=0755 owner=root group=bin
         """
 
-        pkg_implicitdirs5 = """
+    pkg_implicitdirs5 = """
             open implicitdirs5@0,5.11-0
             add dir path=usr/bin mode=0755 owner=root group=sys
         """
 
-        pkg_implicitdirs6 = """
+    pkg_implicitdirs6 = """
             open implicitdirs6@0,5.11-0
             add dir path=usr/bin mode=0755 owner=root group=bin
         """
 
-        pkg_implicitdirs7 = """
+    pkg_implicitdirs7 = """
             open implicitdirs7@0,5.11-0
             add file tmp/file1 path=usr/bin mode=0755 owner=root group=bin
         """
 
-        pkg_dupdir = """
+    pkg_dupdir = """
             open dupdir@0,5.11-0
             add dir path=dir/pathname owner=root group=bin mode=0755
             close
         """
 
-        pkg_dupdirv1 = """
+    pkg_dupdirv1 = """
             open dupdir@1,5.11-0
             close
         """
 
-        pkg_dupdirnowhere = """
+    pkg_dupdirnowhere = """
             open dupdirnowhere@0,5.11-0
             add dir path=dir/pathname owner=root group=bin mode=0755
             close
         """
 
-        pkg_dupdirp1 = """
+    pkg_dupdirp1 = """
             open dupdirp1@1,5.11-0
             add dir path=dir owner=root group=bin mode=0755
             close
         """
 
-        pkg_dupdirp2 = """
+    pkg_dupdirp2 = """
             open dupdirp2@1,5.11-0
             add dir path=dir owner=root group=sys mode=0755
             close
         """
 
-        pkg_dupdirp2_2 = """
+    pkg_dupdirp2_2 = """
             open dupdirp2@2,5.11-0
             add dir path=dir owner=root group=bin mode=0755
             close
         """
 
-        pkg_dupdirp3 = """
+    pkg_dupdirp3 = """
             open dupdirp3@1,5.11-0
             add dir path=dir owner=root group=bin mode=0750
             close
         """
 
-        pkg_dupdirp4 = """
+    pkg_dupdirp4 = """
             open dupdirp4@1,5.11-0
             add dir path=dir owner=root group=sys mode=0750
             close
         """
 
-        pkg_dupdirp5 = """
+    pkg_dupdirp5 = """
             open dupdirp5@1,5.11-0
             add dir path=dir owner=root group=other mode=0755
             close
         """
 
-        pkg_dupdirp6 = """
+    pkg_dupdirp6 = """
             open dupdirp6@1,5.11-0
             add dir path=dir owner=root group=other mode=0755
             close
         """
 
-        pkg_dupdirp7 = """
+    pkg_dupdirp7 = """
             open dupdirp7@1,5.11-0
             add file tmp/file1 path=dir/file owner=root group=other mode=0755
             close
         """
 
-        pkg_dupdirp8 = """
+    pkg_dupdirp8 = """
             open dupdirp8@1,5.11-0
             add dir path=dir owner=root group=bin mode=0755
             close
         """
 
-        pkg_dupdirp8_2 = """
+    pkg_dupdirp8_2 = """
             open dupdirp8@2,5.11-0
             add dir path=dir owner=root group=sys mode=0755
             close
         """
 
-        pkg_dupdirp9 = """
+    pkg_dupdirp9 = """
             open dupdirp9@1,5.11-0
             add dir path=var owner=root group=other mode=0755
             add dir path=usr owner=root group=other mode=0755
             close
         """
 
-        pkg_dupdirp10 = """
+    pkg_dupdirp10 = """
             open dupdirp10@1,5.11-0
             add dir path=var owner=root group=bin mode=0755
             add dir path=usr owner=root group=bin mode=0755
             close
         """
 
-        pkg_dupdirp11 = """
+    pkg_dupdirp11 = """
             open dupdirp11@1,5.11-0
             add dir path=usr/bin owner=root group=bin mode=0755
             add dir path=var/zap owner=root group=bin mode=0755
             close
         """
 
-        pkg_dupdirp12 = """
+    pkg_dupdirp12 = """
             open dupdirp12@1,5.11-0
             add dir path=usr/bin owner=root group=bin mode=0755
             add legacy pkg=dupdirp9
             close
         """
 
-        pkg_userdb = """
+    pkg_userdb = """
             open userdb@0,5.11-0
             add file tmp/passwd mode=0644 owner=root group=bin path=etc/passwd preserve=true
             add file tmp/group mode=0644 owner=root group=bin path=etc/group preserve=true
@@ -10873,79 +11216,79 @@ class TestConflictingActions(_TestHelper, pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        userdb_files = {
-            "tmp/passwd": """\
+    userdb_files = {
+        "tmp/passwd": """\
 root:x:0:0::/root:/usr/bin/bash
 daemon:x:1:1::/:
 bin:x:2:2::/usr/bin:
 sys:x:3:3::/:
 adm:x:4:4:Admin:/var/adm:
 """,
-            "tmp/group": """\
+        "tmp/group": """\
 root::0:
 other::1:root
 bin::2:root,daemon
 sys::3:root,bin,adm
 adm::4:root,daemon
 """,
-            "tmp/shadow": """\
+        "tmp/shadow": """\
 root:9EIfTNBp9elws:13817::::::
 daemon:NP:6445::::::
 bin:NP:6445::::::
 sys:NP:6445::::::
 adm:NP:6445::::::
 """,
-            "tmp/ftpusers": """\
+        "tmp/ftpusers": """\
 root
 bin
 sys
 adm
-"""
-        }
+""",
+    }
 
-        pkg_dupuser = """
+    pkg_dupuser = """
             open dupuser@0,5.11-0
             add user username=kermit group=adm gcos-field="kermit 1"
             add user username=kermit group=adm gcos-field="kermit 2"
             close
         """
 
-        pkg_dupuserp1 = """
+    pkg_dupuserp1 = """
             open dupuserp1@0,5.11-0
             add user username=kermit group=adm gcos-field="kermit 1"
             close
         """
 
-        pkg_dupuserp2 = """
+    pkg_dupuserp2 = """
             open dupuserp2@0,5.11-0
             add user username=kermit group=adm gcos-field="kermit 2"
             close
         """
 
-        pkg_dupuserp2v2 = """
+    pkg_dupuserp2v2 = """
             open dupuserp2@1,5.11-0
             close
         """
 
-        pkg_dupuserp3 = """
+    pkg_dupuserp3 = """
             open dupuserp3@0,5.11-0
             add user username=kermit group=adm gcos-field="kermit 2"
             close
         """
 
-        pkg_dupuserp4 = """
+    pkg_dupuserp4 = """
             open dupuserp4@0,5.11-0
             add user username=kermit group=adm gcos-field="kermit 4"
             close
         """
 
-        pkg_otheruser = """
+    pkg_otheruser = """
             open otheruser@0,5.11-0
             add user username=fozzie group=adm home-dir=/export/home/fozzie
             close
         """
 
-        pkg_othergroup = """
+    pkg_othergroup = """
             open othergroup@0,5.11-0
             add group groupname=fozzie gid=87
             add group groupname=fozzie gid=88
@@ -10953,27 +11296,27 @@ adm
             close
         """
 
-        pkg_othergroup1 = """
+    pkg_othergroup1 = """
             open othergroup@1,5.11-0
             add group groupname=fozzie gid=87
             close
         """
 
-        pkg_conflictgroup1 = """
+    pkg_conflictgroup1 = """
             open conflictgroup1@0,5.11
             add user group=fozzie uid=20 username=fozzie
             add group groupname=fozzie gid=200
             close
         """
 
-        pkg_conflictgroup2 = """
+    pkg_conflictgroup2 = """
             open conflictgroup2@0,5.11
             add user group=fozzie uid=21 username=fozzie
             add group groupname=fozzie gid=201
             close
         """
 
-        pkg_driverdb = """
+    pkg_driverdb = """
             open driverdb@0,5.11-0
             add file tmp/devlink.tab path=etc/devlink.tab mode=0644 owner=root group=bin
             add file tmp/driver_aliases path=etc/driver_aliases mode=0644 owner=root group=bin
@@ -10985,73 +11328,73 @@ adm
             close
         """
 
-        driverdb_files = {
-            "tmp/devlink.tab": "",
-            "tmp/driver_aliases": "",
-            "tmp/driver_classes": "",
-            "tmp/minor_perm": "",
-            "tmp/name_to_major": "",
-            "tmp/device_policy": "",
-            "tmp/extra_privs": ""
-        }
+    driverdb_files = {
+        "tmp/devlink.tab": "",
+        "tmp/driver_aliases": "",
+        "tmp/driver_classes": "",
+        "tmp/minor_perm": "",
+        "tmp/name_to_major": "",
+        "tmp/device_policy": "",
+        "tmp/extra_privs": "",
+    }
 
-        pkg_dupdrv = """
+    pkg_dupdrv = """
             open dupdriver@0,5.11-0
             add driver name=asy perms="* 0666 root sys" perms="*,cu 0600 uucp uucp"
             add driver name=asy perms="* 0666 root sys" alias=pci11c1,480
             close
         """
 
-        pkg_dupdepend1 = """
+    pkg_dupdepend1 = """
             open dupdepend1@0,5.11-0
             add depend type=require fmri=dupfilesp1
             add depend type=require fmri=dupfilesp1
             close
         """
 
-        pkg_dupdepend2 = """
+    pkg_dupdepend2 = """
             open dupdepend2@0,5.11-0
             add depend type=require fmri=dupfilesp1
             add depend type=incorporate fmri=dupfilesp1
             close
         """
 
-        pkg_dupdepend3 = """
+    pkg_dupdepend3 = """
             open dupdepend3@0,5.11-0
             add depend type=require fmri=dupfilesp1@0-0
             add depend type=require fmri=dupfilesp1@0-0
             close
         """
 
-        pkg_dupdepend4 = """
+    pkg_dupdepend4 = """
             open dupdepend4@0,5.11-0
             add depend type=require fmri=dupfilesp1@0-0
             add depend type=incorporate fmri=dupfilesp1@0-0
             close
         """
 
-        pkg_tripledupfilea = """
+    pkg_tripledupfilea = """
             open tripledupfilea@0,5.11-0
             add set name=variant.foo value=one
             add file tmp/file1 path=file owner=root group=other mode=0755
             close
         """
 
-        pkg_tripledupfileb = """
+    pkg_tripledupfileb = """
             open tripledupfileb@0,5.11-0
             add set name=variant.foo value=one value=two
             add file tmp/file2 path=file owner=root group=other mode=0755
             close
         """
 
-        pkg_tripledupfilec = """
+    pkg_tripledupfilec = """
             open tripledupfilec@0,5.11-0
             add set name=variant.foo value=one value=two
             add file tmp/file3 path=file owner=root group=other mode=0755
             close
         """
 
-        pkg_variantedtypes = """
+    pkg_variantedtypes = """
             open vpath@0,5.11-0
             add set name=variant.foo value=one value=two
             add dir group=bin mode=0755 owner=root path=boot/platform \
@@ -11061,1766 +11404,1827 @@ adm
             close
         """
 
-        misc_files = ["tmp/file1", "tmp/file2", "tmp/file3", "tmp/file4",
-            "tmp/unpreserved"]
+    misc_files = [
+        "tmp/file1",
+        "tmp/file2",
+        "tmp/file3",
+        "tmp/file4",
+        "tmp/unpreserved",
+    ]
 
-        # Keep the depots around for the duration of the entire class
-        persistent_setup = True
+    # Keep the depots around for the duration of the entire class
+    persistent_setup = True
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.make_misc_files(self.userdb_files)
-                self.make_misc_files(self.driverdb_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.make_misc_files(self.userdb_files)
+        self.make_misc_files(self.driverdb_files)
 
-                pkgs = []
-                for objname in dir(self.__class__):
-                        obj = getattr(self, objname)
-                        if objname.startswith("pkg_") and type(obj) == str:
-                                pkgs.append(obj)
+        pkgs = []
+        for objname in dir(self.__class__):
+            obj = getattr(self, objname)
+            if objname.startswith("pkg_") and type(obj) == str:
+                pkgs.append(obj)
 
-                for i in range(20):
-                        s = """
+        for i in range(20):
+            s = """
                                 open massivedupdir{0:d}@0,5.11-0
                                 add dir path=usr owner=root group={{0}} mode={{1}} zig={{2}}
                                 close
-                        """.format(i)
-
-                        if i == 14:
-                                s = s.format("root", "0750", "zag")
-                        elif i in (1, 9):
-                                s = s.format("sys", "0750", "zag")
-                        elif i in (3, 8, 12, 17):
-                                s = s.format("root", "0755", "zag")
-                        else:
-                                s = s.format("sys", "0755", "zig")
-
-                        pkgs.append(s)
-
-                self.plist = self.pkgsend_bulk(self.rurl, pkgs)
-
-
-        def test_conflictgroupid_install(self):
-                """Test conflict group IDs will not cause user action failure.
-                """
-
-                self.image_create(self.rurl)
-
-                self.pkg("install userdb")
-                self.pkg("install conflictgroup1")
-                with open(os.path.join(self.img_path(), "etc/group")) as f:
-                        lines = f.readlines()
-                for line in lines:
-                        if "fozzie" in line:
-                                self.assertTrue("200" in line)
-                                break
-                with open(os.path.join(self.img_path(), "etc/passwd")) as f:
-                        lines = f.readlines()
-                for line in lines:
-                        if "fozzie" in line:
-                                self.assertTrue("200" in line)
-                                break
-                self.pkg("install -v --reject conflictgroup1 conflictgroup2")
-
-                self.pkg("list conflictgroup1", exit=1)
-                self.pkg("list conflictgroup2")
-                with open(os.path.join(self.img_path(), "etc/passwd")) as f:
-                        lines = f.readlines()
-                for line in lines:
-                        if "fozzie" in line:
-                                self.assertTrue("201" in line)
-                                break
-                with open(os.path.join(self.img_path(), "etc/group")) as f:
-                        lines = f.readlines()
-                for line in lines:
-                        if "fozzie" in line:
-                                self.assertTrue("201" in line)
-                                break
-                self.pkg("verify")
-
-        def test_multiple_files_install(self):
-                """Test the behavior of pkg(1) when multiple file actions
-                deliver to the same pathname."""
-
-                self.image_create(self.rurl)
-
-                # Duplicate files in the same package
-                self.pkg("install dupfiles", exit=1)
-
-                # Duplicate files in different packages, but in the same
-                # transaction
-                self.pkg("install dupfilesp1 dupfilesp2@0", exit=1)
-
-                # Duplicate files in different packages, in different
-                # transactions
-                self.pkg("install dupfilesp1")
-                self.pkg("install dupfilesp2@0", exit=1)
-
-                # Test that being in a duplicate file situation doesn't break
-                # you completely and allows you to add and remove other packages
-                self.pkg("-D broken-conflicting-action-handling=1 install dupfilesp2@0")
-                self.pkg("install implicitdirs2")
-                self.pkg("uninstall implicitdirs2")
-
-                # If the packages involved get upgraded but leave the actions
-                # themselves alone, we should be okay.
-                self.pkg("install dupfilesp2 dupfilesp3")
-                self.pkg("verify", exit=1)
-
-                # Test that removing one of two offending actions reverts the
-                # system to a clean state.
-                self.pkg("uninstall dupfilesp3")
-                self.pkg("verify")
-
-                # You should be able to upgrade to a fixed set of packages in
-                # order to move past the problem, too.
-                self.pkg("uninstall dupfilesp2")
-                self.pkg("-D broken-conflicting-action-handling=1 install dupfilesp2@0")
-                self.pkg("update")
-                self.pkg("verify")
-
-                # If we upgrade to a version of a conflicting package that no
-                # longer has the conflict, but at the same time introduce a new
-                # file action at the path with different contents, we should
-                # fail.
-                self.pkg("uninstall dupfilesp2")
-                self.pkg("-D broken-conflicting-action-handling=1 install dupfilesp2@0")
-                self.pkg("install dupfilesp2 dupfilesp4", exit=1)
-
-                # Removing one of more than two offending actions can't do much
-                # of anything, but should leave the system alone.
-                self.pkg("uninstall '*'")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupfilesp1 dupfilesp2@0 dupfilesp3")
-                # Verify should report a duplicate action error on dupfilesp1,
-                # dupfilesp2 and dupfilesp3 and shouldn't report it was failing
-                # due to hashes being wrong.
-                self.pkg("verify", exit=1)
-                out1, err1 = self.output, self.errout
-                for i, l in enumerate(self.plist):
-                    if l.startswith("pkg://test/dupfilesp1"):
-                        index = i
-                self.assertTrue(self.plist[index] in err1, err1)
-                self.assertTrue(self.plist[index + 1] in err1, err1)
-                self.assertTrue(self.plist[index + 3] in err1, err1)
-                self.assertTrue("Hash" not in out1)
-                self.pkg("uninstall dupfilesp3")
-                # Removing dupfilesp3, verify should still report a duplicate
-                # action error on dupfilesp1 and dupfilesp2.
-                self.pkg("verify", exit=1)
-                out2, err2 = self.output, self.errout
-                expected = "\n  {0}\n  {1}".format(
-                    self.plist[index], self.plist[index + 1])
-                self.assertTrue(expected in err2)
-                self.assertTrue("Hash" not in out2)
-
-                # Removing all but one of the offending actions should get us
-                # back to sanity.
-                self.pkg("uninstall '*'")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupfilesp1 dupfilesp2@0 dupfilesp3")
-                self.pkg("uninstall dupfilesp3 dupfilesp2")
-                self.pkg("verify")
-
-                # Make sure we handle cleaning up multiple files properly.
-                self.pkg("uninstall '*'")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupfilesp1 dupfilesp2@0 dupotherfilesp1 dupotherfilesp2")
-                self.pkg("uninstall dupfilesp2 dupotherfilesp2")
-                self.pkg("verify")
-
-                # Re-use the overlay packages for some preserve testing.
-                self.pkg("install overlaid@0")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "invalid-overlayer")
-                # We may have been able to lay down the package, but because the
-                # file is marked preserve=true, we didn't actually overwrite
-                self.file_contains("etc/pam.conf", "file2")
-                self.pkg("uninstall invalid-overlayer")
-                self.file_contains("etc/pam.conf", "file2")
-
-                # Make sure we get rid of all implicit directories.
-                self.pkg("uninstall '*'")
-                self.pkg("install implicitdirs3 implicitdirs4")
-                self.pkg("uninstall implicitdirs3 implicitdirs4")
-
-                if os.path.isdir(os.path.join(self.get_img_path(), "usr/bin")):
-                        self.assertTrue(False, "Directory 'usr/bin' should not exist")
-
-                if os.path.isdir(os.path.join(self.get_img_path(), "usr")):
-                        self.assertTrue(False, "Directory 'usr' should not exist")
-
-                # Make sure identical actions don't cause problems
-                self.pkg("install -nv identicalfiles", exit=1)
-
-                # Trigger a bug similar to 17943 via duplicate files.
-                self.pkg("publisher")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupfilesp1@0 dupfilesp2@0 dupfilesp3@0 dupotherfilesp1@0 "
-                    "dupotherfilesp2@0 dupotherfilesp3@0")
-                self.pkg("update")
-
-                # If an uninstall causes a fixup to happen and we can't because
-                # we lost the cached files and the repo is down, make sure we
-                # fail before actually uninstalling anything.
-                self.dc.start()
-                self.pkgsend_bulk(self.durl, (self.pkgremote_pkg1,
-                    self.pkgremote_pkg2))
-                self.image_create(self.durl)
-                self.pkg("install pkg1")
-                self.pkg("-D broken-conflicting-action-handling=1 install pkg2")
-                self.pkg("verify pkg2")
-                self.dc.stop()
-                self.pkg("uninstall pkg2", exit=1)
-                self.pkg("verify pkg2")
-
-        def __check_overlay_install(self, overlaid, overlayer, exit=0):
-                self.image_create(self.rurl)
-                self.pkg("install {0}".format(overlaid))
-                self.file_append("etc/pam.conf", "zigit")
-                self.pkg("install {0}".format(overlayer), exit=exit)
-                # If exit == 0, the file has been overlaid.
-                if exit == 0:
-                        self.file_doesnt_contain("etc/pam.conf", "zigit")
-                else:
-                        self.file_contains("etc/pam.conf", "zigit")
-
-        def test_mismatch_overlay_files_install(self):
-                """Test overlay attributes mismatch."""
-
-                # Test all combo of overlay-attributes on overlaid and
-                # overlayer packages.
-                self.__check_overlay_install("overlaid-attr-deny@0",
-                    "mismatch-overlayer@0", exit=1)
-                self.__check_overlay_install("overlaid-attr-deny@0",
-                    "mismatch-overlayer-allow@0", exit=1)
-                self.__check_overlay_install("overlaid-attr-deny@0",
-                    "mismatch-overlayer-deny@0", exit=1)
-
-                self.__check_overlay_install("overlaid-no-attr@0",
-                    "mismatch-overlayer@0", exit=0)
-                self.__check_overlay_install("overlaid-no-attr@0",
-                    "mismatch-overlayer-allow@0", exit=0)
-                self.__check_overlay_install("overlaid-no-attr@0",
-                    "mismatch-overlayer-deny@0", exit=1)
-
-                self.__check_overlay_install("overlaid-attr-allow@0",
-                    "mismatch-overlayer@0", exit=0)
-                self.__check_overlay_install("overlaid-attr-allow@0",
-                    "mismatch-overlayer-allow@0", exit=0)
-                self.__check_overlay_install("overlaid-attr-allow@0",
-                    "mismatch-overlayer-deny@0", exit=1)
-
-        def test_overlay_files_install(self):
-                """Test the behaviour of pkg(1) when actions for editable files
-                overlay other actions."""
-
-                # Ensure that overlay is allowed for file actions when one
-                # action has specified preserve attribute and overlay=allow,
-                # and *one* (only) other action has specified overlay=true
-                # (preserve does not have to be set).
-                self.image_create(self.rurl)
-
-                # Ensure boring package is installed as conflict checking is
-                # bypassed (and thus, overlay semantics) if all packages are
-                # removed from an image.
-                self.pkg("install boring")
-
-                # Should fail because one action specified overlay=allow,
-                # but not preserve (it isn't editable).
-                self.pkg("install invalid-overlaid")
-                self.pkg("install overlayer", exit=1)
-                self.pkg("uninstall invalid-overlaid")
-
-                # Should fail because one action is overlayable but overlaying
-                # action doesn't declare its intent to overlay.
-                self.pkg("install overlaid@0")
-                self.file_contains("etc/pam.conf", "file1")
-                self.pkg("install invalid-overlayer", exit=1)
-
-                # Should succeed because no overlay-attributes='deny' present
-                # on either action.
-                self.pkg("install mismatch-overlayer")
-                # Uninstall it to not affect the subsequent tests.
-                self.pkg("uninstall mismatch-overlayer")
-
-                # Should succeed because one action is overlayable and
-                # overlaying action declares its intent to overlay.
-                self.pkg("contents -m overlaid")
-                self.pkg("contents -mr overlayer")
-                self.pkg("install --parsable=0 overlayer")
-                self._assertEditables(
-                    installed=["etc/pam.conf"],
-                )
-                self.file_contains("etc/pam.conf", "file2")
-
-                # Should fail because multiple actions are not allowed to
-                # overlay a single action.
-                self.pkg("install multi-overlayer", exit=1)
-
-                # Should succeed even though file is different than originally
-                # delivered since original package permits file modification.
-                self.pkg("verify overlaid overlayer")
-
-                # Should succeed because package delivering overlayable file
-                # permits modification and because package delivering overlay
-                # file permits modification.
-                self.file_append("etc/pam.conf", "zigit")
-                self.pkg("verify overlaid overlayer")
-
-                # Verify that the file isn't touched on uninstall of the
-                # overlaying package if package being overlaid is still
-                # installed.
-                self.pkg("uninstall --parsable=0 overlayer")
-                self._assertEditables()
-                self.file_contains("etc/pam.conf", ["zigit", "file2"])
-
-                # Verify that removing the last package delivering an overlaid
-                # file removes the file.
-                self.pkg("uninstall --parsable=0 overlaid")
-                self._assertEditables(
-                    removed=["etc/pam.conf"],
-                )
-                self.file_doesnt_exist("etc/pam.conf")
-
-                # Verify that installing both packages at the same time results
-                # in only the overlaying file being delivered.
-                self.pkg("install --parsable=0 overlaid@0 overlayer")
-                self._assertEditables(
-                    installed=["etc/pam.conf"],
-                )
-                self.file_contains("etc/pam.conf", "file2")
-
-                # Verify that the file isn't touched on uninstall of the
-                # overlaid package if overlaying package is still installed.
-                self.file_append("etc/pam.conf", "zigit")
-                self.pkg("uninstall --parsable=0 overlaid")
-                self._assertEditables()
-                self.file_contains("etc/pam.conf", ["file2", "zigit"])
-
-                # Re-install overlaid package and verify that file content
-                # does not change.
-                self.pkg("install --parsable=0 overlaid@0")
-                self._assertEditables()
-                self.file_contains("etc/pam.conf", ["file2", "zigit"])
-                self.pkg("uninstall --parsable=0 overlaid overlayer")
-                self._assertEditables(
-                    removed=["etc/pam.conf"],
-                )
-
-                # Should succeed because one action is overlayable and
-                # overlaying action declares its intent to overlay even
-                # though the overlaying action isn't marked with preserve.
-                self.pkg("install -nvv overlaid@0 unpreserved-overlayer")
-                self.pkg("install --parsable=0 overlaid@0 unpreserved-overlayer")
-                self._assertEditables(
-                    installed=["etc/pam.conf"],
-                )
-                self.file_contains("etc/pam.conf", "unpreserved")
-
-                # Should succeed because overlaid action permits modification
-                # and contents matches overlaying action.
-                self.pkg("verify overlaid unpreserved-overlayer")
-
-                # Should fail because it turns into verifying the
-                # overlaying action from unpreserved-overlayer package.
-                self.file_append("etc/pam.conf", "zigit")
-                self.pkg("verify overlaid", exit=1)
-
-                # Should fail because overlaying action does not permit
-                # modification.
-                self.pkg("verify unpreserved-overlayer", exit=1)
-
-                # Should revert to content delivered by overlaying action.
-                self.pkg("fix unpreserved-overlayer")
-                self.file_contains("etc/pam.conf", "unpreserved")
-                self.file_doesnt_contain("etc/pam.conf", "zigit")
-
-                # Should revert to content delivered by overlaying action.
-                self.file_append("etc/pam.conf", "zigit")
-                self.pkg("revert /etc/pam.conf")
-                self.file_contains("etc/pam.conf", "unpreserved")
-                self.file_doesnt_contain("etc/pam.conf", "zigit")
-                self.pkg("uninstall --parsable=0 unpreserved-overlayer")
-                self._assertEditables()
-
-                # Should revert to content delivered by overlaid action.
-                self.file_contains("etc/pam.conf", "unpreserved")
-                self.pkg("revert /etc/pam.conf")
-                self.file_contains("etc/pam.conf", "file1")
-
-                # Install overlaying package, then update overlaid package and
-                # verify that file content does not change if only preserve
-                # attribute changes.
-                self.pkg("install --parsable=0 unpreserved-overlayer")
-                self._assertEditables(
-                    installed=["etc/pam.conf"],
-                )
-                self.file_contains("etc/pam.conf", "unpreserved")
-                self.pkg("install --parsable=0 overlaid@1")
-                self._assertEditables()
-                self.file_contains("etc/pam.conf", "unpreserved")
-                self.pkg("uninstall --parsable=0 overlaid")
-                self._assertEditables()
-
-                # Now update overlaid package again, and verify that file
-                # content does not change even though overlaid content has.
-                self.pkg("install --parsable=0 overlaid@2")
-                self._assertEditables()
-                self.file_contains("etc/pam.conf", "unpreserved")
-
-                # Now update overlaid package again this time as part of a
-                # rename, and verify that file content does not change even
-                # though file has moved between packages.
-                self.pkg("install --parsable=0 overlaid@3")
-                self._assertEditables()
-                self.file_contains("etc/pam.conf", "unpreserved")
-
-                # Verify that unpreserved overlay is not salvaged when both
-                # overlaid and overlaying package are removed at the same time.
-                # (Preserved files are salvaged if they have been modified on
-                # uninstall.)
-
-                # Ensure directory is empty before testing.
-                api_inst = self.get_img_api_obj()
-                img_inst = api_inst.img
-                sroot = os.path.join(img_inst.imgdir, "lost+found")
-                shutil.rmtree(sroot)
-
-                # Verify etc directory not found after uninstall.
-                self.pkg("uninstall --parsable=0 overlaid-renamed "
-                    "unpreserved-overlayer")
-                self._assertEditables(
-                    removed=['etc/pam.conf'],
-                )
-                salvaged = [
-                    n for n in os.listdir(sroot)
-                    if n.startswith("etc")
-                ]
-                self.assertEqualDiff(salvaged, [])
-
-                # Next, update overlaid package again this time as part of a
-                # file move.  Verify that the configuration file exists at both
-                # the new location and the old location, that the content has
-                # not changed in either, and that the new configuration exists
-                # as expected as ".new".
-                self.pkg("install --parsable=0 overlaid-renamed@3 "
-                    "unpreserved-overlayer")
-                self._assertEditables(
-                    installed=['etc/pam.conf'],
-                )
-                self.pkg("install -nvv overlaid-renamed@4.1")
-                self.pkg("install --parsable=0 overlaid-renamed@4.1")
-                self._assertEditables(
-                    moved=[['etc/pam.conf', 'etc/pam/pam.conf']],
-                    installed=['etc/pam/pam.conf.new'],
-                )
-                self.file_contains("etc/pam.conf", "unpreserved")
-                self.file_contains("etc/pam/pam.conf", "unpreserved")
-                self.file_contains("etc/pam/pam.conf.new", "file4")
-
-                # Verify etc/pam.conf not salvaged after uninstall as overlay
-                # file has not been changed.
-                self.pkg("uninstall --parsable=0 overlaid-renamed "
-                    "unpreserved-overlayer")
-                self._assertEditables(
-                    removed=['etc/pam.conf', 'etc/pam/pam.conf'],
-                )
-                salvaged = [
-                    n for n in os.listdir(os.path.join(sroot, "etc"))
-                    if n.startswith("pam.conf")
-                ]
-                self.assertEqualDiff(salvaged, [])
-
-                # Next, repeat the same set of tests performed above for renames
-                # and moves with an overlaying, preserved file.
-                #
-                # Install overlaying package, then update overlaid package and
-                # verify that file content does not change if only preserve
-                # attribute changes.
-                self.pkg("install --parsable=0 overlayer")
-                self._assertEditables(
-                    installed=['etc/pam.conf'],
-                )
-                self.file_contains("etc/pam.conf", "file2")
-                self.file_append("etc/pam.conf", "zigit")
-                self.pkg("install --parsable=0 overlaid@1")
-                self._assertEditables()
-                self.file_contains("etc/pam.conf", "zigit")
-                self.pkg("uninstall --parsable=0 overlaid")
-                self._assertEditables()
-
-                # Now update overlaid package again, and verify that file
-                # content does not change even though overlaid content has.
-                self.pkg("install --parsable=0 overlaid@2")
-                self._assertEditables()
-                self.file_contains("etc/pam.conf", "zigit")
-
-                # Now update overlaid package again this time as part of a
-                # rename, and verify that file content does not change even
-                # though file has moved between packages.
-                self.pkg("install --parsable=0 overlaid@3")
-                self._assertEditables()
-                self.file_contains("etc/pam.conf", "zigit")
-
-                # Verify that preserved overlay is salvaged when both overlaid
-                # and overlaying package are removed at the same time.
-                # (Preserved files are salvaged if they have been modified on
-                # uninstall.)
-
-                # Ensure directory is empty before testing.
-                api_inst = self.get_img_api_obj()
-                img_inst = api_inst.img
-                sroot = os.path.join(img_inst.imgdir, "lost+found")
-                shutil.rmtree(sroot)
-
-                # Verify etc directory found after uninstall.
-                self.pkg("uninstall --parsable=0 overlaid-renamed overlayer")
-                self._assertEditables(
-                    removed=['etc/pam.conf'],
-                )
-                salvaged = [
-                    n for n in os.listdir(sroot)
-                    if n.startswith("etc")
-                ]
-                self.assertEqualDiff(salvaged, ["etc"])
-
-                # Next, update overlaid package again, this time as part of a
-                # file move where the overlay attribute was dropped.  Verify
-                # that the configuration file exists at both the new location
-                # and the old location, that the content has not changed in
-                # either, and that the new configuration exists as expected as
-                # ".new".
-                self.pkg("install --parsable=0 overlaid-renamed@3 overlayer")
-                self._assertEditables(
-                    installed=['etc/pam.conf'],
-                )
-                self.file_append("etc/pam.conf", "zigit")
-                self.pkg("install --parsable=0 overlaid-renamed@4.0")
-                self._assertEditables(
-                    moved=[['etc/pam.conf', 'etc/pam/pam.conf']],
-                    installed=['etc/pam/pam.conf.new'],
-                )
-                self.file_contains("etc/pam.conf", "zigit")
-                self.file_contains("etc/pam/pam.conf", "zigit")
-                self.file_contains("etc/pam/pam.conf.new", "file4")
-                self.pkg("uninstall --parsable=0 overlaid-renamed overlayer")
-                self._assertEditables(
-                    removed=['etc/pam.conf', 'etc/pam/pam.conf'],
-                )
-
-                # Next, update overlaid package again, this time as part of a
-                # file move.  Verify that the configuration file exists at both
-                # the new location and the old location, that the content has
-                # not changed in either, and that the new configuration exists
-                # as expected as ".new".
-                self.pkg("install --parsable=0 overlaid-renamed@3 overlayer")
-                self._assertEditables(
-                    installed=['etc/pam.conf'],
-                )
-                self.file_append("etc/pam.conf", "zigit")
-                self.pkg("install --parsable=0 overlaid-renamed@4.1")
-                self._assertEditables(
-                    moved=[['etc/pam.conf', 'etc/pam/pam.conf']],
-                    installed=['etc/pam/pam.conf.new'],
-                )
-                self.file_contains("etc/pam.conf", "zigit")
-                self.file_contains("etc/pam/pam.conf", "zigit")
-                self.file_contains("etc/pam/pam.conf.new", "file4")
-
-                # Next, downgrade the package and verify that if an overlaid
-                # file moves back to its original location, the content of the
-                # overlay file will not change.
-                self.pkg("update --parsable=0 overlaid-renamed@3")
-                self._assertEditables(
-                    removed=['etc/pam/pam.conf'],
-                )
-                self.file_contains("etc/pam.conf", "zigit")
-
-                # Now upgrade again for remaining tests.
-                self.pkg("install --parsable=0 overlaid-renamed@4.1")
-                self._assertEditables(
-                    moved=[['etc/pam.conf', 'etc/pam/pam.conf']],
-                    installed=['etc/pam/pam.conf.new'],
-                )
-
-                # Verify etc/pam.conf and etc/pam/pam.conf salvaged after
-                # uninstall as overlay file and overlaid file is different from
-                # packaged.
-                shutil.rmtree(sroot)
-                self.pkg("uninstall --parsable=0 overlaid-renamed overlayer")
-                self._assertEditables(
-                    removed=['etc/pam.conf', 'etc/pam/pam.conf'],
-                )
-                salvaged = sorted(
-                    n for n in os.listdir(os.path.join(sroot, "etc"))
-                    if n.startswith("pam")
-                )
-                # Should have three entries; one should be 'pam' directory
-                # (presumably containing pam.conf-X...), another a file starting
-                # with 'pam.conf', and finally a 'pam-XXX' directory containing
-                # the 'pam.conf.new-XXX'.
-                self.assertEqualDiff(salvaged[0], "pam")
-                self.assertTrue(salvaged[1].startswith("pam-"),
-                    msg=str(salvaged))
-                self.assertTrue(salvaged[2].startswith("pam.conf"),
-                    msg=str(salvaged))
-
-                # Next, install overlaid package and overlaying package, then
-                # upgrade each to a version where the file has changed
-                # locations and verify that the content remains intact.
-                self.pkg("install --parsable=0 overlaid@0 overlayer-move@0")
-                self._assertEditables(
-                    installed=['etc/pam.conf'],
-                )
-                self.file_append("etc/pam.conf", "zigit")
-                self.pkg("install --parsable=0 overlaid@3")
-                self._assertEditables()
-                self.file_contains("etc/pam.conf", "zigit")
-                self.pkg("install --parsable=0 overlaid-renamed@4.1 "
-                    "overlayer-move@1")
-                self._assertEditables(
-                    moved=[['etc/pam.conf', 'etc/pam/pam.conf']],
-                )
-                self.file_contains("etc/pam/pam.conf", "zigit")
-
-                # Next, downgrade overlaid-renamed and overlaying package to
-                # versions where the file is restored to its original location
-                # and verify that the content is reverted to the original
-                # overlay version since this is a downgrade.
-                self.pkg("update --parsable=0 overlaid-renamed@3 "
-                    "overlayer-move@0")
-                self._assertEditables(
-                    removed=['etc/pam/pam.conf'],
-                    installed=['etc/pam.conf'],
-                )
-                self.file_contains("etc/pam.conf", "file2")
-                self.pkg("uninstall --parsable=0 overlaid-renamed overlayer-move")
-                self._assertEditables(
-                    removed=['etc/pam.conf'],
-                )
-
-                # Next, install overlaid package and overlaying package and
-                # verify preserve acts as expected for overlay package as it is
-                # updated.
-                self.pkg("install --parsable=0 overlaid@2 overlayer-update@0")
-                self._assertEditables(
-                    installed=['etc/pam.conf'],
-                )
-                self.file_contains("etc/pam.conf", "file1")
-                # unpreserved -> preserved
-                self.pkg("install --parsable=0 overlayer-update@1")
-                self._assertEditables(
-                    updated=['etc/pam.conf'],
-                )
-                self.file_contains("etc/pam.conf", "file2")
-                self.file_append("etc/pam.conf", "zigit")
-                # preserved -> renameold
-                self.pkg("install --parsable=0 overlayer-update@2")
-                self._assertEditables(
-                    moved=[['etc/pam.conf', 'etc/pam.conf.old']],
-                    installed=['etc/pam.conf'],
-                )
-                self.file_doesnt_contain("etc/pam.conf", "zigit")
-                self.file_contains("etc/pam.conf.old", "zigit")
-                self.file_append("etc/pam.conf", "zagat")
-                # renameold -> renamenew
-                self.pkg("install --parsable=0 overlayer-update@3")
-                self._assertEditables(
-                    installed=['etc/pam.conf.new'],
-                )
-                self.file_contains("etc/pam.conf", "zagat")
-                self.file_contains("etc/pam.conf.new", "file4")
-
-        def test_different_types_install(self):
-                """Test the behavior of pkg(1) when multiple actions of
-                different types deliver to the same pathname."""
-
-                self.image_create(self.rurl)
-
-                # In the same package
-                self.pkg("install duppath-filelink", exit=1)
-
-                # In different packages, in the same transaction
-                self.pkg("install dupfilesp1 duplink", exit=1)
-
-                # In different packages, in different transactions
-                self.pkg("install dupfilesp1")
-                self.pkg("install duplink", exit=1)
-
-                # Does removal of one of the busted packages get us out of the
-                # situation?
-                self.pkg("uninstall '*'")
-                self.pkg("-D broken-conflicting-action-handling=1 install dupfilesp1 duplink")
-                self.pkg("verify", exit=1)
-                self.pkg("uninstall dupfilesp1")
-                self.pkg("verify")
-                self.pkg("-D broken-conflicting-action-handling=1 install dupfilesp1")
-                self.pkg("uninstall duplink")
-                self.pkg("verify")
-
-                # Implicit directory conflicts with a file
-                self.pkg("uninstall '*'")
-                self.pkg("install implicitdirs", exit=1)
-
-                # Implicit directory coincides with a delivered directory
-                self.pkg("install implicitdirs2")
-
-                # Make sure that we don't die trying to fixup a directory using
-                # an implicit directory action.
-                self.pkg("uninstall '*'")
-                self.pkg("install implicitdirs4")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "implicitdirs7")
-                self.pkg("uninstall implicitdirs7")
-                # XXX We don't currently fix up anything beneath a directory
-                # that was restored, so we have to do it by hand.
-                os.mkdir("{0}/usr/bin".format(self.img_path()))
-                shutil.copy("{0}/tmp/file1".format(self.test_root),
-                    "{0}/usr/bin/something".format(self.img_path()))
-                owner = portable.get_user_by_name("root", self.img_path(), True)
-                group = portable.get_group_by_name("bin", self.img_path(), True)
-                os.chown("{0}/usr/bin/something".format(self.img_path()), owner, group)
-                os.chmod("{0}/usr/bin/something".format(self.img_path()), 0o755)
-                self.pkg("verify")
-
-                # Removing one of more than two offending actions can't do much
-                # of anything, but should leave the system alone.
-                self.pkg("uninstall '*'")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupfilesp1 duplink dupdir@0")
-                tmap = {
-                    stat.S_IFIFO: "fifo",
-                    stat.S_IFCHR: "character device",
-                    stat.S_IFDIR: "directory",
-                    stat.S_IFBLK: "block device",
-                    stat.S_IFREG: "regular file",
-                    stat.S_IFLNK: "symbolic link",
-                    stat.S_IFSOCK: "socket",
-                }
-                thepath = "{0}/dir/pathname".format(self.img_path())
-                fmt = stat.S_IFMT(os.lstat(thepath).st_mode)
-                # XXX The checks here rely on verify failing due to action types
-                # not matching what's on the system; they should probably report
-                # duplicate actions instead.  Checking the output text is a bit
-                # ugly, too, but we do need to make sure that the two problems
-                # become one.
-                self.pkg("verify", exit=1)
-                verify_type_re = "file type: '(.*?)' should be '(.*?)'"
-                matches = re.findall(verify_type_re, self.output)
-                # We make sure that what got reported is correct -- two actions
-                # of different types in conflict with whatever actually got laid
-                # down.
-                self.assertTrue(len(matches) == 2)
-                whatis = matches[0][0]
-                self.assertTrue(matches[1][0] == whatis)
-                self.assertTrue(whatis == tmap[fmt])
-                shouldbe = set(["symbolic link", "regular file", "directory"]) - \
-                    set([whatis])
-                self.assertTrue(set([matches[0][1], matches[1][1]]) == shouldbe)
-                # Now we uninstall one of the packages delivering a type which
-                # isn't what's on the filesystem.  The filesystem should remain
-                # unchanged, but one of the errors should go away.
-                if whatis == "directory":
-                        self.pkg("uninstall duplink")
-                else:
-                        self.pkg("uninstall dupdir")
-                self.pkg("verify", exit=1)
-                matches = re.findall(verify_type_re, self.output)
-                self.assertTrue(len(matches) == 1)
-                nfmt = stat.S_IFMT(os.lstat(thepath).st_mode)
-                self.assertTrue(nfmt == fmt)
-
-                # Now we do the same thing, but we uninstall the package
-                # delivering the type which *is* what's on the filesystem.  This
-                # should also leave the filesystem alone, even though what's
-                # there will match *neither* of the remaining installed
-                # packages.
-                self.pkg("uninstall '*'")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupfilesp1 duplink dupdir@0")
-                fmt = stat.S_IFMT(os.lstat(thepath).st_mode)
-                self.pkg("verify", exit=1)
-                matches = re.findall(verify_type_re, self.output)
-                self.assertTrue(len(matches) == 2)
-                whatis = matches[0][0]
-                self.assertTrue(matches[1][0] == whatis)
-                self.assertTrue(whatis == tmap[fmt])
-                shouldbe = set(["symbolic link", "regular file", "directory"]) - \
-                    set([whatis])
-                self.assertTrue(set([matches[0][1], matches[1][1]]) == shouldbe)
-                if whatis == "directory":
-                        self.pkg("uninstall dupdir")
-                elif whatis == "symbolic link":
-                        self.pkg("uninstall duplink")
-                elif whatis == "regular file":
-                        self.pkg("uninstall dupfilesp1")
-                self.pkg("verify", exit=1)
-                matches = re.findall(verify_type_re, self.output)
-                self.assertTrue(len(matches) == 2)
-                nfmt = stat.S_IFMT(os.lstat(thepath).st_mode)
-                self.assertTrue(nfmt == fmt)
-
-                # Go from multiple conflicting types down to just one type.
-                # This also tests the case where a package version being newly
-                # installed gets fixed at the same time.
-                self.pkg("uninstall '*'")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupmultitypes@1")
-                self.pkg("install dupmultitypes")
-                self.pkg("verify")
-
-                # Upgrading from multiple instances of one refcounted type to
-                # multiple instances of another (here, link to directory) should
-                # succeed.
-                self.pkg("uninstall '*'")
-                self.pkg("install dupmultitypes3@0")
-                self.pkg("update")
-
-        def test_conflicting_attrs_fs_install(self):
-                """Test the behavior of pkg(1) when multiple non-file actions of
-                the same type deliver to the same pathname, but whose other
-                attributes differ."""
-
-                self.image_create(self.rurl)
-
-                # One package, two links with different targets
-                self.pkg("install duppath-nonidenticallinks", exit=1)
-
-                # One package, two directories with different perms
-                self.pkg("install duppath-nonidenticaldirs", exit=1)
-
-                # One package, two dirs with same modes expressed two ways
-                self.pkg("install duppath-almostidenticaldirs")
-
-                # One package delivers a directory explicitly, another
-                # implicitly.
-                self.pkg("install implicitdirs2 implicitdirs3")
-                self.pkg("verify")
-
-                self.pkg("uninstall '*'")
-
-                # Make sure that we don't die trying to fixup a directory using
-                # an implicit directory action.
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "implicitdirs4 implicitdirs5 implicitdirs6")
-                self.pkg("uninstall implicitdirs5")
-                self.pkg("verify")
-
-                self.pkg("uninstall '*'")
-
-                # Make sure that we don't die trying to fixup a directory using
-                # an implicit directory action when that's all that's left.
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "implicitdirs4 implicitdirs5 implicitdirs6")
-                self.pkg("uninstall implicitdirs5 implicitdirs6")
-                self.pkg("verify")
-
-                self.pkg("uninstall '*'")
-
-                # If two packages deliver conflicting directories and another
-                # package delivers that directory implicitly, make sure the
-                # third package isn't blamed.
-                self.pkg("install implicitdirs4 implicitdirs5 implicitdirs6",
-                    exit=1)
-                self.assertTrue("implicitdirs4" not in self.errout)
-
-                # Two packages, two links with different targets, installed at
-                # once
-                self.pkg("install duppath-nonidenticallinksp1 "
-                    "duppath-nonidenticallinksp2@0", exit=1)
-
-                # Two packages, two links with different targets, installed
-                # separately
-                self.pkg("install duppath-nonidenticallinksp1")
-                self.pkg("install duppath-nonidenticallinksp2@0", exit=1)
-
-                self.pkg("uninstall '*'")
-
-                # If we get into a broken state, can we get out of it?
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "duppath-nonidenticallinksp1 duppath-nonidenticallinksp2@0")
-                self.pkg("verify", exit=1)
-                self.pkg("install duppath-nonidenticallinksp2")
-                self.pkg("verify")
-
-                # If we get into a broken state, can we make it a little bit
-                # better by uninstalling one of the packages?  Removing dupdir5
-                # here won't reduce the number of different groups under which
-                # dir is delivered, but does reduce the number of actions
-                # delivering it.
-                self.pkg("uninstall '*'")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupdirp1 dupdirp2@1 dupdirp5 dupdirp6")
-                self.pkg("uninstall dupdirp5")
-                self.pkg("verify", exit=1)
-
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupdirp5")
-                # Make sure we can install a package delivering an implicit
-                # directory that's currently in conflict.
-                self.pkg("install dupdirp7")
-                # And make sure we can uninstall it again.
-                self.pkg("uninstall dupdirp7")
-
-                # Removing the remaining conflicts in a couple of steps should
-                # result in a verifiable system.
-                self.pkg("uninstall dupdirp2")
-                self.pkg("uninstall dupdirp5 dupdirp6")
-                self.pkg("verify")
-
-                # Add everything back in, remove everything but one variant of
-                # the directory and an implicit directory, and verify.
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupdirp2@1 dupdirp5 dupdirp6 dupdirp7")
-                self.pkg("uninstall dupdirp2 dupdirp5 dupdirp6")
-                self.pkg("verify")
-
-                # Get us into a saner state by upgrading.
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupdirp2@1 dupdirp5 dupdirp6")
-                self.pkg("update dupdirp2@2")
-
-                # Get us into a sane state by upgrading.
-                self.pkg("uninstall dupdirp2 dupdirp5 dupdirp6")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupdirp2@1")
-                self.pkg("update dupdirp2@2")
-                self.pkg("verify")
-
-                # We start in a sane state, but the update would result in
-                # conflict, though no more actions deliver the path in
-                # question.
-                self.pkg("uninstall '*'")
-                self.pkg("install dupdirp1 dupdirp8@1")
-                self.pkg("update", exit=1)
-
-                # How about removing one of the conflicting packages?  We'll
-                # remove the package which doesn't match the state on disk.
-                self.pkg("uninstall '*'")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "duppath-nonidenticallinksp1 duppath-nonidenticallinksp2@0")
-                link = os.readlink("{0}/dir/pathname".format(self.img_path()))
-                if link == "dir/something":
-                        self.pkg("uninstall duppath-nonidenticallinksp2")
-                else:
-                        self.pkg("uninstall duppath-nonidenticallinksp1")
-                self.pkg("verify")
-
-                # Now we'll try removing the package which *does* match the
-                # state on disk.  The code should clean up after us.
-                self.pkg("uninstall '*'")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "duppath-nonidenticallinksp1 duppath-nonidenticallinksp2@0")
-                link = os.readlink("{0}/dir/pathname".format(self.img_path()))
-                if link == "dir/something":
-                        self.pkg("uninstall duppath-nonidenticallinksp1")
-                else:
-                        self.pkg("uninstall duppath-nonidenticallinksp2")
-                self.pkg("verify")
-
-                # Let's try a duplicate directory delivered with all sorts of
-                # crazy conflicts!
-                self.pkg("uninstall '*'")
-                self.pkg("install dupdirp1 dupdirp2@1 dupdirp3 dupdirp4", exit=1)
-
-                pkgs = " ".join("massivedupdir{0:d}".format(x) for x in range(20))
-                self.pkg("install {0}".format(pkgs), exit=1)
-
-                # Trigger bug 17943: we install packages with conflicts in two
-                # directories (p9, p10).  We also install a package (p11) which
-                # delivers those directories implicitly.  Then remove the last,
-                # triggering the stack trace associated with the bug.
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupdirp9 dupdirp10 dupdirp11")
-                self.pkg("uninstall dupdirp11")
-
-                # Do the same, but with a package that delivers var implicitly
-                # via a legacy action.
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupdirp12")
-                self.pkg("uninstall dupdirp12")
-
-        def test_conflicting_attrs_fs_varcets(self):
-                """Test the behavior of pkg(1) when multiple non-file actions of
-                the same type deliver to the same pathname, but differ in their
-                variants or facets."""
-
-                install_cmd = "install"
-                self.image_create(self.rurl)
-
-                # Two packages delivering the same directory, one under the
-                # current architecture, the other not tagged with an arch
-                # variant.
-                self.pkg("{0} dupfilesv1 dupfilesv2".format(install_cmd))
-                self.dir_exists("dir/pathname")
-
-                # Two packages delivering the same directory with different
-                # attributes -- one under the current architecture, the other
-                # tagged with another arch variant.
-                self.pkg("uninstall '*'")
-                self.pkg("{0} dupfilesv1 dupfilesv3".format(install_cmd))
-                if platform.processor() == "sparc":
-                        self.dir_exists("dir/pathname", mode=0o777)
-                else:
-                        self.dir_exists("dir/pathname", mode=0o755)
-
-                # Two packages delivering a file at the same path where one is
-                # tagged only for non-global zones should install successfully
-                # together in a global zone.
-                self.pkg("uninstall '*'")
-                self.pkg("{0} dupfilesv5 dupfilesv6".format(install_cmd))
-                path = os.path.join(self.get_img_path(), "dir/pathname")
-                try:
-                        f = open(path)
-                except OSError as e:
-                        if e.errno == errno.ENOENT:
-                                self.assertTrue(False, "File dir/pathname does not exist")
-                        else:
-                                raise
-                self.assertEqual(f.read().rstrip(), "tmp/file2")
-                f.close()
-
-                # Two packages delivering the same directory, one with the
-                # devel facet false, the other true.
-                self.pkg("uninstall '*'")
-                self.pkg("{0} dupfilesf1 dupfilesf2".format(install_cmd))
-                self.dir_exists("dir/pathname")
-
-                # Two packages delivering the same directory, one with the
-                # devel facet true, the other without.
-                self.pkg("uninstall '*'")
-                self.pkg("{0} dupfilesf1 dupfilesf3".format(install_cmd))
-                self.dir_exists("dir/pathname")
-
-                # Two packages delivering the same directory, one with the
-                # devel facet false, the other without.
-                self.pkg("uninstall '*'")
-                self.pkg("{0} dupfilesf2 dupfilesf3".format(install_cmd))
-                self.dir_exists("dir/pathname")
-
-        def test_conflicting_uninstall_publisher(self):
-                """Test the behaviour of pkg(1) when attempting to remove
-                conflicting packages from a publisher which has also been
-                removed."""
-
-                self.conflicting_uninstall_publisher_helper("install")
-                self.conflicting_uninstall_publisher_helper("exact-install")
-
-        def conflicting_uninstall_publisher_helper(self, install_cmd):
-                self.image_create(self.rurl)
-                # Dummy publisher so test publisher can be removed.
-                self.pkg("set-publisher -P ignored")
-
-                # If packages with conflicting actions are found during
-                # uninstall, and the publisher of the package has been
-                # removed, uninstall should still succeed.
-                self.pkg("-D broken-conflicting-action-handling=1 {0} "
-                    "dupdirp1 dupdirp2@1".format(install_cmd))
-                self.pkg("unset-publisher test")
-                self.pkg("uninstall dupdirp2")
-                self.pkg("verify")
-
-        def test_change_varcet(self):
-                """Test the behavior of pkg(1) when changing a variant or a
-                facet would cause the new image to contain conflicting
-                actions."""
-
-                # Create the image as an x86 image, as the first test only works
-                # changing variant from x86 to sparc.
-                self.image_create(self.rurl, variants={"variant.arch": "i386"})
-
-                # The x86 variant is safe, but the sparc variant has two files
-                # with the same pathname.
-                self.pkg("install dupfilesv4")
-                self.pkg("change-variant arch=sparc", exit=1)
-
-                # With the devel facet turned off, the package is safe, but
-                # turning it on would cause a duplicate file to be added.
-                self.pkg("change-facet devel=false")
-                self.pkg("install dupfilesf4")
-                self.pkg("change-facet devel=true", exit=1)
-
-        def test_change_variant_removes_package(self):
-                """Test that a change-variant that removes a package and
-                improves but doesn't fix a conflicting action situation is
-                allowed."""
-
-                self.image_create(self.rurl, variants={"variant.foo": "one"})
-                self.pkg("install tripledupfileb")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "tripledupfilec")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "tripledupfilea")
-                self.pkg("change-variant -vvv variant.foo=two")
-                self.pkg("change-variant -vvv variant.foo=one", exit=1)
-
-        def test_multiple_users_install(self):
-                """Test the behavior of pkg(1) when multiple user actions
-                deliver the same user."""
-
-                # This is largely identical to test_multiple_files; we may want
-                # to commonize in the future.
-
-                self.image_create(self.rurl)
-
-                self.pkg("install userdb")
-
-                # Duplicate users in the same package
-                self.pkg("install dupuser", exit=1)
-
-                # Duplicate users in different packages, but in the same
-                # transaction
-                self.pkg("install dupuserp1 dupuserp2@0", exit=1)
-
-                # Duplicate users in different packages, in different
-                # transactions
-                self.pkg("install dupuserp1")
-                self.pkg("install dupuserp2@0", exit=1)
-
-                # Test that being in a duplicate user situation doesn't break
-                # you completely and allows you to add and remove other packages
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupuserp2@0")
-                self.pkg("verify", exit=1)
-                self.pkg("install otheruser")
-                self.file_contains("etc/passwd", "fozzie")
-                self.file_contains("etc/shadow", "fozzie")
-                self.pkg("uninstall otheruser")
-                self.file_doesnt_contain("etc/passwd", "fozzie")
-                self.file_doesnt_contain("etc/shadow", "fozzie")
-                self.pkg("verify", exit=1)
-
-                # If the packages involved get upgraded but leave the actions
-                # themselves alone, we should be okay.
-                self.pkg("install dupuserp2 dupuserp3")
-                self.file_contains("etc/passwd", "kermit")
-                self.file_contains("etc/shadow", "kermit")
-                self.pkg("verify", exit=1)
-
-                # Test that removing one of two offending actions reverts the
-                # system to a clean state.
-                self.pkg("uninstall dupuserp3")
-                self.file_contains("etc/passwd", "kermit")
-                self.file_contains("etc/shadow", "kermit")
-                self.pkg("verify")
-
-                # You should be able to upgrade to a fixed set of packages in
-                # order to move past the problem, too.
-                self.pkg("uninstall dupuserp2")
-                self.file_contains("etc/passwd", "kermit")
-                self.file_contains("etc/shadow", "kermit")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupuserp2@0")
-                self.pkg("update")
-                self.pkg("verify")
-                self.file_contains("etc/passwd", "kermit")
-                self.file_contains("etc/shadow", "kermit")
-
-                # If we upgrade to a version of a conflicting package that no
-                # longer has the conflict, but at the same time introduce a new
-                # conflicting user action, we should fail.
-                self.pkg("uninstall dupuserp2")
-                self.file_contains("etc/passwd", "kermit")
-                self.file_contains("etc/shadow", "kermit")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupuserp2@0")
-                self.pkg("install dupuserp2 dupuserp4", exit=1)
-
-                # Removing one of more than two offending actions can't do much
-                # of anything, but should leave the system alone.
-                self.image_destroy()
-                self.image_create(self.rurl)
-                self.pkg("install userdb")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupuserp1 dupuserp2@0 dupuserp3")
-                self.pkg("verify", exit=1)
-                self.file_contains("etc/passwd", "kermit")
-                self.file_contains("etc/shadow", "kermit")
-                out1 = self.output
-                self.pkg("uninstall dupuserp3")
-                self.file_contains("etc/passwd", "kermit")
-                self.file_contains("etc/shadow", "kermit")
-                self.pkg("verify", exit=1)
-                out2 = self.output
-                out2 = out2[out2.index("STATUS\n") + 7:]
-                self.assertTrue(out2 in out1)
-
-                # Removing all but one of the offending actions should get us
-                # back to sanity.
-                self.image_destroy()
-                self.image_create(self.rurl)
-                self.pkg("install userdb")
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "dupuserp1 dupuserp2@0 dupuserp3")
-                self.file_contains("etc/passwd", "kermit")
-                self.file_contains("etc/shadow", "kermit")
-                self.pkg("uninstall dupuserp3 dupuserp2")
-                self.file_contains("etc/passwd", "kermit")
-                self.file_contains("etc/shadow", "kermit")
-                self.pkg("verify")
-
-                # Make sure we don't get confused when two actions in different
-                # namespace groups but with the same key attribute value are
-                # adjacent in the action cache.
-                self.pkg("-D broken-conflicting-action-handling=1 install "
-                    "otheruser othergroup@0")
-                self.pkg("update othergroup")
-
-        def test_multiple_drivers(self):
-                """Test the behavior of pkg(1) when multiple driver actions
-                deliver the same driver."""
-
-                self.multiple_drivers_helper("install")
-                self.multiple_drivers_helper("exact-install")
-
-        def multiple_drivers_helper(self, install_cmd):
-                self.image_create(self.rurl)
-
-                self.pkg("{0} driverdb".format(install_cmd))
-
-                self.pkg("{0} dupdriver".format(install_cmd), exit=1)
-
-        def test_multiple_depend(self):
-                """Test to make sure we can have multiple depend actions on
-                (more or less) the same fmri"""
-
-                self.multiple_depend_helper("install")
-                self.multiple_depend_helper("exact-install")
-
-        def multiple_depend_helper(self, install_cmd):
-                self.image_create(self.rurl)
-
-                # Two identical unversioned require dependencies
-                self.pkg("{0} dupdepend1".format(install_cmd))
-
-                # Two dependencies of different types on an identical
-                # unversioned fmri
-                self.pkg("{0} dupdepend2".format(install_cmd))
-
-                # Two identical versioned require dependencies
-                self.pkg("{0} dupdepend3".format(install_cmd))
-
-                # Two dependencies of different types on an identical versioned
-                # fmri
-                self.pkg("{0} dupdepend4".format(install_cmd))
-
-        def test_varianted_types(self):
-                """Test that actions which would otherwise conflict but are
-                delivered under different variants don't conflict."""
-
-                self.varianted_types_helper("install")
-                self.varianted_types_helper("exact-install")
-
-        def varianted_types_helper(self, install_cmd):
-                self.pkg_image_create(repourl=self.rurl,
-                    additional_args="--variant foo=one")
-                self.pkg("{0} vpath".format(install_cmd))
+                        """.format(
+                i
+            )
+
+            if i == 14:
+                s = s.format("root", "0750", "zag")
+            elif i in (1, 9):
+                s = s.format("sys", "0750", "zag")
+            elif i in (3, 8, 12, 17):
+                s = s.format("root", "0755", "zag")
+            else:
+                s = s.format("sys", "0755", "zig")
+
+            pkgs.append(s)
+
+        self.plist = self.pkgsend_bulk(self.rurl, pkgs)
+
+    def test_conflictgroupid_install(self):
+        """Test conflict group IDs will not cause user action failure."""
+
+        self.image_create(self.rurl)
+
+        self.pkg("install userdb")
+        self.pkg("install conflictgroup1")
+        with open(os.path.join(self.img_path(), "etc/group")) as f:
+            lines = f.readlines()
+        for line in lines:
+            if "fozzie" in line:
+                self.assertTrue("200" in line)
+                break
+        with open(os.path.join(self.img_path(), "etc/passwd")) as f:
+            lines = f.readlines()
+        for line in lines:
+            if "fozzie" in line:
+                self.assertTrue("200" in line)
+                break
+        self.pkg("install -v --reject conflictgroup1 conflictgroup2")
+
+        self.pkg("list conflictgroup1", exit=1)
+        self.pkg("list conflictgroup2")
+        with open(os.path.join(self.img_path(), "etc/passwd")) as f:
+            lines = f.readlines()
+        for line in lines:
+            if "fozzie" in line:
+                self.assertTrue("201" in line)
+                break
+        with open(os.path.join(self.img_path(), "etc/group")) as f:
+            lines = f.readlines()
+        for line in lines:
+            if "fozzie" in line:
+                self.assertTrue("201" in line)
+                break
+        self.pkg("verify")
+
+    def test_multiple_files_install(self):
+        """Test the behavior of pkg(1) when multiple file actions
+        deliver to the same pathname."""
+
+        self.image_create(self.rurl)
+
+        # Duplicate files in the same package
+        self.pkg("install dupfiles", exit=1)
+
+        # Duplicate files in different packages, but in the same
+        # transaction
+        self.pkg("install dupfilesp1 dupfilesp2@0", exit=1)
+
+        # Duplicate files in different packages, in different
+        # transactions
+        self.pkg("install dupfilesp1")
+        self.pkg("install dupfilesp2@0", exit=1)
+
+        # Test that being in a duplicate file situation doesn't break
+        # you completely and allows you to add and remove other packages
+        self.pkg("-D broken-conflicting-action-handling=1 install dupfilesp2@0")
+        self.pkg("install implicitdirs2")
+        self.pkg("uninstall implicitdirs2")
+
+        # If the packages involved get upgraded but leave the actions
+        # themselves alone, we should be okay.
+        self.pkg("install dupfilesp2 dupfilesp3")
+        self.pkg("verify", exit=1)
+
+        # Test that removing one of two offending actions reverts the
+        # system to a clean state.
+        self.pkg("uninstall dupfilesp3")
+        self.pkg("verify")
+
+        # You should be able to upgrade to a fixed set of packages in
+        # order to move past the problem, too.
+        self.pkg("uninstall dupfilesp2")
+        self.pkg("-D broken-conflicting-action-handling=1 install dupfilesp2@0")
+        self.pkg("update")
+        self.pkg("verify")
+
+        # If we upgrade to a version of a conflicting package that no
+        # longer has the conflict, but at the same time introduce a new
+        # file action at the path with different contents, we should
+        # fail.
+        self.pkg("uninstall dupfilesp2")
+        self.pkg("-D broken-conflicting-action-handling=1 install dupfilesp2@0")
+        self.pkg("install dupfilesp2 dupfilesp4", exit=1)
+
+        # Removing one of more than two offending actions can't do much
+        # of anything, but should leave the system alone.
+        self.pkg("uninstall '*'")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupfilesp1 dupfilesp2@0 dupfilesp3"
+        )
+        # Verify should report a duplicate action error on dupfilesp1,
+        # dupfilesp2 and dupfilesp3 and shouldn't report it was failing
+        # due to hashes being wrong.
+        self.pkg("verify", exit=1)
+        out1, err1 = self.output, self.errout
+        for i, l in enumerate(self.plist):
+            if l.startswith("pkg://test/dupfilesp1"):
+                index = i
+        self.assertTrue(self.plist[index] in err1, err1)
+        self.assertTrue(self.plist[index + 1] in err1, err1)
+        self.assertTrue(self.plist[index + 3] in err1, err1)
+        self.assertTrue("Hash" not in out1)
+        self.pkg("uninstall dupfilesp3")
+        # Removing dupfilesp3, verify should still report a duplicate
+        # action error on dupfilesp1 and dupfilesp2.
+        self.pkg("verify", exit=1)
+        out2, err2 = self.output, self.errout
+        expected = "\n  {0}\n  {1}".format(
+            self.plist[index], self.plist[index + 1]
+        )
+        self.assertTrue(expected in err2)
+        self.assertTrue("Hash" not in out2)
+
+        # Removing all but one of the offending actions should get us
+        # back to sanity.
+        self.pkg("uninstall '*'")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupfilesp1 dupfilesp2@0 dupfilesp3"
+        )
+        self.pkg("uninstall dupfilesp3 dupfilesp2")
+        self.pkg("verify")
+
+        # Make sure we handle cleaning up multiple files properly.
+        self.pkg("uninstall '*'")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupfilesp1 dupfilesp2@0 dupotherfilesp1 dupotherfilesp2"
+        )
+        self.pkg("uninstall dupfilesp2 dupotherfilesp2")
+        self.pkg("verify")
+
+        # Re-use the overlay packages for some preserve testing.
+        self.pkg("install overlaid@0")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "invalid-overlayer"
+        )
+        # We may have been able to lay down the package, but because the
+        # file is marked preserve=true, we didn't actually overwrite
+        self.file_contains("etc/pam.conf", "file2")
+        self.pkg("uninstall invalid-overlayer")
+        self.file_contains("etc/pam.conf", "file2")
+
+        # Make sure we get rid of all implicit directories.
+        self.pkg("uninstall '*'")
+        self.pkg("install implicitdirs3 implicitdirs4")
+        self.pkg("uninstall implicitdirs3 implicitdirs4")
+
+        if os.path.isdir(os.path.join(self.get_img_path(), "usr/bin")):
+            self.assertTrue(False, "Directory 'usr/bin' should not exist")
+
+        if os.path.isdir(os.path.join(self.get_img_path(), "usr")):
+            self.assertTrue(False, "Directory 'usr' should not exist")
+
+        # Make sure identical actions don't cause problems
+        self.pkg("install -nv identicalfiles", exit=1)
+
+        # Trigger a bug similar to 17943 via duplicate files.
+        self.pkg("publisher")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupfilesp1@0 dupfilesp2@0 dupfilesp3@0 dupotherfilesp1@0 "
+            "dupotherfilesp2@0 dupotherfilesp3@0"
+        )
+        self.pkg("update")
+
+        # If an uninstall causes a fixup to happen and we can't because
+        # we lost the cached files and the repo is down, make sure we
+        # fail before actually uninstalling anything.
+        self.dc.start()
+        self.pkgsend_bulk(self.durl, (self.pkgremote_pkg1, self.pkgremote_pkg2))
+        self.image_create(self.durl)
+        self.pkg("install pkg1")
+        self.pkg("-D broken-conflicting-action-handling=1 install pkg2")
+        self.pkg("verify pkg2")
+        self.dc.stop()
+        self.pkg("uninstall pkg2", exit=1)
+        self.pkg("verify pkg2")
+
+    def __check_overlay_install(self, overlaid, overlayer, exit=0):
+        self.image_create(self.rurl)
+        self.pkg("install {0}".format(overlaid))
+        self.file_append("etc/pam.conf", "zigit")
+        self.pkg("install {0}".format(overlayer), exit=exit)
+        # If exit == 0, the file has been overlaid.
+        if exit == 0:
+            self.file_doesnt_contain("etc/pam.conf", "zigit")
+        else:
+            self.file_contains("etc/pam.conf", "zigit")
+
+    def test_mismatch_overlay_files_install(self):
+        """Test overlay attributes mismatch."""
+
+        # Test all combo of overlay-attributes on overlaid and
+        # overlayer packages.
+        self.__check_overlay_install(
+            "overlaid-attr-deny@0", "mismatch-overlayer@0", exit=1
+        )
+        self.__check_overlay_install(
+            "overlaid-attr-deny@0", "mismatch-overlayer-allow@0", exit=1
+        )
+        self.__check_overlay_install(
+            "overlaid-attr-deny@0", "mismatch-overlayer-deny@0", exit=1
+        )
+
+        self.__check_overlay_install(
+            "overlaid-no-attr@0", "mismatch-overlayer@0", exit=0
+        )
+        self.__check_overlay_install(
+            "overlaid-no-attr@0", "mismatch-overlayer-allow@0", exit=0
+        )
+        self.__check_overlay_install(
+            "overlaid-no-attr@0", "mismatch-overlayer-deny@0", exit=1
+        )
+
+        self.__check_overlay_install(
+            "overlaid-attr-allow@0", "mismatch-overlayer@0", exit=0
+        )
+        self.__check_overlay_install(
+            "overlaid-attr-allow@0", "mismatch-overlayer-allow@0", exit=0
+        )
+        self.__check_overlay_install(
+            "overlaid-attr-allow@0", "mismatch-overlayer-deny@0", exit=1
+        )
+
+    def test_overlay_files_install(self):
+        """Test the behaviour of pkg(1) when actions for editable files
+        overlay other actions."""
+
+        # Ensure that overlay is allowed for file actions when one
+        # action has specified preserve attribute and overlay=allow,
+        # and *one* (only) other action has specified overlay=true
+        # (preserve does not have to be set).
+        self.image_create(self.rurl)
+
+        # Ensure boring package is installed as conflict checking is
+        # bypassed (and thus, overlay semantics) if all packages are
+        # removed from an image.
+        self.pkg("install boring")
+
+        # Should fail because one action specified overlay=allow,
+        # but not preserve (it isn't editable).
+        self.pkg("install invalid-overlaid")
+        self.pkg("install overlayer", exit=1)
+        self.pkg("uninstall invalid-overlaid")
+
+        # Should fail because one action is overlayable but overlaying
+        # action doesn't declare its intent to overlay.
+        self.pkg("install overlaid@0")
+        self.file_contains("etc/pam.conf", "file1")
+        self.pkg("install invalid-overlayer", exit=1)
+
+        # Should succeed because no overlay-attributes='deny' present
+        # on either action.
+        self.pkg("install mismatch-overlayer")
+        # Uninstall it to not affect the subsequent tests.
+        self.pkg("uninstall mismatch-overlayer")
+
+        # Should succeed because one action is overlayable and
+        # overlaying action declares its intent to overlay.
+        self.pkg("contents -m overlaid")
+        self.pkg("contents -mr overlayer")
+        self.pkg("install --parsable=0 overlayer")
+        self._assertEditables(
+            installed=["etc/pam.conf"],
+        )
+        self.file_contains("etc/pam.conf", "file2")
+
+        # Should fail because multiple actions are not allowed to
+        # overlay a single action.
+        self.pkg("install multi-overlayer", exit=1)
+
+        # Should succeed even though file is different than originally
+        # delivered since original package permits file modification.
+        self.pkg("verify overlaid overlayer")
+
+        # Should succeed because package delivering overlayable file
+        # permits modification and because package delivering overlay
+        # file permits modification.
+        self.file_append("etc/pam.conf", "zigit")
+        self.pkg("verify overlaid overlayer")
+
+        # Verify that the file isn't touched on uninstall of the
+        # overlaying package if package being overlaid is still
+        # installed.
+        self.pkg("uninstall --parsable=0 overlayer")
+        self._assertEditables()
+        self.file_contains("etc/pam.conf", ["zigit", "file2"])
+
+        # Verify that removing the last package delivering an overlaid
+        # file removes the file.
+        self.pkg("uninstall --parsable=0 overlaid")
+        self._assertEditables(
+            removed=["etc/pam.conf"],
+        )
+        self.file_doesnt_exist("etc/pam.conf")
+
+        # Verify that installing both packages at the same time results
+        # in only the overlaying file being delivered.
+        self.pkg("install --parsable=0 overlaid@0 overlayer")
+        self._assertEditables(
+            installed=["etc/pam.conf"],
+        )
+        self.file_contains("etc/pam.conf", "file2")
+
+        # Verify that the file isn't touched on uninstall of the
+        # overlaid package if overlaying package is still installed.
+        self.file_append("etc/pam.conf", "zigit")
+        self.pkg("uninstall --parsable=0 overlaid")
+        self._assertEditables()
+        self.file_contains("etc/pam.conf", ["file2", "zigit"])
+
+        # Re-install overlaid package and verify that file content
+        # does not change.
+        self.pkg("install --parsable=0 overlaid@0")
+        self._assertEditables()
+        self.file_contains("etc/pam.conf", ["file2", "zigit"])
+        self.pkg("uninstall --parsable=0 overlaid overlayer")
+        self._assertEditables(
+            removed=["etc/pam.conf"],
+        )
+
+        # Should succeed because one action is overlayable and
+        # overlaying action declares its intent to overlay even
+        # though the overlaying action isn't marked with preserve.
+        self.pkg("install -nvv overlaid@0 unpreserved-overlayer")
+        self.pkg("install --parsable=0 overlaid@0 unpreserved-overlayer")
+        self._assertEditables(
+            installed=["etc/pam.conf"],
+        )
+        self.file_contains("etc/pam.conf", "unpreserved")
+
+        # Should succeed because overlaid action permits modification
+        # and contents matches overlaying action.
+        self.pkg("verify overlaid unpreserved-overlayer")
+
+        # Should fail because it turns into verifying the
+        # overlaying action from unpreserved-overlayer package.
+        self.file_append("etc/pam.conf", "zigit")
+        self.pkg("verify overlaid", exit=1)
+
+        # Should fail because overlaying action does not permit
+        # modification.
+        self.pkg("verify unpreserved-overlayer", exit=1)
+
+        # Should revert to content delivered by overlaying action.
+        self.pkg("fix unpreserved-overlayer")
+        self.file_contains("etc/pam.conf", "unpreserved")
+        self.file_doesnt_contain("etc/pam.conf", "zigit")
+
+        # Should revert to content delivered by overlaying action.
+        self.file_append("etc/pam.conf", "zigit")
+        self.pkg("revert /etc/pam.conf")
+        self.file_contains("etc/pam.conf", "unpreserved")
+        self.file_doesnt_contain("etc/pam.conf", "zigit")
+        self.pkg("uninstall --parsable=0 unpreserved-overlayer")
+        self._assertEditables()
+
+        # Should revert to content delivered by overlaid action.
+        self.file_contains("etc/pam.conf", "unpreserved")
+        self.pkg("revert /etc/pam.conf")
+        self.file_contains("etc/pam.conf", "file1")
+
+        # Install overlaying package, then update overlaid package and
+        # verify that file content does not change if only preserve
+        # attribute changes.
+        self.pkg("install --parsable=0 unpreserved-overlayer")
+        self._assertEditables(
+            installed=["etc/pam.conf"],
+        )
+        self.file_contains("etc/pam.conf", "unpreserved")
+        self.pkg("install --parsable=0 overlaid@1")
+        self._assertEditables()
+        self.file_contains("etc/pam.conf", "unpreserved")
+        self.pkg("uninstall --parsable=0 overlaid")
+        self._assertEditables()
+
+        # Now update overlaid package again, and verify that file
+        # content does not change even though overlaid content has.
+        self.pkg("install --parsable=0 overlaid@2")
+        self._assertEditables()
+        self.file_contains("etc/pam.conf", "unpreserved")
+
+        # Now update overlaid package again this time as part of a
+        # rename, and verify that file content does not change even
+        # though file has moved between packages.
+        self.pkg("install --parsable=0 overlaid@3")
+        self._assertEditables()
+        self.file_contains("etc/pam.conf", "unpreserved")
+
+        # Verify that unpreserved overlay is not salvaged when both
+        # overlaid and overlaying package are removed at the same time.
+        # (Preserved files are salvaged if they have been modified on
+        # uninstall.)
+
+        # Ensure directory is empty before testing.
+        api_inst = self.get_img_api_obj()
+        img_inst = api_inst.img
+        sroot = os.path.join(img_inst.imgdir, "lost+found")
+        shutil.rmtree(sroot)
+
+        # Verify etc directory not found after uninstall.
+        self.pkg(
+            "uninstall --parsable=0 overlaid-renamed " "unpreserved-overlayer"
+        )
+        self._assertEditables(
+            removed=["etc/pam.conf"],
+        )
+        salvaged = [n for n in os.listdir(sroot) if n.startswith("etc")]
+        self.assertEqualDiff(salvaged, [])
+
+        # Next, update overlaid package again this time as part of a
+        # file move.  Verify that the configuration file exists at both
+        # the new location and the old location, that the content has
+        # not changed in either, and that the new configuration exists
+        # as expected as ".new".
+        self.pkg(
+            "install --parsable=0 overlaid-renamed@3 " "unpreserved-overlayer"
+        )
+        self._assertEditables(
+            installed=["etc/pam.conf"],
+        )
+        self.pkg("install -nvv overlaid-renamed@4.1")
+        self.pkg("install --parsable=0 overlaid-renamed@4.1")
+        self._assertEditables(
+            moved=[["etc/pam.conf", "etc/pam/pam.conf"]],
+            installed=["etc/pam/pam.conf.new"],
+        )
+        self.file_contains("etc/pam.conf", "unpreserved")
+        self.file_contains("etc/pam/pam.conf", "unpreserved")
+        self.file_contains("etc/pam/pam.conf.new", "file4")
+
+        # Verify etc/pam.conf not salvaged after uninstall as overlay
+        # file has not been changed.
+        self.pkg(
+            "uninstall --parsable=0 overlaid-renamed " "unpreserved-overlayer"
+        )
+        self._assertEditables(
+            removed=["etc/pam.conf", "etc/pam/pam.conf"],
+        )
+        salvaged = [
+            n
+            for n in os.listdir(os.path.join(sroot, "etc"))
+            if n.startswith("pam.conf")
+        ]
+        self.assertEqualDiff(salvaged, [])
+
+        # Next, repeat the same set of tests performed above for renames
+        # and moves with an overlaying, preserved file.
+        #
+        # Install overlaying package, then update overlaid package and
+        # verify that file content does not change if only preserve
+        # attribute changes.
+        self.pkg("install --parsable=0 overlayer")
+        self._assertEditables(
+            installed=["etc/pam.conf"],
+        )
+        self.file_contains("etc/pam.conf", "file2")
+        self.file_append("etc/pam.conf", "zigit")
+        self.pkg("install --parsable=0 overlaid@1")
+        self._assertEditables()
+        self.file_contains("etc/pam.conf", "zigit")
+        self.pkg("uninstall --parsable=0 overlaid")
+        self._assertEditables()
+
+        # Now update overlaid package again, and verify that file
+        # content does not change even though overlaid content has.
+        self.pkg("install --parsable=0 overlaid@2")
+        self._assertEditables()
+        self.file_contains("etc/pam.conf", "zigit")
+
+        # Now update overlaid package again this time as part of a
+        # rename, and verify that file content does not change even
+        # though file has moved between packages.
+        self.pkg("install --parsable=0 overlaid@3")
+        self._assertEditables()
+        self.file_contains("etc/pam.conf", "zigit")
+
+        # Verify that preserved overlay is salvaged when both overlaid
+        # and overlaying package are removed at the same time.
+        # (Preserved files are salvaged if they have been modified on
+        # uninstall.)
+
+        # Ensure directory is empty before testing.
+        api_inst = self.get_img_api_obj()
+        img_inst = api_inst.img
+        sroot = os.path.join(img_inst.imgdir, "lost+found")
+        shutil.rmtree(sroot)
+
+        # Verify etc directory found after uninstall.
+        self.pkg("uninstall --parsable=0 overlaid-renamed overlayer")
+        self._assertEditables(
+            removed=["etc/pam.conf"],
+        )
+        salvaged = [n for n in os.listdir(sroot) if n.startswith("etc")]
+        self.assertEqualDiff(salvaged, ["etc"])
+
+        # Next, update overlaid package again, this time as part of a
+        # file move where the overlay attribute was dropped.  Verify
+        # that the configuration file exists at both the new location
+        # and the old location, that the content has not changed in
+        # either, and that the new configuration exists as expected as
+        # ".new".
+        self.pkg("install --parsable=0 overlaid-renamed@3 overlayer")
+        self._assertEditables(
+            installed=["etc/pam.conf"],
+        )
+        self.file_append("etc/pam.conf", "zigit")
+        self.pkg("install --parsable=0 overlaid-renamed@4.0")
+        self._assertEditables(
+            moved=[["etc/pam.conf", "etc/pam/pam.conf"]],
+            installed=["etc/pam/pam.conf.new"],
+        )
+        self.file_contains("etc/pam.conf", "zigit")
+        self.file_contains("etc/pam/pam.conf", "zigit")
+        self.file_contains("etc/pam/pam.conf.new", "file4")
+        self.pkg("uninstall --parsable=0 overlaid-renamed overlayer")
+        self._assertEditables(
+            removed=["etc/pam.conf", "etc/pam/pam.conf"],
+        )
+
+        # Next, update overlaid package again, this time as part of a
+        # file move.  Verify that the configuration file exists at both
+        # the new location and the old location, that the content has
+        # not changed in either, and that the new configuration exists
+        # as expected as ".new".
+        self.pkg("install --parsable=0 overlaid-renamed@3 overlayer")
+        self._assertEditables(
+            installed=["etc/pam.conf"],
+        )
+        self.file_append("etc/pam.conf", "zigit")
+        self.pkg("install --parsable=0 overlaid-renamed@4.1")
+        self._assertEditables(
+            moved=[["etc/pam.conf", "etc/pam/pam.conf"]],
+            installed=["etc/pam/pam.conf.new"],
+        )
+        self.file_contains("etc/pam.conf", "zigit")
+        self.file_contains("etc/pam/pam.conf", "zigit")
+        self.file_contains("etc/pam/pam.conf.new", "file4")
+
+        # Next, downgrade the package and verify that if an overlaid
+        # file moves back to its original location, the content of the
+        # overlay file will not change.
+        self.pkg("update --parsable=0 overlaid-renamed@3")
+        self._assertEditables(
+            removed=["etc/pam/pam.conf"],
+        )
+        self.file_contains("etc/pam.conf", "zigit")
+
+        # Now upgrade again for remaining tests.
+        self.pkg("install --parsable=0 overlaid-renamed@4.1")
+        self._assertEditables(
+            moved=[["etc/pam.conf", "etc/pam/pam.conf"]],
+            installed=["etc/pam/pam.conf.new"],
+        )
+
+        # Verify etc/pam.conf and etc/pam/pam.conf salvaged after
+        # uninstall as overlay file and overlaid file is different from
+        # packaged.
+        shutil.rmtree(sroot)
+        self.pkg("uninstall --parsable=0 overlaid-renamed overlayer")
+        self._assertEditables(
+            removed=["etc/pam.conf", "etc/pam/pam.conf"],
+        )
+        salvaged = sorted(
+            n
+            for n in os.listdir(os.path.join(sroot, "etc"))
+            if n.startswith("pam")
+        )
+        # Should have three entries; one should be 'pam' directory
+        # (presumably containing pam.conf-X...), another a file starting
+        # with 'pam.conf', and finally a 'pam-XXX' directory containing
+        # the 'pam.conf.new-XXX'.
+        self.assertEqualDiff(salvaged[0], "pam")
+        self.assertTrue(salvaged[1].startswith("pam-"), msg=str(salvaged))
+        self.assertTrue(salvaged[2].startswith("pam.conf"), msg=str(salvaged))
+
+        # Next, install overlaid package and overlaying package, then
+        # upgrade each to a version where the file has changed
+        # locations and verify that the content remains intact.
+        self.pkg("install --parsable=0 overlaid@0 overlayer-move@0")
+        self._assertEditables(
+            installed=["etc/pam.conf"],
+        )
+        self.file_append("etc/pam.conf", "zigit")
+        self.pkg("install --parsable=0 overlaid@3")
+        self._assertEditables()
+        self.file_contains("etc/pam.conf", "zigit")
+        self.pkg(
+            "install --parsable=0 overlaid-renamed@4.1 " "overlayer-move@1"
+        )
+        self._assertEditables(
+            moved=[["etc/pam.conf", "etc/pam/pam.conf"]],
+        )
+        self.file_contains("etc/pam/pam.conf", "zigit")
+
+        # Next, downgrade overlaid-renamed and overlaying package to
+        # versions where the file is restored to its original location
+        # and verify that the content is reverted to the original
+        # overlay version since this is a downgrade.
+        self.pkg("update --parsable=0 overlaid-renamed@3 " "overlayer-move@0")
+        self._assertEditables(
+            removed=["etc/pam/pam.conf"],
+            installed=["etc/pam.conf"],
+        )
+        self.file_contains("etc/pam.conf", "file2")
+        self.pkg("uninstall --parsable=0 overlaid-renamed overlayer-move")
+        self._assertEditables(
+            removed=["etc/pam.conf"],
+        )
+
+        # Next, install overlaid package and overlaying package and
+        # verify preserve acts as expected for overlay package as it is
+        # updated.
+        self.pkg("install --parsable=0 overlaid@2 overlayer-update@0")
+        self._assertEditables(
+            installed=["etc/pam.conf"],
+        )
+        self.file_contains("etc/pam.conf", "file1")
+        # unpreserved -> preserved
+        self.pkg("install --parsable=0 overlayer-update@1")
+        self._assertEditables(
+            updated=["etc/pam.conf"],
+        )
+        self.file_contains("etc/pam.conf", "file2")
+        self.file_append("etc/pam.conf", "zigit")
+        # preserved -> renameold
+        self.pkg("install --parsable=0 overlayer-update@2")
+        self._assertEditables(
+            moved=[["etc/pam.conf", "etc/pam.conf.old"]],
+            installed=["etc/pam.conf"],
+        )
+        self.file_doesnt_contain("etc/pam.conf", "zigit")
+        self.file_contains("etc/pam.conf.old", "zigit")
+        self.file_append("etc/pam.conf", "zagat")
+        # renameold -> renamenew
+        self.pkg("install --parsable=0 overlayer-update@3")
+        self._assertEditables(
+            installed=["etc/pam.conf.new"],
+        )
+        self.file_contains("etc/pam.conf", "zagat")
+        self.file_contains("etc/pam.conf.new", "file4")
+
+    def test_different_types_install(self):
+        """Test the behavior of pkg(1) when multiple actions of
+        different types deliver to the same pathname."""
+
+        self.image_create(self.rurl)
+
+        # In the same package
+        self.pkg("install duppath-filelink", exit=1)
+
+        # In different packages, in the same transaction
+        self.pkg("install dupfilesp1 duplink", exit=1)
+
+        # In different packages, in different transactions
+        self.pkg("install dupfilesp1")
+        self.pkg("install duplink", exit=1)
+
+        # Does removal of one of the busted packages get us out of the
+        # situation?
+        self.pkg("uninstall '*'")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install dupfilesp1 duplink"
+        )
+        self.pkg("verify", exit=1)
+        self.pkg("uninstall dupfilesp1")
+        self.pkg("verify")
+        self.pkg("-D broken-conflicting-action-handling=1 install dupfilesp1")
+        self.pkg("uninstall duplink")
+        self.pkg("verify")
+
+        # Implicit directory conflicts with a file
+        self.pkg("uninstall '*'")
+        self.pkg("install implicitdirs", exit=1)
+
+        # Implicit directory coincides with a delivered directory
+        self.pkg("install implicitdirs2")
+
+        # Make sure that we don't die trying to fixup a directory using
+        # an implicit directory action.
+        self.pkg("uninstall '*'")
+        self.pkg("install implicitdirs4")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install " "implicitdirs7"
+        )
+        self.pkg("uninstall implicitdirs7")
+        # XXX We don't currently fix up anything beneath a directory
+        # that was restored, so we have to do it by hand.
+        os.mkdir("{0}/usr/bin".format(self.img_path()))
+        shutil.copy(
+            "{0}/tmp/file1".format(self.test_root),
+            "{0}/usr/bin/something".format(self.img_path()),
+        )
+        owner = portable.get_user_by_name("root", self.img_path(), True)
+        group = portable.get_group_by_name("bin", self.img_path(), True)
+        os.chown("{0}/usr/bin/something".format(self.img_path()), owner, group)
+        os.chmod("{0}/usr/bin/something".format(self.img_path()), 0o755)
+        self.pkg("verify")
+
+        # Removing one of more than two offending actions can't do much
+        # of anything, but should leave the system alone.
+        self.pkg("uninstall '*'")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupfilesp1 duplink dupdir@0"
+        )
+        tmap = {
+            stat.S_IFIFO: "fifo",
+            stat.S_IFCHR: "character device",
+            stat.S_IFDIR: "directory",
+            stat.S_IFBLK: "block device",
+            stat.S_IFREG: "regular file",
+            stat.S_IFLNK: "symbolic link",
+            stat.S_IFSOCK: "socket",
+        }
+        thepath = "{0}/dir/pathname".format(self.img_path())
+        fmt = stat.S_IFMT(os.lstat(thepath).st_mode)
+        # XXX The checks here rely on verify failing due to action types
+        # not matching what's on the system; they should probably report
+        # duplicate actions instead.  Checking the output text is a bit
+        # ugly, too, but we do need to make sure that the two problems
+        # become one.
+        self.pkg("verify", exit=1)
+        verify_type_re = "file type: '(.*?)' should be '(.*?)'"
+        matches = re.findall(verify_type_re, self.output)
+        # We make sure that what got reported is correct -- two actions
+        # of different types in conflict with whatever actually got laid
+        # down.
+        self.assertTrue(len(matches) == 2)
+        whatis = matches[0][0]
+        self.assertTrue(matches[1][0] == whatis)
+        self.assertTrue(whatis == tmap[fmt])
+        shouldbe = set(["symbolic link", "regular file", "directory"]) - set(
+            [whatis]
+        )
+        self.assertTrue(set([matches[0][1], matches[1][1]]) == shouldbe)
+        # Now we uninstall one of the packages delivering a type which
+        # isn't what's on the filesystem.  The filesystem should remain
+        # unchanged, but one of the errors should go away.
+        if whatis == "directory":
+            self.pkg("uninstall duplink")
+        else:
+            self.pkg("uninstall dupdir")
+        self.pkg("verify", exit=1)
+        matches = re.findall(verify_type_re, self.output)
+        self.assertTrue(len(matches) == 1)
+        nfmt = stat.S_IFMT(os.lstat(thepath).st_mode)
+        self.assertTrue(nfmt == fmt)
+
+        # Now we do the same thing, but we uninstall the package
+        # delivering the type which *is* what's on the filesystem.  This
+        # should also leave the filesystem alone, even though what's
+        # there will match *neither* of the remaining installed
+        # packages.
+        self.pkg("uninstall '*'")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupfilesp1 duplink dupdir@0"
+        )
+        fmt = stat.S_IFMT(os.lstat(thepath).st_mode)
+        self.pkg("verify", exit=1)
+        matches = re.findall(verify_type_re, self.output)
+        self.assertTrue(len(matches) == 2)
+        whatis = matches[0][0]
+        self.assertTrue(matches[1][0] == whatis)
+        self.assertTrue(whatis == tmap[fmt])
+        shouldbe = set(["symbolic link", "regular file", "directory"]) - set(
+            [whatis]
+        )
+        self.assertTrue(set([matches[0][1], matches[1][1]]) == shouldbe)
+        if whatis == "directory":
+            self.pkg("uninstall dupdir")
+        elif whatis == "symbolic link":
+            self.pkg("uninstall duplink")
+        elif whatis == "regular file":
+            self.pkg("uninstall dupfilesp1")
+        self.pkg("verify", exit=1)
+        matches = re.findall(verify_type_re, self.output)
+        self.assertTrue(len(matches) == 2)
+        nfmt = stat.S_IFMT(os.lstat(thepath).st_mode)
+        self.assertTrue(nfmt == fmt)
+
+        # Go from multiple conflicting types down to just one type.
+        # This also tests the case where a package version being newly
+        # installed gets fixed at the same time.
+        self.pkg("uninstall '*'")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install " "dupmultitypes@1"
+        )
+        self.pkg("install dupmultitypes")
+        self.pkg("verify")
+
+        # Upgrading from multiple instances of one refcounted type to
+        # multiple instances of another (here, link to directory) should
+        # succeed.
+        self.pkg("uninstall '*'")
+        self.pkg("install dupmultitypes3@0")
+        self.pkg("update")
+
+    def test_conflicting_attrs_fs_install(self):
+        """Test the behavior of pkg(1) when multiple non-file actions of
+        the same type deliver to the same pathname, but whose other
+        attributes differ."""
+
+        self.image_create(self.rurl)
+
+        # One package, two links with different targets
+        self.pkg("install duppath-nonidenticallinks", exit=1)
+
+        # One package, two directories with different perms
+        self.pkg("install duppath-nonidenticaldirs", exit=1)
+
+        # One package, two dirs with same modes expressed two ways
+        self.pkg("install duppath-almostidenticaldirs")
+
+        # One package delivers a directory explicitly, another
+        # implicitly.
+        self.pkg("install implicitdirs2 implicitdirs3")
+        self.pkg("verify")
+
+        self.pkg("uninstall '*'")
+
+        # Make sure that we don't die trying to fixup a directory using
+        # an implicit directory action.
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "implicitdirs4 implicitdirs5 implicitdirs6"
+        )
+        self.pkg("uninstall implicitdirs5")
+        self.pkg("verify")
+
+        self.pkg("uninstall '*'")
+
+        # Make sure that we don't die trying to fixup a directory using
+        # an implicit directory action when that's all that's left.
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "implicitdirs4 implicitdirs5 implicitdirs6"
+        )
+        self.pkg("uninstall implicitdirs5 implicitdirs6")
+        self.pkg("verify")
+
+        self.pkg("uninstall '*'")
+
+        # If two packages deliver conflicting directories and another
+        # package delivers that directory implicitly, make sure the
+        # third package isn't blamed.
+        self.pkg("install implicitdirs4 implicitdirs5 implicitdirs6", exit=1)
+        self.assertTrue("implicitdirs4" not in self.errout)
+
+        # Two packages, two links with different targets, installed at
+        # once
+        self.pkg(
+            "install duppath-nonidenticallinksp1 "
+            "duppath-nonidenticallinksp2@0",
+            exit=1,
+        )
+
+        # Two packages, two links with different targets, installed
+        # separately
+        self.pkg("install duppath-nonidenticallinksp1")
+        self.pkg("install duppath-nonidenticallinksp2@0", exit=1)
+
+        self.pkg("uninstall '*'")
+
+        # If we get into a broken state, can we get out of it?
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "duppath-nonidenticallinksp1 duppath-nonidenticallinksp2@0"
+        )
+        self.pkg("verify", exit=1)
+        self.pkg("install duppath-nonidenticallinksp2")
+        self.pkg("verify")
+
+        # If we get into a broken state, can we make it a little bit
+        # better by uninstalling one of the packages?  Removing dupdir5
+        # here won't reduce the number of different groups under which
+        # dir is delivered, but does reduce the number of actions
+        # delivering it.
+        self.pkg("uninstall '*'")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupdirp1 dupdirp2@1 dupdirp5 dupdirp6"
+        )
+        self.pkg("uninstall dupdirp5")
+        self.pkg("verify", exit=1)
+
+        self.pkg("-D broken-conflicting-action-handling=1 install " "dupdirp5")
+        # Make sure we can install a package delivering an implicit
+        # directory that's currently in conflict.
+        self.pkg("install dupdirp7")
+        # And make sure we can uninstall it again.
+        self.pkg("uninstall dupdirp7")
+
+        # Removing the remaining conflicts in a couple of steps should
+        # result in a verifiable system.
+        self.pkg("uninstall dupdirp2")
+        self.pkg("uninstall dupdirp5 dupdirp6")
+        self.pkg("verify")
+
+        # Add everything back in, remove everything but one variant of
+        # the directory and an implicit directory, and verify.
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupdirp2@1 dupdirp5 dupdirp6 dupdirp7"
+        )
+        self.pkg("uninstall dupdirp2 dupdirp5 dupdirp6")
+        self.pkg("verify")
+
+        # Get us into a saner state by upgrading.
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupdirp2@1 dupdirp5 dupdirp6"
+        )
+        self.pkg("update dupdirp2@2")
+
+        # Get us into a sane state by upgrading.
+        self.pkg("uninstall dupdirp2 dupdirp5 dupdirp6")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install " "dupdirp2@1"
+        )
+        self.pkg("update dupdirp2@2")
+        self.pkg("verify")
+
+        # We start in a sane state, but the update would result in
+        # conflict, though no more actions deliver the path in
+        # question.
+        self.pkg("uninstall '*'")
+        self.pkg("install dupdirp1 dupdirp8@1")
+        self.pkg("update", exit=1)
+
+        # How about removing one of the conflicting packages?  We'll
+        # remove the package which doesn't match the state on disk.
+        self.pkg("uninstall '*'")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "duppath-nonidenticallinksp1 duppath-nonidenticallinksp2@0"
+        )
+        link = os.readlink("{0}/dir/pathname".format(self.img_path()))
+        if link == "dir/something":
+            self.pkg("uninstall duppath-nonidenticallinksp2")
+        else:
+            self.pkg("uninstall duppath-nonidenticallinksp1")
+        self.pkg("verify")
+
+        # Now we'll try removing the package which *does* match the
+        # state on disk.  The code should clean up after us.
+        self.pkg("uninstall '*'")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "duppath-nonidenticallinksp1 duppath-nonidenticallinksp2@0"
+        )
+        link = os.readlink("{0}/dir/pathname".format(self.img_path()))
+        if link == "dir/something":
+            self.pkg("uninstall duppath-nonidenticallinksp1")
+        else:
+            self.pkg("uninstall duppath-nonidenticallinksp2")
+        self.pkg("verify")
+
+        # Let's try a duplicate directory delivered with all sorts of
+        # crazy conflicts!
+        self.pkg("uninstall '*'")
+        self.pkg("install dupdirp1 dupdirp2@1 dupdirp3 dupdirp4", exit=1)
+
+        pkgs = " ".join("massivedupdir{0:d}".format(x) for x in range(20))
+        self.pkg("install {0}".format(pkgs), exit=1)
+
+        # Trigger bug 17943: we install packages with conflicts in two
+        # directories (p9, p10).  We also install a package (p11) which
+        # delivers those directories implicitly.  Then remove the last,
+        # triggering the stack trace associated with the bug.
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupdirp9 dupdirp10 dupdirp11"
+        )
+        self.pkg("uninstall dupdirp11")
+
+        # Do the same, but with a package that delivers var implicitly
+        # via a legacy action.
+        self.pkg("-D broken-conflicting-action-handling=1 install " "dupdirp12")
+        self.pkg("uninstall dupdirp12")
+
+    def test_conflicting_attrs_fs_varcets(self):
+        """Test the behavior of pkg(1) when multiple non-file actions of
+        the same type deliver to the same pathname, but differ in their
+        variants or facets."""
+
+        install_cmd = "install"
+        self.image_create(self.rurl)
+
+        # Two packages delivering the same directory, one under the
+        # current architecture, the other not tagged with an arch
+        # variant.
+        self.pkg("{0} dupfilesv1 dupfilesv2".format(install_cmd))
+        self.dir_exists("dir/pathname")
+
+        # Two packages delivering the same directory with different
+        # attributes -- one under the current architecture, the other
+        # tagged with another arch variant.
+        self.pkg("uninstall '*'")
+        self.pkg("{0} dupfilesv1 dupfilesv3".format(install_cmd))
+        if platform.processor() == "sparc":
+            self.dir_exists("dir/pathname", mode=0o777)
+        else:
+            self.dir_exists("dir/pathname", mode=0o755)
+
+        # Two packages delivering a file at the same path where one is
+        # tagged only for non-global zones should install successfully
+        # together in a global zone.
+        self.pkg("uninstall '*'")
+        self.pkg("{0} dupfilesv5 dupfilesv6".format(install_cmd))
+        path = os.path.join(self.get_img_path(), "dir/pathname")
+        try:
+            f = open(path)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                self.assertTrue(False, "File dir/pathname does not exist")
+            else:
+                raise
+        self.assertEqual(f.read().rstrip(), "tmp/file2")
+        f.close()
+
+        # Two packages delivering the same directory, one with the
+        # devel facet false, the other true.
+        self.pkg("uninstall '*'")
+        self.pkg("{0} dupfilesf1 dupfilesf2".format(install_cmd))
+        self.dir_exists("dir/pathname")
+
+        # Two packages delivering the same directory, one with the
+        # devel facet true, the other without.
+        self.pkg("uninstall '*'")
+        self.pkg("{0} dupfilesf1 dupfilesf3".format(install_cmd))
+        self.dir_exists("dir/pathname")
+
+        # Two packages delivering the same directory, one with the
+        # devel facet false, the other without.
+        self.pkg("uninstall '*'")
+        self.pkg("{0} dupfilesf2 dupfilesf3".format(install_cmd))
+        self.dir_exists("dir/pathname")
+
+    def test_conflicting_uninstall_publisher(self):
+        """Test the behaviour of pkg(1) when attempting to remove
+        conflicting packages from a publisher which has also been
+        removed."""
+
+        self.conflicting_uninstall_publisher_helper("install")
+        self.conflicting_uninstall_publisher_helper("exact-install")
+
+    def conflicting_uninstall_publisher_helper(self, install_cmd):
+        self.image_create(self.rurl)
+        # Dummy publisher so test publisher can be removed.
+        self.pkg("set-publisher -P ignored")
+
+        # If packages with conflicting actions are found during
+        # uninstall, and the publisher of the package has been
+        # removed, uninstall should still succeed.
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 {0} "
+            "dupdirp1 dupdirp2@1".format(install_cmd)
+        )
+        self.pkg("unset-publisher test")
+        self.pkg("uninstall dupdirp2")
+        self.pkg("verify")
+
+    def test_change_varcet(self):
+        """Test the behavior of pkg(1) when changing a variant or a
+        facet would cause the new image to contain conflicting
+        actions."""
+
+        # Create the image as an x86 image, as the first test only works
+        # changing variant from x86 to sparc.
+        self.image_create(self.rurl, variants={"variant.arch": "i386"})
+
+        # The x86 variant is safe, but the sparc variant has two files
+        # with the same pathname.
+        self.pkg("install dupfilesv4")
+        self.pkg("change-variant arch=sparc", exit=1)
+
+        # With the devel facet turned off, the package is safe, but
+        # turning it on would cause a duplicate file to be added.
+        self.pkg("change-facet devel=false")
+        self.pkg("install dupfilesf4")
+        self.pkg("change-facet devel=true", exit=1)
+
+    def test_change_variant_removes_package(self):
+        """Test that a change-variant that removes a package and
+        improves but doesn't fix a conflicting action situation is
+        allowed."""
+
+        self.image_create(self.rurl, variants={"variant.foo": "one"})
+        self.pkg("install tripledupfileb")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install " "tripledupfilec"
+        )
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install " "tripledupfilea"
+        )
+        self.pkg("change-variant -vvv variant.foo=two")
+        self.pkg("change-variant -vvv variant.foo=one", exit=1)
+
+    def test_multiple_users_install(self):
+        """Test the behavior of pkg(1) when multiple user actions
+        deliver the same user."""
+
+        # This is largely identical to test_multiple_files; we may want
+        # to commonize in the future.
+
+        self.image_create(self.rurl)
+
+        self.pkg("install userdb")
+
+        # Duplicate users in the same package
+        self.pkg("install dupuser", exit=1)
+
+        # Duplicate users in different packages, but in the same
+        # transaction
+        self.pkg("install dupuserp1 dupuserp2@0", exit=1)
+
+        # Duplicate users in different packages, in different
+        # transactions
+        self.pkg("install dupuserp1")
+        self.pkg("install dupuserp2@0", exit=1)
+
+        # Test that being in a duplicate user situation doesn't break
+        # you completely and allows you to add and remove other packages
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install " "dupuserp2@0"
+        )
+        self.pkg("verify", exit=1)
+        self.pkg("install otheruser")
+        self.file_contains("etc/passwd", "fozzie")
+        self.file_contains("etc/shadow", "fozzie")
+        self.pkg("uninstall otheruser")
+        self.file_doesnt_contain("etc/passwd", "fozzie")
+        self.file_doesnt_contain("etc/shadow", "fozzie")
+        self.pkg("verify", exit=1)
+
+        # If the packages involved get upgraded but leave the actions
+        # themselves alone, we should be okay.
+        self.pkg("install dupuserp2 dupuserp3")
+        self.file_contains("etc/passwd", "kermit")
+        self.file_contains("etc/shadow", "kermit")
+        self.pkg("verify", exit=1)
+
+        # Test that removing one of two offending actions reverts the
+        # system to a clean state.
+        self.pkg("uninstall dupuserp3")
+        self.file_contains("etc/passwd", "kermit")
+        self.file_contains("etc/shadow", "kermit")
+        self.pkg("verify")
+
+        # You should be able to upgrade to a fixed set of packages in
+        # order to move past the problem, too.
+        self.pkg("uninstall dupuserp2")
+        self.file_contains("etc/passwd", "kermit")
+        self.file_contains("etc/shadow", "kermit")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install " "dupuserp2@0"
+        )
+        self.pkg("update")
+        self.pkg("verify")
+        self.file_contains("etc/passwd", "kermit")
+        self.file_contains("etc/shadow", "kermit")
+
+        # If we upgrade to a version of a conflicting package that no
+        # longer has the conflict, but at the same time introduce a new
+        # conflicting user action, we should fail.
+        self.pkg("uninstall dupuserp2")
+        self.file_contains("etc/passwd", "kermit")
+        self.file_contains("etc/shadow", "kermit")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install " "dupuserp2@0"
+        )
+        self.pkg("install dupuserp2 dupuserp4", exit=1)
+
+        # Removing one of more than two offending actions can't do much
+        # of anything, but should leave the system alone.
+        self.image_destroy()
+        self.image_create(self.rurl)
+        self.pkg("install userdb")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupuserp1 dupuserp2@0 dupuserp3"
+        )
+        self.pkg("verify", exit=1)
+        self.file_contains("etc/passwd", "kermit")
+        self.file_contains("etc/shadow", "kermit")
+        out1 = self.output
+        self.pkg("uninstall dupuserp3")
+        self.file_contains("etc/passwd", "kermit")
+        self.file_contains("etc/shadow", "kermit")
+        self.pkg("verify", exit=1)
+        out2 = self.output
+        out2 = out2[out2.index("STATUS\n") + 7 :]
+        self.assertTrue(out2 in out1)
+
+        # Removing all but one of the offending actions should get us
+        # back to sanity.
+        self.image_destroy()
+        self.image_create(self.rurl)
+        self.pkg("install userdb")
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "dupuserp1 dupuserp2@0 dupuserp3"
+        )
+        self.file_contains("etc/passwd", "kermit")
+        self.file_contains("etc/shadow", "kermit")
+        self.pkg("uninstall dupuserp3 dupuserp2")
+        self.file_contains("etc/passwd", "kermit")
+        self.file_contains("etc/shadow", "kermit")
+        self.pkg("verify")
+
+        # Make sure we don't get confused when two actions in different
+        # namespace groups but with the same key attribute value are
+        # adjacent in the action cache.
+        self.pkg(
+            "-D broken-conflicting-action-handling=1 install "
+            "otheruser othergroup@0"
+        )
+        self.pkg("update othergroup")
+
+    def test_multiple_drivers(self):
+        """Test the behavior of pkg(1) when multiple driver actions
+        deliver the same driver."""
+
+        self.multiple_drivers_helper("install")
+        self.multiple_drivers_helper("exact-install")
+
+    def multiple_drivers_helper(self, install_cmd):
+        self.image_create(self.rurl)
+
+        self.pkg("{0} driverdb".format(install_cmd))
+
+        self.pkg("{0} dupdriver".format(install_cmd), exit=1)
+
+    def test_multiple_depend(self):
+        """Test to make sure we can have multiple depend actions on
+        (more or less) the same fmri"""
+
+        self.multiple_depend_helper("install")
+        self.multiple_depend_helper("exact-install")
+
+    def multiple_depend_helper(self, install_cmd):
+        self.image_create(self.rurl)
+
+        # Two identical unversioned require dependencies
+        self.pkg("{0} dupdepend1".format(install_cmd))
+
+        # Two dependencies of different types on an identical
+        # unversioned fmri
+        self.pkg("{0} dupdepend2".format(install_cmd))
+
+        # Two identical versioned require dependencies
+        self.pkg("{0} dupdepend3".format(install_cmd))
+
+        # Two dependencies of different types on an identical versioned
+        # fmri
+        self.pkg("{0} dupdepend4".format(install_cmd))
+
+    def test_varianted_types(self):
+        """Test that actions which would otherwise conflict but are
+        delivered under different variants don't conflict."""
+
+        self.varianted_types_helper("install")
+        self.varianted_types_helper("exact-install")
+
+    def varianted_types_helper(self, install_cmd):
+        self.pkg_image_create(
+            repourl=self.rurl, additional_args="--variant foo=one"
+        )
+        self.pkg("{0} vpath".format(install_cmd))
 
 
 class TestPkgInstallExplicitInstall(pkg5unittest.SingleDepotTestCase):
-        """Test pkg.depend.explicit-install action behaviors."""
-        persistent_setup = True
+    """Test pkg.depend.explicit-install action behaviors."""
 
-        pkgs = (
-                """
+    persistent_setup = True
+
+    pkgs = (
+        """
                     open group@1.0,5.11-0
                     add depend type=group fmri=pkg:/A
                     close """,
-                """
+        """
                     open incorp@1.0,5.11-0
                     add depend type=incorporate fmri=pkg:/A@1.0,5.11-0.1
                     close """,
-                """
+        """
                     open A@1.0,5.11-0.1
                     close """,
-                """
+        """
                     open A@1.0,5.11-0.1.1.0
                     add depend type=require fmri=pkg:/idr@1.0,5.11-0.1.1.0
                     close """,
-                """
+        """
                     open idr@1.0,5.11-0.1.1.0
                     add set name=pkg.depend.explicit-install value=true
                     add depend type=incorporate fmri=pkg:/A@1.0,5.11-0.1.1.0
                     close """,
-                """
+        """
                     open B@1.0,5.11-0.1.1.0
                     add depend type=require fmri=pkg:/idrb@1.0,5.11-0.1.1.0
                     close """,
-                """
+        """
                     open idrb@1.0,5.11-0.1.1.0
                     add set name=pkg.depend.explicit-install value=true
                     add depend type=incorporate fmri=pkg:/B@1.0,5.11-0.1.1.0
                     add depend type=parent fmri=feature/package/dependency/self
                     close """,
-                # The two versions of C below intentionally have the same
-                # timestamp to ensure that even if the timestamps are the same,
-                # an upgrade to the newer version will be considered.
-                """
+        # The two versions of C below intentionally have the same
+        # timestamp to ensure that even if the timestamps are the same,
+        # an upgrade to the newer version will be considered.
+        """
                     open C@1.0,5.11-0.1:20170513T045531Z
                     add depend type=parent fmri=feature/package/dependency/self
                     close """,
-                """
+        """
                     open C@1.0,5.11-0.1.1.0:20170513T045531Z
                     add depend type=require fmri=pkg:/idrc@1.0,5.11-0.1.1.0
                     add depend type=parent fmri=feature/package/dependency/self
                     close """,
-                """
+        """
                     open idrc@1.0,5.11-0.1.1.0
                     add set name=pkg.depend.explicit-install value=true
                     add depend type=incorporate fmri=pkg:/C@1.0,5.11-0.1.1.0
                     add depend type=parent fmri=feature/package/dependency/self
                     close """,
-                """
+        """
                     open D@1.0,5.11-0.1.1.0
                     add depend type=require fmri=pkg:/idrd@1.0,5.11-0.1.1.0
                     add depend type=parent fmri=feature/package/dependency/self
                     close """,
-                """
+        """
                     open idrd@1.0,5.11-0.1.1.0
                     add set name=pkg.depend.explicit-install value=true
                     add depend type=incorporate fmri=pkg:/D@1.0,5.11-0.1.1.0
                     close """,
-        )
+    )
 
-        pkgs2 = (
-                 """
+    pkgs2 = (
+        """
                     open A@1.0,5.11-0.1.1.1
                     add depend type=require fmri=pkg:/idr@1.0,5.11-0.1.1.1
                     close """,
-                """
+        """
                     open idr@1.0,5.11-0.1.1.1
                     add set name=pkg.depend.explicit-install value=false
                     add depend type=incorporate fmri=pkg:/A@1.0,5.11-0.1.1.1
                     close """,
-        )
+    )
 
-        pkgs3 = (
-                """
+    pkgs3 = (
+        """
                     open A@1.0,5.11-0.1.1.2
                     add depend type=require fmri=pkg:/idr@1.0,5.11-0.1.1.2
                     close """,
-                """
+        """
                     open idr@1.0,5.11-0.1.1.2
                     add depend type=incorporate fmri=pkg:/A@1.0,5.11-0.1.1.2
                     close """,
-        )
+    )
 
-        pkgs4 = (
-                """
+    pkgs4 = (
+        """
                     open C1@1.0
                     add depend type=require-any fmri=pkg:/C2@1.0 fmri=pkg:/C2@2.0
                     close """,
-                """
+        """
                     open C2@1.0
                     add depend type=require fmri=pkg:/C3@1.0,5.11-0.1
                     close """,
-                """
+        """
                     open C2@2.0
                     add set name=pkg.depend.explicit-install value=true
                     add depend type=require fmri=pkg:/C3@1.0,5.11-0.1
                     close """,
-                """
+        """
                     open C3@1.0,5.11-0.1
                     close """,
-        )
+    )
 
-        pkgs5 = (
-                """
+    pkgs5 = (
+        """
                     open Hiera1@1.0
                     add depend type=require fmri=pkg:/Hiera2@1.0
                     close """,
-                """
+        """
                     open Hiera2@1.0
                     add depend type=require fmri=pkg:/Hiera3@1.0
                     close """,
-                """
+        """
                     open Hiera3@1.0
                     add set name=pkg.depend.explicit-install value=true
                     close """,
-        )
+    )
 
-        pkgs6 = (
-                """
+    pkgs6 = (
+        """
                     open p1@1.0,5.11-0.1.1.2
                     add depend type=require fmri=pkg:/p2@2.0,5.11-0.1.1.2
                     close """,
-                """
+        """
                     open p2@1.0,5.11-0.1.1.2
                     add set name=pkg.depend.explicit-install value=true
                     close """,
-                """
+        """
                     open p2@2.0,5.11-0.1.1.2
                     add set name=pkg.depend.explicit-install value=true
                     close """,
-        )
+    )
 
-        pkgs7 = (
-                """
+    pkgs7 = (
+        """
                     open downgrade@1.0
                     close """,
-                """
+        """
                     open downgrade@1.0.1
                     add depend type=require fmri=idrDG@1
                     close """,
-                """
+        """
                     open idrDG@1
                     add set name=pkg.depend.explicit-install value=true
                     add depend type=incorporate fmri=downgrade@1.0.1
                     close """,
-                """
+        """
                     open incorpDG1@1.0
                     add depend type=require fmri=downgrade
                     add depend type=incorporate fmri=downgrade@1.0
-                    close """
+                    close """,
+    )
+
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self, image_count=2)
+        self.__pkgs = self.pkgsend_bulk(self.rurl, self.pkgs)
+
+    def test_01_install(self):
+        self.image_create(self.rurl, prefix="")
+        # Test install works as expected.
+        # This will fail because idr@1.0-0.1.1.0 has
+        # pkg.depend.explicit-install set to true.
+        self.pkg("install -v group incorp A@1.0-0.1.1.0", exit=1)
+        self.pkg("install -v group incorp")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = (
+            "A    1.0-0.1    i--\n"
+            "group    1.0-0    im-\n"
+            "incorp    1.0-0    im-\n"
         )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+        self.pkg("uninstall -v group incorp A")
+        self.pkg("list -H", exit=1)
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self, image_count=2)
-                self.__pkgs = self.pkgsend_bulk(self.rurl, self.pkgs)
+        # Test exact-install works as expected.
+        # This will fail because idr@1.0-0.1.1.0 has
+        # pkg.depend.explicit-install set to true.
+        self.pkg("exact-install -v group incorp A@1.0-0.1.1.0", exit=1)
+        self.pkg("exact-install -v group incorp")
+        self.pkg("verify")
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-        def test_01_install(self):
-                self.image_create(self.rurl, prefix="")
-                # Test install works as expected.
-                # This will fail because idr@1.0-0.1.1.0 has
-                # pkg.depend.explicit-install set to true.
-                self.pkg("install -v group incorp A@1.0-0.1.1.0", exit=1)
-                self.pkg("install -v group incorp")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "A    1.0-0.1    i--\n" \
-                    "group    1.0-0    im-\n" \
-                    "incorp    1.0-0    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-                self.pkg("uninstall -v group incorp A")
-                self.pkg("list -H", exit=1)
+        # Test exact-install idr.
+        self.pkg("exact-install -v idr")
+        self.pkg("list -H")
+        expected = "idr    1.0-0.1.1.0    im-\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-                # Test exact-install works as expected.
-                # This will fail because idr@1.0-0.1.1.0 has
-                # pkg.depend.explicit-install set to true.
-                self.pkg("exact-install -v group incorp A@1.0-0.1.1.0", exit=1)
-                self.pkg("exact-install -v group incorp")
-                self.pkg("verify")
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg("install -v group")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = (
+            "A    1.0-0.1.1.0    i--\n"
+            "group    1.0-0    im-\n"
+            "idr    1.0-0.1.1.0    im-\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-                # Test exact-install idr.
-                self.pkg("exact-install -v idr")
-                self.pkg("list -H")
-                expected = \
-                    "idr    1.0-0.1.1.0    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+        self.pkg("uninstall -v group idr A")
+        self.pkg("list -H", exit=1)
 
-                self.pkg("install -v group")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "A    1.0-0.1.1.0    i--\n" \
-                    "group    1.0-0    im-\n" \
-                    "idr    1.0-0.1.1.0    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+        self.pkg("install -v idr")
+        self.pkg("list -H")
+        expected = "idr    1.0-0.1.1.0    im-\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("uninstall -v group idr A")
-                self.pkg("list -H", exit=1)
+        self.pkg("install -v group")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = (
+            "A    1.0-0.1.1.0    i--\n"
+            "group    1.0-0    im-\n"
+            "idr    1.0-0.1.1.0    im-\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+        self.pkg("uninstall '*'")
+        self.pkg("list -H", exit=1)
 
-                self.pkg("install -v idr")
-                self.pkg("list -H")
-                expected = \
-                    "idr    1.0-0.1.1.0    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+        self.pkgsend_bulk(self.rurl, self.pkgs2)
+        self.pkg("install -v group incorp")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = (
+            "A    1.0-0.1.1.1    i--\n"
+            "group    1.0-0    im-\n"
+            "idr    1.0-0.1.1.1    i--\n"
+            "incorp    1.0-0    im-\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("install -v group")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "A    1.0-0.1.1.0    i--\n" \
-                    "group    1.0-0    im-\n" \
-                    "idr    1.0-0.1.1.0    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-                self.pkg("uninstall '*'")
-                self.pkg("list -H", exit=1)
+        self.pkgsend_bulk(self.rurl, self.pkgs3)
+        # test updating all packages.
+        self.pkg("update")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = (
+            "A    1.0-0.1.1.2    i--\n"
+            "group    1.0-0    im-\n"
+            "idr    1.0-0.1.1.2    i--\n"
+            "incorp    1.0-0    im-\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+        self.pkg("uninstall '*'")
 
-                self.pkgsend_bulk(self.rurl, self.pkgs2)
-                self.pkg("install -v group incorp")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "A    1.0-0.1.1.1    i--\n" \
-                    "group    1.0-0    im-\n" \
-                    "idr    1.0-0.1.1.1    i--\n" \
-                    "incorp    1.0-0    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+        self.pkgsend_bulk(self.rurl, self.pkgs4)
+        # test require-any with pkg.depend.explicit-install tag.
+        self.pkg("install C1")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = (
+            "C1    1.0    im-\n" "C2    1.0    i--\n" "C3    1.0-0.1    i--\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+        self.pkg("uninstall '*'")
 
-                self.pkgsend_bulk(self.rurl, self.pkgs3)
-                # test updating all packages.
-                self.pkg("update")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "A    1.0-0.1.1.2    i--\n" \
-                    "group    1.0-0    im-\n" \
-                    "idr    1.0-0.1.1.2    i--\n" \
-                    "incorp    1.0-0    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-                self.pkg("uninstall '*'")
+        self.pkg("install C1 C2")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = (
+            "C1    1.0    im-\n" "C2    2.0    im-\n" "C3    1.0-0.1    i--\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-                self.pkgsend_bulk(self.rurl, self.pkgs4)
-                # test require-any with pkg.depend.explicit-install tag.
-                self.pkg("install C1")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "C1    1.0    im-\n" \
-                    "C2    1.0    i--\n" \
-                    "C3    1.0-0.1    i--\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-                self.pkg("uninstall '*'")
+        # Test hierarchic dependencies.
+        self.pkgsend_bulk(self.rurl, self.pkgs5)
+        self.pkg("install -v Hiera1@1.0", exit=1)
 
-                self.pkg("install C1 C2")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "C1    1.0    im-\n" \
-                    "C2    2.0    im-\n" \
-                    "C3    1.0-0.1    i--\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+        # Test package with pkg.depend.explicit-install=true
+        # can be installed if a different version of it has already
+        # been installed.
+        self.pkgsend_bulk(self.rurl, self.pkgs6)
+        self.pkg("install p2@1.0")
+        self.pkg("install p1")
 
-                # Test hierarchic dependencies.
-                self.pkgsend_bulk(self.rurl, self.pkgs5)
-                self.pkg("install -v Hiera1@1.0", exit=1)
+    def test_02_update_reject(self):
+        self.image_create(self.rurl, prefix="")
+        self.pkgsend_bulk(self.rurl, self.pkgs2)
+        self.pkgsend_bulk(self.rurl, self.pkgs3)
+        self.pkg("install -v --reject idr group incorp")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = (
+            "A    1.0-0.1    i--\n"
+            "group    1.0-0    im-\n"
+            "incorp    1.0-0    im-\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-                # Test package with pkg.depend.explicit-install=true
-                # can be installed if a different version of it has already
-                # been installed.
-                self.pkgsend_bulk(self.rurl, self.pkgs6)
-                self.pkg("install p2@1.0")
-                self.pkg("install p1")
+        self.pkg("exact-install -v --reject idr group")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = "A    1.0-0.1    i--\n" "group    1.0-0    im-\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-        def test_02_update_reject(self):
-                self.image_create(self.rurl, prefix="")
-                self.pkgsend_bulk(self.rurl, self.pkgs2)
-                self.pkgsend_bulk(self.rurl, self.pkgs3)
-                self.pkg("install -v --reject idr group incorp")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "A    1.0-0.1    i--\n" \
-                    "group    1.0-0    im-\n" \
-                    "incorp    1.0-0    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+        # This will fail, because idr@1.0-0.1.1.0 is filtered.
+        self.pkg("update -v --reject group A@1.0-0.1.1.0", exit=1)
+        # Explicitly install idr@1.0-0.1.1.0.
+        self.pkg("install idr@1.0-0.1.1.0")
+        # Update again.
+        self.pkg("update -v --reject group A@1.0-0.1.1.0")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = "A    1.0-0.1.1.0    i--\n" "idr    1.0-0.1.1.0    im-\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("exact-install -v --reject idr group")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "A    1.0-0.1    i--\n" \
-                    "group    1.0-0    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+        # This will fail.
+        self.pkg("update -v --reject idr", exit=1)
+        self.pkg("update")
+        self.pkg("verify")
+        self.pkg("list -H")
+        expected = "A    1.0-0.1.1.2    i--\n" "idr    1.0-0.1.1.2    im-\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-                # This will fail, because idr@1.0-0.1.1.0 is filtered.
-                self.pkg("update -v --reject group A@1.0-0.1.1.0", exit=1)
-                # Explicitly install idr@1.0-0.1.1.0.
-                self.pkg("install idr@1.0-0.1.1.0")
-                # Update again.
-                self.pkg("update -v --reject group A@1.0-0.1.1.0")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "A    1.0-0.1.1.0    i--\n" \
-                    "idr    1.0-0.1.1.0    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+    def test_03_linked(self):
+        """Ensure pkg.depend.explicit-install works as expected for
+        linked images."""
 
-                # This will fail.
-                self.pkg("update -v --reject idr", exit=1)
-                self.pkg("update")
-                self.pkg("verify")
-                self.pkg("list -H")
-                expected = \
-                    "A    1.0-0.1.1.2    i--\n" \
-                    "idr    1.0-0.1.1.2    im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+        self.set_image(0)
+        self.image_create(self.rurl)
+        self.set_image(1)
+        self.image_create(self.rurl)
 
-        def test_03_linked(self):
-                """Ensure pkg.depend.explicit-install works as expected for
-                linked images."""
+        # attach child to parent
+        self.set_image(0)
+        self.pkg("attach-linked -c system:img1 {0}".format(self.img_path(1)))
+        self.pkg("list-linked")
+        self.set_image(1)
+        self.pkg("list-linked")
 
-                self.set_image(0)
-                self.image_create(self.rurl)
-                self.set_image(1)
-                self.image_create(self.rurl)
+        # Verify that a package that requires a package marked with
+        # pkg.depend.explict-install cannot be installed in both parent
+        # and child image.
+        self.set_image(0)
+        self.pkg("install -nv A@1.0-0.1.1.0", exit=1)
+        self.set_image(1)
+        self.pkg("install -nv A@1.0-0.1.1.0", exit=1)
 
-                # attach child to parent
-                self.set_image(0)
-                self.pkg("attach-linked -c system:img1 {0}".format(
-                    self.img_path(1)))
-                self.pkg("list-linked")
-                self.set_image(1)
-                self.pkg("list-linked")
+        # Install a package that requires a package marked with
+        # pkg.depend.explicit-install into a parent image and then
+        # verify that package cannot be installed in the child image
+        # if the required package is not parent constrained and is not
+        # proposed.
+        self.set_image(0)
+        self.pkg("install -v A@1.0-0.1.1.0 idr")
+        self.set_image(1)
+        self.pkg("install -nv A@1.0-0.1.1.0", exit=1)
+        self.set_image(0)
+        self.pkg("uninstall -v \\*")
 
-                # Verify that a package that requires a package marked with
-                # pkg.depend.explict-install cannot be installed in both parent
-                # and child image.
-                self.set_image(0)
-                self.pkg("install -nv A@1.0-0.1.1.0", exit=1)
-                self.set_image(1)
-                self.pkg("install -nv A@1.0-0.1.1.0", exit=1)
+        # Verify that a package that depends on a parent-constrained
+        # package that is also marked with pkg.depend.explicit-install
+        # cannot be installed in a child image if the parent constraint
+        # is not satisfied and produces the expected error.
+        self.set_image(1)
+        self.pkg("install -nv B@1.0-0.1.1.0", exit=1)
 
-                # Install a package that requires a package marked with
-                # pkg.depend.explicit-install into a parent image and then
-                # verify that package cannot be installed in the child image
-                # if the required package is not parent constrained and is not
-                # proposed.
-                self.set_image(0)
-                self.pkg("install -v A@1.0-0.1.1.0 idr")
-                self.set_image(1)
-                self.pkg("install -nv A@1.0-0.1.1.0", exit=1)
-                self.set_image(0)
-                self.pkg("uninstall -v \\*")
+        # Verify that a package that depends on a parent-constrained
+        # package that is also marked with pkg.depend.explicit-install
+        # can be installed in a parent image *if* the marked package is
+        # also proposed.
+        self.set_image(0)
+        self.pkg("install -v B@1.0-0.1.1.0 idrb")
 
-                # Verify that a package that depends on a parent-constrained
-                # package that is also marked with pkg.depend.explicit-install
-                # cannot be installed in a child image if the parent constraint
-                # is not satisfied and produces the expected error.
-                self.set_image(1)
-                self.pkg("install -nv B@1.0-0.1.1.0", exit=1)
+        # Verify that a package that depends on a parent-constrained
+        # package that is also marked with pkg.depend.explicit-install
+        # can be installed in a child image *without* proposing the
+        # required package if the parent constraint is satisfied.
+        self.set_image(1)
+        self.pkg("install -nv B@1.0-0.1.1.0")
+        self.set_image(0)
+        self.pkg("uninstall -v \\*")
 
-                # Verify that a package that depends on a parent-constrained
-                # package that is also marked with pkg.depend.explicit-install
-                # can be installed in a parent image *if* the marked package is
-                # also proposed.
-                self.set_image(0)
-                self.pkg("install -v B@1.0-0.1.1.0 idrb")
+        # Install a parent-constrained package that requires a package
+        # marked with pkg.depend.explicit-install that is *not*
+        # parent-constrained into a parent image and then verify that
+        # package cannot be installed in the child image if the required
+        # package is not proposed.
+        self.set_image(0)
+        self.pkg("install -v D@1.0-0.1.1.0 idrd")
+        self.set_image(1)
+        self.pkg("install -nv D@1.0-0.1.1.0", exit=1)
+        self.set_image(0)
+        self.pkg("uninstall -r \\*")
 
-                # Verify that a package that depends on a parent-constrained
-                # package that is also marked with pkg.depend.explicit-install
-                # can be installed in a child image *without* proposing the
-                # required package if the parent constraint is satisfied.
-                self.set_image(1)
-                self.pkg("install -nv B@1.0-0.1.1.0")
-                self.set_image(0)
-                self.pkg("uninstall -v \\*")
+    def test_04_linked_upgrade(self):
+        """Ensure pkg.depend.explicit-install works as expected for
+        linked image upgrades."""
 
-                # Install a parent-constrained package that requires a package
-                # marked with pkg.depend.explicit-install that is *not*
-                # parent-constrained into a parent image and then verify that
-                # package cannot be installed in the child image if the required
-                # package is not proposed.
-                self.set_image(0)
-                self.pkg("install -v D@1.0-0.1.1.0 idrd")
-                self.set_image(1)
-                self.pkg("install -nv D@1.0-0.1.1.0", exit=1)
-                self.set_image(0)
-                self.pkg("uninstall -r \\*")
+        self.set_image(0)
+        self.image_create(self.rurl)
+        self.set_image(1)
+        self.image_create(self.rurl)
 
-        def test_04_linked_upgrade(self):
-                """Ensure pkg.depend.explicit-install works as expected for
-                linked image upgrades."""
+        # attach child to parent
+        self.set_image(0)
+        self.pkg("attach-linked -c system:img1 {0}".format(self.img_path(1)))
 
-                self.set_image(0)
-                self.image_create(self.rurl)
-                self.set_image(1)
-                self.image_create(self.rurl)
+        # Install a package into a parent image and child image, and
+        # then verify that upgrading the version in the parent image to
+        # one that requires a package that depends on a parent-constrained
+        # package that is also marked with pkg.depend.explicit-install
+        # also upgrades the child image.
+        self.set_image(0)
+        self.pkg("install -v C")
+        self.pkg("list C@1.0-0.1.1.0", exit=1)
+        self.set_image(1)
+        self.pkg("install -v C")
+        self.pkg("list C@1.0-0.1.1.0", exit=1)
+        # Now upgrade package in parent; this should automatically
+        # upgrade parent-constrained packages in child.
+        self.set_image(0)
+        self.pkg("install -v C@1.0-0.1.1.0 idrc")
+        self.pkg("list C@1.0-0.1.1.0 idrc")
+        self.set_image(1)
+        self.pkg("list")
+        self.pkg("list C@1.0-0.1.1.0 idrc")
 
-                # attach child to parent
-                self.set_image(0)
-                self.pkg("attach-linked -c system:img1 {0}".format(
-                    self.img_path(1)))
+    def test_05_exact_install_downgrade(self):
+        """Ensure explicit-install allows downgrade of
+        existing packages w/ explicit-install."""
 
-                # Install a package into a parent image and child image, and
-                # then verify that upgrading the version in the parent image to
-                # one that requires a package that depends on a parent-constrained
-                # package that is also marked with pkg.depend.explicit-install
-                # also upgrades the child image.
-                self.set_image(0)
-                self.pkg("install -v C")
-                self.pkg("list C@1.0-0.1.1.0", exit=1)
-                self.set_image(1)
-                self.pkg("install -v C")
-                self.pkg("list C@1.0-0.1.1.0", exit=1)
-                # Now upgrade package in parent; this should automatically
-                # upgrade parent-constrained packages in child.
-                self.set_image(0)
-                self.pkg("install -v C@1.0-0.1.1.0 idrc")
-                self.pkg("list C@1.0-0.1.1.0 idrc")
-                self.set_image(1)
-                self.pkg("list")
-                self.pkg("list C@1.0-0.1.1.0 idrc")
+        self.image_create(self.rurl)
+        self.pkgsend_bulk(self.rurl, self.pkgs7)
+        self.pkg("install idrDG@1 downgrade@1.0.1 incorpDG1@1.0")
+        self.pkg("list idrDG@1 downgrade@1.0.1 incorpDG1@1.0")
+        # downgrade should go back to downgrade@1.0 and idrDG should
+        # be removed.
+        self.pkg("exact-install incorpDG1@1.0")
+        self.pkg("list idrDG@1", exit=1)
+        self.pkg("list downgrade@1.0.1", exit=1)
+        self.pkg("list downgrade@1.0 incorpDG1@1.0")
 
-        def test_05_exact_install_downgrade(self):
-                """Ensure explicit-install allows downgrade of
-                existing packages w/ explicit-install."""
+    def test_06_refresh_manual(self):
+        self.image_create(self.rurl, prefix="")
+        self.pkgsend_bulk(self.rurl, self.pkgs3)
 
-                self.image_create(self.rurl)
-                self.pkgsend_bulk(self.rurl, self.pkgs7)
-                self.pkg("install idrDG@1 downgrade@1.0.1 incorpDG1@1.0")
-                self.pkg("list idrDG@1 downgrade@1.0.1 incorpDG1@1.0")
-                # downgrade should go back to downgrade@1.0 and idrDG should
-                # be removed.
-                self.pkg("exact-install incorpDG1@1.0")
-                self.pkg("list idrDG@1", exit=1)
-                self.pkg("list downgrade@1.0.1", exit=1)
-                self.pkg("list downgrade@1.0 incorpDG1@1.0")
+        # Test that a refresh and a full refresh do not remove the
+        # 'manual' flag from an installed package.
 
-        def test_06_refresh_manual(self):
-                self.image_create(self.rurl, prefix="")
-                self.pkgsend_bulk(self.rurl, self.pkgs3)
+        self.pkg("install -v idr")
 
-                # Test that a refresh and a full refresh do not remove the
-                # 'manual' flag from an installed package.
+        expected = "idr    1.0-0.1.1.2    im-\n"
+        expected = self.reduceSpaces(expected)
 
-                self.pkg("install -v idr")
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                expected = \
-                    "idr    1.0-0.1.1.2    im-\n"
-                expected = self.reduceSpaces(expected)
+        self.pkg("refresh")
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg("refresh --full")
+        self.pkg("list -H")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("refresh")
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("refresh --full")
-                self.pkg("list -H")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
 
 class TestPkgOSDowngrade(pkg5unittest.ManyDepotTestCase):
-        persistent_setup = True
+    persistent_setup = True
 
-        pkgs = (
-            """
+    pkgs = (
+        """
                 open entire@5.12-5.12.0.0.0.96.0
                 add set name=pkg.depend.install-hold value=core-os
                 add depend fmri=consolidation/osnet/osnet-incorporation type=require
@@ -12830,306 +13234,312 @@ class TestPkgOSDowngrade(pkg5unittest.ManyDepotTestCase):
                 add depend fmri=consolidation/install/install-incorporation@5.12-5.12.0.0.0.4.0 facet.version-lock.consolidation/install/install-incorporation=true type=incorporate
                 close
             """
-            """
+        """
                 open consolidation/install/install-incorporation@5.12-5.12.0.0.0.4.0
                 add depend fmri=consolidation/osnet/osnet-incorporation type=require
                 close
             """
-            """
+        """
                 open consolidation/osnet/osnet-incorporation@5.12-5.12.0.0.0.96.1
                 add set name=pkg.depend.install-hold value=core-os.osnet
                 add depend fmri=pkg:/system/data/terminfo/terminfo-core@5.12,5.12-5.12.0.0.0.96.1 type=incorporate
                 close
             """
-            """
+        """
                 open system/data/terminfo/terminfo-core@5.12-5.12.0.0.0.96.1
                 add depend fmri=consolidation/osnet/osnet-incorporation type=require
                 close
             """
-        )
+    )
 
-        nightly_pkgs = (
-            """
+    nightly_pkgs = (
+        """
                 open consolidation/osnet/osnet-incorporation@5.12-5.12.0.0.0.97.32830
                 add set name=pkg.depend.install-hold value=core-os.osnet
                 add depend fmri=pkg:/system/data/terminfo/terminfo-core@5.12-5.12.0.0.0.95.32487 type=incorporate
                 close
             """
-            """
+        """
                 open consolidation/install/install-incorporation@5.12-5.12.0.0.0.4.0
                 add depend fmri=consolidation/osnet/osnet-incorporation type=require
                 close
             """
-            """
+        """
                 open system/data/terminfo/terminfo-core@5.12-5.12.0.0.0.95.32487
                 add depend fmri=consolidation/osnet/osnet-incorporation type=require
                 close
             """
+    )
+
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(self, ["solaris", "nightly"])
+        self.rurl = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
+
+        self.__pkgs = self.pkgsend_bulk(self.rurl, self.pkgs)
+        self.__nightly_pkgs = self.pkgsend_bulk(self.rurl2, self.nightly_pkgs)
+
+    def test_downgrade_update(self):
+        """Verify that incorporated packages not affected by install-holds
+        will be downgraded if the incorporating package is requested by
+        the user or will be updated as part of a general update
+        operation."""
+
+        self.image_create(self.rurl, prefix="")
+        self.pkg("install --parsable=0 entire terminfo-core")
+        self.assertEqualParsable(
+            self.output,
+            add_packages=[
+                self.__pkgs[1],
+                self.__pkgs[2],
+                self.__pkgs[0],
+                self.__pkgs[3],
+            ],
         )
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["solaris", "nightly"])
-                self.rurl = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
+        self.pkg("set-publisher --non-sticky solaris")
+        self.pkg(
+            "change-facet "
+            "version-lock.consolidation/osnet/osnet-incorporation=false"
+        )
+        self.pkg("set-publisher -P -p {0}".format(self.rurl2))
+        self.pkg("publisher")
+        self.pkg("facet")
+        self.pkg("list -afv")
 
-                self.__pkgs = self.pkgsend_bulk(self.rurl, self.pkgs)
-                self.__nightly_pkgs = self.pkgsend_bulk(self.rurl2, self.nightly_pkgs)
+        # In this case, we expect osnet-incorporation to be upgraded and
+        # terminfo-core to be downgraded; install-incorporation should
+        # not be modified since it was not named on the command-line.
+        self.pkg("update --parsable=0 -n osnet-incorporation")
+        self.assertEqualParsable(
+            self.output,
+            change_packages=[
+                [self.__pkgs[2], self.__nightly_pkgs[0]],
+                [self.__pkgs[3], self.__nightly_pkgs[2]],
+            ],
+        )
 
-        def test_downgrade_update(self):
-                """Verify that incorporated packages not affected by install-holds
-                will be downgraded if the incorporating package is requested by
-                the user or will be updated as part of a general update
-                operation."""
-
-                self.image_create(self.rurl, prefix="")
-                self.pkg("install --parsable=0 entire terminfo-core")
-                self.assertEqualParsable(self.output,
-                    add_packages=[self.__pkgs[1], self.__pkgs[2],
-                        self.__pkgs[0], self.__pkgs[3]]
-                )
-
-                self.pkg("set-publisher --non-sticky solaris")
-                self.pkg("change-facet "
-                    "version-lock.consolidation/osnet/osnet-incorporation=false")
-                self.pkg("set-publisher -P -p {0}".format(self.rurl2))
-                self.pkg("publisher")
-                self.pkg("facet")
-                self.pkg("list -afv")
-
-                # In this case, we expect osnet-incorporation to be upgraded and
-                # terminfo-core to be downgraded; install-incorporation should
-                # not be modified since it was not named on the command-line.
-                self.pkg("update --parsable=0 -n osnet-incorporation")
-                self.assertEqualParsable(self.output,
-                    change_packages=[
-                        [self.__pkgs[2], self.__nightly_pkgs[0]],
-                        [self.__pkgs[3], self.__nightly_pkgs[2]]
-                    ]
-                )
-
-                # In this case, we expect osnet-incorporation and
-                # install-incorporation to be upgraded, and terminfo-core to be
-                # downgraded.
-                self.pkg("update --parsable=0 -n")
-                self.assertEqualParsable(self.output,
-                    change_packages=[
-                        [self.__pkgs[1], self.__nightly_pkgs[1]],
-                        [self.__pkgs[2], self.__nightly_pkgs[0]],
-                        [self.__pkgs[3], self.__nightly_pkgs[2]]
-                    ]
-                )
+        # In this case, we expect osnet-incorporation and
+        # install-incorporation to be upgraded, and terminfo-core to be
+        # downgraded.
+        self.pkg("update --parsable=0 -n")
+        self.assertEqualParsable(
+            self.output,
+            change_packages=[
+                [self.__pkgs[1], self.__nightly_pkgs[1]],
+                [self.__pkgs[2], self.__nightly_pkgs[0]],
+                [self.__pkgs[3], self.__nightly_pkgs[2]],
+            ],
+        )
 
 
 class TestPkgUpdateDowngradeIncorp(pkg5unittest.ManyDepotTestCase):
-        persistent_setup = True
+    persistent_setup = True
 
-        pkgs = (
-                """
+    pkgs = (
+        """
                     open A@1.0,5.11-0
                     close """,
-                """
+        """
                     open A@2.0,5.11-0
                     close """,
-                """
+        """
                     open B@1.0,5.11-0
                     add set pkg.depend.install-hold=B
                     close """,
-                """
+        """
                     open B@2.0,5.11-0
                     add set pkg.depend.install-hold=B
                     close """,
-                """
+        """
                     open C@1.0,5.11-0
                     add set pkg.depend.install-hold=parent.C
                     close """,
-                """
+        """
                     open C@2.0,5.11-0
                     add set pkg.depend.install-hold=parent.C
                     close """,
-                """
+        """
                     open incorp@1.0,5.11-0
                     add depend type=incorporate fmri=A@2.0
                     close """,
-                """
+        """
                     open incorp@2.0,5.11-0
                     add depend type=incorporate fmri=A@1.0
                     close """,
-                """
+        """
                     open parent_incorp@1.0,5.11-0
                     add depend type=incorporate fmri=child_incorp@2.0
                     close """,
-                """
+        """
                     open parent_incorp@2.0,5.11-0
                     add depend type=incorporate fmri=child_incorp@1.0
                     close """,
-                """
+        """
                     open parent_incorp@3.0,5.11-0
                     add depend type=incorporate fmri=child_incorp@3.0
                     close """,
-                """
+        """
                     open child_incorp@1.0,5.11-0
                     add depend type=incorporate fmri=A@1.0
                     close """,
-                """
+        """
                     open child_incorp@2.0,5.11-0
                     add depend type=incorporate fmri=A@2.0
                     close """,
-                """
+        """
                     open child_incorp@3.0,5.11-0
                     add depend type=incorporate fmri=A@1.0
                     close """,
-                """
+        """
                     open ihold_incorp@1.0,5.11-0
                     add set pkg.depend.install-hold=parent
                     add depend type=incorporate fmri=B@1.0
                     add depend type=incorporate fmri=C@1.0
                     close """,
-                """
+        """
                     open ihold_incorp@2.0,5.11-0
                     add set pkg.depend.install-hold=parent
                     add depend type=incorporate fmri=B@2.0
                     add depend type=incorporate fmri=C@2.0
                     close """,
-
-                """
+        """
                     open p_incorp@1.0,5.11-0
                     add depend type=incorporate fmri=D@2.0
                     close """,
-
-                """
+        """
                     open p_incorp@2.0,5.11-0
                     add depend type=incorporate fmri=D@1.0
                     close """,
-
-                """
+        """
                     open D@2.0,5.11-0
                     close """,
-                )
+    )
 
-        pub2_pkgs = (
-                """
+    pub2_pkgs = (
+        """
                     open D@1.0,5.11-0
                     close """,
-                )
+    )
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
-                self.rurl = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
+        self.rurl = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
 
-                self.pkgsend_bulk(self.rurl, self.pkgs)
-                self.pkgsend_bulk(self.rurl2, self.pub2_pkgs)
+        self.pkgsend_bulk(self.rurl, self.pkgs)
+        self.pkgsend_bulk(self.rurl2, self.pub2_pkgs)
 
-        def test_exact_install_downgrade(self):
-                """ Test exact-install downgrade."""
+    def test_exact_install_downgrade(self):
+        """Test exact-install downgrade."""
 
-                self.image_create(self.rurl, prefix="")
-                self.pkg("install A@2.0")
-                self.pkg("list A@2.0")
-                # Test exact-install A to a lower version.
-                self.pkg("exact-install A@1.0")
-                self.pkg("list A@1.0")
+        self.image_create(self.rurl, prefix="")
+        self.pkg("install A@2.0")
+        self.pkg("list A@2.0")
+        # Test exact-install A to a lower version.
+        self.pkg("exact-install A@1.0")
+        self.pkg("list A@1.0")
 
-                self.pkg("install A incorp@1")
-                self.pkg("list A@2.0 incorp@1.0")
+        self.pkg("install A incorp@1")
+        self.pkg("list A@2.0 incorp@1.0")
 
-                # When incorp moves forward, A should move backwards
-                self.pkg("exact-install A incorp@2")
-                self.pkg("list A@1.0 incorp@2.0")
+        # When incorp moves forward, A should move backwards
+        self.pkg("exact-install A incorp@2")
+        self.pkg("list A@1.0 incorp@2.0")
 
-                self.pkg("install ihold_incorp@2 B")
-                self.pkg("list ihold_incorp@2 B@2")
+        self.pkg("install ihold_incorp@2 B")
+        self.pkg("list ihold_incorp@2 B@2")
 
-                # Test exact-install incorp with install-holds.
-                self.pkg("exact-install ihold_incorp@1 B")
-                self.pkg("list ihold_incorp@1 B@1")
+        # Test exact-install incorp with install-holds.
+        self.pkg("exact-install ihold_incorp@1 B")
+        self.pkg("list ihold_incorp@1 B@1")
 
-                self.pkg("install ihold_incorp@2 B")
-                self.pkg("exact-install ihold_incorp@1")
-                self.pkg("list ihold_incorp@1")
-                self.pkg("list B", exit=1)
+        self.pkg("install ihold_incorp@2 B")
+        self.pkg("exact-install ihold_incorp@1")
+        self.pkg("list ihold_incorp@1")
+        self.pkg("list B", exit=1)
 
-        def test_incorp_downgrade(self):
-                """ Test that downgrades are allowed if they are incorporated
-                by FMRIs which are requested by the user or are about to be
-                updated as part of an update-all operation."""
+    def test_incorp_downgrade(self):
+        """Test that downgrades are allowed if they are incorporated
+        by FMRIs which are requested by the user or are about to be
+        updated as part of an update-all operation."""
 
-                self.image_create(self.rurl, prefix="")
-                self.pkg("install A incorp@1")
-                self.pkg("list A@2.0 incorp@1.0")
+        self.image_create(self.rurl, prefix="")
+        self.pkg("install A incorp@1")
+        self.pkg("list A@2.0 incorp@1.0")
 
-                # When incorp moves forward, A should move backwards
-                self.pkg("update incorp@2")
-                self.pkg("list A@1.0 incorp@2.0")
+        # When incorp moves forward, A should move backwards
+        self.pkg("update incorp@2")
+        self.pkg("list A@1.0 incorp@2.0")
 
-                # start over and test if that also works if we do an update all
-                self.pkg("update incorp@1")
-                self.pkg("update -v")
-                self.pkg("list A@1.0 incorp@2.0")
+        # start over and test if that also works if we do an update all
+        self.pkg("update incorp@1")
+        self.pkg("update -v")
+        self.pkg("list A@1.0 incorp@2.0")
 
-                # prepare test for nested incorporations
-                self.pkg("uninstall incorp")
-                self.pkg("update A@2")
-                self.pkg("install parent_incorp@1 child_incorp@2")
-                self.pkg("list A@2.0 child_incorp@2 parent_incorp@1")
+        # prepare test for nested incorporations
+        self.pkg("uninstall incorp")
+        self.pkg("update A@2")
+        self.pkg("install parent_incorp@1 child_incorp@2")
+        self.pkg("list A@2.0 child_incorp@2 parent_incorp@1")
 
-                # test upgrade of parent incorporation allows downgrade of child
-                # incorporation and packages incorporated by child
-                self.pkg("update -v parent_incorp@2")
-                self.pkg("list A@1 child_incorp@1 parent_incorp@2")
+        # test upgrade of parent incorporation allows downgrade of child
+        # incorporation and packages incorporated by child
+        self.pkg("update -v parent_incorp@2")
+        self.pkg("list A@1 child_incorp@1 parent_incorp@2")
 
-                # reset and test upgrade of parent incorporation allows
-                # downgrade of packages incorporated by child
-                self.pkg("update -v parent_incorp@1")
-                self.pkg("list A@2 child_incorp@2 parent_incorp@1")
-                self.pkg("update -v parent_incorp@3")
-                self.pkg("list A@1 child_incorp@3 parent_incorp@3")
+        # reset and test upgrade of parent incorporation allows
+        # downgrade of packages incorporated by child
+        self.pkg("update -v parent_incorp@1")
+        self.pkg("list A@2 child_incorp@2 parent_incorp@1")
+        self.pkg("update -v parent_incorp@3")
+        self.pkg("list A@1 child_incorp@3 parent_incorp@3")
 
-                # prepare test for explicit downgrade of incorp
-                self.pkg("uninstall parent_incorp")
-                self.pkg("update child_incorp@2")
-                self.pkg("list A@2 child_incorp@2")
+        # prepare test for explicit downgrade of incorp
+        self.pkg("uninstall parent_incorp")
+        self.pkg("update child_incorp@2")
+        self.pkg("list A@2 child_incorp@2")
 
-                # test explicit downgrade of incorp downgrades incorp'ed pkgs
-                self.pkg("update -v child_incorp@1")
-                self.pkg("list A@1 child_incorp@1")
+        # test explicit downgrade of incorp downgrades incorp'ed pkgs
+        self.pkg("update -v child_incorp@1")
+        self.pkg("list A@1 child_incorp@1")
 
-        def test_incorp_downgrade_installhold(self):
-                """Test correct handling of install-holds when determining
-                which pkgs are ok to downgrade."""
+    def test_incorp_downgrade_installhold(self):
+        """Test correct handling of install-holds when determining
+        which pkgs are ok to downgrade."""
 
-                # prepare test for install-hold
-                self.image_create(self.rurl, prefix="")
-                self.pkg("install ihold_incorp@2 B")
-                self.pkg("list ihold_incorp@2 B@2")
-                # test that install hold prevents downgrade
-                self.pkg("update -v ihold_incorp@1", exit=1)
+        # prepare test for install-hold
+        self.image_create(self.rurl, prefix="")
+        self.pkg("install ihold_incorp@2 B")
+        self.pkg("list ihold_incorp@2 B@2")
+        # test that install hold prevents downgrade
+        self.pkg("update -v ihold_incorp@1", exit=1)
 
-                # prep test for parent install-hold
-                self.pkg("install --reject B C@2")
-                self.pkg("list ihold_incorp@2 C@2")
-                # test that downgrade is allowed if install-hold is child of
-                # requested FMRI
-                self.pkg("update -v ihold_incorp@1")
-                self.pkg("list ihold_incorp@1 C@1")
+        # prep test for parent install-hold
+        self.pkg("install --reject B C@2")
+        self.pkg("list ihold_incorp@2 C@2")
+        # test that downgrade is allowed if install-hold is child of
+        # requested FMRI
+        self.pkg("update -v ihold_incorp@1")
+        self.pkg("list ihold_incorp@1 C@1")
 
-        def test_incorp_downgrade_pubswitch(self):
-                """Test that implicit publisher switches of incorporated pkgs
-                are not allowed."""
+    def test_incorp_downgrade_pubswitch(self):
+        """Test that implicit publisher switches of incorporated pkgs
+        are not allowed."""
 
-                # prepare test for publisher switch
-                self.image_create(self.rurl, prefix="")
-                self.pkg("set-publisher --non-sticky test1")
-                self.pkg("set-publisher --non-sticky -p {0}".format(self.rurl2))
-                self.pkg("list -af")
-                self.pkg("install p_incorp@1 D@2")
-                self.pkg("list p_incorp@1 D@2")
+        # prepare test for publisher switch
+        self.image_create(self.rurl, prefix="")
+        self.pkg("set-publisher --non-sticky test1")
+        self.pkg("set-publisher --non-sticky -p {0}".format(self.rurl2))
+        self.pkg("list -af")
+        self.pkg("install p_incorp@1 D@2")
+        self.pkg("list p_incorp@1 D@2")
 
-                self.pkg("update p_incorp@2", exit=1)
+        self.pkg("update p_incorp@2", exit=1)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_intent.py
+++ b/src/tests/cli/t_pkg_intent.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -37,301 +38,350 @@ import pkg.client.api as api
 
 
 class TestPkgIntent(pkg5unittest.SingleDepotTestCase):
-
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1 timestamp="20080731T024051Z"
             close """
-        foo11_timestamp = 1217472051
+    foo11_timestamp = 1217472051
 
-        foo12 = """
+    foo12 = """
             open foo@1.2,5.11-0
             add file tmp/libc.so.1 mode=0555 owner=root group=bin path=/lib/libc.so.1
             close """
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             add depend type=require fmri=pkg:/foo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        bar11 = """
+    bar11 = """
             open bar@1.1,5.11-0
             add depend type=require fmri=pkg:/foo@1.2
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        bar12 = """
+    bar12 = """
             open bar@1.2,5.11-0
             add depend type=require fmri=pkg:/foo@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/cat mode=0555 owner=root group=bin path=/bin/cat
             close """
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             add depend type=require fmri=pkg:/bar@1.0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/baz mode=0555 owner=root group=bin path=/bin/baz
             close """
 
-        misc_files = [ "tmp/libc.so.1", "tmp/cat", "tmp/baz" ]
+    misc_files = ["tmp/libc.so.1", "tmp/cat", "tmp/baz"]
 
-        def setUp(self):
-                # This test suite needs an actual depot.
-                pkg5unittest.SingleDepotTestCase.setUp(self,
-                    debug_features=["headers"], start_depot=True)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        # This test suite needs an actual depot.
+        pkg5unittest.SingleDepotTestCase.setUp(
+            self, debug_features=["headers"], start_depot=True
+        )
+        self.make_misc_files(self.misc_files)
 
-        def get_intent_entries(self):
-                """Scan logpath looking for request header log entries for
-                X-IPkg-Intent.  Returns a list of dicts each representing
-                an intent entry."""
+    def get_intent_entries(self):
+        """Scan logpath looking for request header log entries for
+        X-IPkg-Intent.  Returns a list of dicts each representing
+        an intent entry."""
 
-                hdr = "X-IPKG-INTENT:"
+        hdr = "X-IPKG-INTENT:"
 
-                entries = []
-                for i in sorted(self.dcs.keys()):
-                        dc = self.dcs[i]
-                        logpath = dc.get_logpath()
-                        self.debug("check for intent entries in {0}".format(logpath))
-                        logfile = open(logpath, "r")
-                        for line in logfile.readlines():
-                                spos = line.find(hdr)
-                                if spos > -1:
-                                        spos += len(hdr)
-                                        l = line[spos:].strip()
-                                        l = l.strip("()")
-                                        d = {}
-                                        for e in l.split(";"):
-                                                k, v = e.split("=")
-                                                d[k] = v
-                                        if d:
-                                                entries.append(d)
-                return entries
+        entries = []
+        for i in sorted(self.dcs.keys()):
+            dc = self.dcs[i]
+            logpath = dc.get_logpath()
+            self.debug("check for intent entries in {0}".format(logpath))
+            logfile = open(logpath, "r")
+            for line in logfile.readlines():
+                spos = line.find(hdr)
+                if spos > -1:
+                    spos += len(hdr)
+                    l = line[spos:].strip()
+                    l = l.strip("()")
+                    d = {}
+                    for e in l.split(";"):
+                        k, v = e.split("=")
+                        d[k] = v
+                    if d:
+                        entries.append(d)
+        return entries
 
-        def intent_entry_exists(self, entries, expected):
-                """Returns a boolean value indicating whether the expected
-                intent entry was found."""
-                for entry in entries:
-                        if entry == expected:
-                                return True
-                self.debug("Intent log entries:\n{0}".format(
-                    "\n".join(str(e) for e in entries)))
-                self.debug("Unable to match:\n{0}".format(expected))
-                return False
+    def intent_entry_exists(self, entries, expected):
+        """Returns a boolean value indicating whether the expected
+        intent entry was found."""
+        for entry in entries:
+            if entry == expected:
+                return True
+        self.debug(
+            "Intent log entries:\n{0}".format(
+                "\n".join(str(e) for e in entries)
+            )
+        )
+        self.debug("Unable to match:\n{0}".format(expected))
+        return False
 
-        @staticmethod
-        def __do_install(api_obj, fmris, noexecute=False):
-                api_obj.reset()
-                for pd in api_obj.gen_plan_install(fmris, noexecute=noexecute):
-                        continue
-                if not noexecute:
-                        api_obj.prepare()
-                        api_obj.execute_plan()
+    @staticmethod
+    def __do_install(api_obj, fmris, noexecute=False):
+        api_obj.reset()
+        for pd in api_obj.gen_plan_install(fmris, noexecute=noexecute):
+            continue
+        if not noexecute:
+            api_obj.prepare()
+            api_obj.execute_plan()
 
-        @staticmethod
-        def __do_uninstall(api_obj, fmris, noexecute=False):
-                api_obj.reset()
-                for pd in api_obj.gen_plan_uninstall(fmris,
-                    noexecute=noexecute):
-                        continue
-                if not noexecute:
-                        api_obj.prepare()
-                        api_obj.execute_plan()
+    @staticmethod
+    def __do_uninstall(api_obj, fmris, noexecute=False):
+        api_obj.reset()
+        for pd in api_obj.gen_plan_uninstall(fmris, noexecute=noexecute):
+            continue
+        if not noexecute:
+            api_obj.prepare()
+            api_obj.execute_plan()
 
-        def test_0_info(self):
-                """Verify that informational operations do not send
-                intent information."""
+    def test_0_info(self):
+        """Verify that informational operations do not send
+        intent information."""
 
-                plist = self.pkgsend_bulk(self.durl, self.foo10)
-                api_obj = self.image_create(self.durl)
+        plist = self.pkgsend_bulk(self.durl, self.foo10)
+        api_obj = self.image_create(self.durl)
 
-                api_obj.info(plist, False, frozenset([api.PackageInfo.IDENTITY,
-                    api.PackageInfo.STATE]))
+        api_obj.info(
+            plist,
+            False,
+            frozenset([api.PackageInfo.IDENTITY, api.PackageInfo.STATE]),
+        )
 
-                entries = self.get_intent_entries()
-                self.assertTrue(entries == [])
+        entries = self.get_intent_entries()
+        self.assertTrue(entries == [])
 
-                api_obj.info(plist, False,
-                    frozenset([api.PackageInfo.DEPENDENCIES]))
+        api_obj.info(plist, False, frozenset([api.PackageInfo.DEPENDENCIES]))
 
-                entries = self.get_intent_entries()
-                # Verify that no entries are present
-                self.assertTrue(not entries)
+        entries = self.get_intent_entries()
+        # Verify that no entries are present
+        self.assertTrue(not entries)
 
+    def test_1_install_uninstall(self):
+        """Verify that the install and uninstall of a single package
+        sends the expected intent information."""
 
-        def test_1_install_uninstall(self):
-                """Verify that the install and uninstall of a single package
-                sends the expected intent information."""
+        plist = self.pkgsend_bulk(self.durl, self.foo10)
+        api_obj = self.image_create(self.durl)
 
-                plist = self.pkgsend_bulk(self.durl, self.foo10)
-                api_obj = self.image_create(self.durl)
+        # Test install.
+        self.__do_install(api_obj, ["foo"], noexecute=True)
+        entries = self.get_intent_entries()
+        # no data should be there
+        self.assertTrue(not entries)
 
-                # Test install.
-                self.__do_install(api_obj, ["foo"], noexecute=True)
-                entries = self.get_intent_entries()
-                # no data should be there
-                self.assertTrue(not entries)
+        self.__do_install(api_obj, ["foo"])
 
-                self.__do_install(api_obj, ["foo"])
+        entries = self.get_intent_entries()
 
-                entries = self.get_intent_entries()
+        foo = fmri.PkgFmri(plist[0]).get_fmri(anarchy=True)
 
-                foo = fmri.PkgFmri(plist[0]).get_fmri(anarchy=True)
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {"operation": "install", "new_fmri": foo, "reference": "foo"},
+            )
+        )
 
-                self.assertTrue(self.intent_entry_exists(entries, {
+        # Test uninstall.
+        self.__do_uninstall(api_obj, ["*"])
+
+        # Verify that processing entries are present for uninstall.
+        entries = self.get_intent_entries()
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {"operation": "uninstall", "old_fmri": foo, "reference": "*"},
+            )
+        )
+
+    def test_2_upgrade(self):
+        """Verify the install of a single package, and then an
+        upgrade (install of newer version) of that package sends the
+        expected intent information."""
+
+        plist = self.pkgsend_bulk(self.durl, (self.foo10, self.foo11))
+        api_obj = self.image_create(self.durl)
+
+        foo10 = fmri.PkgFmri(plist[0]).get_fmri(anarchy=True)
+        foo11 = fmri.PkgFmri(plist[1]).get_fmri(anarchy=True)
+
+        # Test install.
+        self.__do_install(api_obj, ["foo@1.0"])
+        self.__do_install(api_obj, ["foo@1.1"])
+
+        # Test uninstall.
+        self.__do_uninstall(api_obj, ["foo"])
+
+        entries = self.get_intent_entries()
+        # Verify that evaluation and processing entries are present
+        # for install.
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {
                     "operation": "install",
-                    "new_fmri" : foo,
-                    "reference": "foo"
-                }))
+                    "new_fmri": foo10,
+                    "reference": "foo@1.0",
+                },
+            )
+        )
 
-                # Test uninstall.
-                self.__do_uninstall(api_obj, ["*"])
-
-                # Verify that processing entries are present for uninstall.
-                entries = self.get_intent_entries()
-                self.assertTrue(self.intent_entry_exists(entries, {
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {
+                    "operation": "install",
+                    "new_fmri": foo11,
+                    "old_fmri": foo10,
+                    "reference": "foo@1.1",
+                },
+            )
+        )
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {
                     "operation": "uninstall",
-                    "old_fmri" :  foo,
-                    "reference": "*"
-                }))
+                    "old_fmri": foo11,
+                    "reference": "foo",
+                },
+            )
+        )
 
-        def test_2_upgrade(self):
-                """Verify the install of a single package, and then an
-                upgrade (install of newer version) of that package sends the
-                expected intent information."""
+    def test_3_dependencies(self):
+        """Verify that an install or uninstall of a single package with
+        a single dependency sends the expected intent information."""
 
-                plist = self.pkgsend_bulk(self.durl, (self.foo10, self.foo11))
-                api_obj = self.image_create(self.durl)
+        plist = self.pkgsend_bulk(self.durl, (self.foo10, self.bar10))
+        api_obj = self.image_create(self.durl)
 
-                foo10 = fmri.PkgFmri(plist[0]).get_fmri(anarchy=True)
-                foo11 = fmri.PkgFmri(plist[1]).get_fmri(anarchy=True)
+        self.__do_install(api_obj, ["bar@1.0"])
+        self.__do_uninstall(api_obj, ["bar", "foo"])
 
-                # Test install.
-                self.__do_install(api_obj, ["foo@1.0"])
-                self.__do_install(api_obj, ["foo@1.1"])
+        foo = fmri.PkgFmri(plist[0]).get_fmri(anarchy=True)
+        bar = fmri.PkgFmri(plist[1]).get_fmri(anarchy=True)
 
-                # Test uninstall.
-                self.__do_uninstall(api_obj, ["foo"])
-
-                entries = self.get_intent_entries()
-                # Verify that evaluation and processing entries are present
-                # for install.
-                self.assertTrue(self.intent_entry_exists(entries, {
+        # Only testing for process; no need to re-test for evaluate.
+        entries = self.get_intent_entries()
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {
                     "operation": "install",
-                    "new_fmri" : foo10,
-                    "reference": "foo@1.0"
-                }))
+                    "new_fmri": bar,
+                    "reference": "bar@1.0",
+                },
+            )
+        )
 
-                self.assertTrue(self.intent_entry_exists(entries, {
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {
                     "operation": "install",
-                    "new_fmri" : foo11,
-                    "old_fmri" : foo10,
-                    "reference": "foo@1.1"
-                }))
-                self.assertTrue(self.intent_entry_exists(entries, {
-                    "operation": "uninstall",
-                    "old_fmri" :  foo11,
-                    "reference": "foo"
-                }))
+                    "new_fmri": foo,
+                },
+            )
+        )
 
-        def test_3_dependencies(self):
-                """Verify that an install or uninstall of a single package with
-                a single dependency sends the expected intent information."""
+    def test_4_image_upgrade(self):
+        """Verify that the correct intent information is sent during an
+        image upgrade."""
 
-                plist = self.pkgsend_bulk(self.durl, (self.foo10, self.bar10))
-                api_obj = self.image_create(self.durl)
+        fmri_list = ["foo10", "foo11", "bar10", "foo12", "bar11"]
 
-                self.__do_install(api_obj, ["bar@1.0"])
-                self.__do_uninstall(api_obj, ["bar", "foo"])
+        plist = []
+        plist.extend(
+            self.pkgsend_bulk(self.durl, (self.foo10, self.foo11, self.bar10))
+        )
 
+        api_obj = self.image_create(self.durl)
 
-                foo = fmri.PkgFmri(plist[0]).get_fmri(anarchy=True)
-                bar = fmri.PkgFmri(plist[1]).get_fmri(anarchy=True)
+        self.__do_install(api_obj, ["bar@1.0"])
 
-                # Only testing for process; no need to re-test for evaluate.
-                entries = self.get_intent_entries()
-                self.assertTrue(self.intent_entry_exists(entries, {
-                    "operation": "install",
-                    "new_fmri" : bar,
-                    "reference": "bar@1.0"
-                }))
+        plist.extend(self.pkgsend_bulk(self.durl, (self.foo12, self.bar11)))
 
-                self.assertTrue(self.intent_entry_exists(entries, {
-                    "operation": "install",
-                    "new_fmri" : foo,
-                }))
+        def print_fmri(a):
+            return fmri.PkgFmri(a).get_fmri(anarchy=True)
 
-        def test_4_image_upgrade(self):
-                """Verify that the correct intent information is sent during an
-                image upgrade."""
+        fmris = dict(zip(fmri_list, [print_fmri(p) for p in plist]))
 
-                fmri_list = ["foo10", "foo11", "bar10", "foo12", "bar11"]
+        api_obj.refresh(immediate=True)
 
-                plist = []
-                plist.extend(self.pkgsend_bulk(self.durl, (self.foo10,
-                    self.foo11, self.bar10)))
+        api_obj.reset()
+        for pd in api_obj.gen_plan_update():
+            continue
+        api_obj.prepare()
+        api_obj.execute_plan()
 
-                api_obj = self.image_create(self.durl)
+        # uninstall foo & bar
+        self.__do_uninstall(api_obj, ["foo", "bar"])
 
-                self.__do_install(api_obj, ["bar@1.0"])
-
-                plist.extend(self.pkgsend_bulk(self.durl, (self.foo12,
-                    self.bar11)))
-
-                def print_fmri(a):
-                        return fmri.PkgFmri(a).get_fmri(anarchy=True)
-
-                fmris = dict(zip(fmri_list, [print_fmri(p) for p in plist]))
-
-                api_obj.refresh(immediate=True)
-
-                api_obj.reset()
-                for pd in api_obj.gen_plan_update():
-                        continue
-                api_obj.prepare()
-                api_obj.execute_plan()
-
-                # uninstall foo & bar
-                self.__do_uninstall(api_obj, ["foo", "bar"])
-
-                entries = self.get_intent_entries()
-                # Verify that foo11 was installed when upgrading to foo12.
-                self.assertTrue(self.intent_entry_exists(entries, {
+        entries = self.get_intent_entries()
+        # Verify that foo11 was installed when upgrading to foo12.
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {
                     "operation": "update",
-                    "new_fmri" : fmris["foo12"],
-                    "old_fmri" : fmris["foo11"]
-                }))
+                    "new_fmri": fmris["foo12"],
+                    "old_fmri": fmris["foo11"],
+                },
+            )
+        )
 
-                # Verify that bar10 was installed when upgrading to bar11.
-                self.assertTrue(self.intent_entry_exists(entries, {
+        # Verify that bar10 was installed when upgrading to bar11.
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {
                     "operation": "update",
-                    "new_fmri" : fmris["bar11"],
-                    "old_fmri" : fmris["bar10"]
-                }))
-                # Verify that bar and foo were uninstalled
-                self.assertTrue(self.intent_entry_exists(entries, {
+                    "new_fmri": fmris["bar11"],
+                    "old_fmri": fmris["bar10"],
+                },
+            )
+        )
+        # Verify that bar and foo were uninstalled
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {
                     "operation": "uninstall",
-                    "old_fmri" : fmris["bar11"],
-                    "reference": "bar"
-                }))
-                self.assertTrue(self.intent_entry_exists(entries, {
+                    "old_fmri": fmris["bar11"],
+                    "reference": "bar",
+                },
+            )
+        )
+        self.assertTrue(
+            self.intent_entry_exists(
+                entries,
+                {
                     "operation": "uninstall",
-                    "old_fmri" : fmris["foo12"],
-                    "reference": "foo"
-                }))
+                    "old_fmri": fmris["foo12"],
+                    "reference": "foo",
+                },
+            )
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_linked.py
+++ b/src/tests/cli/t_pkg_linked.py
@@ -29,8 +29,9 @@ from __future__ import division
 from __future__ import print_function
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import operator
@@ -51,78 +52,80 @@ from pkg.client.pkgdefs import *
 
 
 class TestPkgLinked(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        p_all = []
-        p_sync1 = []
-        p_foo1 = []
-        p_vers = [
-            "@1.2,5.11-145:19700101T000001Z",
-            "@1.2,5.11-145:19700101T000000Z", # old time
-            "@1.1,5.11-145:19700101T000000Z", # old ver
-            "@1.1,5.11-144:19700101T000000Z", # old build
-            "@1.0,5.11-144:19700101T000000Z", # oldest
-        ]
-        p_files = [
-            "tmp/bar",
-            "tmp/baz",
-            "tmp/copyright",
-        ]
+    p_all = []
+    p_sync1 = []
+    p_foo1 = []
+    p_vers = [
+        "@1.2,5.11-145:19700101T000001Z",
+        "@1.2,5.11-145:19700101T000000Z",  # old time
+        "@1.1,5.11-145:19700101T000000Z",  # old ver
+        "@1.1,5.11-144:19700101T000000Z",  # old build
+        "@1.0,5.11-144:19700101T000000Z",  # oldest
+    ]
+    p_files = [
+        "tmp/bar",
+        "tmp/baz",
+        "tmp/copyright",
+    ]
 
-        # generate packages that don't need to be synced
-        pkgs = ["foo1" + ver for ver in p_vers]
-        p_foo1_name = dict(zip(range(len(pkgs)), pkgs))
-        for i in p_foo1_name:
-                p_data = "open {0}\n".format(p_foo1_name[i])
-                p_data += """
+    # generate packages that don't need to be synced
+    pkgs = ["foo1" + ver for ver in p_vers]
+    p_foo1_name = dict(zip(range(len(pkgs)), pkgs))
+    for i in p_foo1_name:
+        p_data = "open {0}\n".format(p_foo1_name[i])
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     add file tmp/bar mode=0555 owner=root group=bin path=foo_bär variant.foo=bar
                     add file tmp/baz mode=0555 owner=root group=bin path=foo_bäz variant.foo=baz
                     close\n"""
-                p_foo1.append(p_data)
+        p_foo1.append(p_data)
 
-        pkgs = ["foo2" + ver for ver in p_vers]
-        p_foo2_name = dict(zip(range(len(pkgs)), pkgs))
-        for i in p_foo2_name:
-                p_data = "open {0}\n".format(p_foo2_name[i])
-                p_data += """
+    pkgs = ["foo2" + ver for ver in p_vers]
+    p_foo2_name = dict(zip(range(len(pkgs)), pkgs))
+    for i in p_foo2_name:
+        p_data = "open {0}\n".format(p_foo2_name[i])
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     add file tmp/bar mode=0555 owner=root group=bin path=foo_bar variant.foo=bar
                     add file tmp/baz mode=0555 owner=root group=bin path=foo_baz variant.foo=baz
                     close\n"""
-                p_all.append(p_data)
+        p_all.append(p_data)
 
-        # generate packages that do need to be synced
-        pkgs = ["sync1" + ver for ver in p_vers]
-        p_sync1_name = dict(zip(range(len(pkgs)), pkgs))
-        for i in p_sync1_name:
-                p_data = "open {0}\n".format(p_sync1_name[i])
-                p_data += "add depend type=parent fmri={0}".format(
-                    pkg.actions.depend.DEPEND_SELF)
-                p_data += """
+    # generate packages that do need to be synced
+    pkgs = ["sync1" + ver for ver in p_vers]
+    p_sync1_name = dict(zip(range(len(pkgs)), pkgs))
+    for i in p_sync1_name:
+        p_data = "open {0}\n".format(p_sync1_name[i])
+        p_data += "add depend type=parent fmri={0}".format(
+            pkg.actions.depend.DEPEND_SELF
+        )
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     add file tmp/bar mode=0555 owner=root group=bin path=sync1_bar variant.foo=bar
                     add file tmp/baz mode=0555 owner=root group=bin path=sync1_baz variant.foo=baz
                     add license tmp/copyright license=copyright_⌘⛷༂
                     close\n"""
-                p_sync1.append(p_data)
+        p_sync1.append(p_data)
 
-        # generate packages that do need to be synced
-        pkgs = ["sync2" + ver for ver in p_vers]
-        p_sync2_name = dict(zip(range(len(pkgs)), pkgs))
-        for i in p_sync2_name:
-                p_data = "open {0}\n".format(p_sync2_name[i])
-                p_data += "add depend type=parent fmri={0}".format(
-                    pkg.actions.depend.DEPEND_SELF)
-                p_data += """
+    # generate packages that do need to be synced
+    pkgs = ["sync2" + ver for ver in p_vers]
+    p_sync2_name = dict(zip(range(len(pkgs)), pkgs))
+    for i in p_sync2_name:
+        p_data = "open {0}\n".format(p_sync2_name[i])
+        p_data += "add depend type=parent fmri={0}".format(
+            pkg.actions.depend.DEPEND_SELF
+        )
+        p_data += """
                     add set name=variant.foo value=bar value=baz
                     add file tmp/bar mode=0555 owner=root group=bin path=sync2_bar variant.foo=bar
                     add file tmp/baz mode=0555 owner=root group=bin path=sync2_baz variant.foo=baz
                     close\n"""
-                p_all.append(p_data)
+        p_all.append(p_data)
 
-        group_pkgs = """
+    group_pkgs = """
             open osnet-incorporation@0.5.11-0.151.0.1
             add set name=pkg.depend.install-hold value=core-os.osnet
             add depend fmri=ipfilter@0.5.11-0.151.0.1 type=incorporate
@@ -147,3428 +150,3834 @@ class TestPkgLinked(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        def setUp(self):
-                self.i_count = 5
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test"],
-                    image_count=self.i_count)
+    def setUp(self):
+        self.i_count = 5
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test"], image_count=self.i_count
+        )
 
-                # create files that go in packages
-                self.make_misc_files(self.p_files)
+        # create files that go in packages
+        self.make_misc_files(self.p_files)
 
-                # get repo url
-                self.rurl1 = self.dcs[1].get_repo_url()
+        # get repo url
+        self.rurl1 = self.dcs[1].get_repo_url()
 
-                # populate repository
-                self.pkgsend_bulk(self.rurl1, self.p_all)
-                self.s1_list = self.pkgsend_bulk(self.rurl1, self.p_sync1)
-                self.foo1_list = self.pkgsend_bulk(self.rurl1, self.p_foo1)
-                self.pkgsend_bulk(self.rurl1, self.group_pkgs)
+        # populate repository
+        self.pkgsend_bulk(self.rurl1, self.p_all)
+        self.s1_list = self.pkgsend_bulk(self.rurl1, self.p_sync1)
+        self.foo1_list = self.pkgsend_bulk(self.rurl1, self.p_foo1)
+        self.pkgsend_bulk(self.rurl1, self.group_pkgs)
 
-                # setup image names and paths
-                self.i_name = []
-                self.i_path = []
-                self.i_api = []
-                self.i_api_reset = []
-                for i in range(self.i_count):
-                        name = "system:img{0:d}".format(i)
-                        self.i_name.insert(i, name)
-                        self.i_path.insert(i, self.img_path(i))
+        # setup image names and paths
+        self.i_name = []
+        self.i_path = []
+        self.i_api = []
+        self.i_api_reset = []
+        for i in range(self.i_count):
+            name = "system:img{0:d}".format(i)
+            self.i_name.insert(i, name)
+            self.i_path.insert(i, self.img_path(i))
 
-        def __img_api_reset(self, i):
-                """__img_api_reset() - reset the api object associated with an
-                image if that object has been updated via a pkg(1) cli
-                invocation."""
+    def __img_api_reset(self, i):
+        """__img_api_reset() - reset the api object associated with an
+        image if that object has been updated via a pkg(1) cli
+        invocation."""
 
-                if self.i_api_reset[i]:
-                        self.i_api[i].reset()
-                        self.i_api_reset[i] = False
+        if self.i_api_reset[i]:
+            self.i_api[i].reset()
+            self.i_api_reset[i] = False
 
-        def __img_children_names(self, i):
-                """__img_children_names() - find the children of an image and
-                return their names"""
+    def __img_children_names(self, i):
+        """__img_children_names() - find the children of an image and
+        return their names"""
 
-                self.__img_api_reset(i)
-                return set([
-                        str(name)
-                        for name, rel, path in self.i_api[i].list_linked()
-                        if rel == "child"
-                ])
+        self.__img_api_reset(i)
+        return set(
+            [
+                str(name)
+                for name, rel, path in self.i_api[i].list_linked()
+                if rel == "child"
+            ]
+        )
 
-        def __img_has_parent(self, i):
-                """__img_has_parent() - check if an image has a parent"""
+    def __img_has_parent(self, i):
+        """__img_has_parent() - check if an image has a parent"""
 
-                self.__img_api_reset(i)
-                return self.i_api[i].ischild()
+        self.__img_api_reset(i)
+        return self.i_api[i].ischild()
 
-        # public verification functions for use by test cases.
-        def _v_has_children(self, i, cl):
-                assert i not in cl
+    # public verification functions for use by test cases.
+    def _v_has_children(self, i, cl):
+        assert i not in cl
 
-                cl_found = self.__img_children_names(i)
-                cl_expected = set([self.i_name[j] for j in cl])
-                self.assertEqual(cl_found, cl_expected,
-                    "error: image has unexpected children\n"
-                    "image: {0:d}, {1}, {2}\n"
-                    "expected children: {3}\n"
-                    "found children: {4}\n".format(
-                    i, self.i_name[i], self.i_path[i],
-                    str(cl_expected),
-                    str(cl_found)))
+        cl_found = self.__img_children_names(i)
+        cl_expected = set([self.i_name[j] for j in cl])
+        self.assertEqual(
+            cl_found,
+            cl_expected,
+            "error: image has unexpected children\n"
+            "image: {0:d}, {1}, {2}\n"
+            "expected children: {3}\n"
+            "found children: {4}\n".format(
+                i,
+                self.i_name[i],
+                self.i_path[i],
+                str(cl_expected),
+                str(cl_found),
+            ),
+        )
 
-        def _v_no_children(self, il):
-                for i in il:
-                        # make sure the we don't have any children
-                        cl_found = self.__img_children_names(i)
-                        self.assertEqual(set(), cl_found,
-                           "error: image has children\n"
-                           "image: {0:d}, {1}, {2}\n"
-                           "found children: {3}\n".format(
-                           i, self.i_name[i], self.i_path[i],
-                           str(cl_found)))
+    def _v_no_children(self, il):
+        for i in il:
+            # make sure the we don't have any children
+            cl_found = self.__img_children_names(i)
+            self.assertEqual(
+                set(),
+                cl_found,
+                "error: image has children\n"
+                "image: {0:d}, {1}, {2}\n"
+                "found children: {3}\n".format(
+                    i, self.i_name[i], self.i_path[i], str(cl_found)
+                ),
+            )
 
-        def _v_has_parent(self, il):
-                # make sure a child has a parent
-                for i in il:
-                        self.assertEqual(True, self.__img_has_parent(i),
-                           "error: image has no parent\n"
-                           "image: {0:d}, {1}, {2}\n".format(
-                           i, self.i_name[i], self.i_path[i]))
+    def _v_has_parent(self, il):
+        # make sure a child has a parent
+        for i in il:
+            self.assertEqual(
+                True,
+                self.__img_has_parent(i),
+                "error: image has no parent\n"
+                "image: {0:d}, {1}, {2}\n".format(
+                    i, self.i_name[i], self.i_path[i]
+                ),
+            )
 
-        def _v_no_parent(self, il):
-                for i in il:
-                        self.assertEqual(False, self.__img_has_parent(i),
-                           "error: image has a parent\n"
-                           "image: {0:d}, {1}, {2}\n".format(
-                           i, self.i_name[i], self.i_path[i]))
+    def _v_no_parent(self, il):
+        for i in il:
+            self.assertEqual(
+                False,
+                self.__img_has_parent(i),
+                "error: image has a parent\n"
+                "image: {0:d}, {1}, {2}\n".format(
+                    i, self.i_name[i], self.i_path[i]
+                ),
+            )
 
-        def _v_not_linked(self, il):
-                self._v_no_parent(il)
-                self._v_no_children(il)
+    def _v_not_linked(self, il):
+        self._v_no_parent(il)
+        self._v_no_children(il)
 
-        # utility functions for use by test cases
-        def _imgs_create(self, limit):
-                variants = {
-                    "variant.foo": "bar",
-                    "variant.opensolaris.zone": "nonglobal",
-                }
+    # utility functions for use by test cases
+    def _imgs_create(self, limit):
+        variants = {
+            "variant.foo": "bar",
+            "variant.opensolaris.zone": "nonglobal",
+        }
 
-                for i in range(0, limit):
-                        self.set_image(i)
-                        self.i_api.insert(i, self.image_create(self.rurl1,
-                            variants=variants, destroy=True))
-                        self.i_api_reset.insert(i, False)
+        for i in range(0, limit):
+            self.set_image(i)
+            self.i_api.insert(
+                i,
+                self.image_create(self.rurl1, variants=variants, destroy=True),
+            )
+            self.i_api_reset.insert(i, False)
 
-                del self.i_api[limit:]
-                del self.i_api_reset[limit:]
-                for i in range(limit, self.i_count):
-                        self.set_image(i)
-                        self.image_destroy()
+        del self.i_api[limit:]
+        del self.i_api_reset[limit:]
+        for i in range(limit, self.i_count):
+            self.set_image(i)
+            self.image_destroy()
 
-                self.set_image(0)
+        self.set_image(0)
 
-        def _ccmd(self, args, rv=0):
-                """Run a 'C' (or other non-python) command."""
-                assert type(args) == str
-                # Ensure 'coverage' is turned off-- it won't work.
-                self.cmdline_run("{0}".format(args), exit=rv, coverage=False)
+    def _ccmd(self, args, rv=0):
+        """Run a 'C' (or other non-python) command."""
+        assert type(args) == str
+        # Ensure 'coverage' is turned off-- it won't work.
+        self.cmdline_run("{0}".format(args), exit=rv, coverage=False)
 
-        def _pkg(self, il, cmd, args=None, rv=None, rvdict=None,
-            output_cb=None, env_arg=None):
-                assert type(il) == list
-                assert type(cmd) == str
-                assert args == None or type(args) == str
-                assert rv == None or type(rv) == int
-                assert rvdict == None or type(rvdict) == dict
-                assert rv == None or rvdict == None
+    def _pkg(
+        self,
+        il,
+        cmd,
+        args=None,
+        rv=None,
+        rvdict=None,
+        output_cb=None,
+        env_arg=None,
+    ):
+        assert type(il) == list
+        assert type(cmd) == str
+        assert args == None or type(args) == str
+        assert rv == None or type(rv) == int
+        assert rvdict == None or type(rvdict) == dict
+        assert rv == None or rvdict == None
 
-                if rv == None:
-                        rv = EXIT_OK
-                if rvdict == None:
-                        rvdict = {}
-                        for i in il:
-                                rvdict[i] = rv
-                assert (set(rvdict) | set(il)) == set(il)
+        if rv == None:
+            rv = EXIT_OK
+        if rvdict == None:
+            rvdict = {}
+            for i in il:
+                rvdict[i] = rv
+        assert (set(rvdict) | set(il)) == set(il)
 
-                if args == None:
-                        args = ""
+        if args == None:
+            args = ""
 
-                # we're updating one or more images, so make sure to reset all
-                # our api instances before using them.
-                self.i_api_reset[:] = [True] * len(self.i_api_reset)
+        # we're updating one or more images, so make sure to reset all
+        # our api instances before using them.
+        self.i_api_reset[:] = [True] * len(self.i_api_reset)
 
-                for i in il:
-                        rv = rvdict.get(i, EXIT_OK)
-                        self.pkg("-R {0} {1} {2}".format(self.i_path[i], cmd, args),
-                            exit=rv, env_arg=env_arg)
-                        if output_cb:
-                                output_cb(self.output)
+        for i in il:
+            rv = rvdict.get(i, EXIT_OK)
+            self.pkg(
+                "-R {0} {1} {2}".format(self.i_path[i], cmd, args),
+                exit=rv,
+                env_arg=env_arg,
+            )
+            if output_cb:
+                output_cb(self.output)
 
-        def _pkg_child(self, i, cl, cmd, args=None, rv=None, rvdict=None):
-                assert type(i) == int
-                assert type(cl) == list
-                assert i not in cl
-                assert type(cmd) == str
-                assert args == None or type(args) == str
-                assert rv == None or type(rv) == int
-                assert rvdict == None or type(rvdict) == dict
-                assert rv == None or rvdict == None
+    def _pkg_child(self, i, cl, cmd, args=None, rv=None, rvdict=None):
+        assert type(i) == int
+        assert type(cl) == list
+        assert i not in cl
+        assert type(cmd) == str
+        assert args == None or type(args) == str
+        assert rv == None or type(rv) == int
+        assert rvdict == None or type(rvdict) == dict
+        assert rv == None or rvdict == None
 
-                if rv == None:
-                        rv = EXIT_OK
-                if rvdict == None:
-                        rvdict = {}
-                        for c in cl:
-                                rvdict[c] = rv
-                assert (set(rvdict) | set(cl)) == set(cl)
+        if rv == None:
+            rv = EXIT_OK
+        if rvdict == None:
+            rvdict = {}
+            for c in cl:
+                rvdict[c] = rv
+        assert (set(rvdict) | set(cl)) == set(cl)
 
-                if args == None:
-                        args = ""
+        if args == None:
+            args = ""
 
-                # sync each child from parent
-                for c in cl:
-                        rv = rvdict.get(c, EXIT_OK)
-                        self._pkg([i], "{0} -l {1}".format(cmd, self.i_name[c]),
-                            args=args, rv=rv)
+        # sync each child from parent
+        for c in cl:
+            rv = rvdict.get(c, EXIT_OK)
+            self._pkg(
+                [i], "{0} -l {1}".format(cmd, self.i_name[c]), args=args, rv=rv
+            )
 
-        def _pkg_child_all(self, i, cmd, args=None, rv=EXIT_OK):
-                assert type(i) == int
-                assert type(cmd) == str
-                assert args == None or type(args) == str
-                assert type(rv) == int
+    def _pkg_child_all(self, i, cmd, args=None, rv=EXIT_OK):
+        assert type(i) == int
+        assert type(cmd) == str
+        assert args == None or type(args) == str
+        assert type(rv) == int
 
-                if args == None:
-                        args = ""
-                self._pkg([i], "{0} -a {1}".format(cmd, args), rv=rv)
+        if args == None:
+            args = ""
+        self._pkg([i], "{0} -a {1}".format(cmd, args), rv=rv)
 
-        def _attach_parent(self, il, p, args=None, rv=EXIT_OK):
-                assert type(il) == list
-                assert type(p) == int
-                assert p not in il
-                assert args == None or type(args) == str
-                assert type(rv) == int
+    def _attach_parent(self, il, p, args=None, rv=EXIT_OK):
+        assert type(il) == list
+        assert type(p) == int
+        assert p not in il
+        assert args == None or type(args) == str
+        assert type(rv) == int
 
-                if args == None:
-                        args = ""
+        if args == None:
+            args = ""
 
-                for i in il:
-                        self._pkg([i], "attach-linked -p {0} {1} {2}".format(
-                            args, self.i_name[i], self.i_path[p]), rv=rv)
+        for i in il:
+            self._pkg(
+                [i],
+                "attach-linked -p {0} {1} {2}".format(
+                    args, self.i_name[i], self.i_path[p]
+                ),
+                rv=rv,
+            )
 
-        def _attach_child(self, i, cl, args=None, rv=None, rvdict=None):
-                assert type(i) == int
-                assert type(cl) == list
-                assert i not in cl
-                assert args == None or type(args) == str
-                assert rvdict == None or type(rvdict) == dict
-                assert rv == None or rvdict == None
+    def _attach_child(self, i, cl, args=None, rv=None, rvdict=None):
+        assert type(i) == int
+        assert type(cl) == list
+        assert i not in cl
+        assert args == None or type(args) == str
+        assert rvdict == None or type(rvdict) == dict
+        assert rv == None or rvdict == None
 
-                if rv == None:
-                        rv = EXIT_OK
-                if rvdict == None:
-                        rvdict = {}
-                        for c in cl:
-                                rvdict[c] = rv
-                assert (set(rvdict) | set(cl)) == set(cl)
+        if rv == None:
+            rv = EXIT_OK
+        if rvdict == None:
+            rvdict = {}
+            for c in cl:
+                rvdict[c] = rv
+        assert (set(rvdict) | set(cl)) == set(cl)
 
-                if args == None:
-                        args = ""
+        if args == None:
+            args = ""
 
-                # attach each child to parent
-                for c in cl:
-                        rv = rvdict.get(c, EXIT_OK)
-                        self._pkg([i], "attach-linked -c {0} {1} {2}".format(
-                            args, self.i_name[c], self.i_path[c]),
-                            rv=rv)
+        # attach each child to parent
+        for c in cl:
+            rv = rvdict.get(c, EXIT_OK)
+            self._pkg(
+                [i],
+                "attach-linked -c {0} {1} {2}".format(
+                    args, self.i_name[c], self.i_path[c]
+                ),
+                rv=rv,
+            )
 
-        def _assertEqual_cb(self, output):
-                return lambda x: self.assertEqual(output, x)
+    def _assertEqual_cb(self, output):
+        return lambda x: self.assertEqual(output, x)
 
 
 class TestPkgLinked1(TestPkgLinked):
-        def test_not_linked(self):
-                self._imgs_create(1)
-
-                self._pkg([0], "list-linked")
-
-                # operations that require a parent
-                rv = EXIT_NOPARENT
-                self._pkg([0], "detach-linked", rv=rv)
-                self._pkg([0], "sync-linked", rv=rv)
-                self._pkg([0], "audit-linked", rv=rv)
-
-        def test_opts_1_invalid(self):
-                self._imgs_create(3)
-
-                # parent has one child
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # invalid options
-                rv = EXIT_BADOPT
-
-                args = "--foobar"
-                self._pkg([0], "attach-linked", args=args, rv=rv)
-                self._pkg([0], "detach-linked", args=args, rv=rv)
-                self._pkg([0], "sync-linked", args=args, rv=rv)
-                self._pkg([0], "audit-linked", args=args, rv=rv)
-                self._pkg([0], "list-linked", args=args, rv=rv)
-                self._pkg([0], "property-linked", args=args, rv=rv)
-                self._pkg([0], "set-property-linked", args=args, rv=rv)
-
-                # can't combine -a and -l
-                args = "-a -l {0}".format(self.i_name[1])
-                self._pkg([0], "detach-linked", args=args, rv=rv)
-                self._pkg([0], "sync-linked", args=args, rv=rv)
-                self._pkg([0], "audit-linked", args=args, rv=rv)
-
-                # can't combine -I and -i
-                args = "-I -i {0}".format(self.i_name[1])
-                self._pkg([0], "detach-linked", args=args, rv=rv)
-                self._pkg([0], "sync-linked", args=args, rv=rv)
-                self._pkg([0], "audit-linked", args=args, rv=rv)
-                self._pkg([0], "list-linked", args=args, rv=rv)
-
-                # can't combine -i and -a
-                args = "-a -i {0}".format(self.i_name[1])
-                self._pkg([0], "detach-linked", args=args, rv=rv)
-                self._pkg([0], "sync-linked", args=args, rv=rv)
-                self._pkg([0], "audit-linked", args=args, rv=rv)
-
-                # can't combine -I and -a
-                args = "-I -a"
-                self._pkg([0], "detach-linked", args=args, rv=rv)
-                self._pkg([0], "sync-linked", args=args, rv=rv)
-                self._pkg([0], "audit-linked", args=args, rv=rv)
-
-                # can't combine -I and -l
-                args = "-I -l {0}".format(self.i_name[1])
-                self._pkg([0], "detach-linked", args=args, rv=rv)
-                self._pkg([0], "sync-linked", args=args, rv=rv)
-                self._pkg([0], "audit-linked", args=args, rv=rv)
-
-                # can't combine -i and -l with same target
-                args = "-i {0} -l {1}".format(self.i_name[1], self.i_name[1])
-                self._pkg([0], "detach-linked", args=args, rv=rv)
-                self._pkg([0], "sync-linked", args=args, rv=rv)
-                self._pkg([0], "audit-linked", args=args, rv=rv)
-
-                # doesn't accept -a
-                args = "-a"
-                self._pkg([0], "attach-linked", args=args, rv=rv)
-                self._pkg([0], "list-linked", args=args, rv=rv)
-                self._pkg([0], "property-linked", args=args, rv=rv)
-                self._pkg([0], "set-property-linked", args=args, rv=rv)
-
-                # doesn't accept -l
-                args = "-l {0}".format(self.i_name[1])
-                self._pkg([0], "attach-linked", args=args, rv=rv)
-                self._pkg([0], "list-linked", args=args, rv=rv)
-
-                # can't combine --no-parent-sync and --linked-md-only
-                args = "--no-parent-sync --linked-md-only"
-                self._pkg([0], "sync-linked -a", args=args, rv=rv)
-                self._pkg([2], "sync-linked", args=args, rv=rv)
-
-                # can't use --no-parent-sync when invoking from parent
-                args = "--no-parent-sync"
-                self._pkg([0], "sync-linked -a", args=args, rv=rv)
-                self._pkg_child(0, [1], "sync-linked", args=args, rv=rv)
-
-                # can't use be options when managing children
-                for arg in ["--deny-new-be", "--require-new-be",
-                    "--be-name=foo"]:
-                        args = "-a {0}".format(arg)
-                        self._pkg([0], "sync-linked", args=args, rv=rv)
-
-                        args = "-l {0} {1}".format(self.i_name[1], arg)
-                        self._pkg([0], "sync-linked", args=args, rv=rv)
-                        self._pkg([0], "set-property-linked", args=args, rv=rv)
-
-        def test_opts_2_invalid_bad_child(self):
-                self._imgs_create(2)
-
-                rv = EXIT_OOPS
-
-                # try using an invalid child name
-                self._pkg([0], "attach-linked -c foobar {0}".format(
-                    self.i_path[1]), rv=rv)
-
-                for lin in ["foobar", self.i_name[1]]:
-                        # try using an invalid and unknown child name
-                        args = "-l {0}".format(lin)
-
-                        self._pkg([0], "sync-linked", args=args, rv=rv)
-                        self._pkg([0], "audit-linked", args=args, rv=rv)
-                        self._pkg([0], "property-linked", args=args, rv=rv)
-                        self._pkg([0], "set-property-linked", args=args, rv=rv)
-                        self._pkg([0], "detach-linked", args=args, rv=rv)
-
-                        # try to ignore invalid unknown children
-                        args = "-i {0}".format(lin)
-
-                        # operations on the parent image
-                        self._pkg([0], "sync-linked", args=args, rv=rv)
-                        self._pkg([0], "list-linked", args=args, rv=rv)
-                        self._pkg([0], "update", args=args, rv=rv)
-                        self._pkg([0], "install", args= \
-                            "-i {0} {1}".format(lin, self.p_foo1_name[1]), rv=rv)
-                        self._pkg([0], "change-variant", args= \
-                            "-i {0} -v variant.foo=baz".format(lin), rv=rv)
-                        # TODO: test change-facet
-
-                rv = EXIT_BADOPT
-
-                for op in ["update", "install", "uninstall"]:
-                        # -z and -Z can't be used together
-                        self._pkg([0], "{0} -r "
-                            "-z system:img1 -Z system:img1 foo".format(op), rv=rv)
-                        # check handling of valid but not existing child names
-                        self._pkg([0], "{0} -r -z system:foo {1}".format(
-                            op, self.p_foo1_name[1]), rv=rv)
-                        self._pkg([0], "{0} -r -Z system:foo {1}".format(
-                            op, self.p_foo1_name[1]), rv=rv)
-                        # check handling of valid but not existing zone names
-                        self._pkg([0], "{0} -r -z foo {1}".format(
-                            op, self.p_foo1_name[1]), rv=rv)
-                        self._pkg([0], "{0} -r -Z foo {1}".format(
-                            op, self.p_foo1_name[1]), rv=rv)
-                        # check handling of invalid child names
-                        self._pkg([0], "{0} -r -z :foo:&& {1}".format(
-                            op, self.p_foo1_name[1]), rv=rv)
-                        self._pkg([0], "{0} -r -Z :foo:&& {1}".format(
-                            op, self.p_foo1_name[1]), rv=rv)
-
-        def test_opts_3_all(self):
-                self._imgs_create(1)
-
-                # the -a option is always valid
-                self._pkg([0], "sync-linked -a")
-                self._pkg([0], "audit-linked -a")
-                self._pkg([0], "detach-linked -a")
-
-        def test_opts_4_noop(self):
-                self._imgs_create(4)
-
-                # plan operations
-                self._attach_child(0, [1, 2], args="-vn")
-                self._attach_child(0, [1, 2], args="-vn")
-                self._attach_parent([3], 0, args="-vn")
-                self._attach_parent([3], 0, args="-vn")
-
-                # do operations
-                self._attach_child(0, [1, 2], args="-v")
-                self._attach_parent([3], 0, args="-v")
-
-                # plan operations
-                self._pkg_child(0, [1, 2], "detach-linked", args="-vn")
-                self._pkg_child(0, [1, 2], "detach-linked", args="-vn")
-                self._pkg_child_all(0, "detach-linked", args="-vn")
-                self._pkg_child_all(0, "detach-linked", args="-vn")
-                self._pkg([3], "detach-linked", args="-vn")
-                self._pkg([3], "detach-linked", args="-vn")
-
-                # do operations
-                self._pkg_child(0, [1], "detach-linked", args="-v")
-                self._pkg_child_all(0, "detach-linked", args="-v")
-                self._pkg([3], "detach-linked", args="-v")
-
-        def test_attach_p2c_1(self):
-                self._imgs_create(4)
-                self._v_not_linked([0, 1, 2, 3])
-
-                # link parents to children as follows:
-                #     0 -> 1 -> 2
-                #          1 -> 3
-
-                # attach parent (0) to child (1), (0 -> 1)
-                self._attach_child(0, [1], args="--parsable=0 -n")
-                self.assertEqualParsable(self.output,
-                    child_images=[{"image_name": "system:img1"}])
-                self._attach_child(0, [1], args="--parsable=0")
-                self.assertEqualParsable(self.output,
-                    child_images=[{"image_name": "system:img1"}])
-                self._v_has_children(0, [1])
-                self._v_has_parent([1])
-                self._v_not_linked([2, 3])
-
-                # attach parent (1) to child (2), (1 -> 2)
-                self._attach_child(1, [2])
-                self._v_has_children(0, [1])
-                self._v_has_children(1, [2])
-                self._v_has_parent([1, 2])
-                self._v_no_children([2])
-                self._v_not_linked([3])
-
-                # attach parent (1) to child (3), (1 -> 3)
-                self._attach_child(1, [3])
-                self._v_has_children(0, [1])
-                self._v_has_children(1, [2, 3])
-                self._v_has_parent([1, 2, 3])
-                self._v_no_children([2, 3])
-
-        def test_detach_p2c_1(self):
-                self._imgs_create(4)
-
-                # link parents to children as follows:
-                #     0 -> 1 -> 2
-                #          1 -> 3
-                self._attach_child(0, [1])
-                self._attach_child(1, [2, 3])
-
-                # detach child (1) from parent (0)
-                self._pkg_child(0, [1], "detach-linked")
-                self._v_has_children(1, [2, 3])
-                self._v_has_parent([2, 3])
-                self._v_no_children([2, 3])
-                self._v_not_linked([0])
-
-                # detach child (3) from parent (1)
-                self._pkg_child(1, [3], "detach-linked")
-                self._v_has_children(1, [2])
-                self._v_has_parent([2])
-                self._v_no_children([2])
-                self._v_not_linked([0, 3])
-
-                # detach child (2) from parent (1)
-                self._pkg_child(1, [2], "detach-linked")
-                self._v_not_linked([0, 1, 2, 3])
-
-        def test_detach_p2c_2(self):
-                self._imgs_create(4)
-
-                # link parents to children as follows:
-                #     0 -> 1 -> 2
-                #          1 -> 3
-                self._attach_child(0, [1])
-                self._attach_child(1, [2, 3])
-
-                # detach child (1) from parent (0)
-                self._pkg_child_all(0, "detach-linked", args="-n")
-                self._pkg_child_all(0, "detach-linked")
-                self._v_has_children(1, [2, 3])
-                self._v_has_parent([2, 3])
-                self._v_no_children([2, 3])
-                self._v_not_linked([0])
-
-                # detach child (3) and child (2) from parent (1)
-                self._pkg_child_all(1, "detach-linked")
-                self._v_not_linked([0, 1, 2, 3])
-
-                # detach all children (there are none)
-                self._pkg_child_all(0, "detach-linked")
-
-        def test_attach_c2p_1(self):
-                self._imgs_create(4)
-                self._v_not_linked([0, 1, 2, 3])
-
-                # link children to parents as follows:
-                #     2 -> 1 -> 0
-                #     3 -> 1
-
-                # attach child (2) to parent (1), (2 -> 1)
-                self._attach_parent([2], 1, args="--parsable=0 -n")
-                self.assertEqualParsable(self.output)
-                self._attach_parent([2], 1, args="--parsable=0")
-                self.assertEqualParsable(self.output)
-                self._v_has_parent([2])
-                self._v_no_children([2])
-                self._v_not_linked([0, 1, 3])
-
-                # attach child (3) to parent (1), (3 -> 1)
-                self._attach_parent([3], 1)
-                self._v_has_parent([2, 3])
-                self._v_no_children([2, 3])
-                self._v_not_linked([0, 1])
-
-                # attach child (1) to parent (0), (1 -> 0)
-                self._attach_parent([1], 0)
-                self._v_has_parent([1, 2, 3])
-                self._v_no_children([1, 2, 3])
-                self._v_not_linked([0])
-
-        def test_detach_c2p_1(self):
-                self._imgs_create(4)
-
-                # link children to parents as follows:
-                #     2 -> 1 -> 0
-                #     3 -> 1
-                self._attach_parent([2, 3], 1)
-                self._attach_parent([1], 0)
-
-                # detach parent (0) from child (1)
-                self._pkg([1], "detach-linked -n")
-                self._pkg([1], "detach-linked")
-                self._v_has_parent([2, 3])
-                self._v_no_children([2, 3])
-                self._v_not_linked([0, 1])
-
-                # detach parent (1) from child (3)
-                self._pkg([3], "detach-linked")
-                self._v_has_parent([2])
-                self._v_no_children([2])
-                self._v_not_linked([0, 1, 3])
-
-                # detach parent (1) from child (2)
-                self._pkg([2], "detach-linked")
-                self._v_not_linked([0, 1, 2, 3])
-
-        def test_attach_already_linked_1_err(self):
-                self._imgs_create(4)
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                rv = EXIT_OOPS
-
-                # try to link the parent image to a new child with a dup name
-                self._pkg([0], "attach-linked -c {0} {1}".format(
-                    self.i_name[1], self.i_path[2]), rv=rv)
-
-                # have a new parent try to link to the p2c child
-                self._attach_child(3, [1], rv=rv)
-
-                # have the p2c child try to link to a new parent
-                self._attach_parent([1], 3, rv=rv)
-
-                # have the c2p child try to link to a new parent
-                self._attach_parent([2], 3, rv=rv)
-
-        def test_attach_already_linked_2_relink(self):
-                self._imgs_create(4)
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # have a new parent try to link to the p2c child
-                self._attach_child(3, [1], args="--allow-relink")
-
-                # have the p2c child try to link to a new parent
-                self._attach_parent([1], 3, args="--allow-relink")
-
-                # have the c2p child try to link to a new parent
-                self._attach_parent([2], 3, args="--allow-relink")
-
-        def test_zone_attach_detach(self):
-                self._imgs_create(2)
-
-                rv = EXIT_OOPS
-
-                # by default we can't attach (p2c) zone image
-                self._pkg([0], "attach-linked -v -c zone:foo {0}".format(
-                    self.i_path[1]), rv=rv)
-                self._v_not_linked([0, 1])
-
-                # force attach (p2c) zone image
-                self._pkg([0], "attach-linked -v -f -c zone:foo {0}".format(
-                    self.i_path[1]))
-                self._v_not_linked([0])
-                self._v_has_parent([1])
-
-                self._imgs_create(2)
-
-                # by default we can't attach (c2p) zone image
-                self._pkg([1], "attach-linked -v -p zone:foo {0}".format(
-                    self.i_path[0]), rv=rv)
-                self._v_not_linked([0, 1])
-
-                # force attach (c2p) zone image
-                self._pkg([1], "attach-linked -v -f -p zone:foo {0}".format(
-                    self.i_path[0]))
-                self._v_not_linked([0])
-                self._v_has_parent([1])
-
-                # by default we can't detach (c2p) zone image
-                self._pkg([1], "detach-linked -v", rv=rv)
-                self._v_not_linked([0])
-                self._v_has_parent([1])
-
-                # force detach (c2p) zone image
-                self._pkg([1], "detach-linked -v -f")
-                self._v_not_linked([0, 1])
-
-        def test_parent_ops_error(self):
-                self._imgs_create(2)
-
-                # attach a child
-                self._attach_child(0, [1])
-
-                rv = EXIT_PARENTOP
-
-                # some operations can't be done from a child when linked to
-                # from a parent
-                self._pkg([1], "detach-linked", rv=EXIT_PARENTOP)
-
-                # TODO: enable this once we support set-property-linked
-                #self._pkg([1], "set-property-linked", rv=EXIT_PARENTOP)
-
-        def test_eaccess_1_parent(self):
-                self._imgs_create(3)
-                self._attach_parent([1], 0)
-
-                rv = EXIT_EACCESS
-
-                for i in [0, 1]:
-                        if i == 0:
-                                # empty the parent image
-                                self.set_image(0)
-                                self.image_destroy()
-                                self._ccmd("mkdir -p {0}".format(self.i_path[0]))
-                        if i == 1:
-                                # delete the parent image
-                                self.set_image(0)
-                                self.image_destroy()
-
-                        # operations that need to access the parent should fail
-                        self._pkg([1], "sync-linked", rv=rv)
-                        self._pkg([1], "audit-linked", rv=rv)
-                        self._pkg([1], "install {0}".format(self.p_foo1_name[1]), \
-                            rv=rv)
-                        self._pkg([1], "image-update", rv=rv)
-
-                        # operations that need to access the parent should fail
-                        self._attach_parent([2], 0, rv=rv)
-
-                # detach should still work
-                self._pkg([1], "detach-linked")
-
-        def test_eaccess_1_child(self):
-                self._imgs_create(2)
-                self._attach_child(0, [1])
-
-                outfile = os.path.join(self.test_root, "res")
-                rv = EXIT_EACCESS
-
-                for i in [0, 1, 2]:
-                        if i == 0:
-                                # corrupt the child image
-                                self._ccmd("mkdir -p "
-                                    "{0}/{1}".format(self.i_path[1],
-                                    image.img_user_prefix))
-                                self._ccmd("mkdir -p "
-                                    "{0}/{1}".format(self.i_path[1],
-                                    image.img_root_prefix))
-                        if i == 1:
-                                # delete the child image
-                                self.set_image(1)
-                                self.image_destroy()
-                                self._ccmd("mkdir -p {0}".format(self.i_path[1]))
-                        if i == 2:
-                                # delete the child image
-                                self.set_image(1)
-                                self.image_destroy()
-
-
-                        # child should still be listed
-                        self._pkg([0], "list-linked -H > {0}".format(outfile))
-                        self._ccmd("cat {0}".format(outfile))
-                        self._ccmd("egrep '^{0}[ 	]' {1}".format(
-                            self.i_name[1], outfile))
-
-                        # child should still be listed
-                        self._pkg([0], "property-linked -H -l {0} > {1}".format(
-                            self.i_name[1], outfile))
-                        self._ccmd("cat {0}".format(outfile))
-                        self._ccmd("egrep '^li-' {0}".format(outfile))
-
-                        # operations that need to access child should fail
-                        self._pkg_child(0, [1], "sync-linked", rv=rv)
-                        self._pkg_child_all(0, "sync-linked", rv=rv)
-
-                        self._pkg_child(0, [1], "audit-linked", rv=rv)
-                        self._pkg_child_all(0, "audit-linked", rv=rv)
-
-                        self._pkg_child(0, [1], "detach-linked", rv=rv)
-                        self._pkg_child_all(0, "detach-linked", rv=rv)
-
-                        # TODO: test more recursive ops here
-                        # image-update, install, uninstall, etc
-
-        def test_ignore_1_no_children(self):
-                self._imgs_create(1)
-                outfile = os.path.join(self.test_root, "res")
-
-                # it's ok to use -I with no children
-                self._pkg([0], "list-linked -H -I > {0}".format(outfile))
-                self._ccmd("cat {0}".format(outfile))
-                self._ccmd("egrep '^$|.' {0}".format(outfile), rv=EXIT_OOPS)
-
-        def test_ignore_2_ok(self):
-                self._imgs_create(3)
-                self._attach_child(0, [1, 2])
-                outfile = os.path.join(self.test_root, "res")
-
-                # ignore one child
-                self._pkg([0], "list-linked -H -i {0} > {1}".format(
-                    self.i_name[1], outfile))
-                self._ccmd("cat {0}".format(outfile))
-                self._ccmd("egrep '^{0}[ 	]' {1}".format(
-                    self.i_name[1], outfile), rv=EXIT_OOPS)
-                self._ccmd("egrep '^{0}[ 	]' {1}".format(
-                    self.i_name[2], outfile))
-
-                # manually ignore all children
-                self._pkg([0], "list-linked -H -i {0} -i {1} > {2}".format(
-                    self.i_name[1], self.i_name[2], outfile))
-                self._ccmd("cat {0}".format(outfile))
-                self._ccmd("egrep '^$|.' {0}".format(outfile), rv=EXIT_OOPS)
-
-                # automatically ignore all children
-                self._pkg([0], "list-linked -H -I > {0}".format(outfile))
-                self._ccmd("cat {0}".format(outfile))
-                self._ccmd("egrep '^$|.' {0}".format(outfile), rv=EXIT_OOPS)
-
-        def test_no_pkg_updates_1_empty_via_attach(self):
-                """test --no-pkg-updates with an empty image."""
-                self._imgs_create(3)
-
-                self._attach_child(0, [1], args="--no-pkg-updates")
-                self._attach_parent([2], 0, args="--no-pkg-updates")
-
-        def test_no_pkg_updates_1_empty_via_sync(self):
-                """test --no-pkg-updates with an empty image."""
-                self._imgs_create(4)
-
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2], args="--linked-md-only")
-                self._attach_parent([3], 0, args="--linked-md-only")
-
-                self._pkg_child(0, [1], "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_NOP)
-                self._pkg_child_all(0, "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_NOP)
-                self._pkg([3], "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_NOP)
-
-        def test_no_pkg_updates_1_empty_via_set_property_linked_TODO(self):
-                """test --no-pkg-updates with an empty image."""
-                pass
-
-        def test_no_pkg_updates_2_foo_via_attach(self):
-                """test --no-pkg-updates with a non-empty image."""
-                self._imgs_create(3)
-
-                # install different un-synced packages into each image
-                for i in [0, 1, 2]:
-                        self._pkg([i], "install -v {0}".format(self.p_foo1_name[i]))
-
-                self._attach_child(0, [1], args="--no-pkg-updates")
-                self._attach_parent([2], 0, args="--no-pkg-updates")
-
-                # verify the un-synced packages
-                for i in [0, 1, 2]:
-                        self._pkg([i], "list -v {0}".format(self.p_foo1_name[i]))
-
-        def test_no_pkg_updates_2_foo_via_sync(self):
-                """test --no-pkg-updates with a non-empty image."""
-                self._imgs_create(4)
-
-                # install different un-synced packages into each image
-                for i in range(4):
-                        self._pkg([i], "install -v {0}".format(self.p_foo1_name[i]))
-
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2], args="--linked-md-only")
-                self._attach_parent([3], 0, args="--linked-md-only")
-
-                self._pkg_child(0, [1], "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_NOP)
-                self._pkg_child_all(0, "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_NOP)
-                self._pkg([3], "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_NOP)
-
-                # verify the un-synced packages
-                for i in range(4):
-                        self._pkg([i], "list -v {0}".format(self.p_foo1_name[i]))
-
-        def test_no_pkg_updates_2_foo_via_set_property_linked_TODO(self):
-                """test --no-pkg-updates with a non-empty image."""
-                pass
-
-        def test_no_pkg_updates_3_sync_via_attach(self):
-                """test --no-pkg-updates with an in sync package"""
-                self._imgs_create(3)
-
-                # install the same synced packages into each image
-                for i in range(3):
-                        self._pkg([i], "install -v {0}".format(self.p_sync1_name[1]))
-
-                self._attach_child(0, [1], args="--no-pkg-updates")
-                self._attach_parent([2], 0, args="--no-pkg-updates")
-
-                # verify the synced packages
-                for i in range(3):
-                        self._pkg([i], "list -v {0}".format(self.p_sync1_name[1]))
-
-        def test_no_pkg_updates_3_sync_via_sync(self):
-                """test --no-pkg-updates with an in sync package"""
-                self._imgs_create(4)
-
-                # install the same synced packages into each image
-                for i in range(4):
-                        self._pkg([i], "install -v {0}".format(self.p_sync1_name[1]))
-
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2], args="--linked-md-only")
-                self._attach_parent([3], 0, args="--linked-md-only")
-
-                # verify the synced packages
-                for i in range(4):
-                        self._pkg([i], "list -v {0}".format(self.p_sync1_name[1]))
-
-                self._pkg_child(0, [1], "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_NOP)
-                self._pkg_child_all(0, "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_NOP)
-                self._pkg([3], "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_NOP)
-
-        def test_no_pkg_updates_3_sync_via_set_property_linked_TODO(self):
-                """test --no-pkg-updates with an in sync package"""
-                pass
-
-        def test_no_pkg_updates_3_fail_via_attach(self):
-                """test --no-pkg-updates with an out of sync package"""
-                self._imgs_create(3)
-
-                # install different synced packages into each image
-                for i in range(3):
-                        self._pkg([i], "install -v {0}".format(self.p_sync1_name[i+1]))
-
-                self._attach_child(0, [1], args="--no-pkg-updates",
-                    rv=EXIT_OOPS)
-                self._attach_parent([2], 0, args="--no-pkg-updates",
-                    rv=EXIT_OOPS)
-
-                # verify packages
-                for i in range(3):
-                        self._pkg([i], "list -v {0}".format(self.p_sync1_name[i+1]))
-
-        def test_no_pkg_updates_3_fail_via_sync(self):
-                """test --no-pkg-updates with an out of sync package"""
-                self._imgs_create(4)
-
-                # install different synced packages into each image
-                for i in range(4):
-                        self._pkg([i], "install -v {0}".format(self.p_sync1_name[i+1]))
-
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2], args="--linked-md-only")
-                self._attach_parent([3], 0, args="--linked-md-only")
-
-                self._pkg_child(0, [1], "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_OOPS)
-                self._pkg_child_all(0, "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_OOPS)
-                self._pkg([3], "sync-linked -v --no-pkg-updates",
-                    rv=EXIT_OOPS)
-
-                # verify packages
-                for i in range(3):
-                        self._pkg([i], "list -v {0}".format(self.p_sync1_name[i+1]))
-
-        def test_no_pkg_updates_3_fail_via_set_property_linked_TODO(self):
-                pass
-
-        def test_audit_synced_1(self):
-                self._imgs_create(4)
-
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2], args="--linked-md-only")
-                self._attach_parent([3], 0, args="--linked-md-only")
-
-                # audit with empty parent and child
-                self._pkg([1, 2, 3], "audit-linked")
-                self._pkg_child(0, [1, 2], "audit-linked")
-                self._pkg_child_all(0, "audit-linked")
-                self._pkg_child_all(3, "audit-linked")
-
-        def test_audit_synced_2(self):
-                self._imgs_create(4)
-
-                # install different un-synced packages into each image
-                for i in [0, 1, 2, 3]:
-                        self._pkg([i], "install -v {0}".format(self.p_foo1_name[i]))
-
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2, 3], args="--linked-md-only")
-
-                self._pkg([1, 2, 3], "audit-linked")
-                self._pkg_child(0, [1, 2, 3], "audit-linked")
-                self._pkg_child_all(0, "audit-linked")
-
-        def test_audit_synced_3(self):
-                self._imgs_create(4)
-
-                # install synced package into parent
-                self._pkg([0], "install -v {0}".format(self.p_sync1_name[0]))
-
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2, 3], args="--linked-md-only")
-
-                self._pkg([1, 2, 3], "audit-linked")
-                self._pkg_child(0, [1, 2, 3], "audit-linked")
-                self._pkg_child_all(0, "audit-linked")
-
-        def test_audit_synced_4(self):
-                self._imgs_create(4)
-
-                # install same synced packages into parent and some children
-                for i in [0, 1, 2, 3]:
-                        self._pkg([i], "install -v {0}".format(self.p_sync1_name[0]))
-
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2, 3], args="--linked-md-only")
-
-                self._pkg([1, 2, 3], "audit-linked")
-                self._pkg_child(0, [1, 2, 3], "audit-linked")
-                self._pkg_child_all(0, "audit-linked")
-
-
-        def test_audit_diverged_1(self):
-                self._imgs_create(4)
-
-                # install different synced package into some child images
-                for i in [1, 3]:
-                        self._pkg([i], "install -v {0}".format(self.p_sync1_name[i]))
-
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2, 3], args="--linked-md-only")
-
-                rvdict = {1: EXIT_DIVERGED, 3: EXIT_DIVERGED}
-                self._pkg([1, 2, 3], "audit-linked", rvdict=rvdict)
-                self._pkg_child(0, [1, 2, 3], "audit-linked", rvdict=rvdict)
-                self._pkg_child_all(0, "audit-linked", rv=EXIT_DIVERGED)
-
-        def test_audit_diverged_2(self):
-                self._imgs_create(4)
-
-                # install different synced package into each image
-                for i in range(4):
-                        self._pkg([i], "install -v {0}".format(self.p_sync1_name[i]))
-
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2, 3], args="--linked-md-only")
-
-                rv = EXIT_DIVERGED
-                self._pkg([1, 2, 3], "audit-linked", rv=rv)
-                self._pkg_child(0, [1, 2, 3], "audit-linked", rv=rv)
-                self._pkg_child_all(0, "audit-linked", rv=rv)
+    def test_not_linked(self):
+        self._imgs_create(1)
+
+        self._pkg([0], "list-linked")
+
+        # operations that require a parent
+        rv = EXIT_NOPARENT
+        self._pkg([0], "detach-linked", rv=rv)
+        self._pkg([0], "sync-linked", rv=rv)
+        self._pkg([0], "audit-linked", rv=rv)
+
+    def test_opts_1_invalid(self):
+        self._imgs_create(3)
+
+        # parent has one child
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # invalid options
+        rv = EXIT_BADOPT
+
+        args = "--foobar"
+        self._pkg([0], "attach-linked", args=args, rv=rv)
+        self._pkg([0], "detach-linked", args=args, rv=rv)
+        self._pkg([0], "sync-linked", args=args, rv=rv)
+        self._pkg([0], "audit-linked", args=args, rv=rv)
+        self._pkg([0], "list-linked", args=args, rv=rv)
+        self._pkg([0], "property-linked", args=args, rv=rv)
+        self._pkg([0], "set-property-linked", args=args, rv=rv)
+
+        # can't combine -a and -l
+        args = "-a -l {0}".format(self.i_name[1])
+        self._pkg([0], "detach-linked", args=args, rv=rv)
+        self._pkg([0], "sync-linked", args=args, rv=rv)
+        self._pkg([0], "audit-linked", args=args, rv=rv)
+
+        # can't combine -I and -i
+        args = "-I -i {0}".format(self.i_name[1])
+        self._pkg([0], "detach-linked", args=args, rv=rv)
+        self._pkg([0], "sync-linked", args=args, rv=rv)
+        self._pkg([0], "audit-linked", args=args, rv=rv)
+        self._pkg([0], "list-linked", args=args, rv=rv)
+
+        # can't combine -i and -a
+        args = "-a -i {0}".format(self.i_name[1])
+        self._pkg([0], "detach-linked", args=args, rv=rv)
+        self._pkg([0], "sync-linked", args=args, rv=rv)
+        self._pkg([0], "audit-linked", args=args, rv=rv)
+
+        # can't combine -I and -a
+        args = "-I -a"
+        self._pkg([0], "detach-linked", args=args, rv=rv)
+        self._pkg([0], "sync-linked", args=args, rv=rv)
+        self._pkg([0], "audit-linked", args=args, rv=rv)
+
+        # can't combine -I and -l
+        args = "-I -l {0}".format(self.i_name[1])
+        self._pkg([0], "detach-linked", args=args, rv=rv)
+        self._pkg([0], "sync-linked", args=args, rv=rv)
+        self._pkg([0], "audit-linked", args=args, rv=rv)
+
+        # can't combine -i and -l with same target
+        args = "-i {0} -l {1}".format(self.i_name[1], self.i_name[1])
+        self._pkg([0], "detach-linked", args=args, rv=rv)
+        self._pkg([0], "sync-linked", args=args, rv=rv)
+        self._pkg([0], "audit-linked", args=args, rv=rv)
+
+        # doesn't accept -a
+        args = "-a"
+        self._pkg([0], "attach-linked", args=args, rv=rv)
+        self._pkg([0], "list-linked", args=args, rv=rv)
+        self._pkg([0], "property-linked", args=args, rv=rv)
+        self._pkg([0], "set-property-linked", args=args, rv=rv)
+
+        # doesn't accept -l
+        args = "-l {0}".format(self.i_name[1])
+        self._pkg([0], "attach-linked", args=args, rv=rv)
+        self._pkg([0], "list-linked", args=args, rv=rv)
+
+        # can't combine --no-parent-sync and --linked-md-only
+        args = "--no-parent-sync --linked-md-only"
+        self._pkg([0], "sync-linked -a", args=args, rv=rv)
+        self._pkg([2], "sync-linked", args=args, rv=rv)
+
+        # can't use --no-parent-sync when invoking from parent
+        args = "--no-parent-sync"
+        self._pkg([0], "sync-linked -a", args=args, rv=rv)
+        self._pkg_child(0, [1], "sync-linked", args=args, rv=rv)
+
+        # can't use be options when managing children
+        for arg in ["--deny-new-be", "--require-new-be", "--be-name=foo"]:
+            args = "-a {0}".format(arg)
+            self._pkg([0], "sync-linked", args=args, rv=rv)
+
+            args = "-l {0} {1}".format(self.i_name[1], arg)
+            self._pkg([0], "sync-linked", args=args, rv=rv)
+            self._pkg([0], "set-property-linked", args=args, rv=rv)
+
+    def test_opts_2_invalid_bad_child(self):
+        self._imgs_create(2)
+
+        rv = EXIT_OOPS
+
+        # try using an invalid child name
+        self._pkg(
+            [0], "attach-linked -c foobar {0}".format(self.i_path[1]), rv=rv
+        )
+
+        for lin in ["foobar", self.i_name[1]]:
+            # try using an invalid and unknown child name
+            args = "-l {0}".format(lin)
+
+            self._pkg([0], "sync-linked", args=args, rv=rv)
+            self._pkg([0], "audit-linked", args=args, rv=rv)
+            self._pkg([0], "property-linked", args=args, rv=rv)
+            self._pkg([0], "set-property-linked", args=args, rv=rv)
+            self._pkg([0], "detach-linked", args=args, rv=rv)
+
+            # try to ignore invalid unknown children
+            args = "-i {0}".format(lin)
+
+            # operations on the parent image
+            self._pkg([0], "sync-linked", args=args, rv=rv)
+            self._pkg([0], "list-linked", args=args, rv=rv)
+            self._pkg([0], "update", args=args, rv=rv)
+            self._pkg(
+                [0],
+                "install",
+                args="-i {0} {1}".format(lin, self.p_foo1_name[1]),
+                rv=rv,
+            )
+            self._pkg(
+                [0],
+                "change-variant",
+                args="-i {0} -v variant.foo=baz".format(lin),
+                rv=rv,
+            )
+            # TODO: test change-facet
+
+        rv = EXIT_BADOPT
+
+        for op in ["update", "install", "uninstall"]:
+            # -z and -Z can't be used together
+            self._pkg(
+                [0],
+                "{0} -r " "-z system:img1 -Z system:img1 foo".format(op),
+                rv=rv,
+            )
+            # check handling of valid but not existing child names
+            self._pkg(
+                [0],
+                "{0} -r -z system:foo {1}".format(op, self.p_foo1_name[1]),
+                rv=rv,
+            )
+            self._pkg(
+                [0],
+                "{0} -r -Z system:foo {1}".format(op, self.p_foo1_name[1]),
+                rv=rv,
+            )
+            # check handling of valid but not existing zone names
+            self._pkg(
+                [0], "{0} -r -z foo {1}".format(op, self.p_foo1_name[1]), rv=rv
+            )
+            self._pkg(
+                [0], "{0} -r -Z foo {1}".format(op, self.p_foo1_name[1]), rv=rv
+            )
+            # check handling of invalid child names
+            self._pkg(
+                [0],
+                "{0} -r -z :foo:&& {1}".format(op, self.p_foo1_name[1]),
+                rv=rv,
+            )
+            self._pkg(
+                [0],
+                "{0} -r -Z :foo:&& {1}".format(op, self.p_foo1_name[1]),
+                rv=rv,
+            )
+
+    def test_opts_3_all(self):
+        self._imgs_create(1)
+
+        # the -a option is always valid
+        self._pkg([0], "sync-linked -a")
+        self._pkg([0], "audit-linked -a")
+        self._pkg([0], "detach-linked -a")
+
+    def test_opts_4_noop(self):
+        self._imgs_create(4)
+
+        # plan operations
+        self._attach_child(0, [1, 2], args="-vn")
+        self._attach_child(0, [1, 2], args="-vn")
+        self._attach_parent([3], 0, args="-vn")
+        self._attach_parent([3], 0, args="-vn")
+
+        # do operations
+        self._attach_child(0, [1, 2], args="-v")
+        self._attach_parent([3], 0, args="-v")
+
+        # plan operations
+        self._pkg_child(0, [1, 2], "detach-linked", args="-vn")
+        self._pkg_child(0, [1, 2], "detach-linked", args="-vn")
+        self._pkg_child_all(0, "detach-linked", args="-vn")
+        self._pkg_child_all(0, "detach-linked", args="-vn")
+        self._pkg([3], "detach-linked", args="-vn")
+        self._pkg([3], "detach-linked", args="-vn")
+
+        # do operations
+        self._pkg_child(0, [1], "detach-linked", args="-v")
+        self._pkg_child_all(0, "detach-linked", args="-v")
+        self._pkg([3], "detach-linked", args="-v")
+
+    def test_attach_p2c_1(self):
+        self._imgs_create(4)
+        self._v_not_linked([0, 1, 2, 3])
+
+        # link parents to children as follows:
+        #     0 -> 1 -> 2
+        #          1 -> 3
+
+        # attach parent (0) to child (1), (0 -> 1)
+        self._attach_child(0, [1], args="--parsable=0 -n")
+        self.assertEqualParsable(
+            self.output, child_images=[{"image_name": "system:img1"}]
+        )
+        self._attach_child(0, [1], args="--parsable=0")
+        self.assertEqualParsable(
+            self.output, child_images=[{"image_name": "system:img1"}]
+        )
+        self._v_has_children(0, [1])
+        self._v_has_parent([1])
+        self._v_not_linked([2, 3])
+
+        # attach parent (1) to child (2), (1 -> 2)
+        self._attach_child(1, [2])
+        self._v_has_children(0, [1])
+        self._v_has_children(1, [2])
+        self._v_has_parent([1, 2])
+        self._v_no_children([2])
+        self._v_not_linked([3])
+
+        # attach parent (1) to child (3), (1 -> 3)
+        self._attach_child(1, [3])
+        self._v_has_children(0, [1])
+        self._v_has_children(1, [2, 3])
+        self._v_has_parent([1, 2, 3])
+        self._v_no_children([2, 3])
+
+    def test_detach_p2c_1(self):
+        self._imgs_create(4)
+
+        # link parents to children as follows:
+        #     0 -> 1 -> 2
+        #          1 -> 3
+        self._attach_child(0, [1])
+        self._attach_child(1, [2, 3])
+
+        # detach child (1) from parent (0)
+        self._pkg_child(0, [1], "detach-linked")
+        self._v_has_children(1, [2, 3])
+        self._v_has_parent([2, 3])
+        self._v_no_children([2, 3])
+        self._v_not_linked([0])
+
+        # detach child (3) from parent (1)
+        self._pkg_child(1, [3], "detach-linked")
+        self._v_has_children(1, [2])
+        self._v_has_parent([2])
+        self._v_no_children([2])
+        self._v_not_linked([0, 3])
+
+        # detach child (2) from parent (1)
+        self._pkg_child(1, [2], "detach-linked")
+        self._v_not_linked([0, 1, 2, 3])
+
+    def test_detach_p2c_2(self):
+        self._imgs_create(4)
+
+        # link parents to children as follows:
+        #     0 -> 1 -> 2
+        #          1 -> 3
+        self._attach_child(0, [1])
+        self._attach_child(1, [2, 3])
+
+        # detach child (1) from parent (0)
+        self._pkg_child_all(0, "detach-linked", args="-n")
+        self._pkg_child_all(0, "detach-linked")
+        self._v_has_children(1, [2, 3])
+        self._v_has_parent([2, 3])
+        self._v_no_children([2, 3])
+        self._v_not_linked([0])
+
+        # detach child (3) and child (2) from parent (1)
+        self._pkg_child_all(1, "detach-linked")
+        self._v_not_linked([0, 1, 2, 3])
+
+        # detach all children (there are none)
+        self._pkg_child_all(0, "detach-linked")
+
+    def test_attach_c2p_1(self):
+        self._imgs_create(4)
+        self._v_not_linked([0, 1, 2, 3])
+
+        # link children to parents as follows:
+        #     2 -> 1 -> 0
+        #     3 -> 1
+
+        # attach child (2) to parent (1), (2 -> 1)
+        self._attach_parent([2], 1, args="--parsable=0 -n")
+        self.assertEqualParsable(self.output)
+        self._attach_parent([2], 1, args="--parsable=0")
+        self.assertEqualParsable(self.output)
+        self._v_has_parent([2])
+        self._v_no_children([2])
+        self._v_not_linked([0, 1, 3])
+
+        # attach child (3) to parent (1), (3 -> 1)
+        self._attach_parent([3], 1)
+        self._v_has_parent([2, 3])
+        self._v_no_children([2, 3])
+        self._v_not_linked([0, 1])
+
+        # attach child (1) to parent (0), (1 -> 0)
+        self._attach_parent([1], 0)
+        self._v_has_parent([1, 2, 3])
+        self._v_no_children([1, 2, 3])
+        self._v_not_linked([0])
+
+    def test_detach_c2p_1(self):
+        self._imgs_create(4)
+
+        # link children to parents as follows:
+        #     2 -> 1 -> 0
+        #     3 -> 1
+        self._attach_parent([2, 3], 1)
+        self._attach_parent([1], 0)
+
+        # detach parent (0) from child (1)
+        self._pkg([1], "detach-linked -n")
+        self._pkg([1], "detach-linked")
+        self._v_has_parent([2, 3])
+        self._v_no_children([2, 3])
+        self._v_not_linked([0, 1])
+
+        # detach parent (1) from child (3)
+        self._pkg([3], "detach-linked")
+        self._v_has_parent([2])
+        self._v_no_children([2])
+        self._v_not_linked([0, 1, 3])
+
+        # detach parent (1) from child (2)
+        self._pkg([2], "detach-linked")
+        self._v_not_linked([0, 1, 2, 3])
+
+    def test_attach_already_linked_1_err(self):
+        self._imgs_create(4)
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        rv = EXIT_OOPS
+
+        # try to link the parent image to a new child with a dup name
+        self._pkg(
+            [0],
+            "attach-linked -c {0} {1}".format(self.i_name[1], self.i_path[2]),
+            rv=rv,
+        )
+
+        # have a new parent try to link to the p2c child
+        self._attach_child(3, [1], rv=rv)
+
+        # have the p2c child try to link to a new parent
+        self._attach_parent([1], 3, rv=rv)
+
+        # have the c2p child try to link to a new parent
+        self._attach_parent([2], 3, rv=rv)
+
+    def test_attach_already_linked_2_relink(self):
+        self._imgs_create(4)
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # have a new parent try to link to the p2c child
+        self._attach_child(3, [1], args="--allow-relink")
+
+        # have the p2c child try to link to a new parent
+        self._attach_parent([1], 3, args="--allow-relink")
+
+        # have the c2p child try to link to a new parent
+        self._attach_parent([2], 3, args="--allow-relink")
+
+    def test_zone_attach_detach(self):
+        self._imgs_create(2)
+
+        rv = EXIT_OOPS
+
+        # by default we can't attach (p2c) zone image
+        self._pkg(
+            [0],
+            "attach-linked -v -c zone:foo {0}".format(self.i_path[1]),
+            rv=rv,
+        )
+        self._v_not_linked([0, 1])
+
+        # force attach (p2c) zone image
+        self._pkg(
+            [0], "attach-linked -v -f -c zone:foo {0}".format(self.i_path[1])
+        )
+        self._v_not_linked([0])
+        self._v_has_parent([1])
+
+        self._imgs_create(2)
+
+        # by default we can't attach (c2p) zone image
+        self._pkg(
+            [1],
+            "attach-linked -v -p zone:foo {0}".format(self.i_path[0]),
+            rv=rv,
+        )
+        self._v_not_linked([0, 1])
+
+        # force attach (c2p) zone image
+        self._pkg(
+            [1], "attach-linked -v -f -p zone:foo {0}".format(self.i_path[0])
+        )
+        self._v_not_linked([0])
+        self._v_has_parent([1])
+
+        # by default we can't detach (c2p) zone image
+        self._pkg([1], "detach-linked -v", rv=rv)
+        self._v_not_linked([0])
+        self._v_has_parent([1])
+
+        # force detach (c2p) zone image
+        self._pkg([1], "detach-linked -v -f")
+        self._v_not_linked([0, 1])
+
+    def test_parent_ops_error(self):
+        self._imgs_create(2)
+
+        # attach a child
+        self._attach_child(0, [1])
+
+        rv = EXIT_PARENTOP
+
+        # some operations can't be done from a child when linked to
+        # from a parent
+        self._pkg([1], "detach-linked", rv=EXIT_PARENTOP)
+
+        # TODO: enable this once we support set-property-linked
+        # self._pkg([1], "set-property-linked", rv=EXIT_PARENTOP)
+
+    def test_eaccess_1_parent(self):
+        self._imgs_create(3)
+        self._attach_parent([1], 0)
+
+        rv = EXIT_EACCESS
+
+        for i in [0, 1]:
+            if i == 0:
+                # empty the parent image
+                self.set_image(0)
+                self.image_destroy()
+                self._ccmd("mkdir -p {0}".format(self.i_path[0]))
+            if i == 1:
+                # delete the parent image
+                self.set_image(0)
+                self.image_destroy()
+
+            # operations that need to access the parent should fail
+            self._pkg([1], "sync-linked", rv=rv)
+            self._pkg([1], "audit-linked", rv=rv)
+            self._pkg([1], "install {0}".format(self.p_foo1_name[1]), rv=rv)
+            self._pkg([1], "image-update", rv=rv)
+
+            # operations that need to access the parent should fail
+            self._attach_parent([2], 0, rv=rv)
+
+        # detach should still work
+        self._pkg([1], "detach-linked")
+
+    def test_eaccess_1_child(self):
+        self._imgs_create(2)
+        self._attach_child(0, [1])
+
+        outfile = os.path.join(self.test_root, "res")
+        rv = EXIT_EACCESS
+
+        for i in [0, 1, 2]:
+            if i == 0:
+                # corrupt the child image
+                self._ccmd(
+                    "mkdir -p "
+                    "{0}/{1}".format(self.i_path[1], image.img_user_prefix)
+                )
+                self._ccmd(
+                    "mkdir -p "
+                    "{0}/{1}".format(self.i_path[1], image.img_root_prefix)
+                )
+            if i == 1:
+                # delete the child image
+                self.set_image(1)
+                self.image_destroy()
+                self._ccmd("mkdir -p {0}".format(self.i_path[1]))
+            if i == 2:
+                # delete the child image
+                self.set_image(1)
+                self.image_destroy()
+
+            # child should still be listed
+            self._pkg([0], "list-linked -H > {0}".format(outfile))
+            self._ccmd("cat {0}".format(outfile))
+            self._ccmd("egrep '^{0}[ 	]' {1}".format(self.i_name[1], outfile))
+
+            # child should still be listed
+            self._pkg(
+                [0],
+                "property-linked -H -l {0} > {1}".format(
+                    self.i_name[1], outfile
+                ),
+            )
+            self._ccmd("cat {0}".format(outfile))
+            self._ccmd("egrep '^li-' {0}".format(outfile))
+
+            # operations that need to access child should fail
+            self._pkg_child(0, [1], "sync-linked", rv=rv)
+            self._pkg_child_all(0, "sync-linked", rv=rv)
+
+            self._pkg_child(0, [1], "audit-linked", rv=rv)
+            self._pkg_child_all(0, "audit-linked", rv=rv)
+
+            self._pkg_child(0, [1], "detach-linked", rv=rv)
+            self._pkg_child_all(0, "detach-linked", rv=rv)
+
+            # TODO: test more recursive ops here
+            # image-update, install, uninstall, etc
+
+    def test_ignore_1_no_children(self):
+        self._imgs_create(1)
+        outfile = os.path.join(self.test_root, "res")
+
+        # it's ok to use -I with no children
+        self._pkg([0], "list-linked -H -I > {0}".format(outfile))
+        self._ccmd("cat {0}".format(outfile))
+        self._ccmd("egrep '^$|.' {0}".format(outfile), rv=EXIT_OOPS)
+
+    def test_ignore_2_ok(self):
+        self._imgs_create(3)
+        self._attach_child(0, [1, 2])
+        outfile = os.path.join(self.test_root, "res")
+
+        # ignore one child
+        self._pkg(
+            [0], "list-linked -H -i {0} > {1}".format(self.i_name[1], outfile)
+        )
+        self._ccmd("cat {0}".format(outfile))
+        self._ccmd(
+            "egrep '^{0}[ 	]' {1}".format(self.i_name[1], outfile), rv=EXIT_OOPS
+        )
+        self._ccmd("egrep '^{0}[ 	]' {1}".format(self.i_name[2], outfile))
+
+        # manually ignore all children
+        self._pkg(
+            [0],
+            "list-linked -H -i {0} -i {1} > {2}".format(
+                self.i_name[1], self.i_name[2], outfile
+            ),
+        )
+        self._ccmd("cat {0}".format(outfile))
+        self._ccmd("egrep '^$|.' {0}".format(outfile), rv=EXIT_OOPS)
+
+        # automatically ignore all children
+        self._pkg([0], "list-linked -H -I > {0}".format(outfile))
+        self._ccmd("cat {0}".format(outfile))
+        self._ccmd("egrep '^$|.' {0}".format(outfile), rv=EXIT_OOPS)
+
+    def test_no_pkg_updates_1_empty_via_attach(self):
+        """test --no-pkg-updates with an empty image."""
+        self._imgs_create(3)
+
+        self._attach_child(0, [1], args="--no-pkg-updates")
+        self._attach_parent([2], 0, args="--no-pkg-updates")
+
+    def test_no_pkg_updates_1_empty_via_sync(self):
+        """test --no-pkg-updates with an empty image."""
+        self._imgs_create(4)
+
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2], args="--linked-md-only")
+        self._attach_parent([3], 0, args="--linked-md-only")
+
+        self._pkg_child(0, [1], "sync-linked -v --no-pkg-updates", rv=EXIT_NOP)
+        self._pkg_child_all(0, "sync-linked -v --no-pkg-updates", rv=EXIT_NOP)
+        self._pkg([3], "sync-linked -v --no-pkg-updates", rv=EXIT_NOP)
+
+    def test_no_pkg_updates_1_empty_via_set_property_linked_TODO(self):
+        """test --no-pkg-updates with an empty image."""
+        pass
+
+    def test_no_pkg_updates_2_foo_via_attach(self):
+        """test --no-pkg-updates with a non-empty image."""
+        self._imgs_create(3)
+
+        # install different un-synced packages into each image
+        for i in [0, 1, 2]:
+            self._pkg([i], "install -v {0}".format(self.p_foo1_name[i]))
+
+        self._attach_child(0, [1], args="--no-pkg-updates")
+        self._attach_parent([2], 0, args="--no-pkg-updates")
+
+        # verify the un-synced packages
+        for i in [0, 1, 2]:
+            self._pkg([i], "list -v {0}".format(self.p_foo1_name[i]))
+
+    def test_no_pkg_updates_2_foo_via_sync(self):
+        """test --no-pkg-updates with a non-empty image."""
+        self._imgs_create(4)
+
+        # install different un-synced packages into each image
+        for i in range(4):
+            self._pkg([i], "install -v {0}".format(self.p_foo1_name[i]))
+
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2], args="--linked-md-only")
+        self._attach_parent([3], 0, args="--linked-md-only")
+
+        self._pkg_child(0, [1], "sync-linked -v --no-pkg-updates", rv=EXIT_NOP)
+        self._pkg_child_all(0, "sync-linked -v --no-pkg-updates", rv=EXIT_NOP)
+        self._pkg([3], "sync-linked -v --no-pkg-updates", rv=EXIT_NOP)
+
+        # verify the un-synced packages
+        for i in range(4):
+            self._pkg([i], "list -v {0}".format(self.p_foo1_name[i]))
+
+    def test_no_pkg_updates_2_foo_via_set_property_linked_TODO(self):
+        """test --no-pkg-updates with a non-empty image."""
+        pass
+
+    def test_no_pkg_updates_3_sync_via_attach(self):
+        """test --no-pkg-updates with an in sync package"""
+        self._imgs_create(3)
+
+        # install the same synced packages into each image
+        for i in range(3):
+            self._pkg([i], "install -v {0}".format(self.p_sync1_name[1]))
+
+        self._attach_child(0, [1], args="--no-pkg-updates")
+        self._attach_parent([2], 0, args="--no-pkg-updates")
+
+        # verify the synced packages
+        for i in range(3):
+            self._pkg([i], "list -v {0}".format(self.p_sync1_name[1]))
+
+    def test_no_pkg_updates_3_sync_via_sync(self):
+        """test --no-pkg-updates with an in sync package"""
+        self._imgs_create(4)
+
+        # install the same synced packages into each image
+        for i in range(4):
+            self._pkg([i], "install -v {0}".format(self.p_sync1_name[1]))
+
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2], args="--linked-md-only")
+        self._attach_parent([3], 0, args="--linked-md-only")
+
+        # verify the synced packages
+        for i in range(4):
+            self._pkg([i], "list -v {0}".format(self.p_sync1_name[1]))
+
+        self._pkg_child(0, [1], "sync-linked -v --no-pkg-updates", rv=EXIT_NOP)
+        self._pkg_child_all(0, "sync-linked -v --no-pkg-updates", rv=EXIT_NOP)
+        self._pkg([3], "sync-linked -v --no-pkg-updates", rv=EXIT_NOP)
+
+    def test_no_pkg_updates_3_sync_via_set_property_linked_TODO(self):
+        """test --no-pkg-updates with an in sync package"""
+        pass
+
+    def test_no_pkg_updates_3_fail_via_attach(self):
+        """test --no-pkg-updates with an out of sync package"""
+        self._imgs_create(3)
+
+        # install different synced packages into each image
+        for i in range(3):
+            self._pkg([i], "install -v {0}".format(self.p_sync1_name[i + 1]))
+
+        self._attach_child(0, [1], args="--no-pkg-updates", rv=EXIT_OOPS)
+        self._attach_parent([2], 0, args="--no-pkg-updates", rv=EXIT_OOPS)
+
+        # verify packages
+        for i in range(3):
+            self._pkg([i], "list -v {0}".format(self.p_sync1_name[i + 1]))
+
+    def test_no_pkg_updates_3_fail_via_sync(self):
+        """test --no-pkg-updates with an out of sync package"""
+        self._imgs_create(4)
+
+        # install different synced packages into each image
+        for i in range(4):
+            self._pkg([i], "install -v {0}".format(self.p_sync1_name[i + 1]))
+
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2], args="--linked-md-only")
+        self._attach_parent([3], 0, args="--linked-md-only")
+
+        self._pkg_child(0, [1], "sync-linked -v --no-pkg-updates", rv=EXIT_OOPS)
+        self._pkg_child_all(0, "sync-linked -v --no-pkg-updates", rv=EXIT_OOPS)
+        self._pkg([3], "sync-linked -v --no-pkg-updates", rv=EXIT_OOPS)
+
+        # verify packages
+        for i in range(3):
+            self._pkg([i], "list -v {0}".format(self.p_sync1_name[i + 1]))
+
+    def test_no_pkg_updates_3_fail_via_set_property_linked_TODO(self):
+        pass
+
+    def test_audit_synced_1(self):
+        self._imgs_create(4)
+
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2], args="--linked-md-only")
+        self._attach_parent([3], 0, args="--linked-md-only")
+
+        # audit with empty parent and child
+        self._pkg([1, 2, 3], "audit-linked")
+        self._pkg_child(0, [1, 2], "audit-linked")
+        self._pkg_child_all(0, "audit-linked")
+        self._pkg_child_all(3, "audit-linked")
+
+    def test_audit_synced_2(self):
+        self._imgs_create(4)
+
+        # install different un-synced packages into each image
+        for i in [0, 1, 2, 3]:
+            self._pkg([i], "install -v {0}".format(self.p_foo1_name[i]))
+
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2, 3], args="--linked-md-only")
+
+        self._pkg([1, 2, 3], "audit-linked")
+        self._pkg_child(0, [1, 2, 3], "audit-linked")
+        self._pkg_child_all(0, "audit-linked")
+
+    def test_audit_synced_3(self):
+        self._imgs_create(4)
+
+        # install synced package into parent
+        self._pkg([0], "install -v {0}".format(self.p_sync1_name[0]))
+
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2, 3], args="--linked-md-only")
+
+        self._pkg([1, 2, 3], "audit-linked")
+        self._pkg_child(0, [1, 2, 3], "audit-linked")
+        self._pkg_child_all(0, "audit-linked")
+
+    def test_audit_synced_4(self):
+        self._imgs_create(4)
+
+        # install same synced packages into parent and some children
+        for i in [0, 1, 2, 3]:
+            self._pkg([i], "install -v {0}".format(self.p_sync1_name[0]))
+
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2, 3], args="--linked-md-only")
+
+        self._pkg([1, 2, 3], "audit-linked")
+        self._pkg_child(0, [1, 2, 3], "audit-linked")
+        self._pkg_child_all(0, "audit-linked")
+
+    def test_audit_diverged_1(self):
+        self._imgs_create(4)
+
+        # install different synced package into some child images
+        for i in [1, 3]:
+            self._pkg([i], "install -v {0}".format(self.p_sync1_name[i]))
+
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2, 3], args="--linked-md-only")
+
+        rvdict = {1: EXIT_DIVERGED, 3: EXIT_DIVERGED}
+        self._pkg([1, 2, 3], "audit-linked", rvdict=rvdict)
+        self._pkg_child(0, [1, 2, 3], "audit-linked", rvdict=rvdict)
+        self._pkg_child_all(0, "audit-linked", rv=EXIT_DIVERGED)
+
+    def test_audit_diverged_2(self):
+        self._imgs_create(4)
+
+        # install different synced package into each image
+        for i in range(4):
+            self._pkg([i], "install -v {0}".format(self.p_sync1_name[i]))
+
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2, 3], args="--linked-md-only")
+
+        rv = EXIT_DIVERGED
+        self._pkg([1, 2, 3], "audit-linked", rv=rv)
+        self._pkg_child(0, [1, 2, 3], "audit-linked", rv=rv)
+        self._pkg_child_all(0, "audit-linked", rv=rv)
+
 
 class TestPkgLinked2(TestPkgLinked):
-        """Class used solely to split up the test suite for parallelization."""
+    """Class used solely to split up the test suite for parallelization."""
 
-        def test_sync_fail(self):
-                self._imgs_create(3)
+    def test_sync_fail(self):
+        self._imgs_create(3)
 
-                # install newer sync'ed package into child
-                self._pkg([0], "install -v {0}".format(self.p_sync1_name[2]))
-                self._pkg([1], "install -v {0}".format(self.p_sync1_name[1]))
-                self._pkg([2], "install -v {0}".format(self.p_sync1_name[1]))
+        # install newer sync'ed package into child
+        self._pkg([0], "install -v {0}".format(self.p_sync1_name[2]))
+        self._pkg([1], "install -v {0}".format(self.p_sync1_name[1]))
+        self._pkg([2], "install -v {0}".format(self.p_sync1_name[1]))
 
-                # attach should fail
-                self._attach_child(0, [1], args="-vn", rv=EXIT_OOPS)
-                self._attach_child(0, [1], args="-v", rv=EXIT_OOPS)
-                self._attach_parent([2], 0, args="-vn", rv=EXIT_OOPS)
-                self._attach_parent([2], 0, args="-v", rv=EXIT_OOPS)
+        # attach should fail
+        self._attach_child(0, [1], args="-vn", rv=EXIT_OOPS)
+        self._attach_child(0, [1], args="-v", rv=EXIT_OOPS)
+        self._attach_parent([2], 0, args="-vn", rv=EXIT_OOPS)
+        self._attach_parent([2], 0, args="-v", rv=EXIT_OOPS)
 
-                # use --linked-md-only so we don't install constraints package
-                # attach should succeed
-                self._attach_child(0, [1], args="-vn --linked-md-only")
-                self._attach_child(0, [1], args="-v --linked-md-only")
-                self._attach_parent([2], 0, args="-vn --linked-md-only")
-                self._attach_parent([2], 0, args="-v --linked-md-only")
+        # use --linked-md-only so we don't install constraints package
+        # attach should succeed
+        self._attach_child(0, [1], args="-vn --linked-md-only")
+        self._attach_child(0, [1], args="-v --linked-md-only")
+        self._attach_parent([2], 0, args="-vn --linked-md-only")
+        self._attach_parent([2], 0, args="-v --linked-md-only")
 
-                # trying to sync the child should fail
-                self._pkg([1, 2], "sync-linked -vn", rv=EXIT_OOPS)
-                self._pkg([1, 2], "sync-linked -v", rv=EXIT_OOPS)
-                self._pkg_child(0, [1], "sync-linked -vn", rv=EXIT_OOPS)
-                self._pkg_child(0, [1], "sync-linked -v", rv=EXIT_OOPS)
+        # trying to sync the child should fail
+        self._pkg([1, 2], "sync-linked -vn", rv=EXIT_OOPS)
+        self._pkg([1, 2], "sync-linked -v", rv=EXIT_OOPS)
+        self._pkg_child(0, [1], "sync-linked -vn", rv=EXIT_OOPS)
+        self._pkg_child(0, [1], "sync-linked -v", rv=EXIT_OOPS)
 
-                # use --linked-md-only so we don't install constraints package
-                # sync should succeed
-                rv = EXIT_NOP
-                self._pkg([1, 2], "sync-linked -vn --linked-md-only", rv=rv)
-                self._pkg([1, 2], "sync-linked -v --linked-md-only", rv=rv)
-                self._pkg_child(0, [1], "sync-linked -vn --linked-md-only",
-                    rv=rv)
-                self._pkg_child(0, [1], "sync-linked -v --linked-md-only",
-                    rv=rv)
+        # use --linked-md-only so we don't install constraints package
+        # sync should succeed
+        rv = EXIT_NOP
+        self._pkg([1, 2], "sync-linked -vn --linked-md-only", rv=rv)
+        self._pkg([1, 2], "sync-linked -v --linked-md-only", rv=rv)
+        self._pkg_child(0, [1], "sync-linked -vn --linked-md-only", rv=rv)
+        self._pkg_child(0, [1], "sync-linked -v --linked-md-only", rv=rv)
 
-                # trying to sync via image-update should fail
-                self._pkg([1, 2], "image-update -vn", rv=EXIT_OOPS)
-                self._pkg([1, 2], "image-update -v", rv=EXIT_OOPS)
+        # trying to sync via image-update should fail
+        self._pkg([1, 2], "image-update -vn", rv=EXIT_OOPS)
+        self._pkg([1, 2], "image-update -v", rv=EXIT_OOPS)
 
-                # trying to sync via install should fail
-                self._pkg([1, 2], "install -vn {0}", self.p_sync1_name[0],
-                    rv=EXIT_OOPS)
-                self._pkg([1, 2], "install -v {0}", self.p_sync1_name[0],
-                    rv=EXIT_OOPS)
+        # trying to sync via install should fail
+        self._pkg([1, 2], "install -vn {0}", self.p_sync1_name[0], rv=EXIT_OOPS)
+        self._pkg([1, 2], "install -v {0}", self.p_sync1_name[0], rv=EXIT_OOPS)
 
-                # verify the child is still divereged
-                rv = EXIT_DIVERGED
-                self._pkg([1, 2], "audit-linked", rv=rv)
+        # verify the child is still divereged
+        rv = EXIT_DIVERGED
+        self._pkg([1, 2], "audit-linked", rv=rv)
 
-        def test_sync_1(self):
-                self._imgs_create(5)
+    def test_sync_1(self):
+        self._imgs_create(5)
 
-                # install different synced package into each image
-                for i in [0, 1, 2, 3, 4]:
-                        self._pkg([i], "install -v {0}".format(self.p_sync1_name[i]))
+        # install different synced package into each image
+        for i in [0, 1, 2, 3, 4]:
+            self._pkg([i], "install -v {0}".format(self.p_sync1_name[i]))
 
-                # install unsynced packages to make sure they aren't molested
-                self._pkg([0], "install -v {0}".format(self.p_foo1_name[1]))
-                self._pkg([1, 2, 3, 4], "install -v {0}".format(self.p_foo1_name[2]))
+        # install unsynced packages to make sure they aren't molested
+        self._pkg([0], "install -v {0}".format(self.p_foo1_name[1]))
+        self._pkg([1, 2, 3, 4], "install -v {0}".format(self.p_foo1_name[2]))
 
-                # use --linked-md-only so we don't install constraints package
-                self._attach_child(0, [1, 2, 3], args="--linked-md-only")
-                self._attach_parent([4], 0, args="--linked-md-only")
+        # use --linked-md-only so we don't install constraints package
+        self._attach_child(0, [1, 2, 3], args="--linked-md-only")
+        self._attach_parent([4], 0, args="--linked-md-only")
 
-                # everyone should be diverged
-                self._pkg([1, 2, 3, 4], "audit-linked", rv=EXIT_DIVERGED)
+        # everyone should be diverged
+        self._pkg([1, 2, 3, 4], "audit-linked", rv=EXIT_DIVERGED)
 
-                # plan sync (direct)
-                self._pkg([1, 4], "sync-linked -vn")
-                self._pkg([1, 2, 3, 4], "audit-linked", rv=EXIT_DIVERGED)
+        # plan sync (direct)
+        self._pkg([1, 4], "sync-linked -vn")
+        self._pkg([1, 2, 3, 4], "audit-linked", rv=EXIT_DIVERGED)
 
-                # sync child (direct)
-                self._pkg([1, 4], "sync-linked", args="--parsable=0 -n")
-                self.assertEqualParsable(self.output,
-                    change_packages=[[self.s1_list[-1], self.s1_list[0]]])
-                self._pkg([1, 4], "sync-linked", args="--parsable=0")
-                self.assertEqualParsable(self.output,
-                    change_packages=[[self.s1_list[-1], self.s1_list[0]]])
-                rvdict = {2: EXIT_DIVERGED, 3: EXIT_DIVERGED}
-                self._pkg([1, 2, 3, 4], "audit-linked", rvdict=rvdict)
-                self._pkg([1, 4], "sync-linked -v", rv=EXIT_NOP)
+        # sync child (direct)
+        self._pkg([1, 4], "sync-linked", args="--parsable=0 -n")
+        self.assertEqualParsable(
+            self.output, change_packages=[[self.s1_list[-1], self.s1_list[0]]]
+        )
+        self._pkg([1, 4], "sync-linked", args="--parsable=0")
+        self.assertEqualParsable(
+            self.output, change_packages=[[self.s1_list[-1], self.s1_list[0]]]
+        )
+        rvdict = {2: EXIT_DIVERGED, 3: EXIT_DIVERGED}
+        self._pkg([1, 2, 3, 4], "audit-linked", rvdict=rvdict)
+        self._pkg([1, 4], "sync-linked -v", rv=EXIT_NOP)
 
-                # plan sync (indirectly via -l)
-                self._pkg_child(0, [2], "sync-linked -vn")
-                self._pkg([1, 2, 3], "audit-linked", rvdict=rvdict)
+        # plan sync (indirectly via -l)
+        self._pkg_child(0, [2], "sync-linked -vn")
+        self._pkg([1, 2, 3], "audit-linked", rvdict=rvdict)
 
-                # sync child (indirectly via -l)
-                self._pkg_child(0, [2], "sync-linked", args="--parsable=0 -n")
-                self.assertEqualParsable(self.output,
-                    child_images=[{
-                        "image_name": "system:img2",
-                        "change_packages": [[self.s1_list[2], self.s1_list[0]]]
-                    }])
-                self._pkg_child(0, [2], "sync-linked", args="--parsable=0")
-                self.assertEqualParsable(self.output,
-                    child_images=[{
-                        "image_name": "system:img2",
-                        "change_packages": [[self.s1_list[2], self.s1_list[0]]]
-                    }])
-                rvdict = {3: EXIT_DIVERGED}
-                self._pkg([1, 2, 3], "audit-linked", rvdict=rvdict)
-                self._pkg_child(0, [2], "sync-linked -vn", rv=EXIT_NOP)
+        # sync child (indirectly via -l)
+        self._pkg_child(0, [2], "sync-linked", args="--parsable=0 -n")
+        self.assertEqualParsable(
+            self.output,
+            child_images=[
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[0]]],
+                }
+            ],
+        )
+        self._pkg_child(0, [2], "sync-linked", args="--parsable=0")
+        self.assertEqualParsable(
+            self.output,
+            child_images=[
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[0]]],
+                }
+            ],
+        )
+        rvdict = {3: EXIT_DIVERGED}
+        self._pkg([1, 2, 3], "audit-linked", rvdict=rvdict)
+        self._pkg_child(0, [2], "sync-linked -vn", rv=EXIT_NOP)
 
-                # plan sync (indirectly via -a)
-                self._pkg_child_all(0, "sync-linked -vn")
-                self._pkg([1, 2, 3], "audit-linked", rvdict=rvdict)
+        # plan sync (indirectly via -a)
+        self._pkg_child_all(0, "sync-linked -vn")
+        self._pkg([1, 2, 3], "audit-linked", rvdict=rvdict)
 
-                # sync child (indirectly via -a)
-                self._pkg_child_all(0, "sync-linked -v")
-                self._pkg([1, 2, 3], "audit-linked")
-                self._pkg_child_all(0, "sync-linked -v", rv=EXIT_NOP)
+        # sync child (indirectly via -a)
+        self._pkg_child_all(0, "sync-linked -v")
+        self._pkg([1, 2, 3], "audit-linked")
+        self._pkg_child_all(0, "sync-linked -v", rv=EXIT_NOP)
 
-                # check unsynced packages
-                self._pkg([1, 2, 3, 4], "list -v {0}".format(self.p_foo1_name[2]))
+        # check unsynced packages
+        self._pkg([1, 2, 3, 4], "list -v {0}".format(self.p_foo1_name[2]))
 
-        def test_sync_2_via_attach(self):
-                self._imgs_create(3)
+    def test_sync_2_via_attach(self):
+        self._imgs_create(3)
 
-                # install different synced package into each image
-                self._pkg([0], "install -v {0}".format(self.p_sync1_name[1]))
-                self._pkg([1, 2], "install -v {0}".format(self.p_sync1_name[2]))
+        # install different synced package into each image
+        self._pkg([0], "install -v {0}".format(self.p_sync1_name[1]))
+        self._pkg([1, 2], "install -v {0}".format(self.p_sync1_name[2]))
 
-                # install unsynced packages to make sure they aren't molested
-                self._pkg([0], "install -v {0}".format(self.p_foo1_name[1]))
-                self._pkg([1, 2], "install -v {0}".format(self.p_foo1_name[2]))
+        # install unsynced packages to make sure they aren't molested
+        self._pkg([0], "install -v {0}".format(self.p_foo1_name[1]))
+        self._pkg([1, 2], "install -v {0}".format(self.p_foo1_name[2]))
 
-                # attach children
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
+        # attach children
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
 
-                # check synced and unsynced packages
-                self._pkg([1, 2], "list -v {0}".format(self.p_sync1_name[1]))
-                self._pkg([1, 2], "list -v {0}".format(self.p_foo1_name[2]))
+        # check synced and unsynced packages
+        self._pkg([1, 2], "list -v {0}".format(self.p_sync1_name[1]))
+        self._pkg([1, 2], "list -v {0}".format(self.p_foo1_name[2]))
 
-        def __test_linked_sync_via_child_op(self, op, op_args, **kwargs):
-                """Verify that if we do a operation "op" on a child image, it
-                automatically brings its packages in sync with its parent.
+    def __test_linked_sync_via_child_op(self, op, op_args, **kwargs):
+        """Verify that if we do a operation "op" on a child image, it
+        automatically brings its packages in sync with its parent.
 
-                We perform operation on three child images.  1 is a push
-                child, 2 and 3 are pull children.  1 and 2 have their linked
-                image metadata in sync with the parent.  3 has its metadata
-                out of sync with the parent and is expected to sync its own
-                metadata."""
+        We perform operation on three child images.  1 is a push
+        child, 2 and 3 are pull children.  1 and 2 have their linked
+        image metadata in sync with the parent.  3 has its metadata
+        out of sync with the parent and is expected to sync its own
+        metadata."""
 
-                # create parent (0), push child (1), and pull child (2, 3)
-                self._imgs_create(4)
-                self._attach_child(0, [1])
-                self._attach_parent([2, 3], 0)
+        # create parent (0), push child (1), and pull child (2, 3)
+        self._imgs_create(4)
+        self._attach_child(0, [1])
+        self._attach_parent([2, 3], 0)
 
-                # install synced package into each image
-                self._pkg([0, 1, 2, 3], "install -v {0}".format(self.p_sync1_name[2]))
+        # install synced package into each image
+        self._pkg([0, 1, 2, 3], "install -v {0}".format(self.p_sync1_name[2]))
 
-                # install unsynced packages
-                self._pkg([0], "install -v {0}".format(self.p_foo1_name[1]))
-                self._pkg([1, 2, 3], "install -v {0}".format(self.p_foo1_name[2]))
+        # install unsynced packages
+        self._pkg([0], "install -v {0}".format(self.p_foo1_name[1]))
+        self._pkg([1, 2, 3], "install -v {0}".format(self.p_foo1_name[2]))
 
-                # update the parent image while ignoring the children (there
-                # by putting them out of sync)
-                self._pkg([0], "install -I -v {0}".format(self.p_sync1_name[1]))
+        # update the parent image while ignoring the children (there
+        # by putting them out of sync)
+        self._pkg([0], "install -I -v {0}".format(self.p_sync1_name[1]))
 
-                # explicitly sync metadata in children 1 and 2
-                self._pkg([0], "sync-linked -a --linked-md-only")
-                self._pkg([2], "sync-linked --linked-md-only")
+        # explicitly sync metadata in children 1 and 2
+        self._pkg([0], "sync-linked -a --linked-md-only")
+        self._pkg([2], "sync-linked --linked-md-only")
 
-                # plan op
-                self._pkg([1, 2, 3], "{0} -nv {1}".format(op, op_args))
+        # plan op
+        self._pkg([1, 2, 3], "{0} -nv {1}".format(op, op_args))
 
-                # verify child images are still diverged
-                self._pkg([1, 2, 3], "audit-linked", rv=EXIT_DIVERGED)
-                self._pkg([0], "audit-linked -a", rv=EXIT_DIVERGED)
+        # verify child images are still diverged
+        self._pkg([1, 2, 3], "audit-linked", rv=EXIT_DIVERGED)
+        self._pkg([0], "audit-linked -a", rv=EXIT_DIVERGED)
 
-                # verify child 3 hasn't updated its metadata
-                # (it still thinks it's in sync)
-                self._pkg([3], "audit-linked --no-parent-sync")
+        # verify child 3 hasn't updated its metadata
+        # (it still thinks it's in sync)
+        self._pkg([3], "audit-linked --no-parent-sync")
 
-                # execute op
-                def output_cb(output):
-                        self.assertEqualParsable(output, **kwargs)
-                self._pkg([1, 2, 3], "{0} --parsable=0 {1}".format(op, op_args),
-                    output_cb=output_cb)
+        # execute op
+        def output_cb(output):
+            self.assertEqualParsable(output, **kwargs)
 
-                # verify sync via audit and sync (which should be a noop)
-                self._pkg([1, 2, 3], "audit-linked")
-                self._pkg([1, 2, 3], "sync-linked -v", rv=EXIT_NOP)
-                self._pkg([0], "audit-linked -a")
-                self._pkg([0], "sync-linked -a", rv=EXIT_NOP)
+        self._pkg(
+            [1, 2, 3],
+            "{0} --parsable=0 {1}".format(op, op_args),
+            output_cb=output_cb,
+        )
 
-        def __test_linked_sync_via_parent_op(self, op, op_args,
-            li_md_change=True, **kwargs):
-                """Verify that if we do a operation "op" on a parent image, it
-                recurses into its children and brings them into sync.
+        # verify sync via audit and sync (which should be a noop)
+        self._pkg([1, 2, 3], "audit-linked")
+        self._pkg([1, 2, 3], "sync-linked -v", rv=EXIT_NOP)
+        self._pkg([0], "audit-linked -a")
+        self._pkg([0], "sync-linked -a", rv=EXIT_NOP)
 
-                We perform operation on two child images.  both are push
-                children.  1 has its linked image metadata in sync with the
-                parent.  2 has its linked image metadata out of in sync with
-                the parent and that metadata should get updated during the
-                operation.
+    def __test_linked_sync_via_parent_op(
+        self, op, op_args, li_md_change=True, **kwargs
+    ):
+        """Verify that if we do a operation "op" on a parent image, it
+        recurses into its children and brings them into sync.
 
-                Note that if the metadata in a child image is in sync with its
-                parent, a recursive operation that isn't changing that
-                metadata will assume that the child is already in sync and
-                that we don't need to recurse into it.  This optimization
-                occurs regardless of if the child image is actually in sync
-                with that metadata (a child can be out of sync with its
-                stored metadata if we do a metadata only update)."""
+        We perform operation on two child images.  both are push
+        children.  1 has its linked image metadata in sync with the
+        parent.  2 has its linked image metadata out of in sync with
+        the parent and that metadata should get updated during the
+        operation.
 
-                # create parent (0), push child (1, 2)
-                self._imgs_create(3)
-                self._attach_child(0, [1, 2])
+        Note that if the metadata in a child image is in sync with its
+        parent, a recursive operation that isn't changing that
+        metadata will assume that the child is already in sync and
+        that we don't need to recurse into it.  This optimization
+        occurs regardless of if the child image is actually in sync
+        with that metadata (a child can be out of sync with its
+        stored metadata if we do a metadata only update)."""
 
-                # install synced package into each image
-                self._pkg([0, 1, 2], "install -v {0}".format(self.p_sync1_name[2]))
+        # create parent (0), push child (1, 2)
+        self._imgs_create(3)
+        self._attach_child(0, [1, 2])
 
-                # install unsynced packages
-                self._pkg([0], "install -v {0}".format(self.p_foo1_name[1]))
-                self._pkg([1, 2], "install -v {0}".format(self.p_foo1_name[2]))
+        # install synced package into each image
+        self._pkg([0, 1, 2], "install -v {0}".format(self.p_sync1_name[2]))
 
-                # update the parent image while ignoring the children (there
-                # by putting them out of sync)
-                self._pkg([0], "install -I -v {0}".format(self.p_sync1_name[1]))
+        # install unsynced packages
+        self._pkg([0], "install -v {0}".format(self.p_foo1_name[1]))
+        self._pkg([1, 2], "install -v {0}".format(self.p_foo1_name[2]))
 
-                # explicitly sync metadata in child 1
-                self._pkg([0], "sync-linked --linked-md-only -l {0}".format(
-                    self.i_name[1]))
+        # update the parent image while ignoring the children (there
+        # by putting them out of sync)
+        self._pkg([0], "install -I -v {0}".format(self.p_sync1_name[1]))
 
-                # plan op
-                self._pkg([0], "{0} -nv {1}".format(op, op_args))
+        # explicitly sync metadata in child 1
+        self._pkg(
+            [0], "sync-linked --linked-md-only -l {0}".format(self.i_name[1])
+        )
 
-                # verify child images are still diverged
-                self._pkg([1], "audit-linked", rv=EXIT_DIVERGED)
-                self._pkg([0], "audit-linked -a", rv=EXIT_DIVERGED)
+        # plan op
+        self._pkg([0], "{0} -nv {1}".format(op, op_args))
 
-                # verify child 2 hasn't updated its metadata
-                # (it still thinks it's in sync)
-                self._pkg([2], "audit-linked")
+        # verify child images are still diverged
+        self._pkg([1], "audit-linked", rv=EXIT_DIVERGED)
+        self._pkg([0], "audit-linked -a", rv=EXIT_DIVERGED)
 
-                # execute op
-                def output_cb(output):
-                        self.assertEqualParsable(output, **kwargs)
-                self._pkg([0], "{0} --parsable=0 {1}".format(op, op_args),
-                    output_cb=output_cb)
+        # verify child 2 hasn't updated its metadata
+        # (it still thinks it's in sync)
+        self._pkg([2], "audit-linked")
 
-                # verify sync via audit and sync (which should be a noop)
-                # if the linked image metadata was changed during this
-                # operation we should have updated both children.  if linked
-                # image metadata was not changed, we'll only have updated one
-                # child.
-                if li_md_change:
-                        synced_children=[1, 2]
-                else:
-                        synced_children=[2]
-                for i in synced_children:
-                        self._pkg([i], "audit-linked")
-                        self._pkg([i], "sync-linked", rv=EXIT_NOP)
-                        self._pkg([0], "audit-linked -l {0}".format(self.i_name[i]))
-                        self._pkg([0], "sync-linked -l {0}".format(self.i_name[i]),
-                            rv=EXIT_NOP)
+        # execute op
+        def output_cb(output):
+            self.assertEqualParsable(output, **kwargs)
 
-        def test_linked_sync_via_update(self):
-                """Verify that if we update child images to be in sync with
-                their constraints when we do an update."""
+        self._pkg(
+            [0], "{0} --parsable=0 {1}".format(op, op_args), output_cb=output_cb
+        )
 
-                self.__test_linked_sync_via_child_op(
-                    "update", "",
-                    change_packages=[
+        # verify sync via audit and sync (which should be a noop)
+        # if the linked image metadata was changed during this
+        # operation we should have updated both children.  if linked
+        # image metadata was not changed, we'll only have updated one
+        # child.
+        if li_md_change:
+            synced_children = [1, 2]
+        else:
+            synced_children = [2]
+        for i in synced_children:
+            self._pkg([i], "audit-linked")
+            self._pkg([i], "sync-linked", rv=EXIT_NOP)
+            self._pkg([0], "audit-linked -l {0}".format(self.i_name[i]))
+            self._pkg(
+                [0], "sync-linked -l {0}".format(self.i_name[i]), rv=EXIT_NOP
+            )
+
+    def test_linked_sync_via_update(self):
+        """Verify that if we update child images to be in sync with
+        their constraints when we do an update."""
+
+        self.__test_linked_sync_via_child_op(
+            "update",
+            "",
+            change_packages=[
+                [self.foo1_list[2], self.foo1_list[0]],
+                [self.s1_list[2], self.s1_list[1]],
+            ],
+        )
+
+        self.__test_linked_sync_via_parent_op(
+            "update",
+            "",
+            change_packages=[
+                [self.foo1_list[1], self.foo1_list[0]],
+                [self.s1_list[1], self.s1_list[0]],
+            ],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.s1_list[2], self.s1_list[0]]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[0]]],
+                },
+            ],
+        )
+
+        # explicit recursion into all children
+        self.__test_linked_sync_via_parent_op(
+            "update -r",
+            "",
+            change_packages=[
+                [self.foo1_list[1], self.foo1_list[0]],
+                [self.s1_list[1], self.s1_list[0]],
+            ],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [
                         [self.foo1_list[2], self.foo1_list[0]],
-                        [self.s1_list[2], self.s1_list[1]]])
+                        [self.s1_list[2], self.s1_list[0]],
+                    ],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [
+                        [self.foo1_list[2], self.foo1_list[0]],
+                        [self.s1_list[2], self.s1_list[0]],
+                    ],
+                },
+            ],
+        )
 
-                self.__test_linked_sync_via_parent_op(
-                    "update", "",
-                    change_packages=[
-                        [self.foo1_list[1], self.foo1_list[0]],
-                        [self.s1_list[1], self.s1_list[0]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[0]]],
-                        },{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[0]]],
-                    }])
+    def test_linked_sync_via_update_pkg(self):
+        """Verify that if we update child images to be in sync with
+        their constraints when we do an update of a specific
+        package."""
 
-                # explicit recursion into all children
-                self.__test_linked_sync_via_parent_op(
-                    "update -r", "",
-                    change_packages=[
-                        [self.foo1_list[1], self.foo1_list[0]],
-                        [self.s1_list[1], self.s1_list[0]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [
-                            [self.foo1_list[2], self.foo1_list[0]],
-                            [self.s1_list[2], self.s1_list[0]]],
-                        },{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.foo1_list[2], self.foo1_list[0]],
-                            [self.s1_list[2], self.s1_list[0]]],
-                    }])
+        self.__test_linked_sync_via_child_op(
+            "update",
+            self.p_foo1_name[3],
+            change_packages=[
+                [self.foo1_list[2], self.foo1_list[3]],
+                [self.s1_list[2], self.s1_list[1]],
+            ],
+        )
 
-        def test_linked_sync_via_update_pkg(self):
-                """Verify that if we update child images to be in sync with
-                their constraints when we do an update of a specific
-                package."""
+        self.__test_linked_sync_via_parent_op(
+            "update",
+            self.p_foo1_name[3],
+            change_packages=[[self.foo1_list[1], self.foo1_list[3]]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+            ],
+        )
 
-                self.__test_linked_sync_via_child_op(
-                    "update", self.p_foo1_name[3],
-                    change_packages=[
+        # explicit recursion into all children
+        self.__test_linked_sync_via_parent_op(
+            "update -r",
+            self.p_foo1_name[3],
+            change_packages=[[self.foo1_list[1], self.foo1_list[3]]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [
                         [self.foo1_list[2], self.foo1_list[3]],
-                        [self.s1_list[2], self.s1_list[1]]])
-
-                self.__test_linked_sync_via_parent_op(
-                    "update", self.p_foo1_name[3],
-                    change_packages=[
-                        [self.foo1_list[1], self.foo1_list[3]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                        },{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                    }])
-
-                # explicit recursion into all children
-                self.__test_linked_sync_via_parent_op(
-                    "update -r", self.p_foo1_name[3],
-                    change_packages=[
-                        [self.foo1_list[1], self.foo1_list[3]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [
-                            [self.foo1_list[2], self.foo1_list[3]],
-                            [self.s1_list[2], self.s1_list[1]]],
-                        },{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.foo1_list[2], self.foo1_list[3]],
-                            [self.s1_list[2], self.s1_list[1]]],
-                    }])
-
-        def test_linked_sync_via_install(self):
-                """Verify that if we update child images to be in sync with
-                their constraints when we do an install."""
-
-                self.__test_linked_sync_via_child_op(
-                    "install", self.p_foo1_name[1],
-                    change_packages=[
-                        [self.foo1_list[2], self.foo1_list[1]],
-                        [self.s1_list[2], self.s1_list[1]]])
-
-                self.__test_linked_sync_via_parent_op(
-                    "install", self.p_foo1_name[0],
-                    change_packages=[
-                        [self.foo1_list[1], self.foo1_list[0]],
+                        [self.s1_list[2], self.s1_list[1]],
                     ],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                        },{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                    }])
-
-                # explicit recursion into all children
-                self.__test_linked_sync_via_parent_op(
-                    "install -r ", self.p_foo1_name[0],
-                    change_packages=[
-                        [self.foo1_list[1], self.foo1_list[0]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [
+                        [self.foo1_list[2], self.foo1_list[3]],
+                        [self.s1_list[2], self.s1_list[1]],
                     ],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [
-                            [self.foo1_list[2], self.foo1_list[0]],
-                            [self.s1_list[2], self.s1_list[1]]],
-                        },{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.foo1_list[2], self.foo1_list[0]],
-                            [self.s1_list[2], self.s1_list[1]]],
-                    }])
+                },
+            ],
+        )
 
-        def test_linked_sync_via_sync(self):
-                """Verify that if we update child images to be in sync with
-                their constraints when we do a sync-linked."""
+    def test_linked_sync_via_install(self):
+        """Verify that if we update child images to be in sync with
+        their constraints when we do an install."""
 
-                self.__test_linked_sync_via_child_op(
-                    "sync-linked", "",
-                    change_packages=[
-                        [self.s1_list[2], self.s1_list[1]]])
+        self.__test_linked_sync_via_child_op(
+            "install",
+            self.p_foo1_name[1],
+            change_packages=[
+                [self.foo1_list[2], self.foo1_list[1]],
+                [self.s1_list[2], self.s1_list[1]],
+            ],
+        )
 
-                self.__test_linked_sync_via_parent_op(
-                    "sync-linked", "-a",
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                        },{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                    }])
+        self.__test_linked_sync_via_parent_op(
+            "install",
+            self.p_foo1_name[0],
+            change_packages=[
+                [self.foo1_list[1], self.foo1_list[0]],
+            ],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+            ],
+        )
 
-        def test_linked_sync_via_change_variant(self):
-                """Verify that if we update child images to be in sync with
-                their constraints when we do a change-variant."""
+        # explicit recursion into all children
+        self.__test_linked_sync_via_parent_op(
+            "install -r ",
+            self.p_foo1_name[0],
+            change_packages=[
+                [self.foo1_list[1], self.foo1_list[0]],
+            ],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [
+                        [self.foo1_list[2], self.foo1_list[0]],
+                        [self.s1_list[2], self.s1_list[1]],
+                    ],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [
+                        [self.foo1_list[2], self.foo1_list[0]],
+                        [self.s1_list[2], self.s1_list[1]],
+                    ],
+                },
+            ],
+        )
 
-                self.__test_linked_sync_via_child_op(
-                    "change-variant", "variant.foo=baz",
-                    change_packages=[
-                        [self.s1_list[2], self.s1_list[1]]],
-                    affect_packages=[
-                        self.foo1_list[2]],
-                    change_variants=[
-                        ['variant.foo', 'baz']])
+    def test_linked_sync_via_sync(self):
+        """Verify that if we update child images to be in sync with
+        their constraints when we do a sync-linked."""
 
-                self.__test_linked_sync_via_parent_op(
-                    "change-variant", "variant.foo=baz",
-                    li_md_change=False,
-                    affect_packages=[
-                        self.foo1_list[1], self.s1_list[1]],
-                    change_variants=[
-                        ['variant.foo', 'baz']],
-                    child_images=[{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                    }])
+        self.__test_linked_sync_via_child_op(
+            "sync-linked",
+            "",
+            change_packages=[[self.s1_list[2], self.s1_list[1]]],
+        )
 
-        def test_linked_sync_via_change_facet(self):
-                """Verify that if we update child images to be in sync with
-                their constraints when we do a change-facet."""
+        self.__test_linked_sync_via_parent_op(
+            "sync-linked",
+            "-a",
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+            ],
+        )
 
-                self.__test_linked_sync_via_child_op(
-                    "change-facet", "facet.foo=True",
-                    change_packages=[
-                        [self.s1_list[2], self.s1_list[1]]],
-                    change_facets=[
-                        ['facet.foo', True, None, 'local', False, False]])
+    def test_linked_sync_via_change_variant(self):
+        """Verify that if we update child images to be in sync with
+        their constraints when we do a change-variant."""
 
-                self.__test_linked_sync_via_parent_op(
-                    "change-facet", "facet.foo=True",
-                    li_md_change=False,
-                    change_facets=[
-                        ['facet.foo', True, None, 'local', False, False]],
-                    child_images=[{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                    }])
+        self.__test_linked_sync_via_child_op(
+            "change-variant",
+            "variant.foo=baz",
+            change_packages=[[self.s1_list[2], self.s1_list[1]]],
+            affect_packages=[self.foo1_list[2]],
+            change_variants=[["variant.foo", "baz"]],
+        )
 
-        def test_linked_sync_via_uninstall(self):
-                """Verify that if we update child images to be in sync with
-                their constraints when we do an uninstall."""
+        self.__test_linked_sync_via_parent_op(
+            "change-variant",
+            "variant.foo=baz",
+            li_md_change=False,
+            affect_packages=[self.foo1_list[1], self.s1_list[1]],
+            change_variants=[["variant.foo", "baz"]],
+            child_images=[
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                }
+            ],
+        )
 
-                self.__test_linked_sync_via_child_op(
-                    "uninstall", self.p_foo1_name[2],
-                    change_packages=[
-                        [self.s1_list[2], self.s1_list[1]]],
-                    remove_packages=[
-                        self.foo1_list[2]])
+    def test_linked_sync_via_change_facet(self):
+        """Verify that if we update child images to be in sync with
+        their constraints when we do a change-facet."""
 
-                self.__test_linked_sync_via_parent_op(
-                    "uninstall", self.foo1_list[1],
-                    remove_packages=[
-                        self.foo1_list[1]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                        },{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                    }])
+        self.__test_linked_sync_via_child_op(
+            "change-facet",
+            "facet.foo=True",
+            change_packages=[[self.s1_list[2], self.s1_list[1]]],
+            change_facets=[["facet.foo", True, None, "local", False, False]],
+        )
 
-                # explicit recursion into all children
-                self.__test_linked_sync_via_parent_op(
-                    "uninstall -r", self.foo1_list[1],
-                    remove_packages=[
-                        self.foo1_list[1]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                        "remove_packages": [],
-                        },{
-                        "image_name": "system:img2",
-                        "change_packages": [
-                            [self.s1_list[2], self.s1_list[1]]],
-                    }])
+        self.__test_linked_sync_via_parent_op(
+            "change-facet",
+            "facet.foo=True",
+            li_md_change=False,
+            change_facets=[["facet.foo", True, None, "local", False, False]],
+            child_images=[
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                }
+            ],
+        )
+
+    def test_linked_sync_via_uninstall(self):
+        """Verify that if we update child images to be in sync with
+        their constraints when we do an uninstall."""
+
+        self.__test_linked_sync_via_child_op(
+            "uninstall",
+            self.p_foo1_name[2],
+            change_packages=[[self.s1_list[2], self.s1_list[1]]],
+            remove_packages=[self.foo1_list[2]],
+        )
+
+        self.__test_linked_sync_via_parent_op(
+            "uninstall",
+            self.foo1_list[1],
+            remove_packages=[self.foo1_list[1]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+            ],
+        )
+
+        # explicit recursion into all children
+        self.__test_linked_sync_via_parent_op(
+            "uninstall -r",
+            self.foo1_list[1],
+            remove_packages=[self.foo1_list[1]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                    "remove_packages": [],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+            ],
+        )
 
 
 class TestPkgLinked3(TestPkgLinked):
-        """Class used solely to split up the test suite for parallelization."""
+    """Class used solely to split up the test suite for parallelization."""
+
+    def test_parent_sync_1_nosync(self):
+        self._imgs_create(2)
+
+        # install synced package into each image
+        self._pkg([0, 1], "install -v {0}".format(self.p_sync1_name[1]))
+
+        self._attach_parent([1], 0)
+
+        # update parent image
+        self._pkg([0], "install -v {0}".format(self.p_sync1_name[0]))
+
+        # there should be no updates with --no-parent-sync
+        self._pkg([1], "sync-linked -v --no-parent-sync", rv=EXIT_NOP)
+        self._pkg(
+            [1],
+            "change-variant -v --no-parent-sync " "variant.foo=bar",
+            rv=EXIT_NOP,
+        )
+        self._pkg([1], "change-facet -v --no-parent-sync " "facet.foo=False")
+        self._pkg(
+            [1], "install -v --no-parent-sync {0}".format(self.p_foo1_name[1])
+        )
+        self._pkg([1], "update -v --no-parent-sync")
+        self._pkg(
+            [1], "uninstall -v --no-parent-sync {0}".format(self.p_foo1_name[0])
+        )
+
+        # an audit without a parent sync should thingk we're in sync
+        self._pkg([1], "audit-linked --no-parent-sync")
+
+        # an full audit should realize we're not in sync
+        self._pkg([1], "audit-linked", rv=EXIT_DIVERGED)
+
+        # the audit above should not have updated our image, so we
+        # should still be out of sync.
+        self._pkg([1], "audit-linked", rv=EXIT_DIVERGED)
+
+    def test_install_constrainted(self):
+        self._imgs_create(3)
+
+        # install synced package into parent
+        self._pkg([0], "install -v {0}".format(self.p_sync1_name[1]))
+
+        # attach children
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # try to install a different vers of synced package
+        for i in [0, 2, 3, 4]:
+            self._pkg(
+                [1, 2],
+                "install -v {0}".format(self.p_sync1_name[i]),
+                rv=EXIT_OOPS,
+            )
+
+        # try to install a different synced package
+        for i in [0, 1, 2, 3, 4]:
+            self._pkg(
+                [1, 2],
+                "install -v {0}".format(self.p_sync2_name[i]),
+                rv=EXIT_OOPS,
+            )
+
+        # install random un-synced package
+        self._pkg([1, 2], "install -v {0}".format(self.p_foo1_name[0]))
+
+        # install the same ver of a synced package in the child
+        self._pkg([1, 2], "install -v {0}".format(self.p_sync1_name[1]))
+
+    def test_install_group(self):
+        self._imgs_create(2)
+
+        # install synced package into parent
+        self._pkg([0], "install -v osnet-incorporation@0.5.11-0.175.3.19.0.1.0")
+
+        # attach children
+        self._attach_child(0, [1])
+
+        # install synced package into child
+        self._pkg([1], "install -v osnet-incorporation@0.5.11-0.175.3.19.0.1.0")
+
+        # verify group package can be installed into child even though
+        # group package and its dependencies are not installed in parent
+        self._pkg([1], "-D plan install solaris-small-server")
+
+        # verify arbitrary un-synced package can be installed into child
+        # even though group dependencies are active and cannot be
+        # satisfied
+        self._pkg([1], "-D plan install -nv {0}".format(self.p_foo1_name[0]))
+
+        # verify parent and child can have parent-constraint package
+        # updated even though child's group dependencies in
+        # solaris-small-server are active and cannot be satisfied
+        self._pkg([0], "-D plan update -nv")
+        self._pkg([0], "-D plan update -v osnet-incorporation")
+
+    def test_install_frozen(self):
+        self._imgs_create(2)
+
+        # install synced package into parent
+        self._pkg([0], "install -v osnet-incorporation@0.5.11-0.175.3.19.0.1.0")
+
+        # attach children
+        self._attach_child(0, [1])
+
+        # install synced package into child
+        self._pkg([1], "install -v osnet-incorporation@0.5.11-0.175.3.19.0.1.0")
+
+        # freeze synced package in parent
+        self._pkg([0], "freeze osnet-incorporation")
 
-        def test_parent_sync_1_nosync(self):
-                self._imgs_create(2)
-
-                # install synced package into each image
-                self._pkg([0, 1], "install -v {0}".format(self.p_sync1_name[1]))
-
-                self._attach_parent([1], 0)
-
-                # update parent image
-                self._pkg([0], "install -v {0}".format(self.p_sync1_name[0]))
-
-                # there should be no updates with --no-parent-sync
-                self._pkg([1], "sync-linked -v --no-parent-sync", rv=EXIT_NOP)
-                self._pkg([1], "change-variant -v --no-parent-sync "
-                    "variant.foo=bar", rv=EXIT_NOP)
-                self._pkg([1], "change-facet -v --no-parent-sync "
-                    "facet.foo=False")
-                self._pkg([1], "install -v --no-parent-sync {0}".format(
-                    self.p_foo1_name[1]))
-                self._pkg([1], "update -v --no-parent-sync")
-                self._pkg([1], "uninstall -v --no-parent-sync {0}".format(
-                    self.p_foo1_name[0]))
-
-                # an audit without a parent sync should thingk we're in sync
-                self._pkg([1], "audit-linked --no-parent-sync")
-
-                # an full audit should realize we're not in sync
-                self._pkg([1], "audit-linked", rv=EXIT_DIVERGED)
-
-                # the audit above should not have updated our image, so we
-                # should still be out of sync.
-                self._pkg([1], "audit-linked", rv=EXIT_DIVERGED)
-
-        def test_install_constrainted(self):
-                self._imgs_create(3)
-
-                # install synced package into parent
-                self._pkg([0], "install -v {0}".format(self.p_sync1_name[1]))
-
-                # attach children
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # try to install a different vers of synced package
-                for i in [0, 2, 3, 4]:
-                        self._pkg([1, 2], "install -v {0}".format(
-                            self.p_sync1_name[i]), rv=EXIT_OOPS)
-
-                # try to install a different synced package
-                for i in [0, 1, 2, 3, 4]:
-                        self._pkg([1, 2], "install -v {0}".format(
-                            self.p_sync2_name[i]), rv=EXIT_OOPS)
-
-                # install random un-synced package
-                self._pkg([1, 2], "install -v {0}".format(self.p_foo1_name[0]))
-
-                # install the same ver of a synced package in the child
-                self._pkg([1, 2], "install -v {0}".format(self.p_sync1_name[1]))
-
-        def test_install_group(self):
-                self._imgs_create(2)
-
-                # install synced package into parent
-                self._pkg([0], "install -v osnet-incorporation@0.5.11-0.175.3.19.0.1.0")
-
-                # attach children
-                self._attach_child(0, [1])
-
-                # install synced package into child
-                self._pkg([1], "install -v osnet-incorporation@0.5.11-0.175.3.19.0.1.0")
-
-                # verify group package can be installed into child even though
-                # group package and its dependencies are not installed in parent
-                self._pkg([1], "-D plan install solaris-small-server")
-
-                # verify arbitrary un-synced package can be installed into child
-                # even though group dependencies are active and cannot be
-                # satisfied
-                self._pkg([1], "-D plan install -nv {0}".format(self.p_foo1_name[0]))
-
-                # verify parent and child can have parent-constraint package
-                # updated even though child's group dependencies in
-                # solaris-small-server are active and cannot be satisfied
-                self._pkg([0], "-D plan update -nv")
-                self._pkg([0], "-D plan update -v osnet-incorporation")
-
-        def test_install_frozen(self):
-                self._imgs_create(2)
-
-                # install synced package into parent
-                self._pkg([0], "install -v osnet-incorporation@0.5.11-0.175.3.19.0.1.0")
-
-                # attach children
-                self._attach_child(0, [1])
-
-                # install synced package into child
-                self._pkg([1], "install -v osnet-incorporation@0.5.11-0.175.3.19.0.1.0")
-
-                # freeze synced package in parent
-                self._pkg([0], "freeze osnet-incorporation")
-
-                # verify that if synced package is frozen in parent, an update
-                # in the child will result in 'nothing to do' instead of 'no
-                # solution found' even though a newer version of synced package
-                # is available; check both with and without arguments cases
-                self._pkg([1], "-D plan update -nv", rv=EXIT_NOP)
-                self._pkg([1], "-D plan update -nv osnet-incorporation", rv=EXIT_NOP)
-
-                # verify that if synced package is frozen in parent, an attempt
-                # to update in the child to the latest version will result in
-                # graceful failure
-                self._pkg([1], "-D plan update -nv osnet-incorporation@latest",
-                    rv=EXIT_OOPS)
-
-                # verify that if synced package is frozen, arbitrary un-synced
-                # package can be installed into child
-                self._pkg([1], "-D plan install -nv {0}".format(self.p_foo1_name[0]))
-
-                # unfreeze synced package in parent
-                self._pkg([0], "unfreeze osnet-incorporation")
-
-                # verify that if synced package is unfrozen in both parent and
-                # child, an update in the child will result in 'nothing to do'
-                # since it is parent-constrained; check both with and without
-                # arguments cases
-                self._pkg([1], "-D plan update -nv", rv=EXIT_NOP)
-                self._pkg([1], "-D plan update -nv osnet-incorporation", rv=EXIT_NOP)
-
-                # freeze synced package in child
-                self._pkg([1], "freeze osnet-incorporation")
-
-                # verify that if synced package is frozen in child, an update
-                # in the parent will result in expected failure
-                self._pkg([0], "-D plan update -nv", rv=EXIT_OOPS)
-
-                # verify that if synced package is frozen in child, an update in
-                # the child will still result in 'nothing to do'
-                self._pkg([1], "-D plan update -nv", rv=EXIT_NOP)
-
-                # verify that if synced package is frozen in child, an attempt
-                # to update in the child to the latest version will result in
-                # graceful failure
-                self._pkg([1], "-D plan update -nv osnet-incorporation@latest",
-                    rv=EXIT_OOPS)
-
-                # upgrade the parent using -I to ignore the children
-                self._pkg([0],
-                    "-D plan update -I -v osnet-incorporation@latest")
-
-                # explicitly sync metadata in child 1
-                self._pkg([0], "sync-linked --linked-md-only -l {0}".format(
-                    self.i_name[1]))
-
-                # verify that an update in the child fails due to out of sync
-                # state, but can't get back into sync because of freeze; check
-                # both with and without arguments cases
-                self._pkg([1], "-D plan update -nv", rv=EXIT_OOPS)
-                self._pkg([1], "-D plan update -nv osnet-incorporation@latest",
-                    rv=EXIT_OOPS)
-
-                # unfreeze synced package in child
-                self._pkg([1], "unfreeze osnet-incorporation")
-
-                # verify that the child can be updated back to in-sync state
-                # with the parent; check both with and without arguments cases
-                self._pkg([1], "-D plan update -nv")
-                self._pkg([1], "-D plan update -nv osnet-incorporation@latest")
-
-        def test_verify(self):
-                self._imgs_create(5)
-
-                # install synced package into each image
-                self._pkg([0, 1], "install -v {0}".format(self.p_sync1_name[1]))
-
-                # test with a newer synced package
-                self._pkg([2], "install -v {0}".format(self.p_sync1_name[0]))
-
-                # test with an older synced package
-                self._pkg([3], "install -v {0}".format(self.p_sync1_name[2]))
-
-                # test with a different synced package
-                self._pkg([4], "install -v {0}".format(self.p_sync2_name[2]))
-
-                self._attach_parent([1], 0)
-                self._attach_parent([2, 3, 4], 0, args="--linked-md-only")
-
-                self._pkg([1], "verify")
-                self._pkg([2, 3, 4], "verify", rv=EXIT_OOPS)
-
-        def test_staged_noop(self):
-                self._imgs_create(1)
-
-                # test staged execution with an noop/empty plan
-                self._pkg([0], "update --stage=plan", rv=EXIT_NOP)
-                self._pkg([0], "update --stage=prepare")
-                self._pkg([0], "update --stage=execute")
-
-        def __test_missing_parent_pkgs_metadata(self,
-            install="", audit_rv=EXIT_OK):
-                """Verify that we can manipulate and update linked child
-                images which are missing their parent package metadata.  Also
-                verify that when we update those children the metadata gets
-                updated correctly."""
-
-                # create parent (0), push child (1), and pull child (2)
-                self._imgs_create(3)
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # paths for the linked image metadata files
-                md_files = [
-                        "{0}/var/pkg/linked/linked_ppkgs".format(self.i_path[i])
-                        for i in [1, 2]
-                ]
-
-                if install:
-                        for i in [0, 1, 2]:
-                                self._pkg([i], "install -v {0}".format(install))
-
-                # delete linked image metadata files
-                for f in md_files:
-                        self.file_exists(f)
-                        self._ccmd("rm {0}".format(f))
-
-                # verify that audit-linked can handle missing metadata.
-                self._pkg([0], "audit-linked -a")
-                self._pkg([2], "audit-linked")
-                self._pkg([1], "audit-linked", rv=audit_rv)
-                self._pkg([2], "audit-linked --no-parent-sync", rv=audit_rv)
-
-                # since we haven't modified the image, make sure the
-                # facet metadata files weren't re-created.
-                for f in md_files:
-                        self.file_doesnt_exist(f)
-
-                # verify that sync-linked can handle missing metadata.
-                # also verify that the operation will succeed and is
-                # not a noop (since it needs to update the metadata).
-                self._pkg([0], "sync-linked -a -n")
-                self._pkg([2], "sync-linked -n")
-
-                # since we haven't modified the image, make sure the
-                # facet metadata files weren't re-created.
-                for f in md_files:
-                        self.file_doesnt_exist(f)
-
-                # do a sync and verify that the files get created
-                self._pkg([0], "sync-linked -a")
-                self._pkg([2], "sync-linked")
-                for f in md_files:
-                        self.file_exists(f)
-
-        def test_missing_parent_pkgs_metadata_1(self):
-                """Verify that we can manipulate and update linked child
-                images which are missing their parent package metadata.  Also
-                verify that when we update those children the metadata gets
-                updated correctly.
-
-                Test when parent has no packages installed.  The children also
-                have no packages installed so they are always in sync."""
-                self.__test_missing_parent_pkgs_metadata()
-
-        def test_missing_parent_pkgs_metadata_2(self):
-                """Verify that we can manipulate and update linked child
-                images which are missing their parent package metadata.  Also
-                verify that when we update those children the metadata gets
-                updated correctly.
-
-                Test when parent and children have sync packages installed.
-                This means the children are diverged if their parent package
-                metadata is missing."""
-                self.__test_missing_parent_pkgs_metadata(
-                    install=self.p_sync1_name[0], audit_rv=EXIT_DIVERGED)
-
-        def __test_missing_parent_publisher_metadata(self,
-            clear_pubs=False):
-                """Verify that we can manipulate and update linked child
-                images which are missing their parent publisher metadata.  Also
-                verify that when we update those children the metadata gets
-                updated correctly."""
-
-                # create parent (0), push child (1), and pull child (2)
-                self._imgs_create(3)
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # paths for the linked image metadata files
-                md_files = [
-                        "{0}/var/pkg/linked/linked_ppubs".format(self.i_path[i])
-                        for i in [1, 2]
-                ]
-
-                if clear_pubs:
-                        self._pkg([0, 1, 2], "unset-publisher test")
-
-                # delete linked image metadata files
-                for f in md_files:
-                        self.file_exists(f)
-                        self._ccmd("rm {0}".format(f))
-
-                # verify that audit-linked can handle missing metadata.
-                self._pkg([0], "audit-linked -a")
-                self._pkg([1, 2], "audit-linked")
-                self._pkg([2], "audit-linked --no-parent-sync")
-
-                # since we haven't modified the image, make sure the
-                # facet metadata files weren't re-created.
-                for f in md_files:
-                        self.file_doesnt_exist(f)
-
-                # verify that sync-linked can handle missing metadata.
-                # also verify that the operation will succeed and is
-                # not a noop (since it needs to update the metadata).
-                self._pkg([0], "sync-linked -a -n")
-                self._pkg([2], "sync-linked -n")
-
-                # since we haven't modified the image, make sure the
-                # facet metadata files weren't re-created.
-                for f in md_files:
-                        self.file_doesnt_exist(f)
-
-                # do a sync and verify that the files get created
-                self._pkg([0], "sync-linked -a")
-                self._pkg([2], "sync-linked")
-                for f in md_files:
-                        self.file_exists(f)
-
-        def test_missing_parent_publisher_metadata_1(self):
-                """Verify that we can manipulate and update linked child
-                images which are missing their parent publisher metadata.  Also
-                verify that when we update those children the metadata gets
-                updated correctly.
-
-                Test when parent has no publishers configured."""
-                self.__test_missing_parent_publisher_metadata(
-                    clear_pubs=True)
-
-        def test_missing_parent_publisher_metadata_2(self):
-                """Verify that we can manipulate and update linked child
-                images which are missing their parent publisher metadata.  Also
-                verify that when we update those children the metadata gets
-                updated correctly.
-
-                Test when parent has publishers configured."""
-                self.__test_missing_parent_publisher_metadata()
+        # verify that if synced package is frozen in parent, an update
+        # in the child will result in 'nothing to do' instead of 'no
+        # solution found' even though a newer version of synced package
+        # is available; check both with and without arguments cases
+        self._pkg([1], "-D plan update -nv", rv=EXIT_NOP)
+        self._pkg([1], "-D plan update -nv osnet-incorporation", rv=EXIT_NOP)
+
+        # verify that if synced package is frozen in parent, an attempt
+        # to update in the child to the latest version will result in
+        # graceful failure
+        self._pkg(
+            [1], "-D plan update -nv osnet-incorporation@latest", rv=EXIT_OOPS
+        )
+
+        # verify that if synced package is frozen, arbitrary un-synced
+        # package can be installed into child
+        self._pkg([1], "-D plan install -nv {0}".format(self.p_foo1_name[0]))
+
+        # unfreeze synced package in parent
+        self._pkg([0], "unfreeze osnet-incorporation")
+
+        # verify that if synced package is unfrozen in both parent and
+        # child, an update in the child will result in 'nothing to do'
+        # since it is parent-constrained; check both with and without
+        # arguments cases
+        self._pkg([1], "-D plan update -nv", rv=EXIT_NOP)
+        self._pkg([1], "-D plan update -nv osnet-incorporation", rv=EXIT_NOP)
+
+        # freeze synced package in child
+        self._pkg([1], "freeze osnet-incorporation")
+
+        # verify that if synced package is frozen in child, an update
+        # in the parent will result in expected failure
+        self._pkg([0], "-D plan update -nv", rv=EXIT_OOPS)
+
+        # verify that if synced package is frozen in child, an update in
+        # the child will still result in 'nothing to do'
+        self._pkg([1], "-D plan update -nv", rv=EXIT_NOP)
+
+        # verify that if synced package is frozen in child, an attempt
+        # to update in the child to the latest version will result in
+        # graceful failure
+        self._pkg(
+            [1], "-D plan update -nv osnet-incorporation@latest", rv=EXIT_OOPS
+        )
+
+        # upgrade the parent using -I to ignore the children
+        self._pkg([0], "-D plan update -I -v osnet-incorporation@latest")
+
+        # explicitly sync metadata in child 1
+        self._pkg(
+            [0], "sync-linked --linked-md-only -l {0}".format(self.i_name[1])
+        )
+
+        # verify that an update in the child fails due to out of sync
+        # state, but can't get back into sync because of freeze; check
+        # both with and without arguments cases
+        self._pkg([1], "-D plan update -nv", rv=EXIT_OOPS)
+        self._pkg(
+            [1], "-D plan update -nv osnet-incorporation@latest", rv=EXIT_OOPS
+        )
+
+        # unfreeze synced package in child
+        self._pkg([1], "unfreeze osnet-incorporation")
+
+        # verify that the child can be updated back to in-sync state
+        # with the parent; check both with and without arguments cases
+        self._pkg([1], "-D plan update -nv")
+        self._pkg([1], "-D plan update -nv osnet-incorporation@latest")
+
+    def test_verify(self):
+        self._imgs_create(5)
+
+        # install synced package into each image
+        self._pkg([0, 1], "install -v {0}".format(self.p_sync1_name[1]))
+
+        # test with a newer synced package
+        self._pkg([2], "install -v {0}".format(self.p_sync1_name[0]))
+
+        # test with an older synced package
+        self._pkg([3], "install -v {0}".format(self.p_sync1_name[2]))
+
+        # test with a different synced package
+        self._pkg([4], "install -v {0}".format(self.p_sync2_name[2]))
+
+        self._attach_parent([1], 0)
+        self._attach_parent([2, 3, 4], 0, args="--linked-md-only")
+
+        self._pkg([1], "verify")
+        self._pkg([2, 3, 4], "verify", rv=EXIT_OOPS)
+
+    def test_staged_noop(self):
+        self._imgs_create(1)
+
+        # test staged execution with an noop/empty plan
+        self._pkg([0], "update --stage=plan", rv=EXIT_NOP)
+        self._pkg([0], "update --stage=prepare")
+        self._pkg([0], "update --stage=execute")
+
+    def __test_missing_parent_pkgs_metadata(self, install="", audit_rv=EXIT_OK):
+        """Verify that we can manipulate and update linked child
+        images which are missing their parent package metadata.  Also
+        verify that when we update those children the metadata gets
+        updated correctly."""
+
+        # create parent (0), push child (1), and pull child (2)
+        self._imgs_create(3)
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # paths for the linked image metadata files
+        md_files = [
+            "{0}/var/pkg/linked/linked_ppkgs".format(self.i_path[i])
+            for i in [1, 2]
+        ]
+
+        if install:
+            for i in [0, 1, 2]:
+                self._pkg([i], "install -v {0}".format(install))
+
+        # delete linked image metadata files
+        for f in md_files:
+            self.file_exists(f)
+            self._ccmd("rm {0}".format(f))
+
+        # verify that audit-linked can handle missing metadata.
+        self._pkg([0], "audit-linked -a")
+        self._pkg([2], "audit-linked")
+        self._pkg([1], "audit-linked", rv=audit_rv)
+        self._pkg([2], "audit-linked --no-parent-sync", rv=audit_rv)
+
+        # since we haven't modified the image, make sure the
+        # facet metadata files weren't re-created.
+        for f in md_files:
+            self.file_doesnt_exist(f)
+
+        # verify that sync-linked can handle missing metadata.
+        # also verify that the operation will succeed and is
+        # not a noop (since it needs to update the metadata).
+        self._pkg([0], "sync-linked -a -n")
+        self._pkg([2], "sync-linked -n")
+
+        # since we haven't modified the image, make sure the
+        # facet metadata files weren't re-created.
+        for f in md_files:
+            self.file_doesnt_exist(f)
+
+        # do a sync and verify that the files get created
+        self._pkg([0], "sync-linked -a")
+        self._pkg([2], "sync-linked")
+        for f in md_files:
+            self.file_exists(f)
+
+    def test_missing_parent_pkgs_metadata_1(self):
+        """Verify that we can manipulate and update linked child
+        images which are missing their parent package metadata.  Also
+        verify that when we update those children the metadata gets
+        updated correctly.
+
+        Test when parent has no packages installed.  The children also
+        have no packages installed so they are always in sync."""
+        self.__test_missing_parent_pkgs_metadata()
+
+    def test_missing_parent_pkgs_metadata_2(self):
+        """Verify that we can manipulate and update linked child
+        images which are missing their parent package metadata.  Also
+        verify that when we update those children the metadata gets
+        updated correctly.
+
+        Test when parent and children have sync packages installed.
+        This means the children are diverged if their parent package
+        metadata is missing."""
+        self.__test_missing_parent_pkgs_metadata(
+            install=self.p_sync1_name[0], audit_rv=EXIT_DIVERGED
+        )
+
+    def __test_missing_parent_publisher_metadata(self, clear_pubs=False):
+        """Verify that we can manipulate and update linked child
+        images which are missing their parent publisher metadata.  Also
+        verify that when we update those children the metadata gets
+        updated correctly."""
+
+        # create parent (0), push child (1), and pull child (2)
+        self._imgs_create(3)
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # paths for the linked image metadata files
+        md_files = [
+            "{0}/var/pkg/linked/linked_ppubs".format(self.i_path[i])
+            for i in [1, 2]
+        ]
+
+        if clear_pubs:
+            self._pkg([0, 1, 2], "unset-publisher test")
+
+        # delete linked image metadata files
+        for f in md_files:
+            self.file_exists(f)
+            self._ccmd("rm {0}".format(f))
+
+        # verify that audit-linked can handle missing metadata.
+        self._pkg([0], "audit-linked -a")
+        self._pkg([1, 2], "audit-linked")
+        self._pkg([2], "audit-linked --no-parent-sync")
+
+        # since we haven't modified the image, make sure the
+        # facet metadata files weren't re-created.
+        for f in md_files:
+            self.file_doesnt_exist(f)
+
+        # verify that sync-linked can handle missing metadata.
+        # also verify that the operation will succeed and is
+        # not a noop (since it needs to update the metadata).
+        self._pkg([0], "sync-linked -a -n")
+        self._pkg([2], "sync-linked -n")
+
+        # since we haven't modified the image, make sure the
+        # facet metadata files weren't re-created.
+        for f in md_files:
+            self.file_doesnt_exist(f)
+
+        # do a sync and verify that the files get created
+        self._pkg([0], "sync-linked -a")
+        self._pkg([2], "sync-linked")
+        for f in md_files:
+            self.file_exists(f)
+
+    def test_missing_parent_publisher_metadata_1(self):
+        """Verify that we can manipulate and update linked child
+        images which are missing their parent publisher metadata.  Also
+        verify that when we update those children the metadata gets
+        updated correctly.
+
+        Test when parent has no publishers configured."""
+        self.__test_missing_parent_publisher_metadata(clear_pubs=True)
+
+    def test_missing_parent_publisher_metadata_2(self):
+        """Verify that we can manipulate and update linked child
+        images which are missing their parent publisher metadata.  Also
+        verify that when we update those children the metadata gets
+        updated correctly.
+
+        Test when parent has publishers configured."""
+        self.__test_missing_parent_publisher_metadata()
 
 
 class TestPkgLinkedRecurse(TestPkgLinked):
-        """Test explicitly requested recursion"""
-
-        def _recursive_pkg(self, op, args, **kwargs):
-                """Run recursive pkg operation, compare results."""
-
-                def output_cb(output):
-                        self.assertEqualParsable(output, **kwargs)
-                self._pkg([0], "{0} -r --parsable=0 {1}".format(op, args),
-                    output_cb=output_cb)
-
-        def test_recursive_install(self):
-                """Test recursive pkg install"""
-
-                # create parent (0), push child (1, 2)
-                self._imgs_create(3)
-                self._attach_child(0, [1, 2])
-
-                self._recursive_pkg("install", self.foo1_list[0],
-                    add_packages=[self.foo1_list[0]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "add_packages": [self.foo1_list[0]]
-                    },{
-                        "image_name": "system:img2",
-                        "add_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-                # remove pkgs from children, leave parent alone, try again
-                self._pkg([1,2], "uninstall {0}".format(self.foo1_list[0]))
-
-                self._recursive_pkg("install", self.foo1_list[0],
-                    add_packages=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "add_packages": [self.foo1_list[0]]
-                    },{
-                        "image_name": "system:img2",
-                        "add_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-                # remove pkgs from parent, leave children alone, try again
-                self._pkg([0], "uninstall {0}".format(self.foo1_list[0]))
-
-                self._recursive_pkg("install", self.foo1_list[0],
-                    add_packages=[self.foo1_list[0]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "add_packages": []
-                    },{
-                        "image_name": "system:img2",
-                        "add_packages": []
-                    }
-                ])
-
-        def test_recursive_uninstall(self):
-                """Test recursive uninstall"""
-
-                # create parent (0), push child (1)
-                self._imgs_create(2)
-                self._attach_child(0, [1])
-
-                # install some packages to remove
-                self._pkg([0, 1], "install {0}".format(self.foo1_list[0]))
-
-                # uninstall package which is present in parent and child
-                self._recursive_pkg("uninstall", self.foo1_list[0],
-                    remove_packages=[self.foo1_list[0]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "remove_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-                # install pkg back into child, leave parent alone, try again
-                self._pkg([1], "install {0}".format(self.foo1_list[0]))
-                self._recursive_pkg("uninstall", self.foo1_list[0],
-                    remove_packages=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "remove_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-                # install pkg back into parent, leave child alone, try again
-                self._pkg([0], "install {0}".format(self.foo1_list[0]))
-                self._recursive_pkg("uninstall", self.foo1_list[0],
-                    remove_packages=[self.foo1_list[0]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "remove_packages": []
-                    }
-                ])
-
-        def test_recursive_update(self):
-                """Test recursive update"""
-
-                # create parent (0), push child (1)
-                self._imgs_create(2)
-                self._attach_child(0, [1])
-
-                # install some packages to update
-                self._pkg([0, 1], "install {0}".format(self.foo1_list[0]))
-
-                # update package which is present in parent and child
-                self._recursive_pkg("update", self.foo1_list[3],
-                    change_packages=[[self.foo1_list[0], self.foo1_list[3]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [[
-                            self.foo1_list[0],
-                            self.foo1_list[3]
-                        ]]
-                    }
-                ])
-
-                # downgrade child, leave parent alone, try again
-                self._pkg([1], "update {0}".format(self.foo1_list[0]))
-                self._recursive_pkg("update", self.foo1_list[3],
-                    change_packages=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [[
-                            self.foo1_list[0],
-                            self.foo1_list[3]
-                        ]]
-                    }
-                ])
-
-                # downgrade parent, leave child alone, try again
-                self._pkg([0], "update {0}".format(self.foo1_list[0]))
-                self._recursive_pkg("update", self.foo1_list[3],
-                    change_packages=[[self.foo1_list[0], self.foo1_list[3]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": []
-                    }
-                ])
-
-        def test_recursive_variant(self):
-                """Test recursive change-variant"""
-
-                # create parent (0), push child (1)
-                self._imgs_create(2)
-                self._attach_child(0, [1])
-
-                # install some packages
-                self._pkg([0, 1], "install {0}".format(self.foo1_list[0]))
-
-                # change variant in parent and child
-                self._recursive_pkg("change-variant", "variant.foo=baz",
-                    change_variants=[["variant.foo", "baz"]],
-                    affect_packages=[self.foo1_list[0]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_variants": [["variant.foo", "baz"]],
-                        "affect_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-                # revert variant in child, leave parent alone, try again
-                self._pkg([1], "change-variant -v variant.foo=bar")
-                self._recursive_pkg("change-variant", "variant.foo=baz",
-                    change_variants=[],
-                    affect_packages=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_variants": [["variant.foo", "baz"]],
-                        "affect_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-                # revert variant in parent, leave child alone, try again
-                self._pkg([0], "change-variant -v variant.foo=bar")
-
-                self._pkg([0], "audit-linked -a")
-                self._recursive_pkg("change-variant", "variant.foo=baz",
-                    change_variants=[["variant.foo", "baz"]],
-                    affect_packages=[self.foo1_list[0]],
-                )
-
-        def test_recursive_facet(self):
-                """Test recursive change-facet"""
-
-                # create parent (0), push child (1)
-                self._imgs_create(2)
-                self._attach_child(0, [1])
-
-                # set facet in parent and child
-                self._recursive_pkg("change-facet", "facet.foo=True",
-                    change_facets=[["facet.foo", True, None, "local", False,
-                        False]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_facets": [["facet.foo", True, None, "local",
-                            False, False]],
-                    }
-                ])
-
-                # change facet in child, leave parent alone, try again
-                self._pkg([1], "change-facet -v facet.foo=False")
-                self._recursive_pkg("change-facet", "facet.foo=True",
-                    change_facets=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_facets": [["facet.foo", True, False, "local",
-                            False, False]],
-                    }
-                ])
-
-                # remove facet in child, leave parent alone, try again
-                self._pkg([1], "change-facet -v facet.foo=None")
-                self._recursive_pkg("change-facet", "facet.foo=True",
-                    change_facets=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_facets": [["facet.foo", True, None, "local",
-                            False, False]],
-                    }
-                ])
-
-                # change facet in parent, leave child alone, try again
-                self._pkg([0], "change-facet -v facet.foo=False")
-                self._recursive_pkg("change-facet", "facet.foo=True",
-                    change_facets=[["facet.foo", True, False, "local",
-                        False, False]],
-                )
-
-                # remove facet in parent, leave child alone, try again
-                self._pkg([0], "change-facet -v facet.foo=None")
-                self._recursive_pkg("change-facet", "facet.foo=True",
-                    change_facets=[["facet.foo", True, None, "local",
-                        False, False]],
-                )
-
-                # change facet in parent and child
-                self._recursive_pkg("change-facet", "facet.foo=False",
-                    change_facets=[["facet.foo", False, True, "local",
-                        False, False]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_facets": [["facet.foo", False, True, "local",
-                            False, False]],
-                    }
-                ])
-
-                # remove facet in parent and child
-                self._recursive_pkg("change-facet", "facet.foo=None",
-                    change_facets=[["facet.foo", None, False, "local",
-                            False, False]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_facets": [["facet.foo", None, False, "local",
-                            False, False]],
-                    }
-                ])
-
-        def test_image_selection(self):
-                """Test that explicit recursion into only the requested child
-                   images works as expected."""
-
-                # We already tested that all the different operations which
-                # support explicit recursion work in general so we only test
-                # with install to see if the image selection works correctly.
-
-                # create parent (0), push child (1,2,3)
-                self._imgs_create(4)
-                self._attach_child(0, [1,2,3])
-
-                # We are only interested if the correct children are selected
-                # for a certain operation so we make sure that operations on
-                # the parent are always a nop.
-                self._pkg([0], "install {0}".format(self.foo1_list[0]))
-
-                # install into all children
-                self._recursive_pkg("install", self.foo1_list[0],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "add_packages": [self.foo1_list[0]]
-                    },{
-                        "image_name": "system:img2",
-                        "add_packages": [self.foo1_list[0]]
-                    },{
-                        "image_name": "system:img3",
-                        "add_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-                # install only into img1
-                self._pkg([1,2,3], "uninstall {0}".format(self.foo1_list[0]))
-                self._recursive_pkg("install -z system:img1", self.foo1_list[0],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "add_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-                # install only into img1 and img3
-                self._pkg([1], "uninstall {0}".format(self.foo1_list[0]))
-                self._recursive_pkg("install -z system:img1 -z system:img3",
-                    self.foo1_list[0],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "add_packages": [self.foo1_list[0]]
-                    },{
-                        "image_name": "system:img3",
-                        "add_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-                # install into all but img1
-                self._pkg([1,3], "uninstall {0}".format(self.foo1_list[0]))
-                self._recursive_pkg("install -Z system:img1", self.foo1_list[0],
-                    child_images=[{
-                        "image_name": "system:img2",
-                        "add_packages": [self.foo1_list[0]]
-                    },{
-                        "image_name": "system:img3",
-                        "add_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-                # install into all but img1 and img3
-                self._pkg([2,3], "uninstall {0}".format(self.foo1_list[0]))
-                self._recursive_pkg("install -Z system:img1 -Z system:img3",
-                    self.foo1_list[0],
-                    child_images=[{
-                        "image_name": "system:img2",
-                        "add_packages": [self.foo1_list[0]]
-                    }
-                ])
-
-        def test_recursive_sync_install(self):
-                """Test that child images not specified for explicit recursion
-                   are still getting synced when installing."""
-
-                # create parent (0), push child (1,2)
-                self._imgs_create(3)
-                self._attach_child(0, [1, 2])
-
-                # install synced package into each image
-                self._pkg([0, 1, 2], "install -v {0}".format(self.p_sync1_name[2]))
-
-                # install new version of synced pkg in parent and one child
-                # explicitly, second child should get synced too
-                self._recursive_pkg("install -z system:img1",
-                    self.p_sync1_name[1],
-                    change_packages=[[self.s1_list[2], self.s1_list[1]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [[self.s1_list[2], self.s1_list[1]]]
-                    },{
-                        "image_name": "system:img2",
-                        "change_packages": [[self.s1_list[2], self.s1_list[1]]]
-                    }
-                ])
-
-        def test_recursive_sync_update(self):
-                """Test that child images not specified for explicit recursion
-                   are still getting synced when updating."""
-
-                # create parent (0), push child (1,2)
-                self._imgs_create(3)
-                self._attach_child(0, [1, 2])
-
-                # install synced package into each image
-                self._pkg([0, 1, 2], "install -v {0}".format(self.p_sync1_name[2]))
-
-                # install new version of synced pkg in parent and one child
-                # explicitly, second child should get synced too
-                self._recursive_pkg("update -z system:img1", "",
-                    change_packages=[[self.s1_list[2], self.s1_list[0]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [[self.s1_list[2], self.s1_list[0]]]
-                    },{
-                        "image_name": "system:img2",
-                        "change_packages": [[self.s1_list[2], self.s1_list[0]]]
-                    }
-                ])
-
-        def test_recursive_sync_update_pkg(self):
-                """Test that child images not specified for explicit recursion
-                   are still getting synced when updating a particular pkg."""
-
-                # create parent (0), push child (1,2)
-                self._imgs_create(3)
-                self._attach_child(0, [1, 2])
-
-                # install synced package into each image
-                self._pkg([0, 1, 2], "install -v {0}".format(self.p_sync1_name[2]))
-
-                # install new version of synced pkg in parent and one child
-                # explicitly, second child should get synced too
-                self._recursive_pkg("update -z system:img1",
-                    self.p_sync1_name[1],
-                    change_packages=[[self.s1_list[2], self.s1_list[1]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [[self.s1_list[2], self.s1_list[1]]]
-                    },{
-                        "image_name": "system:img2",
-                        "change_packages": [[self.s1_list[2], self.s1_list[1]]]
-                    }
-                ])
-
-        def test_recursive_uninstall_synced_pkg(self):
-                """Test that we can uninstall a synced package from all images
-                   with -r."""
-
-                # create parent (0), push child (1,2)
-                self._imgs_create(3)
-                self._attach_child(0, [1, 2])
-
-                # install synced package into each image
-                self._pkg([0, 1, 2], "install -v {0}".format(self.p_sync1_name[2]))
-
-                # uninstall synced pkg from all images
-                self._recursive_pkg("uninstall", self.p_sync1_name[2],
-                    remove_packages=[self.s1_list[2]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "remove_packages": [self.s1_list[2]]
-                    },{
-                        "image_name": "system:img2",
-                        "remove_packages": [self.s1_list[2]]
-                    }
-                ])
-
-        def test_recursive_idr_removal(self):
-                """Test if IDR handling with linked images works as intended."""
-
-                pkgs = (
-                        """
+    """Test explicitly requested recursion"""
+
+    def _recursive_pkg(self, op, args, **kwargs):
+        """Run recursive pkg operation, compare results."""
+
+        def output_cb(output):
+            self.assertEqualParsable(output, **kwargs)
+
+        self._pkg(
+            [0], "{0} -r --parsable=0 {1}".format(op, args), output_cb=output_cb
+        )
+
+    def test_recursive_install(self):
+        """Test recursive pkg install"""
+
+        # create parent (0), push child (1, 2)
+        self._imgs_create(3)
+        self._attach_child(0, [1, 2])
+
+        self._recursive_pkg(
+            "install",
+            self.foo1_list[0],
+            add_packages=[self.foo1_list[0]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "add_packages": [self.foo1_list[0]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "add_packages": [self.foo1_list[0]],
+                },
+            ],
+        )
+
+        # remove pkgs from children, leave parent alone, try again
+        self._pkg([1, 2], "uninstall {0}".format(self.foo1_list[0]))
+
+        self._recursive_pkg(
+            "install",
+            self.foo1_list[0],
+            add_packages=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "add_packages": [self.foo1_list[0]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "add_packages": [self.foo1_list[0]],
+                },
+            ],
+        )
+
+        # remove pkgs from parent, leave children alone, try again
+        self._pkg([0], "uninstall {0}".format(self.foo1_list[0]))
+
+        self._recursive_pkg(
+            "install",
+            self.foo1_list[0],
+            add_packages=[self.foo1_list[0]],
+            child_images=[
+                {"image_name": "system:img1", "add_packages": []},
+                {"image_name": "system:img2", "add_packages": []},
+            ],
+        )
+
+    def test_recursive_uninstall(self):
+        """Test recursive uninstall"""
+
+        # create parent (0), push child (1)
+        self._imgs_create(2)
+        self._attach_child(0, [1])
+
+        # install some packages to remove
+        self._pkg([0, 1], "install {0}".format(self.foo1_list[0]))
+
+        # uninstall package which is present in parent and child
+        self._recursive_pkg(
+            "uninstall",
+            self.foo1_list[0],
+            remove_packages=[self.foo1_list[0]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "remove_packages": [self.foo1_list[0]],
+                }
+            ],
+        )
+
+        # install pkg back into child, leave parent alone, try again
+        self._pkg([1], "install {0}".format(self.foo1_list[0]))
+        self._recursive_pkg(
+            "uninstall",
+            self.foo1_list[0],
+            remove_packages=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "remove_packages": [self.foo1_list[0]],
+                }
+            ],
+        )
+
+        # install pkg back into parent, leave child alone, try again
+        self._pkg([0], "install {0}".format(self.foo1_list[0]))
+        self._recursive_pkg(
+            "uninstall",
+            self.foo1_list[0],
+            remove_packages=[self.foo1_list[0]],
+            child_images=[{"image_name": "system:img1", "remove_packages": []}],
+        )
+
+    def test_recursive_update(self):
+        """Test recursive update"""
+
+        # create parent (0), push child (1)
+        self._imgs_create(2)
+        self._attach_child(0, [1])
+
+        # install some packages to update
+        self._pkg([0, 1], "install {0}".format(self.foo1_list[0]))
+
+        # update package which is present in parent and child
+        self._recursive_pkg(
+            "update",
+            self.foo1_list[3],
+            change_packages=[[self.foo1_list[0], self.foo1_list[3]]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.foo1_list[0], self.foo1_list[3]]],
+                }
+            ],
+        )
+
+        # downgrade child, leave parent alone, try again
+        self._pkg([1], "update {0}".format(self.foo1_list[0]))
+        self._recursive_pkg(
+            "update",
+            self.foo1_list[3],
+            change_packages=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.foo1_list[0], self.foo1_list[3]]],
+                }
+            ],
+        )
+
+        # downgrade parent, leave child alone, try again
+        self._pkg([0], "update {0}".format(self.foo1_list[0]))
+        self._recursive_pkg(
+            "update",
+            self.foo1_list[3],
+            change_packages=[[self.foo1_list[0], self.foo1_list[3]]],
+            child_images=[{"image_name": "system:img1", "change_packages": []}],
+        )
+
+    def test_recursive_variant(self):
+        """Test recursive change-variant"""
+
+        # create parent (0), push child (1)
+        self._imgs_create(2)
+        self._attach_child(0, [1])
+
+        # install some packages
+        self._pkg([0, 1], "install {0}".format(self.foo1_list[0]))
+
+        # change variant in parent and child
+        self._recursive_pkg(
+            "change-variant",
+            "variant.foo=baz",
+            change_variants=[["variant.foo", "baz"]],
+            affect_packages=[self.foo1_list[0]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_variants": [["variant.foo", "baz"]],
+                    "affect_packages": [self.foo1_list[0]],
+                }
+            ],
+        )
+
+        # revert variant in child, leave parent alone, try again
+        self._pkg([1], "change-variant -v variant.foo=bar")
+        self._recursive_pkg(
+            "change-variant",
+            "variant.foo=baz",
+            change_variants=[],
+            affect_packages=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_variants": [["variant.foo", "baz"]],
+                    "affect_packages": [self.foo1_list[0]],
+                }
+            ],
+        )
+
+        # revert variant in parent, leave child alone, try again
+        self._pkg([0], "change-variant -v variant.foo=bar")
+
+        self._pkg([0], "audit-linked -a")
+        self._recursive_pkg(
+            "change-variant",
+            "variant.foo=baz",
+            change_variants=[["variant.foo", "baz"]],
+            affect_packages=[self.foo1_list[0]],
+        )
+
+    def test_recursive_facet(self):
+        """Test recursive change-facet"""
+
+        # create parent (0), push child (1)
+        self._imgs_create(2)
+        self._attach_child(0, [1])
+
+        # set facet in parent and child
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=True",
+            change_facets=[["facet.foo", True, None, "local", False, False]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_facets": [
+                        ["facet.foo", True, None, "local", False, False]
+                    ],
+                }
+            ],
+        )
+
+        # change facet in child, leave parent alone, try again
+        self._pkg([1], "change-facet -v facet.foo=False")
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=True",
+            change_facets=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_facets": [
+                        ["facet.foo", True, False, "local", False, False]
+                    ],
+                }
+            ],
+        )
+
+        # remove facet in child, leave parent alone, try again
+        self._pkg([1], "change-facet -v facet.foo=None")
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=True",
+            change_facets=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_facets": [
+                        ["facet.foo", True, None, "local", False, False]
+                    ],
+                }
+            ],
+        )
+
+        # change facet in parent, leave child alone, try again
+        self._pkg([0], "change-facet -v facet.foo=False")
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=True",
+            change_facets=[["facet.foo", True, False, "local", False, False]],
+        )
+
+        # remove facet in parent, leave child alone, try again
+        self._pkg([0], "change-facet -v facet.foo=None")
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=True",
+            change_facets=[["facet.foo", True, None, "local", False, False]],
+        )
+
+        # change facet in parent and child
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=False",
+            change_facets=[["facet.foo", False, True, "local", False, False]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_facets": [
+                        ["facet.foo", False, True, "local", False, False]
+                    ],
+                }
+            ],
+        )
+
+        # remove facet in parent and child
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=None",
+            change_facets=[["facet.foo", None, False, "local", False, False]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_facets": [
+                        ["facet.foo", None, False, "local", False, False]
+                    ],
+                }
+            ],
+        )
+
+    def test_image_selection(self):
+        """Test that explicit recursion into only the requested child
+        images works as expected."""
+
+        # We already tested that all the different operations which
+        # support explicit recursion work in general so we only test
+        # with install to see if the image selection works correctly.
+
+        # create parent (0), push child (1,2,3)
+        self._imgs_create(4)
+        self._attach_child(0, [1, 2, 3])
+
+        # We are only interested if the correct children are selected
+        # for a certain operation so we make sure that operations on
+        # the parent are always a nop.
+        self._pkg([0], "install {0}".format(self.foo1_list[0]))
+
+        # install into all children
+        self._recursive_pkg(
+            "install",
+            self.foo1_list[0],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "add_packages": [self.foo1_list[0]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "add_packages": [self.foo1_list[0]],
+                },
+                {
+                    "image_name": "system:img3",
+                    "add_packages": [self.foo1_list[0]],
+                },
+            ],
+        )
+
+        # install only into img1
+        self._pkg([1, 2, 3], "uninstall {0}".format(self.foo1_list[0]))
+        self._recursive_pkg(
+            "install -z system:img1",
+            self.foo1_list[0],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "add_packages": [self.foo1_list[0]],
+                }
+            ],
+        )
+
+        # install only into img1 and img3
+        self._pkg([1], "uninstall {0}".format(self.foo1_list[0]))
+        self._recursive_pkg(
+            "install -z system:img1 -z system:img3",
+            self.foo1_list[0],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "add_packages": [self.foo1_list[0]],
+                },
+                {
+                    "image_name": "system:img3",
+                    "add_packages": [self.foo1_list[0]],
+                },
+            ],
+        )
+
+        # install into all but img1
+        self._pkg([1, 3], "uninstall {0}".format(self.foo1_list[0]))
+        self._recursive_pkg(
+            "install -Z system:img1",
+            self.foo1_list[0],
+            child_images=[
+                {
+                    "image_name": "system:img2",
+                    "add_packages": [self.foo1_list[0]],
+                },
+                {
+                    "image_name": "system:img3",
+                    "add_packages": [self.foo1_list[0]],
+                },
+            ],
+        )
+
+        # install into all but img1 and img3
+        self._pkg([2, 3], "uninstall {0}".format(self.foo1_list[0]))
+        self._recursive_pkg(
+            "install -Z system:img1 -Z system:img3",
+            self.foo1_list[0],
+            child_images=[
+                {
+                    "image_name": "system:img2",
+                    "add_packages": [self.foo1_list[0]],
+                }
+            ],
+        )
+
+    def test_recursive_sync_install(self):
+        """Test that child images not specified for explicit recursion
+        are still getting synced when installing."""
+
+        # create parent (0), push child (1,2)
+        self._imgs_create(3)
+        self._attach_child(0, [1, 2])
+
+        # install synced package into each image
+        self._pkg([0, 1, 2], "install -v {0}".format(self.p_sync1_name[2]))
+
+        # install new version of synced pkg in parent and one child
+        # explicitly, second child should get synced too
+        self._recursive_pkg(
+            "install -z system:img1",
+            self.p_sync1_name[1],
+            change_packages=[[self.s1_list[2], self.s1_list[1]]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+            ],
+        )
+
+    def test_recursive_sync_update(self):
+        """Test that child images not specified for explicit recursion
+        are still getting synced when updating."""
+
+        # create parent (0), push child (1,2)
+        self._imgs_create(3)
+        self._attach_child(0, [1, 2])
+
+        # install synced package into each image
+        self._pkg([0, 1, 2], "install -v {0}".format(self.p_sync1_name[2]))
+
+        # install new version of synced pkg in parent and one child
+        # explicitly, second child should get synced too
+        self._recursive_pkg(
+            "update -z system:img1",
+            "",
+            change_packages=[[self.s1_list[2], self.s1_list[0]]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.s1_list[2], self.s1_list[0]]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[0]]],
+                },
+            ],
+        )
+
+    def test_recursive_sync_update_pkg(self):
+        """Test that child images not specified for explicit recursion
+        are still getting synced when updating a particular pkg."""
+
+        # create parent (0), push child (1,2)
+        self._imgs_create(3)
+        self._attach_child(0, [1, 2])
+
+        # install synced package into each image
+        self._pkg([0, 1, 2], "install -v {0}".format(self.p_sync1_name[2]))
+
+        # install new version of synced pkg in parent and one child
+        # explicitly, second child should get synced too
+        self._recursive_pkg(
+            "update -z system:img1",
+            self.p_sync1_name[1],
+            change_packages=[[self.s1_list[2], self.s1_list[1]]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "change_packages": [[self.s1_list[2], self.s1_list[1]]],
+                },
+            ],
+        )
+
+    def test_recursive_uninstall_synced_pkg(self):
+        """Test that we can uninstall a synced package from all images
+        with -r."""
+
+        # create parent (0), push child (1,2)
+        self._imgs_create(3)
+        self._attach_child(0, [1, 2])
+
+        # install synced package into each image
+        self._pkg([0, 1, 2], "install -v {0}".format(self.p_sync1_name[2]))
+
+        # uninstall synced pkg from all images
+        self._recursive_pkg(
+            "uninstall",
+            self.p_sync1_name[2],
+            remove_packages=[self.s1_list[2]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "remove_packages": [self.s1_list[2]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "remove_packages": [self.s1_list[2]],
+                },
+            ],
+        )
+
+    def test_recursive_idr_removal(self):
+        """Test if IDR handling with linked images works as intended."""
+
+        pkgs = (
+            """
                             open kernel@1.0,5.11-0.1
                             add depend type=require fmri=pkg:/incorp
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open kernel@1.0,5.11-0.2
                             add depend type=require fmri=pkg:/incorp
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open network@1.0,5.11-0.1
                             add depend type=require fmri=pkg:/incorp
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open network@1.0,5.11-0.2
                             add depend type=require fmri=pkg:/incorp
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open incorp@1.0,5.11-0.1
                             add depend type=incorporate fmri=kernel@1.0,5.11-0.1
                             add depend type=incorporate fmri=network@1.0,5.11-0.1
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                         """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open incorp@1.0,5.11-0.2
                             add depend type=incorporate fmri=kernel@1.0,5.11-0.2
                             add depend type=incorporate fmri=network@1.0,5.11-0.2
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open kernel@1.0,5.11-0.1.1.0
                             add depend type=require fmri=pkg:/incorp
                             add depend type=require fmri=pkg:/idr1
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open kernel@1.0,5.11-0.1.1.1
                             add depend type=require fmri=pkg:/incorp
                             add depend type=require fmri=pkg:/idr1
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open kernel@1.0,5.11-0.1.2.0
                             add depend type=require fmri=pkg:/incorp
                             add depend type=require fmri=pkg:/idr2
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open network@1.0,5.11-0.1.1.0
                             add depend type=require fmri=pkg:/incorp
                             add depend type=require fmri=pkg:/idr1
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open network@1.0,5.11-0.1.1.1
                             add depend type=require fmri=pkg:/incorp
                             add depend type=require fmri=pkg:/idr1
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open network@1.0,5.11-0.1.2.0
                             add depend type=require fmri=pkg:/incorp
                             add depend type=require fmri=pkg:/idr2
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open idr1@1.0,5.11-0.1.1.0
                             add depend type=incorporate fmri=kernel@1.0,5.11-0.1.1.0
                             add depend type=incorporate fmri=network@1.0,5.11-0.1.1.0
                             add depend type=require fmri=idr1_entitlement
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open idr1@1.0,5.11-0.1.1.1
                             add depend type=incorporate fmri=kernel@1.0,5.11-0.1.1.1
                             add depend type=incorporate fmri=network@1.0,5.11-0.1.1.1
                             add depend type=require fmri=idr1_entitlement
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open idr2@1.0,5.11-0.1.2.0
                             add depend type=incorporate fmri=kernel@1.0,5.11-0.1.2.0
                             add depend type=incorporate fmri=network@1.0,5.11-0.1.2.0
                             add depend type=require fmri=idr2_entitlement
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open idr1_entitlement@1.0,5.11-0
                             add depend type=exclude fmri=no-idrs
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            """
                             open idr2_entitlement@1.0,5.11-0
                             add depend type=exclude fmri=no-idrs
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-
-                        # hack to prevent idrs from being installed from repo...
-
-                        """
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+            # hack to prevent idrs from being installed from repo...
+            """
                             open no-idrs@1.0,5.11-0
                             add depend type=parent fmri={0}
-                            close """.format(pkg.actions.depend.DEPEND_SELF),
-                )
+                            close """.format(
+                pkg.actions.depend.DEPEND_SELF
+            ),
+        )
 
-                # publish additional idr packages
-                self.pkgsend_bulk(self.rurl1, pkgs)
+        # publish additional idr packages
+        self.pkgsend_bulk(self.rurl1, pkgs)
 
-                # create parent (0), push child (1,2)
-                self._imgs_create(3)
-                self._attach_child(0, [1, 2])
+        # create parent (0), push child (1,2)
+        self._imgs_create(3)
+        self._attach_child(0, [1, 2])
 
-                # install kernel pkg; remember version so we can reinstall it
-                # later
-                self._pkg([0, 1, 2], "install -v no-idrs")
-                # install kernel package into all images
-                self._pkg([0, 1 ,2], "install -v kernel@1.0,5.11-0.1")
-                self._pkg([0], "list -Hv kernel@1.0,5.11-0.1 | "
-                    "/usr/bin/awk '{print $1}'")
-                kernel_fmri = self.output.strip()
-                # install network package only in parent and one child
-                self._pkg([0, 1], "install -v network@1.0,5.11-0.1")
-                self._pkg([0], "list -Hv network@1.0,5.11-0.1 | "
-                    "/usr/bin/awk '{print $1}'")
-                network_fmri = self.output.strip()
-                self._pkg([2], "list network", rv=EXIT_OOPS)
+        # install kernel pkg; remember version so we can reinstall it
+        # later
+        self._pkg([0, 1, 2], "install -v no-idrs")
+        # install kernel package into all images
+        self._pkg([0, 1, 2], "install -v kernel@1.0,5.11-0.1")
+        self._pkg(
+            [0], "list -Hv kernel@1.0,5.11-0.1 | " "/usr/bin/awk '{print $1}'"
+        )
+        kernel_fmri = self.output.strip()
+        # install network package only in parent and one child
+        self._pkg([0, 1], "install -v network@1.0,5.11-0.1")
+        self._pkg(
+            [0], "list -Hv network@1.0,5.11-0.1 | " "/usr/bin/awk '{print $1}'"
+        )
+        network_fmri = self.output.strip()
+        self._pkg([2], "list network", rv=EXIT_OOPS)
 
-                # upgrade to next version w/o encountering idrs, children should
-                # be updated automatically.
-                self._pkg([0], "update -v");
-                self._pkg([0, 1, 2], "list kernel@1.0,5.11-0.2")
-                self._pkg([0, 1], "list network@1.0,5.11-0.2")
-                self._pkg([2], "list network", rv=EXIT_OOPS)
+        # upgrade to next version w/o encountering idrs, children should
+        # be updated automatically.
+        self._pkg([0], "update -v")
+        self._pkg([0, 1, 2], "list kernel@1.0,5.11-0.2")
+        self._pkg([0, 1], "list network@1.0,5.11-0.2")
+        self._pkg([2], "list network", rv=EXIT_OOPS)
 
-                # try installing idr1; testing wild card support and -z as well
-                self._pkg([0], "uninstall -r no-idrs")
-                self._pkg([0], "install -r "
-                    "--reject 'k*' --reject 'i*' --reject network no-idrs")
-                self._pkg([0], "install -r -v kernel@1.0,5.11-0.1")
-                self._pkg([0], "install -v -r -z system:img1 "
-                    "network@1.0,5.11-0.1")
+        # try installing idr1; testing wild card support and -z as well
+        self._pkg([0], "uninstall -r no-idrs")
+        self._pkg(
+            [0],
+            "install -r "
+            "--reject 'k*' --reject 'i*' --reject network no-idrs",
+        )
+        self._pkg([0], "install -r -v kernel@1.0,5.11-0.1")
+        self._pkg([0], "install -v -r -z system:img1 " "network@1.0,5.11-0.1")
 
-                self._pkg([0], "install -r -v --reject no-idrs "
-                    "idr1_entitlement")
-                self._pkg([0], "install -r -v idr1@1.0,5.11-0.1.1.0")
-                self._pkg([0], "update -r -v --reject idr2")
-                self._pkg([0, 1, 2], "list idr1@1.0,5.11-0.1.1.1")
+        self._pkg([0], "install -r -v --reject no-idrs " "idr1_entitlement")
+        self._pkg([0], "install -r -v idr1@1.0,5.11-0.1.1.0")
+        self._pkg([0], "update -r -v --reject idr2")
+        self._pkg([0, 1, 2], "list idr1@1.0,5.11-0.1.1.1")
 
-                # switch to idr2, which affects same package
-                self._pkg([0], "install -r -v --reject idr1 --reject 'idr1_*' "
-                    "idr2 idr2_entitlement")
+        # switch to idr2, which affects same package
+        self._pkg(
+            [0],
+            "install -r -v --reject idr1 --reject 'idr1_*' "
+            "idr2 idr2_entitlement",
+        )
 
-                # switch back to base version of kernel and network
-                self._pkg([0], "update -v -r "
-                    "--reject idr2 --reject 'idr2_*' {0} {1}".format(kernel_fmri,
-                    network_fmri))
+        # switch back to base version of kernel and network
+        self._pkg(
+            [0],
+            "update -v -r "
+            "--reject idr2 --reject 'idr2_*' {0} {1}".format(
+                kernel_fmri, network_fmri
+            ),
+        )
 
-                # reinstall idr1, then update to version 2 of base kernel
-                self._pkg([0], "install -r -v "
-                    "idr1@1.0,5.11-0.1.1.0 idr1_entitlement")
-                self._pkg([0, 1, 2], "list kernel@1.0,5.11-0.1.1.0")
-                self._pkg([0, 1], "list network@1.0,5.11-0.1.1.0")
-                self._pkg([2], "list network", rv=EXIT_OOPS)
+        # reinstall idr1, then update to version 2 of base kernel
+        self._pkg(
+            [0], "install -r -v " "idr1@1.0,5.11-0.1.1.0 idr1_entitlement"
+        )
+        self._pkg([0, 1, 2], "list kernel@1.0,5.11-0.1.1.0")
+        self._pkg([0, 1], "list network@1.0,5.11-0.1.1.0")
+        self._pkg([2], "list network", rv=EXIT_OOPS)
 
-                # Wildcards are purposefully used here for both patterns to
-                # ensure pattern matching works as expected for update.
-                self._pkg([0], "update -r -v "
-                    "--reject 'idr1*' '*incorp@1.0-0.2'")
-                self._pkg([0, 1, 2], "list kernel@1.0,5.11-0.2")
-                self._pkg([0, 1], "list network@1.0,5.11-0.2")
-                self._pkg([2], "list network", rv=EXIT_OOPS)
+        # Wildcards are purposefully used here for both patterns to
+        # ensure pattern matching works as expected for update.
+        self._pkg([0], "update -r -v " "--reject 'idr1*' '*incorp@1.0-0.2'")
+        self._pkg([0, 1, 2], "list kernel@1.0,5.11-0.2")
+        self._pkg([0, 1], "list network@1.0,5.11-0.2")
+        self._pkg([2], "list network", rv=EXIT_OOPS)
 
 
 class TestPkgLinkedPropertyRecurse(TestPkgLinked):
-        """Test default recursion via the 'default-recurse' image property
-           This also implicitly tests the -R option"""
+    """Test default recursion via the 'default-recurse' image property
+    This also implicitly tests the -R option"""
 
-        def _recursive_pkg(self, op, args, **kwargs):
-                """Run recursive pkg operation, compare results."""
+    def _recursive_pkg(self, op, args, **kwargs):
+        """Run recursive pkg operation, compare results."""
 
-                def output_cb(output):
-                        self.assertEqualParsable(output, **kwargs)
-                self._pkg([0], "{0} --parsable=0 {1}".format(op, args),
-                    output_cb=output_cb)
+        def output_cb(output):
+            self.assertEqualParsable(output, **kwargs)
 
-        def test_recursive_install(self):
-                """Test pkg install
-                   Even with the property set, this should not recurse"""
+        self._pkg(
+            [0], "{0} --parsable=0 {1}".format(op, args), output_cb=output_cb
+        )
 
-                # create parent (0), push child (1, 2)
-                self._imgs_create(3)
-                self._attach_child(0, [1, 2])
+    def test_recursive_install(self):
+        """Test pkg install
+        Even with the property set, this should not recurse"""
 
-                self._pkg([0], "set-property default-recurse True")
+        # create parent (0), push child (1, 2)
+        self._imgs_create(3)
+        self._attach_child(0, [1, 2])
 
-                # Install - expect changes only in the parent. Install is not
-                # recursive by default even in the presence of the
-                # default-recurse property
-                self._recursive_pkg("install", self.foo1_list[0],
-                    add_packages=[self.foo1_list[0]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "add_packages": []
-                    },{
-                        "image_name": "system:img2",
-                        "add_packages": []
-                    }
-                ])
+        self._pkg([0], "set-property default-recurse True")
 
-                # Install recursively, it's already in the parent so expect
-                # changes in the children only.
-                self._recursive_pkg("install -r", self.foo1_list[0],
-                    add_packages=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "add_packages": [self.foo1_list[0]]
-                    },{
-                        "image_name": "system:img2",
-                        "add_packages": [self.foo1_list[0]]
-                    }
-                ])
+        # Install - expect changes only in the parent. Install is not
+        # recursive by default even in the presence of the
+        # default-recurse property
+        self._recursive_pkg(
+            "install",
+            self.foo1_list[0],
+            add_packages=[self.foo1_list[0]],
+            child_images=[
+                {"image_name": "system:img1", "add_packages": []},
+                {"image_name": "system:img2", "add_packages": []},
+            ],
+        )
 
-                # uninstall package which is present in parent and child
-                # Only the parent should be affected
-                self._recursive_pkg("uninstall", self.foo1_list[0],
-                    remove_packages=[self.foo1_list[0]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "remove_packages": []
-                    },{
-                        "image_name": "system:img2",
-                        "remove_packages": []
-                    }
-                ])
+        # Install recursively, it's already in the parent so expect
+        # changes in the children only.
+        self._recursive_pkg(
+            "install -r",
+            self.foo1_list[0],
+            add_packages=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "add_packages": [self.foo1_list[0]],
+                },
+                {
+                    "image_name": "system:img2",
+                    "add_packages": [self.foo1_list[0]],
+                },
+            ],
+        )
 
-        def test_recursive_update(self):
-                """Test recursive update"""
+        # uninstall package which is present in parent and child
+        # Only the parent should be affected
+        self._recursive_pkg(
+            "uninstall",
+            self.foo1_list[0],
+            remove_packages=[self.foo1_list[0]],
+            child_images=[
+                {"image_name": "system:img1", "remove_packages": []},
+                {"image_name": "system:img2", "remove_packages": []},
+            ],
+        )
 
-                # create parent (0), push child (1)
-                self._imgs_create(2)
-                self._attach_child(0, [1])
+    def test_recursive_update(self):
+        """Test recursive update"""
 
-                self._pkg([0], "set-property default-recurse True")
+        # create parent (0), push child (1)
+        self._imgs_create(2)
+        self._attach_child(0, [1])
 
-                # install some packages to update
-                self._pkg([0, 1], "install {0}".format(self.foo1_list[0]))
+        self._pkg([0], "set-property default-recurse True")
 
-                # update package which is present in parent and child
-                self._recursive_pkg("update", self.foo1_list[3],
-                    change_packages=[[self.foo1_list[0], self.foo1_list[3]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [[
-                            self.foo1_list[0],
-                            self.foo1_list[3]
-                        ]]
-                    }
-                ])
+        # install some packages to update
+        self._pkg([0, 1], "install {0}".format(self.foo1_list[0]))
 
-                # downgrade child, leave parent alone, try again
-                self._pkg([1], "update {0}".format(self.foo1_list[0]))
-                self._recursive_pkg("update", self.foo1_list[3],
-                    change_packages=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": [[
-                            self.foo1_list[0],
-                            self.foo1_list[3]
-                        ]]
-                    }
-                ])
+        # update package which is present in parent and child
+        self._recursive_pkg(
+            "update",
+            self.foo1_list[3],
+            change_packages=[[self.foo1_list[0], self.foo1_list[3]]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.foo1_list[0], self.foo1_list[3]]],
+                }
+            ],
+        )
 
-                # downgrade parent, leave child alone, try again
-                self._pkg([0], "update -R {0}".format(self.foo1_list[0]))
-                self._recursive_pkg("update", self.foo1_list[3],
-                    change_packages=[[self.foo1_list[0], self.foo1_list[3]]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_packages": []
-                    }
-                ])
+        # downgrade child, leave parent alone, try again
+        self._pkg([1], "update {0}".format(self.foo1_list[0]))
+        self._recursive_pkg(
+            "update",
+            self.foo1_list[3],
+            change_packages=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_packages": [[self.foo1_list[0], self.foo1_list[3]]],
+                }
+            ],
+        )
 
-        def test_recursive_variant(self):
-                """Test recursive change-variant"""
+        # downgrade parent, leave child alone, try again
+        self._pkg([0], "update -R {0}".format(self.foo1_list[0]))
+        self._recursive_pkg(
+            "update",
+            self.foo1_list[3],
+            change_packages=[[self.foo1_list[0], self.foo1_list[3]]],
+            child_images=[{"image_name": "system:img1", "change_packages": []}],
+        )
 
-                # create parent (0), push child (1)
-                self._imgs_create(2)
-                self._attach_child(0, [1])
+    def test_recursive_variant(self):
+        """Test recursive change-variant"""
 
-                self._pkg([0], "set-property default-recurse True")
+        # create parent (0), push child (1)
+        self._imgs_create(2)
+        self._attach_child(0, [1])
 
-                # install some packages
-                self._pkg([0, 1], "install {0}".format(self.foo1_list[0]))
+        self._pkg([0], "set-property default-recurse True")
 
-                # change variant in parent and child
-                self._recursive_pkg("change-variant", "variant.foo=baz",
-                    change_variants=[["variant.foo", "baz"]],
-                    affect_packages=[self.foo1_list[0]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_variants": [["variant.foo", "baz"]],
-                        "affect_packages": [self.foo1_list[0]]
-                    }
-                ])
+        # install some packages
+        self._pkg([0, 1], "install {0}".format(self.foo1_list[0]))
 
-                # revert variant in child, leave parent alone, try again
-                self._pkg([1], "change-variant -v variant.foo=bar")
-                self._recursive_pkg("change-variant", "variant.foo=baz",
-                    change_variants=[],
-                    affect_packages=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_variants": [["variant.foo", "baz"]],
-                        "affect_packages": [self.foo1_list[0]]
-                    }
-                ])
+        # change variant in parent and child
+        self._recursive_pkg(
+            "change-variant",
+            "variant.foo=baz",
+            change_variants=[["variant.foo", "baz"]],
+            affect_packages=[self.foo1_list[0]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_variants": [["variant.foo", "baz"]],
+                    "affect_packages": [self.foo1_list[0]],
+                }
+            ],
+        )
 
-                # revert variant in parent, leave child alone, try again
-                self._pkg([0], "change-variant -R -v variant.foo=bar")
+        # revert variant in child, leave parent alone, try again
+        self._pkg([1], "change-variant -v variant.foo=bar")
+        self._recursive_pkg(
+            "change-variant",
+            "variant.foo=baz",
+            change_variants=[],
+            affect_packages=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_variants": [["variant.foo", "baz"]],
+                    "affect_packages": [self.foo1_list[0]],
+                }
+            ],
+        )
 
-                self._pkg([0], "audit-linked -a")
-                self._recursive_pkg("change-variant", "variant.foo=baz",
-                    change_variants=[["variant.foo", "baz"]],
-                    affect_packages=[self.foo1_list[0]],
-                )
+        # revert variant in parent, leave child alone, try again
+        self._pkg([0], "change-variant -R -v variant.foo=bar")
 
-        def test_recursive_facet(self):
-                """Test recursive change-facet"""
+        self._pkg([0], "audit-linked -a")
+        self._recursive_pkg(
+            "change-variant",
+            "variant.foo=baz",
+            change_variants=[["variant.foo", "baz"]],
+            affect_packages=[self.foo1_list[0]],
+        )
 
-                # create parent (0), push child (1)
-                self._imgs_create(2)
-                self._attach_child(0, [1])
+    def test_recursive_facet(self):
+        """Test recursive change-facet"""
 
-                self._pkg([0], "set-property default-recurse True")
+        # create parent (0), push child (1)
+        self._imgs_create(2)
+        self._attach_child(0, [1])
 
-                # set facet in parent and child
-                self._recursive_pkg("change-facet", "facet.foo=True",
-                    change_facets=[["facet.foo", True, None, "local", False,
-                        False]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_facets": [["facet.foo", True, None, "local",
-                            False, False]],
-                    }
-                ])
+        self._pkg([0], "set-property default-recurse True")
 
-                # change facet in child, leave parent alone, try again
-                self._pkg([1], "change-facet -v facet.foo=False")
-                self._recursive_pkg("change-facet", "facet.foo=True",
-                    change_facets=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_facets": [["facet.foo", True, False, "local",
-                            False, False]],
-                    }
-                ])
+        # set facet in parent and child
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=True",
+            change_facets=[["facet.foo", True, None, "local", False, False]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_facets": [
+                        ["facet.foo", True, None, "local", False, False]
+                    ],
+                }
+            ],
+        )
 
-                # remove facet in child, leave parent alone, try again
-                self._pkg([1], "change-facet -v facet.foo=None")
-                self._recursive_pkg("change-facet", "facet.foo=True",
-                    change_facets=[],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_facets": [["facet.foo", True, None, "local",
-                            False, False]],
-                    }
-                ])
+        # change facet in child, leave parent alone, try again
+        self._pkg([1], "change-facet -v facet.foo=False")
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=True",
+            change_facets=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_facets": [
+                        ["facet.foo", True, False, "local", False, False]
+                    ],
+                }
+            ],
+        )
 
-                # change facet in parent, leave child alone, try again
-                self._pkg([0], "change-facet -R -v facet.foo=False")
-                self._recursive_pkg("change-facet", "facet.foo=True",
-                    change_facets=[["facet.foo", True, False, "local",
-                        False, False]],
-                )
+        # remove facet in child, leave parent alone, try again
+        self._pkg([1], "change-facet -v facet.foo=None")
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=True",
+            change_facets=[],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_facets": [
+                        ["facet.foo", True, None, "local", False, False]
+                    ],
+                }
+            ],
+        )
 
-                # remove facet in parent, leave child alone, try again
-                self._pkg([0], "change-facet -R -v facet.foo=None")
-                self._recursive_pkg("change-facet", "facet.foo=True",
-                    change_facets=[["facet.foo", True, None, "local",
-                        False, False]],
-                )
+        # change facet in parent, leave child alone, try again
+        self._pkg([0], "change-facet -R -v facet.foo=False")
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=True",
+            change_facets=[["facet.foo", True, False, "local", False, False]],
+        )
 
-                # change facet in parent and child
-                self._recursive_pkg("change-facet", "facet.foo=False",
-                    change_facets=[["facet.foo", False, True, "local",
-                        False, False]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_facets": [["facet.foo", False, True, "local",
-                            False, False]],
-                    }
-                ])
+        # remove facet in parent, leave child alone, try again
+        self._pkg([0], "change-facet -R -v facet.foo=None")
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=True",
+            change_facets=[["facet.foo", True, None, "local", False, False]],
+        )
 
-                # remove facet in parent and child
-                self._recursive_pkg("change-facet", "facet.foo=None",
-                    change_facets=[["facet.foo", None, False, "local",
-                            False, False]],
-                    child_images=[{
-                        "image_name": "system:img1",
-                        "change_facets": [["facet.foo", None, False, "local",
-                            False, False]],
-                    }
-                ])
+        # change facet in parent and child
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=False",
+            change_facets=[["facet.foo", False, True, "local", False, False]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_facets": [
+                        ["facet.foo", False, True, "local", False, False]
+                    ],
+                }
+            ],
+        )
+
+        # remove facet in parent and child
+        self._recursive_pkg(
+            "change-facet",
+            "facet.foo=None",
+            change_facets=[["facet.foo", None, False, "local", False, False]],
+            child_images=[
+                {
+                    "image_name": "system:img1",
+                    "change_facets": [
+                        ["facet.foo", None, False, "local", False, False]
+                    ],
+                }
+            ],
+        )
+
 
 class TestPkgLinkedIncorpDowngrade(TestPkgLinked):
-        """Test that incorporated pkgs can be downgraded if incorporation is
-        updated."""
+    """Test that incorporated pkgs can be downgraded if incorporation is
+    updated."""
 
-        pkgs = (
-                """
+    pkgs = (
+        """
                     open incorp@1.0,5.11-0.1
                     add depend type=incorporate fmri=A@2
                     add depend type=parent fmri={0}
-                    close """.format(pkg.actions.depend.DEPEND_SELF),
-                """
+                    close """.format(
+            pkg.actions.depend.DEPEND_SELF
+        ),
+        """
                     open incorp@2.0,5.11-0.1
                     add depend type=incorporate fmri=A@1
                     add depend type=parent fmri={0}
-                    close """.format(pkg.actions.depend.DEPEND_SELF),
-                """
+                    close """.format(
+            pkg.actions.depend.DEPEND_SELF
+        ),
+        """
                     open A@1.0,5.11-0.1
                     add depend type=require fmri=pkg:/incorp
                     close """,
-                """
+        """
                     open A@2.0,5.11-0.1
                     add depend type=require fmri=pkg:/incorp
                     close """,
+    )
+
+    def setUp(self):
+        self.i_count = 3
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test"], image_count=self.i_count
         )
 
-        def setUp(self):
-                self.i_count = 3
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test"],
-                    image_count=self.i_count)
+        # get repo url
+        self.rurl1 = self.dcs[1].get_repo_url()
 
-                # get repo url
-                self.rurl1 = self.dcs[1].get_repo_url()
+        # setup image names and paths
+        self.i_name = []
+        self.i_path = []
+        self.i_api = []
+        self.i_api_reset = []
+        for i in range(self.i_count):
+            name = "system:img{0:d}".format(i)
+            self.i_name.insert(i, name)
+            self.i_path.insert(i, self.img_path(i))
 
-                # setup image names and paths
-                self.i_name = []
-                self.i_path = []
-                self.i_api = []
-                self.i_api_reset = []
-                for i in range(self.i_count):
-                        name = "system:img{0:d}".format(i)
-                        self.i_name.insert(i, name)
-                        self.i_path.insert(i, self.img_path(i))
+        self.pkgsend_bulk(self.rurl1, self.pkgs)
 
-                self.pkgsend_bulk(self.rurl1, self.pkgs)
+    def test_incorp_downgrade(self):
+        """Test that incorporated pkgs can be downgraded if
+        incorporation is updated."""
 
+        # create parent (0), push child (1, 2)
+        self._imgs_create(3)
+        self._attach_child(0, [1, 2])
 
-        def test_incorp_downgrade(self):
-                """Test that incorporated pkgs can be downgraded if
-                incorporation is updated."""
-
-                # create parent (0), push child (1, 2)
-                self._imgs_create(3)
-                self._attach_child(0, [1, 2])
-
-                self._pkg([0, 1, 2], "install -v incorp@1 A")
-                self._pkg([0, 1, 2], "list A@2")
-                self._pkg([0], "update -v incorp@2")
-                self._pkg([0, 1, 2], "list A@1")
+        self._pkg([0, 1, 2], "install -v incorp@1 A")
+        self._pkg([0, 1, 2], "list A@2")
+        self._pkg([0], "update -v incorp@2")
+        self._pkg([0, 1, 2], "list A@1")
 
 
 class TestFacetInheritance(TestPkgLinked):
-        """Class to test facet inheritance between images.
+    """Class to test facet inheritance between images.
 
-        These tests focus specifically on facet propagation from parent to
-        child images, masked facet handling, and facet reporting.  These tests
-        do not attempt to verify that the packaging system correctly handles
-        operations when facets and packages are changing at the same time."""
+    These tests focus specifically on facet propagation from parent to
+    child images, masked facet handling, and facet reporting.  These tests
+    do not attempt to verify that the packaging system correctly handles
+    operations when facets and packages are changing at the same time."""
 
-        p_files = [
-            "tmp/foo1",
-            "tmp/foo2",
-            "tmp/foo3",
-            "tmp/sync1",
-            "tmp/sync2",
-            "tmp/sync3",
-        ]
-        p_foo_template = """
+    p_files = [
+        "tmp/foo1",
+        "tmp/foo2",
+        "tmp/foo3",
+        "tmp/sync1",
+        "tmp/sync2",
+        "tmp/sync3",
+    ]
+    p_foo_template = """
             open foo@{ver:d}
             add file tmp/foo1 mode=0555 owner=root group=bin path=foo1_foo1 facet.foo1=true
             add file tmp/foo2 mode=0555 owner=root group=bin path=foo1_foo2 facet.foo2=true
             add file tmp/foo3 mode=0555 owner=root group=bin path=foo1_foo3 facet.foo3=true
             close"""
-        p_sync1_template = """
+    p_sync1_template = """
             open sync1@{ver:d}
             add file tmp/sync1 mode=0555 owner=root group=bin path=sync1_sync1 facet.sync1=true
             add file tmp/sync2 mode=0555 owner=root group=bin path=sync1_sync2 facet.sync2=true
             add file tmp/sync3 mode=0555 owner=root group=bin path=sync1_sync3 facet.sync3=true
             add depend type=parent fmri=feature/package/dependency/self
             close"""
-        p_sync2_template = """
+    p_sync2_template = """
             open sync2@{ver:d}
             add file tmp/sync1 mode=0555 owner=root group=bin path=sync2_sync1 facet.sync1=true
             add file tmp/sync2 mode=0555 owner=root group=bin path=sync2_sync2 facet.sync2=true
             add file tmp/sync3 mode=0555 owner=root group=bin path=sync2_sync3 facet.sync3=true
             add depend type=parent fmri=feature/package/dependency/self
             close"""
-        p_inc1_template = """
+    p_inc1_template = """
             open inc1@{ver:d}
             add depend type=require fmri=sync1
             add depend type=incorporate fmri=sync1@{ver:d} facet.123456=true
             add depend type=parent fmri=feature/package/dependency/self
             close"""
-        p_inc2_template = """
+    p_inc2_template = """
             open inc2@{ver:d}
             add depend type=require fmri=sync2
             add depend type=incorporate fmri=sync2@{ver:d} facet.456789=true
             add depend type=parent fmri=feature/package/dependency/self
             close"""
 
-        p_data_template = [
-            p_foo_template,
-            p_sync1_template,
-            p_sync2_template,
-            p_inc1_template,
-            p_inc2_template,
+    p_data_template = [
+        p_foo_template,
+        p_sync1_template,
+        p_sync2_template,
+        p_inc1_template,
+        p_inc2_template,
+    ]
+    p_data = []
+    for i in range(2):
+        for j in p_data_template:
+            p_data.append(j.format(ver=(i + 1)))
+    p_fmri = {}
+
+    def setUp(self):
+        self.i_count = 3
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test"], image_count=self.i_count
+        )
+
+        # create files that go in packages
+        self.make_misc_files(self.p_files)
+
+        # get repo url
+        self.rurl1 = self.dcs[1].get_repo_url()
+
+        # populate repository
+        for p in self.p_data:
+            fmristr = self.pkgsend_bulk(self.rurl1, p)[0]
+            f = fmri.PkgFmri(fmristr)
+            pkgstr = "{0}@{1}".format(f.pkg_name, f.version.release)
+            self.p_fmri[pkgstr] = fmristr
+
+        # setup image names and paths
+        self.i_name = []
+        self.i_path = []
+        self.i_api = []
+        self.i_api_reset = []
+        for i in range(self.i_count):
+            name = "system:img{0:d}".format(i)
+            self.i_name.insert(i, name)
+            self.i_path.insert(i, self.img_path(i))
+
+    def test_facet_inheritance(self):
+        """Verify basic facet inheritance functionality for both push
+        and pull children."""
+
+        # create parent (0), push child (1), and pull child (2)
+        self._imgs_create(3)
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # install packages with inheritable facets in all images
+        self._pkg([0, 1, 2], "install -v {0}".format(self.p_fmri["inc1@2"]))
+        self._pkg([0, 1, 2], "install -v {0}".format(self.p_fmri["inc2@2"]))
+
+        # verify that there are no facets set in any images
+        self._pkg(
+            [0, 1, 2], "facet -H -F tsv", output_cb=self._assertEqual_cb("")
+        )
+
+        # set some random facets and make sure they aren't inherited
+        # or affected by inherited facets
+        output = {}
+        for i in [0, 1, 2]:
+            i2 = i + 1
+            self._pkg(
+                [i],
+                "change-facet " "sync{0:d}=False foo{1:d}=True".format(i2, i2),
+            )
+        for i in [0, 1, 2]:
+            i2 = i + 1
+            output = "facet.foo{0:d}\tTrue\tlocal\n".format(
+                i2
+            ) + "facet.sync{0:d}\tFalse\tlocal\n".format(i2)
+            self._pkg(
+                [i], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+            )
+
+        # disable an inheritable facet and verify it gets inherited
+        self._pkg([0], "change-facet 123456=False")
+        self._pkg([2], "sync-linked")
+        for i in [1, 2]:
+            i2 = i + 1
+            output = (
+                "facet.123456\tFalse\tparent\n"
+                + "facet.foo{0:d}\tTrue\tlocal\n".format(i2)
+                + "facet.sync{0:d}\tFalse\tlocal\n".format(i2)
+            )
+            self._pkg(
+                [i], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+            )
+
+        # enable an inheritable facet and verify it doesn't get
+        # inherited
+        self._pkg([0], "change-facet 123456=True")
+        self._pkg([2], "sync-linked")
+        for i in [1, 2]:
+            i2 = i + 1
+            output = "facet.foo{0:d}\tTrue\tlocal\n".format(
+                i2
+            ) + "facet.sync{0:d}\tFalse\tlocal\n".format(i2)
+            self._pkg(
+                [i], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+            )
+
+        # clear an inheritable facet and verify it doesn't get
+        # inherited
+        self._pkg([0], "change-facet 123456=False")
+        self._pkg([2], "sync-linked")
+        self._pkg([0], "change-facet 123456=None")
+        self._pkg([2], "sync-linked")
+        for i in [1, 2]:
+            i2 = i + 1
+            output = "facet.foo{0:d}\tTrue\tlocal\n".format(
+                i2
+            ) + "facet.sync{0:d}\tFalse\tlocal\n".format(i2)
+            self._pkg(
+                [i], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+            )
+
+    def test_facet_inheritance_globs(self):
+        """Verify that all facet glob patterns which affect
+        inheritable facets get propagated to children."""
+
+        # create parent (0), push child (1)
+        self._imgs_create(2)
+        self._attach_child(0, [1])
+
+        self._pkg(
+            [0],
+            "change-facet"
+            + " 123456=False"
+            + " 456789=True"
+            + " *456*=False"
+            + " *789=True"
+            + " 123*=True",
+        )
+
+        # verify that no facets are inherited
+        output = ""
+        self._pkg(
+            [1], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # install packages with inheritable facets in the parent
+        self._pkg([0], "install -v {0}".format(self.p_fmri["inc1@2"]))
+
+        # verify that three facets are inherited
+        output = ""
+        output += "facet.*456*\tFalse\tparent\n"
+        output += "facet.123*\tTrue\tparent\n"
+        output += "facet.123456\tFalse\tparent\n"
+        self._pkg(
+            [1], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # install packages with inheritable facets in the parent
+        self._pkg([0], "install -v {0}".format(self.p_fmri["inc2@2"]))
+
+        # verify that five facets are inherited
+        output = ""
+        output += "facet.*456*\tFalse\tparent\n"
+        output += "facet.*789\tTrue\tparent\n"
+        output += "facet.123*\tTrue\tparent\n"
+        output += "facet.123456\tFalse\tparent\n"
+        output += "facet.456789\tTrue\tparent\n"
+        self._pkg(
+            [1], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # remove packages with inheritable facets in the parent
+        self._pkg([0], "uninstall -v {0}".format(self.p_fmri["inc1@2"]))
+
+        # verify that three facets are inherited
+        output = ""
+        output += "facet.*456*\tFalse\tparent\n"
+        output += "facet.*789\tTrue\tparent\n"
+        output += "facet.456789\tTrue\tparent\n"
+        self._pkg(
+            [1], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # remove packages with inheritable facets in the parent
+        self._pkg([0], "uninstall -v {0}".format(self.p_fmri["inc2@2"]))
+
+        # verify that no facets are inherited
+        output = ""
+        self._pkg(
+            [1], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+    def test_facet_inheritance_masked_system(self):
+        """Test reporting of system facets."""
+
+        # create image (0)
+        self._imgs_create(1)
+
+        # install a package with facets in the image
+        self._pkg([0], "install -v {0}".format(self.p_fmri["foo@2"]))
+
+        # set a facet
+        self._pkg([0], "change-facet 'f*1'=False")
+
+        # verify masked output
+        output_am = (
+            "facet.f*1\tFalse\tlocal\tFalse\n"
+            + "facet.foo1\tFalse\tlocal\tFalse\n"
+            + "facet.foo2\tTrue\tsystem\tFalse\n"
+            + "facet.foo3\tTrue\tsystem\tFalse\n"
+        )
+        output_im = (
+            "facet.foo1\tFalse\tlocal\tFalse\n"
+            + "facet.foo2\tTrue\tsystem\tFalse\n"
+            + "facet.foo3\tTrue\tsystem\tFalse\n"
+        )
+        self._pkg(
+            [0],
+            "facet -H -F tsv -m -a",
+            output_cb=self._assertEqual_cb(output_am),
+        )
+        self._pkg(
+            [0],
+            "facet -H -F tsv -m -i",
+            output_cb=self._assertEqual_cb(output_im),
+        )
+
+    def test_facet_inheritance_masked_preserve(self):
+        """Test handling for masked facets
+
+        Verify that pre-existing local facet settings which get masked
+        by inherited facets get restored when the inherited facets go
+        away."""
+
+        # create parent (0), push child (1), and pull child (2)
+        self._imgs_create(3)
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # install a package with inheritable facets in the parent
+        self._pkg([0], "install -v {0}".format(self.p_fmri["inc1@2"]))
+
+        for fv in ["True", "False"]:
+            # set inheritable facet locally in children
+            self._pkg([1, 2], "change-facet 123456={0}".format(fv))
+
+            # disable inheritable facet in parent
+            self._pkg([0], "change-facet 123456=False")
+            self._pkg([2], "sync-linked")
+
+            # verify inheritable facet is disabled in children
+            output = "facet.123456\tFalse\tparent\n"
+            output_m = (
+                "facet.123456\tFalse\tparent\tFalse\n"
+                + "facet.123456\t{0}\tlocal\tTrue\n".format(fv)
+            )
+            for i in [1, 2]:
+                self._pkg(
+                    [i],
+                    "facet -H -F tsv",
+                    output_cb=self._assertEqual_cb(output),
+                )
+                self._pkg(
+                    [i],
+                    "facet -H -F tsv -m",
+                    output_cb=self._assertEqual_cb(output_m),
+                )
+
+            # clear inheritable facet in the parent
+            self._pkg([0], "change-facet 123456=None")
+            self._pkg([2], "sync-linked")
+
+            # verify the local child setting is restored
+            output = "facet.123456\t{0}\tlocal\n".format(fv)
+            output_m = "facet.123456\t{0}\tlocal\tFalse\n".format(fv)
+            for i in [1, 2]:
+                self._pkg(
+                    [i],
+                    "facet -H -F tsv",
+                    output_cb=self._assertEqual_cb(output),
+                )
+                self._pkg(
+                    [i],
+                    "facet -H -F tsv -m",
+                    output_cb=self._assertEqual_cb(output_m),
+                )
+
+    def test_facet_inheritance_masked_update(self):
+        """Test handling for masked facets.
+
+        Verify that local facet changes can be made while inherited
+        facets masking the local settings exist."""
+
+        # create parent (0), push child (1), and pull child (2)
+        self._imgs_create(3)
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # install a package with inheritable facets in the parent
+        self._pkg([0], "install -v {0}".format(self.p_fmri["inc1@2"]))
+
+        # disable inheritable facet in parent
+        self._pkg([0], "change-facet 123456=False")
+        self._pkg([2], "sync-linked")
+
+        # clear inheritable facet in children
+        # the facet is not set in the child so this is a noop
+        self._pkg([1, 2], "change-facet 123456=None", rv=EXIT_NOP)
+
+        # verify inheritable facet is disabled in children
+        output = "facet.123456\tFalse\tparent\n"
+        output_m = "facet.123456\tFalse\tparent\tFalse\n"
+        for i in [1, 2]:
+            self._pkg(
+                [i], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+            )
+            self._pkg(
+                [i],
+                "facet -H -F tsv -m",
+                output_cb=self._assertEqual_cb(output_m),
+            )
+
+        for fv in ["True", "False"]:
+            # set inheritable facet locally in children
+            self._pkg([1, 2], "change-facet 123456={0}".format(fv))
+
+            # verify inheritable facet is disabled in children
+            output = "facet.123456\tFalse\tparent\n"
+            output_m = (
+                "facet.123456\tFalse\tparent\tFalse\n"
+                + "facet.123456\t{0}\tlocal\tTrue\n".format(fv)
+            )
+            for i in [1, 2]:
+                self._pkg(
+                    [i],
+                    "facet -H -F tsv",
+                    output_cb=self._assertEqual_cb(output),
+                )
+                self._pkg(
+                    [i],
+                    "facet -H -F tsv -m",
+                    output_cb=self._assertEqual_cb(output_m),
+                )
+
+            # re-set inheritable facet locall in children
+            # this is a noop
+            self._pkg([1, 2], "change-facet 123456={0}".format(fv), rv=EXIT_NOP)
+
+            # clear inheritable facet in the parent
+            self._pkg([0], "change-facet 123456=None")
+            self._pkg([2], "sync-linked")
+
+            # verify the local child setting is restored
+            output = "facet.123456\t{0}\tlocal\n".format(fv)
+            output_m = "facet.123456\t{0}\tlocal\tFalse\n".format(fv)
+            for i in [1, 2]:
+                self._pkg(
+                    [i],
+                    "facet -H -F tsv",
+                    output_cb=self._assertEqual_cb(output),
+                )
+                self._pkg(
+                    [i],
+                    "facet -H -F tsv -m",
+                    output_cb=self._assertEqual_cb(output_m),
+                )
+
+            # disable inheritable facet in parent
+            self._pkg([0], "change-facet 123456=False")
+            self._pkg([2], "sync-linked")
+
+        # clear inheritable facet locally in children
+        self._pkg([1, 2], "change-facet 123456=None")
+
+        # verify inheritable facet is disabled in children
+        output = "facet.123456\tFalse\tparent\n"
+        output_m = "facet.123456\tFalse\tparent\tFalse\n"
+        for i in [1, 2]:
+            self._pkg(
+                [i], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+            )
+            self._pkg(
+                [i],
+                "facet -H -F tsv -m",
+                output_cb=self._assertEqual_cb(output_m),
+            )
+
+        # re-clear inheritable facet locally in children
+        # this is a noop
+        self._pkg([1, 2], "change-facet 123456=None", rv=EXIT_NOP)
+
+        # clear inheritable facet in the parent
+        self._pkg([0], "change-facet 123456=None")
+        self._pkg([2], "sync-linked")
+
+        # verify the local child setting is restored
+        for i in [1, 2]:
+            self._pkg(
+                [i], "facet -H -F tsv", output_cb=self._assertEqual_cb("")
+            )
+            self._pkg(
+                [i], "facet -H -F tsv -m", output_cb=self._assertEqual_cb("")
+            )
+
+    def __test_facet_inheritance_via_op(self, op):
+        """Verify that if we do a an "op" operation, the latest facet
+        data gets pushed/pulled to child images."""
+
+        # create parent (0), push child (1), and pull child (2)
+        self._imgs_create(3)
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # install synced incorporations
+        self._pkg(
+            [0, 1, 2],
+            "install -v {0} {1}".format(
+                self.p_fmri["inc1@1"], self.p_fmri["foo@1"]
+            ),
+        )
+
+        # disable a random facet in all images
+        self._pkg([0, 1, 2], "change-facet -I foo=False")
+
+        # disable an inheritable facet in the parent while ignoring
+        # children.
+        self._pkg([0], "change-facet -I 123456=False")
+
+        # verify that the change hasn't been propagated to the child
+        output = "facet.foo\tFalse\tlocal\n"
+        self._pkg(
+            [1, 2], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # do "op" in the parent and verify the latest facet data was
+        # pushed to the child
+        self._pkg([0], op)
+        output = "facet.123456\tFalse\tparent\n"
+        output += "facet.foo\tFalse\tlocal\n"
+        self._pkg(
+            [1], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # do "op" in the child and verify the latest facet data was
+        # pulled from the parent.
+        self._pkg([2], op)
+        output = "facet.123456\tFalse\tparent\n"
+        output += "facet.foo\tFalse\tlocal\n"
+        self._pkg(
+            [2], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+    def test_facet_inheritance_via_noop_update(self):
+        """Verify that if we do a noop update operation, the
+        latest facet data still gets pushed/pulled to child images."""
+
+        self.__test_facet_inheritance_via_op("update")
+
+    def test_facet_inheritance_via_noop_install(self):
+        """Verify that if we do a noop install operation, the
+        latest facet data still gets pushed/pulled to child images."""
+
+        self.__test_facet_inheritance_via_op(
+            "install -v {0}".format(self.p_fmri["inc1@1"])
+        )
+
+    def test_facet_inheritance_via_noop_change_facet(self):
+        """Verify that if we do a noop change-facet operation on a
+        parent image, the latest facet data still gets pushed out to
+        child images."""
+
+        self.__test_facet_inheritance_via_op("change-facet foo=False")
+
+    def test_facet_inheritance_via_uninstall(self):
+        """Verify that if we do an uninstall operation on a
+        parent image, the latest facet data still gets pushed out to
+        child images."""
+
+        self.__test_facet_inheritance_via_op(
+            "uninstall -v {0}".format(self.p_fmri["foo@1"])
+        )
+
+    def test_facet_inheritance_cleanup_via_detach(self):
+        """Verify that if we detach a child linked image, that any
+        inherited facets go away."""
+
+        # create parent (0), push child (1), and pull child (2)
+        self._imgs_create(3)
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # install synced incorporations
+        self._pkg(
+            [0, 1, 2],
+            "install -v {0} {1}".format(
+                self.p_fmri["inc1@1"], self.p_fmri["foo@1"]
+            ),
+        )
+
+        # disable a random facet in all images
+        self._pkg([0, 1, 2], "change-facet -I foo=False")
+
+        # disable an inheritable facet in the parent and make sure the
+        # change propagates to all children
+        self._pkg([0], "change-facet 123456=False")
+        self._pkg([2], "sync-linked")
+        output = "facet.123456\tFalse\tparent\n"
+        output += "facet.foo\tFalse\tlocal\n"
+        self._pkg(
+            [1, 2], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # simulate detaching children via metadata only
+        # verify the inherited facets don't get removed
+        self._pkg(
+            [0],
+            "detach-linked --linked-md-only -n -l {0}".format(self.i_name[1]),
+        )
+        self._pkg([2], "detach-linked --linked-md-only -n")
+        self._pkg(
+            [1, 2], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # simulate detaching children
+        # verify the inherited facets don't get removed
+        self._pkg([0], "detach-linked -n -l {0}".format(self.i_name[1]))
+        self._pkg([2], "detach-linked -n")
+        self._pkg(
+            [1, 2], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # detach children via metadata only
+        # verify the inherited facets don't get removed
+        # (they can't get removed until we modify the image)
+        self._pkg(
+            [0], "detach-linked --linked-md-only -l {0}".format(self.i_name[1])
+        )
+        self._pkg([2], "detach-linked --linked-md-only")
+        self._pkg(
+            [1, 2], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # re-attach children and sanity check facets
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+        self._pkg(
+            [1, 2], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # try to detach children with --no-pkg-updates
+        # verify this fails
+        # (removal of inherited facets is the equilivant of a
+        # change-facet operation, which requires updating all
+        # packages, but since we've specified no pkg updates this must
+        # fail.)
+        self._pkg(
+            [0],
+            "detach-linked --no-pkg-updates -l {0}".format(self.i_name[1]),
+            rv=EXIT_OOPS,
+        )
+        self._pkg([2], "detach-linked --no-pkg-updates", rv=EXIT_OOPS)
+        self._pkg(
+            [1, 2], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+        # detach children
+        # verify the inherited facets get removed
+        self._pkg([0], "detach-linked -l {0}".format(self.i_name[1]))
+        self._pkg([2], "detach-linked")
+        output = "facet.foo\tFalse\tlocal\n"
+        self._pkg(
+            [1, 2], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
+
+    def __test_missing_facet_inheritance_metadata(
+        self, pfacets="", cfacet_output=""
+    ):
+        """Verify that we can manipulate and update linked child
+        images which are missing their parent facet metadata.  Also
+        verify that when we update those children the metadata gets
+        updated correctly."""
+
+        # create parent (0), push child (1), and pull child (2)
+        self._imgs_create(3)
+        self._attach_child(0, [1])
+        self._attach_parent([2], 0)
+
+        # paths for the linked image metadata files
+        md_files = [
+            "{0}/var/pkg/linked/linked_pfacets".format(self.i_path[i])
+            for i in [1, 2]
         ]
-        p_data = []
-        for i in range(2):
-                for j in p_data_template:
-                        p_data.append(j.format(ver=(i + 1)))
-        p_fmri = {}
 
-        def setUp(self):
-                self.i_count = 3
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test"],
-                    image_count=self.i_count)
-
-                # create files that go in packages
-                self.make_misc_files(self.p_files)
-
-                # get repo url
-                self.rurl1 = self.dcs[1].get_repo_url()
-
-                # populate repository
-                for p in self.p_data:
-                        fmristr = self.pkgsend_bulk(self.rurl1, p)[0]
-                        f = fmri.PkgFmri(fmristr)
-                        pkgstr = "{0}@{1}".format(f.pkg_name, f.version.release)
-                        self.p_fmri[pkgstr] = fmristr
-
-                # setup image names and paths
-                self.i_name = []
-                self.i_path = []
-                self.i_api = []
-                self.i_api_reset = []
-                for i in range(self.i_count):
-                        name = "system:img{0:d}".format(i)
-                        self.i_name.insert(i, name)
-                        self.i_path.insert(i, self.img_path(i))
-
-        def test_facet_inheritance(self):
-                """Verify basic facet inheritance functionality for both push
-                and pull children."""
-
-                # create parent (0), push child (1), and pull child (2)
-                self._imgs_create(3)
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # install packages with inheritable facets in all images
-                self._pkg([0, 1, 2], "install -v {0}".format(self.p_fmri["inc1@2"]))
-                self._pkg([0, 1, 2], "install -v {0}".format(self.p_fmri["inc2@2"]))
-
-                # verify that there are no facets set in any images
-                self._pkg([0, 1, 2], "facet -H -F tsv", \
-                    output_cb=self._assertEqual_cb(""))
-
-                # set some random facets and make sure they aren't inherited
-                # or affected by inherited facets
-                output = {}
-                for i in [0, 1, 2]:
-                        i2 = i + 1
-                        self._pkg([i], "change-facet "
-                            "sync{0:d}=False foo{1:d}=True".format(i2, i2))
-                for i in [0, 1, 2]:
-                        i2 = i + 1
-                        output = \
-                            "facet.foo{0:d}\tTrue\tlocal\n".format(i2) + \
-                            "facet.sync{0:d}\tFalse\tlocal\n".format(i2)
-                        self._pkg([i], "facet -H -F tsv", \
-                            output_cb=self._assertEqual_cb(output))
-
-                # disable an inheritable facet and verify it gets inherited
-                self._pkg([0], "change-facet 123456=False")
-                self._pkg([2], "sync-linked")
-                for i in [1, 2]:
-                        i2 = i + 1
-                        output = \
-                            "facet.123456\tFalse\tparent\n" + \
-                            "facet.foo{0:d}\tTrue\tlocal\n".format(i2) + \
-                            "facet.sync{0:d}\tFalse\tlocal\n".format(i2)
-                        self._pkg([i], "facet -H -F tsv", \
-                            output_cb=self._assertEqual_cb(output))
-
-                # enable an inheritable facet and verify it doesn't get
-                # inherited
-                self._pkg([0], "change-facet 123456=True")
-                self._pkg([2], "sync-linked")
-                for i in [1, 2]:
-                        i2 = i + 1
-                        output = \
-                            "facet.foo{0:d}\tTrue\tlocal\n".format(i2) + \
-                            "facet.sync{0:d}\tFalse\tlocal\n".format(i2)
-                        self._pkg([i], "facet -H -F tsv", \
-                            output_cb=self._assertEqual_cb(output))
-
-                # clear an inheritable facet and verify it doesn't get
-                # inherited
-                self._pkg([0], "change-facet 123456=False")
-                self._pkg([2], "sync-linked")
-                self._pkg([0], "change-facet 123456=None")
-                self._pkg([2], "sync-linked")
-                for i in [1, 2]:
-                        i2 = i + 1
-                        output = \
-                            "facet.foo{0:d}\tTrue\tlocal\n".format(i2) + \
-                            "facet.sync{0:d}\tFalse\tlocal\n".format(i2)
-                        self._pkg([i], "facet -H -F tsv", \
-                            output_cb=self._assertEqual_cb(output))
-
-        def test_facet_inheritance_globs(self):
-                """Verify that all facet glob patterns which affect
-                inheritable facets get propagated to children."""
-
-                # create parent (0), push child (1)
-                self._imgs_create(2)
-                self._attach_child(0, [1])
-
-                self._pkg([0], "change-facet" +
-                    " 123456=False" +
-                    " 456789=True" +
-                    " *456*=False" +
-                    " *789=True" +
-                    " 123*=True")
-
-                # verify that no facets are inherited
-                output = ""
-                self._pkg([1], "facet -H -F tsv", \
-                    output_cb=self._assertEqual_cb(output))
-
-                # install packages with inheritable facets in the parent
-                self._pkg([0], "install -v {0}".format(self.p_fmri["inc1@2"]))
-
-                # verify that three facets are inherited
-                output = ""
-                output += "facet.*456*\tFalse\tparent\n"
-                output += "facet.123*\tTrue\tparent\n"
-                output += "facet.123456\tFalse\tparent\n"
-                self._pkg([1], "facet -H -F tsv", \
-                    output_cb=self._assertEqual_cb(output))
-
-                # install packages with inheritable facets in the parent
-                self._pkg([0], "install -v {0}".format(self.p_fmri["inc2@2"]))
-
-                # verify that five facets are inherited
-                output = ""
-                output += "facet.*456*\tFalse\tparent\n"
-                output += "facet.*789\tTrue\tparent\n"
-                output += "facet.123*\tTrue\tparent\n"
-                output += "facet.123456\tFalse\tparent\n"
-                output += "facet.456789\tTrue\tparent\n"
-                self._pkg([1], "facet -H -F tsv", \
-                    output_cb=self._assertEqual_cb(output))
-
-                # remove packages with inheritable facets in the parent
-                self._pkg([0], "uninstall -v {0}".format(self.p_fmri["inc1@2"]))
-
-                # verify that three facets are inherited
-                output = ""
-                output += "facet.*456*\tFalse\tparent\n"
-                output += "facet.*789\tTrue\tparent\n"
-                output += "facet.456789\tTrue\tparent\n"
-                self._pkg([1], "facet -H -F tsv", \
-                    output_cb=self._assertEqual_cb(output))
-
-                # remove packages with inheritable facets in the parent
-                self._pkg([0], "uninstall -v {0}".format(self.p_fmri["inc2@2"]))
-
-                # verify that no facets are inherited
-                output = ""
-                self._pkg([1], "facet -H -F tsv", \
-                    output_cb=self._assertEqual_cb(output))
-
-        def test_facet_inheritance_masked_system(self):
-                """Test reporting of system facets."""
-
-                # create image (0)
-                self._imgs_create(1)
-
-                # install a package with facets in the image
-                self._pkg([0], "install -v {0}".format(self.p_fmri["foo@2"]))
-
-                # set a facet
-                self._pkg([0], "change-facet 'f*1'=False")
-
-                # verify masked output
-                output_am  = \
-                    "facet.f*1\tFalse\tlocal\tFalse\n" + \
-                    "facet.foo1\tFalse\tlocal\tFalse\n" + \
-                    "facet.foo2\tTrue\tsystem\tFalse\n" + \
-                    "facet.foo3\tTrue\tsystem\tFalse\n"
-                output_im  = \
-                    "facet.foo1\tFalse\tlocal\tFalse\n" + \
-                    "facet.foo2\tTrue\tsystem\tFalse\n" + \
-                    "facet.foo3\tTrue\tsystem\tFalse\n"
-                self._pkg([0], "facet -H -F tsv -m -a", \
-                    output_cb=self._assertEqual_cb(output_am))
-                self._pkg([0], "facet -H -F tsv -m -i", \
-                    output_cb=self._assertEqual_cb(output_im))
-
-        def test_facet_inheritance_masked_preserve(self):
-                """Test handling for masked facets
-
-                Verify that pre-existing local facet settings which get masked
-                by inherited facets get restored when the inherited facets go
-                away."""
-
-                # create parent (0), push child (1), and pull child (2)
-                self._imgs_create(3)
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # install a package with inheritable facets in the parent
-                self._pkg([0], "install -v {0}".format(self.p_fmri["inc1@2"]))
-
-                for fv in ["True", "False"]:
-
-                        # set inheritable facet locally in children
-                        self._pkg([1, 2], "change-facet 123456={0}".format(fv))
-
-                        # disable inheritable facet in parent
-                        self._pkg([0], "change-facet 123456=False")
-                        self._pkg([2], "sync-linked")
-
-                        # verify inheritable facet is disabled in children
-                        output = "facet.123456\tFalse\tparent\n"
-                        output_m = \
-                            "facet.123456\tFalse\tparent\tFalse\n" + \
-                            "facet.123456\t{0}\tlocal\tTrue\n".format(fv)
-                        for i in [1, 2]:
-                                self._pkg([i], "facet -H -F tsv", \
-                                    output_cb=self._assertEqual_cb(output))
-                                self._pkg([i], "facet -H -F tsv -m", \
-                                    output_cb=self._assertEqual_cb(output_m))
-
-                        # clear inheritable facet in the parent
-                        self._pkg([0], "change-facet 123456=None")
-                        self._pkg([2], "sync-linked")
-
-                        # verify the local child setting is restored
-                        output = "facet.123456\t{0}\tlocal\n".format(fv)
-                        output_m = "facet.123456\t{0}\tlocal\tFalse\n".format(fv)
-                        for i in [1, 2]:
-                                self._pkg([i], "facet -H -F tsv", \
-                                    output_cb=self._assertEqual_cb(output))
-                                self._pkg([i], "facet -H -F tsv -m", \
-                                    output_cb=self._assertEqual_cb(output_m))
-
-        def test_facet_inheritance_masked_update(self):
-                """Test handling for masked facets.
-
-                Verify that local facet changes can be made while inherited
-                facets masking the local settings exist."""
-
-                # create parent (0), push child (1), and pull child (2)
-                self._imgs_create(3)
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # install a package with inheritable facets in the parent
-                self._pkg([0], "install -v {0}".format(self.p_fmri["inc1@2"]))
-
-                # disable inheritable facet in parent
-                self._pkg([0], "change-facet 123456=False")
-                self._pkg([2], "sync-linked")
-
-                # clear inheritable facet in children
-                # the facet is not set in the child so this is a noop
-                self._pkg([1, 2], "change-facet 123456=None", rv=EXIT_NOP)
-
-                # verify inheritable facet is disabled in children
-                output = "facet.123456\tFalse\tparent\n"
-                output_m = "facet.123456\tFalse\tparent\tFalse\n"
-                for i in [1, 2]:
-                        self._pkg([i], "facet -H -F tsv", \
-                            output_cb=self._assertEqual_cb(output))
-                        self._pkg([i], "facet -H -F tsv -m", \
-                            output_cb=self._assertEqual_cb(output_m))
-
-                for fv in ["True", "False"]:
-
-                        # set inheritable facet locally in children
-                        self._pkg([1, 2], "change-facet 123456={0}".format(fv))
-
-                        # verify inheritable facet is disabled in children
-                        output = "facet.123456\tFalse\tparent\n"
-                        output_m = \
-                            "facet.123456\tFalse\tparent\tFalse\n" + \
-                            "facet.123456\t{0}\tlocal\tTrue\n".format(fv)
-                        for i in [1, 2]:
-                                self._pkg([i], "facet -H -F tsv", \
-                                    output_cb=self._assertEqual_cb(output))
-                                self._pkg([i], "facet -H -F tsv -m", \
-                                    output_cb=self._assertEqual_cb(output_m))
-
-                        # re-set inheritable facet locall in children
-                        # this is a noop
-                        self._pkg([1, 2], "change-facet 123456={0}".format(fv),
-                            rv=EXIT_NOP)
-
-                        # clear inheritable facet in the parent
-                        self._pkg([0], "change-facet 123456=None")
-                        self._pkg([2], "sync-linked")
-
-                        # verify the local child setting is restored
-                        output = "facet.123456\t{0}\tlocal\n".format(fv)
-                        output_m = "facet.123456\t{0}\tlocal\tFalse\n".format(fv)
-                        for i in [1, 2]:
-                                self._pkg([i], "facet -H -F tsv", \
-                                    output_cb=self._assertEqual_cb(output))
-                                self._pkg([i], "facet -H -F tsv -m", \
-                                    output_cb=self._assertEqual_cb(output_m))
-
-                        # disable inheritable facet in parent
-                        self._pkg([0], "change-facet 123456=False")
-                        self._pkg([2], "sync-linked")
-
-                # clear inheritable facet locally in children
-                self._pkg([1, 2], "change-facet 123456=None")
-
-                # verify inheritable facet is disabled in children
-                output = "facet.123456\tFalse\tparent\n"
-                output_m = "facet.123456\tFalse\tparent\tFalse\n"
-                for i in [1, 2]:
-                        self._pkg([i], "facet -H -F tsv", \
-                            output_cb=self._assertEqual_cb(output))
-                        self._pkg([i], "facet -H -F tsv -m", \
-                            output_cb=self._assertEqual_cb(output_m))
-
-                # re-clear inheritable facet locally in children
-                # this is a noop
-                self._pkg([1, 2], "change-facet 123456=None", rv=EXIT_NOP)
-
-                # clear inheritable facet in the parent
-                self._pkg([0], "change-facet 123456=None")
-                self._pkg([2], "sync-linked")
-
-                # verify the local child setting is restored
-                for i in [1, 2]:
-                        self._pkg([i], "facet -H -F tsv", \
-                            output_cb=self._assertEqual_cb(""))
-                        self._pkg([i], "facet -H -F tsv -m", \
-                            output_cb=self._assertEqual_cb(""))
-
-        def __test_facet_inheritance_via_op(self, op):
-                """Verify that if we do a an "op" operation, the latest facet
-                data gets pushed/pulled to child images."""
-
-                # create parent (0), push child (1), and pull child (2)
-                self._imgs_create(3)
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # install synced incorporations
-                self._pkg([0, 1, 2], "install -v {0} {1}".format(
-                    self.p_fmri["inc1@1"], self.p_fmri["foo@1"]))
-
-                # disable a random facet in all images
-                self._pkg([0, 1, 2], "change-facet -I foo=False")
-
-                # disable an inheritable facet in the parent while ignoring
-                # children.
-                self._pkg([0], "change-facet -I 123456=False")
-
-                # verify that the change hasn't been propagated to the child
-                output = "facet.foo\tFalse\tlocal\n"
-                self._pkg([1, 2], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
-
-                # do "op" in the parent and verify the latest facet data was
-                # pushed to the child
-                self._pkg([0], op)
-                output  = "facet.123456\tFalse\tparent\n"
-                output += "facet.foo\tFalse\tlocal\n"
-                self._pkg([1], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
-
-                # do "op" in the child and verify the latest facet data was
-                # pulled from the parent.
-                self._pkg([2], op)
-                output  = "facet.123456\tFalse\tparent\n"
-                output += "facet.foo\tFalse\tlocal\n"
-                self._pkg([2], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
-
-        def test_facet_inheritance_via_noop_update(self):
-                """Verify that if we do a noop update operation, the
-                latest facet data still gets pushed/pulled to child images."""
-
-                self.__test_facet_inheritance_via_op(
-                    "update")
-
-        def test_facet_inheritance_via_noop_install(self):
-                """Verify that if we do a noop install operation, the
-                latest facet data still gets pushed/pulled to child images."""
-
-                self.__test_facet_inheritance_via_op(
-                    "install -v {0}".format(self.p_fmri["inc1@1"]))
-
-        def test_facet_inheritance_via_noop_change_facet(self):
-                """Verify that if we do a noop change-facet operation on a
-                parent image, the latest facet data still gets pushed out to
-                child images."""
-
-                self.__test_facet_inheritance_via_op(
-                    "change-facet foo=False")
-
-        def test_facet_inheritance_via_uninstall(self):
-                """Verify that if we do an uninstall operation on a
-                parent image, the latest facet data still gets pushed out to
-                child images."""
-
-                self.__test_facet_inheritance_via_op(
-                    "uninstall -v {0}".format(self.p_fmri["foo@1"]))
-
-        def test_facet_inheritance_cleanup_via_detach(self):
-                """Verify that if we detach a child linked image, that any
-                inherited facets go away."""
-
-                # create parent (0), push child (1), and pull child (2)
-                self._imgs_create(3)
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # install synced incorporations
-                self._pkg([0, 1, 2], "install -v {0} {1}".format(
-                    self.p_fmri["inc1@1"], self.p_fmri["foo@1"]))
-
-                # disable a random facet in all images
-                self._pkg([0, 1, 2], "change-facet -I foo=False")
-
-                # disable an inheritable facet in the parent and make sure the
-                # change propagates to all children
-                self._pkg([0], "change-facet 123456=False")
-                self._pkg([2], "sync-linked")
-                output  = "facet.123456\tFalse\tparent\n"
-                output += "facet.foo\tFalse\tlocal\n"
-                self._pkg([1, 2], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
-
-                # simulate detaching children via metadata only
-                # verify the inherited facets don't get removed
-                self._pkg([0], "detach-linked --linked-md-only -n -l {0}".format(
-                    self.i_name[1]))
-                self._pkg([2], "detach-linked --linked-md-only -n")
-                self._pkg([1, 2], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
-
-                # simulate detaching children
-                # verify the inherited facets don't get removed
-                self._pkg([0], "detach-linked -n -l {0}".format(self.i_name[1]))
-                self._pkg([2], "detach-linked -n")
-                self._pkg([1, 2], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
-
-                # detach children via metadata only
-                # verify the inherited facets don't get removed
-                # (they can't get removed until we modify the image)
-                self._pkg([0], "detach-linked --linked-md-only -l {0}".format(
-                    self.i_name[1]))
-                self._pkg([2], "detach-linked --linked-md-only")
-                self._pkg([1, 2], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
-
-                # re-attach children and sanity check facets
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-                self._pkg([1, 2], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
-
-                # try to detach children with --no-pkg-updates
-                # verify this fails
-                # (removal of inherited facets is the equilivant of a
-                # change-facet operation, which requires updating all
-                # packages, but since we've specified no pkg updates this must
-                # fail.)
-                self._pkg([0], "detach-linked --no-pkg-updates -l {0}".format(
-                    self.i_name[1]), rv=EXIT_OOPS)
-                self._pkg([2], "detach-linked --no-pkg-updates", rv=EXIT_OOPS)
-                self._pkg([1, 2], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
-
-                # detach children
-                # verify the inherited facets get removed
-                self._pkg([0], "detach-linked -l {0}".format(self.i_name[1]))
-                self._pkg([2], "detach-linked")
-                output = "facet.foo\tFalse\tlocal\n"
-                self._pkg([1, 2], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
-
-        def __test_missing_facet_inheritance_metadata(self, pfacets="",
-            cfacet_output=""):
-                """Verify that we can manipulate and update linked child
-                images which are missing their parent facet metadata.  Also
-                verify that when we update those children the metadata gets
-                updated correctly."""
-
-                # create parent (0), push child (1), and pull child (2)
-                self._imgs_create(3)
-                self._attach_child(0, [1])
-                self._attach_parent([2], 0)
-
-                # paths for the linked image metadata files
-                md_files = [
-                        "{0}/var/pkg/linked/linked_pfacets".format(self.i_path[i])
-                        for i in [1, 2]
-                ]
-
-                # isntall foo into each image
-                self._pkg([0], "install -v {0}".format(self.p_fmri["foo@1"]))
-
-                # install synced incorporation and package
-                self._pkg([0], "install -v {0}".format(self.p_fmri["inc1@1"]))
-                self._pkg([2], "sync-linked")
-
-                if pfacets:
-                        self._pkg([0], "change-facet {0}".format(pfacets))
-                        self._pkg([2], "sync-linked")
-
-                # verify the child facet settings
-                self._pkg([1, 2], "facet -H -F tsv", \
-                    output_cb=self._assertEqual_cb(cfacet_output))
-
-                # verify that the child images are in sync.
-                # verify that a sync-linked is a noop
-                self._pkg([0], "audit-linked -a")
-                self._pkg([1, 2], "audit-linked")
-                self._pkg([0], "sync-linked -a -n", rv=EXIT_NOP)
-                self._pkg([2], "sync-linked -n", rv=EXIT_NOP)
-
-                # delete linked image metadata files
-                for f in md_files:
-                        self.file_exists(f)
-                        self._ccmd("rm {0}".format(f))
-
-                # verify the child facet settings
-                self._pkg([1, 2], "facet -H -F tsv", \
-                    output_cb=self._assertEqual_cb(cfacet_output))
-
-                # verify that audit-linked can handle missing metadata.
-                self._pkg([0], "audit-linked -a")
-                self._pkg([1, 2], "audit-linked")
-                self._pkg([2], "audit-linked --no-parent-sync")
-
-                # verify that sync-linked can handle missing metadata.
-                # also verify that the operation will succeed and is
-                # not a noop (since it needs to update the metadata).
-                self._pkg([0], "sync-linked -a -n")
-                self._pkg([2], "sync-linked -n")
-
-                # since we haven't modified the image, make sure the
-                # facet metadata files weren't re-created.
-                for f in md_files:
-                        self.file_doesnt_exist(f)
-
-                # do a sync and verify that the files get created
-                self._pkg([0], "sync-linked -a")
-                self._pkg([2], "sync-linked")
-                for f in md_files:
-                        self.file_exists(f)
-
-        def test_missing_facet_inheritance_metadata_1(self):
-                """Verify that we can manipulate and update linked child
-                images which are missing their parent facet metadata.  Also
-                verify that when we update those children the metadata gets
-                updated correctly.
-
-                Test when there are no inherited facets present."""
-                self.__test_missing_facet_inheritance_metadata()
-
-        def test_missing_facet_inheritance_metadata_2(self):
-                """Verify that we can manipulate and update linked child
-                images which are missing their parent facet metadata.  Also
-                verify that when we update those children the metadata gets
-                updated correctly.
-
-                Test with inherited facets present"""
-                self.__test_missing_facet_inheritance_metadata(
-                    pfacets="123456=False",
-                    cfacet_output="facet.123456\tFalse\tparent\n")
+        # isntall foo into each image
+        self._pkg([0], "install -v {0}".format(self.p_fmri["foo@1"]))
+
+        # install synced incorporation and package
+        self._pkg([0], "install -v {0}".format(self.p_fmri["inc1@1"]))
+        self._pkg([2], "sync-linked")
+
+        if pfacets:
+            self._pkg([0], "change-facet {0}".format(pfacets))
+            self._pkg([2], "sync-linked")
+
+        # verify the child facet settings
+        self._pkg(
+            [1, 2],
+            "facet -H -F tsv",
+            output_cb=self._assertEqual_cb(cfacet_output),
+        )
+
+        # verify that the child images are in sync.
+        # verify that a sync-linked is a noop
+        self._pkg([0], "audit-linked -a")
+        self._pkg([1, 2], "audit-linked")
+        self._pkg([0], "sync-linked -a -n", rv=EXIT_NOP)
+        self._pkg([2], "sync-linked -n", rv=EXIT_NOP)
+
+        # delete linked image metadata files
+        for f in md_files:
+            self.file_exists(f)
+            self._ccmd("rm {0}".format(f))
+
+        # verify the child facet settings
+        self._pkg(
+            [1, 2],
+            "facet -H -F tsv",
+            output_cb=self._assertEqual_cb(cfacet_output),
+        )
+
+        # verify that audit-linked can handle missing metadata.
+        self._pkg([0], "audit-linked -a")
+        self._pkg([1, 2], "audit-linked")
+        self._pkg([2], "audit-linked --no-parent-sync")
+
+        # verify that sync-linked can handle missing metadata.
+        # also verify that the operation will succeed and is
+        # not a noop (since it needs to update the metadata).
+        self._pkg([0], "sync-linked -a -n")
+        self._pkg([2], "sync-linked -n")
+
+        # since we haven't modified the image, make sure the
+        # facet metadata files weren't re-created.
+        for f in md_files:
+            self.file_doesnt_exist(f)
+
+        # do a sync and verify that the files get created
+        self._pkg([0], "sync-linked -a")
+        self._pkg([2], "sync-linked")
+        for f in md_files:
+            self.file_exists(f)
+
+    def test_missing_facet_inheritance_metadata_1(self):
+        """Verify that we can manipulate and update linked child
+        images which are missing their parent facet metadata.  Also
+        verify that when we update those children the metadata gets
+        updated correctly.
+
+        Test when there are no inherited facets present."""
+        self.__test_missing_facet_inheritance_metadata()
+
+    def test_missing_facet_inheritance_metadata_2(self):
+        """Verify that we can manipulate and update linked child
+        images which are missing their parent facet metadata.  Also
+        verify that when we update those children the metadata gets
+        updated correctly.
+
+        Test with inherited facets present"""
+        self.__test_missing_facet_inheritance_metadata(
+            pfacets="123456=False",
+            cfacet_output="facet.123456\tFalse\tparent\n",
+        )
 
 
 class TestConcurrentFacetChange(TestPkgLinked):
-        """Class to test that packaging operations work correctly when facets
-        are changing concurrently.
+    """Class to test that packaging operations work correctly when facets
+    are changing concurrently.
 
-        These tests do not focus on verifying that facets are propagated
-        correctly from parent to child images."""
+    These tests do not focus on verifying that facets are propagated
+    correctly from parent to child images."""
 
-        p_misc = """
+    p_misc = """
             open misc@1,5.11-0
             close"""
-        p_common = """
+    p_common = """
             open common@1,5.11-0
             close"""
-        p_AA_sync_template = """
+    p_AA_sync_template = """
             open AA-sync@{ver:d},5.11-0
             add set name=variant.foo value=bar value=baz
             add depend type=require fmri=common
@@ -3576,7 +3985,7 @@ class TestConcurrentFacetChange(TestPkgLinked):
             add depend type=parent fmri=feature/package/dependency/self \
                 variant.foo=bar
             close"""
-        p_AB_sync_template = """
+    p_AB_sync_template = """
             open AB-sync@{ver:d},5.11-0
             add set name=variant.foo value=bar value=baz
             add depend type=require fmri=common
@@ -3584,17 +3993,17 @@ class TestConcurrentFacetChange(TestPkgLinked):
             add depend type=parent fmri=feature/package/dependency/self \
                 variant.foo=bar
             close"""
-        p_BA_template = """
+    p_BA_template = """
             open BA@{ver:d},5.11-0
             add depend type=require fmri=common
             add depend type=require fmri=B-incorp-sync
             close"""
-        p_CA_template = """
+    p_CA_template = """
             open CA@{ver:d},5.11-0
             add depend type=require fmri=common
             add depend type=require fmri=C-incorp
             close"""
-        p_A_incorp_sync_template = """
+    p_A_incorp_sync_template = """
             open A-incorp-sync@{ver:d},5.11-0
             add set name=variant.foo value=bar value=baz
             add depend type=incorporate fmri=AA-sync@{ver:d} facet.AA-sync=true
@@ -3602,18 +4011,18 @@ class TestConcurrentFacetChange(TestPkgLinked):
             add depend type=parent fmri=feature/package/dependency/self \
                 variant.foo=bar
             close"""
-        p_B_incorp_sync_template = """
+    p_B_incorp_sync_template = """
             open B-incorp-sync@{ver:d},5.11-0
             add set name=variant.foo value=bar value=baz
             add depend type=incorporate fmri=BA@{ver:d} facet.BA=true
             add depend type=parent fmri=feature/package/dependency/self \
                 variant.foo=bar
             close"""
-        p_C_incorp_template = """
+    p_C_incorp_template = """
             open C-incorp@{ver:d},5.11-0
             add depend type=incorporate fmri=CA@{ver:d} facet.CA=true
             close"""
-        p_entire_sync_template = """
+    p_entire_sync_template = """
             open entire-sync@{ver:d},5.11-0
             add set name=variant.foo value=bar value=baz
             add depend type=require fmri=A-incorp-sync
@@ -3629,407 +4038,449 @@ class TestConcurrentFacetChange(TestPkgLinked):
                 variant.foo=bar
             close"""
 
-        p_data_template = [
-            p_AA_sync_template,
-            p_AB_sync_template,
-            p_BA_template,
-            p_CA_template,
-            p_A_incorp_sync_template,
-            p_B_incorp_sync_template,
-            p_C_incorp_template,
-            p_entire_sync_template,
+    p_data_template = [
+        p_AA_sync_template,
+        p_AB_sync_template,
+        p_BA_template,
+        p_CA_template,
+        p_A_incorp_sync_template,
+        p_B_incorp_sync_template,
+        p_C_incorp_template,
+        p_entire_sync_template,
+    ]
+
+    p_data = [p_misc, p_common]
+    for i in range(4):
+        for j in p_data_template:
+            p_data.append(j.format(ver=(i + 1)))
+    p_fmri = {}
+
+    def setUp(self):
+        self.i_count = 2
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test"], image_count=self.i_count
+        )
+
+        # get repo url
+        self.rurl1 = self.dcs[1].get_repo_url()
+
+        # populate repository
+        for p in self.p_data:
+            fmristr = self.pkgsend_bulk(self.rurl1, p)[0]
+            f = fmri.PkgFmri(fmristr)
+            pkgstr = "{0}@{1}".format(f.pkg_name, f.version.release)
+            self.p_fmri[pkgstr] = fmristr
+
+        # setup image names and paths
+        self.i_name = []
+        self.i_path = []
+        self.i_api = []
+        self.i_api_reset = []
+        for i in range(self.i_count):
+            name = "system:img{0:d}".format(i)
+            self.i_name.insert(i, name)
+            self.i_path.insert(i, self.img_path(i))
+
+    def __test_concurrent_facet_change_via_child_op(
+        self,
+        op,
+        op_args,
+        extra_child_pkgs=None,
+        child_variants=None,
+        child_pre_op_audit=True,
+        **kwargs,
+    ):
+        """Verify that if we do a operation "op" on a child image, it
+        automatically brings its packages in sync with its parent."""
+
+        # create parent (0) and pull child (1)
+        self._imgs_create(2)
+
+        # setup the parent image
+        parent_facets = [
+            "facet.AA-sync=False",
+            "facet.A-incorp-sync=False",
+            "facet.BA=False",
         ]
+        parent_pkgs = [
+            "A-incorp-sync@3",
+            "AA-sync@4",
+            "B-incorp-sync@2",
+            "BA@3",
+            "C-incorp@2",
+            "CA@2",
+            "entire-sync@2",
+        ]
+        self._pkg([0], "change-facet -v {0}".format(" ".join(parent_facets)))
+        self._pkg([0], "install -v {0}".format(" ".join(parent_pkgs)))
 
-        p_data = [p_misc, p_common]
-        for i in range(4):
-                for j in p_data_template:
-                        p_data.append(j.format(ver=(i + 1)))
-        p_fmri = {}
+        # setup the child image
+        child_facets = [
+            "facet.C*=False",
+        ]
+        child_pkgs = [
+            "A-incorp-sync@1",
+            "AA-sync@1",
+            "B-incorp-sync@1",
+            "BA@1",
+            "C-incorp@1",
+            "CA@1",
+            "entire-sync@1",
+        ]
+        self._pkg([1], "change-facet -v {0}".format(" ".join(child_facets)))
+        if child_variants is not None:
+            self._pkg(
+                [1], "change-variant -v {0}".format(" ".join(child_variants))
+            )
+        self._pkg([1], "install -v {0}".format(" ".join(child_pkgs)))
+        if extra_child_pkgs:
+            self._pkg([1], "install -v {0}".format(" ".join(extra_child_pkgs)))
 
-        def setUp(self):
-                self.i_count = 2
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test"],
-                    image_count=self.i_count)
+        # attach the child but don't sync it
+        self._attach_parent([1], 0, args="--linked-md-only")
 
-                # get repo url
-                self.rurl1 = self.dcs[1].get_repo_url()
+        # verify the child image is still diverged
+        if child_pre_op_audit:
+            self._pkg([1], "audit-linked", rv=EXIT_DIVERGED)
 
-                # populate repository
-                for p in self.p_data:
-                        fmristr = self.pkgsend_bulk(self.rurl1, p)[0]
-                        f = fmri.PkgFmri(fmristr)
-                        pkgstr = "{0}@{1}".format(f.pkg_name, f.version.release)
-                        self.p_fmri[pkgstr] = fmristr
+        # try and then execute op
+        def output_cb(output):
+            self.assertEqualParsable(output, **kwargs)
 
-                # setup image names and paths
-                self.i_name = []
-                self.i_path = []
-                self.i_api = []
-                self.i_api_reset = []
-                for i in range(self.i_count):
-                        name = "system:img{0:d}".format(i)
-                        self.i_name.insert(i, name)
-                        self.i_path.insert(i, self.img_path(i))
+        self._pkg([1], "{0} -nv {1}".format(op, op_args))
+        self._pkg(
+            [1], "{0} --parsable=0 {1}".format(op, op_args), output_cb=output_cb
+        )
 
-        def __test_concurrent_facet_change_via_child_op(self,
-            op, op_args, extra_child_pkgs=None, child_variants=None,
-            child_pre_op_audit=True, **kwargs):
-                """Verify that if we do a operation "op" on a child image, it
-                automatically brings its packages in sync with its parent."""
+        # verify sync via audit and sync (which should be a noop)
+        self._pkg([1], "audit-linked")
+        self._pkg([1], "sync-linked -v", rv=EXIT_NOP)
 
-                # create parent (0) and pull child (1)
-                self._imgs_create(2)
+    def __pkg_names_to_fmris(self, remove_packages):
+        """Convert a list of pkg names to fmris"""
+        rv = []
+        for s in remove_packages:
+            rv.append(self.p_fmri[s])
+        return rv
 
-                # setup the parent image
-                parent_facets = [
-                    "facet.AA-sync=False",
-                    "facet.A-incorp-sync=False",
-                    "facet.BA=False",
-                ]
-                parent_pkgs = [
-                    "A-incorp-sync@3",
-                    "AA-sync@4",
-                    "B-incorp-sync@2",
-                    "BA@3",
-                    "C-incorp@2",
-                    "CA@2",
-                    "entire-sync@2",
-                ]
-                self._pkg([0], "change-facet -v {0}".format(" ".join(parent_facets)))
-                self._pkg([0], "install -v {0}".format(" ".join(parent_pkgs)))
+    def __pkg_name_tuples_to_fmris(self, change_packages):
+        """Convert a list of pkg name tuples to fmris"""
+        rv = []
+        for s, d in change_packages:
+            rv.append([self.p_fmri[s], self.p_fmri[d]])
+        return rv
 
-                # setup the child image
-                child_facets = [
-                    "facet.C*=False",
-                ]
-                child_pkgs = [
-                    "A-incorp-sync@1",
-                    "AA-sync@1",
-                    "B-incorp-sync@1",
-                    "BA@1",
-                    "C-incorp@1",
-                    "CA@1",
-                    "entire-sync@1",
-                ]
-                self._pkg([1], "change-facet -v {0}".format(" ".join(child_facets)))
-                if child_variants is not None:
-                        self._pkg([1], "change-variant -v {0}".format(
-                            " ".join(child_variants)))
-                self._pkg([1], "install -v {0}".format(" ".join(child_pkgs)))
-                if extra_child_pkgs:
-                        self._pkg([1], "install -v {0}".format(
-                            " ".join(extra_child_pkgs)))
+    def test_concurrent_facet_change_via_update(self):
+        """Verify that we can update and sync a child
+        image while inherited facets are changing."""
 
-                # attach the child but don't sync it
-                self._attach_parent([1], 0, args="--linked-md-only")
+        change_facets = [
+            ["facet.A-incorp-sync", False, None, "parent", False, False],
+            ["facet.AA-sync", False, None, "parent", False, False],
+        ]
+        remove_packages = self.__pkg_names_to_fmris(
+            [
+                "AB-sync@1",
+            ]
+        )
+        change_packages = self.__pkg_name_tuples_to_fmris(
+            [
+                ["A-incorp-sync@1", "A-incorp-sync@3"],
+                ["AA-sync@1", "AA-sync@4"],
+                ["B-incorp-sync@1", "B-incorp-sync@2"],
+                ["BA@1", "BA@2"],
+                ["C-incorp@1", "C-incorp@4"],
+                ["CA@1", "CA@4"],
+                ["entire-sync@1", "entire-sync@2"],
+            ]
+        )
+        self.__test_concurrent_facet_change_via_child_op(
+            "update",
+            "--reject AB-sync",
+            extra_child_pkgs=["AB-sync@1"],
+            change_facets=change_facets,
+            remove_packages=remove_packages,
+            change_packages=change_packages,
+        )
 
-                # verify the child image is still diverged
-                if child_pre_op_audit:
-                        self._pkg([1], "audit-linked", rv=EXIT_DIVERGED)
+    def test_concurrent_facet_change_via_update_pkg(self):
+        """Verify that we can update a package and sync a child
+        image while inherited facets are changing."""
 
-                # try and then execute op
-                def output_cb(output):
-                        self.assertEqualParsable(output, **kwargs)
-                self._pkg([1], "{0} -nv {1}".format(op, op_args))
-                self._pkg([1], "{0} --parsable=0 {1}".format(op, op_args),
-                    output_cb=output_cb)
+        change_facets = [
+            ["facet.A-incorp-sync", False, None, "parent", False, False],
+            ["facet.AA-sync", False, None, "parent", False, False],
+        ]
+        remove_packages = self.__pkg_names_to_fmris(
+            [
+                "AB-sync@1",
+            ]
+        )
+        change_packages = self.__pkg_name_tuples_to_fmris(
+            [
+                ["A-incorp-sync@1", "A-incorp-sync@3"],
+                ["AA-sync@1", "AA-sync@4"],
+                ["B-incorp-sync@1", "B-incorp-sync@2"],
+                ["BA@1", "BA@2"],
+                ["entire-sync@1", "entire-sync@2"],
+            ]
+        )
 
-                # verify sync via audit and sync (which should be a noop)
-                self._pkg([1], "audit-linked")
-                self._pkg([1], "sync-linked -v", rv=EXIT_NOP)
+        # verify update pkg
+        self.__test_concurrent_facet_change_via_child_op(
+            "update",
+            "--reject AB-sync common",
+            extra_child_pkgs=["AB-sync@1"],
+            change_facets=change_facets,
+            remove_packages=remove_packages,
+            change_packages=change_packages,
+        )
 
-        def __pkg_names_to_fmris(self, remove_packages):
-                """Convert a list of pkg names to fmris"""
-                rv = []
-                for s in remove_packages:
-                        rv.append(self.p_fmri[s])
-                return rv
+    def test_concurrent_facet_change_via_install(self):
+        """Verify that we can install a package and sync a child
+        image while inherited facets are changing."""
 
-        def __pkg_name_tuples_to_fmris(self, change_packages):
-                """Convert a list of pkg name tuples to fmris"""
-                rv = []
-                for s, d in change_packages:
-                        rv.append([self.p_fmri[s], self.p_fmri[d]])
-                return rv
+        change_facets = [
+            ["facet.A-incorp-sync", False, None, "parent", False, False],
+            ["facet.AA-sync", False, None, "parent", False, False],
+        ]
+        remove_packages = self.__pkg_names_to_fmris(
+            [
+                "AB-sync@1",
+            ]
+        )
+        add_packages = self.__pkg_names_to_fmris(
+            [
+                "misc@1",
+            ]
+        )
+        change_packages = self.__pkg_name_tuples_to_fmris(
+            [
+                ["A-incorp-sync@1", "A-incorp-sync@3"],
+                ["AA-sync@1", "AA-sync@4"],
+                ["B-incorp-sync@1", "B-incorp-sync@2"],
+                ["BA@1", "BA@2"],
+                ["entire-sync@1", "entire-sync@2"],
+            ]
+        )
+        self.__test_concurrent_facet_change_via_child_op(
+            "install",
+            "--reject AB-sync misc",
+            extra_child_pkgs=["AB-sync@1"],
+            change_facets=change_facets,
+            remove_packages=remove_packages,
+            add_packages=add_packages,
+            change_packages=change_packages,
+        )
 
-        def test_concurrent_facet_change_via_update(self):
-                """Verify that we can update and sync a child
-                image while inherited facets are changing."""
+    def test_concurrent_facet_change_via_sync(self):
+        """Verify that we can sync a child
+        image while inherited facets are changing."""
 
-                change_facets = [
-                    ['facet.A-incorp-sync',
-                        False, None, 'parent', False, False],
-                    ['facet.AA-sync', False, None, 'parent', False, False],
-                ]
-                remove_packages = self.__pkg_names_to_fmris([
-                    "AB-sync@1",
-                ])
-                change_packages = self.__pkg_name_tuples_to_fmris([
-                    ["A-incorp-sync@1", "A-incorp-sync@3"],
-                    ["AA-sync@1",       "AA-sync@4"],
-                    ["B-incorp-sync@1", "B-incorp-sync@2"],
-                    ["BA@1",            "BA@2"],
-                    ["C-incorp@1",      "C-incorp@4"],
-                    ["CA@1",            "CA@4"],
-                    ["entire-sync@1",   "entire-sync@2"],
-                ])
-                self.__test_concurrent_facet_change_via_child_op(
-                    "update", "--reject AB-sync",
-                    extra_child_pkgs=["AB-sync@1"],
-                    change_facets=change_facets,
-                    remove_packages=remove_packages,
-                    change_packages=change_packages)
+        change_facets = [
+            ["facet.A-incorp-sync", False, None, "parent", False, False],
+            ["facet.AA-sync", False, None, "parent", False, False],
+        ]
+        remove_packages = self.__pkg_names_to_fmris(
+            [
+                "AB-sync@1",
+            ]
+        )
+        change_packages = self.__pkg_name_tuples_to_fmris(
+            [
+                ["A-incorp-sync@1", "A-incorp-sync@3"],
+                ["AA-sync@1", "AA-sync@4"],
+                ["B-incorp-sync@1", "B-incorp-sync@2"],
+                ["BA@1", "BA@2"],
+                ["entire-sync@1", "entire-sync@2"],
+            ]
+        )
+        self.__test_concurrent_facet_change_via_child_op(
+            "sync-linked",
+            "--reject AB-sync",
+            extra_child_pkgs=["AB-sync@1"],
+            change_facets=change_facets,
+            remove_packages=remove_packages,
+            change_packages=change_packages,
+        )
 
-        def test_concurrent_facet_change_via_update_pkg(self):
-                """Verify that we can update a package and sync a child
-                image while inherited facets are changing."""
+    def test_concurrent_facet_change_via_uninstall(self):
+        """Verify that we can uninstall a package and sync a child
+        image while inherited facets are changing."""
 
-                change_facets = [
-                    ['facet.A-incorp-sync',
-                        False, None, 'parent', False, False],
-                    ['facet.AA-sync', False, None, 'parent', False, False],
-                ]
-                remove_packages = self.__pkg_names_to_fmris([
-                    "AB-sync@1",
-                ])
-                change_packages = self.__pkg_name_tuples_to_fmris([
-                    ["A-incorp-sync@1", "A-incorp-sync@3"],
-                    ["AA-sync@1",       "AA-sync@4"],
-                    ["B-incorp-sync@1", "B-incorp-sync@2"],
-                    ["BA@1",            "BA@2"],
-                    ["entire-sync@1",   "entire-sync@2"],
-                ])
+        change_facets = [
+            ["facet.A-incorp-sync", False, None, "parent", False, False],
+            ["facet.AA-sync", False, None, "parent", False, False],
+        ]
+        remove_packages = self.__pkg_names_to_fmris(
+            [
+                "AB-sync@1",
+            ]
+        )
+        change_packages = self.__pkg_name_tuples_to_fmris(
+            [
+                ["A-incorp-sync@1", "A-incorp-sync@3"],
+                ["AA-sync@1", "AA-sync@4"],
+                ["B-incorp-sync@1", "B-incorp-sync@2"],
+                ["BA@1", "BA@2"],
+                ["entire-sync@1", "entire-sync@2"],
+            ]
+        )
+        self.__test_concurrent_facet_change_via_child_op(
+            "uninstall",
+            "AB-sync",
+            extra_child_pkgs=["AB-sync@1"],
+            change_facets=change_facets,
+            remove_packages=remove_packages,
+            change_packages=change_packages,
+        )
 
-                # verify update pkg
-                self.__test_concurrent_facet_change_via_child_op(
-                    "update", "--reject AB-sync common",
-                    extra_child_pkgs=["AB-sync@1"],
-                    change_facets=change_facets,
-                    remove_packages=remove_packages,
-                    change_packages=change_packages)
+    def test_concurrent_facet_change_via_change_variant(self):
+        """Verify that we can change variants and sync a child
+        image while inherited facets are changing."""
 
-        def test_concurrent_facet_change_via_install(self):
-                """Verify that we can install a package and sync a child
-                image while inherited facets are changing."""
+        change_facets = [
+            ["facet.A-incorp-sync", False, None, "parent", False, False],
+            ["facet.AA-sync", False, None, "parent", False, False],
+        ]
+        change_variants = [["variant.foo", "bar"]]
+        change_packages = self.__pkg_name_tuples_to_fmris(
+            [
+                ["A-incorp-sync@1", "A-incorp-sync@3"],
+                ["AA-sync@1", "AA-sync@4"],
+                ["B-incorp-sync@1", "B-incorp-sync@2"],
+                ["BA@1", "BA@2"],
+                ["entire-sync@1", "entire-sync@2"],
+            ]
+        )
+        self.__test_concurrent_facet_change_via_child_op(
+            "change-variant",
+            "variant.foo=bar",
+            child_variants=["variant.foo=baz"],
+            child_pre_op_audit=False,
+            change_facets=change_facets,
+            change_variants=change_variants,
+            change_packages=change_packages,
+        )
 
-                change_facets = [
-                    ['facet.A-incorp-sync',
-                        False, None, 'parent', False, False],
-                    ['facet.AA-sync', False, None, 'parent', False, False],
-                ]
-                remove_packages = self.__pkg_names_to_fmris([
-                    "AB-sync@1",
-                ])
-                add_packages = self.__pkg_names_to_fmris([
-                    "misc@1",
-                ])
-                change_packages = self.__pkg_name_tuples_to_fmris([
-                    ["A-incorp-sync@1", "A-incorp-sync@3"],
-                    ["AA-sync@1",       "AA-sync@4"],
-                    ["B-incorp-sync@1", "B-incorp-sync@2"],
-                    ["BA@1",            "BA@2"],
-                    ["entire-sync@1",   "entire-sync@2"],
-                ])
-                self.__test_concurrent_facet_change_via_child_op(
-                    "install", "--reject AB-sync misc",
-                    extra_child_pkgs=["AB-sync@1"],
-                    change_facets=change_facets,
-                    remove_packages=remove_packages,
-                    add_packages=add_packages,
-                    change_packages=change_packages)
+    def test_concurrent_facet_change_via_change_facets(self):
+        """Verify that we can change facets and sync a child
+        image while inherited facets are changing."""
 
-        def test_concurrent_facet_change_via_sync(self):
-                """Verify that we can sync a child
-                image while inherited facets are changing."""
+        change_facets = [
+            ["facet.A-incorp-sync", False, None, "parent", False, False],
+            ["facet.AA-sync", False, None, "parent", False, False],
+            ["facet.C-incorp", True, None, "local", False, False],
+        ]
+        change_packages = self.__pkg_name_tuples_to_fmris(
+            [
+                ["A-incorp-sync@1", "A-incorp-sync@3"],
+                ["AA-sync@1", "AA-sync@4"],
+                ["B-incorp-sync@1", "B-incorp-sync@2"],
+                ["BA@1", "BA@2"],
+                ["C-incorp@1", "C-incorp@2"],
+                ["entire-sync@1", "entire-sync@2"],
+            ]
+        )
+        self.__test_concurrent_facet_change_via_child_op(
+            "change-facet",
+            "facet.C-incorp=True",
+            change_facets=change_facets,
+            change_packages=change_packages,
+        )
 
-                change_facets = [
-                    ['facet.A-incorp-sync',
-                        False, None, 'parent', False, False],
-                    ['facet.AA-sync', False, None, 'parent', False, False],
-                ]
-                remove_packages = self.__pkg_names_to_fmris([
-                    "AB-sync@1",
-                ])
-                change_packages = self.__pkg_name_tuples_to_fmris([
-                    ["A-incorp-sync@1", "A-incorp-sync@3"],
-                    ["AA-sync@1",       "AA-sync@4"],
-                    ["B-incorp-sync@1", "B-incorp-sync@2"],
-                    ["BA@1",            "BA@2"],
-                    ["entire-sync@1",   "entire-sync@2"],
-                ])
-                self.__test_concurrent_facet_change_via_child_op(
-                    "sync-linked", "--reject AB-sync",
-                    extra_child_pkgs=["AB-sync@1"],
-                    change_facets=change_facets,
-                    remove_packages=remove_packages,
-                    change_packages=change_packages)
+    def test_concurrent_facet_change_via_detach(self):
+        """Verify that we can detach a child image which has inherited
+        facets that when removed require updating the image."""
 
-        def test_concurrent_facet_change_via_uninstall(self):
-                """Verify that we can uninstall a package and sync a child
-                image while inherited facets are changing."""
+        # create parent (0) and pull child (1)
+        self._imgs_create(2)
 
-                change_facets = [
-                    ['facet.A-incorp-sync',
-                        False, None, 'parent', False, False],
-                    ['facet.AA-sync', False, None, 'parent', False, False],
-                ]
-                remove_packages = self.__pkg_names_to_fmris([
-                    "AB-sync@1",
-                ])
-                change_packages = self.__pkg_name_tuples_to_fmris([
-                    ["A-incorp-sync@1", "A-incorp-sync@3"],
-                    ["AA-sync@1",       "AA-sync@4"],
-                    ["B-incorp-sync@1", "B-incorp-sync@2"],
-                    ["BA@1",            "BA@2"],
-                    ["entire-sync@1",   "entire-sync@2"],
-                ])
-                self.__test_concurrent_facet_change_via_child_op(
-                    "uninstall", "AB-sync",
-                    extra_child_pkgs=["AB-sync@1"],
-                    change_facets=change_facets,
-                    remove_packages=remove_packages,
-                    change_packages=change_packages)
+        # setup the parent image
+        parent_facets = [
+            "facet.AA-sync=False",
+            "facet.A-incorp-sync=False",
+        ]
+        parent_pkgs = [
+            "A-incorp-sync@2",
+            "AA-sync@1",
+            "B-incorp-sync@3",
+            "BA@3",
+            "C-incorp@3",
+            "CA@3",
+            "entire-sync@3",
+        ]
+        self._pkg([0], "change-facet -v {0}".format(" ".join(parent_facets)))
+        self._pkg([0], "install -v {0}".format(" ".join(parent_pkgs)))
 
-        def test_concurrent_facet_change_via_change_variant(self):
-                """Verify that we can change variants and sync a child
-                image while inherited facets are changing."""
+        # attach the child.
+        self._attach_parent([1], 0)
 
-                change_facets = [
-                    ["facet.A-incorp-sync",
-                        False, None, "parent", False, False],
-                    ["facet.AA-sync", False, None, "parent", False, False],
-                ]
-                change_variants = [
-                    ["variant.foo", "bar"]
-                ]
-                change_packages = self.__pkg_name_tuples_to_fmris([
-                    ["A-incorp-sync@1", "A-incorp-sync@3"],
-                    ["AA-sync@1",       "AA-sync@4"],
-                    ["B-incorp-sync@1", "B-incorp-sync@2"],
-                    ["BA@1",            "BA@2"],
-                    ["entire-sync@1",   "entire-sync@2"],
-                ])
-                self.__test_concurrent_facet_change_via_child_op(
-                    "change-variant", "variant.foo=bar",
-                    child_variants=["variant.foo=baz"],
-                    child_pre_op_audit=False,
-                    change_facets=change_facets,
-                    change_variants=change_variants,
-                    change_packages=change_packages)
+        # setup the child image
+        child_facets = [
+            "facet.C*=False",
+        ]
+        child_pkgs = [
+            "A-incorp-sync@2",
+            "AA-sync@1",
+            "B-incorp-sync@3",
+            "BA@3",
+            "C-incorp@2",
+            "CA@2",
+            "entire-sync@3",
+        ]
+        self._pkg([1], "change-facet -v {0}".format(" ".join(child_facets)))
+        self._pkg([1], "install -v {0}".format(" ".join(child_pkgs)))
 
-        def test_concurrent_facet_change_via_change_facets(self):
-                """Verify that we can change facets and sync a child
-                image while inherited facets are changing."""
+        # a request to detach the child without any package updates
+        # should fail.
+        self._pkg([1], "detach-linked -v --no-pkg-updates", rv=EXIT_OOPS)
 
-                change_facets = [
-                    ["facet.A-incorp-sync",
-                        False, None, "parent", False, False],
-                    ["facet.AA-sync", False, None, "parent", False, False],
-                    ["facet.C-incorp", True, None, "local", False, False],
-                ]
-                change_packages = self.__pkg_name_tuples_to_fmris([
-                    ["A-incorp-sync@1", "A-incorp-sync@3"],
-                    ["AA-sync@1",       "AA-sync@4"],
-                    ["B-incorp-sync@1", "B-incorp-sync@2"],
-                    ["BA@1",            "BA@2"],
-                    ["C-incorp@1",      "C-incorp@2"],
-                    ["entire-sync@1",   "entire-sync@2"],
-                ])
-                self.__test_concurrent_facet_change_via_child_op(
-                    "change-facet", "facet.C-incorp=True",
-                    change_facets=change_facets,
-                    change_packages=change_packages)
+        # detach the child
+        self._pkg([1], "detach-linked -v")
 
-        def test_concurrent_facet_change_via_detach(self):
-                """Verify that we can detach a child image which has inherited
-                facets that when removed require updating the image."""
-
-                # create parent (0) and pull child (1)
-                self._imgs_create(2)
-
-                # setup the parent image
-                parent_facets = [
-                    "facet.AA-sync=False",
-                    "facet.A-incorp-sync=False",
-                ]
-                parent_pkgs = [
-                    "A-incorp-sync@2",
-                    "AA-sync@1",
-                    "B-incorp-sync@3",
-                    "BA@3",
-                    "C-incorp@3",
-                    "CA@3",
-                    "entire-sync@3",
-                ]
-                self._pkg([0], "change-facet -v {0}".format(" ".join(parent_facets)))
-                self._pkg([0], "install -v {0}".format(" ".join(parent_pkgs)))
-
-                # attach the child.
-                self._attach_parent([1], 0)
-
-                # setup the child image
-                child_facets = [
-                    "facet.C*=False",
-                ]
-                child_pkgs = [
-                    "A-incorp-sync@2",
-                    "AA-sync@1",
-                    "B-incorp-sync@3",
-                    "BA@3",
-                    "C-incorp@2",
-                    "CA@2",
-                    "entire-sync@3",
-                ]
-                self._pkg([1], "change-facet -v {0}".format(" ".join(child_facets)))
-                self._pkg([1], "install -v {0}".format(" ".join(child_pkgs)))
-
-                # a request to detach the child without any package updates
-                # should fail.
-                self._pkg([1], "detach-linked -v --no-pkg-updates",
-                    rv=EXIT_OOPS)
-
-                # detach the child
-                self._pkg([1], "detach-linked -v")
-
-                # verify the contents of the child image
-                child_fmris = self.__pkg_names_to_fmris([
-                    "A-incorp-sync@3",
-                    "AA-sync@3",
-                    "B-incorp-sync@3",
-                    "BA@3",
-                    "C-incorp@2",
-                    "CA@2",
-                    "entire-sync@3",
-                ])
-                self._pkg([1], "list -v {0}".format(" ".join(child_fmris)))
-                output  = "facet.C*\tFalse\tlocal\n"
-                self._pkg([1], "facet -H -F tsv",
-                    output_cb=self._assertEqual_cb(output))
+        # verify the contents of the child image
+        child_fmris = self.__pkg_names_to_fmris(
+            [
+                "A-incorp-sync@3",
+                "AA-sync@3",
+                "B-incorp-sync@3",
+                "BA@3",
+                "C-incorp@2",
+                "CA@2",
+                "entire-sync@3",
+            ]
+        )
+        self._pkg([1], "list -v {0}".format(" ".join(child_fmris)))
+        output = "facet.C*\tFalse\tlocal\n"
+        self._pkg(
+            [1], "facet -H -F tsv", output_cb=self._assertEqual_cb(output)
+        )
 
 
 class TestLinkedInstallHoldRelax(TestPkgLinked):
-        """Class to test automatic install-hold relaxing of constrained
-        packages when doing different packaging operations.
+    """Class to test automatic install-hold relaxing of constrained
+    packages when doing different packaging operations.
 
-        When performing packaging operations, any package that has an install
-        hold, but also has dependency on itself in its parent, must have that
-        install hold relaxed if we expect to be able to bring the image in
-        sync with its parent."""
+    When performing packaging operations, any package that has an install
+    hold, but also has dependency on itself in its parent, must have that
+    install hold relaxed if we expect to be able to bring the image in
+    sync with its parent."""
 
-        # the "common" package exists because the solver ignores
-        # install-holds unless the package containing them depends on a
-        # specific version of another package.  so all our packages depend on
-        # the "common" package.
-        p_common = """
+    # the "common" package exists because the solver ignores
+    # install-holds unless the package containing them depends on a
+    # specific version of another package.  so all our packages depend on
+    # the "common" package.
+    p_common = """
             open common@1,5.11-0
             close"""
-        p_A_template = """
+    p_A_template = """
             open A@{ver:d},5.11-0
             add set name=pkg.depend.install-hold value=A
             add depend type=require fmri=common
             add depend type=incorporate fmri=common@1
             close"""
-        p_B_template = """
+    p_B_template = """
             open B@{ver:d},5.11-0
             add set name=variant.foo value=bar value=baz
             add set name=pkg.depend.install-hold value=B
@@ -4038,18 +4489,18 @@ class TestLinkedInstallHoldRelax(TestPkgLinked):
             add depend type=require fmri=common
             add depend type=incorporate fmri=common@1
             close"""
-        p_C_template = """
+    p_C_template = """
             open C@{ver:d},5.11-0
             add set name=pkg.depend.install-hold value=C
             add depend type=require fmri=common
             add depend type=incorporate fmri=common@1
             close"""
-        p_BB_template = """
+    p_BB_template = """
             open BB@{ver:d},5.11-0
             add depend type=require fmri=B
             add depend type=incorporate fmri=B@{ver:d}
             close"""
-        p_BC_template = """
+    p_BC_template = """
             open BC@{ver:d},5.11-0
             add depend type=require fmri=B
             add depend type=incorporate fmri=B@{ver:d}
@@ -4057,458 +4508,506 @@ class TestLinkedInstallHoldRelax(TestPkgLinked):
             add depend type=incorporate fmri=C@{ver:d}
             close"""
 
-        p_data_template = [
-            p_A_template,
-            p_B_template,
-            p_C_template,
-            p_BB_template,
-            p_BC_template,
-        ]
-        p_data = [p_common]
-        for i in range(4):
-                for j in p_data_template:
-                        p_data.append(j.format(ver=(i + 1)))
-        p_fmri = {}
+    p_data_template = [
+        p_A_template,
+        p_B_template,
+        p_C_template,
+        p_BB_template,
+        p_BC_template,
+    ]
+    p_data = [p_common]
+    for i in range(4):
+        for j in p_data_template:
+            p_data.append(j.format(ver=(i + 1)))
+    p_fmri = {}
 
-        def setUp(self):
-                self.i_count = 2
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test"],
-                    image_count=self.i_count)
+    def setUp(self):
+        self.i_count = 2
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test"], image_count=self.i_count
+        )
 
-                # get repo url
-                self.rurl1 = self.dcs[1].get_repo_url()
+        # get repo url
+        self.rurl1 = self.dcs[1].get_repo_url()
 
-                # populate repository
-                for p in self.p_data:
-                        fmristr = self.pkgsend_bulk(self.rurl1, p)[0]
-                        f = fmri.PkgFmri(fmristr)
-                        pkgstr = "{0}@{1}".format(f.pkg_name, f.version.release)
-                        self.p_fmri[pkgstr] = fmristr
+        # populate repository
+        for p in self.p_data:
+            fmristr = self.pkgsend_bulk(self.rurl1, p)[0]
+            f = fmri.PkgFmri(fmristr)
+            pkgstr = "{0}@{1}".format(f.pkg_name, f.version.release)
+            self.p_fmri[pkgstr] = fmristr
 
-                # setup image names and paths
-                self.i_name = []
-                self.i_path = []
-                self.i_api = []
-                self.i_api_reset = []
-                for i in range(self.i_count):
-                        name = "system:img{0:d}".format(i)
-                        self.i_name.insert(i, name)
-                        self.i_path.insert(i, self.img_path(i))
+        # setup image names and paths
+        self.i_name = []
+        self.i_path = []
+        self.i_api = []
+        self.i_api_reset = []
+        for i in range(self.i_count):
+            name = "system:img{0:d}".format(i)
+            self.i_name.insert(i, name)
+            self.i_path.insert(i, self.img_path(i))
 
-        def __test_linked_install_hold_relax(self, child_pkgs, op, op_args,
-            op_rv=EXIT_OK, variant_out_parent_dep=False, **kwargs):
-                """Verify that all install-holds get relaxed during
-                sync-linked operations."""
+    def __test_linked_install_hold_relax(
+        self,
+        child_pkgs,
+        op,
+        op_args,
+        op_rv=EXIT_OK,
+        variant_out_parent_dep=False,
+        **kwargs,
+    ):
+        """Verify that all install-holds get relaxed during
+        sync-linked operations."""
 
-                # create parent (0), and pull child (1)
-                self._imgs_create(2)
+        # create parent (0), and pull child (1)
+        self._imgs_create(2)
 
-                # install B@2 in the parent
-                self._pkg([0], "install -v B@2")
+        # install B@2 in the parent
+        self._pkg([0], "install -v B@2")
 
-                # install A@1 and B@1 in the child
-                self._pkg([1], "install -v {0}".format(child_pkgs))
+        # install A@1 and B@1 in the child
+        self._pkg([1], "install -v {0}".format(child_pkgs))
 
-                # the parent dependency only exists under variant.foo=bar, if
-                # we change variant.foo the parent dependency should go away.
-                if variant_out_parent_dep:
-                        self._pkg([1], "change-variant variant.foo=baz")
+        # the parent dependency only exists under variant.foo=bar, if
+        # we change variant.foo the parent dependency should go away.
+        if variant_out_parent_dep:
+            self._pkg([1], "change-variant variant.foo=baz")
 
-                # link the two images without syncing packages
-                self._attach_parent([1], 0, args="--linked-md-only")
+        # link the two images without syncing packages
+        self._attach_parent([1], 0, args="--linked-md-only")
 
-                if variant_out_parent_dep:
-                        # verify the child is synced
-                        self._pkg([1], "audit-linked", rv=EXIT_OK)
-                else:
-                        # verify the child is diverged
-                        self._pkg([1], "audit-linked", rv=EXIT_DIVERGED)
+        if variant_out_parent_dep:
+            # verify the child is synced
+            self._pkg([1], "audit-linked", rv=EXIT_OK)
+        else:
+            # verify the child is diverged
+            self._pkg([1], "audit-linked", rv=EXIT_DIVERGED)
 
-                # execute op
-                def output_cb(output):
-                        if op_rv == EXIT_OK:
-                                self.assertEqualParsable(output, **kwargs)
-                self._pkg([1], "{0} --parsable=0 {1}".format(op, op_args),
-                    rv=op_rv, output_cb=output_cb)
+        # execute op
+        def output_cb(output):
+            if op_rv == EXIT_OK:
+                self.assertEqualParsable(output, **kwargs)
 
-        def test_linked_install_hold_relax_all(self):
-                """Verify that all install-holds get relaxed during
-                sync-linked operations."""
+        self._pkg(
+            [1],
+            "{0} --parsable=0 {1}".format(op, op_args),
+            rv=op_rv,
+            output_cb=output_cb,
+        )
 
-                # verify that sync-linked operation relaxes the install-hold
-                # in B and syncs it.
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1", "sync-linked", "",
-                    change_packages=[
-                        [self.p_fmri["B@1"], self.p_fmri["B@2"]]])
+    def test_linked_install_hold_relax_all(self):
+        """Verify that all install-holds get relaxed during
+        sync-linked operations."""
 
-                # if we remove the parent dependency in B it should no longer
-                # change during sync-linked operation.
-                self.__test_linked_install_hold_relax(
-                    "BC@1", "sync-linked", "", op_rv=EXIT_NOP,
-                    variant_out_parent_dep=True)
+        # verify that sync-linked operation relaxes the install-hold
+        # in B and syncs it.
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1",
+            "sync-linked",
+            "",
+            change_packages=[[self.p_fmri["B@1"], self.p_fmri["B@2"]]],
+        )
 
-        def test_linked_install_hold_relax_constrained_1(self):
-                """Verify that any install-holds which are associated with
-                constrained packages (ie, packages with parent dependencies)
-                get relaxed during install, uninstall and similar
-                operations.
+        # if we remove the parent dependency in B it should no longer
+        # change during sync-linked operation.
+        self.__test_linked_install_hold_relax(
+            "BC@1",
+            "sync-linked",
+            "",
+            op_rv=EXIT_NOP,
+            variant_out_parent_dep=True,
+        )
 
-                In our child image we'll install 3 packages, A, B, C, all at
-                version 1.  pkg A, B, and C, all have install holds.  pkg B
-                has a parent dependency and is out of sync.
+    def test_linked_install_hold_relax_constrained_1(self):
+        """Verify that any install-holds which are associated with
+        constrained packages (ie, packages with parent dependencies)
+        get relaxed during install, uninstall and similar
+        operations.
 
-                We will modify the child image without touching pkg B directly
-                and then verify that the install hold in B gets relaxed, there
-                by allowing the image to be synced."""
+        In our child image we'll install 3 packages, A, B, C, all at
+        version 1.  pkg A, B, and C, all have install holds.  pkg B
+        has a parent dependency and is out of sync.
 
-                # verify install
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1", "install", "A@2",
-                    change_packages=[
-                        [self.p_fmri["A@1"], self.p_fmri["A@2"]],
-                        [self.p_fmri["B@1"], self.p_fmri["B@2"]]])
+        We will modify the child image without touching pkg B directly
+        and then verify that the install hold in B gets relaxed, there
+        by allowing the image to be synced."""
 
-                # verify update pkg
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1", "update", "A@2",
-                    change_packages=[
-                        [self.p_fmri["A@1"], self.p_fmri["A@2"]],
-                        [self.p_fmri["B@1"], self.p_fmri["B@2"]]])
+        # verify install
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1",
+            "install",
+            "A@2",
+            change_packages=[
+                [self.p_fmri["A@1"], self.p_fmri["A@2"]],
+                [self.p_fmri["B@1"], self.p_fmri["B@2"]],
+            ],
+        )
 
-                # verify uninstall
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1", "uninstall", "A@1",
-                    remove_packages=[
-                        self.p_fmri["A@1"]],
-                    change_packages=[
-                        [self.p_fmri["B@1"], self.p_fmri["B@2"]]])
+        # verify update pkg
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1",
+            "update",
+            "A@2",
+            change_packages=[
+                [self.p_fmri["A@1"], self.p_fmri["A@2"]],
+                [self.p_fmri["B@1"], self.p_fmri["B@2"]],
+            ],
+        )
 
-                # verify change-variant
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1", "change-variant", "variant.haha=hoho",
-                    change_variants=[
-                        ['variant.haha', 'hoho']],
-                    change_packages=[
-                        [self.p_fmri["B@1"], self.p_fmri["B@2"]]])
+        # verify uninstall
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1",
+            "uninstall",
+            "A@1",
+            remove_packages=[self.p_fmri["A@1"]],
+            change_packages=[[self.p_fmri["B@1"], self.p_fmri["B@2"]]],
+        )
 
-                # verify change-facet
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1", "change-facet", "facet.haha=False",
-                    change_facets=[
-                        ['facet.haha', False, None, 'local', False, False]],
-                    change_packages=[
-                        [self.p_fmri["B@1"], self.p_fmri["B@2"]]])
+        # verify change-variant
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1",
+            "change-variant",
+            "variant.haha=hoho",
+            change_variants=[["variant.haha", "hoho"]],
+            change_packages=[[self.p_fmri["B@1"], self.p_fmri["B@2"]]],
+        )
 
-        def test_linked_install_hold_relax_constrained_2(self):
-                """Verify that any install-holds which are not associated with
-                constrained packages (ie, packages with parent dependencies)
-                don't get relaxed during install, uninstall and similar
-                operations.
+        # verify change-facet
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1",
+            "change-facet",
+            "facet.haha=False",
+            change_facets=[["facet.haha", False, None, "local", False, False]],
+            change_packages=[[self.p_fmri["B@1"], self.p_fmri["B@2"]]],
+        )
 
-                In our child image we'll install 4 packages, A, B, C, and BC,
-                all at version 1.  pkg A, B, and C, all have install holds.
-                pkg B has a parent dependency and is out of sync.  pkg BC
-                incorporates B and C and links their versions together.
+    def test_linked_install_hold_relax_constrained_2(self):
+        """Verify that any install-holds which are not associated with
+        constrained packages (ie, packages with parent dependencies)
+        don't get relaxed during install, uninstall and similar
+        operations.
 
-                The child image is out of sync. we should be able to
-                manipulate it, but we won't be able to bring it in sync
-                because of the install hold in C."""
+        In our child image we'll install 4 packages, A, B, C, and BC,
+        all at version 1.  pkg A, B, and C, all have install holds.
+        pkg B has a parent dependency and is out of sync.  pkg BC
+        incorporates B and C and links their versions together.
 
-                # verify install
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1 BC@1", "install", "A@2",
-                    change_packages=[
-                        [self.p_fmri["A@1"], self.p_fmri["A@2"]]])
+        The child image is out of sync. we should be able to
+        manipulate it, but we won't be able to bring it in sync
+        because of the install hold in C."""
 
-                # verify update pkg
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1 BC@1", "update", "A@2",
-                    change_packages=[
-                        [self.p_fmri["A@1"], self.p_fmri["A@2"]]])
+        # verify install
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1 BC@1",
+            "install",
+            "A@2",
+            change_packages=[[self.p_fmri["A@1"], self.p_fmri["A@2"]]],
+        )
 
-                # verify uninstall
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1 BC@1", "uninstall", "A@1",
-                    remove_packages=[
-                        self.p_fmri["A@1"]])
+        # verify update pkg
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1 BC@1",
+            "update",
+            "A@2",
+            change_packages=[[self.p_fmri["A@1"], self.p_fmri["A@2"]]],
+        )
 
-                # verify change-variant
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1 BC@1", "change-variant", "variant.haha=hoho",
-                    change_variants=[
-                        ['variant.haha', 'hoho']])
+        # verify uninstall
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1 BC@1",
+            "uninstall",
+            "A@1",
+            remove_packages=[self.p_fmri["A@1"]],
+        )
 
-                # verify change-facet
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1 BC@1", "change-facet", "facet.haha=False",
-                    change_facets=[
-                        ['facet.haha', False, None, 'local', False, False]])
+        # verify change-variant
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1 BC@1",
+            "change-variant",
+            "variant.haha=hoho",
+            change_variants=[["variant.haha", "hoho"]],
+        )
 
-        def test_linked_install_hold_relax_constrained_3(self):
-                """Verify that any install-holds which are not associated with
-                constrained packages (ie, packages with parent dependencies)
-                don't get relaxed during install, uninstall and similar
-                operations.
+        # verify change-facet
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1 BC@1",
+            "change-facet",
+            "facet.haha=False",
+            change_facets=[["facet.haha", False, None, "local", False, False]],
+        )
 
-                In our child image we'll install 4 packages, A, B, C, and BC,
-                all at version 1.  pkg A, B, and C, all have install holds.
-                pkg B has a parent dependency and is out of sync.  pkg BC
-                incorporates B and C and links their versions together.
+    def test_linked_install_hold_relax_constrained_3(self):
+        """Verify that any install-holds which are not associated with
+        constrained packages (ie, packages with parent dependencies)
+        don't get relaxed during install, uninstall and similar
+        operations.
 
-                We'll try to update BC, which should fail because of the
-                install hold in C."""
+        In our child image we'll install 4 packages, A, B, C, and BC,
+        all at version 1.  pkg A, B, and C, all have install holds.
+        pkg B has a parent dependency and is out of sync.  pkg BC
+        incorporates B and C and links their versions together.
 
-                # verify install
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1 BC@1", "install", "BC@2", op_rv=EXIT_OOPS)
+        We'll try to update BC, which should fail because of the
+        install hold in C."""
 
-                # verify update pkg
-                self.__test_linked_install_hold_relax(
-                    "A@1 B@1 C@1 BC@1", "update", "BC@2", op_rv=EXIT_OOPS)
+        # verify install
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1 BC@1", "install", "BC@2", op_rv=EXIT_OOPS
+        )
 
-        def test_linked_install_hold_relax_constrained_4(self):
-                """Verify that any install-holds which are not associated with
-                constrained packages (ie, packages with parent dependencies)
-                don't get relaxed during install, uninstall and similar
-                operations.
+        # verify update pkg
+        self.__test_linked_install_hold_relax(
+            "A@1 B@1 C@1 BC@1", "update", "BC@2", op_rv=EXIT_OOPS
+        )
 
-                In our child image we'll install 1 package, B@1.  pkg B has an
-                install hold and a parent dependency, but its parent
-                dependency is disabled by a variant, so the image is in sync.
+    def test_linked_install_hold_relax_constrained_4(self):
+        """Verify that any install-holds which are not associated with
+        constrained packages (ie, packages with parent dependencies)
+        don't get relaxed during install, uninstall and similar
+        operations.
 
-                We'll try to install package BC@2, which should fail because
-                of the install hold in B."""
+        In our child image we'll install 1 package, B@1.  pkg B has an
+        install hold and a parent dependency, but its parent
+        dependency is disabled by a variant, so the image is in sync.
 
-                # verify install
-                self.__test_linked_install_hold_relax(
-                    "B@1", "install", "BC@2", op_rv=EXIT_OOPS,
-                    variant_out_parent_dep=True)
+        We'll try to install package BC@2, which should fail because
+        of the install hold in B."""
+
+        # verify install
+        self.__test_linked_install_hold_relax(
+            "B@1",
+            "install",
+            "BC@2",
+            op_rv=EXIT_OOPS,
+            variant_out_parent_dep=True,
+        )
 
 
 class TestPkgLinkedScale(pkg5unittest.ManyDepotTestCase):
-        """Test the scalability of the linked image subsystem."""
+    """Test the scalability of the linked image subsystem."""
 
-        max_image_count = 256
-        if six.PY3:
-                max_image_count = 32
+    max_image_count = 256
+    if six.PY3:
+        max_image_count = 32
 
-        p_sync1 = []
-        p_vers = [
-            "@1.2,5.11-145:19700101T000001Z",
-            "@1.2,5.11-145:19700101T000000Z", # old time
-            "@1.1,5.11-145:19700101T000000Z", # old ver
-            "@1.1,5.11-144:19700101T000000Z", # old build
-            "@1.0,5.11-144:19700101T000000Z", # oldest
-        ]
-        p_files = [
-            "tmp/bar",
-            "tmp/baz",
-        ]
+    p_sync1 = []
+    p_vers = [
+        "@1.2,5.11-145:19700101T000001Z",
+        "@1.2,5.11-145:19700101T000000Z",  # old time
+        "@1.1,5.11-145:19700101T000000Z",  # old ver
+        "@1.1,5.11-144:19700101T000000Z",  # old build
+        "@1.0,5.11-144:19700101T000000Z",  # oldest
+    ]
+    p_files = [
+        "tmp/bar",
+        "tmp/baz",
+    ]
 
-        # generate packages that do need to be synced
-        p_sync1_name_gen = "sync1"
-        pkgs = ["sync1" + ver for ver in p_vers]
-        p_sync1_name = dict(zip(range(len(pkgs)), pkgs))
-        for i in p_sync1_name:
-                p_data = "open {0}\n".format(p_sync1_name[i])
-                p_data += "add depend type=parent fmri={0}".format(
-                    pkg.actions.depend.DEPEND_SELF)
-                p_data += """
+    # generate packages that do need to be synced
+    p_sync1_name_gen = "sync1"
+    pkgs = ["sync1" + ver for ver in p_vers]
+    p_sync1_name = dict(zip(range(len(pkgs)), pkgs))
+    for i in p_sync1_name:
+        p_data = "open {0}\n".format(p_sync1_name[i])
+        p_data += "add depend type=parent fmri={0}".format(
+            pkg.actions.depend.DEPEND_SELF
+        )
+        p_data += """
                     close\n"""
-                p_sync1.append(p_data)
+        p_sync1.append(p_data)
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test"],
-                    image_count=self.max_image_count)
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test"], image_count=self.max_image_count
+        )
 
-                # create files that go in packages
-                self.make_misc_files(self.p_files)
+        # create files that go in packages
+        self.make_misc_files(self.p_files)
 
-                # get repo url
-                self.rurl1 = self.dcs[1].get_repo_url()
+        # get repo url
+        self.rurl1 = self.dcs[1].get_repo_url()
 
-                # populate repository
-                self.pkgsend_bulk(self.rurl1, self.p_sync1)
+        # populate repository
+        self.pkgsend_bulk(self.rurl1, self.p_sync1)
 
-        def __req_phys_mem(self, phys_mem_req):
-                """Verify that the current machine has a minimal amount of
-                physical memory (in GB).  If it doesn't raise
-                TestSkippedException."""
+    def __req_phys_mem(self, phys_mem_req):
+        """Verify that the current machine has a minimal amount of
+        physical memory (in GB).  If it doesn't raise
+        TestSkippedException."""
 
-                psize = os.sysconf(os.sysconf_names["SC_PAGESIZE"])
-                ppages = os.sysconf(os.sysconf_names["SC_PHYS_PAGES"])
-                phys_mem = psize * ppages / 1024.0 / 1024.0 / 1024.0
+        psize = os.sysconf(os.sysconf_names["SC_PAGESIZE"])
+        ppages = os.sysconf(os.sysconf_names["SC_PHYS_PAGES"])
+        phys_mem = psize * ppages / 1024.0 / 1024.0 / 1024.0
 
-                if phys_mem < phys_mem_req:
-                        raise pkg5unittest.TestSkippedException(
-                            "Not enough memory, "\
-                            "{0:f} GB required, {1:f} GB detected.\n".format(
-                            phys_mem_req, phys_mem))
+        if phys_mem < phys_mem_req:
+            raise pkg5unittest.TestSkippedException(
+                "Not enough memory, "
+                "{0:f} GB required, {1:f} GB detected.\n".format(
+                    phys_mem_req, phys_mem
+                )
+            )
 
-        def pkg(self, *args, **kwargs):
-                """This is a wrapper function to disable coverage for all
-                tests in this class since these are essentially stress tests.
-                we don't need the coverage data (since other functional tests
-                should have already covered these code paths) and we don't
-                want the added overhead of gathering coverage data (since we
-                want to use all available resource for actually running the
-                tests)."""
+    def pkg(self, *args, **kwargs):
+        """This is a wrapper function to disable coverage for all
+        tests in this class since these are essentially stress tests.
+        we don't need the coverage data (since other functional tests
+        should have already covered these code paths) and we don't
+        want the added overhead of gathering coverage data (since we
+        want to use all available resource for actually running the
+        tests)."""
 
-                kwargs["coverage"] = False
-                return pkg5unittest.ManyDepotTestCase.pkg(self, *args,
-                    **kwargs);
+        kwargs["coverage"] = False
+        return pkg5unittest.ManyDepotTestCase.pkg(self, *args, **kwargs)
 
-        def test_li_scale(self):
-                """Verify that we can operate on a large number of linked
-                images in parallel.
+    def test_li_scale(self):
+        """Verify that we can operate on a large number of linked
+        images in parallel.
 
-                For parallel linked image operations, 256 images is high
-                enough to cause file descriptor allocation to exceed
-                FD_SETSIZE, which in turn can cause select.select() to fail if
-                it's invoked.  In practice that's the only failure mode we've
-                ever seen when people have tried to update a large number of
-                zones in parallel.
+        For parallel linked image operations, 256 images is high
+        enough to cause file descriptor allocation to exceed
+        FD_SETSIZE, which in turn can cause select.select() to fail if
+        it's invoked.  In practice that's the only failure mode we've
+        ever seen when people have tried to update a large number of
+        zones in parallel.
 
-                The maximum value successfully tested here has been 512.  I
-                tried 1024 but it resulted in death by swapping on a u27 with
-                12 GB of memory.
+        The maximum value successfully tested here has been 512.  I
+        tried 1024 but it resulted in death by swapping on a u27 with
+        12 GB of memory.
 
-                Under Python 3, the maximum value successfully tested is 32.
-                I tried 64 but it resulted in "too many open files" on s12_89 on
-                a ThinkCentre M93p with 16 GB of memory.
-                """
+        Under Python 3, the maximum value successfully tested is 32.
+        I tried 64 but it resulted in "too many open files" on s12_89 on
+        a ThinkCentre M93p with 16 GB of memory.
+        """
 
-                # we will require at least 11 GB of memory to run this test.
-                # This is a rough estimate of required memory based on
-                # observing this test running on s12_20 on an x86 machine.  on
-                # that machine i observed the peak RSS for pkg child process
-                # was about 24 MB.  with 256 child processes this comes out to
-                # about 6 GB of memory.  we require 11 GB so that the machine
-                # doesn't get bogged down and other things can continue to
-                # run.
-                self.__req_phys_mem(11)
+        # we will require at least 11 GB of memory to run this test.
+        # This is a rough estimate of required memory based on
+        # observing this test running on s12_20 on an x86 machine.  on
+        # that machine i observed the peak RSS for pkg child process
+        # was about 24 MB.  with 256 child processes this comes out to
+        # about 6 GB of memory.  we require 11 GB so that the machine
+        # doesn't get bogged down and other things can continue to
+        # run.
+        self.__req_phys_mem(11)
 
-                limit = self.max_image_count
+        limit = self.max_image_count
 
-                # create an image with a synced package
-                self.set_image(0)
-                self.image_create(repourl=self.rurl1)
-                self.pkg("install -v {0}".format(self.p_sync1_name[1]))
+        # create an image with a synced package
+        self.set_image(0)
+        self.image_create(repourl=self.rurl1)
+        self.pkg("install -v {0}".format(self.p_sync1_name[1]))
 
-                # create copies of the image.
-                for i in range(1, self.max_image_count):
-                        self.image_clone(i)
+        # create copies of the image.
+        for i in range(1, self.max_image_count):
+            self.image_clone(i)
 
-                # attach the copies as children of the original image
-                for i in range(1, self.max_image_count):
-                        name = "system:img{0:d}".format(i)
-                        cmd = "attach-linked --linked-md-only -c {0} {1}".format(
-                            name, self.img_path(i))
-                        self.pkg(cmd)
+        # attach the copies as children of the original image
+        for i in range(1, self.max_image_count):
+            name = "system:img{0:d}".format(i)
+            cmd = "attach-linked --linked-md-only -c {0} {1}".format(
+                name, self.img_path(i)
+            )
+            self.pkg(cmd)
 
-                # update the parent image and all child images in parallel
-                self.pkg("update -C0 -q")
+        # update the parent image and all child images in parallel
+        self.pkg("update -C0 -q")
 
 
 class TestPkgLinkedPaths(pkg5unittest.ManyDepotTestCase):
-        """Class to test linked image path management."""
+    """Class to test linked image path management."""
 
-        #
-        # linked image types
-        #
-        T_NONE = "none"
-        T_PUSH = "push"
-        T_PULL = "pull"
+    #
+    # linked image types
+    #
+    T_NONE = "none"
+    T_PUSH = "push"
+    T_PULL = "pull"
 
-        #
-        # Linked image trees for testing.
-        # All trees have an implicit parent node of type T_NONE.
-        # Trees are defined by a vector with up to four elements:
-        #     child 1: parented to root image
-        #     child 2: parented to root image
-        #     child 3: parented to child 1
-        #     child 4: parented to child 1
-        #
-        t_vec_list = [
-                [ T_PUSH ],
-                [ T_PULL ],
-                [ T_PUSH, T_PULL ],
+    #
+    # Linked image trees for testing.
+    # All trees have an implicit parent node of type T_NONE.
+    # Trees are defined by a vector with up to four elements:
+    #     child 1: parented to root image
+    #     child 2: parented to root image
+    #     child 3: parented to child 1
+    #     child 4: parented to child 1
+    #
+    t_vec_list = [
+        [T_PUSH],
+        [T_PULL],
+        [T_PUSH, T_PULL],
+        [T_PUSH, T_NONE, T_PUSH],
+        [T_PUSH, T_NONE, T_PULL],
+        [T_PUSH, T_NONE, T_PUSH, T_PULL],
+        [T_PULL, T_NONE, T_PUSH],
+        [T_PULL, T_NONE, T_PULL],
+        [T_PULL, T_NONE, T_PUSH, T_PULL],
+    ]
 
-                [ T_PUSH, T_NONE, T_PUSH ],
-                [ T_PUSH, T_NONE, T_PULL ],
-                [ T_PUSH, T_NONE, T_PUSH, T_PULL ],
+    #
+    # Linked image child locations.
+    #
+    L_CNEST = "children are nested"
+    L_CPARALLEL = "children are parallel to parent"
+    L_CBELOW = "children are below parent, but not nested"
+    L_CABOVE = "children are above parent, but not nested"
+    l_list = [L_CNEST, L_CPARALLEL, L_CBELOW, L_CABOVE]
 
-                [ T_PULL, T_NONE, T_PUSH ],
-                [ T_PULL, T_NONE, T_PULL ],
-                [ T_PULL, T_NONE, T_PUSH, T_PULL ],
-        ]
+    #
+    # Linked image directory location vectors.
+    # Location vectors consist of 5 image locations:
+    #       root image path
+    #       child 1 path
+    #       child 2 path
+    #       child 3 path
+    #       child 4 path
+    #       child 5 path
+    #
+    l_vec_dict = {
+        L_CNEST: ["./", "d/", "d1/", "d/d/", "d/d1/"],
+        L_CPARALLEL: ["d/", "d1/", "d2/", "d3/", "d4/"],
+        L_CBELOW: ["d/", "d1/d/", "d2/d/", "d3/d1/d/", "d3/d2/d/"],
+        L_CABOVE: ["d/d/d/", "d/d1/", "d/d2/", "d1/", "d2/"],
+    }
 
-        #
-        # Linked image child locations.
-        #
-        L_CNEST = "children are nested"
-        L_CPARALLEL = "children are parallel to parent"
-        L_CBELOW = "children are below parent, but not nested"
-        L_CABOVE = "children are above parent, but not nested"
-        l_list = [ L_CNEST, L_CPARALLEL, L_CBELOW, L_CABOVE ]
+    path_start = "d1/p/p"
+    path_tests = [
+        # test directory moves down
+        # (tests beadm mount <be> /a; pkg -R /a type behavior)
+        "d1/p/p/a",
+        "d1/p/p/d1/p/p",
+        # test directory moves up
+        "d1/p",
+        "d1",
+        # test parallel directory moves
+        "d1/p/b",
+        "d2/p/p",
+        "d2/p",  # and up
+        "d2/p/p/a",  # and down
+    ]
 
-        #
-        # Linked image directory location vectors.
-        # Location vectors consist of 5 image locations:
-        #       root image path
-        #       child 1 path
-        #       child 2 path
-        #       child 3 path
-        #       child 4 path
-        #       child 5 path
-        #
-        l_vec_dict = {
-            L_CNEST:     [ "./",     "d/",    "d1/",   "d/d/",     "d/d1/"    ],
-            L_CPARALLEL: [ "d/",     "d1/",   "d2/",   "d3/",      "d4/"      ],
-            L_CBELOW:    [ "d/",     "d1/d/", "d2/d/", "d3/d1/d/", "d3/d2/d/" ],
-            L_CABOVE:    [ "d/d/d/", "d/d1/", "d/d2/", "d1/",      "d2/"      ],
-        }
+    p_sync1 = []
+    p_vers = [
+        "@1.2,5.11-145:19700101T000001Z",
+        "@1.2,5.11-145:19700101T000000Z",  # old time
+        "@1.1,5.11-145:19700101T000000Z",  # old ver
+        "@1.1,5.11-144:19700101T000000Z",  # old build
+        "@1.0,5.11-144:19700101T000000Z",  # oldest
+    ]
+    p_files = [
+        "tmp/bar",
+        "tmp/baz",
+    ]
 
-        path_start = "d1/p/p"
-        path_tests = [
-                # test directory moves down
-                # (tests beadm mount <be> /a; pkg -R /a type behavior)
-                "d1/p/p/a",
-                "d1/p/p/d1/p/p",
-
-                # test directory moves up
-                "d1/p",
-                "d1",
-
-                # test parallel directory moves
-                "d1/p/b",
-                "d2/p/p",
-                "d2/p",     # and up
-                "d2/p/p/a", # and down
-        ]
-
-        p_sync1 = []
-        p_vers = [
-            "@1.2,5.11-145:19700101T000001Z",
-            "@1.2,5.11-145:19700101T000000Z", # old time
-            "@1.1,5.11-145:19700101T000000Z", # old ver
-            "@1.1,5.11-144:19700101T000000Z", # old build
-            "@1.0,5.11-144:19700101T000000Z", # oldest
-        ]
-        p_files = [
-            "tmp/bar",
-            "tmp/baz",
-        ]
-
-        # fake zonename binary used for testing
-        zonename_sh = """
+    # fake zonename binary used for testing
+    zonename_sh = """
 #!/bin/sh
 echo global
-exit 0""".strip("\n")
+exit 0""".strip(
+        "\n"
+    )
 
-        # fake zoneadm binary used for testing
-        zoneadm_sh = """
+    # fake zoneadm binary used for testing
+    zoneadm_sh = """
 #!/bin/sh
 while getopts "R:" OPT ; do
 case $OPT in
@@ -4526,818 +5025,885 @@ cat <<-EOF
 -:kz:installed:$PKG_GZR/system/volatile/zones/kz1/zonepath::solaris-kz:excl:-:solaris-kz:
 -:s10:installed:$PKG_GZR/s10::solaris10:excl:-::
 EOF
-exit 0""".strip("\n")
+exit 0""".strip(
+        "\n"
+    )
 
-        # generate packages that do need to be synced
-        p_sync1_name_gen = "sync1"
-        pkgs = ["sync1" + ver for ver in p_vers]
-        p_sync1_name = dict(zip(range(len(pkgs)), pkgs))
-        for i in p_sync1_name:
-                p_data = "open {0}\n".format(p_sync1_name[i])
-                p_data += "add depend type=parent fmri={0}".format(
-                    pkg.actions.depend.DEPEND_SELF)
-                p_data += """
+    # generate packages that do need to be synced
+    p_sync1_name_gen = "sync1"
+    pkgs = ["sync1" + ver for ver in p_vers]
+    p_sync1_name = dict(zip(range(len(pkgs)), pkgs))
+    for i in p_sync1_name:
+        p_data = "open {0}\n".format(p_sync1_name[i])
+        p_data += "add depend type=parent fmri={0}".format(
+            pkg.actions.depend.DEPEND_SELF
+        )
+        p_data += """
                     close\n"""
-                p_sync1.append(p_data)
-
-        def setUp(self):
-                self.i_count = 3
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test"],
-                    image_count=self.i_count)
-
-                # create files that go in packages
-                self.make_misc_files(self.p_files)
-
-                # get repo url
-                self.rurl1 = self.dcs[1].get_repo_url()
-
-                # populate repository
-                self.pkgsend_bulk(self.rurl1, self.p_sync1)
-
-                # setup image names and paths
-                self.i_name = []
-                self.i_path = []
-                for i in range(self.i_count):
-                        name = "system:img{0:d}".format(i)
-                        self.i_name.insert(i, name)
-                        self.i_path.insert(i, self.img_path(i))
-
-        def __mk_bin(self, path, txt):
-                with open(path, "w+") as fobj:
-                        print(txt, file=fobj)
-                self.cmdline_run("chmod a+x {0}".format(path), coverage=False)
-
-        def __mk_zone_bins(self, base_path):
-
-                # create a zonename binary
-                bin_zonename = os.path.join(base_path, "zonename")
-                self.__mk_bin(bin_zonename, self.zonename_sh)
-
-                # create a zoneadm binary
-                bin_zoneadm = os.path.join(base_path, "zoneadm")
-                self.__mk_bin(bin_zoneadm, self.zoneadm_sh)
-
-                return (bin_zonename, bin_zoneadm)
-
-        def __attach_params(self, base_path, pdir, cdir):
-                ppath = os.path.join(base_path, pdir)
-                cpath = os.path.join(base_path, cdir)
-                # generate child image name based on the child image dir
-                cname = re.sub('[/]', '_', cdir.rstrip(os.sep))
-                return ppath, cpath, cname
-
-        def __attach_child(self, base_path, pdir, cdir, exit=EXIT_OK):
-                ppath, cpath, cname = \
-                    self.__attach_params(base_path, pdir, cdir)
-                self.pkg("-R {0} attach-linked -c system:{1} {2}".format(
-                    ppath, cname, cpath), exit=exit)
-
-        def __attach_parent(self, base_path, cdir, pdir, exit=EXIT_OK):
-                ppath, cpath, cname = \
-                    self.__attach_params(base_path, pdir, cdir)
-                self.pkg("-R {0} attach-linked -p system:{1} {2}".format(
-                    cpath, cname, ppath), exit=exit)
-
-        def __try_attach(self, base_path, i1, i2):
-                self.__attach_child(base_path, i1, i2, exit=EXIT_OOPS)
-                self.__attach_parent(base_path, i1, i2, exit=EXIT_OOPS)
-
-        def __create_images(self, base_path, img_dirs, repos=None):
-                """Create images (in directory order)"""
-                for d in sorted(img_dirs):
-                        p = os.path.join(base_path, d)
-                        self.cmdline_run("mkdir -p {0}".format(p), coverage=False)
-                        self.image_create(self.rurl1, destroy=False, img_path=p)
-
-        def __define_limages(self, base_path, types, locs):
-                """Given a vector of linked image types and locations, return
-                a list of linked images.  The format of returned list entries
-                is:
-                        <image dir, image type, parent dir>
-                """
-
-                limages = []
-                index = 0
-                assert len(types) <= len(locs)
-
-                # first image is always a parent
-                limages.append([locs[0], self.T_NONE, None])
-
-                for t in types:
-                        index += 1
-
-                        # determine child and parent paths
-                        cdir = locs[index]
-                        pdir = None
-                        if index in [1, 2]:
-                                pdir = locs[0]
-                        elif index in [3, 4]:
-                                pdir = locs[1]
-                        else:
-                                assert "invalid index: ", index
-                        assert pdir is not None
-
-                        # skip this image
-                        if t == self.T_NONE:
-                                continue
-
-                        # add image to the list
-                        limages.append([cdir, t, pdir])
-
-                return limages
-
-        def __create_limages(self, base_path, limages):
-                """Create images (in directory order)"""
-                img_dirs = [
-                        cdir
-                        for cdir, t, pdir in limages
-                ]
-                self.__create_images(base_path, img_dirs)
-
-        def __attach_limages(self, base_path, limages):
-                """Attach images"""
-                for cdir, t, pdir in limages:
-                        if t == self.T_NONE:
-                                continue
-                        if t == self.T_PUSH:
-                                self.__attach_child(base_path, pdir, cdir)
-                                continue
-                        assert t == self.T_PULL
-                        self.__attach_parent(base_path, cdir, pdir)
-
-        def __audit_limages(self, base_path, limages):
-                """Audit images"""
-
-                parents = set([
-                    pdir
-                    for cdir, t, pdir in limages
-                    if t == self.T_PUSH
-                ])
-                for pdir in parents:
-                        p = os.path.join(base_path, pdir)
-                        self.pkg("-R {0} audit-linked -a".format(p))
-
-                children = set([
-                    cdir
-                    for cdir, t, pdir in limages
-                    if t != self.T_NONE
-                ])
-                for pdir in parents:
-                        p = os.path.join(base_path, limages[-1][0])
-                        self.pkg("-R {0} audit-linked".format(p))
-
-        def __ccmd(self, args, rv=0):
-                """Run a 'C' (or other non-python) command."""
-                assert type(args) == str
-                # Ensure 'coverage' is turned off-- it won't work.
-                self.cmdline_run("{0}".format(args), exit=rv, coverage=False)
-
-        def __list_linked_check(self, ipath, lipaths,
-            bin_zonename, bin_zoneadm):
-                """Given an image path (ipath), verify that pkg list-linked
-                displays the expected linked image paths (lipaths).  The
-                caller must specify paths to custom zonename and zoneadm
-                binaries that will output from those commands."""
-
-                outfile1 = os.path.join(ipath, "__list_linked_check")
-
-                self.pkg("--debug zones_supported=1 "
-                    "--debug bin_zonename='{0}' "
-                    "--debug bin_zoneadm='{1}' "
-                    "-R {2} list-linked > {3}".format(
-                    bin_zonename, bin_zoneadm, ipath, outfile1))
-                self.__ccmd("cat {0}".format(outfile1))
-                for lipath in lipaths:
-                        self.__ccmd("egrep '[ 	]{0}[ 	]*$' {1}".format(
-                            lipath, outfile1))
-
-        def __check_linked_props(self, ipath, liname, props,
-            bin_zonename, bin_zoneadm):
-                """Given an image path (ipath), verify that pkg
-                property-linked displays the expected linked image properties.
-                (props).  The caller must specify paths to custom zonename and
-                zoneadm binaries that will output from those commands."""
-
-                outfile1 = os.path.join(ipath, "__check_linked_props1")
-                outfile2 = os.path.join(ipath, "__check_linked_props2")
-
-                if liname:
-                        liname = "-l " + liname
-                else:
-                        liname = ""
-
-                self.pkg("--debug zones_supported=1 "
-                    "--debug bin_zonename='{0}' "
-                    "--debug bin_zoneadm='{1}' "
-                    "-R {2} property-linked {3} -H > {4}".format(
-                    bin_zonename, bin_zoneadm,
-                    ipath, liname, outfile1))
-                self.__ccmd("cat {0}".format(outfile1))
-
-                for p, v in six.iteritems(props):
-                        if v is None:
-                                # verify property is not present
-                                self.__ccmd(
-                                    "grep \"^{0}[ 	]\" {1}".format(
-                                    p, outfile1), rv=1)
-                                continue
-
-                        # verify property and value
-                        self.__ccmd("grep \"^{0}[ 	]\" {1} > {2}".format(
-                            p, outfile1, outfile2))
-                        self.__ccmd("cat {0}".format(outfile2))
-                        # verify property and value
-                        self.__ccmd("grep \"[ 	]{0}[ 	]*$\" {1}".format(
-                            v, outfile2))
-
-        def test_linked_paths_moves(self):
-                """Create trees of linked images, with different relative path
-                configurations.  Then move each tree to a different locations
-                and see if the images within each tree can still find each
-                other."""
-
-                tmp_path = os.path.join(self.img_path(0), "tmp")
-                base_path = os.path.join(self.img_path(0), "images")
-
-                for t_vec, loc in itertools.product(
-                    self.t_vec_list, self.l_list):
-
-                        l_vec = self.l_vec_dict[loc]
-
-                        pcur = os.path.join(base_path, self.path_start)
-
-                        # create and link image tree
-                        limages = self.__define_limages(pcur, t_vec, l_vec)
-                        self.__create_limages(pcur, limages)
-                        self.__attach_limages(pcur, limages)
-
-                        for pnew in self.path_tests:
-
-                                assert limages
-                                assert pcur != pnew
-
-                                # determine the parent images new location
-                                pnew = os.path.join(base_path, pnew)
-
-                                # move the parent to a temporary location
-                                self.__ccmd("mv {0} {1}".format(pcur, tmp_path))
-
-                                # cleanup old directory, avoid "rm -rf"
-                                d = pcur
-                                while True:
-                                        d = os.path.dirname(d)
-                                        if len(d) <= len(base_path):
-                                                break
-                                        self.__ccmd("rmdir {0}".format(d))
-
-                                # move the parent to it's new location
-                                self.__ccmd(
-                                    "mkdir -p {0}".format(os.path.dirname(pnew)))
-                                self.__ccmd("mv {0} {1}".format(tmp_path, pnew))
-
-                                # verify that the images can find each other
-                                self.__audit_limages(pnew, limages)
-
-                                # save the parent images last location
-                                pcur = pnew
-
-                        # cleanup current image tree
-                        shutil.rmtree(base_path)
-
-
-        def test_linked_paths_no_self_link(self):
-                """You can't link images to themselves."""
-
-                base_path = self.img_path(0)
-                img_dirs = [ "./" ]
-                self.__create_images(base_path, img_dirs)
-                self.__try_attach(base_path, "./", "./")
-
-        def test_linked_paths_no_nested_parent(self):
-                """You can't link images if the parent image is nested within
-                the child."""
-
-                base_path = self.img_path(0)
-                img_dirs = [ "./", "1/" ]
-
-                self.__create_images(base_path, img_dirs)
-
-                self.__attach_child(base_path, "1/", "./", exit=EXIT_OOPS)
-                self.__attach_parent(base_path, "./", "1/", exit=EXIT_OOPS)
-
-        def test_linked_paths_no_liveroot_child(self):
-                """You can't link the liveroot image as a child."""
-
-                base_path = self.img_path(0)
-                img_dirs = [ "./", "1/" ]
-
-                self.__create_images(base_path, img_dirs)
-
-                ppath, cpath, cname = \
-                    self.__attach_params(base_path, "./", "1/")
-
-                self.pkg("--debug simulate_live_root='{0}' "
-                    "-R {1} attach-linked -c system:{2} {3}".format(
-                    cpath, ppath, cname, cpath), exit=EXIT_OOPS)
-                self.pkg("--debug simulate_live_root='{0}' "
-                    "-R {1} attach-linked -p system:{2} {3}".format(
-                    cpath, cpath, cname, ppath), exit=EXIT_OOPS)
-
-        def test_linked_paths_no_intermediate_imgs(self):
-                """You can't link images if there are intermediate image in
-                between."""
-
-                base_path = self.img_path(0)
-                img_dirs = [ "./", "1/", "1/11/", "2/" ]
-
-                self.__create_images(base_path, img_dirs)
-
-                # can't link "./" and "1/11/" because "1/" is inbetween
-                self.__try_attach(base_path, "./", "1/11/")
-
-                # can't link "1/" and "2/" because "./" is in between
-                self.__try_attach(base_path, "1/", "2/")
-
-        def test_linked_paths_no_attach_in_temporary_location(self):
-                """You can't link images if we're operating on already linked
-                images in temporary locations."""
-
-                base_path = os.path.join(self.img_path(0), "images1")
-                img_dirs = [ "./",
-                    "p/",
-                    "p/1/", "p/2/", "p/3/",
-                    "p/1/11/", "p/2/22/"
-                ]
-
-                self.__create_images(base_path, img_dirs)
-                self.__attach_child(base_path,  "p/", "p/1/")
-                self.__attach_parent(base_path, "p/2/", "p/")
-
-                # move the images
-                pnew = os.path.join(self.img_path(0), "images2")
-                self.__ccmd("mv {0} {1}".format(base_path, pnew))
-                base_path = pnew
-
-                self.__attach_parent(base_path, "p/",   "./",
-                    exit=EXIT_OOPS)
-                self.__attach_child(base_path,  "p/",   "p/3/",
-                    exit=EXIT_OOPS)
-                self.__attach_child(base_path,  "p/1/", "p/1/11/",
-                    exit=EXIT_OOPS)
-                self.__attach_child(base_path,  "p/2/", "p/2/22/",
-                    exit=EXIT_OOPS)
-
-        def test_linked_paths_staged(self):
-                """Test path handling code with staged operation.  Make sure
-                that we correctly handle images moving around between stages.
-                This simulates normal pkg updates where we plan an update for
-                "/", and then we clone "/", mount it at a  a temporarly
-                location, and then update the clone."""
-
-                tmp_path = os.path.join(self.img_path(0), "tmp")
-                base_path = os.path.join(self.img_path(0), "images")
-
-                t_vec = [ self.T_PUSH, self.T_NONE, self.T_PUSH, self.T_PULL ]
-                l_vec = [ "", "d/", "d1/", "d/d/", "d/d1/"    ]
-                limages = self.__define_limages(base_path, t_vec, l_vec)
-
-                self.__create_limages(base_path, limages)
-                for i in range(len(limages)):
-                        ipath = os.path.join(base_path, limages[i][0])
-                        self.pkg("-R {0} install sync1@1.0".format(ipath))
-                self.__attach_limages(base_path, limages)
-
-                for i in range(len(limages)):
-
-                        # It only makes sense to try and update T_NONE and
-                        # T_PULL images (T_PUSH images will be updated
-                        # implicitly via recursion).
-                        if limages[i][1] == self.T_PUSH:
-                                continue
-
-                        # plan update
-                        ipath = os.path.join(base_path, limages[i][0])
-                        self.pkg("-R {0} update --stage=plan".format(ipath))
-
-                        # move images to /a
-                        self.__ccmd("mv {0} {1}".format(base_path, tmp_path))
-                        new_path = os.path.join(base_path, "a")
-                        self.__ccmd("mkdir -p {0}".format(os.path.dirname(new_path)))
-                        self.__ccmd("mv {0} {1}".format(tmp_path, new_path))
-
-                        # finish update
-                        ipath = os.path.join(new_path, limages[i][0])
-                        self.pkg("-R {0} update --stage=prepare".format(ipath))
-                        self.pkg("-R {0} update --stage=execute".format(ipath))
-
-                        # move images back
-                        # cleanup old directory, avoid "rm -rf"
-                        self.__ccmd("mv {0} {1}".format(new_path, tmp_path))
-                        d = new_path
-                        while True:
-                                d = os.path.dirname(d)
-                                if len(d) < len(base_path):
-                                        break
-                                self.__ccmd("rmdir {0}".format(d))
-                        self.__ccmd("mkdir -p {0}".format(os.path.dirname(base_path)))
-                        self.__ccmd("mv {0} {1}".format(tmp_path, base_path))
-
-        def test_linked_paths_staged_with_zones(self):
-                """Simulate staged packaging operations involving zones."""
-
-                tmp_path = os.path.join(self.img_path(0), "tmp")
-                base_path = os.path.join(self.img_path(0), "images")
-
-                # create a zone binaries
-                bin_zonename, bin_zoneadm = self.__mk_zone_bins(self.test_root)
-
-                # setup image paths
-                img_dirs = [
-                    "", "z1/root"
-                ]
-                gzpath = os.path.join(base_path, img_dirs[0])
-                ngzpath = os.path.join(base_path, img_dirs[1])
-                os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
-
-                # create images, install packages, and link them
-                self.__create_images(base_path, img_dirs)
-                self.pkg("-R {0} install sync1@1.1".format(gzpath))
-                self.pkg("-R {0} install sync1@1.0".format(ngzpath))
-                self.pkg("--debug zones_supported=1 "
-                    "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
-                    "-R {2} attach-linked -v -f -c zone:z1 {3}".format(
-                    bin_zonename, "/bin/true", gzpath, ngzpath))
-
-                # plan update
-                self.pkg("--debug zones_supported=1 "
-                    "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
-                    "-R {2} update -vvv --stage=plan".format(
-                    bin_zonename, bin_zoneadm, gzpath))
-
-                # move images to /a
-                self.__ccmd("mv {0} {1}".format(base_path, tmp_path))
-                base_path = os.path.join(base_path, "a")
-                gzpath = os.path.join(base_path, img_dirs[0])
-                ngzpath = os.path.join(base_path, img_dirs[1])
-                os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
-                self.__ccmd("mkdir -p {0}".format(os.path.dirname(base_path)))
-                self.__ccmd("mv {0} {1}".format(tmp_path, gzpath))
-
-                # finish update
-                self.pkg("--debug zones_supported=1 "
-                    "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
-                    "-R {2} update --stage=prepare".format(
-                    bin_zonename, bin_zoneadm, gzpath))
-                self.pkg("--debug zones_supported=1 "
-                    "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
-                    "-R {2} update --stage=execute".format(
-                    bin_zonename, bin_zoneadm, gzpath))
-
-                # verify that all the images got updated
-                self.pkg("-R {0} list sync1@1.2".format(gzpath))
-                self.pkg("-R {0} list sync1@1.2".format(ngzpath))
-
-                del os.environ["PKG_GZR"]
-
-        def test_linked_paths_list_and_props(self):
-                """Verify that all linked image paths reported by list-linked
-                and property-linked are correct before and after moving trees
-                of images."""
-
-                tmp_path = os.path.join(self.img_path(0), "tmp")
-                base_path = os.path.join(self.img_path(0), "images")
-
-                # create a zone binaries
-                bin_zonename, bin_zoneadm = self.__mk_zone_bins(self.test_root)
-
-                # setup image paths
-                img_dirs = [
-                    "", "s1/", "s2/", "z1/root/"
-                ]
-                img_paths = [
-                        os.path.join(base_path, d)
-                        for d in img_dirs
-                ]
-                gzpath, s1path, s2path, ngzpath = img_paths
-                os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
-
-                # create images and link them
-                self.__create_images(base_path, img_dirs)
-                self.__attach_child(base_path, "", img_dirs[1])
-                self.__attach_parent(base_path, img_dirs[2], "")
-                self.pkg("--debug zones_supported=1 "
-                    "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
-                    "-R {2} attach-linked -v -f -c zone:z1 {3}".format(
-                    bin_zonename, "/bin/true", gzpath, ngzpath))
-
-                # Make sure that list-linked displays the correct paths.
-                for ipath, lipaths in [
-                        [ gzpath,  [ gzpath, s1path, ngzpath ]],
-                        [ s1path,  [ s1path ]],
-                        [ s2path,  [ gzpath, s2path ]],
-                        [ ngzpath, [ ngzpath ]],
-                    ]:
-                        self.__list_linked_check(ipath, lipaths,
-                            bin_zonename, bin_zoneadm)
-
-                # Make sure that property-linked displays the correct paths.
-                for ipath, liname, props in [
-                        [ gzpath, None, {
-                            "li-current-parent": None,
-                            "li-current-path": gzpath,
-                            "li-parent": None,
-                            "li-path": gzpath,
-                            "li-path-transform": "('/', '/')",
-                            }],
-                        [ gzpath, "system:s1", {
-                            "li-current-parent": None,
-                            "li-current-path": s1path,
-                            "li-parent": None,
-                            "li-path": s1path,
-                            "li-path-transform": "('/', '/')",
-                            }],
-                        [ gzpath, "zone:z1", {
-                            "li-current-parent": None,
-                            "li-current-path": ngzpath,
-                            "li-parent": None,
-                            "li-path": ngzpath,
-                            "li-path-transform": "('/', '/')",
-                            }],
-                        [ s1path, None, {
-                            "li-current-parent": None,
-                            "li-current-path": s1path,
-                            "li-parent": None,
-                            "li-path": s1path,
-                            "li-path-transform": "('/', '/')",
-                            }],
-                        [ s2path, None, {
-                            "li-current-parent": gzpath,
-                            "li-current-path": s2path,
-                            "li-parent": gzpath,
-                            "li-path": s2path,
-                            "li-path-transform": "('/', '/')",
-                            }],
-                        [ ngzpath, None, {
-                            "li-current-parent": None,
-                            "li-current-path": ngzpath,
-                            "li-parent": None,
-                            "li-path": "/",
-                            "li-path-transform": "('/', '{0}')".format(ngzpath),
-                            }],
-                    ]:
-                        self.__check_linked_props(ipath, liname, props,
-                            bin_zonename, bin_zoneadm)
-
-                # save old paths
-                ogzpath, os1path, os2path, ongzpath = img_paths
-
-                # move images to /a
-                self.__ccmd("mv {0} {1}".format(base_path, tmp_path))
-                base_path = os.path.join(base_path, "a")
-                self.__ccmd("mkdir -p {0}".format(os.path.dirname(base_path)))
-                self.__ccmd("mv {0} {1}".format(tmp_path, base_path))
-
-                # update paths
-                img_paths = [
-                        os.path.join(base_path, d)
-                        for d in img_dirs
-                ]
-                gzpath, s1path, s2path, ngzpath = img_paths
-                os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
-
-                # Make sure that list-linked displays the correct paths.
-                for ipath, lipaths in [
-                        [ gzpath,  [ gzpath, s1path, ngzpath ]],
-                        [ s1path,  [ s1path ]],
-                        [ s2path,  [ gzpath, s2path ]],
-                        [ ngzpath, [ ngzpath ]],
-                    ]:
-                        self.__list_linked_check(ipath, lipaths,
-                            bin_zonename, bin_zoneadm)
-
-                # Make sure that property-linked displays the correct paths.
-                for ipath, liname, props in [
-                        [ gzpath, None, {
-                            "li-current-parent": None,
-                            "li-current-path": gzpath,
-                            "li-parent": None,
-                            "li-path": ogzpath,
-                            "li-path-transform": "('{0}', '{1}')".format(
-                                ogzpath, gzpath)
-                            }],
-                        [ gzpath, "system:s1", {
-                            "li-current-parent": None,
-                            "li-current-path": s1path,
-                            "li-parent": None,
-                            "li-path": os1path,
-                            "li-path-transform": "('{0}', '{1}')".format(
-                                ogzpath, gzpath)
-                            }],
-                        [ gzpath, "zone:z1", {
-                            "li-current-parent": None,
-                            "li-current-path": ngzpath,
-                            "li-parent": None,
-                            "li-path": ongzpath,
-                            "li-path-transform": "('{0}', '{1}')".format(
-                                ogzpath, gzpath)
-                            }],
-                        [ s1path, None, {
-                            "li-current-parent": None,
-                            "li-current-path": s1path,
-                            "li-parent": None,
-                            "li-path": os1path,
-                            "li-path-transform": "('{0}', '{1}')".format(
-                                ogzpath, gzpath)
-                            }],
-                        [ s2path, None, {
-                            "li-current-parent": gzpath,
-                            "li-current-path": s2path,
-                            "li-parent": ogzpath,
-                            "li-path": os2path,
-                            "li-path-transform": "('{0}', '{1}')".format(
-                                ogzpath, gzpath)
-                            }],
-                        [ ngzpath, None, {
-                            "li-current-parent": None,
-                            "li-current-path": ngzpath,
-                            "li-parent": None,
-                            "li-path": "/",
-                            "li-path-transform": "('/', '{0}')".format(ngzpath),
-                            }],
-                    ]:
-                        self.__check_linked_props(ipath, liname, props,
-                            bin_zonename, bin_zoneadm)
-
-        def test_linked_paths_guess_path_transform(self):
-                """If a parent image has no properties, then rather than
-                throwing an exception (that a user has no way to fix), we try
-                to fabricate some properties to run with.  To do this we ask
-                each linked image plugin if it knows what the current path
-                transform is (which would tell us what original root path was).
-                Only the zones plugin implements this functionality, so test
-                it here."""
-
-                base_path = os.path.join(self.img_path(0), "images")
-
-                # create a zone binaries
-                bin_zonename, bin_zoneadm = self.__mk_zone_bins(self.test_root)
-
-                # setup image paths
-                img_dirs = [
-                    "", "z1/root/"
-                ]
-                img_paths = [
-                        os.path.join(base_path, d)
-                        for d in img_dirs
-                ]
-                gzpath, ngzpath = img_paths
-                os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
-
-                # create images and link them
-                self.__create_images(base_path, img_dirs)
-                self.pkg("--debug zones_supported=1 "
-                    "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
-                    "-R {2} attach-linked -v -f -c zone:z1 {3}".format(
-                    bin_zonename, "/bin/true", gzpath, ngzpath))
-
-                # now delete the global zone linked image metadata
-                self.__ccmd("rm {0}var/pkg/linked/*".format(gzpath))
-
-                # Make sure that list-linked displays the correct paths.
-                for ipath, lipaths in [
-                        [ gzpath,  [ gzpath, ngzpath ]],
-                        [ ngzpath, [ ngzpath ]],
-                    ]:
-                        self.__list_linked_check(ipath, lipaths,
-                            bin_zonename, bin_zoneadm)
-
-                # now verify that the gz thinks it's in an alternate path
-                for ipath, liname, props in [
-                        [ gzpath, None, {
-                            "li-current-parent": None,
-                            "li-current-path": gzpath,
-                            "li-parent": None,
-                            "li-path": "/",
-                            "li-path-transform": "('/', '{0}')".format(gzpath),
-                            }],
-                        [ gzpath, "zone:z1", {
-                            "li-current-parent": None,
-                            "li-current-path": ngzpath,
-                            "li-parent": None,
-                            "li-path": "/z1/root/",
-                            "li-path-transform": "('/', '{0}')".format(gzpath),
-                            }],
-                    ]:
-                        self.__check_linked_props(ipath, liname, props,
-                            bin_zonename, bin_zoneadm)
-
-        def test_linked_paths_BE_cloning(self):
-                """Test that image object plan execution and re-initialization
-                works when the image is moving around.  This simulates an
-                update that involves BE cloning."""
-
-                # setup image paths
-                image1 = os.path.join(self.img_path(0), "image1")
-                image2 = os.path.join(self.img_path(0), "image2")
-                img_dirs = [ "", "c/", ]
-
-                # Create images, link them, and install packages.
-                self.__create_images(image1, img_dirs)
-                self.__attach_child(image1,  "", "c/")
-                for d in img_dirs:
-                        p = os.path.join(image1, d)
-                        self.pkg("-R {0} install sync1@1.0".format(p))
-
-                # Initialize an API object.
-                api_inst = self.get_img_api_obj(
-                    cmd_path=pkg.misc.api_cmdpath(), img_path=image1)
-
-                # Plan and prepare an update for the images.
-                for pd in api_inst.gen_plan_install(["sync1@1.1"]):
-                        continue
-                api_inst.prepare()
-
-                # clone the current images to an alternate location
-                self.__ccmd("mkdir -p {0}".format(image2))
-                self.__ccmd("cd {0}; find . | cpio -pdm {1}".format(image1, image2))
-
-                # Update the API object to point to the new location and
-                # execute the udpate.
-                api_inst._img.find_root(image2)
-                api_inst.execute_plan()
-
-                # Update the API object to point back to the old location.
-                api_inst._img.find_root(image1)
-
-        def test_pull_child_moving_and_parent_staying_fixed(self):
-                """Test what happens if we have a pull child image that gets
-                moved but the parent image doesn't move."""
-
-                # Setup image paths
-                img_dirs = [ "parent/", "child_foo/", ]
-
-                # Create images, link them, and install packages.
-                self.__create_images(self.img_path(0), img_dirs)
-                self.__attach_parent(self.img_path(0),  "child_foo/", "parent/")
-
-                # Move the child image
-                foo_path = os.path.join(self.img_path(0), "child_foo/")
-                bar_path = os.path.join(self.img_path(0), "child_bar/")
-                self.__ccmd("mv {0} {1}".format(foo_path, bar_path))
-
-                # sync the child image
-                self.pkg("-R {0} sync-linked -v".format(bar_path),
-                    exit=EXIT_NOP)
-
-        def test_linked_paths_bad_zoneadm_list_output(self):
-                """Test that we emit an error message if we fail to parse
-                zoneadm list -p output."""
-
-                base_path = self.img_path(0).rstrip(os.sep) + os.sep
-                gzpath = os.path.join(base_path, "gzpath/")
-                self.__ccmd("mkdir -p {0}".format(gzpath))
-
-                # fake zoneadm binary used for testing
-                zoneadm_sh = """
+        p_sync1.append(p_data)
+
+    def setUp(self):
+        self.i_count = 3
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test"], image_count=self.i_count
+        )
+
+        # create files that go in packages
+        self.make_misc_files(self.p_files)
+
+        # get repo url
+        self.rurl1 = self.dcs[1].get_repo_url()
+
+        # populate repository
+        self.pkgsend_bulk(self.rurl1, self.p_sync1)
+
+        # setup image names and paths
+        self.i_name = []
+        self.i_path = []
+        for i in range(self.i_count):
+            name = "system:img{0:d}".format(i)
+            self.i_name.insert(i, name)
+            self.i_path.insert(i, self.img_path(i))
+
+    def __mk_bin(self, path, txt):
+        with open(path, "w+") as fobj:
+            print(txt, file=fobj)
+        self.cmdline_run("chmod a+x {0}".format(path), coverage=False)
+
+    def __mk_zone_bins(self, base_path):
+        # create a zonename binary
+        bin_zonename = os.path.join(base_path, "zonename")
+        self.__mk_bin(bin_zonename, self.zonename_sh)
+
+        # create a zoneadm binary
+        bin_zoneadm = os.path.join(base_path, "zoneadm")
+        self.__mk_bin(bin_zoneadm, self.zoneadm_sh)
+
+        return (bin_zonename, bin_zoneadm)
+
+    def __attach_params(self, base_path, pdir, cdir):
+        ppath = os.path.join(base_path, pdir)
+        cpath = os.path.join(base_path, cdir)
+        # generate child image name based on the child image dir
+        cname = re.sub("[/]", "_", cdir.rstrip(os.sep))
+        return ppath, cpath, cname
+
+    def __attach_child(self, base_path, pdir, cdir, exit=EXIT_OK):
+        ppath, cpath, cname = self.__attach_params(base_path, pdir, cdir)
+        self.pkg(
+            "-R {0} attach-linked -c system:{1} {2}".format(
+                ppath, cname, cpath
+            ),
+            exit=exit,
+        )
+
+    def __attach_parent(self, base_path, cdir, pdir, exit=EXIT_OK):
+        ppath, cpath, cname = self.__attach_params(base_path, pdir, cdir)
+        self.pkg(
+            "-R {0} attach-linked -p system:{1} {2}".format(
+                cpath, cname, ppath
+            ),
+            exit=exit,
+        )
+
+    def __try_attach(self, base_path, i1, i2):
+        self.__attach_child(base_path, i1, i2, exit=EXIT_OOPS)
+        self.__attach_parent(base_path, i1, i2, exit=EXIT_OOPS)
+
+    def __create_images(self, base_path, img_dirs, repos=None):
+        """Create images (in directory order)"""
+        for d in sorted(img_dirs):
+            p = os.path.join(base_path, d)
+            self.cmdline_run("mkdir -p {0}".format(p), coverage=False)
+            self.image_create(self.rurl1, destroy=False, img_path=p)
+
+    def __define_limages(self, base_path, types, locs):
+        """Given a vector of linked image types and locations, return
+        a list of linked images.  The format of returned list entries
+        is:
+                <image dir, image type, parent dir>
+        """
+
+        limages = []
+        index = 0
+        assert len(types) <= len(locs)
+
+        # first image is always a parent
+        limages.append([locs[0], self.T_NONE, None])
+
+        for t in types:
+            index += 1
+
+            # determine child and parent paths
+            cdir = locs[index]
+            pdir = None
+            if index in [1, 2]:
+                pdir = locs[0]
+            elif index in [3, 4]:
+                pdir = locs[1]
+            else:
+                assert "invalid index: ", index
+            assert pdir is not None
+
+            # skip this image
+            if t == self.T_NONE:
+                continue
+
+            # add image to the list
+            limages.append([cdir, t, pdir])
+
+        return limages
+
+    def __create_limages(self, base_path, limages):
+        """Create images (in directory order)"""
+        img_dirs = [cdir for cdir, t, pdir in limages]
+        self.__create_images(base_path, img_dirs)
+
+    def __attach_limages(self, base_path, limages):
+        """Attach images"""
+        for cdir, t, pdir in limages:
+            if t == self.T_NONE:
+                continue
+            if t == self.T_PUSH:
+                self.__attach_child(base_path, pdir, cdir)
+                continue
+            assert t == self.T_PULL
+            self.__attach_parent(base_path, cdir, pdir)
+
+    def __audit_limages(self, base_path, limages):
+        """Audit images"""
+
+        parents = set([pdir for cdir, t, pdir in limages if t == self.T_PUSH])
+        for pdir in parents:
+            p = os.path.join(base_path, pdir)
+            self.pkg("-R {0} audit-linked -a".format(p))
+
+        children = set([cdir for cdir, t, pdir in limages if t != self.T_NONE])
+        for pdir in parents:
+            p = os.path.join(base_path, limages[-1][0])
+            self.pkg("-R {0} audit-linked".format(p))
+
+    def __ccmd(self, args, rv=0):
+        """Run a 'C' (or other non-python) command."""
+        assert type(args) == str
+        # Ensure 'coverage' is turned off-- it won't work.
+        self.cmdline_run("{0}".format(args), exit=rv, coverage=False)
+
+    def __list_linked_check(self, ipath, lipaths, bin_zonename, bin_zoneadm):
+        """Given an image path (ipath), verify that pkg list-linked
+        displays the expected linked image paths (lipaths).  The
+        caller must specify paths to custom zonename and zoneadm
+        binaries that will output from those commands."""
+
+        outfile1 = os.path.join(ipath, "__list_linked_check")
+
+        self.pkg(
+            "--debug zones_supported=1 "
+            "--debug bin_zonename='{0}' "
+            "--debug bin_zoneadm='{1}' "
+            "-R {2} list-linked > {3}".format(
+                bin_zonename, bin_zoneadm, ipath, outfile1
+            )
+        )
+        self.__ccmd("cat {0}".format(outfile1))
+        for lipath in lipaths:
+            self.__ccmd("egrep '[ 	]{0}[ 	]*$' {1}".format(lipath, outfile1))
+
+    def __check_linked_props(
+        self, ipath, liname, props, bin_zonename, bin_zoneadm
+    ):
+        """Given an image path (ipath), verify that pkg
+        property-linked displays the expected linked image properties.
+        (props).  The caller must specify paths to custom zonename and
+        zoneadm binaries that will output from those commands."""
+
+        outfile1 = os.path.join(ipath, "__check_linked_props1")
+        outfile2 = os.path.join(ipath, "__check_linked_props2")
+
+        if liname:
+            liname = "-l " + liname
+        else:
+            liname = ""
+
+        self.pkg(
+            "--debug zones_supported=1 "
+            "--debug bin_zonename='{0}' "
+            "--debug bin_zoneadm='{1}' "
+            "-R {2} property-linked {3} -H > {4}".format(
+                bin_zonename, bin_zoneadm, ipath, liname, outfile1
+            )
+        )
+        self.__ccmd("cat {0}".format(outfile1))
+
+        for p, v in six.iteritems(props):
+            if v is None:
+                # verify property is not present
+                self.__ccmd('grep "^{0}[ 	]" {1}'.format(p, outfile1), rv=1)
+                continue
+
+            # verify property and value
+            self.__ccmd(
+                'grep "^{0}[ 	]" {1} > {2}'.format(p, outfile1, outfile2)
+            )
+            self.__ccmd("cat {0}".format(outfile2))
+            # verify property and value
+            self.__ccmd('grep "[ 	]{0}[ 	]*$" {1}'.format(v, outfile2))
+
+    def test_linked_paths_moves(self):
+        """Create trees of linked images, with different relative path
+        configurations.  Then move each tree to a different locations
+        and see if the images within each tree can still find each
+        other."""
+
+        tmp_path = os.path.join(self.img_path(0), "tmp")
+        base_path = os.path.join(self.img_path(0), "images")
+
+        for t_vec, loc in itertools.product(self.t_vec_list, self.l_list):
+            l_vec = self.l_vec_dict[loc]
+
+            pcur = os.path.join(base_path, self.path_start)
+
+            # create and link image tree
+            limages = self.__define_limages(pcur, t_vec, l_vec)
+            self.__create_limages(pcur, limages)
+            self.__attach_limages(pcur, limages)
+
+            for pnew in self.path_tests:
+                assert limages
+                assert pcur != pnew
+
+                # determine the parent images new location
+                pnew = os.path.join(base_path, pnew)
+
+                # move the parent to a temporary location
+                self.__ccmd("mv {0} {1}".format(pcur, tmp_path))
+
+                # cleanup old directory, avoid "rm -rf"
+                d = pcur
+                while True:
+                    d = os.path.dirname(d)
+                    if len(d) <= len(base_path):
+                        break
+                    self.__ccmd("rmdir {0}".format(d))
+
+                # move the parent to it's new location
+                self.__ccmd("mkdir -p {0}".format(os.path.dirname(pnew)))
+                self.__ccmd("mv {0} {1}".format(tmp_path, pnew))
+
+                # verify that the images can find each other
+                self.__audit_limages(pnew, limages)
+
+                # save the parent images last location
+                pcur = pnew
+
+            # cleanup current image tree
+            shutil.rmtree(base_path)
+
+    def test_linked_paths_no_self_link(self):
+        """You can't link images to themselves."""
+
+        base_path = self.img_path(0)
+        img_dirs = ["./"]
+        self.__create_images(base_path, img_dirs)
+        self.__try_attach(base_path, "./", "./")
+
+    def test_linked_paths_no_nested_parent(self):
+        """You can't link images if the parent image is nested within
+        the child."""
+
+        base_path = self.img_path(0)
+        img_dirs = ["./", "1/"]
+
+        self.__create_images(base_path, img_dirs)
+
+        self.__attach_child(base_path, "1/", "./", exit=EXIT_OOPS)
+        self.__attach_parent(base_path, "./", "1/", exit=EXIT_OOPS)
+
+    def test_linked_paths_no_liveroot_child(self):
+        """You can't link the liveroot image as a child."""
+
+        base_path = self.img_path(0)
+        img_dirs = ["./", "1/"]
+
+        self.__create_images(base_path, img_dirs)
+
+        ppath, cpath, cname = self.__attach_params(base_path, "./", "1/")
+
+        self.pkg(
+            "--debug simulate_live_root='{0}' "
+            "-R {1} attach-linked -c system:{2} {3}".format(
+                cpath, ppath, cname, cpath
+            ),
+            exit=EXIT_OOPS,
+        )
+        self.pkg(
+            "--debug simulate_live_root='{0}' "
+            "-R {1} attach-linked -p system:{2} {3}".format(
+                cpath, cpath, cname, ppath
+            ),
+            exit=EXIT_OOPS,
+        )
+
+    def test_linked_paths_no_intermediate_imgs(self):
+        """You can't link images if there are intermediate image in
+        between."""
+
+        base_path = self.img_path(0)
+        img_dirs = ["./", "1/", "1/11/", "2/"]
+
+        self.__create_images(base_path, img_dirs)
+
+        # can't link "./" and "1/11/" because "1/" is inbetween
+        self.__try_attach(base_path, "./", "1/11/")
+
+        # can't link "1/" and "2/" because "./" is in between
+        self.__try_attach(base_path, "1/", "2/")
+
+    def test_linked_paths_no_attach_in_temporary_location(self):
+        """You can't link images if we're operating on already linked
+        images in temporary locations."""
+
+        base_path = os.path.join(self.img_path(0), "images1")
+        img_dirs = ["./", "p/", "p/1/", "p/2/", "p/3/", "p/1/11/", "p/2/22/"]
+
+        self.__create_images(base_path, img_dirs)
+        self.__attach_child(base_path, "p/", "p/1/")
+        self.__attach_parent(base_path, "p/2/", "p/")
+
+        # move the images
+        pnew = os.path.join(self.img_path(0), "images2")
+        self.__ccmd("mv {0} {1}".format(base_path, pnew))
+        base_path = pnew
+
+        self.__attach_parent(base_path, "p/", "./", exit=EXIT_OOPS)
+        self.__attach_child(base_path, "p/", "p/3/", exit=EXIT_OOPS)
+        self.__attach_child(base_path, "p/1/", "p/1/11/", exit=EXIT_OOPS)
+        self.__attach_child(base_path, "p/2/", "p/2/22/", exit=EXIT_OOPS)
+
+    def test_linked_paths_staged(self):
+        """Test path handling code with staged operation.  Make sure
+        that we correctly handle images moving around between stages.
+        This simulates normal pkg updates where we plan an update for
+        "/", and then we clone "/", mount it at a  a temporarly
+        location, and then update the clone."""
+
+        tmp_path = os.path.join(self.img_path(0), "tmp")
+        base_path = os.path.join(self.img_path(0), "images")
+
+        t_vec = [self.T_PUSH, self.T_NONE, self.T_PUSH, self.T_PULL]
+        l_vec = ["", "d/", "d1/", "d/d/", "d/d1/"]
+        limages = self.__define_limages(base_path, t_vec, l_vec)
+
+        self.__create_limages(base_path, limages)
+        for i in range(len(limages)):
+            ipath = os.path.join(base_path, limages[i][0])
+            self.pkg("-R {0} install sync1@1.0".format(ipath))
+        self.__attach_limages(base_path, limages)
+
+        for i in range(len(limages)):
+            # It only makes sense to try and update T_NONE and
+            # T_PULL images (T_PUSH images will be updated
+            # implicitly via recursion).
+            if limages[i][1] == self.T_PUSH:
+                continue
+
+            # plan update
+            ipath = os.path.join(base_path, limages[i][0])
+            self.pkg("-R {0} update --stage=plan".format(ipath))
+
+            # move images to /a
+            self.__ccmd("mv {0} {1}".format(base_path, tmp_path))
+            new_path = os.path.join(base_path, "a")
+            self.__ccmd("mkdir -p {0}".format(os.path.dirname(new_path)))
+            self.__ccmd("mv {0} {1}".format(tmp_path, new_path))
+
+            # finish update
+            ipath = os.path.join(new_path, limages[i][0])
+            self.pkg("-R {0} update --stage=prepare".format(ipath))
+            self.pkg("-R {0} update --stage=execute".format(ipath))
+
+            # move images back
+            # cleanup old directory, avoid "rm -rf"
+            self.__ccmd("mv {0} {1}".format(new_path, tmp_path))
+            d = new_path
+            while True:
+                d = os.path.dirname(d)
+                if len(d) < len(base_path):
+                    break
+                self.__ccmd("rmdir {0}".format(d))
+            self.__ccmd("mkdir -p {0}".format(os.path.dirname(base_path)))
+            self.__ccmd("mv {0} {1}".format(tmp_path, base_path))
+
+    def test_linked_paths_staged_with_zones(self):
+        """Simulate staged packaging operations involving zones."""
+
+        tmp_path = os.path.join(self.img_path(0), "tmp")
+        base_path = os.path.join(self.img_path(0), "images")
+
+        # create a zone binaries
+        bin_zonename, bin_zoneadm = self.__mk_zone_bins(self.test_root)
+
+        # setup image paths
+        img_dirs = ["", "z1/root"]
+        gzpath = os.path.join(base_path, img_dirs[0])
+        ngzpath = os.path.join(base_path, img_dirs[1])
+        os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
+
+        # create images, install packages, and link them
+        self.__create_images(base_path, img_dirs)
+        self.pkg("-R {0} install sync1@1.1".format(gzpath))
+        self.pkg("-R {0} install sync1@1.0".format(ngzpath))
+        self.pkg(
+            "--debug zones_supported=1 "
+            "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
+            "-R {2} attach-linked -v -f -c zone:z1 {3}".format(
+                bin_zonename, "/bin/true", gzpath, ngzpath
+            )
+        )
+
+        # plan update
+        self.pkg(
+            "--debug zones_supported=1 "
+            "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
+            "-R {2} update -vvv --stage=plan".format(
+                bin_zonename, bin_zoneadm, gzpath
+            )
+        )
+
+        # move images to /a
+        self.__ccmd("mv {0} {1}".format(base_path, tmp_path))
+        base_path = os.path.join(base_path, "a")
+        gzpath = os.path.join(base_path, img_dirs[0])
+        ngzpath = os.path.join(base_path, img_dirs[1])
+        os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
+        self.__ccmd("mkdir -p {0}".format(os.path.dirname(base_path)))
+        self.__ccmd("mv {0} {1}".format(tmp_path, gzpath))
+
+        # finish update
+        self.pkg(
+            "--debug zones_supported=1 "
+            "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
+            "-R {2} update --stage=prepare".format(
+                bin_zonename, bin_zoneadm, gzpath
+            )
+        )
+        self.pkg(
+            "--debug zones_supported=1 "
+            "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
+            "-R {2} update --stage=execute".format(
+                bin_zonename, bin_zoneadm, gzpath
+            )
+        )
+
+        # verify that all the images got updated
+        self.pkg("-R {0} list sync1@1.2".format(gzpath))
+        self.pkg("-R {0} list sync1@1.2".format(ngzpath))
+
+        del os.environ["PKG_GZR"]
+
+    def test_linked_paths_list_and_props(self):
+        """Verify that all linked image paths reported by list-linked
+        and property-linked are correct before and after moving trees
+        of images."""
+
+        tmp_path = os.path.join(self.img_path(0), "tmp")
+        base_path = os.path.join(self.img_path(0), "images")
+
+        # create a zone binaries
+        bin_zonename, bin_zoneadm = self.__mk_zone_bins(self.test_root)
+
+        # setup image paths
+        img_dirs = ["", "s1/", "s2/", "z1/root/"]
+        img_paths = [os.path.join(base_path, d) for d in img_dirs]
+        gzpath, s1path, s2path, ngzpath = img_paths
+        os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
+
+        # create images and link them
+        self.__create_images(base_path, img_dirs)
+        self.__attach_child(base_path, "", img_dirs[1])
+        self.__attach_parent(base_path, img_dirs[2], "")
+        self.pkg(
+            "--debug zones_supported=1 "
+            "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
+            "-R {2} attach-linked -v -f -c zone:z1 {3}".format(
+                bin_zonename, "/bin/true", gzpath, ngzpath
+            )
+        )
+
+        # Make sure that list-linked displays the correct paths.
+        for ipath, lipaths in [
+            [gzpath, [gzpath, s1path, ngzpath]],
+            [s1path, [s1path]],
+            [s2path, [gzpath, s2path]],
+            [ngzpath, [ngzpath]],
+        ]:
+            self.__list_linked_check(ipath, lipaths, bin_zonename, bin_zoneadm)
+
+        # Make sure that property-linked displays the correct paths.
+        for ipath, liname, props in [
+            [
+                gzpath,
+                None,
+                {
+                    "li-current-parent": None,
+                    "li-current-path": gzpath,
+                    "li-parent": None,
+                    "li-path": gzpath,
+                    "li-path-transform": "('/', '/')",
+                },
+            ],
+            [
+                gzpath,
+                "system:s1",
+                {
+                    "li-current-parent": None,
+                    "li-current-path": s1path,
+                    "li-parent": None,
+                    "li-path": s1path,
+                    "li-path-transform": "('/', '/')",
+                },
+            ],
+            [
+                gzpath,
+                "zone:z1",
+                {
+                    "li-current-parent": None,
+                    "li-current-path": ngzpath,
+                    "li-parent": None,
+                    "li-path": ngzpath,
+                    "li-path-transform": "('/', '/')",
+                },
+            ],
+            [
+                s1path,
+                None,
+                {
+                    "li-current-parent": None,
+                    "li-current-path": s1path,
+                    "li-parent": None,
+                    "li-path": s1path,
+                    "li-path-transform": "('/', '/')",
+                },
+            ],
+            [
+                s2path,
+                None,
+                {
+                    "li-current-parent": gzpath,
+                    "li-current-path": s2path,
+                    "li-parent": gzpath,
+                    "li-path": s2path,
+                    "li-path-transform": "('/', '/')",
+                },
+            ],
+            [
+                ngzpath,
+                None,
+                {
+                    "li-current-parent": None,
+                    "li-current-path": ngzpath,
+                    "li-parent": None,
+                    "li-path": "/",
+                    "li-path-transform": "('/', '{0}')".format(ngzpath),
+                },
+            ],
+        ]:
+            self.__check_linked_props(
+                ipath, liname, props, bin_zonename, bin_zoneadm
+            )
+
+        # save old paths
+        ogzpath, os1path, os2path, ongzpath = img_paths
+
+        # move images to /a
+        self.__ccmd("mv {0} {1}".format(base_path, tmp_path))
+        base_path = os.path.join(base_path, "a")
+        self.__ccmd("mkdir -p {0}".format(os.path.dirname(base_path)))
+        self.__ccmd("mv {0} {1}".format(tmp_path, base_path))
+
+        # update paths
+        img_paths = [os.path.join(base_path, d) for d in img_dirs]
+        gzpath, s1path, s2path, ngzpath = img_paths
+        os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
+
+        # Make sure that list-linked displays the correct paths.
+        for ipath, lipaths in [
+            [gzpath, [gzpath, s1path, ngzpath]],
+            [s1path, [s1path]],
+            [s2path, [gzpath, s2path]],
+            [ngzpath, [ngzpath]],
+        ]:
+            self.__list_linked_check(ipath, lipaths, bin_zonename, bin_zoneadm)
+
+        # Make sure that property-linked displays the correct paths.
+        for ipath, liname, props in [
+            [
+                gzpath,
+                None,
+                {
+                    "li-current-parent": None,
+                    "li-current-path": gzpath,
+                    "li-parent": None,
+                    "li-path": ogzpath,
+                    "li-path-transform": "('{0}', '{1}')".format(
+                        ogzpath, gzpath
+                    ),
+                },
+            ],
+            [
+                gzpath,
+                "system:s1",
+                {
+                    "li-current-parent": None,
+                    "li-current-path": s1path,
+                    "li-parent": None,
+                    "li-path": os1path,
+                    "li-path-transform": "('{0}', '{1}')".format(
+                        ogzpath, gzpath
+                    ),
+                },
+            ],
+            [
+                gzpath,
+                "zone:z1",
+                {
+                    "li-current-parent": None,
+                    "li-current-path": ngzpath,
+                    "li-parent": None,
+                    "li-path": ongzpath,
+                    "li-path-transform": "('{0}', '{1}')".format(
+                        ogzpath, gzpath
+                    ),
+                },
+            ],
+            [
+                s1path,
+                None,
+                {
+                    "li-current-parent": None,
+                    "li-current-path": s1path,
+                    "li-parent": None,
+                    "li-path": os1path,
+                    "li-path-transform": "('{0}', '{1}')".format(
+                        ogzpath, gzpath
+                    ),
+                },
+            ],
+            [
+                s2path,
+                None,
+                {
+                    "li-current-parent": gzpath,
+                    "li-current-path": s2path,
+                    "li-parent": ogzpath,
+                    "li-path": os2path,
+                    "li-path-transform": "('{0}', '{1}')".format(
+                        ogzpath, gzpath
+                    ),
+                },
+            ],
+            [
+                ngzpath,
+                None,
+                {
+                    "li-current-parent": None,
+                    "li-current-path": ngzpath,
+                    "li-parent": None,
+                    "li-path": "/",
+                    "li-path-transform": "('/', '{0}')".format(ngzpath),
+                },
+            ],
+        ]:
+            self.__check_linked_props(
+                ipath, liname, props, bin_zonename, bin_zoneadm
+            )
+
+    def test_linked_paths_guess_path_transform(self):
+        """If a parent image has no properties, then rather than
+        throwing an exception (that a user has no way to fix), we try
+        to fabricate some properties to run with.  To do this we ask
+        each linked image plugin if it knows what the current path
+        transform is (which would tell us what original root path was).
+        Only the zones plugin implements this functionality, so test
+        it here."""
+
+        base_path = os.path.join(self.img_path(0), "images")
+
+        # create a zone binaries
+        bin_zonename, bin_zoneadm = self.__mk_zone_bins(self.test_root)
+
+        # setup image paths
+        img_dirs = ["", "z1/root/"]
+        img_paths = [os.path.join(base_path, d) for d in img_dirs]
+        gzpath, ngzpath = img_paths
+        os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
+
+        # create images and link them
+        self.__create_images(base_path, img_dirs)
+        self.pkg(
+            "--debug zones_supported=1 "
+            "--debug bin_zonename='{0}' --debug bin_zoneadm='{1}' "
+            "-R {2} attach-linked -v -f -c zone:z1 {3}".format(
+                bin_zonename, "/bin/true", gzpath, ngzpath
+            )
+        )
+
+        # now delete the global zone linked image metadata
+        self.__ccmd("rm {0}var/pkg/linked/*".format(gzpath))
+
+        # Make sure that list-linked displays the correct paths.
+        for ipath, lipaths in [
+            [gzpath, [gzpath, ngzpath]],
+            [ngzpath, [ngzpath]],
+        ]:
+            self.__list_linked_check(ipath, lipaths, bin_zonename, bin_zoneadm)
+
+        # now verify that the gz thinks it's in an alternate path
+        for ipath, liname, props in [
+            [
+                gzpath,
+                None,
+                {
+                    "li-current-parent": None,
+                    "li-current-path": gzpath,
+                    "li-parent": None,
+                    "li-path": "/",
+                    "li-path-transform": "('/', '{0}')".format(gzpath),
+                },
+            ],
+            [
+                gzpath,
+                "zone:z1",
+                {
+                    "li-current-parent": None,
+                    "li-current-path": ngzpath,
+                    "li-parent": None,
+                    "li-path": "/z1/root/",
+                    "li-path-transform": "('/', '{0}')".format(gzpath),
+                },
+            ],
+        ]:
+            self.__check_linked_props(
+                ipath, liname, props, bin_zonename, bin_zoneadm
+            )
+
+    def test_linked_paths_BE_cloning(self):
+        """Test that image object plan execution and re-initialization
+        works when the image is moving around.  This simulates an
+        update that involves BE cloning."""
+
+        # setup image paths
+        image1 = os.path.join(self.img_path(0), "image1")
+        image2 = os.path.join(self.img_path(0), "image2")
+        img_dirs = [
+            "",
+            "c/",
+        ]
+
+        # Create images, link them, and install packages.
+        self.__create_images(image1, img_dirs)
+        self.__attach_child(image1, "", "c/")
+        for d in img_dirs:
+            p = os.path.join(image1, d)
+            self.pkg("-R {0} install sync1@1.0".format(p))
+
+        # Initialize an API object.
+        api_inst = self.get_img_api_obj(
+            cmd_path=pkg.misc.api_cmdpath(), img_path=image1
+        )
+
+        # Plan and prepare an update for the images.
+        for pd in api_inst.gen_plan_install(["sync1@1.1"]):
+            continue
+        api_inst.prepare()
+
+        # clone the current images to an alternate location
+        self.__ccmd("mkdir -p {0}".format(image2))
+        self.__ccmd("cd {0}; find . | cpio -pdm {1}".format(image1, image2))
+
+        # Update the API object to point to the new location and
+        # execute the udpate.
+        api_inst._img.find_root(image2)
+        api_inst.execute_plan()
+
+        # Update the API object to point back to the old location.
+        api_inst._img.find_root(image1)
+
+    def test_pull_child_moving_and_parent_staying_fixed(self):
+        """Test what happens if we have a pull child image that gets
+        moved but the parent image doesn't move."""
+
+        # Setup image paths
+        img_dirs = [
+            "parent/",
+            "child_foo/",
+        ]
+
+        # Create images, link them, and install packages.
+        self.__create_images(self.img_path(0), img_dirs)
+        self.__attach_parent(self.img_path(0), "child_foo/", "parent/")
+
+        # Move the child image
+        foo_path = os.path.join(self.img_path(0), "child_foo/")
+        bar_path = os.path.join(self.img_path(0), "child_bar/")
+        self.__ccmd("mv {0} {1}".format(foo_path, bar_path))
+
+        # sync the child image
+        self.pkg("-R {0} sync-linked -v".format(bar_path), exit=EXIT_NOP)
+
+    def test_linked_paths_bad_zoneadm_list_output(self):
+        """Test that we emit an error message if we fail to parse
+        zoneadm list -p output."""
+
+        base_path = self.img_path(0).rstrip(os.sep) + os.sep
+        gzpath = os.path.join(base_path, "gzpath/")
+        self.__ccmd("mkdir -p {0}".format(gzpath))
+
+        # fake zoneadm binary used for testing
+        zoneadm_sh = """
 #!/bin/sh
 cat <<-EOF
 this is invalid zoneadm list -p output.
 EOF
-exit 0""".strip("\n")
+exit 0""".strip(
+            "\n"
+        )
 
-                # create a zonename binary
-                bin_zonename = os.path.join(base_path, "zonename")
-                self.__mk_bin(bin_zonename, self.zonename_sh)
+        # create a zonename binary
+        bin_zonename = os.path.join(base_path, "zonename")
+        self.__mk_bin(bin_zonename, self.zonename_sh)
 
-                # create a zoneadm binary
-                bin_zoneadm = os.path.join(base_path, "zoneadm")
-                self.__mk_bin(bin_zoneadm, zoneadm_sh)
+        # create a zoneadm binary
+        bin_zoneadm = os.path.join(base_path, "zoneadm")
+        self.__mk_bin(bin_zoneadm, zoneadm_sh)
 
-                self.image_create(self.rurl1, destroy=False, img_path=gzpath)
+        self.image_create(self.rurl1, destroy=False, img_path=gzpath)
 
-                self.pkg("--debug zones_supported=1 "
-                    "--debug bin_zonename='{0}' "
-                    "--debug bin_zoneadm='{1}' "
-                    "-R {2} list-linked".format(
-                    bin_zonename, bin_zoneadm, gzpath), exit=EXIT_OOPS)
+        self.pkg(
+            "--debug zones_supported=1 "
+            "--debug bin_zonename='{0}' "
+            "--debug bin_zoneadm='{1}' "
+            "-R {2} list-linked".format(bin_zonename, bin_zoneadm, gzpath),
+            exit=EXIT_OOPS,
+        )
 
-                self.assertTrue(self.output == "")
-                self.assertTrue("this is invalid zoneadm list -p output." in
-                    self.errout)
+        self.assertTrue(self.output == "")
+        self.assertTrue(
+            "this is invalid zoneadm list -p output." in self.errout
+        )
 
-        def test_linked_paths_zone_paths_with_colon(self):
-                """Test that we can correctly parse zone paths that have a
-                colon in them."""
+    def test_linked_paths_zone_paths_with_colon(self):
+        """Test that we can correctly parse zone paths that have a
+        colon in them."""
 
-                base_path = self.img_path(0).rstrip(os.sep) + os.sep
-                gzpath = os.path.join(base_path, "gzpath_with_a_:colon/")
-                self.__ccmd("mkdir -p {0}".format(gzpath))
+        base_path = self.img_path(0).rstrip(os.sep) + os.sep
+        gzpath = os.path.join(base_path, "gzpath_with_a_:colon/")
+        self.__ccmd("mkdir -p {0}".format(gzpath))
 
-                os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
+        os.environ["PKG_GZR"] = gzpath.rstrip(os.sep)
 
-
-                # fake zoneadm binary used for testing
-                zoneadm_sh = """
+        # fake zoneadm binary used for testing
+        zoneadm_sh = """
 #!/bin/sh
 while getopts "R:" OPT ; do
 case $OPT in
@@ -5351,25 +5917,26 @@ cat <<-EOF
 0:global:running:$PKG_GZR::solaris:shared:-:none:
 -:z1:installed:$PKG_GZR/ngzzone_path_with_a\\:colon::solaris:excl:-::
 EOF
-exit 0""".strip("\n")
+exit 0""".strip(
+            "\n"
+        )
 
-                # create a zonename binary
-                bin_zonename = os.path.join(base_path, "zonename")
-                self.__mk_bin(bin_zonename, self.zonename_sh)
+        # create a zonename binary
+        bin_zonename = os.path.join(base_path, "zonename")
+        self.__mk_bin(bin_zonename, self.zonename_sh)
 
-                # create a zoneadm binary
-                bin_zoneadm = os.path.join(base_path, "zoneadm")
-                self.__mk_bin(bin_zoneadm, zoneadm_sh)
+        # create a zoneadm binary
+        bin_zoneadm = os.path.join(base_path, "zoneadm")
+        self.__mk_bin(bin_zoneadm, zoneadm_sh)
 
-                self.image_create(self.rurl1, destroy=False, img_path=gzpath)
+        self.image_create(self.rurl1, destroy=False, img_path=gzpath)
 
-                ngzpath = gzpath + "ngzzone_path_with_a:colon/root/"
-                self.__list_linked_check(gzpath, [ngzpath],
-                    bin_zonename, bin_zoneadm)
+        ngzpath = gzpath + "ngzzone_path_with_a:colon/root/"
+        self.__list_linked_check(gzpath, [ngzpath], bin_zonename, bin_zoneadm)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_list.py
+++ b/src/tests/cli/t_pkg_list.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -37,1051 +38,1061 @@ import unittest
 
 
 class TestPkgList(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        foo1 = """
+    foo1 = """
             open foo@1,5.11-0
             close """
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             close """
 
-        foo12 = """
+    foo12 = """
             open foo@1.2,5.11-0
             close """
 
-        foo121 = """
+    foo121 = """
             open foo@1.2.1,5.11-0
             close """
 
-        food12 = """
+    food12 = """
             open food@1.2,5.11-0
             close """
 
-        newpkg10 = """
+    newpkg10 = """
             open newpkg@1.0
             close """
 
-        hierfoo10 = """
+    hierfoo10 = """
             open hier/foo@1.0,5.11-0
             close """
 
-        renamed10 = """
+    renamed10 = """
             open renamed@1.0,5.11-0
             add set name=pkg.renamed value=true
             add depend type=require fmri=foo10@1.0
             close """
 
-        legacy10 = """
+    legacy10 = """
             open legacy@1.0,5.11-0
             add set name=pkg.legacy value=true
             close """
 
-        obsolete10 = """
+    obsolete10 = """
             open obsolete@1.0,5.11-0
             add set name=pkg.obsolete value=true
             close """
 
-        cowley11 = """
+    cowley11 = """
             open cowley@1.1,5.11-0
             add set name=pkg.summary value="Cowley pkg"
             close """
 
-        fenix10 = """
+    fenix10 = """
             open fenix@1.0,5.11-0
             add depend type=require fmri=cowley
             close """
 
-        dragon10 = """
+    dragon10 = """
             open dragon@1.0,5.11-0
             add depend type=optional fmri=cowley
             close """
 
-
-        def __check_qoutput(self, errout=False):
-                self.assertEqualDiff(self.output, "")
-                if errout:
-                        self.assertTrue(self.errout != "",
-                            "-q must print fatal errors!")
-                else:
-                        self.assertTrue(self.errout == "",
-                            "-q should only print fatal errors!")
-
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test2"])
-
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.pkgsend_bulk(self.rurl1, (self.foo1, self.foo10,
-                    self.foo11, self.foo12, self.foo121, self.food12,
-                    self.hierfoo10, self.renamed10, self.legacy10,
-                    self.obsolete10, self.fenix10, self.cowley11,
-                    self.dragon10))
-
-                # Ensure that the second repo's packages have exactly the same
-                # timestamps as those in the first ... by copying the repo over.
-                # If the repos need to have some contents which are different,
-                # send those changes after restarting depot 2.
-                d1dir = self.dcs[1].get_repodir()
-                d2dir = self.dcs[2].get_repodir()
-                self.copy_repository(d1dir, d2dir, { "test1": "test2" })
-
-                # The new repository won't have a catalog, so rebuild it.
-                self.dcs[2].get_repo(auto_create=True).rebuild()
-
-                # The third repository should remain empty and not be
-                # published to.
-
-                # Next, create the image and configure publishers.
-                self.image_create(self.rurl1, prefix="test1")
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.pkg("set-publisher -O " + self.rurl2 + " test2")
-
-                self.rurl3 = self.dcs[3].get_repo_url()
-
-        def test_pkg_list_cli_opts(self):
-
-                self.pkg("list -@", exit=2)
-                self.pkg("list -v -s", exit=2)
-                self.pkg("list -a -u", exit=2)
-                self.pkg("list -a -r", exit=2)
-                self.pkg("list -m -M", exit=2)
-                self.pkg("list -i -r", exit=2)
-                self.pkg("list -i -m", exit=2)
-                self.pkg("list -i -M", exit=2)
-                self.pkg("list -g pkg://test1/ -u", exit=2)
-
-                # Should only print fatal errors when using -q.
-                self.pkg("list -q -v", exit=2)
-                self.__check_qoutput(errout=True)
-
-        def test_00(self):
-                """Verify that sort order and content of a full list matches
-                expected."""
-
-                self.pkg("list -aH")
-                expected = (
-                    "cowley 1.1-0 ---\n"
-                    "cowley (test2) 1.1-0 ---\n"
-                    "dragon 1.0-0 ---\n"
-                    "dragon (test2) 1.0-0 ---\n"
-                    "fenix 1.0-0 ---\n"
-                    "fenix (test2) 1.0-0 ---\n"
-                    "foo 1.2.1-0 ---\n"
-                    "foo (test2) 1.2.1-0 ---\n"
-                    "food 1.2-0 ---\n"
-                    "food (test2) 1.2-0 ---\n"
-                    "hier/foo 1.0-0 ---\n"
-                    "hier/foo (test2) 1.0-0 ---\n"
-                    "legacy 1.0-0 --l\n"
-                    "legacy (test2) 1.0-0 --l\n"
-                    "obsolete 1.0-0 --o\n"
-                    "obsolete (test2) 1.0-0 --o\n"
-                    "renamed 1.0-0 --r\n"
-                    "renamed (test2) 1.0-0 --r\n"
-                )
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # Should only print fatal errors when using -q.
-                self.pkg("list -aqH")
-                self.__check_qoutput(errout=False)
-
-                self.pkg("list -afH")
-                expected = (
-                    "cowley 1.1-0 ---\n"
-                    "cowley (test2) 1.1-0 ---\n"
-                    "dragon 1.0-0 ---\n"
-                    "dragon (test2) 1.0-0 ---\n"
-                    "fenix 1.0-0 ---\n"
-                    "fenix (test2) 1.0-0 ---\n"
-                    "foo 1.2.1-0 ---\n"
-                    "foo 1.2-0 ---\n"
-                    "foo 1.1-0 ---\n"
-                    "foo 1.0-0 ---\n"
-                    "foo 1-0 ---\n"
-                    "foo (test2) 1.2.1-0 ---\n"
-                    "foo (test2) 1.2-0 ---\n"
-                    "foo (test2) 1.1-0 ---\n"
-                    "foo (test2) 1.0-0 ---\n"
-                    "foo (test2) 1-0 ---\n"
-                    "food 1.2-0 ---\n"
-                    "food (test2) 1.2-0 ---\n"
-                    "hier/foo 1.0-0 ---\n"
-                    "hier/foo (test2) 1.0-0 ---\n"
-                    "legacy 1.0-0 --l\n"
-                    "legacy (test2) 1.0-0 --l\n"
-                    "obsolete 1.0-0 --o\n"
-                    "obsolete (test2) 1.0-0 --o\n"
-                    "renamed 1.0-0 --r\n"
-                    "renamed (test2) 1.0-0 --r\n"
-                )
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # Put options in different order to ensure output still matches.
-                self.pkg("list -faH")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-        def test_01(self):
-                """List all "foo@1.0" from auth "test1"."""
-                self.pkg("list -afH pkg://test1/foo@1.0,5.11-0")
-                expected = \
-                    "foo 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # Test 'rooted' name.
-                self.pkg("list -afH //test1/foo@1.0,5.11-0")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-        def test_02(self):
-                """List all "foo@1.0", regardless of publisher, with "pkg:/"
-                or '/' prefix."""
-                self.pkg("list -afH pkg:/foo@1.0,5.11-0")
-                expected = \
-                    "foo 1.0-0 ---\n" \
-                    "foo (test2) 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # Test 'rooted' name.
-                self.pkg("list -afH /foo@1.0,5.11-0")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-        def test_03(self):
-                """List all "foo@1.0", regardless of publisher, without "pkg:/"
-                prefix."""
-                self.pkg("list -afH pkg:/foo@1.0,5.11-0")
-                expected = \
-                    "foo         1.0-0 ---\n" \
-                    "foo (test2) 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-        def test_04(self):
-                """List all versions of package foo, regardless of publisher."""
-                self.pkg("list -aHf foo")
-                expected = \
-                    "foo              1.2.1-0 ---\n" \
-                    "foo              1.2-0   ---\n" \
-                    "foo              1.1-0   ---\n" \
-                    "foo              1.0-0   ---\n" \
-                    "foo              1-0     ---\n" \
-                    "foo (test2)      1.2.1-0 ---\n" \
-                    "foo (test2)      1.2-0   ---\n" \
-                    "foo (test2)      1.1-0   ---\n" \
-                    "foo (test2)      1.0-0   ---\n" \
-                    "foo (test2)      1-0     ---\n" \
-                    "hier/foo         1.0-0 ---\n" \
-                    "hier/foo (test2) 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -aH foo")
-                expected = \
-                    "foo              1.2.1-0 ---\n" \
-                    "foo (test2)      1.2.1-0 ---\n" \
-                    "hier/foo         1.0-0 ---\n" \
-                    "hier/foo (test2) 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-        def test_05(self):
-                """Show foo@1.0 from both depots, but 1.1 only from test2."""
-                self.pkg("list -aHf foo@1.0-0 pkg://test2/foo@1.1-0")
-                expected = \
-                    "foo              1.0-0 ---\n" \
-                    "foo (test2)      1.1-0 ---\n" \
-                    "foo (test2)      1.0-0 ---\n" \
-                    "hier/foo         1.0-0 ---\n" \
-                    "hier/foo (test2) 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -aHf foo@1.0-0 pkg://test2/foo@1.1-0")
-                expected = \
-                    "foo              1.0-0 ---\n" \
-                    "foo (test2)      1.1-0 ---\n" \
-                    "foo (test2)      1.0-0 ---\n" \
-                    "hier/foo         1.0-0 ---\n" \
-                    "hier/foo (test2) 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-        def test_06(self):
-                """Show versions 1.0 and 1.1 of foo only from publisher test2."""
-                self.pkg("list -aHf pkg://test2/foo")
-                expected = \
-                    "foo (test2) 1.2.1-0 ---\n" \
-                    "foo (test2) 1.2-0   ---\n" \
-                    "foo (test2) 1.1-0   ---\n" \
-                    "foo (test2) 1.0-0   ---\n" \
-                    "foo (test2) 1-0     ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -aH pkg://test2/foo")
-                expected = \
-                    "foo (test2) 1.2.1-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-        def test_07(self):
-                """List all foo@1 from test1, but all foo@1.2(.x), and only list
-                the latter once."""
-                self.pkg("list -aHf pkg://test1/foo@1 pkg:/foo@1.2")
-                expected = \
-                    "foo         1.2.1-0 ---\n" \
-                    "foo         1.2-0   ---\n" \
-                    "foo         1.1-0   ---\n" \
-                    "foo         1.0-0   ---\n" \
-                    "foo         1-0     ---\n" \
-                    "foo (test2) 1.2.1-0 ---\n" \
-                    "foo (test2) 1.2-0   ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -aH pkg://test1/foo@1 pkg:/foo@1.2")
-                expected = \
-                    "foo         1.2.1-0 ---\n" + \
-                    "foo (test2) 1.2.1-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-        def test_08_after_pub_update_removal(self):
-                """Install a package from a publisher which is also offered by
-                another publisher.  Then alter or remove the installed package's
-                publisher, and verify that list still shows the package
-                as installed."""
-
-                self.pkg("list -a")
-                # Install a package from the second publisher.
-                self.pkg("install pkg://test2/foo@1.0")
-
-                # Should only print fatal errors when using -q.
-                self.pkg("list -q foo")
-                self.__check_qoutput(errout=False)
-                self.pkg("list -q foo bogus", exit=3)
-                self.__check_qoutput(errout=False)
-
-                # Change the origin of the publisher of an installed package to
-                # that of an empty repository.  The package should still be
-                # shown for test1 and installed for test2.
-                self.pkg("set-publisher -O {0} test2".format(self.rurl3))
-                self.pkg("list -aHf /foo@1.0")
-                expected = \
-                    "foo 1.0-0 ---\n" + \
-                    "foo (test2) 1.0-0 im-\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-                self.pkg("set-publisher -O {0} test2".format(self.rurl2))
-
-                # Remove the publisher of an installed package, then add the
-                # publisher back, but with an empty repository.  The package
-                # should still be shown as for test1 and installed for test2.
-                self.pkg("unset-publisher test2")
-                self.pkg("set-publisher -O {0} test2".format(self.rurl3))
-                self.pkg("list -aHf /foo@1.0")
-                expected = \
-                    "foo 1.0-0 ---\n" + \
-                    "foo (test2) 1.0-0 im-\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-                self.pkg("set-publisher -O {0} test2".format(self.rurl2))
-
-                # With the publisher of an installed package unknown, add a new
-                # publisher using the repository the package was originally
-                # installed from.  The pkg should be shown as for test1,
-                # installed for test2, and test3 shouldn't be listed since the
-                # packages in the specified repository are for publisher test2.
-                self.pkg("unset-publisher test2")
-
-                # Uninstall the package so any remaining tests won't be
-                # impacted.
-                self.pkg("uninstall pkg://test2/foo@1.0")
-
-        def test_09_needs_refresh(self):
-                """Verify that a list operation performed when a publisher's
-                metadata needs refresh works as expected."""
-
-                # Package should not exist as an unprivileged user or as a
-                # privileged user since it hasn't been published yet.
-                self.pkg("list -a | grep newpkg", su_wrap=True, exit=1)
-                self.pkg("list -a | grep newpkg", exit=1)
-                # Should only print fatal errors when using -q.
-                self.pkg("list -aq newpkg", exit=1)
-                self.__check_qoutput(errout=False)
-
-                self.pkgsend_bulk(self.rurl1, self.newpkg10)
-
-                # Package should not exist as an unprivileged user or as a
-                # privileged user since the publisher doesn't need a refresh
-                # yet.
-                self.pkg("list -a | grep newpkg", su_wrap=True, exit=1)
-                self.pkg("list -a | grep newpkg", exit=1)
-
-                # Remove the last_refreshed file for one of the publishers so
-                # that it will be seen as needing refresh.
-                api_inst = self.get_img_api_obj()
-                pub = api_inst.get_publisher("test1")
-                os.remove(os.path.join(pub.meta_root, "last_refreshed"))
-
-                # Package should not exist as an unprivileged user since the
-                # metadata for the publisher has not yet been refreshed and
-                # cannot be.
-                self.pkg("list -a | grep newpkg", su_wrap=True, exit=1)
-
-                # pkg list should work as an unprivileged user even though one
-                # or more publishers need their metadata refreshed.
-                self.pkg("list -a", su_wrap=True)
-
-                # Package should exist as a privileged user since the metadata
-                # for the publisher needs to be refreshed and can be.
-                self.pkg("list -a | grep newpkg")
-
-                # Package should now exist for unprivileged user since the
-                # metadata has been refreshed.
-                self.pkg("list -a | grep newpkg", su_wrap=True)
-                # Should only print fatal errors when using -q.
-                self.pkg("list -aq newpkg")
-                self.__check_qoutput(errout=False)
-
-        def test_symlink_last_refreshed(self):
-                """Verify that we generate an error if the path to the
-                last_refreshed file contains a symlink."""
-
-                # Remove the last_refreshed file for one of the publishers so
-                # that it will be seen as needing refresh.
-                api_inst = self.get_img_api_obj()
-                pub = api_inst.get_publisher("test1")
-
-                file_path = os.path.join(pub.meta_root, "last_refreshed")
-                tmp_file = os.path.join(pub.meta_root, "test_symlink")
-                os.remove(file_path)
-                # We will create last_refreshed as symlink to verify with
-                # pkg operations.
-                fo = open(tmp_file, 'wb+')
-                fo.close()
-                os.symlink(tmp_file, file_path)
-
-                # Verify that both pkg install and refresh generate an error
-                # if the last_refreshed file is a symlink.
-                self.pkg("install newpkg@1.0", su_wrap=False, exit=1)
-                self.assertTrue("contains a symlink" in self.errout)
-
-                self.pkg("refresh test1", su_wrap=False, exit=1)
-                self.assertTrue("contains a symlink" in self.errout)
-
-                # Remove the temporary file and the lock file
-                os.remove(tmp_file)
-                os.remove(file_path)
-
-        def test_10_all_known_failed_refresh(self):
-                """Verify that a failed implicit refresh will not prevent pkg
-                list from working properly when appropriate."""
-
-                # Set test2's origin to an unreachable URI.
-                self.pkg("set-publisher --no-refresh -O http://test.invalid2 "
-                    "test2")
-
-                # Verify pkg list -a works as expected for an unprivileged user
-                # when a permissions failure is encountered.
-                self.pkg("list -a", su_wrap=True)
-
-                # Verify pkg list -a fails for a privileged user when a
-                # publisher's repository is unreachable.
-                self.pkg("list -a", exit=1)
-                # Should only print fatal errors when using -q.
-                self.pkg("list -aq newpkg", exit=1)
-                self.__check_qoutput(errout=True)
-
-                # Reset test2's origin.
-                self.pkg("set-publisher -O {0} test2".format(self.rurl2))
-
-        def test_11_v0_repo(self):
-                """Verify that pkg list works with a v0 repository, especially
-                for unprivileged users."""
-
-                # This test requires an actual depot due to v0 operation usage.
-                dc = self.dcs[1]
-                dc.set_disable_ops(["catalog/1"])
-                dc.start()
-                self.pkg("set-publisher --no-refresh -O {0} test1".format(
-                    dc.get_depot_url()))
-
-                self.pkg("refresh --full")
-
-                # This should work for an unprivileged user, even though it
-                # requires manifest retrieval (because of the v0 repo).
-
-                # we have to disable mandatory validation because v0 has
-                # no catalog checksums.
-                self.pkg("-D manifest_validate=Never list -a", su_wrap=True)
-
-                # This should work for a privileged user.
-                self.pkg("-D manifest_validate=Never list -a")
-
-                dc.stop()
-                dc.unset_disable_ops()
-
-                self.pkg("set-publisher --no-refresh -O {0} test1".format(self.rurl1))
-                self.pkg("refresh --full")
-
-        def test_12_matching(self):
-                """Verify that pkg list pattern matching works as expected."""
-
-                self.pkg("publisher")
-                self.pkg("list -aHf 'foo*'")
-                expected = \
-                    "foo              1.2.1-0 ---\n" \
-                    "foo              1.2-0   ---\n" \
-                    "foo              1.1-0   ---\n" \
-                    "foo              1.0-0   ---\n" \
-                    "foo              1-0     ---\n" \
-                    "foo (test2)      1.2.1-0 ---\n" \
-                    "foo (test2)      1.2-0   ---\n" \
-                    "foo (test2)      1.1-0   ---\n" \
-                    "foo (test2)      1.0-0   ---\n" \
-                    "foo (test2)      1-0     ---\n" \
-                    "food             1.2-0   ---\n" \
-                    "food (test2)     1.2-0   ---\n"
-
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-                self.pkg("list -aHf '/fo*'")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-                self.pkg("list -aHf 'f?o*'")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                expected += \
-                    "hier/foo         1.0-0   ---\n" \
-                    "hier/foo (test2) 1.0-0   ---\n"
-                expected = self.reduceSpaces(expected)
-                self.pkg("list -aHf '*fo*'")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -aH 'foo*'")
-                expected = \
-                    "foo              1.2.1-0 ---\n" \
-                    "foo (test2)      1.2.1-0 ---\n" \
-                    "food             1.2-0   ---\n" \
-                    "food (test2)     1.2-0   ---\n" \
-
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-                self.pkg("list -aH '/fo*'")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-                self.pkg("list -aH 'f?o*'")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                expected += \
-                    "hier/foo         1.0-0   ---\n" \
-                    "hier/foo (test2) 1.0-0   ---\n"
-                expected = self.reduceSpaces(expected)
-                self.pkg("list -aH '*fo*'")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                for pat, ecode in (("foo food", 0), ("bogus", 1),
-                    ("foo bogus", 3), ("foo food bogus", 3),
-                    ("bogus quirky names", 1), ("'fo*' bogus", 3),
-                    ("'fo*' food bogus", 3), ("'f?o*' bogus", 3)):
-                        self.pkg("list -a {0}".format(pat), exit=ecode)
-
-                self.pkg("list junk_pkg_name", exit=1)
-                self.assertTrue("junk_pkg_name" in self.errout)
-
-        def test_13_multi_name(self):
-                """Test for multiple name match listing."""
-                self.pkg("list -aHf '/foo*@1.2'")
-                expected = \
-                    "foo          1.2.1-0 ---\n" + \
-                    "foo          1.2-0   ---\n" + \
-                    "foo  (test2) 1.2.1-0 ---\n" + \
-                    "foo  (test2) 1.2-0   ---\n" + \
-                    "food         1.2-0   ---\n" + \
-                    "food (test2) 1.2-0   ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -aH '/foo*@1.2'")
-                expected = \
-                    "foo          1.2.1-0 ---\n" + \
-                    "foo  (test2) 1.2.1-0 ---\n" + \
-                    "food         1.2-0   ---\n" + \
-                    "food (test2) 1.2-0   ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-        def test_14_invalid_input(self):
-                """Verify that invalid input is handled gracefully."""
-
-                pats = ("bar -v", "*@a", "bar@a", "@1.0", "foo@1.0.a")
-                # First, test individually.
-                for val in pats:
-                        self.pkg("list {0}".format(val), exit=1)
-                        self.assertTrue(self.errout)
-
-                # Next, test invalid input but with options.  The option
-                # should not be in the error output. (If it is, the FMRI
-                # parsing has parsed the option too.)
-                self.pkg("list -a bar@a", exit=1)
-                self.assertTrue(self.output.find("FMRI '-a'") == -1)
-                # Should only print fatal errors when using -q.
-                self.pkg("list -aq bar@a", exit=1)
-                self.__check_qoutput(errout=True)
-
-                # Last, test all at once.
-                self.pkg("list {0}".format(" ".join(pats)), exit=1)
-
-        def test_15_latest(self):
-                """Verify that FMRIs using @latest work as expected and
-                that -n provides the same results."""
-
-                self.pkg("list -aHf foo@latest")
-                expected = \
-                    "foo              1.2.1-0 ---\n" \
-                    "foo (test2)      1.2.1-0 ---\n" \
-                    "hier/foo         1.0-0 ---\n" \
-                    "hier/foo (test2) 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -Hn foo")
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -aHf foo@latest foo@1.1 //test2/foo@1.2")
-                expected = \
-                    "foo              1.2.1-0 ---\n" \
-                    "foo              1.1-0   ---\n" \
-                    "foo (test2)      1.2.1-0 ---\n" \
-                    "foo (test2)      1.2-0   ---\n" \
-                    "foo (test2)      1.1-0   ---\n" \
-                    "hier/foo         1.0-0 ---\n" \
-                    "hier/foo (test2) 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -aHf /hier/foo@latest //test1/foo@latest")
-                expected = \
-                    "foo              1.2.1-0 ---\n" \
-                    "hier/foo         1.0-0 ---\n" \
-                    "hier/foo (test2) 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -Hn /hier/foo //test1/foo")
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-        def test_16_upgradable(self):
-                """Verify that pkg list -u works as expected."""
-
-                self.image_create(self.rurl1)
-                self.pkg("install /foo@1.0")
-
-                # 'foo' should be listed since 1.2.1 is available.
-                self.pkg("list -H")
-                expected = \
-                    "foo              1.0-0 im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                # 'foo' should be listed since 1.2.1 is available.
-                self.pkg("list -Hu foo")
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                # Should not print anything if using -q.
-                self.pkg("list -Hqu foo")
-                self.__check_qoutput(errout=False)
-
-                # Upgrade foo.
-                self.pkg("update foo")
-
-                # Should return error as newest version is now installed.
-                self.pkg("list -Hu foo", exit=1)
-                self.assertEqualDiff(self.output, "")
-                self.assertTrue(self.errout != "")
-                # Should not print anything if using -q.
-                self.pkg("list -Hqu foo", exit=1)
-                self.__check_qoutput(errout=False)
-
-        def test_16b_removable(self):
-                """Verify that pkg list -r works as expected."""
-
-                self.image_create(self.rurl1)
-                self.pkg("install -v /foo@1.0 fenix")
-
-                # foo, fenix and cowley should be installed
-                # (fenix depends on cowley)
-                self.pkg("list -H")
-                expected = \
-                    "cowley           1.1-0 i--\n" \
-                    "fenix            1.0-0 im-\n" \
-                    "foo              1.0-0 im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                # foo and fenix should be listed as removable
-                self.pkg("list -Hr")
-                expected = \
-                    "fenix            1.0-0 im-\n" \
-                    "foo              1.0-0 im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                # uninstalling fenix should make cowley removable
-                self.pkg("uninstall fenix")
-                self.pkg("list -Hr")
-                expected = \
-                    "cowley           1.1-0 i--\n" \
-                    "foo              1.0-0 im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                # install 'dragon', which optionally requires 'cowley'
-                # Now foo and dragon should be removable
-                self.pkg("install /dragon")
-                self.pkg("list -Hr")
-                expected = \
-                    "dragon           1.0-0 im-\n" \
-                    "foo              1.0-0 im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                # with -R, cowley should show up too, but flagged as 'system'
-                self.pkg("list -HR")
-                expected = \
-                    "cowley           1.1-0 iS-\n" \
-                    "dragon           1.0-0 im-\n" \
-                    "foo              1.0-0 im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-        def test_16c_manual(self):
-                """Verify that pkg list -m works as expected."""
-
-                self.image_create(self.rurl1)
-                self.pkg("install -v /foo@1.0 fenix")
-
-                # foo, fenix and cowley should be installed
-                # (fenix depends on cowley)
-                self.pkg("list -H")
-                expected = \
-                    "cowley           1.1-0 i--\n" \
-                    "fenix            1.0-0 im-\n" \
-                    "foo              1.0-0 im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                # -m should remove cowley from the list
-                self.pkg("list -Hm")
-                expected = \
-                    "fenix            1.0-0 im-\n" \
-                    "foo              1.0-0 im-\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                # -M should only show cowley
-                self.pkg("list -HM")
-                expected = \
-                    "cowley           1.1-0 i--\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                # Uninstalling a package should remove its m flag
-                self.pkg("uninstall fenix")
-
-                self.pkg("list -Ha fenix")
-                expected = \
-                    "fenix            1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-        def test_16d_installable(self):
-                """Verify that pkg list -i works as expected."""
-
-                # In a bulk test run, newpkg10 is published by test09
-                # above. To support running the test standalone, publish
-                # it explicitly here.
-                plist = self.pkgsend_bulk(self.rurl1, self.newpkg10)
-
-                self.image_create(self.rurl1)
-
-                self.pkg("list -Hi")
-                expected = \
-                    "cowley           1.1-0 ---\n" \
-                    "dragon           1.0-0 ---\n" \
-                    "fenix            1.0-0 ---\n" \
-                    "foo              1.2.1-0 ---\n" \
-                    "food             1.2-0 ---\n" \
-                    "hier/foo         1.0-0 ---\n" \
-                    "legacy           1.0-0 --l\n" \
-                    "newpkg           1.0   ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                # fenix and cowley should be installed
-                # (fenix depends on cowley)
-                self.pkg("install -v /foo@1.0 fenix")
-
-                self.pkg("list -Hi")
-                expected = \
-                    "dragon           1.0-0 ---\n" \
-                    "foo              1.2.1-0 ---\n" \
-                    "food             1.2-0 ---\n" \
-                    "hier/foo         1.0-0 ---\n" \
-                    "legacy           1.0-0 --l\n" \
-                    "newpkg           1.0   ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -Hi fenix")
-
-                expected = ""
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("uninstall fenix")
-
-                self.pkg("list -Hi fenix")
-
-                expected = \
-                    "fenix            1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-                self.pkg("list -Hi")
-
-                expected = \
-                    "dragon           1.0-0 ---\n" \
-                    "fenix            1.0-0 ---\n" \
-                    "foo              1.2.1-0 ---\n" \
-                    "food             1.2-0 ---\n" \
-                    "hier/foo         1.0-0 ---\n" \
-                    "legacy           1.0-0 --l\n" \
-                    "newpkg           1.0   ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
-
-        def test_17_verbose(self):
-                """Verify that pkg list -v works as expected."""
-
-                # FMRI with no branch component should be displayed correctly.
-                plist = self.pkgsend_bulk(self.rurl1, self.newpkg10)
-                self.pkg("install newpkg@1.0")
-                self.pkg("list -Hv newpkg")
-                output = self.reduceSpaces(self.output)
-                expected = fmri.PkgFmri(plist[0]).get_fmri(
-                    include_build=False) + " im-\n"
-                self.assertEqualDiff(expected, output)
-
-        def test_18_options(self):
-                """Verify some of the pkg list -o options"""
-
-                self.pkg("install fenix", exit=[0,4])
-
-                expected = {
-                    'branch': '0',
-                    'flags': 'im-',
-                    'name': 'fenix',
-                    'namepub': 'fenix',
-                    'osrelease': '5.11',
-                    'publisher': 'test1',
-                    'release': '1.0',
-                    'version': '1.0-0',
-                    'name,osrelease,publisher': 'fenix 5.11 test1',
-                }
-
-                for attr, val in expected.items():
-                        self.pkg(f"list -H -o {attr} fenix")
-                        output = self.reduceSpaces(self.output).rstrip()
-                        self.assertEqual(val, output)
-
-        def test_19_format(self):
-                """Verify pkg list -F"""
-
-                self.pkg("install fenix", exit=[0,4])
-
-                self.pkg("list -F tsv -o name,osrelease,publisher fenix")
-                self.assertEqualDiff(
-                    "NAME\tOS RELEASE\tPUBLISHER\n" + \
-                    "fenix\t5.11\ttest1\n", self.output)
-
-                self.pkg("list -HF tsv -o name,osrelease,publisher fenix")
-                self.assertEqual("fenix\t5.11\ttest1\n", self.output)
-
-                self.pkg("list -F json -o name,osrelease,publisher fenix")
-                self.assertEqualDiff(
-                    '[{"name":"fenix","osrelease":"5.11","publisher":"test1"}]',
-                    self.output)
-
+    def __check_qoutput(self, errout=False):
+        self.assertEqualDiff(self.output, "")
+        if errout:
+            self.assertTrue(self.errout != "", "-q must print fatal errors!")
+        else:
+            self.assertTrue(
+                self.errout == "", "-q should only print fatal errors!"
+            )
+
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2", "test2"])
+
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.pkgsend_bulk(
+            self.rurl1,
+            (
+                self.foo1,
+                self.foo10,
+                self.foo11,
+                self.foo12,
+                self.foo121,
+                self.food12,
+                self.hierfoo10,
+                self.renamed10,
+                self.legacy10,
+                self.obsolete10,
+                self.fenix10,
+                self.cowley11,
+                self.dragon10,
+            ),
+        )
+
+        # Ensure that the second repo's packages have exactly the same
+        # timestamps as those in the first ... by copying the repo over.
+        # If the repos need to have some contents which are different,
+        # send those changes after restarting depot 2.
+        d1dir = self.dcs[1].get_repodir()
+        d2dir = self.dcs[2].get_repodir()
+        self.copy_repository(d1dir, d2dir, {"test1": "test2"})
+
+        # The new repository won't have a catalog, so rebuild it.
+        self.dcs[2].get_repo(auto_create=True).rebuild()
+
+        # The third repository should remain empty and not be
+        # published to.
+
+        # Next, create the image and configure publishers.
+        self.image_create(self.rurl1, prefix="test1")
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.pkg("set-publisher -O " + self.rurl2 + " test2")
+
+        self.rurl3 = self.dcs[3].get_repo_url()
+
+    def test_pkg_list_cli_opts(self):
+        self.pkg("list -@", exit=2)
+        self.pkg("list -v -s", exit=2)
+        self.pkg("list -a -u", exit=2)
+        self.pkg("list -a -r", exit=2)
+        self.pkg("list -m -M", exit=2)
+        self.pkg("list -i -r", exit=2)
+        self.pkg("list -i -m", exit=2)
+        self.pkg("list -i -M", exit=2)
+        self.pkg("list -g pkg://test1/ -u", exit=2)
+
+        # Should only print fatal errors when using -q.
+        self.pkg("list -q -v", exit=2)
+        self.__check_qoutput(errout=True)
+
+    def test_00(self):
+        """Verify that sort order and content of a full list matches
+        expected."""
+
+        self.pkg("list -aH")
+        expected = (
+            "cowley 1.1-0 ---\n"
+            "cowley (test2) 1.1-0 ---\n"
+            "dragon 1.0-0 ---\n"
+            "dragon (test2) 1.0-0 ---\n"
+            "fenix 1.0-0 ---\n"
+            "fenix (test2) 1.0-0 ---\n"
+            "foo 1.2.1-0 ---\n"
+            "foo (test2) 1.2.1-0 ---\n"
+            "food 1.2-0 ---\n"
+            "food (test2) 1.2-0 ---\n"
+            "hier/foo 1.0-0 ---\n"
+            "hier/foo (test2) 1.0-0 ---\n"
+            "legacy 1.0-0 --l\n"
+            "legacy (test2) 1.0-0 --l\n"
+            "obsolete 1.0-0 --o\n"
+            "obsolete (test2) 1.0-0 --o\n"
+            "renamed 1.0-0 --r\n"
+            "renamed (test2) 1.0-0 --r\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # Should only print fatal errors when using -q.
+        self.pkg("list -aqH")
+        self.__check_qoutput(errout=False)
+
+        self.pkg("list -afH")
+        expected = (
+            "cowley 1.1-0 ---\n"
+            "cowley (test2) 1.1-0 ---\n"
+            "dragon 1.0-0 ---\n"
+            "dragon (test2) 1.0-0 ---\n"
+            "fenix 1.0-0 ---\n"
+            "fenix (test2) 1.0-0 ---\n"
+            "foo 1.2.1-0 ---\n"
+            "foo 1.2-0 ---\n"
+            "foo 1.1-0 ---\n"
+            "foo 1.0-0 ---\n"
+            "foo 1-0 ---\n"
+            "foo (test2) 1.2.1-0 ---\n"
+            "foo (test2) 1.2-0 ---\n"
+            "foo (test2) 1.1-0 ---\n"
+            "foo (test2) 1.0-0 ---\n"
+            "foo (test2) 1-0 ---\n"
+            "food 1.2-0 ---\n"
+            "food (test2) 1.2-0 ---\n"
+            "hier/foo 1.0-0 ---\n"
+            "hier/foo (test2) 1.0-0 ---\n"
+            "legacy 1.0-0 --l\n"
+            "legacy (test2) 1.0-0 --l\n"
+            "obsolete 1.0-0 --o\n"
+            "obsolete (test2) 1.0-0 --o\n"
+            "renamed 1.0-0 --r\n"
+            "renamed (test2) 1.0-0 --r\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # Put options in different order to ensure output still matches.
+        self.pkg("list -faH")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+    def test_01(self):
+        """List all "foo@1.0" from auth "test1"."""
+        self.pkg("list -afH pkg://test1/foo@1.0,5.11-0")
+        expected = "foo 1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # Test 'rooted' name.
+        self.pkg("list -afH //test1/foo@1.0,5.11-0")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+    def test_02(self):
+        """List all "foo@1.0", regardless of publisher, with "pkg:/"
+        or '/' prefix."""
+        self.pkg("list -afH pkg:/foo@1.0,5.11-0")
+        expected = "foo 1.0-0 ---\n" "foo (test2) 1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # Test 'rooted' name.
+        self.pkg("list -afH /foo@1.0,5.11-0")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+    def test_03(self):
+        """List all "foo@1.0", regardless of publisher, without "pkg:/"
+        prefix."""
+        self.pkg("list -afH pkg:/foo@1.0,5.11-0")
+        expected = "foo         1.0-0 ---\n" "foo (test2) 1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+    def test_04(self):
+        """List all versions of package foo, regardless of publisher."""
+        self.pkg("list -aHf foo")
+        expected = (
+            "foo              1.2.1-0 ---\n"
+            "foo              1.2-0   ---\n"
+            "foo              1.1-0   ---\n"
+            "foo              1.0-0   ---\n"
+            "foo              1-0     ---\n"
+            "foo (test2)      1.2.1-0 ---\n"
+            "foo (test2)      1.2-0   ---\n"
+            "foo (test2)      1.1-0   ---\n"
+            "foo (test2)      1.0-0   ---\n"
+            "foo (test2)      1-0     ---\n"
+            "hier/foo         1.0-0 ---\n"
+            "hier/foo (test2) 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -aH foo")
+        expected = (
+            "foo              1.2.1-0 ---\n"
+            "foo (test2)      1.2.1-0 ---\n"
+            "hier/foo         1.0-0 ---\n"
+            "hier/foo (test2) 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+    def test_05(self):
+        """Show foo@1.0 from both depots, but 1.1 only from test2."""
+        self.pkg("list -aHf foo@1.0-0 pkg://test2/foo@1.1-0")
+        expected = (
+            "foo              1.0-0 ---\n"
+            "foo (test2)      1.1-0 ---\n"
+            "foo (test2)      1.0-0 ---\n"
+            "hier/foo         1.0-0 ---\n"
+            "hier/foo (test2) 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -aHf foo@1.0-0 pkg://test2/foo@1.1-0")
+        expected = (
+            "foo              1.0-0 ---\n"
+            "foo (test2)      1.1-0 ---\n"
+            "foo (test2)      1.0-0 ---\n"
+            "hier/foo         1.0-0 ---\n"
+            "hier/foo (test2) 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+    def test_06(self):
+        """Show versions 1.0 and 1.1 of foo only from publisher test2."""
+        self.pkg("list -aHf pkg://test2/foo")
+        expected = (
+            "foo (test2) 1.2.1-0 ---\n"
+            "foo (test2) 1.2-0   ---\n"
+            "foo (test2) 1.1-0   ---\n"
+            "foo (test2) 1.0-0   ---\n"
+            "foo (test2) 1-0     ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -aH pkg://test2/foo")
+        expected = "foo (test2) 1.2.1-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+    def test_07(self):
+        """List all foo@1 from test1, but all foo@1.2(.x), and only list
+        the latter once."""
+        self.pkg("list -aHf pkg://test1/foo@1 pkg:/foo@1.2")
+        expected = (
+            "foo         1.2.1-0 ---\n"
+            "foo         1.2-0   ---\n"
+            "foo         1.1-0   ---\n"
+            "foo         1.0-0   ---\n"
+            "foo         1-0     ---\n"
+            "foo (test2) 1.2.1-0 ---\n"
+            "foo (test2) 1.2-0   ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -aH pkg://test1/foo@1 pkg:/foo@1.2")
+        expected = "foo         1.2.1-0 ---\n" + "foo (test2) 1.2.1-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+    def test_08_after_pub_update_removal(self):
+        """Install a package from a publisher which is also offered by
+        another publisher.  Then alter or remove the installed package's
+        publisher, and verify that list still shows the package
+        as installed."""
+
+        self.pkg("list -a")
+        # Install a package from the second publisher.
+        self.pkg("install pkg://test2/foo@1.0")
+
+        # Should only print fatal errors when using -q.
+        self.pkg("list -q foo")
+        self.__check_qoutput(errout=False)
+        self.pkg("list -q foo bogus", exit=3)
+        self.__check_qoutput(errout=False)
+
+        # Change the origin of the publisher of an installed package to
+        # that of an empty repository.  The package should still be
+        # shown for test1 and installed for test2.
+        self.pkg("set-publisher -O {0} test2".format(self.rurl3))
+        self.pkg("list -aHf /foo@1.0")
+        expected = "foo 1.0-0 ---\n" + "foo (test2) 1.0-0 im-\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+        self.pkg("set-publisher -O {0} test2".format(self.rurl2))
+
+        # Remove the publisher of an installed package, then add the
+        # publisher back, but with an empty repository.  The package
+        # should still be shown as for test1 and installed for test2.
+        self.pkg("unset-publisher test2")
+        self.pkg("set-publisher -O {0} test2".format(self.rurl3))
+        self.pkg("list -aHf /foo@1.0")
+        expected = "foo 1.0-0 ---\n" + "foo (test2) 1.0-0 im-\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+        self.pkg("set-publisher -O {0} test2".format(self.rurl2))
+
+        # With the publisher of an installed package unknown, add a new
+        # publisher using the repository the package was originally
+        # installed from.  The pkg should be shown as for test1,
+        # installed for test2, and test3 shouldn't be listed since the
+        # packages in the specified repository are for publisher test2.
+        self.pkg("unset-publisher test2")
+
+        # Uninstall the package so any remaining tests won't be
+        # impacted.
+        self.pkg("uninstall pkg://test2/foo@1.0")
+
+    def test_09_needs_refresh(self):
+        """Verify that a list operation performed when a publisher's
+        metadata needs refresh works as expected."""
+
+        # Package should not exist as an unprivileged user or as a
+        # privileged user since it hasn't been published yet.
+        self.pkg("list -a | grep newpkg", su_wrap=True, exit=1)
+        self.pkg("list -a | grep newpkg", exit=1)
+        # Should only print fatal errors when using -q.
+        self.pkg("list -aq newpkg", exit=1)
+        self.__check_qoutput(errout=False)
+
+        self.pkgsend_bulk(self.rurl1, self.newpkg10)
+
+        # Package should not exist as an unprivileged user or as a
+        # privileged user since the publisher doesn't need a refresh
+        # yet.
+        self.pkg("list -a | grep newpkg", su_wrap=True, exit=1)
+        self.pkg("list -a | grep newpkg", exit=1)
+
+        # Remove the last_refreshed file for one of the publishers so
+        # that it will be seen as needing refresh.
+        api_inst = self.get_img_api_obj()
+        pub = api_inst.get_publisher("test1")
+        os.remove(os.path.join(pub.meta_root, "last_refreshed"))
+
+        # Package should not exist as an unprivileged user since the
+        # metadata for the publisher has not yet been refreshed and
+        # cannot be.
+        self.pkg("list -a | grep newpkg", su_wrap=True, exit=1)
+
+        # pkg list should work as an unprivileged user even though one
+        # or more publishers need their metadata refreshed.
+        self.pkg("list -a", su_wrap=True)
+
+        # Package should exist as a privileged user since the metadata
+        # for the publisher needs to be refreshed and can be.
+        self.pkg("list -a | grep newpkg")
+
+        # Package should now exist for unprivileged user since the
+        # metadata has been refreshed.
+        self.pkg("list -a | grep newpkg", su_wrap=True)
+        # Should only print fatal errors when using -q.
+        self.pkg("list -aq newpkg")
+        self.__check_qoutput(errout=False)
+
+    def test_symlink_last_refreshed(self):
+        """Verify that we generate an error if the path to the
+        last_refreshed file contains a symlink."""
+
+        # Remove the last_refreshed file for one of the publishers so
+        # that it will be seen as needing refresh.
+        api_inst = self.get_img_api_obj()
+        pub = api_inst.get_publisher("test1")
+
+        file_path = os.path.join(pub.meta_root, "last_refreshed")
+        tmp_file = os.path.join(pub.meta_root, "test_symlink")
+        os.remove(file_path)
+        # We will create last_refreshed as symlink to verify with
+        # pkg operations.
+        fo = open(tmp_file, "wb+")
+        fo.close()
+        os.symlink(tmp_file, file_path)
+
+        # Verify that both pkg install and refresh generate an error
+        # if the last_refreshed file is a symlink.
+        self.pkg("install newpkg@1.0", su_wrap=False, exit=1)
+        self.assertTrue("contains a symlink" in self.errout)
+
+        self.pkg("refresh test1", su_wrap=False, exit=1)
+        self.assertTrue("contains a symlink" in self.errout)
+
+        # Remove the temporary file and the lock file
+        os.remove(tmp_file)
+        os.remove(file_path)
+
+    def test_10_all_known_failed_refresh(self):
+        """Verify that a failed implicit refresh will not prevent pkg
+        list from working properly when appropriate."""
+
+        # Set test2's origin to an unreachable URI.
+        self.pkg("set-publisher --no-refresh -O http://test.invalid2 " "test2")
+
+        # Verify pkg list -a works as expected for an unprivileged user
+        # when a permissions failure is encountered.
+        self.pkg("list -a", su_wrap=True)
+
+        # Verify pkg list -a fails for a privileged user when a
+        # publisher's repository is unreachable.
+        self.pkg("list -a", exit=1)
+        # Should only print fatal errors when using -q.
+        self.pkg("list -aq newpkg", exit=1)
+        self.__check_qoutput(errout=True)
+
+        # Reset test2's origin.
+        self.pkg("set-publisher -O {0} test2".format(self.rurl2))
+
+    def test_11_v0_repo(self):
+        """Verify that pkg list works with a v0 repository, especially
+        for unprivileged users."""
+
+        # This test requires an actual depot due to v0 operation usage.
+        dc = self.dcs[1]
+        dc.set_disable_ops(["catalog/1"])
+        dc.start()
+        self.pkg(
+            "set-publisher --no-refresh -O {0} test1".format(dc.get_depot_url())
+        )
+
+        self.pkg("refresh --full")
+
+        # This should work for an unprivileged user, even though it
+        # requires manifest retrieval (because of the v0 repo).
+
+        # we have to disable mandatory validation because v0 has
+        # no catalog checksums.
+        self.pkg("-D manifest_validate=Never list -a", su_wrap=True)
+
+        # This should work for a privileged user.
+        self.pkg("-D manifest_validate=Never list -a")
+
+        dc.stop()
+        dc.unset_disable_ops()
+
+        self.pkg("set-publisher --no-refresh -O {0} test1".format(self.rurl1))
+        self.pkg("refresh --full")
+
+    def test_12_matching(self):
+        """Verify that pkg list pattern matching works as expected."""
+
+        self.pkg("publisher")
+        self.pkg("list -aHf 'foo*'")
+        expected = (
+            "foo              1.2.1-0 ---\n"
+            "foo              1.2-0   ---\n"
+            "foo              1.1-0   ---\n"
+            "foo              1.0-0   ---\n"
+            "foo              1-0     ---\n"
+            "foo (test2)      1.2.1-0 ---\n"
+            "foo (test2)      1.2-0   ---\n"
+            "foo (test2)      1.1-0   ---\n"
+            "foo (test2)      1.0-0   ---\n"
+            "foo (test2)      1-0     ---\n"
+            "food             1.2-0   ---\n"
+            "food (test2)     1.2-0   ---\n"
+        )
+
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+        self.pkg("list -aHf '/fo*'")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+        self.pkg("list -aHf 'f?o*'")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        expected += (
+            "hier/foo         1.0-0   ---\n" "hier/foo (test2) 1.0-0   ---\n"
+        )
+        expected = self.reduceSpaces(expected)
+        self.pkg("list -aHf '*fo*'")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -aH 'foo*'")
+        expected = (
+            "foo              1.2.1-0 ---\n"
+            "foo (test2)      1.2.1-0 ---\n"
+            "food             1.2-0   ---\n"
+            "food (test2)     1.2-0   ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+        self.pkg("list -aH '/fo*'")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+        self.pkg("list -aH 'f?o*'")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        expected += (
+            "hier/foo         1.0-0   ---\n" "hier/foo (test2) 1.0-0   ---\n"
+        )
+        expected = self.reduceSpaces(expected)
+        self.pkg("list -aH '*fo*'")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        for pat, ecode in (
+            ("foo food", 0),
+            ("bogus", 1),
+            ("foo bogus", 3),
+            ("foo food bogus", 3),
+            ("bogus quirky names", 1),
+            ("'fo*' bogus", 3),
+            ("'fo*' food bogus", 3),
+            ("'f?o*' bogus", 3),
+        ):
+            self.pkg("list -a {0}".format(pat), exit=ecode)
+
+        self.pkg("list junk_pkg_name", exit=1)
+        self.assertTrue("junk_pkg_name" in self.errout)
+
+    def test_13_multi_name(self):
+        """Test for multiple name match listing."""
+        self.pkg("list -aHf '/foo*@1.2'")
+        expected = (
+            "foo          1.2.1-0 ---\n"
+            + "foo          1.2-0   ---\n"
+            + "foo  (test2) 1.2.1-0 ---\n"
+            + "foo  (test2) 1.2-0   ---\n"
+            + "food         1.2-0   ---\n"
+            + "food (test2) 1.2-0   ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -aH '/foo*@1.2'")
+        expected = (
+            "foo          1.2.1-0 ---\n"
+            + "foo  (test2) 1.2.1-0 ---\n"
+            + "food         1.2-0   ---\n"
+            + "food (test2) 1.2-0   ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+    def test_14_invalid_input(self):
+        """Verify that invalid input is handled gracefully."""
+
+        pats = ("bar -v", "*@a", "bar@a", "@1.0", "foo@1.0.a")
+        # First, test individually.
+        for val in pats:
+            self.pkg("list {0}".format(val), exit=1)
+            self.assertTrue(self.errout)
+
+        # Next, test invalid input but with options.  The option
+        # should not be in the error output. (If it is, the FMRI
+        # parsing has parsed the option too.)
+        self.pkg("list -a bar@a", exit=1)
+        self.assertTrue(self.output.find("FMRI '-a'") == -1)
+        # Should only print fatal errors when using -q.
+        self.pkg("list -aq bar@a", exit=1)
+        self.__check_qoutput(errout=True)
+
+        # Last, test all at once.
+        self.pkg("list {0}".format(" ".join(pats)), exit=1)
+
+    def test_15_latest(self):
+        """Verify that FMRIs using @latest work as expected and
+        that -n provides the same results."""
+
+        self.pkg("list -aHf foo@latest")
+        expected = (
+            "foo              1.2.1-0 ---\n"
+            "foo (test2)      1.2.1-0 ---\n"
+            "hier/foo         1.0-0 ---\n"
+            "hier/foo (test2) 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -Hn foo")
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -aHf foo@latest foo@1.1 //test2/foo@1.2")
+        expected = (
+            "foo              1.2.1-0 ---\n"
+            "foo              1.1-0   ---\n"
+            "foo (test2)      1.2.1-0 ---\n"
+            "foo (test2)      1.2-0   ---\n"
+            "foo (test2)      1.1-0   ---\n"
+            "hier/foo         1.0-0 ---\n"
+            "hier/foo (test2) 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -aHf /hier/foo@latest //test1/foo@latest")
+        expected = (
+            "foo              1.2.1-0 ---\n"
+            "hier/foo         1.0-0 ---\n"
+            "hier/foo (test2) 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -Hn /hier/foo //test1/foo")
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+    def test_16_upgradable(self):
+        """Verify that pkg list -u works as expected."""
+
+        self.image_create(self.rurl1)
+        self.pkg("install /foo@1.0")
+
+        # 'foo' should be listed since 1.2.1 is available.
+        self.pkg("list -H")
+        expected = "foo              1.0-0 im-\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        # 'foo' should be listed since 1.2.1 is available.
+        self.pkg("list -Hu foo")
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        # Should not print anything if using -q.
+        self.pkg("list -Hqu foo")
+        self.__check_qoutput(errout=False)
+
+        # Upgrade foo.
+        self.pkg("update foo")
+
+        # Should return error as newest version is now installed.
+        self.pkg("list -Hu foo", exit=1)
+        self.assertEqualDiff(self.output, "")
+        self.assertTrue(self.errout != "")
+        # Should not print anything if using -q.
+        self.pkg("list -Hqu foo", exit=1)
+        self.__check_qoutput(errout=False)
+
+    def test_16b_removable(self):
+        """Verify that pkg list -r works as expected."""
+
+        self.image_create(self.rurl1)
+        self.pkg("install -v /foo@1.0 fenix")
+
+        # foo, fenix and cowley should be installed
+        # (fenix depends on cowley)
+        self.pkg("list -H")
+        expected = (
+            "cowley           1.1-0 i--\n"
+            "fenix            1.0-0 im-\n"
+            "foo              1.0-0 im-\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        # foo and fenix should be listed as removable
+        self.pkg("list -Hr")
+        expected = "fenix            1.0-0 im-\n" "foo              1.0-0 im-\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        # uninstalling fenix should make cowley removable
+        self.pkg("uninstall fenix")
+        self.pkg("list -Hr")
+        expected = "cowley           1.1-0 i--\n" "foo              1.0-0 im-\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        # install 'dragon', which optionally requires 'cowley'
+        # Now foo and dragon should be removable
+        self.pkg("install /dragon")
+        self.pkg("list -Hr")
+        expected = "dragon           1.0-0 im-\n" "foo              1.0-0 im-\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        # with -R, cowley should show up too, but flagged as 'system'
+        self.pkg("list -HR")
+        expected = (
+            "cowley           1.1-0 iS-\n"
+            "dragon           1.0-0 im-\n"
+            "foo              1.0-0 im-\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+    def test_16c_manual(self):
+        """Verify that pkg list -m works as expected."""
+
+        self.image_create(self.rurl1)
+        self.pkg("install -v /foo@1.0 fenix")
+
+        # foo, fenix and cowley should be installed
+        # (fenix depends on cowley)
+        self.pkg("list -H")
+        expected = (
+            "cowley           1.1-0 i--\n"
+            "fenix            1.0-0 im-\n"
+            "foo              1.0-0 im-\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        # -m should remove cowley from the list
+        self.pkg("list -Hm")
+        expected = "fenix            1.0-0 im-\n" "foo              1.0-0 im-\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        # -M should only show cowley
+        self.pkg("list -HM")
+        expected = "cowley           1.1-0 i--\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        # Uninstalling a package should remove its m flag
+        self.pkg("uninstall fenix")
+
+        self.pkg("list -Ha fenix")
+        expected = "fenix            1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+    def test_16d_installable(self):
+        """Verify that pkg list -i works as expected."""
+
+        # In a bulk test run, newpkg10 is published by test09
+        # above. To support running the test standalone, publish
+        # it explicitly here.
+        plist = self.pkgsend_bulk(self.rurl1, self.newpkg10)
+
+        self.image_create(self.rurl1)
+
+        self.pkg("list -Hi")
+        expected = (
+            "cowley           1.1-0 ---\n"
+            "dragon           1.0-0 ---\n"
+            "fenix            1.0-0 ---\n"
+            "foo              1.2.1-0 ---\n"
+            "food             1.2-0 ---\n"
+            "hier/foo         1.0-0 ---\n"
+            "legacy           1.0-0 --l\n"
+            "newpkg           1.0   ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        # fenix and cowley should be installed
+        # (fenix depends on cowley)
+        self.pkg("install -v /foo@1.0 fenix")
+
+        self.pkg("list -Hi")
+        expected = (
+            "dragon           1.0-0 ---\n"
+            "foo              1.2.1-0 ---\n"
+            "food             1.2-0 ---\n"
+            "hier/foo         1.0-0 ---\n"
+            "legacy           1.0-0 --l\n"
+            "newpkg           1.0   ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -Hi fenix")
+
+        expected = ""
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("uninstall fenix")
+
+        self.pkg("list -Hi fenix")
+
+        expected = "fenix            1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+        self.pkg("list -Hi")
+
+        expected = (
+            "dragon           1.0-0 ---\n"
+            "fenix            1.0-0 ---\n"
+            "foo              1.2.1-0 ---\n"
+            "food             1.2-0 ---\n"
+            "hier/foo         1.0-0 ---\n"
+            "legacy           1.0-0 --l\n"
+            "newpkg           1.0   ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
+
+    def test_17_verbose(self):
+        """Verify that pkg list -v works as expected."""
+
+        # FMRI with no branch component should be displayed correctly.
+        plist = self.pkgsend_bulk(self.rurl1, self.newpkg10)
+        self.pkg("install newpkg@1.0")
+        self.pkg("list -Hv newpkg")
+        output = self.reduceSpaces(self.output)
+        expected = (
+            fmri.PkgFmri(plist[0]).get_fmri(include_build=False) + " im-\n"
+        )
+        self.assertEqualDiff(expected, output)
+
+    def test_18_options(self):
+        """Verify some of the pkg list -o options"""
+
+        self.pkg("install fenix", exit=[0, 4])
+
+        expected = {
+            "branch": "0",
+            "flags": "im-",
+            "name": "fenix",
+            "namepub": "fenix",
+            "osrelease": "5.11",
+            "publisher": "test1",
+            "release": "1.0",
+            "version": "1.0-0",
+            "name,osrelease,publisher": "fenix 5.11 test1",
+        }
+
+        for attr, val in expected.items():
+            self.pkg(f"list -H -o {attr} fenix")
+            output = self.reduceSpaces(self.output).rstrip()
+            self.assertEqual(val, output)
+
+    def test_19_format(self):
+        """Verify pkg list -F"""
+
+        self.pkg("install fenix", exit=[0, 4])
+
+        self.pkg("list -F tsv -o name,osrelease,publisher fenix")
+        self.assertEqualDiff(
+            "NAME\tOS RELEASE\tPUBLISHER\n" + "fenix\t5.11\ttest1\n",
+            self.output,
+        )
+
+        self.pkg("list -HF tsv -o name,osrelease,publisher fenix")
+        self.assertEqual("fenix\t5.11\ttest1\n", self.output)
+
+        self.pkg("list -F json -o name,osrelease,publisher fenix")
+        self.assertEqualDiff(
+            '[{"name":"fenix","osrelease":"5.11","publisher":"test1"}]',
+            self.output,
+        )
 
 
 class TestPkgListSingle(pkg5unittest.SingleDepotTestCase):
-        # Destroy test space every time.
-        persistent_setup = False
+    # Destroy test space every time.
+    persistent_setup = False
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        unsupp10 = """
+    unsupp10 = """
             open unsupported@1.0
             add depend type=require fmri=foo@1.0
             close """
 
-        def __check_qoutput(self, errout=False):
-                self.assertEqualDiff(self.output, "")
-                if errout:
-                        self.assertTrue(self.errout != "",
-                            "-q must print fatal errors!")
-                else:
-                        self.assertTrue(self.errout == "",
-                            "-q should only print fatal errors!")
+    def __check_qoutput(self, errout=False):
+        self.assertEqualDiff(self.output, "")
+        if errout:
+            self.assertTrue(self.errout != "", "-q must print fatal errors!")
+        else:
+            self.assertTrue(
+                self.errout == "", "-q should only print fatal errors!"
+            )
 
-        def test_01_empty_image(self):
-                """ pkg list should fail in an empty image """
+    def test_01_empty_image(self):
+        """pkg list should fail in an empty image"""
 
-                self.image_create(self.rurl)
-                self.pkg("list", exit=1)
-                self.assertTrue(self.errout)
+        self.image_create(self.rurl)
+        self.pkg("list", exit=1)
+        self.assertTrue(self.errout)
 
-                # Should not print anything if using -q.
-                self.pkg("list -q", exit=1)
-                self.__check_qoutput(errout=False)
+        # Should not print anything if using -q.
+        self.pkg("list -q", exit=1)
+        self.__check_qoutput(errout=False)
 
-        def __populate_repo(self, unsupp_content):
-                # Publish a package and then add some unsupported action data
-                # to the repository's copy of the manifest and catalog.
-                sfmri = self.pkgsend_bulk(self.rurl, self.unsupp10)[0]
-                pfmri = fmri.PkgFmri(sfmri)
-                repo = self.get_repo(self.dcs[1].get_repodir())
-                mpath = repo.manifest(pfmri)
+    def __populate_repo(self, unsupp_content):
+        # Publish a package and then add some unsupported action data
+        # to the repository's copy of the manifest and catalog.
+        sfmri = self.pkgsend_bulk(self.rurl, self.unsupp10)[0]
+        pfmri = fmri.PkgFmri(sfmri)
+        repo = self.get_repo(self.dcs[1].get_repodir())
+        mpath = repo.manifest(pfmri)
 
-                with open(mpath, "a+") as mfile:
-                        mfile.write(unsupp_content + "\n")
+        with open(mpath, "a+") as mfile:
+            mfile.write(unsupp_content + "\n")
 
-                mcontent = None
-                with open(mpath, "r") as mfile:
-                        mcontent = mfile.read()
+        mcontent = None
+        with open(mpath, "r") as mfile:
+            mcontent = mfile.read()
 
-                cat = repo.get_catalog("test")
-                cat.log_updates = False
+        cat = repo.get_catalog("test")
+        cat.log_updates = False
 
-                # Update the catalog signature.
-                entry = cat.get_entry(pfmri)
-                entry["signature-sha-1"] = manifest.Manifest.hash_create(
-                    mcontent)
+        # Update the catalog signature.
+        entry = cat.get_entry(pfmri)
+        entry["signature-sha-1"] = manifest.Manifest.hash_create(mcontent)
 
-                # Update the catalog actions.
-                self.debug(str(cat.parts))
-                dpart = cat.get_part("catalog.dependency.C", must_exist=True)
-                entry = dpart.get_entry(pfmri)
-                entry["actions"].append(unsupp_content)
+        # Update the catalog actions.
+        self.debug(str(cat.parts))
+        dpart = cat.get_part("catalog.dependency.C", must_exist=True)
+        entry = dpart.get_entry(pfmri)
+        entry["actions"].append(unsupp_content)
 
-                # Write out the new catalog.
-                cat.save()
+        # Write out the new catalog.
+        cat.save()
 
-        def test_02_unsupported(self):
-                """Verify that packages with invalid or unsupported actions are
-                handled gracefully.
-                """
+    def test_02_unsupported(self):
+        """Verify that packages with invalid or unsupported actions are
+        handled gracefully.
+        """
 
-                # Base package needed for testing.
-                self.pkgsend_bulk(self.rurl, self.foo10)
+        # Base package needed for testing.
+        self.pkgsend_bulk(self.rurl, self.foo10)
 
-                # Verify that a package with unsupported content doesn't cause
-                # a problem.
-                newact = "depend type=new-type fmri=foo@1.1"
+        # Verify that a package with unsupported content doesn't cause
+        # a problem.
+        newact = "depend type=new-type fmri=foo@1.1"
 
-                # Now create a new image and verify that pkg list will
-                # list both packages even though one of them has an
-                # unparseable manifest.
-                self.__populate_repo(newact)
-                self.image_create(self.rurl)
-                self.pkg("list -aH foo unsupported")
-                expected = \
-                    "foo         1.0-0 ---\n" \
-                    "unsupported 1.0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+        # Now create a new image and verify that pkg list will
+        # list both packages even though one of them has an
+        # unparseable manifest.
+        self.__populate_repo(newact)
+        self.image_create(self.rurl)
+        self.pkg("list -aH foo unsupported")
+        expected = "foo         1.0-0 ---\n" "unsupported 1.0 ---\n"
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("list -qaH foo unsupported")
-                self.__check_qoutput(errout=False)
+        self.pkg("list -qaH foo unsupported")
+        self.__check_qoutput(errout=False)
 
-                # Verify that a package with invalid content doesn't cause
-                # a problem.
-                newact = "depend notvalid"
-                self.__populate_repo(newact)
-                self.pkg("refresh --full")
-                self.pkg("list -afH foo unsupported")
-                expected = \
-                    "foo         1.0-0 ---\n" \
-                    "unsupported 1.0 ---\n" \
-                    "unsupported 1.0 ---\n"
-                output = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, output)
+        # Verify that a package with invalid content doesn't cause
+        # a problem.
+        newact = "depend notvalid"
+        self.__populate_repo(newact)
+        self.pkg("refresh --full")
+        self.pkg("list -afH foo unsupported")
+        expected = (
+            "foo         1.0-0 ---\n"
+            "unsupported 1.0 ---\n"
+            "unsupported 1.0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("list -afqH foo unsupported")
-                self.__check_qoutput(errout=False)
+        self.pkg("list -afqH foo unsupported")
+        self.__check_qoutput(errout=False)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_mediated.py
+++ b/src/tests/cli/t_pkg_mediated.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -41,11 +42,10 @@ import unittest
 
 
 class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
+    # Don't discard repository or setUp() every test.
+    persistent_setup = True
 
-        # Don't discard repository or setUp() every test.
-        persistent_setup = True
-
-        pkg_sendmail = """
+    pkg_sendmail = """
             open pkg://test/sendmail@0.5
             add set name=pkg.summary value="Example sendmail package"
             add file tmp/foosm path=/usr/bin/mailq owner=root group=root mode=0555
@@ -81,7 +81,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add link path=/usr/sbin/sendmail target=../lib/sendmail3-mta/sendmail mediator=mta mediator-implementation=sendmail
             close """
 
-        pkg_sendmail_links = """
+    pkg_sendmail_links = """
             open pkg://test/sendmail-links@1.0
             add set name=pkg.summary value="Example sendmail package for verifying symlink refcounts behaviour"
             add link path=/usr/bin/mailq target=../lib/sendmail-mta/mailq mediator=mta mediator-implementation=sendmail
@@ -97,7 +97,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add hardlink path=/usr/sbin/sendmail target=../lib/sendmail-mta/sendmail mediator=mta mediator-implementation=sendmail
             close """
 
-        pkg_postfix = """
+    pkg_postfix = """
             open pkg://test/postfix@1.0
             add set name=pkg.summary value="Example postfix package"
             add file tmp/foopf path=/opt/postfix/sbin/sendmail owner=root group=root mode=2555
@@ -115,7 +115,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add link path=/usr/sbin/sendmail target=../../opt/postfix/sbin/sendmail mediator=mta mediator-implementation=postfix mediator-priority=site
             close """
 
-        pkg_conflict_mta = """
+    pkg_conflict_mta = """
             open pkg://test/conflict-mta@1.0
             add file tmp/foopf path=/opt/conflict-mta/sbin/sendmail owner=root group=root mode=2555
             add link path=/usr/bin/mailq target=../../opt/conflict-mta/sbin/sendmail mediator=mail mediator-implementation=conflict
@@ -124,7 +124,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add link path=/usr/sbin/sendmail target=../../opt/conflict-mta/sbin/sendmail mediator=mail mediator-implementation=conflict
             close """
 
-        pkg_duplicate_mta = """
+    pkg_duplicate_mta = """
             open pkg://test/duplicate-mta@1.0
             add set name=pkg.summary value="Example mta package that provides duplicate mediation"
             add file tmp/food path=/usr/lib/duplicate-mta/sendmail owner=root group=root mode=2555
@@ -144,7 +144,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add hardlink path=/usr/sbin/sendmail target=../lib/duplicate-mta/sendmail mediator=mta mediator-implementation=sendmail
             close """
 
-        pkg_unmediated_mta = """
+    pkg_unmediated_mta = """
             open pkg://test/unmediated-mta@1.0
             add set name=pkg.summary value="Example unmediated mta package"
             add file tmp/foou path=/opt/unmediated/sbin/sendmail owner=root group=root mode=2555
@@ -162,7 +162,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add hardlink path=/usr/sbin/sendmail target=../../opt/unmediated/sbin/sendmail
             close """
 
-        pkg_perl = """
+    pkg_perl = """
             open pkg://test/runtime/perl-584@5.8.4
             add set name=pkg.summary value="Example perl package"
             add file tmp/foopl path=/usr/perl5/5.8.4/bin/perl5.8.4 owner=root group=bin mode=0555
@@ -176,7 +176,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add link path=/usr/bin/perl target=../perl5/5.10.0/bin/perl mediator=perl mediator-version=5.10.0
             close """
 
-        pkg_python = """
+    pkg_python = """
             open pkg://test/runtime/python-27@2.7.0
             add set name=pkg.summary value="Example python package"
             add file tmp/foopy path=/usr/bin/python2.7 owner=root group=bin mode=0555
@@ -203,7 +203,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add link path=/usr/bin/python target=python3.11-unladen-swallow mediator=python mediator-version=3.5 mediator-implementation=unladen-swallow@3.5
             close """
 
-        pkg_multi_python = """
+    pkg_multi_python = """
             open pkg://test/runtime/multi-impl-python-27@2.7.0
             add set name=pkg.summary value="Example python package with multiple implementations"
             add file tmp/foopy path=/usr/bin/python2.7 owner=root group=bin mode=0555
@@ -224,7 +224,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        pkg_vi = """
+    pkg_vi = """
             open pkg://test/editor/nvi@1.0
             add set name=pkg.summary value="Example nvi vendor priority package"
             add file tmp/foonvi path=/usr/bin/nvi owner=root group=bin mode=0555
@@ -246,7 +246,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add hardlink path=/usr/bin/vi target=vim mediator=vi mediator-implementation=vim mediator-priority=site facet.vi=true
             close """
 
-        pkg_multi_ver = """
+    pkg_multi_ver = """
             open pkg://test/web/server/apache-22/module/apache-php52@5.2.5
             add set name=pkg.summary value="Example multiple version mod_php package"
             add file tmp/fooc path=usr/apache2/2.2/libexec/mod_php5.2.so owner=root group=bin mode=0555
@@ -255,7 +255,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add link path=usr/apache2/2.2/libexec/mod_php5.so target=mod_php5.2.5.so mediator=php mediator-version=5.2.5
             close """
 
-        pkg_variant = """
+    pkg_variant = """
             open pkg://test/multi-ver-variant@1.0
             add set name=pkg.summary value="Example mediated varianted package"
             add file tmp/fooc path=/usr/bin/foo-1-nd owner=root group=bin mode=0555
@@ -268,7 +268,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add hardlink path=usr/bin/foo target=foo-2-d mediator=foo mediator-version=2 variant.debug.osnet=true
             close """
 
-        pkg_edit27 = """
+    pkg_edit27 = """
             open pkg://test/application/edition27@2.7.0
             add set name=pkg.summary value="Example mediated application 2.7"
             add file tmp/edition27 path=/usr/bin/edition27 owner=root group=bin mode=0555
@@ -277,12 +277,12 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add link path=usr/bin/edition-lib target=../lib/edition27 mediator=edition mediator-version=2.7 mediator-implementation=edit27 mediator-priority=vendor
             close """
 
-        pkg_edit271_obsolete = """
+    pkg_edit271_obsolete = """
             open pkg://test/application/edition27@2.7.1
             add set name=pkg.obsolete value=true
             close """
 
-        pkg_edit37 = """
+    pkg_edit37 = """
             open pkg://test/application/edition37@3.7.0
             add set name=pkg.summary value="Example mediated application 3.7"
             add file tmp/edition37 path=/usr/bin/edition37 owner=root group=bin mode=0555
@@ -291,7 +291,7 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add link path=usr/bin/edition-lib target=../lib/edition37 mediator=edition mediator-version=3.7 mediator-implementation=edit27 mediator-priority=vendor
             close """
 
-        pkg_edit371 = """
+    pkg_edit371 = """
             open pkg://test/application/edition37@3.7.1
             add set name=pkg.summary value="Example mediated application 3.7"
             add file tmp/edition371 path=/usr/bin/edition371 owner=root group=bin mode=0555
@@ -300,157 +300,223 @@ class TestPkgMediated(pkg5unittest.SingleDepotTestCase):
             add link path=usr/bin/edition-lib target=../lib/edition371 mediator=edition mediator-version=3.7 mediator-implementation=edit37 mediator-priority=vendor
             close """
 
-        pkg_incorp1 = """
+    pkg_incorp1 = """
             open pkg://test/application/edit-incorp@1.0
             add depend type=incorporate fmri=pkg:/application/edition27@2.7.0
             add depend type=incorporate fmri=pkg:/application/edition37@3.7.0
             close """
 
-        pkg_incorp2 = """
+    pkg_incorp2 = """
             open pkg://test/application/edit-incorp@2.0
             add depend type=incorporate fmri=pkg:/application/edition27@2.7.1
             add depend type=incorporate fmri=pkg:/application/edition37@3.7.1
             close """
 
-        misc_files = ["tmp/fooc", "tmp/food", "tmp/foopl", "tmp/foopy",
-            "tmp/foopyus", "tmp/foosm", "tmp/foopf", "tmp/foou", "tmp/foonvi",
-            "tmp/foovi", "tmp/foovim", "tmp/edition27", "tmp/edition37",
-            "tmp/edition371", "tmp/edition27-lib", "tmp/edition37-lib",
-            "tmp/edition371-lib"]
+    misc_files = [
+        "tmp/fooc",
+        "tmp/food",
+        "tmp/foopl",
+        "tmp/foopy",
+        "tmp/foopyus",
+        "tmp/foosm",
+        "tmp/foopf",
+        "tmp/foou",
+        "tmp/foonvi",
+        "tmp/foovi",
+        "tmp/foovim",
+        "tmp/edition27",
+        "tmp/edition37",
+        "tmp/edition371",
+        "tmp/edition27-lib",
+        "tmp/edition37-lib",
+        "tmp/edition371-lib",
+    ]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.pkgsend_bulk(self.rurl, [
-                    getattr(self, p)
-                    for p in dir(self)
-                    if p.startswith("pkg_") and isinstance(getattr(self, p),
-                        six.string_types)
-                ])
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.pkgsend_bulk(
+            self.rurl,
+            [
+                getattr(self, p)
+                for p in dir(self)
+                if p.startswith("pkg_")
+                and isinstance(getattr(self, p), six.string_types)
+            ],
+        )
 
-        def __assert_mediation_matches(self, expected, mediators=misc.EmptyI):
-                self.pkg("mediator -H -F tsv {0}".format(" ".join(mediators)))
-                self.assertEqualDiff(expected, self.output)
+    def __assert_mediation_matches(self, expected, mediators=misc.EmptyI):
+        self.pkg("mediator -H -F tsv {0}".format(" ".join(mediators)))
+        self.assertEqualDiff(expected, self.output)
 
-        def __assert_available_mediation_matches(self, expected,
-            mediators=misc.EmptyI, su_wrap=False):
-                self.pkg("mediator -H -F tsv -a {0}".format(" ".join(mediators)),
-                    su_wrap=su_wrap)
-                self.assertEqualDiff(expected, self.output)
+    def __assert_available_mediation_matches(
+        self, expected, mediators=misc.EmptyI, su_wrap=False
+    ):
+        self.pkg(
+            "mediator -H -F tsv -a {0}".format(" ".join(mediators)),
+            su_wrap=su_wrap,
+        )
+        self.assertEqualDiff(expected, self.output)
 
-        def __assert_human_mediation_matches(self, expected):
-                self.pkg("mediator")
-                self.assertEqualDiff(expected, self.output)
+    def __assert_human_mediation_matches(self, expected):
+        self.pkg("mediator")
+        self.assertEqualDiff(expected, self.output)
 
-        def test_00_mediator(self):
-                """Verify set-mediator / unset-mediator function as expected
-                when setting / unsetting values only.  Other tests verify
-                mediation change behaviour.
-                """
+    def test_00_mediator(self):
+        """Verify set-mediator / unset-mediator function as expected
+        when setting / unsetting values only.  Other tests verify
+        mediation change behaviour.
+        """
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                # Verify lack of required input results in graceful failure for
-                # set/unset-mediator.
-                self.pkg("set-mediator", exit=2)
-                self.pkg("set-mediator mta", exit=2)
-                self.pkg("unset-mediator", exit=2)
+        # Verify lack of required input results in graceful failure for
+        # set/unset-mediator.
+        self.pkg("set-mediator", exit=2)
+        self.pkg("set-mediator mta", exit=2)
+        self.pkg("unset-mediator", exit=2)
 
-                # Verify unsetting a mediator not set results in nothing to do.
-                self.pkg("unset-mediator mta", exit=4)
+        # Verify unsetting a mediator not set results in nothing to do.
+        self.pkg("unset-mediator mta", exit=4)
 
-                # Verify bad options or option input to set/unset-mediator
-                # result in graceful failure.
-                self.pkg("set-mediator -I not.valid mta", exit=2)
-                self.pkg("set-mediator --nosuchoption -I sendmail mta", exit=2)
-                self.pkg("set-mediator -I notvalid@a mta", exit=2)
-                self.pkg("set-mediator -I notvalid@1.a mta", exit=2)
-                self.pkg("set-mediator -I 'notvalid@$@^&@)' mta", exit=2)
-                self.pkg("set-mediator -I @1.0 mta", exit=2)
-                self.pkg("set-mediator -V not-valid mta", exit=2)
-                self.pkg("set-mediator -I '' mta", exit=2)
-                self.pkg("set-mediator -V '' mta", exit=2)
-                self.pkg("unset-mediator --nosuchoption mta", exit=2)
+        # Verify bad options or option input to set/unset-mediator
+        # result in graceful failure.
+        self.pkg("set-mediator -I not.valid mta", exit=2)
+        self.pkg("set-mediator --nosuchoption -I sendmail mta", exit=2)
+        self.pkg("set-mediator -I notvalid@a mta", exit=2)
+        self.pkg("set-mediator -I notvalid@1.a mta", exit=2)
+        self.pkg("set-mediator -I 'notvalid@$@^&@)' mta", exit=2)
+        self.pkg("set-mediator -I @1.0 mta", exit=2)
+        self.pkg("set-mediator -V not-valid mta", exit=2)
+        self.pkg("set-mediator -I '' mta", exit=2)
+        self.pkg("set-mediator -V '' mta", exit=2)
+        self.pkg("unset-mediator --nosuchoption mta", exit=2)
 
-                # Verify unprivileged user attempting set-mediator results in
-                # graceful failure.
-                self.pkg("set-mediator -vvv -I sendmail mta", exit=1,
-                    su_wrap=True)
+        # Verify unprivileged user attempting set-mediator results in
+        # graceful failure.
+        self.pkg("set-mediator -vvv -I sendmail mta", exit=1, su_wrap=True)
 
-                # Verify mediation can be set and that the parsable output is
-                # correct.
-                self.pkg("set-mediator -n --parsable=0 -I sendmail mta")
-                self.assertEqualParsable(self.output, change_mediators=[
-                    ["mta",
-                        [[None, None], [None, "system"]],
-                        [[None, None], ["sendmail", "local"]]]])
-                self.pkg("set-mediator --parsable=0 -I sendmail mta")
-                self.assertEqualParsable(self.output, change_mediators=[
-                    ["mta",
-                        [[None, None], [None, "system"]],
-                        [[None, None], ["sendmail", "local"]]]])
-                self.__assert_mediation_matches("""\
+        # Verify mediation can be set and that the parsable output is
+        # correct.
+        self.pkg("set-mediator -n --parsable=0 -I sendmail mta")
+        self.assertEqualParsable(
+            self.output,
+            change_mediators=[
+                [
+                    "mta",
+                    [[None, None], [None, "system"]],
+                    [[None, None], ["sendmail", "local"]],
+                ]
+            ],
+        )
+        self.pkg("set-mediator --parsable=0 -I sendmail mta")
+        self.assertEqualParsable(
+            self.output,
+            change_mediators=[
+                [
+                    "mta",
+                    [[None, None], [None, "system"]],
+                    [[None, None], ["sendmail", "local"]],
+                ]
+            ],
+        )
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tlocal\tsendmail\t
-""")
+"""
+        )
 
-                self.pkg("set-mediator -vvv -V 1.0 mta")
-                self.__assert_mediation_matches("""\
+        self.pkg("set-mediator -vvv -V 1.0 mta")
+        self.__assert_mediation_matches(
+            """\
 mta\tlocal\t1.0\tlocal\tsendmail\t
-""")
-                self.pkg("set-mediator -vvv -V '' -I sendmail mta")
-                self.__assert_mediation_matches("""\
+"""
+        )
+        self.pkg("set-mediator -vvv -V '' -I sendmail mta")
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tlocal\tsendmail\t
-""")
-                self.pkg("set-mediator -vvv -V 1.0 -I postfix@1.0 mta")
-                self.__assert_mediation_matches("""\
+"""
+        )
+        self.pkg("set-mediator -vvv -V 1.0 -I postfix@1.0 mta")
+        self.__assert_mediation_matches(
+            """\
 mta\tlocal\t1.0\tlocal\tpostfix@1.0\t
-""")
+"""
+        )
 
-                # Verify unprilveged user attempting unset-mediator results in
-                # graceful failure.
-                self.pkg("unset-mediator -I mta", exit=1, su_wrap=True)
+        # Verify unprilveged user attempting unset-mediator results in
+        # graceful failure.
+        self.pkg("unset-mediator -I mta", exit=1, su_wrap=True)
 
-                # Verify individual components of mediation can be unset.
-                self.pkg("unset-mediator -vvv -V mta")
-                self.__assert_mediation_matches("""\
+        # Verify individual components of mediation can be unset.
+        self.pkg("unset-mediator -vvv -V mta")
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tlocal\tpostfix@1.0\t
-""")
-                # Test the parsable output of set-mediator.
-                self.pkg("set-mediator --parsable=0 -V 1.0 mta")
-                self.assertEqualParsable(self.output, change_mediators=[
-                    ["mta",
-                        [[None, "system"], ["1.0", "local"]],
-                        [["postfix@1.0", "local"], ["postfix@1.0", "local"]]]])
-                self.__assert_mediation_matches("""\
+"""
+        )
+        # Test the parsable output of set-mediator.
+        self.pkg("set-mediator --parsable=0 -V 1.0 mta")
+        self.assertEqualParsable(
+            self.output,
+            change_mediators=[
+                [
+                    "mta",
+                    [[None, "system"], ["1.0", "local"]],
+                    [["postfix@1.0", "local"], ["postfix@1.0", "local"]],
+                ]
+            ],
+        )
+        self.__assert_mediation_matches(
+            """\
 mta\tlocal\t1.0\tlocal\tpostfix@1.0\t
-""")
+"""
+        )
 
-                self.pkg("unset-mediator -n --parsable=0 -I mta")
-                self.assertEqualParsable(self.output, change_mediators=[
-                    ["mta",
-                        [["1.0", "local"], ["1.0", "local"]],
-                        [["postfix@1.0", "local"], [None, "system"]]]])
-                self.pkg("unset-mediator --parsable=0 -I mta")
-                self.assertEqualParsable(self.output, change_mediators=[
-                    ["mta",
-                        [["1.0", "local"], ["1.0", "local"]],
-                        [["postfix@1.0", "local"], [None, "system"]]]])
-                self.__assert_mediation_matches("""\
+        self.pkg("unset-mediator -n --parsable=0 -I mta")
+        self.assertEqualParsable(
+            self.output,
+            change_mediators=[
+                [
+                    "mta",
+                    [["1.0", "local"], ["1.0", "local"]],
+                    [["postfix@1.0", "local"], [None, "system"]],
+                ]
+            ],
+        )
+        self.pkg("unset-mediator --parsable=0 -I mta")
+        self.assertEqualParsable(
+            self.output,
+            change_mediators=[
+                [
+                    "mta",
+                    [["1.0", "local"], ["1.0", "local"]],
+                    [["postfix@1.0", "local"], [None, "system"]],
+                ]
+            ],
+        )
+        self.__assert_mediation_matches(
+            """\
 mta\tlocal\t1.0\tsystem\t\t
-""")
+"""
+        )
 
-                # Verify unsetting last component without installed package
-                # results in completely removing mediation.
-                self.pkg("unset-mediator -vvv -V mta")
-                self.__assert_mediation_matches("""\
-""")
+        # Verify unsetting last component without installed package
+        # results in completely removing mediation.
+        self.pkg("unset-mediator -vvv -V mta")
+        self.__assert_mediation_matches(
+            """\
+"""
+        )
 
-                # Now install some packages to test the ability to list
-                # available mediations.
-                self.pkg("install -vvv \\*/python\\* \\*perl\\* \\*vi\\*")
+        # Now install some packages to test the ability to list
+        # available mediations.
+        self.pkg("install -vvv \\*/python\\* \\*perl\\* \\*vi\\*")
 
-                # Test listing all available mediations.
-                self.__assert_available_mediation_matches("""\
+        # Test listing all available mediations.
+        self.__assert_available_mediation_matches(
+            """\
 perl\tsystem\t5.10.0\tsystem\t\t
 perl\tsystem\t5.8.4\tsystem\t\t
 python\tsystem\t3.5\tsystem\tunladen-swallow@3.5\t
@@ -461,874 +527,982 @@ python\tsystem\t2.7\tsystem\tunladen-swallow\t
 vi\tsite\t\tsite\tvim\t
 vi\tvendor\t\tvendor\tnvi\t
 vi\tsystem\t\tsystem\tsvr4\t
-""")
+"""
+        )
 
-                # Dump image cache before continuing to verify the
-                # information is re-generated and operations succeed.
-                imgdir = self.get_img_api_obj().img.imgdir
-                cdir = os.path.join(imgdir, "cache")
-                assert os.path.exists(cdir)
-                shutil.rmtree(cdir)
+        # Dump image cache before continuing to verify the
+        # information is re-generated and operations succeed.
+        imgdir = self.get_img_api_obj().img.imgdir
+        cdir = os.path.join(imgdir, "cache")
+        assert os.path.exists(cdir)
+        shutil.rmtree(cdir)
 
-                # Test listing specific available mediations.
-                self.__assert_available_mediation_matches("""\
+        # Test listing specific available mediations.
+        self.__assert_available_mediation_matches(
+            """\
 perl\tsystem\t5.10.0\tsystem\t\t
 perl\tsystem\t5.8.4\tsystem\t\t
 vi\tsite\t\tsite\tvim\t
 vi\tvendor\t\tvendor\tnvi\t
 vi\tsystem\t\tsystem\tsvr4\t
-""", ("perl", "vi"), su_wrap=True)
-                self.__assert_available_mediation_matches("""\
+""",
+            ("perl", "vi"),
+            su_wrap=True,
+        )
+        self.__assert_available_mediation_matches(
+            """\
 vi\tsite\t\tsite\tvim\t
 vi\tvendor\t\tvendor\tnvi\t
 vi\tsystem\t\tsystem\tsvr4\t
-""", ("vi",))
+""",
+            ("vi",),
+        )
 
-                # Set facet.vi=false and verify vim mediation is no longer
-                # available but verify still passes.
-                self.pkg("change-facet -vvv vi=false")
-                self.__assert_available_mediation_matches("""\
+        # Set facet.vi=false and verify vim mediation is no longer
+        # available but verify still passes.
+        self.pkg("change-facet -vvv vi=false")
+        self.__assert_available_mediation_matches(
+            """\
 vi\tvendor\t\tvendor\tnvi\t
 vi\tsystem\t\tsystem\tsvr4\t
-""", ("vi",))
-                self.pkg("verify")
+""",
+            ("vi",),
+        )
+        self.pkg("verify")
 
-                # Set facet.vi=true and verify vim mediation is available again.
-                self.pkg("change-facet -vvv vi=true")
-                self.__assert_available_mediation_matches("""\
+        # Set facet.vi=true and verify vim mediation is available again.
+        self.pkg("change-facet -vvv vi=true")
+        self.__assert_available_mediation_matches(
+            """\
 vi\tsite\t\tsite\tvim\t
 vi\tvendor\t\tvendor\tnvi\t
 vi\tsystem\t\tsystem\tsvr4\t
-""", ("vi",))
-                self.pkg("verify")
+""",
+            ("vi",),
+        )
+        self.pkg("verify")
 
-                # Verify exit 1 if no mediators matched.
-                self.pkg("mediator no-match no-match2", exit=1)
-                self.pkg("mediator -a no-match no-match2", exit=1)
+        # Verify exit 1 if no mediators matched.
+        self.pkg("mediator no-match no-match2", exit=1)
+        self.pkg("mediator -a no-match no-match2", exit=1)
 
-                # Verify exit 3 (partial failure) if only some mediators match.
-                self.pkg("mediator perl no-match", exit=3)
-                self.pkg("mediator -a perl no-match", exit=3)
+        # Verify exit 3 (partial failure) if only some mediators match.
+        self.pkg("mediator perl no-match", exit=3)
+        self.pkg("mediator -a perl no-match", exit=3)
 
-        def test_01_symlink_mediation(self):
-                """Verify that package mediation works as expected for install,
-                update, and uninstall with symbolic links.
-                """
+    def test_01_symlink_mediation(self):
+        """Verify that package mediation works as expected for install,
+        update, and uninstall with symbolic links.
+        """
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                def gen_mta_files():
-                        for fname in ("mailq",):
-                                fpath = os.path.join(self.img_path(), "usr",
-                                    "bin", fname)
-                                yield fpath
+        def gen_mta_files():
+            for fname in ("mailq",):
+                fpath = os.path.join(self.img_path(), "usr", "bin", fname)
+                yield fpath
 
-                        for fname in ("sendmail",):
-                                fpath = os.path.join(self.img_path(), "usr",
-                                    "lib", fname)
-                                yield fpath
+            for fname in ("sendmail",):
+                fpath = os.path.join(self.img_path(), "usr", "lib", fname)
+                yield fpath
 
-                def gen_mta_links():
-                        for lname in ("mailq",):
-                                lpath = os.path.join(self.img_path(), "usr",
-                                    "bin", lname)
-                                yield lpath
+        def gen_mta_links():
+            for lname in ("mailq",):
+                lpath = os.path.join(self.img_path(), "usr", "bin", lname)
+                yield lpath
 
-                        for lname in ("newaliases", "sendmail"):
-                                lpath = os.path.join(self.img_path(), "usr",
-                                    "sbin", lname)
-                                yield lpath
+            for lname in ("newaliases", "sendmail"):
+                lpath = os.path.join(self.img_path(), "usr", "sbin", lname)
+                yield lpath
 
-                        for lname in ("sendmail",):
-                                lpath = os.path.join(self.img_path(), "usr",
-                                    "lib", lname)
-                                yield lpath
+            for lname in ("sendmail",):
+                lpath = os.path.join(self.img_path(), "usr", "lib", lname)
+                yield lpath
 
-                def gen_perl_links():
-                        for lname in ("perl",):
-                                lpath = os.path.join(self.img_path(), "usr",
-                                    "bin", lname)
-                                yield lpath
+        def gen_perl_links():
+            for lname in ("perl",):
+                lpath = os.path.join(self.img_path(), "usr", "bin", lname)
+                yield lpath
 
-                def gen_php_links():
-                        for lname in ("mod_php5.so",):
-                                lpath = os.path.join(self.img_path(), "usr",
-                                    "apache2", "2.2", "libexec", lname)
-                                yield lpath
+        def gen_php_links():
+            for lname in ("mod_php5.so",):
+                lpath = os.path.join(
+                    self.img_path(), "usr", "apache2", "2.2", "libexec", lname
+                )
+                yield lpath
 
-                def gen_python_links():
-                        for lname in ("python",):
-                                lpath = os.path.join(self.img_path(), "usr",
-                                    "bin", lname)
-                                yield lpath
+        def gen_python_links():
+            for lname in ("python",):
+                lpath = os.path.join(self.img_path(), "usr", "bin", lname)
+                yield lpath
 
-                def check_files(files):
-                        for fpath in files:
-                                s = os.lstat(fpath)
-                                self.assertTrue(stat.S_ISREG(s.st_mode))
+        def check_files(files):
+            for fpath in files:
+                s = os.lstat(fpath)
+                self.assertTrue(stat.S_ISREG(s.st_mode))
 
-                def check_target(links, target):
-                        for lpath in links:
-                                ltarget = os.readlink(lpath)
-                                self.assertTrue(target in ltarget)
+        def check_target(links, target):
+            for lpath in links:
+                ltarget = os.readlink(lpath)
+                self.assertTrue(target in ltarget)
 
-                def check_not_target(links, target):
-                        for lpath in links:
-                                ltarget = os.readlink(lpath)
-                                self.assertTrue(target not in ltarget)
+        def check_not_target(links, target):
+            for lpath in links:
+                ltarget = os.readlink(lpath)
+                self.assertTrue(target not in ltarget)
 
-                def check_exists(links):
-                        for lpath in links:
-                                self.assertTrue(os.path.exists(lpath))
+        def check_exists(links):
+            for lpath in links:
+                self.assertTrue(os.path.exists(lpath))
 
-                def check_not_exists(links):
-                        for lpath in links:
-                                self.assertTrue(not os.path.exists(lpath))
+        def check_not_exists(links):
+            for lpath in links:
+                self.assertTrue(not os.path.exists(lpath))
 
-                def remove_links(links):
-                        for lpath in links:
-                                portable.remove(lpath)
+        def remove_links(links):
+            for lpath in links:
+                portable.remove(lpath)
 
-                # Some installs are done with extra verbosity to ease in
-                # debugging tests when they fail.
-                self.pkg("install -vvv sendmail@0.5")
-                self.pkg("mediator") # If tests fail, this is helpful.
-                self.pkg("verify -v -p /usr/sbin/sendmail -p /usr/bin/mailq")
+        # Some installs are done with extra verbosity to ease in
+        # debugging tests when they fail.
+        self.pkg("install -vvv sendmail@0.5")
+        self.pkg("mediator")  # If tests fail, this is helpful.
+        self.pkg("verify -v -p /usr/sbin/sendmail -p /usr/bin/mailq")
 
-                # Verify that /usr/bin/mailq and /usr/lib/sendmail are files.
-                check_files(gen_mta_files())
-                self.pkg("verify -v")
+        # Verify that /usr/bin/mailq and /usr/lib/sendmail are files.
+        check_files(gen_mta_files())
+        self.pkg("verify -v")
 
-                # Upgrading to 1.0 should transition the files to links.
-                self.pkg("install -vvv sendmail@1")
-                self.pkg("mediator") # If tests fail, this is helpful.
-                self.pkg("verify -v")
-                self.pkg("verify -v -p /usr/sbin/sendmail -p /usr/bin/mailq")
-                self.pkg("verify -v -p /usr/sbin/sendmail -p /usr/bin/mailq sendmail@1")
+        # Upgrading to 1.0 should transition the files to links.
+        self.pkg("install -vvv sendmail@1")
+        self.pkg("mediator")  # If tests fail, this is helpful.
+        self.pkg("verify -v")
+        self.pkg("verify -v -p /usr/sbin/sendmail -p /usr/bin/mailq")
+        self.pkg("verify -v -p /usr/sbin/sendmail -p /usr/bin/mailq sendmail@1")
 
-                # Check that installed links point to sendmail and that
-                # verify passes.
-                check_target(gen_mta_links(), "sendmail-mta")
-                self.pkg("verify")
-                self.__assert_mediation_matches("""\
+        # Check that installed links point to sendmail and that
+        # verify passes.
+        check_target(gen_mta_links(), "sendmail-mta")
+        self.pkg("verify")
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tsystem\tsendmail\t
-""")
+"""
+        )
 
-                # Upgrading to 3.0 should change the targets of every link.
-                self.pkg("install -vvv sendmail@3")
-                self.pkg("mediator") # If tests fail, this is helpful.
-                check_target(gen_mta_links(), "sendmail3-mta")
-                self.pkg("verify -v")
-                self.pkg("verify -v -p /usr/sbin/sendmail -p /usr/bin/mailq")
-                self.pkg("verify -v -p /usr/sbin/sendmail -p /usr/bin/mailq sendmail@3")
+        # Upgrading to 3.0 should change the targets of every link.
+        self.pkg("install -vvv sendmail@3")
+        self.pkg("mediator")  # If tests fail, this is helpful.
+        check_target(gen_mta_links(), "sendmail3-mta")
+        self.pkg("verify -v")
+        self.pkg("verify -v -p /usr/sbin/sendmail -p /usr/bin/mailq")
+        self.pkg("verify -v -p /usr/sbin/sendmail -p /usr/bin/mailq sendmail@3")
 
-                # Downgrading to 0.5 should change sendmail and mailq links back
-                # to a file.
-                self.pkg("update -vvv sendmail@0.5")
-                self.pkg("mediator") # If tests fail, this is helpful.
-                check_files(gen_mta_files())
-                self.pkg("verify -v")
+        # Downgrading to 0.5 should change sendmail and mailq links back
+        # to a file.
+        self.pkg("update -vvv sendmail@0.5")
+        self.pkg("mediator")  # If tests fail, this is helpful.
+        check_files(gen_mta_files())
+        self.pkg("verify -v")
 
-                # Finally, upgrade to 1.0 again for remaining tests.
-                self.pkg("update -vvv sendmail@1.0")
-                self.pkg("mediator") # If tests fail, this is helpful.
-                check_target(gen_mta_links(), "sendmail-mta")
-                self.pkg("verify -v")
+        # Finally, upgrade to 1.0 again for remaining tests.
+        self.pkg("update -vvv sendmail@1.0")
+        self.pkg("mediator")  # If tests fail, this is helpful.
+        check_target(gen_mta_links(), "sendmail-mta")
+        self.pkg("verify -v")
 
-                # Install postfix (this should succeed even though sendmail is
-                # already installed) and the links should be updated to point to
-                # postfix, and verify should pass.
-                self.pkg("install -vvv postfix@1")
-                check_target(gen_mta_links(), "postfix")
-                self.pkg("verify")
-                self.__assert_mediation_matches("""\
+        # Install postfix (this should succeed even though sendmail is
+        # already installed) and the links should be updated to point to
+        # postfix, and verify should pass.
+        self.pkg("install -vvv postfix@1")
+        check_target(gen_mta_links(), "postfix")
+        self.pkg("verify")
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tsystem\tpostfix\t
-""")
+"""
+        )
 
-                # Remove the links for postfix, and then check that verify
-                # fails and that fix will restore the correct ones.
-                remove_links(gen_mta_links())
-                self.pkg("verify sendmail") # sendmail should be correct
-                self.pkg("verify postfix", exit=1) # postfix links are missing
-                self.pkg("fix")
-                self.pkg("verify")
-                check_target(gen_mta_links(), "postfix")
+        # Remove the links for postfix, and then check that verify
+        # fails and that fix will restore the correct ones.
+        remove_links(gen_mta_links())
+        self.pkg("verify sendmail")  # sendmail should be correct
+        self.pkg("verify postfix", exit=1)  # postfix links are missing
+        self.pkg("fix")
+        self.pkg("verify")
+        check_target(gen_mta_links(), "postfix")
 
-                # Verify that setting mediation to existing value results in
-                # a change since mediation will now be marked as source
-                # 'local'.
-                self.pkg("set-mediator -vvv -I postfix mta")
-                self.__assert_mediation_matches("""\
+        # Verify that setting mediation to existing value results in
+        # a change since mediation will now be marked as source
+        # 'local'.
+        self.pkg("set-mediator -vvv -I postfix mta")
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tlocal\tpostfix\t
-""")
+"""
+        )
 
-                # Verify that setting the same mediation again results in no
-                # changes since mediation is already effective and marked as
-                # source 'local'.
-                self.pkg("set-mediator -vvv -I postfix mta", exit=4)
+        # Verify that setting the same mediation again results in no
+        # changes since mediation is already effective and marked as
+        # source 'local'.
+        self.pkg("set-mediator -vvv -I postfix mta", exit=4)
 
-                # Now change mediation implementation to sendmail.
-                self.pkg("set-mediator -vvv -I sendmail mta")
-                self.__assert_mediation_matches("""\
+        # Now change mediation implementation to sendmail.
+        self.pkg("set-mediator -vvv -I sendmail mta")
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tlocal\tsendmail\t
-""")
+"""
+        )
 
-                # Check that installed links point to sendmail and that verify
-                # passes.
-                check_target(gen_mta_links(), "sendmail-mta")
-                self.pkg("verify")
+        # Check that installed links point to sendmail and that verify
+        # passes.
+        check_target(gen_mta_links(), "sendmail-mta")
+        self.pkg("verify")
 
-                # Now change mediation to implementation not available.  All
-                # mediated links should be removed, and verify should still
-                # pass.
-                self.pkg("set-mediator -vvv -I nosuchmta mta")
-                check_not_exists(gen_mta_links())
-                self.pkg("verify")
-                self.__assert_mediation_matches("""\
+        # Now change mediation to implementation not available.  All
+        # mediated links should be removed, and verify should still
+        # pass.
+        self.pkg("set-mediator -vvv -I nosuchmta mta")
+        check_not_exists(gen_mta_links())
+        self.pkg("verify")
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tlocal\tnosuchmta\t
-""")
+"""
+        )
 
-                # Now uninstall all packages.
-                self.pkg("uninstall -vvv \\*")
-                self.pkg("verify")
-                check_not_exists(gen_mta_links())
-                self.__assert_mediation_matches("""\
+        # Now uninstall all packages.
+        self.pkg("uninstall -vvv \\*")
+        self.pkg("verify")
+        check_not_exists(gen_mta_links())
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tlocal\tnosuchmta\t
-""")
+"""
+        )
 
-                # Now install both at the same time, since the bogus
-                # implementation is still set, no links should be installed.
-                self.pkg("install -vvv sendmail@1 postfix@1")
-                self.pkg("verify")
-                check_not_exists(gen_mta_links())
+        # Now install both at the same time, since the bogus
+        # implementation is still set, no links should be installed.
+        self.pkg("install -vvv sendmail@1 postfix@1")
+        self.pkg("verify")
+        check_not_exists(gen_mta_links())
 
-                # Now unset the mediation, postfix should be preferred since it
-                # is first lexically, and verify should pass.
-                self.pkg("unset-mediator -vvv -I mta")
-                check_target(gen_mta_links(), "postfix")
-                self.pkg("verify")
-                self.__assert_mediation_matches("""\
+        # Now unset the mediation, postfix should be preferred since it
+        # is first lexically, and verify should pass.
+        self.pkg("unset-mediator -vvv -I mta")
+        check_target(gen_mta_links(), "postfix")
+        self.pkg("verify")
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tsystem\tpostfix\t
-""")
+"""
+        )
 
-                # Now uninstall all packages, then reinstall them and verify
-                # that postfix was selected for initial install (since user did
-                # not explicitly set a mediation) and that verify passes.
-                self.pkg("uninstall \\*")
-                self.pkg("install -vvv sendmail@1 postfix@1")
-                check_target(gen_mta_links(), "postfix")
-                self.pkg("verify")
-                self.__assert_mediation_matches("""\
+        # Now uninstall all packages, then reinstall them and verify
+        # that postfix was selected for initial install (since user did
+        # not explicitly set a mediation) and that verify passes.
+        self.pkg("uninstall \\*")
+        self.pkg("install -vvv sendmail@1 postfix@1")
+        check_target(gen_mta_links(), "postfix")
+        self.pkg("verify")
+        self.__assert_mediation_matches(
+            """\
 mta\tsystem\t\tsystem\tpostfix\t
-""")
+"""
+        )
 
-                # Verify that an unmediated package can't be installed if it
-                # conflicts with mediated packages that are installed.
-                self.pkg("install unmediated-mta@1", exit=1)
-                self.pkg("install unmediated-mta@2", exit=1)
+        # Verify that an unmediated package can't be installed if it
+        # conflicts with mediated packages that are installed.
+        self.pkg("install unmediated-mta@1", exit=1)
+        self.pkg("install unmediated-mta@2", exit=1)
 
-                # Verify that a mediated package that delivers conflicting links
-                # with the same mediation as an installed package cannot be
-                # installed.
-                self.pkg("install duplicate-mta@1", exit=1)
-                self.pkg("install duplicate-mta@2", exit=1)
+        # Verify that a mediated package that delivers conflicting links
+        # with the same mediation as an installed package cannot be
+        # installed.
+        self.pkg("install duplicate-mta@1", exit=1)
+        self.pkg("install duplicate-mta@2", exit=1)
 
-                # Verify that a mediated package with a conflicting mediator
-                # can't be installed if it conflicts with mediated packages
-                # that are installed.
-                self.pkg("install conflict-mta", exit=1)
+        # Verify that a mediated package with a conflicting mediator
+        # can't be installed if it conflicts with mediated packages
+        # that are installed.
+        self.pkg("install conflict-mta", exit=1)
 
-                # Verify that an unmediated package can be installed if the
-                # mediated ones are removed.
-                self.pkg("install -vvv --reject postfix --reject sendmail "
-                    "unmediated-mta")
-                self.pkg("verify")
+        # Verify that an unmediated package can be installed if the
+        # mediated ones are removed.
+        self.pkg(
+            "install -vvv --reject postfix --reject sendmail " "unmediated-mta"
+        )
+        self.pkg("verify")
 
-                # Verify that mediated packages cannot be installed if an
-                # unmediated, conflicting package is installed.
-                self.pkg("install postfix", exit=1)
+        # Verify that mediated packages cannot be installed if an
+        # unmediated, conflicting package is installed.
+        self.pkg("install postfix", exit=1)
 
-                # Remove all packages, then install both postfix and sendmail,
-                # verify that postfix was selected, then remove postfix and
-                # verify sendmail is selected (since the user didn't explicitly
-                # set a mediation).
-                self.pkg("uninstall \\*")
-                self.pkg("install -vvv postfix@1 sendmail@1")
-                check_target(gen_mta_links(), "postfix")
-                self.pkg("verify")
-                self.pkg("uninstall -vvv postfix")
-                check_target(gen_mta_links(), "sendmail-mta")
-                self.pkg("verify")
+        # Remove all packages, then install both postfix and sendmail,
+        # verify that postfix was selected, then remove postfix and
+        # verify sendmail is selected (since the user didn't explicitly
+        # set a mediation).
+        self.pkg("uninstall \\*")
+        self.pkg("install -vvv postfix@1 sendmail@1")
+        check_target(gen_mta_links(), "postfix")
+        self.pkg("verify")
+        self.pkg("uninstall -vvv postfix")
+        check_target(gen_mta_links(), "sendmail-mta")
+        self.pkg("verify")
 
-                # Now explicitly set sendmail for the mediation, then remove
-                # sendmail and install postfix, and verify links are not
-                # present.
-                self.pkg("mediator")
-                self.pkg("set-mediator -vvv -I sendmail mta")
-                self.pkg("verify")
-                self.pkg("uninstall -vvv sendmail")
-                self.pkg("verify")
-                self.pkg("install -vvv postfix@1")
-                check_not_exists(gen_mta_links())
-                self.pkg("verify")
+        # Now explicitly set sendmail for the mediation, then remove
+        # sendmail and install postfix, and verify links are not
+        # present.
+        self.pkg("mediator")
+        self.pkg("set-mediator -vvv -I sendmail mta")
+        self.pkg("verify")
+        self.pkg("uninstall -vvv sendmail")
+        self.pkg("verify")
+        self.pkg("install -vvv postfix@1")
+        check_not_exists(gen_mta_links())
+        self.pkg("verify")
 
-                # Install sendmail again and verify links point to sendmail.
-                self.pkg("install -vvv sendmail@1")
-                check_target(gen_mta_links(), "sendmail-mta")
-                self.pkg("verify")
+        # Install sendmail again and verify links point to sendmail.
+        self.pkg("install -vvv sendmail@1")
+        check_target(gen_mta_links(), "sendmail-mta")
+        self.pkg("verify")
 
-                # Remove and install postfix and verify links still point to
-                # sendmail (since user explicitly set mediation to sendmail
-                # previously).
-                self.pkg("uninstall -vvv postfix")
-                self.pkg("verify")
-                self.pkg("install -vvv postfix@1")
-                check_target(gen_mta_links(), "sendmail-mta")
-                self.pkg("verify")
+        # Remove and install postfix and verify links still point to
+        # sendmail (since user explicitly set mediation to sendmail
+        # previously).
+        self.pkg("uninstall -vvv postfix")
+        self.pkg("verify")
+        self.pkg("install -vvv postfix@1")
+        check_target(gen_mta_links(), "sendmail-mta")
+        self.pkg("verify")
 
-                # Verify that a package with an identical set of links for
-                # sendmail can be installed and that verify passes.
-                self.pkg("install -vvv sendmail-links@1")
-                self.pkg("verify")
+        # Verify that a package with an identical set of links for
+        # sendmail can be installed and that verify passes.
+        self.pkg("install -vvv sendmail-links@1")
+        self.pkg("verify")
 
-                # Verify that removing sendmail-links will not remove the links
-                # since sendmail still delivers them and that verify
-                # still passes.
-                self.pkg("uninstall -vvv sendmail-links@1")
-                check_target(gen_mta_links(), "sendmail-mta")
-                self.pkg("verify")
+        # Verify that removing sendmail-links will not remove the links
+        # since sendmail still delivers them and that verify
+        # still passes.
+        self.pkg("uninstall -vvv sendmail-links@1")
+        check_target(gen_mta_links(), "sendmail-mta")
+        self.pkg("verify")
 
-                # Verify that a version of sendmail-links that delivers the
-                # links as hardlinks conflicts even though mediation is the
-                # the same.
-                self.pkg("install -vvv sendmail-links@2", exit=1)
+        # Verify that a version of sendmail-links that delivers the
+        # links as hardlinks conflicts even though mediation is the
+        # the same.
+        self.pkg("install -vvv sendmail-links@2", exit=1)
 
-                # Now install sendmail-links again, remove both of them,
-                # check that the link targets are gone and pkg verify passes.
-                self.pkg("install -vvv sendmail-links@1")
-                check_target(gen_mta_links(), "sendmail-mta")
-                self.pkg("verify")
-                # EXIT_PARTIAL because there is potentially a broken
-                # configuration.
-                self.pkg("uninstall -vvv sendmail sendmail-links",
-                         exit=pkgdefs.EXIT_PARTIAL)
-                check_not_exists(gen_mta_links())
-                self.pkg("verify")
+        # Now install sendmail-links again, remove both of them,
+        # check that the link targets are gone and pkg verify passes.
+        self.pkg("install -vvv sendmail-links@1")
+        check_target(gen_mta_links(), "sendmail-mta")
+        self.pkg("verify")
+        # EXIT_PARTIAL because there is potentially a broken
+        # configuration.
+        self.pkg(
+            "uninstall -vvv sendmail sendmail-links", exit=pkgdefs.EXIT_PARTIAL
+        )
+        check_not_exists(gen_mta_links())
+        self.pkg("verify")
 
-                # Unset mediation for following tests.
-                self.pkg("unset-mediator -vvv mta")
-                self.pkg("verify")
+        # Unset mediation for following tests.
+        self.pkg("unset-mediator -vvv mta")
+        self.pkg("verify")
 
-                # Install sendmail@1 and postfix@1, then upgrade to sendmail@2
-                # and verify that links point to sendmail due to vendor
-                # priority, and then upgrade to postfix@2 and verify that links
-                # point to postfix due to site priority.
-                self.pkg("install -vvv sendmail@1 postfix@1")
-                check_target(gen_mta_links(), "postfix")
-                self.pkg("update -vvv sendmail@2")
-                check_target(gen_mta_links(), "sendmail-mta")
-                self.__assert_mediation_matches("""\
+        # Install sendmail@1 and postfix@1, then upgrade to sendmail@2
+        # and verify that links point to sendmail due to vendor
+        # priority, and then upgrade to postfix@2 and verify that links
+        # point to postfix due to site priority.
+        self.pkg("install -vvv sendmail@1 postfix@1")
+        check_target(gen_mta_links(), "postfix")
+        self.pkg("update -vvv sendmail@2")
+        check_target(gen_mta_links(), "sendmail-mta")
+        self.__assert_mediation_matches(
+            """\
 mta\tvendor\t\tvendor\tsendmail\t
-""")
-                self.pkg("verify")
-                self.pkg("update -vvv postfix@2")
-                check_target(gen_mta_links(), "postfix")
-                self.__assert_mediation_matches("""\
+"""
+        )
+        self.pkg("verify")
+        self.pkg("update -vvv postfix@2")
+        check_target(gen_mta_links(), "postfix")
+        self.__assert_mediation_matches(
+            """\
 mta\tsite\t\tsite\tpostfix\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # The mta packages are left installed to verify that the system
-                # properly handles multiple mediators in an image.
+        # The mta packages are left installed to verify that the system
+        # properly handles multiple mediators in an image.
 
-                # Install perl5.8.4 and verify link targets point to 5.8.4
-                # and verify passes.
-                self.pkg("install -vvv perl-584")
-                check_target(gen_perl_links(), "5.8.4")
-                self.pkg("verify")
+        # Install perl5.8.4 and verify link targets point to 5.8.4
+        # and verify passes.
+        self.pkg("install -vvv perl-584")
+        check_target(gen_perl_links(), "5.8.4")
+        self.pkg("verify")
 
-                # Install perl5.10.0 and verify link targets point to 5.10.0
-                # and verify passes.
-                self.pkg("install -vvv perl-510")
-                check_target(gen_perl_links(), "5.10.0")
-                self.pkg("verify")
+        # Install perl5.10.0 and verify link targets point to 5.10.0
+        # and verify passes.
+        self.pkg("install -vvv perl-510")
+        check_target(gen_perl_links(), "5.10.0")
+        self.pkg("verify")
 
-                # Change mediation to 5.8.4 and verify link targets point to
-                # 5.8.4 and verify passes.
-                self.pkg("set-mediator -vvv -V 5.8.4 perl")
-                check_target(gen_perl_links(), "5.8.4")
-                self.__assert_mediation_matches("""\
-mta\tsite\t\tsite\tpostfix\t
-perl\tlocal\t5.8.4\tsystem\t\t
-""")
-                self.pkg("verify")
-
-                # Remove perl5.8.4 and verify links no longer exist and verify
-                # passes.
-                self.pkg("uninstall -vvv perl-584")
-                check_not_exists(gen_perl_links())
-                self.__assert_mediation_matches("""\
+        # Change mediation to 5.8.4 and verify link targets point to
+        # 5.8.4 and verify passes.
+        self.pkg("set-mediator -vvv -V 5.8.4 perl")
+        check_target(gen_perl_links(), "5.8.4")
+        self.__assert_mediation_matches(
+            """\
 mta\tsite\t\tsite\tpostfix\t
 perl\tlocal\t5.8.4\tsystem\t\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # Unset mediation, verify links point to perl5.10.0,
-                # remove perl-510, verify links do not exist, verify
-                # passes, and mediation is unknown.
-                self.pkg("unset-mediator -vvv perl")
-                check_target(gen_perl_links(), "5.10.0")
-                self.__assert_mediation_matches("""\
+        # Remove perl5.8.4 and verify links no longer exist and verify
+        # passes.
+        self.pkg("uninstall -vvv perl-584")
+        check_not_exists(gen_perl_links())
+        self.__assert_mediation_matches(
+            """\
+mta\tsite\t\tsite\tpostfix\t
+perl\tlocal\t5.8.4\tsystem\t\t
+"""
+        )
+        self.pkg("verify")
+
+        # Unset mediation, verify links point to perl5.10.0,
+        # remove perl-510, verify links do not exist, verify
+        # passes, and mediation is unknown.
+        self.pkg("unset-mediator -vvv perl")
+        check_target(gen_perl_links(), "5.10.0")
+        self.__assert_mediation_matches(
+            """\
 mta\tsite\t\tsite\tpostfix\t
 perl\tsystem\t5.10.0\tsystem\t\t
-""")
-                self.pkg("uninstall -vvv perl-510")
-                self.pkg("mediator perl", exit=1)
-                self.__assert_mediation_matches("""\
+"""
+        )
+        self.pkg("uninstall -vvv perl-510")
+        self.pkg("mediator perl", exit=1)
+        self.__assert_mediation_matches(
+            """\
 mta\tsite\t\tsite\tpostfix\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # Install both perl5.8.4 and perl5.10.0, verify that 5.10.0 is
-                # preferred for links as it has the greatest version, and that
-                # verify passes.
-                self.pkg("install -vvv perl-584 perl-510")
-                check_target(gen_perl_links(), "5.10.0")
-                self.__assert_mediation_matches("""\
+        # Install both perl5.8.4 and perl5.10.0, verify that 5.10.0 is
+        # preferred for links as it has the greatest version, and that
+        # verify passes.
+        self.pkg("install -vvv perl-584 perl-510")
+        check_target(gen_perl_links(), "5.10.0")
+        self.__assert_mediation_matches(
+            """\
 mta\tsite\t\tsite\tpostfix\t
 perl\tsystem\t5.10.0\tsystem\t\t
-""")
-                self.pkg("verify")
-                self.pkg("uninstall -vvv \\*")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
+        self.pkg("uninstall -vvv \\*")
+        self.pkg("verify")
 
-                # Install python and python-unladen-swallow at the same time,
-                # verify that unladen-swallow is NOT selected.
-                self.pkg("install python-27 python-unladen-swallow-27")
-                self.__assert_mediation_matches("""\
+        # Install python and python-unladen-swallow at the same time,
+        # verify that unladen-swallow is NOT selected.
+        self.pkg("install python-27 python-unladen-swallow-27")
+        self.__assert_mediation_matches(
+            """\
 python\tsystem\t2.7\tsystem\t\t
-""")
-                check_not_target(gen_python_links(), "unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_not_target(gen_python_links(), "unladen-swallow")
+        self.pkg("verify")
 
-                # Set only mediation version and verify unladen swallow is NOT
-                # selected.
-                self.pkg("set-mediator -vvv -V 2.7 python")
-                self.__assert_mediation_matches("""\
+        # Set only mediation version and verify unladen swallow is NOT
+        # selected.
+        self.pkg("set-mediator -vvv -V 2.7 python")
+        self.__assert_mediation_matches(
+            """\
 python\tlocal\t2.7\tsystem\t\t
-""")
-                check_not_target(gen_python_links(), "unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_not_target(gen_python_links(), "unladen-swallow")
+        self.pkg("verify")
 
-                # Set mediation implementation to unladen swallow and verify it
-                # was selected.
-                self.pkg("set-mediator -vvv -I unladen-swallow python")
-                self.__assert_mediation_matches("""\
+        # Set mediation implementation to unladen swallow and verify it
+        # was selected.
+        self.pkg("set-mediator -vvv -I unladen-swallow python")
+        self.__assert_mediation_matches(
+            """\
 python\tlocal\t2.7\tlocal\tunladen-swallow\t
-""")
-                check_target(gen_python_links(), "unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_target(gen_python_links(), "unladen-swallow")
+        self.pkg("verify")
 
-                # Unset only version mediation and verify unladen swallow is
-                # still selected.
-                self.pkg("unset-mediator -V python")
-                self.__assert_mediation_matches("""\
+        # Unset only version mediation and verify unladen swallow is
+        # still selected.
+        self.pkg("unset-mediator -V python")
+        self.__assert_mediation_matches(
+            """\
 python\tsystem\t2.7\tlocal\tunladen-swallow\t
-""")
-                check_target(gen_python_links(), "unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_target(gen_python_links(), "unladen-swallow")
+        self.pkg("verify")
 
-                # Install python-34 and verify unladen swallow is still
-                # selected.
-                self.pkg("install python-34")
-                self.__assert_mediation_matches("""\
+        # Install python-34 and verify unladen swallow is still
+        # selected.
+        self.pkg("install python-34")
+        self.__assert_mediation_matches(
+            """\
 python\tsystem\t2.7\tlocal\tunladen-swallow\t
-""")
-                check_target(gen_python_links(), "unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_target(gen_python_links(), "unladen-swallow")
+        self.pkg("verify")
 
-                # Install python-unladen-swallow-34 and verify that version
-                # is selected.
-                self.pkg("install python-unladen-swallow-34")
-                self.__assert_mediation_matches("""\
+        # Install python-unladen-swallow-34 and verify that version
+        # is selected.
+        self.pkg("install python-unladen-swallow-34")
+        self.__assert_mediation_matches(
+            """\
 python\tsystem\t3.4\tlocal\tunladen-swallow\t
-""")
-                check_target(gen_python_links(), "python3.4-unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_target(gen_python_links(), "python3.4-unladen-swallow")
+        self.pkg("verify")
 
-                # Set mediation version to 2.7 and verify that version of
-                # unladen swallow is selected.
-                self.pkg("set-mediator -vvv -V 2.7 python")
-                self.__assert_mediation_matches("""\
+        # Set mediation version to 2.7 and verify that version of
+        # unladen swallow is selected.
+        self.pkg("set-mediator -vvv -V 2.7 python")
+        self.__assert_mediation_matches(
+            """\
 python\tlocal\t2.7\tlocal\tunladen-swallow\t
-""")
-                check_target(gen_python_links(), "python2.7-unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_target(gen_python_links(), "python2.7-unladen-swallow")
+        self.pkg("verify")
 
-                # Unset implementation mediation and verify unladen swallow
-                # is NOT selected.
-                self.pkg("unset-mediator -vvv -I python")
-                self.__assert_mediation_matches("""\
+        # Unset implementation mediation and verify unladen swallow
+        # is NOT selected.
+        self.pkg("unset-mediator -vvv -I python")
+        self.__assert_mediation_matches(
+            """\
 python\tlocal\t2.7\tsystem\t\t
-""")
-                check_not_target(gen_python_links(), "unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_not_target(gen_python_links(), "unladen-swallow")
+        self.pkg("verify")
 
-                # Remove python-27 and python-34 and then verify unladen swallow
-                # is selected.
-                self.pkg("uninstall -vvv python-27 python-34")
-                self.__assert_mediation_matches("""\
+        # Remove python-27 and python-34 and then verify unladen swallow
+        # is selected.
+        self.pkg("uninstall -vvv python-27 python-34")
+        self.__assert_mediation_matches(
+            """\
 python\tlocal\t2.7\tsystem\tunladen-swallow\t
-""")
-                check_target(gen_python_links(), "python2.7-unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_target(gen_python_links(), "python2.7-unladen-swallow")
+        self.pkg("verify")
 
-                # Set mediation implementation to None explicitly and verify
-                # unladen swallow is NOT selected and link does not exist
-                # since no package satisfied mediation.
-                self.pkg("set-mediator -vvv -I None python")
-                self.__assert_mediation_matches("""\
+        # Set mediation implementation to None explicitly and verify
+        # unladen swallow is NOT selected and link does not exist
+        # since no package satisfied mediation.
+        self.pkg("set-mediator -vvv -I None python")
+        self.__assert_mediation_matches(
+            """\
 python\tlocal\t2.7\tlocal\t\t
-""")
-                check_not_exists(gen_python_links())
-                self.pkg("verify")
+"""
+        )
+        check_not_exists(gen_python_links())
+        self.pkg("verify")
 
-                # Install unladen-swallow@3.5, then set mediation implementation
-                # to unladen-swallow@3.5 and verify the 3.5 implementation is
-                # selected.
-                self.pkg("install -vvv python-unladen-swallow-35")
-                check_not_exists(gen_python_links())
-                self.pkg("verify")
-                self.pkg("set-mediator -vvv "
-                    "-V '' -I unladen-swallow@3.5 python")
-                check_target(gen_python_links(), "python3.11-unladen-swallow")
-                self.__assert_mediation_matches("""\
+        # Install unladen-swallow@3.5, then set mediation implementation
+        # to unladen-swallow@3.5 and verify the 3.5 implementation is
+        # selected.
+        self.pkg("install -vvv python-unladen-swallow-35")
+        check_not_exists(gen_python_links())
+        self.pkg("verify")
+        self.pkg("set-mediator -vvv " "-V '' -I unladen-swallow@3.5 python")
+        check_target(gen_python_links(), "python3.11-unladen-swallow")
+        self.__assert_mediation_matches(
+            """\
 python\tsystem\t3.5\tlocal\tunladen-swallow@3.5\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # Set mediation to unladen-swallow and verify
-                # unladen-swallow@3.5 remains selected.
-                self.pkg("set-mediator -vvv -I unladen-swallow python")
-                check_target(gen_python_links(), "python3.11-unladen-swallow")
-                self.__assert_mediation_matches("""\
+        # Set mediation to unladen-swallow and verify
+        # unladen-swallow@3.5 remains selected.
+        self.pkg("set-mediator -vvv -I unladen-swallow python")
+        check_target(gen_python_links(), "python3.11-unladen-swallow")
+        self.__assert_mediation_matches(
+            """\
 python\tsystem\t3.5\tlocal\tunladen-swallow\t3.5
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # Remove installed links and ensure verify fails, then fix and
-                # ensure verify passes.
-                remove_links(gen_python_links())
-                self.pkg("verify -v python-unladen-swallow-27 "
-                    "python-unladen-swallow-34")
-                self.pkg("verify -v python-unladen-swallow-35", exit=1)
-                self.pkg("fix")
-                self.pkg("verify -v")
+        # Remove installed links and ensure verify fails, then fix and
+        # ensure verify passes.
+        remove_links(gen_python_links())
+        self.pkg(
+            "verify -v python-unladen-swallow-27 " "python-unladen-swallow-34"
+        )
+        self.pkg("verify -v python-unladen-swallow-35", exit=1)
+        self.pkg("fix")
+        self.pkg("verify -v")
 
-                # Human-readable output shows any version selected but not
-                # explicitly requested in parentheses.
-                self.__assert_human_mediation_matches("""\
+        # Human-readable output shows any version selected but not
+        # explicitly requested in parentheses.
+        self.__assert_human_mediation_matches(
+            """\
 MEDIATOR VER. SRC. VERSION IMPL. SRC. IMPLEMENTATION
 python   system    3.5     local      unladen-swallow(@3.5)
-""")
+"""
+        )
 
-                # Set mediation to unladen-swallow@ and verify unladen-swallow
-                # 3.4 is selected.
-                self.pkg("set-mediator -vvv -I unladen-swallow@ python")
-                check_target(gen_python_links(), "python3.4-unladen-swallow")
-                self.__assert_mediation_matches("""\
+        # Set mediation to unladen-swallow@ and verify unladen-swallow
+        # 3.4 is selected.
+        self.pkg("set-mediator -vvv -I unladen-swallow@ python")
+        check_target(gen_python_links(), "python3.4-unladen-swallow")
+        self.__assert_mediation_matches(
+            """\
 python\tsystem\t3.4\tlocal\tunladen-swallow@\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # Remove links and ensure verify fails for for unladen-swallow
-                # 3.4, but passes for 2.7 and 3.5, and that fix will allow
-                # verify to pass again.
-                remove_links(gen_python_links())
-                self.pkg("verify -v python-unladen-swallow-27 "
-                    "python-unladen-swallow-35")
-                self.pkg("verify -v python-unladen-swallow-34", exit=1)
-                self.pkg("verify -v -p /usr/bin/python", exit=1)
-                self.pkg("fix")
-                self.pkg("verify -v")
+        # Remove links and ensure verify fails for for unladen-swallow
+        # 3.4, but passes for 2.7 and 3.5, and that fix will allow
+        # verify to pass again.
+        remove_links(gen_python_links())
+        self.pkg(
+            "verify -v python-unladen-swallow-27 " "python-unladen-swallow-35"
+        )
+        self.pkg("verify -v python-unladen-swallow-34", exit=1)
+        self.pkg("verify -v -p /usr/bin/python", exit=1)
+        self.pkg("fix")
+        self.pkg("verify -v")
 
-                # Remove all packages; then verify that installing a single
-                # package that has multiple version mediations works as
-                # expected.
-                self.pkg("unset-mediator -I python")
-                self.pkg("uninstall \\*")
+        # Remove all packages; then verify that installing a single
+        # package that has multiple version mediations works as
+        # expected.
+        self.pkg("unset-mediator -I python")
+        self.pkg("uninstall \\*")
 
-                # Install apache-php52; verify that php 5.2.5 is selected.
-                self.pkg("install -vvv apache-php52")
-                self.__assert_mediation_matches("""\
+        # Install apache-php52; verify that php 5.2.5 is selected.
+        self.pkg("install -vvv apache-php52")
+        self.__assert_mediation_matches(
+            """\
 php\tsystem\t5.2.5\tsystem\t\t
-""")
-                check_target(gen_php_links(), "5.2.5")
-                self.pkg("verify")
+"""
+        )
+        check_target(gen_php_links(), "5.2.5")
+        self.pkg("verify")
 
-                # Test available mediations.
-                self.__assert_available_mediation_matches("""\
+        # Test available mediations.
+        self.__assert_available_mediation_matches(
+            """\
 php\tsystem\t5.2.5\tsystem\t\t
 php\tsystem\t5.2\tsystem\t\t
-""")
+"""
+        )
 
-                # Set mediation version to 5.2 and verify 5.2.5 is NOT selected.
-                self.pkg("set-mediator -vvv -V 5.2 php")
-                self.__assert_mediation_matches("""\
+        # Set mediation version to 5.2 and verify 5.2.5 is NOT selected.
+        self.pkg("set-mediator -vvv -V 5.2 php")
+        self.__assert_mediation_matches(
+            """\
 php\tlocal\t5.2\tsystem\t\t
-""")
-                check_not_target(gen_php_links(), "5.2.5")
-                self.pkg("verify")
+"""
+        )
+        check_not_target(gen_php_links(), "5.2.5")
+        self.pkg("verify")
 
-                # Remove all packages; then verify that installing a single
-                # package that has multiple mediation implementations works as
-                # expected.
-                self.pkg("uninstall \\*")
-                self.pkg("unset-mediator -V php")
+        # Remove all packages; then verify that installing a single
+        # package that has multiple mediation implementations works as
+        # expected.
+        self.pkg("uninstall \\*")
+        self.pkg("unset-mediator -V php")
 
-                # Install multi-impl-python; verify that unladen swallow is NOT
-                # selected.
-                self.pkg("install -vvv multi-impl-python-27")
-                self.__assert_mediation_matches("""\
+        # Install multi-impl-python; verify that unladen swallow is NOT
+        # selected.
+        self.pkg("install -vvv multi-impl-python-27")
+        self.__assert_mediation_matches(
+            """\
 python\tsystem\t\tsystem\tcpython\t
-""")
-                check_not_target(gen_python_links(), "unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_not_target(gen_python_links(), "unladen-swallow")
+        self.pkg("verify")
 
-                # Test available mediations.
-                self.__assert_available_mediation_matches("""\
+        # Test available mediations.
+        self.__assert_available_mediation_matches(
+            """\
 python\tsystem\t\tsystem\tcpython\t
 python\tsystem\t\tsystem\tunladen-swallow\t
-""")
+"""
+        )
 
-                # Set mediation implementation to unladen swallow and verify it
-                # was selected.
-                self.pkg("set-mediator -vvv -I unladen-swallow python")
-                self.__assert_mediation_matches("""\
+        # Set mediation implementation to unladen swallow and verify it
+        # was selected.
+        self.pkg("set-mediator -vvv -I unladen-swallow python")
+        self.__assert_mediation_matches(
+            """\
 python\tsystem\t\tlocal\tunladen-swallow\t
-""")
-                check_target(gen_python_links(), "unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_target(gen_python_links(), "unladen-swallow")
+        self.pkg("verify")
 
-                # Remove all packages; then verify that installing a single
-                # package that has multiple mediation and version
-                # implementations works as expected.
-                self.pkg("uninstall \\*")
-                self.pkg("unset-mediator -I python")
-                self.pkg("install -vvv multi-impl-ver-python")
+        # Remove all packages; then verify that installing a single
+        # package that has multiple mediation and version
+        # implementations works as expected.
+        self.pkg("uninstall \\*")
+        self.pkg("unset-mediator -I python")
+        self.pkg("install -vvv multi-impl-ver-python")
 
-                # Verify that the default implementation of Python 3.4 was
-                # selected even though the package offers Python 2.7 and an
-                # unladen swallow implemenation of each version of Python.
-                self.__assert_mediation_matches("""\
+        # Verify that the default implementation of Python 3.4 was
+        # selected even though the package offers Python 2.7 and an
+        # unladen swallow implemenation of each version of Python.
+        self.__assert_mediation_matches(
+            """\
 python\tsystem\t3.4\tsystem\t\t
-""")
-                check_not_target(gen_python_links(), "unladen-swallow")
-                self.pkg("verify")
+"""
+        )
+        check_not_target(gen_python_links(), "unladen-swallow")
+        self.pkg("verify")
 
-                # Test available mediations.
-                self.__assert_available_mediation_matches("""\
+        # Test available mediations.
+        self.__assert_available_mediation_matches(
+            """\
 python\tsystem\t3.4\tsystem\t\t
 python\tsystem\t3.4\tsystem\tunladen-swallow\t
 python\tsystem\t2.7\tsystem\t\t
 python\tsystem\t2.7\tsystem\tunladen-swallow\t
-""")
+"""
+        )
 
-        def test_02_hardlink_mediation(self):
-                """Verify that package mediation works as expected for install,
-                update, and uninstall with hardlinks.
-                """
+    def test_02_hardlink_mediation(self):
+        """Verify that package mediation works as expected for install,
+        update, and uninstall with hardlinks.
+        """
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                def get_link_path(*parts):
-                        return os.path.join(self.img_path(), *parts)
+        def get_link_path(*parts):
+            return os.path.join(self.img_path(), *parts)
 
-                def assert_target(link, target):
-                        self.assertEqual(os.stat(link).st_ino,
-                            os.stat(target).st_ino)
+        def assert_target(link, target):
+            self.assertEqual(os.stat(link).st_ino, os.stat(target).st_ino)
 
-                def assert_exists(link):
-                        self.assertTrue(os.path.exists(lpath))
+        def assert_exists(link):
+            self.assertTrue(os.path.exists(lpath))
 
-                def assert_not_exists(link):
-                        self.assertTrue(not os.path.exists(lpath))
+        def assert_not_exists(link):
+            self.assertTrue(not os.path.exists(lpath))
 
-                vi_path = get_link_path("usr", "bin", "vi")
-                nvi_path = get_link_path("usr", "bin", "nvi")
-                vim_path = get_link_path("usr", "bin", "vim")
-                svr4_path = get_link_path("usr", "sunos", "bin", "edit")
+        vi_path = get_link_path("usr", "bin", "vi")
+        nvi_path = get_link_path("usr", "bin", "nvi")
+        vim_path = get_link_path("usr", "bin", "vim")
+        svr4_path = get_link_path("usr", "sunos", "bin", "edit")
 
-                # Some installs are done with extra verbosity to ease in
-                # debugging tests when they fail.
-                self.pkg("install -vvv svr4-vi@1")
-                self.pkg("mediator") # If tests fail, this is helpful.
+        # Some installs are done with extra verbosity to ease in
+        # debugging tests when they fail.
+        self.pkg("install -vvv svr4-vi@1")
+        self.pkg("mediator")  # If tests fail, this is helpful.
 
-                # Check that installed links point to svr4-vi and that
-                # verify passes.
-                assert_target(vi_path, svr4_path)
-                self.pkg("verify")
-                self.__assert_mediation_matches("""\
+        # Check that installed links point to svr4-vi and that
+        # verify passes.
+        assert_target(vi_path, svr4_path)
+        self.pkg("verify")
+        self.__assert_mediation_matches(
+            """\
 vi\tsystem\t\tsystem\tsvr4\t
-""")
+"""
+        )
 
-                # Install vim package and verify link still points to svr4-vi
-                # and that verify passes.
-                self.pkg("install -vvv vim@1")
-                assert_target(vi_path, svr4_path)
-                self.pkg("verify")
-                self.__assert_mediation_matches("""\
+        # Install vim package and verify link still points to svr4-vi
+        # and that verify passes.
+        self.pkg("install -vvv vim@1")
+        assert_target(vi_path, svr4_path)
+        self.pkg("verify")
+        self.__assert_mediation_matches(
+            """\
 vi\tsystem\t\tsystem\tsvr4\t
-""")
+"""
+        )
 
-                # Set mediation to use vim implementation of vi, and then
-                # verify link points to that implementation.
-                self.pkg("set-mediator -vvv -I vim vi")
-                assert_target(vi_path, vim_path)
-                self.pkg("verify")
-                self.__assert_mediation_matches("""\
+        # Set mediation to use vim implementation of vi, and then
+        # verify link points to that implementation.
+        self.pkg("set-mediator -vvv -I vim vi")
+        assert_target(vi_path, vim_path)
+        self.pkg("verify")
+        self.__assert_mediation_matches(
+            """\
 vi\tsystem\t\tlocal\tvim\t
-""")
+"""
+        )
 
-                # Remove vi link and then ensure verify fails, fix will fix it,
-                # and then verify will succeed.
-                portable.remove(vi_path)
-                self.pkg("verify svr4-vi") # should pass, because of mediation
-                self.pkg("verify", exit=1) # should fail, because link is gone
-                self.pkg("fix")
-                assert_target(vi_path, vim_path)
-                self.pkg("verify") # should now pass
+        # Remove vi link and then ensure verify fails, fix will fix it,
+        # and then verify will succeed.
+        portable.remove(vi_path)
+        self.pkg("verify svr4-vi")  # should pass, because of mediation
+        self.pkg("verify", exit=1)  # should fail, because link is gone
+        self.pkg("fix")
+        assert_target(vi_path, vim_path)
+        self.pkg("verify")  # should now pass
 
-                # Unset mediation, verify mediation reverts to svr4-vi, then
-                # uninstall svr4-vi and verify mediation reverts to vim.
-                self.pkg("unset-mediator -vvv vi")
-                assert_target(vi_path, svr4_path)
-                self.__assert_mediation_matches("""\
+        # Unset mediation, verify mediation reverts to svr4-vi, then
+        # uninstall svr4-vi and verify mediation reverts to vim.
+        self.pkg("unset-mediator -vvv vi")
+        assert_target(vi_path, svr4_path)
+        self.__assert_mediation_matches(
+            """\
 vi\tsystem\t\tsystem\tsvr4\t
-""")
-                self.pkg("verify")
-                self.pkg("uninstall -vvv svr4-vi")
-                self.__assert_mediation_matches("""\
+"""
+        )
+        self.pkg("verify")
+        self.pkg("uninstall -vvv svr4-vi")
+        self.__assert_mediation_matches(
+            """\
 vi\tsystem\t\tsystem\tvim\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # Install nvi and verify mediation changes to nvi due to
-                # mediator priority of vendor.
-                self.pkg("install -vvv nvi@1")
-                assert_target(vi_path, nvi_path)
-                self.__assert_mediation_matches("""\
+        # Install nvi and verify mediation changes to nvi due to
+        # mediator priority of vendor.
+        self.pkg("install -vvv nvi@1")
+        assert_target(vi_path, nvi_path)
+        self.__assert_mediation_matches(
+            """\
 vi\tvendor\t\tvendor\tnvi\t
-""")
+"""
+        )
 
-                # Update to vim@2 and verify mediation changes to vim due to
-                # mediator priority of site.
-                self.pkg("update -vvv vim@2")
-                assert_target(vi_path, vim_path)
-                self.__assert_mediation_matches("""\
+        # Update to vim@2 and verify mediation changes to vim due to
+        # mediator priority of site.
+        self.pkg("update -vvv vim@2")
+        assert_target(vi_path, vim_path)
+        self.__assert_mediation_matches(
+            """\
 vi\tsite\t\tsite\tvim\t
-""")
+"""
+        )
 
-                # Install svr4-vi and verify mediation remains set to vim due to
-                # mediator priority of site.
-                self.pkg("install -vvv svr4-vi")
-                assert_target(vi_path, vim_path)
-                self.__assert_mediation_matches("""\
+        # Install svr4-vi and verify mediation remains set to vim due to
+        # mediator priority of site.
+        self.pkg("install -vvv svr4-vi")
+        assert_target(vi_path, vim_path)
+        self.__assert_mediation_matches(
+            """\
 vi\tsite\t\tsite\tvim\t
-""")
+"""
+        )
 
-                # Uninstall all packages; then verify that a single package
-                # containing multiple varianted, mediated hardlinks works as
-                # expected.
-                self.pkg("uninstall \\*")
+        # Uninstall all packages; then verify that a single package
+        # containing multiple varianted, mediated hardlinks works as
+        # expected.
+        self.pkg("uninstall \\*")
 
-                foo_path = get_link_path("usr", "bin", "foo")
-                foo_1_nd_path = get_link_path("usr", "bin", "foo-1-nd")
-                foo_1_d_path = get_link_path("usr", "bin", "foo-1-d")
-                foo_2_nd_path = get_link_path("usr", "bin", "foo-2-nd")
-                foo_2_d_path = get_link_path("usr", "bin", "foo-2-d")
+        foo_path = get_link_path("usr", "bin", "foo")
+        foo_1_nd_path = get_link_path("usr", "bin", "foo-1-nd")
+        foo_1_d_path = get_link_path("usr", "bin", "foo-1-d")
+        foo_2_nd_path = get_link_path("usr", "bin", "foo-2-nd")
+        foo_2_d_path = get_link_path("usr", "bin", "foo-2-d")
 
-                # Install multi-ver-variant and verify version 2 non-debug is
-                # selected.
-                self.pkg("install -vvv multi-ver-variant")
-                assert_target(foo_path, foo_2_nd_path)
-                self.__assert_mediation_matches("""\
+        # Install multi-ver-variant and verify version 2 non-debug is
+        # selected.
+        self.pkg("install -vvv multi-ver-variant")
+        assert_target(foo_path, foo_2_nd_path)
+        self.__assert_mediation_matches(
+            """\
 foo\tsystem\t2\tsystem\t\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # Set debug variant and verify version 2 debug is selected.
-                self.pkg("change-variant -vvv debug.osnet=true")
-                assert_target(foo_path, foo_2_d_path)
-                self.__assert_mediation_matches("""\
+        # Set debug variant and verify version 2 debug is selected.
+        self.pkg("change-variant -vvv debug.osnet=true")
+        assert_target(foo_path, foo_2_d_path)
+        self.__assert_mediation_matches(
+            """\
 foo\tsystem\t2\tsystem\t\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # Set mediator version to 1 and verify version 1 debug is
-                # selected.
-                self.pkg("set-mediator -vvv -V 1 foo")
-                assert_target(foo_path, foo_1_d_path)
-                self.__assert_mediation_matches("""\
+        # Set mediator version to 1 and verify version 1 debug is
+        # selected.
+        self.pkg("set-mediator -vvv -V 1 foo")
+        assert_target(foo_path, foo_1_d_path)
+        self.__assert_mediation_matches(
+            """\
 foo\tlocal\t1\tsystem\t\t
-""")
-                self.pkg("verify")
+"""
+        )
+        self.pkg("verify")
 
-                # Reset debug variant and verify version 1 non-debug is
-                # selected.
-                self.pkg("change-variant -vvv debug.osnet=false")
-                self.pkg("verify")
-                assert_target(foo_path, foo_1_nd_path)
-                self.__assert_mediation_matches("""\
+        # Reset debug variant and verify version 1 non-debug is
+        # selected.
+        self.pkg("change-variant -vvv debug.osnet=false")
+        self.pkg("verify")
+        assert_target(foo_path, foo_1_nd_path)
+        self.__assert_mediation_matches(
+            """\
 foo\tlocal\t1\tsystem\t\t
-""")
+"""
+        )
 
-        def test_03_obsoleted_mediator(self):
-                """Verify locally set mediators generate a warning message
-                   if the target of the mediated link is removed.
-                """
+    def test_03_obsoleted_mediator(self):
+        """Verify locally set mediators generate a warning message
+        if the target of the mediated link is removed.
+        """
 
-                self.image_create(self.rurl)
-                self.pkg("install edit-incorp@1.0 edition27 edition37")
+        self.image_create(self.rurl)
+        self.pkg("install edit-incorp@1.0 edition27 edition37")
 
-                # Verify a disappearing local mediator version
-                # triggers a warning, with an exit of EXIT_PARTIAL.
-                self.pkg("set-mediator -V 2.7 edition")
-                self.pkg("update edit-incorp@2.0", exit=pkgdefs.EXIT_PARTIAL)
-                # The large expression below is because the names of the
-                # removed links can appear in any order due to the code
-                # using a set() as the data structure which does not
-                # guarantee an order.
-                self.assertTrue("usr/lib/edition27, usr/bin/edition27" in
-                                self.errout or
-                                "usr/bin/edition27, usr/lib/edition27" in
-                                self.errout)
+        # Verify a disappearing local mediator version
+        # triggers a warning, with an exit of EXIT_PARTIAL.
+        self.pkg("set-mediator -V 2.7 edition")
+        self.pkg("update edit-incorp@2.0", exit=pkgdefs.EXIT_PARTIAL)
+        # The large expression below is because the names of the
+        # removed links can appear in any order due to the code
+        # using a set() as the data structure which does not
+        # guarantee an order.
+        self.assertTrue(
+            "usr/lib/edition27, usr/bin/edition27" in self.errout
+            or "usr/bin/edition27, usr/lib/edition27" in self.errout
+        )
 
-                # Verify a disappearing local mediator implemention
-                # triggers a warning, with an exit of EXIT_PARTIAL.
-                self.pkg("install edit-incorp@1.0 edition27")
-                self.pkg("set-mediator -I edit27 edition")
-                self.pkg("update edit-incorp@2.0", exit=pkgdefs.EXIT_PARTIAL)
-                self.assertTrue("usr/lib/edition27, usr/bin/edition27" in
-                                self.errout or
-                                "usr/bin/edition27, usr/lib/edition27" in
-                                self.errout)
+        # Verify a disappearing local mediator implemention
+        # triggers a warning, with an exit of EXIT_PARTIAL.
+        self.pkg("install edit-incorp@1.0 edition27")
+        self.pkg("set-mediator -I edit27 edition")
+        self.pkg("update edit-incorp@2.0", exit=pkgdefs.EXIT_PARTIAL)
+        self.assertTrue(
+            "usr/lib/edition27, usr/bin/edition27" in self.errout
+            or "usr/bin/edition27, usr/lib/edition27" in self.errout
+        )
 
-                # Verify the setting of a fictious mediator value
-                # has no impact.
-                self.pkg("install edit-incorp@1.0 edition27")
-                self.pkg("set-mediator -V 78 edition")
-                self.pkg("update edit-incorp@2.0")
+        # Verify the setting of a fictious mediator value
+        # has no impact.
+        self.pkg("install edit-incorp@1.0 edition27")
+        self.pkg("set-mediator -V 78 edition")
+        self.pkg("update edit-incorp@2.0")
 
-                # Verify if the mediator is not set to local
-                # update works.
-                self.pkg("install edit-incorp@1.0 edition27")
-                self.pkg("unset-mediator edition")
-                self.pkg("update edit-incorp@2.0")
+        # Verify if the mediator is not set to local
+        # update works.
+        self.pkg("install edit-incorp@1.0 edition27")
+        self.pkg("unset-mediator edition")
+        self.pkg("update edit-incorp@2.0")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_modified.py
+++ b/src/tests/cli/t_pkg_modified.py
@@ -23,197 +23,199 @@
 # Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
 import unittest
 
-class TestPkgModified(pkg5unittest.SingleDepotTestCase):
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
 
-        foo10 = """
+class TestPkgModified(pkg5unittest.SingleDepotTestCase):
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
+
+    foo10 = """
             open foo@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add file tmp/cat mode=0644 owner=root group=bin path=etc/motd
             close """
 
-        misc_files = ["tmp/cat"]
+    misc_files = ["tmp/cat"]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-        def __assert_image_modified(self, api_inst, omtime, modified):
-                mfpath = os.path.join(api_inst.img.imgdir, "modified")
-                nmtime = os.stat(mfpath).st_mtime
-                if modified:
-                        self.assertNotEqual(omtime, nmtime)
-                else:
-                        self.assertEqual(omtime, nmtime)
-                return nmtime
+    def __assert_image_modified(self, api_inst, omtime, modified):
+        mfpath = os.path.join(api_inst.img.imgdir, "modified")
+        nmtime = os.stat(mfpath).st_mtime
+        if modified:
+            self.assertNotEqual(omtime, nmtime)
+        else:
+            self.assertEqual(omtime, nmtime)
+        return nmtime
 
-        def test_modified(self):
-                """Verify that $IMGDIR/modified is updated whenever an
-                image-modifying operation is completed."""
+    def test_modified(self):
+        """Verify that $IMGDIR/modified is updated whenever an
+        image-modifying operation is completed."""
 
-                api_inst = self.image_create(self.rurl)
-                mfpath = os.path.join(api_inst.img.imgdir, "modified")
+        api_inst = self.image_create(self.rurl)
+        mfpath = os.path.join(api_inst.img.imgdir, "modified")
 
-                # Assert /var/pkg/modified exists.
-                self.file_exists(mfpath)
-                omtime = os.stat(mfpath).st_mtime
+        # Assert /var/pkg/modified exists.
+        self.file_exists(mfpath)
+        omtime = os.stat(mfpath).st_mtime
 
-                self.pkgsend_bulk(self.rurl, self.foo10)
+        self.pkgsend_bulk(self.rurl, self.foo10)
 
-                # Now perform various operations and assert the image was marked
-                # as modified or not depending on operation.
-                self.__assert_image_modified(api_inst, omtime, False)
+        # Now perform various operations and assert the image was marked
+        # as modified or not depending on operation.
+        self.__assert_image_modified(api_inst, omtime, False)
 
-                self.pkg("refresh")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("refresh")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                #
-                # Operations that should not mark image as modified.
-                #
-                for op, op_ret in (
-                    ("facet", 0),
-                    ("contents", 1),
-                    ("history", 0),
-                    ("info", 1),
-                    ("info -r \\*", 0),
-                    ("list", 1),
-                    ("mediator", 0),
-                    ("property", 0),
-                    ("unset-property no-such-property", 1),
-                    ("publisher", 0),
-                    ("refresh no-such-publisher", 1),
-                    ("variant", 0)
-                ):
-                        self.pkg(op, exit=op_ret)
-                        self.__assert_image_modified(api_inst, omtime, False)
+        #
+        # Operations that should not mark image as modified.
+        #
+        for op, op_ret in (
+            ("facet", 0),
+            ("contents", 1),
+            ("history", 0),
+            ("info", 1),
+            ("info -r \\*", 0),
+            ("list", 1),
+            ("mediator", 0),
+            ("property", 0),
+            ("unset-property no-such-property", 1),
+            ("publisher", 0),
+            ("refresh no-such-publisher", 1),
+            ("variant", 0),
+        ):
+            self.pkg(op, exit=op_ret)
+            self.__assert_image_modified(api_inst, omtime, False)
 
-                self.pkg("version", use_img_root=False)
-                self.__assert_image_modified(api_inst, omtime, False)
+        self.pkg("version", use_img_root=False)
+        self.__assert_image_modified(api_inst, omtime, False)
 
-                #
-                # Now perform various combos of operations testing modification.
-                #
-                self.pkg("refresh")
-                omtime = self.__assert_image_modified(api_inst, omtime, False)
+        #
+        # Now perform various combos of operations testing modification.
+        #
+        self.pkg("refresh")
+        omtime = self.__assert_image_modified(api_inst, omtime, False)
 
-                self.pkg("install -nv foo")
-                omtime = self.__assert_image_modified(api_inst, omtime, False)
+        self.pkg("install -nv foo")
+        omtime = self.__assert_image_modified(api_inst, omtime, False)
 
-                self.pkg("install --reject foo foo", exit=1)
-                omtime = self.__assert_image_modified(api_inst, omtime, False)
+        self.pkg("install --reject foo foo", exit=1)
+        omtime = self.__assert_image_modified(api_inst, omtime, False)
 
-                self.pkg("install foo")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("install foo")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("set-mediator -I postfix sendmail")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("set-mediator -I postfix sendmail")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("unset-mediator -I sendmail")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("unset-mediator -I sendmail")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("unset-mediator -I sendmail", exit=4)
-                omtime = self.__assert_image_modified(api_inst, omtime, False)
+        self.pkg("unset-mediator -I sendmail", exit=4)
+        omtime = self.__assert_image_modified(api_inst, omtime, False)
 
-                # this should not register a modification; compliance tool
-                # relies on that
-                self.pkg("verify foo")
-                omtime = self.__assert_image_modified(api_inst, omtime, False)
+        # this should not register a modification; compliance tool
+        # relies on that
+        self.pkg("verify foo")
+        omtime = self.__assert_image_modified(api_inst, omtime, False)
 
-                self.pkg("fix foo", exit=4)
-                omtime = self.__assert_image_modified(api_inst, omtime, False)
+        self.pkg("fix foo", exit=4)
+        omtime = self.__assert_image_modified(api_inst, omtime, False)
 
-                # this should not register a modification; compliance tool
-                # relies on that
-                self.pkg("revert -n /etc/motd", exit=4)
-                omtime = self.__assert_image_modified(api_inst, omtime, False)
+        # this should not register a modification; compliance tool
+        # relies on that
+        self.pkg("revert -n /etc/motd", exit=4)
+        omtime = self.__assert_image_modified(api_inst, omtime, False)
 
-                # modify etc/motd; fix should register modification
-                self.file_append("etc/motd", "foo")
-                self.pkg("fix foo")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        # modify etc/motd; fix should register modification
+        self.file_append("etc/motd", "foo")
+        self.pkg("fix foo")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                # modify etc/motd; revert should register modification
-                self.file_append("etc/motd", "foo")
-                self.pkg("revert /etc/motd")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        # modify etc/motd; revert should register modification
+        self.file_append("etc/motd", "foo")
+        self.pkg("revert /etc/motd")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("revert /etc/motd", exit=4)
-                omtime = self.__assert_image_modified(api_inst, omtime, False)
+        self.pkg("revert /etc/motd", exit=4)
+        omtime = self.__assert_image_modified(api_inst, omtime, False)
 
-                self.pkg("fix foo", exit=4)
-                omtime = self.__assert_image_modified(api_inst, omtime, False)
+        self.pkg("fix foo", exit=4)
+        omtime = self.__assert_image_modified(api_inst, omtime, False)
 
-                self.pkg("freeze foo")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("freeze foo")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("unfreeze foo")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("unfreeze foo")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("uninstall foo")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("uninstall foo")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("avoid foo")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("avoid foo")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("unavoid foo")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("unavoid foo")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("set-property be-policy always-new")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("set-property be-policy always-new")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("unset-property be-policy")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("unset-property be-policy")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("change-facet wombat=false")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("change-facet wombat=false")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("change-facet wombat=None")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("change-facet wombat=None")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("change-variant osnet.debug=true")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("change-variant osnet.debug=true")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("change-variant osnet.debug=None")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("change-variant osnet.debug=None")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                # Remove the last_refreshed file for one of the publishers so
-                # that it will be seen as needing refresh.
-                pub = api_inst.get_publisher("test")
-                os.remove(os.path.join(pub.meta_root, "last_refreshed"))
-                self.pkgsend_bulk(self.rurl, self.foo10)
-                self.pkg("list -a")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        # Remove the last_refreshed file for one of the publishers so
+        # that it will be seen as needing refresh.
+        pub = api_inst.get_publisher("test")
+        os.remove(os.path.join(pub.meta_root, "last_refreshed"))
+        self.pkgsend_bulk(self.rurl, self.foo10)
+        self.pkg("list -a")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                # Add, remove, and modify publishers.
-                self.pkg("unset-publisher test")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        # Add, remove, and modify publishers.
+        self.pkg("unset-publisher test")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("set-publisher -p {0}".format(self.rurl))
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("set-publisher -p {0}".format(self.rurl))
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("set-publisher -G {0} test".format(self.rurl))
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("set-publisher -G {0} test".format(self.rurl))
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("set-publisher -g {0} test".format(self.rurl))
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("set-publisher -g {0} test".format(self.rurl))
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("set-publisher --sticky test")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("set-publisher --sticky test")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
-                self.pkg("set-publisher --non-sticky test")
-                omtime = self.__assert_image_modified(api_inst, omtime, True)
+        self.pkg("set-publisher --non-sticky test")
+        omtime = self.__assert_image_modified(api_inst, omtime, True)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_nasty.py
+++ b/src/tests/cli/t_pkg_nasty.py
@@ -26,8 +26,9 @@
 
 from __future__ import print_function
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -40,18 +41,18 @@ import time
 
 import pkg.portable as portable
 
+
 class TestPkgNasty(pkg5unittest.SingleDepotTestCase):
+    need_ro_data = True
 
-        need_ro_data = True
+    # Default number iterations; tune with NASTY_ITERS in environ.
+    NASTY_ITERS = 10
+    # Default nastiness; tune with NASTY_LEVEL in environ.
+    NASTY_LEVEL = 50
 
-        # Default number iterations; tune with NASTY_ITERS in environ.
-        NASTY_ITERS = 10
-        # Default nastiness; tune with NASTY_LEVEL in environ.
-        NASTY_LEVEL = 50
+    NASTY_SLEEP = 2
 
-        NASTY_SLEEP = 2
-
-        template_10 = """
+    template_10 = """
             open testpkg/__SUB__@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/stuff
             add file tmp/file1 mode=0644 owner=root group=bin path=/__SUB__/f1 preserve=true
@@ -59,8 +60,8 @@ class TestPkgNasty(pkg5unittest.SingleDepotTestCase):
             add file tmp/file3 mode=0644 owner=root group=bin path=/__SUB__/f3
             close """
 
-        # in v1.1, file contents are shifted around
-        template_11 = """
+    # in v1.1, file contents are shifted around
+    template_11 = """
             open testpkg/__SUB__@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/stuff
             add file tmp/file2 mode=0644 owner=root group=bin path=/__SUB__/f1 preserve=true
@@ -69,349 +70,374 @@ class TestPkgNasty(pkg5unittest.SingleDepotTestCase):
             add file tmp/file5 mode=0644 owner=root group=bin path=/__SUB__/f4
             close """
 
-        def __make_rand_string(self, outlen):
-                s = ""
-                while outlen > 0:
-                        s += random.choice("\n\n\n\nabcdefghijklmnopqrstuvwxyz"
-                            "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()")
-                        outlen -= 1
-                return s
+    def __make_rand_string(self, outlen):
+        s = ""
+        while outlen > 0:
+            s += random.choice(
+                "\n\n\n\nabcdefghijklmnopqrstuvwxyz"
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()"
+            )
+            outlen -= 1
+        return s
 
-        def __make_rand_files(self):
-                misc_files = {
-                    "tmp/file1": 1,
-                    "tmp/file2": 32,
-                    "tmp/file3": 4096,
-                    "tmp/file4": 16384,
-                    "tmp/file5": 65536
-                }
-                for f in misc_files:
-                        # Overwrite the number with file contents of size
-                        # <that number>
-                        misc_files[f] = \
-                            self.__make_rand_string(misc_files[f])
-                self.make_misc_files(misc_files)
+    def __make_rand_files(self):
+        misc_files = {
+            "tmp/file1": 1,
+            "tmp/file2": 32,
+            "tmp/file3": 4096,
+            "tmp/file4": 16384,
+            "tmp/file5": 65536,
+        }
+        for f in misc_files:
+            # Overwrite the number with file contents of size
+            # <that number>
+            misc_files[f] = self.__make_rand_string(misc_files[f])
+        self.make_misc_files(misc_files)
 
-        def __make_pkgs(self):
-                self.testpkgs = []
-                for pkgname in ["A", "B", "C", "D"]:
-                        self.testpkgs.append(re.sub("__SUB__", pkgname,
-                            self.template_10))
-                        self.testpkgs.append(re.sub("__SUB__", pkgname,
-                            self.template_11))
+    def __make_pkgs(self):
+        self.testpkgs = []
+        for pkgname in ["A", "B", "C", "D"]:
+            self.testpkgs.append(re.sub("__SUB__", pkgname, self.template_10))
+            self.testpkgs.append(re.sub("__SUB__", pkgname, self.template_11))
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
 
-                self.NASTY_ITERS = \
-                    int(os.environ.get("NASTY_ITERS", self.NASTY_ITERS))
-                self.NASTY_LEVEL = \
-                    int(os.environ.get("NASTY_LEVEL", self.NASTY_LEVEL))
+        self.NASTY_ITERS = int(os.environ.get("NASTY_ITERS", self.NASTY_ITERS))
+        self.NASTY_LEVEL = int(os.environ.get("NASTY_LEVEL", self.NASTY_LEVEL))
 
-                os.chdir(self.test_root)
-                self.__make_rand_files()
-                self.__make_pkgs()
-                for pkgcontents in self.testpkgs:
-                        plist = self.pkgsend_bulk(self.rurl, pkgcontents)
-                        self.pkgsign_simple(self.rurl, plist[0])
-                self.dc.set_nasty(self.NASTY_LEVEL)
-                self.dc.set_nasty_sleep(self.NASTY_SLEEP)
+        os.chdir(self.test_root)
+        self.__make_rand_files()
+        self.__make_pkgs()
+        for pkgcontents in self.testpkgs:
+            plist = self.pkgsend_bulk(self.rurl, pkgcontents)
+            self.pkgsign_simple(self.rurl, plist[0])
+        self.dc.set_nasty(self.NASTY_LEVEL)
+        self.dc.set_nasty_sleep(self.NASTY_SLEEP)
 
-                self.nasty_env = {
-                    "PKG_CLIENT_MAX_CONSECUTIVE_ERRORS": "3",
-                    "PKG_CLIENT_MAX_TIMEOUT": "2",
-                    "PKG_CLIENT_LOWSPEED_TIMEOUT": \
-                        "{0:d}".format(self.NASTY_SLEEP - 1),
-                }
+        self.nasty_env = {
+            "PKG_CLIENT_MAX_CONSECUTIVE_ERRORS": "3",
+            "PKG_CLIENT_MAX_TIMEOUT": "2",
+            "PKG_CLIENT_LOWSPEED_TIMEOUT": "{0:d}".format(self.NASTY_SLEEP - 1),
+        }
 
-                self.dc.start()
+        self.dc.start()
 
-                pubname = "test"
-                self.mfst_path = os.path.join(self.img_path(),
-                    "var/pkg/publisher/{0}/pkg".format(pubname))
+        pubname = "test"
+        self.mfst_path = os.path.join(
+            self.img_path(), "var/pkg/publisher/{0}/pkg".format(pubname)
+        )
 
-        def _rm_mfsts(self):
-                # Note that we have chosen not to ignore errors here,
-                # since we're depending on knowing the internal layout
-                # of var/pkg.
-                shutil.rmtree(self.mfst_path)
+    def _rm_mfsts(self):
+        # Note that we have chosen not to ignore errors here,
+        # since we're depending on knowing the internal layout
+        # of var/pkg.
+        shutil.rmtree(self.mfst_path)
 
-        def _dumplog(self):
-                self.debug("---- Last 50 depot log entries:")
-                try:
-                        lp = self.dc.get_logpath()
-                        log = open(lp)
-                        lines = log.readlines()
-                        self.debug("".join(lines[-50:]))
-                except Exception:
-                        self.debug("Failed to print log entries")
+    def _dumplog(self):
+        self.debug("---- Last 50 depot log entries:")
+        try:
+            lp = self.dc.get_logpath()
+            log = open(lp)
+            lines = log.readlines()
+            self.debug("".join(lines[-50:]))
+        except Exception:
+            self.debug("Failed to print log entries")
 
-        def _trythis(self, label, kallable, ntries=10):
-                """Runs kallable ntries times; if after ntries the operation
-                has not returned 0, try again with the nastiness disabled in
-                the depot.  The goal is to push through to get a real result
-                but also to prevent infinite looping."""
-                for tries in range(1, ntries + 1):
-                        if tries > 1:
-                                self.debug(
-                                    "--try: '{0}' try #{1:d}".format(
-                                    label, tries))
-                        ret = kallable()
-                        if ret == 0:
-                                break
-                else:
-                        # Turn nastiness off on the depot and try again;
-                        # this helps prevent waiting around forever for
-                        # something to eventually work.
-                        self.debug("Note: Repeated failures for '{0}' "
-                            "({1:d} times).  Disabling nasty and retrying".format(
-                            label, ntries))
-                        # Reset environment params and depot nastiness.
-                        # We have to edit self.nasty_env in place (as opposed
-                        # to just replacing it) because a reference to it is
-                        # already bound up with kallable.
-                        save_low = self.nasty_env["PKG_CLIENT_LOWSPEED_TIMEOUT"]
-                        save_maxtmo = self.nasty_env["PKG_CLIENT_MAX_TIMEOUT"]
-                        # Set these to "" to make them revert to defaults
-                        self.nasty_env["PKG_CLIENT_LOWSPEED_TIMEOUT"] = ""
-                        self.nasty_env["PKG_CLIENT_MAX_TIMEOUT"] = ""
-                        self.dc.set_nasty(0)
+    def _trythis(self, label, kallable, ntries=10):
+        """Runs kallable ntries times; if after ntries the operation
+        has not returned 0, try again with the nastiness disabled in
+        the depot.  The goal is to push through to get a real result
+        but also to prevent infinite looping."""
+        for tries in range(1, ntries + 1):
+            if tries > 1:
+                self.debug("--try: '{0}' try #{1:d}".format(label, tries))
+            ret = kallable()
+            if ret == 0:
+                break
+        else:
+            # Turn nastiness off on the depot and try again;
+            # this helps prevent waiting around forever for
+            # something to eventually work.
+            self.debug(
+                "Note: Repeated failures for '{0}' "
+                "({1:d} times).  Disabling nasty and retrying".format(
+                    label, ntries
+                )
+            )
+            # Reset environment params and depot nastiness.
+            # We have to edit self.nasty_env in place (as opposed
+            # to just replacing it) because a reference to it is
+            # already bound up with kallable.
+            save_low = self.nasty_env["PKG_CLIENT_LOWSPEED_TIMEOUT"]
+            save_maxtmo = self.nasty_env["PKG_CLIENT_MAX_TIMEOUT"]
+            # Set these to "" to make them revert to defaults
+            self.nasty_env["PKG_CLIENT_LOWSPEED_TIMEOUT"] = ""
+            self.nasty_env["PKG_CLIENT_MAX_TIMEOUT"] = ""
+            self.dc.set_nasty(0)
 
-                        ret = kallable()
+            ret = kallable()
 
-                        # Restore Nastiness and environment parameters.
-                        self.nasty_env["PKG_CLIENT_LOWSPEED_TIMEOUT"] = save_low
-                        self.nasty_env["PKG_CLIENT_MAX_TIMEOUT"] = save_maxtmo
-                        self.dc.set_nasty(self.NASTY_LEVEL)
-                        if ret != 0:
-                                raise self.failureException(
-                                    "Failed '{0}' {1:d} times, then failed again "
-                                    "with nasty disabled.  Test failed".format(
-                                    label, ntries))
+            # Restore Nastiness and environment parameters.
+            self.nasty_env["PKG_CLIENT_LOWSPEED_TIMEOUT"] = save_low
+            self.nasty_env["PKG_CLIENT_MAX_TIMEOUT"] = save_maxtmo
+            self.dc.set_nasty(self.NASTY_LEVEL)
+            if ret != 0:
+                raise self.failureException(
+                    "Failed '{0}' {1:d} times, then failed again "
+                    "with nasty disabled.  Test failed".format(label, ntries)
+                )
 
-        def do_main_loop(self, kallable):
-                """Loop running a nasty test.  Iterations tunable by setting
-                NASTY_ITERS in the process environment, i.e. NASTY_ITERS=100."""
-                for x in range(1, self.NASTY_ITERS + 1):
-                        self.debug("---- Iteration {0:d}/{1:d} ----".format(
-                            x, self.NASTY_ITERS))
-                        try:
-                                kallable()
-                        except:
-                                self._dumplog()
-                                self.debug("---- Iteration {0:d}/{1:d} FAILED ----".format(
-                                    x, self.NASTY_ITERS))
-                                raise
+    def do_main_loop(self, kallable):
+        """Loop running a nasty test.  Iterations tunable by setting
+        NASTY_ITERS in the process environment, i.e. NASTY_ITERS=100."""
+        for x in range(1, self.NASTY_ITERS + 1):
+            self.debug(
+                "---- Iteration {0:d}/{1:d} ----".format(x, self.NASTY_ITERS)
+            )
+            try:
+                kallable()
+            except:
+                self._dumplog()
+                self.debug(
+                    "---- Iteration {0:d}/{1:d} FAILED ----".format(
+                        x, self.NASTY_ITERS
+                    )
+                )
+                raise
 
 
 class TestNastyInstall(TestPkgNasty):
-        # Exists as a subclass only so we can run tests in parallel.
+    # Exists as a subclass only so we can run tests in parallel.
 
-        def __nasty_install_1_run(self):
-                env = self.nasty_env
+    def __nasty_install_1_run(self):
+        env = self.nasty_env
 
-                self._trythis("image create",
-                    lambda: self.pkg_image_create(repourl=self.durl,
-                    env_arg=env, exit=[0, 1]))
+        self._trythis(
+            "image create",
+            lambda: self.pkg_image_create(
+                repourl=self.durl, env_arg=env, exit=[0, 1]
+            ),
+        )
 
-                # Set up signature stuff.
-                emptyCA = os.path.join(self.img_path(), "emptyCA")
-                os.makedirs(emptyCA)
-                self.pkg("set-property trust-anchor-directory emptyCA")
-                self.seed_ta_dir("ta3", dest_dir=emptyCA)
-                self.pkg("set-property signature-policy require-signatures")
+        # Set up signature stuff.
+        emptyCA = os.path.join(self.img_path(), "emptyCA")
+        os.makedirs(emptyCA)
+        self.pkg("set-property trust-anchor-directory emptyCA")
+        self.seed_ta_dir("ta3", dest_dir=emptyCA)
+        self.pkg("set-property signature-policy require-signatures")
 
-                self._trythis("refresh",
-                    lambda: self.pkg("refresh", env_arg=env, exit=[0, 1]))
-                self._trythis("refresh --full",
-                    lambda: self.pkg("refresh --full",
-                        env_arg=env, exit=[0, 1]))
-                self._trythis("search -r /A/f2",
-                    lambda: self.pkg("search -r /A/f2",
-                        env_arg=env, exit=[0, 1, 3]))
+        self._trythis(
+            "refresh", lambda: self.pkg("refresh", env_arg=env, exit=[0, 1])
+        )
+        self._trythis(
+            "refresh --full",
+            lambda: self.pkg("refresh --full", env_arg=env, exit=[0, 1]),
+        )
+        self._trythis(
+            "search -r /A/f2",
+            lambda: self.pkg("search -r /A/f2", env_arg=env, exit=[0, 1, 3]),
+        )
 
-                # test contents -r
-                contentscmd = "contents -m -r testpkg/*A@1.0"
-                self._trythis(contentscmd, 
-                    lambda: self.pkg(contentscmd, env_arg=env, exit=[0, 1]))
-                # clean up mfsts.
-                self._rm_mfsts()
+        # test contents -r
+        contentscmd = "contents -m -r testpkg/*A@1.0"
+        self._trythis(
+            contentscmd, lambda: self.pkg(contentscmd, env_arg=env, exit=[0, 1])
+        )
+        # clean up mfsts.
+        self._rm_mfsts()
 
-                self._trythis("install testpkg/*@1.0",
-                    lambda: self.pkg("install testpkg/*@1.0",
-                        env_arg=env, exit=[0, 1]))
-                self._trythis("update",
-                    lambda: self.pkg("update", env_arg=env, exit=[0, 1]))
+        self._trythis(
+            "install testpkg/*@1.0",
+            lambda: self.pkg("install testpkg/*@1.0", env_arg=env, exit=[0, 1]),
+        )
+        self._trythis(
+            "update", lambda: self.pkg("update", env_arg=env, exit=[0, 1])
+        )
 
-                # Change a file in the image and then revert it.
-                path = os.path.join(self.img_path(), "A", "f1")
-                self.assertTrue(os.path.exists(path))
-                f = open(path, "w")
-                print("I LIKE COCONUTS!", file=f)
-                f.close()
-                self._trythis("revert",
-                    lambda: self.pkg("revert A/f1", env_arg=env, exit=[0, 1]))
+        # Change a file in the image and then revert it.
+        path = os.path.join(self.img_path(), "A", "f1")
+        self.assertTrue(os.path.exists(path))
+        f = open(path, "w")
+        print("I LIKE COCONUTS!", file=f)
+        f.close()
+        self._trythis(
+            "revert", lambda: self.pkg("revert A/f1", env_arg=env, exit=[0, 1])
+        )
 
-                # Try some things which are supposed to fail; we can't really
-                # pick apart transport failures versus the actual semantic
-                # failure; oh well for now.
-                self.pkg("search -r /doesnotexist", env_arg=env, exit=1)
-                self.pkg("contents -r doesnotexist", env_arg=env, exit=1)
-                self.pkg("verify", exit=0)
+        # Try some things which are supposed to fail; we can't really
+        # pick apart transport failures versus the actual semantic
+        # failure; oh well for now.
+        self.pkg("search -r /doesnotexist", env_arg=env, exit=1)
+        self.pkg("contents -r doesnotexist", env_arg=env, exit=1)
+        self.pkg("verify", exit=0)
 
-        def test_install_nasty_looping(self):
-                """Test the pkg command against a nasty depot."""
-                self.do_main_loop(self.__nasty_install_1_run)
+    def test_install_nasty_looping(self):
+        """Test the pkg command against a nasty depot."""
+        self.do_main_loop(self.__nasty_install_1_run)
 
 
 class TestNastyPkgUtils(TestPkgNasty):
-        # Exists as a subclass only so we can run tests in parallel.
-        persistent_setup = True
+    # Exists as a subclass only so we can run tests in parallel.
+    persistent_setup = True
 
-        def __nasty_pkgrecv_1_run(self):
-                env = self.nasty_env
-                self.cmdline_run("rm -rf test_repo", exit=[0, 1],
-                    coverage=False)
-                self.pkgrepo("create test_repo")
-                self._trythis("recv *",
-                    lambda: self.pkgrecv(self.durl,
-                        "-d test_repo '*'", env_arg=env, exit=[0, 1]))
-                # clean up pkgrecv "resume" turds
-                self.cmdline_run("rm -rf pkgrecv-*", exit=[0, 1],
-                    coverage=False)
+    def __nasty_pkgrecv_1_run(self):
+        env = self.nasty_env
+        self.cmdline_run("rm -rf test_repo", exit=[0, 1], coverage=False)
+        self.pkgrepo("create test_repo")
+        self._trythis(
+            "recv *",
+            lambda: self.pkgrecv(
+                self.durl, "-d test_repo '*'", env_arg=env, exit=[0, 1]
+            ),
+        )
+        # clean up pkgrecv "resume" turds
+        self.cmdline_run("rm -rf pkgrecv-*", exit=[0, 1], coverage=False)
 
-        def test_pkgrecv_nasty_looping(self):
-                """Test the pkgrecv command against a nasty depot."""
-                self.do_main_loop(self.__nasty_pkgrecv_1_run)
+    def test_pkgrecv_nasty_looping(self):
+        """Test the pkgrecv command against a nasty depot."""
+        self.do_main_loop(self.__nasty_pkgrecv_1_run)
 
-        def __nasty_pkgrepo_1_run(self):
-                env = self.nasty_env
-                self._trythis("pkgrepo get",
-                    lambda: self.pkgrepo(
-                        "get -s {0}".format(self.durl), env_arg=env, exit=[0, 1]))
-                self._trythis("pkgrepo info",
-                    lambda: self.pkgrepo(
-                        "info -s {0}".format(self.durl), env_arg=env, exit=[0, 1]))
-                self._trythis("pkgrepo list",
-                    lambda: self.pkgrepo(
-                        "list -s {0}".format(self.durl), env_arg=env, exit=[0, 1]))
-                self._trythis("pkgrepo rebuild",
-                    lambda: self.pkgrepo(
-                        "rebuild -s {0}".format(self.durl), env_arg=env, exit=[0, 1]))
-                self._trythis("pkgrepo refresh",
-                    lambda: self.pkgrepo(
-                        "refresh -s {0}".format(self.durl), env_arg=env, exit=[0, 1]))
+    def __nasty_pkgrepo_1_run(self):
+        env = self.nasty_env
+        self._trythis(
+            "pkgrepo get",
+            lambda: self.pkgrepo(
+                "get -s {0}".format(self.durl), env_arg=env, exit=[0, 1]
+            ),
+        )
+        self._trythis(
+            "pkgrepo info",
+            lambda: self.pkgrepo(
+                "info -s {0}".format(self.durl), env_arg=env, exit=[0, 1]
+            ),
+        )
+        self._trythis(
+            "pkgrepo list",
+            lambda: self.pkgrepo(
+                "list -s {0}".format(self.durl), env_arg=env, exit=[0, 1]
+            ),
+        )
+        self._trythis(
+            "pkgrepo rebuild",
+            lambda: self.pkgrepo(
+                "rebuild -s {0}".format(self.durl), env_arg=env, exit=[0, 1]
+            ),
+        )
+        self._trythis(
+            "pkgrepo refresh",
+            lambda: self.pkgrepo(
+                "refresh -s {0}".format(self.durl), env_arg=env, exit=[0, 1]
+            ),
+        )
 
-        def test_pkgrepo_nasty_looping(self):
-                """Test the pkgrepo command against a nasty depot."""
-                self.do_main_loop(self.__nasty_pkgrepo_1_run)
+    def test_pkgrepo_nasty_looping(self):
+        """Test the pkgrepo command against a nasty depot."""
+        self.do_main_loop(self.__nasty_pkgrepo_1_run)
 
 
 class TestNastyTempPub(TestPkgNasty):
-        # Exists as a subclass only so we can run tests in parallel.
+    # Exists as a subclass only so we can run tests in parallel.
 
-        def __nasty_temppub_1_run(self):
-                env = self.nasty_env
+    def __nasty_temppub_1_run(self):
+        env = self.nasty_env
 
-                self.pkg_image_create(repourl=None)
-                # Set up signature stuff.
-                emptyCA = os.path.join(self.img_path(), "emptyCA")
-                os.makedirs(emptyCA)
-                self.pkg("set-property trust-anchor-directory emptyCA")
-                self.seed_ta_dir("ta3", dest_dir=emptyCA)
-                self.pkg("set-property signature-policy require-signatures")
+        self.pkg_image_create(repourl=None)
+        # Set up signature stuff.
+        emptyCA = os.path.join(self.img_path(), "emptyCA")
+        os.makedirs(emptyCA)
+        self.pkg("set-property trust-anchor-directory emptyCA")
+        self.seed_ta_dir("ta3", dest_dir=emptyCA)
+        self.pkg("set-property signature-policy require-signatures")
 
-                # test list with temporary publisher
-                cmd = "list -a -g {0} \\*".format(self.durl)
-                self._trythis(cmd,
-                    lambda: self.pkg(cmd, env_arg=env, exit=[0, 1]))
+        # test list with temporary publisher
+        cmd = "list -a -g {0} \\*".format(self.durl)
+        self._trythis(cmd, lambda: self.pkg(cmd, env_arg=env, exit=[0, 1]))
 
-                # test contents with temporary publisher
-                cmd = "contents -m -g {0} -r testpkg/*A@1.1".format(self.durl)
-                self._trythis(cmd,
-                    lambda: self.pkg(cmd, env_arg=env, exit=[0, 1]))
+        # test contents with temporary publisher
+        cmd = "contents -m -g {0} -r testpkg/*A@1.1".format(self.durl)
+        self._trythis(cmd, lambda: self.pkg(cmd, env_arg=env, exit=[0, 1]))
 
-                # clean out dl'd mfsts
-                self._rm_mfsts()
-                # test info with temporary publisher
-                cmd = "info -g {0} \\*".format(self.durl)
-                self._trythis(cmd,
-                    lambda: self.pkg(cmd, env_arg=env, exit=[0, 1]))
+        # clean out dl'd mfsts
+        self._rm_mfsts()
+        # test info with temporary publisher
+        cmd = "info -g {0} \\*".format(self.durl)
+        self._trythis(cmd, lambda: self.pkg(cmd, env_arg=env, exit=[0, 1]))
 
-                # clean out dl'd mfsts
-                self._rm_mfsts()
-                # test install with temporary publisher
-                cmd = "install -g {0} testpkg/*@1.0".format(self.durl)
-                self._trythis(cmd,
-                    lambda: self.pkg(cmd, env_arg=env, exit=[0, 1]))
+        # clean out dl'd mfsts
+        self._rm_mfsts()
+        # test install with temporary publisher
+        cmd = "install -g {0} testpkg/*@1.0".format(self.durl)
+        self._trythis(cmd, lambda: self.pkg(cmd, env_arg=env, exit=[0, 1]))
 
-                # test update with temporary publisher
-                cmd = "update -g {0}".format(self.durl)
-                self._trythis(cmd,
-                    lambda: self.pkg(cmd, env_arg=env, exit=[0, 1, 4]))
+        # test update with temporary publisher
+        cmd = "update -g {0}".format(self.durl)
+        self._trythis(cmd, lambda: self.pkg(cmd, env_arg=env, exit=[0, 1, 4]))
 
-                self.pkg("verify", exit=0)
+        self.pkg("verify", exit=0)
 
-        def test_temppub_nasty_looping(self):
-                self.do_main_loop(self.__nasty_temppub_1_run)
+    def test_temppub_nasty_looping(self):
+        self.do_main_loop(self.__nasty_temppub_1_run)
 
 
 class TestNastySig(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.pkgsend_bulk(self.rurl, self.foo10)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.pkgsend_bulk(self.rurl, self.foo10)
 
-        def test_00_sig(self):
-                """Verify pkg client handles SIGTERM, SIGHUP, SIGINT gracefully
-                and writes a history entry if possible."""
+    def test_00_sig(self):
+        """Verify pkg client handles SIGTERM, SIGHUP, SIGINT gracefully
+        and writes a history entry if possible."""
 
-                if portable.osname == "windows":
-                        # SIGHUP not supported on Windows.
-                        sigs = (signal.SIGINT, signal.SIGTERM)
-                else:
-                        sigs = (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)
+        if portable.osname == "windows":
+            # SIGHUP not supported on Windows.
+            sigs = (signal.SIGINT, signal.SIGTERM)
+        else:
+            sigs = (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)
 
-                for sig in sigs:
-                        self.pkg_image_create(self.rurl)
+        for sig in sigs:
+            self.pkg_image_create(self.rurl)
 
-                        imgdir = os.path.join(self.img_path(), "var", "pkg")
-                        self.assertTrue(os.path.exists(imgdir))
+            imgdir = os.path.join(self.img_path(), "var", "pkg")
+            self.assertTrue(os.path.exists(imgdir))
 
-                        hfile = os.path.join(imgdir, "pkg5.hang")
-                        self.assertTrue(not os.path.exists(hfile))
+            hfile = os.path.join(imgdir, "pkg5.hang")
+            self.assertTrue(not os.path.exists(hfile))
 
-                        self.pkg("purge-history")
+            self.pkg("purge-history")
 
-                        hndl = self.pkg(
-                            ["-D", "simulate-plan-hang=true", "install", "foo"],
-                            handle=True, coverage=False)
+            hndl = self.pkg(
+                ["-D", "simulate-plan-hang=true", "install", "foo"],
+                handle=True,
+                coverage=False,
+            )
 
-                        # Wait for hang file before sending signal.
-                        while not os.path.exists(hfile):
-                                self.assertEqual(hndl.poll(), None)
-                                time.sleep(0.25)
+            # Wait for hang file before sending signal.
+            while not os.path.exists(hfile):
+                self.assertEqual(hndl.poll(), None)
+                time.sleep(0.25)
 
-                        hndl.send_signal(sig)
-                        rc = hndl.wait()
+            hndl.send_signal(sig)
+            rc = hndl.wait()
 
-                        self.assertEqual(rc, 1)
+            self.assertEqual(rc, 1)
 
-                        # Verify that history records operation as canceled.
-                        self.pkg(["history", "-H"])
-                        hentry = self.output.splitlines()[-1]
-                        self.assertTrue("install" in hentry)
-                        self.assertTrue("Canceled" in hentry)
+            # Verify that history records operation as canceled.
+            self.pkg(["history", "-H"])
+            hentry = self.output.splitlines()[-1]
+            self.assertTrue("install" in hentry)
+            self.assertTrue("Canceled" in hentry)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_property.py
+++ b/src/tests/cli/t_pkg_property.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -37,116 +38,119 @@ import unittest
 
 
 class TestPkgPropertyBasics(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        def test_pkg_properties(self):
-                """pkg: set, unset, and display properties"""
+    def test_pkg_properties(self):
+        """pkg: set, unset, and display properties"""
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                self.pkg("set-property -@", exit=2)
-                self.pkg("get-property -@", exit=2)
-                self.pkg("property -@", exit=2)
+        self.pkg("set-property -@", exit=2)
+        self.pkg("get-property -@", exit=2)
+        self.pkg("property -@", exit=2)
 
-                self.pkg("set-property title sample")
-                self.pkg('set-property description "more than one word"')
-                self.pkg("property")
-                self.pkg("property | grep title")
-                self.pkg("property | grep description")
-                self.pkg("property | grep 'sample'")
-                self.pkg("property | grep 'more than one word'")
-                self.pkg("unset-property description")
-                self.pkg("property -H")
-                self.pkg("property title")
-                self.pkg("property -H title")
-                self.pkg("property description", exit=1)
-                self.pkg("unset-property description", exit=1)
-                self.pkg("unset-property", exit=2)
+        self.pkg("set-property title sample")
+        self.pkg('set-property description "more than one word"')
+        self.pkg("property")
+        self.pkg("property | grep title")
+        self.pkg("property | grep description")
+        self.pkg("property | grep 'sample'")
+        self.pkg("property | grep 'more than one word'")
+        self.pkg("unset-property description")
+        self.pkg("property -H")
+        self.pkg("property title")
+        self.pkg("property -H title")
+        self.pkg("property description", exit=1)
+        self.pkg("unset-property description", exit=1)
+        self.pkg("unset-property", exit=2)
 
-                self.pkg("set-property signature-policy verify")
-                self.pkg("set-property signature-policy verify foo", exit=2)
-                self.pkg("set-property signature-policy vrify", exit=1)
-                self.pkg("set-property signature-policy require-names", exit=1)
-                self.pkg("set-property signature-policy require-names foo")
+        self.pkg("set-property signature-policy verify")
+        self.pkg("set-property signature-policy verify foo", exit=2)
+        self.pkg("set-property signature-policy vrify", exit=1)
+        self.pkg("set-property signature-policy require-names", exit=1)
+        self.pkg("set-property signature-policy require-names foo")
 
-                self.pkg("add-property-value signature-policy verify", exit=1)
-                self.pkg("add-property-value signature-required-names foo")
-                self.pkg("add-property-value signature-required-names bar")
-                self.pkg("remove-property-value signature-required-names foo")
-                self.pkg("remove-property-value signature-required-names baz",
-                    exit=1)
-                self.pkg("add-property-value foo", exit=2)
-                self.pkg("remove-property-value foo", exit=2)
-                self.pkg("set-property foo", exit=2)
-                self.pkg("set-property foo bar")
-                self.pkg("remove-property-value foo bar", exit=1)
-                self.pkg("set-property", exit=2)
+        self.pkg("add-property-value signature-policy verify", exit=1)
+        self.pkg("add-property-value signature-required-names foo")
+        self.pkg("add-property-value signature-required-names bar")
+        self.pkg("remove-property-value signature-required-names foo")
+        self.pkg("remove-property-value signature-required-names baz", exit=1)
+        self.pkg("add-property-value foo", exit=2)
+        self.pkg("remove-property-value foo", exit=2)
+        self.pkg("set-property foo", exit=2)
+        self.pkg("set-property foo bar")
+        self.pkg("remove-property-value foo bar", exit=1)
+        self.pkg("set-property", exit=2)
 
-                self.pkg("set-property trust-anchor-directory {0} {1}".format(
-                    self.test_root, self.test_root), exit=1)
+        self.pkg(
+            "set-property trust-anchor-directory {0} {1}".format(
+                self.test_root, self.test_root
+            ),
+            exit=1,
+        )
 
-                # Verify that properties with single values can be set and
-                # retrieved as expected.
-                self.pkg("set-property flush-content-cache-on-success False")
-                self.pkg("property -H flush-content-cache-on-success |"
-                    "grep -i flush-content-cache-on-success.*false$")
+        # Verify that properties with single values can be set and
+        # retrieved as expected.
+        self.pkg("set-property flush-content-cache-on-success False")
+        self.pkg(
+            "property -H flush-content-cache-on-success |"
+            "grep -i flush-content-cache-on-success.*false$"
+        )
 
-        def test_missing_permissions(self):
-                """Bug 2393"""
+    def test_missing_permissions(self):
+        """Bug 2393"""
 
-                self.image_create(self.rurl)
+        self.image_create(self.rurl)
 
-                self.pkg("property")
-                self.pkg("set-property require-optional True", su_wrap=True,
-                    exit=1)
-                self.pkg("set-property require-optional True")
-                self.pkg("unset-property require-optional", su_wrap=True,
-                    exit=1)
-                self.pkg("unset-property require-optional")
+        self.pkg("property")
+        self.pkg("set-property require-optional True", su_wrap=True, exit=1)
+        self.pkg("set-property require-optional True")
+        self.pkg("unset-property require-optional", su_wrap=True, exit=1)
+        self.pkg("unset-property require-optional")
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/lib
             close """
 
-        def test_pkg_property_keyfiles(self):
-                """key-files image property"""
+    def test_pkg_property_keyfiles(self):
+        """key-files image property"""
 
-                self.pkgsend_bulk(self.rurl, [self.foo10, self.foo11])
+        self.pkgsend_bulk(self.rurl, [self.foo10, self.foo11])
 
-                vanilla = "lib/.vanilla"
-                pecan = "lib/.pecan"
+        vanilla = "lib/.vanilla"
+        pecan = "lib/.pecan"
 
-                self.image_create(self.rurl)
-                self.pkg("install foo@1.0")
+        self.image_create(self.rurl)
+        self.pkg("install foo@1.0")
 
-                self.pkg("add-property-value key-files lib/.vanilla")
-                # Even adding a new keyfile property will fail as the
-                # image configuration cannot be loaded with a missing key-file.
-                self.pkg("add-property-value key-files lib/.pecan", exit=51)
-                self.file_touch(vanilla)
-                self.pkg("add-property-value key-files lib/.pecan")
-                self.file_touch(pecan)
+        self.pkg("add-property-value key-files lib/.vanilla")
+        # Even adding a new keyfile property will fail as the
+        # image configuration cannot be loaded with a missing key-file.
+        self.pkg("add-property-value key-files lib/.pecan", exit=51)
+        self.file_touch(vanilla)
+        self.pkg("add-property-value key-files lib/.pecan")
+        self.file_touch(pecan)
 
-                self.pkg("property key-files")
-                self.assertTrue("vanilla" in self.output)
+        self.pkg("property key-files")
+        self.assertTrue("vanilla" in self.output)
 
-                # pkg update should fail due to missing keyfile
-                self.file_remove(vanilla)
-                self.pkg("update", exit=51)
-                self.assertTrue("Is everything mounted" in self.errout)
+        # pkg update should fail due to missing keyfile
+        self.file_remove(vanilla)
+        self.pkg("update", exit=51)
+        self.assertTrue("Is everything mounted" in self.errout)
 
-                # and now succeed
-                self.file_touch(vanilla)
-                self.pkg("update")
+        # and now succeed
+        self.file_touch(vanilla)
+        self.pkg("update")
 
-        xpkg = """
+    xpkg = """
     open xpkg@1.0,5.11-0
     add dir mode=0755 owner=root group=bin path=/usr
     add dir mode=0755 owner=root group=bin path=/usr/lib
@@ -161,47 +165,49 @@ class TestPkgPropertyBasics(pkg5unittest.SingleDepotTestCase):
     close
         """
 
-        misc_files = [ 'tmp/cat' ]
+    misc_files = ["tmp/cat"]
 
-        def test_pkg_property_excludes(self):
-                """exclude-patterns image property"""
+    def test_pkg_property_excludes(self):
+        """exclude-patterns image property"""
 
-                self.make_misc_files(self.misc_files)
+        self.make_misc_files(self.misc_files)
 
-                self.pkgsend_bulk(self.rurl, self.xpkg)
+        self.pkgsend_bulk(self.rurl, self.xpkg)
 
-                self.image_create(self.rurl)
-                self.pkg("add-property-value exclude-patterns 'usr/(?!lib/fm)'")
-                self.pkg("add-property-value exclude-patterns 'sbin/'")
+        self.image_create(self.rurl)
+        self.pkg("add-property-value exclude-patterns 'usr/(?!lib/fm)'")
+        self.pkg("add-property-value exclude-patterns 'sbin/'")
 
-                self.pkg("set-property exclude-policy ignore")
-                self.pkg("install xpkg")
-                self.assertTrue("libbarney.so" not in self.output);
-                self.assert_files_exist((
-                    ("bambam", True),
-                    ("sbin/dino", False),
-                    ("usr/lib/libfred.so", False),
-                    ("usr/lib/libbarney.so", False),
-                    ("usr/lib/fm/wilma.xml", True),
-                    ("usr/lib/fm/betty.xml", True),
-                ))
-                self.pkg("uninstall xpkg")
+        self.pkg("set-property exclude-policy ignore")
+        self.pkg("install xpkg")
+        self.assertTrue("libbarney.so" not in self.output)
+        self.assert_files_exist(
+            (
+                ("bambam", True),
+                ("sbin/dino", False),
+                ("usr/lib/libfred.so", False),
+                ("usr/lib/libbarney.so", False),
+                ("usr/lib/fm/wilma.xml", True),
+                ("usr/lib/fm/betty.xml", True),
+            )
+        )
+        self.pkg("uninstall xpkg")
 
-                self.pkg("set-property exclude-policy warn")
-                self.pkg("install xpkg")
-                self.assertTrue("actions have not been installed" in
-                    self.output);
-                self.assertTrue("configured exclusions" in self.output)
-                self.assertTrue("libbarney.so" in self.output)
-                self.pkg("uninstall xpkg")
+        self.pkg("set-property exclude-policy warn")
+        self.pkg("install xpkg")
+        self.assertTrue("actions have not been installed" in self.output)
+        self.assertTrue("configured exclusions" in self.output)
+        self.assertTrue("libbarney.so" in self.output)
+        self.pkg("uninstall xpkg")
 
-                self.pkg("set-property exclude-policy reject")
-                self.pkg("install xpkg", exit=1)
-                self.assertTrue("match exclusions which" in self.errout)
-                self.assertTrue("libbarney.so" in self.errout)
+        self.pkg("set-property exclude-policy reject")
+        self.pkg("install xpkg", exit=1)
+        self.assertTrue("match exclusions which" in self.errout)
+        self.assertTrue("libbarney.so" in self.errout)
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_publisher.py
+++ b/src/tests/cli/t_pkg_publisher.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import hashlib
@@ -40,1739 +41,2131 @@ import unittest
 
 
 class TestPkgPublisherBasics(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        # Dummy package
-        foo1 = """
+    # Dummy package
+    foo1 = """
             open foo@1,5.11-0
             close """
 
-        def setUp(self):
-                # This test suite needs actual depots.
-                pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
-
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.pkgsend_bulk(self.durl1, self.foo1)
-
-        def test_pkg_publisher_bogus_opts(self):
-                """ pkg bogus option checks """
-
-                self.image_create(self.rurl)
-
-                self.pkg("set-publisher -@ test3", exit=2)
-                self.pkg("publisher -@ test5", exit=2)
-                self.pkg("set-publisher -k", exit=2)
-                self.pkg("set-publisher -c", exit=2)
-                self.pkg("set-publisher -O", exit=2)
-                self.pkg("unset-publisher", exit=2)
-                self.pkg("unset-publisher -k", exit=2)
-
-        def test_publisher_add_remove(self):
-                """pkg: add and remove a publisher"""
-
-                self.image_create(self.rurl)
-
-                self.pkg("set-publisher -O http://{0}1 test1".format(self.bogus_url),
-                    exit=1)
-
-                # Verify that a publisher can be added initially disabled.
-                self.pkg("set-publisher -d --no-refresh -O http://{0}1 test1".format(
-                    self.bogus_url))
-
-                self.pkg("publisher | grep test")
-                self.pkg("set-publisher -P -O http://{0}2 test2".format(
-                    self.bogus_url), exit=1)
-                self.pkg("set-publisher -P --no-refresh -O http://{0}2 test2".format(
-                    self.bogus_url))
-                self.pkg("publisher | grep test2")
-                self.pkg("unset-publisher test1")
-                self.pkg("publisher | grep test1", exit=1)
-
-                # Now verify that partial success (3) or complete failure (1)
-                # is properly returned if an attempt to remove one or more
-                # publishers only results in some of them being removed:
-
-                # ...when one of two provided is unknown.
-                self.pkg("set-publisher --no-refresh -O http://{0}2 test3".format(
-                    self.bogus_url))
-                self.pkg("unset-publisher test3 test4", exit=3)
-
-                # ...when all provided are unknown.
-                self.pkg("unset-publisher test3 test4", exit=1)
-                self.pkg("unset-publisher test3", exit=1)
-
-                # Now verify that success occurs when attempting to remove
-                # one or more publishers:
-
-                # ...when one is provided and not preferred.
-                self.pkg("set-publisher --no-refresh -O http://{0}2 test3".format(
-                    self.bogus_url))
-                self.pkg("unset-publisher test3")
-
-                # ...when two are provided and not preferred.
-                self.pkg("set-publisher --no-refresh -O http://{0}2 test3".format(
-                    self.bogus_url))
-                self.pkg("set-publisher --no-refresh -O http://{0}2 test4".format(
-                    self.bogus_url))
-                self.pkg("unset-publisher test3 test4")
-
-                # Ensure that some package manifests are cached for the
-                # publisher.
-                self.pkg("info -r '//test/*'")
-
-                # Now verify that success occurs when attempting to remove a
-                # publisher that has already had its private directory removed
-                # from $IMG_DIR/pkg.
-                api_inst = self.get_img_api_obj()
-                pub = api_inst.get_publisher(prefix="test")
-                self.assertTrue(os.path.exists(pub.meta_root))
-                pub.remove_meta_root()
-                self.assertTrue(not os.path.exists(pub.meta_root))
-
-                pub_cache_path = os.path.join(self.img_path(), "var", "pkg",
-                    "cache", "publisher", "test")
-                self.assertTrue(os.path.exists(pub_cache_path),
-                    os.listdir(os.path.join(self.img_path(), "var", "pkg",
-                    "cache", "publisher")))
-                shutil.rmtree(pub_cache_path)
-                self.assertTrue(not os.path.exists(pub_cache_path))
-
-                self.pkg("unset-publisher test")
-
-        def test_publisher_uri(self):
-                """Verify the URI specification"""
-
-                # Create a repository for the test publisher.
-                rpath = os.path.join(self.test_root, "example_repo")
-                self.create_repo(rpath, properties={ "publisher": {
-                    "prefix": "test" } })
-                self.image_create("file:{0}".format(rpath))
-                slash = "/"
-
-                # Verify that an invalid URI specification fails
-                self.pkg("set-publisher -O file:{0}{1} test".format(slash, rpath), exit=1)
-                self.pkg("set-publisher --no-refresh -O file:{0}{1} test".format(slash, rpath), exit=1)
-
-                # Verify that an over specified '/' are reduced correctly
-                for slashes in [ "///", "////" , "/////"]:
-                    self.pkg("set-publisher -O file:{0}{1} test".format(slashes, rpath))
-                    self.pkg("publisher | grep file://{0}".format(rpath))
-                    self.pkg("set-publisher --no-refresh -O file:{0}{1} test".format(slashes, rpath))
-                    self.pkg("publisher | grep file://{0}".format(rpath))
-
-                self.pkg("unset-publisher test")
-
-        def test_publisher_uuid(self):
-                """verify uuid is set manually and automatically for a
-                publisher"""
-
-                self.image_create(self.rurl)
-                self.pkg("set-publisher -O http://{0}1 --no-refresh --reset-uuid test1".format(
-                    self.bogus_url))
-                self.pkg("set-publisher --no-refresh --reset-uuid test1")
-                self.pkg("set-publisher -O http://{0}1 --no-refresh test2".format(
-                    self.bogus_url))
-                self.pkg("publisher test2 | grep 'Client UUID: '")
-                self.pkg("publisher test2 | grep -v 'Client UUID: None'")
-
-        def test_publisher_bad_opts(self):
-                """pkg: more insidious option abuse for set-publisher"""
-
-                self.image_create(self.rurl)
-
-                key_path = os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem")
-                cert_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
-
-                self.pkg(
-                    "set-publisher -O http://{0}1 test1 -O http://{1}2 test2".format(
-                    self.bogus_url, self.bogus_url), exit=2)
-
-                self.pkg("set-publisher -O http://{0}1 test1".format(self.bogus_url),
-                    exit=1)
-                self.pkg("set-publisher -O http://{0}2 test2".format(self.bogus_url),
-                    exit=1)
-                self.pkg("set-publisher --no-refresh -O https://{0}1 test1".format(
-                    self.bogus_url))
-                self.pkg("set-publisher --no-refresh -O http://{0}2 test2".format(
-                    self.bogus_url))
-
-                # Set key for test1.
-                self.pkg("set-publisher --no-refresh -k {0} test1".format(key_path))
-
-                # This should fail since test2 doesn't have any SSL origins or
-                # mirrors.
-                self.pkg("set-publisher --no-refresh -k {0} test2".format(key_path),
-                    exit=2)
-
-                # Listing publishers should succeed even if key file is gone.
-                # This test relies on using the same implementation used in
-                # image.py __store_publisher_ssl() which sets the paths to the
-                # SSL keys/certs.
-                img_key_path = os.path.join(self.img_path(), "var", "pkg",
-                    "ssl", pkg.misc.get_data_digest(key_path,
-                    hash_func=hashlib.sha1)[0])
-                os.unlink(img_key_path)
-                self.pkg("publisher test1")
-
-                # This should fail since key has been removed even though test2
-                # has an https origin.
-                self.pkg("set-publisher --no-refresh -O https://{0}2 test2".format(
-                    self.bogus_url))
-                self.pkg("set-publisher --no-refresh -k {0} test2".format(
-                    img_key_path), exit=1)
-
-                # Reset for next test.
-                self.pkg("set-publisher --no-refresh -k '' test1")
-                self.pkg("set-publisher --no-refresh -O http://{0}2 test2".format(
-                    self.bogus_url))
-
-                # Set cert for test1.
-                self.pkg("set-publisher --no-refresh -c {0} test1".format(cert_path))
-
-                # This should fail since test2 doesn't have any SSL origins or
-                # mirrors.
-                self.pkg("set-publisher --no-refresh -c {0} test2".format(cert_path),
-                    exit=2)
-
-                # Listing publishers should be possible if cert file is gone.
-                img_cert_path = os.path.join(self.img_path(), "var", "pkg",
-                    "ssl", pkg.misc.get_data_digest(cert_path,
-                    hash_func=hashlib.sha1)[0])
-                os.unlink(img_cert_path)
-                self.pkg("publisher test1", exit=3)
-
-                # This should fail since cert has been removed even though test2
-                # has an https origin.
-                self.pkg("set-publisher --no-refresh -O https://{0}2 test2".format(
-                    self.bogus_url))
-                self.pkg("set-publisher --no-refresh -c {0} test2".format(
-                    img_cert_path), exit=1)
-
-                # Reset for next test.
-                self.pkg("set-publisher --no-refresh -O http://{0}2 test2".format(
-                    self.bogus_url))
-
-                # Expect partial failure since cert file is gone for test1.
-                self.pkg("publisher test1", exit=3)
-                self.pkg("publisher test3", exit=1)
-                self.pkg("publisher -H | grep URI", exit=1)
-
-                # Now verify that setting ssl_cert or ssl_key to "" works.
-                self.pkg('set-publisher --no-refresh -c "" test1')
-                self.pkg('publisher -H test1 | grep "SSL Cert: None"')
-
-                self.pkg('set-publisher --no-refresh -k "" test1')
-                self.pkg('publisher -H test1 | grep "SSL Key: None"')
-
-                self.pkg("set-publisher --set-property foo test1", exit=2)
-                self.pkg("set-publisher --set-property foo=bar --set-property "
-                    "foo=baz test1", exit=2)
-                self.pkg("set-publisher --add-property-value foo test1", exit=2)
-                self.pkg("set-publisher --remove-property-value foo test1",
-                    exit=2)
-                self.pkg("set-publisher --approve-ca-cert /shouldnotexist/foo "
-                    "test1", exit=1)
-
-                key_fh, key_path = tempfile.mkstemp()
-                self.pkg("set-publisher --approve-ca-cert {0} test1".format(key_path),
-                    exit=1, su_wrap=True)
-                os.unlink(key_path)
-
-                self.pkg("set-publisher --no-refresh --set-property "
-                    "signature-policy=ignore test1")
-                self.pkg("publisher test1")
-                self.assertTrue("signature-policy = ignore" in self.output)
-                self.pkg("set-publisher --no-refresh --set-property foo=bar "
-                    "test1")
-                self.pkg("publisher test1")
-                self.assertTrue("foo = bar" in self.output)
-                self.pkg("set-publisher --no-refresh  --remove-property-value "
-                    "foo=baz test1", exit=1)
-                self.pkg("publisher test1")
-                self.assertTrue("foo = bar" in self.output)
-                self.pkg("set-publisher --no-refresh  --set-property "
-                    "signature-policy=require-names test1", exit=1)
-                self.pkg("set-publisher --no-refresh --remove-property-value "
-                    "bar=baz test1", exit=1)
-
-                self.pkg("publisher")
-                self.pkg("set-publisher --no-refresh --search-after foo test1",
-                    exit=1)
-                self.pkg("set-publisher --no-refresh --search-before foo test1",
-                    exit=1)
-
-        def test_publisher_validation(self):
-                """Verify that we catch poorly formed auth prefixes and URL"""
-
-                self.image_create(self.rurl, prefix="test")
-
-                self.pkg("set-publisher -O http://{0}1 test1".format(self.bogus_url),
-                    exit=1)
-                self.pkg("set-publisher --no-refresh -O http://{0}1 test1".format(
-                    self.bogus_url))
-
-                self.pkg(("set-publisher -O http://{0}2 ".format(self.bogus_url)) +
-                    "$%^8", exit=1)
-                self.pkg(("set-publisher -O http://{0}2 ".format(self.bogus_url)) +
-                    "8^$%", exit=1)
-                self.pkg("set-publisher -O http://*^5$% test2", exit=1)
-                self.pkg("set-publisher -O http://{0}1:abcde test2".format(
-                    self.bogus_url), exit=1)
-                self.pkg("set-publisher -O ftp://{0}2 test2".format(self.bogus_url),
-                    exit=1)
-
-                # Verify single character in hostname is valid publisher
-                self.pkg("set-publisher --no-refresh -g http://a/ a")
-                self.pkg("set-publisher --no-refresh -g http://a.example.com " \
-                    "a.example.com")
-
-        def test_missing_perms(self):
-                """Verify graceful failure if certificates are unreadable by
-                unprivileged users."""
-
-                self.image_create(self.rurl, prefix="test")
-
-                self.pkg("set-publisher --no-refresh -O http://{0}1 test1".format(
-                    self.bogus_url), su_wrap=True, exit=1)
-                self.pkg("set-publisher --no-refresh -O http://{0}1 foo".format(
-                    self.bogus_url))
-                self.pkg("publisher | grep foo")
-                self.pkg("set-publisher -P --no-refresh -O http://{0}2 test2".format(
-                    self.bogus_url), su_wrap=True, exit=1)
-                self.pkg("unset-publisher foo", su_wrap=True, exit=1)
-                self.pkg("unset-publisher foo")
-
-                self.pkg("set-publisher -m http://{0}1 test".format(self.bogus_url),
-                    su_wrap=True, exit=1)
-                self.pkg("set-publisher -m http://{0}2 test".format(
-                    self.bogus_url))
-
-                self.pkg("set-publisher -M http://{0}2 test".format(
-                    self.bogus_url), su_wrap=True, exit=1)
-                self.pkg("set-publisher -M http://{0}2 test".format(
-                    self.bogus_url))
-
-                # Now change the first publisher to a https URL so that
-                # certificate failure cases can be tested.
-                key_path = os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem")
-                cert_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
-
-                self.pkg("set-publisher --no-refresh -O https://{0}1 test1".format(
-                    self.bogus_url))
-                self.pkg("set-publisher --no-refresh -c {0} test1".format(cert_path))
-                self.pkg("set-publisher --no-refresh -k {0} test1".format(key_path))
-
-                # This test relies on using the same implementation used in
-                # image.py __store_publisher_ssl() which sets the paths to the
-                # SSL keys/certs.
-                img_key_path = os.path.join(self.img_path(), "var", "pkg",
-                    "ssl", pkg.misc.get_data_digest(key_path,
-                    hash_func=hashlib.sha1)[0])
-                img_cert_path = os.path.join(self.img_path(), "var", "pkg",
-                    "ssl", pkg.misc.get_data_digest(cert_path,
-                    hash_func=hashlib.sha1)[0])
-
-                # Make the cert/key unreadable by unprivileged users.
-                os.chmod(img_key_path, 0000)
-                os.chmod(img_cert_path, 0000)
-
-                # Verify that an unreadable certificate results in a
-                # partial failure when displaying publisher information.
-                self.pkg("publisher test1", su_wrap=True, exit=3)
-
-                # Corrupt key/cert and verify invalid cert/key results in a
-                # partial failure when displaying publisher information.
-                open(img_key_path, "wb").close()
-                open(img_cert_path, "wb").close()
-                self.pkg("publisher test1", exit=3)
-
-        def test_publisher_tsv_format(self):
-                """Ensure tsv formatted output is correct."""
-
-                self.image_create(self.rurl)
-
-                self.pkg("set-publisher --no-refresh -O https://{0}1 test1".format(
-                    self.bogus_url))
-                self.pkg("set-publisher --no-refresh -O http://{0}2 test2".format(
-                    self.bogus_url))
-
-                base_string = ("test\ttrue\tfalse\ttrue\torigin\tonline\t"
-                    "{0}/\t-\n"
-                    "test1\ttrue\tfalse\ttrue\torigin\tonline\t"
-                    "https://{1}1/\t-\n"
-                    "test2\ttrue\tfalse\ttrue\torigin\tonline\t"
-                    "http://{2}2/\t-\n".format(self.rurl, self.bogus_url,
-                    self.bogus_url))
-                # With headers
-                self.pkg("publisher -F tsv")
-                expected = "PUBLISHER\tSTICKY\tSYSPUB\tENABLED" \
-                    "\tTYPE\tSTATUS\tURI\tPROXY\n" + base_string
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # Without headers
-                self.pkg("publisher -HF tsv")
-                expected = base_string
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-        def test_old_publisher_ca_certs(self):
-                """Check that approving and revoking CA certs is reflected in
-                the output of pkg publisher and that setting the CA certs when
-                setting an existing publisher works correctly."""
-
-                cert_dir = os.path.join(self.ro_data_root,
-                    "signing_certs", "produced", "chain_certs")
-
-                app1 = os.path.join(cert_dir, "ch1_ta1_cert.pem")
-                app2 = os.path.join(cert_dir, "ch1_ta3_cert.pem")
-                rev1 = os.path.join(cert_dir, "ch1_ta4_cert.pem")
-                rev2 = os.path.join(cert_dir, "ch1_ta5_cert.pem")
-                app1_h = self.calc_pem_hash(app1)
-                app2_h = self.calc_pem_hash(app2)
-                rev1_h = self.calc_pem_hash(rev1)
-                rev2_h = self.calc_pem_hash(rev2)
-                self.image_create(self.rurl)
-                self.pkg("set-publisher "
-                    "--approve-ca-cert {0} "
-                    "--approve-ca-cert {1} --revoke-ca-cert {2} "
-                    "--revoke-ca-cert {3} test ".format(
-                    app1, app2, rev1_h, rev2_h))
-                self.pkg("publisher test")
-                r1 = "         Approved CAs: {0}"
-                r2 = "                     : {0}"
-                r3 = "          Revoked CAs: {0}"
-                ls = self.output.splitlines()
-                found_approved = False
-                found_revoked = False
-                for i in range(0, len(ls)):
-                        if "Approved CAs" in ls[i]:
-                                found_approved = True
-                                if not ((r1.format(app1_h) == ls[i] and
-                                    r2.format(app2_h) == ls[i+1] or \
-                                    (r1.format(app2_h) == ls[i]) and
-                                    r2.format(app1_h) == ls[i+1])):
-                                        raise RuntimeError("Expected to see "
-                                            "{0} and {1} as approved certs. "
-                                            "Output was:\n{2}".format(app1_h,
-                                            app2_h, self.output))
-                        elif "Revoked CAs" in ls[i]:
-                                found_approved = True
-                                if not ((r3.format(rev1_h) == ls[i] and
-                                    r2.format(rev2_h) == ls[i+1]) or \
-                                    (r3.format(rev2_h) == ls[i] and
-                                    r2.format(rev1_h) == ls[i+1])):
-                                        raise RuntimeError("Expected to see "
-                                            "{0} and {1} as revoked certs. "
-                                            "Output was:\n{2}".format(rev1_h,
-                                            rev2_h, self.output))
-
-        def test_publisher_properties(self):
-                """Test that properties set on publishers are correctly
-                displayed in the output of pkg publisher <publisher name>."""
-
-                self.image_create(self.rurl)
-                self.pkg("publisher test")
-                self.assertTrue("Properties:" not in self.output)
-
-                self.pkg("set-publisher --set-property foo=bar test")
-                self.pkg("publisher test")
-                self.assertTrue("Properties:" in self.output)
-                self.assertTrue("foo = bar" in self.output)
-                self.pkg("set-publisher --add-property-value foo=bar1 test",
-                    exit=1)
-
-                self.pkg("set-publisher --set-property "
-                    "signature-policy=require-names --add-property-value "
-                    "signature-required-names=n1 test")
-                self.pkg("publisher test")
-                self.assertTrue("signature-policy = require-names" in self.output)
-                self.assertTrue("signature-required-names = n1" in self.output)
-
-                self.pkg("set-publisher --add-property-value "
-                    "signature-required-names=n2 test")
-                self.pkg("publisher test")
-                self.assertTrue("signature-required-names = n1, n2" in self.output)
-
-        def test_bug_7141684(self):
-                """Test that pkg(1) client does not traceback if no publisher
-                configured and we try to get preferred publisher"""
-
-                self.image_create()
-                self.pkg("publisher -P", exit=0)
-
-                self.pkg("set-publisher -g {0} test".format(self.durl1))
-                self.pkg("install foo")
-                self.pkg("unset-publisher test")
-                self.pkg("publisher -P", exit=0)
-
-        def test_publisher_proxies(self):
-                """Tests that set-publisher can add and remove proxy values
-                per origin."""
-
-                self.image_create(self.rurl)
-                self.pkg("publisher test")
-                self.assertTrue("Proxy:" not in self.output)
-
-                # check origin and mirror addition/removal when proxies are used
-                for add, remove in [("-g", "-G"), ("-m", "-M")]:
-                        self.image_create(self.rurl)
-                        # we can't proxy file repositories
-                        self.pkg("set-publisher --no-refresh {add} {url} "
-                            "--proxy http://foo test".format(
-                            add=add, url=self.rurl), exit=1)
-                        self.pkg("publisher test")
-                        self.assertTrue("Proxy:" not in self.output)
-
-                        # we can set the proxy for http repos
-                        self.pkg("set-publisher --no-refresh {add} {url} "
-                            "--proxy http://foo test".format(
-                            add=add, url=self.durl))
-
-                        self.pkg("publisher test")
-                        self.assertTrue("Proxy: http://foo" in self.output)
-
-                        # remove the file-based repository and ensure we still
-                        # have a proxied http-based publisher
-                        self.pkg("set-publisher --no-refresh -G {0} test".format(
-                            self.rurl))
-                        self.pkg("publisher -F tsv")
-                        self.assertTrue("{0}/\thttp://foo".format(
-                            self.durl in self.output))
-                        self.assertTrue(self.rurl not in self.output)
-
-                        # ensure we can't add duplicate proxied or unproxied
-                        # repositories
-                        self.pkg("set-publisher --no-refresh {add} {url} "
-                            "--proxy http://foo test".format(
-                            add=add, url=self.durl), exit=1)
-                        self.pkg("set-publisher --no-refresh {add} {url} "
-                            "test".format(add=add, url=self.durl), exit=1)
-
-                        # we should have 1 proxied occurrence of our http url
-                        self.pkg("publisher -F tsv")
-                        self.assertTrue("{0}/\thttp://foo".format(
-                            self.durl in self.output))
-                        self.assertTrue("\t\t{0}".format(self.durl not in self.output))
-
-                        # when removing a proxied url, then adding the same url
-                        # unproxied, the proxy configuration does get removed
-                        self.pkg("set-publisher --no-refresh {remove} {url}"
-                            " test".format(remove=remove, url=self.durl),
-                            exit=0)
-                        self.pkg("set-publisher --no-refresh {add} {url} "
-                            "test".format(add=add, url=self.durl), exit=0)
-                        self.pkg("publisher -F tsv")
-                        self.assertTrue("{0}/\thttp://foo".format(
-                            self.durl not in self.output))
-                        self.pkg("set-publisher --no-refresh {remove} "
-                            "{url} test".format(
-                            remove=remove, url=self.durl))
-
-                        # when we add multiple urls, and they all get the same
-                        # proxy value, leaving an existing non-proxied url
-                        # as non-proxied.
-                        self.pkg("set-publisher --no-refresh {add} http://a "
-                            "test".format(add=add))
-                        self.pkg("set-publisher --no-refresh {add} http://b "
-                            "{add} http://c --proxy http://foo test".format(
-                            add=add))
-                        self.pkg("publisher -F tsv")
-                        self.assertTrue("http://a/\t-" in self.output)
-                        self.assertTrue("http://b/\thttp://foo" in self.output)
-                        self.assertTrue("http://c/\thttp://foo" in self.output)
-
-        def test_publisher_special_repo_name(self):
-                """Tests that set-publisher can use the repository name with
-                special characters."""
-
-                self.image_create()
-
-                # "%" is a special character in SafeConfigParser, but needs
-                # to be supported anyway.
-                repo_dir = os.path.join(self.test_root, "repotest{0}ymbol")
-                self.create_repo(repo_dir, properties={ "publisher": {
-                    "prefix": "test1" } })
-                self.pkg("set-publisher -p {0} test1".format(repo_dir))
-                shutil.rmtree(repo_dir)
-
-                # "+" will be converted into "%2B" by URL quoting routines.
-                # "%" is a special character in SafeConfigParser, but we need
-                # to support it here.
-                repo_dir = os.path.join(self.test_root, "repotest+symbol")
-                self.create_repo(repo_dir, properties={ "publisher": {
-                    "prefix": "test2" } })
-                self.pkg("set-publisher -g {0} test2".format(repo_dir))
-                shutil.rmtree(repo_dir)
-
-                # "%()" is the syntax of expansion language in SafeConfigParser
-                # but needs to be raw characters here.
-                repo_dir = os.path.join(self.test_root, "{junkrepo}")
-                self.create_repo(repo_dir, properties={ "publisher": {
-                    "prefix": "test3" } })
-                self.pkg("set-publisher -g {0} test3".format(repo_dir))
-                shutil.rmtree(repo_dir)
-
-        def test_remove_unused_cert_key(self):
-                """Ensure that unused client certificate files are removed."""
-
-                self.image_create(self.rurl)
-
-                # Set the first publisher to a https URL
-                key_path = os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem")
-                cert_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
-
-                img_key_path = os.path.join(self.img_path(), "var", "pkg",
-                    "ssl", pkg.misc.get_data_digest(key_path,
-                    hash_func=hashlib.sha1)[0])
-                img_cert_path = os.path.join(self.img_path(), "var", "pkg",
-                    "ssl", pkg.misc.get_data_digest(cert_path,
-                    hash_func=hashlib.sha1)[0])
-
-                self.pkg("set-publisher --no-refresh -O https://{0} -c {1} \
-                    -k {2} test1" .format(self.bogus_url, cert_path, key_path))
-
-                # cert and key should exist
-                self.assertTrue(os.path.exists(img_key_path))
-                self.assertTrue(os.path.exists(img_cert_path))
-
-                # Now change test1 to http URL to check whether
-                # certificate and key are removed
-                self.pkg("set-publisher --no-refresh -O http://{0} \
-                    test1".format(self.bogus_url))
-
-                # cert and key should not exist.
-                self.assertTrue(not os.path.exists(img_key_path))
-                self.assertTrue(not os.path.exists(img_cert_path))
-
-                # Now test if cert and key is still in use
-                # we should not remove them
-                self.pkg("set-publisher --no-refresh -O https://{0} -c {1} \
-                    -k {2} test1".format(self.bogus_url, cert_path, key_path))
-
-                self.pkg("set-publisher --no-refresh -O https://{0} -c {1} \
-                    -k {2} foo".format(self.bogus_url, cert_path, key_path))
-
-                # cert and key should exist
-                self.assertTrue(os.path.exists(img_key_path))
-                self.assertTrue(os.path.exists(img_cert_path))
-
-                # Remove ssl for test1
-                self.pkg("set-publisher --no-refresh -O http://{0} \
-                    foo".format(self.bogus_url))
-
-                # cert and key should still exist.
-                self.assertTrue(os.path.exists(img_key_path))
-                self.assertTrue(os.path.exists(img_cert_path))
-
-                # Test unset-publisher
-                self.pkg("set-publisher --no-refresh -O https://{0} -c {1} \
-                    -k {2} foo".format(self.bogus_url, cert_path, key_path))
-
-                # cert and key should exist.
-                self.assertTrue(os.path.exists(img_key_path))
-                self.assertTrue(os.path.exists(img_cert_path))
-
-                self.pkg("unset-publisher foo")
-                # cert and key should still exist.
-                self.assertTrue(os.path.exists(img_key_path))
-                self.assertTrue(os.path.exists(img_cert_path))
-
-                self.pkg("unset-publisher test1")
-                # cert and key should not exist.
-                self.assertTrue(not os.path.exists(img_key_path))
-                self.assertTrue(not os.path.exists(img_cert_path))
+    def setUp(self):
+        # This test suite needs actual depots.
+        pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
+
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.pkgsend_bulk(self.durl1, self.foo1)
+
+    def test_pkg_publisher_bogus_opts(self):
+        """pkg bogus option checks"""
+
+        self.image_create(self.rurl)
+
+        self.pkg("set-publisher -@ test3", exit=2)
+        self.pkg("publisher -@ test5", exit=2)
+        self.pkg("set-publisher -k", exit=2)
+        self.pkg("set-publisher -c", exit=2)
+        self.pkg("set-publisher -O", exit=2)
+        self.pkg("unset-publisher", exit=2)
+        self.pkg("unset-publisher -k", exit=2)
+
+    def test_publisher_add_remove(self):
+        """pkg: add and remove a publisher"""
+
+        self.image_create(self.rurl)
+
+        self.pkg(
+            "set-publisher -O http://{0}1 test1".format(self.bogus_url), exit=1
+        )
+
+        # Verify that a publisher can be added initially disabled.
+        self.pkg(
+            "set-publisher -d --no-refresh -O http://{0}1 test1".format(
+                self.bogus_url
+            )
+        )
+
+        self.pkg("publisher | grep test")
+        self.pkg(
+            "set-publisher -P -O http://{0}2 test2".format(self.bogus_url),
+            exit=1,
+        )
+        self.pkg(
+            "set-publisher -P --no-refresh -O http://{0}2 test2".format(
+                self.bogus_url
+            )
+        )
+        self.pkg("publisher | grep test2")
+        self.pkg("unset-publisher test1")
+        self.pkg("publisher | grep test1", exit=1)
+
+        # Now verify that partial success (3) or complete failure (1)
+        # is properly returned if an attempt to remove one or more
+        # publishers only results in some of them being removed:
+
+        # ...when one of two provided is unknown.
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}2 test3".format(
+                self.bogus_url
+            )
+        )
+        self.pkg("unset-publisher test3 test4", exit=3)
+
+        # ...when all provided are unknown.
+        self.pkg("unset-publisher test3 test4", exit=1)
+        self.pkg("unset-publisher test3", exit=1)
+
+        # Now verify that success occurs when attempting to remove
+        # one or more publishers:
+
+        # ...when one is provided and not preferred.
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}2 test3".format(
+                self.bogus_url
+            )
+        )
+        self.pkg("unset-publisher test3")
+
+        # ...when two are provided and not preferred.
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}2 test3".format(
+                self.bogus_url
+            )
+        )
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}2 test4".format(
+                self.bogus_url
+            )
+        )
+        self.pkg("unset-publisher test3 test4")
+
+        # Ensure that some package manifests are cached for the
+        # publisher.
+        self.pkg("info -r '//test/*'")
+
+        # Now verify that success occurs when attempting to remove a
+        # publisher that has already had its private directory removed
+        # from $IMG_DIR/pkg.
+        api_inst = self.get_img_api_obj()
+        pub = api_inst.get_publisher(prefix="test")
+        self.assertTrue(os.path.exists(pub.meta_root))
+        pub.remove_meta_root()
+        self.assertTrue(not os.path.exists(pub.meta_root))
+
+        pub_cache_path = os.path.join(
+            self.img_path(), "var", "pkg", "cache", "publisher", "test"
+        )
+        self.assertTrue(
+            os.path.exists(pub_cache_path),
+            os.listdir(
+                os.path.join(
+                    self.img_path(), "var", "pkg", "cache", "publisher"
+                )
+            ),
+        )
+        shutil.rmtree(pub_cache_path)
+        self.assertTrue(not os.path.exists(pub_cache_path))
+
+        self.pkg("unset-publisher test")
+
+    def test_publisher_uri(self):
+        """Verify the URI specification"""
+
+        # Create a repository for the test publisher.
+        rpath = os.path.join(self.test_root, "example_repo")
+        self.create_repo(rpath, properties={"publisher": {"prefix": "test"}})
+        self.image_create("file:{0}".format(rpath))
+        slash = "/"
+
+        # Verify that an invalid URI specification fails
+        self.pkg(
+            "set-publisher -O file:{0}{1} test".format(slash, rpath), exit=1
+        )
+        self.pkg(
+            "set-publisher --no-refresh -O file:{0}{1} test".format(
+                slash, rpath
+            ),
+            exit=1,
+        )
+
+        # Verify that an over specified '/' are reduced correctly
+        for slashes in ["///", "////", "/////"]:
+            self.pkg("set-publisher -O file:{0}{1} test".format(slashes, rpath))
+            self.pkg("publisher | grep file://{0}".format(rpath))
+            self.pkg(
+                "set-publisher --no-refresh -O file:{0}{1} test".format(
+                    slashes, rpath
+                )
+            )
+            self.pkg("publisher | grep file://{0}".format(rpath))
+
+        self.pkg("unset-publisher test")
+
+    def test_publisher_uuid(self):
+        """verify uuid is set manually and automatically for a
+        publisher"""
+
+        self.image_create(self.rurl)
+        self.pkg(
+            "set-publisher -O http://{0}1 --no-refresh --reset-uuid test1".format(
+                self.bogus_url
+            )
+        )
+        self.pkg("set-publisher --no-refresh --reset-uuid test1")
+        self.pkg(
+            "set-publisher -O http://{0}1 --no-refresh test2".format(
+                self.bogus_url
+            )
+        )
+        self.pkg("publisher test2 | grep 'Client UUID: '")
+        self.pkg("publisher test2 | grep -v 'Client UUID: None'")
+
+    def test_publisher_bad_opts(self):
+        """pkg: more insidious option abuse for set-publisher"""
+
+        self.image_create(self.rurl)
+
+        key_path = os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem")
+        cert_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
+
+        self.pkg(
+            "set-publisher -O http://{0}1 test1 -O http://{1}2 test2".format(
+                self.bogus_url, self.bogus_url
+            ),
+            exit=2,
+        )
+
+        self.pkg(
+            "set-publisher -O http://{0}1 test1".format(self.bogus_url), exit=1
+        )
+        self.pkg(
+            "set-publisher -O http://{0}2 test2".format(self.bogus_url), exit=1
+        )
+        self.pkg(
+            "set-publisher --no-refresh -O https://{0}1 test1".format(
+                self.bogus_url
+            )
+        )
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}2 test2".format(
+                self.bogus_url
+            )
+        )
+
+        # Set key for test1.
+        self.pkg("set-publisher --no-refresh -k {0} test1".format(key_path))
+
+        # This should fail since test2 doesn't have any SSL origins or
+        # mirrors.
+        self.pkg(
+            "set-publisher --no-refresh -k {0} test2".format(key_path), exit=2
+        )
+
+        # Listing publishers should succeed even if key file is gone.
+        # This test relies on using the same implementation used in
+        # image.py __store_publisher_ssl() which sets the paths to the
+        # SSL keys/certs.
+        img_key_path = os.path.join(
+            self.img_path(),
+            "var",
+            "pkg",
+            "ssl",
+            pkg.misc.get_data_digest(key_path, hash_func=hashlib.sha1)[0],
+        )
+        os.unlink(img_key_path)
+        self.pkg("publisher test1")
+
+        # This should fail since key has been removed even though test2
+        # has an https origin.
+        self.pkg(
+            "set-publisher --no-refresh -O https://{0}2 test2".format(
+                self.bogus_url
+            )
+        )
+        self.pkg(
+            "set-publisher --no-refresh -k {0} test2".format(img_key_path),
+            exit=1,
+        )
+
+        # Reset for next test.
+        self.pkg("set-publisher --no-refresh -k '' test1")
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}2 test2".format(
+                self.bogus_url
+            )
+        )
+
+        # Set cert for test1.
+        self.pkg("set-publisher --no-refresh -c {0} test1".format(cert_path))
+
+        # This should fail since test2 doesn't have any SSL origins or
+        # mirrors.
+        self.pkg(
+            "set-publisher --no-refresh -c {0} test2".format(cert_path), exit=2
+        )
+
+        # Listing publishers should be possible if cert file is gone.
+        img_cert_path = os.path.join(
+            self.img_path(),
+            "var",
+            "pkg",
+            "ssl",
+            pkg.misc.get_data_digest(cert_path, hash_func=hashlib.sha1)[0],
+        )
+        os.unlink(img_cert_path)
+        self.pkg("publisher test1", exit=3)
+
+        # This should fail since cert has been removed even though test2
+        # has an https origin.
+        self.pkg(
+            "set-publisher --no-refresh -O https://{0}2 test2".format(
+                self.bogus_url
+            )
+        )
+        self.pkg(
+            "set-publisher --no-refresh -c {0} test2".format(img_cert_path),
+            exit=1,
+        )
+
+        # Reset for next test.
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}2 test2".format(
+                self.bogus_url
+            )
+        )
+
+        # Expect partial failure since cert file is gone for test1.
+        self.pkg("publisher test1", exit=3)
+        self.pkg("publisher test3", exit=1)
+        self.pkg("publisher -H | grep URI", exit=1)
+
+        # Now verify that setting ssl_cert or ssl_key to "" works.
+        self.pkg('set-publisher --no-refresh -c "" test1')
+        self.pkg('publisher -H test1 | grep "SSL Cert: None"')
+
+        self.pkg('set-publisher --no-refresh -k "" test1')
+        self.pkg('publisher -H test1 | grep "SSL Key: None"')
+
+        self.pkg("set-publisher --set-property foo test1", exit=2)
+        self.pkg(
+            "set-publisher --set-property foo=bar --set-property "
+            "foo=baz test1",
+            exit=2,
+        )
+        self.pkg("set-publisher --add-property-value foo test1", exit=2)
+        self.pkg("set-publisher --remove-property-value foo test1", exit=2)
+        self.pkg(
+            "set-publisher --approve-ca-cert /shouldnotexist/foo " "test1",
+            exit=1,
+        )
+
+        key_fh, key_path = tempfile.mkstemp()
+        self.pkg(
+            "set-publisher --approve-ca-cert {0} test1".format(key_path),
+            exit=1,
+            su_wrap=True,
+        )
+        os.unlink(key_path)
+
+        self.pkg(
+            "set-publisher --no-refresh --set-property "
+            "signature-policy=ignore test1"
+        )
+        self.pkg("publisher test1")
+        self.assertTrue("signature-policy = ignore" in self.output)
+        self.pkg("set-publisher --no-refresh --set-property foo=bar " "test1")
+        self.pkg("publisher test1")
+        self.assertTrue("foo = bar" in self.output)
+        self.pkg(
+            "set-publisher --no-refresh  --remove-property-value "
+            "foo=baz test1",
+            exit=1,
+        )
+        self.pkg("publisher test1")
+        self.assertTrue("foo = bar" in self.output)
+        self.pkg(
+            "set-publisher --no-refresh  --set-property "
+            "signature-policy=require-names test1",
+            exit=1,
+        )
+        self.pkg(
+            "set-publisher --no-refresh --remove-property-value "
+            "bar=baz test1",
+            exit=1,
+        )
+
+        self.pkg("publisher")
+        self.pkg("set-publisher --no-refresh --search-after foo test1", exit=1)
+        self.pkg("set-publisher --no-refresh --search-before foo test1", exit=1)
+
+    def test_publisher_validation(self):
+        """Verify that we catch poorly formed auth prefixes and URL"""
+
+        self.image_create(self.rurl, prefix="test")
+
+        self.pkg(
+            "set-publisher -O http://{0}1 test1".format(self.bogus_url), exit=1
+        )
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}1 test1".format(
+                self.bogus_url
+            )
+        )
+
+        self.pkg(
+            ("set-publisher -O http://{0}2 ".format(self.bogus_url)) + "$%^8",
+            exit=1,
+        )
+        self.pkg(
+            ("set-publisher -O http://{0}2 ".format(self.bogus_url)) + "8^$%",
+            exit=1,
+        )
+        self.pkg("set-publisher -O http://*^5$% test2", exit=1)
+        self.pkg(
+            "set-publisher -O http://{0}1:abcde test2".format(self.bogus_url),
+            exit=1,
+        )
+        self.pkg(
+            "set-publisher -O ftp://{0}2 test2".format(self.bogus_url), exit=1
+        )
+
+        # Verify single character in hostname is valid publisher
+        self.pkg("set-publisher --no-refresh -g http://a/ a")
+        self.pkg(
+            "set-publisher --no-refresh -g http://a.example.com "
+            "a.example.com"
+        )
+
+    def test_missing_perms(self):
+        """Verify graceful failure if certificates are unreadable by
+        unprivileged users."""
+
+        self.image_create(self.rurl, prefix="test")
+
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}1 test1".format(
+                self.bogus_url
+            ),
+            su_wrap=True,
+            exit=1,
+        )
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}1 foo".format(
+                self.bogus_url
+            )
+        )
+        self.pkg("publisher | grep foo")
+        self.pkg(
+            "set-publisher -P --no-refresh -O http://{0}2 test2".format(
+                self.bogus_url
+            ),
+            su_wrap=True,
+            exit=1,
+        )
+        self.pkg("unset-publisher foo", su_wrap=True, exit=1)
+        self.pkg("unset-publisher foo")
+
+        self.pkg(
+            "set-publisher -m http://{0}1 test".format(self.bogus_url),
+            su_wrap=True,
+            exit=1,
+        )
+        self.pkg("set-publisher -m http://{0}2 test".format(self.bogus_url))
+
+        self.pkg(
+            "set-publisher -M http://{0}2 test".format(self.bogus_url),
+            su_wrap=True,
+            exit=1,
+        )
+        self.pkg("set-publisher -M http://{0}2 test".format(self.bogus_url))
+
+        # Now change the first publisher to a https URL so that
+        # certificate failure cases can be tested.
+        key_path = os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem")
+        cert_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
+
+        self.pkg(
+            "set-publisher --no-refresh -O https://{0}1 test1".format(
+                self.bogus_url
+            )
+        )
+        self.pkg("set-publisher --no-refresh -c {0} test1".format(cert_path))
+        self.pkg("set-publisher --no-refresh -k {0} test1".format(key_path))
+
+        # This test relies on using the same implementation used in
+        # image.py __store_publisher_ssl() which sets the paths to the
+        # SSL keys/certs.
+        img_key_path = os.path.join(
+            self.img_path(),
+            "var",
+            "pkg",
+            "ssl",
+            pkg.misc.get_data_digest(key_path, hash_func=hashlib.sha1)[0],
+        )
+        img_cert_path = os.path.join(
+            self.img_path(),
+            "var",
+            "pkg",
+            "ssl",
+            pkg.misc.get_data_digest(cert_path, hash_func=hashlib.sha1)[0],
+        )
+
+        # Make the cert/key unreadable by unprivileged users.
+        os.chmod(img_key_path, 0000)
+        os.chmod(img_cert_path, 0000)
+
+        # Verify that an unreadable certificate results in a
+        # partial failure when displaying publisher information.
+        self.pkg("publisher test1", su_wrap=True, exit=3)
+
+        # Corrupt key/cert and verify invalid cert/key results in a
+        # partial failure when displaying publisher information.
+        open(img_key_path, "wb").close()
+        open(img_cert_path, "wb").close()
+        self.pkg("publisher test1", exit=3)
+
+    def test_publisher_tsv_format(self):
+        """Ensure tsv formatted output is correct."""
+
+        self.image_create(self.rurl)
+
+        self.pkg(
+            "set-publisher --no-refresh -O https://{0}1 test1".format(
+                self.bogus_url
+            )
+        )
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0}2 test2".format(
+                self.bogus_url
+            )
+        )
+
+        base_string = (
+            "test\ttrue\tfalse\ttrue\torigin\tonline\t"
+            "{0}/\t-\n"
+            "test1\ttrue\tfalse\ttrue\torigin\tonline\t"
+            "https://{1}1/\t-\n"
+            "test2\ttrue\tfalse\ttrue\torigin\tonline\t"
+            "http://{2}2/\t-\n".format(
+                self.rurl, self.bogus_url, self.bogus_url
+            )
+        )
+        # With headers
+        self.pkg("publisher -F tsv")
+        expected = (
+            "PUBLISHER\tSTICKY\tSYSPUB\tENABLED"
+            "\tTYPE\tSTATUS\tURI\tPROXY\n" + base_string
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # Without headers
+        self.pkg("publisher -HF tsv")
+        expected = base_string
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+    def test_old_publisher_ca_certs(self):
+        """Check that approving and revoking CA certs is reflected in
+        the output of pkg publisher and that setting the CA certs when
+        setting an existing publisher works correctly."""
+
+        cert_dir = os.path.join(
+            self.ro_data_root, "signing_certs", "produced", "chain_certs"
+        )
+
+        app1 = os.path.join(cert_dir, "ch1_ta1_cert.pem")
+        app2 = os.path.join(cert_dir, "ch1_ta3_cert.pem")
+        rev1 = os.path.join(cert_dir, "ch1_ta4_cert.pem")
+        rev2 = os.path.join(cert_dir, "ch1_ta5_cert.pem")
+        app1_h = self.calc_pem_hash(app1)
+        app2_h = self.calc_pem_hash(app2)
+        rev1_h = self.calc_pem_hash(rev1)
+        rev2_h = self.calc_pem_hash(rev2)
+        self.image_create(self.rurl)
+        self.pkg(
+            "set-publisher "
+            "--approve-ca-cert {0} "
+            "--approve-ca-cert {1} --revoke-ca-cert {2} "
+            "--revoke-ca-cert {3} test ".format(app1, app2, rev1_h, rev2_h)
+        )
+        self.pkg("publisher test")
+        r1 = "         Approved CAs: {0}"
+        r2 = "                     : {0}"
+        r3 = "          Revoked CAs: {0}"
+        ls = self.output.splitlines()
+        found_approved = False
+        found_revoked = False
+        for i in range(0, len(ls)):
+            if "Approved CAs" in ls[i]:
+                found_approved = True
+                if not (
+                    (
+                        r1.format(app1_h) == ls[i]
+                        and r2.format(app2_h) == ls[i + 1]
+                        or (r1.format(app2_h) == ls[i])
+                        and r2.format(app1_h) == ls[i + 1]
+                    )
+                ):
+                    raise RuntimeError(
+                        "Expected to see "
+                        "{0} and {1} as approved certs. "
+                        "Output was:\n{2}".format(app1_h, app2_h, self.output)
+                    )
+            elif "Revoked CAs" in ls[i]:
+                found_approved = True
+                if not (
+                    (
+                        r3.format(rev1_h) == ls[i]
+                        and r2.format(rev2_h) == ls[i + 1]
+                    )
+                    or (
+                        r3.format(rev2_h) == ls[i]
+                        and r2.format(rev1_h) == ls[i + 1]
+                    )
+                ):
+                    raise RuntimeError(
+                        "Expected to see "
+                        "{0} and {1} as revoked certs. "
+                        "Output was:\n{2}".format(rev1_h, rev2_h, self.output)
+                    )
+
+    def test_publisher_properties(self):
+        """Test that properties set on publishers are correctly
+        displayed in the output of pkg publisher <publisher name>."""
+
+        self.image_create(self.rurl)
+        self.pkg("publisher test")
+        self.assertTrue("Properties:" not in self.output)
+
+        self.pkg("set-publisher --set-property foo=bar test")
+        self.pkg("publisher test")
+        self.assertTrue("Properties:" in self.output)
+        self.assertTrue("foo = bar" in self.output)
+        self.pkg("set-publisher --add-property-value foo=bar1 test", exit=1)
+
+        self.pkg(
+            "set-publisher --set-property "
+            "signature-policy=require-names --add-property-value "
+            "signature-required-names=n1 test"
+        )
+        self.pkg("publisher test")
+        self.assertTrue("signature-policy = require-names" in self.output)
+        self.assertTrue("signature-required-names = n1" in self.output)
+
+        self.pkg(
+            "set-publisher --add-property-value "
+            "signature-required-names=n2 test"
+        )
+        self.pkg("publisher test")
+        self.assertTrue("signature-required-names = n1, n2" in self.output)
+
+    def test_bug_7141684(self):
+        """Test that pkg(1) client does not traceback if no publisher
+        configured and we try to get preferred publisher"""
+
+        self.image_create()
+        self.pkg("publisher -P", exit=0)
+
+        self.pkg("set-publisher -g {0} test".format(self.durl1))
+        self.pkg("install foo")
+        self.pkg("unset-publisher test")
+        self.pkg("publisher -P", exit=0)
+
+    def test_publisher_proxies(self):
+        """Tests that set-publisher can add and remove proxy values
+        per origin."""
+
+        self.image_create(self.rurl)
+        self.pkg("publisher test")
+        self.assertTrue("Proxy:" not in self.output)
+
+        # check origin and mirror addition/removal when proxies are used
+        for add, remove in [("-g", "-G"), ("-m", "-M")]:
+            self.image_create(self.rurl)
+            # we can't proxy file repositories
+            self.pkg(
+                "set-publisher --no-refresh {add} {url} "
+                "--proxy http://foo test".format(add=add, url=self.rurl),
+                exit=1,
+            )
+            self.pkg("publisher test")
+            self.assertTrue("Proxy:" not in self.output)
+
+            # we can set the proxy for http repos
+            self.pkg(
+                "set-publisher --no-refresh {add} {url} "
+                "--proxy http://foo test".format(add=add, url=self.durl)
+            )
+
+            self.pkg("publisher test")
+            self.assertTrue("Proxy: http://foo" in self.output)
+
+            # remove the file-based repository and ensure we still
+            # have a proxied http-based publisher
+            self.pkg("set-publisher --no-refresh -G {0} test".format(self.rurl))
+            self.pkg("publisher -F tsv")
+            self.assertTrue("{0}/\thttp://foo".format(self.durl in self.output))
+            self.assertTrue(self.rurl not in self.output)
+
+            # ensure we can't add duplicate proxied or unproxied
+            # repositories
+            self.pkg(
+                "set-publisher --no-refresh {add} {url} "
+                "--proxy http://foo test".format(add=add, url=self.durl),
+                exit=1,
+            )
+            self.pkg(
+                "set-publisher --no-refresh {add} {url} "
+                "test".format(add=add, url=self.durl),
+                exit=1,
+            )
+
+            # we should have 1 proxied occurrence of our http url
+            self.pkg("publisher -F tsv")
+            self.assertTrue("{0}/\thttp://foo".format(self.durl in self.output))
+            self.assertTrue("\t\t{0}".format(self.durl not in self.output))
+
+            # when removing a proxied url, then adding the same url
+            # unproxied, the proxy configuration does get removed
+            self.pkg(
+                "set-publisher --no-refresh {remove} {url}"
+                " test".format(remove=remove, url=self.durl),
+                exit=0,
+            )
+            self.pkg(
+                "set-publisher --no-refresh {add} {url} "
+                "test".format(add=add, url=self.durl),
+                exit=0,
+            )
+            self.pkg("publisher -F tsv")
+            self.assertTrue(
+                "{0}/\thttp://foo".format(self.durl not in self.output)
+            )
+            self.pkg(
+                "set-publisher --no-refresh {remove} "
+                "{url} test".format(remove=remove, url=self.durl)
+            )
+
+            # when we add multiple urls, and they all get the same
+            # proxy value, leaving an existing non-proxied url
+            # as non-proxied.
+            self.pkg(
+                "set-publisher --no-refresh {add} http://a "
+                "test".format(add=add)
+            )
+            self.pkg(
+                "set-publisher --no-refresh {add} http://b "
+                "{add} http://c --proxy http://foo test".format(add=add)
+            )
+            self.pkg("publisher -F tsv")
+            self.assertTrue("http://a/\t-" in self.output)
+            self.assertTrue("http://b/\thttp://foo" in self.output)
+            self.assertTrue("http://c/\thttp://foo" in self.output)
+
+    def test_publisher_special_repo_name(self):
+        """Tests that set-publisher can use the repository name with
+        special characters."""
+
+        self.image_create()
+
+        # "%" is a special character in SafeConfigParser, but needs
+        # to be supported anyway.
+        repo_dir = os.path.join(self.test_root, "repotest{0}ymbol")
+        self.create_repo(
+            repo_dir, properties={"publisher": {"prefix": "test1"}}
+        )
+        self.pkg("set-publisher -p {0} test1".format(repo_dir))
+        shutil.rmtree(repo_dir)
+
+        # "+" will be converted into "%2B" by URL quoting routines.
+        # "%" is a special character in SafeConfigParser, but we need
+        # to support it here.
+        repo_dir = os.path.join(self.test_root, "repotest+symbol")
+        self.create_repo(
+            repo_dir, properties={"publisher": {"prefix": "test2"}}
+        )
+        self.pkg("set-publisher -g {0} test2".format(repo_dir))
+        shutil.rmtree(repo_dir)
+
+        # "%()" is the syntax of expansion language in SafeConfigParser
+        # but needs to be raw characters here.
+        repo_dir = os.path.join(self.test_root, "{junkrepo}")
+        self.create_repo(
+            repo_dir, properties={"publisher": {"prefix": "test3"}}
+        )
+        self.pkg("set-publisher -g {0} test3".format(repo_dir))
+        shutil.rmtree(repo_dir)
+
+    def test_remove_unused_cert_key(self):
+        """Ensure that unused client certificate files are removed."""
+
+        self.image_create(self.rurl)
+
+        # Set the first publisher to a https URL
+        key_path = os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem")
+        cert_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
+
+        img_key_path = os.path.join(
+            self.img_path(),
+            "var",
+            "pkg",
+            "ssl",
+            pkg.misc.get_data_digest(key_path, hash_func=hashlib.sha1)[0],
+        )
+        img_cert_path = os.path.join(
+            self.img_path(),
+            "var",
+            "pkg",
+            "ssl",
+            pkg.misc.get_data_digest(cert_path, hash_func=hashlib.sha1)[0],
+        )
+
+        self.pkg(
+            "set-publisher --no-refresh -O https://{0} -c {1} \
+                    -k {2} test1".format(
+                self.bogus_url, cert_path, key_path
+            )
+        )
+
+        # cert and key should exist
+        self.assertTrue(os.path.exists(img_key_path))
+        self.assertTrue(os.path.exists(img_cert_path))
+
+        # Now change test1 to http URL to check whether
+        # certificate and key are removed
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0} \
+                    test1".format(
+                self.bogus_url
+            )
+        )
+
+        # cert and key should not exist.
+        self.assertTrue(not os.path.exists(img_key_path))
+        self.assertTrue(not os.path.exists(img_cert_path))
+
+        # Now test if cert and key is still in use
+        # we should not remove them
+        self.pkg(
+            "set-publisher --no-refresh -O https://{0} -c {1} \
+                    -k {2} test1".format(
+                self.bogus_url, cert_path, key_path
+            )
+        )
+
+        self.pkg(
+            "set-publisher --no-refresh -O https://{0} -c {1} \
+                    -k {2} foo".format(
+                self.bogus_url, cert_path, key_path
+            )
+        )
+
+        # cert and key should exist
+        self.assertTrue(os.path.exists(img_key_path))
+        self.assertTrue(os.path.exists(img_cert_path))
+
+        # Remove ssl for test1
+        self.pkg(
+            "set-publisher --no-refresh -O http://{0} \
+                    foo".format(
+                self.bogus_url
+            )
+        )
+
+        # cert and key should still exist.
+        self.assertTrue(os.path.exists(img_key_path))
+        self.assertTrue(os.path.exists(img_cert_path))
+
+        # Test unset-publisher
+        self.pkg(
+            "set-publisher --no-refresh -O https://{0} -c {1} \
+                    -k {2} foo".format(
+                self.bogus_url, cert_path, key_path
+            )
+        )
+
+        # cert and key should exist.
+        self.assertTrue(os.path.exists(img_key_path))
+        self.assertTrue(os.path.exists(img_cert_path))
+
+        self.pkg("unset-publisher foo")
+        # cert and key should still exist.
+        self.assertTrue(os.path.exists(img_key_path))
+        self.assertTrue(os.path.exists(img_cert_path))
+
+        self.pkg("unset-publisher test1")
+        # cert and key should not exist.
+        self.assertTrue(not os.path.exists(img_key_path))
+        self.assertTrue(not os.path.exists(img_cert_path))
 
 
 class TestPkgPublisherMany(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        foo1 = """
+    foo1 = """
             open foo@1,5.11-0
             close """
 
-        bar1 = """
+    bar1 = """
             open bar@1,5.11-0
             close """
 
-        baz1 = """
+    baz1 = """
             open baz@1,5.11-0
             close """
 
-        origin_1 = """
+    origin_1 = """
             open origin1@1,5.11-0
             add file tmp/cat mode=0444 owner=root group=bin path=etc/cat
             close """
 
-        origin_2 = """
+    origin_2 = """
             open origin2@1,5.11-0
             close """
 
-        test3_pub_cfg = {
+    test3_pub_cfg = {
+        "publisher": {
+            "alias": "t3",
+            "prefix": "test3",
+        },
+        "repository": {
+            "collection_type": "supplemental",
+            "description": "This repository serves packages for test3.",
+            "legal_uris": [
+                "http://www.opensolaris.org/os/copyrights",
+                "http://www.opensolaris.org/os/tou",
+                "http://www.opensolaris.org/os/trademark",
+            ],
+            "name": "The Test3 Repository",
+            "refresh_seconds": 86400,
+            "registration_uri": "",
+            "related_uris": [
+                "http://pkg.opensolaris.org/contrib",
+                "http://jucr.opensolaris.org/pending",
+                "http://jucr.opensolaris.org/contrib",
+            ],
+        },
+    }
+
+    misc_files = ["tmp/cat"]
+
+    def setUp(self):
+        # This test suite needs actual depots.
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self,
+            [
+                "test1",
+                "test2",
+                "test3",
+                "test1",
+                "test1",
+                "test3",
+                "test4",
+                "test5",
+                "test4",
+            ],
+            start_depots=True,
+        )
+        self.make_misc_files(self.misc_files)
+
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.pkgsend_bulk(self.durl1, self.foo1)
+
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.pkgsend_bulk(self.durl2, self.bar1)
+
+        self.durl3 = self.dcs[3].get_depot_url()
+        self.pkgsend_bulk(self.durl3, self.baz1)
+
+        self.image_create(self.durl1, prefix="test1")
+        self.pkg("set-publisher -O " + self.durl2 + " test2")
+        self.pkg("set-publisher -O " + self.durl3 + " test3")
+
+    def __test_mirror_origin(self, etype, add_opt, remove_opt):
+        durl1 = self.dcs[1].get_depot_url()
+        durl4 = self.dcs[4].get_depot_url()
+        durl5 = self.dcs[5].get_depot_url()
+
+        # Test single add; --no-refresh must be used here since the URI
+        # being added is for a non-existent repository.
+        self.pkg(
+            "set-publisher --no-refresh {0} http://{1}1 test1".format(
+                add_opt, self.bogus_url
+            )
+        )
+        self.pkg(
+            "set-publisher --no-refresh {0} http://{1}2 test1".format(
+                add_opt, self.bogus_url
+            )
+        )
+        self.pkg(
+            "set-publisher --no-refresh {0} http://{1}5".format(
+                add_opt, self.bogus_url
+            ),
+            exit=2,
+        )
+        self.pkg("set-publisher {0} test1".format(add_opt), exit=2)
+        self.pkg(
+            "set-publisher --no-refresh {0} http://{1}1 test1".format(
+                add_opt, self.bogus_url
+            ),
+            exit=1,
+        )
+        self.pkg(
+            "set-publisher {0} http://{1}5 test11".format(
+                add_opt, self.bogus_url
+            ),
+            exit=1,
+        )
+        if etype == "origin":
+            self.pkg(
+                "set-publisher {0} {1}7 test1".format(add_opt, self.bogus_url),
+                exit=1,
+            )
+
+        # Test single remove.
+        self.pkg(
+            "set-publisher --no-refresh {0} http://{1}1 test1".format(
+                remove_opt, self.bogus_url
+            )
+        )
+        self.pkg(
+            "set-publisher --no-refresh {0} http://{1}2 test1".format(
+                remove_opt, self.bogus_url
+            )
+        )
+        # URIs to remove not specified using options, so they are seen
+        # as publisher names -- only one publisher name may be
+        # specified at a time.
+        self.pkg(
+            "set-publisher {0} test11 http://{1}2 http://{2}4".format(
+                remove_opt, self.bogus_url, self.bogus_url
+            ),
+            exit=2,
+        )
+        self.pkg(
+            "set-publisher {0} http://{1}5".format(remove_opt, self.bogus_url),
+            exit=2,
+        )
+        # publisher name specified to remove as URI.
+        self.pkg("set-publisher {0} test1".format(remove_opt), exit=2)
+        # URI already removed or never existed.
+        self.pkg(
+            "set-publisher {0} http://{1}5 test11".format(
+                remove_opt, self.bogus_url
+            ),
+            exit=1,
+        )
+        self.pkg(
+            "set-publisher {0} http://{1}6 test1".format(
+                remove_opt, self.bogus_url
+            ),
+            exit=1,
+        )
+        self.pkg(
+            "set-publisher {0} {1}7 test1".format(remove_opt, self.bogus_url),
+            exit=1,
+        )
+
+        # Test a combined add and remove.
+        self.pkg("set-publisher {0} {1} test1".format(add_opt, durl4))
+        self.pkg(
+            "set-publisher {0} {1} {2} {3} test1".format(
+                add_opt, durl5, remove_opt, durl4
+            )
+        )
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl5))
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl4), exit=1)
+        self.pkg("set-publisher {0} {1} test1".format(remove_opt, durl5))
+        self.pkg(
+            "set-publisher {0} {1} {2} {3} {4} \\* test1".format(
+                add_opt, durl4, add_opt, durl5, remove_opt
+            )
+        )
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl4))
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl5))
+        self.pkg("set-publisher {0} \\* test1".format(remove_opt))
+        if etype == "origin":
+            self.pkg("set-publisher {0} {1} test1".format(add_opt, durl1))
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl4), exit=1)
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl5), exit=1)
+
+        # Verify that if one of multiple URLs is not a valid URL, pkg
+        # will exit with an error, and does not add the valid one.
+        self.pkg(
+            "set-publisher {0} {1} {2} http://b^^^/ogus test1".format(
+                add_opt, durl4, add_opt
+            ),
+            exit=1,
+        )
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl4), exit=1)
+
+        # Verify that multiple can be added at one time.
+        self.pkg(
+            "set-publisher {0} {1} {2} {3} test1".format(
+                add_opt, durl4, add_opt, durl5
+            )
+        )
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl4))
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl5))
+
+        # Verify that multiple can be removed at one time.
+        self.pkg(
+            "set-publisher {0} {1} {2} {3} test1".format(
+                remove_opt, durl4, remove_opt, durl5
+            )
+        )
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl4), exit=1)
+        self.pkg("publisher | grep {0}.*{1}".format(etype, durl5), exit=1)
+
+    def __verify_pub_cfg(self, prefix, pub_cfg):
+        """Private helper method to verify publisher configuration."""
+
+        # pretend like the Image object is being allocated from
+        # a pkg command run from within the target image.
+        cmdpath = os.path.join(self.get_img_path(), "pkg")
+
+        img = image.Image(
+            self.get_img_path(),
+            should_exist=True,
+            user_provided_dir=True,
+            cmdpath=cmdpath,
+        )
+        pub = img.get_publisher(prefix=prefix)
+        for section in pub_cfg:
+            for prop, val in six.iteritems(pub_cfg[section]):
+                if section == "publisher":
+                    pub_val = getattr(pub, prop)
+                else:
+                    pub_val = getattr(pub.repository, prop)
+
+                if prop in ("legal_uris", "mirrors", "origins", "related_uris"):
+                    # The publisher will have these as lists,
+                    # so transform both sets of data first
+                    # for reliable comparison.  Remove any
+                    # trailing slashes so comparison can
+                    # succeed.
+                    if not val:
+                        val = set()
+                    else:
+                        val = set(val)
+                    new_pub_val = set()
+                    for u in pub_val:
+                        uri = u.uri
+                        if uri.endswith("/"):
+                            uri = uri[:-1]
+                        new_pub_val.add(uri)
+                    pub_val = new_pub_val
+                self.assertEqual(val, pub_val)
+
+    def __update_repo_pub_cfg(self, dc, pubcfg):
+        """Private helper method to update a repository's publisher
+        configuration based on the provided dictionary structure."""
+
+        rpath = dc.get_repodir()
+        props = ""
+        for sname in pubcfg:
+            for pname, pval in six.iteritems(pubcfg[sname]):
+                if sname == "publisher" and pname == "prefix":
+                    continue
+                pname = pname.replace("_", "-")
+                if isinstance(pval, list):
+                    props += "{0}/{1}='({2})' ".format(
+                        sname, pname, " ".join(pval)
+                    )
+                else:
+                    props += "{0}/{1}='{2}' ".format(sname, pname, pval)
+
+        pfx = pubcfg["publisher"]["prefix"]
+        self.pkgrepo("set -s {0} -p {1} {2}".format(rpath, pfx, props))
+        self.pkgrepo("get -p all -s {0}".format(rpath))
+
+    def test_set_auto(self):
+        """Verify that set-publisher -p works as expected."""
+
+        # Test the single add/update case first.
+        durl1 = self.dcs[1].get_depot_url()
+        durl3 = self.dcs[3].get_depot_url()
+        durl4 = self.dcs[4].get_depot_url()
+        self.image_create(durl1, prefix="test1")
+
+        # Should fail because test3 publisher does not exist.
+        self.pkg("publisher test3", exit=1)
+
+        # Should fail because repository is for test3 not test2.
+        self.pkg("set-publisher -p {0} test2".format(durl3), exit=1)
+
+        # Verify that a publisher can be configured even if the
+        # the repository's publisher configuration does not
+        # include origin information.  In this case, the client
+        # will assume that the provided repository URI for
+        # auto-configuration is also the origin to use for
+        # all configured publishers.
+        t3cfg = {
             "publisher": {
-                "alias": "t3",
                 "prefix": "test3",
             },
             "repository": {
-                "collection_type": "supplemental",
-                "description": "This repository serves packages for test3.",
-                "legal_uris": [
-                    "http://www.opensolaris.org/os/copyrights",
-                    "http://www.opensolaris.org/os/tou",
-                    "http://www.opensolaris.org/os/trademark"
-                ],
-                "name": "The Test3 Repository",
-                "refresh_seconds": 86400,
-                "registration_uri": "",
-                "related_uris": [
-                    "http://pkg.opensolaris.org/contrib",
-                    "http://jucr.opensolaris.org/pending",
-                    "http://jucr.opensolaris.org/contrib"
-                ],
+                "origins": [durl3],
             },
         }
-
-        misc_files = [ "tmp/cat" ]
-
-        def setUp(self):
-                # This test suite needs actual depots.
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test3",  "test1", "test1", "test3", "test4", "test5",
-                    "test4"], start_depots=True)
-                self.make_misc_files(self.misc_files)
-
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.pkgsend_bulk(self.durl1, self.foo1)
-
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.pkgsend_bulk(self.durl2, self.bar1)
-
-                self.durl3 = self.dcs[3].get_depot_url()
-                self.pkgsend_bulk(self.durl3, self.baz1)
-
-                self.image_create(self.durl1, prefix="test1")
-                self.pkg("set-publisher -O " + self.durl2 + " test2")
-                self.pkg("set-publisher -O " + self.durl3 + " test3")
-
-        def __test_mirror_origin(self, etype, add_opt, remove_opt):
-                durl1 = self.dcs[1].get_depot_url()
-                durl4 = self.dcs[4].get_depot_url()
-                durl5 = self.dcs[5].get_depot_url()
-
-                # Test single add; --no-refresh must be used here since the URI
-                # being added is for a non-existent repository.
-                self.pkg("set-publisher --no-refresh {0} http://{1}1 test1".format(
-                    add_opt, self.bogus_url))
-                self.pkg("set-publisher --no-refresh {0} http://{1}2 test1".format(
-                    add_opt, self.bogus_url))
-                self.pkg("set-publisher --no-refresh {0} http://{1}5".format(add_opt,
-                    self.bogus_url), exit=2)
-                self.pkg("set-publisher {0} test1".format(add_opt), exit=2)
-                self.pkg("set-publisher --no-refresh {0} http://{1}1 test1".format(
-                    add_opt, self.bogus_url), exit=1)
-                self.pkg("set-publisher {0} http://{1}5 test11".format(add_opt,
-                    self.bogus_url), exit=1)
-                if etype == "origin":
-                        self.pkg("set-publisher {0} {1}7 test1".format(
-                            add_opt, self.bogus_url), exit=1)
-
-                # Test single remove.
-                self.pkg("set-publisher --no-refresh {0} http://{1}1 test1".format(
-                    remove_opt, self.bogus_url))
-                self.pkg("set-publisher --no-refresh {0} http://{1}2 test1".format(
-                    remove_opt, self.bogus_url))
-                # URIs to remove not specified using options, so they are seen
-                # as publisher names -- only one publisher name may be
-                # specified at a time.
-                self.pkg("set-publisher {0} test11 http://{1}2 http://{2}4".format(
-                    remove_opt, self.bogus_url, self.bogus_url), exit=2)
-                self.pkg("set-publisher {0} http://{1}5".format(remove_opt,
-                    self.bogus_url), exit=2)
-                # publisher name specified to remove as URI.
-                self.pkg("set-publisher {0} test1".format(remove_opt), exit=2)
-                # URI already removed or never existed.
-                self.pkg("set-publisher {0} http://{1}5 test11".format(remove_opt,
-                    self.bogus_url), exit=1)
-                self.pkg("set-publisher {0} http://{1}6 test1".format(remove_opt,
-                    self.bogus_url), exit=1)
-                self.pkg("set-publisher {0} {1}7 test1".format(remove_opt,
-                    self.bogus_url), exit=1)
-
-                # Test a combined add and remove.
-                self.pkg("set-publisher {0} {1} test1".format(add_opt, durl4))
-                self.pkg("set-publisher {0} {1} {2} {3} test1".format(add_opt, durl5,
-                    remove_opt, durl4))
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl5))
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl4), exit=1)
-                self.pkg("set-publisher {0} {1} test1".format(remove_opt, durl5))
-                self.pkg("set-publisher {0} {1} {2} {3} {4} \\* test1".format(add_opt,
-                    durl4, add_opt, durl5, remove_opt))
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl4))
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl5))
-                self.pkg("set-publisher {0} \\* test1".format(remove_opt))
-                if etype == "origin":
-                        self.pkg("set-publisher {0} {1} test1".format(add_opt, durl1))
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl4), exit=1)
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl5), exit=1)
-
-                # Verify that if one of multiple URLs is not a valid URL, pkg
-                # will exit with an error, and does not add the valid one.
-                self.pkg("set-publisher {0} {1} {2} http://b^^^/ogus test1".format(
-                    add_opt, durl4, add_opt), exit=1)
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl4), exit=1)
-
-                # Verify that multiple can be added at one time.
-                self.pkg("set-publisher {0} {1} {2} {3} test1".format(add_opt, durl4,
-                    add_opt, durl5))
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl4))
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl5))
-
-                # Verify that multiple can be removed at one time.
-                self.pkg("set-publisher {0} {1} {2} {3} test1".format(remove_opt, durl4,
-                    remove_opt, durl5))
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl4), exit=1)
-                self.pkg("publisher | grep {0}.*{1}".format(etype, durl5), exit=1)
-
-        def __verify_pub_cfg(self, prefix, pub_cfg):
-                """Private helper method to verify publisher configuration."""
-
-                # pretend like the Image object is being allocated from
-                # a pkg command run from within the target image.
-                cmdpath = os.path.join(self.get_img_path(), "pkg")
-
-                img = image.Image(self.get_img_path(), should_exist=True,
-                    user_provided_dir=True, cmdpath=cmdpath)
-                pub = img.get_publisher(prefix=prefix)
-                for section in pub_cfg:
-                        for prop, val in six.iteritems(pub_cfg[section]):
-                                if section == "publisher":
-                                        pub_val = getattr(pub, prop)
-                                else:
-                                        pub_val = getattr(
-                                            pub.repository, prop)
-
-                                if prop in ("legal_uris", "mirrors", "origins",
-                                    "related_uris"):
-                                        # The publisher will have these as lists,
-                                        # so transform both sets of data first
-                                        # for reliable comparison.  Remove any
-                                        # trailing slashes so comparison can
-                                        # succeed.
-                                        if not val:
-                                                val = set()
-                                        else:
-                                                val = set(val)
-                                        new_pub_val = set()
-                                        for u in pub_val:
-                                                uri = u.uri
-                                                if uri.endswith("/"):
-                                                        uri = uri[:-1]
-                                                new_pub_val.add(uri)
-                                        pub_val = new_pub_val
-                                self.assertEqual(val, pub_val)
-
-        def __update_repo_pub_cfg(self, dc, pubcfg):
-                """Private helper method to update a repository's publisher
-                configuration based on the provided dictionary structure."""
-
-                rpath = dc.get_repodir()
-                props = ""
-                for sname in pubcfg:
-                        for pname, pval in six.iteritems(pubcfg[sname]):
-                                if sname == "publisher" and pname == "prefix":
-                                        continue
-                                pname = pname.replace("_", "-")
-                                if isinstance(pval, list):
-                                        props += "{0}/{1}='({2})' ".format(
-                                            sname, pname, " ".join(pval))
-                                else:
-                                        props += "{0}/{1}='{2}' ".format(
-                                            sname, pname, pval)
-
-                pfx = pubcfg["publisher"]["prefix"]
-                self.pkgrepo("set -s {0} -p {1} {2}".format(rpath, pfx, props))
-                self.pkgrepo("get -p all -s {0}".format(rpath))
-
-        def test_set_auto(self):
-                """Verify that set-publisher -p works as expected."""
-
-                # Test the single add/update case first.
-                durl1 = self.dcs[1].get_depot_url()
-                durl3 = self.dcs[3].get_depot_url()
-                durl4 = self.dcs[4].get_depot_url()
-                self.image_create(durl1, prefix="test1")
-
-                # Should fail because test3 publisher does not exist.
-                self.pkg("publisher test3", exit=1)
-
-                # Should fail because repository is for test3 not test2.
-                self.pkg("set-publisher -p {0} test2".format(durl3), exit=1)
-
-                # Verify that a publisher can be configured even if the
-                # the repository's publisher configuration does not
-                # include origin information.  In this case, the client
-                # will assume that the provided repository URI for
-                # auto-configuration is also the origin to use for
-                # all configured publishers.
-                t3cfg = {
-                    "publisher": {
-                        "prefix": "test3",
-                    },
-                    "repository": {
-                        "origins": [durl3],
-                    },
-                }
-                self.pkg("set-publisher -p {0}".format(durl3))
-
-                # Load image configuration to verify publisher was configured
-                # as expected.
-                self.__verify_pub_cfg("test3", t3cfg)
-
-                # Update configuration of just this depot with more information
-                # for comparison basis.
-                self.dcs[3].stop()
-
-                # Origin and mirror info wasn't known until this point, so add
-                # it to the test configuration.
-                t3cfg = self.test3_pub_cfg.copy()
-                t3cfg["repository"]["origins"] = [durl3]
-                t3cfg["repository"]["mirrors"] = [durl1, durl3, durl4]
-                self.__update_repo_pub_cfg(self.dcs[3], t3cfg)
-                self.dcs[3].start()
-
-                # Should succeed and configure test3 publisher.
-                self.pkg("set-publisher -p {0}".format(durl3))
-
-                # Load image configuration to verify publisher was configured
-                # as expected.
-                self.__verify_pub_cfg("test3", t3cfg)
-
-                # Now test the update case.  This verifies that the existing,
-                # configured origins and mirrors will not be lost (only added
-                # to) and that new data will be accepted.
-                durl6 = self.dcs[6].get_depot_url()
-                self.dcs[6].stop()
-                t6cfg = {}
-                for section in t3cfg:
-                        t6cfg[section] = {}
-                        for prop in t3cfg[section]:
-                                val = t3cfg[section][prop]
-                                if prop == "refresh_seconds":
-                                        val = 1800
-                                elif prop == "collection_type":
-                                        val = "core"
-                                elif prop not in ("alias", "prefix"):
-                                        # Clear all other props.
-                                        val = ""
-                                t6cfg[section][prop] = val
-                t6cfg["repository"]["origins"] = [durl3, durl6]
-                t6cfg["repository"]["mirrors"] = [durl1, durl3, durl4, durl6]
-                self.__update_repo_pub_cfg(self.dcs[6], t6cfg)
-                self.dcs[6].start()
-
-                self.pkg("set-publisher -p {0}".format(durl6))
-
-                # Load image configuration to verify publisher was configured
-                # as expected.
-                self.__verify_pub_cfg("test3", t6cfg)
-
-                # Test multi-publisher add case.
-                self.pkgrepo("set -s {0} -p test2 publisher/alias=''".format(
-                    self.dcs[6].get_repodir()))
-                self.pkg("unset-publisher test3")
-                self.dcs[6].refresh()
-                self.pkg("set-publisher -P -p {0}".format(durl6))
-
-                # Determine publisher order from output and then verify it
-                # matches expected.
-                def get_pubs():
-                        self.pkg("publisher -HF tsv")
-                        pubs = []
-                        for l in self.output.splitlines():
-                                pub, ignored = l.split("\t", 1)
-                                if pub not in pubs:
-                                        pubs.append(pub)
-                        return pubs
-
-                # Since -P was used, new publishers should be set first in
-                # search order alphabetically.
-                self.assertEqual(get_pubs(), ["test2", "test3", "test1"])
-
-                # Now change search order and verify that using -P and -p again
-                # won't change it since publishers already exist.
-                self.pkg("set-publisher --search-after=test1 test2")
-                self.pkg("set-publisher --search-after=test2 test3")
-                self.assertEqual(get_pubs(), ["test1", "test2", "test3"])
-                self.pkg("set-publisher -P -p {0}".format(durl6))
-                self.assertEqual(get_pubs(), ["test1", "test2", "test3"])
-
-                # Check that --proxy arguments are set on all auto-configured
-                # publishers.  We use $no_proxy='*' in the environment so that
-                # we can persist a dummy --proxy value to the image
-                # configuration, yet still reach the test depot to obtain the
-                # publisher/ response.
-                self.pkg("unset-publisher test3")
-                self.pkg("unset-publisher test2")
-                self.pkg("set-publisher -P --proxy http://myproxy -p {0}".format(
-                    durl6), env_arg={"no_proxy": "*"})
-                self.assertEqual(get_pubs(), ["test2", "test3", "test1"])
-
-                # Verify that only test2 and test3 have proxies set, since
-                # test1 already existed, it should not use a proxy. The proxy
-                # column is the last one printed on each line.
-                self.pkg("publisher -HF tsv")
-                for l in self.output.splitlines():
-                        if l.startswith("test2") or l.startswith("test3"):
-                                self.assertEqual("http://myproxy",
-                                    l.split()[-1])
-                        else:
-                                self.assertEqual("-", l.split()[-1])
-
-        def test_set_mirrors_origins(self):
-                """Test set-publisher functionality for mirrors and origins."""
-
-                durl1 = self.dcs[1].get_depot_url()
-                rurl1 = self.dcs[1].get_repo_url()
-                self.image_create(durl1, prefix="test1")
-
-                # Verify that https origins can be mixed with other types
-                # of origins.
-                self.pkg("set-publisher -g {0} test1".format(rurl1))
-                self.pkg("set-publisher --no-refresh -g https://test.invalid1 "
-                    "test1")
-
-                # Verify that a cert and key can be set even when non-https
-                # origins are present.
-                key_path = os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem")
-                cert_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
-
-                self.pkg("set-publisher --no-refresh -k {0} -c {1} test1".format(
-                    key_path, cert_path))
-                self.pkg("publisher test1", exit=[0, 3])
-
-                # An expiring certificate will cause the pkg client to error
-                # with EXIT_OOPS. If it is a certificate expiring issue give
-                # an indication on how to fix it.
-                self.assertFalse("will expire in" in self.errout,
-                    "\nWARNING: Test certificates are about to expire. "
-                    "Please run:\n"
-                    "$ cd src/tests/ro_data/signing_certs/\n"
-                    "$ ./generate_certs.py \n"
-                    "to regenerate the certificates.")
-
-                # For any other text in the errout fail the test
-                self.assertTrue(self.errout is not None)
-
-                # This test relies on using the same implementation used in
-                # image.py __store_publisher_ssl() which sets the paths to the
-                # SSL keys/certs.
-                img_key_path = os.path.join(self.img_path(), "var", "pkg",
-                    "ssl", pkg.misc.get_data_digest(key_path,
-                    hash_func=hashlib.sha1)[0])
-                img_cert_path = os.path.join(self.img_path(), "var", "pkg",
-                    "ssl", pkg.misc.get_data_digest(cert_path,
-                    hash_func=hashlib.sha1)[0])
-                self.assertTrue(img_key_path in self.output)
-                self.assertTrue(img_cert_path in self.output)
-
-                # Verify that removing all SSL origins does not leave key
-                # and cert information intact.
-                self.pkg("set-publisher -G '*' -g {0} test1".format(durl1))
-                self.pkg("publisher test1")
-                self.assertTrue(img_key_path not in self.output)
-                self.assertTrue(img_cert_path not in self.output)
-
-                # Verify that https mirrors can be mixed with other types of
-                # origins.
-                self.pkg("set-publisher -m {0} test1".format(rurl1))
-                self.pkg("set-publisher --no-refresh -m https://test.invalid1 "
-                    "test1")
-                self.pkg("set-publisher --no-refresh -k {0} -c {1} test1".format(
-                    key_path, cert_path))
-
-                # Verify that removing all SSL mirrors does not leave key
-                # and cert information intact.
-                self.pkg("set-publisher -M '*' -m {0} test1".format(durl1))
-                self.pkg("publisher test1")
-                self.assertTrue(img_key_path not in self.output)
-                self.assertTrue(img_cert_path not in self.output)
-
-                # Test short options for mirrors.
-                self.__test_mirror_origin("mirror", "-m", "-M")
-
-                # Test long options for mirrors.
-                self.__test_mirror_origin("mirror", "--add-mirror",
-                    "--remove-mirror")
-
-                # Test short options for origins.
-                self.__test_mirror_origin("origin", "-g", "-G")
-
-                # Test long options for origins.
-                self.__test_mirror_origin("origin", "--add-origin",
-                    "--remove-origin")
-
-                # Verify that if multiple origins are present that -O will
-                # discard all others.
-                durl4 = self.dcs[4].get_depot_url()
-                durl5 = self.dcs[5].get_depot_url()
-                self.pkg("set-publisher -g {0} -g {1} test1".format(durl4, durl5))
-                self.pkg("set-publisher -O {0} test1".format(durl4))
-                self.pkg("publisher | grep origin.*{0}".format(durl1), exit=1)
-                self.pkg("publisher | grep origin.*{0}".format(durl5), exit=1)
-
-                # Verify that if a publisher is set to use a file repository
-                # that removing that repository will not prevent the pkg(1)
-                # command from operating or the set-publisher commands
-                # from working.
-                repo_path = os.path.join(self.test_root, "badrepo")
-                repo_uri = "file:{0}".format(repo_path)
-                self.create_repo(repo_path, properties={ "publisher": {
-                    "prefix": "test1" } })
-                self.pkg("set-publisher -O {0} test1".format(repo_uri))
-                shutil.rmtree(repo_path)
-
-                self.pkg("publisher")
-                self.pkg("set-publisher -O {0} test1".format(
-                    self.dcs[1].get_repo_url()))
-
-                # Now verify that publishers using origins or mirrors that have
-                # IPv6 addresses can be added and removed.
-                self.pkg("set-publisher -g http://[::1] "
-                    "-m http://[::FFFF:129.144.52.38]:80 "
-                    "-m http://[2010:836B:4179::836B:4179] "
-                    "-g http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80 "
-                    "--no-refresh testipv6")
-                self.pkg("publisher | "
-                    "grep 'http://\\[::FFFF:129.144.52.38\\]:80/'")
-                self.pkg("set-publisher -G http://[::1] "
-                    "-M http://[::FFFF:129.144.52.38]:80 "
-                    "-M http://[2010:836B:4179::836B:4179] "
-                    "-G http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80 "
-                    "-g http://[::192.9.5.5]/dev "
-                    "--no-refresh testipv6")
-                self.pkg("publisher | "
-                    "grep 'http://\\[::FFFF:129.144.52.38\\]:80/'", exit=1)
-                self.pkg("unset-publisher testipv6")
-
-        def test_enable_disable(self):
-                """Test enable and disable."""
-
-                self.pkg("publisher")
-                self.pkg("publisher | grep test1")
-                self.pkg("publisher | grep test2")
-
-                self.pkg("set-publisher -d test2")
-                self.pkg("publisher | grep test2") # always show
-                self.pkg("publisher -n | grep test2", exit=1) # unless -n
-
-                self.pkg("list -a bar", exit=1)
-                self.pkg("set-publisher -P test2")
-                self.pkg("publisher test2")
-                self.pkg("set-publisher -e test2")
-                self.pkg("publisher -n | grep test2")
-                self.pkg("list -a bar")
-
-                self.pkg("set-publisher --disable test2")
-                self.pkg("publisher | grep test2")
-                self.pkg("publisher -n | grep test2", exit=1)
-                self.pkg("list -a bar", exit=1)
-                self.pkg("set-publisher --enable test2")
-                self.pkg("publisher -n | grep test2")
-                self.pkg("list -a bar")
-
-        def test_origins_enable_disable(self):
-                """Test enable and disable origins."""
-
-                self.durl7 = self.dcs[7].get_depot_url()
-                self.durl8 = self.dcs[8].get_depot_url()
-                self.durl9 = self.dcs[9].get_depot_url()
-                self.pkgsend_bulk(self.durl7, self.origin_1)
-                self.pkgsend_bulk(self.durl8, self.origin_2)
-                self.pkgsend_bulk(self.durl9, self.origin_2)
-
-                # Test invalid usages.
-                self.pkg("set-publisher -g '*' test4", exit=2)
-                # Test adding an enabled unknown origin.
-                self.pkg("set-publisher -g {0} --enable test1".format(
-                    "http://unknown"), exit=1)
-                # Test adding a disabled origin. Since we do not try to
-                # contact the repo, it should succeed.
-                self.pkg("set-publisher -g {0} --disable test1".format(
-                    "http://unknown"))
-                # Try to enable it will fail.
-                self.pkg("set-publisher -g {0} --enable test1".format(
-                    "http://unknown"), exit=1)
-                self.pkg("publisher -F tsv | grep unknown")
-                output = self.output.split()
-                self.assertTrue(output[3] == "false" and
-                    output[5] == "disabled")
-
-                # Test adding an enabled origin.
-                self.pkg("set-publisher --enable -g " + self.durl7 + " test4")
-                self.pkg("publisher -F tsv | grep test4")
-                output = self.output.split()
-                self.assertTrue(output[3] == "true" and
-                    output[5] == "online")
-                # Test detailed output should also show origin status.
-                self.pkg("publisher test4 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Online")
-
-                # List and info will succeed.
-                self.pkg("list -af origin1")
-                self.pkg("info -r origin1")
-                # Install will succeed.
-                self.pkg("install origin1")
-                self.pkg("uninstall origin1")
-
-                # Disable that origin.
-                self.pkg("set-publisher --disable -g " + self.durl7 + " test4")
-                self.pkg("publisher -F tsv | grep test4")
-                output = self.output.split()
-                self.assertTrue(output[3] == "false" and
-                    output[5] == "disabled")
-                self.pkg("publisher | grep test4")
-                self.assertTrue("(disabled)" not in self.output)
-                # Test detailed output should also show origin status.
-                self.pkg("publisher test4 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Disabled")
-                self.pkg("list -af origin1", exit=1)
-                self.pkg("install origin1", exit=1)
-
-                # Enable it again.
-                self.pkg("set-publisher --enable -g " + self.durl7 + " test4")
-                self.pkg("list -af origin1")
-
-                # Disable the entire publisher.
-                self.pkg("set-publisher --disable test4")
-                self.pkg("publisher | grep test4")
-                self.assertTrue("(disabled)" in self.output)
-
-                # The status of the origin should still be enabled.
-                self.pkg("publisher -F tsv | grep test4")
-                output = self.output.split()
-                self.assertTrue(output[3] == "true" and
-                    output[5] == "online")
-                self.pkg("publisher test4 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Online")
-
-                self.pkg("list -af origin1", exit=1)
-                self.pkg("info origin1", exit=1)
-                self.pkg("install origin1", exit=1)
-                self.pkg("unset-publisher test4")
-
-                # Test adding a disabled origin.
-                self.pkg("set-publisher --disable -g " + self.durl8 + " test5")
-                self.pkg("publisher -F tsv | grep test5")
-                output = self.output.split()
-                self.assertTrue(output[3] == "false")
-                self.pkg("publisher | grep test5")
-                self.assertTrue("(disabled)" not in self.output)
-                self.pkg("publisher test5 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Disabled")
-                self.pkg("list -af origin2", exit=1)
-                self.pkg("info -r origin2", exit=1)
-                # Install will fail.
-                self.pkg("install origin2", exit=1)
-
-                # Remove the origin but do not remove the publisher.
-                self.pkg("set-publisher -G " + self.durl8 + " test5")
-                # Then add the origin back and disable it.
-                self.pkg("set-publisher --disable -g " + self.durl8 + " test5")
-                self.pkg("publisher -F tsv | grep test5")
-                output = self.output.split()
-                self.assertTrue(output[3] == "false" and
-                    output[5] == "disabled")
-                self.pkg("publisher | grep test5")
-                self.assertTrue("(disabled)" not in self.output)
-                self.pkg("publisher test5 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Disabled")
-                self.pkg("list -af origin2", exit=1)
-                self.pkg("info -r origin2", exit=1)
-                # Install will fail.
-                self.pkg("install origin2", exit=1)
-
-                # Test wildcard.
-                self.pkg("set-publisher --enable -g '*' test5")
-                self.pkg("publisher -F tsv | grep test5")
-                output = self.output.split()
-                self.assertTrue(output[3] == "true" and
-                    output[5] == "online")
-                self.pkg("publisher | grep test5")
-                self.assertTrue("(disabled)" not in self.output)
-                self.pkg("publisher test5 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Online")
-                self.pkg("list -af origin2")
-                self.pkg("info -r origin2")
-                self.pkg("install -nv origin2")
-
-                self.pkg("set-publisher --disable -g '*' test5")
-                self.pkg("publisher -F tsv | grep test5")
-                output = self.output.split()
-                self.assertTrue(output[3] == "false" and
-                    output[5] == "disabled")
-                self.pkg("publisher | grep test5")
-                self.assertTrue("(disabled)" not in self.output)
-                self.pkg("publisher test5 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Disabled")
-                self.pkg("list -af origin2", exit=1)
-                self.pkg("info -r origin2", exit=1)
-                # Install will fail.
-                self.pkg("install origin2", exit=1)
-
-                # Test two origins case for one publisher.
-                self.pkg("set-publisher -g {0} test4".format(
-                    self.durl9))
-                # Disable one of origins for test4.
-                self.pkg("set-publisher -g {0} --disable test4".format(
-                    self.durl7))
-                self.pkg("publisher -HF tsv | grep test4")
-                outputs = self.output.split("\n")
-                output = outputs[0].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "false"
-                    and output[5] == "disabled")
-                output = outputs[1].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "true"
-                    and output[5] == "online")
-                # (disabled) indicating publisher level disable should not be
-                # in the output.
-                self.pkg("publisher | grep test4")
-                self.assertTrue("(disabled)" not in self.output)
-
-                self.pkg("publisher test4 | grep 'Origin Status'")
-                output = self.output.splitlines()
-                self.assertTrue("Disabled" in output[0])
-                self.assertTrue("Online" in output[1])
-
-                # Test installing package from a disabled origin should fail.
-                self.pkg("install origin1", exit=1)
-                self.pkg("list -af origin1", exit=1)
-                self.pkg("info -r origin1", exit=1)
-                # Even after refresh, contents for disabled origin should still
-                # remain unavailable.
-                self.pkg("refresh --full")
-                self.pkg("install origin1", exit=1)
-                self.pkg("list -af origin1", exit=1)
-                self.pkg("info -r origin1", exit=1)
-
-                # Test installing package from the other enabled origin should
-                # succeed.
-                self.pkg("install origin2")
-                self.pkg("uninstall origin2")
-
-                # Disable the other origin.
-                self.pkg("set-publisher -g {0} --disable test4".format(
-                    self.durl9))
-                self.pkg("publisher | grep test4")
-                self.assertTrue("(disabled)" not in self.output)
-                self.pkg("publisher -HF tsv | grep test4")
-                outputs = self.output.split("\n")
-                output = outputs[0].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "false"
-                    and output[5] == "disabled")
-                output = outputs[1].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "false"
-                    and output[5] == "disabled")
-                self.pkg("publisher -Hn | grep test4")
-                self.assertTrue("test4" in self.output)
-
-                self.pkg("publisher test4 | grep 'Origin Status'")
-                output = self.output.splitlines()
-                self.assertTrue("Disabled" in output[0])
-                self.assertTrue("Disabled" in output[1])
-                # Install origin2 will fail.
-                self.pkg("install origin2", exit=1)
-                # List and info will also fail.
-                self.pkg("list -af origin2", exit=1)
-                self.pkg("info -r origin2", exit=1)
-
-                # Enable both origins.
-                self.pkg("set-publisher -g '*' --enable test4")
-                self.pkg("publisher | grep test4")
-                self.assertTrue("(disabled)" not in self.output)
-                self.pkg("publisher -HF tsv | grep test4")
-                outputs = self.output.split("\n")
-                output = outputs[0].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "true"
-                    and output[5] == "online")
-                output = outputs[1].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "true"
-                    and output[5] == "online")
-                self.pkg("publisher test4 | grep 'Origin Status'")
-                output = self.output.splitlines()
-                self.assertTrue("Online" in output[0])
-                self.assertTrue("Online" in output[1])
-                self.pkg("publisher -Hn | grep test4")
-                self.pkg("install -nv origin1")
-                self.pkg("install -nv origin2")
-                self.pkg("list -af origin1")
-                self.pkg("info -r origin1")
-                self.pkg("list -af origin2")
-                self.pkg("info -r origin2")
-
-                # Installing package from an enabled unreachable origin will
-                # still fail.
-                self.dcs[7].stop()
-                self.pkg("install origin1", exit=1)
-                self.dcs[7].start()
-
-                # Disable both origins.
-                self.pkg("set-publisher -g '*' --disable test4")
-                self.pkg("publisher -HF tsv | grep test4")
-                outputs = self.output.split("\n")
-                output = outputs[0].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "false"
-                    and output[5] == "disabled")
-                output = outputs[1].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "false"
-                    and output[5] == "disabled")
-                self.pkg("publisher test4 | grep 'Origin Status'")
-                output = self.output.splitlines()
-                self.assertTrue("Disabled" in output[0])
-                self.assertTrue("Disabled" in output[1])
-                self.pkg("install origin1", exit=1)
-                self.pkg("list -af origin1", exit=1)
-                self.pkg("info -r origin1", exit=1)
-                self.pkg("install origin2", exit=1)
-                self.pkg("list -af origin2", exit=1)
-                self.pkg("info -r origin2", exit=1)
-                # Even after refresh, contents for disabled origin should still
-                # remain unavailable.
-                self.pkg("refresh --full")
-                self.pkg("install origin1", exit=1)
-                self.pkg("list -af origin1", exit=1)
-                self.pkg("info -r origin1", exit=1)
-                self.pkg("install origin2", exit=1)
-                self.pkg("list -af origin2", exit=1)
-                self.pkg("info -r origin2", exit=1)
-
-                # Test -g, -G and --disable.
-                self.pkg("set-publisher -G " + self.durl9  + " -g " + self.durl7
-                    + " --disable test4")
-                self.pkg("publisher -HF tsv | grep test4")
-                outputs = self.output.split("\n")
-                output = outputs[0].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "false"
-                    and output[5] == "disabled")
-                self.assertTrue(self.durl7 in self.output)
-                self.assertTrue(self.durl9 not in self.output)
-                self.pkg("publisher test4 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Disabled")
-
-                # Removing an non-existing origin fails the operation.
-                self.pkg("set-publisher -G http://unknown  -g " + self.durl7
-                    + " --enable test4", exit=1)
-                self.pkg("publisher -HF tsv | grep test4")
-                outputs = self.output.split("\n")
-                output = outputs[0].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "false"
-                    and output[5] == "disabled")
-                self.assertTrue(self.durl7 in self.output)
-                self.assertTrue(self.durl9 not in self.output)
-                self.pkg("publisher test4 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Disabled")
-
-                # Remove all origins and add a new one.
-                self.pkg("set-publisher -G '*'  -g " + self.durl9
-                    + " --disable test4")
-                self.pkg("publisher -HF tsv | grep test4")
-                outputs = self.output.split("\n")
-                output = outputs[0].split("\t")
-                self.assertTrue(output[0] == "test4" and output[3] == "false"
-                    and output[5] == "disabled")
-                self.assertTrue(self.durl9 in self.output)
-                self.assertTrue(self.durl7 not in self.output)
-                self.pkg("publisher | grep test4")
-                self.assertTrue("(disabled)" not in self.output)
-                self.pkg("publisher test4 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Disabled")
-
-                # Removing an unknown origin for a publisher not set yet will
-                # fail.
-                self.pkg("unset-publisher test4")
-                self.pkg("set-publisher -G " + self.durl7 + " -g " +
-                    self.durl9 + " --disable " + "test4", exit=1)
-
-                # Add a new publisher with a disabled origin, plus removing any
-                # possible origins (actually no origin exists).
-                self.pkg("unset-publisher test5")
-                self.pkg("set-publisher -G '*' -g " + self.durl8 + " --disable "
-                    + "test5")
-                self.pkg("publisher -HF tsv | grep test5")
-                outputs = self.output.split("\n")
-                output = outputs[0].split("\t")
-                self.assertTrue(output[0] == "test5" and output[3] == "false"
-                    and output[5] == "disabled")
-                self.assertTrue(self.durl8 in self.output)
-                self.pkg("publisher | grep test5")
-                self.assertTrue("(disabled)" not in self.output)
-                self.pkg("publisher test5 | grep 'Origin Status'")
-                output = self.output.split()
-                self.assertTrue(output[2] == "Disabled")
-
-        def test_search_order(self):
-                """Test moving search order around"""
-
-                # The expected publisher order is test1, test2, test3, with all
-                # publishers enabled and sticky.
-                self.pkg("set-publisher -e -P test1")
-                self.pkg("set-publisher -e --search-after test1 test2")
-                self.pkg("set-publisher -e --search-after test2 test3")
-                self.pkg("publisher") # ease debugging
-                self.pkg("publisher -H | head -1 | egrep test1")
-                self.pkg("publisher -H | head -2 | egrep test2")
-                self.pkg("publisher -H | head -3 | egrep test3")
-                # make test2 disabled, make sure order is preserved
-                self.pkg("set-publisher --disable test2")
-                self.pkg("publisher") # ease debugging
-                self.pkg("publisher -H | head -1 | egrep test1")
-                self.pkg("publisher -H | head -2 | egrep test2")
-                self.pkg("publisher -H | head -3 | egrep test3")
-                self.pkg("set-publisher --enable test2")
-                # make test3 preferred
-                self.pkg("set-publisher -P test3")
-                self.pkg("publisher") # ease debugging
-                self.pkg("publisher -H | head -1 | egrep test3")
-                self.pkg("publisher -H | head -2 | egrep test1")
-                self.pkg("publisher -H | head -3 | egrep test2")
-                # move test3 after test1
-                self.pkg("set-publisher --search-after=test1 test3")
-                self.pkg("publisher") # ease debugging
-                self.pkg("publisher -H | head -1 | egrep test1")
-                self.pkg("publisher -H | head -2 | egrep test3")
-                self.pkg("publisher -H | head -3 | egrep test2")
-                # move test2 before test3
-                self.pkg("set-publisher --search-before=test3 test2")
-                self.pkg("publisher") # ease debugging
-                self.pkg("publisher -H | head -1 | egrep test1")
-                self.pkg("publisher -H | head -2 | egrep test2")
-                self.pkg("publisher -H | head -3 | egrep test3")
-                # make sure we cannot get ahead or behind of ourselves
-                self.pkg("set-publisher --search-before=test3 test3", exit=1)
-                self.pkg("set-publisher --search-after=test3 test3", exit=1)
-
-                # make sure that setting search order while adding a publisher
-                # works
-                self.pkg("unset-publisher test2")
-                self.pkg("unset-publisher test3")
-                self.pkg("set-publisher --search-before=test1 test2")
-                self.pkg("set-publisher --search-after=test2 test3")
-                self.pkg("publisher") # ease debugging
-                self.pkg("publisher -H | head -1 | egrep test2")
-                self.pkg("publisher -H | head -2 | egrep test3")
-                self.pkg("publisher -H | head -3 | egrep test1")
-
-        def test_publishers_only_from_installed_packages(self):
-                """Test that get_highest_rank_publisher works when there are
-                installed packages but no configured publishers."""
-
-                self.pkg("install foo bar baz")
-                self.pkg("unset-publisher test1")
-                self.pkg("unset-publisher test2")
-                self.pkg("unset-publisher test3")
-                self.pkg("publisher")
-
-                # set publishers to expected configuration
-                self.pkg("set-publisher -p {0}".format(self.durl1))
-                self.pkg("set-publisher -p {0}".format(self.durl2))
-                self.pkg("set-publisher -p {0}".format(self.durl3))
-
-        def test_bug_18283(self):
-                """Test that having a unset publisher with packages installed
-                doesn't break adding a publisher with the -P option."""
-
-                # Test what happens when another publisher is configured.
-                self.pkg("unset-publisher test2")
-                self.pkg("install foo")
-                self.pkg("unset-publisher test1")
-                self.pkg("set-publisher -P -p {0}".format(self.durl2))
-
-                # Test what happens when no publishers are configured
-                self.pkg("unset-publisher test2")
-                self.pkg("unset-publisher test3")
-                self.pkg("set-publisher -P -p {0}".format(self.durl2))
-
-                # set publishers to expected configuration
-                self.pkg("set-publisher -P -p {0}".format(self.durl1))
-                self.pkg("set-publisher -p {0}".format(self.durl3))
+        self.pkg("set-publisher -p {0}".format(durl3))
+
+        # Load image configuration to verify publisher was configured
+        # as expected.
+        self.__verify_pub_cfg("test3", t3cfg)
+
+        # Update configuration of just this depot with more information
+        # for comparison basis.
+        self.dcs[3].stop()
+
+        # Origin and mirror info wasn't known until this point, so add
+        # it to the test configuration.
+        t3cfg = self.test3_pub_cfg.copy()
+        t3cfg["repository"]["origins"] = [durl3]
+        t3cfg["repository"]["mirrors"] = [durl1, durl3, durl4]
+        self.__update_repo_pub_cfg(self.dcs[3], t3cfg)
+        self.dcs[3].start()
+
+        # Should succeed and configure test3 publisher.
+        self.pkg("set-publisher -p {0}".format(durl3))
+
+        # Load image configuration to verify publisher was configured
+        # as expected.
+        self.__verify_pub_cfg("test3", t3cfg)
+
+        # Now test the update case.  This verifies that the existing,
+        # configured origins and mirrors will not be lost (only added
+        # to) and that new data will be accepted.
+        durl6 = self.dcs[6].get_depot_url()
+        self.dcs[6].stop()
+        t6cfg = {}
+        for section in t3cfg:
+            t6cfg[section] = {}
+            for prop in t3cfg[section]:
+                val = t3cfg[section][prop]
+                if prop == "refresh_seconds":
+                    val = 1800
+                elif prop == "collection_type":
+                    val = "core"
+                elif prop not in ("alias", "prefix"):
+                    # Clear all other props.
+                    val = ""
+                t6cfg[section][prop] = val
+        t6cfg["repository"]["origins"] = [durl3, durl6]
+        t6cfg["repository"]["mirrors"] = [durl1, durl3, durl4, durl6]
+        self.__update_repo_pub_cfg(self.dcs[6], t6cfg)
+        self.dcs[6].start()
+
+        self.pkg("set-publisher -p {0}".format(durl6))
+
+        # Load image configuration to verify publisher was configured
+        # as expected.
+        self.__verify_pub_cfg("test3", t6cfg)
+
+        # Test multi-publisher add case.
+        self.pkgrepo(
+            "set -s {0} -p test2 publisher/alias=''".format(
+                self.dcs[6].get_repodir()
+            )
+        )
+        self.pkg("unset-publisher test3")
+        self.dcs[6].refresh()
+        self.pkg("set-publisher -P -p {0}".format(durl6))
+
+        # Determine publisher order from output and then verify it
+        # matches expected.
+        def get_pubs():
+            self.pkg("publisher -HF tsv")
+            pubs = []
+            for l in self.output.splitlines():
+                pub, ignored = l.split("\t", 1)
+                if pub not in pubs:
+                    pubs.append(pub)
+            return pubs
+
+        # Since -P was used, new publishers should be set first in
+        # search order alphabetically.
+        self.assertEqual(get_pubs(), ["test2", "test3", "test1"])
+
+        # Now change search order and verify that using -P and -p again
+        # won't change it since publishers already exist.
+        self.pkg("set-publisher --search-after=test1 test2")
+        self.pkg("set-publisher --search-after=test2 test3")
+        self.assertEqual(get_pubs(), ["test1", "test2", "test3"])
+        self.pkg("set-publisher -P -p {0}".format(durl6))
+        self.assertEqual(get_pubs(), ["test1", "test2", "test3"])
+
+        # Check that --proxy arguments are set on all auto-configured
+        # publishers.  We use $no_proxy='*' in the environment so that
+        # we can persist a dummy --proxy value to the image
+        # configuration, yet still reach the test depot to obtain the
+        # publisher/ response.
+        self.pkg("unset-publisher test3")
+        self.pkg("unset-publisher test2")
+        self.pkg(
+            "set-publisher -P --proxy http://myproxy -p {0}".format(durl6),
+            env_arg={"no_proxy": "*"},
+        )
+        self.assertEqual(get_pubs(), ["test2", "test3", "test1"])
+
+        # Verify that only test2 and test3 have proxies set, since
+        # test1 already existed, it should not use a proxy. The proxy
+        # column is the last one printed on each line.
+        self.pkg("publisher -HF tsv")
+        for l in self.output.splitlines():
+            if l.startswith("test2") or l.startswith("test3"):
+                self.assertEqual("http://myproxy", l.split()[-1])
+            else:
+                self.assertEqual("-", l.split()[-1])
+
+    def test_set_mirrors_origins(self):
+        """Test set-publisher functionality for mirrors and origins."""
+
+        durl1 = self.dcs[1].get_depot_url()
+        rurl1 = self.dcs[1].get_repo_url()
+        self.image_create(durl1, prefix="test1")
+
+        # Verify that https origins can be mixed with other types
+        # of origins.
+        self.pkg("set-publisher -g {0} test1".format(rurl1))
+        self.pkg("set-publisher --no-refresh -g https://test.invalid1 " "test1")
+
+        # Verify that a cert and key can be set even when non-https
+        # origins are present.
+        key_path = os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem")
+        cert_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
+
+        self.pkg(
+            "set-publisher --no-refresh -k {0} -c {1} test1".format(
+                key_path, cert_path
+            )
+        )
+        self.pkg("publisher test1", exit=[0, 3])
+
+        # An expiring certificate will cause the pkg client to error
+        # with EXIT_OOPS. If it is a certificate expiring issue give
+        # an indication on how to fix it.
+        self.assertFalse(
+            "will expire in" in self.errout,
+            "\nWARNING: Test certificates are about to expire. "
+            "Please run:\n"
+            "$ cd src/tests/ro_data/signing_certs/\n"
+            "$ ./generate_certs.py \n"
+            "to regenerate the certificates.",
+        )
+
+        # For any other text in the errout fail the test
+        self.assertTrue(self.errout is not None)
+
+        # This test relies on using the same implementation used in
+        # image.py __store_publisher_ssl() which sets the paths to the
+        # SSL keys/certs.
+        img_key_path = os.path.join(
+            self.img_path(),
+            "var",
+            "pkg",
+            "ssl",
+            pkg.misc.get_data_digest(key_path, hash_func=hashlib.sha1)[0],
+        )
+        img_cert_path = os.path.join(
+            self.img_path(),
+            "var",
+            "pkg",
+            "ssl",
+            pkg.misc.get_data_digest(cert_path, hash_func=hashlib.sha1)[0],
+        )
+        self.assertTrue(img_key_path in self.output)
+        self.assertTrue(img_cert_path in self.output)
+
+        # Verify that removing all SSL origins does not leave key
+        # and cert information intact.
+        self.pkg("set-publisher -G '*' -g {0} test1".format(durl1))
+        self.pkg("publisher test1")
+        self.assertTrue(img_key_path not in self.output)
+        self.assertTrue(img_cert_path not in self.output)
+
+        # Verify that https mirrors can be mixed with other types of
+        # origins.
+        self.pkg("set-publisher -m {0} test1".format(rurl1))
+        self.pkg("set-publisher --no-refresh -m https://test.invalid1 " "test1")
+        self.pkg(
+            "set-publisher --no-refresh -k {0} -c {1} test1".format(
+                key_path, cert_path
+            )
+        )
+
+        # Verify that removing all SSL mirrors does not leave key
+        # and cert information intact.
+        self.pkg("set-publisher -M '*' -m {0} test1".format(durl1))
+        self.pkg("publisher test1")
+        self.assertTrue(img_key_path not in self.output)
+        self.assertTrue(img_cert_path not in self.output)
+
+        # Test short options for mirrors.
+        self.__test_mirror_origin("mirror", "-m", "-M")
+
+        # Test long options for mirrors.
+        self.__test_mirror_origin("mirror", "--add-mirror", "--remove-mirror")
+
+        # Test short options for origins.
+        self.__test_mirror_origin("origin", "-g", "-G")
+
+        # Test long options for origins.
+        self.__test_mirror_origin("origin", "--add-origin", "--remove-origin")
+
+        # Verify that if multiple origins are present that -O will
+        # discard all others.
+        durl4 = self.dcs[4].get_depot_url()
+        durl5 = self.dcs[5].get_depot_url()
+        self.pkg("set-publisher -g {0} -g {1} test1".format(durl4, durl5))
+        self.pkg("set-publisher -O {0} test1".format(durl4))
+        self.pkg("publisher | grep origin.*{0}".format(durl1), exit=1)
+        self.pkg("publisher | grep origin.*{0}".format(durl5), exit=1)
+
+        # Verify that if a publisher is set to use a file repository
+        # that removing that repository will not prevent the pkg(1)
+        # command from operating or the set-publisher commands
+        # from working.
+        repo_path = os.path.join(self.test_root, "badrepo")
+        repo_uri = "file:{0}".format(repo_path)
+        self.create_repo(
+            repo_path, properties={"publisher": {"prefix": "test1"}}
+        )
+        self.pkg("set-publisher -O {0} test1".format(repo_uri))
+        shutil.rmtree(repo_path)
+
+        self.pkg("publisher")
+        self.pkg(
+            "set-publisher -O {0} test1".format(self.dcs[1].get_repo_url())
+        )
+
+        # Now verify that publishers using origins or mirrors that have
+        # IPv6 addresses can be added and removed.
+        self.pkg(
+            "set-publisher -g http://[::1] "
+            "-m http://[::FFFF:129.144.52.38]:80 "
+            "-m http://[2010:836B:4179::836B:4179] "
+            "-g http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80 "
+            "--no-refresh testipv6"
+        )
+        self.pkg("publisher | " "grep 'http://\\[::FFFF:129.144.52.38\\]:80/'")
+        self.pkg(
+            "set-publisher -G http://[::1] "
+            "-M http://[::FFFF:129.144.52.38]:80 "
+            "-M http://[2010:836B:4179::836B:4179] "
+            "-G http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80 "
+            "-g http://[::192.9.5.5]/dev "
+            "--no-refresh testipv6"
+        )
+        self.pkg(
+            "publisher | " "grep 'http://\\[::FFFF:129.144.52.38\\]:80/'",
+            exit=1,
+        )
+        self.pkg("unset-publisher testipv6")
+
+    def test_enable_disable(self):
+        """Test enable and disable."""
+
+        self.pkg("publisher")
+        self.pkg("publisher | grep test1")
+        self.pkg("publisher | grep test2")
+
+        self.pkg("set-publisher -d test2")
+        self.pkg("publisher | grep test2")  # always show
+        self.pkg("publisher -n | grep test2", exit=1)  # unless -n
+
+        self.pkg("list -a bar", exit=1)
+        self.pkg("set-publisher -P test2")
+        self.pkg("publisher test2")
+        self.pkg("set-publisher -e test2")
+        self.pkg("publisher -n | grep test2")
+        self.pkg("list -a bar")
+
+        self.pkg("set-publisher --disable test2")
+        self.pkg("publisher | grep test2")
+        self.pkg("publisher -n | grep test2", exit=1)
+        self.pkg("list -a bar", exit=1)
+        self.pkg("set-publisher --enable test2")
+        self.pkg("publisher -n | grep test2")
+        self.pkg("list -a bar")
+
+    def test_origins_enable_disable(self):
+        """Test enable and disable origins."""
+
+        self.durl7 = self.dcs[7].get_depot_url()
+        self.durl8 = self.dcs[8].get_depot_url()
+        self.durl9 = self.dcs[9].get_depot_url()
+        self.pkgsend_bulk(self.durl7, self.origin_1)
+        self.pkgsend_bulk(self.durl8, self.origin_2)
+        self.pkgsend_bulk(self.durl9, self.origin_2)
+
+        # Test invalid usages.
+        self.pkg("set-publisher -g '*' test4", exit=2)
+        # Test adding an enabled unknown origin.
+        self.pkg(
+            "set-publisher -g {0} --enable test1".format("http://unknown"),
+            exit=1,
+        )
+        # Test adding a disabled origin. Since we do not try to
+        # contact the repo, it should succeed.
+        self.pkg(
+            "set-publisher -g {0} --disable test1".format("http://unknown")
+        )
+        # Try to enable it will fail.
+        self.pkg(
+            "set-publisher -g {0} --enable test1".format("http://unknown"),
+            exit=1,
+        )
+        self.pkg("publisher -F tsv | grep unknown")
+        output = self.output.split()
+        self.assertTrue(output[3] == "false" and output[5] == "disabled")
+
+        # Test adding an enabled origin.
+        self.pkg("set-publisher --enable -g " + self.durl7 + " test4")
+        self.pkg("publisher -F tsv | grep test4")
+        output = self.output.split()
+        self.assertTrue(output[3] == "true" and output[5] == "online")
+        # Test detailed output should also show origin status.
+        self.pkg("publisher test4 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Online")
+
+        # List and info will succeed.
+        self.pkg("list -af origin1")
+        self.pkg("info -r origin1")
+        # Install will succeed.
+        self.pkg("install origin1")
+        self.pkg("uninstall origin1")
+
+        # Disable that origin.
+        self.pkg("set-publisher --disable -g " + self.durl7 + " test4")
+        self.pkg("publisher -F tsv | grep test4")
+        output = self.output.split()
+        self.assertTrue(output[3] == "false" and output[5] == "disabled")
+        self.pkg("publisher | grep test4")
+        self.assertTrue("(disabled)" not in self.output)
+        # Test detailed output should also show origin status.
+        self.pkg("publisher test4 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Disabled")
+        self.pkg("list -af origin1", exit=1)
+        self.pkg("install origin1", exit=1)
+
+        # Enable it again.
+        self.pkg("set-publisher --enable -g " + self.durl7 + " test4")
+        self.pkg("list -af origin1")
+
+        # Disable the entire publisher.
+        self.pkg("set-publisher --disable test4")
+        self.pkg("publisher | grep test4")
+        self.assertTrue("(disabled)" in self.output)
+
+        # The status of the origin should still be enabled.
+        self.pkg("publisher -F tsv | grep test4")
+        output = self.output.split()
+        self.assertTrue(output[3] == "true" and output[5] == "online")
+        self.pkg("publisher test4 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Online")
+
+        self.pkg("list -af origin1", exit=1)
+        self.pkg("info origin1", exit=1)
+        self.pkg("install origin1", exit=1)
+        self.pkg("unset-publisher test4")
+
+        # Test adding a disabled origin.
+        self.pkg("set-publisher --disable -g " + self.durl8 + " test5")
+        self.pkg("publisher -F tsv | grep test5")
+        output = self.output.split()
+        self.assertTrue(output[3] == "false")
+        self.pkg("publisher | grep test5")
+        self.assertTrue("(disabled)" not in self.output)
+        self.pkg("publisher test5 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Disabled")
+        self.pkg("list -af origin2", exit=1)
+        self.pkg("info -r origin2", exit=1)
+        # Install will fail.
+        self.pkg("install origin2", exit=1)
+
+        # Remove the origin but do not remove the publisher.
+        self.pkg("set-publisher -G " + self.durl8 + " test5")
+        # Then add the origin back and disable it.
+        self.pkg("set-publisher --disable -g " + self.durl8 + " test5")
+        self.pkg("publisher -F tsv | grep test5")
+        output = self.output.split()
+        self.assertTrue(output[3] == "false" and output[5] == "disabled")
+        self.pkg("publisher | grep test5")
+        self.assertTrue("(disabled)" not in self.output)
+        self.pkg("publisher test5 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Disabled")
+        self.pkg("list -af origin2", exit=1)
+        self.pkg("info -r origin2", exit=1)
+        # Install will fail.
+        self.pkg("install origin2", exit=1)
+
+        # Test wildcard.
+        self.pkg("set-publisher --enable -g '*' test5")
+        self.pkg("publisher -F tsv | grep test5")
+        output = self.output.split()
+        self.assertTrue(output[3] == "true" and output[5] == "online")
+        self.pkg("publisher | grep test5")
+        self.assertTrue("(disabled)" not in self.output)
+        self.pkg("publisher test5 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Online")
+        self.pkg("list -af origin2")
+        self.pkg("info -r origin2")
+        self.pkg("install -nv origin2")
+
+        self.pkg("set-publisher --disable -g '*' test5")
+        self.pkg("publisher -F tsv | grep test5")
+        output = self.output.split()
+        self.assertTrue(output[3] == "false" and output[5] == "disabled")
+        self.pkg("publisher | grep test5")
+        self.assertTrue("(disabled)" not in self.output)
+        self.pkg("publisher test5 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Disabled")
+        self.pkg("list -af origin2", exit=1)
+        self.pkg("info -r origin2", exit=1)
+        # Install will fail.
+        self.pkg("install origin2", exit=1)
+
+        # Test two origins case for one publisher.
+        self.pkg("set-publisher -g {0} test4".format(self.durl9))
+        # Disable one of origins for test4.
+        self.pkg("set-publisher -g {0} --disable test4".format(self.durl7))
+        self.pkg("publisher -HF tsv | grep test4")
+        outputs = self.output.split("\n")
+        output = outputs[0].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "false"
+            and output[5] == "disabled"
+        )
+        output = outputs[1].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "true"
+            and output[5] == "online"
+        )
+        # (disabled) indicating publisher level disable should not be
+        # in the output.
+        self.pkg("publisher | grep test4")
+        self.assertTrue("(disabled)" not in self.output)
+
+        self.pkg("publisher test4 | grep 'Origin Status'")
+        output = self.output.splitlines()
+        self.assertTrue("Disabled" in output[0])
+        self.assertTrue("Online" in output[1])
+
+        # Test installing package from a disabled origin should fail.
+        self.pkg("install origin1", exit=1)
+        self.pkg("list -af origin1", exit=1)
+        self.pkg("info -r origin1", exit=1)
+        # Even after refresh, contents for disabled origin should still
+        # remain unavailable.
+        self.pkg("refresh --full")
+        self.pkg("install origin1", exit=1)
+        self.pkg("list -af origin1", exit=1)
+        self.pkg("info -r origin1", exit=1)
+
+        # Test installing package from the other enabled origin should
+        # succeed.
+        self.pkg("install origin2")
+        self.pkg("uninstall origin2")
+
+        # Disable the other origin.
+        self.pkg("set-publisher -g {0} --disable test4".format(self.durl9))
+        self.pkg("publisher | grep test4")
+        self.assertTrue("(disabled)" not in self.output)
+        self.pkg("publisher -HF tsv | grep test4")
+        outputs = self.output.split("\n")
+        output = outputs[0].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "false"
+            and output[5] == "disabled"
+        )
+        output = outputs[1].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "false"
+            and output[5] == "disabled"
+        )
+        self.pkg("publisher -Hn | grep test4")
+        self.assertTrue("test4" in self.output)
+
+        self.pkg("publisher test4 | grep 'Origin Status'")
+        output = self.output.splitlines()
+        self.assertTrue("Disabled" in output[0])
+        self.assertTrue("Disabled" in output[1])
+        # Install origin2 will fail.
+        self.pkg("install origin2", exit=1)
+        # List and info will also fail.
+        self.pkg("list -af origin2", exit=1)
+        self.pkg("info -r origin2", exit=1)
+
+        # Enable both origins.
+        self.pkg("set-publisher -g '*' --enable test4")
+        self.pkg("publisher | grep test4")
+        self.assertTrue("(disabled)" not in self.output)
+        self.pkg("publisher -HF tsv | grep test4")
+        outputs = self.output.split("\n")
+        output = outputs[0].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "true"
+            and output[5] == "online"
+        )
+        output = outputs[1].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "true"
+            and output[5] == "online"
+        )
+        self.pkg("publisher test4 | grep 'Origin Status'")
+        output = self.output.splitlines()
+        self.assertTrue("Online" in output[0])
+        self.assertTrue("Online" in output[1])
+        self.pkg("publisher -Hn | grep test4")
+        self.pkg("install -nv origin1")
+        self.pkg("install -nv origin2")
+        self.pkg("list -af origin1")
+        self.pkg("info -r origin1")
+        self.pkg("list -af origin2")
+        self.pkg("info -r origin2")
+
+        # Installing package from an enabled unreachable origin will
+        # still fail.
+        self.dcs[7].stop()
+        self.pkg("install origin1", exit=1)
+        self.dcs[7].start()
+
+        # Disable both origins.
+        self.pkg("set-publisher -g '*' --disable test4")
+        self.pkg("publisher -HF tsv | grep test4")
+        outputs = self.output.split("\n")
+        output = outputs[0].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "false"
+            and output[5] == "disabled"
+        )
+        output = outputs[1].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "false"
+            and output[5] == "disabled"
+        )
+        self.pkg("publisher test4 | grep 'Origin Status'")
+        output = self.output.splitlines()
+        self.assertTrue("Disabled" in output[0])
+        self.assertTrue("Disabled" in output[1])
+        self.pkg("install origin1", exit=1)
+        self.pkg("list -af origin1", exit=1)
+        self.pkg("info -r origin1", exit=1)
+        self.pkg("install origin2", exit=1)
+        self.pkg("list -af origin2", exit=1)
+        self.pkg("info -r origin2", exit=1)
+        # Even after refresh, contents for disabled origin should still
+        # remain unavailable.
+        self.pkg("refresh --full")
+        self.pkg("install origin1", exit=1)
+        self.pkg("list -af origin1", exit=1)
+        self.pkg("info -r origin1", exit=1)
+        self.pkg("install origin2", exit=1)
+        self.pkg("list -af origin2", exit=1)
+        self.pkg("info -r origin2", exit=1)
+
+        # Test -g, -G and --disable.
+        self.pkg(
+            "set-publisher -G "
+            + self.durl9
+            + " -g "
+            + self.durl7
+            + " --disable test4"
+        )
+        self.pkg("publisher -HF tsv | grep test4")
+        outputs = self.output.split("\n")
+        output = outputs[0].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "false"
+            and output[5] == "disabled"
+        )
+        self.assertTrue(self.durl7 in self.output)
+        self.assertTrue(self.durl9 not in self.output)
+        self.pkg("publisher test4 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Disabled")
+
+        # Removing an non-existing origin fails the operation.
+        self.pkg(
+            "set-publisher -G http://unknown  -g "
+            + self.durl7
+            + " --enable test4",
+            exit=1,
+        )
+        self.pkg("publisher -HF tsv | grep test4")
+        outputs = self.output.split("\n")
+        output = outputs[0].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "false"
+            and output[5] == "disabled"
+        )
+        self.assertTrue(self.durl7 in self.output)
+        self.assertTrue(self.durl9 not in self.output)
+        self.pkg("publisher test4 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Disabled")
+
+        # Remove all origins and add a new one.
+        self.pkg("set-publisher -G '*'  -g " + self.durl9 + " --disable test4")
+        self.pkg("publisher -HF tsv | grep test4")
+        outputs = self.output.split("\n")
+        output = outputs[0].split("\t")
+        self.assertTrue(
+            output[0] == "test4"
+            and output[3] == "false"
+            and output[5] == "disabled"
+        )
+        self.assertTrue(self.durl9 in self.output)
+        self.assertTrue(self.durl7 not in self.output)
+        self.pkg("publisher | grep test4")
+        self.assertTrue("(disabled)" not in self.output)
+        self.pkg("publisher test4 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Disabled")
+
+        # Removing an unknown origin for a publisher not set yet will
+        # fail.
+        self.pkg("unset-publisher test4")
+        self.pkg(
+            "set-publisher -G "
+            + self.durl7
+            + " -g "
+            + self.durl9
+            + " --disable "
+            + "test4",
+            exit=1,
+        )
+
+        # Add a new publisher with a disabled origin, plus removing any
+        # possible origins (actually no origin exists).
+        self.pkg("unset-publisher test5")
+        self.pkg(
+            "set-publisher -G '*' -g " + self.durl8 + " --disable " + "test5"
+        )
+        self.pkg("publisher -HF tsv | grep test5")
+        outputs = self.output.split("\n")
+        output = outputs[0].split("\t")
+        self.assertTrue(
+            output[0] == "test5"
+            and output[3] == "false"
+            and output[5] == "disabled"
+        )
+        self.assertTrue(self.durl8 in self.output)
+        self.pkg("publisher | grep test5")
+        self.assertTrue("(disabled)" not in self.output)
+        self.pkg("publisher test5 | grep 'Origin Status'")
+        output = self.output.split()
+        self.assertTrue(output[2] == "Disabled")
+
+    def test_search_order(self):
+        """Test moving search order around"""
+
+        # The expected publisher order is test1, test2, test3, with all
+        # publishers enabled and sticky.
+        self.pkg("set-publisher -e -P test1")
+        self.pkg("set-publisher -e --search-after test1 test2")
+        self.pkg("set-publisher -e --search-after test2 test3")
+        self.pkg("publisher")  # ease debugging
+        self.pkg("publisher -H | head -1 | egrep test1")
+        self.pkg("publisher -H | head -2 | egrep test2")
+        self.pkg("publisher -H | head -3 | egrep test3")
+        # make test2 disabled, make sure order is preserved
+        self.pkg("set-publisher --disable test2")
+        self.pkg("publisher")  # ease debugging
+        self.pkg("publisher -H | head -1 | egrep test1")
+        self.pkg("publisher -H | head -2 | egrep test2")
+        self.pkg("publisher -H | head -3 | egrep test3")
+        self.pkg("set-publisher --enable test2")
+        # make test3 preferred
+        self.pkg("set-publisher -P test3")
+        self.pkg("publisher")  # ease debugging
+        self.pkg("publisher -H | head -1 | egrep test3")
+        self.pkg("publisher -H | head -2 | egrep test1")
+        self.pkg("publisher -H | head -3 | egrep test2")
+        # move test3 after test1
+        self.pkg("set-publisher --search-after=test1 test3")
+        self.pkg("publisher")  # ease debugging
+        self.pkg("publisher -H | head -1 | egrep test1")
+        self.pkg("publisher -H | head -2 | egrep test3")
+        self.pkg("publisher -H | head -3 | egrep test2")
+        # move test2 before test3
+        self.pkg("set-publisher --search-before=test3 test2")
+        self.pkg("publisher")  # ease debugging
+        self.pkg("publisher -H | head -1 | egrep test1")
+        self.pkg("publisher -H | head -2 | egrep test2")
+        self.pkg("publisher -H | head -3 | egrep test3")
+        # make sure we cannot get ahead or behind of ourselves
+        self.pkg("set-publisher --search-before=test3 test3", exit=1)
+        self.pkg("set-publisher --search-after=test3 test3", exit=1)
+
+        # make sure that setting search order while adding a publisher
+        # works
+        self.pkg("unset-publisher test2")
+        self.pkg("unset-publisher test3")
+        self.pkg("set-publisher --search-before=test1 test2")
+        self.pkg("set-publisher --search-after=test2 test3")
+        self.pkg("publisher")  # ease debugging
+        self.pkg("publisher -H | head -1 | egrep test2")
+        self.pkg("publisher -H | head -2 | egrep test3")
+        self.pkg("publisher -H | head -3 | egrep test1")
+
+    def test_publishers_only_from_installed_packages(self):
+        """Test that get_highest_rank_publisher works when there are
+        installed packages but no configured publishers."""
+
+        self.pkg("install foo bar baz")
+        self.pkg("unset-publisher test1")
+        self.pkg("unset-publisher test2")
+        self.pkg("unset-publisher test3")
+        self.pkg("publisher")
+
+        # set publishers to expected configuration
+        self.pkg("set-publisher -p {0}".format(self.durl1))
+        self.pkg("set-publisher -p {0}".format(self.durl2))
+        self.pkg("set-publisher -p {0}".format(self.durl3))
+
+    def test_bug_18283(self):
+        """Test that having a unset publisher with packages installed
+        doesn't break adding a publisher with the -P option."""
+
+        # Test what happens when another publisher is configured.
+        self.pkg("unset-publisher test2")
+        self.pkg("install foo")
+        self.pkg("unset-publisher test1")
+        self.pkg("set-publisher -P -p {0}".format(self.durl2))
+
+        # Test what happens when no publishers are configured
+        self.pkg("unset-publisher test2")
+        self.pkg("unset-publisher test3")
+        self.pkg("set-publisher -P -p {0}".format(self.durl2))
+
+        # set publishers to expected configuration
+        self.pkg("set-publisher -P -p {0}".format(self.durl1))
+        self.pkg("set-publisher -p {0}".format(self.durl3))
 
 
 class TestMultiPublisherRepo(pkg5unittest.ManyDepotTestCase):
-
-        foo1 = """
+    foo1 = """
             open foo@1,5.11-0
             close """
 
-        bar1 = """
+    bar1 = """
             open bar@1,5.11-0
             close """
 
-        baz1 = """
+    baz1 = """
             open pkg://another-pub/baz@1,5.11-0
             close """
 
+    def setUp(self):
+        # This test suite needs actual depots.
+        pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
 
-        def setUp(self):
-                # This test suite needs actual depots.
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.pkgsend_bulk(self.rurl1, self.foo1 + self.baz1)
 
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.pkgsend_bulk(self.rurl1, self.foo1 + self.baz1)
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.pkgsend_bulk(self.rurl2, self.bar1)
 
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.pkgsend_bulk(self.rurl2, self.bar1)
+    def test_multi_publisher_search_before(self):
+        """Test that using search before and -p on a multipublisher
+        repository works."""
 
-        def test_multi_publisher_search_before(self):
-                """Test that using search before and -p on a multipublisher
-                repository works."""
+        self.image_create(self.rurl2)
+        self.pkg(
+            "set-publisher --search-before test2 -p {0}".format(self.rurl1)
+        )
+        self.pkg("publisher -HF tsv")
+        lines = self.output.splitlines()
+        self.assertEqual(lines[0].split()[0], "another-pub")
+        self.assertEqual(lines[1].split()[0], "test1")
+        self.assertEqual(lines[2].split()[0], "test2")
 
-                self.image_create(self.rurl2)
-                self.pkg("set-publisher --search-before test2 -p {0}".format(
-                    self.rurl1))
-                self.pkg("publisher -HF tsv")
-                lines = self.output.splitlines()
-                self.assertEqual(lines[0].split()[0], "another-pub")
-                self.assertEqual(lines[1].split()[0], "test1")
-                self.assertEqual(lines[2].split()[0], "test2")
-
-        def test_multiple_p_option(self):
-                """Verify that providing multiple repositories using
-                -p option fails"""
-                self.image_create()
-                self.pkg("set-publisher -p {0} -p {1}".format(self.rurl1,
-                    self.rurl2), exit=2)
+    def test_multiple_p_option(self):
+        """Verify that providing multiple repositories using
+        -p option fails"""
+        self.image_create()
+        self.pkg(
+            "set-publisher -p {0} -p {1}".format(self.rurl1, self.rurl2), exit=2
+        )
 
 
 class TestPkgPublisherCACerts(pkg5unittest.ManyDepotTestCase):
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        def setUp(self):
-                # This test suite needs actual depots.
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
+    def setUp(self):
+        # This test suite needs actual depots.
+        pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2"])
 
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.image_create(self.rurl1, prefix="test1")
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.image_create(self.rurl1, prefix="test1")
 
-        def test_new_publisher_ca_certs_with_refresh(self):
-                """Check that approving and revoking CA certs is reflected in
-                the output of pkg publisher and that setting the CA certs when
-                setting a new publisher works correctly."""
+    def test_new_publisher_ca_certs_with_refresh(self):
+        """Check that approving and revoking CA certs is reflected in
+        the output of pkg publisher and that setting the CA certs when
+        setting a new publisher works correctly."""
 
-                cert_dir = os.path.join(self.ro_data_root,
-                    "signing_certs", "produced", "chain_certs")
+        cert_dir = os.path.join(
+            self.ro_data_root, "signing_certs", "produced", "chain_certs"
+        )
 
-                app1 = os.path.join(cert_dir, "ch4_ta1_cert.pem")
-                app2 = os.path.join(cert_dir, "ch1_ta3_cert.pem")
-                rev1 = os.path.join(cert_dir, "ch1_ta4_cert.pem")
-                rev2 = os.path.join(cert_dir, "ch1_ta5_cert.pem")
-                app1_h = self.calc_pem_hash(app1)
-                app2_h = self.calc_pem_hash(app2)
-                rev1_h = self.calc_pem_hash(rev1)
-                rev2_h = self.calc_pem_hash(rev2)
-                self.pkg("set-publisher -O {0} "
-                    "--approve-ca-cert {1} "
-                    "--approve-ca-cert {2} --revoke-ca-cert {3} "
-                    "--revoke-ca-cert {4} test2 ".format(self.dcs[2].get_repo_url(),
-                    app1, app2, rev1_h, rev2_h))
-                self.pkg("publisher test2")
-                r1 = "         Approved CAs: {0}"
-                r2 = "                     : {0}"
-                r3 = "          Revoked CAs: {0}"
-                ls = self.output.splitlines()
-                found_approved = False
-                found_revoked = False
-                for i in range(0, len(ls)):
-                        if "Approved CAs" in ls[i]:
-                                found_approved = True
-                                if not ((r1.format(app1_h) == ls[i] and
-                                    r2.format(app2_h) == ls[i+1]) or \
-                                    (r1.format(app2_h) == ls[i] and
-                                    r2.format(app1_h) == ls[i+1])):
-                                        raise RuntimeError("Expected to see "
-                                            "{0} and {1} as approved certs. "
-                                            "Output was:\n{2}".format(app1_h,
-                                            app2_h, self.output))
-                        elif "Revoked CAs" in ls[i]:
-                                found_approved = True
-                                if not ((r3.format(rev1_h) == ls[i] and
-                                    r2.format(rev2_h) == ls[i+1]) or \
-                                    (r3.format(rev2_h) == ls[i] and
-                                    r2.format(rev1_h) == ls[i+1])):
-                                        raise RuntimeError("Expected to see "
-                                            "{0} and {1} as revoked certs. "
-                                            "Output was:\n{2}".format(rev1_h,
-                                            rev2_h, self.output))
+        app1 = os.path.join(cert_dir, "ch4_ta1_cert.pem")
+        app2 = os.path.join(cert_dir, "ch1_ta3_cert.pem")
+        rev1 = os.path.join(cert_dir, "ch1_ta4_cert.pem")
+        rev2 = os.path.join(cert_dir, "ch1_ta5_cert.pem")
+        app1_h = self.calc_pem_hash(app1)
+        app2_h = self.calc_pem_hash(app2)
+        rev1_h = self.calc_pem_hash(rev1)
+        rev2_h = self.calc_pem_hash(rev2)
+        self.pkg(
+            "set-publisher -O {0} "
+            "--approve-ca-cert {1} "
+            "--approve-ca-cert {2} --revoke-ca-cert {3} "
+            "--revoke-ca-cert {4} test2 ".format(
+                self.dcs[2].get_repo_url(), app1, app2, rev1_h, rev2_h
+            )
+        )
+        self.pkg("publisher test2")
+        r1 = "         Approved CAs: {0}"
+        r2 = "                     : {0}"
+        r3 = "          Revoked CAs: {0}"
+        ls = self.output.splitlines()
+        found_approved = False
+        found_revoked = False
+        for i in range(0, len(ls)):
+            if "Approved CAs" in ls[i]:
+                found_approved = True
+                if not (
+                    (
+                        r1.format(app1_h) == ls[i]
+                        and r2.format(app2_h) == ls[i + 1]
+                    )
+                    or (
+                        r1.format(app2_h) == ls[i]
+                        and r2.format(app1_h) == ls[i + 1]
+                    )
+                ):
+                    raise RuntimeError(
+                        "Expected to see "
+                        "{0} and {1} as approved certs. "
+                        "Output was:\n{2}".format(app1_h, app2_h, self.output)
+                    )
+            elif "Revoked CAs" in ls[i]:
+                found_approved = True
+                if not (
+                    (
+                        r3.format(rev1_h) == ls[i]
+                        and r2.format(rev2_h) == ls[i + 1]
+                    )
+                    or (
+                        r3.format(rev2_h) == ls[i]
+                        and r2.format(rev1_h) == ls[i + 1]
+                    )
+                ):
+                    raise RuntimeError(
+                        "Expected to see "
+                        "{0} and {1} as revoked certs. "
+                        "Output was:\n{2}".format(rev1_h, rev2_h, self.output)
+                    )
 
-        def test_new_publisher_ca_certs_no_refresh(self):
-                """Check that approving and revoking CA certs is reflected in
-                the output of pkg publisher and that setting the CA certs when
-                setting a new publisher works correctly."""
+    def test_new_publisher_ca_certs_no_refresh(self):
+        """Check that approving and revoking CA certs is reflected in
+        the output of pkg publisher and that setting the CA certs when
+        setting a new publisher works correctly."""
 
-                cert_dir = os.path.join(self.ro_data_root,
-                    "signing_certs", "produced", "chain_certs")
+        cert_dir = os.path.join(
+            self.ro_data_root, "signing_certs", "produced", "chain_certs"
+        )
 
-                app1 = os.path.join(cert_dir, "ch3_ta1_cert.pem")
-                app2 = os.path.join(cert_dir, "ch1_ta3_cert.pem")
-                rev1 = os.path.join(cert_dir, "ch1_ta4_cert.pem")
-                rev2 = os.path.join(cert_dir, "ch1_ta5_cert.pem")
-                app1_h = self.calc_pem_hash(app1)
-                app2_h = self.calc_pem_hash(app2)
-                rev1_h = self.calc_pem_hash(rev1)
-                rev2_h = self.calc_pem_hash(rev2)
-                self.pkg("set-publisher -O {0} --no-refresh "
-                    "--approve-ca-cert {1} "
-                    "--approve-ca-cert {2} --revoke-ca-cert {3} "
-                    "--revoke-ca-cert {4} test2 ".format(self.dcs[2].get_repo_url(),
-                    app1, app2, rev1_h, rev2_h))
-                self.pkg("publisher test2")
-                r1 = "         Approved CAs: {0}"
-                r2 = "                     : {0}"
-                r3 = "          Revoked CAs: {0}"
-                ls = self.output.splitlines()
-                found_approved = False
-                found_revoked = False
-                for i in range(0, len(ls)):
-                        if "Approved CAs" in ls[i]:
-                                found_approved = True
-                                if not ((r1.format(app1_h) == ls[i] and
-                                    r2.format(app2_h) == ls[i+1]) or \
-                                    (r1.format(app2_h) == ls[i] and
-                                    r2.format(app1_h) == ls[i+1])):
-                                        raise RuntimeError("Expected to see "
-                                            "{0} and {1} as approved certs. "
-                                            "Output was:\n{2}".format(app1_h,
-                                            app2_h, self.output))
-                        elif "Revoked CAs" in ls[i]:
-                                found_approved = True
-                                if not ((r3.format(rev1_h) == ls[i] and
-                                    r2.format(rev2_h) == ls[i+1]) or \
-                                    (r3.format(rev2_h) == ls[i] and
-                                    r2.format(rev1_h) == ls[i+1])):
-                                        raise RuntimeError("Expected to see "
-                                            "{0} and {1} as revoked certs. "
-                                            "Output was:\n{2}".format(rev1_h,
-                                            rev2_h, self.output))
+        app1 = os.path.join(cert_dir, "ch3_ta1_cert.pem")
+        app2 = os.path.join(cert_dir, "ch1_ta3_cert.pem")
+        rev1 = os.path.join(cert_dir, "ch1_ta4_cert.pem")
+        rev2 = os.path.join(cert_dir, "ch1_ta5_cert.pem")
+        app1_h = self.calc_pem_hash(app1)
+        app2_h = self.calc_pem_hash(app2)
+        rev1_h = self.calc_pem_hash(rev1)
+        rev2_h = self.calc_pem_hash(rev2)
+        self.pkg(
+            "set-publisher -O {0} --no-refresh "
+            "--approve-ca-cert {1} "
+            "--approve-ca-cert {2} --revoke-ca-cert {3} "
+            "--revoke-ca-cert {4} test2 ".format(
+                self.dcs[2].get_repo_url(), app1, app2, rev1_h, rev2_h
+            )
+        )
+        self.pkg("publisher test2")
+        r1 = "         Approved CAs: {0}"
+        r2 = "                     : {0}"
+        r3 = "          Revoked CAs: {0}"
+        ls = self.output.splitlines()
+        found_approved = False
+        found_revoked = False
+        for i in range(0, len(ls)):
+            if "Approved CAs" in ls[i]:
+                found_approved = True
+                if not (
+                    (
+                        r1.format(app1_h) == ls[i]
+                        and r2.format(app2_h) == ls[i + 1]
+                    )
+                    or (
+                        r1.format(app2_h) == ls[i]
+                        and r2.format(app1_h) == ls[i + 1]
+                    )
+                ):
+                    raise RuntimeError(
+                        "Expected to see "
+                        "{0} and {1} as approved certs. "
+                        "Output was:\n{2}".format(app1_h, app2_h, self.output)
+                    )
+            elif "Revoked CAs" in ls[i]:
+                found_approved = True
+                if not (
+                    (
+                        r3.format(rev1_h) == ls[i]
+                        and r2.format(rev2_h) == ls[i + 1]
+                    )
+                    or (
+                        r3.format(rev2_h) == ls[i]
+                        and r2.format(rev1_h) == ls[i + 1]
+                    )
+                ):
+                    raise RuntimeError(
+                        "Expected to see "
+                        "{0} and {1} as revoked certs. "
+                        "Output was:\n{2}".format(rev1_h, rev2_h, self.output)
+                    )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_rebuild_index.py
+++ b/src/tests/cli/t_pkg_rebuild_index.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2021, Oracle and/or its affiliates.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -33,55 +34,56 @@ import shutil
 
 
 class TestPkgRebuildIndex(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        example_pkg11 = """
+    example_pkg11 = """
             open example_pkg@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path11
             close """
 
-        misc_files = ["tmp/example_file"]
+    misc_files = ["tmp/example_file"]
 
-        def setUp(self):
-           # This test suite needs actual depots.
-           pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
-           self.make_misc_files(self.misc_files)
+    def setUp(self):
+        # This test suite needs actual depots.
+        pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
+        self.make_misc_files(self.misc_files)
 
-           self.durl1 = self.dcs[1].get_depot_url()
-           self.pkgsend_bulk(self.durl1, self.example_pkg11)
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.pkgsend_bulk(self.durl1, self.example_pkg11)
 
-        def test_rebuild_index_bad_opts(self):
-                """Test pkg with bad options."""
+    def test_rebuild_index_bad_opts(self):
+        """Test pkg with bad options."""
 
-                self.image_create(self.rurl)
-                self.pkg("rebuild-index -@", exit=2)
-                self.pkg("rebuild-index foo", exit=2)
-                self.pkg("rebuild-index --", exit=2)
+        self.image_create(self.rurl)
+        self.pkg("rebuild-index -@", exit=2)
+        self.pkg("rebuild-index foo", exit=2)
+        self.pkg("rebuild-index --", exit=2)
 
-        def test_rebuild_index_bad_perms(self):
-                """Testing for bug 4570."""
+    def test_rebuild_index_bad_perms(self):
+        """Testing for bug 4570."""
 
-                self.image_create(self.rurl)
-                self.pkg("rebuild-index")
-                self.pkg("rebuild-index", exit=1, su_wrap=True)
+        self.image_create(self.rurl)
+        self.pkg("rebuild-index")
+        self.pkg("rebuild-index", exit=1, su_wrap=True)
 
-        def test_rebuild_index_stale_index_old_dir(self):
-                """Test rebuild-index for a stale index.old dir."""
+    def test_rebuild_index_stale_index_old_dir(self):
+        """Test rebuild-index for a stale index.old dir."""
 
-                self.image_create(self.rurl)
-                self.pkg("install example_pkg@1.1")
+        self.image_create(self.rurl)
+        self.pkg("install example_pkg@1.1")
 
-                index_dir = os.path.join(self.img_path(), "var", "pkg",
-                            "cache", "index")
-                shutil.copytree(index_dir, index_dir + ".old")
+        index_dir = os.path.join(
+            self.img_path(), "var", "pkg", "cache", "index"
+        )
+        shutil.copytree(index_dir, index_dir + ".old")
 
-                self.pkg("rebuild-index")
+        self.pkg("rebuild-index")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_refresh.py
+++ b/src/tests/cli/t_pkg_refresh.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import hashlib
@@ -42,764 +43,763 @@ from pkg.client.debugvalues import DebugValues
 
 
 class TestPkgRefreshMulti(pkg5unittest.ManyDepotTestCase):
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
-
-        foo1 = """
+    foo1 = """
             open foo@1,5.11-0
             close """
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             close """
 
-        foo12 = """
+    foo12 = """
             open foo@1.2,5.11-0
             close """
 
-        foo121 = """
+    foo121 = """
             open foo@1.2.1,5.11-0
             close """
 
-        food12 = """
+    food12 = """
             open food@1.2,5.11-0
             close """
 
-        cache10 = """
+    cache10 = """
             open cache@1.0
             add file tmp/cat mode=0444 owner=root group=bin path=/etc/cat
             close """
 
-        misc_files = ["tmp/cat"]
-
-        def setUp(self):
-                # This test suite needs actual depots.
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test1", "test1"], start_depots=True)
-                self.make_misc_files(self.misc_files)
-
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.durl3 = self.dcs[3].get_depot_url()
-
-                # An empty repository for test1 to enable metadata tests
-                # to continue to work as expected.
-                self.durl4 = self.dcs[4].get_depot_url()
-
-        def reduce_spaces(self, string):
-                """Reduce runs of spaces down to a single space."""
-                return re.sub(" +", " ", string)
-
-        def get_op_entries(self, dc, op, op_ver, method="GET"):
-                """Scan logpath for a specific depotcontroller looking for
-                access log entries for an operation.  Returns a list of request
-                URIs for each log entry found for the operation in chronological
-                order."""
-
-                # 127.0.0.1 - - [15/Oct/2009:00:15:38]
-                # "GET [/<pub>]/catalog/1/catalog.base.C HTTP/1.1" 200 189 ""
-                # "pkg/b1f63b112bff+ (sunos i86pc; 5.11 snv_122; none; pkg)"
-                entry_comps = [
-                    r"(?P<host>\S+)",
-                    r"\S+",
-                    r"(?P<user>\S+)",
-                    r"\[(?P<request_time>.+)\]",
-                    r'"(?P<request>.+)"',
-                    r"(?P<response_status>[0-9]+)",
-                    r"(?P<content_length>\S+)",
-                    r'"(?P<referer>.*)"',
-                    r'"(?P<user_agent>.*)"',
-                ]
-                log_entry = re.compile(r"\s+".join(entry_comps) + r"\s*\Z")
-
-                logpath = dc.get_logpath()
-                self.debug("check for operation entries in {0}".format(logpath))
-                logfile = open(logpath, "r")
-                entries = []
-                for line in logfile.readlines():
-                        m = log_entry.search(line)
-                        if not m:
-                                continue
-
-                        host, user, req_time, req, status, clen, ref, agent = \
-                            m.groups()
-
-                        req_method, uri, protocol = req.split(" ")
-                        if req_method != method:
-                                continue
-
-                        # Strip publisher from URI for this part.
-                        uri = uri.replace("/test1", "")
-                        uri = uri.replace("/test2", "")
-                        req_parts = uri.strip("/").split("/", 3)
-                        if req_parts[0] != op:
-                                continue
-
-                        if req_parts[1] != op_ver:
-                                continue
-                        entries.append(uri)
-                logfile.close()
-                self.debug("Found {0} for {1} /{2}/{3}/".format(entries, method, op,
-                    op_ver))
-                return entries
-
-        def checkAnswer(self, expected, actual):
-                self.assertEqualDiff(
-                    self.reduce_spaces(expected).splitlines().sort(),
-                    self.reduce_spaces(actual).splitlines().sort())
-
-        def test_refresh_cli_options(self):
-                """Test refresh and options."""
-
-                durl = self.dcs[1].get_depot_url()
-                self.image_create(durl, prefix="test1")
-
-                self.pkg("refresh")
-                self.pkg("refresh --full")
-                self.pkg("refresh -q")
-                self.pkg("refresh -F", exit=2)
-
-        def test_general_refresh(self):
-                self.image_create(self.durl1, prefix="test1")
-                self.pkg("set-publisher -O " + self.durl2 + " test2")
-                self.pkgsend_bulk(self.durl1, self.foo10)
-                self.pkgsend_bulk(self.durl2, self.foo12)
-
-                # This should fail as the publisher was just updated seconds
-                # ago, and not enough time has passed yet for the client to
-                # contact the repository to check for updates.
-                self.pkg("list -aH pkg:/foo", exit=1)
-
-                # This should succeed as a full refresh was requested, which
-                # ignores the update check interval the client normally uses
-                # to determine whether or not to contact the repository to
-                # check for updates.
-                self.pkg("refresh --full")
-                self.pkg("list -aH pkg:/foo")
-
-                expected = \
-                    "foo 1.0-0 ---\n" + \
-                    "foo (test2) 1.2-0 ---\n"
-                self.checkAnswer(expected, self.output)
-
-        def test_specific_refresh(self):
-                self.image_create(self.durl1, prefix="test1")
-                self.pkg("set-publisher -O " + self.durl2 + " test2")
-                self.pkgsend_bulk(self.durl1, self.foo10)
-                self.pkgsend_bulk(self.durl2, self.foo12)
-
-                # This should fail since only a few seconds have passed since
-                # the publisher's metadata was last checked, and so the catalog
-                # will not yet reflect the last published package.
-                self.pkg("list -aH pkg:/foo@1,5.11-0", exit=1)
-
-                # This should succeed since a refresh is explicitly performed,
-                # and so the catalog will reflect the last published package.
-                self.pkg("refresh test1")
-                self.pkg("list -aH pkg:/foo@1,5.11-0")
-
-                expected = \
-                    "foo 1.0-0 ---\n"
-                self.checkAnswer(expected, self.output)
-
-                # This should succeed since a refresh is explicitly performed,
-                # and so the catalog will reflect the last published package.
-                self.pkg("refresh test2")
-                self.pkg("list -aH pkg:/foo")
-                expected = \
-                    "foo 1.0-0 ---\n" + \
-                    "foo (test2) 1.2-0 ---\n"
-                self.checkAnswer(expected, self.output)
-                self.pkg("refresh unknownAuth", exit=1)
-                self.pkg("set-publisher -P test2")
-                self.pkg("list -aH pkg:/foo")
-                expected = \
-                    "foo (test1) 1.0-0 ---\n" + \
-                    "foo 1.2-0 ---\n"
-                self.pkgsend_bulk(self.durl1, self.foo11)
-                self.pkgsend_bulk(self.durl2, self.foo11)
-
-                # This should succeed since an explicit refresh is performed,
-                # and so the catalog will reflect the last published package.
-                self.pkg("refresh test1 test2")
-                self.pkg("list -aHf pkg:/foo")
-                expected = \
-                    "foo (test1) 1.0-0 ---\n" + \
-                    "foo (test1) 1.1-0 ---\n" + \
-                    "foo 1.1-0 ---\n" + \
-                    "foo 1.2-0 ---\n"
-                self.checkAnswer(expected, self.output)
-
-        def test_set_publisher_induces_full_refresh(self):
-                self.pkgsend_bulk(self.durl3, self.foo11)
-                self.pkgsend_bulk(self.durl3, self.foo10)
-                self.pkgsend_bulk(self.durl1, self.foo10)
-                self.pkgsend_bulk(self.durl2, self.foo11)
-                self.image_create(self.durl1, prefix="test1")
-                self.pkg("list -aH pkg:/foo")
-                expected = \
-                    "foo 1.0-0 ---\n"
-                self.checkAnswer(expected, self.output)
-
-                # If a privileged user requests this, it should fail since
-                # publisher metadata will have been refreshed, but it will
-                # be the metadata from a repository that does not contain
-                # any package metadata for this publisher.
-                self.pkg("set-publisher -O " + self.durl4 + " test1")
-                self.pkg("list --no-refresh -avH pkg:/foo@1.0", exit=1)
-                self.pkg("list --no-refresh -avH pkg:/foo@1.1", exit=1)
-
-                # If a privileged user requests this, it should succeed since
-                # publisher metadata will have been refreshed, and contains
-                # package data for the publisher.
-                self.pkg("set-publisher -O " + self.durl3 + " test1")
-                self.pkg("list --no-refresh -afH pkg:/foo")
-                expected = \
-                    "foo 1.0-0 ---\n" \
-                    "foo 1.1-0 ---\n"
-                self.checkAnswer(expected, self.output)
-
-        def test_set_publisher_induces_delayed_full_refresh(self):
-                self.pkgsend_bulk(self.durl3, self.foo11)
-                self.pkgsend_bulk(self.durl2, self.foo11)
-                self.pkgsend_bulk(self.durl1, self.foo10)
-                self.image_create(self.durl1, prefix="test1")
-                self.pkg("list -aH pkg:/foo")
-                expected = \
-                    "foo 1.0-0 ---\n"
-                self.checkAnswer(expected, self.output)
-                self.dcs[2].stop()
-                self.pkg("set-publisher --no-refresh -O " + self.durl3 + " test1")
-                self.dcs[2].start()
-
-                # This should fail when listing all known packages, and running
-                # as an unprivileged user since the publisher's metadata can't
-                # be updated.
-                self.pkg("list -aH pkg:/foo@1.1", su_wrap=True, exit=1)
-
-                # This should fail when listing all known packages, and running
-                # as a privileged user since --no-refresh was specified.
-                self.pkg("list -aH --no-refresh pkg:/foo@1.1", exit=1)
-
-                # This should succeed when listing all known packages, and
-                # running as a privileged user since the publisher's metadata
-                # will automatically be updated, and the repository contains
-                # package data for the publisher.
-                self.pkg("list -aH pkg:/foo@1.1")
-                expected = \
-                    "foo 1.1-0 ---\n"
-                self.checkAnswer(expected, self.output)
-
-                # This should fail when listing all known packages, and
-                # running as a privileged user since the publisher's metadata
-                # will automatically be updated, but the repository doesn't
-                # contain any data for the publisher.
-                self.dcs[2].stop()
-                self.pkg("set-publisher -O " + self.durl1 + " test1")
-                self.pkg("set-publisher --no-refresh -O " + self.durl2 + " test1")
-                self.dcs[2].start()
-                self.pkg("list -aH --no-refresh pkg:/foo@1.1", exit=1)
-
-        def test_refresh_certificate_problems(self):
-                """Verify that an invalid or inaccessible certificate does not
-                cause unexpected failure."""
-
-                self.image_create(self.durl1, prefix="test1")
-
-                key_path = os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem")
-                cert_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
-
-                self.pkg("set-publisher --no-refresh -O https://{0}1 test1".format(
-                    self.bogus_url))
-                self.pkg("set-publisher --no-refresh -c {0} test1".format(cert_path))
-                self.pkg("set-publisher --no-refresh -k {0} test1".format(key_path))
-
-
-                # This test relies on using the same implementation used in
-                # image.py __store_publisher_ssl() which sets the paths to the
-                # SSL keys/certs.
-                img_key_path = os.path.join(self.img_path(), "var", "pkg",
-                    "ssl", pkg.misc.get_data_digest(key_path,
-                    hash_func=hashlib.sha1)[0])
-                img_cert_path = os.path.join(self.img_path(), "var", "pkg",
-                    "ssl", pkg.misc.get_data_digest(cert_path,
-                    hash_func=hashlib.sha1)[0])
-
-                # Make the cert/key unreadable by unprivileged users.
-                os.chmod(img_key_path, 0000)
-                os.chmod(img_cert_path, 0000)
-
-                # Verify that an inaccessible certificate results in a normal
-                # failure when attempting to refresh.
-                self.pkg("refresh test1", su_wrap=True, exit=1)
-
-                # Verify that an invalid certificate results in a normal failure
-                # when attempting to refresh.
-                open(img_key_path, "wb").close()
-                open(img_cert_path, "wb").close()
-                self.pkg("refresh test1", exit=1)
-
-        def __get_cache_entries(self, dc):
-                """Returns any HTTP cache headers found."""
-
-                entries = []
-                for hdr in ("CACHE-CONTROL", "PRAGMA"):
-                        logpath = dc.get_logpath()
-                        self.debug("check for HTTP cache headers in {0}".format(
-                            logpath))
-                        logfile = open(logpath, "r")
-                        for line in logfile.readlines():
-                                spos = line.find(hdr)
-                                if spos > -1:
-                                        self.debug("line: {0}".format(line))
-                                        self.debug("hdr: {0} spos: {1}".format(hdr, spos))
-                                        spos += len(hdr) + 1
-                                        l = line[spos:].strip()
-                                        l = l.strip("()")
-                                        self.debug("l: {0}".format(l))
-                                        if l:
-                                                entries.append({ hdr: l })
-                        logfile.close()
-                return entries
-
-        def test_catalog_v1(self):
-                """Verify that refresh works as expected for publishers that
-                have repositories that offer catalog/1/ in exceptional error
-                cases."""
-
-                dc = self.dcs[1]
-                self.pkgsend_bulk(self.durl1, self.foo10)
-
-                # First, verify that full retrieval works.
-                self.image_create(self.durl1, prefix="test1")
-
-                self.pkg("list -aH pkg:/foo@1.0")
-
-                # Only entries for the full catalog files should exist.
-                expected = [
-                    "/catalog/1/catalog.attrs",
-                    "/catalog/1/catalog.base.C"
-                ]
-                returned = self.get_op_entries(dc, "catalog", "1")
-                self.assertEqual(returned, expected)
-
-                # Next, verify that a "normal" incremental update works as
-                # expected when the catalog has changed.
-                self.pkgsend_bulk(self.durl1, self.foo11)
-
-                self.pkg("list -aH")
-                self.pkg("list -aH pkg:/foo@1.0")
-                self.pkg("list -aH pkg:/foo@1.1", exit=1)
-
-                self.pkg("refresh")
-                self.pkg("list -aH pkg:/foo@1.1")
-
-                # A bit hacky, but load the repository's catalog directly
-                # and then get the list of updates files it has created.
-                repo = dc.get_repo()
-                v1_cat = repo.get_catalog("test1")
-                update = list(v1_cat.updates.keys())[-1]
-
-                # All of the entries from the previous operations, and then
-                # entries for the catalog attrs file, and one catalog update
-                # file for the incremental update should be returned.
-                expected += [
-                    "/catalog/1/catalog.attrs",
-                    "/catalog/1/{0}".format(update)
-                ]
-                returned = self.get_op_entries(dc, "catalog", "1")
-                self.assertEqual(returned, expected)
-
-                # Next, verify that a "normal" incremental update works as
-                # expected when the catalog hasn't changed.
-                self.pkg("refresh test1")
-
-                # All of the entries from the previous operations, and then
-                # an entry for the catalog attrs file should be returned.
-                expected += [
-                    "/catalog/1/catalog.attrs"
-                ]
-                returned = self.get_op_entries(dc, "catalog", "1")
-                self.assertEqual(returned, expected)
-
-                # Next, verify that a "full" refresh after incrementals works
-                # as expected.
-                self.pkg("refresh --full test1")
-
-                # All of the entries from the previous operations, and then
-                # entries for each part of the catalog should be returned.
-                expected += ["/catalog/1/catalog.attrs"]
-                expected += ["/catalog/1/{0}".format(p) for p in v1_cat.parts.keys()]
-                returned = self.get_op_entries(dc, "catalog", "1")
-                self.assertEqual(returned, expected)
-
-                # Next, verify that rebuilding the repository's catalog induces
-                # a full refresh.  Note that doing this wipes out the contents
-                # of the log so far, so expected needs to be reset and the
-                # catalog reloaded.
-                expected = []
-                repo = dc.get_repo()
-                v1_cat = repo.get_catalog("test1")
-
-                dc.stop()
-                dc.set_rebuild()
-                dc.start()
-                dc.set_norebuild()
-
-                self.pkg("refresh")
-
-                # The catalog.attrs will be retrieved twice due to the first
-                # request's incremental update failure.
-                expected += ["/catalog/1/catalog.attrs"]
-                expected += ["/catalog/1/catalog.attrs"]
-                expected += ["/catalog/1/{0}".format(p) for p in v1_cat.parts.keys()]
-                returned = self.get_op_entries(dc, "catalog", "1")
-                self.assertEqual(returned, expected)
-
-                # Next, verify that if the client receives an incremental update
-                # but the catalog is then rolled back to an earlier version
-                # (think restoration of repository from backup) that the client
-                # will induce a full refresh.
-
-                # Preserve a copy of the existing repository.
-                tdir = tempfile.mkdtemp(dir=self.test_root)
-                trpath = os.path.join(tdir, os.path.basename(dc.get_repodir()))
-                shutil.copytree(dc.get_repodir(), trpath)
-
-                # Publish a new package.
-                self.pkgsend_bulk(self.durl1, self.foo12)
-
-                # Refresh to get an incremental update, and verify it worked.
-                self.pkg("refresh")
-                update = list(v1_cat.updates.keys())[-1]
-                expected += [
-                    "/catalog/1/catalog.attrs",
-                    "/catalog/1/{0}".format(update)
-                ]
-                repo = dc.get_repo()
-                v1_cat = repo.get_catalog("test1")
-
-                # Stop the depot server and put the old repository data back.
-                dc.stop()
-                shutil.rmtree(dc.get_repodir())
-                shutil.move(trpath, dc.get_repodir())
-                dc.start()
-                expected = []
-                repo = dc.get_repo()
-                v1_cat = repo.get_catalog("test1")
-
-                # Now verify that a refresh induces a full retrieval.  The
-                # catalog.attrs file will be retrieved twice due to the
-                # failure case.
-                self.pkg("refresh")
-                expected += ["/catalog/1/catalog.attrs"]
-                expected += ["/catalog/1/catalog.attrs"]
-                expected += ["/catalog/1/{0}".format(p) for p in v1_cat.parts.keys()]
-                returned = self.get_op_entries(dc, "catalog", "1")
-                self.assertEqual(returned, expected)
-
-                # Next, verify that if the client receives an incremental update
-                # but the catalog is then rolled back to an earlier version
-                # (think restoration of repository from backup) and then an
-                # update that has already happened before is republished that
-                # the client will induce a full refresh.
-
-                # Preserve a copy of the existing repository.
-                trpath = os.path.join(tdir, os.path.basename(dc.get_repodir()))
-                shutil.copytree(dc.get_repodir(), trpath)
-
-                # Publish a new package.
-                self.pkgsend_bulk(self.durl1, self.foo12)
-                repo = dc.get_repo()
-                v1_cat = repo.get_catalog("test1")
-
-                # Refresh to get an incremental update, and verify it worked.
-                self.pkg("refresh")
-                update = list(v1_cat.updates.keys())[-1]
-                expected += [
-                    "/catalog/1/catalog.attrs",
-                    "/catalog/1/{0}".format(update)
-                ]
-                repo = dc.get_repo()
-                v1_cat = repo.get_catalog("test1")
-
-                # Stop the depot server and put the old repository data back.
-                dc.stop()
-                shutil.rmtree(dc.get_repodir())
-                shutil.move(trpath, dc.get_repodir())
-                dc.start()
-                expected = []
-
-                # Re-publish the new package.  This causes the same catalog
-                # entry to exist, but at a different point in time in the
-                # update logs.
-                self.pkgsend_bulk(self.durl1, self.foo12)
-                repo = dc.get_repo()
-                v1_cat = repo.get_catalog("test1")
-                update = list(v1_cat.updates.keys())[-1]
-
-                # Now verify that a refresh induces a full retrieval.  The
-                # catalog.attrs file will be retrieved twice due to the
-                # failure case, and a retrieval of the incremental update
-                # file that failed to be applied should also be seen.
-                self.pkg("refresh")
-                expected += [
-                    "/catalog/1/catalog.attrs",
-                    "/catalog/1/{0}".format(update),
-                    "/catalog/1/catalog.attrs",
-                ]
-                expected += ["/catalog/1/{0}".format(p) for p in v1_cat.parts.keys()]
-                returned = self.get_op_entries(dc, "catalog", "1")
-                self.assertEqual(returned, expected)
-
-                # Now verify that a full refresh will fail if the catalog parts
-                # retrieved don't match the catalog attributes.  Do this by
-                # saving a copy of the current repository catalog, publishing a
-                # new package, putting back the old catalog parts and then
-                # attempting a full refresh.  After that, verify the relevant
-                # log entries exist.
-                dc.stop()
-                dc.set_debug_feature("headers")
-                dc.start()
-
-                old_cat = os.path.join(self.test_root, "old-catalog")
-                cat_root = v1_cat.meta_root
-                shutil.copytree(v1_cat.meta_root, old_cat)
-                self.pkgsend_bulk(self.durl1, self.foo121)
-                v1_cat = catalog.Catalog(meta_root=cat_root, read_only=True)
-                for p in v1_cat.parts.keys():
-                        # Overwrite the existing parts with empty ones.
-                        part = catalog.CatalogPart(p, meta_root=cat_root)
-                        part.destroy()
-
-                        part = catalog.CatalogPart(p, meta_root=cat_root)
-                        part.save()
-
-                self.pkg("refresh --full", exit=1)
-                expected = [
-                    "/catalog/1/catalog.attrs",
-                    "/catalog/1/catalog.base.C",
-                ]
-                returned = self.get_op_entries(dc, "catalog", "1")
-                self.assertEqual(returned, expected)
-
-                entries = self.__get_cache_entries(dc)
-                expected = [
-                    { "CACHE-CONTROL": "no-cache" },
-                    { "CACHE-CONTROL": "no-cache" },
-                    { "PRAGMA": "no-cache" },
-                    { "PRAGMA": "no-cache" }
-                ]
-                self.assertEqualDiff(entries, expected)
-
-                # Next, verify that a refresh without --full but that is
-                # implicity a full because the catalog hasn't already been
-                # retrieved is handled gracefully and the expected log
-                # entries are present.
-                dc.stop()
-                dc.start()
-                self.pkg("refresh", exit=1)
-                expected = [
-                    "/catalog/1/catalog.attrs",
-                    "/catalog/1/catalog.base.C",
-                    "/catalog/1/catalog.attrs",
-                    "/catalog/1/catalog.base.C",
-                ]
-                returned = self.get_op_entries(dc, "catalog", "1")
-                self.assertEqual(returned, expected)
-
-                entries = self.__get_cache_entries(dc)
-                # The first two requests should have not had any cache
-                # headers attached, while the last two should have
-                # triggered transport's revalidation logic.
-                expected = [
-                    { "CACHE-CONTROL": "max-age=0" },
-                    { "CACHE-CONTROL": "max-age=0" },
-                ]
-                self.assertEqualDiff(entries, expected)
-
-                # Next, purposefully corrupt the catalog.attrs file in the
-                # repository and attempt a refresh.  The client should fail
-                # gracefully.
-                f = open(os.path.join(v1_cat.meta_root, "catalog.attrs"), "w")
-                f.write("INVALID")
-                f.close()
-                self.pkg("refresh", exit=1)
-
-                # Finally, restore the catalog and verify the client can
-                # refresh.
-                shutil.rmtree(v1_cat.meta_root)
-                shutil.copytree(old_cat, v1_cat.meta_root)
-                self.pkg("refresh")
-
-        def __gen_expected(self, count):
-                """Generate expected header fields result."""
-                expected = []
-                for i in range(count):
-                        expected.append({ "CACHE-CONTROL": "no-cache" })
-                for i in range(count):
-                        expected.append({ "PRAGMA": "no-cache" })
-                return expected
-
-        def test_ignore_network_cache_1(self):
-                """Verify that --no-network-cache option works for transport
-                module."""
-
-                dc = self.dcs[1]
-                self.pkgsend_bulk(self.durl1, self.cache10)
-
-                # First, verify refresh triggers expected cache headers when
-                # retrieving catalog.
-                self.image_create(self.durl1, prefix="test1")
-                dc.stop()
-                dc.set_debug_feature("headers")
-                dc.start()
-                self.pkg("--no-network-cache refresh")
-                entries = self.__get_cache_entries(dc)
-                expected = self.__gen_expected(2)
-                self.assertEqualDiff(entries, expected)
-
-                # Second, verify contents triggers expected cache headers when
-                # fetch manifest.
-                self.pkg("--no-network-cache contents -rm cache")
-                entries = self.__get_cache_entries(dc)
-                expected = self.__gen_expected(4)
-                self.assertEqualDiff(entries, expected)
-
-                # Third, verify install triggers expected cache headers.
-                self.pkg("--no-network-cache install cache")
-                entries = self.__get_cache_entries(dc)
-                expected = self.__gen_expected(7)
-                self.assertEqualDiff(entries, expected)
-
-        def test_ignore_network_cache_2(self):
-                """Verify that global setting client_no_network_cache works for
-                transport module."""
-
-                dc = self.dcs[1]
-                self.pkgsend_bulk(self.durl1, self.cache10)
-
-                # Verify refresh triggers expected cache headers when
-                # retrieving catalog.
-                api_obj = self.image_create(self.durl1, prefix="test1")
-                global_settings.client_no_network_cache = True
-                dc.stop()
-                dc.set_debug_feature("headers")
-                dc.start()
-                api_obj.refresh()
-                entries = self.__get_cache_entries(dc)
-                expected = self.__gen_expected(2)
-                self.assertEqualDiff(entries, expected)
-
-                # Verify install triggers expected cache headers.
-                self._api_install(api_obj, ["cache"])
-                entries = self.__get_cache_entries(dc)
-                expected = self.__gen_expected(6)
-                self.assertEqualDiff(entries, expected)
-
-        def test_ignore_network_cache_3(self):
-                """Verify that debug value no_network_cache works for
-                transport module."""
-
-                dc = self.dcs[1]
-                self.pkgsend_bulk(self.durl1, self.cache10)
-
-                # Verify refresh triggers expected cache headers when
-                # retrieving catalog.
-                api_obj = self.image_create(self.durl1, prefix="test1")
-                DebugValues["no_network_cache"] = "true"
-                dc.stop()
-                dc.set_debug_feature("headers")
-                dc.start()
-                api_obj.refresh()
-                entries = self.__get_cache_entries(dc)
-                expected = self.__gen_expected(2)
-                self.assertEqualDiff(entries, expected)
-
-                # Verify install triggers expected cache headers.
-                self._api_install(api_obj, ["cache"])
-                entries = self.__get_cache_entries(dc)
-                expected = self.__gen_expected(6)
-                self.assertEqualDiff(entries, expected)
-
-                # Verify pkgrecv triggers expected cache headers.
-                rpth = tempfile.mkdtemp(dir=self.test_root)
-                self.pkgrecv("{0} -d {1} -D no_network_cache=true --raw"
-                    " cache".format(self.durl1, rpth))
-                entries = self.__get_cache_entries(dc)
-                expected = self.__gen_expected(11)
-                self.assertEqualDiff(entries, expected)
-
-        def test_multi_origin_refresh(self):
-                """Test that refresh behaves correctly if some origins of a
-                publisher are not reachable."""
-
-                # Use depots 1,3,4 which are all for pub 'test1'.
-                self.image_create(self.durl1, prefix="test1")
-                self.pkg("set-publisher -g {0} -g {1} test1".format(self.durl3,
-                    self.durl4))
-                self.pkgsend_bulk(self.durl1, self.foo10)
-                self.pkgsend_bulk(self.durl3, self.foo11)
-                self.pkgsend_bulk(self.durl4, self.foo12)
-                self.dcs[3].stop()
-                self.dcs[4].stop()
-
-                # Only packages in depot 1 should be visible,
-                # refresh should exit with partial success.
-                self.pkg("refresh", exit=3)
-                self.pkg("list -af foo@1.0")
-                self.pkg("list -af foo@1.1 foo@1.2", exit=1)
-
-                # Only packages in depot 1 and 2 should be visible,
-                # refresh should exit with partial success.
-                self.dcs[3].start()
-                self.pkg("refresh", exit=3)
-                self.pkg("list -af foo@1.0 foo@1.1")
-                self.pkg("list -af foo@1.2", exit=1)
-
-                # All packages should be visible, refresh should be complete.
-                self.dcs[4].start()
-                self.pkg("refresh")
-                self.pkg("list -af foo@1.0 foo@1.1 foo@1.2")
-
-        def test_implicit_multi_origin_refresh(self):
-                """Test that implicit refresh behaves correctly if some origins
-                of a publisher are not reachable."""
-
-                # Use depots 1,3,4 which are all for pub 'test1'.
-                self.image_create(self.durl1, prefix="test1")
-                self.pkg("set-publisher -g {0} -g {1} test1".format(self.durl3,
-                    self.durl4))
-                self.pkgsend_bulk(self.durl1, self.foo10)
-                self.pkgsend_bulk(self.durl3, self.foo11)
-                self.pkgsend_bulk(self.durl4, self.foo12)
-                self.dcs[3].stop()
-                self.dcs[4].stop()
-
-                # For now we can only install the version which is in the only
-                # online depot. However, the offline depots should not prevent
-                # us from upgrading to whatever is available.
-                self.pkg("install foo@latest")
-                self.pkg("list foo@1.0")
-
-                # When we enable additional depots, newer version of foo should
-                # become available for install without us having to refresh
-                # explicitly.
-                self.dcs[3].start()
-                self.pkg("install foo@latest")
-                self.pkg("list foo@1.1")
-
-                self.dcs[4].start()
-                self.pkg("install foo@latest")
-                self.pkg("list foo@1.2")
+    misc_files = ["tmp/cat"]
+
+    def setUp(self):
+        # This test suite needs actual depots.
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test1", "test2", "test1", "test1"], start_depots=True
+        )
+        self.make_misc_files(self.misc_files)
+
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.durl3 = self.dcs[3].get_depot_url()
+
+        # An empty repository for test1 to enable metadata tests
+        # to continue to work as expected.
+        self.durl4 = self.dcs[4].get_depot_url()
+
+    def reduce_spaces(self, string):
+        """Reduce runs of spaces down to a single space."""
+        return re.sub(" +", " ", string)
+
+    def get_op_entries(self, dc, op, op_ver, method="GET"):
+        """Scan logpath for a specific depotcontroller looking for
+        access log entries for an operation.  Returns a list of request
+        URIs for each log entry found for the operation in chronological
+        order."""
+
+        # 127.0.0.1 - - [15/Oct/2009:00:15:38]
+        # "GET [/<pub>]/catalog/1/catalog.base.C HTTP/1.1" 200 189 ""
+        # "pkg/b1f63b112bff+ (sunos i86pc; 5.11 snv_122; none; pkg)"
+        entry_comps = [
+            r"(?P<host>\S+)",
+            r"\S+",
+            r"(?P<user>\S+)",
+            r"\[(?P<request_time>.+)\]",
+            r'"(?P<request>.+)"',
+            r"(?P<response_status>[0-9]+)",
+            r"(?P<content_length>\S+)",
+            r'"(?P<referer>.*)"',
+            r'"(?P<user_agent>.*)"',
+        ]
+        log_entry = re.compile(r"\s+".join(entry_comps) + r"\s*\Z")
+
+        logpath = dc.get_logpath()
+        self.debug("check for operation entries in {0}".format(logpath))
+        logfile = open(logpath, "r")
+        entries = []
+        for line in logfile.readlines():
+            m = log_entry.search(line)
+            if not m:
+                continue
+
+            host, user, req_time, req, status, clen, ref, agent = m.groups()
+
+            req_method, uri, protocol = req.split(" ")
+            if req_method != method:
+                continue
+
+            # Strip publisher from URI for this part.
+            uri = uri.replace("/test1", "")
+            uri = uri.replace("/test2", "")
+            req_parts = uri.strip("/").split("/", 3)
+            if req_parts[0] != op:
+                continue
+
+            if req_parts[1] != op_ver:
+                continue
+            entries.append(uri)
+        logfile.close()
+        self.debug(
+            "Found {0} for {1} /{2}/{3}/".format(entries, method, op, op_ver)
+        )
+        return entries
+
+    def checkAnswer(self, expected, actual):
+        self.assertEqualDiff(
+            self.reduce_spaces(expected).splitlines().sort(),
+            self.reduce_spaces(actual).splitlines().sort(),
+        )
+
+    def test_refresh_cli_options(self):
+        """Test refresh and options."""
+
+        durl = self.dcs[1].get_depot_url()
+        self.image_create(durl, prefix="test1")
+
+        self.pkg("refresh")
+        self.pkg("refresh --full")
+        self.pkg("refresh -q")
+        self.pkg("refresh -F", exit=2)
+
+    def test_general_refresh(self):
+        self.image_create(self.durl1, prefix="test1")
+        self.pkg("set-publisher -O " + self.durl2 + " test2")
+        self.pkgsend_bulk(self.durl1, self.foo10)
+        self.pkgsend_bulk(self.durl2, self.foo12)
+
+        # This should fail as the publisher was just updated seconds
+        # ago, and not enough time has passed yet for the client to
+        # contact the repository to check for updates.
+        self.pkg("list -aH pkg:/foo", exit=1)
+
+        # This should succeed as a full refresh was requested, which
+        # ignores the update check interval the client normally uses
+        # to determine whether or not to contact the repository to
+        # check for updates.
+        self.pkg("refresh --full")
+        self.pkg("list -aH pkg:/foo")
+
+        expected = "foo 1.0-0 ---\n" + "foo (test2) 1.2-0 ---\n"
+        self.checkAnswer(expected, self.output)
+
+    def test_specific_refresh(self):
+        self.image_create(self.durl1, prefix="test1")
+        self.pkg("set-publisher -O " + self.durl2 + " test2")
+        self.pkgsend_bulk(self.durl1, self.foo10)
+        self.pkgsend_bulk(self.durl2, self.foo12)
+
+        # This should fail since only a few seconds have passed since
+        # the publisher's metadata was last checked, and so the catalog
+        # will not yet reflect the last published package.
+        self.pkg("list -aH pkg:/foo@1,5.11-0", exit=1)
+
+        # This should succeed since a refresh is explicitly performed,
+        # and so the catalog will reflect the last published package.
+        self.pkg("refresh test1")
+        self.pkg("list -aH pkg:/foo@1,5.11-0")
+
+        expected = "foo 1.0-0 ---\n"
+        self.checkAnswer(expected, self.output)
+
+        # This should succeed since a refresh is explicitly performed,
+        # and so the catalog will reflect the last published package.
+        self.pkg("refresh test2")
+        self.pkg("list -aH pkg:/foo")
+        expected = "foo 1.0-0 ---\n" + "foo (test2) 1.2-0 ---\n"
+        self.checkAnswer(expected, self.output)
+        self.pkg("refresh unknownAuth", exit=1)
+        self.pkg("set-publisher -P test2")
+        self.pkg("list -aH pkg:/foo")
+        expected = "foo (test1) 1.0-0 ---\n" + "foo 1.2-0 ---\n"
+        self.pkgsend_bulk(self.durl1, self.foo11)
+        self.pkgsend_bulk(self.durl2, self.foo11)
+
+        # This should succeed since an explicit refresh is performed,
+        # and so the catalog will reflect the last published package.
+        self.pkg("refresh test1 test2")
+        self.pkg("list -aHf pkg:/foo")
+        expected = (
+            "foo (test1) 1.0-0 ---\n"
+            + "foo (test1) 1.1-0 ---\n"
+            + "foo 1.1-0 ---\n"
+            + "foo 1.2-0 ---\n"
+        )
+        self.checkAnswer(expected, self.output)
+
+    def test_set_publisher_induces_full_refresh(self):
+        self.pkgsend_bulk(self.durl3, self.foo11)
+        self.pkgsend_bulk(self.durl3, self.foo10)
+        self.pkgsend_bulk(self.durl1, self.foo10)
+        self.pkgsend_bulk(self.durl2, self.foo11)
+        self.image_create(self.durl1, prefix="test1")
+        self.pkg("list -aH pkg:/foo")
+        expected = "foo 1.0-0 ---\n"
+        self.checkAnswer(expected, self.output)
+
+        # If a privileged user requests this, it should fail since
+        # publisher metadata will have been refreshed, but it will
+        # be the metadata from a repository that does not contain
+        # any package metadata for this publisher.
+        self.pkg("set-publisher -O " + self.durl4 + " test1")
+        self.pkg("list --no-refresh -avH pkg:/foo@1.0", exit=1)
+        self.pkg("list --no-refresh -avH pkg:/foo@1.1", exit=1)
+
+        # If a privileged user requests this, it should succeed since
+        # publisher metadata will have been refreshed, and contains
+        # package data for the publisher.
+        self.pkg("set-publisher -O " + self.durl3 + " test1")
+        self.pkg("list --no-refresh -afH pkg:/foo")
+        expected = "foo 1.0-0 ---\n" "foo 1.1-0 ---\n"
+        self.checkAnswer(expected, self.output)
+
+    def test_set_publisher_induces_delayed_full_refresh(self):
+        self.pkgsend_bulk(self.durl3, self.foo11)
+        self.pkgsend_bulk(self.durl2, self.foo11)
+        self.pkgsend_bulk(self.durl1, self.foo10)
+        self.image_create(self.durl1, prefix="test1")
+        self.pkg("list -aH pkg:/foo")
+        expected = "foo 1.0-0 ---\n"
+        self.checkAnswer(expected, self.output)
+        self.dcs[2].stop()
+        self.pkg("set-publisher --no-refresh -O " + self.durl3 + " test1")
+        self.dcs[2].start()
+
+        # This should fail when listing all known packages, and running
+        # as an unprivileged user since the publisher's metadata can't
+        # be updated.
+        self.pkg("list -aH pkg:/foo@1.1", su_wrap=True, exit=1)
+
+        # This should fail when listing all known packages, and running
+        # as a privileged user since --no-refresh was specified.
+        self.pkg("list -aH --no-refresh pkg:/foo@1.1", exit=1)
+
+        # This should succeed when listing all known packages, and
+        # running as a privileged user since the publisher's metadata
+        # will automatically be updated, and the repository contains
+        # package data for the publisher.
+        self.pkg("list -aH pkg:/foo@1.1")
+        expected = "foo 1.1-0 ---\n"
+        self.checkAnswer(expected, self.output)
+
+        # This should fail when listing all known packages, and
+        # running as a privileged user since the publisher's metadata
+        # will automatically be updated, but the repository doesn't
+        # contain any data for the publisher.
+        self.dcs[2].stop()
+        self.pkg("set-publisher -O " + self.durl1 + " test1")
+        self.pkg("set-publisher --no-refresh -O " + self.durl2 + " test1")
+        self.dcs[2].start()
+        self.pkg("list -aH --no-refresh pkg:/foo@1.1", exit=1)
+
+    def test_refresh_certificate_problems(self):
+        """Verify that an invalid or inaccessible certificate does not
+        cause unexpected failure."""
+
+        self.image_create(self.durl1, prefix="test1")
+
+        key_path = os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem")
+        cert_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
+
+        self.pkg(
+            "set-publisher --no-refresh -O https://{0}1 test1".format(
+                self.bogus_url
+            )
+        )
+        self.pkg("set-publisher --no-refresh -c {0} test1".format(cert_path))
+        self.pkg("set-publisher --no-refresh -k {0} test1".format(key_path))
+
+        # This test relies on using the same implementation used in
+        # image.py __store_publisher_ssl() which sets the paths to the
+        # SSL keys/certs.
+        img_key_path = os.path.join(
+            self.img_path(),
+            "var",
+            "pkg",
+            "ssl",
+            pkg.misc.get_data_digest(key_path, hash_func=hashlib.sha1)[0],
+        )
+        img_cert_path = os.path.join(
+            self.img_path(),
+            "var",
+            "pkg",
+            "ssl",
+            pkg.misc.get_data_digest(cert_path, hash_func=hashlib.sha1)[0],
+        )
+
+        # Make the cert/key unreadable by unprivileged users.
+        os.chmod(img_key_path, 0000)
+        os.chmod(img_cert_path, 0000)
+
+        # Verify that an inaccessible certificate results in a normal
+        # failure when attempting to refresh.
+        self.pkg("refresh test1", su_wrap=True, exit=1)
+
+        # Verify that an invalid certificate results in a normal failure
+        # when attempting to refresh.
+        open(img_key_path, "wb").close()
+        open(img_cert_path, "wb").close()
+        self.pkg("refresh test1", exit=1)
+
+    def __get_cache_entries(self, dc):
+        """Returns any HTTP cache headers found."""
+
+        entries = []
+        for hdr in ("CACHE-CONTROL", "PRAGMA"):
+            logpath = dc.get_logpath()
+            self.debug("check for HTTP cache headers in {0}".format(logpath))
+            logfile = open(logpath, "r")
+            for line in logfile.readlines():
+                spos = line.find(hdr)
+                if spos > -1:
+                    self.debug("line: {0}".format(line))
+                    self.debug("hdr: {0} spos: {1}".format(hdr, spos))
+                    spos += len(hdr) + 1
+                    l = line[spos:].strip()
+                    l = l.strip("()")
+                    self.debug("l: {0}".format(l))
+                    if l:
+                        entries.append({hdr: l})
+            logfile.close()
+        return entries
+
+    def test_catalog_v1(self):
+        """Verify that refresh works as expected for publishers that
+        have repositories that offer catalog/1/ in exceptional error
+        cases."""
+
+        dc = self.dcs[1]
+        self.pkgsend_bulk(self.durl1, self.foo10)
+
+        # First, verify that full retrieval works.
+        self.image_create(self.durl1, prefix="test1")
+
+        self.pkg("list -aH pkg:/foo@1.0")
+
+        # Only entries for the full catalog files should exist.
+        expected = ["/catalog/1/catalog.attrs", "/catalog/1/catalog.base.C"]
+        returned = self.get_op_entries(dc, "catalog", "1")
+        self.assertEqual(returned, expected)
+
+        # Next, verify that a "normal" incremental update works as
+        # expected when the catalog has changed.
+        self.pkgsend_bulk(self.durl1, self.foo11)
+
+        self.pkg("list -aH")
+        self.pkg("list -aH pkg:/foo@1.0")
+        self.pkg("list -aH pkg:/foo@1.1", exit=1)
+
+        self.pkg("refresh")
+        self.pkg("list -aH pkg:/foo@1.1")
+
+        # A bit hacky, but load the repository's catalog directly
+        # and then get the list of updates files it has created.
+        repo = dc.get_repo()
+        v1_cat = repo.get_catalog("test1")
+        update = list(v1_cat.updates.keys())[-1]
+
+        # All of the entries from the previous operations, and then
+        # entries for the catalog attrs file, and one catalog update
+        # file for the incremental update should be returned.
+        expected += [
+            "/catalog/1/catalog.attrs",
+            "/catalog/1/{0}".format(update),
+        ]
+        returned = self.get_op_entries(dc, "catalog", "1")
+        self.assertEqual(returned, expected)
+
+        # Next, verify that a "normal" incremental update works as
+        # expected when the catalog hasn't changed.
+        self.pkg("refresh test1")
+
+        # All of the entries from the previous operations, and then
+        # an entry for the catalog attrs file should be returned.
+        expected += ["/catalog/1/catalog.attrs"]
+        returned = self.get_op_entries(dc, "catalog", "1")
+        self.assertEqual(returned, expected)
+
+        # Next, verify that a "full" refresh after incrementals works
+        # as expected.
+        self.pkg("refresh --full test1")
+
+        # All of the entries from the previous operations, and then
+        # entries for each part of the catalog should be returned.
+        expected += ["/catalog/1/catalog.attrs"]
+        expected += ["/catalog/1/{0}".format(p) for p in v1_cat.parts.keys()]
+        returned = self.get_op_entries(dc, "catalog", "1")
+        self.assertEqual(returned, expected)
+
+        # Next, verify that rebuilding the repository's catalog induces
+        # a full refresh.  Note that doing this wipes out the contents
+        # of the log so far, so expected needs to be reset and the
+        # catalog reloaded.
+        expected = []
+        repo = dc.get_repo()
+        v1_cat = repo.get_catalog("test1")
+
+        dc.stop()
+        dc.set_rebuild()
+        dc.start()
+        dc.set_norebuild()
+
+        self.pkg("refresh")
+
+        # The catalog.attrs will be retrieved twice due to the first
+        # request's incremental update failure.
+        expected += ["/catalog/1/catalog.attrs"]
+        expected += ["/catalog/1/catalog.attrs"]
+        expected += ["/catalog/1/{0}".format(p) for p in v1_cat.parts.keys()]
+        returned = self.get_op_entries(dc, "catalog", "1")
+        self.assertEqual(returned, expected)
+
+        # Next, verify that if the client receives an incremental update
+        # but the catalog is then rolled back to an earlier version
+        # (think restoration of repository from backup) that the client
+        # will induce a full refresh.
+
+        # Preserve a copy of the existing repository.
+        tdir = tempfile.mkdtemp(dir=self.test_root)
+        trpath = os.path.join(tdir, os.path.basename(dc.get_repodir()))
+        shutil.copytree(dc.get_repodir(), trpath)
+
+        # Publish a new package.
+        self.pkgsend_bulk(self.durl1, self.foo12)
+
+        # Refresh to get an incremental update, and verify it worked.
+        self.pkg("refresh")
+        update = list(v1_cat.updates.keys())[-1]
+        expected += [
+            "/catalog/1/catalog.attrs",
+            "/catalog/1/{0}".format(update),
+        ]
+        repo = dc.get_repo()
+        v1_cat = repo.get_catalog("test1")
+
+        # Stop the depot server and put the old repository data back.
+        dc.stop()
+        shutil.rmtree(dc.get_repodir())
+        shutil.move(trpath, dc.get_repodir())
+        dc.start()
+        expected = []
+        repo = dc.get_repo()
+        v1_cat = repo.get_catalog("test1")
+
+        # Now verify that a refresh induces a full retrieval.  The
+        # catalog.attrs file will be retrieved twice due to the
+        # failure case.
+        self.pkg("refresh")
+        expected += ["/catalog/1/catalog.attrs"]
+        expected += ["/catalog/1/catalog.attrs"]
+        expected += ["/catalog/1/{0}".format(p) for p in v1_cat.parts.keys()]
+        returned = self.get_op_entries(dc, "catalog", "1")
+        self.assertEqual(returned, expected)
+
+        # Next, verify that if the client receives an incremental update
+        # but the catalog is then rolled back to an earlier version
+        # (think restoration of repository from backup) and then an
+        # update that has already happened before is republished that
+        # the client will induce a full refresh.
+
+        # Preserve a copy of the existing repository.
+        trpath = os.path.join(tdir, os.path.basename(dc.get_repodir()))
+        shutil.copytree(dc.get_repodir(), trpath)
+
+        # Publish a new package.
+        self.pkgsend_bulk(self.durl1, self.foo12)
+        repo = dc.get_repo()
+        v1_cat = repo.get_catalog("test1")
+
+        # Refresh to get an incremental update, and verify it worked.
+        self.pkg("refresh")
+        update = list(v1_cat.updates.keys())[-1]
+        expected += [
+            "/catalog/1/catalog.attrs",
+            "/catalog/1/{0}".format(update),
+        ]
+        repo = dc.get_repo()
+        v1_cat = repo.get_catalog("test1")
+
+        # Stop the depot server and put the old repository data back.
+        dc.stop()
+        shutil.rmtree(dc.get_repodir())
+        shutil.move(trpath, dc.get_repodir())
+        dc.start()
+        expected = []
+
+        # Re-publish the new package.  This causes the same catalog
+        # entry to exist, but at a different point in time in the
+        # update logs.
+        self.pkgsend_bulk(self.durl1, self.foo12)
+        repo = dc.get_repo()
+        v1_cat = repo.get_catalog("test1")
+        update = list(v1_cat.updates.keys())[-1]
+
+        # Now verify that a refresh induces a full retrieval.  The
+        # catalog.attrs file will be retrieved twice due to the
+        # failure case, and a retrieval of the incremental update
+        # file that failed to be applied should also be seen.
+        self.pkg("refresh")
+        expected += [
+            "/catalog/1/catalog.attrs",
+            "/catalog/1/{0}".format(update),
+            "/catalog/1/catalog.attrs",
+        ]
+        expected += ["/catalog/1/{0}".format(p) for p in v1_cat.parts.keys()]
+        returned = self.get_op_entries(dc, "catalog", "1")
+        self.assertEqual(returned, expected)
+
+        # Now verify that a full refresh will fail if the catalog parts
+        # retrieved don't match the catalog attributes.  Do this by
+        # saving a copy of the current repository catalog, publishing a
+        # new package, putting back the old catalog parts and then
+        # attempting a full refresh.  After that, verify the relevant
+        # log entries exist.
+        dc.stop()
+        dc.set_debug_feature("headers")
+        dc.start()
+
+        old_cat = os.path.join(self.test_root, "old-catalog")
+        cat_root = v1_cat.meta_root
+        shutil.copytree(v1_cat.meta_root, old_cat)
+        self.pkgsend_bulk(self.durl1, self.foo121)
+        v1_cat = catalog.Catalog(meta_root=cat_root, read_only=True)
+        for p in v1_cat.parts.keys():
+            # Overwrite the existing parts with empty ones.
+            part = catalog.CatalogPart(p, meta_root=cat_root)
+            part.destroy()
+
+            part = catalog.CatalogPart(p, meta_root=cat_root)
+            part.save()
+
+        self.pkg("refresh --full", exit=1)
+        expected = [
+            "/catalog/1/catalog.attrs",
+            "/catalog/1/catalog.base.C",
+        ]
+        returned = self.get_op_entries(dc, "catalog", "1")
+        self.assertEqual(returned, expected)
+
+        entries = self.__get_cache_entries(dc)
+        expected = [
+            {"CACHE-CONTROL": "no-cache"},
+            {"CACHE-CONTROL": "no-cache"},
+            {"PRAGMA": "no-cache"},
+            {"PRAGMA": "no-cache"},
+        ]
+        self.assertEqualDiff(entries, expected)
+
+        # Next, verify that a refresh without --full but that is
+        # implicity a full because the catalog hasn't already been
+        # retrieved is handled gracefully and the expected log
+        # entries are present.
+        dc.stop()
+        dc.start()
+        self.pkg("refresh", exit=1)
+        expected = [
+            "/catalog/1/catalog.attrs",
+            "/catalog/1/catalog.base.C",
+            "/catalog/1/catalog.attrs",
+            "/catalog/1/catalog.base.C",
+        ]
+        returned = self.get_op_entries(dc, "catalog", "1")
+        self.assertEqual(returned, expected)
+
+        entries = self.__get_cache_entries(dc)
+        # The first two requests should have not had any cache
+        # headers attached, while the last two should have
+        # triggered transport's revalidation logic.
+        expected = [
+            {"CACHE-CONTROL": "max-age=0"},
+            {"CACHE-CONTROL": "max-age=0"},
+        ]
+        self.assertEqualDiff(entries, expected)
+
+        # Next, purposefully corrupt the catalog.attrs file in the
+        # repository and attempt a refresh.  The client should fail
+        # gracefully.
+        f = open(os.path.join(v1_cat.meta_root, "catalog.attrs"), "w")
+        f.write("INVALID")
+        f.close()
+        self.pkg("refresh", exit=1)
+
+        # Finally, restore the catalog and verify the client can
+        # refresh.
+        shutil.rmtree(v1_cat.meta_root)
+        shutil.copytree(old_cat, v1_cat.meta_root)
+        self.pkg("refresh")
+
+    def __gen_expected(self, count):
+        """Generate expected header fields result."""
+        expected = []
+        for i in range(count):
+            expected.append({"CACHE-CONTROL": "no-cache"})
+        for i in range(count):
+            expected.append({"PRAGMA": "no-cache"})
+        return expected
+
+    def test_ignore_network_cache_1(self):
+        """Verify that --no-network-cache option works for transport
+        module."""
+
+        dc = self.dcs[1]
+        self.pkgsend_bulk(self.durl1, self.cache10)
+
+        # First, verify refresh triggers expected cache headers when
+        # retrieving catalog.
+        self.image_create(self.durl1, prefix="test1")
+        dc.stop()
+        dc.set_debug_feature("headers")
+        dc.start()
+        self.pkg("--no-network-cache refresh")
+        entries = self.__get_cache_entries(dc)
+        expected = self.__gen_expected(2)
+        self.assertEqualDiff(entries, expected)
+
+        # Second, verify contents triggers expected cache headers when
+        # fetch manifest.
+        self.pkg("--no-network-cache contents -rm cache")
+        entries = self.__get_cache_entries(dc)
+        expected = self.__gen_expected(4)
+        self.assertEqualDiff(entries, expected)
+
+        # Third, verify install triggers expected cache headers.
+        self.pkg("--no-network-cache install cache")
+        entries = self.__get_cache_entries(dc)
+        expected = self.__gen_expected(7)
+        self.assertEqualDiff(entries, expected)
+
+    def test_ignore_network_cache_2(self):
+        """Verify that global setting client_no_network_cache works for
+        transport module."""
+
+        dc = self.dcs[1]
+        self.pkgsend_bulk(self.durl1, self.cache10)
+
+        # Verify refresh triggers expected cache headers when
+        # retrieving catalog.
+        api_obj = self.image_create(self.durl1, prefix="test1")
+        global_settings.client_no_network_cache = True
+        dc.stop()
+        dc.set_debug_feature("headers")
+        dc.start()
+        api_obj.refresh()
+        entries = self.__get_cache_entries(dc)
+        expected = self.__gen_expected(2)
+        self.assertEqualDiff(entries, expected)
+
+        # Verify install triggers expected cache headers.
+        self._api_install(api_obj, ["cache"])
+        entries = self.__get_cache_entries(dc)
+        expected = self.__gen_expected(6)
+        self.assertEqualDiff(entries, expected)
+
+    def test_ignore_network_cache_3(self):
+        """Verify that debug value no_network_cache works for
+        transport module."""
+
+        dc = self.dcs[1]
+        self.pkgsend_bulk(self.durl1, self.cache10)
+
+        # Verify refresh triggers expected cache headers when
+        # retrieving catalog.
+        api_obj = self.image_create(self.durl1, prefix="test1")
+        DebugValues["no_network_cache"] = "true"
+        dc.stop()
+        dc.set_debug_feature("headers")
+        dc.start()
+        api_obj.refresh()
+        entries = self.__get_cache_entries(dc)
+        expected = self.__gen_expected(2)
+        self.assertEqualDiff(entries, expected)
+
+        # Verify install triggers expected cache headers.
+        self._api_install(api_obj, ["cache"])
+        entries = self.__get_cache_entries(dc)
+        expected = self.__gen_expected(6)
+        self.assertEqualDiff(entries, expected)
+
+        # Verify pkgrecv triggers expected cache headers.
+        rpth = tempfile.mkdtemp(dir=self.test_root)
+        self.pkgrecv(
+            "{0} -d {1} -D no_network_cache=true --raw"
+            " cache".format(self.durl1, rpth)
+        )
+        entries = self.__get_cache_entries(dc)
+        expected = self.__gen_expected(11)
+        self.assertEqualDiff(entries, expected)
+
+    def test_multi_origin_refresh(self):
+        """Test that refresh behaves correctly if some origins of a
+        publisher are not reachable."""
+
+        # Use depots 1,3,4 which are all for pub 'test1'.
+        self.image_create(self.durl1, prefix="test1")
+        self.pkg(
+            "set-publisher -g {0} -g {1} test1".format(self.durl3, self.durl4)
+        )
+        self.pkgsend_bulk(self.durl1, self.foo10)
+        self.pkgsend_bulk(self.durl3, self.foo11)
+        self.pkgsend_bulk(self.durl4, self.foo12)
+        self.dcs[3].stop()
+        self.dcs[4].stop()
+
+        # Only packages in depot 1 should be visible,
+        # refresh should exit with partial success.
+        self.pkg("refresh", exit=3)
+        self.pkg("list -af foo@1.0")
+        self.pkg("list -af foo@1.1 foo@1.2", exit=1)
+
+        # Only packages in depot 1 and 2 should be visible,
+        # refresh should exit with partial success.
+        self.dcs[3].start()
+        self.pkg("refresh", exit=3)
+        self.pkg("list -af foo@1.0 foo@1.1")
+        self.pkg("list -af foo@1.2", exit=1)
+
+        # All packages should be visible, refresh should be complete.
+        self.dcs[4].start()
+        self.pkg("refresh")
+        self.pkg("list -af foo@1.0 foo@1.1 foo@1.2")
+
+    def test_implicit_multi_origin_refresh(self):
+        """Test that implicit refresh behaves correctly if some origins
+        of a publisher are not reachable."""
+
+        # Use depots 1,3,4 which are all for pub 'test1'.
+        self.image_create(self.durl1, prefix="test1")
+        self.pkg(
+            "set-publisher -g {0} -g {1} test1".format(self.durl3, self.durl4)
+        )
+        self.pkgsend_bulk(self.durl1, self.foo10)
+        self.pkgsend_bulk(self.durl3, self.foo11)
+        self.pkgsend_bulk(self.durl4, self.foo12)
+        self.dcs[3].stop()
+        self.dcs[4].stop()
+
+        # For now we can only install the version which is in the only
+        # online depot. However, the offline depots should not prevent
+        # us from upgrading to whatever is available.
+        self.pkg("install foo@latest")
+        self.pkg("list foo@1.0")
+
+        # When we enable additional depots, newer version of foo should
+        # become available for install without us having to refresh
+        # explicitly.
+        self.dcs[3].start()
+        self.pkg("install foo@latest")
+        self.pkg("list foo@1.1")
+
+        self.dcs[4].start()
+        self.pkg("install foo@latest")
+        self.pkg("list foo@1.2")
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_revert.py
+++ b/src/tests/cli/t_pkg_revert.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -35,16 +36,18 @@ import pkg.misc as misc
 import sys
 
 try:
-        import pkg.sha512_t
-        sha512_supported = True
+    import pkg.sha512_t
+
+    sha512_supported = True
 except ImportError:
-        sha512_supported = False
+    sha512_supported = False
+
 
 class TestPkgRevert(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        pkgs = """
+    pkgs = """
             open A@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add file etc/file1 mode=0555 owner=root group=bin path=etc/file1
@@ -82,8 +85,8 @@ class TestPkgRevert(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        # A set of packages that we publish with additional hash attributes
-        pkgs2 = """
+    # A set of packages that we publish with additional hash attributes
+    pkgs2 = """
             open B@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add file etc/file2 mode=0555 owner=root group=bin path=etc/file2 revert-tag=bob
@@ -103,16 +106,16 @@ class TestPkgRevert(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        # A set of packages that we publish with additional hash attributes
-        pkgs3 = """
+    # A set of packages that we publish with additional hash attributes
+    pkgs3 = """
             open C@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add file etc/file3 mode=0555 owner=root group=bin path=etc/file3 revert-tag=bob revert-tag=ted
             close
             """
 
-        # pkg with preserve=abandon
-        pkgs4 = """
+    # pkg with preserve=abandon
+    pkgs4 = """
             open abd1@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=etc
             add file etc/file6.cfg mode=0555 owner=root group=bin path=etc/file6.cfg preserve=abandon
@@ -127,266 +130,300 @@ class TestPkgRevert(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        misc_files = ["etc/file1", "etc/file2", "etc/file3", "etc/file4",
-            "etc/file5", "etc/file6.cfg", "etc/file7.cfg", "etc/file8.cfg"]
+    misc_files = [
+        "etc/file1",
+        "etc/file2",
+        "etc/file3",
+        "etc/file4",
+        "etc/file5",
+        "etc/file6.cfg",
+        "etc/file7.cfg",
+        "etc/file8.cfg",
+    ]
 
-        additional_files = ["dev/foo", "dev/cfg/bar", "dev/cfg/blah",
-            "dev/cfg/bar1", "dev/cfg/bar2"]
+    additional_files = [
+        "dev/foo",
+        "dev/cfg/bar",
+        "dev/cfg/blah",
+        "dev/cfg/bar1",
+        "dev/cfg/bar2",
+    ]
 
-        def damage_all_files(self):
-                self.damage_files(self.misc_files)
+    def damage_all_files(self):
+        self.damage_files(self.misc_files)
 
-        def damage_files(self, paths):
-                ubin = portable.get_user_by_name("bin", None, False)
-                groot = portable.get_group_by_name("root", None, False)
-                for path in paths:
-                        file_path = os.path.join(self.get_img_path(), path)
-                        with open(file_path, "a+") as f:
-                                f.write("\nbogus\n")
-                        os.chown(file_path, ubin, groot)
-                        os.chmod(file_path, misc.PKG_RO_FILE_MODE)
+    def damage_files(self, paths):
+        ubin = portable.get_user_by_name("bin", None, False)
+        groot = portable.get_group_by_name("root", None, False)
+        for path in paths:
+            file_path = os.path.join(self.get_img_path(), path)
+            with open(file_path, "a+") as f:
+                f.write("\nbogus\n")
+            os.chown(file_path, ubin, groot)
+            os.chmod(file_path, misc.PKG_RO_FILE_MODE)
 
-        def remove_file(self, path):
-                os.unlink(os.path.join(self.get_img_path(), path))
+    def remove_file(self, path):
+        os.unlink(os.path.join(self.get_img_path(), path))
 
-        def remove_dir(self, path):
-                os.rmdir(os.path.join(self.get_img_path(), path))
+    def remove_dir(self, path):
+        os.rmdir(os.path.join(self.get_img_path(), path))
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.make_misc_files(self.additional_files)
-                self.plist = self.pkgsend_bulk(self.rurl, self.pkgs)
-                self.plist.extend(self.pkgsend_bulk(self.rurl, self.pkgs2,
-                    debug_hash="sha1+sha256"))
-                if sha512_supported:
-                        self.plist.extend(self.pkgsend_bulk(self.rurl,
-                            self.pkgs3, debug_hash="sha1+sha512t_256"))
-                else:
-                        self.plist.extend(self.pkgsend_bulk(self.rurl,
-                            self.pkgs3))
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.make_misc_files(self.additional_files)
+        self.plist = self.pkgsend_bulk(self.rurl, self.pkgs)
+        self.plist.extend(
+            self.pkgsend_bulk(self.rurl, self.pkgs2, debug_hash="sha1+sha256")
+        )
+        if sha512_supported:
+            self.plist.extend(
+                self.pkgsend_bulk(
+                    self.rurl, self.pkgs3, debug_hash="sha1+sha512t_256"
+                )
+            )
+        else:
+            self.plist.extend(self.pkgsend_bulk(self.rurl, self.pkgs3))
 
-                self.plist.extend(self.pkgsend_bulk(self.rurl, self.pkgs4))
+        self.plist.extend(self.pkgsend_bulk(self.rurl, self.pkgs4))
 
-        def test_revert(self):
-                self.image_create(self.rurl)
-                # try reverting non-editable files
-                self.pkg("install A@1.0 B@1.0 C@1.0 D@1.0")
-                self.pkg("verify")
-                # modify files
-                self.damage_all_files()
-                # make sure we broke 'em
-                self.pkg("verify A", exit=1)
+    def test_revert(self):
+        self.image_create(self.rurl)
+        # try reverting non-editable files
+        self.pkg("install A@1.0 B@1.0 C@1.0 D@1.0")
+        self.pkg("verify")
+        # modify files
+        self.damage_all_files()
+        # make sure we broke 'em
+        self.pkg("verify A", exit=1)
 
-                # We expect that the SHA-2 hash is used whenever there are SHA-2
-                # hashes on the action. Even though this client is run in
-                # "SHA-1" mode as well as "SHA-2" mode, we always verify with
-                # the most-preferred hash available.
-                self.pkg("-D hash=sha1+sha256 verify B", exit=1)
-                sha2 = "e3868252b2b2de64e85f5b221e46eb23c428fe5168848eb36d113c66628131ce"
-                self.assertTrue(sha2 in self.output)
-                self.pkg("verify B", exit=1)
-                self.assertTrue(sha2 in self.output)
+        # We expect that the SHA-2 hash is used whenever there are SHA-2
+        # hashes on the action. Even though this client is run in
+        # "SHA-1" mode as well as "SHA-2" mode, we always verify with
+        # the most-preferred hash available.
+        self.pkg("-D hash=sha1+sha256 verify B", exit=1)
+        sha2 = (
+            "e3868252b2b2de64e85f5b221e46eb23c428fe5168848eb36d113c66628131ce"
+        )
+        self.assertTrue(sha2 in self.output)
+        self.pkg("verify B", exit=1)
+        self.assertTrue(sha2 in self.output)
 
-                if sha512_supported:
-                        self.pkg("-D hash=sha1+sha512t_256 verify C", exit=1)
-                        sha2 = "13729cb7183961b48ce300c2588c86ad123e7c636f38a0f3c8408a75fd079d09"
-                        self.assertTrue(sha2 in self.output, self.output)
-                self.pkg("verify C", exit=1)
-                self.pkg("verify D", exit=1)
+        if sha512_supported:
+            self.pkg("-D hash=sha1+sha512t_256 verify C", exit=1)
+            sha2 = "13729cb7183961b48ce300c2588c86ad123e7c636f38a0f3c8408a75fd079d09"
+            self.assertTrue(sha2 in self.output, self.output)
+        self.pkg("verify C", exit=1)
+        self.pkg("verify D", exit=1)
 
-                # revert damage to A by path
-                self.pkg("revert /etc/file1")
-                self.pkg("verify A")
-                self.pkg("verify B", exit=1)
-                self.pkg("verify C", exit=1)
-                self.pkg("verify D", exit=1)
-                self.damage_all_files()
+        # revert damage to A by path
+        self.pkg("revert /etc/file1")
+        self.pkg("verify A")
+        self.pkg("verify B", exit=1)
+        self.pkg("verify C", exit=1)
+        self.pkg("verify D", exit=1)
+        self.damage_all_files()
 
-                # revert damage to D by tag
-                self.pkg("revert --tagged carol")
-                self.pkg("verify A", exit=1)
-                self.pkg("verify B", exit=1)
-                self.pkg("verify C", exit=1)
-                self.pkg("verify D")
-                self.damage_all_files()
+        # revert damage to D by tag
+        self.pkg("revert --tagged carol")
+        self.pkg("verify A", exit=1)
+        self.pkg("verify B", exit=1)
+        self.pkg("verify C", exit=1)
+        self.pkg("verify D")
+        self.damage_all_files()
 
-                # revert damage to C,D by tag
-                self.pkg("revert -vvv --tagged ted")
-                self.pkg("verify A", exit=1)
-                self.pkg("verify B", exit=1)
-                self.pkg("verify C")
-                self.pkg("verify D")
-                self.damage_all_files()
+        # revert damage to C,D by tag
+        self.pkg("revert -vvv --tagged ted")
+        self.pkg("verify A", exit=1)
+        self.pkg("verify B", exit=1)
+        self.pkg("verify C")
+        self.pkg("verify D")
+        self.damage_all_files()
 
-                # revert damage to B, C, D by tag and test the parsable output.
-                self.pkg("revert -n --parsable=0 --tagged bob")
-                self.debug("\n".join(self.plist))
-                self.assertEqualParsable(self.output,
-                    affect_packages=[self.plist[9], self.plist[12],
-                    self.plist[1]])
-                # When reverting damage, we always verify using the
-                # most-preferred hash, but retrieve content with the
-                # least-preferred hash: -D hash=sha1+sha256 and
-                # -D hash=sha1+sha512t_256 should have no effect here whatsoever,
-                # but -D hash=sha256 and -D hash=sha512t_256 should fail because
-                # our repository stores its files by the SHA1 hash.
-                self.pkg("-D hash=sha256 revert --parsable=0 --tagged bob",
-                    exit=1)
-                if sha512_supported:
-                        self.pkg("-D hash=sha512t_256 revert --parsable=0 \
-                            --tagged ted", exit=1)
-                        self.pkg("-D hash=sha1+512_256 revert -n --parsable=0 \
-                            --tagged ted")
-                        self.assertEqualParsable(self.output,
-                            affect_packages=[self.plist[12], self.plist[1]])
-                self.pkg("-D hash=sha1+sha256 revert --parsable=0 --tagged bob")
-                self.assertEqualParsable(self.output,
-                    affect_packages=[self.plist[9], self.plist[12],
-                    self.plist[1]])
-                self.pkg("verify A", exit=1)
-                self.pkg("verify B")
-                self.pkg("verify C")
-                self.pkg("verify D")
+        # revert damage to B, C, D by tag and test the parsable output.
+        self.pkg("revert -n --parsable=0 --tagged bob")
+        self.debug("\n".join(self.plist))
+        self.assertEqualParsable(
+            self.output,
+            affect_packages=[self.plist[9], self.plist[12], self.plist[1]],
+        )
+        # When reverting damage, we always verify using the
+        # most-preferred hash, but retrieve content with the
+        # least-preferred hash: -D hash=sha1+sha256 and
+        # -D hash=sha1+sha512t_256 should have no effect here whatsoever,
+        # but -D hash=sha256 and -D hash=sha512t_256 should fail because
+        # our repository stores its files by the SHA1 hash.
+        self.pkg("-D hash=sha256 revert --parsable=0 --tagged bob", exit=1)
+        if sha512_supported:
+            self.pkg(
+                "-D hash=sha512t_256 revert --parsable=0 \
+                            --tagged ted",
+                exit=1,
+            )
+            self.pkg(
+                "-D hash=sha1+512_256 revert -n --parsable=0 \
+                            --tagged ted"
+            )
+            self.assertEqualParsable(
+                self.output, affect_packages=[self.plist[12], self.plist[1]]
+            )
+        self.pkg("-D hash=sha1+sha256 revert --parsable=0 --tagged bob")
+        self.assertEqualParsable(
+            self.output,
+            affect_packages=[self.plist[9], self.plist[12], self.plist[1]],
+        )
+        self.pkg("verify A", exit=1)
+        self.pkg("verify B")
+        self.pkg("verify C")
+        self.pkg("verify D")
 
-                # fix A & update to versions w/ editable files
-                self.pkg("revert /etc/file1")
-                self.pkg("verify")
-                self.pkg("update")
-                self.pkg("list A@1.1 B@1.1 C@1.1 D@1.1")
-                self.pkg("revert /etc/file1", exit=4)
-                self.pkg("revert --tagged bob", exit=4) # nothing to do
-                self.damage_all_files()
-                self.pkg("revert /etc/file1")
-                self.pkg("revert --tagged bob")
-                self.pkg("revert /etc/file1", exit=4)
-                self.pkg("revert --tagged bob", exit=4) # nothing to do
-                self.pkg("verify")
-                # handle missing files too
-                self.remove_file("etc/file1")
-                self.pkg("verify A", exit=1)
-                self.pkg("revert /etc/file1")
-                self.pkg("revert /etc/file1", exit=4)
-                self.pkg("verify")
-                # check that we handle missing files when tagged
-                self.remove_file("etc/file2")
-                self.pkg("verify", exit=1)
-                self.pkg("revert --tagged bob")
-                self.pkg("verify")
-                # make sure we got the default contents
-                self.pkg("revert --tagged bob", exit=4)
-                # check that we handle files that don't exist correctly
-                self.pkg("revert /no/such/file", exit=1)
-                # since tags can be missing, just nothing to do for
-                # tags that we cannot find
-                self.pkg("revert --tagged no-such-tag", exit=4)
+        # fix A & update to versions w/ editable files
+        self.pkg("revert /etc/file1")
+        self.pkg("verify")
+        self.pkg("update")
+        self.pkg("list A@1.1 B@1.1 C@1.1 D@1.1")
+        self.pkg("revert /etc/file1", exit=4)
+        self.pkg("revert --tagged bob", exit=4)  # nothing to do
+        self.damage_all_files()
+        self.pkg("revert /etc/file1")
+        self.pkg("revert --tagged bob")
+        self.pkg("revert /etc/file1", exit=4)
+        self.pkg("revert --tagged bob", exit=4)  # nothing to do
+        self.pkg("verify")
+        # handle missing files too
+        self.remove_file("etc/file1")
+        self.pkg("verify A", exit=1)
+        self.pkg("revert /etc/file1")
+        self.pkg("revert /etc/file1", exit=4)
+        self.pkg("verify")
+        # check that we handle missing files when tagged
+        self.remove_file("etc/file2")
+        self.pkg("verify", exit=1)
+        self.pkg("revert --tagged bob")
+        self.pkg("verify")
+        # make sure we got the default contents
+        self.pkg("revert --tagged bob", exit=4)
+        # check that we handle files that don't exist correctly
+        self.pkg("revert /no/such/file", exit=1)
+        # since tags can be missing, just nothing to do for
+        # tags that we cannot find
+        self.pkg("revert --tagged no-such-tag", exit=4)
 
-                # check that we don't revert files tagged as 'abandon'
-                self.pkg("install abd1@1.0 abd2@1.0 abd3@1.0")
-                self.remove_file("etc/file6.cfg")
-                self.pkg("revert /etc/file6.cfg", exit=4)
-                self.file_doesnt_exist("etc/file6.cfg")
+        # check that we don't revert files tagged as 'abandon'
+        self.pkg("install abd1@1.0 abd2@1.0 abd3@1.0")
+        self.remove_file("etc/file6.cfg")
+        self.pkg("revert /etc/file6.cfg", exit=4)
+        self.file_doesnt_exist("etc/file6.cfg")
 
-                # check that we don't revert files tagged as 'abandon
-                # and revert-tag
-                self.remove_file("etc/file7.cfg")
-                self.pkg("revert /etc/file7.cfg", exit=4)
-                self.file_doesnt_exist("etc/file7.cfg")
+        # check that we don't revert files tagged as 'abandon
+        # and revert-tag
+        self.remove_file("etc/file7.cfg")
+        self.pkg("revert /etc/file7.cfg", exit=4)
+        self.file_doesnt_exist("etc/file7.cfg")
 
-                # check that we only revert files with revert-tag
-                # without 'abandon' attribute
-                self.remove_file("etc/file8.cfg")
-                self.pkg("revert --tagged bart", exit=0)
-                self.file_exists("etc/file8.cfg")
-                self.file_doesnt_exist("etc/file7.cfg")
+        # check that we only revert files with revert-tag
+        # without 'abandon' attribute
+        self.remove_file("etc/file8.cfg")
+        self.pkg("revert --tagged bart", exit=0)
+        self.file_exists("etc/file8.cfg")
+        self.file_doesnt_exist("etc/file7.cfg")
 
-        def test_revert_2(self):
-                """exercise new directory revert facility"""
-                self.image_create(self.rurl)
-                some_files = ["etc/A", "etc/B", "etc/C"]
+    def test_revert_2(self):
+        """exercise new directory revert facility"""
+        self.image_create(self.rurl)
+        some_files = ["etc/A", "etc/B", "etc/C"]
 
-                # first try reverting tag that doesn't exist
-                self.pkg("install A@1.1 W@1")
-                self.pkg("verify")
-                self.pkg("revert --tagged alice", 4)
-                self.pkg("verify")
+        # first try reverting tag that doesn't exist
+        self.pkg("install A@1.1 W@1")
+        self.pkg("verify")
+        self.pkg("revert --tagged alice", 4)
+        self.pkg("verify")
 
-                # now revert a tag that exists, but doesn't need
-                # any work done
-                self.pkg("revert --tagged bob", 4)
+        # now revert a tag that exists, but doesn't need
+        # any work done
+        self.pkg("revert --tagged bob", 4)
 
-                # now create some unpackaged files
-                self.create_some_files(some_files)
-                self.files_are_all_there(some_files)
-                # revert them
-                self.pkg("revert --tagged bob", 0)
-                self.pkg("verify")
-                self.files_are_all_missing(some_files)
+        # now create some unpackaged files
+        self.create_some_files(some_files)
+        self.files_are_all_there(some_files)
+        # revert them
+        self.pkg("revert --tagged bob", 0)
+        self.pkg("verify")
+        self.files_are_all_missing(some_files)
 
-                # now create some unpackaged directories and files
-                some_dirs = ["etc/X/", "etc/Y/", "etc/Z/C", "etc/X/XX/"]
-                self.create_some_files(some_dirs + some_files)
-                self.files_are_all_there(some_dirs + some_files)
-                # revert them
-                self.pkg("revert --tagged bob", 0)
-                self.pkg("verify")
-                self.files_are_all_missing(some_dirs + some_files)
+        # now create some unpackaged directories and files
+        some_dirs = ["etc/X/", "etc/Y/", "etc/Z/C", "etc/X/XX/"]
+        self.create_some_files(some_dirs + some_files)
+        self.files_are_all_there(some_dirs + some_files)
+        # revert them
+        self.pkg("revert --tagged bob", 0)
+        self.pkg("verify")
+        self.files_are_all_missing(some_dirs + some_files)
 
-                # install a package w/ implicit directories
-                self.pkg("install X@1.0")
-                self.create_some_files(some_dirs + some_files + ["etc/wombat/XXX"])
-                self.files_are_all_there(some_dirs + some_files + ["etc/wombat/XXX"])
-                # revert them
-                self.pkg("revert --tagged bob", 0)
-                self.pkg("verify")
-                self.files_are_all_missing(some_dirs + some_files)
-                self.files_are_all_there(["etc/wombat/XXX"])
-                # mix and match w/ regular tests
-                self.pkg("install B@1.1 C@1.1 D@1.1")
-                self.pkg("verify")
-                self.damage_all_files()
-                self.create_some_files(some_dirs + some_files + ["etc/wombat/XXX"])
-                self.files_are_all_there(some_dirs + some_files + ["etc/wombat/XXX"])
-                self.pkg("verify A", exit=1)
-                self.pkg("verify B", exit=1)
-                self.pkg("verify C", exit=1)
-                self.pkg("verify D", exit=1)
-                self.pkg("revert --tagged bob")
-                self.pkg("revert /etc/file1")
-                self.pkg("verify")
-                self.files_are_all_missing(some_dirs + some_files)
-                self.files_are_all_there(["etc/wombat/XXX"])
-                # generate some problems
-                self.pkg("install Y")
-                self.pkg("verify")
-                self.remove_dir("etc/y-dir")
-                self.pkg("revert --tagged bob", 4)
-                self.pkg("fix Y")
-                self.pkg("verify")
-                self.pkg("revert --tagged bob", 4)
+        # install a package w/ implicit directories
+        self.pkg("install X@1.0")
+        self.create_some_files(some_dirs + some_files + ["etc/wombat/XXX"])
+        self.files_are_all_there(some_dirs + some_files + ["etc/wombat/XXX"])
+        # revert them
+        self.pkg("revert --tagged bob", 0)
+        self.pkg("verify")
+        self.files_are_all_missing(some_dirs + some_files)
+        self.files_are_all_there(["etc/wombat/XXX"])
+        # mix and match w/ regular tests
+        self.pkg("install B@1.1 C@1.1 D@1.1")
+        self.pkg("verify")
+        self.damage_all_files()
+        self.create_some_files(some_dirs + some_files + ["etc/wombat/XXX"])
+        self.files_are_all_there(some_dirs + some_files + ["etc/wombat/XXX"])
+        self.pkg("verify A", exit=1)
+        self.pkg("verify B", exit=1)
+        self.pkg("verify C", exit=1)
+        self.pkg("verify D", exit=1)
+        self.pkg("revert --tagged bob")
+        self.pkg("revert /etc/file1")
+        self.pkg("verify")
+        self.files_are_all_missing(some_dirs + some_files)
+        self.files_are_all_there(["etc/wombat/XXX"])
+        # generate some problems
+        self.pkg("install Y")
+        self.pkg("verify")
+        self.remove_dir("etc/y-dir")
+        self.pkg("revert --tagged bob", 4)
+        self.pkg("fix Y")
+        self.pkg("verify")
+        self.pkg("revert --tagged bob", 4)
 
-        def test_revert_3(self):
-                """duplicate usage in /dev as per Ethan's mail"""
-                self.image_create(self.rurl)
-                some_files = ["dev/xxx", "dev/yyy", "dev/zzz",
-                              "dev/dir1/aaaa", "dev/dir1/bbbb", "dev/dir2/cccc",
-                              "dev/cfg/ffff", "dev/cfg/gggg",
-                              "dev/cfg/dir3/iiii", "dev/cfg/dir3/jjjj"]
+    def test_revert_3(self):
+        """duplicate usage in /dev as per Ethan's mail"""
+        self.image_create(self.rurl)
+        some_files = [
+            "dev/xxx",
+            "dev/yyy",
+            "dev/zzz",
+            "dev/dir1/aaaa",
+            "dev/dir1/bbbb",
+            "dev/dir2/cccc",
+            "dev/cfg/ffff",
+            "dev/cfg/gggg",
+            "dev/cfg/dir3/iiii",
+            "dev/cfg/dir3/jjjj",
+        ]
 
-                some_dirs = ["dev/dir1/", "dev/dir1/", "dev/dir2/", "dev/cfg/dir3/"]
-                self.pkg("install dev dev2")
-                self.pkg("verify")
-                self.files_are_all_missing(some_dirs + some_files)
-                self.create_some_files(some_dirs + some_files)
-                self.files_are_all_there(some_dirs + some_files)
-                self.pkg("verify -v")
-                self.damage_files(["dev/cfg/bar2"])
-                self.pkg("revert -vvv --tagged init-dev")
-                self.pkg("verify -v")
-                self.files_are_all_missing(some_dirs + some_files)
+        some_dirs = ["dev/dir1/", "dev/dir1/", "dev/dir2/", "dev/cfg/dir3/"]
+        self.pkg("install dev dev2")
+        self.pkg("verify")
+        self.files_are_all_missing(some_dirs + some_files)
+        self.create_some_files(some_dirs + some_files)
+        self.files_are_all_there(some_dirs + some_files)
+        self.pkg("verify -v")
+        self.damage_files(["dev/cfg/bar2"])
+        self.pkg("revert -vvv --tagged init-dev")
+        self.pkg("verify -v")
+        self.files_are_all_missing(some_dirs + some_files)
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_search.py
+++ b/src/tests/cli/t_pkg_search.py
@@ -26,8 +26,9 @@
 
 from __future__ import print_function
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import copy
@@ -47,14 +48,15 @@ import pkg.indexer as indexer
 import pkg.portable as portable
 
 try:
-        import pkg.sha512_t as sha512_t
-        sha512_supported = True
+    import pkg.sha512_t as sha512_t
+
+    sha512_supported = True
 except ImportError:
-        sha512_supported = False
+    sha512_supported = False
+
 
 class TestPkgSearchBasics(pkg5unittest.SingleDepotTestCase):
-
-        example_pkg10 = """
+    example_pkg10 = """
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
@@ -69,46 +71,46 @@ class TestPkgSearchBasics(pkg5unittest.SingleDepotTestCase):
             add set name='weirdness' value='] [ * ?'
             close """
 
-        example_pkg11 = """
+    example_pkg11 = """
             open example_pkg@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path11
             close """
 
-        incorp_pkg10 = """
+    incorp_pkg10 = """
             open incorp_pkg@1.0,5.11-0
             add depend fmri=example_pkg@1.0,5.11-0 type=incorporate
             close """
 
-        nover_incorp_pkg10 = """
+    nover_incorp_pkg10 = """
             open nover_incorp_pkg@1.0,5.11-0
             add depend fmri=incorp_pkg type=incorporate
             close """
 
-        dup_lines_pkg10 = """
+    dup_lines_pkg10 = """
             open dup_lines@1.0,5.11-0
             add set name=com.sun.service.incorporated_changes value="aa abc a a"
             add set name=com.sun.service.bug_ids value="z x y a abc bb"
             add set name=com.sun.service.keywords value="z a abc"
             close """
 
-        fat_pkg10 = """
+    fat_pkg10 = """
 open fat@1.0,5.11-0
 add set name=variant.arch value=sparc value=i386
 add set name=description value="i386 variant" variant.arch=i386
 add set name=description value="sparc variant" variant.arch=sparc
 close """
 
-        bogus_pkg10 = """
+    bogus_pkg10 = """
 set name=pkg.fmri value=pkg:/bogus_pkg@1.0,5.11-0:20090326T233451Z
 set name=description value=""validation with simple chains of constraints ""
 set name=pkg.description value="pseudo-hashes as arrays tied to a "type" (list of fields)"
 depend fmri=XML-Atom-Entry
 set name=com.sun.service.incorporated_changes value="6556919 6627937"
 """
-        bogus_fmri = fmri.PkgFmri("bogus_pkg@1.0,5.11-0:20090326T233451Z")
+    bogus_fmri = fmri.PkgFmri("bogus_pkg@1.0,5.11-0:20090326T233451Z")
 
-        empty_attr_pkg10 = """
+    empty_attr_pkg10 = """
 open empty@1.0,5.11-0
 add set name=pkg.fmri value=pkg:/empty@1.0 attr1=''
 add set name=empty_set value=''
@@ -123,7 +125,7 @@ add link target=bin/example_path path=link attr7=''
 close
 """
 
-        empty_attr_pkg10_templ = """
+    empty_attr_pkg10_templ = """
 open empty{ver}@1.0,5.11-0
 add set name=pkg.fmri value=pkg:/empty{ver}@1.0 attr1=''
 add set name=empty_set value=''
@@ -138,1093 +140,1221 @@ add link target=bin/example_path path=link attr7=''
 close
 """
 
-        headers = "INDEX ACTION VALUE PACKAGE\n"
-        pkg_headers = "PACKAGE PUBLISHER\n"
+    headers = "INDEX ACTION VALUE PACKAGE\n"
+    pkg_headers = "PACKAGE PUBLISHER\n"
 
-        res_remote_path = set([
+    res_remote_path = set(
+        [
             headers,
-            "basename   file      bin/example_path          pkg:/example_pkg@1.0-0\n"
-        ])
+            "basename   file      bin/example_path          pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_remote_case_sensitive = set([
+    res_remote_case_sensitive = set(
+        [
             headers,
-            "pkg.fmri        set        test/example_pkg pkg:/example_pkg@1.0-0\n"
-        ])
+            "pkg.fmri        set        test/example_pkg pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_remote_bin = set([
+    res_remote_bin = set(
+        [
             headers,
-            "path       dir       bin                       pkg:/example_pkg@1.0-0\n"
-        ])
+            "path       dir       bin                       pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_remote_openssl = set([
+    res_remote_openssl = set(
+        [
             headers,
-            "basename   dir       usr/lib/python3.9/vendor-packages/OpenSSL pkg:/example_pkg@1.0-0\n"
-        ])
+            "basename   dir       usr/lib/python3.9/vendor-packages/OpenSSL pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_remote_bug_id = set([
+    res_remote_bug_id = set(
+        [
             headers,
-            "com.sun.service.bug_ids set       4641790 4725245 4817791 4851433 4897491 4913776 6178339 6556919 6627937                   pkg:/example_pkg@1.0-0\n"
+            "com.sun.service.bug_ids set       4641790 4725245 4817791 4851433 4897491 4913776 6178339 6556919 6627937                   pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        ])
-
-        res_remote_inc_changes = set([
+    res_remote_inc_changes = set(
+        [
             headers,
             "com.sun.service.incorporated_changes set       6556919 6627937                   pkg:/example_pkg@1.0-0\n",
-            "com.sun.service.bug_ids set       4641790 4725245 4817791 4851433 4897491 4913776 6178339 6556919 6627937                   pkg:/example_pkg@1.0-0\n"
+            "com.sun.service.bug_ids set       4641790 4725245 4817791 4851433 4897491 4913776 6178339 6556919 6627937                   pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        ])
-
-        res_remote_random_test = set([
+    res_remote_random_test = set(
+        [
             headers,
-            "com.sun.service.random_test set       42                        pkg:/example_pkg@1.0-0\n"
-        ])
+            "com.sun.service.random_test set       42                        pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_remote_random_test_79 = set([
+    res_remote_random_test_79 = set(
+        [
             headers,
-            "com.sun.service.random_test set       79                        pkg:/example_pkg@1.0-0\n"
-        ])
+            "com.sun.service.random_test set       79                        pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_remote_keywords = set([
+    res_remote_keywords = set(
+        [
             headers,
-            "com.sun.service.keywords set       sort null -n -m -t sort 0x86 separator                 pkg:/example_pkg@1.0-0\n"
-        ])
+            "com.sun.service.keywords set       sort null -n -m -t sort 0x86 separator                 pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_remote_wildcard = set([
+    res_remote_wildcard = set(
+        [
             headers,
             "basename   file      bin/example_path          pkg:/example_pkg@1.0-0\n",
             "basename   dir       bin/example_dir           pkg:/example_pkg@1.0-0\n",
-            "pkg.fmri   set       test/example_pkg          pkg:/example_pkg@1.0-0\n"
-        ])
+            "pkg.fmri   set       test/example_pkg          pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_remote_glob = set([
+    res_remote_glob = set(
+        [
             headers,
             "basename   file      bin/example_path          pkg:/example_pkg@1.0-0\n",
             "basename   dir       bin/example_dir           pkg:/example_pkg@1.0-0\n",
             "path       file      bin/example_path          pkg:/example_pkg@1.0-0\n",
             "path       dir       bin/example_dir           pkg:/example_pkg@1.0-0\n",
-            "pkg.fmri   set       test/example_pkg          pkg:/example_pkg@1.0-0\n"
-        ])
+            "pkg.fmri   set       test/example_pkg          pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_remote_foo = set([
+    res_remote_foo = set(
+        [
             headers,
-            "description set       FOOO bAr O OO OOO                      pkg:/example_pkg@1.0-0\n"
-        ])
+            "description set       FOOO bAr O OO OOO                      pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_local_pkg = set([
+    res_local_pkg = set(
+        [
             headers,
-            "pkg.fmri       set        test/example_pkg              pkg:/example_pkg@1.0-0\n"
-        ])
+            "pkg.fmri       set        test/example_pkg              pkg:/example_pkg@1.0-0\n",
+        ]
+    )
 
-        res_local_path = copy.copy(res_remote_path)
+    res_local_path = copy.copy(res_remote_path)
 
-        res_local_bin = copy.copy(res_remote_bin)
+    res_local_bin = copy.copy(res_remote_bin)
 
-        res_local_bug_id = copy.copy(res_remote_bug_id)
+    res_local_bug_id = copy.copy(res_remote_bug_id)
 
-        res_local_inc_changes = copy.copy(res_remote_inc_changes)
+    res_local_inc_changes = copy.copy(res_remote_inc_changes)
 
-        res_local_random_test = copy.copy(res_remote_random_test)
-        res_local_random_test_79 = copy.copy(res_remote_random_test_79)
+    res_local_random_test = copy.copy(res_remote_random_test)
+    res_local_random_test_79 = copy.copy(res_remote_random_test_79)
 
-        res_local_keywords = copy.copy(res_remote_keywords)
+    res_local_keywords = copy.copy(res_remote_keywords)
 
-        res_local_wildcard = copy.copy(res_remote_wildcard)
+    res_local_wildcard = copy.copy(res_remote_wildcard)
 
-        res_local_glob = copy.copy(res_remote_glob)
+    res_local_glob = copy.copy(res_remote_glob)
 
-        res_local_foo = copy.copy(res_remote_foo)
+    res_local_foo = copy.copy(res_remote_foo)
 
-        res_local_openssl = copy.copy(res_remote_openssl)
+    res_local_openssl = copy.copy(res_remote_openssl)
 
-        # Results expected for degraded local search
-        degraded_warning = set(["To improve, run 'pkg rebuild-index'.\n",
-            'Search capabilities and performance are degraded.\n'])
+    # Results expected for degraded local search
+    degraded_warning = set(
+        [
+            "To improve, run 'pkg rebuild-index'.\n",
+            "Search capabilities and performance are degraded.\n",
+        ]
+    )
 
-        res_local_degraded_pkg = res_local_pkg.union(degraded_warning)
+    res_local_degraded_pkg = res_local_pkg.union(degraded_warning)
 
-        res_local_degraded_path = res_local_path.union(degraded_warning)
+    res_local_degraded_path = res_local_path.union(degraded_warning)
 
-        res_local_degraded_bin = res_local_bin.union(degraded_warning)
+    res_local_degraded_bin = res_local_bin.union(degraded_warning)
 
-        res_local_degraded_bug_id = res_local_bug_id.union(degraded_warning)
+    res_local_degraded_bug_id = res_local_bug_id.union(degraded_warning)
 
-        res_local_degraded_inc_changes = res_local_inc_changes.union(degraded_warning)
+    res_local_degraded_inc_changes = res_local_inc_changes.union(
+        degraded_warning
+    )
 
-        res_local_degraded_random_test = res_local_random_test.union(degraded_warning)
+    res_local_degraded_random_test = res_local_random_test.union(
+        degraded_warning
+    )
 
-        res_local_degraded_keywords = res_local_keywords.union(degraded_warning)
+    res_local_degraded_keywords = res_local_keywords.union(degraded_warning)
 
-        res_local_degraded_openssl = res_local_openssl.union(degraded_warning)
+    res_local_degraded_openssl = res_local_openssl.union(degraded_warning)
 
-        res_bogus_name_result = set([
+    res_bogus_name_result = set(
+        [
             headers,
-            'pkg.fmri       set       bogus_pkg                 pkg:/bogus_pkg@1.0-0\n'
-        ])
+            "pkg.fmri       set       bogus_pkg                 pkg:/bogus_pkg@1.0-0\n",
+        ]
+    )
 
-        res_bogus_number_result = set([
+    res_bogus_number_result = set(
+        [
             headers,
-            'com.sun.service.incorporated_changes set       6556919 6627937                   pkg:/bogus_pkg@1.0-0\n'
-        ])
+            "com.sun.service.incorporated_changes set       6556919 6627937                   pkg:/bogus_pkg@1.0-0\n",
+        ]
+    )
 
-        misc_files = {
-            "tmp/example_file": "magic",
-            "tmp/passwd": """\
+    misc_files = {
+        "tmp/example_file": "magic",
+        "tmp/passwd": """\
 root:x:0:0::/root:/usr/bin/bash
 daemon:x:1:1::/:
 bin:x:2:2::/usr/bin:
 sys:x:3:3::/:
 adm:x:4:4:Admin:/var/adm:
 """,
-            "tmp/group": """\
+        "tmp/group": """\
 root::0:
 other::1:root
 bin::2:root,daemon
 sys::3:root,bin,adm
 adm::4:root,daemon
 """,
-            "tmp/shadow": """\
+        "tmp/shadow": """\
 root:9EIfTNBp9elws:13817::::::
 daemon:NP:6445::::::
 bin:NP:6445::::::
 sys:NP:6445::::::
 adm:NP:6445::::::
 """,
-            }
+    }
 
+    res_local_pkg_ret_pkg = set([pkg_headers, "pkg:/example_pkg@1.0-0\n"])
 
-        res_local_pkg_ret_pkg = set([
-            pkg_headers,
-            "pkg:/example_pkg@1.0-0\n"
-        ])
+    res_remote_pkg_ret_pkg = set([pkg_headers, "pkg:/example_pkg@1.0-0 test\n"])
 
-        res_remote_pkg_ret_pkg = set([
-            pkg_headers,
-            "pkg:/example_pkg@1.0-0 test\n"
-        ])
+    res_remote_file = (
+        set(
+            [
+                "path       file      bin/example_path          pkg:/example_pkg@1.0-0\n",
+                "b40981aab75932c5b2f555f50769d878e44913d7 file      bin/example_path          pkg:/example_pkg@1.0-0\n",
+                "pkg.content-hash file   ['file:sha512t_256:8e3b2cea6dc6c4954cf8205bff833ead1f2eb3d4850525544cde0242c971452d', 'gzip:sha512t_256:8846fa174b11c8241080d58796509ef3f86f1dba119f318d32e5ca1b2be33f91'] pkg:/example_pkg@1.0-0\n",
+                "hash                                     file   bin/example_path pkg:/example_pkg@1.0-0\n",
+            ]
+        )
+        | res_remote_path
+    )
 
-        res_remote_file = set([
-            'path       file      bin/example_path          pkg:/example_pkg@1.0-0\n',
-            'b40981aab75932c5b2f555f50769d878e44913d7 file      bin/example_path          pkg:/example_pkg@1.0-0\n',
+    res_remote_url = set(
+        [
+            headers,
+            "com.sun.service.info_url set       http://service.opensolaris.com/xml/pkg/SUNWcsu@0.5.11,5.11-1:20080514I120000Z pkg:/example_pkg@1.0-0\n",
+        ]
+    )
+
+    res_remote_path_extra = set(
+        [
+            headers,
+            "path       file      bin/example_path          pkg:/example_pkg@1.0-0\n",
+            "basename   file      bin/example_path          pkg:/example_pkg@1.0-0\n",
+            "b40981aab75932c5b2f555f50769d878e44913d7 file      bin/example_path          pkg:/example_pkg@1.0-0\n",
             "pkg.content-hash file   ['file:sha512t_256:8e3b2cea6dc6c4954cf8205bff833ead1f2eb3d4850525544cde0242c971452d', 'gzip:sha512t_256:8846fa174b11c8241080d58796509ef3f86f1dba119f318d32e5ca1b2be33f91'] pkg:/example_pkg@1.0-0\n",
-            'hash                                     file   bin/example_path pkg:/example_pkg@1.0-0\n'
-        ]) | res_remote_path
-
-
-        res_remote_url = set([
-             headers,
-             'com.sun.service.info_url set       http://service.opensolaris.com/xml/pkg/SUNWcsu@0.5.11,5.11-1:20080514I120000Z pkg:/example_pkg@1.0-0\n'
-        ])
-
-        res_remote_path_extra = set([
-             headers,
-             'path       file      bin/example_path          pkg:/example_pkg@1.0-0\n',
-             'basename   file      bin/example_path          pkg:/example_pkg@1.0-0\n',
-             'b40981aab75932c5b2f555f50769d878e44913d7 file      bin/example_path          pkg:/example_pkg@1.0-0\n',
-             "pkg.content-hash file   ['file:sha512t_256:8e3b2cea6dc6c4954cf8205bff833ead1f2eb3d4850525544cde0242c971452d', 'gzip:sha512t_256:8846fa174b11c8241080d58796509ef3f86f1dba119f318d32e5ca1b2be33f91'] pkg:/example_pkg@1.0-0\n",
-             'hash                                     file   bin/example_path pkg:/example_pkg@1.0-0\n'
-        ])
-
-        o_headers = \
-            "ACTION.NAME ACTION.KEY PKG.NAME " \
-            "PKG.SHORTFMRI SEARCH.MATCH " \
-            "SEARCH.MATCH_TYPE MODE OWNER GROUP " \
-            "ACTION.RAW PKG.PUBLISHER\n"
-
-        o_results_no_pub = \
-            "file bin/example_path example_pkg " \
-            "pkg:/example_pkg@1.0-0 bin/example_path " \
-            "basename 0555 root bin " \
-            "file b40981aab75932c5b2f555f50769d878e44913d7 chash=6a4299897fca0c4d0d18870da29a0dc7ae23b79c group=bin mode=0555 owner=root path=bin/example_path pkg.content-hash=file:sha512t_256:8e3b2cea6dc6c4954cf8205bff833ead1f2eb3d4850525544cde0242c971452d pkg.content-hash=gzip:sha512t_256:8846fa174b11c8241080d58796509ef3f86f1dba119f318d32e5ca1b2be33f91 pkg.csize=25 pkg.size=5\n"
-
-        o_results = o_results_no_pub.rstrip() + " test\n"
-
-        res_o_options_remote = set([o_headers, o_results])
-
-        res_o_options_local = set([o_headers, o_results_no_pub])
-
-        pkg_headers = "PKG.NAME PKG.SHORTFMRI PKG.PUBLISHER MODE"
-        pkg_results_no_pub = "example_pkg pkg:/example_pkg@1.0-0"
-        pkg_results = pkg_results_no_pub + " test"
-
-        res_pkg_options_remote = set([pkg_headers, pkg_results])
-        res_pkg_options_local = set([pkg_headers, pkg_results_no_pub])
-
-        # Creating a query string in which the number of terms is > 100
-        large_query = "a b c d e f g h i j k l m n o p q r s t u v w x y z" \
-                      "a b c d e f g h i j k l m n o p q r s t u v w x y z" \
-                      "a b c d e f g h i j k l m n o p q r s t u v w x y z" \
-                      "a b c d e f g h i j k l m n o p q r s t u v w x y z" \
-                      "a b c d e f g h i j k l m n o p q r s t u v w x y z" \
-                      "a b c d e f g h i j k l m n o p q r s t u v w x y z"
-
-        def setUp(self):
-                # This test needs an actual depot for now.
-                pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
-                self.make_misc_files(self.misc_files)
-                self.init_mem_setting = None
-
-        def _check(self, proposed_answer, correct_answer):
-                if correct_answer == proposed_answer:
-                        return True
-                if len(proposed_answer) == len(correct_answer) and \
-                    sorted([p.strip().split() for p in proposed_answer]) == \
-                    sorted([c.strip().split() for c in correct_answer]):
-                        return True
-                self.debug("Proposed Answer: " + str(proposed_answer))
-                self.debug("Correct Answer : " + str(correct_answer))
-                if isinstance(correct_answer, set) and \
-                    isinstance(proposed_answer, set):
-                        print("Missing: " + str(correct_answer - proposed_answer),
-                            file=sys.stderr)
-                        print("Extra  : " + str(proposed_answer - correct_answer),
-                            file=sys.stderr)
-                self.assertTrue(correct_answer == proposed_answer)
-
-        def _search_op(self, remote, token, test_value, case_sensitive=False,
-            return_actions=True, exit=0, su_wrap=False, prune_versions=True,
-            headers=True):
-                outfile = os.path.join(self.test_root, "res")
-                if remote:
-                        token = "-r " + token
-                else:
-                        token = "-l " + token
-                if case_sensitive:
-                        token = "-I " + token
-                if return_actions:
-                        token = "-a " + token
-                else:
-                        token = "-p " + token
-                if not prune_versions:
-                        token = "-f " + token
-                if not headers:
-                        token = "-H " + token
-                self.pkg("search " + token + " > " + outfile, exit=exit)
-                res_list = (open(outfile, "r")).readlines()
-                self._check(set(res_list), test_value)
-
-        def _run_remote_tests(self):
-                # This should be possible now that the server automatically adds
-                # FMRIs to manifests (during publication).
-                self.pkg("search -a -r example_pkg")
-
-                self._search_op(True, "example_path", self.res_remote_path)
-                self._search_op(True, "':set:pkg.fmri:exAMple_pkg'",
-                    self.res_remote_case_sensitive, case_sensitive=False)
-                self._search_op(True, "'(example_path)'", self.res_remote_path)
-                self._search_op(True, "'<exam*:::>'",
-                    self.res_remote_pkg_ret_pkg)
-                self._search_op(True, "'::com.sun.service.info_url:'",
-                    self.res_remote_url)
-                self._search_op(True, "':::e* AND *path'", self.res_remote_path)
-                self._search_op(True, "'e* AND *path'", self.res_remote_path)
-                self._search_op(True, "'<e*>'", self.res_remote_pkg_ret_pkg)
-                self._search_op(True, "'<e*> AND <e*>'",
-                    self.res_remote_pkg_ret_pkg)
-                self._search_op(True, "'<e*> OR <e*>'",
-                    self.res_remote_pkg_ret_pkg)
-                self._search_op(True, "'<exam:::>'",
-                    self.res_remote_pkg_ret_pkg)
-                self._search_op(True, "'exam:::e*path'", self.res_remote_path)
-                self._search_op(True, "'exam:::e*path AND e*:::'",
-                    self.res_remote_path)
-                self._search_op(True, "'e*::: AND exam:::*path'",
-                    self.res_remote_path_extra)
-                self._search_op(True, "'example*'", self.res_remote_wildcard)
-                self._search_op(True, "/bin", self.res_remote_bin)
-                self._search_op(True, "4851433", self.res_remote_bug_id)
-                self._search_op(True, "'<4851433> AND <4725245>'",
-                    self.res_remote_pkg_ret_pkg)
-                self._search_op(True, "4851433 AND 4725245",
-                    self.res_remote_bug_id)
-                self._search_op(True, "4851433 AND 4725245 OR example_path",
-                    self.res_remote_bug_id)
-                self._search_op(True, "'4851433 AND (4725245 OR example_path)'",
-                    self.res_remote_bug_id)
-                self._search_op(True, "'(4851433 AND 4725245) OR example_path'",
-                    self.res_remote_bug_id | self.res_remote_path)
-                self._search_op(True, "4851433 OR 4725245",
-                    self.res_remote_bug_id | self.res_remote_bug_id)
-                self._search_op(True, "6556919", self.res_remote_inc_changes)
-                self._search_op(True, "'6556?19'", self.res_remote_inc_changes)
-                self._search_op(True, "42", self.res_remote_random_test)
-                self._search_op(True, "79", self.res_remote_random_test_79)
-                self._search_op(True, "separator", self.res_remote_keywords)
-                self._search_op(True, "'\"sort 0x86\"'",
-                    self.res_remote_keywords)
-                self._search_op(True, "'*example*'", self.res_remote_glob)
-                self._search_op(True, "fooo", self.res_remote_foo)
-                self._search_op(True, "'fo*'", self.res_remote_foo)
-                self._search_op(True, "bar", self.res_remote_foo)
-                self._search_op(True, "openssl", self.res_remote_openssl)
-                self._search_op(True, "OPENSSL", self.res_remote_openssl)
-                self._search_op(True, "OpEnSsL", self.res_remote_openssl)
-                self._search_op(True, "'OpEnS*'", self.res_remote_openssl)
-
-                # Verify that search will work for an unprivileged user even if
-                # the download directory doesn't exist.
-                img = self.get_img_api_obj().img
-                cache_dirs = [
-                    path
-                    for path, readonly, pub, layout in img.get_cachedirs()
-                ]
-                for path in cache_dirs:
-                        shutil.rmtree(path, ignore_errors=True)
-                        self.assertFalse(os.path.exists(path))
-                self._search_op(True, "'fo*'", self.res_remote_foo,
-                    su_wrap=True)
-
-                # These tests are included because a specific bug
-                # was found during development. This prevents regression back
-                # to that bug. Exit status of 1 is expected because the
-                # token isn't in the packages.
-                self.pkg("search -a -r a_non_existent_token", exit=1)
-                self.pkg("search -a -r a_non_existent_token", exit=1)
-
-                self.pkg("search -a -r '42 AND 4641790'", exit=1)
-                self.pkg("search -a -r '<e*> AND e*'", exit=1)
-                self.pkg("search -a -r 'e* AND <e*>'", exit=1)
-                self.pkg("search -a -r '<e*> OR e*'", exit=1)
-                self.pkg("search -a -r 'e* OR <e*>'", exit=1)
-                self._search_op(True, "pkg:/example_path", self.res_remote_path)
-                self.pkg("search -a -r -I ':set:pkg.fmri:exAMple_pkg'", exit=1)
-                self.assertTrue(self.errout == "" )
-
-                self.pkg("search -a -r {0}".format(self.large_query), exit=1)
-                self.assertTrue(self.errout != "")
-
-        def _run_local_tests(self):
-                outfile = os.path.join(self.test_root, "res")
-
-                # This finds something because the client side
-                # manifest has had the name of the package inserted
-                # into it.
-
-                self._search_op(False, "example_pkg", self.res_local_pkg)
-                self._search_op(False, "'(example_pkg)'", self.res_local_pkg)
-                self._search_op(False, "'<exam*:::>'",
-                    self.res_local_pkg_ret_pkg)
-                self._search_op(False, "'::com.sun.service.info_url:'",
-                    self.res_remote_url)
-                self._search_op(False, "':::e* AND *path'",
-                    self.res_remote_path)
-                self._search_op(False, "'e* AND *path'", self.res_local_path)
-                self._search_op(False, "'<e*>'", self.res_local_pkg_ret_pkg)
-                self._search_op(False, "'<e*> AND <e*>'",
-                    self.res_local_pkg_ret_pkg)
-                self._search_op(False, "'<e*> OR <e*>'",
-                    self.res_local_pkg_ret_pkg)
-                self._search_op(False, "'<exam:::>'",
-                    self.res_local_pkg_ret_pkg)
-                self._search_op(False, "'exam:::e*path'", self.res_remote_path)
-                self._search_op(False, "'exam:::e*path AND e:::'",
-                    self.res_remote_path)
-                self._search_op(False, "'e::: AND exam:::e*path'",
-                    self.res_remote_path_extra)
-                self._search_op(False, "'example*'", self.res_local_wildcard)
-                self._search_op(False, "/bin", self.res_local_bin)
-                self._search_op(False, "4851433", self.res_local_bug_id)
-                self._search_op(False, "'<4851433> AND <4725245>'",
-                    self.res_local_pkg_ret_pkg)
-                self._search_op(False, "4851433 AND 4725245",
-                    self.res_remote_bug_id)
-                self._search_op(False, "4851433 AND 4725245 OR example_path",
-                    self.res_remote_bug_id)
-                self._search_op(False,
-                    "'4851433 AND (4725245 OR example_path)'",
-                    self.res_remote_bug_id)
-                self._search_op(False,
-                    "'(4851433 AND 4725245) OR example_path'",
-                    self.res_remote_bug_id | self.res_local_path)
-                self._search_op(False, "4851433 OR 4725245",
-                    self.res_remote_bug_id | self.res_remote_bug_id)
-                self._search_op(False, "6556919", self.res_local_inc_changes)
-                self._search_op(False, "'65569??'", self.res_local_inc_changes)
-                self._search_op(False, "42", self.res_local_random_test)
-                self._search_op(False, "79", self.res_local_random_test_79)
-                self._search_op(False, "separator", self.res_local_keywords)
-                self._search_op(False, "'\"sort 0x86\"'",
-                    self.res_remote_keywords)
-                self._search_op(False, "'*example*'", self.res_local_glob)
-                self._search_op(False, "fooo", self.res_local_foo)
-                self._search_op(False, "'fo*'", self.res_local_foo)
-                self._search_op(False, "bar", self.res_local_foo)
-                self._search_op(False, "openssl", self.res_local_openssl)
-                self._search_op(False, "OPENSSL", self.res_local_openssl)
-                self._search_op(False, "OpEnSsL", self.res_local_openssl)
-                self._search_op(False, "'OpEnS*'", self.res_local_openssl)
-
-                # These tests are included because a specific bug
-                # was found during development. These tests prevent regression
-                # back to that bug. Exit status of 1 is expected because the
-                # token isn't in the packages.
-                self.pkg("search -a -l a_non_existent_token", exit=1)
-                self.pkg("search -a -l a_non_existent_token", exit=1)
-                self.pkg("search -a -l '42 AND 4641790'", exit=1)
-                self.pkg("search -a -l '<e*> AND e*'", exit=1)
-                self.pkg("search -a -l 'e* AND <e*>'", exit=1)
-                self.pkg("search -a -l '<e*> OR e*'", exit=1)
-                self.pkg("search -a -l 'e* OR <e*>'", exit=1)
-                self._search_op(False, "pkg:/example_path", self.res_local_path)
-
-                self.pkg("search -a -l {0}".format(self.large_query), exit=1)
-                self.assertTrue(self.errout != "")
-
-        def _run_local_empty_tests(self):
-                self.pkg("search -a -l example_pkg", exit=1)
-                self.pkg("search -a -l example_path", exit=1)
-                self.pkg("search -a -l 'example*'", exit=1)
-                self.pkg("search -a -l /bin", exit=1)
-
-        def _run_remote_empty_tests(self):
-                self.pkg("search -a -r example_pkg", exit=1)
-                self.pkg("search -a -r example_path", exit=1)
-                self.pkg("search -a -r 'example*'", exit=1)
-                self.pkg("search -a -r /bin", exit=1)
-                self.pkg("search -a -r '*unique*'", exit=1)
-
-        def _get_index_dirs(self):
-                index_dir = self.get_img_api_obj().img.index_dir
-                index_dir_tmp = os.path.join(index_dir, "TMP")
-                return index_dir, index_dir_tmp
-
-        def pkgsend_bulk(self, durl, pkg):
-                # Ensure indexing is performed for every published package.
-                plist = pkg5unittest.SingleDepotTestCase.pkgsend_bulk(self,
-                    durl, pkg, refresh_index=True)
-                self.wait_repo(self.dc.get_repodir())
-                return plist
-
-        def test_pkg_search_cli(self):
-                """Test search cli options."""
-
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.example_pkg10)
-                self.image_create(durl)
-
-                self.pkg("search", exit=2)
-
-                # Bug 1541
-                self.pkg("search -s {0} bin".format("httP" + durl[4:]))
-                self.pkg("search -s ftp://pkg.opensolaris.org:88 bge", exit=1)
-
-                # Testing interaction of -o and -p options
-                self.pkgsend_bulk(durl, self.example_pkg10)
-                self.pkg("search -o action.name -p pkg", exit=2)
-                self.pkg("search -o action.name -a '<pkg>'", exit=1)
-                self.pkg("search -o action.name -a '<example_path>'", exit=2)
-                self.pkg("search -o action.key -p pkg", exit=2)
-                self.pkg("search -o action.key -a '<pkg>'", exit=1)
-                self.pkg("search -o action.key -a '<example_path>'", exit=2)
-                self.pkg("search -o search.match -p pkg", exit=2)
-                self.pkg("search -o search.match -a '<pkg>'", exit=1)
-                self.pkg("search -o search.match -a '<example_path>'", exit=2)
-                self.pkg("search -o search.match_type -p pkg", exit=2)
-                self.pkg("search -o search.match_type -a '<pkg>'", exit=1)
-                self.pkg("search -o search.match_type -a '<example_path>'",
-                    exit=2)
-                self.pkg("search -o action.foo -a pkg", exit=2)
-
-        def test_remote(self):
-                """Test remote search."""
-                # Need to retain to check that default search does remote, not
-                # local search, and that -r and -s work as expected
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.example_pkg10)
-
-                self.image_create(durl)
-                self._run_remote_tests()
-                self._search_op(True, "':file::'", self.res_remote_file)
-                self.pkg("search '*'")
-                self.pkg("search -r '*'")
-                self.pkg("search -s {0} '*'".format(durl))
-                self.pkg("search -l '*'", exit=1)
-
-        def test_local_0(self):
-                """Install one package, and run the search suite."""
-                # Need to retain that -l works as expected
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.example_pkg10)
-
-                self.image_create(durl)
-
-                self.pkg("install example_pkg")
-
-                self._run_local_tests()
-
-        def test_bug_1873(self):
-                """Test to see if malformed actions cause tracebacks during
-                indexing for client or server."""
-                # Can't be moved to api search since this is to test for
-                # tracebacks
-                durl = self.dc.get_depot_url()
-                depotpath = self.dc.get_repodir()
-                server_manifest_path = os.path.join(depotpath, "publisher",
-                    "test", "pkg", self.bogus_fmri.get_dir_path())
-                os.makedirs(os.path.dirname(server_manifest_path))
-                tmp_ind_dir = os.path.join(depotpath, "index", "TMP")
-
-                fh = open(server_manifest_path, "w")
-                fh.write(self.bogus_pkg10)
-                fh.close()
-
-                self.image_create(durl)
-                self.dc.stop()
-                self.dc.set_rebuild()
-                self.dc.start()
-
-                # Should return nothing, as the server can't build catalog
-                # data for the package since the manifest is unparseable.
-                self._search_op(True, "'*bogus*'", set(), exit=1)
-                self._search_op(True, "6627937", set(), exit=1)
-
-                # Should fail since the bogus_pkg isn't even in the catalog.
-                self.pkg("install bogus_pkg", exit=1)
-
-                client_manifest_file = self.get_img_manifest_path(
-                    self.bogus_fmri)
-                os.makedirs(os.path.dirname(client_manifest_file))
-
-                fh = open(client_manifest_file, "w")
-                fh.write(self.bogus_pkg10)
-                fh.close()
-
-                # Load the 'installed' catalog and add an entry for the
-                # new package version.
-                img = self.get_img_api_obj().img
-                istate_dir = os.path.join(img._statedir, "installed")
-                cat = catalog.Catalog(meta_root=istate_dir)
-                mdata = { "states": [pkgdefs.PKG_STATE_INSTALLED] }
-                bfmri = self.bogus_fmri.copy()
-                bfmri.set_publisher("test")
-                cat.add_package(bfmri, metadata=mdata)
-                cat.save()
-
-                self.pkg("rebuild-index")
-                self._search_op(False, "'*bogus*'",
-                    set(self.res_bogus_name_result))
-                self._search_op(False, "6627937",
-                    set(self.res_bogus_number_result))
-
-        def test_bug_6177(self):
-                """Test that by default search restricts the results to the
-                incorporated packages and that the -f option works as
-                expected."""
-
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, (self.example_pkg10, self.example_pkg11,
-                    self.incorp_pkg10))
-
-                self.image_create(durl)
-
-                res_both_actions = set([
-                    self.headers,
-                    "path       dir    bin   pkg:/example_pkg@1.0-0\n",
-                    "path       dir    bin   pkg:/example_pkg@1.1-0\n"
-                ])
-
-                res_10_action = set([
-                    self.headers,
-                    "path       dir    bin   pkg:/example_pkg@1.0-0\n"
-                ])
-
-
-                res_11_action = set([
-                    self.headers,
-                    "path       dir    bin   pkg:/example_pkg@1.1-0\n"
-                ])
-
-                self.pkg("install incorp_pkg")
-                self._search_op(True, '/bin', res_10_action)
-                self._search_op(True, '/bin', res_both_actions,
-                    prune_versions=False)
-
-                self.pkg("uninstall incorp_pkg")
-                self.pkg("install example_pkg")
-                self._search_op(True, '/bin', res_11_action)
-                self._search_op(True, '/bin', res_both_actions,
-                    prune_versions=False)
-
-        def test_fmri_output(self):
-                """Test that the build_release is dropped from version string
-                of pkg FMRIS for the special case '-o pkg.fmri'."""
-
-                durl = self.dc.get_depot_url()
-                plist = self.pkgsend_bulk(durl, self.incorp_pkg10)
-
-                self.image_create(durl)
-                self.pkg("search -Ho pkg.fmri incorp_pkg")
-                self.assertTrue(fmri.PkgFmri(plist[0]).get_fmri(
-                    include_build=False, anarchy=True) in self.output)
-
-        def test_versionless_incorp(self):
-                """Test that versionless incorporates are ignored by search when
-                restricting results to incorporated packages (see bug 7149895).
-                """
-
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, (self.incorp_pkg10,
-                    self.nover_incorp_pkg10))
-
-                self.image_create(durl)
-
-                res = set([
-                    self.headers,
-                    "pkg.fmri    set    test/incorp_pkg pkg:/incorp_pkg@1.0-0\n",
-                    "incorporate depend incorp_pkg      pkg:/nover_incorp_pkg@1.0-0\n",
-                ])
-
-                self.pkg("install incorp_pkg nover_incorp_pkg")
-                self._search_op(True, 'incorp_pkg', res)
-
-                self.pkg("uninstall nover_incorp_pkg")
-                self._search_op(True, 'incorp_pkg', res)
-
-        def test_bug_7835(self):
-                """Check that installing a package in a non-empty image
-                without an index doesn't build an index."""
-                # This test can't be moved to t_api_search until bug 8497 has
-                # been resolved.
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, (self.fat_pkg10, self.example_pkg10))
-
-                self.image_create(durl)
-
-                self.pkg("install fat")
-
-                id, tid = self._get_index_dirs()
-                self.assertTrue(len(os.listdir(id)) > 0)
-                shutil.rmtree(id)
-                os.makedirs(id)
-                self.pkg("install example_pkg")
-                self.assertTrue(len(os.listdir(id)) == 0)
-                self.pkg("uninstall fat")
-                self.assertTrue(len(os.listdir(id)) == 0)
-                self._run_local_tests()
-                self.pkgsend_bulk(durl, self.example_pkg10)
-                self.pkg("refresh")
-                self.pkg("update")
-                self.assertTrue(len(os.listdir(id)) == 0)
-
-        def test_bug_8098(self):
-                """Check that parse errors don't cause tracebacks in the client
-                or the server."""
-
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.example_pkg10)
-
-                self.image_create(durl)
-
-                self.pkg("install example_pkg")
-
-                self.pkg("search -l 'Intel(R)'", exit=1)
-                self.pkg("search -l 'foo AND <bar>'", exit=1)
-                self.pkg("search -r 'Intel(R)'", exit=1)
-                self.pkg("search -r 'foo AND <bar>'", exit=1)
-
-                urlopen("{0}/en/search.shtml?token=foo+AND+<bar>&"
-                    "action=Search".format(durl))
-                urlopen("{0}/en/search.shtml?token=Intel(R)&"
-                    "action=Search".format(durl))
-
-                pkg5unittest.eval_assert_raises(HTTPError,
-                    lambda x: x.code == 400, urlopen,
-                    "{0}/search/1/False_2_None_None_Intel%28R%29".format(durl))
-                pkg5unittest.eval_assert_raises(HTTPError,
-                    lambda x: x.code == 400, urlopen,
-                    "{0}/search/1/False_2_None_None_foo%20%3Cbar%3E".format(durl))
-
-        def test_bug_10515(self):
-                """Check that -o and -H options work as expected."""
-
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.example_pkg10)
-
-                self.image_create(durl)
-
-                o_options = "action.name,action.key,pkg.name,pkg.shortfmri," \
-                    "search.match,search.match_type,mode,owner,group," \
-                    "action.raw,pkg.publisher"
-
-                pkg_options = "-o pkg.name -o pkg.shortfmri -o pkg.publisher " \
-                    "-o mode"
-
-                self._search_op(True, "-o {0} example_path".format(o_options),
-                    self.res_o_options_remote)
-                self._search_op(True, "-H -o {0} example_path".format(o_options),
-                    [self.o_results])
-                self._search_op(True, "-s {0} -o {1} example_path".format(
-                    durl, o_options), self.res_o_options_remote)
-
-                self._search_op(True, "{0} -p example_path".format(pkg_options),
-                    self.res_pkg_options_remote)
-                self._search_op(True, "{0} '<example_path>'".format(pkg_options),
-                    self.res_pkg_options_remote)
-
-                self.pkg("install example_pkg")
-                self._search_op(False, "-o {0} example_path".format(o_options),
-                    self.res_o_options_local)
-                self._search_op(False, "-H -o {0} example_path".format(o_options),
-                    [self.o_results_no_pub])
-
-                self._search_op(False, "{0} -p example_path".format(pkg_options),
-                    self.res_pkg_options_local)
-                self._search_op(False, "{0} '<example_path>'".format(pkg_options),
-                    self.res_pkg_options_local)
-
-                id, tid = self._get_index_dirs()
-                shutil.rmtree(id)
-                self._search_op(False, "-o {0} example_path".format(o_options),
-                    self.res_o_options_local)
-                self._search_op(False, "-H -o {0} example_path".format(o_options),
-                    [self.o_results_no_pub])
-
-        def test_bug_12271_14088(self):
-                """Check that consecutive duplicate lines are removed and
-                that having a single option to -o still prints the header."""
-
-                # This test assumes that search is basically working and focuses
-                # on testing whether consecutive duplicate lines have been
-                # correctly removed.  For the first three queries, two lines are
-                # expected.  The first line is the headers and the second is
-                # a line for the matching package.  Without consecutive
-                # duplicate line removal, far more than two lines would be
-                # seen.  The final query has four lines of output.  The headers
-                # are the first line and the package name followed by
-                # com.sun.service.incorporated_changes, com.sun.service.bug_ids,
-                # or com.sun.service.keywords.
-
-                # The final query depends on search returning the results in
-                # a consistent ordering so that all the like lines get merged
-                # together.  If this changes in the future, because of parallel
-                # indexing or parallel searching for example, it's possible
-                # this test will need to be removed or reexamined.
-
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(durl, self.dup_lines_pkg10)
-
-                self.image_create(durl)
-
-                self.pkg("search -a 'dup_lines:set:pkg.fmri:'")
-                self.assertEqual(len(self.output.splitlines()), 2)
-
-                self.pkg("search -a -o pkg.shortfmri 'a'")
-                self.assertEqual(len(self.output.splitlines()), 2)
-
-                self.pkg("install dup_lines")
-
-                self.pkg("search -a -l 'dup_lines:set:pkg.fmri:'")
-                self.assertEqual(len(self.output.splitlines()), 2)
-
-                self.pkg("search -l -a -o pkg.shortfmri,action.key 'a'")
-                self.assertEqual(len(self.output.splitlines()), 4)
-
-        def __run_empty_attrs_searches(self, remote):
-                expected = set(["basename\tfile\tetc/group\tpkg:/empty@1.0\n"])
-                self._search_op(remote=remote, token="group",
-                    test_value=expected, headers=False)
-
-                expected = set(["pkg.fmri\tset\ttest/empty\t"
-                    "pkg:/empty@1.0"])
-                self._search_op(remote=remote, token="empty",
-                    test_value=expected, headers=False)
-
-                expected = set(["name\tuser\tfozzie\tpkg:/empty@1.0"])
-                self._search_op(remote=remote, token="fozzie",
-                    test_value=expected, headers=False)
-
-                expected = set(["name\tgroup\tfoo\tpkg:/empty@1.0"])
-                self._search_op(remote=remote, token="foo",
-                    test_value=expected, headers=False)
-
-                expected = set(["path\tlink\tlink\tpkg:/empty@1.0"])
-                self._search_op(remote=remote, token="/link",
-                    test_value=expected, headers=False)
-
-                expected = set(["path\tdir\tempty_dir\tpkg:/empty@1.0"])
-                self._search_op(remote=remote, token="/empty_dir",
-                    test_value=expected, headers=False)
-
-                expected = set(["optional\tdepend\texample_pkg@1.0\t"
-                    "pkg:/empty@1.0"])
-                self._search_op(remote=remote, token="example_pkg",
-                    test_value=expected, headers=False)
-
-        def test_empty_attrs_new(self):
-                """Check that attributes that can have empty values don't break
-                indexing or search when they're added to an empty index."""
-
-                rurl = self.dc.get_repo_url()
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(rurl, self.empty_attr_pkg10)
-
-                self.image_create(durl)
-
-                self.__run_empty_attrs_searches(remote=True)
-                self.pkg("install empty")
-                self.__run_empty_attrs_searches(remote=False)
-
-        def test_empty_attrs_additional(self):
-                """Check that attributes that can have empty values don't break
-                indexing or search when they're being added to an existing
-                index."""
-
-                rurl = self.dc.get_repo_url()
-                durl = self.dc.get_depot_url()
-                self.pkgsend_bulk(rurl, self.fat_pkg10)
-                self.pkgsend_bulk(rurl, self.empty_attr_pkg10)
-
-                self.image_create(durl)
-
-                self.__run_empty_attrs_searches(remote=True)
-                self.pkg("install fat")
-                self.pkg("install empty")
-                self.__run_empty_attrs_searches(remote=False)
-                for i in range(0, indexer.MAX_FAST_INDEXED_PKGS + 1):
-                        self.pkgsend_bulk(durl, self.empty_attr_pkg10_templ.format(
-                            ver=i))
-                self.pkg("install 'empty*'")
-                self.pkg("search 'empty*'")
-
-        def test_missing_manifest(self):
-                """Check that missing manifests don't cause a traceback when
-                indexing or searching."""
-
-                rurl = self.dc.get_repo_url()
-                plist = self.pkgsend_bulk(rurl, self.example_pkg10)
-                api_obj = self.image_create(rurl)
-                self._api_install(api_obj, ["example_pkg"])
-                client_manifest_file = self.get_img_manifest_path(
-                    fmri.PkgFmri(plist[0]))
-                portable.remove(client_manifest_file)
-                # Test search with a missing manifest.
-                self.pkg("search -l /bin", exit=1)
-                # Test rebuilding the index with a missing manifest.
-                self.pkg("rebuild-index")
-
-        def test_15807844(self):
-                """ Check that pkg search for temporary sources is successful
-                when there no publishers configured in the image."""
-
-                rurl = self.dc.get_repo_url()
-                self.pkgsend_bulk(rurl, self.example_pkg10)
-                self.image_create()
-                expected = \
-                "INDEX ACTION VALUE PACKAGE\n" \
-                "basename file bin/example_path pkg:/example_pkg@1.0-0\n"
-                self.pkg("search -s {0} example_path".format(self.rurl))
-                actual = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected)
-                self.assertEqualDiff(expected, actual)
-                self.pkg("search example_path", exit=1)
+            "hash                                     file   bin/example_path pkg:/example_pkg@1.0-0\n",
+        ]
+    )
+
+    o_headers = (
+        "ACTION.NAME ACTION.KEY PKG.NAME "
+        "PKG.SHORTFMRI SEARCH.MATCH "
+        "SEARCH.MATCH_TYPE MODE OWNER GROUP "
+        "ACTION.RAW PKG.PUBLISHER\n"
+    )
+
+    o_results_no_pub = (
+        "file bin/example_path example_pkg "
+        "pkg:/example_pkg@1.0-0 bin/example_path "
+        "basename 0555 root bin "
+        "file b40981aab75932c5b2f555f50769d878e44913d7 chash=6a4299897fca0c4d0d18870da29a0dc7ae23b79c group=bin mode=0555 owner=root path=bin/example_path pkg.content-hash=file:sha512t_256:8e3b2cea6dc6c4954cf8205bff833ead1f2eb3d4850525544cde0242c971452d pkg.content-hash=gzip:sha512t_256:8846fa174b11c8241080d58796509ef3f86f1dba119f318d32e5ca1b2be33f91 pkg.csize=25 pkg.size=5\n"
+    )
+
+    o_results = o_results_no_pub.rstrip() + " test\n"
+
+    res_o_options_remote = set([o_headers, o_results])
+
+    res_o_options_local = set([o_headers, o_results_no_pub])
+
+    pkg_headers = "PKG.NAME PKG.SHORTFMRI PKG.PUBLISHER MODE"
+    pkg_results_no_pub = "example_pkg pkg:/example_pkg@1.0-0"
+    pkg_results = pkg_results_no_pub + " test"
+
+    res_pkg_options_remote = set([pkg_headers, pkg_results])
+    res_pkg_options_local = set([pkg_headers, pkg_results_no_pub])
+
+    # Creating a query string in which the number of terms is > 100
+    large_query = (
+        "a b c d e f g h i j k l m n o p q r s t u v w x y z"
+        "a b c d e f g h i j k l m n o p q r s t u v w x y z"
+        "a b c d e f g h i j k l m n o p q r s t u v w x y z"
+        "a b c d e f g h i j k l m n o p q r s t u v w x y z"
+        "a b c d e f g h i j k l m n o p q r s t u v w x y z"
+        "a b c d e f g h i j k l m n o p q r s t u v w x y z"
+    )
+
+    def setUp(self):
+        # This test needs an actual depot for now.
+        pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
+        self.make_misc_files(self.misc_files)
+        self.init_mem_setting = None
+
+    def _check(self, proposed_answer, correct_answer):
+        if correct_answer == proposed_answer:
+            return True
+        if len(proposed_answer) == len(correct_answer) and sorted(
+            [p.strip().split() for p in proposed_answer]
+        ) == sorted([c.strip().split() for c in correct_answer]):
+            return True
+        self.debug("Proposed Answer: " + str(proposed_answer))
+        self.debug("Correct Answer : " + str(correct_answer))
+        if isinstance(correct_answer, set) and isinstance(proposed_answer, set):
+            print(
+                "Missing: " + str(correct_answer - proposed_answer),
+                file=sys.stderr,
+            )
+            print(
+                "Extra  : " + str(proposed_answer - correct_answer),
+                file=sys.stderr,
+            )
+        self.assertTrue(correct_answer == proposed_answer)
+
+    def _search_op(
+        self,
+        remote,
+        token,
+        test_value,
+        case_sensitive=False,
+        return_actions=True,
+        exit=0,
+        su_wrap=False,
+        prune_versions=True,
+        headers=True,
+    ):
+        outfile = os.path.join(self.test_root, "res")
+        if remote:
+            token = "-r " + token
+        else:
+            token = "-l " + token
+        if case_sensitive:
+            token = "-I " + token
+        if return_actions:
+            token = "-a " + token
+        else:
+            token = "-p " + token
+        if not prune_versions:
+            token = "-f " + token
+        if not headers:
+            token = "-H " + token
+        self.pkg("search " + token + " > " + outfile, exit=exit)
+        res_list = (open(outfile, "r")).readlines()
+        self._check(set(res_list), test_value)
+
+    def _run_remote_tests(self):
+        # This should be possible now that the server automatically adds
+        # FMRIs to manifests (during publication).
+        self.pkg("search -a -r example_pkg")
+
+        self._search_op(True, "example_path", self.res_remote_path)
+        self._search_op(
+            True,
+            "':set:pkg.fmri:exAMple_pkg'",
+            self.res_remote_case_sensitive,
+            case_sensitive=False,
+        )
+        self._search_op(True, "'(example_path)'", self.res_remote_path)
+        self._search_op(True, "'<exam*:::>'", self.res_remote_pkg_ret_pkg)
+        self._search_op(
+            True, "'::com.sun.service.info_url:'", self.res_remote_url
+        )
+        self._search_op(True, "':::e* AND *path'", self.res_remote_path)
+        self._search_op(True, "'e* AND *path'", self.res_remote_path)
+        self._search_op(True, "'<e*>'", self.res_remote_pkg_ret_pkg)
+        self._search_op(True, "'<e*> AND <e*>'", self.res_remote_pkg_ret_pkg)
+        self._search_op(True, "'<e*> OR <e*>'", self.res_remote_pkg_ret_pkg)
+        self._search_op(True, "'<exam:::>'", self.res_remote_pkg_ret_pkg)
+        self._search_op(True, "'exam:::e*path'", self.res_remote_path)
+        self._search_op(True, "'exam:::e*path AND e*:::'", self.res_remote_path)
+        self._search_op(
+            True, "'e*::: AND exam:::*path'", self.res_remote_path_extra
+        )
+        self._search_op(True, "'example*'", self.res_remote_wildcard)
+        self._search_op(True, "/bin", self.res_remote_bin)
+        self._search_op(True, "4851433", self.res_remote_bug_id)
+        self._search_op(
+            True, "'<4851433> AND <4725245>'", self.res_remote_pkg_ret_pkg
+        )
+        self._search_op(True, "4851433 AND 4725245", self.res_remote_bug_id)
+        self._search_op(
+            True, "4851433 AND 4725245 OR example_path", self.res_remote_bug_id
+        )
+        self._search_op(
+            True,
+            "'4851433 AND (4725245 OR example_path)'",
+            self.res_remote_bug_id,
+        )
+        self._search_op(
+            True,
+            "'(4851433 AND 4725245) OR example_path'",
+            self.res_remote_bug_id | self.res_remote_path,
+        )
+        self._search_op(
+            True,
+            "4851433 OR 4725245",
+            self.res_remote_bug_id | self.res_remote_bug_id,
+        )
+        self._search_op(True, "6556919", self.res_remote_inc_changes)
+        self._search_op(True, "'6556?19'", self.res_remote_inc_changes)
+        self._search_op(True, "42", self.res_remote_random_test)
+        self._search_op(True, "79", self.res_remote_random_test_79)
+        self._search_op(True, "separator", self.res_remote_keywords)
+        self._search_op(True, "'\"sort 0x86\"'", self.res_remote_keywords)
+        self._search_op(True, "'*example*'", self.res_remote_glob)
+        self._search_op(True, "fooo", self.res_remote_foo)
+        self._search_op(True, "'fo*'", self.res_remote_foo)
+        self._search_op(True, "bar", self.res_remote_foo)
+        self._search_op(True, "openssl", self.res_remote_openssl)
+        self._search_op(True, "OPENSSL", self.res_remote_openssl)
+        self._search_op(True, "OpEnSsL", self.res_remote_openssl)
+        self._search_op(True, "'OpEnS*'", self.res_remote_openssl)
+
+        # Verify that search will work for an unprivileged user even if
+        # the download directory doesn't exist.
+        img = self.get_img_api_obj().img
+        cache_dirs = [
+            path for path, readonly, pub, layout in img.get_cachedirs()
+        ]
+        for path in cache_dirs:
+            shutil.rmtree(path, ignore_errors=True)
+            self.assertFalse(os.path.exists(path))
+        self._search_op(True, "'fo*'", self.res_remote_foo, su_wrap=True)
+
+        # These tests are included because a specific bug
+        # was found during development. This prevents regression back
+        # to that bug. Exit status of 1 is expected because the
+        # token isn't in the packages.
+        self.pkg("search -a -r a_non_existent_token", exit=1)
+        self.pkg("search -a -r a_non_existent_token", exit=1)
+
+        self.pkg("search -a -r '42 AND 4641790'", exit=1)
+        self.pkg("search -a -r '<e*> AND e*'", exit=1)
+        self.pkg("search -a -r 'e* AND <e*>'", exit=1)
+        self.pkg("search -a -r '<e*> OR e*'", exit=1)
+        self.pkg("search -a -r 'e* OR <e*>'", exit=1)
+        self._search_op(True, "pkg:/example_path", self.res_remote_path)
+        self.pkg("search -a -r -I ':set:pkg.fmri:exAMple_pkg'", exit=1)
+        self.assertTrue(self.errout == "")
+
+        self.pkg("search -a -r {0}".format(self.large_query), exit=1)
+        self.assertTrue(self.errout != "")
+
+    def _run_local_tests(self):
+        outfile = os.path.join(self.test_root, "res")
+
+        # This finds something because the client side
+        # manifest has had the name of the package inserted
+        # into it.
+
+        self._search_op(False, "example_pkg", self.res_local_pkg)
+        self._search_op(False, "'(example_pkg)'", self.res_local_pkg)
+        self._search_op(False, "'<exam*:::>'", self.res_local_pkg_ret_pkg)
+        self._search_op(
+            False, "'::com.sun.service.info_url:'", self.res_remote_url
+        )
+        self._search_op(False, "':::e* AND *path'", self.res_remote_path)
+        self._search_op(False, "'e* AND *path'", self.res_local_path)
+        self._search_op(False, "'<e*>'", self.res_local_pkg_ret_pkg)
+        self._search_op(False, "'<e*> AND <e*>'", self.res_local_pkg_ret_pkg)
+        self._search_op(False, "'<e*> OR <e*>'", self.res_local_pkg_ret_pkg)
+        self._search_op(False, "'<exam:::>'", self.res_local_pkg_ret_pkg)
+        self._search_op(False, "'exam:::e*path'", self.res_remote_path)
+        self._search_op(False, "'exam:::e*path AND e:::'", self.res_remote_path)
+        self._search_op(
+            False, "'e::: AND exam:::e*path'", self.res_remote_path_extra
+        )
+        self._search_op(False, "'example*'", self.res_local_wildcard)
+        self._search_op(False, "/bin", self.res_local_bin)
+        self._search_op(False, "4851433", self.res_local_bug_id)
+        self._search_op(
+            False, "'<4851433> AND <4725245>'", self.res_local_pkg_ret_pkg
+        )
+        self._search_op(False, "4851433 AND 4725245", self.res_remote_bug_id)
+        self._search_op(
+            False, "4851433 AND 4725245 OR example_path", self.res_remote_bug_id
+        )
+        self._search_op(
+            False,
+            "'4851433 AND (4725245 OR example_path)'",
+            self.res_remote_bug_id,
+        )
+        self._search_op(
+            False,
+            "'(4851433 AND 4725245) OR example_path'",
+            self.res_remote_bug_id | self.res_local_path,
+        )
+        self._search_op(
+            False,
+            "4851433 OR 4725245",
+            self.res_remote_bug_id | self.res_remote_bug_id,
+        )
+        self._search_op(False, "6556919", self.res_local_inc_changes)
+        self._search_op(False, "'65569??'", self.res_local_inc_changes)
+        self._search_op(False, "42", self.res_local_random_test)
+        self._search_op(False, "79", self.res_local_random_test_79)
+        self._search_op(False, "separator", self.res_local_keywords)
+        self._search_op(False, "'\"sort 0x86\"'", self.res_remote_keywords)
+        self._search_op(False, "'*example*'", self.res_local_glob)
+        self._search_op(False, "fooo", self.res_local_foo)
+        self._search_op(False, "'fo*'", self.res_local_foo)
+        self._search_op(False, "bar", self.res_local_foo)
+        self._search_op(False, "openssl", self.res_local_openssl)
+        self._search_op(False, "OPENSSL", self.res_local_openssl)
+        self._search_op(False, "OpEnSsL", self.res_local_openssl)
+        self._search_op(False, "'OpEnS*'", self.res_local_openssl)
+
+        # These tests are included because a specific bug
+        # was found during development. These tests prevent regression
+        # back to that bug. Exit status of 1 is expected because the
+        # token isn't in the packages.
+        self.pkg("search -a -l a_non_existent_token", exit=1)
+        self.pkg("search -a -l a_non_existent_token", exit=1)
+        self.pkg("search -a -l '42 AND 4641790'", exit=1)
+        self.pkg("search -a -l '<e*> AND e*'", exit=1)
+        self.pkg("search -a -l 'e* AND <e*>'", exit=1)
+        self.pkg("search -a -l '<e*> OR e*'", exit=1)
+        self.pkg("search -a -l 'e* OR <e*>'", exit=1)
+        self._search_op(False, "pkg:/example_path", self.res_local_path)
+
+        self.pkg("search -a -l {0}".format(self.large_query), exit=1)
+        self.assertTrue(self.errout != "")
+
+    def _run_local_empty_tests(self):
+        self.pkg("search -a -l example_pkg", exit=1)
+        self.pkg("search -a -l example_path", exit=1)
+        self.pkg("search -a -l 'example*'", exit=1)
+        self.pkg("search -a -l /bin", exit=1)
+
+    def _run_remote_empty_tests(self):
+        self.pkg("search -a -r example_pkg", exit=1)
+        self.pkg("search -a -r example_path", exit=1)
+        self.pkg("search -a -r 'example*'", exit=1)
+        self.pkg("search -a -r /bin", exit=1)
+        self.pkg("search -a -r '*unique*'", exit=1)
+
+    def _get_index_dirs(self):
+        index_dir = self.get_img_api_obj().img.index_dir
+        index_dir_tmp = os.path.join(index_dir, "TMP")
+        return index_dir, index_dir_tmp
+
+    def pkgsend_bulk(self, durl, pkg):
+        # Ensure indexing is performed for every published package.
+        plist = pkg5unittest.SingleDepotTestCase.pkgsend_bulk(
+            self, durl, pkg, refresh_index=True
+        )
+        self.wait_repo(self.dc.get_repodir())
+        return plist
+
+    def test_pkg_search_cli(self):
+        """Test search cli options."""
+
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.example_pkg10)
+        self.image_create(durl)
+
+        self.pkg("search", exit=2)
+
+        # Bug 1541
+        self.pkg("search -s {0} bin".format("httP" + durl[4:]))
+        self.pkg("search -s ftp://pkg.opensolaris.org:88 bge", exit=1)
+
+        # Testing interaction of -o and -p options
+        self.pkgsend_bulk(durl, self.example_pkg10)
+        self.pkg("search -o action.name -p pkg", exit=2)
+        self.pkg("search -o action.name -a '<pkg>'", exit=1)
+        self.pkg("search -o action.name -a '<example_path>'", exit=2)
+        self.pkg("search -o action.key -p pkg", exit=2)
+        self.pkg("search -o action.key -a '<pkg>'", exit=1)
+        self.pkg("search -o action.key -a '<example_path>'", exit=2)
+        self.pkg("search -o search.match -p pkg", exit=2)
+        self.pkg("search -o search.match -a '<pkg>'", exit=1)
+        self.pkg("search -o search.match -a '<example_path>'", exit=2)
+        self.pkg("search -o search.match_type -p pkg", exit=2)
+        self.pkg("search -o search.match_type -a '<pkg>'", exit=1)
+        self.pkg("search -o search.match_type -a '<example_path>'", exit=2)
+        self.pkg("search -o action.foo -a pkg", exit=2)
+
+    def test_remote(self):
+        """Test remote search."""
+        # Need to retain to check that default search does remote, not
+        # local search, and that -r and -s work as expected
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.example_pkg10)
+
+        self.image_create(durl)
+        self._run_remote_tests()
+        self._search_op(True, "':file::'", self.res_remote_file)
+        self.pkg("search '*'")
+        self.pkg("search -r '*'")
+        self.pkg("search -s {0} '*'".format(durl))
+        self.pkg("search -l '*'", exit=1)
+
+    def test_local_0(self):
+        """Install one package, and run the search suite."""
+        # Need to retain that -l works as expected
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.example_pkg10)
+
+        self.image_create(durl)
+
+        self.pkg("install example_pkg")
+
+        self._run_local_tests()
+
+    def test_bug_1873(self):
+        """Test to see if malformed actions cause tracebacks during
+        indexing for client or server."""
+        # Can't be moved to api search since this is to test for
+        # tracebacks
+        durl = self.dc.get_depot_url()
+        depotpath = self.dc.get_repodir()
+        server_manifest_path = os.path.join(
+            depotpath,
+            "publisher",
+            "test",
+            "pkg",
+            self.bogus_fmri.get_dir_path(),
+        )
+        os.makedirs(os.path.dirname(server_manifest_path))
+        tmp_ind_dir = os.path.join(depotpath, "index", "TMP")
+
+        fh = open(server_manifest_path, "w")
+        fh.write(self.bogus_pkg10)
+        fh.close()
+
+        self.image_create(durl)
+        self.dc.stop()
+        self.dc.set_rebuild()
+        self.dc.start()
+
+        # Should return nothing, as the server can't build catalog
+        # data for the package since the manifest is unparseable.
+        self._search_op(True, "'*bogus*'", set(), exit=1)
+        self._search_op(True, "6627937", set(), exit=1)
+
+        # Should fail since the bogus_pkg isn't even in the catalog.
+        self.pkg("install bogus_pkg", exit=1)
+
+        client_manifest_file = self.get_img_manifest_path(self.bogus_fmri)
+        os.makedirs(os.path.dirname(client_manifest_file))
+
+        fh = open(client_manifest_file, "w")
+        fh.write(self.bogus_pkg10)
+        fh.close()
+
+        # Load the 'installed' catalog and add an entry for the
+        # new package version.
+        img = self.get_img_api_obj().img
+        istate_dir = os.path.join(img._statedir, "installed")
+        cat = catalog.Catalog(meta_root=istate_dir)
+        mdata = {"states": [pkgdefs.PKG_STATE_INSTALLED]}
+        bfmri = self.bogus_fmri.copy()
+        bfmri.set_publisher("test")
+        cat.add_package(bfmri, metadata=mdata)
+        cat.save()
+
+        self.pkg("rebuild-index")
+        self._search_op(False, "'*bogus*'", set(self.res_bogus_name_result))
+        self._search_op(False, "6627937", set(self.res_bogus_number_result))
+
+    def test_bug_6177(self):
+        """Test that by default search restricts the results to the
+        incorporated packages and that the -f option works as
+        expected."""
+
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(
+            durl, (self.example_pkg10, self.example_pkg11, self.incorp_pkg10)
+        )
+
+        self.image_create(durl)
+
+        res_both_actions = set(
+            [
+                self.headers,
+                "path       dir    bin   pkg:/example_pkg@1.0-0\n",
+                "path       dir    bin   pkg:/example_pkg@1.1-0\n",
+            ]
+        )
+
+        res_10_action = set(
+            [self.headers, "path       dir    bin   pkg:/example_pkg@1.0-0\n"]
+        )
+
+        res_11_action = set(
+            [self.headers, "path       dir    bin   pkg:/example_pkg@1.1-0\n"]
+        )
+
+        self.pkg("install incorp_pkg")
+        self._search_op(True, "/bin", res_10_action)
+        self._search_op(True, "/bin", res_both_actions, prune_versions=False)
+
+        self.pkg("uninstall incorp_pkg")
+        self.pkg("install example_pkg")
+        self._search_op(True, "/bin", res_11_action)
+        self._search_op(True, "/bin", res_both_actions, prune_versions=False)
+
+    def test_fmri_output(self):
+        """Test that the build_release is dropped from version string
+        of pkg FMRIS for the special case '-o pkg.fmri'."""
+
+        durl = self.dc.get_depot_url()
+        plist = self.pkgsend_bulk(durl, self.incorp_pkg10)
+
+        self.image_create(durl)
+        self.pkg("search -Ho pkg.fmri incorp_pkg")
+        self.assertTrue(
+            fmri.PkgFmri(plist[0]).get_fmri(include_build=False, anarchy=True)
+            in self.output
+        )
+
+    def test_versionless_incorp(self):
+        """Test that versionless incorporates are ignored by search when
+        restricting results to incorporated packages (see bug 7149895).
+        """
+
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, (self.incorp_pkg10, self.nover_incorp_pkg10))
+
+        self.image_create(durl)
+
+        res = set(
+            [
+                self.headers,
+                "pkg.fmri    set    test/incorp_pkg pkg:/incorp_pkg@1.0-0\n",
+                "incorporate depend incorp_pkg      pkg:/nover_incorp_pkg@1.0-0\n",
+            ]
+        )
+
+        self.pkg("install incorp_pkg nover_incorp_pkg")
+        self._search_op(True, "incorp_pkg", res)
+
+        self.pkg("uninstall nover_incorp_pkg")
+        self._search_op(True, "incorp_pkg", res)
+
+    def test_bug_7835(self):
+        """Check that installing a package in a non-empty image
+        without an index doesn't build an index."""
+        # This test can't be moved to t_api_search until bug 8497 has
+        # been resolved.
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, (self.fat_pkg10, self.example_pkg10))
+
+        self.image_create(durl)
+
+        self.pkg("install fat")
+
+        id, tid = self._get_index_dirs()
+        self.assertTrue(len(os.listdir(id)) > 0)
+        shutil.rmtree(id)
+        os.makedirs(id)
+        self.pkg("install example_pkg")
+        self.assertTrue(len(os.listdir(id)) == 0)
+        self.pkg("uninstall fat")
+        self.assertTrue(len(os.listdir(id)) == 0)
+        self._run_local_tests()
+        self.pkgsend_bulk(durl, self.example_pkg10)
+        self.pkg("refresh")
+        self.pkg("update")
+        self.assertTrue(len(os.listdir(id)) == 0)
+
+    def test_bug_8098(self):
+        """Check that parse errors don't cause tracebacks in the client
+        or the server."""
+
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.example_pkg10)
+
+        self.image_create(durl)
+
+        self.pkg("install example_pkg")
+
+        self.pkg("search -l 'Intel(R)'", exit=1)
+        self.pkg("search -l 'foo AND <bar>'", exit=1)
+        self.pkg("search -r 'Intel(R)'", exit=1)
+        self.pkg("search -r 'foo AND <bar>'", exit=1)
+
+        urlopen(
+            "{0}/en/search.shtml?token=foo+AND+<bar>&"
+            "action=Search".format(durl)
+        )
+        urlopen(
+            "{0}/en/search.shtml?token=Intel(R)&" "action=Search".format(durl)
+        )
+
+        pkg5unittest.eval_assert_raises(
+            HTTPError,
+            lambda x: x.code == 400,
+            urlopen,
+            "{0}/search/1/False_2_None_None_Intel%28R%29".format(durl),
+        )
+        pkg5unittest.eval_assert_raises(
+            HTTPError,
+            lambda x: x.code == 400,
+            urlopen,
+            "{0}/search/1/False_2_None_None_foo%20%3Cbar%3E".format(durl),
+        )
+
+    def test_bug_10515(self):
+        """Check that -o and -H options work as expected."""
+
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.example_pkg10)
+
+        self.image_create(durl)
+
+        o_options = (
+            "action.name,action.key,pkg.name,pkg.shortfmri,"
+            "search.match,search.match_type,mode,owner,group,"
+            "action.raw,pkg.publisher"
+        )
+
+        pkg_options = "-o pkg.name -o pkg.shortfmri -o pkg.publisher " "-o mode"
+
+        self._search_op(
+            True,
+            "-o {0} example_path".format(o_options),
+            self.res_o_options_remote,
+        )
+        self._search_op(
+            True, "-H -o {0} example_path".format(o_options), [self.o_results]
+        )
+        self._search_op(
+            True,
+            "-s {0} -o {1} example_path".format(durl, o_options),
+            self.res_o_options_remote,
+        )
+
+        self._search_op(
+            True,
+            "{0} -p example_path".format(pkg_options),
+            self.res_pkg_options_remote,
+        )
+        self._search_op(
+            True,
+            "{0} '<example_path>'".format(pkg_options),
+            self.res_pkg_options_remote,
+        )
+
+        self.pkg("install example_pkg")
+        self._search_op(
+            False,
+            "-o {0} example_path".format(o_options),
+            self.res_o_options_local,
+        )
+        self._search_op(
+            False,
+            "-H -o {0} example_path".format(o_options),
+            [self.o_results_no_pub],
+        )
+
+        self._search_op(
+            False,
+            "{0} -p example_path".format(pkg_options),
+            self.res_pkg_options_local,
+        )
+        self._search_op(
+            False,
+            "{0} '<example_path>'".format(pkg_options),
+            self.res_pkg_options_local,
+        )
+
+        id, tid = self._get_index_dirs()
+        shutil.rmtree(id)
+        self._search_op(
+            False,
+            "-o {0} example_path".format(o_options),
+            self.res_o_options_local,
+        )
+        self._search_op(
+            False,
+            "-H -o {0} example_path".format(o_options),
+            [self.o_results_no_pub],
+        )
+
+    def test_bug_12271_14088(self):
+        """Check that consecutive duplicate lines are removed and
+        that having a single option to -o still prints the header."""
+
+        # This test assumes that search is basically working and focuses
+        # on testing whether consecutive duplicate lines have been
+        # correctly removed.  For the first three queries, two lines are
+        # expected.  The first line is the headers and the second is
+        # a line for the matching package.  Without consecutive
+        # duplicate line removal, far more than two lines would be
+        # seen.  The final query has four lines of output.  The headers
+        # are the first line and the package name followed by
+        # com.sun.service.incorporated_changes, com.sun.service.bug_ids,
+        # or com.sun.service.keywords.
+
+        # The final query depends on search returning the results in
+        # a consistent ordering so that all the like lines get merged
+        # together.  If this changes in the future, because of parallel
+        # indexing or parallel searching for example, it's possible
+        # this test will need to be removed or reexamined.
+
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(durl, self.dup_lines_pkg10)
+
+        self.image_create(durl)
+
+        self.pkg("search -a 'dup_lines:set:pkg.fmri:'")
+        self.assertEqual(len(self.output.splitlines()), 2)
+
+        self.pkg("search -a -o pkg.shortfmri 'a'")
+        self.assertEqual(len(self.output.splitlines()), 2)
+
+        self.pkg("install dup_lines")
+
+        self.pkg("search -a -l 'dup_lines:set:pkg.fmri:'")
+        self.assertEqual(len(self.output.splitlines()), 2)
+
+        self.pkg("search -l -a -o pkg.shortfmri,action.key 'a'")
+        self.assertEqual(len(self.output.splitlines()), 4)
+
+    def __run_empty_attrs_searches(self, remote):
+        expected = set(["basename\tfile\tetc/group\tpkg:/empty@1.0\n"])
+        self._search_op(
+            remote=remote, token="group", test_value=expected, headers=False
+        )
+
+        expected = set(["pkg.fmri\tset\ttest/empty\t" "pkg:/empty@1.0"])
+        self._search_op(
+            remote=remote, token="empty", test_value=expected, headers=False
+        )
+
+        expected = set(["name\tuser\tfozzie\tpkg:/empty@1.0"])
+        self._search_op(
+            remote=remote, token="fozzie", test_value=expected, headers=False
+        )
+
+        expected = set(["name\tgroup\tfoo\tpkg:/empty@1.0"])
+        self._search_op(
+            remote=remote, token="foo", test_value=expected, headers=False
+        )
+
+        expected = set(["path\tlink\tlink\tpkg:/empty@1.0"])
+        self._search_op(
+            remote=remote, token="/link", test_value=expected, headers=False
+        )
+
+        expected = set(["path\tdir\tempty_dir\tpkg:/empty@1.0"])
+        self._search_op(
+            remote=remote,
+            token="/empty_dir",
+            test_value=expected,
+            headers=False,
+        )
+
+        expected = set(["optional\tdepend\texample_pkg@1.0\t" "pkg:/empty@1.0"])
+        self._search_op(
+            remote=remote,
+            token="example_pkg",
+            test_value=expected,
+            headers=False,
+        )
+
+    def test_empty_attrs_new(self):
+        """Check that attributes that can have empty values don't break
+        indexing or search when they're added to an empty index."""
+
+        rurl = self.dc.get_repo_url()
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(rurl, self.empty_attr_pkg10)
+
+        self.image_create(durl)
+
+        self.__run_empty_attrs_searches(remote=True)
+        self.pkg("install empty")
+        self.__run_empty_attrs_searches(remote=False)
+
+    def test_empty_attrs_additional(self):
+        """Check that attributes that can have empty values don't break
+        indexing or search when they're being added to an existing
+        index."""
+
+        rurl = self.dc.get_repo_url()
+        durl = self.dc.get_depot_url()
+        self.pkgsend_bulk(rurl, self.fat_pkg10)
+        self.pkgsend_bulk(rurl, self.empty_attr_pkg10)
+
+        self.image_create(durl)
+
+        self.__run_empty_attrs_searches(remote=True)
+        self.pkg("install fat")
+        self.pkg("install empty")
+        self.__run_empty_attrs_searches(remote=False)
+        for i in range(0, indexer.MAX_FAST_INDEXED_PKGS + 1):
+            self.pkgsend_bulk(durl, self.empty_attr_pkg10_templ.format(ver=i))
+        self.pkg("install 'empty*'")
+        self.pkg("search 'empty*'")
+
+    def test_missing_manifest(self):
+        """Check that missing manifests don't cause a traceback when
+        indexing or searching."""
+
+        rurl = self.dc.get_repo_url()
+        plist = self.pkgsend_bulk(rurl, self.example_pkg10)
+        api_obj = self.image_create(rurl)
+        self._api_install(api_obj, ["example_pkg"])
+        client_manifest_file = self.get_img_manifest_path(
+            fmri.PkgFmri(plist[0])
+        )
+        portable.remove(client_manifest_file)
+        # Test search with a missing manifest.
+        self.pkg("search -l /bin", exit=1)
+        # Test rebuilding the index with a missing manifest.
+        self.pkg("rebuild-index")
+
+    def test_15807844(self):
+        """Check that pkg search for temporary sources is successful
+        when there no publishers configured in the image."""
+
+        rurl = self.dc.get_repo_url()
+        self.pkgsend_bulk(rurl, self.example_pkg10)
+        self.image_create()
+        expected = (
+            "INDEX ACTION VALUE PACKAGE\n"
+            "basename file bin/example_path pkg:/example_pkg@1.0-0\n"
+        )
+        self.pkg("search -s {0} example_path".format(self.rurl))
+        actual = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected)
+        self.assertEqualDiff(expected, actual)
+        self.pkg("search example_path", exit=1)
 
 
 class TestSearchMultiPublisher(pkg5unittest.ManyDepotTestCase):
-
-        same_pub1 = """
+    same_pub1 = """
             open same_pub1@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/samepub_file1 mode=0555 owner=root group=bin path=/bin/samepub_file1
             close """
 
-        same_pub2 = """
+    same_pub2 = """
             open same_pub2@1.1,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/samepub_file2 mode=0555 owner=root group=bin path=/bin/samepub_file2
             close """
 
-        example_pkg11 = """
+    example_pkg11 = """
             open pkg://test1/example_pkg@1.2,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path12
             close """
 
-        incorp_pkg11 = """
+    incorp_pkg11 = """
             open pkg://test1/incorp_pkg@1.2,5.11-0
             add depend fmri=pkg://test1/example_pkg@1.2,5.11-0 type=incorporate
             close """
 
-        example_pkg12 = """
+    example_pkg12 = """
             open pkg://test2/example_pkg@1.2,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add file tmp/example_file mode=0555 owner=root group=bin path=/bin/example_path12
             close """
 
-        incorp_pkg12 = """
+    incorp_pkg12 = """
             open pkg://test2/incorp_pkg@1.3,5.11-0
             add depend fmri=pkg://test2/example_pkg@1.2,5.11-0 type=incorporate
             close """
 
-        misc_files = {
-            "tmp/samepub_file1": "magic",
-            "tmp/samepub_file2": "magic",
-            "tmp/example_file": "magic",
-        }
+    misc_files = {
+        "tmp/samepub_file1": "magic",
+        "tmp/samepub_file2": "magic",
+        "tmp/example_file": "magic",
+    }
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["samepub",
-                    "samepub"], start_depots=True)
-                self.make_misc_files(self.misc_files)
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.pkgsend_bulk(self.durl1, self.same_pub1, refresh_index=True)
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["samepub", "samepub"], start_depots=True
+        )
+        self.make_misc_files(self.misc_files)
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.pkgsend_bulk(self.durl1, self.same_pub1, refresh_index=True)
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
 
-        def test_7140657(self):
-                """ Check that pkg search with -s works as intended when there are
-                two repositories with same publisher name configured."""
+    def test_7140657(self):
+        """Check that pkg search with -s works as intended when there are
+        two repositories with same publisher name configured."""
 
-                self.pkgsend_bulk(self.durl1, self.same_pub1, refresh_index=True)
-                self.pkgsend_bulk(self.durl2, self.same_pub2, refresh_index=True)
-                self.image_create(self.durl1, prefix="samepub")
-                self.pkg("set-publisher -g {0} samepub".format(self.durl2))
-                self.pkg("search -s {0} samepub_file1".format(self.durl1))
+        self.pkgsend_bulk(self.durl1, self.same_pub1, refresh_index=True)
+        self.pkgsend_bulk(self.durl2, self.same_pub2, refresh_index=True)
+        self.image_create(self.durl1, prefix="samepub")
+        self.pkg("set-publisher -g {0} samepub".format(self.durl2))
+        self.pkg("search -s {0} samepub_file1".format(self.durl1))
 
-                result_same_pub = \
-                "INDEX ACTION VALUE PACKAGE\n" \
-                "basename file bin/samepub_file1 pkg:/same_pub1@1.1-0\n"
+        result_same_pub = (
+            "INDEX ACTION VALUE PACKAGE\n"
+            "basename file bin/samepub_file1 pkg:/same_pub1@1.1-0\n"
+        )
 
-                actual = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(result_same_pub)
-                self.assertEqualDiff(expected, actual)
-                self.pkg("search -s {0} samepub_file1".format(self.durl2), exit=1)
+        actual = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(result_same_pub)
+        self.assertEqualDiff(expected, actual)
+        self.pkg("search -s {0} samepub_file1".format(self.durl2), exit=1)
 
-        def test_16190165(self):
-                """ Check that pkg search works fine with structured queries
-                    and the scheme name "pkg://" in the query """
+    def test_16190165(self):
+        """Check that pkg search works fine with structured queries
+        and the scheme name "pkg://" in the query"""
 
-                self.pkgsend_bulk(self.durl1, self.example_pkg11, refresh_index=True)
-                self.pkgsend_bulk(self.durl2, self.example_pkg12, refresh_index=True)
-                self.pkgsend_bulk(self.durl1, self.incorp_pkg11, refresh_index=True)
-                self.pkgsend_bulk(self.durl2, self.incorp_pkg12, refresh_index=True)
-                self.image_create(self.durl1, prefix="test1")
-                self.pkg("set-publisher -g {0} test2".format(self.durl2))
+        self.pkgsend_bulk(self.durl1, self.example_pkg11, refresh_index=True)
+        self.pkgsend_bulk(self.durl2, self.example_pkg12, refresh_index=True)
+        self.pkgsend_bulk(self.durl1, self.incorp_pkg11, refresh_index=True)
+        self.pkgsend_bulk(self.durl2, self.incorp_pkg12, refresh_index=True)
+        self.image_create(self.durl1, prefix="test1")
+        self.pkg("set-publisher -g {0} test2".format(self.durl2))
 
-                expected_out1 = \
-                "incorporate\tdepend\tpkg://test1/example_pkg@1.2,5.11-0\tpkg:/incorp_pkg@1.2-0\n" \
-                "incorporate\tdepend\tpkg://test2/example_pkg@1.2,5.11-0\tpkg:/incorp_pkg@1.3-0\n"
+        expected_out1 = (
+            "incorporate\tdepend\tpkg://test1/example_pkg@1.2,5.11-0\tpkg:/incorp_pkg@1.2-0\n"
+            "incorporate\tdepend\tpkg://test2/example_pkg@1.2,5.11-0\tpkg:/incorp_pkg@1.3-0\n"
+        )
 
-                self.pkg("search -H :depend:incorporate:example_pkg",
-                     exit=0)
-                actual = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected_out1)
-                # Output order is unstable in Python 3, we just assert the
-                # results are the same.
-                for l in actual:
-                        assert l in expected
+        self.pkg("search -H :depend:incorporate:example_pkg", exit=0)
+        actual = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected_out1)
+        # Output order is unstable in Python 3, we just assert the
+        # results are the same.
+        for l in actual:
+            assert l in expected
 
-                expected_out2 = \
-                "pkg.fmri\tset\ttest1/example_pkg\tpkg:/example_pkg@1.2-0\n" \
-                "incorporate\tdepend\tpkg://test1/example_pkg@1.2,5.11-0\tpkg:/incorp_pkg@1.2-0\n" \
-                "pkg.fmri\tset\ttest2/example_pkg\tpkg:/example_pkg@1.2-0\n" \
-                "incorporate\tdepend\tpkg://test2/example_pkg@1.2,5.11-0\tpkg:/incorp_pkg@1.3-0\n"
+        expected_out2 = (
+            "pkg.fmri\tset\ttest1/example_pkg\tpkg:/example_pkg@1.2-0\n"
+            "incorporate\tdepend\tpkg://test1/example_pkg@1.2,5.11-0\tpkg:/incorp_pkg@1.2-0\n"
+            "pkg.fmri\tset\ttest2/example_pkg\tpkg:/example_pkg@1.2-0\n"
+            "incorporate\tdepend\tpkg://test2/example_pkg@1.2,5.11-0\tpkg:/incorp_pkg@1.3-0\n"
+        )
 
-                self.pkg("search -H pkg://test1/example_pkg",exit=0)
-                actual = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected_out2)
-                for l in actual:
-                        assert l in expected
+        self.pkg("search -H pkg://test1/example_pkg", exit=0)
+        actual = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected_out2)
+        for l in actual:
+            assert l in expected
 
-                self.pkg("search -H pkg:/example_pkg",exit=0)
-                actual = self.reduceSpaces(self.output)
-                expected = self.reduceSpaces(expected_out2)
-                for l in actual:
-                        assert l in expected
+        self.pkg("search -H pkg:/example_pkg", exit=0)
+        actual = self.reduceSpaces(self.output)
+        expected = self.reduceSpaces(expected_out2)
+        for l in actual:
+            assert l in expected
 
-        def test_search_multi_hash_1(self):
-                """Check that when searching a repository with multiple
-                hashes, all hash attributes are indexed and we can search
-                against all hash attributes.
+    def test_search_multi_hash_1(self):
+        """Check that when searching a repository with multiple
+        hashes, all hash attributes are indexed and we can search
+        against all hash attributes.
 
-                This test depends on pkg.digest having DebugValue settings
-                that add sha256 hashes to the set of hashes we append to
-                actions at publication time."""
-                self.base_search_multi_hash("sha256", hashlib.sha256)
+        This test depends on pkg.digest having DebugValue settings
+        that add sha256 hashes to the set of hashes we append to
+        actions at publication time."""
+        self.base_search_multi_hash("sha256", hashlib.sha256)
 
-        def test_search_multi_hash_2(self):
-                """Check that when searching a repository with multiple
-                hashes, all hash attributes are indexed and we can search
-                against all hash attributes.
+    def test_search_multi_hash_2(self):
+        """Check that when searching a repository with multiple
+        hashes, all hash attributes are indexed and we can search
+        against all hash attributes.
 
-                This test depends on pkg.digest having DebugValue settings
-                that add sha512/256 hashes to the set of hashes we append to
-                actions at publication time."""
-                if sha512_supported:
-                        self.base_search_multi_hash("sha512t_256",
-                            sha512_t.SHA512_t)
+        This test depends on pkg.digest having DebugValue settings
+        that add sha512/256 hashes to the set of hashes we append to
+        actions at publication time."""
+        if sha512_supported:
+            self.base_search_multi_hash("sha512t_256", sha512_t.SHA512_t)
 
-        def base_search_multi_hash(self, hash_alg, hash_fun):
-                # our 2nd depot gets the package published with multiple hash
-                # attributes, but served from a single-hash-aware depot
-                # (the fact that it's single-hash-aware should make no
-                # difference to the content it serves so long as the index was
-                # generated while we were aware of multiple hashes.
-                self.pkgsend_bulk(self.rurl2, self.same_pub2,
-                    refresh_index=True, debug_hash="sha1+{0}".format(hash_alg))
-                self.image_create(self.durl2, prefix="samepub")
+    def base_search_multi_hash(self, hash_alg, hash_fun):
+        # our 2nd depot gets the package published with multiple hash
+        # attributes, but served from a single-hash-aware depot
+        # (the fact that it's single-hash-aware should make no
+        # difference to the content it serves so long as the index was
+        # generated while we were aware of multiple hashes.
+        self.pkgsend_bulk(
+            self.rurl2,
+            self.same_pub2,
+            refresh_index=True,
+            debug_hash="sha1+{0}".format(hash_alg),
+        )
+        self.image_create(self.durl2, prefix="samepub")
 
-                # manually calculate the hashes, in case of bugs in
-                # pkg.misc.get_data_digest
-                sha1_hash = hashlib.sha1(b"magic").hexdigest()
-                sha2_hash = "*" + hash_fun(b"magic").hexdigest()
+        # manually calculate the hashes, in case of bugs in
+        # pkg.misc.get_data_digest
+        sha1_hash = hashlib.sha1(b"magic").hexdigest()
+        sha2_hash = "*" + hash_fun(b"magic").hexdigest()
 
-                self.pkg("search {0}".format(sha1_hash))
-                self.pkg("search {0}".format(sha2_hash))
-                # Test that the correct hash algorithm is being used.
-                self.pkg("search *{0}*".format(hash_alg))
+        self.pkg("search {0}".format(sha1_hash))
+        self.pkg("search {0}".format(sha2_hash))
+        # Test that the correct hash algorithm is being used.
+        self.pkg("search *{0}*".format(hash_alg))
 
-                # Check that we're matching on the correct index.
-                # For sha1 hashes, our the 'index' returned is actually the
-                # hash itself - that seems unusual, but it's the way the
-                # index was built. We also emit a 2nd search result that shows
-                # 'hash', in order to be consistent with the way we print
-                # the pkg.hash.sha* attribute when dealing with other hashes.
-                self.pkg("search -H -o search.match_type {0}".format(sha1_hash))
-                self.assertEqualDiff(
-                    self.reduceSpaces(self.output), "{0}\nhash\n".format(sha1_hash))
+        # Check that we're matching on the correct index.
+        # For sha1 hashes, our the 'index' returned is actually the
+        # hash itself - that seems unusual, but it's the way the
+        # index was built. We also emit a 2nd search result that shows
+        # 'hash', in order to be consistent with the way we print
+        # the pkg.hash.sha* attribute when dealing with other hashes.
+        self.pkg("search -H -o search.match_type {0}".format(sha1_hash))
+        self.assertEqualDiff(
+            self.reduceSpaces(self.output), "{0}\nhash\n".format(sha1_hash)
+        )
 
-                self.pkg("search -H -o search.match_type {0}".format(sha2_hash))
-                self.assertEqualDiff(
-                    self.reduceSpaces(self.output), "pkg.content-hash\n")
+        self.pkg("search -H -o search.match_type {0}".format(sha2_hash))
+        self.assertEqualDiff(
+            self.reduceSpaces(self.output), "pkg.content-hash\n"
+        )
 
-                # check that both searches match the same action
-                self.pkg("search -o action.raw {0}".format(sha1_hash))
-                sha1_action = self.reduceSpaces(self.output)
+        # check that both searches match the same action
+        self.pkg("search -o action.raw {0}".format(sha1_hash))
+        sha1_action = self.reduceSpaces(self.output)
 
-                self.pkg("search -o action.raw {0}".format(sha2_hash))
-                sha2_action = self.reduceSpaces(self.output)
-                self.assertEqualDiff(sha1_action, sha2_action)
+        self.pkg("search -o action.raw {0}".format(sha2_hash))
+        sha2_action = self.reduceSpaces(self.output)
+        self.assertEqualDiff(sha1_action, sha2_action)
 
-        def test_search_indices(self):
-                """Ensure that search indices are generated properly when
-                a new hash is enabled."""
+    def test_search_indices(self):
+        """Ensure that search indices are generated properly when
+        a new hash is enabled."""
 
-                # Publish a package which only contains SHA-1 hashes.
-                self.pkgsend_bulk(self.durl1, self.same_pub2)
-                # Enable SHA-2 hashes in the other repository.
-                self.dcs[2].stop()
-                self.dcs[2].set_debug_feature("hash=sha1+sha256")
-                self.dcs[2].start()
-                # pkgrecv the published package which only contains SHA-1
-                # hashes to a repository which enables SHA-2 hashes.
-                self.pkgrecv(self.durl1, "-d {0} {1}".format(self.durl2,
-                    "same_pub2@1.1"))
-                self.pkgrepo("-s {0} refresh".format(self.durl2))
-                # Ensure no error log entry exists.
-                self.file_doesnt_contain(self.dcs[2].get_logpath(),
-                    "missing the expected attribute")
+        # Publish a package which only contains SHA-1 hashes.
+        self.pkgsend_bulk(self.durl1, self.same_pub2)
+        # Enable SHA-2 hashes in the other repository.
+        self.dcs[2].stop()
+        self.dcs[2].set_debug_feature("hash=sha1+sha256")
+        self.dcs[2].start()
+        # pkgrecv the published package which only contains SHA-1
+        # hashes to a repository which enables SHA-2 hashes.
+        self.pkgrecv(
+            self.durl1, "-d {0} {1}".format(self.durl2, "same_pub2@1.1")
+        )
+        self.pkgrepo("-s {0} refresh".format(self.durl2))
+        # Ensure no error log entry exists.
+        self.file_doesnt_contain(
+            self.dcs[2].get_logpath(), "missing the expected attribute"
+        )
 
-        def test_search_ignore_publisher_with_no_origin(self):
-            """ Check that if pkg search will ignore the publisher with no
-            origin."""
-            self.pkgsend_bulk(self.durl1, self.example_pkg11,
-                    refresh_index=True)
-            self.image_create(self.durl1)
-            self.pkg("set-publisher somepub")
-            self.pkg("search example_pkg")
+    def test_search_ignore_publisher_with_no_origin(self):
+        """Check that if pkg search will ignore the publisher with no
+        origin."""
+        self.pkgsend_bulk(self.durl1, self.example_pkg11, refresh_index=True)
+        self.image_create(self.durl1)
+        self.pkg("set-publisher somepub")
+        self.pkg("search example_pkg")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_sysrepo.py
+++ b/src/tests/cli/t_pkg_sysrepo.py
@@ -26,8 +26,9 @@
 
 from __future__ import print_function
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import copy
@@ -42,78 +43,97 @@ import pkg.digest as digest
 import pkg.misc as misc
 
 try:
-        import pkg.sha512_t
-        sha512_supported = True
+    import pkg.sha512_t
+
+    sha512_supported = True
 except ImportError:
-        sha512_supported = False
+    sha512_supported = False
+
 
 class PC(object):
-        """This class contains publisher configuration used for setting up the
-        depots and https apache instances needed by the tests."""
+    """This class contains publisher configuration used for setting up the
+    depots and https apache instances needed by the tests."""
 
-        def __init__(self, url, sticky=True, mirrors=misc.EmptyI, https=False,
-            server_ta=None, client_ta=None, disabled=False, name=None,
-            sig_pol=None, req_names=None, origins=misc.EmptyI):
-                assert (https and server_ta and client_ta) or \
-                    not (https or server_ta or client_ta)
-                assert not disabled or name
-                self.url= url
-                self.sticky = sticky
-                self.https = https
-                self.mirrors = mirrors
-                self.server_ta = server_ta
-                self.client_ta = client_ta
-                self.disabled = disabled
-                self.name = name
-                self.signature_policy = sig_pol
-                self.required_names = req_names
-                self.origins = origins
+    def __init__(
+        self,
+        url,
+        sticky=True,
+        mirrors=misc.EmptyI,
+        https=False,
+        server_ta=None,
+        client_ta=None,
+        disabled=False,
+        name=None,
+        sig_pol=None,
+        req_names=None,
+        origins=misc.EmptyI,
+    ):
+        assert (https and server_ta and client_ta) or not (
+            https or server_ta or client_ta
+        )
+        assert not disabled or name
+        self.url = url
+        self.sticky = sticky
+        self.https = https
+        self.mirrors = mirrors
+        self.server_ta = server_ta
+        self.client_ta = client_ta
+        self.disabled = disabled
+        self.name = name
+        self.signature_policy = sig_pol
+        self.required_names = req_names
+        self.origins = origins
+
 
 class TestSysrepo(pkg5unittest.ApacheDepotTestCase):
-        """Tests pkg interaction with the system repository."""
+    """Tests pkg interaction with the system repository."""
 
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        example_pkg10 = """
+    example_pkg10 = """
             open example_pkg@1.0,5.11-0
             add file tmp/example_file mode=0555 owner=root group=bin path=/usr/bin/example_path
             close"""
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close"""
 
-        foo11 = """
+    foo11 = """
             open foo@1.1,5.11-0
             add file tmp/example_file mode=0555 owner=root group=bin path=/usr/bin/example_path2
             close"""
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0
             add file tmp/example_two mode=0555 owner=root group=bin path=/usr/bin/example_path3
             close"""
 
-        bar11 = """
+    bar11 = """
             open bar@1.1,5.11-0
             add file tmp/example_two mode=0555 owner=root group=bin path=/usr/bin/example_path3
             add file tmp/example_two mode=0555 owner=root group=bin path=/usr/bin/example_path4
             close"""
 
-        baz10 = """
+    baz10 = """
             open baz@1.0,5.11-0
             add file tmp/example_three mode=0555 owner=root group=bin path=/usr/bin/another_1
             close"""
 
-        caz10 = """
+    caz10 = """
             open caz@1.0,5.11-0
             add file tmp/example_four mode=0555 owner=root group=bin path=/usr/bin/another_2
             close"""
 
-        misc_files = ["tmp/example_file", "tmp/example_two",
-            "tmp/example_three", "tmp/example_four"]
+    misc_files = [
+        "tmp/example_file",
+        "tmp/example_two",
+        "tmp/example_three",
+        "tmp/example_four",
+    ]
 
-        expected_all_access =  """\
+    expected_all_access = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
@@ -121,762 +141,962 @@ test3\ttrue\ttrue\ttrue\torigin\tonline\t{durl3}/\thttp://localhost:{port}
 test4\ttrue\ttrue\ttrue\t\t\t\t
 """
 
-        def setUp(self):
-                # These need to be set before calling setUp in case setUp fails.
-                self.smf_cmds = {}
+    def setUp(self):
+        # These need to be set before calling setUp in case setUp fails.
+        self.smf_cmds = {}
 
-                # These need to set to allow the smf commands to give the right
-                # responses.
-                self.sysrepo_port = self.next_free_port
-                self.next_free_port += 1
-                self.sysrepo_alt_port = self.next_free_port
-                self.next_free_port += 1
+        # These need to set to allow the smf commands to give the right
+        # responses.
+        self.sysrepo_port = self.next_free_port
+        self.next_free_port += 1
+        self.sysrepo_alt_port = self.next_free_port
+        self.next_free_port += 1
 
-                # Set up the smf commands that these tests use.
-                smf_conf_dict = {"proxy_port": self.sysrepo_port}
-                for n in self.__smf_cmds_template:
-                        self.smf_cmds[n] = self.__smf_cmds_template[n].format(**
-                            smf_conf_dict)
+        # Set up the smf commands that these tests use.
+        smf_conf_dict = {"proxy_port": self.sysrepo_port}
+        for n in self.__smf_cmds_template:
+            self.smf_cmds[n] = self.__smf_cmds_template[n].format(
+                **smf_conf_dict
+            )
 
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test12",
-                    "test3", "test4", "test12"], start_depots=True)
-                self.testdata_dir = os.path.join(self.test_root, "testdata")
-                self.make_misc_files(self.misc_files)
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self,
+            ["test1", "test12", "test3", "test4", "test12"],
+            start_depots=True,
+        )
+        self.testdata_dir = os.path.join(self.test_root, "testdata")
+        self.make_misc_files(self.misc_files)
 
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.durl3 = self.dcs[3].get_depot_url()
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.durl3 = self.dcs[3].get_depot_url()
 
-                # we make self.durl3 multi-hash aware, to ensure that the
-                # system-repository can serve packages published with multiple
-                # hashes.
-                self.dcs[3].stop()
-                self.dcs[3].set_debug_feature("hash=sha1+sha256")
-                self.dcs[3].start()
+        # we make self.durl3 multi-hash aware, to ensure that the
+        # system-repository can serve packages published with multiple
+        # hashes.
+        self.dcs[3].stop()
+        self.dcs[3].set_debug_feature("hash=sha1+sha256")
+        self.dcs[3].start()
 
-                self.durl4 = self.dcs[4].get_depot_url()
-                self.durl5 = self.dcs[5].get_depot_url()
+        self.durl4 = self.dcs[4].get_depot_url()
+        self.durl5 = self.dcs[5].get_depot_url()
 
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.rurl3 = self.dcs[3].get_repo_url()
-                self.rurl4 = self.dcs[4].get_repo_url()
-                self.rurl5 = self.dcs[5].get_repo_url()
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.rurl3 = self.dcs[3].get_repo_url()
+        self.rurl4 = self.dcs[4].get_repo_url()
+        self.rurl5 = self.dcs[5].get_repo_url()
 
-                self.apache_dir = os.path.join(self.test_root, "apache")
-                self.apache_log_dir = os.path.join(self.apache_dir,
-                    "apache_logs")
+        self.apache_dir = os.path.join(self.test_root, "apache")
+        self.apache_log_dir = os.path.join(self.apache_dir, "apache_logs")
 
-                self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                self.pkgsend_bulk(self.rurl2, self.foo10)
-                # We send to rurl3 using multi-hash aware publication
-                self.pkgsend_bulk(self.rurl3, self.bar10,
-                    debug_hash="sha1+sha256")
-                self.pkgsend_bulk(self.rurl3, self.baz10,
-                    debug_hash="sha1+sha256")
-                if sha512_supported:
-                        self.pkgsend_bulk(self.rurl3, self.caz10,
-                            debug_hash="sha1+sha512t_256")
-                self.pkgsend_bulk(self.rurl4, self.bar10)
-                self.pkgsend_bulk(self.rurl5, self.foo11)
+        self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        self.pkgsend_bulk(self.rurl2, self.foo10)
+        # We send to rurl3 using multi-hash aware publication
+        self.pkgsend_bulk(self.rurl3, self.bar10, debug_hash="sha1+sha256")
+        self.pkgsend_bulk(self.rurl3, self.baz10, debug_hash="sha1+sha256")
+        if sha512_supported:
+            self.pkgsend_bulk(
+                self.rurl3, self.caz10, debug_hash="sha1+sha512t_256"
+            )
+        self.pkgsend_bulk(self.rurl4, self.bar10)
+        self.pkgsend_bulk(self.rurl5, self.foo11)
 
-                self.common_config_dir = os.path.join(self.test_root,
-                    "apache-serve")
-                self.htdocs_dir = os.path.join(self.common_config_dir, "htdocs")
-                self.apache_confs = {}
+        self.common_config_dir = os.path.join(self.test_root, "apache-serve")
+        self.htdocs_dir = os.path.join(self.common_config_dir, "htdocs")
+        self.apache_confs = {}
 
-                # Establish the different publisher configurations that tests
-                # will need.  self.configs is a dictionary that maps config
-                # names to tuples of (image properties, PC objects).  The image
-                # properties are stored in a dictionary that maps the name of
-                # the property to the value.  The list of PC objects represent
-                # the configuration of each publisher.
-                #
-                # The self.configs dictionary is used to create images whose
-                # configuration is used by pkg.sysrepo to create the
-                # configuration files needed to set up a system-repository
-                # instance for that image.
-                self.configs = {
-                    "all-access": ({}, [
-                        PC(self.durl1),
-                        PC(self.durl2, sticky=False),
-                        PC(self.durl3),
-                        PC(None, name="test4")]),
-                    "all-access-f": ({}, [
-                        PC(self.rurl1),
-                        PC(self.rurl2, sticky=False),
-                        PC(self.rurl3)]),
-                    "disabled": ({}, [
-                        PC(self.durl1, disabled=True, name="test1"),
-                        PC(self.durl2, sticky=False),
-                        PC(self.durl3)]),
-                    "https-access": ({}, [
-                        PC(self.durl1, https=True, server_ta="ta11",
-                            client_ta="ta6"),
-                        PC(self.durl2, sticky=False, https=True,
-                            server_ta="ta7", client_ta="ta8"),
-                        PC(self.durl3, https=True, server_ta="ta9",
-                            client_ta="ta10")]),
-                    "mirror-access": ({}, [
-                        PC(self.durl1, mirrors=[("test1", self.rurl1)]),
-                        PC(self.durl2, sticky=False,
-                            mirrors=[("test12", self.rurl2)]),
-                        PC(self.durl3, mirrors=[("test3", self.rurl3)])]),
-                    "mirror-access-f": ({}, [
-                        PC(self.rurl1, mirrors=[("test1", self.durl1)]),
-                        PC(self.rurl2, sticky=False,
-                            mirrors=[("test12", self.durl2)]),
-                        PC(self.rurl3, mirrors=[("test3", self.durl3)])]),
-                    "mirror-access-user": ({}, [
-                        PC(self.durl1, mirrors=[("test1", self.rurl1)]),
-                        PC(self.durl2, sticky=False),
-                        PC(self.durl3, mirrors=[("test3", self.rurl3)])]),
-                    "none": ({}, []),
-                    "test1": ({}, [PC(self.durl1)]),
-                    "test1-test12": ({}, [
-                        PC(self.durl1),
-                        PC(self.durl2, sticky=False)]),
-                    "test1-test12-test12": ({}, [
-                        PC(self.durl1),
-                        PC(None,
-                            name="test12", origins=[{"url": self.durl2,
-                            "disabled": False}, {"url": self.durl5,
-                            "disabled": False}],
-                            sticky=False)]),
-                    "test1-test3": ({}, [
-                        PC(self.durl1),
-                        PC(self.durl3)]),
-                    "test1-test3-f": ({}, [
-                        PC(self.rurl1),
-                        PC(self.rurl3)]),
-                    "test12": ({}, [
-                        PC(self.durl2, sticky=False)]),
-                    "test12-test12": ({}, [
-                        PC(None,
-                            name="test12", origins=[{"url": self.durl2,
-                            "disabled": False}, {"url": self.durl5,
-                            "disabled": False}],
-                            sticky=False)]),
-                    "test12-test3": ({}, [
-                        PC(self.durl2, sticky=False),
-                        PC(self.durl3)]),
-                    "test3": ({}, [PC(self.durl3)]),
-                    "nourl": ({}, [PC(None, name="test4")]),
-                    "img-sig-ignore": ({"signature-policy": "ignore"}, [
-                        PC(self.rurl1),
-                        PC(self.rurl2, sticky=False),
-                        PC(self.rurl3)]),
-                    "img-sig-require": (
-                        {"signature-policy": "require-signatures"}, [
-                        PC(self.rurl1),
-                        PC(self.rurl2, sticky=False),
-                        PC(self.rurl3)]),
-                    "img-sig-req-names": ({
-                            "signature-policy": "require-names",
-                            "signature-required-names": ["cs1_ch1_ta3"]
-                        }, [
-                        PC(self.rurl1),
-                        PC(self.rurl2, sticky=False),
-                        PC(self.rurl3)]),
-                    "pub-sig-ignore": ({}, [
-                        PC(self.rurl1, sig_pol="ignore"),
-                        PC(self.rurl2, sticky=False,
-                            sig_pol="ignore"),
-                        PC(self.rurl3, sig_pol="ignore")]),
-                    "pub-sig-require": ({}, [
-                        PC(self.rurl1, sig_pol="require-signatures"),
-                        PC(self.rurl2, sticky=False,
-                            sig_pol="require-signatures"),
-                        PC(self.rurl3, sig_pol="require-signatures")]),
-                    "pub-sig-reqnames": ({}, [
-                        PC(self.rurl1, sig_pol="require-names",
-                            req_names="cs1_ch1_ta3"),
-                        PC(self.rurl2, sticky=False,
-                            sig_pol="require-names", req_names=["cs1_ch1_ta3"]),
-                        PC(self.rurl3, sig_pol="require-names",
-                            req_names="cs1_ch1_ta3")]),
-                    "pub-sig-mixed": ({}, [
-                        PC(self.rurl1, sig_pol="require-signatures"),
-                        PC(self.rurl2, sticky=False),
-                        PC(self.rurl3, sig_pol="verify")]),
-                    "img-pub-sig-mixed": ({"signature-policy": "ignore"}, [
-                        PC(self.rurl1, sig_pol="require-signatures"),
-                        PC(self.rurl2, sticky=False, sig_pol="require-names",
-                            req_names=["cs1_ch1_ta3", "foo", "bar", "baz"]),
-                        PC(self.rurl3, sig_pol="ignore")]),
-                    "disabled_1_origin": ({}, [
-                        PC(None,
-                            name="test12", origins=[{"url": self.durl2,
-                            "disabled": True}, {"url": self.durl5,
-                            "disabled": False}],
-                            sticky=False)]),
-                    "disabled_2_origins": ({}, [
-                        PC(None,
-                            name="test12", origins=[{"url": self.durl2,
-                            "disabled": True}, {"url": self.durl5,
-                            "disabled": True}],
-                            sticky=False)]),
-                }
+        # Establish the different publisher configurations that tests
+        # will need.  self.configs is a dictionary that maps config
+        # names to tuples of (image properties, PC objects).  The image
+        # properties are stored in a dictionary that maps the name of
+        # the property to the value.  The list of PC objects represent
+        # the configuration of each publisher.
+        #
+        # The self.configs dictionary is used to create images whose
+        # configuration is used by pkg.sysrepo to create the
+        # configuration files needed to set up a system-repository
+        # instance for that image.
+        self.configs = {
+            "all-access": (
+                {},
+                [
+                    PC(self.durl1),
+                    PC(self.durl2, sticky=False),
+                    PC(self.durl3),
+                    PC(None, name="test4"),
+                ],
+            ),
+            "all-access-f": (
+                {},
+                [PC(self.rurl1), PC(self.rurl2, sticky=False), PC(self.rurl3)],
+            ),
+            "disabled": (
+                {},
+                [
+                    PC(self.durl1, disabled=True, name="test1"),
+                    PC(self.durl2, sticky=False),
+                    PC(self.durl3),
+                ],
+            ),
+            "https-access": (
+                {},
+                [
+                    PC(
+                        self.durl1,
+                        https=True,
+                        server_ta="ta11",
+                        client_ta="ta6",
+                    ),
+                    PC(
+                        self.durl2,
+                        sticky=False,
+                        https=True,
+                        server_ta="ta7",
+                        client_ta="ta8",
+                    ),
+                    PC(
+                        self.durl3,
+                        https=True,
+                        server_ta="ta9",
+                        client_ta="ta10",
+                    ),
+                ],
+            ),
+            "mirror-access": (
+                {},
+                [
+                    PC(self.durl1, mirrors=[("test1", self.rurl1)]),
+                    PC(
+                        self.durl2,
+                        sticky=False,
+                        mirrors=[("test12", self.rurl2)],
+                    ),
+                    PC(self.durl3, mirrors=[("test3", self.rurl3)]),
+                ],
+            ),
+            "mirror-access-f": (
+                {},
+                [
+                    PC(self.rurl1, mirrors=[("test1", self.durl1)]),
+                    PC(
+                        self.rurl2,
+                        sticky=False,
+                        mirrors=[("test12", self.durl2)],
+                    ),
+                    PC(self.rurl3, mirrors=[("test3", self.durl3)]),
+                ],
+            ),
+            "mirror-access-user": (
+                {},
+                [
+                    PC(self.durl1, mirrors=[("test1", self.rurl1)]),
+                    PC(self.durl2, sticky=False),
+                    PC(self.durl3, mirrors=[("test3", self.rurl3)]),
+                ],
+            ),
+            "none": ({}, []),
+            "test1": ({}, [PC(self.durl1)]),
+            "test1-test12": (
+                {},
+                [PC(self.durl1), PC(self.durl2, sticky=False)],
+            ),
+            "test1-test12-test12": (
+                {},
+                [
+                    PC(self.durl1),
+                    PC(
+                        None,
+                        name="test12",
+                        origins=[
+                            {"url": self.durl2, "disabled": False},
+                            {"url": self.durl5, "disabled": False},
+                        ],
+                        sticky=False,
+                    ),
+                ],
+            ),
+            "test1-test3": ({}, [PC(self.durl1), PC(self.durl3)]),
+            "test1-test3-f": ({}, [PC(self.rurl1), PC(self.rurl3)]),
+            "test12": ({}, [PC(self.durl2, sticky=False)]),
+            "test12-test12": (
+                {},
+                [
+                    PC(
+                        None,
+                        name="test12",
+                        origins=[
+                            {"url": self.durl2, "disabled": False},
+                            {"url": self.durl5, "disabled": False},
+                        ],
+                        sticky=False,
+                    )
+                ],
+            ),
+            "test12-test3": (
+                {},
+                [PC(self.durl2, sticky=False), PC(self.durl3)],
+            ),
+            "test3": ({}, [PC(self.durl3)]),
+            "nourl": ({}, [PC(None, name="test4")]),
+            "img-sig-ignore": (
+                {"signature-policy": "ignore"},
+                [PC(self.rurl1), PC(self.rurl2, sticky=False), PC(self.rurl3)],
+            ),
+            "img-sig-require": (
+                {"signature-policy": "require-signatures"},
+                [PC(self.rurl1), PC(self.rurl2, sticky=False), PC(self.rurl3)],
+            ),
+            "img-sig-req-names": (
+                {
+                    "signature-policy": "require-names",
+                    "signature-required-names": ["cs1_ch1_ta3"],
+                },
+                [PC(self.rurl1), PC(self.rurl2, sticky=False), PC(self.rurl3)],
+            ),
+            "pub-sig-ignore": (
+                {},
+                [
+                    PC(self.rurl1, sig_pol="ignore"),
+                    PC(self.rurl2, sticky=False, sig_pol="ignore"),
+                    PC(self.rurl3, sig_pol="ignore"),
+                ],
+            ),
+            "pub-sig-require": (
+                {},
+                [
+                    PC(self.rurl1, sig_pol="require-signatures"),
+                    PC(self.rurl2, sticky=False, sig_pol="require-signatures"),
+                    PC(self.rurl3, sig_pol="require-signatures"),
+                ],
+            ),
+            "pub-sig-reqnames": (
+                {},
+                [
+                    PC(
+                        self.rurl1,
+                        sig_pol="require-names",
+                        req_names="cs1_ch1_ta3",
+                    ),
+                    PC(
+                        self.rurl2,
+                        sticky=False,
+                        sig_pol="require-names",
+                        req_names=["cs1_ch1_ta3"],
+                    ),
+                    PC(
+                        self.rurl3,
+                        sig_pol="require-names",
+                        req_names="cs1_ch1_ta3",
+                    ),
+                ],
+            ),
+            "pub-sig-mixed": (
+                {},
+                [
+                    PC(self.rurl1, sig_pol="require-signatures"),
+                    PC(self.rurl2, sticky=False),
+                    PC(self.rurl3, sig_pol="verify"),
+                ],
+            ),
+            "img-pub-sig-mixed": (
+                {"signature-policy": "ignore"},
+                [
+                    PC(self.rurl1, sig_pol="require-signatures"),
+                    PC(
+                        self.rurl2,
+                        sticky=False,
+                        sig_pol="require-names",
+                        req_names=["cs1_ch1_ta3", "foo", "bar", "baz"],
+                    ),
+                    PC(self.rurl3, sig_pol="ignore"),
+                ],
+            ),
+            "disabled_1_origin": (
+                {},
+                [
+                    PC(
+                        None,
+                        name="test12",
+                        origins=[
+                            {"url": self.durl2, "disabled": True},
+                            {"url": self.durl5, "disabled": False},
+                        ],
+                        sticky=False,
+                    )
+                ],
+            ),
+            "disabled_2_origins": (
+                {},
+                [
+                    PC(
+                        None,
+                        name="test12",
+                        origins=[
+                            {"url": self.durl2, "disabled": True},
+                            {"url": self.durl5, "disabled": True},
+                        ],
+                        sticky=False,
+                    )
+                ],
+            ),
+        }
 
-                # Config needed for https apache instances.
-                self.path_to_certs = os.path.join(self.ro_data_root,
-                    "signing_certs", "produced")
-                self.keys_dir = os.path.join(self.path_to_certs, "keys")
-                self.cs_dir = os.path.join(self.path_to_certs,
-                    "code_signing_certs")
-                self.chain_certs_dir = os.path.join(self.path_to_certs,
-                    "chain_certs")
-                self.pub_cas_dir = os.path.join(self.path_to_certs,
-                    "publisher_cas")
-                self.inter_certs_dir = os.path.join(self.path_to_certs,
-                    "inter_certs")
-                self.raw_trust_anchor_dir = os.path.join(self.path_to_certs,
-                    "trust_anchors")
-                self.crl_dir = os.path.join(self.path_to_certs, "crl")
+        # Config needed for https apache instances.
+        self.path_to_certs = os.path.join(
+            self.ro_data_root, "signing_certs", "produced"
+        )
+        self.keys_dir = os.path.join(self.path_to_certs, "keys")
+        self.cs_dir = os.path.join(self.path_to_certs, "code_signing_certs")
+        self.chain_certs_dir = os.path.join(self.path_to_certs, "chain_certs")
+        self.pub_cas_dir = os.path.join(self.path_to_certs, "publisher_cas")
+        self.inter_certs_dir = os.path.join(self.path_to_certs, "inter_certs")
+        self.raw_trust_anchor_dir = os.path.join(
+            self.path_to_certs, "trust_anchors"
+        )
+        self.crl_dir = os.path.join(self.path_to_certs, "crl")
 
-                self.base_conf_dict = {
-                    "common_log_format": "%h %l %u %t \\\"%r\\\" %>s %b",
-                    "ssl-special": "%{SSL_CLIENT_I_DN_OU}",
-                }
-                # Pick a directory to store all the https apache configuration
-                # in.
-                self.base_https_dir = os.path.join(self.test_root, "https")
+        self.base_conf_dict = {
+            "common_log_format": '%h %l %u %t \\"%r\\" %>s %b',
+            "ssl-special": "%{SSL_CLIENT_I_DN_OU}",
+        }
+        # Pick a directory to store all the https apache configuration
+        # in.
+        self.base_https_dir = os.path.join(self.test_root, "https")
 
-        def __start_https(self, pc):
-                # Start up an https apache config
-                cd = copy.copy(self.base_conf_dict)
+    def __start_https(self, pc):
+        # Start up an https apache config
+        cd = copy.copy(self.base_conf_dict)
 
-                # This apache instance will need a free port.
-                https_port = self.next_free_port
-                self.next_free_port += 1
+        # This apache instance will need a free port.
+        https_port = self.next_free_port
+        self.next_free_port += 1
 
-                # Set up the directories and configuration this instance of
-                # apache will need.
-                instance_dir = os.path.join(self.base_https_dir,
-                    str(https_port))
-                log_dir = os.path.join(instance_dir, "https_logs")
-                content_dir = os.path.join(instance_dir, "content")
-                os.makedirs(instance_dir)
-                os.makedirs(log_dir)
-                os.makedirs(content_dir)
-                cd.update({
-                    "https_port": https_port,
-                    "log_locs": log_dir,
-                    "pidfile": os.path.join(instance_dir, "httpd.pid"),
-                    "port": https_port,
-                    "proxied-server": pc.url,
-                    "server-ca-cert":os.path.join(self.raw_trust_anchor_dir,
-                        "{0}_cert.pem".format(pc.client_ta)),
-                    "server-ca-taname": pc.client_ta,
-                    "serve_root": content_dir,
-                    "server-ssl-cert":os.path.join(self.cs_dir,
-                        "cs1_{0}_cert.pem".format(pc.server_ta)),
-                    "server-ssl-key":os.path.join(self.keys_dir,
-                        "cs1_{0}_key.pem".format(pc.server_ta)),
-               })
-                conf_path = os.path.join(instance_dir, "https.conf")
-                with open(conf_path, "w") as fh:
-                        fh.write(self.https_conf.format(**cd))
+        # Set up the directories and configuration this instance of
+        # apache will need.
+        instance_dir = os.path.join(self.base_https_dir, str(https_port))
+        log_dir = os.path.join(instance_dir, "https_logs")
+        content_dir = os.path.join(instance_dir, "content")
+        os.makedirs(instance_dir)
+        os.makedirs(log_dir)
+        os.makedirs(content_dir)
+        cd.update(
+            {
+                "https_port": https_port,
+                "log_locs": log_dir,
+                "pidfile": os.path.join(instance_dir, "httpd.pid"),
+                "port": https_port,
+                "proxied-server": pc.url,
+                "server-ca-cert": os.path.join(
+                    self.raw_trust_anchor_dir,
+                    "{0}_cert.pem".format(pc.client_ta),
+                ),
+                "server-ca-taname": pc.client_ta,
+                "serve_root": content_dir,
+                "server-ssl-cert": os.path.join(
+                    self.cs_dir, "cs1_{0}_cert.pem".format(pc.server_ta)
+                ),
+                "server-ssl-key": os.path.join(
+                    self.keys_dir, "cs1_{0}_key.pem".format(pc.server_ta)
+                ),
+            }
+        )
+        conf_path = os.path.join(instance_dir, "https.conf")
+        with open(conf_path, "w") as fh:
+            fh.write(self.https_conf.format(**cd))
 
-                ac = pkg5unittest.ApacheController(conf_path, https_port,
-                    instance_dir, testcase=self, https=True)
-                self.register_apache_controller(pc.url, ac)
-                ac.start()
-                return ac
+        ac = pkg5unittest.ApacheController(
+            conf_path, https_port, instance_dir, testcase=self, https=True
+        )
+        self.register_apache_controller(pc.url, ac)
+        ac.start()
+        return ac
 
-        def __prep_configuration(self, names, port=None,
-            use_config_cache=False):
-                """Prepare the system repository configuration given either
-                a string corresponding to a key in self.configs, or a list
-                of keys.
+    def __prep_configuration(self, names, port=None, use_config_cache=False):
+        """Prepare the system repository configuration given either
+        a string corresponding to a key in self.configs, or a list
+        of keys.
 
-                'port' if used overrides the default port to be used.
+        'port' if used overrides the default port to be used.
 
-                'use_config_cache' causes us to call pkg.sysrepo twice for each
-                configuration, ensuring that we use the pkg.sysrepo config
-                cached in var/cache/pkg for the actual configuration.
-                """
+        'use_config_cache' causes us to call pkg.sysrepo twice for each
+        configuration, ensuring that we use the pkg.sysrepo config
+        cached in var/cache/pkg for the actual configuration.
+        """
 
-                if not port:
-                        port = self.sysrepo_port
-                self.__configured_names = []
-                if isinstance(names, six.string_types):
-                        names = [names]
-                for name in names:
-                        props, pcs = self.configs[name]
-                        self.image_create(props=props)
-                        for pc in pcs:
-                                cmd = "set-publisher"
-                                if not pc.sticky:
-                                        cmd += " --non-sticky"
-                                if not pc.https and pc.url:
-                                        cmd += " -p {0}".format(pc.url)
-                                elif not pc.https and not pc.url:
-                                        for o in pc.origins:
-                                                cmd += " -g {0}".format(
-                                                    o["url"])
-                                        cmd += " {0}".format(pc.name)
-                                else:
-                                        if pc.url in self.acs:
-                                                ac = self.acs[pc.url]
-                                        else:
-                                                ac = self.__start_https(pc)
-                                        # Configure image to use apache instance
-                                        cmd = " --debug " \
-                                            "ssl_ca_file={ca_file} {cmd} " \
-                                            "-k {key} -c {cert} " \
-                                            "-p {url}".format(
-                                                ca_file=os.path.join(
-                                                    self.raw_trust_anchor_dir,
-                                                    "{0}_cert.pem".format(
-                                                    pc.server_ta)),
-                                                cert=os.path.join(
-                                                    self.cs_dir,
-                                                    "cs1_{0}_cert.pem".format(
-                                                    pc.client_ta)),
-                                                cmd=cmd,
-                                                key=os.path.join(
-                                                    self.keys_dir,
-                                                    "cs1_{0}_key.pem".format(
-                                                    pc.client_ta)),
-                                                url=ac.url,
-                                            )
-                                if pc.signature_policy:
-                                        cmd += " --set-property " \
-                                            "signature-policy={0}".format(
-                                            pc.signature_policy)
-                                if pc.required_names:
-                                        cmd += " --set-property " \
-                                            "signature-required-names='{0}'".format(
-                                            pc.required_names)
-                                self.pkg(cmd, debug_smf=False)
-                                for pub, m in pc.mirrors:
-                                        self.pkg(
-                                            "set-publisher -m {0} {1}".format(m, pub))
-                                for o in pc.origins:
-                                        if o["disabled"]:
-                                                self.pkg("set-publisher -d -g "
-                                                    "{0} {1}".format(o["url"],
-                                                    pc.name))
-                                if pc.disabled:
-                                        self.pkg("set-publisher -d {0}".format(
-                                            pc.name))
+        if not port:
+            port = self.sysrepo_port
+        self.__configured_names = []
+        if isinstance(names, six.string_types):
+            names = [names]
+        for name in names:
+            props, pcs = self.configs[name]
+            self.image_create(props=props)
+            for pc in pcs:
+                cmd = "set-publisher"
+                if not pc.sticky:
+                    cmd += " --non-sticky"
+                if not pc.https and pc.url:
+                    cmd += " -p {0}".format(pc.url)
+                elif not pc.https and not pc.url:
+                    for o in pc.origins:
+                        cmd += " -g {0}".format(o["url"])
+                    cmd += " {0}".format(pc.name)
+                else:
+                    if pc.url in self.acs:
+                        ac = self.acs[pc.url]
+                    else:
+                        ac = self.__start_https(pc)
+                    # Configure image to use apache instance
+                    cmd = (
+                        " --debug "
+                        "ssl_ca_file={ca_file} {cmd} "
+                        "-k {key} -c {cert} "
+                        "-p {url}".format(
+                            ca_file=os.path.join(
+                                self.raw_trust_anchor_dir,
+                                "{0}_cert.pem".format(pc.server_ta),
+                            ),
+                            cert=os.path.join(
+                                self.cs_dir,
+                                "cs1_{0}_cert.pem".format(pc.client_ta),
+                            ),
+                            cmd=cmd,
+                            key=os.path.join(
+                                self.keys_dir,
+                                "cs1_{0}_key.pem".format(pc.client_ta),
+                            ),
+                            url=ac.url,
+                        )
+                    )
+                if pc.signature_policy:
+                    cmd += " --set-property " "signature-policy={0}".format(
+                        pc.signature_policy
+                    )
+                if pc.required_names:
+                    cmd += (
+                        " --set-property "
+                        "signature-required-names='{0}'".format(
+                            pc.required_names
+                        )
+                    )
+                self.pkg(cmd, debug_smf=False)
+                for pub, m in pc.mirrors:
+                    self.pkg("set-publisher -m {0} {1}".format(m, pub))
+                for o in pc.origins:
+                    if o["disabled"]:
+                        self.pkg(
+                            "set-publisher -d -g "
+                            "{0} {1}".format(o["url"], pc.name)
+                        )
+                if pc.disabled:
+                    self.pkg("set-publisher -d {0}".format(pc.name))
 
-                        if use_config_cache:
-                                # Call self.sysrepo so that a config cache is
-                                # created.  The subsequent call to self.sysrepo
-                                # will use that cache to build the Apache
-                                # configuration.
-                                self.sysrepo("-l {log_locs} -p {port} "
-                                    "-r {common_serve}".format(
-                                        log_locs=self.apache_log_dir,
-                                        port=port,
-                                        common_serve=self.common_config_dir)
-                                   )
+            if use_config_cache:
+                # Call self.sysrepo so that a config cache is
+                # created.  The subsequent call to self.sysrepo
+                # will use that cache to build the Apache
+                # configuration.
+                self.sysrepo(
+                    "-l {log_locs} -p {port} "
+                    "-r {common_serve}".format(
+                        log_locs=self.apache_log_dir,
+                        port=port,
+                        common_serve=self.common_config_dir,
+                    )
+                )
 
-                        self.sysrepo("-l {log_locs} -p {port} "
-                            "-r {common_serve}".format(
-                                log_locs=self.apache_log_dir,
-                                port=port,
-                                common_serve=self.common_config_dir)
-                           )
-                        st = os.stat(os.path.join(self.common_config_dir,
-                            "htdocs"))
-                        uid = st.st_uid
-                        gid = st.st_gid
-                        conf_dir = os.path.join(self.test_root, "apache-conf",
-                            name)
-                        shutil.move(self.common_config_dir, conf_dir)
-                        st2 = os.stat(conf_dir)
-                        new_uid = st2.st_uid
-                        new_gid = st2.st_gid
-                        if new_uid != uid or new_gid != gid:
-                                misc.recursive_chown_dir(conf_dir, uid, gid)
-                        self.apache_confs[name] = os.path.join(self.test_root,
-                            "apache-conf", name, "sysrepo_httpd.conf")
-                        self.__configured_names.append(name)
-                        self.pkg("property")
-                        self.image_destroy()
+            self.sysrepo(
+                "-l {log_locs} -p {port} "
+                "-r {common_serve}".format(
+                    log_locs=self.apache_log_dir,
+                    port=port,
+                    common_serve=self.common_config_dir,
+                )
+            )
+            st = os.stat(os.path.join(self.common_config_dir, "htdocs"))
+            uid = st.st_uid
+            gid = st.st_gid
+            conf_dir = os.path.join(self.test_root, "apache-conf", name)
+            shutil.move(self.common_config_dir, conf_dir)
+            st2 = os.stat(conf_dir)
+            new_uid = st2.st_uid
+            new_gid = st2.st_gid
+            if new_uid != uid or new_gid != gid:
+                misc.recursive_chown_dir(conf_dir, uid, gid)
+            self.apache_confs[name] = os.path.join(
+                self.test_root, "apache-conf", name, "sysrepo_httpd.conf"
+            )
+            self.__configured_names.append(name)
+            self.pkg("property")
+            self.image_destroy()
 
-        def __set_responses(self, name, update_conf=True):
-                """Sets the system-repository to use a named configuration
-                when providing responses."""
+    def __set_responses(self, name, update_conf=True):
+        """Sets the system-repository to use a named configuration
+        when providing responses."""
 
-                if name not in self.__configured_names:
-                        raise RuntimeError("{0} hasn't been prepared for this "
-                            "test.".format(name))
-                base_dir = os.path.join(self.test_root, "apache-conf", name,
-                    "htdocs")
-                if not os.path.isdir(base_dir):
-                        raise RuntimeError("Expected {0} to already exist and "
-                            "be a directory but it's not.".format(base_dir))
-                if os.path.isdir(self.htdocs_dir):
-                        shutil.rmtree(self.htdocs_dir)
-                shutil.copytree(base_dir, self.htdocs_dir)
+        if name not in self.__configured_names:
+            raise RuntimeError(
+                "{0} hasn't been prepared for this " "test.".format(name)
+            )
+        base_dir = os.path.join(self.test_root, "apache-conf", name, "htdocs")
+        if not os.path.isdir(base_dir):
+            raise RuntimeError(
+                "Expected {0} to already exist and "
+                "be a directory but it's not.".format(base_dir)
+            )
+        if os.path.isdir(self.htdocs_dir):
+            shutil.rmtree(self.htdocs_dir)
+        shutil.copytree(base_dir, self.htdocs_dir)
 
-                # We can have multiple crypto conf files
-                cred_path = os.path.join(self.test_root, "apache-conf", name)
-                cred_files = glob.glob(os.path.join(cred_path,
-                    "proxy-creds-*.pem"))
-                for cred_file in cred_files:
-                        destfile = os.path.join(self.common_config_dir,
-                            os.path.basename(cred_file))
-                        if os.path.exists(destfile):
-                                os.chmod(destfile, 0o600)
-                        shutil.copy(cred_file, self.common_config_dir)
-                        os.chmod(destfile, 0o400)
+        # We can have multiple crypto conf files
+        cred_path = os.path.join(self.test_root, "apache-conf", name)
+        cred_files = glob.glob(os.path.join(cred_path, "proxy-creds-*.pem"))
+        for cred_file in cred_files:
+            destfile = os.path.join(
+                self.common_config_dir, os.path.basename(cred_file)
+            )
+            if os.path.exists(destfile):
+                os.chmod(destfile, 0o600)
+            shutil.copy(cred_file, self.common_config_dir)
+            os.chmod(destfile, 0o400)
 
-                st = os.stat(base_dir)
-                uid = st.st_uid
-                gid = st.st_gid
-                st2 = os.stat(self.htdocs_dir)
-                new_uid = st2.st_uid
-                new_gid = st2.st_gid
-                if uid != new_gid or gid != new_gid:
-                        misc.recursive_chown_dir(self.common_config_dir, uid,
-                            gid)
-                if update_conf and "sysrepo" in self.acs:
-                        # changing configuration without registering a new
-                        # ApacheController is safe even if the new configuration
-                        # specifies a different port, because the controller
-                        # gets stopped/started by the __set_conf(..)
-                        # method of ApacheController if the process is running.
-                        self.acs["sysrepo"].conf = self.apache_confs[name]
+        st = os.stat(base_dir)
+        uid = st.st_uid
+        gid = st.st_gid
+        st2 = os.stat(self.htdocs_dir)
+        new_uid = st2.st_uid
+        new_gid = st2.st_gid
+        if uid != new_gid or gid != new_gid:
+            misc.recursive_chown_dir(self.common_config_dir, uid, gid)
+        if update_conf and "sysrepo" in self.acs:
+            # changing configuration without registering a new
+            # ApacheController is safe even if the new configuration
+            # specifies a different port, because the controller
+            # gets stopped/started by the __set_conf(..)
+            # method of ApacheController if the process is running.
+            self.acs["sysrepo"].conf = self.apache_confs[name]
 
-        def __check_publisher_info(self, expected, set_debug_value=True,
-            su_wrap=False, env_arg=None):
-                self.pkg("publisher -F tsv", debug_smf=set_debug_value,
-                    su_wrap=su_wrap, env_arg=env_arg)
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output, bound_white_space=True)
+    def __check_publisher_info(
+        self, expected, set_debug_value=True, su_wrap=False, env_arg=None
+    ):
+        self.pkg(
+            "publisher -F tsv",
+            debug_smf=set_debug_value,
+            su_wrap=su_wrap,
+            env_arg=env_arg,
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output, bound_white_space=True)
 
-        def __check_package_lists(self, expected):
-                self.pkg("list -Ha")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+    def __check_package_lists(self, expected):
+        self.pkg("list -Ha")
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-        def __check_publisher_dirs(self, pubs):
-                pub_dir = os.path.join(self.img_path(), "var/pkg/publisher")
-                for p in pubs:
-                        if not os.path.isdir(os.path.join(pub_dir, p)):
-                                raise RuntimeError("Publisher {0} was expected "
-                                    "to exist but its directory is missing "
-                                    "from the image directory.".format(p))
-                for d in os.listdir(pub_dir):
-                        if d not in pubs:
-                                raise RuntimeError("{0} was not expected in the "
-                                    "publisher directory but was found.".format(d))
+    def __check_publisher_dirs(self, pubs):
+        pub_dir = os.path.join(self.img_path(), "var/pkg/publisher")
+        for p in pubs:
+            if not os.path.isdir(os.path.join(pub_dir, p)):
+                raise RuntimeError(
+                    "Publisher {0} was expected "
+                    "to exist but its directory is missing "
+                    "from the image directory.".format(p)
+                )
+        for d in os.listdir(pub_dir):
+            if d not in pubs:
+                raise RuntimeError(
+                    "{0} was not expected in the "
+                    "publisher directory but was found.".format(d)
+                )
 
-        def test_01_basics(self):
-                """Test that an image with no publishers can be created and that
-                it can pick up its publisher configuration from the system
-                repository."""
-                self.base_01_basics()
+    def test_01_basics(self):
+        """Test that an image with no publishers can be created and that
+        it can pick up its publisher configuration from the system
+        repository."""
+        self.base_01_basics()
 
-        def test_01a_basics(self):
-                """Tests that an image with no publishers can be created and
-                that it can pick up its publisher configuration from the system
-                repository when we're using a cached pkg.sysrepo config."""
-                self.base_01_basics(use_config_cache=True)
+    def test_01a_basics(self):
+        """Tests that an image with no publishers can be created and
+        that it can pick up its publisher configuration from the system
+        repository when we're using a cached pkg.sysrepo config."""
+        self.base_01_basics(use_config_cache=True)
 
-        def base_01_basics(self, use_config_cache=False):
-                """Implementation of test_01_basics, parameterizing
-                use_config_cache"""
+    def base_01_basics(self, use_config_cache=False):
+        """Implementation of test_01_basics, parameterizing
+        use_config_cache"""
 
-                self.__prep_configuration("all-access",
-                    use_config_cache=use_config_cache)
-                self.__set_responses("all-access")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["all-access"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-                # Make sure that the publisher catalogs were created.
-                for n in ("test1", "test12", "test3"):
-                        self.assertTrue(os.path.isdir(os.path.join(self.img_path(),
-                            "var/pkg/publisher/{0}".format(n))))
-                expected = self.expected_all_access.format(
-                    durl1=self.durl1, durl2=self.durl2,
-                    durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+        self.__prep_configuration(
+            "all-access", use_config_cache=use_config_cache
+        )
+        self.__set_responses("all-access")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["all-access"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+        # Make sure that the publisher catalogs were created.
+        for n in ("test1", "test12", "test3"):
+            self.assertTrue(
+                os.path.isdir(
+                    os.path.join(
+                        self.img_path(), "var/pkg/publisher/{0}".format(n)
+                    )
+                )
+            )
+        expected = self.expected_all_access.format(
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                # make sure none of our sysrepo-provided configuration has
-                # leaked into the image configuration
-                self.pkg("set-property use-system-repo False")
-                expected = """\
+        # make sure none of our sysrepo-provided configuration has
+        # leaked into the image configuration
+        self.pkg("set-property use-system-repo False")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 """
-                self.__check_publisher_info(expected)
-                self.pkg("set-property use-system-repo True")
+        self.__check_publisher_info(expected)
+        self.pkg("set-property use-system-repo True")
 
-                self.pkg("publisher test1")
+        self.pkg("publisher test1")
 
-                # check we have the correct number of lines, each containing
-                # <system-repository>
-                self.pkg("publisher -H")
-                count = 0
-                for line in self.output.split("\n"):
-                        count += 1
-                        # publisher 4 does not have any origins set
-                        if not line.startswith("test4") and line:
-                                self.assertTrue("<system-repository>" in line,
-                                    "line {0} does not contain "
-                                    "'<system-repository>'".format(line))
-                self.assertTrue(count == 5,
-                    "expected 5 lines of output in \n{0}\n, got {1}".format(
-                    self.output, count))
+        # check we have the correct number of lines, each containing
+        # <system-repository>
+        self.pkg("publisher -H")
+        count = 0
+        for line in self.output.split("\n"):
+            count += 1
+            # publisher 4 does not have any origins set
+            if not line.startswith("test4") and line:
+                self.assertTrue(
+                    "<system-repository>" in line,
+                    "line {0} does not contain "
+                    "'<system-repository>'".format(line),
+                )
+        self.assertTrue(
+            count == 5,
+            "expected 5 lines of output in \n{0}\n, got {1}".format(
+                self.output, count
+            ),
+        )
 
-                self.pkg("publisher")
-                self.pkg("publisher test1")
-                self.pkg("publisher test12")
-                self.assertTrue("Proxy: http://localhost:{0}".format(self.sysrepo_port)
-                    in self.output)
-                self.assertTrue("<system-repository>" not in self.output)
-                self.debug("looking for {0}".format(self.durl1))
+        self.pkg("publisher")
+        self.pkg("publisher test1")
+        self.pkg("publisher test12")
+        self.assertTrue(
+            "Proxy: http://localhost:{0}".format(self.sysrepo_port)
+            in self.output
+        )
+        self.assertTrue("<system-repository>" not in self.output)
+        self.debug("looking for {0}".format(self.durl1))
 
-                # Test that the publishers have the right uris and appear in
-                # the correct order.
-                self.pkg("publisher -F tsv")
-                expected = """\
+        # Test that the publishers have the right uris and appear in
+        # the correct order.
+        self.pkg("publisher -F tsv")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{one}/\thttp://localhost:{port}
 test12\tfalse\ttrue\ttrue\torigin\tonline\t{two}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{three}/\thttp://localhost:{port}
 test4\ttrue\ttrue\ttrue\t\t\t\t
-""".format(port=self.sysrepo_port, one=self.durl1, two=self.durl2,
-    three=self.durl3)
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output, bound_white_space=True)
+""".format(
+            port=self.sysrepo_port,
+            one=self.durl1,
+            two=self.durl2,
+            three=self.durl3,
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output, bound_white_space=True)
 
-                # Test that a new pkg process will pick up the right catalog.
-                self.pkg("list -a")
-                self.pkg("install example_pkg")
+        # Test that a new pkg process will pick up the right catalog.
+        self.pkg("list -a")
+        self.pkg("install example_pkg")
 
-                # Test that the current api object has the right catalog.
-                self._api_install(api_obj, ["foo", "bar"])
+        # Test that the current api object has the right catalog.
+        self._api_install(api_obj, ["foo", "bar"])
 
-                # Test that we can install a multi-hash package
-                self.pkg("install baz")
-                self.pkg("contents -m baz")
-                self.assertTrue("pkg.content-hash=file:sha256" in self.output)
-                if sha512_supported:
-                        self.pkg("install caz")
-                        self.pkg("contents -m caz")
-                        self.assertTrue("pkg.content-hash=file:sha512t_256"
-                            in self.output)
+        # Test that we can install a multi-hash package
+        self.pkg("install baz")
+        self.pkg("contents -m baz")
+        self.assertTrue("pkg.content-hash=file:sha256" in self.output)
+        if sha512_supported:
+            self.pkg("install caz")
+            self.pkg("contents -m caz")
+            self.assertTrue("pkg.content-hash=file:sha512t_256" in self.output)
 
-        def test_02_communication(self):
-                """Test that the transport for communicating with the depots is
-                actually going through the proxy. This is done by
-                "misconfiguring" the system repository so that it refuses to
-                proxy to certain depots then operations which would communicate
-                with those depots fail.
+    def test_02_communication(self):
+        """Test that the transport for communicating with the depots is
+        actually going through the proxy. This is done by
+        "misconfiguring" the system repository so that it refuses to
+        proxy to certain depots then operations which would communicate
+        with those depots fail.
 
-                We also verify that $http_proxy and $no_proxy environment
-                variables are not used for interactions with the system
-                repository.
-                """
+        We also verify that $http_proxy and $no_proxy environment
+        variables are not used for interactions with the system
+        repository.
+        """
 
-                self.__prep_configuration(["all-access", "none", "test12-test3",
-                    "test3"])
-                self.__set_responses("all-access")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["none"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
+        self.__prep_configuration(
+            ["all-access", "none", "test12-test3", "test3"]
+        )
+        self.__set_responses("all-access")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["none"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
 
-                sc.start()
-                self.assertRaises(apx.CatalogRefreshException,
-                    self.image_create, props={"use-system-repo": True})
-                sc.conf = self.apache_confs["all-access"]
-                api_obj = self.image_create(props={"use-system-repo": True})
-                sc.conf = self.apache_confs["none"]
+        sc.start()
+        self.assertRaises(
+            apx.CatalogRefreshException,
+            self.image_create,
+            props={"use-system-repo": True},
+        )
+        sc.conf = self.apache_confs["all-access"]
+        api_obj = self.image_create(props={"use-system-repo": True})
+        sc.conf = self.apache_confs["none"]
 
-                expected =  self.expected_all_access.format(
-                    durl1=self.durl1, durl2=self.durl2,
-                    durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+        expected = self.expected_all_access.format(
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                self.pkg("list -a")
-                self.pkg("contents -rm example_pkg", exit=1)
-                self.pkg("contents -rm foo", exit=1)
-                self.pkg("contents -rm bar", exit=1)
-                self.pkg("install --no-refresh example_pkg", exit=1)
-                self.pkg("install --no-refresh foo", exit=1)
-                self.pkg("install --no-refresh bar", exit=1)
-                self.assertRaises(tx.TransportFailures, self._api_install,
-                    api_obj, ["example_pkg"], refresh_catalogs=False)
-                self.assertRaises(tx.TransportFailures, self._api_install,
-                    api_obj, ["foo"], refresh_catalogs=False)
-                self.assertRaises(tx.TransportFailures, self._api_install,
-                    api_obj, ["bar"], refresh_catalogs=False)
+        self.pkg("list -a")
+        self.pkg("contents -rm example_pkg", exit=1)
+        self.pkg("contents -rm foo", exit=1)
+        self.pkg("contents -rm bar", exit=1)
+        self.pkg("install --no-refresh example_pkg", exit=1)
+        self.pkg("install --no-refresh foo", exit=1)
+        self.pkg("install --no-refresh bar", exit=1)
+        self.assertRaises(
+            tx.TransportFailures,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+            refresh_catalogs=False,
+        )
+        self.assertRaises(
+            tx.TransportFailures,
+            self._api_install,
+            api_obj,
+            ["foo"],
+            refresh_catalogs=False,
+        )
+        self.assertRaises(
+            tx.TransportFailures,
+            self._api_install,
+            api_obj,
+            ["bar"],
+            refresh_catalogs=False,
+        )
 
-                sc.conf = self.apache_confs["test3"]
-                self.pkg("list -a")
-                self.pkg("contents -rm example_pkg", exit=1)
-                self.pkg("contents -rm foo", exit=1)
-                self.pkg("contents -rm bar")
-                self.assertRaises(tx.TransportFailures, self._api_install,
-                    api_obj, ["example_pkg"], refresh_catalogs=False)
-                self.assertRaises(tx.TransportFailures, self._api_install,
-                    api_obj, ["foo"], refresh_catalogs=False)
-                self._api_install(api_obj, ["bar"], refresh_catalogs=False)
+        sc.conf = self.apache_confs["test3"]
+        self.pkg("list -a")
+        self.pkg("contents -rm example_pkg", exit=1)
+        self.pkg("contents -rm foo", exit=1)
+        self.pkg("contents -rm bar")
+        self.assertRaises(
+            tx.TransportFailures,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+            refresh_catalogs=False,
+        )
+        self.assertRaises(
+            tx.TransportFailures,
+            self._api_install,
+            api_obj,
+            ["foo"],
+            refresh_catalogs=False,
+        )
+        self._api_install(api_obj, ["bar"], refresh_catalogs=False)
 
+        sc.conf = self.apache_confs["test12-test3"]
+        self.pkg("list -a")
+        self.pkg("contents -rm example_pkg", exit=1)
+        self.pkg("contents -rm foo")
+        self.assertRaises(
+            tx.TransportFailures,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+            refresh_catalogs=False,
+        )
+        self._api_install(api_obj, ["foo"], refresh_catalogs=False)
 
-                sc.conf = self.apache_confs["test12-test3"]
-                self.pkg("list -a")
-                self.pkg("contents -rm example_pkg", exit=1)
-                self.pkg("contents -rm foo")
-                self.assertRaises(tx.TransportFailures, self._api_install,
-                    api_obj, ["example_pkg"], refresh_catalogs=False)
-                self._api_install(api_obj, ["foo"], refresh_catalogs=False)
+        sc.conf = self.apache_confs["all-access"]
+        self.pkg("list -a")
+        self.pkg("contents -rm example_pkg")
+        self._api_install(api_obj, ["example_pkg"])
 
-                sc.conf = self.apache_confs["all-access"]
-                self.pkg("list -a")
-                self.pkg("contents -rm example_pkg")
-                self._api_install(api_obj, ["example_pkg"])
+        # check that $http_proxy environment variables are ignored
+        # by setting http_proxy and no_proxy values that would otherwise
+        # cause us to bypass the system-repository.
 
-                # check that $http_proxy environment variables are ignored
-                # by setting http_proxy and no_proxy values that would otherwise
-                # cause us to bypass the system-repository.
+        env = {"http_proxy": "http://noodles"}
+        # create an image the long way, allowing us to pass an environ
+        self.image_destroy()
+        os.mkdir(self.img_path())
+        self.pkg("image-create {0}".format(self.img_path()))
+        self.pkg("set-property use-system-repo True", env_arg=env)
 
-                env = {"http_proxy": "http://noodles"}
-                # create an image the long way, allowing us to pass an environ
-                self.image_destroy()
-                os.mkdir(self.img_path())
-                self.pkg("image-create {0}".format(self.img_path()))
-                self.pkg("set-property use-system-repo True", env_arg=env)
+        self.pkg("refresh --full", env_arg=env)
+        self.pkg("contents -rm example_pkg", env_arg=env)
+        expected = self.expected_all_access.format(
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
+        self.pkg("install example_pkg", env_arg=env)
 
-                self.pkg("refresh --full", env_arg=env)
-                self.pkg("contents -rm example_pkg", env_arg=env)
-                expected =  self.expected_all_access.format(
-                    durl1=self.durl1, durl2=self.durl2,
-                    durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
-                self.pkg("install example_pkg", env_arg=env)
+        env = {"no_proxy": "localhost"}
+        # create an image the long way, allowing us to pass an environ
+        self.image_destroy()
+        os.mkdir(self.img_path())
+        self.pkg("image-create {0}".format(self.img_path()))
+        self.pkg("set-property use-system-repo True", env_arg=env)
 
-                env = {"no_proxy": "localhost"}
-                # create an image the long way, allowing us to pass an environ
-                self.image_destroy()
-                os.mkdir(self.img_path())
-                self.pkg("image-create {0}".format(self.img_path()))
-                self.pkg("set-property use-system-repo True", env_arg=env)
+        self.pkg("refresh --full", env_arg=env)
+        self.pkg("contents -rm example_pkg", env_arg=env)
+        self.__check_publisher_info(expected, env_arg=env)
+        self.pkg("install example_pkg", env_arg=env)
 
-                self.pkg("refresh --full", env_arg=env)
-                self.pkg("contents -rm example_pkg", env_arg=env)
-                self.__check_publisher_info(expected, env_arg=env)
-                self.pkg("install example_pkg", env_arg=env)
+    def test_03_user_modifying_configuration(self):
+        """Test that adding and removing origins to a system publisher
+        works as expected and that modifying other configuration of a
+        system publisher fails."""
 
-        def test_03_user_modifying_configuration(self):
-                """Test that adding and removing origins to a system publisher
-                works as expected and that modifying other configuration of a
-                system publisher fails."""
+        self.__prep_configuration(["test1", "none", "mirror-access-user"])
+        self.__set_responses("test1")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["test1"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
 
-                self.__prep_configuration(["test1", "none",
-                    "mirror-access-user"])
-                self.__set_responses("test1")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["test1"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
+        # Test that most modifications to a system publisher fail.
+        self.pkg(
+            "set-publisher -g {0} --disable test1".format(self.durl1), exit=1
+        )
+        self.pkg(
+            "set-publisher -g {0} --enable test1".format(self.durl1), exit=1
+        )
+        self.pkg("set-publisher -d test1", exit=1)
+        self.pkg("set-publisher -e test1", exit=1)
+        self.pkg("set-publisher --non-sticky test1", exit=1)
+        self.pkg("set-publisher --sticky test1", exit=1)
+        self.pkg("set-publisher --set-property foo=bar test1", exit=1)
+        self.pkg("set-publisher --unset-property test-property test1", exit=1)
+        self.pkg(
+            "set-publisher --add-property-value test-property=bar " "test1",
+            exit=1,
+        )
+        self.pkg(
+            "set-publisher --remove-property-value " "test-property=test test1",
+            exit=1,
+        )
+        self.pkg("unset-publisher test1", exit=1)
+        self.pkg("set-publisher --search-first test1", exit=1)
 
-                # Test that most modifications to a system publisher fail.
-                self.pkg("set-publisher -g {0} --disable test1".format(
-                    self.durl1), exit=1)
-                self.pkg("set-publisher -g {0} --enable test1".format(
-                    self.durl1), exit=1)
-                self.pkg("set-publisher -d test1", exit=1)
-                self.pkg("set-publisher -e test1", exit=1)
-                self.pkg("set-publisher --non-sticky test1", exit=1)
-                self.pkg("set-publisher --sticky test1", exit=1)
-                self.pkg("set-publisher --set-property foo=bar test1", exit=1)
-                self.pkg("set-publisher --unset-property test-property test1",
-                    exit=1)
-                self.pkg("set-publisher --add-property-value test-property=bar "
-                    "test1", exit=1)
-                self.pkg("set-publisher --remove-property-value "
-                    "test-property=test test1", exit=1)
-                self.pkg("unset-publisher test1", exit=1)
-                self.pkg("set-publisher --search-first test1", exit=1)
+        # Add a mirror to an existing system publisher
+        self.pkg("set-publisher -m {0} test1".format(self.rurl1))
 
-                # Add a mirror to an existing system publisher
-                self.pkg("set-publisher -m {0} test1".format(self.rurl1))
+        # Add an origin to an existing system publisher.
+        self.pkg("set-publisher -g {0} test1".format(self.rurl1))
 
-                # Add an origin to an existing system publisher.
-                self.pkg("set-publisher -g {0} test1".format(self.rurl1))
-
-                # Check that the publisher information is shown correctly.
-                expected = """\
+        # Check that the publisher information is shown correctly.
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test1\ttrue\ttrue\ttrue\tmirror\tonline\t{rurl1}/\t-
-""".format(rurl1=self.rurl1, durl1=self.durl1, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1, durl1=self.durl1, port=self.sysrepo_port
+        )
+        self.__check_publisher_info(expected)
 
-                # Check that the publisher specific information has information
-                # for both origins, and that we only have one occurrence of
-                # "Proxy:"
-                self.pkg("publisher test1")
-                self.assertTrue(self.rurl1 in self.output)
-                self.assertTrue(self.durl1 in self.output)
-                self.assertTrue("http://localhost:{0}\n".format(self.sysrepo_port)
-                    in self.output)
-                self.assertTrue(self.output.count("Proxy:") == 1)
+        # Check that the publisher specific information has information
+        # for both origins, and that we only have one occurrence of
+        # "Proxy:"
+        self.pkg("publisher test1")
+        self.assertTrue(self.rurl1 in self.output)
+        self.assertTrue(self.durl1 in self.output)
+        self.assertTrue(
+            "http://localhost:{0}\n".format(self.sysrepo_port) in self.output
+        )
+        self.assertTrue(self.output.count("Proxy:") == 1)
 
-                # Change the proxy configuration so that the image can't use it
-                # to communicate with the depot. This forces communication to
-                # go through the user configured origin.
-                sc.conf = self.apache_confs["none"]
+        # Change the proxy configuration so that the image can't use it
+        # to communicate with the depot. This forces communication to
+        # go through the user configured origin.
+        sc.conf = self.apache_confs["none"]
 
-                # Check that the catalog can't be refreshed and that the
-                # communcation with the repository fails.
-                self.pkg("contents -rm example_pkg")
-                self.pkg("refresh --full", exit=1)
+        # Check that the catalog can't be refreshed and that the
+        # communcation with the repository fails.
+        self.pkg("contents -rm example_pkg")
+        self.pkg("refresh --full", exit=1)
 
-                # Check that removing the system configured origin fails.
-                self.pkg("set-publisher -G {0} test1".format(self.durl1), exit=1)
-                self.pkg("set-publisher -G {0} test1".format(self.durl1),
-                    exit=1)
-                # Check that removing the user configured origin succeeds.
-                # --no-refresh is needed because otherwise we attempt to contact
-                # the publisher to update the catalogs.
-                self.pkg("set-publisher -G {0} --no-refresh test1".format(self.rurl1))
+        # Check that removing the system configured origin fails.
+        self.pkg("set-publisher -G {0} test1".format(self.durl1), exit=1)
+        self.pkg("set-publisher -G {0} test1".format(self.durl1), exit=1)
+        # Check that removing the user configured origin succeeds.
+        # --no-refresh is needed because otherwise we attempt to contact
+        # the publisher to update the catalogs.
+        self.pkg("set-publisher -G {0} --no-refresh test1".format(self.rurl1))
 
-                # Check that the user configured origin is gone.
-                expected = """\
+        # Check that the user configured origin is gone.
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test1\ttrue\ttrue\ttrue\tmirror\tonline\t{rurl1}/\t-
-""".format(durl1=self.durl1, rurl1=self.rurl1, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            durl1=self.durl1, rurl1=self.rurl1, port=self.sysrepo_port
+        )
+        self.__check_publisher_info(expected)
 
-                # Ensure that previous communication was going through the file
-                # repo by confirming that communication to the depot is still
-                # refused.
-                self.pkg("refresh --full", exit=1)
+        # Ensure that previous communication was going through the file
+        # repo by confirming that communication to the depot is still
+        # refused.
+        self.pkg("refresh --full", exit=1)
 
-                # Reenable access to the depot to make sure nothing has been
-                # broken in the image.
-                sc.conf = self.apache_confs["test1"]
-                self.pkg("refresh --full")
+        # Reenable access to the depot to make sure nothing has been
+        # broken in the image.
+        sc.conf = self.apache_confs["test1"]
+        self.pkg("refresh --full")
 
-                # Find the hashes that will be included in the urls of the
-                # proxied file repos.
-                hash1 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[1].get_repodir().rstrip("/"))).hexdigest()
-                hash3 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[3].get_repodir().rstrip("/"))).hexdigest()
+        # Find the hashes that will be included in the urls of the
+        # proxied file repos.
+        hash1 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[1].get_repodir().rstrip("/"))
+        ).hexdigest()
+        hash3 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[3].get_repodir().rstrip("/"))
+        ).hexdigest()
 
-                # Check that a user can add and remove mirrors,
-                # but can't remove repo-provided mirrors
-                sc.conf = self.apache_confs["mirror-access-user"]
-                self.__set_responses("mirror-access-user")
-                self.pkg("set-publisher -m {0} test12".format(self.rurl2))
-                expected_mirrors = """\
+        # Check that a user can add and remove mirrors,
+        # but can't remove repo-provided mirrors
+        sc.conf = self.apache_confs["mirror-access-user"]
+        self.__set_responses("mirror-access-user")
+        self.pkg("set-publisher -m {0} test12".format(self.rurl2))
+        expected_mirrors = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test1\ttrue\ttrue\ttrue\tmirror\tonline\t{rurl1}/\t-
@@ -885,28 +1105,37 @@ test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
 test12\tfalse\ttrue\ttrue\tmirror\tonline\t{rurl2}/\t-
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{durl3}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\tmirror\tonline\thttp://localhost:{port}/test3/{hash3}/\t-
-""".format(port=self.sysrepo_port, hash1=hash1, rurl1=self.rurl1,
-    rurl2=self.rurl2, hash3=hash3, durl1=self.durl1,
-    durl2=self.durl2, durl3=self.durl3)
-                self.__check_publisher_info(expected_mirrors)
+""".format(
+            port=self.sysrepo_port,
+            hash1=hash1,
+            rurl1=self.rurl1,
+            rurl2=self.rurl2,
+            hash3=hash3,
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+        )
+        self.__check_publisher_info(expected_mirrors)
 
-                # turn off the sysrepo property, and ensure the mirror is there
-                self.pkg("set-property use-system-repo False")
-                expected = """\
+        # turn off the sysrepo property, and ensure the mirror is there
+        self.pkg("set-property use-system-repo False")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\tfalse\ttrue\tmirror\tonline\t{rurl1}/\t-
 test12\tfalse\tfalse\ttrue\tmirror\tonline\t{rurl2}/\t-
-""".format(rurl1=self.rurl1, rurl2=self.rurl2)
-                self.__check_publisher_info(expected)
-                self.pkg("set-property use-system-repo True")
+""".format(
+            rurl1=self.rurl1, rurl2=self.rurl2
+        )
+        self.__check_publisher_info(expected)
+        self.pkg("set-property use-system-repo True")
 
-                # ensure we can't remove the sysrepo-provided mirror
-                self.pkg("set-publisher -M {0} test12".format(self.rurl1), exit=1)
-                self.__check_publisher_info(expected_mirrors)
+        # ensure we can't remove the sysrepo-provided mirror
+        self.pkg("set-publisher -M {0} test12".format(self.rurl1), exit=1)
+        self.__check_publisher_info(expected_mirrors)
 
-                # ensure we can remove the user-provided mirror
-                self.pkg("set-publisher -M {0} test12".format(self.rurl2))
-                expected = """\
+        # ensure we can remove the user-provided mirror
+        self.pkg("set-publisher -M {0} test12".format(self.rurl2))
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test1\ttrue\ttrue\ttrue\tmirror\tonline\t{rurl1}/\t-
@@ -914,305 +1143,349 @@ test1\ttrue\ttrue\ttrue\tmirror\tonline\thttp://localhost:{port}/test1/{hash1}/\
 test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{durl3}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\tmirror\tonline\thttp://localhost:{port}/test3/{hash3}/\t-
-""".format(port=self.sysrepo_port, hash1=hash1, rurl1=self.rurl1,
-    hash3=hash3, durl1=self.durl1, durl2=self.durl2,
-    durl3=self.durl3)
+""".format(
+            port=self.sysrepo_port,
+            hash1=hash1,
+            rurl1=self.rurl1,
+            hash3=hash3,
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+        )
 
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-        def test_04_changing_syspub_configuration(self):
-                """Test that changes to the syspub/0 response are handled
-                correctly by the client."""
+    def test_04_changing_syspub_configuration(self):
+        """Test that changes to the syspub/0 response are handled
+        correctly by the client."""
 
-                # Check that a syspub/0 response with no configured publisers
-                # works.
-                self.__prep_configuration(["none", "test1-test12",
-                    "test1-test3", "test12"])
-                self.__set_responses("none")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["none"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
+        # Check that a syspub/0 response with no configured publisers
+        # works.
+        self.__prep_configuration(
+            ["none", "test1-test12", "test1-test3", "test12"]
+        )
+        self.__set_responses("none")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["none"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
 
-                expected = """\
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 """
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-                # The user configures test1 as a publisher.
-                self.pkg("set-publisher --non-sticky -p {0}".format(self.durl1))
-                self.__check_publisher_dirs(["test1"])
-                expected = """\
+        # The user configures test1 as a publisher.
+        self.pkg("set-publisher --non-sticky -p {0}".format(self.durl1))
+        self.__check_publisher_dirs(["test1"])
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\tfalse\tfalse\ttrue\torigin\tonline\t{0}/\t-
-""".format(self.durl1)
-                self.__check_publisher_info(expected)
+""".format(
+            self.durl1
+        )
+        self.__check_publisher_info(expected)
 
-                self.pkg("set-publisher -d test1")
-                expected = """\
+        self.pkg("set-publisher -d test1")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\tfalse\tfalse\ttrue\torigin\tonline\t{0}/\t-
-""".format(self.durl1)
-                self.__check_publisher_info(expected)
-                self.__check_publisher_dirs([])
-                self.pkg("publisher")
-                self.assertTrue("disabled" in self.output)
+""".format(
+            self.durl1
+        )
+        self.__check_publisher_info(expected)
+        self.__check_publisher_dirs([])
+        self.pkg("publisher")
+        self.assertTrue("disabled" in self.output)
 
-                # Now the syspub/0 response configures two publishers. The
-                # test12 publisher is totally new while the test1 publisher
-                # overlaps with the publisher the user configured.
-                self.__set_responses("test1-test12")
+        # Now the syspub/0 response configures two publishers. The
+        # test12 publisher is totally new while the test1 publisher
+        # overlaps with the publisher the user configured.
+        self.__set_responses("test1-test12")
 
-                # Check that the syspub/0 sticky setting has masked the user
-                # configuration and that the other publisher information is as
-                # expected.  Note that the user-configured origin should be
-                # hidden since we can only have a single path to an origin,
-                # so we use the system repository version.
-                expected = """\
+        # Check that the syspub/0 sticky setting has masked the user
+        # configuration and that the other publisher information is as
+        # expected.  Note that the user-configured origin should be
+        # hidden since we can only have a single path to an origin,
+        # so we use the system repository version.
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
-""".format(durl1=self.durl1, durl2=self.durl2, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
-                self.__check_publisher_dirs([])
+""".format(
+            durl1=self.durl1, durl2=self.durl2, port=self.sysrepo_port
+        )
+        self.__check_publisher_info(expected)
+        self.__check_publisher_dirs([])
 
-                expected = """\
+        expected = """\
 example_pkg 1.0-0 ---
 foo (test12) 1.0-0 ---
 """
-                self.__check_package_lists(expected)
-                self.pkg("refresh --full")
+        self.__check_package_lists(expected)
+        self.pkg("refresh --full")
 
-                self.pkg("contents -rm example_pkg")
-                self.pkg("contents -rm foo")
-                self.pkg("contents -rm bar", exit=1)
+        self.pkg("contents -rm example_pkg")
+        self.pkg("contents -rm foo")
+        self.pkg("contents -rm bar", exit=1)
 
-                # Now the syspub/0 response configures two publishers, test1 and
-                # test 3.
-                self.__set_responses("test1-test3")
+        # Now the syspub/0 response configures two publishers, test1 and
+        # test 3.
+        self.__set_responses("test1-test3")
 
-                expected = """\
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{durl3}/\thttp://localhost:{port}
-""".format(durl1=self.durl1, durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
-                # Only test1 is expected to exist because only it was present in
-                # both the old configuration and the current configuration.
-                self.__check_publisher_dirs(["test1"])
+""".format(
+            durl1=self.durl1, durl3=self.durl3, port=self.sysrepo_port
+        )
+        self.__check_publisher_info(expected)
+        # Only test1 is expected to exist because only it was present in
+        # both the old configuration and the current configuration.
+        self.__check_publisher_dirs(["test1"])
 
-                if sha512_supported:
-                        expected = """\
+        if sha512_supported:
+            expected = """\
 bar (test3) 1.0-0 ---
 baz (test3) 1.0-0 ---
 caz (test3) 1.0-0 ---
 example_pkg 1.0-0 ---
 """
-                else:
-                        expected = """\
+        else:
+            expected = """\
 bar (test3) 1.0-0 ---
 baz (test3) 1.0-0 ---
 example_pkg 1.0-0 ---
 """
-                self.__check_package_lists(expected)
+        self.__check_package_lists(expected)
 
-                self.pkg("contents -rm example_pkg")
-                self.pkg("contents -rm foo", exit=1)
-                self.pkg("contents -m foo", exit=1)
-                self.pkg("contents -rm bar")
-                self.pkg("refresh --full")
+        self.pkg("contents -rm example_pkg")
+        self.pkg("contents -rm foo", exit=1)
+        self.pkg("contents -m foo", exit=1)
+        self.pkg("contents -rm bar")
+        self.pkg("refresh --full")
 
-                # The user tries to add an origin to the system publisher test3
-                # using the same url as the system-repository provides, which
-                # should fail, because There Can Be Only One origin for a given
-                # uri.
-                self.pkg("set-publisher -g {0} test3".format(self.durl3), exit=1)
+        # The user tries to add an origin to the system publisher test3
+        # using the same url as the system-repository provides, which
+        # should fail, because There Can Be Only One origin for a given
+        # uri.
+        self.pkg("set-publisher -g {0} test3".format(self.durl3), exit=1)
 
-                expected = """\
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{durl3}/\thttp://localhost:{port}
-""".format(durl1=self.durl1, durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
-                self.__check_publisher_dirs(["test1", "test3"])
+""".format(
+            durl1=self.durl1, durl3=self.durl3, port=self.sysrepo_port
+        )
+        self.__check_publisher_info(expected)
+        self.__check_publisher_dirs(["test1", "test3"])
 
-                if sha512_supported:
-                        expected = """\
+        if sha512_supported:
+            expected = """\
 bar (test3) 1.0-0 ---
 baz (test3) 1.0-0 ---
 caz (test3) 1.0-0 ---
 example_pkg 1.0-0 ---
 """
-                else:
-                        expected = """\
+        else:
+            expected = """\
 bar (test3) 1.0-0 ---
 baz (test3) 1.0-0 ---
 example_pkg 1.0-0 ---
 """
-                self.__check_package_lists(expected)
-                self.pkg("refresh --full")
+        self.__check_package_lists(expected)
+        self.pkg("refresh --full")
 
-                # Now syspub/0 removes test1 and test3 as publishers and returns
-                # test12 as a publisher.
-                self.__set_responses("test12")
+        # Now syspub/0 removes test1 and test3 as publishers and returns
+        # test12 as a publisher.
+        self.__set_responses("test12")
 
-                # test1 should be reinstated as a publisher because the
-                # user added an origin for it before using the system
-                # repository. test1 should also return to
-                # the settings the user had previously configured. test12 should
-                # be listed first since, because it's a system publisher, it's
-                # higher ranked.
-                expected = """\
+        # test1 should be reinstated as a publisher because the
+        # user added an origin for it before using the system
+        # repository. test1 should also return to
+        # the settings the user had previously configured. test12 should
+        # be listed first since, because it's a system publisher, it's
+        # higher ranked.
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
 test1\tfalse\tfalse\ttrue\torigin\tonline\t{durl1}/\t-
-""".format(durl2=self.durl2, durl1=self.durl1, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            durl2=self.durl2, durl1=self.durl1, port=self.sysrepo_port
+        )
+        self.__check_publisher_info(expected)
 
-                self.pkg("refresh --full")
+        self.pkg("refresh --full")
 
-                expected = """\
+        expected = """\
 foo 1.0-0 ---
 """
-                self.__check_package_lists(expected)
+        self.__check_package_lists(expected)
 
-                # Install a package from test12.
-                self.pkg("install foo")
+        # Install a package from test12.
+        self.pkg("install foo")
 
-                # Now syspub/0 removes test12 as a publisher as well.
-                self.__set_responses("none")
+        # Now syspub/0 removes test12 as a publisher as well.
+        self.__set_responses("none")
 
-                # test12 should be disabled and at the bottom of the list
-                # because a package was installed from it prior to its removal
-                # as a system publisher.
-                expected = """\
+        # test12 should be disabled and at the bottom of the list
+        # because a package was installed from it prior to its removal
+        # as a system publisher.
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\tfalse\tfalse\ttrue\torigin\tonline\t{durl1}/\t-
 test12\tfalse\ttrue\tfalse\t\t\t\t
-""".format(durl1=self.durl1)
-                self.__check_publisher_info(expected)
+""".format(
+            durl1=self.durl1
+        )
+        self.__check_publisher_info(expected)
 
-                # Uninstalling foo should remove test12 from the list of
-                # publishers.
-                self.pkg("uninstall foo")
-                expected = """\
+        # Uninstalling foo should remove test12 from the list of
+        # publishers.
+        self.pkg("uninstall foo")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\tfalse\tfalse\ttrue\torigin\tonline\t{durl1}/\t-
-""".format(durl1=self.durl1, durl3=self.durl3)
-                self.__check_publisher_info(expected)
+""".format(
+            durl1=self.durl1, durl3=self.durl3
+        )
+        self.__check_publisher_info(expected)
 
-        def test_05_simultaneous_change(self):
-                """Test that simultaneous changes in both user configuration and
-                system publisher state are handled correctly."""
+    def test_05_simultaneous_change(self):
+        """Test that simultaneous changes in both user configuration and
+        system publisher state are handled correctly."""
 
-                self.__prep_configuration(["none", "test1", "test12"])
-                # Create an image with no user configured publishers and no
-                # system configured publishers.
-                self.__set_responses("none")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["none"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-                expected = """\
+        self.__prep_configuration(["none", "test1", "test12"])
+        # Create an image with no user configured publishers and no
+        # system configured publishers.
+        self.__set_responses("none")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["none"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 """
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-                # Have the user configure test1 at the same time that test1 is
-                # made a system publisher.
-                self.__set_responses("test1")
+        # Have the user configure test1 at the same time that test1 is
+        # made a system publisher.
+        self.__set_responses("test1")
 
-                self.pkg("set-publisher -p {0}".format(self.rurl1))
-                expected = """\
+        self.pkg("set-publisher -p {0}".format(self.rurl1))
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
-""".format(rurl1=self.rurl1, durl1=self.durl1, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1, durl1=self.durl1, port=self.sysrepo_port
+        )
+        self.__check_publisher_info(expected)
 
-                # Adding the origin to the publisher which now exists should
-                # fail.
-                self.pkg("set-publisher -g {0} test1".format(self.rurl1), exit=1)
+        # Adding the origin to the publisher which now exists should
+        # fail.
+        self.pkg("set-publisher -g {0} test1".format(self.rurl1), exit=1)
 
-                # The user adds an origin to test12 at the same time that test12
-                # first becomes known to the image.
-                self.__set_responses("test12")
-                self.pkg("set-publisher -g {0} test12".format(self.rurl2))
-                expected = """\
+        # The user adds an origin to test12 at the same time that test12
+        # first becomes known to the image.
+        self.__set_responses("test12")
+        self.pkg("set-publisher -g {0} test12".format(self.rurl2))
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test12\tfalse\ttrue\ttrue\torigin\tonline\t{rurl2}/\t-
 test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
 test1\ttrue\tfalse\ttrue\torigin\tonline\t{rurl1}/\t-
-""".format(rurl2=self.rurl2, durl2=self.durl2, rurl1=self.rurl1,
-    port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl2=self.rurl2,
+            durl2=self.durl2,
+            rurl1=self.rurl1,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                self.pkg("publisher")
-                self.debug(self.output)
-                # The user removes the origin for test12 at the same time that
-                # test12 stops being a system publisher and test1 is added as a
-                # system publisher.
-                self.__set_responses("test1")
-                self.pkg("set-publisher -G {0} test12".format(self.rurl2))
-                expected = """\
+        self.pkg("publisher")
+        self.debug(self.output)
+        # The user removes the origin for test12 at the same time that
+        # test12 stops being a system publisher and test1 is added as a
+        # system publisher.
+        self.__set_responses("test1")
+        self.pkg("set-publisher -G {0} test12".format(self.rurl2))
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test12\tfalse\tfalse\ttrue\t\t\t\t
-""".format(rurl1=self.rurl1, durl1=self.durl1, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1, durl1=self.durl1, port=self.sysrepo_port
+        )
+        self.__check_publisher_info(expected)
 
-                # The user now removes the originless publisher
-                self.pkg("unset-publisher test12")
-                expected = """\
+        # The user now removes the originless publisher
+        self.pkg("unset-publisher test12")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
-""".format(rurl1=self.rurl1, durl1=self.durl1, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1, durl1=self.durl1, port=self.sysrepo_port
+        )
+        self.__check_publisher_info(expected)
 
-                # The user now unsets test1 at the same time that test1 stops
-                # being a system publisher.
-                self.__set_responses("none")
-                self.pkg("unset-publisher test1")
-                expected = """\
+        # The user now unsets test1 at the same time that test1 stops
+        # being a system publisher.
+        self.__set_responses("none")
+        self.pkg("unset-publisher test1")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 """
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-        def test_06_ordering(self):
-                """Test that publishers have the right search order given both
-                user configuration and whether a publisher is a system
-                publisher."""
+    def test_06_ordering(self):
+        """Test that publishers have the right search order given both
+        user configuration and whether a publisher is a system
+        publisher."""
 
-                self.__prep_configuration(["all-access", "none", "test1"])
-                self.__set_responses("none")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["none"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
+        self.__prep_configuration(["all-access", "none", "test1"])
+        self.__set_responses("none")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["none"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
 
-                self.pkg("set-publisher -p {0}".format(self.rurl3))
-                self.pkg("set-publisher -p {0}".format(self.rurl2))
-                self.pkg("set-publisher -p {0}".format(self.rurl1))
+        self.pkg("set-publisher -p {0}".format(self.rurl3))
+        self.pkg("set-publisher -p {0}".format(self.rurl2))
+        self.pkg("set-publisher -p {0}".format(self.rurl1))
 
-                expected = """\
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test3\ttrue\tfalse\ttrue\torigin\tonline\t{0}/\t-
 test12\ttrue\tfalse\ttrue\torigin\tonline\t{1}/\t-
 test1\ttrue\tfalse\ttrue\torigin\tonline\t{2}/\t-
-""".format(self.rurl3, self.rurl2, self.rurl1)
-                self.__check_publisher_info(expected)
+""".format(
+            self.rurl3, self.rurl2, self.rurl1
+        )
+        self.__check_publisher_info(expected)
 
-                self.__set_responses("all-access")
+        self.__set_responses("all-access")
 
-                expected = """\
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
@@ -1221,22 +1494,30 @@ test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{rurl3}/\t-
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{durl3}/\thttp://localhost:{port}
 test4\ttrue\ttrue\ttrue\t\t\t\t
-""".format(rurl1=self.rurl1, durl1=self.durl1, rurl2=self.rurl2,
-    durl2=self.durl2, rurl3=self.rurl3, durl3=self.durl3,
-    port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1,
+            durl1=self.durl1,
+            rurl2=self.rurl2,
+            durl2=self.durl2,
+            rurl3=self.rurl3,
+            durl3=self.durl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                self.pkg("set-property use-system-repo False")
-                expected = """\
+        self.pkg("set-property use-system-repo False")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test3\ttrue\tfalse\ttrue\torigin\tonline\t{0}/\t-
 test12\ttrue\tfalse\ttrue\torigin\tonline\t{1}/\t-
 test1\ttrue\tfalse\ttrue\torigin\tonline\t{2}/\t-
-""".format(self.rurl3, self.rurl2, self.rurl1)
-                self.__check_publisher_info(expected)
+""".format(
+            self.rurl3, self.rurl2, self.rurl1
+        )
+        self.__check_publisher_info(expected)
 
-                self.pkg("set-property use-system-repo True")
-                expected = """\
+        self.pkg("set-property use-system-repo True")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
@@ -1245,246 +1526,320 @@ test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{rurl3}/\t-
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{durl3}/\thttp://localhost:{port}
 test4\ttrue\ttrue\ttrue\t\t\t\t
-""".format(rurl1=self.rurl1, durl1=self.durl1, rurl2=self.rurl2,
-    durl2=self.durl2, rurl3=self.rurl3, durl3=self.durl3,
-    port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1,
+            durl1=self.durl1,
+            rurl2=self.rurl2,
+            durl2=self.durl2,
+            rurl3=self.rurl3,
+            durl3=self.durl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                self.__set_responses("test1")
-                expected = """\
+        self.__set_responses("test1")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test3\ttrue\tfalse\ttrue\torigin\tonline\t{rurl3}/\t-
 test12\ttrue\tfalse\ttrue\torigin\tonline\t{rurl2}/\t-
-""".format(rurl1=self.rurl1, durl1=self.durl1, rurl3=self.rurl3,
-    rurl2=self.rurl2, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1,
+            durl1=self.durl1,
+            rurl3=self.rurl3,
+            rurl2=self.rurl2,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                self.pkg("set-publisher --search-before test3 test12")
-                expected = """\
+        self.pkg("set-publisher --search-before test3 test12")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test12\ttrue\tfalse\ttrue\torigin\tonline\t{rurl2}/\t-
 test3\ttrue\tfalse\ttrue\torigin\tonline\t{rurl3}/\t-
-""".format(rurl1=self.rurl1, durl1=self.durl1, rurl2=self.rurl2,
-    rurl3=self.rurl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1,
+            durl1=self.durl1,
+            rurl2=self.rurl2,
+            rurl3=self.rurl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                self.pkg("set-publisher --search-after test3 test12")
-                expected = """\
+        self.pkg("set-publisher --search-after test3 test12")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test3\ttrue\tfalse\ttrue\torigin\tonline\t{rurl3}/\t-
 test12\ttrue\tfalse\ttrue\torigin\tonline\t{rurl2}/\t-
-""".format(rurl1=self.rurl1, durl1=self.durl1, rurl3=self.rurl3,
-    rurl2=self.rurl2, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1,
+            durl1=self.durl1,
+            rurl3=self.rurl3,
+            rurl2=self.rurl2,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                self.pkg("set-publisher --search-before test1 test12", exit=1)
-                self.pkg("set-publisher -d --search-before test1 test12",
-                    exit=1)
-                # Ensure that test12 is not disabled.
-                expected = """\
+        self.pkg("set-publisher --search-before test1 test12", exit=1)
+        self.pkg("set-publisher -d --search-before test1 test12", exit=1)
+        # Ensure that test12 is not disabled.
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test3\ttrue\tfalse\ttrue\torigin\tonline\t{rurl3}/\t-
 test12\ttrue\tfalse\ttrue\torigin\tonline\t{rurl2}/\t-
-""".format(rurl1=self.rurl1, durl1=self.durl1, rurl3=self.rurl3,
-    rurl2=self.rurl2, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
-                self.pkg("set-publisher --search-after test1 test12", exit=1)
-                self.pkg("set-publisher --non-sticky --search-after test1 "
-                    "test12", exit=1)
-                # Ensure that test12 is still sticky.
-                expected = """\
+""".format(
+            rurl1=self.rurl1,
+            durl1=self.durl1,
+            rurl3=self.rurl3,
+            rurl2=self.rurl2,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
+        self.pkg("set-publisher --search-after test1 test12", exit=1)
+        self.pkg(
+            "set-publisher --non-sticky --search-after test1 " "test12", exit=1
+        )
+        # Ensure that test12 is still sticky.
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test3\ttrue\tfalse\ttrue\torigin\tonline\t{rurl3}/\t-
 test12\ttrue\tfalse\ttrue\torigin\tonline\t{rurl2}/\t-
-""".format(rurl1=self.rurl1, durl1=self.durl1, rurl3=self.rurl3,
-    rurl2=self.rurl2, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1,
+            durl1=self.durl1,
+            rurl3=self.rurl3,
+            rurl2=self.rurl2,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                # Check that attempting to change test12 relative to test1
-                # fails.
-                self.pkg("set-publisher --search-before test12 test1", exit=1)
-                self.pkg("set-publisher --search-after test12 test1", exit=1)
-                self.pkg("set-publisher --search-first test12")
-                expected = """\
+        # Check that attempting to change test12 relative to test1
+        # fails.
+        self.pkg("set-publisher --search-before test12 test1", exit=1)
+        self.pkg("set-publisher --search-after test12 test1", exit=1)
+        self.pkg("set-publisher --search-first test12")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{rurl1}/\t-
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test12\ttrue\tfalse\ttrue\torigin\tonline\t{rurl2}/\t-
 test3\ttrue\tfalse\ttrue\torigin\tonline\t{rurl3}/\t-
-""".format(rurl1=self.rurl1, durl1=self.durl1, rurl2=self.rurl2,
-    rurl3=self.rurl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1,
+            durl1=self.durl1,
+            rurl2=self.rurl2,
+            rurl3=self.rurl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                self.pkg("set-property use-system-repo False")
-                expected = """\
+        self.pkg("set-property use-system-repo False")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test12\ttrue\tfalse\ttrue\torigin\tonline\t{0}/\t-
 test3\ttrue\tfalse\ttrue\torigin\tonline\t{1}/\t-
 test1\ttrue\tfalse\ttrue\torigin\tonline\t{2}/\t-
-""".format(self.rurl2, self.rurl3, self.rurl1)
-                self.__check_publisher_info(expected)
+""".format(
+            self.rurl2, self.rurl3, self.rurl1
+        )
+        self.__check_publisher_info(expected)
 
-        def test_07_environment_variable(self):
-                """Test that setting the environment variable PKG_SYSREPO_URL
-                sets the url that pkg uses to communicate with the system
-                repository."""
+    def test_07_environment_variable(self):
+        """Test that setting the environment variable PKG_SYSREPO_URL
+        sets the url that pkg uses to communicate with the system
+        repository."""
 
-                self.__prep_configuration(["all-access"],
-                    port=self.sysrepo_alt_port)
-                self.__set_responses("all-access")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["all-access"],
-                    self.sysrepo_alt_port, self.common_config_dir,
-                    testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                old_psu = os.environ.get("PKG_SYSREPO_URL", None)
-                os.environ["PKG_SYSREPO_URL"] = "localhost:{0}".format(
-                    self.sysrepo_alt_port)
-                api_obj = self.image_create(props={"use-system-repo": True})
-                expected =  self.expected_all_access.format(
-                    durl1=self.durl1, durl2=self.durl2,
-                    durl3=self.durl3, port=self.sysrepo_alt_port)
-                self.__check_publisher_info(expected, set_debug_value=False)
-                if old_psu:
-                        os.environ["PKG_SYSREPO_URL"] = old_psu
-                else:
-                        del os.environ["PKG_SYSREPO_URL"]
+        self.__prep_configuration(["all-access"], port=self.sysrepo_alt_port)
+        self.__set_responses("all-access")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["all-access"],
+            self.sysrepo_alt_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        old_psu = os.environ.get("PKG_SYSREPO_URL", None)
+        os.environ["PKG_SYSREPO_URL"] = "localhost:{0}".format(
+            self.sysrepo_alt_port
+        )
+        api_obj = self.image_create(props={"use-system-repo": True})
+        expected = self.expected_all_access.format(
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+            port=self.sysrepo_alt_port,
+        )
+        self.__check_publisher_info(expected, set_debug_value=False)
+        if old_psu:
+            os.environ["PKG_SYSREPO_URL"] = old_psu
+        else:
+            del os.environ["PKG_SYSREPO_URL"]
 
-        def test_08_file_repos(self):
-                """Test that proxied file repos work correctly."""
+    def test_08_file_repos(self):
+        """Test that proxied file repos work correctly."""
 
-                for i in self.dcs:
-                        self.dcs[i].kill(now=True)
-                self.__prep_configuration(["all-access-f", "none"])
-                self.__set_responses("all-access-f")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["all-access-f"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
+        for i in self.dcs:
+            self.dcs[i].kill(now=True)
+        self.__prep_configuration(["all-access-f", "none"])
+        self.__set_responses("all-access-f")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["all-access-f"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
 
-                # Find the hashes that will be included in the urls of the
-                # proxied file repos.
-                # Unicode-objects must be encoded before hashing.
-                hash1 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[1].get_repodir().rstrip("/"))).hexdigest()
-                hash2 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[2].get_repodir().rstrip("/"))).hexdigest()
-                hash3 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[3].get_repodir().rstrip("/"))).hexdigest()
+        # Find the hashes that will be included in the urls of the
+        # proxied file repos.
+        # Unicode-objects must be encoded before hashing.
+        hash1 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[1].get_repodir().rstrip("/"))
+        ).hexdigest()
+        hash2 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[2].get_repodir().rstrip("/"))
+        ).hexdigest()
+        hash3 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[3].get_repodir().rstrip("/"))
+        ).hexdigest()
 
-                expected = """\
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test1/{hash1}/\t-
 test12\tfalse\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test12/{hash2}/\t-
 test3\ttrue\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test3/{hash3}/\t-
-""".format(port=self.sysrepo_port, hash1=hash1, hash2=hash2,
-    hash3=hash3)
+""".format(
+            port=self.sysrepo_port, hash1=hash1, hash2=hash2, hash3=hash3
+        )
 
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-                # Check connectivity with the proxied repos.
-                self.pkg("install example_pkg")
-                self.pkg("contents -rm foo")
-                self.pkg("contents -rm bar")
+        # Check connectivity with the proxied repos.
+        self.pkg("install example_pkg")
+        self.pkg("contents -rm foo")
+        self.pkg("contents -rm bar")
 
-                # Check that proxied file repos that disappear vanish correctly,
-                # and that those with installed packages remain as disabled
-                # publishers.
-                self.__set_responses("none")
-                expected = """\
+        # Check that proxied file repos that disappear vanish correctly,
+        # and that those with installed packages remain as disabled
+        # publishers.
+        self.__set_responses("none")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\tfalse\t\t\t\t
 """
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-                # Check that when the user adds an origin to a former system
-                # publisher with an installed package, the publisher becomes
-                # enabled and is not a system publisher.
-                self.pkg("set-publisher -g {0} test1".format(self.rurl1))
-                expected = """\
+        # Check that when the user adds an origin to a former system
+        # publisher with an installed package, the publisher becomes
+        # enabled and is not a system publisher.
+        self.pkg("set-publisher -g {0} test1".format(self.rurl1))
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\tfalse\ttrue\torigin\tonline\t{rurl1}/\t-
-""".format(rurl1=self.rurl1)
-                self.__check_publisher_info(expected)
+""".format(
+            rurl1=self.rurl1
+        )
+        self.__check_publisher_info(expected)
 
-        def test_09_test_file_http_transitions(self):
-                """Test that changing publishers from http to file repos and
-                back in the sysrepo works as expected."""
+    def test_09_test_file_http_transitions(self):
+        """Test that changing publishers from http to file repos and
+        back in the sysrepo works as expected."""
 
-                self.__prep_configuration(["all-access", "all-access-f",
-                    "none"])
-                self.__set_responses("all-access-f")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["all-access-f"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
+        self.__prep_configuration(["all-access", "all-access-f", "none"])
+        self.__set_responses("all-access-f")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["all-access-f"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
 
-                # Find the hashes that will be included in the urls of the
-                # proxied file repos.
-                # Unicode-objects must be encoded before hashing.
-                hash1 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[1].get_repodir().rstrip("/"))).hexdigest()
-                hash2 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[2].get_repodir().rstrip("/"))).hexdigest()
-                hash3 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[3].get_repodir().rstrip("/"))).hexdigest()
+        # Find the hashes that will be included in the urls of the
+        # proxied file repos.
+        # Unicode-objects must be encoded before hashing.
+        hash1 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[1].get_repodir().rstrip("/"))
+        ).hexdigest()
+        hash2 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[2].get_repodir().rstrip("/"))
+        ).hexdigest()
+        hash3 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[3].get_repodir().rstrip("/"))
+        ).hexdigest()
 
-                self.__set_responses("all-access-f")
-                expected = """\
+        self.__set_responses("all-access-f")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test1/{hash1}/\t-
 test12\tfalse\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test12/{hash2}/\t-
 test3\ttrue\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test3/{hash3}/\t-
-""".format(port=self.sysrepo_port, hash1=hash1, hash2=hash2,
-    hash3=hash3)
+""".format(
+            port=self.sysrepo_port, hash1=hash1, hash2=hash2, hash3=hash3
+        )
 
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-                self.__set_responses("all-access")
-                expected =  self.expected_all_access.format(
-                    durl1=self.durl1, durl2=self.durl2,
-                    durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+        self.__set_responses("all-access")
+        expected = self.expected_all_access.format(
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-        def test_10_test_mirrors(self):
-                """Test that mirror information from the sysrepo is handled
-                correctly."""
+    def test_10_test_mirrors(self):
+        """Test that mirror information from the sysrepo is handled
+        correctly."""
 
-                self.__prep_configuration(["all-access", "all-access-f",
-                    "mirror-access", "mirror-access-f", "none"])
-                self.__set_responses("mirror-access")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["mirror-access"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
+        self.__prep_configuration(
+            [
+                "all-access",
+                "all-access-f",
+                "mirror-access",
+                "mirror-access-f",
+                "none",
+            ]
+        )
+        self.__set_responses("mirror-access")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["mirror-access"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
 
-                # Find the hashes that will be included in the urls of the
-                # proxied file repos.
-                hash1 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[1].get_repodir().rstrip("/"))).hexdigest()
-                hash2 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[2].get_repodir().rstrip("/"))).hexdigest()
-                hash3 = digest.DEFAULT_HASH_FUNC(misc.force_bytes("file://" +
-                    self.dcs[3].get_repodir().rstrip("/"))).hexdigest()
+        # Find the hashes that will be included in the urls of the
+        # proxied file repos.
+        hash1 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[1].get_repodir().rstrip("/"))
+        ).hexdigest()
+        hash2 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[2].get_repodir().rstrip("/"))
+        ).hexdigest()
+        hash3 = digest.DEFAULT_HASH_FUNC(
+            misc.force_bytes("file://" + self.dcs[3].get_repodir().rstrip("/"))
+        ).hexdigest()
 
-                expected = """\
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test1\ttrue\ttrue\ttrue\tmirror\tonline\thttp://localhost:{port}/test1/{hash1}/\t-
@@ -1492,14 +1847,20 @@ test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
 test12\tfalse\ttrue\ttrue\tmirror\tonline\thttp://localhost:{port}/test12/{hash2}/\t-
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{durl3}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\tmirror\tonline\thttp://localhost:{port}/test3/{hash3}/\t-
-""".format(port=self.sysrepo_port, hash1=hash1, hash2=hash2,
-    hash3=hash3, durl1=self.durl1, durl2=self.durl2,
-    durl3=self.durl3)
+""".format(
+            port=self.sysrepo_port,
+            hash1=hash1,
+            hash2=hash2,
+            hash3=hash3,
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+        )
 
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-                self.__set_responses("mirror-access-f")
-                expected = """\
+        self.__set_responses("mirror-access-f")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test1/{hash1}/\t-
 test1\ttrue\ttrue\ttrue\tmirror\tonline\t{durl1}/\thttp://localhost:{port}
@@ -1507,20 +1868,26 @@ test12\tfalse\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test12/{hash2
 test12\tfalse\ttrue\ttrue\tmirror\tonline\t{durl2}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test3/{hash3}/\t-
 test3\ttrue\ttrue\ttrue\tmirror\tonline\t{durl3}/\thttp://localhost:{port}
-""".format(port=self.sysrepo_port, hash1=hash1, hash2=hash2,
-    hash3=hash3, durl1=self.durl1, durl2=self.durl2,
-    durl3=self.durl3)
+""".format(
+            port=self.sysrepo_port,
+            hash1=hash1,
+            hash2=hash2,
+            hash3=hash3,
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+        )
 
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-                self.__set_responses("none")
-                expected = """\
+        self.__set_responses("none")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 """
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-                self.__set_responses("mirror-access-f")
-                expected = """\
+        self.__set_responses("mirror-access-f")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test1/{hash1}/\t-
 test1\ttrue\ttrue\ttrue\tmirror\tonline\t{durl1}/\thttp://localhost:{port}
@@ -1528,20 +1895,29 @@ test12\tfalse\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test12/{hash2
 test12\tfalse\ttrue\ttrue\tmirror\tonline\t{durl2}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\torigin\tonline\thttp://localhost:{port}/test3/{hash3}/\t-
 test3\ttrue\ttrue\ttrue\tmirror\tonline\t{durl3}/\thttp://localhost:{port}
-""".format(port=self.sysrepo_port, hash1=hash1, hash2=hash2,
-    hash3=hash3, durl1=self.durl1, durl2=self.durl2,
-    durl3=self.durl3)
+""".format(
+            port=self.sysrepo_port,
+            hash1=hash1,
+            hash2=hash2,
+            hash3=hash3,
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+        )
 
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-                self.__set_responses("all-access")
-                expected =  self.expected_all_access.format(
-                    durl1=self.durl1, durl2=self.durl2,
-                    durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+        self.__set_responses("all-access")
+        expected = self.expected_all_access.format(
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
 
-                self.__set_responses("mirror-access")
-                expected = """\
+        self.__set_responses("mirror-access")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{durl1}/\thttp://localhost:{port}
 test1\ttrue\ttrue\ttrue\tmirror\tonline\thttp://localhost:{port}/test1/{hash1}/\t-
@@ -1549,791 +1925,876 @@ test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
 test12\tfalse\ttrue\ttrue\tmirror\tonline\thttp://localhost:{port}/test12/{hash2}/\t-
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{durl3}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\tmirror\tonline\thttp://localhost:{port}/test3/{hash3}/\t-
-""".format(port=self.sysrepo_port, hash1=hash1, hash2=hash2,
-    hash3=hash3, durl1=self.durl1, durl2=self.durl2,
-    durl3=self.durl3)
+""".format(
+            port=self.sysrepo_port,
+            hash1=hash1,
+            hash2=hash2,
+            hash3=hash3,
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+        )
 
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-        def test_11_https_repos(self, use_config_cache=False):
-                """Test that https repos are proxied correctly."""
-                self.base_11_https_repos()
+    def test_11_https_repos(self, use_config_cache=False):
+        """Test that https repos are proxied correctly."""
+        self.base_11_https_repos()
 
-        def test_11a_https_repos(self):
-                """Ensure https configurations are created properly when
-                using a cached configuration."""
-                self.base_11_https_repos(use_config_cache=True)
+    def test_11a_https_repos(self):
+        """Ensure https configurations are created properly when
+        using a cached configuration."""
+        self.base_11_https_repos(use_config_cache=True)
 
-        def base_11_https_repos(self, use_config_cache=False):
-                """Implementation of test_11_https_repos, parameterizing
-                use_config_cache."""
+    def base_11_https_repos(self, use_config_cache=False):
+        """Implementation of test_11_https_repos, parameterizing
+        use_config_cache."""
 
-                self.__prep_configuration(["https-access", "none"],
-                    use_config_cache=use_config_cache)
-                self.__set_responses("https-access")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["https-access"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
+        self.__prep_configuration(
+            ["https-access", "none"], use_config_cache=use_config_cache
+        )
+        self.__set_responses("https-access")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["https-access"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
 
-                expected = """\
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test1\ttrue\ttrue\ttrue\torigin\tonline\t{ac1url}/\thttp://localhost:{port}
 test12\tfalse\ttrue\ttrue\torigin\tonline\t{ac2url}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{ac3url}/\thttp://localhost:{port}
 """.format(
-    ac1url=self.acs[self.durl1].url.replace("https", "http"),
-    ac2url=self.acs[self.durl2].url.replace("https", "http"),
-    ac3url=self.acs[self.durl3].url.replace("https", "http"),
-    port=self.sysrepo_port)
+            ac1url=self.acs[self.durl1].url.replace("https", "http"),
+            ac2url=self.acs[self.durl2].url.replace("https", "http"),
+            ac3url=self.acs[self.durl3].url.replace("https", "http"),
+            port=self.sysrepo_port,
+        )
 
-                self.__check_publisher_info(expected)
+        self.__check_publisher_info(expected)
 
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg", "foo", "bar"])
-                api_obj = self.get_img_api_obj()
-                self._api_uninstall(api_obj, ["example_pkg", "foo", "bar"])
-                self.__set_responses("none")
-                expected = """\
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg", "foo", "bar"])
+        api_obj = self.get_img_api_obj()
+        self._api_uninstall(api_obj, ["example_pkg", "foo", "bar"])
+        self.__set_responses("none")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 """
-                self.__check_publisher_info(expected)
-                self.pkg("contents -rm example_pkg", exit=1)
+        self.__check_publisher_info(expected)
+        self.pkg("contents -rm example_pkg", exit=1)
 
-        def test_12_disabled_repos(self):
-                """Test that repos which are disabled in the global zone do not
-                create problems."""
-                self.base_12_disabled_repos()
+    def test_12_disabled_repos(self):
+        """Test that repos which are disabled in the global zone do not
+        create problems."""
+        self.base_12_disabled_repos()
 
-        def test_12a_disabled_repos(self):
-                """Ensure disable configurations are created properly when
-                using a cached configuration."""
-                self.base_12_disabled_repos(use_config_cache=True)
+    def test_12a_disabled_repos(self):
+        """Ensure disable configurations are created properly when
+        using a cached configuration."""
+        self.base_12_disabled_repos(use_config_cache=True)
 
-        def base_12_disabled_repos(self, use_config_cache=False):
-                """Implementation of test_12_disabled_repos, parameterizing
-                use_config_cache."""
+    def base_12_disabled_repos(self, use_config_cache=False):
+        """Implementation of test_12_disabled_repos, parameterizing
+        use_config_cache."""
 
-                self.__prep_configuration(["disabled"],
-                    use_config_cache=use_config_cache)
-                self.__set_responses("disabled")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["disabled"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-                expected = """\
+        self.__prep_configuration(
+            ["disabled"], use_config_cache=use_config_cache
+        )
+        self.__set_responses("disabled")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["disabled"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test12\tfalse\ttrue\ttrue\torigin\tonline\t{durl2}/\thttp://localhost:{port}
 test3\ttrue\ttrue\ttrue\torigin\tonline\t{durl3}/\thttp://localhost:{port}
-""".format(durl2=self.durl2, durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
+""".format(
+            durl2=self.durl2, durl3=self.durl3, port=self.sysrepo_port
+        )
+        self.__check_publisher_info(expected)
 
-        def test_13_no_url(self):
-                """Test that publishers with no urls are allowed as syspubs
-                and that we can add/remove origins."""
-                self.base_13_no_url()
+    def test_13_no_url(self):
+        """Test that publishers with no urls are allowed as syspubs
+        and that we can add/remove origins."""
+        self.base_13_no_url()
 
-        def test_13a_no_url(self):
-                """Test that publishers which use no url are allowed as syspubs
-                when using cached configurations."""
-                self.base_13_no_url(use_config_cache=True)
+    def test_13a_no_url(self):
+        """Test that publishers which use no url are allowed as syspubs
+        when using cached configurations."""
+        self.base_13_no_url(use_config_cache=True)
 
-        def base_13_no_url(self, use_config_cache=False):
-                """Implementation of test_13[a]_no_url, parameterizing
-                use_config_cache."""
+    def base_13_no_url(self, use_config_cache=False):
+        """Implementation of test_13[a]_no_url, parameterizing
+        use_config_cache."""
 
-                self.__prep_configuration(["nourl"],
-                    use_config_cache=use_config_cache)
-                self.__set_responses("nourl")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["nourl"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-                expected_empty = """\
+        self.__prep_configuration(["nourl"], use_config_cache=use_config_cache)
+        self.__set_responses("nourl")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["nourl"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+        expected_empty = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test4\ttrue\ttrue\ttrue\t\t\t\t
 """
-                self.pkg("publisher -F tsv")
-                self.__check_publisher_info(expected_empty)
-                self.pkg("unset-publisher test4", exit=1)
-                self.pkg("set-publisher -g {0} test4".format(self.durl4))
+        self.pkg("publisher -F tsv")
+        self.__check_publisher_info(expected_empty)
+        self.pkg("unset-publisher test4", exit=1)
+        self.pkg("set-publisher -g {0} test4".format(self.durl4))
 
-                expected = """\
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test4\ttrue\ttrue\ttrue\torigin\tonline\t{0}/\t-
-""".format(self.durl4)
-                self.__check_publisher_info(expected)
-                self.pkg("set-publisher -G {0} test4".format(self.durl4))
-                self.__check_publisher_info(expected_empty)
+""".format(
+            self.durl4
+        )
+        self.__check_publisher_info(expected)
+        self.pkg("set-publisher -G {0} test4".format(self.durl4))
+        self.__check_publisher_info(expected_empty)
 
-                # add another empty publisher
-                self.pkg("set-publisher empty")
-                expected = """\
+        # add another empty publisher
+        self.pkg("set-publisher empty")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test4\ttrue\ttrue\ttrue\t\t\t\t
 empty\ttrue\tfalse\ttrue\t\t\t\t
 """
-                self.__check_publisher_info(expected)
-                # toggle the system publisher and verify that
-                # our configuration made it to the image
-                self.pkg("set-property use-system-repo False")
+        self.__check_publisher_info(expected)
+        # toggle the system publisher and verify that
+        # our configuration made it to the image
+        self.pkg("set-property use-system-repo False")
 
-                expected_nonsyspub = """\
+        expected_nonsyspub = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 test4\ttrue\tfalse\ttrue\t\t\t\t
 empty\ttrue\tfalse\ttrue\t\t\t\t
 """
-                # because we've added and removed local configuration for a
-                # publisher, that makes that publisher hang around in the user
-                # image configuration.
-                # The user needs to unset the publisher to make it go away.
-                self.__check_publisher_info(expected_nonsyspub)
+        # because we've added and removed local configuration for a
+        # publisher, that makes that publisher hang around in the user
+        # image configuration.
+        # The user needs to unset the publisher to make it go away.
+        self.__check_publisher_info(expected_nonsyspub)
 
-                # verify the sysrepo configuration is still there
-                self.pkg("set-property use-system-repo True")
-                self.__check_publisher_info(expected)
+        # verify the sysrepo configuration is still there
+        self.pkg("set-property use-system-repo True")
+        self.__check_publisher_info(expected)
 
-        def test_bug_18326(self):
-                """Test that an unprivileged user can use non-image modifying
-                commands and that image modifying commands don't trace back."""
+    def test_bug_18326(self):
+        """Test that an unprivileged user can use non-image modifying
+        commands and that image modifying commands don't trace back."""
 
-                self.__prep_configuration(["all-access", "none"])
-                self.__set_responses("all-access")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["all-access"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
+        self.__prep_configuration(["all-access", "none"])
+        self.__set_responses("all-access")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["all-access"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
 
-                expected =  self.expected_all_access.format(
-                    durl1=self.durl1, durl2=self.durl2,
-                    durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected, su_wrap=True)
-                self.pkg("property", su_wrap=True)
-                self.pkg("install foo", su_wrap=True, exit=1)
+        expected = self.expected_all_access.format(
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected, su_wrap=True)
+        self.pkg("property", su_wrap=True)
+        self.pkg("install foo", su_wrap=True, exit=1)
 
-                self.__set_responses("none")
-                expected = """\
+        self.__set_responses("none")
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 """
-                self.__check_publisher_info(expected, su_wrap=True)
-                self.__check_publisher_info(expected)
-                self.__set_responses("all-access")
-                expected =  self.expected_all_access.format(
-                    durl1=self.durl1, durl2=self.durl2,
-                    durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected, su_wrap=True)
+        self.__check_publisher_info(expected, su_wrap=True)
+        self.__check_publisher_info(expected)
+        self.__set_responses("all-access")
+        expected = self.expected_all_access.format(
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected, su_wrap=True)
 
-                # Test that when the sysrepo isn't available, unprivileged users
-                # don't lose functionality.
-                sc.stop()
-                # Since the last privileged command was done when no
-                # system-publishers were available, that's what's expected when
-                # the system repository isn't available.
-                expected = """\
+        # Test that when the sysrepo isn't available, unprivileged users
+        # don't lose functionality.
+        sc.stop()
+        # Since the last privileged command was done when no
+        # system-publishers were available, that's what's expected when
+        # the system repository isn't available.
+        expected = """\
 PUBLISHER\tSTICKY\tSYSPUB\tENABLED\tTYPE\tSTATUS\tURI\tPROXY
 """
-                self.__check_publisher_info(expected, su_wrap=True)
-                self.pkg("property", su_wrap=True)
-                self.pkg("install foo", su_wrap=True, exit=1)
-
-                # Now do a privileged command command to change what the state
-                # on disk is.
-                sc.start()
-                expected =  self.expected_all_access.format(
-                    durl1=self.durl1, durl2=self.durl2,
-                    durl3=self.durl3, port=self.sysrepo_port)
-                self.__check_publisher_info(expected)
-                sc.stop()
-
-                self.__check_publisher_info(expected, su_wrap=True)
-                self.pkg("property", su_wrap=True)
-                self.pkg("install foo", su_wrap=True, exit=1)
-
-        def test_signature_policy_1(self):
-                """Test that the image signature policy of ignore is propagated
-                by the system-repository."""
-
-                conf_name = "img-sig-ignore"
-                self.__prep_configuration([conf_name])
-                self.__set_responses(conf_name)
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs[conf_name], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                self.pkg("property -H signature-policy", su_wrap=True)
-                self.assertEqualDiff("signature-policy ignore",
-                    self.output.strip())
-                self.pkg("property -H signature-policy")
-                self.assertEqualDiff("signature-policy ignore",
-                    self.output.strip())
-
-        def test_signature_policy_2(self):
-                """Test that the image signature policy of require is propagated
-                by the system-repository."""
-
-                conf_name = "img-sig-require"
-                self.__prep_configuration([conf_name])
-                self.__set_responses(conf_name)
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs[conf_name], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                self.pkg("property -H signature-policy")
-                self.assertEqualDiff("signature-policy require-signatures",
-                    self.output.strip())
-                self.pkg("property -H signature-policy", su_wrap=True)
-                self.assertEqualDiff("signature-policy require-signatures",
-                    self.output.strip())
-
-        def test_signature_policy_3(self):
-                """Test that the image signature policy of require-names and the
-                corresponding required names are propagated by the
-                system-repository."""
-
-                conf_name = "img-sig-req-names"
-                self.__prep_configuration([conf_name])
-                self.__set_responses(conf_name)
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs[conf_name], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                self.pkg("property -H signature-policy", su_wrap=True)
-                self.assertEqualDiff("signature-policy require-names",
-                    self.output.strip())
-                self.pkg("property -H signature-required-names", su_wrap=True)
-                self.assertEqualDiff("signature-required-names ['cs1_ch1_ta3']",
-                    self.output.strip())
-                self.pkg("property -H signature-policy")
-                self.assertEqualDiff("signature-policy require-names",
-                    self.output.strip())
-                self.pkg("property -H signature-required-names")
-                self.assertEqualDiff("signature-required-names ['cs1_ch1_ta3']",
-                    self.output.strip())
-
-        def test_signature_policy_4(self):
-                """Test that the publisher signature policies of ignore are
-                propagated by the system-repository."""
-
-                conf_name = "pub-sig-ignore"
-                self.__prep_configuration([conf_name])
-                self.__set_responses(conf_name)
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs[conf_name], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                self.pkg("publisher test1", su_wrap=True)
-                self.assertTrue("signature-policy = ignore" in self.output)
-                pubs = api_obj.get_publishers()
-                for p in pubs:
-                        self.assertEqualDiff(
-                            p.prefix + ":" + p.properties["signature-policy"],
-                            p.prefix + ":" + "ignore")
-
-        def test_signature_policy_5(self):
-                """Test that the publisher signature policies of
-                require-signatures are propagated by the system-repository."""
-
-                conf_name = "pub-sig-require"
-                self.__prep_configuration([conf_name])
-                self.__set_responses(conf_name)
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs[conf_name], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                pubs = api_obj.get_publishers()
-                for p in pubs:
-                        self.assertEqualDiff(
-                            p.prefix + ":" + p.properties["signature-policy"],
-                            p.prefix + ":" + "require-signatures")
-
-        def test_signature_policy_6(self):
-                """Test that publishers signature policies of require-names and
-                the corresponding required names are propagated by the
-                system-repository."""
-
-                conf_name = "pub-sig-reqnames"
-                self.__prep_configuration([conf_name])
-                self.__set_responses(conf_name)
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs[conf_name], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                pubs = api_obj.get_publishers()
-                for p in pubs:
-                        self.assertEqualDiff(p.prefix + ":" + "require-names",
-                            p.prefix + ":" + p.properties["signature-policy"])
-                        self.assertEqualDiff(p.prefix + ":" + "cs1_ch1_ta3",
-                            p.prefix + ":" +
-                            " ".join(p.properties["signature-required-names"]))
-
-        def test_signature_policy_7(self):
-                """Test that a mixture of publisher signature policies are
-                correctly propagated."""
-
-                conf_name = "pub-sig-mixed"
-                self.__prep_configuration([conf_name])
-                self.__set_responses(conf_name)
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs[conf_name], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                pubs = api_obj.get_publishers()
-                for p in pubs:
-                        if p.prefix == "test1":
-                                self.assertEqualDiff(
-                                    p.prefix + ":" +
-                                    p.properties["signature-policy"],
-                                    p.prefix + ":" + "require-signatures")
-                        elif p.prefix == "test12":
-                                self.assertTrue("signature-policy" not in
-                                    p.properties)
-                        else:
-                                self.assertEqualDiff(
-                                    p.prefix + ":" +
-                                    p.properties["signature-policy"],
-                                    p.prefix + ":" + "verify")
-
-        def test_signature_policy_8(self):
-                """Test that a mixture of image and publisher signature policies
-                are correctly propagated."""
-
-                conf_name = "img-pub-sig-mixed"
-                self.__prep_configuration([conf_name])
-                self.__set_responses(conf_name)
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs[conf_name], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                self.pkg("property -H signature-policy")
-                self.assertEqualDiff("signature-policy ignore",
-                    self.output.strip())
-
-                pubs = api_obj.get_publishers()
-                for p in pubs:
-                        if p.prefix == "test1":
-                                self.assertEqualDiff(
-                                    p.prefix + ":" +
-                                    p.properties["signature-policy"],
-                                    p.prefix + ":" + "require-signatures")
-                        elif p.prefix == "test12":
-                                self.assertEqualDiff(
-                                    p.prefix + ":" +
-                                    p.properties["signature-policy"],
-                                    p.prefix + ":" + "require-names")
-                                self.assertEqualDiff(
-                                    p.prefix + ":" +
-                                    " ".join(p.properties[
-                                        "signature-required-names"]),
-                                    p.prefix + ":" + "cs1_ch1_ta3 foo bar baz")
-                        else:
-                                self.assertEqualDiff(
-                                    p.prefix + ":" +
-                                    p.properties["signature-policy"],
-                                    p.prefix + ":" + "ignore")
-
-        def test_catalog_is_not_cached_http(self):
-                """Test that the catalog response is not cached when dealing
-                with an http repo."""
-
-                conf_name = "test1-test3"
-                self.__prep_configuration([conf_name])
-                self.__set_responses(conf_name)
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs[conf_name], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-                self.pkgsend_bulk(self.rurl1, self.foo11)
-                self.pkgsend_bulk(self.rurl3, self.bar11)
-                self.pkg("install bar@1.1")
-                self.pkg("install foo@1.1")
-
-        def test_catalog_is_not_cached_file(self):
-                """Test that the catalog response is not cached when dealing
-                with an http repo."""
-
-                conf_name = "test1-test3-f"
-                self.__prep_configuration([conf_name])
-                self.__set_responses(conf_name)
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs[conf_name], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                api_obj = self.image_create(props={"use-system-repo": True})
-                self.pkgsend_bulk(self.rurl1, self.foo11)
-                self.pkgsend_bulk(self.rurl3, self.bar11)
-                self.pkg("install foo@1.1")
-                self.pkg("install bar@1.1")
-
-        def test_no_unnecessary_refresh(self):
-                """Test that the pkg client doesn't rebuild the known image
-                catalog unnecessarily.
-
-                The way we test this is kinda obtuse.  To test this we use a
-                staged image operation.  This allows us to break up pkg
-                execution into three stages, planning, preparation, and
-                execution.  At the end of the planning stage, we create and
-                save an image plan to disk.  This image plan includes the last
-                modified timestamp for the known catalog.  Subsequently when
-                we go to load the plan from disk (during preparation and
-                execution) we check that timestamp to make sure the image
-                hasn't changed since the plan was generated (this ensures that
-                the image plan is still valid). So if the pkg client decides
-                to update the known catalog unnecessarily then we'll fail when
-                we try to reload the plan during preparation
-                (--stage=prepare)."""
-
-                self.__prep_configuration(["test1-test12-test12",
-                    "test12-test12"])
-                self.__set_responses("test1-test12-test12")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["test1-test12-test12"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-
-                # enable the test1 and test12 publishers
-                self.__set_responses("test1-test12-test12")
-
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                # install a package from the test1 and test12 publisher
-                self.pkg("install example_pkg foo@1.0")
-
-                # disable the test1 publisher
-                self.__set_responses("test12-test12")
-
-                # do a staged update
-                self.pkg("update --stage=plan")
-                self.pkg("update --stage=prepare")
-                self.pkg("update --stage=execute")
-
-        def test_automatic_refresh(self):
-                """Test that sysrepo publishers get refreshed automatically
-                when sysrepo configuration changes."""
-
-                self.__prep_configuration(["test1", "test1-test12",
-                    "test1-test12-test12"])
-                self.__set_responses("test1-test12")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["test1-test12"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                # the client should see packages from the test1 and test12 pubs.
-                self.pkg("list -afH")
-                expected = (
-                    "example_pkg 1.0-0 ---\n"
-                    "foo (test12) 1.0-0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # remove the test12 pub.
-                self.__set_responses("test1")
-                self.pkg("list -afH")
-                expected = "example_pkg 1.0-0 ---\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # add the test12 pub.
-                self.__set_responses("test1-test12")
-                self.pkg("list -afH")
-                expected = (
-                    "example_pkg 1.0-0 ---\n"
-                    "foo (test12) 1.0-0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # add an origin (with new packages) to the test12 pub.
-                self.__set_responses("test1-test12-test12")
-                self.pkg("list -afH")
-                expected = (
-                    "example_pkg 1.0-0 ---\n"
-                    "foo (test12) 1.1-0 ---\n"
-                    "foo (test12) 1.0-0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # push a new package into one of the test12 repos.
-                # (we have to do an explicit refresh since "list" won't do it
-                # because last_refreshed is too recent.)
-                self.pkgsend_bulk(self.rurl2, self.bar10)
-                self.pkg("refresh")
-                self.pkg("list -afH")
-                expected = (
-                    "bar (test12) 1.0-0 ---\n"
-                    "example_pkg 1.0-0 ---\n"
-                    "foo (test12) 1.1-0 ---\n"
-                    "foo (test12) 1.0-0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # remove an origin from the test12 pub.
-                self.__set_responses("test1-test12")
-                self.pkg("list -afH")
-                expected = (
-                    "bar (test12) 1.0-0 ---\n"
-                    "example_pkg 1.0-0 ---\n"
-                    "foo (test12) 1.0-0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # install a package from the test12 pub.
-                # then re-do a bunch of the tests above.
-                self.pkg("install foo")
-
-                # remove the test12 pub.
-                self.__set_responses("test1")
-                self.pkg("list -afH")
-                expected = (
-                    "example_pkg 1.0-0 ---\n"
-                    "foo (test12) 1.0-0 i--\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # add the test12 pub.
-                self.__set_responses("test1-test12")
-                self.pkg("list -afH")
-                expected = (
-                    "bar (test12) 1.0-0 ---\n"
-                    "example_pkg 1.0-0 ---\n"
-                    "foo (test12) 1.0-0 i--\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # add an origin (with new packages) to the test12 pub.
-                self.__set_responses("test1-test12-test12")
-                self.pkg("list -afH")
-                expected = (
-                    "bar (test12) 1.0-0 ---\n"
-                    "example_pkg 1.0-0 ---\n"
-                    "foo (test12) 1.1-0 ---\n"
-                    "foo (test12) 1.0-0 i--\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # push a new package into one of the test12 repos.
-                # (we have to do an explicit refresh since "list" won't do it
-                # because last_refreshed is too recent.)
-                self.pkgsend_bulk(self.rurl2, self.bar11)
-                self.pkg("refresh")
-                self.pkg("list -afH")
-                expected = (
-                    "bar (test12) 1.1-0 ---\n"
-                    "bar (test12) 1.0-0 ---\n"
-                    "example_pkg 1.0-0 ---\n"
-                    "foo (test12) 1.1-0 ---\n"
-                    "foo (test12) 1.0-0 i--\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # remove an origin from the test12 pub.
-                self.__set_responses("test1-test12")
-                self.pkg("list -afH")
-                expected = (
-                    "bar (test12) 1.1-0 ---\n"
-                    "bar (test12) 1.0-0 ---\n"
-                    "example_pkg 1.0-0 ---\n"
-                    "foo (test12) 1.0-0 i--\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-        def test_syspub_toggle(self):
-                """Test that sysrepo publishers get refreshed automatically
-                when sysrepo configuration changes."""
-
-                self.__prep_configuration(["test1"])
-                self.__set_responses("test1")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["test1"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-
-                api_obj = self.image_create(props={"use-system-repo": True})
-
-                # the client should see packages from the test1 pubs.
-                self.pkg("list -afH")
-                expected = (
-                    "example_pkg 1.0-0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # push a new package into one of the test12 repos.
-                self.pkgsend_bulk(self.rurl1, self.bar10)
-
-                # verify that the client only sees the new package after an
-                # explicit refresh
-                self.pkg("list -afH")
-                expected = (
-                    "example_pkg 1.0-0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-                self.pkg("refresh")
-                self.pkg("list -afH")
-                expected = (
-                    "bar 1.0-0 ---\n"
-                    "example_pkg 1.0-0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # disable the sysrepo.
-                self.pkg("set-property use-system-repo False")
-
-                # the client should not see any packages.
-                self.pkg("list -afH", exit=1)
-                expected = ("")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # push a new package into one of the test12 repos.
-                self.pkgsend_bulk(self.rurl1, self.bar11)
-
-                # enable the sysrepo.
-                self.pkg("set-property use-system-repo True")
-
-                # the client should see packages from the test1 pubs.
-                self.pkg("list -afH")
-                expected = (
-                    "bar 1.1-0 ---\n"
-                    "bar 1.0-0 ---\n"
-                    "example_pkg 1.0-0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # install a package from the test12 pub.
-                # then re-do a bunch of the tests above.
-                self.pkg("install example_pkg")
-
-                # disable the sysrepo.
-                self.pkg("set-property use-system-repo False")
-
-                # the client should only see the installed package.
-                self.pkg("list -afH")
-                expected = (
-                    "example_pkg 1.0-0 i--\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-                # push a new package into one of the test12 repos.
-                self.pkgsend_bulk(self.rurl1, self.foo10)
-
-                # enable the sysrepo.
-                self.pkg("set-property use-system-repo True")
-
-                # the client should see packages from the test1 pubs.
-                self.pkg("list -afH")
-                expected = (
-                    "bar 1.1-0 ---\n"
-                    "bar 1.0-0 ---\n"
-                    "example_pkg 1.0-0 i--\n"
-                    "foo 1.0-0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
-
-        def test_disabled_origins(self):
-                """Test that publishers with disabled origins are handled "
-                correctly."""
-                self.__prep_configuration(["disabled_1_origin"])
-                self.__set_responses("disabled_1_origin")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["disabled_1_origin"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                # Test disabled origin is not shown in system repo.
-                api_obj = self.image_create(props={"use-system-repo": True})
-                self.pkg("publisher -F tsv")
-                self.assertTrue("localhost:12004" not in self.output)
-                self.assertTrue("localhost:12007" in self.output)
-
-                # Use cache configuration this time.
-                self.__prep_configuration(["disabled_1_origin"],
-                    use_config_cache=True)
-                self.__set_responses("disabled_1_origin")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["disabled_1_origin"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                # Test disabled origin is not shown in system repo.
-                api_obj = self.image_create(props={"use-system-repo": True})
-                self.pkg("publisher -F tsv")
-                self.assertTrue("localhost:12004" not in self.output)
-                self.assertTrue("localhost:12007" in self.output)
-
-                self.__prep_configuration(["disabled_2_origins"])
-                self.__set_responses("disabled_2_origins")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["disabled_2_origins"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                # Test publisher with all origins disabled is shown in the
-                # system repo as if no origin is set.
-                api_obj = self.image_create(props={"use-system-repo": True})
-                self.pkg("publisher -F tsv")
-                self.assertTrue("localhost:12004" not in self.output)
-                self.assertTrue("localhost:12007" not in self.output)
-
-                # Use cache configuration this time.
-                self.__prep_configuration(["disabled_2_origins"],
-                    use_config_cache=True)
-                self.__set_responses("disabled_2_origins")
-                sc = pkg5unittest.SysrepoController(
-                    self.apache_confs["disabled_2_origins"], self.sysrepo_port,
-                    self.common_config_dir, testcase=self)
-                self.register_apache_controller("sysrepo", sc)
-                sc.start()
-                # Test publisher with all origins disabled is shown in the
-                # system repo as if no origin is set.
-                api_obj = self.image_create(props={"use-system-repo": True})
-                self.pkg("publisher -F tsv")
-                self.assertTrue("localhost:12004" not in self.output)
-                self.assertTrue("localhost:12007" not in self.output)
-
-
-        __smf_cmds_template = { \
-            "usr/bin/svcprop" : """\
+        self.__check_publisher_info(expected, su_wrap=True)
+        self.pkg("property", su_wrap=True)
+        self.pkg("install foo", su_wrap=True, exit=1)
+
+        # Now do a privileged command command to change what the state
+        # on disk is.
+        sc.start()
+        expected = self.expected_all_access.format(
+            durl1=self.durl1,
+            durl2=self.durl2,
+            durl3=self.durl3,
+            port=self.sysrepo_port,
+        )
+        self.__check_publisher_info(expected)
+        sc.stop()
+
+        self.__check_publisher_info(expected, su_wrap=True)
+        self.pkg("property", su_wrap=True)
+        self.pkg("install foo", su_wrap=True, exit=1)
+
+    def test_signature_policy_1(self):
+        """Test that the image signature policy of ignore is propagated
+        by the system-repository."""
+
+        conf_name = "img-sig-ignore"
+        self.__prep_configuration([conf_name])
+        self.__set_responses(conf_name)
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs[conf_name],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        self.pkg("property -H signature-policy", su_wrap=True)
+        self.assertEqualDiff("signature-policy ignore", self.output.strip())
+        self.pkg("property -H signature-policy")
+        self.assertEqualDiff("signature-policy ignore", self.output.strip())
+
+    def test_signature_policy_2(self):
+        """Test that the image signature policy of require is propagated
+        by the system-repository."""
+
+        conf_name = "img-sig-require"
+        self.__prep_configuration([conf_name])
+        self.__set_responses(conf_name)
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs[conf_name],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        self.pkg("property -H signature-policy")
+        self.assertEqualDiff(
+            "signature-policy require-signatures", self.output.strip()
+        )
+        self.pkg("property -H signature-policy", su_wrap=True)
+        self.assertEqualDiff(
+            "signature-policy require-signatures", self.output.strip()
+        )
+
+    def test_signature_policy_3(self):
+        """Test that the image signature policy of require-names and the
+        corresponding required names are propagated by the
+        system-repository."""
+
+        conf_name = "img-sig-req-names"
+        self.__prep_configuration([conf_name])
+        self.__set_responses(conf_name)
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs[conf_name],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        self.pkg("property -H signature-policy", su_wrap=True)
+        self.assertEqualDiff(
+            "signature-policy require-names", self.output.strip()
+        )
+        self.pkg("property -H signature-required-names", su_wrap=True)
+        self.assertEqualDiff(
+            "signature-required-names ['cs1_ch1_ta3']", self.output.strip()
+        )
+        self.pkg("property -H signature-policy")
+        self.assertEqualDiff(
+            "signature-policy require-names", self.output.strip()
+        )
+        self.pkg("property -H signature-required-names")
+        self.assertEqualDiff(
+            "signature-required-names ['cs1_ch1_ta3']", self.output.strip()
+        )
+
+    def test_signature_policy_4(self):
+        """Test that the publisher signature policies of ignore are
+        propagated by the system-repository."""
+
+        conf_name = "pub-sig-ignore"
+        self.__prep_configuration([conf_name])
+        self.__set_responses(conf_name)
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs[conf_name],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        self.pkg("publisher test1", su_wrap=True)
+        self.assertTrue("signature-policy = ignore" in self.output)
+        pubs = api_obj.get_publishers()
+        for p in pubs:
+            self.assertEqualDiff(
+                p.prefix + ":" + p.properties["signature-policy"],
+                p.prefix + ":" + "ignore",
+            )
+
+    def test_signature_policy_5(self):
+        """Test that the publisher signature policies of
+        require-signatures are propagated by the system-repository."""
+
+        conf_name = "pub-sig-require"
+        self.__prep_configuration([conf_name])
+        self.__set_responses(conf_name)
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs[conf_name],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        pubs = api_obj.get_publishers()
+        for p in pubs:
+            self.assertEqualDiff(
+                p.prefix + ":" + p.properties["signature-policy"],
+                p.prefix + ":" + "require-signatures",
+            )
+
+    def test_signature_policy_6(self):
+        """Test that publishers signature policies of require-names and
+        the corresponding required names are propagated by the
+        system-repository."""
+
+        conf_name = "pub-sig-reqnames"
+        self.__prep_configuration([conf_name])
+        self.__set_responses(conf_name)
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs[conf_name],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        pubs = api_obj.get_publishers()
+        for p in pubs:
+            self.assertEqualDiff(
+                p.prefix + ":" + "require-names",
+                p.prefix + ":" + p.properties["signature-policy"],
+            )
+            self.assertEqualDiff(
+                p.prefix + ":" + "cs1_ch1_ta3",
+                p.prefix
+                + ":"
+                + " ".join(p.properties["signature-required-names"]),
+            )
+
+    def test_signature_policy_7(self):
+        """Test that a mixture of publisher signature policies are
+        correctly propagated."""
+
+        conf_name = "pub-sig-mixed"
+        self.__prep_configuration([conf_name])
+        self.__set_responses(conf_name)
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs[conf_name],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        pubs = api_obj.get_publishers()
+        for p in pubs:
+            if p.prefix == "test1":
+                self.assertEqualDiff(
+                    p.prefix + ":" + p.properties["signature-policy"],
+                    p.prefix + ":" + "require-signatures",
+                )
+            elif p.prefix == "test12":
+                self.assertTrue("signature-policy" not in p.properties)
+            else:
+                self.assertEqualDiff(
+                    p.prefix + ":" + p.properties["signature-policy"],
+                    p.prefix + ":" + "verify",
+                )
+
+    def test_signature_policy_8(self):
+        """Test that a mixture of image and publisher signature policies
+        are correctly propagated."""
+
+        conf_name = "img-pub-sig-mixed"
+        self.__prep_configuration([conf_name])
+        self.__set_responses(conf_name)
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs[conf_name],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        self.pkg("property -H signature-policy")
+        self.assertEqualDiff("signature-policy ignore", self.output.strip())
+
+        pubs = api_obj.get_publishers()
+        for p in pubs:
+            if p.prefix == "test1":
+                self.assertEqualDiff(
+                    p.prefix + ":" + p.properties["signature-policy"],
+                    p.prefix + ":" + "require-signatures",
+                )
+            elif p.prefix == "test12":
+                self.assertEqualDiff(
+                    p.prefix + ":" + p.properties["signature-policy"],
+                    p.prefix + ":" + "require-names",
+                )
+                self.assertEqualDiff(
+                    p.prefix
+                    + ":"
+                    + " ".join(p.properties["signature-required-names"]),
+                    p.prefix + ":" + "cs1_ch1_ta3 foo bar baz",
+                )
+            else:
+                self.assertEqualDiff(
+                    p.prefix + ":" + p.properties["signature-policy"],
+                    p.prefix + ":" + "ignore",
+                )
+
+    def test_catalog_is_not_cached_http(self):
+        """Test that the catalog response is not cached when dealing
+        with an http repo."""
+
+        conf_name = "test1-test3"
+        self.__prep_configuration([conf_name])
+        self.__set_responses(conf_name)
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs[conf_name],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+        self.pkgsend_bulk(self.rurl1, self.foo11)
+        self.pkgsend_bulk(self.rurl3, self.bar11)
+        self.pkg("install bar@1.1")
+        self.pkg("install foo@1.1")
+
+    def test_catalog_is_not_cached_file(self):
+        """Test that the catalog response is not cached when dealing
+        with an http repo."""
+
+        conf_name = "test1-test3-f"
+        self.__prep_configuration([conf_name])
+        self.__set_responses(conf_name)
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs[conf_name],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        api_obj = self.image_create(props={"use-system-repo": True})
+        self.pkgsend_bulk(self.rurl1, self.foo11)
+        self.pkgsend_bulk(self.rurl3, self.bar11)
+        self.pkg("install foo@1.1")
+        self.pkg("install bar@1.1")
+
+    def test_no_unnecessary_refresh(self):
+        """Test that the pkg client doesn't rebuild the known image
+        catalog unnecessarily.
+
+        The way we test this is kinda obtuse.  To test this we use a
+        staged image operation.  This allows us to break up pkg
+        execution into three stages, planning, preparation, and
+        execution.  At the end of the planning stage, we create and
+        save an image plan to disk.  This image plan includes the last
+        modified timestamp for the known catalog.  Subsequently when
+        we go to load the plan from disk (during preparation and
+        execution) we check that timestamp to make sure the image
+        hasn't changed since the plan was generated (this ensures that
+        the image plan is still valid). So if the pkg client decides
+        to update the known catalog unnecessarily then we'll fail when
+        we try to reload the plan during preparation
+        (--stage=prepare)."""
+
+        self.__prep_configuration(["test1-test12-test12", "test12-test12"])
+        self.__set_responses("test1-test12-test12")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["test1-test12-test12"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+
+        # enable the test1 and test12 publishers
+        self.__set_responses("test1-test12-test12")
+
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        # install a package from the test1 and test12 publisher
+        self.pkg("install example_pkg foo@1.0")
+
+        # disable the test1 publisher
+        self.__set_responses("test12-test12")
+
+        # do a staged update
+        self.pkg("update --stage=plan")
+        self.pkg("update --stage=prepare")
+        self.pkg("update --stage=execute")
+
+    def test_automatic_refresh(self):
+        """Test that sysrepo publishers get refreshed automatically
+        when sysrepo configuration changes."""
+
+        self.__prep_configuration(
+            ["test1", "test1-test12", "test1-test12-test12"]
+        )
+        self.__set_responses("test1-test12")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["test1-test12"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        # the client should see packages from the test1 and test12 pubs.
+        self.pkg("list -afH")
+        expected = "example_pkg 1.0-0 ---\n" "foo (test12) 1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # remove the test12 pub.
+        self.__set_responses("test1")
+        self.pkg("list -afH")
+        expected = "example_pkg 1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # add the test12 pub.
+        self.__set_responses("test1-test12")
+        self.pkg("list -afH")
+        expected = "example_pkg 1.0-0 ---\n" "foo (test12) 1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # add an origin (with new packages) to the test12 pub.
+        self.__set_responses("test1-test12-test12")
+        self.pkg("list -afH")
+        expected = (
+            "example_pkg 1.0-0 ---\n"
+            "foo (test12) 1.1-0 ---\n"
+            "foo (test12) 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # push a new package into one of the test12 repos.
+        # (we have to do an explicit refresh since "list" won't do it
+        # because last_refreshed is too recent.)
+        self.pkgsend_bulk(self.rurl2, self.bar10)
+        self.pkg("refresh")
+        self.pkg("list -afH")
+        expected = (
+            "bar (test12) 1.0-0 ---\n"
+            "example_pkg 1.0-0 ---\n"
+            "foo (test12) 1.1-0 ---\n"
+            "foo (test12) 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # remove an origin from the test12 pub.
+        self.__set_responses("test1-test12")
+        self.pkg("list -afH")
+        expected = (
+            "bar (test12) 1.0-0 ---\n"
+            "example_pkg 1.0-0 ---\n"
+            "foo (test12) 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # install a package from the test12 pub.
+        # then re-do a bunch of the tests above.
+        self.pkg("install foo")
+
+        # remove the test12 pub.
+        self.__set_responses("test1")
+        self.pkg("list -afH")
+        expected = "example_pkg 1.0-0 ---\n" "foo (test12) 1.0-0 i--\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # add the test12 pub.
+        self.__set_responses("test1-test12")
+        self.pkg("list -afH")
+        expected = (
+            "bar (test12) 1.0-0 ---\n"
+            "example_pkg 1.0-0 ---\n"
+            "foo (test12) 1.0-0 i--\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # add an origin (with new packages) to the test12 pub.
+        self.__set_responses("test1-test12-test12")
+        self.pkg("list -afH")
+        expected = (
+            "bar (test12) 1.0-0 ---\n"
+            "example_pkg 1.0-0 ---\n"
+            "foo (test12) 1.1-0 ---\n"
+            "foo (test12) 1.0-0 i--\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # push a new package into one of the test12 repos.
+        # (we have to do an explicit refresh since "list" won't do it
+        # because last_refreshed is too recent.)
+        self.pkgsend_bulk(self.rurl2, self.bar11)
+        self.pkg("refresh")
+        self.pkg("list -afH")
+        expected = (
+            "bar (test12) 1.1-0 ---\n"
+            "bar (test12) 1.0-0 ---\n"
+            "example_pkg 1.0-0 ---\n"
+            "foo (test12) 1.1-0 ---\n"
+            "foo (test12) 1.0-0 i--\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # remove an origin from the test12 pub.
+        self.__set_responses("test1-test12")
+        self.pkg("list -afH")
+        expected = (
+            "bar (test12) 1.1-0 ---\n"
+            "bar (test12) 1.0-0 ---\n"
+            "example_pkg 1.0-0 ---\n"
+            "foo (test12) 1.0-0 i--\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+    def test_syspub_toggle(self):
+        """Test that sysrepo publishers get refreshed automatically
+        when sysrepo configuration changes."""
+
+        self.__prep_configuration(["test1"])
+        self.__set_responses("test1")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["test1"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+
+        api_obj = self.image_create(props={"use-system-repo": True})
+
+        # the client should see packages from the test1 pubs.
+        self.pkg("list -afH")
+        expected = "example_pkg 1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # push a new package into one of the test12 repos.
+        self.pkgsend_bulk(self.rurl1, self.bar10)
+
+        # verify that the client only sees the new package after an
+        # explicit refresh
+        self.pkg("list -afH")
+        expected = "example_pkg 1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+        self.pkg("refresh")
+        self.pkg("list -afH")
+        expected = "bar 1.0-0 ---\n" "example_pkg 1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # disable the sysrepo.
+        self.pkg("set-property use-system-repo False")
+
+        # the client should not see any packages.
+        self.pkg("list -afH", exit=1)
+        expected = ""
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # push a new package into one of the test12 repos.
+        self.pkgsend_bulk(self.rurl1, self.bar11)
+
+        # enable the sysrepo.
+        self.pkg("set-property use-system-repo True")
+
+        # the client should see packages from the test1 pubs.
+        self.pkg("list -afH")
+        expected = "bar 1.1-0 ---\n" "bar 1.0-0 ---\n" "example_pkg 1.0-0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # install a package from the test12 pub.
+        # then re-do a bunch of the tests above.
+        self.pkg("install example_pkg")
+
+        # disable the sysrepo.
+        self.pkg("set-property use-system-repo False")
+
+        # the client should only see the installed package.
+        self.pkg("list -afH")
+        expected = "example_pkg 1.0-0 i--\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+        # push a new package into one of the test12 repos.
+        self.pkgsend_bulk(self.rurl1, self.foo10)
+
+        # enable the sysrepo.
+        self.pkg("set-property use-system-repo True")
+
+        # the client should see packages from the test1 pubs.
+        self.pkg("list -afH")
+        expected = (
+            "bar 1.1-0 ---\n"
+            "bar 1.0-0 ---\n"
+            "example_pkg 1.0-0 i--\n"
+            "foo 1.0-0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
+
+    def test_disabled_origins(self):
+        """Test that publishers with disabled origins are handled "
+        correctly."""
+        self.__prep_configuration(["disabled_1_origin"])
+        self.__set_responses("disabled_1_origin")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["disabled_1_origin"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        # Test disabled origin is not shown in system repo.
+        api_obj = self.image_create(props={"use-system-repo": True})
+        self.pkg("publisher -F tsv")
+        self.assertTrue("localhost:12004" not in self.output)
+        self.assertTrue("localhost:12007" in self.output)
+
+        # Use cache configuration this time.
+        self.__prep_configuration(["disabled_1_origin"], use_config_cache=True)
+        self.__set_responses("disabled_1_origin")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["disabled_1_origin"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        # Test disabled origin is not shown in system repo.
+        api_obj = self.image_create(props={"use-system-repo": True})
+        self.pkg("publisher -F tsv")
+        self.assertTrue("localhost:12004" not in self.output)
+        self.assertTrue("localhost:12007" in self.output)
+
+        self.__prep_configuration(["disabled_2_origins"])
+        self.__set_responses("disabled_2_origins")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["disabled_2_origins"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        # Test publisher with all origins disabled is shown in the
+        # system repo as if no origin is set.
+        api_obj = self.image_create(props={"use-system-repo": True})
+        self.pkg("publisher -F tsv")
+        self.assertTrue("localhost:12004" not in self.output)
+        self.assertTrue("localhost:12007" not in self.output)
+
+        # Use cache configuration this time.
+        self.__prep_configuration(["disabled_2_origins"], use_config_cache=True)
+        self.__set_responses("disabled_2_origins")
+        sc = pkg5unittest.SysrepoController(
+            self.apache_confs["disabled_2_origins"],
+            self.sysrepo_port,
+            self.common_config_dir,
+            testcase=self,
+        )
+        self.register_apache_controller("sysrepo", sc)
+        sc.start()
+        # Test publisher with all origins disabled is shown in the
+        # system repo as if no origin is set.
+        api_obj = self.image_create(props={"use-system-repo": True})
+        self.pkg("publisher -F tsv")
+        self.assertTrue("localhost:12004" not in self.output)
+        self.assertTrue("localhost:12007" not in self.output)
+
+    __smf_cmds_template = {
+        "usr/bin/svcprop": """\
 #!/usr/bin/python
 
 import getopt
@@ -2368,8 +2829,7 @@ if __name__ == "__main__":
                 print("{{0}} {{1}}".format(k, v))
         sys.exit(0)
 """,
-
-            "usr/sbin/svcadm" : """\
+        "usr/sbin/svcadm": """\
 #!/usr/bin/python
 
 import getopt
@@ -2390,9 +2850,10 @@ if __name__ == "__main__":
             pargs[1] != "svc:/application/pkg/system-repository":
                 sys.exit(1)
         sys.exit(0)
-"""}
+""",
+    }
 
-        https_conf = """\
+    https_conf = """\
 # Configuration and logfile names: If the filenames you specify for many
 # of the server's control files begin with "/" (or "drive:/" for Win32), the
 # server will use that explicit path.  If the filenames do *not* begin
@@ -2630,5 +3091,6 @@ SSLRandomSeed connect builtin
 
 """
 
+
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_temp_sources.py
+++ b/src/tests/cli/t_pkg_temp_sources.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import json
@@ -45,13 +46,12 @@ import unittest
 
 
 class TestPkgTempSources(pkg5unittest.ManyDepotTestCase):
+    # Don't discard repository or setUp() every test.
+    persistent_setup = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        # Don't discard repository or setUp() every test.
-        persistent_setup = True
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
-
-        foo_pkg = """
+    foo_pkg = """
             open pkg://test/foo@1.0
             add set name=pkg.summary value="Example package foo."
             add set name=variant.debug.foo value=true value=false
@@ -74,7 +74,7 @@ class TestPkgTempSources(pkg5unittest.ManyDepotTestCase):
             add hardlink path=usr/local/bin/hard-foo target=/usr/bin/foo
             close """
 
-        incorp_pkg = """
+    incorp_pkg = """
             open pkg://test/incorp@1.0
             add set name=pkg.summary value="Incorporation"
             add depend type=incorporate fmri=quux@0.1,5.11-0.1
@@ -84,17 +84,17 @@ class TestPkgTempSources(pkg5unittest.ManyDepotTestCase):
             add depend type=incorporate fmri=quux@1.0,5.11-0.2
             close """
 
-        licensed_pkg = """
+    licensed_pkg = """
             open pkg://test2/licensed@1.0
             add license tmp/LICENSE license=sample_license
             close """
 
-        licensed_pkg_2 = """
+    licensed_pkg_2 = """
             open pkg://test2/licensed@2.0
             add license tmp/LICENSE2 license=sample_license
             close """
 
-        signed_pkg = """
+    signed_pkg = """
             open pkg://test/signed@1.0
             add depend type=require fmri=foo@1.0
             add dir mode=0755 owner=root group=bin path=usr/bin
@@ -102,7 +102,7 @@ class TestPkgTempSources(pkg5unittest.ManyDepotTestCase):
             add set name=authorized.species value=bobcat
             close """
 
-        quux_pkg = """
+    quux_pkg = """
             open pkg://test2/quux@0.1,5.11-0.1
             add set name=pkg.summary value="Example package quux."
             add depend type=require fmri=pkg:/incorp
@@ -115,351 +115,387 @@ class TestPkgTempSources(pkg5unittest.ManyDepotTestCase):
             add file tmp/quux mode=0755 owner=root group=bin path=usr/bin/quux
             close """
 
-        misc_files = ["tmp/foo", "tmp/libfoo.so.1", "tmp/libfoo_debug.so.1",
-            "tmp/foo.1", "tmp/README", "tmp/LICENSE", "tmp/LICENSE2", "tmp/quux"]
+    misc_files = [
+        "tmp/foo",
+        "tmp/libfoo.so.1",
+        "tmp/libfoo_debug.so.1",
+        "tmp/foo.1",
+        "tmp/README",
+        "tmp/LICENSE",
+        "tmp/LICENSE2",
+        "tmp/quux",
+    ]
 
-        def __seed_ta_dir(self, certs, dest_dir=None):
-                if isinstance(certs, six.string_types):
-                        certs = [certs]
-                if not dest_dir:
-                        dest_dir = self.ta_dir
-                self.assertTrue(dest_dir)
-                self.assertTrue(self.raw_trust_anchor_dir)
-                for c in certs:
-                        name = "{0}_cert.pem".format(c)
-                        portable.copyfile(
-                            os.path.join(self.raw_trust_anchor_dir, name),
-                            os.path.join(dest_dir, name))
+    def __seed_ta_dir(self, certs, dest_dir=None):
+        if isinstance(certs, six.string_types):
+            certs = [certs]
+        if not dest_dir:
+            dest_dir = self.ta_dir
+        self.assertTrue(dest_dir)
+        self.assertTrue(self.raw_trust_anchor_dir)
+        for c in certs:
+            name = "{0}_cert.pem".format(c)
+            portable.copyfile(
+                os.path.join(self.raw_trust_anchor_dir, name),
+                os.path.join(dest_dir, name),
+            )
 
-        def __publish_packages(self, rurl):
-                """Private helper function to publish packages needed for
-                testing.
-                """
+    def __publish_packages(self, rurl):
+        """Private helper function to publish packages needed for
+        testing.
+        """
 
-                pkgs = "".join([self.foo_pkg, self.incorp_pkg, self.signed_pkg,
-                    self.quux_pkg])
+        pkgs = "".join(
+            [self.foo_pkg, self.incorp_pkg, self.signed_pkg, self.quux_pkg]
+        )
 
-                # Publish packages needed for tests.
-                plist = self.pkgsend_bulk(rurl, pkgs)
+        # Publish packages needed for tests.
+        plist = self.pkgsend_bulk(rurl, pkgs)
 
-                # Sign the 'signed' package.
-                r = self.get_repo(self.dcs[1].get_repodir())
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} -i {i6} {pkg}".format(
-                      key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      i1=os.path.join(self.chain_certs_dir,
-                          "ch1_ta1_cert.pem"),
-                      i2=os.path.join(self.chain_certs_dir,
-                          "ch2_ta1_cert.pem"),
-                      i3= os.path.join(self.chain_certs_dir,
-                          "ch3_ta1_cert.pem"),
-                      i4=os.path.join(self.chain_certs_dir,
-                          "ch4_ta1_cert.pem"),
-                      i5=os.path.join(self.chain_certs_dir,
-                          "ch5_ta1_cert.pem"),
-                      i6=os.path.join(self.chain_certs_dir,
-                          "ch1_ta3_cert.pem"),
-                      pkg=plist[3]
-                    )
-                self.pkgsign(rurl, sign_args)
+        # Sign the 'signed' package.
+        r = self.get_repo(self.dcs[1].get_repodir())
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} -i {i6} {pkg}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                i1=os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
+                i2=os.path.join(self.chain_certs_dir, "ch2_ta1_cert.pem"),
+                i3=os.path.join(self.chain_certs_dir, "ch3_ta1_cert.pem"),
+                i4=os.path.join(self.chain_certs_dir, "ch4_ta1_cert.pem"),
+                i5=os.path.join(self.chain_certs_dir, "ch5_ta1_cert.pem"),
+                i6=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+                pkg=plist[3],
+            )
+        )
+        self.pkgsign(rurl, sign_args)
 
-                # This is just a test assertion to verify that the
-                # package was signed as expected.
-                self.image_create(rurl, prefix=None)
-                self.__seed_ta_dir("ta1")
-                self.pkg("set-property signature-policy verify")
-                self.pkg("install signed")
-                self.image_destroy()
+        # This is just a test assertion to verify that the
+        # package was signed as expected.
+        self.image_create(rurl, prefix=None)
+        self.__seed_ta_dir("ta1")
+        self.pkg("set-property signature-policy verify")
+        self.pkg("install signed")
+        self.image_destroy()
 
-                return [
-                    fmri.PkgFmri(sfmri)
-                    for sfmri in plist
-                ]
+        return [fmri.PkgFmri(sfmri) for sfmri in plist]
 
-        def __archive_packages(self, arc_name, repo, plist):
-                """Private helper function to archive packages needed for
-                testing.
-                """
+    def __archive_packages(self, arc_name, repo, plist):
+        """Private helper function to archive packages needed for
+        testing.
+        """
 
-                arc_path = os.path.join(self.test_root, arc_name)
-                assert not os.path.exists(arc_path)
+        arc_path = os.path.join(self.test_root, arc_name)
+        assert not os.path.exists(arc_path)
 
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                for pfmri in plist:
-                        arc.add_repo_package(pfmri, repo)
-                arc.close()
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        for pfmri in plist:
+            arc.add_repo_package(pfmri, repo)
+        arc.close()
 
-                return arc_path
+        return arc_path
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test", "test",
-                    "empty", "test2"])
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test", "test", "empty", "test2"]
+        )
+        self.make_misc_files(self.misc_files)
 
-                # First repository will contain all packages.
-                self.all_rurl = self.dcs[1].get_repo_url()
+        # First repository will contain all packages.
+        self.all_rurl = self.dcs[1].get_repo_url()
 
-                # Second repository will contain only foo.
-                self.foo_rurl = self.dcs[2].get_repo_url()
+        # Second repository will contain only foo.
+        self.foo_rurl = self.dcs[2].get_repo_url()
 
-                # Third will be empty.
-                self.empty_rurl = self.dcs[3].get_repo_url()
+        # Third will be empty.
+        self.empty_rurl = self.dcs[3].get_repo_url()
 
-                # Fourth will be for license packages only.
-                self.licensed_rurl = self.dcs[4].get_repo_url()
+        # Fourth will be for license packages only.
+        self.licensed_rurl = self.dcs[4].get_repo_url()
 
-                # Setup base test paths.
-                self.path_to_certs = os.path.join(self.ro_data_root,
-                    "signing_certs", "produced")
-                self.keys_dir = os.path.join(self.path_to_certs, "keys")
-                self.cs_dir = os.path.join(self.path_to_certs,
-                    "code_signing_certs")
-                self.chain_certs_dir = os.path.join(self.path_to_certs,
-                    "chain_certs")
-                self.raw_trust_anchor_dir = os.path.join(self.path_to_certs,
-                    "trust_anchors")
-                self.crl_dir = os.path.join(self.path_to_certs, "crl")
+        # Setup base test paths.
+        self.path_to_certs = os.path.join(
+            self.ro_data_root, "signing_certs", "produced"
+        )
+        self.keys_dir = os.path.join(self.path_to_certs, "keys")
+        self.cs_dir = os.path.join(self.path_to_certs, "code_signing_certs")
+        self.chain_certs_dir = os.path.join(self.path_to_certs, "chain_certs")
+        self.raw_trust_anchor_dir = os.path.join(
+            self.path_to_certs, "trust_anchors"
+        )
+        self.crl_dir = os.path.join(self.path_to_certs, "crl")
 
-                # Publish packages.
-                plist = self.__publish_packages(self.all_rurl)
+        # Publish packages.
+        plist = self.__publish_packages(self.all_rurl)
 
-                # Copy foo to second repository.
-                self.pkgrecv(self.all_rurl, "-d {0} foo".format(self.foo_rurl))
+        # Copy foo to second repository.
+        self.pkgrecv(self.all_rurl, "-d {0} foo".format(self.foo_rurl))
 
-                # Now create a package archive containing all packages, and
-                # then one for each.
-                repo = self.dcs[1].get_repo()
-                self.all_arc = self.__archive_packages("all_pkgs.p5p", repo,
-                    plist)
+        # Now create a package archive containing all packages, and
+        # then one for each.
+        repo = self.dcs[1].get_repo()
+        self.all_arc = self.__archive_packages("all_pkgs.p5p", repo, plist)
 
-                for alist in ([plist[0]], [plist[1], plist[2]], [plist[3]],
-                    [plist[4], plist[5]]):
-                        arc_path = self.__archive_packages(
-                            "{0}.p5p".format(alist[0].pkg_name), repo, alist)
-                        setattr(self, "{0}_arc".format(alist[0].pkg_name), arc_path)
+        for alist in (
+            [plist[0]],
+            [plist[1], plist[2]],
+            [plist[3]],
+            [plist[4], plist[5]],
+        ):
+            arc_path = self.__archive_packages(
+                "{0}.p5p".format(alist[0].pkg_name), repo, alist
+            )
+            setattr(self, "{0}_arc".format(alist[0].pkg_name), arc_path)
 
-                self.ta_dir = None
+        self.ta_dir = None
 
-                # Copy an archive and set its permissions to 0000 for testing
-                # unprivileged user access attempts.
-                self.perm_arc = os.path.join(self.test_root, "noaccess.p5p")
-                portable.copyfile(self.foo_arc, self.perm_arc)
-                os.chmod(self.perm_arc, 0)
+        # Copy an archive and set its permissions to 0000 for testing
+        # unprivileged user access attempts.
+        self.perm_arc = os.path.join(self.test_root, "noaccess.p5p")
+        portable.copyfile(self.foo_arc, self.perm_arc)
+        os.chmod(self.perm_arc, 0)
 
-                # Create an empty archive.
-                arc_path = os.path.join(self.test_root, "empty.p5p")
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                arc.close()
-                self.empty_arc = arc_path
+        # Create an empty archive.
+        arc_path = os.path.join(self.test_root, "empty.p5p")
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        arc.close()
+        self.empty_arc = arc_path
 
-                # Store FMRIs for later use.
-                self.foo10 = plist[0]
-                self.incorp10 = plist[1]
-                self.incorp20 = plist[2]
-                self.signed10 = plist[3]
-                self.quux01 = plist[4]
-                self.quux10 = plist[5]
+        # Store FMRIs for later use.
+        self.foo10 = plist[0]
+        self.incorp10 = plist[1]
+        self.incorp20 = plist[2]
+        self.signed10 = plist[3]
+        self.quux01 = plist[4]
+        self.quux10 = plist[5]
 
-                # Handle license package specially.
-                self.licensed10 = self.pkgsend_bulk(self.licensed_rurl,
-                    self.licensed_pkg)[0]
-                self.licensed20 = self.pkgsend_bulk(self.licensed_rurl,
-                    self.licensed_pkg_2)[0]
+        # Handle license package specially.
+        self.licensed10 = self.pkgsend_bulk(
+            self.licensed_rurl, self.licensed_pkg
+        )[0]
+        self.licensed20 = self.pkgsend_bulk(
+            self.licensed_rurl, self.licensed_pkg_2
+        )[0]
 
-        def test_00_list(self):
-                """Verify that the list operation works as expected for
-                temporary origins.
-                """
+    def test_00_list(self):
+        """Verify that the list operation works as expected for
+        temporary origins.
+        """
 
-                # Create an image and verify no packages are known.
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("list -a", exit=1)
+        # Create an image and verify no packages are known.
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("list -a", exit=1)
 
-                # Verify graceful failure for an empty source alone or in
-                # combination with another temporary source.
-                self.pkg("list -H -g {0}".format(self.empty_arc), exit=1)
-                self.pkg("list -H -g {0} -g {1}".format(self.empty_arc,
-                    self.foo_arc), exit=1)
+        # Verify graceful failure for an empty source alone or in
+        # combination with another temporary source.
+        self.pkg("list -H -g {0}".format(self.empty_arc), exit=1)
+        self.pkg(
+            "list -H -g {0} -g {1}".format(self.empty_arc, self.foo_arc), exit=1
+        )
 
-                # Verify graceful failure if source doesn't exist.
-                self.pkg("list -H -g {0}".format(self.foo_arc + ".nosuchpkg"),
-                    exit=1)
+        # Verify graceful failure if source doesn't exist.
+        self.pkg("list -H -g {0}".format(self.foo_arc + ".nosuchpkg"), exit=1)
 
-                # Verify graceful failure if user doesn't have permission to
-                # access temporary source.
-                self.pkg("list -H -g {0}".format(self.perm_arc), su_wrap=True, exit=1)
+        # Verify graceful failure if user doesn't have permission to
+        # access temporary source.
+        self.pkg("list -H -g {0}".format(self.perm_arc), su_wrap=True, exit=1)
 
-                # Verify graceful list failure if -u is used with -g.
-                self.pkg("list -H -u -g {0}".format(self.foo_arc), exit=2)
+        # Verify graceful list failure if -u is used with -g.
+        self.pkg("list -H -u -g {0}".format(self.foo_arc), exit=2)
 
-                # Verify list output for a single package temporary source.
-                # -a is used here to verify that even though -a is implicit,
-                # it is not an error to specify it.
-                self.pkg("list -aH -g {0}".format(self.foo_arc))
-                expected = "foo (test) 1.0 ---\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify list output for a single package temporary source.
+        # -a is used here to verify that even though -a is implicit,
+        # it is not an error to specify it.
+        self.pkg("list -aH -g {0}".format(self.foo_arc))
+        expected = "foo (test) 1.0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Note that -a is implicit when -g is used, so all of
-                # the following tests purposefully omit it.
+        # Note that -a is implicit when -g is used, so all of
+        # the following tests purposefully omit it.
 
-                # Verify list output for a multiple package temporary source
-                # as an unprivileged user.
-                self.pkg("list -fH -g {0}".format(self.all_arc), su_wrap=True)
-                expected = \
-                    ("foo (test) 1.0 ---\n"
-                    "incorp (test) 2.0 ---\n"
-                    "incorp (test) 1.0 ---\n"
-                    "quux (test2) 1.0-0.2 ---\n"
-                    "quux (test2) 0.1-0.1 ---\n"
-                    "signed (test) 1.0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify list output for a multiple package temporary source
+        # as an unprivileged user.
+        self.pkg("list -fH -g {0}".format(self.all_arc), su_wrap=True)
+        expected = (
+            "foo (test) 1.0 ---\n"
+            "incorp (test) 2.0 ---\n"
+            "incorp (test) 1.0 ---\n"
+            "quux (test2) 1.0-0.2 ---\n"
+            "quux (test2) 0.1-0.1 ---\n"
+            "signed (test) 1.0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify list output for a multiple package temporary source.
-                self.pkg("list -fH -g {0}".format(self.all_arc))
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify list output for a multiple package temporary source.
+        self.pkg("list -fH -g {0}".format(self.all_arc))
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify list output for multiple temporary sources using
-                # different combinations of archives and repositories.
-                self.pkg("list -fH -g {0} -g {1}".format(self.signed_arc,
-                    self.foo_rurl))
-                expected = \
-                    ("foo (test) 1.0 ---\n"
-                    "signed (test) 1.0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify list output for multiple temporary sources using
+        # different combinations of archives and repositories.
+        self.pkg(
+            "list -fH -g {0} -g {1}".format(self.signed_arc, self.foo_rurl)
+        )
+        expected = "foo (test) 1.0 ---\n" "signed (test) 1.0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("list -fH -g {0} -g {1} -g {2} -g {3}".format(self.signed_arc,
-                    self.incorp_arc, self.quux_arc, self.foo_arc))
-                expected = \
-                    ("foo (test) 1.0 ---\n"
-                    "incorp (test) 2.0 ---\n"
-                    "incorp (test) 1.0 ---\n"
-                    "quux (test2) 1.0-0.2 ---\n"
-                    "quux (test2) 0.1-0.1 ---\n"
-                    "signed (test) 1.0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg(
+            "list -fH -g {0} -g {1} -g {2} -g {3}".format(
+                self.signed_arc, self.incorp_arc, self.quux_arc, self.foo_arc
+            )
+        )
+        expected = (
+            "foo (test) 1.0 ---\n"
+            "incorp (test) 2.0 ---\n"
+            "incorp (test) 1.0 ---\n"
+            "quux (test2) 1.0-0.2 ---\n"
+            "quux (test2) 0.1-0.1 ---\n"
+            "signed (test) 1.0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("list -fH -g {0} -g {1} -g {2} -g {3}".format(self.signed_arc,
-                    self.quux_arc, self.incorp_arc, self.foo_rurl))
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg(
+            "list -fH -g {0} -g {1} -g {2} -g {3}".format(
+                self.signed_arc, self.quux_arc, self.incorp_arc, self.foo_rurl
+            )
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                self.pkg("list -fH -g {0} -g {1}".format(self.all_arc,
-                    self.all_rurl))
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        self.pkg("list -fH -g {0} -g {1}".format(self.all_arc, self.all_rurl))
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify list -g without -f.
-                self.pkg("list -H -g {0} -g {1} -g {2} -g {3}".format(self.signed_arc,
-                    self.quux_arc, self.incorp_arc, self.foo_rurl))
-                expected = \
-                    ("foo (test) 1.0 ---\n"
-                    "incorp (test) 2.0 ---\n"
-                    "quux (test2) 1.0-0.2 ---\n"
-                    "signed (test) 1.0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify list -g without -f.
+        self.pkg(
+            "list -H -g {0} -g {1} -g {2} -g {3}".format(
+                self.signed_arc, self.quux_arc, self.incorp_arc, self.foo_rurl
+            )
+        )
+        expected = (
+            "foo (test) 1.0 ---\n"
+            "incorp (test) 2.0 ---\n"
+            "quux (test2) 1.0-0.2 ---\n"
+            "signed (test) 1.0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify package installed from archive shows in default list
-                # output.
-                self.pkg("install -g {0} incorp@1.0".format(self.incorp_arc))
-                self.pkg("list -H")
-                expected = "incorp (test) 1.0 im-\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify package installed from archive shows in default list
+        # output.
+        self.pkg("install -g {0} incorp@1.0".format(self.incorp_arc))
+        self.pkg("list -H")
+        expected = "incorp (test) 1.0 im-\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify list -g with an incorp installed without -f.
-                self.pkg("list -H -g {0} -g {1} -g {2} -g {3}".format(self.signed_arc,
-                    self.quux_arc, self.incorp_arc, self.foo_rurl))
-                expected = \
-                    ("foo (test) 1.0 ---\n"
-                    "incorp (test) 1.0 i--\n"
-                    "quux (test2) 0.1-0.1 ---\n"
-                    "signed (test) 1.0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify list -g with an incorp installed without -f.
+        self.pkg(
+            "list -H -g {0} -g {1} -g {2} -g {3}".format(
+                self.signed_arc, self.quux_arc, self.incorp_arc, self.foo_rurl
+            )
+        )
+        expected = (
+            "foo (test) 1.0 ---\n"
+            "incorp (test) 1.0 i--\n"
+            "quux (test2) 0.1-0.1 ---\n"
+            "signed (test) 1.0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify output again as unprivileged user.
-                self.pkg("list -H -g {0} -g {1} -g {2} -g {3}".format(self.signed_arc,
-                    self.quux_arc, self.incorp_arc, self.foo_rurl),
-                    su_wrap=True)
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify output again as unprivileged user.
+        self.pkg(
+            "list -H -g {0} -g {1} -g {2} -g {3}".format(
+                self.signed_arc, self.quux_arc, self.incorp_arc, self.foo_rurl
+            ),
+            su_wrap=True,
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify list -g with an incorp installed with -f.
-                self.pkg("list -fH -g {0} -g {1} -g {2} -g {3}".format(self.signed_arc,
-                    self.quux_arc, self.incorp_arc, self.foo_rurl))
-                expected = \
-                    ("foo (test) 1.0 ---\n"
-                    "incorp (test) 2.0 ---\n"
-                    "incorp (test) 1.0 i--\n"
-                    "quux (test2) 1.0-0.2 ---\n"
-                    "quux (test2) 0.1-0.1 ---\n"
-                    "signed (test) 1.0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify list -g with an incorp installed with -f.
+        self.pkg(
+            "list -fH -g {0} -g {1} -g {2} -g {3}".format(
+                self.signed_arc, self.quux_arc, self.incorp_arc, self.foo_rurl
+            )
+        )
+        expected = (
+            "foo (test) 1.0 ---\n"
+            "incorp (test) 2.0 ---\n"
+            "incorp (test) 1.0 i--\n"
+            "quux (test2) 1.0-0.2 ---\n"
+            "quux (test2) 0.1-0.1 ---\n"
+            "signed (test) 1.0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify list -g with an incorp installed and -n.
-                self.pkg("list -nH -g {0} -g {1} -g {2} -g {3}".format(self.signed_arc,
-                    self.quux_arc, self.incorp_arc, self.foo_rurl))
-                expected = \
-                    ("foo (test) 1.0 ---\n"
-                    "incorp (test) 2.0 ---\n"
-                    "quux (test2) 1.0-0.2 ---\n"
-                    "signed (test) 1.0 ---\n")
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify list -g with an incorp installed and -n.
+        self.pkg(
+            "list -nH -g {0} -g {1} -g {2} -g {3}".format(
+                self.signed_arc, self.quux_arc, self.incorp_arc, self.foo_rurl
+            )
+        )
+        expected = (
+            "foo (test) 1.0 ---\n"
+            "incorp (test) 2.0 ---\n"
+            "quux (test2) 1.0-0.2 ---\n"
+            "signed (test) 1.0 ---\n"
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Uninstall all packages and verify there are no known packages.
-                self.pkg("uninstall \\*")
-                self.pkg("list -af", exit=1)
+        # Uninstall all packages and verify there are no known packages.
+        self.pkg("uninstall \\*")
+        self.pkg("list -af", exit=1)
 
-                # Cleanup.
-                self.image_destroy()
+        # Cleanup.
+        self.image_destroy()
 
-        def test_01_info(self):
-                """Verify that the info operation works as expected for
-                temporary origins.
-                """
-                # because we compare date strings we must run this in
-                # a consistent locale, which we made 'C'
+    def test_01_info(self):
+        """Verify that the info operation works as expected for
+        temporary origins.
+        """
+        # because we compare date strings we must run this in
+        # a consistent locale, which we made 'C'
 
-                os.environ['LC_ALL'] = 'C'
+        os.environ["LC_ALL"] = "C"
 
-                # Create an image and verify no packages are known.
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("list -a", exit=1)
+        # Create an image and verify no packages are known.
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("list -a", exit=1)
 
-                # Verify graceful failure for an empty source alone or in
-                # combination with another temporary source.
-                self.pkg("info -g {0} \\*".format(self.empty_arc), exit=1)
-                self.pkg("info -g {0} -g {1} foo".format(self.empty_arc,
-                    self.foo_arc), exit=1)
+        # Verify graceful failure for an empty source alone or in
+        # combination with another temporary source.
+        self.pkg("info -g {0} \\*".format(self.empty_arc), exit=1)
+        self.pkg(
+            "info -g {0} -g {1} foo".format(self.empty_arc, self.foo_arc),
+            exit=1,
+        )
 
-                # Verify graceful failure if source doesn't exist.
-                self.pkg("info -g {0} foo".format(self.foo_arc + ".nosuchpkg"),
-                    exit=1)
+        # Verify graceful failure if source doesn't exist.
+        self.pkg("info -g {0} foo".format(self.foo_arc + ".nosuchpkg"), exit=1)
 
-                # Verify graceful failure if user doesn't have permission to
-                # access temporary source.
-                self.pkg("info -g {0} foo".format(self.perm_arc), su_wrap=True, exit=1)
+        # Verify graceful failure if user doesn't have permission to
+        # access temporary source.
+        self.pkg("info -g {0} foo".format(self.perm_arc), su_wrap=True, exit=1)
 
-                # Verify graceful failure if -l is used with -g.
-                self.pkg("info -l -g {0} foo".format(self.foo_arc), exit=2)
+        # Verify graceful failure if -l is used with -g.
+        self.pkg("info -l -g {0} foo".format(self.foo_arc), exit=2)
 
-                # Verify output for a single package temporary source.
-                # -r is used here to verify that even though -r is implicit,
-                # it is not an error to specify it.
-                def pd(pfmri):
-                        return pfmri.version.get_timestamp().strftime("%c")
+        # Verify output for a single package temporary source.
+        # -r is used here to verify that even though -r is implicit,
+        # it is not an error to specify it.
+        def pd(pfmri):
+            return pfmri.version.get_timestamp().strftime("%c")
 
-                self.pkg("info -r -g {0} foo".format(self.foo_arc), su_wrap=True)
-                expected = """\
+        self.pkg("info -r -g {0} foo".format(self.foo_arc), su_wrap=True)
+        expected = """\
           Name: foo
        Summary: Example package foo.
          State: Not installed
@@ -469,21 +505,23 @@ class TestPkgTempSources(pkg5unittest.ManyDepotTestCase):
 Packaging Date: {pkg_date}
           Size: 41.00 B
           FMRI: {pkg_fmri}
-""".format(pkg_date=pd(self.foo10), pkg_fmri=self.foo10.get_fmri(
-    include_build=False))
-                self.assertEqualDiff(expected, self.output)
+""".format(
+            pkg_date=pd(self.foo10),
+            pkg_fmri=self.foo10.get_fmri(include_build=False),
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                # Again, as prvileged user.
-                self.pkg("info -r -g {0} foo".format(self.foo_arc))
-                self.assertEqualDiff(expected, self.output)
+        # Again, as prvileged user.
+        self.pkg("info -r -g {0} foo".format(self.foo_arc))
+        self.assertEqualDiff(expected, self.output)
 
-                # Note that -r is implicit when -g is used, so all of
-                # the following tests purposefully omit it.
+        # Note that -r is implicit when -g is used, so all of
+        # the following tests purposefully omit it.
 
-                # Verify info output for a multiple package temporary source
-                # as an unprivileged user.
-                self.pkg("info -g {0} \\*".format(self.all_arc), su_wrap=True)
-                expected = """\
+        # Verify info output for a multiple package temporary source
+        # as an unprivileged user.
+        self.pkg("info -g {0} \\*".format(self.all_arc), su_wrap=True)
+        expected = """\
           Name: foo
        Summary: Example package foo.
          State: Not installed
@@ -522,53 +560,73 @@ Packaging Date: {quux10_pkg_date}
 Packaging Date: {signed10_pkg_date}
           Size: 10.37 kB
           FMRI: {signed10_pkg_fmri}
-""".format(**{"foo10_pkg_date": pd(self.foo10), "foo10_pkg_fmri": \
-        self.foo10.get_fmri(include_build=False),
-    "incorp20_pkg_date": pd(self.incorp20), "incorp20_pkg_fmri": \
-        self.incorp20.get_fmri(include_build=False),
-    "quux10_pkg_date": pd(self.quux10), "quux10_pkg_fmri": \
-        self.quux10.get_fmri(include_build=False),
-    "signed10_pkg_date": pd(self.signed10), "signed10_pkg_fmri": \
-        self.signed10.get_fmri(include_build=False),
-    })
-                self.assertEqualDiff(expected, self.output)
+""".format(
+            **{
+                "foo10_pkg_date": pd(self.foo10),
+                "foo10_pkg_fmri": self.foo10.get_fmri(include_build=False),
+                "incorp20_pkg_date": pd(self.incorp20),
+                "incorp20_pkg_fmri": self.incorp20.get_fmri(
+                    include_build=False
+                ),
+                "quux10_pkg_date": pd(self.quux10),
+                "quux10_pkg_fmri": self.quux10.get_fmri(include_build=False),
+                "signed10_pkg_date": pd(self.signed10),
+                "signed10_pkg_fmri": self.signed10.get_fmri(
+                    include_build=False
+                ),
+            }
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify info output for a multiple package temporary source.
-                self.pkg("info -g {0} foo@1.0 incorp@2.0 signed@1.0 "
-                    "quux@1.0".format(self.all_arc))
-                self.assertEqualDiff(expected, self.output)
+        # Verify info output for a multiple package temporary source.
+        self.pkg(
+            "info -g {0} foo@1.0 incorp@2.0 signed@1.0 "
+            "quux@1.0".format(self.all_arc)
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify info result for multiple temporary sources using
-                # different combinations of archives and repositories.
-                self.pkg("info -g {0} -g {1} signed@1.0 foo@1.0 signed@1.0".format(
-                    self.signed_arc, self.foo_rurl))
+        # Verify info result for multiple temporary sources using
+        # different combinations of archives and repositories.
+        self.pkg(
+            "info -g {0} -g {1} signed@1.0 foo@1.0 signed@1.0".format(
+                self.signed_arc, self.foo_rurl
+            )
+        )
 
-                self.pkg("info -g {0} -g {1} -g {2} -g {3} foo@1.0 incorp@1.0 "
-                    "signed@1.0 quux@0.1".format(
-                    self.signed_arc, self.incorp_arc, self.quux_arc,
-                    self.foo_arc))
+        self.pkg(
+            "info -g {0} -g {1} -g {2} -g {3} foo@1.0 incorp@1.0 "
+            "signed@1.0 quux@0.1".format(
+                self.signed_arc, self.incorp_arc, self.quux_arc, self.foo_arc
+            )
+        )
 
-                self.pkg("info -g {0} -g {1} -g {2} -g {3} foo@1.0 incorp@1.0 "
-                    "signed@1.0 quux@0.1".format(
-                    self.signed_arc, self.incorp_arc, self.quux_arc,
-                    self.foo_rurl))
+        self.pkg(
+            "info -g {0} -g {1} -g {2} -g {3} foo@1.0 incorp@1.0 "
+            "signed@1.0 quux@0.1".format(
+                self.signed_arc, self.incorp_arc, self.quux_arc, self.foo_rurl
+            )
+        )
 
-                self.pkg("info -g {0} -g {1} foo@1.0 incorp@2.0 signed@1.0 "
-                    "quux@1.0".format(self.all_arc, self.all_rurl))
+        self.pkg(
+            "info -g {0} -g {1} foo@1.0 incorp@2.0 signed@1.0 "
+            "quux@1.0".format(self.all_arc, self.all_rurl)
+        )
 
-                # Verify package installed from archive shows in default info
-                # output.
-                self.pkg("install -g {0} foo@1.0".format(self.foo_arc))
-                self.pkg("info")
+        # Verify package installed from archive shows in default info
+        # output.
+        self.pkg("install -g {0} foo@1.0".format(self.foo_arc))
+        self.pkg("info")
 
-                os.environ["LC_ALL"] = "C"
-                path = os.path.join(self.img_path(),
-                    "var/pkg/state/installed/catalog.base.C")
-                entry = json.load(open(path))["test"]["foo"][0]["metadata"]
-                pkg_install = catalog.basic_ts_to_datetime(
-                    entry["last-install"]).strftime("%c")
+        os.environ["LC_ALL"] = "C"
+        path = os.path.join(
+            self.img_path(), "var/pkg/state/installed/catalog.base.C"
+        )
+        entry = json.load(open(path))["test"]["foo"][0]["metadata"]
+        pkg_install = catalog.basic_ts_to_datetime(
+            entry["last-install"]
+        ).strftime("%c")
 
-                expected = """\
+        expected = """\
              Name: foo
           Summary: Example package foo.
             State: Installed (Manually installed)
@@ -579,66 +637,73 @@ Packaging Date: {signed10_pkg_date}
 Last Install Time: {pkg_install}
              Size: 41.00 B
              FMRI: {pkg_fmri}
-""".format(pkg_date=pd(self.foo10), pkg_fmri=self.foo10.get_fmri(
-    include_build=False), pkg_install=pkg_install)
-                self.assertEqualDiff(expected, self.output)
+""".format(
+            pkg_date=pd(self.foo10),
+            pkg_fmri=self.foo10.get_fmri(include_build=False),
+            pkg_install=pkg_install,
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify that when showing package info from archive that
-                # package shows as installed if it matches the installed one.
-                self.pkg("info -g {0} foo".format(self.foo_arc))
-                expected = expected.replace(' (Manually installed)', '')
-                self.assertEqualDiff(expected, self.output)
+        # Verify that when showing package info from archive that
+        # package shows as installed if it matches the installed one.
+        self.pkg("info -g {0} foo".format(self.foo_arc))
+        expected = expected.replace(" (Manually installed)", "")
+        self.assertEqualDiff(expected, self.output)
 
-                # Uninstall all packages and verify there are no known packages.
-                self.pkg("uninstall \\*")
-                self.pkg("info -r \\*", exit=1)
+        # Uninstall all packages and verify there are no known packages.
+        self.pkg("uninstall \\*")
+        self.pkg("info -r \\*", exit=1)
 
-                # Verify that --license works as expected with -g.
-                self.pkg("info -g {0} --license licensed@1.0".format(
-                    self.licensed_rurl))
-                self.assertEqualDiff("tmp/LICENSE\n", self.output)
-                self.pkg("info -g {0} --license licensed".format(
-                    self.licensed_rurl))
-                self.assertEqualDiff("tmp/LICENSE2\n", self.output)
+        # Verify that --license works as expected with -g.
+        self.pkg(
+            "info -g {0} --license licensed@1.0".format(self.licensed_rurl)
+        )
+        self.assertEqualDiff("tmp/LICENSE\n", self.output)
+        self.pkg("info -g {0} --license licensed".format(self.licensed_rurl))
+        self.assertEqualDiff("tmp/LICENSE2\n", self.output)
 
-                # Cleanup.
-                self.image_destroy()
-                # Change locale back to 'UTF-8' to not affect other test cases.
-                if six.PY3:
-                        os.environ["LC_ALL"] = "en_US.UTF-8"
+        # Cleanup.
+        self.image_destroy()
+        # Change locale back to 'UTF-8' to not affect other test cases.
+        if six.PY3:
+            os.environ["LC_ALL"] = "en_US.UTF-8"
 
-        def test_02_contents(self):
-                """Verify that the contents operation works as expected for
-                temporary origins.
-                """
+    def test_02_contents(self):
+        """Verify that the contents operation works as expected for
+        temporary origins.
+        """
 
-                # Create an image and verify no packages are known.
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("list -a", exit=1)
+        # Create an image and verify no packages are known.
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("list -a", exit=1)
 
-                # Verify graceful failure for an empty source alone or in
-                # combination with another temporary source.
-                self.pkg("contents -g {0} \\*".format(self.empty_arc), exit=1)
-                self.pkg("contents -g {0} -g {1} foo".format(self.empty_arc,
-                    self.foo_arc), exit=1)
+        # Verify graceful failure for an empty source alone or in
+        # combination with another temporary source.
+        self.pkg("contents -g {0} \\*".format(self.empty_arc), exit=1)
+        self.pkg(
+            "contents -g {0} -g {1} foo".format(self.empty_arc, self.foo_arc),
+            exit=1,
+        )
 
-                # Verify graceful failure if source doesn't exist.
-                self.pkg("contents -g {0} foo".format(self.foo_arc + ".nosuchpkg"),
-                    exit=1)
+        # Verify graceful failure if source doesn't exist.
+        self.pkg(
+            "contents -g {0} foo".format(self.foo_arc + ".nosuchpkg"), exit=1
+        )
 
-                # Verify graceful failure if user doesn't have permission to
-                # access temporary source.
-                self.pkg("contents -g {0} foo".format(self.perm_arc), su_wrap=True,
-                    exit=1)
+        # Verify graceful failure if user doesn't have permission to
+        # access temporary source.
+        self.pkg(
+            "contents -g {0} foo".format(self.perm_arc), su_wrap=True, exit=1
+        )
 
-                # Verify output for a single package temporary source.
-                # -r is used here to verify that even though -r is implicit,
-                # it is not an error to specify it.
-                def pd(pfmri):
-                        return pfmri.version.get_timestamp().strftime("%c")
+        # Verify output for a single package temporary source.
+        # -r is used here to verify that even though -r is implicit,
+        # it is not an error to specify it.
+        def pd(pfmri):
+            return pfmri.version.get_timestamp().strftime("%c")
 
-                self.pkg("contents -mr -g {0} foo".format(self.foo_arc), su_wrap=True)
-                expected = """\
+        self.pkg("contents -mr -g {0} foo".format(self.foo_arc), su_wrap=True)
+        expected = """\
 set name=pkg.fmri value={0}
 set name=pkg.summary value="Example package foo."
 set name=variant.debug.foo value=true value=false
@@ -659,309 +724,365 @@ file a285ada5f3cae14ea00e97a8d99bd3e357cb0dca chash=97a09a2356d068d8dbe418de9001
 file dc84bd4b606fe43fc892eb245d9602b67f8cba38 chash=e1106f9505253dfe46aa48c353740f9e1896a844 group=bin mode=0444 owner=root path=usr/share/doc/foo/README pkg.content-hash=file:sha512t_256:f57d0e3a47386f7ec82828ac86781a39e5e1763c9d8f013fdce0ca642b80e1d5 pkg.content-hash=gzip:sha512t_256:6e0d5f8b106123b129276a38cf3b8822abc91c5b291ba3e51b4854ba6218ab6d pkg.csize=30 pkg.size=10
 hardlink path=usr/local/bin/hard-foo target=/usr/bin/foo
 link path=usr/local/bin/soft-foo target=usr/bin/foo
-""".format(self.foo10)
+""".format(
+            self.foo10
+        )
 
-                # Again, as prvileged user.
-                self.pkg("contents -mr -g {0} foo".format(self.foo_arc))
-                self.assertEqualDiff(sorted(expected.splitlines()),
-                    sorted(self.output.splitlines()))
+        # Again, as prvileged user.
+        self.pkg("contents -mr -g {0} foo".format(self.foo_arc))
+        self.assertEqualDiff(
+            sorted(expected.splitlines()), sorted(self.output.splitlines())
+        )
 
-                # Note that -r is implicit when -g is used, so all of
-                # the following tests purposefully omit it.
+        # Note that -r is implicit when -g is used, so all of
+        # the following tests purposefully omit it.
 
-                # Verify contents result for multiple temporary sources using
-                # different combinations of archives and repositories.
-                self.pkg("contents -g {0} -g {1} signed@1.0 foo@1.0 "
-                    "signed@1.0".format(self.signed_arc, self.foo_rurl))
+        # Verify contents result for multiple temporary sources using
+        # different combinations of archives and repositories.
+        self.pkg(
+            "contents -g {0} -g {1} signed@1.0 foo@1.0 "
+            "signed@1.0".format(self.signed_arc, self.foo_rurl)
+        )
 
-                self.pkg("contents -g {0} -g {1} -g {2} -g {3} foo@1.0 incorp@1.0 "
-                    "signed@1.0 quux@0.1".format(self.signed_arc, self.incorp_arc,
-                    self.quux_arc, self.foo_arc))
+        self.pkg(
+            "contents -g {0} -g {1} -g {2} -g {3} foo@1.0 incorp@1.0 "
+            "signed@1.0 quux@0.1".format(
+                self.signed_arc, self.incorp_arc, self.quux_arc, self.foo_arc
+            )
+        )
 
-                self.pkg("contents -g {0} -g {1} -g {2} -g {3} foo@1.0 incorp@1.0 "
-                    "signed@1.0 quux@0.1".format(self.signed_arc, self.incorp_arc,
-                    self.quux_arc, self.foo_rurl))
+        self.pkg(
+            "contents -g {0} -g {1} -g {2} -g {3} foo@1.0 incorp@1.0 "
+            "signed@1.0 quux@0.1".format(
+                self.signed_arc, self.incorp_arc, self.quux_arc, self.foo_rurl
+            )
+        )
 
-                self.pkg("contents -g {0} -g {1} foo@1.0 incorp@2.0 signed@1.0 "
-                    "quux@1.0".format(self.all_arc, self.all_rurl))
+        self.pkg(
+            "contents -g {0} -g {1} foo@1.0 incorp@2.0 signed@1.0 "
+            "quux@1.0".format(self.all_arc, self.all_rurl)
+        )
 
-                # Verify package installed from archive can be used with
-                # contents.
-                self.pkg("install -g {0} foo@1.0".format(self.foo_arc))
-                self.pkg("contents foo")
+        # Verify package installed from archive can be used with
+        # contents.
+        self.pkg("install -g {0} foo@1.0".format(self.foo_arc))
+        self.pkg("contents foo")
 
-                # Uninstall all packages and verify there are no known packages.
-                self.pkg("uninstall \\*")
-                self.pkg("contents -r \\*", exit=1)
+        # Uninstall all packages and verify there are no known packages.
+        self.pkg("uninstall \\*")
+        self.pkg("contents -r \\*", exit=1)
 
-                # Cleanup.
-                self.image_destroy()
+        # Cleanup.
+        self.image_destroy()
 
-        def test_03_install_update(self):
-                """Verify that install and update work as expected for temporary
-                origins.
-                """
+    def test_03_install_update(self):
+        """Verify that install and update work as expected for temporary
+        origins.
+        """
 
-                #
-                # Create an image with no configured package sources, and
-                # verify that a package can be installed from a temporary
-                # source.
-                #
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("list -a", exit=1)
-                self.pkg("install -g {0} foo".format(self.foo_arc))
+        #
+        # Create an image with no configured package sources, and
+        # verify that a package can be installed from a temporary
+        # source.
+        #
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("list -a", exit=1)
+        self.pkg("install -g {0} foo".format(self.foo_arc))
 
-                #
-                # Create an image with a network-based source, then make that
-                # source unreachable and verify that a package can be installed
-                # from a temporary source.
-                #
-                self.dcs[4].start()
-                self.image_create(self.dcs[4].get_depot_url(), prefix=None)
-                self.dcs[4].stop()
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("list -a")
-                # --no-refresh is required for now because -g combines temporary
-                # sources with configured soures and pkg(7) currently treats
-                # refresh failure as fatal.  See bug 18323.
-                self.pkg("install --no-refresh -g {0} foo".format(self.foo_arc))
+        #
+        # Create an image with a network-based source, then make that
+        # source unreachable and verify that a package can be installed
+        # from a temporary source.
+        #
+        self.dcs[4].start()
+        self.image_create(self.dcs[4].get_depot_url(), prefix=None)
+        self.dcs[4].stop()
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("list -a")
+        # --no-refresh is required for now because -g combines temporary
+        # sources with configured soures and pkg(7) currently treats
+        # refresh failure as fatal.  See bug 18323.
+        self.pkg("install --no-refresh -g {0} foo".format(self.foo_arc))
 
-                #
-                # Create an image and verify no packages are known.
-                #
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                self.pkg("list -a", exit=1)
+        #
+        # Create an image and verify no packages are known.
+        #
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        self.pkg("list -a", exit=1)
 
-                # Verify graceful failure if source doesn't exist.
-                self.pkg("install -g {0} foo".format(self.foo_arc + ".nosuchpkg"),
-                    exit=1)
+        # Verify graceful failure if source doesn't exist.
+        self.pkg(
+            "install -g {0} foo".format(self.foo_arc + ".nosuchpkg"), exit=1
+        )
 
-                # Verify graceful failure if user doesn't have permission to
-                # access temporary source.
-                self.pkg("install -g {0} foo".format(self.perm_arc), su_wrap=True,
-                    exit=1)
+        # Verify graceful failure if user doesn't have permission to
+        # access temporary source.
+        self.pkg(
+            "install -g {0} foo".format(self.perm_arc), su_wrap=True, exit=1
+        )
 
-                # Verify attempting to install a package with a missing
-                # dependency fails gracefully.
-                self.pkg("install -g {0} signed".format(self.signed_arc), exit=1)
+        # Verify attempting to install a package with a missing
+        # dependency fails gracefully.
+        self.pkg("install -g {0} signed".format(self.signed_arc), exit=1)
 
-                # Verify a package from a publisher not already configured can
-                # be installed using temporary origins.  Installing a package
-                # in this scenario will result in the publisher being added
-                # but without any origin information.
-                self.pkg("install -g {0} foo".format(self.foo_arc))
-                self.pkg("list foo")
+        # Verify a package from a publisher not already configured can
+        # be installed using temporary origins.  Installing a package
+        # in this scenario will result in the publisher being added
+        # but without any origin information.
+        self.pkg("install -g {0} foo".format(self.foo_arc))
+        self.pkg("list foo")
 
-                # Verify that publisher exists now (without origin information)
-                # and is enabled and sticky (-n omits disabled publishers).
-                self.pkg("publisher -nH")
-                expected = """\
+        # Verify that publisher exists now (without origin information)
+        # and is enabled and sticky (-n omits disabled publishers).
+        self.pkg("publisher -nH")
+        expected = """\
 empty origin online F {0}/
 test 
-""".format(self.empty_rurl)
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+""".format(
+            self.empty_rurl
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                # Verify that signed package can now be installed since
-                # dependency was satisfied.
-                self.pkg("install -g {0} signed".format(self.signed_arc))
-                self.pkg("list foo signed")
+        # Verify that signed package can now be installed since
+        # dependency was satisfied.
+        self.pkg("install -g {0} signed".format(self.signed_arc))
+        self.pkg("list foo signed")
 
-                # Verify that removing all packages leaves no packages known
-                # even though publisher remains configured.
-                self.pkg("uninstall \\*")
-                self.pkg("list -af", exit=1)
+        # Verify that removing all packages leaves no packages known
+        # even though publisher remains configured.
+        self.pkg("uninstall \\*")
+        self.pkg("list -af", exit=1)
 
-                # Verify publisher can be removed.
-                self.pkg("unset-publisher test")
+        # Verify publisher can be removed.
+        self.pkg("unset-publisher test")
 
-                #
-                # Create an image using the foo archive.
-                #
-                self.image_create(misc.parse_uri(self.foo_arc), prefix=None)
-                self.__seed_ta_dir("ta1")
+        #
+        # Create an image using the foo archive.
+        #
+        self.image_create(misc.parse_uri(self.foo_arc), prefix=None)
+        self.__seed_ta_dir("ta1")
 
-                # Verify that signed package can be installed and the archive
-                # configured for the publisher allows dependencies to be
-                # satisfied.
-                self.pkg("set-property signature-policy verify")
-                self.pkg("install -g {0} signed".format(self.signed_arc))
-                self.pkg("list foo signed")
+        # Verify that signed package can be installed and the archive
+        # configured for the publisher allows dependencies to be
+        # satisfied.
+        self.pkg("set-property signature-policy verify")
+        self.pkg("install -g {0} signed".format(self.signed_arc))
+        self.pkg("list foo signed")
 
-                # Verify that removing all packages leaves only foo known.
-                self.pkg("uninstall \\*")
-                self.pkg("list -aH")
-                expected = "foo 1.0 ---\n"
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+        # Verify that removing all packages leaves only foo known.
+        self.pkg("uninstall \\*")
+        self.pkg("list -aH")
+        expected = "foo 1.0 ---\n"
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-                #
-                # Create an image and verify no packages are known.
-                #
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("list -a", exit=1)
+        #
+        # Create an image and verify no packages are known.
+        #
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("list -a", exit=1)
 
-                # Install an older version of a known package.
-                self.pkg("install -g {0} quux@0.1".format(self.all_arc))
-                self.pkg("list incorp@1.0 quux@0.1")
+        # Install an older version of a known package.
+        self.pkg("install -g {0} quux@0.1".format(self.all_arc))
+        self.pkg("list incorp@1.0 quux@0.1")
 
-                # Verify graceful failure if source doesn't exist.
-                self.pkg("update -g {0} foo".format(self.foo_arc + ".nosuchpkg"),
-                    exit=1)
+        # Verify graceful failure if source doesn't exist.
+        self.pkg(
+            "update -g {0} foo".format(self.foo_arc + ".nosuchpkg"), exit=1
+        )
 
-                # Verify graceful failure if user doesn't have permission to
-                # access temporary source.
-                self.pkg("update -g {0} foo".format(self.perm_arc), su_wrap=True,
-                    exit=1)
+        # Verify graceful failure if user doesn't have permission to
+        # access temporary source.
+        self.pkg(
+            "update -g {0} foo".format(self.perm_arc), su_wrap=True, exit=1
+        )
 
-                # Verify that packages can be updated using temporary origins.
-                self.pkg("update -g {0} -g {1}".format(self.incorp_arc,
-                    self.quux_arc))
-                self.pkg("list incorp@2.0 quux@1.0")
+        # Verify that packages can be updated using temporary origins.
+        self.pkg("update -g {0} -g {1}".format(self.incorp_arc, self.quux_arc))
+        self.pkg("list incorp@2.0 quux@1.0")
 
-                # Verify that both test and test2 are configured without
-                # origins.
-                self.pkg("publisher -H")
-                expected = """\
+        # Verify that both test and test2 are configured without
+        # origins.
+        self.pkg("publisher -H")
+        expected = """\
 empty origin online F {0}/
 test 
 test2 
-""".format(self.empty_rurl)
-                output = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, output)
+""".format(
+            self.empty_rurl
+        )
+        output = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, output)
 
-        def test_04_change_varcets(self):
-                """Verify that change-facet and change-variant work as expected
-                for temporary origins.
-                """
+    def test_04_change_varcets(self):
+        """Verify that change-facet and change-variant work as expected
+        for temporary origins.
+        """
 
-                #
-                # Create an image and verify no packages are known.
-                #
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("list -a", exit=1)
+        #
+        # Create an image and verify no packages are known.
+        #
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("list -a", exit=1)
 
-                # Install a package from an archive.
-                self.pkg("install -g {0} foo".format(self.foo_arc))
+        # Install a package from an archive.
+        self.pkg("install -g {0} foo".format(self.foo_arc))
 
-                #
-                # Verify change-facet can use temporary origins.
-                #
-                fpath = os.path.join(self.img_path(),
-                    "usr/share/man/man1/foo.1")
-                assert os.path.exists(fpath)
+        #
+        # Verify change-facet can use temporary origins.
+        #
+        fpath = os.path.join(self.img_path(), "usr/share/man/man1/foo.1")
+        assert os.path.exists(fpath)
 
-                # Now set facet.doc.man to false and verify faceted item is
-                # gone.
-                self.pkg("change-facet facet.doc.man=false")
-                assert not os.path.exists(fpath)
+        # Now set facet.doc.man to false and verify faceted item is
+        # gone.
+        self.pkg("change-facet facet.doc.man=false")
+        assert not os.path.exists(fpath)
 
-                # Now attempt to set the facet to true again; this should
-                # fail.
-                self.pkg("change-facet facet.doc.man=true", exit=1)
+        # Now attempt to set the facet to true again; this should
+        # fail.
+        self.pkg("change-facet facet.doc.man=true", exit=1)
 
-                # Verify graceful failure if source doesn't exist.
-                self.pkg("change-facet -g {0} facet.doc.man=true".format(
-                    self.foo_arc + ".nosuchpkg"), exit=1)
+        # Verify graceful failure if source doesn't exist.
+        self.pkg(
+            "change-facet -g {0} facet.doc.man=true".format(
+                self.foo_arc + ".nosuchpkg"
+            ),
+            exit=1,
+        )
 
-                # Verify graceful failure if user doesn't have permission to
-                # access temporary source.
-                self.pkg("change-facet -g {0} facet.doc.man=true".format(
-                    self.perm_arc), su_wrap=True, exit=1)
+        # Verify graceful failure if user doesn't have permission to
+        # access temporary source.
+        self.pkg(
+            "change-facet -g {0} facet.doc.man=true".format(self.perm_arc),
+            su_wrap=True,
+            exit=1,
+        )
 
-                # Verify that if the original archive is provided, the operation
-                # will succeed.
-                self.pkg("change-facet -g {0} facet.doc.man=True".format(self.foo_arc))
-                assert os.path.exists(fpath)
+        # Verify that if the original archive is provided, the operation
+        # will succeed.
+        self.pkg("change-facet -g {0} facet.doc.man=True".format(self.foo_arc))
+        assert os.path.exists(fpath)
 
-                #
-                # Verify change-variant can use temporary origins.
-                #
-                vpath = os.path.join(self.img_path(),
-                    "lib/libfoo.so.1")
-                assert os.path.exists(vpath)
-                self.assertEqual(os.stat(vpath).st_size, 15)
+        #
+        # Verify change-variant can use temporary origins.
+        #
+        vpath = os.path.join(self.img_path(), "lib/libfoo.so.1")
+        assert os.path.exists(vpath)
+        self.assertEqual(os.stat(vpath).st_size, 15)
 
-                # Now attempt to change the debug variant; this should fail.
-                self.pkg("change-variant -vv variant.debug.foo=true", exit=1)
+        # Now attempt to change the debug variant; this should fail.
+        self.pkg("change-variant -vv variant.debug.foo=true", exit=1)
 
-                # Verify graceful failure if source doesn't exist.
-                self.pkg("change-variant -vvg {0} variant.debug.foo=true".format(
-                    self.foo_arc + ".nosuchpkg"), exit=1)
+        # Verify graceful failure if source doesn't exist.
+        self.pkg(
+            "change-variant -vvg {0} variant.debug.foo=true".format(
+                self.foo_arc + ".nosuchpkg"
+            ),
+            exit=1,
+        )
 
-                # Verify graceful failure if user doesn't have permission to
-                # access temporary source.
-                self.pkg("change-variant -vvg {0} variant.debug.foo=true".format(
-                    self.perm_arc), su_wrap=True, exit=1)
+        # Verify graceful failure if user doesn't have permission to
+        # access temporary source.
+        self.pkg(
+            "change-variant -vvg {0} variant.debug.foo=true".format(
+                self.perm_arc
+            ),
+            su_wrap=True,
+            exit=1,
+        )
 
-                # Verify that if the original archive is provided, the operation
-                # will succeed.
-                self.pkg("change-variant -vvg {0} variant.debug.foo=true".format(
-                    self.foo_arc))
-                assert os.path.exists(vpath)
-                self.assertEqual(os.stat(vpath).st_size, 21)
+        # Verify that if the original archive is provided, the operation
+        # will succeed.
+        self.pkg(
+            "change-variant -vvg {0} variant.debug.foo=true".format(
+                self.foo_arc
+            )
+        )
+        assert os.path.exists(vpath)
+        self.assertEqual(os.stat(vpath).st_size, 21)
 
-        def test_05_staged_execution(self):
-                """Verify that staged execution works with temporary
-                origins."""
+    def test_05_staged_execution(self):
+        """Verify that staged execution works with temporary
+        origins."""
 
-                # Create an image and verify no packages are known.
-                self.image_create(self.empty_rurl, prefix=None)
-                self.pkg("list -a", exit=1)
+        # Create an image and verify no packages are known.
+        self.image_create(self.empty_rurl, prefix=None)
+        self.pkg("list -a", exit=1)
 
-                # Install an older version of a known package.
-                self.pkg("install -g {0} quux@0.1".format(self.all_arc))
-                self.pkg("list incorp@1.0 quux@0.1")
+        # Install an older version of a known package.
+        self.pkg("install -g {0} quux@0.1".format(self.all_arc))
+        self.pkg("list incorp@1.0 quux@0.1")
 
-                # Verify that packages can be updated using temporary origins.
-                self.pkg("update --stage=plan -g {0} -g {1}".format(
-                    self.incorp_arc, self.quux_arc))
-                self.pkg("update --stage=prepare -g {0} -g {1}".format(
-                    self.incorp_arc, self.quux_arc))
-                self.pkg("update --stage=execute -g {0} -g {1}".format(
-                    self.incorp_arc, self.quux_arc))
-                self.pkg("list incorp@2.0 quux@1.0")
+        # Verify that packages can be updated using temporary origins.
+        self.pkg(
+            "update --stage=plan -g {0} -g {1}".format(
+                self.incorp_arc, self.quux_arc
+            )
+        )
+        self.pkg(
+            "update --stage=prepare -g {0} -g {1}".format(
+                self.incorp_arc, self.quux_arc
+            )
+        )
+        self.pkg(
+            "update --stage=execute -g {0} -g {1}".format(
+                self.incorp_arc, self.quux_arc
+            )
+        )
+        self.pkg("list incorp@2.0 quux@1.0")
 
-        def test_06_appropriate_license_files(self):
-                """Verify that the correct license file is displayed."""
+    def test_06_appropriate_license_files(self):
+        """Verify that the correct license file is displayed."""
 
-                self.image_create()
+        self.image_create()
 
-                self.pkg("info -g {0} --license licensed".format(self.licensed_rurl))
-                self.assertEqual("tmp/LICENSE2\n", self.output)
-                self.pkg("info -g {0} --license licensed@1.0".format(
-                    self.licensed_rurl))
-                self.assertEqual("tmp/LICENSE\n", self.output)
+        self.pkg("info -g {0} --license licensed".format(self.licensed_rurl))
+        self.assertEqual("tmp/LICENSE2\n", self.output)
+        self.pkg(
+            "info -g {0} --license licensed@1.0".format(self.licensed_rurl)
+        )
+        self.assertEqual("tmp/LICENSE\n", self.output)
 
-                self.pkg("install -g {0} --licenses licensed@1.0".format(
-                    self.licensed_rurl))
-                self.assertTrue("tmp/LICENSE" in self.output, "Expected "
-                    "tmp/LICENSE to be in the output of the install. Output "
-                    "was:\n{0}".format(self.output))
-                self.pkg("info -g {0} --license licensed".format(self.licensed_rurl))
-                self.assertEqual("tmp/LICENSE2\n", self.output)
-                self.pkg("info -g {0} --license licensed@2.0".format(
-                    self.licensed_rurl))
-                self.assertEqual("tmp/LICENSE2\n", self.output)
+        self.pkg(
+            "install -g {0} --licenses licensed@1.0".format(self.licensed_rurl)
+        )
+        self.assertTrue(
+            "tmp/LICENSE" in self.output,
+            "Expected "
+            "tmp/LICENSE to be in the output of the install. Output "
+            "was:\n{0}".format(self.output),
+        )
+        self.pkg("info -g {0} --license licensed".format(self.licensed_rurl))
+        self.assertEqual("tmp/LICENSE2\n", self.output)
+        self.pkg(
+            "info -g {0} --license licensed@2.0".format(self.licensed_rurl)
+        )
+        self.assertEqual("tmp/LICENSE2\n", self.output)
 
-                self.pkg("update -g {0} --licenses licensed@2.0".format(
-                    self.licensed_rurl))
-                self.assertTrue("tmp/LICENSE2" in self.output, "Expected "
-                    "tmp/LICENSE2 to be in the output of the install. Output "
-                    "was:\n{0}".format(self.output))
-                self.pkg("info -g {0} --license licensed".format(self.licensed_rurl))
-                self.assertEqual("tmp/LICENSE2\n", self.output)
-                self.pkg("info -g {0} --license licensed@1.0".format(
-                    self.licensed_rurl))
-                self.assertEqual("tmp/LICENSE\n", self.output)
+        self.pkg(
+            "update -g {0} --licenses licensed@2.0".format(self.licensed_rurl)
+        )
+        self.assertTrue(
+            "tmp/LICENSE2" in self.output,
+            "Expected "
+            "tmp/LICENSE2 to be in the output of the install. Output "
+            "was:\n{0}".format(self.output),
+        )
+        self.pkg("info -g {0} --license licensed".format(self.licensed_rurl))
+        self.assertEqual("tmp/LICENSE2\n", self.output)
+        self.pkg(
+            "info -g {0} --license licensed@1.0".format(self.licensed_rurl)
+        )
+        self.assertEqual("tmp/LICENSE\n", self.output)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_terminal.py
+++ b/src/tests/cli/t_pkg_terminal.py
@@ -23,103 +23,138 @@
 # Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import sys
 import unittest
 
+
 class TestPkgTerminal(pkg5unittest.SingleDepotTestCase):
+    def setUp(self):
+        # This test suite needs actual depots.
+        pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
 
-        def setUp(self):
-                # This test suite needs actual depots.
-                pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
+    def tearDown(self):
+        pkg5unittest.SingleDepotTestCase.tearDown(self)
 
-        def tearDown(self):
-                pkg5unittest.SingleDepotTestCase.tearDown(self)
+    def test_pkg_pty(self):
+        """Smoke test pkg on a PTY"""
 
-        def test_pkg_pty(self):
-                """Smoke test pkg on a PTY"""
+        durl = self.dcs[1].get_depot_url()
+        self.image_create(durl)
+        cmdline = (
+            sys.executable
+            + " "
+            + self.pkg_cmdpath
+            + " -R "
+            + self.img_path()
+            + " refresh"
+        )
+        self.cmdline_run(cmdline, exit=0, usepty=True)
+        cmdline = (
+            sys.executable
+            + " "
+            + self.pkg_cmdpath
+            + " -R "
+            + self.img_path()
+            + " BADCOMMAND"
+        )
+        self.cmdline_run(cmdline, exit=2, usepty=True)
 
-                durl = self.dcs[1].get_depot_url()
-                self.image_create(durl)
-                cmdline = sys.executable + " " + self.pkg_cmdpath + " -R " + \
-                    self.img_path() + " refresh"
-                self.cmdline_run(cmdline, exit=0, usepty=True)
-                cmdline = sys.executable + " " + self.pkg_cmdpath + " -R " + \
-                    self.img_path() + " BADCOMMAND"
-                self.cmdline_run(cmdline, exit=2, usepty=True)
+    def test_pkg_bad_term(self):
+        """Test that pkg runs properly even with a bad $TERM"""
 
-        def test_pkg_bad_term(self):
-                """Test that pkg runs properly even with a bad $TERM"""
+        durl = self.dcs[1].get_depot_url()
+        self.image_create(durl)
 
-                durl = self.dcs[1].get_depot_url()
-                self.image_create(durl)
-
-                cmdline = sys.executable + " " + self.pkg_cmdpath + " -R " + \
-                    self.img_path() + " refresh"
-                # give pkg a bad $TERM, make sure it works
-                self.cmdline_run(cmdline, env_arg={"TERM": "moop"}, exit=0,
-                    usepty=True)
-                # give pkg no $TERM, make sure it works
-                self.cmdline_run(cmdline, env_arg={"TERM": ""}, exit=0,
-                    usepty=True)
+        cmdline = (
+            sys.executable
+            + " "
+            + self.pkg_cmdpath
+            + " -R "
+            + self.img_path()
+            + " refresh"
+        )
+        # give pkg a bad $TERM, make sure it works
+        self.cmdline_run(cmdline, env_arg={"TERM": "moop"}, exit=0, usepty=True)
+        # give pkg no $TERM, make sure it works
+        self.cmdline_run(cmdline, env_arg={"TERM": ""}, exit=0, usepty=True)
 
 
 class TestPkgTerminalTesters(pkg5unittest.CliTestCase):
-        """Test the runprintengine and runprogress test utilities."""
-        def setUp(self):
-                pkg5unittest.CliTestCase.setUp(self)
-                self.runprog = sys.executable + " {0}/interactive/runprogress.py".format(
-                    pkg5unittest.g_test_dir)
-                self.runprint = sys.executable + " {0}/interactive/runprintengine.py".format(
-                    pkg5unittest.g_test_dir)
+    """Test the runprintengine and runprogress test utilities."""
 
-        #
-        # This is also an effective way to spot-check certain behaviors of
-        # the printengine and progress trackers that are hard to test in
-        # the API suite-- such as interactions with environment variables.
-        #
-        def test_runprogress(self):
-                """Smoke test the "runprogress" debugging utility"""
-                self.cmdline_run(self.runprog + " -f fancy -", usepty=True)
+    def setUp(self):
+        pkg5unittest.CliTestCase.setUp(self)
+        self.runprog = (
+            sys.executable
+            + " {0}/interactive/runprogress.py".format(pkg5unittest.g_test_dir)
+        )
+        self.runprint = (
+            sys.executable
+            + " {0}/interactive/runprintengine.py".format(
+                pkg5unittest.g_test_dir
+            )
+        )
 
-        def test_runprogress_fancy_notty(self):
-                """Fail when creating a fancy tracker on a non-tty."""
-                self.cmdline_run(self.runprog + " -f fancy -", usepty=False,
-                    exit=1)
+    #
+    # This is also an effective way to spot-check certain behaviors of
+    # the printengine and progress trackers that are hard to test in
+    # the API suite-- such as interactions with environment variables.
+    #
+    def test_runprogress(self):
+        """Smoke test the "runprogress" debugging utility"""
+        self.cmdline_run(self.runprog + " -f fancy -", usepty=True)
 
-        def test_runprogress_badterm(self):
-                """Fail when creating a fancy tracker with bad $TERM."""
-                self.cmdline_run(self.runprog + " -f fancy -", usepty=True,
-                    env_arg={"TERM": "moop"}, exit=1)
-                self.cmdline_run(self.runprog + " -f fancy -", usepty=True,
-                    env_arg={"TERM": ""}, exit=1)
+    def test_runprogress_fancy_notty(self):
+        """Fail when creating a fancy tracker on a non-tty."""
+        self.cmdline_run(self.runprog + " -f fancy -", usepty=False, exit=1)
 
-        def test_runprogress_slowterm(self):
-                """Test fancy progress tracker on a slow terminal."""
-                self.cmdline_run("stty ispeed 9600 ospeed 9600; " +
-                    self.runprog + " -f fancy -", usepty=True)
+    def test_runprogress_badterm(self):
+        """Fail when creating a fancy tracker with bad $TERM."""
+        self.cmdline_run(
+            self.runprog + " -f fancy -",
+            usepty=True,
+            env_arg={"TERM": "moop"},
+            exit=1,
+        )
+        self.cmdline_run(
+            self.runprog + " -f fancy -",
+            usepty=True,
+            env_arg={"TERM": ""},
+            exit=1,
+        )
 
-        def test_runprintengine(self):
-                """Smoke test the "runprintengine" debugging utility"""
-                self.cmdline_run(self.runprint + " -tTl", usepty=True)
+    def test_runprogress_slowterm(self):
+        """Test fancy progress tracker on a slow terminal."""
+        self.cmdline_run(
+            "stty ispeed 9600 ospeed 9600; " + self.runprog + " -f fancy -",
+            usepty=True,
+        )
 
-        def test_runprintengine_notty(self):
-                """Fail when creating a ttymode printengine on a non-tty."""
-                self.cmdline_run(self.runprint + " -t", usepty=False, exit=1)
+    def test_runprintengine(self):
+        """Smoke test the "runprintengine" debugging utility"""
+        self.cmdline_run(self.runprint + " -tTl", usepty=True)
 
-        def test_runprintengine_badterm(self):
-                """Fail when creating a ttymode printengine with a bad $TERM."""
-                self.cmdline_run(self.runprint + " -t", usepty=True,
-                    env_arg={"TERM": "moop"}, exit=1)
-                self.cmdline_run(self.runprint + " -t", usepty=True,
-                    env_arg={"TERM": ""}, exit=1)
+    def test_runprintengine_notty(self):
+        """Fail when creating a ttymode printengine on a non-tty."""
+        self.cmdline_run(self.runprint + " -t", usepty=False, exit=1)
+
+    def test_runprintengine_badterm(self):
+        """Fail when creating a ttymode printengine with a bad $TERM."""
+        self.cmdline_run(
+            self.runprint + " -t", usepty=True, env_arg={"TERM": "moop"}, exit=1
+        )
+        self.cmdline_run(
+            self.runprint + " -t", usepty=True, env_arg={"TERM": ""}, exit=1
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_uninstall.py
+++ b/src/tests/cli/t_pkg_uninstall.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -33,186 +34,184 @@ import unittest
 
 import pkg.fmri as fmri
 
+
 class TestCommandLine(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self,
-                    ["test", "bogus"])
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(self, ["test", "bogus"])
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
 
-        def test_pkg_bogus_opts(self):
-                """ pkg bogus option checks """
+    def test_pkg_bogus_opts(self):
+        """pkg bogus option checks"""
 
-                # create a image to avoid non-existant image messages
-                self.image_create(self.rurl1)
+        # create a image to avoid non-existant image messages
+        self.image_create(self.rurl1)
 
-                self.pkg("uninstall -@ foo", exit=2)
-                self.pkg("uninstall -vq foo", exit=2)
-                self.pkg("uninstall", exit=2)
-                self.pkg("uninstall foo@x.y", exit=1)
-                self.pkg("uninstall pkg:/foo@bar.baz", exit=1)
-                self.image_destroy()
+        self.pkg("uninstall -@ foo", exit=2)
+        self.pkg("uninstall -vq foo", exit=2)
+        self.pkg("uninstall", exit=2)
+        self.pkg("uninstall foo@x.y", exit=1)
+        self.pkg("uninstall pkg:/foo@bar.baz", exit=1)
+        self.image_destroy()
 
-        foo12 = """
+    foo12 = """
             open foo@1.2,5.11-0
             add dir path=/tmp mode=0755 owner=root group=bin
             close """
 
-        def test_rmdir_cwd(self):
-                """Remove a package containing a directory that's our cwd."""
+    def test_rmdir_cwd(self):
+        """Remove a package containing a directory that's our cwd."""
 
-                self.pkgsend_bulk(self.rurl1, self.foo12)
-                self.image_create(self.rurl1)
+        self.pkgsend_bulk(self.rurl1, self.foo12)
+        self.image_create(self.rurl1)
 
-                self.pkg("install foo")
-                os.chdir(os.path.join(self.get_img_path(), "tmp"))
-                self.pkg("uninstall foo")
-                self.image_destroy()
+        self.pkg("install foo")
+        os.chdir(os.path.join(self.get_img_path(), "tmp"))
+        self.pkg("uninstall foo")
+        self.image_destroy()
 
-        foob20 = """
+    foob20 = """
             open foob@2.0,5.11-0
             add depend type=require fmri=barb@2.0
             close """
 
-        barb20 = """
+    barb20 = """
             open barb@2.0,5.11-0
             add depend type=require fmri=foob@2.0
             close """
 
-        bazb20 = """
+    bazb20 = """
             open bazb@2.0,5.11-0
             add depend type=require fmri=foob@2.0
             close """
 
-        def test_dependencies(self):
-                """This code tests for:
-                  1) uninstall is blocked if dependencies are found
-                  2) packages w/ circular dependencies can be uninstalled
-                  3) if all dependencies are to be deleted, uninstall works."""
-                self.pkgsend_bulk(self.rurl1, (self.foob20, self.barb20,
-                    self.bazb20))
-                self.image_create(self.rurl1)
-                self.pkg("install bazb")
-                self.pkg("verify")
-                self.pkg("uninstall foob", exit=1)
-                self.pkg("uninstall bazb foob barb")
-                self.pkg("verify")
-                self.image_destroy()
+    def test_dependencies(self):
+        """This code tests for:
+        1) uninstall is blocked if dependencies are found
+        2) packages w/ circular dependencies can be uninstalled
+        3) if all dependencies are to be deleted, uninstall works."""
+        self.pkgsend_bulk(self.rurl1, (self.foob20, self.barb20, self.bazb20))
+        self.image_create(self.rurl1)
+        self.pkg("install bazb")
+        self.pkg("verify")
+        self.pkg("uninstall foob", exit=1)
+        self.pkg("uninstall bazb foob barb")
+        self.pkg("verify")
+        self.image_destroy()
 
-        quux10 = """
+    quux10 = """
             open quux@1.0,5.11-0
             close """
 
-        renamed10 = """
+    renamed10 = """
             open renamed@1.0,5.11-0
             add set name=pkg.renamed value=true
             add depend type=require fmri=quux@1.0
             close """
 
-        holder10 = """
+    holder10 = """
             open holder@1.0,5.11-0
             add depend type=require fmri=renamed@1.0
             close """
 
-        implicit11 = """
+    implicit11 = """
             open implicit@1.1,5.11-0
             add file tmp/file1 mode=0644 owner=root group=bin path=implicit/file1
             close """
 
-        def test_uninstalled_state(self):
-                """Uninstalling a package that is no longer known should result
-                in its removal from the output of pkg list -a, even if it has
-                been renamed, etc.""" 
+    def test_uninstalled_state(self):
+        """Uninstalling a package that is no longer known should result
+        in its removal from the output of pkg list -a, even if it has
+        been renamed, etc."""
 
-                self.pkgsend_bulk(self.rurl1, (self.quux10, self.renamed10,
-                    self.holder10))
-                self.image_create(self.rurl1)
-                self.pkg("install -v renamed holder")
-                self.pkg("verify")
-                self.pkg("set-publisher -P -g {0} bogus".format(self.rurl2))
-                self.pkg("unset-publisher test")
-                self.pkg("info quux@1.0 renamed@1.0")
-                self.pkg("uninstall holder renamed")
-                self.pkg("list -a renamed@1.0", exit=1)
-                self.pkg("uninstall quux")
-                self.pkg("list -a quux@1.0", exit=1)
-                self.image_destroy()
+        self.pkgsend_bulk(
+            self.rurl1, (self.quux10, self.renamed10, self.holder10)
+        )
+        self.image_create(self.rurl1)
+        self.pkg("install -v renamed holder")
+        self.pkg("verify")
+        self.pkg("set-publisher -P -g {0} bogus".format(self.rurl2))
+        self.pkg("unset-publisher test")
+        self.pkg("info quux@1.0 renamed@1.0")
+        self.pkg("uninstall holder renamed")
+        self.pkg("list -a renamed@1.0", exit=1)
+        self.pkg("uninstall quux")
+        self.pkg("list -a quux@1.0", exit=1)
+        self.image_destroy()
 
-        def test_uninstall_implicit(self):
-                """Verify uninstall fails gracefully if needed during implicit
-                directory removal.""" 
+    def test_uninstall_implicit(self):
+        """Verify uninstall fails gracefully if needed during implicit
+        directory removal."""
 
-                self.make_misc_files("tmp/file1")
-                self.pkgsend_bulk(self.rurl1, (self.implicit11))
-                self.image_create(self.rurl1)
-                lofs_dir = os.path.join(self.test_root, "image0", "implicit")
-                os.mkdir(lofs_dir)
-                tmp_dir = os.path.join(self.test_root, "image0", "tmp_impl_dir")
-                os.mkdir(tmp_dir)
-                os.system("mount -F lofs {0} {1}".format(tmp_dir, lofs_dir))
-                self.pkg("install implicit")
-                self.pkg("uninstall implicit")
-                os.system("umount {0} ".format(lofs_dir))
-                os.rmdir(lofs_dir)
-                os.rmdir(tmp_dir)
+        self.make_misc_files("tmp/file1")
+        self.pkgsend_bulk(self.rurl1, (self.implicit11))
+        self.image_create(self.rurl1)
+        lofs_dir = os.path.join(self.test_root, "image0", "implicit")
+        os.mkdir(lofs_dir)
+        tmp_dir = os.path.join(self.test_root, "image0", "tmp_impl_dir")
+        os.mkdir(tmp_dir)
+        os.system("mount -F lofs {0} {1}".format(tmp_dir, lofs_dir))
+        self.pkg("install implicit")
+        self.pkg("uninstall implicit")
+        os.system("umount {0} ".format(lofs_dir))
+        os.rmdir(lofs_dir)
+        os.rmdir(tmp_dir)
 
-        def test_uninstall_missing_manifest(self):
-                """Verify graceful failure if a package being removed has a
-                missing manifest."""
+    def test_uninstall_missing_manifest(self):
+        """Verify graceful failure if a package being removed has a
+        missing manifest."""
 
-                def remove_man(pfmri):
-                        # Now remove the manifest and manifest cache for package
-                        # and retry the info for an unprivileged user both local
-                        # and remote.
-                        mdir = os.path.dirname(self.get_img_manifest_path(
-                            pfmri))
-                        shutil.rmtree(mdir)
-                        self.assertFalse(os.path.exists(mdir))
+        def remove_man(pfmri):
+            # Now remove the manifest and manifest cache for package
+            # and retry the info for an unprivileged user both local
+            # and remote.
+            mdir = os.path.dirname(self.get_img_manifest_path(pfmri))
+            shutil.rmtree(mdir)
+            self.assertFalse(os.path.exists(mdir))
 
-                        mcdir = self.get_img_manifest_cache_dir(pfmri)
-                        shutil.rmtree(mcdir)
-                        self.assertFalse(os.path.exists(mcdir))
+            mcdir = self.get_img_manifest_cache_dir(pfmri)
+            shutil.rmtree(mcdir)
+            self.assertFalse(os.path.exists(mcdir))
 
-                pfmri = fmri.PkgFmri(self.pkgsend_bulk(self.rurl1,
-                    self.quux10)[0])
-                self.image_create(self.rurl1)
+        pfmri = fmri.PkgFmri(self.pkgsend_bulk(self.rurl1, self.quux10)[0])
+        self.image_create(self.rurl1)
 
-                # Install a package.
-                self.pkg("install quux")
+        # Install a package.
+        self.pkg("install quux")
 
-                # Should succeed since original manifest can still be retrieved.
-                remove_man(pfmri)
-                self.pkg("uninstall -nv quux")
-                remove_man(pfmri)
+        # Should succeed since original manifest can still be retrieved.
+        remove_man(pfmri)
+        self.pkg("uninstall -nv quux")
+        remove_man(pfmri)
 
-                # Should fail since publisher no longer exists and should
-                # explain why.
-                self.pkg("unset-publisher test")
-                self.pkg("uninstall -nv quux", exit=1)
-                self.assertTrue(len(self.errout) > 1)
-                self.assertTrue("no errors" not in self.errout, self.errout)
-                self.assertTrue("Unknown" not in self.errout, self.errout)
+        # Should fail since publisher no longer exists and should
+        # explain why.
+        self.pkg("unset-publisher test")
+        self.pkg("uninstall -nv quux", exit=1)
+        self.assertTrue(len(self.errout) > 1)
+        self.assertTrue("no errors" not in self.errout, self.errout)
+        self.assertTrue("Unknown" not in self.errout, self.errout)
 
-                # Should fail because publisher has no configured repositories
-                # and should explain why.
-                self.pkg("set-publisher test")
-                self.pkg("uninstall -nv quux", exit=1)
-                self.assertTrue("no errors" not in self.errout, self.errout)
-                self.assertTrue("Unknown" not in self.errout, self.errout)
+        # Should fail because publisher has no configured repositories
+        # and should explain why.
+        self.pkg("set-publisher test")
+        self.pkg("uninstall -nv quux", exit=1)
+        self.assertTrue("no errors" not in self.errout, self.errout)
+        self.assertTrue("Unknown" not in self.errout, self.errout)
 
-        def test_ignore_missing(self):
-                """Test that uninstall shows correct behavior w/ and w/o
-                   --ignore-missing."""
-                self.image_create(self.rurl1)
-                self.pkg("uninstall missing", exit=1)
-                self.pkg("uninstall --ignore-missing missing", exit=4)
+    def test_ignore_missing(self):
+        """Test that uninstall shows correct behavior w/ and w/o
+        --ignore-missing."""
+        self.image_create(self.rurl1)
+        self.pkg("uninstall missing", exit=1)
+        self.pkg("uninstall --ignore-missing missing", exit=4)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_varcet.py
+++ b/src/tests/cli/t_pkg_varcet.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -40,12 +41,12 @@ import unittest
 
 from pkg.client.pkgdefs import EXIT_OOPS
 
+
 class TestPkgVarcet(pkg5unittest.SingleDepotTestCase):
+    # Don't discard repository or setUp() every test.
+    persistent_setup = True
 
-        # Don't discard repository or setUp() every test.
-        persistent_setup = True
-
-        pkg_foo = """
+    pkg_foo = """
             open foo@1.0
             add file tmp/non-debug path=usr/bin/foo mode=0755 owner=root group=root
             add file tmp/man path=usr/man/man1/foo.1 mode=0444 owner=root group=root
@@ -72,618 +73,696 @@ class TestPkgVarcet(pkg5unittest.SingleDepotTestCase):
             add file tmp/pdf path=usr/share/foo/README.pdf mode=0444 owner=root group=root facet.doc.pdf=true
             close """
 
-        pkg_unknown = """
+    pkg_unknown = """
             open unknown@1.0
             add set name=variant.unknown value=bar value=foo
             add file tmp/non-debug path=usr/bin/bar mode=0755 owner=root group=root variant.unknown=bar
             add file tmp/non-debug path=usr/bin/foo mode=0755 owner=root group=root variant.unknown=foo
             close """
 
-        pkg_need_foo = """
+    pkg_need_foo = """
             open need_foo@1.0
             add depend type=require fmri=foo
             """
 
-        misc_files = ["tmp/debug", "tmp/non-debug", "tmp/neapolitan",
-            "tmp/strawberry", "tmp/doc", "tmp/man", "tmp/pdf"]
+    misc_files = [
+        "tmp/debug",
+        "tmp/non-debug",
+        "tmp/neapolitan",
+        "tmp/strawberry",
+        "tmp/doc",
+        "tmp/man",
+        "tmp/pdf",
+    ]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                self.pkgsend_bulk(self.rurl, [
-                    getattr(self, p)
-                    for p in dir(self)
-                    if p.startswith("pkg_") and isinstance(getattr(self, p),
-                        six.string_types)
-                ])
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        self.pkgsend_bulk(
+            self.rurl,
+            [
+                getattr(self, p)
+                for p in dir(self)
+                if p.startswith("pkg_")
+                and isinstance(getattr(self, p), six.string_types)
+            ],
+        )
 
-        def __assert_varcet_matches_default(self, cmd, expected, errout=None,
-            exit=0, opts=misc.EmptyI, names=misc.EmptyI, su_wrap=False):
-                if errout is None and exit != 0:
-                        # Assume there should be error output for non-zero exit
-                        # if not explicitly indicated.
-                        errout = True
+    def __assert_varcet_matches_default(
+        self,
+        cmd,
+        expected,
+        errout=None,
+        exit=0,
+        opts=misc.EmptyI,
+        names=misc.EmptyI,
+        su_wrap=False,
+    ):
+        if errout is None and exit != 0:
+            # Assume there should be error output for non-zero exit
+            # if not explicitly indicated.
+            errout = True
 
-                self.pkg("{0} {1} -H {2}".format(cmd, " ".join(opts), " ".join(names)),
-                    exit=exit, su_wrap=su_wrap)
-                self.assertEqualDiff(expected, self.reduceSpaces(self.output))
-                if errout:
-                        self.assertTrue(self.errout != "")
-                else:
-                        self.assertEqualDiff("", self.errout)
+        self.pkg(
+            "{0} {1} -H {2}".format(cmd, " ".join(opts), " ".join(names)),
+            exit=exit,
+            su_wrap=su_wrap,
+        )
+        self.assertEqualDiff(expected, self.reduceSpaces(self.output))
+        if errout:
+            self.assertTrue(self.errout != "")
+        else:
+            self.assertEqualDiff("", self.errout)
 
-        def __assert_varcet_matches_tsv(self, cmd, prefix, expected, errout=None,
-            exit=0, opts=misc.EmptyI, names=misc.EmptyI, su_wrap=False):
-                self.pkg("{0} {1} -H -F tsv {2}".format(cmd, " ".join(opts),
-                    " ".join(names)), exit=exit, su_wrap=su_wrap)
-                expected = "".join(
-                        (prefix + l)
-                        for l in expected.splitlines(True)
-                )
-                self.assertEqualDiff(expected, self.output)
-                if errout:
-                        self.assertTrue(self.errout != "")
-                else:
-                        self.assertEqualDiff("", self.errout)
+    def __assert_varcet_matches_tsv(
+        self,
+        cmd,
+        prefix,
+        expected,
+        errout=None,
+        exit=0,
+        opts=misc.EmptyI,
+        names=misc.EmptyI,
+        su_wrap=False,
+    ):
+        self.pkg(
+            "{0} {1} -H -F tsv {2}".format(
+                cmd, " ".join(opts), " ".join(names)
+            ),
+            exit=exit,
+            su_wrap=su_wrap,
+        )
+        expected = "".join((prefix + l) for l in expected.splitlines(True))
+        self.assertEqualDiff(expected, self.output)
+        if errout:
+            self.assertTrue(self.errout != "")
+        else:
+            self.assertEqualDiff("", self.errout)
 
-        def __assert_varcet_fails(self, cmd, operands, errout=True, exit=1,
-            su_wrap=False):
-                self.pkg("{0} {1}".format(cmd, operands), exit=exit, su_wrap=su_wrap)
-                if errout:
-                        self.assertTrue(self.errout != "")
-                else:
-                        self.assertEqualDiff("", self.errout)
+    def __assert_varcet_fails(
+        self, cmd, operands, errout=True, exit=1, su_wrap=False
+    ):
+        self.pkg("{0} {1}".format(cmd, operands), exit=exit, su_wrap=su_wrap)
+        if errout:
+            self.assertTrue(self.errout != "")
+        else:
+            self.assertEqualDiff("", self.errout)
 
-        def __assert_facet_matches_default(self, *args, **kwargs):
-                self.__assert_varcet_matches_default("facet", *args,
-                    **kwargs)
+    def __assert_facet_matches_default(self, *args, **kwargs):
+        self.__assert_varcet_matches_default("facet", *args, **kwargs)
 
-        def __assert_facet_matches_tsv(self, *args, **kwargs):
-                self.__assert_varcet_matches_tsv("facet", "facet.", *args,
-                    **kwargs)
+    def __assert_facet_matches_tsv(self, *args, **kwargs):
+        self.__assert_varcet_matches_tsv("facet", "facet.", *args, **kwargs)
 
-        def __assert_facet_matches(self, exp_def, **kwargs):
-                exp_tsv = exp_def.replace(" ", "\t")
-                self.__assert_varcet_matches_default("facet", exp_def,
-                    **kwargs)
-                self.__assert_varcet_matches_tsv("facet", "facet.", exp_tsv,
-                    **kwargs)
+    def __assert_facet_matches(self, exp_def, **kwargs):
+        exp_tsv = exp_def.replace(" ", "\t")
+        self.__assert_varcet_matches_default("facet", exp_def, **kwargs)
+        self.__assert_varcet_matches_tsv("facet", "facet.", exp_tsv, **kwargs)
 
-        def __assert_facet_fails(self, *args, **kwargs):
-                self.__assert_varcet_fails("facet", *args, **kwargs)
+    def __assert_facet_fails(self, *args, **kwargs):
+        self.__assert_varcet_fails("facet", *args, **kwargs)
 
-        def __assert_variant_matches_default(self, *args, **kwargs):
-                self.__assert_varcet_matches_default("variant", *args,
-                    **kwargs)
+    def __assert_variant_matches_default(self, *args, **kwargs):
+        self.__assert_varcet_matches_default("variant", *args, **kwargs)
 
-        def __assert_variant_matches_tsv(self, *args, **kwargs):
-                self.__assert_varcet_matches_tsv("variant", "", *args,
-                    **kwargs)
+    def __assert_variant_matches_tsv(self, *args, **kwargs):
+        self.__assert_varcet_matches_tsv("variant", "", *args, **kwargs)
 
-        def __assert_variant_matches(self, exp_def, **kwargs):
-                exp_tsv = exp_def.replace(" ", "\t")
-                self.__assert_varcet_matches_default("variant", exp_def,
-                    **kwargs)
-                self.__assert_varcet_matches_tsv("variant", "variant.", exp_tsv,
-                    **kwargs)
+    def __assert_variant_matches(self, exp_def, **kwargs):
+        exp_tsv = exp_def.replace(" ", "\t")
+        self.__assert_varcet_matches_default("variant", exp_def, **kwargs)
+        self.__assert_varcet_matches_tsv(
+            "variant", "variant.", exp_tsv, **kwargs
+        )
 
-        def __assert_variant_fails(self, *args, **kwargs):
-                self.__assert_varcet_fails("variant", *args, **kwargs)
+    def __assert_variant_fails(self, *args, **kwargs):
+        self.__assert_varcet_fails("variant", *args, **kwargs)
 
-        def __test_foo_facet_upgrade(self, pkg):
-                #
-                # Next, verify output after upgrading package to faceted
-                # version.
-                #
-                self.pkg("update {0}".format(pkg))
+    def __test_foo_facet_upgrade(self, pkg):
+        #
+        # Next, verify output after upgrading package to faceted
+        # version.
+        #
+        self.pkg("update {0}".format(pkg))
 
-                # Verify output for no options and no patterns.
-                exp_def = """\
+        # Verify output for no options and no patterns.
+        exp_def = """\
 doc.* False local
 doc.html False local
 doc.man False local
 doc.txt True local
 """
-                self.__assert_facet_matches(exp_def)
+        self.__assert_facet_matches(exp_def)
 
-                # Matched because facet is implicitly set.
-                exp_def = """\
+        # Matched because facet is implicitly set.
+        exp_def = """\
 doc.pdf False local
 """
-                self.__assert_facet_matches(exp_def, names=["doc.pdf"])
+        self.__assert_facet_matches(exp_def, names=["doc.pdf"])
 
-                # Unmatched because facet is not explicitly set.
-                self.__assert_facet_fails("'*pdf'")
+        # Unmatched because facet is not explicitly set.
+        self.__assert_facet_fails("'*pdf'")
 
-                # Matched case for explicitly set.
-                exp_def = """\
+        # Matched case for explicitly set.
+        exp_def = """\
 doc.* False local
 doc.txt True local
 """
-                names = ("'facet.doc.[*]'", "doc.txt")
-                self.__assert_facet_matches(exp_def, names=names)
+        names = ("'facet.doc.[*]'", "doc.txt")
+        self.__assert_facet_matches(exp_def, names=names)
 
-                # Verify -a output.
-                exp_def = """\
-doc.* False local
-doc.html False local
-doc.man False local
-doc.pdf False local
-doc.txt True local
-"""
-                opts = ("-a",)
-                self.__assert_facet_matches(exp_def, opts=opts)
-
-                # Matched case for explicitly set and those in packages.
-                exp_def = """\
-doc.* False local
-doc.pdf False local
-doc.txt True local
-"""
-                names = ("'facet.doc.[*]'", "*pdf", "facet.doc.txt")
-                opts = ("-a",)
-                self.__assert_facet_matches(exp_def, opts=opts, names=names)
-
-                # Verify -i output.
-                exp_def = """\
-doc.man False local
-doc.pdf False local
-doc.txt True local
-"""
-                opts = ("-i",)
-                self.__assert_facet_matches(exp_def, opts=opts)
-
-                # Unmatched because facet is not used in package.
-                self.__assert_facet_fails("-i doc.html")
-                self.__assert_facet_fails("-i '*html'")
-
-                # Matched case in packages.
-                exp_def = """\
-doc.man False local
-doc.pdf False local
-"""
-                names = ("'facet.*[!t]'",)
-                opts = ("-i",)
-                self.__assert_facet_matches(exp_def, opts=opts, names=names)
-
-                exp_def = """\
-doc.pdf False local
-"""
-                names = ("'*pdf'",)
-                opts = ("-i",)
-                self.__assert_facet_matches(exp_def, opts=opts, names=names)
-
-                # Now uninstall package and verify output (to ensure any
-                # potentially cached information has been updated).
-                self.pkg("uninstall foo")
-
-                exp_def = """\
+        # Verify -a output.
+        exp_def = """\
 doc.* False local
 doc.html False local
 doc.man False local
+doc.pdf False local
 doc.txt True local
 """
+        opts = ("-a",)
+        self.__assert_facet_matches(exp_def, opts=opts)
 
-                # Output should be the same for both -a and default cases with
-                # no packages installed.
-                for opts in ((), ("-a",)):
-                        self.__assert_facet_matches(exp_def, opts=opts)
+        # Matched case for explicitly set and those in packages.
+        exp_def = """\
+doc.* False local
+doc.pdf False local
+doc.txt True local
+"""
+        names = ("'facet.doc.[*]'", "*pdf", "facet.doc.txt")
+        opts = ("-a",)
+        self.__assert_facet_matches(exp_def, opts=opts, names=names)
 
-                # No output expected for -i.
-                opts = ("-i",)
-                self.__assert_facet_matches("", opts=opts)
+        # Verify -i output.
+        exp_def = """\
+doc.man False local
+doc.pdf False local
+doc.txt True local
+"""
+        opts = ("-i",)
+        self.__assert_facet_matches(exp_def, opts=opts)
 
-        def test_00_facet(self):
-                """Verify facet subcommand works as expected."""
+        # Unmatched because facet is not used in package.
+        self.__assert_facet_fails("-i doc.html")
+        self.__assert_facet_fails("-i '*html'")
 
-                # create an image
-                variants = { "variant.icecream": "strawberry" }
-                self.image_create(self.rurl, variants=variants)
+        # Matched case in packages.
+        exp_def = """\
+doc.man False local
+doc.pdf False local
+"""
+        names = ("'facet.*[!t]'",)
+        opts = ("-i",)
+        self.__assert_facet_matches(exp_def, opts=opts, names=names)
 
-                # Verify invalid options handled gracefully.
-                self.__assert_facet_fails("-z", exit=2)
-                self.__assert_facet_fails("-fi", exit=2)
+        exp_def = """\
+doc.pdf False local
+"""
+        names = ("'*pdf'",)
+        opts = ("-i",)
+        self.__assert_facet_matches(exp_def, opts=opts, names=names)
 
-                #
-                # First, verify output before setting any facets or installing
-                # any packages.
-                #
+        # Now uninstall package and verify output (to ensure any
+        # potentially cached information has been updated).
+        self.pkg("uninstall foo")
 
-                # Output should be the same for all cases with no facets set and
-                # no packages installed.
-                for opts in ((), ("-i",), ("-a",)):
-                        # No operands specified case.
-                        self.__assert_facet_matches("", opts=opts)
-
-                        # Unprivileged user case.
-                        self.__assert_facet_matches("", opts=opts, su_wrap=True)
-
-                # Fails because not used by any installed package.
-                self.__assert_facet_fails("-i bogus")
-
-                # Succeeds because implicitly set in image.
-                self.__assert_facet_matches_tsv("bogus\tTrue\tsystem\n",
-                    opts=("-a",), names=("bogus",))
-
-                #
-                # Next, verify output after setting facets.
-                #
-
-                # Set some facets.
-                self.pkg("change-facet 'doc.*=False' doc.man=False "
-                    "facet.doc.html=False facet.doc.txt=True")
-
-                exp_def = """\
+        exp_def = """\
 doc.* False local
 doc.html False local
 doc.man False local
 doc.txt True local
 """
 
-                # Output should be the same for both -a and default cases with
-                # no packages installed.
-                for opts in ((), ("-a",)):
-                        self.__assert_facet_matches(exp_def, opts=opts)
+        # Output should be the same for both -a and default cases with
+        # no packages installed.
+        for opts in ((), ("-a",)):
+            self.__assert_facet_matches(exp_def, opts=opts)
 
-                #
-                # Next, verify output after installing unfaceted package.
-                #
-                self.pkg("install foo@1.0")
+        # No output expected for -i.
+        opts = ("-i",)
+        self.__assert_facet_matches("", opts=opts)
 
-                # Verify output for no options and no patterns.
-                exp_def = """\
+    def test_00_facet(self):
+        """Verify facet subcommand works as expected."""
+
+        # create an image
+        variants = {"variant.icecream": "strawberry"}
+        self.image_create(self.rurl, variants=variants)
+
+        # Verify invalid options handled gracefully.
+        self.__assert_facet_fails("-z", exit=2)
+        self.__assert_facet_fails("-fi", exit=2)
+
+        #
+        # First, verify output before setting any facets or installing
+        # any packages.
+        #
+
+        # Output should be the same for all cases with no facets set and
+        # no packages installed.
+        for opts in ((), ("-i",), ("-a",)):
+            # No operands specified case.
+            self.__assert_facet_matches("", opts=opts)
+
+            # Unprivileged user case.
+            self.__assert_facet_matches("", opts=opts, su_wrap=True)
+
+        # Fails because not used by any installed package.
+        self.__assert_facet_fails("-i bogus")
+
+        # Succeeds because implicitly set in image.
+        self.__assert_facet_matches_tsv(
+            "bogus\tTrue\tsystem\n", opts=("-a",), names=("bogus",)
+        )
+
+        #
+        # Next, verify output after setting facets.
+        #
+
+        # Set some facets.
+        self.pkg(
+            "change-facet 'doc.*=False' doc.man=False "
+            "facet.doc.html=False facet.doc.txt=True"
+        )
+
+        exp_def = """\
 doc.* False local
 doc.html False local
 doc.man False local
 doc.txt True local
 """
-                self.__assert_facet_matches(exp_def)
 
-                # Verify -a output.
-                opts = ("-a",)
-                self.__assert_facet_matches(exp_def, opts=opts)
+        # Output should be the same for both -a and default cases with
+        # no packages installed.
+        for opts in ((), ("-a",)):
+            self.__assert_facet_matches(exp_def, opts=opts)
 
-                # Verify -i output.
-                opts = ("-i",)
-                self.__assert_facet_matches("", opts=opts)
+        #
+        # Next, verify output after installing unfaceted package.
+        #
+        self.pkg("install foo@1.0")
 
-                # Test upgraded package that does not declare all
-                # facets/variants.
-                self.__test_foo_facet_upgrade("foo@2.0")
+        # Verify output for no options and no patterns.
+        exp_def = """\
+doc.* False local
+doc.html False local
+doc.man False local
+doc.txt True local
+"""
+        self.__assert_facet_matches(exp_def)
 
-                # Reinstall and then retest with upgraded package that declares
-                # all facets/variants.
-                self.pkg("install foo@1.0")
-                self.__test_foo_facet_upgrade("foo@3.0")
+        # Verify -a output.
+        opts = ("-a",)
+        self.__assert_facet_matches(exp_def, opts=opts)
 
-        def __test_foo_variant_upgrade(self, pkg, variants):
-                #
-                # Next, verify output after upgrading package to varianted
-                # version.
-                #
-                self.pkg("update {0}".format(pkg))
+        # Verify -i output.
+        opts = ("-i",)
+        self.__assert_facet_matches("", opts=opts)
 
-                # Verify output for no options and no patterns.
-                exp_def = """\
+        # Test upgraded package that does not declare all
+        # facets/variants.
+        self.__test_foo_facet_upgrade("foo@2.0")
+
+        # Reinstall and then retest with upgraded package that declares
+        # all facets/variants.
+        self.pkg("install foo@1.0")
+        self.__test_foo_facet_upgrade("foo@3.0")
+
+    def __test_foo_variant_upgrade(self, pkg, variants):
+        #
+        # Next, verify output after upgrading package to varianted
+        # version.
+        #
+        self.pkg("update {0}".format(pkg))
+
+        # Verify output for no options and no patterns.
+        exp_def = """\
 arch {0[variant.arch]}
 icecream strawberry
 opensolaris.imagetype full
 opensolaris.zone global
-""".format(variants)
-                self.__assert_variant_matches(exp_def)
+""".format(
+            variants
+        )
+        self.__assert_variant_matches(exp_def)
 
-                # Matched because variant is implicitly false.
-                exp_def = """\
+        # Matched because variant is implicitly false.
+        exp_def = """\
 debug.foo false
-""".format(variants)
-                self.__assert_variant_matches(exp_def, names=["debug.foo"])
+""".format(
+            variants
+        )
+        self.__assert_variant_matches(exp_def, names=["debug.foo"])
 
-                # Unmatched because variant is not explicitly set.
-                self.__assert_variant_fails("'*foo'")
+        # Unmatched because variant is not explicitly set.
+        self.__assert_variant_fails("'*foo'")
 
-                # Matched case for explicitly set.
-                exp_def = """\
+        # Matched case for explicitly set.
+        exp_def = """\
 arch {0[variant.arch]}
 opensolaris.imagetype full
 opensolaris.zone global
-""".format(variants)
-                names = ("arch", "'variant.*imagetype'", "'variant.*zone'")
-                self.__assert_variant_matches(exp_def, names=names)
+""".format(
+            variants
+        )
+        names = ("arch", "'variant.*imagetype'", "'variant.*zone'")
+        self.__assert_variant_matches(exp_def, names=names)
 
-                # Verify -a output.
-                exp_def = """\
+        # Verify -a output.
+        exp_def = """\
 arch {0[variant.arch]}
 debug.foo false
 icecream strawberry
 opensolaris.imagetype full
 opensolaris.zone global
-""".format(variants)
-                opts = ("-a",)
-                self.__assert_variant_matches(exp_def, opts=opts)
+""".format(
+            variants
+        )
+        opts = ("-a",)
+        self.__assert_variant_matches(exp_def, opts=opts)
 
-                # Matched case for explicitly set and those in packages.
-                exp_def = """\
+        # Matched case for explicitly set and those in packages.
+        exp_def = """\
 arch {0[variant.arch]}
 debug.foo false
 opensolaris.imagetype full
 opensolaris.zone global
-""".format(variants)
-                names = ("'variant.debug.*'", "arch", "'*imagetype'", "'*zone'")
-                opts = ("-a",)
-                self.__assert_variant_matches(exp_def, opts=opts, names=names)
+""".format(
+            variants
+        )
+        names = ("'variant.debug.*'", "arch", "'*imagetype'", "'*zone'")
+        opts = ("-a",)
+        self.__assert_variant_matches(exp_def, opts=opts, names=names)
 
-                # Verify -i output.
-                exp_def = """\
+        # Verify -i output.
+        exp_def = """\
 debug.foo false
 icecream strawberry
-""".format(variants)
-                opts = ("-i",)
-                self.__assert_variant_matches(exp_def, opts=opts)
+""".format(
+            variants
+        )
+        opts = ("-i",)
+        self.__assert_variant_matches(exp_def, opts=opts)
 
-                # Unmatched because variant is not used in package.
-                self.__assert_variant_fails("-i opensolaris.zone")
-                self.__assert_variant_fails("-i opensolaris.imagetype")
-                self.__assert_variant_fails("-i '*arch'")
+        # Unmatched because variant is not used in package.
+        self.__assert_variant_fails("-i opensolaris.zone")
+        self.__assert_variant_fails("-i opensolaris.imagetype")
+        self.__assert_variant_fails("-i '*arch'")
 
-                # Verify -v and -av output.
-                exp_def = """\
+        # Verify -v and -av output.
+        exp_def = """\
 debug.foo false
 debug.foo true
 icecream neapolitan
 icecream strawberry
 """
-                for opts in (("-v",), ("-av",)):
-                        self.__assert_variant_matches(exp_def, opts=opts)
+        for opts in (("-v",), ("-av",)):
+            self.__assert_variant_matches(exp_def, opts=opts)
 
-                exp_def = """\
+        exp_def = """\
 icecream neapolitan
 icecream strawberry
-""".format(variants)
-                names = ("'ice*'",)
-                opts = ("-av",)
-                self.__assert_variant_matches(exp_def, opts=opts, names=names)
+""".format(
+            variants
+        )
+        names = ("'ice*'",)
+        opts = ("-av",)
+        self.__assert_variant_matches(exp_def, opts=opts, names=names)
 
-                # Matched case in packages.
-                exp_def = """\
+        # Matched case in packages.
+        exp_def = """\
 icecream strawberry
-""".format(variants)
-                names = ("'variant.*[!o]'",)
-                opts = ("-i",)
-                self.__assert_variant_matches(exp_def, opts=opts, names=names)
+""".format(
+            variants
+        )
+        names = ("'variant.*[!o]'",)
+        opts = ("-i",)
+        self.__assert_variant_matches(exp_def, opts=opts, names=names)
 
-                exp_def = """\
+        exp_def = """\
 debug.foo false
-""".format(variants)
-                names = ("*foo",)
-                opts = ("-i",)
-                self.__assert_variant_matches(exp_def, opts=opts, names=names)
+""".format(
+            variants
+        )
+        names = ("*foo",)
+        opts = ("-i",)
+        self.__assert_variant_matches(exp_def, opts=opts, names=names)
 
-                # Now uninstall package and verify output (to ensure any
-                # potentially cached information has been updated).
-                self.pkg("uninstall foo")
+        # Now uninstall package and verify output (to ensure any
+        # potentially cached information has been updated).
+        self.pkg("uninstall foo")
 
-                exp_def = """\
+        exp_def = """\
 arch {0[variant.arch]}
 icecream strawberry
 opensolaris.imagetype full
 opensolaris.zone global
-""".format(variants)
+""".format(
+            variants
+        )
 
-                # Output should be the same for both -a and default cases with
-                # no packages installed.
-                for opts in ((), ("-a",)):
-                        self.__assert_variant_matches(exp_def, opts=opts)
+        # Output should be the same for both -a and default cases with
+        # no packages installed.
+        for opts in ((), ("-a",)):
+            self.__assert_variant_matches(exp_def, opts=opts)
 
-                # No output expected for -v, -av, -i, or -iv.
-                for opts in (("-v",), ("-av",), ("-i",), ("-iv",)):
-                        self.__assert_variant_matches("", opts=opts)
+        # No output expected for -v, -av, -i, or -iv.
+        for opts in (("-v",), ("-av",), ("-i",), ("-iv",)):
+            self.__assert_variant_matches("", opts=opts)
 
-        def test_01_variant(self):
-                """Verify variant subcommand works as expected."""
+    def test_01_variant(self):
+        """Verify variant subcommand works as expected."""
 
-                # create an image
-                self.image_create(self.rurl)
+        # create an image
+        self.image_create(self.rurl)
 
-                # Get variant data.
-                api_obj = self.get_img_api_obj()
-                variants = dict(v[:-1] for v in api_obj.gen_variants(
-                    api_obj.VARIANT_IMAGE))
+        # Get variant data.
+        api_obj = self.get_img_api_obj()
+        variants = dict(
+            v[:-1] for v in api_obj.gen_variants(api_obj.VARIANT_IMAGE)
+        )
 
-                # Verify invalid options handled gracefully.
-                self.__assert_variant_fails("-z", exit=2)
-                self.__assert_variant_fails("-ai", exit=2)
-                self.__assert_variant_fails("-aiv", exit=2)
+        # Verify invalid options handled gracefully.
+        self.__assert_variant_fails("-z", exit=2)
+        self.__assert_variant_fails("-ai", exit=2)
+        self.__assert_variant_fails("-aiv", exit=2)
 
-                # Verify valid output format values do not cause failure
-                self.__assert_variant_fails("-F default", exit=0, errout=False)
-                self.__assert_variant_fails("--output-format default", exit=0,
-                    errout=False)
+        # Verify valid output format values do not cause failure
+        self.__assert_variant_fails("-F default", exit=0, errout=False)
+        self.__assert_variant_fails(
+            "--output-format default", exit=0, errout=False
+        )
 
-                self.__assert_variant_fails("-F  json", exit=0, errout=False)
-                self.__assert_variant_fails("--output-format  json", exit=0,
-                    errout=False)
+        self.__assert_variant_fails("-F  json", exit=0, errout=False)
+        self.__assert_variant_fails(
+            "--output-format  json", exit=0, errout=False
+        )
 
-                # Verify invalid output format values handled gracefully
-                self.__assert_variant_fails("-F dummy", exit=2)
-                self.__assert_variant_fails("--output-format dummy", exit=2)
+        # Verify invalid output format values handled gracefully
+        self.__assert_variant_fails("-F dummy", exit=2)
+        self.__assert_variant_fails("--output-format dummy", exit=2)
 
-                #
-                # First, verify output before setting any variants or installing
-                # any packages.
-                #
+        #
+        # First, verify output before setting any variants or installing
+        # any packages.
+        #
 
-                # Output should be the same for -a and default cases with no
-                # variants set and no packages installed.
-                exp_def = """\
+        # Output should be the same for -a and default cases with no
+        # variants set and no packages installed.
+        exp_def = """\
 arch {0[variant.arch]}
 opensolaris.imagetype full
 opensolaris.zone global
-""".format(variants)
+""".format(
+            variants
+        )
 
-                for opts in ((), ("-a",)):
-                        # No operands specified case.
-                        self.__assert_variant_matches(exp_def, opts=opts)
+        for opts in ((), ("-a",)):
+            # No operands specified case.
+            self.__assert_variant_matches(exp_def, opts=opts)
 
-                        # Unprivileged user case.
-                        self.__assert_variant_matches(exp_def, opts=opts,
-                            su_wrap=True)
+            # Unprivileged user case.
+            self.__assert_variant_matches(exp_def, opts=opts, su_wrap=True)
 
-                        # Unmatched case.
-                        self.__assert_variant_matches_default("", opts=opts,
-                            names=("bogus",), exit=1)
+            # Unmatched case.
+            self.__assert_variant_matches_default(
+                "", opts=opts, names=("bogus",), exit=1
+            )
 
-                        # Unmatched case tsv; subtly different as no error
-                        # output is expected.
-                        self.__assert_variant_matches_tsv("", opts=opts,
-                            names=("bogus",), exit=1, errout=False)
+            # Unmatched case tsv; subtly different as no error
+            # output is expected.
+            self.__assert_variant_matches_tsv(
+                "", opts=opts, names=("bogus",), exit=1, errout=False
+            )
 
-                # No output expected for with no variants set and no packages
-                # installed for -v, -av, -i, and -iv.
-                for opts in (("-v",), ("-av",), ("-i",), ("-iv",)):
-                        self.__assert_variant_matches("", opts=opts)
+        # No output expected for with no variants set and no packages
+        # installed for -v, -av, -i, and -iv.
+        for opts in (("-v",), ("-av",), ("-i",), ("-iv",)):
+            self.__assert_variant_matches("", opts=opts)
 
-                #
-                # Next, verify output after setting variants.
-                #
+        #
+        # Next, verify output after setting variants.
+        #
 
-                # Set some variants.
-                self.pkg("change-variant variant.icecream=strawberry")
+        # Set some variants.
+        self.pkg("change-variant variant.icecream=strawberry")
 
-                exp_def = """\
-arch {0[variant.arch]}
-icecream strawberry
-opensolaris.imagetype full
-opensolaris.zone global
-""".format(variants)
-
-                # Output should be the same for both -a and default cases with
-                # no packages installed.
-                for opts in ((), ("-a",)):
-                        self.__assert_variant_matches(exp_def, opts=opts)
-
-                #
-                # Next, verify output after installing unvarianted package.
-                #
-                self.pkg("install foo@1.0")
-
-                # Verify output for no options and no patterns.
-                exp_def = """\
+        exp_def = """\
 arch {0[variant.arch]}
 icecream strawberry
 opensolaris.imagetype full
 opensolaris.zone global
-""".format(variants)
-                self.__assert_variant_matches(exp_def)
+""".format(
+            variants
+        )
 
-                # Verify -a output.
-                opts = ("-a",)
-                self.__assert_variant_matches(exp_def, opts=opts)
+        # Output should be the same for both -a and default cases with
+        # no packages installed.
+        for opts in ((), ("-a",)):
+            self.__assert_variant_matches(exp_def, opts=opts)
 
-                # Verify -v, -av, -i, and -iv output.
-                for opts in (("-v",), ("-av",), ("-i",), ("-iv",)):
-                        self.__assert_variant_matches("", opts=opts)
+        #
+        # Next, verify output after installing unvarianted package.
+        #
+        self.pkg("install foo@1.0")
 
-                # Test upgraded package that does not declare all
-                # facets/variants.
-                self.__test_foo_variant_upgrade("foo@2.0", variants)
-
-                # Reinstall and then retest with upgraded package that declares
-                # all facets/variants.
-                self.pkg("install foo@1.0")
-                self.__test_foo_variant_upgrade("foo@3.0", variants)
-
-                # Next, verify output after installing package with unknown
-                # variant.
-                self.pkg("install unknown@1.0")
-
-                # Verify output for no options and no patterns.
-                exp_def = """\
+        # Verify output for no options and no patterns.
+        exp_def = """\
 arch {0[variant.arch]}
 icecream strawberry
 opensolaris.imagetype full
 opensolaris.zone global
-""".format(variants)
-                self.__assert_variant_matches(exp_def)
+""".format(
+            variants
+        )
+        self.__assert_variant_matches(exp_def)
 
-                # Verify -a output.
-                exp_def = """\
+        # Verify -a output.
+        opts = ("-a",)
+        self.__assert_variant_matches(exp_def, opts=opts)
+
+        # Verify -v, -av, -i, and -iv output.
+        for opts in (("-v",), ("-av",), ("-i",), ("-iv",)):
+            self.__assert_variant_matches("", opts=opts)
+
+        # Test upgraded package that does not declare all
+        # facets/variants.
+        self.__test_foo_variant_upgrade("foo@2.0", variants)
+
+        # Reinstall and then retest with upgraded package that declares
+        # all facets/variants.
+        self.pkg("install foo@1.0")
+        self.__test_foo_variant_upgrade("foo@3.0", variants)
+
+        # Next, verify output after installing package with unknown
+        # variant.
+        self.pkg("install unknown@1.0")
+
+        # Verify output for no options and no patterns.
+        exp_def = """\
+arch {0[variant.arch]}
+icecream strawberry
+opensolaris.imagetype full
+opensolaris.zone global
+""".format(
+            variants
+        )
+        self.__assert_variant_matches(exp_def)
+
+        # Verify -a output.
+        exp_def = """\
 arch {0[variant.arch]}
 icecream strawberry
 opensolaris.imagetype full
 opensolaris.zone global
 unknown 
-""".format(variants)
-                self.__assert_variant_matches(exp_def, opts=("-a",))
+""".format(
+            variants
+        )
+        self.__assert_variant_matches(exp_def, opts=("-a",))
 
-                # Verify -i output.
-                exp_def = """\
+        # Verify -i output.
+        exp_def = """\
 unknown 
-""".format(variants)
-                self.__assert_variant_matches(exp_def, opts=("-i",))
+""".format(
+            variants
+        )
+        self.__assert_variant_matches(exp_def, opts=("-i",))
 
-                # Verify -v, -av, and -iv output.
-                for opts in (("-v",), ("-av",), ("-iv",)):
-                        exp_def = """\
+        # Verify -v, -av, and -iv output.
+        for opts in (("-v",), ("-av",), ("-iv",)):
+            exp_def = """\
 unknown bar
 unknown foo
-""".format(variants)
-                        self.__assert_variant_matches(exp_def, opts=opts)
+""".format(
+                variants
+            )
+            self.__assert_variant_matches(exp_def, opts=opts)
 
-        def test_02_varcet_reject(self):
-                """Verify that if we try to --reject packages that should get
-                removed we invoke the solver."""
+    def test_02_varcet_reject(self):
+        """Verify that if we try to --reject packages that should get
+        removed we invoke the solver."""
 
-                # create an image
-                variants = { "variant.icecream": "strawberry" }
-                self.image_create(self.rurl, variants=variants)
+        # create an image
+        variants = {"variant.icecream": "strawberry"}
+        self.image_create(self.rurl, variants=variants)
 
-                # install a package with a dependency
-                self.pkg("install need_foo@1.0")
+        # install a package with a dependency
+        self.pkg("install need_foo@1.0")
 
-                # Set some facets/variant while rejecting a random package.
-                self.pkg("change-facet --reject=nothing "
-                    "facet.doc.txt=True")
-                self.pkg("change-variant --reject=nothing "
-                    "variant.icecream=neapolitan")
+        # Set some facets/variant while rejecting a random package.
+        self.pkg("change-facet --reject=nothing " "facet.doc.txt=True")
+        self.pkg(
+            "change-variant --reject=nothing " "variant.icecream=neapolitan"
+        )
 
-                # Reset the facets/variant to the same value (which would
-                # normally be a noop) while rejecting a package and make sure
-                # that package gets uninstalled.
-                self.pkg("change-facet --reject=need_foo "
-                    "facet.doc.txt=True")
-                self.pkg("install need_foo@1.0")
-                self.pkg("change-variant --reject=need_foo "
-                    "variant.icecream=neapolitan")
-                self.pkg("install need_foo@1.0")
+        # Reset the facets/variant to the same value (which would
+        # normally be a noop) while rejecting a package and make sure
+        # that package gets uninstalled.
+        self.pkg("change-facet --reject=need_foo " "facet.doc.txt=True")
+        self.pkg("install need_foo@1.0")
+        self.pkg(
+            "change-variant --reject=need_foo " "variant.icecream=neapolitan"
+        )
+        self.pkg("install need_foo@1.0")
 
-                # Reset the facets/variant to the same value (which would
-                # normally be a noop) while rejecting a package we can't
-                # uninstall due to dependencies.  Make sure this fails.
-                self.pkg("change-facet --reject=foo "
-                    "facet.doc.txt=True", exit=EXIT_OOPS)
-                self.pkg("change-variant --reject=foo "
-                    "variant.icecream=neapolitan", exit=EXIT_OOPS)
+        # Reset the facets/variant to the same value (which would
+        # normally be a noop) while rejecting a package we can't
+        # uninstall due to dependencies.  Make sure this fails.
+        self.pkg(
+            "change-facet --reject=foo " "facet.doc.txt=True", exit=EXIT_OOPS
+        )
+        self.pkg(
+            "change-variant --reject=foo " "variant.icecream=neapolitan",
+            exit=EXIT_OOPS,
+        )
 
-        def test_03_variant_globbing(self):
-                """Verify that change-variant fails as expected when globbing
-                is used to refer to the variants."""
+    def test_03_variant_globbing(self):
+        """Verify that change-variant fails as expected when globbing
+        is used to refer to the variants."""
 
-                variants = { "variant.icecream": "neapolitan" }
-                self.image_create(self.rurl, variants=variants)
-                self.pkg("install foo@2.0")
+        variants = {"variant.icecream": "neapolitan"}
+        self.image_create(self.rurl, variants=variants)
+        self.pkg("install foo@2.0")
 
-                self.pkg("change-variant 'variant.unknown=strawberry'")
-                self.pkg("change-variant 'variant.unknown=strawberry*'")
-                self.pkg("change-variant 'variant.unknown=strawberry?'")
-                self.pkg("change-variant 'variant.*=strawberry'", exit=1)
-                self.pkg("change-variant 'variant.*=strawberry' "
-                        "'variant.unknown=strawberry'", exit=1)
-                self.pkg("change-variant 'variant?=strawberry'", exit=1)
-                self.pkg("change-variant 'variant?=strawberry' "
-                        "'variant.unknown=strawberry'", exit=1)
+        self.pkg("change-variant 'variant.unknown=strawberry'")
+        self.pkg("change-variant 'variant.unknown=strawberry*'")
+        self.pkg("change-variant 'variant.unknown=strawberry?'")
+        self.pkg("change-variant 'variant.*=strawberry'", exit=1)
+        self.pkg(
+            "change-variant 'variant.*=strawberry' "
+            "'variant.unknown=strawberry'",
+            exit=1,
+        )
+        self.pkg("change-variant 'variant?=strawberry'", exit=1)
+        self.pkg(
+            "change-variant 'variant?=strawberry' "
+            "'variant.unknown=strawberry'",
+            exit=1,
+        )
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_verify.py
+++ b/src/tests/cli/t_pkg_verify.py
@@ -24,8 +24,9 @@
 # Copyright 2020 OmniOS Community Edition (OmniOSce) Association.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -38,11 +39,12 @@ import unittest
 
 import pkg.json as json
 
-class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
-        # Tests in this suite use the read only data directory
-        need_ro_data = True
 
-        foo10 = """
+class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
+    # Tests in this suite use the read only data directory
+    need_ro_data = True
+
+    foo10 = """
             open foo@1.0,5.11-0:20160229T095441Z
             add dir mode=0755 owner=root group=sys path=/etc
             add dir mode=0755 owner=root group=sys path=/etc/security
@@ -62,7 +64,7 @@ class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
             add driver name=zigit alias=pci8086,1234
             close
             """
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0:20110908T004546Z
             add dir mode=0755 owner=root group=sys path=/usr
             add dir mode=0755 owner=root group=bin path=/usr/bin
@@ -72,7 +74,7 @@ class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        bla10 = """
+    bla10 = """
             open bla@1.0,5.11-0
             add dir mode=0755 owner=root group=sys path=/opt
             add dir mode=0755 owner=root group=sys path=/opt/mybin
@@ -80,19 +82,19 @@ class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        sysattr = """
+    sysattr = """
             open sysattr@1.0-0
             add dir mode=0755 owner=root group=bin path=/p1
             add file bobcat mode=0555 owner=root group=bin sysattr=SH path=/p1/bobcat
             close """
 
-        sysattr2 = """
+    sysattr2 = """
             open sysattr2@1.0-0
             add dir mode=0755 owner=root group=bin path=/p2
             add file bobcat mode=0555 owner=root group=bin sysattr=hidden sysattr=nodump path=/p2/bobcat
             close """
 
-        link10 = """
+    link10 = """
             open link@1.0,5.11-0:20160229T095441Z
             add dir mode=0755 owner=root group=sys path=/usr
             add dir mode=0755 owner=root group=bin path=/usr/bin
@@ -102,603 +104,686 @@ class TestPkgVerify(pkg5unittest.SingleDepotTestCase):
             close
             """
 
-        misc_files = {
-           "bobcat": "",
-           "dricon_da": """zigit "pci8086,1234"\n""",
-           "dricon_maj": """zigit 103\n""",
-           "dricon_cls": """\n""",
-           "dricon_mp": """\n""",
-           "dricon_dp": """\n""",
-           "dricon_ep": """\n""",
-           "permission": "",
-           "bronze1": "",
-           "bronze2": "",
-           "test_perm": "Test File"
-        }
-
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
-                # We want at least one ELF file here to check for ELF action
-                # verification.
-                portable.copyfile("/usr/bin/ls", os.path.join(self.test_root,
-                    "ls"))
-                self.pkgsend_bulk(self.rurl, self.foo10)
-
-        def test_00_bad_opts(self):
-                """ test pkg verify with bad options """
-
-                self.image_create(self.rurl)
-                self.pkg_verify("-vq", exit=2)
-
-        def test_01_basics(self):
-                """Ensure that verify returns failure as expected when packages
-                are not correctly installed."""
-
-                # XXX either this should be more comprehensive or more testing
-                # needs to be added somewhere else appropriate.
-                self.image_create(self.rurl)
-
-                # Create a dummy publisher so that test publisher can be removed
-                # and added back as needed.
-                self.pkg("set-publisher -P ignored")
-
-                # Should fail since foo is not installed.
-                self.pkg_verify("foo", exit=1)
-                self.assertTrue("Unexpected Exception" not in self.output)
-
-                # Now install package.
-                self.pkg("install foo")
-
-                # Should not fail since informational messages are not
-                # fatal.
-                self.pkg_verify("foo")
-                # Unprivileged users don't cause a traceback.
-                retcode, output = self.pkg_verify("foo", su_wrap=True, out=True,
-                    exit=1)
-                self.assertTrue("Traceback" not in output)
-
-                # Should not output anything when using -q.
-                self.pkg_verify("-q foo")
-                assert(self.output == "")
-
-                # Should not fail since the path exists in the package
-                # and is intact.
-                self.pkg_verify("-v -p /etc/name_to_major")
-                self.assertTrue("foo" in self.output
-                    and "etc/name_to_major" not in self.output)
-                self.pkg_verify("-v -p /usr/bin/bobcat_link")
-                self.assertTrue("OK" in self.output)
-                self.pkg_verify("-v -p /usr")
-                self.assertTrue(self.output.count("OK") == 1)
-
-                # Should output path not found.
-                self.pkg_verify("-p nonexist")
-                self.assertTrue("not found" in self.output)
-
-                # Should not fail if publisher is disabled and package is ok.
-                self.pkg("set-publisher -d test")
-                self.pkg_verify("foo")
-
-                # Should not fail if publisher is removed and package is ok.
-                self.pkg("unset-publisher test")
-                self.pkg_verify("foo")
-
-                # Should fail with exit code 1 if publisher is removed and
-                # package is not ok.
-                portable.remove(os.path.join(self.get_img_path(), "usr", "bin",
-                    "bobcat"))
-                self.pkg_verify("foo", exit=1)
-                self.assertTrue("Unexpected Exception" not in self.output)
-                self.assertTrue("PACKAGE" in self.output and "STATUS" in self.output)
-
-                # Should fail with exit code 2 because of invalid option combo.
-                self.pkg_verify("-p /usr/bin/bobcat --unpackaged", exit=2)
-                self.pkg_verify("-p /usr/bin/bobcat --unpackaged-only", exit=2)
-
-                # Should fail with exit code 1 because the file is removed
-                # and the package is not ok.
-                self.pkg_verify("-p /usr/bin/bobcat", exit=1)
-                self.assertTrue("PACKAGE" in self.output
-                    and self.output.count("ERROR") == 2)
-                self.assertTrue("usr/bin/bobcat" in self.output)
-
-                # Test that "-H" works as expected.
-                self.pkg_verify("foo -H", exit=1)
-                self.assertTrue("PACKAGE" not in self.output and
-                    "STATUS" not in self.output)
-
-                # Should not output anything when using -q.
-                self.pkg_verify("-q foo", exit=1)
-                assert(self.output == "")
-                self.pkg("set-publisher -p {0}".format(self.rurl))
-                self.pkg("fix foo")
-
-                # Informational messages should not be output unless -v
-                # is provided.
-                self.pkg("set-publisher -p {0}".format(self.rurl))
-                self.pkg_verify("foo | grep bobcat", exit=1)
-                self.pkg_verify("-v foo | grep bobcat")
-
-                # Verify shouldn't care if timestamp has changed on
-                # preserved files.
-                fpath = os.path.join(self.get_img_path(), "etc", "preserved")
-                ctime = time.time() - 1240
-                os.utime(fpath, (ctime, ctime))
-                self.pkg_verify("foo")
-
-                # Verify should fail if file is missing.
-                fpath = os.path.join(self.get_img_path(), "usr", "bin",
-                    "bobcat")
-                portable.remove(fpath)
-                self.pkg_verify("foo", exit=1)
-
-                # Now verify that verify warnings are not fatal (because
-                # package contained bobcat!).
-                self.pkg("fix")
-
-                fpath = os.path.join(self.get_img_path(), "etc",
-                    "driver_aliases")
-
-                with open(fpath, "r+") as f:
-                        out = ""
-                        for l in f:
-                                if l.find("zigit") != -1:
-                                        nl = l.replace("1234", "4321")
-                                        out += nl
-                                out += l
-                        f.seek(0)
-                        f.write(out)
-
-                # Verify should find the extra alias and it should be treated
-                # as a warning.
-                self.pkg_verify("-v foo")
-                #self.assertTrue("4321" in self.output)
-                self.assertTrue("4321" in self.output and "WARNING" in self.output)
-
-                # Test that warnings are displayed by default.
-                self.pkg_verify("foo")
-                self.assertTrue("4321" in self.output and "WARNING" in self.output)
-
-                # Verify on system wide should also find the extra alias.
-                self.pkg_verify("")
-                self.assertTrue("4321" in self.output and "WARNING" in self.output)
-
-        def test_multiple_paths_input(self):
-                """Test that when input is multiple paths, results returned are as
-                expected."""
-
-                self.pkgsend_bulk(self.rurl, self.bar10)
-
-                self.image_create(self.rurl)
-                self.pkg("install foo bar")
-
-                # Test verification of multiple paths in a package.
-                # Should not fail since files specified by paths are all intact.
-                self.pkg_verify("-v -p /etc/driver_aliases -p /etc/minor_perm \
-                    -p /etc/security/extra_privs")
-
-                # Test verification of multiple paths in different packages.
-                # Should not fail since files specified by paths are all intact.
-                self.pkg_verify("-v -p /etc/driver_aliases -p /etc/bronze1 -p /usr/bin/bobcat")
-                self.assertTrue("ERROR" not in self.output
-                    and self.output.count("OK") == 2)
-                self.pkg_verify("-v -p /usr -p /etc/driver_aliases")
-                self.assertTrue("ERROR" not in self.output
-                    and self.output.count("OK") == 2)
-                self.pkg_verify("-v -p /usr -p /usr/bin")
-                self.assertTrue("ERROR" not in self.output
-                    and self.output.count("OK") == 1)
-                self.pkg_verify("-v -p /usr -p /usr/bin/bobcat_link")
-                self.assertTrue("ERROR" not in self.output
-                    and self.output.count("OK") == 1)
-
-
-                # When multiple paths are given to pkg verify, if any of them
-                # are not packaged in the image it should report the file not found.
-                self.pkg_verify("-v -p /etc/driver_aliases -p nonexist")
-                self.assertTrue("ERROR" not in self.output
-                    and self.output.count("OK") == 1)
-                self.assertTrue("nonexist is not found" in self.output)
-
-                fd = open(os.path.join(self.get_img_path(), "usr", "bin", "bobcat"), "w+")
-                fd.write("Bobcats are here")
-                fd.close()
-
-                # When verify multilple paths in a package, should output
-                # ok for one package, error for the other.
-                self.pkg_verify("-v -p /etc/driver_aliases \
-                    -p /usr/bin/bobcat", exit=1)
-                self.assertTrue("usr/bin/bobcat" in self.output
-                    and "etc/driver_aliases" not in self.output)
-                self.assertTrue("foo" in self.output)
-                self.assertTrue("OK" not in self.output
-                    and self.output.count("ERROR") == 2
-                    and "Hash" in self.output)
-
-                # Even though the target file is modified, the link and dir
-                # verification should pass.
-                self.pkg_verify("-v -p /usr -p /usr/bin -p /usr/bin/bobcat_link")
-                self.assertTrue("ERROR" not in self.output
-                    and self.output.count("OK") == 1)
-
-                # When verifying multiple paths in different packages, should fail
-                # the package whose manifest contains the path. Should not
-                # fail the other package.
-                self.pkg_verify("-v -p /usr/bin/bobcat -p /etc/bronze1", exit=1)
-                self.assertTrue("usr/bin/bobcat" in self.output
-                    and "etc/bronze1" not in self.output
-                    and "foo" in self.output and "bar" in self.output)
-                self.assertTrue(self.output.count("OK") == 1
-                    and self.output.count("ERROR") == 2
-                    and "Hash" in self.output)
-                self.pkg_verify("-v -p /usr -p /usr/bin/bobcat", exit=1)
-                self.assertTrue("usr/bin/bobcat" in self.output
-                    and "foo" in self.output and "bar" in self.output)
-                self.assertTrue("OK" in self.output
-                    and self.output.count("ERROR") == 2
-                    and "Hash" in self.output)
-
-                self.pkg("uninstall foo bar")
-
-        def test_verify_perms_py3(self):
-                """Test that verify does adhere to file permissions like other
-                cmds, and do not emit octal notation"""
-
-                self.pkgsend_bulk(self.rurl, self.bla10)
-                self.image_create(self.rurl)
-                self.pkg("install bla")
-                fpath = os.path.join(self.img_path(),"opt/mybin/test_perm")
-                os.chmod(fpath, 0o600)
-                self.pkg_verify("bla", exit=1)
-                self.assertTrue("ERROR: mode: 0600 should be 0644"
-                    in self.output)
-
-                self.pkg("uninstall bla")
-
-        def test_mix_verify_input(self):
-                """Test that when input is mix of FMRIs and paths, verbose output
-                is correct"""
-
-                self.pkgsend_bulk(self.rurl, self.bar10)
-                self.image_create(self.rurl)
-                self.pkg("install foo bar")
-
-                # Should verify the package when only FMRI is provided.
-                self.pkg_verify("-v foo")
-                self.assertTrue("foo" in self.output and "OK" in self.output)
-
-                # Should verify the path when no FMRI is provided.
-                self.pkg_verify("-v -p /etc/name_to_major")
-                self.assertTrue("foo" in self.output and "OK" in self.output)
-
-                # Should verify only the path when both path and FMRI are
-                # provided and an action of the FMRI matches the path.
-                self.pkg_verify("-v -p /etc/name_to_major foo")
-                self.assertTrue("foo" in self.output
-                    and "etc/name_to_major" not in self.output)
-                self.assertTrue(self.output.count("OK") == 1)
-
-                # Should verify only the path when the path and more than
-                # one FMRIs are provided.
-                self.pkg_verify("-v -p /etc/name_to_major foo bar")
-                self.assertTrue("foo" in self.output
-                    and "bar" not in self.output
-                    and "etc/name_to_major" not in self.output)
-                self.assertTrue(self.output.count("OK") == 1)
-                self.pkg_verify("-v -p /usr foo bar")
-                self.assertTrue("bar" in self.output
-                    and "foo" not in self.output)
-                self.assertTrue(self.output.count("OK") == 1)
-                self.pkg_verify("-v -p /usr/bin/bobcat_link foo bar")
-                self.assertTrue("bar" in self.output
-                    and "foo" not in self.output)
-                self.assertTrue(self.output.count("OK") == 1)
-
-                # Should verify the path when both the path and the FMRI are
-                # provided but the path is not in the manifest of the package.
-                self.pkg_verify("-v -p /etc/name_to_major bar")
-                self.assertTrue("foo" not in self.output and
-                    "bar" not in self.output and "not found" in self.output)
-                self.assertTrue("OK" not in self.output)
-
-                fd = open(os.path.join(self.get_img_path(), "usr", "bin", "bobcat"), "w+")
-                fd.write("Bobcats are here")
-                fd.close()
-
-                # Should not output error for the package if the modified file
-                # is not verified.
-                self.pkg_verify("-v -p /etc/bronze1 bar")
-                self.assertTrue("bar" in self.output
-                    and "OK" in self.output and "ERROR" not in self.output)
-
-                # When the path belongs to the manifest of FMRI, should
-                # fail and report error for the path and the FMRI.
-                self.pkg_verify("-v -p /usr/bin/bobcat foo bar", exit=1)
-                self.assertTrue("foo" in self.output and "bar" not in self.output
-                    and "usr/bin/bobcat" in self.output)
-                self.assertTrue(self.output.count("ERROR") == 2
-                    and "OK" not in self.output)
-
-                # Even though the target file is modified, the link and dir
-                # verification should pass.
-                self.pkg_verify("-v -p /usr/bin -p /usr/bin/bobcat_link foo bar")
-                self.assertTrue("ERROR" not in self.output
-                    and self.output.count("OK") == 1)
-
-                self.pkg("uninstall foo bar")
-
-        def test_02_installed(self):
-                """When multiple FMRIs are given to pkg verify, if any of them
-                aren't installed it should fail."""
-
-                self.image_create(self.rurl)
-                self.pkg("install foo")
-                self.pkg_verify("foo non-existent", exit=1)
-                self.pkg("uninstall foo")
-
-        def test_03_invalid(self):
-                """Test that pkg verify handles invalid input gracefully."""
-
-                self.image_create(self.rurl)
-
-                # Verify invalid package causes graceful exit.
-                self.pkg_verify("_not_valid", exit=1)
-
-                # Verify unmatched input fails gracefully.
-                self.pkg_verify("no/such/package", exit=1)
-
-                # Verify invalid package name and unmatched input combined with
-                # installed package name results in graceful failure.
-                self.pkg("install foo")
-                self.pkg_verify("_not_valid no/such/package foo", exit=1)
-
-        def test_03_editable(self):
-                """When editable files are changed, verify should treat these specially"""
-                # check that verify is silent on about modified editable files
-                self.image_create(self.rurl)
-                self.pkg("install foo")
-                fd = open(os.path.join(self.get_img_path(), "etc", "preserved"), "w+")
-                fd.write("Bobcats are here")
-                fd.close()
-                self.pkg_verify("foo")
-                assert("editable file has been changed" not in self.output)
-                # find out about it via -v
-                self.pkg_verify("-v foo")
-                self.output.index("etc/preserved")
-                self.output.index("editable file has been changed")
-
-        def test_verify_changed_manifest(self):
-                """Test that running package verify won't change the manifest of
-                an installed package even if it has changed in the repository.
-                """
-
-                self.image_create(self.rurl)
-                self.pkg("install foo")
-
-                self.pkg_verify("")
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg_verify("", exit=1)
-
-                # Specify location as filesystem path.
-                self.pkgsign_simple(self.dc.get_repodir(), "foo")
-
-                self.pkg_verify("", exit=1)
-
-        def test_links(self):
-
-                self.pkgsend_bulk(self.rurl, self.link10)
-
-                self.image_create(self.rurl)
-
-                self.pkg("install link")
-                self.pkg_verify("link")
-
-                dpath = os.path.join(self.get_img_path(), "usr", "bin");
-                fpath = os.path.join(dpath, "bobcat")
-                lpath = os.path.join(dpath, "bobcat_link")
-                opath = os.path.join(dpath, "bobcat_owner")
-
-                # Change attributes of the symlink target
-                os.chown(fpath, 100, 2)
-                os.chmod(fpath, 0o664)
-
-                # Ownership of links themselves
-                os.lchown(lpath, 100, 2);
-                os.lchown(opath, 100, 2);
-
-                self.pkg_verify("-v -p /usr/bin/bobcat_link")
-                self.pkg_verify("-v -p /usr/bin/bobcat_owner")
-
-                # Remove the link
-                portable.remove(lpath);
-
-                self.pkg_verify("-v -p /usr/bin/bobcat_link", exit=1)
-                self.assertTrue("ERROR: missing: symbolic link" in self.output)
-
-        def test_sysattrs(self):
-                """Test that system attributes are verified correctly."""
-
-                if portable.osname != "sunos":
-                        raise pkg5unittest.TestSkippedException(
-                            "System attributes unsupported on this platform.")
-
-                self.pkgsend_bulk(self.rurl, [self.sysattr, self.sysattr2])
-
-                # Need to create an image in /var/tmp since sysattrs don't work
-                # in tmpfs.
-                old_img_path = self.img_path()
-                self.set_img_path(tempfile.mkdtemp(prefix="test-suite",
-                    dir="/var/tmp"))
-
-                self.image_create(self.rurl)
-                self.pkg("install sysattr sysattr2")
-                self.pkg("verify")
-                fpath = os.path.join(self.img_path(),"p1/bobcat")
-
-                # Need to get creative here to remove the system attributes
-                # since you need the sys_linkdir privilege which we don't have:
-                # see run.py:393
-                # So we re-create the file with correct owner and mode and the
-                # only thing missing are the sysattrs.
-                portable.remove(fpath)
-                portable.copyfile(os.path.join(self.test_root, "bobcat"), fpath)
-                os.chmod(fpath, 0o555)
-                os.chown(fpath, -1, 2)
-                self.pkg("verify", exit=1)
-                for sattr in ('H','S'):
-                        expected = "System attribute '{0}' not set".format(sattr)
-                        self.assertTrue(expected in self.output,
-                            "Missing in verify output:  {0}".format(expected))
-
-                shutil.rmtree(self.img_path())
-                self.set_img_path(old_img_path)
-
-        def test_verify_invalid_fmri(self):
-                """Test invalid fmri triggers correct output."""
-
-                self.image_create(self.rurl)
-                self.pkg("install foo")
-
-                self.pkg_verify("foo@invalid", exit=1)
-                self.assertTrue("verify" in self.errout and "illegal" in
-                    self.errout)
-
-        def test_verify_parsable_output(self):
-                """Test parsable output."""
-
-                self.image_create(self.rurl)
-                self.pkg("install foo")
-                # Test invalid option combo.
-                self.pkg_verify("-v --parsable 0 foo", exit=2)
-                self.pkg_verify("-H --parsable 0 foo", exit=2)
-                # Test invalid option value.
-                self.pkg_verify("--parsable 1 foo", exit=2)
-                self.pkg_verify("--parsable 0 foo")
-                out_json = json.loads(self.output)
-                self.assertTrue("pkg://test/foo@1.0,5.11-0:20160229T095441Z"
-                    in out_json["item-messages"])
-                fmri_entry = out_json["item-messages"][
-                    "pkg://test/foo@1.0,5.11-0:20160229T095441Z"]
-                self.assertTrue(fmri_entry["messages"][0]["msg_level"]
-                    == "info")
-                self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
-
-                # Verify should fail if file is missing.
-                fpath = os.path.join(self.get_img_path(), "usr", "bin",
-                    "bobcat")
-                portable.remove(fpath)
-                self.pkg_verify("--parsable 0 foo", exit=1)
-                out_json = json.loads(self.output)
-                self.assertTrue("pkg://test/foo@1.0,5.11-0:20160229T095441Z"
-                    in out_json["item-messages"])
-                fmri_entry = out_json["item-messages"][
-                    "pkg://test/foo@1.0,5.11-0:20160229T095441Z"]
-                self.assertTrue(fmri_entry["messages"][0]["msg_type"]
-                    == "general")
-                self.assertTrue(fmri_entry["messages"][0]["msg_level"]
-                    == "error")
-                self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
-                self.assertTrue(fmri_entry["file: usr/bin/bobcat"][0]["msg_type"]
-                    == "general")
-                self.assertTrue(fmri_entry["file: usr/bin/bobcat"][0]["msg_level"]
-                    == "error")
-
-        def test_unpackaged(self):
-                """Test unpackaged option."""
-
-                self.image_create(self.rurl)
-                self.pkg("install foo")
-                self.pkg_verify("--unpackaged")
-                self.assertTrue("ERROR" not in self.output and
-                    "WARNING" not in self.output and "Unpackaged" in
-                    self.output and "UNPACKAGED" in self.output)
-                self.assertTrue("----" not in self.output)
-                # Test verbose.
-                self.pkg_verify("-v --unpackaged")
-                self.assertTrue("----" in self.output)
-                self.assertTrue("ERROR" not in self.output and
-                    "WARNING" not in self.output and "Unpackaged" in
-                    self.output and "UNPACKAGED" in self.output)
-                self.assertTrue("ERROR" not in self.output and
-                    "WARNING" not in self.output and "bobcat" in
-                    self.output and "UNPACKAGED" in self.output)
-                # Test omit header.
-                self.pkg_verify("--unpackaged -H")
-                self.assertTrue("----" not in self.output)
-                self.assertTrue("ERROR" not in self.output and
-                    "WARNING" not in self.output and "Unpackaged" in
-                    self.output and "UNPACKAGED" not in self.output)
-                # Test unpackaged only.
-                self.pkg_verify("--unpackaged-only -v")
-                self.assertTrue("----" not in self.output)
-                self.assertTrue("ERROR" not in self.output and
-                    "WARNING" not in self.output and "Unpackaged" in
-                    self.output and "UNPACKAGED" in self.output)
-                self.assertTrue("ERROR" not in self.output and
-                    "WARNING" not in self.output and "Unpackaged" in
-                    self.output and "bobcat" not in self.output)
-
-                # Test quiet result.
-                self.pkg_verify("-q --unpackaged")
-                self.assertTrue(not self.output)
-
-                # Test invalid usage.
-                self.pkg_verify("--unpackaged-only foo", exit=2)
-                self.pkg_verify("--unpackaged --unpackaged-only", exit=2)
-                self.pkg_verify("-H --parsable 0 --unpackaged", exit=2)
-
-                # Test --unpackaged with package arguments.
-                self.pkg_verify("--unpackaged -v foo")
-                self.assertTrue("----" in self.output and "bobcat" in
-                    self.output and "UNPACKAGED" in self.output)
-                self.pkg_verify("--parsable 0 --unpackaged foo")
-                out_json = json.loads(self.output)
-                self.assertTrue("pkg://test/foo@1.0,5.11-0:20160229T095441Z"
-                    in out_json["item-messages"])
-                fmri_entry = out_json["item-messages"][
-                    "pkg://test/foo@1.0,5.11-0:20160229T095441Z"]
-                self.assertTrue(fmri_entry["messages"][0]["msg_level"]
-                    == "info")
-                self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
-
-                # Test parsable output for --unpackaged.
-                self.pkg_verify("--parsable 0 --unpackaged")
-                out_json = json.loads(self.output)
-                self.assertTrue("unpackaged" in out_json["item-messages"]
-                    and out_json["item-messages"]["unpackaged"])
-                out_entry = out_json["item-messages"]["unpackaged"]
-                self.assertTrue("dir" in list(out_entry.keys())[0] or "file" in
-                    out_entry.keys()[0])
-                self.assertTrue(out_entry[list(out_entry.keys())[0]][0]["msg_level"]
-                    == "info")
-                self.assertTrue(out_entry[list(out_entry.keys())[0]][0]["msg_type"]
-                    == "unpackaged")
-                self.assertTrue("pkg://test/foo@1.0,5.11-0:20160229T095441Z"
-                    in out_json["item-messages"])
-                fmri_entry = out_json["item-messages"][
-                    "pkg://test/foo@1.0,5.11-0:20160229T095441Z"]
-                self.assertTrue(fmri_entry["messages"][0]["msg_level"]
-                    == "info")
-                self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
-
-                # Test parsable output for --unpackaged-only.
-                self.pkg_verify("--parsable 0 --unpackaged-only")
-                out_json = json.loads(self.output)
-                self.assertTrue("unpackaged" in out_json["item-messages"]
-                    and out_json["item-messages"]["unpackaged"])
-                out_entry = out_json["item-messages"]["unpackaged"]
-                self.assertTrue("dir" in list(out_entry.keys())[0] or "file" in
-                    out_entry.keys()[0])
-                self.assertTrue(out_entry[list(out_entry.keys())[0]][0]["msg_level"]
-                    == "info")
-                self.assertTrue(out_entry[list(out_entry.keys())[0]][0]["msg_type"]
-                    == "unpackaged")
-                self.assertTrue("pkg://test/foo@1.0,5.11-0:20160229T095441Z"
-                    not in out_json["item-messages"])
+    misc_files = {
+        "bobcat": "",
+        "dricon_da": """zigit "pci8086,1234"\n""",
+        "dricon_maj": """zigit 103\n""",
+        "dricon_cls": """\n""",
+        "dricon_mp": """\n""",
+        "dricon_dp": """\n""",
+        "dricon_ep": """\n""",
+        "permission": "",
+        "bronze1": "",
+        "bronze2": "",
+        "test_perm": "Test File",
+    }
+
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
+        # We want at least one ELF file here to check for ELF action
+        # verification.
+        portable.copyfile("/usr/bin/ls", os.path.join(self.test_root, "ls"))
+        self.pkgsend_bulk(self.rurl, self.foo10)
+
+    def test_00_bad_opts(self):
+        """test pkg verify with bad options"""
+
+        self.image_create(self.rurl)
+        self.pkg_verify("-vq", exit=2)
+
+    def test_01_basics(self):
+        """Ensure that verify returns failure as expected when packages
+        are not correctly installed."""
+
+        # XXX either this should be more comprehensive or more testing
+        # needs to be added somewhere else appropriate.
+        self.image_create(self.rurl)
+
+        # Create a dummy publisher so that test publisher can be removed
+        # and added back as needed.
+        self.pkg("set-publisher -P ignored")
+
+        # Should fail since foo is not installed.
+        self.pkg_verify("foo", exit=1)
+        self.assertTrue("Unexpected Exception" not in self.output)
+
+        # Now install package.
+        self.pkg("install foo")
+
+        # Should not fail since informational messages are not
+        # fatal.
+        self.pkg_verify("foo")
+        # Unprivileged users don't cause a traceback.
+        retcode, output = self.pkg_verify("foo", su_wrap=True, out=True, exit=1)
+        self.assertTrue("Traceback" not in output)
+
+        # Should not output anything when using -q.
+        self.pkg_verify("-q foo")
+        assert self.output == ""
+
+        # Should not fail since the path exists in the package
+        # and is intact.
+        self.pkg_verify("-v -p /etc/name_to_major")
+        self.assertTrue(
+            "foo" in self.output and "etc/name_to_major" not in self.output
+        )
+        self.pkg_verify("-v -p /usr/bin/bobcat_link")
+        self.assertTrue("OK" in self.output)
+        self.pkg_verify("-v -p /usr")
+        self.assertTrue(self.output.count("OK") == 1)
+
+        # Should output path not found.
+        self.pkg_verify("-p nonexist")
+        self.assertTrue("not found" in self.output)
+
+        # Should not fail if publisher is disabled and package is ok.
+        self.pkg("set-publisher -d test")
+        self.pkg_verify("foo")
+
+        # Should not fail if publisher is removed and package is ok.
+        self.pkg("unset-publisher test")
+        self.pkg_verify("foo")
+
+        # Should fail with exit code 1 if publisher is removed and
+        # package is not ok.
+        portable.remove(
+            os.path.join(self.get_img_path(), "usr", "bin", "bobcat")
+        )
+        self.pkg_verify("foo", exit=1)
+        self.assertTrue("Unexpected Exception" not in self.output)
+        self.assertTrue("PACKAGE" in self.output and "STATUS" in self.output)
+
+        # Should fail with exit code 2 because of invalid option combo.
+        self.pkg_verify("-p /usr/bin/bobcat --unpackaged", exit=2)
+        self.pkg_verify("-p /usr/bin/bobcat --unpackaged-only", exit=2)
+
+        # Should fail with exit code 1 because the file is removed
+        # and the package is not ok.
+        self.pkg_verify("-p /usr/bin/bobcat", exit=1)
+        self.assertTrue(
+            "PACKAGE" in self.output and self.output.count("ERROR") == 2
+        )
+        self.assertTrue("usr/bin/bobcat" in self.output)
+
+        # Test that "-H" works as expected.
+        self.pkg_verify("foo -H", exit=1)
+        self.assertTrue(
+            "PACKAGE" not in self.output and "STATUS" not in self.output
+        )
+
+        # Should not output anything when using -q.
+        self.pkg_verify("-q foo", exit=1)
+        assert self.output == ""
+        self.pkg("set-publisher -p {0}".format(self.rurl))
+        self.pkg("fix foo")
+
+        # Informational messages should not be output unless -v
+        # is provided.
+        self.pkg("set-publisher -p {0}".format(self.rurl))
+        self.pkg_verify("foo | grep bobcat", exit=1)
+        self.pkg_verify("-v foo | grep bobcat")
+
+        # Verify shouldn't care if timestamp has changed on
+        # preserved files.
+        fpath = os.path.join(self.get_img_path(), "etc", "preserved")
+        ctime = time.time() - 1240
+        os.utime(fpath, (ctime, ctime))
+        self.pkg_verify("foo")
+
+        # Verify should fail if file is missing.
+        fpath = os.path.join(self.get_img_path(), "usr", "bin", "bobcat")
+        portable.remove(fpath)
+        self.pkg_verify("foo", exit=1)
+
+        # Now verify that verify warnings are not fatal (because
+        # package contained bobcat!).
+        self.pkg("fix")
+
+        fpath = os.path.join(self.get_img_path(), "etc", "driver_aliases")
+
+        with open(fpath, "r+") as f:
+            out = ""
+            for l in f:
+                if l.find("zigit") != -1:
+                    nl = l.replace("1234", "4321")
+                    out += nl
+                out += l
+            f.seek(0)
+            f.write(out)
+
+        # Verify should find the extra alias and it should be treated
+        # as a warning.
+        self.pkg_verify("-v foo")
+        # self.assertTrue("4321" in self.output)
+        self.assertTrue("4321" in self.output and "WARNING" in self.output)
+
+        # Test that warnings are displayed by default.
+        self.pkg_verify("foo")
+        self.assertTrue("4321" in self.output and "WARNING" in self.output)
+
+        # Verify on system wide should also find the extra alias.
+        self.pkg_verify("")
+        self.assertTrue("4321" in self.output and "WARNING" in self.output)
+
+    def test_multiple_paths_input(self):
+        """Test that when input is multiple paths, results returned are as
+        expected."""
+
+        self.pkgsend_bulk(self.rurl, self.bar10)
+
+        self.image_create(self.rurl)
+        self.pkg("install foo bar")
+
+        # Test verification of multiple paths in a package.
+        # Should not fail since files specified by paths are all intact.
+        self.pkg_verify(
+            "-v -p /etc/driver_aliases -p /etc/minor_perm \
+                    -p /etc/security/extra_privs"
+        )
+
+        # Test verification of multiple paths in different packages.
+        # Should not fail since files specified by paths are all intact.
+        self.pkg_verify(
+            "-v -p /etc/driver_aliases -p /etc/bronze1 -p /usr/bin/bobcat"
+        )
+        self.assertTrue(
+            "ERROR" not in self.output and self.output.count("OK") == 2
+        )
+        self.pkg_verify("-v -p /usr -p /etc/driver_aliases")
+        self.assertTrue(
+            "ERROR" not in self.output and self.output.count("OK") == 2
+        )
+        self.pkg_verify("-v -p /usr -p /usr/bin")
+        self.assertTrue(
+            "ERROR" not in self.output and self.output.count("OK") == 1
+        )
+        self.pkg_verify("-v -p /usr -p /usr/bin/bobcat_link")
+        self.assertTrue(
+            "ERROR" not in self.output and self.output.count("OK") == 1
+        )
+
+        # When multiple paths are given to pkg verify, if any of them
+        # are not packaged in the image it should report the file not found.
+        self.pkg_verify("-v -p /etc/driver_aliases -p nonexist")
+        self.assertTrue(
+            "ERROR" not in self.output and self.output.count("OK") == 1
+        )
+        self.assertTrue("nonexist is not found" in self.output)
+
+        fd = open(
+            os.path.join(self.get_img_path(), "usr", "bin", "bobcat"), "w+"
+        )
+        fd.write("Bobcats are here")
+        fd.close()
+
+        # When verify multilple paths in a package, should output
+        # ok for one package, error for the other.
+        self.pkg_verify(
+            "-v -p /etc/driver_aliases \
+                    -p /usr/bin/bobcat",
+            exit=1,
+        )
+        self.assertTrue(
+            "usr/bin/bobcat" in self.output
+            and "etc/driver_aliases" not in self.output
+        )
+        self.assertTrue("foo" in self.output)
+        self.assertTrue(
+            "OK" not in self.output
+            and self.output.count("ERROR") == 2
+            and "Hash" in self.output
+        )
+
+        # Even though the target file is modified, the link and dir
+        # verification should pass.
+        self.pkg_verify("-v -p /usr -p /usr/bin -p /usr/bin/bobcat_link")
+        self.assertTrue(
+            "ERROR" not in self.output and self.output.count("OK") == 1
+        )
+
+        # When verifying multiple paths in different packages, should fail
+        # the package whose manifest contains the path. Should not
+        # fail the other package.
+        self.pkg_verify("-v -p /usr/bin/bobcat -p /etc/bronze1", exit=1)
+        self.assertTrue(
+            "usr/bin/bobcat" in self.output
+            and "etc/bronze1" not in self.output
+            and "foo" in self.output
+            and "bar" in self.output
+        )
+        self.assertTrue(
+            self.output.count("OK") == 1
+            and self.output.count("ERROR") == 2
+            and "Hash" in self.output
+        )
+        self.pkg_verify("-v -p /usr -p /usr/bin/bobcat", exit=1)
+        self.assertTrue(
+            "usr/bin/bobcat" in self.output
+            and "foo" in self.output
+            and "bar" in self.output
+        )
+        self.assertTrue(
+            "OK" in self.output
+            and self.output.count("ERROR") == 2
+            and "Hash" in self.output
+        )
+
+        self.pkg("uninstall foo bar")
+
+    def test_verify_perms_py3(self):
+        """Test that verify does adhere to file permissions like other
+        cmds, and do not emit octal notation"""
+
+        self.pkgsend_bulk(self.rurl, self.bla10)
+        self.image_create(self.rurl)
+        self.pkg("install bla")
+        fpath = os.path.join(self.img_path(), "opt/mybin/test_perm")
+        os.chmod(fpath, 0o600)
+        self.pkg_verify("bla", exit=1)
+        self.assertTrue("ERROR: mode: 0600 should be 0644" in self.output)
+
+        self.pkg("uninstall bla")
+
+    def test_mix_verify_input(self):
+        """Test that when input is mix of FMRIs and paths, verbose output
+        is correct"""
+
+        self.pkgsend_bulk(self.rurl, self.bar10)
+        self.image_create(self.rurl)
+        self.pkg("install foo bar")
+
+        # Should verify the package when only FMRI is provided.
+        self.pkg_verify("-v foo")
+        self.assertTrue("foo" in self.output and "OK" in self.output)
+
+        # Should verify the path when no FMRI is provided.
+        self.pkg_verify("-v -p /etc/name_to_major")
+        self.assertTrue("foo" in self.output and "OK" in self.output)
+
+        # Should verify only the path when both path and FMRI are
+        # provided and an action of the FMRI matches the path.
+        self.pkg_verify("-v -p /etc/name_to_major foo")
+        self.assertTrue(
+            "foo" in self.output and "etc/name_to_major" not in self.output
+        )
+        self.assertTrue(self.output.count("OK") == 1)
+
+        # Should verify only the path when the path and more than
+        # one FMRIs are provided.
+        self.pkg_verify("-v -p /etc/name_to_major foo bar")
+        self.assertTrue(
+            "foo" in self.output
+            and "bar" not in self.output
+            and "etc/name_to_major" not in self.output
+        )
+        self.assertTrue(self.output.count("OK") == 1)
+        self.pkg_verify("-v -p /usr foo bar")
+        self.assertTrue("bar" in self.output and "foo" not in self.output)
+        self.assertTrue(self.output.count("OK") == 1)
+        self.pkg_verify("-v -p /usr/bin/bobcat_link foo bar")
+        self.assertTrue("bar" in self.output and "foo" not in self.output)
+        self.assertTrue(self.output.count("OK") == 1)
+
+        # Should verify the path when both the path and the FMRI are
+        # provided but the path is not in the manifest of the package.
+        self.pkg_verify("-v -p /etc/name_to_major bar")
+        self.assertTrue(
+            "foo" not in self.output
+            and "bar" not in self.output
+            and "not found" in self.output
+        )
+        self.assertTrue("OK" not in self.output)
+
+        fd = open(
+            os.path.join(self.get_img_path(), "usr", "bin", "bobcat"), "w+"
+        )
+        fd.write("Bobcats are here")
+        fd.close()
+
+        # Should not output error for the package if the modified file
+        # is not verified.
+        self.pkg_verify("-v -p /etc/bronze1 bar")
+        self.assertTrue(
+            "bar" in self.output
+            and "OK" in self.output
+            and "ERROR" not in self.output
+        )
+
+        # When the path belongs to the manifest of FMRI, should
+        # fail and report error for the path and the FMRI.
+        self.pkg_verify("-v -p /usr/bin/bobcat foo bar", exit=1)
+        self.assertTrue(
+            "foo" in self.output
+            and "bar" not in self.output
+            and "usr/bin/bobcat" in self.output
+        )
+        self.assertTrue(
+            self.output.count("ERROR") == 2 and "OK" not in self.output
+        )
+
+        # Even though the target file is modified, the link and dir
+        # verification should pass.
+        self.pkg_verify("-v -p /usr/bin -p /usr/bin/bobcat_link foo bar")
+        self.assertTrue(
+            "ERROR" not in self.output and self.output.count("OK") == 1
+        )
+
+        self.pkg("uninstall foo bar")
+
+    def test_02_installed(self):
+        """When multiple FMRIs are given to pkg verify, if any of them
+        aren't installed it should fail."""
+
+        self.image_create(self.rurl)
+        self.pkg("install foo")
+        self.pkg_verify("foo non-existent", exit=1)
+        self.pkg("uninstall foo")
+
+    def test_03_invalid(self):
+        """Test that pkg verify handles invalid input gracefully."""
+
+        self.image_create(self.rurl)
+
+        # Verify invalid package causes graceful exit.
+        self.pkg_verify("_not_valid", exit=1)
+
+        # Verify unmatched input fails gracefully.
+        self.pkg_verify("no/such/package", exit=1)
+
+        # Verify invalid package name and unmatched input combined with
+        # installed package name results in graceful failure.
+        self.pkg("install foo")
+        self.pkg_verify("_not_valid no/such/package foo", exit=1)
+
+    def test_03_editable(self):
+        """When editable files are changed, verify should treat these specially"""
+        # check that verify is silent on about modified editable files
+        self.image_create(self.rurl)
+        self.pkg("install foo")
+        fd = open(os.path.join(self.get_img_path(), "etc", "preserved"), "w+")
+        fd.write("Bobcats are here")
+        fd.close()
+        self.pkg_verify("foo")
+        assert "editable file has been changed" not in self.output
+        # find out about it via -v
+        self.pkg_verify("-v foo")
+        self.output.index("etc/preserved")
+        self.output.index("editable file has been changed")
+
+    def test_verify_changed_manifest(self):
+        """Test that running package verify won't change the manifest of
+        an installed package even if it has changed in the repository.
+        """
+
+        self.image_create(self.rurl)
+        self.pkg("install foo")
+
+        self.pkg_verify("")
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg_verify("", exit=1)
+
+        # Specify location as filesystem path.
+        self.pkgsign_simple(self.dc.get_repodir(), "foo")
+
+        self.pkg_verify("", exit=1)
+
+    def test_links(self):
+        self.pkgsend_bulk(self.rurl, self.link10)
+
+        self.image_create(self.rurl)
+
+        self.pkg("install link")
+        self.pkg_verify("link")
+
+        dpath = os.path.join(self.get_img_path(), "usr", "bin")
+        fpath = os.path.join(dpath, "bobcat")
+        lpath = os.path.join(dpath, "bobcat_link")
+        opath = os.path.join(dpath, "bobcat_owner")
+
+        # Change attributes of the symlink target
+        os.chown(fpath, 100, 2)
+        os.chmod(fpath, 0o664)
+
+        # Ownership of links themselves
+        os.lchown(lpath, 100, 2)
+        os.lchown(opath, 100, 2)
+
+        self.pkg_verify("-v -p /usr/bin/bobcat_link")
+        self.pkg_verify("-v -p /usr/bin/bobcat_owner")
+
+        # Remove the link
+        portable.remove(lpath)
+
+        self.pkg_verify("-v -p /usr/bin/bobcat_link", exit=1)
+        self.assertTrue("ERROR: missing: symbolic link" in self.output)
+
+    def test_sysattrs(self):
+        """Test that system attributes are verified correctly."""
+
+        if portable.osname != "sunos":
+            raise pkg5unittest.TestSkippedException(
+                "System attributes unsupported on this platform."
+            )
+
+        self.pkgsend_bulk(self.rurl, [self.sysattr, self.sysattr2])
+
+        # Need to create an image in /var/tmp since sysattrs don't work
+        # in tmpfs.
+        old_img_path = self.img_path()
+        self.set_img_path(tempfile.mkdtemp(prefix="test-suite", dir="/var/tmp"))
+
+        self.image_create(self.rurl)
+        self.pkg("install sysattr sysattr2")
+        self.pkg("verify")
+        fpath = os.path.join(self.img_path(), "p1/bobcat")
+
+        # Need to get creative here to remove the system attributes
+        # since you need the sys_linkdir privilege which we don't have:
+        # see run.py:393
+        # So we re-create the file with correct owner and mode and the
+        # only thing missing are the sysattrs.
+        portable.remove(fpath)
+        portable.copyfile(os.path.join(self.test_root, "bobcat"), fpath)
+        os.chmod(fpath, 0o555)
+        os.chown(fpath, -1, 2)
+        self.pkg("verify", exit=1)
+        for sattr in ("H", "S"):
+            expected = "System attribute '{0}' not set".format(sattr)
+            self.assertTrue(
+                expected in self.output,
+                "Missing in verify output:  {0}".format(expected),
+            )
+
+        shutil.rmtree(self.img_path())
+        self.set_img_path(old_img_path)
+
+    def test_verify_invalid_fmri(self):
+        """Test invalid fmri triggers correct output."""
+
+        self.image_create(self.rurl)
+        self.pkg("install foo")
+
+        self.pkg_verify("foo@invalid", exit=1)
+        self.assertTrue("verify" in self.errout and "illegal" in self.errout)
+
+    def test_verify_parsable_output(self):
+        """Test parsable output."""
+
+        self.image_create(self.rurl)
+        self.pkg("install foo")
+        # Test invalid option combo.
+        self.pkg_verify("-v --parsable 0 foo", exit=2)
+        self.pkg_verify("-H --parsable 0 foo", exit=2)
+        # Test invalid option value.
+        self.pkg_verify("--parsable 1 foo", exit=2)
+        self.pkg_verify("--parsable 0 foo")
+        out_json = json.loads(self.output)
+        self.assertTrue(
+            "pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+            in out_json["item-messages"]
+        )
+        fmri_entry = out_json["item-messages"][
+            "pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+        ]
+        self.assertTrue(fmri_entry["messages"][0]["msg_level"] == "info")
+        self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
+
+        # Verify should fail if file is missing.
+        fpath = os.path.join(self.get_img_path(), "usr", "bin", "bobcat")
+        portable.remove(fpath)
+        self.pkg_verify("--parsable 0 foo", exit=1)
+        out_json = json.loads(self.output)
+        self.assertTrue(
+            "pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+            in out_json["item-messages"]
+        )
+        fmri_entry = out_json["item-messages"][
+            "pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+        ]
+        self.assertTrue(fmri_entry["messages"][0]["msg_type"] == "general")
+        self.assertTrue(fmri_entry["messages"][0]["msg_level"] == "error")
+        self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
+        self.assertTrue(
+            fmri_entry["file: usr/bin/bobcat"][0]["msg_type"] == "general"
+        )
+        self.assertTrue(
+            fmri_entry["file: usr/bin/bobcat"][0]["msg_level"] == "error"
+        )
+
+    def test_unpackaged(self):
+        """Test unpackaged option."""
+
+        self.image_create(self.rurl)
+        self.pkg("install foo")
+        self.pkg_verify("--unpackaged")
+        self.assertTrue(
+            "ERROR" not in self.output
+            and "WARNING" not in self.output
+            and "Unpackaged" in self.output
+            and "UNPACKAGED" in self.output
+        )
+        self.assertTrue("----" not in self.output)
+        # Test verbose.
+        self.pkg_verify("-v --unpackaged")
+        self.assertTrue("----" in self.output)
+        self.assertTrue(
+            "ERROR" not in self.output
+            and "WARNING" not in self.output
+            and "Unpackaged" in self.output
+            and "UNPACKAGED" in self.output
+        )
+        self.assertTrue(
+            "ERROR" not in self.output
+            and "WARNING" not in self.output
+            and "bobcat" in self.output
+            and "UNPACKAGED" in self.output
+        )
+        # Test omit header.
+        self.pkg_verify("--unpackaged -H")
+        self.assertTrue("----" not in self.output)
+        self.assertTrue(
+            "ERROR" not in self.output
+            and "WARNING" not in self.output
+            and "Unpackaged" in self.output
+            and "UNPACKAGED" not in self.output
+        )
+        # Test unpackaged only.
+        self.pkg_verify("--unpackaged-only -v")
+        self.assertTrue("----" not in self.output)
+        self.assertTrue(
+            "ERROR" not in self.output
+            and "WARNING" not in self.output
+            and "Unpackaged" in self.output
+            and "UNPACKAGED" in self.output
+        )
+        self.assertTrue(
+            "ERROR" not in self.output
+            and "WARNING" not in self.output
+            and "Unpackaged" in self.output
+            and "bobcat" not in self.output
+        )
+
+        # Test quiet result.
+        self.pkg_verify("-q --unpackaged")
+        self.assertTrue(not self.output)
+
+        # Test invalid usage.
+        self.pkg_verify("--unpackaged-only foo", exit=2)
+        self.pkg_verify("--unpackaged --unpackaged-only", exit=2)
+        self.pkg_verify("-H --parsable 0 --unpackaged", exit=2)
+
+        # Test --unpackaged with package arguments.
+        self.pkg_verify("--unpackaged -v foo")
+        self.assertTrue(
+            "----" in self.output
+            and "bobcat" in self.output
+            and "UNPACKAGED" in self.output
+        )
+        self.pkg_verify("--parsable 0 --unpackaged foo")
+        out_json = json.loads(self.output)
+        self.assertTrue(
+            "pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+            in out_json["item-messages"]
+        )
+        fmri_entry = out_json["item-messages"][
+            "pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+        ]
+        self.assertTrue(fmri_entry["messages"][0]["msg_level"] == "info")
+        self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
+
+        # Test parsable output for --unpackaged.
+        self.pkg_verify("--parsable 0 --unpackaged")
+        out_json = json.loads(self.output)
+        self.assertTrue(
+            "unpackaged" in out_json["item-messages"]
+            and out_json["item-messages"]["unpackaged"]
+        )
+        out_entry = out_json["item-messages"]["unpackaged"]
+        self.assertTrue(
+            "dir" in list(out_entry.keys())[0] or "file" in out_entry.keys()[0]
+        )
+        self.assertTrue(
+            out_entry[list(out_entry.keys())[0]][0]["msg_level"] == "info"
+        )
+        self.assertTrue(
+            out_entry[list(out_entry.keys())[0]][0]["msg_type"] == "unpackaged"
+        )
+        self.assertTrue(
+            "pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+            in out_json["item-messages"]
+        )
+        fmri_entry = out_json["item-messages"][
+            "pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+        ]
+        self.assertTrue(fmri_entry["messages"][0]["msg_level"] == "info")
+        self.assertTrue("file: usr/bin/bobcat" in fmri_entry)
+
+        # Test parsable output for --unpackaged-only.
+        self.pkg_verify("--parsable 0 --unpackaged-only")
+        out_json = json.loads(self.output)
+        self.assertTrue(
+            "unpackaged" in out_json["item-messages"]
+            and out_json["item-messages"]["unpackaged"]
+        )
+        out_entry = out_json["item-messages"]["unpackaged"]
+        self.assertTrue(
+            "dir" in list(out_entry.keys())[0] or "file" in out_entry.keys()[0]
+        )
+        self.assertTrue(
+            out_entry[list(out_entry.keys())[0]][0]["msg_level"] == "info"
+        )
+        self.assertTrue(
+            out_entry[list(out_entry.keys())[0]][0]["msg_type"] == "unpackaged"
+        )
+        self.assertTrue(
+            "pkg://test/foo@1.0,5.11-0:20160229T095441Z"
+            not in out_json["item-messages"]
+        )
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkg_version.py
+++ b/src/tests/cli/t_pkg_version.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import unittest
@@ -32,19 +33,18 @@ import os
 
 
 class TestPkgVersion(pkg5unittest.SingleDepotTestCase):
+    def test_pkg_version_bad_opts(self):
+        """test pkg version with bad options"""
 
-        def test_pkg_version_bad_opts(self):
-                """ test pkg version with bad options """
+        self.image_create(self.rurl)
 
-                self.image_create(self.rurl)
-
-                self.pkg("version -vq", use_img_root=False, exit=2)
-                self.pkg("version foo", use_img_root=False, exit=2)
-                self.pkg("version --", use_img_root=False, exit=2)
+        self.pkg("version -vq", use_img_root=False, exit=2)
+        self.pkg("version foo", use_img_root=False, exit=2)
+        self.pkg("version --", use_img_root=False, exit=2)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgdep.py
+++ b/src/tests/cli/t_pkgdep.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import itertools
@@ -47,14 +48,14 @@ DDP = base.Dependency.DEPEND_DEBUG_PREFIX
 py2_ver = "2.7"
 py3_ver = "{}.{}".format(sys.version_info.major, sys.version_info.minor)
 py3_suffix = "m" if sys.version_info.minor < 9 else ""
-py3_ext = "{}{}".format(py3_ver.replace('.', ''), py3_suffix)
+py3_ext = "{}{}".format(py3_ver.replace(".", ""), py3_suffix)
 
 py_ver_default = py3_ver
 py_ver_other = py2_ver
 
-class TestPkgdepBasics(pkg5unittest.SingleDepotTestCase):
 
-        test_manf_1 = """\
+class TestPkgdepBasics(pkg5unittest.SingleDepotTestCase):
+    test_manf_1 = """\
 hardlink path=baz target=var/log/authlog
 file group=bin mode=0755 owner=root \
 path=usr/lib/python{0}/v\
@@ -62,164 +63,203 @@ endor-packages/pkg/client/indexer.py
 file NOHA\
 SH group=bin mode=0755 owner=root path=u\
 sr/xpg4/lib/libcurses.so.1
-""".format(py_ver_default)
+""".format(
+        py_ver_default
+    )
 
-        test_manf_2 = """\
+    test_manf_2 = """\
 set name=variant.arch value=foo value=bar
 file NOHASH group=bin mode=0755 owner=root path=usr/xpg4/lib/libcurses.so.1 variant.arch=foo
 file NOHASH group=bin mode=0755 owner=root path=etc/pam.conf
 """
 
-        test_elf_warning_manf = """\
+    test_elf_warning_manf = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/xpg4/lib/libcurses.so.1
 file group=bin mode=0755 owner=root path=etc/libc.so.1
 """
 
-        test_bypass_manf = """\
+    test_bypass_manf = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/xpg4/lib/libcurses.so.1 pkg.depend.bypass-generate=lib/libc.so.1
 """
 
-        test_64bit_manf = """\
+    test_64bit_manf = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/bin/x64
 """
 
-        int_hardlink_manf = """\
+    int_hardlink_manf = """\
 hardlink path=usr/foo target=../var/log/syslog
 file NOHASH group=sys mode=0644 owner=root path=var/log/syslog
 """
 
-        resolve_dep_manf = """\
+    resolve_dep_manf = """\
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog preserve=true
 """
 
-        payload_manf = """\
+    payload_manf = """\
 hardlink path=usr/baz target=lib/python{0}/foo/bar.py
 file usr/lib/python{0}/vendor-packages/pkg/client/indexer.py \
 group=bin mode=0755 owner=root path=usr/lib/python{0}/foo/bar.py
-""".format(py_ver_default)
+""".format(
+        py_ver_default
+    )
 
-        elf_sub_manf = """\
+    elf_sub_manf = """\
 file {file_loc} group=bin mode=0755 owner=root path=bar/foo
 """
 
-        kernel_manf = """\
+    kernel_manf = """\
 file {file_loc} group=bin mode=0755 owner=root path=kernel/foobar
 """
 
-        miss_payload_manf = """\
+    miss_payload_manf = """\
 file {payload} group=bin mode=0755 owner=root path=foo/bar.py
 """
-        empty_payload_manf = """\
+    empty_payload_manf = """\
 file group=bin mode=0755 owner=root path=foo/bar.py
 """
 
-        nohash_payload_manf = """\
+    nohash_payload_manf = """\
 file NOHASH group=bin mode=0755 owner=root path=foo/bar.py
 """
 
-        if "PYTHONPATH" in os.environ:
-                py_path = [
-                    os.path.normpath(fp)
-                    for fp in os.environ["PYTHONPATH"].split(os.pathsep)
+    if "PYTHONPATH" in os.environ:
+        py_path = [
+            os.path.normpath(fp)
+            for fp in os.environ["PYTHONPATH"].split(os.pathsep)
+        ]
+    else:
+        py_path = []
+
+    glre = re.compile(r"\bpkg\.\S+path=usr/gcc/\d+/lib(/libc\.so\.1)? +")
+
+    def glfilter(self, s):
+        return set([x for x in s if not re.match(r"usr/gcc/\d+/", x)])
+
+    def get_ver_paths(self, ver, proto):
+        """To determine what the correct results should be for several
+        tests, it's necessary to discover what the sys.path is for the
+        version of python the test uses."""
+
+        cur_ver = "{0}.{1}".format(*sys.version_info[0:2])
+        if cur_ver == ver:
+            # Remove any paths that start with the defined python
+            # paths.
+            res = sorted(
+                set(
+                    [
+                        fp
+                        for fp in sys.path
+                        if not mf.DepthLimitedModuleFinder.startswith_path(
+                            fp, self.py_path
+                        )
+                    ]
+                )
+            )
+            return res
+
+        sp = subprocess.Popen(
+            "python{0} -c 'import sys; print(sys.path)'".format(ver),
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        out, err = sp.communicate()
+        if err:
+            raise RuntimeError("Error running python{0}:{1}".format(ver, err))
+        # The first item in sys.path is empty when sys.path is examined
+        # by running python via the -c option. When running an
+        # executable python script, the first item is the directory
+        # containing the script.
+        return sorted(
+            set(
+                [
+                    fp
+                    for fp in eval(out)[1:]
+                    if not mf.DepthLimitedModuleFinder.startswith_path(
+                        fp, self.py_path
+                    )
                 ]
-        else:
-                py_path = []
+            )
+        )
 
-        glre = re.compile(r'\bpkg\.\S+path=usr/gcc/\d+/lib(/libc\.so\.1)? +')
+    @staticmethod
+    def __make_paths(added, paths, install_path):
+        """Append a dependency path for "added" to each of
+        the paths in the list "paths" """
 
-        def glfilter(self, s):
-                return set([x for x in s if not re.match(r'usr/gcc/\d+/', x)])
+        return " ".join(
+            [
+                (
+                    "{pfx}.path={p}/{added}".format(
+                        **{
+                            "pfx": base.Dependency.DEPEND_DEBUG_PREFIX,
+                            "p": p.lstrip("/"),
+                            "added": added,
+                        }
+                    )
+                ).rstrip("/")
+                for p in paths
+            ]
+            + [
+                (
+                    "{pfx}.path={p}/{added}".format(
+                        **{
+                            "pfx": base.Dependency.DEPEND_DEBUG_PREFIX,
+                            "p": os.path.dirname(install_path),
+                            "added": added,
+                        }
+                    )
+                ).rstrip("/")
+            ]
+        )
 
-        def get_ver_paths(self, ver, proto):
-                """To determine what the correct results should be for several
-                tests, it's necessary to discover what the sys.path is for the
-                version of python the test uses."""
+    def make_res_manf_1(self, proto_area, reason, include_os=False):
+        return (
+            "depend {pfx}.file=python "
+            "{pfx}.path=usr/bin fmri={dummy_fmri} "
+            "type=require {pfx}.reason={reason} "
+            "{pfx}.type=script\n"
+            "depend fmri={dummy_fmri} "
+            "{pfx}.file=authlog "
+            "{pfx}.path=var/log "
+            "type=require {pfx}.reason=baz "
+            "{pfx}.type=hardlink\n"
+            + self.make_pyver_python_res(
+                py_ver_default, proto_area, reason, include_os=include_os
+            )
+        ).format(
+            pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+            dummy_fmri=base.Dependency.DUMMY_FMRI,
+            reason=reason,
+        )
 
-                cur_ver = "{0}.{1}".format(*sys.version_info[0:2])
-                if cur_ver == ver:
-                        # Remove any paths that start with the defined python
-                        # paths.
-                        res = sorted(set([
-                            fp for fp in sys.path
-                            if not mf.DepthLimitedModuleFinder.startswith_path(
-                                fp, self.py_path)
-                            ]))
-                        return res
+    def make_full_res_manf_1(self, proto_area, reason, include_os=False):
+        return (
+            self.make_res_manf_1(proto_area, reason, include_os=include_os)
+            + self.test_manf_1
+        )
 
-                sp = subprocess.Popen(
-                    "python{0} -c 'import sys; print(sys.path)'".format(ver),
-                    shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                out, err = sp.communicate()
-                if err:
-                        raise RuntimeError("Error running python{0}:{1}".format(
-                            ver, err))
-                # The first item in sys.path is empty when sys.path is examined
-                # by running python via the -c option. When running an
-                # executable python script, the first item is the directory
-                # containing the script.
-                return sorted(set([
-                    fp for fp in eval(out)[1:]
-                    if not mf.DepthLimitedModuleFinder.startswith_path(fp,
-                        self.py_path)
-                ]))
-
-        @staticmethod
-        def __make_paths(added, paths, install_path):
-                """ Append a dependency path for "added" to each of
-                the paths in the list "paths" """
-
-                return " ".join([
-                    ("{pfx}.path={p}/{added}".format(**{
-                        "pfx":
-                            base.Dependency.DEPEND_DEBUG_PREFIX,
-                        "p": p.lstrip("/"),
-                        "added": added
-                    })).rstrip("/")
-                    for p in paths
-                ] + [("{pfx}.path={p}/{added}".format(**{
-                    "pfx":
-                        base.Dependency.DEPEND_DEBUG_PREFIX,
-                    "p": os.path.dirname(install_path),
-                    "added": added,
-                })).rstrip("/")])
-
-        def make_res_manf_1(self, proto_area, reason, include_os=False):
-                return ("depend {pfx}.file=python "
-                    "{pfx}.path=usr/bin fmri={dummy_fmri} "
-                    "type=require {pfx}.reason={reason} "
-                    "{pfx}.type=script\n"
-
-                    "depend fmri={dummy_fmri} "
-                    "{pfx}.file=authlog "
-                    "{pfx}.path=var/log "
-                    "type=require {pfx}.reason=baz "
-                    "{pfx}.type=hardlink\n" +
-                    self.make_pyver_python_res(py_ver_default, proto_area,
-                        reason, include_os=include_os)).format(
-                    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-                    dummy_fmri=base.Dependency.DUMMY_FMRI,
-                    reason=reason
-               )
-
-        def make_full_res_manf_1(self, proto_area, reason, include_os=False):
-                return self.make_res_manf_1(proto_area, reason,
-                    include_os=include_os) + self.test_manf_1
-
-        err_manf_1 = """\
+    err_manf_1 = """\
 Couldn't find 'usr/xpg4/lib/libcurses.so.1' in any of the specified search directories:
         {0}
 """
-        res_manf_2 = """\
+    res_manf_2 = """\
 depend {pfx}.file=libc.so.1 {pfx}.path=lib {pfx}.path=usr/lib fmri={dummy_fmri} type=require {pfx}.reason=usr/xpg4/lib/libcurses.so.1 variant.arch=foo {pfx}.type=elf
-""".format(pfx=base.Dependency.DEPEND_DEBUG_PREFIX, dummy_fmri=base.Dependency.DUMMY_FMRI)
+""".format(
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+    )
 
-        res_int_manf = """\
+    res_int_manf = """\
 depend {pfx}.file=syslog {pfx}.path=var/log fmri={dummy_fmri} type=require {pfx}.reason=usr/foo {pfx}.type=hardlink
-""".format(pfx=base.Dependency.DEPEND_DEBUG_PREFIX, dummy_fmri=base.Dependency.DUMMY_FMRI)
+""".format(
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+    )
 
-        res_manf_2_missing = str(portable.UNKNOWN)
+    res_manf_2_missing = str(portable.UNKNOWN)
 
-        resolve_error = """\
+    resolve_error = """\
 {manf_path} has unresolved dependency '
     depend type=require fmri={dummy_fmri} {pfx}.file=libc.so.1 \\
         {pfx}.reason=usr/xpg4/lib/libcurses.so.1 \\
@@ -230,38 +270,43 @@ depend {pfx}.file=syslog {pfx}.path=var/log fmri={dummy_fmri} type=require {pfx}
 variant.arch:foo
 """
 
-        def make_full_res_manf_1_mod_proto(self, proto_area, reason,
-            include_os=False):
-                return self.make_full_res_manf_1(proto_area, reason,
-                    include_os=include_os) + \
-                    """\
+    def make_full_res_manf_1_mod_proto(
+        self, proto_area, reason, include_os=False
+    ):
+        return (
+            self.make_full_res_manf_1(proto_area, reason, include_os=include_os)
+            + """\
 depend fmri={dummy_fmri} {pfx}.file=libc.so.1 {pfx}.path=lib {pfx}.path=usr/lib {pfx}.reason=usr/xpg4/lib/libcurses.so.1 {pfx}.type=elf type=require
 """.format(
-    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI
-)
+                pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+                dummy_fmri=base.Dependency.DUMMY_FMRI,
+            )
+        )
 
-        def make_res_payload_1(self, proto_area, reason):
-                return ("depend fmri={dummy_fmri} "
-                    "{pfx}.file=python "
-                    "{pfx}.path=usr/bin "
-                    "{pfx}.reason={reason} "
-                    "{pfx}.type=script type=require\n" +
-                    self.make_pyver_python_res(py_ver_default, proto_area, reason)).format(**{
-                        "pfx":
-                            base.Dependency.DEPEND_DEBUG_PREFIX,
-                        "dummy_fmri":base.Dependency.DUMMY_FMRI,
-                        "reason": reason
-                    })
+    def make_res_payload_1(self, proto_area, reason):
+        return (
+            "depend fmri={dummy_fmri} "
+            "{pfx}.file=python "
+            "{pfx}.path=usr/bin "
+            "{pfx}.reason={reason} "
+            "{pfx}.type=script type=require\n"
+            + self.make_pyver_python_res(py_ver_default, proto_area, reason)
+        ).format(
+            **{
+                "pfx": base.Dependency.DEPEND_DEBUG_PREFIX,
+                "dummy_fmri": base.Dependency.DUMMY_FMRI,
+                "reason": reason,
+            }
+        )
 
-        two_variant_deps = """\
+    two_variant_deps = """\
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
 depend fmri=__TBD pkg.debug.depend.file=var/log/authlog pkg.debug.depend.reason=baz pkg.debug.depend.type=hardlink type=require
 depend fmri=__TBD pkg.debug.depend.file=var/log/file2 pkg.debug.depend.reason=baz pkg.debug.depend.type=hardlink type=require
 """
 
-        two_v_deps_bar = """
+    two_v_deps_bar = """
 set name=pkg.fmri value=pkg:/s-v-bar
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
@@ -269,21 +314,21 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.foo=bar
 file NOHASH group=sys mode=0600 owner=root path=var/log/file2
 """
 
-        two_v_deps_baz_one = """
+    two_v_deps_baz_one = """
 set name=pkg.fmri value=pkg:/s-v-baz-one
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.foo=baz variant.num=one
 """
 
-        two_v_deps_baz_two = """
+    two_v_deps_baz_two = """
 set name=pkg.fmri value=pkg:/s-v-baz-two
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.foo=baz variant.num=two
 """
 
-        two_v_deps_verbose_output = """\
+    two_v_deps_verbose_output = """\
 # {m1_path}
 depend fmri=pkg:/s-v-bar pkg.debug.depend.file=var/log/authlog pkg.debug.depend.file=var/log/file2 pkg.debug.depend.path-id=var/log/authlog pkg.debug.depend.path-id=var/log/file2 pkg.debug.depend.reason=baz pkg.debug.depend.type=hardlink type=require
 depend fmri=pkg:/s-v-baz-one pkg.debug.depend.file=var/log/authlog pkg.debug.depend.path-id=var/log/authlog pkg.debug.depend.reason=baz pkg.debug.depend.type=hardlink type=require variant.foo=baz variant.num=one
@@ -301,7 +346,7 @@ depend fmri=pkg:/s-v-baz-two pkg.debug.depend.file=var/log/authlog pkg.debug.dep
 # {m4_path}
 """
 
-        two_v_deps_output = """\
+    two_v_deps_output = """\
 # {m1_path}
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=three value=two
@@ -322,7 +367,7 @@ depend fmri=pkg:/s-v-baz-two type=require variant.foo=baz variant.num=two
 {m4_fmt}
 """
 
-        dup_variant_deps = """\
+    dup_variant_deps = """\
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two
 depend fmri=pkg:/s-v-bar type=require
@@ -339,7 +384,7 @@ depend fmri=__TBD pkg.debug.depend.file=var/log/f5 pkg.debug.depend.reason=b5 pk
 depend fmri=__TBD pkg.debug.depend.file=var/log/f6 pkg.debug.depend.reason=b5 pkg.debug.depend.type=hardlink type=require variant.foo=bar
 """
 
-        dup_prov = """
+    dup_prov = """
 set name=pkg.fmri value=pkg:/dup-prov
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
@@ -347,7 +392,7 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/f1
 file NOHASH group=sys mode=0600 owner=root path=var/log/f2
 """
 
-        subset_prov = """
+    subset_prov = """
 set name=pkg.fmri value=pkg:/subset-prov
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
@@ -355,7 +400,7 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/f5
 file NOHASH group=sys mode=0600 owner=root path=var/log/f6
 """
 
-        sep_vars = """
+    sep_vars = """
 set name=pkg.fmri value=pkg:/sep_vars
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
@@ -363,7 +408,7 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/f3 variant.foo=bar
 file NOHASH group=sys mode=0600 owner=root path=var/log/f4 variant.foo=baz
 """
 
-        dup_variant_deps_resolved = """\
+    dup_variant_deps_resolved = """\
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two
 depend fmri=pkg:/hand-dep type=require
@@ -377,93 +422,93 @@ depend fmri=pkg:/sep_vars pkg.debug.depend.file=var/log/f3 pkg.debug.depend.file
 depend fmri=pkg:/subset-prov pkg.debug.depend.file=var/log/f6 pkg.debug.depend.file=var/log/f5 pkg.debug.depend.path-id=var/log/f5 pkg.debug.depend.path-id=var/log/f6 pkg.debug.depend.reason=b5 pkg.debug.depend.type=hardlink type=require
 """
 
-        payload_elf_sub_error = """\
+    payload_elf_sub_error = """\
 {payload_path} (which will be installed at {installed_path}) had this token, {tok}, in its run path: {rp}.  It is not currently possible to automatically expand this token. Please specify its value on the command line.\
 """
 
-        payload_elf_sub_stdout = """\
+    payload_elf_sub_stdout = """\
 depend fmri={dummy_fmri} {pfx}.file=libc.so.1{replaced_path} {pfx}.path=lib {pfx}.path=usr/lib {pfx}.reason=bar/foo {pfx}.type=elf type=require\
 """.format(
-    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI,
-    replaced_path="{replaced_path}"
-)
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+        replaced_path="{replaced_path}",
+    )
 
-        #
-        # You may wonder why libc.so.1 is here as a dependency-- it's an
-        # artifact of the way we compile our dummy module, and serves as
-        # a "something to depend on".  In this way, the sample elf file
-        # depends on libc.so.1 in the same way that a kernel module might
-        # depend on another kernel module.
-        #
-        kernel_manf_stdout = """\
+    #
+    # You may wonder why libc.so.1 is here as a dependency-- it's an
+    # artifact of the way we compile our dummy module, and serves as
+    # a "something to depend on".  In this way, the sample elf file
+    # depends on libc.so.1 in the same way that a kernel module might
+    # depend on another kernel module.
+    #
+    kernel_manf_stdout = """\
 depend fmri={dummy_fmri} {pfx}.file=libc.so.1 {pfx}.path=kernel {pfx}.path=usr/kernel {pfx}.reason=kernel/foobar {pfx}.type=elf type=require\
 """.format(
-    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI
-)
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+    )
 
-        kernel_manf_stdout2 = """\
+    kernel_manf_stdout2 = """\
 depend fmri={dummy_fmri} {pfx}.file=libc.so.1 {pfx}.path=baz {pfx}.path=foo/bar {pfx}.reason=kernel/foobar {pfx}.type=elf type=require\
 """.format(
-    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI
-)
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+    )
 
-        kernel_manf_stdout_platform = """\
+    kernel_manf_stdout_platform = """\
 depend fmri={dummy_fmri} {depend_debug_prefix}.file=libc.so.1 {depend_debug_prefix}.path=platform/baz/kernel {depend_debug_prefix}.path=platform/tp/kernel {depend_debug_prefix}.path=kernel {depend_debug_prefix}.path=usr/kernel {depend_debug_prefix}.reason=kernel/foobar {depend_debug_prefix}.type=elf type=require\
 """.format(
-    depend_debug_prefix=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI
-)
+        depend_debug_prefix=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+    )
 
-        miss_payload_manf_error = """\
+    miss_payload_manf_error = """\
 Couldn't find '{payload}' needed for 'foo/bar.py' in any of the specified search directories:
 	{path_pref}
 """
 
-        empty_payload_manf_error = """\
+    empty_payload_manf_error = """\
 Couldn't find 'foo/bar.py' in any of the specified search directories:
         {path_pref}
 """
 
-        double_plat_error = """\
+    double_plat_error = """\
 {proto_dir}/elf_test (which will be installed at bar/foo) had this token, $PLATFORM, in its run path: /platform/$PLATFORM/foo.  It is not currently possible to automatically expand this token. Please specify its value on the command line.
 {proto_dir}/elf_test (which will be installed at bar/foo) had this token, $PLATFORM, in its run path: /isadir/$PLATFORM/baz.  It is not currently possible to automatically expand this token. Please specify its value on the command line."""
 
-        double_plat_stdout = """\
+    double_plat_stdout = """\
 depend fmri={dummy_fmri} {pfx}.file=libc.so.1 {pfx}.path=lib {pfx}.path=usr/lib {pfx}.reason=bar/foo {pfx}.type=elf type=require\
 """.format(
-    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI
-)
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+    )
 
-        double_plat_isa_error = """\
+    double_plat_isa_error = """\
 {proto_dir}/elf_test (which will be installed at bar/foo) had this token, $ISALIST, in its run path: /$ISALIST/$PLATFORM/baz.  It is not currently possible to automatically expand this token. Please specify its value on the command line.\
 """
 
-        double_plat_isa_stdout = """\
+    double_plat_isa_stdout = """\
 depend fmri={dummy_fmri} {pfx}.file=libc.so.1 {pfx}.path=platform/pfoo/foo {pfx}.path=lib {pfx}.path=usr/lib {pfx}.reason=bar/foo {pfx}.type=elf type=require\
 """.format(
-    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI
-)
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+    )
 
-        double_double_stdout = """\
+    double_double_stdout = """\
 depend fmri={dummy_fmri} {pfx}.file=libc.so.1 {pfx}.path=platform/pfoo/foo {pfx}.path=platform/pfoo2/foo {pfx}.path=isadir/pfoo/baz {pfx}.path=isadir/pfoo2/baz {pfx}.path=isadir/pfoo/baz {pfx}.path=isadir/pfoo2/baz {pfx}.path=lib {pfx}.path=usr/lib {pfx}.reason=bar/foo {pfx}.type=elf type=require\
 """.format(
-    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI
-)
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+    )
 
-        two_v_deps_resolve_error = """\
+    two_v_deps_resolve_error = """\
 {manf_path} has unresolved dependency '
     depend type=require fmri={dummy_fmri} {pfx}.file=var/log/authlog \\
         {pfx}.reason=baz {pfx}.type=hardlink
 ' under the following combinations of variants:
 variant.foo:baz variant.num:three
 """
-        usage_msg = """\
+    usage_msg = """\
 Usage:
         pkgdepend [options] command [cmd_options] [operands]
 
@@ -479,27 +524,27 @@ Options:
 Environment:
         PKG_IMAGE"""
 
-        collision_manf = """\
+    collision_manf = """\
 set name=pkg.fmri value=pkg:/collision_manf
 depend fmri=__TBD pkg.debug.depend.file=no_such_named_file pkg.debug.depend.path=platform/foo/baz pkg.debug.depend.path=platform/bar/baz pkg.debug.depend.path=lib pkg.debug.depend.path=usr/lib pkg.debug.depend.reason=foo/bar pkg.debug.depend.type=elf type=require\
 """
 
-        sat_bar_libc = """\
+    sat_bar_libc = """\
 set name=pkg.fmri value=pkg:/sat_bar_libc
 file NOHASH path=platform/bar/baz/no_such_named_file
 """
 
-        sat_bar_libc2 = """\
+    sat_bar_libc2 = """\
 set name=pkg.fmri value=pkg:/sat_bar_libc2
 file NOHASH path=platform/bar/baz/no_such_named_file
 """
 
-        sat_foo_libc = """\
+    sat_foo_libc = """\
 set name=pkg.fmri value=pkg:/sat_foo_libc
 file NOHASH path=platform/foo/baz/no_such_named_file
 """
 
-        run_path_errors = """\
+    run_path_errors = """\
 The file dependency depend fmri={dummy_fmri} {pfx}.file=no_such_named_file {pfx}.path=platform/foo/baz {pfx}.path=platform/bar/baz {pfx}.path=lib {pfx}.path=usr/lib {pfx}.reason=foo/bar {pfx}.type=elf type=require delivered in pkg:/collision_manf has paths which resolve to multiple packages.
 The actions are:
         depend fmri=pkg:/sat_bar_libc {pfx}.file=platform/bar/baz/no_such_named_file {pfx}.reason=foo/bar {pfx}.type=elf type=require
@@ -512,12 +557,12 @@ The actions are:
         {pfx}.path=platform/foo/baz \\
         {pfx}.path=usr/lib'.
 """.format(
-    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI,
-    unresolved_path="{unresolved_path}"
-)
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+        unresolved_path="{unresolved_path}",
+    )
 
-        amb_path_errors = """\
+    amb_path_errors = """\
 The file dependency
     depend type=require fmri={dummy_fmri} {pfx}.file=no_such_named_file \\
         {pfx}.reason=foo/bar {pfx}.type=elf \\
@@ -534,12 +579,12 @@ depends on a path delivered by multiple packages. Those packages are:pkg:/sat_ba
         {pfx}.path=platform/bar/baz \\
         {pfx}.path=usr/lib'.
 """.format(
-    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI,
-    unresolved_path="{unresolved_path}"
-)
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+        unresolved_path="{unresolved_path}",
+    )
 
-        python_text = """\
+    python_text = """\
 #!/usr/bin/python
 
 import pkg.indexer as indexer
@@ -547,91 +592,109 @@ import pkg.search_storage as ss
 from pkg.misc import EmptyI
 """
 
-        python3_so_text = """\
+    python3_so_text = """\
 #!/usr/bin/python{0}
 
 import zlib
-""".format(py3_ver)
+""".format(
+        py3_ver
+    )
 
-        python_amd_text = """\
+    python_amd_text = """\
 #!/usr/bin/amd64/python{0}
 
 import pkg.indexer as indexer
-""".format(py_ver_default)
+""".format(
+        py_ver_default
+    )
 
-        python_amd_manf = """\
+    python_amd_manf = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/bin/amd64/python{0}-config
-""".format(py_ver_default)
+""".format(
+        py_ver_default
+    )
 
-        python_sparcv9_text = """\
+    python_sparcv9_text = """\
 #!/usr/bin/sparcv9/python{0}
 
 from pkg.misc import EmptyI
-""".format(py_ver_default)
+""".format(
+        py_ver_default
+    )
 
-        python_sparcv9_manf = """\
+    python_sparcv9_manf = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/bin/sparcv9/python{0}-config
-""".format(py_ver_default)
+""".format(
+        py_ver_default
+    )
 
-        py_in_usr_bin_manf = """\
+    py_in_usr_bin_manf = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/bin/pkg \
 """
 
-        py_in_usr_bin_manf_non_ex = """\
+    py_in_usr_bin_manf_non_ex = """\
 file NOHASH group=bin mode=0644 owner=root path=usr/bin/pkg \
 """
 
-        # The #! line has lots of spaces to test for bug 14632.
-        pyver_python_text = "#!                  /usr/bin/python{0}     -S  " + \
-"""
+    # The #! line has lots of spaces to test for bug 14632.
+    pyver_python_text = (
+        "#!                  /usr/bin/python{0}     -S  "
+        + """
 import pkg.indexer as indexer
 import pkg.search_storage as ss
 import os.path
 from pkg.misc import EmptyI
 """
+    )
 
-        pyver_test_manf_1 = """\
+    pyver_test_manf_1 = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/client/indexer.py \
 """
 
-        pyver_test_manf_1_run_path = """\
+    pyver_test_manf_1_run_path = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/client/indexer.py pkg.depend.runpath=$PKGDEPEND_RUNPATH \
 """
 
-        pyver_test_manf_1_non_ex = """\
+    pyver_test_manf_1_non_ex = """\
 file NOHASH group=bin mode=0644 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/client/indexer.py \
 """
 
-        inst_pkg = """\
+    inst_pkg = """\
 open example2_pkg@1.0,5.11-0
 add file tmp/foo mode=0555 owner=root group=bin path=/usr/bin/python{0}
-close""".format(py_ver_default)
+close""".format(
+        py_ver_default
+    )
 
-        multi_deps = """\
+    multi_deps = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python{0}/v-p/pkg/client/indexer.py
 depend fmri=__TBD pkg.debug.depend.file=usr/bin/python{0} pkg.debug.depend.reason=usr/lib/python{0}/v-p/pkg/client/indexer.py pkg.debug.depend.type=script type=require
 depend fmri=__TBD pkg.debug.depend.file=usr/lib/python{0}/v-p/pkg/misc.py pkg.debug.depend.reason=usr/lib/python{0}/v-p/pkg/client/indexer.py pkg.debug.depend.type=python type=require
-""".format(py_ver_default)
+""".format(
+        py_ver_default
+    )
 
-        misc_manf = """\
+    misc_manf = """\
 set name=pkg.fmri value=pkg:/footest@0.5.11,5.11-0.117
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{0}/v-p/pkg/misc.py
-""".format(py_ver_default)
+""".format(
+        py_ver_default
+    )
 
-        unsatisfied_manf = """\
+    unsatisfied_manf = """\
 set name=pkg.fmri value=pkg:/unsatisfied_manf
 set name=variant.foo value=bar
 depend fmri=__TBD pkg.debug.depend.file=unsatisfied pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=foo/bar pkg.debug.depend.type=elf type=require
 """
 
-        unsatisfied_error_1 = """\
+    unsatisfied_error_1 = """\
 {0} has unresolved dependency '
     depend type=require fmri=__TBD pkg.debug.depend.file=unsatisfied \\
         pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=foo/bar \\
         pkg.debug.depend.type=elf'.
 """
 
-        unsatisfied_error_2 = """\
+    unsatisfied_error_2 = """\
 {0} has unresolved dependency '
     depend  type=require fmri=__TBD pkg.debug.depend.file=unsatisfied \\
         pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=foo/bar \\
@@ -640,161 +703,166 @@ depend fmri=__TBD pkg.debug.depend.file=unsatisfied pkg.debug.depend.path=usr/bi
 variant.foo:bar
 """
 
-        partially_satisfied_manf = """\
+    partially_satisfied_manf = """\
 set name=pkg.fmri value=pkg:/partially_satisfied_manf
 set name=variant.foo value=bar value=baz
 depend fmri=__TBD pkg.debug.depend.file=unsatisfied pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=foo/bar pkg.debug.depend.type=elf type=require
 """
 
-        satisfying_manf = """\
+    satisfying_manf = """\
 set name=pkg.fmri value=pkg:/satisfying_manf
 set name=variant.foo value=baz
 file NOHASH path=usr/bin/unsatisfied owner=root group=staff mode=0555
 """
 
-        satisfying_out = """\
+    satisfying_out = """\
 depend fmri=pkg:/satisfying_manf type=require variant.foo=baz
 """
 
-        def make_pyver_python_res(self, ver, proto_area, reason,
-            include_os=False):
-                """Create the python dependency results with paths expected for
-                the pyver tests.
+    def make_pyver_python_res(self, ver, proto_area, reason, include_os=False):
+        """Create the python dependency results with paths expected for
+        the pyver tests.
 
-                Because the paths that should be found depend both on the
-                version of python and what is found by the site module, it's
-                necessary to make the results depend on the sys.path that's
-                discovered.
-                """
+        Because the paths that should be found depend both on the
+        version of python and what is found by the site module, it's
+        necessary to make the results depend on the sys.path that's
+        discovered.
+        """
 
-                v3 = ver.startswith("3.") and py3_ext
+        v3 = ver.startswith("3.") and py3_ext
 
-                vp = self.get_ver_paths(ver, proto_area)
-                self.debug("ver_paths is {0}".format(vp))
-                pkg_path = self.__make_paths("pkg", vp, reason)
-                res = ("depend fmri={dummy_fmri} "
-                    "{pfx}.file=indexer.py "
-                    "{pfx}.file=indexer.pyc "
-                    "{pfx}.file=indexer.pyo "
-                    "{pfx}.file=64/indexer.so "
-                    "{pfx}.file=indexer.so "
-                    "{pfx}.file=indexer/__init__.py " +
-                    (v3 and
-                        "{pfx}.file=indexer.abi3.so "
-                        "{pfx}.file=indexer.cpython-{v3}.so "
-                        "{pfx}.file=64/indexer.abi3.so "
-                        "{pfx}.file=64/indexer.cpython-{v3}.so "
-                        or
-                        "{pfx}.file=indexermodule.so "
-                        "{pfx}.file=64/indexermodule.so ") +
-                    pkg_path +
-                    " {pfx}.reason={reason} "
-                    "{pfx}.type=python type=require\n"
+        vp = self.get_ver_paths(ver, proto_area)
+        self.debug("ver_paths is {0}".format(vp))
+        pkg_path = self.__make_paths("pkg", vp, reason)
+        res = (
+            "depend fmri={dummy_fmri} "
+            "{pfx}.file=indexer.py "
+            "{pfx}.file=indexer.pyc "
+            "{pfx}.file=indexer.pyo "
+            "{pfx}.file=64/indexer.so "
+            "{pfx}.file=indexer.so "
+            "{pfx}.file=indexer/__init__.py "
+            + (
+                v3
+                and "{pfx}.file=indexer.abi3.so "
+                "{pfx}.file=indexer.cpython-{v3}.so "
+                "{pfx}.file=64/indexer.abi3.so "
+                "{pfx}.file=64/indexer.cpython-{v3}.so "
+                or "{pfx}.file=indexermodule.so "
+                "{pfx}.file=64/indexermodule.so "
+            )
+            + pkg_path
+            + " {pfx}.reason={reason} "
+            "{pfx}.type=python type=require\n"
+            "depend fmri={dummy_fmri} "
+            "{pfx}.file=misc.py "
+            "{pfx}.file=misc.pyc "
+            "{pfx}.file=misc.pyo "
+            "{pfx}.file=misc.so "
+            "{pfx}.file=64/misc.so "
+            "{pfx}.file=misc/__init__.py "
+            + (
+                v3
+                and "{pfx}.file=misc.abi3.so "
+                "{pfx}.file=misc.cpython-{v3}.so "
+                "{pfx}.file=64/misc.abi3.so "
+                "{pfx}.file=64/misc.cpython-{v3}.so "
+                or "{pfx}.file=64/miscmodule.so " "{pfx}.file=miscmodule.so "
+            )
+            + pkg_path
+            + " {pfx}.reason={reason} "
+            "{pfx}.type=python type=require\n"
+            "depend fmri={dummy_fmri} "
+            "{pfx}.file=pkg/__init__.py "
+            + self.__make_paths("", vp, reason)
+            + " {pfx}.reason={reason} "
+            "{pfx}.type=python type=require\n"
+            "depend fmri={dummy_fmri} "
+            "{pfx}.file=search_storage.py "
+            "{pfx}.file=search_storage.pyc "
+            "{pfx}.file=search_storage.pyo "
+            "{pfx}.file=64/search_storage.so "
+            "{pfx}.file=search_storage.so "
+            "{pfx}.file=search_storage/__init__.py "
+            + (
+                v3
+                and "{pfx}.file=search_storage.abi3.so "
+                "{pfx}.file=search_storage.cpython-{v3}.so "
+                "{pfx}.file=64/search_storage.abi3.so "
+                "{pfx}.file=64/search_storage.cpython-{v3}.so "
+                or "{pfx}.file=64/search_storagemodule.so "
+                "{pfx}.file=search_storagemodule.so "
+            )
+            + pkg_path
+            + " {pfx}.reason={reason} "
+            "{pfx}.type=python type=require\n"
+        )
 
-                    "depend fmri={dummy_fmri} "
-                    "{pfx}.file=misc.py "
-                    "{pfx}.file=misc.pyc "
-                    "{pfx}.file=misc.pyo "
-                    "{pfx}.file=misc.so "
-                    "{pfx}.file=64/misc.so "
-                    "{pfx}.file=misc/__init__.py " +
-                    (v3 and
-                        "{pfx}.file=misc.abi3.so "
-                        "{pfx}.file=misc.cpython-{v3}.so "
-                        "{pfx}.file=64/misc.abi3.so "
-                        "{pfx}.file=64/misc.cpython-{v3}.so "
-                        or
-                        "{pfx}.file=64/miscmodule.so "
-                        "{pfx}.file=miscmodule.so ") +
-                    pkg_path +
-                    " {pfx}.reason={reason} "
-                    "{pfx}.type=python type=require\n"
-
-                    "depend fmri={dummy_fmri} "
-                    "{pfx}.file=pkg/__init__.py " +
-                    self.__make_paths("", vp, reason) +
-                    " {pfx}.reason={reason} "
-                    "{pfx}.type=python type=require\n"
-
-                    "depend fmri={dummy_fmri} "
-                    "{pfx}.file=search_storage.py "
-                    "{pfx}.file=search_storage.pyc "
-                    "{pfx}.file=search_storage.pyo "
-                    "{pfx}.file=64/search_storage.so "
-                    "{pfx}.file=search_storage.so "
-                    "{pfx}.file=search_storage/__init__.py " +
-                    (v3 and
-                        "{pfx}.file=search_storage.abi3.so "
-                        "{pfx}.file=search_storage.cpython-{v3}.so "
-                        "{pfx}.file=64/search_storage.abi3.so "
-                        "{pfx}.file=64/search_storage.cpython-{v3}.so "
-                        or
-                        "{pfx}.file=64/search_storagemodule.so "
-                        "{pfx}.file=search_storagemodule.so ") +
-                    pkg_path +
-                    " {pfx}.reason={reason} "
-                    "{pfx}.type=python type=require\n")
-
-                if include_os:
-                        res += (
-                            "depend fmri={dummy_fmri} "
-                            "{pfx}.file=os.py "
-                            "{pfx}.file=os.pyc "
-                            "{pfx}.file=os.pyo "
-                            "{pfx}.file=os.so "
-                            "{pfx}.file=64/os.so "
-                            "{pfx}.file=os/__init__.py " +
-                            (v3 and
-                                "{pfx}.file=os.abi3.so "
-                                "{pfx}.file=os.cpython-{v3}.so "
-                                "{pfx}.file=64/os.abi3.so "
-                                "{pfx}.file=64/os.cpython-{v3}.so "
-                                or
-                                "{pfx}.file=64/osmodule.so "
-                                "{pfx}.file=osmodule.so ") +
-                            self.__make_paths("", vp, reason) +
-                            " {pfx}.reason={reason} "
-                            "{pfx}.type=python type=require\n")
-                return res.format(
-                    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-                    dummy_fmri=base.Dependency.DUMMY_FMRI,
-                    reason=reason, v3=v3
+        if include_os:
+            res += (
+                "depend fmri={dummy_fmri} "
+                "{pfx}.file=os.py "
+                "{pfx}.file=os.pyc "
+                "{pfx}.file=os.pyo "
+                "{pfx}.file=os.so "
+                "{pfx}.file=64/os.so "
+                "{pfx}.file=os/__init__.py "
+                + (
+                    v3
+                    and "{pfx}.file=os.abi3.so "
+                    "{pfx}.file=os.cpython-{v3}.so "
+                    "{pfx}.file=64/os.abi3.so "
+                    "{pfx}.file=64/os.cpython-{v3}.so "
+                    or "{pfx}.file=64/osmodule.so " "{pfx}.file=osmodule.so "
                 )
+                + self.__make_paths("", vp, reason)
+                + " {pfx}.reason={reason} "
+                "{pfx}.type=python type=require\n"
+            )
+        return res.format(
+            pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+            dummy_fmri=base.Dependency.DUMMY_FMRI,
+            reason=reason,
+            v3=v3,
+        )
 
-        pyver_other_script_full_manf_1 = """\
+    pyver_other_script_full_manf_1 = """\
 file NOHASH group=bin mode=0755 owner=root path={reason} {run_path}
 depend fmri={dummy_fmri} {pfx}.file=python{bin_ver} {pfx}.path=usr/bin {pfx}.reason={reason} {pfx}.type=script type=require
 """.format(
-    pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-    dummy_fmri=base.Dependency.DUMMY_FMRI,
-    reason="{reason}",
-    bin_ver="{bin_ver}",
-    run_path="{run_path}"
-)
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+        reason="{reason}",
+        bin_ver="{bin_ver}",
+        run_path="{run_path}",
+    )
 
-        def pyver_res_full_manf_1(self, ver, proto, reason, include_os=False):
-                """Build the full manifest results for the pyver tests."""
+    def pyver_res_full_manf_1(self, ver, proto, reason, include_os=False):
+        """Build the full manifest results for the pyver tests."""
 
-                if ver == py_ver_other:
-                        tmp = self.pyver_other_script_full_manf_1
-                else:
-                        raise RuntimeError("Unexpected version for "
-                            "pyver_res_full_manf_1 {0}".format(ver))
-                return tmp + self.make_pyver_python_res(ver, proto, reason,
-                    include_os=include_os)
+        if ver == py_ver_other:
+            tmp = self.pyver_other_script_full_manf_1
+        else:
+            raise RuntimeError(
+                "Unexpected version for "
+                "pyver_res_full_manf_1 {0}".format(ver)
+            )
+        return tmp + self.make_pyver_python_res(
+            ver, proto, reason, include_os=include_os
+        )
 
-        if six.PY2:
-                # in this case, py_ver_default = "2.7", py_ver_other = "3.x"
-                pyver_resolve_dep_manf = """
+    if six.PY2:
+        # in this case, py_ver_default = "2.7", py_ver_other = "3.x"
+        pyver_resolve_dep_manf = """
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/indexer.py
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/__init__.py
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/lib-dynload/64/pkg/search_storage.py
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/misc.py
 file NOHASH group=bin mode=0755 owner=root path=usr/bin/python
 """
-        else:
-                # py_ver_default = "3.x", py_ver_other = "2.7"
-                pyver_resolve_dep_manf = """
+    else:
+        # py_ver_default = "3.x", py_ver_other = "2.7"
+        pyver_resolve_dep_manf = """
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/indexer.py
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-packages/pkg/__init__.py
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/lib-tk/pkg/search_storage.py
@@ -802,172 +870,205 @@ file NOHASH group=bin mode=0444 owner=root path=usr/lib/python{py_ver}/vendor-pa
 file NOHASH group=bin mode=0755 owner=root path=usr/bin/python
 """
 
-        def make_pyver_resolve_results(self, proto_area):
-                """Generate the expected results when resolving a manifest which
-                contains a file with a non-default version of python."""
+    def make_pyver_resolve_results(self, proto_area):
+        """Generate the expected results when resolving a manifest which
+        contains a file with a non-default version of python."""
 
-                v3 = py_ver_other.startswith("3.") and py3_ext
+        v3 = py_ver_other.startswith("3.") and py3_ext
 
-                patterns = (
-                    "{0}.py", "{0}.pyc", "{0}.pyo",
-                    "{0}.so", "64/{0}.so",
-                    "{0}/__init__.py"
-                )
-                if v3:
-                        patterns += (
-                            "{0}.abi3.so", "{0}.cpython-{v3}.so",
-                            "64/{0}.abi3.so", "64/{0}.cpython-{v3}.so",
+        patterns = (
+            "{0}.py",
+            "{0}.pyc",
+            "{0}.pyo",
+            "{0}.so",
+            "64/{0}.so",
+            "{0}/__init__.py",
+        )
+        if v3:
+            patterns += (
+                "{0}.abi3.so",
+                "{0}.cpython-{v3}.so",
+                "64/{0}.abi3.so",
+                "64/{0}.cpython-{v3}.so",
+            )
+        else:
+            patterns += ("{0}module.so", "64/{0}module.so")
+
+        files = ["indexer", "misc", "search_storage"]
+
+        # These are the paths to the files which the package depends on.
+        # __init__ isn't part of files because it's not in the path-id.
+        # search_storage.py is handled separately because it's delivered
+        # in a different location than the other files, so it needs a
+        # different path attached to it.
+        rel_paths = [
+            "usr/lib/python{py_ver}/vendor-packages/pkg/" + f + ".py"
+            for f in files + ["__init__"]
+            if f != "search_storage"
+        ]
+
+        if six.PY2:
+            rel_paths += [
+                "usr/bin/python",
+                "usr/lib/python{py_ver}/lib-dynload/64/pkg/search_storage.py",
+            ]
+        else:
+            rel_paths += [
+                "usr/bin/python",
+                "usr/lib/python{py_ver}/lib-tk/pkg/search_storage.py",
+            ]
+
+        # Find the potential locations an imported python module might
+        # be found.
+        vps = self.get_ver_paths(py_ver_other, proto_area) + [
+            "usr/lib/python{0}/vendor-packages/pkg/client".format(py_ver_other)
+        ]
+        vps = [vp.lstrip("/") + "/pkg/" for vp in vps]
+
+        # Produce the expected dependency.  The package name will be
+        # filled in by the caller of this function.  The pdd.file
+        # attributes are taken from rel_paths.  Path-id is an pkgdepend
+        # internal attribute which allows it to know which dependencies
+        # where merged together to form a particular final dependency.
+        # The __init__.py file follows a different pattern than the
+        # other files, so it's handled separately.
+        return (
+            "depend fmri=pkg:/{res_manf} "
+            + " ".join(["{pfx}.file=" + rp for rp in rel_paths])
+            + " "
+            + " ".join(
+                [
+                    "{pfx}.path-id="
+                    + ":".join(
+                        sorted(
+                            [
+                                proto_str + pat.format(f, v3=v3)
+                                for proto_str in vps
+                                for pat in patterns
+                            ]
                         )
-                else:
-                        patterns += ("{0}module.so", "64/{0}module.so")
-
-                files = ["indexer", "misc", "search_storage"]
-
-                # These are the paths to the files which the package depends on.
-                # __init__ isn't part of files because it's not in the path-id.
-                # search_storage.py is handled separately because it's delivered
-                # in a different location than the other files, so it needs a
-                # different path attached to it.
-                rel_paths = [
-                    "usr/lib/python{py_ver}/vendor-packages/pkg/" + f + ".py"
-                    for f in files + ["__init__"] if f != "search_storage"
+                    )
+                    for f in files
                 ]
+            )
+            + " {pfx}.path-id="
+            + ":".join(sorted([vp + "__init__.py" for vp in vps]))
+            + " {pfx}.path-id=usr/bin/python "
+            + "{pfx}.reason=usr/lib/python{py_ver}/"
+            + "vendor-packages/pkg/client/indexer.py "
+            + "{pfx}.type=script {pfx}.type=python type=require"
+        )
 
-                if six.PY2:
-                        rel_paths += ["usr/bin/python",
-                            "usr/lib/python{py_ver}/lib-dynload/64/pkg/search_storage.py"]
-                else:
-                        rel_paths += ["usr/bin/python",
-                            "usr/lib/python{py_ver}/lib-tk/pkg/search_storage.py"]
-
-                # Find the potential locations an imported python module might
-                # be found.
-                vps = self.get_ver_paths(py_ver_other, proto_area) + \
-                    ["usr/lib/python{0}/vendor-packages/pkg/client".format(py_ver_other)]
-                vps = [vp.lstrip("/") + "/pkg/" for vp in vps]
-
-                # Produce the expected dependency.  The package name will be
-                # filled in by the caller of this function.  The pdd.file
-                # attributes are taken from rel_paths.  Path-id is an pkgdepend
-                # internal attribute which allows it to know which dependencies
-                # where merged together to form a particular final dependency.
-                # The __init__.py file follows a different pattern than the
-                # other files, so it's handled separately.
-                return "depend fmri=pkg:/{res_manf} " + \
-                    " ".join(["{pfx}.file=" + rp for rp in rel_paths]) + \
-                    " " + " ".join(["{pfx}.path-id=" + ":".join(sorted([
-                        proto_str + pat.format(f, v3=v3)
-                        for proto_str in vps
-                        for pat in patterns
-                        ]))
-                        for f in files
-                    ]) + " {pfx}.path-id=" + ":".join(sorted(
-                        [vp + "__init__.py" for vp in vps])) + \
-                    " {pfx}.path-id=usr/bin/python " + \
-                    "{pfx}.reason=usr/lib/python{py_ver}/" + \
-                    "vendor-packages/pkg/client/indexer.py " + \
-                    "{pfx}.type=script {pfx}.type=python type=require"
-
-        pyver_mismatch_results = """\
+    pyver_mismatch_results = """\
 depend fmri={dummy_fmri} {pfx}.file=python{default} {pfx}.path=usr/bin {pfx}.reason=usr/lib/python{other}/vendor-packages/pkg/client/indexer.py {pfx}.type=script type=require
-""".format(default=py_ver_default, other=py_ver_other, pfx=base.Dependency.DEPEND_DEBUG_PREFIX, dummy_fmri=base.Dependency.DUMMY_FMRI)
+""".format(
+        default=py_ver_default,
+        other=py_ver_other,
+        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        dummy_fmri=base.Dependency.DUMMY_FMRI,
+    )
 
-        pyver_mismatch_errs = """
+    pyver_mismatch_errs = """
 The file to be installed at usr/lib/python{0}/vendor-packages/pkg/client/indexer.py declares a python version of {1}.  However, the path suggests that the version should be {0}.  The text of the file can be found at {{0}}/usr/lib/python{0}/vendor-packages/pkg/client/indexer.py
-""".format(py_ver_other, py_ver_default)
+""".format(
+        py_ver_other, py_ver_default
+    )
 
-        pyver_unspecified_ver_err = """
+    pyver_unspecified_ver_err = """
 The file to be installed in usr/bin/pkg does not specify a specific version of python either in its installed path nor in its text.  Such a file cannot be analyzed for dependencies since the version of python it will be used with is unknown.  The text of the file is here: {0}/usr/bin/pkg.
 """
 
-        bug_16808_manf = """\
+    bug_16808_manf = """\
 file NOHASH group=bin mode=0755 owner=root path=var/log/syslog variant.opensolaris.zone=global
 hardlink path=var/log/foobar target=syslog
 """
 
-        bug_18640960_manf = """\
+    bug_18640960_manf = """\
 set name=variant.opensolaris.zone value=global
 file NOHASH group=bin mode=0755 owner=root path=var/log/syslog variant.opensolaris.zone=nonglobal
 hardlink path=var/log/foobar target=syslog
 """
 
-        bug_15958_manf = """\
+    bug_15958_manf = (
+        """\
 set name=variant.opensolaris.zone value=global value=nonglobal
-""" + bug_16808_manf
+"""
+        + bug_16808_manf
+    )
 
-        res_bug_15958 = """\
+    res_bug_15958 = """\
 depend fmri=__TBD pkg.debug.depend.file=syslog pkg.debug.depend.path=var/log pkg.debug.depend.reason=var/log/foobar pkg.debug.depend.type=hardlink type=require variant.opensolaris.zone=nonglobal
 """
 
-        bug_16808_warning = """\
+    bug_16808_warning = """\
 WARNING: The action delivering var/log/syslog is tagged with a variant type or value not declared for the package; use pkglint for details.
 The action's variants are:  variant.opensolaris.zone="global"
 The package's variants are: {}
 """
 
-        bug_18640960_warning = """\
+    bug_18640960_warning = """\
 WARNING: The action delivering var/log/syslog is tagged with a variant type or value not declared for the package; use pkglint for details.
 The action's variants are:  variant.opensolaris.zone="global"
 The package's variants are: {}
 """
 
-        res_elf_warning = """\
+    res_elf_warning = """\
 depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib pkg.debug.depend.path=usr/lib pkg.debug.depend.reason=usr/xpg4/lib/libcurses.so.1 pkg.debug.depend.severity=warning pkg.debug.depend.type=elf type=require
 """
 
-        res_bypass = """\
+    res_bypass = """\
 depend fmri=__TBD pkg.debug.depend.fullpath=usr/lib/libc.so.1 pkg.debug.depend.reason=usr/xpg4/lib/libcurses.so.1 pkg.debug.depend.type=elf type=require
 set name=pkg.debug.depend.bypassed value=lib/libc.so.1
 """
 
-        bug_16013_simple_a_dep_manf = """\
+    bug_16013_simple_a_dep_manf = """\
 set name=pkg.fmri value=pkg:/a@0.5.11,5.11-0.151
 depend fmri=__TBD pkg.debug.depend.file=perl pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=usr/bin/perl_app pkg.debug.depend.type=script type=require
 """
-        bug_16013_simple_b_dep_manf = """\
+    bug_16013_simple_b_dep_manf = """\
 set name=pkg.fmri value=pkg:/b@0.5.11,5.11-0.151
 link path=usr/bin target=/b/bin
 dir group=bin mode=0755 owner=root path=b/bin
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl
 """
 
-        bug_16013_simple_b_link_manf = """\
+    bug_16013_simple_b_link_manf = """\
 set name=pkg.fmri value=pkg:/b_link@0.5.11,5.11-0.151
 link path=usr target=/b
 """
 
-        bug_16013_simple_b_link2_manf = """\
+    bug_16013_simple_b_link2_manf = """\
 set name=pkg.fmri value=pkg:/b_link2@0.5.11,5.11-0.151
 dir group=bin mode=0755 owner=root path=b
 link path=b/bin target=/b2/bin
 """
 
-        bug_16013_simple_b_file_manf = """\
+    bug_16013_simple_b_file_manf = """\
 set name=pkg.fmri value=pkg:/b_file@0.5.11,5.11-0.151
 dir group=bin mode=0755 owner=root path=b2/bin
 file NOHASH group=bin mode=0555 owner=root path=b2/bin/perl
 """
 
-        bug_16013_var_a_dep_manf = """\
+    bug_16013_var_a_dep_manf = """\
 set name=pkg.fmri value=pkg:/a@0.5.11,5.11-0.151
 set name=variant.foo value=b value=c value=a
 depend fmri=__TBD pkg.debug.depend.file=perl pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=usr/bin/perl_app pkg.debug.depend.type=script type=require
 """
 
-        bug_16013_var_b_link_manf = """\
+    bug_16013_var_b_link_manf = """\
 set name=pkg.fmri value=pkg:/b_link@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 link path=usr/bin target=/b/bin variant.foo=b
 dir group=bin mode=0755 owner=root path=b/bin variant.foo=b
 """
 
-        bug_16013_var_b_file_manf = """\
+    bug_16013_var_b_file_manf = """\
 set name=pkg.fmri value=pkg:/b_file@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=b
 """
 
-        bug_16013_var_c_manf = """\
+    bug_16013_var_c_manf = """\
 set name=pkg.fmri value=pkg:/c@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 link path=usr/bin target=../c/bin variant.foo=c
@@ -975,304 +1076,307 @@ dir group=bin mode=0755 owner=root path=c/bin variant.foo=c
 file NOHASH group=bin mode=0555 owner=root path=c/bin/perl variant.foo=c
 """
 
-        def bug_16013_check_res_variants_base(self, deps, errs, a_pth):
-                """A common method used by tests for verifying correct
-                dependency resolution when links are traversed and variants are
-                taken into account."""
+    def bug_16013_check_res_variants_base(self, deps, errs, a_pth):
+        """A common method used by tests for verifying correct
+        dependency resolution when links are traversed and variants are
+        taken into account."""
 
-                self.assertEqual(len(errs), 1,
-                    "\n\n".join([str(s) for s in errs]))
-                e = errs[0]
-                self.assertEqual(e.path, a_pth)
+        self.assertEqual(len(errs), 1, "\n\n".join([str(s) for s in errs]))
+        e = errs[0]
+        self.assertEqual(e.path, a_pth)
+        self.assertEqual(e.file_dep.attrs[dependencies.files_prefix], "perl")
+        self.assertEqual(
+            e.pvars.not_sat_set, set([frozenset([("variant.foo", "a")])])
+        )
+        self.assertEqual(
+            len(deps[a_pth]), 3, "\n".join([str(s) for s in deps[a_pth]])
+        )
+        res_fmris = set(
+            [
+                "pkg:/b_link@0.5.11-0.151",
+                "pkg:/c@0.5.11-0.151",
+                "pkg:/b_file@0.5.11-0.151",
+            ]
+        )
+        for d in deps[a_pth]:
+            self.assertTrue(
+                d.attrs["fmri"] in res_fmris,
+                "Unexpected fmri for:{0}".format(d),
+            )
+            res_fmris.remove(d.attrs["fmri"])
+            if d.attrs["fmri"] == "pkg:/b_link@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+            elif d.attrs["fmri"] == "pkg:/b_file@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+            else:
+                self.assertEqual(d.attrs["variant.foo"], "c")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+
+    def bug_16013_check_res_simple_links(self, deps, errs, a_pth):
+        """A common method used by tests for verifying correct
+        dependency resolution when links are traversed."""
+
+        self.assertEqual(len(errs), 0, "\n".join([str(s) for s in errs]))
+        self.assertEqual(
+            len(deps[a_pth]), 3, "\n".join([str(s) for s in deps[a_pth]])
+        )
+        res_fmris = set(
+            [
+                "pkg:/b_link@0.5.11-0.151",
+                "pkg:/b_link2@0.5.11-0.151",
+                "pkg:/b_file@0.5.11-0.151",
+            ]
+        )
+        for d in deps[a_pth]:
+            self.assertTrue(
+                d.attrs["fmri"] in res_fmris,
+                "Unexpected fmri for:{0}".format(d),
+            )
+            res_fmris.remove(d.attrs["fmri"])
+            if d.attrs["fmri"] in (
+                "pkg:/b_link@0.5.11-0.151",
+                "pkg:/b_link2@0.5.11-0.151",
+            ):
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+            else:
                 self.assertEqual(
-                    e.file_dep.attrs[dependencies.files_prefix], "perl")
-                self.assertEqual(e.pvars.not_sat_set,
-                    set([frozenset([("variant.foo", "a")])]))
-                self.assertEqual(len(deps[a_pth]), 3,
-                    "\n".join([str(s) for s in deps[a_pth]]))
-                res_fmris = set(["pkg:/b_link@0.5.11-0.151",
-                    "pkg:/c@0.5.11-0.151", "pkg:/b_file@0.5.11-0.151"])
-                for d in deps[a_pth]:
-                        self.assertTrue(d.attrs["fmri"] in res_fmris,
-                            "Unexpected fmri for:{0}".format(d))
-                        res_fmris.remove(d.attrs["fmri"])
-                        if d.attrs["fmri"] == \
-                            "pkg:/b_link@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix],
-                                    "link")
-                                self.assertEqual(d.attrs["variant.foo"],
-                                    "b")
-                        elif d.attrs["fmri"] == \
-                            "pkg:/b_file@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix],
-                                    "script")
-                                self.assertEqual(d.attrs["variant.foo"],
-                                    "b")
-                        else:
-                                self.assertEqual(d.attrs["variant.foo"],
-                                    "c")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix],
-                                    "script")
+                    d.attrs[dependencies.type_prefix],
+                    "script",
+                    "Was expecting type=script, " + "d:{0}".format(d),
+                )
 
-        def bug_16013_check_res_simple_links(self, deps, errs, a_pth):
-                """A common method used by tests for verifying correct
-                dependency resolution when links are traversed."""
+    def bug_16013_check_res_var_files_links_deps(self, deps, errs, a_pth):
+        """A common method used by tests for verifying correct
+        dependency resolution when links are traversed and variants are
+        present on both files and the links needed to reach those files.
+        """
 
-                self.assertEqual(len(errs), 0,
-                    "\n".join([str(s) for s in errs]))
-                self.assertEqual(len(deps[a_pth]), 3,
-                    "\n".join([str(s) for s in deps[a_pth]]))
-                res_fmris = set(["pkg:/b_link@0.5.11-0.151",
-                    "pkg:/b_link2@0.5.11-0.151",
-                    "pkg:/b_file@0.5.11-0.151"])
-                for d in deps[a_pth]:
-                        self.assertTrue(d.attrs["fmri"] in res_fmris,
-                            "Unexpected fmri for:{0}".format(d))
-                        res_fmris.remove(d.attrs["fmri"])
-                        if d.attrs["fmri"] in \
-                            ("pkg:/b_link@0.5.11-0.151",
-                            "pkg:/b_link2@0.5.11-0.151"):
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix],
-                                    "link")
-                        else:
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix],
-                                    "script",
-                                    "Was expecting type=script, " +
-                                    "d:{0}".format(d))
+        self.assertEqual(len(errs), 1, "\n\n".join([str(s) for s in errs]))
+        e = errs[0]
+        self.assertEqual(e.path, a_pth)
+        self.assertEqual(e.file_dep.attrs[dependencies.files_prefix], "perl")
+        self.assertEqual(
+            e.pvars.not_sat_set, set([frozenset([("variant.foo", "a")])])
+        )
+        self.assertEqual(
+            len(deps[a_pth]), 3, "\n".join([str(s) for s in deps[a_pth]])
+        )
+        res_fmris = set(
+            [
+                "pkg:/b_link@0.5.11-0.151",
+                "pkg:/c@0.5.11-0.151",
+                "pkg:/b_file@0.5.11-0.151",
+            ]
+        )
+        for d in deps[a_pth]:
+            self.assertTrue(
+                d.attrs["fmri"] in res_fmris,
+                "Unexpected fmri for:{0}".format(d),
+            )
+            res_fmris.remove(d.attrs["fmri"])
+            if d.attrs["fmri"] == "pkg:/b_link@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+            elif d.attrs["fmri"] == "pkg:/b_file@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+            else:
+                self.assertEqual(d.attrs["variant.foo"], "c")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
 
-        def bug_16013_check_res_var_files_links_deps(self, deps, errs, a_pth):
-                """A common method used by tests for verifying correct
-                dependency resolution when links are traversed and variants are
-                present on both files and the links needed to reach those files.
-                """
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.rurl1 = self.dcs[1].get_repo_url()
+        #
+        # To test pkgdepend resolve properly, we need an image.
+        # Side by side with the image, we create a testing proto area.
+        #
+        self.pkg_image_create(self.rurl)
 
-                self.assertEqual(len(errs), 1,
-                    "\n\n".join([str(s) for s in errs]))
-                e = errs[0]
-                self.assertEqual(e.path, a_pth)
-                self.assertEqual(
-                    e.file_dep.attrs[dependencies.files_prefix], "perl")
-                self.assertEqual(e.pvars.not_sat_set,
-                    set([frozenset([("variant.foo", "a")])]))
-                self.assertEqual(len(deps[a_pth]), 3,
-                    "\n".join([str(s) for s in deps[a_pth]]))
-                res_fmris = set(["pkg:/b_link@0.5.11-0.151",
-                    "pkg:/c@0.5.11-0.151", "pkg:/b_file@0.5.11-0.151"])
-                for d in deps[a_pth]:
-                        self.assertTrue(d.attrs["fmri"] in res_fmris,
-                            "Unexpected fmri for:{0}".format(d))
-                        res_fmris.remove(d.attrs["fmri"])
-                        if d.attrs["fmri"] == \
-                            "pkg:/b_link@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix],
-                                    "link")
-                                self.assertEqual(d.attrs["variant.foo"],
-                                    "b")
-                        elif d.attrs["fmri"] == \
-                            "pkg:/b_file@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix],
-                                    "script")
-                                self.assertEqual(d.attrs["variant.foo"],
-                                    "b")
-                        else:
-                                self.assertEqual(d.attrs["variant.foo"],
-                                    "c")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix],
-                                    "script")
+        self.test_proto_dir = os.path.join(self.test_root, "proto")
+        os.makedirs(self.test_proto_dir)
 
+    @staticmethod
+    def __compare_res(b1, b2):
+        res = set()
+        for x in b1:
+            x_tmp = x.split()
+            found = False
+            for y in b2:
+                y_tmp = y.split()
+                if x == y or (
+                    len(x_tmp) == len(y_tmp)
+                    and x_tmp[0] == y_tmp[0]
+                    and set(x_tmp) == set(y_tmp)
+                ):
+                    found = True
+                    break
+            if not found:
+                res.add(x)
+        return res
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.rurl1 = self.dcs[1].get_repo_url()
-                #
-                # To test pkgdepend resolve properly, we need an image.
-                # Side by side with the image, we create a testing proto area.
-                #
-                self.pkg_image_create(self.rurl)
+    @staticmethod
+    def __read_file(file_path):
+        fh = open(file_path, "r")
+        lines = fh.read()
+        fh.close()
+        return lines
 
-                self.test_proto_dir = os.path.join(self.test_root, "proto")
-                os.makedirs(self.test_proto_dir)
+    def make_proto_text_file(self, path, contents=""):
+        #
+        # We add a newline if it is missing because file(1) is sensitive
+        # to files which lack them.
+        #
+        contents = contents + "\n"
+        self.make_misc_files({path: contents}, prefix="proto")
 
-        @staticmethod
-        def __compare_res(b1, b2):
-                res = set()
-                for x in b1:
-                        x_tmp = x.split()
-                        found = False
-                        for y in b2:
-                                y_tmp = y.split()
-                                if x == y or (len(x_tmp) == len(y_tmp) and
-                                    x_tmp[0] == y_tmp[0] and
-                                    set(x_tmp) == set(y_tmp)):
-                                        found = True
-                                        break
-                        if not found:
-                                res.add(x)
-                return res
+    def make_elf(
+        self,
+        run_paths=[],
+        output_path="elf_test",
+        bit64=False,
+        deferred_libs=misc.EmptyI,
+        filter_files=misc.EmptyI,
+        lazy_libs=misc.EmptyI,
+        mapfile=None,
+        no_link=False,
+        obj_files=None,
+        optional_filters=misc.EmptyI,
+        program_text=None,
+        shared_lib=False,
+        pic=False,
+    ):
+        assert obj_files is None or program_text is None
+        if obj_files is None and program_text is None:
+            program_text = "int main(){}\n"
+        out_file = os.path.join(self.test_proto_dir, output_path)
 
-        @staticmethod
-        def __read_file(file_path):
-                fh = open(file_path, "r")
-                lines = fh.read()
-                fh.close()
-                return lines
+        # Make sure to quote the runpaths, as they may contain tokens
+        # like $PLATFORM which we do not want the shell to evaluate.
+        opts = ["-R'{0}'".format(rp) for rp in run_paths]
+        if bit64:
+            opts.append("-m64")
+        if shared_lib:
+            # Always link to libc; the compiler may not.
+            opts.append("-lc")
+            opts.append("-shared")
+            # Never link to libgcc_s.so
+            opts.append("-nodefaultlibs")
+        if pic or shared_lib:
+            opts.append("-fPIC")
+            opts.append("-DPIC")
+        if no_link:
+            opts.append("-c")
+        if mapfile:
+            opts.append("-Wl,-M{0}".format(mapfile))
+        opts.extend(["-Wl,-F{0}".format(f) for f in filter_files])
+        opts.extend(["-Wl,-f{0}".format(f) for f in optional_filters])
+        opts.extend(
+            ["-Wl,-z -Wl,deferred"]
+            + list(deferred_libs)
+            + ["-Wl,-z -Wl,nodeferred"]
+        )
+        opts.extend(["-Wl,-z -Wl,lazyload {0}".format(f) for f in lazy_libs])
+        self.c_compile(program_text, opts, out_file, obj_files=obj_files)
 
-        def make_proto_text_file(self, path, contents=""):
-                #
-                # We add a newline if it is missing because file(1) is sensitive
-                # to files which lack them.
-                #
-                contents = contents + "\n"
-                self.make_misc_files({ path: contents }, prefix="proto")
+        return out_file[len(self.test_proto_dir) + 1 :]
 
-        def make_elf(self, run_paths=[], output_path="elf_test", bit64=False,
-            deferred_libs=misc.EmptyI, filter_files=misc.EmptyI,
-            lazy_libs=misc.EmptyI, mapfile=None, no_link=False, obj_files=None,
-            optional_filters=misc.EmptyI, program_text=None, shared_lib=False, pic=False):
-                assert obj_files is None or program_text is None
-                if obj_files is None and program_text is None:
-                        program_text = "int main(){}\n"
-                out_file = os.path.join(self.test_proto_dir, output_path)
+    def pkgsend_with_fmri(self, pth):
+        plist = self.pkgsend(
+            self.rurl1, "publish -d {0} {1}".format(self.test_proto_dir, pth)
+        )
 
-                # Make sure to quote the runpaths, as they may contain tokens
-                # like $PLATFORM which we do not want the shell to evaluate.
-                opts = ["-R'{0}'".format(rp) for rp in run_paths]
-                if bit64:
-                        opts.append("-m64")
-                if shared_lib:
-                        # Always link to libc; the compiler may not.
-                        opts.append("-lc")
-                        opts.append("-shared")
-                        # Never link to libgcc_s.so
-                        opts.append("-nodefaultlibs")
-                if pic or shared_lib:
-                        opts.append("-fPIC")
-                        opts.append("-DPIC")
-                if no_link:
-                        opts.append("-c")
-                if mapfile:
-                        opts.append("-Wl,-M{0}".format(mapfile))
-                opts.extend(["-Wl,-F{0}".format(f) for f in filter_files])
-                opts.extend(["-Wl,-f{0}".format(f) for f in optional_filters])
-                opts.extend(["-Wl,-z -Wl,deferred"] +  list(deferred_libs) +
-                    ["-Wl,-z -Wl,nodeferred"])
-                opts.extend(["-Wl,-z -Wl,lazyload {0}".format(f) for f in lazy_libs])
-                self.c_compile(program_text, opts, out_file,
-                    obj_files=obj_files)
+    def check_res(self, expected, seen):
+        def pick_file(act):
+            fs = act.attrs[DDP + ".file"]
+            if isinstance(fs, six.string_types):
+                fs = [fs]
+            for f in fs:
+                if f.endswith(".py") and "__init__" not in f:
+                    return f
+            return fs[0]
 
-                return out_file[len(self.test_proto_dir)+1:]
+        seen = seen.strip()
+        expected = expected.strip()
+        if seen == expected:
+            return
+        seen = set(seen.splitlines())
+        expected = set(expected.splitlines())
+        seen_but_not_expected = self.__compare_res(seen, expected)
+        expected_but_not_seen = self.__compare_res(expected, seen)
+        try:
+            self.assertEqualDiff(expected_but_not_seen, seen_but_not_expected)
+        except AssertionError as e:
+            # This code is used to make the differences between
+            # expected and seen depend actions with all their debug
+            # information clearer.
+            res = str(e)
+            res += "\n\n\n"
+            try:
+                seen = [actions.fromstr(a) for a in seen_but_not_expected]
+                tmp = [actions.fromstr(a) for a in expected_but_not_seen]
+            except:
+                raise e
+            exp = dict([(pick_file(a), a) for a in tmp])
+            new = set()
+            conflicting = set()
+            for a in seen:
+                n = pick_file(a)
+                t = (
+                    "the results for {0} differ in the "
+                    "following attributes:\n".format(n)
+                )
+                if n in exp:
+                    ea = exp[n]
+                    for ak in a.attrs.keys():
+                        if ak not in ea.attrs:
+                            t += (
+                                "\thas an "
+                                "unexpected "
+                                "attribute {0}\n".format(ak)
+                            )
+                            continue
+                        av = a.attrs[ak]
+                        ev = ea.attrs[ak]
+                        if not isinstance(av, list):
+                            av = [av]
+                        if not isinstance(ev, list):
+                            ev = [ev]
+                        av = set(av)
+                        ev = set(ev)
+                        diffs = sorted(
+                            ["{0}:S".format(d) for d in (av - ev)]
+                            + ["{0}:E".format(d) for d in (ev - av)]
+                        )
+                        if diffs:
+                            t += (
+                                "\t{0} has " "different " "values:\n".format(ak)
+                            )
+                            for d in diffs:
+                                t += "\t\t{0}" "\n".format(d)
+                res += t
+            raise RuntimeError(res)
 
-        def pkgsend_with_fmri(self, pth):
-                plist = self.pkgsend(self.rurl1,
-                    "publish -d {0} {1}".format(
-                    self.test_proto_dir, pth))
+    def test_elf_dependency_tags(self):
+        """Testing related to bug 18990 where pkgdepend doesn't handle
+        all types of elf dependencies correctly."""
 
-        def check_res(self, expected, seen):
-                def pick_file(act):
-                        fs = act.attrs[DDP + ".file"]
-                        if isinstance(fs, six.string_types):
-                                fs = [fs]
-                        for f in fs:
-                                if f.endswith(".py") and "__init__" not in f:
-                                        return f
-                        return fs[0]
+        # Other places test the basic NEEDED elf depedency.
 
-                seen = seen.strip()
-                expected = expected.strip()
-                if seen == expected:
-                        return
-                seen = set(seen.splitlines())
-                expected = set(expected.splitlines())
-                seen_but_not_expected = self.__compare_res(seen, expected)
-                expected_but_not_seen = self.__compare_res(expected, seen)
-                try:
-                        self.assertEqualDiff(expected_but_not_seen,
-                            seen_but_not_expected)
-                except AssertionError as e:
-                        # This code is used to make the differences between
-                        # expected and seen depend actions with all their debug
-                        # information clearer.
-                        res = str(e)
-                        res += "\n\n\n"
-                        try:
-                                seen = [
-                                    actions.fromstr(a)
-                                    for a in seen_but_not_expected
-                                ]
-                                tmp = [
-                                    actions.fromstr(a)
-                                    for a in expected_but_not_seen
-                                ]
-                        except:
-                                raise e
-                        exp = dict([(pick_file(a), a) for a in tmp])
-                        new = set()
-                        conflicting = set()
-                        for a in seen:
-                                n = pick_file(a)
-                                t = "the results for {0} differ in the " \
-                                    "following attributes:\n".format(n)
-                                if n in exp:
-                                        ea = exp[n]
-                                        for ak in a.attrs.keys():
-                                                if ak not in ea.attrs:
-                                                        t += "\thas an " \
-                                                            "unexpected " \
-                                                            "attribute {0}\n".format(
-                                                            ak)
-                                                        continue
-                                                av = a.attrs[ak]
-                                                ev = ea.attrs[ak]
-                                                if not isinstance(av, list):
-                                                        av = [av]
-                                                if not isinstance(ev, list):
-                                                        ev = [ev]
-                                                av = set(av)
-                                                ev = set(ev)
-                                                diffs = sorted([
-                                                    "{0}:S".format(d)
-                                                    for d in
-                                                    (av - ev)
-                                                    ] + [
-                                                    "{0}:E".format(d)
-                                                    for d in (ev - av)
-                                                ])
-                                                if diffs:
-                                                        t += "\t{0} has " \
-                                                            "different " \
-                                                            "values:\n".format(ak)
-                                                        for d in diffs:
-                                                                t += "\t\t{0}" \
-                                                                    "\n".format(d)
-                                res += t
-                        raise RuntimeError(res)
-
-        def test_elf_dependency_tags(self):
-                """Testing related to bug 18990 where pkgdepend doesn't handle
-                all types of elf dependencies correctly."""
-
-                # Other places test the basic NEEDED elf depedency.
-
-                manf = """\
+        manf = """\
 file group=bin mode=0755 owner=sys path=usr/lib/foo.so.1
 """
-                foo_c = """\
+        foo_c = """\
 void bar() {}
 void foo() { bar(); }
 """
 
-                bar_c = """\
+        bar_c = """\
 void bar() {}
 """
-                mapfile_1 = """\
+        mapfile_1 = """\
 $mapfile_version 2
 
 SYMBOL_SCOPE {
@@ -1280,7 +1384,7 @@ SYMBOL_SCOPE {
                 bar { FILTER=bar.so };
 };
 """
-                mapfile_2 = """\
+        mapfile_2 = """\
 $mapfile_version 2
 
 SYMBOL_SCOPE {
@@ -1288,1006 +1392,1260 @@ SYMBOL_SCOPE {
                 bar { AUXILIARY=xxx.so };
 };
 """
-                def __check_res(es, ms, pkg_attrs):
-                        self.assertEqual(len(es), 0,
-                            "\n".join([str(d) for d in es]))
-                        self.assertEqual(len(ms), 0,
-                            "\n".join([str(d) for d in ms]))
-                        self.assertEqual(pkg_attrs, {})
-
-                base_dir = os.path.join(self.test_proto_dir, "usr", "lib")
-                foo_path = os.path.join(base_dir, "foo.o")
-                bar_path = os.path.join(base_dir, "bar.so")
-                so_path = os.path.join(base_dir, "foo.so.1")
-                mapfile_1_path = os.path.join(self.test_root, "mapfile_1")
-                mapfile_2_path = os.path.join(self.test_root, "mapfile_2")
-                mp = self.make_manifest(manf)
-
-                self.make_elf(output_path=bar_path, program_text=bar_c,
-                    shared_lib=True)
-                # Test that FILTER dependencies are treated as needed.
-                self.make_elf(output_path=foo_path, no_link=True,
-                    program_text=foo_c, pic=True)
-                self.make_elf(output_path=so_path, run_paths=[base_dir],
-                    filter_files=[bar_path], shared_lib=True,
-                    obj_files=[foo_path])
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    mp, [self.test_proto_dir], {}, [], convert=False)
-                __check_res(es, ms, pkg_attrs)
-                self.assertEqual(len(ds), 2, "\n".join([str(d) for d in ds]))
-                expected_file_deps = ["bar.so", "libc.so.1"]
-                found_file_deps = sorted(set(itertools.chain.from_iterable(
-                    [d.attrs[DDP + ".file"] for d in ds])))
-                self.assertEqualDiff(expected_file_deps, found_file_deps)
-
-                # Test that SUNW_FILTER dependencies are treated as needed.
-                self.make_file(mapfile_1_path, mapfile_1)
-                self.make_elf(output_path=foo_path, no_link=True,
-                    program_text=foo_c, pic=True)
-                self.make_elf(output_path=so_path, run_paths=[base_dir],
-                    mapfile=mapfile_1_path, obj_files=[foo_path],
-                    shared_lib=True)
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    mp, [self.test_proto_dir], {}, [], convert=False)
-                __check_res(es, ms, pkg_attrs)
-                self.assertEqual(len(ds), 2, "\n".join([str(d) for d in ds]))
-                expected_file_deps = ["bar.so", "libc.so.1"]
-                found_file_deps = sorted(set(itertools.chain.from_iterable(
-                    [d.attrs[DDP + ".file"] for d in ds])))
-                self.assertEqualDiff(expected_file_deps, found_file_deps)
-
-                # Test that AUXILIARY dependencies are ignored.
-                self.make_elf(output_path=foo_path, no_link=True,
-                    program_text=foo_c, pic=True)
-                self.make_elf(output_path=so_path, run_paths=[base_dir],
-                    optional_filters=["xxx.so"], obj_files=[foo_path],
-                    shared_lib=True)
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    mp, [self.test_proto_dir], {}, [], convert=False)
-                __check_res(es, ms, pkg_attrs)
-                self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
-                expected_file_deps = set(["libc.so.1"])
-                found_file_deps = set(itertools.chain.from_iterable(
-                    [d.attrs[DDP + ".file"] for d in ds]))
-                self.assertEqualDiff(expected_file_deps, found_file_deps)
-
-                # Test that SUNW_AUXILIARY dependencies are ignored.
-                self.make_file(mapfile_2_path, mapfile_2)
-                self.make_elf(output_path=foo_path, no_link=True,
-                    program_text=foo_c, pic=True)
-                self.make_elf(output_path=so_path, run_paths=[base_dir],
-                    mapfile=mapfile_2_path, obj_files=[foo_path],
-                    shared_lib=True)
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    mp, [self.test_proto_dir], {}, [], convert=False)
-                __check_res(es, ms, pkg_attrs)
-                self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
-                expected_file_deps = set(["libc.so.1"])
-                found_file_deps = set(itertools.chain.from_iterable(
-                    [d.attrs[DDP + ".file"] for d in ds]))
-                self.assertEqualDiff(expected_file_deps, found_file_deps)
-
-                # Test that a NEEDED dependency with a LAZY DEFERRED POSFLAG_1
-                # before it is ignored.
-                self.make_elf(output_path=foo_path, no_link=True,
-                    program_text=foo_c, pic=True)
-                self.make_elf(output_path=so_path, run_paths=[base_dir],
-                    deferred_libs=[bar_path], shared_lib=True,
-                    obj_files=[foo_path])
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    mp, [self.test_proto_dir], {}, [], convert=False)
-                __check_res(es, ms, pkg_attrs)
-                self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
-                expected_file_deps = set(["libc.so.1"])
-                found_file_deps = set(itertools.chain.from_iterable(
-                    [d.attrs[DDP + ".file"] for d in ds]))
-                self.assertEqualDiff(expected_file_deps, found_file_deps)
-
-                # Test that a lazy loaded dependency is still required.
-                self.make_elf(output_path=foo_path, no_link=True,
-                    program_text=foo_c, pic=True)
-                self.make_elf(output_path=so_path, run_paths=[base_dir],
-                    lazy_libs=[bar_path], shared_lib=True,
-                    obj_files=[foo_path])
-
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    mp, [self.test_proto_dir], {}, [], convert=False)
-                __check_res(es, ms, pkg_attrs)
-                self.assertEqual(len(ds), 2, "\n".join([str(d) for d in ds]))
-                expected_file_deps = ["bar.so", "libc.so.1"]
-                found_file_deps = sorted(set(itertools.chain.from_iterable(
-                    [d.attrs[DDP + ".file"] for d in ds])))
-                self.assertEqualDiff(expected_file_deps, found_file_deps)
-
-        def test_opts(self):
-                """Ensure that incorrect arguments or permissions errors don't
-                cause a traceback."""
-
-                proto = pkg5unittest.g_proto_area
-                self.pkgdepend_generate("-d {0}".format(proto), exit=2)
-                self.pkgdepend_generate("foo", exit=2)
-                self.pkgdepend_generate("-d {0} -z foo bar".format(proto), exit=2)
-                self.pkgdepend_generate("-d {0} no_such_file_should_exist".format(
-                    proto), exit=2)
-                self.pkgdepend_generate("-\\?")
-                self.pkgdepend_generate("--help")
-                tp = self.make_manifest(self.test_manf_1)
-                self.pkgdepend_generate("-d {0} {1}".format(proto, tp),
-                    su_wrap=True, exit=1)
-
-        def test_output(self):
-                """Check that the output is in the format expected."""
-
-                tp = self.make_manifest(self.test_manf_1)
-                fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
-                    py_ver_default)
-
-                self.pkgdepend_generate("-d {0} {1}".format(
-                    pkg5unittest.g_proto_area, tp), exit=1)
-                self.check_res(self.make_res_manf_1(
-                        pkg5unittest.g_proto_area, fp),
-                    self.output)
-                self.check_res(self.err_manf_1.format(pkg5unittest.g_proto_area),
-                    self.errout)
-
-                self.pkgdepend_generate("-m -d {0} {1}".format(
-                    pkg5unittest.g_proto_area, tp), exit=1)
-                self.check_res(
-                    self.make_full_res_manf_1(
-                        pkg5unittest.g_proto_area, fp),
-                    self.output)
-                self.check_res(self.err_manf_1.format(pkg5unittest.g_proto_area),
-                    self.errout)
-
-                self.make_proto_text_file(fp, self.python_text)
-                self.make_elf([], "usr/xpg4/lib/libcurses.so.1")
-
-                self.pkgdepend_generate("-m -d {0} {1}".format(
-                    self.test_proto_dir, tp))
-                self.check_res(
-                    self.make_full_res_manf_1_mod_proto(
-                        pkg5unittest.g_proto_area, fp),
-                    self.glre.sub('', self.output))
-                self.check_res("", self.errout)
-
-                tp = self.make_manifest(self.test_manf_2)
-                self.make_proto_text_file("etc/pam.conf", "text")
-
-                self.pkgdepend_generate("-m -d {0} {1}".format(
-                    self.test_proto_dir, tp))
-                self.check_res(self.res_manf_2 + self.test_manf_2,
-                    self.glre.sub('', self.output))
-                self.check_res("", self.errout)
-
-                res_path = self.make_manifest(self.output)
-
-                # Check that -S doesn't prevent the resolution from happening.
-                #self.pkgdepend_resolve("-S -o {0}".format(res_path), exit=1)
-                #self.check_res("# {0}".format(res_path), self.output)
-                #self.check_res(self.resolve_error.format(
-                #        manf_path=res_path,
-                #        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-                #        dummy_fmri=base.Dependency.DUMMY_FMRI
-                #    ), self.errout)
-
-                self.pkgdepend_generate("-M -d {0} {1}".format(
-                    self.test_proto_dir, tp))
-                self.check_res(self.res_manf_2, self.glre.sub('', self.output))
-                self.check_res(self.res_manf_2_missing, self.errout)
-
-                portable.remove(tp)
-                portable.remove(res_path)
-
-                tp = self.make_manifest(self.int_hardlink_manf)
-
-                self.make_proto_text_file("var/log/syslog", "text")
-
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
-                self.check_res("", self.output)
-                self.check_res("", self.errout)
-
-                self.pkgdepend_generate("-I -d {0} {1}".format(
-                    self.test_proto_dir, tp))
-                self.check_res(self.res_int_manf, self.output)
-                self.check_res("", self.errout)
-
-                portable.remove(tp)
-
-        def test_resolve_screen_out(self):
-                """Check that the results printed to screen are what is
-                expected."""
-
-                m1_path = self.make_manifest(self.two_variant_deps)
-                m2_path = self.make_manifest(self.two_v_deps_bar)
-                m3_path = self.make_manifest(self.two_v_deps_baz_one)
-                m4_path = self.make_manifest(self.two_v_deps_baz_two)
-                # Use pkgfmt on the manifest to test for bug 18740.
-                self.pkgfmt(m1_path)
-                with open(m1_path, "r") as fh:
-                        m1_fmt = fh.read()
-                self.pkgdepend_resolve("-o -m {0}".format(
-                    " ".join([m1_path, m2_path, m3_path, m4_path])), exit=1)
-
-                self.check_res(self.two_v_deps_output.format(
-                        m1_path=m1_path,
-                        m2_path=m2_path,
-                        m3_path=m3_path,
-                        m4_path=m4_path,
-                        m1_fmt=m1_fmt,
-                        m2_fmt=self.two_v_deps_bar,
-                        m3_fmt=self.two_v_deps_baz_one,
-                        m4_fmt=self.two_v_deps_baz_two,
-                   ), self.output)
-
-                self.check_res(self.two_v_deps_resolve_error.format(
-                        manf_path=m1_path,
-                        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-                        dummy_fmri=base.Dependency.DUMMY_FMRI
-                    ), self.errout)
-
-                self.pkgdepend_resolve("-vo {0}".format(
-                    " ".join([m1_path, m2_path, m3_path, m4_path])), exit=1)
-
-                self.check_res(self.two_v_deps_verbose_output.format(
-                        m1_path=m1_path,
-                        m2_path=m2_path,
-                        m3_path=m3_path,
-                        m4_path=m4_path
-                   ), self.output)
-
-        def test_bug_10518(self):
-                """ pkgdepend should exit 2 on input args of the wrong type """
-                m_path = self.make_manifest(self.test_manf_1)
-
-                # Try feeding a directory where a manifest should be--
-                # a typical scenario we play out here is a user
-                # inverting the first and second args.
-                self.pkgdepend_generate("/", exit=2)
-                self.check_res(
-                    "pkgdepend: The manifest file / could not be found.\n" +
-                    self.usage_msg, self.errout)
-
-                self.pkgdepend_resolve("-o /", exit=2)
-                self.check_res(
-                    "pkgdepend: The manifest file / could not be found.\n" +
-                    self.usage_msg, self.errout)
-
-        def test_bug_11517(self):
-                """ Test the pkgdepend handles bad global options """
-
-                m_path = None
-                ill_usage = 'pkgdepend: illegal global option -- M\n'
-                try:
-                        m_path = self.make_manifest(self.test_manf_1)
-
-                        self.pkgdepend_resolve("-M -o {0} ".format(m_path), exit=2)
-                        self.check_res(ill_usage + self.usage_msg,
-                            self.errout)
-                finally:
-                        if m_path:
-                                portable.remove(m_path)
-
-        def test_bug_11805(self):
-                """Test that paths as payloads work for file actions.
-
-                This tests both that file actions with payloads have their
-                dependencies analyzed correctly and that the correct path is
-                used for internal dependency resolution."""
-
-                proto = pkg5unittest.g_proto_area
-                tp = self.make_manifest(self.payload_manf)
-                self.pkgdepend_generate("-d {0} {1}".format(proto, tp))
-                self.check_res(self.make_res_payload_1(proto,
-                    "usr/lib/python{0}/foo/bar.py".format(py_ver_default)),
-                    self.output)
-                self.check_res("", self.errout)
-
-        def test_bug_11829(self):
-                """ pkgdep should gracefully deal with a non-manifest """
-
-                m_path = None
-                atype = "This"
-                nonsense = "This is a nonsense manifest"
-                m_path = self.make_manifest(nonsense)
-
-                self.pkgdepend_generate("-d {0} {1}".format(
-                    self.test_proto_dir, m_path), exit=1)
-                self.debug(self.errout)
-                self.check_res("unknown action type '{0}' in action '{1}'".format(
-                    atype, nonsense), self.errout)
-
-                self.pkgdepend_resolve("-o {0} ".format(m_path), exit=1)
-                self.check_res("unknown action type '{0}' in action '{1}'".format(
-                    atype, nonsense), self.errout)
-
-        def __run_dyn_tok_test(self, run_paths, replaced_path, dep_args):
-                """Using the provided run paths, produces a elf binary with
-                those paths set and checks to make sure that pkgdep run with
-                the provided arguments performs the substitution correctly."""
-
-                elf_path = self.make_elf(run_paths)
-                m_path = self.make_manifest(self.elf_sub_manf.format(
-                    file_loc=elf_path))
-                self.pkgdepend_generate("{0} -d {1} {2}".format(
-                    dep_args, self.test_proto_dir, m_path))
-                self.check_res(self.payload_elf_sub_stdout.format(
-                    replaced_path=\
-                        " {0}.path={1}".format(
-                        base.Dependency.DEPEND_DEBUG_PREFIX, replaced_path)),
-                    self.glre.sub('', self.output))
-
-        def test_bug_12697(self):
-                """Test that the -D and -k options work as expected.
-
-                The -D and -k options provide a way for a user to specify
-                tokens to expand dynamically in run paths and the kernel paths
-                to use for kernel module run paths."""
-
-                elf_path = self.make_elf([])
-                m_path = self.make_manifest(self.kernel_manf.format(
-                    file_loc=elf_path))
-                self.pkgdepend_generate("-d {0} {1}".format(
-                    self.test_proto_dir, m_path))
-                self.check_res("", self.errout)
-                self.check_res(self.kernel_manf_stdout,
-                    self.glre.sub('', self.output))
-
-                self.pkgdepend_generate("-k baz -k foo/bar -d {0} {1}".format(
-                    self.test_proto_dir, m_path))
-                self.check_res("", self.errout)
-                self.check_res(self.kernel_manf_stdout2, self.output)
-
-                self.debug("Test for platform substitution in kernel " \
-                    "module paths. Bug 13057")
-
-                self.pkgdepend_generate(
-                    "-D PLATFORM=baz -D PLATFORM=tp -d {0} {1}".format(
-                    self.test_proto_dir, m_path))
-                self.check_res("", self.errout)
-                self.check_res(self.kernel_manf_stdout_platform,
-                    self.glre.sub('', self.output))
-
-                self.debug("Test unexpanded token")
-
-                rp = ["/platform/$PLATFORM/foo"]
-                elf_path = self.make_elf(rp)
-                m_path = self.make_manifest(self.elf_sub_manf.format(
-                    file_loc=elf_path))
-                self.pkgdepend_generate("-d {0} {1}".format(
-                    self.test_proto_dir, m_path), exit=1)
-                self.check_res((self.payload_elf_sub_error.format(
-                        payload_path=os.path.join(self.test_proto_dir,
-                            elf_path),
-                        installed_path="bar/foo",
-                        tok="$PLATFORM",
-                        rp=rp[0]
-                    )), self.errout)
-
-                self.check_res(self.payload_elf_sub_stdout.format(
-                    replaced_path=""), self.glre.sub('', self.output))
-
-                # Test token expansion
-                self.debug("test token expansion: $PLATFORM")
-                self.__run_dyn_tok_test(["/platform/$PLATFORM/foo"],
-                    "platform/pfoo/foo", "-D PLATFORM=pfoo")
-
-                self.debug("test token expansion: $ISALIST")
-                self.__run_dyn_tok_test(["/foo/bar/$ISALIST/baz"],
-                    "foo/bar/SUBL/baz", "-D '$ISALIST=SUBL'")
-
-                self.debug("test token expansion: $PLATFORM and $ISALIST")
-                self.__run_dyn_tok_test(["/foo/$PLATFORM/$ISALIST/baz"],
-                    "foo/pfoo/bar/SUBL/baz",
-                    "-D ISALIST=SUBL -D PLATFORM=pfoo/bar")
-
-                self.debug("test token expansion: multiple $PLATFORM")
-                self.__run_dyn_tok_test(
-                    ["/$PLATFORM/$PLATFORM/$ISALIST/$PLATFORM"],
-                    "bar/bar/SUBL/bar", "-D ISALIST=SUBL -D PLATFORM=bar")
-
-                self.debug("Test multiple run paths and multiple subs")
-                rp = ["/platform/$PLATFORM/foo", "/$ISALIST/$PLATFORM/baz"]
-                elf_path = self.make_elf(rp)
-                m_path = self.make_manifest(self.elf_sub_manf.format(
-                    file_loc=elf_path))
-                self.pkgdepend_generate("-D ISALIST=isadir -d {0} {1}".format(
-                    self.test_proto_dir, m_path), exit=1)
-                self.check_res(self.double_plat_error.format(
-                    proto_dir=self.test_proto_dir), self.errout)
-                self.check_res(self.double_plat_stdout,
-                    self.glre.sub('', self.output))
-
-                self.pkgdepend_generate("-D PLATFORM=pfoo -d {0} {1}".format(
-                    self.test_proto_dir, m_path), exit=1)
-                self.check_res(self.double_plat_isa_error.format(
-                    proto_dir=self.test_proto_dir), self.errout)
-                self.check_res(self.double_plat_isa_stdout,
-                    self.glre.sub('', self.output))
-
-                self.pkgdepend_generate("-D PLATFORM=pfoo -D PLATFORM=pfoo2 "
-                    "-D ISALIST=isadir -D ISALIST=isadir -d {0} {1}".format(
-                    self.test_proto_dir, m_path))
-                self.check_res("", self.errout)
-                self.check_res(self.double_double_stdout,
-                    self.glre.sub('', self.output))
-
-        def test_missing_payload(self):
-                """Test that the error produced by a missing payload action
-                uses the right path."""
-                payload = "tmp/file/should/not/exist/here/foo"
-                m1_path = self.make_manifest(self.miss_payload_manf.format(
-                    payload=payload))
-                self.pkgdepend_generate("-d {0} {1}".format(
-                    self.test_proto_dir, m1_path), exit=1)
-                self.check_res(self.miss_payload_manf_error.format(
-                    payload=payload, path_pref=self.test_proto_dir),
-                    self.errout)
-                self.check_res("", self.output)
-
-                m2_path = self.make_manifest(self.empty_payload_manf)
-                self.pkgdepend_generate("-d {0} {1}".format(
-                    self.test_proto_dir, m2_path), exit=1)
-                self.check_res(self.empty_payload_manf_error.format(
-                    path_pref=self.test_proto_dir), self.errout)
-                self.check_res("", self.output)
-
-                m3_path = self.make_manifest(self.nohash_payload_manf)
-                self.pkgdepend_generate("-d {0} {1}".format(
-                    self.test_proto_dir, m3_path), exit=1)
-                self.check_res(self.empty_payload_manf_error.format(
-                    path_pref=self.test_proto_dir), self.errout)
-                self.check_res("", self.output)
-
-        def test_bug_14116(self):
-                foo_path = self.make_proto_text_file("bar/foo", "#!perl -w\n\n")
-                m_path = self.make_manifest(self.elf_sub_manf.format(
-                    file_loc="bar/foo"))
-                self.pkgdepend_generate("-d {0} {1}".format(
-                    self.test_proto_dir, m_path), exit=1)
-                self.check_res(self.output, "")
-                self.check_res(self.errout, "{0}/bar/foo says it should be run "
-                    "with 'perl' which is a relative path.".format(
-                    self.test_proto_dir))
-
-        def test_unsatisfied_deps(self):
-                """Test resolution behaviour with various unsatisfied
-                dependencies"""
-                unsat = self.make_manifest(self.unsatisfied_manf)
-                partial = self.make_manifest(self.partially_satisfied_manf)
-                satisfying = self.make_manifest(self.satisfying_manf)
-
-                # Generally unsatisfied dependency
-                self.pkgdepend_resolve(" -o {0}".format(unsat), exit=1)
-                self.check_res(self.unsatisfied_error_1.format(unsat), self.errout)
-
-                # Dependency that would be satisfied were it not for
-                # mismatched variants
-                self.pkgdepend_resolve(" -o {0} {1}".format(unsat, satisfying),
-                    exit=1)
-                self.check_res(self.unsatisfied_error_1.format(unsat), self.errout)
-
-                # Partially satisfied dependency (for one variant
-                # value, not another)
-                self.pkgdepend_resolve(" -o {0} {1}".format(partial, satisfying),
-                    exit=1)
-                self.check_res(self.unsatisfied_error_2.format(partial), self.errout)
-                self.check_res("# {0}\n{1}\n\n# {2}\n".format(partial,
-                    self.satisfying_out, satisfying), self.output)
-
-                # No dependencies at all
-                self.pkgdepend_resolve(" -o {0}".format(satisfying))
-
-        def test_bug_14118(self):
-                """Check that duplicate dependency actions are consolitdated
-                correctly, taking the variants into accout."""
-
-                # In the comments below, v.f stands for variant.foo and v.n
-                # stands for variant.num.
-
-                # dup_variant_deps contains all the dependencies to be resolved.
-                # It is published as dup-v-deps.
-                m1_path = self.make_manifest(self.dup_variant_deps)
-
-                # two_v_deps_bar is published as the package s-v-bar.  It
-                # provides var/log/authlog when v.f=bar and var/log/file2 under
-                # all variants.  This means that dup-v-deps should depend
-                # unconditionally on s-v-bar.  This resolution tests that a
-                # dependency on X which exists only under a specific combination
-                # of variants is merged into a more general dependency
-                # appropriately.
-                m2_path = self.make_manifest(self.two_v_deps_bar)
-
-                # two_v_deps_baz_one is published as the package s-v-baz-one.
-                # It provides var/log/authlog when v.f=baz and v.n=one.  This
-                # means that dup-v-deps should depend on s-v-baz-one when
-                # v.f=baz and v.n=one.  This resolution tests that dependencies
-                # are still versioned correctly when necessary.
-                m3_path = self.make_manifest(self.two_v_deps_baz_one)
-
-                # two_v_deps_baz_two is identical to two_v_deps_baz_one except
-                # that it provides var/log/authlog when v.f=baz and v.n=two.
-                m4_path = self.make_manifest(self.two_v_deps_baz_two)
-
-                # dup_prov is published as the package dup-prov.  It provides
-                # var/log/f1 and var/log/f2 under all variants.  dup-v-deps
-                # depends on dup-prov under all combinations of variants because
-                # of each file.  This tests that when two dependencies are valid
-                # under same set of variants, they're combined correctly.
-                m5_path = self.make_manifest(self.dup_prov)
-
-                # sep_vars is published as sep_vars.  It provides var/log/f3
-                # when v.f=bar and var/log/f4 when v.f=baz.  This means that
-                # dup-v-deps depends on sep_vars for different reasons when
-                # v.f=bar and when v.f=baz.  This tests that those dependencies
-                # continue to be reported as separate dependencies.
-                m6_path = self.make_manifest(self.sep_vars)
-
-                # subset_prov unconditionally provides two files, f5 and f6.
-                # dup-v-deps unconditionally depends on f5, and conditionally
-                # depends on f6.  This means that dup-v-deps should
-                # unconditionally depend on dup-v-deps.  This also tests that
-                # variants are removed and added during the internal processing
-                # of dependency resolution.
-                m7_path = self.make_manifest(self.subset_prov)
-
-                # This empty manifest will be published as hand-dep. This checks
-                # that manually added dependencies are propogated correctly.
-                m8_path = self.make_manifest("\n\n")
-
-                # Test that resolve handles multiline actions correctly when
-                # echoing the manifest.  Bug 18740
-                self.pkgfmt(m1_path)
-
-                self.pkgdepend_resolve(" -vm {0}".format(" ".join([m1_path, m2_path,
-                        m3_path, m4_path, m5_path, m6_path, m7_path, m8_path])))
-                fh = open(m1_path + ".res")
-                res = fh.read()
-                fh.close()
-                self.check_res(self.dup_variant_deps_resolved, res)
-
-                pfmris = {
-                    m1_path: "pkg:/dup-v-deps@0.1-0.2",
-                    m2_path: "pkg:/s-v-bar@0.1-0.2",
-                    m3_path: "pkg:/s-v-baz-one@0.1-0.2",
-                    m4_path: "pkg:/s-v-baz-two@0.1-0.2",
-                    m5_path: "pkg:/dup-prov@0.1-0.2",
-                    m6_path: "pkg:/sep_vars@0.1-0.2",
-                    m7_path: "pkg:/subset-prov@0.1-0.2 ",
-                    m8_path: "pkg:/hand-dep@0.1-0.2",
-                }
-
-                # Add FMRI to each manifest for use with publish.
-                for mpath, pfmri in pfmris.items():
-                        lines = open(mpath + ".res", "r").readlines()
-                        with open(mpath + ".res", "w") as mf:
-                                mf.write("set name=pkg.fmri value={0}\n".format(pfmri))
-                                for l in lines:
-                                        if "pkg.fmri" in l:
-                                                continue
-                                        mf.write(l)
-
-                # Check that the results can be installed correctly.
-                self.make_proto_text_file("var/log/file2")
-                self.make_proto_text_file("var/log/authlog")
-                self.make_proto_text_file("var/log/f1")
-                self.make_proto_text_file("var/log/f2")
-                self.make_proto_text_file("var/log/f3")
-                self.make_proto_text_file("var/log/f4")
-                self.make_proto_text_file("var/log/f5")
-                self.make_proto_text_file("var/log/f6")
-                self.make_proto_text_file(
-                    "platform/i86pc/kernel/dacf/amd64/consconfig_dacf")
-                self.make_proto_text_file(
-                    "platform/i86pc/kernel/dacf/consconfig_dacf")
-                self.pkgsend(self.rurl, "publish -d {0} {1}".format(
-                    self.test_proto_dir, m1_path + ".res"))
-                self.pkgsend(self.rurl, "publish -d {0} {1}".format(
-                    self.test_proto_dir, m2_path + ".res"))
-                self.pkgsend(self.rurl, "publish -d {0} {1}".format(
-                    self.test_proto_dir, m3_path + ".res"))
-                self.pkgsend(self.rurl, "publish -d {0} {1}".format(
-                    self.test_proto_dir, m4_path + ".res"))
-                self.pkgsend(self.rurl, "publish -d {0} {1}".format(
-                    self.test_proto_dir, m5_path + ".res"))
-                self.pkgsend(self.rurl, "publish -d {0} {1}".format(
-                    self.test_proto_dir, m6_path + ".res"))
-                self.pkgsend(self.rurl, "publish -d {0} {1}".format(
-                    self.test_proto_dir, m7_path + ".res"))
-                self.pkgsend(self.rurl, "publish -d {0} {1}".format(
-                    self.test_proto_dir, m8_path + ".res"))
-                foo_vars = ["bar", "baz"]
-                num_vars = ["one", "two"]
-                for fv in foo_vars:
-                        for nv in num_vars:
-                                variants = { "variant.foo": fv,
-                                    "variant.num": nv }
-                                self.image_create(self.rurl, variants=variants)
-                                self.pkg("install dup-v-deps")
-                                self.image_destroy()
-
-        def test_bug_15777(self):
-                """Test that -S switch disables resolving dependencies against
-                the installed system."""
-
-                self.make_misc_files(["tmp/foo"])
-                self.pkgsend_bulk(self.rurl, self.inst_pkg)
-                api_obj = self.get_img_api_obj()
-                api_obj.refresh(immediate=True)
-                self._api_install(api_obj, ["example2_pkg"])
-
-                m1_path = self.make_manifest(self.multi_deps)
-                m2_path = self.make_manifest(self.misc_manf)
-
-                self.pkgdepend_resolve("-o {0} {1}".format(m1_path, m2_path))
-                self.pkgdepend_resolve("-o -S {0} {1}".format(m1_path, m2_path),
-                    exit=1)
-
-        def test_bug_15843(self):
-                """Test that multiple proto_dirs work as expected."""
-
-                curses = "usr/xpg4/lib/libcurses.so.1"
-                pam = "etc/pam.conf"
-                self.make_elf([], "d1/{0}".format(curses))
-                self.make_proto_text_file("d2/{0}".format(pam), "text")
-                tp = self.make_manifest(self.test_manf_2)
-
-                # Check that files are not found.
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp),
-                    exit=1)
-                self.check_res("", self.output)
-                self.check_res("\n".join([
+
+        def __check_res(es, ms, pkg_attrs):
+            self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
+            self.assertEqual(len(ms), 0, "\n".join([str(d) for d in ms]))
+            self.assertEqual(pkg_attrs, {})
+
+        base_dir = os.path.join(self.test_proto_dir, "usr", "lib")
+        foo_path = os.path.join(base_dir, "foo.o")
+        bar_path = os.path.join(base_dir, "bar.so")
+        so_path = os.path.join(base_dir, "foo.so.1")
+        mapfile_1_path = os.path.join(self.test_root, "mapfile_1")
+        mapfile_2_path = os.path.join(self.test_root, "mapfile_2")
+        mp = self.make_manifest(manf)
+
+        self.make_elf(output_path=bar_path, program_text=bar_c, shared_lib=True)
+        # Test that FILTER dependencies are treated as needed.
+        self.make_elf(
+            output_path=foo_path, no_link=True, program_text=foo_c, pic=True
+        )
+        self.make_elf(
+            output_path=so_path,
+            run_paths=[base_dir],
+            filter_files=[bar_path],
+            shared_lib=True,
+            obj_files=[foo_path],
+        )
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            mp, [self.test_proto_dir], {}, [], convert=False
+        )
+        __check_res(es, ms, pkg_attrs)
+        self.assertEqual(len(ds), 2, "\n".join([str(d) for d in ds]))
+        expected_file_deps = ["bar.so", "libc.so.1"]
+        found_file_deps = sorted(
+            set(
+                itertools.chain.from_iterable(
+                    [d.attrs[DDP + ".file"] for d in ds]
+                )
+            )
+        )
+        self.assertEqualDiff(expected_file_deps, found_file_deps)
+
+        # Test that SUNW_FILTER dependencies are treated as needed.
+        self.make_file(mapfile_1_path, mapfile_1)
+        self.make_elf(
+            output_path=foo_path, no_link=True, program_text=foo_c, pic=True
+        )
+        self.make_elf(
+            output_path=so_path,
+            run_paths=[base_dir],
+            mapfile=mapfile_1_path,
+            obj_files=[foo_path],
+            shared_lib=True,
+        )
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            mp, [self.test_proto_dir], {}, [], convert=False
+        )
+        __check_res(es, ms, pkg_attrs)
+        self.assertEqual(len(ds), 2, "\n".join([str(d) for d in ds]))
+        expected_file_deps = ["bar.so", "libc.so.1"]
+        found_file_deps = sorted(
+            set(
+                itertools.chain.from_iterable(
+                    [d.attrs[DDP + ".file"] for d in ds]
+                )
+            )
+        )
+        self.assertEqualDiff(expected_file_deps, found_file_deps)
+
+        # Test that AUXILIARY dependencies are ignored.
+        self.make_elf(
+            output_path=foo_path, no_link=True, program_text=foo_c, pic=True
+        )
+        self.make_elf(
+            output_path=so_path,
+            run_paths=[base_dir],
+            optional_filters=["xxx.so"],
+            obj_files=[foo_path],
+            shared_lib=True,
+        )
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            mp, [self.test_proto_dir], {}, [], convert=False
+        )
+        __check_res(es, ms, pkg_attrs)
+        self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
+        expected_file_deps = set(["libc.so.1"])
+        found_file_deps = set(
+            itertools.chain.from_iterable([d.attrs[DDP + ".file"] for d in ds])
+        )
+        self.assertEqualDiff(expected_file_deps, found_file_deps)
+
+        # Test that SUNW_AUXILIARY dependencies are ignored.
+        self.make_file(mapfile_2_path, mapfile_2)
+        self.make_elf(
+            output_path=foo_path, no_link=True, program_text=foo_c, pic=True
+        )
+        self.make_elf(
+            output_path=so_path,
+            run_paths=[base_dir],
+            mapfile=mapfile_2_path,
+            obj_files=[foo_path],
+            shared_lib=True,
+        )
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            mp, [self.test_proto_dir], {}, [], convert=False
+        )
+        __check_res(es, ms, pkg_attrs)
+        self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
+        expected_file_deps = set(["libc.so.1"])
+        found_file_deps = set(
+            itertools.chain.from_iterable([d.attrs[DDP + ".file"] for d in ds])
+        )
+        self.assertEqualDiff(expected_file_deps, found_file_deps)
+
+        # Test that a NEEDED dependency with a LAZY DEFERRED POSFLAG_1
+        # before it is ignored.
+        self.make_elf(
+            output_path=foo_path, no_link=True, program_text=foo_c, pic=True
+        )
+        self.make_elf(
+            output_path=so_path,
+            run_paths=[base_dir],
+            deferred_libs=[bar_path],
+            shared_lib=True,
+            obj_files=[foo_path],
+        )
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            mp, [self.test_proto_dir], {}, [], convert=False
+        )
+        __check_res(es, ms, pkg_attrs)
+        self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
+        expected_file_deps = set(["libc.so.1"])
+        found_file_deps = set(
+            itertools.chain.from_iterable([d.attrs[DDP + ".file"] for d in ds])
+        )
+        self.assertEqualDiff(expected_file_deps, found_file_deps)
+
+        # Test that a lazy loaded dependency is still required.
+        self.make_elf(
+            output_path=foo_path, no_link=True, program_text=foo_c, pic=True
+        )
+        self.make_elf(
+            output_path=so_path,
+            run_paths=[base_dir],
+            lazy_libs=[bar_path],
+            shared_lib=True,
+            obj_files=[foo_path],
+        )
+
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            mp, [self.test_proto_dir], {}, [], convert=False
+        )
+        __check_res(es, ms, pkg_attrs)
+        self.assertEqual(len(ds), 2, "\n".join([str(d) for d in ds]))
+        expected_file_deps = ["bar.so", "libc.so.1"]
+        found_file_deps = sorted(
+            set(
+                itertools.chain.from_iterable(
+                    [d.attrs[DDP + ".file"] for d in ds]
+                )
+            )
+        )
+        self.assertEqualDiff(expected_file_deps, found_file_deps)
+
+    def test_opts(self):
+        """Ensure that incorrect arguments or permissions errors don't
+        cause a traceback."""
+
+        proto = pkg5unittest.g_proto_area
+        self.pkgdepend_generate("-d {0}".format(proto), exit=2)
+        self.pkgdepend_generate("foo", exit=2)
+        self.pkgdepend_generate("-d {0} -z foo bar".format(proto), exit=2)
+        self.pkgdepend_generate(
+            "-d {0} no_such_file_should_exist".format(proto), exit=2
+        )
+        self.pkgdepend_generate("-\\?")
+        self.pkgdepend_generate("--help")
+        tp = self.make_manifest(self.test_manf_1)
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(proto, tp), su_wrap=True, exit=1
+        )
+
+    def test_output(self):
+        """Check that the output is in the format expected."""
+
+        tp = self.make_manifest(self.test_manf_1)
+        fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
+            py_ver_default
+        )
+
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(pkg5unittest.g_proto_area, tp), exit=1
+        )
+        self.check_res(
+            self.make_res_manf_1(pkg5unittest.g_proto_area, fp), self.output
+        )
+        self.check_res(
+            self.err_manf_1.format(pkg5unittest.g_proto_area), self.errout
+        )
+
+        self.pkgdepend_generate(
+            "-m -d {0} {1}".format(pkg5unittest.g_proto_area, tp), exit=1
+        )
+        self.check_res(
+            self.make_full_res_manf_1(pkg5unittest.g_proto_area, fp),
+            self.output,
+        )
+        self.check_res(
+            self.err_manf_1.format(pkg5unittest.g_proto_area), self.errout
+        )
+
+        self.make_proto_text_file(fp, self.python_text)
+        self.make_elf([], "usr/xpg4/lib/libcurses.so.1")
+
+        self.pkgdepend_generate("-m -d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(
+            self.make_full_res_manf_1_mod_proto(pkg5unittest.g_proto_area, fp),
+            self.glre.sub("", self.output),
+        )
+        self.check_res("", self.errout)
+
+        tp = self.make_manifest(self.test_manf_2)
+        self.make_proto_text_file("etc/pam.conf", "text")
+
+        self.pkgdepend_generate("-m -d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(
+            self.res_manf_2 + self.test_manf_2, self.glre.sub("", self.output)
+        )
+        self.check_res("", self.errout)
+
+        res_path = self.make_manifest(self.output)
+
+        # Check that -S doesn't prevent the resolution from happening.
+        # self.pkgdepend_resolve("-S -o {0}".format(res_path), exit=1)
+        # self.check_res("# {0}".format(res_path), self.output)
+        # self.check_res(self.resolve_error.format(
+        #        manf_path=res_path,
+        #        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+        #        dummy_fmri=base.Dependency.DUMMY_FMRI
+        #    ), self.errout)
+
+        self.pkgdepend_generate("-M -d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(self.res_manf_2, self.glre.sub("", self.output))
+        self.check_res(self.res_manf_2_missing, self.errout)
+
+        portable.remove(tp)
+        portable.remove(res_path)
+
+        tp = self.make_manifest(self.int_hardlink_manf)
+
+        self.make_proto_text_file("var/log/syslog", "text")
+
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res("", self.output)
+        self.check_res("", self.errout)
+
+        self.pkgdepend_generate("-I -d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(self.res_int_manf, self.output)
+        self.check_res("", self.errout)
+
+        portable.remove(tp)
+
+    def test_resolve_screen_out(self):
+        """Check that the results printed to screen are what is
+        expected."""
+
+        m1_path = self.make_manifest(self.two_variant_deps)
+        m2_path = self.make_manifest(self.two_v_deps_bar)
+        m3_path = self.make_manifest(self.two_v_deps_baz_one)
+        m4_path = self.make_manifest(self.two_v_deps_baz_two)
+        # Use pkgfmt on the manifest to test for bug 18740.
+        self.pkgfmt(m1_path)
+        with open(m1_path, "r") as fh:
+            m1_fmt = fh.read()
+        self.pkgdepend_resolve(
+            "-o -m {0}".format(" ".join([m1_path, m2_path, m3_path, m4_path])),
+            exit=1,
+        )
+
+        self.check_res(
+            self.two_v_deps_output.format(
+                m1_path=m1_path,
+                m2_path=m2_path,
+                m3_path=m3_path,
+                m4_path=m4_path,
+                m1_fmt=m1_fmt,
+                m2_fmt=self.two_v_deps_bar,
+                m3_fmt=self.two_v_deps_baz_one,
+                m4_fmt=self.two_v_deps_baz_two,
+            ),
+            self.output,
+        )
+
+        self.check_res(
+            self.two_v_deps_resolve_error.format(
+                manf_path=m1_path,
+                pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+                dummy_fmri=base.Dependency.DUMMY_FMRI,
+            ),
+            self.errout,
+        )
+
+        self.pkgdepend_resolve(
+            "-vo {0}".format(" ".join([m1_path, m2_path, m3_path, m4_path])),
+            exit=1,
+        )
+
+        self.check_res(
+            self.two_v_deps_verbose_output.format(
+                m1_path=m1_path,
+                m2_path=m2_path,
+                m3_path=m3_path,
+                m4_path=m4_path,
+            ),
+            self.output,
+        )
+
+    def test_bug_10518(self):
+        """pkgdepend should exit 2 on input args of the wrong type"""
+        m_path = self.make_manifest(self.test_manf_1)
+
+        # Try feeding a directory where a manifest should be--
+        # a typical scenario we play out here is a user
+        # inverting the first and second args.
+        self.pkgdepend_generate("/", exit=2)
+        self.check_res(
+            "pkgdepend: The manifest file / could not be found.\n"
+            + self.usage_msg,
+            self.errout,
+        )
+
+        self.pkgdepend_resolve("-o /", exit=2)
+        self.check_res(
+            "pkgdepend: The manifest file / could not be found.\n"
+            + self.usage_msg,
+            self.errout,
+        )
+
+    def test_bug_11517(self):
+        """Test the pkgdepend handles bad global options"""
+
+        m_path = None
+        ill_usage = "pkgdepend: illegal global option -- M\n"
+        try:
+            m_path = self.make_manifest(self.test_manf_1)
+
+            self.pkgdepend_resolve("-M -o {0} ".format(m_path), exit=2)
+            self.check_res(ill_usage + self.usage_msg, self.errout)
+        finally:
+            if m_path:
+                portable.remove(m_path)
+
+    def test_bug_11805(self):
+        """Test that paths as payloads work for file actions.
+
+        This tests both that file actions with payloads have their
+        dependencies analyzed correctly and that the correct path is
+        used for internal dependency resolution."""
+
+        proto = pkg5unittest.g_proto_area
+        tp = self.make_manifest(self.payload_manf)
+        self.pkgdepend_generate("-d {0} {1}".format(proto, tp))
+        self.check_res(
+            self.make_res_payload_1(
+                proto, "usr/lib/python{0}/foo/bar.py".format(py_ver_default)
+            ),
+            self.output,
+        )
+        self.check_res("", self.errout)
+
+    def test_bug_11829(self):
+        """pkgdep should gracefully deal with a non-manifest"""
+
+        m_path = None
+        atype = "This"
+        nonsense = "This is a nonsense manifest"
+        m_path = self.make_manifest(nonsense)
+
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(self.test_proto_dir, m_path), exit=1
+        )
+        self.debug(self.errout)
+        self.check_res(
+            "unknown action type '{0}' in action '{1}'".format(atype, nonsense),
+            self.errout,
+        )
+
+        self.pkgdepend_resolve("-o {0} ".format(m_path), exit=1)
+        self.check_res(
+            "unknown action type '{0}' in action '{1}'".format(atype, nonsense),
+            self.errout,
+        )
+
+    def __run_dyn_tok_test(self, run_paths, replaced_path, dep_args):
+        """Using the provided run paths, produces a elf binary with
+        those paths set and checks to make sure that pkgdep run with
+        the provided arguments performs the substitution correctly."""
+
+        elf_path = self.make_elf(run_paths)
+        m_path = self.make_manifest(self.elf_sub_manf.format(file_loc=elf_path))
+        self.pkgdepend_generate(
+            "{0} -d {1} {2}".format(dep_args, self.test_proto_dir, m_path)
+        )
+        self.check_res(
+            self.payload_elf_sub_stdout.format(
+                replaced_path=" {0}.path={1}".format(
+                    base.Dependency.DEPEND_DEBUG_PREFIX, replaced_path
+                )
+            ),
+            self.glre.sub("", self.output),
+        )
+
+    def test_bug_12697(self):
+        """Test that the -D and -k options work as expected.
+
+        The -D and -k options provide a way for a user to specify
+        tokens to expand dynamically in run paths and the kernel paths
+        to use for kernel module run paths."""
+
+        elf_path = self.make_elf([])
+        m_path = self.make_manifest(self.kernel_manf.format(file_loc=elf_path))
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(self.test_proto_dir, m_path)
+        )
+        self.check_res("", self.errout)
+        self.check_res(self.kernel_manf_stdout, self.glre.sub("", self.output))
+
+        self.pkgdepend_generate(
+            "-k baz -k foo/bar -d {0} {1}".format(self.test_proto_dir, m_path)
+        )
+        self.check_res("", self.errout)
+        self.check_res(self.kernel_manf_stdout2, self.output)
+
+        self.debug(
+            "Test for platform substitution in kernel "
+            "module paths. Bug 13057"
+        )
+
+        self.pkgdepend_generate(
+            "-D PLATFORM=baz -D PLATFORM=tp -d {0} {1}".format(
+                self.test_proto_dir, m_path
+            )
+        )
+        self.check_res("", self.errout)
+        self.check_res(
+            self.kernel_manf_stdout_platform, self.glre.sub("", self.output)
+        )
+
+        self.debug("Test unexpanded token")
+
+        rp = ["/platform/$PLATFORM/foo"]
+        elf_path = self.make_elf(rp)
+        m_path = self.make_manifest(self.elf_sub_manf.format(file_loc=elf_path))
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(self.test_proto_dir, m_path), exit=1
+        )
+        self.check_res(
+            (
+                self.payload_elf_sub_error.format(
+                    payload_path=os.path.join(self.test_proto_dir, elf_path),
+                    installed_path="bar/foo",
+                    tok="$PLATFORM",
+                    rp=rp[0],
+                )
+            ),
+            self.errout,
+        )
+
+        self.check_res(
+            self.payload_elf_sub_stdout.format(replaced_path=""),
+            self.glre.sub("", self.output),
+        )
+
+        # Test token expansion
+        self.debug("test token expansion: $PLATFORM")
+        self.__run_dyn_tok_test(
+            ["/platform/$PLATFORM/foo"], "platform/pfoo/foo", "-D PLATFORM=pfoo"
+        )
+
+        self.debug("test token expansion: $ISALIST")
+        self.__run_dyn_tok_test(
+            ["/foo/bar/$ISALIST/baz"], "foo/bar/SUBL/baz", "-D '$ISALIST=SUBL'"
+        )
+
+        self.debug("test token expansion: $PLATFORM and $ISALIST")
+        self.__run_dyn_tok_test(
+            ["/foo/$PLATFORM/$ISALIST/baz"],
+            "foo/pfoo/bar/SUBL/baz",
+            "-D ISALIST=SUBL -D PLATFORM=pfoo/bar",
+        )
+
+        self.debug("test token expansion: multiple $PLATFORM")
+        self.__run_dyn_tok_test(
+            ["/$PLATFORM/$PLATFORM/$ISALIST/$PLATFORM"],
+            "bar/bar/SUBL/bar",
+            "-D ISALIST=SUBL -D PLATFORM=bar",
+        )
+
+        self.debug("Test multiple run paths and multiple subs")
+        rp = ["/platform/$PLATFORM/foo", "/$ISALIST/$PLATFORM/baz"]
+        elf_path = self.make_elf(rp)
+        m_path = self.make_manifest(self.elf_sub_manf.format(file_loc=elf_path))
+        self.pkgdepend_generate(
+            "-D ISALIST=isadir -d {0} {1}".format(self.test_proto_dir, m_path),
+            exit=1,
+        )
+        self.check_res(
+            self.double_plat_error.format(proto_dir=self.test_proto_dir),
+            self.errout,
+        )
+        self.check_res(self.double_plat_stdout, self.glre.sub("", self.output))
+
+        self.pkgdepend_generate(
+            "-D PLATFORM=pfoo -d {0} {1}".format(self.test_proto_dir, m_path),
+            exit=1,
+        )
+        self.check_res(
+            self.double_plat_isa_error.format(proto_dir=self.test_proto_dir),
+            self.errout,
+        )
+        self.check_res(
+            self.double_plat_isa_stdout, self.glre.sub("", self.output)
+        )
+
+        self.pkgdepend_generate(
+            "-D PLATFORM=pfoo -D PLATFORM=pfoo2 "
+            "-D ISALIST=isadir -D ISALIST=isadir -d {0} {1}".format(
+                self.test_proto_dir, m_path
+            )
+        )
+        self.check_res("", self.errout)
+        self.check_res(
+            self.double_double_stdout, self.glre.sub("", self.output)
+        )
+
+    def test_missing_payload(self):
+        """Test that the error produced by a missing payload action
+        uses the right path."""
+        payload = "tmp/file/should/not/exist/here/foo"
+        m1_path = self.make_manifest(
+            self.miss_payload_manf.format(payload=payload)
+        )
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(self.test_proto_dir, m1_path), exit=1
+        )
+        self.check_res(
+            self.miss_payload_manf_error.format(
+                payload=payload, path_pref=self.test_proto_dir
+            ),
+            self.errout,
+        )
+        self.check_res("", self.output)
+
+        m2_path = self.make_manifest(self.empty_payload_manf)
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(self.test_proto_dir, m2_path), exit=1
+        )
+        self.check_res(
+            self.empty_payload_manf_error.format(path_pref=self.test_proto_dir),
+            self.errout,
+        )
+        self.check_res("", self.output)
+
+        m3_path = self.make_manifest(self.nohash_payload_manf)
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(self.test_proto_dir, m3_path), exit=1
+        )
+        self.check_res(
+            self.empty_payload_manf_error.format(path_pref=self.test_proto_dir),
+            self.errout,
+        )
+        self.check_res("", self.output)
+
+    def test_bug_14116(self):
+        foo_path = self.make_proto_text_file("bar/foo", "#!perl -w\n\n")
+        m_path = self.make_manifest(
+            self.elf_sub_manf.format(file_loc="bar/foo")
+        )
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(self.test_proto_dir, m_path), exit=1
+        )
+        self.check_res(self.output, "")
+        self.check_res(
+            self.errout,
+            "{0}/bar/foo says it should be run "
+            "with 'perl' which is a relative path.".format(self.test_proto_dir),
+        )
+
+    def test_unsatisfied_deps(self):
+        """Test resolution behaviour with various unsatisfied
+        dependencies"""
+        unsat = self.make_manifest(self.unsatisfied_manf)
+        partial = self.make_manifest(self.partially_satisfied_manf)
+        satisfying = self.make_manifest(self.satisfying_manf)
+
+        # Generally unsatisfied dependency
+        self.pkgdepend_resolve(" -o {0}".format(unsat), exit=1)
+        self.check_res(self.unsatisfied_error_1.format(unsat), self.errout)
+
+        # Dependency that would be satisfied were it not for
+        # mismatched variants
+        self.pkgdepend_resolve(" -o {0} {1}".format(unsat, satisfying), exit=1)
+        self.check_res(self.unsatisfied_error_1.format(unsat), self.errout)
+
+        # Partially satisfied dependency (for one variant
+        # value, not another)
+        self.pkgdepend_resolve(
+            " -o {0} {1}".format(partial, satisfying), exit=1
+        )
+        self.check_res(self.unsatisfied_error_2.format(partial), self.errout)
+        self.check_res(
+            "# {0}\n{1}\n\n# {2}\n".format(
+                partial, self.satisfying_out, satisfying
+            ),
+            self.output,
+        )
+
+        # No dependencies at all
+        self.pkgdepend_resolve(" -o {0}".format(satisfying))
+
+    def test_bug_14118(self):
+        """Check that duplicate dependency actions are consolitdated
+        correctly, taking the variants into accout."""
+
+        # In the comments below, v.f stands for variant.foo and v.n
+        # stands for variant.num.
+
+        # dup_variant_deps contains all the dependencies to be resolved.
+        # It is published as dup-v-deps.
+        m1_path = self.make_manifest(self.dup_variant_deps)
+
+        # two_v_deps_bar is published as the package s-v-bar.  It
+        # provides var/log/authlog when v.f=bar and var/log/file2 under
+        # all variants.  This means that dup-v-deps should depend
+        # unconditionally on s-v-bar.  This resolution tests that a
+        # dependency on X which exists only under a specific combination
+        # of variants is merged into a more general dependency
+        # appropriately.
+        m2_path = self.make_manifest(self.two_v_deps_bar)
+
+        # two_v_deps_baz_one is published as the package s-v-baz-one.
+        # It provides var/log/authlog when v.f=baz and v.n=one.  This
+        # means that dup-v-deps should depend on s-v-baz-one when
+        # v.f=baz and v.n=one.  This resolution tests that dependencies
+        # are still versioned correctly when necessary.
+        m3_path = self.make_manifest(self.two_v_deps_baz_one)
+
+        # two_v_deps_baz_two is identical to two_v_deps_baz_one except
+        # that it provides var/log/authlog when v.f=baz and v.n=two.
+        m4_path = self.make_manifest(self.two_v_deps_baz_two)
+
+        # dup_prov is published as the package dup-prov.  It provides
+        # var/log/f1 and var/log/f2 under all variants.  dup-v-deps
+        # depends on dup-prov under all combinations of variants because
+        # of each file.  This tests that when two dependencies are valid
+        # under same set of variants, they're combined correctly.
+        m5_path = self.make_manifest(self.dup_prov)
+
+        # sep_vars is published as sep_vars.  It provides var/log/f3
+        # when v.f=bar and var/log/f4 when v.f=baz.  This means that
+        # dup-v-deps depends on sep_vars for different reasons when
+        # v.f=bar and when v.f=baz.  This tests that those dependencies
+        # continue to be reported as separate dependencies.
+        m6_path = self.make_manifest(self.sep_vars)
+
+        # subset_prov unconditionally provides two files, f5 and f6.
+        # dup-v-deps unconditionally depends on f5, and conditionally
+        # depends on f6.  This means that dup-v-deps should
+        # unconditionally depend on dup-v-deps.  This also tests that
+        # variants are removed and added during the internal processing
+        # of dependency resolution.
+        m7_path = self.make_manifest(self.subset_prov)
+
+        # This empty manifest will be published as hand-dep. This checks
+        # that manually added dependencies are propogated correctly.
+        m8_path = self.make_manifest("\n\n")
+
+        # Test that resolve handles multiline actions correctly when
+        # echoing the manifest.  Bug 18740
+        self.pkgfmt(m1_path)
+
+        self.pkgdepend_resolve(
+            " -vm {0}".format(
+                " ".join(
+                    [
+                        m1_path,
+                        m2_path,
+                        m3_path,
+                        m4_path,
+                        m5_path,
+                        m6_path,
+                        m7_path,
+                        m8_path,
+                    ]
+                )
+            )
+        )
+        fh = open(m1_path + ".res")
+        res = fh.read()
+        fh.close()
+        self.check_res(self.dup_variant_deps_resolved, res)
+
+        pfmris = {
+            m1_path: "pkg:/dup-v-deps@0.1-0.2",
+            m2_path: "pkg:/s-v-bar@0.1-0.2",
+            m3_path: "pkg:/s-v-baz-one@0.1-0.2",
+            m4_path: "pkg:/s-v-baz-two@0.1-0.2",
+            m5_path: "pkg:/dup-prov@0.1-0.2",
+            m6_path: "pkg:/sep_vars@0.1-0.2",
+            m7_path: "pkg:/subset-prov@0.1-0.2 ",
+            m8_path: "pkg:/hand-dep@0.1-0.2",
+        }
+
+        # Add FMRI to each manifest for use with publish.
+        for mpath, pfmri in pfmris.items():
+            lines = open(mpath + ".res", "r").readlines()
+            with open(mpath + ".res", "w") as mf:
+                mf.write("set name=pkg.fmri value={0}\n".format(pfmri))
+                for l in lines:
+                    if "pkg.fmri" in l:
+                        continue
+                    mf.write(l)
+
+        # Check that the results can be installed correctly.
+        self.make_proto_text_file("var/log/file2")
+        self.make_proto_text_file("var/log/authlog")
+        self.make_proto_text_file("var/log/f1")
+        self.make_proto_text_file("var/log/f2")
+        self.make_proto_text_file("var/log/f3")
+        self.make_proto_text_file("var/log/f4")
+        self.make_proto_text_file("var/log/f5")
+        self.make_proto_text_file("var/log/f6")
+        self.make_proto_text_file(
+            "platform/i86pc/kernel/dacf/amd64/consconfig_dacf"
+        )
+        self.make_proto_text_file("platform/i86pc/kernel/dacf/consconfig_dacf")
+        self.pkgsend(
+            self.rurl,
+            "publish -d {0} {1}".format(self.test_proto_dir, m1_path + ".res"),
+        )
+        self.pkgsend(
+            self.rurl,
+            "publish -d {0} {1}".format(self.test_proto_dir, m2_path + ".res"),
+        )
+        self.pkgsend(
+            self.rurl,
+            "publish -d {0} {1}".format(self.test_proto_dir, m3_path + ".res"),
+        )
+        self.pkgsend(
+            self.rurl,
+            "publish -d {0} {1}".format(self.test_proto_dir, m4_path + ".res"),
+        )
+        self.pkgsend(
+            self.rurl,
+            "publish -d {0} {1}".format(self.test_proto_dir, m5_path + ".res"),
+        )
+        self.pkgsend(
+            self.rurl,
+            "publish -d {0} {1}".format(self.test_proto_dir, m6_path + ".res"),
+        )
+        self.pkgsend(
+            self.rurl,
+            "publish -d {0} {1}".format(self.test_proto_dir, m7_path + ".res"),
+        )
+        self.pkgsend(
+            self.rurl,
+            "publish -d {0} {1}".format(self.test_proto_dir, m8_path + ".res"),
+        )
+        foo_vars = ["bar", "baz"]
+        num_vars = ["one", "two"]
+        for fv in foo_vars:
+            for nv in num_vars:
+                variants = {"variant.foo": fv, "variant.num": nv}
+                self.image_create(self.rurl, variants=variants)
+                self.pkg("install dup-v-deps")
+                self.image_destroy()
+
+    def test_bug_15777(self):
+        """Test that -S switch disables resolving dependencies against
+        the installed system."""
+
+        self.make_misc_files(["tmp/foo"])
+        self.pkgsend_bulk(self.rurl, self.inst_pkg)
+        api_obj = self.get_img_api_obj()
+        api_obj.refresh(immediate=True)
+        self._api_install(api_obj, ["example2_pkg"])
+
+        m1_path = self.make_manifest(self.multi_deps)
+        m2_path = self.make_manifest(self.misc_manf)
+
+        self.pkgdepend_resolve("-o {0} {1}".format(m1_path, m2_path))
+        self.pkgdepend_resolve("-o -S {0} {1}".format(m1_path, m2_path), exit=1)
+
+    def test_bug_15843(self):
+        """Test that multiple proto_dirs work as expected."""
+
+        curses = "usr/xpg4/lib/libcurses.so.1"
+        pam = "etc/pam.conf"
+        self.make_elf([], "d1/{0}".format(curses))
+        self.make_proto_text_file("d2/{0}".format(pam), "text")
+        tp = self.make_manifest(self.test_manf_2)
+
+        # Check that files are not found.
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(self.test_proto_dir, tp), exit=1
+        )
+        self.check_res("", self.output)
+        self.check_res(
+            "\n".join(
+                [
                     "Couldn't find '{0}' in any of the specified search "
                     "directories:\n\t{1}".format(d, self.test_proto_dir)
-                    for d in (curses, pam)]),
-                    self.errout)
+                    for d in (curses, pam)
+                ]
+            ),
+            self.errout,
+        )
 
-                # Check that the files are now correctly found.
-                self.pkgdepend_generate("-d {0} -d {1} -d {2} {3}".format(
-                    self.test_proto_dir,
-                    os.path.join(self.test_proto_dir, "d1"),
-                    os.path.join(self.test_proto_dir, "d2"), tp))
-                self.check_res(self.res_manf_2,
-                    self.glre.sub('', self.output))
-                self.check_res("", self.errout)
+        # Check that the files are now correctly found.
+        self.pkgdepend_generate(
+            "-d {0} -d {1} -d {2} {3}".format(
+                self.test_proto_dir,
+                os.path.join(self.test_proto_dir, "d1"),
+                os.path.join(self.test_proto_dir, "d2"),
+                tp,
+            )
+        )
+        self.check_res(self.res_manf_2, self.glre.sub("", self.output))
+        self.check_res("", self.errout)
 
-                # Check that ordering among proto_dirs is correct.
-                # This should produce no dependencies because the text file
-                # in self.test_proto_dir should be found first.
-                self.make_proto_text_file("usr/xpg4/lib/libcurses.so.1", "text")
-                self.pkgdepend_generate("-d {0} -d {1} -d {2} {3}".format(
-                    self.test_proto_dir,
-                    os.path.join(self.test_proto_dir, "d1"),
-                    os.path.join(self.test_proto_dir, "d2"), tp))
-                self.check_res("", self.output)
-                self.check_res("", self.errout)
+        # Check that ordering among proto_dirs is correct.
+        # This should produce no dependencies because the text file
+        # in self.test_proto_dir should be found first.
+        self.make_proto_text_file("usr/xpg4/lib/libcurses.so.1", "text")
+        self.pkgdepend_generate(
+            "-d {0} -d {1} -d {2} {3}".format(
+                self.test_proto_dir,
+                os.path.join(self.test_proto_dir, "d1"),
+                os.path.join(self.test_proto_dir, "d2"),
+                tp,
+            )
+        )
+        self.check_res("", self.output)
+        self.check_res("", self.errout)
 
-                # This should produce the normal results for this manifest
-                # because the compiled elf file should be found before the
-                # text file.
-                self.pkgdepend_generate("-d {0} -d {1} -d {2} {3}".format(
-                    os.path.join(self.test_proto_dir, "d2"),
-                    os.path.join(self.test_proto_dir, "d1"),
-                    self.test_proto_dir, tp))
-                self.check_res(self.res_manf_2, self.glre.sub('', self.output))
-                self.check_res("", self.errout)
+        # This should produce the normal results for this manifest
+        # because the compiled elf file should be found before the
+        # text file.
+        self.pkgdepend_generate(
+            "-d {0} -d {1} -d {2} {3}".format(
+                os.path.join(self.test_proto_dir, "d2"),
+                os.path.join(self.test_proto_dir, "d1"),
+                self.test_proto_dir,
+                tp,
+            )
+        )
+        self.check_res(self.res_manf_2, self.glre.sub("", self.output))
+        self.check_res("", self.errout)
 
-                # Check the ordering among -d dirs is correct.
-                self.pkgdepend_generate("-d {0} -d {1} -d {2} {3}".format(
-                    os.path.join(self.test_proto_dir, "d2"),
-                    self.test_proto_dir,
-                    os.path.join(self.test_proto_dir, "d1"), tp))
-                self.check_res("", self.output)
-                self.check_res("", self.errout)
+        # Check the ordering among -d dirs is correct.
+        self.pkgdepend_generate(
+            "-d {0} -d {1} -d {2} {3}".format(
+                os.path.join(self.test_proto_dir, "d2"),
+                self.test_proto_dir,
+                os.path.join(self.test_proto_dir, "d1"),
+                tp,
+            )
+        )
+        self.check_res("", self.output)
+        self.check_res("", self.errout)
 
-        def test_bug_15958(self):
-                """Test that a dependency which is not satisfied internally
-                under certain variants is reported correctly."""
+    def test_bug_15958(self):
+        """Test that a dependency which is not satisfied internally
+        under certain variants is reported correctly."""
 
-                tp = self.make_manifest(self.bug_15958_manf)
-                self.make_proto_text_file("var/log/syslog", "text")
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
-                self.check_res("", self.errout)
-                self.check_res(self.res_bug_15958, self.output)
+        tp = self.make_manifest(self.bug_15958_manf)
+        self.make_proto_text_file("var/log/syslog", "text")
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res("", self.errout)
+        self.check_res(self.res_bug_15958, self.output)
 
-        def test_bug_16013_base(self):
-                """Test that dependencies which involve links in their paths
-                work correctly.  Also tests that dependencies with build
-                versions set cannot be produced (bug 17412).  Build versions are
-                the ,5.11 components in the fmris."""
+    def test_bug_16013_base(self):
+        """Test that dependencies which involve links in their paths
+        work correctly.  Also tests that dependencies with build
+        versions set cannot be produced (bug 17412).  Build versions are
+        the ,5.11 components in the fmris."""
 
-                api_obj = self.get_img_api_obj()
+        api_obj = self.get_img_api_obj()
 
-                self.make_proto_text_file("b/bin/perl")
-                a_pth = self.make_manifest(self.bug_16013_simple_a_dep_manf)
-                b_pth = self.make_manifest(self.bug_16013_simple_b_dep_manf)
+        self.make_proto_text_file("b/bin/perl")
+        a_pth = self.make_manifest(self.bug_16013_simple_a_dep_manf)
+        b_pth = self.make_manifest(self.bug_16013_simple_b_dep_manf)
 
-                plist = self.pkgsend_with_fmri(b_pth)
+        plist = self.pkgsend_with_fmri(b_pth)
 
-                # Test that pkgdep can resolve dependencies through symlinks
-                # in paths at all.
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_pth, b_pth], None, [],
-                        prune_attrs=False)
-                def check_res(deps, errs):
-                        self.assertEqual(len(errs), 0,
-                            "\n" + "\n\n".join([str(s) for s in errs]))
-                        self.assertEqual(len(deps[a_pth]), 1,
-                            "\n".join([str(s) for s in deps[a_pth]]))
-                        d = deps[a_pth][0]
-                        self.assertEqual(d.attrs["fmri"], "pkg:/b@0.5.11-0.151")
-                        self.assertEqual(d.attrs[dependencies.type_prefix],
-                            "script")
-                check_res(deps, errs)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(deps[b_pth]), 0,
-                    "\n".join([str(s) for s in deps[b_pth]]))
-                self._api_install(api_obj, ["b"])
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_pth], api_obj, ["*"],
-                        prune_attrs=False)
-                check_res(deps, errs)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["b"]), external_deps)
-                self._api_uninstall(api_obj, ["b"])
+        # Test that pkgdep can resolve dependencies through symlinks
+        # in paths at all.
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, b_pth], None, [], prune_attrs=False
+        )
 
-        def test_bug_16013_packages_delivering_links(self):
-                """Test that packages which provide path symlinks needed to
-                resolve a dependency are included in the final set of
-                dependencies."""
+        def check_res(deps, errs):
+            self.assertEqual(
+                len(errs), 0, "\n" + "\n\n".join([str(s) for s in errs])
+            )
+            self.assertEqual(
+                len(deps[a_pth]), 1, "\n".join([str(s) for s in deps[a_pth]])
+            )
+            d = deps[a_pth][0]
+            self.assertEqual(d.attrs["fmri"], "pkg:/b@0.5.11-0.151")
+            self.assertEqual(d.attrs[dependencies.type_prefix], "script")
 
-                self.make_proto_text_file("b2/bin/perl")
-                a_pth = self.make_manifest(self.bug_16013_simple_a_dep_manf)
-                b_link_pth = self.make_manifest(
-                    self.bug_16013_simple_b_link_manf)
-                b_link2_pth = self.make_manifest(
-                    self.bug_16013_simple_b_link2_manf)
-                b_file_pth = self.make_manifest(
-                    self.bug_16013_simple_b_file_manf)
+        check_res(deps, errs)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(
+            len(deps[b_pth]), 0, "\n".join([str(s) for s in deps[b_pth]])
+        )
+        self._api_install(api_obj, ["b"])
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth], api_obj, ["*"], prune_attrs=False
+        )
+        check_res(deps, errs)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["b"]), external_deps)
+        self._api_uninstall(api_obj, ["b"])
 
-                plist = self.pkgsend_with_fmri(b_link_pth)
-                plist = self.pkgsend_with_fmri(b_link2_pth)
-                plist = self.pkgsend_with_fmri(b_file_pth)
+    def test_bug_16013_packages_delivering_links(self):
+        """Test that packages which provide path symlinks needed to
+        resolve a dependency are included in the final set of
+        dependencies."""
 
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [a_pth, b_file_pth, b_link_pth, b_link2_pth], None, [],
-                        prune_attrs=False)
+        self.make_proto_text_file("b2/bin/perl")
+        a_pth = self.make_manifest(self.bug_16013_simple_a_dep_manf)
+        b_link_pth = self.make_manifest(self.bug_16013_simple_b_link_manf)
+        b_link2_pth = self.make_manifest(self.bug_16013_simple_b_link2_manf)
+        b_file_pth = self.make_manifest(self.bug_16013_simple_b_file_manf)
 
-                self.bug_16013_check_res_simple_links(deps, errs,
-                    a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(deps[b_file_pth]), 0)
-                self.assertEqual(len(deps[b_link_pth]), 0)
+        plist = self.pkgsend_with_fmri(b_link_pth)
+        plist = self.pkgsend_with_fmri(b_link2_pth)
+        plist = self.pkgsend_with_fmri(b_file_pth)
 
-        def test_bug_16013_variants_base(self):
-                """Test that variants on files, links and dependencies work
-                correctly when resolving dependencies."""
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, b_file_pth, b_link_pth, b_link2_pth],
+            None,
+            [],
+            prune_attrs=False,
+        )
 
-                self.make_proto_text_file("c/bin/perl")
-                a_pth = self.make_manifest(self.bug_16013_var_a_dep_manf)
-                b_link_pth = self.make_manifest(self.bug_16013_var_b_link_manf)
-                b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
-                c_pth = self.make_manifest(self.bug_16013_var_c_manf)
+        self.bug_16013_check_res_simple_links(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(deps[b_file_pth]), 0)
+        self.assertEqual(len(deps[b_link_pth]), 0)
 
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [a_pth, b_file_pth, b_link_pth, c_pth], None, [],
-                        prune_attrs=False)
+    def test_bug_16013_variants_base(self):
+        """Test that variants on files, links and dependencies work
+        correctly when resolving dependencies."""
 
-                self.bug_16013_check_res_variants_base(deps, errs, a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(deps[c_pth]), 0)
-                self.assertEqual(len(deps[b_file_pth]), 0)
-                self.assertEqual(len(deps[b_link_pth]), 0)
+        self.make_proto_text_file("c/bin/perl")
+        a_pth = self.make_manifest(self.bug_16013_var_a_dep_manf)
+        b_link_pth = self.make_manifest(self.bug_16013_var_b_link_manf)
+        b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
+        c_pth = self.make_manifest(self.bug_16013_var_c_manf)
 
-        def test_bug_16013_variants_filtered_by_links(self):
-                """Test that variants due to files are appropriately filtered by
-                the links needed to reach them."""
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, b_file_pth, b_link_pth, c_pth], None, [], prune_attrs=False
+        )
 
-                multivar_b_file_manf = """\
+        self.bug_16013_check_res_variants_base(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(deps[c_pth]), 0)
+        self.assertEqual(len(deps[b_file_pth]), 0)
+        self.assertEqual(len(deps[b_link_pth]), 0)
+
+    def test_bug_16013_variants_filtered_by_links(self):
+        """Test that variants due to files are appropriately filtered by
+        the links needed to reach them."""
+
+        multivar_b_file_manf = """\
 set name=pkg.fmri value=pkg:/b_file@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=b
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=c
 """
-                self.make_proto_text_file("c/bin/perl")
-                a_pth = self.make_manifest(self.bug_16013_var_a_dep_manf)
-                b_link_pth = self.make_manifest(self.bug_16013_var_b_link_manf)
-                c_pth = self.make_manifest(self.bug_16013_var_c_manf)
+        self.make_proto_text_file("c/bin/perl")
+        a_pth = self.make_manifest(self.bug_16013_var_a_dep_manf)
+        b_link_pth = self.make_manifest(self.bug_16013_var_b_link_manf)
+        c_pth = self.make_manifest(self.bug_16013_var_c_manf)
 
-                multivar_b_file_pth = self.make_manifest(multivar_b_file_manf)
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [a_pth, multivar_b_file_pth, b_link_pth, c_pth], None,
-                        [])
-                self.bug_16013_check_res_variants_base(deps, errs, a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(deps[c_pth]), 0)
-                self.assertEqual(len(deps[multivar_b_file_pth]), 0)
-                self.assertEqual(len(deps[b_link_pth]), 0)
+        multivar_b_file_pth = self.make_manifest(multivar_b_file_manf)
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, multivar_b_file_pth, b_link_pth, c_pth], None, []
+        )
+        self.bug_16013_check_res_variants_base(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(deps[c_pth]), 0)
+        self.assertEqual(len(deps[multivar_b_file_pth]), 0)
+        self.assertEqual(len(deps[b_link_pth]), 0)
 
-        def test_bug_16013_meaningless_files_ok(self):
-                """Test that files which are irrelevant due to variants do not
-                cause issues resolving dependencies."""
+    def test_bug_16013_meaningless_files_ok(self):
+        """Test that files which are irrelevant due to variants do not
+        cause issues resolving dependencies."""
 
-                a_var_b_dep_manf = """\
+        a_var_b_dep_manf = """\
 set name=pkg.fmri value=pkg:/a@0.5.11,5.11-0.151
 set name=variant.foo value=b value=c value=a
 depend fmri=__TBD pkg.debug.depend.file=perl pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=usr/bin/perl_app pkg.debug.depend.type=script type=require
 """
 
-                c_no_link_manf = """\
+        c_no_link_manf = """\
 set name=pkg.fmri value=pkg:/c@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 file NOHASH group=bin mode=0555 owner=root path=usr/bin/perl variant.foo=c
 """
-                self.make_proto_text_file("c/bin/perl")
-                a_var_b_dep_pth = self.make_manifest(a_var_b_dep_manf)
-                b_link_pth = self.make_manifest(self.bug_16013_var_b_link_manf)
-                b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
-                c_no_link_pth = self.make_manifest(c_no_link_manf)
+        self.make_proto_text_file("c/bin/perl")
+        a_var_b_dep_pth = self.make_manifest(a_var_b_dep_manf)
+        b_link_pth = self.make_manifest(self.bug_16013_var_b_link_manf)
+        b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
+        c_no_link_pth = self.make_manifest(c_no_link_manf)
 
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_var_b_dep_pth, b_file_pth,
-                        b_link_pth, c_no_link_pth], None, [], prune_attrs=False)
-                self.assertEqual(len(errs), 1,
-                    "\n\n".join([str(s) for s in errs]))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                e = errs[0]
-                self.assertEqual(e.path, a_var_b_dep_pth)
-                self.assertEqual(e.file_dep.attrs[dependencies.files_prefix],
-                    "perl")
-                self.assertEqual(e.pvars.not_sat_set,
-                    set([frozenset([("variant.foo", "a")])]))
-                self.assertEqual(len(deps[a_var_b_dep_pth]), 3,
-                    "\n".join([str(s) for s in deps[a_var_b_dep_pth]]))
-                res_fmris = set(["pkg:/b_link@0.5.11-0.151",
-                    "pkg:/b_file@0.5.11-0.151", "pkg:/c@0.5.11-0.151"])
-                for d in deps[a_var_b_dep_pth]:
-                        self.assertTrue(d.attrs["fmri"] in res_fmris,
-                            "Unexpected fmri for:{0}".format(d))
-                        res_fmris.remove(d.attrs["fmri"])
-                        if d.attrs["fmri"] == "pkg:/b_link@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "link")
-                                self.assertEqual(d.attrs["variant.foo"], "b")
-                        elif d.attrs["fmri"] == "pkg:/b_file@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "script")
-                                self.assertEqual(d.attrs["variant.foo"], "b")
-                        else:
-                                self.assertEqual(d.attrs["variant.foo"], "c")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "script")
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_var_b_dep_pth, b_file_pth, b_link_pth, c_no_link_pth],
+            None,
+            [],
+            prune_attrs=False,
+        )
+        self.assertEqual(len(errs), 1, "\n\n".join([str(s) for s in errs]))
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        e = errs[0]
+        self.assertEqual(e.path, a_var_b_dep_pth)
+        self.assertEqual(e.file_dep.attrs[dependencies.files_prefix], "perl")
+        self.assertEqual(
+            e.pvars.not_sat_set, set([frozenset([("variant.foo", "a")])])
+        )
+        self.assertEqual(
+            len(deps[a_var_b_dep_pth]),
+            3,
+            "\n".join([str(s) for s in deps[a_var_b_dep_pth]]),
+        )
+        res_fmris = set(
+            [
+                "pkg:/b_link@0.5.11-0.151",
+                "pkg:/b_file@0.5.11-0.151",
+                "pkg:/c@0.5.11-0.151",
+            ]
+        )
+        for d in deps[a_var_b_dep_pth]:
+            self.assertTrue(
+                d.attrs["fmri"] in res_fmris,
+                "Unexpected fmri for:{0}".format(d),
+            )
+            res_fmris.remove(d.attrs["fmri"])
+            if d.attrs["fmri"] == "pkg:/b_link@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+            elif d.attrs["fmri"] == "pkg:/b_file@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+            else:
+                self.assertEqual(d.attrs["variant.foo"], "c")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
 
-                self.assertEqual(len(deps[c_no_link_pth]), 0)
-                self.assertEqual(len(deps[b_file_pth]), 0)
-                self.assertEqual(len(deps[b_link_pth]), 0)
+        self.assertEqual(len(deps[c_no_link_pth]), 0)
+        self.assertEqual(len(deps[b_file_pth]), 0)
+        self.assertEqual(len(deps[b_link_pth]), 0)
 
-        def test_bug_16013_variants_due_to_links_filtered(self):
-                """Test that variants due to links are appropriately filtered by
-                the files they link to."""
+    def test_bug_16013_variants_due_to_links_filtered(self):
+        """Test that variants due to links are appropriately filtered by
+        the files they link to."""
 
-                multivar_b_link_manf = """\
+        multivar_b_link_manf = """\
 set name=pkg.fmri value=pkg:/b_link@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 link path=usr/bin target=/b/bin variant.foo=b
 link path=usr/bin target=/b/bin variant.foo=c
 dir group=bin mode=0755 owner=root path=b/bin variant.foo=b
 """
-                a_pth = self.make_manifest(self.bug_16013_var_a_dep_manf)
-                multivar_b_link_pth = self.make_manifest(multivar_b_link_manf)
-                b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
-                c_pth = self.make_manifest(self.bug_16013_var_c_manf)
+        a_pth = self.make_manifest(self.bug_16013_var_a_dep_manf)
+        multivar_b_link_pth = self.make_manifest(multivar_b_link_manf)
+        b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
+        c_pth = self.make_manifest(self.bug_16013_var_c_manf)
 
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [a_pth, b_file_pth, multivar_b_link_pth, c_pth], None,
-                        [], prune_attrs=False)
-                self.bug_16013_check_res_variants_base(deps, errs, a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(deps[c_pth]), 0)
-                self.assertEqual(len(deps[b_file_pth]), 0)
-                self.assertEqual(len(deps[multivar_b_link_pth]), 0)
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, b_file_pth, multivar_b_link_pth, c_pth],
+            None,
+            [],
+            prune_attrs=False,
+        )
+        self.bug_16013_check_res_variants_base(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(deps[c_pth]), 0)
+        self.assertEqual(len(deps[b_file_pth]), 0)
+        self.assertEqual(len(deps[multivar_b_link_pth]), 0)
 
-        def test_bug_16013_links_restricted(self):
-                """Test that links without specific variant tags are restricted
-                correctly."""
+    def test_bug_16013_links_restricted(self):
+        """Test that links without specific variant tags are restricted
+        correctly."""
 
-                multivar2_b_link_manf = """\
+        multivar2_b_link_manf = """\
 set name=pkg.fmri value=pkg:/b_link@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 link path=usr/bin target=/b/bin
 dir group=bin mode=0755 owner=root path=b/bin variant.foo=b
 """
 
-                self.make_proto_text_file("c/bin/perl")
-                a_pth = self.make_manifest(self.bug_16013_var_a_dep_manf)
-                b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
-                c_pth = self.make_manifest(self.bug_16013_var_c_manf)
+        self.make_proto_text_file("c/bin/perl")
+        a_pth = self.make_manifest(self.bug_16013_var_a_dep_manf)
+        b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
+        c_pth = self.make_manifest(self.bug_16013_var_c_manf)
 
-                multivar2_b_link_pth = self.make_manifest(multivar2_b_link_manf)
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [a_pth, b_file_pth, multivar2_b_link_pth, c_pth], None,
-                        [], prune_attrs=False)
-                self.bug_16013_check_res_variants_base(deps, errs, a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(deps[c_pth]), 0)
-                self.assertEqual(len(deps[b_file_pth]), 0)
-                self.assertEqual(len(deps[multivar2_b_link_pth]), 0)
+        multivar2_b_link_pth = self.make_manifest(multivar2_b_link_manf)
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, b_file_pth, multivar2_b_link_pth, c_pth],
+            None,
+            [],
+            prune_attrs=False,
+        )
+        self.bug_16013_check_res_variants_base(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(deps[c_pth]), 0)
+        self.assertEqual(len(deps[b_file_pth]), 0)
+        self.assertEqual(len(deps[multivar2_b_link_pth]), 0)
 
-        def test_bug_16013_varianted_dependency_resolution(self):
-                """Test that a dependency that only applies under certain
-                variant combinations is resolved correctly."""
+    def test_bug_16013_varianted_dependency_resolution(self):
+        """Test that a dependency that only applies under certain
+        variant combinations is resolved correctly."""
 
-                a_var_limited_dep_manf = """\
+        a_var_limited_dep_manf = """\
 set name=pkg.fmri value=pkg:/a@0.5.11,5.11-0.151
 set name=variant.foo value=b value=c value=a
 depend fmri=__TBD pkg.debug.depend.file=perl pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=usr/bin/perl_app pkg.debug.depend.type=script type=require variant.foo=b
 depend fmri=__TBD pkg.debug.depend.file=perl pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=usr/bin/perl_app pkg.debug.depend.type=script type=require variant.foo=c
 """
-                a_var_limited_pth = self.make_manifest(a_var_limited_dep_manf)
-                b_link_pth = self.make_manifest(self.bug_16013_var_b_link_manf)
-                b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
-                c_pth = self.make_manifest(self.bug_16013_var_c_manf)
+        a_var_limited_pth = self.make_manifest(a_var_limited_dep_manf)
+        b_link_pth = self.make_manifest(self.bug_16013_var_b_link_manf)
+        b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
+        c_pth = self.make_manifest(self.bug_16013_var_c_manf)
 
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [a_var_limited_pth, b_file_pth, b_link_pth, c_pth],
-                        None, [], prune_attrs=False)
-                self.assertEqual(len(errs), 0,
-                    "\n\n".join([str(s) for s in errs]))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(deps[a_var_limited_pth]), 3,
-                    "\n".join([str(s) for s in deps[a_var_limited_pth]]))
-                res_fmris = set(["pkg:/b_link@0.5.11-0.151",
-                    "pkg:/c@0.5.11-0.151", "pkg:/b_file@0.5.11-0.151"])
-                for d in deps[a_var_limited_pth]:
-                        self.assertTrue(d.attrs["fmri"] in res_fmris,
-                            "Unexpected fmri for:{0}".format(d))
-                        res_fmris.remove(d.attrs["fmri"])
-                        if d.attrs["fmri"] == "pkg:/b_link@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "link")
-                                self.assertEqual(d.attrs["variant.foo"], "b")
-                        elif d.attrs["fmri"] == "pkg:/b_file@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "script")
-                                self.assertEqual(d.attrs["variant.foo"], "b")
-                        else:
-                                self.assertEqual(d.attrs["variant.foo"], "c")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "script")
-                self.assertEqual(len(deps[c_pth]), 0)
-                self.assertEqual(len(deps[b_file_pth]), 0)
-                self.assertEqual(len(deps[b_link_pth]), 0)
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_var_limited_pth, b_file_pth, b_link_pth, c_pth],
+            None,
+            [],
+            prune_attrs=False,
+        )
+        self.assertEqual(len(errs), 0, "\n\n".join([str(s) for s in errs]))
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(
+            len(deps[a_var_limited_pth]),
+            3,
+            "\n".join([str(s) for s in deps[a_var_limited_pth]]),
+        )
+        res_fmris = set(
+            [
+                "pkg:/b_link@0.5.11-0.151",
+                "pkg:/c@0.5.11-0.151",
+                "pkg:/b_file@0.5.11-0.151",
+            ]
+        )
+        for d in deps[a_var_limited_pth]:
+            self.assertTrue(
+                d.attrs["fmri"] in res_fmris,
+                "Unexpected fmri for:{0}".format(d),
+            )
+            res_fmris.remove(d.attrs["fmri"])
+            if d.attrs["fmri"] == "pkg:/b_link@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+            elif d.attrs["fmri"] == "pkg:/b_file@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+            else:
+                self.assertEqual(d.attrs["variant.foo"], "c")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+        self.assertEqual(len(deps[c_pth]), 0)
+        self.assertEqual(len(deps[b_file_pth]), 0)
+        self.assertEqual(len(deps[b_link_pth]), 0)
 
-        def test_bug_16013_two_d_external(self):
-                """Test that two dimensions of variants works correctly when
-                resolving between packages."""
+    def test_bug_16013_two_d_external(self):
+        """Test that two dimensions of variants works correctly when
+        resolving between packages."""
 
-                twod_a_dep_manf = """\
+        twod_a_dep_manf = """\
 set name=pkg.fmri value=pkg:/a@0.5.11,5.11-0.151
 set name=variant.foo value=b value=c value=a
 set name=variant.bar value=v value=w value=x value=y value=z
 depend fmri=__TBD pkg.debug.depend.file=perl pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=usr/bin/perl_app pkg.debug.depend.type=script type=require
 """
 
-                twod_b_vw_link_manf = """\
+        twod_b_vw_link_manf = """\
 set name=pkg.fmri value=pkg:/b_vw_link@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 set name=variant.bar value=v value=w value=x value=y value=z
@@ -2296,7 +2654,7 @@ link path=usr/bin target=/b/bin variant.foo=b variant.bar=w
 dir group=bin mode=0755 owner=root path=b/bin variant.foo=b
 """
 
-                twod_b_yz_link_manf = """\
+        twod_b_yz_link_manf = """\
 set name=pkg.fmri value=pkg:/b_yz_link@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 set name=variant.bar value=v value=w value=x value=y value=z
@@ -2305,7 +2663,7 @@ link path=usr/bin target=/b/bin variant.foo=b variant.bar=z
 dir group=bin mode=0755 owner=root path=b/bin variant.foo=b
 """
 
-                twod_b_vwx_file_manf = """\
+        twod_b_vwx_file_manf = """\
 set name=pkg.fmri value=pkg:/b_vwx_file@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 set name=variant.bar value=v value=w value=x value=y value=z
@@ -2314,14 +2672,14 @@ file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=b variant
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=b variant.bar=x
 """
 
-                twod_b_y_file_manf = """\
+        twod_b_y_file_manf = """\
 set name=pkg.fmri value=pkg:/b_y_file@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 set name=variant.bar value=v value=w value=x value=y value=z
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=b variant.bar=y
 """
 
-                twod_c_manf = """\
+        twod_c_manf = """\
 set name=pkg.fmri value=pkg:/c@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 set name=variant.bar value=v value=w value=x value=y value=z
@@ -2329,265 +2687,338 @@ link path=usr/bin target=../c/bin variant.foo=c
 dir group=bin mode=0755 owner=root path=c/bin variant.foo=c
 file NOHASH group=bin mode=0555 owner=root path=c/bin/perl variant.foo=c
 """
-                twod_a_pth = self.make_manifest(twod_a_dep_manf)
-                twod_b_vw_link_pth = self.make_manifest(twod_b_vw_link_manf)
-                twod_b_yz_link_pth = self.make_manifest(twod_b_yz_link_manf)
-                twod_b_vwx_file_pth = self.make_manifest(twod_b_vwx_file_manf)
-                twod_b_y_file_pth = self.make_manifest(twod_b_y_file_manf)
-                twod_c_pth = self.make_manifest(twod_c_manf)
+        twod_a_pth = self.make_manifest(twod_a_dep_manf)
+        twod_b_vw_link_pth = self.make_manifest(twod_b_vw_link_manf)
+        twod_b_yz_link_pth = self.make_manifest(twod_b_yz_link_manf)
+        twod_b_vwx_file_pth = self.make_manifest(twod_b_vwx_file_manf)
+        twod_b_y_file_pth = self.make_manifest(twod_b_y_file_manf)
+        twod_c_pth = self.make_manifest(twod_c_manf)
 
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([twod_a_pth, twod_b_vw_link_pth,
-                        twod_b_yz_link_pth, twod_b_vwx_file_pth,
-                        twod_b_y_file_pth, twod_c_pth], None, [],
-                        prune_attrs=False)
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [
+                twod_a_pth,
+                twod_b_vw_link_pth,
+                twod_b_yz_link_pth,
+                twod_b_vwx_file_pth,
+                twod_b_y_file_pth,
+                twod_c_pth,
+            ],
+            None,
+            [],
+            prune_attrs=False,
+        )
 
-                self.assertEqual(len(errs), 1,
-                    "\n\n".join([str(s) for s in errs]))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                missing_vcs = []
-                e = errs[0]
-                self.assertEqual(e.path, twod_a_pth)
-                self.assertEqual(e.file_dep.attrs[dependencies.files_prefix],
-                    "perl")
-                # Set is unordered, the output might be different in order, so
-                # we just assert the sets are equal.
-                self.assertEqual(set([
+        self.assertEqual(len(errs), 1, "\n\n".join([str(s) for s in errs]))
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        missing_vcs = []
+        e = errs[0]
+        self.assertEqual(e.path, twod_a_pth)
+        self.assertEqual(e.file_dep.attrs[dependencies.files_prefix], "perl")
+        # Set is unordered, the output might be different in order, so
+        # we just assert the sets are equal.
+        self.assertEqual(
+            set(
+                [
                     frozenset([("variant.foo", "a")]),
                     frozenset([("variant.foo", "b"), ("variant.bar", "x")]),
-                    frozenset([("variant.foo", "b"), ("variant.bar", "z")])
-                ]), e.pvars.not_sat_set)
-                self.assertEqual(len(deps[twod_a_pth]), 7,
-                    "\n\n".join([str(s) for s in deps[twod_a_pth]]))
-                res_fmris = set(["pkg:/b_vw_link@0.5.11-0.151",
-                    "pkg:/b_yz_link@0.5.11-0.151", "pkg:/c@0.5.11-0.151",
-                    "pkg:/b_vwx_file@0.5.11-0.151",
-                    "pkg:/b_y_file@0.5.11-0.151"])
-                b_vw_link_var = set(["v", "w"])
-                b_vwx_file_var = set(["v", "w"])
-                b_yz_link_var = set(["y"])
-                b_y_file_var = set(["y"])
-                for d in deps[twod_a_pth]:
-                        self.assertTrue(d.attrs["fmri"] in res_fmris,
-                            "Unexpected fmri for:{0}".format(d))
-                        if d.attrs["fmri"] == "pkg:/b_vw_link@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "link")
-                                self.assertEqual(d.attrs["variant.foo"], "b")
-                                self.assertTrue(
-                                    d.attrs["variant.bar"] in b_vw_link_var)
-                                b_vw_link_var.remove(d.attrs["variant.bar"])
-                        elif d.attrs["fmri"] == "pkg:/b_vwx_file@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "script")
-                                self.assertEqual(d.attrs["variant.foo"], "b")
-                                self.assertTrue(
-                                    d.attrs["variant.bar"] in b_vwx_file_var)
-                                b_vwx_file_var.remove(d.attrs["variant.bar"])
-                        elif d.attrs["fmri"] == "pkg:/b_y_file@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "script")
-                                self.assertEqual(d.attrs["variant.foo"], "b")
-                                self.assertTrue(
-                                    d.attrs["variant.bar"] in b_y_file_var)
-                                b_y_file_var.remove(d.attrs["variant.bar"])
-                        elif d.attrs["fmri"] == "pkg:/b_yz_link@0.5.11-0.151":
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "link")
-                                self.assertEqual(d.attrs["variant.foo"], "b")
-                                self.assertTrue(
-                                    d.attrs["variant.bar"] in b_yz_link_var)
-                                b_yz_link_var.remove(d.attrs["variant.bar"])
-                        else:
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "script")
-                                self.assertEqual(d.attrs["variant.foo"], "c")
-                                self.assertTrue("variant.bar" not in d.attrs)
+                    frozenset([("variant.foo", "b"), ("variant.bar", "z")]),
+                ]
+            ),
+            e.pvars.not_sat_set,
+        )
+        self.assertEqual(
+            len(deps[twod_a_pth]),
+            7,
+            "\n\n".join([str(s) for s in deps[twod_a_pth]]),
+        )
+        res_fmris = set(
+            [
+                "pkg:/b_vw_link@0.5.11-0.151",
+                "pkg:/b_yz_link@0.5.11-0.151",
+                "pkg:/c@0.5.11-0.151",
+                "pkg:/b_vwx_file@0.5.11-0.151",
+                "pkg:/b_y_file@0.5.11-0.151",
+            ]
+        )
+        b_vw_link_var = set(["v", "w"])
+        b_vwx_file_var = set(["v", "w"])
+        b_yz_link_var = set(["y"])
+        b_y_file_var = set(["y"])
+        for d in deps[twod_a_pth]:
+            self.assertTrue(
+                d.attrs["fmri"] in res_fmris,
+                "Unexpected fmri for:{0}".format(d),
+            )
+            if d.attrs["fmri"] == "pkg:/b_vw_link@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+                self.assertTrue(d.attrs["variant.bar"] in b_vw_link_var)
+                b_vw_link_var.remove(d.attrs["variant.bar"])
+            elif d.attrs["fmri"] == "pkg:/b_vwx_file@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+                self.assertTrue(d.attrs["variant.bar"] in b_vwx_file_var)
+                b_vwx_file_var.remove(d.attrs["variant.bar"])
+            elif d.attrs["fmri"] == "pkg:/b_y_file@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+                self.assertTrue(d.attrs["variant.bar"] in b_y_file_var)
+                b_y_file_var.remove(d.attrs["variant.bar"])
+            elif d.attrs["fmri"] == "pkg:/b_yz_link@0.5.11-0.151":
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+                self.assertEqual(d.attrs["variant.foo"], "b")
+                self.assertTrue(d.attrs["variant.bar"] in b_yz_link_var)
+                b_yz_link_var.remove(d.attrs["variant.bar"])
+            else:
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+                self.assertEqual(d.attrs["variant.foo"], "c")
+                self.assertTrue("variant.bar" not in d.attrs)
 
-                self.assertEqual(len(deps[twod_c_pth]), 0)
-                self.assertEqual(len(deps[twod_b_vwx_file_pth]), 0)
-                self.assertEqual(len(deps[twod_b_y_file_pth]), 0)
-                self.assertEqual(len(deps[twod_b_vw_link_pth]), 0)
-                self.assertEqual(len(deps[twod_b_yz_link_pth]), 0)
+        self.assertEqual(len(deps[twod_c_pth]), 0)
+        self.assertEqual(len(deps[twod_b_vwx_file_pth]), 0)
+        self.assertEqual(len(deps[twod_b_y_file_pth]), 0)
+        self.assertEqual(len(deps[twod_b_vw_link_pth]), 0)
+        self.assertEqual(len(deps[twod_b_yz_link_pth]), 0)
 
-        def test_bug_16013_installed_combinations(self):
-                """Test various combinations of installed and delivered
-                packages."""
+    def test_bug_16013_installed_combinations(self):
+        """Test various combinations of installed and delivered
+        packages."""
 
-                # We need to explicitly set the image variant or we'll blow up
-                # due to conflicting actions.
-                self.pkg("change-variant variant.foo=b")
+        # We need to explicitly set the image variant or we'll blow up
+        # due to conflicting actions.
+        self.pkg("change-variant variant.foo=b")
 
-                self.make_proto_text_file("c/bin/perl")
-                self.make_proto_text_file("b/bin/perl")
-                a_pth = self.make_manifest(self.bug_16013_var_a_dep_manf)
-                b_link_pth = self.make_manifest(self.bug_16013_var_b_link_manf)
-                b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
-                c_pth = self.make_manifest(self.bug_16013_var_c_manf)
+        self.make_proto_text_file("c/bin/perl")
+        self.make_proto_text_file("b/bin/perl")
+        a_pth = self.make_manifest(self.bug_16013_var_a_dep_manf)
+        b_link_pth = self.make_manifest(self.bug_16013_var_b_link_manf)
+        b_file_pth = self.make_manifest(self.bug_16013_var_b_file_manf)
+        c_pth = self.make_manifest(self.bug_16013_var_c_manf)
 
-                plist = self.pkgsend_with_fmri(a_pth)
-                plist = self.pkgsend_with_fmri(b_link_pth)
-                plist = self.pkgsend_with_fmri(b_file_pth)
-                plist = self.pkgsend_with_fmri(c_pth)
+        plist = self.pkgsend_with_fmri(a_pth)
+        plist = self.pkgsend_with_fmri(b_link_pth)
+        plist = self.pkgsend_with_fmri(b_file_pth)
+        plist = self.pkgsend_with_fmri(c_pth)
 
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["c"])
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_pth, b_file_pth, b_link_pth],
-                        api_obj, ["*"], prune_attrs=False)
-                self.bug_16013_check_res_var_files_links_deps(deps, errs,
-                    a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["c"]), external_deps)
-                self.assertEqual(len(deps[b_file_pth]), 0)
-                self.assertEqual(len(deps[b_link_pth]), 0)
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["c"])
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, b_file_pth, b_link_pth], api_obj, ["*"], prune_attrs=False
+        )
+        self.bug_16013_check_res_var_files_links_deps(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["c"]), external_deps)
+        self.assertEqual(len(deps[b_file_pth]), 0)
+        self.assertEqual(len(deps[b_link_pth]), 0)
 
-                self._api_install(api_obj, ["b_link"])
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_pth, b_file_pth], api_obj,
-                        ["*"], prune_attrs=False)
-                self.bug_16013_check_res_var_files_links_deps(deps, errs,
-                    a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["b_link", "c"]), external_deps)
-                self.assertEqual(len(deps[b_file_pth]), 0)
+        self._api_install(api_obj, ["b_link"])
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, b_file_pth], api_obj, ["*"], prune_attrs=False
+        )
+        self.bug_16013_check_res_var_files_links_deps(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["b_link", "c"]), external_deps)
+        self.assertEqual(len(deps[b_file_pth]), 0)
 
-                self._api_install(api_obj, ["b_file"])
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_pth], api_obj, ["*"],
-                        prune_attrs=False)
-                self.bug_16013_check_res_var_files_links_deps(deps, errs,
-                    a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["b_file", "b_link", "c"]),
-                    external_deps)
+        self._api_install(api_obj, ["b_file"])
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth], api_obj, ["*"], prune_attrs=False
+        )
+        self.bug_16013_check_res_var_files_links_deps(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["b_file", "b_link", "c"]), external_deps)
 
-                # Test that delivering installed packages works correctly.
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [a_pth, b_file_pth, b_link_pth, c_pth], api_obj, ["*"],
-                        prune_attrs=False)
-                self.bug_16013_check_res_var_files_links_deps(deps, errs,
-                    a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(deps[b_file_pth]), 0)
-                self.assertEqual(len(deps[b_link_pth]), 0)
-                self.assertEqual(len(deps[c_pth]), 0)
+        # Test that delivering installed packages works correctly.
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, b_file_pth, b_link_pth, c_pth],
+            api_obj,
+            ["*"],
+            prune_attrs=False,
+        )
+        self.bug_16013_check_res_var_files_links_deps(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(deps[b_file_pth]), 0)
+        self.assertEqual(len(deps[b_link_pth]), 0)
+        self.assertEqual(len(deps[c_pth]), 0)
 
-                # Test more combinations of installed and delivered
-                self._api_uninstall(api_obj, ["c"])
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_pth, c_pth], api_obj, ["*"],
-                        prune_attrs=False)
-                self.bug_16013_check_res_var_files_links_deps(deps, errs,
-                    a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["b_file", "b_link"]), external_deps)
-                self.assertEqual(len(deps[c_pth]), 0)
+        # Test more combinations of installed and delivered
+        self._api_uninstall(api_obj, ["c"])
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, c_pth], api_obj, ["*"], prune_attrs=False
+        )
+        self.bug_16013_check_res_var_files_links_deps(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["b_file", "b_link"]), external_deps)
+        self.assertEqual(len(deps[c_pth]), 0)
 
-                self._api_uninstall(api_obj, ["b_link"])
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_pth, b_link_pth, c_pth],
-                        api_obj, ["*"], prune_attrs=False)
-                self.bug_16013_check_res_var_files_links_deps(deps, errs,
-                    a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["b_file"]), external_deps)
-                self.assertEqual(len(deps[c_pth]), 0)
-                self.assertEqual(len(deps[b_link_pth]), 0)
+        self._api_uninstall(api_obj, ["b_link"])
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, b_link_pth, c_pth], api_obj, ["*"], prune_attrs=False
+        )
+        self.bug_16013_check_res_var_files_links_deps(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["b_file"]), external_deps)
+        self.assertEqual(len(deps[c_pth]), 0)
+        self.assertEqual(len(deps[b_link_pth]), 0)
 
-                bad_b_link_manf = """\
+        bad_b_link_manf = """\
 set name=pkg.fmri value=pkg:/b_link@0.5.11,5.11-0.152
 set name=variant.foo value=b value=c
 link path=usr/bin target=/bad_b/bin variant.foo=b
 dir group=bin mode=0755 owner=root path=bad_b/bin variant.foo=b
 """
-                bad_b_link_pth = self.make_manifest(bad_b_link_manf)
-                plist = self.pkgsend_with_fmri(bad_b_link_pth)
-                self._api_install(api_obj, ["b_link"])
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_pth, c_pth], api_obj, ["*"],
-                        prune_attrs=False)
-                def bad_b_link_check_res(deps, errs):
-                        self.assertEqual(len(errs), 1,
-                            "\n".join([str(s) for s in errs]))
-                        e = errs[0]
-                        self.assertEqual(e.path, a_pth)
-                        self.assertEqual(
-                            e.file_dep.attrs[dependencies.files_prefix], "perl")
-                        self.assertEqual(e.pvars.not_sat_set,
-                            set([frozenset([("variant.foo", "a")]),
-                                frozenset([("variant.foo", "b")])]))
-                        self.assertEqual(len(deps[a_pth]), 1,
-                            "\n".join([str(s) for s in deps[a_pth]]))
-                        res_fmris = set(["pkg:/c@0.5.11-0.151"])
-                        for d in deps[a_pth]:
-                                self.assertTrue(d.attrs["fmri"] in res_fmris,
-                                    "Unexpected fmri for:{0}".format(d))
-                                res_fmris.remove(d.attrs["fmri"])
-                                self.assertEqual(d.attrs["variant.foo"], "c")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix],
-                                    "script")
-                bad_b_link_check_res(deps, errs)
-                self.assertEqualDiff(set(["b_file", "b_link"]), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(deps[c_pth]), 0)
+        bad_b_link_pth = self.make_manifest(bad_b_link_manf)
+        plist = self.pkgsend_with_fmri(bad_b_link_pth)
+        self._api_install(api_obj, ["b_link"])
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, c_pth], api_obj, ["*"], prune_attrs=False
+        )
 
-                # Check that the delivered manifests take priority over the
-                # installed manifests.
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_pth, b_link_pth, c_pth],
-                        api_obj, ["*"], prune_attrs=False)
-                self.bug_16013_check_res_var_files_links_deps(deps, errs,
-                    a_pth)
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["b_file"]), external_deps)
-                self.assertEqual(len(deps[c_pth]), 0)
-                self.assertEqual(len(deps[b_link_pth]), 0)
+        def bad_b_link_check_res(deps, errs):
+            self.assertEqual(len(errs), 1, "\n".join([str(s) for s in errs]))
+            e = errs[0]
+            self.assertEqual(e.path, a_pth)
+            self.assertEqual(
+                e.file_dep.attrs[dependencies.files_prefix], "perl"
+            )
+            self.assertEqual(
+                e.pvars.not_sat_set,
+                set(
+                    [
+                        frozenset([("variant.foo", "a")]),
+                        frozenset([("variant.foo", "b")]),
+                    ]
+                ),
+            )
+            self.assertEqual(
+                len(deps[a_pth]), 1, "\n".join([str(s) for s in deps[a_pth]])
+            )
+            res_fmris = set(["pkg:/c@0.5.11-0.151"])
+            for d in deps[a_pth]:
+                self.assertTrue(
+                    d.attrs["fmri"] in res_fmris,
+                    "Unexpected fmri for:{0}".format(d),
+                )
+                res_fmris.remove(d.attrs["fmri"])
+                self.assertEqual(d.attrs["variant.foo"], "c")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
 
-                self._api_uninstall(api_obj, ["b_link"])
-                self._api_install(api_obj, ["b_link@0.5.11,5.11-0.151"])
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([a_pth, bad_b_link_pth, c_pth],
-                        api_obj, ["*"], prune_attrs=False)
-                bad_b_link_check_res(deps, errs)
-                self.assertEqual(len(deps[c_pth]), 0)
-                self.assertEqual(len(deps[bad_b_link_pth]), 0)
+        bad_b_link_check_res(deps, errs)
+        self.assertEqualDiff(set(["b_file", "b_link"]), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(deps[c_pth]), 0)
 
-        def test_bug_16013_internal_resolution(self):
-                """Check that a dependency involving symbolic links is resolved
-                internally during the generation phase."""
+        # Check that the delivered manifests take priority over the
+        # installed manifests.
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, b_link_pth, c_pth], api_obj, ["*"], prune_attrs=False
+        )
+        self.bug_16013_check_res_var_files_links_deps(deps, errs, a_pth)
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["b_file"]), external_deps)
+        self.assertEqual(len(deps[c_pth]), 0)
+        self.assertEqual(len(deps[b_link_pth]), 0)
 
-                foo_path = self.make_proto_text_file("bar/foo",
-                    "#!/usr/bin/perl\n\n")
-                self.make_proto_text_file("b/bin/perl")
-                internal_dep_manf = """\
+        self._api_uninstall(api_obj, ["b_link"])
+        self._api_install(api_obj, ["b_link@0.5.11,5.11-0.151"])
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [a_pth, bad_b_link_pth, c_pth], api_obj, ["*"], prune_attrs=False
+        )
+        bad_b_link_check_res(deps, errs)
+        self.assertEqual(len(deps[c_pth]), 0)
+        self.assertEqual(len(deps[bad_b_link_pth]), 0)
+
+    def test_bug_16013_internal_resolution(self):
+        """Check that a dependency involving symbolic links is resolved
+        internally during the generation phase."""
+
+        foo_path = self.make_proto_text_file("bar/foo", "#!/usr/bin/perl\n\n")
+        self.make_proto_text_file("b/bin/perl")
+        internal_dep_manf = """\
 set name=pkg.fmri value=pkg:/internal@0.5.11,5.11-0.151
 file NOHASH group=bin mode=0755 owner=root path=bar/foo
 link path=usr/bin target=/b/bin
 dir group=bin mode=0755 owner=root path=b/bin
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl
 """
-                internal_dep_pth = self.make_manifest(internal_dep_manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    internal_dep_pth, [self.test_proto_dir], {}, [],
-                    convert=False)
+        internal_dep_pth = self.make_manifest(internal_dep_manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            internal_dep_pth, [self.test_proto_dir], {}, [], convert=False
+        )
 
-                self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
-                self.assertEqual(len(ds), 0, "\n".join([str(d) for d in ds]))
-                self.assertEqual(pkg_attrs, {})
+        self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
+        self.assertEqual(len(ds), 0, "\n".join([str(d) for d in ds]))
+        self.assertEqual(pkg_attrs, {})
 
-        def test_bug_16013_internal_variants(self):
-                """Test that variants are handled correctly when links are
-                involved in package internal dependency resolution."""
+    def test_bug_16013_internal_variants(self):
+        """Test that variants are handled correctly when links are
+        involved in package internal dependency resolution."""
 
-                foo_path = self.make_proto_text_file("bar/foo",
-                    "#!/usr/bin/perl\n\n")
-                self.make_proto_text_file("b/bin/perl")
-                internal_dep_manf = """\
+        foo_path = self.make_proto_text_file("bar/foo", "#!/usr/bin/perl\n\n")
+        self.make_proto_text_file("b/bin/perl")
+        internal_dep_manf = """\
 set name=pkg.fmri value=pkg:/internal@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c
 file NOHASH group=bin mode=0755 owner=root path=bar/foo
@@ -2597,27 +3028,34 @@ dir group=bin mode=0755 owner=root path=b/bin
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=b
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=c
 """
-                internal_dep_pth = self.make_manifest(internal_dep_manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    internal_dep_pth, [self.test_proto_dir], {}, [],
-                    convert=False)
+        internal_dep_pth = self.make_manifest(internal_dep_manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            internal_dep_pth, [self.test_proto_dir], {}, [], convert=False
+        )
 
-                self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
-                self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
-                d = ds[0]
-                self.assertEqual(d.attrs[dependencies.files_prefix], ["perl"])
-                self.assertEqual(d.dep_vars.not_sat_set,
-                    set([frozenset([("variant.foo", "a")]),
-                        frozenset([("variant.foo", "c")])]))
-                self.assertEqual(d.dep_vars.sat_set,
-                    set([frozenset([("variant.foo", "b")])]))
-                self.assertEqual(pkg_attrs, {})
+        self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
+        self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
+        d = ds[0]
+        self.assertEqual(d.attrs[dependencies.files_prefix], ["perl"])
+        self.assertEqual(
+            d.dep_vars.not_sat_set,
+            set(
+                [
+                    frozenset([("variant.foo", "a")]),
+                    frozenset([("variant.foo", "c")]),
+                ]
+            ),
+        )
+        self.assertEqual(
+            d.dep_vars.sat_set, set([frozenset([("variant.foo", "b")])])
+        )
+        self.assertEqual(pkg_attrs, {})
 
-        def test_bug_16013_internal_links_and_variants(self):
-                """Test that if the file doesn't exist for all package variants,
-                the dependencies have the correct variant tags."""
+    def test_bug_16013_internal_links_and_variants(self):
+        """Test that if the file doesn't exist for all package variants,
+        the dependencies have the correct variant tags."""
 
-                internal_dep_manf = """\
+        internal_dep_manf = """\
 set name=pkg.fmri value=pkg:/internal@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c value=d
 file NOHASH group=bin mode=0755 owner=root path=bar/foo variant.foo=a
@@ -2631,36 +3069,36 @@ file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=b
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=c
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=d
 """
-                self.make_proto_text_file("b/bin/perl")
-                foo_path = self.make_proto_text_file("bar/foo",
-                    "#!/usr/bin/perl\n\n")
-                internal_dep_pth = self.make_manifest(internal_dep_manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    internal_dep_pth, [self.test_proto_dir], {}, [],
-                    convert=False)
+        self.make_proto_text_file("b/bin/perl")
+        foo_path = self.make_proto_text_file("bar/foo", "#!/usr/bin/perl\n\n")
+        internal_dep_pth = self.make_manifest(internal_dep_manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            internal_dep_pth, [self.test_proto_dir], {}, [], convert=False
+        )
 
-                self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
-                self.assertEqual(len(ds), 2,
-                    "\n" + "\n".join([str(d) for d in ds]))
-                res_not_sat_set = set([frozenset([("variant.foo", "a")]),
-                    frozenset([("variant.foo", "c")])])
-                for d in ds:
-                        self.assertEqual(d.attrs[dependencies.files_prefix],
-                            ["perl"])
-                        self.assertEqual(len(d.dep_vars.not_sat_set), 1)
-                        self.assertTrue(d.dep_vars.not_sat_set.issubset(
-                            res_not_sat_set))
-                        for t in d.dep_vars.not_sat_set:
-                                res_not_sat_set.remove(t)
-                        self.assertEqual(d.dep_vars.sat_set, set())
-                self.assertEqual(res_not_sat_set, set())
-                self.assertEqual(pkg_attrs, {})
+        self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
+        self.assertEqual(len(ds), 2, "\n" + "\n".join([str(d) for d in ds]))
+        res_not_sat_set = set(
+            [
+                frozenset([("variant.foo", "a")]),
+                frozenset([("variant.foo", "c")]),
+            ]
+        )
+        for d in ds:
+            self.assertEqual(d.attrs[dependencies.files_prefix], ["perl"])
+            self.assertEqual(len(d.dep_vars.not_sat_set), 1)
+            self.assertTrue(d.dep_vars.not_sat_set.issubset(res_not_sat_set))
+            for t in d.dep_vars.not_sat_set:
+                res_not_sat_set.remove(t)
+            self.assertEqual(d.dep_vars.sat_set, set())
+        self.assertEqual(res_not_sat_set, set())
+        self.assertEqual(pkg_attrs, {})
 
-        def test_bug_16013_two_d_internal(self):
-                """Check that two dimensions of variants produce the expected
-                results when resolving dependends internally to a package."""
+    def test_bug_16013_two_d_internal(self):
+        """Check that two dimensions of variants produce the expected
+        results when resolving dependends internally to a package."""
 
-                internal_dep_manf = """\
+        internal_dep_manf = """\
 set name=pkg.fmri value=pkg:/internal@0.5.11,5.11-0.151
 set name=variant.foo value=a value=b value=c value=d
 set name=variant.bar value=x value=y value=z
@@ -2675,480 +3113,548 @@ file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=c
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=d variant.bar=y
 file NOHASH group=bin mode=0555 owner=root path=b/bin/perl variant.foo=d variant.bar=z
 """
-                self.make_proto_text_file("b/bin/perl")
-                foo_path = self.make_proto_text_file("bar/foo",
-                    "#!/usr/bin/perl\n\n")
-                internal_dep_pth = self.make_manifest(internal_dep_manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    internal_dep_pth, [self.test_proto_dir], {}, [],
-                    convert=False)
+        self.make_proto_text_file("b/bin/perl")
+        foo_path = self.make_proto_text_file("bar/foo", "#!/usr/bin/perl\n\n")
+        internal_dep_pth = self.make_manifest(internal_dep_manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            internal_dep_pth, [self.test_proto_dir], {}, [], convert=False
+        )
 
-                self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
-                self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
-                d = ds[0]
-                self.assertEqual(d.attrs[dependencies.files_prefix], ["perl"])
-                not_sat_set = set([
-                    frozenset([("variant.foo", "a")]),
-                    frozenset([("variant.foo", "c")]),
-                    frozenset([("variant.foo", "d"), ("variant.bar", "x")]),
-                    frozenset([("variant.foo", "d"), ("variant.bar", "z")]),
-                ])
+        self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
+        self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
+        d = ds[0]
+        self.assertEqual(d.attrs[dependencies.files_prefix], ["perl"])
+        not_sat_set = set(
+            [
+                frozenset([("variant.foo", "a")]),
+                frozenset([("variant.foo", "c")]),
+                frozenset([("variant.foo", "d"), ("variant.bar", "x")]),
+                frozenset([("variant.foo", "d"), ("variant.bar", "z")]),
+            ]
+        )
 
-                self.assertEqual(not_sat_set, d.dep_vars.not_sat_set)
-                self.assertEqual(set([
+        self.assertEqual(not_sat_set, d.dep_vars.not_sat_set)
+        self.assertEqual(
+            set(
+                [
                     frozenset([("variant.foo", "b")]),
-                    frozenset([("variant.foo", "d"), ("variant.bar", "y")])
-                ]), d.dep_vars.sat_set)
-                self.assertEqual(pkg_attrs, {})
+                    frozenset([("variant.foo", "d"), ("variant.bar", "y")]),
+                ]
+            ),
+            d.dep_vars.sat_set,
+        )
+        self.assertEqual(pkg_attrs, {})
 
-        def test_bug_16808(self):
-                """Test that if an action uses a variant not declared at the
-                package level, an warning is reported."""
+    def test_bug_16808(self):
+        """Test that if an action uses a variant not declared at the
+        package level, an warning is reported."""
 
-                tp = self.make_manifest(self.bug_16808_manf)
-                self.make_proto_text_file("var/log/syslog", "text")
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
-                self.check_res(self.bug_16808_warning, self.errout)
+        tp = self.make_manifest(self.bug_16808_manf)
+        self.make_proto_text_file("var/log/syslog", "text")
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(self.bug_16808_warning, self.errout)
 
-        def test_bug_18640960(self):
-                """Test that if an action uses a variant value not declared at the
-                package level, an warning is reported."""
+    def test_bug_18640960(self):
+        """Test that if an action uses a variant value not declared at the
+        package level, an warning is reported."""
 
-                tp = self.make_manifest(self.bug_16808_manf)
-                self.make_proto_text_file("var/log/syslog", "text")
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
-                self.check_res(self.bug_18640960_warning, self.errout)
+        tp = self.make_manifest(self.bug_16808_manf)
+        self.make_proto_text_file("var/log/syslog", "text")
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(self.bug_18640960_warning, self.errout)
 
-        def test_bug_17808(self):
-                """Test that a 64-bit binary has its runpaths set to /lib/64 and
-                /usr/lib/64 instead of /lib and /usr/lib."""
+    def test_bug_17808(self):
+        """Test that a 64-bit binary has its runpaths set to /lib/64 and
+        /usr/lib/64 instead of /lib and /usr/lib."""
 
-                self.make_elf(bit64=True, output_path="usr/bin/x64")
-                mp = self.make_manifest(self.test_64bit_manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    mp, [self.test_proto_dir], {}, [], convert=False)
-                self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
-                self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
-                d = ds[0]
-                self.assertEqual(d.attrs[DDP + ".file"], ["libc.so.1"])
-                self.assertEqual(self.glfilter(set(d.attrs[DDP + ".path"])),
-                    set(["lib/64", "usr/lib/64"]))
+        self.make_elf(bit64=True, output_path="usr/bin/x64")
+        mp = self.make_manifest(self.test_64bit_manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            mp, [self.test_proto_dir], {}, [], convert=False
+        )
+        self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
+        self.assertEqual(len(ds), 1, "\n".join([str(d) for d in ds]))
+        d = ds[0]
+        self.assertEqual(d.attrs[DDP + ".file"], ["libc.so.1"])
+        self.assertEqual(
+            self.glfilter(set(d.attrs[DDP + ".path"])),
+            set(["lib/64", "usr/lib/64"]),
+        )
 
-        def test_elf_warning(self):
-                """Test that if an action uses a variant not declared at the
-                package level, an error is reported."""
+    def test_elf_warning(self):
+        """Test that if an action uses a variant not declared at the
+        package level, an error is reported."""
 
-                tp = self.make_manifest(self.test_elf_warning_manf)
-                self.make_proto_text_file("etc/libc.so.1", "text")
-                self.make_elf([], "usr/xpg4/lib/libcurses.so.1")
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
-                self.check_res("", self.errout)
-                self.check_res(self.res_elf_warning,
-                    self.glre.sub('', self.output))
+        tp = self.make_manifest(self.test_elf_warning_manf)
+        self.make_proto_text_file("etc/libc.so.1", "text")
+        self.make_elf([], "usr/xpg4/lib/libcurses.so.1")
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res("", self.errout)
+        self.check_res(self.res_elf_warning, self.glre.sub("", self.output))
 
-        def test_relative_run_path(self):
-                """Test that a runpath containing ../ is handled correctly."""
+    def test_relative_run_path(self):
+        """Test that a runpath containing ../ is handled correctly."""
 
-                tp = self.make_manifest(self.test_elf_warning_manf)
-                self.make_proto_text_file("etc/libc.so.1", "text")
-                self.make_elf(["$ORIGIN/../../../etc/"],
-                    "usr/xpg4/lib/libcurses.so.1")
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
-                self.check_res("", self.errout)
-                self.check_res("", self.output)
+        tp = self.make_manifest(self.test_elf_warning_manf)
+        self.make_proto_text_file("etc/libc.so.1", "text")
+        self.make_elf(["$ORIGIN/../../../etc/"], "usr/xpg4/lib/libcurses.so.1")
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res("", self.errout)
+        self.check_res("", self.output)
 
-                dependent_manf = """\
+        dependent_manf = """\
 set name=pkg.fmri value=pkg:/a@0.5.11,5.11-0.151
 depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib pkg.debug.depend.path=usr/lib pkg.debug.depend.path=usr/xpg4/lib/../../../etc pkg.debug.depend.reason=usr/xpg4/lib/libcurses.so.1 pkg.debug.depend.severity=warning pkg.debug.depend.type=elf type=require
 """
-                dependee_manf = """\
+        dependee_manf = """\
 set name=pkg.fmri value=pkg:/b@0.5.11,5.11-0.151
 file NOHASH group=bin mode=0755 owner=root path=etc/libc.so.1
 """
 
-                p1 = self.make_manifest(dependent_manf)
-                p2 = self.make_manifest(dependee_manf)
-                deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([p1, p2], None, [],
-                        prune_attrs=False)
-                self.assertEqual(len(errs), 0,
-                    "\n" + "\n\n".join([str(s) for s in errs]))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(deps[p1]), 1,
-                    "\n".join([str(s) for s in deps[p1]]))
-                d = deps[p1][0]
-                self.assertEqual(d.attrs["fmri"], "pkg:/b@0.5.11-0.151")
-                self.assertEqual(d.attrs[dependencies.type_prefix], "elf")
+        p1 = self.make_manifest(dependent_manf)
+        p2 = self.make_manifest(dependee_manf)
+        (
+            deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([p1, p2], None, [], prune_attrs=False)
+        self.assertEqual(
+            len(errs), 0, "\n" + "\n\n".join([str(s) for s in errs])
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(
+            len(deps[p1]), 1, "\n".join([str(s) for s in deps[p1]])
+        )
+        d = deps[p1][0]
+        self.assertEqual(d.attrs["fmri"], "pkg:/b@0.5.11-0.151")
+        self.assertEqual(d.attrs[dependencies.type_prefix], "elf")
 
-        def test_multiple_run_paths(self):
-                """Test that specifying multiple $PKGDEPEND_RUNPATH tokens
-                results in an error."""
+    def test_multiple_run_paths(self):
+        """Test that specifying multiple $PKGDEPEND_RUNPATH tokens
+        results in an error."""
 
-                mf = """\
+        mf = """\
 set name=pkg.fmri value=pkg:/a@0.5.11,5.11-0.160
 file NOHASH group=bin mode=0755 owner=root path=etc/file.py \
     pkg.depend.runpath=$PKGDEPEND_RUNPATH:$PKGDEPEND_RUNPATH
     """
-                self.make_proto_text_file(
-                    "etc/file.py", "#!/usr/bin/python{0}".format(py_ver_default))
-                tp = self.make_manifest(mf)
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp),
-                    exit=1)
-                expected = (
-                    "More than one $PKGDEPEND_RUNPATH token was set on the "
-                    "same action in this manifest.")
-                self.check_res(expected, self.errout)
-                self.check_res("", self.output)
+        self.make_proto_text_file(
+            "etc/file.py", "#!/usr/bin/python{0}".format(py_ver_default)
+        )
+        tp = self.make_manifest(mf)
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(self.test_proto_dir, tp), exit=1
+        )
+        expected = (
+            "More than one $PKGDEPEND_RUNPATH token was set on the "
+            "same action in this manifest."
+        )
+        self.check_res(expected, self.errout)
+        self.check_res("", self.output)
 
-        def test_bug_16271(self):
-                """Test that scripts which reference a specific platform in the
-                path to python are treated as python files which need
-                dependencies analyzed."""
+    def test_bug_16271(self):
+        """Test that scripts which reference a specific platform in the
+        path to python are treated as python files which need
+        dependencies analyzed."""
 
-                self.make_proto_text_file(
-                    "usr/bin/amd64/python{0}-config".format(py_ver_default),
-                     self.python_amd_text)
-                mp = self.make_manifest(self.python_amd_manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    mp, [self.test_proto_dir], {}, [], convert=False)
-                self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
-                self.assertEqual(len(ds), 3, "\n".join([str(d) for d in ds]))
-                for d in ds:
-                        if d.attrs[DDP + ".type"] == "script":
-                                self.assertEqual(d.attrs[DDP + ".file"],
-                                    ["python{0}".format(py_ver_default)])
-                                self.assertEqual(d.attrs[DDP + ".path"],
-                                    ["usr/bin/amd64"])
-                                continue
-                        self.assertEqual(d.attrs[DDP + ".type"], "python")
+        self.make_proto_text_file(
+            "usr/bin/amd64/python{0}-config".format(py_ver_default),
+            self.python_amd_text,
+        )
+        mp = self.make_manifest(self.python_amd_manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            mp, [self.test_proto_dir], {}, [], convert=False
+        )
+        self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
+        self.assertEqual(len(ds), 3, "\n".join([str(d) for d in ds]))
+        for d in ds:
+            if d.attrs[DDP + ".type"] == "script":
+                self.assertEqual(
+                    d.attrs[DDP + ".file"], ["python{0}".format(py_ver_default)]
+                )
+                self.assertEqual(d.attrs[DDP + ".path"], ["usr/bin/amd64"])
+                continue
+            self.assertEqual(d.attrs[DDP + ".type"], "python")
 
-                self.make_proto_text_file(
-                    "usr/bin/sparcv9/python{0}-config".format(py_ver_default),
-                    self.python_amd_text)
-                mp = self.make_manifest(self.python_sparcv9_manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    mp, [self.test_proto_dir], {}, [], convert=False)
-                self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
-                self.assertEqual(len(ds), 3, "\n".join([str(d) for d in ds]))
-                for d in ds:
-                        if d.attrs[DDP + ".type"] == "script":
-                                self.assertEqual(d.attrs[DDP + ".file"],
-                                    ["python{0}".format(py_ver_default)])
-                                self.assertEqual(d.attrs[DDP + ".path"],
-                                    ["usr/bin/amd64"])
-                                continue
-                        self.assertEqual(d.attrs[DDP + ".type"], "python")
+        self.make_proto_text_file(
+            "usr/bin/sparcv9/python{0}-config".format(py_ver_default),
+            self.python_amd_text,
+        )
+        mp = self.make_manifest(self.python_sparcv9_manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            mp, [self.test_proto_dir], {}, [], convert=False
+        )
+        self.assertEqual(len(es), 0, "\n".join([str(d) for d in es]))
+        self.assertEqual(len(ds), 3, "\n".join([str(d) for d in ds]))
+        for d in ds:
+            if d.attrs[DDP + ".type"] == "script":
+                self.assertEqual(
+                    d.attrs[DDP + ".file"], ["python{0}".format(py_ver_default)]
+                )
+                self.assertEqual(d.attrs[DDP + ".path"], ["usr/bin/amd64"])
+                continue
+            self.assertEqual(d.attrs[DDP + ".type"], "python")
 
-        def test_bug_18011(self):
-                """Test that a missing file delivers a helpful error message."""
+    def test_bug_18011(self):
+        """Test that a missing file delivers a helpful error message."""
 
-                mp = self.make_manifest(self.python_amd_manf)
-                foo_dir = os.path.join(self.test_proto_dir, "foo")
-                bar_dir = os.path.join(self.test_proto_dir, "bar")
-                os.makedirs(foo_dir)
-                os.makedirs(bar_dir)
-                self.pkgdepend_generate("-d {0} -d {1} -d {2} {3}".format(
-                    self.test_proto_dir,foo_dir, bar_dir, mp), exit=1)
-                self.assertEqual("Couldn't find "
-                    "'usr/bin/amd64/python{0}-config' in any of the specified "
-                    "search directories:\n{1}\n".format(py_ver_default, "\n".join(
-                    "\t" + d for d in sorted(
-                        [foo_dir, bar_dir, self.test_proto_dir]))),
-                    self.errout)
+        mp = self.make_manifest(self.python_amd_manf)
+        foo_dir = os.path.join(self.test_proto_dir, "foo")
+        bar_dir = os.path.join(self.test_proto_dir, "bar")
+        os.makedirs(foo_dir)
+        os.makedirs(bar_dir)
+        self.pkgdepend_generate(
+            "-d {0} -d {1} -d {2} {3}".format(
+                self.test_proto_dir, foo_dir, bar_dir, mp
+            ),
+            exit=1,
+        )
+        self.assertEqual(
+            "Couldn't find "
+            "'usr/bin/amd64/python{0}-config' in any of the specified "
+            "search directories:\n{1}\n".format(
+                py_ver_default,
+                "\n".join(
+                    "\t" + d
+                    for d in sorted([foo_dir, bar_dir, self.test_proto_dir])
+                ),
+            ),
+            self.errout,
+        )
 
-        def test_bug_18101(self):
-                """Test that importing os.path in a file using the system python
-                results in the right set of dependencies."""
+    def test_bug_18101(self):
+        """Test that importing os.path in a file using the system python
+        results in the right set of dependencies."""
 
-                # Set up the files for generate.
-                fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
-                    py_ver_default)
-                self.make_proto_text_file(fp, self.pyver_python_text.format(
-                    py_ver_default))
-                mp = self.make_manifest(self.pyver_test_manf_1_non_ex.format(
-                    py_ver=py_ver_default))
+        # Set up the files for generate.
+        fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
+            py_ver_default
+        )
+        self.make_proto_text_file(
+            fp, self.pyver_python_text.format(py_ver_default)
+        )
+        mp = self.make_manifest(
+            self.pyver_test_manf_1_non_ex.format(py_ver=py_ver_default)
+        )
 
-                # Run generate and check the output.
-                self.pkgdepend_generate("-d {0} {1}".format(
-                    self.test_proto_dir, mp))
-                self.check_res(
-                    self.make_pyver_python_res(py_ver_default,
-                        pkg5unittest.g_proto_area, fp, include_os=True).format(
-                        bin_ver=py_ver_default),
-                    self.output)
-                self.check_res("", self.errout)
+        # Run generate and check the output.
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, mp))
+        self.check_res(
+            self.make_pyver_python_res(
+                py_ver_default, pkg5unittest.g_proto_area, fp, include_os=True
+            ).format(bin_ver=py_ver_default),
+            self.output,
+        )
+        self.check_res("", self.errout)
 
-        def test_bug_19029(self):
-                """Test that a package with an action which doesn't validate
-                causes pkgdepend generate to fail."""
+    def test_bug_19029(self):
+        """Test that a package with an action which doesn't validate
+        causes pkgdepend generate to fail."""
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=bug_18019@1.0,5.11-1
 depend fmri=pkg:/a@0,5.11-1 type=conditional
 """
-                manf_path = self.make_manifest(manf)
-                ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
-                    manf_path, [self.test_proto_dir], {}, [],
-                    convert=False)
-                self.assertEqual(len(es), 1)
-                self.assertTrue(isinstance(es[0],
-                    actions.InvalidActionAttributesError))
+        manf_path = self.make_manifest(manf)
+        ds, es, ws, ms, pkg_attrs = dependencies.list_implicit_deps(
+            manf_path, [self.test_proto_dir], {}, [], convert=False
+        )
+        self.assertEqual(len(es), 1)
+        self.assertTrue(isinstance(es[0], actions.InvalidActionAttributesError))
 
-        def test_python_combinations(self):
-                """Test that each line in the following table is accounted for
-                by a test case.
+    def test_python_combinations(self):
+        """Test that each line in the following table is accounted for
+        by a test case.
 
-                There are three conditions which determine whether python
-                dependency analysis is performed on a file with python in its
-                #! line.
-                1) Is the file executable.
-                    (Represented in the table below by X)
-                2) Is the file installed into a directory which provides
-                    information about what version of python should be used
-                    for it.
-                    (Represented by D)
-                3) Does the first line of the file include a specific version
-                    of python.
-                    (Represented by F)
+        There are three conditions which determine whether python
+        dependency analysis is performed on a file with python in its
+        #! line.
+        1) Is the file executable.
+            (Represented in the table below by X)
+        2) Is the file installed into a directory which provides
+            information about what version of python should be used
+            for it.
+            (Represented by D)
+        3) Does the first line of the file include a specific version
+            of python.
+            (Represented by F)
 
-                Conditions || Perform Analysis
-                 X  D  F   || Y, if F and D disagree, display a warning in the
-                           ||     output and use D to analyze the file.
-                 X  D !F   || Y
-                 X !D  F   || Y
-                 X !D !F   || N, and display a warning in the output.
-                !X  D  F   || Y
-                !X  D !F   || Y
-                !X !D  F   || N
-                !X !D !F   || N
-                """
+        Conditions || Perform Analysis
+         X  D  F   || Y, if F and D disagree, display a warning in the
+                   ||     output and use D to analyze the file.
+         X  D !F   || Y
+         X !D  F   || Y
+         X !D !F   || N, and display a warning in the output.
+        !X  D  F   || Y
+        !X  D !F   || Y
+        !X !D  F   || N
+        !X !D !F   || N
+        """
 
-                # The test for line 1 with matching versions is done by
-                # test_bug_13059.
+        # The test for line 1 with matching versions is done by
+        # test_bug_13059.
 
-                # Test line 1 (X D F) with mismatched versions.
-                tp = self.make_manifest(self.pyver_test_manf_1.format(
-                    py_ver=py_ver_other))
-                fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
-                    py_ver_other)
-                self.make_proto_text_file(fp, self.pyver_python_text.format(
-                    py_ver_default))
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp),
-                     exit=1)
-                self.check_res(self.pyver_mismatch_results +
-                    self.make_pyver_python_res(py_ver_other, self.test_proto_dir, fp,
-                        include_os=True).format(bin_ver=py_ver_default),
-                    self.output)
-                self.check_res(self.pyver_mismatch_errs.format(self.test_proto_dir),
-                    self.errout)
+        # Test line 1 (X D F) with mismatched versions.
+        tp = self.make_manifest(
+            self.pyver_test_manf_1.format(py_ver=py_ver_other)
+        )
+        fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
+            py_ver_other
+        )
+        self.make_proto_text_file(
+            fp, self.pyver_python_text.format(py_ver_default)
+        )
+        self.pkgdepend_generate(
+            "-d {0} {1}".format(self.test_proto_dir, tp), exit=1
+        )
+        self.check_res(
+            self.pyver_mismatch_results
+            + self.make_pyver_python_res(
+                py_ver_other, self.test_proto_dir, fp, include_os=True
+            ).format(bin_ver=py_ver_default),
+            self.output,
+        )
+        self.check_res(
+            self.pyver_mismatch_errs.format(self.test_proto_dir), self.errout
+        )
 
-                # Test line 2 (X D !F)
-                tp = self.make_manifest(self.pyver_test_manf_1.format(
-                    py_ver=py_ver_other))
-                fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
-                    py_ver_other)
-                self.make_proto_text_file(fp, self.pyver_python_text.format(""))
-                self.pkgdepend_generate("-m -d {0} {1}".format(
-                    self.test_proto_dir, tp))
-                self.check_res(
-                    self.pyver_res_full_manf_1(py_ver_other, self.test_proto_dir, fp,
-                        include_os=True).format(
-                        reason=fp, bin_ver="", run_path=""),
-                    self.output)
-                self.check_res("", self.errout)
+        # Test line 2 (X D !F)
+        tp = self.make_manifest(
+            self.pyver_test_manf_1.format(py_ver=py_ver_other)
+        )
+        fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
+            py_ver_other
+        )
+        self.make_proto_text_file(fp, self.pyver_python_text.format(""))
+        self.pkgdepend_generate("-m -d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(
+            self.pyver_res_full_manf_1(
+                py_ver_other, self.test_proto_dir, fp, include_os=True
+            ).format(reason=fp, bin_ver="", run_path=""),
+            self.output,
+        )
+        self.check_res("", self.errout)
 
-                # Test line 3 (X !D F)
-                tp = self.make_manifest(self.py_in_usr_bin_manf)
-                fp = "usr/bin/pkg"
-                self.make_proto_text_file(fp, self.pyver_python_text.format(
-                    py_ver_other))
-                self.pkgdepend_generate("-m -d {0} {1}".format(
-                    self.test_proto_dir, tp))
-                self.check_res(
-                    self.pyver_res_full_manf_1(py_ver_other, self.test_proto_dir, fp,
-                        include_os=True).format(
-                        reason=fp, bin_ver=py_ver_other, run_path=""),
-                    self.output)
-                self.check_res("", self.errout)
+        # Test line 3 (X !D F)
+        tp = self.make_manifest(self.py_in_usr_bin_manf)
+        fp = "usr/bin/pkg"
+        self.make_proto_text_file(
+            fp, self.pyver_python_text.format(py_ver_other)
+        )
+        self.pkgdepend_generate("-m -d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(
+            self.pyver_res_full_manf_1(
+                py_ver_other, self.test_proto_dir, fp, include_os=True
+            ).format(reason=fp, bin_ver=py_ver_other, run_path=""),
+            self.output,
+        )
+        self.check_res("", self.errout)
 
-                # Test line 4 (X !D !F)
-                tp = self.make_manifest(self.py_in_usr_bin_manf)
-                fp = "usr/bin/pkg"
-                self.make_proto_text_file(fp, self.pyver_python_text.format(""))
-                self.pkgdepend_generate("-m -d {0} {1}".format(
-                    self.test_proto_dir, tp), exit=1)
-                self.check_res(
-                    self.pyver_other_script_full_manf_1.format(
-                        reason=fp, bin_ver="", run_path=""),
-                    self.output)
-                self.check_res(self.pyver_unspecified_ver_err.format(
-                    self.test_proto_dir), self.errout)
+        # Test line 4 (X !D !F)
+        tp = self.make_manifest(self.py_in_usr_bin_manf)
+        fp = "usr/bin/pkg"
+        self.make_proto_text_file(fp, self.pyver_python_text.format(""))
+        self.pkgdepend_generate(
+            "-m -d {0} {1}".format(self.test_proto_dir, tp), exit=1
+        )
+        self.check_res(
+            self.pyver_other_script_full_manf_1.format(
+                reason=fp, bin_ver="", run_path=""
+            ),
+            self.output,
+        )
+        self.check_res(
+            self.pyver_unspecified_ver_err.format(self.test_proto_dir),
+            self.errout,
+        )
 
-                # Test line 5 (!X D F)
-                tp = self.make_manifest(self.pyver_test_manf_1_non_ex.format(
-                    py_ver=py_ver_other))
-                fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
-                    py_ver_other)
-                self.make_proto_text_file(fp, self.pyver_python_text.format(py_ver_default))
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
-                self.check_res(
-                    self.make_pyver_python_res(py_ver_other, self.test_proto_dir, fp,
-                        include_os=True),
-                    self.output)
-                self.check_res("", self.errout)
+        # Test line 5 (!X D F)
+        tp = self.make_manifest(
+            self.pyver_test_manf_1_non_ex.format(py_ver=py_ver_other)
+        )
+        fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
+            py_ver_other
+        )
+        self.make_proto_text_file(
+            fp, self.pyver_python_text.format(py_ver_default)
+        )
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(
+            self.make_pyver_python_res(
+                py_ver_other, self.test_proto_dir, fp, include_os=True
+            ),
+            self.output,
+        )
+        self.check_res("", self.errout)
 
-                # Test line 6 (!X D !F)
-                tp = self.make_manifest(self.pyver_test_manf_1_non_ex.format(
-                    py_ver=py_ver_other))
-                fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
-                    py_ver_other)
-                self.make_proto_text_file(fp, self.pyver_python_text.format(""))
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
-                self.check_res(
-                    self.make_pyver_python_res(py_ver_other, self.test_proto_dir, fp,
-                        include_os=True),
-                    self.output)
-                self.check_res("", self.errout)
+        # Test line 6 (!X D !F)
+        tp = self.make_manifest(
+            self.pyver_test_manf_1_non_ex.format(py_ver=py_ver_other)
+        )
+        fp = "usr/lib/python{0}/vendor-packages/pkg/client/indexer.py".format(
+            py_ver_other
+        )
+        self.make_proto_text_file(fp, self.pyver_python_text.format(""))
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(
+            self.make_pyver_python_res(
+                py_ver_other, self.test_proto_dir, fp, include_os=True
+            ),
+            self.output,
+        )
+        self.check_res("", self.errout)
 
-                # Test line 7 (!X !D F)
-                tp = self.make_manifest(self.py_in_usr_bin_manf_non_ex)
-                fp = "usr/bin/pkg"
-                self.make_proto_text_file(fp, self.pyver_python_text.format(py_ver_other))
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
-                self.check_res("", self.output)
-                self.check_res("", self.errout)
+        # Test line 7 (!X !D F)
+        tp = self.make_manifest(self.py_in_usr_bin_manf_non_ex)
+        fp = "usr/bin/pkg"
+        self.make_proto_text_file(
+            fp, self.pyver_python_text.format(py_ver_other)
+        )
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res("", self.output)
+        self.check_res("", self.errout)
 
-                # Test line 8 (!X !D !F)
-                tp = self.make_manifest(self.py_in_usr_bin_manf_non_ex)
-                fp = "usr/bin/pkg"
-                self.make_proto_text_file(fp, self.pyver_python_text.format(""))
-                self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
-                self.check_res("", self.output)
-                self.check_res("", self.errout)
+        # Test line 8 (!X !D !F)
+        tp = self.make_manifest(self.py_in_usr_bin_manf_non_ex)
+        fp = "usr/bin/pkg"
+        self.make_proto_text_file(fp, self.pyver_python_text.format(""))
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res("", self.output)
+        self.check_res("", self.errout)
 
-        def test_bug_13059(self):
-                """Test that python modules written for a version of python
-                other than the current system version are analyzed correctly."""
+    def test_bug_13059(self):
+        """Test that python modules written for a version of python
+        other than the current system version are analyzed correctly."""
 
-                # Set up the files for generate.
-                tp = self.make_manifest(
-                    self.pyver_test_manf_1.format(py_ver=py_ver_other))
-                fp = "usr/lib/python{0}/vendor-packages/pkg/" \
-                    "client/indexer.py".format(py_ver_other)
-                self.make_proto_text_file(fp, self.python_text)
+        # Set up the files for generate.
+        tp = self.make_manifest(
+            self.pyver_test_manf_1.format(py_ver=py_ver_other)
+        )
+        fp = (
+            "usr/lib/python{0}/vendor-packages/pkg/"
+            "client/indexer.py".format(py_ver_other)
+        )
+        self.make_proto_text_file(fp, self.python_text)
 
-                # Run generate and check the output.
-                self.pkgdepend_generate("-m -d {0} {1}".format(
-                    self.test_proto_dir, tp))
-                self.check_res(
-                    self.pyver_res_full_manf_1(py_ver_other,
-                        self.test_proto_dir, fp).format(
-                        bin_ver="", reason=fp, run_path=""),
-                    self.output)
-                self.check_res("", self.errout)
+        # Run generate and check the output.
+        self.pkgdepend_generate("-m -d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(
+            self.pyver_res_full_manf_1(
+                py_ver_other, self.test_proto_dir, fp
+            ).format(bin_ver="", reason=fp, run_path=""),
+            self.output,
+        )
+        self.check_res("", self.errout)
 
-                # Take the output from the run and make it a file
-                # for the resolver to use.
-                dependency_mp = self.make_manifest(self.output)
-                provider_mp = self.make_manifest(
-                    self.pyver_resolve_dep_manf.format(py_ver=py_ver_other))
+        # Take the output from the run and make it a file
+        # for the resolver to use.
+        dependency_mp = self.make_manifest(self.output)
+        provider_mp = self.make_manifest(
+            self.pyver_resolve_dep_manf.format(py_ver=py_ver_other)
+        )
 
-                # Run resolver and check the output.
-                self.pkgdepend_resolve(
-                    "-v {0} {1}".format(dependency_mp, provider_mp))
-                self.check_res("", self.output)
-                self.check_res("", self.errout)
-                dependency_res_p = dependency_mp + ".res"
-                provider_res_p = provider_mp + ".res"
-                lines = self.__read_file(dependency_res_p)
-                self.check_res(self.make_pyver_resolve_results(
-                    pkg5unittest.g_proto_area).format(
-                        res_manf=os.path.basename(provider_mp),
-                        pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
-                        py_ver=py_ver_other,
-                        reason=fp
-                    ), lines)
-                lines = self.__read_file(provider_res_p)
-                self.check_res("", lines)
+        # Run resolver and check the output.
+        self.pkgdepend_resolve("-v {0} {1}".format(dependency_mp, provider_mp))
+        self.check_res("", self.output)
+        self.check_res("", self.errout)
+        dependency_res_p = dependency_mp + ".res"
+        provider_res_p = provider_mp + ".res"
+        lines = self.__read_file(dependency_res_p)
+        self.check_res(
+            self.make_pyver_resolve_results(pkg5unittest.g_proto_area).format(
+                res_manf=os.path.basename(provider_mp),
+                pfx=base.Dependency.DEPEND_DEBUG_PREFIX,
+                py_ver=py_ver_other,
+                reason=fp,
+            ),
+            lines,
+        )
+        lines = self.__read_file(provider_res_p)
+        self.check_res("", lines)
 
-                # Clean up
-                portable.remove(dependency_res_p)
-                portable.remove(provider_res_p)
+        # Clean up
+        portable.remove(dependency_res_p)
+        portable.remove(provider_res_p)
 
-                # Now test that generating dependencies when runpaths
-                # have been set works.
-                tp = self.make_manifest(
-                    self.pyver_test_manf_1_run_path.format(py_ver=py_ver_other))
-                fp = "usr/lib/python{0}/vendor-packages/pkg/" \
-                    "client/indexer.py".format(py_ver_other)
-                self.make_proto_text_file(fp, self.python_text)
+        # Now test that generating dependencies when runpaths
+        # have been set works.
+        tp = self.make_manifest(
+            self.pyver_test_manf_1_run_path.format(py_ver=py_ver_other)
+        )
+        fp = (
+            "usr/lib/python{0}/vendor-packages/pkg/"
+            "client/indexer.py".format(py_ver_other)
+        )
+        self.make_proto_text_file(fp, self.python_text)
 
-                # Run generate and check the output.
-                self.pkgdepend_generate("-m -d {0} {1}".format(
-                    self.test_proto_dir, tp))
-                self.check_res(
-                    self.pyver_res_full_manf_1(py_ver_other,
-                        self.test_proto_dir, fp).format(
-                            bin_ver="",
-                            reason=fp,
-                            run_path=\
-                                "pkg.depend.runpath=$PKGDEPEND_RUNPATH"),
-                    self.output)
-                self.check_res("", self.errout)
+        # Run generate and check the output.
+        self.pkgdepend_generate("-m -d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res(
+            self.pyver_res_full_manf_1(
+                py_ver_other, self.test_proto_dir, fp
+            ).format(
+                bin_ver="",
+                reason=fp,
+                run_path="pkg.depend.runpath=$PKGDEPEND_RUNPATH",
+            ),
+            self.output,
+        )
+        self.check_res("", self.errout)
 
-        def test_PEP_3149(self):
-                """Test that Python 3 modules importing native modules can find
-                them in the right place, following PEP 3149.
+    def test_PEP_3149(self):
+        """Test that Python 3 modules importing native modules can find
+        them in the right place, following PEP 3149.
 
-                On Solaris, this means 64-bit only, and with the "m" (pymalloc)
-                flag turned on.
-                """
+        On Solaris, this means 64-bit only, and with the "m" (pymalloc)
+        flag turned on.
+        """
 
-                # Create a python 3.x file that imports a native module.
-                tp = self.make_manifest(
-                    self.pyver_test_manf_1.format(py_ver=py3_ver))
-                fp = "usr/lib/python{0}/vendor-packages/pkg/" \
-                    "client/indexer.py".format(py3_ver)
-                self.make_proto_text_file(fp, self.python3_so_text)
+        # Create a python 3.x file that imports a native module.
+        tp = self.make_manifest(self.pyver_test_manf_1.format(py_ver=py3_ver))
+        fp = (
+            "usr/lib/python{0}/vendor-packages/pkg/"
+            "client/indexer.py".format(py3_ver)
+        )
+        self.make_proto_text_file(fp, self.python3_so_text)
 
-                # Run generate
-                self.pkgdepend_generate("-m -d {0} {1}".format(
-                    self.test_proto_dir, tp))
+        # Run generate
+        self.pkgdepend_generate("-m -d {0} {1}".format(self.test_proto_dir, tp))
 
-                # Take the output, split it into actions, and find exactly one
-                # action which generated a correct dependency on zlib based on
-                # indexer.py.
-                pfx = base.Dependency.DEPEND_DEBUG_PREFIX
-                acts = [
-                    a
-                    for a in (
-                        actions.fromstr(l)
-                        for l in self.output.strip().splitlines()
-                    )
-                    if a.attrs.get(pfx + ".reason") == fp and
-                        "64/zlib.cpython-{}.so".format(py3_ext)
-                         in a.attrs[pfx + ".file"]
-                ]
-                self.assertTrue(len(acts) == 1)
+        # Take the output, split it into actions, and find exactly one
+        # action which generated a correct dependency on zlib based on
+        # indexer.py.
+        pfx = base.Dependency.DEPEND_DEBUG_PREFIX
+        acts = [
+            a
+            for a in (
+                actions.fromstr(l) for l in self.output.strip().splitlines()
+            )
+            if a.attrs.get(pfx + ".reason") == fp
+            and "64/zlib.cpython-{}.so".format(py3_ext)
+            in a.attrs[pfx + ".file"]
+        ]
+        self.assertTrue(len(acts) == 1)
 
-                self.check_res("", self.errout)
+        self.check_res("", self.errout)
 
-        def test_bypass_full_paths(self):
-                """Test that when a match between the full paths of a dependency
-                and something specified in the pkg.depend.bypass-generate is
-                found, pkgdepend ignores the dependency as expected.
-                """
+    def test_bypass_full_paths(self):
+        """Test that when a match between the full paths of a dependency
+        and something specified in the pkg.depend.bypass-generate is
+        found, pkgdepend ignores the dependency as expected.
+        """
 
-                tp = self.make_manifest(self.test_bypass_manf)
-                self.make_elf([], "usr/xpg4/lib/libcurses.so.1")
-                self.pkgdepend_generate("-d {0} {1}".format(
-                    self.test_proto_dir, tp))
-                self.check_res("", self.errout)
-                self.check_res(self.res_bypass, self.glre.sub('', self.output))
+        tp = self.make_manifest(self.test_bypass_manf)
+        self.make_elf([], "usr/xpg4/lib/libcurses.so.1")
+        self.pkgdepend_generate("-d {0} {1}".format(self.test_proto_dir, tp))
+        self.check_res("", self.errout)
+        self.check_res(self.res_bypass, self.glre.sub("", self.output))
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgdep_resolve.py
+++ b/src/tests/cli/t_pkgdep_resolve.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -42,12 +43,12 @@ import pkg.publish.dependencies as dependencies
 
 
 class TestApiDependencies(pkg5unittest.SingleDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = False
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = False
 
-        depend_dp = base.Dependency.DEPEND_DEBUG_PREFIX
+    depend_dp = base.Dependency.DEPEND_DEBUG_PREFIX
 
-        hardlink1_manf_deps = """\
+    hardlink1_manf_deps = """\
 hardlink path=usr/foo target=../var/log/syslog
 hardlink path=usr/bar target=../var/log/syslog
 depend fmri=__TBD pkg.debug.depend.file=var/log/syslog pkg.debug.depend.reason=usr/bar pkg.debug.depend.type=hardlink type=require
@@ -55,137 +56,137 @@ depend fmri=__TBD pkg.debug.depend.file=var/log/syslog pkg.debug.depend.reason=u
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog
 """
 
-        hardlink2_manf_deps = """\
+    hardlink2_manf_deps = """\
 hardlink path=baz target=var/log/authlog
 depend fmri=__TBD pkg.debug.depend.file=var/log/authlog pkg.debug.depend.reason=baz pkg.debug.depend.type=hardlink type=require
 file NOHASH group=sys mode=0644 owner=root path=var/log/syslog
 """
-        multi_deps = """\
+    multi_deps = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python2.7/v-p/pkg/client/indexer.py
 depend fmri=__TBD pkg.debug.depend.file=usr/bin/python2.7 pkg.debug.depend.reason=usr/lib/python2.7/v-p/pkg/client/indexer.py pkg.debug.depend.type=script type=require
 depend fmri=__TBD pkg.debug.depend.file=usr/lib/python2.7/v-p/pkg/misc.py pkg.debug.depend.reason=usr/lib/python2.7/v-p/pkg/client/indexer.py pkg.debug.depend.type=python type=require
 """
 
-        misc_manf = """\
+    misc_manf = """\
 set name=fmri value=pkg:/footest@0.5.11,5.11-0.117
 file NOHASH group=bin mode=0444 owner=root path=usr/lib/python2.7/v-p/pkg/misc.py
 """
 
-        simp_manf = """\
+    simp_manf = """\
 set name=variant.foo value=bar value=baz
 depend fmri=__TBD pkg.debug.depend.file=var/log/syslog pkg.debug.depend.reason=usr/bar pkg.debug.depend.type=hardlink type=require
 """
 
-        simple_variant_deps = """\
+    simple_variant_deps = """\
 set name=variant.foo value=bar value=baz
 depend fmri=__TBD pkg.debug.depend.file=var/log/authlog pkg.debug.depend.reason=baz pkg.debug.depend.type=hardlink type=require
 """
 
-        simple_v_deps_bar = """
+    simple_v_deps_bar = """
 set name=fmri value=pkg:/s-v-bar
 set name=variant.foo value=bar value=baz
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.foo=bar
 """
 
-        simple_v_deps_bar2 = """
+    simple_v_deps_bar2 = """
 set name=fmri value=pkg:/s-v-bar
 set name=variant.foo value=bar
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog
 """
 
-        simple_v_deps_baz = """
+    simple_v_deps_baz = """
 set name=fmri value=pkg:/s-v-baz
 set name=variant.foo value=bar value=baz
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.foo=baz
 """
 
-        simple_v_deps_baz2 = """
+    simple_v_deps_baz2 = """
 set name=fmri value=pkg:/s-v-baz
 set name=variant.foo value=baz
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog
 """
 
-        two_variant_deps = """\
+    two_variant_deps = """\
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
 depend fmri=__TBD pkg.debug.depend.file=var/log/authlog pkg.debug.depend.reason=baz pkg.debug.depend.type=hardlink type=require
 """
 
-        two_v_deps_bar = """
+    two_v_deps_bar = """
 set name=fmri value=pkg:/s-v-bar
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.foo=bar
 """
 
-        two_v_deps_baz_one = """
+    two_v_deps_baz_one = """
 set name=fmri value=pkg:/s-v-baz-one
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.foo=baz variant.num=one
 """
 
-        two_v_deps_baz_two = """
+    two_v_deps_baz_two = """
 set name=fmri value=pkg:/s-v-baz-two
 set name=variant.foo value=bar value=baz
 set name=variant.num value=one value=two value=three
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.foo=baz variant.num=two
 """
 
-        collision_manf = """\
+    collision_manf = """\
 set name=fmri value=pkg:/collision_manf
 depend fmri=__TBD pkg.debug.depend.file=no_such_named_file pkg.debug.depend.path=platform/foo/baz pkg.debug.depend.path=platform/bar/baz pkg.debug.depend.path=lib pkg.debug.depend.path=usr/lib pkg.debug.depend.reason=foo/bar pkg.debug.depend.type=elf type=require\
 """
 
-        collision_manf_num_var = """\
+    collision_manf_num_var = """\
 set name=fmri value=pkg:/collision_manf
 set name=variant.num value=one value=two
 depend fmri=__TBD pkg.debug.depend.file=no_such_named_file pkg.debug.depend.path=platform/foo/baz pkg.debug.depend.path=platform/bar/baz pkg.debug.depend.path=lib pkg.debug.depend.path=usr/lib pkg.debug.depend.reason=foo/bar pkg.debug.depend.type=elf type=require\
 """
 
-        sat_both = """\
+    sat_both = """\
 set name=fmri value=pkg:/sat_both
 file NOHASH path=platform/bar/baz/no_such_named_file group=sys mode=0600 owner=root
 file NOHASH path=platform/foo/baz/no_such_named_file group=sys mode=0600 owner=root
 """
 
-        sat_bar_libc = """\
+    sat_bar_libc = """\
 set name=fmri value=pkg:/sat_bar_libc
 file NOHASH path=platform/bar/baz/no_such_named_file group=sys mode=0600 owner=root
 """
 
-        sat_bar_libc2 = """\
+    sat_bar_libc2 = """\
 set name=fmri value=pkg:/sat_bar_libc2
 file NOHASH path=platform/bar/baz/no_such_named_file group=sys mode=0600 owner=root
 """
 
-        sat_foo_libc = """\
+    sat_foo_libc = """\
 set name=fmri value=pkg:/sat_foo_libc
 file NOHASH path=platform/foo/baz/no_such_named_file group=sys mode=0600 owner=root
 """
 
-        sat_bar_libc_num_var = """\
+    sat_bar_libc_num_var = """\
 set name=fmri value=pkg:/sat_bar_libc
 set name=variant.num value=one
 file NOHASH path=platform/bar/baz/no_such_named_file group=sys mode=0600 owner=root
 """
-        sat_foo_libc_num_var = """\
+    sat_foo_libc_num_var = """\
 set name=fmri value=pkg:/sat_foo_libc
 set name=variant.num value=two
 file NOHASH path=platform/foo/baz/no_such_named_file group=sys mode=0600 owner=root
 """
-        sat_foo_libc_num_var_both = """\
+    sat_foo_libc_num_var_both = """\
 set name=fmri value=pkg:/sat_foo_libc
 set name=variant.num value=one value=two
 file NOHASH path=platform/foo/baz/no_such_named_file group=sys mode=0600 owner=root
 """
 
-        multi_file_dep_manf = """\
+    multi_file_dep_manf = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python2.7/vendor-packages/pkg/client/indexer.py
 depend fmri=__TBD pkg.debug.depend.file=search_storage.py pkg.debug.depend.file=search_storage.pyc pkg.debug.depend.file=search_storage/__init__.py pkg.debug.depend.path=usr/lib/python2.7/pkg pkg.debug.depend.path=usr/lib/python2.7/lib-dynload/pkg pkg.debug.depend.path=usr/lib/python2.7/lib-old/pkg pkg.debug.depend.path=usr/lib/python2.7/lib-tk/pkg pkg.debug.depend.path=usr/lib/python2.7/plat-sunos5/pkg pkg.debug.depend.path=usr/lib/python2.7/site-packages/pkg pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/pkg pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/gst-0.10/pkg pkg.debug.depend.path=usr/lib/python2.7/vendor-packages/gtk-2.0/pkg pkg.debug.depend.path=usr/lib/python27.zip/pkg pkg.debug.depend.reason=usr/lib/python2.7/vendor-packages/pkg/client/indexer.py pkg.debug.depend.type=python type=require
 """
 
-        multi_file_dep_fullpath_manf = """\
+    multi_file_dep_fullpath_manf = """\
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python2.7/vendor-packages/pkg/client/indexer.py
 depend fmri=__TBD pkg.debug.depend.file=search_storage.py \
     pkg.debug.depend.fullpath=usr/lib/python2.7/pkg/search_storage.py \
@@ -222,85 +223,85 @@ depend fmri=__TBD pkg.debug.depend.file=search_storage.py \
     pkg.debug.depend.type=python type=require
 """
 
-        multi_file_sat_both = """\
+    multi_file_sat_both = """\
 set name=fmri value=pkg:/sat_both
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python2.7/vendor-packages/pkg/search_storage.py
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python2.7/vendor-packages/pkg/search_storage.pyc
 """
 
-        multi_file_sat_py = """\
+    multi_file_sat_py = """\
 set name=fmri value=pkg:/sat_py
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python2.7/vendor-packages/pkg/search_storage.py
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python2.7/lib-tk/pkg/search_storage.py
 """
-        multi_file_sat_pyc = """\
+    multi_file_sat_pyc = """\
 set name=fmri value=pkg:/sat_pyc
 file NOHASH group=bin mode=0755 owner=root path=usr/lib/python2.7/vendor-packages/pkg/search_storage.pyc
 """
 
-        inst_pkg = """\
+    inst_pkg = """\
 open example2_pkg@1.0,5.11-0
 add file tmp/foo mode=0555 owner=root group=bin path=/usr/bin/python2.7
 close"""
 
-        var_pkg = """\
+    var_pkg = """\
 open variant_pkg@1.0,5.11-0
 add set name=variant.foo value=bar value=baz
 add file tmp/foo group=sys mode=0644 owner=root path=var/log/syslog
 close"""
 
-        double_deps = """\
+    double_deps = """\
 set name=pkg.fmri value=double_deps@1.0,5.11-0
 set name=variant.opensolaris.zone value=global value=nonglobal
 depend fmri=__TBD pkg.debug.depend.file=elfexec pkg.debug.depend.path=kernel/exec pkg.debug.depend.path=platform/i86hvm/kernel/exec pkg.debug.depend.path=platform/i86pc/kernel/exec pkg.debug.depend.path=platform/i86xpv/kernel/exec pkg.debug.depend.path=usr/kernel/exec pkg.debug.depend.reason=usr/kernel/brand/s10_brand pkg.debug.depend.type=elf type=require
 depend fmri=__TBD pkg.debug.depend.file=elfexec pkg.debug.depend.path=kernel/exec/amd64 pkg.debug.depend.path=platform/i86hvm/kernel/exec/amd64 pkg.debug.depend.path=platform/i86pc/kernel/exec/amd64 pkg.debug.depend.path=platform/i86xpv/kernel/exec/amd64 pkg.debug.depend.path=usr/kernel/exec/amd64 pkg.debug.depend.reason=usr/kernel/brand/amd64/s10_brand pkg.debug.depend.type=elf type=require
 """
-        installed_double_provides = """\
+    installed_double_provides = """\
 open double_provides@1.0,5.11-0
 add file tmp/foo group=sys mode=0755 owner=root path=kernel/exec/amd64/elfexec reboot-needed=true variant.opensolaris.zone=global
 add file tmp/foo group=sys mode=0755 owner=root path=kernel/exec/elfexec reboot-needed=true variant.opensolaris.zone=global
 close"""
 
-        newer_double_provides = """\
+    newer_double_provides = """\
 set name=pkg.fmri value=double_provides@1.0,5.11-1
 file NOHASH group=sys mode=0755 owner=root path=kernel/exec/amd64/elfexec reboot-needed=true variant.opensolaris.zone=global
 file NOHASH group=sys mode=0755 owner=root path=kernel/exec/elfexec reboot-needed=true variant.opensolaris.zone=global
 """
 
-        bug_16849_missing_build_version = """
+    bug_16849_missing_build_version = """
 set name=pkg.fmri value=pkg:/foo/bar@2.0.0
 file NOHASH group=sys mode=0644 owner=root path=var/log/syslog
 """
 
-        bug_16849_corrupted_version = """
+    bug_16849_corrupted_version = """
 set name=pkg.fmri value=pkg:/foo/bar@__whee__,5.11-1
 file NOHASH group=sys mode=0644 owner=root path=var/log/syslog
 """
 
-        bug_16849_leading_zeros = """
+    bug_16849_leading_zeros = """
 set name=pkg.fmri value=pkg:/foo/bar@2.06
 file NOHASH group=sys mode=0644 owner=root path=var/log/syslog
 """
 
-        bug_16849_depender = """
+    bug_16849_depender = """
 set name=pkg.fmri value=depender
 depend fmri=__TBD pkg.debug.depend.file=var/log/syslog pkg.debug.depend.reason=usr/bar pkg.debug.depend.type=hardlink type=require
 """
 
-        bug_17700_dep = """\
+    bug_17700_dep = """\
 set name=pkg.fmri value=b17700_dep@1.0,5.11-1
 set name=variant.opensolaris.zone value=global value=nonglobal
 set name=variant.arch value=sparc value=i386
 depend fmri=__TBD pkg.debug.depend.file=bignum pkg.debug.depend.path=kernel/misc/sparcv9 pkg.debug.depend.path=platform/sun4u/kernel/misc/sparcv9 pkg.debug.depend.path=platform/sun4v/kernel/misc/sparcv9 pkg.debug.depend.path=usr/kernel/misc/sparcv9 pkg.debug.depend.reason=kernel/drv/sparcv9/emlxs pkg.debug.depend.type=elf type=require variant.arch=sparc variant.opensolaris.zone=global
 """
-        bug_17700_res1 = """\
+    bug_17700_res1 = """\
 set name=pkg.fmri value=system/kernel@1.0,5.11-1
 set name=variant.opensolaris.zone value=global value=nonglobal
 set name=variant.arch value=sparc value=i386
 file NOHASH group=bin mode=0755 owner=root path=kernel/misc/sparcv9/bignum variant.arch=sparc variant.opensolaris.zone=global
 """
 
-        installed_17700_res1 = """\
+    installed_17700_res1 = """\
 open system/kernel@1.0,5.11-1
 add set name=variant.opensolaris.zone value=global value=nonglobal
 add set name=variant.arch value=sparc value=i386
@@ -308,14 +309,14 @@ add file tmp/foo group=bin mode=0755 owner=root path=kernel/misc/sparcv9/bignum 
 close
 """
 
-        bug_17700_res2 = """\
+    bug_17700_res2 = """\
 set name=pkg.fmri value=system/kernel/platform@1.0,5.11-1
 set name=variant.opensolaris.zone value=global value=nonglobal
 set name=variant.arch value=sparc value=i386
 file NOHASH group=bin mode=0755 owner=root path=platform/sun4u/kernel/misc/sparcv9/bignum variant.arch=sparc variant.opensolaris.zone=global
 """
 
-        installed_17700_res2 = """\
+    installed_17700_res2 = """\
 open system/kernel/platform@1.0,5.11-1
 add set name=variant.opensolaris.zone value=global value=nonglobal
 add set name=variant.arch value=sparc value=i386
@@ -323,58 +324,58 @@ add file tmp/foo group=bin mode=0755 owner=root path=platform/sun4u/kernel/misc/
 close
 """
 
-        # there's a single variant.arch value set here,
-        # but no variant.opensolaris.zone values
-        installed_18045 = """\
+    # there's a single variant.arch value set here,
+    # but no variant.opensolaris.zone values
+    installed_18045 = """\
 open runtime/python-27@2.7.8,5.11-0.161
 add set name=variant.foo value=i386
 add file tmp/foo group=bin mode=0755 owner=root path=usr/bin/python
 close
 """
-        # a file dependency that declares variant.opensolaris.zone values
-        bug_18045_dep = """
+    # a file dependency that declares variant.opensolaris.zone values
+    bug_18045_dep = """
 set name=pkg.fmri value=system/kernel/platform@1.0,5.11-1
 set name=variant.foo value=i386
 set name=variant.opensolaris.zone value=global value=nonglobal
 depend fmri=__TBD pkg.debug.depend.file=python pkg.debug.depend.path=usr/bin type=require
 """
 
-        # there's a single variant.arch value set here,
-        # and variant.opensolaris.zone values
-        installed_18045_reverse = """\
+    # there's a single variant.arch value set here,
+    # and variant.opensolaris.zone values
+    installed_18045_reverse = """\
 open runtime/python-27@2.7.8,5.11-0.161
 add set name=variant.foo value=i386
 add set name=variant.opensolaris.zone value=global value=nonglobal
 add file tmp/foo group=bin mode=0755 owner=root path=usr/bin/python
 close
 """
-        # a file dependency that doesn't declare variant.opensolaris.zone values
-        bug_18045_dep_reverse = """
+    # a file dependency that doesn't declare variant.opensolaris.zone values
+    bug_18045_dep_reverse = """
 set name=pkg.fmri value=system/kernel/platform@1.0,5.11-1
 set name=variant.foo value=i386
 depend fmri=__TBD pkg.debug.depend.file=python pkg.debug.depend.path=usr/bin type=require
 """
 
-        # there's a single variant.arch value set here,
-        # but no variant.opensolaris.zone values
-        installed_18045_mixed = """\
+    # there's a single variant.arch value set here,
+    # but no variant.opensolaris.zone values
+    installed_18045_mixed = """\
 open runtime/python-27@2.7.8,5.11-0.161
 add set name=variant.foo value=i386
 add file tmp/foo group=bin mode=0755 owner=root path=usr/bin/python
 close
 """
-        # a file dependency that only declares variant.opensolaris.zone values
-        bug_18045_dep_mixed = """
+    # a file dependency that only declares variant.opensolaris.zone values
+    bug_18045_dep_mixed = """
 set name=pkg.fmri value=system/kernel/platform@1.0,5.11-1
 set name=variant.opensolaris.zone value=global value=nonglobal
 depend fmri=__TBD pkg.debug.depend.file=python pkg.debug.depend.path=usr/bin type=require
 """
 
-        bug_18130_dep = """\
+    bug_18130_dep = """\
 depend fmri=__TBD pkg.debug.depend.file=var/log/authlog pkg.debug.depend.reason=baz pkg.debug.depend.type=hardlink type=require
 """
 
-        bug_18130_provider_1 = """\
+    bug_18130_provider_1 = """\
 set name=pkg.fmri value=provider@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -382,7 +383,7 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=spa
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=i386
 """
 
-        bug_18130_provider_2 = """\
+    bug_18130_provider_2 = """\
 set name=pkg.fmri value=provider@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -392,7 +393,7 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=i38
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=i386 variant.opensolaris.zone=global
 """
 
-        bug_18130_provider_3_1 = """\
+    bug_18130_provider_3_1 = """\
 set name=pkg.fmri value=provider1@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -401,14 +402,14 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=spa
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=i386 variant.opensolaris.zone=nonglobal
 """
 
-        bug_18130_provider_3_2 = """\
+    bug_18130_provider_3_2 = """\
 set name=pkg.fmri value=provider2@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc
 set name=variant.opensolaris.zone value=global value=nonglobal
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=i386 variant.opensolaris.zone=global
 """
 
-        bug_18130_provider_4 = """\
+    bug_18130_provider_4 = """\
 set name=pkg.fmri value=provider1@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -427,7 +428,7 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo variant.opensolaris.zone=nonglobal variant.debug=False
 """
 
-        bug_18130_provider_5_1 = """\
+    bug_18130_provider_5_1 = """\
 set name=pkg.fmri value=provider1@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -445,7 +446,7 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=i38
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo variant.opensolaris.zone=global variant.debug=False
 """
 
-        bug_18130_provider_5_2 = """\
+    bug_18130_provider_5_2 = """\
 set name=pkg.fmri value=provider2@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -453,7 +454,7 @@ set name=variant.debug value=True value=False
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo variant.opensolaris.zone=nonglobal variant.debug=False
 """
 
-        bug_18130_provider_6_1 = """\
+    bug_18130_provider_6_1 = """\
 set name=pkg.fmri value=provider1@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -466,7 +467,7 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo variant.opensolaris.zone=nonglobal variant.debug=True
 """
 
-        bug_18130_provider_6_2 = """\
+    bug_18130_provider_6_2 = """\
 set name=pkg.fmri value=provider2@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -479,7 +480,7 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=i38
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo variant.opensolaris.zone=global variant.debug=False
 """
 
-        bug_18130_provider_7_1 = """\
+    bug_18130_provider_7_1 = """\
 set name=pkg.fmri value=provider1@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -492,7 +493,7 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo variant.opensolaris.zone=global variant.debug=False
 """
 
-        bug_18130_provider_7_2 = """\
+    bug_18130_provider_7_2 = """\
 set name=pkg.fmri value=provider2@1.0,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -505,28 +506,28 @@ file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo
 file NOHASH group=sys mode=0600 owner=root path=var/log/authlog variant.arch=foo variant.opensolaris.zone=nonglobal variant.debug=False
 """
 
-        bug_18172_top = """\
+    bug_18172_top = """\
 set name=pkg.fmri value=top@0.5.11,5.11-1
 depend fmri=__TBD pkg.debug.depend.file=ksh pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=usr/lib/brand/shared/dsconvert pkg.debug.depend.type=script type=require
 """
-        bug_18172_l1 = """\
+    bug_18172_l1 = """\
 set name=pkg.fmri value=ksh@0.5.11,5.11-1
 link path=usr/bin/ksh target=../../usr/lib/l1
 """
-        bug_18172_l2 = """\
+    bug_18172_l2 = """\
 set name=pkg.fmri value=l2@0.5.11,5.11-1
 link path=usr/lib/l1 target=l2
 """
-        bug_18172_l3 = """\
+    bug_18172_l3 = """\
 set name=pkg.fmri value=l3@0.5.11,5.11-1
 link path=usr/lib/l2 target=isaexec
 """
-        bug_18172_dest = """\
+    bug_18172_dest = """\
 set name=pkg.fmri value=dest@0.5.11,5.11-1
 file tmp/foo path=usr/lib/isaexec group=sys mode=0600 owner=root
 """
 
-        bug_18173_cs_1 = """\
+    bug_18173_cs_1 = """\
 open cs@0.5.11,5.11-1
 add set name=pkg.fmri value=cs@0.5.11,5.11-1
 add file NOHASH path=usr/lib/isaexec mode=0755 owner=root group=sys
@@ -536,44 +537,44 @@ add hardlink path=usr/bin/ksh target=../../usr/lib/isaexec
 close
 """
 
-        bug_18173_cs_2 = """\
+    bug_18173_cs_2 = """\
 set name=pkg.fmri value=cs@0.5.11,5.11-2
 file tmp/foo path=usr/lib/isaexec group=sys mode=0600 owner=root
 """
 
-        bug_18173_ksh = """\
+    bug_18173_ksh = """\
 set name=pkg.fmri value=ksh@0.5.11,5.11-2
 hardlink path=usr/bin/ksh target=../../usr/lib/isaexec
 depend fmri=__TBD pkg.debug.depend.file=isaexec pkg.debug.depend.path=usr/lib pkg.debug.depend.reason=usr/bin/ksh pkg.debug.depend.type=hardlink type=require
 """
 
-        bug_18173_zones = """\
+    bug_18173_zones = """\
 set name=pkg.fmri value=zones@0.5.11,5.11-2
 file NOHASH path=usr/lib/brand/shared/dsconvert group=sys mode=0755 owner=root
 depend fmri=__TBD pkg.debug.depend.file=ksh pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=usr/lib/brand/shared/dsconvert pkg.debug.depend.type=script type=require
 """
 
-        bug_18315_link1_manf = """ \
+    bug_18315_link1_manf = """ \
 set name=pkg.fmri value=link1@1,5.11-1
 link path=lib/64 target=amd64
 """
 
-        bug_18315_link2_manf = """ \
+    bug_18315_link2_manf = """ \
 set name=pkg.fmri value=link2@1,5.11-1
 link path=lib/64 target=amd64
 """
 
-        bug_18315_depender_manf = """ \
+    bug_18315_depender_manf = """ \
 set name=pkg.fmri value=depender@1,5.11-1
 depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib/64 pkg.depend.reason=usr/bin/binary pkg.debug.depend.type=elf type=require
 """
 
-        bug_18315_dependee_manf = """ \
+    bug_18315_dependee_manf = """ \
 set name=pkg.fmri value=dependee@1,5.11-1
 file NOHASH path=lib/amd64/libc.so.1 group=sys mode=0600 owner=root
 """
 
-        bug_18315_var_link1_manf = """ \
+    bug_18315_var_link1_manf = """ \
 set name=pkg.fmri value=link1@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -581,7 +582,7 @@ link path=lib/64 target=amd64 variant.arch=i386
 link path=lib/64 target=amd64 variant.arch=sparc
 """
 
-        bug_18315_var_link2_manf = """ \
+    bug_18315_var_link2_manf = """ \
 set name=pkg.fmri value=link2@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -589,819 +590,1110 @@ link path=lib/64 target=amd64 variant.arch=i386
 link path=lib/64 target=amd64 variant.arch=sparc
 """
 
-        bug_18315_var_depender_manf = """ \
+    bug_18315_var_depender_manf = """ \
 set name=pkg.fmri value=depender@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
 depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib/64 pkg.depend.reason=usr/bin/binary pkg.debug.depend.type=elf type=require
 """
 
-        bug_18315_var_dependee_manf = """ \
+    bug_18315_var_dependee_manf = """ \
 set name=pkg.fmri value=dependee@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
 file NOHASH path=lib/amd64/libc.so.1 group=sys mode=0600 owner=root
 """
 
-        bug_18315_var_link3_manf = """ \
+    bug_18315_var_link3_manf = """ \
 set name=pkg.fmri value=link3@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
 link path=lib/64 target=amd64 variant.arch=i386
 """
 
-        bug_18315_var_link4_manf = """ \
+    bug_18315_var_link4_manf = """ \
 set name=pkg.fmri value=link4@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
 link path=lib/64 target=amd64 variant.arch=i386 variant.opensolaris.zone=global
 """
 
-        bug_18315_var_link5_manf = """ \
+    bug_18315_var_link5_manf = """ \
 set name=pkg.fmri value=link5@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
 link path=lib/64 target=amd64 variant.arch=foo
 """
 
-        misc_files = {
-            "empty": "\n\n\n",
-            "var_pat": "var*\n",
-            "var_fmri": "variant_pkg\n",
-            "bad_pat": "abcde\n",
-            "ex_pat": "ex*\n",
-            "tmp/foo": "tmp/foo",
-        }
+    misc_files = {
+        "empty": "\n\n\n",
+        "var_pat": "var*\n",
+        "var_fmri": "variant_pkg\n",
+        "bad_pat": "abcde\n",
+        "ex_pat": "ex*\n",
+        "tmp/foo": "tmp/foo",
+    }
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(self.misc_files)
 
-                self.image_create(self.rurl)
-                self.api_obj = self.get_img_api_obj()
+        self.image_create(self.rurl)
+        self.api_obj = self.get_img_api_obj()
 
-        def test_broken_manifests(self):
-                """Test that resolving manifests which have strange or
-                unexpected depend actions doesn't cause a traceback."""
+    def test_broken_manifests(self):
+        """Test that resolving manifests which have strange or
+        unexpected depend actions doesn't cause a traceback."""
 
-                bad_require_dep_manf = """\
+        bad_require_dep_manf = """\
 set name=pkg.fmri value=badreq@1,5.11
 depend fmri=pkg://// type=require
 """
-                m1_path = self.make_manifest(bad_require_dep_manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([m1_path], self.api_obj, ["*"])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(errs), 1)
-                self.assertTrue(isinstance(errs[0],
-                    actions.InvalidActionAttributesError))
+        m1_path = self.make_manifest(bad_require_dep_manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([m1_path], self.api_obj, ["*"])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(errs), 1)
+        self.assertTrue(
+            isinstance(errs[0], actions.InvalidActionAttributesError)
+        )
 
-                bad_require_any_dep_manf = """\
+        bad_require_any_dep_manf = """\
 depend fmri=example_pkg fmri=pkg://////// fmri=pkg://// type=require-any
 """
-                m1_path = self.make_manifest(bad_require_any_dep_manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([m1_path], self.api_obj, ["*"])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(errs), 1)
-                self.assertTrue(isinstance(errs[0],
-                    actions.InvalidActionAttributesError))
+        m1_path = self.make_manifest(bad_require_any_dep_manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([m1_path], self.api_obj, ["*"])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(errs), 1)
+        self.assertTrue(
+            isinstance(errs[0], actions.InvalidActionAttributesError)
+        )
 
-                bad_variant = """\
+        bad_variant = """\
 set name=pkg.fmri value=foo@1.0,5.11-1
 set name=variant.num value=one value=two
 depend fmri=pkg:/a@0,5.11-1 type=conditional predicate=pkg:/b@2,5.11-1 variant.nn
 """
-                m1_path = self.make_manifest(bad_variant)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([m1_path], self.api_obj, ["*"])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(errs), 1)
-                self.assertTrue(isinstance(errs[0],
-                    actions.MalformedActionError),
-                    "Error was of the type. The type was:{0}. The error "
-                    "was:\n:{1}".format(type(errs[0]), errs[0]))
+        m1_path = self.make_manifest(bad_variant)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([m1_path], self.api_obj, ["*"])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(errs), 1)
+        self.assertTrue(
+            isinstance(errs[0], actions.MalformedActionError),
+            "Error was of the type. The type was:{0}. The error "
+            "was:\n:{1}".format(type(errs[0]), errs[0]),
+        )
 
-        def test_constraint_files(self):
-                """Test that the constraint files (-e) work as expected and that
-                the output with -E is also as expected."""
+    def test_constraint_files(self):
+        """Test that the constraint files (-e) work as expected and that
+        the output with -E is also as expected."""
 
-                m1_path = self.make_manifest(self.hardlink1_manf_deps)
-                self.pkgsend_bulk(self.rurl, self.inst_pkg)
-                self.pkgsend_bulk(self.rurl, self.var_pkg)
-                self.api_obj.refresh(immediate=True)
+        m1_path = self.make_manifest(self.hardlink1_manf_deps)
+        self.pkgsend_bulk(self.rurl, self.inst_pkg)
+        self.pkgsend_bulk(self.rurl, self.var_pkg)
+        self.api_obj.refresh(immediate=True)
 
-                empty_path = os.path.join(self.test_root, "empty")
-                ex_path = os.path.join(self.test_root, "ex_pat")
-                var_pat_path = os.path.join(self.test_root, "var_pat")
-                var_fmri_path = os.path.join(self.test_root, "var_fmri")
+        empty_path = os.path.join(self.test_root, "empty")
+        ex_path = os.path.join(self.test_root, "ex_pat")
+        var_pat_path = os.path.join(self.test_root, "var_pat")
+        var_fmri_path = os.path.join(self.test_root, "var_fmri")
 
-                # Test that having constraint files but no constraints errors
-                # correctly.
-                self.pkgdepend_resolve("-e {0} -m {1}".format(empty_path, m1_path),
-                    exit=1)
-                self.assertEqualDiff("pkgdepend: External package list files "
-                    "were provided but did not contain any fmri patterns.\n",
-                    self.errout)
+        # Test that having constraint files but no constraints errors
+        # correctly.
+        self.pkgdepend_resolve(
+            "-e {0} -m {1}".format(empty_path, m1_path), exit=1
+        )
+        self.assertEqualDiff(
+            "pkgdepend: External package list files "
+            "were provided but did not contain any fmri patterns.\n",
+            self.errout,
+        )
 
-                # Test that only constrained files are used to resolve
-                # dependencies.
-                self._api_install(self.api_obj, ["variant_pkg"])
-                self.pkgdepend_resolve("-e {0} -E -m {1}".format(
-                    var_pat_path, m1_path))
-                self.assertEqualDiff("", self.errout)
+        # Test that only constrained files are used to resolve
+        # dependencies.
+        self._api_install(self.api_obj, ["variant_pkg"])
+        self.pkgdepend_resolve("-e {0} -E -m {1}".format(var_pat_path, m1_path))
+        self.assertEqualDiff("", self.errout)
 
-                expected_txt = """
+        expected_txt = """
 The following fmris matched a pattern in a constraint file but were not used in
 dependency resolution:
 	example2_pkg
 """
-                # Test that extraneous packages are properly displayed when -E
-                # is used.
-                self._api_install(self.api_obj, ["example2_pkg"])
-                self.pkgdepend_resolve("-e {0} -e {1} -e {2} -E -m {3}".format(
-                    var_fmri_path, ex_path, empty_path, m1_path))
-                self.assertEqualDiff(expected_txt, self.output)
+        # Test that extraneous packages are properly displayed when -E
+        # is used.
+        self._api_install(self.api_obj, ["example2_pkg"])
+        self.pkgdepend_resolve(
+            "-e {0} -e {1} -e {2} -E -m {3}".format(
+                var_fmri_path, ex_path, empty_path, m1_path
+            )
+        )
+        self.assertEqualDiff(expected_txt, self.output)
 
-                # Check that changing the order of the -e options doesn't change
-                # the results.
-                self.pkgdepend_resolve("-e {0} -e {1} -e {2} -E -m {3}".format(
-                    ex_path, var_fmri_path, empty_path, m1_path))
-                self.assertEqualDiff(expected_txt, self.output)
+        # Check that changing the order of the -e options doesn't change
+        # the results.
+        self.pkgdepend_resolve(
+            "-e {0} -e {1} -e {2} -E -m {3}".format(
+                ex_path, var_fmri_path, empty_path, m1_path
+            )
+        )
+        self.assertEqualDiff(expected_txt, self.output)
 
-                # Check that if -e points at a file that doesn't exist, no
-                # traceback happens.
-                self.pkgdepend_resolve("-e {0} -e {1} -e {2} -E -m {3}".format(
-                    ex_path + "foobar", var_fmri_path, empty_path, m1_path),
-                    exit=1)
+        # Check that if -e points at a file that doesn't exist, no
+        # traceback happens.
+        self.pkgdepend_resolve(
+            "-e {0} -e {1} -e {2} -E -m {3}".format(
+                ex_path + "foobar", var_fmri_path, empty_path, m1_path
+            ),
+            exit=1,
+        )
 
-                # Check that if -e points at a directory, no traceback happens.
-                self.pkgdepend_resolve("-e {0} -E -m {1}".format(
-                    self.test_root, m1_path), exit=1)
+        # Check that if -e points at a directory, no traceback happens.
+        self.pkgdepend_resolve(
+            "-e {0} -E -m {1}".format(self.test_root, m1_path), exit=1
+        )
 
-        def test_resolve_permissions(self):
-                """Test that a manifest or constraint file that pkgdepend
-                resolve can't access doesn't cause a traceback."""
+    def test_resolve_permissions(self):
+        """Test that a manifest or constraint file that pkgdepend
+        resolve can't access doesn't cause a traceback."""
 
-                m1_path = self.make_manifest(self.hardlink1_manf_deps)
-                self.pkgdepend_resolve("-m {0}".format(m1_path), su_wrap=True, exit=1)
-                os.chmod(m1_path, 0o444)
-                pattern_path = os.path.join(self.test_root, "ex_pat")
-                os.chmod(pattern_path, 0000)
-                self.pkgdepend_resolve("-e {0} -o {1}".format(
-                    pattern_path, m1_path), su_wrap=True, exit=1)
+        m1_path = self.make_manifest(self.hardlink1_manf_deps)
+        self.pkgdepend_resolve("-m {0}".format(m1_path), su_wrap=True, exit=1)
+        os.chmod(m1_path, 0o444)
+        pattern_path = os.path.join(self.test_root, "ex_pat")
+        os.chmod(pattern_path, 0000)
+        self.pkgdepend_resolve(
+            "-e {0} -o {1}".format(pattern_path, m1_path), su_wrap=True, exit=1
+        )
 
-        def test_resolve_cross_package(self):
-                """test that cross dependencies between published packages
-                works."""
+    def test_resolve_cross_package(self):
+        """test that cross dependencies between published packages
+        works."""
 
-                m1_path = self.make_manifest(self.hardlink1_manf_deps)
-                m2_path = self.make_manifest(self.hardlink2_manf_deps)
-                p1_name = 'pkg:/{0}'.format(os.path.basename(m1_path))
-                p2_name = 'pkg:/{0}'.format(os.path.basename(m2_path))
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([m1_path, m2_path], self.api_obj,
-                        ["*"])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 2)
-                self.assertEqual(len(pkg_deps[m1_path]), 1)
-                self.assertEqual(len(pkg_deps[m1_path][0].attrs["{0}.reason".format(
-                    base.Dependency.DEPEND_DEBUG_PREFIX)]), 2)
-                self.assertEqual(len(pkg_deps[m2_path]), 1)
-                for d in pkg_deps[m1_path]:
-                        self.assertEqual(d.attrs["fmri"], p2_name)
-                for d in pkg_deps[m2_path]:
-                        self.assertEqual(d.attrs["fmri"], p1_name)
+        m1_path = self.make_manifest(self.hardlink1_manf_deps)
+        m2_path = self.make_manifest(self.hardlink2_manf_deps)
+        p1_name = "pkg:/{0}".format(os.path.basename(m1_path))
+        p2_name = "pkg:/{0}".format(os.path.basename(m2_path))
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([m1_path, m2_path], self.api_obj, ["*"])
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 2)
+        self.assertEqual(len(pkg_deps[m1_path]), 1)
+        self.assertEqual(
+            len(
+                pkg_deps[m1_path][0].attrs[
+                    "{0}.reason".format(base.Dependency.DEPEND_DEBUG_PREFIX)
+                ]
+            ),
+            2,
+        )
+        self.assertEqual(len(pkg_deps[m2_path]), 1)
+        for d in pkg_deps[m1_path]:
+            self.assertEqual(d.attrs["fmri"], p2_name)
+        for d in pkg_deps[m2_path]:
+            self.assertEqual(d.attrs["fmri"], p1_name)
 
-        def test_resolve_mix(self):
-                """Test that resolving against both packages installed on the
-                image and packages works for the same package and that the
-                resolver picks up the name of the package if it's defined in
-                the package."""
+    def test_resolve_mix(self):
+        """Test that resolving against both packages installed on the
+        image and packages works for the same package and that the
+        resolver picks up the name of the package if it's defined in
+        the package."""
 
-                self.pkgsend_bulk(self.rurl, self.inst_pkg)
-                self.api_obj.refresh(immediate=True)
-                self._api_install(self.api_obj, ["example2_pkg"])
+        self.pkgsend_bulk(self.rurl, self.inst_pkg)
+        self.api_obj.refresh(immediate=True)
+        self._api_install(self.api_obj, ["example2_pkg"])
 
-                m1_path = self.make_manifest(self.multi_deps)
-                m2_path = self.make_manifest(self.misc_manf)
-                p3_name = "pkg:/example2_pkg@1.0-0"
-                p2_name = "pkg:/footest@0.5.11-0.117"
+        m1_path = self.make_manifest(self.multi_deps)
+        m2_path = self.make_manifest(self.misc_manf)
+        p3_name = "pkg:/example2_pkg@1.0-0"
+        p2_name = "pkg:/footest@0.5.11-0.117"
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([m1_path, m2_path], self.api_obj,
-                        ["*"])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["example2_pkg"]), external_deps)
-                self.assertEqual(len(pkg_deps), 2)
-                self.assertEqual(len(pkg_deps[m1_path]), 2)
-                self.assertEqual(len(pkg_deps[m2_path]), 0)
-                self.assertEqual(len(errs), 0)
-                for d in pkg_deps[m1_path]:
-                        if d.attrs["fmri"] == p2_name:
-                                self.assertEqual(
-                                    d.attrs["{0}.file".format(self.depend_dp)],
-                                    ["usr/lib/python2.7/v-p/pkg/misc.py"])
-                        elif d.attrs["fmri"] == p3_name:
-                                self.assertEqual(
-                                    d.attrs["{0}.file".format(self.depend_dp)],
-                                    ["usr/bin/python2.7"])
-                        else:
-                                raise RuntimeError("Got unexpected fmri "
-                                    "{0} for in dependency {1}".format(
-                                    d.attrs["fmri"], d))
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([m1_path, m2_path], self.api_obj, ["*"])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["example2_pkg"]), external_deps)
+        self.assertEqual(len(pkg_deps), 2)
+        self.assertEqual(len(pkg_deps[m1_path]), 2)
+        self.assertEqual(len(pkg_deps[m2_path]), 0)
+        self.assertEqual(len(errs), 0)
+        for d in pkg_deps[m1_path]:
+            if d.attrs["fmri"] == p2_name:
+                self.assertEqual(
+                    d.attrs["{0}.file".format(self.depend_dp)],
+                    ["usr/lib/python2.7/v-p/pkg/misc.py"],
+                )
+            elif d.attrs["fmri"] == p3_name:
+                self.assertEqual(
+                    d.attrs["{0}.file".format(self.depend_dp)],
+                    ["usr/bin/python2.7"],
+                )
+            else:
+                raise RuntimeError(
+                    "Got unexpected fmri "
+                    "{0} for in dependency {1}".format(d.attrs["fmri"], d)
+                )
 
-                # Check that with system_patterns set to [], the system is
-                # not resolved against.  Bug 15777
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([m1_path, m2_path], self.api_obj,
-                        [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 2)
-                self.assertEqual(len(pkg_deps[m1_path]), 1)
-                self.assertEqual(len(pkg_deps[m2_path]), 0)
-                self.assertEqual(len(errs), 1)
-                for d in pkg_deps[m1_path]:
-                        if d.attrs["fmri"] == p2_name:
-                                self.assertEqual(
-                                    d.attrs["{0}.file".format(self.depend_dp)],
-                                    ["usr/lib/python2.7/v-p/pkg/misc.py"])
-                        elif d.attrs["fmri"] == p3_name:
-                                self.assertEqual(
-                                    d.attrs["{0}.file".format(self.depend_dp)],
-                                    ["usr/bin/python2.7"])
-                        else:
-                                raise RuntimeError("Got unexpected fmri "
-                                    "{0} for in dependency {1}".format(
-                                    d.attrs["fmri"], d))
-                for e in errs:
-                        if isinstance(e,
-                            dependencies.UnresolvedDependencyError):
-                                self.assertEqual(e.path, m1_path)
-                                self.assertEqual(e.file_dep.attrs[
-                                    "{0}.file".format(self.depend_dp)],
-                                    "usr/bin/python2.7")
-                        else:
-                                raise RuntimeError("Unexpected error:{0}".format(e))
+        # Check that with system_patterns set to [], the system is
+        # not resolved against.  Bug 15777
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([m1_path, m2_path], self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 2)
+        self.assertEqual(len(pkg_deps[m1_path]), 1)
+        self.assertEqual(len(pkg_deps[m2_path]), 0)
+        self.assertEqual(len(errs), 1)
+        for d in pkg_deps[m1_path]:
+            if d.attrs["fmri"] == p2_name:
+                self.assertEqual(
+                    d.attrs["{0}.file".format(self.depend_dp)],
+                    ["usr/lib/python2.7/v-p/pkg/misc.py"],
+                )
+            elif d.attrs["fmri"] == p3_name:
+                self.assertEqual(
+                    d.attrs["{0}.file".format(self.depend_dp)],
+                    ["usr/bin/python2.7"],
+                )
+            else:
+                raise RuntimeError(
+                    "Got unexpected fmri "
+                    "{0} for in dependency {1}".format(d.attrs["fmri"], d)
+                )
+        for e in errs:
+            if isinstance(e, dependencies.UnresolvedDependencyError):
+                self.assertEqual(e.path, m1_path)
+                self.assertEqual(
+                    e.file_dep.attrs["{0}.file".format(self.depend_dp)],
+                    "usr/bin/python2.7",
+                )
+            else:
+                raise RuntimeError("Unexpected error:{0}".format(e))
 
-        def test_simple_variants_1(self):
-                """Test that variants declared on the actions work correctly
-                when resolving dependencies."""
+    def test_simple_variants_1(self):
+        """Test that variants declared on the actions work correctly
+        when resolving dependencies."""
 
-                m1_path = self.make_manifest(self.simple_variant_deps)
-                m2_path = self.make_manifest(self.simple_v_deps_bar)
-                m3_path = self.make_manifest(self.simple_v_deps_baz)
-                p2_name = "s-v-bar"
-                p3_name = "s-v-baz"
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([m1_path, m2_path, m3_path],
-                        self.api_obj, ["*"])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                for d in pkg_deps[m1_path]:
-                        if d.attrs["fmri"] == "pkg:/s-v-bar":
-                                self.assertEqual(
-                                    d.attrs["variant.foo"],
-                                    "bar")
-                        elif d.attrs["fmri"] == "pkg:/s-v-baz":
-                                self.assertEqual(
-                                    d.attrs["variant.foo"],
-                                    "baz")
-                        else:
-                                raise RuntimeError("Unexpected fmri {0} "
-                                    "for dependency {1}".format(
-                                    d.attrs["fmri"], d))
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join([
-                            "{0}".format(e,) for e in errs])))
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[m1_path]), 2)
-                self.assertEqual(len(pkg_deps[m2_path]), 0)
-                self.assertEqual(len(pkg_deps[m3_path]), 0)
+        m1_path = self.make_manifest(self.simple_variant_deps)
+        m2_path = self.make_manifest(self.simple_v_deps_bar)
+        m3_path = self.make_manifest(self.simple_v_deps_baz)
+        p2_name = "s-v-bar"
+        p3_name = "s-v-baz"
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [m1_path, m2_path, m3_path], self.api_obj, ["*"]
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        for d in pkg_deps[m1_path]:
+            if d.attrs["fmri"] == "pkg:/s-v-bar":
+                self.assertEqual(d.attrs["variant.foo"], "bar")
+            elif d.attrs["fmri"] == "pkg:/s-v-baz":
+                self.assertEqual(d.attrs["variant.foo"], "baz")
+            else:
+                raise RuntimeError(
+                    "Unexpected fmri {0} "
+                    "for dependency {1}".format(d.attrs["fmri"], d)
+                )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(
+                        [
+                            "{0}".format(
+                                e,
+                            )
+                            for e in errs
+                        ]
+                    )
+                )
+            )
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[m1_path]), 2)
+        self.assertEqual(len(pkg_deps[m2_path]), 0)
+        self.assertEqual(len(pkg_deps[m3_path]), 0)
 
-        def test_simple_variants_2 (self):
-                """Test that variants declared on the packages work correctly
-                when resolving dependencies."""
+    def test_simple_variants_2(self):
+        """Test that variants declared on the packages work correctly
+        when resolving dependencies."""
 
-                m1_path = self.make_manifest(self.simple_variant_deps)
-                m2_path = self.make_manifest(self.simple_v_deps_bar2)
-                m3_path = self.make_manifest(self.simple_v_deps_baz2)
-                p2_name = "s-v-bar"
-                p3_name = "s-v-baz"
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([m1_path, m2_path, m3_path],
-                        self.api_obj, ["*"])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[m1_path]), 2)
-                self.assertEqual(len(pkg_deps[m2_path]), 0)
-                self.assertEqual(len(pkg_deps[m3_path]), 0)
-                self.assertEqual(len(errs), 0)
-                for d in pkg_deps[m1_path]:
-                        if d.attrs["fmri"] == "pkg:/s-v-bar":
-                                self.assertEqual(
-                                    d.attrs["variant.foo"],
-                                    "bar")
-                        elif d.attrs["fmri"] == "pkg:/s-v-baz":
-                                self.assertEqual(
-                                    d.attrs["variant.foo"],
-                                    "baz")
-                        else:
-                                raise RuntimeError("Unexpected fmri {0} "
-                                    "for dependency {1}".format(
-                                    d.attrs["fmri"], d))
+        m1_path = self.make_manifest(self.simple_variant_deps)
+        m2_path = self.make_manifest(self.simple_v_deps_bar2)
+        m3_path = self.make_manifest(self.simple_v_deps_baz2)
+        p2_name = "s-v-bar"
+        p3_name = "s-v-baz"
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [m1_path, m2_path, m3_path], self.api_obj, ["*"]
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[m1_path]), 2)
+        self.assertEqual(len(pkg_deps[m2_path]), 0)
+        self.assertEqual(len(pkg_deps[m3_path]), 0)
+        self.assertEqual(len(errs), 0)
+        for d in pkg_deps[m1_path]:
+            if d.attrs["fmri"] == "pkg:/s-v-bar":
+                self.assertEqual(d.attrs["variant.foo"], "bar")
+            elif d.attrs["fmri"] == "pkg:/s-v-baz":
+                self.assertEqual(d.attrs["variant.foo"], "baz")
+            else:
+                raise RuntimeError(
+                    "Unexpected fmri {0} "
+                    "for dependency {1}".format(d.attrs["fmri"], d)
+                )
 
-        def test_two_variants (self):
-                """Test that variants declared on the packages work correctly
-                when resolving dependencies."""
+    def test_two_variants(self):
+        """Test that variants declared on the packages work correctly
+        when resolving dependencies."""
 
-                m1_path = self.make_manifest(self.two_variant_deps)
-                m2_path = self.make_manifest(self.two_v_deps_bar)
-                m3_path = self.make_manifest(self.two_v_deps_baz_one)
-                m4_path = self.make_manifest(self.two_v_deps_baz_two)
-                p2_name = "s-v-bar"
-                p3_name = "s-v-baz-one"
-                p4_name = "s-v-baz-two"
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [m1_path, m2_path, m3_path, m4_path], self.api_obj,
-                        ["*"])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 4)
-                # This is 5 because the variant.num values are not collapsed
-                # like they could be.
-                self.assertEqual(len(pkg_deps[m1_path]), 3)
-                self.assertEqual(len(pkg_deps[m2_path]), 0)
-                self.assertEqual(len(pkg_deps[m3_path]), 0)
-                self.assertEqual(len(pkg_deps[m4_path]), 0)
-                self.assertEqual(len(errs), 1)
-                for d in pkg_deps[m1_path]:
-                        if d.attrs["fmri"] == "pkg:/s-v-bar":
-                                self.assertEqual(
-                                    d.attrs["variant.foo"],
-                                    "bar")
-                                self.assertTrue("variant.num" not in d.attrs)
-                        elif d.attrs["fmri"] == "pkg:/s-v-baz-one":
-                                self.assertEqual(
-                                    d.attrs["variant.foo"],
-                                    "baz")
-                                self.assertEqual(
-                                    d.attrs["variant.num"],
-                                    "one")
-                        elif d.attrs["fmri"] == "pkg:/s-v-baz-two":
-                                self.assertEqual(
-                                    d.attrs["variant.foo"],
-                                    "baz")
-                                self.assertEqual(
-                                    d.attrs["variant.num"],
-                                    "two")
-                        else:
-                                raise RuntimeError("Unexpected fmri {0} "
-                                    "for dependency {1}".format(
-                                    d.attrs["fmri"], d))
+        m1_path = self.make_manifest(self.two_variant_deps)
+        m2_path = self.make_manifest(self.two_v_deps_bar)
+        m3_path = self.make_manifest(self.two_v_deps_baz_one)
+        m4_path = self.make_manifest(self.two_v_deps_baz_two)
+        p2_name = "s-v-bar"
+        p3_name = "s-v-baz-one"
+        p4_name = "s-v-baz-two"
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [m1_path, m2_path, m3_path, m4_path], self.api_obj, ["*"]
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 4)
+        # This is 5 because the variant.num values are not collapsed
+        # like they could be.
+        self.assertEqual(len(pkg_deps[m1_path]), 3)
+        self.assertEqual(len(pkg_deps[m2_path]), 0)
+        self.assertEqual(len(pkg_deps[m3_path]), 0)
+        self.assertEqual(len(pkg_deps[m4_path]), 0)
+        self.assertEqual(len(errs), 1)
+        for d in pkg_deps[m1_path]:
+            if d.attrs["fmri"] == "pkg:/s-v-bar":
+                self.assertEqual(d.attrs["variant.foo"], "bar")
+                self.assertTrue("variant.num" not in d.attrs)
+            elif d.attrs["fmri"] == "pkg:/s-v-baz-one":
+                self.assertEqual(d.attrs["variant.foo"], "baz")
+                self.assertEqual(d.attrs["variant.num"], "one")
+            elif d.attrs["fmri"] == "pkg:/s-v-baz-two":
+                self.assertEqual(d.attrs["variant.foo"], "baz")
+                self.assertEqual(d.attrs["variant.num"], "two")
+            else:
+                raise RuntimeError(
+                    "Unexpected fmri {0} "
+                    "for dependency {1}".format(d.attrs["fmri"], d)
+                )
 
-        def test_multi_file_dependencies(self):
-                """This checks manifests with multiple files, both with
-                pkg.debug.depend.file/path combinations, as well as
-                with pkg.debug.depend.fullpath lists."""
-                def __check_results(pkg_deps, errs, unused_fmris, external_deps,
-                    exp_pkg, no_deps, one_dep):
-                        if errs:
-                                raise RuntimeError("Got the following "
-                                    "unexpected errors:\n{0}".format(
-                                    "\n".join([str(e) for e in errs])))
-                        self.assertEqualDiff(set(), unused_fmris)
-                        self.assertEqualDiff(set(), external_deps)
-                        self.assertEqual(len(pkg_deps), 2)
-                        self.assertEqual(len(pkg_deps[no_deps]), 0)
-                        if len(pkg_deps[one_dep]) != 1:
-                                raise RuntimeError("Got more than one "
-                                    "dependency:\n{0}".format(
-                                    "\n".join(
-                                        [str(d) for d in pkg_deps[one_dep]])))
-                        d = pkg_deps[one_dep][0]
-                        self.assertEqual(d.attrs["fmri"], exp_pkg)
-                        self.assertEqual(d.attrs["type"], "require",
-                            "Dependency was:{0}".format(d))
+    def test_multi_file_dependencies(self):
+        """This checks manifests with multiple files, both with
+        pkg.debug.depend.file/path combinations, as well as
+        with pkg.debug.depend.fullpath lists."""
 
-                col_path = self.make_manifest(self.multi_file_dep_manf)
-                # the following manifest is logically equivalent to col_path
-                col_fullpath_path = self.make_manifest(self.multi_file_dep_manf)
-                # This manifest provides two files that satisfy col*_path's
-                # file dependencies.
-                both_path = self.make_manifest(self.multi_file_sat_both)
-                # This manifest provides a file that satisfies the dependency
-                # in col*_path by delivering a py or pyc file..
-                py_path = self.make_manifest(self.multi_file_sat_py)
-                pyc_path = self.make_manifest(self.multi_file_sat_pyc)
+        def __check_results(
+            pkg_deps,
+            errs,
+            unused_fmris,
+            external_deps,
+            exp_pkg,
+            no_deps,
+            one_dep,
+        ):
+            if errs:
+                raise RuntimeError(
+                    "Got the following "
+                    "unexpected errors:\n{0}".format(
+                        "\n".join([str(e) for e in errs])
+                    )
+                )
+            self.assertEqualDiff(set(), unused_fmris)
+            self.assertEqualDiff(set(), external_deps)
+            self.assertEqual(len(pkg_deps), 2)
+            self.assertEqual(len(pkg_deps[no_deps]), 0)
+            if len(pkg_deps[one_dep]) != 1:
+                raise RuntimeError(
+                    "Got more than one "
+                    "dependency:\n{0}".format(
+                        "\n".join([str(d) for d in pkg_deps[one_dep]])
+                    )
+                )
+            d = pkg_deps[one_dep][0]
+            self.assertEqual(d.attrs["fmri"], exp_pkg)
+            self.assertEqual(
+                d.attrs["type"], "require", "Dependency was:{0}".format(d)
+            )
 
-                # The following tests should all succeed because either the same
-                # package delivers both files which could satisfy the dependency
-                # or only one package which delivers the dependency is being
-                # resolved against.
-                for mf_path in [col_path, col_fullpath_path]:
-                        pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                            dependencies.resolve_deps([mf_path, both_path],
-                                self.api_obj, ["*"])
-                        __check_results(pkg_deps, errs, unused_fmris,
-                            external_deps, "pkg:/sat_both", both_path, mf_path)
+        col_path = self.make_manifest(self.multi_file_dep_manf)
+        # the following manifest is logically equivalent to col_path
+        col_fullpath_path = self.make_manifest(self.multi_file_dep_manf)
+        # This manifest provides two files that satisfy col*_path's
+        # file dependencies.
+        both_path = self.make_manifest(self.multi_file_sat_both)
+        # This manifest provides a file that satisfies the dependency
+        # in col*_path by delivering a py or pyc file..
+        py_path = self.make_manifest(self.multi_file_sat_py)
+        pyc_path = self.make_manifest(self.multi_file_sat_pyc)
 
-                        pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                            dependencies.resolve_deps([mf_path, py_path],
-                                self.api_obj, ["*"])
-                        __check_results(pkg_deps, errs, unused_fmris,
-                            external_deps, "pkg:/sat_py", py_path, mf_path)
+        # The following tests should all succeed because either the same
+        # package delivers both files which could satisfy the dependency
+        # or only one package which delivers the dependency is being
+        # resolved against.
+        for mf_path in [col_path, col_fullpath_path]:
+            (
+                pkg_deps,
+                errs,
+                warnings,
+                unused_fmris,
+                external_deps,
+            ) = dependencies.resolve_deps(
+                [mf_path, both_path], self.api_obj, ["*"]
+            )
+            __check_results(
+                pkg_deps,
+                errs,
+                unused_fmris,
+                external_deps,
+                "pkg:/sat_both",
+                both_path,
+                mf_path,
+            )
 
-                        pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                            dependencies.resolve_deps([mf_path, pyc_path],
-                                self.api_obj, ["*"])
-                        __check_results(pkg_deps, errs, unused_fmris,
-                            external_deps, "pkg:/sat_pyc", pyc_path, mf_path)
+            (
+                pkg_deps,
+                errs,
+                warnings,
+                unused_fmris,
+                external_deps,
+            ) = dependencies.resolve_deps(
+                [mf_path, py_path], self.api_obj, ["*"]
+            )
+            __check_results(
+                pkg_deps,
+                errs,
+                unused_fmris,
+                external_deps,
+                "pkg:/sat_py",
+                py_path,
+                mf_path,
+            )
 
-                        # This resolution should produce require-any
-                        # dependencies because files which satisfy the
-                        # dependency are delivered in two packages.
-                        pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                            dependencies.resolve_deps([mf_path, py_path, pyc_path],
-                                self.api_obj, ["*"])
-                        self.assertEqual(len(pkg_deps), 3)
-                        if len(errs) != 0:
-                                raise RuntimeError("Unexpected errors:\n{0}".format(
-                                    "\n".join(str(e) for e in errs)))
-                        self.assertEqualDiff(set(), unused_fmris)
-                        self.assertEqualDiff(set(), external_deps)
-                        self.assertEqual(len(pkg_deps[py_path]), 0)
-                        self.assertEqual(len(pkg_deps[pyc_path]), 0)
-                        self.assertEqual(len(pkg_deps[mf_path]), 1,
-                            "Didn't get one dependency:\n{0}".format(
-                            "\n".join([str(d) for d in pkg_deps[mf_path]])))
-                        d = pkg_deps[mf_path][0]
-                        self.assertEqual(d.attrs["type"], "require-any")
-                        self.assertEqual(set(d.attrs["fmri"]),
-                            set(["pkg:/sat_py", "pkg:/sat_pyc"]))
+            (
+                pkg_deps,
+                errs,
+                warnings,
+                unused_fmris,
+                external_deps,
+            ) = dependencies.resolve_deps(
+                [mf_path, pyc_path], self.api_obj, ["*"]
+            )
+            __check_results(
+                pkg_deps,
+                errs,
+                unused_fmris,
+                external_deps,
+                "pkg:/sat_pyc",
+                pyc_path,
+                mf_path,
+            )
 
-                        pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                            dependencies.resolve_deps(
-                                [both_path, mf_path, py_path, pyc_path],
-                                self.api_obj, ["*"])
-                        self.assertEqual(len(pkg_deps), 4)
-                        if len(errs) != 0:
-                                raise RuntimeError("Unexpected errors:\n{0}".format(
-                                    "\n".join(str(e) for e in errs)))
-                        self.assertEqualDiff(set(), unused_fmris)
-                        self.assertEqualDiff(set(), external_deps)
-                        self.assertEqual(len(pkg_deps[py_path]), 0)
-                        self.assertEqual(len(pkg_deps[both_path]), 0)
-                        self.assertEqual(len(pkg_deps[pyc_path]), 0)
-                        self.assertEqual(len(pkg_deps[mf_path]), 1,
-                            "Didn't get one dependency:\n{0}".format(
-                            "\n".join([str(d) for d in pkg_deps[mf_path]])))
-                        d = pkg_deps[mf_path][0]
-                        self.assertEqual(d.attrs["type"], "require-any")
-                        self.assertEqual(set(d.attrs["fmri"]), set(
-                            ["pkg:/sat_py", "pkg:/sat_pyc", "pkg:/sat_both"]))
+            # This resolution should produce require-any
+            # dependencies because files which satisfy the
+            # dependency are delivered in two packages.
+            (
+                pkg_deps,
+                errs,
+                warnings,
+                unused_fmris,
+                external_deps,
+            ) = dependencies.resolve_deps(
+                [mf_path, py_path, pyc_path], self.api_obj, ["*"]
+            )
+            self.assertEqual(len(pkg_deps), 3)
+            if len(errs) != 0:
+                raise RuntimeError(
+                    "Unexpected errors:\n{0}".format(
+                        "\n".join(str(e) for e in errs)
+                    )
+                )
+            self.assertEqualDiff(set(), unused_fmris)
+            self.assertEqualDiff(set(), external_deps)
+            self.assertEqual(len(pkg_deps[py_path]), 0)
+            self.assertEqual(len(pkg_deps[pyc_path]), 0)
+            self.assertEqual(
+                len(pkg_deps[mf_path]),
+                1,
+                "Didn't get one dependency:\n{0}".format(
+                    "\n".join([str(d) for d in pkg_deps[mf_path]])
+                ),
+            )
+            d = pkg_deps[mf_path][0]
+            self.assertEqual(d.attrs["type"], "require-any")
+            self.assertEqual(
+                set(d.attrs["fmri"]), set(["pkg:/sat_py", "pkg:/sat_pyc"])
+            )
 
-        def test_bug_11518(self):
-                """Test that resolving against an installed, cached, manifest
-                works with variants."""
+            (
+                pkg_deps,
+                errs,
+                warnings,
+                unused_fmris,
+                external_deps,
+            ) = dependencies.resolve_deps(
+                [both_path, mf_path, py_path, pyc_path], self.api_obj, ["*"]
+            )
+            self.assertEqual(len(pkg_deps), 4)
+            if len(errs) != 0:
+                raise RuntimeError(
+                    "Unexpected errors:\n{0}".format(
+                        "\n".join(str(e) for e in errs)
+                    )
+                )
+            self.assertEqualDiff(set(), unused_fmris)
+            self.assertEqualDiff(set(), external_deps)
+            self.assertEqual(len(pkg_deps[py_path]), 0)
+            self.assertEqual(len(pkg_deps[both_path]), 0)
+            self.assertEqual(len(pkg_deps[pyc_path]), 0)
+            self.assertEqual(
+                len(pkg_deps[mf_path]),
+                1,
+                "Didn't get one dependency:\n{0}".format(
+                    "\n".join([str(d) for d in pkg_deps[mf_path]])
+                ),
+            )
+            d = pkg_deps[mf_path][0]
+            self.assertEqual(d.attrs["type"], "require-any")
+            self.assertEqual(
+                set(d.attrs["fmri"]),
+                set(["pkg:/sat_py", "pkg:/sat_pyc", "pkg:/sat_both"]),
+            )
 
-                self.pkgsend_bulk(self.rurl, self.var_pkg)
-                self.api_obj.refresh(immediate=True)
-                self._api_install(self.api_obj, ["variant_pkg"])
+    def test_bug_11518(self):
+        """Test that resolving against an installed, cached, manifest
+        works with variants."""
 
-                m1_path = self.make_manifest(self.simp_manf)
-                p2_name = "pkg:/variant_pkg@1.0-0"
+        self.pkgsend_bulk(self.rurl, self.var_pkg)
+        self.api_obj.refresh(immediate=True)
+        self._api_install(self.api_obj, ["variant_pkg"])
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([m1_path], self.api_obj, ["*"])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["variant_pkg"]), external_deps)
-                self.assertEqual(len(pkg_deps), 1)
-                self.assertEqual(len(pkg_deps[m1_path]), 1)
-                self.assertEqual(len(errs), 0)
-                for d in pkg_deps[m1_path]:
-                        if d.attrs["fmri"] == p2_name:
-                                self.assertEqual(
-                                    d.attrs["{0}.file".format(self.depend_dp)],
-                                    ["var/log/syslog"])
-                        else:
-                                raise RuntimeError("Was expecting {0}, got fmri "
-                                    "{1} for dependency {2}".format(
-                                    p2_name, d.attrs["fmri"], d))
+        m1_path = self.make_manifest(self.simp_manf)
+        p2_name = "pkg:/variant_pkg@1.0-0"
 
-        def test_bug_12697_and_12896(self):
-                """Test that pkgdep resolve handles multiple run path
-                dependencies correctly when the files are delivered in the same
-                package and when the files are delivered in different packages.
-                """
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([m1_path], self.api_obj, ["*"])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["variant_pkg"]), external_deps)
+        self.assertEqual(len(pkg_deps), 1)
+        self.assertEqual(len(pkg_deps[m1_path]), 1)
+        self.assertEqual(len(errs), 0)
+        for d in pkg_deps[m1_path]:
+            if d.attrs["fmri"] == p2_name:
+                self.assertEqual(
+                    d.attrs["{0}.file".format(self.depend_dp)],
+                    ["var/log/syslog"],
+                )
+            else:
+                raise RuntimeError(
+                    "Was expecting {0}, got fmri "
+                    "{1} for dependency {2}".format(p2_name, d.attrs["fmri"], d)
+                )
 
-                def __check_results(pkg_deps, errs, unused_fmris, external_deps,
-                    exp_pkg, no_deps, one_dep):
-                        if errs:
-                                raise RuntimeError("Got the following "
-                                    "unexpected errors:\n{0}".format(
-                                    "\n".join([str(e) for e in errs])))
-                        self.assertEqualDiff(set(), unused_fmris)
-                        self.assertEqualDiff(set(), external_deps)
-                        self.assertEqual(len(pkg_deps), 2)
-                        self.assertEqual(len(pkg_deps[no_deps]), 0)
-                        if len(pkg_deps[one_dep]) != 1:
-                                raise RuntimeError("Got more than one "
-                                    "dependency:\n{0}".format(
-                                    "\n".join(
-                                        [str(d) for d in pkg_deps[col_path]])))
-                        d = pkg_deps[one_dep][0]
-                        self.assertEqual(d.attrs["fmri"], exp_pkg,
-                            "Expected dependency {0}; found {1}.".format(exp_pkg,
-                                d.attrs["fmri"]))
+    def test_bug_12697_and_12896(self):
+        """Test that pkgdep resolve handles multiple run path
+        dependencies correctly when the files are delivered in the same
+        package and when the files are delivered in different packages.
+        """
 
-                col_path = self.make_manifest(self.collision_manf)
-                col_path_num_var = self.make_manifest(
-                    self.collision_manf_num_var)
-                # This manifest provides both files that satisfy col_path's
-                # dependencies.
-                both_path = self.make_manifest(self.sat_both)
-                # This manifest provides a file that satisfies the dependency
-                # in col_path by delivering a file in patform/bar/baz/.
-                bar_path = self.make_manifest(self.sat_bar_libc)
-                bar2_path = self.make_manifest(self.sat_bar_libc2)
-                # This manifest provides a file that satisfies the dependency
-                # in col_path by delivering a file in patform/foo/baz/.
-                foo_path = self.make_manifest(self.sat_foo_libc)
-                # This manifest provides a file that satisfies the dependency
-                # in col_path by delivering a file in patform/bar/baz/, but that
-                # file is tagged with variant.num=one.
-                bar_path_num_var = self.make_manifest(self.sat_bar_libc_num_var)
-                # This manifest provides a file that satisfies the dependency
-                # in col_path by delivering a file in patform/foo/baz/, but that
-                # file is tagged with variant.num=two.
-                foo_path_num_var = self.make_manifest(self.sat_foo_libc_num_var)
-                # This manifest provides a file that satisfies the dependency
-                # in col_path by delivering a file in patform/foo/baz/, but that
-                # file is tagged with variant.num=one and variant.num=two.
-                foo_path_num_var_both = self.make_manifest(
-                    self.sat_foo_libc_num_var_both)
+        def __check_results(
+            pkg_deps,
+            errs,
+            unused_fmris,
+            external_deps,
+            exp_pkg,
+            no_deps,
+            one_dep,
+        ):
+            if errs:
+                raise RuntimeError(
+                    "Got the following "
+                    "unexpected errors:\n{0}".format(
+                        "\n".join([str(e) for e in errs])
+                    )
+                )
+            self.assertEqualDiff(set(), unused_fmris)
+            self.assertEqualDiff(set(), external_deps)
+            self.assertEqual(len(pkg_deps), 2)
+            self.assertEqual(len(pkg_deps[no_deps]), 0)
+            if len(pkg_deps[one_dep]) != 1:
+                raise RuntimeError(
+                    "Got more than one "
+                    "dependency:\n{0}".format(
+                        "\n".join([str(d) for d in pkg_deps[col_path]])
+                    )
+                )
+            d = pkg_deps[one_dep][0]
+            self.assertEqual(
+                d.attrs["fmri"],
+                exp_pkg,
+                "Expected dependency {0}; found {1}.".format(
+                    exp_pkg, d.attrs["fmri"]
+                ),
+            )
 
-                # The following tests should all succeed because either the same
-                # package delivers both files which could satisfy the dependency
-                # or only one package which delivers the dependency is being
-                # resolved against.
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([col_path, both_path],
-                        self.api_obj, ["*"])
-                __check_results(pkg_deps, errs, unused_fmris, external_deps,
-                    "pkg:/sat_both", both_path, col_path)
+        col_path = self.make_manifest(self.collision_manf)
+        col_path_num_var = self.make_manifest(self.collision_manf_num_var)
+        # This manifest provides both files that satisfy col_path's
+        # dependencies.
+        both_path = self.make_manifest(self.sat_both)
+        # This manifest provides a file that satisfies the dependency
+        # in col_path by delivering a file in patform/bar/baz/.
+        bar_path = self.make_manifest(self.sat_bar_libc)
+        bar2_path = self.make_manifest(self.sat_bar_libc2)
+        # This manifest provides a file that satisfies the dependency
+        # in col_path by delivering a file in patform/foo/baz/.
+        foo_path = self.make_manifest(self.sat_foo_libc)
+        # This manifest provides a file that satisfies the dependency
+        # in col_path by delivering a file in patform/bar/baz/, but that
+        # file is tagged with variant.num=one.
+        bar_path_num_var = self.make_manifest(self.sat_bar_libc_num_var)
+        # This manifest provides a file that satisfies the dependency
+        # in col_path by delivering a file in patform/foo/baz/, but that
+        # file is tagged with variant.num=two.
+        foo_path_num_var = self.make_manifest(self.sat_foo_libc_num_var)
+        # This manifest provides a file that satisfies the dependency
+        # in col_path by delivering a file in patform/foo/baz/, but that
+        # file is tagged with variant.num=one and variant.num=two.
+        foo_path_num_var_both = self.make_manifest(
+            self.sat_foo_libc_num_var_both
+        )
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([col_path, bar_path],
-                        self.api_obj, ["*"])
-                __check_results(pkg_deps, errs, unused_fmris, external_deps,
-                    "pkg:/sat_bar_libc", bar_path, col_path)
+        # The following tests should all succeed because either the same
+        # package delivers both files which could satisfy the dependency
+        # or only one package which delivers the dependency is being
+        # resolved against.
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [col_path, both_path], self.api_obj, ["*"]
+        )
+        __check_results(
+            pkg_deps,
+            errs,
+            unused_fmris,
+            external_deps,
+            "pkg:/sat_both",
+            both_path,
+            col_path,
+        )
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([col_path, foo_path],
-                        self.api_obj, ["*"])
-                __check_results(pkg_deps, errs, unused_fmris, external_deps,
-                    "pkg:/sat_foo_libc", foo_path, col_path)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([col_path, bar_path], self.api_obj, ["*"])
+        __check_results(
+            pkg_deps,
+            errs,
+            unused_fmris,
+            external_deps,
+            "pkg:/sat_bar_libc",
+            bar_path,
+            col_path,
+        )
 
-                # This test should also pass because the dependencies will be
-                # variant tagged, just as the file delivery is.
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [col_path_num_var, foo_path_num_var, bar_path_num_var],
-                        self.api_obj, ["*"])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format(
-                            "\n".join([str(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[foo_path_num_var]), 0)
-                self.assertEqual(len(pkg_deps[bar_path_num_var]), 0)
-                self.assertEqual(len(pkg_deps[col_path_num_var]), 2)
-                for d in pkg_deps[col_path_num_var]:
-                        if d.attrs["fmri"] not in \
-                            ("pkg:/sat_foo_libc", "pkg:/sat_bar_libc"):
-                                raise RuntimeError("Unexpected fmri in {0}".format(d))
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([col_path, foo_path], self.api_obj, ["*"])
+        __check_results(
+            pkg_deps,
+            errs,
+            unused_fmris,
+            external_deps,
+            "pkg:/sat_foo_libc",
+            foo_path,
+            col_path,
+        )
 
-                # This resolution should result in two, varianted, dependencies.
-                # The first should have variant.num=one and a type of
-                # require-any because in that case files which satisfy the
-                # dependency are delivered in two packages.  The other
-                # dependency should be a require dependency with
-                # variant.num=two.
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                    [col_path_num_var, foo_path_num_var_both, bar_path_num_var],
-                    self.api_obj, ["*"])
-                self.assertEqual(len(pkg_deps), 3)
-                if len(errs) != 0:
-                        raise RuntimeError("Got an unexpected error:\n{0}".format(
-                            "\n".join(str(e) for e in errs)))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps[foo_path_num_var_both]), 0)
-                self.assertEqual(len(pkg_deps[bar_path_num_var]), 0)
-                self.assertEqual(len(pkg_deps[col_path_num_var]), 2)
-                have_req_any = False
-                have_require = False
-                for d in pkg_deps[col_path_num_var]:
-                        if d.attrs["type"] == "require-any" and \
-                            set(d.attrs["fmri"]) == \
-                            set(["pkg:/sat_foo_libc", "pkg:/sat_bar_libc"]) and\
-                            d.attrs["variant.num"] == "one":
-                                have_req_any = True
-                        elif d.attrs["type"] == "require" and \
-                            d.attrs["fmri"] == "pkg:/sat_foo_libc" and \
-                            d.attrs["variant.num"] == "two":
-                                have_require = True
-                        else:
-                                raise RuntimeError("Unexpected dependency:{0}".format(
-                                    d))
-                self.assertTrue(have_req_any)
-                self.assertTrue(have_require)
+        # This test should also pass because the dependencies will be
+        # variant tagged, just as the file delivery is.
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [col_path_num_var, foo_path_num_var, bar_path_num_var],
+            self.api_obj,
+            ["*"],
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format("\n".join([str(e) for e in errs]))
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[foo_path_num_var]), 0)
+        self.assertEqual(len(pkg_deps[bar_path_num_var]), 0)
+        self.assertEqual(len(pkg_deps[col_path_num_var]), 2)
+        for d in pkg_deps[col_path_num_var]:
+            if d.attrs["fmri"] not in (
+                "pkg:/sat_foo_libc",
+                "pkg:/sat_bar_libc",
+            ):
+                raise RuntimeError("Unexpected fmri in {0}".format(d))
 
-                # This resolution should also produce a require-any dependency.
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([col_path, bar_path, foo_path],
-                        self.api_obj, ["*"])
-                self.assertEqual(len(pkg_deps), 3)
-                if len(errs) != 0:
-                        raise RuntimeError("Got an unexpected error:\n{0}".format(
-                            "\n".join(str(e) for e in errs)))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps[foo_path]), 0)
-                self.assertEqual(len(pkg_deps[bar_path]), 0)
-                self.assertEqual(len(pkg_deps[col_path]), 1)
-                d = pkg_deps[col_path][0]
-                self.assertEqual(d.attrs["type"], "require-any")
-                self.assertEqual(set(d.attrs["fmri"]),
-                    set(["pkg:/sat_bar_libc", "pkg:/sat_foo_libc"]))
+        # This resolution should result in two, varianted, dependencies.
+        # The first should have variant.num=one and a type of
+        # require-any because in that case files which satisfy the
+        # dependency are delivered in two packages.  The other
+        # dependency should be a require dependency with
+        # variant.num=two.
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [col_path_num_var, foo_path_num_var_both, bar_path_num_var],
+            self.api_obj,
+            ["*"],
+        )
+        self.assertEqual(len(pkg_deps), 3)
+        if len(errs) != 0:
+            raise RuntimeError(
+                "Got an unexpected error:\n{0}".format(
+                    "\n".join(str(e) for e in errs)
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps[foo_path_num_var_both]), 0)
+        self.assertEqual(len(pkg_deps[bar_path_num_var]), 0)
+        self.assertEqual(len(pkg_deps[col_path_num_var]), 2)
+        have_req_any = False
+        have_require = False
+        for d in pkg_deps[col_path_num_var]:
+            if (
+                d.attrs["type"] == "require-any"
+                and set(d.attrs["fmri"])
+                == set(["pkg:/sat_foo_libc", "pkg:/sat_bar_libc"])
+                and d.attrs["variant.num"] == "one"
+            ):
+                have_req_any = True
+            elif (
+                d.attrs["type"] == "require"
+                and d.attrs["fmri"] == "pkg:/sat_foo_libc"
+                and d.attrs["variant.num"] == "two"
+            ):
+                have_require = True
+            else:
+                raise RuntimeError("Unexpected dependency:{0}".format(d))
+        self.assertTrue(have_req_any)
+        self.assertTrue(have_require)
 
-                # This resolution should also produce a require-any dependency.
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([col_path, bar_path, bar2_path],
-                        self.api_obj, ["*"])
-                self.assertEqual(len(pkg_deps), 3)
-                if len(errs) != 0:
-                        raise RuntimeError("Got an unexpected error:\n{0}".format(
-                            "\n".join(str(e) for e in errs)))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps[bar2_path]), 0)
-                self.assertEqual(len(pkg_deps[bar_path]), 0)
-                self.assertEqual(len(pkg_deps[col_path]), 1)
-                d = pkg_deps[col_path][0]
-                self.assertEqual(d.attrs["type"], "require-any")
-                self.assertEqual(set(d.attrs["fmri"]),
-                    set(["pkg:/sat_bar_libc", "pkg:/sat_bar_libc2"]))
+        # This resolution should also produce a require-any dependency.
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [col_path, bar_path, foo_path], self.api_obj, ["*"]
+        )
+        self.assertEqual(len(pkg_deps), 3)
+        if len(errs) != 0:
+            raise RuntimeError(
+                "Got an unexpected error:\n{0}".format(
+                    "\n".join(str(e) for e in errs)
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps[foo_path]), 0)
+        self.assertEqual(len(pkg_deps[bar_path]), 0)
+        self.assertEqual(len(pkg_deps[col_path]), 1)
+        d = pkg_deps[col_path][0]
+        self.assertEqual(d.attrs["type"], "require-any")
+        self.assertEqual(
+            set(d.attrs["fmri"]),
+            set(["pkg:/sat_bar_libc", "pkg:/sat_foo_libc"]),
+        )
 
-        def test_bug_15647(self):
-                """Verify that in cases where both the provided manifests and
-                installed image provide a resolution for a given dependency
-                that the dependency is only resolved once for a given variant
-                and that the resolution provided by the manifests is used."""
+        # This resolution should also produce a require-any dependency.
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [col_path, bar_path, bar2_path], self.api_obj, ["*"]
+        )
+        self.assertEqual(len(pkg_deps), 3)
+        if len(errs) != 0:
+            raise RuntimeError(
+                "Got an unexpected error:\n{0}".format(
+                    "\n".join(str(e) for e in errs)
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps[bar2_path]), 0)
+        self.assertEqual(len(pkg_deps[bar_path]), 0)
+        self.assertEqual(len(pkg_deps[col_path]), 1)
+        d = pkg_deps[col_path][0]
+        self.assertEqual(d.attrs["type"], "require-any")
+        self.assertEqual(
+            set(d.attrs["fmri"]),
+            set(["pkg:/sat_bar_libc", "pkg:/sat_bar_libc2"]),
+        )
 
-                self.pkgsend_bulk(self.rurl, self.installed_double_provides)
-                self.api_obj.refresh(immediate=True)
-                self._api_install(self.api_obj, ["double_provides"])
+    def test_bug_15647(self):
+        """Verify that in cases where both the provided manifests and
+        installed image provide a resolution for a given dependency
+        that the dependency is only resolved once for a given variant
+        and that the resolution provided by the manifests is used."""
 
-                manifests = [self.make_manifest(x) for x in
-                    (self.newer_double_provides, self.double_deps)]
+        self.pkgsend_bulk(self.rurl, self.installed_double_provides)
+        self.api_obj.refresh(immediate=True)
+        self._api_install(self.api_obj, ["double_provides"])
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(manifests, self.api_obj, ["*"])
+        manifests = [
+            self.make_manifest(x)
+            for x in (self.newer_double_provides, self.double_deps)
+        ]
 
-                self.assertEqual(len(pkg_deps[manifests[1]]), 1)
-                for d in pkg_deps[manifests[1]]:
-                        fmri = PkgFmri(d.attrs["fmri"])
-                        if str(fmri).startswith("pkg:/double_provides"):
-                                self.assertEqual(str(fmri.version.branch), "1")
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(manifests, self.api_obj, ["*"])
 
-        def test_bug_16849(self):
-                """Test that when packages have bad fmris, or should resolve to
-                depend on packages with bad fmris, pkgdep provides a reasonable
-                error."""
+        self.assertEqual(len(pkg_deps[manifests[1]]), 1)
+        for d in pkg_deps[manifests[1]]:
+            fmri = PkgFmri(d.attrs["fmri"])
+            if str(fmri).startswith("pkg:/double_provides"):
+                self.assertEqual(str(fmri.version.branch), "1")
 
-                missing_build = self.make_manifest(
-                    self.bug_16849_missing_build_version)
-                corrupted_version = self.make_manifest(
-                    self.bug_16849_corrupted_version)
-                leading_zeros = self.make_manifest(
-                    self.bug_16849_leading_zeros)
-                depender = self.make_manifest(
-                    self.bug_16849_depender)
+    def test_bug_16849(self):
+        """Test that when packages have bad fmris, or should resolve to
+        depend on packages with bad fmris, pkgdep provides a reasonable
+        error."""
 
-                # This is a valid FMRI since bug 18243 was fixed.
-                self.pkgdepend_resolve("-m {0}".format(missing_build))
+        missing_build = self.make_manifest(self.bug_16849_missing_build_version)
+        corrupted_version = self.make_manifest(self.bug_16849_corrupted_version)
+        leading_zeros = self.make_manifest(self.bug_16849_leading_zeros)
+        depender = self.make_manifest(self.bug_16849_depender)
 
-                self.pkgdepend_resolve("-m {0}".format(corrupted_version), exit=1)
-                self.pkgdepend_resolve("-m {0}".format(leading_zeros), exit=1)
+        # This is a valid FMRI since bug 18243 was fixed.
+        self.pkgdepend_resolve("-m {0}".format(missing_build))
 
-                # This is a valid FMRI since bug 18243 was fixed.
-                self.pkgdepend_resolve("-m {0} {1}".format(depender, missing_build))
+        self.pkgdepend_resolve("-m {0}".format(corrupted_version), exit=1)
+        self.pkgdepend_resolve("-m {0}".format(leading_zeros), exit=1)
 
-                self.pkgdepend_resolve("-m {0} {1}".format(
-                    corrupted_version, depender), exit=1)
-                self.pkgdepend_resolve("-m {0} {1}".format(depender, leading_zeros),
-                    exit=1)
+        # This is a valid FMRI since bug 18243 was fixed.
+        self.pkgdepend_resolve("-m {0} {1}".format(depender, missing_build))
 
-        def test_bug_17700(self):
-                """Test that when multiple packages satisfy a dependency under
-                the same combination of two variants, that a require-any
-                dependency is produced."""
+        self.pkgdepend_resolve(
+            "-m {0} {1}".format(corrupted_version, depender), exit=1
+        )
+        self.pkgdepend_resolve(
+            "-m {0} {1}".format(depender, leading_zeros), exit=1
+        )
 
-                self.pkgsend_bulk(self.rurl, self.installed_17700_res1)
-                self.pkgsend_bulk(self.rurl, self.installed_17700_res2)
-                self.api_obj.refresh(immediate=True)
-                self._api_install(self.api_obj, ["system/kernel",
-                    "system/kernel/platform"])
-                dep_path = self.make_manifest(self.bug_17700_dep)
-                res1_path = self.make_manifest(self.bug_17700_res1)
-                res2_path = self.make_manifest(self.bug_17700_res2)
+    def test_bug_17700(self):
+        """Test that when multiple packages satisfy a dependency under
+        the same combination of two variants, that a require-any
+        dependency is produced."""
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path, res1_path, res2_path],
-                        self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 3)
-                if len(errs) != 0:
-                        raise RuntimeError("Got an unexpected error:\n{0}".format(
-                            "\n".join(str(e) for e in errs)))
-                self.assertEqual(len(pkg_deps[res1_path]), 0)
-                self.assertEqual(len(pkg_deps[res2_path]), 0)
-                self.assertEqual(len(pkg_deps[dep_path]), 1)
-                d = pkg_deps[dep_path][0]
-                self.assertEqual(d.attrs["type"], "require-any")
-                self.assertEqual(set(d.attrs["fmri"]), set([
+        self.pkgsend_bulk(self.rurl, self.installed_17700_res1)
+        self.pkgsend_bulk(self.rurl, self.installed_17700_res2)
+        self.api_obj.refresh(immediate=True)
+        self._api_install(
+            self.api_obj, ["system/kernel", "system/kernel/platform"]
+        )
+        dep_path = self.make_manifest(self.bug_17700_dep)
+        res1_path = self.make_manifest(self.bug_17700_res1)
+        res2_path = self.make_manifest(self.bug_17700_res2)
+
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [dep_path, res1_path, res2_path], self.api_obj, []
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 3)
+        if len(errs) != 0:
+            raise RuntimeError(
+                "Got an unexpected error:\n{0}".format(
+                    "\n".join(str(e) for e in errs)
+                )
+            )
+        self.assertEqual(len(pkg_deps[res1_path]), 0)
+        self.assertEqual(len(pkg_deps[res2_path]), 0)
+        self.assertEqual(len(pkg_deps[dep_path]), 1)
+        d = pkg_deps[dep_path][0]
+        self.assertEqual(d.attrs["type"], "require-any")
+        self.assertEqual(
+            set(d.attrs["fmri"]),
+            set(
+                [
                     "pkg:/system/kernel@1.0-1",
-                    "pkg:/system/kernel/platform@1.0-1"]))
+                    "pkg:/system/kernel/platform@1.0-1",
+                ]
+            ),
+        )
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path, res1_path, res2_path],
-                        self.api_obj, ["*"])
-                self.assertEqual(len(pkg_deps), 3)
-                if len(errs) != 0:
-                        raise RuntimeError("Got an unexpected error:\n{0}".format(
-                            "\n".join(str(e) for e in errs)))
-                self.assertEqual(len(pkg_deps[res1_path]), 0)
-                self.assertEqual(len(pkg_deps[res2_path]), 0)
-                self.assertEqual(len(pkg_deps[dep_path]), 1)
-                d = pkg_deps[dep_path][0]
-                self.assertEqual(d.attrs["type"], "require-any")
-                self.assertEqual(set(d.attrs["fmri"]), set([
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [dep_path, res1_path, res2_path], self.api_obj, ["*"]
+        )
+        self.assertEqual(len(pkg_deps), 3)
+        if len(errs) != 0:
+            raise RuntimeError(
+                "Got an unexpected error:\n{0}".format(
+                    "\n".join(str(e) for e in errs)
+                )
+            )
+        self.assertEqual(len(pkg_deps[res1_path]), 0)
+        self.assertEqual(len(pkg_deps[res2_path]), 0)
+        self.assertEqual(len(pkg_deps[dep_path]), 1)
+        d = pkg_deps[dep_path][0]
+        self.assertEqual(d.attrs["type"], "require-any")
+        self.assertEqual(
+            set(d.attrs["fmri"]),
+            set(
+                [
                     "pkg:/system/kernel@1.0-1",
-                    "pkg:/system/kernel/platform@1.0-1"]))
+                    "pkg:/system/kernel/platform@1.0-1",
+                ]
+            ),
+        )
 
-        def test_bug_17756(self):
-                """Test that when a package has manually specified dependencies
-                which have a variant that's not set on the package or generates
-                file dependencies with a variant that's not set on the package,
-                pkgdepend resolve handles the error and displays it
-                correctly."""
+    def test_bug_17756(self):
+        """Test that when a package has manually specified dependencies
+        which have a variant that's not set on the package or generates
+        file dependencies with a variant that's not set on the package,
+        pkgdepend resolve handles the error and displays it
+        correctly."""
 
-                def __check_generated(e):
-                        self.assertEqual("test17756", e.pkg.pkg_name)
-                        self.assertEqual(["usr/bin/foo", "usr/bin/ls"],
-                            sorted(e.rvs.keys()))
-                        d = e.rvs["usr/bin/foo"]
-                        self.assertEqual(set(), d.type_diffs)
-                        self.assertEqual(set([("variant.num", "two")]),
-                            d.value_diffs)
-                        d = e.rvs["usr/bin/ls"]
-                        self.assertEqual(set(["variant.foo"]), d.type_diffs)
-                        self.assertEqual(set(
-                            [("variant.num", "two"), ("variant.num", "three")]),
-                            d.value_diffs)
-                        str(e)
+        def __check_generated(e):
+            self.assertEqual("test17756", e.pkg.pkg_name)
+            self.assertEqual(
+                ["usr/bin/foo", "usr/bin/ls"], sorted(e.rvs.keys())
+            )
+            d = e.rvs["usr/bin/foo"]
+            self.assertEqual(set(), d.type_diffs)
+            self.assertEqual(set([("variant.num", "two")]), d.value_diffs)
+            d = e.rvs["usr/bin/ls"]
+            self.assertEqual(set(["variant.foo"]), d.type_diffs)
+            self.assertEqual(
+                set([("variant.num", "two"), ("variant.num", "three")]),
+                d.value_diffs,
+            )
+            str(e)
 
-                def __check_manual(e):
-                        self.assertEqual("test17756", e.pkg.pkg_name)
-                        self.assertEqual(["pkg1", "pkg2"], sorted(e.rvs.keys()))
-                        d = e.rvs["pkg1"]
-                        self.assertEqual(set(), d.type_diffs)
-                        self.assertEqual(set([("variant.num", "four")]),
-                            d.value_diffs)
-                        d = e.rvs["pkg2"]
-                        self.assertEqual(set(["variant.foo"]), d.type_diffs)
-                        self.assertEqual(set(), d.value_diffs)
-                        str(e)
+        def __check_manual(e):
+            self.assertEqual("test17756", e.pkg.pkg_name)
+            self.assertEqual(["pkg1", "pkg2"], sorted(e.rvs.keys()))
+            d = e.rvs["pkg1"]
+            self.assertEqual(set(), d.type_diffs)
+            self.assertEqual(set([("variant.num", "four")]), d.value_diffs)
+            d = e.rvs["pkg2"]
+            self.assertEqual(set(["variant.foo"]), d.type_diffs)
+            self.assertEqual(set(), d.value_diffs)
+            str(e)
 
-                dep_manf = """\
+        dep_manf = """\
 set name=pkg.fmri value=test17756@1,5.11
 set name=variant.num value=one
 depend fmri=__TBD pkg.debug.depend.file=libsec.so.1 pkg.debug.depend.path=lib pkg.debug.depend.path=usr/lib pkg.debug.depend.reason=usr/bin/ls pkg.debug.depend.type=elf type=require variant.foo=bar
@@ -1412,870 +1704,1204 @@ depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib pkg.
 depend fmri=pkg1 type=require variant.num=four
 depend fmri=pkg2 type=require variant.foo=bar
 """
-                manf_path = self.make_manifest(dep_manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([manf_path], self.api_obj,
-                        [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 1)
-                self.assertEqual(len(pkg_deps[manf_path]), 0)
-                self.assertEqual(len(errs), 2)
-                if errs[0].manual:
-                        __check_manual(errs[0])
-                        __check_generated(errs[1])
+        manf_path = self.make_manifest(dep_manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([manf_path], self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 1)
+        self.assertEqual(len(pkg_deps[manf_path]), 0)
+        self.assertEqual(len(errs), 2)
+        if errs[0].manual:
+            __check_manual(errs[0])
+            __check_generated(errs[1])
+        else:
+            __check_manual(errs[1])
+            __check_generated(errs[0])
+
+    def test_bug_18019(self):
+        """Test that a package with manually annotated group,
+        incorporate, or other types of dependencies doesn't end up with
+        two copies of any dependencies."""
+
+        manf = ["set name=pkg.fmri value=bug_18019@1.0,5.11-1"]
+        for t in depend.known_types:
+            if t == "conditional":
+                s = (
+                    "depend fmri=pkg:/{type}@0,5.11-1 "
+                    "predicate=pkg:/foo@0,5.11-1 "
+                    "type={type}".format(type=t)
+                )
+            else:
+                s = "depend fmri=pkg:/{type}@0,5.11-1 " "type={type}".format(
+                    type=t
+                )
+            manf.append(s)
+
+        manf_path = self.make_manifest("\n".join(manf))
+        self.pkgdepend_resolve("-m {0}".format(manf_path))
+        res_path = manf_path + ".res"
+        with open(res_path, "r") as fh:
+            s = fh.read()
+        s = s.splitlines()
+        self.assertEqualDiff("\n".join(sorted(manf)), "\n".join(sorted(s)))
+
+    def test_bug_18045_normal(self):
+        """Test that when a package without variants has a file
+        dependency on a file in a package that declares variants,
+        that dependency is satisfied."""
+
+        self.pkgsend_bulk(self.rurl, self.installed_18045)
+        self.api_obj.refresh(immediate=True)
+        self._api_install(self.api_obj, ["runtime/python-27"])
+        dep_path = self.make_manifest(self.bug_18045_dep)
+
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([dep_path], self.api_obj, ["*"])
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(
+                        [
+                            "{0}".format(
+                                e,
+                            )
+                            for e in errs
+                        ]
+                    )
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["runtime/python-27"]), external_deps)
+        self.assertEqual(len(pkg_deps), 1)
+        self.assertEqual(len(pkg_deps[dep_path]), 1)
+        self.debug("fmri:{0}".format(pkg_deps[dep_path][0].attrs["fmri"]))
+        self.assertTrue(
+            pkg_deps[dep_path][0]
+            .attrs["fmri"]
+            .startswith("pkg:/runtime/python-27@2.7.8-0.161")
+        )
+
+    def test_bug_18045_reverse(self):
+        """Test that when a package with variants has a file dependency
+        on a file in a package that declares no variants, that
+        dependency is satisfied."""
+
+        self.pkgsend_bulk(self.rurl, self.installed_18045_reverse)
+        self.api_obj.refresh(immediate=True)
+        self._api_install(self.api_obj, ["runtime/python-27"])
+        dep_path = self.make_manifest(self.bug_18045_dep_reverse)
+
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([dep_path], self.api_obj, ["*"])
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(
+                        [
+                            "{0}".format(
+                                e,
+                            )
+                            for e in errs
+                        ]
+                    )
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["runtime/python-27"]), external_deps)
+        self.assertEqual(len(pkg_deps), 1)
+        self.assertEqual(len(pkg_deps[dep_path]), 1)
+        self.debug("fmri:{0}".format(pkg_deps[dep_path][0].attrs["fmri"]))
+        self.assertTrue(
+            pkg_deps[dep_path][0]
+            .attrs["fmri"]
+            .startswith("pkg:/runtime/python-27@2.7.8-0.161")
+        )
+
+    def test_bug_18045_mixed(self):
+        """Test that when a package with variants has a file dependency
+        on a file in a package that declares a different set of variant
+        types, that dependency is satisfied."""
+
+        self.pkgsend_bulk(self.rurl, self.installed_18045_mixed)
+        self.api_obj.refresh(immediate=True)
+        self._api_install(self.api_obj, ["runtime/python-27"])
+        dep_path = self.make_manifest(self.bug_18045_dep_mixed)
+
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([dep_path], self.api_obj, ["*"])
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(
+                        [
+                            "{0}".format(
+                                e,
+                            )
+                            for e in errs
+                        ]
+                    )
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["runtime/python-27"]), external_deps)
+        self.assertEqual(len(pkg_deps), 1)
+        self.assertEqual(len(pkg_deps[dep_path]), 1)
+        self.debug("fmri:{0}".format(pkg_deps[dep_path][0].attrs["fmri"]))
+        self.assertTrue(
+            pkg_deps[dep_path][0]
+            .attrs["fmri"]
+            .startswith("pkg:/runtime/python-27@2.7.8-0.161")
+        )
+
+    def test_bug_18077(self):
+        """Test that a package with manually annotated group,
+        incorporate, or other types of dependencies on the same package
+        doesn't cause pkgdep resolve to traceback."""
+
+        manf = ["set name=pkg.fmri value=bug_18077@1.0,5.11-1"]
+        for t in depend.known_types:
+            if t == "conditional":
+                s = "depend fmri=pkg:/foo2@0,5.11-1 predicate=pkg:/foo3@0,5.11-1 type={type}".format(
+                    type=t
+                )
+            else:
+                s = "depend fmri=pkg:/foo@0,5.11-1 type={type}".format(type=t)
+
+            manf.append(s)
+        manf_path = self.make_manifest("\n".join(manf))
+        self.pkgdepend_resolve("-m {0}".format(manf_path))
+        res_path = manf_path + ".res"
+        with open(res_path, "r") as fh:
+            s = fh.read()
+        s = s.splitlines()
+        self.assertEqualDiff(
+            "\n".join(sorted([l for l in manf if "require-any" not in l])),
+            "\n".join(sorted(s)),
+        )
+
+    def test_bug_18130(self):
+        """Test that dependency variants get collapsed where
+        possible."""
+
+        VA = "variant.arch"
+        VOZ = "variant.opensolaris.zone"
+        VD = "variant.debug"
+
+        d_path = self.make_manifest(self.bug_18130_dep)
+
+        # Test that a single variant with two values is collapsed
+        # correctly.
+        p_path = self.make_manifest(self.bug_18130_provider_1)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([d_path, p_path], self.api_obj, [])
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 2)
+        self.assertEqual(len(pkg_deps[p_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[d_path]),
+            1,
+            "Got wrong number "
+            "of pkgdeps for the dependent package. Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
+        for k in pkg_deps[d_path][0].attrs:
+            self.assertTrue(
+                not k.startswith("variant."),
+                "The "
+                "resulting dependency should not contain any "
+                "variants. The action is:\n{0}".format(pkg_deps[d_path][0]),
+            )
+
+        # Test that combinations of two variant types works.
+        p_path = self.make_manifest(self.bug_18130_provider_2)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([d_path, p_path], self.api_obj, [])
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 2)
+        self.assertEqual(len(pkg_deps[p_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[d_path]),
+            1,
+            "Got wrong number "
+            "of pkgdeps for the dependent package. Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
+
+        # Test that splitting the variants across two packages gives the
+        # right simplification.
+        p_path = self.make_manifest(self.bug_18130_provider_3_1)
+        p2_path = self.make_manifest(self.bug_18130_provider_3_2)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [d_path, p_path, p2_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[p_path]), 0)
+        self.assertEqual(len(pkg_deps[p2_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[d_path]),
+            3,
+            "Got wrong number "
+            "of pkgdeps for the dependent package. Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
+        got_prov_2 = False
+        got_prov_1_i386 = False
+        got_prov_1_sparc = False
+        for d in pkg_deps[d_path]:
+            if d.attrs["fmri"].startswith("pkg:/provider2"):
+                self.assertEqual(d.attrs[VA], "i386")
+                self.assertEqual(d.attrs[VOZ], "global")
+                got_prov_2 = True
+            elif d.attrs["fmri"].startswith("pkg:/provider1"):
+                self.assertTrue(VA in d.attrs)
+                if d.attrs[VA] == "i386":
+                    self.assertEqual(d.attrs[VOZ], "nonglobal")
+                    got_prov_1_i386 = True
                 else:
-                        __check_manual(errs[1])
-                        __check_generated(errs[0])
+                    self.assertEqual(d.attrs[VA], "sparc")
+                    self.assertTrue(VOZ not in d.attrs)
+                    got_prov_1_sparc = True
+            else:
+                raise RuntimeError("Unexpected fmri seen:{0}".format(d))
+        self.assertTrue(
+            got_prov_2 and got_prov_1_i386 and got_prov_1_sparc,
+            "Got the right number of dependencies "
+            "but missed one of the expected ones. Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
 
-        def test_bug_18019(self):
-                """Test that a package with manually annotated group,
-                incorporate, or other types of dependencies doesn't end up with
-                two copies of any dependencies."""
+        # Test that when a variant combination is satisfied, it's
+        # reported as being unresolved.
+        p_path = self.make_manifest(self.bug_18130_provider_3_1)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([d_path, p_path], self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(errs), 1)
+        self.assertEqual(len(pkg_deps), 2)
+        self.assertEqual(len(pkg_deps[p_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[d_path]),
+            2,
+            "Got wrong number "
+            "of pkgdeps for the dependent package. Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
 
-                manf = ["set name=pkg.fmri value=bug_18019@1.0,5.11-1"]
-                for t in depend.known_types:
-                        if t == "conditional":
-                                s = "depend fmri=pkg:/{type}@0,5.11-1 " \
-                                    "predicate=pkg:/foo@0,5.11-1 " \
-                                    "type={type}".format(type=t)
-                        else:
-                                s = "depend fmri=pkg:/{type}@0,5.11-1 " \
-                                    "type={type}".format(type=t)
-                        manf.append(s)
+        # Test that variants with 3 values as well as a combination of
+        # three variant types are collapsed correctly.
+        p_path = self.make_manifest(self.bug_18130_provider_4)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([d_path, p_path], self.api_obj, [])
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 2)
+        self.assertEqual(len(pkg_deps[p_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[d_path]),
+            1,
+            "Got wrong number "
+            "of pkgdeps for the dependent package. Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
+        for k in pkg_deps[d_path][0].attrs:
+            self.assertTrue(
+                not k.startswith("variant."),
+                "The "
+                "resulting dependency should not contain any "
+                "variants. The action is:\n{0}".format(pkg_deps[d_path][0]),
+            )
 
-                manf_path = self.make_manifest("\n".join(manf))
-                self.pkgdepend_resolve("-m {0}".format(manf_path))
-                res_path = manf_path + ".res"
-                with open(res_path, "r") as fh:
-                        s = fh.read()
-                s = s.splitlines()
-                self.assertEqualDiff("\n".join(sorted(manf)),
-                    "\n".join(sorted(s)))
+        # Test all but one dependency satisfier in one file, and one in
+        # another package.
+        p_path = self.make_manifest(self.bug_18130_provider_5_1)
+        p2_path = self.make_manifest(self.bug_18130_provider_5_2)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [d_path, p_path, p2_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[p_path]), 0)
+        self.assertEqual(len(pkg_deps[p2_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[d_path]),
+            5,
+            "Got wrong number "
+            "of pkgdeps for the dependent package. Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
+        got_prov_2 = False
+        got_prov_1_i386 = False
+        got_prov_1_sparc = False
+        got_prov_1_foo_debug = False
+        got_prov_1_foo_nondebug_global = False
+        for d in pkg_deps[d_path]:
+            if d.attrs["fmri"].startswith("pkg:/provider2"):
+                self.assertEqual(d.attrs[VA], "foo")
+                self.assertEqual(d.attrs[VOZ], "nonglobal")
+                self.assertEqual(d.attrs[VD], "False")
+                got_prov_2 = True
+            elif d.attrs["fmri"].startswith("pkg:/provider1"):
+                self.assertTrue(VA in d.attrs)
+                if d.attrs[VA] == "i386":
+                    self.assertTrue(VD not in d.attrs)
+                    self.assertTrue(VOZ not in d.attrs)
+                    got_prov_1_i386 = True
+                elif d.attrs[VA] == "sparc":
+                    self.assertTrue(VD not in d.attrs)
+                    self.assertTrue(VOZ not in d.attrs)
+                    got_prov_1_sparc = True
+                else:
+                    self.assertEqual(d.attrs[VA], "foo")
+                    if d.attrs[VD] == "True":
+                        self.assertTrue(VOZ not in d.attrs)
+                        got_prov_1_foo_debug = True
+                    else:
+                        self.assertEqual(d.attrs[VD], "False")
+                        self.assertEqual(d.attrs[VOZ], "global")
+                        got_prov_1_foo_nondebug_global = True
+            else:
+                raise RuntimeError("Unexpected fmri seen:{0}".format(d))
+        self.assertTrue(
+            got_prov_2
+            and got_prov_1_i386
+            and got_prov_1_sparc
+            and got_prov_1_foo_debug
+            and got_prov_1_foo_nondebug_global,
+            "Got the right number "
+            "of dependencies but missed one of the expected ones. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
 
-        def test_bug_18045_normal(self):
-                """Test that when a package without variants has a file
-                dependency on a file in a package that declares variants,
-                that dependency is satisfied."""
+        # Test that when two manifests split on debug, non-debug, the
+        # variants are collapsed correctly.
+        p_path = self.make_manifest(self.bug_18130_provider_6_1)
+        p2_path = self.make_manifest(self.bug_18130_provider_6_2)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [d_path, p_path, p2_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[p_path]), 0)
+        self.assertEqual(len(pkg_deps[p2_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[d_path]),
+            2,
+            "Got wrong number "
+            "of pkgdeps for the dependent package. Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
+        got_prov_2 = False
+        got_prov_1 = False
+        for d in pkg_deps[d_path]:
+            if d.attrs["fmri"].startswith("pkg:/provider2"):
+                self.assertEqual(d.attrs[VD], "False")
+                self.assertTrue(VOZ not in d.attrs)
+                self.assertTrue(VA not in d.attrs)
+                got_prov_2 = True
+            else:
+                self.assertTrue(d.attrs["fmri"].startswith("pkg:/provider1"))
+                self.assertEqual(d.attrs[VD], "True")
+                self.assertTrue(VA not in d.attrs)
+                self.assertTrue(VOZ not in d.attrs)
+                got_prov_1 = True
+        self.assertTrue(
+            got_prov_2 and got_prov_1,
+            "Got the right number "
+            "of dependencies but missed one of the expected ones. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
 
-                self.pkgsend_bulk(self.rurl, self.installed_18045)
-                self.api_obj.refresh(immediate=True)
-                self._api_install(self.api_obj, ["runtime/python-27"])
-                dep_path = self.make_manifest(self.bug_18045_dep)
+        # Test that variants won't be combined when they shouldn't be.
+        p_path = self.make_manifest(self.bug_18130_provider_7_1)
+        p2_path = self.make_manifest(self.bug_18130_provider_7_2)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [d_path, p_path, p2_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[p_path]), 0)
+        self.assertEqual(len(pkg_deps[p2_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[d_path]),
+            12,
+            "Got wrong number "
+            "of pkgdeps for the dependent package. Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[d_path]])
+            ),
+        )
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path], self.api_obj, ["*"])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join([
-                            "{0}".format(e,) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["runtime/python-27"]), external_deps)
-                self.assertEqual(len(pkg_deps), 1)
-                self.assertEqual(len(pkg_deps[dep_path]), 1)
-                self.debug("fmri:{0}".format(pkg_deps[dep_path][0].attrs["fmri"]))
-                self.assertTrue(pkg_deps[dep_path][0].attrs["fmri"].startswith(
-                    "pkg:/runtime/python-27@2.7.8-0.161"))
+    def test_bug_18172(self):
+        """Test that the via-links attribute is set correctly when
+        multiple packages deliver a chain of links."""
 
-        def test_bug_18045_reverse(self):
-                """Test that when a package with variants has a file dependency
-                on a file in a package that declares no variants, that
-                dependency is satisfied."""
+        top_path = self.make_manifest(self.bug_18172_top)
+        l1_path = self.make_manifest(self.bug_18172_l1)
+        l2_path = self.make_manifest(self.bug_18172_l2)
+        l3_path = self.make_manifest(self.bug_18172_l3)
+        dest_path = self.make_manifest(self.bug_18172_dest)
 
-                self.pkgsend_bulk(self.rurl, self.installed_18045_reverse)
-                self.api_obj.refresh(immediate=True)
-                self._api_install(self.api_obj, ["runtime/python-27"])
-                dep_path = self.make_manifest(self.bug_18045_dep_reverse)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [top_path, l1_path, l2_path, l3_path, dest_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 5)
+        self.assertEqual(len(pkg_deps[dest_path]), 0)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[l3_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[top_path]),
+            4,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[top_path]])
+            ),
+        )
+        got_top = False
+        got_l1 = False
+        got_l2 = False
+        got_l3 = False
+        for d in pkg_deps[top_path]:
+            pfmri = d.attrs["fmri"]
+            if pfmri.startswith("pkg:/dest"):
+                self.assertEqual(
+                    d.attrs[dependencies.files_prefix], ["usr/lib/isaexec"]
+                )
+                self.assertEqual(
+                    d.attrs[dependencies.via_links_prefix],
+                    "usr/bin/ksh:usr/lib/l1:usr/lib/l2",
+                )
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+                got_top = True
+            elif pfmri.startswith("pkg:/ksh"):
+                got_l1 = True
+            elif pfmri.startswith("pkg:/l2"):
+                got_l2 = True
+            else:
+                self.assertTrue(pfmri.startswith("pkg:/l3"))
+                got_l3 = True
+        self.assertTrue(
+            got_top and got_l1 and got_l2 and got_l3,
+            "Got "
+            "the right number of dependencies but missed one of the "
+            "expected ones. Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[top_path]])
+            ),
+        )
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path], self.api_obj, ["*"])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join([
-                            "{0}".format(e,) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["runtime/python-27"]), external_deps)
-                self.assertEqual(len(pkg_deps), 1)
-                self.assertEqual(len(pkg_deps[dep_path]), 1)
-                self.debug("fmri:{0}".format(pkg_deps[dep_path][0].attrs["fmri"]))
-                self.assertTrue(pkg_deps[dep_path][0].attrs["fmri"].startswith(
-                    "pkg:/runtime/python-27@2.7.8-0.161"))
+    def test_bug_18173(self):
+        """Test that if a link moves in a new version of a package, the
+        link in the installed version of the package doesn't interfere
+        with dependency resolution."""
 
-        def test_bug_18045_mixed(self):
-                """Test that when a package with variants has a file dependency
-                on a file in a package that declares a different set of variant
-                types, that dependency is satisfied."""
+        self.make_misc_files("usr/lib/isaexec")
+        self.pkgsend_bulk(self.rurl, self.bug_18173_cs_1)
+        cs2_path = self.make_manifest(self.bug_18173_cs_2)
+        ksh_path = self.make_manifest(self.bug_18173_ksh)
+        zones_path = self.make_manifest(self.bug_18173_zones)
 
-                self.pkgsend_bulk(self.rurl, self.installed_18045_mixed)
-                self.api_obj.refresh(immediate=True)
-                self._api_install(self.api_obj, ["runtime/python-27"])
-                dep_path = self.make_manifest(self.bug_18045_dep_mixed)
+        self.api_obj.refresh(immediate=True)
+        self._api_install(self.api_obj, ["cs"])
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path], self.api_obj, ["*"])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join([
-                            "{0}".format(e,) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["runtime/python-27"]), external_deps)
-                self.assertEqual(len(pkg_deps), 1)
-                self.assertEqual(len(pkg_deps[dep_path]), 1)
-                self.debug("fmri:{0}".format(pkg_deps[dep_path][0].attrs["fmri"]))
-                self.assertTrue(pkg_deps[dep_path][0].attrs["fmri"].startswith(
-                    "pkg:/runtime/python-27@2.7.8-0.161"))
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [cs2_path, ksh_path, zones_path], self.api_obj, ["*"]
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[cs2_path]), 0)
+        self.assertEqual(len(pkg_deps[ksh_path]), 1)
+        self.assertEqual(
+            len(pkg_deps[zones_path]),
+            2,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[zones_path]])
+            ),
+        )
+        got_cs2 = False
+        got_ksh = False
+        for d in pkg_deps[zones_path]:
+            pfmri = d.attrs["fmri"]
+            if pfmri.startswith("pkg:/cs"):
+                self.assertTrue(pfmri.endswith("-2"))
+                self.assertEqual(
+                    d.attrs[dependencies.files_prefix], ["usr/lib/isaexec"]
+                )
+                self.assertEqual(
+                    d.attrs[dependencies.via_links_prefix], "usr/bin/ksh"
+                )
+                self.assertEqual(d.attrs[dependencies.type_prefix], "script")
+                got_cs2 = True
+            else:
+                self.assertTrue(pfmri.startswith("pkg:/ksh"))
+                self.assertEqual(
+                    d.attrs[dependencies.files_prefix], ["usr/bin/ksh"]
+                )
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+                got_ksh = True
+        self.assertTrue(
+            got_cs2 and got_ksh,
+            "Got the right number "
+            "of dependencies but missed one of the expected ones. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[zones_path]])
+            ),
+        )
 
-        def test_bug_18077(self):
-                """Test that a package with manually annotated group,
-                incorporate, or other types of dependencies on the same package
-                doesn't cause pkgdep resolve to traceback."""
+    def test_bug_18315_1(self):
+        """Test that when two packages deliver a link which is needed in
+        a dependency, a require-any dependency is created."""
 
-                manf = ["set name=pkg.fmri value=bug_18077@1.0,5.11-1"]
-                for t in depend.known_types:
-                        if t == "conditional":
-                                s = "depend fmri=pkg:/foo2@0,5.11-1 predicate=pkg:/foo3@0,5.11-1 type={type}".format(type=t)
-                        else:
-                                s = "depend fmri=pkg:/foo@0,5.11-1 type={type}".format(type=t)
+        l1_path = self.make_manifest(self.bug_18315_link1_manf)
+        l2_path = self.make_manifest(self.bug_18315_link2_manf)
+        der_path = self.make_manifest(self.bug_18315_depender_manf)
+        dee_path = self.make_manifest(self.bug_18315_dependee_manf)
 
-                        manf.append(s)
-                manf_path = self.make_manifest("\n".join(manf))
-                self.pkgdepend_resolve("-m {0}".format(manf_path))
-                res_path = manf_path + ".res"
-                with open(res_path, "r") as fh:
-                        s = fh.read()
-                s = s.splitlines()
-                self.assertEqualDiff("\n".join(sorted(
-                    [l for l in manf if "require-any" not in l])),
-                    "\n".join(sorted(s)))
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [l1_path, l2_path, der_path, dee_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 4)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[dee_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[der_path]),
+            2,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[der_path]])
+            ),
+        )
+        for d in pkg_deps[der_path]:
+            if d.attrs["type"] == "require":
+                self.assertTrue(d.attrs["fmri"].startswith("pkg:/dependee"))
+            else:
+                self.assertEqual(d.attrs["type"], "require-any")
+                self.assertEqual(len(d.attrs["fmri"]), 2)
+                fmri0 = d.attrs["fmri"][0]
+                fmri1 = d.attrs["fmri"][1]
+                self.assertTrue(
+                    (
+                        fmri0.startswith("pkg:/link1")
+                        and fmri1.startswith("pkg:/link2")
+                    )
+                    or (
+                        fmri0.startswith("pkg:/link2")
+                        and fmri1.startswith("pkg:/link1")
+                    )
+                )
 
-        def test_bug_18130(self):
-                """Test that dependency variants get collapsed where
-                possible."""
+    def test_bug_18315_2(self):
+        """Test that variants are handled correctly when multiple
+        packages deliver a link under various combinations of
+        variants."""
 
-                VA = "variant.arch"
-                VOZ = "variant.opensolaris.zone"
-                VD = "variant.debug"
+        lv1_path = self.make_manifest(self.bug_18315_var_link1_manf)
+        lv2_path = self.make_manifest(self.bug_18315_var_link2_manf)
+        lv3_path = self.make_manifest(self.bug_18315_var_link3_manf)
+        l1_path = self.make_manifest(self.bug_18315_var_link4_manf)
+        l2_path = self.make_manifest(self.bug_18315_var_link5_manf)
+        der_path = self.make_manifest(self.bug_18315_var_depender_manf)
+        dee_path = self.make_manifest(self.bug_18315_var_dependee_manf)
 
-                d_path = self.make_manifest(self.bug_18130_dep)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [
+                l1_path,
+                l2_path,
+                der_path,
+                dee_path,
+                lv1_path,
+                lv2_path,
+                lv3_path,
+            ],
+            self.api_obj,
+            [],
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 7)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[dee_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[der_path]),
+            5,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[der_path]])
+            ),
+        )
+        for d in pkg_deps[der_path]:
+            if d.attrs["type"] == "require":
+                if d.attrs.get("variant.arch", None) == "foo":
+                    self.assertTrue(d.attrs["fmri"].startswith("pkg:/link5"))
+                else:
+                    self.assertTrue(d.attrs["fmri"].startswith("pkg:/dependee"))
+                continue
+            self.assertEqual(d.attrs["type"], "require-any")
+            if d.attrs["variant.arch"] == "sparc":
+                self.assertEqual(len(d.attrs["fmri"]), 2)
+            elif d.attrs["variant.opensolaris.zone"] == "nonglobal":
+                self.assertEqual(d.attrs["variant.arch"], "i386")
+                self.assertEqual(len(d.attrs["fmri"]), 3)
+            else:
+                self.assertEqual(d.attrs["variant.opensolaris.zone"], "global")
+                self.assertEqual(d.attrs["variant.arch"], "i386")
+                self.assertEqual(len(d.attrs["fmri"]), 4)
 
-                # Test that a single variant with two values is collapsed
-                # correctly.
-                p_path = self.make_manifest(self.bug_18130_provider_1)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([d_path, p_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 2)
-                self.assertEqual(len(pkg_deps[p_path]), 0)
-                self.assertEqual(len(pkg_deps[d_path]), 1, "Got wrong number "
-                    "of pkgdeps for the dependent package. Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-                for k in pkg_deps[d_path][0].attrs:
-                        self.assertTrue(not k.startswith("variant."), "The "
-                            "resulting dependency should not contain any "
-                            "variants. The action is:\n{0}".format(
-                            pkg_deps[d_path][0]))
+    def test_bug_18318_1(self):
+        """Test that require-any dependencies are correctly removed when
+        no variants are involved and a manual dependency has been set on
+        one of the members of a require-any dependency."""
 
-                # Test that combinations of two variant types works.
-                p_path = self.make_manifest(self.bug_18130_provider_2)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([d_path, p_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 2)
-                self.assertEqual(len(pkg_deps[p_path]), 0)
-                self.assertEqual(len(pkg_deps[d_path]), 1, "Got wrong number "
-                    "of pkgdeps for the dependent package. Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-
-                # Test that splitting the variants across two packages gives the
-                # right simplification.
-                p_path = self.make_manifest(self.bug_18130_provider_3_1)
-                p2_path = self.make_manifest(self.bug_18130_provider_3_2)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([d_path, p_path, p2_path],
-                        self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[p_path]), 0)
-                self.assertEqual(len(pkg_deps[p2_path]), 0)
-                self.assertEqual(len(pkg_deps[d_path]), 3, "Got wrong number "
-                    "of pkgdeps for the dependent package. Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-                got_prov_2 = False
-                got_prov_1_i386 = False
-                got_prov_1_sparc = False
-                for d in pkg_deps[d_path]:
-                        if d.attrs["fmri"].startswith("pkg:/provider2"):
-                                self.assertEqual(d.attrs[VA], "i386")
-                                self.assertEqual(d.attrs[VOZ], "global")
-                                got_prov_2 = True
-                        elif d.attrs["fmri"].startswith("pkg:/provider1"):
-                                self.assertTrue(VA in d.attrs)
-                                if d.attrs[VA] == "i386":
-                                        self.assertEqual(d.attrs[VOZ],
-                                            "nonglobal")
-                                        got_prov_1_i386 = True
-                                else:
-                                        self.assertEqual(d.attrs[VA], "sparc")
-                                        self.assertTrue(VOZ not in d.attrs)
-                                        got_prov_1_sparc = True
-                        else:
-                                raise RuntimeError("Unexpected fmri seen:{0}".format(
-                                    d))
-                self.assertTrue(got_prov_2 and got_prov_1_i386 and
-                    got_prov_1_sparc, "Got the right number of dependencies "
-                    "but missed one of the expected ones. Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-
-                # Test that when a variant combination is satisfied, it's
-                # reported as being unresolved.
-                p_path = self.make_manifest(self.bug_18130_provider_3_1)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([d_path, p_path], self.api_obj,
-                        [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(errs), 1)
-                self.assertEqual(len(pkg_deps), 2)
-                self.assertEqual(len(pkg_deps[p_path]), 0)
-                self.assertEqual(len(pkg_deps[d_path]), 2, "Got wrong number "
-                    "of pkgdeps for the dependent package. Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-
-                # Test that variants with 3 values as well as a combination of
-                # three variant types are collapsed correctly.
-                p_path = self.make_manifest(self.bug_18130_provider_4)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([d_path, p_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 2)
-                self.assertEqual(len(pkg_deps[p_path]), 0)
-                self.assertEqual(len(pkg_deps[d_path]), 1, "Got wrong number "
-                    "of pkgdeps for the dependent package. Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-                for k in pkg_deps[d_path][0].attrs:
-                        self.assertTrue(not k.startswith("variant."), "The "
-                            "resulting dependency should not contain any "
-                            "variants. The action is:\n{0}".format(
-                            pkg_deps[d_path][0]))
-
-                # Test all but one dependency satisfier in one file, and one in
-                # another package.
-                p_path = self.make_manifest(self.bug_18130_provider_5_1)
-                p2_path = self.make_manifest(self.bug_18130_provider_5_2)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([d_path, p_path, p2_path],
-                        self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[p_path]), 0)
-                self.assertEqual(len(pkg_deps[p2_path]), 0)
-                self.assertEqual(len(pkg_deps[d_path]), 5, "Got wrong number "
-                    "of pkgdeps for the dependent package. Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-                got_prov_2 = False
-                got_prov_1_i386 = False
-                got_prov_1_sparc = False
-                got_prov_1_foo_debug = False
-                got_prov_1_foo_nondebug_global = False
-                for d in pkg_deps[d_path]:
-                        if d.attrs["fmri"].startswith("pkg:/provider2"):
-                                self.assertEqual(d.attrs[VA], "foo")
-                                self.assertEqual(d.attrs[VOZ], "nonglobal")
-                                self.assertEqual(d.attrs[VD], "False")
-                                got_prov_2 = True
-                        elif d.attrs["fmri"].startswith("pkg:/provider1"):
-                                self.assertTrue(VA in d.attrs)
-                                if d.attrs[VA] == "i386":
-                                        self.assertTrue(VD not in d.attrs)
-                                        self.assertTrue(VOZ not in d.attrs)
-                                        got_prov_1_i386 = True
-                                elif d.attrs[VA] == "sparc":
-                                        self.assertTrue(VD not in d.attrs)
-                                        self.assertTrue(VOZ not in d.attrs)
-                                        got_prov_1_sparc = True
-                                else:
-                                        self.assertEqual(d.attrs[VA], "foo")
-                                        if d.attrs[VD] == "True":
-                                                self.assertTrue(VOZ not in d.attrs)
-                                                got_prov_1_foo_debug = True
-                                        else:
-                                                self.assertEqual(d.attrs[VD],
-                                                    "False")
-                                                self.assertEqual(d.attrs[VOZ],
-                                                    "global")
-                                                got_prov_1_foo_nondebug_global = True
-                        else:
-                                raise RuntimeError("Unexpected fmri seen:{0}".format(
-                                    d))
-                self.assertTrue(got_prov_2 and got_prov_1_i386 and
-                    got_prov_1_sparc and got_prov_1_foo_debug and
-                    got_prov_1_foo_nondebug_global, "Got the right number "
-                    "of dependencies but missed one of the expected ones. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-
-                # Test that when two manifests split on debug, non-debug, the
-                # variants are collapsed correctly.
-                p_path = self.make_manifest(self.bug_18130_provider_6_1)
-                p2_path = self.make_manifest(self.bug_18130_provider_6_2)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([d_path, p_path, p2_path],
-                        self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[p_path]), 0)
-                self.assertEqual(len(pkg_deps[p2_path]), 0)
-                self.assertEqual(len(pkg_deps[d_path]), 2, "Got wrong number "
-                    "of pkgdeps for the dependent package. Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-                got_prov_2 = False
-                got_prov_1 = False
-                for d in pkg_deps[d_path]:
-                        if d.attrs["fmri"].startswith("pkg:/provider2"):
-                                self.assertEqual(d.attrs[VD], "False")
-                                self.assertTrue(VOZ not in d.attrs)
-                                self.assertTrue(VA not in d.attrs)
-                                got_prov_2 = True
-                        else:
-                                self.assertTrue(d.attrs["fmri"].startswith(
-                                    "pkg:/provider1"))
-                                self.assertEqual(d.attrs[VD], "True")
-                                self.assertTrue(VA not in d.attrs)
-                                self.assertTrue(VOZ not in d.attrs)
-                                got_prov_1 = True
-                self.assertTrue(got_prov_2 and got_prov_1, "Got the right number "
-                    "of dependencies but missed one of the expected ones. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-
-                # Test that variants won't be combined when they shouldn't be.
-                p_path = self.make_manifest(self.bug_18130_provider_7_1)
-                p2_path = self.make_manifest(self.bug_18130_provider_7_2)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([d_path, p_path, p2_path],
-                        self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[p_path]), 0)
-                self.assertEqual(len(pkg_deps[p2_path]), 0)
-                self.assertEqual(len(pkg_deps[d_path]), 12, "Got wrong number "
-                    "of pkgdeps for the dependent package. Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[d_path]])))
-
-        def test_bug_18172(self):
-                """Test that the via-links attribute is set correctly when
-                multiple packages deliver a chain of links."""
-
-                top_path = self.make_manifest(self.bug_18172_top)
-                l1_path = self.make_manifest(self.bug_18172_l1)
-                l2_path = self.make_manifest(self.bug_18172_l2)
-                l3_path = self.make_manifest(self.bug_18172_l3)
-                dest_path = self.make_manifest(self.bug_18172_dest)
-
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [top_path, l1_path, l2_path, l3_path, dest_path],
-                        self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 5)
-                self.assertEqual(len(pkg_deps[dest_path]), 0)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[l3_path]), 0)
-                self.assertEqual(len(pkg_deps[top_path]), 4,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[top_path]])))
-                got_top = False
-                got_l1 = False
-                got_l2 = False
-                got_l3 = False
-                for d in pkg_deps[top_path]:
-                        pfmri = d.attrs["fmri"]
-                        if pfmri.startswith("pkg:/dest"):
-                                self.assertEqual(
-                                    d.attrs[dependencies.files_prefix],
-                                    ["usr/lib/isaexec"])
-                                self.assertEqual(
-                                    d.attrs[dependencies.via_links_prefix],
-                                    "usr/bin/ksh:usr/lib/l1:usr/lib/l2")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "script")
-                                got_top = True
-                        elif pfmri.startswith("pkg:/ksh"):
-                                got_l1 = True
-                        elif pfmri.startswith("pkg:/l2"):
-                                got_l2 = True
-                        else:
-                                self.assertTrue(pfmri.startswith(
-                                    "pkg:/l3"))
-                                got_l3 = True
-                self.assertTrue(got_top and got_l1 and got_l2 and got_l3, "Got "
-                    "the right number of dependencies but missed one of the "
-                    "expected ones. Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[top_path]])))
-
-        def test_bug_18173(self):
-                """Test that if a link moves in a new version of a package, the
-                link in the installed version of the package doesn't interfere
-                with dependency resolution."""
-
-                self.make_misc_files("usr/lib/isaexec")
-                self.pkgsend_bulk(self.rurl, self.bug_18173_cs_1)
-                cs2_path = self.make_manifest(self.bug_18173_cs_2)
-                ksh_path = self.make_manifest(self.bug_18173_ksh)
-                zones_path = self.make_manifest(self.bug_18173_zones)
-
-                self.api_obj.refresh(immediate=True)
-                self._api_install(self.api_obj, ["cs"])
-
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([cs2_path, ksh_path, zones_path],
-                        self.api_obj, ["*"])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[cs2_path]), 0)
-                self.assertEqual(len(pkg_deps[ksh_path]), 1)
-                self.assertEqual(len(pkg_deps[zones_path]), 2,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[zones_path]])))
-                got_cs2 = False
-                got_ksh = False
-                for d in pkg_deps[zones_path]:
-                        pfmri = d.attrs["fmri"]
-                        if pfmri.startswith("pkg:/cs"):
-                                self.assertTrue(pfmri.endswith("-2"))
-                                self.assertEqual(
-                                    d.attrs[dependencies.files_prefix],
-                                    ["usr/lib/isaexec"])
-                                self.assertEqual(
-                                    d.attrs[dependencies.via_links_prefix],
-                                    "usr/bin/ksh")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "script")
-                                got_cs2 = True
-                        else:
-                                self.assertTrue(pfmri.startswith(
-                                    "pkg:/ksh"))
-                                self.assertEqual(
-                                    d.attrs[dependencies.files_prefix],
-                                    ["usr/bin/ksh"])
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "link")
-                                got_ksh = True
-                self.assertTrue(got_cs2 and got_ksh, "Got the right number "
-                    "of dependencies but missed one of the expected ones. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[zones_path]])))
-
-        def test_bug_18315_1(self):
-                """Test that when two packages deliver a link which is needed in
-                a dependency, a require-any dependency is created."""
-
-                l1_path = self.make_manifest(self.bug_18315_link1_manf)
-                l2_path = self.make_manifest(self.bug_18315_link2_manf)
-                der_path = self.make_manifest(self.bug_18315_depender_manf)
-                dee_path = self.make_manifest(self.bug_18315_dependee_manf)
-
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [l1_path, l2_path, der_path, dee_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 4)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[dee_path]), 0)
-                self.assertEqual(len(pkg_deps[der_path]), 2,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[der_path]])))
-                for d in pkg_deps[der_path]:
-                        if d.attrs["type"] == "require":
-                                self.assertTrue(d.attrs["fmri"].startswith(
-                                    "pkg:/dependee"))
-                        else:
-                                self.assertEqual(d.attrs["type"], "require-any")
-                                self.assertEqual(len(d.attrs["fmri"]), 2)
-                                fmri0 = d.attrs["fmri"][0]
-                                fmri1 = d.attrs["fmri"][1]
-                                self.assertTrue(
-                                    (fmri0.startswith("pkg:/link1") and
-                                    fmri1.startswith("pkg:/link2")) or
-                                    (fmri0.startswith("pkg:/link2") and
-                                    fmri1.startswith("pkg:/link1")))
-
-        def test_bug_18315_2(self):
-                """Test that variants are handled correctly when multiple
-                packages deliver a link under various combinations of
-                variants."""
-
-                lv1_path = self.make_manifest(self.bug_18315_var_link1_manf)
-                lv2_path = self.make_manifest(self.bug_18315_var_link2_manf)
-                lv3_path = self.make_manifest(self.bug_18315_var_link3_manf)
-                l1_path = self.make_manifest(self.bug_18315_var_link4_manf)
-                l2_path = self.make_manifest(self.bug_18315_var_link5_manf)
-                der_path = self.make_manifest(self.bug_18315_var_depender_manf)
-                dee_path = self.make_manifest(self.bug_18315_var_dependee_manf)
-
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([l1_path, l2_path, der_path,
-                        dee_path, lv1_path, lv2_path, lv3_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 7)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[dee_path]), 0)
-                self.assertEqual(len(pkg_deps[der_path]), 5,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[der_path]])))
-                for d in pkg_deps[der_path]:
-                        if d.attrs["type"] == "require":
-                                if d.attrs.get("variant.arch", None) == "foo":
-                                        self.assertTrue(d.attrs["fmri"].startswith(
-                                            "pkg:/link5"))
-                                else:
-                                        self.assertTrue(d.attrs["fmri"].startswith(
-                                            "pkg:/dependee"))
-                                continue
-                        self.assertEqual(d.attrs["type"], "require-any")
-                        if d.attrs["variant.arch"] == "sparc":
-                                self.assertEqual(len(d.attrs["fmri"]), 2)
-                        elif d.attrs["variant.opensolaris.zone"] == "nonglobal":
-                                self.assertEqual(d.attrs["variant.arch"],
-                                    "i386")
-                                self.assertEqual(len(d.attrs["fmri"]), 3)
-                        else:
-                                self.assertEqual(
-                                    d.attrs["variant.opensolaris.zone"],
-                                    "global")
-                                self.assertEqual(d.attrs["variant.arch"],
-                                    "i386")
-                                self.assertEqual(len(d.attrs["fmri"]), 4)
-
-        def test_bug_18318_1(self):
-                """Test that require-any dependencies are correctly removed when
-                no variants are involved and a manual dependency has been set on
-                one of the members of a require-any dependency."""
-
-                bug_18318_depender_manf = """ \
+        bug_18318_depender_manf = """ \
 set name=pkg.fmri value=depender@1,5.11-1
 depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib/64 pkg.depend.reason=usr/bin/binary pkg.debug.depend.type=elf type=require
 depend fmri=link1@1-1 type=require
 """
-                l1_path = self.make_manifest(self.bug_18315_link1_manf)
-                l2_path = self.make_manifest(self.bug_18315_link2_manf)
-                der_path = self.make_manifest(bug_18318_depender_manf)
-                dee_path = self.make_manifest(self.bug_18315_dependee_manf)
+        l1_path = self.make_manifest(self.bug_18315_link1_manf)
+        l2_path = self.make_manifest(self.bug_18315_link2_manf)
+        der_path = self.make_manifest(bug_18318_depender_manf)
+        dee_path = self.make_manifest(self.bug_18315_dependee_manf)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [l1_path, l2_path, der_path, dee_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 4)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[dee_path]), 0)
-                self.assertEqual(len(pkg_deps[der_path]), 2,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[der_path]])))
-                for d in pkg_deps[der_path]:
-                        self.assertEqual(d.attrs["type"], "require")
-                        if d.attrs["fmri"].startswith("pkg:/dependee"):
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "elf")
-                        else:
-                                self.assertEqual(d.attrs["fmri"], "link1@1-1")
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [l1_path, l2_path, der_path, dee_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 4)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[dee_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[der_path]),
+            2,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[der_path]])
+            ),
+        )
+        for d in pkg_deps[der_path]:
+            self.assertEqual(d.attrs["type"], "require")
+            if d.attrs["fmri"].startswith("pkg:/dependee"):
+                self.assertEqual(d.attrs[dependencies.type_prefix], "elf")
+            else:
+                self.assertEqual(d.attrs["fmri"], "link1@1-1")
 
-                # Test that things work when the order of the require-any and
-                # require dependencies are changed and when the require
-                # dependency is on the second fmri instead of the first.
-                bug_18318_depender_manf = """ \
+        # Test that things work when the order of the require-any and
+        # require dependencies are changed and when the require
+        # dependency is on the second fmri instead of the first.
+        bug_18318_depender_manf = """ \
 set name=pkg.fmri value=depender@1,5.11-1
 depend fmri=link2@1-1 type=require
 depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib/64 pkg.depend.reason=usr/bin/binary pkg.debug.depend.type=elf type=require
 """
-                der_path = self.make_manifest(bug_18318_depender_manf)
+        der_path = self.make_manifest(bug_18318_depender_manf)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [l1_path, l2_path, der_path, dee_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 4)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[dee_path]), 0)
-                self.assertEqual(len(pkg_deps[der_path]), 2,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[der_path]])))
-                for d in pkg_deps[der_path]:
-                        self.assertEqual(d.attrs["type"], "require")
-                        if d.attrs["fmri"].startswith("pkg:/dependee"):
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "elf")
-                        else:
-                                self.assertEqual(d.attrs["fmri"], "link2@1-1")
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [l1_path, l2_path, der_path, dee_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 4)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[dee_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[der_path]),
+            2,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[der_path]])
+            ),
+        )
+        for d in pkg_deps[der_path]:
+            self.assertEqual(d.attrs["type"], "require")
+            if d.attrs["fmri"].startswith("pkg:/dependee"):
+                self.assertEqual(d.attrs[dependencies.type_prefix], "elf")
+            else:
+                self.assertEqual(d.attrs["fmri"], "link2@1-1")
 
-                # Check that the require-any dependency isn't removed when the
-                # require dependency is on an unversioned or lower version than
-                # the require-any.
-                bug_18318_depender_manf = """ \
+        # Check that the require-any dependency isn't removed when the
+        # require dependency is on an unversioned or lower version than
+        # the require-any.
+        bug_18318_depender_manf = """ \
 set name=pkg.fmri value=depender@1,5.11-1
 depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib/64 pkg.depend.reason=usr/bin/binary pkg.debug.depend.type=elf type=require
 depend fmri=link1 type=require
 """
-                l1_path = self.make_manifest(self.bug_18315_link1_manf)
-                l2_path = self.make_manifest(self.bug_18315_link2_manf)
-                der_path = self.make_manifest(bug_18318_depender_manf)
-                dee_path = self.make_manifest(self.bug_18315_dependee_manf)
+        l1_path = self.make_manifest(self.bug_18315_link1_manf)
+        l2_path = self.make_manifest(self.bug_18315_link2_manf)
+        der_path = self.make_manifest(bug_18318_depender_manf)
+        dee_path = self.make_manifest(self.bug_18315_dependee_manf)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [l1_path, l2_path, der_path, dee_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 4)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[dee_path]), 0)
-                self.assertEqual(len(pkg_deps[der_path]), 3,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[der_path]])))
-                have_req_any = False
-                for d in pkg_deps[der_path]:
-                        if d.attrs["type"] == "require-any":
-                                self.assertEqual(len(d.attrlist("fmri")), 2)
-                                have_req_any = True
-                        elif d.attrs["fmri"].startswith("pkg:/dependee"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "elf")
-                        else:
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["fmri"], "link1")
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [l1_path, l2_path, der_path, dee_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 4)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[dee_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[der_path]),
+            3,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[der_path]])
+            ),
+        )
+        have_req_any = False
+        for d in pkg_deps[der_path]:
+            if d.attrs["type"] == "require-any":
+                self.assertEqual(len(d.attrlist("fmri")), 2)
                 have_req_any = True
+            elif d.attrs["fmri"].startswith("pkg:/dependee"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "elf")
+            else:
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["fmri"], "link1")
+        have_req_any = True
 
-                bug_18318_depender_manf = """ \
+        bug_18318_depender_manf = """ \
 set name=pkg.fmri value=depender@1,5.11-1
 depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib/64 pkg.depend.reason=usr/bin/binary pkg.debug.depend.type=elf type=require
 depend fmri=link1@0.1 type=require
 """
-                l1_path = self.make_manifest(self.bug_18315_link1_manf)
-                l2_path = self.make_manifest(self.bug_18315_link2_manf)
-                der_path = self.make_manifest(bug_18318_depender_manf)
-                dee_path = self.make_manifest(self.bug_18315_dependee_manf)
+        l1_path = self.make_manifest(self.bug_18315_link1_manf)
+        l2_path = self.make_manifest(self.bug_18315_link2_manf)
+        der_path = self.make_manifest(bug_18318_depender_manf)
+        dee_path = self.make_manifest(self.bug_18315_dependee_manf)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [l1_path, l2_path, der_path, dee_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 4)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[dee_path]), 0)
-                self.assertEqual(len(pkg_deps[der_path]), 3,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[der_path]])))
-                have_req_any = False
-                for d in pkg_deps[der_path]:
-                        if d.attrs["type"] == "require-any":
-                                self.assertEqual(len(d.attrlist("fmri")), 2)
-                                have_req_any = True
-                        elif d.attrs["fmri"].startswith("pkg:/dependee"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "elf")
-                        else:
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["fmri"], "link1@0.1")
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [l1_path, l2_path, der_path, dee_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 4)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[dee_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[der_path]),
+            3,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[der_path]])
+            ),
+        )
+        have_req_any = False
+        for d in pkg_deps[der_path]:
+            if d.attrs["type"] == "require-any":
+                self.assertEqual(len(d.attrlist("fmri")), 2)
                 have_req_any = True
+            elif d.attrs["fmri"].startswith("pkg:/dependee"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "elf")
+            else:
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["fmri"], "link1@0.1")
+        have_req_any = True
 
-        def test_bug_18318_2(self):
-                """Test that a manually tagged dependency cancels out
-                require-any dependencies which contain that fmri."""
+    def test_bug_18318_2(self):
+        """Test that a manually tagged dependency cancels out
+        require-any dependencies which contain that fmri."""
 
-                bug_18318_var_depender_manf = """ \
+        bug_18318_var_depender_manf = """ \
 set name=pkg.fmri value=depender@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
 depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib/64 pkg.depend.reason=usr/bin/binary pkg.debug.depend.type=elf type=require
 depend fmri=link1@1-1 type=require
 """
-                lv1_path = self.make_manifest(self.bug_18315_var_link1_manf)
-                lv2_path = self.make_manifest(self.bug_18315_var_link2_manf)
-                lv3_path = self.make_manifest(self.bug_18315_var_link3_manf)
-                l1_path = self.make_manifest(self.bug_18315_var_link4_manf)
-                l2_path = self.make_manifest(self.bug_18315_var_link5_manf)
-                der_path = self.make_manifest(bug_18318_var_depender_manf)
-                dee_path = self.make_manifest(self.bug_18315_var_dependee_manf)
+        lv1_path = self.make_manifest(self.bug_18315_var_link1_manf)
+        lv2_path = self.make_manifest(self.bug_18315_var_link2_manf)
+        lv3_path = self.make_manifest(self.bug_18315_var_link3_manf)
+        l1_path = self.make_manifest(self.bug_18315_var_link4_manf)
+        l2_path = self.make_manifest(self.bug_18315_var_link5_manf)
+        der_path = self.make_manifest(bug_18318_var_depender_manf)
+        dee_path = self.make_manifest(self.bug_18315_var_dependee_manf)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([l1_path, l2_path,
-                        der_path, dee_path, lv1_path, lv2_path, lv3_path],
-                        self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(warnings), 2)
-                for i in range(len(errs)):
-                        self.assertTrue(isinstance(errs[i],
-                            dependencies.DropPackageWarning))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 7)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[dee_path]), 0)
-                self.assertEqual(len(pkg_deps[der_path]), 3,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[der_path]])))
-                for d in pkg_deps[der_path]:
-                        self.assertEqual(d.attrs["type"], "require")
-                        if d.attrs["fmri"].startswith("pkg:/dependee"):
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "elf")
-                        elif d.attrs["fmri"].startswith("pkg:/link5"):
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "link")
-                        else:
-                                self.assertEqual(d.attrs["fmri"],"link1@1-1")
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [
+                l1_path,
+                l2_path,
+                der_path,
+                dee_path,
+                lv1_path,
+                lv2_path,
+                lv3_path,
+            ],
+            self.api_obj,
+            [],
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(warnings), 2)
+        for i in range(len(errs)):
+            self.assertTrue(
+                isinstance(errs[i], dependencies.DropPackageWarning)
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 7)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[dee_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[der_path]),
+            3,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[der_path]])
+            ),
+        )
+        for d in pkg_deps[der_path]:
+            self.assertEqual(d.attrs["type"], "require")
+            if d.attrs["fmri"].startswith("pkg:/dependee"):
+                self.assertEqual(d.attrs[dependencies.type_prefix], "elf")
+            elif d.attrs["fmri"].startswith("pkg:/link5"):
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+            else:
+                self.assertEqual(d.attrs["fmri"], "link1@1-1")
 
-        def test_bug_18318_3(self):
-                """Test that a manually tagged dependency with variants cancels
-                out require-any dependencies which contain that fmri."""
+    def test_bug_18318_3(self):
+        """Test that a manually tagged dependency with variants cancels
+        out require-any dependencies which contain that fmri."""
 
-                bug_18318_var_depender_manf = """ \
+        bug_18318_var_depender_manf = """ \
 set name=pkg.fmri value=depender@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
 depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib/64 pkg.depend.reason=usr/bin/binary pkg.debug.depend.type=elf type=require
 depend fmri=link1@1-1 type=require variant.arch=sparc
 """
-                lv1_path = self.make_manifest(self.bug_18315_var_link1_manf)
-                lv2_path = self.make_manifest(self.bug_18315_var_link2_manf)
-                lv3_path = self.make_manifest(self.bug_18315_var_link3_manf)
-                l1_path = self.make_manifest(self.bug_18315_var_link4_manf)
-                l2_path = self.make_manifest(self.bug_18315_var_link5_manf)
-                der_path = self.make_manifest(bug_18318_var_depender_manf)
-                dee_path = self.make_manifest(self.bug_18315_var_dependee_manf)
+        lv1_path = self.make_manifest(self.bug_18315_var_link1_manf)
+        lv2_path = self.make_manifest(self.bug_18315_var_link2_manf)
+        lv3_path = self.make_manifest(self.bug_18315_var_link3_manf)
+        l1_path = self.make_manifest(self.bug_18315_var_link4_manf)
+        l2_path = self.make_manifest(self.bug_18315_var_link5_manf)
+        der_path = self.make_manifest(bug_18318_var_depender_manf)
+        dee_path = self.make_manifest(self.bug_18315_var_dependee_manf)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([l1_path, l2_path, der_path,
-                        dee_path, lv1_path, lv2_path, lv3_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 7)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[dee_path]), 0)
-                self.assertEqual(len(pkg_deps[der_path]), 5,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[der_path]])))
-                for d in pkg_deps[der_path]:
-                        if d.attrs.get("variant.opensolaris.zone", None) == \
-                            "nonglobal":
-                                self.assertEqual(d.attrs["variant.arch"],
-                                    "i386")
-                                self.assertEqual(len(d.attrs["fmri"]), 3)
-                        elif d.attrs.get("variant.opensolaris.zone", None) == \
-                            "global":
-                                self.assertEqual(d.attrs["variant.arch"],
-                                    "i386")
-                                self.assertEqual(len(d.attrs["fmri"]), 4)
-                        elif d.attrs["fmri"].startswith("pkg:/dependee"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "elf")
-                        elif d.attrs["fmri"].startswith("pkg:/link5"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "link")
-                        else:
-                                self.assertEqual(d.attrs["fmri"], "link1@1-1")
-                                self.assertEqual(d.attrs["type"], "require")
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [
+                l1_path,
+                l2_path,
+                der_path,
+                dee_path,
+                lv1_path,
+                lv2_path,
+                lv3_path,
+            ],
+            self.api_obj,
+            [],
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 7)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[dee_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[der_path]),
+            5,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[der_path]])
+            ),
+        )
+        for d in pkg_deps[der_path]:
+            if d.attrs.get("variant.opensolaris.zone", None) == "nonglobal":
+                self.assertEqual(d.attrs["variant.arch"], "i386")
+                self.assertEqual(len(d.attrs["fmri"]), 3)
+            elif d.attrs.get("variant.opensolaris.zone", None) == "global":
+                self.assertEqual(d.attrs["variant.arch"], "i386")
+                self.assertEqual(len(d.attrs["fmri"]), 4)
+            elif d.attrs["fmri"].startswith("pkg:/dependee"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "elf")
+            elif d.attrs["fmri"].startswith("pkg:/link5"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+            else:
+                self.assertEqual(d.attrs["fmri"], "link1@1-1")
+                self.assertEqual(d.attrs["type"], "require")
 
-                # Now test with the manual dependency valid when variant.arch is
-                # i386, this should clobber more require-any dependencies.
-                bug_18318_var_depender_manf = """ \
+        # Now test with the manual dependency valid when variant.arch is
+        # i386, this should clobber more require-any dependencies.
+        bug_18318_var_depender_manf = """ \
 set name=pkg.fmri value=depender@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -2283,48 +2909,70 @@ depend fmri=__TBD pkg.debug.depend.file=libc.so.1 pkg.debug.depend.path=lib/64 p
 depend fmri=link1@1-1 type=require variant.arch=i386
 """
 
-                der_path = self.make_manifest(bug_18318_var_depender_manf)
+        der_path = self.make_manifest(bug_18318_var_depender_manf)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([l1_path, l2_path, der_path,
-                        dee_path, lv1_path, lv2_path, lv3_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(warnings), 1)
-                self.assertTrue(isinstance(warnings[0],
-                    dependencies.DropPackageWarning))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 7)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[dee_path]), 0)
-                self.assertEqual(len(pkg_deps[der_path]), 4,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[der_path]])))
-                for d in pkg_deps[der_path]:
-                        if d.attrs.get("variant.arch", None) == "sparc":
-                                self.assertEqual(len(d.attrs["fmri"]), 2)
-                        elif d.attrs["fmri"].startswith("pkg:/dependee"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "elf")
-                        elif d.attrs["fmri"].startswith("pkg:/link5"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "link")
-                        else:
-                                self.assertEqual(d.attrs["fmri"], "link1@1-1")
-                                self.assertEqual(d.attrs["type"], "require")
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [
+                l1_path,
+                l2_path,
+                der_path,
+                dee_path,
+                lv1_path,
+                lv2_path,
+                lv3_path,
+            ],
+            self.api_obj,
+            [],
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(warnings), 1)
+        self.assertTrue(
+            isinstance(warnings[0], dependencies.DropPackageWarning)
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 7)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[dee_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[der_path]),
+            4,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[der_path]])
+            ),
+        )
+        for d in pkg_deps[der_path]:
+            if d.attrs.get("variant.arch", None) == "sparc":
+                self.assertEqual(len(d.attrs["fmri"]), 2)
+            elif d.attrs["fmri"].startswith("pkg:/dependee"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "elf")
+            elif d.attrs["fmri"].startswith("pkg:/link5"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+            else:
+                self.assertEqual(d.attrs["fmri"], "link1@1-1")
+                self.assertEqual(d.attrs["type"], "require")
 
-        def test_bug_18318_4(self):
-                """Test that automatically generated dependencies can cancel
-                require-any dependencies."""
+    def test_bug_18318_4(self):
+        """Test that automatically generated dependencies can cancel
+        require-any dependencies."""
 
-                bug_18318_var_depender_manf = """ \
+        bug_18318_var_depender_manf = """ \
 set name=pkg.fmri value=depender@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -2334,7 +2982,7 @@ depend fmri=link2@1 fmri=link3@1 fmri=link4@1 type=require-any
 depend fmri=__TBD pkg.debug.depend.reason=usr/bin/bar pkg.debug.depend.file=usr/bin/baz pkg.debug.depend.type=hardlink type=require variant.arch=i386
 """
 
-                bug_18318_var_link1_manf = """ \
+        bug_18318_var_link1_manf = """ \
 set name=pkg.fmri value=link1@1,5.11-1
 set name=variant.arch value=i386 value=sparc value=foo
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -2343,110 +2991,145 @@ link path=lib/64 target=amd64 variant.arch=sparc
 file NOHASH path=usr/bin/baz group=sys mode=0600 owner=root
 """
 
-                lv1_path = self.make_manifest(bug_18318_var_link1_manf)
-                lv2_path = self.make_manifest(self.bug_18315_var_link2_manf)
-                lv3_path = self.make_manifest(self.bug_18315_var_link3_manf)
-                l1_path = self.make_manifest(self.bug_18315_var_link4_manf)
-                l2_path = self.make_manifest(self.bug_18315_var_link5_manf)
-                der_path = self.make_manifest(bug_18318_var_depender_manf)
-                dee_path = self.make_manifest(self.bug_18315_var_dependee_manf)
+        lv1_path = self.make_manifest(bug_18318_var_link1_manf)
+        lv2_path = self.make_manifest(self.bug_18315_var_link2_manf)
+        lv3_path = self.make_manifest(self.bug_18315_var_link3_manf)
+        l1_path = self.make_manifest(self.bug_18315_var_link4_manf)
+        l2_path = self.make_manifest(self.bug_18315_var_link5_manf)
+        der_path = self.make_manifest(bug_18318_var_depender_manf)
+        dee_path = self.make_manifest(self.bug_18315_var_dependee_manf)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([l1_path, l2_path, der_path,
-                        dee_path, lv1_path, lv2_path, lv3_path], self.api_obj,
-                        [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(warnings), 1)
-                self.assertTrue(isinstance(warnings[0],
-                    dependencies.DropPackageWarning))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 7)
-                self.assertEqual(len(pkg_deps[l1_path]), 0)
-                self.assertEqual(len(pkg_deps[l2_path]), 0)
-                self.assertEqual(len(pkg_deps[dee_path]), 0)
-                self.assertEqual(len(pkg_deps[der_path]), 5,
-                    "Got wrong number of pkgdeps for the dependent package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[der_path]])))
-                for d in pkg_deps[der_path]:
-                        if d.attrs.get("variant.arch", None) == "sparc":
-                                self.assertEqual(len(d.attrs["fmri"]), 2)
-                        elif d.attrs["type"] == "require-any":
-                                self.assertEqual(len(d.attrs["fmri"]), 3)
-                        elif d.attrs["fmri"].startswith("pkg:/dependee"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "elf")
-                        elif d.attrs["fmri"].startswith("pkg:/link5"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix], "link")
-                        else:
-                                self.assertTrue(
-                                    d.attrs["fmri"].startswith("pkg:/link1"))
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs[dependencies.type_prefix],
-                                    "hardlink")
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [
+                l1_path,
+                l2_path,
+                der_path,
+                dee_path,
+                lv1_path,
+                lv2_path,
+                lv3_path,
+            ],
+            self.api_obj,
+            [],
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(warnings), 1)
+        self.assertTrue(
+            isinstance(warnings[0], dependencies.DropPackageWarning)
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 7)
+        self.assertEqual(len(pkg_deps[l1_path]), 0)
+        self.assertEqual(len(pkg_deps[l2_path]), 0)
+        self.assertEqual(len(pkg_deps[dee_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[der_path]),
+            5,
+            "Got wrong number of pkgdeps for the dependent package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[der_path]])
+            ),
+        )
+        for d in pkg_deps[der_path]:
+            if d.attrs.get("variant.arch", None) == "sparc":
+                self.assertEqual(len(d.attrs["fmri"]), 2)
+            elif d.attrs["type"] == "require-any":
+                self.assertEqual(len(d.attrs["fmri"]), 3)
+            elif d.attrs["fmri"].startswith("pkg:/dependee"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "elf")
+            elif d.attrs["fmri"].startswith("pkg:/link5"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "link")
+            else:
+                self.assertTrue(d.attrs["fmri"].startswith("pkg:/link1"))
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs[dependencies.type_prefix], "hardlink")
 
-        def test_bug_18359(self):
-                """Test that if package A needs another package to provide a
-                link so one of its files can depend on the other, that A doesn't
-                have a dependency on itself."""
+    def test_bug_18359(self):
+        """Test that if package A needs another package to provide a
+        link so one of its files can depend on the other, that A doesn't
+        have a dependency on itself."""
 
-                file_manf = """ \
+        file_manf = """ \
 set name=pkg.fmri value=file1@1,5.11-1
 file NOHASH path=usr/lib/amd64/lib.so.1 group=sys mode=0644 owner=root
 file NOHASH path=usr/bin/prog group=sys mode=0644 owner=root
 depend fmri=__TBD pkg.debug.depend.reason=usr/bin/prog pkg.debug.depend.file=usr/lib/64/lib.so.1 pkg.debug.depend.type=elf type=require
 """
 
-                link_manf = """ \
+        link_manf = """ \
 set name=pkg.fmri value=link1@1,5.11-1
 link path=usr/lib/64 target=amd64
 """
-                file_path = self.make_manifest(file_manf)
-                link_path = self.make_manifest(link_manf)
+        file_path = self.make_manifest(file_manf)
+        link_path = self.make_manifest(link_manf)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([file_path, link_path],
-                        self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 2)
-                self.assertEqual(len(pkg_deps[link_path]), 0)
-                self.assertEqual(len(pkg_deps[file_path]), 1,
-                    "Got wrong number of pkgdeps for the file package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[file_path]])))
-                dep = pkg_deps[file_path][0]
-                self.assertEqual(dep.attrs["type"], "require",
-                    "type was {0} instead of require\ndep:{1}".format(
-                    dep.attrs["type"], dep))
-                self.assertTrue("predicate" not in dep.attrs)
-                self.assertTrue(dep.attrs["fmri"].startswith("pkg:/link1"))
-                self.assertEqual(dep.attrs[self.depend_dp + ".type"], "link")
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([file_path, link_path], self.api_obj, [])
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 2)
+        self.assertEqual(len(pkg_deps[link_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[file_path]),
+            1,
+            "Got wrong number of pkgdeps for the file package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[file_path]])
+            ),
+        )
+        dep = pkg_deps[file_path][0]
+        self.assertEqual(
+            dep.attrs["type"],
+            "require",
+            "type was {0} instead of require\ndep:{1}".format(
+                dep.attrs["type"], dep
+            ),
+        )
+        self.assertTrue("predicate" not in dep.attrs)
+        self.assertTrue(dep.attrs["fmri"].startswith("pkg:/link1"))
+        self.assertEqual(dep.attrs[self.depend_dp + ".type"], "link")
 
-        def test_bug_18884_1(self):
-                """Test that a file dependency on a link whose target has
-                different content under different variant combinations results
-                in the correct variants (in this case, none) being tagged on the
-                resolved dependency."""
+    def test_bug_18884_1(self):
+        """Test that a file dependency on a link whose target has
+        different content under different variant combinations results
+        in the correct variants (in this case, none) being tagged on the
+        resolved dependency."""
 
-                dep_manf = """ \
+        dep_manf = """ \
 set name=pkg.fmri value=test@1.0
 depend type=require fmri=__TBD pkg.debug.depend.file=ksh93 \
     pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=test-script.ksh93 \
     pkg.debug.depend.type=script
 """
 
-                ksh_manf = """ \
+        ksh_manf = """ \
 set name=pkg.fmri value=shell/ksh@1.0
 set name=variant.debug.osnet value=true value=false
 set name=variant.foo value=sparc value=i386
@@ -2454,7 +3137,7 @@ set name=variant.opensolaris.zone value=global value=nonglobal
 hardlink path=usr/bin/ksh93 target=../../usr/lib/isaexec
 """
 
-                core_os = """ \
+        core_os = """ \
 set name=pkg.fmri value=system/core-os@1.0
 set name=variant.debug.osnet value=true value=false
 set name=variant.opensolaris.zone value=global value=nonglobal
@@ -2464,283 +3147,329 @@ file elfarch=sparc elfbits=32 group=bin mode=0555 owner=root path=usr/lib/isaexe
 file  elfarch=i386 elfbits=32 group=bin mode=0555 owner=root path=usr/lib/isaexec pkg.csize=3791 pkg.size=9696 variant.foo=i386 variant.debug.osnet=true
 file elfarch=i386 elfbits=32 group=bin mode=0555 owner=root path=usr/lib/isaexec pkg.csize=3137 pkg.size=8208 variant.foo=i386 variant.debug.osnet=false
 """
-                dep_path = self.make_manifest(dep_manf)
-                ksh_path = self.make_manifest(ksh_manf)
-                cos_path = self.make_manifest(core_os)
+        dep_path = self.make_manifest(dep_manf)
+        ksh_path = self.make_manifest(ksh_manf)
+        cos_path = self.make_manifest(core_os)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path, ksh_path, cos_path],
-                        self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[ksh_path]), 0)
-                self.assertEqual(len(pkg_deps[cos_path]), 0)
-                self.assertEqual(len(pkg_deps[dep_path]), 2,
-                    "Got wrong number of pkgdeps for the file package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[dep_path]])))
-                for dep in pkg_deps[dep_path]:
-                        self.assertTrue("variant.foo" not in dep.attrs, str(dep))
-                        self.assertTrue("variant.debug.osnet" not in
-                            dep.attrs, str(dep))
-                        self.assertTrue("variant.opensolaris.zone" not in
-                            dep.attrs, str(dep))
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [dep_path, ksh_path, cos_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[ksh_path]), 0)
+        self.assertEqual(len(pkg_deps[cos_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[dep_path]),
+            2,
+            "Got wrong number of pkgdeps for the file package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[dep_path]])
+            ),
+        )
+        for dep in pkg_deps[dep_path]:
+            self.assertTrue("variant.foo" not in dep.attrs, str(dep))
+            self.assertTrue("variant.debug.osnet" not in dep.attrs, str(dep))
+            self.assertTrue(
+                "variant.opensolaris.zone" not in dep.attrs, str(dep)
+            )
 
-        def test_bug_18884_2(self):
-                """Similar test to test_bug_18884_1 except only two variants are
-                in play, not three.  This may make future debugging easier to
-                handle."""
+    def test_bug_18884_2(self):
+        """Similar test to test_bug_18884_1 except only two variants are
+        in play, not three.  This may make future debugging easier to
+        handle."""
 
-                dep_manf = """ \
+        dep_manf = """ \
 set name=pkg.fmri value=test@1.0
 depend type=require fmri=__TBD pkg.debug.depend.file=ksh93 \
     pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=test-script.ksh93 \
     pkg.debug.depend.type=script
 """
 
-                ksh_manf = """ \
+        ksh_manf = """ \
 set name=pkg.fmri value=shell/ksh@1.0
 set name=variant.foo value=sparc value=i386
 set name=variant.opensolaris.zone value=global value=nonglobal
 hardlink path=usr/bin/ksh93 target=../../usr/lib/isaexec
 """
 
-                core_os = """ \
+        core_os = """ \
 set name=pkg.fmri value=system/core-os@1.0
 set name=variant.opensolaris.zone value=global value=nonglobal
 set name=variant.foo value=sparc value=i386
 file elfarch=sparc elfbits=32 group=bin mode=0555 owner=root path=usr/lib/isaexec pkg.csize=3633 pkg.size=12124 variant.foo=sparc
 file elfarch=i386 elfbits=32 group=bin mode=0555 owner=root path=usr/lib/isaexec pkg.csize=3137 pkg.size=8208 variant.foo=i386
 """
-                dep_path = self.make_manifest(dep_manf)
-                ksh_path = self.make_manifest(ksh_manf)
-                cos_path = self.make_manifest(core_os)
+        dep_path = self.make_manifest(dep_manf)
+        ksh_path = self.make_manifest(ksh_manf)
+        cos_path = self.make_manifest(core_os)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path, ksh_path, cos_path],
-                        self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[ksh_path]), 0)
-                self.assertEqual(len(pkg_deps[cos_path]), 0)
-                self.assertEqual(len(pkg_deps[dep_path]), 2,
-                    "Got wrong number of pkgdeps for the file package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[dep_path]])))
-                for dep in pkg_deps[dep_path]:
-                        self.assertTrue("variant.opensolaris.zone" not in
-                            dep.attrs, str(dep))
-                        self.assertTrue("variant.debug.osnet" not in
-                            dep.attrs, str(dep))
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [dep_path, ksh_path, cos_path], self.api_obj, []
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[ksh_path]), 0)
+        self.assertEqual(len(pkg_deps[cos_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[dep_path]),
+            2,
+            "Got wrong number of pkgdeps for the file package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[dep_path]])
+            ),
+        )
+        for dep in pkg_deps[dep_path]:
+            self.assertTrue(
+                "variant.opensolaris.zone" not in dep.attrs, str(dep)
+            )
+            self.assertTrue("variant.debug.osnet" not in dep.attrs, str(dep))
 
-        def test_bug_19009_conditional_collapsing_corner_cases(self):
-                """Check that conditional dependencies are handled correctly in
-                unusual situations."""
+    def test_bug_19009_conditional_collapsing_corner_cases(self):
+        """Check that conditional dependencies are handled correctly in
+        unusual situations."""
 
-                # Check that conditionals are only reduced to required
-                # dependencies if the require dependency specifies a successor
-                # to the predicate fmri.
-                manf = """
+        # Check that conditionals are only reduced to required
+        # dependencies if the require dependency specifies a successor
+        # to the predicate fmri.
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 depend fmri=pkg:/a@0-1 type=conditional predicate=pkg:/b@2-1
 depend fmri=pkg:/b@1-1 type=require
 """
 
-                manf_path = self.make_manifest(manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([manf_path], self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["a", "b"]), external_deps)
-                self.assertEqual(len(errs), 0,
-                    "\n".join([str(e) for e in errs]))
-                self.debug("pkg_deps:{0}".format(pkg_deps))
-                self.assertEqual(len(pkg_deps), 1)
-                self.assertEqual(len(pkg_deps[manf_path]), 2)
-                for d in pkg_deps[manf_path]:
-                        if d.attrs["fmri"].startswith("pkg:/a"):
-                                self.assertEqual(d.attrs["type"], "conditional")
+        manf_path = self.make_manifest(manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([manf_path], self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["a", "b"]), external_deps)
+        self.assertEqual(len(errs), 0, "\n".join([str(e) for e in errs]))
+        self.debug("pkg_deps:{0}".format(pkg_deps))
+        self.assertEqual(len(pkg_deps), 1)
+        self.assertEqual(len(pkg_deps[manf_path]), 2)
+        for d in pkg_deps[manf_path]:
+            if d.attrs["fmri"].startswith("pkg:/a"):
+                self.assertEqual(d.attrs["type"], "conditional")
 
-                # The following tests check that conditional collapsing happens
-                # correctly in the face of variants of conditional and require
-                # dependencies.
+        # The following tests check that conditional collapsing happens
+        # correctly in the face of variants of conditional and require
+        # dependencies.
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 set name=variant.num value=one value=two
 depend fmri=pkg:/a@0-1 type=conditional predicate=pkg:/b@2-1
 depend fmri=pkg:/b@2-1 type=require variant.num=two
 """
 
-                manf_path = self.make_manifest(manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([manf_path], self.api_obj, [])
-                self.assertEqual(len(errs), 0,
-                    "\n".join([str(e) for e in errs]))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["a", "b"]), external_deps)
-                self.debug("pkg_deps:{0}".format(pkg_deps))
-                self.assertEqual(len(pkg_deps), 1)
-                self.assertEqual(len(pkg_deps[manf_path]), 3,
-                    "Expected 3 dependencies got {0}. Deps are:\n{1}".format(
-                    len(pkg_deps[manf_path]), "\n".join(
-                    [str(s) for s in pkg_deps[manf_path]])))
-                have_req = False
-                have_uncollapsed_cond = False
-                have_collapsed_cond = False
-                for d in pkg_deps[manf_path]:
-                        if d.attrs["fmri"].startswith("pkg:/b"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["variant.num"], "two")
-                                have_req = True
-                        elif d.attrs["type"] == "conditional":
-                                self.assertEqual(d.attrs["fmri"],
-                                    "pkg:/a@0-1")
-                                self.assertEqual(d.attrs["variant.num"], "one")
-                                self.assertTrue("predicate" in d.attrs)
-                                have_uncollapsed_cond = True
-                        else:
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["fmri"],
-                                    "pkg:/a@0-1")
-                                self.assertEqual(d.attrs["variant.num"], "two")
-                                self.assertTrue("predicate" not in d.attrs)
-                                have_collapsed_cond = True
-                self.assertTrue(have_req)
-                self.assertTrue(have_uncollapsed_cond)
-                self.assertTrue(have_collapsed_cond)
+        manf_path = self.make_manifest(manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([manf_path], self.api_obj, [])
+        self.assertEqual(len(errs), 0, "\n".join([str(e) for e in errs]))
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["a", "b"]), external_deps)
+        self.debug("pkg_deps:{0}".format(pkg_deps))
+        self.assertEqual(len(pkg_deps), 1)
+        self.assertEqual(
+            len(pkg_deps[manf_path]),
+            3,
+            "Expected 3 dependencies got {0}. Deps are:\n{1}".format(
+                len(pkg_deps[manf_path]),
+                "\n".join([str(s) for s in pkg_deps[manf_path]]),
+            ),
+        )
+        have_req = False
+        have_uncollapsed_cond = False
+        have_collapsed_cond = False
+        for d in pkg_deps[manf_path]:
+            if d.attrs["fmri"].startswith("pkg:/b"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["variant.num"], "two")
+                have_req = True
+            elif d.attrs["type"] == "conditional":
+                self.assertEqual(d.attrs["fmri"], "pkg:/a@0-1")
+                self.assertEqual(d.attrs["variant.num"], "one")
+                self.assertTrue("predicate" in d.attrs)
+                have_uncollapsed_cond = True
+            else:
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["fmri"], "pkg:/a@0-1")
+                self.assertEqual(d.attrs["variant.num"], "two")
+                self.assertTrue("predicate" not in d.attrs)
+                have_collapsed_cond = True
+        self.assertTrue(have_req)
+        self.assertTrue(have_uncollapsed_cond)
+        self.assertTrue(have_collapsed_cond)
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 set name=variant.num value=one value=two
 depend fmri=pkg:/a@0-1 type=conditional predicate=pkg:/b@2-1 variant.num=two
 depend fmri=pkg:/b@2-1 type=require
 """
 
-                manf_path = self.make_manifest(manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([manf_path], self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["a", "b"]), external_deps)
-                self.assertEqual(len(errs), 0,
-                    "\n".join([str(e) for e in errs]))
-                self.debug("pkg_deps:{0}".format(pkg_deps))
-                self.assertEqual(len(pkg_deps), 1)
-                self.assertEqual(len(pkg_deps[manf_path]), 2)
-                have_req = False
-                have_collapsed_cond = False
-                for d in pkg_deps[manf_path]:
-                        if d.attrs["fmri"].startswith("pkg:/b"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                have_req = True
-                        else:
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["fmri"],
-                                    "pkg:/a@0-1")
-                                self.assertEqual(d.attrs["variant.num"], "two")
-                                self.assertTrue("predicate" not in d.attrs)
-                                have_collapsed_cond = True
-                self.assertTrue(have_req)
-                self.assertTrue(have_collapsed_cond)
+        manf_path = self.make_manifest(manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([manf_path], self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["a", "b"]), external_deps)
+        self.assertEqual(len(errs), 0, "\n".join([str(e) for e in errs]))
+        self.debug("pkg_deps:{0}".format(pkg_deps))
+        self.assertEqual(len(pkg_deps), 1)
+        self.assertEqual(len(pkg_deps[manf_path]), 2)
+        have_req = False
+        have_collapsed_cond = False
+        for d in pkg_deps[manf_path]:
+            if d.attrs["fmri"].startswith("pkg:/b"):
+                self.assertEqual(d.attrs["type"], "require")
+                have_req = True
+            else:
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["fmri"], "pkg:/a@0-1")
+                self.assertEqual(d.attrs["variant.num"], "two")
+                self.assertTrue("predicate" not in d.attrs)
+                have_collapsed_cond = True
+        self.assertTrue(have_req)
+        self.assertTrue(have_collapsed_cond)
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 set name=variant.num value=one value=two
 depend fmri=pkg:/a@0-1 type=conditional predicate=pkg:/b@2-1 variant.num=one
 depend fmri=pkg:/b@2-1 type=require variant.num=two
 """
 
-                manf_path = self.make_manifest(manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([manf_path], self.api_obj, [])
-                self.assertEqual(len(errs), 0,
-                    "\n".join([str(e) for e in errs]))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["a", "b"]), external_deps)
-                self.debug("pkg_deps:{0}".format(pkg_deps))
-                self.assertEqual(len(pkg_deps), 1)
-                self.assertEqual(len(pkg_deps[manf_path]), 2)
-                have_req = False
-                have_uncollapsed_cond = False
-                for d in pkg_deps[manf_path]:
-                        if d.attrs["fmri"].startswith("pkg:/b"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["variant.num"], "two")
-                                have_req = True
-                        else:
-                                self.assertEqual(d.attrs["type"], "conditional")
-                                self.assertEqual(d.attrs["fmri"],
-                                    "pkg:/a@0-1")
-                                self.assertEqual(d.attrs["variant.num"], "one")
-                                self.assertTrue("predicate" in d.attrs)
-                                have_uncollapsed_cond = True
-                self.assertTrue(have_req)
-                self.assertTrue(have_uncollapsed_cond)
+        manf_path = self.make_manifest(manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([manf_path], self.api_obj, [])
+        self.assertEqual(len(errs), 0, "\n".join([str(e) for e in errs]))
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["a", "b"]), external_deps)
+        self.debug("pkg_deps:{0}".format(pkg_deps))
+        self.assertEqual(len(pkg_deps), 1)
+        self.assertEqual(len(pkg_deps[manf_path]), 2)
+        have_req = False
+        have_uncollapsed_cond = False
+        for d in pkg_deps[manf_path]:
+            if d.attrs["fmri"].startswith("pkg:/b"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["variant.num"], "two")
+                have_req = True
+            else:
+                self.assertEqual(d.attrs["type"], "conditional")
+                self.assertEqual(d.attrs["fmri"], "pkg:/a@0-1")
+                self.assertEqual(d.attrs["variant.num"], "one")
+                self.assertTrue("predicate" in d.attrs)
+                have_uncollapsed_cond = True
+        self.assertTrue(have_req)
+        self.assertTrue(have_uncollapsed_cond)
 
-        def test_bug_19009_collapsing_conditional_to_require_any(self):
-                """Check that conditional dependencies don't get collapsed into
-                require-any dependencies and that manually specified
-                dependencies aren't improperly collapsed."""
+    def test_bug_19009_collapsing_conditional_to_require_any(self):
+        """Check that conditional dependencies don't get collapsed into
+        require-any dependencies and that manually specified
+        dependencies aren't improperly collapsed."""
 
-                # Check that manually specified conditional dependencies aren't
-                # collapsed into require-any dependencies.
+        # Check that manually specified conditional dependencies aren't
+        # collapsed into require-any dependencies.
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 depend fmri=pkg:/a@0-1 type=conditional predicate=pkg:/b@2-1
 depend fmri=pkg:/c@0-1 type=conditional predicate=pkg:/b@2-1
 depend fmri=pkg:/b@2-1 type=require
 """
 
-                manf_path = self.make_manifest(manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([manf_path], self.api_obj, [])
-                self.assertEqual(len(errs), 0,
-                    "\n".join([str(e) for e in errs]))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(["a", "b", "c"]), external_deps)
-                self.debug("pkg_deps:{0}".format(pkg_deps))
-                self.assertEqual(len(pkg_deps), 1)
-                self.assertEqual(len(pkg_deps[manf_path]), 3)
-                have_req = False
-                have_cond_a = False
-                have_cond_c = False
-                for d in pkg_deps[manf_path]:
-                        if d.attrs["fmri"].startswith("pkg:/b"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                have_req = True
-                        elif d.attrs["fmri"].startswith("pkg:/a"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["fmri"],
-                                    "pkg:/a@0-1")
-                                have_cond_a = True
-                        else:
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["fmri"],
-                                    "pkg:/c@0-1")
-                                have_cond_c = True
-                self.assertTrue(have_req)
-                self.assertTrue(have_cond_a)
-                self.assertTrue(have_cond_c)
+        manf_path = self.make_manifest(manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([manf_path], self.api_obj, [])
+        self.assertEqual(len(errs), 0, "\n".join([str(e) for e in errs]))
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(["a", "b", "c"]), external_deps)
+        self.debug("pkg_deps:{0}".format(pkg_deps))
+        self.assertEqual(len(pkg_deps), 1)
+        self.assertEqual(len(pkg_deps[manf_path]), 3)
+        have_req = False
+        have_cond_a = False
+        have_cond_c = False
+        for d in pkg_deps[manf_path]:
+            if d.attrs["fmri"].startswith("pkg:/b"):
+                self.assertEqual(d.attrs["type"], "require")
+                have_req = True
+            elif d.attrs["fmri"].startswith("pkg:/a"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["fmri"], "pkg:/a@0-1")
+                have_cond_a = True
+            else:
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["fmri"], "pkg:/c@0-1")
+                have_cond_c = True
+        self.assertTrue(have_req)
+        self.assertTrue(have_cond_a)
+        self.assertTrue(have_cond_c)
 
-                # Check that manually specified conditional dependencies aren't
-                # collapsed into require-any dependencies even if other
-                # conditional dependencies are being reduced to require-any
-                # dependencies.  If the manual dependencies were not included in
-                # the manifest, then a require dependency on b and a require-any
-                # dependency on a and c would be produced.  Since the manual
-                # conditional dependencies on a and c will reduce to simple
-                # require dependencies on a and c, the require-any dependency on
-                # a and c will be dropped.
+        # Check that manually specified conditional dependencies aren't
+        # collapsed into require-any dependencies even if other
+        # conditional dependencies are being reduced to require-any
+        # dependencies.  If the manual dependencies were not included in
+        # the manifest, then a require dependency on b and a require-any
+        # dependency on a and c would be produced.  Since the manual
+        # conditional dependencies on a and c will reduce to simple
+        # require dependencies on a and c, the require-any dependency on
+        # a and c will be dropped.
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 depend fmri=pkg:/a@3-1 type=conditional predicate=pkg:/b@2-1
 depend fmri=pkg:/c@3-1 type=conditional predicate=pkg:/b@2-1
@@ -2748,62 +3477,67 @@ depend fmri=pkg:/b@2-1 type=require
 depend fmri=__TBD pkg.debug.depend.file=var/log/syslog pkg.debug.depend.reason=usr/bar pkg.debug.depend.type=hardlink type=require
 """
 
-                a_manf = """
+        a_manf = """
 set name=pkg.fmri value=a@0.0,5.11-1
 link path=var/log/syslog target=bar
 """
 
-                c_manf = """
+        c_manf = """
 set name=pkg.fmri value=c@0.0,5.11-1
 link path=var/log/syslog target=bar
 """
 
-                b_manf = """
+        b_manf = """
 set name=pkg.fmri value=b@2.0,5.11-1
 file NOHASH group=sys mode=0600 owner=root path=var/log/bar
 """
-                manf_path = self.make_manifest(manf)
-                a_path = self.make_manifest(a_manf)
-                b_path = self.make_manifest(b_manf)
-                c_path = self.make_manifest(c_manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [manf_path, a_path, b_path, c_path],
-                        self.api_obj, [])
-                self.assertEqual(len(errs), 0,
-                    "\n".join([str(e) for e in errs]))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.debug("pkg_deps:\n{0}".format("\n".join(
-                    [str(d) for d in pkg_deps[manf_path]])))
-                self.assertEqual(len(pkg_deps), 4)
-                self.assertEqual(len(pkg_deps[manf_path]), 4)
-                have_req = 0
-                have_cond_a = False
-                have_cond_c = False
-                for d in pkg_deps[manf_path]:
-                        if d.attrs["fmri"].startswith("pkg:/b"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                have_req += 1
-                        elif d.attrs["fmri"].startswith("pkg:/a"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["fmri"],
-                                    "pkg:/a@3-1")
-                                have_cond_a = True
-                        else:
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["fmri"],
-                                    "pkg:/c@3-1")
-                                have_cond_c = True
-                self.assertEqual(have_req, 2)
-                self.assertTrue(have_cond_a)
-                self.assertTrue(have_cond_c)
+        manf_path = self.make_manifest(manf)
+        a_path = self.make_manifest(a_manf)
+        b_path = self.make_manifest(b_manf)
+        c_path = self.make_manifest(c_manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [manf_path, a_path, b_path, c_path], self.api_obj, []
+        )
+        self.assertEqual(len(errs), 0, "\n".join([str(e) for e in errs]))
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "pkg_deps:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[manf_path]])
+            )
+        )
+        self.assertEqual(len(pkg_deps), 4)
+        self.assertEqual(len(pkg_deps[manf_path]), 4)
+        have_req = 0
+        have_cond_a = False
+        have_cond_c = False
+        for d in pkg_deps[manf_path]:
+            if d.attrs["fmri"].startswith("pkg:/b"):
+                self.assertEqual(d.attrs["type"], "require")
+                have_req += 1
+            elif d.attrs["fmri"].startswith("pkg:/a"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["fmri"], "pkg:/a@3-1")
+                have_cond_a = True
+            else:
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["fmri"], "pkg:/c@3-1")
+                have_cond_c = True
+        self.assertEqual(have_req, 2)
+        self.assertTrue(have_cond_a)
+        self.assertTrue(have_cond_c)
 
-                # Check that an inferred require-any dependency will not be
-                # removed if the require dependencies in the package are at a
-                # lower version of the pacakge.
+        # Check that an inferred require-any dependency will not be
+        # removed if the require dependencies in the package are at a
+        # lower version of the pacakge.
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 depend fmri=pkg:/a@0-1 type=conditional predicate=pkg:/b@2-1
 depend fmri=pkg:/c@0-1 type=conditional predicate=pkg:/b@2-1
@@ -2811,1372 +3545,1857 @@ depend fmri=pkg:/b@2-1 type=require
 depend fmri=__TBD pkg.debug.depend.file=var/log/syslog pkg.debug.depend.reason=usr/bar pkg.debug.depend.type=hardlink type=require
 """
 
-                a_manf = """
+        a_manf = """
 set name=pkg.fmri value=a@2,5.11-1
 link path=var/log/syslog target=bar
 """
 
-                c_manf = """
+        c_manf = """
 set name=pkg.fmri value=c@2,5.11-1
 link path=var/log/syslog target=bar
 """
 
-                b_manf = """
+        b_manf = """
 set name=pkg.fmri value=b@2.0,5.11-1
 file NOHASH group=sys mode=0600 owner=root path=var/log/bar
 """
-                manf_path = self.make_manifest(manf)
-                a_path = self.make_manifest(a_manf)
-                b_path = self.make_manifest(b_manf)
-                c_path = self.make_manifest(c_manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([manf_path, a_path, b_path, c_path],
-                        self.api_obj, [])
-                self.assertEqual(len(errs), 0,
-                    "\n".join([str(e) for e in errs]))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.debug("pkg_deps:\n{0}".format("\n".join(
-                    [str(d) for d in pkg_deps[manf_path]])))
-                self.assertEqual(len(pkg_deps), 4)
-                self.assertEqual(len(pkg_deps[manf_path]), 5)
-                have_req = 0
-                have_cond_a = False
-                have_cond_c = False
-                have_req_any = False
-                for d in pkg_deps[manf_path]:
-                        if d.attrs["type"] == "require-any":
-                                self.assertEqual(set(d.attrlist("fmri")),
-                                    set(["pkg:/a@2-1", "pkg:/c@2-1"]))
-                                self.assertTrue("predicate" not in d.attrs)
-                                have_req_any = True
-                        elif d.attrs["fmri"].startswith("pkg:/b"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                have_req += 1
-                        elif d.attrs["fmri"].startswith("pkg:/a"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["fmri"],
-                                    "pkg:/a@0-1")
-                                have_cond_a = True
-                        elif d.attrs["fmri"].startswith("pkg:/c"):
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(d.attrs["fmri"],
-                                    "pkg:/c@0-1")
-                                have_cond_c = True
-                self.assertEqual(have_req, 2)
-                self.assertTrue(have_cond_a)
-                self.assertTrue(have_cond_c)
-                self.assertTrue(have_req_any)
+        manf_path = self.make_manifest(manf)
+        a_path = self.make_manifest(a_manf)
+        b_path = self.make_manifest(b_manf)
+        c_path = self.make_manifest(c_manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [manf_path, a_path, b_path, c_path], self.api_obj, []
+        )
+        self.assertEqual(len(errs), 0, "\n".join([str(e) for e in errs]))
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "pkg_deps:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[manf_path]])
+            )
+        )
+        self.assertEqual(len(pkg_deps), 4)
+        self.assertEqual(len(pkg_deps[manf_path]), 5)
+        have_req = 0
+        have_cond_a = False
+        have_cond_c = False
+        have_req_any = False
+        for d in pkg_deps[manf_path]:
+            if d.attrs["type"] == "require-any":
+                self.assertEqual(
+                    set(d.attrlist("fmri")), set(["pkg:/a@2-1", "pkg:/c@2-1"])
+                )
+                self.assertTrue("predicate" not in d.attrs)
+                have_req_any = True
+            elif d.attrs["fmri"].startswith("pkg:/b"):
+                self.assertEqual(d.attrs["type"], "require")
+                have_req += 1
+            elif d.attrs["fmri"].startswith("pkg:/a"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["fmri"], "pkg:/a@0-1")
+                have_cond_a = True
+            elif d.attrs["fmri"].startswith("pkg:/c"):
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs["fmri"], "pkg:/c@0-1")
+                have_cond_c = True
+        self.assertEqual(have_req, 2)
+        self.assertTrue(have_cond_a)
+        self.assertTrue(have_cond_c)
+        self.assertTrue(have_req_any)
 
-        def __check_19009_results(self, pkg_deps, errs, paths,
-            expected_conditionals, expected_require_any, expected_require,
-            expected_num_deps):
-                """Check that the generated dependencies match the expected
-                dependencies.  This function is designed for tests associated
-                with bug 19009."""
+    def __check_19009_results(
+        self,
+        pkg_deps,
+        errs,
+        paths,
+        expected_conditionals,
+        expected_require_any,
+        expected_require,
+        expected_num_deps,
+    ):
+        """Check that the generated dependencies match the expected
+        dependencies.  This function is designed for tests associated
+        with bug 19009."""
 
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(pkg_deps), len(paths))
-                # Only the first manifest should have any dependencies since the
-                # others only provide files and links.
-                for p in paths[1:]:
-                        self.assertEqual(len(pkg_deps[p]), 0,
-                            "Got unexpected dependencies for {0}.  Dependencies "
-                            "are:\n{1}".format(p, pkg_deps[p]))
-                deps = pkg_deps[paths[0]]
-                self.debug("Dependencies are:\n{0}".format(
-                    "\n".join([str(d) for d in deps])))
-                self.assertEqual(len(deps), expected_num_deps,
-                    "Expected {0} dependencies got {1}. The dependencies "
-                    "were:\n\t{2}".format(expected_num_deps, len(deps),
-                    "\n\t".join([str(s) for s in deps])))
-                lec = len(expected_conditionals)
-                lera = len(expected_require_any)
-                ler = len(expected_require)
-                self.debug("ec:{0} era:{1} er:{2}".format(lec, lera, ler))
-                self.assertEqual(expected_num_deps, lec + lera + ler,
-                    "Manually expected {0} but the number of dependencies in "
-                    "the expected types was {1}. The dependencies were:\n\t{2}".format(
-                    len(deps), lec + lera + ler,
-                    "\n\t".join([str(s) for s in deps])))
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(pkg_deps), len(paths))
+        # Only the first manifest should have any dependencies since the
+        # others only provide files and links.
+        for p in paths[1:]:
+            self.assertEqual(
+                len(pkg_deps[p]),
+                0,
+                "Got unexpected dependencies for {0}.  Dependencies "
+                "are:\n{1}".format(p, pkg_deps[p]),
+            )
+        deps = pkg_deps[paths[0]]
+        self.debug(
+            "Dependencies are:\n{0}".format("\n".join([str(d) for d in deps]))
+        )
+        self.assertEqual(
+            len(deps),
+            expected_num_deps,
+            "Expected {0} dependencies got {1}. The dependencies "
+            "were:\n\t{2}".format(
+                expected_num_deps,
+                len(deps),
+                "\n\t".join([str(s) for s in deps]),
+            ),
+        )
+        lec = len(expected_conditionals)
+        lera = len(expected_require_any)
+        ler = len(expected_require)
+        self.debug("ec:{0} era:{1} er:{2}".format(lec, lera, ler))
+        self.assertEqual(
+            expected_num_deps,
+            lec + lera + ler,
+            "Manually expected {0} but the number of dependencies in "
+            "the expected types was {1}. The dependencies were:\n\t{2}".format(
+                len(deps), lec + lera + ler, "\n\t".join([str(s) for s in deps])
+            ),
+        )
 
-                found_conditionals = set()
-                found_require = set()
-                found_require_any = set()
-                for d in deps:
-                        if d.attrs["type"] == "require":
-                                found_require.add(d.attrs["fmri"])
+        found_conditionals = set()
+        found_require = set()
+        found_require_any = set()
+        for d in deps:
+            if d.attrs["type"] == "require":
+                found_require.add(d.attrs["fmri"])
 
-                        elif d.attrs["type"] == "require-any":
-                                found_require_any.add(frozenset(
-                                    d.attrs["fmri"]))
-                                self.assertTrue(len(d.attrlist("fmri")) > 1)
-                        elif d.attrs["type"] == "conditional":
-                                found_conditionals.add((d.attrs["fmri"],
-                                    d.attrs["predicate"]))
-                        else:
-                                raise RuntimeError(
-                                    "Got unexpected dependency:{0}".format(d))
+            elif d.attrs["type"] == "require-any":
+                found_require_any.add(frozenset(d.attrs["fmri"]))
+                self.assertTrue(len(d.attrlist("fmri")) > 1)
+            elif d.attrs["type"] == "conditional":
+                found_conditionals.add((d.attrs["fmri"], d.attrs["predicate"]))
+            else:
+                raise RuntimeError("Got unexpected dependency:{0}".format(d))
 
-                self.assertEqualDiff(sorted(expected_conditionals),
-                    sorted(found_conditionals))
-                self.assertEqualDiff(sorted(expected_require),
-                    sorted(found_require))
-                expected_but_not_seen = expected_require_any - found_require_any
-                seen_but_not_expected = found_require_any - expected_require_any
-                self.assertEqualDiff(expected_but_not_seen,
-                    seen_but_not_expected)
+        self.assertEqualDiff(
+            sorted(expected_conditionals), sorted(found_conditionals)
+        )
+        self.assertEqualDiff(sorted(expected_require), sorted(found_require))
+        expected_but_not_seen = expected_require_any - found_require_any
+        seen_but_not_expected = found_require_any - expected_require_any
+        self.assertEqualDiff(expected_but_not_seen, seen_but_not_expected)
 
-        def __construct_19009_info(self, chains):
-                """Many of the tests for bug 19009 are similar.  This function
-                takes a description of the combinations of packages which should
-                satisfy a file dependency and generates a set of manifests to
-                match that desctiption, the dot encoding of the package
-                dependency graph, and the set of expected dependencies of
-                different types needed to represent the package dependencies."""
+    def __construct_19009_info(self, chains):
+        """Many of the tests for bug 19009 are similar.  This function
+        takes a description of the combinations of packages which should
+        satisfy a file dependency and generates a set of manifests to
+        match that desctiption, the dot encoding of the package
+        dependency graph, and the set of expected dependencies of
+        different types needed to represent the package dependencies."""
 
-                expected_conditionals = set()
-                expected_require_any = set()
-                expected_require = set()
+        expected_conditionals = set()
+        expected_require_any = set()
+        expected_require = set()
 
-                manf_info = {}
-                start_pfmri = None
-                end_pfmris = set()
-                dot_encoding = """\
+        manf_info = {}
+        start_pfmri = None
+        end_pfmris = set()
+        dot_encoding = """\
 digraph G {
         rankdir=BT;
         A [shape=box];
 """
-                spacer = "        "
-                pkg_template = "pkg:/{0}@1.0"
+        spacer = "        "
+        pkg_template = "pkg:/{0}@1.0"
 
-                # Collect the set of package names which should deliver a file.
-                for c in chains:
-                        self.assertTrue(len(c) > 1)
-                        end_pfmris.add(c[-1])
-                # If only a single package delivers a file, then a require
-                # dependency is expected.
-                if len(end_pfmris) == 1:
-                        expected_require.add(pkg_template.format(end_pfmris.pop()))
-                else:
-                        # Otherwise all the package names which ended a chain
-                        # form a require-any dependency.
-                        for p in end_pfmris:
-                                expected_require_any.add(pkg_template.format(p))
+        # Collect the set of package names which should deliver a file.
+        for c in chains:
+            self.assertTrue(len(c) > 1)
+            end_pfmris.add(c[-1])
+        # If only a single package delivers a file, then a require
+        # dependency is expected.
+        if len(end_pfmris) == 1:
+            expected_require.add(pkg_template.format(end_pfmris.pop()))
+        else:
+            # Otherwise all the package names which ended a chain
+            # form a require-any dependency.
+            for p in end_pfmris:
+                expected_require_any.add(pkg_template.format(p))
 
-                # Determine what dependencies are needed to represent each chain
-                # of packages.
-                for c in chains:
-                        if start_pfmri is None:
-                                start_pfmri = c[0]
-                        else:
-                                self.assertEqual(c[0], start_pfmri)
-                        dot_encoding += spacer + "->".join(c) + ";\n"
-                        if len(c) > 2:
-                                t = [pkg_template.format(p) for p in c]
-                                for node, child in zip(t[1:], t[2:]):
-                                        if child in expected_require:
-                                                expected_require_any.add(node)
-                                        else:
-                                                expected_conditionals.add(
-                                                    (node, child))
-                        for pth, pfmri in zip(c, c[1:]):
-                                manf_info.setdefault(pfmri, {}).setdefault(
-                                    "path", []).append(pth.lower())
-                        # Triangles indicate packages which deliver a file.
-                        dot_encoding += spacer + c[-1] + " [shape=triangle]\n"
-                        manf_info.setdefault(c[-1], {})["provides_file"] = \
-                            c[-1].lower()
+        # Determine what dependencies are needed to represent each chain
+        # of packages.
+        for c in chains:
+            if start_pfmri is None:
+                start_pfmri = c[0]
+            else:
+                self.assertEqual(c[0], start_pfmri)
+            dot_encoding += spacer + "->".join(c) + ";\n"
+            if len(c) > 2:
+                t = [pkg_template.format(p) for p in c]
+                for node, child in zip(t[1:], t[2:]):
+                    if child in expected_require:
+                        expected_require_any.add(node)
+                    else:
+                        expected_conditionals.add((node, child))
+            for pth, pfmri in zip(c, c[1:]):
+                manf_info.setdefault(pfmri, {}).setdefault("path", []).append(
+                    pth.lower()
+                )
+            # Triangles indicate packages which deliver a file.
+            dot_encoding += spacer + c[-1] + " [shape=triangle]\n"
+            manf_info.setdefault(c[-1], {})["provides_file"] = c[-1].lower()
 
-                expected_require_any = set([frozenset(expected_require_any)])
-                dot_encoding += "}"
-                # The first manifest always contains only a file dependency.
-                manfs = ["""\
+        expected_require_any = set([frozenset(expected_require_any)])
+        dot_encoding += "}"
+        # The first manifest always contains only a file dependency.
+        manfs = [
+            """\
 set name=pkg.fmri value={pfmri}@1.0
 depend type=require fmri=__TBD pkg.debug.depend.file={path} \\
     pkg.debug.depend.reason=needs_{path} pkg.debug.depend.type=elf
-""".format(pfmri=start_pfmri, path=start_pfmri.lower())]
+""".format(
+                pfmri=start_pfmri, path=start_pfmri.lower()
+            )
+        ]
 
-                # These templates are used to generate the other manifests.
-                template = """\
+        # These templates are used to generate the other manifests.
+        template = """\
 set name=pkg.fmri value={0}@1.0
 """
-                file_template = """\
+        file_template = """\
 file path={0} group=sys mode=0600 owner=root
 """
-                link_template = """\
+        link_template = """\
 link path={path} target={target}
 """
-                # Generate each manifest desired.
-                for pfmri, detail in sorted(manf_info.items()):
-                        m = template.format(pfmri)
-                        if "provides_file" in detail:
-                                m += file_template.format(detail["provides_file"])
-                        for pth in set(detail.get("path", [])):
-                                m += link_template.format(
-                                    path=pth, target=pfmri.lower())
-                        manfs.append(m)
+        # Generate each manifest desired.
+        for pfmri, detail in sorted(manf_info.items()):
+            m = template.format(pfmri)
+            if "provides_file" in detail:
+                m += file_template.format(detail["provides_file"])
+            for pth in set(detail.get("path", [])):
+                m += link_template.format(path=pth, target=pfmri.lower())
+            manfs.append(m)
 
-                # Include useful information in the debugging output of the
-                # test.
-                self.debug("To see the link graph of this test use dot on "
-                    "this:\n{0}".format(dot_encoding))
-                self.debug("The manifests for this test are:")
-                for m in sorted(manfs):
-                        self.debug(m + "\n")
-                self.debug("Expected conditionals are:")
-                for pair in sorted(expected_conditionals):
-                        self.debug("\tfmri:{0}\tpredicate:{1}".format(*pair))
-                if len(expected_require_any) > 1:
-                        self.debug("Expected pfmris in require-any are: {0}".format(
-                            " ".join(sorted(expected_require_any))))
-                if expected_require:
-                        self.debug("Expected pfmri in require is:{0}".format(
-                            expected_require))
+        # Include useful information in the debugging output of the
+        # test.
+        self.debug(
+            "To see the link graph of this test use dot on "
+            "this:\n{0}".format(dot_encoding)
+        )
+        self.debug("The manifests for this test are:")
+        for m in sorted(manfs):
+            self.debug(m + "\n")
+        self.debug("Expected conditionals are:")
+        for pair in sorted(expected_conditionals):
+            self.debug("\tfmri:{0}\tpredicate:{1}".format(*pair))
+        if len(expected_require_any) > 1:
+            self.debug(
+                "Expected pfmris in require-any are: {0}".format(
+                    " ".join(sorted(expected_require_any))
+                )
+            )
+        if expected_require:
+            self.debug(
+                "Expected pfmri in require is:{0}".format(expected_require)
+            )
 
-                return manfs, expected_conditionals, expected_require_any, \
-                    expected_require
+        return (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        )
 
-        def test_bug_19009_inexpressible_1(self):
-                """Check that when resolve a configuration of dependencies that
-                can't be represented using the existing dependency types, an
-                error occurs."""
+    def test_bug_19009_inexpressible_1(self):
+        """Check that when resolve a configuration of dependencies that
+        can't be represented using the existing dependency types, an
+        error occurs."""
 
-                chains = [
-                    ("A", "B", "E"),
-                    ("A", "C", "E"),
-                    ("A", "D", "F"),
-                ]
+        chains = [
+            ("A", "B", "E"),
+            ("A", "C", "E"),
+            ("A", "D", "F"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.debug("Deps:\n{0}".format("\n".join([
-                    str(d) for d in pkg_deps[paths[0]]])))
-                self.assertEqual(len(errs), 1)
-                err = errs[0]
-                self.assertEqual(len(err.conditionals), 1)
-                self.assertTrue(isinstance(err,
-                    dependencies.NeedConditionalRequireAny))
-                # Check that the exception prints correctly.
-                self.debug(err)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Deps:\n{0}".format("\n".join([str(d) for d in pkg_deps[paths[0]]]))
+        )
+        self.assertEqual(len(errs), 1)
+        err = errs[0]
+        self.assertEqual(len(err.conditionals), 1)
+        self.assertTrue(isinstance(err, dependencies.NeedConditionalRequireAny))
+        # Check that the exception prints correctly.
+        self.debug(err)
 
-        def test_bug_19009_inexpressible_2(self):
-                """Check that when resolve a configuration of dependencies that
-                can't be represented using the existing dependency types, an
-                error occurs."""
+    def test_bug_19009_inexpressible_2(self):
+        """Check that when resolve a configuration of dependencies that
+        can't be represented using the existing dependency types, an
+        error occurs."""
 
-                chains = [
-                    ("A", "B", "E", "G"),
-                    ("A", "C", "E", "G"),
-                    ("A", "D", "F")
-                ]
+        chains = [("A", "B", "E", "G"), ("A", "C", "E", "G"), ("A", "D", "F")]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.debug("Deps:\n{0}".format("\n".join([
-                    str(d) for d in pkg_deps[paths[0]]])))
-                self.assertEqual(len(errs), 1)
-                err = errs[0]
-                self.assertEqual(len(err.conditionals), 1)
-                self.assertTrue(isinstance(err,
-                    dependencies.NeedConditionalRequireAny))
-                # Check that the exception prints correctly.
-                self.debug(err)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Deps:\n{0}".format("\n".join([str(d) for d in pkg_deps[paths[0]]]))
+        )
+        self.assertEqual(len(errs), 1)
+        err = errs[0]
+        self.assertEqual(len(err.conditionals), 1)
+        self.assertTrue(isinstance(err, dependencies.NeedConditionalRequireAny))
+        # Check that the exception prints correctly.
+        self.debug(err)
 
-        def test_bug_19009_inexpressible_3(self):
-                """Check that when resolve a configuration of dependencies that
-                can't be represented using the existing dependency types, an
-                error occurs."""
+    def test_bug_19009_inexpressible_3(self):
+        """Check that when resolve a configuration of dependencies that
+        can't be represented using the existing dependency types, an
+        error occurs."""
 
-                chains = [
-                    ("A", "B", "D", "F", "H"),
-                    ("A", "B", "E", "G", "H"),
-                    ("A", "C", "I"),
-                ]
+        chains = [
+            ("A", "B", "D", "F", "H"),
+            ("A", "B", "E", "G", "H"),
+            ("A", "C", "I"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.debug("Deps:\n{0}".format("\n".join([
-                    str(d) for d in pkg_deps[paths[0]]])))
-                self.assertEqual(len(errs), 1)
-                err = errs[0]
-                self.assertEqual(len(err.conditionals), 1)
-                self.assertTrue(isinstance(err,
-                    dependencies.NeedConditionalRequireAny))
-                # Check that the exception prints correctly.
-                self.debug(err)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Deps:\n{0}".format("\n".join([str(d) for d in pkg_deps[paths[0]]]))
+        )
+        self.assertEqual(len(errs), 1)
+        err = errs[0]
+        self.assertEqual(len(err.conditionals), 1)
+        self.assertTrue(isinstance(err, dependencies.NeedConditionalRequireAny))
+        # Check that the exception prints correctly.
+        self.debug(err)
 
-        def test_bug_19009_inexpressible_4(self):
-                """Check that when resolve a configuration of dependencies that
-                can't be represented using the existing dependency types, an
-                error occurs."""
+    def test_bug_19009_inexpressible_4(self):
+        """Check that when resolve a configuration of dependencies that
+        can't be represented using the existing dependency types, an
+        error occurs."""
 
-                chains = [
-                    ("A", "B", "D", "F", "I"),
-                    ("A", "B", "E", "H"),
-                    ("A", "C", "G", "I"),
-                ]
+        chains = [
+            ("A", "B", "D", "F", "I"),
+            ("A", "B", "E", "H"),
+            ("A", "C", "G", "I"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.debug("Deps:\n{0}".format("\n".join([
-                    str(d) for d in pkg_deps[paths[0]]])))
-                self.assertEqual(len(errs), 1)
-                err = errs[0]
-                self.assertEqual(len(err.conditionals), 1)
-                self.assertTrue(isinstance(err,
-                    dependencies.NeedConditionalRequireAny))
-                # Check that the exception prints correctly.
-                self.debug(err)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Deps:\n{0}".format("\n".join([str(d) for d in pkg_deps[paths[0]]]))
+        )
+        self.assertEqual(len(errs), 1)
+        err = errs[0]
+        self.assertEqual(len(err.conditionals), 1)
+        self.assertTrue(isinstance(err, dependencies.NeedConditionalRequireAny))
+        # Check that the exception prints correctly.
+        self.debug(err)
 
-        def test_bug_19009_inexpressible_5(self):
-                """Check that when resolve a configuration of dependencies that
-                can't be represented using the existing dependency types, an
-                error occurs."""
+    def test_bug_19009_inexpressible_5(self):
+        """Check that when resolve a configuration of dependencies that
+        can't be represented using the existing dependency types, an
+        error occurs."""
 
-                chains = [
-                    ("A", "B", "E"),
-                    ("A", "C", "E"),
-                    ("A", "D"),
-                ]
+        chains = [
+            ("A", "B", "E"),
+            ("A", "C", "E"),
+            ("A", "D"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.debug("Deps:\n{0}".format("\n".join([
-                    str(d) for d in pkg_deps[paths[0]]])))
-                self.assertEqual(len(errs), 1)
-                err = errs[0]
-                self.assertEqual(len(err.conditionals), 1)
-                self.assertTrue(isinstance(err,
-                    dependencies.NeedConditionalRequireAny))
-                # Check that the exception prints correctly.
-                self.debug(err)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Deps:\n{0}".format("\n".join([str(d) for d in pkg_deps[paths[0]]]))
+        )
+        self.assertEqual(len(errs), 1)
+        err = errs[0]
+        self.assertEqual(len(err.conditionals), 1)
+        self.assertTrue(isinstance(err, dependencies.NeedConditionalRequireAny))
+        # Check that the exception prints correctly.
+        self.debug(err)
 
-        def test_bug_19009_inexpressible_with_variants_1(self):
-                """Check that when resolve a configuration of dependencies that
-                can't be represented using the existing dependency types, an
-                error occurs and that the right error happens when variants are
-                involved."""
+    def test_bug_19009_inexpressible_with_variants_1(self):
+        """Check that when resolve a configuration of dependencies that
+        can't be represented using the existing dependency types, an
+        error occurs and that the right error happens when variants are
+        involved."""
 
-                chains = [
-                    ("A", "B", "E"),
-                    ("A", "C", "E"),
-                    ("A", "D", "F"),
-                ]
+        chains = [
+            ("A", "B", "E"),
+            ("A", "C", "E"),
+            ("A", "D", "F"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                manfs[0] += "set name=variant.num value=one value=two\n"
-                manfs[1] += "set name=variant.num value=one\n"
-                self.debug("The manifest for package B has been modified to "
-                    "only apply when variant.num is one.")
+        manfs[0] += "set name=variant.num value=one value=two\n"
+        manfs[1] += "set name=variant.num value=one\n"
+        self.debug(
+            "The manifest for package B has been modified to "
+            "only apply when variant.num is one."
+        )
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.debug("Deps:\n{0}".format("\n".join([
-                    str(d) for d in pkg_deps[paths[0]]])))
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Deps:\n{0}".format("\n".join([str(d) for d in pkg_deps[paths[0]]]))
+        )
 
-                self.assertEqual(len(errs), 1)
-                err = errs[0]
-                self.assertTrue(isinstance(err,
-                    dependencies.NeedConditionalRequireAny))
-                self.assertEqual(len(err.conditionals), 1)
-                self.assertEqualDiff(sorted(set([
-                    frozenset([("variant.num", "one")])])),
-                    sorted(err.conditionals[0][2].sat_set))
-                # Check that the exception prints correctly.
-                self.debug(err)
+        self.assertEqual(len(errs), 1)
+        err = errs[0]
+        self.assertTrue(isinstance(err, dependencies.NeedConditionalRequireAny))
+        self.assertEqual(len(err.conditionals), 1)
+        self.assertEqualDiff(
+            sorted(set([frozenset([("variant.num", "one")])])),
+            sorted(err.conditionals[0][2].sat_set),
+        )
+        # Check that the exception prints correctly.
+        self.debug(err)
 
-        def test_bug_19009_inexpressible_with_variants_2(self):
-                """Check that when resolve a configuration of dependencies that
-                can't be represented using the existing dependency types, an
-                error occurs and that the right error happens when variants are
-                involved."""
+    def test_bug_19009_inexpressible_with_variants_2(self):
+        """Check that when resolve a configuration of dependencies that
+        can't be represented using the existing dependency types, an
+        error occurs and that the right error happens when variants are
+        involved."""
 
-                chains = [
-                    ("A", "B", "E"),
-                    ("A", "C", "E"),
-                    ("A", "D", "F"),
-                ]
+        chains = [
+            ("A", "B", "E"),
+            ("A", "C", "E"),
+            ("A", "D", "F"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                manfs[0] += "set name=variant.num value=one value=two\n"
-                manfs[0] += "set name=variant.foo value=bar value=baz\n"
-                manfs[1] += "set name=variant.num value=one\n"
-                manfs[1] += "set name=variant.foo value=bar\n"
+        manfs[0] += "set name=variant.num value=one value=two\n"
+        manfs[0] += "set name=variant.foo value=bar value=baz\n"
+        manfs[1] += "set name=variant.num value=one\n"
+        manfs[1] += "set name=variant.foo value=bar\n"
 
-                self.debug("The manifest for package B has been modified to "
-                    "only apply when variant.num is one and variant.foo is "
-                    "bar.")
+        self.debug(
+            "The manifest for package B has been modified to "
+            "only apply when variant.num is one and variant.foo is "
+            "bar."
+        )
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.debug("Deps:\n{0}".format("\n".join([
-                    str(d) for d in pkg_deps[paths[0]]])))
-                self.assertEqual(len(errs), 1)
-                err = errs[0]
-                self.assertTrue(isinstance(err,
-                    dependencies.NeedConditionalRequireAny))
-                self.assertEqual(len(err.conditionals), 1)
-                self.assertEqualDiff(sorted(set([
-                    frozenset([("variant.foo", "bar"),
-                        ("variant.num", "one")])])),
-                    sorted(err.conditionals[0][2].sat_set))
-                # Check that the exception prints correctly.
-                self.debug(err)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Deps:\n{0}".format("\n".join([str(d) for d in pkg_deps[paths[0]]]))
+        )
+        self.assertEqual(len(errs), 1)
+        err = errs[0]
+        self.assertTrue(isinstance(err, dependencies.NeedConditionalRequireAny))
+        self.assertEqual(len(err.conditionals), 1)
+        self.assertEqualDiff(
+            sorted(
+                set(
+                    [
+                        frozenset(
+                            [("variant.foo", "bar"), ("variant.num", "one")]
+                        )
+                    ]
+                )
+            ),
+            sorted(err.conditionals[0][2].sat_set),
+        )
+        # Check that the exception prints correctly.
+        self.debug(err)
 
-        def test_bug_19009_inexpressible_with_variants_3(self):
-                """Check that when resolve a configuration of dependencies that
-                can't be represented using the existing dependency types, an
-                error occurs and that the right error happens when variants are
-                involved."""
+    def test_bug_19009_inexpressible_with_variants_3(self):
+        """Check that when resolve a configuration of dependencies that
+        can't be represented using the existing dependency types, an
+        error occurs and that the right error happens when variants are
+        involved."""
 
-                chains = [
-                    ("A", "B", "E"),
-                    ("A", "C", "E"),
-                    ("A", "D", "F"),
-                ]
+        chains = [
+            ("A", "B", "E"),
+            ("A", "C", "E"),
+            ("A", "D", "F"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                manfs[0] += "set name=variant.num value=one value=two\n"
-                manfs[0] += "set name=variant.foo value=bar value=baz\n"
-                manfs[1] += "set name=variant.num value=one\n"
+        manfs[0] += "set name=variant.num value=one value=two\n"
+        manfs[0] += "set name=variant.foo value=bar value=baz\n"
+        manfs[1] += "set name=variant.num value=one\n"
 
-                self.debug("The manifest for package B has been modified to "
-                    "only apply when variant.num is one.")
+        self.debug(
+            "The manifest for package B has been modified to "
+            "only apply when variant.num is one."
+        )
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.debug("Deps:\n{0}".format("\n".join([
-                    str(d) for d in pkg_deps[paths[0]]])))
-                self.assertEqual(len(errs), 1)
-                err = errs[0]
-                self.assertTrue(isinstance(err,
-                    dependencies.NeedConditionalRequireAny))
-                self.assertEqual(len(err.conditionals), 1)
-                expected_vars = set([
-                    frozenset([("variant.foo", "bar"), ("variant.num", "one")]),
-                    frozenset([("variant.foo", "baz"), ("variant.num", "one")])
-                ])
-                expected_but_not_seen = expected_vars - \
-                    err.conditionals[0][2].sat_set
-                seen_but_not_expected = err.conditionals[0][2].sat_set - \
-                    expected_vars
-                self.assertEqualDiff(expected_but_not_seen,
-                    seen_but_not_expected)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Deps:\n{0}".format("\n".join([str(d) for d in pkg_deps[paths[0]]]))
+        )
+        self.assertEqual(len(errs), 1)
+        err = errs[0]
+        self.assertTrue(isinstance(err, dependencies.NeedConditionalRequireAny))
+        self.assertEqual(len(err.conditionals), 1)
+        expected_vars = set(
+            [
+                frozenset([("variant.foo", "bar"), ("variant.num", "one")]),
+                frozenset([("variant.foo", "baz"), ("variant.num", "one")]),
+            ]
+        )
+        expected_but_not_seen = expected_vars - err.conditionals[0][2].sat_set
+        seen_but_not_expected = err.conditionals[0][2].sat_set - expected_vars
+        self.assertEqualDiff(expected_but_not_seen, seen_but_not_expected)
 
-                # Check that the exception prints correctly.
-                self.debug(err)
-                self.assertTrue("variant.foo" not in str(err))
+        # Check that the exception prints correctly.
+        self.debug(err)
+        self.assertTrue("variant.foo" not in str(err))
 
-        def test_bug_19009_no_links_one_variant(self):
-                """Test that resolve correctly handles multiple packages
-                delivering a file which is the target of a file dependency when
-                variants are involved."""
+    def test_bug_19009_no_links_one_variant(self):
+        """Test that resolve correctly handles multiple packages
+        delivering a file which is the target of a file dependency when
+        variants are involved."""
 
-                dep_manf_two_val = """\
+        dep_manf_two_val = """\
 set name=pkg.fmri value=test@1.0
 set name=variant.num value=one value=two
 depend type=require fmri=__TBD pkg.debug.depend.file=foo \
     pkg.debug.depend.reason=needs_foo pkg.debug.depend.type=elf
 """
 
-                dep_manf_three_val = """\
+        dep_manf_three_val = """\
 set name=pkg.fmri value=test@1.0
 set name=variant.num value=one value=two value=three
 depend type=require fmri=__TBD pkg.debug.depend.file=foo \
     pkg.debug.depend.reason=needs_foo pkg.debug.depend.type=elf
 """
 
-                res1_manf_1 = """\
+        res1_manf_1 = """\
 set name=pkg.fmri value=res1@1.0
 set name=variant.num value=one
 file group=bin mode=0555 owner=root path=foo
 """
 
-                res1_manf_13 = """\
+        res1_manf_13 = """\
 set name=pkg.fmri value=res1@1.0
 set name=variant.num value=one value=three
 file group=bin mode=0555 owner=root path=foo
 """
 
-                res2_manf_12 = """\
+        res2_manf_12 = """\
 set name=pkg.fmri value=res2@1.0
 set name=variant.num value=one value=two
 file group=bin mode=0555 owner=root path=foo
 """
 
-                res3_manf_3 = """\
+        res3_manf_3 = """\
 set name=pkg.fmri value=res3@1.0
 set name=variant.num value=three
 file group=bin mode=0555 owner=root path=foo
 """
 
-                res3_manf_23 = """\
+        res3_manf_23 = """\
 set name=pkg.fmri value=res3@1.0
 set name=variant.num value=two value=three
 file group=bin mode=0555 owner=root path=foo
 """
 
-                dep_path = self.make_manifest(dep_manf_two_val)
-                res1_path = self.make_manifest(res1_manf_1)
-                res2_path = self.make_manifest(res2_manf_12)
+        dep_path = self.make_manifest(dep_manf_two_val)
+        res1_path = self.make_manifest(res1_manf_1)
+        res2_path = self.make_manifest(res2_manf_12)
 
-                # Check that one package delivering under all variants and one
-                # delivering under a particular combination works.
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path, res1_path, res2_path],
-                        self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[res1_path]), 0)
-                self.assertEqual(len(pkg_deps[res2_path]), 0)
-                self.assertEqual(len(pkg_deps[dep_path]), 2,
-                    "Got wrong number of pkgdeps for the file package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[dep_path]])))
-                have_req_any = False
-                have_required = False
-                for d in pkg_deps[dep_path]:
-                        if d.attrs["type"] == "require-any" and \
-                            set(d.attrs["fmri"]) == \
-                            set(["pkg:/res1@1.0", "pkg:/res2@1.0"]) and \
-                            d.attrs["variant.num"] == "one":
-                                have_req_any = True
-                        elif d.attrs["type"] == "require" and \
-                            d.attrs["fmri"] == "pkg:/res2@1.0" and \
-                            d.attrs["variant.num"] == "two":
-                                have_required = True
-                        else:
-                                raise RuntimeError("Unexpected dependency:{0}"%
-                                    d)
-                self.assertTrue(have_req_any)
-                self.assertTrue(have_required)
+        # Check that one package delivering under all variants and one
+        # delivering under a particular combination works.
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [dep_path, res1_path, res2_path], self.api_obj, []
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[res1_path]), 0)
+        self.assertEqual(len(pkg_deps[res2_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[dep_path]),
+            2,
+            "Got wrong number of pkgdeps for the file package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[dep_path]])
+            ),
+        )
+        have_req_any = False
+        have_required = False
+        for d in pkg_deps[dep_path]:
+            if (
+                d.attrs["type"] == "require-any"
+                and set(d.attrs["fmri"])
+                == set(["pkg:/res1@1.0", "pkg:/res2@1.0"])
+                and d.attrs["variant.num"] == "one"
+            ):
+                have_req_any = True
+            elif (
+                d.attrs["type"] == "require"
+                and d.attrs["fmri"] == "pkg:/res2@1.0"
+                and d.attrs["variant.num"] == "two"
+            ):
+                have_required = True
+            else:
+                raise RuntimeError("Unexpected dependency:{0}" % d)
+        self.assertTrue(have_req_any)
+        self.assertTrue(have_required)
 
-                # Check that three packages each delivering under two of three
-                # variant values works.
-                dep_path = self.make_manifest(dep_manf_three_val)
-                res1_path = self.make_manifest(res1_manf_13)
-                res2_path = self.make_manifest(res2_manf_12)
-                res3_path = self.make_manifest(res3_manf_23)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [dep_path, res1_path, res2_path, res3_path],
-                        self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(pkg_deps), 4)
-                self.assertEqual(len(pkg_deps[res1_path]), 0)
-                self.assertEqual(len(pkg_deps[res2_path]), 0)
-                self.assertEqual(len(pkg_deps[res3_path]), 0)
-                self.assertEqual(len(pkg_deps[dep_path]), 3,
-                    "Got wrong number of pkgdeps for the file package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[dep_path]])))
-                var_one = False
-                var_two = False
-                var_three = False
-                for d in pkg_deps[dep_path]:
-                        self.assertEqual(d.attrs["type"], "require-any")
-                        if set(d.attrs["fmri"]) == \
-                            set(["pkg:/res1@1.0", "pkg:/res2@1.0"]) and \
-                            d.attrs["variant.num"] == "one":
-                                var_one = True
-                        elif set(d.attrs["fmri"]) == \
-                            set(["pkg:/res2@1.0", "pkg:/res3@1.0"]) and \
-                            d.attrs["variant.num"] == "two":
-                                var_two = True
-                        elif set(d.attrs["fmri"]) == \
-                            set(["pkg:/res1@1.0", "pkg:/res3@1.0"]) and \
-                            d.attrs["variant.num"] == "three":
-                                var_three = True
-                        else:
-                                raise RuntimeError(
-                                    "Unexpected dependency:{0}".format(d))
+        # Check that three packages each delivering under two of three
+        # variant values works.
+        dep_path = self.make_manifest(dep_manf_three_val)
+        res1_path = self.make_manifest(res1_manf_13)
+        res2_path = self.make_manifest(res2_manf_12)
+        res3_path = self.make_manifest(res3_manf_23)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [dep_path, res1_path, res2_path, res3_path], self.api_obj, []
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(pkg_deps), 4)
+        self.assertEqual(len(pkg_deps[res1_path]), 0)
+        self.assertEqual(len(pkg_deps[res2_path]), 0)
+        self.assertEqual(len(pkg_deps[res3_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[dep_path]),
+            3,
+            "Got wrong number of pkgdeps for the file package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[dep_path]])
+            ),
+        )
+        var_one = False
+        var_two = False
+        var_three = False
+        for d in pkg_deps[dep_path]:
+            self.assertEqual(d.attrs["type"], "require-any")
+            if (
+                set(d.attrs["fmri"]) == set(["pkg:/res1@1.0", "pkg:/res2@1.0"])
+                and d.attrs["variant.num"] == "one"
+            ):
+                var_one = True
+            elif (
+                set(d.attrs["fmri"]) == set(["pkg:/res2@1.0", "pkg:/res3@1.0"])
+                and d.attrs["variant.num"] == "two"
+            ):
+                var_two = True
+            elif (
+                set(d.attrs["fmri"]) == set(["pkg:/res1@1.0", "pkg:/res3@1.0"])
+                and d.attrs["variant.num"] == "three"
+            ):
+                var_three = True
+            else:
+                raise RuntimeError("Unexpected dependency:{0}".format(d))
 
-        def test_bug_19009_no_links_unvarianted(self):
-                """Test that resolve correctly handles multiple packages
-                delivering a file which is the target of a file dependency."""
+    def test_bug_19009_no_links_unvarianted(self):
+        """Test that resolve correctly handles multiple packages
+        delivering a file which is the target of a file dependency."""
 
-                dep_manf = """\
+        dep_manf = """\
 set name=pkg.fmri value=test@1.0
 depend type=require fmri=__TBD pkg.debug.depend.file=foo \
     pkg.debug.depend.reason=needs_foo pkg.debug.depend.type=elf
 """
 
-                res1_manf = """\
+        res1_manf = """\
 set name=pkg.fmri value=res1@1.0
 file group=bin mode=0555 owner=root path=foo
 """
 
-                res2_manf = """\
+        res2_manf = """\
 set name=pkg.fmri value=res2@1.0
 file group=bin mode=0555 owner=root path=foo
 """
 
-                res3_manf = """\
+        res3_manf = """\
 set name=pkg.fmri value=res3@1.0
 file group=bin mode=0555 owner=root path=foo
 """
 
-                dep_path = self.make_manifest(dep_manf)
-                res1_path = self.make_manifest(res1_manf)
-                res2_path = self.make_manifest(res2_manf)
-                res3_path = self.make_manifest(res3_manf)
+        dep_path = self.make_manifest(dep_manf)
+        res1_path = self.make_manifest(res1_manf)
+        res2_path = self.make_manifest(res2_manf)
+        res3_path = self.make_manifest(res3_manf)
 
-                # Check that resolving with two packages works...
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path, res1_path, res2_path],
-                        self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(pkg_deps), 3)
-                self.assertEqual(len(pkg_deps[res1_path]), 0)
-                self.assertEqual(len(pkg_deps[res2_path]), 0)
-                self.assertEqual(len(pkg_deps[dep_path]), 1,
-                    "Got wrong number of pkgdeps for the file package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[dep_path]])))
-                d = pkg_deps[dep_path][0]
-                self.assertEqual(d.attrs["type"], "require-any")
-                self.assertEqual(set(d.attrs["fmri"]),
-                    set(["pkg:/res1@1.0", "pkg:/res2@1.0"]))
+        # Check that resolving with two packages works...
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [dep_path, res1_path, res2_path], self.api_obj, []
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(pkg_deps), 3)
+        self.assertEqual(len(pkg_deps[res1_path]), 0)
+        self.assertEqual(len(pkg_deps[res2_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[dep_path]),
+            1,
+            "Got wrong number of pkgdeps for the file package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[dep_path]])
+            ),
+        )
+        d = pkg_deps[dep_path][0]
+        self.assertEqual(d.attrs["type"], "require-any")
+        self.assertEqual(
+            set(d.attrs["fmri"]), set(["pkg:/res1@1.0", "pkg:/res2@1.0"])
+        )
 
-                # And that three does as well.
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(
-                        [dep_path, res1_path, res2_path, res3_path],
-                        self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(pkg_deps), 4)
-                self.assertEqual(len(pkg_deps[res1_path]), 0)
-                self.assertEqual(len(pkg_deps[res2_path]), 0)
-                self.assertEqual(len(pkg_deps[res3_path]), 0)
-                self.assertEqual(len(pkg_deps[dep_path]), 1,
-                    "Got wrong number of pkgdeps for the file package. "
-                    "Deps were:\n{0}".format(
-                    "\n".join([str(d) for d in pkg_deps[dep_path]])))
-                d = pkg_deps[dep_path][0]
-                self.assertEqual(d.attrs["type"], "require-any")
-                self.assertEqual(set(d.attrs["fmri"]),
-                    set(["pkg:/res1@1.0", "pkg:/res2@1.0", "pkg:/res3@1.0"]))
+        # And that three does as well.
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [dep_path, res1_path, res2_path, res3_path], self.api_obj, []
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(pkg_deps), 4)
+        self.assertEqual(len(pkg_deps[res1_path]), 0)
+        self.assertEqual(len(pkg_deps[res2_path]), 0)
+        self.assertEqual(len(pkg_deps[res3_path]), 0)
+        self.assertEqual(
+            len(pkg_deps[dep_path]),
+            1,
+            "Got wrong number of pkgdeps for the file package. "
+            "Deps were:\n{0}".format(
+                "\n".join([str(d) for d in pkg_deps[dep_path]])
+            ),
+        )
+        d = pkg_deps[dep_path][0]
+        self.assertEqual(d.attrs["type"], "require-any")
+        self.assertEqual(
+            set(d.attrs["fmri"]),
+            set(["pkg:/res1@1.0", "pkg:/res2@1.0", "pkg:/res3@1.0"]),
+        )
 
-        def test_bug_19009_remove_paths_1(self):
-                """Test that when a require dependency on one of the packages in
-                the inferred require-any dependency exists, the path to that
-                package is chosen by resolve."""
+    def test_bug_19009_remove_paths_1(self):
+        """Test that when a require dependency on one of the packages in
+        the inferred require-any dependency exists, the path to that
+        package is chosen by resolve."""
 
-                chains = [
-                    ("A", "B", "D"),
-                    ("A", "C", "E"),
-                ]
+        chains = [
+            ("A", "B", "D"),
+            ("A", "C", "E"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                orig_a_manf = manfs[0]
-                dep_line = "depend fmri=pkg:/D@2.0 type=require\n"
+        orig_a_manf = manfs[0]
+        dep_line = "depend fmri=pkg:/D@2.0 type=require\n"
 
-                self.debug("Adding the following line to the manifest for "
-                    "A:\n:{0}".format(dep_line))
+        self.debug(
+            "Adding the following line to the manifest for "
+            "A:\n:{0}".format(dep_line)
+        )
 
-                new_a_manf = orig_a_manf + dep_line
-                paths = [
-                    self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])
-                ]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                expected_require_any = set()
-                expected_conditionals = set()
-                expected_require = set(["pkg:/D@2.0", "pkg:/B@1.0"])
-                self.debug("Because of the additional dependency, there should "
-                    "be two require dependencies and no conditional "
-                    "dependencies.")
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 2)
+        new_a_manf = orig_a_manf + dep_line
+        paths = [self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        expected_require_any = set()
+        expected_conditionals = set()
+        expected_require = set(["pkg:/D@2.0", "pkg:/B@1.0"])
+        self.debug(
+            "Because of the additional dependency, there should "
+            "be two require dependencies and no conditional "
+            "dependencies."
+        )
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            2,
+        )
 
-        def test_bug_19009_remove_paths_2(self):
-                """Test that when a require dependency on one of the packages in
-                the inferred require-any dependency exists under some variant
-                combinations, the path to that package is chosen by resolve only
-                under those variant combinations."""
+    def test_bug_19009_remove_paths_2(self):
+        """Test that when a require dependency on one of the packages in
+        the inferred require-any dependency exists under some variant
+        combinations, the path to that package is chosen by resolve only
+        under those variant combinations."""
 
-                chains = [
-                    ("A", "B", "D"),
-                    ("A", "C", "E"),
-                ]
+        chains = [
+            ("A", "B", "D"),
+            ("A", "C", "E"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                orig_a_manf = manfs[0]
-                dep_line = """\
+        orig_a_manf = manfs[0]
+        dep_line = """\
 set name=variant.num value=one value=two
 depend fmri=pkg:/D@2.0 type=require variant.num=one
 """
-                self.debug("Adding the following lines to the manifest for "
-                    "A:\n:{0}".format(dep_line))
+        self.debug(
+            "Adding the following lines to the manifest for "
+            "A:\n:{0}".format(dep_line)
+        )
 
-                new_a_manf = orig_a_manf + dep_line
-                paths = [
-                    self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])
-                ]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
+        new_a_manf = orig_a_manf + dep_line
+        paths = [self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
 
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(pkg_deps), len(paths))
-                for p in paths[1:]:
-                        self.assertEqual(len(pkg_deps[p]), 0, "Got unexpected "
-                            "dependencies for {0}.  Dependencies are:\n{1}".format(
-                            p, pkg_deps[p]))
-                deps = pkg_deps[paths[0]]
-                self.debug("Dependencies are:\n{0}".format("\n".join(
-                    [str(d) for d in deps])))
-                self.debug("Five dependencies are expected.  Two require "
-                    "dependencies when variant.num=one, and three (one "
-                    "require-any and two conditional) when variant.num=two.")
-                expected_require = set(["pkg:/D@2.0", "pkg:/B@1.0"])
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 5)
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(pkg_deps), len(paths))
+        for p in paths[1:]:
+            self.assertEqual(
+                len(pkg_deps[p]),
+                0,
+                "Got unexpected "
+                "dependencies for {0}.  Dependencies are:\n{1}".format(
+                    p, pkg_deps[p]
+                ),
+            )
+        deps = pkg_deps[paths[0]]
+        self.debug(
+            "Dependencies are:\n{0}".format("\n".join([str(d) for d in deps]))
+        )
+        self.debug(
+            "Five dependencies are expected.  Two require "
+            "dependencies when variant.num=one, and three (one "
+            "require-any and two conditional) when variant.num=two."
+        )
+        expected_require = set(["pkg:/D@2.0", "pkg:/B@1.0"])
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            5,
+        )
 
-                # Now check the variants are set correctly on all the
-                # dependencies.
-                for d in deps:
-                        if d.attrs["type"] in ("conditional", "require-any"):
-                                self.assertEqual(
-                                    d.attrs.get("variant.num", None), "two",
-                                    "Bad dependency was:{0}".format(d))
-                        else:
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs.get("variant.num", None), "one",
-                                    "Bad dependency was:{0}".format(d))
+        # Now check the variants are set correctly on all the
+        # dependencies.
+        for d in deps:
+            if d.attrs["type"] in ("conditional", "require-any"):
+                self.assertEqual(
+                    d.attrs.get("variant.num", None),
+                    "two",
+                    "Bad dependency was:{0}".format(d),
+                )
+            else:
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(
+                    d.attrs.get("variant.num", None),
+                    "one",
+                    "Bad dependency was:{0}".format(d),
+                )
 
-        def test_bug_19009_remove_paths_3(self):
-                """Test that when a require dependency on one of the packages in
-                the inferred require-any dependency exists under some variant
-                combinations, the path to that package is chosen by resolve only
-                under those variant combinations."""
+    def test_bug_19009_remove_paths_3(self):
+        """Test that when a require dependency on one of the packages in
+        the inferred require-any dependency exists under some variant
+        combinations, the path to that package is chosen by resolve only
+        under those variant combinations."""
 
-                chains = [
-                    ("A", "B", "D", "F"),
-                    ("A", "C", "E", "G"),
-                ]
+        chains = [
+            ("A", "B", "D", "F"),
+            ("A", "C", "E", "G"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                orig_a_manf = manfs[0]
-                dep_line = """\
+        orig_a_manf = manfs[0]
+        dep_line = """\
 set name=variant.num value=one value=two
 depend fmri=pkg:/F@2.0 type=require variant.num=one
 """
-                self.debug("Adding the following lines to the manifest for "
-                    "A:\n{0}".format(dep_line))
-                new_a_manf = orig_a_manf + dep_line
-                paths = [
-                    self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])
-                ]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Adding the following lines to the manifest for "
+            "A:\n{0}".format(dep_line)
+        )
+        new_a_manf = orig_a_manf + dep_line
+        paths = [self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
 
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(pkg_deps), len(paths))
-                for p in paths[1:]:
-                        self.assertEqual(len(pkg_deps[p]), 0, "Got unexpected "
-                            "dependencies for {0}.  Dependencies are:\n{1}".format(
-                            p, pkg_deps[p]))
-                deps = pkg_deps[paths[0]]
-                self.debug("Dependencies are:\n{0}".format("\n".join(
-                    [str(d) for d in deps])))
-                expected_require = set(["pkg:/B@1.0", "pkg:/D@1.0",
-                    "pkg:/F@2.0"])
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 8)
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(pkg_deps), len(paths))
+        for p in paths[1:]:
+            self.assertEqual(
+                len(pkg_deps[p]),
+                0,
+                "Got unexpected "
+                "dependencies for {0}.  Dependencies are:\n{1}".format(
+                    p, pkg_deps[p]
+                ),
+            )
+        deps = pkg_deps[paths[0]]
+        self.debug(
+            "Dependencies are:\n{0}".format("\n".join([str(d) for d in deps]))
+        )
+        expected_require = set(["pkg:/B@1.0", "pkg:/D@1.0", "pkg:/F@2.0"])
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            8,
+        )
 
-                # Now check the variants are set correctly on all the
-                # dependencies.
-                for d in deps:
-                        if d.attrs["type"] in ("conditional", "require-any"):
-                                self.assertEqual(
-                                    d.attrs.get("variant.num", None), "two",
-                                    "Bad dependency was:{0}".format(d))
-                        else:
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs.get("variant.num", None), "one",
-                                    "Bad dependency was:{0}".format(d))
+        # Now check the variants are set correctly on all the
+        # dependencies.
+        for d in deps:
+            if d.attrs["type"] in ("conditional", "require-any"):
+                self.assertEqual(
+                    d.attrs.get("variant.num", None),
+                    "two",
+                    "Bad dependency was:{0}".format(d),
+                )
+            else:
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(
+                    d.attrs.get("variant.num", None),
+                    "one",
+                    "Bad dependency was:{0}".format(d),
+                )
 
-        def test_bug_19009_remove_paths_4(self):
-                """Test that when a require dependency on one of the packages in
-                the inferred require-any dependency exists under some variant
-                combinations, the path to that package is chosen by resolve only
-                under those variant combinations."""
+    def test_bug_19009_remove_paths_4(self):
+        """Test that when a require dependency on one of the packages in
+        the inferred require-any dependency exists under some variant
+        combinations, the path to that package is chosen by resolve only
+        under those variant combinations."""
 
-                chains = [
-                    ("A", "B", "D", "F"),
-                    ("A", "C", "E", "G"),
-                ]
+        chains = [
+            ("A", "B", "D", "F"),
+            ("A", "C", "E", "G"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                orig_a_manf = manfs[0]
-                dep_line = """\
+        orig_a_manf = manfs[0]
+        dep_line = """\
 set name=variant.num value=one value=two
 depend fmri=pkg:/F@2.0 type=require variant.num=one
 depend fmri=pkg:/G@2.0 type=require variant.num=two
 """
-                self.debug("Adding the following lines to the manifest for "
-                    "A:\n{0}".format(dep_line))
-                new_a_manf = orig_a_manf + dep_line
-                paths = [
-                    self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])
-                ]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Adding the following lines to the manifest for "
+            "A:\n{0}".format(dep_line)
+        )
+        new_a_manf = orig_a_manf + dep_line
+        paths = [self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
 
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(pkg_deps), len(paths))
-                for p in paths[1:]:
-                        self.assertEqual(len(pkg_deps[p]), 0, "Got unexpected "
-                            "dependencies for {0}.  Dependencies are:\n{1}".format(
-                            p, pkg_deps[p]))
-                deps = pkg_deps[paths[0]]
-                self.debug("Dependencies are:\n{0}".format("\n".join(
-                    [str(d) for d in deps])))
-                self.debug("Six require dependencies are expected since all "
-                    "conditional dependencies collapse to require dependencies "
-                    "under one of the two variants.")
-                expected_require_any = set()
-                expected_conditionals = set()
-                expected_require = set(["pkg:/B@1.0", "pkg:/C@1.0",
-                    "pkg:/D@1.0", "pkg:/E@1.0", "pkg:/F@2.0", "pkg:/G@2.0"])
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 6)
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(pkg_deps), len(paths))
+        for p in paths[1:]:
+            self.assertEqual(
+                len(pkg_deps[p]),
+                0,
+                "Got unexpected "
+                "dependencies for {0}.  Dependencies are:\n{1}".format(
+                    p, pkg_deps[p]
+                ),
+            )
+        deps = pkg_deps[paths[0]]
+        self.debug(
+            "Dependencies are:\n{0}".format("\n".join([str(d) for d in deps]))
+        )
+        self.debug(
+            "Six require dependencies are expected since all "
+            "conditional dependencies collapse to require dependencies "
+            "under one of the two variants."
+        )
+        expected_require_any = set()
+        expected_conditionals = set()
+        expected_require = set(
+            [
+                "pkg:/B@1.0",
+                "pkg:/C@1.0",
+                "pkg:/D@1.0",
+                "pkg:/E@1.0",
+                "pkg:/F@2.0",
+                "pkg:/G@2.0",
+            ]
+        )
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            6,
+        )
 
-                # Now check the variants are set correctly on all the
-                # dependencies.
-                for d in deps:
-                        if d.attrs["fmri"] in \
-                            ("pkg:/B@1.0", "pkg:/D@1.0", "pkg:/F@2.0"):
-                                self.assertEqual(
-                                    d.attrs.get("variant.num", None), "one")
-                        elif d.attrs["fmri"] in \
-                            ("pkg:/C@1.0", "pkg:/E@1.0", "pkg:/G@2.0"):
-                                self.assertEqual(
-                                    d.attrs.get("variant.num", None), "two")
-                        else:
-                                raise RuntimeError("Unexpected fmri in "
-                                    "dependency:{0}".format(d))
+        # Now check the variants are set correctly on all the
+        # dependencies.
+        for d in deps:
+            if d.attrs["fmri"] in ("pkg:/B@1.0", "pkg:/D@1.0", "pkg:/F@2.0"):
+                self.assertEqual(d.attrs.get("variant.num", None), "one")
+            elif d.attrs["fmri"] in ("pkg:/C@1.0", "pkg:/E@1.0", "pkg:/G@2.0"):
+                self.assertEqual(d.attrs.get("variant.num", None), "two")
+            else:
+                raise RuntimeError(
+                    "Unexpected fmri in " "dependency:{0}".format(d)
+                )
 
-        def test_bug_19009_remove_paths_5(self):
-                """Test that when a require dependency on the middle of a
-                dependency chain exists under a particular variant combination,
-                the right thing happens."""
+    def test_bug_19009_remove_paths_5(self):
+        """Test that when a require dependency on the middle of a
+        dependency chain exists under a particular variant combination,
+        the right thing happens."""
 
-                chains = [
-                    ("A", "B", "D", "F"),
-                    ("A", "C", "E", "G"),
-                ]
+        chains = [
+            ("A", "B", "D", "F"),
+            ("A", "C", "E", "G"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                orig_a_manf = manfs[0]
-                dep_line = """\
+        orig_a_manf = manfs[0]
+        dep_line = """\
 set name=variant.num value=one value=two
 depend fmri=pkg:/D@2.0 type=require variant.num=one
 """
-                self.debug("Adding the following lines to the manifest for "
-                    "A:\n{0}".format(dep_line))
-                new_a_manf = orig_a_manf + dep_line
-                paths = [
-                    self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])
-                ]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Adding the following lines to the manifest for "
+            "A:\n{0}".format(dep_line)
+        )
+        new_a_manf = orig_a_manf + dep_line
+        paths = [self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
 
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(pkg_deps), len(paths))
-                for p in paths[1:]:
-                        self.assertEqual(len(pkg_deps[p]), 0, "Got unexpected "
-                            "dependencies for {0}.  Dependencies are:\n{1}".format(
-                            p, pkg_deps[p]))
-                deps = pkg_deps[paths[0]]
-                self.debug("Dependencies are:\n{0}".format("\n".join(
-                    [str(d) for d in deps])))
-                self.debug("Seven dependencies are expected:\ntwo require "
-                    "dependencies (on B and D) when variant.num is one\nfour "
-                    "conditional dependencies (B->D, D->F, C->E, E->G) when "
-                    "variant.num is two\none require-any dependency on F and G "
-                    "when variant.num is two")
-                expected_require = set(["pkg:/B@1.0", "pkg:/D@2.0"])
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 7)
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(pkg_deps), len(paths))
+        for p in paths[1:]:
+            self.assertEqual(
+                len(pkg_deps[p]),
+                0,
+                "Got unexpected "
+                "dependencies for {0}.  Dependencies are:\n{1}".format(
+                    p, pkg_deps[p]
+                ),
+            )
+        deps = pkg_deps[paths[0]]
+        self.debug(
+            "Dependencies are:\n{0}".format("\n".join([str(d) for d in deps]))
+        )
+        self.debug(
+            "Seven dependencies are expected:\ntwo require "
+            "dependencies (on B and D) when variant.num is one\nfour "
+            "conditional dependencies (B->D, D->F, C->E, E->G) when "
+            "variant.num is two\none require-any dependency on F and G "
+            "when variant.num is two"
+        )
+        expected_require = set(["pkg:/B@1.0", "pkg:/D@2.0"])
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            7,
+        )
 
-                # Now check the variants are set correctly on all the
-                # dependencies.
-                for d in deps:
-                        if d.attrs["fmri"] in ("pkg:/C@1.0", "pkg:/E@1.0"):
-                                self.assertEqual(d.attrs["type"], "conditional")
-                                self.assertTrue("variant.num" not in d.attrs)
-                        elif d.attrs["fmri"] == "pkg:/B@1.0":
-                                if d.attrs["type"] == "conditional":
-                                        self.assertEqual(
-                                            d.attrs.get("variant.num", None),
-                                            "two")
-                                else:
-                                        self.assertEqual(d.attrs["type"],
-                                            "require")
-                                        self.assertEqual(
-                                            d.attrs.get("variant.num", None),
-                                            "one")
-                        elif d.attrs["fmri"] == "pkg:/D@1.0":
-                                self.assertEqual(d.attrs["type"], "conditional")
-                                self.assertEqual(
-                                    d.attrs.get("variant.num", None),
-                                    "two")
-                        elif d.attrs["fmri"] == "pkg:/D@2.0":
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertEqual(
-                                    d.attrs.get("variant.num", None), "one")
-                        else:
-                                self.assertEqual(d.attrs["type"], "require-any")
-                                self.assertEqual(set(d.attrs["fmri"]),
-                                    set(["pkg:/F@1.0", "pkg:/G@1.0"]))
-                                self.assertTrue("variant.num" not in d.attrs)
+        # Now check the variants are set correctly on all the
+        # dependencies.
+        for d in deps:
+            if d.attrs["fmri"] in ("pkg:/C@1.0", "pkg:/E@1.0"):
+                self.assertEqual(d.attrs["type"], "conditional")
+                self.assertTrue("variant.num" not in d.attrs)
+            elif d.attrs["fmri"] == "pkg:/B@1.0":
+                if d.attrs["type"] == "conditional":
+                    self.assertEqual(d.attrs.get("variant.num", None), "two")
+                else:
+                    self.assertEqual(d.attrs["type"], "require")
+                    self.assertEqual(d.attrs.get("variant.num", None), "one")
+            elif d.attrs["fmri"] == "pkg:/D@1.0":
+                self.assertEqual(d.attrs["type"], "conditional")
+                self.assertEqual(d.attrs.get("variant.num", None), "two")
+            elif d.attrs["fmri"] == "pkg:/D@2.0":
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertEqual(d.attrs.get("variant.num", None), "one")
+            else:
+                self.assertEqual(d.attrs["type"], "require-any")
+                self.assertEqual(
+                    set(d.attrs["fmri"]), set(["pkg:/F@1.0", "pkg:/G@1.0"])
+                )
+                self.assertTrue("variant.num" not in d.attrs)
 
-        def test_bug_19009_remove_paths_6(self):
-                """Test that when a require dependency on the middle of a
-                dependency chain exists, the right thing happens."""
+    def test_bug_19009_remove_paths_6(self):
+        """Test that when a require dependency on the middle of a
+        dependency chain exists, the right thing happens."""
 
-                chains = [
-                    ("A", "B", "D", "F"),
-                    ("A", "C", "E", "G"),
-                ]
+        chains = [
+            ("A", "B", "D", "F"),
+            ("A", "C", "E", "G"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                orig_a_manf = manfs[0]
-                dep_line = """\
+        orig_a_manf = manfs[0]
+        dep_line = """\
 set name=variant.num value=one value=two
 depend fmri=pkg:/D@2.0 type=require
 """
-                self.debug("Adding the following lines to the manifest for "
-                    "A:\n{0}".format(dep_line))
-                new_a_manf = orig_a_manf + dep_line
-                paths = [
-                    self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])
-                ]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
+        self.debug(
+            "Adding the following lines to the manifest for "
+            "A:\n{0}".format(dep_line)
+        )
+        new_a_manf = orig_a_manf + dep_line
+        paths = [self.make_manifest(m) for m in ([new_a_manf] + manfs[1:])]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
 
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e) for e in errs])))
-                self.assertEqual(len(pkg_deps), len(paths))
-                for p in paths[1:]:
-                        self.assertEqual(len(pkg_deps[p]), 0, "Got unexpected "
-                            "dependencies for {0}.  Dependencies are:\n{1}".format(
-                            p, pkg_deps[p]))
-                deps = pkg_deps[paths[0]]
-                self.debug("Dependencies are:\n{0}".format("\n".join(
-                    [str(d) for d in deps])))
-                self.debug("Five dependencies are expected:\nrequire "
-                    "dependencies on B and D\na require-any dependency on F "
-                    "and G\nconditional dependencies from C to E and E to G.")
-                expected_conditionals.remove(("pkg:/B@1.0", "pkg:/D@1.0"))
-                expected_conditionals.remove(("pkg:/D@1.0", "pkg:/F@1.0"))
-                expected_require = set(["pkg:/B@1.0", "pkg:/D@2.0"])
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 5)
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        self.assertEqual(len(pkg_deps), len(paths))
+        for p in paths[1:]:
+            self.assertEqual(
+                len(pkg_deps[p]),
+                0,
+                "Got unexpected "
+                "dependencies for {0}.  Dependencies are:\n{1}".format(
+                    p, pkg_deps[p]
+                ),
+            )
+        deps = pkg_deps[paths[0]]
+        self.debug(
+            "Dependencies are:\n{0}".format("\n".join([str(d) for d in deps]))
+        )
+        self.debug(
+            "Five dependencies are expected:\nrequire "
+            "dependencies on B and D\na require-any dependency on F "
+            "and G\nconditional dependencies from C to E and E to G."
+        )
+        expected_conditionals.remove(("pkg:/B@1.0", "pkg:/D@1.0"))
+        expected_conditionals.remove(("pkg:/D@1.0", "pkg:/F@1.0"))
+        expected_require = set(["pkg:/B@1.0", "pkg:/D@2.0"])
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            5,
+        )
 
-                # Now check the variants are set correctly on all the
-                # dependencies.
-                for d in deps:
-                        if d.attrs["fmri"] in ("pkg:/C@1.0", "pkg:/E@1.0"):
-                                self.assertEqual(d.attrs["type"], "conditional")
-                                self.assertTrue("variant.num" not in d.attrs)
-                        elif d.attrs["fmri"] == "pkg:/B@1.0":
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertTrue("variant.num" not in d.attrs)
-                        elif d.attrs["fmri"] == "pkg:/D@2.0":
-                                self.assertEqual(d.attrs["type"], "require")
-                                self.assertTrue("variant.num" not in d.attrs)
-                        else:
-                                self.assertEqual(d.attrs["type"], "require-any")
-                                self.assertEqual(set(d.attrs["fmri"]),
-                                    set(["pkg:/F@1.0", "pkg:/G@1.0"]))
-                                self.assertTrue("variant.num" not in d.attrs)
+        # Now check the variants are set correctly on all the
+        # dependencies.
+        for d in deps:
+            if d.attrs["fmri"] in ("pkg:/C@1.0", "pkg:/E@1.0"):
+                self.assertEqual(d.attrs["type"], "conditional")
+                self.assertTrue("variant.num" not in d.attrs)
+            elif d.attrs["fmri"] == "pkg:/B@1.0":
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertTrue("variant.num" not in d.attrs)
+            elif d.attrs["fmri"] == "pkg:/D@2.0":
+                self.assertEqual(d.attrs["type"], "require")
+                self.assertTrue("variant.num" not in d.attrs)
+            else:
+                self.assertEqual(d.attrs["type"], "require-any")
+                self.assertEqual(
+                    set(d.attrs["fmri"]), set(["pkg:/F@1.0", "pkg:/G@1.0"])
+                )
+                self.assertTrue("variant.num" not in d.attrs)
 
-        def test_bug_19009_simple_1(self):
-                """Check that resolve infers the correct dependencies when more
-                than one package delivers a file which satisfies a file
-                dependency."""
+    def test_bug_19009_simple_1(self):
+        """Check that resolve infers the correct dependencies when more
+        than one package delivers a file which satisfies a file
+        dependency."""
 
-                chains = [
-                    ("A", "B", "D"),
-                    ("A", "C", "E"),
-                ]
+        chains = [
+            ("A", "B", "D"),
+            ("A", "C", "E"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 3)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            3,
+        )
 
-        def test_bug_19009_simple_2(self):
-                """Check that resolve infers the correct dependencies when more
-                than one package delivers a file which satisfies a file
-                dependency."""
+    def test_bug_19009_simple_2(self):
+        """Check that resolve infers the correct dependencies when more
+        than one package delivers a file which satisfies a file
+        dependency."""
 
-                chains = [
-                    ("A", "B", "E", "H"),
-                    ("A", "C", "F", "I"),
-                    ("A", "D", "G")
-                ]
+        chains = [("A", "B", "E", "H"), ("A", "C", "F", "I"), ("A", "D", "G")]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 6)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            6,
+        )
 
-        def test_bug_19009_simple_3(self):
-                """Check that resolve infers the correct dependencies when more
-                than one package delivers a file which satisfies a file
-                dependency."""
+    def test_bug_19009_simple_3(self):
+        """Check that resolve infers the correct dependencies when more
+        than one package delivers a file which satisfies a file
+        dependency."""
 
-                chains = [
-                    ("A", "B", "D", "F"),
-                    ("A", "C", "E", "G"),
-                ]
+        chains = [
+            ("A", "B", "D", "F"),
+            ("A", "C", "E", "G"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 5)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            5,
+        )
 
-        def test_bug_19009_simple_4(self):
-                """Check that resolve infers the correct dependencies when more
-                than one package delivers a file which satisfies a file
-                dependency."""
+    def test_bug_19009_simple_4(self):
+        """Check that resolve infers the correct dependencies when more
+        than one package delivers a file which satisfies a file
+        dependency."""
 
-                chains = [
-                    ("A", "B", "D", "F"),
-                    ("A", "C", "E", "F"),
-                ]
+        chains = [
+            ("A", "B", "D", "F"),
+            ("A", "C", "E", "F"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 4)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            4,
+        )
 
-        def test_bug_19009_simple_5(self):
-                """Check that resolve infers the correct dependencies when more
-                than one package delivers a file which satisfies a file
-                dependency.  This test also tests bug 19037."""
+    def test_bug_19009_simple_5(self):
+        """Check that resolve infers the correct dependencies when more
+        than one package delivers a file which satisfies a file
+        dependency.  This test also tests bug 19037."""
 
-                chains = [
-                    ("A", "B", "D", "F"),
-                    ("A", "B", "E", "G"),
-                    ("A", "C", "H"),
-                ]
+        chains = [
+            ("A", "B", "D", "F"),
+            ("A", "B", "E", "G"),
+            ("A", "C", "H"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 6)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            6,
+        )
 
-        def test_bug_19009_simple_6(self):
-                """Check that resolve infers the correct dependencies when more
-                than one package delivers a file which satisfies a file
-                dependency."""
+    def test_bug_19009_simple_6(self):
+        """Check that resolve infers the correct dependencies when more
+        than one package delivers a file which satisfies a file
+        dependency."""
 
-                chains = [
-                    ("A", "B", "C", "E"),
-                    ("A", "B", "D", "F"),
-                ]
+        chains = [
+            ("A", "B", "C", "E"),
+            ("A", "B", "D", "F"),
+        ]
 
-                manfs, expected_conditionals, expected_require_any, \
-                    expected_require = self.__construct_19009_info(chains)
+        (
+            manfs,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+        ) = self.__construct_19009_info(chains)
 
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 5)
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            5,
+        )
 
-        def test_bug_19009_two_paths(self):
-                """Test that multiple file dependencies don't interact
-                improperly with each other when inferring dependencies."""
+    def test_bug_19009_two_paths(self):
+        """Test that multiple file dependencies don't interact
+        improperly with each other when inferring dependencies."""
 
-                a_manf = """\
+        a_manf = """\
 set name=pkg.fmri value=A@1.0
 depend type=require fmri=__TBD pkg.debug.depend.file=a \
     pkg.debug.depend.reason=needs_a pkg.debug.depend.type=elf
 depend type=require fmri=__TBD pkg.debug.depend.file=a2 \
     pkg.debug.depend.reason=needs_a pkg.debug.depend.type=elf
 """
-                b_manf = """\
+        b_manf = """\
 set name=pkg.fmri value=B@1.0
 link path=a target=b
 """
-                c_manf = """\
+        c_manf = """\
 set name=pkg.fmri value=C@1.0
 link path=a target=c
 link path=a2 target=c2
 """
-                d_manf = """\
+        d_manf = """\
 set name=pkg.fmri value=D@1.0
 file path=d group=sys mode=0600 owner=root
 link path=b target=d
 """
-                e_manf = """\
+        e_manf = """\
 set name=pkg.fmri value=E@1.0
 file path=e group=sys mode=0600 owner=root
 link path=c target=e
 file path=e2 group=sys mode=0600 owner=root
 link path=c2 target=e2
 """
-                f_manf = """\
+        f_manf = """\
 set name=pkg.fmri value=F@1.0
 link path=a2 target=f2
 """
-                g_manf = """\
+        g_manf = """\
 set name=pkg.fmri value=G@1.0
 file path=g2 group=sys mode=0600 owner=root
 link path=f2 target=g2
 """
 
-                manfs = [a_manf, b_manf, c_manf, d_manf, e_manf, f_manf, g_manf]
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
+        manfs = [a_manf, b_manf, c_manf, d_manf, e_manf, f_manf, g_manf]
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
 
-                expected_conditionals = set([("pkg:/B@1.0", "pkg:/D@1.0"),
-                    ("pkg:/C@1.0", "pkg:/E@1.0"), ("pkg:/F@1.0", "pkg:/G@1.0")])
-                expected_require = []
-                expected_require_any = set([
-                    frozenset(["pkg:/D@1.0", "pkg:/E@1.0"]),
-                    frozenset(["pkg:/E@1.0", "pkg:/G@1.0"])])
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 5)
+        expected_conditionals = set(
+            [
+                ("pkg:/B@1.0", "pkg:/D@1.0"),
+                ("pkg:/C@1.0", "pkg:/E@1.0"),
+                ("pkg:/F@1.0", "pkg:/G@1.0"),
+            ]
+        )
+        expected_require = []
+        expected_require_any = set(
+            [
+                frozenset(["pkg:/D@1.0", "pkg:/E@1.0"]),
+                frozenset(["pkg:/E@1.0", "pkg:/G@1.0"]),
+            ]
+        )
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            5,
+        )
 
-                a_req_d_manf = a_manf + "depend fmri=pkg:/D@1.0 type=require\n"
-                manfs = [a_req_d_manf, b_manf, c_manf, d_manf, e_manf, f_manf,
-                    g_manf]
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
+        a_req_d_manf = a_manf + "depend fmri=pkg:/D@1.0 type=require\n"
+        manfs = [a_req_d_manf, b_manf, c_manf, d_manf, e_manf, f_manf, g_manf]
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
 
-                expected_conditionals = set([("pkg:/C@1.0", "pkg:/E@1.0"),
-                    ("pkg:/F@1.0", "pkg:/G@1.0")])
-                expected_require = set(["pkg:/B@1.0", "pkg:/D@1.0"])
-                expected_require_any = set([
-                    frozenset(["pkg:/E@1.0", "pkg:/G@1.0"])])
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 5)
+        expected_conditionals = set(
+            [("pkg:/C@1.0", "pkg:/E@1.0"), ("pkg:/F@1.0", "pkg:/G@1.0")]
+        )
+        expected_require = set(["pkg:/B@1.0", "pkg:/D@1.0"])
+        expected_require_any = set([frozenset(["pkg:/E@1.0", "pkg:/G@1.0"])])
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            5,
+        )
 
-                a_req_g_manf = a_manf + "depend fmri=pkg:/G@1.0 type=require\n"
-                manfs = [a_req_g_manf, b_manf, c_manf, d_manf, e_manf, f_manf,
-                    g_manf]
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
+        a_req_g_manf = a_manf + "depend fmri=pkg:/G@1.0 type=require\n"
+        manfs = [a_req_g_manf, b_manf, c_manf, d_manf, e_manf, f_manf, g_manf]
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
 
-                expected_conditionals = set([("pkg:/C@1.0", "pkg:/E@1.0"),
-                    ("pkg:/B@1.0", "pkg:/D@1.0")])
-                expected_require = set(["pkg:/F@1.0", "pkg:/G@1.0"])
-                expected_require_any = set([
-                    frozenset(["pkg:/D@1.0", "pkg:/E@1.0"])])
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 5)
+        expected_conditionals = set(
+            [("pkg:/C@1.0", "pkg:/E@1.0"), ("pkg:/B@1.0", "pkg:/D@1.0")]
+        )
+        expected_require = set(["pkg:/F@1.0", "pkg:/G@1.0"])
+        expected_require_any = set([frozenset(["pkg:/D@1.0", "pkg:/E@1.0"])])
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            5,
+        )
 
-                a_req_e_manf = a_manf + "depend fmri=pkg:/E@1.0 type=require\n"
-                manfs = [a_req_e_manf, b_manf, c_manf, d_manf, e_manf, f_manf,
-                    g_manf]
-                paths = [self.make_manifest(m) for m in manfs]
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps(paths, self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
+        a_req_e_manf = a_manf + "depend fmri=pkg:/E@1.0 type=require\n"
+        manfs = [a_req_e_manf, b_manf, c_manf, d_manf, e_manf, f_manf, g_manf]
+        paths = [self.make_manifest(m) for m in manfs]
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(paths, self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
 
-                expected_conditionals = set()
-                expected_require = set(["pkg:/C@1.0", "pkg:/E@1.0"])
-                expected_require_any = set()
-                self.__check_19009_results(pkg_deps, errs, paths,
-                    expected_conditionals, expected_require_any,
-                    expected_require, 2)
+        expected_conditionals = set()
+        expected_require = set(["pkg:/C@1.0", "pkg:/E@1.0"])
+        expected_require_any = set()
+        self.__check_19009_results(
+            pkg_deps,
+            errs,
+            paths,
+            expected_conditionals,
+            expected_require_any,
+            expected_require,
+            2,
+        )
 
-        def test_bug_19029(self):
-                """Test that a package with an action which doesn't validate
-                causes resolve to fail."""
+    def test_bug_19029(self):
+        """Test that a package with an action which doesn't validate
+        causes resolve to fail."""
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 depend fmri=pkg:/a@0-1 type=conditional
 """
-                manf_path = self.make_manifest(manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([manf_path], self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(errs), 1)
-                self.assertTrue(isinstance(errs[0],
-                    actions.InvalidActionAttributesError))
+        manf_path = self.make_manifest(manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([manf_path], self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(errs), 1)
+        self.assertTrue(
+            isinstance(errs[0], actions.InvalidActionAttributesError)
+        )
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 depend fmri=pkg:/a@0-1 type=conditionalpredicate
 """
-                manf_path = self.make_manifest(manf)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([manf_path], self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(errs), 1)
-                self.assertTrue(isinstance(errs[0], actions.InvalidActionError))
+        manf_path = self.make_manifest(manf)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps([manf_path], self.api_obj, [])
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(errs), 1)
+        self.assertTrue(isinstance(errs[0], actions.InvalidActionError))
 
-        def test_duplicate_require_any(self):
-                """Test that when one require-any dependency is the subset of
-                the other require-any dependency, the superset is omitted."""
+    def test_duplicate_require_any(self):
+        """Test that when one require-any dependency is the subset of
+        the other require-any dependency, the superset is omitted."""
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 set name=variant.foo value=i386
 file NOHASH group=bin mode=0755 owner=root path=usr/bin/perl_app
@@ -4184,171 +5403,215 @@ depend fmri=__TBD pkg.debug.depend.file=perl pkg.debug.depend.path=usr/bin pkg.d
 depend fmri=__TBD pkg.debug.depend.file=perl pkg.debug.depend.path=usr/perl5/bin pkg.debug.depend.reason=usr/bin/perl_app pkg.debug.depend.type=script type=require
 """
 
-                manual_dep = """
+        manual_dep = """
 depend fmri=pkg:/perl-512@5.12.5-1 fmri=pkg:/perl-516@5.16.3-1 fmri=pkg:/perl-520@5.20.1-1 type=require-any
 """
-                perl512_manf = """
+        perl512_manf = """
 set name=pkg.fmri value=pkg:/perl-512@5.12.5-1
 set name=variant.foo value=i386
 file tmp/foo group=bin mode=0755 owner=root path=usr/perl5/5.12/bin/perl
 link path=usr/bin/perl target=../perl5/5.12/bin/perl
 link path=usr/perl5/bin target=5.12/bin
 """
-                # perl-516 doesn't deliver the link points to usr/perl5/bin,
-                # which trigger this bug
-                perl516_manf = """
+        # perl-516 doesn't deliver the link points to usr/perl5/bin,
+        # which trigger this bug
+        perl516_manf = """
 set name=pkg.fmri value=pkg:/perl-516@5.16.3-1
 set name=variant.foo value=i386
 file tmp/foo group=bin mode=0755 owner=root path=usr/perl5/5.16/bin/perl
 link path=usr/bin/perl target=../perl5/5.16/bin/perl
 """
-                perl520_manf = """
+        perl520_manf = """
 set name=pkg.fmri value=pkg:/perl-520@5.20.1-1
 set name=variant.foo value=i386
 file tmp/foo group=bin mode=0755 owner=root path=usr/perl5/5.20/bin/perl
 link path=usr/bin/perl target=../perl5/5.20/bin/perl
 link path=usr/perl5/bin target=5.20/bin
 """
-                dep_path = self.make_manifest(manf)
-                perl512_path = self.make_manifest(perl512_manf)
-                perl516_path = self.make_manifest(perl516_manf)
-                perl520_path = self.make_manifest(perl520_manf)
-                p1_name = "pkg:/perl-512@5.12.5-1"
-                p2_name = "pkg:/perl-516@5.16.3-1"
-                p3_name = "pkg:/perl-520@5.20.1-1"
+        dep_path = self.make_manifest(manf)
+        perl512_path = self.make_manifest(perl512_manf)
+        perl516_path = self.make_manifest(perl516_manf)
+        perl520_path = self.make_manifest(perl520_manf)
+        p1_name = "pkg:/perl-512@5.12.5-1"
+        p2_name = "pkg:/perl-516@5.16.3-1"
+        p3_name = "pkg:/perl-520@5.20.1-1"
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path, perl512_path,
-                    perl516_path, perl520_path], self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join(["{0}".format(e)
-                            for e in errs])))
-                # Verify that a warning is emitted.
-                self.assertEqual(len(warnings), 1)
-                self.assertTrue(isinstance(warnings[0],
-                    dependencies.DropPackageWarning))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 4)
-                # Ensure that only one require-any dependency is in the result.
-                self.assertEqual(len(pkg_deps[dep_path]), 1)
-                # Check that the subset is selected; the superset is omitted.
-                fmris = []
-                for f in pkg_deps[dep_path][0].attrs["fmri"]:
-                        fmris.append(f)
-                assert p1_name in fmris and p3_name in fmris
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [dep_path, perl512_path, perl516_path, perl520_path],
+            self.api_obj,
+            [],
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(["{0}".format(e) for e in errs])
+                )
+            )
+        # Verify that a warning is emitted.
+        self.assertEqual(len(warnings), 1)
+        self.assertTrue(
+            isinstance(warnings[0], dependencies.DropPackageWarning)
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 4)
+        # Ensure that only one require-any dependency is in the result.
+        self.assertEqual(len(pkg_deps[dep_path]), 1)
+        # Check that the subset is selected; the superset is omitted.
+        fmris = []
+        for f in pkg_deps[dep_path][0].attrs["fmri"]:
+            fmris.append(f)
+        assert p1_name in fmris and p3_name in fmris
 
-                # Verify that pkgdep resolve doesn't exit with error code 1.
-                self.pkgdepend_resolve("{0} {1} {2} {3}".format(
-                    dep_path, perl512_path, perl516_path, perl520_path))
+        # Verify that pkgdep resolve doesn't exit with error code 1.
+        self.pkgdepend_resolve(
+            "{0} {1} {2} {3}".format(
+                dep_path, perl512_path, perl516_path, perl520_path
+            )
+        )
 
-                # Test that if a developer add a require-any dependency of
-                # their own, we won't omit it.
-                manual_path = self.make_manifest(manf + manual_dep)
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([manual_path, perl512_path,
-                    perl516_path, perl520_path], self.api_obj, [])
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 4)
-                # Ensure the custom require-any dependency is in the result.
-                self.assertEqual(len(pkg_deps[manual_path]), 2)
-                fmris = []
-                for f in pkg_deps[manual_path][0].attrs["fmri"]:
-                        fmris.append(f)
-                assert p1_name in fmris and p2_name in fmris and p3_name in fmris
+        # Test that if a developer add a require-any dependency of
+        # their own, we won't omit it.
+        manual_path = self.make_manifest(manf + manual_dep)
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [manual_path, perl512_path, perl516_path, perl520_path],
+            self.api_obj,
+            [],
+        )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 4)
+        # Ensure the custom require-any dependency is in the result.
+        self.assertEqual(len(pkg_deps[manual_path]), 2)
+        fmris = []
+        for f in pkg_deps[manual_path][0].attrs["fmri"]:
+            fmris.append(f)
+        assert p1_name in fmris and p2_name in fmris and p3_name in fmris
 
-                # Test that when one require-any dependency has the fmris that
-                # is a subset of the other require-any dependency's fmris,
-                # but if they are under different variant combinations, then the
-                # first dependency is not treated as a subset, therefore the
-                # superset could not be omitted.
+        # Test that when one require-any dependency has the fmris that
+        # is a subset of the other require-any dependency's fmris,
+        # but if they are under different variant combinations, then the
+        # first dependency is not treated as a subset, therefore the
+        # superset could not be omitted.
 
-                manf = """
+        manf = """
 set name=pkg.fmri value=foo@1.0,5.11-1
 set name=variant.foo value=a value=b
 file NOHASH group=bin mode=0755 owner=root path=usr/bin/perl_app
 depend fmri=__TBD pkg.debug.depend.file=perl pkg.debug.depend.path=usr/bin pkg.debug.depend.reason=usr/bin/perl_app pkg.debug.depend.type=script type=require variant.foo=a
 depend fmri=__TBD pkg.debug.depend.file=perl pkg.debug.depend.path=usr/perl5/bin pkg.debug.depend.reason=usr/bin/perl_app pkg.debug.depend.type=script type=require variant.foo=b
 """
-                perl512_manf = """
+        perl512_manf = """
 set name=pkg.fmri value=pkg:/perl-512@5.12.5-1
 set name=variant.foo value=a value=b
 file tmp/foo group=bin mode=0755 owner=root path=usr/perl5/5.12/bin/perl variant.foo=a variant.foo=b
 link path=usr/bin/perl target=../perl5/5.12/bin/perl
 link path=usr/perl5/bin target=5.12/bin
 """
-                perl516_manf = """
+        perl516_manf = """
 set name=pkg.fmri value=pkg:/perl-516@5.16.3-1
 set name=variant.foo value=a value=b
 file tmp/foo group=bin mode=0755 owner=root path=usr/perl5/5.16/bin/perl variant.foo=a variant.foo=b
 link path=usr/bin/perl target=../perl5/5.16/bin/perl
 """
-                perl520_manf = """
+        perl520_manf = """
 set name=pkg.fmri value=pkg:/perl-520@5.20.1-1
 set name=variant.foo value=a value=b
 file tmp/foo group=bin mode=0755 owner=root path=usr/perl5/5.20/bin/perl variant.foo=a variant.foo=b
 link path=usr/bin/perl target=../perl5/5.20/bin/perl
 link path=usr/perl5/bin target=5.20/bin
 """
-                dep_path = self.make_manifest(manf)
-                perl512_path = self.make_manifest(perl512_manf)
-                perl516_path = self.make_manifest(perl516_manf)
-                perl520_path = self.make_manifest(perl520_manf)
+        dep_path = self.make_manifest(manf)
+        perl512_path = self.make_manifest(perl512_manf)
+        perl516_path = self.make_manifest(perl516_manf)
+        perl520_path = self.make_manifest(perl520_manf)
 
-                pkg_deps, errs, warnings, unused_fmris, external_deps = \
-                    dependencies.resolve_deps([dep_path, perl512_path,
-                    perl516_path, perl520_path], self.api_obj, [])
-                if errs:
-                        raise RuntimeError("Got the following unexpected "
-                            "errors:\n{0}".format("\n".join([
-                            "{0}".format(e,) for e in errs])))
-                self.assertEqualDiff(set(), unused_fmris)
-                self.assertEqualDiff(set(), external_deps)
-                self.assertEqual(len(pkg_deps), 4)
-                # Ensure that two require-any dependencies are in the result.
-                self.assertEqual(len(pkg_deps[dep_path]), 2)
-                for d in pkg_deps[dep_path]:
-                        if d.attrs["variant.foo"] == "a":
-                                self.assertTrue(p1_name in d.attrs["fmri"])
-                                self.assertTrue(p2_name in d.attrs["fmri"])
-                                self.assertTrue(p3_name in d.attrs["fmri"])
-                        elif d.attrs["variant.foo"] == "b":
-                                self.assertTrue(p1_name in d.attrs["fmri"])
-                                self.assertTrue(p3_name in d.attrs["fmri"])
+        (
+            pkg_deps,
+            errs,
+            warnings,
+            unused_fmris,
+            external_deps,
+        ) = dependencies.resolve_deps(
+            [dep_path, perl512_path, perl516_path, perl520_path],
+            self.api_obj,
+            [],
+        )
+        if errs:
+            raise RuntimeError(
+                "Got the following unexpected "
+                "errors:\n{0}".format(
+                    "\n".join(
+                        [
+                            "{0}".format(
+                                e,
+                            )
+                            for e in errs
+                        ]
+                    )
+                )
+            )
+        self.assertEqualDiff(set(), unused_fmris)
+        self.assertEqualDiff(set(), external_deps)
+        self.assertEqual(len(pkg_deps), 4)
+        # Ensure that two require-any dependencies are in the result.
+        self.assertEqual(len(pkg_deps[dep_path]), 2)
+        for d in pkg_deps[dep_path]:
+            if d.attrs["variant.foo"] == "a":
+                self.assertTrue(p1_name in d.attrs["fmri"])
+                self.assertTrue(p2_name in d.attrs["fmri"])
+                self.assertTrue(p3_name in d.attrs["fmri"])
+            elif d.attrs["variant.foo"] == "b":
+                self.assertTrue(p1_name in d.attrs["fmri"])
+                self.assertTrue(p3_name in d.attrs["fmri"])
 
-                # Verify that a warning is not emitted.
-                self.pkgdepend_resolve("{0} {1} {2} {3}".format(
-                    dep_path, perl512_path, perl516_path, perl520_path))
-                self.assertTrue("WARNING: dropping dependency" not in self.output)
+        # Verify that a warning is not emitted.
+        self.pkgdepend_resolve(
+            "{0} {1} {2} {3}".format(
+                dep_path, perl512_path, perl516_path, perl520_path
+            )
+        )
+        self.assertTrue("WARNING: dropping dependency" not in self.output)
 
-        def test_variant_empty_intersection(self):
-                """Test that when two conditional depend actions have empty
-                intersection, it should not report NeedConditionalRequireAny
-                error because they actually refer to different packages under
-                different variants."""
+    def test_variant_empty_intersection(self):
+        """Test that when two conditional depend actions have empty
+        intersection, it should not report NeedConditionalRequireAny
+        error because they actually refer to different packages under
+        different variants."""
 
-                manf_a = """
+        manf_a = """
 set name=pkg.fmri value=a@1.0
 set name=variant.arch value=foo value=bar
 depend fmri=pkg:/b@1.0 pkg.debug.depend.path-id=var/log/authlog predicate=pkg:/d@1.0 type=conditional variant.arch=foo
 depend fmri=pkg:/c@1.0 pkg.debug.depend.path-id=var/log/authlog predicate=pkg:/d@1.0 type=conditional variant.arch=bar
 """
-                res = """\
+        res = """\
 depend fmri=pkg:/b@1.0 predicate=pkg:/d@1.0 type=conditional variant.arch=foo
 depend fmri=pkg:/c@1.0 predicate=pkg:/d@1.0 type=conditional variant.arch=bar
 """
-                manf_a_p = self.make_manifest(manf_a)
+        manf_a_p = self.make_manifest(manf_a)
 
-                self.pkgdepend_resolve("{0}".format(manf_a_p))
-                with open(manf_a_p + ".res", "r") as fh:
-                        s = fh.read()
-                self.assertEqual(res, s)
+        self.pkgdepend_resolve("{0}".format(manf_a_p))
+        with open(manf_a_p + ".res", "r") as fh:
+            s = fh.read()
+        self.assertEqual(res, s)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgdiff.py
+++ b/src/tests/cli/t_pkgdiff.py
@@ -25,34 +25,36 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
 import unittest
 
-class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
-        # Cleanup after every test.
-        persistent_setup = False
 
-        stub1 = """
+class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
+    # Cleanup after every test.
+    persistent_setup = False
+
+    stub1 = """
             dir owner=root group=root mode=0755 path=etc
             file tmp/empty mode=0555 owner=root group=bin path=/etc/empty
             file tmp/truck1 mode=0444 owner=root group=bin path=/etc/trailer"""
 
-        stub2 = """
+    stub2 = """
             dir owner=root group=root mode=0755 path=etc
             file tmp/empty mode=0555 owner=root group=bin path=/etc/empty
             file tmp/truck1 mode=0444 owner=root group=bin path=/etc/ditch """
 
-        depend_any = """
+    depend_any = """
             depend fmri=pkg:/pkg1 fmri=pkg:/pkg2 type=require-any"""
 
-        depend_require = """
+    depend_require = """
             depend fmri=pkg:/pkg1 type=require variant.opensolaris.zone=global"""
 
-        tree10 = """
+    tree10 = """
             set name=pkg.fmri value=tree@1.0,5.11-0:20110804T203458Z
             set name=pkg.summary value="Leafy SPARC package" variant.arch=sparc
             set name=pkg.summary value="Leafy i386 package" variant.arch=i386
@@ -60,7 +62,7 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             set name=variant.arch value=i386 value=sparc
             file tmp/truck1 mode=0444 owner=root group=bin path=/etc/trailer"""
 
-        tree20 = """
+    tree20 = """
             set name=pkg.fmri value=tree@2.0,5.11-0:20120804T203458Z
             set name=pkg.summary value="Leafy SPARC package" variant.arch=sparc
             set name=pkg.summary value="Leafy i386 package" variant.arch=i386
@@ -70,7 +72,7 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             file tmp/empty mode=0555 owner=root group=bin path=/etc/empty
             file tmp/truck1 mode=0444 owner=root group=bin path=/etc/trailer"""
 
-        tree30 = """
+    tree30 = """
             set name=pkg.fmri value=tree@3.0,5.11-0:20130804T203458Z
             set name=pkg.summary value="Leafy SPARC package" variant.arch=sparc
             set name=pkg.summary value="Leafy i386 package" variant.arch=i386
@@ -80,40 +82,40 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             file tmp/empty mode=0555 owner=root group=bin path=/etc/empty
             file tmp/truck1 mode=0444 owner=root group=bin path=/etc/trailer"""
 
-        #
-        # etc/hosts: file action.hash changes, other attrs don't change
-        # they are considered as different
-        #
-        # etc/motd: file action.hash and chash change,
-        # they are considered as different
-        #
-        # etc/passwd: file action.hash doesn't change, file content-hash changes
-        # they are considered as different
-        #
-        # etc/remote: file action.hash changes, file content-hash doesn't change
-        # this case is special, since file content-hash is preferred over
-        # action.hash, they are considered as the same
-        #
-        # bin/true: file action.hash and gelf content-hash don't change,
-        # file content-hash changes.
-        # they are consider as different in the case of CMP_ALL, the same in the
-        # case of CMP_UNSIGNED.
-        #
-        # bin/ls: file action.hash and gelf content-hash change,
-        # file content-hash doesn't change
-        # they are consider as different
-        #
-        # bin/cat: file action.hash, file content-hash and gelf signed
-        # content-hash change, gelf unsigned content-hash doesn't change
-        # they are consider as different in the case of CMP_ALL, the same in
-        # the case of CMP_UNSIGNED.
-        #
-        # bin/false: additional pkg.content-hash attributes are added in the
-        # newer version
-        # they are considered as different in the case of CMP_ALL, the same in
-        # the case of CMP_UNSIGNED because the preferred unsinged hash match.
-        #
-        hashed10 = """
+    #
+    # etc/hosts: file action.hash changes, other attrs don't change
+    # they are considered as different
+    #
+    # etc/motd: file action.hash and chash change,
+    # they are considered as different
+    #
+    # etc/passwd: file action.hash doesn't change, file content-hash changes
+    # they are considered as different
+    #
+    # etc/remote: file action.hash changes, file content-hash doesn't change
+    # this case is special, since file content-hash is preferred over
+    # action.hash, they are considered as the same
+    #
+    # bin/true: file action.hash and gelf content-hash don't change,
+    # file content-hash changes.
+    # they are consider as different in the case of CMP_ALL, the same in the
+    # case of CMP_UNSIGNED.
+    #
+    # bin/ls: file action.hash and gelf content-hash change,
+    # file content-hash doesn't change
+    # they are consider as different
+    #
+    # bin/cat: file action.hash, file content-hash and gelf signed
+    # content-hash change, gelf unsigned content-hash doesn't change
+    # they are consider as different in the case of CMP_ALL, the same in
+    # the case of CMP_UNSIGNED.
+    #
+    # bin/false: additional pkg.content-hash attributes are added in the
+    # newer version
+    # they are considered as different in the case of CMP_ALL, the same in
+    # the case of CMP_UNSIGNED because the preferred unsinged hash match.
+    #
+    hashed10 = """
             set name=pkg.fmri value=hashed@1.0:20130804T203459Z
             license 6aba708bd383553aa84bba4fefe8495239927767 chash=60c3aa47dce2ba0132efdace8d3b88b6589767f4 license=lic_OTN
             file abcd path=etc/hosts
@@ -126,7 +128,7 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             file nohash elfarch=i386 elfbits=64 elfhash=abcd path=bin/false pkg.content-hash=gelf:sha512t_256:abcd pkg.content-hash=gelf.unsigned:sha512t_256:abcd
             """
 
-        hashed20 = """
+    hashed20 = """
             set name=pkg.fmri value=hashed@2.0:20130904T203001Z
             license 7ab6de3107a63f5cf454485f720cac025f1b7001 chash=cc05afd488e3b3e4c4993d2403d7e15603b0a398 license=lic_OTN
             file efgh path=etc/hosts
@@ -139,136 +141,150 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             file nohash elfarch=i386 elfbits=64 elfhash=abcd path=bin/false pkg.content-hash=gelf:sha512t_256:abcd pkg.content-hash=gelf.unsigned:sha512t_256:abcd pkg.content-hash=gelf:sha3_384:wxyz pkg.content-hash=gelf.unsigned:sha3_384:wxyz
             """
 
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        tfiles = self.make_misc_files(
+            ["tmp/empty", "tmp/truck1", "tmp/noaccess"]
+        )
+        self.stub1_p5m = self.make_manifest(self.stub1)
+        self.stub2_p5m = self.make_manifest(self.stub2)
+        self.depend_any_p5m = self.make_manifest(self.depend_any)
+        self.depend_require_p5m = self.make_manifest(self.depend_require)
+        self.tree10_p5m = self.make_manifest(self.tree10)
+        self.tree20_p5m = self.make_manifest(self.tree20)
+        self.tree30_p5m = self.make_manifest(self.tree30)
+        self.hashed10_p5m = self.make_manifest(self.hashed10)
+        self.hashed20_p5m = self.make_manifest(self.hashed20)
+        self.bogus_p5m = os.path.join(self.test_root, "nosuch.p5m")
+        self.noaccess_p5m = self.make_misc_files(["tmp/noaccess.p5m"])[0]
+        os.chmod(self.noaccess_p5m, 0000)
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                tfiles = self.make_misc_files(["tmp/empty", "tmp/truck1",
-                    "tmp/noaccess"])
-                self.stub1_p5m = self.make_manifest(self.stub1)
-                self.stub2_p5m = self.make_manifest(self.stub2)
-                self.depend_any_p5m = self.make_manifest(self.depend_any)
-                self.depend_require_p5m = self.make_manifest(self.depend_require)
-                self.tree10_p5m = self.make_manifest(self.tree10)
-                self.tree20_p5m = self.make_manifest(self.tree20)
-                self.tree30_p5m = self.make_manifest(self.tree30)
-                self.hashed10_p5m = self.make_manifest(self.hashed10)
-                self.hashed20_p5m = self.make_manifest(self.hashed20)
-                self.bogus_p5m = os.path.join(self.test_root, "nosuch.p5m")
-                self.noaccess_p5m = self.make_misc_files(
-                    ["tmp/noaccess.p5m"])[0]
-                os.chmod(self.noaccess_p5m, 0000)
+    def test_00_base(self):
+        """Verify pkgdiff handles basic option and subcommand parsing as
+        expected.
+        """
 
-        def test_00_base(self):
-                """Verify pkgdiff handles basic option and subcommand parsing as
-                expected.
-                """
+        # --help, -? should exit with 0.
+        self.pkgdiff("--help", exit=0)
+        self.pkgdiff("'-?'", exit=0)
 
-                # --help, -? should exit with 0.
-                self.pkgdiff("--help", exit=0)
-                self.pkgdiff("'-?'", exit=0)
+        # unknown options should exit with 2.
+        self.pkgdiff("-U", exit=2)
+        self.pkgdiff("--unknown", exit=2)
 
-                # unknown options should exit with 2.
-                self.pkgdiff("-U", exit=2)
-                self.pkgdiff("--unknown", exit=2)
+        # no arguments should exit with 2.
+        self.pkgdiff("", exit=2)
 
-                # no arguments should exit with 2.
-                self.pkgdiff("", exit=2)
+        # one argument should exit with 2.
+        self.pkgdiff(self.tree10_p5m, exit=2)
 
-                # one argument should exit with 2.
-                self.pkgdiff(self.tree10_p5m, exit=2)
+    def test_01_input(self):
+        """Verify that pkgdiff can accept input from both files and
+        stdin and works as expected."""
 
-        def test_01_input(self):
-                """Verify that pkgdiff can accept input from both files and
-                stdin and works as expected."""
+        #
+        # Verify file input.
+        #
 
-                #
-                # Verify file input.
-                #
+        # Verify that pkgdiff finds no difference for the same file.
+        self.pkgdiff(" ".join((self.tree10_p5m, self.tree10_p5m)))
 
-                # Verify that pkgdiff finds no difference for the same file.
-                self.pkgdiff(" ".join((self.tree10_p5m, self.tree10_p5m)))
+        # Verify that pkgdiff finds a difference for different files.
+        self.pkgdiff(" ".join((self.tree10_p5m, self.tree20_p5m)), exit=1)
 
-                # Verify that pkgdiff finds a difference for different files.
-                self.pkgdiff(" ".join((self.tree10_p5m, self.tree20_p5m)),
-                    exit=1)
+        # Verify that pkgdiff gracefully handles no such file errors.
+        self.pkgdiff(" ".join((self.tree10_p5m, self.bogus_p5m)), exit=3)
 
-                # Verify that pkgdiff gracefully handles no such file errors.
-                self.pkgdiff(" ".join((self.tree10_p5m, self.bogus_p5m)), exit=3)
+        # Verify that pkgdiff gracefully handles permission errors.
+        self.pkgdiff(
+            " ".join((self.tree10_p5m, self.noaccess_p5m)), su_wrap=True, exit=3
+        )
 
-                # Verify that pkgdiff gracefully handles permission errors.
-                self.pkgdiff(" ".join((self.tree10_p5m, self.noaccess_p5m)),
-                    su_wrap=True, exit=3)
+        #
+        # Verify stdin input.
+        #
 
-                #
-                # Verify stdin input.
-                #
+        # Verify that both arguments cannot be stdin.
+        self.pkgdiff("- -", exit=2)
 
-                # Verify that both arguments cannot be stdin.
-                self.pkgdiff("- -", exit=2)
+        # Verify that one argument can be stdin with no differences for
+        # identical case.
+        self.pkgdiff("- {0} < {1}".format(self.tree10_p5m, self.tree10_p5m))
 
-                # Verify that one argument can be stdin with no differences for
-                # identical case.
-                self.pkgdiff("- {0} < {1}".format(self.tree10_p5m, self.tree10_p5m))
+        # Verify that one argument can be stdin with differences.
+        self.pkgdiff(
+            "{0} - < {1}".format(self.tree10_p5m, self.tree20_p5m), exit=1
+        )
 
-                # Verify that one argument can be stdin with differences.
-                self.pkgdiff("{0} - < {1}".format(self.tree10_p5m, self.tree20_p5m),
-                    exit=1)
+    def test_02_type_filter(self):
+        """Verify that pkgdiff action type filtering works as expected."""
 
-        def test_02_type_filter(self):
-                """Verify that pkgdiff action type filtering works as expected."""
+        # Verify unknown types cause graceful failure.
+        self.pkgdiff(
+            " ".join(("-t bogus,nosuchtype", self.tree10_p5m, self.tree10_p5m)),
+            exit=2,
+        )
+        self.pkgdiff(
+            " ".join(
+                ("-t bogus", "-t nosuchtype", self.tree10_p5m, self.tree10_p5m)
+            ),
+            exit=2,
+        )
+        self.pkgdiff(
+            " ".join(("-t bogus", "-t file", self.tree10_p5m, self.tree10_p5m)),
+            exit=2,
+        )
 
-                # Verify unknown types cause graceful failure.
-                self.pkgdiff(" ".join(("-t bogus,nosuchtype", self.tree10_p5m,
-                    self.tree10_p5m)), exit=2)
-                self.pkgdiff(" ".join(("-t bogus", "-t nosuchtype",
-                    self.tree10_p5m, self.tree10_p5m)), exit=2)
-                self.pkgdiff(" ".join(("-t bogus", "-t file", self.tree10_p5m,
-                    self.tree10_p5m)), exit=2)
+        # Verify no differences for same manifest.
+        self.pkgdiff(" ".join(("-t file", self.tree10_p5m, self.tree10_p5m)))
 
-                # Verify no differences for same manifest.
-                self.pkgdiff(" ".join(("-t file", self.tree10_p5m,
-                    self.tree10_p5m)))
+        # Verify differences found for file actions between 1.0 and 2.0.
+        self.pkgdiff(
+            " ".join(("-t file", self.tree10_p5m, self.tree20_p5m)), exit=1
+        )
 
-                # Verify differences found for file actions between 1.0 and 2.0.
-                self.pkgdiff(" ".join(("-t file", self.tree10_p5m,
-                    self.tree20_p5m)), exit=1)
+        # Verify differences found for dir actions between 1.0 and 2.0.
+        self.pkgdiff(
+            " ".join(("-t dir", self.tree10_p5m, self.tree20_p5m)), exit=1
+        )
 
-                # Verify differences found for dir actions between 1.0 and 2.0.
-                self.pkgdiff(" ".join(("-t dir", self.tree10_p5m,
-                    self.tree20_p5m)), exit=1)
+        # Verify no differences found for file actions between 2.0 and
+        # 3.0.
+        self.pkgdiff(" ".join(("-t file", self.tree20_p5m, self.tree30_p5m)))
 
-                # Verify no differences found for file actions between 2.0 and
-                # 3.0.
-                self.pkgdiff(" ".join(("-t file", self.tree20_p5m,
-                    self.tree30_p5m)))
+        # Verify no differences found for dir and file actions between
+        # 2.0 and 3.0 using both option forms.
+        self.pkgdiff(
+            " ".join(("-t dir,file", self.tree20_p5m, self.tree30_p5m)),
+            stderr=True,
+        )
 
-                # Verify no differences found for dir and file actions between
-                # 2.0 and 3.0 using both option forms.
-                self.pkgdiff(" ".join(("-t dir,file", self.tree20_p5m,
-                    self.tree30_p5m)), stderr=True)
+        self.pkgdiff(
+            " ".join(("-t dir", "-t file", self.tree20_p5m, self.tree30_p5m))
+        )
 
-                self.pkgdiff(" ".join(("-t dir", "-t file", self.tree20_p5m,
-                    self.tree30_p5m)))
+        # Verify differences found when only one action of a given type
+        # of two differs between stub1 and stub2 and other actions are
+        # the same.
+        self.pkgdiff(
+            " ".join(("-t file", self.stub1_p5m, self.stub2_p5m)), exit=1
+        )
 
-                # Verify differences found when only one action of a given type
-                # of two differs between stub1 and stub2 and other actions are
-                # the same.
-                self.pkgdiff(" ".join(("-t file", self.stub1_p5m,
-                    self.stub2_p5m)), exit=1)
+    def test_03_hash(self):
+        """Verify that hash attributes are compared as expected."""
 
-        def test_03_hash(self):
-                """Verify that hash attributes are compared as expected."""
+        # Verify no differences for same manifest.
+        self.pkgdiff(
+            " ".join(("-t file", self.hashed10_p5m, self.hashed10_p5m))
+        )
 
-                # Verify no differences for same manifest.
-                self.pkgdiff(" ".join(("-t file", self.hashed10_p5m,
-                    self.hashed10_p5m)))
-
-                # Verify differences found for file actions between 1.0 and 2.0;
-                # in particular, that the 'old' hash values match 1.0 and the
-                # 'new' hash values match 2.0.
-                self.pkgdiff(" ".join(("-t file", self.hashed10_p5m,
-                    self.hashed20_p5m)), exit=1)
-                expected = """\
+        # Verify differences found for file actions between 1.0 and 2.0;
+        # in particular, that the 'old' hash values match 1.0 and the
+        # 'new' hash values match 2.0.
+        self.pkgdiff(
+            " ".join(("-t file", self.hashed10_p5m, self.hashed20_p5m)), exit=1
+        )
+        expected = """\
 file path=bin/cat elfarch=i386 elfbits=32 elfhash=abcd
  - foo
  + bar
@@ -298,14 +314,16 @@ file path=etc/passwd
  - pkg.content-hash=file:sha512t_256:abcd
  + pkg.content-hash=file:sha512t_256:efgh
 """
-                actual = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, actual)
+        actual = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, actual)
 
-                # Verify that only the unsigned value will be compared if it
-                # exists in the action when '-u' option is enabled.
-                self.pkgdiff(" ".join(("-t file -u", self.hashed10_p5m,
-                    self.hashed20_p5m)), exit=1)
-                expected = """\
+        # Verify that only the unsigned value will be compared if it
+        # exists in the action when '-u' option is enabled.
+        self.pkgdiff(
+            " ".join(("-t file -u", self.hashed10_p5m, self.hashed20_p5m)),
+            exit=1,
+        )
+        expected = """\
 file path=bin/ls elfarch=i386 elfbits=32 elfhash=abcd
  - foo
  + bar
@@ -323,13 +341,15 @@ file path=etc/passwd
  - pkg.content-hash=file:sha512t_256:abcd
  + pkg.content-hash=file:sha512t_256:efgh
 """
-                actual = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, actual)
+        actual = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, actual)
 
-                # Again, but only comparing hash attribute.
-                self.pkgdiff(" ".join(("-t file -o hash", self.hashed10_p5m,
-                    self.hashed20_p5m)), exit=1)
-                expected = """\
+        # Again, but only comparing hash attribute.
+        self.pkgdiff(
+            " ".join(("-t file -o hash", self.hashed10_p5m, self.hashed20_p5m)),
+            exit=1,
+        )
+        expected = """\
 file path=bin/cat elfarch=i386 elfbits=32 elfhash=abcd
  - foo
  + bar
@@ -343,63 +363,86 @@ file path=etc/motd
  - 4ab5de3107a63f5cf454485f720cac025f1b7002
  + 3aba408bd383553aa84bba4fefe8495239927763
 """
-                actual = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, actual)
+        actual = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, actual)
 
-                # Again, ignoring hash attributes (should find no differences).
-                self.pkgdiff(" ".join(("-t file -i hash -i chash -i elfhash "
+        # Again, ignoring hash attributes (should find no differences).
+        self.pkgdiff(
+            " ".join(
+                (
+                    "-t file -i hash -i chash -i elfhash "
                     "-i pkg.content-hash",
-                    self.hashed10_p5m, self.hashed20_p5m)), exit=0)
+                    self.hashed10_p5m,
+                    self.hashed20_p5m,
+                )
+            ),
+            exit=0,
+        )
 
-                # Verify differences found for license actions between 2.0 and 1.0;
-                # in particular, that the 'old' hash values match 2.0 and the
-                # 'new' hash values match 1.0.
-                self.pkgdiff(" ".join(("-t license", self.hashed20_p5m,
-                    self.hashed10_p5m)), exit=1)
-                expected = """\
+        # Verify differences found for license actions between 2.0 and 1.0;
+        # in particular, that the 'old' hash values match 2.0 and the
+        # 'new' hash values match 1.0.
+        self.pkgdiff(
+            " ".join(("-t license", self.hashed20_p5m, self.hashed10_p5m)),
+            exit=1,
+        )
+        expected = """\
 license license=lic_OTN 
  - 7ab6de3107a63f5cf454485f720cac025f1b7001
  + 6aba708bd383553aa84bba4fefe8495239927767
  - chash=cc05afd488e3b3e4c4993d2403d7e15603b0a398
  + chash=60c3aa47dce2ba0132efdace8d3b88b6589767f4
 """
-                actual = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, actual)
+        actual = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, actual)
 
-                # Again, but only comparing hash attribute.
-                self.pkgdiff(" ".join(("-t license -o hash", self.hashed20_p5m,
-                    self.hashed10_p5m)), exit=1)
-                expected = """\
+        # Again, but only comparing hash attribute.
+        self.pkgdiff(
+            " ".join(
+                ("-t license -o hash", self.hashed20_p5m, self.hashed10_p5m)
+            ),
+            exit=1,
+        )
+        expected = """\
 license license=lic_OTN 
  - 7ab6de3107a63f5cf454485f720cac025f1b7001
  + 6aba708bd383553aa84bba4fefe8495239927767
 """
-                actual = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, actual)
+        actual = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, actual)
 
-                # Again, ignoring hash attributes (should find no differences).
-                self.pkgdiff(" ".join(("-t license -i hash -i chash",
-                    self.hashed20_p5m, self.hashed10_p5m)), exit=0)
+        # Again, ignoring hash attributes (should find no differences).
+        self.pkgdiff(
+            " ".join(
+                (
+                    "-t license -i hash -i chash",
+                    self.hashed20_p5m,
+                    self.hashed10_p5m,
+                )
+            ),
+            exit=0,
+        )
 
-        def test_04_dependency(self):
-                """Verify that pkgdiff that different types of dependency
-                   do not cause failures.
-                """
-                # Verify require vers require-any work.
-                self.pkgdiff(" ".join((self.depend_require_p5m,
-                    self.depend_any_p5m)), exit=1)
+    def test_04_dependency(self):
+        """Verify that pkgdiff that different types of dependency
+        do not cause failures.
+        """
+        # Verify require vers require-any work.
+        self.pkgdiff(
+            " ".join((self.depend_require_p5m, self.depend_any_p5m)), exit=1
+        )
 
-                expected = """\
+        expected = """\
 + depend fmri=pkg:/pkg1 fmri=pkg:/pkg2 type=require-any
 - depend fmri=pkg:/pkg1 type=require variant.opensolaris.zone=global
 """
 
-                actual = self.reduceSpaces(self.output)
-                self.assertEqualDiff(expected, actual)
+        actual = self.reduceSpaces(self.output)
+        self.assertEqualDiff(expected, actual)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgfmt.py
+++ b/src/tests/cli/t_pkgfmt.py
@@ -24,8 +24,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -39,9 +40,9 @@ import unittest
 
 import pkg.portable
 
+
 class TestPkgFmt(pkg5unittest.CliTestCase):
-        pkgcontents = \
-            """
+    pkgcontents = """
 #Begin Comment
 set name=pkg.fmri value=pkg:/system/kernel@$(PKGVERS)
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
@@ -949,7 +950,7 @@ $(USE_INTERNAL_CRYPTO)depend fmri=driver/crypto/dprov type=require
 #End Comment
 """
 
-        needs_formatting = """\
+    needs_formatting = """\
 # This comment was the first line in the file.
 # The depend actions here should have their type attribute first, followed by
 # fmri, other attributes, facets, and then variants.  In addition, they should
@@ -1052,7 +1053,7 @@ set name=pkg.fmri value=pkg://solaris/package/pkg@0.5.11,5.11-0.163:20110410T074
 
 # This comment was the last line of the manifest."""
 
-        v1_fmt = """\
+    v1_fmt = """\
 # This comment was the first line in the file.
 # The depend actions here should have their type attribute first, followed by
 # fmri, other attributes, facets, and then variants.  In addition, they should
@@ -1192,7 +1193,7 @@ depend fmri=zorch@2.0 type=optional
 # This comment was the last line of the manifest.
 """
 
-        v2_fmt = """\
+    v2_fmt = """\
 # This comment was the first line in the file.
 # The depend actions here should have their type attribute first, followed by
 # fmri, other attributes, facets, and then variants.  In addition, they should
@@ -1335,132 +1336,137 @@ depend type=require-any fmri=apple fmri=barge fmri=zoo
 # This comment was the last line of the manifest.
 """
 
-        def setUp(self):
-                pkg5unittest.CliTestCase.setUp(self)
+    def setUp(self):
+        pkg5unittest.CliTestCase.setUp(self)
 
-                with open(os.path.join(self.test_root, "source_file"),
-                    "w") as f:
-                        f.write(self.pkgcontents)
+        with open(os.path.join(self.test_root, "source_file"), "w") as f:
+            f.write(self.pkgcontents)
 
-                with open(os.path.join(self.test_root, "needs_fmt_file"),
-                    "w") as f:
-                        f.write(self.needs_formatting)
+        with open(os.path.join(self.test_root, "needs_fmt_file"), "w") as f:
+            f.write(self.needs_formatting)
 
-        def test_0_checkfmt(self):
-                """Verify that pkgfmt -c format checking works as expected."""
+    def test_0_checkfmt(self):
+        """Verify that pkgfmt -c format checking works as expected."""
 
-                man = os.path.join(self.test_root, "man.p5m")
-                original = os.path.join(self.test_root, "needs_fmt_file")
-                portable.copyfile(original, man)
+        man = os.path.join(self.test_root, "man.p5m")
+        original = os.path.join(self.test_root, "needs_fmt_file")
+        portable.copyfile(original, man)
 
-                # Copy man to man2 before executing tests.
-                man2 = os.path.join(self.test_root, "man2.p5m")
-                pkg.portable.copyfile(man, man2)
+        # Copy man to man2 before executing tests.
+        man2 = os.path.join(self.test_root, "man2.p5m")
+        pkg.portable.copyfile(man, man2)
 
-                # Verify pkgfmt exits 1 when checking format for manifest that
-                # needs formatting (both from a file and from stdin).
-                self.pkgfmt("-c {0}".format(man), exit=1)
-                # Ensure "error:" is in output (for the benefit of ON nightly).
-                self.assertTrue("pkgfmt: error:" in self.errout)
-                self.pkgfmt("-c < {0}".format(man), exit=1)
+        # Verify pkgfmt exits 1 when checking format for manifest that
+        # needs formatting (both from a file and from stdin).
+        self.pkgfmt("-c {0}".format(man), exit=1)
+        # Ensure "error:" is in output (for the benefit of ON nightly).
+        self.assertTrue("pkgfmt: error:" in self.errout)
+        self.pkgfmt("-c < {0}".format(man), exit=1)
 
-                # Verify pkgfmt exits 1 when checking format for multiple
-                # manifests that need formatting.
-                self.pkgfmt("-c {0} {1}".format(man, man2), exit=1)
+        # Verify pkgfmt exits 1 when checking format for multiple
+        # manifests that need formatting.
+        self.pkgfmt("-c {0} {1}".format(man, man2), exit=1)
 
-                # Verify formatted manifest is identical to expected.
-                for pfmt, mfmt in (("v1", self.v1_fmt), ("v2", self.v2_fmt)):
-                        portable.copyfile(original, man)
-                        self.pkgfmt("-f {0} {1}".format(pfmt, man))
-                        with open(man, "r") as f:
-                                actual = f.read()
-                                self.assertEqualDiff(mfmt, actual,
-                                    msg="{0} format".format(pfmt))
+        # Verify formatted manifest is identical to expected.
+        for pfmt, mfmt in (("v1", self.v1_fmt), ("v2", self.v2_fmt)):
+            portable.copyfile(original, man)
+            self.pkgfmt("-f {0} {1}".format(pfmt, man))
+            with open(man, "r") as f:
+                actual = f.read()
+                self.assertEqualDiff(
+                    mfmt, actual, msg="{0} format".format(pfmt)
+                )
 
-                        # Test using environment variable.
-                        portable.copyfile(original, man)
-                        os.environ["PKGFMT_OUTPUT"] = pfmt
-                        self.pkgfmt(man)
-                        with open(man, "r") as f:
-                                actual = f.read()
-                                self.assertEqualDiff(mfmt, actual,
-                                    msg="{0} format".format(pfmt))
-                os.environ["PKGFMT_OUTPUT"] = ""
+            # Test using environment variable.
+            portable.copyfile(original, man)
+            os.environ["PKGFMT_OUTPUT"] = pfmt
+            self.pkgfmt(man)
+            with open(man, "r") as f:
+                actual = f.read()
+                self.assertEqualDiff(
+                    mfmt, actual, msg="{0} format".format(pfmt)
+                )
+        os.environ["PKGFMT_OUTPUT"] = ""
 
-                # Verify pkgfmt exits 1 when any of the manifests named need
-                # formatting.  (Ordering matters here, the good one must be
-                # specified last.)
-                self.pkgfmt("-c {0} {1}".format(man2, man), exit=1)
+        # Verify pkgfmt exits 1 when any of the manifests named need
+        # formatting.  (Ordering matters here, the good one must be
+        # specified last.)
+        self.pkgfmt("-c {0} {1}".format(man2, man), exit=1)
 
-                # Verify pkgfmt exits 0 when a manifest doesn't need formatting.
-                self.pkgfmt("-c {0}".format(man))
+        # Verify pkgfmt exits 0 when a manifest doesn't need formatting.
+        self.pkgfmt("-c {0}".format(man))
 
-                # Format the second manifest.
-                self.pkgfmt(man2)
+        # Format the second manifest.
+        self.pkgfmt(man2)
 
-                # Verify pkgfmt exits 0 when none of the manifests named need
-                # formatting.
-                self.pkgfmt("-c {0} {1}".format(man, man2))
+        # Verify pkgfmt exits 0 when none of the manifests named need
+        # formatting.
+        self.pkgfmt("-c {0} {1}".format(man, man2))
 
-                # Verify pkgfmt -c accepts a manifest in v1 or v2 format, and
-                # that the output for each version matches expected.
-                for contents in (self.v1_fmt, self.v2_fmt):
-                        with open(man, "w") as f:
-                                f.write(contents)
-                        self.pkgfmt("-c {0}".format(man))
+        # Verify pkgfmt -c accepts a manifest in v1 or v2 format, and
+        # that the output for each version matches expected.
+        for contents in (self.v1_fmt, self.v2_fmt):
+            with open(man, "w") as f:
+                f.write(contents)
+            self.pkgfmt("-c {0}".format(man))
 
-                # Verify pkgfmt -c accepts both a v1 and v2 format manifest
-                # at the same time.
-                with open(man, "w") as f:
-                        f.write(self.v1_fmt)
-                with open(man2, "w") as f:
-                        f.write(self.v2_fmt)
-                self.pkgfmt("-c {0} {1}".format(man, man2))
+        # Verify pkgfmt -c accepts both a v1 and v2 format manifest
+        # at the same time.
+        with open(man, "w") as f:
+            f.write(self.v1_fmt)
+        with open(man2, "w") as f:
+            f.write(self.v2_fmt)
+        self.pkgfmt("-c {0} {1}".format(man, man2))
 
-        def test_1_difference(self):
-                """display that pkgfmt makes no diff in manifest"""
-                source_file = os.path.join(self.test_root, "source_file")
-                mod_file = os.path.join(self.test_root, "mod_file")
-                # Remove comments from source file; they don't sort
-                # since pkgfmt tries to maintain comment position in
-                # file.
-                self.cmdline_run("sed '/^#/d' < {0} > {1}; mv {2} {3}".format(
-                                source_file,
-                                mod_file,
-                                mod_file,
-                                source_file))
-                # remove backslashes in place
-                self.pkgfmt("-u < {0} > {1}".format(source_file, mod_file))
-                # sort into alternate order and format
-                self.cmdline_run("/usr/bin/sort -o {0} {1}".format(
-                    mod_file, mod_file), coverage=False)
-                self.pkgfmt("{0}".format(mod_file))
-                self.pkgfmt("{0}".format(source_file))
-                self.cmdline_run("/usr/bin/diff {0} {1}".format(
-                    source_file, mod_file), coverage=False)
+    def test_1_difference(self):
+        """display that pkgfmt makes no diff in manifest"""
+        source_file = os.path.join(self.test_root, "source_file")
+        mod_file = os.path.join(self.test_root, "mod_file")
+        # Remove comments from source file; they don't sort
+        # since pkgfmt tries to maintain comment position in
+        # file.
+        self.cmdline_run(
+            "sed '/^#/d' < {0} > {1}; mv {2} {3}".format(
+                source_file, mod_file, mod_file, source_file
+            )
+        )
+        # remove backslashes in place
+        self.pkgfmt("-u < {0} > {1}".format(source_file, mod_file))
+        # sort into alternate order and format
+        self.cmdline_run(
+            "/usr/bin/sort -o {0} {1}".format(mod_file, mod_file),
+            coverage=False,
+        )
+        self.pkgfmt("{0}".format(mod_file))
+        self.pkgfmt("{0}".format(source_file))
+        self.cmdline_run(
+            "/usr/bin/diff {0} {1}".format(source_file, mod_file),
+            coverage=False,
+        )
 
-        def test_2_unprivileged(self):
-                """Verify pkgfmt handles unprivileged user gracefully."""
+    def test_2_unprivileged(self):
+        """Verify pkgfmt handles unprivileged user gracefully."""
 
-                source_file = os.path.join(self.test_root, "source_file")
-                # Should fail since manifest needs formatting and user can't
-                # replace file.
-                self.pkgfmt("{0}".format(source_file), su_wrap=True, exit=1)
+        source_file = os.path.join(self.test_root, "source_file")
+        # Should fail since manifest needs formatting and user can't
+        # replace file.
+        self.pkgfmt("{0}".format(source_file), su_wrap=True, exit=1)
 
-                # Now reformat the file.
-                self.pkgfmt("{0}".format(source_file))
+        # Now reformat the file.
+        self.pkgfmt("{0}".format(source_file))
 
-                # Should not fail even though user is unprivileged.
-                self.pkgfmt("-c {0}".format(source_file), su_wrap=True)
+        # Should not fail even though user is unprivileged.
+        self.pkgfmt("-c {0}".format(source_file), su_wrap=True)
 
-        def test_3_handle_comments(self):
-                """Verify pkgfmt handles comments, does stdin"""
-                source_file = os.path.join(self.test_root, "source_file")
-                self.pkgfmt("< {0}".format(source_file))
-                assert "Begin Comment" in self.output
-                assert "Bobcat" not in self.output
-                assert "Middle Comment" in self.output
-                assert "End Comment" in self.output
+    def test_3_handle_comments(self):
+        """Verify pkgfmt handles comments, does stdin"""
+        source_file = os.path.join(self.test_root, "source_file")
+        self.pkgfmt("< {0}".format(source_file))
+        assert "Begin Comment" in self.output
+        assert "Bobcat" not in self.output
+        assert "Middle Comment" in self.output
+        assert "End Comment" in self.output
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkglint.py
+++ b/src/tests/cli/t_pkglint.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -36,9 +37,9 @@ import tempfile
 import threading
 import subprocess
 
-class TestPkglintBasics(pkg5unittest.CliTestCase):
 
-        manifest = """
+class TestPkglintBasics(pkg5unittest.CliTestCase):
+    manifest = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/kernel@0.5.11,5.11-0.141:20100603T215050Z
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -47,8 +48,8 @@ set name=org.opensolaris.consolidation value=ON
 set name=variant.arch value=i386 value=sparc
 set name=test value=i386 variant.arch=sparc
 """
-        # has two set actions, which we should catch
-        broken_manifest = """
+    # has two set actions, which we should catch
+    broken_manifest = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/kernel@0.5.11,5.11-0.141:20100603T215050Z
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -58,8 +59,8 @@ set name=org.opensolaris.consolidation value=ON
 set name=variant.arch value=i386 value=sparc
 """
 
-        # has two set actions, one of which is linted
-        linted_action = """
+    # has two set actions, one of which is linted
+    linted_action = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/lintedaction@0.5.11,5.11-0.141:20100603T215050Z
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -69,8 +70,8 @@ set name=org.opensolaris.consolidation value=ON pkg.linted=True
 set name=variant.arch value=i386 value=sparc
 """
 
-        # has two set actions, one of which is linted
-        linted_manifest = """
+    # has two set actions, one of which is linted
+    linted_manifest = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/lintedmf@0.5.11,5.11-0.141:20100603T215050Z
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -81,11 +82,11 @@ set name=org.opensolaris.consolidation value=ON
 set name=variant.arch value=i386 value=sparc
 """
 
-        # a basic manifest with a given fmri, used to test ordering
-        # - when linting 'manifest' and 'manifest_ordered' together,
-        # we should always visit this one first, regardless of the
-        # order used on the command line.
-        manifest_ordered = """
+    # a basic manifest with a given fmri, used to test ordering
+    # - when linting 'manifest' and 'manifest_ordered' together,
+    # we should always visit this one first, regardless of the
+    # order used on the command line.
+    manifest_ordered = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/jkernel@0.5.11,5.11-0.141:20100603T215050Z
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -95,8 +96,8 @@ set name=variant.arch value=i386 value=sparc
 set name=test value=i386 variant.arch=sparc
 """
 
-        # has two set actions, one of which is linted
-        linted_manifest1 = """
+    # has two set actions, one of which is linted
+    linted_manifest1 = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/lintedmf1@0.5.11,5.11-0.141:20100603T215050Z
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 # allow the System/Noodles info.classification value in this manifest
@@ -111,11 +112,11 @@ set name=variant.arch value=i386 value=sparc
 depend fmri=foo type=require
 """
 
-        # has a dependency which we'll be unable to resolve at runtime,
-        # resulting in a pkglint.action005.1 warning, unless we run with
-        # a pkglintrc file that specifies pkglint.action005.1.missing-deps
-        # parameter
-        missing_dep_manifest = """
+    # has a dependency which we'll be unable to resolve at runtime,
+    # resulting in a pkglint.action005.1 warning, unless we run with
+    # a pkglintrc file that specifies pkglint.action005.1.missing-deps
+    # parameter
+    missing_dep_manifest = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/kernel@0.5.11,5.11-0.141:20100603T215050Z
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -125,7 +126,7 @@ set name=variant.arch value=i386 value=sparc
 depend type=require fmri=does/not/exist
 """
 
-        missing_dep_manifest_action = """
+    missing_dep_manifest_action = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/kernel@0.5.11,5.11-0.141:20100603T215050Z
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -136,7 +137,7 @@ set name=variant.arch value=i386 value=sparc
 depend type=require fmri=does/not/exist pkg.lint.pkglint.action005.1.missing-deps=pkg:/does/not/exist
 """
 
-        missing_dep_manifest_mf = """
+    missing_dep_manifest_mf = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/kernel@0.5.11,5.11-0.141:20100603T215050Z
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -148,7 +149,7 @@ set name=pkg.lint.pkglint.action005.1.missing-deps value="pkg:/does/not/exist pk
 depend type=require fmri=does/not/exist
 """
 
-        broken_fmri_mf = """
+    broken_fmri_mf = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/kernel@@@
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -157,7 +158,7 @@ set name=org.opensolaris.consolidation value=ON
 set name=variant.arch value=i386 value=sparc
 """
 
-        no_build_release_mf = """
+    no_build_release_mf = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/kernel@1
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -166,7 +167,7 @@ set name=org.opensolaris.consolidation value=ON
 set name=variant.arch value=i386 value=sparc
 """
 
-        no_version_mf = """
+    no_version_mf = """
 set name=pkg.fmri value=pkg://opensolaris.org/system/kernel
 set name=pkg.description value="core kernel software for a specific instruction-set architecture"
 set name=info.classification value=org.opensolaris.category.2008:System/Core
@@ -174,299 +175,363 @@ set name=pkg.summary value="Core Solaris Kernel"
 set name=org.opensolaris.consolidation value=ON
 set name=variant.arch value=i386 value=sparc
 """
-        # for the rcfiles below, we also need to point the
-        # info_classification_path field to the sections file we deliver in the
-        # proto area
-        module_exclusion_rc = """
+    # for the rcfiles below, we also need to point the
+    # info_classification_path field to the sections file we deliver in the
+    # proto area
+    module_exclusion_rc = """
 [pkglint]
 pkglint.exclude: pkg.lint.pkglint_manifest.PkgManifestChecker
 info_classification_path: {0}/usr/share/lib/pkg/opensolaris.org.sections
 """
 
-        method_exclusion_rc = """
+    method_exclusion_rc = """
 [pkglint]
 pkglint.exclude: pkg.lint.pkglint_manifest.PkgManifestChecker.duplicate_sets
 info_classification_path: {0}/usr/share/lib/pkg/opensolaris.org.sections
 """
 
-        low_noise_rc = """
+    low_noise_rc = """
 [pkglint]
 log_level = CRITICAL
 info_classification_path: {0}/usr/share/lib/pkg/opensolaris.org.sections
 """
 
-        missing_dep_rc = """
+    missing_dep_rc = """
 [pkglint]
 info_classification_path: {0}/usr/share/lib/pkg/opensolaris.org.sections
 pkglint.action005.1.missing-deps = pkg:/does/not/exist
 """
 
-        missing_dep_rc_versioned = """
+    missing_dep_rc_versioned = """
 [pkglint]
 info_classification_path: {0}/usr/share/lib/pkg/opensolaris.org.sections
 pkglint.action005.1.missing-deps = pkg:/does/not/exist@2.0
 """
-        # in each of the cases below, we disable the check that reports on
-        # the presence of pkg.linted attributes.  However it's the report-linted
-        # parameter that differs.
-        no_linted_messages_rc = """
+    # in each of the cases below, we disable the check that reports on
+    # the presence of pkg.linted attributes.  However it's the report-linted
+    # parameter that differs.
+    no_linted_messages_rc = """
 [pkglint]
 pkglint001.5.report-linted = False
 pkglint.exclude = pkg.lint.pkglint_action.PkgActionChecker.linted \
     pkg.lint.pkglint_manifest.PkgManifestChecker.linted
 """
 
-        linted_messages_rc = """
+    linted_messages_rc = """
 [pkglint]
 pkglint001.5.report-linted = True
 pkglint.exclude = pkg.lint.pkglint_action.PkgActionChecker.linted \
     pkg.lint.pkglint_manifest.PkgManifestChecker.linted
 """
 
-        def setUp(self):                
-                pkg5unittest.CliTestCase.setUp(self)
+    def setUp(self):
+        pkg5unittest.CliTestCase.setUp(self)
 
-        def test_1_usage(self):
-                """Tests that we show a usage message."""
-                ret, output, err = self.pkglint("--help")
-                self.assertTrue("Usage:" in output,
-                    "No usage string printed")
+    def test_1_usage(self):
+        """Tests that we show a usage message."""
+        ret, output, err = self.pkglint("--help")
+        self.assertTrue("Usage:" in output, "No usage string printed")
 
-        def test_2_badopts(self):
-                """Tests that we exit with an error on wrong or missing args"""
+    def test_2_badopts(self):
+        """Tests that we exit with an error on wrong or missing args"""
 
-                for opt in ["-x", "--asdf", "-c test_bad_opts -l zappo://cats"]:
-                        ret, output, err = self.pkglint(opt, exit=2)
+        for opt in ["-x", "--asdf", "-c test_bad_opts -l zappo://cats"]:
+            ret, output, err = self.pkglint(opt, exit=2)
 
-        def test_3_list(self):
-                """Tests that -L prints headers and descriptions or methods."""
-                for flag in ["-L", "-vL"]:
-                        ret, output, err = self.pkglint(flag)
-                        self.assertTrue("pkglint.dupaction001" in output,
-                            "short name didn't appear in {0} output".format(flag))
+    def test_3_list(self):
+        """Tests that -L prints headers and descriptions or methods."""
+        for flag in ["-L", "-vL"]:
+            ret, output, err = self.pkglint(flag)
+            self.assertTrue(
+                "pkglint.dupaction001" in output,
+                "short name didn't appear in {0} output".format(flag),
+            )
 
-                        self.assertTrue("NAME" in output,
-                            "Header not printed in {0} output".format(flag))
-                        if flag == "-vL":
-                                self.assertTrue(
-                                    "pkg.lint.pkglint_action.PkgDupActionChecker.duplicate_paths"
-                                    in output,
-                                    "verbose list output didn't show method")
-                        elif flag == "-L":
-                                self.assertTrue(
-                                    "Paths should be unique." in output,
-                                    "description didn't appear in "
-                                    "-L output: {0}".format(output))
-                                self.assertTrue("pkg.lint." not in output,
-                                    "description contained pkg.lint, possible "
-                                    "missing <checker>.pkglint_desc attribute.")
-
-        def test_4_manifests(self):
-                """Tests that we exit normally with a correct manifest."""
-                mpath = self.make_manifest(self.manifest)
-                self.pkglint(mpath)
-
-        def test_5_broken_manifest(self):
-                """Tests that we exit with an error when presented one or more
-                broken manifests."""
-                mpath = self.make_manifest(self.manifest)
-                mpath1 = self.make_manifest(self.broken_manifest)
-                self.pkglint(mpath1, exit=1)
-                # only one of these is broken
-                self.pkglint("{0} {1}".format(mpath, mpath1), exit=1)
-
-        def test_6_rcfile(self):
-                """Checks that check exclusion works, by testing a broken
-                manifest, excluding checks designed to catch the fault.
-                This tests part of the engine, as well as the -f handling
-                in the CLI.
-                """
-                mpath1 = self.make_manifest(self.broken_manifest)
-                self.make_misc_files({"rcfile": self.module_exclusion_rc.format(
-                    pkg5unittest.g_pkg_path)})
-                self.make_misc_files({"rcfile1": self.method_exclusion_rc.format(
-                    pkg5unittest.g_pkg_path)})
-
-                # verify we fail first
-                self.pkglint("{0}".format(mpath1), exit=1)
-
-                # now we should succeed
-                self.pkglint("-f {0}/rcfile {1}".format(self.test_root,  mpath1),
-                    testrc=False, exit=0)
-                self.pkglint("-f {0}/rcfile1 {1}".format(self.test_root, mpath1),
-                    exit=0)
-
-                ret, output, err = self.pkglint("-f {0}/rcfile -vL".format(
-                    self.test_root, testrc=False, exit=0))
+            self.assertTrue(
+                "NAME" in output,
+                "Header not printed in {0} output".format(flag),
+            )
+            if flag == "-vL":
                 self.assertTrue(
-                    "pkg.lint.pkglint_manifest.PkgManifestChecker.duplicate_sets"
-                    in output, "List output missing excluded checker")
-                self.assertTrue("Excluded checks:" in output)
-
-                ret, output, err = self.pkglint("-f {0}/rcfile1 -vL".format(
-                    self.test_root, testrc=False, exit=0))
+                    "pkg.lint.pkglint_action.PkgDupActionChecker.duplicate_paths"
+                    in output,
+                    "verbose list output didn't show method",
+                )
+            elif flag == "-L":
                 self.assertTrue(
-                    "pkg.lint.pkglint_manifest.PkgManifestChecker.duplicate_sets"
-                    in output, "List output missing excluded checker")
-                self.assertTrue("Excluded checks:" in output)
+                    "Paths should be unique." in output,
+                    "description didn't appear in "
+                    "-L output: {0}".format(output),
+                )
+                self.assertTrue(
+                    "pkg.lint." not in output,
+                    "description contained pkg.lint, possible "
+                    "missing <checker>.pkglint_desc attribute.",
+                )
 
-        def test_7_linted(self):
-                """Checks that the pkg.linted keyword works for actions and
-                manifests.  While this tests the linted functionality of the
-                engine, it's also a CLI test to ensure we report a zero
-                exit code from a lint check that has emitted output, but
-                doesn't indicate an error."""
-                mpath1 = self.make_manifest(self.broken_manifest)
-                linted_action_path = self.make_manifest(self.linted_action)
-                linted_manifest_path = self.make_manifest(self.linted_manifest)
-                linted_manifest_path1 = self.make_manifest(self.linted_manifest1)
+    def test_4_manifests(self):
+        """Tests that we exit normally with a correct manifest."""
+        mpath = self.make_manifest(self.manifest)
+        self.pkglint(mpath)
 
-                # verify we fail first
-                self.pkglint("{0}".format(mpath1), exit=1)
+    def test_5_broken_manifest(self):
+        """Tests that we exit with an error when presented one or more
+        broken manifests."""
+        mpath = self.make_manifest(self.manifest)
+        mpath1 = self.make_manifest(self.broken_manifest)
+        self.pkglint(mpath1, exit=1)
+        # only one of these is broken
+        self.pkglint("{0} {1}".format(mpath, mpath1), exit=1)
 
-                # now we should succeed
-                self.pkglint(linted_action_path, exit=0)
-                self.pkglint(linted_manifest_path, exit=0)
+    def test_6_rcfile(self):
+        """Checks that check exclusion works, by testing a broken
+        manifest, excluding checks designed to catch the fault.
+        This tests part of the engine, as well as the -f handling
+        in the CLI.
+        """
+        mpath1 = self.make_manifest(self.broken_manifest)
+        self.make_misc_files(
+            {"rcfile": self.module_exclusion_rc.format(pkg5unittest.g_pkg_path)}
+        )
+        self.make_misc_files(
+            {
+                "rcfile1": self.method_exclusion_rc.format(
+                    pkg5unittest.g_pkg_path
+                )
+            }
+        )
 
-                # we should succeed, but get a warning from one check
-                ret, output, err = self.pkglint(linted_manifest_path1, exit=0)
-                self.assertTrue("pkglint.action005.1" in err,
-                    "Expected to get a pkglint.action005.1 warning from "
-                    "linted_manifest_path_1:\n{0}".format(err))
+        # verify we fail first
+        self.pkglint("{0}".format(mpath1), exit=1)
 
-        def test_8_verbose(self):
-                """Checks that the -v flag works, overriding the log level
-                in pkglintrc."""
-                mpath = self.make_manifest(self.broken_manifest)
+        # now we should succeed
+        self.pkglint(
+            "-f {0}/rcfile {1}".format(self.test_root, mpath1),
+            testrc=False,
+            exit=0,
+        )
+        self.pkglint(
+            "-f {0}/rcfile1 {1}".format(self.test_root, mpath1), exit=0
+        )
 
-                # default log setting
-                ret, output, err = self.pkglint("{0}".format(mpath), exit=1)
-                self.assertTrue("Total number of checks found" not in output,
-                    "verbose output detected in non-verbose mode")
+        ret, output, err = self.pkglint(
+            "-f {0}/rcfile -vL".format(self.test_root, testrc=False, exit=0)
+        )
+        self.assertTrue(
+            "pkg.lint.pkglint_manifest.PkgManifestChecker.duplicate_sets"
+            in output,
+            "List output missing excluded checker",
+        )
+        self.assertTrue("Excluded checks:" in output)
 
-                self.assertTrue("duplicate set actions" in err)
+        ret, output, err = self.pkglint(
+            "-f {0}/rcfile1 -vL".format(self.test_root, testrc=False, exit=0)
+        )
+        self.assertTrue(
+            "pkg.lint.pkglint_manifest.PkgManifestChecker.duplicate_sets"
+            in output,
+            "List output missing excluded checker",
+        )
+        self.assertTrue("Excluded checks:" in output)
 
-                ret, output_verbose, err = self.pkglint("-v {0}".format(mpath), exit=1)
-                self.assertTrue("Total number of checks found" in output_verbose,
-                    "verbose output not printed in verbose mode")
-                self.assertTrue("duplicate set actions" in err)
+    def test_7_linted(self):
+        """Checks that the pkg.linted keyword works for actions and
+        manifests.  While this tests the linted functionality of the
+        engine, it's also a CLI test to ensure we report a zero
+        exit code from a lint check that has emitted output, but
+        doesn't indicate an error."""
+        mpath1 = self.make_manifest(self.broken_manifest)
+        linted_action_path = self.make_manifest(self.linted_action)
+        linted_manifest_path = self.make_manifest(self.linted_manifest)
+        linted_manifest_path1 = self.make_manifest(self.linted_manifest1)
 
-                # override log setting in config file
-                self.make_misc_files(
-                    {"low_noise_rc": self.low_noise_rc.format(
-                    pkg5unittest.g_pkg_path)})
-                ret, output, err = self.pkglint("-f {0}/low_noise_rc {1}".format(
-                    self.test_root, mpath), exit=0)
-                self.assertTrue("Total number of checks found" not in output,
-                    "verbose output detected in non-verbose mode")
-                self.assertTrue("duplicate set actions" not in err)
+        # verify we fail first
+        self.pkglint("{0}".format(mpath1), exit=1)
 
-                ret, output, err = self.pkglint("-v -f {0}/low_noise_rc {1}".format(
-                    self.test_root, mpath), exit=1)
-                self.assertTrue("Total number of checks found" in output,
-                    "verbose output detected in non-verbose mode")
-                self.assertTrue("duplicate set actions" in err)
+        # now we should succeed
+        self.pkglint(linted_action_path, exit=0)
+        self.pkglint(linted_manifest_path, exit=0)
 
-        def test_9_order(self):
-                """Checks that we always visit manifests in the same order."""
-                mpath = self.make_manifest(self.manifest)
-                mpath1 = self.make_manifest(self.manifest_ordered)
-                ret, out, err = self.pkglint("-v {0} {1}".format(mpath, mpath1))
-                ret, out2, err2 = self.pkglint("-v {0} {1}".format(mpath1, mpath))
+        # we should succeed, but get a warning from one check
+        ret, output, err = self.pkglint(linted_manifest_path1, exit=0)
+        self.assertTrue(
+            "pkglint.action005.1" in err,
+            "Expected to get a pkglint.action005.1 warning from "
+            "linted_manifest_path_1:\n{0}".format(err),
+        )
 
-                self.assertTrue(out == out2,
-                    "different stdout with different cli order")
-                self.assertTrue(err == err2,
-                    "different stderr with different cli order")
+    def test_8_verbose(self):
+        """Checks that the -v flag works, overriding the log level
+        in pkglintrc."""
+        mpath = self.make_manifest(self.broken_manifest)
 
-        def test_10_rcfile_params(self):
-                """Loading pkglint parameters from an rcfile works"""
+        # default log setting
+        ret, output, err = self.pkglint("{0}".format(mpath), exit=1)
+        self.assertTrue(
+            "Total number of checks found" not in output,
+            "verbose output detected in non-verbose mode",
+        )
 
-                mpath = self.make_manifest(self.missing_dep_manifest)
-                self.make_misc_files({"rcfile": self.missing_dep_rc.format(
-                    pkg5unittest.g_pkg_path),
-                    "versioned": self.missing_dep_rc_versioned.format(
-                    pkg5unittest.g_pkg_path)})
+        self.assertTrue("duplicate set actions" in err)
 
-                # verify we fail first
-                ret, output, err = self.pkglint("{0}".format(mpath))
-                self.assertTrue("pkglint.action005.1" in err,
-                    "Expected missing dependency warning not printed")
+        ret, output_verbose, err = self.pkglint("-v {0}".format(mpath), exit=1)
+        self.assertTrue(
+            "Total number of checks found" in output_verbose,
+            "verbose output not printed in verbose mode",
+        )
+        self.assertTrue("duplicate set actions" in err)
 
-                # verify that with the given rc file, we don't report an error
-                # since our pkglintrc now passes a parameter to
-                # pkglint.action005.1 whitelisting that particular dependency
-                ret, output, err = self.pkglint("-f {0}/rcfile {1}".format(
-                    self.test_root, mpath), testrc=False)
-                self.assertTrue("pkglint.action005.1" not in err,
-                    "Missing dependency warning printed, despite parameter")
+        # override log setting in config file
+        self.make_misc_files(
+            {"low_noise_rc": self.low_noise_rc.format(pkg5unittest.g_pkg_path)}
+        )
+        ret, output, err = self.pkglint(
+            "-f {0}/low_noise_rc {1}".format(self.test_root, mpath), exit=0
+        )
+        self.assertTrue(
+            "Total number of checks found" not in output,
+            "verbose output detected in non-verbose mode",
+        )
+        self.assertTrue("duplicate set actions" not in err)
 
-                # this time, we've whitelisted a versioned dependency, but
-                # we don't depend on any given version - we should still
-                # complain
-                ret, output, err = self.pkglint("-f {0}/versioned {1}".format(
-                    self.test_root, mpath), testrc=False)
-                self.assertTrue("pkglint.action005.1" in err,
-                    "Missing dep warning not printed, despite versioned rcfile")
+        ret, output, err = self.pkglint(
+            "-v -f {0}/low_noise_rc {1}".format(self.test_root, mpath), exit=1
+        )
+        self.assertTrue(
+            "Total number of checks found" in output,
+            "verbose output detected in non-verbose mode",
+        )
+        self.assertTrue("duplicate set actions" in err)
 
-                # finally, verify the parameter set in either the action or
-                # manifest works
-                for mf in [self.missing_dep_manifest_action,
-                    self.missing_dep_manifest_mf]:
-                        mpath = self.make_manifest(mf)
-                        ret, output, err = self.pkglint(mpath)
-                        self.assertTrue("pkglint.action005.1" not in err,
-                            "Missing dependency warning printed, despite "
-                            "parameter set in {0}".format(mf))
+    def test_9_order(self):
+        """Checks that we always visit manifests in the same order."""
+        mpath = self.make_manifest(self.manifest)
+        mpath1 = self.make_manifest(self.manifest_ordered)
+        ret, out, err = self.pkglint("-v {0} {1}".format(mpath, mpath1))
+        ret, out2, err2 = self.pkglint("-v {0} {1}".format(mpath1, mpath))
 
-        def test_11_broken_missing_rcfile(self):
-                """Tests that we fail gracefully with a broken or missing
-                config file argument """
-                mpath = self.make_manifest(self.missing_dep_manifest)
-                self.pkglint("-f /dev/null {0}".format(mpath), testrc=False, exit=2)
-                self.pkglint("-f /no/such/pkg5/file {0}".format(mpath), testrc=False,
-                    exit=2)
-                self.pkglint("-f /etc/shadow {0}".format(mpath), testrc=False, exit=2)
+        self.assertTrue(
+            out == out2, "different stdout with different cli order"
+        )
+        self.assertTrue(
+            err == err2, "different stderr with different cli order"
+        )
 
-        def test_12_pkg_versions(self):
-                """Tests that the CLI deals with pkg.fmri values properly."""
+    def test_10_rcfile_params(self):
+        """Loading pkglint parameters from an rcfile works"""
 
-                mpath = self.make_manifest(self.broken_fmri_mf)
-                self.pkglint(mpath, exit=1)
-                mpath = self.make_manifest(self.no_version_mf)
-                self.pkglint(mpath, exit=1)
-                # pkglint will add a default build_release if one is missing,
-                # in line with pkgsend.
-                mpath = self.make_manifest(self.no_build_release_mf)
-                self.pkglint(mpath)
+        mpath = self.make_manifest(self.missing_dep_manifest)
+        self.make_misc_files(
+            {
+                "rcfile": self.missing_dep_rc.format(pkg5unittest.g_pkg_path),
+                "versioned": self.missing_dep_rc_versioned.format(
+                    pkg5unittest.g_pkg_path
+                ),
+            }
+        )
 
-        def test_13_linted_ignore(self):
-                """Tests that our rcfile parameter to avoid printing linted
-                messages works properly"""
+        # verify we fail first
+        ret, output, err = self.pkglint("{0}".format(mpath))
+        self.assertTrue(
+            "pkglint.action005.1" in err,
+            "Expected missing dependency warning not printed",
+        )
 
-                mpath1 = self.make_manifest(self.linted_manifest1)
-                self.make_misc_files({"rcfile": self.no_linted_messages_rc})
-                self.make_misc_files({"rcfile1": self.linted_messages_rc})
+        # verify that with the given rc file, we don't report an error
+        # since our pkglintrc now passes a parameter to
+        # pkglint.action005.1 whitelisting that particular dependency
+        ret, output, err = self.pkglint(
+            "-f {0}/rcfile {1}".format(self.test_root, mpath), testrc=False
+        )
+        self.assertTrue(
+            "pkglint.action005.1" not in err,
+            "Missing dependency warning printed, despite parameter",
+        )
 
-                ret, output, err = self.pkglint("-f {0}/rcfile1 {1}".format(
-                    self.test_root,  mpath1), exit=0)
-                self.assertTrue("INFO " in err, "error output: {0}".format(err))
-                self.assertTrue("Linted message: pkglint.manifest008.6" in err,
-                    "error output: {0}".format(err))
+        # this time, we've whitelisted a versioned dependency, but
+        # we don't depend on any given version - we should still
+        # complain
+        ret, output, err = self.pkglint(
+            "-f {0}/versioned {1}".format(self.test_root, mpath), testrc=False
+        )
+        self.assertTrue(
+            "pkglint.action005.1" in err,
+            "Missing dep warning not printed, despite versioned rcfile",
+        )
 
-                # now we should still fail, but should not emit the linted INFO
-                ret, output, err = self.pkglint("-f {0}/rcfile {1}".format(
-                    self.test_root,  mpath1), testrc=False, exit=0)
-                self.assertTrue("INFO " not in err, "error output: {0}".format(err))
-                self.assertTrue("Linted message: pkglint.manifest008.6" not in
-                    err, "error output: {0}".format(err))
+        # finally, verify the parameter set in either the action or
+        # manifest works
+        for mf in [
+            self.missing_dep_manifest_action,
+            self.missing_dep_manifest_mf,
+        ]:
+            mpath = self.make_manifest(mf)
+            ret, output, err = self.pkglint(mpath)
+            self.assertTrue(
+                "pkglint.action005.1" not in err,
+                "Missing dependency warning printed, despite "
+                "parameter set in {0}".format(mf),
+            )
+
+    def test_11_broken_missing_rcfile(self):
+        """Tests that we fail gracefully with a broken or missing
+        config file argument"""
+        mpath = self.make_manifest(self.missing_dep_manifest)
+        self.pkglint("-f /dev/null {0}".format(mpath), testrc=False, exit=2)
+        self.pkglint(
+            "-f /no/such/pkg5/file {0}".format(mpath), testrc=False, exit=2
+        )
+        self.pkglint("-f /etc/shadow {0}".format(mpath), testrc=False, exit=2)
+
+    def test_12_pkg_versions(self):
+        """Tests that the CLI deals with pkg.fmri values properly."""
+
+        mpath = self.make_manifest(self.broken_fmri_mf)
+        self.pkglint(mpath, exit=1)
+        mpath = self.make_manifest(self.no_version_mf)
+        self.pkglint(mpath, exit=1)
+        # pkglint will add a default build_release if one is missing,
+        # in line with pkgsend.
+        mpath = self.make_manifest(self.no_build_release_mf)
+        self.pkglint(mpath)
+
+    def test_13_linted_ignore(self):
+        """Tests that our rcfile parameter to avoid printing linted
+        messages works properly"""
+
+        mpath1 = self.make_manifest(self.linted_manifest1)
+        self.make_misc_files({"rcfile": self.no_linted_messages_rc})
+        self.make_misc_files({"rcfile1": self.linted_messages_rc})
+
+        ret, output, err = self.pkglint(
+            "-f {0}/rcfile1 {1}".format(self.test_root, mpath1), exit=0
+        )
+        self.assertTrue("INFO " in err, "error output: {0}".format(err))
+        self.assertTrue(
+            "Linted message: pkglint.manifest008.6" in err,
+            "error output: {0}".format(err),
+        )
+
+        # now we should still fail, but should not emit the linted INFO
+        ret, output, err = self.pkglint(
+            "-f {0}/rcfile {1}".format(self.test_root, mpath1),
+            testrc=False,
+            exit=0,
+        )
+        self.assertTrue("INFO " not in err, "error output: {0}".format(err))
+        self.assertTrue(
+            "Linted message: pkglint.manifest008.6" not in err,
+            "error output: {0}".format(err),
+        )
 
 
 class TestPkglintCliDepot(pkg5unittest.ManyDepotTestCase):
-        """Tests that exercise the CLI aspect of dealing with repositories"""
+    """Tests that exercise the CLI aspect of dealing with repositories"""
 
-        ref_mf = {}
-        ref_mf["ref-sample1.mf"] = """
+    ref_mf = {}
+    ref_mf[
+        "ref-sample1.mf"
+    ] = """
 #
 # A sample package which delivers several actions
 #
@@ -480,7 +545,9 @@ file /etc/passwd path=etc/passwd group=sys mode=0644 owner=root preserve=true
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        ref_mf["ref-sample2.mf"] = """
+    ref_mf[
+        "ref-sample2.mf"
+    ] = """
 #
 # A sample package which delivers several actions
 #
@@ -495,7 +562,9 @@ dir group=sys mode=0755 owner=root path=etc
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        ref_mf["ref-sample3.mf"] = """
+    ref_mf[
+        "ref-sample3.mf"
+    ] = """
 #
 # A sample package which delivers several actions
 #
@@ -509,244 +578,332 @@ file /etc/group group=sys mode=0644 owner=root path=etc/group
 dir group=sys mode=0755 owner=root path=etc
 """
 
-        lint_mf = {}
+    lint_mf = {}
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["opensolaris.org",
-                    "opensolaris.org", "test", "nopubconfig", "test"],
-                    start_depots=True)
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self,
+            [
+                "opensolaris.org",
+                "opensolaris.org",
+                "test",
+                "nopubconfig",
+                "test",
+            ],
+            start_depots=True,
+        )
 
-                self.ref_uri = self.dcs[1].get_depot_url()
-                self.lint_uri = self.dcs[2].get_depot_url()
-                self.lint_repo_path = self.dcs[2].get_repo_url()
-                self.cache_dir = os.path.join(self.test_root, "pkglint-cache")
+        self.ref_uri = self.dcs[1].get_depot_url()
+        self.lint_uri = self.dcs[2].get_depot_url()
+        self.lint_repo_path = self.dcs[2].get_repo_url()
+        self.cache_dir = os.path.join(self.test_root, "pkglint-cache")
 
-                paths = self.make_misc_files(self.ref_mf)
+        paths = self.make_misc_files(self.ref_mf)
 
-                for item in paths:
-                        self.pkgsend(depot_url=self.ref_uri,
-                            command="publish {0}".format(item))
-                self.pkgsend(depot_url=self.ref_uri,
-                            command="refresh-index")
+        for item in paths:
+            self.pkgsend(
+                depot_url=self.ref_uri, command="publish {0}".format(item)
+            )
+        self.pkgsend(depot_url=self.ref_uri, command="refresh-index")
 
-        def test_1_invalid_uri(self):
-                """ Tests that we can cope with bad URIs for both ref and
-                lint repository arguments."""
+    def test_1_invalid_uri(self):
+        """Tests that we can cope with bad URIs for both ref and
+        lint repository arguments."""
 
-                bad = ["htto://foobar", "https://nosuchhost", "file:/dev/null",
-                    "file:///dev/null", "utternonsense"]
+        bad = [
+            "htto://foobar",
+            "https://nosuchhost",
+            "file:/dev/null",
+            "file:///dev/null",
+            "utternonsense",
+        ]
 
-                cache = tempfile.mkdtemp("pkglint-cache", "", self.test_root)
-                for uri in bad:
-                        # bad usage, missing a -c argument
-                        self.pkglint("-l {0}".format(uri), exit=2)
-                        self.pkglint("-r {0} -l {1}".format(self.lint_uri, uri),
-                            exit=2)
-                        self.pkglint("-r {0} -l {1}".format(uri, self.ref_uri),
-                            exit=2)
+        cache = tempfile.mkdtemp("pkglint-cache", "", self.test_root)
+        for uri in bad:
+            # bad usage, missing a -c argument
+            self.pkglint("-l {0}".format(uri), exit=2)
+            self.pkglint("-r {0} -l {1}".format(self.lint_uri, uri), exit=2)
+            self.pkglint("-r {0} -l {1}".format(uri, self.ref_uri), exit=2)
 
-                        if os.path.exists(cache):
-                                shutil.rmtree(cache)
-                        self.pkglint("-c {0} -l {1}".format(cache, uri), exit=2)
-                        self.pkglint("-c {0} -r {1} -l {2}".format(
-                            cache, self.lint_uri, uri), exit=2)
-                        self.pkglint("-c {0} -r {1} -l {2}".format(
-                            cache, uri, self.ref_uri), exit=2)
+            if os.path.exists(cache):
+                shutil.rmtree(cache)
+            self.pkglint("-c {0} -l {1}".format(cache, uri), exit=2)
+            self.pkglint(
+                "-c {0} -r {1} -l {2}".format(cache, self.lint_uri, uri), exit=2
+            )
+            self.pkglint(
+                "-c {0} -r {1} -l {2}".format(cache, uri, self.ref_uri), exit=2
+            )
 
-                        # If one of the specified repositories is bad, pkglint
-                        # should fail.
-                        self.pkglint("-c {0} -r {1} -r {2} -l {3}".format(
-                            cache, self.ref_uri, uri, self.lint_uri), exit=2)
-                        shutil.rmtree(cache)
-                        self.pkglint("-c {0} -l {1} -l {2}".format(
-                            cache, self.ref_uri, uri), exit=2)
+            # If one of the specified repositories is bad, pkglint
+            # should fail.
+            self.pkglint(
+                "-c {0} -r {1} -r {2} -l {3}".format(
+                    cache, self.ref_uri, uri, self.lint_uri
+                ),
+                exit=2,
+            )
+            shutil.rmtree(cache)
+            self.pkglint(
+                "-c {0} -l {1} -l {2}".format(cache, self.ref_uri, uri), exit=2
+            )
 
-        def test_2_badcache(self):
-                """Checks we can deal with bad -c options """
+    def test_2_badcache(self):
+        """Checks we can deal with bad -c options"""
 
-                opts = ["/dev/null", "/system/contract", "/etc/passwd"]
-                for cache in opts:
-                        self.pkglint("-c {0} -r {1} -l {2}".format(
-                            cache, self.ref_uri, self.lint_uri), exit=2)
+        opts = ["/dev/null", "/system/contract", "/etc/passwd"]
+        for cache in opts:
+            self.pkglint(
+                "-c {0} -r {1} -l {2}".format(
+                    cache, self.ref_uri, self.lint_uri
+                ),
+                exit=2,
+            )
 
-                # now sufficiently corrupt the cache, such that we couldn't
-                # use the provided cache dir
-                for name in ["lint_image", "ref_image"]:
-                        cache = tempfile.mkdtemp("pkglint-cache", "",
-                            self.test_root)
-                        path = os.path.join(cache, name)
-                        f = open(path, "w")
-                        f.close()
-                        self.pkglint("-c {0} -r {1} -l {2}".format(
-                            cache, self.ref_uri, self.lint_uri), exit=2)
-                        shutil.rmtree(cache)
+        # now sufficiently corrupt the cache, such that we couldn't
+        # use the provided cache dir
+        for name in ["lint_image", "ref_image"]:
+            cache = tempfile.mkdtemp("pkglint-cache", "", self.test_root)
+            path = os.path.join(cache, name)
+            f = open(path, "w")
+            f.close()
+            self.pkglint(
+                "-c {0} -r {1} -l {2}".format(
+                    cache, self.ref_uri, self.lint_uri
+                ),
+                exit=2,
+            )
+            shutil.rmtree(cache)
 
-        def test_3_badrelease(self):
-                """Checks we can deal with bad -b options """
+    def test_3_badrelease(self):
+        """Checks we can deal with bad -b options"""
 
-                for opt in ["chickens", "0,1234", "0.16b"]:
-                        self.pkglint("-c {0} -l {1} -b {2}".format(
-                            self.cache_dir, self.lint_uri, opt), exit=2)
+        for opt in ["chickens", "0,1234", "0.16b"]:
+            self.pkglint(
+                "-c {0} -l {1} -b {2}".format(
+                    self.cache_dir, self.lint_uri, opt
+                ),
+                exit=2,
+            )
 
-        def test_4_fancy_unix_progress_tracking(self):
-                """When stdout is not a tty, pkglint uses a
-                CommandLineProgressTracker. This test runs pkglint with a tty
-                in order to sanity-check the FancyUnixProgressTracker.
-                See also t_progress.TestProgressTrackers.__t_pty_tracker(..)
-                """
+    def test_4_fancy_unix_progress_tracking(self):
+        """When stdout is not a tty, pkglint uses a
+        CommandLineProgressTracker. This test runs pkglint with a tty
+        in order to sanity-check the FancyUnixProgressTracker.
+        See also t_progress.TestProgressTrackers.__t_pty_tracker(..)
+        """
 
-                mpath1 = self.make_manifest(self.ref_mf["ref-sample1.mf"])
-                cache = tempfile.mkdtemp("pkglint-cache", "", self.test_root)
+        mpath1 = self.make_manifest(self.ref_mf["ref-sample1.mf"])
+        cache = tempfile.mkdtemp("pkglint-cache", "", self.test_root)
 
-                for args in [[mpath1], ["-c", cache, "-l", self.lint_uri]]:
-                        cmdline = [sys.executable, "{0}/usr/bin/pkglint".format(
-                            pkg5unittest.g_pkg_path)]
-                        cmdline.extend(args)
+        for args in [[mpath1], ["-c", cache, "-l", self.lint_uri]]:
+            cmdline = [
+                sys.executable,
+                "{0}/usr/bin/pkglint".format(pkg5unittest.g_pkg_path),
+            ]
+            cmdline.extend(args)
 
-                        # ensure the command works first
-                        self.pkglint(" ".join(args))
-                        self.cmdline_run(" ".join(cmdline), exit=0, usepty=True)
+            # ensure the command works first
+            self.pkglint(" ".join(args))
+            self.cmdline_run(" ".join(cmdline), exit=0, usepty=True)
 
-                if os.path.exists(cache):
-                        shutil.rmtree(cache)
+        if os.path.exists(cache):
+            shutil.rmtree(cache)
 
-        def test_5_file_paths(self):
-                """Checks that we can use file paths to repository, with
-                file:// schemes, absolute paths and relative paths."""
+    def test_5_file_paths(self):
+        """Checks that we can use file paths to repository, with
+        file:// schemes, absolute paths and relative paths."""
 
-                lint_repo_no_scheme = self.lint_repo_path.replace("file://", "")
-                rel_path = lint_repo_no_scheme.replace(self.test_root, "")
-                lint_repo_relative  = os.path.sep.join([self.test_root, "..",
-                    os.path.basename(self.test_root), rel_path])
+        lint_repo_no_scheme = self.lint_repo_path.replace("file://", "")
+        rel_path = lint_repo_no_scheme.replace(self.test_root, "")
+        lint_repo_relative = os.path.sep.join(
+            [self.test_root, "..", os.path.basename(self.test_root), rel_path]
+        )
 
-                cmdlines = [
-                    "-c {0} -l {1}".format(self.cache_dir, self.lint_repo_path),
-                    "-c {0} -l {1}".format(self.cache_dir, lint_repo_no_scheme),
-                    "-c {0} -l {1}".format(self.cache_dir, lint_repo_relative)
-                ]
+        cmdlines = [
+            "-c {0} -l {1}".format(self.cache_dir, self.lint_repo_path),
+            "-c {0} -l {1}".format(self.cache_dir, lint_repo_no_scheme),
+            "-c {0} -l {1}".format(self.cache_dir, lint_repo_relative),
+        ]
 
-                for cmd in cmdlines:
-                        self.pkglint(cmd)
-                        shutil.rmtree(self.cache_dir)
+        for cmd in cmdlines:
+            self.pkglint(cmd)
+            shutil.rmtree(self.cache_dir)
 
-        def test_6_multiple_repos(self):
-                """Checks that pkglint can accept multiple ref and lint
-                repositories. Actually it is to test multiple publishers can be
-                set on the same ref or lint image after it was created."""
+    def test_6_multiple_repos(self):
+        """Checks that pkglint can accept multiple ref and lint
+        repositories. Actually it is to test multiple publishers can be
+        set on the same ref or lint image after it was created."""
 
-                mpath1 = self.make_manifest(self.ref_mf["ref-sample1.mf"])
-                durl3 = self.dcs[3].get_depot_url()
-                durl4 = self.dcs[4].get_depot_url()
-                durl5 = self.dcs[5].get_depot_url()
+        mpath1 = self.make_manifest(self.ref_mf["ref-sample1.mf"])
+        durl3 = self.dcs[3].get_depot_url()
+        durl4 = self.dcs[4].get_depot_url()
+        durl5 = self.dcs[5].get_depot_url()
 
-                # First test the case of adding new publishers.
-                # Verify that adding new publishers from following ref/lint
-                # repositories will work. When repository configuration info was
-                # not provided, pkglint will assume the repo uri is the origin...
-                self.pkglint("-c {0} -r {1} -r {2} -r {3} {4}".format(
-                    self.cache_dir, self.ref_uri, durl3, durl5, mpath1))
-                self.pkg("-R {0}/ref_image publisher".format(self.cache_dir))
-                self.assertTrue("opensolaris.org" in self.output and
-                    "test" in self.output and durl3 in self.output and
-                    durl5 in self.output)
-                self.pkglint("-c {0} -l {1} -l {2} -l {3}".format(
-                    self.cache_dir, self.ref_uri, durl3, durl5))
-                self.pkg("-R {0}/lint_image publisher".format(self.cache_dir))
-                self.assertTrue("opensolaris.org" in self.output and
-                    "test" in self.output and durl3 in self.output and
-                    durl5 in self.output)
-                shutil.rmtree(self.cache_dir)
+        # First test the case of adding new publishers.
+        # Verify that adding new publishers from following ref/lint
+        # repositories will work. When repository configuration info was
+        # not provided, pkglint will assume the repo uri is the origin...
+        self.pkglint(
+            "-c {0} -r {1} -r {2} -r {3} {4}".format(
+                self.cache_dir, self.ref_uri, durl3, durl5, mpath1
+            )
+        )
+        self.pkg("-R {0}/ref_image publisher".format(self.cache_dir))
+        self.assertTrue(
+            "opensolaris.org" in self.output
+            and "test" in self.output
+            and durl3 in self.output
+            and durl5 in self.output
+        )
+        self.pkglint(
+            "-c {0} -l {1} -l {2} -l {3}".format(
+                self.cache_dir, self.ref_uri, durl3, durl5
+            )
+        )
+        self.pkg("-R {0}/lint_image publisher".format(self.cache_dir))
+        self.assertTrue(
+            "opensolaris.org" in self.output
+            and "test" in self.output
+            and durl3 in self.output
+            and durl5 in self.output
+        )
+        shutil.rmtree(self.cache_dir)
 
-                # ... and when no origin was provided in repository
-                # configuration, pkglint will assume that the provided
-                # repo uri is the origin to add.
-                self.pkgrepo("set -s {0} -p test repository/origins=''".format(
-                    self.dcs[3].get_repodir()))
-                self.dcs[3].refresh()
-                self.pkglint("-c {0} -r {1} -r {2} {3}".format(
-                    self.cache_dir, self.ref_uri, durl3, mpath1))
-                self.pkg("-R {0}/ref_image publisher | grep {1}".format(
-                    self.cache_dir, durl3))
-                self.pkglint("-c {0} -l {1} -l {2}".format(
-                    self.cache_dir, self.ref_uri, durl3))
-                self.pkg("-R {0}/lint_image publisher | grep {1}".format(
-                    self.cache_dir, durl3))
-                shutil.rmtree(self.cache_dir)
+        # ... and when no origin was provided in repository
+        # configuration, pkglint will assume that the provided
+        # repo uri is the origin to add.
+        self.pkgrepo(
+            "set -s {0} -p test repository/origins=''".format(
+                self.dcs[3].get_repodir()
+            )
+        )
+        self.dcs[3].refresh()
+        self.pkglint(
+            "-c {0} -r {1} -r {2} {3}".format(
+                self.cache_dir, self.ref_uri, durl3, mpath1
+            )
+        )
+        self.pkg(
+            "-R {0}/ref_image publisher | grep {1}".format(
+                self.cache_dir, durl3
+            )
+        )
+        self.pkglint(
+            "-c {0} -l {1} -l {2}".format(self.cache_dir, self.ref_uri, durl3)
+        )
+        self.pkg(
+            "-R {0}/lint_image publisher | grep {1}".format(
+                self.cache_dir, durl3
+            )
+        )
+        shutil.rmtree(self.cache_dir)
 
-                # Verify that adding new publishers from multipublisher
-                # repository will work.
-                self.pkgrepo("set -s {0} -p second-pub -p third-pub "
-                    "publisher/alias=''".format(self.dcs[3].get_repodir()))
-                self.dcs[3].refresh()
-                self.pkglint("-c {0} -r {1} -r {2} {3}".format(
-                    self.cache_dir, self.ref_uri, durl3, mpath1))
-                self.pkg("-R {0}/ref_image publisher".format(self.cache_dir))
-                self.assertTrue("opensolaris.org" in self.output and
-                    "test" in self.output and "second-pub" in self.output and
-                    "third-pub" in self.output)
-                self.pkglint("-c {0} -l {1} -l {2}".format(
-                    self.cache_dir, self.ref_uri, durl3))
-                self.pkg("-R {0}/lint_image publisher".format(self.cache_dir))
-                self.assertTrue("opensolaris.org" in self.output and
-                    "test" in self.output and "second-pub" in self.output and
-                    "third-pub" in self.output)
-                shutil.rmtree(self.cache_dir)
- 
-                # The fourth depot is purposefully one with the publisher
-                # operation disabled.
-                self.dcs[4].stop()
-                self.dcs[4].set_disable_ops(["publisher/0"])
-                self.dcs[4].start()
- 
-                # Verify that a repository that doesn't support publisher
-                # operation will fail.
-                cmdlines = ["-c {0} -r {1} -r {2} {3}".format(
-                    self.cache_dir, self.ref_uri, durl4, mpath1),
-                    "-c {0} -l {1} -l {2}".format(
-                    self.cache_dir, self.ref_uri, durl4)
-                ]
-                for cmd in cmdlines:
-                        self.pkglint(cmd, exit=2)
-                shutil.rmtree(self.cache_dir)
- 
-                # Now test the case of updating publishers.
-                # Verify that updating the exising publishers by following
-                # ref/lint repositories will work.
-                self.pkglint("-c {0} -r {1} -r {2} {3}".format(
-                    self.cache_dir, self.ref_uri, self.lint_uri, mpath1))
-                self.pkg("-R {0}/ref_image publisher".format(self.cache_dir))
-                self.assertTrue(self.ref_uri in self.output,
-                    self.lint_uri in self.output)
-                self.pkglint("-c {0} -l {1} -l {2}".format(
-                    self.cache_dir, self.ref_uri, self.lint_uri))
-                self.pkg("-R {0}/lint_image publisher".format(self.cache_dir))
-                self.assertTrue(self.ref_uri in self.output,
-                    self.lint_uri in self.output)
-                shutil.rmtree(self.cache_dir)
- 
-                # Verify that when origins were provided in a repository, pkglint
-                # will only add those unknown origins of the repository to the
-                # existing and configured origins of the image.
-                self.pkgrepo("set -s {0} -p test repository/origins={1} "
-                    "repository/origins={2}".format(
-                    self.dcs[3].get_repodir(), durl3, durl5))
-                self.pkgrepo("set -s {0} -p test repository/origins={1} "
-                    "repository/origins={2}".format(
-                    self.dcs[5].get_repodir(), durl3, durl5))
-                self.dcs[5].refresh()
-                self.pkglint("-c {0} -r {1} -r {2} {3}".format(
-                    self.cache_dir, durl3, durl5, mpath1))
-                self.pkg("-R {0}/ref_image publisher".format(self.cache_dir))
-                self.assertTrue(self.output.count(durl5) == 1)
-                self.pkglint("-c {0} -l {1} -l {2}".format(
-                    self.cache_dir, durl3, durl5))
-                self.pkg("-R {0}/lint_image publisher".format(self.cache_dir))
-                self.assertTrue(self.output.count(durl5) == 1)
-                shutil.rmtree(self.cache_dir)
+        # Verify that adding new publishers from multipublisher
+        # repository will work.
+        self.pkgrepo(
+            "set -s {0} -p second-pub -p third-pub "
+            "publisher/alias=''".format(self.dcs[3].get_repodir())
+        )
+        self.dcs[3].refresh()
+        self.pkglint(
+            "-c {0} -r {1} -r {2} {3}".format(
+                self.cache_dir, self.ref_uri, durl3, mpath1
+            )
+        )
+        self.pkg("-R {0}/ref_image publisher".format(self.cache_dir))
+        self.assertTrue(
+            "opensolaris.org" in self.output
+            and "test" in self.output
+            and "second-pub" in self.output
+            and "third-pub" in self.output
+        )
+        self.pkglint(
+            "-c {0} -l {1} -l {2}".format(self.cache_dir, self.ref_uri, durl3)
+        )
+        self.pkg("-R {0}/lint_image publisher".format(self.cache_dir))
+        self.assertTrue(
+            "opensolaris.org" in self.output
+            and "test" in self.output
+            and "second-pub" in self.output
+            and "third-pub" in self.output
+        )
+        shutil.rmtree(self.cache_dir)
+
+        # The fourth depot is purposefully one with the publisher
+        # operation disabled.
+        self.dcs[4].stop()
+        self.dcs[4].set_disable_ops(["publisher/0"])
+        self.dcs[4].start()
+
+        # Verify that a repository that doesn't support publisher
+        # operation will fail.
+        cmdlines = [
+            "-c {0} -r {1} -r {2} {3}".format(
+                self.cache_dir, self.ref_uri, durl4, mpath1
+            ),
+            "-c {0} -l {1} -l {2}".format(self.cache_dir, self.ref_uri, durl4),
+        ]
+        for cmd in cmdlines:
+            self.pkglint(cmd, exit=2)
+        shutil.rmtree(self.cache_dir)
+
+        # Now test the case of updating publishers.
+        # Verify that updating the exising publishers by following
+        # ref/lint repositories will work.
+        self.pkglint(
+            "-c {0} -r {1} -r {2} {3}".format(
+                self.cache_dir, self.ref_uri, self.lint_uri, mpath1
+            )
+        )
+        self.pkg("-R {0}/ref_image publisher".format(self.cache_dir))
+        self.assertTrue(
+            self.ref_uri in self.output, self.lint_uri in self.output
+        )
+        self.pkglint(
+            "-c {0} -l {1} -l {2}".format(
+                self.cache_dir, self.ref_uri, self.lint_uri
+            )
+        )
+        self.pkg("-R {0}/lint_image publisher".format(self.cache_dir))
+        self.assertTrue(
+            self.ref_uri in self.output, self.lint_uri in self.output
+        )
+        shutil.rmtree(self.cache_dir)
+
+        # Verify that when origins were provided in a repository, pkglint
+        # will only add those unknown origins of the repository to the
+        # existing and configured origins of the image.
+        self.pkgrepo(
+            "set -s {0} -p test repository/origins={1} "
+            "repository/origins={2}".format(
+                self.dcs[3].get_repodir(), durl3, durl5
+            )
+        )
+        self.pkgrepo(
+            "set -s {0} -p test repository/origins={1} "
+            "repository/origins={2}".format(
+                self.dcs[5].get_repodir(), durl3, durl5
+            )
+        )
+        self.dcs[5].refresh()
+        self.pkglint(
+            "-c {0} -r {1} -r {2} {3}".format(
+                self.cache_dir, durl3, durl5, mpath1
+            )
+        )
+        self.pkg("-R {0}/ref_image publisher".format(self.cache_dir))
+        self.assertTrue(self.output.count(durl5) == 1)
+        self.pkglint(
+            "-c {0} -l {1} -l {2}".format(self.cache_dir, durl3, durl5)
+        )
+        self.pkg("-R {0}/lint_image publisher".format(self.cache_dir))
+        self.assertTrue(self.output.count(durl5) == 1)
+        shutil.rmtree(self.cache_dir)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgmerge.py
+++ b/src/tests/cli/t_pkgmerge.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -42,34 +43,35 @@ import zlib
 
 import sys
 
-class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
-        persistent_setup = True
 
-        scheme10 = """
+class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
+    persistent_setup = True
+
+    scheme10 = """
             open scheme@1.0,5.11-0
             add file tmp/sparc-only mode=0444 owner=root group=bin path=/etc/tree
             close
         """
 
-        tree10 = """
+    tree10 = """
             open tree@1.0,5.11-0
             add file tmp/sparc-only mode=0444 owner=root group=bin path=/etc/tree
             close
         """
 
-        amber10 = """
+    amber10 = """
             open amber@1.0,5.11-0
             add depend fmri=pkg:/tree@1.0 type=require
             close
         """
 
-        amber20 = """
+    amber20 = """
             open amber@2.0,5.11-0
             add depend fmri=pkg:/tree@1.0 type=require
             close
         """
 
-        bronze10 = """
+    bronze10 = """
             open bronze@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/usr
             add dir mode=0755 owner=root group=bin path=/usr/bin
@@ -84,7 +86,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        bronze20 = """
+    bronze20 = """
             open bronze@2.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/etc
             add dir mode=0755 owner=root group=bin path=/lib
@@ -100,7 +102,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        bronze20b = """
+    bronze20b = """
             open bronze@2.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/etc
             add dir mode=0755 owner=root group=bin path=/lib
@@ -117,7 +119,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        bronze20c = """
+    bronze20c = """
             open bronze@2.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/etc
             add dir mode=0755 owner=root group=bin path=/lib
@@ -136,22 +138,22 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        silverA = """
+    silverA = """
             open silver@1.0,5.11-0
             add file tmp/bronze1 mode=0444 owner=root group=bin path=/etc/bronze1
             add file tmp/sh mode=0444 owner=root group=bin path=/etc/tree pkg.merge.blend=arch
             close
         """
-        silverB = """
+    silverB = """
             open silver@1.0,5.11-0
             add file tmp/bronze1 mode=0555 owner=root group=bin path=/etc/bronze1
            close
         """
 
-        # etc/tree is purposefully delivered by this package to verify that
-        # pkgmerge can have an identical file being present in multiple
-        # packages (this and scheme@1.0) with different publishers.
-        multiA = """
+    # etc/tree is purposefully delivered by this package to verify that
+    # pkgmerge can have an identical file being present in multiple
+    # packages (this and scheme@1.0) with different publishers.
+    multiA = """
             open gold@1.0,5.11-0
             add file tmp/sparc-only mode=0444 owner=root group=bin path=/etc/tree
             add file tmp/sparc1 mode=0444 owner=root group=bin path=/etc/debug-notes pkg.merge.blend=arch
@@ -161,7 +163,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        multiB = """
+    multiB = """
             open gold@1.0,5.11-0
             add file tmp/sparc4 mode=0444 owner=root group=bin path=/etc/everywhere-notes pkg.merge.blend=arch pkg.merge.blend=debug
             add file tmp/sparc4 mode=0444 owner=root group=bin path=/etc/binary
@@ -169,14 +171,14 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        multiC = """
+    multiC = """
             open gold@1.0,5.11-0
             add file tmp/i3862 mode=0444 owner=root group=bin path=/etc/binary
             add depend type=require-any fmri=foo fmri=bar
             close
         """
 
-        multiD = """
+    multiD = """
             open gold@1.0,5.11-0
             add file tmp/i3861 mode=0444 owner=root group=bin path=/etc/nondebug-notes pkg.merge.blend=variant.arch
             add file tmp/i3863 mode=0444 owner=root group=bin path=/etc/binary
@@ -184,20 +186,20 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        tinA = """
+    tinA = """
             open tin@1.0,5.11-0
             add file tmp/bronze1 mode=0444 owner=root group=bin path=/etc/bronze1
             add file tmp/sh mode=0444 owner=root group=bin path=/etc/tree pkg.merge.blend=arch
             close
         """
-        tinB = """
+    tinB = """
             open tin@1.0,5.11-0
             add file tmp/bronze1 mode=0555 owner=root group=bin path=/etc/bronze1
             add file tmp/scheme mode=0444 owner=root group=bin path=/etc/tree pkg.merge.blend=arch
            close
         """
 
-        mediatorPPC = """
+    mediatorPPC = """
             open mediator@1.0,5.11-0
             add link path=wombat target=blue mediator=color mediator-implementation=blue pkg.merge.blend=arch
             add link path=wombat target=red mediator=color mediator-implementation=red pkg.merge.blend=arch
@@ -210,7 +212,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        mediatorARM = """
+    mediatorARM = """
             open mediator@1.0,5.11-0
             add link path=wombat target=teal mediator=color mediator-implementation=teal pkg.merge.blend=arch
             add link path=wombat target=pink mediator=color mediator-implementation=pink pkg.merge.blend=arch
@@ -223,7 +225,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        depend_conds = """
+    depend_conds = """
             open dependcond1@1.0
             add dir path=opt/dir/sparc owner=root group=bin mode=755 variant.arch=sparc
             add depend type=conditional fmri=appdep@1.0 predicate=app-2
@@ -231,7 +233,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        depend_condx = """
+    depend_condx = """
             open dependcond1@1.0
             add dir path=opt/dir/amd64 owner=root group=bin mode=755 variant.arch=i386
             add depend type=conditional fmri=appdep@1.0 predicate=app-2
@@ -239,7 +241,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        depend_same_conds = """
+    depend_same_conds = """
             open dependcond2@1.0
             add dir path=opt/dir/sparc owner=root group=bin mode=755 variant.arch=sparc
             add depend type=conditional fmri=appdep@1.0 predicate=app-2
@@ -247,7 +249,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        depend_same_condx = """
+    depend_same_condx = """
             open dependcond2@1.0
             add dir path=opt/dir/amd64 owner=root group=bin mode=755 variant.arch=i386
             add depend type=conditional fmri=appdep@1.0 predicate=app-2
@@ -255,7 +257,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        depend_reqs = """
+    depend_reqs = """
             open dependreq@1.0
             add dir path=opt/dir/sparc owner=root group=bin mode=755 variant.arch=sparc
             add depend type=require fmri=appdep@1.0
@@ -263,7 +265,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        depend_reqx = """
+    depend_reqx = """
             open dependreq@1.0
             add dir path=opt/dir/amd64 owner=root group=bin mode=755 variant.arch=i386
             add depend type=require fmri=appdep@1.0
@@ -271,7 +273,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        depend_reqs_any = """
+    depend_reqs_any = """
             open dependreqany@1.0
             add dir path=opt/dir/sparc owner=root group=bin mode=755 variant.arch=sparc
             add depend type=require-any fmri=appdep@1.0 fmri=appdep2@1.0
@@ -279,7 +281,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        depend_reqx_any = """
+    depend_reqx_any = """
             open dependreqany@1.0
             add dir path=opt/dir/amd64 owner=root group=bin mode=755 variant.arch=i386
             add depend type=require-any fmri=appdep@1.0 fmri=appdep2@1.0
@@ -287,279 +289,414 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        misc_files = [ "tmp/bronzeA1",  "tmp/bronzeA2", "tmp/bronze1",
-            "tmp/bronze2", "tmp/copyright2", "tmp/copyright3", "tmp/libc.so.1",
-            "tmp/sh", "tmp/scheme", "tmp/sparc-only", "tmp/sparc1", "tmp/sparc2",
-            "tmp/sparc3", "tmp/sparc4", "tmp/i3861", "tmp/i3862", "tmp/i3863"]
+    misc_files = [
+        "tmp/bronzeA1",
+        "tmp/bronzeA2",
+        "tmp/bronze1",
+        "tmp/bronze2",
+        "tmp/copyright2",
+        "tmp/copyright3",
+        "tmp/libc.so.1",
+        "tmp/sh",
+        "tmp/scheme",
+        "tmp/sparc-only",
+        "tmp/sparc1",
+        "tmp/sparc2",
+        "tmp/sparc3",
+        "tmp/sparc4",
+        "tmp/i3861",
+        "tmp/i3862",
+        "tmp/i3863",
+    ]
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self, 20 * ["os.org"])
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(self, 20 * ["os.org"])
+        self.make_misc_files(self.misc_files)
 
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.rurl3 = self.dcs[3].get_repo_url()
-                self.rurl4 = self.dcs[4].get_repo_url()
-                self.rurl5 = self.dcs[5].get_repo_url()
-                self.rurl6 = self.dcs[6].get_repo_url()
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.rurl3 = self.dcs[3].get_repo_url()
+        self.rurl4 = self.dcs[4].get_repo_url()
+        self.rurl5 = self.dcs[5].get_repo_url()
+        self.rurl6 = self.dcs[6].get_repo_url()
 
-                # Empty repository.
-                self.rurl7 = self.dcs[7].get_repo_url()
+        # Empty repository.
+        self.rurl7 = self.dcs[7].get_repo_url()
 
-                # a bunch for testing blending
-                self.rurl8 = self.dcs[8].get_repo_url()
-                self.rurl9 = self.dcs[9].get_repo_url()
-                self.rurl10 = self.dcs[10].get_repo_url()
-                self.rurl11 = self.dcs[11].get_repo_url()
-                self.rurl12 = self.dcs[12].get_repo_url()
-                self.rurl13 = self.dcs[13].get_repo_url()
+        # a bunch for testing blending
+        self.rurl8 = self.dcs[8].get_repo_url()
+        self.rurl9 = self.dcs[9].get_repo_url()
+        self.rurl10 = self.dcs[10].get_repo_url()
+        self.rurl11 = self.dcs[11].get_repo_url()
+        self.rurl12 = self.dcs[12].get_repo_url()
+        self.rurl13 = self.dcs[13].get_repo_url()
 
-                # repositories which will contain several publishers
-                self.rurl14 = self.dcs[14].get_repo_url()
-                self.rurl15 = self.dcs[15].get_repo_url()
+        # repositories which will contain several publishers
+        self.rurl14 = self.dcs[14].get_repo_url()
+        self.rurl15 = self.dcs[15].get_repo_url()
 
-                # mediator testing
-                self.rurl16 = self.dcs[16].get_repo_url()
-                self.rurl17 = self.dcs[17].get_repo_url()
+        # mediator testing
+        self.rurl16 = self.dcs[16].get_repo_url()
+        self.rurl17 = self.dcs[17].get_repo_url()
 
-                # depend action checks
-                self.rurl18 = self.dcs[18].get_repo_url()
-                self.rurl19 = self.dcs[19].get_repo_url()
+        # depend action checks
+        self.rurl18 = self.dcs[18].get_repo_url()
+        self.rurl19 = self.dcs[19].get_repo_url()
 
-                # Publish a set of packages to one repository.
-                self.published = self.pkgsend_bulk(self.rurl1, (self.amber10,
-                    self.amber20, self.bronze10, self.bronze20, self.tree10,
-                    self.scheme10))
+        # Publish a set of packages to one repository.
+        self.published = self.pkgsend_bulk(
+            self.rurl1,
+            (
+                self.amber10,
+                self.amber20,
+                self.bronze10,
+                self.bronze20,
+                self.tree10,
+                self.scheme10,
+            ),
+        )
 
-                # Ensure timestamps of all successive publications are greater.
-                time.sleep(1)
+        # Ensure timestamps of all successive publications are greater.
+        time.sleep(1)
 
-                # Publish the same set to another repository (minus the tree
-                # and scheme packages, and with a slightly different version
-                # of the bronze20 package).
-                self.published += self.pkgsend_bulk(self.rurl2, (self.amber10,
-                    self.amber20, self.bronze10, self.bronze20b))
+        # Publish the same set to another repository (minus the tree
+        # and scheme packages, and with a slightly different version
+        # of the bronze20 package).
+        self.published += self.pkgsend_bulk(
+            self.rurl2,
+            (self.amber10, self.amber20, self.bronze10, self.bronze20b),
+        )
 
-                # Ensure timestamps of all successive publications are greater.
-                time.sleep(1)
+        # Ensure timestamps of all successive publications are greater.
+        time.sleep(1)
 
-                # Publish the same set to another repository (with a slightly
-                # different version of the bronze20b package and with tree).
-                self.published += self.pkgsend_bulk(self.rurl3, (self.amber10,
-                    self.amber20, self.bronze10, self.bronze20c, self.tree10))
+        # Publish the same set to another repository (with a slightly
+        # different version of the bronze20b package and with tree).
+        self.published += self.pkgsend_bulk(
+            self.rurl3,
+            (
+                self.amber10,
+                self.amber20,
+                self.bronze10,
+                self.bronze20c,
+                self.tree10,
+            ),
+        )
 
-                # Ensure timestamps of all successive publications are greater.
-                time.sleep(1)
+        # Ensure timestamps of all successive publications are greater.
+        time.sleep(1)
 
-                # Everything above again, but this time using the debug version
-                # of the misc. files and a different set of repositories.
-                dfiles = dict((f, f + ".debug") for f in self.misc_files)
+        # Everything above again, but this time using the debug version
+        # of the misc. files and a different set of repositories.
+        dfiles = dict((f, f + ".debug") for f in self.misc_files)
 
-                # For testing purposes, don't change this file for the debug
-                # variant case.
-                dfiles["tmp/libc.so.1"] = "tmp/libc.so.1"
-                self.make_misc_files(dfiles)
+        # For testing purposes, don't change this file for the debug
+        # variant case.
+        dfiles["tmp/libc.so.1"] = "tmp/libc.so.1"
+        self.make_misc_files(dfiles)
 
-                self.published_debug = self.pkgsend_bulk(self.rurl4,
-                    (self.amber10, self.amber20, self.bronze10, self.bronze20,
-                    self.tree10, self.scheme10))
-                time.sleep(1)
+        self.published_debug = self.pkgsend_bulk(
+            self.rurl4,
+            (
+                self.amber10,
+                self.amber20,
+                self.bronze10,
+                self.bronze20,
+                self.tree10,
+                self.scheme10,
+            ),
+        )
+        time.sleep(1)
 
-                self.published_debug += self.pkgsend_bulk(self.rurl5,
-                    (self.amber10, self.amber20, self.bronze10, self.bronze20b))
-                time.sleep(1)
+        self.published_debug += self.pkgsend_bulk(
+            self.rurl5,
+            (self.amber10, self.amber20, self.bronze10, self.bronze20b),
+        )
+        time.sleep(1)
 
-                self.published_debug += self.pkgsend_bulk(self.rurl6, (
-                    self.amber10, self.amber20, self.bronze10, self.bronze20c,
-                    self.tree10))
+        self.published_debug += self.pkgsend_bulk(
+            self.rurl6,
+            (
+                self.amber10,
+                self.amber20,
+                self.bronze10,
+                self.bronze20c,
+                self.tree10,
+            ),
+        )
 
-                self.published_blend = self.pkgsend_bulk(self.rurl8, (self.silverA,
-                    self.tinA))
-                time.sleep(1)
-                self.published_blend += self.pkgsend_bulk(self.rurl9, (self.silverB,
-                    self.tinB))
+        self.published_blend = self.pkgsend_bulk(
+            self.rurl8, (self.silverA, self.tinA)
+        )
+        time.sleep(1)
+        self.published_blend += self.pkgsend_bulk(
+            self.rurl9, (self.silverB, self.tinB)
+        )
 
-                time.sleep(1)
-                self.published_blend += self.pkgsend_bulk(self.rurl10, (self.multiA,))
-                time.sleep(1)
-                self.published_blend += self.pkgsend_bulk(self.rurl11, (self.multiB,))
-                time.sleep(1)
-                self.published_blend += self.pkgsend_bulk(self.rurl12, (self.multiC,))
-                time.sleep(1)
-                self.published_blend += self.pkgsend_bulk(self.rurl13, (self.multiD,))
+        time.sleep(1)
+        self.published_blend += self.pkgsend_bulk(self.rurl10, (self.multiA,))
+        time.sleep(1)
+        self.published_blend += self.pkgsend_bulk(self.rurl11, (self.multiB,))
+        time.sleep(1)
+        self.published_blend += self.pkgsend_bulk(self.rurl12, (self.multiC,))
+        time.sleep(1)
+        self.published_blend += self.pkgsend_bulk(self.rurl13, (self.multiD,))
 
-                # Publish to multiple repositories, maintaining lists of which
-                # FMRIs are published to which repository.
-                self.published_multi_14 = []
-                self.published_multi_15 = []
+        # Publish to multiple repositories, maintaining lists of which
+        # FMRIs are published to which repository.
+        self.published_multi_14 = []
+        self.published_multi_15 = []
 
-                for url, record in [
-                    (self.rurl14, self.published_multi_14),
-                    (self.rurl15, self.published_multi_15)]:
-                        time.sleep(1)
-                        record += self.pkgsend_bulk(url, (self.scheme10))
-                        time.sleep(1)
-                        record += self.pkgsend_bulk(url, (self.tree10))
+        for url, record in [
+            (self.rurl14, self.published_multi_14),
+            (self.rurl15, self.published_multi_15),
+        ]:
+            time.sleep(1)
+            record += self.pkgsend_bulk(url, (self.scheme10))
+            time.sleep(1)
+            record += self.pkgsend_bulk(url, (self.tree10))
 
-                        time.sleep(1)
-                        record += self.pkgsend_bulk(url,
-                            self.bronze20.replace("open ",
-                            "open pkg://altpub/"))
-                        time.sleep(1)
-                        record += self.pkgsend_bulk(url,
-                            (self.amber10.replace("open ",
-                            "open pkg://altpub/")))
-                        time.sleep(1)
-                        record += self.pkgsend_bulk(url,
-                            (self.multiA.replace("open ",
-                            "open pkg://last/")))
+            time.sleep(1)
+            record += self.pkgsend_bulk(
+                url, self.bronze20.replace("open ", "open pkg://altpub/")
+            )
+            time.sleep(1)
+            record += self.pkgsend_bulk(
+                url, (self.amber10.replace("open ", "open pkg://altpub/"))
+            )
+            time.sleep(1)
+            record += self.pkgsend_bulk(
+                url, (self.multiA.replace("open ", "open pkg://last/"))
+            )
 
-                # add bronze20b to one repository so that we have at least one
-                # package where more complex merging happens.
-                time.sleep(1)
-                self.published_multi_15 += self.pkgsend_bulk(self.rurl15,
-                    self.bronze20b.replace("open ", "open pkg://altpub/"))
+        # add bronze20b to one repository so that we have at least one
+        # package where more complex merging happens.
+        time.sleep(1)
+        self.published_multi_15 += self.pkgsend_bulk(
+            self.rurl15, self.bronze20b.replace("open ", "open pkg://altpub/")
+        )
 
-                # one of our source repositories also contains a newer
-                # version of pkg:/gold (self.multi*)
-                time.sleep(1)
-                self.published_multi_15 += self.pkgsend_bulk(self.rurl15,
-                    (self.multiB.replace("open ", "open pkg://last/")))
+        # one of our source repositories also contains a newer
+        # version of pkg:/gold (self.multi*)
+        time.sleep(1)
+        self.published_multi_15 += self.pkgsend_bulk(
+            self.rurl15, (self.multiB.replace("open ", "open pkg://last/"))
+        )
 
-                # publish to our mediator repos
-                self.published_16 = self.pkgsend_bulk(self.rurl16,
-                    (self.mediatorPPC))
-                self.published_17 = self.pkgsend_bulk(self.rurl17,
-                    (self.mediatorARM))
+        # publish to our mediator repos
+        self.published_16 = self.pkgsend_bulk(self.rurl16, (self.mediatorPPC))
+        self.published_17 = self.pkgsend_bulk(self.rurl17, (self.mediatorARM))
 
-                # publish the depend packages
-                self.published_deps = self.pkgsend_bulk(self.rurl18,
-                    (self.depend_conds, self.depend_same_conds,
-                     self.depend_reqs, self.depend_reqs_any))
-                self.published_depx = self.pkgsend_bulk(self.rurl19,
-                    (self.depend_condx, self.depend_same_condx,
-                     self.depend_reqx, self.depend_reqx_any))
+        # publish the depend packages
+        self.published_deps = self.pkgsend_bulk(
+            self.rurl18,
+            (
+                self.depend_conds,
+                self.depend_same_conds,
+                self.depend_reqs,
+                self.depend_reqs_any,
+            ),
+        )
+        self.published_depx = self.pkgsend_bulk(
+            self.rurl19,
+            (
+                self.depend_condx,
+                self.depend_same_condx,
+                self.depend_reqx,
+                self.depend_reqx_any,
+            ),
+        )
 
-        def test_0_options(self):
-                """Verify that pkgmerge gracefully fails when given bad option
-                values."""
+    def test_0_options(self):
+        """Verify that pkgmerge gracefully fails when given bad option
+        values."""
 
-                # Should fail because no source was specified.
-                self.pkgmerge(" ".join([
+        # Should fail because no source was specified.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-d {0}".format(self.rurl2),
-                ]), exit=2)
+                ]
+            ),
+            exit=2,
+        )
 
-                # Should fail because no destination was specified.
-                self.pkgmerge(" ".join([
+        # Should fail because no destination was specified.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386,{0}".format(self.rurl2),
-                ]), exit=2)
+                ]
+            ),
+            exit=2,
+        )
 
-                # Should fail because variant for source was not provided.
-                self.pkgmerge(" ".join([
+        # Should fail because variant for source was not provided.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s {0}".format(self.rurl1),
                     "-d {0}".format(self.rurl2),
-                ]), exit=2)
+                ]
+            ),
+            exit=2,
+        )
 
-                # Should fail because only source variant was provided.
-                self.pkgmerge(" ".join([
+        # Should fail because only source variant was provided.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386",
                     "-d {0}".format(self.rurl2),
-                ]), exit=2)
+                ]
+            ),
+            exit=2,
+        )
 
-                # Should fail because user did not specify the same variants
-                # for every source.
-                self.pkgmerge(" ".join([
+        # Should fail because user did not specify the same variants
+        # for every source.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=sparc,{0}".format(self.dcs[1].get_repodir()),
-                    "-s arch=i386,debug=true,{0}".format(self.dcs[2].get_repodir()),
-                    "-d {0}".format(self.rurl7)
-                ]), exit=2)
+                    "-s arch=i386,debug=true,{0}".format(
+                        self.dcs[2].get_repodir()
+                    ),
+                    "-d {0}".format(self.rurl7),
+                ]
+            ),
+            exit=2,
+        )
 
-                # Should fail because user did not specify a source for all
-                # variant combinations (e.g. i386 & arm debug).
-                self.pkgmerge(" ".join([
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[1].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[2].get_repodir()),
-                    "-s arch=arm,debug=false,{0}".format(self.dcs[3].get_repodir()),
-                    "-s arch=sparc,debug=true,{0}".format(self.dcs[4].get_repodir()),
-                    "-d {0}".format(self.rurl7)
-                ]), exit=2)
+        # Should fail because user did not specify a source for all
+        # variant combinations (e.g. i386 & arm debug).
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[1].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[2].get_repodir()
+                    ),
+                    "-s arch=arm,debug=false,{0}".format(
+                        self.dcs[3].get_repodir()
+                    ),
+                    "-s arch=sparc,debug=true,{0}".format(
+                        self.dcs[4].get_repodir()
+                    ),
+                    "-d {0}".format(self.rurl7),
+                ]
+            ),
+            exit=2,
+        )
 
-                # Should fail because source is not a repository.
-                self.pkgmerge(" ".join([
+        # Should fail because source is not a repository.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386,{0}".format(self.test_root),
                     "-d {0}".format(self.rurl2),
-                ]), exit=1)
+                ]
+            ),
+            exit=1,
+        )
 
-                # Should fail because destination is not a repository.
-                self.pkgmerge(" ".join([
+        # Should fail because destination is not a repository.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386,{0}".format(self.rurl2),
                     "-d {0}".format(self.test_root),
-                ]), exit=1)
+                ]
+            ),
+            exit=1,
+        )
 
-                # Should fail because of no matching -p publishers.
-                self.pkgmerge(" ".join([
+        # Should fail because of no matching -p publishers.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386,{0}".format(self.rurl2),
                     "-d {0} -p noodles".format(self.test_root),
-                ]), exit=1)
+                ]
+            ),
+            exit=1,
+        )
 
-                # Create the target repository.
-                repodir = os.path.join(self.test_root, "test_0_repo")
-                self.create_repo(repodir)
+        # Create the target repository.
+        repodir = os.path.join(self.test_root, "test_0_repo")
+        self.create_repo(repodir)
 
-                # Should fail because of no matching packages.
-                self.pkgmerge(" ".join([
+        # Should fail because of no matching packages.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386,{0}".format(self.rurl1),
                     "-d {0} nomatching".format(repodir),
-                ]), exit=1)
-                shutil.rmtree(repodir)
+                ]
+            ),
+            exit=1,
+        )
+        shutil.rmtree(repodir)
 
-        def test_1_single_merge(self):
-                """Verify that merge functionality works as expected when
-                specifying a single source."""
+    def test_1_single_merge(self):
+        """Verify that merge functionality works as expected when
+        specifying a single source."""
 
-                #
-                # First, verify that merging all packages from a single source
-                # works as expected.
-                #
+        #
+        # First, verify that merging all packages from a single source
+        # works as expected.
+        #
 
-                # Create the target repository.
-                repodir = os.path.join(self.test_root, "1merge_repo")
-                self.create_repo(repodir)
+        # Create the target repository.
+        repodir = os.path.join(self.test_root, "1merge_repo")
+        self.create_repo(repodir)
 
-                # Perform a dry-run.
-                self.pkgmerge(" ".join([
+        # Perform a dry-run.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386,{0}".format(self.rurl2),
                     "-d {0}".format(repodir),
                     "-n",
-                ]))
+                ]
+            )
+        )
 
-                # Merge the packages.
-                self.pkgmerge(" ".join([
+        # Merge the packages.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386,{0}".format(self.rurl2),
                     "-d {0}".format(repodir),
-                ]))
-
-                # Get target repository catalog.
-                repo = self.get_repo(repodir)
-                cat = repo.get_catalog(pub="os.org")
-
-                # Verify the list of expected packages in the target repository.
-                expected = [
-                    self.published[7], # pkg://os.org/amber@2.0-0
-                    self.published[9], # pkg://os.org/bronze@2.0-0
                 ]
-                actual = [str(f) for f in sorted(cat.fmris())]
+            )
+        )
 
-                self.assertEqualDiff(expected, actual)
+        # Get target repository catalog.
+        repo = self.get_repo(repodir)
+        cat = repo.get_catalog(pub="os.org")
 
-                # Verify that each package was merged correctly.
-                merged_expected = {
-                    "amber": """\
+        # Verify the list of expected packages in the target repository.
+        expected = [
+            self.published[7],  # pkg://os.org/amber@2.0-0
+            self.published[9],  # pkg://os.org/bronze@2.0-0
+        ]
+        actual = [str(f) for f in sorted(cat.fmris())]
+
+        self.assertEqualDiff(expected, actual)
+
+        # Verify that each package was merged correctly.
+        merged_expected = {
+            "amber": """\
 depend fmri=pkg:/tree@1.0 type=require
 set name=pkg.fmri value={0}
 set name=variant.arch value=i386\
-""".format(self.published[7]), # pkg://os.org/amber@2.0-0
-                    "bronze": """\
+""".format(
+                self.published[7]
+            ),  # pkg://os.org/amber@2.0-0
+            "bronze": """\
 depend fmri=pkg:/amber@2.0 type=require
 depend fmri=pkg:/scheme@1.0 type=require
 dir group=bin mode=0755 owner=root path=etc
@@ -574,119 +711,139 @@ license 995ad376b9c7ae79d67e673504fc4199fbfb32eb chash=9374d402ed3034a553119e179
 link path=usr/bin/jsh target=./sh
 set name=pkg.fmri value={0}
 set name=variant.arch value=i386\
-""".format(self.published[9]) # pkg://os.org/bronze@2.0-0
-                }
+""".format(
+                self.published[9]
+            ),  # pkg://os.org/bronze@2.0-0
+        }
 
-                for f in cat.fmris():
-                        with open(repo.manifest(f), "r") as m:
-                                actual = "".join(sorted(l for l in m)).strip()
-                        expected = merged_expected[f.pkg_name]
-                        self.assertEqualDiff(expected, actual)
+        for f in cat.fmris():
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+            expected = merged_expected[f.pkg_name]
+            self.assertEqualDiff(expected, actual)
 
-                #
-                # Next, verify that merging specific packages from a single
-                # source works as expected.
-                #
+        #
+        # Next, verify that merging specific packages from a single
+        # source works as expected.
+        #
 
-                # Create the target repository.
-                shutil.rmtree(repodir)
-                self.create_repo(repodir)
+        # Create the target repository.
+        shutil.rmtree(repodir)
+        self.create_repo(repodir)
 
-                # Perform a dry-run.
-                self.pkgmerge(" ".join([
+        # Perform a dry-run.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386,{0}".format(self.rurl2),
                     "-d {0}".format(repodir),
                     "-n",
                     "amber@latest",
-                ]))
+                ]
+            )
+        )
 
-                # Merge the packages.
-                self.pkgmerge(" ".join([
+        # Merge the packages.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386,{0}".format(self.rurl2),
                     "-d {0}".format(repodir),
                     "amber@latest",
-                ]))
-
-                # Get target repository catalog.
-                repo = self.get_repo(repodir)
-                cat = repo.get_catalog(pub="os.org")
-
-                # Verify the list of expected packages in the target repository.
-                expected = [
-                    self.published[7], # pkg://os.org/amber@2.0-0
                 ]
-                actual = [str(f) for f in sorted(cat.fmris())]
-                self.assertEqualDiff(expected, actual)
+            )
+        )
 
-                # Verify that each package was merged correctly.
-                for f in cat.fmris():
-                        with open(repo.manifest(f), "r") as m:
-                                actual = "".join(sorted(l for l in m)).strip()
-                        expected = merged_expected[f.pkg_name]
-                        self.assertEqualDiff(expected, actual)
+        # Get target repository catalog.
+        repo = self.get_repo(repodir)
+        cat = repo.get_catalog(pub="os.org")
 
-                # Next, verify that an attempt to merge using a variant that
-                # doesn't match what is already declared in a source's packages
-                # results in failure.  (e.g. packages are tagged i386, but
-                # source was claimed to be sparc.)
-                junk_repodir = os.path.join(self.test_root, "1junk_repo")
-                self.create_repo(junk_repodir)
+        # Verify the list of expected packages in the target repository.
+        expected = [
+            self.published[7],  # pkg://os.org/amber@2.0-0
+        ]
+        actual = [str(f) for f in sorted(cat.fmris())]
+        self.assertEqualDiff(expected, actual)
 
-                self.pkgmerge(" ".join([
+        # Verify that each package was merged correctly.
+        for f in cat.fmris():
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+            expected = merged_expected[f.pkg_name]
+            self.assertEqualDiff(expected, actual)
+
+        # Next, verify that an attempt to merge using a variant that
+        # doesn't match what is already declared in a source's packages
+        # results in failure.  (e.g. packages are tagged i386, but
+        # source was claimed to be sparc.)
+        junk_repodir = os.path.join(self.test_root, "1junk_repo")
+        self.create_repo(junk_repodir)
+
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=sparc,{0}".format(repodir),
                     "-d {0}".format(junk_repodir),
                     "amber@latest",
-                ]), exit=1)
+                ]
+            ),
+            exit=1,
+        )
 
-                # Cleanup.
-                shutil.rmtree(repodir)
+        # Cleanup.
+        shutil.rmtree(repodir)
 
-        def test_2_multi_merge(self):
-                """Verify that merge functionality works as expected when
-                specifying multiple sources."""
+    def test_2_multi_merge(self):
+        """Verify that merge functionality works as expected when
+        specifying multiple sources."""
 
-                #
-                # First, verify that merging all packages from multiple sources
-                # works as expected when specifying two variant values.
-                #
+        #
+        # First, verify that merging all packages from multiple sources
+        # works as expected when specifying two variant values.
+        #
 
-                # Create the target repository.
-                repodir = os.path.join(self.test_root, "2merge_repo")
-                self.create_repo(repodir)
+        # Create the target repository.
+        repodir = os.path.join(self.test_root, "2merge_repo")
+        self.create_repo(repodir)
 
-                # Merge the packages.
-                self.pkgmerge(" ".join([
+        # Merge the packages.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=i386,{0}".format(self.rurl2),
                     "-s arch=sparc,{0}".format(self.rurl1),
-                    "-d {0}".format(repodir)
-                ]))
+                    "-d {0}".format(repodir),
+                ]
+            )
+        )
 
-                # Get target repository catalog.
-                repo = self.get_repo(repodir)
-                cat = repo.get_catalog(pub="os.org")
+        # Get target repository catalog.
+        repo = self.get_repo(repodir)
+        cat = repo.get_catalog(pub="os.org")
 
-                # Verify the list of expected packages in the target repository.
-                nlist = {}
-                for s in self.published[:10]:
-                        f = fmri.PkgFmri(s)
-                        if f.pkg_name not in nlist or \
-                            f.version > nlist[f.pkg_name].version:
-                                nlist[f.pkg_name] = f
-                nlist = sorted(nlist.values())
+        # Verify the list of expected packages in the target repository.
+        nlist = {}
+        for s in self.published[:10]:
+            f = fmri.PkgFmri(s)
+            if f.pkg_name not in nlist or f.version > nlist[f.pkg_name].version:
+                nlist[f.pkg_name] = f
+        nlist = sorted(nlist.values())
 
-                expected = [str(f) for f in nlist]
-                actual = [str(f) for f in sorted(cat.fmris())]
+        expected = [str(f) for f in nlist]
+        actual = [str(f) for f in sorted(cat.fmris())]
 
-                self.assertEqualDiff(expected, actual)
+        self.assertEqualDiff(expected, actual)
 
-                # Verify that each package was merged correctly.
-                merged_expected = {
-                    "amber": """\
+        # Verify that each package was merged correctly.
+        merged_expected = {
+            "amber": """\
 depend fmri=pkg:/tree@1.0 type=require
 set name=pkg.fmri value={0}
 set name=variant.arch value=i386 value=sparc\
-""".format(self.published[7]), # pkg://os.org/amber@2.0-0
-                    "bronze": """\
+""".format(
+                self.published[7]
+            ),  # pkg://os.org/amber@2.0-0
+            "bronze": """\
 depend fmri=pkg:/amber@2.0 type=require
 depend fmri=pkg:/scheme@1.0 type=require variant.arch=i386
 dir group=bin mode=0755 owner=root path=etc
@@ -702,67 +859,78 @@ license 995ad376b9c7ae79d67e673504fc4199fbfb32eb chash=9374d402ed3034a553119e179
 link path=usr/bin/jsh target=./sh
 set name=pkg.fmri value={0}
 set name=variant.arch value=i386 value=sparc\
-""".format(self.published[9]), # pkg://os.org/bronze@2.0-0
-                    "scheme": """\
+""".format(
+                self.published[9]
+            ),  # pkg://os.org/bronze@2.0-0
+            "scheme": """\
 file 3b7cee8797632f83a11b66d028016946b4fa47fa chash=00621927edeb8e5b96ef63a93b4c5d125f2a3298 group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:6650b24e5c5ceab211c95614def1ae53905a8f415f7fcfdfcc40b778041ed974 pkg.content-hash=gzip:sha512t_256:079a76079a1c22c13f3c2bb4b6efe8b589c1061b48e893c597c74adb62cac195 pkg.csize=34 pkg.size=14
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc\
-""".format(self.published[5]), # pkg://os.org/scheme@1.0-0
-                    "tree": """\
+""".format(
+                self.published[5]
+            ),  # pkg://os.org/scheme@1.0-0
+            "tree": """\
 file 3b7cee8797632f83a11b66d028016946b4fa47fa chash=00621927edeb8e5b96ef63a93b4c5d125f2a3298 group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:6650b24e5c5ceab211c95614def1ae53905a8f415f7fcfdfcc40b778041ed974 pkg.content-hash=gzip:sha512t_256:079a76079a1c22c13f3c2bb4b6efe8b589c1061b48e893c597c74adb62cac195 pkg.csize=34 pkg.size=14
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc\
-""".format(self.published[4]), # pkg://os.org/tree@1.0-0
-               }
+""".format(
+                self.published[4]
+            ),  # pkg://os.org/tree@1.0-0
+        }
 
-                for f in nlist:
-                        with open(repo.manifest(f), "r") as m:
-                                actual = "".join(sorted(l for l in m)).strip()
-                        expected = merged_expected[f.pkg_name]
-                        self.assertEqualDiff(expected, actual)
+        for f in nlist:
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+            expected = merged_expected[f.pkg_name]
+            self.assertEqualDiff(expected, actual)
 
-                #
-                # Next, verify that merging packages for three variant values
-                # works as expected.
-                #
+        #
+        # Next, verify that merging packages for three variant values
+        # works as expected.
+        #
 
-                # Create the target repository.
-                shutil.rmtree(repodir)
-                self.create_repo(repodir)
+        # Create the target repository.
+        shutil.rmtree(repodir)
+        self.create_repo(repodir)
 
-                # Merge the packages.
-                self.pkgmerge(" ".join([
+        # Merge the packages.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=sparc,{0}".format(self.rurl1),
                     "-s arch=i386,{0}".format(self.rurl2),
                     "-s arch=arm,{0}".format(self.rurl3),
-                    "-d {0}".format(repodir)
-                ]))
+                    "-d {0}".format(repodir),
+                ]
+            )
+        )
 
-                # Get target repository catalog.
-                repo = self.get_repo(repodir)
-                cat = repo.get_catalog(pub="os.org")
+        # Get target repository catalog.
+        repo = self.get_repo(repodir)
+        cat = repo.get_catalog(pub="os.org")
 
-                # Verify the list of expected packages in the target repository.
-                nlist = {}
-                for s in self.published:
-                        f = fmri.PkgFmri(s)
-                        if f.pkg_name not in nlist or \
-                            f.version > nlist[f.pkg_name].version:
-                                nlist[f.pkg_name] = f
-                nlist = sorted(nlist.values())
+        # Verify the list of expected packages in the target repository.
+        nlist = {}
+        for s in self.published:
+            f = fmri.PkgFmri(s)
+            if f.pkg_name not in nlist or f.version > nlist[f.pkg_name].version:
+                nlist[f.pkg_name] = f
+        nlist = sorted(nlist.values())
 
-                expected = [str(f) for f in nlist]
-                actual = [str(f) for f in sorted(cat.fmris())]
-                self.assertEqualDiff(expected, actual)
+        expected = [str(f) for f in nlist]
+        actual = [str(f) for f in sorted(cat.fmris())]
+        self.assertEqualDiff(expected, actual)
 
-                # Verify that each package was merged correctly.
-                merged_expected = {
-                    "amber": """\
+        # Verify that each package was merged correctly.
+        merged_expected = {
+            "amber": """\
 depend fmri=pkg:/tree@1.0 type=require
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386 value=arm\
-""".format(self.published[11]), # pkg://os.org/amber@2.0-0
-                    "bronze": """\
+""".format(
+                self.published[11]
+            ),  # pkg://os.org/amber@2.0-0
+            "bronze": """\
 depend fmri=pkg:/amber@2.0 type=require
 depend fmri=pkg:/scheme@1.0 type=require variant.arch=arm
 depend fmri=pkg:/scheme@1.0 type=require variant.arch=i386
@@ -782,134 +950,160 @@ license 995ad376b9c7ae79d67e673504fc4199fbfb32eb chash=9374d402ed3034a553119e179
 link path=usr/bin/jsh target=./sh
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386 value=arm\
-""".format(self.published[13]), # pkg://os.org/bronze@2.0-0
-                    "scheme": """\
+""".format(
+                self.published[13]
+            ),  # pkg://os.org/bronze@2.0-0
+            "scheme": """\
 file 3b7cee8797632f83a11b66d028016946b4fa47fa chash=00621927edeb8e5b96ef63a93b4c5d125f2a3298 group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:6650b24e5c5ceab211c95614def1ae53905a8f415f7fcfdfcc40b778041ed974 pkg.content-hash=gzip:sha512t_256:079a76079a1c22c13f3c2bb4b6efe8b589c1061b48e893c597c74adb62cac195 pkg.csize=34 pkg.size=14
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc\
-""".format(self.published[5]), # pkg://os.org/scheme@1.0-0
-                    "tree": """\
+""".format(
+                self.published[5]
+            ),  # pkg://os.org/scheme@1.0-0
+            "tree": """\
 file 3b7cee8797632f83a11b66d028016946b4fa47fa chash=00621927edeb8e5b96ef63a93b4c5d125f2a3298 group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:6650b24e5c5ceab211c95614def1ae53905a8f415f7fcfdfcc40b778041ed974 pkg.content-hash=gzip:sha512t_256:079a76079a1c22c13f3c2bb4b6efe8b589c1061b48e893c597c74adb62cac195 pkg.csize=34 pkg.size=14
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=arm\
-""".format(self.published[14]), # pkg://os.org/tree@1.0-0
-               }
+""".format(
+                self.published[14]
+            ),  # pkg://os.org/tree@1.0-0
+        }
 
-                for f in nlist:
-                        with open(repo.manifest(f), "r") as m:
-                                actual = "".join(sorted(l for l in m)).strip()
-                        expected = merged_expected[f.pkg_name]
-                        self.assertEqualDiff(expected, actual)
+        for f in nlist:
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+            expected = merged_expected[f.pkg_name]
+            self.assertEqualDiff(expected, actual)
 
-                #
-                # Next, verify that merging specific packages from multiple
-                # sources works as expected.
-                #
+        #
+        # Next, verify that merging specific packages from multiple
+        # sources works as expected.
+        #
 
-                # Create the target repository.
-                shutil.rmtree(repodir)
-                self.create_repo(repodir)
+        # Create the target repository.
+        shutil.rmtree(repodir)
+        self.create_repo(repodir)
 
-                # Merge the packages.
-                self.pkgmerge(" ".join([
+        # Merge the packages.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=sparc,{0}".format(self.rurl1),
                     "-s arch=i386,{0}".format(self.rurl2),
                     "-s arch=arm,{0}".format(self.rurl3),
                     "-d {0}".format(repodir),
                     "scheme amber@1.0 bronze@latest",
-                ]))
-
-                # Get target repository catalog.
-                repo = self.get_repo(repodir)
-                cat = repo.get_catalog(pub="os.org")
-
-                # Verify the list of expected packages in the target repository.
-                expected = [
-                    self.published[10], # pkg://os.org/amber@1.0-0
-                    self.published[13], # pkg://os.org/bronze@2.0-0
-                    self.published[5], # pkg://os.org/scheme@1.0-0
                 ]
-                actual = [str(f) for f in sorted(cat.fmris())]
-                self.assertEqualDiff(expected, actual)
+            )
+        )
 
-                merged_expected["amber"] = """\
+        # Get target repository catalog.
+        repo = self.get_repo(repodir)
+        cat = repo.get_catalog(pub="os.org")
+
+        # Verify the list of expected packages in the target repository.
+        expected = [
+            self.published[10],  # pkg://os.org/amber@1.0-0
+            self.published[13],  # pkg://os.org/bronze@2.0-0
+            self.published[5],  # pkg://os.org/scheme@1.0-0
+        ]
+        actual = [str(f) for f in sorted(cat.fmris())]
+        self.assertEqualDiff(expected, actual)
+
+        merged_expected[
+            "amber"
+        ] = """\
 depend fmri=pkg:/tree@1.0 type=require
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386 value=arm\
-""".format(self.published[10]) # pkg://os.org/amber@1.0-0
+""".format(
+            self.published[10]
+        )  # pkg://os.org/amber@1.0-0
 
-                # Verify that each package was merged correctly.
-                for f in cat.fmris():
-                        with open(repo.manifest(f), "r") as m:
-                                actual = "".join(sorted(l for l in m)).strip()
-                        expected = merged_expected[f.pkg_name]
-                        self.assertEqualDiff(expected, actual)
+        # Verify that each package was merged correctly.
+        for f in cat.fmris():
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+            expected = merged_expected[f.pkg_name]
+            self.assertEqualDiff(expected, actual)
 
-                # Cleanup.
-                shutil.rmtree(repodir)
+        # Cleanup.
+        shutil.rmtree(repodir)
 
-        def test_3_cross_merge(self):
-                """Verify that pkgmerge works as expected when the resulting
-                merge is a cross-product (e.g. a prior merge in steps or all at
-                once for sparc/x86 with debug/non-debug)."""
+    def test_3_cross_merge(self):
+        """Verify that pkgmerge works as expected when the resulting
+        merge is a cross-product (e.g. a prior merge in steps or all at
+        once for sparc/x86 with debug/non-debug)."""
 
-                # Create final merge repository.
-                repodir = os.path.join(self.test_root, "3merge_repo")
-                self.create_repo(repodir)
+        # Create final merge repository.
+        repodir = os.path.join(self.test_root, "3merge_repo")
+        self.create_repo(repodir)
 
-                for i, arch in enumerate(("sparc", "i386", "arm")):
-                        # For each arch, merge the debug and non-debug variants
-                        # first.
-                        rdir = os.path.join(self.test_root, "3{0}_repo".format(arch))
-                        self.create_repo(rdir)
+        for i, arch in enumerate(("sparc", "i386", "arm")):
+            # For each arch, merge the debug and non-debug variants
+            # first.
+            rdir = os.path.join(self.test_root, "3{0}_repo".format(arch))
+            self.create_repo(rdir)
 
-                        ndrepo = self.dcs[i + 1].get_repodir()
-                        drepo = self.dcs[i + 4].get_repodir()
+            ndrepo = self.dcs[i + 1].get_repodir()
+            drepo = self.dcs[i + 4].get_repodir()
 
-                        # Merge the packages.
-                        self.pkgmerge(" ".join([
-                            "-s debug=false,{0}".format(ndrepo),
-                            "-s variant.debug=true,{0}".format(drepo),
-                            "-d {0}".format(rdir)
-                        ]))
+            # Merge the packages.
+            self.pkgmerge(
+                " ".join(
+                    [
+                        "-s debug=false,{0}".format(ndrepo),
+                        "-s variant.debug=true,{0}".format(drepo),
+                        "-d {0}".format(rdir),
+                    ]
+                )
+            )
 
-                # Now merge all of the debug/non-debug repositories.
-                self.pkgmerge(" ".join([
-                    "-s arch=sparc,{0}".format(os.path.join(self.test_root,
-                        "3sparc_repo")),
-                    "-s arch=i386,{0}".format(os.path.join(self.test_root,
-                        "3i386_repo")),
-                    "-s arch=arm,{0}".format(os.path.join(self.test_root,
-                        "3arm_repo")),
+        # Now merge all of the debug/non-debug repositories.
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=sparc,{0}".format(
+                        os.path.join(self.test_root, "3sparc_repo")
+                    ),
+                    "-s arch=i386,{0}".format(
+                        os.path.join(self.test_root, "3i386_repo")
+                    ),
+                    "-s arch=arm,{0}".format(
+                        os.path.join(self.test_root, "3arm_repo")
+                    ),
                     "-d {0}".format(repodir),
-                ]))
+                ]
+            )
+        )
 
-                # Get target repository catalog.
-                repo = self.get_repo(repodir)
-                cat = repo.get_catalog(pub="os.org")
+        # Get target repository catalog.
+        repo = self.get_repo(repodir)
+        cat = repo.get_catalog(pub="os.org")
 
-                # Verify the list of expected packages in the target repository.
-                nlist = {}
-                for s in self.published + self.published_debug:
-                        f = fmri.PkgFmri(s)
-                        if f.pkg_name not in nlist or \
-                            f.version > nlist[f.pkg_name].version:
-                                nlist[f.pkg_name] = f
-                nlist = sorted(nlist.values())
+        # Verify the list of expected packages in the target repository.
+        nlist = {}
+        for s in self.published + self.published_debug:
+            f = fmri.PkgFmri(s)
+            if f.pkg_name not in nlist or f.version > nlist[f.pkg_name].version:
+                nlist[f.pkg_name] = f
+        nlist = sorted(nlist.values())
 
-                expected = [str(f) for f in nlist]
-                actual = [str(f) for f in sorted(cat.fmris())]
-                self.assertEqualDiff(expected, actual)
+        expected = [str(f) for f in nlist]
+        actual = [str(f) for f in sorted(cat.fmris())]
+        self.assertEqualDiff(expected, actual)
 
-                # Verify that each package was merged correctly.
-                merged_expected = {
-                    "amber": """\
+        # Verify that each package was merged correctly.
+        merged_expected = {
+            "amber": """\
 depend fmri=pkg:/tree@1.0 type=require
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386 value=arm
 set name=variant.debug value=false value=true\
-""".format(self.published_debug[11]), # pkg://os.org/amber@2.0-0
-                    "bronze": """\
+""".format(
+                self.published_debug[11]
+            ),  # pkg://os.org/amber@2.0-0
+            "bronze": """\
 depend fmri=pkg:/amber@2.0 type=require
 depend fmri=pkg:/scheme@1.0 type=require variant.arch=arm
 depend fmri=pkg:/scheme@1.0 type=require variant.arch=i386
@@ -938,93 +1132,132 @@ link path=usr/bin/jsh target=./sh
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386 value=arm
 set name=variant.debug value=false value=true\
-""".format(self.published_debug[13]), # pkg://os.org/bronze@2.0-0
-                    "scheme": """\
+""".format(
+                self.published_debug[13]
+            ),  # pkg://os.org/bronze@2.0-0
+            "scheme": """\
 file 3a06aa547ffe0186a2b9db55b8853874a048fb47 chash=ab50364de4ce8f847d765d402d80e37431e1f0aa group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:e1152d631b4c2fda4a2b739d38e4cbc3e8d7ccf2aa5be2aef6ab776a60d5a187 pkg.content-hash=gzip:sha512t_256:bfdce1dc4ab94f2321f2bae46505dd204b2df323df55efadf4f3b4c3326b204d pkg.csize=40 pkg.size=20 variant.debug=true
 file 3b7cee8797632f83a11b66d028016946b4fa47fa chash=00621927edeb8e5b96ef63a93b4c5d125f2a3298 group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:6650b24e5c5ceab211c95614def1ae53905a8f415f7fcfdfcc40b778041ed974 pkg.content-hash=gzip:sha512t_256:079a76079a1c22c13f3c2bb4b6efe8b589c1061b48e893c597c74adb62cac195 pkg.csize=34 pkg.size=14 variant.debug=false
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc
 set name=variant.debug value=false value=true\
-""".format(self.published_debug[5]), # pkg://os.org/scheme@1.0-0
-                    "tree": """\
+""".format(
+                self.published_debug[5]
+            ),  # pkg://os.org/scheme@1.0-0
+            "tree": """\
 file 3a06aa547ffe0186a2b9db55b8853874a048fb47 chash=ab50364de4ce8f847d765d402d80e37431e1f0aa group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:e1152d631b4c2fda4a2b739d38e4cbc3e8d7ccf2aa5be2aef6ab776a60d5a187 pkg.content-hash=gzip:sha512t_256:bfdce1dc4ab94f2321f2bae46505dd204b2df323df55efadf4f3b4c3326b204d pkg.csize=40 pkg.size=20 variant.debug=true
 file 3b7cee8797632f83a11b66d028016946b4fa47fa chash=00621927edeb8e5b96ef63a93b4c5d125f2a3298 group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:6650b24e5c5ceab211c95614def1ae53905a8f415f7fcfdfcc40b778041ed974 pkg.content-hash=gzip:sha512t_256:079a76079a1c22c13f3c2bb4b6efe8b589c1061b48e893c597c74adb62cac195 pkg.csize=34 pkg.size=14 variant.debug=false
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=arm
 set name=variant.debug value=false value=true\
-""".format(self.published_debug[14]), # pkg://os.org/tree@1.0-0
-               }
+""".format(
+                self.published_debug[14]
+            ),  # pkg://os.org/tree@1.0-0
+        }
 
-                for f in nlist:
-                        with open(repo.manifest(f), "r") as m:
-                                actual = "".join(sorted(l for l in m)).strip()
-                        expected = merged_expected[f.pkg_name]
-                        self.assertEqualDiff(expected, actual)
+        for f in nlist:
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+            expected = merged_expected[f.pkg_name]
+            self.assertEqualDiff(expected, actual)
 
-                # Cleanup.
-                shutil.rmtree(repodir)
+        # Cleanup.
+        shutil.rmtree(repodir)
 
-                #
-                # Attempt to merge x86 and sparc debug/non-debug all at once.
-                #
-                self.create_repo(repodir)
-                self.pkgmerge(" ".join([
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[1].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[2].get_repodir()),
-                    "-s arch=arm,debug=false,{0}".format(self.dcs[3].get_repodir()),
-                    "-s arch=sparc,debug=true,{0}".format(self.dcs[4].get_repodir()),
-                    "-s arch=i386,debug=true,{0}".format(self.dcs[5].get_repodir()),
-                    "-s arch=arm,debug=true,{0}".format(self.dcs[6].get_repodir()),
-                    "-d {0}".format(repodir)
-                ]))
+        #
+        # Attempt to merge x86 and sparc debug/non-debug all at once.
+        #
+        self.create_repo(repodir)
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[1].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[2].get_repodir()
+                    ),
+                    "-s arch=arm,debug=false,{0}".format(
+                        self.dcs[3].get_repodir()
+                    ),
+                    "-s arch=sparc,debug=true,{0}".format(
+                        self.dcs[4].get_repodir()
+                    ),
+                    "-s arch=i386,debug=true,{0}".format(
+                        self.dcs[5].get_repodir()
+                    ),
+                    "-s arch=arm,debug=true,{0}".format(
+                        self.dcs[6].get_repodir()
+                    ),
+                    "-d {0}".format(repodir),
+                ]
+            )
+        )
 
-                repo = self.get_repo(repodir)
-                for f in nlist:
-                        with open(repo.manifest(f), "r") as m:
-                                actual = "".join(sorted(l for l in m)).strip()
-                        expected = merged_expected[f.pkg_name]
-                        self.assertEqualDiff(expected, actual)
+        repo = self.get_repo(repodir)
+        for f in nlist:
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+            expected = merged_expected[f.pkg_name]
+            self.assertEqualDiff(expected, actual)
 
-                # Cleanup.
-                shutil.rmtree(repodir)
+        # Cleanup.
+        shutil.rmtree(repodir)
 
-                #
-                # Verify that naming an empty source allows a user to perform
-                # mismatched merges (i.e. merge sparc debug/non-debug with i386
-                # and arm non-debug) if empty repositories are used to fill in
-                # the missing cases.
-                nlist = {}
-                for s in self.published + self.published_debug[:6]:
-                        f = fmri.PkgFmri(s)
-                        if f.pkg_name not in nlist or \
-                            f.version > nlist[f.pkg_name].version:
-                                nlist[f.pkg_name] = f
-                nlist = sorted(nlist.values())
+        #
+        # Verify that naming an empty source allows a user to perform
+        # mismatched merges (i.e. merge sparc debug/non-debug with i386
+        # and arm non-debug) if empty repositories are used to fill in
+        # the missing cases.
+        nlist = {}
+        for s in self.published + self.published_debug[:6]:
+            f = fmri.PkgFmri(s)
+            if f.pkg_name not in nlist or f.version > nlist[f.pkg_name].version:
+                nlist[f.pkg_name] = f
+        nlist = sorted(nlist.values())
 
-                self.create_repo(repodir)
-                self.pkgmerge(" ".join([
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[1].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[2].get_repodir()),
-                    "-s arch=arm,debug=false,{0}".format(self.dcs[3].get_repodir()),
-                    "-s arch=sparc,debug=true,{0}".format(self.dcs[4].get_repodir()),
+        self.create_repo(repodir)
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[1].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[2].get_repodir()
+                    ),
+                    "-s arch=arm,debug=false,{0}".format(
+                        self.dcs[3].get_repodir()
+                    ),
+                    "-s arch=sparc,debug=true,{0}".format(
+                        self.dcs[4].get_repodir()
+                    ),
                     # Explicitly state debug packages don't exist for these
                     # arch values by using an empty repository.
-                    "-s arch=i386,debug=true,{0}".format(self.dcs[7].get_repodir()),
-                    "-s arch=arm,debug=true,{0}".format(self.dcs[7].get_repodir()),
-                    "-d {0}".format(repodir)
-                ]))
+                    "-s arch=i386,debug=true,{0}".format(
+                        self.dcs[7].get_repodir()
+                    ),
+                    "-s arch=arm,debug=true,{0}".format(
+                        self.dcs[7].get_repodir()
+                    ),
+                    "-d {0}".format(repodir),
+                ]
+            )
+        )
 
-                # Verify that each package was merged correctly.
-                merged_expected = {
-                    "amber": """\
+        # Verify that each package was merged correctly.
+        merged_expected = {
+            "amber": """\
 depend fmri=pkg:/tree@1.0 type=require
 set name=pkg.fmri value={0}
 set name=variant.arch value=i386 value=arm value=sparc
 set name=variant.debug value=false value=true variant.arch=sparc
 set name=variant.debug value=false variant.arch=arm
 set name=variant.debug value=false variant.arch=i386\
-""".format(self.published_debug[1]), # pkg://os.org/amber@2.0-0
-                    "bronze": """\
+""".format(
+                self.published_debug[1]
+            ),  # pkg://os.org/amber@2.0-0
+            "bronze": """\
 depend fmri=pkg:/amber@2.0 type=require
 depend fmri=pkg:/scheme@1.0 type=require variant.arch=arm
 depend fmri=pkg:/scheme@1.0 type=require variant.arch=i386
@@ -1060,15 +1293,19 @@ set name=variant.arch value=i386 value=arm value=sparc
 set name=variant.debug value=false value=true variant.arch=sparc
 set name=variant.debug value=false variant.arch=arm
 set name=variant.debug value=false variant.arch=i386\
-""".format(self.published_debug[3]), # pkg://os.org/bronze@2.0-0
-                    "scheme": """\
+""".format(
+                self.published_debug[3]
+            ),  # pkg://os.org/bronze@2.0-0
+            "scheme": """\
 file 3a06aa547ffe0186a2b9db55b8853874a048fb47 chash=ab50364de4ce8f847d765d402d80e37431e1f0aa group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:e1152d631b4c2fda4a2b739d38e4cbc3e8d7ccf2aa5be2aef6ab776a60d5a187 pkg.content-hash=gzip:sha512t_256:bfdce1dc4ab94f2321f2bae46505dd204b2df323df55efadf4f3b4c3326b204d pkg.csize=40 pkg.size=20 variant.debug=true
 file 3b7cee8797632f83a11b66d028016946b4fa47fa chash=00621927edeb8e5b96ef63a93b4c5d125f2a3298 group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:6650b24e5c5ceab211c95614def1ae53905a8f415f7fcfdfcc40b778041ed974 pkg.content-hash=gzip:sha512t_256:079a76079a1c22c13f3c2bb4b6efe8b589c1061b48e893c597c74adb62cac195 pkg.csize=34 pkg.size=14 variant.debug=false
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc
 set name=variant.debug value=false value=true\
-""".format(self.published_debug[5]), # pkg://os.org/scheme@1.0-0
-                    "tree": """\
+""".format(
+                self.published_debug[5]
+            ),  # pkg://os.org/scheme@1.0-0
+            "tree": """\
 file 3a06aa547ffe0186a2b9db55b8853874a048fb47 chash=ab50364de4ce8f847d765d402d80e37431e1f0aa group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:e1152d631b4c2fda4a2b739d38e4cbc3e8d7ccf2aa5be2aef6ab776a60d5a187 pkg.content-hash=gzip:sha512t_256:bfdce1dc4ab94f2321f2bae46505dd204b2df323df55efadf4f3b4c3326b204d pkg.csize=40 pkg.size=20 variant.arch=sparc variant.debug=true
 file 3b7cee8797632f83a11b66d028016946b4fa47fa chash=00621927edeb8e5b96ef63a93b4c5d125f2a3298 group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:6650b24e5c5ceab211c95614def1ae53905a8f415f7fcfdfcc40b778041ed974 pkg.content-hash=gzip:sha512t_256:079a76079a1c22c13f3c2bb4b6efe8b589c1061b48e893c597c74adb62cac195 pkg.csize=34 pkg.size=14 variant.arch=arm
 file 3b7cee8797632f83a11b66d028016946b4fa47fa chash=00621927edeb8e5b96ef63a93b4c5d125f2a3298 group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:6650b24e5c5ceab211c95614def1ae53905a8f415f7fcfdfcc40b778041ed974 pkg.content-hash=gzip:sha512t_256:079a76079a1c22c13f3c2bb4b6efe8b589c1061b48e893c597c74adb62cac195 pkg.csize=34 pkg.size=14 variant.arch=sparc variant.debug=false
@@ -1076,79 +1313,105 @@ set name=pkg.fmri value={0}
 set name=variant.arch value=arm value=sparc
 set name=variant.debug value=false value=true variant.arch=sparc
 set name=variant.debug value=false variant.arch=arm\
-""".format(self.published_debug[4]), # pkg://os.org/tree@1.0-0
-               }
+""".format(
+                self.published_debug[4]
+            ),  # pkg://os.org/tree@1.0-0
+        }
 
-                repo = self.get_repo(repodir)
-                for f in nlist:
-                        with open(repo.manifest(f), "r") as m:
-                                actual = "".join(sorted(l for l in m)).strip()
-                        expected = merged_expected[f.pkg_name]
-                        self.assertEqualDiff(expected, actual)
+        repo = self.get_repo(repodir)
+        for f in nlist:
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+            expected = merged_expected[f.pkg_name]
+            self.assertEqualDiff(expected, actual)
 
-                # Cleanup.
-                shutil.rmtree(repodir)
+        # Cleanup.
+        shutil.rmtree(repodir)
 
-        def test_4_blend(self):
-                """Make sure simple blending works"""
+    def test_4_blend(self):
+        """Make sure simple blending works"""
 
-                # Create the target repository.
-                repodir = os.path.join(self.test_root, "4merge_repo")
-                self.create_repo(repodir)
+        # Create the target repository.
+        repodir = os.path.join(self.test_root, "4merge_repo")
+        self.create_repo(repodir)
 
-                # Merge the silver packages.
-                self.pkgmerge(" ".join([
+        # Merge the silver packages.
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=sparc,{0}".format(self.rurl8),
                     "-s arch=i386,{0}".format(self.rurl9),
-                    "-d {0} silver".format(repodir)
-                ]))
+                    "-d {0} silver".format(repodir),
+                ]
+            )
+        )
 
-                # get target repo
-                repo = self.get_repo(repodir)
-                cat = repo.get_catalog(pub="os.org")
-                expected = """\
+        # get target repo
+        repo = self.get_repo(repodir)
+        cat = repo.get_catalog(pub="os.org")
+        expected = """\
 file 1abe1a7084720f501912eceb1312ddd799fb2a34 chash=ea7230676e13986491d7405c5a9298e074930575 group=bin mode=0444 owner=root path=etc/bronze1 pkg.content-hash=file:sha512t_256:f0316c9af93368a37c837317681af5d6ac5d8fa4feab284cd952906a1689d203 pkg.content-hash=gzip:sha512t_256:012f554bf1011be581f891682a7c406156bfef7be6ad6f785db586caf3a50f48 pkg.csize=37 pkg.size=17 variant.arch=sparc
 file 1abe1a7084720f501912eceb1312ddd799fb2a34 chash=ea7230676e13986491d7405c5a9298e074930575 group=bin mode=0555 owner=root path=etc/bronze1 pkg.content-hash=file:sha512t_256:f0316c9af93368a37c837317681af5d6ac5d8fa4feab284cd952906a1689d203 pkg.content-hash=gzip:sha512t_256:012f554bf1011be581f891682a7c406156bfef7be6ad6f785db586caf3a50f48 pkg.csize=37 pkg.size=17 variant.arch=i386
 file 34f88965d55d3a730fa7683bc0f370fc6e42bf95 chash=66eebb69ee0299dcb495162336db81a3188de037 group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:23589d1dbb98cc597ed74ed10e38afed113e73c30ed6dcfd98971541477f1167 pkg.content-hash=gzip:sha512t_256:5446e3eab72747cfe5e2b01fb0936a626693088d5e214dbe7af20823d76a61fb pkg.csize=32 pkg.size=12
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386\
-""".format(self.published_blend[2])
+""".format(
+            self.published_blend[2]
+        )
 
-                for f in cat.fmris():
-                        with open(repo.manifest(f), "r") as m:
-                                actual = "".join(sorted(l for l in m)).strip()
-                self.assertEqualDiff(expected, actual)
-                shutil.rmtree(repodir)
+        for f in cat.fmris():
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+        self.assertEqualDiff(expected, actual)
+        shutil.rmtree(repodir)
 
-        def test_5_blend(self):
-                """test duplicate action detection during blending"""
-                repodir = os.path.join(self.test_root, "5merge_repo")
-                self.create_repo(repodir)
+    def test_5_blend(self):
+        """test duplicate action detection during blending"""
+        repodir = os.path.join(self.test_root, "5merge_repo")
+        self.create_repo(repodir)
 
-               # Merge the tin packages - whoops
-                self.pkgmerge(" ".join([
+        # Merge the tin packages - whoops
+        self.pkgmerge(
+            " ".join(
+                [
                     "-s arch=sparc,{0}".format(self.rurl8),
                     "-s arch=i386,{0}".format(self.rurl9),
-                    "-d {0} tin".format(repodir)
-                ]), exit=1)
-                self.assertTrue("pkgmerge: Duplicate action(s):" in self.errout)
-                shutil.rmtree(repodir)
+                    "-d {0} tin".format(repodir),
+                ]
+            ),
+            exit=1,
+        )
+        self.assertTrue("pkgmerge: Duplicate action(s):" in self.errout)
+        shutil.rmtree(repodir)
 
-        def test_6_blend(self):
-                """check complex blending"""
-                repodir = os.path.join(self.test_root, "6merge_repo")
-                self.create_repo(repodir)
+    def test_6_blend(self):
+        """check complex blending"""
+        repodir = os.path.join(self.test_root, "6merge_repo")
+        self.create_repo(repodir)
 
-                # merge the multi packages
-                self.pkgmerge(" ".join([
-                    "-s arch=sparc,debug=true,{0}".format(self.dcs[10].get_repodir()),
-                    "-s arch=i386,debug=true,{0}".format(self.dcs[12].get_repodir()),
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[11].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[13].get_repodir()),
-                    "-d {0}".format(repodir)]))
+        # merge the multi packages
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=sparc,debug=true,{0}".format(
+                        self.dcs[10].get_repodir()
+                    ),
+                    "-s arch=i386,debug=true,{0}".format(
+                        self.dcs[12].get_repodir()
+                    ),
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[11].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[13].get_repodir()
+                    ),
+                    "-d {0}".format(repodir),
+                ]
+            )
+        )
 
-                actual = self.get_manifest(repodir)
-                expected = """\
+        actual = self.get_manifest(repodir)
+        expected = """\
 depend fmri=foo fmri=bar type=require-any
 file 24bb3b46361cf7d180d0227beea4f75a872b6ff4 chash=b91fb7bdd4d35779bbd70c6b0367198e48290373 group=bin mode=0444 owner=root path=etc/nondebug-notes pkg.content-hash=file:sha512t_256:d34e775f60268293b5eb36a2a803cc0826c170259153859aefdd1abaa823b706 pkg.content-hash=gzip:sha512t_256:8a3f3142777f861779784a776036b3baf90fde79d12378913a5078977c81a84b pkg.csize=35 pkg.size=15 variant.debug=false
 file 3a06aa547ffe0186a2b9db55b8853874a048fb47 chash=ab50364de4ce8f847d765d402d80e37431e1f0aa group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:e1152d631b4c2fda4a2b739d38e4cbc3e8d7ccf2aa5be2aef6ab776a60d5a187 pkg.content-hash=gzip:sha512t_256:bfdce1dc4ab94f2321f2bae46505dd204b2df323df55efadf4f3b4c3326b204d pkg.csize=40 pkg.size=20 variant.arch=sparc variant.debug=true
@@ -1162,85 +1425,121 @@ file aab699c6424ed1fc258b6b39eb113e624a9ee368 chash=43c3b9a83a112727264390002c3d
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386
 set name=variant.debug value=true value=false\
-""".format(self.published_blend[-1])
-                self.assertEqualDiff(expected, actual)
-                shutil.rmtree(repodir)
+""".format(
+            self.published_blend[-1]
+        )
+        self.assertEqualDiff(expected, actual)
+        shutil.rmtree(repodir)
 
-        def test_7_multipub_merge(self):
-                """Tests that we can merge packages from repositories with
-                several publishers."""
+    def test_7_multipub_merge(self):
+        """Tests that we can merge packages from repositories with
+        several publishers."""
 
-                repodir = os.path.join(self.test_root, "7merge_repo")
-                self.create_repo(repodir)
+        repodir = os.path.join(self.test_root, "7merge_repo")
+        self.create_repo(repodir)
 
-                # test dry run
-                self.pkgmerge(" ".join([
+        # test dry run
+        self.pkgmerge(
+            " ".join(
+                [
                     "-n",
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[14].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[15].get_repodir()),
-                    "-d {0}".format(repodir)]))
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[14].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[15].get_repodir()
+                    ),
+                    "-d {0}".format(repodir),
+                ]
+            )
+        )
 
-                # test dry run with selected publishers
-                self.pkgmerge(" ".join([
+        # test dry run with selected publishers
+        self.pkgmerge(
+            " ".join(
+                [
                     "-p os.org",
                     "-p altpub",
                     "-n",
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[14].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[15].get_repodir()),
-                    "-d {0}".format(repodir)]))
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[14].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[15].get_repodir()
+                    ),
+                    "-d {0}".format(repodir),
+                ]
+            )
+        )
 
-                # this should fail, as no -p noodles publisher exists in any of
-                # the source repositories
-                self.pkgmerge(" ".join([
+        # this should fail, as no -p noodles publisher exists in any of
+        # the source repositories
+        self.pkgmerge(
+            " ".join(
+                [
                     "-p os.org",
                     "-p altpub",
                     "-p noodles",
                     "-n",
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[14].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[15].get_repodir()),
-                    "-d {0}".format(repodir)]), exit=1)
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[14].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[15].get_repodir()
+                    ),
+                    "-d {0}".format(repodir),
+                ]
+            ),
+            exit=1,
+        )
 
-                # now we want to perform the merge operations and validate the
-                # results. This was the order we published packages to multi_15
-                # 0  = pkg://os.org/scheme@1.0,5.11-0:20120920T085857Z
-                # 1  = pkg://os.org/tree@1.0,5.11-0:20120920T085859Z
-                # 2  = pkg://altpub/bronze@2.0,5.11-0:20120920T085902Z
-                # 3  = pkg://altpub/amber@1.0,5.11-0:20120920T085904Z
-                # 4  = pkg://last/gold@1.0,5.11-0:20120920T085906Z
-                # 5  = pkg://altpub/bronze@2.0,5.11-0:20120920T085920Z
-                # 6  = pkg://last/gold@1.0,5.11-0:20120920T085923Z
+        # now we want to perform the merge operations and validate the
+        # results. This was the order we published packages to multi_15
+        # 0  = pkg://os.org/scheme@1.0,5.11-0:20120920T085857Z
+        # 1  = pkg://os.org/tree@1.0,5.11-0:20120920T085859Z
+        # 2  = pkg://altpub/bronze@2.0,5.11-0:20120920T085902Z
+        # 3  = pkg://altpub/amber@1.0,5.11-0:20120920T085904Z
+        # 4  = pkg://last/gold@1.0,5.11-0:20120920T085906Z
+        # 5  = pkg://altpub/bronze@2.0,5.11-0:20120920T085920Z
+        # 6  = pkg://last/gold@1.0,5.11-0:20120920T085923Z
 
-                # build a dictionary of the FMRIs we're interested in
-                repo15_fmris = {
-                    "osorg_scheme": self.published_multi_15[0],
-                    "osorg_tree": self.published_multi_15[1],
-                    "altpub_amber": self.published_multi_15[3],
-                    # we published two versions of bronze and gold, use the
-                    # latest FMRI
-                    "altpub_bronze": self.published_multi_15[5],
-                    "last_gold": self.published_multi_15[6]
-                }
+        # build a dictionary of the FMRIs we're interested in
+        repo15_fmris = {
+            "osorg_scheme": self.published_multi_15[0],
+            "osorg_tree": self.published_multi_15[1],
+            "altpub_amber": self.published_multi_15[3],
+            # we published two versions of bronze and gold, use the
+            # latest FMRI
+            "altpub_bronze": self.published_multi_15[5],
+            "last_gold": self.published_multi_15[6],
+        }
 
-                # the some expected manifests we should get after merging.
-                expected_osorg_scheme = """\
+        # the some expected manifests we should get after merging.
+        expected_osorg_scheme = """\
 file 3a06aa547ffe0186a2b9db55b8853874a048fb47 chash=ab50364de4ce8f847d765d402d80e37431e1f0aa group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:e1152d631b4c2fda4a2b739d38e4cbc3e8d7ccf2aa5be2aef6ab776a60d5a187 pkg.content-hash=gzip:sha512t_256:bfdce1dc4ab94f2321f2bae46505dd204b2df323df55efadf4f3b4c3326b204d pkg.csize=40 pkg.size=20
 set name=pkg.fmri value={osorg_scheme}
 set name=variant.arch value=sparc value=i386
 set name=variant.debug value=false\
-""".format(**repo15_fmris)
-                expected_osorg_tree = """\
+""".format(
+            **repo15_fmris
+        )
+        expected_osorg_tree = """\
 file 3a06aa547ffe0186a2b9db55b8853874a048fb47 chash=ab50364de4ce8f847d765d402d80e37431e1f0aa group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:e1152d631b4c2fda4a2b739d38e4cbc3e8d7ccf2aa5be2aef6ab776a60d5a187 pkg.content-hash=gzip:sha512t_256:bfdce1dc4ab94f2321f2bae46505dd204b2df323df55efadf4f3b4c3326b204d pkg.csize=40 pkg.size=20
 set name=pkg.fmri value={osorg_tree}
 set name=variant.arch value=sparc value=i386
 set name=variant.debug value=false\
-""".format(**repo15_fmris)
-                expected_altpub_amber = """\
+""".format(
+            **repo15_fmris
+        )
+        expected_altpub_amber = """\
 depend fmri=pkg:/tree@1.0 type=require
 set name=pkg.fmri value={altpub_amber}
 set name=variant.arch value=sparc value=i386
 set name=variant.debug value=false\
-""".format(**repo15_fmris)
-                expected_altpub_bronze = """\
+""".format(
+            **repo15_fmris
+        )
+        expected_altpub_bronze = """\
 depend fmri=pkg:/amber@2.0 type=require
 depend fmri=pkg:/scheme@1.0 type=require variant.arch=i386
 dir group=bin mode=0755 owner=root path=etc
@@ -1257,8 +1556,10 @@ link path=usr/bin/jsh target=./sh
 set name=pkg.fmri value={altpub_bronze}
 set name=variant.arch value=sparc value=i386
 set name=variant.debug value=false\
-""".format(**repo15_fmris)
-                expected_last_gold = """\
+""".format(
+            **repo15_fmris
+        )
+        expected_last_gold = """\
 depend fmri=foo fmri=bar type=require-any
 file 3a06aa547ffe0186a2b9db55b8853874a048fb47 chash=ab50364de4ce8f847d765d402d80e37431e1f0aa group=bin mode=0444 owner=root path=etc/tree pkg.content-hash=file:sha512t_256:e1152d631b4c2fda4a2b739d38e4cbc3e8d7ccf2aa5be2aef6ab776a60d5a187 pkg.content-hash=gzip:sha512t_256:bfdce1dc4ab94f2321f2bae46505dd204b2df323df55efadf4f3b4c3326b204d pkg.csize=40 pkg.size=20 variant.arch=sparc
 file 6b7161cb29262ea4924a8874818da189bb70da09 chash=77e271370cec04931346c969a85d6af37c1ea83f group=bin mode=0444 owner=root path=etc/binary pkg.content-hash=file:sha512t_256:4bf36eb94a392e1b7c664835a979179050f678e34b6dc99a0136cd5ee97bc810 pkg.content-hash=gzip:sha512t_256:035274037f7db947b55535ff16137d9f91e2692cf425bdf080d79bef2fba78af pkg.csize=36 pkg.size=16 variant.arch=i386
@@ -1269,120 +1570,169 @@ file aab699c6424ed1fc258b6b39eb113e624a9ee368 chash=43c3b9a83a112727264390002c3d
 set name=pkg.fmri value={last_gold}
 set name=variant.arch value=sparc value=i386
 set name=variant.debug value=false\
-""".format(**repo15_fmris)
+""".format(
+            **repo15_fmris
+        )
 
-                # A dictionary of the expected package contents, keyed by FMRI
-                expected = {
-                    repo15_fmris["altpub_bronze"]: expected_altpub_bronze,
-                    repo15_fmris["altpub_amber"]: expected_altpub_amber,
-                    repo15_fmris["osorg_tree"]: expected_osorg_tree,
-                    repo15_fmris["osorg_scheme"]: expected_osorg_scheme,
-                    repo15_fmris["last_gold"]: expected_last_gold
-                }
+        # A dictionary of the expected package contents, keyed by FMRI
+        expected = {
+            repo15_fmris["altpub_bronze"]: expected_altpub_bronze,
+            repo15_fmris["altpub_amber"]: expected_altpub_amber,
+            repo15_fmris["osorg_tree"]: expected_osorg_tree,
+            repo15_fmris["osorg_scheme"]: expected_osorg_scheme,
+            repo15_fmris["last_gold"]: expected_last_gold,
+        }
 
-                def check_repo(repodir, keys, fmri_dic, expected):
-                        """Check that packages corresponding to the list of
-                        keys 'keys' to items in 'fmri_dic' are present in the
-                        repository, and match the contents from the dictionary
-                        'expected'.  We also check that the repository has no
-                        packages other than those specified by 'keys', and no
-                        more publishers than are present in those packages."""
-                        sr = self.get_repo(repodir)
-                        # check that the packages from 'keys' exist,
-                        # and their content matches what we expect.
-                        for key in keys:
-                                f = fmri_dic[key]
-                                with open(sr.manifest(f), "r") as manf:
-                                        actual = "".join(
-                                            sorted(l for l in manf)).strip()
-                                self.assertEqualDiff(expected[f], actual)
+        def check_repo(repodir, keys, fmri_dic, expected):
+            """Check that packages corresponding to the list of
+            keys 'keys' to items in 'fmri_dic' are present in the
+            repository, and match the contents from the dictionary
+            'expected'.  We also check that the repository has no
+            packages other than those specified by 'keys', and no
+            more publishers than are present in those packages."""
+            sr = self.get_repo(repodir)
+            # check that the packages from 'keys' exist,
+            # and their content matches what we expect.
+            for key in keys:
+                f = fmri_dic[key]
+                with open(sr.manifest(f), "r") as manf:
+                    actual = "".join(sorted(l for l in manf)).strip()
+                self.assertEqualDiff(expected[f], actual)
 
-                        # check that we have only the publishers used
-                        # by packages from 'keys' in the repository
-                        fmris = [fmri_dic[key] for key in keys]
-                        pubs = set([fmri.PkgFmri(entry).get_publisher()
-                            for entry in fmris])
-                        known_pubs = set(
-                            [p.prefix for p in sr.get_publishers()])
-                        self.assertTrue(pubs == known_pubs,
-                            "Repository at {0} didn't contain the "
-                            "expected set of publishers")
+            # check that we have only the publishers used
+            # by packages from 'keys' in the repository
+            fmris = [fmri_dic[key] for key in keys]
+            pubs = set([fmri.PkgFmri(entry).get_publisher() for entry in fmris])
+            known_pubs = set([p.prefix for p in sr.get_publishers()])
+            self.assertTrue(
+                pubs == known_pubs,
+                "Repository at {0} didn't contain the "
+                "expected set of publishers",
+            )
 
-                        # check that we have only the packages defined
-                        # in 'keys' in the repository by walking all
-                        # publishers, and all packages in the repository
-                        for pub in sr.get_publishers():
-                                cat = sr.get_catalog(pub=pub.prefix)
-                                for f in cat.fmris():
-                                        if f.get_fmri() not in fmris:
-                                                self.assertTrue(False,
-                                                    "{0} not in repository".format(f))
+            # check that we have only the packages defined
+            # in 'keys' in the repository by walking all
+            # publishers, and all packages in the repository
+            for pub in sr.get_publishers():
+                cat = sr.get_catalog(pub=pub.prefix)
+                for f in cat.fmris():
+                    if f.get_fmri() not in fmris:
+                        self.assertTrue(
+                            False, "{0} not in repository".format(f)
+                        )
 
-                # test merging all publishers.
-                self.pkgmerge(" ".join([
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[14].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[15].get_repodir()),
-                    "-d {0}".format(repodir)]))
+        # test merging all publishers.
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[14].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[15].get_repodir()
+                    ),
+                    "-d {0}".format(repodir),
+                ]
+            )
+        )
 
-                check_repo(repodir, repo15_fmris.keys(), repo15_fmris, expected)
+        check_repo(repodir, repo15_fmris.keys(), repo15_fmris, expected)
 
-                # test merging only altpub and os.org.
-                shutil.rmtree(repodir)
-                self.create_repo(repodir)
-                self.pkgmerge(" ".join([
+        # test merging only altpub and os.org.
+        shutil.rmtree(repodir)
+        self.create_repo(repodir)
+        self.pkgmerge(
+            " ".join(
+                [
                     "-p altpub",
                     "-p os.org",
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[14].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[15].get_repodir()),
-                    "-d {0}".format(repodir)]))
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[14].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[15].get_repodir()
+                    ),
+                    "-d {0}".format(repodir),
+                ]
+            )
+        )
 
-                check_repo(repodir, ["altpub_bronze", "altpub_amber",
-                    "osorg_tree", "osorg_scheme"], repo15_fmris, expected)
+        check_repo(
+            repodir,
+            ["altpub_bronze", "altpub_amber", "osorg_tree", "osorg_scheme"],
+            repo15_fmris,
+            expected,
+        )
 
-                # test merging only altpub
-                shutil.rmtree(repodir)
-                self.create_repo(repodir)
-                self.pkgmerge(" ".join([
+        # test merging only altpub
+        shutil.rmtree(repodir)
+        self.create_repo(repodir)
+        self.pkgmerge(
+            " ".join(
+                [
                     "-p altpub",
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[14].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[15].get_repodir()),
-                    "-d {0}".format(repodir)]))
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[14].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[15].get_repodir()
+                    ),
+                    "-d {0}".format(repodir),
+                ]
+            )
+        )
 
-                check_repo(repodir, ["altpub_bronze", "altpub_amber"],
-                    repo15_fmris, expected)
+        check_repo(
+            repodir, ["altpub_bronze", "altpub_amber"], repo15_fmris, expected
+        )
 
-                # this should exit with a 1, but we should get the same results
-                # in the repository as last time.
-                shutil.rmtree(repodir)
-                self.create_repo(repodir)
-                self.pkgmerge(" ".join([
+        # this should exit with a 1, but we should get the same results
+        # in the repository as last time.
+        shutil.rmtree(repodir)
+        self.create_repo(repodir)
+        self.pkgmerge(
+            " ".join(
+                [
                     "-p altpub",
                     "-p noodles",
-                    "-s arch=sparc,debug=false,{0}".format(self.dcs[14].get_repodir()),
-                    "-s arch=i386,debug=false,{0}".format(self.dcs[15].get_repodir()),
-                    "-d {0}".format(repodir)]), exit=1)
+                    "-s arch=sparc,debug=false,{0}".format(
+                        self.dcs[14].get_repodir()
+                    ),
+                    "-s arch=i386,debug=false,{0}".format(
+                        self.dcs[15].get_repodir()
+                    ),
+                    "-d {0}".format(repodir),
+                ]
+            ),
+            exit=1,
+        )
 
-                check_repo(repodir, ["altpub_bronze", "altpub_amber"],
-                    repo15_fmris, expected)
+        check_repo(
+            repodir, ["altpub_bronze", "altpub_amber"], repo15_fmris, expected
+        )
 
-        def test_8_mediators(self):
-                """test to make sure mediator-mediated links are not detected as collisions
-                in the same package or the merged package"""
-                # Create the target repository.
-                repodir = os.path.join(self.test_root, "8mediator_repo")
-                self.create_repo(repodir)
+    def test_8_mediators(self):
+        """test to make sure mediator-mediated links are not detected as collisions
+        in the same package or the merged package"""
+        # Create the target repository.
+        repodir = os.path.join(self.test_root, "8mediator_repo")
+        self.create_repo(repodir)
 
-                # Merge the two packages.
-                self.pkgmerge(" ".join([
-                        "-s arch=PPC,{0}".format(self.rurl16),
-                        "-s arch=ARM,{0}".format(self.rurl17),
-                    "-d {0} mediator".format(repodir)
-                ]))
+        # Merge the two packages.
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=PPC,{0}".format(self.rurl16),
+                    "-s arch=ARM,{0}".format(self.rurl17),
+                    "-d {0} mediator".format(repodir),
+                ]
+            )
+        )
 
-                # get target repo
-                repo = self.get_repo(repodir)
-                cat = repo.get_catalog(pub="os.org")
-                expected = """\
+        # get target repo
+        repo = self.get_repo(repodir)
+        cat = repo.get_catalog(pub="os.org")
+        expected = """\
 link mediator=color mediator-implementation=blue path=wombat target=blue
 link mediator=color mediator-implementation=green path=wombat target=green
 link mediator=color mediator-implementation=mauve path=wombat target=mauve
@@ -1401,109 +1751,133 @@ link mediator=version mediator-version=7 path=aardvark target=7
 link mediator=version mediator-version=8 path=aardvark target=8
 set name=pkg.fmri value={0}
 set name=variant.arch value=PPC value=ARM\
-""".format(self.published_17[0])
+""".format(
+            self.published_17[0]
+        )
 
-                for f in cat.fmris():
-                        with open(repo.manifest(f), "r") as m:
-                                actual = "".join(sorted(l for l in m)).strip()
-                self.assertEqualDiff(expected, actual)
-                shutil.rmtree(repodir)
+        for f in cat.fmris():
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+        self.assertEqualDiff(expected, actual)
+        shutil.rmtree(repodir)
 
+    def test_9_dependency(self):
+        """Test dependency actions duplication detection."""
+        repodir = os.path.join(self.test_root, "9dependency")
+        self.create_repo(repodir)
 
-        def test_9_dependency(self):
-             """Test dependency actions duplication detection. 
-             """
-             repodir = os.path.join(self.test_root, "9dependency")
-             self.create_repo(repodir)
+        # Test that conditional dependency with different
+        # predicates do not fail.
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=sparc,{0}".format(self.rurl18),
+                    "-s arch=i386,{0}".format(self.rurl19),
+                    "-d {0} dependcond1".format(repodir),
+                ]
+            )
+        )
 
-             # Test that conditional dependency with different
-             # predicates do not fail.
-             self.pkgmerge(" ".join([
-                     "-s arch=sparc,{0}".format(self.rurl18),
-                     "-s arch=i386,{0}".format(self.rurl19),
-                     "-d {0} dependcond1".format(repodir)
-             ]))
+        # The same dependencies will be collapsed
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=sparc,{0}".format(self.rurl18),
+                    "-s arch=i386,{0}".format(self.rurl19),
+                    "-d {0} dependcond2".format(repodir),
+                ]
+            )
+        )
 
-             # The same dependencies will be collapsed
-             self.pkgmerge(" ".join([
-                     "-s arch=sparc,{0}".format(self.rurl18),
-                     "-s arch=i386,{0}".format(self.rurl19),
-                     "-d {0} dependcond2".format(repodir)
-             ]))
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=sparc,{0}".format(self.rurl18),
+                    "-s arch=i386,{0}".format(self.rurl19),
+                    "-d {0} dependreq".format(repodir),
+                ]
+            )
+        )
 
-             self.pkgmerge(" ".join([
-                     "-s arch=sparc,{0}".format(self.rurl18),
-                     "-s arch=i386,{0}".format(self.rurl19),
-                     "-d {0} dependreq".format(repodir)
-             ]))
+        self.pkgmerge(
+            " ".join(
+                [
+                    "-s arch=sparc,{0}".format(self.rurl18),
+                    "-s arch=i386,{0}".format(self.rurl19),
+                    "-d {0} dependreqany".format(repodir),
+                ]
+            )
+        )
 
-             self.pkgmerge(" ".join([
-                     "-s arch=sparc,{0}".format(self.rurl18),
-                     "-s arch=i386,{0}".format(self.rurl19),
-                     "-d {0} dependreqany".format(repodir)
-             ]))
+        repo = self.get_repo(repodir)
+        cat = repo.get_catalog(pub="os.org")
 
-             repo = self.get_repo(repodir)
-             cat = repo.get_catalog(pub="os.org")
-
-             merged_expected = {
-                "dependcond1": """\
+        merged_expected = {
+            "dependcond1": """\
 depend fmri=appdep@1.0 predicate=app-2 type=conditional
 depend fmri=appdep@1.0 predicate=app-3 type=conditional
 dir group=bin mode=755 owner=root path=opt/dir/amd64 variant.arch=i386
 dir group=bin mode=755 owner=root path=opt/dir/sparc variant.arch=sparc
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386\
-""".format(self.published_depx[0]), # pkg://os.org/dependcond1@1.0
-                "dependcond2": """\
+""".format(
+                self.published_depx[0]
+            ),  # pkg://os.org/dependcond1@1.0
+            "dependcond2": """\
 depend fmri=appdep@1.0 predicate=app-2 type=conditional
 dir group=bin mode=755 owner=root path=opt/dir/amd64 variant.arch=i386
 dir group=bin mode=755 owner=root path=opt/dir/sparc variant.arch=sparc
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386\
-""".format(self.published_depx[1]), # pkg://os.org/dependcond2@1.0
-                "dependreq": """\
+""".format(
+                self.published_depx[1]
+            ),  # pkg://os.org/dependcond2@1.0
+            "dependreq": """\
 depend fmri=appdep@1.0 type=incorporate
 depend fmri=appdep@1.0 type=require
 dir group=bin mode=755 owner=root path=opt/dir/amd64 variant.arch=i386
 dir group=bin mode=755 owner=root path=opt/dir/sparc variant.arch=sparc
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386\
-""".format(self.published_depx[2]), # pkg://os.org/dependreq@1.0
-                "dependreqany": """\
+""".format(
+                self.published_depx[2]
+            ),  # pkg://os.org/dependreq@1.0
+            "dependreqany": """\
 depend fmri=appdep@1.0 fmri=appdep2@1.0 type=require-any
 depend fmri=appdep@1.0 fmri=appdep3@1.0 type=require-any
 dir group=bin mode=755 owner=root path=opt/dir/amd64 variant.arch=i386
 dir group=bin mode=755 owner=root path=opt/dir/sparc variant.arch=sparc
 set name=pkg.fmri value={0}
 set name=variant.arch value=sparc value=i386\
-""".format(self.published_depx[3]) # pkg://os.org/dependreqany@1.0
-                }
+""".format(
+                self.published_depx[3]
+            ),  # pkg://os.org/dependreqany@1.0
+        }
 
-             # Verify the merge has worked and that real
-             # duplicate dependencies have been merged
-             # correctly (dependcond2).
-             for f in cat.fmris():
-                     with open(repo.manifest(f), "r") as m:
-                             actual = "".join(sorted(l for l in m)).strip()
-                     expected = merged_expected[f.pkg_name]
-                     self.assertEqualDiff(expected, actual)
-             shutil.rmtree(repodir)
+        # Verify the merge has worked and that real
+        # duplicate dependencies have been merged
+        # correctly (dependcond2).
+        for f in cat.fmris():
+            with open(repo.manifest(f), "r") as m:
+                actual = "".join(sorted(l for l in m)).strip()
+            expected = merged_expected[f.pkg_name]
+            self.assertEqualDiff(expected, actual)
+        shutil.rmtree(repodir)
 
-        def get_manifest(self, repodir, pubs=["os.org"]):
-                repository = self.get_repo(repodir)
-                actual = ""
-                for pub in pubs:
-                        cat = repository.get_catalog(pub=pub)
-                        for f in cat.fmris():
-                                with open(repository.manifest(f), "r") as m:
-                                        actual += "".join(
-                                            sorted(l for l in m)).strip()
-                        actual += "\n"
-                return actual.strip()
+    def get_manifest(self, repodir, pubs=["os.org"]):
+        repository = self.get_repo(repodir)
+        actual = ""
+        for pub in pubs:
+            cat = repository.get_catalog(pub=pub)
+            for f in cat.fmris():
+                with open(repository.manifest(f), "r") as m:
+                    actual += "".join(sorted(l for l in m)).strip()
+            actual += "\n"
+        return actual.strip()
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgmogrify.py
+++ b/src/tests/cli/t_pkgmogrify.py
@@ -24,8 +24,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -39,12 +40,13 @@ import tempfile
 import unittest
 from pkg.misc import EmptyI
 
+
 class TestPkgMogrify(pkg5unittest.CliTestCase):
-        """Tests for the pkgmogrify publication tool."""
+    """Tests for the pkgmogrify publication tool."""
 
-        persistent_setup = True
+    persistent_setup = True
 
-        pkgcontents = """\
+    pkgcontents = """\
 # directories
 dir group=bin mode=0755 owner=root path=usr/X11
 dir group=bin mode=0755 owner=root path=usr/X11/bin
@@ -68,7 +70,7 @@ link path=usr/X11/lib/libXinerama.so target=./libXinerama.so.1
 link path=usr/X11/lib/libXmu.so target=./libXmu.so.4
 """
 
-        pkgcontents2 = """\
+    pkgcontents2 = """\
 set name=pkg.fmri value=wombat/heaven@1.0,5.11-0.101
 set name=bugs value=12345 value=54321 value=13524
 set name=justonebug value=12345
@@ -83,7 +85,7 @@ set name=pkg.summary value="Doo wah diddy"
 legacy pkg=SUNWwombat version=3
 """
 
-        pkgcontents3 = """\
+    pkgcontents3 = """\
 $(i386_ONLY)file NOHASH path=kernel/drv/x86_only1 reboot-needed=true
 $(i386_ONLY)file NOHASH path=kernel/drv/x86_only2 reboot-needed=true
 $(sparc_ONLY)file NOHASH path=kernel/drv/sparc_only1 reboot-needed=true
@@ -92,566 +94,652 @@ file NOHASH path=kernel/drv/common1 reboot-needed=true
 file NOHASH path=kernel/drv/common2 reboot-needed=true
 """
 
-        # Give names to simple transforms.  These transforms can use <include>
-        # by referring to the named transforms using the %()s construct.
-        transforms = {
-            "X11->Y11": "<transform file link dir -> edit path X11 Y11>",
-            "drop xkbprint": "<transform file path='.*xkbprint.*' -> drop>",
-            "X11mode": "<transform file path='usr/X11/bin/.*' -> set mode 0555>",
-            "drop mode=0755": "<transform file -> delete mode 0755> ",
-            "empty": "<transform file >",
-            "empty edit": "<transform file -> edit bar >",
-            "2include": "<include {X11->Y11}>\n<include {X11mode}>",
-            "include 9": "<include {include 5}>",
-            "include 5": "<include {empty}>",
-            "add bobcat": "<transform file -> add bobcat 1>",
-            "print ouch": '<transform file bobcat=1 -> print "ouch" >',
-            "abort on bobcat": "<transform file bobcat=1 -> abort >",
-            "exit7 on bobcat": "<transform file bobcat=1 -> exit 7>",
-            "exit6 on bobcat": "<transform file bobcat=1 -> exit 6 found a bobcat>",
-            "pkg.fmri": "<transform file path=usr/bin/foo -> print pkg attr \"%{{pkg.fmri}}\" and the rest>",
-            "pkg.bugs": "<transform file path=usr/bin/foo -> print pkg attr \"%{{bugs}}\" and the rest>",
-            "fmrival": "<transform set name=pkg.fmri -> print test of \"%(value)\" ... or is it?>",
-            "fmrinoval": "<transform set name=pkg.fmri -> print test of \"%(valuee)\" ... or is it?>",
-            "fmrisaved": "<transform set name=pkg.fmri -> print test of \"%(valuee;notfound=noprint)\" ... or is it?>",
-            "fmriqsaved": "<transform set name=pkg.fmri -> print test of \"%(valuee;notfound=\"got quotes\")\" ... or is it?>",
-            "fmrinotsaved": "<transform set name=pkg.fmri -> print test of \"%(value;notfound=noprint)\" ... or is it?>",
-            "list": "<transform set name=bugs -> print test of listval \"%(value)\">",
-            "listsep": "<transform set name=bugs -> print test of listval \"%(value;sep=\",\")\">",
-            "listsufpresep": "<transform set name=bugs -> print test of listval \"%(value;sep=\", \";prefix=\"bug='\";suffix=\"'\")\">",
-            "nolistsufpre": "<transform set name=justonebug -> print test of \"%(value;prefix=\"bug='\";suffix=\"'\")\">",
-            "emitblank": "<transform set name=pkg.fmri -> emit>",
-            "emitcomment": "<transform set name=pkg.fmri -> emit # comment>",
-            "emitaction": "<transform set name=pkg.fmri -> emit depend type=incorporate fmri=%(value)>",
-            "synthetic": "<transform file path=usr/bin/foo -> print %(pkg.manifest.filename) %(pkg.manifest.lineno)>",
-            "synthetic2": "<transform file path=usr/bin/foo -> print %(action.hash) %(action.key) %(action.name)>",
-            "synthetic3": "<transform file -> print %(action.hash)>",
-            "synthetic4": "<transform set -> print %(action.hash)>",
-            "synthetic5": "<transform set -> print %(action.hash;notfound=something)>",
-            "pkgmatch": "<transform pkg -> default $(MYATTR) false>",
-            "pkggen": "<transform pkg $(MYATTR)=false -> emit depend fmri=consolidation type=require>",
-            "recurse": "<transform file mode=0777 -> emit file path=usr/bin/bar mode=0777>",
-            "rbneeded": "<transform file reboot-needed=true -> emit set name=magic value=true>",
-            "brdefault": "<transform depend fmri=__TBD path=([^/]*)/([^/]*)/ mode=0(.)55 -> default pkg.debug.depend.path %<1>/%<2>>",
-            "brdefault2": "<transform depend fmri=__TBD mode=0(.)55 path=([^/]*)/([^/]*)/ -> default pkg.debug.depend.path %<2>/%<3>>",
-            "brdefault3": "<transform depend fmri=__TBD mode=0(.)55 path=([^/]*)/([^/]*)/ -> default pkg.debug.depend.path %<2>/%<4>>",
-            "brdefault3a": "<transform depend fmri=__TBD mode=0(.)55 path=([^/]*)/([^/]*)/ -> default pkg.debug.depend.path %<2>/%<0>>",
-            "brdefault4": "<transform file path=usr/share/locale/([^/]+).* -> default locale.%<1> true>",
-            "brweirdquote": "<transform file moo=(.*) path='\\'.*/([^/]*)\\'' -> default refs %<1>,%<2>>",
-            "bradd": "<transform file path=usr/share/locale/([^/]+).* -> add locale.%<1> true>",
-            "brset": "<transform file path=usr/share/locale/([^/]+).* -> set locale.%<1> true>",
-            "bredit": "<transform file path=usr/share/locale/([^/]+).* -> edit path .*/([^/]*\\.mo) another/place/for/locales/%<1>/\\\\1>",
-            "bredit2": "<transform file path=usr/share/locale/([^/]+).* -> edit path %<1> LANG>",
-            "edit1": "<transform file path=usr/(share|lib)/locale.* -> edit path usr/(lib|share)/locale place/\\\\1/langs>",
-            "doublequote": "<transform legacy -> default name %{{pkg.summary}}>",
-            "delete-with-no-operand": "<transform file -> delete >",
-            "backreference-no-object": "<transform file path=(local/)?usr/* -> default refs %<1>>",
-            "backreference-empty-string": "<transform file path=usr/bin/foo(.*)-> emit file path=usr/sbin/foo%<1>>"
-        }
-
-        basic_defines = {
-            "i386_ONLY": "#",
-            "BUILDID": 0.126
-        }
-
-        def setUp(self):
-                pkg5unittest.CliTestCase.setUp(self)
-
-                with open(os.path.join(self.test_root, "source_file"), "w") as f:
-                        f.write(self.pkgcontents)
-
-                with open(os.path.join(self.test_root, "source_file2"), "w") as f:
-                        f.write(self.pkgcontents2)
-
-                with open(os.path.join(self.test_root, "source_file3"), "w") as f:
-                        f.write(self.pkgcontents3)
-
-                # Map the transform names to path names
-                xformpaths = dict((
-                    (name, os.path.join(self.test_root, "transform_{0}".format(i)))
-                    for i, name in enumerate(six.iterkeys(self.transforms))
-                ))
-
-                # Now that we have path names, we can use the expandos in the
-                # transform contents to embed those pathnames, and write the
-                # transform files out.
-                for name, path in six.iteritems(xformpaths):
-                        with open(path, "w") as f:
-                                self.transforms[name] = self.transforms[name].format(**xformpaths)
-                                f.write(self.transforms[name])
-
-                self.transform_contents = self.transforms
-                self.transforms = xformpaths
-
-        def pkgmogrify(self, sources=EmptyI, defines=None,
-            output=None, args="", exit=0, stdin=None):
-                if defines is None:
-                        defines = self.basic_defines
-
-                defines = " ".join([
-                    "-D {0}={1}".format(k, v)
-                    for k, v in six.iteritems(defines)
-                ])
-
-                sources = " ".join(sources)
+    # Give names to simple transforms.  These transforms can use <include>
+    # by referring to the named transforms using the %()s construct.
+    transforms = {
+        "X11->Y11": "<transform file link dir -> edit path X11 Y11>",
+        "drop xkbprint": "<transform file path='.*xkbprint.*' -> drop>",
+        "X11mode": "<transform file path='usr/X11/bin/.*' -> set mode 0555>",
+        "drop mode=0755": "<transform file -> delete mode 0755> ",
+        "empty": "<transform file >",
+        "empty edit": "<transform file -> edit bar >",
+        "2include": "<include {X11->Y11}>\n<include {X11mode}>",
+        "include 9": "<include {include 5}>",
+        "include 5": "<include {empty}>",
+        "add bobcat": "<transform file -> add bobcat 1>",
+        "print ouch": '<transform file bobcat=1 -> print "ouch" >',
+        "abort on bobcat": "<transform file bobcat=1 -> abort >",
+        "exit7 on bobcat": "<transform file bobcat=1 -> exit 7>",
+        "exit6 on bobcat": "<transform file bobcat=1 -> exit 6 found a bobcat>",
+        "pkg.fmri": '<transform file path=usr/bin/foo -> print pkg attr "%{{pkg.fmri}}" and the rest>',
+        "pkg.bugs": '<transform file path=usr/bin/foo -> print pkg attr "%{{bugs}}" and the rest>',
+        "fmrival": '<transform set name=pkg.fmri -> print test of "%(value)" ... or is it?>',
+        "fmrinoval": '<transform set name=pkg.fmri -> print test of "%(valuee)" ... or is it?>',
+        "fmrisaved": '<transform set name=pkg.fmri -> print test of "%(valuee;notfound=noprint)" ... or is it?>',
+        "fmriqsaved": '<transform set name=pkg.fmri -> print test of "%(valuee;notfound="got quotes")" ... or is it?>',
+        "fmrinotsaved": '<transform set name=pkg.fmri -> print test of "%(value;notfound=noprint)" ... or is it?>',
+        "list": '<transform set name=bugs -> print test of listval "%(value)">',
+        "listsep": '<transform set name=bugs -> print test of listval "%(value;sep=",")">',
+        "listsufpresep": '<transform set name=bugs -> print test of listval "%(value;sep=", ";prefix="bug=\'";suffix="\'")">',
+        "nolistsufpre": '<transform set name=justonebug -> print test of "%(value;prefix="bug=\'";suffix="\'")">',
+        "emitblank": "<transform set name=pkg.fmri -> emit>",
+        "emitcomment": "<transform set name=pkg.fmri -> emit # comment>",
+        "emitaction": "<transform set name=pkg.fmri -> emit depend type=incorporate fmri=%(value)>",
+        "synthetic": "<transform file path=usr/bin/foo -> print %(pkg.manifest.filename) %(pkg.manifest.lineno)>",
+        "synthetic2": "<transform file path=usr/bin/foo -> print %(action.hash) %(action.key) %(action.name)>",
+        "synthetic3": "<transform file -> print %(action.hash)>",
+        "synthetic4": "<transform set -> print %(action.hash)>",
+        "synthetic5": "<transform set -> print %(action.hash;notfound=something)>",
+        "pkgmatch": "<transform pkg -> default $(MYATTR) false>",
+        "pkggen": "<transform pkg $(MYATTR)=false -> emit depend fmri=consolidation type=require>",
+        "recurse": "<transform file mode=0777 -> emit file path=usr/bin/bar mode=0777>",
+        "rbneeded": "<transform file reboot-needed=true -> emit set name=magic value=true>",
+        "brdefault": "<transform depend fmri=__TBD path=([^/]*)/([^/]*)/ mode=0(.)55 -> default pkg.debug.depend.path %<1>/%<2>>",
+        "brdefault2": "<transform depend fmri=__TBD mode=0(.)55 path=([^/]*)/([^/]*)/ -> default pkg.debug.depend.path %<2>/%<3>>",
+        "brdefault3": "<transform depend fmri=__TBD mode=0(.)55 path=([^/]*)/([^/]*)/ -> default pkg.debug.depend.path %<2>/%<4>>",
+        "brdefault3a": "<transform depend fmri=__TBD mode=0(.)55 path=([^/]*)/([^/]*)/ -> default pkg.debug.depend.path %<2>/%<0>>",
+        "brdefault4": "<transform file path=usr/share/locale/([^/]+).* -> default locale.%<1> true>",
+        "brweirdquote": "<transform file moo=(.*) path='\\'.*/([^/]*)\\'' -> default refs %<1>,%<2>>",
+        "bradd": "<transform file path=usr/share/locale/([^/]+).* -> add locale.%<1> true>",
+        "brset": "<transform file path=usr/share/locale/([^/]+).* -> set locale.%<1> true>",
+        "bredit": "<transform file path=usr/share/locale/([^/]+).* -> edit path .*/([^/]*\\.mo) another/place/for/locales/%<1>/\\\\1>",
+        "bredit2": "<transform file path=usr/share/locale/([^/]+).* -> edit path %<1> LANG>",
+        "edit1": "<transform file path=usr/(share|lib)/locale.* -> edit path usr/(lib|share)/locale place/\\\\1/langs>",
+        "doublequote": "<transform legacy -> default name %{{pkg.summary}}>",
+        "delete-with-no-operand": "<transform file -> delete >",
+        "backreference-no-object": "<transform file path=(local/)?usr/* -> default refs %<1>>",
+        "backreference-empty-string": "<transform file path=usr/bin/foo(.*)-> emit file path=usr/sbin/foo%<1>>",
+    }
+
+    basic_defines = {"i386_ONLY": "#", "BUILDID": 0.126}
+
+    def setUp(self):
+        pkg5unittest.CliTestCase.setUp(self)
+
+        with open(os.path.join(self.test_root, "source_file"), "w") as f:
+            f.write(self.pkgcontents)
+
+        with open(os.path.join(self.test_root, "source_file2"), "w") as f:
+            f.write(self.pkgcontents2)
+
+        with open(os.path.join(self.test_root, "source_file3"), "w") as f:
+            f.write(self.pkgcontents3)
+
+        # Map the transform names to path names
+        xformpaths = dict(
+            (
+                (name, os.path.join(self.test_root, "transform_{0}".format(i)))
+                for i, name in enumerate(six.iterkeys(self.transforms))
+            )
+        )
+
+        # Now that we have path names, we can use the expandos in the
+        # transform contents to embed those pathnames, and write the
+        # transform files out.
+        for name, path in six.iteritems(xformpaths):
+            with open(path, "w") as f:
+                self.transforms[name] = self.transforms[name].format(
+                    **xformpaths
+                )
+                f.write(self.transforms[name])
+
+        self.transform_contents = self.transforms
+        self.transforms = xformpaths
+
+    def pkgmogrify(
+        self,
+        sources=EmptyI,
+        defines=None,
+        output=None,
+        args="",
+        exit=0,
+        stdin=None,
+    ):
+        if defines is None:
+            defines = self.basic_defines
 
-                if output:
-                        args += " -O {0}".format(output)
+        defines = " ".join(
+            ["-D {0}={1}".format(k, v) for k, v in six.iteritems(defines)]
+        )
+
+        sources = " ".join(sources)
+
+        if output:
+            args += " -O {0}".format(output)
 
-                cmd = sys.executable + " {0}/usr/bin/pkgmogrify {1} {2} {3}".format(
-                    pkg5unittest.g_pkg_path, defines, args, sources)
+        cmd = sys.executable + " {0}/usr/bin/pkgmogrify {1} {2} {3}".format(
+            pkg5unittest.g_pkg_path, defines, args, sources
+        )
 
-                self.cmdline_run(cmd, stdin=stdin, exit=exit)
+        self.cmdline_run(cmd, stdin=stdin, exit=exit)
+
+    def __countMatches(self, regex, path=None):
+        """Count how many lines in the output of the previously run
+        command match the regular expression 'regex'.  If 'path' is
+        specified, the contents of that file are searched."""
+
+        if path is not None:
+            with open(path) as f:
+                output = f.read()
+        else:
+            output = self.output + self.errout
+
+        c = sum(
+            (int(bool(re.search(regex, line))) for line in output.splitlines())
+        )
+
+        return c
+
+    def assertMatch(self, regex, path=None, count=0):
+        """Assert that the regular expression 'regex' matches in the
+        output of the previously run command.  If 'path' is specified,
+        the contents of that file are searched.  If 'count' is greater
+        than zero, then the number of lines which match must equal that
+        number."""
+
+        c = self.__countMatches(regex, path)
+
+        self.assertFalse(
+            count == c == 0, "No matches for '{0}' found".format(regex)
+        )
+        if count > 0:
+            self.assertTrue(
+                c == count,
+                "{0} matches for '{1}' found, {2} expected".format(
+                    c, regex, count
+                ),
+            )
+
+    def assertNoMatch(self, regex, path=None):
+        """Assert that the regular expression 'regex' is not found in
+        the output of the previously run command.  If 'path' is
+        specified, the contents of that file are searched."""
+
+        c = self.__countMatches(regex, path)
+
+        self.assertTrue(
+            c == 0, "Match for '{0}' found unexpectedly".format(regex)
+        )
+
+    def test_1(self):
+        """Basic and nested macro substitution.  Allow a macro to
+        comment out a manifest line."""
+
+        source_file = os.path.join(self.test_root, "source_file")
+
+        sources = [source_file]
+
+        # Lines commented out by macros remain in the output.
+        self.pkgmogrify(sources)
+        self.assertNoMatch("^[^#].*SUNWxorg-mesa")
+
+        defines = self.basic_defines.copy()
+        defines["i386_ONLY"] = " "
+        self.pkgmogrify(sources, defines=defines)
+        self.assertMatch("SUNWxorg-mesa")
+
+        # nested macros
+        defines["BUILDID"] = "$(FOO)"
+        defines["FOO"] = "0.126"
+        self.pkgmogrify(sources, defines=defines)
+        self.assertMatch("SUNWxorg-mesa")
+
+        # stdin only
+        with open(source_file, "r") as f:
+            self.pkgmogrify(stdin=f, defines=defines)
+            self.assertMatch("SUNWxorg-mesa")
+
+    def test_2(self):
+        """The -O option: output goes to a file rather than stdout."""
+
+        source_file = os.path.join(self.test_root, "source_file")
+        output_file = os.path.join(self.test_root, "output_file")
+
+        sources = [source_file]
+
+        defines = self.basic_defines.copy()
+        defines["i386_ONLY"] = " "
+        self.pkgmogrify(sources, defines=defines, output=output_file)
+        self.assertMatch("SUNWxorg-mesa@7.4.4-0.126", path=output_file)
+
+    def test_3(self):
+        source_file = os.path.join(self.test_root, "source_file")
+
+        self.pkgmogrify([self.transforms["X11->Y11"], source_file])
+        self.assertNoMatch("X11")
+        self.assertMatch("Y11")
+
+        # stdin and source file combined
+        with open(source_file, "r") as f:
+            self.pkgmogrify(["-", self.transforms["X11->Y11"]], stdin=f)
+            self.assertNoMatch("X11")
+            self.assertMatch("Y11")
+
+        self.pkgmogrify([self.transforms["add bobcat"], source_file])
+        self.assertMatch("bobcat", count=3)
+
+        self.pkgmogrify([self.transforms["drop mode=0755"], source_file])
+        self.assertNoMatch("^file.*mode=0755")
+        self.pkgmogrify(
+            [self.transforms["delete-with-no-operand"], source_file], exit=1
+        )
+
+    def test_4(self):
+        source_file = os.path.join(self.test_root, "source_file")
+
+        self.pkgmogrify([self.transforms["drop xkbprint"], source_file])
+        self.assertNoMatch("xkbprint")
+        # Make sure that the line really got dropped, not just changed
+        # unrecognizably.
+        self.assertMatch("^.*$", count=19)
+
+    def test_5(self):
+        source_file = os.path.join(self.test_root, "source_file")
+
+        # Basic attribute editing.
+        self.pkgmogrify([self.transforms["X11mode"], source_file])
+        self.assertMatch(
+            "file NOHASH group=bin mode=0555 owner=root "
+            "path=usr/X11/bin/Xserver"
+        )
+
+        # Ensure that modifying an attribute used as matching criteria
+        # by a later transform means that the later transform is not
+        # invoked.
+        self.pkgmogrify(
+            [
+                self.transforms["X11->Y11"],
+                self.transforms["X11mode"],
+                source_file,
+            ]
+        )
+        self.assertMatch(
+            "file NOHASH group=bin mode=0755 owner=root "
+            "path=usr/Y11/bin/Xserver"
+        )
+
+        # Make sure that the -I flag works, with files specified on the
+        # commandline as well as ones <include>d by others.
+        self.pkgmogrify(
+            [os.path.basename(self.transforms["2include"]), source_file],
+            args="-I {0}".format(self.test_root),
+        )
+        self.assertMatch(
+            "file NOHASH group=bin mode=0755 owner=root "
+            "path=usr/Y11/bin/Xserver"
+        )
+
+        # Ensure that modifying an attribute used as matching criteria
+        # by an earlier transform doesn't prevent the earlier transform
+        # from being invoked.
+        self.pkgmogrify(
+            [
+                self.transforms["X11mode"],
+                self.transforms["X11->Y11"],
+                source_file,
+            ]
+        )
+        self.assertMatch(
+            "file NOHASH group=bin mode=0555 owner=root "
+            "path=usr/Y11/bin/Xserver"
+        )
+
+    def test_6(self):
+        source_file = os.path.join(self.test_root, "source_file")
+
+        # If NOHASH is omitted from the original manifest, check that it
+        # gets added.
+        self.pkgmogrify(
+            [
+                self.transforms["X11mode"],
+                self.transforms["X11->Y11"],
+                source_file,
+            ]
+        )
+        self.assertMatch(
+            "file NOHASH group=bin mode=0555 owner=root "
+            "path=usr/Y11/bin/bdftopcf"
+        )
+
+    def test_7(self):
+        """Test various error conditions."""
+
+        source_file = os.path.join(self.test_root, "source_file")
+
+        # Bad argument
+        self.pkgmogrify([], args="--froob", exit=2)
+
+        # Bad transform
+        self.pkgmogrify([self.transforms["empty edit"], source_file], exit=1)
+
+        # file not found XXX this fails because of a bad transform
+        self.pkgmogrify([self.transforms["include 9"]], exit=1)
+
+        # nested tranform error XXX this fails because of a bad transform
+        self.pkgmogrify(
+            [self.transforms["include 9"]],
+            args="-I {0}".format(self.test_root),
+            exit=1,
+        )
+
+        # Wombats!
+        self.pkgmogrify(["/wombat-farm"], exit=1)
+
+    def test_8(self):
+        """Test for graceful exit with no output on abort."""
+
+        source_file = os.path.join(self.test_root, "source_file")
+        no_output = os.path.join(self.test_root, "no_output")
+        no_print = os.path.join(self.test_root, "no_print")
+
+        # Add an abort transform that's expected to trigger.  This
+        # should cover the "exit gracefully" part of abort.
+        self.pkgmogrify(
+            [
+                self.transforms["add bobcat"],
+                self.transforms["abort on bobcat"],
+                source_file,
+            ],
+            output=no_output,
+            args="-P {0}".format(no_print),
+        )
+
+        # Make sure neither output nor print file was created.
+        self.assertFalse(os.access(no_output, os.F_OK))
+        self.assertFalse(os.access(no_print, os.F_OK))
+
+        # Trigger an exit transform with a specific exit code.
+        self.pkgmogrify(
+            [
+                self.transforms["add bobcat"],
+                self.transforms["exit7 on bobcat"],
+                source_file,
+            ],
+            output=no_output,
+            args="-P {0}".format(no_print),
+            exit=7,
+        )
+
+        # Make sure neither output nor print file was created.
+        self.assertFalse(os.access(no_output, os.F_OK))
+        self.assertFalse(os.access(no_print, os.F_OK))
+
+        # Trigger an exit transform with a specific exit code and
+        # message.
+        self.pkgmogrify(
+            [
+                self.transforms["add bobcat"],
+                self.transforms["exit6 on bobcat"],
+                source_file,
+            ],
+            output=no_output,
+            args="-P {0}".format(no_print),
+            exit=6,
+        )
+        self.assertMatch("found a bobcat")
+
+    def test_9(self):
+        """Test for print output to specified file."""
+
+        source_file = os.path.join(self.test_root, "source_file")
+        output_file = os.path.join(self.test_root, "output_file")
+        print_file = os.path.join(self.test_root, "print_file")
+
+        # Generate output for each file action, and count resulting
+        # lines in print file to be sure it matches our expectations.
+        defines = self.basic_defines.copy()
+        defines["i386_ONLY"] = " "
+        self.pkgmogrify(
+            [
+                self.transforms["add bobcat"],
+                self.transforms["print ouch"],
+                source_file,
+            ],
+            defines=defines,
+            output=output_file,
+            args="-P {0}".format(print_file),
+        )
+        self.assertMatch("ouch", path=print_file, count=3)
+
+    def test_10(self):
+        """Test to make sure we can handle leading macros, preserve comments"""
+
+        source_file = os.path.join(self.test_root, "source_file")
+        output_file = os.path.join(self.test_root, "output_file")
+
+        self.pkgmogrify([source_file], output=output_file, defines={})
+        self.cmdline_run(
+            "diff {0} {1}".format(source_file, output_file), coverage=False
+        )
+
+    def test_11(self):
+        """Test the generation of new actions."""
+
+        source_file = os.path.join(self.test_root, "source_file2")
+
+        # The emit operation can emit a blank line ...
+        self.pkgmogrify([self.transforms["emitblank"], source_file])
+        self.assertMatch("^$")
+
+        # ... or a comment ...
+        self.pkgmogrify([self.transforms["emitcomment"], source_file])
+        self.assertMatch("^# comment$")
+
+        # ... or an action ...
+        self.pkgmogrify([self.transforms["emitaction"], source_file])
+        self.assertMatch(
+            "^depend fmri=wombat/heaven@1.0,5.11-0.101 type=incorporate"
+        )
+
+        # Recursive transforms shouldn't blow up.
+        self.pkgmogrify([self.transforms["recurse"], source_file], exit=1)
+
+        # Emitted actions shouldn't be duplicated, modulo a macro
+        # prefix.
+        source_file = os.path.join(self.test_root, "source_file3")
+        defines = self.basic_defines.copy()
+        del defines["i386_ONLY"]
+
+        self.pkgmogrify(
+            [self.transforms["rbneeded"], source_file], defines=defines
+        )
+        self.assertMatch("name=magic", count=3)
+
+    def test_12(self):
+        """Test the use of action attributes."""
+
+        source_file = os.path.join(self.test_root, "source_file2")
+
+        expect = r'^test of "{0}" ... or is it\?$'
+        fmri = "wombat/heaven@1.0,5.11-0.101"
+
+        # Simple %() replacement
+        self.pkgmogrify([self.transforms["fmrival"], source_file])
+        self.assertMatch(expect.format(fmri))
+
+        # We should exit with an error and exit code 1 when the %()
+        # replacement fails because of a missing attribute.
+        self.pkgmogrify([self.transforms["fmrinoval"], source_file], exit=1)
+        self.assertMatch("'valuee' not found")
+
+        # When the attribute is missing but a notfound token is present,
+        # we should see that value show up.
+        self.pkgmogrify([self.transforms["fmrisaved"], source_file])
+        self.assertMatch(expect.format("noprint"))
+
+        # If the notfound value has quotes, the quoted value should show
+        # up, and the quotes dropped.
+        self.pkgmogrify([self.transforms["fmriqsaved"], source_file])
+        self.assertMatch(expect.format('"got quotes"'))
+
+        # When a notfound value is present, but the original attribute
+        # is also present, the notfound value should be ignored.
+        self.pkgmogrify([self.transforms["fmrinotsaved"], source_file])
+        self.assertMatch(expect.format(fmri))
+
+        # Basic list-valued attribute
+        self.pkgmogrify([self.transforms["list"], source_file])
+        self.assertMatch('^test of listval "12345 54321 13524"$')
+
+        # List-valued attribute with a separator
+        self.pkgmogrify([self.transforms["listsep"], source_file])
+        self.assertMatch('^test of listval "12345,54321,13524"$')
+
+        # List-valued attribute with a prefix, suffix, and separator
+        self.pkgmogrify([self.transforms["listsufpresep"], source_file])
+        self.assertMatch(
+            "^test of listval \"bug='12345', bug='54321', " "bug='13524'\"$"
+        )
+
+        # Singly-valued attribute with a prefix and suffix
+        self.pkgmogrify([self.transforms["nolistsufpre"], source_file])
+        self.assertMatch("^test of \"bug='12345'\"$")
+
+        # Synthetic attributes
+        self.pkgmogrify([self.transforms["synthetic"], source_file])
+        self.assertMatch("^{0} 4$".format(source_file))
+
+        # Synthetic attributes
+        self.pkgmogrify([self.transforms["synthetic2"], source_file])
+        self.assertMatch("^thisismyhashvalue usr/bin/foo file$")
+
+        # The "action.hash" attribute shouldn't cause a problem when a
+        # file action doesn't specify the hash in the manifest.
+        self.pkgmogrify([self.transforms["synthetic3"], source_file])
+
+        # The "action.hash" attribute shouldn't explode when an action
+        # which doesn't have one tries to use it.
+        self.pkgmogrify([self.transforms["synthetic4"], source_file], exit=1)
+
+        # The "action.hash" attribute can have a "notfound" value.
+        self.pkgmogrify([self.transforms["synthetic5"], source_file])
+        self.assertMatch("^something$")
+
+        self.pkgmogrify([self.transforms["doublequote"], source_file])
+        self.assertNoMatch("^legacy .*'\"")
+
+    def test_13(self):
+        """Test the use of package attributes."""
+
+        source_file = os.path.join(self.test_root, "source_file2")
+
+        # Simple valued
+        self.pkgmogrify([self.transforms["pkg.fmri"], source_file])
+        self.assertMatch(
+            '^pkg attr "wombat/heaven@1.0,5.11-0.101" and ' "the rest$"
+        )
+
+        # List valued
+        self.pkgmogrify([self.transforms["pkg.bugs"], source_file])
+        self.assertMatch('^pkg attr "12345 54321 13524" and the rest$')
+
+        defines = self.basic_defines.copy()
+        defines["MYATTR"] = "pkg.obsolete"
+        # Match on package attributes, and generate temporary ones
+        self.pkgmogrify(
+            [
+                self.transforms["pkgmatch"],
+                self.transforms["pkggen"],
+                source_file,
+            ],
+            defines=defines,
+        )
+        self.assertMatch("^depend fmri=consolidation type=require$")
+
+        # If we don't match, don't generate
+        defines["MYATTR"] = "bugs"
+        self.pkgmogrify(
+            [
+                self.transforms["pkgmatch"],
+                self.transforms["pkggen"],
+                source_file,
+            ],
+            defines=defines,
+        )
+        self.assertNoMatch("^depend fmri=consolidation type=require$")
+
+    def test_14(self):
+        """Test the use of backreferences to the matching portion of the
+        transform."""
+
+        source_file = os.path.join(self.test_root, "source_file2")
+
+        # Basic test of backreferences, using the default operation.
+        self.pkgmogrify([self.transforms["brdefault"], source_file])
+        self.assertMatch("pkg.debug.depend.path=usr/bin($| )")
+
+        # Same operation, but reorder the match criteria (and the
+        # references to match) to show that the reference numbers are
+        # based on the literal order of the match criteria, rather than
+        # some internal storage mechanism.
+        self.pkgmogrify([self.transforms["brdefault2"], source_file])
+        self.assertMatch("pkg.debug.depend.path=usr/bin($| )")
+
+        # A reference to a group that doesn't exist should die
+        # gracefully.
+        self.pkgmogrify([self.transforms["brdefault3"], source_file], exit=1)
+
+        # A reference to group 0 should die gracefully.
+        self.pkgmogrify([self.transforms["brdefault3a"], source_file], exit=1)
+
+        # A backreference may very well be used as part of an attribute
+        # name.  Make sure that the "default" operation takes the fully
+        # substituted attribute name into account.
+        self.pkgmogrify([self.transforms["brdefault4"], source_file])
+        self.assertMatch("locale.de=true")
+        self.assertMatch("locale.fr=oui")
+
+        # Quoting in a match attribute may not agree with the quoting
+        # that actions use, confusing the mechanism we use to ensure
+        # backreference numbers refer to the right groups.  Make sure
+        # we don't tip over, but show that we didn't get the backrefs
+        # right.  The right solution for this is probably to have a
+        # mode for fromstr() that returns a list rather than a dict.
+        self.pkgmogrify([self.transforms["brweirdquote"], source_file])
+        # XXX # self.assertMatch("refs=cowssayit,quotedpath")
+
+        # A "set" operation with a backreference works.
+        self.pkgmogrify([self.transforms["brset"], source_file])
+        self.assertMatch("locale.de=true")
+        self.assertMatch("locale.fr=true")
+
+        # An "add" operation with a backreference works.
+        self.pkgmogrify([self.transforms["bradd"], source_file])
+        self.assertMatch("locale.de=true", count=1)
+        self.assertMatch("locale.fr=oui", count=1)
+        self.assertMatch("locale.fr=true", count=1)
+
+        # This is the "normal" kind of backreferencing, only available
+        # for the "edit" operation, where a \1 in the replacement string
+        # refers to a group in the regex string, all on the operation
+        # side of the transform.
+        self.pkgmogrify([self.transforms["edit1"], source_file])
+        self.assertMatch("path=place/share/langs/de/foo.mo")
+
+        # An "edit" operation with a backreference in the replacement
+        # value works.  This one also uses the \1-style backreference.
+        self.pkgmogrify([self.transforms["bredit"], source_file])
+        self.assertMatch("path=another/place/for/locales/de/foo.mo")
+
+        # An "edit" operation with a backreference in the matching
+        # expression works.
+        self.pkgmogrify([self.transforms["bredit2"], source_file])
+        self.assertMatch("path=usr/share/locale/LANG/foo.mo")
+
+        # A backreference to an unmatched group is an error.
+        self.pkgmogrify(
+            [self.transforms["backreference-no-object"], source_file], exit=1
+        )
+
+        # A backreference to an empty string should work.
+        self.pkgmogrify(
+            [self.transforms["backreference-empty-string"], source_file]
+        )
+        self.assertMatch("path=usr/sbin/foo")
 
-        def __countMatches(self, regex, path=None):
-                """Count how many lines in the output of the previously run
-                command match the regular expression 'regex'.  If 'path' is
-                specified, the contents of that file are searched."""
-
-                if path is not None:
-                        with open(path) as f:
-                                output = f.read()
-                else:
-                        output = self.output + self.errout
-
-                c = sum((
-                    int(bool(re.search(regex, line)))
-                    for line in output.splitlines()
-                ))
-
-                return c
-
-        def assertMatch(self, regex, path=None, count=0):
-                """Assert that the regular expression 'regex' matches in the
-                output of the previously run command.  If 'path' is specified,
-                the contents of that file are searched.  If 'count' is greater
-                than zero, then the number of lines which match must equal that
-                number."""
-
-                c = self.__countMatches(regex, path)
-
-                self.assertFalse(count == c == 0,
-                    "No matches for '{0}' found".format(regex))
-                if count > 0:
-                        self.assertTrue(c == count,
-                            "{0} matches for '{1}' found, {2} expected".format(
-                            c, regex, count))
-
-        def assertNoMatch(self, regex, path=None):
-                """Assert that the regular expression 'regex' is not found in
-                the output of the previously run command.  If 'path' is
-                specified, the contents of that file are searched."""
-
-                c = self.__countMatches(regex, path)
-
-                self.assertTrue(c == 0, "Match for '{0}' found unexpectedly".format(regex))
-
-        def test_1(self):
-                """Basic and nested macro substitution.  Allow a macro to
-                comment out a manifest line."""
-
-                source_file = os.path.join(self.test_root, "source_file")
-
-                sources = [ source_file ]
-
-                # Lines commented out by macros remain in the output.
-                self.pkgmogrify(sources)
-                self.assertNoMatch("^[^#].*SUNWxorg-mesa")
-
-                defines = self.basic_defines.copy()
-                defines["i386_ONLY"] = " "
-                self.pkgmogrify(sources, defines=defines)
-                self.assertMatch("SUNWxorg-mesa")
-
-                # nested macros
-                defines["BUILDID"] = "$(FOO)"; defines["FOO"] = "0.126"
-                self.pkgmogrify(sources, defines=defines)
-                self.assertMatch("SUNWxorg-mesa")
-
-                # stdin only
-                with open(source_file, "r") as f:
-                        self.pkgmogrify(stdin=f, defines=defines)
-                        self.assertMatch("SUNWxorg-mesa")
-
-        def test_2(self):
-                """The -O option: output goes to a file rather than stdout."""
-
-                source_file = os.path.join(self.test_root, "source_file")
-                output_file = os.path.join(self.test_root, "output_file")
-
-                sources = [ source_file ]
-
-                defines = self.basic_defines.copy()
-                defines["i386_ONLY"] = " "
-                self.pkgmogrify(sources, defines=defines, output=output_file)
-                self.assertMatch("SUNWxorg-mesa@7.4.4-0.126", path=output_file)
-
-        def test_3(self):
-                source_file = os.path.join(self.test_root, "source_file")
-
-                self.pkgmogrify([self.transforms["X11->Y11"], source_file])
-                self.assertNoMatch("X11")
-                self.assertMatch("Y11")
-
-                # stdin and source file combined
-                with open(source_file, "r") as f:
-                        self.pkgmogrify(["-", self.transforms["X11->Y11"]], stdin=f)
-                        self.assertNoMatch("X11")
-                        self.assertMatch("Y11")
-
-                self.pkgmogrify([self.transforms["add bobcat"], source_file])
-                self.assertMatch("bobcat", count=3)
-
-                self.pkgmogrify([self.transforms["drop mode=0755"], source_file])
-                self.assertNoMatch("^file.*mode=0755")
-                self.pkgmogrify([self.transforms["delete-with-no-operand"],
-                    source_file], exit=1)
-
-        def test_4(self):
-                source_file = os.path.join(self.test_root, "source_file")
-
-                self.pkgmogrify([self.transforms["drop xkbprint"], source_file])
-                self.assertNoMatch("xkbprint")
-                # Make sure that the line really got dropped, not just changed
-                # unrecognizably.
-                self.assertMatch("^.*$", count=19)
-
-        def test_5(self):
-                source_file = os.path.join(self.test_root, "source_file")
-
-                # Basic attribute editing.
-                self.pkgmogrify([self.transforms["X11mode"], source_file])
-                self.assertMatch("file NOHASH group=bin mode=0555 owner=root "
-                    "path=usr/X11/bin/Xserver")
-
-                # Ensure that modifying an attribute used as matching criteria
-                # by a later transform means that the later transform is not
-                # invoked.
-                self.pkgmogrify([self.transforms["X11->Y11"],
-                    self.transforms["X11mode"], source_file])
-                self.assertMatch("file NOHASH group=bin mode=0755 owner=root "
-                    "path=usr/Y11/bin/Xserver")
-
-                # Make sure that the -I flag works, with files specified on the
-                # commandline as well as ones <include>d by others.
-                self.pkgmogrify([os.path.basename(self.transforms["2include"]),
-                    source_file], args="-I {0}".format(self.test_root))
-                self.assertMatch("file NOHASH group=bin mode=0755 owner=root "
-                    "path=usr/Y11/bin/Xserver")
-
-                # Ensure that modifying an attribute used as matching criteria
-                # by an earlier transform doesn't prevent the earlier transform
-                # from being invoked.
-                self.pkgmogrify([self.transforms["X11mode"],
-                    self.transforms["X11->Y11"], source_file])
-                self.assertMatch("file NOHASH group=bin mode=0555 owner=root "
-                    "path=usr/Y11/bin/Xserver")
-
-        def test_6(self):
-                source_file = os.path.join(self.test_root, "source_file")
-
-                # If NOHASH is omitted from the original manifest, check that it
-                # gets added.
-                self.pkgmogrify([self.transforms["X11mode"],
-                    self.transforms["X11->Y11"], source_file])
-                self.assertMatch("file NOHASH group=bin mode=0555 owner=root "
-                    "path=usr/Y11/bin/bdftopcf")
-
-        def test_7(self):
-                """Test various error conditions."""
-
-                source_file = os.path.join(self.test_root, "source_file")
-
-                # Bad argument
-                self.pkgmogrify([], args="--froob", exit=2)
-
-                # Bad transform
-                self.pkgmogrify([self.transforms["empty edit"], source_file],
-                    exit=1)
-
-                # file not found XXX this fails because of a bad transform
-                self.pkgmogrify([self.transforms["include 9"]], exit=1)
-
-                # nested tranform error XXX this fails because of a bad transform
-                self.pkgmogrify([self.transforms["include 9"]],
-                    args="-I {0}".format(self.test_root), exit=1)
-
-                # Wombats!
-                self.pkgmogrify(["/wombat-farm"], exit=1)
-
-        def test_8(self):
-                """Test for graceful exit with no output on abort."""
-
-                source_file = os.path.join(self.test_root, "source_file")
-                no_output = os.path.join(self.test_root, "no_output")
-                no_print = os.path.join(self.test_root, "no_print")
-
-                # Add an abort transform that's expected to trigger.  This
-                # should cover the "exit gracefully" part of abort.
-                self.pkgmogrify([self.transforms["add bobcat"],
-                    self.transforms["abort on bobcat"], source_file],
-                    output=no_output, args="-P {0}".format(no_print))
-
-                # Make sure neither output nor print file was created.
-                self.assertFalse(os.access(no_output, os.F_OK))
-                self.assertFalse(os.access(no_print, os.F_OK))
-
-                # Trigger an exit transform with a specific exit code.
-                self.pkgmogrify([self.transforms["add bobcat"],
-                    self.transforms["exit7 on bobcat"], source_file],
-                    output=no_output, args="-P {0}".format(no_print), exit=7)
-
-                # Make sure neither output nor print file was created.
-                self.assertFalse(os.access(no_output, os.F_OK))
-                self.assertFalse(os.access(no_print, os.F_OK))
-
-                # Trigger an exit transform with a specific exit code and
-                # message.
-                self.pkgmogrify([self.transforms["add bobcat"],
-                    self.transforms["exit6 on bobcat"], source_file],
-                    output=no_output, args="-P {0}".format(no_print), exit=6)
-                self.assertMatch("found a bobcat")
-
-        def test_9(self):
-                """Test for print output to specified file."""
-
-                source_file = os.path.join(self.test_root, "source_file")
-                output_file = os.path.join(self.test_root, "output_file")
-                print_file = os.path.join(self.test_root, "print_file")
-
-                # Generate output for each file action, and count resulting
-                # lines in print file to be sure it matches our expectations.
-                defines = self.basic_defines.copy()
-                defines["i386_ONLY"] = " "
-                self.pkgmogrify([self.transforms["add bobcat"],
-                    self.transforms["print ouch"], source_file],
-                    defines=defines, output=output_file,
-                    args="-P {0}".format(print_file))
-                self.assertMatch("ouch", path=print_file, count=3)
-
-        def test_10(self):
-                """Test to make sure we can handle leading macros, preserve comments"""
-
-                source_file = os.path.join(self.test_root, "source_file")
-                output_file = os.path.join(self.test_root, "output_file")
-
-                self.pkgmogrify([source_file], output=output_file, defines={})
-                self.cmdline_run("diff {0} {1}".format(source_file, output_file),
-                    coverage=False)
-                
-        def test_11(self):
-                """Test the generation of new actions."""
-
-                source_file = os.path.join(self.test_root, "source_file2")
-
-                # The emit operation can emit a blank line ...
-                self.pkgmogrify([self.transforms["emitblank"], source_file])
-                self.assertMatch("^$")
-
-                # ... or a comment ...
-                self.pkgmogrify([self.transforms["emitcomment"], source_file])
-                self.assertMatch("^# comment$")
-
-                # ... or an action ...
-                self.pkgmogrify([self.transforms["emitaction"], source_file])
-                self.assertMatch("^depend fmri=wombat/heaven@1.0,5.11-0.101 type=incorporate")
-
-                # Recursive transforms shouldn't blow up.
-                self.pkgmogrify([self.transforms["recurse"], source_file],
-                    exit=1)
-
-                # Emitted actions shouldn't be duplicated, modulo a macro
-                # prefix.
-                source_file = os.path.join(self.test_root, "source_file3")
-                defines = self.basic_defines.copy()
-                del defines["i386_ONLY"]
-
-                self.pkgmogrify([self.transforms["rbneeded"], source_file],
-                    defines=defines)
-                self.assertMatch("name=magic", count=3)
-
-        def test_12(self):
-                """Test the use of action attributes."""
-
-                source_file = os.path.join(self.test_root, "source_file2")
-
-                expect = r'^test of "{0}" ... or is it\?$'
-                fmri = "wombat/heaven@1.0,5.11-0.101"
-
-                # Simple %() replacement
-                self.pkgmogrify([self.transforms["fmrival"], source_file])
-                self.assertMatch(expect.format(fmri))
-
-                # We should exit with an error and exit code 1 when the %()
-                # replacement fails because of a missing attribute.
-                self.pkgmogrify([self.transforms["fmrinoval"], source_file],
-                    exit=1)
-                self.assertMatch("'valuee' not found")
-
-                # When the attribute is missing but a notfound token is present,
-                # we should see that value show up.
-                self.pkgmogrify([self.transforms["fmrisaved"], source_file])
-                self.assertMatch(expect.format("noprint"))
-
-                # If the notfound value has quotes, the quoted value should show
-                # up, and the quotes dropped.
-                self.pkgmogrify([self.transforms["fmriqsaved"], source_file])
-                self.assertMatch(expect.format('"got quotes"'))
-
-                # When a notfound value is present, but the original attribute
-                # is also present, the notfound value should be ignored.
-                self.pkgmogrify([self.transforms["fmrinotsaved"], source_file])
-                self.assertMatch(expect.format(fmri))
-
-                # Basic list-valued attribute
-                self.pkgmogrify([self.transforms["list"], source_file])
-                self.assertMatch("^test of listval \"12345 54321 13524\"$")
-
-                # List-valued attribute with a separator
-                self.pkgmogrify([self.transforms["listsep"], source_file])
-                self.assertMatch("^test of listval \"12345,54321,13524\"$")
-
-                # List-valued attribute with a prefix, suffix, and separator
-                self.pkgmogrify([self.transforms["listsufpresep"], source_file])
-                self.assertMatch("^test of listval \"bug='12345', bug='54321', "
-                    "bug='13524'\"$")
-
-                # Singly-valued attribute with a prefix and suffix
-                self.pkgmogrify([self.transforms["nolistsufpre"], source_file])
-                self.assertMatch("^test of \"bug='12345'\"$")
-
-                # Synthetic attributes
-                self.pkgmogrify([self.transforms["synthetic"], source_file])
-                self.assertMatch("^{0} 4$".format(source_file))
-
-                # Synthetic attributes
-                self.pkgmogrify([self.transforms["synthetic2"], source_file])
-                self.assertMatch("^thisismyhashvalue usr/bin/foo file$")
-
-                # The "action.hash" attribute shouldn't cause a problem when a
-                # file action doesn't specify the hash in the manifest.
-                self.pkgmogrify([self.transforms["synthetic3"], source_file])
-
-                # The "action.hash" attribute shouldn't explode when an action
-                # which doesn't have one tries to use it.
-                self.pkgmogrify([self.transforms["synthetic4"], source_file],
-                    exit=1)
-
-                # The "action.hash" attribute can have a "notfound" value.
-                self.pkgmogrify([self.transforms["synthetic5"], source_file])
-                self.assertMatch("^something$")
-
-                self.pkgmogrify([self.transforms["doublequote"], source_file])
-                self.assertNoMatch("^legacy .*'\"")
-
-        def test_13(self):
-                """Test the use of package attributes."""
-
-                source_file = os.path.join(self.test_root, "source_file2")
-
-                # Simple valued
-                self.pkgmogrify([self.transforms["pkg.fmri"], source_file])
-                self.assertMatch('^pkg attr "wombat/heaven@1.0,5.11-0.101" and '
-                    'the rest$')
-
-                # List valued
-                self.pkgmogrify([self.transforms["pkg.bugs"], source_file])
-                self.assertMatch('^pkg attr "12345 54321 13524" and the rest$')
-
-                defines = self.basic_defines.copy()
-                defines["MYATTR"] = "pkg.obsolete"
-                # Match on package attributes, and generate temporary ones
-                self.pkgmogrify([self.transforms["pkgmatch"],
-                    self.transforms["pkggen"], source_file], defines=defines)
-                self.assertMatch("^depend fmri=consolidation type=require$")
-
-                # If we don't match, don't generate
-                defines["MYATTR"] = "bugs"
-                self.pkgmogrify([self.transforms["pkgmatch"],
-                    self.transforms["pkggen"], source_file], defines=defines)
-                self.assertNoMatch("^depend fmri=consolidation type=require$")
-
-        def test_14(self):
-                """Test the use of backreferences to the matching portion of the
-                transform."""
-
-                source_file = os.path.join(self.test_root, "source_file2")
-
-                # Basic test of backreferences, using the default operation.
-                self.pkgmogrify([self.transforms["brdefault"], source_file])
-                self.assertMatch("pkg.debug.depend.path=usr/bin($| )")
-
-                # Same operation, but reorder the match criteria (and the
-                # references to match) to show that the reference numbers are
-                # based on the literal order of the match criteria, rather than
-                # some internal storage mechanism.
-                self.pkgmogrify([self.transforms["brdefault2"], source_file])
-                self.assertMatch("pkg.debug.depend.path=usr/bin($| )")
-
-                # A reference to a group that doesn't exist should die
-                # gracefully.
-                self.pkgmogrify([self.transforms["brdefault3"], source_file],
-                    exit=1)
-
-                # A reference to group 0 should die gracefully.
-                self.pkgmogrify([self.transforms["brdefault3a"], source_file],
-                    exit=1)
-
-                # A backreference may very well be used as part of an attribute
-                # name.  Make sure that the "default" operation takes the fully
-                # substituted attribute name into account.
-                self.pkgmogrify([self.transforms["brdefault4"], source_file])
-                self.assertMatch("locale.de=true")
-                self.assertMatch("locale.fr=oui")
-
-                # Quoting in a match attribute may not agree with the quoting
-                # that actions use, confusing the mechanism we use to ensure
-                # backreference numbers refer to the right groups.  Make sure
-                # we don't tip over, but show that we didn't get the backrefs
-                # right.  The right solution for this is probably to have a
-                # mode for fromstr() that returns a list rather than a dict.
-                self.pkgmogrify([self.transforms["brweirdquote"], source_file])
-                # XXX # self.assertMatch("refs=cowssayit,quotedpath")
-
-                # A "set" operation with a backreference works.
-                self.pkgmogrify([self.transforms["brset"], source_file])
-                self.assertMatch("locale.de=true")
-                self.assertMatch("locale.fr=true")
-
-                # An "add" operation with a backreference works.
-                self.pkgmogrify([self.transforms["bradd"], source_file])
-                self.assertMatch("locale.de=true", count=1)
-                self.assertMatch("locale.fr=oui", count=1)
-                self.assertMatch("locale.fr=true", count=1)
-
-                # This is the "normal" kind of backreferencing, only available
-                # for the "edit" operation, where a \1 in the replacement string
-                # refers to a group in the regex string, all on the operation
-                # side of the transform.
-                self.pkgmogrify([self.transforms["edit1"], source_file])
-                self.assertMatch("path=place/share/langs/de/foo.mo")
-
-                # An "edit" operation with a backreference in the replacement
-                # value works.  This one also uses the \1-style backreference.
-                self.pkgmogrify([self.transforms["bredit"], source_file])
-                self.assertMatch("path=another/place/for/locales/de/foo.mo")
-
-                # An "edit" operation with a backreference in the matching
-                # expression works.
-                self.pkgmogrify([self.transforms["bredit2"], source_file])
-                self.assertMatch("path=usr/share/locale/LANG/foo.mo")
-
-                # A backreference to an unmatched group is an error.
-                self.pkgmogrify([self.transforms["backreference-no-object"],
-                    source_file], exit=1)
-
-                # A backreference to an empty string should work.
-                self.pkgmogrify([self.transforms["backreference-empty-string"],
-                    source_file])
-                self.assertMatch("path=usr/sbin/foo")
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgrecv.py
+++ b/src/tests/cli/t_pkgrecv.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -56,87 +57,89 @@ from six.moves.urllib.parse import urlparse
 from six.moves.urllib.request import url2pathname
 
 try:
-        import pkg.sha512_t
-        sha512_supported = True
+    import pkg.sha512_t
+
+    sha512_supported = True
 except ImportError:
-        sha512_supported = False
+    sha512_supported = False
+
 
 class TestPkgrecvMulti(pkg5unittest.ManyDepotTestCase):
-        # Cleanup after every test.
-        persistent_setup = False
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Cleanup after every test.
+    persistent_setup = False
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        scheme10 = """
+    scheme10 = """
             open pkg:/scheme@1.0,5.11-0
             close
         """
 
-        filetrans110 = """
+    filetrans110 = """
             open pkg:/filetrans1@1.0,5.11-0
             add file tmp/bronze1 mode=0444 owner=root group=bin path=/etc/bronze1
             close
         """
 
-        filetrans210 = """
+    filetrans210 = """
             open pkg:/filetrans2@1.0,5.11-0
             add file tmp/bronze1 mode=0444 owner=root group=bin path=/etc/bronze1
             close
         """
 
-        filetrans310 = """
+    filetrans310 = """
             open pkg:/filetrans3@1.0,5.11-0
             add file tmp/bronze1 mode=0444 owner=root group=bin path=/etc/bronze1
             close
         """
 
-        filetrans410 = """
+    filetrans410 = """
             open pkg:/filetrans4@1.0,5.11-0
             add file tmp/bronzeA1 mode=0444 owner=root group=bin path=/etc/bronze1
             close
         """
 
-        signature10 = """
+    signature10 = """
             open pkg:/signature@1.0,5.11-0
             add signature tmp/extrafile value=d2ff algorithm=sha256 variant.arch=i386
             close
         """
 
-        tree10 = """
+    tree10 = """
             open tree@1.0,5.11-0
             add depend type=require-any fmri=leaf@1.0 fmri=branch@1.0
             close
         """
 
-        leaf10 = """
+    leaf10 = """
             open leaf@1.0,5.11-0
             close
         """
 
-        branch10 = """
+    branch10 = """
             open branch@1.0,5.11-0
             close
         """
 
-        amber10 = """
+    amber10 = """
             open amber@1.0,5.11-0
             add depend fmri=pkg:/tree@1.0 type=require
             close
         """
 
-        amber20 = """
+    amber20 = """
             open amber@2.0,5.11-0
             add depend fmri=pkg:/tree@1.0 type=require
             close
         """
 
-        amber30 = """
+    amber30 = """
             open amber@3.0,5.11-0
             add depend fmri=pkg:/tree@1.0 type=require
             close
         """
 
-        bronze10 = """
+    bronze10 = """
             open bronze@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/usr
             add dir mode=0755 owner=root group=bin path=/usr/bin
@@ -151,7 +154,7 @@ class TestPkgrecvMulti(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        bronze20 = """
+    bronze20 = """
             open bronze@2.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/etc
             add dir mode=0755 owner=root group=bin path=/lib
@@ -168,1529 +171,1845 @@ class TestPkgrecvMulti(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        # /etc/bronze1 is purposefully delivered by this package to verify that
-        # pkgrecv can have an identical file being present in multiple packages
-        # with different publishers.
-        samefile10 = """
+    # /etc/bronze1 is purposefully delivered by this package to verify that
+    # pkgrecv can have an identical file being present in multiple packages
+    # with different publishers.
+    samefile10 = """
             open pkg://pub1/samefile@1.0,5.11-0
             add file tmp/bronze1 mode=0444 owner=root group=bin path=/etc/bronze1
             add file tmp/foo mode=0444 owner=root group=bin path=/etc/foo
             close
         """
 
-        misc_files = [ "tmp/bronzeA1",  "tmp/bronzeA2", "tmp/bronze1",
-            "tmp/bronze2", "tmp/copyright2", "tmp/copyright3", "tmp/libc.so.1",
-            "tmp/sh", "tmp/extrafile", "tmp/foo"]
+    misc_files = [
+        "tmp/bronzeA1",
+        "tmp/bronzeA2",
+        "tmp/bronze1",
+        "tmp/bronze2",
+        "tmp/copyright2",
+        "tmp/copyright3",
+        "tmp/libc.so.1",
+        "tmp/sh",
+        "tmp/extrafile",
+        "tmp/foo",
+    ]
 
-        def setUp(self):
-                """ Start six depots.
-                    depot 1 gets foo and moo, depot 2 gets foo and bar
-                    depot1 is mapped to publisher test1 (preferred)
-                    depot2 is mapped to publisher test1 (alternate)
-                    depot3 and depot4 are scratch depots
-                    depot5 and depot6 are for testing mogrify."""
+    def setUp(self):
+        """Start six depots.
+        depot 1 gets foo and moo, depot 2 gets foo and bar
+        depot1 is mapped to publisher test1 (preferred)
+        depot2 is mapped to publisher test1 (alternate)
+        depot3 and depot4 are scratch depots
+        depot5 and depot6 are for testing mogrify."""
 
-                # This test suite needs actual depots.
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test1",
-                    "test2", "test2", "test1", "test1"], start_depots=True)
+        # This test suite needs actual depots.
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self,
+            ["test1", "test1", "test2", "test2", "test1", "test1"],
+            start_depots=True,
+        )
 
-                self.make_misc_files(self.misc_files)
+        self.make_misc_files(self.misc_files)
 
-                self.dpath1 = self.dcs[1].get_repodir()
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.published = self.pkgsend_bulk(self.durl1, (self.amber10,
-                    self.amber20, self.bronze10, self.bronze20))
+        self.dpath1 = self.dcs[1].get_repodir()
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.published = self.pkgsend_bulk(
+            self.durl1,
+            (self.amber10, self.amber20, self.bronze10, self.bronze20),
+        )
 
-                # Purposefully republish bronze20 a second later so a version
-                # exists that only differs in timestamp.  Also publish tree
-                # and scheme after that.
-                time.sleep(1)
-                self.published.extend(self.pkgsend_bulk(self.durl1,
-                    (self.bronze20, self.tree10, self.branch10, self.leaf10,
-                    self.scheme10)))
+        # Purposefully republish bronze20 a second later so a version
+        # exists that only differs in timestamp.  Also publish tree
+        # and scheme after that.
+        time.sleep(1)
+        self.published.extend(
+            self.pkgsend_bulk(
+                self.durl1,
+                (
+                    self.bronze20,
+                    self.tree10,
+                    self.branch10,
+                    self.leaf10,
+                    self.scheme10,
+                ),
+            )
+        )
 
-                self.dpath2 = self.dcs[2].get_repodir()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.tempdir = tempfile.mkdtemp(dir=self.test_root)
+        self.dpath2 = self.dcs[2].get_repodir()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.tempdir = tempfile.mkdtemp(dir=self.test_root)
 
-                self.mogdir = tempfile.mkdtemp(dir=self.test_root)
+        self.mogdir = tempfile.mkdtemp(dir=self.test_root)
 
-                self.durl3 = self.dcs[3].get_depot_url()
-                self.durl4 = self.dcs[4].get_depot_url()
+        self.durl3 = self.dcs[3].get_depot_url()
+        self.durl4 = self.dcs[4].get_depot_url()
 
-                self.durl5 = self.dcs[5].get_depot_url()
-                self.durl6 = self.dcs[6].get_depot_url()
-                self.dpath5 = self.dcs[5].get_repodir()
-                self.dpath6 = self.dcs[6].get_repodir()
-                self.test_mog = self.pkgsend_bulk(self.durl5,
-                    (self.filetrans110, self.filetrans210, self.filetrans310,
-                    self.filetrans410, self.signature10))
+        self.durl5 = self.dcs[5].get_depot_url()
+        self.durl6 = self.dcs[6].get_depot_url()
+        self.dpath5 = self.dcs[5].get_repodir()
+        self.dpath6 = self.dcs[6].get_repodir()
+        self.test_mog = self.pkgsend_bulk(
+            self.durl5,
+            (
+                self.filetrans110,
+                self.filetrans210,
+                self.filetrans310,
+                self.filetrans410,
+                self.signature10,
+            ),
+        )
 
-                self.transforms = {
-                    "pub_change": "<transform set name=pkg.fmri -> edit value (pkg://).*?(/.*) \\\\1testpub\\\\2>",
-                    "name_change": "<transform set name=pkg.fmri -> edit value (pkg://.*?/).*?(@.*) \\\\1testname\\\\2>",
-                    "add_file": "<transform file path=etc/bronze1 -> emit file {0} path=/etc/bronze2 owner=root group=bin mode=0755>".format(os.path.join(self.test_root, self.misc_files[8])),
-                    "add_none_file": "<transform file path=etc/bronze1 -> emit file tmp/nonono_such_file path=/etc/bronze2 owner=root group=bin mode=0755>",
-                    "drop_file": "<transform file path=etc/bronze1 -> drop>",
-                    "file_path_change": "<transform file path=etc/bronze1 -> edit path .* /opt/bronze2>",
-                    "add_invalid_act": "<transform file path=etc/bronze1 -> emit invalid_action name=invalid value=invalid>",
-                    "add_invalid_act2": "<transform file path=etc/bronze1 -> emit depend name=invalid value=invalid>",
-                    "add_invalid_act3": "<transform file path=etc/bronze1 -> emit depend fmri=*$# type=require>",
-                    "add_valid_act": "<transform file path=etc/bronze1 -> emit depend fmri=foo@1.0 type=require>"
-                }
-                # Map the transform names to path names
-                xformpaths = dict((
-                    (name, os.path.join(self.test_root, "transform_{0}".format(i)))
-                    for i, name in enumerate(six.iterkeys(self.transforms))
-                ))
+        self.transforms = {
+            "pub_change": "<transform set name=pkg.fmri -> edit value (pkg://).*?(/.*) \\\\1testpub\\\\2>",
+            "name_change": "<transform set name=pkg.fmri -> edit value (pkg://.*?/).*?(@.*) \\\\1testname\\\\2>",
+            "add_file": "<transform file path=etc/bronze1 -> emit file {0} path=/etc/bronze2 owner=root group=bin mode=0755>".format(
+                os.path.join(self.test_root, self.misc_files[8])
+            ),
+            "add_none_file": "<transform file path=etc/bronze1 -> emit file tmp/nonono_such_file path=/etc/bronze2 owner=root group=bin mode=0755>",
+            "drop_file": "<transform file path=etc/bronze1 -> drop>",
+            "file_path_change": "<transform file path=etc/bronze1 -> edit path .* /opt/bronze2>",
+            "add_invalid_act": "<transform file path=etc/bronze1 -> emit invalid_action name=invalid value=invalid>",
+            "add_invalid_act2": "<transform file path=etc/bronze1 -> emit depend name=invalid value=invalid>",
+            "add_invalid_act3": "<transform file path=etc/bronze1 -> emit depend fmri=*$# type=require>",
+            "add_valid_act": "<transform file path=etc/bronze1 -> emit depend fmri=foo@1.0 type=require>",
+        }
+        # Map the transform names to path names
+        xformpaths = dict(
+            (
+                (name, os.path.join(self.test_root, "transform_{0}".format(i)))
+                for i, name in enumerate(six.iterkeys(self.transforms))
+            )
+        )
 
-                # Now that we have path names, we can use the expandos in the
-                # transform contents to embed those pathnames, and write the
-                # transform files out.
-                for name, path in six.iteritems(xformpaths):
-                        f = open(path, "w")
-                        self.transforms[name] = self.transforms[name].format(**xformpaths)
-                        f.write(self.transforms[name])
-                        f.close()
+        # Now that we have path names, we can use the expandos in the
+        # transform contents to embed those pathnames, and write the
+        # transform files out.
+        for name, path in six.iteritems(xformpaths):
+            f = open(path, "w")
+            self.transforms[name] = self.transforms[name].format(**xformpaths)
+            f.write(self.transforms[name])
+            f.close()
 
-                self.transform_contents = self.transforms
-                self.transforms = xformpaths
+        self.transform_contents = self.transforms
+        self.transforms = xformpaths
 
-        @staticmethod
-        def get_repo(uri):
-                parts = urlparse(uri, "file", allow_fragments=0)
-                path = url2pathname(parts[2])
+    @staticmethod
+    def get_repo(uri):
+        parts = urlparse(uri, "file", allow_fragments=0)
+        path = url2pathname(parts[2])
 
-                try:
-                        return repo.Repository(root=path)
-                except cfg.ConfigError as e:
-                        raise repo.RepositoryError(_("The specified "
-                            "repository's configuration data is not "
-                            "valid:\n{0}").format(e))
+        try:
+            return repo.Repository(root=path)
+        except cfg.ConfigError as e:
+            raise repo.RepositoryError(
+                _(
+                    "The specified "
+                    "repository's configuration data is not "
+                    "valid:\n{0}"
+                ).format(e)
+            )
 
-        def __get_mf_path(self, fmri_str, dc_num, pub=None, repo_path=None):
-                """Given an FMRI, return the path to its manifest in our
-                repository."""
+    def __get_mf_path(self, fmri_str, dc_num, pub=None, repo_path=None):
+        """Given an FMRI, return the path to its manifest in our
+        repository."""
 
-                usepub = "test"
-                if pub:
-                        usepub = pub
-                if not repo_path:
-                        repo_path = self.dcs[dc_num].get_repodir()
-                path_comps = [repo_path, "publisher",
-                    usepub, "pkg"]
-                pfmri = fmri.PkgFmri(fmri_str)
-                path_comps.append(pfmri.get_name())
-                path_comps.append(pfmri.get_link_path().split("@")[1])
-                return os.path.sep.join(path_comps)
+        usepub = "test"
+        if pub:
+            usepub = pub
+        if not repo_path:
+            repo_path = self.dcs[dc_num].get_repodir()
+        path_comps = [repo_path, "publisher", usepub, "pkg"]
+        pfmri = fmri.PkgFmri(fmri_str)
+        path_comps.append(pfmri.get_name())
+        path_comps.append(pfmri.get_link_path().split("@")[1])
+        return os.path.sep.join(path_comps)
 
-        def __get_manifest_contents(self, fmri_str, dc_num, pub=None,
-            repo_path=None):
-                """Given an FMRI, return the unsorted manifest contents from our
-                repository as a string."""
+    def __get_manifest_contents(
+        self, fmri_str, dc_num, pub=None, repo_path=None
+    ):
+        """Given an FMRI, return the unsorted manifest contents from our
+        repository as a string."""
 
-                mpath = self.__get_mf_path(fmri_str, dc_num, pub=pub,
-                    repo_path=repo_path)
-                mf = manifest.Manifest()
-                mf.set_content(pathname=mpath)
-                return mf.tostr_unsorted()
+        mpath = self.__get_mf_path(
+            fmri_str, dc_num, pub=pub, repo_path=repo_path
+        )
+        mf = manifest.Manifest()
+        mf.set_content(pathname=mpath)
+        return mf.tostr_unsorted()
 
-        def test_0_opts(self):
-                """Verify that various basic options work as expected and that
-                invalid options or option values return expected exit code."""
+    def test_0_opts(self):
+        """Verify that various basic options work as expected and that
+        invalid options or option values return expected exit code."""
 
-                # Test that bad options return expected exit code.
-                self.pkgrecv(command="--newest", exit=2)
-                self.pkgrecv(self.durl1, "-!", exit=2)
-                self.pkgrecv(self.durl1, "-p foo", exit=2)
-                self.pkgrecv(self.durl1, "-d {0} gold@1.0-1".format(self.tempdir),
-                    exit=1)
-                self.pkgrecv(self.durl1, "-d {0} invalid.fmri@1.0.a".format(
-                    self.tempdir), exit=1)
+        # Test that bad options return expected exit code.
+        self.pkgrecv(command="--newest", exit=2)
+        self.pkgrecv(self.durl1, "-!", exit=2)
+        self.pkgrecv(self.durl1, "-p foo", exit=2)
+        self.pkgrecv(
+            self.durl1, "-d {0} gold@1.0-1".format(self.tempdir), exit=1
+        )
+        self.pkgrecv(
+            self.durl1, "-d {0} invalid.fmri@1.0.a".format(self.tempdir), exit=1
+        )
 
-                self.pkgrecv(self.durl1, "-d {0} --mog-file fakefile --clone"
-                    .format(self.dpath2), exit=2)
+        self.pkgrecv(
+            self.durl1,
+            "-d {0} --mog-file fakefile --clone".format(self.dpath2),
+            exit=2,
+        )
 
-                self.pkgrecv(self.durl1, "-d {0} --mog-file fakefile --a amber@1.0"
-                    .format(self.dpath2), exit=2)
+        self.pkgrecv(
+            self.durl1,
+            "-d {0} --mog-file fakefile --a amber@1.0".format(self.dpath2),
+            exit=2,
+        )
 
-                self.pkgrecv(self.durl1, "-d {0} --mog-file ++ amber@1.0"
-                    .format(self.dpath2), exit=1)
+        self.pkgrecv(
+            self.durl1,
+            "-d {0} --mog-file ++ amber@1.0".format(self.dpath2),
+            exit=1,
+        )
 
-                # Test help.
-                self.pkgrecv(command="-h", exit=0)
+        # Test help.
+        self.pkgrecv(command="-h", exit=0)
 
-                # Verify that pkgrecv requires a destination repository.
-                self.pkgrecv(self.durl1, "'*'", exit=2)
+        # Verify that pkgrecv requires a destination repository.
+        self.pkgrecv(self.durl1, "'*'", exit=2)
 
-                # Verify that a non-existent repository results in failure.
-                npath = os.path.join(self.test_root, "nochance")
-                self.pkgrecv(self.durl1, "-d file://{0} foo".format(npath),  exit=1)
+        # Verify that a non-existent repository results in failure.
+        npath = os.path.join(self.test_root, "nochance")
+        self.pkgrecv(self.durl1, "-d file://{0} foo".format(npath), exit=1)
 
-                # Test list newest.
-                self.pkgrecv(self.durl1, "--newest")
-                output = self.reduceSpaces(self.output)
+        # Test list newest.
+        self.pkgrecv(self.durl1, "--newest")
+        output = self.reduceSpaces(self.output)
 
-                def  _nobuild_fmri(pfmri):
-                        return fmri.PkgFmri(pfmri).get_fmri(
-                            include_build=False)
+        def _nobuild_fmri(pfmri):
+            return fmri.PkgFmri(pfmri).get_fmri(include_build=False)
 
-                # The latest version of amber and bronze should be listed
-                # (sans publisher prefix currently).
-                amber = _nobuild_fmri(self.published[1])
-                scheme = _nobuild_fmri(self.published[8])
-                bronze = _nobuild_fmri(self.published[4])
-                tree = _nobuild_fmri(self.published[5])
-                branch = _nobuild_fmri(self.published[6])
-                leaf = _nobuild_fmri(self.published[7])
+        # The latest version of amber and bronze should be listed
+        # (sans publisher prefix currently).
+        amber = _nobuild_fmri(self.published[1])
+        scheme = _nobuild_fmri(self.published[8])
+        bronze = _nobuild_fmri(self.published[4])
+        tree = _nobuild_fmri(self.published[5])
+        branch = _nobuild_fmri(self.published[6])
+        leaf = _nobuild_fmri(self.published[7])
 
-                expected = "\n".join((amber, branch, bronze, leaf, scheme, tree)) + "\n"
-                self.assertEqualDiff(expected, output)
+        expected = "\n".join((amber, branch, bronze, leaf, scheme, tree)) + "\n"
+        self.assertEqualDiff(expected, output)
 
-        def test_1_recv_pkgsend(self):
-                """Verify that a received package can be used by pkgsend."""
+    def test_1_recv_pkgsend(self):
+        """Verify that a received package can be used by pkgsend."""
 
-                f = fmri.PkgFmri(self.published[3], None)
+        f = fmri.PkgFmri(self.published[3], None)
 
-                # First, retrieve the package.
-                self.pkgrecv(self.durl1, "--raw -d {0} {1}".format(self.tempdir, f))
+        # First, retrieve the package.
+        self.pkgrecv(self.durl1, "--raw -d {0} {1}".format(self.tempdir, f))
 
-                # Next, load the manifest.
-                basedir = os.path.join(self.tempdir, f.get_dir_path())
-                mpath = os.path.join(basedir, "manifest")
+        # Next, load the manifest.
+        basedir = os.path.join(self.tempdir, f.get_dir_path())
+        mpath = os.path.join(basedir, "manifest")
 
-                m = manifest.Manifest()
-                raw = open(mpath, "r").read()
-                m.set_content(raw)
+        m = manifest.Manifest()
+        raw = open(mpath, "r").read()
+        m.set_content(raw)
 
-                # Verify that the files aren't compressed since -k wasn't used.
-                # This is also the format pkgsend will expect for correct
-                # republishing.
-                ofile = open(os.devnull, "r")
-                for atype in ("file", "license"):
-                        for a in m.gen_actions_by_type(atype):
-                                if not hasattr(a, "hash"):
-                                        continue
+        # Verify that the files aren't compressed since -k wasn't used.
+        # This is also the format pkgsend will expect for correct
+        # republishing.
+        ofile = open(os.devnull, "r")
+        for atype in ("file", "license"):
+            for a in m.gen_actions_by_type(atype):
+                if not hasattr(a, "hash"):
+                    continue
 
-                                ifile = open(os.path.join(basedir, a.hash),
-                                    "rb")
+                ifile = open(os.path.join(basedir, a.hash), "rb")
 
-                                # Since the file shouldn't be compressed, this
-                                # should return a zlib.error.
-                                self.assertRaises(zlib.error,
-                                    misc.gunzip_from_stream, ifile, ofile,
-                                    ignore_hash=True)
+                # Since the file shouldn't be compressed, this
+                # should return a zlib.error.
+                self.assertRaises(
+                    zlib.error,
+                    misc.gunzip_from_stream,
+                    ifile,
+                    ofile,
+                    ignore_hash=True,
+                )
 
-                # Next, send it to another depot
-                self.pkgsend(self.durl2, "open foo@1.0-1")
-                self.pkgsend(self.durl2,
-                    "include -d {0} {1}".format(basedir, mpath))
-                self.pkgsend(self.durl2, "close")
+        # Next, send it to another depot
+        self.pkgsend(self.durl2, "open foo@1.0-1")
+        self.pkgsend(self.durl2, "include -d {0} {1}".format(basedir, mpath))
+        self.pkgsend(self.durl2, "close")
 
-        def test_2_recv_compare(self):
-                """Verify that a received package is identical to the
-                original source."""
+    def test_2_recv_compare(self):
+        """Verify that a received package is identical to the
+        original source."""
 
-                f = fmri.PkgFmri(self.published[4], None)
+        f = fmri.PkgFmri(self.published[4], None)
 
-                # First, pkgrecv the pkg to a directory.  The files are
-                # kept compressed so they can be compared directly to the
-                # repository's internal copy.
-                self.pkgrecv(self.durl1, "--raw -k -d {0} {1}".format(self.tempdir,
-                    f))
+        # First, pkgrecv the pkg to a directory.  The files are
+        # kept compressed so they can be compared directly to the
+        # repository's internal copy.
+        self.pkgrecv(self.durl1, "--raw -k -d {0} {1}".format(self.tempdir, f))
 
-                # Next, compare the manifests.
-                orepo = self.get_repo(self.dpath1)
-                old = orepo.manifest(f)
-                new = os.path.join(self.tempdir, f.get_dir_path(), "manifest")
+        # Next, compare the manifests.
+        orepo = self.get_repo(self.dpath1)
+        old = orepo.manifest(f)
+        new = os.path.join(self.tempdir, f.get_dir_path(), "manifest")
 
+        self.assertEqual(
+            misc.get_data_digest(old, hash_func=DEFAULT_HASH_FUNC),
+            misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC),
+        )
+
+        # Next, load the manifest.
+        m = manifest.Manifest()
+        raw = open(new, "r").read()
+        m.set_content(raw)
+
+        # Next, compare the package actions that have data.
+        for atype in ("file", "license"):
+            for a in m.gen_actions_by_type(atype):
+                if not hasattr(a, "hash"):
+                    continue
+
+                old = orepo.file(a.hash)
+                new = os.path.join(self.tempdir, f.get_dir_path(), a.hash)
+                self.assertNotEqual(old, new)
                 self.assertEqual(
                     misc.get_data_digest(old, hash_func=DEFAULT_HASH_FUNC),
-                    misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC))
+                    misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC),
+                )
 
-                # Next, load the manifest.
-                m = manifest.Manifest()
-                raw = open(new, "r").read()
-                m.set_content(raw)
+        # Second, pkgrecv to the pkg to a file repository.
+        npath = tempfile.mkdtemp(dir=self.test_root)
+        self.pkgsend(
+            "file://{0}".format(npath),
+            "create-repository --set-property publisher.prefix=test1",
+        )
+        self.pkgrecv(self.durl1, "-d file://{0} {1}".format(npath, f))
 
-                # Next, compare the package actions that have data.
-                for atype in ("file", "license"):
-                        for a in m.gen_actions_by_type(atype):
-                                if not hasattr(a, "hash"):
-                                        continue
+        # Next, compare the manifests (this will also only succeed if
+        # the fmris are exactly the same including timestamp).
+        nrepo = self.get_repo(npath)
+        old = orepo.manifest(f)
+        new = nrepo.manifest(f)
 
-                                old = orepo.file(a.hash)
-                                new = os.path.join(self.tempdir,
-                                    f.get_dir_path(), a.hash)
-                                self.assertNotEqual(old, new)
-                                self.assertEqual(misc.get_data_digest(old,
-                                    hash_func=DEFAULT_HASH_FUNC),
-                                    misc.get_data_digest(new,
-                                    hash_func=DEFAULT_HASH_FUNC))
+        self.debug(old)
+        self.debug(new)
+        self.assertEqual(
+            misc.get_data_digest(old, hash_func=DEFAULT_HASH_FUNC),
+            misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC),
+        )
 
-                # Second, pkgrecv to the pkg to a file repository.
-                npath = tempfile.mkdtemp(dir=self.test_root)
-                self.pkgsend("file://{0}".format(npath),
-                    "create-repository --set-property publisher.prefix=test1")
-                self.pkgrecv(self.durl1, "-d file://{0} {1}".format(npath, f))
+        # Next, load the manifest.
+        m = manifest.Manifest()
+        raw = open(new, "r").read()
+        m.set_content(raw)
 
-                # Next, compare the manifests (this will also only succeed if
-                # the fmris are exactly the same including timestamp).
-                nrepo = self.get_repo(npath)
-                old = orepo.manifest(f)
-                new = nrepo.manifest(f)
+        # Next, compare the package actions that have data.
+        for atype in ("file", "license"):
+            for a in m.gen_actions_by_type(atype):
+                if not hasattr(a, "hash"):
+                    continue
 
-                self.debug(old)
-                self.debug(new)
+                old = orepo.file(a.hash)
+                new = nrepo.file(a.hash)
+                self.assertNotEqual(old, new)
                 self.assertEqual(
                     misc.get_data_digest(old, hash_func=DEFAULT_HASH_FUNC),
-                    misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC))
+                    misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC),
+                )
 
-                # Next, load the manifest.
-                m = manifest.Manifest()
-                raw = open(new, "r").read()
-                m.set_content(raw)
+        # Third, pkgrecv to the pkg to a http repository from the
+        # file repository from the last test.
+        self.pkgrecv(
+            "file://{0}".format(npath), "-d {0} {1}".format(self.durl2, f)
+        )
+        orepo = nrepo
 
-                # Next, compare the package actions that have data.
-                for atype in ("file", "license"):
-                        for a in m.gen_actions_by_type(atype):
-                                if not hasattr(a, "hash"):
-                                        continue
+        # Next, compare the manifests (this will also only succeed if
+        # the fmris are exactly the same including timestamp).
+        nrepo = self.get_repo(self.dpath2)
+        old = orepo.manifest(f)
+        new = nrepo.manifest(f)
 
-                                old = orepo.file(a.hash)
-                                new = nrepo.file(a.hash)
-                                self.assertNotEqual(old, new)
-                                self.assertEqual(misc.get_data_digest(old,
-                                    hash_func=DEFAULT_HASH_FUNC),
-                                    misc.get_data_digest(new,
-                                    hash_func=DEFAULT_HASH_FUNC))
+        self.assertEqual(
+            misc.get_data_digest(old, hash_func=DEFAULT_HASH_FUNC),
+            misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC),
+        )
 
-                # Third, pkgrecv to the pkg to a http repository from the
-                # file repository from the last test.
-                self.pkgrecv("file://{0}".format(npath), "-d {0} {1}".format(
-                    self.durl2, f))
-                orepo = nrepo
+        # Next, load the manifest.
+        m = manifest.Manifest()
+        raw = open(new, "r").read()
+        m.set_content(raw)
 
-                # Next, compare the manifests (this will also only succeed if
-                # the fmris are exactly the same including timestamp).
-                nrepo = self.get_repo(self.dpath2)
-                old = orepo.manifest(f)
-                new = nrepo.manifest(f)
+        # Next, compare the package actions that have data.
+        for atype in ("file", "license"):
+            for a in m.gen_actions_by_type(atype):
+                if not hasattr(a, "hash"):
+                    continue
 
+                old = orepo.file(a.hash)
+                new = nrepo.file(a.hash)
+                self.assertNotEqual(old, new)
                 self.assertEqual(
                     misc.get_data_digest(old, hash_func=DEFAULT_HASH_FUNC),
-                    misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC))
-
-                # Next, load the manifest.
-                m = manifest.Manifest()
-                raw = open(new, "r").read()
-                m.set_content(raw)
-
-                # Next, compare the package actions that have data.
-                for atype in ("file", "license"):
-                        for a in m.gen_actions_by_type(atype):
-                                if not hasattr(a, "hash"):
-                                        continue
-
-                                old = orepo.file(a.hash)
-                                new = nrepo.file(a.hash)
-                                self.assertNotEqual(old, new)
-                                self.assertEqual(
-                                    misc.get_data_digest(old,
-                                    hash_func=DEFAULT_HASH_FUNC),
-                                    misc.get_data_digest(new,
-                                    hash_func=DEFAULT_HASH_FUNC))
-
-                # Fourth, create an image and verify that the sent package is
-                # seen by the client.
-                self.wait_repo(self.dpath2)
-                self.image_create(self.durl2, prefix="test1")
-                self.pkg("info -r bronze@2.0")
-
-                # Fifth, pkgrecv the pkg to a file repository and compare the
-                # manifest of a package published with the scheme (pkg:/) given.
-                f = fmri.PkgFmri(self.published[6], None)
-                npath = tempfile.mkdtemp(dir=self.test_root)
-                self.pkgsend("file://{0}".format(npath),
-                    "create-repository --set-property publisher.prefix=test1")
-                self.pkgrecv(self.durl1, "-d file://{0} {1}".format(npath, f))
-
-                # Next, compare the manifests (this will also only succeed if
-                # the fmris are exactly the same including timestamp).
-                orepo = self.get_repo(self.dpath1)
-                nrepo = self.get_repo(npath)
-                old = orepo.manifest(f)
-                new = nrepo.manifest(f)
-
-                self.assertEqual(
-                    misc.get_data_digest(old, hash_func=DEFAULT_HASH_FUNC),
-                    misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC))
-
-        def test_3_recursive(self):
-                """Verify that retrieving a package recursively will retrieve
-                its dependencies as well."""
-
-                bronze = fmri.PkgFmri(self.published[4], None)
-
-                # Retrieve bronze recursively to a directory, this should
-                # also retrieve its dependency: amber, and amber's dependency:
-                # tree.
-                self.pkgrecv(self.durl1, "--raw -r -k -d {0} {1}".format(self.tempdir,
-                    bronze))
-
-                amber = fmri.PkgFmri(self.published[1], None)
-                tree = fmri.PkgFmri(self.published[5], None)
-
-                # Verify that the manifests for each package was retrieved.
-                for f in (amber, bronze, tree):
-                        mpath = os.path.join(self.tempdir, f.get_dir_path(),
-                            "manifest")
-                        self.assertTrue(os.path.isfile(mpath))
-
-                # Verify --mog-file option changes all package fmris into new
-                # publisher name. Also verify the manifest pkg.fmri value is
-                # changed correspondingly.
-                npath = tempfile.mkdtemp(dir=self.test_root)
-                self.create_repo(npath)
-                self.pkgrecv(self.durl1, "-r --mog-file {0} -d {1} {2}".format(
-                    self.transforms["pub_change"], npath, bronze))
-                self.pkgrepo("verify -s {0}".format(npath))
-                self.pkgrepo("-s {0} list -F json".format(npath))
-                out_json = json.loads(self.output)
-                for elem in out_json:
-                        self.assertTrue(elem["publisher"] == "testpub" and
-                            "testpub" in elem["pkg.fmri"])
-                        ma = self.__get_manifest_contents(elem["pkg.fmri"], 0,
-                            pub="testpub", repo_path=npath)
-                        self.assertTrue("pkg://testpub/" in ma)
-
-                # Verify again with --raw option.
-                self.pkgrecv(self.durl1, "-r --raw --mog-file {0} -d {1} -v "
-                    "{2}".format(self.transforms["pub_change"],
-                    npath, bronze))
-                xport, xport_cfg = transport.setup_transport()
-                xport_cfg.pkg_root = npath
-                pkgdir = xport_cfg.get_pkg_dir(bronze)
-                with open(os.path.join(pkgdir, "manifest")) as f:
-                        mcontent = f.read()
-                self.assertTrue("testpub" in mcontent)
-                with open(os.path.join(os.path.join(pkgdir, "manifest.set"))) \
-                    as f:
-                        ms = f.read()
-                self.assertTrue("testpub" in ms)
-                pkgdir = xport_cfg.get_pkg_dir(amber)
-                with open(os.path.join(pkgdir, "manifest")) as f:
-                        mcontent = f.read()
-                self.assertTrue("testpub" in mcontent)
-                with open(os.path.join(os.path.join(pkgdir, "manifest.set"))) \
-                    as f:
-                        ms = f.read()
-                self.assertTrue("testpub" in ms)
-
-                # Verify changing package name works.
-                npath2 = tempfile.mkdtemp(dir=self.test_root)
-                self.pkgrecv(self.durl1, "-r --raw --mog-file {0} -d {1} -v "
-                    "{2}".format(self.transforms["name_change"],
-                    npath2, bronze))
-                xport, xport_cfg = transport.setup_transport()
-                xport_cfg.pkg_root = npath2
-                bronze = self.published[4]
-                # Assert old path does not exist
-                oldpath = xport_cfg.get_pkg_dir(fmri.PkgFmri(bronze))
-                self.assertTrue(not os.path.exists(oldpath))
-                self.assertTrue(not os.path.exists(os.path.dirname(oldpath)))
-                bronze = bronze.replace("bronze", "testname")
-                bronze = fmri.PkgFmri(bronze, None)
-                pkgdir = xport_cfg.get_pkg_dir(bronze)
-                with open(os.path.join(pkgdir, "manifest")) as f:
-                        mcontent = f.read()
-                self.assertTrue("testname" in mcontent)
-                with open(os.path.join(os.path.join(pkgdir, "manifest.set"))) \
-                    as f:
-                        ms = f.read()
-                self.assertTrue("testname" in ms)
-
-                amber = self.published[1]
-                # Assert old path does not exist
-                oldpath = xport_cfg.get_pkg_dir(fmri.PkgFmri(amber))
-                self.assertTrue(not os.path.exists(oldpath))
-                self.assertTrue(not os.path.exists(os.path.dirname(oldpath)))
-                amber = amber.replace("amber", "testname")
-                amber = fmri.PkgFmri(amber, None)
-                pkgdir = xport_cfg.get_pkg_dir(amber)
-                with open(os.path.join(pkgdir, "manifest")) as f:
-                        mcontent = f.read()
-                self.assertTrue("testname" in mcontent)
-                with open(os.path.join(os.path.join(pkgdir, "manifest.set"))) \
-                    as f:
-                        ms = f.read()
-                self.assertTrue("testname" in ms)
-
-        def test_4_timever(self):
-                """Verify that receiving with -m options work as expected."""
-
-                bronze10 = fmri.PkgFmri(self.published[2], None)
-                bronze20_1 = fmri.PkgFmri(self.published[3], None)
-                bronze20_2 = fmri.PkgFmri(self.published[4], None)
-
-                # Retrieve bronze using -m all-timestamps and a version pattern.
-                # This should only retrieve bronze20_1 and bronze20_2.
-                self.pkgrecv(self.durl1, "--raw -m all-timestamps -r -k "
-                    "-d {0} {1}".format(self.tempdir, "/bronze@2.0"))
-
-                # Verify that only expected packages were retrieved.
-                expected = [
-                    bronze20_1.get_dir_path(),
-                    bronze20_2.get_dir_path(),
-                ]
-
-                for d in os.listdir(os.path.join(self.tempdir, "bronze")):
-                        self.assertTrue(os.path.join("bronze", d) in expected)
-
-                        mpath = os.path.join(self.tempdir, "bronze", d,
-                            "manifest")
-                        self.assertTrue(os.path.isfile(mpath))
-
-                # Cleanup for next test.
-                shutil.rmtree(os.path.join(self.tempdir, "bronze"))
-
-                # Retrieve bronze using -m all-timestamps and a package stem.
-                # This should retrieve bronze10, bronze20_1, and bronze20_2.
-                self.pkgrecv(self.durl1, "--raw -m all-timestamps -r -k "
-                    "-d {0} {1}".format(self.tempdir, "bronze"))
-
-                # Verify that only expected packages were retrieved.
-                expected = [
-                    bronze10.get_dir_path(),
-                    bronze20_1.get_dir_path(),
-                    bronze20_2.get_dir_path(),
-                ]
-
-                for d in os.listdir(os.path.join(self.tempdir, "bronze")):
-                        self.assertTrue(os.path.join("bronze", d) in expected)
-
-                        mpath = os.path.join(self.tempdir, "bronze", d,
-                            "manifest")
-                        self.assertTrue(os.path.isfile(mpath))
-
-                # Cleanup for next test.
-                shutil.rmtree(os.path.join(self.tempdir, "bronze"))
-
-                # Retrieve bronze using -m all-versions, this should only
-                # retrieve bronze10 and bronze20_2.
-                self.pkgrecv(self.durl1, "--raw -m all-versions -r -k "
-                    "-d {0} {1}".format(self.tempdir, "bronze"))
-
-                # Verify that only expected packages were retrieved.
-                expected = [
-                    bronze10.get_dir_path(),
-                    bronze20_2.get_dir_path(),
-                ]
-
-                for d in os.listdir(os.path.join(self.tempdir, "bronze")):
-                        self.assertTrue(os.path.join("bronze", d) in expected)
-
-                        mpath = os.path.join(self.tempdir, "bronze", d,
-                            "manifest")
-                        self.assertTrue(os.path.isfile(mpath))
-
-                # Cleanup for next test.
-                shutil.rmtree(os.path.join(self.tempdir, "bronze"))
-
-                # Retrieve bronze using -m latest, this should only
-                # retrieve bronze20_2.
-                self.pkgrecv(self.durl1, "--raw -m latest -r -k "
-                    "-d {0} {1}".format(self.tempdir, "bronze"))
-
-                # Verify that only expected packages were retrieved.
-                expected = [
-                    bronze20_2.get_dir_path(),
-                ]
-
-                for d in os.listdir(os.path.join(self.tempdir, "bronze")):
-                        self.assertTrue(os.path.join("bronze", d) in expected)
-
-                        mpath = os.path.join(self.tempdir, "bronze", d,
-                            "manifest")
-                        self.assertTrue(os.path.isfile(mpath))
-
-                # Cleanup for next test.
-                shutil.rmtree(os.path.join(self.tempdir, "bronze"))
-
-                # Retrieve bronze using default setting.
-                # This should retrieve bronze10, bronze20_1, and bronze20_2.
-                self.pkgrecv(self.durl1, "--raw -r -k "
-                    "-d {0} {1}".format(self.tempdir, "bronze"))
-
-                # Verify that all expected packages were retrieved.
-                expected = [
-                    bronze10.get_dir_path(),
-                    bronze20_1.get_dir_path(),
-                    bronze20_2.get_dir_path(),
-                ]
-
-                for d in expected:
-                        paths = os.listdir(os.path.join(self.tempdir, "bronze"))
-                        self.assertTrue(os.path.basename(d) in paths)
-
-                        mpath = os.path.join(self.tempdir, d, "manifest")
-                        self.assertTrue(os.path.isfile(mpath))
-
-        def test_5_recv_env(self):
-                """Verify that pkgrecv environment vars work as expected."""
-
-                f = fmri.PkgFmri(self.published[3], None)
-
-                os.environ["PKG_SRC"] = self.durl1
-                os.environ["PKG_DEST"] = self.tempdir
-
-                # First, retrieve the package.
-                self.pkgrecv(command="--raw {0}".format(f))
-
-                # Next, load the manifest.
-                basedir = os.path.join(self.tempdir, f.get_dir_path())
-                mpath = os.path.join(basedir, "manifest")
-
-                m = manifest.Manifest()
-                raw = open(mpath, "r").read()
-                m.set_content(raw)
-
-                # This is also the format pkgsend will expect for correct
-                # republishing.
-                ofile = open(os.devnull, "r")
-                for atype in ("file", "license"):
-                        for a in m.gen_actions_by_type(atype):
-                                if not hasattr(a, "hash"):
-                                        continue
-
-                                ifile = open(os.path.join(basedir, a.hash),
-                                    "rb")
-
-                                # Since the file shouldn't be compressed, this
-                                # should return a zlib.error.
-                                self.assertRaises(zlib.error,
-                                    misc.gunzip_from_stream, ifile, ofile,
-                                    ignore_hash=True)
-
-                for var in ("PKG_SRC", "PKG_DEST"):
-                        del os.environ[var]
-
-        def test_6_recv_republish_preexisting(self):
-                f = fmri.PkgFmri(self.published[5], None)
-                f2 = fmri.PkgFmri(self.published[4], None)
-
-                # First, pkgrecv tree into a file repository
-                npath = tempfile.mkdtemp(dir=self.test_root)
-                self.pkgsend("file://{0}".format(npath),
-                    "create-repository --set-property publisher.prefix=test1")
-                self.pkgrecv(self.durl1, "-d file://{0} {1}".format(npath, f))
-
-                # Next, recursively pkgrecv bronze2.0 into a file repository
-                # This would fail before behavior fixed to skip existing pkgs.
-                self.pkgrecv(self.durl1, "-r -d file://{0} {1}".format(npath, f2))
-
-                npath = tempfile.mkdtemp(dir=self.test_root)
-                self.pkgsend("file://{0}".format(npath),
-                    "create-repository --set-property publisher.prefix=testpub")
-                # Verify by changing publisher name, the second time run also
-                # does not fail with existing package error.
-                self.pkgrecv(self.durl1, "--mog-file {0} -d file://{1} {2}"
-                    .format(self.transforms["pub_change"], npath, f))
-                self.pkgrecv(self.durl1, "--mog-file {0} -r -d file://{1} {2}"
-                    .format(self.transforms["pub_change"], npath, f2))
-
-        def test_7_recv_multipublisher(self):
-                """Verify that pkgrecv handles multi-publisher repositories as
-                expected."""
-
-                # Setup a repository with packages from multiple publishers.
-                amber = self.amber10.replace("open ", "open //test2/")
-                self.pkgsend_bulk(self.durl3, amber)
-                self.pkgrecv(self.durl1, "-d {0} amber@1.0 bronze@1.0".format(
-                    self.durl3))
-
-                # Now attempt to receive from a repository with packages from
-                # multiple publishers and verify entry exists only for test1.
-                self.pkgrecv(self.durl3, "-d {0} bronze".format(self.durl4))
-                self.pkgrecv(self.durl3, "--newest")
-                self.assertNotEqual(self.output.find("test1/bronze"), -1)
-                self.assertEqual(self.output.find("test2/bronze"), -1)
-
-                # Now retrieve amber, and verify entries exist for both pubs.
-                self.wait_repo(self.dcs[4].get_repodir())
-                self.wait_repo(self.dcs[3].get_repodir())
-                self.pkgrecv(self.durl3, "-d {0} amber".format(self.durl4))
-                self.pkgrecv(self.durl4, "--newest")
-                self.assertNotEqual(self.output.find("test1/amber"), -1)
-                self.assertNotEqual(self.output.find("test2/amber"), -1)
-
-                # Test using --mog-file to change publishers of packages from
-                # multiple publishers.
-                npath = tempfile.mkdtemp(dir=self.test_root)
-                self.create_repo(npath)
-                self.pkgrecv(self.durl1, "--mog-file {0} -d {1} amber@1.0 "
-                    "bronze@1.0".format(self.transforms["pub_change"], npath))
-                self.pkgrepo("verify -s {0} --disable dependency"
-                    .format(npath))
-                self.pkgrepo("-s {0} list -F json".format(npath))
-                out_json = json.loads(self.output)
-                for elem in out_json:
-                        self.assertTrue(elem["publisher"] == "testpub" and
-                            "testpub" in elem["pkg.fmri"])
-                        ma = self.__get_manifest_contents(elem["pkg.fmri"], 0,
-                            pub="testpub", repo_path=npath)
-                        self.assertTrue("pkg://testpub/" in ma)
-
-                # Verify attempting to retrieve a non-existent package fails
-                # for a multi-publisher repository.
-                self.pkgrecv(self.durl3, "-d {0} nosuchpackage".format(self.durl4),
-                    exit=1)
-
-        def test_8_archive(self):
-                """Verify that pkgrecv handles package archives as expected."""
-
-                # Setup a repository with packages from multiple publishers.
-                amber = self.amber10.replace("open ", "open pkg://test2/")
-                t2_amber10 = self.pkgsend_bulk(self.durl3, amber)[0]
-                self.pkgrecv(self.durl1, "-d {0} amber@1.0 bronze@1.0".format(
-                    self.durl3))
-
-                # Now attempt to receive from a repository to a package archive.
-                arc_path = os.path.join(self.test_root, "test.p5p")
-                self.pkgrecv(self.durl3, "-a -d {0} \\*".format(arc_path))
-
-                #
-                # Verify that the archive can be opened and the expected
-                # packages are inside.
-                #
-                amber10 = self.published[0]
-                bronze10 = self.published[2]
-                arc = p5p.Archive(arc_path, mode="r")
-
-                # Check for expected publishers.
-                expected = ["test1", "test2"]
-                pubs = sorted(set(p.prefix for p in arc.get_publishers()))
-                self.assertEqualDiff(expected, pubs)
-
-                # Check for expected package FMRIs.
-                expected = set([amber10, t2_amber10, bronze10])
-                tmpdir = tempfile.mkdtemp(dir=self.test_root)
-                returned = []
-                for pfx in pubs:
-                        catdir = os.path.join(tmpdir, pfx)
-                        os.mkdir(catdir)
-                        for part in ("catalog.attrs", "catalog.base.C"):
-                                arc.extract_catalog1(part, catdir, pfx)
-
-                        cat = catalog.Catalog(meta_root=catdir, read_only=True)
-                        returned.extend(str(f) for f in cat.fmris())
-                self.assertEqualDiff(expected, set(returned))
-                arc.close()
-                shutil.rmtree(tmpdir)
-
-                #
-                # Verify that packages can be received from an archive to an
-                # archive.
-                #
-                arc2_path = os.path.join(self.test_root, "test2.p5p")
-                self.pkgrecv(arc_path, "-a -d {0} pkg://test2/amber".format(arc2_path))
-
-                # Check for expected publishers.
-                arc = p5p.Archive(arc2_path, mode="r")
-                expected = set(["test2"])
-                pubs = set(p.prefix for p in arc.get_publishers())
-                self.assertEqualDiff(expected, pubs)
-
-                # Check for expected package FMRIs.
-                expected = set([t2_amber10])
-                tmpdir = tempfile.mkdtemp(dir=self.test_root)
-                returned = []
-                for pfx in pubs:
-                        catdir = os.path.join(tmpdir, pfx)
-                        os.mkdir(catdir)
-                        for part in ("catalog.attrs", "catalog.base.C"):
-                                arc.extract_catalog1(part, catdir, pfx)
-
-                        cat = catalog.Catalog(meta_root=catdir, read_only=True)
-                        returned.extend(str(f) for f in cat.fmris())
-                self.assertEqualDiff(expected, set(returned))
-                arc.close()
-
-                #
-                # Verify that pkgrecv gracefully fails if archive already
-                # exists.
-                #
-                self.pkgrecv(arc_path, "-d {0} \\*".format(arc2_path), exit=1)
-
-                #
-                # Verify that packages can be received from an archive to
-                # a repository.
-                #
-                self.pkgrecv(arc_path, "--newest")
-                self.pkgrecv(arc_path, "-d {0} pkg://test2/amber bronze".format(
-                    self.durl4))
-                self.wait_repo(self.dcs[4].get_repodir())
-                repo = self.dcs[4].get_repo()
-                self.pkgrecv(repo.root, "--newest")
-
-                # Check for expected publishers.
-                expected = ["test1", "test2"]
-                pubs = sorted(repo.publishers)
-                self.assertEqualDiff(expected, pubs)
-
-                # Check for expected package FMRIs.
-                expected = sorted([t2_amber10, bronze10])
-                returned = []
-                for pfx in repo.publishers:
-                        cat = repo.get_catalog(pub=pfx)
-                        returned.extend(str(f) for f in cat.fmris())
-                self.assertEqualDiff(expected, sorted(returned))
-
-                # Attempt a dry-run to receive a package archive.
-                # We should not have the archive created in this case.
-                arc_path = os.path.join(self.test_root, "dry-run.p5p")
-                self.pkgrecv(self.durl3, "-n -a -d {0} \\*".format(arc_path))
-                self.assertFalse(os.path.exists(arc_path))
-
-                #
-                # Verify that packages can be received from an archive to an
-                # archive.
-                #
-                arc_mog_path = os.path.join(self.test_root, "test_mog.p5p")
-                self.pkgrecv(self.durl1, "-a --mog-file {0} --mog-file {1} "
-                    "-d {2} bronze@1".format(self.transforms["drop_file"],
-                    self.transforms["pub_change"], arc_mog_path))
-
-                # Check for expected publishers.
-                arc = p5p.Archive(arc_mog_path, mode="r")
-                expected = set(["testpub"])
-                pubs = set(p.prefix for p in arc.get_publishers())
-                self.assertEqualDiff(expected, pubs)
-
-                # Check for expected package FMRIs.
-                bronze = self.published[2]
-                bronze = bronze.replace("test1", "testpub")
-                expected = set([bronze])
-                tmpdir = tempfile.mkdtemp(dir=self.test_root)
-                returned = []
-                for pfx in pubs:
-                        catdir = os.path.join(tmpdir, pfx)
-                        os.mkdir(catdir)
-                        for part in ("catalog.attrs", "catalog.base.C"):
-                                arc.extract_catalog1(part, catdir, pfx)
-
-                        cat = catalog.Catalog(meta_root=catdir, read_only=True)
-                        returned.extend(str(f) for f in cat.fmris())
-                        fileObjs = []
-                        allcontents = ""
-                        for idx in arc.get_index():
-                                tarf = arc.get_file(idx)
-                                if tarf:
-                                        fileObjs.append(tarf)
-                                        allcontents += str(tarf.readlines())
-                        # 3 files + 1 license + 1 manifest +
-                        # 1 repo configuration.
-                        self.assertTrue(len(fileObjs) == 6)
-                        # etc/bronze1 has been dropped.
-                        self.assertTrue("etc/bronze1" not in allcontents)
-                self.assertEqualDiff(expected, set(returned))
-                arc.close()
-
-        def test_9_dryruns(self):
-                """Test that the dry run option to pkgrecv works as expected."""
-
-                f = fmri.PkgFmri(self.published[3], None)
-
-                rpth = tempfile.mkdtemp(dir=self.test_root)
-                self.pkgrepo("create {0}".format(rpth))
-                expected = ["pkg5.repository"]
-                self.pkgrecv(self.durl1, "-n -d {0} {1}".format(rpth, f))
-                self.assertEqualDiff(expected, os.listdir(rpth))
-
-                self.pkgrecv(self.durl1, "-r -n -d {0} {1}".format(rpth, f))
-                self.assertEqualDiff(expected, os.listdir(rpth))
-
-                self.pkgrecv(self.durl1, "--clone -n -p '*' -d {0}".format(rpth))
-                self.assertEqualDiff(expected, os.listdir(rpth))
-
-                arc_path = os.path.join(self.test_root, "test.p5p")
-                self.pkgrecv(self.durl1, "-a -n -d {0} \\*".format(arc_path))
-                self.assertTrue(not os.path.exists(arc_path))
-
-                # --raw actually populates the destination with manifests even
-                # with -n, so just check that it exits 0.
-                self.pkgrecv(self.durl1, "--raw -n -d {0} {1}".format(
-                    self.tempdir, f))
-
-                # --raw actually populates the destination with manifests even
-                # with -n, so just check that it exits 0.
-                self.pkgrecv(self.durl1, "--raw -r -n -d {0} {1}".format(
-                    self.tempdir, f))
-
-        def test_10_unsupported_actions(self):
-                """Test that pkgrecv skips packages with actions it can't
-                understand, processes those it can, and exits with appropriate
-                exit codes."""
-
-                def __count_pulled_packages(pth):
-                        self.pkgrepo("list -F tsv -H -s {0}".format(pth))
-                        return len(self.output.splitlines())
-
-                def __check_errout(pfmri):
-                        s1 = "in package '{0}'".format(pfmri)
-                        self.assertTrue(s1 in self.errout,
-                            "{0} not in error".format(pfmri))
-
-                def __empty_repo(uri, arg_string):
-                        if uri.startswith("http://"):
-                                rurl = self.dcs[4].get_repo_url()
-                                self.pkgrepo("remove -s {0} '*'".format(rurl))
-                                # Refresh the depot to get it to realize that
-                                # the catalog has changed.
-                                self.dcs[4].refresh()
-                        elif arg_string:
-                                portable.remove(uri)
-                        else:
-                                self.pkgrepo("remove -s {0} '*'".format(uri))
-
-
-                def __test_rec(duri, arg_string, pfmris):
-                        self.debug("\n\nNow pkgrecv'ing to {0}".format(duri))
-
-                        # It's necessary to use the -D option below because
-                        # otherwise pkgrecv will fail because the manifest
-                        # doesn't validate.
-
-                        novalidate = "-D manifest_validate=Never "
-                        # Check that invalid action attributes don't cause
-                        # tracebacks.
-                        self.pkgrecv(self.durl1, novalidate +
-                            "-d {0} {1} {2}".format(duri, arg_string,
-                            " ".join(pfmris)), exit=pkgdefs.EXIT_OOPS)
-                        for pfmri in pfmris:
-                                __check_errout(pfmri)
-                        self.assertEqual(__count_pulled_packages(duri), 0)
-                        if arg_string:
-                                portable.remove(duri)
-
-                        self.pkgrecv(self.rurl1, novalidate +
-                            "-d {0} {1} {2}".format(duri, arg_string,
-                            " ".join(pfmris)), exit=pkgdefs.EXIT_OOPS)
-                        for pfmri in pfmris:
-                                __check_errout(pfmri)
-                        self.assertEqual(__count_pulled_packages(duri), 0)
-                        if arg_string:
-                                portable.remove(duri)
-
-                        # Check that other packages are retrieved and the exit
-                        # code reflects partial success.
-                        self.pkgrecv(self.durl1, novalidate +
-                            "-d {0} {1} -m all-timestamps '*'".format(
-                            duri, arg_string), exit=pkgdefs.EXIT_PARTIAL)
-                        for pfmri in pfmris:
-                                __check_errout(pfmri)
-                        self.assertEqual(__count_pulled_packages(duri),
-                            len(self.published) - len(pfmris))
-                        __empty_repo(duri, arg_string)
-
-                        self.pkgrecv(self.rurl1, novalidate +
-                            "-d {0} {1} -m all-timestamps '*'".format(
-                            duri, arg_string), exit=pkgdefs.EXIT_PARTIAL)
-                        for pfmri in pfmris:
-                                __check_errout(pfmri)
-                        self.assertEqual(__count_pulled_packages(duri),
-                            len(self.published) - len(pfmris))
-                        __empty_repo(duri, arg_string)
-
-                self.rurl1 = self.dcs[1].get_repo_url()
-                repo = self.dcs[1].get_repo()
-                rd = repo.get_pub_rstore()
-                pfmri = fmri.PkgFmri(self.published[4])
-                mp = rd.manifest(pfmri)
-
-                with open(mp, "r") as fh:
-                        original_txt = fh.read()
-                txt = original_txt.replace("type=require", "type=foo")
-                with open(mp, "w") as fh:
-                        fh.write(txt)
-
-                rpth = tempfile.mkdtemp(dir=self.test_root)
-                self.pkgrepo("create {0}".format(rpth))
-                adir = tempfile.mkdtemp(dir=self.test_root)
-
-                # The __empty repo function above assumes that the only http uri
-                # used is the one for depot number 4.
-                dest_uris = ((rpth, ""), (self.durl4, ""),
-                    (os.path.join(adir, "archive.p5p"), "-a"))
-                for duri, arg_string in dest_uris:
-                        __test_rec(duri, arg_string, [self.published[4]])
-
-                # Test that multiple packages failing are handled correctly.
-                for i in range(5, 7):
-                        pfmri = fmri.PkgFmri(self.published[i])
-                        mp = rd.manifest(pfmri)
-                        with open(mp, "r") as fh:
-                                original_txt = fh.read()
-                        txt = "foop\n" + original_txt
-                        with open(mp, "w") as fh:
-                                fh.write(txt)
-
-                for duri, arg_string, in dest_uris:
-                        __test_rec(duri, arg_string, self.published[4:7])
-
-        def test_11_clone(self):
-                """Verify that pkgrecv handles cloning repos as expected."""
-                # Test basic operation of cloning repo which contains one
-                # publisher to repo which contains same publisher
-                self.pkgrecv(self.durl1, "--clone -d {0}".format(self.dpath2))
-
-                ret = subprocess.call(["/usr/bin/gdiff", "-Naur", "-x",
-                    "index", "-x", "trans", self.dpath1, self.dpath2])
-                self.assertTrue(ret==0)
-
-                # Test that packages in dst which are not in src get removed.
-                self.pkgsend_bulk(self.durl2, (self.amber30))
-                self.pkgrecv(self.durl1, "--clone -d {0}".format(self.dpath2))
-                ret = subprocess.call(["/usr/bin/gdiff", "-Naur", "-x",
-                    "index", "-x", "trans", self.dpath1, self.dpath2])
-                self.assertTrue(ret==0)
-
-                # Test that clone reports publishers not in the dest repo.
-                amber = self.amber10.replace("open ", "open pkg://test2/")
-                self.pkgsend_bulk(self.durl1, amber)
-                self.pkgrecv(self.durl1, "--clone -d {0}".format(self.dpath2), exit=1)
-
-                # Test that clone adds new publishers if requested.
-                amber = self.amber10.replace("open ", "open pkg://test2/")
-                self.pkgsend_bulk(self.durl1, amber)
-                self.pkgrecv(self.durl1, "--clone -d {0} -p test2".format(self.dpath2))
-                ret = subprocess.call(["/usr/bin/gdiff", "-Naur", "-x",
-                    "index", "-x", "trans", self.dpath1,
-                    self.dpath2])
-                self.assertTrue(ret==0)
-
-                # Test that clone removes all packages if source is empty
-                self.pkgrecv(self.durl3, "--clone -d {0}".format(self.dpath2))
-                self.pkgrepo("-s {0} list -H -p test2".format(self.dpath2))
-                self.assertEqualDiff("", self.output)
-
-                # Test that clone works fine with mulitple publishers
-                amber = self.amber10.replace("open ", "open pkg://test2/")
-                self.pkgsend_bulk(self.durl1, amber)
-
-                path = os.path.join(self.dpath2, "publisher/test1")
-                shutil.rmtree(path)
-                path = os.path.join(self.dpath2, "publisher/test2")
-                shutil.rmtree(path)
-                self.pkgrecv(self.durl1, "--clone -d {0} -p test2 -p test1".format(
-                    self.dpath2))
-                ret = subprocess.call(["/usr/bin/gdiff", "-Naur", "-x",
-                    "index", "-x", "trans", self.dpath1, self.dpath2])
-                self.assertTrue(ret==0)
-
-                # Test that clone fails if --raw is specified.
-                self.pkgrecv(self.durl1, "--raw --clone -d {0} -p test2".format(
-                    self.dpath2), exit=2)
-
-                # Test that clone fails if -c is specified.
-                self.pkgrecv(self.durl1, "-c /tmp/ --clone -d {0} -p test2".format(
-                    self.dpath2), exit=2)
-
-                # Test that clone fails if -a is specified.
-                self.pkgrecv(self.durl1, "-a --clone -d {0} -p test2".format(
-                    self.dpath2), exit=2)
-
-                # Test that clone fails if --newest is specified.
-                self.pkgrecv(self.durl1, "--newest --clone -d {0} -p test2".format(
-                    self.dpath2), exit=2)
-
-        def test_12_multihash(self):
-                """Tests that we can recv to and from repositories with
-                multi-hash support, interoperating with repositories without
-                multi-hash support."""
-                if sha512_supported:
-                        self.base_12_multihash("sha256")
-                else:
-                        self.base_12_multihash("sha512t_256")
-
-        def base_12_multihash(self, hash_alg):
-                f = fmri.PkgFmri(self.published[3], None)
-                # We create an image simply so we can use "contents -g" to
-                # inspect the repository.
-                self.image_create()
-
-                # First, recv the package and verify it has no extended hashes
-                self.pkgrecv(self.durl1, "-d {0} {1}".format(self.durl3, f))
-                self.pkg("contents -g {0} -m {1}".format(self.durl3, f))
-                self.assertTrue("pkg.content-hash=file:{0}".format(hash_alg)
-                    not in self.output)
-
-                # Now stop and start the repository as multi-hash aware, and
-                # recv it again, making sure that we do not get multiple hashes
-                # added (because modifying the manifest would break signatures)
-                self.dcs[3].stop()
-                self.dcs[3].set_debug_feature("hash=sha1+{0}".format(hash_alg))
-                self.dcs[3].start()
-                self.pkgrecv(self.durl1, "-d {0} {1}".format(self.durl3, f))
-                self.pkg("contents -g {0} -m {1}".format(self.durl3, f))
-                self.assertTrue("pkg.content-hash=file:{0}".format(hash_alg)
-                    not in self.output)
-
-                # Now check the reverse - that a package with multiple hashes
-                # can be received into a repository that is not multi-hash aware
-                b = "bronze@1.0,5.11-0"
-                self.pkgsend_bulk(self.durl3, self.bronze10,
-                    debug_hash="sha1+{0}".format(hash_alg))
-                self.pkg("contents -g {0} -m {1}".format(self.durl3, b))
-                self.assertTrue("pkg.content-hash=file:{0}".format(hash_alg)
-                    in self.output)
-                self.pkgrecv(self.durl3, "-d {0} {1}".format(self.durl4, b))
-                self.pkg("contents -g {0} -m {1}".format(self.durl4, b))
-                self.assertTrue("pkg.content-hash=file:{0}".format(hash_alg)
-                    in self.output)
-
-                # Ensure that we can recv multi-hash packages into p5p files
-                p5p_path = os.path.join(self.test_root,
-                    "multi-hash-{0}.p5p".format(hash_alg))
-                self.pkgrecv(self.durl3, "-ad {0} {1}".format(p5p_path, b))
-                self.pkg("contents -g {0} -m {1}".format(p5p_path, b))
-                self.assertTrue("pkg.content-hash=file:{0}".format(hash_alg)
-                    in self.output)
-
-                # Finally, stop and start our scratch repository to clear the
-                # debug feature. If this doesn't happen because we've failed
-                # before now, it's not the end of the world.
-                self.dcs[3].stop()
-                self.dcs[3].unset_debug_feature("hash=sha1+{0}".format(hash_alg))
-                self.dcs[3].start()
-
-        def test_13_output(self):
-                """Verify that pkgrecv handles verbose output as expected."""
-
-                # Now attempt to receive from a repository.
-                self.pkgrepo("create {0}".format(self.tempdir))
-                self.pkgrecv(self.dpath1, "-d {0} -n -v \\*".format(self.tempdir))
-                expected = """\
+                    misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC),
+                )
+
+        # Fourth, create an image and verify that the sent package is
+        # seen by the client.
+        self.wait_repo(self.dpath2)
+        self.image_create(self.durl2, prefix="test1")
+        self.pkg("info -r bronze@2.0")
+
+        # Fifth, pkgrecv the pkg to a file repository and compare the
+        # manifest of a package published with the scheme (pkg:/) given.
+        f = fmri.PkgFmri(self.published[6], None)
+        npath = tempfile.mkdtemp(dir=self.test_root)
+        self.pkgsend(
+            "file://{0}".format(npath),
+            "create-repository --set-property publisher.prefix=test1",
+        )
+        self.pkgrecv(self.durl1, "-d file://{0} {1}".format(npath, f))
+
+        # Next, compare the manifests (this will also only succeed if
+        # the fmris are exactly the same including timestamp).
+        orepo = self.get_repo(self.dpath1)
+        nrepo = self.get_repo(npath)
+        old = orepo.manifest(f)
+        new = nrepo.manifest(f)
+
+        self.assertEqual(
+            misc.get_data_digest(old, hash_func=DEFAULT_HASH_FUNC),
+            misc.get_data_digest(new, hash_func=DEFAULT_HASH_FUNC),
+        )
+
+    def test_3_recursive(self):
+        """Verify that retrieving a package recursively will retrieve
+        its dependencies as well."""
+
+        bronze = fmri.PkgFmri(self.published[4], None)
+
+        # Retrieve bronze recursively to a directory, this should
+        # also retrieve its dependency: amber, and amber's dependency:
+        # tree.
+        self.pkgrecv(
+            self.durl1, "--raw -r -k -d {0} {1}".format(self.tempdir, bronze)
+        )
+
+        amber = fmri.PkgFmri(self.published[1], None)
+        tree = fmri.PkgFmri(self.published[5], None)
+
+        # Verify that the manifests for each package was retrieved.
+        for f in (amber, bronze, tree):
+            mpath = os.path.join(self.tempdir, f.get_dir_path(), "manifest")
+            self.assertTrue(os.path.isfile(mpath))
+
+        # Verify --mog-file option changes all package fmris into new
+        # publisher name. Also verify the manifest pkg.fmri value is
+        # changed correspondingly.
+        npath = tempfile.mkdtemp(dir=self.test_root)
+        self.create_repo(npath)
+        self.pkgrecv(
+            self.durl1,
+            "-r --mog-file {0} -d {1} {2}".format(
+                self.transforms["pub_change"], npath, bronze
+            ),
+        )
+        self.pkgrepo("verify -s {0}".format(npath))
+        self.pkgrepo("-s {0} list -F json".format(npath))
+        out_json = json.loads(self.output)
+        for elem in out_json:
+            self.assertTrue(
+                elem["publisher"] == "testpub" and "testpub" in elem["pkg.fmri"]
+            )
+            ma = self.__get_manifest_contents(
+                elem["pkg.fmri"], 0, pub="testpub", repo_path=npath
+            )
+            self.assertTrue("pkg://testpub/" in ma)
+
+        # Verify again with --raw option.
+        self.pkgrecv(
+            self.durl1,
+            "-r --raw --mog-file {0} -d {1} -v "
+            "{2}".format(self.transforms["pub_change"], npath, bronze),
+        )
+        xport, xport_cfg = transport.setup_transport()
+        xport_cfg.pkg_root = npath
+        pkgdir = xport_cfg.get_pkg_dir(bronze)
+        with open(os.path.join(pkgdir, "manifest")) as f:
+            mcontent = f.read()
+        self.assertTrue("testpub" in mcontent)
+        with open(os.path.join(os.path.join(pkgdir, "manifest.set"))) as f:
+            ms = f.read()
+        self.assertTrue("testpub" in ms)
+        pkgdir = xport_cfg.get_pkg_dir(amber)
+        with open(os.path.join(pkgdir, "manifest")) as f:
+            mcontent = f.read()
+        self.assertTrue("testpub" in mcontent)
+        with open(os.path.join(os.path.join(pkgdir, "manifest.set"))) as f:
+            ms = f.read()
+        self.assertTrue("testpub" in ms)
+
+        # Verify changing package name works.
+        npath2 = tempfile.mkdtemp(dir=self.test_root)
+        self.pkgrecv(
+            self.durl1,
+            "-r --raw --mog-file {0} -d {1} -v "
+            "{2}".format(self.transforms["name_change"], npath2, bronze),
+        )
+        xport, xport_cfg = transport.setup_transport()
+        xport_cfg.pkg_root = npath2
+        bronze = self.published[4]
+        # Assert old path does not exist
+        oldpath = xport_cfg.get_pkg_dir(fmri.PkgFmri(bronze))
+        self.assertTrue(not os.path.exists(oldpath))
+        self.assertTrue(not os.path.exists(os.path.dirname(oldpath)))
+        bronze = bronze.replace("bronze", "testname")
+        bronze = fmri.PkgFmri(bronze, None)
+        pkgdir = xport_cfg.get_pkg_dir(bronze)
+        with open(os.path.join(pkgdir, "manifest")) as f:
+            mcontent = f.read()
+        self.assertTrue("testname" in mcontent)
+        with open(os.path.join(os.path.join(pkgdir, "manifest.set"))) as f:
+            ms = f.read()
+        self.assertTrue("testname" in ms)
+
+        amber = self.published[1]
+        # Assert old path does not exist
+        oldpath = xport_cfg.get_pkg_dir(fmri.PkgFmri(amber))
+        self.assertTrue(not os.path.exists(oldpath))
+        self.assertTrue(not os.path.exists(os.path.dirname(oldpath)))
+        amber = amber.replace("amber", "testname")
+        amber = fmri.PkgFmri(amber, None)
+        pkgdir = xport_cfg.get_pkg_dir(amber)
+        with open(os.path.join(pkgdir, "manifest")) as f:
+            mcontent = f.read()
+        self.assertTrue("testname" in mcontent)
+        with open(os.path.join(os.path.join(pkgdir, "manifest.set"))) as f:
+            ms = f.read()
+        self.assertTrue("testname" in ms)
+
+    def test_4_timever(self):
+        """Verify that receiving with -m options work as expected."""
+
+        bronze10 = fmri.PkgFmri(self.published[2], None)
+        bronze20_1 = fmri.PkgFmri(self.published[3], None)
+        bronze20_2 = fmri.PkgFmri(self.published[4], None)
+
+        # Retrieve bronze using -m all-timestamps and a version pattern.
+        # This should only retrieve bronze20_1 and bronze20_2.
+        self.pkgrecv(
+            self.durl1,
+            "--raw -m all-timestamps -r -k "
+            "-d {0} {1}".format(self.tempdir, "/bronze@2.0"),
+        )
+
+        # Verify that only expected packages were retrieved.
+        expected = [
+            bronze20_1.get_dir_path(),
+            bronze20_2.get_dir_path(),
+        ]
+
+        for d in os.listdir(os.path.join(self.tempdir, "bronze")):
+            self.assertTrue(os.path.join("bronze", d) in expected)
+
+            mpath = os.path.join(self.tempdir, "bronze", d, "manifest")
+            self.assertTrue(os.path.isfile(mpath))
+
+        # Cleanup for next test.
+        shutil.rmtree(os.path.join(self.tempdir, "bronze"))
+
+        # Retrieve bronze using -m all-timestamps and a package stem.
+        # This should retrieve bronze10, bronze20_1, and bronze20_2.
+        self.pkgrecv(
+            self.durl1,
+            "--raw -m all-timestamps -r -k "
+            "-d {0} {1}".format(self.tempdir, "bronze"),
+        )
+
+        # Verify that only expected packages were retrieved.
+        expected = [
+            bronze10.get_dir_path(),
+            bronze20_1.get_dir_path(),
+            bronze20_2.get_dir_path(),
+        ]
+
+        for d in os.listdir(os.path.join(self.tempdir, "bronze")):
+            self.assertTrue(os.path.join("bronze", d) in expected)
+
+            mpath = os.path.join(self.tempdir, "bronze", d, "manifest")
+            self.assertTrue(os.path.isfile(mpath))
+
+        # Cleanup for next test.
+        shutil.rmtree(os.path.join(self.tempdir, "bronze"))
+
+        # Retrieve bronze using -m all-versions, this should only
+        # retrieve bronze10 and bronze20_2.
+        self.pkgrecv(
+            self.durl1,
+            "--raw -m all-versions -r -k "
+            "-d {0} {1}".format(self.tempdir, "bronze"),
+        )
+
+        # Verify that only expected packages were retrieved.
+        expected = [
+            bronze10.get_dir_path(),
+            bronze20_2.get_dir_path(),
+        ]
+
+        for d in os.listdir(os.path.join(self.tempdir, "bronze")):
+            self.assertTrue(os.path.join("bronze", d) in expected)
+
+            mpath = os.path.join(self.tempdir, "bronze", d, "manifest")
+            self.assertTrue(os.path.isfile(mpath))
+
+        # Cleanup for next test.
+        shutil.rmtree(os.path.join(self.tempdir, "bronze"))
+
+        # Retrieve bronze using -m latest, this should only
+        # retrieve bronze20_2.
+        self.pkgrecv(
+            self.durl1,
+            "--raw -m latest -r -k "
+            "-d {0} {1}".format(self.tempdir, "bronze"),
+        )
+
+        # Verify that only expected packages were retrieved.
+        expected = [
+            bronze20_2.get_dir_path(),
+        ]
+
+        for d in os.listdir(os.path.join(self.tempdir, "bronze")):
+            self.assertTrue(os.path.join("bronze", d) in expected)
+
+            mpath = os.path.join(self.tempdir, "bronze", d, "manifest")
+            self.assertTrue(os.path.isfile(mpath))
+
+        # Cleanup for next test.
+        shutil.rmtree(os.path.join(self.tempdir, "bronze"))
+
+        # Retrieve bronze using default setting.
+        # This should retrieve bronze10, bronze20_1, and bronze20_2.
+        self.pkgrecv(
+            self.durl1,
+            "--raw -r -k " "-d {0} {1}".format(self.tempdir, "bronze"),
+        )
+
+        # Verify that all expected packages were retrieved.
+        expected = [
+            bronze10.get_dir_path(),
+            bronze20_1.get_dir_path(),
+            bronze20_2.get_dir_path(),
+        ]
+
+        for d in expected:
+            paths = os.listdir(os.path.join(self.tempdir, "bronze"))
+            self.assertTrue(os.path.basename(d) in paths)
+
+            mpath = os.path.join(self.tempdir, d, "manifest")
+            self.assertTrue(os.path.isfile(mpath))
+
+    def test_5_recv_env(self):
+        """Verify that pkgrecv environment vars work as expected."""
+
+        f = fmri.PkgFmri(self.published[3], None)
+
+        os.environ["PKG_SRC"] = self.durl1
+        os.environ["PKG_DEST"] = self.tempdir
+
+        # First, retrieve the package.
+        self.pkgrecv(command="--raw {0}".format(f))
+
+        # Next, load the manifest.
+        basedir = os.path.join(self.tempdir, f.get_dir_path())
+        mpath = os.path.join(basedir, "manifest")
+
+        m = manifest.Manifest()
+        raw = open(mpath, "r").read()
+        m.set_content(raw)
+
+        # This is also the format pkgsend will expect for correct
+        # republishing.
+        ofile = open(os.devnull, "r")
+        for atype in ("file", "license"):
+            for a in m.gen_actions_by_type(atype):
+                if not hasattr(a, "hash"):
+                    continue
+
+                ifile = open(os.path.join(basedir, a.hash), "rb")
+
+                # Since the file shouldn't be compressed, this
+                # should return a zlib.error.
+                self.assertRaises(
+                    zlib.error,
+                    misc.gunzip_from_stream,
+                    ifile,
+                    ofile,
+                    ignore_hash=True,
+                )
+
+        for var in ("PKG_SRC", "PKG_DEST"):
+            del os.environ[var]
+
+    def test_6_recv_republish_preexisting(self):
+        f = fmri.PkgFmri(self.published[5], None)
+        f2 = fmri.PkgFmri(self.published[4], None)
+
+        # First, pkgrecv tree into a file repository
+        npath = tempfile.mkdtemp(dir=self.test_root)
+        self.pkgsend(
+            "file://{0}".format(npath),
+            "create-repository --set-property publisher.prefix=test1",
+        )
+        self.pkgrecv(self.durl1, "-d file://{0} {1}".format(npath, f))
+
+        # Next, recursively pkgrecv bronze2.0 into a file repository
+        # This would fail before behavior fixed to skip existing pkgs.
+        self.pkgrecv(self.durl1, "-r -d file://{0} {1}".format(npath, f2))
+
+        npath = tempfile.mkdtemp(dir=self.test_root)
+        self.pkgsend(
+            "file://{0}".format(npath),
+            "create-repository --set-property publisher.prefix=testpub",
+        )
+        # Verify by changing publisher name, the second time run also
+        # does not fail with existing package error.
+        self.pkgrecv(
+            self.durl1,
+            "--mog-file {0} -d file://{1} {2}".format(
+                self.transforms["pub_change"], npath, f
+            ),
+        )
+        self.pkgrecv(
+            self.durl1,
+            "--mog-file {0} -r -d file://{1} {2}".format(
+                self.transforms["pub_change"], npath, f2
+            ),
+        )
+
+    def test_7_recv_multipublisher(self):
+        """Verify that pkgrecv handles multi-publisher repositories as
+        expected."""
+
+        # Setup a repository with packages from multiple publishers.
+        amber = self.amber10.replace("open ", "open //test2/")
+        self.pkgsend_bulk(self.durl3, amber)
+        self.pkgrecv(
+            self.durl1, "-d {0} amber@1.0 bronze@1.0".format(self.durl3)
+        )
+
+        # Now attempt to receive from a repository with packages from
+        # multiple publishers and verify entry exists only for test1.
+        self.pkgrecv(self.durl3, "-d {0} bronze".format(self.durl4))
+        self.pkgrecv(self.durl3, "--newest")
+        self.assertNotEqual(self.output.find("test1/bronze"), -1)
+        self.assertEqual(self.output.find("test2/bronze"), -1)
+
+        # Now retrieve amber, and verify entries exist for both pubs.
+        self.wait_repo(self.dcs[4].get_repodir())
+        self.wait_repo(self.dcs[3].get_repodir())
+        self.pkgrecv(self.durl3, "-d {0} amber".format(self.durl4))
+        self.pkgrecv(self.durl4, "--newest")
+        self.assertNotEqual(self.output.find("test1/amber"), -1)
+        self.assertNotEqual(self.output.find("test2/amber"), -1)
+
+        # Test using --mog-file to change publishers of packages from
+        # multiple publishers.
+        npath = tempfile.mkdtemp(dir=self.test_root)
+        self.create_repo(npath)
+        self.pkgrecv(
+            self.durl1,
+            "--mog-file {0} -d {1} amber@1.0 "
+            "bronze@1.0".format(self.transforms["pub_change"], npath),
+        )
+        self.pkgrepo("verify -s {0} --disable dependency".format(npath))
+        self.pkgrepo("-s {0} list -F json".format(npath))
+        out_json = json.loads(self.output)
+        for elem in out_json:
+            self.assertTrue(
+                elem["publisher"] == "testpub" and "testpub" in elem["pkg.fmri"]
+            )
+            ma = self.__get_manifest_contents(
+                elem["pkg.fmri"], 0, pub="testpub", repo_path=npath
+            )
+            self.assertTrue("pkg://testpub/" in ma)
+
+        # Verify attempting to retrieve a non-existent package fails
+        # for a multi-publisher repository.
+        self.pkgrecv(
+            self.durl3, "-d {0} nosuchpackage".format(self.durl4), exit=1
+        )
+
+    def test_8_archive(self):
+        """Verify that pkgrecv handles package archives as expected."""
+
+        # Setup a repository with packages from multiple publishers.
+        amber = self.amber10.replace("open ", "open pkg://test2/")
+        t2_amber10 = self.pkgsend_bulk(self.durl3, amber)[0]
+        self.pkgrecv(
+            self.durl1, "-d {0} amber@1.0 bronze@1.0".format(self.durl3)
+        )
+
+        # Now attempt to receive from a repository to a package archive.
+        arc_path = os.path.join(self.test_root, "test.p5p")
+        self.pkgrecv(self.durl3, "-a -d {0} \\*".format(arc_path))
+
+        #
+        # Verify that the archive can be opened and the expected
+        # packages are inside.
+        #
+        amber10 = self.published[0]
+        bronze10 = self.published[2]
+        arc = p5p.Archive(arc_path, mode="r")
+
+        # Check for expected publishers.
+        expected = ["test1", "test2"]
+        pubs = sorted(set(p.prefix for p in arc.get_publishers()))
+        self.assertEqualDiff(expected, pubs)
+
+        # Check for expected package FMRIs.
+        expected = set([amber10, t2_amber10, bronze10])
+        tmpdir = tempfile.mkdtemp(dir=self.test_root)
+        returned = []
+        for pfx in pubs:
+            catdir = os.path.join(tmpdir, pfx)
+            os.mkdir(catdir)
+            for part in ("catalog.attrs", "catalog.base.C"):
+                arc.extract_catalog1(part, catdir, pfx)
+
+            cat = catalog.Catalog(meta_root=catdir, read_only=True)
+            returned.extend(str(f) for f in cat.fmris())
+        self.assertEqualDiff(expected, set(returned))
+        arc.close()
+        shutil.rmtree(tmpdir)
+
+        #
+        # Verify that packages can be received from an archive to an
+        # archive.
+        #
+        arc2_path = os.path.join(self.test_root, "test2.p5p")
+        self.pkgrecv(arc_path, "-a -d {0} pkg://test2/amber".format(arc2_path))
+
+        # Check for expected publishers.
+        arc = p5p.Archive(arc2_path, mode="r")
+        expected = set(["test2"])
+        pubs = set(p.prefix for p in arc.get_publishers())
+        self.assertEqualDiff(expected, pubs)
+
+        # Check for expected package FMRIs.
+        expected = set([t2_amber10])
+        tmpdir = tempfile.mkdtemp(dir=self.test_root)
+        returned = []
+        for pfx in pubs:
+            catdir = os.path.join(tmpdir, pfx)
+            os.mkdir(catdir)
+            for part in ("catalog.attrs", "catalog.base.C"):
+                arc.extract_catalog1(part, catdir, pfx)
+
+            cat = catalog.Catalog(meta_root=catdir, read_only=True)
+            returned.extend(str(f) for f in cat.fmris())
+        self.assertEqualDiff(expected, set(returned))
+        arc.close()
+
+        #
+        # Verify that pkgrecv gracefully fails if archive already
+        # exists.
+        #
+        self.pkgrecv(arc_path, "-d {0} \\*".format(arc2_path), exit=1)
+
+        #
+        # Verify that packages can be received from an archive to
+        # a repository.
+        #
+        self.pkgrecv(arc_path, "--newest")
+        self.pkgrecv(
+            arc_path, "-d {0} pkg://test2/amber bronze".format(self.durl4)
+        )
+        self.wait_repo(self.dcs[4].get_repodir())
+        repo = self.dcs[4].get_repo()
+        self.pkgrecv(repo.root, "--newest")
+
+        # Check for expected publishers.
+        expected = ["test1", "test2"]
+        pubs = sorted(repo.publishers)
+        self.assertEqualDiff(expected, pubs)
+
+        # Check for expected package FMRIs.
+        expected = sorted([t2_amber10, bronze10])
+        returned = []
+        for pfx in repo.publishers:
+            cat = repo.get_catalog(pub=pfx)
+            returned.extend(str(f) for f in cat.fmris())
+        self.assertEqualDiff(expected, sorted(returned))
+
+        # Attempt a dry-run to receive a package archive.
+        # We should not have the archive created in this case.
+        arc_path = os.path.join(self.test_root, "dry-run.p5p")
+        self.pkgrecv(self.durl3, "-n -a -d {0} \\*".format(arc_path))
+        self.assertFalse(os.path.exists(arc_path))
+
+        #
+        # Verify that packages can be received from an archive to an
+        # archive.
+        #
+        arc_mog_path = os.path.join(self.test_root, "test_mog.p5p")
+        self.pkgrecv(
+            self.durl1,
+            "-a --mog-file {0} --mog-file {1} "
+            "-d {2} bronze@1".format(
+                self.transforms["drop_file"],
+                self.transforms["pub_change"],
+                arc_mog_path,
+            ),
+        )
+
+        # Check for expected publishers.
+        arc = p5p.Archive(arc_mog_path, mode="r")
+        expected = set(["testpub"])
+        pubs = set(p.prefix for p in arc.get_publishers())
+        self.assertEqualDiff(expected, pubs)
+
+        # Check for expected package FMRIs.
+        bronze = self.published[2]
+        bronze = bronze.replace("test1", "testpub")
+        expected = set([bronze])
+        tmpdir = tempfile.mkdtemp(dir=self.test_root)
+        returned = []
+        for pfx in pubs:
+            catdir = os.path.join(tmpdir, pfx)
+            os.mkdir(catdir)
+            for part in ("catalog.attrs", "catalog.base.C"):
+                arc.extract_catalog1(part, catdir, pfx)
+
+            cat = catalog.Catalog(meta_root=catdir, read_only=True)
+            returned.extend(str(f) for f in cat.fmris())
+            fileObjs = []
+            allcontents = ""
+            for idx in arc.get_index():
+                tarf = arc.get_file(idx)
+                if tarf:
+                    fileObjs.append(tarf)
+                    allcontents += str(tarf.readlines())
+            # 3 files + 1 license + 1 manifest +
+            # 1 repo configuration.
+            self.assertTrue(len(fileObjs) == 6)
+            # etc/bronze1 has been dropped.
+            self.assertTrue("etc/bronze1" not in allcontents)
+        self.assertEqualDiff(expected, set(returned))
+        arc.close()
+
+    def test_9_dryruns(self):
+        """Test that the dry run option to pkgrecv works as expected."""
+
+        f = fmri.PkgFmri(self.published[3], None)
+
+        rpth = tempfile.mkdtemp(dir=self.test_root)
+        self.pkgrepo("create {0}".format(rpth))
+        expected = ["pkg5.repository"]
+        self.pkgrecv(self.durl1, "-n -d {0} {1}".format(rpth, f))
+        self.assertEqualDiff(expected, os.listdir(rpth))
+
+        self.pkgrecv(self.durl1, "-r -n -d {0} {1}".format(rpth, f))
+        self.assertEqualDiff(expected, os.listdir(rpth))
+
+        self.pkgrecv(self.durl1, "--clone -n -p '*' -d {0}".format(rpth))
+        self.assertEqualDiff(expected, os.listdir(rpth))
+
+        arc_path = os.path.join(self.test_root, "test.p5p")
+        self.pkgrecv(self.durl1, "-a -n -d {0} \\*".format(arc_path))
+        self.assertTrue(not os.path.exists(arc_path))
+
+        # --raw actually populates the destination with manifests even
+        # with -n, so just check that it exits 0.
+        self.pkgrecv(self.durl1, "--raw -n -d {0} {1}".format(self.tempdir, f))
+
+        # --raw actually populates the destination with manifests even
+        # with -n, so just check that it exits 0.
+        self.pkgrecv(
+            self.durl1, "--raw -r -n -d {0} {1}".format(self.tempdir, f)
+        )
+
+    def test_10_unsupported_actions(self):
+        """Test that pkgrecv skips packages with actions it can't
+        understand, processes those it can, and exits with appropriate
+        exit codes."""
+
+        def __count_pulled_packages(pth):
+            self.pkgrepo("list -F tsv -H -s {0}".format(pth))
+            return len(self.output.splitlines())
+
+        def __check_errout(pfmri):
+            s1 = "in package '{0}'".format(pfmri)
+            self.assertTrue(s1 in self.errout, "{0} not in error".format(pfmri))
+
+        def __empty_repo(uri, arg_string):
+            if uri.startswith("http://"):
+                rurl = self.dcs[4].get_repo_url()
+                self.pkgrepo("remove -s {0} '*'".format(rurl))
+                # Refresh the depot to get it to realize that
+                # the catalog has changed.
+                self.dcs[4].refresh()
+            elif arg_string:
+                portable.remove(uri)
+            else:
+                self.pkgrepo("remove -s {0} '*'".format(uri))
+
+        def __test_rec(duri, arg_string, pfmris):
+            self.debug("\n\nNow pkgrecv'ing to {0}".format(duri))
+
+            # It's necessary to use the -D option below because
+            # otherwise pkgrecv will fail because the manifest
+            # doesn't validate.
+
+            novalidate = "-D manifest_validate=Never "
+            # Check that invalid action attributes don't cause
+            # tracebacks.
+            self.pkgrecv(
+                self.durl1,
+                novalidate
+                + "-d {0} {1} {2}".format(duri, arg_string, " ".join(pfmris)),
+                exit=pkgdefs.EXIT_OOPS,
+            )
+            for pfmri in pfmris:
+                __check_errout(pfmri)
+            self.assertEqual(__count_pulled_packages(duri), 0)
+            if arg_string:
+                portable.remove(duri)
+
+            self.pkgrecv(
+                self.rurl1,
+                novalidate
+                + "-d {0} {1} {2}".format(duri, arg_string, " ".join(pfmris)),
+                exit=pkgdefs.EXIT_OOPS,
+            )
+            for pfmri in pfmris:
+                __check_errout(pfmri)
+            self.assertEqual(__count_pulled_packages(duri), 0)
+            if arg_string:
+                portable.remove(duri)
+
+            # Check that other packages are retrieved and the exit
+            # code reflects partial success.
+            self.pkgrecv(
+                self.durl1,
+                novalidate
+                + "-d {0} {1} -m all-timestamps '*'".format(duri, arg_string),
+                exit=pkgdefs.EXIT_PARTIAL,
+            )
+            for pfmri in pfmris:
+                __check_errout(pfmri)
+            self.assertEqual(
+                __count_pulled_packages(duri), len(self.published) - len(pfmris)
+            )
+            __empty_repo(duri, arg_string)
+
+            self.pkgrecv(
+                self.rurl1,
+                novalidate
+                + "-d {0} {1} -m all-timestamps '*'".format(duri, arg_string),
+                exit=pkgdefs.EXIT_PARTIAL,
+            )
+            for pfmri in pfmris:
+                __check_errout(pfmri)
+            self.assertEqual(
+                __count_pulled_packages(duri), len(self.published) - len(pfmris)
+            )
+            __empty_repo(duri, arg_string)
+
+        self.rurl1 = self.dcs[1].get_repo_url()
+        repo = self.dcs[1].get_repo()
+        rd = repo.get_pub_rstore()
+        pfmri = fmri.PkgFmri(self.published[4])
+        mp = rd.manifest(pfmri)
+
+        with open(mp, "r") as fh:
+            original_txt = fh.read()
+        txt = original_txt.replace("type=require", "type=foo")
+        with open(mp, "w") as fh:
+            fh.write(txt)
+
+        rpth = tempfile.mkdtemp(dir=self.test_root)
+        self.pkgrepo("create {0}".format(rpth))
+        adir = tempfile.mkdtemp(dir=self.test_root)
+
+        # The __empty repo function above assumes that the only http uri
+        # used is the one for depot number 4.
+        dest_uris = (
+            (rpth, ""),
+            (self.durl4, ""),
+            (os.path.join(adir, "archive.p5p"), "-a"),
+        )
+        for duri, arg_string in dest_uris:
+            __test_rec(duri, arg_string, [self.published[4]])
+
+        # Test that multiple packages failing are handled correctly.
+        for i in range(5, 7):
+            pfmri = fmri.PkgFmri(self.published[i])
+            mp = rd.manifest(pfmri)
+            with open(mp, "r") as fh:
+                original_txt = fh.read()
+            txt = "foop\n" + original_txt
+            with open(mp, "w") as fh:
+                fh.write(txt)
+
+        for (
+            duri,
+            arg_string,
+        ) in dest_uris:
+            __test_rec(duri, arg_string, self.published[4:7])
+
+    def test_11_clone(self):
+        """Verify that pkgrecv handles cloning repos as expected."""
+        # Test basic operation of cloning repo which contains one
+        # publisher to repo which contains same publisher
+        self.pkgrecv(self.durl1, "--clone -d {0}".format(self.dpath2))
+
+        ret = subprocess.call(
+            [
+                "/usr/bin/gdiff",
+                "-Naur",
+                "-x",
+                "index",
+                "-x",
+                "trans",
+                self.dpath1,
+                self.dpath2,
+            ]
+        )
+        self.assertTrue(ret == 0)
+
+        # Test that packages in dst which are not in src get removed.
+        self.pkgsend_bulk(self.durl2, (self.amber30))
+        self.pkgrecv(self.durl1, "--clone -d {0}".format(self.dpath2))
+        ret = subprocess.call(
+            [
+                "/usr/bin/gdiff",
+                "-Naur",
+                "-x",
+                "index",
+                "-x",
+                "trans",
+                self.dpath1,
+                self.dpath2,
+            ]
+        )
+        self.assertTrue(ret == 0)
+
+        # Test that clone reports publishers not in the dest repo.
+        amber = self.amber10.replace("open ", "open pkg://test2/")
+        self.pkgsend_bulk(self.durl1, amber)
+        self.pkgrecv(self.durl1, "--clone -d {0}".format(self.dpath2), exit=1)
+
+        # Test that clone adds new publishers if requested.
+        amber = self.amber10.replace("open ", "open pkg://test2/")
+        self.pkgsend_bulk(self.durl1, amber)
+        self.pkgrecv(self.durl1, "--clone -d {0} -p test2".format(self.dpath2))
+        ret = subprocess.call(
+            [
+                "/usr/bin/gdiff",
+                "-Naur",
+                "-x",
+                "index",
+                "-x",
+                "trans",
+                self.dpath1,
+                self.dpath2,
+            ]
+        )
+        self.assertTrue(ret == 0)
+
+        # Test that clone removes all packages if source is empty
+        self.pkgrecv(self.durl3, "--clone -d {0}".format(self.dpath2))
+        self.pkgrepo("-s {0} list -H -p test2".format(self.dpath2))
+        self.assertEqualDiff("", self.output)
+
+        # Test that clone works fine with mulitple publishers
+        amber = self.amber10.replace("open ", "open pkg://test2/")
+        self.pkgsend_bulk(self.durl1, amber)
+
+        path = os.path.join(self.dpath2, "publisher/test1")
+        shutil.rmtree(path)
+        path = os.path.join(self.dpath2, "publisher/test2")
+        shutil.rmtree(path)
+        self.pkgrecv(
+            self.durl1, "--clone -d {0} -p test2 -p test1".format(self.dpath2)
+        )
+        ret = subprocess.call(
+            [
+                "/usr/bin/gdiff",
+                "-Naur",
+                "-x",
+                "index",
+                "-x",
+                "trans",
+                self.dpath1,
+                self.dpath2,
+            ]
+        )
+        self.assertTrue(ret == 0)
+
+        # Test that clone fails if --raw is specified.
+        self.pkgrecv(
+            self.durl1,
+            "--raw --clone -d {0} -p test2".format(self.dpath2),
+            exit=2,
+        )
+
+        # Test that clone fails if -c is specified.
+        self.pkgrecv(
+            self.durl1,
+            "-c /tmp/ --clone -d {0} -p test2".format(self.dpath2),
+            exit=2,
+        )
+
+        # Test that clone fails if -a is specified.
+        self.pkgrecv(
+            self.durl1, "-a --clone -d {0} -p test2".format(self.dpath2), exit=2
+        )
+
+        # Test that clone fails if --newest is specified.
+        self.pkgrecv(
+            self.durl1,
+            "--newest --clone -d {0} -p test2".format(self.dpath2),
+            exit=2,
+        )
+
+    def test_12_multihash(self):
+        """Tests that we can recv to and from repositories with
+        multi-hash support, interoperating with repositories without
+        multi-hash support."""
+        if sha512_supported:
+            self.base_12_multihash("sha256")
+        else:
+            self.base_12_multihash("sha512t_256")
+
+    def base_12_multihash(self, hash_alg):
+        f = fmri.PkgFmri(self.published[3], None)
+        # We create an image simply so we can use "contents -g" to
+        # inspect the repository.
+        self.image_create()
+
+        # First, recv the package and verify it has no extended hashes
+        self.pkgrecv(self.durl1, "-d {0} {1}".format(self.durl3, f))
+        self.pkg("contents -g {0} -m {1}".format(self.durl3, f))
+        self.assertTrue(
+            "pkg.content-hash=file:{0}".format(hash_alg) not in self.output
+        )
+
+        # Now stop and start the repository as multi-hash aware, and
+        # recv it again, making sure that we do not get multiple hashes
+        # added (because modifying the manifest would break signatures)
+        self.dcs[3].stop()
+        self.dcs[3].set_debug_feature("hash=sha1+{0}".format(hash_alg))
+        self.dcs[3].start()
+        self.pkgrecv(self.durl1, "-d {0} {1}".format(self.durl3, f))
+        self.pkg("contents -g {0} -m {1}".format(self.durl3, f))
+        self.assertTrue(
+            "pkg.content-hash=file:{0}".format(hash_alg) not in self.output
+        )
+
+        # Now check the reverse - that a package with multiple hashes
+        # can be received into a repository that is not multi-hash aware
+        b = "bronze@1.0,5.11-0"
+        self.pkgsend_bulk(
+            self.durl3, self.bronze10, debug_hash="sha1+{0}".format(hash_alg)
+        )
+        self.pkg("contents -g {0} -m {1}".format(self.durl3, b))
+        self.assertTrue(
+            "pkg.content-hash=file:{0}".format(hash_alg) in self.output
+        )
+        self.pkgrecv(self.durl3, "-d {0} {1}".format(self.durl4, b))
+        self.pkg("contents -g {0} -m {1}".format(self.durl4, b))
+        self.assertTrue(
+            "pkg.content-hash=file:{0}".format(hash_alg) in self.output
+        )
+
+        # Ensure that we can recv multi-hash packages into p5p files
+        p5p_path = os.path.join(
+            self.test_root, "multi-hash-{0}.p5p".format(hash_alg)
+        )
+        self.pkgrecv(self.durl3, "-ad {0} {1}".format(p5p_path, b))
+        self.pkg("contents -g {0} -m {1}".format(p5p_path, b))
+        self.assertTrue(
+            "pkg.content-hash=file:{0}".format(hash_alg) in self.output
+        )
+
+        # Finally, stop and start our scratch repository to clear the
+        # debug feature. If this doesn't happen because we've failed
+        # before now, it's not the end of the world.
+        self.dcs[3].stop()
+        self.dcs[3].unset_debug_feature("hash=sha1+{0}".format(hash_alg))
+        self.dcs[3].start()
+
+    def test_13_output(self):
+        """Verify that pkgrecv handles verbose output as expected."""
+
+        # Now attempt to receive from a repository.
+        self.pkgrepo("create {0}".format(self.tempdir))
+        self.pkgrecv(self.dpath1, "-d {0} -n -v \\*".format(self.tempdir))
+        expected = """\
 Retrieving packages (dry-run) ...
         Packages to add:       9
       Files to retrieve:      19
 Estimated transfer size: 3.17 kB
 """
-                self.assertTrue(expected in self.output, self.output)
-                for s in self.published:
-                        self.assertTrue(fmri.PkgFmri(s).get_fmri(anarchy=True,
-                            include_scheme=False) in self.output)
+        self.assertTrue(expected in self.output, self.output)
+        for s in self.published:
+            self.assertTrue(
+                fmri.PkgFmri(s).get_fmri(anarchy=True, include_scheme=False)
+                in self.output
+            )
 
-                # Clean up for next test.
-                shutil.rmtree(self.tempdir)
+        # Clean up for next test.
+        shutil.rmtree(self.tempdir)
 
-                # Now attempt to receive from a repository to a package archive.
-                self.pkgrecv(self.dpath1, "-a -d {0} -n -v \\*".format(self.tempdir))
-                expected = """\
+        # Now attempt to receive from a repository to a package archive.
+        self.pkgrecv(self.dpath1, "-a -d {0} -n -v \\*".format(self.tempdir))
+        expected = """\
 Archiving packages (dry-run) ...
         Packages to add:       9
       Files to retrieve:      19
 Estimated transfer size: 3.17 kB
 """
-                self.assertTrue(expected in self.output, self.output)
-                for s in self.published:
-                        self.assertTrue(fmri.PkgFmri(s).get_fmri(anarchy=True,
-                            include_scheme=False) in self.output)
+        self.assertTrue(expected in self.output, self.output)
+        for s in self.published:
+            self.assertTrue(
+                fmri.PkgFmri(s).get_fmri(anarchy=True, include_scheme=False)
+                in self.output
+            )
 
-                # Now attempt to clone a repository.
-                self.pkgrepo("create {0}".format(self.tempdir))
-                self.pkgrecv(self.dpath1, "--clone -d {0} -p \\* -n -v" \
-                   .format(self.tempdir))
-                expected = """\
+        # Now attempt to clone a repository.
+        self.pkgrepo("create {0}".format(self.tempdir))
+        self.pkgrecv(
+            self.dpath1, "--clone -d {0} -p \\* -n -v".format(self.tempdir)
+        )
+        expected = """\
 Retrieving packages (dry-run) ...
         Packages to add:       9
       Files to retrieve:      19
 Estimated transfer size: 3.17 kB
 """
-                self.assertTrue(expected in self.output, self.output)
-                for s in self.published:
-                        self.assertTrue(fmri.PkgFmri(s).get_fmri(anarchy=True,
-                            include_scheme=False) in self.output)
+        self.assertTrue(expected in self.output, self.output)
+        for s in self.published:
+            self.assertTrue(
+                fmri.PkgFmri(s).get_fmri(anarchy=True, include_scheme=False)
+                in self.output
+            )
 
-                # Verify mogrify works by retrieving mogrified pkgs from the
-                # new target catalog.
-                self.pkgrecv(self.dpath1, "--mog-file {0} -d {1} -v \\*".format(
-                    self.transforms["pub_change"], self.tempdir))
-                self.assertTrue("target catalog 'testpub'" in self.output)
-                self.pkgrepo("verify -s {0}".format(self.tempdir))
+        # Verify mogrify works by retrieving mogrified pkgs from the
+        # new target catalog.
+        self.pkgrecv(
+            self.dpath1,
+            "--mog-file {0} -d {1} -v \\*".format(
+                self.transforms["pub_change"], self.tempdir
+            ),
+        )
+        self.assertTrue("target catalog 'testpub'" in self.output)
+        self.pkgrepo("verify -s {0}".format(self.tempdir))
 
-                # Test that output is correct if -n is not specified.
-                self.pkgrecv(self.dpath1, "-d {0} -v \\*".format(self.tempdir))
-                self.assertTrue("dry-run" not in self.output)
+        # Test that output is correct if -n is not specified.
+        self.pkgrecv(self.dpath1, "-d {0} -v \\*".format(self.tempdir))
+        self.assertTrue("dry-run" not in self.output)
 
-        def test_14_mog_manifest(self):
-                """Mogrify some contents in the manifest, and verify
-                republish behaviour."""
+    def test_14_mog_manifest(self):
+        """Mogrify some contents in the manifest, and verify
+        republish behaviour."""
 
-                # Test with add an invalid action will fail.
-                rpth = tempfile.mkdtemp(dir=self.test_root)
-                self.pkgrecv(self.durl5, "--mog-file {0} -d {1} -v filetrans1"
-                    .format(self.transforms["add_invalid_act"], self.durl6),
-                    exit=1)
-                self.pkgrecv(self.durl5, "--raw --mog-file {0} -d {1} "
-                    "-v filetrans1".format(self.transforms["add_invalid_act"],
-                    rpth), exit=1)
+        # Test with add an invalid action will fail.
+        rpth = tempfile.mkdtemp(dir=self.test_root)
+        self.pkgrecv(
+            self.durl5,
+            "--mog-file {0} -d {1} -v filetrans1".format(
+                self.transforms["add_invalid_act"], self.durl6
+            ),
+            exit=1,
+        )
+        self.pkgrecv(
+            self.durl5,
+            "--raw --mog-file {0} -d {1} "
+            "-v filetrans1".format(self.transforms["add_invalid_act"], rpth),
+            exit=1,
+        )
 
-                # Test add a depend action without fmri attribute will fail.
-                self.pkgrecv(self.durl5, "--mog-file {0} -d {1} -v filetrans1"
-                    .format(self.transforms["add_invalid_act2"], self.durl6),
-                    exit=1)
-                self.pkgrecv(self.durl5, "--raw --mog-file {0} -d {1} "
-                    "-v filetrans1".format(self.transforms["add_invalid_act2"],
-                    rpth), exit=1)
+        # Test add a depend action without fmri attribute will fail.
+        self.pkgrecv(
+            self.durl5,
+            "--mog-file {0} -d {1} -v filetrans1".format(
+                self.transforms["add_invalid_act2"], self.durl6
+            ),
+            exit=1,
+        )
+        self.pkgrecv(
+            self.durl5,
+            "--raw --mog-file {0} -d {1} "
+            "-v filetrans1".format(self.transforms["add_invalid_act2"], rpth),
+            exit=1,
+        )
 
-                # Test add a depend action with invalid fmri attribute will
-                # fail.
-                self.pkgrecv(self.durl5, "--mog-file {0} -d {1} -v filetrans1"
-                    .format(self.transforms["add_invalid_act3"], self.durl6),
-                    exit=1)
-                self.pkgrecv(self.durl5, "--raw --mog-file {0} -d {1} -v "
-                    "filetrans1".format(self.transforms["add_invalid_act3"],
-                    rpth), exit=1)
+        # Test add a depend action with invalid fmri attribute will
+        # fail.
+        self.pkgrecv(
+            self.durl5,
+            "--mog-file {0} -d {1} -v filetrans1".format(
+                self.transforms["add_invalid_act3"], self.durl6
+            ),
+            exit=1,
+        )
+        self.pkgrecv(
+            self.durl5,
+            "--raw --mog-file {0} -d {1} -v "
+            "filetrans1".format(self.transforms["add_invalid_act3"], rpth),
+            exit=1,
+        )
 
-                # Test with adding a non-existing file will fail.
-                self.pkgrecv(self.durl5, "--mog-file {0} -d {1} -v filetrans1"
-                    .format(self.transforms["add_none_file"], self.durl6),
-                    exit=1)
-                self.pkgrecv(self.durl5, "--raw --mog-file {0} -d {1} -v "
-                    "filetrans1".format(self.transforms["add_none_file"],
-                    rpth), exit=1)
-                self.assertTrue("not allowed" in self.errout)
+        # Test with adding a non-existing file will fail.
+        self.pkgrecv(
+            self.durl5,
+            "--mog-file {0} -d {1} -v filetrans1".format(
+                self.transforms["add_none_file"], self.durl6
+            ),
+            exit=1,
+        )
+        self.pkgrecv(
+            self.durl5,
+            "--raw --mog-file {0} -d {1} -v "
+            "filetrans1".format(self.transforms["add_none_file"], rpth),
+            exit=1,
+        )
+        self.assertTrue("not allowed" in self.errout)
 
-                # Test with adding an additional existing file
-                # (hashable content) should fail.
-                self.pkgrecv(self.durl5, "--mog-file {0} -d {1} -v filetrans1"
-                    .format(self.transforms["add_file"], self.durl6), exit=1)
-                self.assertTrue("not allowed" in self.errout)
+        # Test with adding an additional existing file
+        # (hashable content) should fail.
+        self.pkgrecv(
+            self.durl5,
+            "--mog-file {0} -d {1} -v filetrans1".format(
+                self.transforms["add_file"], self.durl6
+            ),
+            exit=1,
+        )
+        self.assertTrue("not allowed" in self.errout)
 
-                # Test with adding an depend action should succeed.
-                self.pkgrecv(self.durl5, "--mog-file {0} -d {1} -v filetrans1"
-                    .format(self.transforms["add_valid_act"], self.durl6))
-                self.pkgrecv(self.durl5, "--raw --mog-file {0} -d {1} -v "
-                    "filetrans1".format(self.transforms["add_valid_act"],
-                    self.dpath6))
-                xport, xport_cfg = transport.setup_transport()
-                xport_cfg.pkg_root = self.dpath6
-                pkgdir = xport_cfg.get_pkg_dir(fmri.PkgFmri(
-                    self.test_mog[0]))
-                with open(os.path.join(pkgdir, "manifest")) as f:
-                        mcontent = f.read()
-                self.assertTrue("depend" in mcontent)
-                self.assertTrue(os.path.exists(os.path.join(pkgdir,
-                    "manifest.depend")))
+        # Test with adding an depend action should succeed.
+        self.pkgrecv(
+            self.durl5,
+            "--mog-file {0} -d {1} -v filetrans1".format(
+                self.transforms["add_valid_act"], self.durl6
+            ),
+        )
+        self.pkgrecv(
+            self.durl5,
+            "--raw --mog-file {0} -d {1} -v "
+            "filetrans1".format(self.transforms["add_valid_act"], self.dpath6),
+        )
+        xport, xport_cfg = transport.setup_transport()
+        xport_cfg.pkg_root = self.dpath6
+        pkgdir = xport_cfg.get_pkg_dir(fmri.PkgFmri(self.test_mog[0]))
+        with open(os.path.join(pkgdir, "manifest")) as f:
+            mcontent = f.read()
+        self.assertTrue("depend" in mcontent)
+        self.assertTrue(os.path.exists(os.path.join(pkgdir, "manifest.depend")))
 
-                # Drop the file.
-                self.pkgrecv(self.durl5, "--mog-file {0} -d {1} filetrans2"
-                    .format(self.transforms["drop_file"], self.durl6))
-                self.pkgrecv(self.durl5, "-v --raw --mog-file {0} -d {1} "
-                    "filetrans4".format(self.transforms["drop_file"],
-                    self.dpath6))
-                pkgdir = xport_cfg.get_pkg_dir(fmri.PkgFmri(
-                    self.test_mog[3]))
-                with open(os.path.join(pkgdir, "manifest")) as f:
-                        mcontent = f.read()
-                self.assertTrue("path" not in mcontent)
-                self.assertTrue(not os.path.exists(os.path.join(pkgdir,
-                    "manifest.file")))
+        # Drop the file.
+        self.pkgrecv(
+            self.durl5,
+            "--mog-file {0} -d {1} filetrans2".format(
+                self.transforms["drop_file"], self.durl6
+            ),
+        )
+        self.pkgrecv(
+            self.durl5,
+            "-v --raw --mog-file {0} -d {1} "
+            "filetrans4".format(self.transforms["drop_file"], self.dpath6),
+        )
+        pkgdir = xport_cfg.get_pkg_dir(fmri.PkgFmri(self.test_mog[3]))
+        with open(os.path.join(pkgdir, "manifest")) as f:
+            mcontent = f.read()
+        self.assertTrue("path" not in mcontent)
+        self.assertTrue(
+            not os.path.exists(os.path.join(pkgdir, "manifest.file"))
+        )
 
-                # With -v.
-                self.pkgrecv(self.durl5, "--mog-file {0} -d {1} -v filetrans2"
-                    .format(self.transforms["drop_file"], self.durl6))
-                self.pkgrepo("-s {0} list -F json filetrans2".format(
-                    self.dpath6))
-                out_json = json.loads(self.output)
-                elem = out_json[0]
-                ma = self.__get_manifest_contents(elem["pkg.fmri"], 6,
-                    pub="test1")
-                self.assertTrue("etc/bronze1" not in ma)
+        # With -v.
+        self.pkgrecv(
+            self.durl5,
+            "--mog-file {0} -d {1} -v filetrans2".format(
+                self.transforms["drop_file"], self.durl6
+            ),
+        )
+        self.pkgrepo("-s {0} list -F json filetrans2".format(self.dpath6))
+        out_json = json.loads(self.output)
+        elem = out_json[0]
+        ma = self.__get_manifest_contents(elem["pkg.fmri"], 6, pub="test1")
+        self.assertTrue("etc/bronze1" not in ma)
 
-                # Change file path attribute.
-                self.pkgrecv(self.durl5, "--mog-file {0} -d {1} -v filetrans3"
-                    .format(self.transforms["file_path_change"], self.durl6))
-                self.pkgrepo("-s {0} list -F json filetrans3".format(
-                    self.dpath6))
-                out_json = json.loads(self.output)
-                elem = out_json[0]
-                ma = self.__get_manifest_contents(elem["pkg.fmri"], 6,
-                    pub="test1")
-                self.assertTrue("opt/bronze2" in ma)
-                self.pkgrepo("verify -s {0} --disable dependency"
-                    .format(self.dpath6))
+        # Change file path attribute.
+        self.pkgrecv(
+            self.durl5,
+            "--mog-file {0} -d {1} -v filetrans3".format(
+                self.transforms["file_path_change"], self.durl6
+            ),
+        )
+        self.pkgrepo("-s {0} list -F json filetrans3".format(self.dpath6))
+        out_json = json.loads(self.output)
+        elem = out_json[0]
+        ma = self.__get_manifest_contents(elem["pkg.fmri"], 6, pub="test1")
+        self.assertTrue("opt/bronze2" in ma)
+        self.pkgrepo("verify -s {0} --disable dependency".format(self.dpath6))
 
-                self.pkgrecv(self.durl5, "--raw --mog-file {0} -d {1} -v "
-                    "filetrans3".format(self.transforms["file_path_change"],
-                    self.dpath6))
-                pkgdir = xport_cfg.get_pkg_dir(fmri.PkgFmri(
-                    self.test_mog[2]))
-                with open(os.path.join(pkgdir, "manifest")) as f:
-                        mcontent = f.read()
-                self.assertTrue("opt/bronze2" in mcontent)
-                self.assertTrue(os.path.exists(os.path.join(pkgdir,
-                    "manifest.file")))
-                with open(os.path.join(pkgdir, "manifest.file")) as f:
-                        mf = f.read()
-                self.assertTrue("opt/bronze2" in mf)
+        self.pkgrecv(
+            self.durl5,
+            "--raw --mog-file {0} -d {1} -v "
+            "filetrans3".format(
+                self.transforms["file_path_change"], self.dpath6
+            ),
+        )
+        pkgdir = xport_cfg.get_pkg_dir(fmri.PkgFmri(self.test_mog[2]))
+        with open(os.path.join(pkgdir, "manifest")) as f:
+            mcontent = f.read()
+        self.assertTrue("opt/bronze2" in mcontent)
+        self.assertTrue(os.path.exists(os.path.join(pkgdir, "manifest.file")))
+        with open(os.path.join(pkgdir, "manifest.file")) as f:
+            mf = f.read()
+        self.assertTrue("opt/bronze2" in mf)
 
-                self.pkgrecv(self.durl5, "--mog-file {0} -d {1} -v signature"
-                    .format(self.transforms["pub_change"], self.durl6))
-                ma = self.__get_manifest_contents(elem["pkg.fmri"], 6,
-                    pub="test1")
-                self.assertTrue("signature" not in ma)
-                self.pkgrepo("verify -s {0} --disable dependency"
-                    .format(self.dpath6))
+        self.pkgrecv(
+            self.durl5,
+            "--mog-file {0} -d {1} -v signature".format(
+                self.transforms["pub_change"], self.durl6
+            ),
+        )
+        ma = self.__get_manifest_contents(elem["pkg.fmri"], 6, pub="test1")
+        self.assertTrue("signature" not in ma)
+        self.pkgrepo("verify -s {0} --disable dependency".format(self.dpath6))
 
-        def test_15_content_attrs(self):
-                """Ensure that relevant content-related attributes will not be
-                modified by pkgrecv.  This is important if changes are made to
-                how some attributes are calculated in the future and
-                modifications would invalidate signatures."""
+    def test_15_content_attrs(self):
+        """Ensure that relevant content-related attributes will not be
+        modified by pkgrecv.  This is important if changes are made to
+        how some attributes are calculated in the future and
+        modifications would invalidate signatures."""
 
-                mfpath = os.path.join(self.test_root, "content-attrs.p5m")
-                with open(mfpath, "w") as mf:
-                        mf.write("""\
+        mfpath = os.path.join(self.test_root, "content-attrs.p5m")
+        with open(mfpath, "w") as mf:
+            mf.write(
+                """\
 set name=pkg.fmri value=pkg://test/content-attrs@1.0
 file elftest.so.1 mode=0755 owner=root group=bin path=bin/true
-""")
+"""
+            )
 
-                # Create a repository and publish sample package.
-                rpath = tempfile.mkdtemp(dir=self.test_root)
-                self.create_repo(rpath)
-                ret, pfmri = self.pkgsend(rpath,
-                    "publish -d {0} {1}".format(self.ro_data_root, mfpath))
-                self.pkgrepo("list -s {0}".format(rpath))
+        # Create a repository and publish sample package.
+        rpath = tempfile.mkdtemp(dir=self.test_root)
+        self.create_repo(rpath)
+        ret, pfmri = self.pkgsend(
+            rpath, "publish -d {0} {1}".format(self.ro_data_root, mfpath)
+        )
+        self.pkgrepo("list -s {0}".format(rpath))
 
-                # Now get the actual manifest and get current elfhash value.
-                orepo = repo.Repository(root=rpath)
-                rmpath = orepo.manifest(pfmri)
-                rm = manifest.Manifest()
-                rm.set_content(pathname=rmpath)
-                ract = list(rm.gen_actions_by_type('file'))[0]
-                oelfhash = ract.attrs["elfhash"]
-                # 'pkg.content-hash' values contains signed and unsigned value,
-                # we just need to extract one of them.
-                ocontenthash = ract.attrs["pkg.content-hash"][0]
+        # Now get the actual manifest and get current elfhash value.
+        orepo = repo.Repository(root=rpath)
+        rmpath = orepo.manifest(pfmri)
+        rm = manifest.Manifest()
+        rm.set_content(pathname=rmpath)
+        ract = list(rm.gen_actions_by_type("file"))[0]
+        oelfhash = ract.attrs["elfhash"]
+        # 'pkg.content-hash' values contains signed and unsigned value,
+        # we just need to extract one of them.
+        ocontenthash = ract.attrs["pkg.content-hash"][0]
 
-                # Create a new repository and pkgrecv package to that one so
-                # that we can safely modify it in place.
-                nrpath = tempfile.mkdtemp(dir=self.test_root)
-                self.create_repo(nrpath)
-                self.pkgrecv(rpath, "-d {0} \\*".format(nrpath))
-                nrepo = repo.Repository(root=nrpath)
-                nmpath = nrepo.manifest(pfmri)
-                nm = manifest.Manifest()
-                nmcontent = rm.tostr_unsorted().replace(
-                    "elfhash=", "elfhash=42.")
-                nmcontent = nmcontent.replace(
-                    "pkg.content-hash=", "pkg.content-hash=42.")
-                nm.set_content(nmcontent)
-                nm.store(nmpath)
-                # Modifying the manifest requires a catalog rebuild.
-                self.pkgrepo("rebuild --no-index -s {0}".format(nrpath))
+        # Create a new repository and pkgrecv package to that one so
+        # that we can safely modify it in place.
+        nrpath = tempfile.mkdtemp(dir=self.test_root)
+        self.create_repo(nrpath)
+        self.pkgrecv(rpath, "-d {0} \\*".format(nrpath))
+        nrepo = repo.Repository(root=nrpath)
+        nmpath = nrepo.manifest(pfmri)
+        nm = manifest.Manifest()
+        nmcontent = rm.tostr_unsorted().replace("elfhash=", "elfhash=42.")
+        nmcontent = nmcontent.replace(
+            "pkg.content-hash=", "pkg.content-hash=42."
+        )
+        nm.set_content(nmcontent)
+        nm.store(nmpath)
+        # Modifying the manifest requires a catalog rebuild.
+        self.pkgrepo("rebuild --no-index -s {0}".format(nrpath))
 
-                # Now create another repository and pkgrecv package *without*
-                # using --clone to that one and verify that elfhash remains
-                # unchanged from previous repository version.
-                trpath = tempfile.mkdtemp(dir=self.test_root)
-                self.create_repo(trpath)
-                self.pkgrecv(nrpath, "-d {0} \\*".format(trpath))
-                trepo = repo.Repository(root=trpath)
-                tmpath = trepo.manifest(pfmri)
-                tm = manifest.Manifest()
-                tm.set_content(pathname=tmpath)
-                tact = list(tm.gen_actions_by_type('file'))[0]
-                self.assertEqual("42." + oelfhash, tact.attrs["elfhash"])
-                self.assertEqual("42." + ocontenthash,
-                    tact.attrs["pkg.content-hash"][0])
+        # Now create another repository and pkgrecv package *without*
+        # using --clone to that one and verify that elfhash remains
+        # unchanged from previous repository version.
+        trpath = tempfile.mkdtemp(dir=self.test_root)
+        self.create_repo(trpath)
+        self.pkgrecv(nrpath, "-d {0} \\*".format(trpath))
+        trepo = repo.Repository(root=trpath)
+        tmpath = trepo.manifest(pfmri)
+        tm = manifest.Manifest()
+        tm.set_content(pathname=tmpath)
+        tact = list(tm.gen_actions_by_type("file"))[0]
+        self.assertEqual("42." + oelfhash, tact.attrs["elfhash"])
+        self.assertEqual(
+            "42." + ocontenthash, tact.attrs["pkg.content-hash"][0]
+        )
 
-                # Do the same thing again, but use --clone this time.
-                trpath = tempfile.mkdtemp(dir=self.test_root)
-                self.create_repo(trpath)
-                self.pkgrecv(nrpath, "--clone -d {0} -p \\*".format(trpath))
-                trepo = repo.Repository(root=trpath)
-                tmpath = trepo.manifest(pfmri)
-                tm = manifest.Manifest()
-                tm.set_content(pathname=tmpath)
-                tact = list(tm.gen_actions_by_type('file'))[0]
-                self.assertEqual("42." + oelfhash, tact.attrs["elfhash"])
-                self.assertEqual("42." + ocontenthash,
-                    tact.attrs["pkg.content-hash"][0])
+        # Do the same thing again, but use --clone this time.
+        trpath = tempfile.mkdtemp(dir=self.test_root)
+        self.create_repo(trpath)
+        self.pkgrecv(nrpath, "--clone -d {0} -p \\*".format(trpath))
+        trepo = repo.Repository(root=trpath)
+        tmpath = trepo.manifest(pfmri)
+        tm = manifest.Manifest()
+        tm.set_content(pathname=tmpath)
+        tact = list(tm.gen_actions_by_type("file"))[0]
+        self.assertEqual("42." + oelfhash, tact.attrs["elfhash"])
+        self.assertEqual(
+            "42." + ocontenthash, tact.attrs["pkg.content-hash"][0]
+        )
 
-        def test_16_recv_old_republish(self):
-                """Verify that older logic of republication in pkgrecv works."""
+    def test_16_recv_old_republish(self):
+        """Verify that older logic of republication in pkgrecv works."""
 
-                f = fmri.PkgFmri(self.published[3], None)
+        f = fmri.PkgFmri(self.published[3], None)
 
-                self.dcs[2].stop()
-                self.dcs[2].set_disable_ops(["manifest/1"])
-                self.dcs[2].start()
+        self.dcs[2].stop()
+        self.dcs[2].set_disable_ops(["manifest/1"])
+        self.dcs[2].start()
 
-                self.pkgrecv(self.durl1, "-d {0} {1}".format(self.durl2, f))
-                self.dcs[2].unset_disable_ops()
+        self.pkgrecv(self.durl1, "-d {0} {1}".format(self.durl2, f))
+        self.dcs[2].unset_disable_ops()
 
-        def test_17_multiple_publishers(self):
-                """"Verify that pkgrecv handles multiple publishers as
-                expected."""
+    def test_17_multiple_publishers(self):
+        """ "Verify that pkgrecv handles multiple publishers as
+        expected."""
 
-                # Publish a package under the publisher 'pub1'.
-                self.pkgsend_bulk(self.durl1, (self.samefile10))
-                # All other packages has been published under the publisher
-                # 'test1', so retrieving all packages will involve multiple
-                # publishers.
-                self.pkgrecv(self.durl1, "-d {0} '*'".format(self.durl2))
+        # Publish a package under the publisher 'pub1'.
+        self.pkgsend_bulk(self.durl1, (self.samefile10))
+        # All other packages has been published under the publisher
+        # 'test1', so retrieving all packages will involve multiple
+        # publishers.
+        self.pkgrecv(self.durl1, "-d {0} '*'".format(self.durl2))
+
 
 class TestPkgrecvHTTPS(pkg5unittest.HTTPSTestClass):
-
-        example_pkg10 = """
+    example_pkg10 = """
             open example_pkg@1.0,5.11-0
             add file tmp/example_file mode=0555 owner=root group=bin path=/usr/bin/example_path
             close"""
 
-        misc_files = ["tmp/example_file", "tmp/empty", "tmp/verboten"]
+    misc_files = ["tmp/example_file", "tmp/empty", "tmp/verboten"]
 
-        def setUp(self):
-                pubs = ["src", "dst"]
+    def setUp(self):
+        pubs = ["src", "dst"]
 
-                pkg5unittest.HTTPSTestClass.setUp(self, pubs,
-                    start_depots=True)
+        pkg5unittest.HTTPSTestClass.setUp(self, pubs, start_depots=True)
 
-                self.srurl = self.dcs[1].get_repo_url()
-                self.make_misc_files(self.misc_files)
-                self.pkgsend_bulk(self.srurl, self.example_pkg10)
+        self.srurl = self.dcs[1].get_repo_url()
+        self.make_misc_files(self.misc_files)
+        self.pkgsend_bulk(self.srurl, self.example_pkg10)
 
-                self.surl = self.ac.url + "/{0}".format(pubs[0])
-                self.durl = self.ac.url + "/{0}".format(pubs[1])
+        self.surl = self.ac.url + "/{0}".format(pubs[0])
+        self.durl = self.ac.url + "/{0}".format(pubs[1])
 
-                #set permissions of tmp/verboten to make it non-readable
-                self.verboten = os.path.join(self.test_root, "tmp/verboten")
-                os.system("chmod 600 {0}".format(self.verboten))
+        # set permissions of tmp/verboten to make it non-readable
+        self.verboten = os.path.join(self.test_root, "tmp/verboten")
+        os.system("chmod 600 {0}".format(self.verboten))
 
+    def test_01_basics(self):
+        """Test that transferring a package from an https repo to
+        another https repo works"""
 
-        def test_01_basics(self):
-                """Test that transferring a package from an https repo to
-                another https repo works"""
+        self.ac.start()
 
-                self.ac.start()
+        arg_dict = {
+            "cert": os.path.join(self.cs_dir, self.get_cli_cert("src")),
+            "key": os.path.join(self.keys_dir, self.get_cli_key("src")),
+            "dst": self.durl,
+            "dcert": os.path.join(self.cs_dir, self.get_cli_cert("dst")),
+            "dkey": os.path.join(self.keys_dir, self.get_cli_key("dst")),
+            "pkg": "example_pkg@1.0,5.11-0",
+            "empty": os.path.join(self.test_root, "tmp/empty"),
+            "noexist": os.path.join(self.test_root, "octopus"),
+            "verboten": self.verboten,
+        }
 
-                arg_dict = {
-                    "cert": os.path.join(self.cs_dir, self.get_cli_cert("src")),
-                    "key": os.path.join(self.keys_dir, self.get_cli_key("src")),
-                    "dst": self.durl,
-                    "dcert": os.path.join(self.cs_dir, self.get_cli_cert("dst")),
-                    "dkey": os.path.join(self.keys_dir, self.get_cli_key("dst")),
-                    "pkg": "example_pkg@1.0,5.11-0",
-                    "empty": os.path.join(self.test_root, "tmp/empty"),
-                    "noexist": os.path.join(self.test_root, "octopus"),
-                    "verboten": self.verboten,
-                }
+        # We need an image for seed_ta_dir() to work.
+        # TODO: there might be a cleaner way of doing this
+        self.image_create()
+        # Add the trust anchor needed to verify the server's identity.
+        self.seed_ta_dir("ta7")
 
-                # We need an image for seed_ta_dir() to work.
-                # TODO: there might be a cleaner way of doing this
-                self.image_create()
-                # Add the trust anchor needed to verify the server's identity.
-                self.seed_ta_dir("ta7")
+        # We try to receive a pkg from a secured repo and publish it to
+        # another secured repo where both repos require different
+        # credentials
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {cert} "
+            "-d {dst} --dkey {dkey} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+        )
 
-                # We try to receive a pkg from a secured repo and publish it to
-                # another secured repo where both repos require different
-                # credentials
-                self.pkgrecv(self.surl, "--key {key} --cert {cert} "
-                    "-d {dst} --dkey {dkey} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict))
+        # Now try to use the same credentials for source and dest.
+        # This should fail.
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {cert} "
+            "-d {dst} --dkey {key} --dcert {cert} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Now try to use the same credentials for source and dest.
-                # This should fail.
-                self.pkgrecv(self.surl, "--key {key} --cert {cert} "
-                    "-d {dst} --dkey {key} --dcert {cert} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Make sure we don't traceback when credential files are invalid
+        # Src certificate option missing
+        self.pkgrecv(
+            self.surl,
+            "--key {key} -d {dst} "
+            "--dkey {dkey} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Make sure we don't traceback when credential files are invalid
-                # Src certificate option missing
-                self.pkgrecv(self.surl, "--key {key} -d {dst} "
-                    "--dkey {dkey} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Dst certificate option missing
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {cert} "
+            "-d {dst} --dkey {dkey} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Dst certificate option missing
-                self.pkgrecv(self.surl, "--key {key} --cert {cert} "
-                    "-d {dst} --dkey {dkey} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Src key option missing
+        self.pkgrecv(
+            self.surl,
+            "--cert {cert} "
+            "-d {dst} --dkey {dkey} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Src key option missing
-                self.pkgrecv(self.surl, "--cert {cert} "
-                    "-d {dst} --dkey {dkey} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Dst key option missing
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {cert} "
+            "-d {dst} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Dst key option missing
-                self.pkgrecv(self.surl, "--key {key} --cert {cert} "
-                    "-d {dst} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Src certificate not found
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {noexist} "
+            "-d {dst} --dkey {dkey} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Src certificate not found
-                self.pkgrecv(self.surl, "--key {key} --cert {noexist} "
-                    "-d {dst} --dkey {dkey} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Dst certificate not found
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {cert} "
+            "-d {dst} --dkey {dkey} --dcert {noexist} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Dst certificate not found
-                self.pkgrecv(self.surl, "--key {key} --cert {cert} "
-                    "-d {dst} --dkey {dkey} --dcert {noexist} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Src key not found
+        self.pkgrecv(
+            self.surl,
+            "--key {noexist} --cert {cert} "
+            "-d {dst} --dkey {dkey} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Src key not found
-                self.pkgrecv(self.surl, "--key {noexist} --cert {cert} "
-                    "-d {dst} --dkey {dkey} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Dst key not found
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {cert} "
+            "-d {dst} --dkey {noexist} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Dst key not found
-                self.pkgrecv(self.surl, "--key {key} --cert {cert} "
-                    "-d {dst} --dkey {noexist} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Src certificate is empty file
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {empty} "
+            "-d {dst} --dkey {dkey} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Src certificate is empty file
-                self.pkgrecv(self.surl, "--key {key} --cert {empty} "
-                    "-d {dst} --dkey {dkey} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Dst certificate is empty file
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {cert} "
+            "-d {dst} --dkey {dkey} --dcert {empty} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Dst certificate is empty file
-                self.pkgrecv(self.surl, "--key {key} --cert {cert} "
-                    "-d {dst} --dkey {dkey} --dcert {empty} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Src key is empty file
+        self.pkgrecv(
+            self.surl,
+            "--key {empty} --cert {cert} "
+            "-d {dst} --dkey {dkey} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Src key is empty file
-                self.pkgrecv(self.surl, "--key {empty} --cert {cert} "
-                    "-d {dst} --dkey {dkey} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # Dst key is empty file
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {cert} "
+            "-d {dst} --dkey {empty} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Dst key is empty file
-                self.pkgrecv(self.surl, "--key {key} --cert {cert} "
-                    "-d {dst} --dkey {empty} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), exit=1)
+        # No permissions to read src certificate
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {verboten} "
+            "-d {dst} --dkey {dkey} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            su_wrap=True,
+            exit=1,
+        )
 
-                # No permissions to read src certificate
-                self.pkgrecv(self.surl, "--key {key} --cert {verboten} "
-                    "-d {dst} --dkey {dkey} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), su_wrap=True, exit=1)
+        # No permissions to read dst certificate
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {cert} "
+            "-d {dst} --dkey {dkey} --dcert {verboten} "
+            "{pkg}".format(**arg_dict),
+            su_wrap=True,
+            exit=1,
+        )
 
-                # No permissions to read dst certificate
-                self.pkgrecv(self.surl, "--key {key} --cert {cert} "
-                    "-d {dst} --dkey {dkey} --dcert {verboten} "
-                    "{pkg}".format(**arg_dict), su_wrap=True, exit=1)
+        # No permissions to read src key
+        self.pkgrecv(
+            self.surl,
+            "--key {verboten} --cert {cert} "
+            "-d {dst} --dkey {dkey} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            su_wrap=True,
+            exit=1,
+        )
 
-                # No permissions to read src key
-                self.pkgrecv(self.surl, "--key {verboten} --cert {cert} "
-                    "-d {dst} --dkey {dkey} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), su_wrap=True, exit=1)
-
-                # No permissions to read dst key
-                self.pkgrecv(self.surl, "--key {key} --cert {cert} "
-                    "-d {dst} --dkey {verboten} --dcert {dcert} "
-                    "{pkg}".format(**arg_dict), su_wrap=True, exit=1)
+        # No permissions to read dst key
+        self.pkgrecv(
+            self.surl,
+            "--key {key} --cert {cert} "
+            "-d {dst} --dkey {verboten} --dcert {dcert} "
+            "{pkg}".format(**arg_dict),
+            su_wrap=True,
+            exit=1,
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgrepo.py
+++ b/src/tests/cli/t_pkgrepo.py
@@ -26,8 +26,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 from pkg.server.query_parser import Query
@@ -51,19 +52,21 @@ import time
 import unittest
 
 try:
-        import pkg.sha512_t
-        sha512_supported = True
+    import pkg.sha512_t
+
+    sha512_supported = True
 except ImportError:
-        sha512_supported = False
+    sha512_supported = False
+
 
 class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
-        # Cleanup after every test.
-        persistent_setup = False
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
-        maxDiff = None
+    # Cleanup after every test.
+    persistent_setup = False
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
+    maxDiff = None
 
-        tree10 = """
+    tree10 = """
             open tree@1.0,5.11-0:20110804T203458Z
             add file tmp/empty mode=0555 owner=root group=bin path=/etc/empty
             add file tmp/truck1 mode=0444 owner=root group=bin path=/etc/trailer
@@ -74,7 +77,7 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        amber10 = """
+    amber10 = """
             open amber@1.0,5.11-0:20110804T203458Z
             add depend fmri=pkg:/tree@1.0,5.11-0:20110804T203458Z type=require
             add set name=pkg.summary value="Millenia old resin"
@@ -82,32 +85,32 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        amber20 = """
+    amber20 = """
             open amber@2.0,5.11-0:20110804T203458Z
             add depend fmri=pkg:/tree@1.0 type=require
             close
         """
 
-        amber30 = """
+    amber30 = """
             open amber@3.0,5.11-0:20110804T203458Z
             add set name=pkg.renamed value=true
             add depend fmri=pkg:/bronze@1.0 type=require
             close
         """
 
-        amber35 = """
+    amber35 = """
             open amber@3.5,5.11-0:20110804T203458Z
             add set name=pkg.legacy value=true
             close
         """
 
-        amber40 = """
+    amber40 = """
             open amber@4.0,5.11-0:20110804T203458Z
             add set name=pkg.obsolete value=true
             close
         """
 
-        truck10 = """
+    truck10 = """
             open truck@1.0,5.11-0:20110804T203458Z
             add file tmp/empty mode=0555 owner=root group=bin path=/etc/NOTICES/empty
             add file tmp/truck1 mode=0444 owner=root group=bin path=/etc/truck1
@@ -115,14 +118,14 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        trucknd10 = """
+    trucknd10 = """
             open trucknd@1.0,5.11-0:20110804T203458Z
             add file tmp/empty mode=0555 owner=root group=bin path=/etc/NOTICES/empty
             add file tmp/truck1 mode=0444 owner=root group=bin path=/etc/truck1
             close
         """
 
-        truck20 = """
+    truck20 = """
             open truck@2.0,5.11-0:20110804T203458Z
             add file tmp/empty mode=0555 owner=root group=bin path=/etc/NOTICES/empty
             add file tmp/truck1 mode=0444 owner=root group=bin path=/etc/truck1
@@ -131,46 +134,46 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        zoo10 = """
+    zoo10 = """
             open zoo@1.0,5.11-0:20110804T203458Z
             close
         """
 
-        refuse10 = """
+    refuse10 = """
             open refuse@1.0,5.11-0:20110804T203458Z
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other
             add depend fmri=pkg:/amber@2.0 type=exclude
             close
         """
 
-        illegaldep10 = """
+    illegaldep10 = """
             open illegaldep@1.0,5.11-0:20110804T203458Z
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
             close
         """
 
-        wtinstallhold10 = """
+    wtinstallhold10 = """
             open wtinstallhold@1.0,5.11-0:20110804T203458Z
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
             add depend fmri=pkg:/amber@1.0 type=require
             close
         """
 
-        wtinstallhold20 = """
+    wtinstallhold20 = """
             open wtinstallhold@2.0,5.11-0:20110804T203458Z
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
             add depend fmri=pkg:/amber@2.0 type=require
             close
         """
 
-        withpub1_10 = """
+    withpub1_10 = """
             open pkg://test1/withpub1@1.0,5.11-0:20110804T203458Z
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
             add depend fmri=pkg:/amber@1.0 type=require
             close
         """
 
-        withpub1_20 = """
+    withpub1_20 = """
             open pkg://test2/withpub1@2.0,5.11-0:20110804T203458Z
             add set name=pkg.depend.install-hold value=test
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
@@ -178,7 +181,7 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        withpub2_10 = """
+    withpub2_10 = """
             open pkg://test2/withpub2@1.0,5.11-0:20110804T203458Z
             add set name=pkg.depend.install-hold value=test
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
@@ -186,144 +189,148 @@ class TestPkgRepo(pkg5unittest.SingleDepotTestCase):
             close
         """
 
-        incorp10 = """
+    incorp10 = """
             open incorp@1.0,5.11-0:20110804T203458Z
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
             close
         """
 
-        require_any10 = """
+    require_any10 = """
             open requireany@1.0,5.11-0:20110804T203458Z
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
             add depend fmri=pkg:/amber@1.0 fmri=pkg:/amber@2.0 type=require-any
             close
         """
 
-        depchecktag10 = """
+    depchecktag10 = """
             open depchecktag@1.0,5.11-0:20110804T203458Z
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
             add depend fmri=pkg:/depcheckdep@1.0 type=require
             close
         """
 
-        depcheckdep10 = """
+    depcheckdep10 = """
             open depcheckdep@1.0,5.11-0:20110804T203458Z
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
             close
         """
 
-        optionalpkg10 = """
+    optionalpkg10 = """
             open optionalpkg@1.0,5.11-0:20110804T203458Z
             add file tmp/other mode=0444 owner=root group=bin path=/etc/other1
             add depend fmri=pkg:/zoo@2.0 type=optional
             close
         """
-        # These hashes should remain as SHA-1 until such time as we bump the
-        # least-preferred hash for actions.
-        fhashes = {
-             "tmp/empty": "5f5fb715934e0fa2bfb5611fd941d33228027006",
-             "tmp/truck1": "c9e257b659ace6c3fbc4d334f49326b3889fd109",
-             "tmp/truck2": "c07fd27b5b57f8131f42e5f2c719a469d9fc71c5",
-        }
+    # These hashes should remain as SHA-1 until such time as we bump the
+    # least-preferred hash for actions.
+    fhashes = {
+        "tmp/empty": "5f5fb715934e0fa2bfb5611fd941d33228027006",
+        "tmp/truck1": "c9e257b659ace6c3fbc4d334f49326b3889fd109",
+        "tmp/truck2": "c07fd27b5b57f8131f42e5f2c719a469d9fc71c5",
+    }
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.make_misc_files(["tmp/empty", "tmp/truck1", "tmp/truck2",
-                    "tmp/other"])
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.make_misc_files(
+            ["tmp/empty", "tmp/truck1", "tmp/truck2", "tmp/other"]
+        )
 
-        def test_00_base(self):
-                """Verify pkgrepo handles basic option and subcommand parsing
-                as expected.
-                """
+    def test_00_base(self):
+        """Verify pkgrepo handles basic option and subcommand parsing
+        as expected.
+        """
 
-                # --help, -? should exit with 0.
-                self.pkgrepo("--help", exit=0)
-                self.pkgrepo("'-?'", exit=0)
+        # --help, -? should exit with 0.
+        self.pkgrepo("--help", exit=0)
+        self.pkgrepo("'-?'", exit=0)
 
-                # unknown options should exit with 2.
-                self.pkgrepo("-U", exit=2)
-                self.pkgrepo("--unknown", exit=2)
+        # unknown options should exit with 2.
+        self.pkgrepo("-U", exit=2)
+        self.pkgrepo("--unknown", exit=2)
 
-                # unknown subcommands should exit with 2.
-                self.pkgrepo("unknown_subcmd", exit=2)
+        # unknown subcommands should exit with 2.
+        self.pkgrepo("unknown_subcmd", exit=2)
 
-                # no subcommand should exit with 2.
-                self.pkgrepo("", exit=2)
+        # no subcommand should exit with 2.
+        self.pkgrepo("", exit=2)
 
-                # global option with no subcommand should exit with 2.
-                self.pkgrepo("-s {0}".format(self.test_root), exit=2)
+        # global option with no subcommand should exit with 2.
+        self.pkgrepo("-s {0}".format(self.test_root), exit=2)
 
-                # Verify an invalid URI causes an exit 2.
-                for baduri in ("file://not/valid", "http://not@$$_-^valid"):
-                        self.pkgrepo("info -s {0}".format(baduri), exit=2)
+        # Verify an invalid URI causes an exit 2.
+        for baduri in ("file://not/valid", "http://not@$$_-^valid"):
+            self.pkgrepo("info -s {0}".format(baduri), exit=2)
 
-        def test_01_create(self):
-                """Verify pkgrepo create works as expected."""
+    def test_01_create(self):
+        """Verify pkgrepo create works as expected."""
 
-                # Verify create without a destination exits.
-                self.pkgrepo("create", exit=2)
+        # Verify create without a destination exits.
+        self.pkgrepo("create", exit=2)
 
-                # Verify create with an invalid URI as an operand exits with 2.
-                for baduri in ("file://not/valid", "http://not@$$_-^valid"):
-                        self.pkgrepo("create {0}".format(baduri), exit=2)
+        # Verify create with an invalid URI as an operand exits with 2.
+        for baduri in ("file://not/valid", "http://not@$$_-^valid"):
+            self.pkgrepo("create {0}".format(baduri), exit=2)
 
-                # Verify create works whether -s is used to supply the location
-                # of the new repository or it is passed as an operand.  Also
-                # verify that either a path or URI can be used to provide the
-                # repository's location.
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                repo_uri = self.dc.get_repo_url()
+        # Verify create works whether -s is used to supply the location
+        # of the new repository or it is passed as an operand.  Also
+        # verify that either a path or URI can be used to provide the
+        # repository's location.
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        repo_uri = self.dc.get_repo_url()
 
-                # Specify using global option and path.
-                self.pkgrepo("create -s {0}".format(repo_path))
-                # This will fail if a repository wasn't created.
-                self.dc.get_repo()
-                shutil.rmtree(repo_path)
+        # Specify using global option and path.
+        self.pkgrepo("create -s {0}".format(repo_path))
+        # This will fail if a repository wasn't created.
+        self.dc.get_repo()
+        shutil.rmtree(repo_path)
 
-                # Specify using operand and URI.
-                self.pkgrepo("create {0}".format(repo_uri))
-                # This will fail if a repository wasn't created.
-                self.get_repo(repo_path)
-                shutil.rmtree(repo_path)
+        # Specify using operand and URI.
+        self.pkgrepo("create {0}".format(repo_uri))
+        # This will fail if a repository wasn't created.
+        self.get_repo(repo_path)
+        shutil.rmtree(repo_path)
 
-                # Verify create works for an empty, pre-existing directory.
-                os.mkdir(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                # This will fail if a repository wasn't created.
-                self.get_repo(repo_path)
+        # Verify create works for an empty, pre-existing directory.
+        os.mkdir(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        # This will fail if a repository wasn't created.
+        self.get_repo(repo_path)
 
-                # Verify create fails for a non-empty, pre-existing directory.
-                self.pkgrepo("create {0}".format(repo_path), exit=1)
+        # Verify create fails for a non-empty, pre-existing directory.
+        self.pkgrepo("create {0}".format(repo_path), exit=1)
 
-        def test_02_get_set_property(self):
-                """Verify pkgrepo get and set works as expected."""
+    def test_02_get_set_property(self):
+        """Verify pkgrepo get and set works as expected."""
 
-                # Verify command without a repository exits.
-                self.pkgrepo("get", exit=2)
+        # Verify command without a repository exits.
+        self.pkgrepo("get", exit=2)
 
-                # Create a repository (a version 3 one is needed for these
-                # tests).
-                repo_path = self.dc.get_repodir()
-                repo_uri = self.dc.get_repo_url()
-                depot_uri = self.dc.get_depot_url()
-                shutil.rmtree(repo_path)
-                self.assertTrue(not os.path.exists(repo_path))
-                self.pkgrepo("create -s {0} --version=3".format(repo_path))
+        # Create a repository (a version 3 one is needed for these
+        # tests).
+        repo_path = self.dc.get_repodir()
+        repo_uri = self.dc.get_repo_url()
+        depot_uri = self.dc.get_depot_url()
+        shutil.rmtree(repo_path)
+        self.assertTrue(not os.path.exists(repo_path))
+        self.pkgrepo("create -s {0} --version=3".format(repo_path))
 
-                # Verify get handles unknown properties gracefully.
-                self.pkgrepo("get -s {0} repository/unknown".format(repo_uri), exit=1)
+        # Verify get handles unknown properties gracefully.
+        self.pkgrepo("get -s {0} repository/unknown".format(repo_uri), exit=1)
 
-                # Verify get returns partial failure if only some
-                # properties cannot be found.
-                self.pkgrepo("get -s {0} repository/origins "
-                    "repository/unknown".format(repo_uri), exit=3)
+        # Verify get returns partial failure if only some
+        # properties cannot be found.
+        self.pkgrepo(
+            "get -s {0} repository/origins "
+            "repository/unknown".format(repo_uri),
+            exit=3,
+        )
 
-                # Verify full default output for both network and file case.
-                self.dc.start()
-                for uri in (repo_uri, depot_uri):
-                        self.pkgrepo("get -s {0}".format(uri))
-                        expected = """\
+        # Verify full default output for both network and file case.
+        self.dc.start()
+        for uri in (repo_uri, depot_uri):
+            self.pkgrepo("get -s {0}".format(uri))
+            expected = """\
 SECTION    PROPERTY         VALUE
 feed       description      ""
 feed       icon             web/_themes/pkg-block-icon.png
@@ -347,12 +354,12 @@ repository registration_uri ""
 repository related_uris     ()
 repository version          3
 """
-                        self.assertEqualDiff(expected, self.output)
-                self.dc.stop()
+            self.assertEqualDiff(expected, self.output)
+        self.dc.stop()
 
-                # Verify full tsv output.
-                self.pkgrepo("get -s {0} -Ftsv".format(repo_uri))
-                expected = """\
+        # Verify full tsv output.
+        self.pkgrepo("get -s {0} -Ftsv".format(repo_uri))
+        expected = """\
 SECTION\tPROPERTY\tVALUE
 feed\tdescription\t""
 feed\ticon\tweb/_themes/pkg-block-icon.png
@@ -376,126 +383,141 @@ repository\tregistration_uri\t""
 repository\trelated_uris\t()
 repository\tversion\t3
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify that -H omits headers for full output.
-                self.pkgrepo("get -s {0} -H".format(repo_uri))
-                self.assertTrue(self.output.find("SECTION") == -1)
+        # Verify that -H omits headers for full output.
+        self.pkgrepo("get -s {0} -H".format(repo_uri))
+        self.assertTrue(self.output.find("SECTION") == -1)
 
-                # Verify specific get default output and that
-                # -H omits headers for specific get output.
-                self.pkgrepo("get -s {0} publisher/prefix".format(
-                    repo_uri))
-                expected = """\
+        # Verify specific get default output and that
+        # -H omits headers for specific get output.
+        self.pkgrepo("get -s {0} publisher/prefix".format(repo_uri))
+        expected = """\
 SECTION    PROPERTY         VALUE
 publisher  prefix           test
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("get -s {0} -H publisher/prefix "
-                    "repository/origins".format(repo_uri))
-                expected = """\
+        self.pkgrepo(
+            "get -s {0} -H publisher/prefix "
+            "repository/origins".format(repo_uri)
+        )
+        expected = """\
 publisher  prefix           test
 repository origins          ()
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify specific get tsv output.
-                self.pkgrepo("get -s {0} -F tsv publisher/prefix".format(
-                    repo_uri))
-                expected = """\
+        # Verify specific get tsv output.
+        self.pkgrepo("get -s {0} -F tsv publisher/prefix".format(repo_uri))
+        expected = """\
 SECTION\tPROPERTY\tVALUE
 publisher\tprefix\ttest
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("get -s {0} -HF tsv publisher/prefix "
-                    "repository/origins".format(repo_uri))
-                expected = """\
+        self.pkgrepo(
+            "get -s {0} -HF tsv publisher/prefix "
+            "repository/origins".format(repo_uri)
+        )
+        expected = """\
 publisher\tprefix\ttest
 repository\torigins\t()
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify set fails if no property is provided.
-                self.pkgrepo("set -s {0}".format(repo_uri), exit=2)
+        # Verify set fails if no property is provided.
+        self.pkgrepo("set -s {0}".format(repo_uri), exit=2)
 
-                # Verify set gracefully handles bad property values.
-                self.pkgrepo("set -s {0} publisher/prefix=_invalid".format(repo_uri),
-                    exit=1)
+        # Verify set gracefully handles bad property values.
+        self.pkgrepo(
+            "set -s {0} publisher/prefix=_invalid".format(repo_uri), exit=1
+        )
 
-                # Verify set can set single value properties.
-                self.pkgrepo("set -s {0} publisher/prefix=opensolaris.org".format(
-                    repo_uri))
-                self.pkgrepo("get -s {0} -HF tsv publisher/prefix".format(repo_uri))
-                expected = """\
+        # Verify set can set single value properties.
+        self.pkgrepo(
+            "set -s {0} publisher/prefix=opensolaris.org".format(repo_uri)
+        )
+        self.pkgrepo("get -s {0} -HF tsv publisher/prefix".format(repo_uri))
+        expected = """\
 publisher\tprefix\topensolaris.org
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify set can set multi-value properties.
-                self.pkgrepo("set -s {0} "
-                    "'repository/origins=(http://pkg.opensolaris.org/dev "
-                    "http://pkg-eu-2.opensolaris.org/dev)'".format(repo_uri))
-                self.pkgrepo("get -s {0} -HF tsv repository/origins".format(repo_uri))
-                expected = """\
+        # Verify set can set multi-value properties.
+        self.pkgrepo(
+            "set -s {0} "
+            "'repository/origins=(http://pkg.opensolaris.org/dev "
+            "http://pkg-eu-2.opensolaris.org/dev)'".format(repo_uri)
+        )
+        self.pkgrepo("get -s {0} -HF tsv repository/origins".format(repo_uri))
+        expected = """\
 repository\torigins\t(http://pkg.opensolaris.org/dev http://pkg-eu-2.opensolaris.org/dev)
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify set can set unknown properties.
-                self.pkgrepo("set -s {0} 'foo/bar=value'".format(repo_uri))
-                self.pkgrepo("get -s {0} -HF tsv foo/bar".format(repo_uri))
-                expected = """\
+        # Verify set can set unknown properties.
+        self.pkgrepo("set -s {0} 'foo/bar=value'".format(repo_uri))
+        self.pkgrepo("get -s {0} -HF tsv foo/bar".format(repo_uri))
+        expected = """\
 foo\tbar\tvalue
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Create a repository (a version 3 one is needed for this
-                # test).
-                repo_path = self.dc.get_repodir()
-                repo_uri = self.dc.get_repo_url()
-                depot_uri = self.dc.get_depot_url()
-                shutil.rmtree(repo_path)
-                self.assertTrue(not os.path.exists(repo_path))
-                self.pkgrepo("create -s {0} --version=3".format(repo_path))
-                self.pkgrepo("set -s {0} publisher/prefix=test".format(repo_path))
+        # Create a repository (a version 3 one is needed for this
+        # test).
+        repo_path = self.dc.get_repodir()
+        repo_uri = self.dc.get_repo_url()
+        depot_uri = self.dc.get_depot_url()
+        shutil.rmtree(repo_path)
+        self.assertTrue(not os.path.exists(repo_path))
+        self.pkgrepo("create -s {0} --version=3".format(repo_path))
+        self.pkgrepo("set -s {0} publisher/prefix=test".format(repo_path))
 
-                # Verify setting publisher properties fails for version 3
-                # repositories.
-                self.pkgrepo("set -s {0} -p all "
-                    "repository/origins=http://localhost".format(repo_uri), exit=1)
+        # Verify setting publisher properties fails for version 3
+        # repositories.
+        self.pkgrepo(
+            "set -s {0} -p all "
+            "repository/origins=http://localhost".format(repo_uri),
+            exit=1,
+        )
 
-                # Create version 4 repository.
-                shutil.rmtree(repo_path)
-                self.assertTrue(not os.path.exists(repo_path))
-                self.create_repo(repo_path)
+        # Create version 4 repository.
+        shutil.rmtree(repo_path)
+        self.assertTrue(not os.path.exists(repo_path))
+        self.create_repo(repo_path)
 
-                # Verify get handles unknown publishers gracefully.
-                self.pkgrepo("get -s {0} -p test repository/origins".format(repo_uri),
-                    exit=1)
+        # Verify get handles unknown publishers gracefully.
+        self.pkgrepo(
+            "get -s {0} -p test repository/origins".format(repo_uri), exit=1
+        )
 
-                # Add a publisher by setting properties for one that doesn't
-                # exist yet.
-                self.pkgrepo("set -s {0} -p test "
-                    "repository/name='package repository' "
-                    "repository/refresh-seconds=7200".format(
-                    repo_uri))
+        # Add a publisher by setting properties for one that doesn't
+        # exist yet.
+        self.pkgrepo(
+            "set -s {0} -p test "
+            "repository/name='package repository' "
+            "repository/refresh-seconds=7200".format(repo_uri)
+        )
 
-                # Verify get handles unknown properties gracefully.
-                self.pkgrepo("get -s {0} -p test repository/unknown".format(repo_uri),
-                    exit=1)
+        # Verify get handles unknown properties gracefully.
+        self.pkgrepo(
+            "get -s {0} -p test repository/unknown".format(repo_uri), exit=1
+        )
 
-                # Verify get returns partial failure if only some properties
-                # cannot be found.
-                self.pkgrepo("get -s {0} -p all repository/origins "
-                    "repository/unknown".format(repo_uri), exit=3)
+        # Verify get returns partial failure if only some properties
+        # cannot be found.
+        self.pkgrepo(
+            "get -s {0} -p all repository/origins "
+            "repository/unknown".format(repo_uri),
+            exit=3,
+        )
 
-                # Verify full default output for both network and file case.
-                self.dc.start()
-                for uri in (repo_uri, depot_uri):
-                        self.pkgrepo("get -s {0} -p all".format(uri))
-                        expected = """\
+        # Verify full default output for both network and file case.
+        self.dc.start()
+        for uri in (repo_uri, depot_uri):
+            self.pkgrepo("get -s {0} -p all".format(uri))
+            expected = """\
 PUBLISHER SECTION    PROPERTY         VALUE
 test      publisher  alias            
 test      publisher  prefix           test
@@ -509,12 +531,12 @@ test      repository refresh-seconds  7200
 test      repository registration-uri ""
 test      repository related-uris     ()
 """
-                        self.assertEqualDiff(expected, self.output)
-                self.dc.stop()
+            self.assertEqualDiff(expected, self.output)
+        self.dc.stop()
 
-                # Verify full tsv output.
-                self.pkgrepo("get -s {0} -p all -Ftsv".format(repo_uri))
-                expected = """\
+        # Verify full tsv output.
+        self.pkgrepo("get -s {0} -p all -Ftsv".format(repo_uri))
+        expected = """\
 PUBLISHER\tSECTION\tPROPERTY\tVALUE
 test\tpublisher\talias\t
 test\tpublisher\tprefix\ttest
@@ -528,88 +550,101 @@ test\trepository\trefresh-seconds\t7200
 test\trepository\tregistration-uri\t""
 test\trepository\trelated-uris\t()
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify that -H omits headers for full output.
-                self.pkgrepo("get -s {0} -p all -H".format(repo_uri))
-                self.assertTrue(self.output.find("SECTION") == -1)
+        # Verify that -H omits headers for full output.
+        self.pkgrepo("get -s {0} -p all -H".format(repo_uri))
+        self.assertTrue(self.output.find("SECTION") == -1)
 
-                # Verify specific get default output and that
-                # -H omits headers for specific get output.
-                self.pkgrepo("get -s {0} -p all publisher/prefix".format(
-                    repo_uri))
-                expected = """\
+        # Verify specific get default output and that
+        # -H omits headers for specific get output.
+        self.pkgrepo("get -s {0} -p all publisher/prefix".format(repo_uri))
+        expected = """\
 PUBLISHER SECTION    PROPERTY         VALUE
 test      publisher  prefix           test
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("get -s {0} -p all -H publisher/prefix "
-                    "repository/origins".format(repo_uri))
-                expected = """\
+        self.pkgrepo(
+            "get -s {0} -p all -H publisher/prefix "
+            "repository/origins".format(repo_uri)
+        )
+        expected = """\
 test      publisher  prefix           test
 test      repository origins          ()
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify specific get tsv output.
-                self.pkgrepo("get -s {0} -p all -F tsv publisher/prefix".format(
-                    repo_uri))
-                expected = """\
+        # Verify specific get tsv output.
+        self.pkgrepo(
+            "get -s {0} -p all -F tsv publisher/prefix".format(repo_uri)
+        )
+        expected = """\
 PUBLISHER\tSECTION\tPROPERTY\tVALUE
 test\tpublisher\tprefix\ttest
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("get -s {0} -HF tsv -p all publisher/prefix "
-                    "repository/origins".format(repo_uri))
-                expected = """\
+        self.pkgrepo(
+            "get -s {0} -HF tsv -p all publisher/prefix "
+            "repository/origins".format(repo_uri)
+        )
+        expected = """\
 test\tpublisher\tprefix\ttest
 test\trepository\torigins\t()
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify set fails if no property is provided.
-                self.pkgrepo("set -s {0} -p test".format(repo_uri), exit=2)
+        # Verify set fails if no property is provided.
+        self.pkgrepo("set -s {0} -p test".format(repo_uri), exit=2)
 
-                # Verify set gracefully handles bad property values and
-                # properties that can't be set.
-                self.pkgrepo("set -s {0} -p test publisher/alias=_invalid".format(
-                    repo_uri), exit=1)
-                self.pkgrepo("set -s {0} -p test publisher/prefix=_invalid".format(
-                    repo_uri), exit=2)
+        # Verify set gracefully handles bad property values and
+        # properties that can't be set.
+        self.pkgrepo(
+            "set -s {0} -p test publisher/alias=_invalid".format(repo_uri),
+            exit=1,
+        )
+        self.pkgrepo(
+            "set -s {0} -p test publisher/prefix=_invalid".format(repo_uri),
+            exit=2,
+        )
 
-                # Verify set can set single value properties.
-                self.pkgrepo("set -s {0} -p all publisher/alias=test1".format(
-                    repo_uri))
-                self.pkgrepo("get -s {0} -p all -HF tsv publisher/alias "
-                    "publisher/prefix".format(repo_uri))
-                expected = """\
+        # Verify set can set single value properties.
+        self.pkgrepo("set -s {0} -p all publisher/alias=test1".format(repo_uri))
+        self.pkgrepo(
+            "get -s {0} -p all -HF tsv publisher/alias "
+            "publisher/prefix".format(repo_uri)
+        )
+        expected = """\
 test\tpublisher\talias\ttest1
 test\tpublisher\tprefix\ttest
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify set can set multi-value properties.
-                self.pkgrepo("set -s {0} -p all "
-                    "'repository/origins=(http://pkg.opensolaris.org/dev "
-                    "http://pkg-eu-2.opensolaris.org/dev)'".format(repo_uri))
-                self.pkgrepo("get -s {0} -p all -HF tsv repository/origins".format(
-                    repo_uri))
-                expected = """\
+        # Verify set can set multi-value properties.
+        self.pkgrepo(
+            "set -s {0} -p all "
+            "'repository/origins=(http://pkg.opensolaris.org/dev "
+            "http://pkg-eu-2.opensolaris.org/dev)'".format(repo_uri)
+        )
+        self.pkgrepo(
+            "get -s {0} -p all -HF tsv repository/origins".format(repo_uri)
+        )
+        expected = """\
 test\trepository\torigins\t(http://pkg-eu-2.opensolaris.org/dev/ http://pkg.opensolaris.org/dev/)
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify set can not set unknown properties.
-                self.pkgrepo("set -s {0} -p all 'foo/bar=value'".format(repo_uri),
-                    exit=2)
+        # Verify set can not set unknown properties.
+        self.pkgrepo(
+            "set -s {0} -p all 'foo/bar=value'".format(repo_uri), exit=2
+        )
 
-                # Add another publisher by setting a property for it.
-                self.pkgrepo("set -p test2 -s {0} publisher/alias=''".format(repo_uri))
+        # Add another publisher by setting a property for it.
+        self.pkgrepo("set -p test2 -s {0} publisher/alias=''".format(repo_uri))
 
-                # Verify get returns properties for multiple publishers.
-                expected = """\
+        # Verify get returns properties for multiple publishers.
+        expected = """\
 test\tpublisher\talias\ttest1
 test\tpublisher\tprefix\ttest
 test\trepository\tcollection-type\tcore
@@ -633,25 +668,27 @@ test2\trepository\trefresh-seconds\t""
 test2\trepository\tregistration-uri\t""
 test2\trepository\trelated-uris\t()
 """
-                self.pkgrepo("get -s {0} -p all -HFtsv".format(repo_uri))
-                self.assertEqualDiff(expected, self.output)
+        self.pkgrepo("get -s {0} -p all -HFtsv".format(repo_uri))
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("get -s {0} -p test -p test2 -HFtsv".format(repo_uri))
-                self.assertEqualDiff(expected, self.output)
+        self.pkgrepo("get -s {0} -p test -p test2 -HFtsv".format(repo_uri))
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify get can list multiple specific properties for
-                # multiple specific publishers correctly.
-                expected = """\
+        # Verify get can list multiple specific properties for
+        # multiple specific publishers correctly.
+        expected = """\
 test\tpublisher\talias\ttest1
 test2\tpublisher\talias\t""
 """
-                self.pkgrepo("get -s {0} -HFtsv -p test -p test2 "
-                    "publisher/alias".format(repo_uri))
-                self.assertEqualDiff(expected, self.output)
+        self.pkgrepo(
+            "get -s {0} -HFtsv -p test -p test2 "
+            "publisher/alias".format(repo_uri)
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify get has correct output even when some publishers
-                # can't be found (and exits with partial failure).
-                expected = """\
+        # Verify get has correct output even when some publishers
+        # can't be found (and exits with partial failure).
+        expected = """\
 test\tpublisher\talias\ttest1
 test\tpublisher\tprefix\ttest
 test\trepository\tcollection-type\tcore
@@ -664,980 +701,1083 @@ test\trepository\trefresh-seconds\t7200
 test\trepository\tregistration-uri\t""
 test\trepository\trelated-uris\t()
 """
-                self.pkgrepo("get -s {0} -p test -p bogus -HFtsv".format(repo_uri),
-                    exit=3)
-                self.assertEqualDiff(expected, self.output)
+        self.pkgrepo(
+            "get -s {0} -p test -p bogus -HFtsv".format(repo_uri), exit=3
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify set can set multiple properties for all or specific
-                # publishers when multiple publishers are known.
-                self.pkgrepo("set -s {0} -p all "
-                    "repository/description='Support Repository'".format(repo_uri))
-                expected = """\
+        # Verify set can set multiple properties for all or specific
+        # publishers when multiple publishers are known.
+        self.pkgrepo(
+            "set -s {0} -p all "
+            "repository/description='Support Repository'".format(repo_uri)
+        )
+        expected = """\
 test\trepository\tdescription\tSupport\\ Repository
 test2\trepository\tdescription\tSupport\\ Repository
 """
-                self.pkgrepo("get -s {0} -HFtsv -p all repository/description".format(
-                    repo_uri))
-                self.assertEqualDiff(expected, self.output)
+        self.pkgrepo(
+            "get -s {0} -HFtsv -p all repository/description".format(repo_uri)
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("set -s {0} -p test2 "
-                    "repository/description='2nd Support Repository'".format(
-                        repo_uri))
-                expected = """\
+        self.pkgrepo(
+            "set -s {0} -p test2 "
+            "repository/description='2nd Support Repository'".format(repo_uri)
+        )
+        expected = """\
 test\trepository\tdescription\tSupport\\ Repository
 test2\trepository\tdescription\t2nd\\ Support\\ Repository
 """
-                self.pkgrepo("get -s {0} -HFtsv -p all repository/description".format(
-                    repo_uri))
-                self.assertEqualDiff(expected, self.output)
+        self.pkgrepo(
+            "get -s {0} -HFtsv -p all repository/description".format(repo_uri)
+        )
+        self.assertEqualDiff(expected, self.output)
 
-        def __test_info(self, repo_path, repo_uri):
-                """Private function to verify publisher subcommand behaviour."""
+    def __test_info(self, repo_path, repo_uri):
+        """Private function to verify publisher subcommand behaviour."""
 
-                # Verify subcommand behaviour for empty repository and -H
-                # functionality.
-                self.pkgrepo("info -s {0}".format(repo_uri))
-                expected = """\
+        # Verify subcommand behaviour for empty repository and -H
+        # functionality.
+        self.pkgrepo("info -s {0}".format(repo_uri))
+        expected = """\
 PUBLISHER PACKAGES STATUS           UPDATED
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("info -s {0} -H".format(repo_uri))
-                expected = """\
+        self.pkgrepo("info -s {0} -H".format(repo_uri))
+        expected = """\
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Set a default publisher.
-                self.pkgrepo("set -s {0} publisher/prefix=test".format(repo_path))
+        # Set a default publisher.
+        self.pkgrepo("set -s {0} publisher/prefix=test".format(repo_path))
 
-                # If a depot is running, this will trigger a reload of the
-                # configuration data.
-                self.dc.refresh()
+        # If a depot is running, this will trigger a reload of the
+        # configuration data.
+        self.dc.refresh()
 
-                # Publish some packages.
-                self.pkgsend_bulk(repo_uri, (self.tree10, self.amber10,
-                    self.amber20, self.truck10, self.truck20))
+        # Publish some packages.
+        self.pkgsend_bulk(
+            repo_uri,
+            (
+                self.tree10,
+                self.amber10,
+                self.amber20,
+                self.truck10,
+                self.truck20,
+            ),
+        )
 
-                # Verify info handles unknown publishers gracefully.
-                self.pkgrepo("info -s {0} -p unknown".format(repo_uri), exit=1)
+        # Verify info handles unknown publishers gracefully.
+        self.pkgrepo("info -s {0} -p unknown".format(repo_uri), exit=1)
 
-                # Verify info returns partial failure if only some publishers
-                # cannot be found.
-                self.pkgrepo("info -s {0} -p test -p unknown".format(repo_uri), exit=3)
+        # Verify info returns partial failure if only some publishers
+        # cannot be found.
+        self.pkgrepo("info -s {0} -p test -p unknown".format(repo_uri), exit=3)
 
-                # Verify full default output.
-                repo = self.get_repo(repo_path)
-                self.pkgrepo("info -s {0} -H".format(repo_uri))
-                cat = repo.get_catalog("test")
-                cat_lm = cat.last_modified.isoformat()
-                expected = """\
+        # Verify full default output.
+        repo = self.get_repo(repo_path)
+        self.pkgrepo("info -s {0} -H".format(repo_uri))
+        cat = repo.get_catalog("test")
+        cat_lm = cat.last_modified.isoformat()
+        expected = """\
 test      3        online           {0}Z
-""".format(cat_lm)
-                self.assertEqualDiff(expected, self.output)
+""".format(
+            cat_lm
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify full tsv output.
-                self.pkgrepo("info -s {0} -HF tsv".format(repo_uri))
-                expected = """\
+        # Verify full tsv output.
+        self.pkgrepo("info -s {0} -HF tsv".format(repo_uri))
+        expected = """\
 test\t3\tonline\t{0}Z
-""".format(cat_lm)
-                self.assertEqualDiff(expected, self.output)
+""".format(
+            cat_lm
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify info specific publisher default output.
-                self.pkgrepo("info -s {0} -H -p test".format(repo_uri))
-                expected = """\
+        # Verify info specific publisher default output.
+        self.pkgrepo("info -s {0} -H -p test".format(repo_uri))
+        expected = """\
 test      3        online           {0}Z
-""".format(cat_lm)
-                self.assertEqualDiff(expected, self.output)
+""".format(
+            cat_lm
+        )
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify info specific publisher tsv output.
-                self.pkgrepo("info -s {0} -HF tsv -p test".format(repo_uri))
-                expected = """\
+        # Verify info specific publisher tsv output.
+        self.pkgrepo("info -s {0} -HF tsv -p test".format(repo_uri))
+        expected = """\
 test\t3\tonline\t{0}Z
-""".format(cat_lm)
-                self.assertEqualDiff(expected, self.output)
+""".format(
+            cat_lm
+        )
+        self.assertEqualDiff(expected, self.output)
 
-        def test_03_info(self):
-                """Verify pkgrepo info works as expected."""
-                def sort_lines(text):
-                        """Sort lines in text"""
-                        arr = text.split('\n')
-                        arr.sort()
-                        return "\n".join(arr)
+    def test_03_info(self):
+        """Verify pkgrepo info works as expected."""
 
-                # Verify command without a repository exits.
-                self.pkgrepo("info", exit=2)
+        def sort_lines(text):
+            """Sort lines in text"""
+            arr = text.split("\n")
+            arr.sort()
+            return "\n".join(arr)
 
-                # Create a repository, verify file-based repository access,
-                # and then discard the repository.
-                repo_path = self.dc.get_repodir()
-                repo_uri = self.dc.get_repo_url()
-                shutil.rmtree(repo_path)
-                self.create_repo(repo_path)
-                self.__test_info(repo_path, repo_uri)
-                shutil.rmtree(repo_path)
+        # Verify command without a repository exits.
+        self.pkgrepo("info", exit=2)
 
-                # Create a repository.
-                repo_path = self.dc.get_repodir()
-                self.create_repo(repo_path)
-                # Set a default publisher.
-                self.pkgrepo("set -s {0} publisher/prefix=test".format(repo_path))
-                plist = self.pkgsend_bulk(self.rurl, (self. tree10,
-                    self.amber10, self.amber20))
-                tree10 = fmri.PkgFmri(plist[0])
-                amber10 = fmri.PkgFmri(plist[1])
-                amber20 = fmri.PkgFmri(plist[2])
+        # Create a repository, verify file-based repository access,
+        # and then discard the repository.
+        repo_path = self.dc.get_repodir()
+        repo_uri = self.dc.get_repo_url()
+        shutil.rmtree(repo_path)
+        self.create_repo(repo_path)
+        self.__test_info(repo_path, repo_uri)
+        shutil.rmtree(repo_path)
 
-                # Add a new publisher and set it as default.
-                self.pkgrepo("add-publisher -s {0} test1".format(repo_path))
-                self.pkgrepo("set -s {0} publisher/prefix=test1".format(
-                    repo_uri))
-                repo = self.get_repo(self.dc.get_repodir())
-                plist = self.pkgsend_bulk(self.rurl, self.zoo10)
-                zoo10 = fmri.PkgFmri(plist[0])
+        # Create a repository.
+        repo_path = self.dc.get_repodir()
+        self.create_repo(repo_path)
+        # Set a default publisher.
+        self.pkgrepo("set -s {0} publisher/prefix=test".format(repo_path))
+        plist = self.pkgsend_bulk(
+            self.rurl, (self.tree10, self.amber10, self.amber20)
+        )
+        tree10 = fmri.PkgFmri(plist[0])
+        amber10 = fmri.PkgFmri(plist[1])
+        amber20 = fmri.PkgFmri(plist[2])
 
-                # Prep the archive.
-                arc_path = os.path.join(self.test_root,
-                    "test_info_empty_archive.p5p")
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                arc.close()
+        # Add a new publisher and set it as default.
+        self.pkgrepo("add-publisher -s {0} test1".format(repo_path))
+        self.pkgrepo("set -s {0} publisher/prefix=test1".format(repo_uri))
+        repo = self.get_repo(self.dc.get_repodir())
+        plist = self.pkgsend_bulk(self.rurl, self.zoo10)
+        zoo10 = fmri.PkgFmri(plist[0])
 
-                # pkg info on empty archive will not print anything.
-                self.pkgrepo("info -s {0} -HF tsv".format(arc_path))
-                self.assertEqualDiff("", self.output)
+        # Prep the archive.
+        arc_path = os.path.join(self.test_root, "test_info_empty_archive.p5p")
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        arc.close()
 
-                # Archive with one publisher and 2 packages. One of the
-                # package has two versions
-                arc_path = os.path.join(self.test_root,
-                    "test_info_1pub_archive.p5p")
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                # Create an archive with packages.
-                arc.add_repo_package(tree10, repo)
-                arc.add_repo_package(amber10, repo)
-                arc.add_repo_package(amber20, repo)
-                arc.close()
-                self.pkgrepo("info -s {0} -HF tsv".format(arc_path))
-                expected="""\
+        # pkg info on empty archive will not print anything.
+        self.pkgrepo("info -s {0} -HF tsv".format(arc_path))
+        self.assertEqualDiff("", self.output)
+
+        # Archive with one publisher and 2 packages. One of the
+        # package has two versions
+        arc_path = os.path.join(self.test_root, "test_info_1pub_archive.p5p")
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        # Create an archive with packages.
+        arc.add_repo_package(tree10, repo)
+        arc.add_repo_package(amber10, repo)
+        arc.add_repo_package(amber20, repo)
+        arc.close()
+        self.pkgrepo("info -s {0} -HF tsv".format(arc_path))
+        expected = """\
 test\t2\tonline\t2011-08-04T20:34:58Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Archive with two publishers.
-                arc_path = os.path.join(self.test_root,
-                    "test_info_2pub_archive.p5p")
-                arc = pkg.p5p.Archive(arc_path, mode="w")
-                arc.add_repo_package(tree10, repo)
-                arc.add_repo_package(amber10, repo)
-                arc.add_repo_package(amber20, repo)
-                arc.add_repo_package(zoo10, repo)
-                arc.close()
-                self.pkgrepo("info -s {0} -HF tsv".format(arc_path))
-                expected="""\
+        # Archive with two publishers.
+        arc_path = os.path.join(self.test_root, "test_info_2pub_archive.p5p")
+        arc = pkg.p5p.Archive(arc_path, mode="w")
+        arc.add_repo_package(tree10, repo)
+        arc.add_repo_package(amber10, repo)
+        arc.add_repo_package(amber20, repo)
+        arc.add_repo_package(zoo10, repo)
+        arc.close()
+        self.pkgrepo("info -s {0} -HF tsv".format(arc_path))
+        expected = """\
 test\t2\tonline\t2011-08-04T20:34:58Z
 test1\t1\tonline\t2011-08-04T20:34:58Z
 """
-                self.assertEqualDiff(sort_lines(expected), sort_lines(self.output))
-                shutil.rmtree(repo_path)
+        self.assertEqualDiff(sort_lines(expected), sort_lines(self.output))
+        shutil.rmtree(repo_path)
 
-                # Create a repository and verify http-based repository access.
-                self.assertTrue(not os.path.exists(repo_path))
-                self.create_repo(repo_path)
-                self.dc.clear_property("publisher", "prefix")
-                self.dc.start()
-                repo_uri = self.dc.get_depot_url()
-                self.__test_info(repo_path, repo_uri)
-                self.dc.stop()
+        # Create a repository and verify http-based repository access.
+        self.assertTrue(not os.path.exists(repo_path))
+        self.create_repo(repo_path)
+        self.dc.clear_property("publisher", "prefix")
+        self.dc.start()
+        repo_uri = self.dc.get_depot_url()
+        self.__test_info(repo_path, repo_uri)
+        self.dc.stop()
 
-        def __test_rebuild(self, repo_path, repo_uri):
-                """Private function to verify rebuild subcommand behaviour."""
+    def __test_rebuild(self, repo_path, repo_uri):
+        """Private function to verify rebuild subcommand behaviour."""
 
-                #
-                # Verify rebuild works for an empty repository.
-                #
-                repo = self.get_repo(repo_path)
-                lm = repo.get_catalog("test").last_modified.isoformat()
-                self.pkgrepo("rebuild -s {0}".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path)
-                nlm = repo.get_catalog("test").last_modified.isoformat()
-                self.assertNotEqual(lm, nlm)
+        #
+        # Verify rebuild works for an empty repository.
+        #
+        repo = self.get_repo(repo_path)
+        lm = repo.get_catalog("test").last_modified.isoformat()
+        self.pkgrepo("rebuild -s {0}".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path)
+        nlm = repo.get_catalog("test").last_modified.isoformat()
+        self.assertNotEqual(lm, nlm)
 
-                #
-                # Verify rebuild --no-index works for an empty repository.
-                #
-                lm = repo.get_catalog("test").last_modified.isoformat()
-                self.pkgrepo("rebuild -s {0} --no-index".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path)
-                nlm = repo.get_catalog("test").last_modified.isoformat()
-                self.assertNotEqual(lm, nlm)
+        #
+        # Verify rebuild --no-index works for an empty repository.
+        #
+        lm = repo.get_catalog("test").last_modified.isoformat()
+        self.pkgrepo("rebuild -s {0} --no-index".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path)
+        nlm = repo.get_catalog("test").last_modified.isoformat()
+        self.assertNotEqual(lm, nlm)
 
-                #
-                # Verify rebuild --no-catalog works for an empty repository,
-                # and that the catalog itself does not change.
-                #
-                lm = repo.get_catalog("test").last_modified.isoformat()
-                self.pkgrepo("rebuild -s {0} --no-catalog".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path)
-                nlm = repo.get_catalog("test").last_modified.isoformat()
-                self.assertEqual(lm, nlm)
+        #
+        # Verify rebuild --no-catalog works for an empty repository,
+        # and that the catalog itself does not change.
+        #
+        lm = repo.get_catalog("test").last_modified.isoformat()
+        self.pkgrepo("rebuild -s {0} --no-catalog".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path)
+        nlm = repo.get_catalog("test").last_modified.isoformat()
+        self.assertEqual(lm, nlm)
 
-                #
-                # Publish some packages and verify they are known afterwards.
-                #
-                plist = self.pkgsend_bulk(repo_uri, (self.amber10, self.tree10))
-                repo = self.get_repo(repo_path)
-                self.assertEqual(list(
-                    str(f) for f in repo.get_catalog("test").fmris(ordered=True)
-                ), plist)
+        #
+        # Publish some packages and verify they are known afterwards.
+        #
+        plist = self.pkgsend_bulk(repo_uri, (self.amber10, self.tree10))
+        repo = self.get_repo(repo_path)
+        self.assertEqual(
+            list(str(f) for f in repo.get_catalog("test").fmris(ordered=True)),
+            plist,
+        )
 
-                #
-                # Verify that rebuild --no-catalog works for a repository with
-                # packages.
-                #
+        #
+        # Verify that rebuild --no-catalog works for a repository with
+        # packages.
+        #
 
-                # Now rebuild and verify packages are still known and catalog
-                # remains unchanged.
-                lm = repo.get_catalog("test").last_modified.isoformat()
-                self.pkgrepo("rebuild -s {0} --no-catalog".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path)
-                self.assertEqual(plist,
-                    list(str(f) for f in repo.get_catalog("test").fmris(
-                    ordered=True)))
-                nlm = repo.get_catalog("test").last_modified.isoformat()
-                self.assertEqual(lm, nlm)
+        # Now rebuild and verify packages are still known and catalog
+        # remains unchanged.
+        lm = repo.get_catalog("test").last_modified.isoformat()
+        self.pkgrepo("rebuild -s {0} --no-catalog".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path)
+        self.assertEqual(
+            plist,
+            list(str(f) for f in repo.get_catalog("test").fmris(ordered=True)),
+        )
+        nlm = repo.get_catalog("test").last_modified.isoformat()
+        self.assertEqual(lm, nlm)
 
-                # Destroy the catalog.
-                repo.get_catalog("test").destroy()
+        # Destroy the catalog.
+        repo.get_catalog("test").destroy()
 
-                # Reload the repository object and verify no packages are known.
-                repo = self.get_repo(repo_path)
-                self.assertEqual(set(), repo.get_catalog("test").names())
+        # Reload the repository object and verify no packages are known.
+        repo = self.get_repo(repo_path)
+        self.assertEqual(set(), repo.get_catalog("test").names())
 
-                # Now rebuild and verify packages are still unknown and catalog
-                # remains unchanged.
-                lm = repo.get_catalog("test").last_modified.isoformat()
-                self.pkgrepo("rebuild -s {0} --no-catalog".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path)
-                self.assertEqual(set(), repo.get_catalog("test").names())
-                nlm = repo.get_catalog("test").last_modified.isoformat()
-                self.assertEqual(lm, nlm)
+        # Now rebuild and verify packages are still unknown and catalog
+        # remains unchanged.
+        lm = repo.get_catalog("test").last_modified.isoformat()
+        self.pkgrepo("rebuild -s {0} --no-catalog".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path)
+        self.assertEqual(set(), repo.get_catalog("test").names())
+        nlm = repo.get_catalog("test").last_modified.isoformat()
+        self.assertEqual(lm, nlm)
 
-                #
-                # Verify rebuild will find all the packages again and that they
-                # can be searched for.
-                #
+        #
+        # Verify rebuild will find all the packages again and that they
+        # can be searched for.
+        #
 
-                # Destroy the catalog.
-                repo.get_catalog("test").destroy()
+        # Destroy the catalog.
+        repo.get_catalog("test").destroy()
 
-                # Reload the repository object and verify no packages are known.
-                repo = self.get_repo(repo_path)
-                self.assertEqual(set(), repo.get_catalog("test").names())
+        # Reload the repository object and verify no packages are known.
+        repo = self.get_repo(repo_path)
+        self.assertEqual(set(), repo.get_catalog("test").names())
 
-                # Now rebuild and verify packages are known and can be searched
-                # for.
-                self.pkgrepo("rebuild -s {0}".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path)
-                self.assertEqual(plist,
-                    list(str(f) for f in repo.get_catalog("test").fmris(
-                    ordered=True)))
+        # Now rebuild and verify packages are known and can be searched
+        # for.
+        self.pkgrepo("rebuild -s {0}".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path)
+        self.assertEqual(
+            plist,
+            list(str(f) for f in repo.get_catalog("test").fmris(ordered=True)),
+        )
 
-                query = Query("tree", False, Query.RETURN_PACKAGES, None, None)
-                result = list(e for e in [r for r in repo.search([query])][0])
-                fmris = [fmri.PkgFmri(f).get_fmri(anarchy=True) for f in plist]
-                expected = [
-                    [1, 2, [fmris[0], 'require',
-                        'depend fmri=pkg:/tree@1.0 type=require\n']],
-                    [1, 2, [fmris[1], 'test/tree',
-                        'set name=pkg.fmri value={0}\n'.format(plist[1])]]
-                ]
+        query = Query("tree", False, Query.RETURN_PACKAGES, None, None)
+        result = list(e for e in [r for r in repo.search([query])][0])
+        fmris = [fmri.PkgFmri(f).get_fmri(anarchy=True) for f in plist]
+        expected = [
+            [
+                1,
+                2,
+                [
+                    fmris[0],
+                    "require",
+                    "depend fmri=pkg:/tree@1.0 type=require\n",
+                ],
+            ],
+            [
+                1,
+                2,
+                [
+                    fmris[1],
+                    "test/tree",
+                    "set name=pkg.fmri value={0}\n".format(plist[1]),
+                ],
+            ],
+        ]
 
-                # To ensure comparison works, the actual FMRI object in the
-                # result has to be stringified.
-                result = [list(e) for e in expected]
-                for e in result:
-                        e[2] = list(e[2])
-                        e[2][0] = str(e[2][0])
-                self.assertEqualDiff(expected, result)
+        # To ensure comparison works, the actual FMRI object in the
+        # result has to be stringified.
+        result = [list(e) for e in expected]
+        for e in result:
+            e[2] = list(e[2])
+            e[2][0] = str(e[2][0])
+        self.assertEqualDiff(expected, result)
 
-                #
-                # Now rebuild again, but with --no-index, and verify that
-                # search data is gone.
-                #
+        #
+        # Now rebuild again, but with --no-index, and verify that
+        # search data is gone.
+        #
 
-                # Destroy the catalog only (to verify that rebuild destroys
-                # the index).
-                repo.get_catalog("test").destroy()
+        # Destroy the catalog only (to verify that rebuild destroys
+        # the index).
+        repo.get_catalog("test").destroy()
 
-                # Reload the repository object and verify no packages are known.
-                repo = self.get_repo(repo_path)
-                self.assertEqual(set(), repo.get_catalog("test").names())
+        # Reload the repository object and verify no packages are known.
+        repo = self.get_repo(repo_path)
+        self.assertEqual(set(), repo.get_catalog("test").names())
 
-                self.pkgrepo("rebuild -s {0} --no-index".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path, read_only=True)
-                self.assertEqual(plist,
-                    list(str(f) for f in repo.get_catalog("test").fmris(
-                    ordered=True)))
+        self.pkgrepo("rebuild -s {0} --no-index".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path, read_only=True)
+        self.assertEqual(
+            plist,
+            list(str(f) for f in repo.get_catalog("test").fmris(ordered=True)),
+        )
 
-                query = Query("tree", False, Query.RETURN_PACKAGES, None, None)
-                try:
-                        result = list(
-                            e for e in [
-                                r for r in repo.search([query])
-                            ][0]
-                        )
-                except Exception as e:
-                        self.debug("query exception: {0}".format(e))
-                        self.assertTrue(isinstance(e,
-                            sr.RepositorySearchUnavailableError))
-                else:
-                        raise RuntimeError("Expected "
-                            "RepositorySearchUnavailableError")
+        query = Query("tree", False, Query.RETURN_PACKAGES, None, None)
+        try:
+            result = list(e for e in [r for r in repo.search([query])][0])
+        except Exception as e:
+            self.debug("query exception: {0}".format(e))
+            self.assertTrue(isinstance(e, sr.RepositorySearchUnavailableError))
+        else:
+            raise RuntimeError("Expected " "RepositorySearchUnavailableError")
 
-        def test_04_rebuild(self):
-                """Verify pkgrepo rebuild works as expected."""
+    def test_04_rebuild(self):
+        """Verify pkgrepo rebuild works as expected."""
 
-                # Verify rebuild without a target exits.
-                self.pkgrepo("rebuild", exit=2)
+        # Verify rebuild without a target exits.
+        self.pkgrepo("rebuild", exit=2)
 
-                # Create a repository, verify file-based repository access,
-                # and then discard the repository.
-                repo_path = self.dc.get_repodir()
-                repo_uri = self.dc.get_repo_url()
-                self.__test_rebuild(repo_path, repo_uri)
-                shutil.rmtree(repo_path)
+        # Create a repository, verify file-based repository access,
+        # and then discard the repository.
+        repo_path = self.dc.get_repodir()
+        repo_uri = self.dc.get_repo_url()
+        self.__test_rebuild(repo_path, repo_uri)
+        shutil.rmtree(repo_path)
 
-                # Create a repository, add a publisher, remove its catalog,
-                # and then verify rebuild still works.
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("add-publisher -s {0} test".format(repo_path))
-                repo = self.get_repo(repo_path, read_only=True)
-                cat = repo.get_catalog(pub="test")
-                cat.destroy()
-                self.pkgrepo("rebuild -s {0}".format(repo_path))
-                shutil.rmtree(repo_path)
+        # Create a repository, add a publisher, remove its catalog,
+        # and then verify rebuild still works.
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("add-publisher -s {0} test".format(repo_path))
+        repo = self.get_repo(repo_path, read_only=True)
+        cat = repo.get_catalog(pub="test")
+        cat.destroy()
+        self.pkgrepo("rebuild -s {0}".format(repo_path))
+        shutil.rmtree(repo_path)
 
-                # Create a repository and verify network-based repository
-                # access.
-                self.assertTrue(not os.path.exists(repo_path))
-                self.create_repo(repo_path, properties={ "publisher": {
-                    "prefix": "test" } })
-                self.dc.clear_property("publisher", "prefix")
-                self.dc.start()
-                repo_uri = self.dc.get_depot_url()
-                self.__test_rebuild(repo_path, repo_uri)
+        # Create a repository and verify network-based repository
+        # access.
+        self.assertTrue(not os.path.exists(repo_path))
+        self.create_repo(
+            repo_path, properties={"publisher": {"prefix": "test"}}
+        )
+        self.dc.clear_property("publisher", "prefix")
+        self.dc.start()
+        repo_uri = self.dc.get_depot_url()
+        self.__test_rebuild(repo_path, repo_uri)
 
-                # Verify rebuild only rebuilds package data for specified
-                # publisher in the case that the repository contains package
-                # data for multiple publishers.
-                self.pkgsend_bulk(repo_uri, """
+        # Verify rebuild only rebuilds package data for specified
+        # publisher in the case that the repository contains package
+        # data for multiple publishers.
+        self.pkgsend_bulk(
+            repo_uri,
+            """
                     open pkg://test2/foo@1.0
                     close
-                    """)
+                    """,
+        )
 
-                repo = self.get_repo(repo_path, read_only=True)
-                cat = repo.get_catalog(pub="test")
-                test_cts = cat.created
-                cat = repo.get_catalog(pub="test2")
-                test2_cts = cat.created
+        repo = self.get_repo(repo_path, read_only=True)
+        cat = repo.get_catalog(pub="test")
+        test_cts = cat.created
+        cat = repo.get_catalog(pub="test2")
+        test2_cts = cat.created
 
-                self.pkgrepo("rebuild -s {0} -p test".format(repo_uri))
-                self.wait_repo(repo_path)
+        self.pkgrepo("rebuild -s {0} -p test".format(repo_uri))
+        self.wait_repo(repo_path)
 
-                # Now compare creation timestamps of each publisher's
-                # catalog to verify only test's catalog was rebuilt.
-                repo = self.get_repo(repo_path, read_only=True)
-                cat = repo.get_catalog(pub="test")
-                self.assertNotEqual(cat.created, test_cts)
-                test_cts = cat.created
-                cat = repo.get_catalog(pub="test2")
-                self.assertEqual(cat.created, test2_cts)
-                test2_cts = cat.created
+        # Now compare creation timestamps of each publisher's
+        # catalog to verify only test's catalog was rebuilt.
+        repo = self.get_repo(repo_path, read_only=True)
+        cat = repo.get_catalog(pub="test")
+        self.assertNotEqual(cat.created, test_cts)
+        test_cts = cat.created
+        cat = repo.get_catalog(pub="test2")
+        self.assertEqual(cat.created, test2_cts)
+        test2_cts = cat.created
 
-                # Verify rebuild without specifying a publisher
-                # will rebuild the catalogs for all publishers.
-                self.pkgrepo("rebuild -s {0}".format(repo_uri))
-                self.wait_repo(repo_path)
-                self.dc.stop()
+        # Verify rebuild without specifying a publisher
+        # will rebuild the catalogs for all publishers.
+        self.pkgrepo("rebuild -s {0}".format(repo_uri))
+        self.wait_repo(repo_path)
+        self.dc.stop()
 
-                # Now compare creation timestamps of each publisher's
-                # catalog to verify all catalogs were rebuilt.
-                repo = self.get_repo(repo_path, read_only=True)
-                cat = repo.get_catalog(pub="test")
-                self.assertNotEqual(cat.created, test_cts)
-                cat = repo.get_catalog(pub="test2")
-                self.assertNotEqual(cat.created, test2_cts)
-                shutil.rmtree(repo_path)
+        # Now compare creation timestamps of each publisher's
+        # catalog to verify all catalogs were rebuilt.
+        repo = self.get_repo(repo_path, read_only=True)
+        cat = repo.get_catalog(pub="test")
+        self.assertNotEqual(cat.created, test_cts)
+        cat = repo.get_catalog(pub="test2")
+        self.assertNotEqual(cat.created, test2_cts)
+        shutil.rmtree(repo_path)
 
-                # Now create a repository, publish a package, and deposit a
-                # junk file in the manifest directory.
-                self.assertTrue(not os.path.exists(repo_path))
-                self.create_repo(repo_path)
-                pfmri = self.pkgsend_bulk(repo_path, """
+        # Now create a repository, publish a package, and deposit a
+        # junk file in the manifest directory.
+        self.assertTrue(not os.path.exists(repo_path))
+        self.create_repo(repo_path)
+        pfmri = self.pkgsend_bulk(
+            repo_path,
+            """
                     open pkg://test/foo@1.0
                     close
-                    """)[0]
-                repo = self.get_repo(repo_path, read_only=True)
-                mdir = os.path.dirname(repo.manifest(pfmri))
-                jpath = os.path.join(mdir, "junk")
-                with open(jpath, "w") as f:
-                        f.write("random junk")
-                self.assertTrue(os.path.exists(jpath))
+                    """,
+        )[0]
+        repo = self.get_repo(repo_path, read_only=True)
+        mdir = os.path.dirname(repo.manifest(pfmri))
+        jpath = os.path.join(mdir, "junk")
+        with open(jpath, "w") as f:
+            f.write("random junk")
+        self.assertTrue(os.path.exists(jpath))
 
-                # Verify rebuild succeeds.
-                self.pkgrepo("rebuild -s {0}".format(repo_path))
+        # Verify rebuild succeeds.
+        self.pkgrepo("rebuild -s {0}".format(repo_path))
 
-                # Verify junk file is still there.
-                self.assertTrue(os.path.exists(jpath))
+        # Verify junk file is still there.
+        self.assertTrue(os.path.exists(jpath))
 
-                # Verify expected package is still known.
-                repo = self.get_repo(repo_path, read_only=True)
-                self.assertEqualDiff([pfmri],
-                    [str(f) for f in repo.get_catalog("test").fmris()])
+        # Verify expected package is still known.
+        repo = self.get_repo(repo_path, read_only=True)
+        self.assertEqualDiff(
+            [pfmri], [str(f) for f in repo.get_catalog("test").fmris()]
+        )
 
-                # Now verify that 'pkgrepo rebuild' will still work
-                # (filesystem-based repos only) if the catalog is corrupted.
-                cat = repo.get_catalog("test")
-                part = cat.get_part("catalog.attrs")
-                apath = part.pathname
+        # Now verify that 'pkgrepo rebuild' will still work
+        # (filesystem-based repos only) if the catalog is corrupted.
+        cat = repo.get_catalog("test")
+        part = cat.get_part("catalog.attrs")
+        apath = part.pathname
 
-                with open(apath, "r+b") as cfile:
-                        cfile.truncate(4)
-                        cfile.close()
+        with open(apath, "r+b") as cfile:
+            cfile.truncate(4)
+            cfile.close()
 
-                # Should fail, since catalog is corrupt.
-                self.pkgrepo("refresh -s {0}".format(repo_path), exit=1)
+        # Should fail, since catalog is corrupt.
+        self.pkgrepo("refresh -s {0}".format(repo_path), exit=1)
 
-                # Should fail, because --no-catalog was specified.
-                self.pkgrepo("rebuild -s {0} --no-catalog".format(repo_path), exit=1)
+        # Should fail, because --no-catalog was specified.
+        self.pkgrepo("rebuild -s {0} --no-catalog".format(repo_path), exit=1)
 
-                # Should succeed.
-                self.pkgrepo("rebuild -s {0} --no-index".format(repo_path))
+        # Should succeed.
+        self.pkgrepo("rebuild -s {0} --no-index".format(repo_path))
 
-                # Should succeed now that catalog is valid.
-                self.pkgrepo("refresh -s {0}".format(repo_path))
+        # Should succeed now that catalog is valid.
+        self.pkgrepo("refresh -s {0}".format(repo_path))
 
-                # Verify expected package is still known.
-                self.assertEqualDiff([pfmri],
-                    [str(f) for f in repo.get_catalog("test").fmris()])
+        # Verify expected package is still known.
+        self.assertEqualDiff(
+            [pfmri], [str(f) for f in repo.get_catalog("test").fmris()]
+        )
 
-        def __test_refresh(self, repo_path, repo_uri):
-                """Private function to verify refresh subcommand behaviour."""
+    def __test_refresh(self, repo_path, repo_uri):
+        """Private function to verify refresh subcommand behaviour."""
 
-                # Verify refresh doesn't fail for an empty repository.
-                self.pkgrepo("refresh -s {0}".format(repo_path))
-                self.wait_repo(repo_path)
+        # Verify refresh doesn't fail for an empty repository.
+        self.pkgrepo("refresh -s {0}".format(repo_path))
+        self.wait_repo(repo_path)
 
-                # Publish some packages.
-                plist = self.pkgsend_bulk(repo_uri, (self.amber10, self.tree10))
+        # Publish some packages.
+        plist = self.pkgsend_bulk(repo_uri, (self.amber10, self.tree10))
 
-                #
-                # Verify refresh will find new packages and that they can be
-                # searched for.
-                #
+        #
+        # Verify refresh will find new packages and that they can be
+        # searched for.
+        #
 
-                # Reload the repository object and verify published packages
-                # are known.
-                repo = self.get_repo(repo_path, read_only=True)
-                self.assertEqual(plist,
-                    list(str(f) for f in repo.get_catalog("test").fmris(
-                    ordered=True)))
+        # Reload the repository object and verify published packages
+        # are known.
+        repo = self.get_repo(repo_path, read_only=True)
+        self.assertEqual(
+            plist,
+            list(str(f) for f in repo.get_catalog("test").fmris(ordered=True)),
+        )
 
-                self.pkgrepo("refresh -s {0}".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path, read_only=True)
-                self.assertEqual(plist,
-                    list(str(f) for f in repo.get_catalog("test").fmris(
-                    ordered=True)))
+        self.pkgrepo("refresh -s {0}".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path, read_only=True)
+        self.assertEqual(
+            plist,
+            list(str(f) for f in repo.get_catalog("test").fmris(ordered=True)),
+        )
 
-                query = Query("tree", False, Query.RETURN_PACKAGES, None, None)
-                result = list(e for e in [r for r in repo.search([query])][0])
-                fmris = [fmri.PkgFmri(f).get_fmri(anarchy=True) for f in plist]
-                expected = [
-                    [1, 2, [fmris[0], 'require',
-                        'depend fmri=pkg:/tree@1.0 type=require\n']],
-                    [1, 2, [fmris[1], 'test/tree',
-                        'set name=pkg.fmri value={0}\n'.format(plist[1])]]
-                ]
+        query = Query("tree", False, Query.RETURN_PACKAGES, None, None)
+        result = list(e for e in [r for r in repo.search([query])][0])
+        fmris = [fmri.PkgFmri(f).get_fmri(anarchy=True) for f in plist]
+        expected = [
+            [
+                1,
+                2,
+                [
+                    fmris[0],
+                    "require",
+                    "depend fmri=pkg:/tree@1.0 type=require\n",
+                ],
+            ],
+            [
+                1,
+                2,
+                [
+                    fmris[1],
+                    "test/tree",
+                    "set name=pkg.fmri value={0}\n".format(plist[1]),
+                ],
+            ],
+        ]
 
-                # To ensure comparison works, the actual FMRI object in the
-                # result has to be stringified.
-                result = [list(e) for e in expected]
-                for e in result:
-                        e[2] = list(e[2])
-                        e[2][0] = str(e[2][0])
-                self.assertEqualDiff(expected, result)
+        # To ensure comparison works, the actual FMRI object in the
+        # result has to be stringified.
+        result = [list(e) for e in expected]
+        for e in result:
+            e[2] = list(e[2])
+            e[2][0] = str(e[2][0])
+        self.assertEqualDiff(expected, result)
 
-                #
-                # Now publish a new package and refresh again with --no-index,
-                # and verify that search data doesn't include the new package.
-                #
-                plist.extend(self.pkgsend_bulk(repo_uri, self.truck10))
-                fmris.append(fmri.PkgFmri(plist[-1]).get_fmri(anarchy=True))
+        #
+        # Now publish a new package and refresh again with --no-index,
+        # and verify that search data doesn't include the new package.
+        #
+        plist.extend(self.pkgsend_bulk(repo_uri, self.truck10))
+        fmris.append(fmri.PkgFmri(plist[-1]).get_fmri(anarchy=True))
 
-                self.pkgrepo("refresh -s {0} --no-index".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path, read_only=True)
-                self.assertEqualDiff(plist,
-                    list(str(f) for f in repo.get_catalog("test").fmris(
-                    ordered=True)))
+        self.pkgrepo("refresh -s {0} --no-index".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path, read_only=True)
+        self.assertEqualDiff(
+            plist,
+            list(str(f) for f in repo.get_catalog("test").fmris(ordered=True)),
+        )
 
-                query = Query("truck", False, Query.RETURN_PACKAGES, None, None)
-                result = list(e for e in [r for r in repo.search([query])][0])
-                self.assertEqualDiff([], result)
+        query = Query("truck", False, Query.RETURN_PACKAGES, None, None)
+        result = list(e for e in [r for r in repo.search([query])][0])
+        self.assertEqualDiff([], result)
 
-                #
-                # Now publish a new package and refresh again with --no-catalog,
-                # the package above should now be returned by search, but the
-                # just published package shouldn't be found in the catalog or
-                # search.
-                #
-                plist.extend(self.pkgsend_bulk(repo_uri, self.zoo10,
-                    no_catalog=True))
-                fmris.append(fmri.PkgFmri(plist[-1]).get_fmri(anarchy=True))
+        #
+        # Now publish a new package and refresh again with --no-catalog,
+        # the package above should now be returned by search, but the
+        # just published package shouldn't be found in the catalog or
+        # search.
+        #
+        plist.extend(self.pkgsend_bulk(repo_uri, self.zoo10, no_catalog=True))
+        fmris.append(fmri.PkgFmri(plist[-1]).get_fmri(anarchy=True))
 
-                self.pkgrepo("refresh -s {0} --no-catalog".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path, read_only=True)
-                self.assertEqual(plist[:-1], list(
-                    str(f) for f in repo.get_catalog("test").fmris(ordered=True)
-                ))
+        self.pkgrepo("refresh -s {0} --no-catalog".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path, read_only=True)
+        self.assertEqual(
+            plist[:-1],
+            list(str(f) for f in repo.get_catalog("test").fmris(ordered=True)),
+        )
 
-                query = Query("truck", False, Query.RETURN_PACKAGES, None, None)
-                result = list(e for e in [r for r in repo.search([query])][0])
-                fmris = [fmri.PkgFmri(f).get_fmri(anarchy=True) for f in plist]
-                expected = [
-                ]
+        query = Query("truck", False, Query.RETURN_PACKAGES, None, None)
+        result = list(e for e in [r for r in repo.search([query])][0])
+        fmris = [fmri.PkgFmri(f).get_fmri(anarchy=True) for f in plist]
+        expected = []
 
-                query = Query("zoo", False, Query.RETURN_PACKAGES, None, None)
-                result = list(e for e in [r for r in repo.search([query])][0])
-                self.assertEqualDiff([], result)
+        query = Query("zoo", False, Query.RETURN_PACKAGES, None, None)
+        result = list(e for e in [r for r in repo.search([query])][0])
+        self.assertEqualDiff([], result)
 
-                # Store time all packages in catalog were added.
-                cat = repo.get_catalog("test")
-                uname = [part for part in cat.updates][0]
-                ulog = pkg.catalog.CatalogUpdate(uname, meta_root=cat.meta_root)
-                expected = set()
-                for pfmri, op_type, op_time, metadata in ulog.updates():
-                        expected.add((str(pfmri), op_time))
+        # Store time all packages in catalog were added.
+        cat = repo.get_catalog("test")
+        uname = [part for part in cat.updates][0]
+        ulog = pkg.catalog.CatalogUpdate(uname, meta_root=cat.meta_root)
+        expected = set()
+        for pfmri, op_type, op_time, metadata in ulog.updates():
+            expected.add((str(pfmri), op_time))
 
-                # Finally, run refresh once more and verify that all packages
-                # are now visible in the catalog and that refresh was
-                # incremental.
-                self.pkgrepo("refresh -s {0}".format(repo_uri))
-                self.wait_repo(repo_path)
-                repo = self.get_repo(repo_path, read_only=True)
-                self.assertEqual(plist, list(
-                    str(f) for f in repo.get_catalog("test").fmris(ordered=True)
-                ))
+        # Finally, run refresh once more and verify that all packages
+        # are now visible in the catalog and that refresh was
+        # incremental.
+        self.pkgrepo("refresh -s {0}".format(repo_uri))
+        self.wait_repo(repo_path)
+        repo = self.get_repo(repo_path, read_only=True)
+        self.assertEqual(
+            plist,
+            list(str(f) for f in repo.get_catalog("test").fmris(ordered=True)),
+        )
 
-                # Get time all packages in catalog were added.
-                cat = repo.get_catalog("test")
-                uname = [part for part in cat.updates][0]
-                ulog = pkg.catalog.CatalogUpdate(uname, meta_root=cat.meta_root)
-                returned = set()
-                for pfmri, op_type, op_time, metadata in ulog.updates():
-                        if pfmri.pkg_name == "zoo":
-                                continue
-                        returned.add((str(pfmri), op_time))
+        # Get time all packages in catalog were added.
+        cat = repo.get_catalog("test")
+        uname = [part for part in cat.updates][0]
+        ulog = pkg.catalog.CatalogUpdate(uname, meta_root=cat.meta_root)
+        returned = set()
+        for pfmri, op_type, op_time, metadata in ulog.updates():
+            if pfmri.pkg_name == "zoo":
+                continue
+            returned.add((str(pfmri), op_time))
 
-                # Entries for all packages (except zoo) should have the same
-                # operation timestamp (when they were added) before the pkgrepo
-                # refresh in update log.
-                self.assertEqualDiff(expected, returned)
+        # Entries for all packages (except zoo) should have the same
+        # operation timestamp (when they were added) before the pkgrepo
+        # refresh in update log.
+        self.assertEqualDiff(expected, returned)
 
-        def test_05_refresh(self):
-                """Verify pkgrepo refresh works as expected."""
+    def test_05_refresh(self):
+        """Verify pkgrepo refresh works as expected."""
 
-                # Verify create without a destination exits.
-                self.pkgrepo("refresh", exit=2)
+        # Verify create without a destination exits.
+        self.pkgrepo("refresh", exit=2)
 
-                # Create a repository, verify file-based repository access,
-                # and then discard the repository.
-                repo_path = self.dc.get_repodir()
-                repo_uri = self.dc.get_repo_url()
-                self.__test_refresh(repo_path, repo_uri)
-                shutil.rmtree(repo_path)
+        # Create a repository, verify file-based repository access,
+        # and then discard the repository.
+        repo_path = self.dc.get_repodir()
+        repo_uri = self.dc.get_repo_url()
+        self.__test_refresh(repo_path, repo_uri)
+        shutil.rmtree(repo_path)
 
-                # Create a repository, add a publisher, remove its catalog,
-                # and then verify refresh still works.
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("add-publisher -s {0} test".format(repo_path))
-                repo = self.get_repo(repo_path, read_only=True)
-                cat = repo.get_catalog(pub="test")
-                cat.destroy()
-                self.pkgrepo("refresh -s {0}".format(repo_path))
-                shutil.rmtree(repo_path)
+        # Create a repository, add a publisher, remove its catalog,
+        # and then verify refresh still works.
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("add-publisher -s {0} test".format(repo_path))
+        repo = self.get_repo(repo_path, read_only=True)
+        cat = repo.get_catalog(pub="test")
+        cat.destroy()
+        self.pkgrepo("refresh -s {0}".format(repo_path))
+        shutil.rmtree(repo_path)
 
-                # Create a repository and verify network-based repository
-                # access.
-                self.assertTrue(not os.path.exists(repo_path))
-                self.create_repo(repo_path, properties={ "publisher": {
-                    "prefix": "test" } })
-                self.dc.clear_property("publisher", "prefix")
-                self.dc.start()
-                repo_uri = self.dc.get_depot_url()
-                self.__test_refresh(repo_path, repo_uri)
+        # Create a repository and verify network-based repository
+        # access.
+        self.assertTrue(not os.path.exists(repo_path))
+        self.create_repo(
+            repo_path, properties={"publisher": {"prefix": "test"}}
+        )
+        self.dc.clear_property("publisher", "prefix")
+        self.dc.start()
+        repo_uri = self.dc.get_depot_url()
+        self.__test_refresh(repo_path, repo_uri)
 
-                # Verify refresh only refreshes package data for specified
-                # publisher in the case that the repository contains package
-                # data for multiple publishers.
+        # Verify refresh only refreshes package data for specified
+        # publisher in the case that the repository contains package
+        # data for multiple publishers.
 
-                # This is needed to ensure test2 exists as a publisher before
-                # the package ever is created.
-                self.pkgrepo("set -s {0} -p test2 publisher/alias=".format(repo_path))
-                self.dc.stop()
-                self.dc.start()
+        # This is needed to ensure test2 exists as a publisher before
+        # the package ever is created.
+        self.pkgrepo("set -s {0} -p test2 publisher/alias=".format(repo_path))
+        self.dc.stop()
+        self.dc.start()
 
-                repo = self.get_repo(repo_path, read_only=True)
-                cat = repo.get_catalog(pub="test")
-                test_plist = [str(f) for f in cat.fmris()]
-                cat = repo.get_catalog(pub="test2")
-                test2_plist = [str(f) for f in cat.fmris()]
+        repo = self.get_repo(repo_path, read_only=True)
+        cat = repo.get_catalog(pub="test")
+        test_plist = [str(f) for f in cat.fmris()]
+        cat = repo.get_catalog(pub="test2")
+        test2_plist = [str(f) for f in cat.fmris()]
 
-                self.pkgsend_bulk(repo_uri, """
+        self.pkgsend_bulk(
+            repo_uri,
+            """
                     open pkg://test/refresh@1.0
                     close
                     open pkg://test2/refresh@1.0
                     close
-                    """, no_catalog=True)
+                    """,
+            no_catalog=True,
+        )
 
-                self.pkgrepo("refresh -s {0} -p test".format(repo_uri))
-                self.wait_repo(repo_path)
+        self.pkgrepo("refresh -s {0} -p test".format(repo_uri))
+        self.wait_repo(repo_path)
 
-                # Now compare package lists to ensure new package is only seen
-                # for 'test' publisher.
-                repo = self.get_repo(repo_path, read_only=True)
-                cat = repo.get_catalog(pub="test")
-                self.assertNotEqual([str(f) for f in cat.fmris()], test_plist)
-                test_plist = [str(f) for f in cat.fmris()]
-                cat = repo.get_catalog(pub="test2")
-                self.assertEqual([str(f) for f in cat.fmris()], test2_plist)
-                test2_plist = [str(f) for f in cat.fmris()]
+        # Now compare package lists to ensure new package is only seen
+        # for 'test' publisher.
+        repo = self.get_repo(repo_path, read_only=True)
+        cat = repo.get_catalog(pub="test")
+        self.assertNotEqual([str(f) for f in cat.fmris()], test_plist)
+        test_plist = [str(f) for f in cat.fmris()]
+        cat = repo.get_catalog(pub="test2")
+        self.assertEqual([str(f) for f in cat.fmris()], test2_plist)
+        test2_plist = [str(f) for f in cat.fmris()]
 
-                # Verify refresh without specifying a publisher will refresh the
-                # the catalogs for all publishers.
-                self.pkgrepo("refresh -s {0}".format(repo_uri))
-                self.wait_repo(repo_path)
+        # Verify refresh without specifying a publisher will refresh the
+        # the catalogs for all publishers.
+        self.pkgrepo("refresh -s {0}".format(repo_uri))
+        self.wait_repo(repo_path)
 
-                # Now compare package lists to ensure new package is seen for
-                # all publishers.
-                repo = self.get_repo(repo_path, read_only=True)
-                cat = repo.get_catalog(pub="test")
-                self.assertEqual([str(f) for f in cat.fmris()], test_plist)
-                cat = repo.get_catalog(pub="test2")
-                self.assertNotEqual([str(f) for f in cat.fmris()], test2_plist)
+        # Now compare package lists to ensure new package is seen for
+        # all publishers.
+        repo = self.get_repo(repo_path, read_only=True)
+        cat = repo.get_catalog(pub="test")
+        self.assertEqual([str(f) for f in cat.fmris()], test_plist)
+        cat = repo.get_catalog(pub="test2")
+        self.assertNotEqual([str(f) for f in cat.fmris()], test2_plist)
 
-                self.dc.stop()
+        self.dc.stop()
 
-        def test_06_version(self):
-                """Verify pkgrepo version works as expected."""
+    def test_06_version(self):
+        """Verify pkgrepo version works as expected."""
 
-                # Verify version exits with error if operands are provided.
-                self.pkgrepo("version operand", exit=2)
+        # Verify version exits with error if operands are provided.
+        self.pkgrepo("version operand", exit=2)
 
-                # Verify version exits with error if a repository location is
-                # provided.
-                self.pkgrepo("version -s {0}".format(self.test_root), exit=2)
+        # Verify version exits with error if a repository location is
+        # provided.
+        self.pkgrepo("version -s {0}".format(self.test_root), exit=2)
 
-                # Verify version output is sane.
-                self.pkgrepo("version")
-                self.assertTrue(self.output.find(pkg.VERSION) != -1)
+        # Verify version output is sane.
+        self.pkgrepo("version")
+        self.assertTrue(self.output.find(pkg.VERSION) != -1)
 
-        def test_07_add_publisher(self):
-                """Verify that add-publisher subcommand works as expected."""
+    def test_07_add_publisher(self):
+        """Verify that add-publisher subcommand works as expected."""
 
-                # Create a repository.
-                repo_path = os.path.join(self.test_root, "repo")
-                self.create_repo(repo_path)
+        # Create a repository.
+        repo_path = os.path.join(self.test_root, "repo")
+        self.create_repo(repo_path)
 
-                # Verify invalid publisher prefixes are rejected gracefully.
-                self.pkgrepo("-s {0} add-publisher !valid".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} add-publisher file:{1}".format(repo_path,
-                    repo_path), exit=1)
-                self.pkgrepo("-s {0} add-publisher valid !valid".format(repo_path),
-                    exit=1)
+        # Verify invalid publisher prefixes are rejected gracefully.
+        self.pkgrepo("-s {0} add-publisher !valid".format(repo_path), exit=1)
+        self.pkgrepo(
+            "-s {0} add-publisher file:{1}".format(repo_path, repo_path), exit=1
+        )
+        self.pkgrepo(
+            "-s {0} add-publisher valid !valid".format(repo_path), exit=1
+        )
 
-                # Verify that multiple publishers can be added at a time, and
-                # that the first publisher named will be set as the default
-                # publisher if a default was not already set.
-                self.pkgrepo("-s {0} add-publisher example.com example.net".format(
-                    repo_path))
-                self.pkgrepo("-s {0} get -p example.com -p example.net "
-                    "publisher/alias".format(repo_path))
-                self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
-                expected = """\
+        # Verify that multiple publishers can be added at a time, and
+        # that the first publisher named will be set as the default
+        # publisher if a default was not already set.
+        self.pkgrepo(
+            "-s {0} add-publisher example.com example.net".format(repo_path)
+        )
+        self.pkgrepo(
+            "-s {0} get -p example.com -p example.net "
+            "publisher/alias".format(repo_path)
+        )
+        self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
+        expected = """\
 publisher\tprefix\texample.com
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify that add-publisher will exit with complete failure if
-                # all publishers being added already exist.
-                self.pkgrepo("-s {0} add-publisher example.com example.net".format(
-                    repo_path), exit=1)
+        # Verify that add-publisher will exit with complete failure if
+        # all publishers being added already exist.
+        self.pkgrepo(
+            "-s {0} add-publisher example.com example.net".format(repo_path),
+            exit=1,
+        )
 
-                # Verify that add-publisher will exit with partial failure if
-                # only some publishers already exist.
-                self.pkgrepo("-s {0} add-publisher example.com example.org".format(
-                    repo_path), exit=3)
+        # Verify that add-publisher will exit with partial failure if
+        # only some publishers already exist.
+        self.pkgrepo(
+            "-s {0} add-publisher example.com example.org".format(repo_path),
+            exit=3,
+        )
 
-                # Now set a default publisher before adding a publisher for
-                # the first time.
-                shutil.rmtree(repo_path)
-                self.create_repo(repo_path)
-                self.pkgrepo("-s {0} set publisher/prefix=example.net".format(
-                    repo_path))
-                self.pkgrepo("-s {0} add-publisher example.org".format(repo_path))
-                self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
-                expected = """\
+        # Now set a default publisher before adding a publisher for
+        # the first time.
+        shutil.rmtree(repo_path)
+        self.create_repo(repo_path)
+        self.pkgrepo(
+            "-s {0} set publisher/prefix=example.net".format(repo_path)
+        )
+        self.pkgrepo("-s {0} add-publisher example.org".format(repo_path))
+        self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
+        expected = """\
 publisher\tprefix\texample.net
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-        def test_09_remove_packages(self):
-                """Verify that remove subcommand works as expected."""
+    def test_09_remove_packages(self):
+        """Verify that remove subcommand works as expected."""
 
-                # Create a repository and then copy it somewhere for testing
-                # to make it easy to restore the original as needed.
-                src_repo = os.path.join(self.test_root, "remove-repo")
+        # Create a repository and then copy it somewhere for testing
+        # to make it easy to restore the original as needed.
+        src_repo = os.path.join(self.test_root, "remove-repo")
 
-                self.create_repo(src_repo)
-                self.pkgrepo("set -s {0} publisher/prefix=test".format(src_repo))
+        self.create_repo(src_repo)
+        self.pkgrepo("set -s {0} publisher/prefix=test".format(src_repo))
 
-                # Test that removing a package when no files have been published
-                # works (bug 18424).
-                published = self.pkgsend_bulk(src_repo, self.zoo10)
-                self.pkgrepo("remove -s {0} zoo".format(src_repo))
+        # Test that removing a package when no files have been published
+        # works (bug 18424).
+        published = self.pkgsend_bulk(src_repo, self.zoo10)
+        self.pkgrepo("remove -s {0} zoo".format(src_repo))
 
-                # Reset the src_repo for the rest of the test.
-                shutil.rmtree(src_repo)
-                self.create_repo(src_repo)
-                self.pkgrepo("set -s {0} publisher/prefix=test".format(src_repo))
+        # Reset the src_repo for the rest of the test.
+        shutil.rmtree(src_repo)
+        self.create_repo(src_repo)
+        self.pkgrepo("set -s {0} publisher/prefix=test".format(src_repo))
 
-                published = self.pkgsend_bulk(src_repo, (self.tree10,
-                    self.amber10, self.amber20, self.truck10, self.truck20,
-                    self.zoo10))
-                self.pkgrepo("set -s {0} publisher/prefix=test2".format(src_repo))
-                published += self.pkgsend_bulk(src_repo, (self.tree10,
-                    self.zoo10))
+        published = self.pkgsend_bulk(
+            src_repo,
+            (
+                self.tree10,
+                self.amber10,
+                self.amber20,
+                self.truck10,
+                self.truck20,
+                self.zoo10,
+            ),
+        )
+        self.pkgrepo("set -s {0} publisher/prefix=test2".format(src_repo))
+        published += self.pkgsend_bulk(src_repo, (self.tree10, self.zoo10))
 
-                # Restore repository for next test.
-                dest_repo = os.path.join(self.test_root, "test-repo")
-                shutil.copytree(src_repo, dest_repo)
+        # Restore repository for next test.
+        dest_repo = os.path.join(self.test_root, "test-repo")
+        shutil.copytree(src_repo, dest_repo)
 
-                # Verify that specifying something other than a filesystem-
-                # based repository fails.
-                self.pkgrepo("remove -s {0} tree".format(self.durl), exit=2)
+        # Verify that specifying something other than a filesystem-
+        # based repository fails.
+        self.pkgrepo("remove -s {0} tree".format(self.durl), exit=2)
 
-                # Verify that non-matching patterns result in error.
-                self.pkgrepo("remove -s {0} nosuchpackage".format(dest_repo), exit=1)
-                self.pkgrepo("remove -s {0} tree nosuchpackage".format(dest_repo),
-                    exit=1)
+        # Verify that non-matching patterns result in error.
+        self.pkgrepo("remove -s {0} nosuchpackage".format(dest_repo), exit=1)
+        self.pkgrepo(
+            "remove -s {0} tree nosuchpackage".format(dest_repo), exit=1
+        )
 
-                # Verify that -n works as expected.
-                self.pkgrepo("remove -n -s {0} zoo".format(dest_repo))
-                # Since package was not removed, this succeeds.
-                self.pkgrepo("remove -n -s {0} zoo".format(dest_repo))
+        # Verify that -n works as expected.
+        self.pkgrepo("remove -n -s {0} zoo".format(dest_repo))
+        # Since package was not removed, this succeeds.
+        self.pkgrepo("remove -n -s {0} zoo".format(dest_repo))
 
-                # Verify that -p works as expected.
-                self.pkgrepo("remove -s {0} -p nosuchpub zoo".format(dest_repo),
-                    exit=1)
-                self.pkgrepo("remove -s {0} -p test -p test2 zoo".format(dest_repo))
-                self.pkgrepo("remove -s {0} -p test zoo".format(dest_repo), exit=1)
-                self.pkgrepo("remove -s {0} -p test2 zoo".format(dest_repo), exit=1)
+        # Verify that -p works as expected.
+        self.pkgrepo("remove -s {0} -p nosuchpub zoo".format(dest_repo), exit=1)
+        self.pkgrepo("remove -s {0} -p test -p test2 zoo".format(dest_repo))
+        self.pkgrepo("remove -s {0} -p test zoo".format(dest_repo), exit=1)
+        self.pkgrepo("remove -s {0} -p test2 zoo".format(dest_repo), exit=1)
 
-                # Restore repository for next test.
-                shutil.rmtree(dest_repo)
-                shutil.copytree(src_repo, dest_repo)
+        # Restore repository for next test.
+        shutil.rmtree(dest_repo)
+        shutil.copytree(src_repo, dest_repo)
 
-                # Verify a single version of a package can be removed and that
-                # package files will not be removed since older versions still
-                # reference them.  (This also tests that packages that only
-                # exist for one publisher in a multi-publisher repository can
-                # be removed.)
-                repo = self.get_repo(dest_repo)
-                mpath = repo.manifest(published[4])
-                self.pkgrepo("remove -s {0} truck@2.0".format(dest_repo))
+        # Verify a single version of a package can be removed and that
+        # package files will not be removed since older versions still
+        # reference them.  (This also tests that packages that only
+        # exist for one publisher in a multi-publisher repository can
+        # be removed.)
+        repo = self.get_repo(dest_repo)
+        mpath = repo.manifest(published[4])
+        self.pkgrepo("remove -s {0} truck@2.0".format(dest_repo))
 
-                # The manifest should no longer exist.
-                self.assertTrue(not os.path.exists(mpath))
+        # The manifest should no longer exist.
+        self.assertTrue(not os.path.exists(mpath))
 
-                # These two files are in use by other packages so should still
-                # exist.
-                repo.file(self.fhashes["tmp/empty"])
-                repo.file(self.fhashes["tmp/truck1"])
+        # These two files are in use by other packages so should still
+        # exist.
+        repo.file(self.fhashes["tmp/empty"])
+        repo.file(self.fhashes["tmp/truck1"])
 
-                # This file was only referenced by truck@2.0 so should be gone.
-                self.assertRaises(sr.RepositoryFileNotFoundError, repo.file,
-                    self.fhashes["tmp/truck2"])
+        # This file was only referenced by truck@2.0 so should be gone.
+        self.assertRaises(
+            sr.RepositoryFileNotFoundError,
+            repo.file,
+            self.fhashes["tmp/truck2"],
+        )
 
-                # Restore repository for next test.
-                shutil.rmtree(dest_repo)
-                shutil.copytree(src_repo, dest_repo)
+        # Restore repository for next test.
+        shutil.rmtree(dest_repo)
+        shutil.copytree(src_repo, dest_repo)
 
-                # Verify that all versions of a specific package can be removed
-                # and that only files not referenced by other packages are
-                # removed.
-                self.pkgrepo("remove -s {0} truck".format(dest_repo))
+        # Verify that all versions of a specific package can be removed
+        # and that only files not referenced by other packages are
+        # removed.
+        self.pkgrepo("remove -s {0} truck".format(dest_repo))
 
-                # This file is still in use by other packages.
-                repo = self.get_repo(dest_repo)
-                repo.file(self.fhashes["tmp/empty"])
-                repo.file(self.fhashes["tmp/truck1"])
+        # This file is still in use by other packages.
+        repo = self.get_repo(dest_repo)
+        repo.file(self.fhashes["tmp/empty"])
+        repo.file(self.fhashes["tmp/truck1"])
 
-                # These files should have been removed since other packages
-                # don't reference them.
-                self.assertRaises(sr.RepositoryFileNotFoundError, repo.file,
-                    self.fhashes["tmp/truck2"])
+        # These files should have been removed since other packages
+        # don't reference them.
+        self.assertRaises(
+            sr.RepositoryFileNotFoundError,
+            repo.file,
+            self.fhashes["tmp/truck2"],
+        )
 
-                # Restore repository for next test.
-                shutil.rmtree(dest_repo)
-                shutil.copytree(src_repo, dest_repo)
+        # Restore repository for next test.
+        shutil.rmtree(dest_repo)
+        shutil.copytree(src_repo, dest_repo)
 
-                # Verify that removing all packages that reference files
-                # results in all files being removed and an empty file_root
-                # for the repository.
-                repo = self.get_repo(dest_repo)
-                mpaths = []
-                for f in published:
-                        if "tree" in f or "truck" in f:
-                                mpaths.append(repo.manifest(f))
+        # Verify that removing all packages that reference files
+        # results in all files being removed and an empty file_root
+        # for the repository.
+        repo = self.get_repo(dest_repo)
+        mpaths = []
+        for f in published:
+            if "tree" in f or "truck" in f:
+                mpaths.append(repo.manifest(f))
 
-                self.pkgrepo("remove -s {0} tree truck".format(dest_repo))
+        self.pkgrepo("remove -s {0} tree truck".format(dest_repo))
 
-                self.assertRaises(sr.RepositoryFileNotFoundError, repo.file,
-                    self.fhashes["tmp/empty"])
-                self.assertRaises(sr.RepositoryFileNotFoundError, repo.file,
-                    self.fhashes["tmp/truck1"])
-                self.assertRaises(sr.RepositoryFileNotFoundError, repo.file,
-                    self.fhashes["tmp/truck2"])
+        self.assertRaises(
+            sr.RepositoryFileNotFoundError, repo.file, self.fhashes["tmp/empty"]
+        )
+        self.assertRaises(
+            sr.RepositoryFileNotFoundError,
+            repo.file,
+            self.fhashes["tmp/truck1"],
+        )
+        self.assertRaises(
+            sr.RepositoryFileNotFoundError,
+            repo.file,
+            self.fhashes["tmp/truck2"],
+        )
 
-                # Verify that directories for manifests no longer exist since
-                # all versions were removed.
-                for mpath in mpaths:
-                        pdir = os.path.dirname(mpath)
-                        self.assertTrue(not os.path.exists(pdir))
+        # Verify that directories for manifests no longer exist since
+        # all versions were removed.
+        for mpath in mpaths:
+            pdir = os.path.dirname(mpath)
+            self.assertTrue(not os.path.exists(pdir))
 
-                # Verify that entries for each package that was removed no
-                # longer exist in the catalog, but do exist in the catalog's
-                # updatelog.
-                repo = self.get_repo(dest_repo)
-                for pfx in ("test", "test2"):
-                        c = repo.get_catalog(pub=pfx)
-                        for f in c.fmris():
-                                self.assertTrue(f.pkg_name not in ("tree",
-                                    "truck"))
+        # Verify that entries for each package that was removed no
+        # longer exist in the catalog, but do exist in the catalog's
+        # updatelog.
+        repo = self.get_repo(dest_repo)
+        for pfx in ("test", "test2"):
+            c = repo.get_catalog(pub=pfx)
+            for f in c.fmris():
+                self.assertTrue(f.pkg_name not in ("tree", "truck"))
 
-                        removed = set()
-                        for name in c.updates:
-                                ulog = pkg.catalog.CatalogUpdate(name,
-                                    meta_root=c.meta_root, sign=False)
+            removed = set()
+            for name in c.updates:
+                ulog = pkg.catalog.CatalogUpdate(
+                    name, meta_root=c.meta_root, sign=False
+                )
 
-                                for pfmri, op_type, op_time, md in ulog.updates():
-                                        if op_type == ulog.REMOVE:
-                                                removed.add(str(pfmri))
+                for pfmri, op_type, op_time, md in ulog.updates():
+                    if op_type == ulog.REMOVE:
+                        removed.add(str(pfmri))
 
-                        expected = set(
-                            f
-                            for f in published
-                            if ("tree" in f or "truck" in f) and \
-                                f.startswith("pkg://{0}/".format(pfx))
-                        )
-                        self.assertEqualDiff(expected, removed)
+            expected = set(
+                f
+                for f in published
+                if ("tree" in f or "truck" in f)
+                and f.startswith("pkg://{0}/".format(pfx))
+            )
+            self.assertEqualDiff(expected, removed)
 
-                # Verify repository file_root is empty.
-                for rstore in repo.rstores:
-                        if not rstore.publisher:
-                                continue
-                        self.assertTrue(not os.listdir(rstore.file_root))
+        # Verify repository file_root is empty.
+        for rstore in repo.rstores:
+            if not rstore.publisher:
+                continue
+            self.assertTrue(not os.listdir(rstore.file_root))
 
-                hash_alg_list = ["sha256"]
-                if sha512_supported:
-                        hash_alg_list.append("sha512t_256")
-                for hash_alg in hash_alg_list:
-                        # Reset the src_repo for the rest of the test.
-                        shutil.rmtree(src_repo)
-                        self.create_repo(src_repo)
-                        self.pkgrepo("set -s {0} publisher/prefix=test".format(
-                            src_repo))
-                        published = self.pkgsend_bulk(src_repo, (self.tree10),
-                            debug_hash="sha1+{0}".format(hash_alg))
+        hash_alg_list = ["sha256"]
+        if sha512_supported:
+            hash_alg_list.append("sha512t_256")
+        for hash_alg in hash_alg_list:
+            # Reset the src_repo for the rest of the test.
+            shutil.rmtree(src_repo)
+            self.create_repo(src_repo)
+            self.pkgrepo("set -s {0} publisher/prefix=test".format(src_repo))
+            published = self.pkgsend_bulk(
+                src_repo, (self.tree10), debug_hash="sha1+{0}".format(hash_alg)
+            )
 
-                        # Verify that we only have SHA-1 hashes in the rstore
-                        repo = self.get_repo(src_repo)
-                        known_hashes = self.fhashes.values()
-                        for rstore in repo.rstores:
-                                if not rstore.publisher:
-                                        continue
-                                for dir, dnames, fnames in \
-                                    os.walk(rstore.file_root):
-                                        for f in fnames:
-                                                if f not in known_hashes:
-                                                        self.assertTrue(False,
-                                                            "Unexpected content "
-                                                            "in repodir: {0}".format(f))
+            # Verify that we only have SHA-1 hashes in the rstore
+            repo = self.get_repo(src_repo)
+            known_hashes = self.fhashes.values()
+            for rstore in repo.rstores:
+                if not rstore.publisher:
+                    continue
+                for dir, dnames, fnames in os.walk(rstore.file_root):
+                    for f in fnames:
+                        if f not in known_hashes:
+                            self.assertTrue(
+                                False,
+                                "Unexpected content "
+                                "in repodir: {0}".format(f),
+                            )
 
-                        # Verify that when a repository has been published with
-                        # multiple hashes, on removal, we only attempt to remove
-                        # files using the least-preferred hash.
-                        self.pkgrepo("remove -s {0} tree".format(src_repo))
+            # Verify that when a repository has been published with
+            # multiple hashes, on removal, we only attempt to remove
+            # files using the least-preferred hash.
+            self.pkgrepo("remove -s {0} tree".format(src_repo))
 
-                        # Verify repository file_root is empty.
-                        for rstore in repo.rstores:
-                                if not rstore.publisher:
-                                        continue
-                                self.assertTrue(not os.listdir(rstore.file_root))
+            # Verify repository file_root is empty.
+            for rstore in repo.rstores:
+                if not rstore.publisher:
+                    continue
+                self.assertTrue(not os.listdir(rstore.file_root))
 
-                # Verify that removing a package does not fail if some files are
-                # already removed/missing.
-                repo_path = self.dc.get_repodir()
-                published = self.pkgsend_bulk(repo_path, (self.tree10))
-                missing_file = self.__inject_nofile("tmp/truck1")
-                tree = fmri.PkgFmri(published[0])
+        # Verify that removing a package does not fail if some files are
+        # already removed/missing.
+        repo_path = self.dc.get_repodir()
+        published = self.pkgsend_bulk(repo_path, (self.tree10))
+        missing_file = self.__inject_nofile("tmp/truck1")
+        tree = fmri.PkgFmri(published[0])
 
-                self.pkgrepo("remove -s {0} tree".format(repo_path))
+        self.pkgrepo("remove -s {0} tree".format(repo_path))
 
-                # Cleanup.
-                shutil.rmtree(src_repo)
-                shutil.rmtree(dest_repo)
+        # Cleanup.
+        shutil.rmtree(src_repo)
+        shutil.rmtree(dest_repo)
 
-        def test_10_list(self):
-                """Verify the list subcommand works as expected."""
+    def test_10_list(self):
+        """Verify the list subcommand works as expected."""
 
-                repo_path = self.dc.get_repodir()
-                repo_uri = self.dc.get_repo_url()
+        repo_path = self.dc.get_repodir()
+        repo_uri = self.dc.get_repo_url()
 
-                # Publish some packages.
-                self.pkgsend_bulk(repo_uri, (self.tree10, self.amber10,
-                    self.amber20, self.amber30, self.amber35, self.amber40))
+        # Publish some packages.
+        self.pkgsend_bulk(
+            repo_uri,
+            (
+                self.tree10,
+                self.amber10,
+                self.amber20,
+                self.amber30,
+                self.amber35,
+                self.amber40,
+            ),
+        )
 
-                # Verify graceful exit if invalid or incomplete set of
-                # options specified.
-                self.pkgrepo("list", exit=2)
-                self.pkgrepo("-s bogus://location list", exit=1)
-                self.pkgrepo("list -s bogus://location list", exit=1)
-                self.pkgrepo("list -s {0} -F bad-format".format(repo_uri), exit=2)
+        # Verify graceful exit if invalid or incomplete set of
+        # options specified.
+        self.pkgrepo("list", exit=2)
+        self.pkgrepo("-s bogus://location list", exit=1)
+        self.pkgrepo("list -s bogus://location list", exit=1)
+        self.pkgrepo("list -s {0} -F bad-format".format(repo_uri), exit=2)
 
-                # Verify graceful exit for bad repository.
-                self.pkgrepo("list -s /no/such/repository", exit=1)
+        # Verify graceful exit for bad repository.
+        self.pkgrepo("list -s /no/such/repository", exit=1)
 
-                # Verify graceful exit if invalid package name given.
-                self.pkgrepo("list -s {0} ^notvalid".format(repo_path), exit=1)
+        # Verify graceful exit if invalid package name given.
+        self.pkgrepo("list -s {0} ^notvalid".format(repo_path), exit=1)
 
-                # Verify graceful exit if no matching package found.
-                self.pkgrepo("list -s {0} nosuchpackage".format(repo_path), exit=1)
+        # Verify graceful exit if no matching package found.
+        self.pkgrepo("list -s {0} nosuchpackage".format(repo_path), exit=1)
 
-                # Verify default output when listing all packages for both
-                # file and http cases:
-                for src in (repo_path, repo_uri):
-                        # json output.
-                        self.pkgrepo("list -s {0} -F json".format(src))
-                        expected = """\
+        # Verify default output when listing all packages for both
+        # file and http cases:
+        for src in (repo_path, repo_uri):
+            # json output.
+            self.pkgrepo("list -s {0} -F json".format(src))
+            expected = """\
 [{"branch":"0","build-release":"5.11","name":"amber",\
 "pkg.fmri":"pkg://test/amber@4.0,5.11-0:20110804T203458Z",\
 "pkg.obsolete":[{"value":["true"]}],"publisher":"test",\
@@ -1671,14 +1811,14 @@ publisher\tprefix\texample.net
 "publisher":"test","release":"1.0","timestamp":"20110804T203458Z",\
 "variant.arch":[{"value":["i386","sparc"]}],\
 "version":"1.0,5.11-0:20110804T203458Z"}]"""
-                        self.assertEqualDiff(expected, self.output)
+            self.assertEqualDiff(expected, self.output)
 
-                # Now verify list output in different formats but only using
-                # file repository for test efficiency.
+        # Now verify list output in different formats but only using
+        # file repository for test efficiency.
 
-                # Human readable (default) output.
-                self.pkgrepo("list -s {0}".format(src))
-                expected = """\
+        # Human readable (default) output.
+        self.pkgrepo("list -s {0}".format(src))
+        expected = """\
 PUBLISHER NAME                                          O VERSION
 test      amber                                         o 4.0-0:20110804T203458Z
 test      amber                                         l 3.5-0:20110804T203458Z
@@ -1687,11 +1827,11 @@ test      amber                                           2.0-0:20110804T203458Z
 test      amber                                           1.0-0:20110804T203458Z
 test      tree                                            1.0-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Human readable (default) output with no header.
-                self.pkgrepo("list -s {0} -H".format(repo_path))
-                expected = """\
+        # Human readable (default) output with no header.
+        self.pkgrepo("list -s {0} -H".format(repo_path))
+        expected = """\
 test      amber                                         o 4.0-0:20110804T203458Z
 test      amber                                         l 3.5-0:20110804T203458Z
 test      amber                                         r 3.0-0:20110804T203458Z
@@ -1699,11 +1839,11 @@ test      amber                                           2.0-0:20110804T203458Z
 test      amber                                           1.0-0:20110804T203458Z
 test      tree                                            1.0-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # tsv output.
-                self.pkgrepo("list -s {0} -F tsv".format(repo_path))
-                expected = """\
+        # tsv output.
+        self.pkgrepo("list -s {0} -F tsv".format(repo_path))
+        expected = """\
 PUBLISHER	NAME	O	RELEASE	BUILD RELEASE	BRANCH	PACKAGING DATE	FMRI
 test	amber	o	4.0	5.11	0	20110804T203458Z	pkg://test/amber@4.0,5.11-0:20110804T203458Z
 test	amber	l	3.5	5.11	0	20110804T203458Z	pkg://test/amber@3.5,5.11-0:20110804T203458Z
@@ -1712,13 +1852,13 @@ test	amber		2.0	5.11	0	20110804T203458Z	pkg://test/amber@2.0,5.11-0:20110804T203
 test	amber		1.0	5.11	0	20110804T203458Z	pkg://test/amber@1.0,5.11-0:20110804T203458Z
 test	tree		1.0	5.11	0	20110804T203458Z	pkg://test/tree@1.0,5.11-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # json-formatted output.
-                # NOTE -> spaces at the end of lines, or lack thereof, are
-                # important and to which attention should be paid.
-                self.pkgrepo("list -s %s -F json-formatted" % src)
-                expected = """\
+        # json-formatted output.
+        # NOTE -> spaces at the end of lines, or lack thereof, are
+        # important and to which attention should be paid.
+        self.pkgrepo("list -s %s -F json-formatted" % src)
+        expected = """\
 [
   {
     "branch": "0",
@@ -1850,51 +1990,54 @@ test	tree		1.0	5.11	0	20110804T203458Z	pkg://test/tree@1.0,5.11-0:20110804T20345
   }
 ]
 """
-                self.assertEqualJSON(expected, self.output)
+        self.assertEqualJSON(expected, self.output)
 
-                # Verify ability to list specific packages.
-                self.pkgrepo("list -s {0} -H -F tsv tree amber@2.0".format(repo_path))
-                expected = """\
+        # Verify ability to list specific packages.
+        self.pkgrepo("list -s {0} -H -F tsv tree amber@2.0".format(repo_path))
+        expected = """\
 test	amber		2.0	5.11	0	20110804T203458Z	pkg://test/amber@2.0,5.11-0:20110804T203458Z
 test	tree		1.0	5.11	0	20110804T203458Z	pkg://test/tree@1.0,5.11-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("list -s {0} -H -F tsv tree amber@4.0 amber@2.0".format(
-                    repo_path))
-                expected = """\
+        self.pkgrepo(
+            "list -s {0} -H -F tsv tree amber@4.0 amber@2.0".format(repo_path)
+        )
+        expected = """\
 test	amber	o	4.0	5.11	0	20110804T203458Z	pkg://test/amber@4.0,5.11-0:20110804T203458Z
 test	amber		2.0	5.11	0	20110804T203458Z	pkg://test/amber@2.0,5.11-0:20110804T203458Z
 test	tree		1.0	5.11	0	20110804T203458Z	pkg://test/tree@1.0,5.11-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("list -s {0} -H -F tsv amber@latest tree".format(
-                    repo_path))
-                expected = """\
+        self.pkgrepo(
+            "list -s {0} -H -F tsv amber@latest tree".format(repo_path)
+        )
+        expected = """\
 test	amber	o	4.0	5.11	0	20110804T203458Z	pkg://test/amber@4.0,5.11-0:20110804T203458Z
 test	tree		1.0	5.11	0	20110804T203458Z	pkg://test/tree@1.0,5.11-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify exit with partial failure if one match fails.
-                self.pkgrepo("list -s {0} -H -F tsv tree bogus".format(repo_path),
-                    exit=3)
-                expected = """\
+        # Verify exit with partial failure if one match fails.
+        self.pkgrepo(
+            "list -s {0} -H -F tsv tree bogus".format(repo_path), exit=3
+        )
+        expected = """\
 test	tree		1.0	5.11	0	20110804T203458Z	pkg://test/tree@1.0,5.11-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                #
-                # Add packages for a different publisher.
-                #
-                self.pkgrepo("set -s {0} publisher/prefix=test2".format(repo_path))
-                self.pkgsend_bulk(repo_path, (self.truck10, self.zoo10))
+        #
+        # Add packages for a different publisher.
+        #
+        self.pkgrepo("set -s {0} publisher/prefix=test2".format(repo_path))
+        self.pkgsend_bulk(repo_path, (self.truck10, self.zoo10))
 
-                # Verify list of all package includes all publishers.
-                # tsv output.
-                self.pkgrepo("list -s {0} -H -F tsv".format(repo_path))
-                expected = """\
+        # Verify list of all package includes all publishers.
+        # tsv output.
+        self.pkgrepo("list -s {0} -H -F tsv".format(repo_path))
+        expected = """\
 test	amber	o	4.0	5.11	0	20110804T203458Z	pkg://test/amber@4.0,5.11-0:20110804T203458Z
 test	amber	l	3.5	5.11	0	20110804T203458Z	pkg://test/amber@3.5,5.11-0:20110804T203458Z
 test	amber	r	3.0	5.11	0	20110804T203458Z	pkg://test/amber@3.0,5.11-0:20110804T203458Z
@@ -1904,2206 +2047,2390 @@ test	tree		1.0	5.11	0	20110804T203458Z	pkg://test/tree@1.0,5.11-0:20110804T20345
 test2	truck		1.0	5.11	0	20110804T203458Z	pkg://test2/truck@1.0,5.11-0:20110804T203458Z
 test2	zoo		1.0	5.11	0	20110804T203458Z	pkg://test2/zoo@1.0,5.11-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("list -s {0} -H -F tsv -p all".format(repo_path))
-                self.assertEqualDiff(expected, self.output)
+        self.pkgrepo("list -s {0} -H -F tsv -p all".format(repo_path))
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify that packages for a single publisher can be listed.
-                self.pkgrepo("list -s {0} -H -F tsv -p test2".format(repo_path))
-                expected = """\
+        # Verify that packages for a single publisher can be listed.
+        self.pkgrepo("list -s {0} -H -F tsv -p test2".format(repo_path))
+        expected = """\
 test2	truck		1.0	5.11	0	20110804T203458Z	pkg://test2/truck@1.0,5.11-0:20110804T203458Z
 test2	zoo		1.0	5.11	0	20110804T203458Z	pkg://test2/zoo@1.0,5.11-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify that patterns matching packages only provided by one
-                # publisher will not result in partial failure.
-                self.pkgrepo("list -s {0} -H -F tsv zoo".format(repo_path))
-                expected = """\
+        # Verify that patterns matching packages only provided by one
+        # publisher will not result in partial failure.
+        self.pkgrepo("list -s {0} -H -F tsv zoo".format(repo_path))
+        expected = """\
 test2	zoo		1.0	5.11	0	20110804T203458Z	pkg://test2/zoo@1.0,5.11-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                self.pkgrepo("list -s {0} -H -F tsv '//test2/*'".format(repo_path))
-                expected = """\
+        self.pkgrepo("list -s {0} -H -F tsv '//test2/*'".format(repo_path))
+        expected = """\
 test2	truck		1.0	5.11	0	20110804T203458Z	pkg://test2/truck@1.0,5.11-0:20110804T203458Z
 test2	zoo		1.0	5.11	0	20110804T203458Z	pkg://test2/zoo@1.0,5.11-0:20110804T203458Z
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify that a package provided by no publisher will result
-                # in graceful failure when multiple publishers are present.
-                self.pkgrepo("list -s {0} -H -F tsv nosuchpackage".format(repo_path),
-                    exit=1)
+        # Verify that a package provided by no publisher will result
+        # in graceful failure when multiple publishers are present.
+        self.pkgrepo(
+            "list -s {0} -H -F tsv nosuchpackage".format(repo_path), exit=1
+        )
 
-        def __get_mf_path(self, fmri_str, pub=None):
-                """Given an FMRI, return the path to its manifest in our
-                repository."""
+    def __get_mf_path(self, fmri_str, pub=None):
+        """Given an FMRI, return the path to its manifest in our
+        repository."""
 
-                usepub = "test"
-                if pub:
-                        usepub = pub
-                path_comps = [self.dc.get_repodir(), "publisher",
-                    usepub, "pkg"]
-                pfmri = pkg.fmri.PkgFmri(fmri_str)
-                path_comps.append(pfmri.get_name())
-                path_comps.append(pfmri.get_link_path().split("@")[1])
-                return os.path.sep.join(path_comps)
+        usepub = "test"
+        if pub:
+            usepub = pub
+        path_comps = [self.dc.get_repodir(), "publisher", usepub, "pkg"]
+        pfmri = pkg.fmri.PkgFmri(fmri_str)
+        path_comps.append(pfmri.get_name())
+        path_comps.append(pfmri.get_link_path().split("@")[1])
+        return os.path.sep.join(path_comps)
 
-        def __get_file_path(self, path):
-                """Returns the path to a file in the repository. The path name
-                must be present in self.fhashes."""
+    def __get_file_path(self, path):
+        """Returns the path to a file in the repository. The path name
+        must be present in self.fhashes."""
 
-                fpath = os.path.sep.join([self.dc.get_repodir(), "publisher",
-                    "test", "file"])
-                fhash = self.fhashes[path]
-                return os.path.sep.join([fpath, fhash[0:2], fhash])
+        fpath = os.path.sep.join(
+            [self.dc.get_repodir(), "publisher", "test", "file"]
+        )
+        fhash = self.fhashes[path]
+        return os.path.sep.join([fpath, fhash[0:2], fhash])
 
-        def __get_manifest_contents(self, fmri_str):
-                """Given an FMRI, return the unsorted manifest contents from our
-                repository as a string."""
+    def __get_manifest_contents(self, fmri_str):
+        """Given an FMRI, return the unsorted manifest contents from our
+        repository as a string."""
 
-                mpath = self.__get_mf_path(fmri_str)
-                mf = pkg.manifest.Manifest()
-                mf.set_content(pathname=mpath)
-                return mf.tostr_unsorted()
+        mpath = self.__get_mf_path(fmri_str)
+        mf = pkg.manifest.Manifest()
+        mf.set_content(pathname=mpath)
+        return mf.tostr_unsorted()
 
-        def __inject_depend(self, fmri_str, depend_str, pub=None):
-                mpath = self.__get_mf_path(fmri_str, pub=pub)
-                with open(mpath, "a+") as mf:
-                        mf.write(depend_str)
-                return mpath
+    def __inject_depend(self, fmri_str, depend_str, pub=None):
+        mpath = self.__get_mf_path(fmri_str, pub=pub)
+        with open(mpath, "a+") as mf:
+            mf.write(depend_str)
+        return mpath
 
-        def __inject_badhash(self, path, valid_gzip=True):
-                """Corrupt a file in the repository with the given path, where
-                that path is a key in self.fhashes, returning the repository
-                path of the file that was corrupted.  If valid_gzip is set,
-                we write a gzip file into the repository, otherwise the file
-                contains plaintext."""
+    def __inject_badhash(self, path, valid_gzip=True):
+        """Corrupt a file in the repository with the given path, where
+        that path is a key in self.fhashes, returning the repository
+        path of the file that was corrupted.  If valid_gzip is set,
+        we write a gzip file into the repository, otherwise the file
+        contains plaintext."""
 
-                corrupt_path = self.__get_file_path(path)
-                other_path = os.path.join(self.test_root, "tmp/other")
+        corrupt_path = self.__get_file_path(path)
+        other_path = os.path.join(self.test_root, "tmp/other")
 
-                with open(other_path, "rb") as other:
-                        with open(corrupt_path, "wb") as corrupt:
-                                if valid_gzip:
-                                        gz = pkg.pkggzip.PkgGzipFile(
-                                            fileobj=corrupt, mode="wb")
-                                        gz.write(other.read())
-                                        gz.close()
-                                else:
-                                        corrupt.write(other.read())
-                return corrupt_path
-
-        def __repair_badhash(self, path):
-                """Fix a file in the repository that corresponds to this path.
-                """
-                fpath = self.__get_file_path(path)
-                fixed_path = os.path.join(self.test_root, path)
-                with open(fixed_path, "rb") as fixed:
-                        with open(fpath, "wb") as broken:
-                                gz = pkg.pkggzip.PkgGzipFile(
-                                    fileobj=broken, mode="wb")
-                                gz.write(fixed.read())
-                                gz.close()
-
-        def __inject_badmanifest(self, fmri_str):
-                """Corrupt a manifest in the repository for the given fmri,
-                returning the path to that FMRI."""
-                mpath = self.__get_mf_path(fmri_str)
-                other_path = os.path.join(self.test_root, "tmp/other")
-
-                with open(other_path, "r") as other:
-                        with open(mpath, "a") as mf:
-                                mf.write(other.read())
-                return mpath
-
-        def __inject_dir_for_manifest(self, fmri_str):
-                """Put a dir in place of a manifest."""
-                mpath = self.__get_mf_path(fmri_str)
-                os.remove(mpath)
-                os.mkdir(mpath)
-                return mpath
-
-        def __inject_nofile(self, path):
-                fpath = self.__get_file_path(path)
-                os.remove(fpath)
-                return fpath
-
-        def __inject_perm(self, path=None, fmri_str=None, parent=False,
-            chown=False):
-                """Set restrictive file permissions on the given path or fmri in
-                the repository. If 'parent' is set to True, we change
-                permissions on the parent directory of the file or fmri.
-                If chown is set, we chown the file and its parent dir to root.
-                """
-                if path:
-                        fpath = self.__get_file_path(path)
-                        if parent:
-                                fpath = os.path.dirname(fpath)
-                        os.chmod(fpath, 0000)
-                        if chown:
-                                os.chown(fpath, 0, 0)
-                                os.chown(os.path.dirname(mpath), 0, 0)
-                        return fpath
-                elif fmri_str:
-                        mpath = self.__get_mf_path(fmri_str)
-                        if parent:
-                                mpath = os.path.dirname(mpath)
-                        os.chmod(mpath, 0000)
-                        if chown:
-                                os.chown(mpath, 0, 0)
-                                os.chown(os.path.dirname(mpath), 0, 0)
-                        return mpath
+        with open(other_path, "rb") as other:
+            with open(corrupt_path, "wb") as corrupt:
+                if valid_gzip:
+                    gz = pkg.pkggzip.PkgGzipFile(fileobj=corrupt, mode="wb")
+                    gz.write(other.read())
+                    gz.close()
                 else:
-                        assertTrue(False, "Invalid use of __inject_perm(..)!")
+                    corrupt.write(other.read())
+        return corrupt_path
 
-        def __repair_perm(self, path, parent=False):
-                """Repair errors introduced by __inject_perm."""
-                if parent:
-                        fpath = os.path.dirname(path)
+    def __repair_badhash(self, path):
+        """Fix a file in the repository that corresponds to this path."""
+        fpath = self.__get_file_path(path)
+        fixed_path = os.path.join(self.test_root, path)
+        with open(fixed_path, "rb") as fixed:
+            with open(fpath, "wb") as broken:
+                gz = pkg.pkggzip.PkgGzipFile(fileobj=broken, mode="wb")
+                gz.write(fixed.read())
+                gz.close()
+
+    def __inject_badmanifest(self, fmri_str):
+        """Corrupt a manifest in the repository for the given fmri,
+        returning the path to that FMRI."""
+        mpath = self.__get_mf_path(fmri_str)
+        other_path = os.path.join(self.test_root, "tmp/other")
+
+        with open(other_path, "r") as other:
+            with open(mpath, "a") as mf:
+                mf.write(other.read())
+        return mpath
+
+    def __inject_dir_for_manifest(self, fmri_str):
+        """Put a dir in place of a manifest."""
+        mpath = self.__get_mf_path(fmri_str)
+        os.remove(mpath)
+        os.mkdir(mpath)
+        return mpath
+
+    def __inject_nofile(self, path):
+        fpath = self.__get_file_path(path)
+        os.remove(fpath)
+        return fpath
+
+    def __inject_perm(
+        self, path=None, fmri_str=None, parent=False, chown=False
+    ):
+        """Set restrictive file permissions on the given path or fmri in
+        the repository. If 'parent' is set to True, we change
+        permissions on the parent directory of the file or fmri.
+        If chown is set, we chown the file and its parent dir to root.
+        """
+        if path:
+            fpath = self.__get_file_path(path)
+            if parent:
+                fpath = os.path.dirname(fpath)
+            os.chmod(fpath, 0000)
+            if chown:
+                os.chown(fpath, 0, 0)
+                os.chown(os.path.dirname(mpath), 0, 0)
+            return fpath
+        elif fmri_str:
+            mpath = self.__get_mf_path(fmri_str)
+            if parent:
+                mpath = os.path.dirname(mpath)
+            os.chmod(mpath, 0000)
+            if chown:
+                os.chown(mpath, 0, 0)
+                os.chown(os.path.dirname(mpath), 0, 0)
+            return mpath
+        else:
+            assertTrue(False, "Invalid use of __inject_perm(..)!")
+
+    def __repair_perm(self, path, parent=False):
+        """Repair errors introduced by __inject_perm."""
+        if parent:
+            fpath = os.path.dirname(path)
+        else:
+            fpath = path
+        if os.path.isdir(fpath):
+            os.chmod(fpath, misc.PKG_DIR_MODE)
+        elif os.path.isfile(fpath):
+            os.chmod(fpath, misc.PKG_FILE_MODE)
+
+    def __inject_badsig(self, fmri_str):
+        mpath = self.__get_mf_path(fmri_str)
+        with open(mpath, "a+") as mf:
+            mf.write("set name=pkg.t_pkgrepo.bad_sig value=foo")
+        return mpath
+
+    def __repair_badsig(self, path):
+        mpath_new = path + ".new"
+        with open(path, "r") as mf:
+            with open(mpath_new, "w") as mf_new:
+                for line in mf.readlines():
+                    if "pkg.t_pkgrepo.bad_sig" not in line:
+                        mf_new.write(line)
+        os.rename(mpath_new, path)
+
+    def __inject_badchain(self, fmri_str):
+        """Given an fmri with a signature action, locate the chain
+        hashes used by that signature action in that package, and
+        remove the corresponding file from the repository. If the chain
+        references more one file, those subsequent files are
+        corrupted."""
+
+        mpath = self.__get_mf_path(fmri_str)
+        mf = pkg.manifest.Manifest()
+        mf.set_content(pathname=mpath)
+        fpath = os.path.sep.join(
+            [self.dc.get_repodir(), "publisher", "test", "file"]
+        )
+
+        bad_paths = []
+        removed_file = False
+        corrupted_file = False
+        for ac in mf.gen_actions_by_type("signature"):
+            for chain in ac.attrs["chain"].split():
+                cpath = os.path.join(fpath, chain[0:2], chain)
+                if not removed_file:
+                    os.unlink(cpath)
+                    removed_file = True
+                elif not corrupted_file:
+                    with open(cpath, "w") as f:
+                        f.write("noodles")
+                    corrupted_file = True
                 else:
-                        fpath = path
-                if os.path.isdir(fpath):
-                        os.chmod(fpath, misc.PKG_DIR_MODE)
-                elif os.path.isfile(fpath):
-                        os.chmod(fpath, misc.PKG_FILE_MODE)
-
-        def __inject_badsig(self, fmri_str):
-                mpath = self.__get_mf_path(fmri_str)
-                with open(mpath, "a+") as mf:
-                        mf.write("set name=pkg.t_pkgrepo.bad_sig value=foo")
-                return mpath
-
-        def __repair_badsig(self, path):
-                mpath_new = path + ".new"
-                with open(path, "r") as mf:
-                        with open(mpath_new, "w") as mf_new:
-                                for line in mf.readlines():
-                                        if "pkg.t_pkgrepo.bad_sig" not in line:
-                                                mf_new.write(line)
-                os.rename(mpath_new, path)
-
-        def __inject_badchain(self, fmri_str):
-                """Given an fmri with a signature action, locate the chain
-                hashes used by that signature action in that package, and
-                remove the corresponding file from the repository. If the chain
-                references more one file, those subsequent files are
-                corrupted."""
-
-                mpath = self.__get_mf_path(fmri_str)
-                mf = pkg.manifest.Manifest()
-                mf.set_content(pathname=mpath)
-                fpath = os.path.sep.join([self.dc.get_repodir(), "publisher",
-                    "test", "file"])
-
-                bad_paths = []
-                removed_file = False
-                corrupted_file = False
-                for ac in mf.gen_actions_by_type("signature"):
-                        for chain in ac.attrs["chain"].split():
-                                cpath = os.path.join(fpath, chain[0:2], chain)
-                                if not removed_file:
-                                        os.unlink(cpath)
-                                        removed_file = True
-                                elif not corrupted_file:
-                                        with open(cpath, "w") as f:
-                                            f.write("noodles")
-                                        corrupted_file = True
-                                else:
-                                        with open(cpath, "wb") as badfile:
-                                                gz = pkg.pkggzip.PkgGzipFile(
-                                                    fileobj=badfile, mode="wb")
-                                                gz.write(b"noodles")
-                                                gz.close()
-                                bad_paths.append(cpath)
-                return bad_paths
-
-        def __inject_unknown(self):
-                pass
-
-        def test_11_verify_badhash(self):
-                """Test that verify finds bad hashes and invalid gzip files."""
-
-                repo_path = self.dc.get_repodir()
-                repo_uri = self.dc.get_repo_url()
-
-                # publish a single package and make sure the repository is clean
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
-
-                # break a file in the repository and ensure we spot it
-                bad_hash_path = self.__inject_badhash("tmp/truck1")
-
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.assertTrue(
-                    self.output.count("ERROR: Invalid file hash") == 1)
-                self.assertTrue(bad_hash_path in self.output)
-                self.assertTrue(fmris[0] in self.output)
-
-                # fix the file in the repository, and publish another package
-                self.__repair_badhash("tmp/truck1")
-                self.pkgsend_bulk(repo_path, (self.amber20))
-                fmris += self.pkgsend_bulk(repo_path, (self.truck10))
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
-                self.assertTrue(bad_hash_path not in self.output)
-                bad_hash_path = self.__inject_badhash("tmp/truck1")
-
-                # verify we now get two errors when verifying the repository
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.assertTrue(
-                    self.output.count("ERROR: Invalid file hash") == 2)
-                for fmri in fmris:
-                        self.assertTrue(fmri in self.output)
-                self.assertTrue(bad_hash_path in self.output)
-                # check we also print paths which deliver that corrupted file
-                self.assertTrue("etc/truck1" in self.output)
-                self.assertTrue("etc/trailer" in self.output)
-
-                # Corrupt another file to see that we can also spot files that
-                # aren't gzipped.
-                fmris += self.pkgsend_bulk(repo_path, (self.truck20))
-                bad_gzip_path = self.__inject_badhash("tmp/truck2",
-                    valid_gzip=False)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                # we should get 3 bad file hashes now, since we've added truck20
-                # which also references etc/truck1, which is bad.
-                self.assertTrue(
-                    self.output.count("ERROR: Invalid file hash") == 3)
-                self.assertTrue(
-                    self.output.count("ERROR: Corrupted gzip file") == 1)
-                self.assertTrue(bad_gzip_path in self.output)
-
-                # Check that when verifying content, we always use the most
-                # preferred hash.
-                hash_alg_list = ["sha256"]
-                if sha512_supported:
-                        hash_alg_list.append("sha512t_256")
-                for hash_alg in hash_alg_list:
-                        # Remove all existing packages first.
-                        self.pkgrepo("-s {0} remove {1}".format(repo_path,
-                            " ".join(fmris)))
-                        fmris = self.pkgsend_bulk(repo_path, (self.tree10),
-                            debug_hash="sha1+{0}".format(hash_alg))
-                        self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
-
-                        # break a file in the repository and ensure we spot it.
-                        bad_hash_path = self.__inject_badhash("tmp/truck1")
-                        bad_basename = os.path.basename(bad_hash_path)
-
-                        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                        self.assertTrue(
-                            self.output.count("ERROR: Invalid file hash") == 1)
-
-                        # We should be verifying using the SHA-2 hash, and so we
-                        # should only see the SHA-1 value in the output once,
-                        # when printing the path to the file in the repository,
-                        # not when reporting the computed or expected hash.
-                        self.assertTrue(self.output.count(bad_basename) == 1)
-
-                        # Verify that when we publish using SHA-1 only, that we
-                        # get the SHA-1 value printed twice: once when printing
-                        # the path to the file in the repository, and once when
-                        # printing the expected hash.
-                        self.pkgrepo("-s {0} remove {1}".format(repo_path,
-                            " ".join(fmris)))
-                        fmris = self.pkgsend_bulk(repo_path, (self.tree10),
-                            debug_hash="sha1")
-                        self.__inject_badhash("tmp/truck1")
-
-                        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                        self.assertTrue(self.output.count(bad_basename) == 2)
-
-        def test_12_verify_badmanifest(self):
-                """Test that verify finds bad manifests."""
-                repo_path = self.dc.get_repodir()
-
-                # publish a single package
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-
-                # corrupt a manifest and make sure pkglint agrees
-                bad_mf = self.__inject_badmanifest(fmris[0])
-                self.pkglint(bad_mf, exit=1)
-
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.assertTrue(bad_mf in self.output)
-                self.assertTrue("Corrupt manifest." in self.output)
-
-                # publish more packages, and verify we still get the one error
-                fmris += self.pkgsend_bulk(repo_path, (self.truck10,
-                    self.amber10))
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.assertTrue(
-                    self.output.count("ERROR: Corrupt manifest.") == 1)
-
-                # break another manifest, and check we get two errors
-                another_bad_mf = self.__inject_badmanifest(fmris[-1])
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.assertTrue(another_bad_mf in self.output)
-                self.assertTrue(bad_mf in self.output)
-                self.assertTrue(
-                    self.output.count("Corrupt manifest.") == 2)
-
-        def test_13_verify_nofile(self):
-                """Test that verify finds missing files."""
-
-                repo_path = self.dc.get_repodir()
-
-                # publish a single package and break it
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                missing_file = self.__inject_nofile("tmp/truck1")
-
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.assertTrue(missing_file in self.output)
-                self.assertTrue("ERROR: Missing file: {0}".format(
-                    self.fhashes["tmp/truck1"] in self.output))
-                self.assertTrue(fmris[0] in self.output)
-
-                # publish another package that also delivers the file
-                # and inject the error again, checking that both manifests
-                # appear in the output
-                fmris += self.pkgsend_bulk(repo_path, (self.truck10))
-                self.__inject_nofile("tmp/truck1")
-
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.assertTrue(missing_file in self.output)
-                self.assertTrue(self.output.count("ERROR: Missing file: {0}".format(
-                    self.fhashes["tmp/truck1"])) == 2)
-                for f in fmris:
-                        self.assertTrue(f in self.output)
-
-        def test_14_verify_permissions(self):
-                """Check that we can find files and manifests in the
-                repository that have invalid permissions."""
-
-                repo_path = self.dc.get_repodir()
-
-                shutil.rmtree(repo_path)
-                os.mkdir(repo_path)
-                os.chmod(repo_path, 0o777)
-                self.pkgrepo("create {0}".format(repo_path), su_wrap=True)
-                self.pkgrepo("set -s {0} publisher/prefix=test".format(repo_path),
-                    su_wrap=True)
-                # publish a single package and break it
-                fmris = self.pkgsend_bulk(repo_path, (self.truck10),
-                    su_wrap=True)
-                bad_path = self.__inject_perm(path="tmp/truck1")
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1, su_wrap=True)
-                self.assertTrue(bad_path in self.output)
-                self.assertTrue("ERROR: Verification failure" in self.output)
-                self.assertTrue(fmris[0] in self.output)
-                self.__repair_perm(bad_path)
-
-                # Just break the parent directory, we should still report the
-                # hash file as unreadable
-                bad_parent = self.__inject_perm(path="tmp/truck1", parent=True)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1, su_wrap=True)
-                self.assertTrue(bad_path in self.output)
-                self.assertTrue("ERROR: Verification failure" in self.output)
-                self.assertTrue(fmris[0] in self.output)
-                self.__repair_perm(bad_parent)
-                # break some manifests
-                fmris = self.pkgsend_bulk(repo_path, (self.truck20),
-                    su_wrap=True)
-
-                bad_mf_path = self.__inject_perm(fmri_str=fmris[0])
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1, su_wrap=True)
-                self.assertTrue(bad_mf_path in self.output)
-                self.assertTrue("ERROR: Verification failure" in self.output)
-
-                # this should cause both manifests to report errors
-                bad_mf_path = self.__inject_perm(fmri_str=fmris[0], parent=True)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1, su_wrap=True)
-                self.assertTrue(bad_mf_path in self.output)
-                self.assertTrue("ERROR: Verification failure" in self.output)
-                self.__repair_perm(bad_mf_path)
-
-        def test_15_verify_badsig(self):
-                repo_path = self.dc.get_repodir()
-
-                # publish a single package and break it
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                self.pkgsign(repo_path, "\\*")
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                bad_path = self.__inject_badsig(fmris[0])
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.assertTrue(bad_path in self.output)
-                self.assertTrue("ERROR: Bad signature." in self.output)
-                self.__repair_badsig(bad_path)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
-
-                # now sign with a key, cert and chain cert and check we fail
-                # to verify
-                self.pkgsign_simple(repo_path, "\\*")
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.assertTrue("ERROR: Bad signature." in self.output)
-
-                # now set a trust anchor directory, and expect that pkgrepo
-                # verify will now pass
-                ta_dir = os.path.join(self.test_root,
-                    "ro_data/signing_certs/produced/ta3")
-                self.pkgrepo("-s {0} set repository/trust-anchor-directory={1}".format(
-                    repo_path, ta_dir))
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
-
-                # remove the old package and republish it so it can be signed
-                # again.
-                self.pkgrepo("-s {0} remove {1}".format(repo_path, fmris[0]))
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-
-                # Create an image, setup its trust-anchor dir, then use that
-                # for our repository so that pkgrepo verify can perform
-                # signature verification against it.
-                self.image_create()
-                self.seed_ta_dir("ta1")
-                self.pkgrepo("-s {0} set repository/trust-anchor-directory={1}".format(
-                    repo_path, self.raw_trust_anchor_dir))
-
-                # We sign with several certs so that we get a 'chain' attribute
-                # that contains several hashes.
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5}".format(
-                      key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      i1=os.path.join(self.chain_certs_dir,
-                          "ch1_ta1_cert.pem"),
-                      i2=os.path.join(self.chain_certs_dir,
-                          "ch2_ta1_cert.pem"),
-                      i3=os.path.join(self.chain_certs_dir,
-                          "ch3_ta1_cert.pem"),
-                      i4=os.path.join(self.chain_certs_dir,
-                          "ch4_ta1_cert.pem"),
-                      i5=os.path.join(self.chain_certs_dir,
-                          "ch5_ta1_cert.pem")
-                    )
-
-                self.pkgsign(repo_path, "{0} \\*".format(sign_args))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-                bad_paths = self.__inject_badchain(fmris[0])
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                for bad_path in bad_paths:
-                        self.assertTrue(bad_path in self.output)
-
-        def test_16_verify_warn_openperms(self):
-                """Test that we emit a warning message when the repository is
-                not world-readable."""
-
-                repo_path = self.dc.get_repodir()
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                os.chmod(self.test_root, 0o700)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
-                self.assertTrue("WARNING: " in self.output)
-                self.assertTrue("svc:/application/pkg/system-repository" \
-                    in self.output)
-                self.assertTrue("ERROR: " not in self.output)
-                os.chmod(self.test_root, 0o755)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
-                self.assertTrue("WARNING: " not in self.output)
-
-        def test_17_verify_empty_pub(self):
-                """Test that we can verify a repository that contains a
-                publisher with no packages."""
-                repo_path = self.dc.get_repodir()
-                fmris = self.pkgsend_bulk(repo_path, (self.truck10))
-                self.pkgrepo("-s {0} add-publisher empty".format(repo_path))
-                self.pkgrepo("-s {0} verify -p empty".format(repo_path))
-
-        def test_18_verify_invalid_repos(self):
-                """Test that we exit with a usage message for v3 repos and
-                network repositories."""
-                repo_path = self.dc.get_repodir()
-                fmris = self.pkgsend_bulk(repo_path, (self.truck10))
-                depot_uri = self.dc.get_depot_url()
-                self.dc.start()
-                self.pkgrepo("-s {0} verify".format(depot_uri), exit=2)
-                self.dc.stop()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create --version=3 {0}".format(repo_path))
-                self.pkgrepo("set -s {0} publisher/prefix=test".format(repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.truck10))
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-
-        def test_19_verify_valid_dependency(self):
-                """Test package with valid dependency will not cause verify
-                failure."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                self.pkgsend_bulk(repo_path, (self.truck10, self.truck20,
-                    self.amber10, self.amber20, self.tree10))
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-        def test_20_verify_missing_nonincorp_dependency(self):
-                """Test that we can verify which dependency is missing from
-                a repository."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                # Test that missing dependency will be reported in -d mode.
-                self.pkgsend_bulk(repo_path, (self.wtinstallhold10,
-                    self.wtinstallhold20))
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                # Test that it will also be reported without -d.
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                # Test that disabling dependency check works.
-                self.pkgrepo("-s {0} verify --disable dependency".format(repo_path))
-                self.pkgrepo("-s {0} verify --disable dependency "
-                    "--disable dependency".format(repo_path))
-                # Test that disabling unknown check fails.
-                self.pkgrepo("-s {0} verify --disable unknown".format(repo_path),
-                    exit=2)
-                # Test that disabling dependency check will disallow -i or -d
-                # option
-                self.pkgrepo("-s {0} verify --disable dependency -i file".format(
-                    repo_path), exit=2)
-                self.pkgrepo("-s {0} verify --disable dependency -d".format(
-                    repo_path), exit=2)
-                # Test that complete dependency will pass verification and
-                # miner version dependency will be used if the exact version
-                # required is missing.
-                self.pkgsend_bulk(repo_path, (self.amber20,
-                    self.tree10))
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                self.pkgsend_bulk(repo_path, self.optionalpkg10)
-                # Should be no problem for completely missing optional
-                # dependency.
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgsend_bulk(repo_path, (self.zoo10))
-                # Should fail this time.
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-
-        def test_21_verify_exclude_dependency(self):
-                """Test that exclude dependency does not cause failure."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                self.pkgsend_bulk(repo_path, (self.refuse10))
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-        def test_22_verify_illegal_dependency(self):
-                """Test illegal dependency will cause verification errors."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.illegaldep10))
-
-                # Test bad depend version number causes reporting error.
-                badversion = "depend fmri=pkg:/amber@1.x type=require"
-                self.__inject_depend(fmris[0], badversion)
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-
-                # Test bad depend package name causes reporting error.
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.illegaldep10))
-                badname = "depend fmri=pkg:/_amber@1.0 type=require"
-                self.__inject_depend(fmris[0], badname)
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-
-        def test_23_verify_no_install_hold(self):
-                """Test if there is no install-hold, then dependency check will
-                still run with or without -d."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                self.pkgsend_bulk(repo_path, (self.truck10, self.truck20))
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                # Sending amber@1.0 without tree@1.0 still fail.
-                self.pkgsend_bulk(repo_path, (self.amber10))
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                # Sending amber@2.0 still fail.
-                self.pkgsend_bulk(repo_path, (self.amber20))
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                # Finally send tree@1.0 to make the repo complete.
-                self.pkgsend_bulk(repo_path, (self.tree10))
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-        def test_24_verify_provided_publisher(self):
-                """Test verifying only the dependencies of provided publisher
-                by -p option."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test1".format(
-                    repo_path))
-                self.pkgrepo("-s {0} add-publisher test2".format(repo_path))
-                self.pkgsend_bulk(repo_path, (self.withpub1_10,
-                    self.withpub2_10))
-                #This should fail, because dependency amber@1.0 is missing
-                # for withpub1@1.0 under test1.
-                self.pkgrepo("-s {0} verify -p test1 -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify -p test1".format(repo_path), exit=1)
-                # Send the missing dependency should lead to verifaction
-                # success.
-                self.pkgsend_bulk(repo_path, (self.amber10, self.tree10))
-                self.pkgrepo("-s {0} verify -p test1 -d".format(repo_path))
-                self.pkgrepo("-s {0} verify -p test1".format(repo_path))
-                # Package withpub2 under test2 should still fail on
-                # verification.
-                self.pkgrepo("-s {0} verify -p test2 -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify -p test2".format(repo_path), exit=1)
-
-        def __make_repo_incorp(self, repo_path, dep_inj):
-                """Create a repository with incorporation dependency."""
-
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.incorp10,
-                    self.amber10, self.tree10))
-                self.__inject_depend(fmris[0], dep_inj)
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-
-        def test_25_verify_missing_incorp_dependency(self):
-                """Test missing incorporate dependency will cause verify
-                failure."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.incorp10,
-                    self.amber10, self.tree10))
-                # Test just specifying same release number will not cause
-                # verify failure.
-                verrel = "depend fmri=pkg:/amber@1.0 type=incorporate"
-                self.__make_repo_incorp(repo_path, verrel)
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-                # Shorter release number will work.
-                verrel = "depend fmri=pkg:/amber@1 type=incorporate"
-                self.__make_repo_incorp(repo_path, verrel)
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-                # Test specifying different release version will cause verify
-                # failure.
-                verrel = "depend fmri=pkg:/amber@2.0 type=incorporate"
-                self.__make_repo_incorp(repo_path, verrel)
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-
-                verrel = "depend fmri=pkg:/amber@0.8 type=incorporate"
-                self.__make_repo_incorp(repo_path, verrel)
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-
-                # Test specifying same release and build version will not lead
-                # to fail.
-                version = "depend fmri=pkg:/amber@1.0,5.11 type=incorporate"
-                self.__make_repo_incorp(repo_path, version)
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-                # Test specifying same release and different build version
-                # will not cause verify failure, simply because the build
-                # version is ignored.
-                version = "depend fmri=pkg:/amber@1.0,5.10 type=incorporate"
-                self.__make_repo_incorp(repo_path, version)
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-                version = "depend fmri=pkg:/amber@1.0,5.12 type=incorporate"
-                self.__make_repo_incorp(repo_path, version)
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-                # Test specifying same release, build and branch version will
-                # not cause verify failure.
-                version = "depend fmri=pkg:/amber@1.0,5.11-0 type=incorporate"
-                self.__make_repo_incorp(repo_path, version)
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-                # Test specifying same release and build version but different
-                # branch version will cause verify failure.
-                version = "depend fmri=pkg:/amber@1.0,5.11-1 type=incorporate"
-                self.__make_repo_incorp(repo_path, version)
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-
-                version = "depend fmri=pkg:/amber@1.0,5.11-0.1 " \
-                    "type=incorporate"
-                self.__make_repo_incorp(repo_path, version)
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                # Test specifying same release, build, branch version and time
-                # stamp will not cause verify failure.
-                version = \
-                    "depend fmri=pkg:/amber@1.0,5.11-0:20110804T203458Z " \
-                    "type=incorporate"
-                self.__make_repo_incorp(repo_path, version)
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-                # Test specifying same release, build and branch version but
-                # different time stamp will cause verify failure.
-                version = \
-                    "depend fmri=pkg:/amber@1.0,5.11-0:20100804T203458Z " \
-                    "type=incorporate"
-                self.__make_repo_incorp(repo_path, version)
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-
-                version = \
-                    "depend fmri=pkg:/amber@1.0,5.11-0:20120804T203458Z " \
-                    "type=incorporate"
-                self.__make_repo_incorp(repo_path, version)
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-
-                version = \
-                    "depend fmri=pkg:/amber@1.0,5.11-0:20120804 " \
-                    "type=incorporate"
-                self.__make_repo_incorp(repo_path, version)
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-
-        def test_26_verify_require_any_dependency(self):
-                """Test require-any dependency verification."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                self.pkgsend_bulk(repo_path, (self.require_any10, self.tree10))
-                # Test missing dependency will cause verify failure.
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                # Test sending one of the require-any dependency still cause
-                # verify failed.
-                self.pkgsend_bulk(repo_path, (self.amber10))
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                # Test sending all of the require-any dependency lead
-                # to success.
-                self.pkgsend_bulk(repo_path, (self.amber20))
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-        def test_27_verify_publisher_merge(self):
-                """Test packages with same package, different version and
-                different publisher are merged together for verification."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test1".format(
-                    repo_path))
-                self.pkgrepo("-s {0} add-publisher test2".format(repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.incorp10,
-                    self.withpub1_10, self.withpub1_20, self.amber10,
-                    self.tree10))
-
-                dep_str = "depend fmri=pkg:/withpub1@2.0 type=require"
-                self.__inject_depend(fmris[0], dep_str, pub="test1")
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-
-        def test_28_verify_ignore_dep_attr(self):
-                """Test whether ignore-check tag works as expected."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.depchecktag10))
-                # Missing unignored dependency causes failure.
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-                # Sending missing dependency leads to success.
-                fmris = self.pkgsend_bulk(repo_path, (self.depcheckdep10))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-
-                # Check if Ignore check label works.
-                dep_str = "depend fmri=tree@1.0 type=require " \
-                    "ignore-check=\"external\"\n"
-                self.__inject_depend(fmris[0], dep_str)
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                dep_str = "depend fmri=incorp@1.0 type=require " \
-                    "ignore-check=\"excluded\"\n"
-                self.__inject_depend(fmris[0], dep_str)
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
-
-        def test_29_verify_parent_and_special_dep(self):
-                """Test parent dependency and special dependency are handled
-                properly."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                dep_str = "depend fmri=incorp@1.0 type=parent\n"
-                self.__inject_depend(fmris[0], dep_str)
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                dep_str = "depend fmri=feature/test/magic@1.0 type=require\n"
-                self.__inject_depend(fmris[0], dep_str)
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                self.pkgrepo("-s {0} verify -d".format(repo_path))
-
-        def __make_repo_ignore_dep(self, repo_path, dep_inj):
-                """Create a repository with incorporation dependency."""
-
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.incorp10))
-                self.__inject_depend(fmris[0], dep_inj)
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-
-        def __run_verify_with_ignore_file(self, repo_path, ientry, ifpath,
-            exit1=0, exit2=0):
-                """Run pkgrepo verify with ignored dep files."""
-
-                with open(ifpath, "w") as iff:
-                        iff.write(ientry)
-                self.pkgrepo("-s {0} verify -i {1}".format(repo_path, ifpath),
-                    exit=exit1)
-                self.pkgrepo("-s {0} verify -i {1} -d".format(repo_path, ifpath),
-                    exit=exit2)
-
-        def test_30_verify_ignore_pkgs(self):
-                """Test if supplied ignored packages in ignored dep files are
-                handled properly."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test1".format(
-                    repo_path))
-                self.pkgsend_bulk(repo_path, (self.amber10, self.amber20))
-                ifpath = os.path.join(self.test_root, "tmp",
-                    "ignored_dep_file")
-
-                # Test invalid entry causes failure.
-                ientry = "tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=tree@x.1"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=amber depend=tree@x.1"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=amber min_ver=4abc* depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=amber max_ver=x.1 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=tree@x.1 unknown=2"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=tree@x.1 unknown1=2, unknown2=\"u\""
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                # Test bad file path causes failure.
-                badifpath = os.path.join(self.test_root, "tmp",
-                    "bad_ignored_dep_file")
-                self.pkgrepo("-s {0} verify -i {1}".format(repo_path, badifpath),
-                    exit=1)
-                self.pkgrepo("-s {0} verify -i {1} -d".format(repo_path, badifpath),
-                    exit=1)
-
-                # Test file with arbitary new line or other space symbols does
-                # not cause failure.
-                ientry = "   pkg=amber   \t\t depend=tree   \n\t\r\n\n"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                # Test with comment line
-                ientry = " # this comments test \npkg=amber depend=tree\n"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                # Test duplicate entries will not cause problem.
-                ientry = "pkg=amber   depend=tree\npkg=amber   depend=tree"
-                with open(ifpath, "w") as iff:
-                        iff.write(ientry)
-                self.pkgrepo("-s {0} verify -i {1}".format(repo_path, ifpath))
-                # Test in -d mode, ignored_dep_file will not be used.
-                self.pkgrepo("-s {0} verify -i {1} -d".format(repo_path, ifpath),
-                    exit=1)
-
-                # Test min version bound
-                ientry = "pkg=amber min_ver=1.0 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber min_ver=1 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber min_ver=0.9.1 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber min_ver=1.0-0:20110804T203458Z depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber min_ver=1.0-1:20110804T203458Z depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=amber min_ver=1.0-0:20110804T203459Z depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=amber min_ver=0.5 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber min_ver=0.5-2 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber min_ver=2.0 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=amber min_ver=2.5 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                # Test max version bound
-                ientry = "pkg=amber max_ver=2 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber max_ver=2.0 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber max_ver=2.0.1 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber max_ver=1.9.1 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=amber max_ver=2.0-0 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber max_ver=2.0-0:20110804T203458Z " \
-                    "depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber max_ver=2.0-0:20110804T203457Z " \
-                    "depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                ientry = "pkg=amber max_ver=2.5-0:20110804T203457Z " \
-                    "depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber max_ver=2.5 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=amber max_ver=1.0 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                # Test combination of max and min bound.
-                ientry = "pkg=amber min_ver=1.0 max_ver=2.0 depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                # Test with publisher specified.
-                ientry = "pkg=pkg://test1/amber depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=pkg://test2/amber depend=tree"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                # Test gaps between two pairs of min and max version bounds.
-                self.pkgsend_bulk(repo_path, (self.amber30))
-                ientry = "pkg=amber min_ver=1.0 max_ver=1.0 depend=tree\n" \
-                    "pkg=amber min_ver=3.0 max_ver=3.5 depend=bronze\n"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-        def test_31_verify_ignore_deps(self):
-                """ Test if dependencies specified in ignored dep files are
-                handled correctly."""
-
-                repo_path = self.dc.get_repodir()
-                ifpath = os.path.join(self.test_root, "tmp",
-                    "ignored_dep_file")
-                dep_inj = "depend fmri=tree type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "pkg=incorp@1.0 depend=tree"
-                with open(ifpath, "w") as iff:
-                        iff.write(ientry)
-                self.pkgrepo("-s {0} verify -i {1}".format(repo_path, ifpath))
-                self.pkgrepo("-s {0} verify -i {1} -d".format(repo_path, ifpath),
-                    exit=1)
-
-                dep_inj = "depend fmri=tree@1.0-1.1:20110804T203458Z " \
-                    "type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "pkg=incorp depend=tree@1.0"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=incorp depend=tree@1.0-1"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=incorp depend=tree@1.0-1.1"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "pkg=incorp depend=tree@1.0-1.1:20110804T203458Z"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                dep_inj = "depend fmri=tree@1.0 type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "pkg=incorp depend=tree@1.0,5.11"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                dep_inj = "depend fmri=tree@1.0 type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=tree@1.0,5.11-0 pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                dep_inj = "depend fmri=tree@1.0 type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=tree@1.0,5.11-0:20110804T203458Z pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                # Test multiple ignore entries or multiple dependency actions.
-                dep_inj = "depend fmri=tree@1.0 type=require\n" \
-                    "depend fmri=forest@1.0 type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=tree@1.0 depend=forest@1.0 pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                ientry = "depend=tree@1.0 pkg=incorp\n"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                dep_inj = "depend fmri=tree@1.0 type=require\n" \
-                    "depend fmri=tree@1.1 type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=tree@1 pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                dep_inj = "depend fmri=tree type=require\n"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "pkg=incorp depend=tree@1.0\npkg=incorp depend=tree\n"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                # Test multiple files input.
-                dep_inj = "depend fmri=tree@1.0 type=require\n" \
-                    "depend fmri=forest@1.0 type=require\n"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                i1entry = "depend=tree@1.0 pkg=incorp\n"
-                with open(ifpath, "w") as iff:
-                        iff.write(i1entry)
-                i2entry = "depend=forest@1.0 pkg=incorp\n"
-                if2path = os.path.join(self.test_root, "tmp",
-                    "ignored_dep_file2")
-                with open(if2path, "w") as iff:
-                        iff.write(i2entry)
-                self.pkgrepo("-s {0} verify -i {1} -i {2}".format(repo_path, ifpath,
-                    if2path))
-                self.pkgrepo("-s {0} verify -i {1} -i {2} -d".format(repo_path, ifpath,
-                    if2path), exit=1)
-
-                # Test if there is no version limit for dependency, then it
-                # should not be ignored unless user specifies an ignored
-                # package without version as well.
-                dep_inj = "depend fmri=tree type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=tree@1.0 pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                # Test more wrong versions.
-                dep_inj = "depend fmri=tree@1 type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=tree@1.0 pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                dep_inj = "depend fmri=tree@1.0,5.11-0 type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=tree@1.0,5.11-1:20110804T203458Z pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                dep_inj = "depend fmri=tree@1.0,5.11-0:20120804T203458Z " \
-                    "type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=tree@1.0,5.11-1:20110804T203458Z pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-                # Test giving publisher for both dependency and ignored pkg
-                # works.
-                dep_inj = "depend fmri=pkg://test/tree@1.0 type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=pkg://test/tree@1.0 pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                # Test giving publisher for only dependency works.
-                ientry = "depend=tree@1.0 pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                # Test giving publisher for ignored pkg works.
-                dep_inj = "depend fmri=tree@1.0 type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=pkg://test/tree@1.0 pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit2=1)
-
-                # Test wrong publisher will not work.
-                dep_inj = "depend fmri=pkg://test/tree@1.0 type=require"
-                self.__make_repo_ignore_dep(repo_path, dep_inj)
-                ientry = "depend=pkg://test1/tree@1.0 pkg=incorp"
-                self.__run_verify_with_ignore_file(repo_path, ientry, ifpath,
-                    exit1=1, exit2=1)
-
-        def test_verify_ignore_non_certificate_file_or_directory(self):
-                """Ensure that invalid certificate files and directories
-                are ignored."""
-                repo_path = self.dc.get_repodir()
-                repo = self.dc.get_repo()
-                trust_anchor_dir = repo.cfg.get_property("repository",
-                    "trust-anchor-directory")
-                cert_path = os.path.join(trust_anchor_dir, "foo.pem")
-                cert_dir = os.path.join(trust_anchor_dir, "foo")
-                file_created = False
-                dir_created = False
-
-                # Test certificate load will not fail with a directoy in
-                # the trust anchor directory
-                if not os.path.exists(cert_dir):
-                        dir_created = True
-                        os.makedirs(cert_dir)
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                if dir_created:
-                        os.rmdir(cert_dir)
-
-                # Test certificate load will not fail with an invalid 
-                # certificate file in the trust anchor directory
-                if not os.path.exists(cert_path):
-                        file_created = True
-                        open(cert_path, 'w').close()
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                if file_created:
-                        os.remove(cert_path)
-
-        def __inject_truncate_file(self, path):
-                fpath = self.__get_file_path(path)
-                self.cmdline_run("/usr/bin/truncate --size 5 {path}".format(
-                    path=fpath), coverage=False)
-                return fpath
-
-        def test_verify_truncated_file(self):
-                """Test that verify handles the case of truncated files."""
-
-                repo_path = self.dc.get_repodir()
-
-                # publish a single package and truncate a file in it
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                truncate_file = self.__inject_truncate_file("tmp/truck1")
-
-                self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
-                self.assertTrue(truncate_file in self.output)
-                self.assertTrue(
-                    self.output.count("ERROR: Corrupted gzip file") == 1)                
-
-        def __get_fhashes(self, repodir, pub):
-                """Returns a list of file hashes for the publisher
-                pub in a given repository."""
-                fhashes = []
-                files_dir = os.path.sep.join(["publisher", pub, "file"])
-                for dirpath, dirs, files in os.walk(os.path.join(repodir,
-                    files_dir)):
-                        fhashes.extend(files)
-                return fhashes
-
-        def test_32_fix_brokenmanifest(self):
-                """Test that fix operations correct a bad manifest in a file
-                repo."""
-
-                repo_path = self.dc.get_repodir()
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                self.pkgsign(repo_path, "\\*")
-
-                self.pkgrepo("-s {0} fix".format(repo_path))
-
-                valid_hashes = self.__get_fhashes(repo_path, "test")
-                self.debug(valid_hashes)
-                bad_path = self.__inject_badsig(fmris[0])
-                self.pkgrepo("-s {0} fix".format(repo_path))
-                self.assertTrue(fmris[0] in self.output)
-                self.assertTrue(not os.path.exists(bad_path))
-
-                # check our quarantine dir has been created
-                q_dir = os.path.sep.join([repo_path, "publisher", "test",
-                    "pkg5-quarantine"])
-                self.assertTrue(os.path.exists(q_dir))
-
-                # check the broken manifest is in the quarantine dir
-                mf_path_sub = bad_path.replace(
-                    os.path.sep.join([repo_path, "publisher", "test"]), "")
-                # quarantined items are stored in a new tmpdir per-session
-                q_dir_tmp = os.listdir(q_dir)[0]
-                q_mf_path = os.path.sep.join([q_dir, q_dir_tmp, mf_path_sub])
-                self.assertTrue(os.path.exists(q_mf_path))
-
-                # make sure the package no longer appears in the catalog
-                self.pkgrepo("-s {0} list -F tsv".format(repo_path))
-                self.assertTrue(fmris[0] not in self.output)
-
-                # ensure that only the manifest was quarantined - file hashes
-                # were left alone.
-                remaining_hashes = self.__get_fhashes(repo_path, "test")
-                self.assertTrue(set(valid_hashes) == set(remaining_hashes))
-
-                # finally, ensure we can republish this package
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                self.pkgrepo("-s {0} list -F tsv".format(repo_path))
-                self.assertTrue(fmris[0] in self.output)
-
-        def test_33_fix_brokenfile(self):
-                """Test that operations that cause us to fix a file shared
-                by several packages cause all of those packages to be
-                quarantined.
-
-                This also tests the -v option of pkg fix, which prints the
-                pkgrepo verify output and prints details of which files are
-                being quarantined.
-                """
-
-                repo_path = self.dc.get_repodir()
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10,
-                    self.trucknd10))
-                self.pkgrepo("-s {0} fix".format(repo_path))
-                bad_file = self.__inject_badhash("tmp/truck1")
-
-                old_hashes = self.__get_fhashes(repo_path, "test1")
-
-                self.pkgrepo("-s {0} fix -v".format(repo_path))
-
-                # since the file was shared by two manifests, we should get
-                # the manifest name printed twice: once when we encounter the
-                # broken file, then again when we print the summary of which
-                # packages need to be republished.
-                self.assertTrue(self.output.count(fmris[0]) == 2)
-                self.assertTrue(self.output.count(fmris[1]) == 2)
-                self.assertTrue(self.output.count("ERROR: Invalid file hash") == 2)
-
-                # the bad file name gets printed 3 times, once for each time
-                # a manifest references it and verify discovered the error,
-                # and once when we report where the file was moved to.
-                self.assertTrue(self.output.count(bad_file) == 3)
-
-                # check the broken file is in the quarantine dir and that
-                # we printed where it moved to
-                bad_file_sub = bad_file.replace(
-                    os.path.sep.join([repo_path, "publisher", "test"]), "")
-                # quarantined items are stored in a new tmpdir per-session
-                q_dir = os.path.sep.join([repo_path, "publisher", "test",
-                    "pkg5-quarantine"])
-                q_dir_tmp = os.listdir(q_dir)[0]
-                q_file_path = os.path.normpath(
-                    os.path.sep.join([q_dir, q_dir_tmp, bad_file_sub]))
-                self.assertTrue(os.path.exists(q_file_path))
-                self.debug(q_file_path)
-                self.assertTrue(q_file_path in self.output)
-
-                remaining_hashes = self.__get_fhashes(repo_path, "test1")
-                # check that we only quarantined the bad hash file
-                self.assertTrue(set(remaining_hashes) == \
-                    set(old_hashes) - set(os.path.basename(bad_file)))
-
-                # Make sure the repository is now clean, and remains so even
-                # after we republish the packages, and that all file content is
-                # replaced.
-                self.pkgrepo("-s {0} fix".format(repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10,
-                    self.trucknd10))
-                new_hashes = self.__get_fhashes(repo_path, "test1")
-                self.assertTrue(set(new_hashes) == set(old_hashes))
-                self.pkgrepo("-s {0} fix".format(repo_path))
-
-        def test_34_fix_brokenperm(self):
-                """Tests that when running fix as an unpriviliged user that we
-                fail to fix the repository."""
-
-                repo_path = self.dc.get_repodir()
-
-                shutil.rmtree(repo_path)
-                os.mkdir(repo_path)
-                os.chmod(repo_path, 0o777)
-                self.pkgrepo("create {0}".format(repo_path), su_wrap=True)
-                self.pkgrepo("set -s {0} publisher/prefix=test".format(repo_path),
-                    su_wrap=True)
-                # publish a single package and break it
-                fmris = self.pkgsend_bulk(repo_path, (self.truck10),
-                    su_wrap=True)
-                # this breaks the permissions of one of the manifests and
-                # chowns is such that we shouldn't be able to quarantine it.
-                bad_path = self.__inject_perm(fmri_str=fmris[0], chown=True)
-
-                self.pkgrepo("-s {0} fix".format(repo_path), exit=1, stderr=True,
-                    su_wrap=True)
-                self.assertTrue(bad_path in self.errout)
-                # the fix should succeed now, but not emit any output, because
-                # it's running as root, and the permissions are fine according
-                # to a root user
-                self.pkgrepo("-s {0} fix".format(repo_path))
-                # but we should still be able to warn about the bad path for
-                # pkg5srv access.
-                self.pkgrepo("-s {0} verify".format(repo_path))
-                self.assertTrue("WARNING: " in self.output)
-
-        def test_35_fix_unsupported_repo(self):
-                """Tests that when running fix on a v3 repo fails"""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create --version=3 {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.truck10))
-                self.pkgrepo("-s {0} fix".format(repo_path), exit=1)
-                self.assertTrue("only version 4 repositories are supported." in
-                    self.errout)
-
-        def test_36_fix_empty_missing_pub(self):
-                """Test that we can attempt to fix a repository that contains a
-                publisher with no packages, and that we fail on missing pubs"""
-
-                repo_path = self.dc.get_repodir()
-                fmris = self.pkgsend_bulk(repo_path, (self.tree10))
-                self.pkgrepo("-s {0} add-publisher empty".format(repo_path))
-                self.pkgrepo("-s {0} fix -p test".format(repo_path))
-                self.pkgrepo("-s {0} fix -p missing".format(repo_path), exit=1)
-                self.assertTrue("no matching publishers" in self.errout)
-
-        def test_37_fix_dependency(self):
-                """Test with dependency errors, fix will fail."""
-
-                repo_path = self.dc.get_repodir()
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                self.pkgsend_bulk(repo_path, (self.wtinstallhold20,
-                    self.amber10))
-                self.dc.start()
-                self.pkgrepo("-s {0} fix -v".format(repo_path), exit=1)
-
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.illegaldep10))
-
-                # Test bad depend version number causes reporting error.
-                badversion = "depend fmri=pkg:/amber@1.x type=require"
-                self.__inject_depend(fmris[0], badversion)
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-                self.pkgrepo("-s {0} fix -v".format(repo_path), exit=1)
-
-                # Test bad depend package name causes reporting error.
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=test".format(
-                    repo_path))
-                fmris = self.pkgsend_bulk(repo_path, (self.illegaldep10))
-                badname = "depend fmri=pkg:/_amber@1.0 type=require"
-                self.__inject_depend(fmris[0], badname)
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-                self.pkgrepo("-s {0} fix".format(repo_path), exit=1)
-
-        def test_38_invalid_repo(self):
-                """Test that trying to open an invalid repository is handled
-                correctly"""
-
-                tmpdir = tempfile.mkdtemp(dir=self.test_root)
-
-                with open(os.path.join(tmpdir, "pkg5.image"), "w") as f:
-                    f.write("[image]\nversion = 2")
-
-                self.assertRaises(sr.RepositoryInvalidError, sr.Repository, 
-                    root=tmpdir)
-
-        def test_39_remove_publisher(self):
-                """Verify that remove-publisher subcommand works as expected."""
-
-                # Create a repository.
-                repo_path = os.path.join(self.test_root, "repo")
-                self.create_repo(repo_path)
-
-                # Verify invalid publisher prefixes are rejected gracefully.
-                self.pkgrepo("-s {0} remove-publisher !valid".format(repo_path), exit=1)
-                self.pkgrepo("-s {0} remove-publisher file:{1}".format(repo_path,
-                    repo_path), exit=1)
-                self.pkgrepo("-s {0} remove-publisher valid !valid".format(repo_path),
-                    exit=1)
-
-                # Verify that remove-publisher will exit with complete failure
-                # if no publisher in the repo.
-                self.pkgrepo("-s {0} remove-publisher example.com".format(
-                    repo_path), exit=1)
-
-                # Verify that single publisher can be removed at a time, and
-                # if it is default publisher, the prefix field is unset.
-                self.pkgrepo("-s {0} add-publisher example.com".format(
-                    repo_path))
-
-                # If a depot is running, this will trigger a reload of the
-                # configuration data.
-                self.dc.refresh()
-
-                # Publish some packages.
-                self.pkgsend_bulk(repo_path, (self.tree10, self.amber10,
-                    self.amber20, self.truck10, self.truck20))
-                self.pkgrepo("-s {0} remove-publisher example.com".format(
-                    repo_path))
-                self.assertTrue("has been unset" in self.output)
-                self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
-                expected = """\
+                    with open(cpath, "wb") as badfile:
+                        gz = pkg.pkggzip.PkgGzipFile(fileobj=badfile, mode="wb")
+                        gz.write(b"noodles")
+                        gz.close()
+                bad_paths.append(cpath)
+        return bad_paths
+
+    def __inject_unknown(self):
+        pass
+
+    def test_11_verify_badhash(self):
+        """Test that verify finds bad hashes and invalid gzip files."""
+
+        repo_path = self.dc.get_repodir()
+        repo_uri = self.dc.get_repo_url()
+
+        # publish a single package and make sure the repository is clean
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
+
+        # break a file in the repository and ensure we spot it
+        bad_hash_path = self.__inject_badhash("tmp/truck1")
+
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.assertTrue(self.output.count("ERROR: Invalid file hash") == 1)
+        self.assertTrue(bad_hash_path in self.output)
+        self.assertTrue(fmris[0] in self.output)
+
+        # fix the file in the repository, and publish another package
+        self.__repair_badhash("tmp/truck1")
+        self.pkgsend_bulk(repo_path, (self.amber20))
+        fmris += self.pkgsend_bulk(repo_path, (self.truck10))
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
+        self.assertTrue(bad_hash_path not in self.output)
+        bad_hash_path = self.__inject_badhash("tmp/truck1")
+
+        # verify we now get two errors when verifying the repository
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.assertTrue(self.output.count("ERROR: Invalid file hash") == 2)
+        for fmri in fmris:
+            self.assertTrue(fmri in self.output)
+        self.assertTrue(bad_hash_path in self.output)
+        # check we also print paths which deliver that corrupted file
+        self.assertTrue("etc/truck1" in self.output)
+        self.assertTrue("etc/trailer" in self.output)
+
+        # Corrupt another file to see that we can also spot files that
+        # aren't gzipped.
+        fmris += self.pkgsend_bulk(repo_path, (self.truck20))
+        bad_gzip_path = self.__inject_badhash("tmp/truck2", valid_gzip=False)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        # we should get 3 bad file hashes now, since we've added truck20
+        # which also references etc/truck1, which is bad.
+        self.assertTrue(self.output.count("ERROR: Invalid file hash") == 3)
+        self.assertTrue(self.output.count("ERROR: Corrupted gzip file") == 1)
+        self.assertTrue(bad_gzip_path in self.output)
+
+        # Check that when verifying content, we always use the most
+        # preferred hash.
+        hash_alg_list = ["sha256"]
+        if sha512_supported:
+            hash_alg_list.append("sha512t_256")
+        for hash_alg in hash_alg_list:
+            # Remove all existing packages first.
+            self.pkgrepo("-s {0} remove {1}".format(repo_path, " ".join(fmris)))
+            fmris = self.pkgsend_bulk(
+                repo_path, (self.tree10), debug_hash="sha1+{0}".format(hash_alg)
+            )
+            self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
+
+            # break a file in the repository and ensure we spot it.
+            bad_hash_path = self.__inject_badhash("tmp/truck1")
+            bad_basename = os.path.basename(bad_hash_path)
+
+            self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+            self.assertTrue(self.output.count("ERROR: Invalid file hash") == 1)
+
+            # We should be verifying using the SHA-2 hash, and so we
+            # should only see the SHA-1 value in the output once,
+            # when printing the path to the file in the repository,
+            # not when reporting the computed or expected hash.
+            self.assertTrue(self.output.count(bad_basename) == 1)
+
+            # Verify that when we publish using SHA-1 only, that we
+            # get the SHA-1 value printed twice: once when printing
+            # the path to the file in the repository, and once when
+            # printing the expected hash.
+            self.pkgrepo("-s {0} remove {1}".format(repo_path, " ".join(fmris)))
+            fmris = self.pkgsend_bulk(
+                repo_path, (self.tree10), debug_hash="sha1"
+            )
+            self.__inject_badhash("tmp/truck1")
+
+            self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+            self.assertTrue(self.output.count(bad_basename) == 2)
+
+    def test_12_verify_badmanifest(self):
+        """Test that verify finds bad manifests."""
+        repo_path = self.dc.get_repodir()
+
+        # publish a single package
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+
+        # corrupt a manifest and make sure pkglint agrees
+        bad_mf = self.__inject_badmanifest(fmris[0])
+        self.pkglint(bad_mf, exit=1)
+
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.assertTrue(bad_mf in self.output)
+        self.assertTrue("Corrupt manifest." in self.output)
+
+        # publish more packages, and verify we still get the one error
+        fmris += self.pkgsend_bulk(repo_path, (self.truck10, self.amber10))
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.assertTrue(self.output.count("ERROR: Corrupt manifest.") == 1)
+
+        # break another manifest, and check we get two errors
+        another_bad_mf = self.__inject_badmanifest(fmris[-1])
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.assertTrue(another_bad_mf in self.output)
+        self.assertTrue(bad_mf in self.output)
+        self.assertTrue(self.output.count("Corrupt manifest.") == 2)
+
+    def test_13_verify_nofile(self):
+        """Test that verify finds missing files."""
+
+        repo_path = self.dc.get_repodir()
+
+        # publish a single package and break it
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        missing_file = self.__inject_nofile("tmp/truck1")
+
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.assertTrue(missing_file in self.output)
+        self.assertTrue(
+            "ERROR: Missing file: {0}".format(
+                self.fhashes["tmp/truck1"] in self.output
+            )
+        )
+        self.assertTrue(fmris[0] in self.output)
+
+        # publish another package that also delivers the file
+        # and inject the error again, checking that both manifests
+        # appear in the output
+        fmris += self.pkgsend_bulk(repo_path, (self.truck10))
+        self.__inject_nofile("tmp/truck1")
+
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.assertTrue(missing_file in self.output)
+        self.assertTrue(
+            self.output.count(
+                "ERROR: Missing file: {0}".format(self.fhashes["tmp/truck1"])
+            )
+            == 2
+        )
+        for f in fmris:
+            self.assertTrue(f in self.output)
+
+    def test_14_verify_permissions(self):
+        """Check that we can find files and manifests in the
+        repository that have invalid permissions."""
+
+        repo_path = self.dc.get_repodir()
+
+        shutil.rmtree(repo_path)
+        os.mkdir(repo_path)
+        os.chmod(repo_path, 0o777)
+        self.pkgrepo("create {0}".format(repo_path), su_wrap=True)
+        self.pkgrepo(
+            "set -s {0} publisher/prefix=test".format(repo_path), su_wrap=True
+        )
+        # publish a single package and break it
+        fmris = self.pkgsend_bulk(repo_path, (self.truck10), su_wrap=True)
+        bad_path = self.__inject_perm(path="tmp/truck1")
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1, su_wrap=True)
+        self.assertTrue(bad_path in self.output)
+        self.assertTrue("ERROR: Verification failure" in self.output)
+        self.assertTrue(fmris[0] in self.output)
+        self.__repair_perm(bad_path)
+
+        # Just break the parent directory, we should still report the
+        # hash file as unreadable
+        bad_parent = self.__inject_perm(path="tmp/truck1", parent=True)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1, su_wrap=True)
+        self.assertTrue(bad_path in self.output)
+        self.assertTrue("ERROR: Verification failure" in self.output)
+        self.assertTrue(fmris[0] in self.output)
+        self.__repair_perm(bad_parent)
+        # break some manifests
+        fmris = self.pkgsend_bulk(repo_path, (self.truck20), su_wrap=True)
+
+        bad_mf_path = self.__inject_perm(fmri_str=fmris[0])
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1, su_wrap=True)
+        self.assertTrue(bad_mf_path in self.output)
+        self.assertTrue("ERROR: Verification failure" in self.output)
+
+        # this should cause both manifests to report errors
+        bad_mf_path = self.__inject_perm(fmri_str=fmris[0], parent=True)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1, su_wrap=True)
+        self.assertTrue(bad_mf_path in self.output)
+        self.assertTrue("ERROR: Verification failure" in self.output)
+        self.__repair_perm(bad_mf_path)
+
+    def test_15_verify_badsig(self):
+        repo_path = self.dc.get_repodir()
+
+        # publish a single package and break it
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        self.pkgsign(repo_path, "\\*")
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        bad_path = self.__inject_badsig(fmris[0])
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.assertTrue(bad_path in self.output)
+        self.assertTrue("ERROR: Bad signature." in self.output)
+        self.__repair_badsig(bad_path)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
+
+        # now sign with a key, cert and chain cert and check we fail
+        # to verify
+        self.pkgsign_simple(repo_path, "\\*")
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.assertTrue("ERROR: Bad signature." in self.output)
+
+        # now set a trust anchor directory, and expect that pkgrepo
+        # verify will now pass
+        ta_dir = os.path.join(
+            self.test_root, "ro_data/signing_certs/produced/ta3"
+        )
+        self.pkgrepo(
+            "-s {0} set repository/trust-anchor-directory={1}".format(
+                repo_path, ta_dir
+            )
+        )
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
+
+        # remove the old package and republish it so it can be signed
+        # again.
+        self.pkgrepo("-s {0} remove {1}".format(repo_path, fmris[0]))
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+
+        # Create an image, setup its trust-anchor dir, then use that
+        # for our repository so that pkgrepo verify can perform
+        # signature verification against it.
+        self.image_create()
+        self.seed_ta_dir("ta1")
+        self.pkgrepo(
+            "-s {0} set repository/trust-anchor-directory={1}".format(
+                repo_path, self.raw_trust_anchor_dir
+            )
+        )
+
+        # We sign with several certs so that we get a 'chain' attribute
+        # that contains several hashes.
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                i1=os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
+                i2=os.path.join(self.chain_certs_dir, "ch2_ta1_cert.pem"),
+                i3=os.path.join(self.chain_certs_dir, "ch3_ta1_cert.pem"),
+                i4=os.path.join(self.chain_certs_dir, "ch4_ta1_cert.pem"),
+                i5=os.path.join(self.chain_certs_dir, "ch5_ta1_cert.pem"),
+            )
+        )
+
+        self.pkgsign(repo_path, "{0} \\*".format(sign_args))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+        bad_paths = self.__inject_badchain(fmris[0])
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        for bad_path in bad_paths:
+            self.assertTrue(bad_path in self.output)
+
+    def test_16_verify_warn_openperms(self):
+        """Test that we emit a warning message when the repository is
+        not world-readable."""
+
+        repo_path = self.dc.get_repodir()
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        os.chmod(self.test_root, 0o700)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
+        self.assertTrue("WARNING: " in self.output)
+        self.assertTrue("svc:/application/pkg/system-repository" in self.output)
+        self.assertTrue("ERROR: " not in self.output)
+        os.chmod(self.test_root, 0o755)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=0)
+        self.assertTrue("WARNING: " not in self.output)
+
+    def test_17_verify_empty_pub(self):
+        """Test that we can verify a repository that contains a
+        publisher with no packages."""
+        repo_path = self.dc.get_repodir()
+        fmris = self.pkgsend_bulk(repo_path, (self.truck10))
+        self.pkgrepo("-s {0} add-publisher empty".format(repo_path))
+        self.pkgrepo("-s {0} verify -p empty".format(repo_path))
+
+    def test_18_verify_invalid_repos(self):
+        """Test that we exit with a usage message for v3 repos and
+        network repositories."""
+        repo_path = self.dc.get_repodir()
+        fmris = self.pkgsend_bulk(repo_path, (self.truck10))
+        depot_uri = self.dc.get_depot_url()
+        self.dc.start()
+        self.pkgrepo("-s {0} verify".format(depot_uri), exit=2)
+        self.dc.stop()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create --version=3 {0}".format(repo_path))
+        self.pkgrepo("set -s {0} publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.truck10))
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+
+    def test_19_verify_valid_dependency(self):
+        """Test package with valid dependency will not cause verify
+        failure."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        self.pkgsend_bulk(
+            repo_path,
+            (
+                self.truck10,
+                self.truck20,
+                self.amber10,
+                self.amber20,
+                self.tree10,
+            ),
+        )
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+    def test_20_verify_missing_nonincorp_dependency(self):
+        """Test that we can verify which dependency is missing from
+        a repository."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        # Test that missing dependency will be reported in -d mode.
+        self.pkgsend_bulk(
+            repo_path, (self.wtinstallhold10, self.wtinstallhold20)
+        )
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        # Test that it will also be reported without -d.
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        # Test that disabling dependency check works.
+        self.pkgrepo("-s {0} verify --disable dependency".format(repo_path))
+        self.pkgrepo(
+            "-s {0} verify --disable dependency "
+            "--disable dependency".format(repo_path)
+        )
+        # Test that disabling unknown check fails.
+        self.pkgrepo(
+            "-s {0} verify --disable unknown".format(repo_path), exit=2
+        )
+        # Test that disabling dependency check will disallow -i or -d
+        # option
+        self.pkgrepo(
+            "-s {0} verify --disable dependency -i file".format(repo_path),
+            exit=2,
+        )
+        self.pkgrepo(
+            "-s {0} verify --disable dependency -d".format(repo_path), exit=2
+        )
+        # Test that complete dependency will pass verification and
+        # miner version dependency will be used if the exact version
+        # required is missing.
+        self.pkgsend_bulk(repo_path, (self.amber20, self.tree10))
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        self.pkgsend_bulk(repo_path, self.optionalpkg10)
+        # Should be no problem for completely missing optional
+        # dependency.
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgsend_bulk(repo_path, (self.zoo10))
+        # Should fail this time.
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+
+    def test_21_verify_exclude_dependency(self):
+        """Test that exclude dependency does not cause failure."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        self.pkgsend_bulk(repo_path, (self.refuse10))
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+    def test_22_verify_illegal_dependency(self):
+        """Test illegal dependency will cause verification errors."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.illegaldep10))
+
+        # Test bad depend version number causes reporting error.
+        badversion = "depend fmri=pkg:/amber@1.x type=require"
+        self.__inject_depend(fmris[0], badversion)
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+
+        # Test bad depend package name causes reporting error.
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.illegaldep10))
+        badname = "depend fmri=pkg:/_amber@1.0 type=require"
+        self.__inject_depend(fmris[0], badname)
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+
+    def test_23_verify_no_install_hold(self):
+        """Test if there is no install-hold, then dependency check will
+        still run with or without -d."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        self.pkgsend_bulk(repo_path, (self.truck10, self.truck20))
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        # Sending amber@1.0 without tree@1.0 still fail.
+        self.pkgsend_bulk(repo_path, (self.amber10))
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        # Sending amber@2.0 still fail.
+        self.pkgsend_bulk(repo_path, (self.amber20))
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        # Finally send tree@1.0 to make the repo complete.
+        self.pkgsend_bulk(repo_path, (self.tree10))
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+    def test_24_verify_provided_publisher(self):
+        """Test verifying only the dependencies of provided publisher
+        by -p option."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test1".format(repo_path))
+        self.pkgrepo("-s {0} add-publisher test2".format(repo_path))
+        self.pkgsend_bulk(repo_path, (self.withpub1_10, self.withpub2_10))
+        # This should fail, because dependency amber@1.0 is missing
+        # for withpub1@1.0 under test1.
+        self.pkgrepo("-s {0} verify -p test1 -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify -p test1".format(repo_path), exit=1)
+        # Send the missing dependency should lead to verifaction
+        # success.
+        self.pkgsend_bulk(repo_path, (self.amber10, self.tree10))
+        self.pkgrepo("-s {0} verify -p test1 -d".format(repo_path))
+        self.pkgrepo("-s {0} verify -p test1".format(repo_path))
+        # Package withpub2 under test2 should still fail on
+        # verification.
+        self.pkgrepo("-s {0} verify -p test2 -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify -p test2".format(repo_path), exit=1)
+
+    def __make_repo_incorp(self, repo_path, dep_inj):
+        """Create a repository with incorporation dependency."""
+
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(
+            repo_path, (self.incorp10, self.amber10, self.tree10)
+        )
+        self.__inject_depend(fmris[0], dep_inj)
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+
+    def test_25_verify_missing_incorp_dependency(self):
+        """Test missing incorporate dependency will cause verify
+        failure."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(
+            repo_path, (self.incorp10, self.amber10, self.tree10)
+        )
+        # Test just specifying same release number will not cause
+        # verify failure.
+        verrel = "depend fmri=pkg:/amber@1.0 type=incorporate"
+        self.__make_repo_incorp(repo_path, verrel)
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+        # Shorter release number will work.
+        verrel = "depend fmri=pkg:/amber@1 type=incorporate"
+        self.__make_repo_incorp(repo_path, verrel)
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+        # Test specifying different release version will cause verify
+        # failure.
+        verrel = "depend fmri=pkg:/amber@2.0 type=incorporate"
+        self.__make_repo_incorp(repo_path, verrel)
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+
+        verrel = "depend fmri=pkg:/amber@0.8 type=incorporate"
+        self.__make_repo_incorp(repo_path, verrel)
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+
+        # Test specifying same release and build version will not lead
+        # to fail.
+        version = "depend fmri=pkg:/amber@1.0,5.11 type=incorporate"
+        self.__make_repo_incorp(repo_path, version)
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+        # Test specifying same release and different build version
+        # will not cause verify failure, simply because the build
+        # version is ignored.
+        version = "depend fmri=pkg:/amber@1.0,5.10 type=incorporate"
+        self.__make_repo_incorp(repo_path, version)
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+        version = "depend fmri=pkg:/amber@1.0,5.12 type=incorporate"
+        self.__make_repo_incorp(repo_path, version)
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+        # Test specifying same release, build and branch version will
+        # not cause verify failure.
+        version = "depend fmri=pkg:/amber@1.0,5.11-0 type=incorporate"
+        self.__make_repo_incorp(repo_path, version)
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+        # Test specifying same release and build version but different
+        # branch version will cause verify failure.
+        version = "depend fmri=pkg:/amber@1.0,5.11-1 type=incorporate"
+        self.__make_repo_incorp(repo_path, version)
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+
+        version = "depend fmri=pkg:/amber@1.0,5.11-0.1 " "type=incorporate"
+        self.__make_repo_incorp(repo_path, version)
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        # Test specifying same release, build, branch version and time
+        # stamp will not cause verify failure.
+        version = (
+            "depend fmri=pkg:/amber@1.0,5.11-0:20110804T203458Z "
+            "type=incorporate"
+        )
+        self.__make_repo_incorp(repo_path, version)
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+        # Test specifying same release, build and branch version but
+        # different time stamp will cause verify failure.
+        version = (
+            "depend fmri=pkg:/amber@1.0,5.11-0:20100804T203458Z "
+            "type=incorporate"
+        )
+        self.__make_repo_incorp(repo_path, version)
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+
+        version = (
+            "depend fmri=pkg:/amber@1.0,5.11-0:20120804T203458Z "
+            "type=incorporate"
+        )
+        self.__make_repo_incorp(repo_path, version)
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+
+        version = (
+            "depend fmri=pkg:/amber@1.0,5.11-0:20120804 " "type=incorporate"
+        )
+        self.__make_repo_incorp(repo_path, version)
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+
+    def test_26_verify_require_any_dependency(self):
+        """Test require-any dependency verification."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        self.pkgsend_bulk(repo_path, (self.require_any10, self.tree10))
+        # Test missing dependency will cause verify failure.
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        # Test sending one of the require-any dependency still cause
+        # verify failed.
+        self.pkgsend_bulk(repo_path, (self.amber10))
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        # Test sending all of the require-any dependency lead
+        # to success.
+        self.pkgsend_bulk(repo_path, (self.amber20))
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+    def test_27_verify_publisher_merge(self):
+        """Test packages with same package, different version and
+        different publisher are merged together for verification."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test1".format(repo_path))
+        self.pkgrepo("-s {0} add-publisher test2".format(repo_path))
+        fmris = self.pkgsend_bulk(
+            repo_path,
+            (
+                self.incorp10,
+                self.withpub1_10,
+                self.withpub1_20,
+                self.amber10,
+                self.tree10,
+            ),
+        )
+
+        dep_str = "depend fmri=pkg:/withpub1@2.0 type=require"
+        self.__inject_depend(fmris[0], dep_str, pub="test1")
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+
+    def test_28_verify_ignore_dep_attr(self):
+        """Test whether ignore-check tag works as expected."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.depchecktag10))
+        # Missing unignored dependency causes failure.
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+        # Sending missing dependency leads to success.
+        fmris = self.pkgsend_bulk(repo_path, (self.depcheckdep10))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+
+        # Check if Ignore check label works.
+        dep_str = (
+            "depend fmri=tree@1.0 type=require " 'ignore-check="external"\n'
+        )
+        self.__inject_depend(fmris[0], dep_str)
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        dep_str = (
+            "depend fmri=incorp@1.0 type=require " 'ignore-check="excluded"\n'
+        )
+        self.__inject_depend(fmris[0], dep_str)
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        self.pkgrepo("-s {0} verify -d".format(repo_path), exit=1)
+
+    def test_29_verify_parent_and_special_dep(self):
+        """Test parent dependency and special dependency are handled
+        properly."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        dep_str = "depend fmri=incorp@1.0 type=parent\n"
+        self.__inject_depend(fmris[0], dep_str)
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        dep_str = "depend fmri=feature/test/magic@1.0 type=require\n"
+        self.__inject_depend(fmris[0], dep_str)
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        self.pkgrepo("-s {0} verify -d".format(repo_path))
+
+    def __make_repo_ignore_dep(self, repo_path, dep_inj):
+        """Create a repository with incorporation dependency."""
+
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.incorp10))
+        self.__inject_depend(fmris[0], dep_inj)
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+
+    def __run_verify_with_ignore_file(
+        self, repo_path, ientry, ifpath, exit1=0, exit2=0
+    ):
+        """Run pkgrepo verify with ignored dep files."""
+
+        with open(ifpath, "w") as iff:
+            iff.write(ientry)
+        self.pkgrepo(
+            "-s {0} verify -i {1}".format(repo_path, ifpath), exit=exit1
+        )
+        self.pkgrepo(
+            "-s {0} verify -i {1} -d".format(repo_path, ifpath), exit=exit2
+        )
+
+    def test_30_verify_ignore_pkgs(self):
+        """Test if supplied ignored packages in ignored dep files are
+        handled properly."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test1".format(repo_path))
+        self.pkgsend_bulk(repo_path, (self.amber10, self.amber20))
+        ifpath = os.path.join(self.test_root, "tmp", "ignored_dep_file")
+
+        # Test invalid entry causes failure.
+        ientry = "tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = "pkg=tree@x.1"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = "pkg=amber depend=tree@x.1"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = "pkg=amber min_ver=4abc* depend=tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = "pkg=amber max_ver=x.1 depend=tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = "pkg=tree@x.1 unknown=2"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = 'pkg=tree@x.1 unknown1=2, unknown2="u"'
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        # Test bad file path causes failure.
+        badifpath = os.path.join(self.test_root, "tmp", "bad_ignored_dep_file")
+        self.pkgrepo(
+            "-s {0} verify -i {1}".format(repo_path, badifpath), exit=1
+        )
+        self.pkgrepo(
+            "-s {0} verify -i {1} -d".format(repo_path, badifpath), exit=1
+        )
+
+        # Test file with arbitary new line or other space symbols does
+        # not cause failure.
+        ientry = "   pkg=amber   \t\t depend=tree   \n\t\r\n\n"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        # Test with comment line
+        ientry = " # this comments test \npkg=amber depend=tree\n"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        # Test duplicate entries will not cause problem.
+        ientry = "pkg=amber   depend=tree\npkg=amber   depend=tree"
+        with open(ifpath, "w") as iff:
+            iff.write(ientry)
+        self.pkgrepo("-s {0} verify -i {1}".format(repo_path, ifpath))
+        # Test in -d mode, ignored_dep_file will not be used.
+        self.pkgrepo(
+            "-s {0} verify -i {1} -d".format(repo_path, ifpath), exit=1
+        )
+
+        # Test min version bound
+        ientry = "pkg=amber min_ver=1.0 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber min_ver=1 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber min_ver=0.9.1 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber min_ver=1.0-0:20110804T203458Z depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber min_ver=1.0-1:20110804T203458Z depend=tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = "pkg=amber min_ver=1.0-0:20110804T203459Z depend=tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = "pkg=amber min_ver=0.5 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber min_ver=0.5-2 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber min_ver=2.0 depend=tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = "pkg=amber min_ver=2.5 depend=tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        # Test max version bound
+        ientry = "pkg=amber max_ver=2 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber max_ver=2.0 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber max_ver=2.0.1 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber max_ver=1.9.1 depend=tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = "pkg=amber max_ver=2.0-0 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber max_ver=2.0-0:20110804T203458Z " "depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber max_ver=2.0-0:20110804T203457Z " "depend=tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        ientry = "pkg=amber max_ver=2.5-0:20110804T203457Z " "depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber max_ver=2.5 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=amber max_ver=1.0 depend=tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        # Test combination of max and min bound.
+        ientry = "pkg=amber min_ver=1.0 max_ver=2.0 depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        # Test with publisher specified.
+        ientry = "pkg=pkg://test1/amber depend=tree"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=pkg://test2/amber depend=tree"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        # Test gaps between two pairs of min and max version bounds.
+        self.pkgsend_bulk(repo_path, (self.amber30))
+        ientry = (
+            "pkg=amber min_ver=1.0 max_ver=1.0 depend=tree\n"
+            "pkg=amber min_ver=3.0 max_ver=3.5 depend=bronze\n"
+        )
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+    def test_31_verify_ignore_deps(self):
+        """Test if dependencies specified in ignored dep files are
+        handled correctly."""
+
+        repo_path = self.dc.get_repodir()
+        ifpath = os.path.join(self.test_root, "tmp", "ignored_dep_file")
+        dep_inj = "depend fmri=tree type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "pkg=incorp@1.0 depend=tree"
+        with open(ifpath, "w") as iff:
+            iff.write(ientry)
+        self.pkgrepo("-s {0} verify -i {1}".format(repo_path, ifpath))
+        self.pkgrepo(
+            "-s {0} verify -i {1} -d".format(repo_path, ifpath), exit=1
+        )
+
+        dep_inj = "depend fmri=tree@1.0-1.1:20110804T203458Z " "type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "pkg=incorp depend=tree@1.0"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=incorp depend=tree@1.0-1"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=incorp depend=tree@1.0-1.1"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "pkg=incorp depend=tree@1.0-1.1:20110804T203458Z"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        dep_inj = "depend fmri=tree@1.0 type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "pkg=incorp depend=tree@1.0,5.11"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        dep_inj = "depend fmri=tree@1.0 type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=tree@1.0,5.11-0 pkg=incorp"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        dep_inj = "depend fmri=tree@1.0 type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=tree@1.0,5.11-0:20110804T203458Z pkg=incorp"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        # Test multiple ignore entries or multiple dependency actions.
+        dep_inj = (
+            "depend fmri=tree@1.0 type=require\n"
+            "depend fmri=forest@1.0 type=require"
+        )
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=tree@1.0 depend=forest@1.0 pkg=incorp"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        ientry = "depend=tree@1.0 pkg=incorp\n"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        dep_inj = (
+            "depend fmri=tree@1.0 type=require\n"
+            "depend fmri=tree@1.1 type=require"
+        )
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=tree@1 pkg=incorp"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        dep_inj = "depend fmri=tree type=require\n"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "pkg=incorp depend=tree@1.0\npkg=incorp depend=tree\n"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        # Test multiple files input.
+        dep_inj = (
+            "depend fmri=tree@1.0 type=require\n"
+            "depend fmri=forest@1.0 type=require\n"
+        )
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        i1entry = "depend=tree@1.0 pkg=incorp\n"
+        with open(ifpath, "w") as iff:
+            iff.write(i1entry)
+        i2entry = "depend=forest@1.0 pkg=incorp\n"
+        if2path = os.path.join(self.test_root, "tmp", "ignored_dep_file2")
+        with open(if2path, "w") as iff:
+            iff.write(i2entry)
+        self.pkgrepo(
+            "-s {0} verify -i {1} -i {2}".format(repo_path, ifpath, if2path)
+        )
+        self.pkgrepo(
+            "-s {0} verify -i {1} -i {2} -d".format(repo_path, ifpath, if2path),
+            exit=1,
+        )
+
+        # Test if there is no version limit for dependency, then it
+        # should not be ignored unless user specifies an ignored
+        # package without version as well.
+        dep_inj = "depend fmri=tree type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=tree@1.0 pkg=incorp"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        # Test more wrong versions.
+        dep_inj = "depend fmri=tree@1 type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=tree@1.0 pkg=incorp"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        dep_inj = "depend fmri=tree@1.0,5.11-0 type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=tree@1.0,5.11-1:20110804T203458Z pkg=incorp"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        dep_inj = "depend fmri=tree@1.0,5.11-0:20120804T203458Z " "type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=tree@1.0,5.11-1:20110804T203458Z pkg=incorp"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+        # Test giving publisher for both dependency and ignored pkg
+        # works.
+        dep_inj = "depend fmri=pkg://test/tree@1.0 type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=pkg://test/tree@1.0 pkg=incorp"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        # Test giving publisher for only dependency works.
+        ientry = "depend=tree@1.0 pkg=incorp"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        # Test giving publisher for ignored pkg works.
+        dep_inj = "depend fmri=tree@1.0 type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=pkg://test/tree@1.0 pkg=incorp"
+        self.__run_verify_with_ignore_file(repo_path, ientry, ifpath, exit2=1)
+
+        # Test wrong publisher will not work.
+        dep_inj = "depend fmri=pkg://test/tree@1.0 type=require"
+        self.__make_repo_ignore_dep(repo_path, dep_inj)
+        ientry = "depend=pkg://test1/tree@1.0 pkg=incorp"
+        self.__run_verify_with_ignore_file(
+            repo_path, ientry, ifpath, exit1=1, exit2=1
+        )
+
+    def test_verify_ignore_non_certificate_file_or_directory(self):
+        """Ensure that invalid certificate files and directories
+        are ignored."""
+        repo_path = self.dc.get_repodir()
+        repo = self.dc.get_repo()
+        trust_anchor_dir = repo.cfg.get_property(
+            "repository", "trust-anchor-directory"
+        )
+        cert_path = os.path.join(trust_anchor_dir, "foo.pem")
+        cert_dir = os.path.join(trust_anchor_dir, "foo")
+        file_created = False
+        dir_created = False
+
+        # Test certificate load will not fail with a directoy in
+        # the trust anchor directory
+        if not os.path.exists(cert_dir):
+            dir_created = True
+            os.makedirs(cert_dir)
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        if dir_created:
+            os.rmdir(cert_dir)
+
+        # Test certificate load will not fail with an invalid
+        # certificate file in the trust anchor directory
+        if not os.path.exists(cert_path):
+            file_created = True
+            open(cert_path, "w").close()
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        if file_created:
+            os.remove(cert_path)
+
+    def __inject_truncate_file(self, path):
+        fpath = self.__get_file_path(path)
+        self.cmdline_run(
+            "/usr/bin/truncate --size 5 {path}".format(path=fpath),
+            coverage=False,
+        )
+        return fpath
+
+    def test_verify_truncated_file(self):
+        """Test that verify handles the case of truncated files."""
+
+        repo_path = self.dc.get_repodir()
+
+        # publish a single package and truncate a file in it
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        truncate_file = self.__inject_truncate_file("tmp/truck1")
+
+        self.pkgrepo("-s {0} verify".format(repo_path), exit=1)
+        self.assertTrue(truncate_file in self.output)
+        self.assertTrue(self.output.count("ERROR: Corrupted gzip file") == 1)
+
+    def __get_fhashes(self, repodir, pub):
+        """Returns a list of file hashes for the publisher
+        pub in a given repository."""
+        fhashes = []
+        files_dir = os.path.sep.join(["publisher", pub, "file"])
+        for dirpath, dirs, files in os.walk(os.path.join(repodir, files_dir)):
+            fhashes.extend(files)
+        return fhashes
+
+    def test_32_fix_brokenmanifest(self):
+        """Test that fix operations correct a bad manifest in a file
+        repo."""
+
+        repo_path = self.dc.get_repodir()
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        self.pkgsign(repo_path, "\\*")
+
+        self.pkgrepo("-s {0} fix".format(repo_path))
+
+        valid_hashes = self.__get_fhashes(repo_path, "test")
+        self.debug(valid_hashes)
+        bad_path = self.__inject_badsig(fmris[0])
+        self.pkgrepo("-s {0} fix".format(repo_path))
+        self.assertTrue(fmris[0] in self.output)
+        self.assertTrue(not os.path.exists(bad_path))
+
+        # check our quarantine dir has been created
+        q_dir = os.path.sep.join(
+            [repo_path, "publisher", "test", "pkg5-quarantine"]
+        )
+        self.assertTrue(os.path.exists(q_dir))
+
+        # check the broken manifest is in the quarantine dir
+        mf_path_sub = bad_path.replace(
+            os.path.sep.join([repo_path, "publisher", "test"]), ""
+        )
+        # quarantined items are stored in a new tmpdir per-session
+        q_dir_tmp = os.listdir(q_dir)[0]
+        q_mf_path = os.path.sep.join([q_dir, q_dir_tmp, mf_path_sub])
+        self.assertTrue(os.path.exists(q_mf_path))
+
+        # make sure the package no longer appears in the catalog
+        self.pkgrepo("-s {0} list -F tsv".format(repo_path))
+        self.assertTrue(fmris[0] not in self.output)
+
+        # ensure that only the manifest was quarantined - file hashes
+        # were left alone.
+        remaining_hashes = self.__get_fhashes(repo_path, "test")
+        self.assertTrue(set(valid_hashes) == set(remaining_hashes))
+
+        # finally, ensure we can republish this package
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        self.pkgrepo("-s {0} list -F tsv".format(repo_path))
+        self.assertTrue(fmris[0] in self.output)
+
+    def test_33_fix_brokenfile(self):
+        """Test that operations that cause us to fix a file shared
+        by several packages cause all of those packages to be
+        quarantined.
+
+        This also tests the -v option of pkg fix, which prints the
+        pkgrepo verify output and prints details of which files are
+        being quarantined.
+        """
+
+        repo_path = self.dc.get_repodir()
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10, self.trucknd10))
+        self.pkgrepo("-s {0} fix".format(repo_path))
+        bad_file = self.__inject_badhash("tmp/truck1")
+
+        old_hashes = self.__get_fhashes(repo_path, "test1")
+
+        self.pkgrepo("-s {0} fix -v".format(repo_path))
+
+        # since the file was shared by two manifests, we should get
+        # the manifest name printed twice: once when we encounter the
+        # broken file, then again when we print the summary of which
+        # packages need to be republished.
+        self.assertTrue(self.output.count(fmris[0]) == 2)
+        self.assertTrue(self.output.count(fmris[1]) == 2)
+        self.assertTrue(self.output.count("ERROR: Invalid file hash") == 2)
+
+        # the bad file name gets printed 3 times, once for each time
+        # a manifest references it and verify discovered the error,
+        # and once when we report where the file was moved to.
+        self.assertTrue(self.output.count(bad_file) == 3)
+
+        # check the broken file is in the quarantine dir and that
+        # we printed where it moved to
+        bad_file_sub = bad_file.replace(
+            os.path.sep.join([repo_path, "publisher", "test"]), ""
+        )
+        # quarantined items are stored in a new tmpdir per-session
+        q_dir = os.path.sep.join(
+            [repo_path, "publisher", "test", "pkg5-quarantine"]
+        )
+        q_dir_tmp = os.listdir(q_dir)[0]
+        q_file_path = os.path.normpath(
+            os.path.sep.join([q_dir, q_dir_tmp, bad_file_sub])
+        )
+        self.assertTrue(os.path.exists(q_file_path))
+        self.debug(q_file_path)
+        self.assertTrue(q_file_path in self.output)
+
+        remaining_hashes = self.__get_fhashes(repo_path, "test1")
+        # check that we only quarantined the bad hash file
+        self.assertTrue(
+            set(remaining_hashes)
+            == set(old_hashes) - set(os.path.basename(bad_file))
+        )
+
+        # Make sure the repository is now clean, and remains so even
+        # after we republish the packages, and that all file content is
+        # replaced.
+        self.pkgrepo("-s {0} fix".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10, self.trucknd10))
+        new_hashes = self.__get_fhashes(repo_path, "test1")
+        self.assertTrue(set(new_hashes) == set(old_hashes))
+        self.pkgrepo("-s {0} fix".format(repo_path))
+
+    def test_34_fix_brokenperm(self):
+        """Tests that when running fix as an unpriviliged user that we
+        fail to fix the repository."""
+
+        repo_path = self.dc.get_repodir()
+
+        shutil.rmtree(repo_path)
+        os.mkdir(repo_path)
+        os.chmod(repo_path, 0o777)
+        self.pkgrepo("create {0}".format(repo_path), su_wrap=True)
+        self.pkgrepo(
+            "set -s {0} publisher/prefix=test".format(repo_path), su_wrap=True
+        )
+        # publish a single package and break it
+        fmris = self.pkgsend_bulk(repo_path, (self.truck10), su_wrap=True)
+        # this breaks the permissions of one of the manifests and
+        # chowns is such that we shouldn't be able to quarantine it.
+        bad_path = self.__inject_perm(fmri_str=fmris[0], chown=True)
+
+        self.pkgrepo(
+            "-s {0} fix".format(repo_path), exit=1, stderr=True, su_wrap=True
+        )
+        self.assertTrue(bad_path in self.errout)
+        # the fix should succeed now, but not emit any output, because
+        # it's running as root, and the permissions are fine according
+        # to a root user
+        self.pkgrepo("-s {0} fix".format(repo_path))
+        # but we should still be able to warn about the bad path for
+        # pkg5srv access.
+        self.pkgrepo("-s {0} verify".format(repo_path))
+        self.assertTrue("WARNING: " in self.output)
+
+    def test_35_fix_unsupported_repo(self):
+        """Tests that when running fix on a v3 repo fails"""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create --version=3 {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.truck10))
+        self.pkgrepo("-s {0} fix".format(repo_path), exit=1)
+        self.assertTrue(
+            "only version 4 repositories are supported." in self.errout
+        )
+
+    def test_36_fix_empty_missing_pub(self):
+        """Test that we can attempt to fix a repository that contains a
+        publisher with no packages, and that we fail on missing pubs"""
+
+        repo_path = self.dc.get_repodir()
+        fmris = self.pkgsend_bulk(repo_path, (self.tree10))
+        self.pkgrepo("-s {0} add-publisher empty".format(repo_path))
+        self.pkgrepo("-s {0} fix -p test".format(repo_path))
+        self.pkgrepo("-s {0} fix -p missing".format(repo_path), exit=1)
+        self.assertTrue("no matching publishers" in self.errout)
+
+    def test_37_fix_dependency(self):
+        """Test with dependency errors, fix will fail."""
+
+        repo_path = self.dc.get_repodir()
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        self.pkgsend_bulk(repo_path, (self.wtinstallhold20, self.amber10))
+        self.dc.start()
+        self.pkgrepo("-s {0} fix -v".format(repo_path), exit=1)
+
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.illegaldep10))
+
+        # Test bad depend version number causes reporting error.
+        badversion = "depend fmri=pkg:/amber@1.x type=require"
+        self.__inject_depend(fmris[0], badversion)
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+        self.pkgrepo("-s {0} fix -v".format(repo_path), exit=1)
+
+        # Test bad depend package name causes reporting error.
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=test".format(repo_path))
+        fmris = self.pkgsend_bulk(repo_path, (self.illegaldep10))
+        badname = "depend fmri=pkg:/_amber@1.0 type=require"
+        self.__inject_depend(fmris[0], badname)
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+        self.pkgrepo("-s {0} fix".format(repo_path), exit=1)
+
+    def test_38_invalid_repo(self):
+        """Test that trying to open an invalid repository is handled
+        correctly"""
+
+        tmpdir = tempfile.mkdtemp(dir=self.test_root)
+
+        with open(os.path.join(tmpdir, "pkg5.image"), "w") as f:
+            f.write("[image]\nversion = 2")
+
+        self.assertRaises(sr.RepositoryInvalidError, sr.Repository, root=tmpdir)
+
+    def test_39_remove_publisher(self):
+        """Verify that remove-publisher subcommand works as expected."""
+
+        # Create a repository.
+        repo_path = os.path.join(self.test_root, "repo")
+        self.create_repo(repo_path)
+
+        # Verify invalid publisher prefixes are rejected gracefully.
+        self.pkgrepo("-s {0} remove-publisher !valid".format(repo_path), exit=1)
+        self.pkgrepo(
+            "-s {0} remove-publisher file:{1}".format(repo_path, repo_path),
+            exit=1,
+        )
+        self.pkgrepo(
+            "-s {0} remove-publisher valid !valid".format(repo_path), exit=1
+        )
+
+        # Verify that remove-publisher will exit with complete failure
+        # if no publisher in the repo.
+        self.pkgrepo(
+            "-s {0} remove-publisher example.com".format(repo_path), exit=1
+        )
+
+        # Verify that single publisher can be removed at a time, and
+        # if it is default publisher, the prefix field is unset.
+        self.pkgrepo("-s {0} add-publisher example.com".format(repo_path))
+
+        # If a depot is running, this will trigger a reload of the
+        # configuration data.
+        self.dc.refresh()
+
+        # Publish some packages.
+        self.pkgsend_bulk(
+            repo_path,
+            (
+                self.tree10,
+                self.amber10,
+                self.amber20,
+                self.truck10,
+                self.truck20,
+            ),
+        )
+        self.pkgrepo("-s {0} remove-publisher example.com".format(repo_path))
+        self.assertTrue("has been unset" in self.output)
+        self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
+        expected = """\
 publisher\tprefix\t""
 """
-                self.assertEqualDiff(expected, self.output)
-                pdir = os.path.join(repo_path, "publisher", "example.com")
-                self.assertTrue(not os.path.exists(pdir))
+        self.assertEqualDiff(expected, self.output)
+        pdir = os.path.join(repo_path, "publisher", "example.com")
+        self.assertTrue(not os.path.exists(pdir))
 
-                # Verify that multiple publishers can be removed at a time
-                # if there is a default one, the prefix field in repo con-
-                # figuration file will be set to empty
-                self.pkgrepo("-s {0} add-publisher example.com example.net".format(
-                    repo_path))
-                self.pkgrepo("-s {0} remove-publisher example.com example.net".format(
-                    repo_path))
-                self.assertTrue("has been unset"
-                    in self.output)
-                self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
-                expected = """\
+        # Verify that multiple publishers can be removed at a time
+        # if there is a default one, the prefix field in repo con-
+        # figuration file will be set to empty
+        self.pkgrepo(
+            "-s {0} add-publisher example.com example.net".format(repo_path)
+        )
+        self.pkgrepo(
+            "-s {0} remove-publisher example.com example.net".format(repo_path)
+        )
+        self.assertTrue("has been unset" in self.output)
+        self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
+        expected = """\
 publisher\tprefix\t""
 """
-                self.assertEqualDiff(expected, self.output)
-                pdir = os.path.join(repo_path, "publisher", "example.com")
-                self.assertTrue(not os.path.exists(pdir))
-                pdir = os.path.join(repo_path, "publisher", "example.net")
-                self.assertTrue(not os.path.exists(pdir))
+        self.assertEqualDiff(expected, self.output)
+        pdir = os.path.join(repo_path, "publisher", "example.com")
+        self.assertTrue(not os.path.exists(pdir))
+        pdir = os.path.join(repo_path, "publisher", "example.net")
+        self.assertTrue(not os.path.exists(pdir))
 
-                # Verify that if one publisher is removed and only one left
-                # if the removed one a default one, the prefix field in repo con-
-                # figuration file will be set to the one left
-                self.pkgrepo("-s {0} add-publisher example.com example.net".format(
-                    repo_path))
-                self.pkgrepo("-s {0} remove-publisher example.com".format(
-                    repo_path))
-                self.assertTrue("the only publisher left" in self.output)
-                self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
-                expected = """\
+        # Verify that if one publisher is removed and only one left
+        # if the removed one a default one, the prefix field in repo con-
+        # figuration file will be set to the one left
+        self.pkgrepo(
+            "-s {0} add-publisher example.com example.net".format(repo_path)
+        )
+        self.pkgrepo("-s {0} remove-publisher example.com".format(repo_path))
+        self.assertTrue("the only publisher left" in self.output)
+        self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
+        expected = """\
 publisher\tprefix\texample.net
 """
-                self.assertEqualDiff(expected, self.output)
-                pdir = os.path.join(repo_path, "publisher", "example.com")
-                self.assertTrue(not os.path.exists(pdir))
-                pdir = os.path.join(repo_path, "publisher", "example.net")
-                self.assertTrue(os.path.exists(pdir))
+        self.assertEqualDiff(expected, self.output)
+        pdir = os.path.join(repo_path, "publisher", "example.com")
+        self.assertTrue(not os.path.exists(pdir))
+        pdir = os.path.join(repo_path, "publisher", "example.net")
+        self.assertTrue(os.path.exists(pdir))
 
-                # Verify that remove-publisher will exit with complete failure
-                # if all publishers do not exist.
-                self.pkgrepo("-s {0} remove-publisher example.some example.what".format(
-                    repo_path), exit=1)
+        # Verify that remove-publisher will exit with complete failure
+        # if all publishers do not exist.
+        self.pkgrepo(
+            "-s {0} remove-publisher example.some example.what".format(
+                repo_path
+            ),
+            exit=1,
+        )
 
-                # Verify that remove-publisher will exit with complete failure if
-                # only some publishers already exist.
-                self.pkgrepo("-s {0} remove-publisher example.net example.org".format(
-                    repo_path), exit=1)
-                pdir = os.path.join(repo_path, "publisher", "example.net")
-                self.assertTrue(os.path.exists(pdir))
-                self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
-                expected = """\
+        # Verify that remove-publisher will exit with complete failure if
+        # only some publishers already exist.
+        self.pkgrepo(
+            "-s {0} remove-publisher example.net example.org".format(repo_path),
+            exit=1,
+        )
+        pdir = os.path.join(repo_path, "publisher", "example.net")
+        self.assertTrue(os.path.exists(pdir))
+        self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
+        expected = """\
 publisher\tprefix\texample.net
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify that dry-run will not remove anything, and print correct
-                # message
-                # First publish some packages
-                self.pkgsend_bulk(repo_path, (self.tree10, self.amber10,
-                    self.amber20, self.truck10, self.truck20))
+        # Verify that dry-run will not remove anything, and print correct
+        # message
+        # First publish some packages
+        self.pkgsend_bulk(
+            repo_path,
+            (
+                self.tree10,
+                self.amber10,
+                self.amber20,
+                self.truck10,
+                self.truck20,
+            ),
+        )
 
-                # Secondly copy the whole publisher folder into a tmp folder
-                dry_pubpath = os.path.join(repo_path, "tmp_dry", "example.net")
-                pubpath = os.path.join(repo_path, "publisher", "example.net")
-                misc.copytree(pubpath, dry_pubpath)
-                self.pkgrepo("-s {0} remove-publisher -n example.net".format(
-                    repo_path))
-                expected = """\
+        # Secondly copy the whole publisher folder into a tmp folder
+        dry_pubpath = os.path.join(repo_path, "tmp_dry", "example.net")
+        pubpath = os.path.join(repo_path, "publisher", "example.net")
+        misc.copytree(pubpath, dry_pubpath)
+        self.pkgrepo("-s {0} remove-publisher -n example.net".format(repo_path))
+        expected = """\
 Removing publisher(s)\n\
 \'example.net\'\t(3 package(s))
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Thirdly check whether two folders are identical
-                self.cmdline_run("/usr/bin/gdiff {pub_path} {dry_path}".format(
-                    pub_path=pubpath, dry_path=dry_pubpath),
-                    coverage=False)
+        # Thirdly check whether two folders are identical
+        self.cmdline_run(
+            "/usr/bin/gdiff {pub_path} {dry_path}".format(
+                pub_path=pubpath, dry_path=dry_pubpath
+            ),
+            coverage=False,
+        )
 
-                self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
-                expected = """\
+        self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
+        expected = """\
 publisher\tprefix\texample.net
 """
-                self.assertEqualDiff(expected, self.output)
+        self.assertEqualDiff(expected, self.output)
 
-                # Verify that if one publisher is removed and there are
-                # more than one left, and one of the removed publishers
-                # was the default publisher, that we unset the publisher/prefix
-                # property.
-                self.pkgrepo("-s {0} add-publisher example.com example.org".format(
-                    repo_path))
-                self.pkgrepo("-s {0} remove-publisher example.net".format(
-                    repo_path))
-                self.assertTrue("has been unset" in self.output)
-                self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
-                expected = """\
+        # Verify that if one publisher is removed and there are
+        # more than one left, and one of the removed publishers
+        # was the default publisher, that we unset the publisher/prefix
+        # property.
+        self.pkgrepo(
+            "-s {0} add-publisher example.com example.org".format(repo_path)
+        )
+        self.pkgrepo("-s {0} remove-publisher example.net".format(repo_path))
+        self.assertTrue("has been unset" in self.output)
+        self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
+        expected = """\
 publisher\tprefix\t""
 """
-                self.assertEqualDiff(expected, self.output)
-                pdir = os.path.join(repo_path, "publisher", "example.net")
-                self.assertTrue(not os.path.exists(pdir))
+        self.assertEqualDiff(expected, self.output)
+        pdir = os.path.join(repo_path, "publisher", "example.net")
+        self.assertTrue(not os.path.exists(pdir))
 
-                # Verify that inaccessible publishers are handled correctly
-                shutil.rmtree(repo_path)
-                os.system("chown noaccess {0}".format(self.test_root))
-                self.pkgrepo("create {0}".format(repo_path), su_wrap=True)
-                self.pkgrepo("-s {0} add-publisher example.com".format(repo_path))
-                self.pkgrepo("-s {0} remove-publisher example.com".format(repo_path),
-                    su_wrap=True, exit=1)
-                os.system("chown root {0}".format(self.test_root))
+        # Verify that inaccessible publishers are handled correctly
+        shutil.rmtree(repo_path)
+        os.system("chown noaccess {0}".format(self.test_root))
+        self.pkgrepo("create {0}".format(repo_path), su_wrap=True)
+        self.pkgrepo("-s {0} add-publisher example.com".format(repo_path))
+        self.pkgrepo(
+            "-s {0} remove-publisher example.com".format(repo_path),
+            su_wrap=True,
+            exit=1,
+        )
+        os.system("chown root {0}".format(self.test_root))
 
-                # Verify that synchronous option works as specified.
-                shutil.rmtree(repo_path)
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrepo("-s {0} add-publisher example.com".format(repo_path))
-                self.pkgsend_bulk(repo_path, (self.tree10, self.amber10,
-                    self.amber20, self.truck10, self.truck20))
-                self.pkgrepo("-s {0} remove-publisher --synchronous example.com"
-                   .format(repo_path))
-                repo_tmp_path = os.path.join(repo_path, "tmp")
-                self.assertTrue(os.listdir(repo_tmp_path) == [])
-                self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
-                expected = """\
+        # Verify that synchronous option works as specified.
+        shutil.rmtree(repo_path)
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrepo("-s {0} add-publisher example.com".format(repo_path))
+        self.pkgsend_bulk(
+            repo_path,
+            (
+                self.tree10,
+                self.amber10,
+                self.amber20,
+                self.truck10,
+                self.truck20,
+            ),
+        )
+        self.pkgrepo(
+            "-s {0} remove-publisher --synchronous example.com".format(
+                repo_path
+            )
+        )
+        repo_tmp_path = os.path.join(repo_path, "tmp")
+        self.assertTrue(os.listdir(repo_tmp_path) == [])
+        self.pkgrepo("get -s {0} -HFtsv publisher/prefix".format(repo_path))
+        expected = """\
 publisher\tprefix\t""
 """
-                self.assertEqualDiff(expected, self.output)
-                pdir = os.path.join(repo_path, "publisher", "example.com")
-                self.assertTrue(not os.path.exists(pdir))
+        self.assertEqualDiff(expected, self.output)
+        pdir = os.path.join(repo_path, "publisher", "example.com")
+        self.assertTrue(not os.path.exists(pdir))
 
-        def test_40_contents(self):
-                """Verify that contents subcommand works as expected."""
+    def test_40_contents(self):
+        """Verify that contents subcommand works as expected."""
 
-                repo_path = self.dc.get_repodir()
-                repo_uri = self.dc.get_repo_url()
+        repo_path = self.dc.get_repodir()
+        repo_uri = self.dc.get_repo_url()
 
-                # Publish some packages.
-                plist = self.pkgsend_bulk(repo_uri, (self.tree10, self.amber10,
-                    self.amber20))
+        # Publish some packages.
+        plist = self.pkgsend_bulk(
+            repo_uri, (self.tree10, self.amber10, self.amber20)
+        )
 
-                # Verify graceful exit if invalid or incomplete set of
-                # options specified.
-                self.pkgrepo("contents", exit=2)
-                self.pkgrepo("contents -s bogus://location list", exit=1)
+        # Verify graceful exit if invalid or incomplete set of
+        # options specified.
+        self.pkgrepo("contents", exit=2)
+        self.pkgrepo("contents -s bogus://location list", exit=1)
 
-                # Verify graceful exit for bad repository.
-                self.pkgrepo("contents -s /no/such/repository", exit=1)
+        # Verify graceful exit for bad repository.
+        self.pkgrepo("contents -s /no/such/repository", exit=1)
 
-                # Verify graceful exit if invalid package name given.
-                self.pkgrepo("contents -s {0} ^notvalid".format(repo_path), exit=1)
+        # Verify graceful exit if invalid package name given.
+        self.pkgrepo("contents -s {0} ^notvalid".format(repo_path), exit=1)
 
-                # Verify graceful exit if no matching package found.
-                self.pkgrepo("contents -s {0} nosuchpackage".format(repo_path), exit=1)
+        # Verify graceful exit if no matching package found.
+        self.pkgrepo("contents -s {0} nosuchpackage".format(repo_path), exit=1)
 
-                # Verify default output when listing all packages for both
-                # file and http cases:
-                for src in (repo_path, repo_uri):
-                        self.pkgrepo("contents -s {0}".format(src))
-                        for p in plist:
-                                self.assertTrue(self.__get_manifest_contents(p)
-                                    in self.output)
+        # Verify default output when listing all packages for both
+        # file and http cases:
+        for src in (repo_path, repo_uri):
+            self.pkgrepo("contents -s {0}".format(src))
+            for p in plist:
+                self.assertTrue(self.__get_manifest_contents(p) in self.output)
 
-                # Verify ability to display specific packages but only using
-                # file repository for test efficiency.
+        # Verify ability to display specific packages but only using
+        # file repository for test efficiency.
 
-                # Verify ability to display specific packages.
-                self.pkgrepo("contents -s {0} amber@2.0".format(repo_path))
-                self.assertEqualDiff(self.__get_manifest_contents(plist[2]),
-                    self.output)
+        # Verify ability to display specific packages.
+        self.pkgrepo("contents -s {0} amber@2.0".format(repo_path))
+        self.assertEqualDiff(
+            self.__get_manifest_contents(plist[2]), self.output
+        )
 
-                # Verify ability to display multiple packages.
-                self.pkgrepo("contents -s {0} tree amber@1.0".format(repo_path))
-                for i in range(2):
-                        self.assertTrue(self.__get_manifest_contents(plist[i]) in
-                            self.output)
+        # Verify ability to display multiple packages.
+        self.pkgrepo("contents -s {0} tree amber@1.0".format(repo_path))
+        for i in range(2):
+            self.assertTrue(
+                self.__get_manifest_contents(plist[i]) in self.output
+            )
 
-                # Verify -m option works fine.
-                self.pkgrepo("contents -m -s {0} amber@2.0".format(repo_path))
-                self.assertEqualDiff(self.__get_manifest_contents(plist[2]),
-                    self.output)
+        # Verify -m option works fine.
+        self.pkgrepo("contents -m -s {0} amber@2.0".format(repo_path))
+        self.assertEqualDiff(
+            self.__get_manifest_contents(plist[2]), self.output
+        )
 
-                # Verify -t option works fine.
-                self.pkgrepo("contents -s {0} -t set tree".format(repo_path))
-                self.assertTrue("set" in self.output and "file" not in self.output)
+        # Verify -t option works fine.
+        self.pkgrepo("contents -s {0} -t set tree".format(repo_path))
+        self.assertTrue("set" in self.output and "file" not in self.output)
 
-                # Verify graceful exit if no matching action type specified.
-                self.pkgrepo("contents -s {0} -t nosuchtype tree".format(repo_path),
-                    exit=1)
+        # Verify graceful exit if no matching action type specified.
+        self.pkgrepo(
+            "contents -s {0} -t nosuchtype tree".format(repo_path), exit=1
+        )
 
-                # Add packages for a different publisher.
-                self.pkgrepo("set -s {0} publisher/prefix=test2".format(repo_path))
-                self.pkgsend_bulk(repo_path, (self.truck10, self.zoo10))
+        # Add packages for a different publisher.
+        self.pkgrepo("set -s {0} publisher/prefix=test2".format(repo_path))
+        self.pkgsend_bulk(repo_path, (self.truck10, self.zoo10))
 
-                # Verify that patterns matching packages only provided by one
-                # publisher will not result in partial failure.
-                self.pkgrepo("contents -s {0} zoo".format(repo_path))
+        # Verify that patterns matching packages only provided by one
+        # publisher will not result in partial failure.
+        self.pkgrepo("contents -s {0} zoo".format(repo_path))
+
 
 class TestPkgrepoMultiRepo(pkg5unittest.ManyDepotTestCase):
-        # Only start/stop the depot once (instead of for every test)
-        persistent_setup = True
+    # Only start/stop the depot once (instead of for every test)
+    persistent_setup = True
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0:20110804T203458Z
             close"""
 
-        foo20t1 = """
+    foo20t1 = """
             open foo@2.0,5.11-0:20120804T203458Z
             close"""
 
-        foo20t2 = """
+    foo20t2 = """
             open foo@2.0,5.11-0:20130804T203458Z
             close"""
 
-        bar10 = """
+    bar10 = """
             open bar@1.0,5.11-0:20130804T203458Z
             close"""
 
-        moo10 = """
+    moo10 = """
             open moo@1.0,5.11-0:20130804T203458Z
             close"""
 
-        noo10 = """
+    noo10 = """
             open noo@1.0,5.11-0:20130804T203458Z
             close"""
 
-        def setUp(self):
-                """Create four repositories. Three with the same publisher name
-                and one with a different publisher name.
-                """
+    def setUp(self):
+        """Create four repositories. Three with the same publisher name
+        and one with a different publisher name.
+        """
 
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["test1", "test2",
-                    "test1", "test1", "test1"])
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test1", "test2", "test1", "test1", "test1"]
+        )
 
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.rdir1 = self.dcs[1].get_repodir()
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.rdir1 = self.dcs[1].get_repodir()
 
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.rdir2 = self.dcs[2].get_repodir()
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.rdir2 = self.dcs[2].get_repodir()
 
-                self.rurl3 = self.dcs[3].get_repo_url()
-                self.durl3 = self.dcs[3].get_depot_url()
-                self.rdir3 = self.dcs[3].get_repodir()
+        self.rurl3 = self.dcs[3].get_repo_url()
+        self.durl3 = self.dcs[3].get_depot_url()
+        self.rdir3 = self.dcs[3].get_repodir()
 
-                self.rurl4 = self.dcs[4].get_repo_url()
-                self.rdir4 = self.dcs[4].get_repodir()
-                self.pkgsend_bulk(self.rurl4, (self.moo10, self.noo10))
+        self.rurl4 = self.dcs[4].get_repo_url()
+        self.rdir4 = self.dcs[4].get_repodir()
+        self.pkgsend_bulk(self.rurl4, (self.moo10, self.noo10))
 
-                self.rurl5 = self.dcs[5].get_repo_url()
-                self.rdir5 = self.dcs[5].get_repodir()
+        self.rurl5 = self.dcs[5].get_repo_url()
+        self.rdir5 = self.dcs[5].get_repodir()
 
-        def test_01_diff(self):
-                """Verify that diff subcommand works as expected."""
+    def test_01_diff(self):
+        """Verify that diff subcommand works as expected."""
 
-                # Verify invalid input will cause failure.
-                self.pkgrepo("diff".format(self.rurl1), exit=2)
-                self.pkgrepo("diff -s {0}".format(self.rurl1), exit=2)
-                self.pkgrepo("diff {0}".format(self.rurl1), exit=2)
-                self.pkgrepo("diff --unknown -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=2)
-                self.pkgrepo("diff --unknown -s {0} -s {1} -s {2}".format(
-                    self.rurl1, self.rurl2, self.rurl3), exit=2)
-                self.pkgrepo("diff --!invalid -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=2)
-                self.pkgrepo("diff -s {0} -s {1} invalidarg".format(self.rurl1,
-                    self.rurl2), exit=2)
-                self.pkgrepo("diff -p +faf -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=1)
-                self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1,
-                    "+++1a"), exit=1)
-                self.pkgrepo("diff -qv -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=2)
+        # Verify invalid input will cause failure.
+        self.pkgrepo("diff".format(self.rurl1), exit=2)
+        self.pkgrepo("diff -s {0}".format(self.rurl1), exit=2)
+        self.pkgrepo("diff {0}".format(self.rurl1), exit=2)
+        self.pkgrepo(
+            "diff --unknown -s {0} -s {1}".format(self.rurl1, self.rurl2),
+            exit=2,
+        )
+        self.pkgrepo(
+            "diff --unknown -s {0} -s {1} -s {2}".format(
+                self.rurl1, self.rurl2, self.rurl3
+            ),
+            exit=2,
+        )
+        self.pkgrepo(
+            "diff --!invalid -s {0} -s {1}".format(self.rurl1, self.rurl2),
+            exit=2,
+        )
+        self.pkgrepo(
+            "diff -s {0} -s {1} invalidarg".format(self.rurl1, self.rurl2),
+            exit=2,
+        )
+        self.pkgrepo(
+            "diff -p +faf -s {0} -s {1}".format(self.rurl1, self.rurl2), exit=1
+        )
+        self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1, "+++1a"), exit=1)
+        self.pkgrepo(
+            "diff -qv -s {0} -s {1}".format(self.rurl1, self.rurl2), exit=2
+        )
 
-                self.dcs[1].start()
-                self.dcs[2].start()
-                self.dcs[3].start()
-                # Verify empty repos comparison with just publisher names.
-                self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=10)
-                self.assertTrue("test1" in self.output and "test2" in
-                    self.output)
-                self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3))
-                self.pkgrepo("diff -s {0} -s {1}".format(self.durl1,
-                    self.durl3))
-                self.assertTrue(not self.output)
-                self.pkgrepo("diff -p test1 -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=1)
-                self.pkgrepo("diff -s {0} -s {1}".format(self.durl1,
-                    self.durl2), exit=10)
-                self.pkgrepo("diff -p test2 -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=1)
-                self.pkgrepo("diff -p test2 -s {0} -s {1}".format(self.durl1,
-                    self.durl2), exit=1)
-                self.pkgrepo("diff -p test1 -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3))
+        self.dcs[1].start()
+        self.dcs[2].start()
+        self.dcs[3].start()
+        # Verify empty repos comparison with just publisher names.
+        self.pkgrepo(
+            "diff -s {0} -s {1}".format(self.rurl1, self.rurl2), exit=10
+        )
+        self.assertTrue("test1" in self.output and "test2" in self.output)
+        self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1, self.rurl3))
+        self.pkgrepo("diff -s {0} -s {1}".format(self.durl1, self.durl3))
+        self.assertTrue(not self.output)
+        self.pkgrepo(
+            "diff -p test1 -s {0} -s {1}".format(self.rurl1, self.rurl2), exit=1
+        )
+        self.pkgrepo(
+            "diff -s {0} -s {1}".format(self.durl1, self.durl2), exit=10
+        )
+        self.pkgrepo(
+            "diff -p test2 -s {0} -s {1}".format(self.rurl1, self.rurl2), exit=1
+        )
+        self.pkgrepo(
+            "diff -p test2 -s {0} -s {1}".format(self.durl1, self.durl2), exit=1
+        )
+        self.pkgrepo(
+            "diff -p test1 -s {0} -s {1}".format(self.rurl1, self.rurl3)
+        )
 
-                # Publish some pkgs.
-                self.pkgsend_bulk(self.rurl1, (self.foo10))
-                self.pkgsend_bulk(self.rurl2, (self.foo10))
-                self.pkgsend_bulk(self.rurl3, (self.foo10))
-                self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3))
-                self.assertTrue(not self.output)
-                self.pkgrepo("diff -v -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3))
-                self.assertTrue(not self.output)
-                self.pkgrepo("diff -v -s {0} -s {1}".format(self.durl1,
-                    self.durl3))
-                self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=10)
-                self.assertTrue("test1" in self.output and "test2" in
-                    self.output)
+        # Publish some pkgs.
+        self.pkgsend_bulk(self.rurl1, (self.foo10))
+        self.pkgsend_bulk(self.rurl2, (self.foo10))
+        self.pkgsend_bulk(self.rurl3, (self.foo10))
+        self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1, self.rurl3))
+        self.assertTrue(not self.output)
+        self.pkgrepo("diff -v -s {0} -s {1}".format(self.rurl1, self.rurl3))
+        self.assertTrue(not self.output)
+        self.pkgrepo("diff -v -s {0} -s {1}".format(self.durl1, self.durl3))
+        self.pkgrepo(
+            "diff -s {0} -s {1}".format(self.rurl1, self.rurl2), exit=10
+        )
+        self.assertTrue("test1" in self.output and "test2" in self.output)
 
-                # Test -q option.
-                self.pkgrepo("diff -q -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=10)
-                self.assertTrue(not self.output)
-                self.pkgrepo("diff -q -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3))
-                self.assertTrue(not self.output)
+        # Test -q option.
+        self.pkgrepo(
+            "diff -q -s {0} -s {1}".format(self.rurl1, self.rurl2), exit=10
+        )
+        self.assertTrue(not self.output)
+        self.pkgrepo("diff -q -s {0} -s {1}".format(self.rurl1, self.rurl3))
+        self.assertTrue(not self.output)
 
-                self.pkgsend_bulk(self.rurl1, (self.foo20t1))
-                self.pkgsend_bulk(self.rurl2, (self.foo20t1))
-                self.pkgsend_bulk(self.rurl3, (self.foo20t2))
-                self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3), exit=10)
-                self.assertTrue("test1" in self.output)
-                self.pkgrepo("diff -v -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3), exit=10)
-                self.assertTrue("- pkg://test1/foo@2.0,5.11-0:20120804T203458Z" in
-                    self.output)
-                self.assertTrue("+ pkg://test1/foo@2.0,5.11-0:20130804T203458Z" in
-                    self.output)
-                self.assertTrue("(1 pkg(s) with 1 version(s) are in both "
-                    "repositories.)" in self.output)
-                self.assertTrue("test1" in self.output)
+        self.pkgsend_bulk(self.rurl1, (self.foo20t1))
+        self.pkgsend_bulk(self.rurl2, (self.foo20t1))
+        self.pkgsend_bulk(self.rurl3, (self.foo20t2))
+        self.pkgrepo(
+            "diff -s {0} -s {1}".format(self.rurl1, self.rurl3), exit=10
+        )
+        self.assertTrue("test1" in self.output)
+        self.pkgrepo(
+            "diff -v -s {0} -s {1}".format(self.rurl1, self.rurl3), exit=10
+        )
+        self.assertTrue(
+            "- pkg://test1/foo@2.0,5.11-0:20120804T203458Z" in self.output
+        )
+        self.assertTrue(
+            "+ pkg://test1/foo@2.0,5.11-0:20130804T203458Z" in self.output
+        )
+        self.assertTrue(
+            "(1 pkg(s) with 1 version(s) are in both "
+            "repositories.)" in self.output
+        )
+        self.assertTrue("test1" in self.output)
 
-                # Test --strict option.
-                self.pkgrepo("diff --strict -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3), exit=10)
-                self.assertTrue("catalog" in self.output)
+        # Test --strict option.
+        self.pkgrepo(
+            "diff --strict -s {0} -s {1}".format(self.rurl1, self.rurl3),
+            exit=10,
+        )
+        self.assertTrue("catalog" in self.output)
 
-                self.pkgrepo("diff --strict -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=10)
+        self.pkgrepo(
+            "diff --strict -s {0} -s {1}".format(self.rurl1, self.rurl2),
+            exit=10,
+        )
 
-                # Make repo1 has publishers: test1, test2
-                # repo2 has publishers: test2, test3
-                # repo3 has publishers: test1, test2
-                self.pkgrepo("-s {0} add-publisher test2".format(
-                    self.rurl1))
-                self.pkgrepo("-s {0} add-publisher test2".format(
-                    self.rurl3))
-                self.pkgrepo("-s {0} add-publisher test3".format(
-                    self.rurl2))
-                self.pkgrepo("set -s {0} publisher/prefix=test2".format(
-                    self.rurl1))
-                self.pkgrepo("set -s {0} publisher/prefix=test3".format(
-                    self.rurl2))
-                self.pkgrepo("set -s {0} publisher/prefix=test2".format(
-                    self.rurl3))
-                # Make repo1 test2 the same as repo2 test2
-                self.pkgsend_bulk(self.rurl1, (self.foo10, self.foo20t1))
-                # Make repo3 test2 the same as repo2 test2
-                self.pkgsend_bulk(self.rurl3, (self.foo10, self.foo20t1))
+        # Make repo1 has publishers: test1, test2
+        # repo2 has publishers: test2, test3
+        # repo3 has publishers: test1, test2
+        self.pkgrepo("-s {0} add-publisher test2".format(self.rurl1))
+        self.pkgrepo("-s {0} add-publisher test2".format(self.rurl3))
+        self.pkgrepo("-s {0} add-publisher test3".format(self.rurl2))
+        self.pkgrepo("set -s {0} publisher/prefix=test2".format(self.rurl1))
+        self.pkgrepo("set -s {0} publisher/prefix=test3".format(self.rurl2))
+        self.pkgrepo("set -s {0} publisher/prefix=test2".format(self.rurl3))
+        # Make repo1 test2 the same as repo2 test2
+        self.pkgsend_bulk(self.rurl1, (self.foo10, self.foo20t1))
+        # Make repo3 test2 the same as repo2 test2
+        self.pkgsend_bulk(self.rurl3, (self.foo10, self.foo20t1))
 
-                self.pkgsend_bulk(self.rurl2, (self.bar10, self.moo10))
-                # repo1 and repo3 contain same pkgs, but one pkg has different
-                # timestamps.
-                self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3), exit=10)
-                self.assertTrue("test1" in self.output)
-                self.assertTrue("test2" not in self.output)
-                self.pkgrepo("diff -q -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=10)
-                self.assertTrue(not self.output)
+        self.pkgsend_bulk(self.rurl2, (self.bar10, self.moo10))
+        # repo1 and repo3 contain same pkgs, but one pkg has different
+        # timestamps.
+        self.pkgrepo(
+            "diff -s {0} -s {1}".format(self.rurl1, self.rurl3), exit=10
+        )
+        self.assertTrue("test1" in self.output)
+        self.assertTrue("test2" not in self.output)
+        self.pkgrepo(
+            "diff -q -s {0} -s {1}".format(self.rurl1, self.rurl2), exit=10
+        )
+        self.assertTrue(not self.output)
 
-                self.pkgrepo("diff -v -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=10)
-                self.assertTrue("- test1" in self.output and "test2" not in
-                    self.output and "+ test3" in self.output)
-                self.pkgrepo("diff -q -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2), exit=10)
-                self.assertTrue(not self.output)
-                self.pkgrepo("diff --parsable --strict -s {0} -s {1}".format(
-                    self.rurl1, self.rurl2), exit=10)
-                expected = {
-"table_header": ["Publisher", "Repo1 only", "Repo2 only", "In both", "Total"],
-"table_data": [["test1", {"packages": 1, "versions": 2},
-                None, {"packages": 0, "versions": 0},
-                {"packages": 1, "versions": 2}],
-                ["test3", None, {"packages": 2, "versions": 2},
-    {"packages": 0, "versions": 0}, {"packages": 2, "versions": 2}]],
-"table_legend": [["Repo1", self.rurl1],
-                 ["Repo2", self.rurl2]],
-"nonstrict_pubs": ["test2"]}
-                self.assertEqualJSON(json.dumps(expected), self.output)
-                self.pkgrepo("diff --parsable --strict -vs {0} -s {1}".format(
-                    self.rurl1, self.rurl2), exit=10)
-                expected = {
-"common_pubs": [{"publisher": "test2", "+": [], "-": [],
-    "catalog": {"+": "replaced",
-                "-": "replaced"}}],
-"minus_pubs": [{"publisher": "test1", "packages": 1, "versions": 2}],
-"plus_pubs": [{"publisher": "test3", "packages": 2, "versions": 2}]}
-                output = json.loads(self.output)
-                self.assertTrue("common_pubs" in output)
-                output["common_pubs"][0]["catalog"]["+"] = "replaced"
-                output["common_pubs"][0]["catalog"]["-"] = "replaced"
-                self.assertEqualJSON(json.dumps(expected),
-                    json.dumps(output))
-                # Test -p option.
-                self.pkgrepo("diff -vp test2 -s {0} -s {1}".format(self.rurl1,
-                    self.rurl2))
-                self.assertTrue(not self.output)
-                # Enable strict check.
-                self.pkgrepo("diff -vp test2 --strict -s {0} -s {1}".format(
-                    self.rurl1, self.rurl2), exit=10)
-                self.assertTrue("test2" in self.output)
-                self.pkgrepo("diff -p test2 --strict -s {0} -s {1}".format(
-                    self.rurl1, self.rurl2), exit=10)
-                self.assertTrue("test2" in self.output)
-                self.assertTrue("Repo1:" not in self.output)
+        self.pkgrepo(
+            "diff -v -s {0} -s {1}".format(self.rurl1, self.rurl2), exit=10
+        )
+        self.assertTrue(
+            "- test1" in self.output
+            and "test2" not in self.output
+            and "+ test3" in self.output
+        )
+        self.pkgrepo(
+            "diff -q -s {0} -s {1}".format(self.rurl1, self.rurl2), exit=10
+        )
+        self.assertTrue(not self.output)
+        self.pkgrepo(
+            "diff --parsable --strict -s {0} -s {1}".format(
+                self.rurl1, self.rurl2
+            ),
+            exit=10,
+        )
+        expected = {
+            "table_header": [
+                "Publisher",
+                "Repo1 only",
+                "Repo2 only",
+                "In both",
+                "Total",
+            ],
+            "table_data": [
+                [
+                    "test1",
+                    {"packages": 1, "versions": 2},
+                    None,
+                    {"packages": 0, "versions": 0},
+                    {"packages": 1, "versions": 2},
+                ],
+                [
+                    "test3",
+                    None,
+                    {"packages": 2, "versions": 2},
+                    {"packages": 0, "versions": 0},
+                    {"packages": 2, "versions": 2},
+                ],
+            ],
+            "table_legend": [["Repo1", self.rurl1], ["Repo2", self.rurl2]],
+            "nonstrict_pubs": ["test2"],
+        }
+        self.assertEqualJSON(json.dumps(expected), self.output)
+        self.pkgrepo(
+            "diff --parsable --strict -vs {0} -s {1}".format(
+                self.rurl1, self.rurl2
+            ),
+            exit=10,
+        )
+        expected = {
+            "common_pubs": [
+                {
+                    "publisher": "test2",
+                    "+": [],
+                    "-": [],
+                    "catalog": {"+": "replaced", "-": "replaced"},
+                }
+            ],
+            "minus_pubs": [
+                {"publisher": "test1", "packages": 1, "versions": 2}
+            ],
+            "plus_pubs": [{"publisher": "test3", "packages": 2, "versions": 2}],
+        }
+        output = json.loads(self.output)
+        self.assertTrue("common_pubs" in output)
+        output["common_pubs"][0]["catalog"]["+"] = "replaced"
+        output["common_pubs"][0]["catalog"]["-"] = "replaced"
+        self.assertEqualJSON(json.dumps(expected), json.dumps(output))
+        # Test -p option.
+        self.pkgrepo(
+            "diff -vp test2 -s {0} -s {1}".format(self.rurl1, self.rurl2)
+        )
+        self.assertTrue(not self.output)
+        # Enable strict check.
+        self.pkgrepo(
+            "diff -vp test2 --strict -s {0} -s {1}".format(
+                self.rurl1, self.rurl2
+            ),
+            exit=10,
+        )
+        self.assertTrue("test2" in self.output)
+        self.pkgrepo(
+            "diff -p test2 --strict -s {0} -s {1}".format(
+                self.rurl1, self.rurl2
+            ),
+            exit=10,
+        )
+        self.assertTrue("test2" in self.output)
+        self.assertTrue("Repo1:" not in self.output)
 
-                # Test set relationship.
-                self.pkgsend_bulk(self.rurl1, (self.bar10))
-                self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3), exit=10)
-                self.assertTrue("test1" in self.output)
-                self.assertTrue("test2" in self.output and "0 [0]" in \
-                    self.output)
-                self.pkgrepo("diff --parsable -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3), exit=10)
-                output = json.loads(self.output)
-                # test2 in repo1 is the superset of test2 in repo2.
-                self.assertTrue(output["table_data"][1][2]["packages"] == 0)
-                self.assertTrue(output["table_data"][1][2]["versions"] == 0)
+        # Test set relationship.
+        self.pkgsend_bulk(self.rurl1, (self.bar10))
+        self.pkgrepo(
+            "diff -s {0} -s {1}".format(self.rurl1, self.rurl3), exit=10
+        )
+        self.assertTrue("test1" in self.output)
+        self.assertTrue("test2" in self.output and "0 [0]" in self.output)
+        self.pkgrepo(
+            "diff --parsable -s {0} -s {1}".format(self.rurl1, self.rurl3),
+            exit=10,
+        )
+        output = json.loads(self.output)
+        # test2 in repo1 is the superset of test2 in repo2.
+        self.assertTrue(output["table_data"][1][2]["packages"] == 0)
+        self.assertTrue(output["table_data"][1][2]["versions"] == 0)
 
-                self.pkgrepo("diff --parsable -v -s {0} -s {1}".format(
-                    self.rurl1, self.rurl3), exit=10)
-                output = json.loads(self.output)
-                # test2 in repo1 is the superset of test2 in repo2.
-                self.assertTrue(output["common_pubs"][1]["-"])
-                self.assertTrue(not output["common_pubs"][1]["+"])
-                self.assertTrue("common" in output["common_pubs"][1])
+        self.pkgrepo(
+            "diff --parsable -v -s {0} -s {1}".format(self.rurl1, self.rurl3),
+            exit=10,
+        )
+        output = json.loads(self.output)
+        # test2 in repo1 is the superset of test2 in repo2.
+        self.assertTrue(output["common_pubs"][1]["-"])
+        self.assertTrue(not output["common_pubs"][1]["+"])
+        self.assertTrue("common" in output["common_pubs"][1])
 
-                self.pkgsend_bulk(self.rurl3, (self.bar10, self.moo10))
-                self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3), exit=10)
-                self.assertTrue("test1" in self.output)
-                self.assertTrue("test2" in self.output and "0 [0]" in \
-                    self.output)
-                self.pkgrepo("diff --parsable -s {0} -s {1}".format(self.rurl1,
-                    self.rurl3), exit=10)
-                output = json.loads(self.output)
-                # test2 in repo1 is the subset of test2 in repo2.
-                self.assertTrue(output["table_data"][1][1]["packages"] == 0)
-                self.assertTrue(output["table_data"][1][1]["versions"] == 0)
+        self.pkgsend_bulk(self.rurl3, (self.bar10, self.moo10))
+        self.pkgrepo(
+            "diff -s {0} -s {1}".format(self.rurl1, self.rurl3), exit=10
+        )
+        self.assertTrue("test1" in self.output)
+        self.assertTrue("test2" in self.output and "0 [0]" in self.output)
+        self.pkgrepo(
+            "diff --parsable -s {0} -s {1}".format(self.rurl1, self.rurl3),
+            exit=10,
+        )
+        output = json.loads(self.output)
+        # test2 in repo1 is the subset of test2 in repo2.
+        self.assertTrue(output["table_data"][1][1]["packages"] == 0)
+        self.assertTrue(output["table_data"][1][1]["versions"] == 0)
 
-                self.pkgrepo("diff --parsable -v -s {0} -s {1}".format(
-                    self.rurl1, self.rurl3), exit=10)
-                output = json.loads(self.output)
-                # test2 in repo1 is the superset of test2 in repo2.
-                self.assertTrue(not output["common_pubs"][1]["-"])
-                self.assertTrue(output["common_pubs"][1]["+"])
+        self.pkgrepo(
+            "diff --parsable -v -s {0} -s {1}".format(self.rurl1, self.rurl3),
+            exit=10,
+        )
+        output = json.loads(self.output)
+        # test2 in repo1 is the superset of test2 in repo2.
+        self.assertTrue(not output["common_pubs"][1]["-"])
+        self.assertTrue(output["common_pubs"][1]["+"])
 
-                self.pkgrepo("diff -s {0} -s {1}".format(self.rurl1,
-                    self.rurl4), exit=10)
-                self.assertTrue("test2" in self.output)
-                self.assertTrue("test1" in self.output and "-" in \
-                    self.output and "0 [0]" in self.output)
-                self.pkgrepo("diff --parsable -s {0} -s {1}".format(self.rurl1,
-                    self.rurl4), exit=10)
-                output = json.loads(self.output)
-                # test1 in repo4 contains completely different fmris for the
-                # the one in repo1.
-                self.assertTrue(output["table_data"][0][3]["packages"] == 0)
-                self.assertTrue(output["table_data"][0][3]["versions"] == 0)
+        self.pkgrepo(
+            "diff -s {0} -s {1}".format(self.rurl1, self.rurl4), exit=10
+        )
+        self.assertTrue("test2" in self.output)
+        self.assertTrue(
+            "test1" in self.output
+            and "-" in self.output
+            and "0 [0]" in self.output
+        )
+        self.pkgrepo(
+            "diff --parsable -s {0} -s {1}".format(self.rurl1, self.rurl4),
+            exit=10,
+        )
+        output = json.loads(self.output)
+        # test1 in repo4 contains completely different fmris for the
+        # the one in repo1.
+        self.assertTrue(output["table_data"][0][3]["packages"] == 0)
+        self.assertTrue(output["table_data"][0][3]["versions"] == 0)
 
-                # Test clone repositories are exactly the same as the
-                # originals.
-                self.pkgrecv(self.rurl4, "--clone -d {0}".format(self.rdir5))
-                ret = subprocess.call(["/usr/bin/gdiff", "-Naur", "-x",
-                    "index", "-x", "trans", self.rdir4, self.rdir5])
-                self.assertTrue(ret==0)
-                self.pkgrepo("diff -v --strict -s {0} -s {1}".format(
-                    self.rurl4, self.rurl5))
-                self.assertTrue(not self.output)
+        # Test clone repositories are exactly the same as the
+        # originals.
+        self.pkgrecv(self.rurl4, "--clone -d {0}".format(self.rdir5))
+        ret = subprocess.call(
+            [
+                "/usr/bin/gdiff",
+                "-Naur",
+                "-x",
+                "index",
+                "-x",
+                "trans",
+                self.rdir4,
+                self.rdir5,
+            ]
+        )
+        self.assertTrue(ret == 0)
+        self.pkgrepo(
+            "diff -v --strict -s {0} -s {1}".format(self.rurl4, self.rurl5)
+        )
+        self.assertTrue(not self.output)
 
-                # Test that clone removes all the packages if the source catalog
-                # does not exist.
-                # Source and destination have the same publishers.
-                self.pkgrepo("remove -s {0} -p test1 '*'".format(self.rdir4))
-                # Delete the catlog
-                repo = self.get_repo(self.rdir4)
-                repo.get_catalog('test1').destroy()
-                self.pkgrecv(self.rdir4, "--clone -d {0} -p test1".
-                        format(self.rdir3))
-                expected = "The source catalog 'test1' is empty"
-                self.assertTrue(expected in self.output, self.output)
+        # Test that clone removes all the packages if the source catalog
+        # does not exist.
+        # Source and destination have the same publishers.
+        self.pkgrepo("remove -s {0} -p test1 '*'".format(self.rdir4))
+        # Delete the catlog
+        repo = self.get_repo(self.rdir4)
+        repo.get_catalog("test1").destroy()
+        self.pkgrecv(self.rdir4, "--clone -d {0} -p test1".format(self.rdir3))
+        expected = "The source catalog 'test1' is empty"
+        self.assertTrue(expected in self.output, self.output)
 
-                # Mention all the publishers while cloning
-                self.pkgrepo("remove -s {0} '*'".format(self.rdir2))
-                repo = self.get_repo(self.rdir2)
-                # Delete the catalog
-                repo.get_catalog('test2').destroy()
-                self.pkgrecv(self.rdir2, "--clone -d {0} -p '*'".
-                        format(self.rdir1))
-                expected = "The source catalog 'test2' is empty"
-                self.assertTrue(expected in self.output, self.output)
+        # Mention all the publishers while cloning
+        self.pkgrepo("remove -s {0} '*'".format(self.rdir2))
+        repo = self.get_repo(self.rdir2)
+        # Delete the catalog
+        repo.get_catalog("test2").destroy()
+        self.pkgrecv(self.rdir2, "--clone -d {0} -p '*'".format(self.rdir1))
+        expected = "The source catalog 'test2' is empty"
+        self.assertTrue(expected in self.output, self.output)
 
 
 class TestPkgrepoHTTPS(pkg5unittest.HTTPSTestClass):
-
-        example_pkg10 = """
+    example_pkg10 = """
             open example_pkg@1.0,5.11-0
             add file tmp/example_file mode=0555 owner=root group=bin path=/usr/bin/example_path
             close"""
 
-        misc_files = ["tmp/example_file", "tmp/empty", "tmp/verboten"]
+    misc_files = ["tmp/example_file", "tmp/empty", "tmp/verboten"]
 
-        def setUp(self):
-                pub = "test"
+    def setUp(self):
+        pub = "test"
 
-                pkg5unittest.HTTPSTestClass.setUp(self, [pub],
-                    start_depots=True)
+        pkg5unittest.HTTPSTestClass.setUp(self, [pub], start_depots=True)
 
-                self.url = self.ac.url + "/{0}".format(pub)
+        self.url = self.ac.url + "/{0}".format(pub)
 
-                # publish a simple test package
-                self.srurl = self.dcs[1].get_repo_url()
-                self.make_misc_files(self.misc_files)
-                self.pkgsend_bulk(self.srurl, self.example_pkg10)
+        # publish a simple test package
+        self.srurl = self.dcs[1].get_repo_url()
+        self.make_misc_files(self.misc_files)
+        self.pkgsend_bulk(self.srurl, self.example_pkg10)
 
-                #set permissions of tmp/verboten to make it non-readable
-                self.verboten = os.path.join(self.test_root, "tmp/verboten")
-                os.system("chmod 600 {0}".format(self.verboten))
+        # set permissions of tmp/verboten to make it non-readable
+        self.verboten = os.path.join(self.test_root, "tmp/verboten")
+        os.system("chmod 600 {0}".format(self.verboten))
 
+    def test_01_basics(self):
+        """Test that running pkgrepo on an SSL-secured repo works for
+        all operations which are valid for network repos"""
 
-        def test_01_basics(self):
-                """Test that running pkgrepo on an SSL-secured repo works for
-                all operations which are valid for network repos"""
+        self.ac.start()
 
-                self.ac.start()
+        arg_dict = {
+            "cert": os.path.join(self.cs_dir, self.get_cli_cert("test")),
+            "key": os.path.join(self.keys_dir, self.get_cli_key("test")),
+            "url": self.url,
+            "srurl": self.srurl,
+            "empty": os.path.join(self.test_root, "tmp/empty"),
+            "noexist": os.path.join(self.test_root, "octopus"),
+            "verboten": self.verboten,
+        }
 
-                arg_dict = {
-                    "cert": os.path.join(self.cs_dir,
-                    self.get_cli_cert("test")),
-                    "key": os.path.join(self.keys_dir,
-                    self.get_cli_key("test")),
-                    "url": self.url,
-                    "srurl": self.srurl,
-                    "empty": os.path.join(self.test_root, "tmp/empty"),
-                    "noexist": os.path.join(self.test_root, "octopus"),
-                    "verboten": self.verboten,
-                }
+        # We need an image for seed_ta_dir() to work.
+        # TODO: there might be a cleaner way of doing this
+        self.image_create()
+        # Add the trust anchor needed to verify the server's identity.
+        self.seed_ta_dir("ta7")
 
-                # We need an image for seed_ta_dir() to work.
-                # TODO: there might be a cleaner way of doing this
-                self.image_create()
-                # Add the trust anchor needed to verify the server's identity.
-                self.seed_ta_dir("ta7")
+        # Try all pkgrepo operations which are valid for network repos.
+        # pkgrepo info
+        self.pkgrepo(
+            "-s {url} info --key {key} --cert {cert}".format(**arg_dict)
+        )
 
-                # Try all pkgrepo operations which are valid for network repos.
-                # pkgrepo info
-                self.pkgrepo("-s {url} info --key {key} --cert {cert}"
-                   .format(**arg_dict))
+        # pkgrepo list
+        self.pkgrepo(
+            "-s {url} list --key {key} --cert {cert}".format(**arg_dict)
+        )
 
-                # pkgrepo list
-                self.pkgrepo("-s {url} list --key {key} --cert {cert}"
-                   .format(**arg_dict))
+        # pkgrepo get
+        self.pkgrepo(
+            "-s {url} get --key {key} --cert {cert}".format(**arg_dict)
+        )
 
-                # pkgrepo get
-                self.pkgrepo("-s {url} get --key {key} --cert {cert}"
-                   .format(**arg_dict))
+        # pkgrepo refresh
+        self.pkgrepo(
+            "-s {url} refresh --key {key} --cert {cert}".format(**arg_dict)
+        )
 
-                # pkgrepo refresh
-                self.pkgrepo("-s {url} refresh --key {key} --cert {cert}"
-                   .format(**arg_dict))
+        # pkgrepo rebuild
+        self.pkgrepo(
+            "-s {url} rebuild --key {key} --cert {cert}".format(**arg_dict)
+        )
 
-                # pkgrepo rebuild
-                self.pkgrepo("-s {url} rebuild --key {key} --cert {cert}"
-                   .format(**arg_dict))
+        # pkgrepo contents
+        self.pkgrepo(
+            "-s {url} contents --key {key} --cert {cert}".format(**arg_dict)
+        )
 
-                # pkgrepo contents
-                self.pkgrepo("-s {url} contents --key {key} --cert {cert}"
-                   .format(**arg_dict))
+        # pkgrepo diff.
+        self.pkgrepo(
+            "-s {url} diff --key {key} --cert {cert}"
+            " -s {url} --key {key} --cert {cert}".format(**arg_dict)
+        )
 
-                # pkgrepo diff.
-                self.pkgrepo("-s {url} diff --key {key} --cert {cert}"
-                   " -s {url} --key {key} --cert {cert}".format(**arg_dict))
+        self.pkgrepo(
+            "diff --key {key} --cert {cert} -s {url}"
+            " -s {url} --key {key} --cert {cert}".format(**arg_dict),
+            exit=2,
+        )
 
-                self.pkgrepo("diff --key {key} --cert {cert} -s {url}"
-                   " -s {url} --key {key} --cert {cert}".format(**arg_dict),
-                   exit=2)
+        # Test only provides key and cert to the first repo.
+        self.pkgrepo(
+            "-s {url} diff --key {key} --cert {cert} "
+            "-s {srurl}".format(**arg_dict)
+        )
 
-                # Test only provides key and cert to the first repo.
-                self.pkgrepo("-s {url} diff --key {key} --cert {cert} "
-                    "-s {srurl}".format(**arg_dict))
+        self.pkgrepo(
+            "-s {url} diff --key {key} --cert {cert} "
+            "-s {url}".format(**arg_dict),
+            exit=1,
+        )
 
-                self.pkgrepo("-s {url} diff --key {key} --cert {cert} "
-                    "-s {url}".format(**arg_dict), exit=1)
+        # Test only provides key and cert to the second repo.
+        self.pkgrepo(
+            "-s {srurl} diff -s {url} --key {key} "
+            "--cert {cert}".format(**arg_dict)
+        )
 
-                # Test only provides key and cert to the second repo.
-                self.pkgrepo("-s {srurl} diff -s {url} --key {key} "
-                    "--cert {cert}".format(**arg_dict))
+        self.pkgrepo(
+            "-s {url} diff -s {url} --key {key} "
+            "--cert {cert}".format(**arg_dict),
+            exit=1,
+        )
 
-                self.pkgrepo("-s {url} diff -s {url} --key {key} "
-                    "--cert {cert}".format(**arg_dict), exit=1)
+        # Try without key and cert (should fail)
+        self.pkgrepo("-s {url} rebuild".format(**arg_dict), exit=1)
 
-                # Try without key and cert (should fail)
-                self.pkgrepo("-s {url} rebuild".format(**arg_dict), exit=1)
+        # Make sure we don't traceback when credential files are invalid
+        # Certificate option missing
+        self.pkgrepo("-s {url} rebuild --key {key}".format(**arg_dict), exit=1)
 
-                # Make sure we don't traceback when credential files are invalid
-                # Certificate option missing
-                self.pkgrepo("-s {url} rebuild --key {key}".format(**arg_dict),
-                    exit=1)
+        # Key option missing
+        self.pkgrepo(
+            "-s {url} rebuild --cert {cert}".format(**arg_dict), exit=1
+        )
 
-                # Key option missing
-                self.pkgrepo("-s {url} rebuild --cert {cert}".format(**arg_dict),
-                    exit=1)
+        # Certificate not found
+        self.pkgrepo(
+            "-s {url} rebuild --key {key} "
+            "--cert {noexist}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Certificate not found
-                self.pkgrepo("-s {url} rebuild --key {key} "
-                    "--cert {noexist}".format(**arg_dict), exit=1)
+        # Key not found
+        self.pkgrepo(
+            "-s {url} rebuild --key {noexist} "
+            "--cert {cert}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Key not found
-                self.pkgrepo("-s {url} rebuild --key {noexist} "
-                    "--cert {cert}".format(**arg_dict), exit=1)
+        # Certificate is empty file
+        self.pkgrepo(
+            "-s {url} rebuild --key {key} " "--cert {empty}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Certificate is empty file
-                self.pkgrepo("-s {url} rebuild --key {key} "
-                    "--cert {empty}".format(**arg_dict), exit=1)
+        # Key is empty file
+        self.pkgrepo(
+            "-s {url} rebuild --key {empty} "
+            "--cert {cert}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Key is empty file
-                self.pkgrepo("-s {url} rebuild --key {empty} "
-                    "--cert {cert}".format(**arg_dict), exit=1)
+        # No permissions to read certificate
+        self.pkgrepo(
+            "-s {url} rebuild --key {key} "
+            "--cert {verboten}".format(**arg_dict),
+            su_wrap=True,
+            exit=1,
+        )
 
-                # No permissions to read certificate 
-                self.pkgrepo("-s {url} rebuild --key {key} "
-                    "--cert {verboten}".format(**arg_dict), su_wrap=True, exit=1)
-
-                # No permissions to read key 
-                self.pkgrepo("-s {url} rebuild --key {verboten} "
-                    "--cert {cert}".format(**arg_dict), su_wrap=True, exit=1)
+        # No permissions to read key
+        self.pkgrepo(
+            "-s {url} rebuild --key {verboten} "
+            "--cert {cert}".format(**arg_dict),
+            su_wrap=True,
+            exit=1,
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgsend.py
+++ b/src/tests/cli/t_pkgsend.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import grp
@@ -48,489 +49,542 @@ from pkg.digest import DEFAULT_HASH_FUNC
 import pkg.portable as portable
 
 try:
-        import pkg.sha512_t
-        sha512_supported = True
+    import pkg.sha512_t
+
+    sha512_supported = True
 except ImportError:
-        sha512_supported = False
+    sha512_supported = False
 
 
 class TestPkgsendBasics(pkg5unittest.SingleDepotTestCase):
-        persistent_setup = False
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    persistent_setup = False
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        def setUp(self):
-                # This test suite needs an actual depot.
-                pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
+    def setUp(self):
+        # This test suite needs an actual depot.
+        pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
 
-        def __validate_bundle_dir_package(self, pfmri, expected):
-                """Used to validate a package imported or generated using
-                a DirectoryBundle.  Validation includes installing and
-                verifying the specified package, as well as comparing
-                the package manifest actions to the expected action data.
-                Only dir, file, link, and hardlink actions are compared.
+    def __validate_bundle_dir_package(self, pfmri, expected):
+        """Used to validate a package imported or generated using
+        a DirectoryBundle.  Validation includes installing and
+        verifying the specified package, as well as comparing
+        the package manifest actions to the expected action data.
+        Only dir, file, link, and hardlink actions are compared.
 
-                'pfmri' is a package FMRI object for the package.
+        'pfmri' is a package FMRI object for the package.
 
-                'expected' is a string containing the raw action data to
-                use to validate the package.  Only the attributes present
-                on each action will be compared."""
+        'expected' is a string containing the raw action data to
+        use to validate the package.  Only the attributes present
+        on each action will be compared."""
 
-                self.pkg("install {0}".format(pfmri))
-                self.pkg("verify {0}".format(pfmri))
+        self.pkg("install {0}".format(pfmri))
+        self.pkg("verify {0}".format(pfmri))
 
-                m = manifest.Manifest()
-                content = self.get_img_manifest(pfmri)
-                m.set_content(content)
+        m = manifest.Manifest()
+        content = self.get_img_manifest(pfmri)
+        m.set_content(content)
 
-                # Now build action objects from expected data indexed by path.
-                exp_actions = {}
-                for entry in expected.splitlines():
-                        a = fromstr(entry)
+        # Now build action objects from expected data indexed by path.
+        exp_actions = {}
+        for entry in expected.splitlines():
+            a = fromstr(entry)
 
-                        if a.attrs["path"] in exp_actions:
-                                raise RuntimeError(a.attrs["path"])
+            if a.attrs["path"] in exp_actions:
+                raise RuntimeError(a.attrs["path"])
 
-                        exp_actions[a.attrs["path"]] = a
+            exp_actions[a.attrs["path"]] = a
 
-                # Number of actions should match number of expected entries.
-                self.assertEqual(len(exp_actions), len(expected.splitlines()))
+        # Number of actions should match number of expected entries.
+        self.assertEqual(len(exp_actions), len(expected.splitlines()))
 
-                # Number of expected actions should match number of actual.
-                actual = [
-                    a for a in m.gen_actions()
-                    if a.name in ("dir", "file", "link", "hardlink")
-                ]
-                self.assertEqual(len(exp_actions), len(actual))
+        # Number of expected actions should match number of actual.
+        actual = [
+            a
+            for a in m.gen_actions()
+            if a.name in ("dir", "file", "link", "hardlink")
+        ]
+        self.assertEqual(len(exp_actions), len(actual))
 
-                # For each dir, file, link, or hardlink action, verify that the
-                # attributes match expected.
-                for a in actual:
-                        exp = exp_actions[a.attrs["path"]]
-                        for attr in exp.attrs:
-                                self.assertEqual(exp.attrs[attr], a.attrs[attr])
+        # For each dir, file, link, or hardlink action, verify that the
+        # attributes match expected.
+        for a in actual:
+            exp = exp_actions[a.attrs["path"]]
+            for attr in exp.attrs:
+                self.assertEqual(exp.attrs[attr], a.attrs[attr])
 
-                self.pkg("uninstall {0}".format(pfmri))
+        self.pkg("uninstall {0}".format(pfmri))
 
-        def test_0_pkgsend_bad_opts(self):
-                """Verify that non-existent or invalid option combinations
-                cannot be specified."""
+    def test_0_pkgsend_bad_opts(self):
+        """Verify that non-existent or invalid option combinations
+        cannot be specified."""
 
-                durl = self.dc.get_depot_url()
-                self.pkgsend(durl, "-@ open foo@1.0,5.11-0", exit=2)
-                self.pkgsend(durl, "close -@", exit=2)
+        durl = self.dc.get_depot_url()
+        self.pkgsend(durl, "-@ open foo@1.0,5.11-0", exit=2)
+        self.pkgsend(durl, "close -@", exit=2)
 
-                # The -e and -n options are opposites and cannot be combined.
-                self.pkgsend(durl, "open -en foo@1.0", exit=2)
-                self.pkgsend(durl, "open -ne foo@1.0", exit=2)
+        # The -e and -n options are opposites and cannot be combined.
+        self.pkgsend(durl, "open -en foo@1.0", exit=2)
+        self.pkgsend(durl, "open -ne foo@1.0", exit=2)
 
-                # A destination repository must be specified.
-                self.pkgsend("", "close", exit=2)
-                self.pkgsend("", "publish", exit=2)
-                self.assertTrue("pkgsend publish:" in self.errout)
+        # A destination repository must be specified.
+        self.pkgsend("", "close", exit=2)
+        self.pkgsend("", "publish", exit=2)
+        self.assertTrue("pkgsend publish:" in self.errout)
 
-        def test_1_pkgsend_abandon(self):
-                """Verify that an abandoned tranasaction is not published."""
+    def test_1_pkgsend_abandon(self):
+        """Verify that an abandoned tranasaction is not published."""
 
-                dhurl = self.dc.get_depot_url()
-                dfurl = "file://{0}".format(self.dc.get_repodir())
+        dhurl = self.dc.get_depot_url()
+        dfurl = "file://{0}".format(self.dc.get_repodir())
 
-                for url in (dhurl, dfurl):
-                        for line in \
-                            """open shouldnotexist@1.0,5.11-0
+        for url in (dhurl, dfurl):
+            for line in """open shouldnotexist@1.0,5.11-0
                             add dir mode=0755 owner=root group=bin path=/bin
                             close -A""".splitlines():
-                                self.pkgsend(url, line)
+                self.pkgsend(url, line)
 
-                        if url == dfurl:
-                                # Must restart pkg.depotd so it will pickup the
-                                # changes to the catalog.
-                                self.restart_depots()
+            if url == dfurl:
+                # Must restart pkg.depotd so it will pickup the
+                # changes to the catalog.
+                self.restart_depots()
 
-                        # For now, the pkg(1) client only supports http, so use
-                        # the http url always.
-                        self.image_create(dhurl)
-                        self.pkg("list -a shouldnotexist", exit=1)
-                        self.image_destroy()
+            # For now, the pkg(1) client only supports http, so use
+            # the http url always.
+            self.image_create(dhurl)
+            self.pkg("list -a shouldnotexist", exit=1)
+            self.image_destroy()
 
-        def test_2_invalid_url(self):
-                """Verify that an invalid repository URL will result in an
-                error."""
+    def test_2_invalid_url(self):
+        """Verify that an invalid repository URL will result in an
+        error."""
 
-                # Verify that specifying a malformed or incomplete URL fails
-                # gracefully for every known scheme and a few bogus schemes.
-                for scheme in ("bogus", "file", "http", "https", "null"):
-                        # The first two cases should succeed for 'null'
-                        self.pkgsend(scheme + "://", "open notarepo@1.0",
-                            exit=scheme != "null")
-                        self.pkgsend(scheme + ":", "open notarepo@1.0",
-                            exit=scheme != "null")
-                        self.pkgsend(scheme, "open notarepo@1.0", exit=1)
+        # Verify that specifying a malformed or incomplete URL fails
+        # gracefully for every known scheme and a few bogus schemes.
+        for scheme in ("bogus", "file", "http", "https", "null"):
+            # The first two cases should succeed for 'null'
+            self.pkgsend(
+                scheme + "://", "open notarepo@1.0", exit=scheme != "null"
+            )
+            self.pkgsend(
+                scheme + ":", "open notarepo@1.0", exit=scheme != "null"
+            )
+            self.pkgsend(scheme, "open notarepo@1.0", exit=1)
 
-                # Create an empty directory to abuse as a repository.
-                junk_repo = os.path.join(self.test_root, "junk-repo")
-                os.makedirs(junk_repo, misc.PKG_DIR_MODE)
+        # Create an empty directory to abuse as a repository.
+        junk_repo = os.path.join(self.test_root, "junk-repo")
+        os.makedirs(junk_repo, misc.PKG_DIR_MODE)
 
-                # Point at a valid directory that does not contain a repository.
-                dfurl = "file://" + junk_repo
+        # Point at a valid directory that does not contain a repository.
+        dfurl = "file://" + junk_repo
 
-                # Verify that specifying a non-existent directory for a file://
-                # repository fails gracefully.
-                self.pkgsend(os.path.join(dfurl, "nochance"),
-                    "open nosuchdir@1.0", exit=1)
+        # Verify that specifying a non-existent directory for a file://
+        # repository fails gracefully.
+        self.pkgsend(
+            os.path.join(dfurl, "nochance"), "open nosuchdir@1.0", exit=1
+        )
 
-                # Verify that specifying a directory that is not a file://
-                # repository fails gracefully.
-                self.pkgsend(dfurl, "open notarepo@1.0", exit=1)
+        # Verify that specifying a directory that is not a file://
+        # repository fails gracefully.
+        self.pkgsend(dfurl, "open notarepo@1.0", exit=1)
 
-                # Point at a non-existent http(s) repository; port 1 is an
-                # unassigned port that nothing should use.
-                dhurl = "http://localhost:1"
-                dshurl = "http://localhost:1"
+        # Point at a non-existent http(s) repository; port 1 is an
+        # unassigned port that nothing should use.
+        dhurl = "http://localhost:1"
+        dshurl = "http://localhost:1"
 
-                # Verify that specifying a non-existent (i.e. unable to connect
-                # to) http:// repository fails gracefully.
-                self.pkgsend(dhurl, "open nosuchdir@1.0", exit=1)
-                self.pkgsend(dshurl, "open nosuchdir@1.0", exit=1)
+        # Verify that specifying a non-existent (i.e. unable to connect
+        # to) http:// repository fails gracefully.
+        self.pkgsend(dhurl, "open nosuchdir@1.0", exit=1)
+        self.pkgsend(dshurl, "open nosuchdir@1.0", exit=1)
 
-        def test_3_bad_transaction(self):
-                """Verify that invalid Transaction IDs are handled correctly."""
+    def test_3_bad_transaction(self):
+        """Verify that invalid Transaction IDs are handled correctly."""
 
-                dhurl = self.dc.get_depot_url()
-                dfurl = "file://{0}".format(self.dc.get_repodir())
+        dhurl = self.dc.get_depot_url()
+        dfurl = "file://{0}".format(self.dc.get_repodir())
 
-                os.environ["PKG_TRANS_ID"] = "foobarbaz"
+        os.environ["PKG_TRANS_ID"] = "foobarbaz"
 
-                for url in (dfurl, dhurl):
-                        self.pkgsend(url, "add file bin/ls path=/bin/ls",
-                            exit=1)
+        for url in (dfurl, dhurl):
+            self.pkgsend(url, "add file bin/ls path=/bin/ls", exit=1)
 
-        def test_4_bad_actions(self):
-                """Verify that malformed or invalid actions are handled
-                correctly.  This only checks a few cases as the pkg.action
-                class itself should be handling the actual verification;
-                the client just needs to handle the appropriate exceptions
-                gracefully."""
+    def test_4_bad_actions(self):
+        """Verify that malformed or invalid actions are handled
+        correctly.  This only checks a few cases as the pkg.action
+        class itself should be handling the actual verification;
+        the client just needs to handle the appropriate exceptions
+        gracefully."""
 
-                dhurl = self.dc.get_depot_url()
-                dfurl = "file://{0}".format(self.dc.get_repodir())
-                imaginary_file = os.path.join(self.test_root, "imaginary_file")
+        dhurl = self.dc.get_depot_url()
+        dfurl = "file://{0}".format(self.dc.get_repodir())
+        imaginary_file = os.path.join(self.test_root, "imaginary_file")
 
-                # Must open transaction using HTTP url first so that transaction
-                # will be seen by the depot server and when using file://.
-                self.pkgsend(dhurl, "open foo@1.0")
+        # Must open transaction using HTTP url first so that transaction
+        # will be seen by the depot server and when using file://.
+        self.pkgsend(dhurl, "open foo@1.0")
 
-                # Create a dummy file.
-                self.make_misc_files("tmp/dummy1")
+        # Create a dummy file.
+        self.make_misc_files("tmp/dummy1")
 
-                for url in (dhurl, dfurl):
-                        # Should fail because type attribute is missing.
-                        self.pkgsend(url,
-                            "add depend fmri=foo@1.0", exit=1)
+        for url in (dhurl, dfurl):
+            # Should fail because type attribute is missing.
+            self.pkgsend(url, "add depend fmri=foo@1.0", exit=1)
 
-                        # Should fail because type attribute is invalid.
-                        self.pkgsend(url,
-                            "add depend type=unknown fmri=foo@1.0", exit=1)
+            # Should fail because type attribute is invalid.
+            self.pkgsend(url, "add depend type=unknown fmri=foo@1.0", exit=1)
 
-                        # Should fail because path attribute is missing.
-                        self.pkgsend(url,
-                            "add file bin/ls", exit=1)
+            # Should fail because path attribute is missing.
+            self.pkgsend(url, "add file bin/ls", exit=1)
 
-                        # Should fail because mode attribute is missing.
-                        self.pkgsend(url,
-                            "add file tmp/dummy1 owner=root group=bin "
-                            "path=/tmp/dummy1", exit=1)
+            # Should fail because mode attribute is missing.
+            self.pkgsend(
+                url,
+                "add file tmp/dummy1 owner=root group=bin " "path=/tmp/dummy1",
+                exit=1,
+            )
 
-                        # Should fail because mode attribute is invalid.
-                        self.pkgsend(url,
-                            """add file tmp/dummy1 owner=root group=bin """
-                            """mode="" path=/tmp/dummy1""", exit=1)
-                        self.pkgsend(url,
-                            "add file tmp/dummy1 owner=root group=bin "
-                            "mode=44755 path=/tmp/dummy1", exit=1)
-                        self.pkgsend(url,
-                            "add file tmp/dummy1 owner=root group=bin "
-                            "mode=44 path=/tmp/dummy1", exit=1)
-                        self.pkgsend(url,
-                            """add file tmp/dummy1 owner=root group=bin """
-                            """mode=???? path=/tmp/dummy1""", exit=1)
+            # Should fail because mode attribute is invalid.
+            self.pkgsend(
+                url,
+                """add file tmp/dummy1 owner=root group=bin """
+                """mode="" path=/tmp/dummy1""",
+                exit=1,
+            )
+            self.pkgsend(
+                url,
+                "add file tmp/dummy1 owner=root group=bin "
+                "mode=44755 path=/tmp/dummy1",
+                exit=1,
+            )
+            self.pkgsend(
+                url,
+                "add file tmp/dummy1 owner=root group=bin "
+                "mode=44 path=/tmp/dummy1",
+                exit=1,
+            )
+            self.pkgsend(
+                url,
+                """add file tmp/dummy1 owner=root group=bin """
+                """mode=???? path=/tmp/dummy1""",
+                exit=1,
+            )
 
-                        # Should fail because owner attribute is missing.
-                        self.pkgsend(url,
-                            "add file tmp/dummy1 group=bin "
-                            "mode=0644 path=/tmp/dummy1", exit=1)
+            # Should fail because owner attribute is missing.
+            self.pkgsend(
+                url,
+                "add file tmp/dummy1 group=bin " "mode=0644 path=/tmp/dummy1",
+                exit=1,
+            )
 
-                        # Should fail because owner attribute is invalid.
-                        self.pkgsend(url,
-                            """add file tmp/dummy1 owner=" " group=bin """
-                            """mode=0644 path=/tmp/dummy1""", exit=1)
+            # Should fail because owner attribute is invalid.
+            self.pkgsend(
+                url,
+                """add file tmp/dummy1 owner=" " group=bin """
+                """mode=0644 path=/tmp/dummy1""",
+                exit=1,
+            )
 
-                        # Should fail because group attribute is missing.
-                        self.pkgsend(url,
-                            "add file tmp/dummy1 owner=root "
-                            "mode=0644 path=/tmp/dummy1", exit=1)
+            # Should fail because group attribute is missing.
+            self.pkgsend(
+                url,
+                "add file tmp/dummy1 owner=root " "mode=0644 path=/tmp/dummy1",
+                exit=1,
+            )
 
-                        # Should fail because group attribute is invalid.
-                        self.pkgsend(url,
-                            """add file tmp/dummy1 owner=root group=" " """
-                            """mode=0644 path=/tmp/dummy1""", exit=1)
+            # Should fail because group attribute is invalid.
+            self.pkgsend(
+                url,
+                """add file tmp/dummy1 owner=root group=" " """
+                """mode=0644 path=/tmp/dummy1""",
+                exit=1,
+            )
 
-                        # Should fail because path attribute is missing a value.
-                        self.pkgsend(url,
-                            "add file bin/ls path=", exit=1)
+            # Should fail because path attribute is missing a value.
+            self.pkgsend(url, "add file bin/ls path=", exit=1)
 
-                        # Should fail because the file does not exist.
-                        self.pkgsend(url,
-                            "add file {0} path=/bin/ls".format(imaginary_file), exit=1)
+            # Should fail because the file does not exist.
+            self.pkgsend(
+                url, "add file {0} path=/bin/ls".format(imaginary_file), exit=1
+            )
 
-                        # Should fail because path=/bin/ls will be interpreted
-                        # as the filename and is not a valid file.
-                        self.pkgsend(url,
-                            "add file path=/bin/ls", exit=1)
+            # Should fail because path=/bin/ls will be interpreted
+            # as the filename and is not a valid file.
+            self.pkgsend(url, "add file path=/bin/ls", exit=1)
 
-                        # Should fail because the action is unknown.
-                        self.pkgsend(url,
-                            "add bogusaction", exit=1)
+            # Should fail because the action is unknown.
+            self.pkgsend(url, "add bogusaction", exit=1)
 
-                        # Should fail because we never publish unknown actions.
-                        self.pkgsend(url,
-                             "add unknown path=foo", exit=1)
+            # Should fail because we never publish unknown actions.
+            self.pkgsend(url, "add unknown path=foo", exit=1)
 
-                # Simulate bad action data being sent by client via HTTP; this
-                # should be rejected by the server.
-                trx_id = os.environ["PKG_TRANS_ID"]
-                headers = {
-                    "X-IPKG-SETATTR0": "name=multiple_value",
-                    "X-IPKG-SETATTR1": 'value=[__import__("sys").exit(99)]'
-                }
+        # Simulate bad action data being sent by client via HTTP; this
+        # should be rejected by the server.
+        trx_id = os.environ["PKG_TRANS_ID"]
+        headers = {
+            "X-IPKG-SETATTR0": "name=multiple_value",
+            "X-IPKG-SETATTR1": 'value=[__import__("sys").exit(99)]',
+        }
 
-                try:
-                        url = "{0}/{1}/0/{2}".format(dhurl, "add", "/".join((trx_id,
-                            "set")))
-                        req = Request(url=url, headers=headers)
-                        urlopen(req)
-                except HTTPError as e:
-                        err_txt = e.read()
-                        # err_txt is bytes
-                        self.assertTrue(b"The specified Action attribute "
-                            b"value" in err_txt)
-                        self.assertTrue(b"is not valid." in err_txt)
-                else:
-                        raise RuntimeError("Test failed!")
+        try:
+            url = "{0}/{1}/0/{2}".format(
+                dhurl, "add", "/".join((trx_id, "set"))
+            )
+            req = Request(url=url, headers=headers)
+            urlopen(req)
+        except HTTPError as e:
+            err_txt = e.read()
+            # err_txt is bytes
+            self.assertTrue(
+                b"The specified Action attribute " b"value" in err_txt
+            )
+            self.assertTrue(b"is not valid." in err_txt)
+        else:
+            raise RuntimeError("Test failed!")
 
-        def test_5_bad_open(self):
-                """Verify that a bad open is handled properly.  This could be
-                because of an invalid FMRI that was specified, or many other
-                reasons."""
+    def test_5_bad_open(self):
+        """Verify that a bad open is handled properly.  This could be
+        because of an invalid FMRI that was specified, or many other
+        reasons."""
 
-                dhurl = self.dc.get_depot_url()
-                dfurl = "file://{0}".format(self.dc.get_repodir())
+        dhurl = self.dc.get_depot_url()
+        dfurl = "file://{0}".format(self.dc.get_repodir())
 
-                for url in (dhurl, dfurl):
-                        # Should fail because no fmri was specified.
-                        self.pkgsend(url, "open", exit=2)
+        for url in (dhurl, dfurl):
+            # Should fail because no fmri was specified.
+            self.pkgsend(url, "open", exit=2)
 
-                        # Should fail because an invalid fmri was specified.
-                        self.pkgsend(url, "open foo@1.a", exit=1)
+            # Should fail because an invalid fmri was specified.
+            self.pkgsend(url, "open foo@1.a", exit=1)
 
-                # Should fail because repository does not exist.
-                self.pkgsend(dfurl + "junk", "open foo@1.a", exit=1)
+        # Should fail because repository does not exist.
+        self.pkgsend(dfurl + "junk", "open foo@1.a", exit=1)
 
-        def test_6_help(self):
-                """Verify that help works as expected."""
+    def test_6_help(self):
+        """Verify that help works as expected."""
 
-                self.pkgsend(command="-?")
-                self.pkgsend(command="--help")
+        self.pkgsend(command="-?")
+        self.pkgsend(command="--help")
 
-                self.pkgsend(command="-? bobcat")
-                self.pkgsend(command="--help bobcat")
+        self.pkgsend(command="-? bobcat")
+        self.pkgsend(command="--help bobcat")
 
-                # Specifying no commands should result in usage error.
-                self.pkgsend(exit=2)
+        # Specifying no commands should result in usage error.
+        self.pkgsend(exit=2)
 
-        def test_7_create_repo(self):
-                """Verify that create-repository works as expected."""
+    def test_7_create_repo(self):
+        """Verify that create-repository works as expected."""
 
-                self.dc.stop()
-                rpath = os.path.join(self.test_root, "example_repo")
+        self.dc.stop()
+        rpath = os.path.join(self.test_root, "example_repo")
 
-                # ensure we fail when presented with a file://host/path/example_repo
-                # which includes a hostname, bug 14022
-                self.pkgsend("file:/{0}".format(rpath), "create-repository"
-                    " --set-property publisher.prefix=test", exit=1)
+        # ensure we fail when presented with a file://host/path/example_repo
+        # which includes a hostname, bug 14022
+        self.pkgsend(
+            "file:/{0}".format(rpath),
+            "create-repository" " --set-property publisher.prefix=test",
+            exit=1,
+        )
 
-                # check that we can create a repository using URIs with varying
-                # number of '/' characters and verify the repo was created.
-                for slashes in [ "", "//", "///", "////" ]:
-                        if os.path.exists(rpath):
-                                shutil.rmtree(rpath)
-                        self.pkgsend("file:{0}{1}".format(slashes, rpath), "create-repository"
-                            " --set-property publisher.prefix=test")
+        # check that we can create a repository using URIs with varying
+        # number of '/' characters and verify the repo was created.
+        for slashes in ["", "//", "///", "////"]:
+            if os.path.exists(rpath):
+                shutil.rmtree(rpath)
+            self.pkgsend(
+                "file:{0}{1}".format(slashes, rpath),
+                "create-repository" " --set-property publisher.prefix=test",
+            )
 
-                        # Assert that create-repository creates as version 3
-                        # repository for compatibility with older consumers.
-                        for expected in ("catalog", "file", "index", "pkg",
-                            "trans", "tmp", "cfg_cache"):
-                                # A v3 repository must have all of the above.
-                                assert os.path.exists(os.path.join(rpath,
-                                    expected))
+            # Assert that create-repository creates as version 3
+            # repository for compatibility with older consumers.
+            for expected in (
+                "catalog",
+                "file",
+                "index",
+                "pkg",
+                "trans",
+                "tmp",
+                "cfg_cache",
+            ):
+                # A v3 repository must have all of the above.
+                assert os.path.exists(os.path.join(rpath, expected))
 
-                        # Now verify that the repository was created by starting the
-                        # depot server in readonly mode using the target repository.
-                        # If it wasn't, restart_depots should fail with an exception
-                        # since the depot process will exit with a non-zero return
-                        # code.
-                        self.dc.set_repodir(rpath)
-                        self.dc.set_readonly()
-                        self.dc.start()
-                        self.dc.stop()
+            # Now verify that the repository was created by starting the
+            # depot server in readonly mode using the target repository.
+            # If it wasn't, restart_depots should fail with an exception
+            # since the depot process will exit with a non-zero return
+            # code.
+            self.dc.set_repodir(rpath)
+            self.dc.set_readonly()
+            self.dc.start()
+            self.dc.stop()
 
-                # Now verify that creation of a repository is rejected for all
-                # schemes except file://.
-                self.pkgsend("http://invalid.test1", "create-repository", exit=1)
-                self.pkgsend("https://invalid.test2", "create-repository", exit=1)
+        # Now verify that creation of a repository is rejected for all
+        # schemes except file://.
+        self.pkgsend("http://invalid.test1", "create-repository", exit=1)
+        self.pkgsend("https://invalid.test2", "create-repository", exit=1)
 
-        def test_8_bug_7908(self):
-                """Verify that when provided the name of a symbolic link to a
-                file, that publishing will still work as expected."""
+    def test_8_bug_7908(self):
+        """Verify that when provided the name of a symbolic link to a
+        file, that publishing will still work as expected."""
 
-                # First create our dummy data file.
-                fd, fpath = tempfile.mkstemp(dir=self.test_root)
-                fp = os.fdopen(fd, "w")
-                fp.write("foo")
-                fp.close()
+        # First create our dummy data file.
+        fd, fpath = tempfile.mkstemp(dir=self.test_root)
+        fp = os.fdopen(fd, "w")
+        fp.write("foo")
+        fp.close()
 
-                # Then, create a link to it.
-                lpath = os.path.join(self.test_root, "test_8_foo")
-                os.symlink(fpath, lpath)
+        # Then, create a link to it.
+        lpath = os.path.join(self.test_root, "test_8_foo")
+        os.symlink(fpath, lpath)
 
-                # Next, publish it using both the real path and the linked path
-                # but using different names.
-                dhurl = self.dc.get_depot_url()
-                self.pkgsend_bulk(dhurl,
-                    """open testlinkedfile@1.0
+        # Next, publish it using both the real path and the linked path
+        # but using different names.
+        dhurl = self.dc.get_depot_url()
+        self.pkgsend_bulk(
+            dhurl,
+            """open testlinkedfile@1.0
                     add file {0} mode=0755 owner=root group=bin path=/tmp/f.foo
                     add file {1} mode=0755 owner=root group=bin path=/tmp/l.foo
-                    close""".format(os.path.basename(fpath), os.path.basename(lpath)))
+                    close""".format(
+                os.path.basename(fpath), os.path.basename(lpath)
+            ),
+        )
 
-                # Finally, verify that both files were published.
-                self.image_create(dhurl)
-                self.pkg("contents -r -H -o action.raw -t file testlinkedfile |"
-                   " grep 'f.foo.*pkg.size=3'")
-                self.pkg("contents -r -H -o action.raw -t file testlinkedfile |"
-                   " grep 'l.foo.*pkg.size=3'")
-                self.image_destroy()
+        # Finally, verify that both files were published.
+        self.image_create(dhurl)
+        self.pkg(
+            "contents -r -H -o action.raw -t file testlinkedfile |"
+            " grep 'f.foo.*pkg.size=3'"
+        )
+        self.pkg(
+            "contents -r -H -o action.raw -t file testlinkedfile |"
+            " grep 'l.foo.*pkg.size=3'"
+        )
+        self.image_destroy()
 
-        def test_9_multiple_dirs(self):
-                rootdir = self.test_root
-                dir_1 = os.path.join(rootdir, "dir_1")
-                dir_2 = os.path.join(rootdir, "dir_2")
-                os.mkdir(dir_1)
-                os.mkdir(dir_2)
-                open(os.path.join(dir_1, "A"), "w").close()
-                open(os.path.join(dir_2, "B"), "w").close()
-                mfpath = os.path.join(rootdir, "manifest_test")
-                with open(mfpath, "w") as mf:
-                        mf.write("""file NOHASH mode=0755 owner=root group=bin path=/A
+    def test_9_multiple_dirs(self):
+        rootdir = self.test_root
+        dir_1 = os.path.join(rootdir, "dir_1")
+        dir_2 = os.path.join(rootdir, "dir_2")
+        os.mkdir(dir_1)
+        os.mkdir(dir_2)
+        open(os.path.join(dir_1, "A"), "w").close()
+        open(os.path.join(dir_2, "B"), "w").close()
+        mfpath = os.path.join(rootdir, "manifest_test")
+        with open(mfpath, "w") as mf:
+            mf.write(
+                """file NOHASH mode=0755 owner=root group=bin path=/A
                             file NOHASH mode=0755 owner=root group=bin path=/B
                             set name=pkg.fmri value=testmultipledirs@1.0
-                            """)
+                            """
+            )
 
-                dhurl = self.dc.get_depot_url()
-                self.pkgsend(dhurl, """publish -d {0} -d {1} < {2}""".format(dir_1,
-                    dir_2, mfpath))
+        dhurl = self.dc.get_depot_url()
+        self.pkgsend(
+            dhurl,
+            """publish -d {0} -d {1} < {2}""".format(dir_1, dir_2, mfpath),
+        )
 
-                self.image_create(dhurl)
-                self.pkg("install testmultipledirs")
-                self.pkg("verify")
-                self.image_destroy()
+        self.image_create(dhurl)
+        self.pkg("install testmultipledirs")
+        self.pkg("verify")
+        self.image_destroy()
 
-        def test_10_bundle_dir(self):
-                """Verify that import and generate of a directory bundle works
-                as expected."""
+    def test_10_bundle_dir(self):
+        """Verify that import and generate of a directory bundle works
+        as expected."""
 
-                rootdir = self.test_root
-                src_dir1 = os.path.join(rootdir, "foo")
-                src_dir2 = os.path.join(rootdir, "bar")
+        rootdir = self.test_root
+        src_dir1 = os.path.join(rootdir, "foo")
+        src_dir2 = os.path.join(rootdir, "bar")
 
-                # Build a file tree under each source directory to test
-                # import and generate functionality.  Tree should look like:
-                #   src-foo/
-                #       file-foo
-                #       link-foo -> file-foo
-                #       hardlink-foo -> file-foo
-                #       dir-foo/
-                #           subfile-foo
-                #           sublink-foo -> ../file-foo
-                #           subhardlink-foo -> ../file-foo
-                #           subfilelink-foo -> subfile-foo
-                #           subfilehardlink-foo -> subfile-foo
-                #           subdir-foo/
-                #               subdirfile-foo
-                #
-                #  Where 'foo' is replaced with 'bar' for the second source dir.
+        # Build a file tree under each source directory to test
+        # import and generate functionality.  Tree should look like:
+        #   src-foo/
+        #       file-foo
+        #       link-foo -> file-foo
+        #       hardlink-foo -> file-foo
+        #       dir-foo/
+        #           subfile-foo
+        #           sublink-foo -> ../file-foo
+        #           subhardlink-foo -> ../file-foo
+        #           subfilelink-foo -> subfile-foo
+        #           subfilehardlink-foo -> subfile-foo
+        #           subdir-foo/
+        #               subdirfile-foo
+        #
+        #  Where 'foo' is replaced with 'bar' for the second source dir.
 
-                cwd = os.getcwd()
-                for src_dir in (src_dir1, src_dir2):
-                        # Final component used as part of name for all entries.
-                        name = os.path.basename(src_dir)
+        cwd = os.getcwd()
+        for src_dir in (src_dir1, src_dir2):
+            # Final component used as part of name for all entries.
+            name = os.path.basename(src_dir)
 
-                        # File at top level in source directory.
-                        top_file = os.path.join(src_dir, "file-{0}".format(name))
-                        self.make_misc_files(os.path.relpath(top_file, src_dir),
-                            prefix=name, mode=0o644)
+            # File at top level in source directory.
+            top_file = os.path.join(src_dir, "file-{0}".format(name))
+            self.make_misc_files(
+                os.path.relpath(top_file, src_dir), prefix=name, mode=0o644
+            )
 
-                        # Link at top level in source directory.
-                        os.chdir(src_dir)
-                        os.symlink(os.path.basename(top_file), "link-{0}".format(name))
-                        os.chdir(cwd)
+            # Link at top level in source directory.
+            os.chdir(src_dir)
+            os.symlink(os.path.basename(top_file), "link-{0}".format(name))
+            os.chdir(cwd)
 
-                        # Hard link at top level in source directory.
-                        os.link(top_file, os.path.join(src_dir,
-                            "hardlink-{0}".format(name)))
+            # Hard link at top level in source directory.
+            os.link(
+                top_file, os.path.join(src_dir, "hardlink-{0}".format(name))
+            )
 
-                        # Directory at top level in source directory.
-                        top_dir = os.path.join(src_dir, "dir-{0}".format(name))
-                        os.mkdir(top_dir, 0o755)
+            # Directory at top level in source directory.
+            top_dir = os.path.join(src_dir, "dir-{0}".format(name))
+            os.mkdir(top_dir, 0o755)
 
-                        # File in top_dir.
-                        top_dir_file = os.path.join(top_dir,
-                            "subfile-{0}".format(name))
-                        self.make_misc_files(os.path.relpath(top_dir_file,
-                            src_dir), prefix=name, mode=0o444)
+            # File in top_dir.
+            top_dir_file = os.path.join(top_dir, "subfile-{0}".format(name))
+            self.make_misc_files(
+                os.path.relpath(top_dir_file, src_dir), prefix=name, mode=0o444
+            )
 
-                        # Link in top_dir to file in parent dir.
-                        os.chdir(top_dir)
-                        os.symlink(os.path.relpath(top_file, top_dir),
-                            "sublink-{0}".format(name))
-                        os.chdir(cwd)
+            # Link in top_dir to file in parent dir.
+            os.chdir(top_dir)
+            os.symlink(
+                os.path.relpath(top_file, top_dir), "sublink-{0}".format(name)
+            )
+            os.chdir(cwd)
 
-                        # Link in top_dir to file in top_dir.
-                        os.chdir(top_dir)
-                        os.symlink(os.path.basename(top_dir_file),
-                            "subfilelink-{0}".format(name))
-                        os.chdir(cwd)
+            # Link in top_dir to file in top_dir.
+            os.chdir(top_dir)
+            os.symlink(
+                os.path.basename(top_dir_file), "subfilelink-{0}".format(name)
+            )
+            os.chdir(cwd)
 
-                        # Hard link in top_dir to file in parent dir.
-                        os.link(top_file, os.path.join(top_dir,
-                            "subhardlink-{0}".format(name)))
+            # Hard link in top_dir to file in parent dir.
+            os.link(
+                top_file, os.path.join(top_dir, "subhardlink-{0}".format(name))
+            )
 
-                        # Hard link in top_dir to file in top_dir.
-                        os.link(top_dir_file, os.path.join(top_dir,
-                            "subfilehardlink-{0}".format(name)))
+            # Hard link in top_dir to file in top_dir.
+            os.link(
+                top_dir_file,
+                os.path.join(top_dir, "subfilehardlink-{0}".format(name)),
+            )
 
-                        # Directory in top_dir.
-                        sub_dir = os.path.join(top_dir, "subdir-{0}".format(name))
-                        os.mkdir(sub_dir, 0o750)
+            # Directory in top_dir.
+            sub_dir = os.path.join(top_dir, "subdir-{0}".format(name))
+            os.mkdir(sub_dir, 0o750)
 
-                        # File in sub_dir.
-                        sub_dir_file = os.path.join(sub_dir,
-                            "subdirfile-{0}".format(name))
-                        self.make_misc_files(os.path.relpath(sub_dir_file,
-                            src_dir), prefix=name, mode=0o400)
+            # File in sub_dir.
+            sub_dir_file = os.path.join(sub_dir, "subdirfile-{0}".format(name))
+            self.make_misc_files(
+                os.path.relpath(sub_dir_file, src_dir), prefix=name, mode=0o400
+            )
 
-                # Pre-generated result used for package validation.
-                expected = """\
+        # Pre-generated result used for package validation.
+        expected = """\
 dir group=bin mode=0755 owner=root path=dir-foo
 file 4b5e791c627772d731d6c1623228a9c147a7dc3a chash=57ac66d45c0c4adb6d3626bd711c6f09f10fd286 group=bin mode=0644 owner=root path=file-foo
 link path=link-foo target=file-foo
@@ -554,84 +608,89 @@ hardlink path=dir-bar/subhardlink-bar target=../file-bar
 hardlink path=dir-bar/subfilehardlink-bar target=subfile-bar
 file 6a1ae3def902f5612a43f0c0836fe05bc4f237cf chash=be9c91959ec782acb0f081bf4bf16677cb09125e group=bin mode=0400 owner=root path=dir-bar/subdir-bar/subdirfile-bar"""
 
-                # Test with and without trailing slash on import path.
-                # This cannot be done using pkgsend_bulk, which doesn't
-                # support import.
-                url = self.dc.get_depot_url()
-                self.pkgsend(url, "open foo@1.0")
-                self.pkgsend(url, "import {0}".format(src_dir1))
-                self.pkgsend(url, "import {0}/".format(src_dir2))
-                ret, sfmri = self.pkgsend(url, "close")
-                foo_fmri = fmri.PkgFmri(sfmri)
+        # Test with and without trailing slash on import path.
+        # This cannot be done using pkgsend_bulk, which doesn't
+        # support import.
+        url = self.dc.get_depot_url()
+        self.pkgsend(url, "open foo@1.0")
+        self.pkgsend(url, "import {0}".format(src_dir1))
+        self.pkgsend(url, "import {0}/".format(src_dir2))
+        ret, sfmri = self.pkgsend(url, "close")
+        foo_fmri = fmri.PkgFmri(sfmri)
 
-                # Test with and without trailing slash on generate path.
-                # This cannot be done using pkgsend_bulk, which doesn't
-                # support generate.
-                rc, out1 = self.pkgsend(url, "generate {0}".format(src_dir1))
-                rc, out2 = self.pkgsend(url, "generate {0}/".format(src_dir2))
+        # Test with and without trailing slash on generate path.
+        # This cannot be done using pkgsend_bulk, which doesn't
+        # support generate.
+        rc, out1 = self.pkgsend(url, "generate {0}".format(src_dir1))
+        rc, out2 = self.pkgsend(url, "generate {0}/".format(src_dir2))
 
-                # Test with non existing bundle
-                non_existing_bundle = os.path.join(self.test_root,
-                    "non_existing_bundle.tar")
-                rc, out3 = self.pkgsend(url, "generate {0}".format(non_existing_bundle),
-                    exit=1)
+        # Test with non existing bundle
+        non_existing_bundle = os.path.join(
+            self.test_root, "non_existing_bundle.tar"
+        )
+        rc, out3 = self.pkgsend(
+            url, "generate {0}".format(non_existing_bundle), exit=1
+        )
 
-                # Test with unknown bundle
-                unknown_bundle = self.make_misc_files("tmp/unknown_file")
-                rc, out3 = self.pkgsend(url, "generate {0}".format(unknown_bundle),
-                    exit=1)
+        # Test with unknown bundle
+        unknown_bundle = self.make_misc_files("tmp/unknown_file")
+        rc, out3 = self.pkgsend(
+            url, "generate {0}".format(unknown_bundle), exit=1
+        )
 
-                self.pkgsend(url, "open bar@1.0")
-                mpath = self.make_misc_files({ "bar.mfst": out1 + out2 })[0]
-                self.pkgsend(url, "include -d {0} -d {1} {2}".format(src_dir1,
-                    src_dir2, mpath))
-                ret, sfmri = self.pkgsend(url, "close")
-                bar_fmri = fmri.PkgFmri(sfmri)
+        self.pkgsend(url, "open bar@1.0")
+        mpath = self.make_misc_files({"bar.mfst": out1 + out2})[0]
+        self.pkgsend(
+            url, "include -d {0} -d {1} {2}".format(src_dir1, src_dir2, mpath)
+        )
+        ret, sfmri = self.pkgsend(url, "close")
+        bar_fmri = fmri.PkgFmri(sfmri)
 
-                self.image_create(url)
+        self.image_create(url)
 
-                # Perform actual validation; content should be identical
-                # whether import or generate was used.
-                for pfmri in (foo_fmri, bar_fmri):
-                        self.__validate_bundle_dir_package(pfmri, expected)
+        # Perform actual validation; content should be identical
+        # whether import or generate was used.
+        for pfmri in (foo_fmri, bar_fmri):
+            self.__validate_bundle_dir_package(pfmri, expected)
 
+    # A map used to create a SVR4 package, and check an installed pkg(7)
+    # version of that package, created via 'pkgsend import'.  We map the
+    # path name to
+    # [ type, mode, user, group, digest ] initially setting the digest to None
+    sysv_contents = {
+        "foobar": ["d", 0o715, "nobody", "nobody", None],
+        "foobar/bar": ["f", 0o614, "root", "sys", None],
+        "foobar/baz": ["f", 0o644, "daemon", "adm", None],
+        "foobar/symlink": ["s", None, "daemon", "adm", None],
+        "foobar/hardlink": ["l", 0o644, "daemon", "adm", None],
+        "copyright": ["i", None, None, None, None],
+        # check that pkgsend doesn't generate an Action for "i" files
+        "pkginfo": ["i", None, None, None, None],
+        "myclass": ["i", None, None, None, None],
+        "prototype": ["i", None, None, None, None],
+        "postinstall": ["i", None, None, None, None],
+        # pkgmap is not an "i" file, but we still want to
+        # check that it is not installed in the image
+        "pkgmap": ["i", None, None, None, None],
+    }
 
-        # A map used to create a SVR4 package, and check an installed pkg(7)
-        # version of that package, created via 'pkgsend import'.  We map the
-        # path name to
-        # [ type, mode, user, group, digest ] initially setting the digest to None
-        sysv_contents = {
-            "foobar": [ "d", 0o715, "nobody", "nobody", None ],
-            "foobar/bar": [ "f", 0o614, "root", "sys", None ],
-            "foobar/baz": [ "f", 0o644, "daemon", "adm", None ],
-            "foobar/symlink": [ "s", None, "daemon", "adm", None ],
-            "foobar/hardlink": [ "l", 0o644, "daemon", "adm", None ],
-            "copyright": [ "i", None, None, None, None ],
-            # check that pkgsend doesn't generate an Action for "i" files
-            "pkginfo": [ "i", None, None, None, None ],
-            "myclass": [ "i", None, None, None, None ],
-            "prototype": [ "i", None, None, None, None ],
-            "postinstall": [ "i", None, None, None, None ],
-            # pkgmap is not an "i" file, but we still want to
-            # check that it is not installed in the image
-            "pkgmap": [ "i", None, None, None, None ] }
+    # Same, but for the non-relocatable package
+    sysv_nonreloc_contents = {
+        "etc": ["d", 0o755, "root", "sys", None],
+        "etc/foo.conf": ["f", 0o644, "root", "sys", None],
+        "SUNWfoo/bin": ["d", 0o755, "root", "bin", None],
+        "SUNWfoo/bin/foo": ["f", 0o755, "root", "bin", None],
+        "copyright": ["i", None, None, None, None],
+        # check that pkgsend doesn't generate an Action for "i" files
+        "pkginfo": ["i", None, None, None, None],
+        # pkgmap is not an "i" file, but we still want to
+        # check that it is not installed in the image
+        "pkgmap": ["i", None, None, None, None],
+    }
 
-        # Same, but for the non-relocatable package
-        sysv_nonreloc_contents = {
-            "etc": [ "d", 0o755, "root", "sys", None ],
-            "etc/foo.conf": [ "f", 0o644, "root", "sys", None ],
-            "SUNWfoo/bin": [ "d", 0o755, "root", "bin", None ],
-            "SUNWfoo/bin/foo": [ "f", 0o755, "root", "bin", None ],
-            "copyright": [ "i", None, None, None, None ],
-            # check that pkgsend doesn't generate an Action for "i" files
-            "pkginfo": [ "i", None, None, None, None ],
-            # pkgmap is not an "i" file, but we still want to
-            # check that it is not installed in the image
-            "pkgmap": [ "i", None, None, None, None ] }
-
-        # a prototype that uses classes and postinstall scripts, which
-        # pkgsend should complain about
-        sysv_classes_prototype = """i pkginfo
+    # a prototype that uses classes and postinstall scripts, which
+    # pkgsend should complain about
+    sysv_classes_prototype = """i pkginfo
             i copyright
             i postinstall
             d none foobar 0715 nobody nobody
@@ -641,7 +700,7 @@ file 6a1ae3def902f5612a43f0c0836fe05bc4f237cf chash=be9c91959ec782acb0f081bf4bf1
             l none foobar/hardlink=baz
             i myclass"""
 
-        sysv_prototype = """i pkginfo
+    sysv_prototype = """i pkginfo
             i copyright
             d none foobar 0715 nobody nobody
             f none foobar/bar 0614 root sys
@@ -649,7 +708,7 @@ file 6a1ae3def902f5612a43f0c0836fe05bc4f237cf chash=be9c91959ec782acb0f081bf4bf1
             s none foobar/symlink=baz
             l none foobar/hardlink=baz"""
 
-        sysv_nonreloc_prototype = """\
+    sysv_nonreloc_prototype = """\
             i pkginfo
             i copyright
             d none /etc 0755 root sys
@@ -657,301 +716,335 @@ file 6a1ae3def902f5612a43f0c0836fe05bc4f237cf chash=be9c91959ec782acb0f081bf4bf1
             d none SUNWfoo/bin 0755 root bin
             f none SUNWfoo/bin/foo 0755 root bin"""
 
-        sysv_pkginfo = 'PKG="nopkg"\n'\
-            'NAME="No package"\n'\
-            'DESC="This is a sample package"\n'\
-            'ARCH="all"\n'\
-            'CLASSES="none myclass"\n'\
-            'PKG_CONTENTS="bobcat"\n'\
-            'CATEGORY="utility"\n'\
-            'VENDOR="nobody"\n'\
-            'PSTAMP="7thOct83"\n'\
-            'ISTATES="S s 1 2 3"\n'\
-            'RSTATES="S s 1 2 3"\n'\
-            'BASEDIR="/"'
+    sysv_pkginfo = (
+        'PKG="nopkg"\n'
+        'NAME="No package"\n'
+        'DESC="This is a sample package"\n'
+        'ARCH="all"\n'
+        'CLASSES="none myclass"\n'
+        'PKG_CONTENTS="bobcat"\n'
+        'CATEGORY="utility"\n'
+        'VENDOR="nobody"\n'
+        'PSTAMP="7thOct83"\n'
+        'ISTATES="S s 1 2 3"\n'
+        'RSTATES="S s 1 2 3"\n'
+        'BASEDIR="/"'
+    )
 
-        sysv_pkginfo_2 = 'PKG="nopkgtwo"\n'\
-            'NAME="No package"\n'\
-            'DESC="This is another sample package"\n'\
-            'ARCH="all"\n'\
-            'CLASSES="none myclass"\n'\
-            'PKG_CONTENTS="bobcat"\n'\
-            'CATEGORY="utility"\n'\
-            'VENDOR="nobody"\n'\
-            'PSTAMP="7thOct83"\n'\
-            'ISTATES="S s 1 2 3"\n'\
-            'RSTATES="S s 1 2 3"\n'\
-            'BASEDIR="/"'
+    sysv_pkginfo_2 = (
+        'PKG="nopkgtwo"\n'
+        'NAME="No package"\n'
+        'DESC="This is another sample package"\n'
+        'ARCH="all"\n'
+        'CLASSES="none myclass"\n'
+        'PKG_CONTENTS="bobcat"\n'
+        'CATEGORY="utility"\n'
+        'VENDOR="nobody"\n'
+        'PSTAMP="7thOct83"\n'
+        'ISTATES="S s 1 2 3"\n'
+        'RSTATES="S s 1 2 3"\n'
+        'BASEDIR="/"'
+    )
 
-        def create_sysv_package(self, rootdir, prototype_contents,
-            contents_dict, pkginfo_contents=sysv_pkginfo):
-                """Create a SVR4 package at a given location using some predefined
-                contents and a given prototype."""
-                pkgroot = os.path.join(rootdir, "sysvpkg")
-                os.mkdir(pkgroot)
+    def create_sysv_package(
+        self,
+        rootdir,
+        prototype_contents,
+        contents_dict,
+        pkginfo_contents=sysv_pkginfo,
+    ):
+        """Create a SVR4 package at a given location using some predefined
+        contents and a given prototype."""
+        pkgroot = os.path.join(rootdir, "sysvpkg")
+        os.mkdir(pkgroot)
 
-                # create files and directories in our proto area
-                for entry in contents_dict:
-                        ftype, mode  = contents_dict[entry][:2]
-                        if ftype in "fi":
-                                dirname = os.path.dirname(entry)
-                                try:
-                                        os.makedirs(os.path.join(pkgroot, dirname))
-                                except OSError as err: # in case the dir exists already
-                                        if err.errno != errno.EEXIST:
-                                                raise
-                                fpath = os.path.join(pkgroot, entry)
-                                f = open(fpath, "w")
-                                f.write("test" + entry)
-                                f.close()
-                                # compute a digest of the file we just created,
-                                # which we can use when validating later.
-                                contents_dict[entry][4] = \
-                                    misc.get_data_digest(fpath,
-                                    hash_func=DEFAULT_HASH_FUNC)[0]
+        # create files and directories in our proto area
+        for entry in contents_dict:
+            ftype, mode = contents_dict[entry][:2]
+            if ftype in "fi":
+                dirname = os.path.dirname(entry)
+                try:
+                    os.makedirs(os.path.join(pkgroot, dirname))
+                except OSError as err:  # in case the dir exists already
+                    if err.errno != errno.EEXIST:
+                        raise
+                fpath = os.path.join(pkgroot, entry)
+                f = open(fpath, "w")
+                f.write("test" + entry)
+                f.close()
+                # compute a digest of the file we just created,
+                # which we can use when validating later.
+                contents_dict[entry][4] = misc.get_data_digest(
+                    fpath, hash_func=DEFAULT_HASH_FUNC
+                )[0]
 
-                        elif ftype == "d":
-                                try:
-                                        os.makedirs(os.path.join(pkgroot, entry), mode)
-                                except OSError as err:
-                                        if err.errno != errno.EEXIST:
-                                                raise
+            elif ftype == "d":
+                try:
+                    os.makedirs(os.path.join(pkgroot, entry), mode)
+                except OSError as err:
+                    if err.errno != errno.EEXIST:
+                        raise
 
-                pkginfopath = os.path.join(pkgroot, "pkginfo")
-                pkginfo = open(pkginfopath, "w")
-                pkginfo.write(pkginfo_contents)
-                pkginfo.close()
+        pkginfopath = os.path.join(pkgroot, "pkginfo")
+        pkginfo = open(pkginfopath, "w")
+        pkginfo.write(pkginfo_contents)
+        pkginfo.close()
 
-                prototypepath = os.path.join(pkgroot, "prototype")
-                prototype = open(prototypepath, "w")
-                prototype.write(prototype_contents)
-                prototype.close()
+        prototypepath = os.path.join(pkgroot, "prototype")
+        prototype = open(prototypepath, "w")
+        prototype.write(prototype_contents)
+        prototype.close()
 
-                self.cmdline_run("pkgmk -o -r {0} -d {1} -f {2}".format(
-                         pkgroot, rootdir, prototypepath), coverage=False)
+        self.cmdline_run(
+            "pkgmk -o -r {0} -d {1} -f {2}".format(
+                pkgroot, rootdir, prototypepath
+            ),
+            coverage=False,
+        )
 
-                shutil.rmtree(pkgroot)
+        shutil.rmtree(pkgroot)
 
-        def __test_sysv_import(self, url, spath, contents):
-                """Private helper function to test pkgsend import."""
+    def __test_sysv_import(self, url, spath, contents):
+        """Private helper function to test pkgsend import."""
 
-                self.pkgsend(url, "open nopkg@1.0")
-                self.pkgsend(url, "import {0}".format(spath))
-                self.pkgsend(url, "close")
+        self.pkgsend(url, "open nopkg@1.0")
+        self.pkgsend(url, "import {0}".format(spath))
+        self.pkgsend(url, "close")
 
-                self.image_create(url)
-                self.pkg("install nopkg")
-                self.validate_sysv_contents("nopkg", contents)
-                self.pkg("verify")
-                self.pkg("contents -m nopkg")
-                self.image_destroy()
+        self.image_create(url)
+        self.pkg("install nopkg")
+        self.validate_sysv_contents("nopkg", contents)
+        self.pkg("verify")
+        self.pkg("contents -m nopkg")
+        self.image_destroy()
 
-        def __test_sysv_gen_publish(self, rpath, spath, contents):
-                """Private helper function to test pkgsend generate and
-                publish for sysv packages."""
+    def __test_sysv_gen_publish(self, rpath, spath, contents):
+        """Private helper function to test pkgsend generate and
+        publish for sysv packages."""
 
-                mpath = os.path.join(self.test_root, "sysv.p5m")
-                self.create_repo(rpath,
-                    properties={ "publisher": { "prefix": "test" }})
+        mpath = os.path.join(self.test_root, "sysv.p5m")
+        self.create_repo(rpath, properties={"publisher": {"prefix": "test"}})
 
-                self.pkgsend(None, "generate {0} > {1}".format(spath, mpath))
-                with open(mpath, "a+") as mf:
-                        mf.write("set name=pkg.fmri value=nopkg@1.0\n")
-                with open(mpath, "r") as mf:
-                        self.debug(mf.read())
-                self.pkgsend(rpath, "publish -b {0} {1}".format(spath, mpath))
+        self.pkgsend(None, "generate {0} > {1}".format(spath, mpath))
+        with open(mpath, "a+") as mf:
+            mf.write("set name=pkg.fmri value=nopkg@1.0\n")
+        with open(mpath, "r") as mf:
+            self.debug(mf.read())
+        self.pkgsend(rpath, "publish -b {0} {1}".format(spath, mpath))
 
-                self.image_create("file://{0}".format(rpath))
-                self.pkg("install nopkg")
-                self.validate_sysv_contents("nopkg", contents)
-                self.pkg("verify")
-                self.image_destroy()
+        self.image_create("file://{0}".format(rpath))
+        self.pkg("install nopkg")
+        self.validate_sysv_contents("nopkg", contents)
+        self.pkg("verify")
+        self.image_destroy()
 
-        def test_11_bundle_sysv_dir(self):
-                """ A SVR4 directory-format package can be imported, its contents
-                published to a repo and installed to an image."""
-                self.create_sysv_package(self.test_root, self.sysv_prototype,
-                    self.sysv_contents)
+    def test_11_bundle_sysv_dir(self):
+        """A SVR4 directory-format package can be imported, its contents
+        published to a repo and installed to an image."""
+        self.create_sysv_package(
+            self.test_root, self.sysv_prototype, self.sysv_contents
+        )
 
-                # Test both HTTP and file-based access since there are subtle
-                # differences in action publication.
-                spath = os.path.join(self.test_root, "nopkg")
-                self.__test_sysv_import(self.dc.get_depot_url(), spath,
-                    self.sysv_contents)
+        # Test both HTTP and file-based access since there are subtle
+        # differences in action publication.
+        spath = os.path.join(self.test_root, "nopkg")
+        self.__test_sysv_import(
+            self.dc.get_depot_url(), spath, self.sysv_contents
+        )
 
-                rpath = os.path.join(self.test_root, "test11-repo")
-                self.create_repo(rpath,
-                    properties={ "publisher": { "prefix": "test" } })
-                self.__test_sysv_gen_publish(rpath, spath,
-                    self.sysv_contents)
+        rpath = os.path.join(self.test_root, "test11-repo")
+        self.create_repo(rpath, properties={"publisher": {"prefix": "test"}})
+        self.__test_sysv_gen_publish(rpath, spath, self.sysv_contents)
 
-                # Test with trailing slash to verify that doesn't matter.
-                shutil.rmtree(rpath)
-                self.create_repo(rpath,
-                    properties={ "publisher": { "prefix": "test" } })
-                self.__test_sysv_gen_publish(rpath, spath + "/",
-                    self.sysv_contents)
+        # Test with trailing slash to verify that doesn't matter.
+        shutil.rmtree(rpath)
+        self.create_repo(rpath, properties={"publisher": {"prefix": "test"}})
+        self.__test_sysv_gen_publish(rpath, spath + "/", self.sysv_contents)
 
-        def test_11_bundle_sysv_dir_nonrelocatable(self):
-                """A SVr4 directory format package with non-relocatable elements
-                can be imported, its contents published to a repo and installed
-                to an image."""
+    def test_11_bundle_sysv_dir_nonrelocatable(self):
+        """A SVr4 directory format package with non-relocatable elements
+        can be imported, its contents published to a repo and installed
+        to an image."""
 
-                self.create_sysv_package(self.test_root,
-                    self.sysv_nonreloc_prototype, self.sysv_nonreloc_contents)
+        self.create_sysv_package(
+            self.test_root,
+            self.sysv_nonreloc_prototype,
+            self.sysv_nonreloc_contents,
+        )
 
-                url = self.dc.get_depot_url()
-                spath = os.path.join(self.test_root, "nopkg")
-                self.__test_sysv_import(url, spath, self.sysv_nonreloc_contents)
+        url = self.dc.get_depot_url()
+        spath = os.path.join(self.test_root, "nopkg")
+        self.__test_sysv_import(url, spath, self.sysv_nonreloc_contents)
 
-                # This time, use 'generate' and 'publish' to do the import
-                # directly to a new file repository.
-                rpath = os.path.join(self.test_root, "test11-genrepo")
-                self.__test_sysv_gen_publish(rpath, spath,
-                    self.sysv_nonreloc_contents)
+        # This time, use 'generate' and 'publish' to do the import
+        # directly to a new file repository.
+        rpath = os.path.join(self.test_root, "test11-genrepo")
+        self.__test_sysv_gen_publish(rpath, spath, self.sysv_nonreloc_contents)
 
-                # Test with trailing slash to verify that doesn't matter.
-                shutil.rmtree(rpath)
-                self.create_repo(rpath,
-                    properties={ "publisher": { "prefix": "test" } })
-                self.__test_sysv_gen_publish(rpath, spath + "/",
-                    self.sysv_nonreloc_contents)
+        # Test with trailing slash to verify that doesn't matter.
+        shutil.rmtree(rpath)
+        self.create_repo(rpath, properties={"publisher": {"prefix": "test"}})
+        self.__test_sysv_gen_publish(
+            rpath, spath + "/", self.sysv_nonreloc_contents
+        )
 
-        def test_12_bundle_sysv_datastream(self):
-                """ A SVR4 datastream package can be imported, its contents
-                published to a repo and installed to an image."""
-                self.create_sysv_package(self.test_root, self.sysv_prototype,
-                    self.sysv_contents)
-                self.cmdline_run("pkgtrans -s {0} {1} nopkg".format(self.test_root,
-                        os.path.join(self.test_root, "nopkg.pkg")),
-                        coverage=False)
+    def test_12_bundle_sysv_datastream(self):
+        """A SVR4 datastream package can be imported, its contents
+        published to a repo and installed to an image."""
+        self.create_sysv_package(
+            self.test_root, self.sysv_prototype, self.sysv_contents
+        )
+        self.cmdline_run(
+            "pkgtrans -s {0} {1} nopkg".format(
+                self.test_root, os.path.join(self.test_root, "nopkg.pkg")
+            ),
+            coverage=False,
+        )
 
-                url = self.dc.get_depot_url()
-                spath = os.path.join(self.test_root, "nopkg")
-                self.__test_sysv_import(url, spath, self.sysv_contents)
+        url = self.dc.get_depot_url()
+        spath = os.path.join(self.test_root, "nopkg")
+        self.__test_sysv_import(url, spath, self.sysv_contents)
 
-                # This time, use 'generate' and 'publish' to do the import
-                # directly to a new file repository.
-                rpath = os.path.join(self.test_root, "test12-genrepo")
-                self.__test_sysv_gen_publish(rpath, spath, self.sysv_contents)
+        # This time, use 'generate' and 'publish' to do the import
+        # directly to a new file repository.
+        rpath = os.path.join(self.test_root, "test12-genrepo")
+        self.__test_sysv_gen_publish(rpath, spath, self.sysv_contents)
 
-        def validate_sysv_contents(self, pkgname, contents_dict):
-                """ Check that the image contents correspond to the SVR4 package.
-                The tests in t_pkginstall cover most of the below, however
-                here we're interested in ensuring that pkgsend really did import
-                and publish everything we expected from the sysv package.
-                """
+    def validate_sysv_contents(self, pkgname, contents_dict):
+        """Check that the image contents correspond to the SVR4 package.
+        The tests in t_pkginstall cover most of the below, however
+        here we're interested in ensuring that pkgsend really did import
+        and publish everything we expected from the sysv package.
+        """
 
-                # verify we have copyright text
-                self.pkg("info --license {0}".format(pkgname))
+        # verify we have copyright text
+        self.pkg("info --license {0}".format(pkgname))
 
-                for entry in contents_dict:
-                        name = os.path.join(self.img_path(), entry)
-                        ftype, mode, user, group, digest = contents_dict[entry]
+        for entry in contents_dict:
+            name = os.path.join(self.img_path(), entry)
+            ftype, mode, user, group, digest = contents_dict[entry]
 
-                        if ftype in "fl":
-                                self.assertTrue(os.path.isfile(name))
-                        elif ftype == "d":
-                                self.assertTrue(os.path.isdir(name))
-                        elif ftype == "s":
-                                self.assertTrue(os.path.islink(name))
-                        elif ftype == "i":
-                                # we should not have installed these
-                                self.assertFalse(os.path.exists(name))
-                                continue
+            if ftype in "fl":
+                self.assertTrue(os.path.isfile(name))
+            elif ftype == "d":
+                self.assertTrue(os.path.isdir(name))
+            elif ftype == "s":
+                self.assertTrue(os.path.islink(name))
+            elif ftype == "i":
+                # we should not have installed these
+                self.assertFalse(os.path.exists(name))
+                continue
 
-                        if digest:
-                                # the hash_func used here just needs to
-                                # correspond with the one used when creating
-                                # the svr4 package - it does not consult the
-                                # pkg(7) hash or chash attributes.
-                                pkg5_digest, contents = misc.get_data_digest(
-                                    name, return_content=True,
-                                    hash_func=DEFAULT_HASH_FUNC)
-                                self.assertEqual(digest, pkg5_digest,
-                                    "{0}: {1} != {2}, '{3}'".format(name, digest,
-                                    pkg5_digest, contents))
+            if digest:
+                # the hash_func used here just needs to
+                # correspond with the one used when creating
+                # the svr4 package - it does not consult the
+                # pkg(7) hash or chash attributes.
+                pkg5_digest, contents = misc.get_data_digest(
+                    name, return_content=True, hash_func=DEFAULT_HASH_FUNC
+                )
+                self.assertEqual(
+                    digest,
+                    pkg5_digest,
+                    "{0}: {1} != {2}, '{3}'".format(
+                        name, digest, pkg5_digest, contents
+                    ),
+                )
 
-                        st = os.stat(os.path.join(self.img_path(), name))
-                        if mode is not None:
-                                portable.assert_mode(name, stat.S_IMODE(mode))
-                        self.assertEqual(portable.get_user_by_name(user,
-                            self.img_path(), use_file=True), st.st_uid)
-                        self.assertEqual(portable.get_group_by_name(group,
-                            self.img_path(), use_file=True), st.st_gid)
+            st = os.stat(os.path.join(self.img_path(), name))
+            if mode is not None:
+                portable.assert_mode(name, stat.S_IMODE(mode))
+            self.assertEqual(
+                portable.get_user_by_name(user, self.img_path(), use_file=True),
+                st.st_uid,
+            )
+            self.assertEqual(
+                portable.get_group_by_name(
+                    group, self.img_path(), use_file=True
+                ),
+                st.st_gid,
+            )
 
-        def test_13_pkgsend_indexcontrol(self):
-                """Verify that "pkgsend refresh-index" triggers indexing."""
+    def test_13_pkgsend_indexcontrol(self):
+        """Verify that "pkgsend refresh-index" triggers indexing."""
 
-                dhurl = self.dc.get_depot_url()
-                dfurl = "file://{0}".format(pathname2url(self.dc.get_repodir()))
+        dhurl = self.dc.get_depot_url()
+        dfurl = "file://{0}".format(pathname2url(self.dc.get_repodir()))
 
-                fd, fpath = tempfile.mkstemp(dir=self.test_root)
+        fd, fpath = tempfile.mkstemp(dir=self.test_root)
 
-                self.image_create(dhurl)
+        self.image_create(dhurl)
 
-                self.dc.stop()
-                self.dc.set_readonly()
+        self.dc.stop()
+        self.dc.set_readonly()
 
-                self.pkgsend(dfurl, "open file@1.0")
-                self.pkgsend(dfurl, "add file {0} {1} path=/tmp/f.foo" \
-                   .format(fpath, "mode=0755 owner=root group=bin"))
+        self.pkgsend(dfurl, "open file@1.0")
+        self.pkgsend(
+            dfurl,
+            "add file {0} {1} path=/tmp/f.foo".format(
+                fpath, "mode=0755 owner=root group=bin"
+            ),
+        )
 
-                # Verify that --no-index (even though it is now ignored) can be
-                # specified and doesn't cause pkgsend failure.
-                self.pkgsend(dfurl, "close --no-index")
-                self.wait_repo(self.dc.get_repodir())
+        # Verify that --no-index (even though it is now ignored) can be
+        # specified and doesn't cause pkgsend failure.
+        self.pkgsend(dfurl, "close --no-index")
+        self.wait_repo(self.dc.get_repodir())
 
-                self.dc.start()
-                self.pkg("search file:::", exit=1)
+        self.dc.start()
+        self.pkg("search file:::", exit=1)
 
-                self.dc.stop()
-                self.pkgsend(dfurl, "refresh-index")
-                self.dc.start()
-                self.pkg("search file:::")
+        self.dc.stop()
+        self.pkgsend(dfurl, "refresh-index")
+        self.dc.start()
+        self.pkg("search file:::")
 
-                self.dc.stop()
-                self.dc.set_readwrite()
-                self.dc.start()
+        self.dc.stop()
+        self.dc.set_readwrite()
+        self.dc.start()
 
-                self.pkgsend(dhurl, "open http@1.0")
-                self.pkgsend(dhurl, "add file {0} {1} path=/tmp/f.foo" \
-                   .format(fpath, "mode=0755 owner=root group=bin"))
-                self.pkgsend(dhurl, "close")
+        self.pkgsend(dhurl, "open http@1.0")
+        self.pkgsend(
+            dhurl,
+            "add file {0} {1} path=/tmp/f.foo".format(
+                fpath, "mode=0755 owner=root group=bin"
+            ),
+        )
+        self.pkgsend(dhurl, "close")
 
-                self.wait_repo(self.dc.get_repodir())
-                self.pkg("search http:::", exit=1)
+        self.wait_repo(self.dc.get_repodir())
+        self.pkg("search http:::", exit=1)
 
-                self.pkgsend(dhurl, "refresh-index")
+        self.pkgsend(dhurl, "refresh-index")
 
-                self.pkg("search http:::")
+        self.pkg("search http:::")
 
-                self.image_destroy()
-                os.close(fd)
-                os.unlink(fpath)
+        self.image_destroy()
+        os.close(fd)
+        os.unlink(fpath)
 
-        def test_14_obsolete(self):
-                """Obsolete and renamed packages can only have very specific
-                content."""
+    def test_14_obsolete(self):
+        """Obsolete and renamed packages can only have very specific
+        content."""
 
-                # Obsolete packages can't have contents
-                badobs1 = """
+        # Obsolete packages can't have contents
+        badobs1 = """
                     open badobs@<ver>
                     add dir path=usr mode=0755 owner=root group=root
                     add set name=pkg.obsolete value=true
                     close
                 """
 
-                # Obsolete packages can't have contents (reordered)
-                badobs2 = """
+        # Obsolete packages can't have contents (reordered)
+        badobs2 = """
                     open badobs@<ver>
                     add set name=pkg.obsolete value=true
                     add dir path=usr mode=0755 owner=root group=root
                     close
                 """
 
-                # Renamed packages can't have contents
-                badren1 = """
+        # Renamed packages can't have contents
+        badren1 = """
                     open badren@<ver>
                     add set name=pkg.renamed value=true
                     add dir path=usr mode=0755 owner=root group=root
@@ -959,768 +1052,903 @@ file 6a1ae3def902f5612a43f0c0836fe05bc4f237cf chash=be9c91959ec782acb0f081bf4bf1
                     close
                 """
 
-                # Renamed packages must have dependencies
-                badren2 = """
+        # Renamed packages must have dependencies
+        badren2 = """
                     open badren@<ver>
                     add set name=pkg.renamed value=true
                     close
                 """
 
-                # A package can't be marked both obsolete and renamed
-                badrenobs1 = """
+        # A package can't be marked both obsolete and renamed
+        badrenobs1 = """
                     open badrenobs@<ver>
                     add set name=pkg.obsolete value=true
                     add set name=pkg.renamed value=true
                     close
                 """
 
-                # Obsolete packages can have metadata
-                bob = """
+        # Obsolete packages can have metadata
+        bob = """
                     open bobsyeruncle@<ver>
                     add set name=pkg.obsolete value=true
                     add set name=pkg.summary value="A test package"
                     close
                 """
 
-                # Package contents and line number where it should fail.
-                pkgs = [
-                    (badobs1, 3),
-                    (badobs2, 3),
-                    (badren1, 3),
-                    (badren2, 3),
-                    (badrenobs1, 3),
-                    (bob, -1)
-                ]
-                dhurl = self.dc.get_depot_url()
-                junk_repo = os.path.join(self.test_root, "obs-junkrepo")
-                dfurl = "file://" + junk_repo
-                self.pkgsend(dfurl,
-                    "create-repository --set-property publisher.prefix=test")
+        # Package contents and line number where it should fail.
+        pkgs = [
+            (badobs1, 3),
+            (badobs2, 3),
+            (badren1, 3),
+            (badren2, 3),
+            (badrenobs1, 3),
+            (bob, -1),
+        ]
+        dhurl = self.dc.get_depot_url()
+        junk_repo = os.path.join(self.test_root, "obs-junkrepo")
+        dfurl = "file://" + junk_repo
+        self.pkgsend(
+            dfurl, "create-repository --set-property publisher.prefix=test"
+        )
 
-                ver = 0
-                for p, line in pkgs:
-                        for url in (dhurl, dfurl):
-                                # Try a bulk pkgsend first
-                                exit = int(line >= 0)
-                                # We publish fast enough that we can end up
-                                # publishing the same package version twice
-                                # within the same second, so force the version
-                                # to be incremented.
-                                p2 = p.replace("<ver>", str(ver))
-                                try:
-                                        self.pkgsend_bulk(url, p2, exit=exit)
-                                except:
-                                        self.debug("Expected exit code {0} "
-                                            "while publishing {1}".format(exit,
-                                            p2))
-                                        raise
+        ver = 0
+        for p, line in pkgs:
+            for url in (dhurl, dfurl):
+                # Try a bulk pkgsend first
+                exit = int(line >= 0)
+                # We publish fast enough that we can end up
+                # publishing the same package version twice
+                # within the same second, so force the version
+                # to be incremented.
+                p2 = p.replace("<ver>", str(ver))
+                try:
+                    self.pkgsend_bulk(url, p2, exit=exit)
+                except:
+                    self.debug(
+                        "Expected exit code {0} "
+                        "while publishing {1}".format(exit, p2)
+                    )
+                    raise
 
-                                # Then do it line-by-line
-                                for i, l in enumerate(p.splitlines()):
-                                        if not l.strip():
-                                                continue
-                                        exit = int(i == line)
-                                        l = l.replace("<ver>", str(ver + 1))
-                                        self.pkgsend(url, l.strip(), exit=exit)
-                                        if exit:
-                                                self.pkgsend(url, "close -A")
-                                                break
-                                ver += 2
+                # Then do it line-by-line
+                for i, l in enumerate(p.splitlines()):
+                    if not l.strip():
+                        continue
+                    exit = int(i == line)
+                    l = l.replace("<ver>", str(ver + 1))
+                    self.pkgsend(url, l.strip(), exit=exit)
+                    if exit:
+                        self.pkgsend(url, "close -A")
+                        break
+                ver += 2
 
-        def test_15_test_no_catalog_option(self):
-                """Verify that --no-catalog works as expected.  Also exercise
-                --fmri-in-manifest"""
-                pkg_manifest = \
-"""set name=pkg.fmri value=foo@0.5.11,5.11-0.129
+    def test_15_test_no_catalog_option(self):
+        """Verify that --no-catalog works as expected.  Also exercise
+        --fmri-in-manifest"""
+        pkg_manifest = """set name=pkg.fmri value=foo@0.5.11,5.11-0.129
 dir path=foo mode=0755 owner=root group=bin
 dir path=foo/bar mode=0755 owner=root group=bin
 """
-                self.dc.stop()
-                rpath = self.dc.get_repodir()
-                fpath = os.path.join(self.test_root, "manifest")
-                f = open(fpath, "w")
-                f.write(pkg_manifest)
-                f.close()
-                self.pkgsend("file://{0}".format(rpath),
-                    "create-repository --set-property publisher.prefix=test")
+        self.dc.stop()
+        rpath = self.dc.get_repodir()
+        fpath = os.path.join(self.test_root, "manifest")
+        f = open(fpath, "w")
+        f.write(pkg_manifest)
+        f.close()
+        self.pkgsend(
+            "file://{0}".format(rpath),
+            "create-repository --set-property publisher.prefix=test",
+        )
 
-                repo = self.dc.get_repo()
-                cat_path = repo.catalog_1("catalog.attrs")
-                mtime = os.stat(cat_path).st_mtime
-                self.pkgsend("file://{0}".format(rpath), "publish --fmri-in-manifest "
-                    "--no-catalog {0}".format(fpath))
-                new_mtime = os.stat(cat_path).st_mtime
-                # Check that modified times are the same before and after
-                # publication.
-                self.assertEqual(mtime, new_mtime)
+        repo = self.dc.get_repo()
+        cat_path = repo.catalog_1("catalog.attrs")
+        mtime = os.stat(cat_path).st_mtime
+        self.pkgsend(
+            "file://{0}".format(rpath),
+            "publish --fmri-in-manifest " "--no-catalog {0}".format(fpath),
+        )
+        new_mtime = os.stat(cat_path).st_mtime
+        # Check that modified times are the same before and after
+        # publication.
+        self.assertEqual(mtime, new_mtime)
 
-                self.pkgsend("file://{0}".format(rpath), "open bar@1.0")
-                self.pkgsend("file://{0}".format(rpath), "close --no-catalog")
-                new_mtime = os.stat(cat_path).st_mtime
-                # Check that modified times are the same before and after
-                # publication
-                self.assertEqual(mtime, new_mtime)
+        self.pkgsend("file://{0}".format(rpath), "open bar@1.0")
+        self.pkgsend("file://{0}".format(rpath), "close --no-catalog")
+        new_mtime = os.stat(cat_path).st_mtime
+        # Check that modified times are the same before and after
+        # publication
+        self.assertEqual(mtime, new_mtime)
 
-                # Now start depot and verify both packages are visible when
-                # set to add content on startup.
-                self.dc.set_add_content()
-                self.dc.start()
-                dhurl = self.dc.get_depot_url()
-                self.dc.set_repodir(rpath)
-                self.image_create(dhurl)
-                self.pkg("list -a bar foo")
-                self.image_destroy()
+        # Now start depot and verify both packages are visible when
+        # set to add content on startup.
+        self.dc.set_add_content()
+        self.dc.start()
+        dhurl = self.dc.get_depot_url()
+        self.dc.set_repodir(rpath)
+        self.image_create(dhurl)
+        self.pkg("list -a bar foo")
+        self.image_destroy()
 
-        def test_16_multiple_manifests(self):
-                """Verify that when sending multiple manifests, the contents
-                of all manifests are published."""
+    def test_16_multiple_manifests(self):
+        """Verify that when sending multiple manifests, the contents
+        of all manifests are published."""
 
-                # First create two dummy data files.
-                test_files = ["dummy1", "dummy2"]
-                self.make_misc_files(test_files)
+        # First create two dummy data files.
+        test_files = ["dummy1", "dummy2"]
+        self.make_misc_files(test_files)
 
-                # create two manifests.
-                for path in test_files:
-                        manfpath = path + ".manifest"
-                        self.make_misc_files({
-                            manfpath:
-                                "file {0} mode=0644 owner=root group=bin "
-                                "path=/foo{1}".format(path, path)})
+        # create two manifests.
+        for path in test_files:
+            manfpath = path + ".manifest"
+            self.make_misc_files(
+                {
+                    manfpath: "file {0} mode=0644 owner=root group=bin "
+                    "path=/foo{1}".format(path, path)
+                }
+            )
 
-                # publish
-                url = self.dc.get_depot_url()
-                self.pkgsend(url, "open multiple_mf@1.0")
-                manifests = " ".join([path + ".manifest" for path in test_files])
-                self.pkgsend(url, "include " + manifests)
-                self.pkgsend(url, "close")
+        # publish
+        url = self.dc.get_depot_url()
+        self.pkgsend(url, "open multiple_mf@1.0")
+        manifests = " ".join([path + ".manifest" for path in test_files])
+        self.pkgsend(url, "include " + manifests)
+        self.pkgsend(url, "close")
 
-                # Finally, verify that both files were published.
-                self.image_create(url)
-                for path in test_files:
-                        self.pkg("contents -r -H -o action.raw -t file multiple_mf |"
-                            " grep {0}".format(path))
-                self.image_destroy()
+        # Finally, verify that both files were published.
+        self.image_create(url)
+        for path in test_files:
+            self.pkg(
+                "contents -r -H -o action.raw -t file multiple_mf |"
+                " grep {0}".format(path)
+            )
+        self.image_destroy()
 
-        def test_17_include_errors(self):
-                """Verify that pkgsend include handles error conditions
-                gracefully."""
+    def test_17_include_errors(self):
+        """Verify that pkgsend include handles error conditions
+        gracefully."""
 
-                url = self.dc.get_depot_url()
+        url = self.dc.get_depot_url()
 
-                # Start a transaction.
-                self.pkgsend(url, "open foo@1.0")
+        # Start a transaction.
+        self.pkgsend(url, "open foo@1.0")
 
-                # Verify no such include file handled.
-                self.pkgsend(url, "include nosuchfile", exit=1)
+        # Verify no such include file handled.
+        self.pkgsend(url, "include nosuchfile", exit=1)
 
-                # Verify files with invalid content handled.
-                misc = self.make_misc_files({
-                    "invalid": "!%^$%^@*&$ bobcat",
-                    "empty": "",
-                })
-                self.pkgsend(url, "include {0}".format(" ".join(misc)), exit=1)
+        # Verify files with invalid content handled.
+        misc = self.make_misc_files(
+            {
+                "invalid": "!%^$%^@*&$ bobcat",
+                "empty": "",
+            }
+        )
+        self.pkgsend(url, "include {0}".format(" ".join(misc)), exit=1)
 
-        def test_18_broken_sysv_dir(self):
-                """ A SVR4 directory-format package containing class action
-                scripts fails to be imported or is generated with errors"""
-                rootdir = self.test_root
-                self.create_sysv_package(rootdir, self.sysv_classes_prototype,
-                    self.sysv_contents)
-                url = self.dc.get_depot_url()
+    def test_18_broken_sysv_dir(self):
+        """A SVR4 directory-format package containing class action
+        scripts fails to be imported or is generated with errors"""
+        rootdir = self.test_root
+        self.create_sysv_package(
+            rootdir, self.sysv_classes_prototype, self.sysv_contents
+        )
+        url = self.dc.get_depot_url()
 
-                self.pkgsend(url, "open nopkg@1.0")
-                self.pkgsend(url, "import {0}".format(os.path.join(rootdir, "nopkg")),
-                    exit=1)
-                self.check_sysv_scripting(self.errout)
+        self.pkgsend(url, "open nopkg@1.0")
+        self.pkgsend(
+            url, "import {0}".format(os.path.join(rootdir, "nopkg")), exit=1
+        )
+        self.check_sysv_scripting(self.errout)
 
-                self.pkgsend(url, "generate {0}".format(os.path.join(rootdir, "nopkg")),
-                    exit=1)
-                self.check_sysv_scripting(self.errout)
-                self.check_sysv_parameters(self.output)
+        self.pkgsend(
+            url, "generate {0}".format(os.path.join(rootdir, "nopkg")), exit=1
+        )
+        self.check_sysv_scripting(self.errout)
+        self.check_sysv_parameters(self.output)
 
-        def test_19_broken_sysv_datastream(self):
-                """ A SVR4 datastream package containing class action scripts
-                fails to be imported or is generated with errors"""
-                rootdir = self.test_root
-                self.create_sysv_package(rootdir, self.sysv_classes_prototype,
-                    self.sysv_contents)
-                self.cmdline_run("pkgtrans -s {0} {1} nopkg".format(rootdir,
-                        os.path.join(rootdir, "nopkg.pkg")), coverage=False)
+    def test_19_broken_sysv_datastream(self):
+        """A SVR4 datastream package containing class action scripts
+        fails to be imported or is generated with errors"""
+        rootdir = self.test_root
+        self.create_sysv_package(
+            rootdir, self.sysv_classes_prototype, self.sysv_contents
+        )
+        self.cmdline_run(
+            "pkgtrans -s {0} {1} nopkg".format(
+                rootdir, os.path.join(rootdir, "nopkg.pkg")
+            ),
+            coverage=False,
+        )
 
-                url = self.dc.get_depot_url()
+        url = self.dc.get_depot_url()
 
-                def check_errors(err):
-                        self.assertTrue('ERROR: class action script used in nopkg: foobar/baz belongs to "myclass" class' in err)
-                        self.assertTrue("ERROR: script present in nopkg: myclass" in err)
-                        self.assertTrue("ERROR: script present in nopkg: postinstall" in err)
+        def check_errors(err):
+            self.assertTrue(
+                'ERROR: class action script used in nopkg: foobar/baz belongs to "myclass" class'
+                in err
+            )
+            self.assertTrue("ERROR: script present in nopkg: myclass" in err)
+            self.assertTrue(
+                "ERROR: script present in nopkg: postinstall" in err
+            )
 
-                self.pkgsend(url, "open nopkg@1.0")
-                self.pkgsend(url, "import {0}".format(os.path.join(rootdir, "nopkg.pkg")),
-                    exit=1)
-                self.check_sysv_scripting(self.errout)
+        self.pkgsend(url, "open nopkg@1.0")
+        self.pkgsend(
+            url, "import {0}".format(os.path.join(rootdir, "nopkg.pkg")), exit=1
+        )
+        self.check_sysv_scripting(self.errout)
 
-                self.pkgsend(url, "generate {0}".format(os.path.join(rootdir,
-                    "nopkg.pkg")), exit=1)
-                self.check_sysv_scripting(self.errout)
-                self.check_sysv_parameters(self.output)
+        self.pkgsend(
+            url,
+            "generate {0}".format(os.path.join(rootdir, "nopkg.pkg")),
+            exit=1,
+        )
+        self.check_sysv_scripting(self.errout)
+        self.check_sysv_parameters(self.output)
 
-        def check_sysv_scripting(self, err):
-                """Verify we've reported any class action or install scripts"""
-                self.assertTrue('ERROR: class action script used in nopkg: foobar/baz belongs to "myclass" class' in err)
-                self.assertTrue("ERROR: script present in nopkg: myclass" in err)
-                self.assertTrue("ERROR: script present in nopkg: postinstall" in err)
+    def check_sysv_scripting(self, err):
+        """Verify we've reported any class action or install scripts"""
+        self.assertTrue(
+            'ERROR: class action script used in nopkg: foobar/baz belongs to "myclass" class'
+            in err
+        )
+        self.assertTrue("ERROR: script present in nopkg: myclass" in err)
+        self.assertTrue("ERROR: script present in nopkg: postinstall" in err)
 
-        def check_sysv_parameters(self, output):
-                """Verify we've automatically converted some pkginfo parameters
-                """
-                self.assertTrue(
-                    "set name=pkg.description value=\"This is a sample package\""
-                    in output)
-                self.assertTrue("set name=pkg.summary value=\"No package\""
-                    in output)
-                self.assertTrue("set name=pkg.send.convert.pkg-contents value=bobcat"
-                    in output)
-                # this pkginfo parameter should be ignored
-                self.assertTrue("rstate" not in output)
+    def check_sysv_parameters(self, output):
+        """Verify we've automatically converted some pkginfo parameters"""
+        self.assertTrue(
+            'set name=pkg.description value="This is a sample package"'
+            in output
+        )
+        self.assertTrue('set name=pkg.summary value="No package"' in output)
+        self.assertTrue(
+            "set name=pkg.send.convert.pkg-contents value=bobcat" in output
+        )
+        # this pkginfo parameter should be ignored
+        self.assertTrue("rstate" not in output)
 
-        def test_20_multi_pkg_bundle(self):
-                """Verify we return an error for a multi-package datastream."""
+    def test_20_multi_pkg_bundle(self):
+        """Verify we return an error for a multi-package datastream."""
 
-                rootdir = self.test_root
-                self.create_sysv_package(rootdir, self.sysv_classes_prototype,
-                    self.sysv_contents)
-                self.create_sysv_package(rootdir, self.sysv_prototype,
-                    self.sysv_contents, pkginfo_contents=self.sysv_pkginfo_2)
-                url = self.dc.get_depot_url()
+        rootdir = self.test_root
+        self.create_sysv_package(
+            rootdir, self.sysv_classes_prototype, self.sysv_contents
+        )
+        self.create_sysv_package(
+            rootdir,
+            self.sysv_prototype,
+            self.sysv_contents,
+            pkginfo_contents=self.sysv_pkginfo_2,
+        )
+        url = self.dc.get_depot_url()
 
-                self.cmdline_run("pkgtrans -s {0} {1} nopkg nopkgtwo".format(rootdir,
-                    os.path.join(rootdir, "nopkg.pkg")), coverage=False)
-                self.pkgsend(url, "generate {0}".format(os.path.join(rootdir,
-                    "nopkg.pkg")), exit=1)
-                self.assertTrue("Multi-package datastreams are not supported." in
-                    self.errout)
+        self.cmdline_run(
+            "pkgtrans -s {0} {1} nopkg nopkgtwo".format(
+                rootdir, os.path.join(rootdir, "nopkg.pkg")
+            ),
+            coverage=False,
+        )
+        self.pkgsend(
+            url,
+            "generate {0}".format(os.path.join(rootdir, "nopkg.pkg")),
+            exit=1,
+        )
+        self.assertTrue(
+            "Multi-package datastreams are not supported." in self.errout
+        )
 
-        def test_21_uri_paths(self):
-                """Verify that a repository path with characters that must be
-                URI-encoded or that are can be created and used with pkgsend."""
+    def test_21_uri_paths(self):
+        """Verify that a repository path with characters that must be
+        URI-encoded or that are can be created and used with pkgsend."""
 
-                for name in ("a%3A%2Fb", "a:b"):
-                        rpath = os.path.join(self.test_root, name)
-                        self.pkgsend(rpath, "create-repository "
-                            "--set-property publisher.prefix=test")
+        for name in ("a%3A%2Fb", "a:b"):
+            rpath = os.path.join(self.test_root, name)
+            self.pkgsend(
+                rpath,
+                "create-repository " "--set-property publisher.prefix=test",
+            )
 
-                        self.pkgsend(rpath, "open pkg://test/foo@1.0")
-                        self.pkgsend(rpath, "close")
+            self.pkgsend(rpath, "open pkg://test/foo@1.0")
+            self.pkgsend(rpath, "close")
 
-                        # This will fail if the repository wasn't created with
-                        # the expected name.
-                        shutil.rmtree(rpath)
+            # This will fail if the repository wasn't created with
+            # the expected name.
+            shutil.rmtree(rpath)
 
-        def __test_publish(self, dir_1, dir_2, mfpath):
-                dhurl = self.dc.get_depot_url()
-                # -s may be specified either as a global option or as a local
-                # option for the publish subcommand.
-                self.pkgsend("", "-s {0} publish -d {1} -d {2} < {3}".format(dhurl,
-                    dir_1, dir_2, mfpath))
+    def __test_publish(self, dir_1, dir_2, mfpath):
+        dhurl = self.dc.get_depot_url()
+        # -s may be specified either as a global option or as a local
+        # option for the publish subcommand.
+        self.pkgsend(
+            "",
+            "-s {0} publish -d {1} -d {2} < {3}".format(
+                dhurl, dir_1, dir_2, mfpath
+            ),
+        )
 
-                self.image_create(dhurl)
-                self.pkg("install testmultipledirs")
-                self.pkg("list -vH testmultipledirs@1.0")
-                self.assertTrue("testmultipledirs@1.0" in self.output)
+        self.image_create(dhurl)
+        self.pkg("install testmultipledirs")
+        self.pkg("list -vH testmultipledirs@1.0")
+        self.assertTrue("testmultipledirs@1.0" in self.output)
 
-                self.pkg("verify")
-                self.image_destroy()
+        self.pkg("verify")
+        self.image_destroy()
 
-                self.pkgsend("", "publish -s {0} -d {1} -d {2} < {3}".format(dhurl,
-                    dir_1, dir_2, mfpath))
+        self.pkgsend(
+            "",
+            "publish -s {0} -d {1} -d {2} < {3}".format(
+                dhurl, dir_1, dir_2, mfpath
+            ),
+        )
 
-                self.image_create(dhurl)
-                self.pkg("install testmultipledirs")
-                self.pkg("verify")
-                self.image_destroy()
+        self.image_create(dhurl)
+        self.pkg("install testmultipledirs")
+        self.pkg("verify")
+        self.image_destroy()
 
-        def test_22_publish(self):
-                """Verify that pkgsend publish works as expected."""
+    def test_22_publish(self):
+        """Verify that pkgsend publish works as expected."""
 
-                rootdir = self.test_root
-                dir_1 = os.path.join(rootdir, "dir_1")
-                dir_2 = os.path.join(rootdir, "dir_2")
-                os.mkdir(dir_1)
-                os.mkdir(dir_2)
-                open(os.path.join(dir_1, "A"), "w").close()
-                open(os.path.join(dir_2, "B"), "w").close()
-                mfpath = os.path.join(rootdir, "manifest_test")
-                with open(mfpath, "w") as mf:
-                        mf.write("""file NOHASH mode=0755 owner=root group=bin path=/A
+        rootdir = self.test_root
+        dir_1 = os.path.join(rootdir, "dir_1")
+        dir_2 = os.path.join(rootdir, "dir_2")
+        os.mkdir(dir_1)
+        os.mkdir(dir_2)
+        open(os.path.join(dir_1, "A"), "w").close()
+        open(os.path.join(dir_2, "B"), "w").close()
+        mfpath = os.path.join(rootdir, "manifest_test")
+        with open(mfpath, "w") as mf:
+            mf.write(
+                """file NOHASH mode=0755 owner=root group=bin path=/A
                             file NOHASH mode=0755 owner=root group=bin path=/B
                             set name=pkg.fmri value=testmultipledirs@1.0,5.10
-                            """)
-                self.__test_publish(dir_1, dir_2, mfpath)
+                            """
+            )
+        self.__test_publish(dir_1, dir_2, mfpath)
 
-                # Test the publication of elf files.
-                elfmfpath = os.path.join(self.test_root, "elftest.p5m")
-                with open(elfmfpath, "w") as mf:
-                        mf.write("""\
+        # Test the publication of elf files.
+        elfmfpath = os.path.join(self.test_root, "elftest.p5m")
+        with open(elfmfpath, "w") as mf:
+            mf.write(
+                """\
                             set name=pkg.fmri value=pkg://test/elftest@1.0
                             file elftest.so.1 mode=0755 owner=root group=bin path=bin/true
-                            """)
+                            """
+            )
 
-                self.pkgsend(self.dc.get_depot_url(),
-                    "publish -d {0} {1}".format(self.ro_data_root, elfmfpath))
+        self.pkgsend(
+            self.dc.get_depot_url(),
+            "publish -d {0} {1}".format(self.ro_data_root, elfmfpath),
+        )
 
-                # Verify that older logic for pkgsend publish works.
-                self.dc.stop()
-                self.dc.set_disable_ops(["manifest/1"])
-                self.dc.start()
-                self.__test_publish(dir_1, dir_2, mfpath)
-                self.pkgsend(self.dc.get_depot_url(),
-                    "publish -d {0} {1}".format(self.ro_data_root, elfmfpath))
-                self.dc.unset_disable_ops()
+        # Verify that older logic for pkgsend publish works.
+        self.dc.stop()
+        self.dc.set_disable_ops(["manifest/1"])
+        self.dc.start()
+        self.__test_publish(dir_1, dir_2, mfpath)
+        self.pkgsend(
+            self.dc.get_depot_url(),
+            "publish -d {0} {1}".format(self.ro_data_root, elfmfpath),
+        )
+        self.dc.unset_disable_ops()
 
-        def test_23_pkgsend_no_version(self):
-                """Verify that FMRI without version cannot be specified."""
+    def test_23_pkgsend_no_version(self):
+        """Verify that FMRI without version cannot be specified."""
 
-                rootdir = self.test_root
-                dir_1 = os.path.join(rootdir, "dir_1")
-                os.mkdir(dir_1)
-                open(os.path.join(dir_1, "A"), "w").close()
-                mfpath = os.path.join(rootdir, "manifest_test")
-                with open(mfpath, "w") as mf:
-                        mf.write("""file NOHASH mode=0755 owner=root group=bin path=/A
+        rootdir = self.test_root
+        dir_1 = os.path.join(rootdir, "dir_1")
+        os.mkdir(dir_1)
+        open(os.path.join(dir_1, "A"), "w").close()
+        mfpath = os.path.join(rootdir, "manifest_test")
+        with open(mfpath, "w") as mf:
+            mf.write(
+                """file NOHASH mode=0755 owner=root group=bin path=/A
                             set name=pkg.fmri value=testnoversion
-                            """)
+                            """
+            )
 
-                dhurl = self.dc.get_depot_url()
-                self.pkgsend("", "-s {0} publish -d {1} < {2}".format(dhurl,
-                    dir_1, mfpath), exit=1)
+        dhurl = self.dc.get_depot_url()
+        self.pkgsend(
+            "",
+            "-s {0} publish -d {1} < {2}".format(dhurl, dir_1, mfpath),
+            exit=1,
+        )
 
-        def test_24_pkgsend_publish_payloaded_link(self):
-                """Verify that publishing a manifest with a link with a payload
-                doesn't traceback."""
+    def test_24_pkgsend_publish_payloaded_link(self):
+        """Verify that publishing a manifest with a link with a payload
+        doesn't traceback."""
 
-                mfpath = os.path.join(self.test_root, "foo.p5m")
-                with open(mfpath, "w") as mf:
-                        mf.write("""set name=pkg.fmri value=foo@1
-link payload-pathname path=/usr/bin/foo target=bar""")
-                self.pkgsend("", "-s {0} publish {1}".format(
-                    self.dc.get_depot_url(), mfpath), exit=1)
-                self.pkgsend("", "-s {0} publish {1}".format(
-                    self.dc.get_repo_url(), mfpath), exit=1)
-                with open(mfpath, "w") as mf:
-                        mf.write("""set name=pkg.fmri value=foo@1
-dir path=/usr/bin/foo target=bar hash=payload-pathname""")
-                self.pkgsend("", "-s {0} publish {1}".format(
-                    self.dc.get_depot_url(), mfpath), exit=1)
-                self.pkgsend("", "-s {0} publish {1}".format(
-                    self.dc.get_repo_url(), mfpath), exit=1)
+        mfpath = os.path.join(self.test_root, "foo.p5m")
+        with open(mfpath, "w") as mf:
+            mf.write(
+                """set name=pkg.fmri value=foo@1
+link payload-pathname path=/usr/bin/foo target=bar"""
+            )
+        self.pkgsend(
+            "",
+            "-s {0} publish {1}".format(self.dc.get_depot_url(), mfpath),
+            exit=1,
+        )
+        self.pkgsend(
+            "",
+            "-s {0} publish {1}".format(self.dc.get_repo_url(), mfpath),
+            exit=1,
+        )
+        with open(mfpath, "w") as mf:
+            mf.write(
+                """set name=pkg.fmri value=foo@1
+dir path=/usr/bin/foo target=bar hash=payload-pathname"""
+            )
+        self.pkgsend(
+            "",
+            "-s {0} publish {1}".format(self.dc.get_depot_url(), mfpath),
+            exit=1,
+        )
+        self.pkgsend(
+            "",
+            "-s {0} publish {1}".format(self.dc.get_repo_url(), mfpath),
+            exit=1,
+        )
 
-        def test_25_pkgsend_publish_nohash_license(self):
-                """Verify that publishing a manifest with hash attribute
-                missing for license action doesn't traceback"""
+    def test_25_pkgsend_publish_nohash_license(self):
+        """Verify that publishing a manifest with hash attribute
+        missing for license action doesn't traceback"""
 
-                durl = self.dc.get_depot_url()
-                # Should fail because hash attribute is missing.
-                self.pkgsend_bulk(durl,
-                    """open foo@1.0
+        durl = self.dc.get_depot_url()
+        # Should fail because hash attribute is missing.
+        self.pkgsend_bulk(
+            durl,
+            """open foo@1.0
                     add license license=copyright
-                    close""", exit=1)
+                    close""",
+            exit=1,
+        )
 
-        def test_26_pkgsend_multihash(self):
-                """Tests that when publishing packages with mutiple hashes,
-                we only overwrite those hashes if we're in multi-hash mode
-                and only if they match the hash attributes we know how to
-                compute, other attributes are left alone."""
+    def test_26_pkgsend_multihash(self):
+        """Tests that when publishing packages with mutiple hashes,
+        we only overwrite those hashes if we're in multi-hash mode
+        and only if they match the hash attributes we know how to
+        compute, other attributes are left alone."""
 
-                self.base_26_pkgsend_multihash("sha256")
-                if sha512_supported:
-                        self.base_26_pkgsend_multihash("sha512t_256")
+        self.base_26_pkgsend_multihash("sha256")
+        if sha512_supported:
+            self.base_26_pkgsend_multihash("sha512t_256")
 
-        def base_26_pkgsend_multihash(self, hash_alg):
-                # we use a file:// URI rather than the repo URI so we don't have
-                # to worry about starting the depot in SHA-2 mode. Other tests
-                # in the test suite ensure SHA-2 publication is working over
-                # HTTP.
-                furi = self.dc.get_repo_url()
-                mfpath = os.path.join(self.test_root, "pkgsend_multihash.mf")
-                payload = self.make_misc_files(["pkgsend_multihash"])[0]
+    def base_26_pkgsend_multihash(self, hash_alg):
+        # we use a file:// URI rather than the repo URI so we don't have
+        # to worry about starting the depot in SHA-2 mode. Other tests
+        # in the test suite ensure SHA-2 publication is working over
+        # HTTP.
+        furi = self.dc.get_repo_url()
+        mfpath = os.path.join(self.test_root, "pkgsend_multihash.mf")
+        payload = self.make_misc_files(["pkgsend_multihash"])[0]
 
-                with open(mfpath, "w") as mf:
-                        mf.write("""
+        with open(mfpath, "w") as mf:
+            mf.write(
+                """
 set name=pkg.fmri value=pkg:/multihash@1.0
 file {0} path=/foo owner=root group=sys mode=0644 pkg.hash.rot13=caesar
-""".format(payload, hash_alg))
-                self.pkgsend("", "-s {0} publish {1}".format(furi, mfpath))
-                self.image_create(furi)
-                self.pkg("contents -rm multihash")
-                # The default case.
-                if sha512_supported:
-                        self.assertTrue("pkg.content-hash=file:sha512t_256"
-                            in self.output)
-                else:
-                        self.assertTrue("pkg.content-hash=file:sha256"
-                            in self.output)
+""".format(
+                    payload, hash_alg
+                )
+            )
+        self.pkgsend("", "-s {0} publish {1}".format(furi, mfpath))
+        self.image_create(furi)
+        self.pkg("contents -rm multihash")
+        # The default case.
+        if sha512_supported:
+            self.assertTrue("pkg.content-hash=file:sha512t_256" in self.output)
+        else:
+            self.assertTrue("pkg.content-hash=file:sha256" in self.output)
 
-                # "sha1 + hash_alg" case.
-                self.pkgsend("", "-s {0} publish {1}".format(furi, mfpath),
-                    debug_hash="sha1+{0}".format(hash_alg))
-                self.pkg("refresh")
+        # "sha1 + hash_alg" case.
+        self.pkgsend(
+            "",
+            "-s {0} publish {1}".format(furi, mfpath),
+            debug_hash="sha1+{0}".format(hash_alg),
+        )
+        self.pkg("refresh")
 
-                self.pkg("contents -rm multihash")
-                self.assertTrue("pkg.content-hash=file:{0}".format(
-                    hash_alg in self.output))
-                self.assertTrue("pkg.hash.rot13=caesar" in self.output)
+        self.pkg("contents -rm multihash")
+        self.assertTrue(
+            "pkg.content-hash=file:{0}".format(hash_alg in self.output)
+        )
+        self.assertTrue("pkg.hash.rot13=caesar" in self.output)
 
-                # hash_alg case.
-                self.pkgsend("", "-s {0} publish {1}".format(furi, mfpath),
-                    debug_hash="{0}".format(hash_alg))
-                self.pkg("refresh")
+        # hash_alg case.
+        self.pkgsend(
+            "",
+            "-s {0} publish {1}".format(furi, mfpath),
+            debug_hash="{0}".format(hash_alg),
+        )
+        self.pkg("refresh")
 
-                self.pkg("contents -rm multihash")
-                self.assertTrue("pkg.content-hash=file:{0}".format(
-                    hash_alg in self.output))
+        self.pkg("contents -rm multihash")
+        self.assertTrue(
+            "pkg.content-hash=file:{0}".format(hash_alg in self.output)
+        )
 
-        def test_27_ownership(self):
-                """Test whether the ownership of the file will change if the
-                ownership flag is set during the manifest generation."""
+    def test_27_ownership(self):
+        """Test whether the ownership of the file will change if the
+        ownership flag is set during the manifest generation."""
 
-                rootdir = self.test_root
-                src_dir = os.path.join(rootdir, "foo")
-                url = self.dc.get_depot_url()
+        rootdir = self.test_root
+        src_dir = os.path.join(rootdir, "foo")
+        url = self.dc.get_depot_url()
 
-                # Build a file tree under each source directory to test
-                # import and generate functionality.  Tree should look like:
-                #   src-foo/
-                #       file-foo
-                #       dir-foo/
-                #           subfile-foo
-                #           subdir-foo/
-                #               subdirfile-foo
-                cwd = os.getcwd()
-                # Final component used as part of name for all entries.
-                name = os.path.basename(src_dir)
+        # Build a file tree under each source directory to test
+        # import and generate functionality.  Tree should look like:
+        #   src-foo/
+        #       file-foo
+        #       dir-foo/
+        #           subfile-foo
+        #           subdir-foo/
+        #               subdirfile-foo
+        cwd = os.getcwd()
+        # Final component used as part of name for all entries.
+        name = os.path.basename(src_dir)
 
-                # File at top level in source directory.
-                top_file = os.path.join(src_dir, "file-{0}".format(name))
-                self.make_misc_files(os.path.relpath(top_file, src_dir),
-                    prefix=name, mode=0o644)
+        # File at top level in source directory.
+        top_file = os.path.join(src_dir, "file-{0}".format(name))
+        self.make_misc_files(
+            os.path.relpath(top_file, src_dir), prefix=name, mode=0o644
+        )
 
-                top_dir = os.path.join(src_dir, "dir-{0}".format(name))
-                os.mkdir(top_dir, 0o755)
+        top_dir = os.path.join(src_dir, "dir-{0}".format(name))
+        os.mkdir(top_dir, 0o755)
 
-                # File in top_dir.
-                top_dir_file = os.path.join(top_dir,
-                    "subfile-{0}".format(name))
-                self.make_misc_files(os.path.relpath(top_dir_file,
-                    src_dir), prefix=name, mode=0o444)
+        # File in top_dir.
+        top_dir_file = os.path.join(top_dir, "subfile-{0}".format(name))
+        self.make_misc_files(
+            os.path.relpath(top_dir_file, src_dir), prefix=name, mode=0o444
+        )
 
-                # Directory in top_dir.
-                sub_dir = os.path.join(top_dir, "subdir-{0}".format(name))
-                os.mkdir(sub_dir, 0o750)
+        # Directory in top_dir.
+        sub_dir = os.path.join(top_dir, "subdir-{0}".format(name))
+        os.mkdir(sub_dir, 0o750)
 
-                # File in sub_dir.
-                sub_dir_file = os.path.join(sub_dir,
-                    "subdirfile-{0}".format(name))
-                self.make_misc_files(os.path.relpath(sub_dir_file,
-                    src_dir), prefix=name, mode=0o400)
+        # File in sub_dir.
+        sub_dir_file = os.path.join(sub_dir, "subdirfile-{0}".format(name))
+        self.make_misc_files(
+            os.path.relpath(sub_dir_file, src_dir), prefix=name, mode=0o400
+        )
 
-                # Change ownership.
-                owner_id, group_id =  pkg5unittest.get_su_wrap_user(uid_gid = True)
-                for root, folders, files in os.walk(src_dir):
-                        os.chown(root, owner_id, group_id)
-                        for f in files:
-                                os.chown(os.path.join(root,f), owner_id,
-                                    group_id)
+        # Change ownership.
+        owner_id, group_id = pkg5unittest.get_su_wrap_user(uid_gid=True)
+        for root, folders, files in os.walk(src_dir):
+            os.chown(root, owner_id, group_id)
+            for f in files:
+                os.chown(os.path.join(root, f), owner_id, group_id)
 
-                rc, actual = self.pkgsend(url, "generate -u {0}".format(src_dir))
+        rc, actual = self.pkgsend(url, "generate -u {0}".format(src_dir))
 
-                # Pre-generated result used for package validation.
-                owner = pwd.getpwuid(owner_id).pw_name
-                group = grp.getgrgid(group_id).gr_name
-                expected = """\
+        # Pre-generated result used for package validation.
+        owner = pwd.getpwuid(owner_id).pw_name
+        group = grp.getgrgid(group_id).gr_name
+        expected = """\
 dir group={group} mode=0755 owner={owner} path=dir-foo
 file file-foo group={group} mode=0644 owner={owner} path=file-foo
 dir group={group} mode=0750 owner={owner} path=dir-foo/subdir-foo
 file dir-foo/subfile-foo group={group} mode=0444 owner={owner} path=dir-foo/subfile-foo
 file dir-foo/subdir-foo/subdirfile-foo group={group} mode=0400 owner={owner} \
 path=dir-foo/subdir-foo/subdirfile-foo\n""".format(
-                        owner=owner, group=group)
+            owner=owner, group=group
+        )
 
-                self.assertEqualDiff(self.reduceSpaces(expected),
-                    self.reduceSpaces(actual))
+        self.assertEqualDiff(
+            self.reduceSpaces(expected), self.reduceSpaces(actual)
+        )
 
-        def test_28_content_attrs(self):
-                """Ensure that content-related attributes are ignored for
-                'pgksend publish'."""
+    def test_28_content_attrs(self):
+        """Ensure that content-related attributes are ignored for
+        'pgksend publish'."""
 
-                mfpath = os.path.join(self.test_root, "content-attrs.p5m")
-                with open(mfpath, "w") as mf:
-                        mf.write("""\
+        mfpath = os.path.join(self.test_root, "content-attrs.p5m")
+        with open(mfpath, "w") as mf:
+            mf.write(
+                """\
 set name=pkg.fmri value=pkg://test/content-attrs@1.0
 file elftest.so.1 mode=0755 owner=root group=bin path=bin/true pkg.size=ignored pkg.csize=ignored elfhash=ignored elfbits=ignored elfarch=ignored pkg.content-hash=ignored
-""")
+"""
+            )
 
-                # Verify pkgsend publish can be performed even though values for
-                # content-related attributes are invalid.  They should be
-                # forcibly dropped and added back.
-                ret, pfmri = self.pkgsend(self.dc.get_depot_url(),
-                    "publish -d {0} {1}".format(self.ro_data_root, mfpath))
+        # Verify pkgsend publish can be performed even though values for
+        # content-related attributes are invalid.  They should be
+        # forcibly dropped and added back.
+        ret, pfmri = self.pkgsend(
+            self.dc.get_depot_url(),
+            "publish -d {0} {1}".format(self.ro_data_root, mfpath),
+        )
 
-                # Now get the actual manifest and ensure all attributes were
-                # overwritten.
-                repo = self.dc.get_repo()
-                rmpath = repo.manifest(pfmri)
-                rm = manifest.Manifest()
-                rm.set_content(pathname=rmpath)
-                a = list(rm.gen_actions_by_type('file'))[0]
+        # Now get the actual manifest and ensure all attributes were
+        # overwritten.
+        repo = self.dc.get_repo()
+        rmpath = repo.manifest(pfmri)
+        rm = manifest.Manifest()
+        rm.set_content(pathname=rmpath)
+        a = list(rm.gen_actions_by_type("file"))[0]
 
-                # These attributes should always match pre-determined values.
-                expected = {
-                    'elfarch': 'i386',
-                    'elfbits': '32',
-                    'group': 'bin',
-                    'mode': '0755',
-                    'owner': 'root',
-                    'path': 'bin/true',
-                    'pkg.csize': '1358',
-                    'pkg.size': '3948'
-                }
-                actual = dict(
-                    (k, v) for (k, v) in six.iteritems(a.attrs)
-                    if k in expected
-                )
-                self.assertEqualDiff(expected, actual)
+        # These attributes should always match pre-determined values.
+        expected = {
+            "elfarch": "i386",
+            "elfbits": "32",
+            "group": "bin",
+            "mode": "0755",
+            "owner": "root",
+            "path": "bin/true",
+            "pkg.csize": "1358",
+            "pkg.size": "3948",
+        }
+        actual = dict(
+            (k, v) for (k, v) in six.iteritems(a.attrs) if k in expected
+        )
+        self.assertEqualDiff(expected, actual)
 
-                # 'elfhash' and 'pkg.content-hash' can vary depending upon
-                # whether we've changed the content-hashing algorithms, so we
-                # only verify it exists and doesn't have a value of 'ignored'.
-                self.assertNotEqual(a.attrs['elfhash'], 'ignored')
-                self.assertNotEqual(a.attrs['pkg.content-hash'][0], 'ignored')
+        # 'elfhash' and 'pkg.content-hash' can vary depending upon
+        # whether we've changed the content-hashing algorithms, so we
+        # only verify it exists and doesn't have a value of 'ignored'.
+        self.assertNotEqual(a.attrs["elfhash"], "ignored")
+        self.assertNotEqual(a.attrs["pkg.content-hash"][0], "ignored")
 
 
 class TestPkgsendHardlinks(pkg5unittest.CliTestCase):
+    def test_bundle_dir_hardlinks(self):
+        """Verify that hardlink targeting works correctly."""
 
-        def test_bundle_dir_hardlinks(self):
-                """Verify that hardlink targeting works correctly."""
+        rootdir = os.path.join(self.test_root, "bundletest")
 
-                rootdir = os.path.join(self.test_root, "bundletest")
+        def diffmf(src, dst):
+            added, changed, removed = src.difference(dst)
 
-                def diffmf(src, dst):
-                        added, changed, removed = src.difference(dst)
+            # Strip all attributes from file actions other than path
+            for aa in added + changed + removed:
+                for a in aa:
+                    if a and a.name in ("file", "dir"):
+                        a.attrs = {"path": a.attrs["path"]}
 
-                        # Strip all attributes from file actions other than path
-                        for aa in added + changed + removed:
-                                for a in aa:
-                                        if a and a.name in ("file", "dir"):
-                                                a.attrs = {
-                                                    "path": a.attrs["path"]
-                                                }
+            # Re-do the difference to eliminate actions, if the
+            # above changed anything:
+            added, changed, removed = src.difference(dst)
 
-                        # Re-do the difference to eliminate actions, if the
-                        # above changed anything:
-                        added, changed, removed = src.difference(dst)
+            res = []
+            for a1, a2 in added:
+                res.append("+ {0}".format(a2))
+            for a1, a2 in changed:
+                res.append("- {0}".format(a1))
+                res.append("+ {0}".format(a2))
+            for a1, a2 in removed:
+                res.append("- {0}".format(a1))
 
-                        res = []
-                        for a1, a2 in added:
-                                res.append("+ {0}".format(a2))
-                        for a1, a2 in changed:
-                                res.append("- {0}".format(a1))
-                                res.append("+ {0}".format(a2))
-                        for a1, a2 in removed:
-                                res.append("- {0}".format(a1))
+            return "\n".join(res)
 
-                        return "\n".join(res)
+        def dirlist(dir):
+            l = [dir]
+            while dir:
+                dir = os.path.dirname(dir)
+                l.append(dir)
+            return l
 
-                def dirlist(dir):
-                        l = [dir]
-                        while dir:
-                                dir = os.path.dirname(dir)
-                                l.append(dir)
-                        return l
+        def do_test(*pathnames):
+            self.debug("=" * 70)
+            self.debug(
+                "Testing: {0}".format(
+                    pathnames,
+                )
+            )
+            for i in range(len(pathnames)):
+                l = list(pathnames)
+                p = l.pop(i)
+                do_test_one(p, l)
 
-                def do_test(*pathnames):
-                        self.debug("=" * 70)
-                        self.debug("Testing: {0}".format(pathnames,))
-                        for i in range(len(pathnames)):
-                                l = list(pathnames)
-                                p = l.pop(i)
-                                do_test_one(p, l)
+        def do_test_one(target, links):
+            self.debug("-" * 70)
+            self.debug("Testing: {0} {1}".format(target, links))
+            tpath = self.make_misc_files(target, rootdir)[0]
+            expected_mf = "file {0} path={1}\n".format(target, target)
+            dirs = set()
 
-                def do_test_one(target, links):
-                        self.debug("-" * 70)
-                        self.debug("Testing: {0} {1}".format(target, links))
-                        tpath = self.make_misc_files(target, rootdir)[0]
-                        expected_mf = "file {0} path={1}\n".format(target, target)
-                        dirs = set()
+            # Iterate over the links, creating them and adding them
+            # to the expected manifest.
+            for link in links:
+                lpath = os.path.join(rootdir, link)
+                ldir = os.path.dirname(lpath)
+                if not os.path.exists(ldir):
+                    os.makedirs(ldir)
+                os.link(tpath, lpath)
+                expected_mf += "hardlink path={0} target={1}\n".format(
+                    link, os.path.relpath(tpath, ldir)
+                )
+                # Add the directories implied by the link
+                dirs.update(dirlist(os.path.dirname(link)))
 
-                        # Iterate over the links, creating them and adding them
-                        # to the expected manifest.
-                        for link in links:
-                                lpath = os.path.join(rootdir, link)
-                                ldir = os.path.dirname(lpath)
-                                if not os.path.exists(ldir):
-                                        os.makedirs(ldir)
-                                os.link(tpath, lpath)
-                                expected_mf += "hardlink path={0} target={1}\n".format(
-                                    link, os.path.relpath(tpath, ldir))
-                                # Add the directories implied by the link
-                                dirs.update(dirlist(os.path.dirname(link)))
+            # Add the directories implied by the target
+            dirs.update(dirlist(os.path.dirname(target)))
+            dirs.discard("")
+            dirs.discard(".")
+            for d in dirs:
+                expected_mf += "dir path={0}\n".format(d)
 
-                        # Add the directories implied by the target
-                        dirs.update(dirlist(os.path.dirname(target)))
-                        dirs.discard(""); dirs.discard(".")
-                        for d in dirs:
-                                expected_mf += "dir path={0}\n".format(d)
+            self.debug("EXPECTED:\n" + expected_mf + 40 * "=")
 
-                        self.debug("EXPECTED:\n" + expected_mf + 40 * "=")
+            # Generate the manifest
+            targetargs = "".join(("--target {0} ".format(t) for t in [target]))
+            rc, out = self.pkgsend(command="generate " + targetargs + rootdir)
 
-                        # Generate the manifest
-                        targetargs = "".join(("--target {0} ".format(t) for t in
-                            [target]))
-                        rc, out = self.pkgsend(command="generate " +
-                            targetargs + rootdir)
+            # Create manifest objects
+            genmf = manifest.Manifest()
+            genmf.set_content(out)
+            cmpmf = manifest.Manifest()
+            cmpmf.set_content(expected_mf)
 
-                        # Create manifest objects
-                        genmf = manifest.Manifest()
-                        genmf.set_content(out)
-                        cmpmf = manifest.Manifest()
-                        cmpmf.set_content(expected_mf)
+            # Run the differ
+            diffs = diffmf(genmf, cmpmf)
 
-                        # Run the differ
-                        diffs = diffmf(genmf, cmpmf)
+            # Print and fail if there are any diffs
+            if diffs:
+                self.debug(diffs)
+                self.fail("YOU FAIL")
 
-                        # Print and fail if there are any diffs
-                        if diffs:
-                                self.debug(diffs)
-                                self.fail("YOU FAIL")
+            # Remove the tree before starting over
+            shutil.rmtree(rootdir)
 
-                        # Remove the tree before starting over
-                        shutil.rmtree(rootdir)
+        # Target and link in the same directory
+        do_test("f1", "f2")
 
-                # Target and link in the same directory
-                do_test("f1", "f2")
+        # Target and link in the same directory, one level down
+        do_test("d1/f1", "d1/f2")
 
-                # Target and link in the same directory, one level down
-                do_test("d1/f1", "d1/f2")
+        # Target and link in different directories, at the same level
+        do_test("d1/f1", "d2/f2")
 
-                # Target and link in different directories, at the same level
-                do_test("d1/f1", "d2/f2")
+        # Target and link at different levels
+        do_test("d1/f1", "f2")
 
-                # Target and link at different levels
-                do_test("d1/f1", "f2")
+        # Just the reverse
+        do_test("f1", "d1/f2")
 
-                # Just the reverse
-                do_test("f1", "d1/f2")
+        # Target and link at different levels, one level lower
+        do_test("d1/f1", "d2/d3/f2")
 
-                # Target and link at different levels, one level lower
-                do_test("d1/f1", "d2/d3/f2")
+        # Target and link at different levels, two levels apart
+        do_test("d1/f1", "d2/d3/d4/f2")
 
-                # Target and link at different levels, two levels apart
-                do_test("d1/f1", "d2/d3/d4/f2")
-
-                # Two links in the same directory as the target
-                do_test("f1", "f2", "f3")
-                do_test("d1/f1", "d1/f2", "f3")
-                do_test("d1/f1", "d1/f2", "d2/f3")
+        # Two links in the same directory as the target
+        do_test("f1", "f2", "f3")
+        do_test("d1/f1", "d1/f2", "f3")
+        do_test("d1/f1", "d1/f2", "d2/f3")
 
 
 class TestPkgsendHTTPS(pkg5unittest.HTTPSTestClass):
+    misc_files = ["tmp/empty", "tmp/verboten"]
 
-        misc_files = ["tmp/empty", "tmp/verboten"]
+    def setUp(self):
+        pub = "test"
 
-        def setUp(self):
-                pub = "test"
+        pkg5unittest.HTTPSTestClass.setUp(self, [pub], start_depots=True)
 
-                pkg5unittest.HTTPSTestClass.setUp(self, [pub],
-                    start_depots=True)
+        self.url = self.ac.url + "/{0}".format(pub)
+        self.make_misc_files(self.misc_files)
+        # set permissions of tmp/verboten to make it non-readable
+        self.verboten = os.path.join(self.test_root, "tmp/verboten")
+        os.system("chmod 600 {0}".format(self.verboten))
 
-                self.url = self.ac.url + "/{0}".format(pub)
-                self.make_misc_files(self.misc_files)
-                #set permissions of tmp/verboten to make it non-readable
-                self.verboten = os.path.join(self.test_root, "tmp/verboten")
-                os.system("chmod 600 {0}".format(self.verboten))
+    def test_01_basics(self):
+        """Test that publishing to an SSL-secured repo works"""
 
-        def test_01_basics(self):
-                """Test that publishing to an SSL-secured repo works"""
+        self.ac.start()
 
-                self.ac.start()
-
-                rootdir = self.test_root
-                dir_1 = os.path.join(rootdir, "dir_1")
-                os.mkdir(dir_1)
-                open(os.path.join(dir_1, "A"), "w").close()
-                open(os.path.join(dir_1, "B"), "w").close()
-                mfpath = os.path.join(rootdir, "manifest_test")
-                with open(mfpath, "w") as mf:
-                        mf.write("""file NOHASH mode=0755 owner=root group=bin path=/A
+        rootdir = self.test_root
+        dir_1 = os.path.join(rootdir, "dir_1")
+        os.mkdir(dir_1)
+        open(os.path.join(dir_1, "A"), "w").close()
+        open(os.path.join(dir_1, "B"), "w").close()
+        mfpath = os.path.join(rootdir, "manifest_test")
+        with open(mfpath, "w") as mf:
+            mf.write(
+                """file NOHASH mode=0755 owner=root group=bin path=/A
                             file NOHASH mode=0755 owner=root group=bin path=/B
                             set name=pkg.fmri value=httpstest@1.0,5.10
-                            """)
+                            """
+            )
 
-                arg_dict = {
-                    "cert": os.path.join(self.cs_dir, self.get_cli_cert("test")),
-                    "key": os.path.join(self.keys_dir, self.get_cli_key("test")),
-                    "url": self.url,
-                    "dir": dir_1,
-                    "mani": mfpath,
-                    "empty": os.path.join(self.test_root, "tmp/empty"),
-                    "noexist": os.path.join(self.test_root, "octopus"),
-                    "verboten": self.verboten,
+        arg_dict = {
+            "cert": os.path.join(self.cs_dir, self.get_cli_cert("test")),
+            "key": os.path.join(self.keys_dir, self.get_cli_key("test")),
+            "url": self.url,
+            "dir": dir_1,
+            "mani": mfpath,
+            "empty": os.path.join(self.test_root, "tmp/empty"),
+            "noexist": os.path.join(self.test_root, "octopus"),
+            "verboten": self.verboten,
+        }
 
-                }
+        # We need an image for seed_ta_dir() to work.
+        # TODO: there might be a cleaner way of doing this
+        self.image_create()
+        # Add the trust anchor needed to verify the server's identity.
+        self.seed_ta_dir("ta7")
 
-                # We need an image for seed_ta_dir() to work.
-                # TODO: there might be a cleaner way of doing this
-                self.image_create()
-                # Add the trust anchor needed to verify the server's identity.
-                self.seed_ta_dir("ta7")
+        # Try to publish a simple package to SSL-secured repo
+        self.pkgsend(
+            self.url,
+            "publish --key {key} --cert {cert} "
+            "-d {dir} {mani}".format(**arg_dict),
+        )
 
-                # Try to publish a simple package to SSL-secured repo
-                self.pkgsend(self.url, "publish --key {key} --cert {cert} "
-                    "-d {dir} {mani}".format(**arg_dict))
+        # Try to publish a simple package to SSL-secured repo without
+        # prvoviding certs (should fail).
+        self.pkgsend(
+            self.url, "publish -d {dir} {mani}".format(**arg_dict), exit=1
+        )
 
-                # Try to publish a simple package to SSL-secured repo without
-                # prvoviding certs (should fail).
-                self.pkgsend(self.url, "publish -d {dir} {mani}".format(**arg_dict),
-                    exit=1)
+        # Make sure we don't traceback when credential files are invalid
+        # Certificate option missing
+        self.pkgsend(
+            self.url,
+            "publish --key {key} " "-d {dir} {mani}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Make sure we don't traceback when credential files are invalid
-                # Certificate option missing
-                self.pkgsend(self.url, "publish --key {key} "
-                    "-d {dir} {mani}".format(**arg_dict), exit=1)
+        # Key option missing
+        self.pkgsend(
+            self.url,
+            "publish --cert {cert} " "-d {dir} {mani}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Key option missing
-                self.pkgsend(self.url, "publish --cert {cert} "
-                    "-d {dir} {mani}".format(**arg_dict), exit=1)
+        # Certificate not found
+        self.pkgsend(
+            self.url,
+            "publish --key {key} "
+            "--cert {noexist} -d {dir} {mani}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Certificate not found
-                self.pkgsend(self.url, "publish --key {key} "
-                    "--cert {noexist} -d {dir} {mani}".format(**arg_dict), exit=1)
+        # Key not found
+        self.pkgsend(
+            self.url,
+            "publish --key {noexist} "
+            "--cert {cert} -d {dir} {mani}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Key not found
-                self.pkgsend(self.url, "publish --key {noexist} "
-                    "--cert {cert} -d {dir} {mani}".format(**arg_dict), exit=1)
+        # Certificate is empty file
+        self.pkgsend(
+            self.url,
+            "publish --key {key} --cert {empty} "
+            "-d {dir} {mani}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Certificate is empty file
-                self.pkgsend(self.url, "publish --key {key} --cert {empty} "
-                    "-d {dir} {mani}".format(**arg_dict), exit=1)
+        # Key is empty file
+        self.pkgsend(
+            self.url,
+            "publish --key {empty} "
+            "--cert {cert} -d {dir} {mani}".format(**arg_dict),
+            exit=1,
+        )
 
-                # Key is empty file
-                self.pkgsend(self.url, "publish --key {empty} "
-                    "--cert {cert} -d {dir} {mani}".format(**arg_dict), exit=1)
+        # No permissions to read certificate
+        self.pkgsend(
+            self.url,
+            "publish --key {key} "
+            "--cert {verboten} -d {dir} {mani}".format(**arg_dict),
+            su_wrap=True,
+            exit=1,
+        )
 
-                # No permissions to read certificate
-                self.pkgsend(self.url, "publish --key {key} "
-                    "--cert {verboten} -d {dir} {mani}".format(**arg_dict),
-                    su_wrap=True, exit=1)
-
-                # No permissions to read key
-                self.pkgsend(self.url, "publish --key {verboten} "
-                    "--cert {cert} -d {dir} {mani}".format(**arg_dict),
-                    su_wrap=True, exit=1)
+        # No permissions to read key
+        self.pkgsend(
+            self.url,
+            "publish --key {verboten} "
+            "--cert {cert} -d {dir} {mani}".format(**arg_dict),
+            su_wrap=True,
+            exit=1,
+        )
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgsign.py
+++ b/src/tests/cli/t_pkgsign.py
@@ -26,8 +26,9 @@
 
 from __future__ import print_function
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -54,10 +55,11 @@ from pkg.client.debugvalues import DebugValues
 from pkg.pkggzip import PkgGzipFile
 
 try:
-        import pkg.sha512_t
-        sha512_supported = True
+    import pkg.sha512_t
+
+    sha512_supported = True
 except ImportError:
-        sha512_supported = False
+    sha512_supported = False
 
 obsolete_pkg = """
     open obs@1.0,5.11-0
@@ -73,10 +75,10 @@ renamed_pkg = """
 
 
 class TestPkgSign(pkg5unittest.SingleDepotTestCase):
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        example_pkg10 = """
+    example_pkg10 = """
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
@@ -91,32 +93,32 @@ class TestPkgSign(pkg5unittest.SingleDepotTestCase):
             add set name='weirdness' value='] [ * ?'
             close """
 
-        example_pkg20 = """
+    example_pkg20 = """
             open example_pkg@2.0,5.11-0
             close """
 
-        varsig_pkg = """
+    varsig_pkg = """
             open example_pkg@1.0,5.15-0
             add set name=variant.arch value=sparc value=i386
             add dir mode=0755 owner=root group=bin path=/bin
             add signature tmp/example_file value=d2ff algorithm=sha256 variant.arch=i386
             close """
 
-        var_pkg = """
+    var_pkg = """
             open var_pkg@1.0,5.11-0
             add set name=variant.arch value=sparc value=i386
             add dir mode=0755 owner=root group=bin path=/bin variant.arch=sparc
             add dir mode=0755 owner=root group=bin path=/baz variant.arch=i386
             close """
 
-        facet_pkg = """
+    facet_pkg = """
             open facet_pkg@1.0,5.11-0
             add set name=variant.arch value=sparc value=i386
             add file tmp/example_file mode=0444 owner=root group=bin path=usr/share/doc/i386_doc.txt facet.doc=true variant.arch=i386
             add file tmp/example_file mode=0444 owner=root group=bin path=usr/share/doc/sparc_devel.txt facet.devel=true variant.arch=sparc
             close """
 
-        med_pkg = """
+    med_pkg = """
             open med_pkg@1.0,5.11-0
             add file tmp/example_file mode=0755 owner=root group=bin path=/bin/example-1.6
             add file tmp/example_file mode=0755 owner=root group=bin path=/bin/example-1.7
@@ -124,7 +126,7 @@ class TestPkgSign(pkg5unittest.SingleDepotTestCase):
             add link path=bin/example target=bin/example-1.7 mediator=example mediator-version=1.7
             close """
 
-        conflict_pkgs = """
+    conflict_pkgs = """
             open conflict_a_pkg@1.0,5.11-0
             add file tmp/example_file mode=0444 owner=root group=root path=etc/release
             close
@@ -132,2760 +134,3048 @@ class TestPkgSign(pkg5unittest.SingleDepotTestCase):
             add file tmp/example_file2 mode=0444 owner=root group=root path=etc/release
             close """
 
-        need_renamed_pkg = """
+    need_renamed_pkg = """
             open need_renamed@1.0,5.11-0
             add depend fmri=renamed type=require
             close """
 
-        pub2_example = """
+    pub2_example = """
             open pkg://pub2/example_pkg@1.0,5.11-0
             add set description='a package with an alternate publisher'
             close """
 
-        pub2_pkg = """
+    pub2_pkg = """
             open pkg://pub2/pub2pkg@1.0,5.11-0
             add set description='a package with an alternate publisher'
             close """
 
-        bug_18880_pkg = """
+    bug_18880_pkg = """
             open b18880@1.0,5.11-0
             add file tmp/example_file mode=0555 owner=root group=bin path=bin/example_path variant.foo=bar
             add file tmp/example_file2 mode=0555 owner=root group=bin path=bin/example_path variant.foo=baz
             close"""
 
-        image_files = ['simple_file']
-        misc_files = ['tmp/example_file', 'tmp/example_file2']
-
-        def pkg(self, command, *args, **kwargs):
-                # The value for crl_host is pulled from DebugValues because
-                # crl__host needs to be set there so the api object calls work
-                # as desired.
-                command = "--debug crl_host={0} {1}".format(
-                    DebugValues["crl_host"], command)
-                return pkg5unittest.SingleDepotTestCase.pkg(self, command,
-                    *args, **kwargs)
-
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self, image_count=2)
-                self.make_misc_files(self.misc_files)
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.rurl1 = self.dcs[1].get_repo_url()
-                DebugValues["crl_host"] = self.durl1
-
-        def test_sign_0(self):
-                """Test that packages signed with hashes only work correctly."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                # Test that things work with unsigned packages.
-                self.image_create(self.rurl1)
-
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy ignore")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Tests that the cli handles RequiredSignaturePolicyExceptions.
-                self.pkg("install example_pkg", exit=1)
-                self.pkg("set-property signature-policy require-names foo")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.MissingRequiredNamesException,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Tests that the cli handles MissingRequiredNamesException.
-                self.pkg("install example_pkg", exit=1)
-
-                self.pkg("unset-property signature-policy")
-
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-publisher --set-property signature-policy=verify "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-publisher "
-                    "--set-property signature-policy=require-signatures test")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["example_pkg"])
-                self.pkg("set-publisher "
-                    "--set-property signature-policy=require-names "
-                    "--set-property signature-required-names=foo test")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.MissingRequiredNamesException,
-                    self._api_install, api_obj, ["example_pkg"])
-
-                self.pkgsign(self.rurl1, plist[0])
-                self.image_destroy()
-                self.image_create(self.rurl1)
-
-                # Test that things work hashes instead of signatures.
-                self.pkg("refresh --full")
-
-                self.pkg("set-publisher --unset-property signature-policy "
-                    "--unset-property signature-required-names test")
-
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self.pkg("search -l sha256")
-                self._api_uninstall(api_obj, ["example_pkg"])
-
-                self.pkg("set-property signature-policy ignore")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-names foo")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.MissingRequiredNamesException,
-                    self._api_install, api_obj, ["example_pkg"])
-
-                self.pkg("unset-property signature-policy")
-
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-publisher --set-property signature-policy=verify "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-publisher --set-property "
-                    "signature-policy=require-signatures test")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["example_pkg"])
-                self.pkg("set-publisher "
-                    "--set-property signature-policy=require-names "
-                    "--set-property signature-required-names=foo test")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.MissingRequiredNamesException,
-                    self._api_install, api_obj, ["example_pkg"])
-
-        def test_sign_1(self):
-                """Test that packages signed using private keys function
-                correctly.  Uses a chain of certificates three certificates
-                long."""
-
-                chain_cert_path = os.path.join(self.chain_certs_dir,
-                    "ch1_ta3_cert.pem")
-                ta_cert_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta3_cert.pem")
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {ch1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        ch1=chain_cert_path
-                )
-                td = os.environ["TMPDIR"]
-                sd = os.path.join(td, "tmp_sign")
-                os.makedirs(sd)
-                os.environ["TMPDIR"] = sd
-
-                # Specify location as filesystem path.
-                self.pkgsign(self.dc.get_repodir(), sign_args)
-
-                # Ensure that all temp files from signing have been removed.
-                self.assertEqual(os.listdir(sd), [])
-                os.environ["TMPDIR"] = td
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                # Find the hash of the publisher CA cert used.
-                hsh = self.calc_pem_hash(chain_cert_path)
-
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self.pkg("search -l rsa-sha256")
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy ignore")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-
-                emptyCA = os.path.join(self.img_path(), "emptyCA")
-                os.makedirs(emptyCA)
-                self.pkg("set-property trust-anchor-directory emptyCA")
-                # This should fail because the chain is rooted in an untrusted
-                # self-signed cert.
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.BrokenChain, self._api_install, api_obj,
-                    ["example_pkg"])
-                # Test that the cli handles BrokenChain exceptions.
-                self.pkg("install example_pkg", exit=1)
-                # Now seed the emptyCA directory to test that certs can be
-                # pulled from it correctly.
-                self.seed_ta_dir("ta3", dest_dir=emptyCA)
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-names foo")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.MissingRequiredNamesException,
-                    self._api_install, api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy "
-                    "require-names 'cs1_ch1_ta3'")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("add-property-value signature-required-names "
-                    "'ch1_ta3'")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("remove-property-value signature-required-names "
-                    "'cs1_ch1_ta3'")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-
-                # Test setting publisher level policies.
-                self.pkg("unset-property signature-policy")
-
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-publisher --set-property signature-policy=verify "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-publisher "
-                    "--set-property signature-policy=require-signatures test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-publisher "
-                    "--set-property signature-policy=require-names "
-                    "--set-property signature-required-names='cs1_ch1_ta3' "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-publisher --add-property-value "
-                    "signature-required-names='ch1_ta3' test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-publisher --remove-property-value "
-                    "signature-required-names='cs1_ch1_ta3' test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-publisher --add-property-value "
-                    "signature-required-names='foo' test")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.MissingRequiredNamesException,
-                    self._api_install, api_obj, ["example_pkg"])
-                self.pkg("set-publisher --remove-property-value "
-                    "signature-required-names='foo' test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-
-                # Test combining publisher and image require-names policies.
-                self.pkg("set-property signature-policy require-names foo")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.MissingRequiredNamesException,
-                    self._api_install, api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-names "
-                    "ch1_ta3")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("unset-property signature-policy")
-
-                # Test removing and adding chain certs
-                self.pkg("set-publisher --set-property signature-policy=verify "
-                    "test")
-                self.pkg("set-publisher --revoke-ca-cert={0} test".format(hsh))
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.BrokenChain, self._api_install, api_obj,
-                    ["example_pkg"])
-                self.pkg("set-publisher --approve-ca-cert={0} test".format(
-                    chain_cert_path))
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self.pkg("set-publisher --revoke-ca-cert={0} test".format(hsh))
-                self.pkg("verify", exit=1)
-                self.pkg("fix", exit=1)
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                # These should fail because the image, though not the publisher
-                # verifies signatures.
-                self.pkg("set-property signature-policy verify")
-                self.pkg("verify", exit=1)
-                self.pkg("fix", exit=1)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("verify")
-                self.pkg("fix", exit=4)
-                self.pkg("set-publisher --set-property signature-policy=verify "
-                    "test")
-                # These should fail because the publisher, though not the image
-                # verifies signatures.
-                self.pkg("verify", exit=1)
-                self.pkg("fix", exit=1)
-                self.pkg("set-publisher --approve-ca-cert={0} test".format(
-                    chain_cert_path))
-                self.pkg("verify")
-                self.pkg("fix", exit=4)
-                api_obj = self.get_img_api_obj()
-                self._api_uninstall(api_obj, ["example_pkg"])
-
-                # Test that manually approving a trust anchor works.
-                self.pkg("set-publisher --unset-ca-cert={0} test".format(hsh))
-                self.pkg("set-publisher --approve-ca-cert={0} test".format(
-                    ta_cert_path))
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_sign_2(self):
-                """Test that verification of the CS cert failing means the
-                install fails."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"))
-
-                # Specify repository location as relative path.
-                cwd = os.getcwd()
-                repodir = self.dc.get_repodir()
-                os.chdir(os.path.dirname(repodir))
-                self.pkgsign(os.path.basename(repodir), sign_args)
-                os.chdir(cwd)
-
-                self.image_create(self.rurl1)
-                self.pkg("set-property signature-policy verify")
-
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.BrokenChain, self._api_install, api_obj,
-                    ["example_pkg"])
-
-        def test_sign_3(self):
-                """Test that using a chain seven certificates long works.  It
-                also tests that having an extra chain certificate doesn't break
-                anything."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} -i {i6} {pkg}".format(**{
-                      "key": os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      "cert": os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      "i1": os.path.join(self.chain_certs_dir,
-                          "ch1_ta1_cert.pem"),
-                      "i2": os.path.join(self.chain_certs_dir,
-                          "ch2_ta1_cert.pem"),
-                      "i3": os.path.join(self.chain_certs_dir,
-                          "ch3_ta1_cert.pem"),
-                      "i4": os.path.join(self.chain_certs_dir,
-                          "ch4_ta1_cert.pem"),
-                      "i5": os.path.join(self.chain_certs_dir,
-                          "ch5_ta1_cert.pem"),
-                      "i6": os.path.join(self.chain_certs_dir,
-                          "ch1_ta3_cert.pem"),
-                      "pkg": plist[0]
-                    })
-
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta1")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_multiple_signatures(self):
-                """Test that having a package signed with more than one
-                signature doesn't cause anything to break."""
-
-                self.base_multiple_signatures("sha256")
-                if sha512_supported:
-                        self.base_multiple_signatures("sha512t_256")
-
-        def test_no_empty_chain(self):
-                """Test that signing do not create empty chain"""
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10,
-                    debug_hash="sha1+sha512t_256")
-                sign_args = "-k {key} -c {cert} {pkg}".format(**{
-                    "key": os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                    "cert": os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
-                    "pkg": plist[0]})
-
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta2")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-                # Make sure signing haven't created empty chain attrs
-                self.pkg("contents -m")
-                self.assertTrue(self.output.count("chain=") == 0)
-
-        def base_multiple_signatures(self, hash_alg):
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} {pkg}".format(**{
-                        "key":
-                        os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                        "cert":
-                        os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                        "i1":
-                        os.path.join(self.chain_certs_dir,
-                            "ch1_ta1_cert.pem"),
-                        "i2":
-                        os.path.join(self.chain_certs_dir,
-                            "ch2_ta1_cert.pem"),
-                        "i3":
-                        os.path.join(self.chain_certs_dir,
-                            "ch3_ta1_cert.pem"),
-                        "i4":
-                        os.path.join(self.chain_certs_dir,
-                            "ch4_ta1_cert.pem"),
-                        "i5":
-                        os.path.join(self.chain_certs_dir,
-                            "ch5_ta1_cert.pem"),
-                        "pkg": plist[0]
-                    })
-                self.pkgsign(self.rurl1, sign_args,
-                    debug_hash="sha1+{0}".format(hash_alg))
-
-                sign_args = "-k {key} -c {cert} {name}".format(
-                    name=plist[0],
-                    key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                    cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"))
-
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir(["ta1", "ta2"])
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-                # Make sure we've got exactly 1 signature with SHA2 hashes
-                self.pkg("contents -m")
-                self.assertTrue(self.output.count("pkg.chain.{0}".format(hash_alg)) == 1)
-                self.assertTrue(self.output.count("pkg.chain.chashes") == 1)
-                # and SHA1 hashes on both signatures
-                self.assertTrue(self.output.count("chain=") == 1)
-                self.assertTrue(self.output.count("chain.chashes=") == 1)
-
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-names "
-                    "'cs1_ta2'")
-                self.pkg("add-property-value signature-required-names "
-                    "'ch1_ta1'")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("add-property-value signature-required-names 'foo'")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.MissingRequiredNamesException,
-                    self._api_install, api_obj, ["example_pkg"])
-
-        def test_sign_4(self):
-                """Test that not providing a needed intermediate cert makes
-                verification fail."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i2} -i {i3} "\
-                    "-i {i4} -i {i5} {pkg}".format(**{
-                        "key": os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                        "cert": os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                        "i2":
-                        os.path.join(self.chain_certs_dir,
-                            "ch2_ta1_cert.pem"),
-                        "i3":
-                        os.path.join(self.chain_certs_dir,
-                            "ch3_ta1_cert.pem"),
-                        "i4":
-                        os.path.join(self.chain_certs_dir,
-                            "ch4_ta1_cert.pem"),
-                        "i5":
-                        os.path.join(self.chain_certs_dir,
-                            "ch5_ta1_cert.pem"),
-                      "pkg": plist[0]
-                    })
-                self.pkgsign(self.rurl1, sign_args)
-                self.image_create(self.rurl1)
-                self.pkg("set-property signature-policy verify")
-
-                self.pkg("install example_pkg", exit=1)
-
-        def base_sign_5(self):
-                """Test that http repos work."""
-
-                self.dcs[1].start()
-                plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} {pkg}".format(**{
-                      "key": os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      "cert": os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      "i1": os.path.join(self.chain_certs_dir,
-                          "ch1_ta1_cert.pem"),
-                      "i2": os.path.join(self.chain_certs_dir,
-                          "ch2_ta1_cert.pem"),
-                      "i3": os.path.join(self.chain_certs_dir,
-                          "ch3_ta1_cert.pem"),
-                      "i4": os.path.join(self.chain_certs_dir,
-                          "ch4_ta1_cert.pem"),
-                      "i5": os.path.join(self.chain_certs_dir,
-                          "ch5_ta1_cert.pem"),
-                      "pkg": plist[0]
-                    })
-                self.pkgsign(self.durl1, sign_args)
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta1")
-
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_sign_5(self):
-                """Test that http repos work."""
-
-                self.base_sign_5()
-
-                # Verify that older logic of publication api works.
-                self.dcs[1].stop()
-                self.dcs[1].set_disable_ops(["manifest/1"])
-                self.base_sign_5()
-
-        def test_length_two_chains(self):
-                """Check that chains of length two work correctly."""
-
-                ta_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta2_cert.pem")
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
-                      ta=ta_path,
-                      pkg=plist[0]
-                   )
-
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-
-                self.pkg("set-property signature-policy verify")
-                # This should trigger a UntrustedSelfSignedCert error.
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.UntrustedSelfSignedCert,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Test that the cli handles an UntrustedSelfSignedCert.
-                self.pkg("install example_pkg", exit=1)
-                self.seed_ta_dir("ta2")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-names foo")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.MissingRequiredNamesException,
-                    self._api_install, api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-names "
-                    "'cs1_ta2'")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("add-property-value signature-required-names 'ta2'")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-
-        def test_length_two_chains_two(self):
-                """Check that chains of length two work correctly when the trust
-                anchor is not included as an intermediate cert."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} {pkg}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
-                      pkg=plist[0]
-                   )
-
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-
-                self.pkg("set-property signature-policy verify")
-                # This should trigger a BrokenChain error.
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.BrokenChain,
-                    self._api_install, api_obj, ["example_pkg"])
-                self.seed_ta_dir("ta2")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-names foo")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.MissingRequiredNamesException,
-                    self._api_install, api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-names "
-                    "'cs1_ta2'")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("add-property-value signature-required-names 'ta2'")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-
-        def test_variant_sigs(self):
-                """Test that variant tagged signatures are ignored."""
-                plist = self.pkgsend_bulk(self.rurl1, self.varsig_pkg)
-                self.pkg_image_create(self.rurl1)
-
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["example_pkg"])
-
-        def test_bad_opts_1(self):
-                self.pkgsign(self.durl1, "--help")
-                self.dcs[1].start()
-                self.pkgsign(self.durl1, "foo@1.2.3", exit=1)
-                self.pkgsign(self.durl1, "example_pkg", exit=1)
-                plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
-
-                # Test that not specifying a destination repository fails.
-                self.pkgsign("", "'*'", exit=2)
-
-                # Test that passing a repo that doesn't exist doesn't cause
-                # a traceback.
-                self.pkgsign("http://foobar.baz",
-                    "{name}".format(name=plist[0]), exit=1)
-
-                # Test that passing no fmris or patterns results in an error.
-                self.pkgsign(self.durl1, "", exit=2)
-
-                # Test bad sig.alg setting.
-                self.pkgsign(self.durl1, "-a foo -k {key} -c {cert} "
-                    "{name}".format(
-                      key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      name=plist[0]), exit=2)
-
-                # Test missing cert option
-                self.pkgsign(self.durl1, "-k {key} {name}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      name=plist[0]), exit=2)
-                # Test missing key option
-                self.pkgsign(self.durl1, "-c %(cert) {name}".format(
-                    cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      name=plist[0]), exit=2)
-                # Test -i with missing -c and -k
-                self.pkgsign(self.durl1, "-i {i1} {name}".format(
-                    i1=os.path.join(self.chain_certs_dir,
-                          "ch1_ta1_cert.pem"),
-                      name=plist[0]), exit=2)
-                # Test passing a cert as a key
-                self.pkgsign(self.durl1, "-c {cert} -k {cert} {name}".format(
-                    cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      name=plist[0]), exit=1)
-                # Test passing a non-existent certificate file
-                self.pkgsign(self.durl1, "-c /shouldnotexist -k {key} "
-                    "{name}".format(
-                      key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      name=plist[0]), exit=2)
-                # Test passing a non-existent key file
-                self.pkgsign(self.durl1, "-c {cert} -k /shouldnotexist "
-                    "{name}".format(
-                      cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      name=plist[0]), exit=2)
-                # Test passing a file that's not a key file as a key file
-                self.pkgsign(self.durl1, "-k {key} -c {cert} {name}".format(
-                    key=os.path.join(self.test_root, "tmp/example_file"),
-                      cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      name=plist[0]), exit=1)
-                # Test passing a non-existent file as an intermediate cert
-                self.pkgsign(self.durl1, "-k {key} -c {cert} -i {i1} "
-                    "{name}".format(
-                      key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      i1=os.path.join(self.chain_certs_dir,
-                          "shouldnot/exist"),
-                      name=plist[0]), exit=2)
-                # Test passing a directory as an intermediate cert
-                self.pkgsign(self.durl1, "-k {key} -c {cert} -i {i1} "
-                    "{name}".format(
-                      key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      i1=self.chain_certs_dir,
-                      name=plist[0]), exit=2)
-                # Test setting the signature algorithm to be one which requires
-                # a key and cert, but not passing -k or -c.
-                self.pkgsign(self.durl1, "-a rsa-sha256 {0}".format(plist[0]), exit=2)
-                # Test setting the signature algorithm to be one which does not
-                # use a key and cert, but passing -k and -c.
-                self.pkgsign(self.durl1, "-a sha256 -k {key} -c {cert} "
-                    "{name}".format(
-                      key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      name=plist[0]), exit=2)
-                # Test that signing a package using a bogus certificate fails.
-                self.pkgsign(self.durl1, "-k {key} -c {cert} {name}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      cert=os.path.join(self.test_root, "tmp/example_file"),
-                      name=plist[0]), exit =1)
-                self.pkg_image_create(self.durl1)
-                self.pkg("set-property signature-policy verify")
-                self.pkg("set-property trust-anchor-directory {0}".format(
-                    os.path.join("simple_file")))
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.InvalidPropertyValue, self._api_install,
-                    api_obj, ["example_pkg"])
-                # Test that the cli handles an InvalidPropertyValue exception.
-                self.pkg("install example_pkg", exit=1)
-
-        def test_bad_opts_2(self):
-                """Test that having a bogus trust anchor will stop install."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                self.pkgsign(self.rurl1, "-k {key} -c {cert} {name}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
-                      name=plist[0]))
-                self.pkg_image_create(self.rurl1)
-                self.pkg("set-property signature-policy verify")
-                self.pkg("set-property trust-anchor-directory {0}".format(
-                    os.path.join("simple_file")))
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.InvalidPropertyValue, self._api_install,
-                    api_obj, ["example_pkg"])
-
-        def test_dry_run_option(self):
-                """Test that -n doesn't actually sign packages."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-n -k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(additional_args=\
-                    "--set-property signature-policy=require-signatures")
-                self.seed_ta_dir("ta3")
-                self.pkg("set-publisher -p {0}".format(self.rurl1))
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["example_pkg"])
-
-        def test_multiple_hash_algs(self):
-                """Test that signing with other hash algorithms works
-                correctly."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                self.pkgsign_simple(self.rurl1, plist[0])
-
-                sign_args = "-a rsa-sha512 -k {key} -c {cert} -i {i1} " \
-                    "{name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                sign_args = "-a sha384 {name}".format(name=plist[0])
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property require-signatures verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_mismatched_sigs(self):
-                """Test that if the certificate can't validate the signature,
-                an error happens."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-
-                self.assertRaises(apx.UnverifiedSignature, self._api_install,
-                    api_obj, ["example_pkg"])
-                # Test that the cli handles an UnverifiedSignature exception.
-                self.pkg("install example_pkg", exit=1)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("unset-property signature-policy")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.UnverifiedSignature, self._api_install,
-                    api_obj, ["example_pkg"])
-
-        def test_mismatched_hashes(self):
-                """Test that if the hash signature isn't correct, an error
-                happens."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "{name}".format(name=plist[0])
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-
-                # Make sure the manifest is locally stored.
-                self.pkg("install -n example_pkg")
-                # Append an action to the manifest.
-                pfmri = fmri.PkgFmri(plist[0])
-                s = self.get_img_manifest(pfmri)
-                s += "\nset name=foo value=bar"
-                self.write_img_manifest(pfmri, s)
-
-                DebugValues["manifest_validate"] = "Never"
-
-                self.pkg("set-property signature-policy verify")
-                # This should fail because the text of manifest has changed
-                # so the hash should no longer validate.
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.UnverifiedSignature, self._api_install,
-                    api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self.pkg("unset-property signature-policy")
-                # Make sure the manifest is locally stored.
-                self.pkg("install -n example_pkg")
-                # Append an action to the manifest.
-                pfmri = fmri.PkgFmri(plist[0])
-                s = self.get_img_manifest(pfmri)
-                s += "\nset name=foo value=bar"
-                self.write_img_manifest(pfmri, s)
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.UnverifiedSignature, self._api_install,
-                    api_obj, ["example_pkg"])
-
-        def test_unknown_sig_alg(self):
-                """Test that if the certificate can't validate the signature,
-                an error happens."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                # Make sure the manifest is locally stored.
-                api_obj = self.get_img_api_obj()
-                for pd in api_obj.gen_plan_install(["example_pkg"],
-                    noexecute=True):
-                        continue
-                # Change the signature action.
-                pfmri = fmri.PkgFmri(plist[0])
-                s = self.get_img_manifest(pfmri)
-                s = s.replace("rsa-sha256", "rsa-foobar")
-                self.write_img_manifest(pfmri, s)
-
-                DebugValues["manifest_validate"] = "Never"
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["example_pkg"])
-                # This passes because 'foobar' isn't a recognized hash algorithm
-                # so the signature action is skipped.
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-
-                # Write manifest to image cache again.
-                self.write_img_manifest(pfmri, s)
-
-                # Change the signature action.
-                pfmri = fmri.PkgFmri(plist[0])
-                s = self.get_img_manifest(pfmri)
-                s = s.replace("rsa-foobar", "foo-sha256")
-                self.write_img_manifest(pfmri, s)
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["example_pkg"])
-                self.pkg("--debug manifest_validate=Never install "
-                    "example_pkg", exit=1)
-                # This passes because 'foobar' isn't a recognized signature
-                # algorithm so the signature action is skipped.
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_unsupported_critical_extension_1(self):
-                """Test that packages signed using a certificate with an
-                unsupported critical extension will not have valid signatures.
-                """
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs2_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs2_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.UnsupportedCriticalExtension,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Tests that the cli can handle an UnsupportedCriticalExtension.
-                self.pkg("install example_pkg", exit=1)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_unsupported_critical_extension_2(self):
-                """Test that packages signed using a certificate whose chain of
-                trust contains a certificate with an unsupported critical
-                extension will not have valid signatures."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1.1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1.1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1.1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.BrokenChain, self._api_install, api_obj,
-                    ["example_pkg"])
-
-        def test_unsupported_critical_extension_3(self):
-                """Test that packages signed using a certificate whose chain of
-                trust contains a certificate with an unsupported critical
-                extension will not have valid signatures."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} {name}".format(**{
-                        "name": plist[0],
-                        "key": os.path.join(self.keys_dir,
-                            "cs1_ch5.1_ta1_key.pem"),
-                        "cert": os.path.join(self.cs_dir,
-                            "cs1_ch5.1_ta1_cert.pem"),
-                        "i1": os.path.join(self.chain_certs_dir,
-                            "ch1_ta1_cert.pem"),
-                        "i2": os.path.join(self.chain_certs_dir,
-                            "ch2_ta1_cert.pem"),
-                        "i3": os.path.join(self.chain_certs_dir,
-                            "ch3_ta1_cert.pem"),
-                        "i4": os.path.join(self.chain_certs_dir,
-                            "ch4_ta1_cert.pem"),
-                        "i5": os.path.join(self.chain_certs_dir,
-                            "ch5.1_ta1_cert.pem")
-                })
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta1")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.BrokenChain, self._api_install, api_obj,
-                    ["example_pkg"])
-
-        def test_inappropriate_use_of_code_signing_cert(self):
-                """Test that signing a certificate with a code signing
-                certificate results in a broken chain."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "{name}".format(**{
-                        "name": plist[0],
-                        "key": os.path.join(self.keys_dir,
-                            "cs1_cs8_ch1_ta3_key.pem"),
-                        "cert": os.path.join(self.cs_dir,
-                            "cs1_cs8_ch1_ta3_cert.pem"),
-                        "i1": os.path.join(self.cs_dir,
-                            "cs8_ch1_ta3_cert.pem"),
-                        "i2": os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"),
-                })
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                # This raises a BrokenChain exception because the certificate
-                # check_ca method checks the keyUsage extension if it's set
-                # as well as the basicConstraints extension.
-                self.assertRaises(apx.BrokenChain, self._api_install, api_obj,
-                    ["example_pkg"])
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_inappropriate_use_of_cert_signing_cert(self):
-                """Test that using a CA cert without the digitalSignature
-                value for the keyUsage extension to sign a package means
-                that the package's signature doesn't verify."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "ch1_ta3_key.pem"),
-                        cert=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.InappropriateCertificateUse,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Tests that the cli can handle an InappropriateCertificateUse
-                # exception.
-                self.pkg("install example_pkg", exit=1)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_no_crlsign_on_revoking_ca(self):
-                """Test that if a CRL is signed with a CA that has the keyUsage
-                extension but not the cRLSign value is not considered a valid
-                CRL."""
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                rstore = r.get_pub_rstore(pub="test")
-                os.makedirs(os.path.join(rstore.file_root, "ch"))
-                portable.copyfile(os.path.join(self.crl_dir,
-                    "ch1.1_ta4_crl.pem"),
-                    os.path.join(rstore.file_root, "ch", "ch1.1_ta4_crl.pem"))
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1.1_ta4_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1.1_ta4_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1.1_ta4_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.dcs[1].start()
-
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta4")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                # This succeeds because the CA which signed the revoking CRL
-                # did not have the cRLSign keyUsage extension set.
-                self._api_install(api_obj, ["example_pkg"])
-        def test_no_empty_chain(self):
-                """Test that signing do not create empty chain"""
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10,
-                    debug_hash="sha1+sha512t_256")
-                sign_args = "-k %(key)s -c %(cert)s %(pkg)s" % {
-                    "key": os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                    "cert": os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
-                    "pkg": plist[0]}
-
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta2")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-                # Make sure signing haven't created empty chain attrs
-                self.pkg("contents -m")
-                self.assertTrue(self.output.count("chain=") == 0)
-
-        def test_unknown_value_for_non_critical_extension(self):
-                """Test that an unknown value for a recognized non-critical
-                extension causes an exception to be raised."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs5_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs5_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.UnsupportedExtensionValue,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Tests that the cli can handle an UnsupportedExtensionValue.
-                self.pkg("install example_pkg", exit=1)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_unknown_value_for_critical_extension(self):
-                """Test that an unknown value for a recognized critical
-                extension causes an exception to be raised."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs6_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs6_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.UnsupportedExtensionValue,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Tests that the cli can handle an UnsupportedExtensionValue.
-                self.pkg("install example_pkg", exit=1)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_invalid_extension_1(self):
-                """Test that an invalid value in the extension causes an
-                exception to be raised."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs9_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs9_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.InvalidCertificateExtensions,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Tests that the cli can handle an InvalidCertificateExtensions.
-                self.pkg("install example_pkg", exit=1)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_invalid_extension_2(self):
-                """Test that a critical extension that Cryptography can't
-                understand causes an exception to be raised."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cust_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cust_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("cust")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.UnsupportedCriticalExtension,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Tests that the cli can handle an InvalidCertificateExtensions.
-                self.pkg("install example_pkg", exit=1)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_unset_keyUsage_for_code_signing(self):
-                """Test that if keyUsage has not been set, the code signing
-                certificate is considered valid."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs7_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs7_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_unset_keyUsage_for_cert_signing(self):
-                """Test that if keyUsage has not been set, the CA certificate is
-                considered valid."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1.4_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1.4_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1.4_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_sign_no_server_update(self):
-                """Test --no-index and --no-catalog."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "--no-index --no-catalog -i {i1} -k {key} " \
-                    "-c {cert} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                # This fails because the index hasn't been updated.
-                self.pkg("search -r rsa-sha256", exit=1)
-                self.pkg("set-property signature-policy require-signatures")
-                # This fails because the catalog hasn't been updated with
-                # the signed manifest yet.
-                self.pkg("install example_pkg", exit=1)
-                r = self.get_repo(self.dcs[1].get_repodir())
-                r.rebuild()
-                self.pkg("install example_pkg")
-
-        def test_bogus_client_certs(self):
-                """Tests that if a certificate stored on the client is replaced
-                with a different certificate, installation fails."""
-
-                chain_cert_path = os.path.join(os.path.join(
-                     self.chain_certs_dir, "ch1_ta3_cert.pem"))
-                cs_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
-                cs2_path = os.path.join(self.cs_dir, "cs1_ta2_cert.pem")
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} " \
-                    "{name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=cs_path,
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-
-                # Replace the client CS cert.
-                hsh = self.calc_pem_hash(cs_path)
-                pth = os.path.join(self.img_path(), "var", "pkg", "publisher",
-                    "test", "certs", hsh)
-                portable.copyfile(cs2_path, pth)
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.ModifiedCertificateException,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Test that the cli handles a ModifiedCertificateException.
-                self.pkg("install example_pkg", exit=1)
-
-                # Test that removing the CS cert will cause it to be downloaded
-                # again and the installation will then work.
-
-                portable.remove(pth)
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-
-                # Repeat the test but change the chain cert instead of the CS
-                # cert.
-
-                # Replace the client chain cert.
-                hsh = self.calc_pem_hash(chain_cert_path)
-                pth = os.path.join(self.img_path(), "var", "pkg", "publisher",
-                    "test", "certs", hsh)
-                portable.copyfile(cs2_path, pth)
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.BrokenChain, self._api_install, api_obj,
-                    ["example_pkg"])
-
-                # Test that removing the chain cert will cause it to be
-                # downloaded again and the installation will then work.
-
-                portable.remove(pth)
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_crl_0(self):
-                """Test that the X509 CRL revocation works correctly."""
-
-                with open(os.path.join(self.crl_dir, "ch1_ta4_crl.pem"),
-                    "rb") as f:
-                        crl = x509.load_pem_x509_crl(
-                            f.read(), default_backend())
-
-                with open(os.path.join(self.cs_dir,
-                    "cs1_ch1_ta4_cert.pem"), "rb") as f:
-                        cert = x509.load_pem_x509_certificate(
-                            f.read(), default_backend())
-
-                self.assertTrue(crl.issuer == cert.issuer)
-                for rev in crl:
-                        if rev.serial_number == cert.serial_number:
-                                break
-                else:
-                        self.assertTrue(False, "Can not find revoked "
-                            "certificate in CRL!")
-
-        def test_bogus_inter_certs(self):
-                """Test that if SignatureAction.set_signature is given invalid
-                paths to intermediate certs, it errors as expected.  This
-                cannot be tested from the command line because the command
-                line rejects certificates that aren't of the right format."""
-
-                attrs = {
-                    "algorithm": "sha256",
+    image_files = ["simple_file"]
+    misc_files = ["tmp/example_file", "tmp/example_file2"]
+
+    def pkg(self, command, *args, **kwargs):
+        # The value for crl_host is pulled from DebugValues because
+        # crl__host needs to be set there so the api object calls work
+        # as desired.
+        command = "--debug crl_host={0} {1}".format(
+            DebugValues["crl_host"], command
+        )
+        return pkg5unittest.SingleDepotTestCase.pkg(
+            self, command, *args, **kwargs
+        )
+
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self, image_count=2)
+        self.make_misc_files(self.misc_files)
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.rurl1 = self.dcs[1].get_repo_url()
+        DebugValues["crl_host"] = self.durl1
+
+    def test_sign_0(self):
+        """Test that packages signed with hashes only work correctly."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        # Test that things work with unsigned packages.
+        self.image_create(self.rurl1)
+
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy ignore")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Tests that the cli handles RequiredSignaturePolicyExceptions.
+        self.pkg("install example_pkg", exit=1)
+        self.pkg("set-property signature-policy require-names foo")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.MissingRequiredNamesException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Tests that the cli handles MissingRequiredNamesException.
+        self.pkg("install example_pkg", exit=1)
+
+        self.pkg("unset-property signature-policy")
+
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-publisher --set-property signature-policy=verify " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg(
+            "set-publisher "
+            "--set-property signature-policy=require-signatures test"
+        )
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        self.pkg(
+            "set-publisher "
+            "--set-property signature-policy=require-names "
+            "--set-property signature-required-names=foo test"
+        )
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.MissingRequiredNamesException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+
+        self.pkgsign(self.rurl1, plist[0])
+        self.image_destroy()
+        self.image_create(self.rurl1)
+
+        # Test that things work hashes instead of signatures.
+        self.pkg("refresh --full")
+
+        self.pkg(
+            "set-publisher --unset-property signature-policy "
+            "--unset-property signature-required-names test"
+        )
+
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self.pkg("search -l sha256")
+        self._api_uninstall(api_obj, ["example_pkg"])
+
+        self.pkg("set-property signature-policy ignore")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        self.pkg("set-property signature-policy require-names foo")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.MissingRequiredNamesException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+
+        self.pkg("unset-property signature-policy")
+
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-publisher --set-property signature-policy=verify " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg(
+            "set-publisher --set-property "
+            "signature-policy=require-signatures test"
+        )
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        self.pkg(
+            "set-publisher "
+            "--set-property signature-policy=require-names "
+            "--set-property signature-required-names=foo test"
+        )
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.MissingRequiredNamesException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+
+    def test_sign_1(self):
+        """Test that packages signed using private keys function
+        correctly.  Uses a chain of certificates three certificates
+        long."""
+
+        chain_cert_path = os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem")
+        ta_cert_path = os.path.join(self.raw_trust_anchor_dir, "ta3_cert.pem")
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {ch1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            ch1=chain_cert_path,
+        )
+        td = os.environ["TMPDIR"]
+        sd = os.path.join(td, "tmp_sign")
+        os.makedirs(sd)
+        os.environ["TMPDIR"] = sd
+
+        # Specify location as filesystem path.
+        self.pkgsign(self.dc.get_repodir(), sign_args)
+
+        # Ensure that all temp files from signing have been removed.
+        self.assertEqual(os.listdir(sd), [])
+        os.environ["TMPDIR"] = td
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        # Find the hash of the publisher CA cert used.
+        hsh = self.calc_pem_hash(chain_cert_path)
+
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self.pkg("search -l rsa-sha256")
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy ignore")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+
+        emptyCA = os.path.join(self.img_path(), "emptyCA")
+        os.makedirs(emptyCA)
+        self.pkg("set-property trust-anchor-directory emptyCA")
+        # This should fail because the chain is rooted in an untrusted
+        # self-signed cert.
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.BrokenChain, self._api_install, api_obj, ["example_pkg"]
+        )
+        # Test that the cli handles BrokenChain exceptions.
+        self.pkg("install example_pkg", exit=1)
+        # Now seed the emptyCA directory to test that certs can be
+        # pulled from it correctly.
+        self.seed_ta_dir("ta3", dest_dir=emptyCA)
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy require-names foo")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.MissingRequiredNamesException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        self.pkg("set-property signature-policy " "require-names 'cs1_ch1_ta3'")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("add-property-value signature-required-names " "'ch1_ta3'")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg(
+            "remove-property-value signature-required-names " "'cs1_ch1_ta3'"
+        )
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+
+        # Test setting publisher level policies.
+        self.pkg("unset-property signature-policy")
+
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-publisher --set-property signature-policy=verify " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg(
+            "set-publisher "
+            "--set-property signature-policy=require-signatures test"
+        )
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg(
+            "set-publisher "
+            "--set-property signature-policy=require-names "
+            "--set-property signature-required-names='cs1_ch1_ta3' "
+            "test"
+        )
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg(
+            "set-publisher --add-property-value "
+            "signature-required-names='ch1_ta3' test"
+        )
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg(
+            "set-publisher --remove-property-value "
+            "signature-required-names='cs1_ch1_ta3' test"
+        )
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg(
+            "set-publisher --add-property-value "
+            "signature-required-names='foo' test"
+        )
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.MissingRequiredNamesException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        self.pkg(
+            "set-publisher --remove-property-value "
+            "signature-required-names='foo' test"
+        )
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+
+        # Test combining publisher and image require-names policies.
+        self.pkg("set-property signature-policy require-names foo")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.MissingRequiredNamesException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        self.pkg("set-property signature-policy require-names " "ch1_ta3")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("unset-property signature-policy")
+
+        # Test removing and adding chain certs
+        self.pkg("set-publisher --set-property signature-policy=verify " "test")
+        self.pkg("set-publisher --revoke-ca-cert={0} test".format(hsh))
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.BrokenChain, self._api_install, api_obj, ["example_pkg"]
+        )
+        self.pkg(
+            "set-publisher --approve-ca-cert={0} test".format(chain_cert_path)
+        )
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self.pkg("set-publisher --revoke-ca-cert={0} test".format(hsh))
+        self.pkg("verify", exit=1)
+        self.pkg("fix", exit=1)
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        # These should fail because the image, though not the publisher
+        # verifies signatures.
+        self.pkg("set-property signature-policy verify")
+        self.pkg("verify", exit=1)
+        self.pkg("fix", exit=1)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("verify")
+        self.pkg("fix", exit=4)
+        self.pkg("set-publisher --set-property signature-policy=verify " "test")
+        # These should fail because the publisher, though not the image
+        # verifies signatures.
+        self.pkg("verify", exit=1)
+        self.pkg("fix", exit=1)
+        self.pkg(
+            "set-publisher --approve-ca-cert={0} test".format(chain_cert_path)
+        )
+        self.pkg("verify")
+        self.pkg("fix", exit=4)
+        api_obj = self.get_img_api_obj()
+        self._api_uninstall(api_obj, ["example_pkg"])
+
+        # Test that manually approving a trust anchor works.
+        self.pkg("set-publisher --unset-ca-cert={0} test".format(hsh))
+        self.pkg(
+            "set-publisher --approve-ca-cert={0} test".format(ta_cert_path)
+        )
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_sign_2(self):
+        """Test that verification of the CS cert failing means the
+        install fails."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+        )
+
+        # Specify repository location as relative path.
+        cwd = os.getcwd()
+        repodir = self.dc.get_repodir()
+        os.chdir(os.path.dirname(repodir))
+        self.pkgsign(os.path.basename(repodir), sign_args)
+        os.chdir(cwd)
+
+        self.image_create(self.rurl1)
+        self.pkg("set-property signature-policy verify")
+
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.BrokenChain, self._api_install, api_obj, ["example_pkg"]
+        )
+
+    def test_sign_3(self):
+        """Test that using a chain seven certificates long works.  It
+        also tests that having an extra chain certificate doesn't break
+        anything."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} -i {i6} {pkg}".format(
+                **{
+                    "key": os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                    "i1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta1_cert.pem"
+                    ),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5_ta1_cert.pem"
+                    ),
+                    "i6": os.path.join(
+                        self.chain_certs_dir, "ch1_ta3_cert.pem"
+                    ),
+                    "pkg": plist[0],
                 }
-                key_pth = os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem")
-                cert_pth = os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem")
-                sig_act = signature.SignatureAction(cert_pth, **attrs)
-                self.assertRaises(action.ActionDataError, sig_act.set_signature,
-                    [sig_act], key_path=key_pth,
-                    chain_paths=["/shouldnot/exist"])
-                self.assertRaises(action.ActionDataError, sig_act.set_signature,
-                    [sig_act], key_path=key_pth, chain_paths=[self.test_root])
-
-        def test_signing_all(self):
-                """Test that using '*' works correctly, signing all packages in
-                a repository."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                plist = self.pkgsend_bulk(self.rurl1, self.var_pkg)
-
-                self.pkgsign_simple(self.rurl1, "'*'")
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self._api_install(api_obj, ["var_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self._api_uninstall(api_obj, ["var_pkg"])
-
-        def test_crl_1(self):
-                """Test that revoking a code signing certificate by the
-                publisher CA works correctly."""
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                rstore = r.get_pub_rstore(pub="test")
-                os.makedirs(os.path.join(rstore.file_root, "ch"))
-                portable.copyfile(os.path.join(self.crl_dir,
-                    "ch1_ta4_crl.pem"),
-                    os.path.join(rstore.file_root, "ch", "ch1_ta4_crl.pem"))
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta4_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta4_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta4_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.dcs[1].start()
-
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta4")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                # Check that when the check-certificate-revocation is False, its
-                # default value, that the install succeedes.
-                self._api_install(api_obj, ["example_pkg"])
-                self.pkg("set-property check-certificate-revocation true")
-                self.pkg("verify", su_wrap=True, exit=1)
-                self._api_uninstall(api_obj, ["example_pkg"])
-                api_obj.reset()
-                self.assertRaises(apx.RevokedCertificate, self._api_install,
-                    api_obj, ["example_pkg"])
-                # Test that cli handles RevokedCertificate exception.
-                self.pkg("install example_pkg", exit=1)
-
-        def test_crl_2(self):
-                """Test that revoking a code signing certificate by the
-                publisher CA works correctly."""
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                rstore = r.get_pub_rstore(pub="test")
-                os.makedirs(os.path.join(rstore.file_root, "ta"))
-                portable.copyfile(os.path.join(self.crl_dir,
-                    "ta5_crl.pem"),
-                    os.path.join(rstore.file_root, "ta", "ta5_crl.pem"))
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta5_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta5_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta5_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.dcs[1].start()
-
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta5")
-                self.pkg("set-property check-certificate-revocation true")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.BrokenChain, self._api_install, api_obj,
-                    ["example_pkg"])
-
-        def test_crl_3(self):
-                """Test that a CRL with a bad file format does not cause
-                breakage."""
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                rstore = r.get_pub_rstore(pub="test")
-                os.makedirs(os.path.join(rstore.file_root, "ex"))
-                portable.copyfile(os.path.join(self.test_root,
-                    "tmp/example_file"),
-                    os.path.join(rstore.file_root, "ex", "example_file"))
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs2_ch1_ta4_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs2_ch1_ta4_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta4_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.dcs[1].start()
-
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta4")
-                self.pkg("set-property check-certificate-revocation true")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_crl_4(self):
-                """Test that a CRL which cannot be retrieved does not cause
-                breakage."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs2_ch1_ta4_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs2_ch1_ta4_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta4_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.dcs[1].start()
-
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta4")
-                self.pkg("set-property check-certificate-revocation true")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_crl_5(self):
-                """Test that revocation by CRL validated by a grandparent of the
-                certificate in question works."""
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                rstore = r.get_pub_rstore(pub="test")
-                os.makedirs(os.path.join(rstore.file_root, "ch"))
-                portable.copyfile(os.path.join(self.crl_dir,
-                    "ch5_ta1_crl.pem"),
-                    os.path.join(rstore.file_root, "ch", "ch5_ta1_crl.pem"))
-
-                self.dcs[1].start()
-
-                plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} {pkg}".format(**{
-                      "key": os.path.join(self.keys_dir, "cs2_ch5_ta1_key.pem"),
-                      "cert": os.path.join(self.cs_dir, "cs2_ch5_ta1_cert.pem"),
-                      "i1": os.path.join(self.chain_certs_dir,
-                          "ch1_ta1_cert.pem"),
-                      "i2": os.path.join(self.chain_certs_dir,
-                          "ch2_ta1_cert.pem"),
-                      "i3": os.path.join(self.chain_certs_dir,
-                          "ch3_ta1_cert.pem"),
-                      "i4": os.path.join(self.chain_certs_dir,
-                          "ch4_ta1_cert.pem"),
-                      "i5": os.path.join(self.chain_certs_dir,
-                          "ch5_ta1_cert.pem"),
-                      "pkg": plist[0]
-                    })
-
-                self.pkgsign(self.durl1, sign_args)
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta1")
-                self.pkg("set-property check-certificate-revocation true")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RevokedCertificate, self._api_install,
-                    api_obj, ["example_pkg"])
-
-        def test_crl_6(self):
-                """Test that revocation by CRL validated by an intermediate
-                certificate of the certificate in question works."""
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                rstore = r.get_pub_rstore(pub="test")
-                os.makedirs(os.path.join(rstore.file_root, "ch"))
-                portable.copyfile(os.path.join(self.crl_dir,
-                    "ch5_ta1_crl.pem"),
-                    os.path.join(rstore.file_root, "ch", "ch5_ta1_crl.pem"))
-
-                self.dcs[1].start()
-
-                plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} {pkg}".format(**{
-                      "key": os.path.join(self.keys_dir, "cs2_ch5_ta1_key.pem"),
-                      "cert": os.path.join(self.cs_dir, "cs2_ch5_ta1_cert.pem"),
-                      "i1": os.path.join(self.chain_certs_dir,
-                          "ch1_ta1_cert.pem"),
-                      "i2": os.path.join(self.chain_certs_dir,
-                          "ch2_ta1_cert.pem"),
-                      "i3": os.path.join(self.chain_certs_dir,
-                          "ch3_ta1_cert.pem"),
-                      "i4": os.path.join(self.chain_certs_dir,
-                          "ch4_ta1_cert.pem"),
-                      "i5": os.path.join(self.chain_certs_dir,
-                          "ch5_ta1_cert.pem"),
-                      "pkg": plist[0]
-                    })
-
-                self.pkgsign(self.durl1, sign_args)
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta1")
-                self.pkg("set-property check-certificate-revocation true")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RevokedCertificate, self._api_install,
-                    api_obj, ["example_pkg"])
-
-        def test_crl_7(self):
-                """Test that a CRL location which isn't in a known URI format
-                doesn't cause breakage."""
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs3_ch1_ta4_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs3_ch1_ta4_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta4_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.dcs[1].start()
-
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta4")
-                self.pkg("set-property check-certificate-revocation true")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.InvalidResourceLocation,
-                    self._api_install, api_obj, ["example_pkg"])
-                # Test that the cli can handle a InvalidResourceLocation
-                # exception.
-                self.pkg("install example_pkg", exit=1)
-                self.pkg("set-property signature-policy ignore")
-                self.pkg("set-publisher --set-property signature-policy=ignore "
-                    "test")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("verify", exit=1)
-
-        def test_crl_8(self):
-                """Test that if two packages share the same CRL, it's only
-                downloaded once even if it can't be stored permanently in the
-                image."""
-
-                def cnt_crl_contacts(log_path):
-                        c = 0
-                        with open(log_path, "r") as fh:
-                                for line in fh:
-                                        if "ch1_ta4_crl.pem" in line:
-                                                c += 1
-                        return c
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                rstore = r.get_pub_rstore(pub="test")
-                os.makedirs(os.path.join(rstore.file_root, "ch"))
-                portable.copyfile(os.path.join(self.crl_dir,
-                    "ch1_ta4_crl.pem"),
-                    os.path.join(rstore.file_root, "ch", "ch1_ta4_crl.pem"))
-
-                plist = self.pkgsend_bulk(self.rurl1,
-                    [self.example_pkg10, self.var_pkg])
-
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=" ".join(plist),
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta4_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta4_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta4_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.dcs[1].start()
-
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta4")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg", "var_pkg"])
-                self.pkg("set-property check-certificate-revocation true")
-                # Check that the server is only contacted once per CRL, not once
-                # per package with that CRL.
-                self.pkg("verify", su_wrap=True, exit=1)
-                self.assertEqual(cnt_crl_contacts(self.dcs[1].get_logpath()), 1)
-                self.pkg("verify", exit=1)
-                # Pkg should contact the server once more then store it in its
-                # permanent location.
-                self.assertEqual(cnt_crl_contacts(self.dcs[1].get_logpath()), 2)
-                # Check that once the crl file is in its permanent location,
-                # it's not retrieved again.
-                self.pkg("verify", su_wrap=True, exit=1)
-                self.assertEqual(cnt_crl_contacts(self.dcs[1].get_logpath()), 2)
-                self.pkg("verify", exit=1)
-                self.assertEqual(cnt_crl_contacts(self.dcs[1].get_logpath()), 2)
-
-        def __setup_signed_simple(self, pkg_srcs, pkg_names):
-                plist = self.pkgsend_bulk(self.rurl1, pkg_srcs)
-
-                for pfmri in plist:
-                        self.pkgsign_simple(self.rurl1, pfmri)
-
-                self.pkg_image_create(self.rurl1,
-                    additional_args="--variant variant.arch=i386")
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, pkg_names)
-                return api_obj
-
-        def test_var_pkg(self):
-                """Test that actions tagged with variants don't break signing.
-                """
-
-                api_obj = self.__setup_signed_simple([self.var_pkg],
-                    ["var_pkg"])
-                self.pkg("verify")
-                self.assertTrue(os.path.exists(os.path.join(self.img_path(),
-                    "baz")))
-                self.assertTrue(not os.path.exists(
-                    os.path.join(self.img_path(), "bin")))
-
-                # verify changing variant after install also works
-                self._api_change_varcets(api_obj,
-                    variants={ "variant.arch": "sparc" },
-                    refresh_catalogs=False)
-
-                self.assertTrue(not os.path.exists(
-                    os.path.join(self.img_path(), "baz")))
-                self.assertTrue(os.path.exists(
-                    os.path.join(self.img_path(), "bin")))
-                self.pkg("verify")
-
-        def test_facet_pkg(self):
-                """Test that actions tagged with facets don't break signing."""
-
-                api_obj = self.__setup_signed_simple([self.facet_pkg],
-                    ["facet_pkg"])
-                self.pkg("verify")
-                self.assertTrue(os.path.exists(os.path.join(self.img_path(),
-                    "usr", "share", "doc", "i386_doc.txt")))
-                self.assertTrue(not os.path.exists(os.path.join(self.img_path(),
-                    "usr", "share", "doc", "sparc_devel.txt")))
-
-                # verify changing facet after install also works
-                nfacets = facet.Facets({ "facet.doc": False })
-                self._api_change_varcets(api_obj, facets=nfacets,
-                    refresh_catalogs=False)
-                self.assertTrue(not os.path.exists(os.path.join(self.img_path(),
-                    "usr", "share", "doc", "i386_doc.txt")))
-                self.assertTrue(not os.path.exists(os.path.join(self.img_path(),
-                    "usr", "share", "doc", "sparc_devel.txt")))
-                self.pkg("verify")
-
-        def test_mediator_pkg(self):
-                """Test that actions tagged with mediators don't break
-                signing."""
-
-                def check_target(links, target):
-                        for lpath in links:
-                                ltarget = os.readlink(lpath)
-                                self.assertTrue(ltarget.endswith(target))
-
-                api_obj = self.__setup_signed_simple([self.med_pkg],
-                    ["med_pkg"])
-                self.pkg("verify")
-
-                # verify /bin/example mediation points to example-1.7 by default
-                ex_link = self.get_img_file_path("bin/example")
-                check_target([ex_link], "example-1.7")
-
-                # verify changing mediation after install works as expected
-                self.pkg("set-mediator -V1.6 example")
-                check_target([ex_link], "example-1.6")
-                self.pkg("verify")
-
-                # Verify removal of mediated links when no mediation applies
-                # works as expected.
-                self.pkg("set-mediator -V1.8 example")
-                self.assertTrue(not os.path.exists(ex_link))
-                self.pkg("verify")
-
-                # Verify mediated links are restored when mediation is reset.
-                self.pkg("set-property signature-policy require-signatures")
-                self.pkg("set-mediator -V1.6 example")
-                check_target([ex_link], "example-1.6")
-                self.pkg("verify")
-
-        def test_fix_revert_pkg(self):
-                """Test that fix and revert works with signed packages."""
-
-                api_obj = self.__setup_signed_simple([self.facet_pkg],
-                    ["facet_pkg"])
-                self.pkg("verify")
-                doc_path = self.get_img_file_path("usr/share/doc/i386_doc.txt")
-                self.assertTrue(os.path.exists(doc_path))
-
-                # Remove doc, then verify that fix and revert will restore it.
-                for cmd in ("fix", "revert usr/share/doc/i386_doc.txt"):
-                        portable.remove(doc_path)
-                        self.assertTrue(not os.path.exists(doc_path))
-                        self.pkg(cmd)
-                        self.assertTrue(os.path.exists(doc_path))
-
-        def test_conflicting_pkgs(self):
-                """Test that conflicting package repair works with signed
-                packages."""
-
-                DebugValues["broken-conflicting-action-handling"] = 1
-                try:
-                        # Install conflicting packages.
-                        api_obj = self.__setup_signed_simple([self.conflict_pkgs],
-                            ["conflict_a_pkg", "conflict_b_pkg"])
-                        rel_path = self.get_img_file_path("etc/release")
-                        self.assertTrue(os.path.exists(rel_path))
-                finally:
-                        del DebugValues["broken-conflicting-action-handling"]
-
-                # Now remove one of the conflicting packages and verify that the
-                # repair happens as expected.
-                self._api_uninstall(api_obj, ["conflict_b_pkg"])
-                self.pkg("verify")
-                self.file_contains("etc/release", "tmp/example_file")
-
-        def test_disabled_append(self):
-                """Test that publishing to a depot which doesn't support append
-                fails as expected."""
-
-                self.dcs[1].set_disable_ops(["append"])
-                self.dcs[1].start()
-
-                plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
-
-                self.pkgsign_simple(self.durl1, plist[0], exit=1)
-
-        def test_disabled_add(self):
-                """Test that publishing to a depot which doesn't support add
-                fails as expected."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                # New publication uses manifest/1 to upload manifest as-is
-                # and avoid using add ops. Disable manifest/1 to fall back
-                # to older logic here for testing.
-                self.dcs[1].set_disable_ops(["add", "manifest/1"])
-                self.dcs[1].start()
-
-                sign_args = "-k {key} -c {cert} {pkg}".format(
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        pkg=plist[0])
-                self.pkgsign(self.durl1, sign_args, exit=1)
-
-        def test_disabled_file(self):
-                """Test that publishing to a depot which doesn't support file
-                fails as expected."""
-
-                # New publication uses manifest/1 which uses file/1, so if we
-                # disable file ops, we can't use the new publication model.
-                # Disable manifest/1 to fall back to older logic here for
-                # testing.
-                self.dcs[1].set_disable_ops(["file", "manifest/1"])
-                self.dcs[1].start()
-
-                plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
-
-                self.pkgsign_simple(self.durl1, plist[0], exit=1)
-
-        def test_expired_certs(self):
-                """Test that expiration dates on the signing cert are
-                ignored."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs3_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs3_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                # This should succeed because we currently ignore certificate
-                # expiration and start dates.
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_future_certs(self):
-                """Test that expiration dates on the signing cert are
-                ignored."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs4_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs4_ch1_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                # This should succeed because we currently ignore certificate
-                # expiration and start dates.
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_expired_chain_certs(self):
-                """Test that expiration dates on a chain cert are ignored."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1.2_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1.2_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1.2_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                # This should succeed because we currently ignore certificate
-                # expiration and start dates.
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_future_chain_certs(self):
-                """Test that expiration dates on a chain cert are ignored."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1.3_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1.3_ta3_cert.pem"),
-                        i1=os.path.join(self.chain_certs_dir,
-                            "ch1.3_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                # This should succeed because we currently ignore certificate
-                # expiration and start dates.
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_cert_retrieval_failure(self):
-                """Test that a certificate that can't be retrieved doesn't
-                cause a traceback."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.var_pkg)
-                self.pkgsign_simple(self.rurl1, plist[0])
-
-                self.dcs[1].start()
-
-                self.pkg_image_create(self.durl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("info -r var_pkg")
-                self.dcs[1].stop()
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                # This should succeed because we currently ignore certificate
-                # expiration and start dates.
-                self.assertRaises(apx.TransportError, self._api_install,
-                    api_obj, ["var_pkg"], refresh_catalogs=False)
-
-                # Test that a TransportError from certificate retrieval is
-                # handled correctly.
-                self.pkg("install --no-refresh var_pkg", exit=1)
-
-        def test_manual_pub_cert_approval(self):
-                """Test that manually approving a publisher's CA cert works
-                correctly."""
-
-                ca_path = os.path.join(os.path.join(self.chain_certs_dir,
-                    "ch1_ta3_cert.pem"))
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        i1=ca_path)
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1,
-                    additional_args="--set-property signature-policy=require-signatures")
-                self.pkg("set-publisher --approve-ca-cert {0} test".format(ca_path))
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_higher_signature_version(self):
-                """Test that a signature version that isn't recognized is
-                ignored."""
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                self.pkgsign_simple(self.rurl1, plist[0])
-                mp = r.manifest(plist[0])
-                with open(mp, "r") as fh:
-                        ls = fh.readlines()
-                s = []
-                old_ver = action.generic.Action.sig_version
-                new_ver = old_ver + 1
-                # Replace the published manifest with one whose signature
-                # action has a version one higher than what the current
-                # supported version is.
-                for l in ls:
-                        if not l.startswith("signature"):
-                                s.append(l)
-                                continue
-                        tmp = l.replace("version={0}".format(old_ver),
-                            "version={0}".format(new_ver))
-                        s.append(tmp)
-                with open(mp, "w") as fh:
-                        for l in s:
-                                fh.write(l)
-                # Rebuild the repository catalog so that hash verification for
-                # the manifest won't cause problems.
-                r.rebuild()
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["example_pkg"])
-                # This passes because it ignores the signature with a version
-                # it doesn't understand.
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_using_default_cert_loc(self):
-                """Test that the default location is properly image relative
-                and is used."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                self.pkgsign_simple(self.rurl1, plist[0])
-
-                self.pkg_image_create(self.rurl1,
-                    additional_args="--set-property "
-                        "signature-policy=require-signatures")
-                self.seed_ta_dir("ta3")
-
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_using_pkg_image_cert_loc(self):
-                """Test that trust anchors are properly pulled from the image
-                that the pkg command was run from."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                self.pkgsign_simple(self.rurl1, plist[0])
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-
-                # This changes the default image we're operating on.
-                self.set_image(1)
-                self.image_create(self.rurl1, destroy=False)
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                # This raises an exception because the command is run from
-                # within the sub-image, which has now trust anchors installed.
-                self.assertRaises(apx.BrokenChain, self._api_install, api_obj,
-                    ["example_pkg"])
-                # This should work because the command is run from within the
-                # original image which contains the trust anchors needed to
-                # validate the chain.
-                cmd_path = os.path.join(self.img_path(0), "pkg")
-                api_obj = self.get_img_api_obj(cmd_path=cmd_path)
-                self._api_install(api_obj, ["example_pkg"])
-                # Check that the package is installed into the correct image.
-                self.pkg("list example_pkg")
-                self.pkg("-R {0} list example_pkg".format(self.img_path(0)), exit=1)
-                api_obj = self.get_img_api_obj()
-                self._api_uninstall(api_obj, ["example_pkg"])
-                # Repeat the test using the pkg command interface instead of the
-                # api.
-                self.pkg("-D simulate_cmdpath={0} -R {1} install example_pkg".format(
-                    cmd_path, self.img_path()))
-                self.pkg("list example_pkg")
-                self.pkg("-R {0} list example_pkg".format(self.img_path(0)), exit=1)
-
-        def test_big_pathlen(self):
-                """Test that a chain cert which has a larger pathlen value than
-                is needed is allowed."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} {pkg}".format(**{
-                      "key": os.path.join(self.keys_dir,
-                          "cs1_ch5.2_ta1_key.pem"),
-                      "cert": os.path.join(self.cs_dir,
-                          "cs1_ch5.2_ta1_cert.pem"),
-                      "i1": os.path.join(self.chain_certs_dir,
-                          "ch1_ta1_cert.pem"),
-                      "i2": os.path.join(self.chain_certs_dir,
-                          "ch2_ta1_cert.pem"),
-                      "i3": os.path.join(self.chain_certs_dir,
-                          "ch3_ta1_cert.pem"),
-                      "i4": os.path.join(self.chain_certs_dir,
-                          "ch4_ta1_cert.pem"),
-                      "i5": os.path.join(self.chain_certs_dir,
-                          "ch5.2_ta1_cert.pem"),
-                      "pkg": plist[0]
-                    })
-
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta1")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_small_pathlen(self):
-                """Test that a chain cert which has a smaller pathlen value than
-                is needed is disallowed."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} {pkg}".format(**{
-                      "key": os.path.join(self.keys_dir,
-                          "cs1_ch5.3_ta1_key.pem"),
-                      "cert": os.path.join(self.cs_dir,
-                          "cs1_ch5.3_ta1_cert.pem"),
-                      "i1": os.path.join(self.chain_certs_dir,
-                          "ch1_ta1_cert.pem"),
-                      "i2": os.path.join(self.chain_certs_dir,
-                          "ch2_ta1_cert.pem"),
-                      "i3": os.path.join(self.chain_certs_dir,
-                          "ch3_ta1_cert.pem"),
-                      "i4": os.path.join(self.chain_certs_dir,
-                          "ch4.3_ta1_cert.pem"),
-                      "i5": os.path.join(self.chain_certs_dir,
-                          "ch5.3_ta1_cert.pem"),
-                      "pkg": plist[0]
-                    })
-
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta1")
-
-                self.pkg("set-property signature-policy verify")
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.PathlenTooShort, self._api_install,
-                    api_obj, ["example_pkg"])
-                # Check that the cli hands PathlenTooShort exceptions.
-                self.pkg("install example_pkg", exit=1)
-
-        def test_bug_16861_1(self):
-                """Test whether obsolete packages can be signed and still
-                function."""
-
-                plist = self.pkgsend_bulk(self.rurl1, obsolete_pkg)
-                self.pkgsign_simple(self.rurl1, plist[0])
-
-                self.pkg_image_create(self.rurl1,
-                    additional_args="--set-property "
-                        "signature-policy=require-signatures")
-                self.seed_ta_dir("ta3")
-
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["obs"])
-
-        def test_bug_16861_2(self):
-                """Test whether renamed packages can be signed and still
-                function."""
-
-                plist = self.pkgsend_bulk(self.rurl1, [self.example_pkg10,
-                    renamed_pkg, self.need_renamed_pkg])
-                for name in plist:
-                        self.pkgsign_simple(self.rurl1, name)
-
-                self.pkg_image_create(self.rurl1,
-                    additional_args="--set-property "
-                        "signature-policy=require-signatures")
-                self.seed_ta_dir("ta3")
-
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["need_renamed"])
-
-        def test_bug_16867_1(self):
-                """Test whether signing a package multiple times makes a package
-                uninstallable."""
-
-                chain_cert_path = os.path.join(self.chain_certs_dir,
-                    "ch1_ta3_cert.pem")
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                self.pkgsign_simple(self.rurl1, plist[0])
-                self.pkgsign_simple(self.rurl1, plist[0])
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy verify")
-
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_bug_16867_2(self):
-                """Test whether signing a package which already has multiple
-                identical signatures results in an error."""
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                self.pkgsign_simple(self.rurl1, plist[0])
-
-                mp = r.manifest(plist[0])
-                with open(mp, "r") as fh:
-                        ls = fh.readlines()
-                s = []
-                for l in ls:
-                        # Double all signature actions.
-                        if l.startswith("signature"):
-                                s.append(l)
-                        s.append(l)
-                with open(mp, "w") as fh:
-                        for l in s:
-                                fh.write(l)
-
-                hash_alg_list = ["sha256"]
-                if sha512_supported:
-                        hash_alg_list.append("sha512t_256")
-                for hash_alg in hash_alg_list:
-                        # Rebuild the catalog so that hash verification for the
-                        # manifest won't cause problems.
-                        r.rebuild()
-                        # This should fail because the manifest already has
-                        # identical signature actions in it.
-                        self.pkgsign_simple(self.rurl1, plist[0], exit=1)
-
-                        # The addition of SHA-256 hashes should still result in
-                        # us believing the signatures are identical.
-                        self.pkgsign_simple(self.rurl1, plist[0], exit=1,
-                            debug_hash="sha1+{0}".format(hash_alg))
-
-                        self.pkg_image_create(self.rurl1)
-                        self.seed_ta_dir("ta3")
-                        self.pkg("set-property signature-policy verify")
-
-                        # This fails because the manifest contains duplicate
-                        # signatures.
-                        api_obj = self.get_img_api_obj()
-                        self.assertRaises(apx.UnverifiedSignature,
-                                self._api_install, api_obj, ["example_pkg"])
-
-        def test_bug_16867_hashes_1(self):
-                """Test whether signing a package a second time with hashes
-                fails."""
-
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                sign_args = "{name}".format(
-                        name=plist[0],
-               )
-                self.pkgsign(self.rurl1, sign_args)
-                self.pkgsign(self.rurl1, sign_args)
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy verify")
-
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_bug_16867_almost_identical(self):
-                """Test whether signing a package which already has a similar
-                but not identical signature results in an error."""
-
-                r = self.get_repo(self.dcs[1].get_repodir())
-                chain_cert_path = os.path.join(self.chain_certs_dir,
-                    "ch1_ta3_cert.pem")
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-                self.pkgsign_simple(self.rurl1, plist[0])
-
-                mp = r.manifest(plist[0])
-                with open(mp, "r") as fh:
-                        ls = fh.readlines()
-                s = []
-                for l in ls:
-                        # Double all signature actions.
-                        if l.startswith("signature"):
-                                a = action.fromstr(l)
-                                a.attrs["value"] = "foo"
-                                s.append(str(a))
-                        else:
-                                s.append(l)
-                with open(mp, "w") as fh:
-                        for l in s:
-                                fh.write(l)
-                # Rebuild the catalog so that hash verification for the manifest
-                # won't cause problems.
-                r.rebuild()
-                # This should fail because the manifest already has almost
-                # identical signature actions in it.
-                self.pkgsign_simple(self.rurl1, plist[0], exit=1)
-
-        def test_bug_17740_default_pub(self):
-                """Test that signing a package in the default publisher of a
-                multi-publisher repository works."""
-
-                self.pkgrepo("add_publisher -s {0} pub2".format(self.rurl1))
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                self.pkgsign_simple(self.rurl1, "'ex*'")
-
-                self.pkg_image_create(additional_args=
-                    "--set-property signature-policy=require-signatures")
-                self.seed_ta_dir("ta3")
-                self.pkg("set-publisher -p {0}".format(self.rurl1))
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, plist)
-
-        def test_bug_17740_alternate_pub(self):
-                """Test that signing a package in an alternate publisher of a
-                multi-publisher repository works."""
-
-                self.pkgrepo("add_publisher -s {0} pub2".format(self.rurl1))
-                plist = self.pkgsend_bulk(self.rurl1, self.pub2_pkg)
-
-                self.pkgsign_simple(self.rurl1, "'*2pk*'")
-
-                self.pkg_image_create(additional_args=
-                    "--set-property signature-policy=require-signatures")
-                self.seed_ta_dir("ta3")
-                self.pkg("set-publisher -p {0}".format(self.rurl1))
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, plist)
-
-        def test_bug_17740_name_collision_1(self):
-                """Test that when two publishers have packages with the same
-                name, the publisher in the sign command is respected.  This test
-                signs the package from the default publisher."""
-
-                self.pkgrepo("add_publisher -s {0} pub2".format(self.rurl1))
-                plist = self.pkgsend_bulk(self.rurl1,
-                    [self.example_pkg10, self.pub2_example])
-
-                self.pkgsign_simple(self.rurl1, "pkg://test/example_pkg")
-
-                self.pkg_image_create(additional_args=
-                    "--set-property signature-policy=require-signatures")
-                self.seed_ta_dir("ta3")
-                self.pkg("set-publisher -p {0}".format(self.rurl1))
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["pkg://pub2/example_pkg"])
-                self._api_install(api_obj, ["pkg://test/example_pkg"])
-
-        def test_bug_17740_name_collision_2(self):
-                """Test that when two publishers have packages with the same
-                name, the publisher in the sign command is respected.  This test
-                signs the package from the non-default publisher."""
-
-                self.pkgrepo("add_publisher -s {0} pub2".format(self.rurl1))
-                plist = self.pkgsend_bulk(self.rurl1,
-                    [self.example_pkg10, self.pub2_example])
-
-                self.pkgsign_simple(self.rurl1, "pkg://pub2/example_pkg")
-
-                self.pkg_image_create(additional_args=
-                    "--set-property signature-policy=require-signatures")
-                self.seed_ta_dir("ta3")
-                self.pkg("set-publisher -p {0}".format(self.rurl1))
-                api_obj = self.get_img_api_obj()
-                self.assertRaises(apx.RequiredSignaturePolicyException,
-                    self._api_install, api_obj, ["pkg://test/example_pkg"])
-                self._api_install(api_obj, ["pkg://pub2/example_pkg"])
-
-        def test_bug_17740_anarchistic_pkg(self):
-                """Test that signing a package present in both repositories
-                signs both packages."""
-
-                self.pkgrepo("add_publisher -s {0} pub2".format(self.rurl1))
-                plist = self.pkgsend_bulk(self.rurl1,
-                    [self.example_pkg10, self.pub2_example])
-
-                self.pkgsign_simple(self.rurl1, "example_pkg")
-
-                self.pkg_image_create(additional_args=
-                    "--set-property signature-policy=require-signatures")
-                self.seed_ta_dir("ta3")
-                self.pkg("set-publisher -p {0}".format(self.rurl1))
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["pkg://test/example_pkg"])
-                self._api_uninstall(api_obj, ["example_pkg"])
-                self._api_install(api_obj, ["pkg://pub2/example_pkg"])
-
-        def test_18620(self):
-                """Test that verifying a signed package doesn't require
-                privs."""
-
-                chain_cert_path = os.path.join(self.chain_certs_dir,
-                    "ch1_ta3_cert.pem")
-                ta_cert_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta3_cert.pem")
-                plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
-
-                # Specify location as filesystem path.
-                self.pkgsign_simple(self.dc.get_repodir(), plist[0])
-
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy ignore")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
-                self.pkg("set-property signature-policy verify")
-                self.pkg("verify", su_wrap=True)
-
-        def test_bug_18880_hash(self):
-                plist = self.pkgsend_bulk(self.rurl1, self.bug_18880_pkg)
-                self.pkgsign(self.rurl1, plist[0])
-                self.image_create(self.rurl1, variants={"variant.foo":"bar"})
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["b18880"])
-                self.pkg("verify")
-                self.pkg("fix", exit=4)
-                portable.remove(os.path.join(self.img_path(),
-                    "bin/example_path"))
-                self.pkg("verify", exit=1)
-                self.assertTrue("signature" not in self.errout)
-                self.pkg("fix")
-                self.assertTrue("signature" not in self.errout)
-
-        def test_bug_18880_sig(self):
-                plist = self.pkgsend_bulk(self.rurl1, self.bug_18880_pkg)
-                sign_args = "-k {key} -c {cert} {pkg}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
-                      pkg=plist[0])
-                self.pkgsign(self.rurl1, sign_args)
-                self.image_create(self.rurl1, variants={"variant.foo":"bar"})
-                api_obj = self.get_img_api_obj()
-                self.seed_ta_dir("ta2")
-                self._api_install(api_obj, ["b18880"])
-                self.pkg("verify")
-                self.pkg("fix", exit=4)
-                portable.remove(os.path.join(self.img_path(),
-                    "bin/example_path"))
-                self.pkg("verify", exit=1)
-                self.assertTrue("signature" not in self.errout)
-                self.pkg("fix")
-                self.assertTrue("signature" not in self.errout)
-
-        def test_bug_19055(self):
-                plist = self.pkgsend_bulk(self.rurl1,
-                    [self.example_pkg10, self.example_pkg20])
-                sign_args = "-k {key} -c {cert} -i {ch1} {name}".format(
-                        name=" ".join(plist),
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        ch1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-                repo = self.dc.get_repo()
-                for pfmri in plist:
-                        found = False
-                        with open(repo.manifest(pfmri), "r") as fh:
-                                for l in fh:
-                                        if l.startswith("signature"):
-                                                found = True
-                                                break
-                        self.assertTrue(found, "{0} was not signed.".format(pfmri))
-
-        def test_bug_19114_1(self):
-                """Test that an unparsable trust anchor which isn't needed
-                doesn't cause problems."""
-
-                plist = self.pkgsend_bulk(self.rurl1,
-                    [self.example_pkg10])
-                sign_args = "-k {key} -c {cert} -i {ch1} {name}".format(
-                        name=" ".join(plist),
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        ch1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-                self.image_create(self.rurl1)
-                api_obj = self.get_img_api_obj()
-                self.seed_ta_dir("ta3")
-                # Create an empty file in the trust anchor directory
-                fh = open(os.path.join(self.ta_dir, "empty"), "wb")
-                fh.close()
-                # This install should succeed because the trust anchor needed to
-                # verify the certificate is still there.
-                self._api_install(api_obj, ["example_pkg"])
-
-        def test_bug_19114_2(self):
-                """Test that a unparsable trust anchor which is needed during
-                installation triggers the proper exception."""
-
-                plist = self.pkgsend_bulk(self.rurl1,
-                    [self.example_pkg10])
-                sign_args = "-k {key} -c {cert} -i {ch1} {name}".format(
-                        name=" ".join(plist),
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        ch1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"))
-                self.pkgsign(self.rurl1, sign_args)
-                self.image_create(self.rurl1)
-                api_obj = self.get_img_api_obj()
-                self.seed_ta_dir("ta3")
-                # Replace the trust anchor with an empty file.
-                fh = open(os.path.join(self.ta_dir, "ta3_cert.pem"), "wb")
-                fh.close()
-                # This install should fail because the needed trust anchor has
-                # been emptied.
-                try:
-                        self._api_install(api_obj, ["example_pkg"])
-                except apx.BrokenChain as e:
-                        assert len(e.ext_exs) == 1
-                else:
-                        raise RuntimeError("Didn't get expected exception")
-                self.pkg("install example_pkg", exit=1)
-
-        def test_signed_mediators(self):
-                """Test that packages with mediated links and other varianted
-                actions work correctly when signed."""
-
-                bar = """\
+            )
+        )
+
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta1")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_multiple_signatures(self):
+        """Test that having a package signed with more than one
+        signature doesn't cause anything to break."""
+
+        self.base_multiple_signatures("sha256")
+        if sha512_supported:
+            self.base_multiple_signatures("sha512t_256")
+
+    def test_no_empty_chain(self):
+        """Test that signing do not create empty chain"""
+        plist = self.pkgsend_bulk(
+            self.rurl1, self.example_pkg10, debug_hash="sha1+sha512t_256"
+        )
+        sign_args = "-k {key} -c {cert} {pkg}".format(
+            **{
+                "key": os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+                "cert": os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
+                "pkg": plist[0],
+            }
+        )
+
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta2")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+        # Make sure signing haven't created empty chain attrs
+        self.pkg("contents -m")
+        self.assertTrue(self.output.count("chain=") == 0)
+
+    def base_multiple_signatures(self, hash_alg):
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} {pkg}".format(
+                **{
+                    "key": os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                    "i1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta1_cert.pem"
+                    ),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5_ta1_cert.pem"
+                    ),
+                    "pkg": plist[0],
+                }
+            )
+        )
+        self.pkgsign(
+            self.rurl1, sign_args, debug_hash="sha1+{0}".format(hash_alg)
+        )
+
+        sign_args = "-k {key} -c {cert} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
+        )
+
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir(["ta1", "ta2"])
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+        # Make sure we've got exactly 1 signature with SHA2 hashes
+        self.pkg("contents -m")
+        self.assertTrue(
+            self.output.count("pkg.chain.{0}".format(hash_alg)) == 1
+        )
+        self.assertTrue(self.output.count("pkg.chain.chashes") == 1)
+        # and SHA1 hashes on both signatures
+        self.assertTrue(self.output.count("chain=") == 1)
+        self.assertTrue(self.output.count("chain.chashes=") == 1)
+
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy require-names " "'cs1_ta2'")
+        self.pkg("add-property-value signature-required-names " "'ch1_ta1'")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("add-property-value signature-required-names 'foo'")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.MissingRequiredNamesException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+
+    def test_sign_4(self):
+        """Test that not providing a needed intermediate cert makes
+        verification fail."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = (
+            "-k {key} -c {cert} -i {i2} -i {i3} "
+            "-i {i4} -i {i5} {pkg}".format(
+                **{
+                    "key": os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5_ta1_cert.pem"
+                    ),
+                    "pkg": plist[0],
+                }
+            )
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        self.image_create(self.rurl1)
+        self.pkg("set-property signature-policy verify")
+
+        self.pkg("install example_pkg", exit=1)
+
+    def base_sign_5(self):
+        """Test that http repos work."""
+
+        self.dcs[1].start()
+        plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} {pkg}".format(
+                **{
+                    "key": os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                    "i1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta1_cert.pem"
+                    ),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5_ta1_cert.pem"
+                    ),
+                    "pkg": plist[0],
+                }
+            )
+        )
+        self.pkgsign(self.durl1, sign_args)
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta1")
+
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_sign_5(self):
+        """Test that http repos work."""
+
+        self.base_sign_5()
+
+        # Verify that older logic of publication api works.
+        self.dcs[1].stop()
+        self.dcs[1].set_disable_ops(["manifest/1"])
+        self.base_sign_5()
+
+    def test_length_two_chains(self):
+        """Check that chains of length two work correctly."""
+
+        ta_path = os.path.join(self.raw_trust_anchor_dir, "ta2_cert.pem")
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
+            ta=ta_path,
+            pkg=plist[0],
+        )
+
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+
+        self.pkg("set-property signature-policy verify")
+        # This should trigger a UntrustedSelfSignedCert error.
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.UntrustedSelfSignedCert,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Test that the cli handles an UntrustedSelfSignedCert.
+        self.pkg("install example_pkg", exit=1)
+        self.seed_ta_dir("ta2")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy require-names foo")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.MissingRequiredNamesException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        self.pkg("set-property signature-policy require-names " "'cs1_ta2'")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("add-property-value signature-required-names 'ta2'")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+
+    def test_length_two_chains_two(self):
+        """Check that chains of length two work correctly when the trust
+        anchor is not included as an intermediate cert."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} {pkg}".format(
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
+            pkg=plist[0],
+        )
+
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+
+        self.pkg("set-property signature-policy verify")
+        # This should trigger a BrokenChain error.
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.BrokenChain, self._api_install, api_obj, ["example_pkg"]
+        )
+        self.seed_ta_dir("ta2")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy require-names foo")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.MissingRequiredNamesException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        self.pkg("set-property signature-policy require-names " "'cs1_ta2'")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("add-property-value signature-required-names 'ta2'")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+
+    def test_variant_sigs(self):
+        """Test that variant tagged signatures are ignored."""
+        plist = self.pkgsend_bulk(self.rurl1, self.varsig_pkg)
+        self.pkg_image_create(self.rurl1)
+
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+
+    def test_bad_opts_1(self):
+        self.pkgsign(self.durl1, "--help")
+        self.dcs[1].start()
+        self.pkgsign(self.durl1, "foo@1.2.3", exit=1)
+        self.pkgsign(self.durl1, "example_pkg", exit=1)
+        plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
+
+        # Test that not specifying a destination repository fails.
+        self.pkgsign("", "'*'", exit=2)
+
+        # Test that passing a repo that doesn't exist doesn't cause
+        # a traceback.
+        self.pkgsign(
+            "http://foobar.baz", "{name}".format(name=plist[0]), exit=1
+        )
+
+        # Test that passing no fmris or patterns results in an error.
+        self.pkgsign(self.durl1, "", exit=2)
+
+        # Test bad sig.alg setting.
+        self.pkgsign(
+            self.durl1,
+            "-a foo -k {key} -c {cert} "
+            "{name}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                name=plist[0],
+            ),
+            exit=2,
+        )
+
+        # Test missing cert option
+        self.pkgsign(
+            self.durl1,
+            "-k {key} {name}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                name=plist[0],
+            ),
+            exit=2,
+        )
+        # Test missing key option
+        self.pkgsign(
+            self.durl1,
+            "-c %(cert) {name}".format(
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                name=plist[0],
+            ),
+            exit=2,
+        )
+        # Test -i with missing -c and -k
+        self.pkgsign(
+            self.durl1,
+            "-i {i1} {name}".format(
+                i1=os.path.join(self.chain_certs_dir, "ch1_ta1_cert.pem"),
+                name=plist[0],
+            ),
+            exit=2,
+        )
+        # Test passing a cert as a key
+        self.pkgsign(
+            self.durl1,
+            "-c {cert} -k {cert} {name}".format(
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                name=plist[0],
+            ),
+            exit=1,
+        )
+        # Test passing a non-existent certificate file
+        self.pkgsign(
+            self.durl1,
+            "-c /shouldnotexist -k {key} "
+            "{name}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                name=plist[0],
+            ),
+            exit=2,
+        )
+        # Test passing a non-existent key file
+        self.pkgsign(
+            self.durl1,
+            "-c {cert} -k /shouldnotexist "
+            "{name}".format(
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                name=plist[0],
+            ),
+            exit=2,
+        )
+        # Test passing a file that's not a key file as a key file
+        self.pkgsign(
+            self.durl1,
+            "-k {key} -c {cert} {name}".format(
+                key=os.path.join(self.test_root, "tmp/example_file"),
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                name=plist[0],
+            ),
+            exit=1,
+        )
+        # Test passing a non-existent file as an intermediate cert
+        self.pkgsign(
+            self.durl1,
+            "-k {key} -c {cert} -i {i1} "
+            "{name}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                i1=os.path.join(self.chain_certs_dir, "shouldnot/exist"),
+                name=plist[0],
+            ),
+            exit=2,
+        )
+        # Test passing a directory as an intermediate cert
+        self.pkgsign(
+            self.durl1,
+            "-k {key} -c {cert} -i {i1} "
+            "{name}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                i1=self.chain_certs_dir,
+                name=plist[0],
+            ),
+            exit=2,
+        )
+        # Test setting the signature algorithm to be one which requires
+        # a key and cert, but not passing -k or -c.
+        self.pkgsign(self.durl1, "-a rsa-sha256 {0}".format(plist[0]), exit=2)
+        # Test setting the signature algorithm to be one which does not
+        # use a key and cert, but passing -k and -c.
+        self.pkgsign(
+            self.durl1,
+            "-a sha256 -k {key} -c {cert} "
+            "{name}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                name=plist[0],
+            ),
+            exit=2,
+        )
+        # Test that signing a package using a bogus certificate fails.
+        self.pkgsign(
+            self.durl1,
+            "-k {key} -c {cert} {name}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                cert=os.path.join(self.test_root, "tmp/example_file"),
+                name=plist[0],
+            ),
+            exit=1,
+        )
+        self.pkg_image_create(self.durl1)
+        self.pkg("set-property signature-policy verify")
+        self.pkg(
+            "set-property trust-anchor-directory {0}".format(
+                os.path.join("simple_file")
+            )
+        )
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.InvalidPropertyValue,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Test that the cli handles an InvalidPropertyValue exception.
+        self.pkg("install example_pkg", exit=1)
+
+    def test_bad_opts_2(self):
+        """Test that having a bogus trust anchor will stop install."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        self.pkgsign(
+            self.rurl1,
+            "-k {key} -c {cert} {name}".format(
+                key=os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                cert=os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                name=plist[0],
+            ),
+        )
+        self.pkg_image_create(self.rurl1)
+        self.pkg("set-property signature-policy verify")
+        self.pkg(
+            "set-property trust-anchor-directory {0}".format(
+                os.path.join("simple_file")
+            )
+        )
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.InvalidPropertyValue,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+
+    def test_dry_run_option(self):
+        """Test that -n doesn't actually sign packages."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-n -k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(
+            additional_args="--set-property signature-policy=require-signatures"
+        )
+        self.seed_ta_dir("ta3")
+        self.pkg("set-publisher -p {0}".format(self.rurl1))
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+
+    def test_multiple_hash_algs(self):
+        """Test that signing with other hash algorithms works
+        correctly."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        self.pkgsign_simple(self.rurl1, plist[0])
+
+        sign_args = "-a rsa-sha512 -k {key} -c {cert} -i {i1} " "{name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        sign_args = "-a sha384 {name}".format(name=plist[0])
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property require-signatures verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_mismatched_sigs(self):
+        """Test that if the certificate can't validate the signature,
+        an error happens."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+
+        self.assertRaises(
+            apx.UnverifiedSignature, self._api_install, api_obj, ["example_pkg"]
+        )
+        # Test that the cli handles an UnverifiedSignature exception.
+        self.pkg("install example_pkg", exit=1)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("unset-property signature-policy")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.UnverifiedSignature, self._api_install, api_obj, ["example_pkg"]
+        )
+
+    def test_mismatched_hashes(self):
+        """Test that if the hash signature isn't correct, an error
+        happens."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "{name}".format(name=plist[0])
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+
+        # Make sure the manifest is locally stored.
+        self.pkg("install -n example_pkg")
+        # Append an action to the manifest.
+        pfmri = fmri.PkgFmri(plist[0])
+        s = self.get_img_manifest(pfmri)
+        s += "\nset name=foo value=bar"
+        self.write_img_manifest(pfmri, s)
+
+        DebugValues["manifest_validate"] = "Never"
+
+        self.pkg("set-property signature-policy verify")
+        # This should fail because the text of manifest has changed
+        # so the hash should no longer validate.
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.UnverifiedSignature, self._api_install, api_obj, ["example_pkg"]
+        )
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self.pkg("unset-property signature-policy")
+        # Make sure the manifest is locally stored.
+        self.pkg("install -n example_pkg")
+        # Append an action to the manifest.
+        pfmri = fmri.PkgFmri(plist[0])
+        s = self.get_img_manifest(pfmri)
+        s += "\nset name=foo value=bar"
+        self.write_img_manifest(pfmri, s)
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.UnverifiedSignature, self._api_install, api_obj, ["example_pkg"]
+        )
+
+    def test_unknown_sig_alg(self):
+        """Test that if the certificate can't validate the signature,
+        an error happens."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        # Make sure the manifest is locally stored.
+        api_obj = self.get_img_api_obj()
+        for pd in api_obj.gen_plan_install(["example_pkg"], noexecute=True):
+            continue
+        # Change the signature action.
+        pfmri = fmri.PkgFmri(plist[0])
+        s = self.get_img_manifest(pfmri)
+        s = s.replace("rsa-sha256", "rsa-foobar")
+        self.write_img_manifest(pfmri, s)
+
+        DebugValues["manifest_validate"] = "Never"
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # This passes because 'foobar' isn't a recognized hash algorithm
+        # so the signature action is skipped.
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+
+        # Write manifest to image cache again.
+        self.write_img_manifest(pfmri, s)
+
+        # Change the signature action.
+        pfmri = fmri.PkgFmri(plist[0])
+        s = self.get_img_manifest(pfmri)
+        s = s.replace("rsa-foobar", "foo-sha256")
+        self.write_img_manifest(pfmri, s)
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        self.pkg(
+            "--debug manifest_validate=Never install " "example_pkg", exit=1
+        )
+        # This passes because 'foobar' isn't a recognized signature
+        # algorithm so the signature action is skipped.
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_unsupported_critical_extension_1(self):
+        """Test that packages signed using a certificate with an
+        unsupported critical extension will not have valid signatures.
+        """
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs2_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs2_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.UnsupportedCriticalExtension,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Tests that the cli can handle an UnsupportedCriticalExtension.
+        self.pkg("install example_pkg", exit=1)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_unsupported_critical_extension_2(self):
+        """Test that packages signed using a certificate whose chain of
+        trust contains a certificate with an unsupported critical
+        extension will not have valid signatures."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1.1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1.1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1.1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.BrokenChain, self._api_install, api_obj, ["example_pkg"]
+        )
+
+    def test_unsupported_critical_extension_3(self):
+        """Test that packages signed using a certificate whose chain of
+        trust contains a certificate with an unsupported critical
+        extension will not have valid signatures."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} {name}".format(
+                **{
+                    "name": plist[0],
+                    "key": os.path.join(self.keys_dir, "cs1_ch5.1_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs1_ch5.1_ta1_cert.pem"),
+                    "i1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta1_cert.pem"
+                    ),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5.1_ta1_cert.pem"
+                    ),
+                }
+            )
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta1")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.BrokenChain, self._api_install, api_obj, ["example_pkg"]
+        )
+
+    def test_inappropriate_use_of_code_signing_cert(self):
+        """Test that signing a certificate with a code signing
+        certificate results in a broken chain."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " "{name}".format(
+            **{
+                "name": plist[0],
+                "key": os.path.join(self.keys_dir, "cs1_cs8_ch1_ta3_key.pem"),
+                "cert": os.path.join(self.cs_dir, "cs1_cs8_ch1_ta3_cert.pem"),
+                "i1": os.path.join(self.cs_dir, "cs8_ch1_ta3_cert.pem"),
+                "i2": os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+            }
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        # This raises a BrokenChain exception because the certificate
+        # check_ca method checks the keyUsage extension if it's set
+        # as well as the basicConstraints extension.
+        self.assertRaises(
+            apx.BrokenChain, self._api_install, api_obj, ["example_pkg"]
+        )
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_inappropriate_use_of_cert_signing_cert(self):
+        """Test that using a CA cert without the digitalSignature
+        value for the keyUsage extension to sign a package means
+        that the package's signature doesn't verify."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "ch1_ta3_key.pem"),
+            cert=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.InappropriateCertificateUse,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Tests that the cli can handle an InappropriateCertificateUse
+        # exception.
+        self.pkg("install example_pkg", exit=1)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_no_crlsign_on_revoking_ca(self):
+        """Test that if a CRL is signed with a CA that has the keyUsage
+        extension but not the cRLSign value is not considered a valid
+        CRL."""
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        rstore = r.get_pub_rstore(pub="test")
+        os.makedirs(os.path.join(rstore.file_root, "ch"))
+        portable.copyfile(
+            os.path.join(self.crl_dir, "ch1.1_ta4_crl.pem"),
+            os.path.join(rstore.file_root, "ch", "ch1.1_ta4_crl.pem"),
+        )
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1.1_ta4_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1.1_ta4_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1.1_ta4_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.dcs[1].start()
+
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta4")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        # This succeeds because the CA which signed the revoking CRL
+        # did not have the cRLSign keyUsage extension set.
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_no_empty_chain(self):
+        """Test that signing do not create empty chain"""
+        plist = self.pkgsend_bulk(
+            self.rurl1, self.example_pkg10, debug_hash="sha1+sha512t_256"
+        )
+        sign_args = "-k %(key)s -c %(cert)s %(pkg)s" % {
+            "key": os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            "cert": os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
+            "pkg": plist[0],
+        }
+
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta2")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+        # Make sure signing haven't created empty chain attrs
+        self.pkg("contents -m")
+        self.assertTrue(self.output.count("chain=") == 0)
+
+    def test_unknown_value_for_non_critical_extension(self):
+        """Test that an unknown value for a recognized non-critical
+        extension causes an exception to be raised."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs5_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs5_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.UnsupportedExtensionValue,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Tests that the cli can handle an UnsupportedExtensionValue.
+        self.pkg("install example_pkg", exit=1)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_unknown_value_for_critical_extension(self):
+        """Test that an unknown value for a recognized critical
+        extension causes an exception to be raised."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs6_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs6_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.UnsupportedExtensionValue,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Tests that the cli can handle an UnsupportedExtensionValue.
+        self.pkg("install example_pkg", exit=1)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_invalid_extension_1(self):
+        """Test that an invalid value in the extension causes an
+        exception to be raised."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs9_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs9_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.InvalidCertificateExtensions,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Tests that the cli can handle an InvalidCertificateExtensions.
+        self.pkg("install example_pkg", exit=1)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_invalid_extension_2(self):
+        """Test that a critical extension that Cryptography can't
+        understand causes an exception to be raised."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cust_key.pem"),
+            cert=os.path.join(self.cs_dir, "cust_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("cust")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.UnsupportedCriticalExtension,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Tests that the cli can handle an InvalidCertificateExtensions.
+        self.pkg("install example_pkg", exit=1)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_unset_keyUsage_for_code_signing(self):
+        """Test that if keyUsage has not been set, the code signing
+        certificate is considered valid."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs7_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs7_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_unset_keyUsage_for_cert_signing(self):
+        """Test that if keyUsage has not been set, the CA certificate is
+        considered valid."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1.4_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1.4_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1.4_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_sign_no_server_update(self):
+        """Test --no-index and --no-catalog."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = (
+            "--no-index --no-catalog -i {i1} -k {key} "
+            "-c {cert} {name}".format(
+                name=plist[0],
+                key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+                cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+                i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+            )
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        # This fails because the index hasn't been updated.
+        self.pkg("search -r rsa-sha256", exit=1)
+        self.pkg("set-property signature-policy require-signatures")
+        # This fails because the catalog hasn't been updated with
+        # the signed manifest yet.
+        self.pkg("install example_pkg", exit=1)
+        r = self.get_repo(self.dcs[1].get_repodir())
+        r.rebuild()
+        self.pkg("install example_pkg")
+
+    def test_bogus_client_certs(self):
+        """Tests that if a certificate stored on the client is replaced
+        with a different certificate, installation fails."""
+
+        chain_cert_path = os.path.join(
+            os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem")
+        )
+        cs_path = os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem")
+        cs2_path = os.path.join(self.cs_dir, "cs1_ta2_cert.pem")
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} " "{name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=cs_path,
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+
+        # Replace the client CS cert.
+        hsh = self.calc_pem_hash(cs_path)
+        pth = os.path.join(
+            self.img_path(), "var", "pkg", "publisher", "test", "certs", hsh
+        )
+        portable.copyfile(cs2_path, pth)
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.ModifiedCertificateException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Test that the cli handles a ModifiedCertificateException.
+        self.pkg("install example_pkg", exit=1)
+
+        # Test that removing the CS cert will cause it to be downloaded
+        # again and the installation will then work.
+
+        portable.remove(pth)
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+
+        # Repeat the test but change the chain cert instead of the CS
+        # cert.
+
+        # Replace the client chain cert.
+        hsh = self.calc_pem_hash(chain_cert_path)
+        pth = os.path.join(
+            self.img_path(), "var", "pkg", "publisher", "test", "certs", hsh
+        )
+        portable.copyfile(cs2_path, pth)
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.BrokenChain, self._api_install, api_obj, ["example_pkg"]
+        )
+
+        # Test that removing the chain cert will cause it to be
+        # downloaded again and the installation will then work.
+
+        portable.remove(pth)
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_crl_0(self):
+        """Test that the X509 CRL revocation works correctly."""
+
+        with open(os.path.join(self.crl_dir, "ch1_ta4_crl.pem"), "rb") as f:
+            crl = x509.load_pem_x509_crl(f.read(), default_backend())
+
+        with open(os.path.join(self.cs_dir, "cs1_ch1_ta4_cert.pem"), "rb") as f:
+            cert = x509.load_pem_x509_certificate(f.read(), default_backend())
+
+        self.assertTrue(crl.issuer == cert.issuer)
+        for rev in crl:
+            if rev.serial_number == cert.serial_number:
+                break
+        else:
+            self.assertTrue(
+                False, "Can not find revoked " "certificate in CRL!"
+            )
+
+    def test_bogus_inter_certs(self):
+        """Test that if SignatureAction.set_signature is given invalid
+        paths to intermediate certs, it errors as expected.  This
+        cannot be tested from the command line because the command
+        line rejects certificates that aren't of the right format."""
+
+        attrs = {
+            "algorithm": "sha256",
+        }
+        key_pth = os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem")
+        cert_pth = os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem")
+        sig_act = signature.SignatureAction(cert_pth, **attrs)
+        self.assertRaises(
+            action.ActionDataError,
+            sig_act.set_signature,
+            [sig_act],
+            key_path=key_pth,
+            chain_paths=["/shouldnot/exist"],
+        )
+        self.assertRaises(
+            action.ActionDataError,
+            sig_act.set_signature,
+            [sig_act],
+            key_path=key_pth,
+            chain_paths=[self.test_root],
+        )
+
+    def test_signing_all(self):
+        """Test that using '*' works correctly, signing all packages in
+        a repository."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        plist = self.pkgsend_bulk(self.rurl1, self.var_pkg)
+
+        self.pkgsign_simple(self.rurl1, "'*'")
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self._api_install(api_obj, ["var_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self._api_uninstall(api_obj, ["var_pkg"])
+
+    def test_crl_1(self):
+        """Test that revoking a code signing certificate by the
+        publisher CA works correctly."""
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        rstore = r.get_pub_rstore(pub="test")
+        os.makedirs(os.path.join(rstore.file_root, "ch"))
+        portable.copyfile(
+            os.path.join(self.crl_dir, "ch1_ta4_crl.pem"),
+            os.path.join(rstore.file_root, "ch", "ch1_ta4_crl.pem"),
+        )
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta4_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta4_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta4_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.dcs[1].start()
+
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta4")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        # Check that when the check-certificate-revocation is False, its
+        # default value, that the install succeedes.
+        self._api_install(api_obj, ["example_pkg"])
+        self.pkg("set-property check-certificate-revocation true")
+        self.pkg("verify", su_wrap=True, exit=1)
+        self._api_uninstall(api_obj, ["example_pkg"])
+        api_obj.reset()
+        self.assertRaises(
+            apx.RevokedCertificate, self._api_install, api_obj, ["example_pkg"]
+        )
+        # Test that cli handles RevokedCertificate exception.
+        self.pkg("install example_pkg", exit=1)
+
+    def test_crl_2(self):
+        """Test that revoking a code signing certificate by the
+        publisher CA works correctly."""
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        rstore = r.get_pub_rstore(pub="test")
+        os.makedirs(os.path.join(rstore.file_root, "ta"))
+        portable.copyfile(
+            os.path.join(self.crl_dir, "ta5_crl.pem"),
+            os.path.join(rstore.file_root, "ta", "ta5_crl.pem"),
+        )
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta5_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta5_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta5_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.dcs[1].start()
+
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta5")
+        self.pkg("set-property check-certificate-revocation true")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.BrokenChain, self._api_install, api_obj, ["example_pkg"]
+        )
+
+    def test_crl_3(self):
+        """Test that a CRL with a bad file format does not cause
+        breakage."""
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        rstore = r.get_pub_rstore(pub="test")
+        os.makedirs(os.path.join(rstore.file_root, "ex"))
+        portable.copyfile(
+            os.path.join(self.test_root, "tmp/example_file"),
+            os.path.join(rstore.file_root, "ex", "example_file"),
+        )
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs2_ch1_ta4_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs2_ch1_ta4_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta4_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.dcs[1].start()
+
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta4")
+        self.pkg("set-property check-certificate-revocation true")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_crl_4(self):
+        """Test that a CRL which cannot be retrieved does not cause
+        breakage."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs2_ch1_ta4_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs2_ch1_ta4_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta4_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.dcs[1].start()
+
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta4")
+        self.pkg("set-property check-certificate-revocation true")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_crl_5(self):
+        """Test that revocation by CRL validated by a grandparent of the
+        certificate in question works."""
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        rstore = r.get_pub_rstore(pub="test")
+        os.makedirs(os.path.join(rstore.file_root, "ch"))
+        portable.copyfile(
+            os.path.join(self.crl_dir, "ch5_ta1_crl.pem"),
+            os.path.join(rstore.file_root, "ch", "ch5_ta1_crl.pem"),
+        )
+
+        self.dcs[1].start()
+
+        plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} {pkg}".format(
+                **{
+                    "key": os.path.join(self.keys_dir, "cs2_ch5_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs2_ch5_ta1_cert.pem"),
+                    "i1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta1_cert.pem"
+                    ),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5_ta1_cert.pem"
+                    ),
+                    "pkg": plist[0],
+                }
+            )
+        )
+
+        self.pkgsign(self.durl1, sign_args)
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta1")
+        self.pkg("set-property check-certificate-revocation true")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RevokedCertificate, self._api_install, api_obj, ["example_pkg"]
+        )
+
+    def test_crl_6(self):
+        """Test that revocation by CRL validated by an intermediate
+        certificate of the certificate in question works."""
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        rstore = r.get_pub_rstore(pub="test")
+        os.makedirs(os.path.join(rstore.file_root, "ch"))
+        portable.copyfile(
+            os.path.join(self.crl_dir, "ch5_ta1_crl.pem"),
+            os.path.join(rstore.file_root, "ch", "ch5_ta1_crl.pem"),
+        )
+
+        self.dcs[1].start()
+
+        plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} {pkg}".format(
+                **{
+                    "key": os.path.join(self.keys_dir, "cs2_ch5_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs2_ch5_ta1_cert.pem"),
+                    "i1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta1_cert.pem"
+                    ),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5_ta1_cert.pem"
+                    ),
+                    "pkg": plist[0],
+                }
+            )
+        )
+
+        self.pkgsign(self.durl1, sign_args)
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta1")
+        self.pkg("set-property check-certificate-revocation true")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RevokedCertificate, self._api_install, api_obj, ["example_pkg"]
+        )
+
+    def test_crl_7(self):
+        """Test that a CRL location which isn't in a known URI format
+        doesn't cause breakage."""
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs3_ch1_ta4_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs3_ch1_ta4_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta4_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.dcs[1].start()
+
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta4")
+        self.pkg("set-property check-certificate-revocation true")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.InvalidResourceLocation,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # Test that the cli can handle a InvalidResourceLocation
+        # exception.
+        self.pkg("install example_pkg", exit=1)
+        self.pkg("set-property signature-policy ignore")
+        self.pkg("set-publisher --set-property signature-policy=ignore " "test")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("verify", exit=1)
+
+    def test_crl_8(self):
+        """Test that if two packages share the same CRL, it's only
+        downloaded once even if it can't be stored permanently in the
+        image."""
+
+        def cnt_crl_contacts(log_path):
+            c = 0
+            with open(log_path, "r") as fh:
+                for line in fh:
+                    if "ch1_ta4_crl.pem" in line:
+                        c += 1
+            return c
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        rstore = r.get_pub_rstore(pub="test")
+        os.makedirs(os.path.join(rstore.file_root, "ch"))
+        portable.copyfile(
+            os.path.join(self.crl_dir, "ch1_ta4_crl.pem"),
+            os.path.join(rstore.file_root, "ch", "ch1_ta4_crl.pem"),
+        )
+
+        plist = self.pkgsend_bulk(
+            self.rurl1, [self.example_pkg10, self.var_pkg]
+        )
+
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=" ".join(plist),
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta4_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta4_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta4_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.dcs[1].start()
+
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta4")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg", "var_pkg"])
+        self.pkg("set-property check-certificate-revocation true")
+        # Check that the server is only contacted once per CRL, not once
+        # per package with that CRL.
+        self.pkg("verify", su_wrap=True, exit=1)
+        self.assertEqual(cnt_crl_contacts(self.dcs[1].get_logpath()), 1)
+        self.pkg("verify", exit=1)
+        # Pkg should contact the server once more then store it in its
+        # permanent location.
+        self.assertEqual(cnt_crl_contacts(self.dcs[1].get_logpath()), 2)
+        # Check that once the crl file is in its permanent location,
+        # it's not retrieved again.
+        self.pkg("verify", su_wrap=True, exit=1)
+        self.assertEqual(cnt_crl_contacts(self.dcs[1].get_logpath()), 2)
+        self.pkg("verify", exit=1)
+        self.assertEqual(cnt_crl_contacts(self.dcs[1].get_logpath()), 2)
+
+    def __setup_signed_simple(self, pkg_srcs, pkg_names):
+        plist = self.pkgsend_bulk(self.rurl1, pkg_srcs)
+
+        for pfmri in plist:
+            self.pkgsign_simple(self.rurl1, pfmri)
+
+        self.pkg_image_create(
+            self.rurl1, additional_args="--variant variant.arch=i386"
+        )
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, pkg_names)
+        return api_obj
+
+    def test_var_pkg(self):
+        """Test that actions tagged with variants don't break signing."""
+
+        api_obj = self.__setup_signed_simple([self.var_pkg], ["var_pkg"])
+        self.pkg("verify")
+        self.assertTrue(os.path.exists(os.path.join(self.img_path(), "baz")))
+        self.assertTrue(
+            not os.path.exists(os.path.join(self.img_path(), "bin"))
+        )
+
+        # verify changing variant after install also works
+        self._api_change_varcets(
+            api_obj, variants={"variant.arch": "sparc"}, refresh_catalogs=False
+        )
+
+        self.assertTrue(
+            not os.path.exists(os.path.join(self.img_path(), "baz"))
+        )
+        self.assertTrue(os.path.exists(os.path.join(self.img_path(), "bin")))
+        self.pkg("verify")
+
+    def test_facet_pkg(self):
+        """Test that actions tagged with facets don't break signing."""
+
+        api_obj = self.__setup_signed_simple([self.facet_pkg], ["facet_pkg"])
+        self.pkg("verify")
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(
+                    self.img_path(), "usr", "share", "doc", "i386_doc.txt"
+                )
+            )
+        )
+        self.assertTrue(
+            not os.path.exists(
+                os.path.join(
+                    self.img_path(), "usr", "share", "doc", "sparc_devel.txt"
+                )
+            )
+        )
+
+        # verify changing facet after install also works
+        nfacets = facet.Facets({"facet.doc": False})
+        self._api_change_varcets(
+            api_obj, facets=nfacets, refresh_catalogs=False
+        )
+        self.assertTrue(
+            not os.path.exists(
+                os.path.join(
+                    self.img_path(), "usr", "share", "doc", "i386_doc.txt"
+                )
+            )
+        )
+        self.assertTrue(
+            not os.path.exists(
+                os.path.join(
+                    self.img_path(), "usr", "share", "doc", "sparc_devel.txt"
+                )
+            )
+        )
+        self.pkg("verify")
+
+    def test_mediator_pkg(self):
+        """Test that actions tagged with mediators don't break
+        signing."""
+
+        def check_target(links, target):
+            for lpath in links:
+                ltarget = os.readlink(lpath)
+                self.assertTrue(ltarget.endswith(target))
+
+        api_obj = self.__setup_signed_simple([self.med_pkg], ["med_pkg"])
+        self.pkg("verify")
+
+        # verify /bin/example mediation points to example-1.7 by default
+        ex_link = self.get_img_file_path("bin/example")
+        check_target([ex_link], "example-1.7")
+
+        # verify changing mediation after install works as expected
+        self.pkg("set-mediator -V1.6 example")
+        check_target([ex_link], "example-1.6")
+        self.pkg("verify")
+
+        # Verify removal of mediated links when no mediation applies
+        # works as expected.
+        self.pkg("set-mediator -V1.8 example")
+        self.assertTrue(not os.path.exists(ex_link))
+        self.pkg("verify")
+
+        # Verify mediated links are restored when mediation is reset.
+        self.pkg("set-property signature-policy require-signatures")
+        self.pkg("set-mediator -V1.6 example")
+        check_target([ex_link], "example-1.6")
+        self.pkg("verify")
+
+    def test_fix_revert_pkg(self):
+        """Test that fix and revert works with signed packages."""
+
+        api_obj = self.__setup_signed_simple([self.facet_pkg], ["facet_pkg"])
+        self.pkg("verify")
+        doc_path = self.get_img_file_path("usr/share/doc/i386_doc.txt")
+        self.assertTrue(os.path.exists(doc_path))
+
+        # Remove doc, then verify that fix and revert will restore it.
+        for cmd in ("fix", "revert usr/share/doc/i386_doc.txt"):
+            portable.remove(doc_path)
+            self.assertTrue(not os.path.exists(doc_path))
+            self.pkg(cmd)
+            self.assertTrue(os.path.exists(doc_path))
+
+    def test_conflicting_pkgs(self):
+        """Test that conflicting package repair works with signed
+        packages."""
+
+        DebugValues["broken-conflicting-action-handling"] = 1
+        try:
+            # Install conflicting packages.
+            api_obj = self.__setup_signed_simple(
+                [self.conflict_pkgs], ["conflict_a_pkg", "conflict_b_pkg"]
+            )
+            rel_path = self.get_img_file_path("etc/release")
+            self.assertTrue(os.path.exists(rel_path))
+        finally:
+            del DebugValues["broken-conflicting-action-handling"]
+
+        # Now remove one of the conflicting packages and verify that the
+        # repair happens as expected.
+        self._api_uninstall(api_obj, ["conflict_b_pkg"])
+        self.pkg("verify")
+        self.file_contains("etc/release", "tmp/example_file")
+
+    def test_disabled_append(self):
+        """Test that publishing to a depot which doesn't support append
+        fails as expected."""
+
+        self.dcs[1].set_disable_ops(["append"])
+        self.dcs[1].start()
+
+        plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
+
+        self.pkgsign_simple(self.durl1, plist[0], exit=1)
+
+    def test_disabled_add(self):
+        """Test that publishing to a depot which doesn't support add
+        fails as expected."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        # New publication uses manifest/1 to upload manifest as-is
+        # and avoid using add ops. Disable manifest/1 to fall back
+        # to older logic here for testing.
+        self.dcs[1].set_disable_ops(["add", "manifest/1"])
+        self.dcs[1].start()
+
+        sign_args = "-k {key} -c {cert} {pkg}".format(
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            pkg=plist[0],
+        )
+        self.pkgsign(self.durl1, sign_args, exit=1)
+
+    def test_disabled_file(self):
+        """Test that publishing to a depot which doesn't support file
+        fails as expected."""
+
+        # New publication uses manifest/1 which uses file/1, so if we
+        # disable file ops, we can't use the new publication model.
+        # Disable manifest/1 to fall back to older logic here for
+        # testing.
+        self.dcs[1].set_disable_ops(["file", "manifest/1"])
+        self.dcs[1].start()
+
+        plist = self.pkgsend_bulk(self.durl1, self.example_pkg10)
+
+        self.pkgsign_simple(self.durl1, plist[0], exit=1)
+
+    def test_expired_certs(self):
+        """Test that expiration dates on the signing cert are
+        ignored."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs3_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs3_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        # This should succeed because we currently ignore certificate
+        # expiration and start dates.
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_future_certs(self):
+        """Test that expiration dates on the signing cert are
+        ignored."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs4_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs4_ch1_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        # This should succeed because we currently ignore certificate
+        # expiration and start dates.
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_expired_chain_certs(self):
+        """Test that expiration dates on a chain cert are ignored."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1.2_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1.2_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1.2_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        # This should succeed because we currently ignore certificate
+        # expiration and start dates.
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_future_chain_certs(self):
+        """Test that expiration dates on a chain cert are ignored."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1.3_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1.3_ta3_cert.pem"),
+            i1=os.path.join(self.chain_certs_dir, "ch1.3_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        # This should succeed because we currently ignore certificate
+        # expiration and start dates.
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_cert_retrieval_failure(self):
+        """Test that a certificate that can't be retrieved doesn't
+        cause a traceback."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.var_pkg)
+        self.pkgsign_simple(self.rurl1, plist[0])
+
+        self.dcs[1].start()
+
+        self.pkg_image_create(self.durl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("info -r var_pkg")
+        self.dcs[1].stop()
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        # This should succeed because we currently ignore certificate
+        # expiration and start dates.
+        self.assertRaises(
+            apx.TransportError,
+            self._api_install,
+            api_obj,
+            ["var_pkg"],
+            refresh_catalogs=False,
+        )
+
+        # Test that a TransportError from certificate retrieval is
+        # handled correctly.
+        self.pkg("install --no-refresh var_pkg", exit=1)
+
+    def test_manual_pub_cert_approval(self):
+        """Test that manually approving a publisher's CA cert works
+        correctly."""
+
+        ca_path = os.path.join(
+            os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem")
+        )
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            i1=ca_path,
+        )
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(
+            self.rurl1,
+            additional_args="--set-property signature-policy=require-signatures",
+        )
+        self.pkg("set-publisher --approve-ca-cert {0} test".format(ca_path))
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_higher_signature_version(self):
+        """Test that a signature version that isn't recognized is
+        ignored."""
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        self.pkgsign_simple(self.rurl1, plist[0])
+        mp = r.manifest(plist[0])
+        with open(mp, "r") as fh:
+            ls = fh.readlines()
+        s = []
+        old_ver = action.generic.Action.sig_version
+        new_ver = old_ver + 1
+        # Replace the published manifest with one whose signature
+        # action has a version one higher than what the current
+        # supported version is.
+        for l in ls:
+            if not l.startswith("signature"):
+                s.append(l)
+                continue
+            tmp = l.replace(
+                "version={0}".format(old_ver), "version={0}".format(new_ver)
+            )
+            s.append(tmp)
+        with open(mp, "w") as fh:
+            for l in s:
+                fh.write(l)
+        # Rebuild the repository catalog so that hash verification for
+        # the manifest won't cause problems.
+        r.rebuild()
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["example_pkg"],
+        )
+        # This passes because it ignores the signature with a version
+        # it doesn't understand.
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_using_default_cert_loc(self):
+        """Test that the default location is properly image relative
+        and is used."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        self.pkgsign_simple(self.rurl1, plist[0])
+
+        self.pkg_image_create(
+            self.rurl1,
+            additional_args="--set-property "
+            "signature-policy=require-signatures",
+        )
+        self.seed_ta_dir("ta3")
+
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_using_pkg_image_cert_loc(self):
+        """Test that trust anchors are properly pulled from the image
+        that the pkg command was run from."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        self.pkgsign_simple(self.rurl1, plist[0])
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+
+        # This changes the default image we're operating on.
+        self.set_image(1)
+        self.image_create(self.rurl1, destroy=False)
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        # This raises an exception because the command is run from
+        # within the sub-image, which has now trust anchors installed.
+        self.assertRaises(
+            apx.BrokenChain, self._api_install, api_obj, ["example_pkg"]
+        )
+        # This should work because the command is run from within the
+        # original image which contains the trust anchors needed to
+        # validate the chain.
+        cmd_path = os.path.join(self.img_path(0), "pkg")
+        api_obj = self.get_img_api_obj(cmd_path=cmd_path)
+        self._api_install(api_obj, ["example_pkg"])
+        # Check that the package is installed into the correct image.
+        self.pkg("list example_pkg")
+        self.pkg("-R {0} list example_pkg".format(self.img_path(0)), exit=1)
+        api_obj = self.get_img_api_obj()
+        self._api_uninstall(api_obj, ["example_pkg"])
+        # Repeat the test using the pkg command interface instead of the
+        # api.
+        self.pkg(
+            "-D simulate_cmdpath={0} -R {1} install example_pkg".format(
+                cmd_path, self.img_path()
+            )
+        )
+        self.pkg("list example_pkg")
+        self.pkg("-R {0} list example_pkg".format(self.img_path(0)), exit=1)
+
+    def test_big_pathlen(self):
+        """Test that a chain cert which has a larger pathlen value than
+        is needed is allowed."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} {pkg}".format(
+                **{
+                    "key": os.path.join(self.keys_dir, "cs1_ch5.2_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs1_ch5.2_ta1_cert.pem"),
+                    "i1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta1_cert.pem"
+                    ),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5.2_ta1_cert.pem"
+                    ),
+                    "pkg": plist[0],
+                }
+            )
+        )
+
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta1")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_small_pathlen(self):
+        """Test that a chain cert which has a smaller pathlen value than
+        is needed is disallowed."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} {pkg}".format(
+                **{
+                    "key": os.path.join(self.keys_dir, "cs1_ch5.3_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs1_ch5.3_ta1_cert.pem"),
+                    "i1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta1_cert.pem"
+                    ),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4.3_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5.3_ta1_cert.pem"
+                    ),
+                    "pkg": plist[0],
+                }
+            )
+        )
+
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta1")
+
+        self.pkg("set-property signature-policy verify")
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.PathlenTooShort, self._api_install, api_obj, ["example_pkg"]
+        )
+        # Check that the cli hands PathlenTooShort exceptions.
+        self.pkg("install example_pkg", exit=1)
+
+    def test_bug_16861_1(self):
+        """Test whether obsolete packages can be signed and still
+        function."""
+
+        plist = self.pkgsend_bulk(self.rurl1, obsolete_pkg)
+        self.pkgsign_simple(self.rurl1, plist[0])
+
+        self.pkg_image_create(
+            self.rurl1,
+            additional_args="--set-property "
+            "signature-policy=require-signatures",
+        )
+        self.seed_ta_dir("ta3")
+
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["obs"])
+
+    def test_bug_16861_2(self):
+        """Test whether renamed packages can be signed and still
+        function."""
+
+        plist = self.pkgsend_bulk(
+            self.rurl1, [self.example_pkg10, renamed_pkg, self.need_renamed_pkg]
+        )
+        for name in plist:
+            self.pkgsign_simple(self.rurl1, name)
+
+        self.pkg_image_create(
+            self.rurl1,
+            additional_args="--set-property "
+            "signature-policy=require-signatures",
+        )
+        self.seed_ta_dir("ta3")
+
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["need_renamed"])
+
+    def test_bug_16867_1(self):
+        """Test whether signing a package multiple times makes a package
+        uninstallable."""
+
+        chain_cert_path = os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem")
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        self.pkgsign_simple(self.rurl1, plist[0])
+        self.pkgsign_simple(self.rurl1, plist[0])
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy verify")
+
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_bug_16867_2(self):
+        """Test whether signing a package which already has multiple
+        identical signatures results in an error."""
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        self.pkgsign_simple(self.rurl1, plist[0])
+
+        mp = r.manifest(plist[0])
+        with open(mp, "r") as fh:
+            ls = fh.readlines()
+        s = []
+        for l in ls:
+            # Double all signature actions.
+            if l.startswith("signature"):
+                s.append(l)
+            s.append(l)
+        with open(mp, "w") as fh:
+            for l in s:
+                fh.write(l)
+
+        hash_alg_list = ["sha256"]
+        if sha512_supported:
+            hash_alg_list.append("sha512t_256")
+        for hash_alg in hash_alg_list:
+            # Rebuild the catalog so that hash verification for the
+            # manifest won't cause problems.
+            r.rebuild()
+            # This should fail because the manifest already has
+            # identical signature actions in it.
+            self.pkgsign_simple(self.rurl1, plist[0], exit=1)
+
+            # The addition of SHA-256 hashes should still result in
+            # us believing the signatures are identical.
+            self.pkgsign_simple(
+                self.rurl1,
+                plist[0],
+                exit=1,
+                debug_hash="sha1+{0}".format(hash_alg),
+            )
+
+            self.pkg_image_create(self.rurl1)
+            self.seed_ta_dir("ta3")
+            self.pkg("set-property signature-policy verify")
+
+            # This fails because the manifest contains duplicate
+            # signatures.
+            api_obj = self.get_img_api_obj()
+            self.assertRaises(
+                apx.UnverifiedSignature,
+                self._api_install,
+                api_obj,
+                ["example_pkg"],
+            )
+
+    def test_bug_16867_hashes_1(self):
+        """Test whether signing a package a second time with hashes
+        fails."""
+
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        sign_args = "{name}".format(
+            name=plist[0],
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        self.pkgsign(self.rurl1, sign_args)
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy verify")
+
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_bug_16867_almost_identical(self):
+        """Test whether signing a package which already has a similar
+        but not identical signature results in an error."""
+
+        r = self.get_repo(self.dcs[1].get_repodir())
+        chain_cert_path = os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem")
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+        self.pkgsign_simple(self.rurl1, plist[0])
+
+        mp = r.manifest(plist[0])
+        with open(mp, "r") as fh:
+            ls = fh.readlines()
+        s = []
+        for l in ls:
+            # Double all signature actions.
+            if l.startswith("signature"):
+                a = action.fromstr(l)
+                a.attrs["value"] = "foo"
+                s.append(str(a))
+            else:
+                s.append(l)
+        with open(mp, "w") as fh:
+            for l in s:
+                fh.write(l)
+        # Rebuild the catalog so that hash verification for the manifest
+        # won't cause problems.
+        r.rebuild()
+        # This should fail because the manifest already has almost
+        # identical signature actions in it.
+        self.pkgsign_simple(self.rurl1, plist[0], exit=1)
+
+    def test_bug_17740_default_pub(self):
+        """Test that signing a package in the default publisher of a
+        multi-publisher repository works."""
+
+        self.pkgrepo("add_publisher -s {0} pub2".format(self.rurl1))
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        self.pkgsign_simple(self.rurl1, "'ex*'")
+
+        self.pkg_image_create(
+            additional_args="--set-property signature-policy=require-signatures"
+        )
+        self.seed_ta_dir("ta3")
+        self.pkg("set-publisher -p {0}".format(self.rurl1))
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, plist)
+
+    def test_bug_17740_alternate_pub(self):
+        """Test that signing a package in an alternate publisher of a
+        multi-publisher repository works."""
+
+        self.pkgrepo("add_publisher -s {0} pub2".format(self.rurl1))
+        plist = self.pkgsend_bulk(self.rurl1, self.pub2_pkg)
+
+        self.pkgsign_simple(self.rurl1, "'*2pk*'")
+
+        self.pkg_image_create(
+            additional_args="--set-property signature-policy=require-signatures"
+        )
+        self.seed_ta_dir("ta3")
+        self.pkg("set-publisher -p {0}".format(self.rurl1))
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, plist)
+
+    def test_bug_17740_name_collision_1(self):
+        """Test that when two publishers have packages with the same
+        name, the publisher in the sign command is respected.  This test
+        signs the package from the default publisher."""
+
+        self.pkgrepo("add_publisher -s {0} pub2".format(self.rurl1))
+        plist = self.pkgsend_bulk(
+            self.rurl1, [self.example_pkg10, self.pub2_example]
+        )
+
+        self.pkgsign_simple(self.rurl1, "pkg://test/example_pkg")
+
+        self.pkg_image_create(
+            additional_args="--set-property signature-policy=require-signatures"
+        )
+        self.seed_ta_dir("ta3")
+        self.pkg("set-publisher -p {0}".format(self.rurl1))
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["pkg://pub2/example_pkg"],
+        )
+        self._api_install(api_obj, ["pkg://test/example_pkg"])
+
+    def test_bug_17740_name_collision_2(self):
+        """Test that when two publishers have packages with the same
+        name, the publisher in the sign command is respected.  This test
+        signs the package from the non-default publisher."""
+
+        self.pkgrepo("add_publisher -s {0} pub2".format(self.rurl1))
+        plist = self.pkgsend_bulk(
+            self.rurl1, [self.example_pkg10, self.pub2_example]
+        )
+
+        self.pkgsign_simple(self.rurl1, "pkg://pub2/example_pkg")
+
+        self.pkg_image_create(
+            additional_args="--set-property signature-policy=require-signatures"
+        )
+        self.seed_ta_dir("ta3")
+        self.pkg("set-publisher -p {0}".format(self.rurl1))
+        api_obj = self.get_img_api_obj()
+        self.assertRaises(
+            apx.RequiredSignaturePolicyException,
+            self._api_install,
+            api_obj,
+            ["pkg://test/example_pkg"],
+        )
+        self._api_install(api_obj, ["pkg://pub2/example_pkg"])
+
+    def test_bug_17740_anarchistic_pkg(self):
+        """Test that signing a package present in both repositories
+        signs both packages."""
+
+        self.pkgrepo("add_publisher -s {0} pub2".format(self.rurl1))
+        plist = self.pkgsend_bulk(
+            self.rurl1, [self.example_pkg10, self.pub2_example]
+        )
+
+        self.pkgsign_simple(self.rurl1, "example_pkg")
+
+        self.pkg_image_create(
+            additional_args="--set-property signature-policy=require-signatures"
+        )
+        self.seed_ta_dir("ta3")
+        self.pkg("set-publisher -p {0}".format(self.rurl1))
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["pkg://test/example_pkg"])
+        self._api_uninstall(api_obj, ["example_pkg"])
+        self._api_install(api_obj, ["pkg://pub2/example_pkg"])
+
+    def test_18620(self):
+        """Test that verifying a signed package doesn't require
+        privs."""
+
+        chain_cert_path = os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem")
+        ta_cert_path = os.path.join(self.raw_trust_anchor_dir, "ta3_cert.pem")
+        plist = self.pkgsend_bulk(self.rurl1, self.example_pkg10)
+
+        # Specify location as filesystem path.
+        self.pkgsign_simple(self.dc.get_repodir(), plist[0])
+
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy ignore")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
+        self.pkg("set-property signature-policy verify")
+        self.pkg("verify", su_wrap=True)
+
+    def test_bug_18880_hash(self):
+        plist = self.pkgsend_bulk(self.rurl1, self.bug_18880_pkg)
+        self.pkgsign(self.rurl1, plist[0])
+        self.image_create(self.rurl1, variants={"variant.foo": "bar"})
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["b18880"])
+        self.pkg("verify")
+        self.pkg("fix", exit=4)
+        portable.remove(os.path.join(self.img_path(), "bin/example_path"))
+        self.pkg("verify", exit=1)
+        self.assertTrue("signature" not in self.errout)
+        self.pkg("fix")
+        self.assertTrue("signature" not in self.errout)
+
+    def test_bug_18880_sig(self):
+        plist = self.pkgsend_bulk(self.rurl1, self.bug_18880_pkg)
+        sign_args = "-k {key} -c {cert} {pkg}".format(
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
+            pkg=plist[0],
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        self.image_create(self.rurl1, variants={"variant.foo": "bar"})
+        api_obj = self.get_img_api_obj()
+        self.seed_ta_dir("ta2")
+        self._api_install(api_obj, ["b18880"])
+        self.pkg("verify")
+        self.pkg("fix", exit=4)
+        portable.remove(os.path.join(self.img_path(), "bin/example_path"))
+        self.pkg("verify", exit=1)
+        self.assertTrue("signature" not in self.errout)
+        self.pkg("fix")
+        self.assertTrue("signature" not in self.errout)
+
+    def test_bug_19055(self):
+        plist = self.pkgsend_bulk(
+            self.rurl1, [self.example_pkg10, self.example_pkg20]
+        )
+        sign_args = "-k {key} -c {cert} -i {ch1} {name}".format(
+            name=" ".join(plist),
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            ch1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        repo = self.dc.get_repo()
+        for pfmri in plist:
+            found = False
+            with open(repo.manifest(pfmri), "r") as fh:
+                for l in fh:
+                    if l.startswith("signature"):
+                        found = True
+                        break
+            self.assertTrue(found, "{0} was not signed.".format(pfmri))
+
+    def test_bug_19114_1(self):
+        """Test that an unparsable trust anchor which isn't needed
+        doesn't cause problems."""
+
+        plist = self.pkgsend_bulk(self.rurl1, [self.example_pkg10])
+        sign_args = "-k {key} -c {cert} -i {ch1} {name}".format(
+            name=" ".join(plist),
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            ch1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        self.image_create(self.rurl1)
+        api_obj = self.get_img_api_obj()
+        self.seed_ta_dir("ta3")
+        # Create an empty file in the trust anchor directory
+        fh = open(os.path.join(self.ta_dir, "empty"), "wb")
+        fh.close()
+        # This install should succeed because the trust anchor needed to
+        # verify the certificate is still there.
+        self._api_install(api_obj, ["example_pkg"])
+
+    def test_bug_19114_2(self):
+        """Test that a unparsable trust anchor which is needed during
+        installation triggers the proper exception."""
+
+        plist = self.pkgsend_bulk(self.rurl1, [self.example_pkg10])
+        sign_args = "-k {key} -c {cert} -i {ch1} {name}".format(
+            name=" ".join(plist),
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            ch1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        self.image_create(self.rurl1)
+        api_obj = self.get_img_api_obj()
+        self.seed_ta_dir("ta3")
+        # Replace the trust anchor with an empty file.
+        fh = open(os.path.join(self.ta_dir, "ta3_cert.pem"), "wb")
+        fh.close()
+        # This install should fail because the needed trust anchor has
+        # been emptied.
+        try:
+            self._api_install(api_obj, ["example_pkg"])
+        except apx.BrokenChain as e:
+            assert len(e.ext_exs) == 1
+        else:
+            raise RuntimeError("Didn't get expected exception")
+        self.pkg("install example_pkg", exit=1)
+
+    def test_signed_mediators(self):
+        """Test that packages with mediated links and other varianted
+        actions work correctly when signed."""
+
+        bar = """\
 set name=pkg.fmri value=bar@1.7
 set name=variant.num value=one value=two
 link mediator=foobar mediator-version=1.7 path=usr/foobar target=whee1.7
 """
 
-                foo = """\
+        foo = """\
 set name=pkg.fmri value=foo@1.6
 set name=variant.num value=one value=two
 set name=foo value=bar variant.arch=one
 link mediator=foobar mediator-version=1.6 path=usr/foobar target=whee1.6
 """
 
-                foo_pth = self.make_manifest(foo)
-                bar_pth = self.make_manifest(bar)
-                self.make_misc_files(["tmp/foo"])
-                self.pkgsend(self.rurl1, "publish -d {0} {1}".format(
-                    self.test_root, foo_pth))
-                self.pkgsend(self.rurl1, "publish -d {0} {1}".format(
-                    self.test_root, bar_pth))
-                chain_cert_path = os.path.join(self.chain_certs_dir,
-                    "ch1_ta3_cert.pem")
-                ta_cert_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta3_cert.pem")
-                sign_args = "-k {key} -c {cert} -i {ch1} '*'".format(
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        ch1=chain_cert_path)
-                self.pkgsign(self.rurl1, sign_args)
-                self.image_create(self.rurl1, variants={"variant.num":"one"})
-                self.seed_ta_dir("ta3")
-                self.pkg("install foo bar")
-                self.pkg("set-mediator -V 1.6 foobar")
+        foo_pth = self.make_manifest(foo)
+        bar_pth = self.make_manifest(bar)
+        self.make_misc_files(["tmp/foo"])
+        self.pkgsend(
+            self.rurl1, "publish -d {0} {1}".format(self.test_root, foo_pth)
+        )
+        self.pkgsend(
+            self.rurl1, "publish -d {0} {1}".format(self.test_root, bar_pth)
+        )
+        chain_cert_path = os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem")
+        ta_cert_path = os.path.join(self.raw_trust_anchor_dir, "ta3_cert.pem")
+        sign_args = "-k {key} -c {cert} -i {ch1} '*'".format(
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            ch1=chain_cert_path,
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        self.image_create(self.rurl1, variants={"variant.num": "one"})
+        self.seed_ta_dir("ta3")
+        self.pkg("install foo bar")
+        self.pkg("set-mediator -V 1.6 foobar")
 
-        def test_reverting_signed_packages(self):
-                """Test that reverting signed packages with variants works."""
+    def test_reverting_signed_packages(self):
+        """Test that reverting signed packages with variants works."""
 
-                b = """\
+        b = """\
 set name=pkg.fmri value=B@1.0,5.11-0
 set name=variant.num value=one value=two
 file tmp/foo mode=0555 owner=root group=bin path=etc/fileB revert-tag=bob
 dir mode=0755 owner=root group=bin path=etc variant.num=two
 """
 
-                c = """\
+        c = """\
 set name=pkg.fmri value=C@1.0,5.11-0
 set name=variant.num value=one value=two
 file tmp/foo mode=0555 owner=root group=bin path=etc2/fileC revert-tag=bob variant.num=two
 dir mode=0755 owner=root group=bin path=etc2 variant.num=two
 """
 
-                b_pth = self.make_manifest(b)
-                c_pth = self.make_manifest(c)
-                self.make_misc_files(["tmp/foo"])
-                self.pkgsend(self.rurl1, "publish -d {0} {1}".format(
-                    self.test_root, b_pth))
-                self.pkgsend(self.rurl1, "publish -d {0} {1}".format(
-                    self.test_root, c_pth))
-                chain_cert_path = os.path.join(self.chain_certs_dir,
-                    "ch1_ta3_cert.pem")
-                ta_cert_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta3_cert.pem")
-                sign_args = "-k {key} -c {cert} -i {ch1} '*'".format(
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        ch1=chain_cert_path)
-                self.pkgsign(self.rurl1, sign_args)
-                self.image_create(self.rurl1, variants={"variant.num":"one"})
-                self.seed_ta_dir("ta3")
-                self.pkg("install B")
-                self.pkg("verify B")
-                # Now test reverting by file.
-                with open(
-                    os.path.join(self.get_img_path(), "etc/fileB"), "w") as fh:
-                        fh.write("\n")
-                self.pkg("verify B", exit=1)
-                self.pkg("revert /etc/fileB")
-                self.pkg("verify B")
-                # Now test reverting by tag since that's a separate code path in
-                # ImagePlan.plan_revert.
-                with open(
-                    os.path.join(self.get_img_path(), "etc/fileB"), "w") as fh:
-                        fh.write("\n")
-                self.pkg("verify B", exit=1)
-                self.pkg("revert --tagged bob")
-                self.pkg("verify B")
-                # Now test reverting a file that's delivered in another variant.
-                self.pkg("install C")
-                self.pkg("verify C")
-                self.pkg("revert etc2/fileC", exit=1)
+        b_pth = self.make_manifest(b)
+        c_pth = self.make_manifest(c)
+        self.make_misc_files(["tmp/foo"])
+        self.pkgsend(
+            self.rurl1, "publish -d {0} {1}".format(self.test_root, b_pth)
+        )
+        self.pkgsend(
+            self.rurl1, "publish -d {0} {1}".format(self.test_root, c_pth)
+        )
+        chain_cert_path = os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem")
+        ta_cert_path = os.path.join(self.raw_trust_anchor_dir, "ta3_cert.pem")
+        sign_args = "-k {key} -c {cert} -i {ch1} '*'".format(
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            ch1=chain_cert_path,
+        )
+        self.pkgsign(self.rurl1, sign_args)
+        self.image_create(self.rurl1, variants={"variant.num": "one"})
+        self.seed_ta_dir("ta3")
+        self.pkg("install B")
+        self.pkg("verify B")
+        # Now test reverting by file.
+        with open(os.path.join(self.get_img_path(), "etc/fileB"), "w") as fh:
+            fh.write("\n")
+        self.pkg("verify B", exit=1)
+        self.pkg("revert /etc/fileB")
+        self.pkg("verify B")
+        # Now test reverting by tag since that's a separate code path in
+        # ImagePlan.plan_revert.
+        with open(os.path.join(self.get_img_path(), "etc/fileB"), "w") as fh:
+            fh.write("\n")
+        self.pkg("verify B", exit=1)
+        self.pkg("revert --tagged bob")
+        self.pkg("verify B")
+        # Now test reverting a file that's delivered in another variant.
+        self.pkg("install C")
+        self.pkg("verify C")
+        self.pkg("revert etc2/fileC", exit=1)
 
 
 class TestPkgSignMultiDepot(pkg5unittest.ManyDepotTestCase):
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        example_pkg10 = """
+    example_pkg10 = """
             open example_pkg@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/bin
             add dir mode=0755 owner=root group=bin path=/bin/example_dir
@@ -2900,487 +3190,494 @@ class TestPkgSignMultiDepot(pkg5unittest.ManyDepotTestCase):
             add set name='weirdness' value='] [ * ?'
             close """
 
-        foo10 = """
+    foo10 = """
             open foo@1.0,5.11-0
             close """
 
-        image_files = ['simple_file']
-        misc_files = ['tmp/example_file']
+    image_files = ["simple_file"]
+    misc_files = ["tmp/example_file"]
 
-        def pkg(self, command, *args, **kwargs):
-                # The value for crl_host is pulled from DebugValues because
-                # crl_host needs to be set there so the api object calls work
-                # as desired.
-                command = "--debug crl_host={0} {1}".format(
-                    DebugValues["crl_host"], command)
-                return pkg5unittest.ManyDepotTestCase.pkg(self, command,
-                    *args, **kwargs)
+    def pkg(self, command, *args, **kwargs):
+        # The value for crl_host is pulled from DebugValues because
+        # crl_host needs to be set there so the api object calls work
+        # as desired.
+        command = "--debug crl_host={0} {1}".format(
+            DebugValues["crl_host"], command
+        )
+        return pkg5unittest.ManyDepotTestCase.pkg(
+            self, command, *args, **kwargs
+        )
 
-        def setUp(self):
-                pkg5unittest.ManyDepotTestCase.setUp(self,
-                    ["test", "test", "crl", "test"])
-                self.make_misc_files(self.misc_files)
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.rurl2 = self.dcs[2].get_repo_url()
-                self.durl4 = self.dcs[4].get_depot_url()
-                DebugValues["crl_host"] = self.dcs[3].get_depot_url()
-                self.ta_dir = None
+    def setUp(self):
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["test", "test", "crl", "test"]
+        )
+        self.make_misc_files(self.misc_files)
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.rurl2 = self.dcs[2].get_repo_url()
+        self.durl4 = self.dcs[4].get_depot_url()
+        DebugValues["crl_host"] = self.dcs[3].get_depot_url()
+        self.ta_dir = None
 
-                self.path_to_certs = os.path.join(self.ro_data_root,
-                    "signing_certs", "produced")
-                self.keys_dir = os.path.join(self.path_to_certs, "keys")
-                self.cs_dir = os.path.join(self.path_to_certs,
-                    "code_signing_certs")
-                self.chain_certs_dir = os.path.join(self.path_to_certs,
-                    "chain_certs")
-                self.raw_trust_anchor_dir = os.path.join(self.path_to_certs,
-                    "trust_anchors")
-                self.crl_dir = os.path.join(self.path_to_certs, "crl")
+        self.path_to_certs = os.path.join(
+            self.ro_data_root, "signing_certs", "produced"
+        )
+        self.keys_dir = os.path.join(self.path_to_certs, "keys")
+        self.cs_dir = os.path.join(self.path_to_certs, "code_signing_certs")
+        self.chain_certs_dir = os.path.join(self.path_to_certs, "chain_certs")
+        self.raw_trust_anchor_dir = os.path.join(
+            self.path_to_certs, "trust_anchors"
+        )
+        self.crl_dir = os.path.join(self.path_to_certs, "crl")
 
-        def test_sign_pkgrecv(self):
-                """Check that signed packages can be transferred between
-                repos."""
+    def test_sign_pkgrecv(self):
+        """Check that signed packages can be transferred between
+        repos."""
 
-                plist = self.pkgsend_bulk(self.rurl2, self.example_pkg10)
-                ta_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta2_cert.pem")
-                sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
-                      ta=ta_path,
-                      pkg=plist[0]
-                   )
+        plist = self.pkgsend_bulk(self.rurl2, self.example_pkg10)
+        ta_path = os.path.join(self.raw_trust_anchor_dir, "ta2_cert.pem")
+        sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
+            ta=ta_path,
+            pkg=plist[0],
+        )
 
-                self.pkgsign(self.rurl2, sign_args)
+        self.pkgsign(self.rurl2, sign_args)
 
-                repo_location = self.dcs[1].get_repodir()
-                self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.rurl1))
-                shutil.rmtree(repo_location)
-                self.pkgrepo("create {0}".format(repo_location))
+        repo_location = self.dcs[1].get_repodir()
+        self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.rurl1))
+        shutil.rmtree(repo_location)
+        self.pkgrepo("create {0}".format(repo_location))
 
-                # Add another signature that is just signed with the hash of
-                # the manifest.
-                sign_args = "{pkg}".format(
-                    pkg=plist[0]
-                )
-                self.pkgsign(self.rurl2, sign_args)
-                self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.rurl1))
-                shutil.rmtree(repo_location)
-                self.pkgrepo("create {0}".format(repo_location))
+        # Add another signature that is just signed with the hash of
+        # the manifest.
+        sign_args = "{pkg}".format(pkg=plist[0])
+        self.pkgsign(self.rurl2, sign_args)
+        self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.rurl1))
+        shutil.rmtree(repo_location)
+        self.pkgrepo("create {0}".format(repo_location))
 
-                # Add another signature that is just signed with the hash of
-                # the manifest. Test "-a" option.
-                sign_args = "-a sha256 {pkg}".format(
-                    pkg=plist[0]
-                )
-                self.pkgsign(self.rurl2, sign_args)
-                self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.rurl1))
-                shutil.rmtree(repo_location)
-                self.pkgrepo("create {0}".format(repo_location))
+        # Add another signature that is just signed with the hash of
+        # the manifest. Test "-a" option.
+        sign_args = "-a sha256 {pkg}".format(pkg=plist[0])
+        self.pkgsign(self.rurl2, sign_args)
+        self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.rurl1))
+        shutil.rmtree(repo_location)
+        self.pkgrepo("create {0}".format(repo_location))
 
-                # Add another signature which includes the same chain cert used
-                # in the first signature.
-                sign_args = "-k {key} -c {cert} -i {ch1} -i {ta} " \
-                    "{name}".format(**{
-                        "name": plist[0],
-                        "key": os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        "cert": os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        "ch1": os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"),
-                        "ta": ta_path,
-                })
-                self.pkgsign(self.rurl2, sign_args)
-                self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.rurl1))
-                shutil.rmtree(repo_location)
-                self.pkgrepo("create {0}".format(repo_location))
+        # Add another signature which includes the same chain cert used
+        # in the first signature.
+        sign_args = "-k {key} -c {cert} -i {ch1} -i {ta} " "{name}".format(
+            **{
+                "name": plist[0],
+                "key": os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+                "cert": os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+                "ch1": os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+                "ta": ta_path,
+            }
+        )
+        self.pkgsign(self.rurl2, sign_args)
+        self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.rurl1))
+        shutil.rmtree(repo_location)
+        self.pkgrepo("create {0}".format(repo_location))
 
-                # Add another signature to further test duplicate chain
-                # certificates as well as having a chain cert that's a signing
-                # certificate in other signatures.
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} -i {ch1} -i {ta} " \
-                    "-i {cs1_ch1_ta3} {name} ".format(**{
-                        "name": plist[0],
-                        "key": os.path.join(self.keys_dir,
-                            "cs1_ch5_ta1_key.pem"),
-                        "cert": os.path.join(self.cs_dir,
-                            "cs1_ch5_ta1_cert.pem"),
-                        "i1": os.path.join(self.chain_certs_dir,
-                            "ch1_ta1_cert.pem"),
-                        "i2": os.path.join(self.chain_certs_dir,
-                            "ch2_ta1_cert.pem"),
-                        "i3": os.path.join(self.chain_certs_dir,
-                            "ch3_ta1_cert.pem"),
-                        "i4": os.path.join(self.chain_certs_dir,
-                            "ch4_ta1_cert.pem"),
-                        "i5": os.path.join(self.chain_certs_dir,
-                            "ch5_ta1_cert.pem"),
-                        "ta": ta_path,
-                        "ch1": os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"),
-                        "cs1_ch1_ta3": os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                })
-                self.pkgsign(self.rurl2, sign_args)
-                self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.rurl1))
+        # Add another signature to further test duplicate chain
+        # certificates as well as having a chain cert that's a signing
+        # certificate in other signatures.
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} -i {ch1} -i {ta} "
+            "-i {cs1_ch1_ta3} {name} ".format(
+                **{
+                    "name": plist[0],
+                    "key": os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                    "i1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta1_cert.pem"
+                    ),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5_ta1_cert.pem"
+                    ),
+                    "ta": ta_path,
+                    "ch1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta3_cert.pem"
+                    ),
+                    "cs1_ch1_ta3": os.path.join(
+                        self.cs_dir, "cs1_ch1_ta3_cert.pem"
+                    ),
+                }
+            )
+        )
+        self.pkgsign(self.rurl2, sign_args)
+        self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.rurl1))
 
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta1")
-                self.seed_ta_dir("ta2")
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy verify")
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta1")
+        self.seed_ta_dir("ta2")
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy verify")
 
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg"])
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg"])
 
-        def test_sign_pkgrecv_delivered_cert(self):
-                """Check that if a cache directory contains the payload for a
-                signature action with intermediate certificates but nothing
-                else, pkgrecv still works."""
+    def test_sign_pkgrecv_delivered_cert(self):
+        """Check that if a cache directory contains the payload for a
+        signature action with intermediate certificates but nothing
+        else, pkgrecv still works."""
 
-                manf = """
+        manf = """
 open a@1,5.11-0
 close
 """
-                self.pkgsend_bulk(self.rurl2, manf)
+        self.pkgsend_bulk(self.rurl2, manf)
 
-                cert_path = os.path.join(self.cs_dir, "cs1_ta2_cert.pem")
-                ta_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta2_cert.pem")
-                sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                      cert=cert_path,
-                      ta=ta_path,
-                      pkg="a"
-                   )
+        cert_path = os.path.join(self.cs_dir, "cs1_ta2_cert.pem")
+        ta_path = os.path.join(self.raw_trust_anchor_dir, "ta2_cert.pem")
+        sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=cert_path,
+            ta=ta_path,
+            pkg="a",
+        )
 
-                self.pkgsign(self.rurl2, sign_args)
+        self.pkgsign(self.rurl2, sign_args)
 
-                # Artificially fill the cache directory with a gzipped version
-                # of the transformed certificate file, as if pkgrecv had put it
-                # there itself.
-                repo_location = self.dcs[1].get_repodir()
-                cache_dir = os.path.join(self.test_root, "cache")
-                os.mkdir(cache_dir)
+        # Artificially fill the cache directory with a gzipped version
+        # of the transformed certificate file, as if pkgrecv had put it
+        # there itself.
+        repo_location = self.dcs[1].get_repodir()
+        cache_dir = os.path.join(self.test_root, "cache")
+        os.mkdir(cache_dir)
 
-                with open(cert_path, "rb") as f:
-                        cert = x509.load_pem_x509_certificate(
-                            f.read(), default_backend())
+        with open(cert_path, "rb") as f:
+            cert = x509.load_pem_x509_certificate(f.read(), default_backend())
 
+        fd, new_cert = tempfile.mkstemp(dir=self.test_root)
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(cert.public_bytes(serialization.Encoding.PEM))
 
-                fd, new_cert = tempfile.mkstemp(dir=self.test_root)
-                with os.fdopen(fd, "wb") as fh:
-                        fh.write(cert.public_bytes(
-                            serialization.Encoding.PEM))
+        # the file-store uses the least-preferred hash when storing
+        # content
+        alg = digest.HASH_ALGS["hash"]
+        file_name = misc.get_data_digest(new_cert, hash_func=alg)[0]
+        subdir = os.path.join(cache_dir, file_name[:2])
+        os.mkdir(subdir)
+        fp = os.path.join(subdir, file_name)
+        fh = PkgGzipFile(fp, "wb")
+        fh.write(cert.public_bytes(serialization.Encoding.PEM))
+        fh.close()
 
-                # the file-store uses the least-preferred hash when storing
-                # content
-                alg = digest.HASH_ALGS["hash"]
-                file_name = misc.get_data_digest(new_cert,
-                    hash_func=alg)[0]
-                subdir = os.path.join(cache_dir, file_name[:2])
-                os.mkdir(subdir)
-                fp = os.path.join(subdir, file_name)
-                fh = PkgGzipFile(fp, "wb")
-                fh.write(cert.public_bytes(serialization.Encoding.PEM))
-                fh.close()
+        self.pkgrecv(
+            self.rurl2, "-c {0} -d {1} '*'".format(cache_dir, self.rurl1)
+        )
 
-                self.pkgrecv(self.rurl2, "-c {0} -d {1} '*'".format(
-                    cache_dir, self.rurl1))
+    def test_sign_pkgrecv_delivered_intermediate_cert(self):
+        """Check that if a cache directory contains an intermediate file
+        for a signature action with intermediate certificates but
+        nothing else, pkgrecv still works."""
 
-        def test_sign_pkgrecv_delivered_intermediate_cert(self):
-                """Check that if a cache directory contains an intermediate file
-                for a signature action with intermediate certificates but
-                nothing else, pkgrecv still works."""
-
-                manf = """
+        manf = """
 open a@1,5.11-0
 close
 """
-                self.pkgsend_bulk(self.rurl2, manf)
+        self.pkgsend_bulk(self.rurl2, manf)
 
-                ta_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta2_cert.pem")
-                sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
-                      ta=ta_path,
-                      pkg="a"
-                   )
+        ta_path = os.path.join(self.raw_trust_anchor_dir, "ta2_cert.pem")
+        sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
+            ta=ta_path,
+            pkg="a",
+        )
 
-                self.pkgsign(self.rurl2, sign_args)
+        self.pkgsign(self.rurl2, sign_args)
 
-                # Artificially fill the cache directory with a gzipped version
-                # of the transformed certificate file, as if pkgrecv had put it
-                # there itself.
-                repo_location = self.dcs[1].get_repodir()
-                cache_dir = os.path.join(self.test_root, "cache")
-                os.mkdir(cache_dir)
+        # Artificially fill the cache directory with a gzipped version
+        # of the transformed certificate file, as if pkgrecv had put it
+        # there itself.
+        repo_location = self.dcs[1].get_repodir()
+        cache_dir = os.path.join(self.test_root, "cache")
+        os.mkdir(cache_dir)
 
-                with open(ta_path, "rb") as f:
-                        cert = x509.load_pem_x509_certificate(
-                            f.read(), default_backend())
+        with open(ta_path, "rb") as f:
+            cert = x509.load_pem_x509_certificate(f.read(), default_backend())
 
-                fd, new_cert = tempfile.mkstemp(dir=self.test_root)
-                with os.fdopen(fd, "wb") as fh:
-                        fh.write(cert.public_bytes(
-                            serialization.Encoding.PEM))
+        fd, new_cert = tempfile.mkstemp(dir=self.test_root)
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(cert.public_bytes(serialization.Encoding.PEM))
 
-                for attr in digest.DEFAULT_HASH_ATTRS:
-                        if attr == "pkg.content-hash":
-                                continue
-                        alg = digest.HASH_ALGS[attr]
-                        file_name = misc.get_data_digest(new_cert,
-                            hash_func=alg)[0]
-                        subdir = os.path.join(cache_dir, file_name[:2])
-                        os.mkdir(subdir)
-                        fp = os.path.join(subdir, file_name)
-                        fh = PkgGzipFile(fp, "wb")
-                        fh.write(cert.public_bytes(
-                            serialization.Encoding.PEM))
-                        fh.close()
+        for attr in digest.DEFAULT_HASH_ATTRS:
+            if attr == "pkg.content-hash":
+                continue
+            alg = digest.HASH_ALGS[attr]
+            file_name = misc.get_data_digest(new_cert, hash_func=alg)[0]
+            subdir = os.path.join(cache_dir, file_name[:2])
+            os.mkdir(subdir)
+            fp = os.path.join(subdir, file_name)
+            fh = PkgGzipFile(fp, "wb")
+            fh.write(cert.public_bytes(serialization.Encoding.PEM))
+            fh.close()
 
-                self.pkgrecv(self.rurl2, "-c {0} -d {1} '*'".format(
-                    cache_dir, self.rurl1))
+        self.pkgrecv(
+            self.rurl2, "-c {0} -d {1} '*'".format(cache_dir, self.rurl1)
+        )
 
-        def test_sign_pkgrecv_cache_sign_interaction(self):
-                """Check that if a cache directory is used and multiple packages
-                are signed with the same certificates and intermediate
-                certificates are involved, pkgrecv continues to work."""
+    def test_sign_pkgrecv_cache_sign_interaction(self):
+        """Check that if a cache directory is used and multiple packages
+        are signed with the same certificates and intermediate
+        certificates are involved, pkgrecv continues to work."""
 
-                self.__test_sign_pkgrecv_cache_sign_interaction()
-                # Verify that older logic of publication api works.
-                self.dcs[1].stop()
-                self.dcs[2].stop()
-                self.dcs[1].set_disable_ops(["manifest/1"])
-                self.dcs[2].set_disable_ops(["manifest/1"])
-                self.__test_sign_pkgrecv_cache_sign_interaction()
+        self.__test_sign_pkgrecv_cache_sign_interaction()
+        # Verify that older logic of publication api works.
+        self.dcs[1].stop()
+        self.dcs[2].stop()
+        self.dcs[1].set_disable_ops(["manifest/1"])
+        self.dcs[2].set_disable_ops(["manifest/1"])
+        self.__test_sign_pkgrecv_cache_sign_interaction()
 
-        def __test_sign_pkgrecv_cache_sign_interaction(self):
-                self.dcs[1].start()
-                self.dcs[2].start()
-                manf = """
+    def __test_sign_pkgrecv_cache_sign_interaction(self):
+        self.dcs[1].start()
+        self.dcs[2].start()
+        manf = """
 open a@1,5.11-0
 close
 """
-                self.pkgsend_bulk(self.durl2, manf)
-                manf = """
+        self.pkgsend_bulk(self.durl2, manf)
+        manf = """
 open b@1,5.11-0
 close
 """
-                self.pkgsend_bulk(self.durl2, manf)
+        self.pkgsend_bulk(self.durl2, manf)
 
-                ta_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta2_cert.pem")
-                sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
-                      ta=ta_path,
-                      pkg="'*'"
-                   )
+        ta_path = os.path.join(self.raw_trust_anchor_dir, "ta2_cert.pem")
+        sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
+            ta=ta_path,
+            pkg="'*'",
+        )
 
-                self.pkgsign(self.durl2, sign_args)
+        self.pkgsign(self.durl2, sign_args)
 
-                cache_dir = os.path.join(self.test_root, "cache")
-                self.pkgrecv(self.durl2, "-c {0} -d {1} '*'".format(
-                    cache_dir, self.durl1))
+        cache_dir = os.path.join(self.test_root, "cache")
+        self.pkgrecv(
+            self.durl2, "-c {0} -d {1} '*'".format(cache_dir, self.durl1)
+        )
 
-        def test_sign_pkgrecv_a(self):
-                """Check that signed packages can be archived."""
+    def test_sign_pkgrecv_a(self):
+        """Check that signed packages can be archived."""
 
-                plist = self.pkgsend_bulk(self.rurl2, self.example_pkg10)
+        plist = self.pkgsend_bulk(self.rurl2, self.example_pkg10)
 
-                ta_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta2_cert.pem")
-                sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
-                    key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
-                      cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
-                      ta=ta_path,
-                      pkg=plist[0]
-                   )
+        ta_path = os.path.join(self.raw_trust_anchor_dir, "ta2_cert.pem")
+        sign_args = "-k {key} -c {cert} -i {ta} {pkg}".format(
+            key=os.path.join(self.keys_dir, "cs1_ta2_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ta2_cert.pem"),
+            ta=ta_path,
+            pkg=plist[0],
+        )
 
-                self.pkgsign(self.rurl2, sign_args)
+        self.pkgsign(self.rurl2, sign_args)
 
-                arch_location = os.path.join(self.test_root, "pkg_arch")
-                self.pkgrecv(self.rurl2, "-a -d {0} example_pkg".format(arch_location))
-                portable.remove(arch_location)
+        arch_location = os.path.join(self.test_root, "pkg_arch")
+        self.pkgrecv(self.rurl2, "-a -d {0} example_pkg".format(arch_location))
+        portable.remove(arch_location)
 
-                # Add another signature which includes the same chain cert used
-                # in the first signature.
-                sign_args = "-k {key} -c {cert} -i {ch1} -i {ta} " \
-                    "{name}".format(
-                        name=plist[0],
-                        key=os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        cert=os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        ch1=os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"),
-                        ta=ta_path)
-                self.pkgsign(self.rurl2, sign_args)
-                self.pkgrecv(self.rurl2, "-a -d {0} example_pkg".format(arch_location))
-                portable.remove(arch_location)
+        # Add another signature which includes the same chain cert used
+        # in the first signature.
+        sign_args = "-k {key} -c {cert} -i {ch1} -i {ta} " "{name}".format(
+            name=plist[0],
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            ch1=os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+            ta=ta_path,
+        )
+        self.pkgsign(self.rurl2, sign_args)
+        self.pkgrecv(self.rurl2, "-a -d {0} example_pkg".format(arch_location))
+        portable.remove(arch_location)
 
-                # Add another signature to further test duplicate chain
-                # certificates as well as having a chain cert that's a signing
-                # certificate in other signatures.
-                sign_args = "-k {key} -c {cert} -i {i1} -i {i2} " \
-                    "-i {i3} -i {i4} -i {i5} -i {ch1} -i {ta} " \
-                    "-i {cs1_ch1_ta3} {name} ".format(**{
-                        "name": plist[0],
-                        "key": os.path.join(self.keys_dir,
-                            "cs1_ch5_ta1_key.pem"),
-                        "cert": os.path.join(self.cs_dir,
-                            "cs1_ch5_ta1_cert.pem"),
-                        "i1": os.path.join(self.chain_certs_dir,
-                            "ch1_ta1_cert.pem"),
-                        "i2": os.path.join(self.chain_certs_dir,
-                            "ch2_ta1_cert.pem"),
-                        "i3": os.path.join(self.chain_certs_dir,
-                            "ch3_ta1_cert.pem"),
-                        "i4": os.path.join(self.chain_certs_dir,
-                            "ch4_ta1_cert.pem"),
-                        "i5": os.path.join(self.chain_certs_dir,
-                            "ch5_ta1_cert.pem"),
-                        "ta": ta_path,
-                        "ch1": os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"),
-                        "cs1_ch1_ta3": os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                })
-                self.pkgsign(self.rurl2, sign_args)
-                self.pkgrecv(self.rurl2, "-a -d {0} example_pkg".format(arch_location))
+        # Add another signature to further test duplicate chain
+        # certificates as well as having a chain cert that's a signing
+        # certificate in other signatures.
+        sign_args = (
+            "-k {key} -c {cert} -i {i1} -i {i2} "
+            "-i {i3} -i {i4} -i {i5} -i {ch1} -i {ta} "
+            "-i {cs1_ch1_ta3} {name} ".format(
+                **{
+                    "name": plist[0],
+                    "key": os.path.join(self.keys_dir, "cs1_ch5_ta1_key.pem"),
+                    "cert": os.path.join(self.cs_dir, "cs1_ch5_ta1_cert.pem"),
+                    "i1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta1_cert.pem"
+                    ),
+                    "i2": os.path.join(
+                        self.chain_certs_dir, "ch2_ta1_cert.pem"
+                    ),
+                    "i3": os.path.join(
+                        self.chain_certs_dir, "ch3_ta1_cert.pem"
+                    ),
+                    "i4": os.path.join(
+                        self.chain_certs_dir, "ch4_ta1_cert.pem"
+                    ),
+                    "i5": os.path.join(
+                        self.chain_certs_dir, "ch5_ta1_cert.pem"
+                    ),
+                    "ta": ta_path,
+                    "ch1": os.path.join(
+                        self.chain_certs_dir, "ch1_ta3_cert.pem"
+                    ),
+                    "cs1_ch1_ta3": os.path.join(
+                        self.cs_dir, "cs1_ch1_ta3_cert.pem"
+                    ),
+                }
+            )
+        )
+        self.pkgsign(self.rurl2, sign_args)
+        self.pkgrecv(self.rurl2, "-a -d {0} example_pkg".format(arch_location))
 
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta1")
-                self.seed_ta_dir("ta2")
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy verify")
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta1")
+        self.seed_ta_dir("ta2")
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy verify")
 
-                api_obj = self.get_img_api_obj()
-                self.pkg("install -g file://{0} example_pkg".format(arch_location))
+        api_obj = self.get_img_api_obj()
+        self.pkg("install -g file://{0} example_pkg".format(arch_location))
 
-        def test_bug_16861_recv(self):
-                """Check that signed obsolete and renamed packages can be
-                transferred from one repo to another."""
+    def test_bug_16861_recv(self):
+        """Check that signed obsolete and renamed packages can be
+        transferred from one repo to another."""
 
-                plist = self.pkgsend_bulk(self.rurl2, [renamed_pkg,
-                    obsolete_pkg])
-                for name in plist:
-                        sign_args = "-k {key} -c {cert} -i {i1} " \
-                            "-i {i2} -i {i3} -i {i4} -i {i5} " \
-                            "{name}".format(**{
-                                "name": name,
-                                "key": os.path.join(self.keys_dir,
-                                    "cs1_ch5_ta1_key.pem"),
-                                "cert": os.path.join(self.cs_dir,
-                                    "cs1_ch5_ta1_cert.pem"),
-                                "i1": os.path.join(self.chain_certs_dir,
-                                    "ch1_ta1_cert.pem"),
-                                "i2": os.path.join(self.chain_certs_dir,
-                                    "ch2_ta1_cert.pem"),
-                                "i3": os.path.join(self.chain_certs_dir,
-                                    "ch3_ta1_cert.pem"),
-                                "i4": os.path.join(self.chain_certs_dir,
-                                    "ch4_ta1_cert.pem"),
-                                "i5": os.path.join(self.chain_certs_dir,
-                                    "ch5_ta1_cert.pem"),
-                        })
-                        self.pkgsign(self.rurl2, sign_args)
+        plist = self.pkgsend_bulk(self.rurl2, [renamed_pkg, obsolete_pkg])
+        for name in plist:
+            sign_args = (
+                "-k {key} -c {cert} -i {i1} "
+                "-i {i2} -i {i3} -i {i4} -i {i5} "
+                "{name}".format(
+                    **{
+                        "name": name,
+                        "key": os.path.join(
+                            self.keys_dir, "cs1_ch5_ta1_key.pem"
+                        ),
+                        "cert": os.path.join(
+                            self.cs_dir, "cs1_ch5_ta1_cert.pem"
+                        ),
+                        "i1": os.path.join(
+                            self.chain_certs_dir, "ch1_ta1_cert.pem"
+                        ),
+                        "i2": os.path.join(
+                            self.chain_certs_dir, "ch2_ta1_cert.pem"
+                        ),
+                        "i3": os.path.join(
+                            self.chain_certs_dir, "ch3_ta1_cert.pem"
+                        ),
+                        "i4": os.path.join(
+                            self.chain_certs_dir, "ch4_ta1_cert.pem"
+                        ),
+                        "i5": os.path.join(
+                            self.chain_certs_dir, "ch5_ta1_cert.pem"
+                        ),
+                    }
+                )
+            )
+            self.pkgsign(self.rurl2, sign_args)
 
-                self.pkgrecv(self.rurl2, "-d {0} renamed obs".format(self.rurl1))
+        self.pkgrecv(self.rurl2, "-d {0} renamed obs".format(self.rurl1))
 
-        def test_bug_18463(self):
-                """Check that the crl host is only contacted twice, instead of
-                twice per package."""
+    def test_bug_18463(self):
+        """Check that the crl host is only contacted twice, instead of
+        twice per package."""
 
-                self.dcs[3].start()
+        self.dcs[3].start()
 
-                plist = self.pkgsend_bulk(self.rurl1,
-                    [self.example_pkg10, self.foo10])
-                sign_args = "-k {key} -c {cert} -i {i1} {name}".format(**{
-                        "name": "{0} {1}".format(plist[0], plist[1]),
-                        "key": os.path.join(self.keys_dir,
-                            "cs1_ch1.1_ta4_key.pem"),
-                        "cert": os.path.join(self.cs_dir,
-                            "cs1_ch1.1_ta4_cert.pem"),
-                        "i1": os.path.join(self.chain_certs_dir,
-                            "ch1.1_ta4_cert.pem")
-                })
-                self.pkgsign(self.rurl1, sign_args)
+        plist = self.pkgsend_bulk(self.rurl1, [self.example_pkg10, self.foo10])
+        sign_args = "-k {key} -c {cert} -i {i1} {name}".format(
+            **{
+                "name": "{0} {1}".format(plist[0], plist[1]),
+                "key": os.path.join(self.keys_dir, "cs1_ch1.1_ta4_key.pem"),
+                "cert": os.path.join(self.cs_dir, "cs1_ch1.1_ta4_cert.pem"),
+                "i1": os.path.join(self.chain_certs_dir, "ch1.1_ta4_cert.pem"),
+            }
+        )
+        self.pkgsign(self.rurl1, sign_args)
 
-                self.pkg_image_create(self.rurl1)
-                self.seed_ta_dir("ta4")
-                self.pkg("set-property check-certificate-revocation true")
-                self.pkg("set-property signature-policy require-signatures")
-                api_obj = self.get_img_api_obj()
-                self._api_install(api_obj, ["example_pkg", "foo"])
-                cnt = 0
-                with open(self.dcs[3].get_logpath(), "r") as fh:
-                        for l in fh:
-                                if "ch1.1_ta4_crl.pem" in l:
-                                        cnt += 1
-                self.assertEqual(cnt, 2)
+        self.pkg_image_create(self.rurl1)
+        self.seed_ta_dir("ta4")
+        self.pkg("set-property check-certificate-revocation true")
+        self.pkg("set-property signature-policy require-signatures")
+        api_obj = self.get_img_api_obj()
+        self._api_install(api_obj, ["example_pkg", "foo"])
+        cnt = 0
+        with open(self.dcs[3].get_logpath(), "r") as fh:
+            for l in fh:
+                if "ch1.1_ta4_crl.pem" in l:
+                    cnt += 1
+        self.assertEqual(cnt, 2)
 
-        def test_sign_pkgrecv_across_repositories(self):
-                """Check that signed packages can be pkgrecved to a new
-                repository that enables new hashes but the new hashes won't
-                be added to the packages so that the existing signatures won't
-                be invalidated"""
+    def test_sign_pkgrecv_across_repositories(self):
+        """Check that signed packages can be pkgrecved to a new
+        repository that enables new hashes but the new hashes won't
+        be added to the packages so that the existing signatures won't
+        be invalidated"""
 
-                # We create an image simply so we can use "contents -g" to
-                # inspect the repository.
-                self.image_create()
-                self.dcs[1].start()
-                self.dcs[2].start()
-                plist = self.pkgsend_bulk(self.rurl2, self.example_pkg10)
-                ta_path = os.path.join(self.raw_trust_anchor_dir,
-                    "ta3_cert.pem")
-                sign_args = "-k {key} -c {cert} -i {ch1} -i {ta} " \
-                    "{name}".format(**{
-                        "name": plist[0],
-                        "key": os.path.join(self.keys_dir,
-                            "cs1_ch1_ta3_key.pem"),
-                        "cert": os.path.join(self.cs_dir,
-                            "cs1_ch1_ta3_cert.pem"),
-                        "ch1": os.path.join(self.chain_certs_dir,
-                            "ch1_ta3_cert.pem"),
-                        "ta": ta_path,
-                })
+        # We create an image simply so we can use "contents -g" to
+        # inspect the repository.
+        self.image_create()
+        self.dcs[1].start()
+        self.dcs[2].start()
+        plist = self.pkgsend_bulk(self.rurl2, self.example_pkg10)
+        ta_path = os.path.join(self.raw_trust_anchor_dir, "ta3_cert.pem")
+        sign_args = "-k {key} -c {cert} -i {ch1} -i {ta} " "{name}".format(
+            **{
+                "name": plist[0],
+                "key": os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+                "cert": os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+                "ch1": os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem"),
+                "ta": ta_path,
+            }
+        )
 
-                self.pkgsign(self.rurl2, sign_args)
-                self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.durl1))
-                self.pkg("contents -g {0} -m example_pkg".format(self.durl1))
-                self.assertTrue("pkg.content-hash=file:sha256" not in self.output)
-                self.image_create(self.durl1)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy verify")
-                self.pkg("install example_pkg")
-                self.image_destroy()
+        self.pkgsign(self.rurl2, sign_args)
+        self.pkgrecv(self.rurl2, "-d {0} example_pkg".format(self.durl1))
+        self.pkg("contents -g {0} -m example_pkg".format(self.durl1))
+        self.assertTrue("pkg.content-hash=file:sha256" not in self.output)
+        self.image_create(self.durl1)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy verify")
+        self.pkg("install example_pkg")
+        self.image_destroy()
 
-                self.dcs[4].set_debug_feature("hash=sha1+sha256")
-                self.dcs[4].start()
-                self.image_create(self.durl4, destroy=True)
-                # pkgrecv to a new repository which enables SHA-2 hashes
-                self.pkgrecv(self.durl1, "-d {0} example_pkg".format(self.durl4))
-                self.pkg("contents -g {0} -m example_pkg".format(self.durl4))
-                # make sure that we don not get multiple hashes
-                self.assertTrue("pkg.content-hash=file:sha256" not in self.output)
-                self.seed_ta_dir("ta3")
-                self.pkg("set-property signature-policy verify")
-                # should not invalidate the signature
-                self.pkg("install example_pkg")
+        self.dcs[4].set_debug_feature("hash=sha1+sha256")
+        self.dcs[4].start()
+        self.image_create(self.durl4, destroy=True)
+        # pkgrecv to a new repository which enables SHA-2 hashes
+        self.pkgrecv(self.durl1, "-d {0} example_pkg".format(self.durl4))
+        self.pkg("contents -g {0} -m example_pkg".format(self.durl4))
+        # make sure that we don not get multiple hashes
+        self.assertTrue("pkg.content-hash=file:sha256" not in self.output)
+        self.seed_ta_dir("ta3")
+        self.pkg("set-property signature-policy verify")
+        # should not invalidate the signature
+        self.pkg("install example_pkg")
 
-                self.dcs[4].stop()
-                self.dcs[4].unset_debug_feature("hash=sha1+sha256")
+        self.dcs[4].stop()
+        self.dcs[4].unset_debug_feature("hash=sha1+sha256")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_pkgsurf.py
+++ b/src/tests/cli/t_pkgsurf.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -40,26 +41,27 @@ import tempfile
 import unittest
 from pkg.misc import CMP_UNSIGNED
 
+
 class TestPkgsurf(pkg5unittest.ManyDepotTestCase):
-        # Cleanup after every test.
-        persistent_setup = True
-        need_ro_data = True
+    # Cleanup after every test.
+    persistent_setup = True
+    need_ro_data = True
 
-        # The 1.0 version of each package will be in the reference repo,
-        # the 2.0 version in the target.
-        # Since we publish the expected package to an additional repo, we have
-        # to set the timestamps to make sure the target and expected packages
-        # are equal.
+    # The 1.0 version of each package will be in the reference repo,
+    # the 2.0 version in the target.
+    # Since we publish the expected package to an additional repo, we have
+    # to set the timestamps to make sure the target and expected packages
+    # are equal.
 
-        # The test cases are mainly in the different types of packages we
-        # have in the repo.
+    # The test cases are mainly in the different types of packages we
+    # have in the repo.
 
-        # Test cases:
+    # Test cases:
 
-        # Pkg with no content change, should be reversioned.
-        # Pkg has all sorts of actions to make sure everything gets moved
-        # correctly.
-        tiger_ref = """
+    # Pkg with no content change, should be reversioned.
+    # Pkg has all sorts of actions to make sure everything gets moved
+    # correctly.
+    tiger_ref = """
             open tiger@1.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/bat
             add dir mode=0755 owner=root group=bin path=/usr/tiger
@@ -72,7 +74,7 @@ class TestPkgsurf(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        tiger_targ = """
+    tiger_targ = """
             open tiger@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/bat
             add dir mode=0755 owner=root group=bin path=/usr/tiger
@@ -85,149 +87,149 @@ class TestPkgsurf(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        tiger_exp = tiger_ref
+    tiger_exp = tiger_ref
 
-        # Another basic pkg which gets reversioned
-        sandtiger_ref = """
+    # Another basic pkg which gets reversioned
+    sandtiger_ref = """
             open sandtiger@1.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/sandtiger
             close
         """
 
-        sandtiger_targ = """
+    sandtiger_targ = """
             open sandtiger@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/sandtiger
             close
         """
 
-        sandtiger_exp = sandtiger_ref
+    sandtiger_exp = sandtiger_ref
 
-        # Basic package with content change, should not be reversioned.
-        # These packages deliver the same file but the target one's gelf signed
-        # content-hash value will be changed.
-        elftest_ref = """
+    # Basic package with content change, should not be reversioned.
+    # These packages deliver the same file but the target one's gelf signed
+    # content-hash value will be changed.
+    elftest_ref = """
             open elftest@1.0,5.11-0:20000101T000000Z
             add file ro_data/elftest.so.1 mode=0755 owner=root group=bin path=/bin/true
             close
         """
 
-        elftest_targ = """
+    elftest_targ = """
             open elftest@2.0,5.11-0:20000101T000000Z
             add file ro_data/elftest.so.1 mode=0755 owner=root group=bin path=/bin/true
             close
         """
 
-        elftest_exp = elftest_targ
+    elftest_exp = elftest_targ
 
-        # Basic package with content change, should not be reversioned.
-        # These packages deliver different files, but they have the same gelf
-        # content-hash values.
-        elfdiff_ref = """
+    # Basic package with content change, should not be reversioned.
+    # These packages deliver different files, but they have the same gelf
+    # content-hash values.
+    elfdiff_ref = """
             open elfdiff@1.0,5.11-0:20000101T000000Z
             add file ro_data/elftest.so.1 mode=0755 owner=root group=bin path=/bin/false
             close
         """
 
-        elfdiff_targ = """
+    elfdiff_targ = """
             open elfdiff@2.0,5.11-0:20000101T000000Z
             add file ro_data/elftest.so.2 mode=0755 owner=root group=bin path=/bin/false
             close
         """
-        elfdiff_exp = elfdiff_targ
+    elfdiff_exp = elfdiff_targ
 
-        # package that uses the same file elftest.so.2 as elfdiff package
-        elfshare_ref = """
+    # package that uses the same file elftest.so.2 as elfdiff package
+    elfshare_ref = """
             open elfshare@1.0,5.11-0:20000101T000000Z
             add file ro_data/elftest.so.2 mode=0755 owner=root group=bin path=/bin/share
             close
         """
 
-        elfshare_targ = elfshare_ref
-        elfshare_exp = elfshare_ref
+    elfshare_targ = elfshare_ref
+    elfshare_exp = elfshare_ref
 
-        # Basic package with content change, should not be reversioned.
-        hammerhead_ref = """
+    # Basic package with content change, should not be reversioned.
+    hammerhead_ref = """
             open hammerhead@1.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/hammerhead
             close
         """
 
-        hammerhead_targ = """
+    hammerhead_targ = """
             open hammerhead@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0644 owner=root group=bin path=/etc/hammerhead
             close
         """
 
-        hammerhead_exp = hammerhead_targ
+    hammerhead_exp = hammerhead_targ
 
-        # Package has only dep change but dependency package changed,
-        # should not be reversioned.
-        blue_ref = """
+    # Package has only dep change but dependency package changed,
+    # should not be reversioned.
+    blue_ref = """
             open blue@1.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/hammerhead@1.0 type=require
             close
         """
 
-        blue_targ = """
+    blue_targ = """
             open blue@2.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/hammerhead@2.0 type=require
             close
         """
 
-        blue_exp = blue_targ
+    blue_exp = blue_targ
 
-        # Same as above but let's try an additional level in the dep chain.
-        bull_ref = """
+    # Same as above but let's try an additional level in the dep chain.
+    bull_ref = """
             open bull@1.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/blue@1.0 type=require
             close
         """
 
-        bull_targ = """
+    bull_targ = """
             open bull@2.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/blue@2.0 type=require
             close
         """
 
-        bull_exp = bull_targ
+    bull_exp = bull_targ
 
-        # Package has only dep change and dependency package didn't change,
-        # should be reversioned.
-        mako_ref = """
+    # Package has only dep change and dependency package didn't change,
+    # should be reversioned.
+    mako_ref = """
             open mako@1.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/tiger@1.0 type=require
             close
         """
 
-        mako_targ = """
+    mako_targ = """
             open mako@2.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/tiger@2.0 type=require
             close
         """
 
-        mako_exp = mako_ref
+    mako_exp = mako_ref
 
-        # Same as above but let's try an additional level in the dep chain.
-        white_ref = """
+    # Same as above but let's try an additional level in the dep chain.
+    white_ref = """
             open white@1.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/mako@1.0 type=require
             close
         """
 
-        white_targ = """
+    white_targ = """
             open white@2.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/mako@2.0 type=require
             close
         """
 
-        white_exp = white_ref
+    white_exp = white_ref
 
-        # Package has content change but depends on package which got reversioned,
-        # dependencies should be fixed.
-        # Pkg has all sorts of actions to make sure everything gets moved
-        # correctly.
+    # Package has content change but depends on package which got reversioned,
+    # dependencies should be fixed.
+    # Pkg has all sorts of actions to make sure everything gets moved
+    # correctly.
 
-        angel_ref = """
+    angel_ref = """
             open angel@1.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/angel
             add dir mode=0755 owner=root group=bin path=/usr/angel
@@ -242,7 +244,7 @@ class TestPkgsurf(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        angel_targ = """
+    angel_targ = """
             open angel@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0644 owner=root group=bin path=/etc/angel
             add dir mode=0755 owner=root group=bin path=/usr/angel
@@ -257,7 +259,7 @@ class TestPkgsurf(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        angel_exp = """
+    angel_exp = """
             open angel@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0644 owner=root group=bin path=/etc/angel
             add dir mode=0755 owner=root group=bin path=/usr/angel
@@ -272,201 +274,199 @@ class TestPkgsurf(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        # Package has content change and depends on package which didn't get
-        # reversioned, shouldn't be touched.
+    # Package has content change and depends on package which didn't get
+    # reversioned, shouldn't be touched.
 
-        horn_ref = """
+    horn_ref = """
             open horn@1.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/horn
             add depend fmri=pkg:/hammerhead@1.0 type=require
             close
         """
 
-        horn_targ = """
+    horn_targ = """
             open horn@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0644 owner=root group=bin path=/etc/horn
             add depend fmri=pkg:/hammerhead@2.0 type=require
             close
         """
 
-        horn_exp = horn_targ
+    horn_exp = horn_targ
 
+    # Package has content change but has require-any dep on package which
+    # got reversioned, dependencies should be fixed.
 
-        # Package has content change but has require-any dep on package which
-        # got reversioned, dependencies should be fixed.
-
-        lemon_ref = """
+    lemon_ref = """
             open lemon@1.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/lemon
             add depend fmri=pkg:/angel@1.0 fmri=pkg:/tiger@1.0 type=require-any
             close
         """
 
-        lemon_targ = """
+    lemon_targ = """
             open lemon@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0644 owner=root group=bin path=/etc/lemon
             add depend fmri=pkg:/angel@2.0 fmri=pkg:/tiger@2.0 type=require-any
             close
         """
 
-        lemon_exp = """
+    lemon_exp = """
             open lemon@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0644 owner=root group=bin path=/etc/lemon
             add depend fmri=pkg:/angel@2.0 fmri=pkg:/tiger@1.0 type=require-any
             close
         """
 
-        # Package has content change but has require-any dep on package which
-        # got reversioned, however, the require-any dependency wasn't in the old
-        # version. The version of the pkg in the ref repo should be substituted
-        # for tiger but not for sandtiger (since dep pkg is still successor of
-        # dep FMRI).
+    # Package has content change but has require-any dep on package which
+    # got reversioned, however, the require-any dependency wasn't in the old
+    # version. The version of the pkg in the ref repo should be substituted
+    # for tiger but not for sandtiger (since dep pkg is still successor of
+    # dep FMRI).
 
-        leopard_ref = """
+    leopard_ref = """
             open leopard@1.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/leopard
             add depend fmri=pkg:/blue@1.0 fmri=pkg:/angel@1.0 type=require-any
             close
         """
 
-        leopard_targ = """
+    leopard_targ = """
             open leopard@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0644 owner=root group=bin path=/etc/leopard
             add depend fmri=pkg:/blue@2.0 fmri=pkg:/angel@2.0 fmri=pkg:/tiger@2.0 fmri=pkg:/sandtiger@1.0 type=require-any
             close
         """
 
-        leopard_exp = """
+    leopard_exp = """
             open leopard@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0644 owner=root group=bin path=/etc/leopard
             add depend fmri=pkg:/blue@2.0 fmri=pkg:/angel@2.0 fmri=pkg:/tiger@1.0-0 fmri=pkg:/sandtiger@1.0 type=require-any
             close
         """
 
-        # Package has no content change but dependency stem changed, should
-        # always be treated as content change.
-        blacktip_ref = """
+    # Package has no content change but dependency stem changed, should
+    # always be treated as content change.
+    blacktip_ref = """
             open blacktip@1.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/tiger@1.0 type=require
             close
         """
 
-        blacktip_targ = """
+    blacktip_targ = """
             open blacktip@2.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/hammerhead@2.0 type=require
             close
         """
 
-        blacktip_exp = blacktip_targ
+    blacktip_exp = blacktip_targ
 
-        # Package has no content change but dependency got added, should
-        # always be treated as content change, other dependencies should be
-        # adjusted.
-        whitetip_ref = """
+    # Package has no content change but dependency got added, should
+    # always be treated as content change, other dependencies should be
+    # adjusted.
+    whitetip_ref = """
             open whitetip@1.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/tiger@1.0 type=require
             close
         """
 
-        whitetip_targ = """
+    whitetip_targ = """
             open whitetip@2.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/tiger@2.0 type=require
             add depend fmri=pkg:/hammerhead@2.0 type=require
             close
         """
 
-        whitetip_exp = """
+    whitetip_exp = """
             open whitetip@2.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/tiger@1.0 type=require
             add depend fmri=pkg:/hammerhead@2.0 type=require
             close
         """
 
-        # Package has no content change but a change in an attribute,
-        # should be treated as content change by default but reversioned if
-        # proper CLI options are given (goblin_exp is just for the default
-        # behavior, gets modified in actual test case)
+    # Package has no content change but a change in an attribute,
+    # should be treated as content change by default but reversioned if
+    # proper CLI options are given (goblin_exp is just for the default
+    # behavior, gets modified in actual test case)
 
-        goblin_ref = """
+    goblin_ref = """
             open goblin@1.0,5.11-0:20000101T000000Z
             add set name=info.home value="deep sea"
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/goblin
             close
         """
 
-        goblin_targ = """
+    goblin_targ = """
             open goblin@2.0,5.11-0:20000101T000000Z
             add set name=info.home value="deeper sea"
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/goblin
             close
         """
 
-        goblin_exp = goblin_targ
+    goblin_exp = goblin_targ
 
-        # Package only found in target, not in ref, with dependency on
-        # reversioned package. Dependency should be fixed.
-        reef_targ = """
+    # Package only found in target, not in ref, with dependency on
+    # reversioned package. Dependency should be fixed.
+    reef_targ = """
             open reef@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/reef
             add depend fmri=pkg:/tiger@2.0 type=require
             close
         """
 
-        reef_exp = """
+    reef_exp = """
             open reef@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/reef
             add depend fmri=pkg:/tiger@1.0-0 type=require
             close
         """
 
-        # Package is exactly the same as in ref repo, shouldn't be touched
-        sandbar_targ = """
+    # Package is exactly the same as in ref repo, shouldn't be touched
+    sandbar_targ = """
             open sandbar@1.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/sandbar
             close
         """
 
-        sandbar_ref = """
+    sandbar_ref = """
             open sandbar@1.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/sandbar
             close
         """
 
-        sandbar_exp = sandbar_ref
+    sandbar_exp = sandbar_ref
 
-        # Packages with circular dependency and no change in dep chain.
-        greenland_ref = """
+    # Packages with circular dependency and no change in dep chain.
+    greenland_ref = """
             open greenland@1.0,5.11-0:20000101T000000Z
             add depend fmri=sleeper@1.0 type=require
             close
         """
 
-        greenland_targ = """
+    greenland_targ = """
             open greenland@2.0,5.11-0:20000101T000000Z
             add depend fmri=sleeper@2.0 type=require
             close
         """
 
-        greenland_exp = greenland_ref
+    greenland_exp = greenland_ref
 
-        sleeper_ref = """
+    sleeper_ref = """
             open sleeper@1.0,5.11-0:20000101T000000Z
             add depend fmri=greenland@1.0 type=require
             close
         """
-        sleeper_targ = """
+    sleeper_targ = """
             open sleeper@2.0,5.11-0:20000101T000000Z
             add depend fmri=greenland@2.0 type=require
             close
         """
 
-        sleeper_exp = sleeper_ref
+    sleeper_exp = sleeper_ref
 
-
-        # Check for correct handling of Varcets. Pkg contains same dep FMRI stem
-        # twice. It also covers the case where a facet changes and the tool has
-        # to sustitute the version in the ref repo (sandtiger case).
-        whale_ref = """
+    # Check for correct handling of Varcets. Pkg contains same dep FMRI stem
+    # twice. It also covers the case where a facet changes and the tool has
+    # to sustitute the version in the ref repo (sandtiger case).
+    whale_ref = """
             open whale@1.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0444 owner=root group=bin path=/etc/whale
             add depend fmri=pkg:/tiger@1.0 facet.version-lock=True type=require
@@ -475,7 +475,7 @@ class TestPkgsurf(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        whale_targ = """
+    whale_targ = """
             open whale@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0644 owner=root group=bin path=/etc/whale
             add depend fmri=pkg:/tiger@2.0 facet.version-lock=True type=require
@@ -484,7 +484,7 @@ class TestPkgsurf(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        whale_exp = """
+    whale_exp = """
             open whale@2.0,5.11-0:20000101T000000Z
             add file tmp/bat mode=0644 owner=root group=bin path=/etc/whale
             add depend fmri=pkg:/tiger@1.0 facet.version-lock=True type=require
@@ -493,386 +493,437 @@ class TestPkgsurf(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        # Pkg in ref repo is newer than the one in target.
-        # Should not be reversioned.
-        thresher_ref = """
+    # Pkg in ref repo is newer than the one in target.
+    # Should not be reversioned.
+    thresher_ref = """
             open thresher@2.0,5.11-0:20000101T000000Z
             close
         """
 
-        thresher_targ = """
+    thresher_targ = """
             open thresher@1.0,5.11-0:20000101T000000Z
             close
         """
 
-        thresher_exp = thresher_targ
+    thresher_exp = thresher_targ
 
-        # Package only found in target, not in ref.
-        # Package has a dep on a reversioned pkg, but the reversioned pkg is
-        # still a successor of the dep FMRI.
-        # The dep should not be changed.
-        bamboo_targ = """
+    # Package only found in target, not in ref.
+    # Package has a dep on a reversioned pkg, but the reversioned pkg is
+    # still a successor of the dep FMRI.
+    # The dep should not be changed.
+    bamboo_targ = """
             open bamboo@2.0,5.11-0:20000101T000000Z
             add depend fmri=pkg:/tiger@1 type=require
             close
         """
 
-        bamboo_exp = bamboo_targ
+    bamboo_exp = bamboo_targ
 
-
-        # Create some packages for an additional publisher
-        humpback_targ = """
+    # Create some packages for an additional publisher
+    humpback_targ = """
             open pkg://cetacea/humpback@2.0,5.11-0:20000101T000000Z
             close
         """
 
-        humpback_ref = """
+    humpback_ref = """
             open pkg://cetacea/humpback@1.0,5.11-0:20000101T000000Z
             close
         """
 
-        humpback_exp = humpback_targ
+    humpback_exp = humpback_targ
 
+    misc_files = ["tmp/bat", "tmp/sting", "tmp/copyright"]
 
-        misc_files = [ "tmp/bat", "tmp/sting", "tmp/copyright" ]
+    pkgs = [
+        "tiger",
+        "sandtiger",
+        "hammerhead",
+        "blue",
+        "bull",
+        "mako",
+        "white",
+        "angel",
+        "horn",
+        "lemon",
+        "leopard",
+        "blacktip",
+        "whitetip",
+        "goblin",
+        "reef",
+        "sandbar",
+        "greenland",
+        "sleeper",
+        "whale",
+        "thresher",
+        "bamboo",
+        "elftest",
+        "elfdiff",
+        "elfshare",
+    ]
 
-        pkgs = ["tiger", "sandtiger", "hammerhead", "blue", "bull", "mako",
-            "white", "angel", "horn", "lemon", "leopard", "blacktip",
-            "whitetip", "goblin", "reef", "sandbar", "greenland", "sleeper",
-            "whale", "thresher", "bamboo", "elftest", "elfdiff", "elfshare"]
+    def setUp(self):
+        """Start 3 depots, 1 for reference repo, 1 for the target and
+        1 which should be equal to the reversioned target.
+        """
 
-        def setUp(self):
-                """Start 3 depots, 1 for reference repo, 1 for the target and
-                1 which should be equal to the reversioned target.
-                """
+        self.ref_pkgs = []
+        self.targ_pkgs = []
+        self.exp_pkgs = []
+        for s in self.pkgs:
+            ref = s + "_ref"
+            targ = s + "_targ"
+            exp = s + "_exp"
+            try:
+                self.ref_pkgs.append(getattr(self, ref))
+            except AttributeError:
+                # reef_ref, bamboo_ref don't exist intentionally
+                pass
+            self.targ_pkgs.append(getattr(self, targ))
+            self.exp_pkgs.append(getattr(self, exp))
 
-                self.ref_pkgs = []
-                self.targ_pkgs = []
-                self.exp_pkgs = []
-                for s in self.pkgs:
-                        ref = s + "_ref"
-                        targ = s + "_targ"
-                        exp = s + "_exp"
-                        try:
-                                self.ref_pkgs.append(getattr(self, ref))
-                        except AttributeError:
-                                # reef_ref, bamboo_ref don't exist intentionally
-                                pass
-                        self.targ_pkgs.append(getattr(self, targ))
-                        self.exp_pkgs.append(getattr(self, exp))
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self,
+            [
+                "selachii",
+                "selachii",
+                "selachii",
+                "selachii",
+                "selachii",
+                "selachii",
+            ],
+            start_depots=True,
+        )
 
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["selachii",
-                    "selachii", "selachii", "selachii", "selachii", "selachii"],
-                    start_depots=True)
+        self.make_misc_files(self.misc_files)
 
-                self.make_misc_files(self.misc_files)
+        self.dpath1 = self.dcs[1].get_repodir()
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.published_ref = self.pkgsend_bulk(self.dpath1, self.ref_pkgs)
 
-                self.dpath1 = self.dcs[1].get_repodir()
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.published_ref = self.pkgsend_bulk(self.dpath1,
-                    self.ref_pkgs)
+        self.dpath2 = self.dcs[2].get_repodir()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.published_targ = self.pkgsend_bulk(self.dpath2, self.targ_pkgs)
 
-                self.dpath2 = self.dcs[2].get_repodir()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.published_targ = self.pkgsend_bulk(self.dpath2,
-                    self.targ_pkgs)
+        self.dpath3 = self.dcs[3].get_repodir()
+        self.durl3 = self.dcs[3].get_depot_url()
+        self.published_exp = self.pkgsend_bulk(self.dpath3, self.exp_pkgs)
 
-                self.dpath3 = self.dcs[3].get_repodir()
-                self.durl3 = self.dcs[3].get_depot_url()
-                self.published_exp = self.pkgsend_bulk(self.dpath3,
-                    self.exp_pkgs)
+        # keep a tmp repo to copy the target into for each new test
+        self.dpath_tmp = self.dcs[4].get_repodir()
 
-                # keep a tmp repo to copy the target into for each new test
-                self.dpath_tmp = self.dcs[4].get_repodir()
+        self.dpath5 = self.dcs[5].get_repodir()
+        self.dpath6 = self.dcs[6].get_repodir()
 
-                self.dpath5 = self.dcs[5].get_repodir()
-                self.dpath6 = self.dcs[6].get_repodir()
+    def test_0_options(self):
+        """Check for correct input handling."""
+        self.pkgsurf("-x", exit=2)
+        self.pkgsurf("-s pacific", exit=2)
+        self.pkgsurf("-s pacific -r atlantic arctic antarctic", exit=2)
+        # invalid patterns for -c
+        self.pkgsurf(
+            "-n -s {0} -r {1} -c tiger@2.0".format(self.dpath2, self.dpath1),
+            exit=1,
+        )
+        self.pkgsurf(
+            "-n -s {0} -r {1} -c tig".format(self.dpath2, self.dpath1), exit=1
+        )
 
-        def test_0_options(self):
-                """Check for correct input handling."""
-                self.pkgsurf("-x", exit=2)
-                self.pkgsurf("-s pacific", exit=2)
-                self.pkgsurf("-s pacific -r atlantic arctic antarctic", exit=2)
-                # invalid patterns for -c
-                self.pkgsurf("-n -s {0} -r {1} -c tiger@2.0".format(self.dpath2,
-                    self.dpath1), exit=1)
-                self.pkgsurf("-n -s {0} -r {1} -c tig".format(self.dpath2,
-                    self.dpath1), exit=1)
+        # Check that -n doesn't modify repo.
+        tmpdir = tempfile.mkdtemp(dir=self.test_root)
+        path = os.path.join(tmpdir, "repo")
+        shutil.copytree(self.dpath2, path)
 
-                # Check that -n doesn't modify repo.
-                tmpdir = tempfile.mkdtemp(dir=self.test_root)
-                path = os.path.join(tmpdir, "repo")
-                shutil.copytree(self.dpath2, path)
+        self.pkgsurf("-s {0} -r {1} -n".format(self.dpath2, self.dpath1))
 
-                self.pkgsurf("-s {0} -r {1} -n".format(self.dpath2, self.dpath1))
+        ret = subprocess.call(["/usr/bin/gdiff", "-Naur", path, self.dpath2])
+        self.assertTrue(ret == 0)
 
-                ret = subprocess.call(["/usr/bin/gdiff", "-Naur", path,
-                    self.dpath2])
-                self.assertTrue(ret==0)
+    def __change_content_hash(self):
+        """Change the content-hash attr in the manifest located at the
+        target and expected repos."""
 
-        def __change_content_hash(self):
-                """Change the content-hash attr in the manifest located at the
-                target and expected repos."""
+        mapping = {
+            self.dpath2: self.published_targ,
+            self.dpath3: self.published_exp,
+        }
+        for repodir in (self.dpath2, self.dpath3):
+            for s in mapping[repodir]:
+                # Find elftest package
+                if "elftest" in s:
+                    break
+            f = fmri.PkgFmri(s, None)
+            repo = self.get_repo(repodir)
+            mpath = repo.manifest(f)
+            # load manifest, change content-hash attr and store back
+            # to disk
+            mani = manifest.Manifest()
+            mani.set_content(pathname=mpath)
+            for a in mani.gen_actions():
+                if "bin/true" in str(a):
+                    # change the signed version of hash of
+                    # the ELF file
+                    a.attrs["pkg.content-hash"][0] = "gelf:sha512t_256:foo"
+            mani.store(mpath)
+            # rebuild repo catalog since manifest digest changed
+            repo.rebuild()
 
-                mapping = {self.dpath2: self.published_targ,
-                           self.dpath3: self.published_exp}
-                for repodir in (self.dpath2, self.dpath3):
-                        for s in mapping[repodir]:
-                                # Find elftest package
-                                if "elftest" in s:
-                                        break
-                        f = fmri.PkgFmri(s, None)
-                        repo = self.get_repo(repodir)
-                        mpath = repo.manifest(f)
-                        # load manifest, change content-hash attr and store back
-                        # to disk
-                        mani = manifest.Manifest()
-                        mani.set_content(pathname=mpath)
-                        for a in mani.gen_actions():
-                                if "bin/true" in str(a):
-                                        # change the signed version of hash of
-                                        # the ELF file
-                                        a.attrs["pkg.content-hash"][
-                                                0] = "gelf:sha512t_256:foo"
-                        mani.store(mpath)
-                        # rebuild repo catalog since manifest digest changed
-                        repo.rebuild()
+    def test_1_basics(self):
+        """Test basic resurfacing operation."""
 
-        def test_1_basics(self):
-                """Test basic resurfacing operation."""
+        self.__change_content_hash()
 
-                self.__change_content_hash()
+        # Copy target repo to tmp repo
+        self.copy_repository(
+            self.dpath2, self.dpath_tmp, {"selachii": "selachii"}
+        )
+        # The new repository won't have a catalog, so rebuild it.
+        self.dcs[4].get_repo(auto_create=True).rebuild()
 
-                # Copy target repo to tmp repo
-                self.copy_repository(self.dpath2, self.dpath_tmp,
-                    { "selachii": "selachii" })
-                # The new repository won't have a catalog, so rebuild it.
-                self.dcs[4].get_repo(auto_create=True).rebuild()
+        # Check that empty repos get handled correctly
+        tempdir = tempfile.mkdtemp(dir=self.test_root)
+        # No repo at all
+        self.pkgsurf("-s {0} -r {1}".format(tempdir, self.dpath1), exit=1)
+        self.pkgsurf("-s {0} -r {1}".format(self.dpath1, tempdir), exit=1)
 
-                # Check that empty repos get handled correctly
-                tempdir = tempfile.mkdtemp(dir=self.test_root)
-                # No repo at all
-                self.pkgsurf("-s {0} -r {1}".format(tempdir, self.dpath1), exit=1)
-                self.pkgsurf("-s {0} -r {1}".format(self.dpath1, tempdir), exit=1)
+        # Repo empty
+        self.pkgrepo("create -s {0}".format(tempdir))
+        self.pkgsurf("-s {0} -r {1}".format(tempdir, self.dpath1), exit=1)
+        self.pkgsurf("-s {0} -r {1}".format(self.dpath1, tempdir), exit=1)
 
-                # Repo empty
-                self.pkgrepo("create -s {0}".format(tempdir))
-                self.pkgsurf("-s {0} -r {1}".format(tempdir, self.dpath1), exit=1)
-                self.pkgsurf("-s {0} -r {1}".format(self.dpath1, tempdir), exit=1)
+        # No packages
+        self.pkgrepo("add-publisher -s {0} selachii".format(tempdir))
+        self.pkgsurf("-s {0} -r {1}".format(tempdir, self.dpath1))
+        self.assertTrue("No packages to reversion." in self.output)
+        self.pkgsurf("-s {0} -r {1}".format(self.dpath1, tempdir))
+        self.assertTrue("No packages to reversion." in self.output)
+        shutil.rmtree(tempdir)
 
-                # No packages
-                self.pkgrepo("add-publisher -s {0} selachii".format(tempdir))
-                self.pkgsurf("-s {0} -r {1}".format(tempdir, self.dpath1))
-                self.assertTrue("No packages to reversion." in self.output)
-                self.pkgsurf("-s {0} -r {1}".format(self.dpath1, tempdir))
-                self.assertTrue("No packages to reversion." in self.output)
-                shutil.rmtree(tempdir)
+        # Now check if it actually works.
+        self.pkgsurf("-s {0} -r {1}".format(self.dpath_tmp, self.dpath1))
 
-                # Now check if it actually works.
-                self.pkgsurf("-s {0} -r {1}".format(self.dpath_tmp, self.dpath1))
+        ref_repo = self.get_repo(self.dpath1)
+        targ_repo = self.get_repo(self.dpath_tmp)
+        exp_repo = self.get_repo(self.dpath3)
+        for s in self.published_exp:
+            f = fmri.PkgFmri(s, None)
+            targ = targ_repo.manifest(f)
 
-                ref_repo = self.get_repo(self.dpath1)
-                targ_repo = self.get_repo(self.dpath_tmp)
-                exp_repo = self.get_repo(self.dpath3)
-                for s in self.published_exp:
-                        f = fmri.PkgFmri(s, None)
-                        targ = targ_repo.manifest(f)
+            # Load target manifest
+            targm = manifest.Manifest()
+            targm.set_content(pathname=targ)
 
-                        # Load target manifest
-                        targm = manifest.Manifest()
-                        targm.set_content(pathname=targ)
+            # Load expected manifest
+            exp = exp_repo.manifest(f)
+            expm = manifest.Manifest()
+            expm.set_content(pathname=exp)
 
-                        # Load expected manifest
-                        exp = exp_repo.manifest(f)
-                        expm = manifest.Manifest()
-                        expm.set_content(pathname=exp)
+            ta, ra, ca = manifest.Manifest.comm([targm, expm])
+            self.debug("{0}: {1:d} {2:d}".format(str(s), len(ta), len(ra)))
 
-                        ta, ra, ca = manifest.Manifest.comm([targm, expm])
-                        self.debug("{0}: {1:d} {2:d}".format(str(s), len(ta), len(ra)))
+            self.assertEqual(
+                0,
+                len(ta),
+                "{0} had unexpected actions:"
+                " \n{1}".format(s, "\n".join([str(x) for x in ta])),
+            )
+            self.assertEqual(
+                0,
+                len(ra),
+                "{0} had missing actions: "
+                "\n{1}".format(s, "\n".join([str(x) for x in ra])),
+            )
 
-                        self.assertEqual(0, len(ta), "{0} had unexpected actions:"
-                            " \n{1}".format(s, "\n".join([str(x) for x in ta])))
-                        self.assertEqual(0, len(ra), "{0} had missing actions: "
-                            "\n{1}".format(s, "\n".join([str(x) for x in ra])))
+        # Check that pkgsurf informed the user that there is a newer
+        # version of a pkg in the ref repo.
+        self.assertTrue("Packages with successors" in self.output)
 
-                # Check that pkgsurf informed the user that there is a newer
-                # version of a pkg in the ref repo.
-                self.assertTrue("Packages with successors" in self.output)
+        # Check that ignore option works.
+        # Just run again and see if goblin pkg now gets reversioned.
+        self.pkgsurf(
+            "-s {0} -r {1} -i info.home".format(self.dpath_tmp, self.dpath1)
+        )
 
-                # Check that ignore option works.
-                # Just run again and see if goblin pkg now gets reversioned.
-                self.pkgsurf("-s {0} -r {1} -i info.home".format(self.dpath_tmp,
-                    self.dpath1))
+        # Find goblin package
+        for s in self.published_ref:
+            if "goblin" in s:
+                break
+        f = fmri.PkgFmri(s, None)
+        targ = targ_repo.manifest(f)
+        ref = ref_repo.manifest(f)
+        self.assertEqual(
+            misc.get_data_digest(targ, hash_func=digest.DEFAULT_HASH_FUNC),
+            misc.get_data_digest(ref, hash_func=digest.DEFAULT_HASH_FUNC),
+        )
 
-                # Find goblin package
-                for s in self.published_ref:
-                        if "goblin" in s:
-                                break
-                f = fmri.PkgFmri(s, None)
-                targ = targ_repo.manifest(f)
-                ref = ref_repo.manifest(f)
-                self.assertEqual(misc.get_data_digest(targ,
-                    hash_func=digest.DEFAULT_HASH_FUNC),
-                    misc.get_data_digest(ref,
-                    hash_func=digest.DEFAULT_HASH_FUNC))
+        # Check that running the tool again doesn't find any pkgs
+        # to reversion. Use http for accessing reference repo this time.
+        self.pkgsurf("-s {0} -r {1}".format(self.dpath_tmp, self.durl1))
+        self.assertTrue("No packages to reversion." in self.output)
 
-                # Check that running the tool again doesn't find any pkgs
-                # to reversion. Use http for accessing reference repo this time.
-                self.pkgsurf("-s {0} -r {1}".format(self.dpath_tmp, self.durl1))
-                self.assertTrue("No packages to reversion." in self.output)
+    def test_4_unsigned_option(self):
+        # XXX - OmniOS, test disabled
+        return
 
-        def test_4_unsigned_option(self):
+        self.__change_content_hash()
 
-                # XXX - OmniOS, test disabled
-                return
+        # Copy target repo to tmp repo
+        self.copy_repository(
+            self.dpath2, self.dpath_tmp, {"selachii": "selachii"}
+        )
+        # The new repository won't have a catalog, so rebuild it.
+        self.dcs[4].get_repo(auto_create=True).rebuild()
 
-                self.__change_content_hash()
+        # If '-u' is enabled, we just check the unsigned version of
+        # hashes so that the target basic package is treated as no
+        # content change and should be reversioned.
+        elftest_exp = self.elftest_ref
+        efldiff_exp = self.elfdiff_ref
+        # Replace elftest package in the expected repo.
+        for i, s in enumerate(self.published_exp):
+            if "elftest" in s:
+                self.published_exp[i] = self.pkgsend_bulk(
+                    self.dpath3, (elftest_exp,)
+                )[0]
+            if "elfdiff" in s:
+                self.published_exp[i] = self.pkgsend_bulk(
+                    self.dpath3, (efldiff_exp,)
+                )[0]
 
-                # Copy target repo to tmp repo
-                self.copy_repository(self.dpath2, self.dpath_tmp,
-                    {"selachii": "selachii"})
-                # The new repository won't have a catalog, so rebuild it.
-                self.dcs[4].get_repo(auto_create=True).rebuild()
+        # Check that '-u' option works and should not affect other
+        # packages.
+        self.pkgsurf("-s {0} -r {1} -u".format(self.dpath_tmp, self.dpath1))
 
-                # If '-u' is enabled, we just check the unsigned version of
-                # hashes so that the target basic package is treated as no
-                # content change and should be reversioned.
-                elftest_exp = self.elftest_ref
-                efldiff_exp = self.elfdiff_ref
-                # Replace elftest package in the expected repo.
-                for i, s in enumerate(self.published_exp):
-                        if "elftest" in s:
-                                self.published_exp[i] = self.pkgsend_bulk(
-                                    self.dpath3, (elftest_exp,))[0]
-                        if "elfdiff" in s:
-                                self.published_exp[i] = self.pkgsend_bulk(
-                                    self.dpath3, (efldiff_exp,))[0]
+        self.pkgrepo(
+            "-s {0} verify --disable dependency".format(self.dpath_tmp)
+        )
 
-                # Check that '-u' option works and should not affect other
-                # packages.
-                self.pkgsurf("-s {0} -r {1} -u".format(self.dpath_tmp,
-                    self.dpath1))
+        # Create a target repo that just contains elfdiff and elfshare
+        # package. Ultimately the file elftest.so.1 and elftest.so.2
+        # should reside in the target repo.
+        self.pkgsend_bulk(self.dpath5, [self.elfdiff_targ, self.elfshare_targ])
+        self.pkgsurf("-s {0} -r {1} -u".format(self.dpath5, self.dpath1))
+        self.pkgrepo("-s {0} verify --disable dependency".format(self.dpath5))
 
-                self.pkgrepo("-s {0} verify --disable dependency".format(
-                    self.dpath_tmp))
+        # Test the HTTP-based reference repo case.
+        self.pkgsend_bulk(self.dpath6, [self.elfdiff_targ, self.elfshare_targ])
+        self.pkgsurf("-s {0} -r {1} -u".format(self.dpath6, self.durl1))
+        self.pkgrepo("-s {0} verify --disable dependency".format(self.dpath6))
 
-                # Create a target repo that just contains elfdiff and elfshare
-                # package. Ultimately the file elftest.so.1 and elftest.so.2
-                # should reside in the target repo.
-                self.pkgsend_bulk(self.dpath5, [self.elfdiff_targ,
-                    self.elfshare_targ])
-                self.pkgsurf("-s {0} -r {1} -u".format(self.dpath5,
-                    self.dpath1))
-                self.pkgrepo("-s {0} verify --disable dependency".format(
-                    self.dpath5))
+        ref_repo = self.get_repo(self.dpath1)
+        targ_repo = self.get_repo(self.dpath_tmp)
+        exp_repo = self.get_repo(self.dpath3)
+        for s in self.published_exp:
+            f = fmri.PkgFmri(s, None)
+            targ = targ_repo.manifest(f)
 
-                # Test the HTTP-based reference repo case.
-                self.pkgsend_bulk(self.dpath6, [self.elfdiff_targ,
-                    self.elfshare_targ])
-                self.pkgsurf("-s {0} -r {1} -u".format(self.dpath6,
-                    self.durl1))
-                self.pkgrepo("-s {0} verify --disable dependency".format(
-                    self.dpath6))
+            # Load target manifest
+            targm = manifest.Manifest()
+            targm.set_content(pathname=targ)
 
-                ref_repo = self.get_repo(self.dpath1)
-                targ_repo = self.get_repo(self.dpath_tmp)
-                exp_repo = self.get_repo(self.dpath3)
-                for s in self.published_exp:
-                        f = fmri.PkgFmri(s, None)
-                        targ = targ_repo.manifest(f)
+            # Load expected manifest
+            exp = exp_repo.manifest(f)
+            expm = manifest.Manifest()
+            expm.set_content(pathname=exp)
 
-                        # Load target manifest
-                        targm = manifest.Manifest()
-                        targm.set_content(pathname=targ)
+            ta, ra, ca = manifest.Manifest.comm(
+                [targm, expm], cmp_policy=CMP_UNSIGNED
+            )
+            self.debug("{0}: {1:d} {2:d}".format(str(s), len(ta), len(ra)))
 
-                        # Load expected manifest
-                        exp = exp_repo.manifest(f)
-                        expm = manifest.Manifest()
-                        expm.set_content(pathname=exp)
+            self.assertEqual(
+                0,
+                len(ta),
+                "{0} had unexpected actions:"
+                " \n{1}".format(s, "\n".join([str(x) for x in ta])),
+            )
+            self.assertEqual(
+                0,
+                len(ra),
+                "{0} had missing actions: "
+                "\n{1}".format(s, "\n".join([str(x) for x in ra])),
+            )
 
-                        ta, ra, ca = manifest.Manifest.comm([targm, expm],
-                            cmp_policy=CMP_UNSIGNED)
-                        self.debug("{0}: {1:d} {2:d}".format(str(s), len(ta),
-                            len(ra)))
+    def test_2_publishers(self):
+        """Tests for correct publisher handling."""
 
-                        self.assertEqual(0, len(ta), "{0} had unexpected actions:"
-                            " \n{1}".format(s, "\n".join([str(x) for x in ta])))
-                        self.assertEqual(0, len(ra), "{0} had missing actions: "
-                            "\n{1}".format(s, "\n".join([str(x) for x in ra])))
+        # Copy target repo to tmp repo
+        self.copy_repository(
+            self.dpath2, self.dpath_tmp, {"selachii": "selachii"}
+        )
+        # The new repository won't have a catalog, so rebuild it.
+        self.dcs[4].get_repo(auto_create=True).rebuild()
 
-        def test_2_publishers(self):
-                """Tests for correct publisher handling."""
+        # Add a package from a different publisher to target
+        self.pkgsend_bulk(self.dpath_tmp, [self.humpback_targ])
 
-                # Copy target repo to tmp repo
-                self.copy_repository(self.dpath2, self.dpath_tmp,
-                    { "selachii": "selachii" })
-                # The new repository won't have a catalog, so rebuild it.
-                self.dcs[4].get_repo(auto_create=True).rebuild()
+        # Test that unknown publisher in ref repo gets skipped without
+        # issue.
+        self.pkgsurf("-s {0} -r {1} -n".format(self.dpath_tmp, self.dpath1))
+        # Test that we also print a skipping notice
+        self.assertTrue("Skipping" in self.output)
 
-                # Add a package from a different publisher to target
-                self.pkgsend_bulk(self.dpath_tmp, [self.humpback_targ])
+        # Test that we fail if we specify a publisher which is not in
+        # reference repo.
+        self.pkgsurf(
+            "-s {0} -r {1} -p cetacea -n".format(self.dpath_tmp, self.dpath1),
+            exit=1,
+        )
 
-                # Test that unknown publisher in ref repo gets skipped without
-                # issue.
-                self.pkgsurf("-s {0} -r {1} -n".format(self.dpath_tmp,
-                    self.dpath1))
-                # Test that we also print a skipping notice
-                self.assertTrue("Skipping" in self.output)
+        # Now add packages from the 2nd pub to the ref repo
+        self.pkgsend_bulk(self.durl1, [self.humpback_ref])
 
-                # Test that we fail if we specify a publisher which is not in
-                # reference repo.
-                self.pkgsurf("-s {0} -r {1} -p cetacea -n".format(self.dpath_tmp,
-                    self.dpath1), exit=1)
+        # Test that only specified publisher is processed
+        self.pkgsurf(
+            "-s {0} -r {1} -p cetacea -n".format(self.dpath_tmp, self.dpath1)
+        )
+        self.assertFalse("selachii" in self.output)
+        self.pkgsurf(
+            "-s {0} -r {1} -p selachii -n".format(self.dpath_tmp, self.dpath1)
+        )
+        self.assertFalse("cetacea" in self.output)
 
-                # Now add packages from the 2nd pub to the ref repo
-                self.pkgsend_bulk(self.durl1, [self.humpback_ref])
+        # Now do an actual resurfacing of just one publisher
+        self.pkgsurf(
+            "-s {0} -r {1} -p selachii".format(self.dpath_tmp, self.dpath1)
+        )
+        # Check if we see anything about the unspecified publisher
+        # in the output.
+        self.assertFalse("cetacea" in self.output)
+        # Check if we didn't reversion packages of the unspecified
+        # publisher.
+        self.pkgrepo("-s {0} list humpback".format(self.dpath_tmp))
+        self.assertTrue("2.0" in self.output)
 
-                # Test that only specified publisher is processed
-                self.pkgsurf("-s {0} -r {1} -p cetacea -n".format(self.dpath_tmp,
-                    self.dpath1))
-                self.assertFalse("selachii" in self.output)
-                self.pkgsurf("-s {0} -r {1} -p selachii -n".format(self.dpath_tmp,
-                    self.dpath1))
-                self.assertFalse("cetacea" in self.output)
+    def test_3_override_pkgs(self):
+        """Test for correct handling of user specified packages which
+        should not get reversioned."""
 
-                # Now do an actual resurfacing of just one publisher
-                self.pkgsurf("-s {0} -r {1} -p selachii".format(self.dpath_tmp,
-                    self.dpath1))
-                # Check if we see anything about the unspecified publisher
-                # in the output.
-                self.assertFalse("cetacea" in self.output)
-                # Check if we didn't reversion packages of the unspecified
-                # publisher.
-                self.pkgrepo("-s {0} list humpback".format(self.dpath_tmp))
-                self.assertTrue("2.0" in self.output)
+        # Copy target repo to tmp repo
+        self.copy_repository(
+            self.dpath2, self.dpath_tmp, {"selachii": "selachii"}
+        )
+        # The new repository won't have a catalog, so rebuild it.
+        self.dcs[4].get_repo(auto_create=True).rebuild()
 
-        def test_3_override_pkgs(self):
-                """Test for correct handling of user specified packages which
-                should not get reversioned."""
+        # Check multiple patterns with globbing
+        self.pkgsurf(
+            "-s {0} -r {1} -c *iger".format(self.dpath_tmp, self.dpath1)
+        )
+        self.pkgrepo("-s {0} list tiger".format(self.dpath_tmp))
+        self.assertTrue("2.0" in self.output)
+        self.pkgrepo("-s {0} list sandtiger".format(self.dpath_tmp))
+        self.assertTrue("2.0" in self.output)
 
-                # Copy target repo to tmp repo
-                self.copy_repository(self.dpath2, self.dpath_tmp,
-                    { "selachii": "selachii" })
-                # The new repository won't have a catalog, so rebuild it.
-                self.dcs[4].get_repo(auto_create=True).rebuild()
-
-                # Check multiple patterns with globbing
-                self.pkgsurf("-s {0} -r {1} -c *iger".format(self.dpath_tmp,
-                    self.dpath1))
-                self.pkgrepo("-s {0} list tiger".format(self.dpath_tmp))
-                self.assertTrue("2.0" in self.output)
-                self.pkgrepo("-s {0} list sandtiger".format(self.dpath_tmp))
-                self.assertTrue("2.0" in self.output)
-
-                # Check specific name.
-                self.pkgsurf("-s {0} -r {1} -c tiger".format(self.dpath_tmp,
-                    self.dpath1))
-                self.pkgrepo("-s {0} list tiger".format(self.dpath_tmp))
-                self.assertTrue("2.0" in self.output)
+        # Check specific name.
+        self.pkgsurf(
+            "-s {0} -r {1} -c tiger".format(self.dpath_tmp, self.dpath1)
+        )
+        self.pkgrepo("-s {0} list tiger".format(self.dpath_tmp))
+        self.assertTrue("2.0" in self.output)
 
 
 if __name__ == "__main__":
-                unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_publish_api.py
+++ b/src/tests/cli/t_publish_api.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -38,67 +39,67 @@ import pkg.client.transport.transport as transport
 import pkg.fmri as fmri
 import pkg.publish.transaction as trans
 
+
 class TestPkgPublicationApi(pkg5unittest.SingleDepotTestCase):
-        """Various publication tests."""
+    """Various publication tests."""
 
-        # Restart the depot and recreate the repository every test.
-        persistent_setup = False
+    # Restart the depot and recreate the repository every test.
+    persistent_setup = False
 
-        def setUp(self):
-                # This test suite needs an actual depot.
-                pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
+    def setUp(self):
+        # This test suite needs an actual depot.
+        pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
 
-        def test_stress_http_publish(self):
-                """Publish lots of packages rapidly ensuring that http
-                publication can handle it."""
+    def test_stress_http_publish(self):
+        """Publish lots of packages rapidly ensuring that http
+        publication can handle it."""
 
-                durl = self.dc.get_depot_url()
-                repouriobj = publisher.RepositoryURI(durl)
-                repo = publisher.Repository(origins=[repouriobj])
-                pub = publisher.Publisher(prefix="repo1", repository=repo)
-                xport_cfg = transport.GenericTransportCfg()
-                xport_cfg.add_publisher(pub)
-                xport = transport.Transport(xport_cfg)
+        durl = self.dc.get_depot_url()
+        repouriobj = publisher.RepositoryURI(durl)
+        repo = publisher.Repository(origins=[repouriobj])
+        pub = publisher.Publisher(prefix="repo1", repository=repo)
+        xport_cfg = transport.GenericTransportCfg()
+        xport_cfg.add_publisher(pub)
+        xport = transport.Transport(xport_cfg)
 
-                # Each version number must be unique since multiple packages
-                # will be published within the same second.
-                for i in range(100):
-                        pf = fmri.PkgFmri("foo@{0:d}.0".format(i))
-                        t = trans.Transaction(durl, pkg_name=str(pf),
-                            xport=xport, pub=pub)
-                        t.open()
-                        pkg_fmri, pkg_state = t.close()
-                        self.debug("{0}: {1}".format(pkg_fmri, pkg_state))
+        # Each version number must be unique since multiple packages
+        # will be published within the same second.
+        for i in range(100):
+            pf = fmri.PkgFmri("foo@{0:d}.0".format(i))
+            t = trans.Transaction(durl, pkg_name=str(pf), xport=xport, pub=pub)
+            t.open()
+            pkg_fmri, pkg_state = t.close()
+            self.debug("{0}: {1}".format(pkg_fmri, pkg_state))
 
-        def test_stress_file_publish(self):
-                """Publish lots of packages rapidly ensuring that file
-                publication can handle it."""
+    def test_stress_file_publish(self):
+        """Publish lots of packages rapidly ensuring that file
+        publication can handle it."""
 
-                location = self.dc.get_repodir()
-                location = os.path.abspath(location)
-                location = urlunparse(("file", "",
-                    pathname2url(location), "", "", ""))
+        location = self.dc.get_repodir()
+        location = os.path.abspath(location)
+        location = urlunparse(("file", "", pathname2url(location), "", "", ""))
 
-                repouriobj = publisher.RepositoryURI(location)
-                repo = publisher.Repository(origins=[repouriobj])
-                pub = publisher.Publisher(prefix="repo1", repository=repo)
-                xport_cfg = transport.GenericTransportCfg()
-                xport_cfg.add_publisher(pub)
-                xport = transport.Transport(xport_cfg)
+        repouriobj = publisher.RepositoryURI(location)
+        repo = publisher.Repository(origins=[repouriobj])
+        pub = publisher.Publisher(prefix="repo1", repository=repo)
+        xport_cfg = transport.GenericTransportCfg()
+        xport_cfg.add_publisher(pub)
+        xport = transport.Transport(xport_cfg)
 
-                # Each version number must be unique since multiple packages
-                # will be published within the same second.
-                for i in range(100):
-                        pf = fmri.PkgFmri("foo@{0:d}.0".format(i))
-                        t = trans.Transaction(location, pkg_name=str(pf),
-                            xport=xport, pub=pub)
-                        t.open()
-                        pkg_fmri, pkg_state = t.close()
-                        self.debug("{0}: {1}".format(pkg_fmri, pkg_state))
+        # Each version number must be unique since multiple packages
+        # will be published within the same second.
+        for i in range(100):
+            pf = fmri.PkgFmri("foo@{0:d}.0".format(i))
+            t = trans.Transaction(
+                location, pkg_name=str(pf), xport=xport, pub=pub
+            )
+            t.open()
+            pkg_fmri, pkg_state = t.close()
+            self.debug("{0}: {1}".format(pkg_fmri, pkg_state))
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_sysrepo.py
+++ b/src/tests/cli/t_sysrepo.py
@@ -27,8 +27,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -56,1099 +57,1221 @@ from pkg.digest import DEFAULT_HASH_FUNC
 
 SYSREPO_USER = "pkg5srv"
 
+
 class TestBasicSysrepoCli(pkg5unittest.ApacheDepotTestCase):
-        """Some basic tests checking that we can deal with all of our arguments
-        and that we handle invalid input correctly."""
+    """Some basic tests checking that we can deal with all of our arguments
+    and that we handle invalid input correctly."""
 
-        def setUp(self):
-                self.sc = None
-                pkg5unittest.ApacheDepotTestCase.setUp(self, ["test"])
-                self.image_create()
-                self.default_sc_runtime = os.path.join(self.test_root,
-                    "sysrepo_runtime")
-                self.default_sc_conf = os.path.join(self.default_sc_runtime,
-                    "sysrepo_httpd.conf")
+    def setUp(self):
+        self.sc = None
+        pkg5unittest.ApacheDepotTestCase.setUp(self, ["test"])
+        self.image_create()
+        self.default_sc_runtime = os.path.join(
+            self.test_root, "sysrepo_runtime"
+        )
+        self.default_sc_conf = os.path.join(
+            self.default_sc_runtime, "sysrepo_httpd.conf"
+        )
 
-        def _start_sysrepo(self, runtime_dir=None):
-                if not runtime_dir:
-                        runtime_dir = self.default_sc_runtime
-                self.sysrepo_port = self.next_free_port
-                self.next_free_port += 1
-                self.sc = pkg5unittest.SysrepoController(self.default_sc_conf,
-                    self.sysrepo_port, runtime_dir, testcase=self)
-                self.register_apache_controller("sysrepo", self.sc)
-                self.sc.start()
+    def _start_sysrepo(self, runtime_dir=None):
+        if not runtime_dir:
+            runtime_dir = self.default_sc_runtime
+        self.sysrepo_port = self.next_free_port
+        self.next_free_port += 1
+        self.sc = pkg5unittest.SysrepoController(
+            self.default_sc_conf, self.sysrepo_port, runtime_dir, testcase=self
+        )
+        self.register_apache_controller("sysrepo", self.sc)
+        self.sc.start()
 
-        def test_0_sysrepo(self):
-                """A very basic test to see that we can start the sysrepo."""
+    def test_0_sysrepo(self):
+        """A very basic test to see that we can start the sysrepo."""
 
-                # ensure we fail when not supplying the required argument
-                self.sysrepo("", exit=2, fill_missing_args=False)
+        # ensure we fail when not supplying the required argument
+        self.sysrepo("", exit=2, fill_missing_args=False)
 
-                self.sysrepo("")
-                self._start_sysrepo()
-                self.sc.stop()
+        self.sysrepo("")
+        self._start_sysrepo()
+        self.sc.stop()
 
-        def test_1_sysrepo_usage(self):
-                """Tests that we show a usage message."""
+    def test_1_sysrepo_usage(self):
+        """Tests that we show a usage message."""
 
-                ret, output = self.sysrepo("--help", out=True, exit=2)
-                self.assertTrue("Usage:" in output,
-                    "No usage string printed: {0}".format(output))
+        ret, output = self.sysrepo("--help", out=True, exit=2)
+        self.assertTrue(
+            "Usage:" in output, "No usage string printed: {0}".format(output)
+        )
 
-        def test_2_invalid_root(self):
-                """We return an error given an invalid image root"""
+    def test_2_invalid_root(self):
+        """We return an error given an invalid image root"""
 
-                for invalid_root in ["/dev/null", "/etc/passwd", "/proc"]:
-                        ret, output, err = self.sysrepo("-R {0}".format(invalid_root),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_root in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_root, err))
+        for invalid_root in ["/dev/null", "/etc/passwd", "/proc"]:
+            ret, output, err = self.sysrepo(
+                "-R {0}".format(invalid_root), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_root in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_root, err),
+            )
 
-        def test_3_invalid_cache_dir(self):
-                """We return an error given an invalid cache_dir"""
+    def test_3_invalid_cache_dir(self):
+        """We return an error given an invalid cache_dir"""
 
-                for invalid_cache in ["/dev/null", "/etc/passwd"]:
-                        ret, output, err = self.sysrepo("-c {0}".format(invalid_cache),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_cache in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_cache, err))
+        for invalid_cache in ["/dev/null", "/etc/passwd"]:
+            ret, output, err = self.sysrepo(
+                "-c {0}".format(invalid_cache), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_cache in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_cache, err),
+            )
 
-        def test_4_invalid_hostname(self):
-                """We return an error given an invalid hostname"""
+    def test_4_invalid_hostname(self):
+        """We return an error given an invalid hostname"""
 
-                for invalid_host in ["1.2.3.4.5.6", "pkgsysrepotestname", "."]:
-                        ret, output, err = self.sysrepo("-h {0}".format(invalid_host),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_host in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_host, err))
+        for invalid_host in ["1.2.3.4.5.6", "pkgsysrepotestname", "."]:
+            ret, output, err = self.sysrepo(
+                "-h {0}".format(invalid_host), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_host in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_host, err),
+            )
 
-        def test_5_invalid_logs_dir(self):
-                """We return an error given an invalid logs_dir"""
+    def test_5_invalid_logs_dir(self):
+        """We return an error given an invalid logs_dir"""
 
-                for invalid_log in ["/dev/null", "/etc/passwd"]:
-                        ret, output, err = self.sysrepo("-l {0}".format(invalid_log),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_log in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_log, err))
+        for invalid_log in ["/dev/null", "/etc/passwd"]:
+            ret, output, err = self.sysrepo(
+                "-l {0}".format(invalid_log), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_log in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_log, err),
+            )
 
-                for invalid_log in ["/proc"]:
-                        port = self.next_free_port
-                        ret, output, err = self.sysrepo("-l {0} -p {1}".format(
-                            invalid_log, port), out=True, stderr=True, exit=0)
-                        self.assertRaises(pkg5unittest.ApacheStateException,
-                            self._start_sysrepo)
-                        self.sc.stop()
+        for invalid_log in ["/proc"]:
+            port = self.next_free_port
+            ret, output, err = self.sysrepo(
+                "-l {0} -p {1}".format(invalid_log, port),
+                out=True,
+                stderr=True,
+                exit=0,
+            )
+            self.assertRaises(
+                pkg5unittest.ApacheStateException, self._start_sysrepo
+            )
+            self.sc.stop()
 
-        def test_6_invalid_port(self):
-                """We return an error given an invalid port"""
+    def test_6_invalid_port(self):
+        """We return an error given an invalid port"""
 
-                for invalid_port in [999999, "bobcat", "-1234"]:
-                        ret, output, err = self.sysrepo("-p {0}".format(invalid_port),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue(str(invalid_port) in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_port, err))
+        for invalid_port in [999999, "bobcat", "-1234"]:
+            ret, output, err = self.sysrepo(
+                "-p {0}".format(invalid_port), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                str(invalid_port) in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_port, err),
+            )
 
-        def test_7_invalid_runtime_dir(self):
-                """We return an error given an invalid runtime_dir"""
+    def test_7_invalid_runtime_dir(self):
+        """We return an error given an invalid runtime_dir"""
 
-                for invalid_runtime in ["/dev/null", "/etc/passwd", "/proc"]:
-                        ret, output, err = self.sysrepo("-r {0}".format(
-                            invalid_runtime), out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_runtime in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_runtime, err))
+        for invalid_runtime in ["/dev/null", "/etc/passwd", "/proc"]:
+            ret, output, err = self.sysrepo(
+                "-r {0}".format(invalid_runtime), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_runtime in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_runtime, err),
+            )
 
-        def test_8_invalid_cache_size(self):
-                """We return an error given an invalid cache_size"""
+    def test_8_invalid_cache_size(self):
+        """We return an error given an invalid cache_size"""
 
-                for invalid_csize in [0, "cats", "-1234"]:
-                        ret, output, err = self.sysrepo("-s {0}".format(invalid_csize),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue(str(invalid_csize) in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_csize, err))
+        for invalid_csize in [0, "cats", "-1234"]:
+            ret, output, err = self.sysrepo(
+                "-s {0}".format(invalid_csize), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                str(invalid_csize) in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_csize, err),
+            )
 
-        def test_9_invalid_templates_dir(self):
-                """We return an error given an invalid templates_dir"""
+    def test_9_invalid_templates_dir(self):
+        """We return an error given an invalid templates_dir"""
 
-                for invalid_tmp in ["/dev/null", "/etc/passwd", "/proc"]:
-                        ret, output, err = self.sysrepo("-t {0}".format(invalid_tmp),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue(invalid_tmp in err, "error message "
-                            "did not contain {0}: {1}".format(invalid_tmp, err))
+        for invalid_tmp in ["/dev/null", "/etc/passwd", "/proc"]:
+            ret, output, err = self.sysrepo(
+                "-t {0}".format(invalid_tmp), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                invalid_tmp in err,
+                "error message "
+                "did not contain {0}: {1}".format(invalid_tmp, err),
+            )
 
-        def test_10_invalid_http_timeout(self):
-                """We return an error given an invalid http_timeout"""
+    def test_10_invalid_http_timeout(self):
+        """We return an error given an invalid http_timeout"""
 
-                for invalid_time in ["cats", "0", "-1"]:
-                        ret, output, err = self.sysrepo("-T {0}".format(invalid_time),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue("http_timeout" in err, "error message "
-                             "did not contain http_timeout: {0}".format(err))
+        for invalid_time in ["cats", "0", "-1"]:
+            ret, output, err = self.sysrepo(
+                "-T {0}".format(invalid_time), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                "http_timeout" in err,
+                "error message "
+                "did not contain http_timeout: {0}".format(err),
+            )
 
-        def test_11_invalid_proxies(self):
-                """We return an error given invalid proxies"""
+    def test_11_invalid_proxies(self):
+        """We return an error given invalid proxies"""
 
-                for invalid_proxy in ["http://", "https://foo.bar", "-1",
-                    "http://user:password@hostname:3128"]:
-                        ret, output, err = self.sysrepo("-w {0}".format(invalid_proxy),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue("http_proxy" in err, "error message "
-                             "did not contain http_proxy: {0}".format(err))
-                        ret, output, err = self.sysrepo("-W {0}".format(invalid_proxy),
-                            out=True, stderr=True, exit=1)
-                        self.assertTrue("https_proxy" in err, "error message "
-                             "did not contain https_proxy: {0}".format(err))
+        for invalid_proxy in [
+            "http://",
+            "https://foo.bar",
+            "-1",
+            "http://user:password@hostname:3128",
+        ]:
+            ret, output, err = self.sysrepo(
+                "-w {0}".format(invalid_proxy), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                "http_proxy" in err,
+                "error message " "did not contain http_proxy: {0}".format(err),
+            )
+            ret, output, err = self.sysrepo(
+                "-W {0}".format(invalid_proxy), out=True, stderr=True, exit=1
+            )
+            self.assertTrue(
+                "https_proxy" in err,
+                "error message " "did not contain https_proxy: {0}".format(err),
+            )
 
 
 class TestDetailedSysrepoCli(pkg5unittest.ApacheDepotTestCase):
+    persistent_setup = True
 
-        persistent_setup = True
-
-        sample_pkg = """
+    sample_pkg = """
             open sample@1.0,5.11-0
             add file tmp/sample_file mode=0444 owner=root group=bin path=/usr/bin/sample
             close"""
 
-        new_pkg = """
+    new_pkg = """
             open new@1.0,5.11-0
             add file tmp/sample_file mode=0444 owner=root group=bin path=/usr/bin/new
             close"""
 
-        misc_files = ["tmp/sample_file"]
-
-        def setUp(self):
-                # see test_7_response_overlaps
-                self.overlap_pubs = ["versions", "versionsX", "syspub",
-                    "Xsyspub"]
-                pubs = ["test1", "test2"]
-                pubs.extend(self.overlap_pubs)
-                pkg5unittest.ApacheDepotTestCase.setUp(self, pubs,
-                    start_depots=True)
-
-                # Most tests use a single system-repository instance, "sc",
-                # but some also use an alternative instance, "alt_sc".
-                self.sc = None
-                self.alt_sc = None
-
-                self.default_sc_runtime = os.path.join(self.test_root,
-                    "sysrepo_runtime")
-                # add another level to the tree used to store the alternative
-                # runtime dir, since the sysrepo writes
-                # <runtime>/../sysrepo_httpd.pid, which would clash with the
-                # default instance
-                self.alt_sc_runtime = os.path.sep.join([self.test_root,
-                    "alt_sysrepo_runtime", "alt"])
-                self.default_sc_conf = os.path.join(self.default_sc_runtime,
-                    "sysrepo_httpd.conf")
-                self.alt_sc_conf = os.path.join(self.alt_sc_runtime,
-                    "sysrepo_httpd.conf")
-                self.default_sc_p5s = os.path.sep.join([self.default_sc_runtime,
-                    "htdocs", "syspub", "0", "index.html"])
-                self.make_misc_files(self.misc_files)
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.rurl1 = self.dcs[1].get_repo_url()
-                self.durl2 = self.dcs[2].get_depot_url()
-                for dc_num in self.dcs:
-                        durl = self.dcs[dc_num].get_depot_url()
-                        self.pkgsend_bulk(durl, self.sample_pkg)
-
-        def _start_sysrepo(self, runtime_dir=None, alt=False):
-                """Starts a system repository instance, either using the default
-                or alternative configurations."""
-                if not runtime_dir:
-                        runtime_dir = self.default_sc_runtime
-                self.sysrepo_port = self.next_free_port
-                self.next_free_port += 1
-
-                if alt:
-                        conf = self.alt_sc_conf
-                        runtime_dir = self.alt_sc_runtime
-                        self.alt_sc = pkg5unittest.SysrepoController(conf,
-                            self.sysrepo_port, runtime_dir, testcase=self)
-                        self.register_apache_controller("alt_sysrepo",
-                            self.alt_sc)
-                        self.alt_sc.start()
-                else:
-                        self.sc = pkg5unittest.SysrepoController(
-                            self.default_sc_conf,
-                            self.sysrepo_port, runtime_dir, testcase=self)
-                        self.register_apache_controller("sysrepo",
-                            self.sc)
-                        self.sc.start()
-
-        def test_1_substring_proxy(self):
-                """We can proxy publishers that are substrings of each other"""
-                # XXX not implemented yet
-                pass
-
-        def test_2_invalid_proxy(self):
-                """We return an invalid response for urls we don't proxy"""
-                # XXX not implemented yet
-                pass
-
-        def test_3_cache_dir(self):
-                """Our cache_dir value is used"""
-
-                self.image_create(prefix="test1", repourl=self.durl1)
-
-                cache_dir = os.path.join(self.test_root, "t_sysrepo_cache")
-                port = self.next_free_port
-                self.sysrepo("-R {0} -c {1} -p {2}".format(self.get_img_path(),
-                    cache_dir, port))
-                self._start_sysrepo()
-
-                # 1. grep for the Cache keyword in the httpd.conf
-                self.file_contains(self.default_sc_conf, "CacheEnable disk /")
-                self.file_doesnt_contain(self.default_sc_conf,
-                    "CacheEnable mem")
-                self.file_doesnt_contain(self.default_sc_conf, "MCacheSize")
-                self.file_contains(self.default_sc_conf, "CacheRoot {0}".format(
-                    cache_dir))
-
-                # 2. publish a file, then install using the proxy
-                # check that the proxy has written some content into the cache
-                # XXX not implemented yet.
-                self.sc.stop()
-
-                # 3. use urllib to pull the url for the file again, verify
-                # we've got a cache header on the HTTP response
-                # XXX not implemented yet.
-
-                # 4. ensure memory and None settings are written
-                cache_dir = "None"
-                self.sysrepo("-c {0} -p {1}".format(cache_dir, port))
-                self.file_doesnt_contain(self.default_sc_conf, "CacheEnable")
-
-                cache_dir = "memory"
-                self.sysrepo("-c {0} -p {1}".format(cache_dir, port))
-                self.file_doesnt_contain(self.default_sc_conf,
-                    "CacheEnable disk")
-                self.file_contains(self.default_sc_conf, "CacheEnable mem")
-                self.file_contains(self.default_sc_conf, "MCacheSize")
-
-        def test_4_logs_dir(self):
-                """Our logs_dir value is used"""
-
-                self.image_create(prefix="test1", repourl=self.durl1)
-
-                logs_dir = os.path.join(self.test_root, "t_sysrepo_logs")
-                port = self.next_free_port
-                self.sysrepo("-l {0} -p {1}".format(logs_dir, port))
-                self._start_sysrepo()
-
-                # 1. grep for the logs dir in the httpd.conf
-                self.file_contains(self.default_sc_conf,
-                    "ErrorLog \"{0}/error_log\"".format(logs_dir))
-                self.file_contains(self.default_sc_conf,
-                    "CustomLog \"{0}/access_log\"".format(logs_dir))
-                # 2. verify our log files exist once the sysrepo has started
-                for name in ["error_log", "access_log"]:
-                        os.path.exists(os.path.join(logs_dir, name))
-                self.sc.stop()
-
-        def test_5_port_host(self):
-                """Our port value is used"""
-                self.image_create(prefix="test1", repourl=self.durl1)
-
-                port = self.next_free_port
-                self.sysrepo("-p {0} -h localhost".format(port))
-                self._start_sysrepo()
-                self.file_contains(self.default_sc_conf, "Listen localhost:{0}".format(
-                    port))
-                self.sc.stop()
-
-        def test_6_permissions(self):
-                """Our permissions are correct on all generated files"""
-
-                # 1. check the permissions
-                # XXX not implemented yet.
-                pass
-
-        def test_7_response_overlaps(self):
-                """We can proxy publishers that are == or substrings of our
-                known responses"""
-
-                self.image_create(prefix="test1", repourl=self.durl1)
-
-                overlap_dcs = []
-                # identify the interesting repos, those that we've configured
-                # using publisher prefixes that match our responses
-                for dc_num in [num for num in self.dcs if
-                    (self.dcs[num].get_property("publisher", "prefix")
-                    in self.overlap_pubs)]:
-                        dc = self.dcs[dc_num]
-                        name = dc.get_property("publisher", "prefix")
-                        overlap_dcs.append(dc)
-                        # we need to use -R here since it doesn't get added
-                        # automatically by self.pkg() because we've got
-                        # "versions" as one of the CLI args (it being an
-                        # overlapping publisher name)
-                        self.pkg("-R {img} set-publisher -g {url} {pub}".format(
-                            img=self.get_img_path(),
-                            url=dc.get_repo_url(), pub=name))
-
-                # Start a system repo based on the configuration above
-                self.sysrepo("")
-                self._start_sysrepo()
-
-                # attempt to create images using the sysrepo
-                for dc in overlap_dcs:
-                        pub = dc.get_property("publisher", "prefix")
-                        hash = hashlib.sha1(misc.force_bytes("file://" +
-                            dc.get_repodir().rstrip("/"))).hexdigest()
-                        url = "http://localhost:{port}/{pub}/{hash}/".format(
-                            port=self.sysrepo_port, hash=hash,
-                            pub=pub)
-                        self.set_img_path(os.path.join(self.test_root,
-                            "sysrepo_image"))
-                        self.pkg_image_create(prefix=pub, repourl=url)
-                        self.pkg("-R {0} install sample".format(self.get_img_path()))
-
-                self.sc.stop()
-
-        def test_8_file_publisher(self):
-                """A proxied file publisher works as a normal file publisher,
-                including package archives"""
-                #
-                # The standard system publisher client code does not use the
-                # "publisher/0" response, so we need this test to exercise that.
-
-                self.image_create(prefix="test1", repourl=self.durl1)
-
-                # create a version of this url with a symlink, to ensure we
-                # can follow links in urls
-                urlresult = urlparse(self.rurl1)
-                symlink_path = os.path.join(self.test_root, "repo_symlink")
-                os.symlink(urlresult.path, symlink_path)
-                symlinked_url = "file://{0}".format(symlink_path)
-
-                # create a p5p archive
-                p5p_path = os.path.join(self.test_root,
-                    "test_8_file_publisher_archive.p5p")
-                p5p_url = "file://{0}".format(p5p_path)
-                self.pkgrecv(server_url=self.durl1, command="-a -d {0} sample".format(
-                    p5p_path))
-
-                for file_url in [self.rurl1, symlinked_url, p5p_url]:
-                        self.image_create(prefix="test1", repourl=self.durl1)
-                        self.pkg("set-publisher -g {0} test1".format(file_url))
-                        self.sysrepo("")
-                        self._start_sysrepo()
-
-                        hash = hashlib.sha1(misc.force_bytes(
-                            file_url.rstrip("/"))).hexdigest()
-                        url = "http://localhost:{port}/test1/{hash}/".format(
-                            port=self.sysrepo_port, hash=hash)
-                        self.pkg_image_create(prefix="test1", repourl=url)
-                        self.pkg("install sample")
-                        self.pkg("contents -rm sample")
-                        # the sysrepo doesn't support search ops for file repos
-                        self.pkg("search -r sample", exit=1)
-                        self.sc.stop()
-
-        def test_9_unsupported_publishers(self):
-                """Ensure we fail when asked to proxy < v4 file repos"""
-
-                v3_repo_root = os.path.join(self.test_root, "sysrepo_test_9")
-                os.mkdir(v3_repo_root)
-                v3_repo_path = os.path.join(v3_repo_root, "repo")
-
-                self.pkgrepo("create --version 3 {0}".format(v3_repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=foo".format(v3_repo_path))
-                for path in [v3_repo_path]:
-                        self.image_create(repourl="file://{0}".format(path))
-                        self.sysrepo("-R {0}".format(self.img_path()), exit=1)
-
-        def test_10_missing_file_repo(self):
-                """Ensure we print the right error message in the face of
-                a missing repository."""
-                repo_path = os.path.join(self.test_root, "test_10_missing_repo")
-                self.pkgrepo("create {0}".format(repo_path))
-                self.pkgrecv(server_url=self.durl1, command="-d {0} sample".format(
-                    repo_path))
-                self.pkgrepo("-s {0} set publisher/prefix=foo".format(repo_path))
-                self.pkgrepo("-s {0} rebuild".format(repo_path))
-                self.image_create(repourl="file://{0}".format(repo_path))
-                shutil.rmtree(repo_path)
-                ret, output, err = self.sysrepo("-R {0}".format(self.img_path()),
-                    out=True, stderr=True, exit=1)
-                # restore our image before going any further
-                self.assertTrue("does not exist" in err, "unable to find expected "
-                    "error message in stderr: {0}".format(err))
-
-        def test_11_proxy_args(self):
-                """Ensure we write configuration to tell Apache to use a remote
-                proxy when proxying requests when using -w or -W"""
-                self.image_create(prefix="test1", repourl=self.durl1)
-
-                for arg, directives in [
-                    ("-w http://foo", ["ProxyRemote http http://foo"]),
-                    ("-W http://foo", ["ProxyRemote https http://foo"]),
-                    ("-w http://foo -W http://foo",
-                    ["ProxyRemote http http://foo",
-                    "ProxyRemote https http://foo"])]:
-                            self.sysrepo(arg)
-                            for d in directives:
-                                    self.file_contains(self.default_sc_conf, d)
-
-        def test_12_cache_dir_permissions(self):
-                """Our cache_dir permissions and ownership are verified"""
-
-                exp_uid = portable.get_user_by_name(SYSREPO_USER, None, False)
-                self.image_create(prefix="test1", repourl=self.durl1)
-
-                cache_dir = os.path.join(self.test_root, "t_sysrepo_cache")
-                # first verify that the user running the test has permissions
-                try:
-                        os.mkdir(cache_dir)
-                        os.chown(cache_dir, exp_uid, 1)
-                        os.rmdir(cache_dir)
-                except OSError as e:
-                        if e.errno == errno.EPERM:
-                                raise pkg5unittest.TestSkippedException(
-                                    "User running test does not have "
-                                    "permissions to chown to uid {0}".format(exp_uid))
-                        raise
-
-                # Run sysrepo to create cache directory
-                port = self.next_free_port
-                self.sysrepo("-R {0} -c {1} -p {2}".format(self.get_img_path(),
-                    cache_dir, port))
-
-                self._start_sysrepo()
-                self.sc.stop()
-
-                # Remove cache directory
-                os.rmdir(cache_dir)
-
-                # Again run sysrepo and then verify permissions
-                cache_dir = os.path.join(self.test_root, "t_sysrepo_cache")
-                port = self.next_free_port
-                self.sysrepo("-R {0} -c {1} -p {2}".format(self.get_img_path(),
-                    cache_dir, port))
-                self._start_sysrepo()
-
-                # Wait for service to come online. Try for 30 seconds.
-                count = 0
-                while (count < 10):
-                        time.sleep(3)
-                        count = count + 1
-                        if (os.access(cache_dir, os.F_OK)):
-                                break
-
-                # Verify cache directory exists.
-                self.assertTrue(os.access(cache_dir, os.F_OK))
-
-                filemode = stat.S_IMODE(os.stat(cache_dir).st_mode)
-                self.assertEqualDiff(0o755, filemode)
-                uid = os.stat(cache_dir)[4]
-                exp_uid = portable.get_user_by_name(SYSREPO_USER, None, False)
-                self.assertEqualDiff(exp_uid, uid)
-
-                self.sc.stop()
-
-        def test_13_changing_p5p(self):
-                """Ensure that when a p5p file changes from beneath us, or
-                disappears, the system repository and any pkg(7) clients
-                react correctly."""
-
-                # create a p5p archive
-                p5p_path = os.path.join(self.test_root,
-                    "test_12_changing_p5p_archive.p5p")
-                p5p_url = "file://{0}".format(p5p_path)
-                self.pkgrecv(server_url=self.durl1, command="-a -d {0} sample".format(
-                    p5p_path))
-
-                # configure an image from which to generate a sysrepo config
-                self.image_create(prefix="test1", repourl=self.durl1)
-                self.pkg("set-publisher -g {0} test1".format(p5p_url))
-                self.sysrepo("")
-                self._start_sysrepo()
-
-                # create an image which uses the system publisher
-                hash = hashlib.sha1(misc.force_bytes(p5p_url.rstrip("/"))).hexdigest()
-                url = "http://localhost:{port}/test1/{hash}/".format(
-                    port=self.sysrepo_port, hash=hash)
-
-                self.debug("using {0} as repo url".format(url))
-                self.pkg_image_create(prefix="test1", repourl=url)
-                self.pkg("install sample")
-
-                # modify the p5p file - publish a new package and an
-                # update of the existing package, then recreate the p5p file.
-                self.pkgsend_bulk(self.durl1, self.new_pkg)
-                self.pkgsend_bulk(self.durl1, self.sample_pkg)
-                os.unlink(p5p_path)
-                self.pkgrecv(server_url=self.durl1,
-                    command="-a -d {0} sample new".format(p5p_path))
-
-                # ensure we can install our new packages through the system
-                # publisher url
-                self.pkg("install new")
-                self.pkg("publisher")
-
-                # remove the p5p file, which should still allow us to uninstall
-                renamed_p5p_path = p5p_path + ".renamed"
-                os.rename(p5p_path, renamed_p5p_path)
-                self.pkg("uninstall new")
-
-                # ensure we can't install the packages or perform operations
-                # that require the p5p file to be present
-                self.pkg("install new", exit=1)
-                self.pkg("contents -rm new", exit=1)
-
-                # replace the p5p file, and ensure the client can install again
-                os.rename(renamed_p5p_path, p5p_path)
-                self.pkg("install new")
-                self.pkg("contents -rm new")
-
-                self.sc.stop()
-
-        def test_14_bad_input(self):
-                """Tests the system repository with some bad input: wrong
-                paths, unicode in urls, and some very long urls to ensure
-                the responses are as expected."""
-                # create a p5p archive
-                p5p_path = os.path.join(self.test_root,
-                    "test_13_bad_input.p5p")
-                p5p_url = "file://{0}".format(p5p_path)
-                self.pkgrecv(server_url=self.durl1, command="-a -d {0} sample".format(
-                    p5p_path))
-                p5p_hash = hashlib.sha1(misc.force_bytes(
-                    p5p_url.rstrip("/"))).hexdigest()
-                file_url = self.dcs[2].get_repo_url()
-                file_hash = hashlib.sha1(misc.force_bytes(
-                    file_url.rstrip("/"))).hexdigest()
-
-                # configure an image from which to generate a sysrepo config
-                self.image_create(prefix="test1", repourl=self.durl1)
-
-                self.pkg("set-publisher -p {0}".format(file_url))
-                self.pkg("set-publisher -g {0} test1".format(p5p_url))
-                self.sysrepo("")
-                self._start_sysrepo()
-
-                # some incorrect urls
-                queries_404 = [
-                    "noodles"
-                    "/versions/1"
-                    "/"
+    misc_files = ["tmp/sample_file"]
+
+    def setUp(self):
+        # see test_7_response_overlaps
+        self.overlap_pubs = ["versions", "versionsX", "syspub", "Xsyspub"]
+        pubs = ["test1", "test2"]
+        pubs.extend(self.overlap_pubs)
+        pkg5unittest.ApacheDepotTestCase.setUp(self, pubs, start_depots=True)
+
+        # Most tests use a single system-repository instance, "sc",
+        # but some also use an alternative instance, "alt_sc".
+        self.sc = None
+        self.alt_sc = None
+
+        self.default_sc_runtime = os.path.join(
+            self.test_root, "sysrepo_runtime"
+        )
+        # add another level to the tree used to store the alternative
+        # runtime dir, since the sysrepo writes
+        # <runtime>/../sysrepo_httpd.pid, which would clash with the
+        # default instance
+        self.alt_sc_runtime = os.path.sep.join(
+            [self.test_root, "alt_sysrepo_runtime", "alt"]
+        )
+        self.default_sc_conf = os.path.join(
+            self.default_sc_runtime, "sysrepo_httpd.conf"
+        )
+        self.alt_sc_conf = os.path.join(
+            self.alt_sc_runtime, "sysrepo_httpd.conf"
+        )
+        self.default_sc_p5s = os.path.sep.join(
+            [self.default_sc_runtime, "htdocs", "syspub", "0", "index.html"]
+        )
+        self.make_misc_files(self.misc_files)
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.rurl1 = self.dcs[1].get_repo_url()
+        self.durl2 = self.dcs[2].get_depot_url()
+        for dc_num in self.dcs:
+            durl = self.dcs[dc_num].get_depot_url()
+            self.pkgsend_bulk(durl, self.sample_pkg)
+
+    def _start_sysrepo(self, runtime_dir=None, alt=False):
+        """Starts a system repository instance, either using the default
+        or alternative configurations."""
+        if not runtime_dir:
+            runtime_dir = self.default_sc_runtime
+        self.sysrepo_port = self.next_free_port
+        self.next_free_port += 1
+
+        if alt:
+            conf = self.alt_sc_conf
+            runtime_dir = self.alt_sc_runtime
+            self.alt_sc = pkg5unittest.SysrepoController(
+                conf, self.sysrepo_port, runtime_dir, testcase=self
+            )
+            self.register_apache_controller("alt_sysrepo", self.alt_sc)
+            self.alt_sc.start()
+        else:
+            self.sc = pkg5unittest.SysrepoController(
+                self.default_sc_conf,
+                self.sysrepo_port,
+                runtime_dir,
+                testcase=self,
+            )
+            self.register_apache_controller("sysrepo", self.sc)
+            self.sc.start()
+
+    def test_1_substring_proxy(self):
+        """We can proxy publishers that are substrings of each other"""
+        # XXX not implemented yet
+        pass
+
+    def test_2_invalid_proxy(self):
+        """We return an invalid response for urls we don't proxy"""
+        # XXX not implemented yet
+        pass
+
+    def test_3_cache_dir(self):
+        """Our cache_dir value is used"""
+
+        self.image_create(prefix="test1", repourl=self.durl1)
+
+        cache_dir = os.path.join(self.test_root, "t_sysrepo_cache")
+        port = self.next_free_port
+        self.sysrepo(
+            "-R {0} -c {1} -p {2}".format(self.get_img_path(), cache_dir, port)
+        )
+        self._start_sysrepo()
+
+        # 1. grep for the Cache keyword in the httpd.conf
+        self.file_contains(self.default_sc_conf, "CacheEnable disk /")
+        self.file_doesnt_contain(self.default_sc_conf, "CacheEnable mem")
+        self.file_doesnt_contain(self.default_sc_conf, "MCacheSize")
+        self.file_contains(
+            self.default_sc_conf, "CacheRoot {0}".format(cache_dir)
+        )
+
+        # 2. publish a file, then install using the proxy
+        # check that the proxy has written some content into the cache
+        # XXX not implemented yet.
+        self.sc.stop()
+
+        # 3. use urllib to pull the url for the file again, verify
+        # we've got a cache header on the HTTP response
+        # XXX not implemented yet.
+
+        # 4. ensure memory and None settings are written
+        cache_dir = "None"
+        self.sysrepo("-c {0} -p {1}".format(cache_dir, port))
+        self.file_doesnt_contain(self.default_sc_conf, "CacheEnable")
+
+        cache_dir = "memory"
+        self.sysrepo("-c {0} -p {1}".format(cache_dir, port))
+        self.file_doesnt_contain(self.default_sc_conf, "CacheEnable disk")
+        self.file_contains(self.default_sc_conf, "CacheEnable mem")
+        self.file_contains(self.default_sc_conf, "MCacheSize")
+
+    def test_4_logs_dir(self):
+        """Our logs_dir value is used"""
+
+        self.image_create(prefix="test1", repourl=self.durl1)
+
+        logs_dir = os.path.join(self.test_root, "t_sysrepo_logs")
+        port = self.next_free_port
+        self.sysrepo("-l {0} -p {1}".format(logs_dir, port))
+        self._start_sysrepo()
+
+        # 1. grep for the logs dir in the httpd.conf
+        self.file_contains(
+            self.default_sc_conf, 'ErrorLog "{0}/error_log"'.format(logs_dir)
+        )
+        self.file_contains(
+            self.default_sc_conf, 'CustomLog "{0}/access_log"'.format(logs_dir)
+        )
+        # 2. verify our log files exist once the sysrepo has started
+        for name in ["error_log", "access_log"]:
+            os.path.exists(os.path.join(logs_dir, name))
+        self.sc.stop()
+
+    def test_5_port_host(self):
+        """Our port value is used"""
+        self.image_create(prefix="test1", repourl=self.durl1)
+
+        port = self.next_free_port
+        self.sysrepo("-p {0} -h localhost".format(port))
+        self._start_sysrepo()
+        self.file_contains(
+            self.default_sc_conf, "Listen localhost:{0}".format(port)
+        )
+        self.sc.stop()
+
+    def test_6_permissions(self):
+        """Our permissions are correct on all generated files"""
+
+        # 1. check the permissions
+        # XXX not implemented yet.
+        pass
+
+    def test_7_response_overlaps(self):
+        """We can proxy publishers that are == or substrings of our
+        known responses"""
+
+        self.image_create(prefix="test1", repourl=self.durl1)
+
+        overlap_dcs = []
+        # identify the interesting repos, those that we've configured
+        # using publisher prefixes that match our responses
+        for dc_num in [
+            num
+            for num in self.dcs
+            if (
+                self.dcs[num].get_property("publisher", "prefix")
+                in self.overlap_pubs
+            )
+        ]:
+            dc = self.dcs[dc_num]
+            name = dc.get_property("publisher", "prefix")
+            overlap_dcs.append(dc)
+            # we need to use -R here since it doesn't get added
+            # automatically by self.pkg() because we've got
+            # "versions" as one of the CLI args (it being an
+            # overlapping publisher name)
+            self.pkg(
+                "-R {img} set-publisher -g {url} {pub}".format(
+                    img=self.get_img_path(), url=dc.get_repo_url(), pub=name
+                )
+            )
+
+        # Start a system repo based on the configuration above
+        self.sysrepo("")
+        self._start_sysrepo()
+
+        # attempt to create images using the sysrepo
+        for dc in overlap_dcs:
+            pub = dc.get_property("publisher", "prefix")
+            hash = hashlib.sha1(
+                misc.force_bytes("file://" + dc.get_repodir().rstrip("/"))
+            ).hexdigest()
+            url = "http://localhost:{port}/{pub}/{hash}/".format(
+                port=self.sysrepo_port, hash=hash, pub=pub
+            )
+            self.set_img_path(os.path.join(self.test_root, "sysrepo_image"))
+            self.pkg_image_create(prefix=pub, repourl=url)
+            self.pkg("-R {0} install sample".format(self.get_img_path()))
+
+        self.sc.stop()
+
+    def test_8_file_publisher(self):
+        """A proxied file publisher works as a normal file publisher,
+        including package archives"""
+        #
+        # The standard system publisher client code does not use the
+        # "publisher/0" response, so we need this test to exercise that.
+
+        self.image_create(prefix="test1", repourl=self.durl1)
+
+        # create a version of this url with a symlink, to ensure we
+        # can follow links in urls
+        urlresult = urlparse(self.rurl1)
+        symlink_path = os.path.join(self.test_root, "repo_symlink")
+        os.symlink(urlresult.path, symlink_path)
+        symlinked_url = "file://{0}".format(symlink_path)
+
+        # create a p5p archive
+        p5p_path = os.path.join(
+            self.test_root, "test_8_file_publisher_archive.p5p"
+        )
+        p5p_url = "file://{0}".format(p5p_path)
+        self.pkgrecv(
+            server_url=self.durl1, command="-a -d {0} sample".format(p5p_path)
+        )
+
+        for file_url in [self.rurl1, symlinked_url, p5p_url]:
+            self.image_create(prefix="test1", repourl=self.durl1)
+            self.pkg("set-publisher -g {0} test1".format(file_url))
+            self.sysrepo("")
+            self._start_sysrepo()
+
+            hash = hashlib.sha1(
+                misc.force_bytes(file_url.rstrip("/"))
+            ).hexdigest()
+            url = "http://localhost:{port}/test1/{hash}/".format(
+                port=self.sysrepo_port, hash=hash
+            )
+            self.pkg_image_create(prefix="test1", repourl=url)
+            self.pkg("install sample")
+            self.pkg("contents -rm sample")
+            # the sysrepo doesn't support search ops for file repos
+            self.pkg("search -r sample", exit=1)
+            self.sc.stop()
+
+    def test_9_unsupported_publishers(self):
+        """Ensure we fail when asked to proxy < v4 file repos"""
+
+        v3_repo_root = os.path.join(self.test_root, "sysrepo_test_9")
+        os.mkdir(v3_repo_root)
+        v3_repo_path = os.path.join(v3_repo_root, "repo")
+
+        self.pkgrepo("create --version 3 {0}".format(v3_repo_path))
+        self.pkgrepo("-s {0} set publisher/prefix=foo".format(v3_repo_path))
+        for path in [v3_repo_path]:
+            self.image_create(repourl="file://{0}".format(path))
+            self.sysrepo("-R {0}".format(self.img_path()), exit=1)
+
+    def test_10_missing_file_repo(self):
+        """Ensure we print the right error message in the face of
+        a missing repository."""
+        repo_path = os.path.join(self.test_root, "test_10_missing_repo")
+        self.pkgrepo("create {0}".format(repo_path))
+        self.pkgrecv(
+            server_url=self.durl1, command="-d {0} sample".format(repo_path)
+        )
+        self.pkgrepo("-s {0} set publisher/prefix=foo".format(repo_path))
+        self.pkgrepo("-s {0} rebuild".format(repo_path))
+        self.image_create(repourl="file://{0}".format(repo_path))
+        shutil.rmtree(repo_path)
+        ret, output, err = self.sysrepo(
+            "-R {0}".format(self.img_path()), out=True, stderr=True, exit=1
+        )
+        # restore our image before going any further
+        self.assertTrue(
+            "does not exist" in err,
+            "unable to find expected "
+            "error message in stderr: {0}".format(err),
+        )
+
+    def test_11_proxy_args(self):
+        """Ensure we write configuration to tell Apache to use a remote
+        proxy when proxying requests when using -w or -W"""
+        self.image_create(prefix="test1", repourl=self.durl1)
+
+        for arg, directives in [
+            ("-w http://foo", ["ProxyRemote http http://foo"]),
+            ("-W http://foo", ["ProxyRemote https http://foo"]),
+            (
+                "-w http://foo -W http://foo",
+                ["ProxyRemote http http://foo", "ProxyRemote https http://foo"],
+            ),
+        ]:
+            self.sysrepo(arg)
+            for d in directives:
+                self.file_contains(self.default_sc_conf, d)
+
+    def test_12_cache_dir_permissions(self):
+        """Our cache_dir permissions and ownership are verified"""
+
+        exp_uid = portable.get_user_by_name(SYSREPO_USER, None, False)
+        self.image_create(prefix="test1", repourl=self.durl1)
+
+        cache_dir = os.path.join(self.test_root, "t_sysrepo_cache")
+        # first verify that the user running the test has permissions
+        try:
+            os.mkdir(cache_dir)
+            os.chown(cache_dir, exp_uid, 1)
+            os.rmdir(cache_dir)
+        except OSError as e:
+            if e.errno == errno.EPERM:
+                raise pkg5unittest.TestSkippedException(
+                    "User running test does not have "
+                    "permissions to chown to uid {0}".format(exp_uid)
+                )
+            raise
+
+        # Run sysrepo to create cache directory
+        port = self.next_free_port
+        self.sysrepo(
+            "-R {0} -c {1} -p {2}".format(self.get_img_path(), cache_dir, port)
+        )
+
+        self._start_sysrepo()
+        self.sc.stop()
+
+        # Remove cache directory
+        os.rmdir(cache_dir)
+
+        # Again run sysrepo and then verify permissions
+        cache_dir = os.path.join(self.test_root, "t_sysrepo_cache")
+        port = self.next_free_port
+        self.sysrepo(
+            "-R {0} -c {1} -p {2}".format(self.get_img_path(), cache_dir, port)
+        )
+        self._start_sysrepo()
+
+        # Wait for service to come online. Try for 30 seconds.
+        count = 0
+        while count < 10:
+            time.sleep(3)
+            count = count + 1
+            if os.access(cache_dir, os.F_OK):
+                break
+
+        # Verify cache directory exists.
+        self.assertTrue(os.access(cache_dir, os.F_OK))
+
+        filemode = stat.S_IMODE(os.stat(cache_dir).st_mode)
+        self.assertEqualDiff(0o755, filemode)
+        uid = os.stat(cache_dir)[4]
+        exp_uid = portable.get_user_by_name(SYSREPO_USER, None, False)
+        self.assertEqualDiff(exp_uid, uid)
+
+        self.sc.stop()
+
+    def test_13_changing_p5p(self):
+        """Ensure that when a p5p file changes from beneath us, or
+        disappears, the system repository and any pkg(7) clients
+        react correctly."""
+
+        # create a p5p archive
+        p5p_path = os.path.join(
+            self.test_root, "test_12_changing_p5p_archive.p5p"
+        )
+        p5p_url = "file://{0}".format(p5p_path)
+        self.pkgrecv(
+            server_url=self.durl1, command="-a -d {0} sample".format(p5p_path)
+        )
+
+        # configure an image from which to generate a sysrepo config
+        self.image_create(prefix="test1", repourl=self.durl1)
+        self.pkg("set-publisher -g {0} test1".format(p5p_url))
+        self.sysrepo("")
+        self._start_sysrepo()
+
+        # create an image which uses the system publisher
+        hash = hashlib.sha1(misc.force_bytes(p5p_url.rstrip("/"))).hexdigest()
+        url = "http://localhost:{port}/test1/{hash}/".format(
+            port=self.sysrepo_port, hash=hash
+        )
+
+        self.debug("using {0} as repo url".format(url))
+        self.pkg_image_create(prefix="test1", repourl=url)
+        self.pkg("install sample")
+
+        # modify the p5p file - publish a new package and an
+        # update of the existing package, then recreate the p5p file.
+        self.pkgsend_bulk(self.durl1, self.new_pkg)
+        self.pkgsend_bulk(self.durl1, self.sample_pkg)
+        os.unlink(p5p_path)
+        self.pkgrecv(
+            server_url=self.durl1,
+            command="-a -d {0} sample new".format(p5p_path),
+        )
+
+        # ensure we can install our new packages through the system
+        # publisher url
+        self.pkg("install new")
+        self.pkg("publisher")
+
+        # remove the p5p file, which should still allow us to uninstall
+        renamed_p5p_path = p5p_path + ".renamed"
+        os.rename(p5p_path, renamed_p5p_path)
+        self.pkg("uninstall new")
+
+        # ensure we can't install the packages or perform operations
+        # that require the p5p file to be present
+        self.pkg("install new", exit=1)
+        self.pkg("contents -rm new", exit=1)
+
+        # replace the p5p file, and ensure the client can install again
+        os.rename(renamed_p5p_path, p5p_path)
+        self.pkg("install new")
+        self.pkg("contents -rm new")
+
+        self.sc.stop()
+
+    def test_14_bad_input(self):
+        """Tests the system repository with some bad input: wrong
+        paths, unicode in urls, and some very long urls to ensure
+        the responses are as expected."""
+        # create a p5p archive
+        p5p_path = os.path.join(self.test_root, "test_13_bad_input.p5p")
+        p5p_url = "file://{0}".format(p5p_path)
+        self.pkgrecv(
+            server_url=self.durl1, command="-a -d {0} sample".format(p5p_path)
+        )
+        p5p_hash = hashlib.sha1(
+            misc.force_bytes(p5p_url.rstrip("/"))
+        ).hexdigest()
+        file_url = self.dcs[2].get_repo_url()
+        file_hash = hashlib.sha1(
+            misc.force_bytes(file_url.rstrip("/"))
+        ).hexdigest()
+
+        # configure an image from which to generate a sysrepo config
+        self.image_create(prefix="test1", repourl=self.durl1)
+
+        self.pkg("set-publisher -p {0}".format(file_url))
+        self.pkg("set-publisher -g {0} test1".format(p5p_url))
+        self.sysrepo("")
+        self._start_sysrepo()
+
+        # some incorrect urls
+        queries_404 = ["noodles" "/versions/1" "/"]
+
+        # a place to store some long urls
+        queries_414 = []
+
+        # add urls and some unicode.  We test a file repository,
+        # which makes sure Apache can deal with the URLs appropriately,
+        # as well as a p5p repository, exercising our mod_wsgi app.
+        for hsh, pub in [("test1", p5p_hash), ("test2", file_hash)]:
+            queries_404.append("{0}/{1}/catalog/1/ΰŇﺇ⊂⏣⊅ℇ".format(pub, hsh))
+            queries_404.append(
+                "{0}/{1}/catalog/1/{2}".format(pub, hsh, "f" + "u" * 1000)
+            )
+            queries_414.append(
+                "{0}/{1}/catalog/1/{2}".format(pub, hsh, "f" * 900000 + "u")
+            )
+
+        def test_response(part, code):
+            """Given a url substring and an expected error code,
+            check that the system repository returns that code
+            for a url constructed from that part."""
+            url = "http://localhost:{0}/{1}".format(self.sysrepo_port, part)
+            try:
+                resp = urlopen(url, None, None)
+            except HTTPError as e:
+                if e.code != code:
+                    self.assertTrue(
+                        False, "url {0} returned: {1}".format(url, e)
+                    )
+
+        for url_part in queries_404:
+            # Python 3's http.client try to encode the url with
+            # ASCII encoding, so non-ASCII characters should have
+            # been eliminated earlier.
+            test_response(misc.force_bytes(url_part), 404)
+        for url_part in queries_414:
+            test_response(url_part, 414)
+        self.sc.stop()
+
+    def test_15_unicode(self):
+        """Tests the system repository with some unicode paths to p5p
+        files."""
+        # Running test on remote machines, the locale is usally "C",
+        # then the file system encoding will be "ascii" and os.mkdir
+        # will fail with some unicode characters in Python 3 because
+        # os.mkdir uses the file system encoding. We don't have a way
+        # to set the file system encoding in Python, so we just skip.
+        if six.PY3 and sys.getfilesystemencoding() == "ascii":
+            return
+        unicode_str = "ΰŇﺇ⊂⏣⊅ℇ"
+        unicode_dir = os.path.join(self.test_root, unicode_str)
+        os.mkdir(unicode_dir)
+
+        # create paths to p5p files, using unicode dir or file names
+        p5p_unicode_dir = os.path.join(unicode_dir, "test_14_unicode.p5p")
+        p5p_unicode_file = os.path.join(
+            self.test_root, "{0}.p5p".format(unicode_str)
+        )
+
+        for p5p_path in [p5p_unicode_dir, p5p_unicode_file]:
+            p5p_url = "file://{0}".format(p5p_path)
+            self.pkgrecv(
+                server_url=self.durl1,
+                command="-a -d {0} sample".format(p5p_path),
+            )
+            p5p_hash = hashlib.sha1(
+                misc.force_bytes(p5p_url.rstrip("/"))
+            ).hexdigest()
+
+            self.image_create()
+            self.pkg("set-publisher -p {0}".format(p5p_url))
+
+            self.sysrepo("")
+            self._start_sysrepo()
+
+            # ensure we can get content from the p5p file
+            for path in [
+                "catalog/1/catalog.attrs",
+                "catalog/1/catalog.base.C",
+                "file/1/f5da841b7c3601be5629bb8aef928437de7d534e",
+            ]:
+                url = "http://localhost:{0}/test1/{1}/{2}".format(
+                    self.sysrepo_port, p5p_hash, path
+                )
+                resp = urlopen(url, None, None)
+                self.debug(resp.readlines())
+
+            self.sc.stop()
+
+    def test_16_config_cache(self):
+        """We can load/store our configuration cache correctly."""
+
+        cache_path = "var/cache/pkg/sysrepo_pub_cache.dat"
+        full_cache_path = os.path.join(self.get_img_path(), cache_path)
+        sysrepo_runtime_dir = os.path.join(self.test_root, "sysrepo_runtime")
+        sysrepo_conf = os.path.join(sysrepo_runtime_dir, "sysrepo_httpd.conf")
+
+        # a basic check that the config cache looks sane
+        self.image_create(prefix="test1", repourl=self.durl1)
+        self.file_doesnt_exist(cache_path)
+
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Unable to load config" not in self.output)
+        self.assertTrue("Unable to store config" not in self.output)
+        self.file_exists(cache_path)
+        self.file_contains(sysrepo_conf, self.durl1)
+        self.file_remove(cache_path)
+
+        # install some sample packages to our image, just to ensure
+        # that sysrepo doesn't mind, and cache creation works
+        self.pkg("install sample")
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Unable to load config" not in self.output)
+        self.assertTrue("Unable to store config" not in self.output)
+        self.file_exists(cache_path)
+        self.file_contains(sysrepo_conf, self.durl1)
+        self.file_remove(cache_path)
+
+        # ensure we get warnings when we can't load/store the config
+        os.makedirs(full_cache_path)
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Unable to load config" in self.errout)
+        self.assertTrue("Unable to store config" in self.errout)
+        self.file_contains(sysrepo_conf, self.durl1)
+        os.rmdir(full_cache_path)
+
+        # ensure we get warnings when loading a corrupt cache
+        self.sysrepo("")
+        self.file_append(cache_path, "noodles")
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Invalid config cache file at" in self.errout)
+        # we should have overwritten the corrupt cache, so check again
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Invalid config cache file at" not in self.errout)
+        self.file_contains(cache_path, self.durl1)
+        self.file_remove(cache_path)
+
+        # ensure that despite valid JSON in the cache, we still
+        # treat it as corrupt, and clobber the old cache
+        rubbish = {"food preference": "I like noodles."}
+        other = ["nonsense here"]
+        with open(full_cache_path, "w") as cache_file:
+            json.dump((rubbish, other), cache_file)
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Invalid config cache at" in self.errout)
+        self.file_doesnt_contain(cache_path, "noodles")
+        self.file_contains(cache_path, self.durl1)
+        self.file_contains(sysrepo_conf, self.durl1)
+
+        # ensure we get a new cache on publisher modification
+        self.file_doesnt_contain(cache_path, self.rurl1)
+        self.pkg("set-publisher -g {0} test1".format(self.rurl1))
+        self.file_doesnt_exist(cache_path)
+        self.sysrepo("")
+        self.file_contains(cache_path, [self.rurl1, self.durl1])
+
+        # record the last modification time of the cache
+        st_cache = os.lstat(full_cache_path)
+        mtime = st_cache.st_mtime
+
+        # no image modification, so no new config file
+        self.sysrepo("")
+        self.assertTrue(
+            mtime == os.lstat(full_cache_path).st_mtime,
+            "Changed mtime of cache despite no image config change",
+        )
+
+        # load the config from the cache, remove a URI then save
+        # it - despite being well-formed, the cache doesn't contain the
+        # same configuration as the image, simulating an older version
+        # of pkg(1) having changed publisher configuration.
+        with open(full_cache_path, "r") as cache_file:
+            uri_pub_map, no_uri_pubs = json.load(cache_file)
+
+        with open(full_cache_path, "w") as cache_file:
+            del uri_pub_map[self.durl1]
+            json.dump((uri_pub_map, no_uri_pubs), cache_file, indent=4)
+        # make sure we've definitely broken it
+        self.file_doesnt_contain(cache_path, self.durl1)
+
+        # we expect an 'invalid config cache' message, and a new cache
+        # written with correct content.
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Invalid config cache at" in self.errout)
+        self.file_contains(cache_path, self.durl1)
+        self.sysrepo("")
+
+        # rename the cache file, then symlink it
+        os.rename(full_cache_path, full_cache_path + ".new")
+        os.symlink(full_cache_path + ".new", full_cache_path)
+        self.pkg("set-publisher -G {0} test1".format(self.durl1))
+        # by running pkg set-publisher, we should have removed the
+        # symlink
+        self.file_doesnt_exist(cache_path)
+        # replace the symlink
+        os.symlink(full_cache_path + ".new", full_cache_path)
+
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Unable to load config" in self.errout)
+        self.assertTrue("not a regular file" in self.errout)
+        self.assertTrue("Unable to store config" in self.errout)
+        # our symlinked cache should be untouched, and still contain
+        # rurl1, despite it being absent from our actual configuration.
+        self.file_contains(cache_path, self.durl1)
+        self.file_doesnt_contain(sysrepo_conf, self.durl1)
+
+        # check that an image with no publishers works
+        self.pkg("unset-publisher test1")
+        self.pkg("publisher", out=True, stderr=True)
+        self.file_doesnt_exist(cache_path)
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Unable to load config" not in self.output)
+        self.assertTrue("Unable to store config" not in self.output)
+        self.file_doesnt_contain(sysrepo_conf, self.durl1)
+
+        # check that removing packages doesn't impact the cache
+        self.pkg("uninstall sample")
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Unable to load config" not in self.output)
+        self.assertTrue("Unable to store config" not in self.output)
+        self.file_remove(cache_path)
+        self.sysrepo("", stderr=True)
+        self.assertTrue("Unable to load config" not in self.output)
+        self.assertTrue("Unable to store config" not in self.output)
+
+        # check that when a file-repository is inaccessible, the
+        # sysrepo_httpd.conf generated from the cache remains identical
+        self.pkg("set-publisher -g {0} test1".format(self.rurl1))
+        self.sysrepo("", stderr=True)
+        saved_sysrepo_conf = os.path.join(
+            self.test_root, "test_16_config_cache_sysrepo_httpd.conf.old"
+        )
+        os.rename(sysrepo_conf, saved_sysrepo_conf)
+        # Make the file repository inaccessible (simulating eg. an
+        # offline NFS server)
+        # We should still be able to generate the same sysrepo config
+        # using our cached information.
+        repo_dir = self.dcs[1].get_repodir()
+        os.rename(repo_dir, repo_dir + ".new")
+        try:
+            self.sysrepo("", stderr=True)
+            self.assertTrue(
+                misc.get_data_digest(sysrepo_conf, hash_func=DEFAULT_HASH_FUNC)[
+                    0
                 ]
+                == misc.get_data_digest(
+                    saved_sysrepo_conf, hash_func=DEFAULT_HASH_FUNC
+                )[0],
+                "system repository configuration changed " "unexpectedly.",
+            )
+        finally:
+            os.rename(repo_dir + ".new", repo_dir)
 
-                # a place to store some long urls
-                queries_414 = []
+    def test_17_proxy(self):
+        """Ensure that the system repository can proxy access
+        through another proxy."""
 
-                # add urls and some unicode.  We test a file repository,
-                # which makes sure Apache can deal with the URLs appropriately,
-                # as well as a p5p repository, exercising our mod_wsgi app.
-                for hsh, pub in [("test1", p5p_hash), ("test2", file_hash)]:
-                        queries_404.append("{0}/{1}/catalog/1/ΰŇﺇ⊂⏣⊅ℇ".format(
-                            pub, hsh))
-                        queries_404.append("{0}/{1}/catalog/1/{2}".format(
-                            pub, hsh, "f" + "u" * 1000))
-                        queries_414.append("{0}/{1}/catalog/1/{2}".format(
-                            pub, hsh, "f" * 900000 + "u"))
+        self.image_create(prefix="test1", repourl=self.durl1)
 
-                def test_response(part, code):
-                        """Given a url substring and an expected error code,
-                        check that the system repository returns that code
-                        for a url constructed from that part."""
-                        url = "http://localhost:{0}/{1}".format(
-                            self.sysrepo_port, part)
-                        try:
-                                resp =  urlopen(url, None, None)
-                        except HTTPError as e:
-                                if e.code != code:
-                                        self.assertTrue(False,
-                                            "url {0} returned: {1}".format(url, e))
+        # Start a system repository instance that we will use as a
+        # convenient way to configure a simple http proxy
+        alt_logs_dir = os.path.join(self.test_root, "alt_sysrepo_logs")
+        self.sysrepo("-r {0} -l {1}".format(self.alt_sc_runtime, alt_logs_dir))
+        self._start_sysrepo(alt=True)
+        alt_sc_port = self.sysrepo_port
 
-                for url_part in queries_404:
-                        # Python 3's http.client try to encode the url with
-                        # ASCII encoding, so non-ASCII characters should have
-                        # been eliminated earlier.
-                        test_response(misc.force_bytes(url_part), 404)
-                for url_part in queries_414:
-                        test_response(url_part, 414)
-                self.sc.stop()
+        # Start another system-repository using the 1st sysrepo instance
+        # as a http proxy
+        def_logs_dir = os.path.join(self.test_root, "def_sysrepo_logs")
+        self.sysrepo(
+            "-r {0} -w http://localhost:{1} -l {2}".format(
+                self.default_sc_runtime, alt_sc_port, def_logs_dir
+            )
+        )
+        self._start_sysrepo()
 
-        def test_15_unicode(self):
-                """Tests the system repository with some unicode paths to p5p
-                files."""
-                # Running test on remote machines, the locale is usally "C",
-                # then the file system encoding will be "ascii" and os.mkdir
-                # will fail with some unicode characters in Python 3 because
-                # os.mkdir uses the file system encoding. We don't have a way
-                # to set the file system encoding in Python, so we just skip.
-                if six.PY3 and sys.getfilesystemencoding() == "ascii":
-                        return
-                unicode_str = "ΰŇﺇ⊂⏣⊅ℇ"
-                unicode_dir = os.path.join(self.test_root, unicode_str)
-                os.mkdir(unicode_dir)
+        # check the configuration
+        self.file_contains(
+            self.default_sc_conf,
+            "ProxyRemote http http://localhost:{0}".format(alt_sc_port),
+        )
 
-                # create paths to p5p files, using unicode dir or file names
-                p5p_unicode_dir = os.path.join(unicode_dir,
-                    "test_14_unicode.p5p")
-                p5p_unicode_file = os.path.join(self.test_root,
-                    "{0}.p5p".format(unicode_str))
+        # configure an image to use the system repository
+        saved_sysrepo_env = os.environ.get("PKG_SYSREPO_URL")
+        os.environ["PKG_SYSREPO_URL"] = "http://localhost:{0}".format(
+            self.sysrepo_port
+        )
+        self.image_create()
+        self.pkg("set-property use-system-repo True")
+        self.pkg("refresh")
+        self.pkg("list -af")
 
-                for p5p_path in [p5p_unicode_dir, p5p_unicode_file]:
-                        p5p_url = "file://{0}".format(p5p_path)
-                        self.pkgrecv(server_url=self.durl1,
-                            command="-a -d {0} sample".format(p5p_path))
-                        p5p_hash = hashlib.sha1(misc.force_bytes(
-                            p5p_url.rstrip("/"))).hexdigest()
+        # Both logs should show access requests for our catalogs, but
+        # only the system-repository this image is configured to use
+        # should show access requests for /versions/0 (the versions
+        # response of  the system repository itself, not the pkg.depot
+        # we're pointing at via the http proxy)
+        alt_log = os.path.join(alt_logs_dir, "access_log")
+        def_log = os.path.join(def_logs_dir, "access_log")
 
-                        self.image_create()
-                        self.pkg("set-publisher -p {0}".format(p5p_url))
+        self.file_contains(alt_log, "catalog/1/catalog.attrs")
+        self.file_contains(def_log, "catalog/1/catalog.attrs")
+        self.file_doesnt_contain(alt_log, "GET /versions/0/")
+        self.file_contains(def_log, "GET /versions/0/")
 
-                        self.sysrepo("")
-                        self._start_sysrepo()
+        # When we disable the proxy, pkg operations through the system
+        # repository are affected
+        self.alt_sc.stop()
 
-                        # ensure we can get content from the p5p file
-                        for path in ["catalog/1/catalog.attrs",
-                            "catalog/1/catalog.base.C",
-                            "file/1/f5da841b7c3601be5629bb8aef928437de7d534e"]:
-                                url = "http://localhost:{0}/test1/{1}/{2}".format(
-                                    self.sysrepo_port, p5p_hash, path)
-                                resp = urlopen(url, None, None)
-                                self.debug(resp.readlines())
+        self.image_create()
+        self.pkg("set-property use-system-repo True")
+        ret, out, err = self.pkg("refresh", exit=1, stderr=True, out=True)
+        self.assertTrue("503 reason: Service Unavailable" in err)
 
-                        self.sc.stop()
+        # By enabling the remote proxy, the system-repository should
+        # now be able to proxy this resource.
+        self.alt_sc.start()
 
-        def test_16_config_cache(self):
-                """We can load/store our configuration cache correctly."""
+        self.pkg("set-property use-system-repo True")
+        self.pkg("refresh")
 
-                cache_path = "var/cache/pkg/sysrepo_pub_cache.dat"
-                full_cache_path = os.path.join(self.get_img_path(), cache_path)
-                sysrepo_runtime_dir = os.path.join(self.test_root,
-                    "sysrepo_runtime")
-                sysrepo_conf = os.path.join(sysrepo_runtime_dir,
-                    "sysrepo_httpd.conf")
+        self.alt_sc.stop()
+        self.sc.stop()
 
-                # a basic check that the config cache looks sane
-                self.image_create(prefix="test1", repourl=self.durl1)
-                self.file_doesnt_exist(cache_path)
+        if saved_sysrepo_env:
+            os.environ["PKG_SYSREPO_URL"] = saved_sysrepo_env
+        else:
+            del os.environ["PKG_SYSREPO_URL"]
 
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Unable to load config" not in self.output)
-                self.assertTrue("Unable to store config" not in self.output)
-                self.file_exists(cache_path)
-                self.file_contains(sysrepo_conf, self.durl1)
-                self.file_remove(cache_path)
+    def test_17_granular_proxies(self):
+        """Ensure that when an image has --proxy values set, that we add
+        appropriate ProxyRemote directives for those publishers."""
 
-                # install some sample packages to our image, just to ensure
-                # that sysrepo doesn't mind, and cache creation works
-                self.pkg("install sample")
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Unable to load config" not in self.output)
-                self.assertTrue("Unable to store config" not in self.output)
-                self.file_exists(cache_path)
-                self.file_contains(sysrepo_conf, self.durl1)
-                self.file_remove(cache_path)
+        # We use --no-refresh because our proxy doesn't exist
+        self.image_create()
+        self.pkg(
+            "set-publisher --no-refresh -g {0} "
+            "--proxy http://foobar test1".format(self.durl1)
+        )
 
-                # ensure we get warnings when we can't load/store the config
-                os.makedirs(full_cache_path)
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Unable to load config" in self.errout)
-                self.assertTrue("Unable to store config" in self.errout)
-                self.file_contains(sysrepo_conf, self.durl1)
-                os.rmdir(full_cache_path)
+        self.sysrepo("")
+        self.file_contains(
+            self.default_sc_conf,
+            "ProxyRemote {0} http://foobar".format(self.durl1),
+        )
 
-                # ensure we get warnings when loading a corrupt cache
-                self.sysrepo("")
-                self.file_append(cache_path, "noodles")
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Invalid config cache file at" in self.errout)
-                # we should have overwritten the corrupt cache, so check again
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Invalid config cache file at" not in self.errout)
-                self.file_contains(cache_path, self.durl1)
-                self.file_remove(cache_path)
+        self.pkg(
+            "set-publisher --no-refresh -g {0} "
+            "--proxy http://bar test2".format(self.durl2)
+        )
 
-                # ensure that despite valid JSON in the cache, we still
-                # treat it as corrupt, and clobber the old cache
-                rubbish = {"food preference": "I like noodles."}
-                other = ["nonsense here"]
-                with open(full_cache_path, "w") as cache_file:
-                        json.dump((rubbish, other), cache_file)
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Invalid config cache at" in self.errout)
-                self.file_doesnt_contain(cache_path, "noodles")
-                self.file_contains(cache_path, self.durl1)
-                self.file_contains(sysrepo_conf, self.durl1)
+        self.sysrepo("")
+        self.file_contains(
+            self.default_sc_conf,
+            "ProxyRemote {0} http://foobar".format(self.durl1),
+        )
+        self.file_contains(
+            self.default_sc_conf,
+            "ProxyRemote {0} http://bar".format(self.durl2),
+        )
 
-                # ensure we get a new cache on publisher modification
-                self.file_doesnt_contain(cache_path, self.rurl1)
-                self.pkg("set-publisher -g {0} test1".format(self.rurl1))
-                self.file_doesnt_exist(cache_path)
-                self.sysrepo("")
-                self.file_contains(cache_path, [self.rurl1, self.durl1])
-
-                # record the last modification time of the cache
-                st_cache = os.lstat(full_cache_path)
-                mtime = st_cache.st_mtime
-
-                # no image modification, so no new config file
-                self.sysrepo("")
-                self.assertTrue(mtime == os.lstat(full_cache_path).st_mtime,
-                    "Changed mtime of cache despite no image config change")
-
-                # load the config from the cache, remove a URI then save
-                # it - despite being well-formed, the cache doesn't contain the
-                # same configuration as the image, simulating an older version
-                # of pkg(1) having changed publisher configuration.
-                with open(full_cache_path, "r") as cache_file:
-                        uri_pub_map, no_uri_pubs = json.load(cache_file)
-
-                with open(full_cache_path, "w") as cache_file:
-                        del uri_pub_map[self.durl1]
-                        json.dump((uri_pub_map, no_uri_pubs), cache_file,
-                            indent=4)
-                # make sure we've definitely broken it
-                self.file_doesnt_contain(cache_path, self.durl1)
-
-                # we expect an 'invalid config cache' message, and a new cache
-                # written with correct content.
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Invalid config cache at" in self.errout)
-                self.file_contains(cache_path, self.durl1)
-                self.sysrepo("")
-
-                # rename the cache file, then symlink it
-                os.rename(full_cache_path, full_cache_path + ".new")
-                os.symlink(full_cache_path + ".new", full_cache_path)
-                self.pkg("set-publisher -G {0} test1".format(self.durl1))
-                # by running pkg set-publisher, we should have removed the
-                # symlink
-                self.file_doesnt_exist(cache_path)
-                # replace the symlink
-                os.symlink(full_cache_path + ".new", full_cache_path)
-
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Unable to load config" in self.errout)
-                self.assertTrue("not a regular file" in self.errout)
-                self.assertTrue("Unable to store config" in self.errout)
-                # our symlinked cache should be untouched, and still contain
-                # rurl1, despite it being absent from our actual configuration.
-                self.file_contains(cache_path, self.durl1)
-                self.file_doesnt_contain(sysrepo_conf, self.durl1)
-
-                # check that an image with no publishers works
-                self.pkg("unset-publisher test1")
-                self.pkg("publisher", out=True, stderr=True)
-                self.file_doesnt_exist(cache_path)
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Unable to load config" not in self.output)
-                self.assertTrue("Unable to store config" not in self.output)
-                self.file_doesnt_contain(sysrepo_conf, self.durl1)
-
-                # check that removing packages doesn't impact the cache
-                self.pkg("uninstall sample")
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Unable to load config" not in self.output)
-                self.assertTrue("Unable to store config" not in self.output)
-                self.file_remove(cache_path)
-                self.sysrepo("", stderr=True)
-                self.assertTrue("Unable to load config" not in self.output)
-                self.assertTrue("Unable to store config" not in self.output)
-
-                # check that when a file-repository is inaccessible, the
-                # sysrepo_httpd.conf generated from the cache remains identical
-                self.pkg("set-publisher -g {0} test1".format(self.rurl1))
-                self.sysrepo("", stderr=True)
-                saved_sysrepo_conf = os.path.join(self.test_root,
-                    "test_16_config_cache_sysrepo_httpd.conf.old")
-                os.rename(sysrepo_conf, saved_sysrepo_conf)
-                # Make the file repository inaccessible (simulating eg. an
-                # offline NFS server)
-                # We should still be able to generate the same sysrepo config
-                # using our cached information.
-                repo_dir = self.dcs[1].get_repodir()
-                os.rename(repo_dir, repo_dir + ".new")
-                try:
-                        self.sysrepo("", stderr=True)
-                        self.assertTrue(misc.get_data_digest(sysrepo_conf,
-                            hash_func=DEFAULT_HASH_FUNC)[0] ==
-                            misc.get_data_digest(saved_sysrepo_conf,
-                            hash_func=DEFAULT_HASH_FUNC)[0],
-                            "system repository configuration changed "
-                            "unexpectedly.")
-                finally:
-                        os.rename(repo_dir + ".new", repo_dir)
-
-        def test_17_proxy(self):
-                """ Ensure that the system repository can proxy access
-                through another proxy."""
-
-                self.image_create(prefix="test1", repourl=self.durl1)
-
-                # Start a system repository instance that we will use as a
-                # convenient way to configure a simple http proxy
-                alt_logs_dir = os.path.join(self.test_root, "alt_sysrepo_logs")
-                self.sysrepo("-r {0} -l {1}".format(self.alt_sc_runtime,
-                    alt_logs_dir))
-                self._start_sysrepo(alt=True)
-                alt_sc_port = self.sysrepo_port
-
-                # Start another system-repository using the 1st sysrepo instance
-                # as a http proxy
-                def_logs_dir = os.path.join(self.test_root, "def_sysrepo_logs")
-                self.sysrepo("-r {0} -w http://localhost:{1} -l {2}".format(
-                    self.default_sc_runtime, alt_sc_port, def_logs_dir))
-                self._start_sysrepo()
-
-                # check the configuration
-                self.file_contains(self.default_sc_conf,
-                    "ProxyRemote http http://localhost:{0}".format(alt_sc_port))
-
-                # configure an image to use the system repository
-                saved_sysrepo_env = os.environ.get("PKG_SYSREPO_URL")
-                os.environ["PKG_SYSREPO_URL"] = "http://localhost:{0}".format(
-                    self.sysrepo_port)
-                self.image_create()
-                self.pkg("set-property use-system-repo True")
-                self.pkg("refresh")
-                self.pkg("list -af")
-
-                # Both logs should show access requests for our catalogs, but
-                # only the system-repository this image is configured to use
-                # should show access requests for /versions/0 (the versions
-                # response of  the system repository itself, not the pkg.depot
-                # we're pointing at via the http proxy)
-                alt_log = os.path.join(alt_logs_dir, "access_log")
-                def_log = os.path.join(def_logs_dir, "access_log")
-
-                self.file_contains(alt_log, "catalog/1/catalog.attrs")
-                self.file_contains(def_log, "catalog/1/catalog.attrs")
-                self.file_doesnt_contain(alt_log, "GET /versions/0/")
-                self.file_contains(def_log, "GET /versions/0/")
-
-                # When we disable the proxy, pkg operations through the system
-                # repository are affected
-                self.alt_sc.stop()
-
-                self.image_create()
-                self.pkg("set-property use-system-repo True")
-                ret, out, err = self.pkg("refresh", exit=1, stderr=True,
-                    out=True)
-                self.assertTrue("503 reason: Service Unavailable" in err)
-
-                # By enabling the remote proxy, the system-repository should
-                # now be able to proxy this resource.
-                self.alt_sc.start()
-
-                self.pkg("set-property use-system-repo True")
-                self.pkg("refresh")
-
-                self.alt_sc.stop()
-                self.sc.stop()
-
-                if saved_sysrepo_env:
-                        os.environ["PKG_SYSREPO_URL"] = saved_sysrepo_env
-                else:
-                        del os.environ["PKG_SYSREPO_URL"]
-
-        def test_17_granular_proxies(self):
-                """Ensure that when an image has --proxy values set, that we add
-                appropriate ProxyRemote directives for those publishers."""
-
-                # We use --no-refresh because our proxy doesn't exist
-                self.image_create()
-                self.pkg("set-publisher --no-refresh -g {0} "
-                    "--proxy http://foobar test1".format(self.durl1))
-
-                self.sysrepo("")
-                self.file_contains(self.default_sc_conf,
-                    "ProxyRemote {0} http://foobar".format(self.durl1))
-
-                self.pkg("set-publisher --no-refresh -g {0} "
-                    "--proxy http://bar test2".format(self.durl2))
-
-                self.sysrepo("")
-                self.file_contains(self.default_sc_conf,
-                    "ProxyRemote {0} http://foobar".format(self.durl1))
-                self.file_contains(self.default_sc_conf,
-                    "ProxyRemote {0} http://bar".format(self.durl2))
-
-                # Ensure we fail when an image is set with a proxy we don't
-                # support.
-                self.image_create()
-                self.pkg("set-publisher --no-refresh -g {0} "
-                    "--proxy http://user:password@foobar test1".format(self.durl1))
-                self.sysrepo("", exit=1)
+        # Ensure we fail when an image is set with a proxy we don't
+        # support.
+        self.image_create()
+        self.pkg(
+            "set-publisher --no-refresh -g {0} "
+            "--proxy http://user:password@foobar test1".format(self.durl1)
+        )
+        self.sysrepo("", exit=1)
 
 
 class TestP5pWsgi(pkg5unittest.SingleDepotTestCase):
-        """A class to directly exercise the p4p mod_wsgi application outside
-        of Apache and the system repository itself.
+    """A class to directly exercise the p4p mod_wsgi application outside
+    of Apache and the system repository itself.
 
-        By calling the web application directly, we have a little more
-        flexibility when writing tests.  Other system-repository tests will
-        exercise much of the mod_wsgi configuration and framework, but these
-        tests will be easier to debug and faster to run.
+    By calling the web application directly, we have a little more
+    flexibility when writing tests.  Other system-repository tests will
+    exercise much of the mod_wsgi configuration and framework, but these
+    tests will be easier to debug and faster to run.
 
-        Note that since we call the web application directly, the web app can
-        intentionally emit some tracebacks to stderr, which will be seen by
-        the test framework."""
+    Note that since we call the web application directly, the web app can
+    intentionally emit some tracebacks to stderr, which will be seen by
+    the test framework."""
 
-        persistent_setup = False
+    persistent_setup = False
 
-        sample_pkg = """
+    sample_pkg = """
             open sample@1.0,5.11-0
             add file tmp/sample_file mode=0444 owner=root group=bin path=/usr/bin/sample
             close"""
 
-        new_pkg = """
+    new_pkg = """
             open new@1.0,5.11-0
             add file tmp/sample_file mode=0444 owner=root group=bin path=/usr/bin/new
             close"""
 
-        misc_files = { "tmp/sample_file": "carrots" }
+    misc_files = {"tmp/sample_file": "carrots"}
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
-                self.image_create()
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self, start_depot=True)
+        self.image_create()
 
-                # we have to dynamically load the mod_wsgi webapp, since it
-                # lives outside our normal search path
-                mod_name = "sysrepo_p5p"
-                src_name = "{0}.py".format(mod_name)
-                spec = importlib.util.spec_from_file_location(mod_name,
-                    os.path.join(self.sysrepo_template_dir, src_name))
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-                self.sysrepo_p5p = module
+        # we have to dynamically load the mod_wsgi webapp, since it
+        # lives outside our normal search path
+        mod_name = "sysrepo_p5p"
+        src_name = "{0}.py".format(mod_name)
+        spec = importlib.util.spec_from_file_location(
+            mod_name, os.path.join(self.sysrepo_template_dir, src_name)
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        self.sysrepo_p5p = module
 
-                # now create a simple p5p file that we can use in our tests
-                self.make_misc_files(self.misc_files)
-                self.pkgsend_bulk(self.durl, self.sample_pkg)
-                self.pkgsend_bulk(self.durl, self.new_pkg)
+        # now create a simple p5p file that we can use in our tests
+        self.make_misc_files(self.misc_files)
+        self.pkgsend_bulk(self.durl, self.sample_pkg)
+        self.pkgsend_bulk(self.durl, self.new_pkg)
 
-                self.p5p_path = os.path.join(self.test_root,
-                    "mod_wsgi_archive.p5p")
+        self.p5p_path = os.path.join(self.test_root, "mod_wsgi_archive.p5p")
 
-                self.pkgrecv(server_url=self.durl,
-                    command="-a -d {0} sample new".format(self.p5p_path))
+        self.pkgrecv(
+            server_url=self.durl,
+            command="-a -d {0} sample new".format(self.p5p_path),
+        )
+        self.http_status = ""
+
+    def test_queries(self):
+        """Ensure that we return proper HTTP response codes."""
+
+        def start_response(status, response_headers, exc_info=None):
+            """A dummy response function, used to capture output"""
+            self.http_status = status
+
+        environ = {}
+        hsh = "123abcdef"
+        environ["SYSREPO_RUNTIME_DIR"] = self.test_root
+        environ["PKG5_TEST_ENV"] = "True"
+        environ[hsh] = self.p5p_path
+
+        def test_query_responses(queries, code, expect_content=False):
+            """Given a list of queries, and a string we expect to
+            appear in each response, invoke the wsgi application
+            with each query and check response codes.  Also check
+            that content was returned or not."""
+
+            for query in queries:
+                seen_content = False
+                environ["QUERY_STRING"] = unquote(query)
                 self.http_status = ""
 
-        def test_queries(self):
-                """Ensure that we return proper HTTP response codes."""
+                try:
+                    # The WSGI application writes to stdout
+                    # so to reduce console noise, we
+                    # redirect that temporarily.
+                    saved_stdout = sys.stdout
+                    sys.stdout = six.StringIO()
+                    for item in self.sysrepo_p5p.application(
+                        environ, start_response
+                    ):
+                        seen_content = item
+                finally:
+                    sys.stdout = saved_stdout
 
-                def start_response(status, response_headers, exc_info=None):
-                        """A dummy response function, used to capture output"""
-                        self.http_status = status
+                self.assertTrue(
+                    code in self.http_status,
+                    "Query {0} response did not contain {1}: {2}".format(
+                        query, code, self.http_status
+                    ),
+                )
+                if expect_content:
+                    self.assertTrue(
+                        seen_content,
+                        "No content returned for {0}".format(query),
+                    )
+                else:
+                    self.assertFalse(
+                        seen_content, "Unexpected content for {0}".format(query)
+                    )
 
-                environ = {}
-                hsh = "123abcdef"
-                environ["SYSREPO_RUNTIME_DIR"] = self.test_root
-                environ["PKG5_TEST_ENV"] = "True"
-                environ[hsh] = self.p5p_path
+        # the easiest way to get the name of one of the manifests
+        # in the archive is to look for it in the index
+        archive = pkg.p5p.Archive(self.p5p_path)
+        idx = archive.get_index()
+        mf = None
+        for item in idx.keys():
+            if item.startswith("publisher/test/pkg/new/"):
+                mf = item.replace("publisher/test/pkg/new/", "new@")
+        archive.close()
 
-                def test_query_responses(queries, code, expect_content=False):
-                        """Given a list of queries, and a string we expect to
-                        appear in each response, invoke the wsgi application
-                        with each query and check response codes.  Also check
-                        that content was returned or not."""
+        queries_200 = [
+            # valid file, matches the hash of the content in misc_files
+            "pub=test&hash={0}&path=file/1/f890d49474e943dc07a766c21d2bf35d6e527e89".format(
+                hsh
+            ),
+            # valid catalog parts
+            "pub=test&hash={0}&path=catalog/1/catalog.attrs".format(hsh),
+            "pub=test&hash={0}&path=catalog/1/catalog.base.C".format(hsh),
+            # valid manifest
+            "pub=test&hash={0}&path=manifest/0/{1}".format(hsh, mf),
+        ]
 
-                        for query in queries:
-                                seen_content = False
-                                environ["QUERY_STRING"] = unquote(query)
-                                self.http_status = ""
+        queries_404 = [
+            # wrong path
+            "pub=test&hash={0}&path=catalog/1/catalog.attrsX".format(hsh),
+            # invalid publisher
+            "pub=WRONG&hash={0}&path=catalog/1/catalog.attrs".format(hsh),
+            # incorrect path
+            "pub=test&hash={0}&path=file/1/12u3yt123123".format(hsh),
+            # incorrect path (where the first path component is unknown)
+            "pub=test&hash={0}&path=carrots/1/12u3yt123123".format(hsh),
+            # incorrect manifest, with an unknown package name
+            "pub=test&hash={0}&path=manifest/0/foo{1}".format(hsh, mf),
+            # incorrect manifest, with an illegal FMRI
+            "pub=test&hash={0}&path=manifest/0/{1}foo".format(hsh, mf),
+        ]
 
-                                try:
-                                        # The WSGI application writes to stdout
-                                        # so to reduce console noise, we
-                                        # redirect that temporarily.
-                                        saved_stdout = sys.stdout
-                                        sys.stdout = six.StringIO()
-                                        for item in self.sysrepo_p5p.application(
-                                            environ, start_response):
-                                                seen_content = item
-                                finally:
-                                        sys.stdout = saved_stdout
+        queries_400 = [
+            # missing publisher (while p5p files can return content
+            # despite no publisher, our mod_wsgi app requires a
+            # publisher)
+            "hash={0}&path=catalog/1/catalog.attrs".format(hsh),
+            # missing path
+            "pub=test&hash={0}".format(hsh),
+            # malformed query
+            "&&???&&&",
+            # no hash key
+            "pub=test&hashX={0}&path=catalog/1/catalog.attrs".format(hsh),
+            # unknown hash value
+            "pub=test&hash=carrots&path=catalog/1/catalog.attrs",
+        ]
 
-                                self.assertTrue(code in self.http_status,
-                                    "Query {0} response did not contain {1}: {2}".format(
-                                    query, code, self.http_status))
-                                if expect_content:
-                                        self.assertTrue(seen_content,
-                                            "No content returned for {0}".format(
-                                            query))
-                                else:
-                                        self.assertFalse(seen_content,
-                                            "Unexpected content for {0}".format(query))
+        test_query_responses(queries_200, "200", expect_content=True)
+        test_query_responses(queries_400, "400")
+        test_query_responses(queries_404, "404")
 
-                # the easiest way to get the name of one of the manifests
-                # in the archive is to look for it in the index
-                archive = pkg.p5p.Archive(self.p5p_path)
-                idx = archive.get_index()
-                mf = None
-                for item in idx.keys():
-                        if item.startswith("publisher/test/pkg/new/"):
-                                mf = item.replace(
-                                    "publisher/test/pkg/new/", "new@")
-                archive.close()
-
-                queries_200 = [
-                    # valid file, matches the hash of the content in misc_files
-                    "pub=test&hash={0}&path=file/1/f890d49474e943dc07a766c21d2bf35d6e527e89".format(hsh),
-                    # valid catalog parts
-                    "pub=test&hash={0}&path=catalog/1/catalog.attrs".format(hsh),
-                    "pub=test&hash={0}&path=catalog/1/catalog.base.C".format(hsh),
-                    # valid manifest
-                    "pub=test&hash={0}&path=manifest/0/{1}".format(hsh, mf)
-                ]
-
-                queries_404 = [
-                    # wrong path
-                    "pub=test&hash={0}&path=catalog/1/catalog.attrsX".format(hsh),
-                    # invalid publisher
-                    "pub=WRONG&hash={0}&path=catalog/1/catalog.attrs".format(hsh),
-                    # incorrect path
-                    "pub=test&hash={0}&path=file/1/12u3yt123123".format(hsh),
-                    # incorrect path (where the first path component is unknown)
-                    "pub=test&hash={0}&path=carrots/1/12u3yt123123".format(hsh),
-                    # incorrect manifest, with an unknown package name
-                    "pub=test&hash={0}&path=manifest/0/foo{1}".format(hsh, mf),
-                    # incorrect manifest, with an illegal FMRI
-                    "pub=test&hash={0}&path=manifest/0/{1}foo".format(hsh, mf)
-                ]
-
-                queries_400 = [
-                    # missing publisher (while p5p files can return content
-                    # despite no publisher, our mod_wsgi app requires a
-                    # publisher)
-                    "hash={0}&path=catalog/1/catalog.attrs".format(hsh),
-                    # missing path
-                    "pub=test&hash={0}".format(hsh),
-                    # malformed query
-                    "&&???&&&",
-                    # no hash key
-                    "pub=test&hashX={0}&path=catalog/1/catalog.attrs".format(hsh),
-                    # unknown hash value
-                    "pub=test&hash=carrots&path=catalog/1/catalog.attrs"
-                ]
-
-                test_query_responses(queries_200, "200", expect_content=True)
-                test_query_responses(queries_400, "400")
-                test_query_responses(queries_404, "404")
-
-                # generally we try to shield users from internal server errors,
-                # however in the case of a missing p5p file on the server
-                # this seems like the right thing to do, rather than to return
-                # a 404.
-                # The end result for pkg client with 500 or a 404 code is the
-                # same, but the former will result in more useful information
-                # in the system-repository error_log.
-                os.unlink(self.p5p_path)
-                queries_500 = queries_200 + queries_404
-                test_query_responses(queries_500, "500")
-                # despite the missing p5p file, we should still get 400 errors
-                test_query_responses(queries_400, "400")
+        # generally we try to shield users from internal server errors,
+        # however in the case of a missing p5p file on the server
+        # this seems like the right thing to do, rather than to return
+        # a 404.
+        # The end result for pkg client with 500 or a 404 code is the
+        # same, but the former will result in more useful information
+        # in the system-repository error_log.
+        os.unlink(self.p5p_path)
+        queries_500 = queries_200 + queries_404
+        test_query_responses(queries_500, "500")
+        # despite the missing p5p file, we should still get 400 errors
+        test_query_responses(queries_400, "400")
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_util_merge.py
+++ b/src/tests/cli/t_util_merge.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -42,33 +43,34 @@ import zlib
 from six.moves.urllib.parse import urlparse
 from six.moves.urllib.request import url2pathname
 
-class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
-        # Cleanup after every test.
-        persistent_setup = False
 
-        scheme10 = """
+class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
+    # Cleanup after every test.
+    persistent_setup = False
+
+    scheme10 = """
             open pkg:/scheme@1.0,5.11-0
             close
         """
 
-        tree10 = """
+    tree10 = """
             open tree@1.0,5.11-0
             close
         """
 
-        amber10 = """
+    amber10 = """
             open amber@1.0,5.11-0
             add depend fmri=pkg:/tree@1.0 type=require
             close
         """
 
-        amber20 = """
+    amber20 = """
             open amber@2.0,5.11-0
             add depend fmri=pkg:/tree@1.0 type=require
             close
         """
 
-        bronze10 = """
+    bronze10 = """
             open bronze@1.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/usr
             add dir mode=0755 owner=root group=bin path=/usr/bin
@@ -83,7 +85,7 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        bronze20 = """
+    bronze20 = """
             open bronze@2.0,5.11-0
             add dir mode=0755 owner=root group=bin path=/etc
             add dir mode=0755 owner=root group=bin path=/lib
@@ -99,126 +101,150 @@ class TestUtilMerge(pkg5unittest.ManyDepotTestCase):
             close
         """
 
-        misc_files = [ "tmp/bronzeA1",  "tmp/bronzeA2",
-                    "tmp/bronze1", "tmp/bronze2",
-                    "tmp/copyright2", "tmp/copyright3",
-                    "tmp/libc.so.1", "tmp/sh"]
+    misc_files = [
+        "tmp/bronzeA1",
+        "tmp/bronzeA2",
+        "tmp/bronze1",
+        "tmp/bronze2",
+        "tmp/copyright2",
+        "tmp/copyright3",
+        "tmp/libc.so.1",
+        "tmp/sh",
+    ]
 
-        def setUp(self):
-                """ Start two depots.
-                    depot 1 gets foo and moo, depot 2 gets foo and bar
-                    depot1 is mapped to publisher test1 (preferred)
-                    depot2 is mapped to publisher test2 """
+    def setUp(self):
+        """Start two depots.
+        depot 1 gets foo and moo, depot 2 gets foo and bar
+        depot1 is mapped to publisher test1 (preferred)
+        depot2 is mapped to publisher test2"""
 
-                # This test suite needs an actual depot.
-                pkg5unittest.ManyDepotTestCase.setUp(self, ["os.org", "os.org"],
-                    start_depots=True)
-                self.make_misc_files(self.misc_files)
+        # This test suite needs an actual depot.
+        pkg5unittest.ManyDepotTestCase.setUp(
+            self, ["os.org", "os.org"], start_depots=True
+        )
+        self.make_misc_files(self.misc_files)
 
-                # Publish a set of packages to one repository.
-                self.dpath1 = self.dcs[1].get_repodir()
-                self.durl1 = self.dcs[1].get_depot_url()
-                self.published = self.pkgsend_bulk(self.durl1, (self.amber10,
-                    self.amber20, self.bronze10, self.bronze20, self.tree10,
-                    self.scheme10))
+        # Publish a set of packages to one repository.
+        self.dpath1 = self.dcs[1].get_repodir()
+        self.durl1 = self.dcs[1].get_depot_url()
+        self.published = self.pkgsend_bulk(
+            self.durl1,
+            (
+                self.amber10,
+                self.amber20,
+                self.bronze10,
+                self.bronze20,
+                self.tree10,
+                self.scheme10,
+            ),
+        )
 
-                # Ensure timestamps of all successive publications are greater.
-                time.sleep(1)
+        # Ensure timestamps of all successive publications are greater.
+        time.sleep(1)
 
-                # Publish the same set to another repository (minus the tree
-                # and scheme packages).
-                self.dpath2 = self.dcs[2].get_repodir()
-                self.durl2 = self.dcs[2].get_depot_url()
-                self.published += self.pkgsend_bulk(self.durl2, (self.amber10,
-                    self.amber20, self.bronze10, self.bronze20))
+        # Publish the same set to another repository (minus the tree
+        # and scheme packages).
+        self.dpath2 = self.dcs[2].get_repodir()
+        self.durl2 = self.dcs[2].get_depot_url()
+        self.published += self.pkgsend_bulk(
+            self.durl2,
+            (self.amber10, self.amber20, self.bronze10, self.bronze20),
+        )
 
-                self.merge_dir = tempfile.mkdtemp(dir=self.test_root)
-                repo.repository_create(self.merge_dir)
+        self.merge_dir = tempfile.mkdtemp(dir=self.test_root)
+        repo.repository_create(self.merge_dir)
 
-        @staticmethod
-        def get_repo(uri):
-                parts = urlparse(uri, "file", allow_fragments=0)
-                path = url2pathname(parts[2])
+    @staticmethod
+    def get_repo(uri):
+        parts = urlparse(uri, "file", allow_fragments=0)
+        path = url2pathname(parts[2])
 
-                try:
-                        return repo.Repository(root=path)
-                except cfg.ConfigError as e:
-                        raise repo.RepositoryError(_("The specified "
-                            "repository's configuration data is not "
-                            "valid:\n{0}").format(e))
+        try:
+            return repo.Repository(root=path)
+        except cfg.ConfigError as e:
+            raise repo.RepositoryError(
+                _(
+                    "The specified "
+                    "repository's configuration data is not "
+                    "valid:\n{0}"
+                ).format(e)
+            )
 
-        def test_0_merge(self):
-                """Verify that merge functionality works as expected."""
+    def test_0_merge(self):
+        """Verify that merge functionality works as expected."""
 
-                pkg_names = set()
-                flist = []
-                for p in self.published:
-                        f = fmri.PkgFmri(p)
-                        pkg_names.add(f.pkg_name)
-                        flist.append(f)
+        pkg_names = set()
+        flist = []
+        for p in self.published:
+            f = fmri.PkgFmri(p)
+            pkg_names.add(f.pkg_name)
+            flist.append(f)
 
-                self.merge([
-                    "-d {0}".format(self.merge_dir),
-                    "-s arch=sparc,{0}".format(self.durl1),
-                    "-s arch=i386,{0}".format(self.durl2),
-                    " ".join(pkg_names),
-                ])
+        self.merge(
+            [
+                "-d {0}".format(self.merge_dir),
+                "-s arch=sparc,{0}".format(self.durl1),
+                "-s arch=i386,{0}".format(self.durl2),
+                " ".join(pkg_names),
+            ]
+        )
 
-                # Only get the newest FMRIs for each package.
-                flist.sort()
-                nlist = {}
-                for f in reversed(flist):
-                        if f.pkg_name in nlist:
-                                continue
-                        nlist[f.pkg_name] = f
-                nlist = nlist.values()
+        # Only get the newest FMRIs for each package.
+        flist.sort()
+        nlist = {}
+        for f in reversed(flist):
+            if f.pkg_name in nlist:
+                continue
+            nlist[f.pkg_name] = f
+        nlist = nlist.values()
 
-                def get_expected(f):
-                        exp_lines = ["set name=pkg.fmri value={0}".format(f)]
-                        for dc in self.dcs.values():
-                                repo = dc.get_repo()
-                                mpath = repo.manifest(f)
-                                if not os.path.exists(mpath):
-                                        # Not in this repository, check next.
-                                        continue
+        def get_expected(f):
+            exp_lines = ["set name=pkg.fmri value={0}".format(f)]
+            for dc in self.dcs.values():
+                repo = dc.get_repo()
+                mpath = repo.manifest(f)
+                if not os.path.exists(mpath):
+                    # Not in this repository, check next.
+                    continue
 
-                                m = open(mpath, "r")
-                                for l in m:
-                                        if l.find("name=pkg.fmri") > -1:
-                                                continue
-                                        if l.find("name=variant") > -1:
-                                                continue
-                                        if not l.strip():
-                                                continue
-                                        exp_lines.append(l.strip())
-                                m.close()
+                m = open(mpath, "r")
+                for l in m:
+                    if l.find("name=pkg.fmri") > -1:
+                        continue
+                    if l.find("name=variant") > -1:
+                        continue
+                    if not l.strip():
+                        continue
+                    exp_lines.append(l.strip())
+                m.close()
 
-                        if f.pkg_name in ("tree", "scheme"):
-                                # These packages are only published for sparc.
-                                exp_lines.append("set name=variant.arch value=sparc")
-                        else:
-                                # Everything else is published for all variants.
-                                exp_lines.append("set name=variant.arch value=sparc value=i386")
-                        return "\n".join(sorted(exp_lines))
+            if f.pkg_name in ("tree", "scheme"):
+                # These packages are only published for sparc.
+                exp_lines.append("set name=variant.arch value=sparc")
+            else:
+                # Everything else is published for all variants.
+                exp_lines.append("set name=variant.arch value=sparc value=i386")
+            return "\n".join(sorted(exp_lines))
 
-                # Now load the manifest file for each package and verify that
-                # the merged manifest matches expectations.
-                for f in nlist:
-                        mpath = os.path.join(self.merge_dir, "publisher",
-                            "os.org", "pkg", f.get_dir_path())
+        # Now load the manifest file for each package and verify that
+        # the merged manifest matches expectations.
+        for f in nlist:
+            mpath = os.path.join(
+                self.merge_dir, "publisher", "os.org", "pkg", f.get_dir_path()
+            )
 
-                        m = open(mpath, "r")
-                        returned = "".join(sorted(l for l in m))
-                        returned = returned.strip()
-                        m.close()
+            m = open(mpath, "r")
+            returned = "".join(sorted(l for l in m))
+            returned = returned.strip()
+            m.close()
 
-                        # Generate expected and verify.
-                        expected = get_expected(f)
-                        self.assertEqualDiff(expected, returned)
+            # Generate expected and verify.
+            expected = get_expected(f)
+            self.assertEqualDiff(expected, returned)
 
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_util_update_file_layout.py
+++ b/src/tests/cli/t_util_update_file_layout.py
@@ -25,8 +25,9 @@
 #
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import errno
@@ -42,79 +43,80 @@ import pkg.file_layout.layout as layout
 
 path_to_pub_util = "../util/publish"
 
+
 class TestFileManager(pkg5unittest.CliTestCase):
+    def setUp(self):
+        pkg5unittest.CliTestCase.setUp(self)
+        self.base_dir = os.path.join(self.test_root, "fm")
+        os.mkdir(self.base_dir)
 
-        def setUp(self):
-                pkg5unittest.CliTestCase.setUp(self)
-                self.base_dir = os.path.join(self.test_root, "fm")
-                os.mkdir(self.base_dir)
+    @staticmethod
+    def old_hash(s):
+        return os.path.join(s[0:2], s[2:8], s)
 
-        @staticmethod
-        def old_hash(s):
-                return os.path.join(s[0:2], s[2:8], s)
+    def touch_old_file(self, s):
+        p = os.path.join(self.base_dir, self.old_hash(s))
+        if not os.path.exists(os.path.dirname(p)):
+            os.makedirs(os.path.dirname(p))
+        fh = open(p, "w")
+        fh.write(s)
+        fh.close()
+        return p
 
-        def touch_old_file(self, s):
-                p = os.path.join(self.base_dir, self.old_hash(s))
-                if not os.path.exists(os.path.dirname(p)):
-                        os.makedirs(os.path.dirname(p))
-                fh = open(p, "w")
-                fh.write(s)
-                fh.close()
-                return p
+    def update_file_layout(self, dir_path, exit=0):
+        """Run the script from the util directory."""
+        py_version = ".".join(platform.python_version_tuple()[:2])
+        cmdline = "python{2} {0}/update_file_layout.py {1}".format(
+            path_to_pub_util, dir_path, py_version
+        )
+        self.cmdline_run(cmdline, exit=exit)
 
-        def update_file_layout(self, dir_path, exit=0):
-                """ Run the script from the util directory."""
-                py_version = '.'.join(platform.python_version_tuple()[:2])
-                cmdline = "python{2} {0}/update_file_layout.py {1}".format(
-                    path_to_pub_util, dir_path, py_version)
-                self.cmdline_run(cmdline, exit=exit)
+    def test_1(self):
+        """Test that pkg.migrate correctly moves files from the old
+        layout to the new layout correctly."""
 
-        def test_1(self):
-                """ Test that pkg.migrate correctly moves files from the old
-                layout to the new layout correctly."""
+        hashes = [
+            "2be802388acdf0e17c1ea0855be5d29715290d01",
+            "0338a1ee2a98c7c9cedbff6e5a4a93a88ba05b72",
+            "ff9ea25633b995eeb4c0ae896b9f7586f8effceb",
+            "ff9ea25633b995eeb4c0ae896b9f7586f8effcec",
+            "a24ba602e0f43bac4eb6223de54a003c63d9b8d9",
+        ]
 
-                hashes = ["2be802388acdf0e17c1ea0855be5d29715290d01",
-                    "0338a1ee2a98c7c9cedbff6e5a4a93a88ba05b72",
-                    "ff9ea25633b995eeb4c0ae896b9f7586f8effceb",
-                    "ff9ea25633b995eeb4c0ae896b9f7586f8effcec",
-                    "a24ba602e0f43bac4eb6223de54a003c63d9b8d9"
-                ]
+        old_paths = [self.touch_old_file(h) for h in hashes]
 
-                old_paths = [self.touch_old_file(h) for h in hashes]
+        self.update_file_layout(self.base_dir)
+        for p in old_paths:
+            if os.path.exists(p):
+                raise RuntimeError("{0} should not exist".format(p))
+            if os.path.exists(os.path.dirname(p)):
+                raise RuntimeError("directory {0} should not " "exist")
+        l = layout.get_preferred_layout()
+        for h in hashes:
+            if not os.path.exists(os.path.join(self.base_dir, l.lookup(h))):
+                raise RuntimeError("file for {0} is missing".format(h))
 
-                self.update_file_layout(self.base_dir)
-                for p in old_paths:
-                        if os.path.exists(p):
-                                raise RuntimeError("{0} should not exist".format(p))
-                        if os.path.exists(os.path.dirname(p)):
-                                raise RuntimeError("directory {0} should not "
-                                    "exist")
-                l = layout.get_preferred_layout()
-                for h in hashes:
-                        if not os.path.exists(os.path.join(self.base_dir,
-                            l.lookup(h))):
-                                raise RuntimeError("file for {0} is missing".format(h))
+        self.update_file_layout(self.base_dir)
+        for h in hashes:
+            if not os.path.exists(os.path.join(self.base_dir, l.lookup(h))):
+                raise RuntimeError("file for {0} is missing".format(h))
 
-                self.update_file_layout(self.base_dir)
-                for h in hashes:
-                        if not os.path.exists(os.path.join(self.base_dir,
-                            l.lookup(h))):
-                                raise RuntimeError("file for {0} is missing".format(h))
+    def test_opts(self):
+        """Test command options work correctly and that migrating an
+        empty directory performs as expected."""
 
-        def test_opts(self):
-                """Test command options work correctly and that migrating an
-                empty directory performs as expected."""
+        self.update_file_layout("", exit=2)
+        self.update_file_layout(
+            "{0} {1}".format(self.base_dir, self.base_dir), exit=2
+        )
+        self.update_file_layout("/foo/doesntexist/", exit=2)
 
-                self.update_file_layout("", exit=2)
-                self.update_file_layout("{0} {1}".format(
-                    self.base_dir, self.base_dir), exit=2)
-                self.update_file_layout("/foo/doesntexist/", exit=2)
+        empty_dir = tempfile.mkdtemp(dir=self.base_dir)
+        self.update_file_layout(empty_dir)
 
-                empty_dir = tempfile.mkdtemp(dir=self.base_dir)
-                self.update_file_layout(empty_dir)
-                 
+
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/t_variants.py
+++ b/src/tests/cli/t_variants.py
@@ -23,8 +23,9 @@
 # Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
 
 from . import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -32,8 +33,7 @@ import unittest
 
 
 class TestPkgVariants(pkg5unittest.SingleDepotTestCase):
-
-        bronze10 = """
+    bronze10 = """
         open bronze@1.0,5.11-0
         add set name=variant.arch value=sparc value=i386 value=zos
         add dir mode=0755 owner=root group=bin path=/etc
@@ -52,14 +52,14 @@ class TestPkgVariants(pkg5unittest.SingleDepotTestCase):
         add file tmp/bronze_zone/true mode=0555 owner=root group=bin path=etc/isdebug variant.debug.kernel=true
         close"""
 
-        silver10 = """
+    silver10 = """
         open silver@1.0,5.11-0
         add set name=variant.arch value=i386
         add dir mode=0755 owner=root group=bin path=/etc
         add file tmp/bronze_i386/etc/motd mode=0555 owner=root group=bin path=etc/motd variant.arch=i386
         close"""
 
-        mumble10 = """
+    mumble10 = """
         open mumble-true@1.0,5.11-0
         add set name=variant.mumble value=true
         close
@@ -67,7 +67,7 @@ class TestPkgVariants(pkg5unittest.SingleDepotTestCase):
         add set name=variant.mumble value=false
         close"""
 
-        mumblefratz = """
+    mumblefratz = """
         open mumblefratz@1.0,5.11-0
         add set name=variant.mumble value=true
         close
@@ -75,131 +75,131 @@ class TestPkgVariants(pkg5unittest.SingleDepotTestCase):
         add set name=variant.mumble value=false
         close"""
 
-        i386_pkg = """
+    i386_pkg = """
         open i386_pkg@1.0,5.11-0
         add set name=variant.arch value=i386
         close"""
 
-        i386_pkg_indirect = """
+    i386_pkg_indirect = """
         open i386_pkg_indirect@1.0,5.11-0
         add depend type=require fmri=pkg:/i386_pkg@1.0,5.11-0
         close"""
 
-        misc_files = [
-            "tmp/bronze_sparc/etc/motd",
-            "tmp/bronze_i386/etc/motd",
-            "tmp/bronze_zos/etc/motd",
-            "tmp/bronze_zone/etc/nonglobal_motd",
-            "tmp/bronze_zone/etc/global_motd",
-            "tmp/bronze_zone/etc/i386_nonglobal",
-            "tmp/bronze_zone/etc/sparc_nonglobal",
-            "tmp/bronze_zone/etc/zos_nonglobal",
-            "tmp/bronze_zone/etc/i386_global",
-            "tmp/bronze_zone/etc/sparc_global",
-            "tmp/bronze_zone/etc/zos_global",
-            "tmp/bronze_zone/false",
-            "tmp/bronze_zone/true",
-        ]
+    misc_files = [
+        "tmp/bronze_sparc/etc/motd",
+        "tmp/bronze_i386/etc/motd",
+        "tmp/bronze_zos/etc/motd",
+        "tmp/bronze_zone/etc/nonglobal_motd",
+        "tmp/bronze_zone/etc/global_motd",
+        "tmp/bronze_zone/etc/i386_nonglobal",
+        "tmp/bronze_zone/etc/sparc_nonglobal",
+        "tmp/bronze_zone/etc/zos_nonglobal",
+        "tmp/bronze_zone/etc/i386_global",
+        "tmp/bronze_zone/etc/sparc_global",
+        "tmp/bronze_zone/etc/zos_global",
+        "tmp/bronze_zone/false",
+        "tmp/bronze_zone/true",
+    ]
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                self.pkgsend_bulk(self.rurl, self.mumble10)
-                self.pkgsend_bulk(self.rurl, self.mumblefratz)
-                self.make_misc_files(self.misc_files)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        self.pkgsend_bulk(self.rurl, self.mumble10)
+        self.pkgsend_bulk(self.rurl, self.mumblefratz)
+        self.make_misc_files(self.misc_files)
 
-        def test_variant_1(self):
-                self.__test_common("no-change", "no-change")
+    def test_variant_1(self):
+        self.__test_common("no-change", "no-change")
 
-        def test_variant_2_matching(self):
-                """Verify that install matching allows '*' even when some
-                packages are not supported by image variant."""
+    def test_variant_2_matching(self):
+        """Verify that install matching allows '*' even when some
+        packages are not supported by image variant."""
 
-                self.image_create(self.rurl,
-                    variants={ "variant.mumble": "false" })
-                self.pkg("install \\*")
-                self.pkg("info mumble-true", exit=1)
-                self.pkg("info mumble-false")
+        self.image_create(self.rurl, variants={"variant.mumble": "false"})
+        self.pkg("install \\*")
+        self.pkg("info mumble-true", exit=1)
+        self.pkg("info mumble-false")
 
-        def test_variant_3_latest(self):
-                """Verify that install matching for '@latest' matches the
-                newest version allowed by image variants."""
+    def test_variant_3_latest(self):
+        """Verify that install matching for '@latest' matches the
+        newest version allowed by image variants."""
 
-                self.image_create(self.rurl,
-                    variants={ "variant.mumble": "true" })
-                self.pkg("install mumblefratz@latest")
-                self.pkg("info mumblefratz@1.0")
-                self.pkg("info mumblefratz@2.0", exit=1)
+        self.image_create(self.rurl, variants={"variant.mumble": "true"})
+        self.pkg("install mumblefratz@latest")
+        self.pkg("info mumblefratz@1.0")
+        self.pkg("info mumblefratz@2.0", exit=1)
 
-                self.image_create(self.rurl,
-                    variants={ "variant.mumble": "false" })
-                self.pkg("install mumblefratz@latest")
-                self.pkg("info mumblefratz@1.0", exit=1)
-                self.pkg("info mumblefratz@2.0")
+        self.image_create(self.rurl, variants={"variant.mumble": "false"})
+        self.pkg("install mumblefratz@latest")
+        self.pkg("info mumblefratz@1.0", exit=1)
+        self.pkg("info mumblefratz@2.0")
 
-        def test_variant_4_indirect(self):
-                """Verify that we can't indirectly install a package tagged
-                with a variant that doesn't match ours."""
+    def test_variant_4_indirect(self):
+        """Verify that we can't indirectly install a package tagged
+        with a variant that doesn't match ours."""
 
-                self.pkgsend_bulk(self.rurl, self.i386_pkg)
-                self.pkgsend_bulk(self.rurl, self.i386_pkg_indirect)
+        self.pkgsend_bulk(self.rurl, self.i386_pkg)
+        self.pkgsend_bulk(self.rurl, self.i386_pkg_indirect)
 
-                self.image_create(self.rurl,
-                    variants={ "variant.arch": "sparc" })
+        self.image_create(self.rurl, variants={"variant.arch": "sparc"})
 
-                # we should not be able to install an i386 package directly
-                self.pkg("install i386_pkg", exit=1)
+        # we should not be able to install an i386 package directly
+        self.pkg("install i386_pkg", exit=1)
 
-                # we should not be able to install an i386 package indirectly
-                self.pkg("install i386_pkg_indirect", exit=1)
+        # we should not be able to install an i386 package indirectly
+        self.pkg("install i386_pkg_indirect", exit=1)
 
+    def test_old_zones_pkgs(self):
+        self.__test_common("variant.opensolaris.zone", "opensolaris.zone")
 
-        def test_old_zones_pkgs(self):
-                self.__test_common("variant.opensolaris.zone",
-                    "opensolaris.zone")
+    def __test_common(self, orig, new):
+        self.pkgsend_bulk(self.rurl, self.bronze10.replace(orig, new))
+        self.pkgsend_bulk(self.rurl, self.silver10.replace(orig, new))
 
-        def __test_common(self, orig, new):
-                self.pkgsend_bulk(self.rurl, self.bronze10.replace(orig, new))
-                self.pkgsend_bulk(self.rurl, self.silver10.replace(orig, new))
+        self.__vtest(self.rurl, "sparc", "global")
+        self.__vtest(self.rurl, "i386", "global")
+        self.__vtest(self.rurl, "zos", "global", "true")
+        self.__vtest(self.rurl, "sparc", "nonglobal", "true")
+        self.__vtest(self.rurl, "i386", "nonglobal", "false")
+        self.__vtest(self.rurl, "zos", "nonglobal", "false")
 
-                self.__vtest(self.rurl, "sparc", "global")
-                self.__vtest(self.rurl, "i386", "global")
-                self.__vtest(self.rurl, "zos", "global", "true")
-                self.__vtest(self.rurl, "sparc", "nonglobal", "true")
-                self.__vtest(self.rurl, "i386", "nonglobal", "false")
-                self.__vtest(self.rurl, "zos", "nonglobal", "false")
+        self.pkg_image_create(
+            self.rurl,
+            additional_args="--variant variant.arch={0}".format("sparc"),
+        )
+        self.pkg("install silver", exit=1)
 
-                self.pkg_image_create(self.rurl,
-                    additional_args="--variant variant.arch={0}".format("sparc"))
-                self.pkg("install silver", exit=1)
+        # Verify that debug variants are implicitly false and shown in
+        # output of 'pkg variant' before any variants are set.
+        self.pkg("variant -H -F tsv debug", exit=1)  # only 'debug.'
+        self.pkg("variant -H -F tsv debug.kernel")
+        self.assertEqual("variant.debug.kernel\tfalse\n", self.output)
 
-                # Verify that debug variants are implicitly false and shown in
-                # output of 'pkg variant' before any variants are set.
-                self.pkg("variant -H -F tsv debug", exit=1) # only 'debug.'
-                self.pkg("variant -H -F tsv debug.kernel")
-                self.assertEqual("variant.debug.kernel\tfalse\n", self.output)
+    def __vtest(self, depot, arch, zone, isdebug=""):
+        """test if install works for spec'd arch"""
 
-        def __vtest(self, depot, arch, zone, isdebug=""):
-                """ test if install works for spec'd arch"""
+        if isdebug:
+            do_isdebug = "--variant variant.debug.kernel={0}".format(isdebug)
+        else:
+            do_isdebug = ""
+            is_debug = "false"
 
-                if isdebug:
-                        do_isdebug = "--variant variant.debug.kernel={0}".format(isdebug)
-                else:
-                        do_isdebug = ""
-                        is_debug = "false"
+        self.pkg_image_create(
+            depot,
+            additional_args="--variant variant.arch={0} --variant variant.opensolaris.zone={1} {2}".format(
+                arch, zone, do_isdebug
+            ),
+        )
+        self.pkg("install bronze")
+        self.pkg("verify")
+        self.file_contains("etc/motd", arch)
+        self.file_contains("etc/zone_motd", zone)
+        self.file_contains("etc/zone_arch", [zone, arch])
+        self.file_contains("etc/isdebug", isdebug)
+        self.image_destroy()
 
-                self.pkg_image_create(depot,
-                    additional_args="--variant variant.arch={0} --variant variant.opensolaris.zone={1} {2}".format(
-                    arch, zone, do_isdebug))
-                self.pkg("install bronze")
-                self.pkg("verify")
-                self.file_contains("etc/motd", arch)
-                self.file_contains("etc/zone_motd", zone)
-                self.file_contains("etc/zone_arch", [zone, arch])
-                self.file_contains("etc/isdebug", isdebug)
-                self.image_destroy()
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/cli/testutils.py
+++ b/src/tests/cli/testutils.py
@@ -29,12 +29,14 @@ import sys
 # Set the path so that modules can be found
 path_to_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if path_to_parent not in sys.path:
-        sys.path.insert(0, path_to_parent)
+    sys.path.insert(0, path_to_parent)
 
 import pkg5testenv
 
+
 def setup_environment(proto):
-        pkg5testenv.setup_environment(proto)
+    pkg5testenv.setup_environment(proto)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/interactive/runprintengine.py
+++ b/src/tests/interactive/runprintengine.py
@@ -36,55 +36,54 @@ import pkg.client.printengine as printengine
 import pkg.misc as misc
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", None)
-        gettext.install("pkg", "/usr/share/locale")
+    misc.setlocale(locale.LC_ALL, "", None)
+    gettext.install("pkg", "/usr/share/locale")
 
-        test_ttymode = test_nottymode = test_logging = False
-        opts, argv = getopt.getopt(sys.argv[1:], "tTl")
-        for (opt, arg) in opts:
-                if opt == '-t':
-                        test_ttymode = True
-                elif opt == '-T':
-                        test_nottymode = True
-                elif opt == '-l':
-                        test_logging = True
-                else:
-                        print("bad option {0}".format(opt), file=sys.stderr)
-                        sys.exit(2)
-
-        if not (test_ttymode or test_nottymode or test_logging):
-                print("must specify one or more of -t, -T or -l",
-                    file=sys.stderr)
-                sys.exit(2)
-
-        if len(argv) == 1:
-                output_file = open(argv[0], "w")
-        elif len(argv) > 1:
-                print("too many arguments", file=sys.stderr)
-                sys.exit(2)
+    test_ttymode = test_nottymode = test_logging = False
+    opts, argv = getopt.getopt(sys.argv[1:], "tTl")
+    for opt, arg in opts:
+        if opt == "-t":
+            test_ttymode = True
+        elif opt == "-T":
+            test_nottymode = True
+        elif opt == "-l":
+            test_logging = True
         else:
-                output_file = sys.stdout
+            print("bad option {0}".format(opt), file=sys.stderr)
+            sys.exit(2)
 
-        try:
-                if test_ttymode:
-                        print("---test_ttymode---", file=output_file)
-                        print(("-" * 60), file=output_file)
-                        printengine.test_posix_printengine(output_file, True)
-                if test_nottymode:
-                        print("---test_nottymode---", file=output_file)
-                        print(("-" * 60), file=output_file)
-                        printengine.test_posix_printengine(output_file, False)
-                if test_logging:
-                        print("---test_logging---", file=output_file)
-                        print(("-" * 60), output_file)
-                        printengine.test_logging_printengine(output_file)
-        except printengine.PrintEngineException as e:
-                print(e, file=sys.stderr)
-                sys.exit(1)
-        except:
-                traceback.print_exc()
-                sys.exit(99)
-        sys.exit(0)
+    if not (test_ttymode or test_nottymode or test_logging):
+        print("must specify one or more of -t, -T or -l", file=sys.stderr)
+        sys.exit(2)
+
+    if len(argv) == 1:
+        output_file = open(argv[0], "w")
+    elif len(argv) > 1:
+        print("too many arguments", file=sys.stderr)
+        sys.exit(2)
+    else:
+        output_file = sys.stdout
+
+    try:
+        if test_ttymode:
+            print("---test_ttymode---", file=output_file)
+            print(("-" * 60), file=output_file)
+            printengine.test_posix_printengine(output_file, True)
+        if test_nottymode:
+            print("---test_nottymode---", file=output_file)
+            print(("-" * 60), file=output_file)
+            printengine.test_posix_printengine(output_file, False)
+        if test_logging:
+            print("---test_logging---", file=output_file)
+            print(("-" * 60), output_file)
+            printengine.test_logging_printengine(output_file)
+    except printengine.PrintEngineException as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
+    except:
+        traceback.print_exc()
+        sys.exit(99)
+    sys.exit(0)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/interactive/runprogress.py
+++ b/src/tests/interactive/runprogress.py
@@ -32,65 +32,69 @@ import locale
 import pkg.client.progress as progress
 import pkg.misc as misc
 
+
 def parse_argv():
-        misc.setlocale(locale.LC_ALL, "", None)
-        gettext.install("pkg", "/usr/share/locale")
+    misc.setlocale(locale.LC_ALL, "", None)
+    gettext.install("pkg", "/usr/share/locale")
 
-        gofast = False
-        opts, argv = getopt.getopt(sys.argv[1:], "f")
-        for (opt, arg) in opts:
-                if opt == '-f':
-                        gofast = True
-                else:
-                        sys.exit(2)
-
-        trackers = {
-            "null": progress.NullProgressTracker,
-            "func": progress.FunctionProgressTracker,
-            "fancy": progress.FancyUNIXProgressTracker,
-            "cli": progress.CommandLineProgressTracker,
-            "dot": progress.DotProgressTracker,
-            "quiet": progress.QuietProgressTracker,
-            "default": progress.FancyUNIXProgressTracker,
-        }
-
-        pts = []
-
-        first = True
-        while first or len(argv) > 0:
-                first = False
-
-                outputdevname = "/dev/stdout"
-                if len(argv) >= 2 and argv[1] != "-":
-                        outputdevname = argv[1]
-
-                tname = "default"
-                if len(argv) >= 1 and argv[0] != "-":
-                        tname = argv[0]
-                outputdev = open(outputdevname, "w")
-
-                # Get a reference to the tracker class
-                try:
-                        trackerclass = trackers[tname]
-                except KeyError:
-                        print("unknown tracker {0}".format(argv[0]))
-                        sys.exit(2)
-
-                try:
-                        st = trackerclass(output_file=outputdev)
-                except TypeError:
-                        st = trackerclass()
-                pts.append(st)
-
-                print("Created {0} progress tracker on {1}".format(
-                    trackerclass.__name__, outputdevname))
-                argv = argv[2:]
-
-        if len(pts) > 1:
-                t = progress.MultiProgressTracker(pts)
+    gofast = False
+    opts, argv = getopt.getopt(sys.argv[1:], "f")
+    for opt, arg in opts:
+        if opt == "-f":
+            gofast = True
         else:
-                t = pts[0]
-        return (t, gofast)
+            sys.exit(2)
+
+    trackers = {
+        "null": progress.NullProgressTracker,
+        "func": progress.FunctionProgressTracker,
+        "fancy": progress.FancyUNIXProgressTracker,
+        "cli": progress.CommandLineProgressTracker,
+        "dot": progress.DotProgressTracker,
+        "quiet": progress.QuietProgressTracker,
+        "default": progress.FancyUNIXProgressTracker,
+    }
+
+    pts = []
+
+    first = True
+    while first or len(argv) > 0:
+        first = False
+
+        outputdevname = "/dev/stdout"
+        if len(argv) >= 2 and argv[1] != "-":
+            outputdevname = argv[1]
+
+        tname = "default"
+        if len(argv) >= 1 and argv[0] != "-":
+            tname = argv[0]
+        outputdev = open(outputdevname, "w")
+
+        # Get a reference to the tracker class
+        try:
+            trackerclass = trackers[tname]
+        except KeyError:
+            print("unknown tracker {0}".format(argv[0]))
+            sys.exit(2)
+
+        try:
+            st = trackerclass(output_file=outputdev)
+        except TypeError:
+            st = trackerclass()
+        pts.append(st)
+
+        print(
+            "Created {0} progress tracker on {1}".format(
+                trackerclass.__name__, outputdevname
+            )
+        )
+        argv = argv[2:]
+
+    if len(pts) > 1:
+        t = progress.MultiProgressTracker(pts)
+    else:
+        t = pts[0]
+    return (t, gofast)
 
 
 #
@@ -106,14 +110,14 @@ def parse_argv():
 # Happy hacking.
 #
 if __name__ == "__main__":
-        try:
-                (_tracker, _gofast) = parse_argv()
-                progress.test_progress_tracker(_tracker, gofast=_gofast)
-        except progress.ProgressTrackerException as e:
-                print("Error: {0}".format(e), file=sys.stderr)
-                sys.exit(1)
-        sys.exit(0)
+    try:
+        (_tracker, _gofast) = parse_argv()
+        progress.test_progress_tracker(_tracker, gofast=_gofast)
+    except progress.ProgressTrackerException as e:
+        print("Error: {0}".format(e), file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/multiplatform.py
+++ b/src/tests/multiplatform.py
@@ -27,6 +27,7 @@ from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 from logilab.common.modutils import get_module_part
 
+
 class MultiPlatformAPIChecker(BaseChecker):
     """
     This class implements a pylint extension which checks for the use
@@ -54,80 +55,145 @@ class MultiPlatformAPIChecker(BaseChecker):
     python library module names within an importing module.  For example,
     if there is an import such as "import os as foo", then a call to
     foo.symlink, this would not be caught with a traditional 'grep'-style
-    checker.  This is caught using this class. """
+    checker.  This is caught using this class."""
 
     #
     # The list of APIs that are not available on all modern, supported
     # platforms.
     #
     VERBOTEN = [
-        'getpass.getuser', 'os.chown', 'os.chroot', 'os.confstr',
-        'os.confstr_names', 'os.ctermid', 'os.fchdir',
-        'os.fdatasync', 'os.fork', 'os.forkpty', 'os.fpathconf',
-        'os.fstatvfs', 'os.ftruncate', 'os.getegid', 'os.geteuid',
-        'os.getgid', 'os.getgroups', 'os.getlogin', 'os.getpgid',
-        'os.getpgrp', 'os.getppid', 'os.getsid', 'os.getuid',
-        'os.isatty', 'os.kill', 'os.killpg', 'os.lchown', 'os.link',
-        'os.linkmknod', 'os.lstat', 'os.major', 'os.makedev',
-        'os.minor', 'os.mkfifo', 'os.nice', 'os.openpty',
-        'os.pathconf', 'os.pathconf_names', 'os.plock',
-        'os.readlink', 'os.setegid', 'os.seteuid', 'os.setgid',
-        'os.setgroups', 'os.setpgid', 'os.setpgrp', 'os.setregid',
-        'os.setreuid', 'os.setsid', 'os.setuid', 'os.spawnl',
-        'os.spawnle', 'os.spawnlp', 'os.spawnlpe', 'os.spawnv',
-        'os.spawnve', 'os.spawnvp', 'os.spawnvpe', 'os.startfile',
-        'os.statvfs', 'os.symlink', 'os.sysconf',
-        'os.sysconf_names', 'os.tcgetpgrp', 'os.tcsetpgrp',
-        'os.ttyname', 'os.uname', 'os.wait3', 'os.wait4',
-        'signal.alarm', 'signal.getsignal', 'signal.signal',
-        'socket.fromfd', 'socket.inet_ntop', 'socket.inet_pton',
-        'socket.socketpair', 'sys.getdlopenflags',
-        'sys.getwindowsversion', 'sys.setdlopenflags',
-        'thread.stack_size', 'time.tzset', 'fcntl.fcntl', 'fcntl.ioctl',
-        'fcntl.flock', 'fcntl.lockf',
+        "getpass.getuser",
+        "os.chown",
+        "os.chroot",
+        "os.confstr",
+        "os.confstr_names",
+        "os.ctermid",
+        "os.fchdir",
+        "os.fdatasync",
+        "os.fork",
+        "os.forkpty",
+        "os.fpathconf",
+        "os.fstatvfs",
+        "os.ftruncate",
+        "os.getegid",
+        "os.geteuid",
+        "os.getgid",
+        "os.getgroups",
+        "os.getlogin",
+        "os.getpgid",
+        "os.getpgrp",
+        "os.getppid",
+        "os.getsid",
+        "os.getuid",
+        "os.isatty",
+        "os.kill",
+        "os.killpg",
+        "os.lchown",
+        "os.link",
+        "os.linkmknod",
+        "os.lstat",
+        "os.major",
+        "os.makedev",
+        "os.minor",
+        "os.mkfifo",
+        "os.nice",
+        "os.openpty",
+        "os.pathconf",
+        "os.pathconf_names",
+        "os.plock",
+        "os.readlink",
+        "os.setegid",
+        "os.seteuid",
+        "os.setgid",
+        "os.setgroups",
+        "os.setpgid",
+        "os.setpgrp",
+        "os.setregid",
+        "os.setreuid",
+        "os.setsid",
+        "os.setuid",
+        "os.spawnl",
+        "os.spawnle",
+        "os.spawnlp",
+        "os.spawnlpe",
+        "os.spawnv",
+        "os.spawnve",
+        "os.spawnvp",
+        "os.spawnvpe",
+        "os.startfile",
+        "os.statvfs",
+        "os.symlink",
+        "os.sysconf",
+        "os.sysconf_names",
+        "os.tcgetpgrp",
+        "os.tcsetpgrp",
+        "os.ttyname",
+        "os.uname",
+        "os.wait3",
+        "os.wait4",
+        "signal.alarm",
+        "signal.getsignal",
+        "signal.signal",
+        "socket.fromfd",
+        "socket.inet_ntop",
+        "socket.inet_pton",
+        "socket.socketpair",
+        "sys.getdlopenflags",
+        "sys.getwindowsversion",
+        "sys.setdlopenflags",
+        "thread.stack_size",
+        "time.tzset",
+        "fcntl.fcntl",
+        "fcntl.ioctl",
+        "fcntl.flock",
+        "fcntl.lockf",
     ]
-    
+
     # The list of package prefixes that are allowed to call VERBOTEN APIs
     ALLOWED = [
-        'pkg.portable',
+        "pkg.portable",
     ]
 
     #
     # Messages to show when checking detects an error
     #
     msgs = {
-    'E0900': ('Imported Non-Portable API (%s)' ,
-              'imported non-portable api',
-              'Used when a non-portable API is imported.'),
-    'E0901': ('Non-portable API used (%s)',
-              'non-portable api',
-              'Used when a non-portable API is called.'),
+        "E0900": (
+            "Imported Non-Portable API (%s)",
+            "imported non-portable api",
+            "Used when a non-portable API is imported.",
+        ),
+        "E0901": (
+            "Non-portable API used (%s)",
+            "non-portable api",
+            "Used when a non-portable API is called.",
+        ),
     }
 
     __implements__ = IAstroidChecker
-    name = 'multiplatform'
+    name = "multiplatform"
     options = ()
 
-    imported_modules={}
-    calledfuncname=[]
-    calledfuncstack=[]
+    imported_modules = {}
+    calledfuncname = []
+    calledfuncstack = []
 
     # this is important so that your checker is executed before others
-    priority = -1 
+    priority = -1
 
     def leave_getattr(self, node):
         self.calledfuncname.append(node.attrname)
 
     def leave_name(self, node):
-        self.calledfuncname=[node.name]
+        self.calledfuncname = [node.name]
 
     def visit_callfunc(self, node):
         self.calledfuncstack.append(self.calledfuncname)
-        self.calledfuncname=[]
+        self.calledfuncname = []
 
     def leave_callfunc(self, node):
         self._check_verboten_call(node, self.calledfuncname)
-        self.calledfuncname=self.calledfuncstack.pop()
+        self.calledfuncname = self.calledfuncstack.pop()
 
     def visit_import(self, node):
         """triggered when an import statement is seen"""
@@ -141,17 +207,18 @@ class MultiPlatformAPIChecker(BaseChecker):
         """triggered when an import statement is seen"""
         basename = node.modname
         for name, alias in node.names:
-            fullname = '{0}.{1}'.format(basename, name)
+            fullname = "{0}.{1}".format(basename, name)
             self._check_verboten_import(node, fullname)
-            if fullname.find('.') > -1:
+            if fullname.find(".") > -1:
                 try:
-                    fullname = get_module_part(fullname,
-                                               context_file=node.root().file)
+                    fullname = get_module_part(
+                        fullname, context_file=node.root().file
+                    )
                 except ImportError as ex:
                     # this is checked elsewhere in pylint (F0401)
                     continue
             if alias == None:
-                alias = fullname         
+                alias = fullname
             self.imported_modules.update({alias: fullname})
 
     def _is_allowed(self, node):
@@ -164,24 +231,25 @@ class MultiPlatformAPIChecker(BaseChecker):
         if self._is_allowed(node):
             return
         if name in self.VERBOTEN:
-            self.add_message('E0900', args=(name), node=node)
+            self.add_message("E0900", args=(name), node=node)
 
     def _unalias(self, name):
-        for i,e in enumerate(name):
-            fullname = '.'.join(name[:i])
+        for i, e in enumerate(name):
+            fullname = ".".join(name[:i])
             if fullname in self.imported_modules:
                 alias = self.imported_modules.get(fullname)
-                return alias.split('.') +  name[i:]
+                return alias.split(".") + name[i:]
         return name
 
-    def _check_verboten_call(self,node, name):
+    def _check_verboten_call(self, node, name):
         if self._is_allowed(node):
             return
         name = self._unalias(name)
-        for i,e in enumerate(name):
-            fullname = '.'.join(name[:i + 1])
+        for i, e in enumerate(name):
+            fullname = ".".join(name[: i + 1])
             if fullname in self.VERBOTEN:
-                self.add_message('E0901', args=(fullname), node=node)
+                self.add_message("E0901", args=(fullname), node=node)
+
 
 def register(linter):
     """required method to auto register this checker"""
@@ -189,4 +257,4 @@ def register(linter):
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/perf/actionbench.py
+++ b/src/tests/perf/actionbench.py
@@ -40,68 +40,76 @@ import timeit
 # so that we can more easily detect these in testing of the CLI commands.
 #
 if __name__ == "__main__":
+    setup1 = "import pkg.actions as actions"
+    str1 = 'action = actions.fromstr("file 58371e22b5e75ec66602b966edf29bcce7038db5 elfarch=i386 elfbits=32 elfhash=cd12b081ddaef993fd0276dd04d653222d25fa77 group=bin mode=0755 owner=root path=usr/lib/libzonecfg.so.1 pkg.size=178072")'
 
-        setup1 = "import pkg.actions as actions"
-        str1 = 'action = actions.fromstr("file 58371e22b5e75ec66602b966edf29bcce7038db5 elfarch=i386 elfbits=32 elfhash=cd12b081ddaef993fd0276dd04d653222d25fa77 group=bin mode=0755 owner=root path=usr/lib/libzonecfg.so.1 pkg.size=178072")'
+    print("action creation")
+    n = 20000
+    for i in (1, 2, 3):
+        try:
+            t = timeit.Timer(str1, setup1).timeit(n)
+            print("{0:>20f}  {1:>8d} actions/sec".format(t, int(n // t)))
+        except KeyboardInterrupt:
+            import sys
 
-        print("action creation")
-        n = 20000
-        for i in (1, 2, 3):
-                try:
-                        t = timeit.Timer(str1, setup1).timeit(n)
-                        print("{0:>20f}  {1:>8d} actions/sec".format(t,
-                            int(n // t)))
-                except KeyboardInterrupt:
-                        import sys
-                        sys.exit(0)
+            sys.exit(0)
 
-        setup2 = """import pkg.actions as actions
+    setup2 = """import pkg.actions as actions
 a1 = actions.fromstr("file 1234 group=bin mode=0755 owner=root path=usr/lib/libzonecfg.so.1")
 a2 = actions.fromstr("dir group=bin mode=0755 owner=root path=usr/lib/libzonecfg.so.2")
         """
 
-        n = 520000
-        str2 = "a1 == a2"
+    n = 520000
+    str2 = "a1 == a2"
 
-        print("action comparison")
-        print("\tequality")
-        for i in (1, 2, 3):
+    print("action comparison")
+    print("\tequality")
+    for i in (1, 2, 3):
+        try:
+            t = timeit.Timer(str2, setup2).timeit(n)
+            print(
+                "{0:>20f}  {1:>8d} action comparisons/sec".format(
+                    t, int(n // t)
+                )
+            )
+        except KeyboardInterrupt:
+            import sys
 
-                try:
-                        t = timeit.Timer(str2, setup2).timeit(n)
-                        print("{0:>20f}  {1:>8d} action comparisons/sec".format(t,
-                            int(n // t)))
-                except KeyboardInterrupt:
-                        import sys
-                        sys.exit(0)
+            sys.exit(0)
 
-        str2 = "a1 > a2"
-        print("\tgt")
-        for i in (1, 2, 3):
+    str2 = "a1 > a2"
+    print("\tgt")
+    for i in (1, 2, 3):
+        try:
+            t = timeit.Timer(str2, setup2).timeit(n)
+            print(
+                "{0:>20f}  {1:>8d} action comparisons/sec".format(
+                    t, int(n // t)
+                )
+            )
+        except KeyboardInterrupt:
+            import sys
 
-                try:
-                        t = timeit.Timer(str2, setup2).timeit(n)
-                        print("{0:>20f}  {1:>8d} action comparisons/sec".format(t,
-                            int(n // t)))
-                except KeyboardInterrupt:
-                        import sys
-                        sys.exit(0)
+            sys.exit(0)
 
-        str2 = "a1 < a2"
-        print("\tlt")
-        for i in (1, 2, 3):
+    str2 = "a1 < a2"
+    print("\tlt")
+    for i in (1, 2, 3):
+        try:
+            t = timeit.Timer(str2, setup2).timeit(n)
+            print(
+                "{0:>20f}  {1:>8d} action comparisons/sec".format(
+                    t, int(n // t)
+                )
+            )
+        except KeyboardInterrupt:
+            import sys
 
-                try:
-                        t = timeit.Timer(str2, setup2).timeit(n)
-                        print("{0:>20f}  {1:>8d} action comparisons/sec".format(t,
-                            int(n // t)))
-                except KeyboardInterrupt:
-                        import sys
-                        sys.exit(0)
+            sys.exit(0)
 
-        print("minimalist comparison equality")
+    print("minimalist comparison equality")
 
-        setup3 = """
+    setup3 = """
 class superc(object):
         def __lt__(a, b):
                 return a.ordinality == b.ordinality
@@ -118,38 +126,37 @@ a = aa()
 b = bb()
         """
 
-        str3 = "a == b"
-        for i in (1, 2, 3):
+    str3 = "a == b"
+    for i in (1, 2, 3):
+        try:
+            t = timeit.Timer(str3, setup3).timeit(n)
+            print("{0:>20f}  {1:>8d} comparisons/sec".format(t, int(n // t)))
+        except KeyboardInterrupt:
+            import sys
 
-                try:
-                        t = timeit.Timer(str3, setup3).timeit(n)
-                        print("{0:>20f}  {1:>8d} comparisons/sec".format(t,
-                            int(n // t)))
-                except KeyboardInterrupt:
-                        import sys
-                        sys.exit(0)
+            sys.exit(0)
 
-
-        setup4 = """import pkg.actions as actions
+    setup4 = """import pkg.actions as actions
 a1 = actions.fromstr("file 1234 group=bin mode=0755 owner=root path=usr/lib/libzonecfg.so.1")
         """
 
-        n = 260000
-        str4 = "str(a1)"
+    n = 260000
+    str4 = "str(a1)"
 
-        print("action to string conversion")
-        for i in (1, 2, 3):
+    print("action to string conversion")
+    for i in (1, 2, 3):
+        try:
+            t = timeit.Timer(str4, setup4).timeit(n)
+            print(
+                "{0:>20f}  {1:>8d} actions to string/sec".format(t, int(n // t))
+            )
+        except KeyboardInterrupt:
+            import sys
 
-                try:
-                        t = timeit.Timer(str4, setup4).timeit(n)
-                        print("{0:>20f}  {1:>8d} actions to string/sec".format(t,
-                            int(n // t)))
-                except KeyboardInterrupt:
-                        import sys
-                        sys.exit(0)
+            sys.exit(0)
 
-        # I took an existing manifest and randomized the lines.
-        setup5 = """
+    # I took an existing manifest and randomized the lines.
+    setup5 = """
 import pkg.manifest as manifest
 m=\"\"\"
 dir group=sys mode=0755 owner=root path=usr/share
@@ -215,32 +222,37 @@ license f9562cfd7500134682a60f6d9d6dc256902917c8 license=SUNWzoner.copyright pat
 \"\"\"
 """
 
-        n = 1000
+    n = 1000
 
-        str5="""
+    str5 = """
 mf = manifest.Manifest()
 mf.set_content(m)
 """
 
-        try:
-                print("manifest contents loading")
-                for i in (1, 2, 3):
+    try:
+        print("manifest contents loading")
+        for i in (1, 2, 3):
+            t = timeit.Timer(str5, setup5).timeit(n)
+            print(
+                "{0:>20f} {1:>8d} manifest contents loads/sec ({2:d} actions/sec)".format(
+                    t, int(n // t), int((n * 60) // t)
+                )
+            )
 
-                        t = timeit.Timer(str5, setup5).timeit(n)
-                        print("{0:>20f} {1:>8d} manifest contents loads/sec ({2:d} actions/sec)".format(
-                            t, int(n // t), int((n * 60) // t)))
+        n = 1000000
+        str6 = "id(a1)"
+        print("id() speed")
+        for i in (1, 2, 3):
+            t = timeit.Timer(str6, setup4).timeit(n)
+            print(
+                "{0:>20f} {1:>8d} calls to id(action) /sec".format(
+                    t, int(n // t)
+                )
+            )
+    except KeyboardInterrupt:
+        import sys
 
-                n = 1000000
-                str6 = "id(a1)"
-                print("id() speed")
-                for i in (1, 2, 3):
-
-                        t = timeit.Timer(str6, setup4).timeit(n)
-                        print("{0:>20f} {1:>8d} calls to id(action) /sec".format(t,
-                            int(n // t)))
-        except KeyboardInterrupt:
-                import sys
-                sys.exit(0)
+        sys.exit(0)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/perf/fmribench.py
+++ b/src/tests/perf/fmribench.py
@@ -39,223 +39,250 @@ import timeit
 import sys
 
 benches = [
-        
-        [ "dotsequence creation", 100000,
+    [
+        "dotsequence creation",
+        100000,
         """import pkg.version as version""",
-        """v1 = version.DotSequence("0.72.1")"""
-        ],
-
-        [ "dotsequence cmp 1 (v2 > v1)", 1000000,
+        """v1 = version.DotSequence("0.72.1")""",
+    ],
+    [
+        "dotsequence cmp 1 (v2 > v1)",
+        1000000,
         """import pkg.version as version
 v1 = version.DotSequence("0.72.1")
 v2 = version.DotSequence("0.73.1")""",
-        """v2 > v1"""
-        ],
-
-        [ "dotsequence cmp 2 (v1 > None)", 1000000,
+        """v2 > v1""",
+    ],
+    [
+        "dotsequence cmp 2 (v1 > None)",
+        1000000,
         """import pkg.version as version
 v1 = version.DotSequence("0.72.1")""",
-        """v1 > None"""
-        ],
-
-        [ "dotsequence cmp 3 (same)", 1000000,
+        """v1 > None""",
+    ],
+    [
+        "dotsequence cmp 3 (same)",
+        1000000,
         """import pkg.version as version
 v1 = version.DotSequence("0.72.1")
 v2 = version.DotSequence("0.72.1")""",
-        """v1 == v2"""
-        ],
-
-        [ "dotsequence is_subsequence (true)", 100000,
+        """v1 == v2""",
+    ],
+    [
+        "dotsequence is_subsequence (true)",
+        100000,
         """import pkg.version as version
 v1 = version.DotSequence("0.72.1")
 v2 = version.DotSequence("0.72.1.3.4.5")""",
-        """v1.is_subsequence(v2)"""
-        ],
-
-        [ "dotsequence is_subsequence (false)", 100000,
+        """v1.is_subsequence(v2)""",
+    ],
+    [
+        "dotsequence is_subsequence (false)",
+        100000,
         """import pkg.version as version
 v1 = version.DotSequence("0.72.1")
 v2 = version.DotSequence("0.72.1.3.4.5")""",
-        """v2.is_subsequence(v1)"""
-        ],
-
-        [ "dotsequence to string", 100000,
+        """v2.is_subsequence(v1)""",
+    ],
+    [
+        "dotsequence to string",
+        100000,
         """import pkg.version as version
 v1 = version.DotSequence("0.72.1")""",
-        """str(v1)"""
-        ],
-
-        [ "version hash (tstamp)", 100000,
+        """str(v1)""",
+    ],
+    [
+        "version hash (tstamp)",
+        100000,
         """import pkg.version as version
 f1 = version.Version("5.11-0.72:20070921T203926Z", "0.5.11")""",
-        """hash(f1)"""
-        ],
-
-        [ "version hash (no-tstamp)", 100000,
+        """hash(f1)""",
+    ],
+    [
+        "version hash (no-tstamp)",
+        100000,
         """import pkg.version as version
 f1 = version.Version("5.11-0.72", "0.5.11")""",
-        """hash(f1)"""
-        ],
-
-        [ "fmri create (string)", 50000,
+        """hash(f1)""",
+    ],
+    [
+        "fmri create (string)",
+        50000,
         """import pkg.fmri as fmri""",
-        """f = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")"""
-        ],
-
-        [ "fmri create (parts)", 50000,
+        """f = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")""",
+    ],
+    [
+        "fmri create (parts)",
+        50000,
         """import pkg.fmri as fmri""",
-        """f = fmri.PkgFmri(publisher="origin", name="SUNWxwssu", version="0.5.11,5.11-0.72:20070921T203926Z")"""
-        ],
-
-        [ "fmri create (no tstamp)", 50000,
+        """f = fmri.PkgFmri(publisher="origin", name="SUNWxwssu", version="0.5.11,5.11-0.72:20070921T203926Z")""",
+    ],
+    [
+        "fmri create (no tstamp)",
+        50000,
         """import pkg.fmri as fmri""",
-        """f = fmri.PkgFmri("pkg://origin/SUNWlxml@2.6.31,0.5.11-0.90")"""
-        ],
-
-        [ "fmri create (no tstamp, no bld/branch)", 50000,
+        """f = fmri.PkgFmri("pkg://origin/SUNWlxml@2.6.31,0.5.11-0.90")""",
+    ],
+    [
+        "fmri create (no tstamp, no bld/branch)",
+        50000,
         """import pkg.fmri as fmri""",
-        """f = fmri.PkgFmri("pkg://origin/SUNWlxml@2.6.31")"""
-        ],
-
-        [ "fmri create (no tstamp, no bld/branch, no origin)", 50000,
+        """f = fmri.PkgFmri("pkg://origin/SUNWlxml@2.6.31")""",
+    ],
+    [
+        "fmri create (no tstamp, no bld/branch, no origin)",
+        50000,
         """import pkg.fmri as fmri""",
-        """f = fmri.PkgFmri("pkg:/SUNWlxml@2.6.31-0.90")"""
-        ],
-
-        [ "fmri to string (no tstamp)", 100000,
+        """f = fmri.PkgFmri("pkg:/SUNWlxml@2.6.31-0.90")""",
+    ],
+    [
+        "fmri to string (no tstamp)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg:/SUNWxwssu@0.5.11,5.11-0.72")""",
-        """str(f1)"""
-        ],
-
-        [ "fmri to string (no publisher)", 100000,
+        """str(f1)""",
+    ],
+    [
+        "fmri to string (no publisher)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg:/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")""",
-        """str(f1)"""
-        ],
-
-        [ "fmri to string (with publisher)", 100000,
+        """str(f1)""",
+    ],
+    [
+        "fmri to string (with publisher)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")""",
-        """str(f1)"""
-        ],
-
-        [ "fmri hash (tstamp)", 100000,
+        """str(f1)""",
+    ],
+    [
+        "fmri hash (tstamp)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")""",
-        """hash(f1)"""
-        ],
-
-        [ "fmri hash (no-tstamp)", 100000,
+        """hash(f1)""",
+    ],
+    [
+        "fmri hash (no-tstamp)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72")""",
-        """hash(f1)"""
-        ],
-
-        [ "fmri equality (timestamp)", 500000,
+        """hash(f1)""",
+    ],
+    [
+        "fmri equality (timestamp)",
+        500000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203927Z")""",
-        """f1 == f2"""
-        ],
-
-        [ "fmri equality (branch)", 500000,
+        """f1 == f2""",
+    ],
+    [
+        "fmri equality (branch)",
+        500000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.74:20070921T203927Z")""",
-        """f1 == f2"""
-        ],
-
-        [ "fmri equality (version)", 500000,
+        """f1 == f2""",
+    ],
+    [
+        "fmri equality (version)",
+        500000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.12,5.11-0.74:20070921T203927Z")""",
-        """f1 == f2"""
-        ],
-
-        [ "fmri equality (pkgname)", 100000,
+        """f1 == f2""",
+    ],
+    [
+        "fmri equality (pkgname)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssx@0.5.12,5.11-0.74:20070921T203927Z")""",
-        """f1 == f2"""
-        ],
-
-        [ "fmri equality (same)", 100000,
+        """f1 == f2""",
+    ],
+    [
+        "fmri equality (same)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")""",
-        """f1 == f2"""
-        ],
-
-        [ "fmri gt (timestamp)", 500000,
+        """f1 == f2""",
+    ],
+    [
+        "fmri gt (timestamp)",
+        500000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203927Z")""",
-        """f1 > f2"""
-        ],
-
-        [ "fmri is_successor (timestamp)", 100000,
+        """f1 > f2""",
+    ],
+    [
+        "fmri is_successor (timestamp)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203927Z")""",
-        """f1.is_successor(f2)"""
-        ],
-
-        [ "fmri is_successor (branch)", 100000,
+        """f1.is_successor(f2)""",
+    ],
+    [
+        "fmri is_successor (branch)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.74:20070921T203926Z")""",
-        """f1.is_successor(f2)"""
-        ],
-
-        [ "fmri is_successor (version, false)", 100000,
+        """f1.is_successor(f2)""",
+    ],
+    [
+        "fmri is_successor (version, false)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.12,5.11-0.74:20070921T203926Z")""",
-        """f1.is_successor(f2)"""
-        ],
-
-        [ "fmri is_successor (version, true)", 100000,
+        """f1.is_successor(f2)""",
+    ],
+    [
+        "fmri is_successor (version, true)",
+        100000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.12,5.11-0.74:20070921T203926Z")""",
-        """f2.is_successor(f1)"""
-        ],
-
-        [ "fmri is_successor (pkgname)", 1000000,
+        """f2.is_successor(f1)""",
+    ],
+    [
+        "fmri is_successor (pkgname)",
+        1000000,
         """import pkg.fmri as fmri
 f1 = fmri.PkgFmri("pkg://origin/SUNWxwssu@0.5.11,5.11-0.72:20070921T203926Z")
 f2 = fmri.PkgFmri("pkg://origin/SUNWxwssx@0.5.12,5.11-0.74:20070921T203926Z")""",
-        """f1.is_successor(f2)"""
-        ],
-
-
+        """f1.is_successor(f2)""",
+    ],
 ]
 
 if __name__ == "__main__":
-
-        for b in benches:
-                bname = b[0]
-                iter = b[1]
-                setup = b[2]
-                action = b[3]
-                tsum = 0
-                itersum = 0
-                print("# {0}".format(bname))
-                try:
-                        for i in (1, 2, 3):
-                                t = timeit.Timer(action, setup).timeit(iter)
-                                print("#   {0:>6.2f}s   {1:>9d}/sec".format(t, int(iter // t)))
-                                tsum += t
-                                itersum += iter
-                        print("#\n{0:40}  {1:>9d}/sec".format(bname, int(itersum // tsum)))
-                        print("#\n#")
-                except KeyboardInterrupt:
-                        print("Tests stopped at user request.")
-                        sys.exit(1)
-                except:
-                        print("#\n{0:40}  <Test Failed>".format(bname))
-                        raise
+    for b in benches:
+        bname = b[0]
+        iter = b[1]
+        setup = b[2]
+        action = b[3]
+        tsum = 0
+        itersum = 0
+        print("# {0}".format(bname))
+        try:
+            for i in (1, 2, 3):
+                t = timeit.Timer(action, setup).timeit(iter)
+                print("#   {0:>6.2f}s   {1:>9d}/sec".format(t, int(iter // t)))
+                tsum += t
+                itersum += iter
+            print("#\n{0:40}  {1:>9d}/sec".format(bname, int(itersum // tsum)))
+            print("#\n#")
+        except KeyboardInterrupt:
+            print("Tests stopped at user request.")
+            sys.exit(1)
+        except:
+            print("#\n{0:40}  <Test Failed>".format(bname))
+            raise
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/perf/manbench.py
+++ b/src/tests/perf/manbench.py
@@ -40,9 +40,8 @@ import timeit
 # so that we can more easily detect these in testing of the CLI commands.
 #
 if __name__ == "__main__":
-
-        # I took an existing manifest and randomized the lines.
-        setup1 = """
+    # I took an existing manifest and randomized the lines.
+    setup1 = """
 import pkg.manifest as manifest
 m=\"\"\"
 dir group=sys mode=0755 owner=root path=usr/share
@@ -110,30 +109,34 @@ mf = manifest.Manifest()
 mf.set_content(m)
 """
 
-        n = 1000
-        
-        str1="""
+    n = 1000
+
+    str1 = """
 for act in mf.gen_actions():
         continue
 """
-        str2="""
+    str2 = """
 for act in mf.gen_actions(attr_match={ "mode": "0444" }):
         continue
 """
 
-        try:
-                print("manifest gen_actions")
-                for i in (1, 2, 3):
-                        t = timeit.Timer(str1, setup1).timeit(n)
-                        print("{0:>20f} {1:>8d} manifest gen_actions()/sec " \
-                            "({2:d} actions/sec)".format(t, int(n // t), int((n * 60) // t)))
-                print("manifest gen_actions - attr_match")
-                for i in (1, 2, 3):
-                        t = timeit.Timer(str2, setup1).timeit(n)
-                        print("{0:>20f} {1:>8d} manifest gen_actions()/sec " \
-                            "({2:d} actions/sec)".format(t, int(n // t), int((n * 60) // t)))
-        except KeyboardInterrupt:
-                sys.exit(0)
+    try:
+        print("manifest gen_actions")
+        for i in (1, 2, 3):
+            t = timeit.Timer(str1, setup1).timeit(n)
+            print(
+                "{0:>20f} {1:>8d} manifest gen_actions()/sec "
+                "({2:d} actions/sec)".format(t, int(n // t), int((n * 60) // t))
+            )
+        print("manifest gen_actions - attr_match")
+        for i in (1, 2, 3):
+            t = timeit.Timer(str2, setup1).timeit(n)
+            print(
+                "{0:>20f} {1:>8d} manifest gen_actions()/sec "
+                "({2:d} actions/sec)".format(t, int(n // t), int((n * 60) // t))
+            )
+    except KeyboardInterrupt:
+        sys.exit(0)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/perf/membench.py
+++ b/src/tests/perf/membench.py
@@ -37,47 +37,69 @@ import sys
 import os
 import pkg.misc as misc
 
+
 def dotseq(num):
-        return version.DotSequence("5.111111")
+    return version.DotSequence("5.111111")
+
 
 def dotseq_different(num):
-        return version.DotSequence("5.{0:d}".format(num))
+    return version.DotSequence("5.{0:d}".format(num))
+
 
 def vers(num):
-        return version.Version("0.5.11-0.111:20090428T172804Z")
+    return version.Version("0.5.11-0.111:20090428T172804Z")
+
 
 def vers_different(num):
-        return version.Version("0.5.11,5.11-0.{0:d}:{1:0=8d}T172804Z".format(num, num))
+    return version.Version(
+        "0.5.11,5.11-0.{0:d}:{1:0=8d}T172804Z".format(num, num)
+    )
+
 
 def mfmri(num):
-        return fmri.PkgFmri("pkg:/SUNWttf-google-droid@0.5.11,5.11-0.121:20090816T233516Z")
-                
+    return fmri.PkgFmri(
+        "pkg:/SUNWttf-google-droid@0.5.11,5.11-0.121:20090816T233516Z"
+    )
+
+
 def mfmri_different(num):
-        return fmri.PkgFmri("pkg:/SUNWttf-google-{0:d}@0.5.11,5.11-0.{1:d}:{2:0=8d}T233516Z".format(num, num, num)) 
+    return fmri.PkgFmri(
+        "pkg:/SUNWttf-google-{0:d}@0.5.11,5.11-0.{1:d}:{2:0=8d}T233516Z".format(
+            num, num, num
+        )
+    )
+
 
 collection = []
 funcs = [dotseq, dotseq_different, vers, vers_different, mfmri, mfmri_different]
 
 for func in funcs:
-        print("#", func.__name__)
-        pid = os.fork()
-        if pid == 0:
-                startusage = misc.__getvmusage()
-                n = 0
-                # Generate a good sized series of valid YYYYMMDD strings
-                for y in range(1, 10000):
-                        for m in range(1, 10):
-                                for d in range(1, 2):
-                                        n += 1
-                                        collection.append(func(int("{0:0=4d}{1:0=2d}{2:0=2d}".format(y, m, d))))
-                endusage = misc.__getvmusage()
+    print("#", func.__name__)
+    pid = os.fork()
+    if pid == 0:
+        startusage = misc.__getvmusage()
+        n = 0
+        # Generate a good sized series of valid YYYYMMDD strings
+        for y in range(1, 10000):
+            for m in range(1, 10):
+                for d in range(1, 2):
+                    n += 1
+                    collection.append(
+                        func(int("{0:0=4d}{1:0=2d}{2:0=2d}".format(y, m, d)))
+                    )
+        endusage = misc.__getvmusage()
 
-                est = (endusage - startusage) // n
-                print(func.__name__, "{0:d} rounds, estimated memory per object: {1:d} bytes".format(n, est))
-                sys.exit(0)
-        else:
-                os.wait()
+        est = (endusage - startusage) // n
+        print(
+            func.__name__,
+            "{0:d} rounds, estimated memory per object: {1:d} bytes".format(
+                n, est
+            ),
+        )
+        sys.exit(0)
+    else:
+        os.wait()
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/pkg5testenv.py
+++ b/src/tests/pkg5testenv.py
@@ -30,119 +30,125 @@ import tempfile
 
 from site import getsitepackages, getusersitepackages, addsitedir
 
+
 def setup_environment(path_to_proto, debug=False, system_test=False):
-        """ Set up environment for doing testing.
+    """Set up environment for doing testing.
 
-            We set PYTHONPATH and PATH so that they reference the proto
-            area, and clear packaging related environment variables
-            (every variable prefixed with PKG_).
+    We set PYTHONPATH and PATH so that they reference the proto
+    area, and clear packaging related environment variables
+    (every variable prefixed with PKG_).
 
-            path_to_proto should be a relative path indicating a path
-            to proto area of the workspace.  So, if your test case is
-            three levels deep: ex. src/tests/cli/foo.py, this should be
-            "../../../proto"
+    path_to_proto should be a relative path indicating a path
+    to proto area of the workspace.  So, if your test case is
+    three levels deep: ex. src/tests/cli/foo.py, this should be
+    "../../../proto"
 
-            This function looks at argv[0] to compute the ultimate
-            path to the proto area; this is nice because you can then
-            invoke test cases like normal commands; i.e.:
-            "python cli/t_my_test_case.py" will just work.
+    This function looks at argv[0] to compute the ultimate
+    path to the proto area; this is nice because you can then
+    invoke test cases like normal commands; i.e.:
+    "python cli/t_my_test_case.py" will just work.
 
-            If 'covdir' is provided, coverage will be started and the
-            related coverage object returned.
+    If 'covdir' is provided, coverage will be started and the
+    related coverage object returned.
 
-            If 'system_test' is True, tests will run on live system.
-        """
+    If 'system_test' is True, tests will run on live system.
+    """
 
-        osname = platform.uname()[0].lower()
-        proc = 'unknown'
-        if osname == 'sunos':
-                proc = platform.processor()
-        elif osname == 'linux':
-                proc = "linux_" + platform.machine()
-        elif osname == 'windows':
-                proc = osname
-        elif osname == 'darwin':
-                proc = osname
-        elif osname == 'aix':
-                proc = osname
+    osname = platform.uname()[0].lower()
+    proc = "unknown"
+    if osname == "sunos":
+        proc = platform.processor()
+    elif osname == "linux":
+        proc = "linux_" + platform.machine()
+    elif osname == "windows":
+        proc = osname
+    elif osname == "darwin":
+        proc = osname
+    elif osname == "aix":
+        proc = osname
+    else:
+        print("Unable to determine appropriate proto area location.")
+        print("This is a porting problem.")
+        sys.exit(1)
+
+    # Figure out from where we're invoking the command
+    cmddir, cmdname = os.path.split(sys.argv[0])
+    cmddir = os.path.realpath(cmddir)
+
+    if "ROOT" in os.environ:
+        pkg_path = os.environ["ROOT"]
+    else:
+        if system_test:
+            pkg_path = "/"
         else:
-                print("Unable to determine appropriate proto area location.")
-                print("This is a porting problem.")
-                sys.exit(1)
+            pkg_path = "{0}/{1}/root_{2}".format(cmddir, path_to_proto, proc)
 
-        # Figure out from where we're invoking the command
-        cmddir, cmdname = os.path.split(sys.argv[0])
-        cmddir = os.path.realpath(cmddir)
+    proto_area = "{0}/{1}/root_{2}".format(cmddir, path_to_proto, proc)
 
-        if "ROOT" in os.environ:
-                pkg_path = os.environ["ROOT"]
-        else:
-                if system_test:
-                        pkg_path = "/"
-                else:
-                        pkg_path = "{0}/{1}/root_{2}".format(
-                            cmddir, path_to_proto, proc)
+    # Clean up relative ../../, etc. out of path to proto
+    pkg_path = os.path.realpath(pkg_path)
+    proto_area = os.path.realpath(proto_area)
 
-        proto_area = "{0}/{1}/root_{2}".format(cmddir, path_to_proto, proc)
+    py_version = ".".join(platform.python_version_tuple()[:2])
+    bundledpkgs = os.path.join(
+        pkg_path, "usr/lib/pkg/python{0}".format(py_version)
+    )
+    pkgs = os.path.join(
+        pkg_path, "usr/lib/python{0}/vendor-packages".format(py_version)
+    )
+    sys.path, remainder = sys.path[:2], sys.path[2:]
+    addsitedir(bundledpkgs)
+    addsitedir(pkgs)
+    sys.path.extend(remainder)
 
-        # Clean up relative ../../, etc. out of path to proto
-        pkg_path = os.path.realpath(pkg_path)
-        proto_area = os.path.realpath(proto_area)
+    bins = os.path.join(pkg_path, "usr/bin")
 
-        py_version = '.'.join(platform.python_version_tuple()[:2])
-        bundledpkgs = os.path.join(pkg_path,
-            "usr/lib/pkg/python{0}".format(py_version))
-        pkgs = os.path.join(pkg_path,
-            "usr/lib/python{0}/vendor-packages".format(py_version))
-        sys.path, remainder = sys.path[:2], sys.path[2:]
-        addsitedir(bundledpkgs)
-        addsitedir(pkgs)
-        sys.path.extend(remainder)
+    #
+    # Because subprocesses must also source from the proto area,
+    # we need to set PYTHONPATH in the environment as well as
+    # in sys.path.
+    #
+    if "PYTHONPATH" in os.environ:
+        pypath = os.pathsep + os.environ["PYTHONPATH"]
+    else:
+        pypath = ""
+    os.environ["PYTHONPATH"] = (
+        os.pathsep.join([".", bundledpkgs, pkgs]) + pypath
+    )
 
-        bins = os.path.join(pkg_path, "usr/bin")
+    os.environ["PATH"] = bins + os.pathsep + os.environ["PATH"]
 
-        #
-        # Because subprocesses must also source from the proto area,
-        # we need to set PYTHONPATH in the environment as well as
-        # in sys.path.
-        #
-        if "PYTHONPATH" in os.environ:
-                pypath = os.pathsep + os.environ["PYTHONPATH"]
-        else:
-                pypath = ""
-        os.environ["PYTHONPATH"] = (
-            os.pathsep.join(['.', bundledpkgs, pkgs]) + pypath)
+    # Because some test cases will fail under Python 3 if the locale is set
+    # to "C". A "C" locale supports only "ascii" characters, so essentially
+    # if we want to test unicode characters, we need to use "utf-8" locale.
+    os.environ["LC_ALL"] = "en_US.UTF-8"
 
-        os.environ["PATH"] = bins + os.pathsep + os.environ["PATH"]
+    # Proxy environment variables cause all kinds of problems, strip them
+    # all out.
+    # Use "keys"; otherwise we'll change dictionary size during iteration.
+    for k in list(os.environ.keys()):
+        if k.startswith("PKG_") or k.lower().endswith("_proxy"):
+            del os.environ[k]
 
-        # Because some test cases will fail under Python 3 if the locale is set
-        # to "C". A "C" locale supports only "ascii" characters, so essentially
-        # if we want to test unicode characters, we need to use "utf-8" locale.
-        os.environ["LC_ALL"] = "en_US.UTF-8"
+    #
+    # Tell package manager where its application data files live.
+    #
+    os.environ["PACKAGE_MANAGER_ROOT"] = pkg_path
 
-        # Proxy environment variables cause all kinds of problems, strip them
-        # all out.
-        # Use "keys"; otherwise we'll change dictionary size during iteration.
-        for k in list(os.environ.keys()):
-                if k.startswith("PKG_") or k.lower().endswith("_proxy"):
-                        del os.environ[k]
+    from pkg.client import global_settings
 
-        #
-        # Tell package manager where its application data files live.
-        #
-        os.environ["PACKAGE_MANAGER_ROOT"] = pkg_path
+    global_settings.client_name = "pkg"
 
-        from pkg.client import global_settings
-        global_settings.client_name = "pkg"
+    import pkg5unittest
 
-        import pkg5unittest
-        pkg5unittest.g_proto_area = proto_area
-        pkg5unittest.g_test_dir = cmddir
-        pkg5unittest.g_pkg_path = pkg_path
+    pkg5unittest.g_proto_area = proto_area
+    pkg5unittest.g_test_dir = cmddir
+    pkg5unittest.g_pkg_path = pkg_path
 
-        # Save off the value for tempdir when we were invoked, since the
-        # suite will subsequently modify tempdir to sandbox test cases.
-        pkg5unittest.g_tempdir = tempfile.gettempdir()
+    # Save off the value for tempdir when we were invoked, since the
+    # suite will subsequently modify tempdir to sandbox test cases.
+    pkg5unittest.g_tempdir = tempfile.gettempdir()
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/pkg5unittest.py
+++ b/src/tests/pkg5unittest.py
@@ -103,32 +103,35 @@ g_pkg_path = "TOXIC"
 
 g_debug_output = False
 if "DEBUG" in os.environ:
-        g_debug_output = True
+    g_debug_output = True
 
 #
 # XXX?
 #
 gettext.install("pkg", "/usr/share/locale")
 
-OUTPUT_DOTS = 0         # Dots ...
-OUTPUT_VERBOSE = 1      # Verbose
-OUTPUT_PARSEABLE = 2    # Machine readable
+OUTPUT_DOTS = 0  # Dots ...
+OUTPUT_VERBOSE = 1  # Verbose
+OUTPUT_PARSEABLE = 2  # Machine readable
+
 
 class TestStopException(Exception):
-        """An exception used to signal that all testing should cease.
-        This is a framework-internal exception that tests should not
-        raise"""
-        pass
+    """An exception used to signal that all testing should cease.
+    This is a framework-internal exception that tests should not
+    raise"""
+
+    pass
+
 
 class TestSkippedException(Exception):
-        """An exception used to signal that a test was skipped.
-        Should be initialized with a string giving a more detailed
-        reason.  Test cases can raise this to the framework
-        that some prerequisite of the test is unsatisfied.  A string
-        explaining the error should be passed at construction.  """
-        def __str__(self):
-                return "Test Skipped: " + " ".join(self.args)
+    """An exception used to signal that a test was skipped.
+    Should be initialized with a string giving a more detailed
+    reason.  Test cases can raise this to the framework
+    that some prerequisite of the test is unsatisfied.  A string
+    explaining the error should be passed at construction."""
 
+    def __str__(self):
+        return "Test Skipped: " + " ".join(self.args)
 
 
 #
@@ -145,3865 +148,4383 @@ from pkg.client.debugvalues import DebugValues
 PKG_CLIENT_NAME = "pkg"
 CLIENT_API_VERSION = 82
 
-ELIDABLE_ERRORS = [ TestSkippedException, depotcontroller.DepotStateException ]
+ELIDABLE_ERRORS = [TestSkippedException, depotcontroller.DepotStateException]
+
 
 class Pkg5CommonException(AssertionError):
-        def __init__(self, com = ""):
-                Pkg5TestCase.failureException.__init__(self, com)
+    def __init__(self, com=""):
+        Pkg5TestCase.failureException.__init__(self, com)
 
-        topdivider = \
-        ",---------------------------------------------------------------------\n"
-        botdivider = \
-        "`---------------------------------------------------------------------\n"
-        def format_comment(self, comment):
-                if comment is not None:
-                        comment = comment.expandtabs()
-                        comm = ""
-                        for line in comment.splitlines():
-                                line = line.strip()
-                                if line == "":
-                                        continue
-                                comm += "  " + line + "\n"
-                        return comm + "\n"
-                else:
-                        return "<no comment>\n\n"
+    topdivider = ",---------------------------------------------------------------------\n"
+    botdivider = "`---------------------------------------------------------------------\n"
 
-        def format_output(self, command, output):
-                str = "  Output Follows:\n"
-                str += self.topdivider
-                if command is not None:
-                        str += "| $ " + command + "\n"
+    def format_comment(self, comment):
+        if comment is not None:
+            comment = comment.expandtabs()
+            comm = ""
+            for line in comment.splitlines():
+                line = line.strip()
+                if line == "":
+                    continue
+                comm += "  " + line + "\n"
+            return comm + "\n"
+        else:
+            return "<no comment>\n\n"
 
-                if output is None or output == "":
-                        str += "| <no output>\n"
-                else:
-                        for line in output.split("\n"):
-                                str += "| " + line.rstrip() + "\n"
-                str += self.botdivider
-                return str
+    def format_output(self, command, output):
+        str = "  Output Follows:\n"
+        str += self.topdivider
+        if command is not None:
+            str += "| $ " + command + "\n"
 
-        def format_debug(self, output):
-                str = "  Debug Buffer Follows:\n"
-                str += self.topdivider
+        if output is None or output == "":
+            str += "| <no output>\n"
+        else:
+            for line in output.split("\n"):
+                str += "| " + line.rstrip() + "\n"
+        str += self.botdivider
+        return str
 
-                if output is None or output == "":
-                        str += "| <no debug buffer>\n"
-                else:
-                        for line in output.split("\n"):
-                                str += "| " + line.rstrip() + "\n"
-                str += self.botdivider
-                return str
+    def format_debug(self, output):
+        str = "  Debug Buffer Follows:\n"
+        str += self.topdivider
+
+        if output is None or output == "":
+            str += "| <no debug buffer>\n"
+        else:
+            for line in output.split("\n"):
+                str += "| " + line.rstrip() + "\n"
+        str += self.botdivider
+        return str
 
 
 class AssFailException(Pkg5CommonException):
-        def __init__(self, comment = None, debug=None):
-                Pkg5CommonException.__init__(self, comment)
-                self.__comment = comment
-                self.__debug = debug
+    def __init__(self, comment=None, debug=None):
+        Pkg5CommonException.__init__(self, comment)
+        self.__comment = comment
+        self.__debug = debug
 
-        def __str__(self):
-                str = ""
-                if self.__comment is None:
-                        str += Exception.__str__(self)
-                else:
-                        str += self.format_comment(self.__comment)
-                if self.__debug is not None and self.__debug != "":
-                        str += self.format_debug(self.__debug)
-                return str
+    def __str__(self):
+        str = ""
+        if self.__comment is None:
+            str += Exception.__str__(self)
+        else:
+            str += self.format_comment(self.__comment)
+        if self.__debug is not None and self.__debug != "":
+            str += self.format_debug(self.__debug)
+        return str
 
 
 class DebugLogHandler(logging.Handler):
-        """This class is a special log handler to redirect logger output to
-        the test case class' debug() method.
-        """
+    """This class is a special log handler to redirect logger output to
+    the test case class' debug() method.
+    """
 
-        def __init__(self, test_case):
-                self.test_case = test_case
-                logging.Handler.__init__(self)
+    def __init__(self, test_case):
+        self.test_case = test_case
+        logging.Handler.__init__(self)
 
-        def emit(self, record):
-                self.test_case.debug(record)
+    def emit(self, record):
+        self.test_case.debug(record)
+
 
 def setup_logging(test_case):
-        # Ensure logger messages output by unit tests are redirected
-        # to debug output so they are not shown by default.
-        from pkg.client import global_settings
-        log_handler = DebugLogHandler(test_case)
-        global_settings.info_log_handler = log_handler
-        global_settings.error_log_handler = log_handler
+    # Ensure logger messages output by unit tests are redirected
+    # to debug output so they are not shown by default.
+    from pkg.client import global_settings
+
+    log_handler = DebugLogHandler(test_case)
+    global_settings.info_log_handler = log_handler
+    global_settings.error_log_handler = log_handler
 
 
 class Pkg5TestCase(unittest.TestCase):
+    # Needed for compatibility
+    failureException = AssertionError
 
-        # Needed for compatibility
-        failureException = AssertionError
+    #
+    # Some dns servers return results for unknown dns names to redirect
+    # callers to a common landing page.  To avoid getting tripped up by
+    # these stupid servers make sure that bogus_url actually contains an
+    # syntactically invalid dns name so we'll never succeed at the lookup.
+    #
+    bogus_url = "test.0.invalid"
+    __debug_buf = ""
 
-        #
-        # Some dns servers return results for unknown dns names to redirect
-        # callers to a common landing page.  To avoid getting tripped up by
-        # these stupid servers make sure that bogus_url actually contains an
-        # syntactically invalid dns name so we'll never succeed at the lookup.
-        #
-        bogus_url = "test.0.invalid"
-        __debug_buf = ""
-
-        smf_cmds = { \
-            "usr/bin/svcprop" : """\
+    smf_cmds = {
+        "usr/bin/svcprop": """\
 #!/usr/bin/python
 
 import sys
 
 if __name__ == "__main__":
         sys.exit(1)
-"""}
+"""
+    }
 
-        def __init__(self, methodName='runTest'):
-                super(Pkg5TestCase, self).__init__(methodName)
-                self.__test_root = None
-                self.__pid = os.getpid()
-                self.__pwd = os.getcwd()
-                self.__didteardown = False
-                self.__base_port = None
-                self.coverage_cmd = ""
-                self.coverage_env = {}
-                self.next_free_port = None
-                self.ident = None
-                self.pkg_cmdpath = "TOXIC"
-                self.debug_output = g_debug_output
-                setup_logging(self)
-                global g_proto_readable
-                if not g_proto_readable:
-                        self.assertProtoReadable()
-                        g_proto_readable = True
+    def __init__(self, methodName="runTest"):
+        super(Pkg5TestCase, self).__init__(methodName)
+        self.__test_root = None
+        self.__pid = os.getpid()
+        self.__pwd = os.getcwd()
+        self.__didteardown = False
+        self.__base_port = None
+        self.coverage_cmd = ""
+        self.coverage_env = {}
+        self.next_free_port = None
+        self.ident = None
+        self.pkg_cmdpath = "TOXIC"
+        self.debug_output = g_debug_output
+        setup_logging(self)
+        global g_proto_readable
+        if not g_proto_readable:
+            self.assertProtoReadable()
+            g_proto_readable = True
 
-                locale.setlocale(locale.LC_ALL, 'C')
+        locale.setlocale(locale.LC_ALL, "C")
 
-        @property
-        def methodName(self):
-                return self._testMethodName
+    @property
+    def methodName(self):
+        return self._testMethodName
 
-        @property
-        def suite_name(self):
-                return self.__suite_name
+    @property
+    def suite_name(self):
+        return self.__suite_name
 
-        def __str__(self):
-                return "{0}.py {1}.{2}".format(self.__class__.__module__,
-                    self.__class__.__name__, self._testMethodName)
+    def __str__(self):
+        return "{0}.py {1}.{2}".format(
+            self.__class__.__module__,
+            self.__class__.__name__,
+            self._testMethodName,
+        )
 
-        def __set_base_port(self, port):
-                if self.__base_port is not None or \
-                    self.next_free_port is not None:
-                        raise RuntimeError("Setting the base port twice isn't "
-                            "allowed")
-                self.__base_port = port
-                self.next_free_port = port
+    def __set_base_port(self, port):
+        if self.__base_port is not None or self.next_free_port is not None:
+            raise RuntimeError("Setting the base port twice isn't " "allowed")
+        self.__base_port = port
+        self.next_free_port = port
 
-        base_port = property(lambda self: self.__base_port, __set_base_port)
+    base_port = property(lambda self: self.__base_port, __set_base_port)
 
-        def assertProtoReadable(self):
-                """Ensure proto area is readable by unprivileged user."""
-                try:
-                        self.cmdline_run("dir {0}".format(g_proto_area),
-                            su_wrap=True)
-                except:
-                        raise TestStopException("proto area '{0} is not "
-                            "readable by unprivileged user {1}".format(
-                                g_proto_area, get_su_wrap_user()))
+    def assertProtoReadable(self):
+        """Ensure proto area is readable by unprivileged user."""
+        try:
+            self.cmdline_run("dir {0}".format(g_proto_area), su_wrap=True)
+        except:
+            raise TestStopException(
+                "proto area '{0} is not "
+                "readable by unprivileged user {1}".format(
+                    g_proto_area, get_su_wrap_user()
+                )
+            )
 
-        def assertRegexp(self, text, regexp):
-                """Test that a regexp search matches text."""
+    def assertRegexp(self, text, regexp):
+        """Test that a regexp search matches text."""
 
-                if re.search(regexp, text):
-                        return
-                raise self.failureException(
-                    "\"{0}\" does not match \"{1}\"".format(regexp, text))
+        if re.search(regexp, text):
+            return
+        raise self.failureException(
+            '"{0}" does not match "{1}"'.format(regexp, text)
+        )
 
-        def assertRaisesRegexp(self, excClass, regexp,
-            callableObj, *args, **kwargs):
-                """Perform the same logic as assertRaises, but then verify
-                that the stringified version of the exception contains the
-                regexp pattern.
+    def assertRaisesRegexp(
+        self, excClass, regexp, callableObj, *args, **kwargs
+    ):
+        """Perform the same logic as assertRaises, but then verify
+        that the stringified version of the exception contains the
+        regexp pattern.
 
-                Introduced in in python 2.7"""
+        Introduced in in python 2.7"""
 
-                try:
-                        callableObj(*args, **kwargs)
+        try:
+            callableObj(*args, **kwargs)
 
-                except excClass as e:
-                        if re.search(regexp, str(e)):
-                                return
-                        raise self.failureException(
-                            "\"{0}\" does not match \"{1}\"".format(regexp, str(e)))
+        except excClass as e:
+            if re.search(regexp, str(e)):
+                return
+            raise self.failureException(
+                '"{0}" does not match "{1}"'.format(regexp, str(e))
+            )
 
-                raise self.failureException("{0} not raised".format(excClass))
+        raise self.failureException("{0} not raised".format(excClass))
 
-        def assertRaisesStringify(self, excClass, callableObj, *args, **kwargs):
-                """Perform the same logic as assertRaises, but then verify that
-                the exception raised can be stringified."""
+    def assertRaisesStringify(self, excClass, callableObj, *args, **kwargs):
+        """Perform the same logic as assertRaises, but then verify that
+        the exception raised can be stringified."""
 
-                try:
-                        callableObj(*args, **kwargs)
-                except excClass as e:
-                        str(e)
-                        return
-                except Exception as e:
-                        raise self.failureException(
-                            "{1} raised instead of {0}"
-                            .format(excClass, type(e).__name__))
-                else:
-                        raise self.failureException("{0} not raised".format(excClass))
+        try:
+            callableObj(*args, **kwargs)
+        except excClass as e:
+            str(e)
+            return
+        except Exception as e:
+            raise self.failureException(
+                "{1} raised instead of {0}".format(excClass, type(e).__name__)
+            )
+        else:
+            raise self.failureException("{0} not raised".format(excClass))
+
+    #
+    # Uses property() to implements test_root as a read-only attribute.
+    #
+    test_root = property(fget=lambda self: self.__test_root)
+
+    def __get_ro_data_root(self):
+        if not self.__test_root:
+            return None
+        return os.path.join(self.__test_root, "ro_data")
+
+    ro_data_root = property(fget=__get_ro_data_root)
+
+    def persistent_setup_copy(self, orig):
+        pass
+
+    @staticmethod
+    def ptyPopen(args, executable=None, env=None, shell=False):
+        """Less featureful but inspired by subprocess.Popen.
+        Runs subprocess in a pty"""
 
         #
-        # Uses property() to implements test_root as a read-only attribute.
+        # Note: In theory the right answer here is to subclass Popen,
+        # but we found that in practice we'd have to reimplement most
+        # of that class, because its handling of file descriptors is
+        # too brittle in its _execute_child() code.
         #
-        test_root = property(fget=lambda self: self.__test_root)
-
-        def __get_ro_data_root(self):
-                if not self.__test_root:
-                        return None
-                return os.path.join(self.__test_root, "ro_data")
-
-        ro_data_root = property(fget=__get_ro_data_root)
-
-        def persistent_setup_copy(self, orig):
-                pass
-
-        @staticmethod
-        def ptyPopen(args, executable=None, env=None, shell=False):
-                """Less featureful but inspired by subprocess.Popen.
-                Runs subprocess in a pty"""
-                #
-                # Note: In theory the right answer here is to subclass Popen,
-                # but we found that in practice we'd have to reimplement most
-                # of that class, because its handling of file descriptors is
-                # too brittle in its _execute_child() code.
-                #
-                def __drain(masterf, outlist):
-                        # Use a list as a way to pass by reference
-                        while True:
-                                termdata = masterf.read(1024)
-                                if len(termdata) < 1024:
-                                        if len(termdata) > 0:
-                                                outlist.append(termdata)
-                                        break
-                                else:
-                                        outlist.append(termdata)
-
-                # This is the arg handling protocol from Popen
-                if isinstance(args, six.string_types):
-                        args = [args]
+        def __drain(masterf, outlist):
+            # Use a list as a way to pass by reference
+            while True:
+                termdata = masterf.read(1024)
+                if len(termdata) < 1024:
+                    if len(termdata) > 0:
+                        outlist.append(termdata)
+                    break
                 else:
-                        args = list(args)
+                    outlist.append(termdata)
 
-                if shell:
-                        args = ["/bin/sh", "-c"] + args
-                        if executable:
-                                args[0] = executable
+        # This is the arg handling protocol from Popen
+        if isinstance(args, six.string_types):
+            args = [args]
+        else:
+            args = list(args)
 
-                if executable is None:
-                        executable = args[0]
+        if shell:
+            args = ["/bin/sh", "-c"] + args
+            if executable:
+                args[0] = executable
 
-                pid,fd = pty.fork()
-                if pid == 0:
-                        try:
-                                # Child
-                                if env is None:
-                                        os.execvp(executable, args)
-                                else:
-                                        os.execvpe(executable, args, env)
-                        except:
-                                traceback.print_exc()
-                                os._exit(99)
+        if executable is None:
+            executable = args[0]
+
+        pid, fd = pty.fork()
+        if pid == 0:
+            try:
+                # Child
+                if env is None:
+                    os.execvp(executable, args)
                 else:
-                        masterf = os.fdopen(fd, "rb")
-                        outlist = []
-                        t = threading.Thread(target=__drain,
-                            args=(masterf, outlist))
-                        t.start()
-                        waitedpid, retcode = os.waitpid(pid, 0)
-                        retcode = retcode >> 8
-                        t.join()
-                return retcode, b"".join(outlist)
+                    os.execvpe(executable, args, env)
+            except:
+                traceback.print_exc()
+                os._exit(99)
+        else:
+            masterf = os.fdopen(fd, "rb")
+            outlist = []
+            t = threading.Thread(target=__drain, args=(masterf, outlist))
+            t.start()
+            waitedpid, retcode = os.waitpid(pid, 0)
+            retcode = retcode >> 8
+            t.join()
+        return retcode, b"".join(outlist)
 
-        def cmdline_run(self, cmdline, comment="", coverage=True, exit=0,
-            handle=False, out=False, prefix="", raise_error=True, su_wrap=None,
-            stdin=None, stderr=False, env_arg=None, usepty=False):
+    def cmdline_run(
+        self,
+        cmdline,
+        comment="",
+        coverage=True,
+        exit=0,
+        handle=False,
+        out=False,
+        prefix="",
+        raise_error=True,
+        su_wrap=None,
+        stdin=None,
+        stderr=False,
+        env_arg=None,
+        usepty=False,
+    ):
+        self.assertFalse(usepty and stdin, "usepty not supported with stdin")
 
-                self.assertFalse(usepty and stdin,
-                    "usepty not supported with stdin")
+        # If caller provides arguments as a string, the shell must
+        # process them.
+        shell = not isinstance(cmdline, list)
 
-                # If caller provides arguments as a string, the shell must
-                # process them.
-                shell = not isinstance(cmdline, list)
+        wrapper = ""
+        if coverage:
+            wrapper = self.coverage_cmd
+        su_wrap, su_end = self.get_su_wrapper(su_wrap=su_wrap, shell=shell)
 
-                wrapper = ""
-                if coverage:
-                        wrapper = self.coverage_cmd
-                su_wrap, su_end = self.get_su_wrapper(su_wrap=su_wrap,
-                    shell=shell)
+        if isinstance(cmdline, list):
+            if wrapper:
+                # Coverage command must be split into arguments.
+                wrapper = wrapper.split()
+                while wrapper:
+                    cmdline.insert(0, wrapper.pop())
+            if su_wrap:
+                # This ensures that all parts of the command
+                # line to be passed to 'su -c' are passed as a
+                # single argument.
+                while su_wrap[-1] != "-c":
+                    cmdline.insert(0, su_wrap.pop())
+                cmdline = [" ".join(cmdline)]
+                while su_wrap:
+                    cmdline.insert(0, su_wrap.pop())
+            if prefix:
+                cmdline.insert(0, prefix)
+        else:
+            # Space needed between su_wrap and wrapper.
+            cmdline = "{0}{1} {2} {3}{4}".format(
+                prefix, su_wrap, wrapper, cmdline, su_end
+            )
 
-                if isinstance(cmdline, list):
-                        if wrapper:
-                                # Coverage command must be split into arguments.
-                                wrapper = wrapper.split()
-                                while wrapper:
-                                        cmdline.insert(0, wrapper.pop())
-                        if su_wrap:
-                                # This ensures that all parts of the command
-                                # line to be passed to 'su -c' are passed as a
-                                # single argument.
-                                while su_wrap[-1] != "-c":
-                                        cmdline.insert(0, su_wrap.pop())
-                                cmdline = [" ".join(cmdline)]
-                                while su_wrap:
-                                        cmdline.insert(0, su_wrap.pop())
-                        if prefix:
-                                cmdline.insert(0, prefix)
-                else:
-                        # Space needed between su_wrap and wrapper.
-                        cmdline = "{0}{1} {2} {3}{4}".format(prefix, su_wrap, wrapper,
-                            cmdline, su_end)
+        self.debugcmd(cmdline)
 
-                self.debugcmd(cmdline)
+        newenv = os.environ.copy()
+        if coverage:
+            newenv.update(self.coverage_env)
+        if env_arg:
+            newenv.update(env_arg)
+        if not usepty:
+            p = subprocess.Popen(
+                cmdline,
+                env=newenv,
+                shell=shell,
+                stdin=stdin,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
 
-                newenv = os.environ.copy()
-                if coverage:
-                        newenv.update(self.coverage_env)
-                if env_arg:
-                        newenv.update(env_arg)
-                if not usepty:
-                        p = subprocess.Popen(cmdline,
-                            env=newenv,
-                            shell=shell,
-                            stdin=stdin,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+            if handle:
+                # Do nothing more.
+                return p
 
-                        if handle:
-                                # Do nothing more.
-                                return p
+            self.output, self.errout = p.communicate()
+            retcode = p.returncode
+        else:
+            retcode, self.output = self.ptyPopen(
+                cmdline, env=newenv, shell=True
+            )
+            self.errout = ""
 
-                        self.output, self.errout = p.communicate()
-                        retcode = p.returncode
-                else:
-                        retcode, self.output = self.ptyPopen(cmdline,
-                            env=newenv, shell=True)
-                        self.errout = ""
+        # In Python 3, subprocess returns bytes, while our pkg CLI
+        # utilites' standard output and error streams return
+        # str (unicode). To mimic the behavior of CLI, we force the
+        # output to be str. This is a no-op in Python 2.
+        encoding = "utf-8"
+        # For testing encoding other than utf-8, we need to pass the
+        # encoding to force_str.
+        if newenv.get("LC_ALL", None) not in (None, "en_US.utf-8"):
+            # locale is a form of "x.y" and we ignore the C locale
+            index = newenv["LC_ALL"].find(".")
+            if index > -1:
+                encoding = newenv["LC_ALL"][index + 1 :]
+        self.output = misc.force_str(self.output, encoding)
+        self.errout = misc.force_str(self.errout, encoding)
+        self.debugresult(retcode, exit, self.output + self.errout)
 
-                # In Python 3, subprocess returns bytes, while our pkg CLI
-                # utilites' standard output and error streams return
-                # str (unicode). To mimic the behavior of CLI, we force the
-                # output to be str. This is a no-op in Python 2.
-                encoding = "utf-8"
-                # For testing encoding other than utf-8, we need to pass the
-                # encoding to force_str.
-                if newenv.get("LC_ALL", None) not in (None, "en_US.utf-8"):
-                        # locale is a form of "x.y" and we ignore the C locale
-                        index = newenv["LC_ALL"].find(".")
-                        if index > -1:
-                                encoding = newenv["LC_ALL"][index + 1:]
-                self.output = misc.force_str(self.output, encoding)
-                self.errout = misc.force_str(self.errout, encoding)
-                self.debugresult(retcode, exit, self.output + self.errout)
+        if raise_error and retcode == 99:
+            raise TracebackException(
+                cmdline, self.output + self.errout, comment
+            )
 
-                if raise_error and retcode == 99:
-                        raise TracebackException(cmdline, self.output +
-                            self.errout, comment)
+        if not isinstance(exit, list):
+            exit = [exit]
 
-                if not isinstance(exit, list):
-                        exit = [exit]
+        if raise_error and retcode not in exit:
+            raise UnexpectedExitCodeException(
+                cmdline, exit, retcode, self.output + self.errout, comment
+            )
 
-                if raise_error and retcode not in exit:
-                        raise UnexpectedExitCodeException(cmdline,
-                            exit, retcode, self.output + self.errout,
-                            comment)
+        if out:
+            if stderr:
+                return retcode, self.output, self.errout
+            return retcode, self.output
+        return retcode
 
-                if out:
-                        if stderr:
-                                return retcode, self.output, self.errout
-                        return retcode, self.output
-                return retcode
+    def debug(self, s):
+        s = str(s)
+        for x in s.splitlines():
+            if self.debug_output:
+                print("# {0}".format(x), file=sys.stderr)
+            self.__debug_buf += x + "\n"
 
-        def debug(self, s):
-                s = str(s)
-                for x in s.splitlines():
-                        if self.debug_output:
-                                print("# {0}".format(x), file=sys.stderr)
-                        self.__debug_buf += x + "\n"
+    def debugcmd(self, cmdline):
+        wrapper = textwrap.TextWrapper(
+            initial_indent="$ ",
+            subsequent_indent="\t",
+            break_long_words=False,
+            break_on_hyphens=False,
+        )
+        if isinstance(cmdline, list):
+            res = wrapper.wrap(" ".join(cmdline).strip())
+        else:
+            res = wrapper.wrap(cmdline.strip())
+        self.debug(" \\\n".join(res))
 
-        def debugcmd(self, cmdline):
-                wrapper = textwrap.TextWrapper(initial_indent="$ ",
-                    subsequent_indent="\t",
-                    break_long_words=False,
-                    break_on_hyphens=False)
-                if isinstance(cmdline, list):
-                        res = wrapper.wrap(" ".join(cmdline).strip())
-                else:
-                        res = wrapper.wrap(cmdline.strip())
-                self.debug(" \\\n".join(res))
+    def debugfilecreate(self, content, path):
+        lines = content.splitlines()
+        if lines == []:
+            lines = [""]
+        if len(lines) > 1:
+            ins = " [+{0:d} lines...]".format(len(lines) - 1)
+        else:
+            ins = ""
+        if isinstance(lines[0], six.text_type):
+            lines[0] = lines[0].encode("utf-8")
+        self.debugcmd("echo '{0}{1}' > {2}".format(lines[0], ins, path))
 
-        def debugfilecreate(self, content, path):
-                lines = content.splitlines()
-                if lines == []:
-                        lines = [""]
-                if len(lines) > 1:
-                        ins = " [+{0:d} lines...]".format(len(lines) - 1)
-                else:
-                        ins = ""
-                if isinstance(lines[0], six.text_type):
-                        lines[0] = lines[0].encode("utf-8")
-                self.debugcmd(
-                    "echo '{0}{1}' > {2}".format(lines[0], ins, path))
+    def debugresult(self, retcode, expected, output):
+        if output.strip() != "":
+            self.debug(output.strip())
+        if not isinstance(expected, list):
+            expected = [expected]
+        if retcode is None or retcode != 0 or retcode not in expected:
+            self.debug(
+                "[exited {0}, expected {1}]".format(
+                    retcode, ", ".join(str(e) for e in expected)
+                )
+            )
 
-        def debugresult(self, retcode, expected, output):
-                if output.strip() != "":
-                        self.debug(output.strip())
-                if not isinstance(expected, list):
-                        expected = [expected]
-                if retcode is None or retcode != 0 or \
-                    retcode not in expected:
-                        self.debug("[exited {0}, expected {1}]".format(
-                            retcode, ", ".join(str(e) for e in expected)))
+    def get_debugbuf(self):
+        return self.__debug_buf
 
-        def get_debugbuf(self):
-                return self.__debug_buf
+    def set_debugbuf(self, s):
+        self.__debug_buf = s
 
-        def set_debugbuf(self, s):
-                self.__debug_buf = s
+    def get_su_wrapper(self, su_wrap=None, shell=True):
+        """If 'shell' is True, the wrapper will be returned as a tuple of
+        strings of the form (su_wrap, su_end).  If 'shell' is False, the
+        wrapper willbe returned as a tuple of (args, ignore) where
+        'args' is a list of the commands and their arguments that should
+        come before the command being executed."""
 
-        def get_su_wrapper(self, su_wrap=None, shell=True):
-                """If 'shell' is True, the wrapper will be returned as a tuple of
-                strings of the form (su_wrap, su_end).  If 'shell' is False, the
-                wrapper willbe returned as a tuple of (args, ignore) where
-                'args' is a list of the commands and their arguments that should
-                come before the command being executed."""
+        if not su_wrap:
+            return "", ""
 
-                if not su_wrap:
-                        return "", ""
+        if su_wrap == True:
+            su_user = get_su_wrap_user()
+        else:
+            su_user = ""
 
-                if su_wrap == True:
-                        su_user = get_su_wrap_user()
-                else:
-                        su_user = ""
+        cov_env = ["{0}={1}".format(*e) for e in self.coverage_env.items()]
 
-                cov_env = [
-                    "{0}={1}".format(*e)
-                    for e in self.coverage_env.items()
-                ]
+        su_wrap = ["su"]
 
-                su_wrap = ["su"]
+        if su_user:
+            su_wrap.append(su_user)
 
-                if su_user:
-                        su_wrap.append(su_user)
+        if shell:
+            su_wrap.append(
+                "-c 'env LD_LIBRARY_PATH={0}".format(
+                    os.getenv("LD_LIBRARY_PATH", "")
+                )
+            )
+        else:
+            # If this ever changes, cmdline_run must be updated.
+            su_wrap.append("-c")
+            su_wrap.append("env")
+            su_wrap.append(
+                "LD_LIBRARY_PATH={0}".format(os.getenv("LD_LIBRARY_PATH", ""))
+            )
 
-                if shell:
-                        su_wrap.append("-c 'env LD_LIBRARY_PATH={0}".format(
-                            os.getenv("LD_LIBRARY_PATH", "")))
-                else:
-                        # If this ever changes, cmdline_run must be updated.
-                        su_wrap.append("-c")
-                        su_wrap.append("env")
-                        su_wrap.append("LD_LIBRARY_PATH={0}".format(
-                            os.getenv("LD_LIBRARY_PATH", "")))
+        su_wrap.extend(cov_env)
 
-                su_wrap.extend(cov_env)
+        if shell:
+            su_wrap = " ".join(su_wrap)
+            su_end = "'"
+        else:
+            su_end = ""
 
-                if shell:
-                        su_wrap = " ".join(su_wrap)
-                        su_end = "'"
-                else:
-                        su_end = ""
+        return su_wrap, su_end
 
-                return su_wrap, su_end
+    def getTeardownFunc(self):
+        return (self, self.tearDown)
 
-        def getTeardownFunc(self):
-                return (self, self.tearDown)
+    def getSetupFunc(self):
+        return (self, self.setUp)
 
-        def getSetupFunc(self):
-                return (self, self.setUp)
+    def setUp(self):
+        assert self.ident is not None
+        self.__test_root = os.path.join(
+            g_tempdir,
+            "ips.test.{0:d}".format(self.__pid),
+            "{0:d}".format(self.ident),
+        )
+        self.__didtearDown = False
+        try:
+            os.makedirs(self.__test_root, 0o755)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise e
+        if getattr(self, "need_ro_data", False):
+            shutil.copytree(
+                os.path.join(g_test_dir, "ro_data"), self.ro_data_root
+            )
+            self.path_to_certs = os.path.join(
+                self.ro_data_root, "signing_certs", "produced"
+            )
+            self.keys_dir = os.path.join(self.path_to_certs, "keys")
+            self.cs_dir = os.path.join(self.path_to_certs, "code_signing_certs")
+            self.chain_certs_dir = os.path.join(
+                self.path_to_certs, "chain_certs"
+            )
+            self.raw_trust_anchor_dir = os.path.join(
+                self.path_to_certs, "trust_anchors"
+            )
+            self.crl_dir = os.path.join(self.path_to_certs, "crl")
 
-        def setUp(self):
-                assert self.ident is not None
-                self.__test_root = os.path.join(g_tempdir,
-                    "ips.test.{0:d}".format(self.__pid), "{0:d}".format(self.ident))
-                self.__didtearDown = False
+        #
+        # TMPDIR affects the behavior of mkdtemp and mkstemp.
+        # Setting this here should ensure that tests will make temp
+        # files and dirs inside the test directory rather than
+        # polluting /tmp.
+        #
+        os.environ["TMPDIR"] = self.__test_root
+        tempfile.tempdir = self.__test_root
+        setup_logging(self)
+
+        # Create a pkglintrc file that points to our info.classification
+        # data, and doesn't exclude any shipped plugins.
+        self.configure_rcfile(
+            os.path.join(g_pkg_path, "usr/share/lib/pkg/pkglintrc"),
+            {
+                "info_classification_path": os.path.join(
+                    g_pkg_path, "usr/share/lib/pkg/opensolaris.org.sections"
+                ),
+                "pkglint.exclude": "",
+            },
+            self.test_root,
+            section="pkglint",
+        )
+
+        self.sysrepo_template_dir = os.path.join(g_pkg_path, "etc/pkg/sysrepo")
+        self.depot_template_dir = os.path.join(g_pkg_path, "etc/pkg/depot")
+        self.make_misc_files(self.smf_cmds, prefix="smf_cmds", mode=0o755)
+        DebugValues["smf_cmds_dir"] = os.path.join(self.test_root, "smf_cmds")
+
+    def impl_tearDown(self):
+        # impl_tearDown exists so that we can ensure that this class's
+        # teardown is actually called.  Sometimes, subclasses will
+        # implement teardown but forget to call the superclass teardown.
+        if self.__didteardown:
+            return
+        self.__didteardown = True
+        try:
+            os.chdir(self.__pwd)
+        except OSError:
+            # working directory of last resort.
+            os.chdir(g_tempdir)
+
+        #
+        # Kill depots before blowing away test dir-- otherwise
+        # the depot can race with the shutil.rmtree()
+        #
+        if hasattr(self, "killalldepots"):
+            try:
+                self.killalldepots()
+            except Exception as e:
+                print(str(e), file=sys.stderr)
+
+        #
+        # We have some sloppy subclasses which don't call the superclass
+        # setUp-- in which case the dir might not exist.  Tolerate it.
+        #
+        # Also, avoid deleting our fakeroot since then we'd have to
+        # keep re-creating it.
+        #
+        if self.__test_root is not None and os.path.exists(self.__test_root):
+            for d in os.listdir(self.__test_root):
+                path = os.path.join(self.__test_root, d)
+                self.debug("removing: {0}".format(path))
                 try:
-                        os.makedirs(self.__test_root, 0o755)
+                    os.remove(path)
                 except OSError as e:
-                        if e.errno != errno.EEXIST:
-                                raise e
-                if getattr(self, "need_ro_data", False):
-                        shutil.copytree(os.path.join(g_test_dir, "ro_data"),
-                            self.ro_data_root)
-                        self.path_to_certs = os.path.join(self.ro_data_root,
-                            "signing_certs", "produced")
-                        self.keys_dir = os.path.join(self.path_to_certs, "keys")
-                        self.cs_dir = os.path.join(self.path_to_certs,
-                            "code_signing_certs")
-                        self.chain_certs_dir = os.path.join(self.path_to_certs,
-                            "chain_certs")
-                        self.raw_trust_anchor_dir = os.path.join(
-                            self.path_to_certs, "trust_anchors")
-                        self.crl_dir = os.path.join(self.path_to_certs, "crl")
+                    if e.errno == errno.EPERM:
+                        shutil.rmtree(path)
+                    else:
+                        raise
 
-                #
-                # TMPDIR affects the behavior of mkdtemp and mkstemp.
-                # Setting this here should ensure that tests will make temp
-                # files and dirs inside the test directory rather than
-                # polluting /tmp.
-                #
-                os.environ["TMPDIR"] = self.__test_root
-                tempfile.tempdir = self.__test_root
-                setup_logging(self)
+    def tearDown(self):
+        # In reality this call does nothing.
+        unittest.TestCase.tearDown(self)
 
-                # Create a pkglintrc file that points to our info.classification
-                # data, and doesn't exclude any shipped plugins.
-                self.configure_rcfile(os.path.join(g_pkg_path,
-                    "usr/share/lib/pkg/pkglintrc"),
-                    {"info_classification_path":
-                    os.path.join(g_pkg_path,
-                    "usr/share/lib/pkg/opensolaris.org.sections"),
-                    "pkglint.exclude": ""}, self.test_root, section="pkglint")
+        self.impl_tearDown()
 
-                self.sysrepo_template_dir = os.path.join(g_pkg_path,
-                    "etc/pkg/sysrepo")
-                self.depot_template_dir = os.path.join(g_pkg_path,
-                    "etc/pkg/depot")
-                self.make_misc_files(self.smf_cmds, prefix="smf_cmds",
-                    mode=0o755)
-                DebugValues["smf_cmds_dir"] = \
-                    os.path.join(self.test_root, "smf_cmds")
-
-        def impl_tearDown(self):
-                # impl_tearDown exists so that we can ensure that this class's
-                # teardown is actually called.  Sometimes, subclasses will
-                # implement teardown but forget to call the superclass teardown.
-                if self.__didteardown:
-                        return
-                self.__didteardown = True
+    def run(self, result=None):
+        assert self.base_port is not None
+        if result is None:
+            result = self.defaultTestResult()
+        pwd = os.getcwd()
+        result.startTest(self)
+        testMethod = getattr(self, self._testMethodName)
+        if getattr(result, "coverage", None) is not None:
+            self.coverage_cmd, self.coverage_env = result.coverage
+        try:
+            needtodie = False
+            try:
+                self.setUp()
+            except KeyboardInterrupt:
+                # Try hard to make sure we've done a teardown.
                 try:
-                        os.chdir(self.__pwd)
-                except OSError:
-                        # working directory of last resort.
-                        os.chdir(g_tempdir)
-
-                #
-                # Kill depots before blowing away test dir-- otherwise
-                # the depot can race with the shutil.rmtree()
-                #
-                if hasattr(self, "killalldepots"):
-                        try:
-                                self.killalldepots()
-                        except Exception as e:
-                                print(str(e), file=sys.stderr)
-
-                #
-                # We have some sloppy subclasses which don't call the superclass
-                # setUp-- in which case the dir might not exist.  Tolerate it.
-                #
-                # Also, avoid deleting our fakeroot since then we'd have to
-                # keep re-creating it.
-                #
-                if self.__test_root is not None and \
-                    os.path.exists(self.__test_root):
-                        for d in os.listdir(self.__test_root):
-                                path = os.path.join(self.__test_root, d)
-                                self.debug("removing: {0}".format(path))
-                                try:
-                                        os.remove(path)
-                                except OSError as e:
-                                        if e.errno == errno.EPERM:
-                                                shutil.rmtree(path)
-                                        else:
-                                                raise
-
-        def tearDown(self):
-                # In reality this call does nothing.
-                unittest.TestCase.tearDown(self)
-
+                    self.tearDown()
+                except:
+                    pass
                 self.impl_tearDown()
-
-        def run(self, result=None):
-                assert self.base_port is not None
-                if result is None:
-                        result = self.defaultTestResult()
-                pwd = os.getcwd()
-                result.startTest(self)
-                testMethod = getattr(self, self._testMethodName)
-                if getattr(result, "coverage", None) is not None:
-                        self.coverage_cmd, self.coverage_env = result.coverage
+                raise TestStopException
+            except:
+                # teardown could fail too, esp. if setup failed...
                 try:
-                        needtodie = False
-                        try:
-                                self.setUp()
-                        except KeyboardInterrupt:
-                                # Try hard to make sure we've done a teardown.
-                                try:
-                                        self.tearDown()
-                                except:
-                                        pass
-                                self.impl_tearDown()
-                                raise TestStopException
-                        except:
-                                # teardown could fail too, esp. if setup failed...
-                                try:
-                                        self.tearDown()
-                                except:
-                                        pass
-                                # Try hard to make sure we've done a teardown.
-                                self.impl_tearDown()
-                                result.addError(self, sys.exc_info())
-                                return
+                    self.tearDown()
+                except:
+                    pass
+                # Try hard to make sure we've done a teardown.
+                self.impl_tearDown()
+                result.addError(self, sys.exc_info())
+                return
 
-                        ok = False
-                        error_added = False
-                        try:
-                                testMethod()
-                                ok = True
-                        except self.failureException:
-                                result.addFailure(self, sys.exc_info())
-                        except KeyboardInterrupt:
-                                # Try hard to make sure we've done a teardown.
-                                needtodie = True
-                        except TestSkippedException as err:
-                                result.addSkip(self, err)
-                        except:
-                                error_added = True
-                                result.addError(self, sys.exc_info())
+            ok = False
+            error_added = False
+            try:
+                testMethod()
+                ok = True
+            except self.failureException:
+                result.addFailure(self, sys.exc_info())
+            except KeyboardInterrupt:
+                # Try hard to make sure we've done a teardown.
+                needtodie = True
+            except TestSkippedException as err:
+                result.addSkip(self, err)
+            except:
+                error_added = True
+                result.addError(self, sys.exc_info())
 
-                        try:
-                                self.tearDown()
-                        except KeyboardInterrupt:
-                                needtodie = True
-                        except:
-                                # Try hard to make sure we've done a teardown.
-                                self.impl_tearDown()
-                                # Make sure we don't mark this error'd twice.
-                                if not error_added:
-                                        result.addError(self, sys.exc_info())
-                                ok = False
+            try:
+                self.tearDown()
+            except KeyboardInterrupt:
+                needtodie = True
+            except:
+                # Try hard to make sure we've done a teardown.
+                self.impl_tearDown()
+                # Make sure we don't mark this error'd twice.
+                if not error_added:
+                    result.addError(self, sys.exc_info())
+                ok = False
 
-                        if needtodie:
-                                try:
-                                        self.impl_tearDown()
-                                except:
-                                        pass
-                                raise TestStopException
+            if needtodie:
+                try:
+                    self.impl_tearDown()
+                except:
+                    pass
+                raise TestStopException
 
-                        if ok:
-                                result.addSuccess(self)
-                finally:
-                        result.stopTest(self)
-                        # make sure we restore our directory if it still exists.
-                        try:
-                                os.chdir(pwd)
-                        except OSError as e:
-                                # If directory doesn't exist anymore it doesn't
-                                # matter.
-                                if e.errno != errno.ENOENT:
-                                        raise
+            if ok:
+                result.addSuccess(self)
+        finally:
+            result.stopTest(self)
+            # make sure we restore our directory if it still exists.
+            try:
+                os.chdir(pwd)
+            except OSError as e:
+                # If directory doesn't exist anymore it doesn't
+                # matter.
+                if e.errno != errno.ENOENT:
+                    raise
+
+    #
+    # The following are utility functions for use by testcases.
+    #
+    def c_compile(self, prog_text, opts, outputfile, obj_files=None):
+        """Given a C program (as a string), compile it into the
+        executable given by outputfile.  Outputfile should be
+        given as a relative path, and will be located below the
+        test prefix path.  Additional compiler options should be
+        passed in 'opts'.  Suitable for compiling small test
+        programs."""
 
         #
-        # The following are utility functions for use by testcases.
+        # We use a series of likely compilers.  At present we support
+        # this testing with GCC.
         #
-        def c_compile(self, prog_text, opts, outputfile, obj_files=None):
-                """Given a C program (as a string), compile it into the
-                executable given by outputfile.  Outputfile should be
-                given as a relative path, and will be located below the
-                test prefix path.  Additional compiler options should be
-                passed in 'opts'.  Suitable for compiling small test
-                programs."""
+        assert obj_files is not None or prog_text is not None
+        assert obj_files is None or prog_text is None
+        if os.path.dirname(outputfile) != "":
+            try:
+                os.makedirs(os.path.dirname(outputfile))
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+        if prog_text:
+            c_fd, c_path = tempfile.mkstemp(suffix=".c", dir=self.test_root)
+            c_fh = os.fdopen(c_fd, "w")
+            c_fh.write(prog_text)
+            c_fh.close()
+        else:
+            c_path = " ".join(obj_files)
 
-                #
-                # We use a series of likely compilers.  At present we support
-                # this testing with GCC.
-                #
-                assert obj_files is not None or prog_text is not None
-                assert obj_files is None or prog_text is None
-                if os.path.dirname(outputfile) != "":
-                        try:
-                                os.makedirs(os.path.dirname(outputfile))
-                        except OSError as e:
-                                if e.errno != errno.EEXIST:
-                                        raise
-                if prog_text:
-                        c_fd, c_path = tempfile.mkstemp(suffix=".c",
-                            dir=self.test_root)
-                        c_fh = os.fdopen(c_fd, "w")
-                        c_fh.write(prog_text)
-                        c_fh.close()
-                else:
-                        c_path = " ".join(obj_files)
-
-                found = False
-                outpath = os.path.join(self.test_root, outputfile)
-                compilers = ["$CC", "/usr/bin/gcc", "gcc"]
-                for compiler in compilers:
-                        cmd = [compiler, "-m32", "-o", outpath]
-                        cmd.extend(opts)
-                        cmd.append(c_path)
-                        try:
-                                # Make sure to use shell=True so that env.
-                                # vars and $PATH are evaluated.
-                                self.debugcmd(" ".join(cmd))
-                                s = subprocess.Popen(" ".join(cmd),
-                                    shell=True,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.STDOUT)
-                                sout, serr = s.communicate()
-                                rc = s.returncode
-                                if rc != 0 and rc != 127:
-                                        try: os.remove(outpath)
-                                        except OSError: pass
-                                        try: os.remove(c_path)
-                                        except OSError: pass
-                                        raise RuntimeError(
-                                            "Compile failed: {0} --> {1:d}\n{2}".format(
-                                            cmd, rc, sout))
-                                if rc == 127:
-                                        self.debug("[{0} not found]".format(compiler))
-                                        continue
-                                # so rc == 0
-                                found = True
-                                break
-                        except OSError:
-                                continue
-                try:
-                        os.remove(c_path)
-                except OSError:
+        found = False
+        outpath = os.path.join(self.test_root, outputfile)
+        compilers = ["$CC", "/usr/bin/gcc", "gcc"]
+        for compiler in compilers:
+            cmd = [compiler, "-m32", "-o", outpath]
+            cmd.extend(opts)
+            cmd.append(c_path)
+            try:
+                # Make sure to use shell=True so that env.
+                # vars and $PATH are evaluated.
+                self.debugcmd(" ".join(cmd))
+                s = subprocess.Popen(
+                    " ".join(cmd),
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                )
+                sout, serr = s.communicate()
+                rc = s.returncode
+                if rc != 0 and rc != 127:
+                    try:
+                        os.remove(outpath)
+                    except OSError:
                         pass
-                if not found:
-                        raise TestSkippedException(
-                            "No suitable GCC compiler found. "
-                            "Tried: {0}.  Try setting $CC to a valid"
-                            "compiler.".format(compilers))
+                    try:
+                        os.remove(c_path)
+                    except OSError:
+                        pass
+                    raise RuntimeError(
+                        "Compile failed: {0} --> {1:d}\n{2}".format(
+                            cmd, rc, sout
+                        )
+                    )
+                if rc == 127:
+                    self.debug("[{0} not found]".format(compiler))
+                    continue
+                # so rc == 0
+                found = True
+                break
+            except OSError:
+                continue
+        try:
+            os.remove(c_path)
+        except OSError:
+            pass
+        if not found:
+            raise TestSkippedException(
+                "No suitable GCC compiler found. "
+                "Tried: {0}.  Try setting $CC to a valid"
+                "compiler.".format(compilers)
+            )
 
-        def make_file(self, path, content, mode=0o644, copy=False):
-                if not os.path.exists(os.path.dirname(path)):
-                        os.makedirs(os.path.dirname(path), 0o777)
-                self.debugfilecreate(content, path)
+    def make_file(self, path, content, mode=0o644, copy=False):
+        if not os.path.exists(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path), 0o777)
+        self.debugfilecreate(content, path)
+        if six.PY2:
+            if isinstance(content, six.text_type):
+                content = content.encode("utf-8")
+            with open(path, "wb") as fh:
+                fh.write(content)
+        else:
+            if copy:
+                shutil.copy(content, path)
+            else:
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(content)
+        os.chmod(path, mode)
+
+    def make_misc_files(self, files, prefix=None, mode=0o644, copy=False):
+        """Make miscellaneous text files.  Files can be a
+        single relative pathname, a list of relative pathnames,
+        or a hash mapping relative pathnames to specific contents.
+        If file contents are not specified, the pathname of the
+        file is placed into the file as default content."""
+
+        outpaths = []
+        #
+        # If files is a string, make it a list.  Then, if it is
+        # a list, simply turn it into a dict where each file's
+        # contents is its own name, so that we get some uniqueness.
+        #
+        if isinstance(files, six.string_types):
+            files = [files]
+
+        if isinstance(files, list):
+            nfiles = {}
+            for f in files:
+                nfiles[f] = f
+            files = nfiles
+
+        if prefix is None:
+            prefix = self.test_root
+        else:
+            assert not prefix.startswith(os.pathsep)
+            prefix = os.path.join(self.test_root, prefix)
+
+        # Ensure output paths are returned in consistent order.
+        for f in sorted(files):
+            content = files[f]
+            assert not f.startswith(
+                "/"
+            ), "{0}: misc file paths must be relative!".format(f)
+            path = os.path.join(prefix, f)
+            self.make_file(path, content, mode, copy)
+            outpaths.append(path)
+        return outpaths
+
+    def make_manifest(self, content, manifest_dir="manifests", pfmri=None):
+        # Trim to ensure nice looking output.
+        content = content.strip()
+
+        # Place inside of test prefix.
+        manifest_dir = os.path.join(self.test_root, manifest_dir)
+
+        if not os.path.exists(manifest_dir):
+            os.makedirs(manifest_dir)
+        t_fd, t_path = tempfile.mkstemp(prefix="mfst.", dir=manifest_dir)
+        t_fh = os.fdopen(t_fd, "w")
+        if pfmri:
+            t_fh.write("set name=pkg.fmri value={0}\n".format(pfmri))
+        t_fh.write(content)
+        t_fh.close()
+        self.debugfilecreate(content, t_path)
+        return t_path
+
+    @staticmethod
+    def calc_pem_hash(pth):
+        """Find the hash of pem representation the file."""
+        with open(pth, "rb") as f:
+            cert = x509.load_pem_x509_certificate(f.read(), default_backend())
+        return hashlib.sha1(
+            cert.public_bytes(serialization.Encoding.PEM)
+        ).hexdigest()
+
+    def reduceSpaces(self, string):
+        """Reduce runs of spaces down to a single space."""
+        return re.sub(" +", " ", string)
+
+    def assertEqualJSON(self, expected, actual, msg=""):
+        """Compare two JSON-encoded strings."""
+        je = json.loads(expected)
+        ja = json.loads(actual)
+        try:
+            misc.json_diff("test", je, ja, je, ja)
+        except AssertionError as e:
+            if msg:
+                msg += "\n"
+            self.fail(msg + str(e))
+
+    def assertEqualDiff(
+        self, expected, actual, bound_white_space=False, msg=""
+    ):
+        """Compare two strings."""
+
+        if not isinstance(expected, six.string_types):
+            expected = pprint.pformat(expected)
+        if not isinstance(actual, six.string_types):
+            actual = pprint.pformat(actual)
+
+        expected_lines = expected.splitlines()
+        actual_lines = actual.splitlines()
+        if bound_white_space:
+            expected_lines = ["'{0}'".format(l) for l in expected_lines]
+            actual_lines = ["'{0}'".format(l) for l in actual_lines]
+        if msg:
+            msg += "\n"
+        self.assertEqual(
+            expected,
+            actual,
+            msg
+            + "Actual output differed from expected output\n"
+            + msg
+            + "\n".join(
+                difflib.unified_diff(
+                    expected_lines,
+                    actual_lines,
+                    "Expected output",
+                    "Actual output",
+                    lineterm="",
+                )
+            ),
+        )
+
+    def __compare_child_images(self, ev, ov):
+        """A helper function used to match child images with their
+        expected values so that they can be checked."""
+
+        enames = [d["image_name"] for d in ev]
+        onames = [d["image-name"] for d in ov]
+        if sorted(enames) != sorted(onames):
+            raise RuntimeError(
+                "Got a different set of image names "
+                "than was expected.\nExpected:\n{0}\nSeen:\n{1}".format(
+                    " ".join(enames), " ".join(onames)
+                )
+            )
+        for ed in ev:
+            for od in ov:
+                if ed["image_name"] == od["image-name"]:
+                    self.assertEqualParsable(od, **ed)
+                    break
+
+    def assertEqualParsable(
+        self,
+        output,
+        activate_be=True,
+        add_packages=EmptyI,
+        affect_packages=EmptyI,
+        affect_services=EmptyI,
+        backup_be_name=None,
+        be_name=None,
+        boot_archive_rebuild=False,
+        change_editables=EmptyI,
+        change_facets=EmptyI,
+        change_packages=EmptyI,
+        change_mediators=EmptyI,
+        change_variants=EmptyI,
+        child_images=EmptyI,
+        create_backup_be=False,
+        create_new_be=False,
+        image_name=None,
+        licenses=EmptyI,
+        remove_packages=EmptyI,
+        release_notes=EmptyI,
+        include=EmptyI,
+        version=0,
+    ):
+        """Check that the parsable output in 'output' is what is
+        expected."""
+
+        if isinstance(output, six.string_types):
+            try:
+                outd = json.loads(output)
+            except Exception as e:
+                raise RuntimeError(
+                    "JSON couldn't parse the "
+                    "output.\nError was: {0}\nOutput was:\n{1}".format(
+                        e, output
+                    )
+                )
+        else:
+            self.assertTrue(isinstance(output, dict))
+            outd = output
+        expected = locals()
+        # It's difficult to check that space-available is correct in the
+        # test suite.
+        self.assertTrue("space-available" in outd)
+        del outd["space-available"]
+        # While we could check for space-required, it just means lots of
+        # tests would need to be changed if we ever changed our size
+        # measurement and other tests should be ensuring that the number
+        # is correct.
+        self.assertTrue("space-required" in outd)
+        del outd["space-required"]
+        # Do not check item-messages, since it will be checked
+        # somewhere else.
+        self.assertTrue("item-messages" in outd)
+        del outd["item-messages"]
+        # Add 4 to account for self, output, include, and outd.
+        self.assertEqual(
+            len(expected),
+            len(outd) + 4,
+            "Got a "
+            "different set of keys for expected and outd.  Those in "
+            "expected but not in outd:\n{0}\nThose in outd but not in "
+            "expected:\n{1}".format(
+                sorted(
+                    set([k.replace("_", "-") for k in expected]) - set(outd)
+                ),
+                sorted(
+                    set(outd) - set([k.replace("_", "-") for k in expected])
+                ),
+            ),
+        )
+
+        seen = set()
+        for k in sorted(outd):
+            seen.add(k)
+            if include and k not in include:
+                continue
+
+            ek = k.replace("-", "_")
+            ev = expected[ek]
+            if ev == EmptyI:
+                ev = []
+            if ek == "child_images" and ev != []:
+                self.__compare_child_images(ev, outd[k])
+                continue
+            self.assertEqual(
+                ev,
+                outd[k],
+                "In image {0}, the value "
+                "of {1} was expected to be\n{2} but was\n{3}".format(
+                    image_name, k, ev, outd[k]
+                ),
+            )
+
+        if include:
+            # Assert all sections expicitly requested were matched.
+            self.assertEqualDiff(
+                include, list(x for x in (seen & set(include)))
+            )
+
+    def configure_rcfile(
+        self, rcfile, config, test_root, section="DEFAULT", suffix=""
+    ):
+        """Reads the provided rcfile file, setting key/value
+        pairs in the provided section those from the 'config'
+        dictionary. The new config file is written to the supplied
+        test_root, returning the name of that new file.
+
+        Used to set keys to point to paths beneath our test_root,
+        which would otherwise be shipped as hard-coded paths, relative
+        to /.
+        """
+
+        with open(
+            "{0}/{1}{2}".format(test_root, os.path.basename(rcfile), suffix),
+            "w",
+        ) as new_rcfile:
+            conf = configparser.RawConfigParser()
+            with open(rcfile) as f:
                 if six.PY2:
-                        if isinstance(content, six.text_type):
-                                content = content.encode("utf-8")
-                        with open(path, "wb") as fh:
-                                fh.write(content)
+                    conf.readfp(f)
                 else:
-                        if copy:
-                            shutil.copy(content, path)
-                        else:
-                            with open(path, "w", encoding="utf-8") as fh:
-                                fh.write(content)
-                os.chmod(path, mode)
+                    conf.read_file(f)
 
-        def make_misc_files(self, files, prefix=None, mode=0o644,
-                            copy=False):
-                """ Make miscellaneous text files.  Files can be a
-                single relative pathname, a list of relative pathnames,
-                or a hash mapping relative pathnames to specific contents.
-                If file contents are not specified, the pathname of the
-                file is placed into the file as default content. """
+            for key in config:
+                conf.set(section, key, config[key])
 
-                outpaths = []
-                #
-                # If files is a string, make it a list.  Then, if it is
-                # a list, simply turn it into a dict where each file's
-                # contents is its own name, so that we get some uniqueness.
-                #
-                if isinstance(files, six.string_types):
-                        files = [files]
-
-                if isinstance(files, list):
-                        nfiles = {}
-                        for f in files:
-                                nfiles[f] = f
-                        files = nfiles
-
-                if prefix is None:
-                        prefix = self.test_root
-                else:
-                        assert(not prefix.startswith(os.pathsep))
-                        prefix = os.path.join(self.test_root, prefix)
-
-                # Ensure output paths are returned in consistent order.
-                for f in sorted(files):
-                        content = files[f]
-                        assert not f.startswith("/"), \
-                            ("{0}: misc file paths must be relative!".format(f))
-                        path = os.path.join(prefix, f)
-                        self.make_file(path, content, mode, copy)
-                        outpaths.append(path)
-                return outpaths
-
-        def make_manifest(self, content, manifest_dir="manifests", pfmri=None):
-                # Trim to ensure nice looking output.
-                content = content.strip()
-
-                # Place inside of test prefix.
-                manifest_dir = os.path.join(self.test_root,
-                    manifest_dir)
-
-                if not os.path.exists(manifest_dir):
-                        os.makedirs(manifest_dir)
-                t_fd, t_path = tempfile.mkstemp(prefix="mfst.",
-                    dir=manifest_dir)
-                t_fh = os.fdopen(t_fd, "w")
-                if pfmri:
-                        t_fh.write("set name=pkg.fmri value={0}\n".format(pfmri))
-                t_fh.write(content)
-                t_fh.close()
-                self.debugfilecreate(content, t_path)
-                return t_path
-
-        @staticmethod
-        def calc_pem_hash(pth):
-                """Find the hash of pem representation the file."""
-                with open(pth, "rb") as f:
-                        cert = x509.load_pem_x509_certificate(
-                            f.read(), default_backend())
-                return hashlib.sha1(
-                    cert.public_bytes(serialization.Encoding.PEM)).hexdigest()
-
-        def reduceSpaces(self, string):
-                """Reduce runs of spaces down to a single space."""
-                return re.sub(" +", " ", string)
-
-        def assertEqualJSON(self, expected, actual, msg=""):
-                """Compare two JSON-encoded strings."""
-                je = json.loads(expected)
-                ja = json.loads(actual)
-                try:
-                        misc.json_diff("test", je, ja, je, ja)
-                except AssertionError as e:
-                        if msg:
-                                msg += "\n"
-                        self.fail(msg + str(e))
-
-        def assertEqualDiff(self, expected, actual, bound_white_space=False,
-            msg=""):
-                """Compare two strings."""
-
-                if not isinstance(expected, six.string_types):
-                        expected = pprint.pformat(expected)
-                if not isinstance(actual, six.string_types):
-                        actual = pprint.pformat(actual)
-
-                expected_lines = expected.splitlines()
-                actual_lines = actual.splitlines()
-                if bound_white_space:
-                        expected_lines = ["'{0}'".format(l) for l in expected_lines]
-                        actual_lines = ["'{0}'".format(l) for l in actual_lines]
-                if msg:
-                        msg += "\n"
-                self.assertEqual(expected, actual, msg +
-                    "Actual output differed from expected output\n" + msg +
-                    "\n".join(difflib.unified_diff(expected_lines, actual_lines,
-                        "Expected output", "Actual output", lineterm="")))
-
-        def __compare_child_images(self, ev, ov):
-                """A helper function used to match child images with their
-                expected values so that they can be checked."""
-
-                enames = [d["image_name"] for d in ev]
-                onames = [d["image-name"] for d in ov]
-                if sorted(enames) != sorted(onames):
-                        raise RuntimeError("Got a different set of image names "
-                            "than was expected.\nExpected:\n{0}\nSeen:\n{1}".format(
-                            " ".join(enames), " ".join(onames)))
-                for ed in ev:
-                        for od in ov:
-                                if ed["image_name"] == od["image-name"]:
-                                        self.assertEqualParsable(od, **ed)
-                                        break
-
-        def assertEqualParsable(self, output, activate_be=True,
-            add_packages=EmptyI, affect_packages=EmptyI, affect_services=EmptyI,
-            backup_be_name=None, be_name=None, boot_archive_rebuild=False,
-            change_editables=EmptyI, change_facets=EmptyI,
-            change_packages=EmptyI, change_mediators=EmptyI,
-            change_variants=EmptyI, child_images=EmptyI, create_backup_be=False,
-            create_new_be=False, image_name=None, licenses=EmptyI,
-            remove_packages=EmptyI, release_notes=EmptyI, include=EmptyI,
-            version=0):
-                """Check that the parsable output in 'output' is what is
-                expected."""
-
-                if isinstance(output, six.string_types):
-                        try:
-                                outd = json.loads(output)
-                        except Exception as e:
-                                raise RuntimeError("JSON couldn't parse the "
-                                    "output.\nError was: {0}\nOutput was:\n{1}".format(
-                                    e, output))
-                else:
-                        self.assertTrue(isinstance(output, dict))
-                        outd = output
-                expected = locals()
-                # It's difficult to check that space-available is correct in the
-                # test suite.
-                self.assertTrue("space-available" in outd)
-                del outd["space-available"]
-                # While we could check for space-required, it just means lots of
-                # tests would need to be changed if we ever changed our size
-                # measurement and other tests should be ensuring that the number
-                # is correct.
-                self.assertTrue("space-required" in outd)
-                del outd["space-required"]
-                # Do not check item-messages, since it will be checked
-                # somewhere else.
-                self.assertTrue("item-messages" in outd)
-                del outd["item-messages"]
-                # Add 4 to account for self, output, include, and outd.
-                self.assertEqual(len(expected), len(outd) + 4, "Got a "
-                    "different set of keys for expected and outd.  Those in "
-                    "expected but not in outd:\n{0}\nThose in outd but not in "
-                    "expected:\n{1}".format(
-                        sorted(set([k.replace("_", "-") for k in expected]) -
-                        set(outd)),
-                        sorted(set(outd) -
-                        set([k.replace("_", "-") for k in expected]))))
-
-                seen = set()
-                for k in sorted(outd):
-                        seen.add(k)
-                        if include and k not in include:
-                                continue
-
-                        ek = k.replace("-", "_")
-                        ev = expected[ek]
-                        if ev == EmptyI:
-                                ev = []
-                        if ek == "child_images" and ev != []:
-                                self.__compare_child_images(ev, outd[k])
-                                continue
-                        self.assertEqual(ev, outd[k], "In image {0}, the value "
-                            "of {1} was expected to be\n{2} but was\n{3}".format(
-                            image_name, k, ev, outd[k]))
-
-                if include:
-                        # Assert all sections expicitly requested were matched.
-                        self.assertEqualDiff(include, list(x for x in (seen &
-                            set(include))))
-
-        def configure_rcfile(self, rcfile, config, test_root, section="DEFAULT",
-            suffix=""):
-                """Reads the provided rcfile file, setting key/value
-                pairs in the provided section those from the 'config'
-                dictionary. The new config file is written to the supplied
-                test_root, returning the name of that new file.
-
-                Used to set keys to point to paths beneath our test_root,
-                which would otherwise be shipped as hard-coded paths, relative
-                to /.
-                """
-
-                with open("{0}/{1}{2}".format(test_root, os.path.basename(rcfile),
-                    suffix), "w") as new_rcfile:
-
-                        conf = configparser.RawConfigParser()
-                        with open(rcfile) as f:
-                                if six.PY2:
-                                        conf.readfp(f)
-                                else:
-                                        conf.read_file(f)
-
-                        for key in config:
-                                conf.set(section, key, config[key])
-
-                        conf.write(new_rcfile)
-                        return new_rcfile.name
+            conf.write(new_rcfile)
+            return new_rcfile.name
 
 
 class _OverTheWireResults(object):
-        """Class for passing test results between processes."""
+    """Class for passing test results between processes."""
 
-        separator1 = '=' * 70
-        separator2 = '-' * 70
+    separator1 = "=" * 70
+    separator2 = "-" * 70
 
-        list_attrs = ["baseline_failures", "errors", "failures", "skips",
-            "timing"]
-        num_attrs = ["mismatches", "num_successes", "testsRun"]
+    list_attrs = ["baseline_failures", "errors", "failures", "skips", "timing"]
+    num_attrs = ["mismatches", "num_successes", "testsRun"]
 
-        def __init__(self, res):
-                self.errors = [(str(test), err) for  test, err in res.errors]
-                self.failures = [(str(test), err) for test, err in res.failures]
-                self.mismatches = len(res.mismatches)
-                self.num_successes = len(res.success)
-                self.skips = res.skips
-                self.testsRun = res.testsRun
-                self.timing = []
-                self.text = ""
-                self.baseline_failures = []
-                self.debug_buf = ""
+    def __init__(self, res):
+        self.errors = [(str(test), err) for test, err in res.errors]
+        self.failures = [(str(test), err) for test, err in res.failures]
+        self.mismatches = len(res.mismatches)
+        self.num_successes = len(res.success)
+        self.skips = res.skips
+        self.testsRun = res.testsRun
+        self.timing = []
+        self.text = ""
+        self.baseline_failures = []
+        self.debug_buf = ""
 
-        def wasSuccessful(self):
-                return self.mismatches == 0
+    def wasSuccessful(self):
+        return self.mismatches == 0
 
-        def wasSkipped(self):
-                return len(self.skips) != 0
+    def wasSkipped(self):
+        return len(self.skips) != 0
 
-        def printErrors(self):
-                self.stream.write("\n")
-                self.printErrorList('ERROR', self.errors)
-                self.printErrorList('FAIL', self.failures)
+    def printErrors(self):
+        self.stream.write("\n")
+        self.printErrorList("ERROR", self.errors)
+        self.printErrorList("FAIL", self.failures)
 
-        def printErrorList(self, flavour, errors):
-                for test, err in errors:
-                        self.stream.write(self.separator1 + "\n")
-                        self.stream.write("{0}: {1}\n".format(
-                            flavour, test))
-                        self.stream.write(self.separator2 + "\n")
-                        self.stream.write("{0}\n".format(err))
+    def printErrorList(self, flavour, errors):
+        for test, err in errors:
+            self.stream.write(self.separator1 + "\n")
+            self.stream.write("{0}: {1}\n".format(flavour, test))
+            self.stream.write(self.separator2 + "\n")
+            self.stream.write("{0}\n".format(err))
 
 
 class _CombinedResult(_OverTheWireResults):
-        """Class for combining test results from different test cases."""
+    """Class for combining test results from different test cases."""
 
-        def __init__(self):
-                for l in self.list_attrs:
-                        setattr(self, l, [])
-                for n in self.num_attrs:
-                        setattr(self, n, 0)
+    def __init__(self):
+        for l in self.list_attrs:
+            setattr(self, l, [])
+        for n in self.num_attrs:
+            setattr(self, n, 0)
 
-        def combine(self, o):
-                for l in self.list_attrs:
-                        v = getattr(self, l)
-                        v.extend(getattr(o, l))
-                        setattr(self, l, v)
-                for n in self.num_attrs:
-                        v = getattr(self, n)
-                        v += getattr(o, n)
-                        setattr(self, n, v)
+    def combine(self, o):
+        for l in self.list_attrs:
+            v = getattr(self, l)
+            v.extend(getattr(o, l))
+            setattr(self, l, v)
+        for n in self.num_attrs:
+            v = getattr(self, n)
+            v += getattr(o, n)
+            setattr(self, n, v)
 
 
 class _Pkg5TestResult(unittest._TextTestResult):
-        baseline = None
-        machsep = "|"
+    baseline = None
+    machsep = "|"
 
-        def __init__(self, stream, output, baseline, bailonfail=False,
-            show_on_expected_fail=False, archive_dir=None):
-                unittest.TestResult.__init__(self)
-                self.stream = stream
-                self.output = output
-                self.baseline = baseline
-                self.success = []
-                self.mismatches = []
-                self.bailonfail = bailonfail
-                self.show_on_expected_fail = show_on_expected_fail
-                self.archive_dir = archive_dir
-                self.skips = []
+    def __init__(
+        self,
+        stream,
+        output,
+        baseline,
+        bailonfail=False,
+        show_on_expected_fail=False,
+        archive_dir=None,
+    ):
+        unittest.TestResult.__init__(self)
+        self.stream = stream
+        self.output = output
+        self.baseline = baseline
+        self.success = []
+        self.mismatches = []
+        self.bailonfail = bailonfail
+        self.show_on_expected_fail = show_on_expected_fail
+        self.archive_dir = archive_dir
+        self.skips = []
 
-        def collapse(self):
-                return _OverTheWireResults(self)
+    def collapse(self):
+        return _OverTheWireResults(self)
 
-        def getDescription(self, test):
-                return str(test)
+    def getDescription(self, test):
+        return str(test)
 
-        # Override the unittest version of this so that success is
-        # considered "matching the baseline"
-        def wasSuccessful(self):
-                return len(self.mismatches) == 0
+    # Override the unittest version of this so that success is
+    # considered "matching the baseline"
+    def wasSuccessful(self):
+        return len(self.mismatches) == 0
 
-        def wasSkipped(self):
-                return len(self.skips) != 0
+    def wasSkipped(self):
+        return len(self.skips) != 0
 
-        def dobailout(self, test):
-                """ Pull the ejection lever.  Stop execution, doing as
-                much forcible cleanup as possible. """
-                inst, tdf = test.getTeardownFunc()
-                try:
-                        tdf()
-                except Exception as e:
-                        print(str(e), file=sys.stderr)
-                        pass
+    def dobailout(self, test):
+        """Pull the ejection lever.  Stop execution, doing as
+        much forcible cleanup as possible."""
+        inst, tdf = test.getTeardownFunc()
+        try:
+            tdf()
+        except Exception as e:
+            print(str(e), file=sys.stderr)
+            pass
 
-                if getattr(test, "persistent_setup", None):
-                        try:
-                                test.reallytearDown()
-                        except Exception as e:
-                                print(str(e), file=sys.stderr)
-                                pass
+        if getattr(test, "persistent_setup", None):
+            try:
+                test.reallytearDown()
+            except Exception as e:
+                print(str(e), file=sys.stderr)
+                pass
 
-                if hasattr(inst, "killalldepots"):
-                        try:
-                                inst.killalldepots()
-                        except Exception as e:
-                                print(str(e), file=sys.stderr)
-                                pass
-                raise TestStopException()
+        if hasattr(inst, "killalldepots"):
+            try:
+                inst.killalldepots()
+            except Exception as e:
+                print(str(e), file=sys.stderr)
+                pass
+        raise TestStopException()
 
-        def fmt_parseable(self, match, actual, expected):
-                if match == baseline.BASELINE_MATCH:
-                        mstr = "MATCH"
-                else:
-                        mstr = "MISMATCH"
-                return "{0}|{1}|{2}".format(mstr, actual, expected)
+    def fmt_parseable(self, match, actual, expected):
+        if match == baseline.BASELINE_MATCH:
+            mstr = "MATCH"
+        else:
+            mstr = "MISMATCH"
+        return "{0}|{1}|{2}".format(mstr, actual, expected)
 
+    @staticmethod
+    def fmt_prefix_with(instr, prefix):
+        res = ""
+        for s in instr.splitlines():
+            res += "{0}{1}\n".format(prefix, s)
+        return res
 
-        @staticmethod
-        def fmt_prefix_with(instr, prefix):
-                res = ""
-                for s in instr.splitlines():
-                        res += "{0}{1}\n".format(prefix, s)
-                return res
+    @staticmethod
+    def fmt_box(instr, title, prefix=""):
+        trailingdashes = (50 - len(title)) * "-"
+        res = "\n.---" + title + trailingdashes + "\n"
+        for s in instr.splitlines():
+            if s.strip() == "":
+                continue
+            res += "| {0}\n".format(s)
+        res += "`---" + len(title) * "-" + trailingdashes
+        return _Pkg5TestResult.fmt_prefix_with(res, prefix)
 
-        @staticmethod
-        def fmt_box(instr, title, prefix=""):
-                trailingdashes = (50 - len(title)) * "-"
-                res = "\n.---" + title + trailingdashes + "\n"
-                for s in instr.splitlines():
-                        if s.strip() == "":
-                                continue
-                        res += "| {0}\n".format(s)
-                res += "`---" + len(title) * "-" + trailingdashes
-                return _Pkg5TestResult.fmt_prefix_with(res, prefix)
+    def do_archive(self, test, info):
+        assert self.archive_dir
+        if not os.path.exists(self.archive_dir):
+            os.makedirs(self.archive_dir, mode=0o755)
 
-        def do_archive(self, test, info):
-                assert self.archive_dir
-                if not os.path.exists(self.archive_dir):
-                        os.makedirs(self.archive_dir, mode=0o755)
+        archive_path = os.path.join(
+            self.archive_dir, "{0:d}".format(os.getpid())
+        )
+        if not os.path.exists(archive_path):
+            os.makedirs(archive_path, mode=0o755)
+        archive_path = os.path.join(archive_path, test.id())
+        if test.debug_output:
+            self.stream.write("# Archiving to {0}\n".format(archive_path))
 
-                archive_path = os.path.join(self.archive_dir,
-                    "{0:d}".format(os.getpid()))
-                if not os.path.exists(archive_path):
-                        os.makedirs(archive_path, mode=0o755)
-                archive_path = os.path.join(archive_path, test.id())
-                if test.debug_output:
-                        self.stream.write("# Archiving to {0}\n".format(archive_path))
+        if os.path.exists(test.test_root):
+            try:
+                misc.copytree(test.test_root, archive_path)
+            except socketerror as e:
+                pass
+        else:
+            # If the test has failed without creating its directory,
+            # make it manually, so that we have a place to write out
+            # ERROR_INFO.
+            os.makedirs(archive_path, mode=0o755)
 
-                if os.path.exists(test.test_root):
-                        try:
-                                misc.copytree(test.test_root, archive_path)
-                        except socketerror as e:
-                                pass
-                else:
-                        # If the test has failed without creating its directory,
-                        # make it manually, so that we have a place to write out
-                        # ERROR_INFO.
-                        os.makedirs(archive_path, mode=0o755)
+        f = open(os.path.join(archive_path, "ERROR_INFO"), "w")
+        f.write("------------------DEBUG LOG---------------\n")
+        f.write(test.get_debugbuf())
+        if info is not None:
+            f.write("\n\n------------------EXCEPTION---------------\n")
+            f.write(info)
+        f.close()
 
-                f = open(os.path.join(archive_path, "ERROR_INFO"), "w")
-                f.write("------------------DEBUG LOG---------------\n")
-                f.write(test.get_debugbuf())
-                if info is not None:
-                        f.write("\n\n------------------EXCEPTION---------------\n")
-                        f.write(info)
-                f.close()
+    def addSuccess(self, test):
+        unittest.TestResult.addSuccess(self, test)
 
-        def addSuccess(self, test):
-                unittest.TestResult.addSuccess(self, test)
+        # If we're debugging, we'll have had output since we
+        # announced the name of the test, so restate it.
+        if test.debug_output:
+            self.statename(test)
 
-                # If we're debugging, we'll have had output since we
-                # announced the name of the test, so restate it.
-                if test.debug_output:
-                        self.statename(test)
+        errinfo = self.format_output_and_exc(test, None)
 
-                errinfo = self.format_output_and_exc(test, None)
+        bresult = self.baseline.handleresult(str(test), "pass")
+        expected = self.baseline.expectedresult(str(test))
+        if self.output == OUTPUT_PARSEABLE:
+            res = self.fmt_parseable(bresult, "pass", expected)
 
-                bresult = self.baseline.handleresult(str(test), "pass")
-                expected = self.baseline.expectedresult(str(test))
-                if self.output == OUTPUT_PARSEABLE:
-                        res = self.fmt_parseable(bresult, "pass", expected)
+        elif self.output == OUTPUT_VERBOSE:
+            if bresult == baseline.BASELINE_MATCH:
+                res = "match pass"
+            else:
+                res = "MISMATCH pass (expected: {0})".format(expected)
+                res = self.fmt_box(errinfo, "Successful Test", "# ")
+        else:
+            assert self.output == OUTPUT_DOTS
+            res = "."
 
-                elif self.output == OUTPUT_VERBOSE:
-                        if bresult == baseline.BASELINE_MATCH:
-                                res = "match pass"
-                        else:
-                                res = "MISMATCH pass (expected: {0})".format(
-                                    expected)
-                                res = self.fmt_box(errinfo,
-                                    "Successful Test", "# ")
-                else:
-                        assert self.output == OUTPUT_DOTS
-                        res = "."
+        if self.output != OUTPUT_DOTS:
+            self.stream.write(res + "\n")
+        else:
+            self.stream.write(res)
+        self.success.append(test)
 
-                if self.output != OUTPUT_DOTS:
-                        self.stream.write(res + "\n")
-                else:
-                        self.stream.write(res)
-                self.success.append(test)
+        if bresult == baseline.BASELINE_MISMATCH:
+            self.mismatches.append(test)
 
-                if bresult == baseline.BASELINE_MISMATCH:
-                        self.mismatches.append(test)
+        if bresult == baseline.BASELINE_MISMATCH and self.archive_dir:
+            self.do_archive(test, None)
 
-                if bresult == baseline.BASELINE_MISMATCH and self.archive_dir:
-                        self.do_archive(test, None)
+        # Bail out completely if the 'bail on fail' flag is set
+        # but iff the result disagrees with the baseline.
+        if self.bailonfail and bresult == baseline.BASELINE_MISMATCH:
+            self.dobailout(test)
 
-                # Bail out completely if the 'bail on fail' flag is set
-                # but iff the result disagrees with the baseline.
-                if self.bailonfail and bresult == baseline.BASELINE_MISMATCH:
-                        self.dobailout(test)
+    def addError(self, test, err):
+        errtype, errval = err[:2]
+        # for a few special exceptions, we delete the traceback so
+        # as to elide it.  use only when the traceback itself
+        # is not likely to be useful.
+        if errtype in ELIDABLE_ERRORS:
+            unittest.TestResult.addError(self, test, (err[0], err[1], None))
+        else:
+            unittest.TestResult.addError(self, test, err)
 
+        # If we're debugging, we'll have had output since we
+        # announced the name of the test, so restate it.
+        if test.debug_output:
+            self.statename(test)
 
-        def addError(self, test, err):
-                errtype, errval = err[:2]
-                # for a few special exceptions, we delete the traceback so
-                # as to elide it.  use only when the traceback itself
-                # is not likely to be useful.
-                if errtype in ELIDABLE_ERRORS:
-                        unittest.TestResult.addError(self, test,
-                            (err[0], err[1], None))
-                else:
-                        unittest.TestResult.addError(self, test, err)
+        errinfo = self.format_output_and_exc(test, err)
 
-                # If we're debugging, we'll have had output since we
-                # announced the name of the test, so restate it.
-                if test.debug_output:
-                        self.statename(test)
+        bresult = self.baseline.handleresult(str(test), "error")
+        expected = self.baseline.expectedresult(str(test))
+        if self.output == OUTPUT_PARSEABLE:
+            if errtype in ELIDABLE_ERRORS:
+                res = self.fmt_parseable(bresult, "ERROR", expected)
+                res += "\n# {0}\n".format(str(errval).strip())
+            else:
+                res = self.fmt_parseable(bresult, "ERROR", expected)
+                res += "\n"
+                if (
+                    bresult == baseline.BASELINE_MISMATCH
+                    or self.show_on_expected_fail
+                ):
+                    res += self.fmt_prefix_with(errinfo, "# ")
 
-                errinfo = self.format_output_and_exc(test, err)
+        elif self.output == OUTPUT_VERBOSE:
+            if bresult == baseline.BASELINE_MATCH:
+                b = "match"
+            else:
+                b = "MISMATCH"
 
-                bresult = self.baseline.handleresult(str(test), "error")
-                expected = self.baseline.expectedresult(str(test))
-                if self.output == OUTPUT_PARSEABLE:
-                        if errtype in ELIDABLE_ERRORS:
-                                res = self.fmt_parseable(bresult, "ERROR", expected)
-                                res += "\n# {0}\n".format(str(errval).strip())
-                        else:
-                                res = self.fmt_parseable(bresult, "ERROR", expected)
-                                res += "\n"
-                                if bresult == baseline.BASELINE_MISMATCH \
-                                   or self.show_on_expected_fail:
-                                        res += self.fmt_prefix_with(errinfo, "# ")
+            if errtype in ELIDABLE_ERRORS:
+                res = "{0} ERROR\n".format(b)
+                res += "#\t{0}".format(str(errval))
+            else:
+                res = "{0} ERROR\n".format(b)
+                if (
+                    bresult == baseline.BASELINE_MISMATCH
+                    or self.show_on_expected_fail
+                ):
+                    res += self.fmt_box(errinfo, "Error Information", "# ")
 
-                elif self.output == OUTPUT_VERBOSE:
-                        if bresult == baseline.BASELINE_MATCH:
-                                b = "match"
-                        else:
-                                b = "MISMATCH"
+        elif self.output == OUTPUT_DOTS:
+            if bresult == baseline.BASELINE_MATCH:
+                res = "e"
+            else:
+                res = "E"
 
-                        if errtype in ELIDABLE_ERRORS:
-                                res = "{0} ERROR\n".format(b)
-                                res += "#\t{0}".format(str(errval))
-                        else:
-                                res = "{0} ERROR\n".format(b)
-                                if bresult == baseline.BASELINE_MISMATCH \
-                                   or self.show_on_expected_fail:
-                                        res += self.fmt_box(errinfo,
-                                            "Error Information", "# ")
+        if self.output == OUTPUT_DOTS:
+            self.stream.write(res)
+        else:
+            self.stream.write(res + "\n")
 
-                elif self.output == OUTPUT_DOTS:
-                        if bresult == baseline.BASELINE_MATCH:
-                                res = "e"
-                        else:
-                                res = "E"
+        if bresult == baseline.BASELINE_MISMATCH:
+            self.mismatches.append(test)
 
-                if self.output == OUTPUT_DOTS:
-                        self.stream.write(res)
-                else:
-                        self.stream.write(res + "\n")
+        # Check to see if we should archive this baseline mismatch.
+        if bresult == baseline.BASELINE_MISMATCH and self.archive_dir:
+            self.do_archive(test, self._exc_info_to_string(err, test))
 
-                if bresult == baseline.BASELINE_MISMATCH:
-                        self.mismatches.append(test)
+        # Bail out completely if the 'bail on fail' flag is set
+        # but iff the result disagrees with the baseline.
+        if self.bailonfail and bresult == baseline.BASELINE_MISMATCH:
+            self.dobailout(test)
 
-                # Check to see if we should archive this baseline mismatch.
-                if bresult == baseline.BASELINE_MISMATCH and self.archive_dir:
-                        self.do_archive(test, self._exc_info_to_string(err, test))
+    def format_output_and_exc(self, test, error):
+        res = ""
+        dbgbuf = test.get_debugbuf()
+        if dbgbuf != "":
+            res += dbgbuf
+        if error is not None:
+            res += self._exc_info_to_string(error, test)
+        return res
 
-                # Bail out completely if the 'bail on fail' flag is set
-                # but iff the result disagrees with the baseline.
-                if self.bailonfail and bresult == baseline.BASELINE_MISMATCH:
-                        self.dobailout(test)
+    def addFailure(self, test, err):
+        unittest.TestResult.addFailure(self, test, err)
 
-        def format_output_and_exc(self, test, error):
-                res = ""
-                dbgbuf = test.get_debugbuf()
-                if dbgbuf != "":
-                        res += dbgbuf
-                if error is not None:
-                        res += self._exc_info_to_string(error, test)
-                return res
+        bresult = self.baseline.handleresult(str(test), "fail")
+        expected = self.baseline.expectedresult(str(test))
 
-        def addFailure(self, test, err):
-                unittest.TestResult.addFailure(self, test, err)
+        # If we're debugging, we'll have had output since we
+        # announced the name of the test, so restate it.
+        if test.debug_output:
+            self.statename(test)
 
-                bresult = self.baseline.handleresult(str(test), "fail")
-                expected = self.baseline.expectedresult(str(test))
+        errinfo = self.format_output_and_exc(test, err)
 
-                # If we're debugging, we'll have had output since we
-                # announced the name of the test, so restate it.
-                if test.debug_output:
-                        self.statename(test)
+        if self.output == OUTPUT_PARSEABLE:
+            res = self.fmt_parseable(bresult, "FAIL", expected)
+            res += "\n"
+            if (
+                bresult == baseline.BASELINE_MISMATCH
+                or self.show_on_expected_fail
+            ):
+                res += self.fmt_prefix_with(errinfo, "# ")
+        elif self.output == OUTPUT_VERBOSE:
+            if bresult == baseline.BASELINE_MISMATCH:
+                res = "MISMATCH FAIL (expected: {0})".format(expected)
+            else:
+                res = "match FAIL (expected: FAIL)"
 
-                errinfo = self.format_output_and_exc(test, err)
+            if (
+                bresult == baseline.BASELINE_MISMATCH
+                or self.show_on_expected_fail
+            ):
+                res += self.fmt_box(errinfo, "Failure Information", "# ")
 
-                if self.output == OUTPUT_PARSEABLE:
-                        res = self.fmt_parseable(bresult, "FAIL", expected)
-                        res += "\n"
-                        if bresult == baseline.BASELINE_MISMATCH \
-                           or self.show_on_expected_fail:
-                                res += self.fmt_prefix_with(errinfo, "# ")
-                elif self.output == OUTPUT_VERBOSE:
-                        if bresult == baseline.BASELINE_MISMATCH:
-                                res = "MISMATCH FAIL (expected: {0})".format(expected)
-                        else:
-                                res = "match FAIL (expected: FAIL)"
+        elif self.output == OUTPUT_DOTS:
+            if bresult == baseline.BASELINE_MATCH:
+                res = "f"
+            else:
+                res = "F"
 
-                        if bresult == baseline.BASELINE_MISMATCH \
-                           or self.show_on_expected_fail:
-                                res += self.fmt_box(errinfo,
-                                    "Failure Information", "# ")
+        if self.output == OUTPUT_DOTS:
+            self.stream.write(res)
+        else:
+            self.stream.write(res + "\n")
 
-                elif self.output == OUTPUT_DOTS:
-                        if bresult == baseline.BASELINE_MATCH:
-                                res = "f"
-                        else:
-                                res = "F"
+        if bresult == baseline.BASELINE_MISMATCH:
+            self.mismatches.append(test)
 
-                if self.output == OUTPUT_DOTS:
-                        self.stream.write(res)
-                else:
-                        self.stream.write(res + "\n")
+        # Check to see if we should archive this baseline mismatch.
+        if bresult == baseline.BASELINE_MISMATCH and self.archive_dir:
+            self.do_archive(test, self._exc_info_to_string(err, test))
 
-                if bresult == baseline.BASELINE_MISMATCH:
-                        self.mismatches.append(test)
+        # Bail out completely if the 'bail on fail' flag is set
+        # but iff the result disagrees with the baseline.
+        if self.bailonfail and bresult == baseline.BASELINE_MISMATCH:
+            self.dobailout(test)
 
-                # Check to see if we should archive this baseline mismatch.
-                if bresult == baseline.BASELINE_MISMATCH and self.archive_dir:
-                        self.do_archive(test, self._exc_info_to_string(err, test))
+    def addSkip(self, test, err):
+        """Python 2.7 adds formal support for skipped tests in unittest
+        For now, we'll record this as a success, but also save the
+        reason why we wanted to skip this test"""
+        self.addSuccess(test)
+        self.skips.append((str(test), err))
 
-                # Bail out completely if the 'bail on fail' flag is set
-                # but iff the result disagrees with the baseline.
-                if self.bailonfail and bresult == baseline.BASELINE_MISMATCH:
-                        self.dobailout(test)
+    def addPersistentSetupError(self, test, err):
+        errtype, errval = err[:2]
 
-        def addSkip(self, test, err):
-                """Python 2.7 adds formal support for skipped tests in unittest
-                For now, we'll record this as a success, but also save the
-                reason why we wanted to skip this test"""
-                self.addSuccess(test)
-                self.skips.append((str(test), err))
+        errinfo = self.format_output_and_exc(test, err)
 
-        def addPersistentSetupError(self, test, err):
-                errtype, errval = err[:2]
+        res = "# ERROR during persistent setup for {0}\n".format(test.id())
+        res += (
+            "# As a result, all test cases in this class will "
+            "result in errors!\n#\n"
+        )
 
-                errinfo = self.format_output_and_exc(test, err)
+        if errtype in ELIDABLE_ERRORS:
+            res += "#   " + str(errval)
+        else:
+            res += self.fmt_box(
+                errinfo, "Persistent Setup Error Information", "# "
+            )
+        self.stream.write(res + "\n")
 
-                res = "# ERROR during persistent setup for {0}\n".format(test.id())
-                res += "# As a result, all test cases in this class will " \
-                    "result in errors!\n#\n"
+    def addPersistentTeardownError(self, test, err):
+        errtype, errval = err[:2]
 
-                if errtype in ELIDABLE_ERRORS:
-                        res += "#   " + str(errval)
-                else:
-                        res += self.fmt_box(errinfo, \
-                            "Persistent Setup Error Information", "# ")
-                self.stream.write(res + "\n")
+        errinfo = self.format_output_and_exc(test, err)
 
-        def addPersistentTeardownError(self, test, err):
-                errtype, errval = err[:2]
+        res = "# ERROR during persistent teardown for {0}\n".format(test.id())
+        if errtype in ELIDABLE_ERRORS:
+            res += "#   " + str(errval)
+        else:
+            res += self.fmt_box(
+                errinfo, "Persistent Teardown Error Information", "# "
+            )
+        self.stream.write(res + "\n")
 
-                errinfo = self.format_output_and_exc(test, err)
+    def statename(self, test, prefix=""):
+        name = self.getDescription(test)
+        if self.output == OUTPUT_VERBOSE:
+            name = name.ljust(65) + "  "
+        elif self.output == OUTPUT_PARSEABLE:
+            name += "|"
+        elif self.output == OUTPUT_DOTS:
+            return
+        self.stream.write(name)
 
-                res = "# ERROR during persistent teardown for {0}\n".format(test.id())
-                if errtype in ELIDABLE_ERRORS:
-                        res += "#   " + str(errval)
-                else:
-                        res += self.fmt_box(errinfo, \
-                            "Persistent Teardown Error Information", "# ")
-                self.stream.write(res + "\n")
+    def startTest(self, test):
+        unittest.TestResult.startTest(self, test)
+        test.debug("_" * 75)
+        test.debug("Start:   {0}".format(self.getDescription(test)))
+        if test._testMethodDoc is not None:
+            docs = ["  " + x.strip() for x in test._testMethodDoc.splitlines()]
+            while len(docs) > 0 and docs[-1] == "":
+                del docs[-1]
+            for x in docs:
+                test.debug(x)
+        test.debug("_" * 75)
+        test.debug("")
 
-        def statename(self, test, prefix=""):
-                name = self.getDescription(test)
-                if self.output == OUTPUT_VERBOSE:
-                        name = name.ljust(65) + "  "
-                elif self.output == OUTPUT_PARSEABLE:
-                        name += "|"
-                elif self.output == OUTPUT_DOTS:
-                        return
-                self.stream.write(name)
+        if not test.debug_output:
+            self.statename(test)
 
-        def startTest(self, test):
-                unittest.TestResult.startTest(self, test)
-                test.debug("_" * 75)
-                test.debug("Start:   {0}".format(
-                    self.getDescription(test)))
-                if test._testMethodDoc is not None:
-                        docs = ["  " + x.strip() \
-                            for x in test._testMethodDoc.splitlines()]
-                        while len(docs) > 0 and docs[-1] == "":
-                                del docs[-1]
-                        for x in docs:
-                                test.debug(x)
-                test.debug("_" * 75)
-                test.debug("")
+    def printErrors(self):
+        self.stream.write("\n")
+        self.printErrorList("ERROR", self.errors)
+        self.printErrorList("FAIL", self.failures)
 
-                if not test.debug_output:
-                        self.statename(test)
-
-        def printErrors(self):
-                self.stream.write("\n")
-                self.printErrorList('ERROR', self.errors)
-                self.printErrorList('FAIL', self.failures)
-
-        def printErrorList(self, flavour, errors):
-                for test, err in errors:
-                        self.stream.write(self.separator1 + "\n")
-                        self.stream.write("{0}: {1}\n".format(
-                            flavour, self.getDescription(test)))
-                        self.stream.write(self.separator2 + "\n")
-                        self.stream.write("{0}\n".format(err))
+    def printErrorList(self, flavour, errors):
+        for test, err in errors:
+            self.stream.write(self.separator1 + "\n")
+            self.stream.write(
+                "{0}: {1}\n".format(flavour, self.getDescription(test))
+            )
+            self.stream.write(self.separator2 + "\n")
+            self.stream.write("{0}\n".format(err))
 
 
 def find_names(s):
-        """Find the module and class names for the given test suite."""
+    """Find the module and class names for the given test suite."""
 
-        l = str(s).split()
-        mod = l[0]
-        c = l[1].split(".")[0]
-        return mod, c
+    l = str(s).split()
+    mod = l[0]
+    c = l[1].split(".")[0]
+    return mod, c
+
 
 def q_makeResult(s, o, b, bail_on_fail, show_on_expected_fail, a, cov):
-        """Construct a test result for use in the parallel test suite."""
+    """Construct a test result for use in the parallel test suite."""
 
-        res = _Pkg5TestResult(s, o, b, bailonfail=bail_on_fail,
-            show_on_expected_fail=show_on_expected_fail, archive_dir=a)
-        res.coverage = cov
-        return res
+    res = _Pkg5TestResult(
+        s,
+        o,
+        b,
+        bailonfail=bail_on_fail,
+        show_on_expected_fail=show_on_expected_fail,
+        archive_dir=a,
+    )
+    res.coverage = cov
+    return res
 
-def q_run(inq, outq, i, o, baseline_filepath, bail_on_fail,
-    show_on_expected_fail, a, cov, port, suite_name):
-        """Function used to run the test suite in parallel.
 
-        The 'inq' parameter is the queue to pull from to get test suites.
+def q_run(
+    inq,
+    outq,
+    i,
+    o,
+    baseline_filepath,
+    bail_on_fail,
+    show_on_expected_fail,
+    a,
+    cov,
+    port,
+    suite_name,
+):
+    """Function used to run the test suite in parallel.
 
-        The 'outq' parameter is the queue on which to post results."""
+    The 'inq' parameter is the queue to pull from to get test suites.
 
-        # Set up the coverage environment if it's needed.
-        cov_cmd, cov_env = cov
-        cov_inst = None
-        if cov_env:
-                cov_env["COVERAGE_FILE"] += ".{0}.{1}".format(suite_name, i)
-                import coverage
-                cov_inst = coverage.coverage(
-                    data_file=cov_env["COVERAGE_FILE"], data_suffix=True)
-                cov_inst.start()
-        cov = (cov_cmd, cov_env)
-        try:
-                while True:
-                        # Get the next test suite to run.
-                        test_suite = inq.get()
-                        if test_suite == "STOP":
-                                break
+    The 'outq' parameter is the queue on which to post results."""
 
-                        # Set up the test so that it plays nicely with tests
-                        # running in other processes.
-                        test_suite.parallel_init(port + i * 20, i, cov)
-                        # Let the master process know that we have this test
-                        # suite and we're about to start running it.
-                        outq.put(("START", find_names(test_suite.tests[0]), i),
-                            block=True)
+    # Set up the coverage environment if it's needed.
+    cov_cmd, cov_env = cov
+    cov_inst = None
+    if cov_env:
+        cov_env["COVERAGE_FILE"] += ".{0}.{1}".format(suite_name, i)
+        import coverage
 
-                        buf = six.StringIO()
-                        b = baseline.ReadOnlyBaseLine(
-                            filename=baseline_filepath)
-                        b.load()
-                        # Build a _Pkg5TestResult object to use for this test.
-                        result = q_makeResult(buf, o, b, bail_on_fail,
-                            show_on_expected_fail, a, cov)
-                        try:
-                                test_suite.run(result)
-                        except TestStopException:
-                                pass
-                        otw = result.collapse()
-                        # Pull in the information stored in places other than
-                        # the _Pkg5TestResult that we need to send back to the
-                        # master process.
-                        otw.timing = list(test_suite.timing.items())
-                        otw.text = buf.getvalue()
-                        otw.baseline_failures = b.getfailures()
-                        if g_debug_output:
-                                otw.debug_buf = test_suite.get_debug_bufs()
-                        outq.put(
-                            ("RESULT", find_names(test_suite.tests[0]), i, otw),
-                            block=True)
-        finally:
-                if cov_inst:
-                        cov_inst.stop()
-                        cov_inst.save()
+        cov_inst = coverage.coverage(
+            data_file=cov_env["COVERAGE_FILE"], data_suffix=True
+        )
+        cov_inst.start()
+    cov = (cov_cmd, cov_env)
+    try:
+        while True:
+            # Get the next test suite to run.
+            test_suite = inq.get()
+            if test_suite == "STOP":
+                break
+
+            # Set up the test so that it plays nicely with tests
+            # running in other processes.
+            test_suite.parallel_init(port + i * 20, i, cov)
+            # Let the master process know that we have this test
+            # suite and we're about to start running it.
+            outq.put(("START", find_names(test_suite.tests[0]), i), block=True)
+
+            buf = six.StringIO()
+            b = baseline.ReadOnlyBaseLine(filename=baseline_filepath)
+            b.load()
+            # Build a _Pkg5TestResult object to use for this test.
+            result = q_makeResult(
+                buf, o, b, bail_on_fail, show_on_expected_fail, a, cov
+            )
+            try:
+                test_suite.run(result)
+            except TestStopException:
+                pass
+            otw = result.collapse()
+            # Pull in the information stored in places other than
+            # the _Pkg5TestResult that we need to send back to the
+            # master process.
+            otw.timing = list(test_suite.timing.items())
+            otw.text = buf.getvalue()
+            otw.baseline_failures = b.getfailures()
+            if g_debug_output:
+                otw.debug_buf = test_suite.get_debug_bufs()
+            outq.put(
+                ("RESULT", find_names(test_suite.tests[0]), i, otw), block=True
+            )
+    finally:
+        if cov_inst:
+            cov_inst.stop()
+            cov_inst.save()
 
 
 class Pkg5TestRunner(unittest.TextTestRunner):
-        """TestRunner for test suites that we want to be able to compare
-        against a result baseline."""
-        baseline = None
+    """TestRunner for test suites that we want to be able to compare
+    against a result baseline."""
 
-        def __init__(self, baseline, stream=sys.stderr, output=OUTPUT_DOTS,
-            timing_file=None, timing_history=None, bailonfail=False,
-            coverage=None,
-            show_on_expected_fail=False, archive_dir=None):
-                """Set up the test runner"""
-                # output is one of OUTPUT_DOTS, OUTPUT_VERBOSE, OUTPUT_PARSEABLE
-                super(Pkg5TestRunner, self).__init__(stream)
-                self.baseline = baseline
-                self.output = output
-                self.timing_file = timing_file
-                self.timing_history = timing_history
-                self.bailonfail = bailonfail
-                self.coverage = coverage
-                self.show_on_expected_fail = show_on_expected_fail
-                self.archive_dir = archive_dir
+    baseline = None
 
-        def _makeResult(self):
-                return _Pkg5TestResult(self.stream, self.output, self.baseline,
-                    bailonfail=self.bailonfail,
-                    show_on_expected_fail=self.show_on_expected_fail,
-                    archive_dir=self.archive_dir)
+    def __init__(
+        self,
+        baseline,
+        stream=sys.stderr,
+        output=OUTPUT_DOTS,
+        timing_file=None,
+        timing_history=None,
+        bailonfail=False,
+        coverage=None,
+        show_on_expected_fail=False,
+        archive_dir=None,
+    ):
+        """Set up the test runner"""
+        # output is one of OUTPUT_DOTS, OUTPUT_VERBOSE, OUTPUT_PARSEABLE
+        super(Pkg5TestRunner, self).__init__(stream)
+        self.baseline = baseline
+        self.output = output
+        self.timing_file = timing_file
+        self.timing_history = timing_history
+        self.bailonfail = bailonfail
+        self.coverage = coverage
+        self.show_on_expected_fail = show_on_expected_fail
+        self.archive_dir = archive_dir
 
-        @staticmethod
-        def __write_timing_info(stream, suite_name, class_list, method_list):
-                if not class_list and not method_list:
-                        return
-                tot = 0
-                print("Tests run for '{0}' Suite, broken down by class:\n".format(
-                    suite_name), file=stream)
-                for secs, cname in class_list:
-                        print("{0:>6.2f} {1}.{2}".format(
-                            secs, suite_name, cname), file=stream)
-                        tot += secs
-                        for secs, mcname, mname in method_list:
-                                if mcname != cname:
-                                        continue
-                                print("    {0:>6.2f} {1}".format(secs, mname), file=stream)
-                        print(file=stream)
-                print("{0:>6.2f} Total time\n".format(tot), file=stream)
-                print("=" * 60, file=stream)
-                print("\nTests run for '{0}' Suite, " \
-                    "sorted by time taken:\n".format(suite_name), file=stream)
-                for secs, cname, mname in method_list:
-                        print("{0:>6.2f} {1} {2}".format(secs, cname, mname), file=stream)
-                print("{0:>6.2f} Total time\n".format(tot), file=stream)
-                print("=" * 60, file=stream)
-                print("", file=stream)
+    def _makeResult(self):
+        return _Pkg5TestResult(
+            self.stream,
+            self.output,
+            self.baseline,
+            bailonfail=self.bailonfail,
+            show_on_expected_fail=self.show_on_expected_fail,
+            archive_dir=self.archive_dir,
+        )
 
-        @staticmethod
-        def __write_timing_history(stream, suite_name, method_list,
-            time_estimates):
+    @staticmethod
+    def __write_timing_info(stream, suite_name, class_list, method_list):
+        if not class_list and not method_list:
+            return
+        tot = 0
+        print(
+            "Tests run for '{0}' Suite, broken down by class:\n".format(
+                suite_name
+            ),
+            file=stream,
+        )
+        for secs, cname in class_list:
+            print(
+                "{0:>6.2f} {1}.{2}".format(secs, suite_name, cname), file=stream
+            )
+            tot += secs
+            for secs, mcname, mname in method_list:
+                if mcname != cname:
+                    continue
+                print("    {0:>6.2f} {1}".format(secs, mname), file=stream)
+            print(file=stream)
+        print("{0:>6.2f} Total time\n".format(tot), file=stream)
+        print("=" * 60, file=stream)
+        print(
+            "\nTests run for '{0}' Suite, "
+            "sorted by time taken:\n".format(suite_name),
+            file=stream,
+        )
+        for secs, cname, mname in method_list:
+            print("{0:>6.2f} {1} {2}".format(secs, cname, mname), file=stream)
+        print("{0:>6.2f} Total time\n".format(tot), file=stream)
+        print("=" * 60, file=stream)
+        print("", file=stream)
 
-                assert suite_name
-                total = 0
+    @staticmethod
+    def __write_timing_history(stream, suite_name, method_list, time_estimates):
+        assert suite_name
+        total = 0
 
-                time_estimates.setdefault(suite_name, {})
+        time_estimates.setdefault(suite_name, {})
 
-                # Calculate the new time estimates for each test suite method
-                # run in the last run.
-                for secs, cname, mname in method_list:
-                        time_estimates[suite_name].setdefault(cname,
-                            {}).setdefault(mname, secs)
-                        time_estimates[suite_name][cname][mname] = \
-                            (time_estimates[suite_name][cname][mname] + secs) \
-                            / 2.0
+        # Calculate the new time estimates for each test suite method
+        # run in the last run.
+        for secs, cname, mname in method_list:
+            time_estimates[suite_name].setdefault(cname, {}).setdefault(
+                mname, secs
+            )
+            time_estimates[suite_name][cname][mname] = (
+                time_estimates[suite_name][cname][mname] + secs
+            ) / 2.0
 
-                # For each test class, find the average time each test in the
-                # class takes to run.
-                total = 0
-                m_cnt = 0
-                for cname in time_estimates[suite_name]:
-                # for c in class_tot:
-                        if cname == "TOTAL":
-                                continue
-                        c_tot = 0
-                        c_cnt = 0
-                        for mname in time_estimates[suite_name][cname]:
-                                if mname == "CLASS":
-                                        continue
-                                c_tot += \
-                                    time_estimates[suite_name][cname][mname]
-                                c_cnt += 1
-                        total += c_tot
-                        m_cnt += c_cnt
-                        c_avg = c_tot // max(c_cnt, 1)
-                        time_estimates[suite_name][cname].setdefault(
-                            "CLASS", c_avg)
-                        time_estimates[suite_name][cname]["CLASS"] = \
-                            (time_estimates[suite_name][cname]["CLASS"] +
-                            c_avg) // 2
+        # For each test class, find the average time each test in the
+        # class takes to run.
+        total = 0
+        m_cnt = 0
+        for cname in time_estimates[suite_name]:
+            # for c in class_tot:
+            if cname == "TOTAL":
+                continue
+            c_tot = 0
+            c_cnt = 0
+            for mname in time_estimates[suite_name][cname]:
+                if mname == "CLASS":
+                    continue
+                c_tot += time_estimates[suite_name][cname][mname]
+                c_cnt += 1
+            total += c_tot
+            m_cnt += c_cnt
+            c_avg = c_tot // max(c_cnt, 1)
+            time_estimates[suite_name][cname].setdefault("CLASS", c_avg)
+            time_estimates[suite_name][cname]["CLASS"] = (
+                time_estimates[suite_name][cname]["CLASS"] + c_avg
+            ) // 2
 
-                # Calculate the average per test, regardless of which test class
-                # or method is being run.
-                tot_avg = total // max(m_cnt, 1)
-                time_estimates[suite_name].setdefault("TOTAL", tot_avg)
-                time_estimates[suite_name]["TOTAL"] = \
-                    (time_estimates[suite_name]["TOTAL"] + tot_avg) // 2
+        # Calculate the average per test, regardless of which test class
+        # or method is being run.
+        tot_avg = total // max(m_cnt, 1)
+        time_estimates[suite_name].setdefault("TOTAL", tot_avg)
+        time_estimates[suite_name]["TOTAL"] = (
+            time_estimates[suite_name]["TOTAL"] + tot_avg
+        ) // 2
 
-                # Save the estimates to disk.
-                json.dump(("1", time_estimates), stream)
+        # Save the estimates to disk.
+        json.dump(("1", time_estimates), stream)
 
-        def _do_timings(self, result, time_estimates):
-                timing = {}
-                lst = []
-                suite_name = None
+    def _do_timings(self, result, time_estimates):
+        timing = {}
+        lst = []
+        suite_name = None
 
-                for (sname, cname, mname), secs in result.timing:
-                        lst.append((secs, cname, mname))
-                        if cname not in timing:
-                                timing[cname] = 0
-                        timing[cname] += secs
-                        suite_name = sname
-                if not lst:
-                        return
-                lst.sort()
-                clst = sorted((secs, cname) for cname, secs in timing.items())
+        for (sname, cname, mname), secs in result.timing:
+            lst.append((secs, cname, mname))
+            if cname not in timing:
+                timing[cname] = 0
+            timing[cname] += secs
+            suite_name = sname
+        if not lst:
+            return
+        lst.sort()
+        clst = sorted((secs, cname) for cname, secs in timing.items())
 
-                if self.timing_history:
-                        try:
-                                # simpleson module will produce str
-                                # in Python 3, therefore fh.write()
-                                # must support str input.
-                                with open(self.timing_history + ".tmp",
-                                    "w+") as fh:
-                                        self.__write_timing_history(fh,
-                                            suite_name, lst, time_estimates)
-                                portable.rename(self.timing_history + ".tmp",
-                                    self.timing_history)
-                                os.chmod(self.timing_history, stat.S_IRUSR |
-                                    stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP |
-                                    stat.S_IROTH | stat.S_IWOTH)
-                        except KeyboardInterrupt:
-                                raise TestStopException()
+        if self.timing_history:
+            try:
+                # simpleson module will produce str
+                # in Python 3, therefore fh.write()
+                # must support str input.
+                with open(self.timing_history + ".tmp", "w+") as fh:
+                    self.__write_timing_history(
+                        fh, suite_name, lst, time_estimates
+                    )
+                portable.rename(
+                    self.timing_history + ".tmp", self.timing_history
+                )
+                os.chmod(
+                    self.timing_history,
+                    stat.S_IRUSR
+                    | stat.S_IWUSR
+                    | stat.S_IRGRP
+                    | stat.S_IWGRP
+                    | stat.S_IROTH
+                    | stat.S_IWOTH,
+                )
+            except KeyboardInterrupt:
+                raise TestStopException()
 
-                if not self.timing_file:
-                        return
-                try:
-                        fh = open(self.timing_file, "a+")
-                        opened = True
-                except KeyboardInterrupt:
-                        raise TestStopException()
-                except Exception:
-                        fh = sys.stderr
-                        opened = False
-                self.__write_timing_info(fh, suite_name, clst, lst)
-                if opened:
-                        fh.close()
+        if not self.timing_file:
+            return
+        try:
+            fh = open(self.timing_file, "a+")
+            opened = True
+        except KeyboardInterrupt:
+            raise TestStopException()
+        except Exception:
+            fh = sys.stderr
+            opened = False
+        self.__write_timing_info(fh, suite_name, clst, lst)
+        if opened:
+            fh.close()
 
-        @staticmethod
-        def estimate_method_time(time_estimates, suite_name, c, method_name):
-                # If there's an estimate for the method, use it.  If no method
-                # estimate is available, fall back to the average time each test
-                # in this class takes, if it's available.  If not class estimate
-                # is available, fall back to the average time for each test in
-                # the test suite.
+    @staticmethod
+    def estimate_method_time(time_estimates, suite_name, c, method_name):
+        # If there's an estimate for the method, use it.  If no method
+        # estimate is available, fall back to the average time each test
+        # in this class takes, if it's available.  If not class estimate
+        # is available, fall back to the average time for each test in
+        # the test suite.
 
-                if c in time_estimates[suite_name]:
-                        return time_estimates[suite_name][c].get(
-                            method_name,
-                            time_estimates[suite_name][c]["CLASS"])
-                return time_estimates[suite_name]["TOTAL"]
+        if c in time_estimates[suite_name]:
+            return time_estimates[suite_name][c].get(
+                method_name, time_estimates[suite_name][c]["CLASS"]
+            )
+        return time_estimates[suite_name]["TOTAL"]
 
-        @staticmethod
-        def __calc_remaining_time(test_classes, test_map, time_estimates,
-            procs, start_times):
-                """Given the running and unfinished tests, estimate the amount
-                of time remaining before the remaining tests finish."""
+    @staticmethod
+    def __calc_remaining_time(
+        test_classes, test_map, time_estimates, procs, start_times
+    ):
+        """Given the running and unfinished tests, estimate the amount
+        of time remaining before the remaining tests finish."""
 
-                secs = 0
-                long_pole = 0
-                for mod, c in test_classes:
-                        suite_name = mod.split(".")[0]
-                        if suite_name not in time_estimates:
-                                return None
-                        class_tot = 0
-                        for test in test_map[(mod, c)]:
-                                class_tot += \
-                                    Pkg5TestRunner.estimate_method_time(
-                                    time_estimates, suite_name, c,
-                                    test.methodName)
-                        # Some tests have been running for a while, adjust the
-                        # remaining time using this info.
-                        if (mod, c) in start_times:
-                                class_tot -= time.time() - start_times[(mod, c)]
-                        class_tot = max(class_tot, 0)
-                        secs += class_tot
-                        if class_tot > long_pole:
-                                long_pole = class_tot
-                est = secs//max(min(procs, len(test_classes)), 1)
-                return max(est, long_pole)
+        secs = 0
+        long_pole = 0
+        for mod, c in test_classes:
+            suite_name = mod.split(".")[0]
+            if suite_name not in time_estimates:
+                return None
+            class_tot = 0
+            for test in test_map[(mod, c)]:
+                class_tot += Pkg5TestRunner.estimate_method_time(
+                    time_estimates, suite_name, c, test.methodName
+                )
+            # Some tests have been running for a while, adjust the
+            # remaining time using this info.
+            if (mod, c) in start_times:
+                class_tot -= time.time() - start_times[(mod, c)]
+            class_tot = max(class_tot, 0)
+            secs += class_tot
+            if class_tot > long_pole:
+                long_pole = class_tot
+        est = secs // max(min(procs, len(test_classes)), 1)
+        return max(est, long_pole)
 
-        def test_start_display(self, started_tests, remaining_time, p_dict,
-            quiet):
-                if quiet:
-                        return
-                print("\n\n", file=self.stream)
-                print("Tests in progress:", file=self.stream)
-                for p in sorted(started_tests.keys()):
-                        print("\t{0}\t{1}\t{2} {3}".format(
-                            p, p_dict[p].pid, started_tests[p][0],
-                            started_tests[p][1]), file=self.stream)
-                if remaining_time is not None:
-                        print("Estimated time remaining {0:d} " \
-                            "seconds".format(int(round(remaining_time))),
-                            file=self.stream)
+    def test_start_display(self, started_tests, remaining_time, p_dict, quiet):
+        if quiet:
+            return
+        print("\n\n", file=self.stream)
+        print("Tests in progress:", file=self.stream)
+        for p in sorted(started_tests.keys()):
+            print(
+                "\t{0}\t{1}\t{2} {3}".format(
+                    p, p_dict[p].pid, started_tests[p][0], started_tests[p][1]
+                ),
+                file=self.stream,
+            )
+        if remaining_time is not None:
+            print(
+                "Estimated time remaining {0:d} "
+                "seconds".format(int(round(remaining_time))),
+                file=self.stream,
+            )
 
-        def test_done_display(self, result, all_tests, finished_tests,
-            started_tests, total_tests, quiet, remaining_time, output_text,
-            comm):
-                if quiet:
-                        self.stream.write(output_text)
-                        return
-                if g_debug_output:
-                        print("\n{0}".format(comm[3].debug_buf), file=sys.stderr)
-                print("\n\n", file=self.stream)
-                print("Finished {0} {1} in process {2}".format(
-                    comm[1][0], comm[1][1], comm[2]), file=self.stream)
-                print("Total test classes:{0} Finished test "
-                    "classes:{1} Running tests:{2}".format(
-                    len(all_tests), len(finished_tests), len(started_tests)),
-                    file=self.stream)
-                print("Total tests:{0} Tests run:{1} "
-                    "Errors:{2} Failures:{3} Skips:{4}".format(
-                    total_tests, result.testsRun, len(result.errors),
-                    len(result.failures), len(result.skips)),
-                    file=self.stream)
-                if remaining_time and all_tests - finished_tests:
-                        print("Estimated time remaining {0:d} "
-                            "seconds".format(int(round(remaining_time))), file=self.stream)
+    def test_done_display(
+        self,
+        result,
+        all_tests,
+        finished_tests,
+        started_tests,
+        total_tests,
+        quiet,
+        remaining_time,
+        output_text,
+        comm,
+    ):
+        if quiet:
+            self.stream.write(output_text)
+            return
+        if g_debug_output:
+            print("\n{0}".format(comm[3].debug_buf), file=sys.stderr)
+        print("\n\n", file=self.stream)
+        print(
+            "Finished {0} {1} in process {2}".format(
+                comm[1][0], comm[1][1], comm[2]
+            ),
+            file=self.stream,
+        )
+        print(
+            "Total test classes:{0} Finished test "
+            "classes:{1} Running tests:{2}".format(
+                len(all_tests), len(finished_tests), len(started_tests)
+            ),
+            file=self.stream,
+        )
+        print(
+            "Total tests:{0} Tests run:{1} "
+            "Errors:{2} Failures:{3} Skips:{4}".format(
+                total_tests,
+                result.testsRun,
+                len(result.errors),
+                len(result.failures),
+                len(result.skips),
+            ),
+            file=self.stream,
+        )
+        if remaining_time and all_tests - finished_tests:
+            print(
+                "Estimated time remaining {0:d} "
+                "seconds".format(int(round(remaining_time))),
+                file=self.stream,
+            )
 
-        @staticmethod
-        def __terminate_processes(jobs):
-                """Terminate all processes in this process's task.  This
-                assumes that test suite is running in its own task which
-                run.py should ensure."""
+    @staticmethod
+    def __terminate_processes(jobs):
+        """Terminate all processes in this process's task.  This
+        assumes that test suite is running in its own task which
+        run.py should ensure."""
 
-                signal.signal(signal.SIGTERM, signal.SIG_IGN)
-                cmd = ["pkill", "-T", "0"]
-                subprocess.call(cmd)
-                print("All spawned processes should be terminated, now "
-                    "cleaning up directories.", file=sys.stderr)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        cmd = ["pkill", "-T", "0"]
+        subprocess.call(cmd)
+        print(
+            "All spawned processes should be terminated, now "
+            "cleaning up directories.",
+            file=sys.stderr,
+        )
 
-                # Terminated test jobs may have mounted filesystems under their
-                # images and not told us about them, so we catch EBUSY, unmount,
-                # and keep trying.
-                finished = False
-                retry = 0
+        # Terminated test jobs may have mounted filesystems under their
+        # images and not told us about them, so we catch EBUSY, unmount,
+        # and keep trying.
+        finished = False
+        retry = 0
 
-                while not finished and retry < 10:
-                        try:
-                                shutil.rmtree(os.path.join(g_tempdir,
-                                    "ips.test.{0}".format(os.getpid())))
-                        except OSError as e:
-                                if e.errno == errno.ENOENT:
-                                        #
-                                        # seems to sporadically happen if we
-                                        # race with e.g. something shutting
-                                        # down which has a pid file; retry.
-                                        #
-                                        retry += 1
-                                        continue
-                                elif e.errno == errno.EBUSY:
-                                        ret = subprocess.call(
-                                            ["/usr/sbin/umount",
-                                            e.filename])
-                                        # if the umount failed, bump retry so
-                                        # we won't be stuck doing this forever.
-                                        if ret != 0:
-                                                retry += 1
-                                        continue
-                                else:
-                                        raise
-                        else:
-                                finished = True
-
-                if not finished:
-                        print("Not all directories removed!", file=sys.stderr)
+        while not finished and retry < 10:
+            try:
+                shutil.rmtree(
+                    os.path.join(g_tempdir, "ips.test.{0}".format(os.getpid()))
+                )
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    #
+                    # seems to sporadically happen if we
+                    # race with e.g. something shutting
+                    # down which has a pid file; retry.
+                    #
+                    retry += 1
+                    continue
+                elif e.errno == errno.EBUSY:
+                    ret = subprocess.call(["/usr/sbin/umount", e.filename])
+                    # if the umount failed, bump retry so
+                    # we won't be stuck doing this forever.
+                    if ret != 0:
+                        retry += 1
+                    continue
                 else:
-                        print("Directories successfully removed.", file=sys.stderr)
-                sys.exit(1)
+                    raise
+            else:
+                finished = True
 
-        def run(self, suite_list, jobs, port, time_estimates, quiet,
-            baseline_filepath):
-                "Run the given test case or test suite."
+        if not finished:
+            print("Not all directories removed!", file=sys.stderr)
+        else:
+            print("Directories successfully removed.", file=sys.stderr)
+        sys.exit(1)
 
-                terminate = False
+    def run(
+        self, suite_list, jobs, port, time_estimates, quiet, baseline_filepath
+    ):
+        "Run the given test case or test suite."
 
-                all_tests = set()
-                started_tests = {}
-                finished_tests = set()
-                total_tests = 0
-                test_map = {}
+        terminate = False
 
-                start_times = {}
-                suite_name = None
+        all_tests = set()
+        started_tests = {}
+        finished_tests = set()
+        total_tests = 0
+        test_map = {}
 
-                # test case setUp() may require running pkg commands
-                # so setup a fakeroot to run them from.
-                fakeroot, fakeroot_cmdpath = fakeroot_create()
+        start_times = {}
+        suite_name = None
 
-                inq = multiprocessing.Queue(len(suite_list) + jobs)
-                for t in suite_list:
-                        if not t.tests:
-                                continue
-                        mod, c = find_names(t.tests[0])
-                        for test in t.tests:
-                                tmp = find_names(test)
-                                if suite_name is None:
-                                        suite_name = test.suite_name
-                                else:
-                                        assert suite_name == test.suite_name
-                                if tmp[0] != mod or tmp[1] != c:
-                                        raise RuntimeError("tmp:{0} mod:{1} "
-                                            "c:{2}".format(tmp, mod, c))
-                        all_tests.add((mod, c))
-                        t.pkg_cmdpath = fakeroot_cmdpath
-                        if jobs > 1:
-                                t.debug_output = False
-                        inq.put(t, block=True)
-                        total_tests += len(t.tests)
-                        test_map[(mod, c)] = t.tests
+        # test case setUp() may require running pkg commands
+        # so setup a fakeroot to run them from.
+        fakeroot, fakeroot_cmdpath = fakeroot_create()
 
-                result = _CombinedResult()
-                if not all_tests:
-                        try:
-                                shutil.rmtree(os.path.join(g_tempdir,
-                                    "ips.test.{0}".format(os.getpid())))
-                        except OSError as e:
-                                if e.errno != errno.ENOENT:
-                                        raise
-                        return result
+        inq = multiprocessing.Queue(len(suite_list) + jobs)
+        for t in suite_list:
+            if not t.tests:
+                continue
+            mod, c = find_names(t.tests[0])
+            for test in t.tests:
+                tmp = find_names(test)
+                if suite_name is None:
+                    suite_name = test.suite_name
+                else:
+                    assert suite_name == test.suite_name
+                if tmp[0] != mod or tmp[1] != c:
+                    raise RuntimeError(
+                        "tmp:{0} mod:{1} " "c:{2}".format(tmp, mod, c)
+                    )
+            all_tests.add((mod, c))
+            t.pkg_cmdpath = fakeroot_cmdpath
+            if jobs > 1:
+                t.debug_output = False
+            inq.put(t, block=True)
+            total_tests += len(t.tests)
+            test_map[(mod, c)] = t.tests
 
-                assert suite_name is not None
+        result = _CombinedResult()
+        if not all_tests:
+            try:
+                shutil.rmtree(
+                    os.path.join(g_tempdir, "ips.test.{0}".format(os.getpid()))
+                )
+            except OSError as e:
+                if e.errno != errno.ENOENT:
+                    raise
+            return result
 
-                startTime = time.time()
-                outq = multiprocessing.Queue(jobs * 10)
-                p_dict = {}
-                try:
-                        for i in range(0, jobs):
-                                p_dict[i] = multiprocessing.Process(
-                                    target=q_run,
-                                    args=(inq, outq, i, self.output,
-                                    baseline_filepath, self.bailonfail,
-                                    self.show_on_expected_fail,
-                                    self.archive_dir, self.coverage, port,
-                                    suite_name))
-                                p_dict[i].start()
-                except KeyboardInterrupt:
-                        self.__terminate_processes(jobs)
-                try:
-                        while all_tests - finished_tests:
-                                comm = outq.get(block=True)
-                                remaining_time = None
-                                if time_estimates:
-                                        remaining_time = \
-                                            self.__calc_remaining_time(
-                                            all_tests - finished_tests,
-                                            test_map, time_estimates,
-                                            jobs, start_times)
+        assert suite_name is not None
 
-                                if comm[0] == "START":
-                                        if comm[1] not in all_tests:
-                                                raise RuntimeError("Got "
-                                                    "unexpected start "
-                                                    "comm:{0}".format(comm))
-                                        started_tests[comm[2]] = comm[1]
-                                        start_times[comm[1]] = time.time()
-                                        self.test_start_display(started_tests,
-                                            remaining_time, p_dict, quiet)
-                                elif comm[0] == "RESULT":
-                                        partial_result = comm[3]
-                                        result.combine(partial_result)
-                                        finished_tests.add(comm[1])
-                                        for n, r in \
-                                            partial_result.baseline_failures:
-                                                self.baseline.handleresult(n, r)
-                                        if started_tests[comm[2]] != comm[1]:
-                                                raise RuntimeError("mismatch")
-                                        del started_tests[comm[2]]
-                                        del start_times[comm[1]]
-                                        self.test_done_display(result,
-                                            all_tests, finished_tests,
-                                            started_tests, total_tests, quiet,
-                                            remaining_time, partial_result.text,
-                                            comm)
-                                else:
-                                        raise RuntimeError("unexpected "
-                                            "communication:{0}".format(comm))
-                                if self.bailonfail and \
-                                    (result.errors or result.failures):
-                                        raise TestStopException()
-                                # Check to make sure that all processes are
-                                # still running.
-                                broken = set()
-                                for i in p_dict:
-                                        if not p_dict[i].is_alive():
-                                                broken.add(i)
-                                if broken:
+        startTime = time.time()
+        outq = multiprocessing.Queue(jobs * 10)
+        p_dict = {}
+        try:
+            for i in range(0, jobs):
+                p_dict[i] = multiprocessing.Process(
+                    target=q_run,
+                    args=(
+                        inq,
+                        outq,
+                        i,
+                        self.output,
+                        baseline_filepath,
+                        self.bailonfail,
+                        self.show_on_expected_fail,
+                        self.archive_dir,
+                        self.coverage,
+                        port,
+                        suite_name,
+                    ),
+                )
+                p_dict[i].start()
+        except KeyboardInterrupt:
+            self.__terminate_processes(jobs)
+        try:
+            while all_tests - finished_tests:
+                comm = outq.get(block=True)
+                remaining_time = None
+                if time_estimates:
+                    remaining_time = self.__calc_remaining_time(
+                        all_tests - finished_tests,
+                        test_map,
+                        time_estimates,
+                        jobs,
+                        start_times,
+                    )
 
-                                        print("The following "
-                                            "processes have died, "
-                                            "terminating the others: {0}".format(
-                                            ",".join([
-                                                str(p_dict[i].pid)
-                                                for i in sorted(broken)
-                                            ])), file=sys.stderr)
-                                        raise TestStopException()
-                        for i in range(0, jobs * 2):
-                                inq.put("STOP")
-                        for p in p_dict:
-                                p_dict[p].join()
-                except (KeyboardInterrupt, TestStopException):
-                        terminate = True
-                except Exception as e:
-                        print(e)
-                        terminate = True
-                        raise
-                finally:
-                        try:
-                                result.stream = self.stream
-                                stopTime = time.time()
-                                timeTaken = stopTime - startTime
+                if comm[0] == "START":
+                    if comm[1] not in all_tests:
+                        raise RuntimeError(
+                            "Got " "unexpected start " "comm:{0}".format(comm)
+                        )
+                    started_tests[comm[2]] = comm[1]
+                    start_times[comm[1]] = time.time()
+                    self.test_start_display(
+                        started_tests, remaining_time, p_dict, quiet
+                    )
+                elif comm[0] == "RESULT":
+                    partial_result = comm[3]
+                    result.combine(partial_result)
+                    finished_tests.add(comm[1])
+                    for n, r in partial_result.baseline_failures:
+                        self.baseline.handleresult(n, r)
+                    if started_tests[comm[2]] != comm[1]:
+                        raise RuntimeError("mismatch")
+                    del started_tests[comm[2]]
+                    del start_times[comm[1]]
+                    self.test_done_display(
+                        result,
+                        all_tests,
+                        finished_tests,
+                        started_tests,
+                        total_tests,
+                        quiet,
+                        remaining_time,
+                        partial_result.text,
+                        comm,
+                    )
+                else:
+                    raise RuntimeError(
+                        "unexpected " "communication:{0}".format(comm)
+                    )
+                if self.bailonfail and (result.errors or result.failures):
+                    raise TestStopException()
+                # Check to make sure that all processes are
+                # still running.
+                broken = set()
+                for i in p_dict:
+                    if not p_dict[i].is_alive():
+                        broken.add(i)
+                if broken:
+                    print(
+                        "The following "
+                        "processes have died, "
+                        "terminating the others: {0}".format(
+                            ",".join(
+                                [str(p_dict[i].pid) for i in sorted(broken)]
+                            )
+                        ),
+                        file=sys.stderr,
+                    )
+                    raise TestStopException()
+            for i in range(0, jobs * 2):
+                inq.put("STOP")
+            for p in p_dict:
+                p_dict[p].join()
+        except (KeyboardInterrupt, TestStopException):
+            terminate = True
+        except Exception as e:
+            print(e)
+            terminate = True
+            raise
+        finally:
+            try:
+                result.stream = self.stream
+                stopTime = time.time()
+                timeTaken = stopTime - startTime
 
-                                run = result.testsRun
-                                if run > 0:
-                                        if self.output != OUTPUT_VERBOSE:
-                                                result.printErrors()
-                                                self.stream.write("# " +
-                                                    result.separator2 + "\n")
-                                        self.stream.write("\n# Ran {0:d} test{1} "
-                                            "in {2:>.3f}s - skipped {3:d} tests.\n".format(
-                                            run, run != 1 and "s" or "",
-                                            timeTaken, len(result.skips)))
+                run = result.testsRun
+                if run > 0:
+                    if self.output != OUTPUT_VERBOSE:
+                        result.printErrors()
+                        self.stream.write("# " + result.separator2 + "\n")
+                    self.stream.write(
+                        "\n# Ran {0:d} test{1} "
+                        "in {2:>.3f}s - skipped {3:d} tests.\n".format(
+                            run,
+                            run != 1 and "s" or "",
+                            timeTaken,
+                            len(result.skips),
+                        )
+                    )
 
-                                        if result.wasSkipped() and \
-                                            self.output == OUTPUT_VERBOSE:
-                                                self.stream.write("Skipped "
-                                                    "tests:\n")
-                                                for test,reason in result.skips:
-                                                        self.stream.write(
-                                                            "{0}: {1}\n".format(
-                                                            test, reason))
-                                        self.stream.write("\n")
-                                if not result.wasSuccessful():
-                                        self.stream.write("FAILED (")
-                                        success = result.num_successes
-                                        mismatches = result.mismatches
-                                        failed, errored = map(len,
-                                            (result.failures, result.errors))
-                                        self.stream.write("successes={0:d}, ".format(
-                                            success))
-                                        self.stream.write("failures={0:d}, ".format(
-                                            failed))
-                                        self.stream.write("errors={0:d}, ".format(
-                                            errored))
-                                        self.stream.write("mismatches={0:d}".format(
-                                            mismatches))
-                                        self.stream.write(")\n")
+                    if result.wasSkipped() and self.output == OUTPUT_VERBOSE:
+                        self.stream.write("Skipped " "tests:\n")
+                        for test, reason in result.skips:
+                            self.stream.write("{0}: {1}\n".format(test, reason))
+                    self.stream.write("\n")
+                if not result.wasSuccessful():
+                    self.stream.write("FAILED (")
+                    success = result.num_successes
+                    mismatches = result.mismatches
+                    failed, errored = map(len, (result.failures, result.errors))
+                    self.stream.write("successes={0:d}, ".format(success))
+                    self.stream.write("failures={0:d}, ".format(failed))
+                    self.stream.write("errors={0:d}, ".format(errored))
+                    self.stream.write("mismatches={0:d}".format(mismatches))
+                    self.stream.write(")\n")
 
-                                self._do_timings(result, time_estimates)
-                        finally:
-                                if terminate:
-                                        self.__terminate_processes(jobs)
-                                shutil.rmtree(os.path.join(g_tempdir,
-                                    "ips.test.{0}".format(os.getpid())))
-                return result
+                self._do_timings(result, time_estimates)
+            finally:
+                if terminate:
+                    self.__terminate_processes(jobs)
+                shutil.rmtree(
+                    os.path.join(g_tempdir, "ips.test.{0}".format(os.getpid()))
+                )
+        return result
 
 
 class Pkg5TestSuite(unittest.TestSuite):
-        """Test suite that extends unittest.TestSuite to handle persistent
-        tests.  Persistent tests are ones that are able to only call their
-        setUp/tearDown functions once per class, instead of before and after
-        every test case.  Aside from actually running the test it defers the
-        majority of its work to unittest.TestSuite.
+    """Test suite that extends unittest.TestSuite to handle persistent
+    tests.  Persistent tests are ones that are able to only call their
+    setUp/tearDown functions once per class, instead of before and after
+    every test case.  Aside from actually running the test it defers the
+    majority of its work to unittest.TestSuite.
 
-        To make a test class into a persistent one, add this class
-        variable declaration:
-                persistent_setup = True
-        """
+    To make a test class into a persistent one, add this class
+    variable declaration:
+            persistent_setup = True
+    """
 
-        def __init__(self, tests=()):
-                unittest.TestSuite.__init__(self, tests)
-                self.timing = {}
-                self.__pid = os.getpid()
-                self.pkg_cmdpath = "TOXIC"
-                self.__debug_output = g_debug_output
+    def __init__(self, tests=()):
+        unittest.TestSuite.__init__(self, tests)
+        self.timing = {}
+        self.__pid = os.getpid()
+        self.pkg_cmdpath = "TOXIC"
+        self.__debug_output = g_debug_output
 
-                # The site module deletes the function to change the
-                # default encoding so a forced reload of sys has to
-                # be done at least once.
-                reload(sys)
+        # The site module deletes the function to change the
+        # default encoding so a forced reload of sys has to
+        # be done at least once.
+        reload(sys)
 
-        def cleanup_and_die(self, inst, info):
-                print("\nCtrl-C: Attempting cleanup during {0}".format(info),
-                    file=sys.stderr)
+    def cleanup_and_die(self, inst, info):
+        print(
+            "\nCtrl-C: Attempting cleanup during {0}".format(info),
+            file=sys.stderr,
+        )
 
-                if hasattr(inst, "killalldepots"):
-                        print("Killing depots...", file=sys.stderr)
-                        inst.killalldepots()
-                print("Stopping tests...", file=sys.stderr)
-                raise TestStopException()
+        if hasattr(inst, "killalldepots"):
+            print("Killing depots...", file=sys.stderr)
+            inst.killalldepots()
+        print("Stopping tests...", file=sys.stderr)
+        raise TestStopException()
 
-        def run(self, result):
-                self.timing = {}
-                inst = None
-                tdf = None
-                try:
-                        persistent_setup = getattr(self._tests[0],
-                            "persistent_setup", False)
-                except IndexError:
-                        # No tests; that's ok.
-                        return
+    def run(self, result):
+        self.timing = {}
+        inst = None
+        tdf = None
+        try:
+            persistent_setup = getattr(
+                self._tests[0], "persistent_setup", False
+            )
+        except IndexError:
+            # No tests; that's ok.
+            return
 
-                # This is needed because the import of some modules (such as
-                # pygtk or pango) causes the default encoding for Python to be
-                # changed which can can cause tests to succeed when they should
-                # fail due to unicode issues:
-                #     https://bugzilla.gnome.org/show_bug.cgi?id=132040
-                if six.PY2:
-                        default_utf8 = getattr(self._tests[0], "default_utf8",
-                            False)
-                        if not default_utf8:
-                                # Now reset to the default a standard Python
-                                # distribution uses.
-                                sys.setdefaultencoding("ascii")
-                        else:
-                                sys.setdefaultencoding("utf-8")
+        # This is needed because the import of some modules (such as
+        # pygtk or pango) causes the default encoding for Python to be
+        # changed which can can cause tests to succeed when they should
+        # fail due to unicode issues:
+        #     https://bugzilla.gnome.org/show_bug.cgi?id=132040
+        if six.PY2:
+            default_utf8 = getattr(self._tests[0], "default_utf8", False)
+            if not default_utf8:
+                # Now reset to the default a standard Python
+                # distribution uses.
+                sys.setdefaultencoding("ascii")
+            else:
+                sys.setdefaultencoding("utf-8")
 
-                def setUp_donothing():
-                        pass
+        def setUp_donothing():
+            pass
 
-                def tearDown_donothing():
-                        pass
+        def tearDown_donothing():
+            pass
 
-                def setUp_dofail():
-                        raise TestSkippedException(
-                            "Persistent setUp Failed, skipping test.")
+        def setUp_dofail():
+            raise TestSkippedException(
+                "Persistent setUp Failed, skipping test."
+            )
 
-                env_sanitize(self.pkg_cmdpath)
+        env_sanitize(self.pkg_cmdpath)
 
-                if persistent_setup:
-                        setUpFailed = False
+        if persistent_setup:
+            setUpFailed = False
 
-                        # Save a reference to the tearDown func and neuter
-                        # normal per-test-function teardown.
-                        inst, tdf = self._tests[0].getTeardownFunc()
-                        inst.reallytearDown = tdf
-                        inst.tearDown = tearDown_donothing
+            # Save a reference to the tearDown func and neuter
+            # normal per-test-function teardown.
+            inst, tdf = self._tests[0].getTeardownFunc()
+            inst.reallytearDown = tdf
+            inst.tearDown = tearDown_donothing
 
-                        if result.coverage:
-                                inst.coverage_cmd, inst.coverage_env = result.coverage
-                        else:
-                                inst.coverage_cmd, inst.coverage_env = "", {}
+            if result.coverage:
+                inst.coverage_cmd, inst.coverage_env = result.coverage
+            else:
+                inst.coverage_cmd, inst.coverage_env = "", {}
 
-                        try:
-                                inst.setUp()
-                        except KeyboardInterrupt:
-                                self.cleanup_and_die(inst, "persistent setup")
-                        except:
-                                result.addPersistentSetupError(inst, sys.exc_info())
-                                setUpFailed = True
-                                # XXX do cleanup?
+            try:
+                inst.setUp()
+            except KeyboardInterrupt:
+                self.cleanup_and_die(inst, "persistent setup")
+            except:
+                result.addPersistentSetupError(inst, sys.exc_info())
+                setUpFailed = True
+                # XXX do cleanup?
 
-                        # If the setUp function didn't work, then cause
-                        # every test case to fail.
-                        if setUpFailed:
-                                inst.setUp = setUp_dofail
-                        else:
-                                inst.setUp = setUp_donothing
+            # If the setUp function didn't work, then cause
+            # every test case to fail.
+            if setUpFailed:
+                inst.setUp = setUp_dofail
+            else:
+                inst.setUp = setUp_donothing
 
-                for test in self._tests:
-                        if result.shouldStop:
-                                break
-                        real_test_name = test._testMethodName
-                        suite_name = test.suite_name
-                        cname = test.__class__.__name__
+        for test in self._tests:
+            if result.shouldStop:
+                break
+            real_test_name = test._testMethodName
+            suite_name = test.suite_name
+            cname = test.__class__.__name__
 
-                        #
-                        # Update test environment settings. We redo this
-                        # before running each test case since previously
-                        # executed test cases may have messed with these
-                        # environment settings.
-                        #
-                        env_sanitize(self.pkg_cmdpath, dv_keep=["smf_cmds_dir"])
+            #
+            # Update test environment settings. We redo this
+            # before running each test case since previously
+            # executed test cases may have messed with these
+            # environment settings.
+            #
+            env_sanitize(self.pkg_cmdpath, dv_keep=["smf_cmds_dir"])
 
-                        # Populate test with the data from the instance
-                        # already constructed, but update the method name.
-                        # We need to do this so that we have all the state
-                        # that the object is populated with when setUp() is
-                        # called (depot controller list, etc).
-                        if persistent_setup:
-                                name = test._testMethodName
-                                doc = test._testMethodDoc
-                                buf = test.get_debugbuf()
-                                rtest = copy.copy(inst)
-                                rtest._testMethodName = name
-                                rtest._testMethodDoc = doc
-                                rtest.persistent_setup_copy(inst)
-                                rtest.set_debugbuf(buf)
-                                setup_logging(rtest)
-                        else:
-                                rtest = test
+            # Populate test with the data from the instance
+            # already constructed, but update the method name.
+            # We need to do this so that we have all the state
+            # that the object is populated with when setUp() is
+            # called (depot controller list, etc).
+            if persistent_setup:
+                name = test._testMethodName
+                doc = test._testMethodDoc
+                buf = test.get_debugbuf()
+                rtest = copy.copy(inst)
+                rtest._testMethodName = name
+                rtest._testMethodDoc = doc
+                rtest.persistent_setup_copy(inst)
+                rtest.set_debugbuf(buf)
+                setup_logging(rtest)
+            else:
+                rtest = test
 
-                        test_start = time.time()
-                        rtest(result)
-                        test_end = time.time()
-                        self.timing[suite_name, cname, real_test_name] = \
-                            test_end - test_start
+            test_start = time.time()
+            rtest(result)
+            test_end = time.time()
+            self.timing[suite_name, cname, real_test_name] = (
+                test_end - test_start
+            )
 
-                        # If rtest is a copy of test, then we need to copy
-                        # rtest's buffer back to test's so that it has the
-                        # output from the run.
-                        if persistent_setup:
-                                test.set_debugbuf(rtest.get_debugbuf())
+            # If rtest is a copy of test, then we need to copy
+            # rtest's buffer back to test's so that it has the
+            # output from the run.
+            if persistent_setup:
+                test.set_debugbuf(rtest.get_debugbuf())
 
-                        for fs in getattr(rtest, "fs", ()):
-                                subprocess.call(["/usr/sbin/umount", fs])
+            for fs in getattr(rtest, "fs", ()):
+                subprocess.call(["/usr/sbin/umount", fs])
 
-                if persistent_setup:
-                        try:
-                                inst.reallytearDown()
-                        except KeyboardInterrupt:
-                                self.cleanup_and_die(inst, "persistent teardown")
-                        except:
-                                result.addPersistentTeardownError(inst, sys.exc_info())
+        if persistent_setup:
+            try:
+                inst.reallytearDown()
+            except KeyboardInterrupt:
+                self.cleanup_and_die(inst, "persistent teardown")
+            except:
+                result.addPersistentTeardownError(inst, sys.exc_info())
 
-                # Try to ensure that all depots have been nuked.
-                if hasattr(inst, "killalldepots"):
-                        inst.killalldepots()
+        # Try to ensure that all depots have been nuked.
+        if hasattr(inst, "killalldepots"):
+            inst.killalldepots()
 
-        def parallel_init(self, p, i, cov):
-                for t in self._tests:
-                        t.base_port = p
-                        t.ident = i
-                        t.coverage = cov
-                        t.pkg_cmdpath = self.pkg_cmdpath
+    def parallel_init(self, p, i, cov):
+        for t in self._tests:
+            t.base_port = p
+            t.ident = i
+            t.coverage = cov
+            t.pkg_cmdpath = self.pkg_cmdpath
 
-        def test_count(self):
-                return len(self._tests)
+    def test_count(self):
+        return len(self._tests)
 
-        @property
-        def tests(self):
-                return [t for t in self._tests]
+    @property
+    def tests(self):
+        return [t for t in self._tests]
 
-        def __set_debug_output(self, v):
-                self.__debug_output = v
-                for t in self._tests:
-                        t.debug_output = v
+    def __set_debug_output(self, v):
+        self.__debug_output = v
+        for t in self._tests:
+            t.debug_output = v
 
-        def __get_debug_output(self):
-                return self.__debug_output
+    def __get_debug_output(self):
+        return self.__debug_output
 
-        debug_output = property(__get_debug_output, __set_debug_output)
+    debug_output = property(__get_debug_output, __set_debug_output)
 
-        def get_debug_bufs(self):
-                res = ""
-                for t in self._tests:
-                        res += "\n".join(
-                            ["# {0}".format(l) for l in t.get_debugbuf().splitlines()])
-                        res += "\n"
-                return res
+    def get_debug_bufs(self):
+        res = ""
+        for t in self._tests:
+            res += "\n".join(
+                ["# {0}".format(l) for l in t.get_debugbuf().splitlines()]
+            )
+            res += "\n"
+        return res
 
 
 def get_su_wrap_user(uid_gid=False):
-        for u in ["noaccess", "nobody"]:
-                try:
-                        pw = pwd.getpwnam(u)
-                        if uid_gid:
-                                return operator.attrgetter(
-                                    'pw_uid', 'pw_gid')(pw)
-                        return u
-                except (KeyError, NameError):
-                        pass
-        raise RuntimeError("Unable to determine user for su.")
+    for u in ["noaccess", "nobody"]:
+        try:
+            pw = pwd.getpwnam(u)
+            if uid_gid:
+                return operator.attrgetter("pw_uid", "pw_gid")(pw)
+            return u
+        except (KeyError, NameError):
+            pass
+    raise RuntimeError("Unable to determine user for su.")
 
 
 class DepotTracebackException(Pkg5CommonException):
-        def __init__(self, logfile, output):
-                Pkg5CommonException.__init__(self)
-                self.__logfile = logfile
-                self.__output = output
+    def __init__(self, logfile, output):
+        Pkg5CommonException.__init__(self)
+        self.__logfile = logfile
+        self.__output = output
 
-        def __str__(self):
-                str = "During this test, a depot Traceback was detected.\n"
-                str += "Log file: {0}.\n".format(self.__logfile)
-                str += "Log file output is:\n"
-                str += self.format_output(None, self.__output)
-                return str
+    def __str__(self):
+        str = "During this test, a depot Traceback was detected.\n"
+        str += "Log file: {0}.\n".format(self.__logfile)
+        str += "Log file output is:\n"
+        str += self.format_output(None, self.__output)
+        return str
+
 
 class TracebackException(Pkg5CommonException):
-        def __init__(self, command, output=None, comment=None, debug=None):
-                Pkg5CommonException.__init__(self)
-                self.__command = command
-                self.__output = output
-                self.__comment = comment
-                self.__debug = debug
+    def __init__(self, command, output=None, comment=None, debug=None):
+        Pkg5CommonException.__init__(self)
+        self.__command = command
+        self.__output = output
+        self.__comment = comment
+        self.__debug = debug
 
-        def __str__(self):
-                if self.__comment is None and self.__output is None:
-                        return (Exception.__str__(self))
+    def __str__(self):
+        if self.__comment is None and self.__output is None:
+            return Exception.__str__(self)
 
-                str = ""
-                str += self.format_comment(self.__comment)
-                str += self.format_output(self.__command, self.__output)
-                if self.__debug is not None and self.__debug != "":
-                        str += self.format_debug(self.__debug)
-                return str
+        str = ""
+        str += self.format_comment(self.__comment)
+        str += self.format_output(self.__command, self.__output)
+        if self.__debug is not None and self.__debug != "":
+            str += self.format_debug(self.__debug)
+        return str
+
 
 class UnexpectedExitCodeException(Pkg5CommonException):
-        def __init__(self, command, expected, got, output=None, comment=None):
-                Pkg5CommonException.__init__(self)
-                self.__command = command
-                self.__output = output
-                self.__expected = expected
-                self.__got = got
-                self.__comment = comment
+    def __init__(self, command, expected, got, output=None, comment=None):
+        Pkg5CommonException.__init__(self)
+        self.__command = command
+        self.__output = output
+        self.__expected = expected
+        self.__got = got
+        self.__comment = comment
 
-        def __str__(self):
-                if self.__comment is None and self.__output is None:
-                        return (Exception.__str__(self))
+    def __str__(self):
+        if self.__comment is None and self.__output is None:
+            return Exception.__str__(self)
 
-                str = ""
-                str += self.format_comment(self.__comment)
+        str = ""
+        str += self.format_comment(self.__comment)
 
-                str += "  Invoked: {0}\n".format(self.__command)
-                str += "  Expected exit status: {0}.  Got: {1:d}.".format(
-                    self.__expected, self.__got)
+        str += "  Invoked: {0}\n".format(self.__command)
+        str += "  Expected exit status: {0}.  Got: {1:d}.".format(
+            self.__expected, self.__got
+        )
 
-                str += self.format_output(self.__command, self.__output)
-                return str
+        str += self.format_output(self.__command, self.__output)
+        return str
 
-        @property
-        def exitcode(self):
-                return self.__got
+    @property
+    def exitcode(self):
+        return self.__got
+
 
 class PkgSendOpenException(Pkg5CommonException):
-        def __init__(self, com = ""):
-                Pkg5CommonException.__init__(self, com)
+    def __init__(self, com=""):
+        Pkg5CommonException.__init__(self, com)
+
 
 class CliTestCase(Pkg5TestCase):
-        bail_on_fail = False
+    bail_on_fail = False
 
-        image_files = []
+    image_files = []
 
-        def setUp(self, image_count=1):
-                Pkg5TestCase.setUp(self)
+    def setUp(self, image_count=1):
+        Pkg5TestCase.setUp(self)
 
-                self.__imgs_path = {}
-                self.__imgs_index = -1
+        self.__imgs_path = {}
+        self.__imgs_index = -1
 
-                for i in range(0, image_count):
-                        path = os.path.join(self.test_root, "image{0:d}".format(i))
-                        self.__imgs_path[i] = path
+        for i in range(0, image_count):
+            path = os.path.join(self.test_root, "image{0:d}".format(i))
+            self.__imgs_path[i] = path
 
-                self.set_image(0)
+        self.set_image(0)
 
-        def tearDown(self):
-                Pkg5TestCase.tearDown(self)
+    def tearDown(self):
+        Pkg5TestCase.tearDown(self)
 
-        def persistent_setup_copy(self, orig):
-                Pkg5TestCase.persistent_setup_copy(self, orig)
-                self.__imgs_path = copy.copy(orig.__imgs_path)
+    def persistent_setup_copy(self, orig):
+        Pkg5TestCase.persistent_setup_copy(self, orig)
+        self.__imgs_path = copy.copy(orig.__imgs_path)
 
-        def set_image(self, ii):
-                # ii is the image index
-                if self.__imgs_index == ii:
-                        return
+    def set_image(self, ii):
+        # ii is the image index
+        if self.__imgs_index == ii:
+            return
 
-                self.__imgs_index = ii
-                path = self.__imgs_path[self.__imgs_index]
-                assert path and path != "/"
+        self.__imgs_index = ii
+        path = self.__imgs_path[self.__imgs_index]
+        assert path and path != "/"
 
-                self.debug("image {0:d} selected: {1}".format(ii, path))
+        self.debug("image {0:d} selected: {1}".format(ii, path))
 
-        def set_img_path(self, path):
-                self.__imgs_path[self.__imgs_index] = path
+    def set_img_path(self, path):
+        self.__imgs_path[self.__imgs_index] = path
 
-        def img_index(self):
-                return self.__imgs_index
+    def img_index(self):
+        return self.__imgs_index
 
-        def img_path(self, ii=None):
-                if ii != None:
-                        return self.__imgs_path[ii]
-                return self.__imgs_path[self.__imgs_index]
+    def img_path(self, ii=None):
+        if ii != None:
+            return self.__imgs_path[ii]
+        return self.__imgs_path[self.__imgs_index]
 
-        def get_img_path(self):
-                # for backward compatibilty
-                return self.img_path()
+    def get_img_path(self):
+        # for backward compatibilty
+        return self.img_path()
 
-        def get_img_file_path(self, relpath):
-                """Given a path relative to root, return the absolute path of
-                the item in the image."""
+    def get_img_file_path(self, relpath):
+        """Given a path relative to root, return the absolute path of
+        the item in the image."""
 
-                return os.path.join(self.img_path(), relpath)
+        return os.path.join(self.img_path(), relpath)
 
-        def get_img_api_obj(self, cmd_path=None, ii=None, img_path=None):
-                progresstracker = pkg.client.progress.NullProgressTracker()
-                if not cmd_path:
-                        cmd_path = os.path.join(self.img_path(), "pkg")
-                if not img_path:
-                        img_path = self.img_path(ii=ii)
-                res = pkg.client.api.ImageInterface(img_path,
-                    CLIENT_API_VERSION, progresstracker, lambda x: False,
-                    PKG_CLIENT_NAME, cmdpath=cmd_path)
-                return res
+    def get_img_api_obj(self, cmd_path=None, ii=None, img_path=None):
+        progresstracker = pkg.client.progress.NullProgressTracker()
+        if not cmd_path:
+            cmd_path = os.path.join(self.img_path(), "pkg")
+        if not img_path:
+            img_path = self.img_path(ii=ii)
+        res = pkg.client.api.ImageInterface(
+            img_path,
+            CLIENT_API_VERSION,
+            progresstracker,
+            lambda x: False,
+            PKG_CLIENT_NAME,
+            cmdpath=cmd_path,
+        )
+        return res
 
-        def __setup_signing_files(self):
-                if not getattr(self, "need_ro_data", False):
-                        return
-                # Set up the trust anchor directory
-                self.ta_dir = os.path.join(self.img_path(), "etc/ssl/pkg")
-                os.makedirs(self.ta_dir)
-                for f in self.image_files:
-                        with open(os.path.join(self.img_path(), f), "wb") as fh:
-                                fh.close()
+    def __setup_signing_files(self):
+        if not getattr(self, "need_ro_data", False):
+            return
+        # Set up the trust anchor directory
+        self.ta_dir = os.path.join(self.img_path(), "etc/ssl/pkg")
+        os.makedirs(self.ta_dir)
+        for f in self.image_files:
+            with open(os.path.join(self.img_path(), f), "wb") as fh:
+                fh.close()
 
-        def image_create(self, repourl=None, destroy=True, fs=(),
-            img_path=None, **kwargs):
-                """A convenience wrapper for callers that only need basic image
-                creation functionality.  This wrapper creates a full (as opposed
-                to user) image using the pkg.client.api and returns the related
-                API object."""
+    def image_create(
+        self, repourl=None, destroy=True, fs=(), img_path=None, **kwargs
+    ):
+        """A convenience wrapper for callers that only need basic image
+        creation functionality.  This wrapper creates a full (as opposed
+        to user) image using the pkg.client.api and returns the related
+        API object."""
 
-                if img_path is None:
-                        img_path = self.img_path()
+        if img_path is None:
+            img_path = self.img_path()
 
-                if destroy:
-                        self.image_destroy(img_path=img_path)
+        if destroy:
+            self.image_destroy(img_path=img_path)
 
-                mkdir_eexist_ok(img_path)
+        mkdir_eexist_ok(img_path)
 
-                self.fs = set()
+        self.fs = set()
 
-                force = False
-                for path in fs:
-                        full_path = os.path.join(img_path,
-                            path.lstrip(os.path.sep))
-                        os.makedirs(full_path)
-                        self.cmdline_run("/usr/sbin/mount -F tmpfs swap " +
-                            full_path, coverage=False)
-                        self.fs.add(full_path)
-                        if path.lstrip(os.path.sep) == "var":
-                                force = True
+        force = False
+        for path in fs:
+            full_path = os.path.join(img_path, path.lstrip(os.path.sep))
+            os.makedirs(full_path)
+            self.cmdline_run(
+                "/usr/sbin/mount -F tmpfs swap " + full_path, coverage=False
+            )
+            self.fs.add(full_path)
+            if path.lstrip(os.path.sep) == "var":
+                force = True
 
-                self.debug("image_create {0}".format(img_path))
-                progtrack = pkg.client.progress.NullProgressTracker()
-                api_inst = pkg.client.api.image_create(PKG_CLIENT_NAME,
-                    CLIENT_API_VERSION, img_path,
-                    pkg.client.api.IMG_TYPE_ENTIRE, False, repo_uri=repourl,
-                    progtrack=progtrack, force=force,
-                    **kwargs)
-                self.__setup_signing_files()
-                return api_inst
+        self.debug("image_create {0}".format(img_path))
+        progtrack = pkg.client.progress.NullProgressTracker()
+        api_inst = pkg.client.api.image_create(
+            PKG_CLIENT_NAME,
+            CLIENT_API_VERSION,
+            img_path,
+            pkg.client.api.IMG_TYPE_ENTIRE,
+            False,
+            repo_uri=repourl,
+            progtrack=progtrack,
+            force=force,
+            **kwargs,
+        )
+        self.__setup_signing_files()
+        return api_inst
 
-        def pkg_image_create(self, repourl=None, prefix=None,
-            additional_args="", exit=0, env_arg=None):
-                """Executes pkg(1) client to create a full (as opposed to user)
-                image; returns exit code of client or raises an exception if
-                exit code doesn't match 'exit' or equals 99."""
+    def pkg_image_create(
+        self,
+        repourl=None,
+        prefix=None,
+        additional_args="",
+        exit=0,
+        env_arg=None,
+    ):
+        """Executes pkg(1) client to create a full (as opposed to user)
+        image; returns exit code of client or raises an exception if
+        exit code doesn't match 'exit' or equals 99."""
 
-                if repourl and prefix is None:
-                        prefix = "test"
+        if repourl and prefix is None:
+            prefix = "test"
 
-                self.image_destroy()
-                os.mkdir(self.img_path())
-                cmdline = sys.executable + " {0} image-create -F ".format(
-                    self.pkg_cmdpath)
-                if repourl:
-                        cmdline = "{0} -p {1}={2} ".format(cmdline, prefix, repourl)
-                cmdline += additional_args
-                cmdline = "{0} {1}".format(cmdline, self.img_path())
+        self.image_destroy()
+        os.mkdir(self.img_path())
+        cmdline = sys.executable + " {0} image-create -F ".format(
+            self.pkg_cmdpath
+        )
+        if repourl:
+            cmdline = "{0} -p {1}={2} ".format(cmdline, prefix, repourl)
+        cmdline += additional_args
+        cmdline = "{0} {1}".format(cmdline, self.img_path())
 
-                retcode = self.cmdline_run(cmdline, exit=exit, env_arg=env_arg)
+        retcode = self.cmdline_run(cmdline, exit=exit, env_arg=env_arg)
 
-                self.__setup_signing_files()
-                return retcode
+        self.__setup_signing_files()
+        return retcode
 
-        def image_clone(self, dst):
+    def image_clone(self, dst):
+        # the currently selected image is the source
+        src = self.img_index()
+        src_path = self.img_path()
 
-                # the currently selected image is the source
-                src = self.img_index()
-                src_path = self.img_path()
+        # create an empty destination image
+        self.set_image(dst)
+        self.image_destroy()
+        os.mkdir(self.img_path())
+        dst_path = self.img_path()
 
-                # create an empty destination image
-                self.set_image(dst)
-                self.image_destroy()
-                os.mkdir(self.img_path())
-                dst_path = self.img_path()
+        # reactivate the source image
+        self.set_image(src)
 
-                # reactivate the source image
-                self.set_image(src)
+        # populate the destination image
+        cmdline = "cd {0}; find . | cpio -pdm {1}".format(src_path, dst_path)
+        retcode = self.cmdline_run(cmdline, coverage=False)
 
-                # populate the destination image
-                cmdline = "cd {0}; find . | cpio -pdm {1}".format(src_path, dst_path)
-                retcode = self.cmdline_run(cmdline, coverage=False)
+    def image_destroy(self, img_path=None):
+        if img_path is None:
+            img_path = self.img_path()
 
-        def image_destroy(self, img_path=None):
+        if os.path.exists(img_path):
+            self.debug("image_destroy {0}".format(img_path))
+            # Make sure we're not in the image.
+            os.chdir(self.test_root)
+            for path in getattr(self, "fs", set()).copy():
+                self.cmdline_run("/usr/sbin/umount " + path, coverage=False)
+                self.fs.remove(path)
+            shutil.rmtree(img_path)
 
-                if img_path is None:
-                        img_path = self.img_path()
-
-                if os.path.exists(img_path):
-                        self.debug("image_destroy {0}".format(img_path))
-                        # Make sure we're not in the image.
-                        os.chdir(self.test_root)
-                        for path in getattr(self, "fs", set()).copy():
-                                self.cmdline_run("/usr/sbin/umount " + path,
-                                    coverage=False)
-                                self.fs.remove(path)
-                        shutil.rmtree(img_path)
-
-        def image_walk(self, img_path=None, subdir=None):
-                if img_path is None:
-                        img_path = self.img_path()
-                if subdir is not None:
-                        img_path += subdir
-                print(f'>>>>> walking {img_path}')
-                for dirpath, dirnames, fnames in os.walk(img_path):
-                        rd = dirpath[len(img_path):]
-                        if rd.startswith('/var/pkg/cache'): continue
-                        for f in fnames:
-                                path = os.path.join(dirpath, f)
-                                st = os.lstat(path)
-                                if stat.S_ISLNK(st.st_mode):
-                                        t = os.readlink(path)
-                                        print(f' l {rd}/{f} -> {t}')
-                                else:
-                                        print(f' f {rd}/{f}')
-                        for d in dirnames:
-                                print(f' d {rd}/{d}')
-
-        def pkg(self, command, exit=0, comment="", prefix="", su_wrap=None,
-            out=False, stderr=False, cmd_path=None, use_img_root=True,
-            debug_smf=True, env_arg=None, coverage=True, handle=False,
-            assert_solution=True):
-
-                if isinstance(command, list):
-                        cmdstr = " ".join(command)
+    def image_walk(self, img_path=None, subdir=None):
+        if img_path is None:
+            img_path = self.img_path()
+        if subdir is not None:
+            img_path += subdir
+        print(f">>>>> walking {img_path}")
+        for dirpath, dirnames, fnames in os.walk(img_path):
+            rd = dirpath[len(img_path) :]
+            if rd.startswith("/var/pkg/cache"):
+                continue
+            for f in fnames:
+                path = os.path.join(dirpath, f)
+                st = os.lstat(path)
+                if stat.S_ISLNK(st.st_mode):
+                    t = os.readlink(path)
+                    print(f" l {rd}/{f} -> {t}")
                 else:
-                        cmdstr = command
+                    print(f" f {rd}/{f}")
+            for d in dirnames:
+                print(f" d {rd}/{d}")
 
-                cmdline = [sys.executable]
+    def pkg(
+        self,
+        command,
+        exit=0,
+        comment="",
+        prefix="",
+        su_wrap=None,
+        out=False,
+        stderr=False,
+        cmd_path=None,
+        use_img_root=True,
+        debug_smf=True,
+        env_arg=None,
+        coverage=True,
+        handle=False,
+        assert_solution=True,
+    ):
+        if isinstance(command, list):
+            cmdstr = " ".join(command)
+        else:
+            cmdstr = command
 
-                if not cmd_path:
-                        cmd_path = self.pkg_cmdpath
+        cmdline = [sys.executable]
 
-                cmdline.append(cmd_path)
+        if not cmd_path:
+            cmd_path = self.pkg_cmdpath
 
-                if (use_img_root and "-R" not in cmdstr and
-                    "image-create" not in cmdstr):
-                        cmdline.extend(("-R", self.get_img_path()))
+        cmdline.append(cmd_path)
 
-                cmdline.extend(("-D", "plandesc_validate=1"))
-                cmdline.extend(("-D", "manifest_validate=Always"))
+        if use_img_root and "-R" not in cmdstr and "image-create" not in cmdstr:
+            cmdline.extend(("-R", self.get_img_path()))
 
-                if debug_smf and "smf_cmds_dir" not in cmdstr:
-                        cmdline.extend(("-D", "smf_cmds_dir={0}".format(
-                            DebugValues["smf_cmds_dir"])))
+        cmdline.extend(("-D", "plandesc_validate=1"))
+        cmdline.extend(("-D", "manifest_validate=Always"))
 
-                if not isinstance(command, list):
-                        cmdline = "{0} {1}".format(" ".join(cmdline), command)
-                else:
-                        cmdline.extend(command)
+        if debug_smf and "smf_cmds_dir" not in cmdstr:
+            cmdline.extend(
+                ("-D", "smf_cmds_dir={0}".format(DebugValues["smf_cmds_dir"]))
+            )
 
-                rval = self.cmdline_run(cmdline, exit=exit, comment=comment,
-                    prefix=prefix, su_wrap=su_wrap, out=out, stderr=stderr,
-                    env_arg=env_arg, coverage=coverage, handle=handle)
+        if not isinstance(command, list):
+            cmdline = "{0} {1}".format(" ".join(cmdline), command)
+        else:
+            cmdline.extend(command)
 
-                if assert_solution:
-                        # Ensure solver never fails with 'No solution' by
-                        # default to prevent silent failures for the wrong
-                        # reason.
-                        for buf in (self.errout, self.output):
-                                self.assertTrue("No solution" not in buf,
-                                    msg="Solver could not find solution for "
-                                    "operation; set assert_solution=False if "
-                                    "this is expected when calling pkg().")
+        rval = self.cmdline_run(
+            cmdline,
+            exit=exit,
+            comment=comment,
+            prefix=prefix,
+            su_wrap=su_wrap,
+            out=out,
+            stderr=stderr,
+            env_arg=env_arg,
+            coverage=coverage,
+            handle=handle,
+        )
 
-                return rval
+        if assert_solution:
+            # Ensure solver never fails with 'No solution' by
+            # default to prevent silent failures for the wrong
+            # reason.
+            for buf in (self.errout, self.output):
+                self.assertTrue(
+                    "No solution" not in buf,
+                    msg="Solver could not find solution for "
+                    "operation; set assert_solution=False if "
+                    "this is expected when calling pkg().",
+                )
 
-        def pkg_verify(self, command, exit=0, comment="", prefix="",
-            su_wrap=None, out=False, stderr=False, cmd_path=None,
-            use_img_root=True, debug_smf=True, env_arg=None, coverage=True):
-                """Wraps self.pkg(..) and checks that the 'verify' command run
-                does not contain the string 'Unexpected Exception', indicating
-                something has gone wrong during package verification."""
+        return rval
 
-                cmd = "verify {0}".format(command)
-                res = self.pkg(command=cmd, exit=exit, comment=comment,
-                    prefix=prefix, su_wrap=su_wrap, out=out, stderr=stderr,
-                    cmd_path=cmd_path, use_img_root=use_img_root,
-                    debug_smf=debug_smf, env_arg=env_arg, coverage=coverage)
-                if "Unexpected Exception" in self.output:
-                        raise TracebackException(cmd, self.output,
-                            "Unexpected errors encountered while verifying.")
-                return res
+    def pkg_verify(
+        self,
+        command,
+        exit=0,
+        comment="",
+        prefix="",
+        su_wrap=None,
+        out=False,
+        stderr=False,
+        cmd_path=None,
+        use_img_root=True,
+        debug_smf=True,
+        env_arg=None,
+        coverage=True,
+    ):
+        """Wraps self.pkg(..) and checks that the 'verify' command run
+        does not contain the string 'Unexpected Exception', indicating
+        something has gone wrong during package verification."""
 
-        def pkgdepend_resolve(self, args, exit=0, comment="", su_wrap=False,
-            env_arg=None):
-                ops = ""
-                if "-R" not in args:
-                        ops = "-R {0}".format(self.get_img_path())
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/bin/pkgdepend {0} resolve {1}".format(ops, args))
-                return self.cmdline_run(cmdline, comment=comment, exit=exit,
-                    su_wrap=su_wrap, env_arg=env_arg)
+        cmd = "verify {0}".format(command)
+        res = self.pkg(
+            command=cmd,
+            exit=exit,
+            comment=comment,
+            prefix=prefix,
+            su_wrap=su_wrap,
+            out=out,
+            stderr=stderr,
+            cmd_path=cmd_path,
+            use_img_root=use_img_root,
+            debug_smf=debug_smf,
+            env_arg=env_arg,
+            coverage=coverage,
+        )
+        if "Unexpected Exception" in self.output:
+            raise TracebackException(
+                cmd,
+                self.output,
+                "Unexpected errors encountered while verifying.",
+            )
+        return res
 
-        def pkgdepend_generate(self, args, exit=0, comment="", su_wrap=False,
-            env_arg=None):
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/bin/pkgdepend generate {0}".format(args))
-                return self.cmdline_run(cmdline, comment=comment, exit=exit,
-                    su_wrap=su_wrap, env_arg=env_arg)
+    def pkgdepend_resolve(
+        self, args, exit=0, comment="", su_wrap=False, env_arg=None
+    ):
+        ops = ""
+        if "-R" not in args:
+            ops = "-R {0}".format(self.get_img_path())
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(
+                g_pkg_path,
+                "usr/bin/pkgdepend {0} resolve {1}".format(ops, args),
+            )
+        )
+        return self.cmdline_run(
+            cmdline,
+            comment=comment,
+            exit=exit,
+            su_wrap=su_wrap,
+            env_arg=env_arg,
+        )
 
-        def pkgdiff(self, command, comment="", exit=0, su_wrap=False,
-            env_arg=None, stderr=False, out=False):
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/bin/pkgdiff {0}".format(command))
-                return self.cmdline_run(cmdline, comment=comment, exit=exit,
-                    su_wrap=su_wrap, env_arg=env_arg, out=out, stderr=stderr)
+    def pkgdepend_generate(
+        self, args, exit=0, comment="", su_wrap=False, env_arg=None
+    ):
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(
+                g_pkg_path, "usr/bin/pkgdepend generate {0}".format(args)
+            )
+        )
+        return self.cmdline_run(
+            cmdline,
+            comment=comment,
+            exit=exit,
+            su_wrap=su_wrap,
+            env_arg=env_arg,
+        )
 
-        def pkgfmt(self, args, exit=0, su_wrap=False, env_arg=None):
-                cmd= sys.executable + " " + \
-                     os.path.join(g_pkg_path, "usr/bin/pkgfmt {0}".format(args))
-                self.cmdline_run(cmd, exit=exit, su_wrap=su_wrap,
-                    env_arg=env_arg)
+    def pkgdiff(
+        self,
+        command,
+        comment="",
+        exit=0,
+        su_wrap=False,
+        env_arg=None,
+        stderr=False,
+        out=False,
+    ):
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(g_pkg_path, "usr/bin/pkgdiff {0}".format(command))
+        )
+        return self.cmdline_run(
+            cmdline,
+            comment=comment,
+            exit=exit,
+            su_wrap=su_wrap,
+            env_arg=env_arg,
+            out=out,
+            stderr=stderr,
+        )
 
-        def pkglint(self, args, exit=0, comment="", testrc=True,
-            env_arg=None):
-                if testrc:
-                        rcpath = "{0}/pkglintrc".format(self.test_root)
-                        cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                            "usr/bin/pkglint -f {0} {1}".format(rcpath, args))
-                else:
-                        cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                            "usr/bin/pkglint {0}".format(args))
-                return self.cmdline_run(cmdline, exit=exit, out=True,
-                    comment=comment, stderr=True, env_arg=env_arg)
+    def pkgfmt(self, args, exit=0, su_wrap=False, env_arg=None):
+        cmd = (
+            sys.executable
+            + " "
+            + os.path.join(g_pkg_path, "usr/bin/pkgfmt {0}".format(args))
+        )
+        self.cmdline_run(cmd, exit=exit, su_wrap=su_wrap, env_arg=env_arg)
 
-        def pkgrecv(self, server_url=None, command=None, exit=0, out=False,
-            comment="", env_arg=None, su_wrap=False):
-                args = []
-                if server_url:
-                        args.append("-s {0}".format(server_url))
+    def pkglint(self, args, exit=0, comment="", testrc=True, env_arg=None):
+        if testrc:
+            rcpath = "{0}/pkglintrc".format(self.test_root)
+            cmdline = (
+                sys.executable
+                + " "
+                + os.path.join(
+                    g_pkg_path,
+                    "usr/bin/pkglint -f {0} {1}".format(rcpath, args),
+                )
+            )
+        else:
+            cmdline = (
+                sys.executable
+                + " "
+                + os.path.join(g_pkg_path, "usr/bin/pkglint {0}".format(args))
+            )
+        return self.cmdline_run(
+            cmdline,
+            exit=exit,
+            out=True,
+            comment=comment,
+            stderr=True,
+            env_arg=env_arg,
+        )
 
-                if command:
-                        args.append(command)
+    def pkgrecv(
+        self,
+        server_url=None,
+        command=None,
+        exit=0,
+        out=False,
+        comment="",
+        env_arg=None,
+        su_wrap=False,
+    ):
+        args = []
+        if server_url:
+            args.append("-s {0}".format(server_url))
 
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/bin/pkgrecv {0}".format(" ".join(args)))
+        if command:
+            args.append(command)
 
-                return self.cmdline_run(cmdline, comment=comment, exit=exit,
-                    out=out, su_wrap=su_wrap, env_arg=env_arg)
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(
+                g_pkg_path, "usr/bin/pkgrecv {0}".format(" ".join(args))
+            )
+        )
 
-        def pkgmerge(self, args, comment="", exit=0, su_wrap=False,
-            env_arg=None):
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/bin/pkgmerge {0}".format(args))
-                return self.cmdline_run(cmdline, comment=comment, exit=exit,
-                    su_wrap=su_wrap, env_arg=env_arg)
+        return self.cmdline_run(
+            cmdline,
+            comment=comment,
+            exit=exit,
+            out=out,
+            su_wrap=su_wrap,
+            env_arg=env_arg,
+        )
 
-        def pkgrepo(self, command, comment="", exit=0, su_wrap=False,
-            env_arg=None, stderr=False, out=False, debug_hash=None):
-                if debug_hash:
-                        debug_arg = "-D hash={0} ".format(debug_hash)
-                else:
-                        debug_arg = ""
+    def pkgmerge(self, args, comment="", exit=0, su_wrap=False, env_arg=None):
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(g_pkg_path, "usr/bin/pkgmerge {0}".format(args))
+        )
+        return self.cmdline_run(
+            cmdline,
+            comment=comment,
+            exit=exit,
+            su_wrap=su_wrap,
+            env_arg=env_arg,
+        )
 
-                # Always add the current ignored_deps dir path.
-                debug_arg += "-D ignored_deps={0} ".format(os.path.join(
-                    g_pkg_path, "usr/share/pkg/ignored_deps"))
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/bin/pkgrepo {0}{1}".format(debug_arg, command))
-                return self.cmdline_run(cmdline, comment=comment, exit=exit,
-                    su_wrap=su_wrap, env_arg=env_arg, out=out, stderr=stderr)
+    def pkgrepo(
+        self,
+        command,
+        comment="",
+        exit=0,
+        su_wrap=False,
+        env_arg=None,
+        stderr=False,
+        out=False,
+        debug_hash=None,
+    ):
+        if debug_hash:
+            debug_arg = "-D hash={0} ".format(debug_hash)
+        else:
+            debug_arg = ""
 
-        def pkgsurf(self, command, comment="", exit=0, su_wrap=False,
-            env_arg=None, stderr=False, out=False):
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/bin/pkgsurf {0}".format(command))
-                return self.cmdline_run(cmdline, comment=comment, exit=exit,
-                    su_wrap=su_wrap, env_arg=env_arg, out=out, stderr=stderr)
+        # Always add the current ignored_deps dir path.
+        debug_arg += "-D ignored_deps={0} ".format(
+            os.path.join(g_pkg_path, "usr/share/pkg/ignored_deps")
+        )
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(
+                g_pkg_path, "usr/bin/pkgrepo {0}{1}".format(debug_arg, command)
+            )
+        )
+        return self.cmdline_run(
+            cmdline,
+            comment=comment,
+            exit=exit,
+            su_wrap=su_wrap,
+            env_arg=env_arg,
+            out=out,
+            stderr=stderr,
+        )
 
-        def pkgsign(self, depot_url, command, exit=0, comment="",
-            env_arg=None, debug_hash=None):
-                args = []
-                if depot_url:
-                        args.append("-s {0}".format(depot_url))
+    def pkgsurf(
+        self,
+        command,
+        comment="",
+        exit=0,
+        su_wrap=False,
+        env_arg=None,
+        stderr=False,
+        out=False,
+    ):
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(g_pkg_path, "usr/bin/pkgsurf {0}".format(command))
+        )
+        return self.cmdline_run(
+            cmdline,
+            comment=comment,
+            exit=exit,
+            su_wrap=su_wrap,
+            env_arg=env_arg,
+            out=out,
+            stderr=stderr,
+        )
 
-                if debug_hash:
-                        args.append("-D hash={0}".format(debug_hash))
+    def pkgsign(
+        self,
+        depot_url,
+        command,
+        exit=0,
+        comment="",
+        env_arg=None,
+        debug_hash=None,
+    ):
+        args = []
+        if depot_url:
+            args.append("-s {0}".format(depot_url))
 
-                if command:
-                        args.append(command)
+        if debug_hash:
+            args.append("-D hash={0}".format(debug_hash))
 
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/bin/pkgsign {0}".format(" ".join(args)))
-                return self.cmdline_run(cmdline, comment=comment, exit=exit,
-                    env_arg=env_arg)
+        if command:
+            args.append(command)
 
-        def pkgsign_simple(self, depot_url, pkg_name, exit=0, env_arg=None,
-            debug_hash=None):
-                chain_cert_path = os.path.join(self.chain_certs_dir,
-                    "ch1_ta3_cert.pem")
-                sign_args = "-k {key} -c {cert} -i {ch1} {name}".format(
-                    name=pkg_name,
-                    key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
-                    cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
-                    ch1=chain_cert_path,
-               )
-                return self.pkgsign(depot_url, sign_args, exit=exit,
-                    env_arg=env_arg, debug_hash=debug_hash)
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(
+                g_pkg_path, "usr/bin/pkgsign {0}".format(" ".join(args))
+            )
+        )
+        return self.cmdline_run(
+            cmdline, comment=comment, exit=exit, env_arg=env_arg
+        )
 
-        def pkgsend(self, depot_url="", command="", exit=0, comment="",
-            allow_timestamp=False, env_arg=None, su_wrap=False,
-            debug_hash=None):
-                args = []
-                if allow_timestamp:
-                        args.append("-D allow-timestamp")
-                if depot_url:
-                        args.append("-s " + depot_url)
+    def pkgsign_simple(
+        self, depot_url, pkg_name, exit=0, env_arg=None, debug_hash=None
+    ):
+        chain_cert_path = os.path.join(self.chain_certs_dir, "ch1_ta3_cert.pem")
+        sign_args = "-k {key} -c {cert} -i {ch1} {name}".format(
+            name=pkg_name,
+            key=os.path.join(self.keys_dir, "cs1_ch1_ta3_key.pem"),
+            cert=os.path.join(self.cs_dir, "cs1_ch1_ta3_cert.pem"),
+            ch1=chain_cert_path,
+        )
+        return self.pkgsign(
+            depot_url,
+            sign_args,
+            exit=exit,
+            env_arg=env_arg,
+            debug_hash=debug_hash,
+        )
 
-                # debug_hash lets us choose the type of hash attributes that
-                # should be added to this package on publication. Valid values
-                # are: sha1, sha256, sha1+sha256, sha512t_256, sha1+sha512t_256
-                if debug_hash:
-                        args.append("-D hash={0}".format(debug_hash))
+    def pkgsend(
+        self,
+        depot_url="",
+        command="",
+        exit=0,
+        comment="",
+        allow_timestamp=False,
+        env_arg=None,
+        su_wrap=False,
+        debug_hash=None,
+    ):
+        args = []
+        if allow_timestamp:
+            args.append("-D allow-timestamp")
+        if depot_url:
+            args.append("-s " + depot_url)
 
-                if command:
-                        args.append(command)
+        # debug_hash lets us choose the type of hash attributes that
+        # should be added to this package on publication. Valid values
+        # are: sha1, sha256, sha1+sha256, sha512t_256, sha1+sha512t_256
+        if debug_hash:
+            args.append("-D hash={0}".format(debug_hash))
 
-                prefix = "cd {0};".format(self.test_root)
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/bin/pkgsend {0}".format(" ".join(args)))
+        if command:
+            args.append(command)
 
-                retcode, out = self.cmdline_run(cmdline, comment=comment,
-                    exit=exit, out=True, prefix=prefix, raise_error=False,
-                    env_arg=env_arg, su_wrap=su_wrap)
-                errout = self.errout
+        prefix = "cd {0};".format(self.test_root)
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(
+                g_pkg_path, "usr/bin/pkgsend {0}".format(" ".join(args))
+            )
+        )
 
-                cmdop = command.split(' ')[0]
-                if cmdop in ("open", "append") and retcode == 0:
-                        out = out.rstrip()
-                        assert out.startswith("export PKG_TRANS_ID=")
-                        arr = out.split("=")
-                        assert arr
-                        out = arr[1]
-                        os.environ["PKG_TRANS_ID"] = out
-                        self.debug("$ export PKG_TRANS_ID={0}".format(out))
-                        # retcode != 0 will be handled below
+        retcode, out = self.cmdline_run(
+            cmdline,
+            comment=comment,
+            exit=exit,
+            out=True,
+            prefix=prefix,
+            raise_error=False,
+            env_arg=env_arg,
+            su_wrap=su_wrap,
+        )
+        errout = self.errout
 
-                published = None
-                if (cmdop == "close" and retcode == 0) or cmdop == "publish":
-                        os.environ["PKG_TRANS_ID"] = ""
-                        self.debug("$ export PKG_TRANS_ID=")
-                        for l in out.splitlines():
-                                if l.startswith("pkg:/"):
-                                        published = l
-                                        break
-                elif (cmdop == "generate" and retcode == 0):
-                        published = out
+        cmdop = command.split(" ")[0]
+        if cmdop in ("open", "append") and retcode == 0:
+            out = out.rstrip()
+            assert out.startswith("export PKG_TRANS_ID=")
+            arr = out.split("=")
+            assert arr
+            out = arr[1]
+            os.environ["PKG_TRANS_ID"] = out
+            self.debug("$ export PKG_TRANS_ID={0}".format(out))
+            # retcode != 0 will be handled below
 
-                if retcode == 99:
-                        raise TracebackException(cmdline, out + errout, comment)
+        published = None
+        if (cmdop == "close" and retcode == 0) or cmdop == "publish":
+            os.environ["PKG_TRANS_ID"] = ""
+            self.debug("$ export PKG_TRANS_ID=")
+            for l in out.splitlines():
+                if l.startswith("pkg:/"):
+                    published = l
+                    break
+        elif cmdop == "generate" and retcode == 0:
+            published = out
 
-                if retcode != exit:
-                        raise UnexpectedExitCodeException(cmdline, exit,
-                            retcode, out + errout, comment)
+        if retcode == 99:
+            raise TracebackException(cmdline, out + errout, comment)
 
-                return retcode, published
+        if retcode != exit:
+            raise UnexpectedExitCodeException(
+                cmdline, exit, retcode, out + errout, comment
+            )
 
-        def pkgsend_bulk(self, depot_url, commands, exit=0, comment="",
-            no_catalog=False, refresh_index=False, su_wrap=False,
-            debug_hash=None):
-                """ Send a series of packaging commands; useful  for quickly
-                    doing a bulk-load of stuff into the repo.  All commands are
-                    expected to work; if not, the transaction is abandoned.  If
-                    'exit' is set, then if none of the actions triggers that
-                    exit code, an UnexpectedExitCodeException is raised.
+        return retcode, published
 
-                    A list containing the fmris of any packages that were
-                    published as a result of the commands executed will be
-                    returned; it will be empty if none were. """
+    def pkgsend_bulk(
+        self,
+        depot_url,
+        commands,
+        exit=0,
+        comment="",
+        no_catalog=False,
+        refresh_index=False,
+        su_wrap=False,
+        debug_hash=None,
+    ):
+        """Send a series of packaging commands; useful  for quickly
+        doing a bulk-load of stuff into the repo.  All commands are
+        expected to work; if not, the transaction is abandoned.  If
+        'exit' is set, then if none of the actions triggers that
+        exit code, an UnexpectedExitCodeException is raised.
 
-                if isinstance(commands, (list, tuple)):
-                        commands = "".join(commands)
+        A list containing the fmris of any packages that were
+        published as a result of the commands executed will be
+        returned; it will be empty if none were."""
 
-                extra_opts = []
-                if no_catalog:
-                        extra_opts.append("--no-catalog")
-                extra_opts = " ".join(extra_opts)
+        if isinstance(commands, (list, tuple)):
+            commands = "".join(commands)
 
-                plist = []
-                try:
-                        accumulate = []
+        extra_opts = []
+        if no_catalog:
+            extra_opts.append("--no-catalog")
+        extra_opts = " ".join(extra_opts)
+
+        plist = []
+        try:
+            accumulate = []
+            current_fmri = None
+            retcode = None
+
+            for line in commands.split("\n"):
+                line = line.strip()
+
+                # pkgsend_bulk can't be used w/ import or
+                # generate.
+                assert not line.startswith(
+                    "import"
+                ), "pkgsend_bulk cannot be used with import"
+                assert not line.startswith(
+                    "generate"
+                ), "pkgsend_bulk cannot be used with generate"
+
+                if line == "":
+                    continue
+                if line.startswith("add"):
+                    self.assertTrue(
+                        current_fmri != None, "Missing open in pkgsend string"
+                    )
+                    accumulate.append(line[4:])
+                    continue
+
+                if current_fmri:  # send any content seen so far (can be 0)
+                    fd, f_path = tempfile.mkstemp(dir=self.test_root)
+                    for l in accumulate:
+                        os.write(fd, misc.force_bytes("{0}\n".format(l)))
+                    os.close(fd)
+                    if su_wrap:
+                        os.chown(f_path, *get_su_wrap_user(uid_gid=True))
+                    try:
+                        cmd = "publish {0} -d {1} {2}".format(
+                            extra_opts, self.test_root, f_path
+                        )
                         current_fmri = None
-                        retcode = None
+                        accumulate = []
+                        # Various tests rely on the
+                        # ability to specify version
+                        # down to timestamp for ease
+                        # of testing or because they're
+                        # actually testing timestamp
+                        # package behaviour.
+                        retcode, published = self.pkgsend(
+                            depot_url,
+                            cmd,
+                            allow_timestamp=True,
+                            su_wrap=su_wrap,
+                            debug_hash=debug_hash,
+                        )
+                        if retcode == 0 and published:
+                            plist.append(published)
+                    except:
+                        os.remove(f_path)
+                        raise
+                    os.remove(f_path)
+                if line.startswith("open"):
+                    current_fmri = line[5:].strip()
+                    if commands.find("pkg.fmri") == -1:
+                        # If no explicit pkg.fmri set
+                        # action was found, add one.
+                        accumulate.append(
+                            "set "
+                            "name=pkg.fmri value={0}".format(current_fmri)
+                        )
 
-                        for line in commands.split("\n"):
-                                line = line.strip()
+            if exit == 0 and refresh_index:
+                self.pkgrepo(
+                    "-s {0} refresh --no-catalog".format(depot_url),
+                    su_wrap=su_wrap,
+                    debug_hash=debug_hash,
+                )
+        except UnexpectedExitCodeException as e:
+            if e.exitcode != exit:
+                raise
+            retcode = e.exitcode
 
-                                # pkgsend_bulk can't be used w/ import or
-                                # generate.
-                                assert not line.startswith("import"), \
-                                    "pkgsend_bulk cannot be used with import"
-                                assert not line.startswith("generate"), \
-                                    "pkgsend_bulk cannot be used with generate"
+        if retcode != exit:
+            raise UnexpectedExitCodeException(
+                line, exit, retcode, self.output + self.errout
+            )
 
-                                if line == "":
-                                        continue
-                                if line.startswith("add"):
-                                        self.assertTrue(current_fmri != None,
-                                            "Missing open in pkgsend string")
-                                        accumulate.append(line[4:])
-                                        continue
+        return plist
 
-                                if current_fmri: # send any content seen so far (can be 0)
-                                        fd, f_path = tempfile.mkstemp(dir=self.test_root)
-                                        for l in accumulate:
-                                                os.write(fd, misc.force_bytes(
-                                                    "{0}\n".format(l)))
-                                        os.close(fd)
-                                        if su_wrap:
-                                                os.chown(f_path,
-                                                    *get_su_wrap_user(
-                                                    uid_gid=True))
-                                        try:
-                                                cmd = "publish {0} -d {1} {2}".format(
-                                                    extra_opts, self.test_root,
-                                                    f_path)
-                                                current_fmri = None
-                                                accumulate = []
-                                                # Various tests rely on the
-                                                # ability to specify version
-                                                # down to timestamp for ease
-                                                # of testing or because they're
-                                                # actually testing timestamp
-                                                # package behaviour.
-                                                retcode, published = \
-                                                    self.pkgsend(depot_url, cmd,
-                                                    allow_timestamp=True,
-                                                    su_wrap=su_wrap,
-                                                    debug_hash=debug_hash)
-                                                if retcode == 0 and published:
-                                                        plist.append(published)
-                                        except:
-                                                os.remove(f_path)
-                                                raise
-                                        os.remove(f_path)
-                                if line.startswith("open"):
-                                        current_fmri = line[5:].strip()
-                                        if commands.find("pkg.fmri") == -1:
-                                                # If no explicit pkg.fmri set
-                                                # action was found, add one.
-                                                accumulate.append("set "
-                                                    "name=pkg.fmri value={0}".format(
-                                                    current_fmri))
+    def merge(self, args=EmptyI, exit=0):
+        cmd = (
+            sys.executable
+            + " "
+            + os.path.join(
+                g_pkg_path, "usr/bin/pkgmerge {0}".format(" ".join(args))
+            )
+        )
+        self.cmdline_run(cmd, exit=exit)
 
-                        if exit == 0 and refresh_index:
-                                self.pkgrepo("-s {0} refresh --no-catalog".format(
-                                    depot_url), su_wrap=su_wrap,
-                                    debug_hash=debug_hash)
-                except UnexpectedExitCodeException as e:
-                        if e.exitcode != exit:
-                                raise
-                        retcode = e.exitcode
+    def sysrepo(
+        self,
+        args,
+        exit=0,
+        out=False,
+        stderr=False,
+        comment="",
+        env_arg=None,
+        fill_missing_args=True,
+    ):
+        ops = ""
+        if "-R" not in args:
+            args += " -R {0}".format(self.get_img_path())
+        if "-c" not in args:
+            args += " -c {0}".format(
+                os.path.join(self.test_root, "sysrepo_cache")
+            )
+        if "-l" not in args:
+            args += " -l {0}".format(
+                os.path.join(self.test_root, "sysrepo_logs")
+            )
+        if "-p" not in args and fill_missing_args:
+            args += " -p {0}".format(self.next_free_port)
+        if "-r" not in args:
+            args += " -r {0}".format(
+                os.path.join(self.test_root, "sysrepo_runtime")
+            )
+        if "-t" not in args:
+            args += " -t {0}".format(self.sysrepo_template_dir)
 
-                if retcode != exit:
-                        raise UnexpectedExitCodeException(line, exit, retcode,
-                            self.output + self.errout)
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(g_pkg_path, "usr/lib/pkg.sysrepo {0}".format(args))
+        )
+        if env_arg is None:
+            env_arg = {}
+        env_arg["PKG5_TEST_ENV"] = "1"
+        return self.cmdline_run(
+            cmdline,
+            comment=comment,
+            exit=exit,
+            out=out,
+            stderr=stderr,
+            env_arg=env_arg,
+        )
 
-                return plist
+    def snooze(self, sleeptime=10800, show_stack=True):
+        """A convenient method to cause test execution to pause for
+        up to 'sleeptime' seconds, which can be helpful during testcase
+        development.  sleeptime defaults to 3 hours."""
+        self.debug("YAWN ... going to sleep now\n")
+        if show_stack:
+            self.debug("\n\n\n")
+            self.debug("".join(traceback.format_stack()))
+        time.sleep(sleeptime)
 
-        def merge(self, args=EmptyI, exit=0):
-                cmd = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/bin/pkgmerge {0}".format(" ".join(args)))
-                self.cmdline_run(cmd, exit=exit)
+    def depotconfig(
+        self,
+        args,
+        exit=0,
+        out=False,
+        stderr=False,
+        comment="",
+        env_arg=None,
+        fill_missing_args=True,
+        debug_smf=True,
+    ):
+        """Run pkg.depot-config, with command line arguments in args.
+        If fill_missing_args is set, we use default settings for several
+        arguments to point to template, logs, cache and proto areas
+        within our test root."""
 
-        def sysrepo(self, args, exit=0, out=False, stderr=False, comment="",
-            env_arg=None, fill_missing_args=True):
-                ops = ""
-                if "-R" not in args:
-                        args += " -R {0}".format(self.get_img_path())
-                if "-c" not in args:
-                        args += " -c {0}".format(os.path.join(self.test_root,
-                            "sysrepo_cache"))
-                if "-l" not in args:
-                        args += " -l {0}".format(os.path.join(self.test_root,
-                            "sysrepo_logs"))
-                if "-p" not in args and fill_missing_args:
-                        args += " -p {0}".format(self.next_free_port)
-                if "-r" not in args:
-                        args += " -r {0}".format(os.path.join(self.test_root,
-                            "sysrepo_runtime"))
-                if "-t" not in args:
-                        args += " -t {0}".format(self.sysrepo_template_dir)
+        if "-S" not in args and "-d " not in args and fill_missing_args:
+            args += " -S "
+        if "-c " not in args and fill_missing_args:
+            args += " -c {0}".format(
+                os.path.join(self.test_root, "depot_cache")
+            )
+        if "-l" not in args:
+            args += " -l {0}".format(os.path.join(self.test_root, "depot_logs"))
+        if "-p" not in args and "-F" not in args and fill_missing_args:
+            args += " -p {0}".format(self.depot_port)
+        if "-r" not in args:
+            args += " -r {0}".format(
+                os.path.join(self.test_root, "depot_runtime")
+            )
+        if "-T" not in args:
+            args += " -T {0}".format(self.depot_template_dir)
 
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/lib/pkg.sysrepo {0}".format(args))
-                if env_arg is None:
-                        env_arg = {}
-                env_arg["PKG5_TEST_ENV"] = "1"
-                return self.cmdline_run(cmdline, comment=comment, exit=exit,
-                    out=out, stderr=stderr, env_arg=env_arg)
+        if debug_smf and "smf_cmds_dir" not in args:
+            args += " --debug smf_cmds_dir={0}".format(
+                DebugValues["smf_cmds_dir"]
+            )
 
-        def snooze(self, sleeptime=10800, show_stack=True):
-                """A convenient method to cause test execution to pause for
-                up to 'sleeptime' seconds, which can be helpful during testcase
-                development.  sleeptime defaults to 3 hours."""
-                self.debug("YAWN ... going to sleep now\n")
-                if show_stack:
-                        self.debug("\n\n\n")
-                        self.debug("".join(traceback.format_stack()))
-                time.sleep(sleeptime)
+        cmdline = (
+            sys.executable
+            + " "
+            + os.path.join(
+                g_pkg_path, "usr/lib/pkg.depot-config {0}".format(args)
+            )
+        )
+        if env_arg is None:
+            env_arg = {}
+        env_arg["PKG5_TEST_PROTO"] = g_pkg_path
+        return self.cmdline_run(
+            cmdline,
+            comment=comment,
+            exit=exit,
+            out=out,
+            stderr=stderr,
+            env_arg=env_arg,
+        )
 
-        def depotconfig(self, args, exit=0, out=False, stderr=False, comment="",
-            env_arg=None, fill_missing_args=True, debug_smf=True):
-                """Run pkg.depot-config, with command line arguments in args.
-                If fill_missing_args is set, we use default settings for several
-                arguments to point to template, logs, cache and proto areas
-                within our test root."""
+    def copy_repository(self, src, dest, pub_map):
+        """Copies the packages from the src repository to a new
+        destination repository that will be created at dest.  In
+        addition, any packages from the src_pub will be assigned
+        to the dest_pub during the copy.  The new repository will
+        not have a catalog or search indices, so a depot server
+        pointed at the new repository must be started with the
+        --rebuild option.
+        """
 
-                if "-S" not in args and "-d " not in args and fill_missing_args:
-                        args += " -S "
-                if "-c " not in args and fill_missing_args:
-                        args += " -c {0}".format(os.path.join(self.test_root,
-                            "depot_cache"))
-                if "-l" not in args:
-                        args += " -l {0}".format(os.path.join(self.test_root,
-                            "depot_logs"))
-                if "-p" not in args and "-F" not in args and fill_missing_args:
-                        args += " -p {0}".format(self.depot_port)
-                if "-r" not in args:
-                        args += " -r {0}".format(os.path.join(self.test_root,
-                            "depot_runtime"))
-                if "-T" not in args:
-                        args += " -T {0}".format(self.depot_template_dir)
+        # Preserve destination repository's configuration if it exists.
+        dest_cfg = os.path.join(dest, "pkg5.repository")
+        dest_cfg_data = None
+        if os.path.exists(dest_cfg):
+            with open(dest_cfg, "rb") as f:
+                dest_cfg_data = f.read()
+        shutil.rmtree(dest, True)
+        os.makedirs(dest, mode=0o755)
 
-                if debug_smf and "smf_cmds_dir" not in args:
-                        args += " --debug smf_cmds_dir={0}".format(
-                            DebugValues["smf_cmds_dir"])
+        # Ensure config is written back out.
+        if dest_cfg_data:
+            with open(dest_cfg, "wb") as f:
+                f.write(dest_cfg_data)
 
-                cmdline = sys.executable + " " + os.path.join(g_pkg_path,
-                    "usr/lib/pkg.depot-config {0}".format(args))
-                if env_arg is None:
-                        env_arg = {}
-                env_arg["PKG5_TEST_PROTO"] = g_pkg_path
-                return self.cmdline_run(cmdline, comment=comment, exit=exit,
-                    out=out, stderr=stderr, env_arg=env_arg)
+        def copy_manifests(src_root, dest_root):
+            # Now copy each manifest and replace any references to
+            # the old publisher with that of the new publisher as
+            # they are copied.
+            src_pkg_root = os.path.join(src_root, "pkg")
+            dest_pkg_root = os.path.join(dest_root, "pkg")
+            for stem in os.listdir(src_pkg_root):
+                src_pkg_path = os.path.join(src_pkg_root, stem)
+                dest_pkg_path = os.path.join(dest_pkg_root, stem)
+                for mname in os.listdir(src_pkg_path):
+                    # Ensure destination manifest directory
+                    # exists.
+                    if not os.path.isdir(dest_pkg_path):
+                        os.makedirs(dest_pkg_path, mode=0o755)
 
-        def copy_repository(self, src, dest, pub_map):
-                """Copies the packages from the src repository to a new
-                destination repository that will be created at dest.  In
-                addition, any packages from the src_pub will be assigned
-                to the dest_pub during the copy.  The new repository will
-                not have a catalog or search indices, so a depot server
-                pointed at the new repository must be started with the
-                --rebuild option.
-                """
+                    msrc = open(os.path.join(src_pkg_path, mname), "r")
+                    mdest = open(os.path.join(dest_pkg_path, mname), "w")
+                    for l in msrc:
+                        if l.find("pkg://") == -1:
+                            mdest.write(l)
+                            continue
+                        nl = l
+                        for src_pub in pub_map:
+                            nl = nl.replace(src_pub, pub_map[src_pub])
+                        mdest.write(nl)
+                    msrc.close()
+                    mdest.close()
 
-                # Preserve destination repository's configuration if it exists.
-                dest_cfg = os.path.join(dest, "pkg5.repository")
-                dest_cfg_data = None
-                if os.path.exists(dest_cfg):
-                        with open(dest_cfg, "rb") as f:
-                                dest_cfg_data = f.read()
-                shutil.rmtree(dest, True)
-                os.makedirs(dest, mode=0o755)
+        src_pub_root = os.path.join(src, "publisher")
+        if os.path.exists(src_pub_root):
+            dest_pub_root = os.path.join(dest, "publisher")
+            for pub in os.listdir(src_pub_root):
+                if pub not in pub_map:
+                    continue
+                src_root = os.path.join(src_pub_root, pub)
+                dest_root = os.path.join(dest_pub_root, pub_map[pub])
+                for entry in os.listdir(src_root):
+                    # Skip the catalog, index, and pkg
+                    # directories as they will be copied
+                    # manually.
+                    if entry not in ("catalog", "index", "pkg", "tmp", "trans"):
+                        spath = os.path.join(src_root, entry)
+                        dpath = os.path.join(dest_root, entry)
+                        shutil.copytree(spath, dpath)
+                        continue
+                    if entry != "pkg":
+                        continue
+                    copy_manifests(src_root, dest_root)
 
-                # Ensure config is written back out.
-                if dest_cfg_data:
-                        with open(dest_cfg, "wb") as f:
-                                f.write(dest_cfg_data)
+    def get_img_manifest_cache_dir(self, pfmri, ii=None):
+        """Returns the path to the manifest cache directory for the
+        given fmri."""
 
-                def copy_manifests(src_root, dest_root):
-                        # Now copy each manifest and replace any references to
-                        # the old publisher with that of the new publisher as
-                        # they are copied.
-                        src_pkg_root = os.path.join(src_root, "pkg")
-                        dest_pkg_root = os.path.join(dest_root, "pkg")
-                        for stem in os.listdir(src_pkg_root):
-                                src_pkg_path = os.path.join(src_pkg_root, stem)
-                                dest_pkg_path = os.path.join(dest_pkg_root,
-                                    stem)
-                                for mname in os.listdir(src_pkg_path):
-                                        # Ensure destination manifest directory
-                                        # exists.
-                                        if not os.path.isdir(dest_pkg_path):
-                                                os.makedirs(dest_pkg_path,
-                                                    mode=0o755)
+        img = self.get_img_api_obj(ii=ii).img
 
-                                        msrc = open(os.path.join(src_pkg_path,
-                                            mname), "r")
-                                        mdest = open(os.path.join(dest_pkg_path,
-                                            mname), "w")
-                                        for l in msrc:
-                                                if l.find("pkg://") == -1:
-                                                        mdest.write(l)
-                                                        continue
-                                                nl = l
-                                                for src_pub in pub_map:
-                                                        nl = nl.replace(
-                                                            src_pub,
-                                                            pub_map[src_pub])
-                                                mdest.write(nl)
-                                        msrc.close()
-                                        mdest.close()
+        if not pfmri.publisher:
+            # Allow callers to not specify a fully-qualified FMRI
+            # if it can be asssumed which publisher likely has
+            # the package.
+            pubs = [p.prefix for p in img.gen_publishers(inc_disabled=True)]
+            assert len(pubs) == 1
+            pfmri.publisher = pubs[0]
+        return img.get_manifest_dir(pfmri)
 
-                src_pub_root = os.path.join(src, "publisher")
-                if os.path.exists(src_pub_root):
-                        dest_pub_root = os.path.join(dest, "publisher")
-                        for pub in os.listdir(src_pub_root):
-                                if pub not in pub_map:
-                                        continue
-                                src_root = os.path.join(src_pub_root, pub)
-                                dest_root = os.path.join(dest_pub_root,
-                                    pub_map[pub])
-                                for entry in os.listdir(src_root):
-                                        # Skip the catalog, index, and pkg
-                                        # directories as they will be copied
-                                        # manually.
-                                        if entry not in ("catalog", "index",
-                                            "pkg", "tmp", "trans"):
-                                                spath = os.path.join(src_root,
-                                                    entry)
-                                                dpath = os.path.join(dest_root,
-                                                    entry)
-                                                shutil.copytree(spath, dpath)
-                                                continue
-                                        if entry != "pkg":
-                                                continue
-                                        copy_manifests(src_root, dest_root)
+    def get_img_manifest_path(self, pfmri):
+        """Returns the path to the manifest for the given fmri."""
 
-        def get_img_manifest_cache_dir(self, pfmri, ii=None):
-                """Returns the path to the manifest cache directory for the
-                given fmri."""
+        img = self.get_img_api_obj().img
 
-                img = self.get_img_api_obj(ii=ii).img
+        if not pfmri.publisher:
+            # Allow callers to not specify a fully-qualified FMRI
+            # if it can be asssumed which publisher likely has
+            # the package.
+            pubs = [p.prefix for p in img.gen_publishers(inc_disabled=True)]
+            assert len(pubs) == 1
+            pfmri.publisher = pubs[0]
+        return img.get_manifest_path(pfmri)
 
-                if not pfmri.publisher:
-                        # Allow callers to not specify a fully-qualified FMRI
-                        # if it can be asssumed which publisher likely has
-                        # the package.
-                        pubs = [
-                            p.prefix
-                            for p in img.gen_publishers(inc_disabled=True)
-                        ]
-                        assert len(pubs) == 1
-                        pfmri.publisher = pubs[0]
-                return img.get_manifest_dir(pfmri)
+    def get_img_manifest(self, pfmri):
+        """Retrieves the client's cached copy of the manifest for the
+        given package FMRI and returns it as a string.  Callers are
+        responsible for all error handling."""
 
-        def get_img_manifest_path(self, pfmri):
-                """Returns the path to the manifest for the given fmri."""
+        mpath = self.get_img_manifest_path(pfmri)
+        with open(mpath, "r") as f:
+            return f.read()
 
-                img = self.get_img_api_obj().img
+    def write_img_manifest(self, pfmri, mdata):
+        """Overwrites the client's cached copy of the manifest for the
+        given package FMRI using the provided string.  Callers are
+        responsible for all error handling."""
 
-                if not pfmri.publisher:
-                        # Allow callers to not specify a fully-qualified FMRI
-                        # if it can be asssumed which publisher likely has
-                        # the package.
-                        pubs = [
-                            p.prefix
-                            for p in img.gen_publishers(inc_disabled=True)
-                        ]
-                        assert len(pubs) == 1
-                        pfmri.publisher = pubs[0]
-                return img.get_manifest_path(pfmri)
+        mpath = self.get_img_manifest_path(pfmri)
+        mdir = os.path.dirname(mpath)
+        mcdir = self.get_img_manifest_cache_dir(pfmri)
 
-        def get_img_manifest(self, pfmri):
-                """Retrieves the client's cached copy of the manifest for the
-                given package FMRI and returns it as a string.  Callers are
-                responsible for all error handling."""
+        # Dump the manifest directories for the package to ensure any
+        # cached information related to it is gone.
+        shutil.rmtree(mdir, True)
+        shutil.rmtree(mcdir, True)
+        self.assertTrue(not os.path.exists(mdir))
+        self.assertTrue(not os.path.exists(mcdir))
+        os.makedirs(mdir, mode=0o755)
+        os.makedirs(mcdir, mode=0o755)
 
-                mpath = self.get_img_manifest_path(pfmri)
-                with open(mpath, "r") as f:
-                        return f.read()
+        # Finally, write the new manifest.
+        with open(mpath, "w") as f:
+            f.write(mdata)
 
-        def write_img_manifest(self, pfmri, mdata):
-                """Overwrites the client's cached copy of the manifest for the
-                given package FMRI using the provided string.  Callers are
-                responsible for all error handling."""
+    def validate_fsobj_attrs(self, act, target=None):
+        """Used to verify that the target item's mode, attrs, timestamp,
+        etc. match as expected.  The actual"""
 
-                mpath = self.get_img_manifest_path(pfmri)
-                mdir = os.path.dirname(mpath)
-                mcdir = self.get_img_manifest_cache_dir(pfmri)
+        if act.name not in ("file", "dir"):
+            return
 
-                # Dump the manifest directories for the package to ensure any
-                # cached information related to it is gone.
-                shutil.rmtree(mdir, True)
-                shutil.rmtree(mcdir, True)
-                self.assertTrue(not os.path.exists(mdir))
-                self.assertTrue(not os.path.exists(mcdir))
-                os.makedirs(mdir, mode=0o755)
-                os.makedirs(mcdir, mode=0o755)
+        img_path = self.img_path()
+        if not target:
+            target = act.attrs["path"]
 
-                # Finally, write the new manifest.
-                with open(mpath, "w") as f:
-                        f.write(mdata)
+        fpath = os.path.join(img_path, target)
+        lstat = os.lstat(fpath)
 
-        def validate_fsobj_attrs(self, act, target=None):
-                """Used to verify that the target item's mode, attrs, timestamp,
-                etc. match as expected.  The actual"""
+        # Verify owner.
+        expected = portable.get_user_by_name(act.attrs["owner"], None, False)
+        actual = lstat.st_uid
+        self.assertEqual(expected, actual)
 
-                if act.name not in ("file", "dir"):
-                        return
+        # Verify group.
+        expected = portable.get_group_by_name(act.attrs["group"], None, False)
+        actual = lstat.st_gid
+        self.assertEqual(expected, actual)
 
-                img_path = self.img_path()
-                if not target:
-                        target = act.attrs["path"]
+        # Verify mode.
+        expected = int(act.attrs["mode"], 8)
+        actual = stat.S_IMODE(lstat.st_mode)
+        self.assertEqual(expected, actual)
 
-                fpath = os.path.join(img_path, target)
-                lstat = os.lstat(fpath)
+    def validate_html_file(
+        self,
+        fname,
+        exit=0,
+        comment="",
+        options="--doctype strict -utf8 -quiet",
+        drop_prop_attrs=False,
+    ):
+        """Run a html file specified by fname through a html validator
+        (tidy). The drop_prop_attrs parameter can be used to ignore
+        proprietary attributes which would otherwise make tidy fail.
+        """
+        if drop_prop_attrs:
+            tfname = fname + ".tmp"
+            os.rename(fname, tfname)
+            moptions = options + " --drop-proprietary-attributes y"
+            cmdline = "tidy {0} {1} > {2}".format(moptions, tfname, fname)
+            self.cmdline_run(
+                cmdline,
+                comment=comment,
+                coverage=False,
+                exit=exit,
+                raise_error=False,
+            )
+            os.unlink(tfname)
 
-                # Verify owner.
-                expected = portable.get_user_by_name(act.attrs["owner"], None,
-                    False)
-                actual = lstat.st_uid
-                self.assertEqual(expected, actual)
+        cmdline = "tidy {0} {1}".format(options, fname)
+        return self.cmdline_run(
+            cmdline, comment=comment, coverage=False, exit=exit
+        )
 
-                # Verify group.
-                expected = portable.get_group_by_name(act.attrs["group"], None,
-                    False)
-                actual = lstat.st_gid
-                self.assertEqual(expected, actual)
+    def create_repo(self, repodir, properties=EmptyDict, version=None):
+        """Convenience routine to help subclasses create a package
+        repository.  Returns a pkg.server.repository.Repository
+        object."""
 
-                # Verify mode.
-                expected = int(act.attrs["mode"], 8)
-                actual = stat.S_IMODE(lstat.st_mode)
-                self.assertEqual(expected, actual)
+        # Note that this must be deferred until after PYTHONPATH
+        # is set up.
+        import pkg.server.repository as sr
 
-        def validate_html_file(self, fname, exit=0, comment="",
-            options="--doctype strict -utf8 -quiet", drop_prop_attrs=False):
-                """ Run a html file specified by fname through a html validator
-                    (tidy). The drop_prop_attrs parameter can be used to ignore
-                    proprietary attributes which would otherwise make tidy fail.
-                """
-                if drop_prop_attrs:
-                        tfname = fname + ".tmp"
-                        os.rename(fname, tfname)
-                        moptions = options + " --drop-proprietary-attributes y"
-                        cmdline = "tidy {0} {1} > {2}".format(moptions, tfname, fname)
-                        self.cmdline_run(cmdline, comment=comment,
-                            coverage=False, exit=exit, raise_error=False)
-                        os.unlink(tfname)
+        try:
+            repo = sr.repository_create(
+                repodir, properties=properties, version=version
+            )
+            self.debug("created repository {0}".format(repodir))
+        except sr.RepositoryExistsError:
+            # Already exists.
+            repo = sr.Repository(root=repodir, properties=properties)
+        return repo
 
-                cmdline = "tidy {0} {1}".format(options, fname)
-                return self.cmdline_run(cmdline, comment=comment,
-                    coverage=False, exit=exit)
+    def get_repo(self, repodir, read_only=False):
+        """Convenience routine to help subclasses retrieve a
+        pkg.server.repository.Repository object for a given
+        path."""
 
-        def create_repo(self, repodir, properties=EmptyDict, version=None):
-                """ Convenience routine to help subclasses create a package
-                    repository.  Returns a pkg.server.repository.Repository
-                    object. """
+        # Note that this must be deferred until after PYTHONPATH
+        # is set up.
+        import pkg.server.repository as sr
 
-                # Note that this must be deferred until after PYTHONPATH
-                # is set up.
-                import pkg.server.repository as sr
-                try:
-                        repo = sr.repository_create(repodir,
-                            properties=properties, version=version)
-                        self.debug("created repository {0}".format(repodir))
-                except sr.RepositoryExistsError:
-                        # Already exists.
-                        repo = sr.Repository(root=repodir,
-                            properties=properties)
-                return repo
+        return sr.Repository(read_only=read_only, root=repodir)
 
-        def get_repo(self, repodir, read_only=False):
-                """ Convenience routine to help subclasses retrieve a
-                    pkg.server.repository.Repository object for a given
-                    path. """
+    def prep_depot(
+        self,
+        port,
+        repodir,
+        logpath,
+        refresh_index=False,
+        debug_features=EmptyI,
+        properties=EmptyI,
+        start=False,
+    ):
+        """Convenience routine to help subclasses prepare
+        depots.  Returns a depotcontroller."""
 
-                # Note that this must be deferred until after PYTHONPATH
-                # is set up.
-                import pkg.server.repository as sr
-                return sr.Repository(read_only=read_only, root=repodir)
+        # Note that this must be deferred until after PYTHONPATH
+        # is set up.
+        import pkg.depotcontroller as depotcontroller
 
-        def prep_depot(self, port, repodir, logpath, refresh_index=False,
-            debug_features=EmptyI, properties=EmptyI, start=False):
-                """ Convenience routine to help subclasses prepare
-                    depots.  Returns a depotcontroller. """
+        self.debug("prep_depot: set depot port {0:d}".format(port))
+        self.debug("prep_depot: set depot repository {0}".format(repodir))
+        self.debug("prep_depot: set depot log to {0}".format(logpath))
 
-                # Note that this must be deferred until after PYTHONPATH
-                # is set up.
-                import pkg.depotcontroller as depotcontroller
+        dc = depotcontroller.DepotController(
+            wrapper_start=self.coverage_cmd.split(), env=self.coverage_env
+        )
+        dc.set_depotd_path(os.path.join(g_pkg_path, "usr/lib/pkg.depotd"))
+        dc.set_depotd_content_root(
+            os.path.join(g_pkg_path, "usr/share/lib/pkg")
+        )
+        for f in debug_features:
+            dc.set_debug_feature(f)
+        dc.set_repodir(repodir)
+        dc.set_logpath(logpath)
+        dc.set_port(port)
 
-                self.debug("prep_depot: set depot port {0:d}".format(port))
-                self.debug("prep_depot: set depot repository {0}".format(repodir))
-                self.debug("prep_depot: set depot log to {0}".format(logpath))
+        for section in properties:
+            for prop, val in six.iteritems(properties[section]):
+                dc.set_property(section, prop, val)
+        if refresh_index:
+            dc.set_refresh_index()
 
-                dc = depotcontroller.DepotController(
-                    wrapper_start=self.coverage_cmd.split(),
-                    env=self.coverage_env)
-                dc.set_depotd_path(os.path.join(g_pkg_path,
-                    "usr/lib/pkg.depotd"))
-                dc.set_depotd_content_root(os.path.join(g_pkg_path,
-                    "usr/share/lib/pkg"))
-                for f in debug_features:
-                        dc.set_debug_feature(f)
-                dc.set_repodir(repodir)
-                dc.set_logpath(logpath)
-                dc.set_port(port)
+        if start:
+            # If the caller requested the depot be started, then let
+            # the depot process create the repository.
+            self.debug("prep_depot: starting depot")
+            try:
+                dc.start()
+            except Exception as e:
+                self.debug(
+                    "prep_depot: failed to start " "depot!: {0}".format(e)
+                )
+                raise
+            self.debug("depot on port {0} started".format(port))
+        else:
+            # Otherwise, create the repository with the assumption
+            # that the caller wants that at the least, but doesn't
+            # need the depot server (yet).
+            self.create_repo(repodir, properties=properties)
+        return dc
 
-                for section in properties:
-                        for prop, val in six.iteritems(properties[section]):
-                                dc.set_property(section, prop, val)
-                if refresh_index:
-                        dc.set_refresh_index()
+    def wait_repo(self, repodir, timeout=5.0):
+        """Wait for the specified repository to complete its current
+        operations before continuing."""
 
-                if start:
-                        # If the caller requested the depot be started, then let
-                        # the depot process create the repository.
-                        self.debug("prep_depot: starting depot")
-                        try:
-                                dc.start()
-                        except Exception as e:
-                                self.debug("prep_depot: failed to start "
-                                    "depot!: {0}".format(e))
-                                raise
-                        self.debug("depot on port {0} started".format(port))
+        check_interval = 0.20
+        time.sleep(check_interval)
+
+        begintime = time.time()
+        ready = False
+        while (time.time() - begintime) <= timeout:
+            status = self.get_repo(repodir).get_status()
+            rdata = status.get("repository", {})
+            repo_status = rdata.get("status", "")
+            if repo_status == "online":
+                for pubdata in rdata.get("publishers", {}).values():
+                    if pubdata.get("status", "") != "online":
+                        ready = False
+                        break
                 else:
-                        # Otherwise, create the repository with the assumption
-                        # that the caller wants that at the least, but doesn't
-                        # need the depot server (yet).
-                        self.create_repo(repodir, properties=properties)
-                return dc
+                    # All repository stores were ready.
+                    ready = True
 
-        def wait_repo(self, repodir, timeout=5.0):
-                """Wait for the specified repository to complete its current
-                operations before continuing."""
-
-                check_interval = 0.20
+            if not ready:
                 time.sleep(check_interval)
+            else:
+                break
 
-                begintime = time.time()
-                ready = False
-                while (time.time() - begintime) <= timeout:
-                        status = self.get_repo(repodir).get_status()
-                        rdata = status.get("repository", {})
-                        repo_status = rdata.get("status", "")
-                        if repo_status == "online":
-                                for pubdata in rdata.get("publishers",
-                                    {}).values():
-                                        if pubdata.get("status", "") != "online":
-                                                ready = False
-                                                break
-                                else:
-                                        # All repository stores were ready.
-                                        ready = True
+        if not ready:
+            raise RuntimeError("Repository readiness " "timeout exceeded.")
 
-                        if not ready:
-                                time.sleep(check_interval)
-                        else:
-                                break
+    def _api_attach(self, api_obj, catch_wsie=True, **kwargs):
+        self.debug("attach: {0}".format(str(kwargs)))
+        for pd in api_obj.gen_plan_attach(**kwargs):
+            continue
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-                if not ready:
-                        raise RuntimeError("Repository readiness "
-                            "timeout exceeded.")
+    def _api_detach(self, api_obj, catch_wsie=True, **kwargs):
+        self.debug("detach: {0}".format(str(kwargs)))
+        for pd in api_obj.gen_plan_detach(**kwargs):
+            continue
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-        def _api_attach(self, api_obj, catch_wsie=True, **kwargs):
-                self.debug("attach: {0}".format(str(kwargs)))
-                for pd in api_obj.gen_plan_attach(**kwargs):
-                        continue
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+    def _api_sync(self, api_obj, catch_wsie=True, **kwargs):
+        self.debug("sync: {0}".format(str(kwargs)))
+        for pd in api_obj.gen_plan_sync(**kwargs):
+            continue
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-        def _api_detach(self, api_obj, catch_wsie=True, **kwargs):
-                self.debug("detach: {0}".format(str(kwargs)))
-                for pd in api_obj.gen_plan_detach(**kwargs):
-                        continue
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+    def _api_install(
+        self,
+        api_obj,
+        pkg_list,
+        catch_wsie=True,
+        show_licenses=False,
+        accept_licenses=False,
+        noexecute=False,
+        **kwargs,
+    ):
+        self.debug("install {0}".format(" ".join(pkg_list)))
 
-        def _api_sync(self, api_obj, catch_wsie=True, **kwargs):
-                self.debug("sync: {0}".format(str(kwargs)))
-                for pd in api_obj.gen_plan_sync(**kwargs):
-                        continue
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+        plan = None
+        for pd in api_obj.gen_plan_install(
+            pkg_list, noexecute=noexecute, **kwargs
+        ):
+            if plan is not None:
+                continue
+            plan = api_obj.describe()
 
-        def _api_install(self, api_obj, pkg_list, catch_wsie=True,
-            show_licenses=False, accept_licenses=False, noexecute=False,
-            **kwargs):
-                self.debug("install {0}".format(" ".join(pkg_list)))
+            # update license status
+            for pfmri, src, dest, accepted, displayed in plan.get_licenses():
+                api_obj.set_plan_license_status(
+                    pfmri,
+                    dest.license,
+                    displayed=show_licenses,
+                    accepted=accept_licenses,
+                )
 
-                plan = None
-                for pd in api_obj.gen_plan_install(pkg_list,
-                    noexecute=noexecute, **kwargs):
+        if noexecute:
+            return
 
-                        if plan is not None:
-                                continue
-                        plan = api_obj.describe()
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-                        # update license status
-                        for pfmri, src, dest, accepted, displayed in \
-                            plan.get_licenses():
-                                api_obj.set_plan_license_status(pfmri,
-                                    dest.license,
-                                    displayed=show_licenses,
-                                    accepted=accept_licenses)
+    def _api_revert(
+        self, api_obj, args, catch_wsie=True, noexecute=False, **kwargs
+    ):
+        self.debug("revert {0}".format(" ".join(args)))
+        for pd in api_obj.gen_plan_revert(args, **kwargs):
+            continue
+        if noexecute:
+            return
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-                if noexecute:
-                        return
+    def _api_dehydrate(
+        self, api_obj, publishers=[], catch_wsie=True, noexecute=False, **kwargs
+    ):
+        self.debug("dehydrate {0}".format(" ".join(publishers)))
+        for pd in api_obj.gen_plan_dehydrate(publishers, **kwargs):
+            continue
+        if noexecute:
+            return
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+    def _api_rehydrate(
+        self, api_obj, publishers=[], catch_wsie=True, noexecute=False, **kwargs
+    ):
+        self.debug("rehydrate {0}".format(" ".join(publishers)))
+        for pd in api_obj.gen_plan_rehydrate(publishers, **kwargs):
+            continue
+        if noexecute:
+            return
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-        def _api_revert(self, api_obj, args, catch_wsie=True, noexecute=False,
-            **kwargs):
-                self.debug("revert {0}".format(" ".join(args)))
-                for pd in api_obj.gen_plan_revert(args, **kwargs):
-                        continue
-                if noexecute:
-                        return
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+    def _api_fix(
+        self, api_obj, args="", catch_wsie=True, noexecute=False, **kwargs
+    ):
+        self.debug("planning fix")
+        for pd in api_obj.gen_plan_fix(args, **kwargs):
+            continue
+        if noexecute:
+            return
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-        def _api_dehydrate(self, api_obj, publishers=[], catch_wsie=True,
-            noexecute=False, **kwargs):
-                self.debug("dehydrate {0}".format(" ".join(publishers)))
-                for pd in api_obj.gen_plan_dehydrate(publishers, **kwargs):
-                        continue
-                if noexecute:
-                        return
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+    def _api_uninstall(self, api_obj, pkg_list, catch_wsie=True, **kwargs):
+        self.debug("uninstall {0}".format(" ".join(pkg_list)))
+        for pd in api_obj.gen_plan_uninstall(pkg_list, **kwargs):
+            continue
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-        def _api_rehydrate(self, api_obj, publishers=[], catch_wsie=True,
-            noexecute=False, **kwargs):
-                self.debug("rehydrate {0}".format(" ".join(publishers)))
-                for pd in api_obj.gen_plan_rehydrate(publishers, **kwargs):
-                        continue
-                if noexecute:
-                        return
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+    def _api_update(self, api_obj, catch_wsie=True, noexecute=False, **kwargs):
+        self.debug("planning update")
+        for pd in api_obj.gen_plan_update(noexecute=noexecute, **kwargs):
+            continue
+        if noexecute:
+            return
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-        def _api_fix(self, api_obj, args="", catch_wsie=True, noexecute=False,
-            **kwargs):
-                self.debug("planning fix")
-                for pd in api_obj.gen_plan_fix(args, **kwargs):
-                        continue
-                if noexecute:
-                        return
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+    def _api_change_varcets(self, api_obj, catch_wsie=True, **kwargs):
+        self.debug("change varcets: {0}".format(str(kwargs)))
+        for pd in api_obj.gen_plan_change_varcets(**kwargs):
+            continue
+        self._api_finish(api_obj, catch_wsie=catch_wsie)
 
-        def _api_uninstall(self, api_obj, pkg_list, catch_wsie=True, **kwargs):
-                self.debug("uninstall {0}".format(" ".join(pkg_list)))
-                for pd in api_obj.gen_plan_uninstall(pkg_list, **kwargs):
-                        continue
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+    def _api_finish(self, api_obj, catch_wsie=True):
+        api_obj.prepare()
+        try:
+            api_obj.execute_plan()
+        except apx.WrapSuccessfulIndexingException:
+            if not catch_wsie:
+                raise
+        api_obj.reset()
 
-        def _api_update(self, api_obj, catch_wsie=True, noexecute=False,
-            **kwargs):
-                self.debug("planning update")
-                for pd in api_obj.gen_plan_update(noexecute=noexecute,
-                    **kwargs):
-                        continue
-                if noexecute:
-                        return
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+    def file_inode(self, path):
+        """Return the inode number of a file in the image."""
 
-        def _api_change_varcets(self, api_obj, catch_wsie=True, **kwargs):
-                self.debug("change varcets: {0}".format(str(kwargs)))
-                for pd in api_obj.gen_plan_change_varcets(**kwargs):
-                        continue
-                self._api_finish(api_obj, catch_wsie=catch_wsie)
+        file_path = os.path.join(self.get_img_path(), path)
+        st = os.stat(file_path)
+        return st.st_ino
 
-        def _api_finish(self, api_obj, catch_wsie=True):
+    def file_size(self, path):
+        """Return the size of a file in the image."""
 
-                api_obj.prepare()
-                try:
-                        api_obj.execute_plan()
-                except apx.WrapSuccessfulIndexingException:
-                        if not catch_wsie:
-                                raise
-                api_obj.reset()
+        file_path = os.path.join(self.get_img_path(), path)
+        st = os.stat(file_path)
+        return st.st_size
 
-        def file_inode(self, path):
-                """Return the inode number of a file in the image."""
+    def file_chmod(self, path, mode):
+        """Change the mode of a file in the image."""
 
-                file_path = os.path.join(self.get_img_path(), path)
-                st = os.stat(file_path)
-                return st.st_ino
+        file_path = os.path.join(self.get_img_path(), path)
+        os.chmod(file_path, mode)
 
-        def file_size(self, path):
-                """Return the size of a file in the image."""
+    def file_chown(self, path, owner=None, group=None):
+        """Change the ownership of a file in the image."""
 
-                file_path = os.path.join(self.get_img_path(), path)
-                st = os.stat(file_path)
-                return st.st_size
+        file_path = os.path.join(self.get_img_path(), path)
+        uid = pwd.getpwnam(owner).pw_uid
+        gid = grp.getgrnam(group).gr_gid
+        os.chown(file_path, uid, gid)
 
-        def file_chmod(self, path, mode):
-                """Change the mode of a file in the image."""
+    def file_exists(self, path, mode=None, owner=None, group=None):
+        """Assert the existence of a file in the image."""
 
-                file_path = os.path.join(self.get_img_path(), path)
-                os.chmod(file_path, mode)
+        file_path = os.path.join(self.get_img_path(), path)
+        try:
+            st = os.stat(file_path)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                self.assertTrue(False, "File {0} does not exist".format(path))
+            else:
+                raise
+        if mode is not None:
+            self.assertEqual(mode, stat.S_IMODE(st.st_mode))
+        if owner is not None:
+            uid = pwd.getpwnam(owner).pw_uid
+            self.assertEqual(uid, st.st_uid)
+        if group is not None:
+            gid = grp.getgrnam(group).gr_gid
+            self.assertEqual(gid, st.st_gid)
 
-        def file_chown(self, path, owner=None, group=None):
-                """Change the ownership of a file in the image."""
+    def dir_exists(self, path, mode=None, owner=None, group=None):
+        """Assert the existence of a directory in the image."""
 
-                file_path = os.path.join(self.get_img_path(), path)
-                uid = pwd.getpwnam(owner).pw_uid
-                gid = grp.getgrnam(group).gr_gid
-                os.chown(file_path, uid, gid)
+        dir_path = os.path.join(self.get_img_path(), path)
+        try:
+            st = os.stat(dir_path)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                self.assertTrue(
+                    False, "Directory {0} does not exist".format(path)
+                )
+            else:
+                raise
+        if mode is not None:
+            self.assertEqual(mode, stat.S_IMODE(st.st_mode))
+        if owner is not None:
+            uid = pwd.getpwnam(owner).pw_uid
+            self.assertEqual(uid, st.st_uid)
+        if group is not None:
+            gid = grp.getgrnam(group).gr_gid
+            self.assertEqual(gid, st.st_gid)
 
-        def file_exists(self, path, mode=None, owner=None, group=None):
-                """Assert the existence of a file in the image."""
+    def link_exists(self, path, target=None):
+        """Assert the existence of a link in the image."""
 
-                file_path = os.path.join(self.get_img_path(), path)
-                try:
-                        st = os.stat(file_path)
-                except OSError as e:
-                        if e.errno == errno.ENOENT:
-                                self.assertTrue(False,
-                                    "File {0} does not exist".format(path))
-                        else:
-                                raise
-                if mode is not None:
-                        self.assertEqual(mode, stat.S_IMODE(st.st_mode))
-                if owner is not None:
-                        uid = pwd.getpwnam(owner).pw_uid
-                        self.assertEqual(uid, st.st_uid)
-                if group is not None:
-                        gid = grp.getgrnam(group).gr_gid
-                        self.assertEqual(gid, st.st_gid)
+        file_path = os.path.join(self.get_img_path(), path)
+        try:
+            st = os.lstat(file_path)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                self.assertTrue(False, "Link {0} does not exist".format(path))
+            else:
+                raise
+        self.assertTrue(stat.S_ISLNK(st.st_mode), f"{path} is not a link")
+        if target is not None:
+            atarget = os.readlink(file_path)
+            self.assertTrue(
+                target == atarget,
+                f"link target is {atarget} should be {target}",
+            )
 
-        def dir_exists(self, path, mode=None, owner=None, group=None):
-                """Assert the existence of a directory in the image."""
+    def file_doesnt_exist(self, path):
+        """Assert the non-existence of a file in the image."""
 
-                dir_path = os.path.join(self.get_img_path(), path)
-                try:
-                        st = os.stat(dir_path)
-                except OSError as e:
-                        if e.errno == errno.ENOENT:
-                                self.assertTrue(False,
-                                    "Directory {0} does not exist".format(path))
-                        else:
-                                raise
-                if mode is not None:
-                        self.assertEqual(mode, stat.S_IMODE(st.st_mode))
-                if owner is not None:
-                        uid = pwd.getpwnam(owner).pw_uid
-                        self.assertEqual(uid, st.st_uid)
-                if group is not None:
-                        gid = grp.getgrnam(group).gr_gid
-                        self.assertEqual(gid, st.st_gid)
+        file_path = os.path.join(self.get_img_path(), path)
+        if os.path.exists(file_path):
+            self.assertTrue(False, "File {0} exists".format(path))
 
-        def link_exists(self, path, target=None):
-                """Assert the existence of a link in the image."""
+    def files_are_all_there(self, paths):
+        """ "Assert that files are there in the image."""
+        for p in paths:
+            if p.endswith(os.path.sep):
+                file_path = os.path.join(self.get_img_path(), p)
+                if not os.path.isdir(file_path):
+                    if not os.path.exists(file_path):
+                        self.assertTrue(
+                            False, "missing dir {0}".format(file_path)
+                        )
+                    else:
+                        self.assertTrue(False, "not dir: {0}".format(file_path))
+            else:
+                self.file_exists(p)
 
-                file_path = os.path.join(self.get_img_path(), path)
-                try:
-                        st = os.lstat(file_path)
-                except OSError as e:
-                        if e.errno == errno.ENOENT:
-                                self.assertTrue(False,
-                                    "Link {0} does not exist".format(path))
-                        else:
-                                raise
-                self.assertTrue(stat.S_ISLNK(st.st_mode),
-                    f'{path} is not a link')
-                if target is not None:
-                        atarget = os.readlink(file_path)
-                        self.assertTrue(target == atarget,
-                            f'link target is {atarget} should be {target}')
+    def files_are_all_missing(self, paths):
+        """Assert that files are all missing in the image."""
+        for p in paths:
+            self.file_doesnt_exist(p)
 
-        def file_doesnt_exist(self, path):
-                """Assert the non-existence of a file in the image."""
+    def assert_file_exists(self, path, negate=False):
+        """Verify that the specified path exists. If negate is
+        true, then make sure the path doesn't exist"""
 
-                file_path = os.path.join(self.get_img_path(), path)
-                if os.path.exists(file_path):
-                        self.assertTrue(False, "File {0} exists".format(path))
+        file_path = os.path.join(self.get_img_path(), str(path))
 
-        def files_are_all_there(self, paths):
-                """"Assert that files are there in the image."""
-                for p in paths:
-                        if p.endswith(os.path.sep):
-                                file_path = os.path.join(self.get_img_path(), p)
-                                if not os.path.isdir(file_path):
-                                        if not os.path.exists(file_path):
-                                                self.assertTrue(False,
-                                                    "missing dir {0}".format(file_path))
-                                        else:
-                                                self.assertTrue(False,
-                                                    "not dir: {0}".format(file_path))
-                        else:
-                                self.file_exists(p)
-
-        def files_are_all_missing(self, paths):
-                """Assert that files are all missing in the image."""
-                for p in paths:
-                        self.file_doesnt_exist(p)
-
-        def assert_file_exists(self, path, negate=False):
-                """Verify that the specified path exists. If negate is
-                    true, then make sure the path doesn't exist"""
-
-                file_path = os.path.join(self.get_img_path(), str(path))
-
-                try:
-                        open(file_path).close()
-                except IOError as e:
-                        if e.errno == errno.ENOENT and negate:
-                                return
-                        self.assertTrue(False,
-                            "File {0} is missing".format(path))
-                # file is there
-                if negate:
-                        self.assertTrue(False,
-                            "File {0} should not exist".format(path))
+        try:
+            open(file_path).close()
+        except IOError as e:
+            if e.errno == errno.ENOENT and negate:
                 return
+            self.assertTrue(False, "File {0} is missing".format(path))
+        # file is there
+        if negate:
+            self.assertTrue(False, "File {0} should not exist".format(path))
+        return
 
-        def assert_files_exist(self, flist):
-                error = ""
-                for (path, exist) in flist:
-                        file_path = os.path.join(self.get_img_path(), path)
-                        try:
-                                self.assert_file_exists(file_path,
-                                    negate=not exist)
-                        except AssertionError as e:
-                                error += "\n{0}".format(e)
-                if error:
-                        raise AssertionError(error)
+    def assert_files_exist(self, flist):
+        error = ""
+        for path, exist in flist:
+            file_path = os.path.join(self.get_img_path(), path)
+            try:
+                self.assert_file_exists(file_path, negate=not exist)
+            except AssertionError as e:
+                error += "\n{0}".format(e)
+        if error:
+            raise AssertionError(error)
 
-        def file_remove(self, path):
-                """Remove a file in the image."""
+    def file_remove(self, path):
+        """Remove a file in the image."""
 
-                file_path = os.path.join(self.get_img_path(), path)
-                portable.remove(file_path)
+        file_path = os.path.join(self.get_img_path(), path)
+        portable.remove(file_path)
 
-        def file_contains(self, path, strings, appearances=1):
-                """Assert the existence of strings provided in a file in the
-                image. The counting of appearances is line based. Repeated
-                string on the same line will be count once."""
+    def file_contains(self, path, strings, appearances=1):
+        """Assert the existence of strings provided in a file in the
+        image. The counting of appearances is line based. Repeated
+        string on the same line will be count once."""
 
-                if isinstance(strings, six.string_types):
-                        strings = [strings]
+        if isinstance(strings, six.string_types):
+            strings = [strings]
 
-                # Initialize a dict for counting appearances.
-                sdict = {}
-                for s in strings:
-                        sdict[s] = appearances
+        # Initialize a dict for counting appearances.
+        sdict = {}
+        for s in strings:
+            sdict[s] = appearances
 
-                file_path = os.path.join(self.get_img_path(), path)
-                try:
-                        f = open(file_path)
-                except:
-                        self.assertTrue(False,
-                            "File {0} does not exist or contain {1}".format(
-                            path, strings))
+        file_path = os.path.join(self.get_img_path(), path)
+        try:
+            f = open(file_path)
+        except:
+            self.assertTrue(
+                False,
+                "File {0} does not exist or contain {1}".format(path, strings),
+            )
 
-                for line in f:
-                        for k in sdict:
-                                if k in line:
-                                        sdict[k] -= 1
-                        # If all counts become < 0, we know we have found all
-                        # occurrences for all strings.
-                        if all(v <= 0 for v in sdict.values()):
-                                f.close()
-                                break
-                else:
-                        f.close()
-                        self.assertTrue(False, "File {0} does not contain {1} "
-                            "{2}".format(path, appearances, strings))
+        for line in f:
+            for k in sdict:
+                if k in line:
+                    sdict[k] -= 1
+            # If all counts become < 0, we know we have found all
+            # occurrences for all strings.
+            if all(v <= 0 for v in sdict.values()):
+                f.close()
+                break
+        else:
+            f.close()
+            self.assertTrue(
+                False,
+                "File {0} does not contain {1} "
+                "{2}".format(path, appearances, strings),
+            )
 
-        def file_doesnt_contain(self, path, strings):
-                """Assert the non-existence of strings in a file in the image.
-                """
-                if isinstance(strings, six.string_types):
-                        strings = [strings]
+    def file_doesnt_contain(self, path, strings):
+        """Assert the non-existence of strings in a file in the image."""
+        if isinstance(strings, six.string_types):
+            strings = [strings]
 
-                file_path = os.path.join(self.get_img_path(), path)
-                f = open(file_path)
-                for line in f:
-                        if any(s in line for s in strings):
-                                f.close()
-                                self.assertTrue(False, "File {0} contains any "
-                                    "of {1}".format(path, strings))
-                else:
-                        f.close()
+        file_path = os.path.join(self.get_img_path(), path)
+        f = open(file_path)
+        for line in f:
+            if any(s in line for s in strings):
+                f.close()
+                self.assertTrue(
+                    False,
+                    "File {0} contains any " "of {1}".format(path, strings),
+                )
+        else:
+            f.close()
 
-        def file_create(self, path, string=None):
-                """Create a new file containing "string" """
-                file_path = self.get_img_file_path(path)
-                if not os.path.exists(os.path.dirname(file_path)):
-                        os.makedirs(os.path.dirname(file_path))
-                with open(file_path, "a") as f:
-                        if string: f.write("{0}".format(string))
+    def file_create(self, path, string=None):
+        """Create a new file containing "string" """
+        file_path = self.get_img_file_path(path)
+        if not os.path.exists(os.path.dirname(file_path)):
+            os.makedirs(os.path.dirname(file_path))
+        with open(file_path, "a") as f:
+            if string:
+                f.write("{0}".format(string))
 
-        def file_touch(self, path, times=None):
-                self.file_create(path)
-                os.utime(self.get_img_file_path(path), times)
+    def file_touch(self, path, times=None):
+        self.file_create(path)
+        os.utime(self.get_img_file_path(path), times)
 
-        def file_append(self, path, string):
-                """Append a line to a file in the image."""
+    def file_append(self, path, string):
+        """Append a line to a file in the image."""
 
-                file_path = os.path.join(self.get_img_path(), path)
-                with open(file_path, "a+") as f:
-                        f.write("\n{0}\n".format(string))
+        file_path = os.path.join(self.get_img_path(), path)
+        with open(file_path, "a+") as f:
+            f.write("\n{0}\n".format(string))
 
-        def seed_ta_dir(self, certs, dest_dir=None):
-                if isinstance(certs, six.string_types):
-                        certs = [certs]
-                if not dest_dir:
-                        dest_dir = self.ta_dir
-                self.assertTrue(dest_dir)
-                self.assertTrue(self.raw_trust_anchor_dir)
-                for c in certs:
-                        name = "{0}_cert.pem".format(c)
-                        portable.copyfile(
-                            os.path.join(self.raw_trust_anchor_dir, name),
-                            os.path.join(dest_dir, name))
+    def seed_ta_dir(self, certs, dest_dir=None):
+        if isinstance(certs, six.string_types):
+            certs = [certs]
+        if not dest_dir:
+            dest_dir = self.ta_dir
+        self.assertTrue(dest_dir)
+        self.assertTrue(self.raw_trust_anchor_dir)
+        for c in certs:
+            name = "{0}_cert.pem".format(c)
+            portable.copyfile(
+                os.path.join(self.raw_trust_anchor_dir, name),
+                os.path.join(dest_dir, name),
+            )
 
-        def create_some_files(self, paths):
-                ubin = portable.get_user_by_name("bin", None, False)
-                groot = portable.get_group_by_name("root", None, False)
-                for p in paths:
-                        if p.startswith(os.path.sep):
-                                p = p[1:]
-                        file_path = os.path.join(self.get_img_path(), p)
-                        dirpath = os.path.dirname(file_path)
-                        if not os.path.exists(dirpath):
-                                os.mkdir(dirpath)
-                        if p.endswith(os.path.sep):
-                                continue
-                        with open(file_path, "a+") as f:
-                                f.write("\ncontents\n")
-                        os.chown(file_path, ubin, groot)
-                        os.chmod(file_path, misc.PKG_RO_FILE_MODE)
+    def create_some_files(self, paths):
+        ubin = portable.get_user_by_name("bin", None, False)
+        groot = portable.get_group_by_name("root", None, False)
+        for p in paths:
+            if p.startswith(os.path.sep):
+                p = p[1:]
+            file_path = os.path.join(self.get_img_path(), p)
+            dirpath = os.path.dirname(file_path)
+            if not os.path.exists(dirpath):
+                os.mkdir(dirpath)
+            if p.endswith(os.path.sep):
+                continue
+            with open(file_path, "a+") as f:
+                f.write("\ncontents\n")
+            os.chown(file_path, ubin, groot)
+            os.chmod(file_path, misc.PKG_RO_FILE_MODE)
 
 
 class ManyDepotTestCase(CliTestCase):
+    def __init__(self, methodName="runTest"):
+        super(ManyDepotTestCase, self).__init__(methodName)
+        self.dcs = {}
 
-        def __init__(self, methodName="runTest"):
-                super(ManyDepotTestCase, self).__init__(methodName)
-                self.dcs = {}
+    def setUp(
+        self,
+        publishers,
+        debug_features=EmptyI,
+        start_depots=False,
+        image_count=1,
+    ):
+        CliTestCase.setUp(self, image_count=image_count)
 
-        def setUp(self, publishers, debug_features=EmptyI, start_depots=False,
-            image_count=1):
-                CliTestCase.setUp(self, image_count=image_count)
+        self.debug("setup: {0}".format(self.id()))
+        self.debug("creating {0:d} repo(s)".format(len(publishers)))
+        self.debug("publishers: {0}".format(publishers))
+        self.debug("debug_features: {0}".format(list(debug_features)))
+        self.dcs = {}
 
-                self.debug("setup: {0}".format(self.id()))
-                self.debug("creating {0:d} repo(s)".format(len(publishers)))
-                self.debug("publishers: {0}".format(publishers))
-                self.debug("debug_features: {0}".format(list(debug_features)))
-                self.dcs = {}
+        for n, pub in enumerate(publishers):
+            i = n + 1
+            testdir = os.path.join(self.test_root)
 
-                for n, pub in enumerate(publishers):
-                        i = n + 1
-                        testdir = os.path.join(self.test_root)
+            try:
+                os.makedirs(testdir, 0o755)
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise e
 
-                        try:
-                                os.makedirs(testdir, 0o755)
-                        except OSError as e:
-                                if e.errno != errno.EEXIST:
-                                        raise e
+            depot_logfile = os.path.join(
+                testdir, "depot_logfile{0:d}".format(i)
+            )
 
-                        depot_logfile = os.path.join(testdir,
-                            "depot_logfile{0:d}".format(i))
+            props = {"publisher": {"prefix": pub}}
 
-                        props = { "publisher": { "prefix": pub } }
+            # We pick an arbitrary base port.  This could be more
+            # automated in the future.
+            repodir = os.path.join(testdir, "repo_contents{0:d}".format(i))
+            self.dcs[i] = self.prep_depot(
+                self.next_free_port,
+                repodir,
+                depot_logfile,
+                debug_features=debug_features,
+                properties=props,
+                start=start_depots,
+            )
+            self.next_free_port += 1
 
-                        # We pick an arbitrary base port.  This could be more
-                        # automated in the future.
-                        repodir = os.path.join(testdir, "repo_contents{0:d}".format(i))
-                        self.dcs[i] = self.prep_depot(self.next_free_port,
-                            repodir,
-                            depot_logfile, debug_features=debug_features,
-                            properties=props, start=start_depots)
-                        self.next_free_port += 1
+    def check_traceback(self, logpath):
+        """Scan logpath looking for tracebacks.
+        Raise a DepotTracebackException if one is seen.
+        """
+        self.debug("check for depot tracebacks in {0}".format(logpath))
+        logfile = open(logpath, "r")
+        output = logfile.read()
+        for line in output.splitlines():
+            if line.find("Traceback") > -1:
+                raise DepotTracebackException(logpath, output)
+        logfile.close()
 
-        def check_traceback(self, logpath):
-                """ Scan logpath looking for tracebacks.
-                    Raise a DepotTracebackException if one is seen.
-                """
-                self.debug("check for depot tracebacks in {0}".format(logpath))
-                logfile = open(logpath, "r")
-                output = logfile.read()
-                for line in output.splitlines():
-                        if line.find("Traceback") > -1:
-                                raise DepotTracebackException(logpath, output)
-                logfile.close()
+    def restart_depots(self):
+        self.debug("restarting {0:d} depot(s)".format(len(self.dcs)))
+        for i in sorted(self.dcs.keys()):
+            dc = self.dcs[i]
+            self.debug("stopping depot at url: {0}".format(dc.get_depot_url()))
+            dc.stop()
+            self.debug("starting depot at url: {0}".format(dc.get_depot_url()))
+            dc.start()
 
-        def restart_depots(self):
-                self.debug("restarting {0:d} depot(s)".format(len(self.dcs)))
-                for i in sorted(self.dcs.keys()):
-                        dc = self.dcs[i]
-                        self.debug("stopping depot at url: {0}".format(dc.get_depot_url()))
-                        dc.stop()
-                        self.debug("starting depot at url: {0}".format(dc.get_depot_url()))
-                        dc.start()
+    def killall_sighandler(self, signum, frame):
+        print("Ctrl-C: I'm killing depots, please wait.\n", file=sys.stderr)
+        print(self)
+        self.signalled = True
 
-        def killall_sighandler(self, signum, frame):
-                print("Ctrl-C: I'm killing depots, please wait.\n",
-                    file=sys.stderr)
-                print(self)
-                self.signalled = True
+    def killalldepots(self):
+        self.signalled = False
+        self.debug("killalldepots: {0}".format(self.id()))
 
-        def killalldepots(self):
-                self.signalled = False
-                self.debug("killalldepots: {0}".format(self.id()))
+        oldhdlr = signal.signal(signal.SIGINT, self.killall_sighandler)
 
-                oldhdlr = signal.signal(signal.SIGINT, self.killall_sighandler)
+        try:
+            check_dc = []
+            for i in sorted(self.dcs.keys()):
+                dc = self.dcs[i]
+                if not dc.started:
+                    continue
+                check_dc.append(dc)
+                path = dc.get_repodir()
+                self.debug(
+                    "stopping depot at url: {0}, {1}".format(
+                        dc.get_depot_url(), path
+                    )
+                )
 
+                status = 0
                 try:
-                        check_dc = []
-                        for i in sorted(self.dcs.keys()):
-                                dc = self.dcs[i]
-                                if not dc.started:
-                                        continue
-                                check_dc.append(dc)
-                                path = dc.get_repodir()
-                                self.debug("stopping depot at url: {0}, {1}".format(
-                                    dc.get_depot_url(), path))
+                    status = dc.kill()
+                except Exception:
+                    pass
 
-                                status = 0
-                                try:
-                                        status = dc.kill()
-                                except Exception:
-                                        pass
+                if status:
+                    self.debug("depot: {0}".format(status))
 
-                                if status:
-                                        self.debug("depot: {0}".format(status))
+            for dc in check_dc:
+                try:
+                    self.check_traceback(dc.get_logpath())
+                except Exception:
+                    pass
+        finally:
+            signal.signal(signal.SIGINT, oldhdlr)
 
-                        for dc in check_dc:
-                                try:
-                                        self.check_traceback(dc.get_logpath())
-                                except Exception:
-                                        pass
-                finally:
-                        signal.signal(signal.SIGINT, oldhdlr)
+        self.dcs = {}
+        if self.signalled:
+            raise KeyboardInterrupt("Ctrl-C while killing depots.")
 
-                self.dcs = {}
-                if self.signalled:
-                        raise KeyboardInterrupt("Ctrl-C while killing depots.")
+    def tearDown(self):
+        self.debug("ManyDepotTestCase.tearDown: {0}".format(self.id()))
 
-        def tearDown(self):
-                self.debug("ManyDepotTestCase.tearDown: {0}".format(self.id()))
+        self.killalldepots()
+        CliTestCase.tearDown(self)
 
-                self.killalldepots()
-                CliTestCase.tearDown(self)
-
-        def run(self, result=None):
-                if result is None:
-                        result = self.defaultTestResult()
-                CliTestCase.run(self, result)
+    def run(self, result=None):
+        if result is None:
+            result = self.defaultTestResult()
+        CliTestCase.run(self, result)
 
 
 class ApacheDepotTestCase(ManyDepotTestCase):
-        """A TestCase that uses one or more Apache instances in the course of
-        its work, along with potentially one or more DepotControllers.
-        """
+    """A TestCase that uses one or more Apache instances in the course of
+    its work, along with potentially one or more DepotControllers.
+    """
 
-        def __init__(self, methodName="runTest"):
-                super(ManyDepotTestCase, self).__init__(methodName)
-                self.dcs = {}
-                self.acs = {}
+    def __init__(self, methodName="runTest"):
+        super(ManyDepotTestCase, self).__init__(methodName)
+        self.dcs = {}
+        self.acs = {}
 
-        def register_apache_controller(self, name, ac):
-                """Registers an ApacheController with this TestCase.
-                We include this method here to make it easier to kill any
-                instances of Apache that were left floating around at the end
-                of the test.
+    def register_apache_controller(self, name, ac):
+        """Registers an ApacheController with this TestCase.
+        We include this method here to make it easier to kill any
+        instances of Apache that were left floating around at the end
+        of the test.
 
-                We enforce the use of this method in
-                <ApacheController>.start() by refusing to start instances until
-                they are registered, which makes the test suite as a whole more
-                resilient, when setting up and tearing down test classes."""
+        We enforce the use of this method in
+        <ApacheController>.start() by refusing to start instances until
+        they are registered, which makes the test suite as a whole more
+        resilient, when setting up and tearing down test classes."""
 
-                if name in self.acs:
-                        # registering an Apache controller that is already
-                        # registered causes us to kill the existing controller
-                        # first.
-                        try:
-                                self.acs[name].stop()
-                        except Exception as e:
-                                try:
-                                        self.acs[name].kill()
-                                except Exception as e:
-                                        pass
-                self.acs[name] = ac
-
-        def __get_ac(self):
-                """If we only use a single ApacheController, self.ac will
-                return that controller, otherwise we return None."""
-                if self.acs and len(self.acs) == 1:
-                        return self.acs[list(self.acs.keys())[0]]
-                else:
-                        return None
-
-        def killalldepots(self):
+        if name in self.acs:
+            # registering an Apache controller that is already
+            # registered causes us to kill the existing controller
+            # first.
+            try:
+                self.acs[name].stop()
+            except Exception as e:
                 try:
-                        ManyDepotTestCase.killalldepots(self)
-                finally:
-                        for name, ac in self.acs.items():
-                                self.debug("stopping apache controller {0}".format(
-                                    name))
-                                try:
-                                        ac.stop()
-                                except Exception as e :
-                                        try:
-                                                self.debug("killing apache "
-                                                    "instance {0}".format(name))
-                                                ac.kill()
-                                        except Exception as e:
-                                                self.debug("Unable to kill "
-                                                    "apache instance {0}. This "
-                                                    "could cause subsequent "
-                                                    "tests to fail.".format(name))
+                    self.acs[name].kill()
+                except Exception as e:
+                    pass
+        self.acs[name] = ac
 
-        # ac is a readonly property which returns a registered ApacheController
-        # provided there is exactly one registered, for convenience of writing
-        # test cases.
-        ac = property(fget=__get_ac)
+    def __get_ac(self):
+        """If we only use a single ApacheController, self.ac will
+        return that controller, otherwise we return None."""
+        if self.acs and len(self.acs) == 1:
+            return self.acs[list(self.acs.keys())[0]]
+        else:
+            return None
+
+    def killalldepots(self):
+        try:
+            ManyDepotTestCase.killalldepots(self)
+        finally:
+            for name, ac in self.acs.items():
+                self.debug("stopping apache controller {0}".format(name))
+                try:
+                    ac.stop()
+                except Exception as e:
+                    try:
+                        self.debug(
+                            "killing apache " "instance {0}".format(name)
+                        )
+                        ac.kill()
+                    except Exception as e:
+                        self.debug(
+                            "Unable to kill "
+                            "apache instance {0}. This "
+                            "could cause subsequent "
+                            "tests to fail.".format(name)
+                        )
+
+    # ac is a readonly property which returns a registered ApacheController
+    # provided there is exactly one registered, for convenience of writing
+    # test cases.
+    ac = property(fget=__get_ac)
+
 
 class HTTPSTestClass(ApacheDepotTestCase):
-        # Tests in this suite use the read only data directory.
-        need_ro_data = True
+    # Tests in this suite use the read only data directory.
+    need_ro_data = True
 
-        def pkg(self, command, *args, **kwargs):
-                # The value for ssl_ca_file is pulled from DebugValues because
-                # ssl_ca_file needs to be set there so the api object calls work
-                # as desired.
-                command = "--debug ssl_ca_file={0} {1}".format(
-                    DebugValues["ssl_ca_file"], command)
-                return ApacheDepotTestCase.pkg(self, command,
-                    *args, **kwargs)
+    def pkg(self, command, *args, **kwargs):
+        # The value for ssl_ca_file is pulled from DebugValues because
+        # ssl_ca_file needs to be set there so the api object calls work
+        # as desired.
+        command = "--debug ssl_ca_file={0} {1}".format(
+            DebugValues["ssl_ca_file"], command
+        )
+        return ApacheDepotTestCase.pkg(self, command, *args, **kwargs)
 
-        def pkgrecv(self, command, *args, **kwargs):
-                # The value for ssl_ca_file is pulled from DebugValues because
-                # ssl_ca_file needs to be set there so the api object calls work
-                # as desired.
-                command = "{0} --debug ssl_ca_file={1}".format(
-                    command, DebugValues["ssl_ca_file"])
-                return ApacheDepotTestCase.pkgrecv(self, command,
-                    *args, **kwargs)
+    def pkgrecv(self, command, *args, **kwargs):
+        # The value for ssl_ca_file is pulled from DebugValues because
+        # ssl_ca_file needs to be set there so the api object calls work
+        # as desired.
+        command = "{0} --debug ssl_ca_file={1}".format(
+            command, DebugValues["ssl_ca_file"]
+        )
+        return ApacheDepotTestCase.pkgrecv(self, command, *args, **kwargs)
 
-        def pkgsend(self, command, *args, **kwargs):
-                # The value for ssl_ca_file is pulled from DebugValues because
-                # ssl_ca_file needs to be set there so the api object calls work
-                # as desired.
-                command = "{0} --debug ssl_ca_file={1}".format(
-                    command, DebugValues["ssl_ca_file"])
-                return ApacheDepotTestCase.pkgsend(self, command,
-                    *args, **kwargs)
+    def pkgsend(self, command, *args, **kwargs):
+        # The value for ssl_ca_file is pulled from DebugValues because
+        # ssl_ca_file needs to be set there so the api object calls work
+        # as desired.
+        command = "{0} --debug ssl_ca_file={1}".format(
+            command, DebugValues["ssl_ca_file"]
+        )
+        return ApacheDepotTestCase.pkgsend(self, command, *args, **kwargs)
 
-        def pkgrepo(self, command, *args, **kwargs):
-                # The value for ssl_ca_file is pulled from DebugValues because
-                # ssl_ca_file needs to be set there so the api object calls work
-                # as desired.
-                command = "--debug ssl_ca_file={0} {1}".format(
-                    DebugValues["ssl_ca_file"], command)
-                return ApacheDepotTestCase.pkgrepo(self, command,
-                    *args, **kwargs)
+    def pkgrepo(self, command, *args, **kwargs):
+        # The value for ssl_ca_file is pulled from DebugValues because
+        # ssl_ca_file needs to be set there so the api object calls work
+        # as desired.
+        command = "--debug ssl_ca_file={0} {1}".format(
+            DebugValues["ssl_ca_file"], command
+        )
+        return ApacheDepotTestCase.pkgrepo(self, command, *args, **kwargs)
 
-        def seed_ta_dir(self, certs, dest_dir=None):
-                if isinstance(certs, six.string_types):
-                        certs = [certs]
-                if not dest_dir:
-                        dest_dir = self.ta_dir
-                self.assertTrue(dest_dir)
-                self.assertTrue(self.raw_trust_anchor_dir)
-                for c in certs:
-                        name = "{0}_cert.pem".format(c)
-                        portable.copyfile(
-                            os.path.join(self.raw_trust_anchor_dir, name),
-                            os.path.join(dest_dir, name))
-                        DebugValues["ssl_ca_file"] = os.path.join(dest_dir,
-                            name)
+    def seed_ta_dir(self, certs, dest_dir=None):
+        if isinstance(certs, six.string_types):
+            certs = [certs]
+        if not dest_dir:
+            dest_dir = self.ta_dir
+        self.assertTrue(dest_dir)
+        self.assertTrue(self.raw_trust_anchor_dir)
+        for c in certs:
+            name = "{0}_cert.pem".format(c)
+            portable.copyfile(
+                os.path.join(self.raw_trust_anchor_dir, name),
+                os.path.join(dest_dir, name),
+            )
+            DebugValues["ssl_ca_file"] = os.path.join(dest_dir, name)
 
-        def get_cli_cert(self, publisher):
-                ta = self.pub_ta_map[publisher]
-                return "cs1_ta{0:d}_cert.pem".format(ta)
+    def get_cli_cert(self, publisher):
+        ta = self.pub_ta_map[publisher]
+        return "cs1_ta{0:d}_cert.pem".format(ta)
 
-        def get_cli_key(self, publisher):
-                ta = self.pub_ta_map[publisher]
-                return "cs1_ta{0:d}_key.pem".format(ta)
+    def get_cli_key(self, publisher):
+        ta = self.pub_ta_map[publisher]
+        return "cs1_ta{0:d}_key.pem".format(ta)
 
-        def get_pub_ta(self, publisher):
-                ta = self.pub_ta_map[publisher]
-                return "ta{0:d}".format(ta)
+    def get_pub_ta(self, publisher):
+        ta = self.pub_ta_map[publisher]
+        return "ta{0:d}".format(ta)
 
-        def setUp(self, publishers, start_depots=True):
+    def setUp(self, publishers, start_depots=True):
+        # We only have 5 usable CA certs and there are not many usecases
+        # for setting up more than 5 different SSL-secured depots.
+        assert len(publishers) < 6
 
-                # We only have 5 usable CA certs and there are not many usecases
-                # for setting up more than 5 different SSL-secured depots.
-                assert len(publishers) < 6
+        # Maintains a mapping of which TA is used for which publisher
+        self.pub_ta_map = {}
 
-                # Maintains a mapping of which TA is used for which publisher
-                self.pub_ta_map = {}
+        ApacheDepotTestCase.setUp(self, publishers, start_depots=True)
+        self.testdata_dir = os.path.join(self.test_root, "testdata")
 
-                ApacheDepotTestCase.setUp(self, publishers,
-                    start_depots=True)
-                self.testdata_dir = os.path.join(self.test_root, "testdata")
+        # Set up the directories that apache needs.
+        self.apache_dir = os.path.join(self.test_root, "apache")
+        os.makedirs(self.apache_dir)
+        self.apache_log_dir = os.path.join(self.apache_dir, "apache_logs")
+        os.makedirs(self.apache_log_dir)
+        self.apache_content_dir = os.path.join(
+            self.apache_dir, "apache_content"
+        )
+        self.pidfile = os.path.join(self.apache_dir, "httpd.pid")
+        self.common_config_dir = os.path.join(self.test_root, "apache-serve")
 
-                # Set up the directories that apache needs.
-                self.apache_dir = os.path.join(self.test_root, "apache")
-                os.makedirs(self.apache_dir)
-                self.apache_log_dir = os.path.join(self.apache_dir,
-                    "apache_logs")
-                os.makedirs(self.apache_log_dir)
-                self.apache_content_dir = os.path.join(self.apache_dir,
-                    "apache_content")
-                self.pidfile = os.path.join(self.apache_dir, "httpd.pid")
-                self.common_config_dir = os.path.join(self.test_root,
-                    "apache-serve")
+        # Choose ports for apache to run on.
+        self.https_port = self.next_free_port
+        self.next_free_port += 1
+        self.proxy_port = self.next_free_port
+        self.next_free_port += 1
+        self.bad_proxy_port = self.next_free_port
+        self.next_free_port += 1
 
-                # Choose ports for apache to run on.
-                self.https_port = self.next_free_port
-                self.next_free_port += 1
-                self.proxy_port = self.next_free_port
-                self.next_free_port += 1
-                self.bad_proxy_port = self.next_free_port
-                self.next_free_port += 1
+        # Set up the paths to the certificates that will be needed.
+        self.path_to_certs = os.path.join(
+            self.ro_data_root, "signing_certs", "produced"
+        )
+        self.keys_dir = os.path.join(self.path_to_certs, "keys")
+        self.cs_dir = os.path.join(self.path_to_certs, "code_signing_certs")
+        self.chain_certs_dir = os.path.join(self.path_to_certs, "chain_certs")
+        self.pub_cas_dir = os.path.join(self.path_to_certs, "publisher_cas")
+        self.inter_certs_dir = os.path.join(self.path_to_certs, "inter_certs")
+        self.raw_trust_anchor_dir = os.path.join(
+            self.path_to_certs, "trust_anchors"
+        )
+        self.crl_dir = os.path.join(self.path_to_certs, "crl")
 
-                # Set up the paths to the certificates that will be needed.
-                self.path_to_certs = os.path.join(self.ro_data_root,
-                    "signing_certs", "produced")
-                self.keys_dir = os.path.join(self.path_to_certs, "keys")
-                self.cs_dir = os.path.join(self.path_to_certs,
-                    "code_signing_certs")
-                self.chain_certs_dir = os.path.join(self.path_to_certs,
-                    "chain_certs")
-                self.pub_cas_dir = os.path.join(self.path_to_certs,
-                    "publisher_cas")
-                self.inter_certs_dir = os.path.join(self.path_to_certs,
-                    "inter_certs")
-                self.raw_trust_anchor_dir = os.path.join(self.path_to_certs,
-                    "trust_anchors")
-                self.crl_dir = os.path.join(self.path_to_certs, "crl")
+        location_tags = ""
+        # Usable CA certs are ta6 to ta11 with the exception of ta7.
+        # We already checked that not more than 5 publishers have been
+        # requested.
+        count = 6
+        for dc in self.dcs:
+            # Create a <Location> tag for each publisher. The server
+            # path is set to the publisher name.
+            if count == 7:
+                # TA7 needs password to unlock cert, don't use
+                count += 1
+            dc_pub = self.dcs[dc].get_property("publisher", "prefix")
+            self.pub_ta_map[dc_pub] = count
+            loc_dict = {
+                "server-path": dc_pub,
+                "server-ca-taname": "ta{0:d}".format(count),
+                "ssl-special": "%{SSL_CLIENT_I_DN_OU}",
+                "proxied-server": self.dcs[dc].get_depot_url(),
+            }
 
-                location_tags = ""
-                # Usable CA certs are ta6 to ta11 with the exception of ta7.
-                # We already checked that not more than 5 publishers have been
-                # requested.
-                count = 6
-                for dc in self.dcs:
-                        # Create a <Location> tag for each publisher. The server
-                        # path is set to the publisher name.
-                        if count == 7:
-                                # TA7 needs password to unlock cert, don't use
-                                count += 1
-                        dc_pub = self.dcs[dc].get_property("publisher",
-                            "prefix")
-                        self.pub_ta_map[dc_pub] = count
-                        loc_dict = {
-                            "server-path":dc_pub,
-                            "server-ca-taname":"ta{0:d}".format(count),
-                            "ssl-special":"%{SSL_CLIENT_I_DN_OU}",
-                            "proxied-server":self.dcs[dc].get_depot_url(),
-                        }
+            location_tags += loc_tag.format(**loc_dict)
+            count += 1
 
-                        location_tags += loc_tag.format(**loc_dict)
-                        count += 1
+        conf_dict = {
+            "common_log_format": '%h %l %u %t \\"%r\\" %>s %b',
+            "https_port": self.https_port,
+            "proxy_port": self.proxy_port,
+            "bad_proxy_port": self.bad_proxy_port,
+            "log_locs": self.apache_log_dir,
+            "pidfile": self.pidfile,
+            "port": self.https_port,
+            "serve_root": self.apache_content_dir,
+            "server-ssl-cert": os.path.join(self.cs_dir, "cs1_ta7_cert.pem"),
+            "server-ssl-key": os.path.join(self.keys_dir, "cs1_ta7_key.pem"),
+            "server-ca-cert": os.path.join(
+                self.path_to_certs, "combined_cas.pem"
+            ),
+            "location-tags": location_tags,
+        }
 
-                conf_dict = {
-                    "common_log_format": "%h %l %u %t \\\"%r\\\" %>s %b",
-                    "https_port": self.https_port,
-                    "proxy_port": self.proxy_port,
-                    "bad_proxy_port": self.bad_proxy_port,
-                    "log_locs": self.apache_log_dir,
-                    "pidfile": self.pidfile,
-                    "port": self.https_port,
-                    "serve_root": self.apache_content_dir,
-                    "server-ssl-cert":os.path.join(self.cs_dir,
-                        "cs1_ta7_cert.pem"),
-                    "server-ssl-key":os.path.join(self.keys_dir,
-                        "cs1_ta7_key.pem"),
-                    "server-ca-cert":os.path.join(self.path_to_certs, "combined_cas.pem"),
-                    "location-tags":location_tags,
-                }
+        self.https_conf_path = os.path.join(self.test_root, "https.conf")
+        with open(self.https_conf_path, "w") as fh:
+            fh.write(self.https_conf.format(**conf_dict))
 
-                self.https_conf_path = os.path.join(self.test_root,
-                    "https.conf")
-                with open(self.https_conf_path, "w") as fh:
-                        fh.write(self.https_conf.format(**conf_dict))
+        ac = ApacheController(
+            self.https_conf_path,
+            self.https_port,
+            self.common_config_dir,
+            https=True,
+            testcase=self,
+        )
+        self.register_apache_controller("default", ac)
 
-                ac = ApacheController(self.https_conf_path,
-                    self.https_port, self.common_config_dir, https=True,
-                    testcase=self)
-                self.register_apache_controller("default", ac)
-
-        https_conf = """\
+    https_conf = """\
 # Configuration and logfile names: If the filenames you specify for many
 # of the server's control files begin with "/" (or "drive:/" for Win32), the
 # server will use that explicit path.  If the filenames do *not* begin
@@ -4268,6 +4789,7 @@ SSLRandomSeed connect builtin
 </VirtualHost>
 """
 
+
 loc_tag = """
         <Location /{server-path}>
                 SSLVerifyDepth 1
@@ -4283,512 +4805,549 @@ loc_tag = """
 
 
 class SingleDepotTestCase(ManyDepotTestCase):
+    def setUp(
+        self,
+        debug_features=EmptyI,
+        publisher="test",
+        start_depot=False,
+        image_count=1,
+    ):
+        ManyDepotTestCase.setUp(
+            self,
+            [publisher],
+            debug_features=debug_features,
+            start_depots=start_depot,
+            image_count=image_count,
+        )
 
-        def setUp(self, debug_features=EmptyI, publisher="test",
-            start_depot=False, image_count=1):
-                ManyDepotTestCase.setUp(self, [publisher],
-                    debug_features=debug_features, start_depots=start_depot,
-                    image_count=image_count)
+    def __get_dc(self):
+        if self.dcs:
+            return self.dcs[1]
+        else:
+            return None
 
-        def __get_dc(self):
-                if self.dcs:
-                        return self.dcs[1]
-                else:
-                        return None
+    @property
+    def durl(self):
+        return self.dc.get_depot_url()
 
-        @property
-        def durl(self):
-                return self.dc.get_depot_url()
+    @property
+    def rurl(self):
+        return self.dc.get_repo_url()
 
-        @property
-        def rurl(self):
-                return self.dc.get_repo_url()
-
-        # dc is a readonly property which is an alias for self.dcs[1],
-        # for convenience of writing test cases.
-        dc = property(fget=__get_dc)
+    # dc is a readonly property which is an alias for self.dcs[1],
+    # for convenience of writing test cases.
+    dc = property(fget=__get_dc)
 
 
 class SingleDepotTestCaseCorruptImage(SingleDepotTestCase):
-        """ A class which allows manipulation of the image directory that
-        SingleDepotTestCase creates. Specifically, it supports removing one
-        or more of the files or subdirectories inside an image (publisher,
-        cfg_cache, etc...) in a controlled way.
+    """A class which allows manipulation of the image directory that
+    SingleDepotTestCase creates. Specifically, it supports removing one
+    or more of the files or subdirectories inside an image (publisher,
+    cfg_cache, etc...) in a controlled way.
 
-        To add a new directory or file to be corrupted, it will be necessary
-        to update corrupt_image_create to recognize a new option in config
-        and perform the appropriate action (removing the directory or file
-        for example).
-        """
+    To add a new directory or file to be corrupted, it will be necessary
+    to update corrupt_image_create to recognize a new option in config
+    and perform the appropriate action (removing the directory or file
+    for example).
+    """
 
-        def setUp(self, debug_features=EmptyI, publisher="test",
-            start_depot=False):
-                SingleDepotTestCase.setUp(self, debug_features=debug_features,
-                    publisher=publisher, start_depot=start_depot)
+    def setUp(self, debug_features=EmptyI, publisher="test", start_depot=False):
+        SingleDepotTestCase.setUp(
+            self,
+            debug_features=debug_features,
+            publisher=publisher,
+            start_depot=start_depot,
+        )
 
-                self.__imgs_path_backup = {}
+        self.__imgs_path_backup = {}
 
-        def tearDown(self):
-                SingleDepotTestCase.tearDown(self)
+    def tearDown(self):
+        SingleDepotTestCase.tearDown(self)
 
-        def backup_img_path(self, ii=None):
-                if ii != None:
-                        return self.__imgs_path_backup[ii]
-                return self.__imgs_path_backup[self.img_index()]
+    def backup_img_path(self, ii=None):
+        if ii != None:
+            return self.__imgs_path_backup[ii]
+        return self.__imgs_path_backup[self.img_index()]
 
-        def corrupt_image_create(self, repourl, config, subdirs, prefix="test",
-            destroy=True):
-                """ Creates two levels of directories under the original image
-                directory. In the first level (called bad), it builds a "corrupt
-                image" which means it builds subdirectories the subdirectories
-                specified by subdirs (essentially determining whether a user
-                image or a full image will be built). It populates these
-                subdirectories with a partial image directory stucture as
-                specified by config. As another subdirectory of bad, it
-                creates a subdirectory called final which represents the
-                directory the command was actually run from (which is why
-                img_path is set to that location). Existing image destruction
-                was made optional to allow testing of two images installed next
-                to each other (a user and full image created in the same
-                directory for example). """
+    def corrupt_image_create(
+        self, repourl, config, subdirs, prefix="test", destroy=True
+    ):
+        """Creates two levels of directories under the original image
+        directory. In the first level (called bad), it builds a "corrupt
+        image" which means it builds subdirectories the subdirectories
+        specified by subdirs (essentially determining whether a user
+        image or a full image will be built). It populates these
+        subdirectories with a partial image directory stucture as
+        specified by config. As another subdirectory of bad, it
+        creates a subdirectory called final which represents the
+        directory the command was actually run from (which is why
+        img_path is set to that location). Existing image destruction
+        was made optional to allow testing of two images installed next
+        to each other (a user and full image created in the same
+        directory for example)."""
 
-                ii = self.img_index()
-                if ii not in self.__imgs_path_backup:
-                        self.__imgs_path_backup[ii] = self.img_path()
+        ii = self.img_index()
+        if ii not in self.__imgs_path_backup:
+            self.__imgs_path_backup[ii] = self.img_path()
 
-                self.set_img_path(os.path.join(self.img_path(), "bad"))
+        self.set_img_path(os.path.join(self.img_path(), "bad"))
 
-                if destroy:
-                        self.image_destroy()
+        if destroy:
+            self.image_destroy()
 
-                for s in subdirs:
-                        if s == "var/pkg":
-                                cmdline = "image-create -F -p {0}={1} {2}".format(
-                                    prefix, repourl, self.img_path())
-                        elif s == ".org.opensolaris,pkg":
-                                cmdline = "image-create -U -p {0}={1} {2}".format(
-                                    prefix, repourl, self.img_path())
-                        else:
-                                raise RuntimeError("Got unknown subdir option:"
-                                    "{0}\n".format(s))
+        for s in subdirs:
+            if s == "var/pkg":
+                cmdline = "image-create -F -p {0}={1} {2}".format(
+                    prefix, repourl, self.img_path()
+                )
+            elif s == ".org.opensolaris,pkg":
+                cmdline = "image-create -U -p {0}={1} {2}".format(
+                    prefix, repourl, self.img_path()
+                )
+            else:
+                raise RuntimeError(
+                    "Got unknown subdir option:" "{0}\n".format(s)
+                )
 
-                        cmdline = sys.executable + " " + self.pkg_cmdpath + \
-                            " " + cmdline
-                        self.cmdline_run(cmdline, exit=0)
+            cmdline = sys.executable + " " + self.pkg_cmdpath + " " + cmdline
+            self.cmdline_run(cmdline, exit=0)
 
-                        tmpDir = os.path.join(self.img_path(), s)
+            tmpDir = os.path.join(self.img_path(), s)
 
-                        # This is where the actual corruption of the
-                        # image takes place. A normal image was created
-                        # above and this goes in and removes critical
-                        # directories and files.
-                        if "publisher_absent" in config or \
-                           "publisher_empty" in config:
-                                shutil.rmtree(os.path.join(tmpDir, "publisher"))
-                        if "known_absent" in config or \
-                           "known_empty" in config:
-                                shutil.rmtree(os.path.join(tmpDir, "state",
-                                    "known"))
-                        if "known_empty" in config:
-                                os.mkdir(os.path.join(tmpDir, "state", "known"))
-                        if "publisher_empty" in config:
-                                os.mkdir(os.path.join(tmpDir, "publisher"))
-                        if "cfg_cache_absent" in config:
-                                os.remove(os.path.join(tmpDir, "pkg5.image"))
-                        if "index_absent" in config:
-                                shutil.rmtree(os.path.join(tmpDir, "cache",
-                                    "index"))
+            # This is where the actual corruption of the
+            # image takes place. A normal image was created
+            # above and this goes in and removes critical
+            # directories and files.
+            if "publisher_absent" in config or "publisher_empty" in config:
+                shutil.rmtree(os.path.join(tmpDir, "publisher"))
+            if "known_absent" in config or "known_empty" in config:
+                shutil.rmtree(os.path.join(tmpDir, "state", "known"))
+            if "known_empty" in config:
+                os.mkdir(os.path.join(tmpDir, "state", "known"))
+            if "publisher_empty" in config:
+                os.mkdir(os.path.join(tmpDir, "publisher"))
+            if "cfg_cache_absent" in config:
+                os.remove(os.path.join(tmpDir, "pkg5.image"))
+            if "index_absent" in config:
+                shutil.rmtree(os.path.join(tmpDir, "cache", "index"))
 
-                # Make find root start at final. (See the doc string for
-                # more explanation.)
-                cmd_path = os.path.join(self.img_path(), "final")
+        # Make find root start at final. (See the doc string for
+        # more explanation.)
+        cmd_path = os.path.join(self.img_path(), "final")
 
-                os.mkdir(cmd_path)
-                return cmd_path
+        os.mkdir(cmd_path)
+        return cmd_path
+
 
 def debug(s):
-        s = str(s)
-        for x in s.splitlines():
-                if g_debug_output:
-                        print("# {0}".format(x), file=sys.stderr)
+    s = str(s)
+    for x in s.splitlines():
+        if g_debug_output:
+            print("# {0}".format(x), file=sys.stderr)
+
 
 def mkdir_eexist_ok(p):
-        try:
-                os.mkdir(p)
-        except OSError as e:
-                if e.errno != errno.EEXIST:
-                        raise e
+    try:
+        os.mkdir(p)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise e
+
 
 def env_sanitize(pkg_cmdpath, dv_keep=None):
-        if dv_keep == None:
-                dv_keep = []
+    if dv_keep == None:
+        dv_keep = []
 
-        dv_saved = {}
-        for dv in dv_keep:
-                # save some DebugValues settings
-                dv_saved[dv] = DebugValues[dv]
+    dv_saved = {}
+    for dv in dv_keep:
+        # save some DebugValues settings
+        dv_saved[dv] = DebugValues[dv]
 
-        # clear any existing DebugValues settings
-        DebugValues.clear()
+    # clear any existing DebugValues settings
+    DebugValues.clear()
 
-        # clear misc environment variables
-        for e in ["PKG_CMDPATH"]:
-                if e in os.environ:
-                        del os.environ[e]
+    # clear misc environment variables
+    for e in ["PKG_CMDPATH"]:
+        if e in os.environ:
+            del os.environ[e]
 
-        # Set image path to a path that's not actually an
-        # image to force failure of tests that don't
-        # explicitly provide an image root either through the
-        # default behaviour of the pkg() helper routine or
-        # another method.
-        os.environ["PKG_IMAGE"] = g_tempdir
+    # Set image path to a path that's not actually an
+    # image to force failure of tests that don't
+    # explicitly provide an image root either through the
+    # default behaviour of the pkg() helper routine or
+    # another method.
+    os.environ["PKG_IMAGE"] = g_tempdir
 
-        # Test suite should never attempt to access the
-        # live root image.
-        os.environ["PKG_NO_LIVE_ROOT"] = "1"
+    # Test suite should never attempt to access the
+    # live root image.
+    os.environ["PKG_NO_LIVE_ROOT"] = "1"
 
-        # Pkg interfaces should never know they are being
-        # run from within the test suite.
-        os.environ["PKG_NO_RUNPY_CMDPATH"] = "1"
+    # Pkg interfaces should never know they are being
+    # run from within the test suite.
+    os.environ["PKG_NO_RUNPY_CMDPATH"] = "1"
 
-        # verify PlanDescription serialization and that the PlanDescription
-        # isn't modified while we're preparing to for execution.
-        DebugValues["plandesc_validate"] = 1
-        os.environ["PKG_PLANDESC_VALIDATE"] = "1"
+    # verify PlanDescription serialization and that the PlanDescription
+    # isn't modified while we're preparing to for execution.
+    DebugValues["plandesc_validate"] = 1
+    os.environ["PKG_PLANDESC_VALIDATE"] = "1"
 
-        # Pretend that we're being run from the fakeroot image.
-        assert pkg_cmdpath != "TOXIC"
-        DebugValues["simulate_cmdpath"] = pkg_cmdpath
+    # Pretend that we're being run from the fakeroot image.
+    assert pkg_cmdpath != "TOXIC"
+    DebugValues["simulate_cmdpath"] = pkg_cmdpath
 
-        # Update the path to smf commands
-        for dv in dv_keep:
-                DebugValues[dv] = dv_saved[dv]
+    # Update the path to smf commands
+    for dv in dv_keep:
+        DebugValues[dv] = dv_saved[dv]
 
-        # always get detailed data from the solver
-        DebugValues["plan"] = True
+    # always get detailed data from the solver
+    DebugValues["plan"] = True
+
 
 def fakeroot_create():
+    test_root = os.path.join(g_tempdir, "ips.test.{0:d}".format(os.getpid()))
+    fakeroot = os.path.join(test_root, "fakeroot")
+    cmd_path = os.path.join(fakeroot, "pkg")
 
-        test_root = os.path.join(g_tempdir, "ips.test.{0:d}".format(os.getpid()))
-        fakeroot = os.path.join(test_root, "fakeroot")
-        cmd_path = os.path.join(fakeroot, "pkg")
+    try:
+        os.stat(cmd_path)
+    except OSError as e:
+        pass
+    else:
+        # fakeroot already exists
+        raise RuntimeError(
+            "The fakeroot shouldn't already exist.\n"
+            "Path is:{0}".format(cmd_path)
+        )
 
-        try:
-                os.stat(cmd_path)
-        except OSError as e:
-                pass
-        else:
-                # fakeroot already exists
-                raise RuntimeError("The fakeroot shouldn't already exist.\n"
-                    "Path is:{0}".format(cmd_path))
+    # when creating the fakeroot we want to make sure pkg doesn't
+    # touch the real root.
+    env_sanitize(cmd_path)
 
-        # when creating the fakeroot we want to make sure pkg doesn't
-        # touch the real root.
-        env_sanitize(cmd_path)
+    #
+    # When accessing images via the pkg apis those apis will try
+    # to access the image containing the command from which the
+    # apis were invoked.  Normally when running the test suite the
+    # command is run.py in a developers workspace, and that
+    # workspace lives in the root image.  But accessing the root
+    # image during a test suite run is verboten.  Hence, here we
+    # create a temporary image from which we can run the pkg
+    # command.
+    #
 
-        #
-        # When accessing images via the pkg apis those apis will try
-        # to access the image containing the command from which the
-        # apis were invoked.  Normally when running the test suite the
-        # command is run.py in a developers workspace, and that
-        # workspace lives in the root image.  But accessing the root
-        # image during a test suite run is verboten.  Hence, here we
-        # create a temporary image from which we can run the pkg
-        # command.
-        #
+    # create directories
+    mkdir_eexist_ok(test_root)
+    mkdir_eexist_ok(fakeroot)
 
-        # create directories
-        mkdir_eexist_ok(test_root)
-        mkdir_eexist_ok(fakeroot)
+    debug("fakeroot image create {0}".format(fakeroot))
+    progtrack = pkg.client.progress.NullProgressTracker()
+    api_inst = pkg.client.api.image_create(
+        PKG_CLIENT_NAME,
+        CLIENT_API_VERSION,
+        fakeroot,
+        pkg.client.api.IMG_TYPE_ENTIRE,
+        False,
+        progtrack=progtrack,
+        cmdpath=cmd_path,
+    )
 
-        debug("fakeroot image create {0}".format(fakeroot))
-        progtrack = pkg.client.progress.NullProgressTracker()
-        api_inst = pkg.client.api.image_create(PKG_CLIENT_NAME,
-            CLIENT_API_VERSION, fakeroot,
-            pkg.client.api.IMG_TYPE_ENTIRE, False,
-            progtrack=progtrack, cmdpath=cmd_path)
+    #
+    # put a copy of the pkg command in our fake root directory.
+    # we do this because when recursive linked image commands are
+    # run, the pkg interfaces may fork and exec additional copies
+    # of pkg(1), and in this case we want them to run the copy of
+    # pkg from the fake root.
+    #
+    fakeroot_cmdpath = os.path.join(fakeroot, "pkg")
+    shutil.copy(os.path.join(g_pkg_path, "usr", "bin", "pkg"), fakeroot_cmdpath)
 
-        #
-        # put a copy of the pkg command in our fake root directory.
-        # we do this because when recursive linked image commands are
-        # run, the pkg interfaces may fork and exec additional copies
-        # of pkg(1), and in this case we want them to run the copy of
-        # pkg from the fake root.
-        #
-        fakeroot_cmdpath = os.path.join(fakeroot, "pkg")
-        shutil.copy(os.path.join(g_pkg_path, "usr", "bin", "pkg"),
-            fakeroot_cmdpath)
+    return fakeroot, fakeroot_cmdpath
 
-        return fakeroot, fakeroot_cmdpath
 
 def eval_assert_raises(ex_type, eval_ex_func, func, *args):
-        try:
-                func(*args)
-        except ex_type as e:
-                print(str(e))
-                if not eval_ex_func(e):
-                        raise
-        else:
-                raise RuntimeError("Function did not raise exception.")
+    try:
+        func(*args)
+    except ex_type as e:
+        print(str(e))
+        if not eval_ex_func(e):
+            raise
+    else:
+        raise RuntimeError("Function did not raise exception.")
+
 
 class ApacheStateException(Exception):
-        pass
+    pass
+
 
 class ApacheController(object):
+    def __init__(self, conf, port, work_dir, testcase=None, https=False):
+        """
+        The 'conf' parameter is a path to a httpd.conf file.  The 'port'
+        parameter is a port to run on.  The 'work_dir' is a temporary
+        directory to store runtime state.  The 'testcase' parameter is
+        the ApacheDepotTestCase to use when writing output.  The 'https'
+        parameter is a boolean indicating whether this instance expects
+        to be contacted via https or not.
+        """
 
-        def __init__(self, conf, port, work_dir, testcase=None, https=False):
-                """
-                The 'conf' parameter is a path to a httpd.conf file.  The 'port'
-                parameter is a port to run on.  The 'work_dir' is a temporary
-                directory to store runtime state.  The 'testcase' parameter is
-                the ApacheDepotTestCase to use when writing output.  The 'https'
-                parameter is a boolean indicating whether this instance expects
-                to be contacted via https or not.
-                """
+        self.apachectl = "/usr/apache2/2.2/bin/httpd.worker"
+        if not os.path.exists(work_dir):
+            os.makedirs(work_dir)
+        self.__conf_path = os.path.join(work_dir, "httpd.conf")
+        self.__port = port
+        self.__repo_hdl = None
+        self.__starttime = 0
+        self.__state = "stopped"
+        if not testcase:
+            raise RuntimeError("No testcase parameter specified")
+        self.__tc = testcase
+        prefix = "http"
+        if https:
+            prefix = "https"
+        self.__url = "{0}://localhost:{1:d}".format(prefix, self.__port)
+        portable.copyfile(conf, self.__conf_path)
 
-                self.apachectl = "/usr/apache2/2.2/bin/httpd.worker"
-                if not os.path.exists(work_dir):
-                        os.makedirs(work_dir)
-                self.__conf_path = os.path.join(work_dir, "httpd.conf")
-                self.__port = port
-                self.__repo_hdl = None
-                self.__starttime = 0
-                self.__state = "stopped"
-                if not testcase:
-                        raise RuntimeError("No testcase parameter specified")
-                self.__tc = testcase
-                prefix = "http"
-                if https:
-                        prefix = "https"
-                self.__url = "{0}://localhost:{1:d}".format(prefix, self.__port)
-                portable.copyfile(conf, self.__conf_path)
+    def __set_conf(self, path):
+        portable.copyfile(path, self.__conf_path)
+        if self.__state == "started":
+            self.restart()
 
-        def __set_conf(self, path):
-                portable.copyfile(path, self.__conf_path)
-                if self.__state == "started":
-                        self.restart()
+    def __get_conf(self):
+        return self.__conf_path
 
-        def __get_conf(self):
-                return self.__conf_path
+    conf = property(__get_conf, __set_conf)
 
-        conf = property(__get_conf, __set_conf)
-
-        def _network_ping(self):
-                try:
-                        urlopen(self.__url)
-                except HTTPError as e:
-                        if e.code == http_client.FORBIDDEN:
-                                return True
-                        return False
-                except URLError as e:
-                        if isinstance(e.reason, ssl.SSLError):
-                                return True
-                        return False
+    def _network_ping(self):
+        try:
+            urlopen(self.__url)
+        except HTTPError as e:
+            if e.code == http_client.FORBIDDEN:
                 return True
+            return False
+        except URLError as e:
+            if isinstance(e.reason, ssl.SSLError):
+                return True
+            return False
+        return True
 
-        def debug(self, msg):
-                if self.__tc:
-                        self.__tc.debug(msg)
+    def debug(self, msg):
+        if self.__tc:
+            self.__tc.debug(msg)
 
-        def debugresult(self, result, expected, msg):
-                if self.__tc:
-                        self.__tc.debugresult(result, expected, msg)
+    def debugresult(self, result, expected, msg):
+        if self.__tc:
+            self.__tc.debugresult(result, expected, msg)
 
-        def start(self):
-                if self not in self.__tc.acs.values():
-                        # An attempt to start an ApacheController that has not
-                        # been registered can result in it not getting cleaned
-                        # up properly when the test completes, which can cause
-                        # other tests to fail. We don't allow that to happen.
-                        raise RuntimeError(
-                            "This ApacheController has not been registered with"
-                            " the ApacheDepotTestCase {0} using "
-                            "set_apache_controller(name, ac)".format(self.__tc))
+    def start(self):
+        if self not in self.__tc.acs.values():
+            # An attempt to start an ApacheController that has not
+            # been registered can result in it not getting cleaned
+            # up properly when the test completes, which can cause
+            # other tests to fail. We don't allow that to happen.
+            raise RuntimeError(
+                "This ApacheController has not been registered with"
+                " the ApacheDepotTestCase {0} using "
+                "set_apache_controller(name, ac)".format(self.__tc)
+            )
 
-                if self._network_ping():
-                        raise ApacheStateException("A depot (or some " +
-                            "other network process) seems to be " +
-                            "running on port {0:d} already!".format(self.__port))
-                cmdline = ["/usr/bin/setpgrp", self.apachectl, "-f",
-                    self.__conf_path, "-k", "start", "-DFOREGROUND"]
-                try:
-                        self.__starttime = time.time()
-                        # change the state so that we try to do work in
-                        # self.stop() in the face of a False result from
-                        # is_alive()
-                        self.__state = "starting"
-                        self.debug(" ".join(cmdline))
-                        self.__repo_hdl = subprocess.Popen(cmdline, shell=False,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-                        if self.__repo_hdl is None:
-                                self.__state = "stopped"
-                                raise ApacheStateException("Could not start "
-                                    "apache")
-                        begintime = time.time()
+        if self._network_ping():
+            raise ApacheStateException(
+                "A depot (or some "
+                + "other network process) seems to be "
+                + "running on port {0:d} already!".format(self.__port)
+            )
+        cmdline = [
+            "/usr/bin/setpgrp",
+            self.apachectl,
+            "-f",
+            self.__conf_path,
+            "-k",
+            "start",
+            "-DFOREGROUND",
+        ]
+        try:
+            self.__starttime = time.time()
+            # change the state so that we try to do work in
+            # self.stop() in the face of a False result from
+            # is_alive()
+            self.__state = "starting"
+            self.debug(" ".join(cmdline))
+            self.__repo_hdl = subprocess.Popen(
+                cmdline,
+                shell=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            if self.__repo_hdl is None:
+                self.__state = "stopped"
+                raise ApacheStateException("Could not start " "apache")
+            begintime = time.time()
 
-                        check_interval = 0.20
-                        contact = False
-                        while (time.time() - begintime) <= 40.0:
-                                rc = self.__repo_hdl.poll()
-                                if rc is not None:
-                                        self.__state = "stopped"
-                                        raise ApacheStateException("Apache "
-                                            "exited unexpectedly while "
-                                            "starting (exit code {0:d})".format(rc))
+            check_interval = 0.20
+            contact = False
+            while (time.time() - begintime) <= 40.0:
+                rc = self.__repo_hdl.poll()
+                if rc is not None:
+                    self.__state = "stopped"
+                    raise ApacheStateException(
+                        "Apache "
+                        "exited unexpectedly while "
+                        "starting (exit code {0:d})".format(rc)
+                    )
 
-                                if self.is_alive():
-                                        contact = True
-                                        break
-                                time.sleep(check_interval)
+                if self.is_alive():
+                    contact = True
+                    break
+                time.sleep(check_interval)
 
-                        if contact == False:
-                                self.stop()
-                                raise ApacheStateException("Apache did not "
-                                    "respond to repeated attempts to make "
-                                    "contact")
-                        self.__state = "started"
-                except KeyboardInterrupt:
-                        if self.__repo_hdl:
-                                self.kill(now=True)
-                        raise
-
-        def kill(self, now=False):
-                if not self.__repo_hdl:
-                        return
-                try:
-                        lifetime = time.time() - self.__starttime
-                        if now == False and lifetime < 1.0:
-                                time.sleep(1.0 - lifetime)
-                finally:
-                        try:
-                                os.kill(-1 * self.__repo_hdl.pid,
-                                    signal.SIGKILL)
-                        except OSError:
-                                pass
-                        self.__repo_hdl.wait()
-                        self.__state = "killed"
-
-        def stop(self):
-                if self.__state == "stopped":
-                        return
-                cmdline = [self.apachectl, "-f", self.__conf_path, "-k",
-                    "stop"]
-
-                try:
-                        hdl = subprocess.Popen(cmdline, shell=False,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-                        stop_output, stop_errout = hdl.communicate()
-                        stop_retcode = hdl.returncode
-
-                        self.debugresult(stop_retcode, 0, stop_output)
-
-                        if stop_errout != "":
-                                self.debug(stop_errout)
-                        if stop_output != "":
-                                self.debug(stop_output)
-
-                        if stop_retcode != 0:
-                                self.kill(now=True)
-                        else:
-                                self.__state = "stopped"
-
-                        # Ensure that the apache process gets shutdown
-                        begintime = time.time()
-
-                        check_interval = 0.20
-                        stopped = False
-                        while (time.time() - begintime) <= 40.0:
-                                rc = self.__repo_hdl.poll()
-                                if rc is not None:
-                                        stopped = True
-                                        break
-                                time.sleep(check_interval)
-                        if not stopped:
-                                self.kill(now=True)
-
-                        # retrieve output from the apache process we've just
-                        # stopped
-                        output, errout = self.__repo_hdl.communicate()
-                        self.debug(errout)
-                except KeyboardInterrupt:
-                        self.kill(now=True)
-                        raise
-
-        def restart(self):
+            if contact == False:
                 self.stop()
-                self.start()
+                raise ApacheStateException(
+                    "Apache did not "
+                    "respond to repeated attempts to make "
+                    "contact"
+                )
+            self.__state = "started"
+        except KeyboardInterrupt:
+            if self.__repo_hdl:
+                self.kill(now=True)
+            raise
 
-        def chld_sighandler(self, signum, frame):
+    def kill(self, now=False):
+        if not self.__repo_hdl:
+            return
+        try:
+            lifetime = time.time() - self.__starttime
+            if now == False and lifetime < 1.0:
+                time.sleep(1.0 - lifetime)
+        finally:
+            try:
+                os.kill(-1 * self.__repo_hdl.pid, signal.SIGKILL)
+            except OSError:
                 pass
+            self.__repo_hdl.wait()
+            self.__state = "killed"
 
-        def killall_sighandler(self, signum, frame):
-                print("Ctrl-C: I'm killing depots, please wait.\n",
-                    file=sys.stderr)
-                print(self)
-                self.signalled = True
+    def stop(self):
+        if self.__state == "stopped":
+            return
+        cmdline = [self.apachectl, "-f", self.__conf_path, "-k", "stop"]
 
-        def is_alive(self):
-                """ First, check that the depot process seems to be alive.
-                    Then make a little HTTP request to see if the depot is
-                    responsive to requests """
+        try:
+            hdl = subprocess.Popen(
+                cmdline,
+                shell=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stop_output, stop_errout = hdl.communicate()
+            stop_retcode = hdl.returncode
 
-                if self.__repo_hdl == None:
-                        return False
+            self.debugresult(stop_retcode, 0, stop_output)
 
-                status = self.__repo_hdl.poll()
-                if status != None:
-                        return False
-                return self._network_ping()
+            if stop_errout != "":
+                self.debug(stop_errout)
+            if stop_output != "":
+                self.debug(stop_output)
 
-        @property
-        def url(self):
-                return self.__url
+            if stop_retcode != 0:
+                self.kill(now=True)
+            else:
+                self.__state = "stopped"
+
+            # Ensure that the apache process gets shutdown
+            begintime = time.time()
+
+            check_interval = 0.20
+            stopped = False
+            while (time.time() - begintime) <= 40.0:
+                rc = self.__repo_hdl.poll()
+                if rc is not None:
+                    stopped = True
+                    break
+                time.sleep(check_interval)
+            if not stopped:
+                self.kill(now=True)
+
+            # retrieve output from the apache process we've just
+            # stopped
+            output, errout = self.__repo_hdl.communicate()
+            self.debug(errout)
+        except KeyboardInterrupt:
+            self.kill(now=True)
+            raise
+
+    def restart(self):
+        self.stop()
+        self.start()
+
+    def chld_sighandler(self, signum, frame):
+        pass
+
+    def killall_sighandler(self, signum, frame):
+        print("Ctrl-C: I'm killing depots, please wait.\n", file=sys.stderr)
+        print(self)
+        self.signalled = True
+
+    def is_alive(self):
+        """First, check that the depot process seems to be alive.
+        Then make a little HTTP request to see if the depot is
+        responsive to requests"""
+
+        if self.__repo_hdl == None:
+            return False
+
+        status = self.__repo_hdl.poll()
+        if status != None:
+            return False
+        return self._network_ping()
+
+    @property
+    def url(self):
+        return self.__url
+
 
 class SysrepoController(ApacheController):
+    def __init__(self, conf, port, work_dir, testcase=None, https=False):
+        ApacheController.__init__(
+            self, conf, port, work_dir, testcase=testcase, https=https
+        )
+        self.apachectl = "/usr/apache2/2.2/bin/httpd.worker"
 
-        def __init__(self, conf, port, work_dir, testcase=None, https=False):
-                ApacheController.__init__(self, conf, port, work_dir,
-                    testcase=testcase, https=https)
-                self.apachectl = "/usr/apache2/2.2/bin/httpd.worker"
-
-        def _network_ping(self):
-                try:
-                        urlopen(urljoin(self.url, "syspub/0"))
-                except HTTPError as e:
-                        if e.code == http_client.FORBIDDEN:
-                                return True
-                        return False
-                except URLError:
-                        return False
+    def _network_ping(self):
+        try:
+            urlopen(urljoin(self.url, "syspub/0"))
+        except HTTPError as e:
+            if e.code == http_client.FORBIDDEN:
                 return True
+            return False
+        except URLError:
+            return False
+        return True
 
 
 class HttpDepotController(ApacheController):
+    def __init__(self, conf, port, work_dir, testcase=None, https=False):
+        ApacheController.__init__(
+            self, conf, port, work_dir, testcase=testcase, https=https
+        )
+        self.apachectl = "/usr/apache2/2.2/bin/httpd.worker"
 
-        def __init__(self, conf, port, work_dir, testcase=None, https=False):
-                ApacheController.__init__(self, conf, port, work_dir,
-                    testcase=testcase, https=https)
-                self.apachectl = "/usr/apache2/2.2/bin/httpd.worker"
-
-        def _network_ping(self):
-                try:
-                        # Ping the versions URL, rather than the default /
-                        # so that we don't initialize the BUI code yet.
-                        repourl = urljoin(self.url, "versions/0")
-                        # Disable SSL peer verification, we just want to check
-                        # if the depot is running.
-                        urlopen(repourl,
-                            context=ssl._create_unverified_context())
-                except HTTPError as e:
-                        if e.code == http_client.FORBIDDEN:
-                                return True
-                        return False
-                except URLError:
-                        return False
+    def _network_ping(self):
+        try:
+            # Ping the versions URL, rather than the default /
+            # so that we don't initialize the BUI code yet.
+            repourl = urljoin(self.url, "versions/0")
+            # Disable SSL peer verification, we just want to check
+            # if the depot is running.
+            urlopen(repourl, context=ssl._create_unverified_context())
+        except HTTPError as e:
+            if e.code == http_client.FORBIDDEN:
                 return True
+            return False
+        except URLError:
+            return False
+        return True
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/ro_data/signing_certs/generate_certs.py
+++ b/src/tests/ro_data/signing_certs/generate_certs.py
@@ -36,171 +36,209 @@ import certgenerator
 output_dir = "./produced"
 
 if __name__ == "__main__":
-        # Remove any existing output from previous runs of this program.
-        if os.path.isdir(output_dir):
-                shutil.rmtree(output_dir)
-        os.mkdir(output_dir)
+    # Remove any existing output from previous runs of this program.
+    if os.path.isdir(output_dir):
+        shutil.rmtree(output_dir)
+    os.mkdir(output_dir)
 
-        cg = certgenerator.CertGenerator(base_dir=output_dir)
+    cg = certgenerator.CertGenerator(base_dir=output_dir)
 
-        # Make a length 7 chain.
-        cg.make_trust_anchor("ta1")
-        cg.make_ca_cert("ch1_ta1", "ta1", ext="v3_ca_lp4")
-        cg.make_ca_cert("ch2_ta1", "ch1_ta1", parent_loc="chain_certs",
-            ext="v3_ca_lp3")
-        cg.make_ca_cert("ch3_ta1", "ch2_ta1", parent_loc="chain_certs",
-            ext="v3_ca_lp2")
-        cg.make_ca_cert("ch4_ta1", "ch3_ta1", parent_loc="chain_certs",
-            ext="v3_ca_lp1")
-        cg.make_ca_cert("ch5_ta1", "ch4_ta1", parent_loc="chain_certs",
-            ext="v3_ca_lp0")
-        cg.make_cs_cert("cs1_ch5_ta1", "ch5_ta1", parent_loc="chain_certs")
-        # Make a chain where a chain cert has revoked the code signing cert.
-        cg.make_cs_cert("cs2_ch5_ta1", "ch5_ta1", parent_loc="chain_certs",
-            ext="ch5_ta1_crl")
-        cg.revoke_cert("ch5_ta1", "cs2_ch5_ta1", ca_dir="chain_certs")
-        # Make a chain where the chain cert has an unsupported critical
-        # extension.
-        cg.make_ca_cert("ch5.1_ta1", "ch4_ta1", parent_loc="chain_certs",
-            ext="issuer_ext_ca")
-        cg.make_cs_cert("cs1_ch5.1_ta1", "ch5.1_ta1", parent_loc="chain_certs")
-        # Make a chain where a chain cert has a larger number than is needed.
-        cg.make_ca_cert("ch5.2_ta1", "ch4_ta1", parent_loc="chain_certs",
-            ext="v3_ca_lp1")
-        cg.make_cs_cert("cs1_ch5.2_ta1", "ch5.2_ta1", parent_loc="chain_certs")
-        # Make a chain where a chain cert has a smaller number than is needed.
-        cg.make_ca_cert("ch4.3_ta1", "ch3_ta1", parent_loc="chain_certs",
-            ext="v3_ca_lp0")
-        cg.make_ca_cert("ch5.3_ta1", "ch4.3_ta1", parent_loc="chain_certs",
-            ext="v3_ca_lp0")
-        cg.make_cs_cert("cs1_ch5.3_ta1", "ch5.3_ta1", parent_loc="chain_certs")
+    # Make a length 7 chain.
+    cg.make_trust_anchor("ta1")
+    cg.make_ca_cert("ch1_ta1", "ta1", ext="v3_ca_lp4")
+    cg.make_ca_cert(
+        "ch2_ta1", "ch1_ta1", parent_loc="chain_certs", ext="v3_ca_lp3"
+    )
+    cg.make_ca_cert(
+        "ch3_ta1", "ch2_ta1", parent_loc="chain_certs", ext="v3_ca_lp2"
+    )
+    cg.make_ca_cert(
+        "ch4_ta1", "ch3_ta1", parent_loc="chain_certs", ext="v3_ca_lp1"
+    )
+    cg.make_ca_cert(
+        "ch5_ta1", "ch4_ta1", parent_loc="chain_certs", ext="v3_ca_lp0"
+    )
+    cg.make_cs_cert("cs1_ch5_ta1", "ch5_ta1", parent_loc="chain_certs")
+    # Make a chain where a chain cert has revoked the code signing cert.
+    cg.make_cs_cert(
+        "cs2_ch5_ta1", "ch5_ta1", parent_loc="chain_certs", ext="ch5_ta1_crl"
+    )
+    cg.revoke_cert("ch5_ta1", "cs2_ch5_ta1", ca_dir="chain_certs")
+    # Make a chain where the chain cert has an unsupported critical
+    # extension.
+    cg.make_ca_cert(
+        "ch5.1_ta1", "ch4_ta1", parent_loc="chain_certs", ext="issuer_ext_ca"
+    )
+    cg.make_cs_cert("cs1_ch5.1_ta1", "ch5.1_ta1", parent_loc="chain_certs")
+    # Make a chain where a chain cert has a larger number than is needed.
+    cg.make_ca_cert(
+        "ch5.2_ta1", "ch4_ta1", parent_loc="chain_certs", ext="v3_ca_lp1"
+    )
+    cg.make_cs_cert("cs1_ch5.2_ta1", "ch5.2_ta1", parent_loc="chain_certs")
+    # Make a chain where a chain cert has a smaller number than is needed.
+    cg.make_ca_cert(
+        "ch4.3_ta1", "ch3_ta1", parent_loc="chain_certs", ext="v3_ca_lp0"
+    )
+    cg.make_ca_cert(
+        "ch5.3_ta1", "ch4.3_ta1", parent_loc="chain_certs", ext="v3_ca_lp0"
+    )
+    cg.make_cs_cert("cs1_ch5.3_ta1", "ch5.3_ta1", parent_loc="chain_certs")
 
-        # Make a length 2 chain
-        cg.make_trust_anchor("ta2")
-        cg.make_cs_cert("cs1_ta2", "ta2")
+    # Make a length 2 chain
+    cg.make_trust_anchor("ta2")
+    cg.make_cs_cert("cs1_ta2", "ta2")
 
-        # Make a length 3 chain
-        cg.make_trust_anchor("ta3")
-        cg.make_ca_cert("ch1_ta3", "ta3")
-        cg.make_cs_cert("cs1_ch1_ta3", "ch1_ta3", parent_loc="chain_certs")
-        # Add a certificate to the length 3 chain with an unsupported critical
-        # extension.
-        cg.make_cs_cert("cs2_ch1_ta3", "ch1_ta3", parent_loc="chain_certs",
-            ext="issuer_ext")
-        # Add a certificate to the length 3 chain that has already expired.
-        cg.make_cs_cert("cs3_ch1_ta3", "ch1_ta3", parent_loc="chain_certs",
-            expired=True)
-        # Add a certificate to the length 3 chain that is in the future.
-        cg.make_cs_cert("cs4_ch1_ta3", "ch1_ta3", parent_loc="chain_certs",
-            future=True)
-        # Add a certificate to the length 3 chain that has an unknown value for
-        # a recognized non-critical extension.
-        cg.make_cs_cert("cs5_ch1_ta3", "ch1_ta3", parent_loc="chain_certs",
-            ext="issuer_ext_non_critical")
-        # Add a certificate to the length 3 chain that has an unknown value for
-        # a recognized critical extension.
-        cg.make_cs_cert("cs6_ch1_ta3", "ch1_ta3", parent_loc="chain_certs",
-            ext="issuer_ext_bad_val")
-        # Add a certificate to the length 3 chain that has keyUsage information
-        # but cannot be used to sign code.
-        cg.make_cs_cert("cs7_ch1_ta3", "ch1_ta3", parent_loc="chain_certs",
-            ext="v3_no_keyUsage")
-        # Make a chain where a CS is used to sign another CS.
-        cg.make_cs_cert("cs8_ch1_ta3", "ch1_ta3", parent_loc="chain_certs",
-            ext="v3_confused_cs")
-        cg.make_cs_cert("cs1_cs8_ch1_ta3", "cs8_ch1_ta3",
-            parent_loc="code_signing_certs")
-        # Add a certificate to the length 3 chain that has an invalid extension.
-        cg.make_cs_cert("cs9_ch1_ta3", "ch1_ta3", parent_loc="chain_certs",
-            ext="invalid_ext")
-        # Make a chain where the CA has an unsupported critical extension.
-        cg.make_ca_cert("ch1.1_ta3", "ta3", ext="issuer_ext_ca")
-        cg.make_cs_cert("cs1_ch1.1_ta3", "ch1.1_ta3", parent_loc="chain_certs")
-        # Make a chain where the CA is expired but the CS is current.
-        cg.make_ca_cert("ch1.2_ta3", "ta3", expired=True)
-        cg.make_cs_cert("cs1_ch1.2_ta3", "ch1.2_ta3", parent_loc="chain_certs")
-        # Make a chain where the CA is in the future but the CS is current.
-        cg.make_ca_cert("ch1.3_ta3", "ta3", future=True)
-        cg.make_cs_cert("cs1_ch1.3_ta3", "ch1.3_ta3", parent_loc="chain_certs")
-        # Make a chain where the CA does not have keyUsage set.
-        cg.make_ca_cert("ch1.4_ta3", "ta3", future=True, ext="v3_ca_no_keyUsage")
-        cg.make_cs_cert("cs1_ch1.4_ta3", "ch1.4_ta3", parent_loc="chain_certs")
+    # Make a length 3 chain
+    cg.make_trust_anchor("ta3")
+    cg.make_ca_cert("ch1_ta3", "ta3")
+    cg.make_cs_cert("cs1_ch1_ta3", "ch1_ta3", parent_loc="chain_certs")
+    # Add a certificate to the length 3 chain with an unsupported critical
+    # extension.
+    cg.make_cs_cert(
+        "cs2_ch1_ta3", "ch1_ta3", parent_loc="chain_certs", ext="issuer_ext"
+    )
+    # Add a certificate to the length 3 chain that has already expired.
+    cg.make_cs_cert(
+        "cs3_ch1_ta3", "ch1_ta3", parent_loc="chain_certs", expired=True
+    )
+    # Add a certificate to the length 3 chain that is in the future.
+    cg.make_cs_cert(
+        "cs4_ch1_ta3", "ch1_ta3", parent_loc="chain_certs", future=True
+    )
+    # Add a certificate to the length 3 chain that has an unknown value for
+    # a recognized non-critical extension.
+    cg.make_cs_cert(
+        "cs5_ch1_ta3",
+        "ch1_ta3",
+        parent_loc="chain_certs",
+        ext="issuer_ext_non_critical",
+    )
+    # Add a certificate to the length 3 chain that has an unknown value for
+    # a recognized critical extension.
+    cg.make_cs_cert(
+        "cs6_ch1_ta3",
+        "ch1_ta3",
+        parent_loc="chain_certs",
+        ext="issuer_ext_bad_val",
+    )
+    # Add a certificate to the length 3 chain that has keyUsage information
+    # but cannot be used to sign code.
+    cg.make_cs_cert(
+        "cs7_ch1_ta3", "ch1_ta3", parent_loc="chain_certs", ext="v3_no_keyUsage"
+    )
+    # Make a chain where a CS is used to sign another CS.
+    cg.make_cs_cert(
+        "cs8_ch1_ta3", "ch1_ta3", parent_loc="chain_certs", ext="v3_confused_cs"
+    )
+    cg.make_cs_cert(
+        "cs1_cs8_ch1_ta3", "cs8_ch1_ta3", parent_loc="code_signing_certs"
+    )
+    # Add a certificate to the length 3 chain that has an invalid extension.
+    cg.make_cs_cert(
+        "cs9_ch1_ta3", "ch1_ta3", parent_loc="chain_certs", ext="invalid_ext"
+    )
+    # Make a chain where the CA has an unsupported critical extension.
+    cg.make_ca_cert("ch1.1_ta3", "ta3", ext="issuer_ext_ca")
+    cg.make_cs_cert("cs1_ch1.1_ta3", "ch1.1_ta3", parent_loc="chain_certs")
+    # Make a chain where the CA is expired but the CS is current.
+    cg.make_ca_cert("ch1.2_ta3", "ta3", expired=True)
+    cg.make_cs_cert("cs1_ch1.2_ta3", "ch1.2_ta3", parent_loc="chain_certs")
+    # Make a chain where the CA is in the future but the CS is current.
+    cg.make_ca_cert("ch1.3_ta3", "ta3", future=True)
+    cg.make_cs_cert("cs1_ch1.3_ta3", "ch1.3_ta3", parent_loc="chain_certs")
+    # Make a chain where the CA does not have keyUsage set.
+    cg.make_ca_cert("ch1.4_ta3", "ta3", future=True, ext="v3_ca_no_keyUsage")
+    cg.make_cs_cert("cs1_ch1.4_ta3", "ch1.4_ta3", parent_loc="chain_certs")
 
-        # Revoke a code signing certificate from the publisher.
-        cg.make_trust_anchor("ta4")
-        cg.make_ca_cert("ch1_ta4", "ta4")
-        cg.make_cs_cert("cs1_ch1_ta4", "ch1_ta4", parent_loc="chain_certs",
-            ext="crl_ext")
-        cg.revoke_cert("ch1_ta4", "cs1_ch1_ta4", ca_dir="chain_certs")
-        cg.make_cs_cert("cs2_ch1_ta4", "ch1_ta4", parent_loc="chain_certs",
-            ext="bad_crl")
-        cg.make_cs_cert("cs3_ch1_ta4", "ch1_ta4", parent_loc="chain_certs",
-            ext="bad_crl_loc")
-        # Revoke a code signing certificate but sign the CRL with a CA
-        # certificate that does not have that keyUsage set.
-        cg.make_ca_cert("ch1.1_ta4", "ta4", ext="v3_ca_no_crl")
-        cg.make_cs_cert("cs1_ch1.1_ta4", "ch1.1_ta4", parent_loc="chain_certs",
-            ext="ch1.1_ta4_crl")
-        cg.revoke_cert("ch1.1_ta4", "cs1_ch1.1_ta4", ca_dir="chain_certs")
+    # Revoke a code signing certificate from the publisher.
+    cg.make_trust_anchor("ta4")
+    cg.make_ca_cert("ch1_ta4", "ta4")
+    cg.make_cs_cert(
+        "cs1_ch1_ta4", "ch1_ta4", parent_loc="chain_certs", ext="crl_ext"
+    )
+    cg.revoke_cert("ch1_ta4", "cs1_ch1_ta4", ca_dir="chain_certs")
+    cg.make_cs_cert(
+        "cs2_ch1_ta4", "ch1_ta4", parent_loc="chain_certs", ext="bad_crl"
+    )
+    cg.make_cs_cert(
+        "cs3_ch1_ta4", "ch1_ta4", parent_loc="chain_certs", ext="bad_crl_loc"
+    )
+    # Revoke a code signing certificate but sign the CRL with a CA
+    # certificate that does not have that keyUsage set.
+    cg.make_ca_cert("ch1.1_ta4", "ta4", ext="v3_ca_no_crl")
+    cg.make_cs_cert(
+        "cs1_ch1.1_ta4",
+        "ch1.1_ta4",
+        parent_loc="chain_certs",
+        ext="ch1.1_ta4_crl",
+    )
+    cg.revoke_cert("ch1.1_ta4", "cs1_ch1.1_ta4", ca_dir="chain_certs")
 
-        # Revoke a CA cert from the trust anchor
-        cg.make_trust_anchor("ta5")
-        cg.make_ca_cert("ch1_ta5", "ta5", ext="crl_ca")
-        cg.make_cs_cert("cs1_ch1_ta5", "ch1_ta5", parent_loc="chain_certs")
-        cg.revoke_cert("ta5", "ch1_ta5", cert_dir="chain_certs")
+    # Revoke a CA cert from the trust anchor
+    cg.make_trust_anchor("ta5")
+    cg.make_ca_cert("ch1_ta5", "ta5", ext="crl_ca")
+    cg.make_cs_cert("cs1_ch1_ta5", "ch1_ta5", parent_loc="chain_certs")
+    cg.revoke_cert("ta5", "ch1_ta5", cert_dir="chain_certs")
 
-        # Make more length 2 chains for testing https repos.
-        cg.make_trust_anchor("ta6", https=True)
-        cg.make_cs_cert("cs1_ta6", "ta6", https=True)
-        cg.make_trust_anchor("ta7", https=True)
-        # A passphrase is added to this one to test depot HTTPS functionality.
-        cg.make_cs_cert("cs1_ta7", "ta7", https=True, passphrase="123")
-        cg.make_trust_anchor("ta8", https=True)
-        cg.make_cs_cert("cs1_ta8", "ta8", https=True)
-        cg.make_trust_anchor("ta9", https=True)
-        cg.make_cs_cert("cs1_ta9", "ta9", https=True)
-        cg.make_trust_anchor("ta10", https=True)
-        cg.make_cs_cert("cs1_ta10", "ta10", https=True)
-        cg.make_trust_anchor("ta11", https=True)
-        cg.make_cs_cert("cs1_ta11", "ta11", https=True)
+    # Make more length 2 chains for testing https repos.
+    cg.make_trust_anchor("ta6", https=True)
+    cg.make_cs_cert("cs1_ta6", "ta6", https=True)
+    cg.make_trust_anchor("ta7", https=True)
+    # A passphrase is added to this one to test depot HTTPS functionality.
+    cg.make_cs_cert("cs1_ta7", "ta7", https=True, passphrase="123")
+    cg.make_trust_anchor("ta8", https=True)
+    cg.make_cs_cert("cs1_ta8", "ta8", https=True)
+    cg.make_trust_anchor("ta9", https=True)
+    cg.make_cs_cert("cs1_ta9", "ta9", https=True)
+    cg.make_trust_anchor("ta10", https=True)
+    cg.make_cs_cert("cs1_ta10", "ta10", https=True)
+    cg.make_trust_anchor("ta11", https=True)
+    cg.make_cs_cert("cs1_ta11", "ta11", https=True)
 
-        # Create a combined CA file to test different client certs with Apache
-        fhw = open(os.path.join(output_dir, "combined_cas.pem"), "w")
-        for x in range(6,12):
-                if x == 7:
-                        # ta requires a password to unlock cert, don't use
-                        continue
-                fn = "{0}/ta{1:d}/ta{2:d}_cert.pem".format(output_dir, x, x)
-                fhr = open(fn, "r")
-                fhw.write(fhr.read())
-                fhr.close()
-        fhw.close()
+    # Create a combined CA file to test different client certs with Apache
+    fhw = open(os.path.join(output_dir, "combined_cas.pem"), "w")
+    for x in range(6, 12):
+        if x == 7:
+            # ta requires a password to unlock cert, don't use
+            continue
+        fn = "{0}/ta{1:d}/ta{2:d}_cert.pem".format(output_dir, x, x)
+        fhr = open(fn, "r")
+        fhw.write(fhr.read())
+        fhr.close()
+    fhw.close()
 
-        # Create a certificate with an extension that Cryptography can't
-        # understand. We can't do it by the OpenSSL CLI, but we can use a C
-        # program that calls OpenSSL libraries to do it.
-        os.chdir("../../../util/mkcert")
-        cmdline = "./certgen"
-        p = subprocess.Popen(cmdline, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, shell=True)
-        p.wait()
+    # Create a certificate with an extension that Cryptography can't
+    # understand. We can't do it by the OpenSSL CLI, but we can use a C
+    # program that calls OpenSSL libraries to do it.
+    os.chdir("../../../util/mkcert")
+    cmdline = "./certgen"
+    p = subprocess.Popen(
+        cmdline, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    )
+    p.wait()
 
-        output, error = p.communicate()
-        if p.returncode == 127:
-                print("certgen not found; execute 'make' in the mkcert "
-                    "directory first")
-                sys.exit(p.returncode)
-        elif p.returncode != 0:
-                print("failed: {0} {1}".format(output, error))
-                sys.exit(p.returncode)
+    output, error = p.communicate()
+    if p.returncode == 127:
+        print(
+            "certgen not found; execute 'make' in the mkcert " "directory first"
+        )
+        sys.exit(p.returncode)
+    elif p.returncode != 0:
+        print("failed: {0} {1}".format(output, error))
+        sys.exit(p.returncode)
 
-        # copy the generated cert files from util/mkcert to the ro_data area
-        shutil.copy("cust_key.pem",
-            "../../tests/ro_data/signing_certs/produced/keys/")
-        shutil.copy("cust_cert.pem",
-            "../../tests/ro_data/signing_certs/produced/code_signing_certs/")
-        shutil.copy("cust_cert.pem",
-            "../../tests/ro_data/signing_certs/produced/trust_anchors/")
+    # copy the generated cert files from util/mkcert to the ro_data area
+    shutil.copy(
+        "cust_key.pem", "../../tests/ro_data/signing_certs/produced/keys/"
+    )
+    shutil.copy(
+        "cust_cert.pem",
+        "../../tests/ro_data/signing_certs/produced/code_signing_certs/",
+    )
+    shutil.copy(
+        "cust_cert.pem",
+        "../../tests/ro_data/signing_certs/produced/trust_anchors/",
+    )
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -36,12 +36,13 @@ from functools import reduce
 
 pdir = os.path.dirname(__file__)
 if pdir != "" and pdir != "." and pdir != os.getcwd():
-        os.putenv('PYEXE', sys.executable)
-        os.chdir(pdir)
-        import subprocess
-        cmd = [sys.executable, "run.py"]
-        cmd.extend(sys.argv[1:]) # Skip argv[0]
-        sys.exit(subprocess.call(cmd))
+    os.putenv("PYEXE", sys.executable)
+    os.chdir(pdir)
+    import subprocess
+
+    cmd = [sys.executable, "run.py"]
+    cmd.extend(sys.argv[1:])  # Skip argv[0]
+    sys.exit(subprocess.call(cmd))
 
 #
 # Some modules we use are located in our own proto area.  So before doing
@@ -53,18 +54,25 @@ sys.path.insert(0, ".")
 
 # Create a temporary directory for storing coverage data.
 import tempfile
+
 covdir = tempfile.mkdtemp(prefix=".coverage-", dir=os.getcwd())
 
 import getopt
 import pkg5testenv
 import warnings
+
 cov = None
 
+
 def usage(exitcode=2):
-        print("Usage: {0} [-dfghlpqtvVx] [-a dir] [-b filename] [-c format]\n"\
-             "              [-j jobs] [-o regexp] [-s regexp]\n"\
-             "              [-z port] ".format(sys.argv[0]), file=sys.stderr)
-        print("""\
+    print(
+        "Usage: {0} [-dfghlpqtvVx] [-a dir] [-b filename] [-c format]\n"
+        "              [-j jobs] [-o regexp] [-s regexp]\n"
+        "              [-z port] ".format(sys.argv[0]),
+        file=sys.stderr,
+    )
+    print(
+        """\
    -a <dir>       Archive failed test cases to <dir>/$pid/$testcasename
    -b <filename>  Baseline filename
    -c <format>    Collect code coverage data in xml or html format
@@ -83,111 +91,127 @@ def usage(exitcode=2):
    -V             Do not redirect stdout
    -x             Stop after the first baseline mismatch
    -z <port>      Lowest port the test suite should use
-""", file=sys.stderr)
-        sys.exit(exitcode)
+""",
+        file=sys.stderr,
+    )
+    sys.exit(exitcode)
+
 
 if __name__ == "__main__":
+    #
+    # Start coverage before proceeding so that reports are accurate.
+    #
+    if covdir:
+        import coverage
+
+        os.chmod(covdir, 0o1777)
+        cov_file = "{0}/pkg5".format(covdir)
+        cov = coverage.coverage(data_file=cov_file, data_suffix=True)
+        cov.start()
+    # Make all warnings be errors.
+    warnings.simplefilter("error")
+
+    # These warnings only happen in the test suite when importing
+    # pkg5unittest. It may be because of circular import inside pkg5unittest.
+    # Suppress the warning.
+    warnings.filterwarnings(
+        "ignore", message="Not importing directory .*", category=ImportWarning
+    )
+    warnings.filterwarnings(
+        "ignore",
+        message="CRLExtensionOID has been " "renamed to CRLEntryExtensionOID",
+        category=PendingDeprecationWarning,
+    )
+
+    # Suppress ResourceWarning: unclosed file.
+    warnings.filterwarnings("ignore", category=ResourceWarning)
+
+    try:
         #
-        # Start coverage before proceeding so that reports are accurate.
+        # !!! WARNING !!!
         #
-        if covdir:
-                import coverage
-                os.chmod(covdir, 0o1777)
-                cov_file = "{0}/pkg5".format(covdir)
-                cov = coverage.coverage(data_file=cov_file, data_suffix=True)
-                cov.start()
-        # Make all warnings be errors.
-        warnings.simplefilter('error')
+        # If you add options here, you need to also update setup.py's
+        # test_func to include said options.
+        #
+        opts, pargs = getopt.getopt(
+            sys.argv[1:],
+            "a:c:dfghj:lpqtuvVxb:o:s:z:",
+            [
+                "generate-baseline",
+                "parseable",
+                "port",
+                "timing",
+                "verbose",
+                "baseline-file",
+                "only",
+            ],
+        )
+    except getopt.GetoptError as e:
+        print("Illegal option -- {0}".format(e.opt), file=sys.stderr)
+        usage(1)
 
-        # These warnings only happen in the test suite when importing
-        # pkg5unittest. It may be because of circular import inside pkg5unittest.
-        # Suppress the warning.
-        warnings.filterwarnings('ignore', message='Not importing directory .*',
-            category=ImportWarning)
-        warnings.filterwarnings('ignore', message='CRLExtensionOID has been '
-            'renamed to CRLEntryExtensionOID',
-            category=PendingDeprecationWarning)
+    bfile = os.path.join(os.getcwd(), "baseline3.txt")
+    generate = False
+    onlyval = []
+    output = ""
+    sstdout = False
+    bailonfail = False
+    startattest = ""
+    timing_file = False
+    do_coverage = False
+    debug_output = False
+    show_on_expected_fail = False
+    archive_dir = None
+    port = 12001
+    quiet = False
+    system_test = False
+    jobs = 1
 
-        # Suppress ResourceWarning: unclosed file.
-        warnings.filterwarnings("ignore", category=ResourceWarning)
+    for opt, arg in opts:
+        if opt == "-v":
+            output = "v"
+        elif opt == "-V":
+            sstdout = True
+        elif opt == "-p":
+            output = "p"
+        elif opt == "-c":
+            do_coverage = True
+            coverage_format = arg
+        elif opt == "-d":
+            debug_output = True
+        elif opt == "-f":
+            show_on_expected_fail = True
+        elif opt == "-g":
+            generate = True
+        elif opt == "-b":
+            bfile = arg
+        elif opt == "-o":
+            onlyval.append(arg)
+        elif opt == "-x":
+            bailonfail = True
+        elif opt == "-t":
+            timing_file = True
+        elif opt == "-s":
+            startattest = arg
+        elif opt == "-a":
+            archive_dir = arg
+        elif opt == "-z":
+            try:
+                port = int(arg)
+            except ValueError:
+                print("The provided port must be an integer.", file=sys.stderr)
+                usage()
+        elif opt == "-h":
+            usage()
+        elif opt == "-j":
+            jobs = int(arg)
+        elif opt == "-q":
+            quiet = True
+        elif opt == "-l":
+            system_test = True
+            print("Running tests on live system.")
 
-        try:
-                #
-                # !!! WARNING !!!
-                #
-                # If you add options here, you need to also update setup.py's
-                # test_func to include said options.
-                #
-                opts, pargs = getopt.getopt(sys.argv[1:], "a:c:dfghj:lpqtuvVxb:o:s:z:",
-                    ["generate-baseline", "parseable", "port", "timing",
-                    "verbose", "baseline-file", "only"])
-        except getopt.GetoptError as e:
-                print("Illegal option -- {0}".format(e.opt), file=sys.stderr)
-                usage(1)
-
-        bfile = os.path.join(os.getcwd(), "baseline3.txt")
-        generate = False
-        onlyval = []
-        output = ""
-        sstdout = False
-        bailonfail = False
-        startattest = ""
-        timing_file = False
-        do_coverage = False
-        debug_output = False
-        show_on_expected_fail = False
-        archive_dir = None
-        port = 12001
-        quiet = False
-        system_test = False
-        jobs = 1
-
-        for opt, arg in opts:
-                if opt == "-v":
-                        output = "v"
-                elif opt == "-V":
-                        sstdout = True
-                elif opt == "-p":
-                        output = "p"
-                elif opt == "-c":
-                        do_coverage = True
-                        coverage_format = arg
-                elif opt == "-d":
-                        debug_output = True
-                elif opt == "-f":
-                        show_on_expected_fail = True
-                elif opt == "-g":
-                        generate = True
-                elif opt == "-b":
-                        bfile = arg
-                elif opt == "-o":
-                        onlyval.append(arg)
-                elif opt == "-x":
-                        bailonfail = True
-                elif opt == "-t":
-                        timing_file = True
-                elif opt == "-s":
-                        startattest = arg
-                elif opt == "-a":
-                        archive_dir = arg
-                elif opt == "-z":
-                        try:
-                                port = int(arg)
-                        except ValueError:
-                                print("The provided port must be an integer.",
-                                    file=sys.stderr)
-                                usage()
-                elif opt == "-h":
-                        usage()
-                elif opt == "-j":
-                        jobs = int(arg)
-                elif opt == "-q":
-                        quiet = True
-                elif opt == "-l":
-                        system_test = True
-                        print("Running tests on live system.")
-
-        pkg5testenv.setup_environment("../../proto", system_test=system_test)
+    pkg5testenv.setup_environment("../../proto", system_test=system_test)
 
 import baseline
 import platform
@@ -203,412 +227,426 @@ from pkg5unittest import OUTPUT_DOTS, OUTPUT_VERBOSE, OUTPUT_PARSEABLE
 
 # Verify that CLIENT_API_VERSION is compatible.
 if pkg5unittest.CLIENT_API_VERSION not in api.COMPATIBLE_API_VERSIONS:
-        print("Test suite needs to be synced with the pkg bits.")
-        sys.exit(1)
+    print("Test suite needs to be synced with the pkg bits.")
+    sys.exit(1)
 
 osname = platform.uname()[0].lower()
-arch = 'unknown'
-if osname == 'sunos':
-        arch = platform.processor()
-elif osname == 'linux':
-        arch = "linux_" + platform.machine()
-elif osname == 'windows':
-        arch = osname
-elif osname == 'darwin':
-        arch = osname
+arch = "unknown"
+if osname == "sunos":
+    arch = platform.processor()
+elif osname == "linux":
+    arch = "linux_" + platform.machine()
+elif osname == "windows":
+    arch = osname
+elif osname == "darwin":
+    arch = osname
 elif osname == "aix":
-        arch = osname
+    arch = osname
 
 ostype = os.name
-if ostype == '':
-        ostype = 'unknown'
+if ostype == "":
+    ostype = "unknown"
+
 
 class Pkg5TestLoader(unittest.TestLoader):
-        suiteClass = pkg5unittest.Pkg5TestSuite
+    suiteClass = pkg5unittest.Pkg5TestSuite
 
-def find_tests(testdir, testpats, startatpat=False, output=OUTPUT_DOTS,
-    time_estimates=None):
-        # Test pattern to match against
-        pats = [ re.compile("{0}".format(pat), re.IGNORECASE) for pat in testpats ]
-        startatpat = re.compile("{0}".format(startattest), re.IGNORECASE)
-        seen = False
 
-        def _istest(obj):
-                if (isinstance(obj, type) and
-                    issubclass(obj, unittest.TestCase)):
-                        return True
-                return False
-        def _istestmethod(name, obj):
-                if name.startswith("test"):
-                    # There is no unbound methods in Python 3, instead they
-                    # simply become functions.
-                    if isinstance(obj, types.FunctionType):
-                        return True
-                return False
+def find_tests(
+    testdir, testpats, startatpat=False, output=OUTPUT_DOTS, time_estimates=None
+):
+    # Test pattern to match against
+    pats = [re.compile("{0}".format(pat), re.IGNORECASE) for pat in testpats]
+    startatpat = re.compile("{0}".format(startattest), re.IGNORECASE)
+    seen = False
 
-        def _vprint(*text):
-                if output == OUTPUT_VERBOSE or output == OUTPUT_PARSEABLE:
-                        print(' '.join([str(l) for l in text]), end=" ")
+    def _istest(obj):
+        if isinstance(obj, type) and issubclass(obj, unittest.TestCase):
+            return True
+        return False
 
-        loader = Pkg5TestLoader()
-        testclasses = []
-        # "testdir" will be "api", "cli", etc., so find all the files in that 
-        # directory that match the pattern "t_*.py".
-        _vprint("# Loading {0} tests:\n".format(testdir))
-        curlinepos = 0
-        for f in sorted(os.listdir(testdir)):
-                if curlinepos == 0:
-                        _vprint("#        ")
-                        curlinepos += 9
+    def _istestmethod(name, obj):
+        if name.startswith("test"):
+            # There is no unbound methods in Python 3, instead they
+            # simply become functions.
+            if isinstance(obj, types.FunctionType):
+                return True
+        return False
 
-                if not (f.startswith("t_") and f.endswith(".py")):
+    def _vprint(*text):
+        if output == OUTPUT_VERBOSE or output == OUTPUT_PARSEABLE:
+            print(" ".join([str(l) for l in text]), end=" ")
+
+    loader = Pkg5TestLoader()
+    testclasses = []
+    # "testdir" will be "api", "cli", etc., so find all the files in that
+    # directory that match the pattern "t_*.py".
+    _vprint("# Loading {0} tests:\n".format(testdir))
+    curlinepos = 0
+    for f in sorted(os.listdir(testdir)):
+        if curlinepos == 0:
+            _vprint("#        ")
+            curlinepos += 9
+
+        if not (f.startswith("t_") and f.endswith(".py")):
+            continue
+        name = os.path.join(testdir, f)
+        name = name.replace(".py", "")
+        name = ".".join(name.split(os.path.sep))
+        # "api.t_filter" -> ["api", "t_filter"]
+        suitename, filename = name.split(".")
+
+        try:
+            obj = __import__(name)
+        except ImportError as e:
+            print("Skipping {0}: {1}".format(name, str(e)))
+            continue
+
+        if curlinepos != 0 and (curlinepos + len(filename) + 1) >= 78:
+            _vprint("\n#        ")
+            curlinepos = 9
+        _vprint("{0}".format(filename))
+        curlinepos += len(filename) + 1
+
+        # file object (t_filter, etc)
+        fileobj = getattr(obj, filename)
+        # Get all the classes from the file
+        for cname in dir(fileobj):
+            # Get the actual class object
+            classobj = getattr(fileobj, cname)
+            # Make sure it's a test case
+            if not _istest(classobj):
+                continue
+
+            # We tack this in for pretty-printing.
+            classobj._Pkg5TestCase__suite_name = suitename
+
+            # Skip some test classes. OmniOS does not currently
+            # have Apache-backed repos or depots
+            if cname in [
+                "TestSysrepo",
+                "TestHTTPS",
+                "TestBasicSysrepoCli",
+                "TestDetailedSysrepoCli",
+                "TestHttpDepot",
+                "TestHttpsDepot",
+                "TestPkgInstallApache",
+                "TestPkgrecvHTTPS",
+                "TestPkgrepoHTTPS",
+                "TestPkgsendHTTPS",
+                "TestP5pWsgi",
+            ]:
+                continue
+
+            for attrname in dir(classobj):
+                methobj = getattr(classobj, attrname)
+                # Make sure its a test method
+                if not _istestmethod(attrname, methobj):
+                    continue
+                # Skip some test cases for Python 3.
+                # test_bootenv requires boot-environment-utils
+                # Python 3.x package
+                if attrname in ["test_bootenv"]:
+                    delattr(classobj, attrname)
+                    continue
+                full = "{0}.{1}.{2}.{3}".format(
+                    testdir, filename, cname, attrname
+                )
+                # Remove this function from our class obj if
+                # it doesn't match the test pattern
+                if not seen:
+                    if re.search(startatpat, full):
+                        seen = True
+                    else:
+                        delattr(classobj, attrname)
                         continue
-                name = os.path.join(testdir, f)
-                name = name.replace(".py", "")
-                name = '.'.join(name.split(os.path.sep))
-                # "api.t_filter" -> ["api", "t_filter"]
-                suitename, filename = name.split(".")
+                found = reduce(
+                    lambda x, y: x or y,
+                    [re.search(pat, full) for pat in pats],
+                    None,
+                )
+                if not found:
+                    delattr(classobj, attrname)
+            testclasses.append(classobj)
+    _vprint("\n#\n")
 
-                try:
-                        obj = __import__(name)
-                except ImportError as e:
-                        print("Skipping {0}: {1}".format(name, str(e)))
-                        continue
+    testclasses = [loader.loadTestsFromTestCase(cobj) for cobj in testclasses]
+    if time_estimates is None:
 
-                if curlinepos != 0 and (curlinepos + len(filename) + 1) >= 78:
-                        _vprint("\n#        ")
-                        curlinepos = 9
-                _vprint("{0}".format(filename))
-                curlinepos += len(filename) + 1
+        def __key(c):
+            return c.test_count()
 
-                # file object (t_filter, etc)
-                fileobj = getattr(obj, filename)
-                # Get all the classes from the file
-                for cname in dir(fileobj):
-                        # Get the actual class object
-                        classobj = getattr(fileobj, cname)
-                        # Make sure it's a test case
-                        if not _istest(classobj):
-                                continue
+    else:
 
-                        # We tack this in for pretty-printing.
-                        classobj._Pkg5TestCase__suite_name = suitename
+        def __key(c):
+            if testdir not in time_estimates:
+                return c.test_count()
+            if not c.tests:
+                return 0
+            mod, c_name = pkg5unittest.find_names(c.tests[0])
+            res = 0
+            for test in c.tests:
+                res += pkg5unittest.Pkg5TestRunner.estimate_method_time(
+                    time_estimates, testdir, c_name, test.methodName
+                )
+            return res
 
-                        # Skip some test classes. OmniOS does not currently
-                        # have Apache-backed repos or depots
-                        if cname in ['TestSysrepo', 'TestHTTPS',
-                            'TestBasicSysrepoCli', 'TestDetailedSysrepoCli',
-                            'TestHttpDepot', 'TestHttpsDepot',
-                            'TestPkgInstallApache', 'TestPkgrecvHTTPS',
-                            'TestPkgrepoHTTPS', 'TestPkgsendHTTPS',
-                            'TestP5pWsgi']:
-                                continue
+    suite_list = []
+    for t in sorted(testclasses, key=__key, reverse=True):
+        if t.test_count():
+            suite_list.append(t)
 
-                        for attrname in dir(classobj):
-                                methobj = getattr(classobj, attrname)
-                                # Make sure its a test method
-                                if not _istestmethod(attrname, methobj):
-                                        continue
-                                # Skip some test cases for Python 3.
-                                # test_bootenv requires boot-environment-utils
-                                # Python 3.x package
-                                if attrname in ["test_bootenv"]:
-                                    delattr(classobj, attrname)
-                                    continue
-                                full = "{0}.{1}.{2}.{3}".format(testdir,
-                                    filename, cname, attrname)
-                                # Remove this function from our class obj if
-                                # it doesn't match the test pattern
-                                if not seen:
-                                        if re.search(startatpat, full):
-                                                seen = True
-                                        else:
-                                                delattr(classobj, attrname)
-                                                continue
-                                found = reduce(lambda x, y: x or y,
-                                    [ re.search(pat, full) for pat in pats ],
-                                    None)
-                                if not found:
-                                        delattr(classobj, attrname)
-                        testclasses.append(classobj)
-        _vprint("\n#\n")
+    return suite_list
 
-        testclasses = [
-            loader.loadTestsFromTestCase(cobj) for cobj in testclasses
-        ]
-        if time_estimates is None:
-                def __key(c):
-                        return c.test_count()
-        else:
-                def __key(c):
-                        if testdir not in time_estimates:
-                                return c.test_count()
-                        if not c.tests:
-                                return 0
-                        mod, c_name = pkg5unittest.find_names(c.tests[0])
-                        res = 0
-                        for test in c.tests:
-                                res += pkg5unittest.Pkg5TestRunner.\
-                                    estimate_method_time(
-                                    time_estimates, testdir, c_name,
-                                    test.methodName)
-                        return res
-        suite_list = []
-        for t in sorted(testclasses, key=__key, reverse=True):
-                if t.test_count():
-                        suite_list.append(t)
-
-        return suite_list
 
 def generate_coverage(cov_format, includes, omits, dest):
+    if cov_format == "html":
+        cov_option = "-d"
+        cov_dest = dest + "_html"
+    elif cov_format == "xml":
+        cov_option = "-o"
+        cov_dest = dest + ".xml"
+    else:
+        raise Exception("Unsupported coverage format")
+
+    cmd = ["coverage", cov_format]
+    if includes and len(includes):
+        cmd.extend(["--include", ",".join(includes)])
+    if omits and len(omits):
+        cmd.extend(["--omit", ",".join(omits)])
+    cmd.extend([cov_option, cov_dest])
+
+    print("Generating coverage report via: ", " ".join(cmd), file=sys.stderr)
+    if subprocess.Popen(cmd).wait() != 0:
+        raise Exception("Failed to generate coverage report!")
+
+    # The coverage data file and report are most likely owned by
+    # root, if a true test run was performed.  Make the files owned
+    # by the owner of the test directory, so they can be easily
+    # removed.
+    try:
+        uid, gid = os.stat(".")[4:6]
+        os.chown(cov_dest, uid, gid)
         if cov_format == "html":
-                cov_option = "-d"
-                cov_dest = dest + "_html"
-        elif cov_format == "xml":
-                cov_option = "-o"
-                cov_dest = dest + ".xml"
-        else:
-                raise Exception("Unsupported coverage format")
+            for f in os.listdir(cov_dest):
+                os.chown("{0}/{1}".format(cov_dest, f), uid, gid)
+    except EnvironmentError:
+        pass
 
-        cmd = ["coverage", cov_format]
-        if includes and len(includes):
-                cmd.extend(["--include", ",".join(includes)])
-        if omits and len(omits):
-                cmd.extend(["--omit", ",".join(omits)])
-        cmd.extend([cov_option, cov_dest])
 
-        print("Generating coverage report via: ", " ".join(cmd), file=sys.stderr)
-        if subprocess.Popen(cmd).wait() != 0:
-                raise Exception("Failed to generate coverage report!")
+if __name__ == "__main__":
+    pkg5unittest.g_debug_output = debug_output
+    output = {"v": OUTPUT_VERBOSE, "p": OUTPUT_PARSEABLE}.get(
+        output, OUTPUT_DOTS
+    )
+
+    if (bailonfail or startattest) and generate:
+        usage()
+    if quiet and (output != OUTPUT_DOTS):
+        print("-q cannot be used with -v or -p", file=sys.stderr)
+        usage()
+
+    if output != OUTPUT_DOTS:
+        quiet = True
+    if not onlyval:
+        onlyval = [""]
+
+    # If coverage wasn't requested, stop it and delete the temporary data.
+    if not do_coverage:
+        cov.stop()
+        shutil.rmtree(covdir)
+        cov = None
+    elif not coverage_format in ("xml", "html"):
+        print("-c <format> must be xml or html", file=sys.stderr)
+        usage()
+
+    # Allow relative archive dir, but first convert it to abs. paths.
+    if archive_dir is not None:
+        archive_dir = os.path.abspath(archive_dir)
+        if not os.path.exists(archive_dir):
+            os.makedirs(archive_dir)
+
+    import pkg.portable
+
+    if not pkg.portable.is_admin():
+        print(
+            "WARNING: You don't seem to be root." " Some tests may fail.",
+            file=sys.stderr,
+        )
+    else:
+        ppriv = "/usr/bin/ppriv"
+        if os.path.exists(ppriv):
+            # One of the tests actually calls unlink() on a directory,
+            # and expects it to fail as it does on ZFS, but on tmpfs
+            # it scarily succeeds.
+            subprocess.call([ppriv, "-s", "A-sys_linkdir", str(os.getpid())])
+
+    time_estimates = {}
+    timing_history = os.path.join(os.getcwd(), ".timing_history.txt")
+    if os.path.exists(timing_history):
+        with open(timing_history, "r") as fh:
+            ver, time_estimates = stdlibjson.load(fh)
+
+    api_suite = find_tests("api", onlyval, startattest, output, time_estimates)
+    cli_suite = find_tests("cli", onlyval, startattest, output, time_estimates)
+
+    suites = []
+    suites.append(api_suite)
+    if ostype == "posix":
+        suites.append(cli_suite)
+
+    # This is primarily of interest to developers altering the test suite,
+    # so don't enable it for now.  The testsuite suite tends to emit a bunch
+    # of harmless but noisy errors to the screen due to the way it exercises
+    # various corner cases.
+    # testsuite_suite = find_tests("testsuite", onlyval, startattest, output)
+    # suites.append(testsuite_suite)
+
+    # Initialize the baseline results and load them
+    baseline = baseline.BaseLine(bfile, generate)
+    baseline.load()
+
+    if sstdout:
+        testlogfp = None
+    else:
+        # Make sure we capture stdout
+        testlogfd, testlogpath = tempfile.mkstemp(suffix=".pkg-test.log")
+        testlogfp = os.fdopen(testlogfd, "w")
+        print("# logging to {0}".format(testlogpath))
+        sys.stdout = testlogfp
+
+    if timing_file:
+        timing_file = os.path.join(os.getcwd(), "timing_info.txt")
+        if os.path.exists(timing_file):
+            os.remove(timing_file)
+
+    # Set up coverage for cli tests
+    if do_coverage:
+        cov_env = {"COVERAGE_FILE": "{0}/pkg5".format(covdir)}
+        cov_cmd = "coverage run -p"
+    else:
+        cov_env = {}
+        cov_cmd = ""
+
+    # Set the task id for this process so that we can cleanly kill
+    # all processes started.
+    cmd = ["newtask", "-c", str(os.getpid())]
+    ret = subprocess.call(cmd)
+    if ret != 0:
+        print(
+            "Couldn't find the 'newtask' command.  "
+            "Please ensure it's in your path before running the test "
+            "suite.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Run the python test suites
+    runner = pkg5unittest.Pkg5TestRunner(
+        baseline,
+        output=output,
+        timing_file=timing_file,
+        timing_history=timing_history,
+        bailonfail=bailonfail,
+        coverage=(cov_cmd, cov_env),
+        show_on_expected_fail=show_on_expected_fail,
+        archive_dir=archive_dir,
+    )
+    exitval = 0
+    for suite_list in suites:
+        try:
+            res = runner.run(
+                suite_list, jobs, port, time_estimates, quiet, bfile
+            )
+        except pkg5unittest.Pkg5TestCase.failureException as e:
+            exitval = 1
+            print(file=sys.stderr)
+            print(e, file=sys.stderr)
+            break
+        except pkg5unittest.TestStopException as e:
+            exitval = 1
+            print(file=sys.stderr)
+            break
+        if res.mismatches:
+            exitval = 1
+
+    if testlogfp:
+        testlogfp.close()
+
+    # Update baseline results and display mismatches (failures)
+
+    if onlyval[0] != "":
+        # Do not overwrite failure file if running selected tests
+        failfile = None
+    else:
+        failfile = "failures.3"
+
+    baseline.store()
+    baseline.reportfailures(failfile)
+
+    # Stop and save coverage data for API tests, and combine coverage data
+    # from all processes.
+    if do_coverage:
+        cov.stop()
+        cov.save()
+        newenv = os.environ.copy()
+        newenv.update(cov_env)
+        subprocess.Popen(["coverage", "combine"], env=newenv).wait()
+        os.rename("{0}/pkg5".format(covdir), ".coverage")
+        shutil.rmtree(covdir)
+
+        omits = [
+            # These mako templates fail.
+            "*etc_pkg_*mako",
+            "_depot_conf_mako",
+            # Complex use of module importer makes this fail.
+            "*sysrepo_p5p.py",
+            # Reading source file */fakeroot/pkg make this fail.
+            "*/fakeroot/pkg",
+        ]
+        pkg_path = [os.path.join(pkg5unittest.g_pkg_path, "*")]
+        proto = ["{0}/*".format(pkg5unittest.g_proto_area)]
+
+        try:
+            generate_coverage(coverage_format, pkg_path, omits, "cov_pkg_path")
+            generate_coverage(coverage_format, None, proto + omits, "cov_tests")
+        except Exception as e:
+            print(e, file=sys.stderr)
+            exitval = 1
 
         # The coverage data file and report are most likely owned by
         # root, if a true test run was performed.  Make the files owned
         # by the owner of the test directory, so they can be easily
         # removed.
         try:
-                uid, gid = os.stat(".")[4:6]
-                os.chown(cov_dest, uid, gid)
-                if cov_format == "html":
-                        for f in os.listdir(cov_dest):
-                                os.chown("{0}/{1}".format(cov_dest, f), uid, gid)
+            uid, gid = os.stat(".")[4:6]
+            os.chown(".coverage", uid, gid)
         except EnvironmentError:
-                pass
+            pass
 
+    # The tree likely contains files and python cache objects owned by
+    # root, if a true test run was performed. Adjust the ownership to match
+    # the test directory so they can be easily removed.
+    try:
+        uid, gid = os.stat(".")[4:6]
+        for f in [timing_file, failfile]:
+            if not f:
+                continue
+            f = os.path.join(os.getcwd(), f)
+            if os.path.exists(f):
+                os.chown(f, uid, gid)
 
-if __name__ == "__main__":
-        pkg5unittest.g_debug_output = debug_output
-        output = { "v": OUTPUT_VERBOSE,
-            "p": OUTPUT_PARSEABLE }.get(output, OUTPUT_DOTS)
+        for dir in [".", "../../proto"]:
+            for root, dirs, files in os.walk(dir):
+                if os.path.basename(root) != "__pycache__":
+                    continue
+                os.chown(root, uid, gid)
+                for name in [*dirs, *files]:
+                    os.chown(os.path.join(root, name), uid, gid)
+    except EnvironmentError:
+        pass
 
-        if (bailonfail or startattest) and generate:
-                usage()
-        if quiet and (output != OUTPUT_DOTS):
-                print("-q cannot be used with -v or -p", file=sys.stderr)
-                usage()
-
-        if output != OUTPUT_DOTS:
-                quiet = True
-        if not onlyval:
-                onlyval = [ "" ]
-
-        # If coverage wasn't requested, stop it and delete the temporary data.
-        if not do_coverage:
-                cov.stop()
-                shutil.rmtree(covdir)
-                cov = None
-        elif not coverage_format in ("xml", "html"):
-                print("-c <format> must be xml or html", file=sys.stderr)
-                usage()
-
-        # Allow relative archive dir, but first convert it to abs. paths.
-        if archive_dir is not None:
-                archive_dir = os.path.abspath(archive_dir)
-                if not os.path.exists(archive_dir):
-                        os.makedirs(archive_dir)
-
-        import pkg.portable
-
-        if not pkg.portable.is_admin():
-                print("WARNING: You don't seem to be root."
-                    " Some tests may fail.", file=sys.stderr)
-        else:
-                ppriv = "/usr/bin/ppriv"
-                if os.path.exists(ppriv):
-                        # One of the tests actually calls unlink() on a directory,
-                        # and expects it to fail as it does on ZFS, but on tmpfs
-                        # it scarily succeeds.
-                        subprocess.call([
-                            ppriv, "-s", "A-sys_linkdir", str(os.getpid())
-                        ])
-
-
-        time_estimates = {}
-        timing_history = os.path.join(os.getcwd(), ".timing_history.txt")
-        if os.path.exists(timing_history):
-                with open(timing_history, "r") as fh:
-                        ver, time_estimates = stdlibjson.load(fh)
-
-        api_suite = find_tests("api", onlyval, startattest, output,
-            time_estimates)
-        cli_suite = find_tests("cli", onlyval, startattest, output,
-            time_estimates)
-
-        suites = []
-        suites.append(api_suite)
-        if ostype == "posix":
-                suites.append(cli_suite)
-
-        # This is primarily of interest to developers altering the test suite,
-        # so don't enable it for now.  The testsuite suite tends to emit a bunch
-        # of harmless but noisy errors to the screen due to the way it exercises
-        # various corner cases.
-        #testsuite_suite = find_tests("testsuite", onlyval, startattest, output)
-        #suites.append(testsuite_suite)
-
-        # Initialize the baseline results and load them
-        baseline = baseline.BaseLine(bfile, generate)
-        baseline.load()
-
-        if sstdout:
-                testlogfp = None
-        else:
-                # Make sure we capture stdout
-                testlogfd, testlogpath = tempfile.mkstemp(
-                    suffix='.pkg-test.log')
-                testlogfp = os.fdopen(testlogfd, "w")
-                print("# logging to {0}".format(testlogpath))
-                sys.stdout = testlogfp
-
-        if timing_file:
-                timing_file = os.path.join(os.getcwd(), "timing_info.txt")
-                if os.path.exists(timing_file):
-                        os.remove(timing_file)
-
-        # Set up coverage for cli tests
-        if do_coverage:
-                cov_env = {
-                    "COVERAGE_FILE": "{0}/pkg5".format(covdir)
-                }
-                cov_cmd = "coverage run -p"
-        else:
-                cov_env = {}
-                cov_cmd = ""
-
-        # Set the task id for this process so that we can cleanly kill
-        # all processes started.
-        cmd = ["newtask", "-c", str(os.getpid())]
-        ret = subprocess.call(cmd)
-        if ret != 0:
-                print("Couldn't find the 'newtask' command.  " \
-                    "Please ensure it's in your path before running the test " \
-                    "suite.", file=sys.stderr)
-                sys.exit(1)
-
-        # Run the python test suites
-        runner = pkg5unittest.Pkg5TestRunner(baseline, output=output,
-            timing_file=timing_file,
-            timing_history=timing_history,
-            bailonfail=bailonfail,
-            coverage=(cov_cmd, cov_env),
-            show_on_expected_fail=show_on_expected_fail,
-            archive_dir=archive_dir)
-        exitval = 0
-        for suite_list in suites:
-                try:
-                        res = runner.run(suite_list, jobs, port,
-                            time_estimates, quiet, bfile)
-                except pkg5unittest.Pkg5TestCase.failureException as e:
-                        exitval = 1
-                        print(file=sys.stderr)
-                        print(e, file=sys.stderr)
-                        break
-                except pkg5unittest.TestStopException as e:
-                        exitval = 1
-                        print(file=sys.stderr)
-                        break
-                if res.mismatches:
-                        exitval = 1
-
-        if testlogfp:
-                testlogfp.close()
-
-        # Update baseline results and display mismatches (failures)
-
-        if onlyval[0] != "":
-                # Do not overwrite failure file if running selected tests
-                failfile = None
-        else:
-                failfile = 'failures.3'
-
-        baseline.store()
-        baseline.reportfailures(failfile)
-
-        # Stop and save coverage data for API tests, and combine coverage data
-        # from all processes.
-        if do_coverage:
-                cov.stop()
-                cov.save()
-                newenv = os.environ.copy()
-                newenv.update(cov_env)
-                subprocess.Popen(["coverage", "combine"], env=newenv).wait()
-                os.rename("{0}/pkg5".format(covdir), ".coverage")
-                shutil.rmtree(covdir)
-
-                omits = [
-                    # These mako templates fail.
-                    "*etc_pkg_*mako", "_depot_conf_mako",
-                    # Complex use of module importer makes this fail.
-                    "*sysrepo_p5p.py",
-                    # Reading source file */fakeroot/pkg make this fail.
-                    "*/fakeroot/pkg",
-                ]
-                pkg_path = [os.path.join(pkg5unittest.g_pkg_path, "*")]
-                proto = ["{0}/*".format(pkg5unittest.g_proto_area)]
-
-                try:
-                        generate_coverage(coverage_format,
-                            pkg_path,
-                            omits, "cov_pkg_path")
-                        generate_coverage(coverage_format, None,
-                            proto + omits, "cov_tests")
-                except Exception as e:
-                        print(e, file=sys.stderr)
-                        exitval = 1
-
-                # The coverage data file and report are most likely owned by
-                # root, if a true test run was performed.  Make the files owned
-                # by the owner of the test directory, so they can be easily
-                # removed.
-                try:
-                        uid, gid = os.stat(".")[4:6]
-                        os.chown(".coverage", uid, gid)
-                except EnvironmentError:
-                        pass
-
-        # The tree likely contains files and python cache objects owned by
-        # root, if a true test run was performed. Adjust the ownership to match
-        # the test directory so they can be easily removed.
-        try:
-                uid, gid = os.stat(".")[4:6]
-                for f in [timing_file, failfile]:
-                        if not f:
-                                continue
-                        f = os.path.join(os.getcwd(), f)
-                        if os.path.exists(f):
-                                os.chown(f, uid, gid);
-
-                for dir in ['.', '../../proto']:
-                        for root, dirs, files in os.walk(dir):
-                                if os.path.basename(root) != '__pycache__':
-                                        continue
-                                os.chown(root, uid, gid);
-                                for name in [*dirs, *files]:
-                                        os.chown(os.path.join(root, name),
-                                            uid, gid)
-        except EnvironmentError:
-                pass
-
-        sys.exit(exitval)
+    sys.exit(exitval)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/testsuite/__init__.py
+++ b/src/tests/testsuite/__init__.py
@@ -25,4 +25,4 @@
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/testsuite/t_setup_teardown.py
+++ b/src/tests/testsuite/t_setup_teardown.py
@@ -24,8 +24,9 @@
 # Use is subject to license terms.
 
 import testutils
+
 if __name__ == "__main__":
-        testutils.setup_environment("../../../proto")
+    testutils.setup_environment("../../../proto")
 import pkg5unittest
 
 import os
@@ -33,103 +34,109 @@ import unittest
 
 from pkg import misc
 
+
 class TestAllFine(pkg5unittest.SingleDepotTestCase):
-        
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
 
-        def tearDown(self):
-                pkg5unittest.SingleDepotTestCase.tearDown(self)
+    def tearDown(self):
+        pkg5unittest.SingleDepotTestCase.tearDown(self)
 
-        def test_shouldpass1(self):
-                pass
+    def test_shouldpass1(self):
+        pass
 
-        def test_shouldpass2(self):
-                pass
+    def test_shouldpass2(self):
+        pass
+
 
 class TestSetupFailing(pkg5unittest.SingleDepotTestCase):
-        
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                raise RuntimeError("setup failing")
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        raise RuntimeError("setup failing")
 
-        def test_shoulderror1(self):
-                pass
+    def test_shoulderror1(self):
+        pass
 
-        def test_shoulderror2(self):
-                pass
+    def test_shoulderror2(self):
+        pass
+
 
 class TestSetupFailingEarly(pkg5unittest.SingleDepotTestCase):
-        
-        def setUp(self):
-                raise RuntimeError("setup failing")
-                pkg5unittest.SingleDepotTestCase.setUp(self)
+    def setUp(self):
+        raise RuntimeError("setup failing")
+        pkg5unittest.SingleDepotTestCase.setUp(self)
 
-        def test_shoulderror1(self):
-                pass
+    def test_shoulderror1(self):
+        pass
+
 
 class TestSetupFailingP(pkg5unittest.SingleDepotTestCase):
-        persistent_setup = True
-        
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
-                raise RuntimeError("setup failing")
+    persistent_setup = True
 
-        def test_shoulderror1(self):
-                pass
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+        raise RuntimeError("setup failing")
 
-        def test_shoulderror2(self):
-                pass
+    def test_shoulderror1(self):
+        pass
+
+    def test_shoulderror2(self):
+        pass
+
 
 class TestSetupFailingEarlyP(pkg5unittest.SingleDepotTestCase):
-        persistent_setup = True
-        
-        def setUp(self):
-                raise RuntimeError("setup failing")
-                pkg5unittest.SingleDepotTestCase.setUp(self)
+    persistent_setup = True
 
-        def test_shoulderror1(self):
-                pass
+    def setUp(self):
+        raise RuntimeError("setup failing")
+        pkg5unittest.SingleDepotTestCase.setUp(self)
+
+    def test_shoulderror1(self):
+        pass
+
 
 class TestTeardownFailing(pkg5unittest.SingleDepotTestCase):
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
 
-        def tearDown(self):
-                raise RuntimeError("tearDown failing")
+    def tearDown(self):
+        raise RuntimeError("tearDown failing")
 
-        def test_shoulderror1(self):
-                pass
+    def test_shoulderror1(self):
+        pass
 
-        def test_shoulderror2(self):
-                pass
+    def test_shoulderror2(self):
+        pass
+
 
 class TestTeardownFailingP(pkg5unittest.SingleDepotTestCase):
-        persistent_setup = True
+    persistent_setup = True
 
-        def setUp(self):
-                pkg5unittest.SingleDepotTestCase.setUp(self)
+    def setUp(self):
+        pkg5unittest.SingleDepotTestCase.setUp(self)
 
-        def tearDown(self):
-                raise RuntimeError("tearDown failing")
+    def tearDown(self):
+        raise RuntimeError("tearDown failing")
 
-        def test_shouldpass1(self):
-                pass
+    def test_shouldpass1(self):
+        pass
 
-        def test_shouldpass2(self):
-                pass
+    def test_shouldpass2(self):
+        pass
+
 
 class TestMisc(pkg5unittest.CliTestCase):
-        def doassign(self):
-                self.test_root = "foo"
+    def doassign(self):
+        self.test_root = "foo"
 
-        def test_testroot_readonly(self):
-                """ Test that test_root is readable but not writable """
-                x = self.test_root
-                self.assertRaises(AttributeError, self.doassign)
+    def test_testroot_readonly(self):
+        """Test that test_root is readable but not writable"""
+        x = self.test_root
+        self.assertRaises(AttributeError, self.doassign)
+
 
 if __name__ == "__main__":
-        unittest.main()
+    unittest.main()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/tests/testsuite/testutils.py
+++ b/src/tests/testsuite/testutils.py
@@ -29,12 +29,14 @@ import sys
 # Set the path so that modules can be found
 path_to_parent = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if path_to_parent not in sys.path:
-        sys.path.insert(0, path_to_parent)
+    sys.path.insert(0, path_to_parent)
 
 import pkg5testenv
 
+
 def setup_environment(proto):
-        pkg5testenv.setup_environment(proto)
+    pkg5testenv.setup_environment(proto)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/apache2/depot/depot_index.py
+++ b/src/util/apache2/depot/depot_index.py
@@ -66,6 +66,7 @@ depot_https = {}
 repository_lock = threading.Lock()
 
 import gettext
+
 gettext.install("/")
 
 # How often we ping the depot while long-running background tasks are running.
@@ -74,757 +75,795 @@ gettext.install("/")
 # Python interpreter.)
 KEEP_BUSY_INTERVAL = 120
 
-class DepotException(Exception):
-        """Super class for all exceptions raised by depot_index."""
-        def __init__(self, request, message):
-                self.request = request
-                self.message = message
-                self.http_status = http_client.INTERNAL_SERVER_ERROR
 
-        def __str__(self):
-                return "{0}: {1}".format(self.message, self.request)
+class DepotException(Exception):
+    """Super class for all exceptions raised by depot_index."""
+
+    def __init__(self, request, message):
+        self.request = request
+        self.message = message
+        self.http_status = http_client.INTERNAL_SERVER_ERROR
+
+    def __str__(self):
+        return "{0}: {1}".format(self.message, self.request)
 
 
 class AdminOpsDisabledException(DepotException):
-        """An exception thrown when this wsgi application hasn't been configured
-        to allow admin/0 pkg(7) depot responses."""
+    """An exception thrown when this wsgi application hasn't been configured
+    to allow admin/0 pkg(7) depot responses."""
 
-        def __init__(self, request):
-                self.request = request
-                self.http_status = http_client.FORBIDDEN
+    def __init__(self, request):
+        self.request = request
+        self.http_status = http_client.FORBIDDEN
 
-        def __str__(self):
-                return "admin/0 operations are disabled. " \
-                    "See the config/allow_refresh SMF property. " \
-                    "Request was: {0}".format(self.request)
+    def __str__(self):
+        return (
+            "admin/0 operations are disabled. "
+            "See the config/allow_refresh SMF property. "
+            "Request was: {0}".format(self.request)
+        )
 
 
 class AdminOpNotSupportedException(DepotException):
-        """An exception thrown when an admin request was made that isn't
-        supported by the http-depot."""
+    """An exception thrown when an admin request was made that isn't
+    supported by the http-depot."""
 
-        def __init__(self, request, cmd):
-                self.request = request
-                self.cmd = cmd
-                self.http_status = http_client.NOT_IMPLEMENTED
+    def __init__(self, request, cmd):
+        self.request = request
+        self.cmd = cmd
+        self.http_status = http_client.NOT_IMPLEMENTED
 
-        def __str__(self):
-                return "admin/0 operations of type {type} are not " \
-                    "supported by this repository. " \
-                    "Request was: {request}".format(request=self.request,
-                    type=self.cmd)
+    def __str__(self):
+        return (
+            "admin/0 operations of type {type} are not "
+            "supported by this repository. "
+            "Request was: {request}".format(request=self.request, type=self.cmd)
+        )
 
 
 class IndexOpDisabledException(DepotException):
-        """An exception thrown when we've been asked to refresh an index for
-        a repository that doesn't have a writable_root property set."""
+    """An exception thrown when we've been asked to refresh an index for
+    a repository that doesn't have a writable_root property set."""
 
-        def __init__(self, request):
-                self.request = request
-                self.http_status = http_client.FORBIDDEN
+    def __init__(self, request):
+        self.request = request
+        self.http_status = http_client.FORBIDDEN
 
-        def __str__(self):
-                return "admin/0 operations to refresh indexes are not " \
-                    "allowed on this repository because it is read-only and " \
-                    "the svc:/application/pkg/server instance does not have " \
-                    "a config/writable_root SMF property set. " \
-                    "Request was: {0}".format(self.request)
+    def __str__(self):
+        return (
+            "admin/0 operations to refresh indexes are not "
+            "allowed on this repository because it is read-only and "
+            "the svc:/application/pkg/server instance does not have "
+            "a config/writable_root SMF property set. "
+            "Request was: {0}".format(self.request)
+        )
 
 
 class BackgroundTask(object):
-        """Allow us to process a limited set of threads in the background."""
+    """Allow us to process a limited set of threads in the background."""
 
-        def __init__(self, size=10, busy_url=None):
-                self.size = size
-                self.__q = queue.Queue(self.size)
-                self.__thread = None
-                self.__running = False
-                self.__keep_busy_thread = None
-                self.__keep_busy = False
-                self.__busy_url = busy_url
+    def __init__(self, size=10, busy_url=None):
+        self.size = size
+        self.__q = queue.Queue(self.size)
+        self.__thread = None
+        self.__running = False
+        self.__keep_busy_thread = None
+        self.__keep_busy = False
+        self.__busy_url = busy_url
 
-        def join(self):
-                """perform a Queue.join(), which blocks until all the tasks
-                in the queue have been completed."""
-                self.__q.join()
+    def join(self):
+        """perform a Queue.join(), which blocks until all the tasks
+        in the queue have been completed."""
+        self.__q.join()
 
-        def unfinished_tasks(self):
-                """Return the number of tasks remaining in our Queue."""
-                return self.__q.unfinished_tasks
+    def unfinished_tasks(self):
+        """Return the number of tasks remaining in our Queue."""
+        return self.__q.unfinished_tasks
 
-        def put(self, task, *args, **kwargs):
-                """Schedule the given task for background execution if queue
-                isn't full.
-                """
-                if self.__q.unfinished_tasks > self.size - 1:
-                        raise queue.Full()
-                self.__q.put_nowait((task, args, kwargs))
-                self.__keep_busy = True
+    def put(self, task, *args, **kwargs):
+        """Schedule the given task for background execution if queue
+        isn't full.
+        """
+        if self.__q.unfinished_tasks > self.size - 1:
+            raise queue.Full()
+        self.__q.put_nowait((task, args, kwargs))
+        self.__keep_busy = True
 
-        def run(self):
-                """Run any background task scheduled for execution."""
-                while self.__running:
-                        try:
-                                try:
-                                        # A brief timeout here is necessary
-                                        # to reduce CPU usage and to ensure
-                                        # that shutdown doesn't wait forever
-                                        # for a new task to appear.
-                                        task, args, kwargs = \
-                                            self.__q.get(timeout=.5)
-                                except queue.Empty:
-                                        continue
-                                task(*args, **kwargs)
-                                if hasattr(self.__q, "task_done"):
-                                        # Task is done; mark it so.
-                                        self.__q.task_done()
-                                        if self.__q.unfinished_tasks == 0:
-                                                self.__keep_busy = False
-                        except Exception as e:
-                                print("Failure encountered executing "
-                                    "background task {0!r}.".format(self))
+    def run(self):
+        """Run any background task scheduled for execution."""
+        while self.__running:
+            try:
+                try:
+                    # A brief timeout here is necessary
+                    # to reduce CPU usage and to ensure
+                    # that shutdown doesn't wait forever
+                    # for a new task to appear.
+                    task, args, kwargs = self.__q.get(timeout=0.5)
+                except queue.Empty:
+                    continue
+                task(*args, **kwargs)
+                if hasattr(self.__q, "task_done"):
+                    # Task is done; mark it so.
+                    self.__q.task_done()
+                    if self.__q.unfinished_tasks == 0:
+                        self.__keep_busy = False
+            except Exception as e:
+                print(
+                    "Failure encountered executing "
+                    "background task {0!r}.".format(self)
+                )
 
-        def run_keep_busy(self):
-                """Run our keep_busy thread, periodically sending a HTTP
-                request if the __keep_busy flag is set."""
-                while self.__running:
-                        # wait for a period of time, then ping our busy_url
-                        time.sleep(KEEP_BUSY_INTERVAL)
-                        if self.__keep_busy:
-                                try:
-                                        urlopen(self.__busy_url).close()
-                                except Exception as e:
-                                        print("Failure encountered retrieving "
-                                            "busy url {0}: {1}".format(
-                                            self.__busy_url, e))
+    def run_keep_busy(self):
+        """Run our keep_busy thread, periodically sending a HTTP
+        request if the __keep_busy flag is set."""
+        while self.__running:
+            # wait for a period of time, then ping our busy_url
+            time.sleep(KEEP_BUSY_INTERVAL)
+            if self.__keep_busy:
+                try:
+                    urlopen(self.__busy_url).close()
+                except Exception as e:
+                    print(
+                        "Failure encountered retrieving "
+                        "busy url {0}: {1}".format(self.__busy_url, e)
+                    )
 
-        def start(self):
-                """Start the background task thread. Since we configure
-                mod_wsgi with an inactivity-timeout, long-running background
-                tasks which don't cause new WSGI HTTP requests can
-                result in us hitting that inactivity-timeout. To prevent this,
-                while background tasks are running, we periodically send a HTTP
-                request to the server."""
-                self.__running = True
-                if not self.__thread:
-                        # Create and start a thread for the caller.
-                        self.__thread = threading.Thread(target=self.run)
-                        self.__thread.start()
+    def start(self):
+        """Start the background task thread. Since we configure
+        mod_wsgi with an inactivity-timeout, long-running background
+        tasks which don't cause new WSGI HTTP requests can
+        result in us hitting that inactivity-timeout. To prevent this,
+        while background tasks are running, we periodically send a HTTP
+        request to the server."""
+        self.__running = True
+        if not self.__thread:
+            # Create and start a thread for the caller.
+            self.__thread = threading.Thread(target=self.run)
+            self.__thread.start()
 
-                        self.__keep_busy_thread = threading.Thread(
-                            target=self.run_keep_busy)
-                        self.__keep_busy_thread.start()
+            self.__keep_busy_thread = threading.Thread(
+                target=self.run_keep_busy
+            )
+            self.__keep_busy_thread.start()
 
 
 class DepotBUI(object):
-        """A data object that pkg.server.face can use for configuration.
-        This object should look like a pkg.server.depot.DepotHTTP to
-        pkg.server.face, but it doesn't need to perform any operations.
+    """A data object that pkg.server.face can use for configuration.
+    This object should look like a pkg.server.depot.DepotHTTP to
+    pkg.server.face, but it doesn't need to perform any operations.
 
-        pkg5_test_proto should point to a proto area where we can access
-        web resources (css, html, etc)
-        """
+    pkg5_test_proto should point to a proto area where we can access
+    web resources (css, html, etc)
+    """
 
-        def __init__(self, repo, dconf, writable_root, pkg5_test_proto=""):
-                self.repo = repo
-                self.cfg = dconf
-                if writable_root:
-                        self.tmp_root = writable_root
-                else:
-                        self.tmp_root = tempfile.mkdtemp(prefix="pkg-depot.")
-                        # try to clean up the temporary area on exit
-                        atexit.register(shutil.rmtree, self.tmp_root,
-                            ignore_errors=True)
+    def __init__(self, repo, dconf, writable_root, pkg5_test_proto=""):
+        self.repo = repo
+        self.cfg = dconf
+        if writable_root:
+            self.tmp_root = writable_root
+        else:
+            self.tmp_root = tempfile.mkdtemp(prefix="pkg-depot.")
+            # try to clean up the temporary area on exit
+            atexit.register(shutil.rmtree, self.tmp_root, ignore_errors=True)
 
-                # we hardcode these for the depot.
-                self.content_root = "{0}/usr/share/lib/pkg".format(pkg5_test_proto)
-                self.web_root = "{0}/usr/share/lib/pkg/web/".format(pkg5_test_proto)
+        # we hardcode these for the depot.
+        self.content_root = "{0}/usr/share/lib/pkg".format(pkg5_test_proto)
+        self.web_root = "{0}/usr/share/lib/pkg/web/".format(pkg5_test_proto)
 
-                # ensure we have the right values in our cfg, needed when
-                # creating DepotHTTP objects.
-                self.cfg.set_property("pkg", "content_root", self.content_root)
-                self.cfg.set_property("pkg", "pkg_root", self.repo.root)
-                self.cfg.set_property("pkg", "writable_root", self.tmp_root)
-                face.init(self)
+        # ensure we have the right values in our cfg, needed when
+        # creating DepotHTTP objects.
+        self.cfg.set_property("pkg", "content_root", self.content_root)
+        self.cfg.set_property("pkg", "pkg_root", self.repo.root)
+        self.cfg.set_property("pkg", "writable_root", self.tmp_root)
+        face.init(self)
 
 
 class WsgiDepot(object):
-        """A WSGI application object that allows us to process search/1 and
-        certain admin/0 requests from pkg(7) clients of the depot.  Other
-        requests for BUI content are dealt with by instances of DepotHTTP, which
-        are created as necessary.
+    """A WSGI application object that allows us to process search/1 and
+    certain admin/0 requests from pkg(7) clients of the depot.  Other
+    requests for BUI content are dealt with by instances of DepotHTTP, which
+    are created as necessary.
 
-        In the server-side WSGI environment, apart from the default WSGI
-        values, defined in PEP333, we expect the following:
+    In the server-side WSGI environment, apart from the default WSGI
+    values, defined in PEP333, we expect the following:
 
-        PKG5_RUNTIME_DIR  A directory that contains runtime state, notably
-                          a htdocs/ directory.
+    PKG5_RUNTIME_DIR  A directory that contains runtime state, notably
+                      a htdocs/ directory.
 
-        PKG5_REPOSITORY_<repo_prefix> A path to the repository root for the
-                          given <repo_prefix>.  <repo_prefix> is a unique
-                          alphanumeric prefix for the depot, each corresponding
-                          to a given <repo_root>.  Many PKG5_REPOSITORY_*
-                          variables can be configured, possibly containing
-                          pkg5 publishers of the same name.
+    PKG5_REPOSITORY_<repo_prefix> A path to the repository root for the
+                      given <repo_prefix>.  <repo_prefix> is a unique
+                      alphanumeric prefix for the depot, each corresponding
+                      to a given <repo_root>.  Many PKG5_REPOSITORY_*
+                      variables can be configured, possibly containing
+                      pkg5 publishers of the same name.
 
-        PKG5_WRITABLE_ROOT_<repo_prefix> A path to the writable root for the
-                          given <repo_prefix>. If a writable root is not set,
-                          and a search index does not already exist in the
-                          repository root, search functionality is not
-                          available.
+    PKG5_WRITABLE_ROOT_<repo_prefix> A path to the writable root for the
+                      given <repo_prefix>. If a writable root is not set,
+                      and a search index does not already exist in the
+                      repository root, search functionality is not
+                      available.
 
-        PKG5_ALLOW_REFRESH Set to 'true', this determines whether we process
-                          admin/0 requests that have the query 'cmd=refresh' or
-                          'cmd=refresh-indexes'.
+    PKG5_ALLOW_REFRESH Set to 'true', this determines whether we process
+                      admin/0 requests that have the query 'cmd=refresh' or
+                      'cmd=refresh-indexes'.
 
-                          If not true, we return a HTTP 503 response. Otherwise,
-                          we start a server-side job that rebuilds the
-                          index for the given repository.  Catalogs are not
-                          rebuilt by 'cmd=rebuild' queries, since this
-                          application only supports 'pkg/readonly' instances
-                          of svc:/application/pkg/depot.
+                      If not true, we return a HTTP 503 response. Otherwise,
+                      we start a server-side job that rebuilds the
+                      index for the given repository.  Catalogs are not
+                      rebuilt by 'cmd=rebuild' queries, since this
+                      application only supports 'pkg/readonly' instances
+                      of svc:/application/pkg/depot.
 
-        PKG5_TEST_PROTO   If set, this points at the top of a proto area, used
-                          to ensure the WSGI application uses files from there
-                          rather than the test system.  This is only used when
-                          running the pkg5 test suite for depot_index.py
+    PKG5_TEST_PROTO   If set, this points at the top of a proto area, used
+                      to ensure the WSGI application uses files from there
+                      rather than the test system.  This is only used when
+                      running the pkg5 test suite for depot_index.py
+    """
+
+    def __init__(self):
+        self.bgtask = None
+
+    def setup(self, request):
+        """Builds a dictionary of sr.Repository objects, keyed by the
+        repository prefix, and ensures our search indexes exist."""
+
+        def get_repo_paths():
+            """Return a dictionary of repository paths, and writable
+            root directories for the repositories we're serving."""
+
+            repo_paths = {}
+            for key in request.wsgi_environ:
+                if key.startswith("PKG5_REPOSITORY"):
+                    prefix = key.replace("PKG5_REPOSITORY_", "")
+                    repo_paths[prefix] = request.wsgi_environ[key]
+                    writable_root = request.wsgi_environ.get(
+                        "PKG5_WRITABLE_ROOT_{0}".format(prefix)
+                    )
+                    repo_paths[prefix] = (
+                        request.wsgi_environ[key],
+                        writable_root,
+                    )
+            return repo_paths
+
+        if repositories:
+            return
+
+        # if running the pkg5 test suite, store the correct proto area
+        pkg5_test_proto = request.wsgi_environ.get("PKG5_TEST_PROTO", "")
+
+        repository_lock.acquire()
+        repo_paths = get_repo_paths()
+
+        # We must ensure our BackgroundTask object has at least as many
+        # slots available as we have repositories, to allow the indexes
+        # to be refreshed. Ideally, we'd also account for a slot
+        # per-publisher, per-repository, but that might be overkill on a
+        # system with many repositories and many publishers that rarely
+        # get 'pkgrepo refresh' requests.
+        self.bgtask = BackgroundTask(
+            len(repo_paths),
+            busy_url="{0}/depot/depot-keepalive".format(request.base),
+        )
+        self.bgtask.start()
+
+        for prefix in repo_paths:
+            path, writable_root = repo_paths[prefix]
+            try:
+                repo = sr.Repository(
+                    root=path, read_only=True, writable_root=writable_root
+                )
+            except sr.RepositoryError as e:
+                print("Unable to load repository: {0}".format(e))
+                continue
+
+            repositories[prefix] = repo
+            dconf = sd.DepotConfig()
+            if writable_root is not None:
+                self.bgtask.put(repo.refresh_index)
+
+            depot = DepotBUI(
+                repo, dconf, writable_root, pkg5_test_proto=pkg5_test_proto
+            )
+            depot_buis[prefix] = depot
+
+        repository_lock.release()
+
+    def get_accept_lang(self, request, depot_bui):
+        """Determine a language that this accept can request that we
+        also have templates for."""
+
+        rlangs = []
+        for entry in request.headers.elements("Accept-Language"):
+            rlangs.append(str(entry).split(";")[0])
+        for rl in rlangs:
+            if os.path.exists(os.path.join(depot_bui.web_root, rl)):
+                return rl
+        return "en"
+
+    def repo_index(self, *tokens, **params):
+        """Generate a page showing the list of repositories served by
+        this Apache instance."""
+
+        self.setup(cherrypy.request)
+        # In order to reuse the pkg.depotd shtml files, we need to use
+        # the pkg.server.api, which means passing a DepotBUI object,
+        # despite the fact that we're not serving content for any one
+        # repository.  For the purposes of rendering this page, we'll
+        # use the first object we come across.
+        depot = depot_buis[list(depot_buis.keys())[0]]
+        accept_lang = self.get_accept_lang(cherrypy.request, depot)
+        cherrypy.request.path_info = "/{0}".format(accept_lang)
+        tlookup = mako.lookup.TemplateLookup(directories=[depot.web_root])
+        pub = None
+        base = pkg.server.api.BaseInterface(cherrypy.request, depot, pub)
+
+        # build a list of all repositories URIs and BUI links,
+        # and a dictionary of publishers for each repository URI
+        repo_list = []
+        repo_pubs = {}
+        for repo_prefix in repositories.keys():
+            repo = repositories[repo_prefix]
+            depot = depot_buis[repo_prefix]
+            repo_url = "{0}/{1}".format(cherrypy.request.base, repo_prefix)
+            bui_link = "{0}/{1}/index.shtml".format(repo_prefix, accept_lang)
+            repo_list.append((repo_url, bui_link))
+            repo_pubs[repo_url] = [
+                (
+                    pub,
+                    "{0}/{1}/{2}".format(
+                        cherrypy.request.base, repo_prefix, pub
+                    ),
+                )
+                for pub in repo.publishers
+            ]
+        repo_list.sort()
+        template = tlookup.get_template("repos.shtml")
+        # Starting in CherryPy 3.2, cherrypy.response.body only allows
+        # bytes.
+        return misc.force_bytes(
+            template.render(
+                g_vars={
+                    "base": base,
+                    "pub": None,
+                    "http_depot": "true",
+                    "lang": accept_lang,
+                    "repo_list": repo_list,
+                    "repo_pubs": repo_pubs,
+                }
+            )
+        )
+
+    def default(self, *tokens, **params):
+        """Our default handler is here to make sure we've called
+        setup, grabbing configuration from httpd.conf, then redirecting.
+        It also knows whether a request should be passed off to the
+        BUI, or whether we can just report an error."""
+
+        self.setup(cherrypy.request)
+
+        def request_pub_func(path):
+            """Return the name of the publisher to be used
+            for a given path. This function intentionally
+            returns None for all paths."""
+            return None
+
+        if "_themes" in tokens:
+            # manipulate the path to remove everything up to _themes
+            theme_index = tokens.index("_themes")
+            cherrypy.request.path_info = "/".join(tokens[theme_index:])
+            # When serving  theme resources we just choose the first
+            # repository we find, which is fine since we're serving
+            # content that's generic to all repositories, so we
+            repo_prefix = list(repositories.keys())[0]
+            repo = repositories[repo_prefix]
+            depot_bui = depot_buis[repo_prefix]
+            # use our custom request_pub_func, since theme resources
+            # are not publisher-specific
+            dh = sd.DepotHTTP(
+                repo, depot_bui.cfg, request_pub_func=request_pub_func
+            )
+            return dh.default(*tokens[theme_index:])
+
+        elif tokens[0] not in repositories:
+            raise cherrypy.NotFound()
+
+        # Otherwise, we'll try to serve the request from the BUI.
+
+        repo_prefix = tokens[0]
+        depot_bui = depot_buis[repo_prefix]
+        repo = repositories[repo_prefix]
+        # when serving reources, the publisher is not used
+        # to locate templates, so use our custom
+        # request_pub_func
+        dh = sd.DepotHTTP(
+            repo, depot_bui.cfg, request_pub_func=request_pub_func
+        )
+
+        # trim the repo_prefix
+        cherrypy.request.path_info = re.sub(
+            "^/{0}".format(repo_prefix), "", cherrypy.request.path_info
+        )
+
+        accept_lang = self.get_accept_lang(cherrypy.request, depot_bui)
+        path = cherrypy.request.path_info.rstrip("/").lstrip("/")
+        toks = path.split("/")
+        pub = None
+
+        # look for a publisher in the path
+        if toks[0] in repo.publishers:
+            path = "/".join(toks[1:])
+            pub = toks[0]
+            toks = self.__strip_pub(toks, repo)
+            cherrypy.request.path_info = "/".join(toks)
+
+        # deal with users browsing directories
+        dirs = ["", accept_lang, repo_prefix]
+        if path in dirs:
+            if not pub:
+                raise cherrypy.HTTPRedirect(
+                    "/{0}/{1}/index.shtml".format(repo_prefix, accept_lang)
+                )
+            else:
+                raise cherrypy.HTTPRedirect(
+                    "/{0}/{1}/{2}/index.shtml".format(
+                        repo_prefix, pub, accept_lang
+                    )
+                )
+
+        resp = face.respond(
+            depot_bui,
+            cherrypy.request,
+            cherrypy.response,
+            pub,
+            http_depot=repo_prefix,
+        )
+        return resp
+
+    def manifest(self, *tokens):
+        """Manifest requests coming from the BUI need to be redirected
+        back through the RewriteRules defined in the Apache
+        configuration in order to be served directly.
+        pkg(1) will never hit this code, as those requests don't get
+        handled by this webapp.
         """
 
-        def __init__(self):
-                self.bgtask = None
+        self.setup(cherrypy.request)
+        rel_uri = cherrypy.request.path_info
 
-        def setup(self, request):
-                """Builds a dictionary of sr.Repository objects, keyed by the
-                repository prefix, and ensures our search indexes exist."""
+        # we need to recover the escaped portions of the URI
+        redir = rel_uri.lstrip("/").split("/")
+        pub_mf = "/".join(redir[0:4])
+        pkg_name = "/".join(redir[4:])
+        # encode the URI so our RewriteRules can process them
+        pkg_name = quote(pkg_name)
+        pkg_name = pkg_name.replace("/", "%2F")
+        pkg_name = pkg_name.replace("%40", "@", 1)
 
-                def get_repo_paths():
-                        """Return a dictionary of repository paths, and writable
-                        root directories for the repositories we're serving."""
+        # build a URI that we can redirect to
+        redir = "{0}/{1}".format(pub_mf, pkg_name)
+        redir = "/{0}".format(redir.lstrip("/"))
+        raise cherrypy.HTTPRedirect(redir)
 
-                        repo_paths = {}
-                        for key in request.wsgi_environ:
-                                if key.startswith("PKG5_REPOSITORY"):
-                                        prefix = key.replace("PKG5_REPOSITORY_",
-                                            "")
-                                        repo_paths[prefix] = \
-                                            request.wsgi_environ[key]
-                                        writable_root = \
-                                            request.wsgi_environ.get(
-                                            "PKG5_WRITABLE_ROOT_{0}".format(prefix))
-                                        repo_paths[prefix] = \
-                                            (request.wsgi_environ[key],
-                                            writable_root)
-                        return repo_paths
+    def __build_depot_http(self):
+        """Build a DepotHTTP object to handle the current request."""
+        self.setup(cherrypy.request)
+        headers = cherrypy.response.headers
+        headers["Content-Type"] = "text/plain; charset=utf-8"
 
-                if repositories:
-                        return
+        toks = cherrypy.request.path_info.lstrip("/").split("/")
+        repo_prefix = toks[0]
+        if repo_prefix not in repositories:
+            raise cherrypy.NotFound()
 
-                # if running the pkg5 test suite, store the correct proto area
-                pkg5_test_proto = request.wsgi_environ.get("PKG5_TEST_PROTO",
-                    "")
+        repo = repositories[repo_prefix]
+        depot_bui = depot_buis[repo_prefix]
+        if repo_prefix in depot_https:
+            return depot_https[repo_prefix]
 
-                repository_lock.acquire()
-                repo_paths = get_repo_paths()
+        def request_pub_func(path_info):
+            """A function that can be called to determine the
+            publisher for a given request. We always want None
+            here, to force DepotHTTP to fallback to the publisher
+            information in the FMRI provided as part of the request,
+            rather than the /publisher/ portion of path_info.
+            """
+            return None
 
-                # We must ensure our BackgroundTask object has at least as many
-                # slots available as we have repositories, to allow the indexes
-                # to be refreshed. Ideally, we'd also account for a slot
-                # per-publisher, per-repository, but that might be overkill on a
-                # system with many repositories and many publishers that rarely
-                # get 'pkgrepo refresh' requests.
-                self.bgtask = BackgroundTask(len(repo_paths),
-                    busy_url="{0}/depot/depot-keepalive".format(request.base))
-                self.bgtask.start()
+        depot_https[repo_prefix] = sd.DepotHTTP(
+            repo, depot_bui.cfg, request_pub_func=request_pub_func
+        )
+        return depot_https[repo_prefix]
 
-                for prefix in repo_paths:
-                        path, writable_root = repo_paths[prefix]
-                        try:
-                                repo = sr.Repository(root=path, read_only=True,
-                                    writable_root=writable_root)
-                        except sr.RepositoryError as e:
-                                print("Unable to load repository: {0}".format(e))
-                                continue
+    def __strip_pub(self, tokens, repo):
+        """Attempt to strip at most one publisher from the path
+        described by 'tokens' looking for the publishers configured
+        in 'repo', returning new tokens."""
 
-                        repositories[prefix] = repo
-                        dconf = sd.DepotConfig()
-                        if writable_root is not None:
-                                self.bgtask.put(repo.refresh_index)
+        if len(tokens) <= 0:
+            return tokens
+        stripped = False
+        # For our purposes, the first token is always the repo_prefix
+        # indicating which repository we're talking to.
+        new_tokens = [tokens[0]]
+        for t in tokens[1:]:
+            if t in repo.publishers and not stripped:
+                stripped = True
+                pass
+            else:
+                new_tokens.append(t)
+        return new_tokens
 
-                        depot = DepotBUI(repo, dconf, writable_root,
-                            pkg5_test_proto=pkg5_test_proto)
-                        depot_buis[prefix] = depot
+    def info(self, *tokens):
+        """Use a DepotHTTP to return an info response."""
 
-                repository_lock.release()
+        dh = self.__build_depot_http()
+        tokens = self.__strip_pub(tokens, dh.repo)
+        # In Python 3, a WSGI application must return bytes as its output
+        return misc.force_bytes(dh.info_0(*tokens[3:]))
 
-        def get_accept_lang(self, request, depot_bui):
-                """Determine a language that this accept can request that we
-                also have templates for."""
+    def p5i(self, *tokens):
+        """Use a DepotHTTP to return a p5i response."""
 
-                rlangs = []
-                for entry in request.headers.elements("Accept-Language"):
-                        rlangs.append(str(entry).split(";")[0])
-                for rl in rlangs:
-                        if os.path.exists(os.path.join(depot_bui.web_root, rl)):
-                                return rl
-                return "en"
+        dh = self.__build_depot_http()
+        tokens = self.__strip_pub(tokens, dh.repo)
+        headers = cherrypy.response.headers
+        headers["Content-Type"] = pkg.p5i.MIME_TYPE
+        return dh.p5i_0(*tokens[3:])
 
-        def repo_index(self, *tokens, **params):
-                """Generate a page showing the list of repositories served by
-                this Apache instance."""
+    def search_1(self, *tokens, **params):
+        """Use a DepotHTTP to return a search/1 response."""
 
-                self.setup(cherrypy.request)
-                # In order to reuse the pkg.depotd shtml files, we need to use
-                # the pkg.server.api, which means passing a DepotBUI object,
-                # despite the fact that we're not serving content for any one
-                # repository.  For the purposes of rendering this page, we'll
-                # use the first object we come across.
-                depot = depot_buis[list(depot_buis.keys())[0]]
-                accept_lang = self.get_accept_lang(cherrypy.request, depot)
-                cherrypy.request.path_info = "/{0}".format(accept_lang)
-                tlookup = mako.lookup.TemplateLookup(
-                    directories=[depot.web_root])
-                pub = None
-                base = pkg.server.api.BaseInterface(cherrypy.request, depot,
-                    pub)
+        toks = cherrypy.request.path_info.lstrip("/").split("/")
+        dh = self.__build_depot_http()
+        toks = self.__strip_pub(tokens, dh.repo)
+        query_str = "/".join(toks[3:])
+        return dh.search_1(query_str)
 
-                # build a list of all repositories URIs and BUI links,
-                # and a dictionary of publishers for each repository URI
-                repo_list = []
-                repo_pubs = {}
-                for repo_prefix in repositories.keys():
-                        repo = repositories[repo_prefix]
-                        depot = depot_buis[repo_prefix]
-                        repo_url = "{0}/{1}".format(cherrypy.request.base,
-                            repo_prefix)
-                        bui_link = "{0}/{1}/index.shtml".format(
-                            repo_prefix, accept_lang)
-                        repo_list.append((repo_url, bui_link))
-                        repo_pubs[repo_url] = \
-                            [(pub, "{0}/{1}/{2}".format(
-                            cherrypy.request.base, repo_prefix,
-                            pub)) for pub in repo.publishers]
-                repo_list.sort()
-                template = tlookup.get_template("repos.shtml")
-                # Starting in CherryPy 3.2, cherrypy.response.body only allows
-                # bytes.
-                return misc.force_bytes(template.render(g_vars={"base": base,
-                    "pub": None, "http_depot": "true", "lang": accept_lang,
-                    "repo_list": repo_list, "repo_pubs": repo_pubs
-                    }))
+    def search_0(self, *tokens):
+        """Use a DepotHTTP to return a search/0 response."""
 
-        def default(self, *tokens, **params):
-                """ Our default handler is here to make sure we've called
-                setup, grabbing configuration from httpd.conf, then redirecting.
-                It also knows whether a request should be passed off to the
-                BUI, or whether we can just report an error."""
+        toks = cherrypy.request.path_info.lstrip("/").split("/")
+        dh = self.__build_depot_http()
+        toks = self.__strip_pub(tokens, dh.repo)
+        return dh.search_0(toks[-1])
 
-                self.setup(cherrypy.request)
+    def admin(self, *tokens, **params):
+        """We support limited admin/0 operations.  For a repository
+        refresh, we only honor the index rebuild itself.
 
-                def request_pub_func(path):
-                        """Return the name of the publisher to be used
-                        for a given path. This function intentionally
-                        returns None for all paths."""
-                        return None
+        Since a given http-depot server may be serving many repositories
+        we expend a little more effort than pkg.server.depot when
+        accepting refresh requests when our existing BackgroundTask
+        Queue is full, retrying jobs for up to a minute.  In the future,
+        we may want to make the Queue scale according to the size of the
+        depot/repository.
+        """
+        self.setup(cherrypy.request)
+        request = cherrypy.request
+        cmd = params.get("cmd")
+        if not cmd:
+            return
+        if cmd not in ["refresh", "refresh-indexes"]:
+            raise AdminOpNotSupportedException(
+                request.wsgi_environ["REQUEST_URI"], cmd
+            )
 
-                if "_themes" in tokens:
-                        # manipulate the path to remove everything up to _themes
-                        theme_index = tokens.index("_themes")
-                        cherrypy.request.path_info = "/".join(
-                            tokens[theme_index:])
-                        # When serving  theme resources we just choose the first
-                        # repository we find, which is fine since we're serving
-                        # content that's generic to all repositories, so we
-                        repo_prefix = list(repositories.keys())[0]
-                        repo = repositories[repo_prefix]
-                        depot_bui = depot_buis[repo_prefix]
-                        # use our custom request_pub_func, since theme resources
-                        # are not publisher-specific
-                        dh = sd.DepotHTTP(repo, depot_bui.cfg,
-                            request_pub_func=request_pub_func)
-                        return dh.default(*tokens[theme_index:])
+        # Determine whether to allow index rebuilds
+        if (
+            request.wsgi_environ.get("PKG5_ALLOW_REFRESH", "false").lower()
+            != "true"
+        ):
+            raise AdminOpsDisabledException(request.wsgi_environ["REQUEST_URI"])
 
-                elif tokens[0] not in repositories:
-                        raise cherrypy.NotFound()
+        repository_lock.acquire()
+        try:
+            if len(tokens) <= 2:
+                raise cherrypy.NotFound()
+            repo_prefix = tokens[0]
+            pub_prefix = tokens[1]
 
-                # Otherwise, we'll try to serve the request from the BUI.
+            if repo_prefix not in repositories:
+                raise cherrypy.NotFound()
 
-                repo_prefix = tokens[0]
-                depot_bui = depot_buis[repo_prefix]
-                repo = repositories[repo_prefix]
-                # when serving reources, the publisher is not used
-                # to locate templates, so use our custom
-                # request_pub_func
-                dh = sd.DepotHTTP(repo, depot_bui.cfg,
-                    request_pub_func=request_pub_func)
+            repo = repositories[repo_prefix]
+            if pub_prefix not in repo.publishers:
+                raise cherrypy.NotFound()
 
-                # trim the repo_prefix
-                cherrypy.request.path_info = re.sub("^/{0}".format(repo_prefix),
-                    "", cherrypy.request.path_info)
+            # Since the repository is read-only, we only honour
+            # index refresh requests if we have a writable root.
+            if not repo.writable_root:
+                raise IndexOpDisabledException(
+                    request.wsgi_environ["REQUEST_URI"]
+                )
 
-                accept_lang = self.get_accept_lang(cherrypy.request,
-                    depot_bui)
-                path = cherrypy.request.path_info.rstrip("/").lstrip("/")
-                toks = path.split("/")
-                pub = None
+            # we need to reload the repository in order to get
+            # any new catalog contents before refreshing the
+            # index.
+            repo.reload()
+            try:
+                self.bgtask.put(repo.refresh_index, pub=pub_prefix)
+            except queue.Full as e:
+                retries = 10
+                success = False
+                while retries > 0 and not success:
+                    time.sleep(5)
+                    try:
+                        self.bgtask.put(repo.refresh_index, pub=pub_prefix)
+                        success = True
+                    except Exception as ex:
+                        pass
+                if not success:
+                    raise cherrypy.HTTPError(
+                        status=http_client.SERVICE_UNAVAILABLE,
+                        message="Unable to refresh the "
+                        "index for {0} after repeated "
+                        "retries. Try again later.".format(request.path_info),
+                    )
+        finally:
+            repository_lock.release()
+        # In Python 3, a WSGI application must return bytes as its output
+        return b""
 
-                # look for a publisher in the path
-                if toks[0] in repo.publishers:
-                        path = "/".join(toks[1:])
-                        pub = toks[0]
-                        toks = self.__strip_pub(toks, repo)
-                        cherrypy.request.path_info = "/".join(toks)
+    def wait_refresh(self, *tokens, **params):
+        """Not a pkg(7) operation, this allows clients to wait until any
+        pending index refresh operations have completed.
 
-                # deal with users browsing directories
-                dirs = ["", accept_lang, repo_prefix]
-                if path in dirs:
-                        if not pub:
-                                raise cherrypy.HTTPRedirect(
-                                    "/{0}/{1}/index.shtml".format(
-                                    repo_prefix, accept_lang))
-                        else:
-                                raise cherrypy.HTTPRedirect(
-                                    "/{0}/{1}/{2}/index.shtml".format(
-                                    repo_prefix, pub, accept_lang))
-
-                resp = face.respond(depot_bui, cherrypy.request,
-                    cherrypy.response, pub, http_depot=repo_prefix)
-                return resp
-
-        def manifest(self, *tokens):
-                """Manifest requests coming from the BUI need to be redirected
-                back through the RewriteRules defined in the Apache
-                configuration in order to be served directly.
-                pkg(1) will never hit this code, as those requests don't get
-                handled by this webapp.
-                """
-
-                self.setup(cherrypy.request)
-                rel_uri = cherrypy.request.path_info
-
-                # we need to recover the escaped portions of the URI
-                redir = rel_uri.lstrip("/").split("/")
-                pub_mf = "/".join(redir[0:4])
-                pkg_name = "/".join(redir[4:])
-                # encode the URI so our RewriteRules can process them
-                pkg_name = quote(pkg_name)
-                pkg_name = pkg_name.replace("/", "%2F")
-                pkg_name = pkg_name.replace("%40", "@", 1)
-
-                # build a URI that we can redirect to
-                redir = "{0}/{1}".format(pub_mf, pkg_name)
-                redir = "/{0}".format(redir.lstrip("/"))
-                raise cherrypy.HTTPRedirect(redir)
-
-        def __build_depot_http(self):
-                """Build a DepotHTTP object to handle the current request."""
-                self.setup(cherrypy.request)
-                headers = cherrypy.response.headers
-                headers["Content-Type"] = "text/plain; charset=utf-8"
-
-                toks = cherrypy.request.path_info.lstrip("/").split("/")
-                repo_prefix = toks[0]
-                if repo_prefix not in repositories:
-                        raise cherrypy.NotFound()
-
-                repo = repositories[repo_prefix]
-                depot_bui = depot_buis[repo_prefix]
-                if repo_prefix in depot_https:
-                        return depot_https[repo_prefix]
-
-                def request_pub_func(path_info):
-                        """A function that can be called to determine the
-                        publisher for a given request. We always want None
-                        here, to force DepotHTTP to fallback to the publisher
-                        information in the FMRI provided as part of the request,
-                        rather than the /publisher/ portion of path_info.
-                        """
-                        return None
-
-                depot_https[repo_prefix] = sd.DepotHTTP(repo, depot_bui.cfg,
-                    request_pub_func=request_pub_func)
-                return depot_https[repo_prefix]
-
-        def __strip_pub(self, tokens, repo):
-                """Attempt to strip at most one publisher from the path
-                described by 'tokens' looking for the publishers configured
-                in 'repo', returning new tokens."""
-
-                if len(tokens) <= 0:
-                        return tokens
-                stripped = False
-                # For our purposes, the first token is always the repo_prefix
-                # indicating which repository we're talking to.
-                new_tokens = [tokens[0]]
-                for t in tokens[1:]:
-                        if t in repo.publishers and not stripped:
-                                stripped = True
-                                pass
-                        else:
-                                new_tokens.append(t)
-                return new_tokens
-
-        def info(self, *tokens):
-                """Use a DepotHTTP to return an info response."""
-
-                dh = self.__build_depot_http()
-                tokens = self.__strip_pub(tokens, dh.repo)
-                # In Python 3, a WSGI application must return bytes as its output
-                return misc.force_bytes(dh.info_0(*tokens[3:]))
-
-        def p5i(self, *tokens):
-                """Use a DepotHTTP to return a p5i response."""
-
-                dh = self.__build_depot_http()
-                tokens = self.__strip_pub(tokens, dh.repo)
-                headers = cherrypy.response.headers
-                headers["Content-Type"] = pkg.p5i.MIME_TYPE
-                return dh.p5i_0(*tokens[3:])
-
-        def search_1(self, *tokens, **params):
-                """Use a DepotHTTP to return a search/1 response."""
-
-                toks = cherrypy.request.path_info.lstrip("/").split("/")
-                dh = self.__build_depot_http()
-                toks = self.__strip_pub(tokens, dh.repo)
-                query_str = "/".join(toks[3:])
-                return dh.search_1(query_str)
-
-        def search_0(self, *tokens):
-                """Use a DepotHTTP to return a search/0 response."""
-
-                toks = cherrypy.request.path_info.lstrip("/").split("/")
-                dh = self.__build_depot_http()
-                toks = self.__strip_pub(tokens, dh.repo)
-                return dh.search_0(toks[-1])
-
-        def admin(self, *tokens, **params):
-                """ We support limited admin/0 operations.  For a repository
-                refresh, we only honor the index rebuild itself.
-
-                Since a given http-depot server may be serving many repositories
-                we expend a little more effort than pkg.server.depot when
-                accepting refresh requests when our existing BackgroundTask
-                Queue is full, retrying jobs for up to a minute.  In the future,
-                we may want to make the Queue scale according to the size of the
-                depot/repository.
-                """
-                self.setup(cherrypy.request)
-                request = cherrypy.request
-                cmd = params.get("cmd")
-                if not cmd:
-                        return
-                if cmd not in ["refresh", "refresh-indexes"]:
-                        raise AdminOpNotSupportedException(
-                            request.wsgi_environ["REQUEST_URI"], cmd)
-
-                # Determine whether to allow index rebuilds
-                if request.wsgi_environ.get(
-                    "PKG5_ALLOW_REFRESH", "false").lower() != "true":
-                        raise AdminOpsDisabledException(
-                            request.wsgi_environ["REQUEST_URI"])
-
-                repository_lock.acquire()
-                try:
-                        if len(tokens) <= 2:
-                                raise cherrypy.NotFound()
-                        repo_prefix = tokens[0]
-                        pub_prefix = tokens[1]
-
-                        if repo_prefix not in repositories:
-                                raise cherrypy.NotFound()
-
-                        repo = repositories[repo_prefix]
-                        if pub_prefix not in repo.publishers:
-                                raise cherrypy.NotFound()
-
-                        # Since the repository is read-only, we only honour
-                        # index refresh requests if we have a writable root.
-                        if not repo.writable_root:
-                                raise IndexOpDisabledException(
-                                    request.wsgi_environ["REQUEST_URI"])
-
-                        # we need to reload the repository in order to get
-                        # any new catalog contents before refreshing the
-                        # index.
-                        repo.reload()
-                        try:
-                                self.bgtask.put(repo.refresh_index,
-                                    pub=pub_prefix)
-                        except queue.Full as e:
-                                retries = 10
-                                success = False
-                                while retries > 0 and not success:
-                                        time.sleep(5)
-                                        try:
-                                                self.bgtask.put(
-                                                    repo.refresh_index,
-                                                    pub=pub_prefix)
-                                                success = True
-                                        except Exception as ex:
-                                                pass
-                                if not success:
-                                        raise cherrypy.HTTPError(
-                                            status=http_client.SERVICE_UNAVAILABLE,
-                                            message="Unable to refresh the "
-                                            "index for {0} after repeated "
-                                            "retries. Try again later.".format(
-                                            request.path_info))
-                finally:
-                        repository_lock.release()
-                # In Python 3, a WSGI application must return bytes as its output
-                return b""
-
-        def wait_refresh(self, *tokens, **params):
-                """Not a pkg(7) operation, this allows clients to wait until any
-                pending index refresh operations have completed.
-
-                This method exists primarily for the pkg(7) test suite to ensure
-                that we do not attempt to perform searches when the server is
-                still coming up.
-                """
-                self.setup(cherrypy.request)
-                self.bgtask.join()
-                return b""
+        This method exists primarily for the pkg(7) test suite to ensure
+        that we do not attempt to perform searches when the server is
+        still coming up.
+        """
+        self.setup(cherrypy.request)
+        self.bgtask.join()
+        return b""
 
 
 class Pkg5Dispatch(object):
-        """A custom CherryPy dispatcher used by our application.
-        We use this, because the default dispatcher in CherryPy seems to dislike
-        trying to have an exposed "default" method (the special method name used
-        by CherryPy in its default dispatcher to handle unmapped resources) as
-        well as trying to serve resources named "default", a common name for
-        svc:/application/pkg/server SMF instances, which become the names of the
-        repo_prefixes used by the http-depot.
-        """
+    """A custom CherryPy dispatcher used by our application.
+    We use this, because the default dispatcher in CherryPy seems to dislike
+    trying to have an exposed "default" method (the special method name used
+    by CherryPy in its default dispatcher to handle unmapped resources) as
+    well as trying to serve resources named "default", a common name for
+    svc:/application/pkg/server SMF instances, which become the names of the
+    repo_prefixes used by the http-depot.
+    """
 
-        def __init__(self, wsgi_depot):
-                self.app = wsgi_depot
-                # needed to convince CherryPy that we are a valid dispatcher
-                self.config = {}
+    def __init__(self, wsgi_depot):
+        self.app = wsgi_depot
+        # needed to convince CherryPy that we are a valid dispatcher
+        self.config = {}
 
-        @staticmethod
-        def default_error_page(status=http_client.NOT_FOUND, message="oops",
-            traceback=None, version=None):
-                """This function is registered as the default error page
-                for CherryPy errors.  This sets the response headers to
-                be uncacheable, and then returns a HTTP response."""
+    @staticmethod
+    def default_error_page(
+        status=http_client.NOT_FOUND,
+        message="oops",
+        traceback=None,
+        version=None,
+    ):
+        """This function is registered as the default error page
+        for CherryPy errors.  This sets the response headers to
+        be uncacheable, and then returns a HTTP response."""
 
-                response = cherrypy.response
-                for key in ('Cache-Control', 'Pragma'):
-                        if key in response.headers:
-                                del response.headers[key]
+        response = cherrypy.response
+        for key in ("Cache-Control", "Pragma"):
+            if key in response.headers:
+                del response.headers[key]
 
-                # Server errors are interesting, so let's log them.  In the case
-                # of an internal server error, we send a 404 to the client. but
-                # log the full details in the server log.
-                if (status == http_client.INTERNAL_SERVER_ERROR or
-                    status.startswith("500 ")):
-                        # Convert the error to a 404 to obscure implementation
-                        # from the client, but log the original error to the
-                        # server logs.
-                        error = cherrypy._cperror._HTTPErrorTemplate % \
-                            {"status": http_client.NOT_FOUND,
-                            "message": http_client.responses[http_client.NOT_FOUND],
-                            "traceback": "",
-                            "version": cherrypy.__version__}
-                        print("Path that raised exception was {0}".format(
-                            cherrypy.request.path_info))
-                        print(message)
-                        return error
-                else:
-                        error = cherrypy._cperror._HTTPErrorTemplate % \
-                            {"status": http_client.NOT_FOUND, "message": message,
-                            "traceback": "", "version": cherrypy.__version__}
-                        return error
+        # Server errors are interesting, so let's log them.  In the case
+        # of an internal server error, we send a 404 to the client. but
+        # log the full details in the server log.
+        if status == http_client.INTERNAL_SERVER_ERROR or status.startswith(
+            "500 "
+        ):
+            # Convert the error to a 404 to obscure implementation
+            # from the client, but log the original error to the
+            # server logs.
+            error = cherrypy._cperror._HTTPErrorTemplate % {
+                "status": http_client.NOT_FOUND,
+                "message": http_client.responses[http_client.NOT_FOUND],
+                "traceback": "",
+                "version": cherrypy.__version__,
+            }
+            print(
+                "Path that raised exception was {0}".format(
+                    cherrypy.request.path_info
+                )
+            )
+            print(message)
+            return error
+        else:
+            error = cherrypy._cperror._HTTPErrorTemplate % {
+                "status": http_client.NOT_FOUND,
+                "message": message,
+                "traceback": "",
+                "version": cherrypy.__version__,
+            }
+            return error
 
-        def dispatch(self, path_info):
-                request = cherrypy.request
-                request.config = {}
-                request.error_page["default"] = Pkg5Dispatch.default_error_page
+    def dispatch(self, path_info):
+        request = cherrypy.request
+        request.config = {}
+        request.error_page["default"] = Pkg5Dispatch.default_error_page
 
-                toks = path_info.lstrip("/").split("/")
-                params = request.params
-                if not params:
-                        try:
-                                # Starting in CherryPy 3.2, it seems that
-                                # query_string doesn't pass into request.params,
-                                # so try harder here.
-                                from cherrypy.lib.httputil import parse_query_string
-                                params = parse_query_string(
-                                    request.query_string)
-                                request.params.update(params)
-                        except ImportError:
-                                pass
-                file_type = toks[-1].split(".")[-1]
+        toks = path_info.lstrip("/").split("/")
+        params = request.params
+        if not params:
+            try:
+                # Starting in CherryPy 3.2, it seems that
+                # query_string doesn't pass into request.params,
+                # so try harder here.
+                from cherrypy.lib.httputil import parse_query_string
 
-                try:
-                        if "/search/1/" in path_info:
-                                cherrypy.response.stream = True
-                                cherrypy.response.body = self.app.search_1(
-                                    *toks, **params)
-                        elif "/search/0/" in path_info:
-                                cherrypy.response.stream = True
-                                cherrypy.response.body = self.app.search_0(
-                                    *toks)
-                        elif "/manifest/0/" in path_info:
-                                cherrypy.response.body = self.app.manifest(
-                                    *toks)
-                        elif "/info/0/" in path_info:
-                                cherrypy.response.body = self.app.info(*toks,
-                                    **params)
-                        elif "/p5i/0/" in path_info:
-                                cherrypy.response.body = self.app.p5i(*toks,
-                                    **params)
-                        elif "/admin/0" in path_info:
-                                cherrypy.response.body = self.app.admin(*toks,
-                                    **params)
-                        elif "/depot-keepalive" in path_info:
-                                return b""
-                        elif "/depot-wait-refresh" in path_info:
-                                self.app.wait_refresh(*toks, **params)
-                                return b""
-                        elif path_info == "/" or path_info == "/repos.shtml":
-                                cherrypy.response.body = self.app.repo_index(
-                                    *toks, **params)
-                        elif file_type in ["css", "shtml", "png"]:
-                                cherrypy.response.body = self.app.default(*toks,
-                                    **params)
-                        else:
-                                cherrypy.response.body = self.app.default(*toks,
-                                    **params)
-                except Exception as e:
-                        if isinstance(e, cherrypy.HTTPRedirect):
-                                raise
-                        elif isinstance(e, cherrypy.HTTPError):
-                                raise
-                        elif isinstance(e, AdminOpsDisabledException):
-                                raise cherrypy.HTTPError(e.http_status,
-                                    "This operation has been disabled by the "
-                                    "server administrator.")
-                        elif isinstance(e, AdminOpNotSupportedException):
-                                raise cherrypy.HTTPError(e.http_status,
-                                    "This operation is not supported.")
-                        elif isinstance(e, IndexOpDisabledException):
-                                raise cherrypy.HTTPError(e.http_status,
-                                    "This operation has been disabled by the "
-                                    "server administrator.")
-                        else:
-                                # we leave this as a 500 for now. It will be
-                                # converted and logged by our error handler
-                                # before the client sees it.
-                                raise cherrypy.HTTPError(
-                                    status=http_client.INTERNAL_SERVER_ERROR,
-                                    message="".join(traceback.format_exc(e)))
+                params = parse_query_string(request.query_string)
+                request.params.update(params)
+            except ImportError:
+                pass
+        file_type = toks[-1].split(".")[-1]
+
+        try:
+            if "/search/1/" in path_info:
+                cherrypy.response.stream = True
+                cherrypy.response.body = self.app.search_1(*toks, **params)
+            elif "/search/0/" in path_info:
+                cherrypy.response.stream = True
+                cherrypy.response.body = self.app.search_0(*toks)
+            elif "/manifest/0/" in path_info:
+                cherrypy.response.body = self.app.manifest(*toks)
+            elif "/info/0/" in path_info:
+                cherrypy.response.body = self.app.info(*toks, **params)
+            elif "/p5i/0/" in path_info:
+                cherrypy.response.body = self.app.p5i(*toks, **params)
+            elif "/admin/0" in path_info:
+                cherrypy.response.body = self.app.admin(*toks, **params)
+            elif "/depot-keepalive" in path_info:
+                return b""
+            elif "/depot-wait-refresh" in path_info:
+                self.app.wait_refresh(*toks, **params)
+                return b""
+            elif path_info == "/" or path_info == "/repos.shtml":
+                cherrypy.response.body = self.app.repo_index(*toks, **params)
+            elif file_type in ["css", "shtml", "png"]:
+                cherrypy.response.body = self.app.default(*toks, **params)
+            else:
+                cherrypy.response.body = self.app.default(*toks, **params)
+        except Exception as e:
+            if isinstance(e, cherrypy.HTTPRedirect):
+                raise
+            elif isinstance(e, cherrypy.HTTPError):
+                raise
+            elif isinstance(e, AdminOpsDisabledException):
+                raise cherrypy.HTTPError(
+                    e.http_status,
+                    "This operation has been disabled by the "
+                    "server administrator.",
+                )
+            elif isinstance(e, AdminOpNotSupportedException):
+                raise cherrypy.HTTPError(
+                    e.http_status, "This operation is not supported."
+                )
+            elif isinstance(e, IndexOpDisabledException):
+                raise cherrypy.HTTPError(
+                    e.http_status,
+                    "This operation has been disabled by the "
+                    "server administrator.",
+                )
+            else:
+                # we leave this as a 500 for now. It will be
+                # converted and logged by our error handler
+                # before the client sees it.
+                raise cherrypy.HTTPError(
+                    status=http_client.INTERNAL_SERVER_ERROR,
+                    message="".join(traceback.format_exc(e)),
+                )
+
 
 wsgi_depot = WsgiDepot()
 dispatcher = Pkg5Dispatch(wsgi_depot)
 
-conf = {"/":
-    {'request.dispatch': dispatcher.dispatch}}
+conf = {"/": {"request.dispatch": dispatcher.dispatch}}
 application = cherrypy.Application(wsgi_depot, None, config=conf)
 # Raise the level of the access log to make it quiet. For some reason,
 # setting log.access_file = "" or None doesn't work.
 application.log.access_log.setLevel(logging.WARNING)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/apache2/sysrepo/sysrepo_p5p.py
+++ b/src/util/apache2/sysrepo/sysrepo_p5p.py
@@ -38,13 +38,19 @@ from pkg.misc import force_str
 # redirecting stdout for proper WSGI portability
 sys.stdout = sys.stderr
 
-SERVER_OK_STATUS = "{0} {1}".format(http_client.OK, http_client.responses[http_client.OK])
-SERVER_ERROR_STATUS = "{0} {1}".format(http_client.INTERNAL_SERVER_ERROR,
-    http_client.responses[http_client.INTERNAL_SERVER_ERROR])
-SERVER_NOTFOUND_STATUS = "{0} {1}".format(http_client.NOT_FOUND,
-    http_client.responses[http_client.NOT_FOUND])
-SERVER_BADREQUEST_STATUS = "{0} {1}".format(http_client.BAD_REQUEST,
-    http_client.responses[http_client.BAD_REQUEST])
+SERVER_OK_STATUS = "{0} {1}".format(
+    http_client.OK, http_client.responses[http_client.OK]
+)
+SERVER_ERROR_STATUS = "{0} {1}".format(
+    http_client.INTERNAL_SERVER_ERROR,
+    http_client.responses[http_client.INTERNAL_SERVER_ERROR],
+)
+SERVER_NOTFOUND_STATUS = "{0} {1}".format(
+    http_client.NOT_FOUND, http_client.responses[http_client.NOT_FOUND]
+)
+SERVER_BADREQUEST_STATUS = "{0} {1}".format(
+    http_client.BAD_REQUEST, http_client.responses[http_client.BAD_REQUEST]
+)
 
 response_headers = [("content-type", "application/binary")]
 
@@ -54,321 +60,317 @@ p5p_indices = {}
 # at the same time.
 p5p_update_lock = threading.Lock()
 
-class UnknownPathException(Exception):
-        """An exception thrown when a client requests a path within a p5p file
-        which does not exist."""
-        def __init__(self, path):
-                self.path = path
 
-        def __str__(self):
-                return "Unknown path: {0}".format(self.path)
+class UnknownPathException(Exception):
+    """An exception thrown when a client requests a path within a p5p file
+    which does not exist."""
+
+    def __init__(self, path):
+        self.path = path
+
+    def __str__(self):
+        return "Unknown path: {0}".format(self.path)
 
 
 class MalformedQueryException(Exception):
-        """An exception thrown when this wsgi application cannot parse a query
-        from the client."""
-        def __init__(self, query, reason):
-                self.query = query
-                self.reason = reason
+    """An exception thrown when this wsgi application cannot parse a query
+    from the client."""
 
-        def __str__(self):
-                return "Malformed query {0}: {1}".format(self.query, self.reason)
+    def __init__(self, query, reason):
+        self.query = query
+        self.reason = reason
+
+    def __str__(self):
+        return "Malformed query {0}: {1}".format(self.query, self.reason)
 
 
 class MissingArchiveException(Exception):
-        """An exception thrown when the p5p file referred to by the
-        configuration does not exist."""
-        def __init__(self, path):
-                self.path = path
+    """An exception thrown when the p5p file referred to by the
+    configuration does not exist."""
 
-        def __str__(self):
-                return "Missing p5p archive: {0}".format(self.path)
+    def __init__(self, path):
+        self.path = path
+
+    def __str__(self):
+        return "Missing p5p archive: {0}".format(self.path)
 
 
 class SysrepoP5p(object):
-        """An object to handle a request for p5p file contents from the
-        system repository."""
+    """An object to handle a request for p5p file contents from the
+    system repository."""
 
-        def __init__(self, environ, start_response):
-                self.environ = environ
-                self.start_response = start_response
-                self.p5p_path = None
-                self.p5p = None
+    def __init__(self, environ, start_response):
+        self.environ = environ
+        self.start_response = start_response
+        self.p5p_path = None
+        self.p5p = None
 
-                self.query = self.environ["QUERY_STRING"]
-                self.runtime_dir = self.environ["SYSREPO_RUNTIME_DIR"]
+        self.query = self.environ["QUERY_STRING"]
+        self.runtime_dir = self.environ["SYSREPO_RUNTIME_DIR"]
 
-        def close(self):
-                """Release any resources we have used."""
-                if self.p5p:
-                        self.p5p.close()
+    def close(self):
+        """Release any resources we have used."""
+        if self.p5p:
+            self.p5p.close()
 
-        def log_exception(self, status=SERVER_ERROR_STATUS):
-                """Print some information in the Apache log that will help
-                determine what went wrong as well as updating the client
-                response code.  The WSGI spec says we can call
-                start_response multiple times, but must include exc_info
-                if we do so."""
+    def log_exception(self, status=SERVER_ERROR_STATUS):
+        """Print some information in the Apache log that will help
+        determine what went wrong as well as updating the client
+        response code.  The WSGI spec says we can call
+        start_response multiple times, but must include exc_info
+        if we do so."""
 
-                # we only want error_log output if our status is not 4xx
-                if status != SERVER_NOTFOUND_STATUS and \
-                    status != SERVER_BADREQUEST_STATUS:
-                        print(traceback.format_exc())
-                self.start_response(status, response_headers,
-                    sys.exc_info())
+        # we only want error_log output if our status is not 4xx
+        if (
+            status != SERVER_NOTFOUND_STATUS
+            and status != SERVER_BADREQUEST_STATUS
+        ):
+            print(traceback.format_exc())
+        self.start_response(status, response_headers, sys.exc_info())
 
-        def need_update(self, pub, hsh):
-                """Determine if we need to update our cached catalog and
-                reload the index by comparing the last modification time of a
-                file we create per p5p archive, and the p5p archive itself."""
+    def need_update(self, pub, hsh):
+        """Determine if we need to update our cached catalog and
+        reload the index by comparing the last modification time of a
+        file we create per p5p archive, and the p5p archive itself."""
 
-                htdocs_path = os.path.join(self.runtime_dir, "htdocs")
-                timestamp_path = \
-                    "{htdocs_path}/{pub}/{hsh}/sysrepo.timestamp".format(
-                    **locals())
+        htdocs_path = os.path.join(self.runtime_dir, "htdocs")
+        timestamp_path = "{htdocs_path}/{pub}/{hsh}/sysrepo.timestamp".format(
+            **locals()
+        )
 
-                update = False
+        update = False
 
-                # Locking here is quite basic: we want to ensure that no two
-                # threads simultaneously decide that they need to rebuild our
-                # local catalog cache, stepping on each others toes.  It is
-                # possible that while processing a single query, a user will
-                # replace the p5p file on the server after this method has been
-                # called, causing stale data to be returned at best, and a HTTP
-                # 500 response at worst (as the p5p index used by this web
-                # application will not match the one in the new archive)
+        # Locking here is quite basic: we want to ensure that no two
+        # threads simultaneously decide that they need to rebuild our
+        # local catalog cache, stepping on each others toes.  It is
+        # possible that while processing a single query, a user will
+        # replace the p5p file on the server after this method has been
+        # called, causing stale data to be returned at best, and a HTTP
+        # 500 response at worst (as the p5p index used by this web
+        # application will not match the one in the new archive)
+        p5p_update_lock.acquire()
+        try:
+            # don't write a timestamp if we're testing
+            if self.environ.get("PKG5_TEST_ENV") == "True":
+                return True
+
+            try:
+                st_p5p = os.stat(self.p5p_path)
+            except OSError as e:
+                if e.errno == os.errno.ENOENT:
+                    raise MissingArchiveException(self.p5p_path)
+            try:
+                st_ts = os.stat(timestamp_path)
+                if st_ts.st_mtime < st_p5p.st_mtime:
+                    open(timestamp_path, "wb").close()
+                    update = True
+            except OSError as e:
+                if e.errno == os.errno.ENOENT:
+                    open(timestamp_path, "wb").close()
+                    update = True
+
+        except MissingArchiveException as e:
+            raise
+        except Exception as e:
+            self.log_exception()
+        finally:
+            p5p_update_lock.release()
+        return update
+
+    def _file_response(self, path, pub):
+        """Process our file query."""
+
+        # use the basename of the path, which is the pkg(7) hash
+        self.start_response(SERVER_OK_STATUS, response_headers)
+        try:
+            return self.p5p.get_package_file(os.path.basename(path), pub=pub)
+        except pkg.p5p.UnknownArchiveFiles as e:
+            self.log_exception(status=SERVER_NOTFOUND_STATUS)
+        except Exception as e:
+            self.log_exception()
+
+    def _catalog_response(self, path, pub, hsh):
+        """Process our catalog query"""
+
+        cat_part = os.path.basename(path)
+        htdocs_path = os.path.join(self.runtime_dir, "htdocs")
+        cat_path = "{htdocs_path}/{pub}/{hsh}/catalog/1/{cat_part}".format(
+            **locals()
+        )
+        self.start_response(SERVER_OK_STATUS, response_headers)
+        if os.path.exists(cat_path):
+            return open(cat_path, "rb")
+
+        # this is unlikely to happen: it implies a catalog part has been
+        # requested that wasn't listed in the catalog.attrs file
+        # extracted during _precache_catalog() or the file has been
+        # removed on the server.  Do our best to return the content.
+        try:
+            cat_dir = os.path.dirname(cat_path)
+            p5p_update_lock.acquire()
+            try:
+                if not os.path.exists(cat_dir):
+                    os.makedirs(cat_dir, 0o755)
+                self.p5p.extract_catalog1(cat_part, cat_dir, pub=pub)
+                return open(cat_path, "rb")
+            except (pkg.p5p.UnknownArchiveFiles, IOError) as e:
+                self.log_exception(status=SERVER_NOTFOUND_STATUS)
+            except Exception as e:
+                self.log_exception()
+            finally:
+                p5p_update_lock.release()
+        except OSError as e:
+            if e.errno == os.errno.ENOENT:
+                return open(cat_path, "rb")
+            else:
+                raise
+
+    def _manifest_response(self, path, pub):
+        """Return our manifest_response."""
+
+        pkg_name = path.replace("manifest/0/", "")
+        fmri = "pkg://{0}/{1}".format(pub, pkg_name)
+        mf = None
+        self.start_response(SERVER_OK_STATUS, response_headers)
+        try:
+            mf = self.p5p.get_package_manifest(fmri, raw=True)
+            return mf
+        except pkg.p5p.UnknownPackageManifest as e:
+            self.log_exception(status=SERVER_NOTFOUND_STATUS)
+        except pkg.fmri.IllegalFmri as e:
+            self.log_exception(status=SERVER_NOTFOUND_STATUS)
+        except Exception as e:
+            self.log_exception()
+
+    def _precache_catalog(self, pub, hsh):
+        """Extract the parts from the catalog_dir to the given path."""
+
+        htdocs_path = os.path.join(self.runtime_dir, "htdocs")
+        cat_dir = "{htdocs_path}/{pub}/{hsh}/catalog/1".format(**locals())
+
+        if os.path.exists(cat_dir):
+            shutil.rmtree(cat_dir)
+
+        os.makedirs(cat_dir)
+        try:
+            self.p5p.extract_catalog1("catalog.attrs", cat_dir, pub=pub)
+            with open(
+                os.path.join(cat_dir, "catalog.attrs"), "rb"
+            ) as catalog_attrs:
+                ret_json = json.load(catalog_attrs)
+                for part in ret_json["parts"]:
+                    self.p5p.extract_catalog1(part, cat_dir, pub=pub)
+
+        except pkg.p5p.UnknownArchiveFiles as e:
+            # if the catalog part is unavailable,
+            # we ignore this for now.  It will be
+            # reported later anyway.
+            pass
+
+    def _parse_query(self):
+        """Parse our query, returning publisher, hash, and path
+        values."""
+
+        keyvals = self.query.split("&")
+        attrs = {}
+        for keyval in keyvals:
+            try:
+                key, val = keyval.split("=", 1)
+                attrs[key] = val
+            except ValueError:
+                raise MalformedQueryException(
+                    self.query, "missing key=value pair for {0}.".format(keyval)
+                )
+
+        pub = attrs.get("pub")
+        hsh = attrs.get("hash")
+        path = attrs.get("path")
+
+        if not hsh:
+            raise MalformedQueryException(self.query, "missing hash.")
+        if hsh not in self.environ:
+            raise MalformedQueryException(
+                self.query, "unknown hash {0}.".format(hsh)
+            )
+        if not pub:
+            raise MalformedQueryException(self.query, "missing publisher.")
+        if not path:
+            raise MalformedQueryException(self.query, "missing path.")
+        return pub, hsh, path
+
+    def execute(self):
+        """Process a query of the form:
+
+        pub=<publisher>&hash=<hash>&path=<path>
+
+        where:
+            <publisher>    the name of the publisher from the p5p file
+            <hash>         the sha1 hash of the location of the p5p file
+            <path>         the path of the pkg(7) client request
+
+        In the environment of this WSGI application, apart from the
+        default WSGI values, defined in PEP333, we expect:
+
+        "SYSREPO_RUNTIME_DIR", a location pointing to the runtime
+        directory, allowing us to serve static html from beneath a
+        "htdocs" subdir.
+
+        <hash>, which maps the sha1 hash of the p5p archive path, to the
+        path itself, which is not visible to clients.
+        """
+
+        buf = []
+        try:
+            pub, hsh, path = self._parse_query()
+            self.p5p_path = self.environ[hsh]
+            if six.PY3:
+                # The pathname return from environ contains
+                # hex escaped sequences, but we need its unicode
+                # character to be able to find the file.
+                self.p5p_path = self.p5p_path.encode("iso-8859-1").decode(
+                    "utf-8"
+                )
+            # In order to keep only one copy of the p5p index in
+            # memory, we cache it locally, and reuse it any time
+            # we're opening the same p5p file.  Before doing
+            # so, we need to ensure the p5p file hasn't been
+            # modified since we last looked at it.
+            if self.need_update(pub, hsh) or self.p5p_path not in p5p_indices:
                 p5p_update_lock.acquire()
                 try:
-                        # don't write a timestamp if we're testing
-                        if self.environ.get("PKG5_TEST_ENV") == "True":
-                                return True
-
-                        try:
-                                st_p5p = os.stat(self.p5p_path)
-                        except OSError as e:
-                                if e.errno == os.errno.ENOENT:
-                                        raise MissingArchiveException(
-                                            self.p5p_path)
-                        try:
-                                st_ts = os.stat(timestamp_path)
-                                if st_ts.st_mtime < st_p5p.st_mtime:
-                                        open(timestamp_path, "wb").close()
-                                        update = True
-                        except OSError as e:
-                                if e.errno == os.errno.ENOENT:
-                                        open(timestamp_path, "wb").close()
-                                        update = True
-
-                except MissingArchiveException as e:
-                        raise
-                except Exception as e:
-                        self.log_exception()
+                    self.p5p = pkg.p5p.Archive(self.p5p_path)
+                    p5p_indices[self.p5p_path] = self.p5p.get_index()
+                    self._precache_catalog(pub, hsh)
+                except:
+                    raise
                 finally:
-                        p5p_update_lock.release()
-                return update
+                    p5p_update_lock.release()
+            else:
+                self.p5p = pkg.p5p.Archive(
+                    self.p5p_path, archive_index=p5p_indices[self.p5p_path]
+                )
 
-        def _file_response(self, path, pub):
-                """Process our file query."""
-
-                # use the basename of the path, which is the pkg(7) hash
-                self.start_response(SERVER_OK_STATUS, response_headers)
-                try:
-                        return self.p5p.get_package_file(os.path.basename(path),
-                            pub=pub)
-                except pkg.p5p.UnknownArchiveFiles as e:
-                        self.log_exception(status=SERVER_NOTFOUND_STATUS)
-                except Exception as e:
-                        self.log_exception()
-
-        def _catalog_response(self, path, pub, hsh):
-                """Process our catalog query"""
-
-                cat_part = os.path.basename(path)
-                htdocs_path = os.path.join(self.runtime_dir, "htdocs")
-                cat_path = \
-                    "{htdocs_path}/{pub}/{hsh}/catalog/1/{cat_part}".format(
-                    **locals())
-                self.start_response(SERVER_OK_STATUS, response_headers)
-                if os.path.exists(cat_path):
-                        return open(cat_path, "rb")
-
-                # this is unlikely to happen: it implies a catalog part has been
-                # requested that wasn't listed in the catalog.attrs file
-                # extracted during _precache_catalog() or the file has been
-                # removed on the server.  Do our best to return the content.
-                try:
-                        cat_dir = os.path.dirname(cat_path)
-                        p5p_update_lock.acquire()
-                        try:
-                                if not os.path.exists(cat_dir):
-                                        os.makedirs(cat_dir, 0o755)
-                                self.p5p.extract_catalog1(cat_part, cat_dir,
-                                    pub=pub)
-                                return open(cat_path, "rb")
-                        except (pkg.p5p.UnknownArchiveFiles, IOError) as e:
-                                self.log_exception(
-                                    status=SERVER_NOTFOUND_STATUS)
-                        except Exception as e:
-                                self.log_exception()
-                        finally:
-                                p5p_update_lock.release()
-                except OSError as e:
-                        if e.errno == os.errno.ENOENT:
-                                return open(cat_path, "rb")
-                        else:
-                                raise
-
-        def _manifest_response(self, path, pub):
-                """Return our manifest_response. """
-
-                pkg_name = path.replace("manifest/0/", "")
-                fmri = "pkg://{0}/{1}".format(pub, pkg_name)
-                mf = None
-                self.start_response(SERVER_OK_STATUS, response_headers)
-                try:
-                        mf = self.p5p.get_package_manifest(fmri, raw=True)
-                        return mf
-                except pkg.p5p.UnknownPackageManifest as e:
-                        self.log_exception(status=SERVER_NOTFOUND_STATUS)
-                except pkg.fmri.IllegalFmri as e:
-                        self.log_exception(status=SERVER_NOTFOUND_STATUS)
-                except Exception as e:
-                        self.log_exception()
-
-        def _precache_catalog(self, pub, hsh):
-                """Extract the parts from the catalog_dir to the given path."""
-
-                htdocs_path = os.path.join(self.runtime_dir, "htdocs")
-                cat_dir = "{htdocs_path}/{pub}/{hsh}/catalog/1".format(
-                    **locals())
-
-                if os.path.exists(cat_dir):
-                        shutil.rmtree(cat_dir)
-
-                os.makedirs(cat_dir)
-                try:
-                        self.p5p.extract_catalog1("catalog.attrs", cat_dir,
-                            pub=pub)
-                        with open(os.path.join(cat_dir, "catalog.attrs"),
-                            "rb") as catalog_attrs:
-                                ret_json = json.load(catalog_attrs)
-                                for part in ret_json["parts"]:
-                                        self.p5p.extract_catalog1(part, cat_dir,
-                                            pub=pub)
-
-                except pkg.p5p.UnknownArchiveFiles as e:
-                        # if the catalog part is unavailable,
-                        # we ignore this for now.  It will be
-                        # reported later anyway.
-                        pass
-
-        def _parse_query(self):
-                """Parse our query, returning publisher, hash, and path
-                values."""
-
-                keyvals = self.query.split("&")
-                attrs = {}
-                for keyval in keyvals:
-                        try:
-                                key, val = keyval.split("=", 1)
-                                attrs[key] = val
-                        except ValueError:
-                                raise MalformedQueryException(self.query,
-                                    "missing key=value pair for {0}.".format(keyval))
-
-                pub = attrs.get("pub")
-                hsh = attrs.get("hash")
-                path = attrs.get("path")
-
-                if not hsh:
-                        raise MalformedQueryException(self.query,
-                            "missing hash.")
-                if hsh not in self.environ:
-                        raise MalformedQueryException(self.query,
-                            "unknown hash {0}.".format(hsh))
-                if not pub:
-                        raise MalformedQueryException(self.query,
-                            "missing publisher.")
-                if not path:
-                        raise MalformedQueryException(self.query,
-                            "missing path.")
-                return pub, hsh, path
-
-        def execute(self):
-                """Process a query of the form:
-
-                pub=<publisher>&hash=<hash>&path=<path>
-
-                where:
-                    <publisher>    the name of the publisher from the p5p file
-                    <hash>         the sha1 hash of the location of the p5p file
-                    <path>         the path of the pkg(7) client request
-
-                In the environment of this WSGI application, apart from the
-                default WSGI values, defined in PEP333, we expect:
-
-                "SYSREPO_RUNTIME_DIR", a location pointing to the runtime
-                directory, allowing us to serve static html from beneath a
-                "htdocs" subdir.
-
-                <hash>, which maps the sha1 hash of the p5p archive path, to the
-                path itself, which is not visible to clients.
-                """
-
-                buf = []
-                try:
-                        pub, hsh, path = self._parse_query()
-                        self.p5p_path = self.environ[hsh]
-                        if six.PY3:
-                                # The pathname return from environ contains
-                                # hex escaped sequences, but we need its unicode
-                                # character to be able to find the file.
-                                self.p5p_path = self.p5p_path.encode(
-                                        "iso-8859-1").decode("utf-8")
-                        # In order to keep only one copy of the p5p index in
-                        # memory, we cache it locally, and reuse it any time
-                        # we're opening the same p5p file.  Before doing
-                        # so, we need to ensure the p5p file hasn't been
-                        # modified since we last looked at it.
-                        if self.need_update(pub, hsh) or \
-                            self.p5p_path not in p5p_indices:
-                                p5p_update_lock.acquire()
-                                try:
-                                        self.p5p = pkg.p5p.Archive(
-                                            self.p5p_path)
-                                        p5p_indices[self.p5p_path] = \
-                                            self.p5p.get_index()
-                                        self._precache_catalog(pub, hsh)
-                                except:
-                                        raise
-                                finally:
-                                        p5p_update_lock.release()
-                        else:
-                                self.p5p = pkg.p5p.Archive(self.p5p_path,
-                                    archive_index=p5p_indices[self.p5p_path])
-
-                        if path.startswith("file"):
-                                buf = self._file_response(path, pub)
-                        elif path.startswith("catalog/1/"):
-                                buf = self._catalog_response(path, pub, hsh)
-                        elif path.startswith("manifest/0"):
-                                buf = self._manifest_response(path, pub)
-                        else:
-                                raise UnknownPathException(path)
-                except OSError as e:
-                        print(e.errno)
-                        if e.errno == os.errno.ENOENT:
-                                self.log_Exception(
-                                    status=SERVER_NOTFOUND_STATUS)
-                except UnknownPathException as e:
-                        self.log_exception(status=SERVER_NOTFOUND_STATUS)
-                except MalformedQueryException as e:
-                        self.log_exception(status=SERVER_BADREQUEST_STATUS)
-                except MissingArchiveException as e:
-                        self.log_exception()
-                except Exception as e:
-                        self.log_exception()
-                return buf
+            if path.startswith("file"):
+                buf = self._file_response(path, pub)
+            elif path.startswith("catalog/1/"):
+                buf = self._catalog_response(path, pub, hsh)
+            elif path.startswith("manifest/0"):
+                buf = self._manifest_response(path, pub)
+            else:
+                raise UnknownPathException(path)
+        except OSError as e:
+            print(e.errno)
+            if e.errno == os.errno.ENOENT:
+                self.log_Exception(status=SERVER_NOTFOUND_STATUS)
+        except UnknownPathException as e:
+            self.log_exception(status=SERVER_NOTFOUND_STATUS)
+        except MalformedQueryException as e:
+            self.log_exception(status=SERVER_BADREQUEST_STATUS)
+        except MissingArchiveException as e:
+            self.log_exception()
+        except Exception as e:
+            self.log_exception()
+        return buf
 
 
 #
@@ -380,86 +382,87 @@ class SysrepoP5p(object):
 # received it)
 #
 
+
 def _application(environ, start_response):
-        sysrepo = SysrepoP5p(environ, start_response)
-        result = sysrepo.execute()
-        return result, sysrepo
+    sysrepo = SysrepoP5p(environ, start_response)
+    result = sysrepo.execute()
+    return result, sysrepo
 
 
 class CloseGenerator(object):
-        """A wrapper class to ensure we have a close() method on the iterable
-        returned from the mod_wsgi application, see PEP333."""
+    """A wrapper class to ensure we have a close() method on the iterable
+    returned from the mod_wsgi application, see PEP333."""
 
-        def __init__(self, iterable, closeable):
-                self.__iterable = iterable
-                self.__closeable = closeable
+    def __init__(self, iterable, closeable):
+        self.__iterable = iterable
+        self.__closeable = closeable
 
-        def __iter__(self):
-                # if we haven't produced an iterable, that's
-                # likely because of an exception. Do nothing.
-                if not self.__iterable:
-                        return
-                for item in self.__iterable:
-                        yield item
+    def __iter__(self):
+        # if we haven't produced an iterable, that's
+        # likely because of an exception. Do nothing.
+        if not self.__iterable:
+            return
+        for item in self.__iterable:
+            yield item
 
-        def close(self):
-                try:
-                        if hasattr(self.__iterable, "close"):
-                                self.__iterable.close()
-                finally:
-                        self.__closeable.close()
+    def close(self):
+        try:
+            if hasattr(self.__iterable, "close"):
+                self.__iterable.close()
+        finally:
+            self.__closeable.close()
 
 
 class AppWrapper(object):
-        """Wrap a callable application with this class in order for its results
-        to be handled by CloseGenerator when that callable is called."""
+    """Wrap a callable application with this class in order for its results
+    to be handled by CloseGenerator when that callable is called."""
 
-        def __init__(self, application):
-                self.__application = application
+    def __init__(self, application):
+        self.__application = application
 
-        def __call__(self, environ, start_response):
-                result, closeable = self.__application(environ, start_response)
-                return CloseGenerator(result, closeable)
+    def __call__(self, environ, start_response):
+        result, closeable = self.__application(environ, start_response)
+        return CloseGenerator(result, closeable)
 
 
 application = AppWrapper(_application)
 
 if __name__ == "__main__":
-        """A simple main function to allows us to test any given query/env"""
-        from six.moves.urllib.parse import unquote
+    """A simple main function to allows us to test any given query/env"""
+    from six.moves.urllib.parse import unquote
 
-        def start_response(status, response_headers, exc_info=None):
-                """A dummy response function."""
-                print("responding with {0}".format(status))
-                if exc_info:
-                        print(traceback.format_exc(exc_info))
+    def start_response(status, response_headers, exc_info=None):
+        """A dummy response function."""
+        print("responding with {0}".format(status))
+        if exc_info:
+            print(traceback.format_exc(exc_info))
 
-        if len(sys.argv) != 3:
-                query = \
-                ("'pub=test&hash=de5acae11333890c457665379eec812a67f78dd3"
-                "&path=manifest/0/mypackage@1.2.9%2C5.11-1%3A20110617T204846Z'")
-                alias = \
-                "de5acae11333890c457665379eec812a67f78dd3=/tmp/archive.p5p"
-                print("usage: sysrepo_p5p <query> <hash>=<path to p5p file>")
-                print("eg: ./sysrepo_p5p.py {0} {1}".format(query, alias))
-                sys.exit(2)
+    if len(sys.argv) != 3:
+        query = (
+            "'pub=test&hash=de5acae11333890c457665379eec812a67f78dd3"
+            "&path=manifest/0/mypackage@1.2.9%2C5.11-1%3A20110617T204846Z'"
+        )
+        alias = "de5acae11333890c457665379eec812a67f78dd3=/tmp/archive.p5p"
+        print("usage: sysrepo_p5p <query> <hash>=<path to p5p file>")
+        print("eg: ./sysrepo_p5p.py {0} {1}".format(query, alias))
+        sys.exit(2)
 
-        environ = {}
+    environ = {}
 
-        # unquote the url, so that we can easily copy/paste entries from
-        # Apache logs when testing.
-        environ["QUERY_STRING"] = unquote(sys.argv[1])
-        environ["SYSREPO_RUNTIME_DIR"] = os.environ["PWD"]
-        environ["PKG5_TEST_ENV"] = "True"
-        hsh, path = sys.argv[2].split("=")
-        environ[hsh] = path
+    # unquote the url, so that we can easily copy/paste entries from
+    # Apache logs when testing.
+    environ["QUERY_STRING"] = unquote(sys.argv[1])
+    environ["SYSREPO_RUNTIME_DIR"] = os.environ["PWD"]
+    environ["PKG5_TEST_ENV"] = "True"
+    hsh, path = sys.argv[2].split("=")
+    environ[hsh] = path
 
-        for response in application(environ, start_response):
-                if isinstance(response, six.string_types):
-                        print(response.rstrip())
-                elif response:
-                        for line in response.readlines():
-                                print(line.rstrip())
+    for response in application(environ, start_response):
+        if isinstance(response, six.string_types):
+            print(response.rstrip())
+        elif response:
+            for line in response.readlines():
+                print(line.rstrip())
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/an2_ip.py
+++ b/src/util/log-scripts/an2_ip.py
@@ -33,16 +33,16 @@ from an_report import *
 
 total_by_ip = {}
 
-ip_files = [ "{0}-ip.dat".format(i) for i in sys.argv[2:] ]
-ip_files = [ i for i in ip_files if os.path.exists(i) ]
+ip_files = ["{0}-ip.dat".format(i) for i in sys.argv[2:]]
+ip_files = [i for i in ip_files if os.path.exists(i)]
 
 for l in fileinput.input(ip_files):
-        x = l.split()
+    x = l.split()
 
-        try:
-                total_by_ip[x[1]] += int(x[0])
-        except KeyError:
-                total_by_ip[x[1]] = int(x[0])
+    try:
+        total_by_ip[x[1]] += int(x[0])
+    except KeyError:
+        total_by_ip[x[1]] = int(x[0])
 
 total_by_country = ip_to_country(total_by_ip)
 
@@ -58,4 +58,4 @@ report_cols_end()
 report_section_end()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/an2_ip_active.py
+++ b/src/util/log-scripts/an2_ip_active.py
@@ -34,74 +34,93 @@ from an_report import *
 
 ndays = 0
 
-def report_by_date(data, title, summary_file = None):
-        global ndays
 
-        chart_data = ""
-        chart_min = 0
-        chart_max = 0
-        days = 0
-        total = 0
-        chart_hz = 440
-        chart_vt = 330
+def report_by_date(data, title, summary_file=None):
+    global ndays
 
-        sdkeys = sorted(data.keys())
-        start_day = sdkeys[0]
-        end_day = sdkeys[-1]
+    chart_data = ""
+    chart_min = 0
+    chart_max = 0
+    days = 0
+    total = 0
+    chart_hz = 440
+    chart_vt = 330
 
-        for i in sdkeys:
-                days += 1
-                total += data[i]
+    sdkeys = sorted(data.keys())
+    start_day = sdkeys[0]
+    end_day = sdkeys[-1]
 
-                if chart_data == "":
-                        chart_data = "{0:d}".format(data[i])
-                else:
-                        chart_data += ",{0:d}".format(data[i])
-                if data[i] > chart_max:
-                        chart_max = data[i]
+    for i in sdkeys:
+        days += 1
+        total += data[i]
 
-        msg = """\
+        if chart_data == "":
+            chart_data = "{0:d}".format(data[i])
+        else:
+            chart_data += ",{0:d}".format(data[i])
+        if data[i] > chart_max:
+            chart_max = data[i]
+
+    msg = """\
 <p>
 Period: {0} - {1} ({2:d} days)<br />
-""".format(start_day, end_day, days)
+""".format(
+        start_day, end_day, days
+    )
 
-        ndays = days
-        sz = (chart_hz // ndays)
+    ndays = days
+    sz = chart_hz // ndays
 
-        url = "cht=lc&chs={0:d}x{1:d}&chg={2:d},{3:d}&chds={4:d},{5:d}&chxt=y,x&chxl=0:|0|{6:d}|1:|{7}|{8}&chd=t:{9}".format(ndays * sz, chart_vt, 7 * sz, 250 * (chart_vt // chart_max), chart_min, chart_max, chart_max, start_day, end_day, chart_data)
+    url = "cht=lc&chs={0:d}x{1:d}&chg={2:d},{3:d}&chds={4:d},{5:d}&chxt=y,x&chxl=0:|0|{6:d}|1:|{7}|{8}&chd=t:{9}".format(
+        ndays * sz,
+        chart_vt,
+        7 * sz,
+        250 * (chart_vt // chart_max),
+        chart_min,
+        chart_max,
+        chart_max,
+        start_day,
+        end_day,
+        chart_data,
+    )
 
-        fname = retrieve_chart("http://chart.apis.google.com/chart?{0}".format(url),
-            "{0}-date".format(title))
+    fname = retrieve_chart(
+        "http://chart.apis.google.com/chart?{0}".format(url),
+        "{0}-date".format(title),
+    )
 
-        msg += """\
+    msg += """\
 <!-- {0} -->
-<img src=\"{1}\" alt=\"{2}\" /><br />""".format(url, fname, "Active catalog IPs over {0:d} day window".format(ndays))
+<img src=\"{1}\" alt=\"{2}\" /><br />""".format(
+        url, fname, "Active catalog IPs over {0:d} day window".format(ndays)
+    )
 
-        print(msg)
-        if summary_file:
-                print(msg, file=summary_file)
+    print(msg)
+    if summary_file:
+        print(msg, file=summary_file)
+
 
 merge_entries_by_date = {}
 
 for fn in sys.argv[1:]:
-        f = open(fn, "rb")
-        ebd = pickle.load(f)
-        f.close()
+    f = open(fn, "rb")
+    ebd = pickle.load(f)
+    f.close()
 
-        for k in ebd:
-                if k in merge_entries_by_date:
-                        for v in ebd[k]:
-                                if not v in merge_entries_by_date[k]:
-                                        merge_entries_by_date[k].append(v)
+    for k in ebd:
+        if k in merge_entries_by_date:
+            for v in ebd[k]:
+                if not v in merge_entries_by_date[k]:
+                    merge_entries_by_date[k].append(v)
 
-                else:
-                        merge_entries_by_date[k] = ebd[k]
+        else:
+            merge_entries_by_date[k] = ebd[k]
 
 dates = sorted(merge_entries_by_date.keys())
 data = {}
 
 for d in dates:
-        data[d] = len(merge_entries_by_date[d])       
+    data[d] = len(merge_entries_by_date[d])
 
 ip_counts = {}
 firstdate = dates[0]
@@ -109,45 +128,47 @@ firstn = 0
 firstdt = datetime.datetime(*(time.strptime(firstdate, "%Y-%m-%d")[0:6]))
 
 for ip in merge_entries_by_date[firstdate]:
-        ip_counts[ip] = 1
+    ip_counts[ip] = 1
 
 window = datetime.timedelta(30)
 data = {}
 
 for d in dates[1:]:
-        dt = datetime.datetime(*(time.strptime(d, "%Y-%m-%d")[0:6]))
-        ips = merge_entries_by_date[d]
+    dt = datetime.datetime(*(time.strptime(d, "%Y-%m-%d")[0:6]))
+    ips = merge_entries_by_date[d]
 
-        for ip in ips:
-                try:
-                        ip_counts[ip] += 1
-                except KeyError:
-                        ip_counts[ip] = 1
+    for ip in ips:
+        try:
+            ip_counts[ip] += 1
+        except KeyError:
+            ip_counts[ip] = 1
 
+    delta = dt - firstdt
+
+    while delta > window:
+        #   run through merge_entries_by_date[firstdate] and decrement
+        rips = merge_entries_by_date[firstdate]
+        for rip in rips:
+            ip_counts[rip] -= 1
+            if ip_counts[rip] == 0:
+                del ip_counts[rip]
+
+        #   advance firstn, set firstdate, firstdt to dates[firstn]
+        firstn += 1
+        firstdate = dates[firstn]
+        firstdt = datetime.datetime(
+            *(time.strptime(firstdate, "%Y-%m-%d")[0:6])
+        )
+
+        #   recalculate delta
         delta = dt - firstdt
 
-        while delta > window:
-                #   run through merge_entries_by_date[firstdate] and decrement
-                rips = merge_entries_by_date[firstdate]
-                for rip in rips:
-                        ip_counts[rip] -= 1
-                        if ip_counts[rip] == 0:
-                                del ip_counts[rip]
+    data[d] = len(ip_counts.keys())
 
-                #   advance firstn, set firstdate, firstdt to dates[firstn]
-                firstn += 1
-                firstdate = dates[firstn]
-                firstdt = datetime.datetime(*(time.strptime(firstdate, "%Y-%m-%d")[0:6]))
-
-                #   recalculate delta
-                delta = dt - firstdt
-        
-        data[d] = len(ip_counts.keys())
-        
 report_section_begin("Active IP addresses")
 print("<h3>Distinct IP addresses, by date</h3>")
 report_by_date(data, "distinct-cat-1d")
 report_section_end()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/an_catalog.py
+++ b/src/util/log-scripts/an_catalog.py
@@ -71,107 +71,121 @@ catalog_by_raw_agent = {}
 catalog_by_pkg_version = {}
 catalog_by_arch = {}
 
-def report_catalog_by_arch():
-        print("<pre>")
-        for i in catalog_by_arch.keys():
-                print(i, catalog_by_arch[i])
-        print("</pre>")
 
-def report_catalog_by_raw_agent(summary_file = None):
-        print("<pre>")
-        for i, n in (sorted(catalog_by_raw_agent.items(), key=lambda k_v: (k_v[1],k_v[0]))):
-                print(i, n)
-        print("</pre>")
+def report_catalog_by_arch():
+    print("<pre>")
+    for i in catalog_by_arch.keys():
+        print(i, catalog_by_arch[i])
+    print("</pre>")
+
+
+def report_catalog_by_raw_agent(summary_file=None):
+    print("<pre>")
+    for i, n in sorted(
+        catalog_by_raw_agent.items(), key=lambda k_v: (k_v[1], k_v[0])
+    ):
+        print(i, n)
+    print("</pre>")
+
 
 def report_catalog_by_pkg_version():
-        print("<pre>")
-        for i, n in (sorted(catalog_by_pkg_version.items(), key=lambda k_v: (k_v[1],k_v[0]))):
-                print(i, n)
-        print("</pre>")
+    print("<pre>")
+    for i, n in sorted(
+        catalog_by_pkg_version.items(), key=lambda k_v: (k_v[1], k_v[0])
+    ):
+        print(i, n)
+    print("</pre>")
+
 
 def report_catalog_by_lang():
-        labels = ""
-        data = ""
-        min = 0
-        max = 0
+    labels = ""
+    data = ""
+    min = 0
+    max = 0
 
-        print("<pre>")
-        for i, n in (sorted(catalog_by_lang.items(), key=lambda k_v: (k_v[1],k_v[0]))):
-                if labels == "":
-                        labels = "{0}".format(i)
-                else:
-                        labels += "|{0}".format(i)
-                if data == "":
-                        data = "{0:d}".format(n)
-                else:
-                        data += ",{0:d}".format(n)
+    print("<pre>")
+    for i, n in sorted(
+        catalog_by_lang.items(), key=lambda k_v: (k_v[1], k_v[0])
+    ):
+        if labels == "":
+            labels = "{0}".format(i)
+        else:
+            labels += "|{0}".format(i)
+        if data == "":
+            data = "{0:d}".format(n)
+        else:
+            data += ",{0:d}".format(n)
 
-                print(i, n)
-                if n > max:
-                        max = n
+        print(i, n)
+        if n > max:
+            max = n
 
-        print("</pre>")
+    print("</pre>")
 
-        url = "cht=p3&chs=800x300&chl={0}&chds={1:d},{2:d}&chd=t:{3}".format(labels,min,max,data)
-        fname = retrieve_chart("http://chart.apis.google.com/chart?{0}".format(url, "lang"))
-        print ("<img src=\"{0}\" />".format(fname))
+    url = "cht=p3&chs=800x300&chl={0}&chds={1:d},{2:d}&chd=t:{3}".format(
+        labels, min, max, data
+    )
+    fname = retrieve_chart(
+        "http://chart.apis.google.com/chart?{0}".format(url, "lang")
+    )
+    print('<img src="{0}" />'.format(fname))
+
 
 def count_catalog(mg, d):
+    try:
+        catalog_by_date[d.date().isoformat()] += 1
+    except KeyError:
+        catalog_by_date[d.date().isoformat()] = 1
+    try:
+        catalog_by_ip[mg["ip"]] += 1
+    except KeyError:
+        catalog_by_ip[mg["ip"]] = 1
 
-        try:
-                catalog_by_date[d.date().isoformat()] += 1
-        except KeyError:
-                catalog_by_date[d.date().isoformat()] = 1
-        try:
-                catalog_by_ip[mg["ip"]] += 1
-        except KeyError:
-                catalog_by_ip[mg["ip"]] = 1
+    try:
+        if not d in catalog_by_ip_active[mg["ip"]]:
+            catalog_by_ip_active[mg["ip"]].append(d)
+    except KeyError:
+        catalog_by_ip_active[mg["ip"]] = [d]
 
+    try:
+        catalog_by_raw_agent[mg["agent"]] += 1
+    except:
+        catalog_by_raw_agent[mg["agent"]] = 1
 
-        try:
-                if not d in catalog_by_ip_active[mg["ip"]]:
-                        catalog_by_ip_active[mg["ip"]].append(d)
-        except KeyError:
-                catalog_by_ip_active[mg["ip"]] = [d]
+    # Agent-specific measurements.
 
-        try:
-                catalog_by_raw_agent[mg["agent"]] += 1
-        except:
-                catalog_by_raw_agent[mg["agent"]] = 1
+    agent = pkg_agent_pat.search(mg["agent"])
+    if agent == None:
+        return
 
-        # Agent-specific measurements.
+    ag = agent.groupdict()
+    try:
+        catalog_by_arch[ag["arch"]] += 1
+    except KeyError:
+        catalog_by_arch[ag["arch"]] = 1
+    try:
+        catalog_by_pkg_version[ag["pversion"]] += 1
+    except KeyError:
+        catalog_by_pkg_version[ag["pversion"]] = 1
 
-        agent = pkg_agent_pat.search(mg["agent"])
-        if agent == None:
-                return
-
-        ag = agent.groupdict()
-        try:
-                catalog_by_arch[ag["arch"]] += 1
-        except KeyError:
-                catalog_by_arch[ag["arch"]] = 1
-        try:
-                catalog_by_pkg_version[ag["pversion"]] += 1
-        except KeyError:
-                catalog_by_pkg_version[ag["pversion"]] = 1
 
 opts, args = getopt.getopt(sys.argv[1:], "a:b:sw:")
 
 for opt, arg in opts:
-        if opt == "-a":
-                try:
-                        after = datetime.datetime(*(time.strptime(arg, "%Y-%b-%d")[0:6]))
-                except ValueError:
-                        after = datetime.datetime(*(time.strptime(arg, "%Y-%m-%d")[0:6]))
+    if opt == "-a":
+        try:
+            after = datetime.datetime(*(time.strptime(arg, "%Y-%b-%d")[0:6]))
+        except ValueError:
+            after = datetime.datetime(*(time.strptime(arg, "%Y-%m-%d")[0:6]))
 
-        if opt == "-b":
-                before = arg
+    if opt == "-b":
+        before = arg
 
-        if opt == "-s":
-                summary_file = prefix_summary_open("catalog")
+    if opt == "-s":
+        summary_file = prefix_summary_open("catalog")
 
-        if opt == "-w":
-                active_window = arg
+    if opt == "-w":
+        active_window = arg
 
 host_cache_set_file_name()
 host_cache_load()
@@ -180,45 +194,45 @@ lastdate = None
 lastdatetime = None
 
 for l in fileinput.input(args):
-        m = comb_log_pat.search(l)
-        if not m:
-                continue
+    m = comb_log_pat.search(l)
+    if not m:
+        continue
 
-        mg = m.groupdict()
+    mg = m.groupdict()
 
-        d = None
+    d = None
 
-        if lastdatetime and mg["date"] == lastdate:
-                d = lastdatetime
-        else:
-                d = datetime.datetime(*(time.strptime(mg["date"], "%d/%b/%Y")[0:6]))
-                lastdate = mg["date"]
-                lastdatetime = d
+    if lastdatetime and mg["date"] == lastdate:
+        d = lastdatetime
+    else:
+        d = datetime.datetime(*(time.strptime(mg["date"], "%d/%b/%Y")[0:6]))
+        lastdate = mg["date"]
+        lastdatetime = d
 
-        if after and d < after:
-                continue
+    if after and d < after:
+        continue
 
-        count_catalog(mg, d)
+    count_catalog(mg, d)
 
 host_cache_save()
 catalog_by_country = ip_to_country(catalog_by_ip)
 
-report_section_begin("Catalogs", summary_file = summary_file)
-report_cols_begin(summary_file = summary_file)
-report_col_begin("l", summary_file = summary_file)
-report_by_ip(catalog_by_ip, "catalog", summary_file = summary_file)
-report_by_date(catalog_by_date, "catalog", summary_file = summary_file)
-report_col_end("l", summary_file = summary_file)
-report_col_begin("r", summary_file = summary_file)
-report_by_country(catalog_by_country, "catalog", summary_file = summary_file)
-report_col_end("r", summary_file = summary_file)
-report_cols_end(summary_file = summary_file)
+report_section_begin("Catalogs", summary_file=summary_file)
+report_cols_begin(summary_file=summary_file)
+report_col_begin("l", summary_file=summary_file)
+report_by_ip(catalog_by_ip, "catalog", summary_file=summary_file)
+report_by_date(catalog_by_date, "catalog", summary_file=summary_file)
+report_col_end("l", summary_file=summary_file)
+report_col_begin("r", summary_file=summary_file)
+report_by_country(catalog_by_country, "catalog", summary_file=summary_file)
+report_col_end("r", summary_file=summary_file)
+report_cols_end(summary_file=summary_file)
 
-report_by_raw_agent(catalog_by_raw_agent, "catalog", summary_file = summary_file)
+report_by_raw_agent(catalog_by_raw_agent, "catalog", summary_file=summary_file)
 report_catalog_by_pkg_version()
 report_catalog_by_arch()
-report_section_end(summary_file = summary_file)
+report_section_end(summary_file=summary_file)
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/an_filelist.py
+++ b/src/util/log-scripts/an_filelist.py
@@ -49,49 +49,61 @@ filelist_totals["bytes"] = 0
 
 pkg_pat = re.compile(r"/filelist/(?P<mversion>\d+)/(?P<trailing>.*)")
 
+
 # old-division; pylint: disable=W1619
 def report_filelist_by_bytes():
-        print("<p>Total kilobytes sent via filelist: {0:f}</p>".format(filelist_totals["kilobytes"] + filelist_totals["bytes"]/1024))
+    print(
+        "<p>Total kilobytes sent via filelist: {0:f}</p>".format(
+            filelist_totals["kilobytes"] + filelist_totals["bytes"] / 1024
+        )
+    )
 
-        if summary_file:
-                print("<p>Total kilobytes sent via filelist: {0:f}</p>".format(filelist_totals["kilobytes"] + filelist_totals["bytes"]/1024), file=summary_file)
+    if summary_file:
+        print(
+            "<p>Total kilobytes sent via filelist: {0:f}</p>".format(
+                filelist_totals["kilobytes"] + filelist_totals["bytes"] / 1024
+            ),
+            file=summary_file,
+        )
+
 
 def count_filelist(mg, d):
-        try:
-                filelist_by_date[d.date().isoformat()] += 1
-        except KeyError:
-                filelist_by_date[d.date().isoformat()] = 1
+    try:
+        filelist_by_date[d.date().isoformat()] += 1
+    except KeyError:
+        filelist_by_date[d.date().isoformat()] = 1
 
-        pm = pkg_pat.search(mg["uri"])
-        if pm != None:
-                pg = pm.groupdict()
+    pm = pkg_pat.search(mg["uri"])
+    if pm != None:
+        pg = pm.groupdict()
 
-                if mg["response"] == "200":
-                        filelist_totals["bytes"] += int(mg["subcode"])
+        if mg["response"] == "200":
+            filelist_totals["bytes"] += int(mg["subcode"])
 
-                        if filelist_totals["bytes"] > 1024:
-                                filelist_totals["kilobytes"] += filelist_totals["bytes"] // 1024
-                                filelist_totals["bytes"] = filelist_totals["bytes"] % 1024
+            if filelist_totals["bytes"] > 1024:
+                filelist_totals["kilobytes"] += filelist_totals["bytes"] // 1024
+                filelist_totals["bytes"] = filelist_totals["bytes"] % 1024
 
-                # XXX should measure downtime via 503, other failure responses
+        # XXX should measure downtime via 503, other failure responses
+
 
 opts, args = getopt.getopt(sys.argv[1:], "a:b:sw:")
 
 for opt, arg in opts:
-        if opt == "-a":
-                try:
-                        after = datetime.datetime(*(time.strptime(arg, "%Y-%b-%d")[0:6]))
-                except ValueError:
-                        after = datetime.datetime(*(time.strptime(arg, "%Y-%m-%d")[0:6]))
+    if opt == "-a":
+        try:
+            after = datetime.datetime(*(time.strptime(arg, "%Y-%b-%d")[0:6]))
+        except ValueError:
+            after = datetime.datetime(*(time.strptime(arg, "%Y-%m-%d")[0:6]))
 
-        if opt == "-b":
-                before = arg
+    if opt == "-b":
+        before = arg
 
-        if opt == "-s":
-                summary_file = prefix_summary_open("filelist")
+    if opt == "-s":
+        summary_file = prefix_summary_open("filelist")
 
-        if opt == "-w":
-                active_window = arg
+    if opt == "-w":
+        active_window = arg
 
 host_cache_set_file_name()
 host_cache_load()
@@ -100,32 +112,32 @@ lastdate = None
 lastdatetime = None
 
 for l in fileinput.input(args):
-        m = comb_log_pat.search(l)
-        if not m:
-                continue
+    m = comb_log_pat.search(l)
+    if not m:
+        continue
 
-        mg = m.groupdict()
+    mg = m.groupdict()
 
-        d = None
+    d = None
 
-        if lastdatetime and mg["date"] == lastdate:
-                d = lastdatetime
-        else:
-                d = datetime.datetime(*(time.strptime(mg["date"], "%d/%b/%Y")[0:6]))
-                lastdate = mg["date"]
-                lastdatetime = d
+    if lastdatetime and mg["date"] == lastdate:
+        d = lastdatetime
+    else:
+        d = datetime.datetime(*(time.strptime(mg["date"], "%d/%b/%Y")[0:6]))
+        lastdate = mg["date"]
+        lastdatetime = d
 
-        if after and d < after:
-                continue
+    if after and d < after:
+        continue
 
-        count_filelist(mg, d)
+    count_filelist(mg, d)
 
 host_cache_save()
 
-report_section_begin("Filelist", summary_file = summary_file)
+report_section_begin("Filelist", summary_file=summary_file)
 report_filelist_by_bytes()
-report_by_date(filelist_by_date, "filelist", summary_file = summary_file)
-report_section_end(summary_file = summary_file)
+report_by_date(filelist_by_date, "filelist", summary_file=summary_file)
+report_section_end(summary_file=summary_file)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/an_first_timestamp.py
+++ b/src/util/log-scripts/an_first_timestamp.py
@@ -37,24 +37,32 @@ import time
 
 # Apache combined log pattern
 #   Canonical version is in an_report.py
-comb_log_pat = re.compile(r"(?P<ip>[\d\.]*) - - \[(?P<date>[^:]*):(?P<time>\S*) (?P<tz>[^\]]*)\] \"(?P<op>GET|POST|HEAD|\S*) (?P<uri>\S*) HTTP/(?P<httpver>[^\"]*)\" (?P<response>\d*) (?P<subcode>\d*|-) \"(?P<refer>[^\"]*)\" \"(?P<agent>[^\"]*)\"")
+comb_log_pat = re.compile(
+    r"(?P<ip>[\d\.]*) - - \[(?P<date>[^:]*):(?P<time>\S*) (?P<tz>[^\]]*)\] \"(?P<op>GET|POST|HEAD|\S*) (?P<uri>\S*) HTTP/(?P<httpver>[^\"]*)\" (?P<response>\d*) (?P<subcode>\d*|-) \"(?P<refer>[^\"]*)\" \"(?P<agent>[^\"]*)\""
+)
 
 lastdate = None
 lastdatetime = None
 printed = False
 
 for l in fileinput.input(sys.argv[1:]):
-        m = comb_log_pat.search(l)
-        if not m:
-                continue
+    m = comb_log_pat.search(l)
+    if not m:
+        continue
 
-        mg = m.groupdict()
+    mg = m.groupdict()
 
-        d = datetime.datetime(*(time.strptime(mg["date"] + ":" + mg["time"], "%d/%b/%Y:%H:%M:%S")[0:6]))
+    d = datetime.datetime(
+        *(
+            time.strptime(mg["date"] + ":" + mg["time"], "%d/%b/%Y:%H:%M:%S")[
+                0:6
+            ]
+        )
+    )
 
-        print("{0:d}".format(time.mktime(d.timetuple())))
-        sys.exit(0)
+    print("{0:d}".format(time.mktime(d.timetuple())))
+    sys.exit(0)
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/an_ip_active.py
+++ b/src/util/log-scripts/an_ip_active.py
@@ -50,70 +50,72 @@ country_by_hashed_ip = {}
 
 gi = GeoIP.new(GeoIP.GEOIP_MEMORY_CACHE)
 
+
 def count_entry(mg, d):
-        di = d.date().isoformat()
+    di = d.date().isoformat()
 
-        ip = mg["ip"]
-        cc = gi.country_code_by_addr(ip)
+    ip = mg["ip"]
+    cc = gi.country_code_by_addr(ip)
 
-        dip = md5.md5(ip)
-        dipd = dip.hexdigest()
+    dip = md5.md5(ip)
+    dipd = dip.hexdigest()
 
-        if di in entry_by_date:
-                if not dipd in entry_by_date[di]:
-                        entry_by_date[di].append(dipd)
-        else:
-                entry_by_date[di] = [dipd]
+    if di in entry_by_date:
+        if not dipd in entry_by_date[di]:
+            entry_by_date[di].append(dipd)
+    else:
+        entry_by_date[di] = [dipd]
+
 
 opts, args = getopt.getopt(sys.argv[1:], "a:b:S:t:w:")
 
 for opt, arg in opts:
-        if opt == "-a":
-                try:
-                        after = datetime.datetime(*(time.strptime(arg, "%Y-%b-%d")[0:6]))
-                except ValueError:
-                        after = datetime.datetime(*(time.strptime(arg, "%Y-%m-%d")[0:6]))
+    if opt == "-a":
+        try:
+            after = datetime.datetime(*(time.strptime(arg, "%Y-%b-%d")[0:6]))
+        except ValueError:
+            after = datetime.datetime(*(time.strptime(arg, "%Y-%m-%d")[0:6]))
 
-        if opt == "-b":
-                before = arg
+    if opt == "-b":
+        before = arg
 
-        if opt == "-S":
-                stem = arg
+    if opt == "-S":
+        stem = arg
 
-        if opt == "-t":
-                timestamp = arg
+    if opt == "-t":
+        timestamp = arg
 
-        if opt == "-w":
-                active_window = arg
+    if opt == "-w":
+        active_window = arg
 
 lastdate = None
 lastdatetime = None
 
 for l in fileinput.input(args):
-        m = comb_log_pat.search(l)
-        if not m:
-                continue
+    m = comb_log_pat.search(l)
+    if not m:
+        continue
 
-        mg = m.groupdict()
+    mg = m.groupdict()
 
-        d = None
+    d = None
 
-        if lastdatetime and mg["date"] == lastdate:
-                d = lastdatetime
-        else:
-                try:
-                        d = datetime.datetime(*(time.strptime(mg["date"], "%d/%b/%Y")[0:6]))
-                        lastdate = mg["date"]
-                        lastdatetime = d
-                except ValueError:
-                        # In the case the line can't be parsed for a date, it's
-                        # probably corrupt.
-                        continue
+    if lastdatetime and mg["date"] == lastdate:
+        d = lastdatetime
+    else:
+        try:
+            d = datetime.datetime(*(time.strptime(mg["date"], "%d/%b/%Y")[0:6]))
+            lastdate = mg["date"]
+            lastdatetime = d
+        except ValueError:
+            # In the case the line can't be parsed for a date, it's
+            # probably corrupt.
+            continue
 
-        if after and d < after:
-                continue
+    if after and d < after:
+        continue
 
-        count_entry(mg, d)
+    count_entry(mg, d)
 
 # open, trunc
 pklfile = open("{0}.{1}.pkl".format(stem, timestamp), "wb")
@@ -121,4 +123,4 @@ pickle.dump(entry_by_date, pklfile)
 pklfile.close()
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/an_manifest.py
+++ b/src/util/log-scripts/an_manifest.py
@@ -50,77 +50,88 @@ manifest_by_raw_agent = {}
 manifest_by_pkg = {}
 manifest_by_ver_pkg = {}
 
-pkg_pat = re.compile(r"/manifest/(?P<mversion>\d+)/(?P<stem>[^@]*)@(?P<version>.*)")
+pkg_pat = re.compile(
+    r"/manifest/(?P<mversion>\d+)/(?P<stem>[^@]*)@(?P<version>.*)"
+)
+
 
 def report_manifest_by_arch():
-        print("<pre>")
-        for i in manifest_by_arch.keys():
-                print(i, manifest_by_arch[i])
-        print("</pre>")
+    print("<pre>")
+    for i in manifest_by_arch.keys():
+        print(i, manifest_by_arch[i])
+    print("</pre>")
+
 
 def report_manifest_by_pkg():
-        print("<pre>")
-        for i, n in (sorted(manifest_by_pkg.items(), key=lambda k_v: (k_v[1],k_v[0]))):
-                print(i, n)
-        print("</pre>")
+    print("<pre>")
+    for i, n in sorted(
+        manifest_by_pkg.items(), key=lambda k_v: (k_v[1], k_v[0])
+    ):
+        print(i, n)
+    print("</pre>")
+
 
 def report_manifest_by_ver_pkg():
-        print("<pre>")
-        for i, n in (sorted(manifest_by_ver_pkg.items(), key=lambda k_v: (k_v[1],k_v[0]))):
-                print(i, n)
-        print("</pre>")
+    print("<pre>")
+    for i, n in sorted(
+        manifest_by_ver_pkg.items(), key=lambda k_v: (k_v[1], k_v[0])
+    ):
+        print(i, n)
+    print("</pre>")
+
 
 def count_manifest(mg, d):
+    try:
+        manifest_by_date[d.date().isoformat()] += 1
+    except KeyError:
+        manifest_by_date[d.date().isoformat()] = 1
+    try:
+        manifest_by_ip[mg["ip"]] += 1
+    except KeyError:
+        manifest_by_ip[mg["ip"]] = 1
+
+    pm = pkg_pat.search(mg["uri"])
+    if pm != None and mg["response"] == "200":
+        pg = pm.groupdict()
+
         try:
-                manifest_by_date[d.date().isoformat()] += 1
+            manifest_by_pkg[unquote(pg["stem"])] += 1
         except KeyError:
-                manifest_by_date[d.date().isoformat()] = 1
+            manifest_by_pkg[unquote(pg["stem"])] = 1
+
         try:
-                manifest_by_ip[mg["ip"]] += 1
+            manifest_by_ver_pkg[unquote(pg["stem"] + "@" + pg["version"])] += 1
         except KeyError:
-                manifest_by_ip[mg["ip"]] = 1
+            manifest_by_ver_pkg[unquote(pg["stem"] + "@" + pg["version"])] = 1
 
-        pm = pkg_pat.search(mg["uri"])
-        if pm != None and mg["response"] == "200":
-                pg = pm.groupdict()
+    agent = pkg_agent_pat.search(mg["agent"])
+    if agent == None:
+        return
 
-                try:
-                        manifest_by_pkg[unquote(pg["stem"])] += 1
-                except KeyError:
-                        manifest_by_pkg[unquote(pg["stem"])] = 1
+    ag = agent.groupdict()
+    try:
+        manifest_by_arch[ag["arch"]] += 1
+    except KeyError:
+        manifest_by_arch[ag["arch"]] = 1
 
-                try:
-                        manifest_by_ver_pkg[unquote(pg["stem"] + "@" + pg["version"])] += 1
-                except KeyError:
-                        manifest_by_ver_pkg[unquote(pg["stem"] + "@" + pg["version"])] = 1
-
-        agent = pkg_agent_pat.search(mg["agent"])
-        if agent == None:
-                return
-
-        ag = agent.groupdict()
-        try:
-                manifest_by_arch[ag["arch"]] += 1
-        except KeyError:
-                manifest_by_arch[ag["arch"]] = 1
 
 opts, args = getopt.getopt(sys.argv[1:], "a:b:sw:")
 
 for opt, arg in opts:
-        if opt == "-a":
-                try:
-                        after = datetime.datetime(*(time.strptime(arg, "%Y-%b-%d")[0:6]))
-                except ValueError:
-                        after = datetime.datetime(*(time.strptime(arg, "%Y-%m-%d")[0:6]))
+    if opt == "-a":
+        try:
+            after = datetime.datetime(*(time.strptime(arg, "%Y-%b-%d")[0:6]))
+        except ValueError:
+            after = datetime.datetime(*(time.strptime(arg, "%Y-%m-%d")[0:6]))
 
-        if opt == "-b":
-                before = arg
+    if opt == "-b":
+        before = arg
 
-        if opt == "-s":
-                summary_file = prefix_summary_open("manifest")
+    if opt == "-s":
+        summary_file = prefix_summary_open("manifest")
 
-        if opt == "-w":
-                active_window = arg
+    if opt == "-w":
+        active_window = arg
 
 host_cache_set_file_name()
 host_cache_load()
@@ -129,49 +140,51 @@ lastdate = None
 lastdatetime = None
 
 for l in fileinput.input(args):
-        m = comb_log_pat.search(l)
-        if not m:
-                continue
+    m = comb_log_pat.search(l)
+    if not m:
+        continue
 
-        mg = m.groupdict()
+    mg = m.groupdict()
 
-        d = None
+    d = None
 
-        if lastdatetime and mg["date"] == lastdate:
-                d = lastdatetime
-        else:
-                try:
-                        d = datetime.datetime(*(time.strptime(mg["date"], "%d/%b/%Y")[0:6]))
-                        lastdate = mg["date"]
-                        lastdatetime = d
-                except ValueError:
-                        # In the case the line can't be parsed for a date, it's
-                        # probably corrupt.
-                        continue
+    if lastdatetime and mg["date"] == lastdate:
+        d = lastdatetime
+    else:
+        try:
+            d = datetime.datetime(*(time.strptime(mg["date"], "%d/%b/%Y")[0:6]))
+            lastdate = mg["date"]
+            lastdatetime = d
+        except ValueError:
+            # In the case the line can't be parsed for a date, it's
+            # probably corrupt.
+            continue
 
-        if after and d < after:
-                continue
+    if after and d < after:
+        continue
 
-        count_manifest(mg, d)
+    count_manifest(mg, d)
 
 host_cache_save()
 manifest_by_country = ip_to_country(manifest_by_ip)
 
-report_section_begin("Manifest", summary_file = summary_file)
-report_cols_begin(summary_file = summary_file)
-report_col_begin("l", summary_file = summary_file)
-report_by_date(manifest_by_date, "manifest", summary_file = summary_file)
-report_col_end("l", summary_file = summary_file)
-report_col_begin("r", summary_file = summary_file)
-report_by_country(manifest_by_country, "manifest", summary_file = summary_file)
-report_col_end("r", summary_file = summary_file)
-report_cols_end(summary_file = summary_file)
-report_by_ip(manifest_by_ip, "manifest", summary_file = summary_file)
-report_by_raw_agent(manifest_by_raw_agent, "manifest", summary_file = summary_file)
+report_section_begin("Manifest", summary_file=summary_file)
+report_cols_begin(summary_file=summary_file)
+report_col_begin("l", summary_file=summary_file)
+report_by_date(manifest_by_date, "manifest", summary_file=summary_file)
+report_col_end("l", summary_file=summary_file)
+report_col_begin("r", summary_file=summary_file)
+report_by_country(manifest_by_country, "manifest", summary_file=summary_file)
+report_col_end("r", summary_file=summary_file)
+report_cols_end(summary_file=summary_file)
+report_by_ip(manifest_by_ip, "manifest", summary_file=summary_file)
+report_by_raw_agent(
+    manifest_by_raw_agent, "manifest", summary_file=summary_file
+)
 
 report_manifest_by_pkg()
 report_manifest_by_ver_pkg()
-report_section_end(summary_file = summary_file)
+report_section_end(summary_file=summary_file)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/an_report.py
+++ b/src/util/log-scripts/an_report.py
@@ -39,11 +39,17 @@ import config
 from six.moves.urllib.request import urlopen
 
 # Apache combined log pattern
-comb_log_pat = re.compile(r"(?P<ip>[\d\.]*) - - \[(?P<date>[^:]*):(?P<time>\S*) (?P<tz>[^\]]*)\] \"(?P<op>GET|POST|HEAD|\S*) (?P<uri>\S*) HTTP/(?P<httpver>[^\"]*)\" (?P<response>\d*) (?P<subcode>\d*|-) \"(?P<refer>[^\"]*)\" \"(?P<agent>[^\"]*)\" \"(?P<uuid>[^\"]*)\" \"(?P<intent>[^\"]*)\"")
+comb_log_pat = re.compile(
+    r"(?P<ip>[\d\.]*) - - \[(?P<date>[^:]*):(?P<time>\S*) (?P<tz>[^\]]*)\] \"(?P<op>GET|POST|HEAD|\S*) (?P<uri>\S*) HTTP/(?P<httpver>[^\"]*)\" (?P<response>\d*) (?P<subcode>\d*|-) \"(?P<refer>[^\"]*)\" \"(?P<agent>[^\"]*)\" \"(?P<uuid>[^\"]*)\" \"(?P<intent>[^\"]*)\""
+)
 
 # Agent field log patterns
-browser_agent_pat = re.compile(r".*X11; U; SunOS (?P<arch>[^;]*); (?P<lang>[^;]*)")
-pkg_agent_pat = re.compile(r"pkg/(?P<pversion>\S*) \((?P<pos>\S*) (?P<arch>[^;]*); (?P<uname>\S*) (?P<build>[^;]*); (?P<imagetype>[^)]*)\)")
+browser_agent_pat = re.compile(
+    r".*X11; U; SunOS (?P<arch>[^;]*); (?P<lang>[^;]*)"
+)
+pkg_agent_pat = re.compile(
+    r"pkg/(?P<pversion>\S*) \((?P<pos>\S*) (?P<arch>[^;]*); (?P<uname>\S*) (?P<build>[^;]*); (?P<imagetype>[^)]*)\)"
+)
 
 host_cache = {}
 host_props = {}
@@ -52,297 +58,367 @@ host_props["outstanding"] = 0
 
 gi = GeoIP.new(GeoIP.GEOIP_MEMORY_CACHE)
 
-def host_cache_set_file_name(path = "./host-cache.pkl"):
-        host_props["file_name"] = path
+
+def host_cache_set_file_name(path="./host-cache.pkl"):
+    host_props["file_name"] = path
+
 
 def host_cache_load():
-        try:
-                pklfile = open(host_props["file_name"], 'rb')
-                host_cache = pickle.load(pklfile)
-                pklfile.close()
-        except:
-                host_cache = {}
-        host_props["outstanding"] = 0
+    try:
+        pklfile = open(host_props["file_name"], "rb")
+        host_cache = pickle.load(pklfile)
+        pklfile.close()
+    except:
+        host_cache = {}
+    host_props["outstanding"] = 0
+
 
 def host_cache_save():
-        pklfile = open(host_props["file_name"], 'wb')
-        pickle.dump(host_cache, pklfile)
-        pklfile.close()
+    pklfile = open(host_props["file_name"], "wb")
+    pickle.dump(host_cache, pklfile)
+    pklfile.close()
+
 
 def host_cache_add():
-        if host_props["outstanding"] > 128:
-                host_cache_save()
-                host_props["outstanding"] = 0
+    if host_props["outstanding"] > 128:
+        host_cache_save()
+        host_props["outstanding"] = 0
 
-        host_props["outstanding"] += 1
+    host_props["outstanding"] += 1
+
 
 def host_cache_lookup(ip):
-        try:
-                return host_cache[ip]
-        except KeyError:
-                pass
-
-        try:
-                hname = socket.gethostbyaddr(ip)[0]
-                host_cache[ip] = hname
-
-                host_cache_add()
-
-                return host_cache[ip]
-        except socket.herror:
-                pass
-
-        host_cache[ip] = ip
+    try:
         return host_cache[ip]
+    except KeyError:
+        pass
+
+    try:
+        hname = socket.gethostbyaddr(ip)[0]
+        host_cache[ip] = hname
+
+        host_cache_add()
+
+        return host_cache[ip]
+    except socket.herror:
+        pass
+
+    host_cache[ip] = ip
+    return host_cache[ip]
+
 
 # Countries we're not allowed to report on (iran, north korea)
 filtered_countries = config.get("excluded").split(",")
 filtered_countries = [x.strip() for x in filtered_countries]
+
+
 def ip_to_country(ips):
-        cs = {}
-        for ip in ips.keys():
-                cc = gi.country_code_by_addr(ip)
-                if cc in filtered_countries:
-                        continue
-                try:
-                        cs[cc] += ips[ip]
-                except KeyError:
-                        cs[cc] = ips[ip]
-        return cs
+    cs = {}
+    for ip in ips.keys():
+        cc = gi.country_code_by_addr(ip)
+        if cc in filtered_countries:
+            continue
+        try:
+            cs[cc] += ips[ip]
+        except KeyError:
+            cs[cc] = ips[ip]
+    return cs
+
 
 def retrieve_chart(url, fileprefix):
-        f = open("{0}.png".format(fileprefix), "w")
-        try:
-                u = urlopen(url)
-                f.write(u.read())
-        except:
-                print("an_catalog: couldn't retrieve chart '{0}'".format(url),
-                    file=sys.stderr)
+    f = open("{0}.png".format(fileprefix), "w")
+    try:
+        u = urlopen(url)
+        f.write(u.read())
+    except:
+        print(
+            "an_catalog: couldn't retrieve chart '{0}'".format(url),
+            file=sys.stderr,
+        )
 
-        f.close()
+    f.close()
 
-        return f.name
+    return f.name
+
 
 def prefix_raw_open(fileprefix, reportname):
-        f = open("{0}-{1}.dat".format(fileprefix, reportname), "w")
+    f = open("{0}-{1}.dat".format(fileprefix, reportname), "w")
 
-        return f
+    return f
+
 
 def prefix_summary_open(fileprefix):
-        f = open("{0}-summary.html".format(fileprefix), "w")
+    f = open("{0}-summary.html".format(fileprefix), "w")
 
-        return f
+    return f
+
 
 def report_begin(cap_title):
-        print("""\
+    print(
+        """\
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
 <head>
 <title>pkg.depotd Logs: {0}</title>
 </head>
-<body>""".format(cap_title))
+<body>""".format(
+            cap_title
+        )
+    )
+
 
 def report_end():
-        print("""\
+    print(
+        """\
 </body>
-</html>""")
+</html>"""
+    )
 
 
-def report_section_begin(cap_title, summary_file = None):
-        msg = """\
+def report_section_begin(cap_title, summary_file=None):
+    msg = """\
 <br clear="all" />
 <div class="section">
-<h2>{0}</h2>""".format(cap_title)
+<h2>{0}</h2>""".format(
+        cap_title
+    )
 
-        print(msg)
-        if summary_file:
-                print(msg, file=summary_file)
-
-def report_section_end(summary_file = None):
-        msg = """</div> <!--end class=section-->"""
-        print(msg)
-        if summary_file:
-                print(msg, file=summary_file)
+    print(msg)
+    if summary_file:
+        print(msg, file=summary_file)
 
 
-def report_cols_begin(summary_file = None):
-        msg = """<div class="colwrapper">"""
-        print(msg)
-        if summary_file:
-                print(msg, file=summary_file)
-
-def report_cols_end(summary_file = None):
-        msg = """<br clear="all" /></div>"""
-        print(msg)
-        if summary_file:
-                print(msg, file=summary_file)
-
-def report_col_begin(col, summary_file = None):
-        msg = """<div class="{0}column">""".format(col)
-
-        print(msg)
-        if summary_file:
-                print(msg, file=summary_file)
-
-def report_col_end(col, summary_file = None):
-        msg = """</div> <!-- end class={0}column -->""".format(col)
-
-        print(msg)
-        if summary_file:
-                pprint(msg, file=summary_file)
+def report_section_end(summary_file=None):
+    msg = """</div> <!--end class=section-->"""
+    print(msg)
+    if summary_file:
+        print(msg, file=summary_file)
 
 
+def report_cols_begin(summary_file=None):
+    msg = """<div class="colwrapper">"""
+    print(msg)
+    if summary_file:
+        print(msg, file=summary_file)
 
-def report_by_date(data, title, summary_file = None):
-        chart_data = ""
-        chart_min = 0
-        chart_max = 0
-        days = 0
-        total = 0
-        chart_hz = 440
-        chart_vt = 330
 
-        rf = prefix_raw_open(title, "date")
+def report_cols_end(summary_file=None):
+    msg = """<br clear="all" /></div>"""
+    print(msg)
+    if summary_file:
+        print(msg, file=summary_file)
 
-        sdkeys = sorted(data.keys())
-        start_day = sdkeys[0]
-        end_day = sdkeys[-1]
 
-        for i in sdkeys:
-                days += 1
-                total += data[i]
+def report_col_begin(col, summary_file=None):
+    msg = """<div class="{0}column">""".format(col)
 
-                print(i, data[i], file=rf)
-                if chart_data == "":
-                        chart_data = "{0:d}".format(data[i])
-                else:
-                        chart_data += ",{0:d}".format(data[i])
-                if data[i] > chart_max:
-                        chart_max = data[i]
+    print(msg)
+    if summary_file:
+        print(msg, file=summary_file)
 
-        msg = """\
+
+def report_col_end(col, summary_file=None):
+    msg = """</div> <!-- end class={0}column -->""".format(col)
+
+    print(msg)
+    if summary_file:
+        pprint(msg, file=summary_file)
+
+
+def report_by_date(data, title, summary_file=None):
+    chart_data = ""
+    chart_min = 0
+    chart_max = 0
+    days = 0
+    total = 0
+    chart_hz = 440
+    chart_vt = 330
+
+    rf = prefix_raw_open(title, "date")
+
+    sdkeys = sorted(data.keys())
+    start_day = sdkeys[0]
+    end_day = sdkeys[-1]
+
+    for i in sdkeys:
+        days += 1
+        total += data[i]
+
+        print(i, data[i], file=rf)
+        if chart_data == "":
+            chart_data = "{0:d}".format(data[i])
+        else:
+            chart_data += ",{0:d}".format(data[i])
+        if data[i] > chart_max:
+            chart_max = data[i]
+
+    msg = """\
 <p>
 Total {0} requests: <b>{1:d}</b><br />
 Period: {2} - {3} ({4:d} days)<br />
-Average {5} requests per day: {6:.1f}</p>""".format(title, total, start_day, end_day,
-            days, title, total / days) # old-division; pylint: disable=W1619
+Average {5} requests per day: {6:.1f}</p>""".format(
+        title, total, start_day, end_day, days, title, total / days
+    )  # old-division; pylint: disable=W1619
 
-        ndays = int(str(days))
-        sz = (chart_hz // ndays)
+    ndays = int(str(days))
+    sz = chart_hz // ndays
 
-        url = "cht=lc&chs={0:d}x{1:d}&chg={2:d},{3:d}&chds={4:d},{5:d}&chxt=y,x&chxl=0:|0|{6:d}|1:|{7}|{8}&chd=t:{9}".format(ndays * sz, chart_vt, 7 * sz, 250 * (chart_vt // chart_max, chart_min, chart_max, chart_max, start_day, end_day, chart_data))
+    url = "cht=lc&chs={0:d}x{1:d}&chg={2:d},{3:d}&chds={4:d},{5:d}&chxt=y,x&chxl=0:|0|{6:d}|1:|{7}|{8}&chd=t:{9}".format(
+        ndays * sz,
+        chart_vt,
+        7 * sz,
+        250
+        * (
+            chart_vt // chart_max,
+            chart_min,
+            chart_max,
+            chart_max,
+            start_day,
+            end_day,
+            chart_data,
+        ),
+    )
 
-        fname = retrieve_chart("http://chart.apis.google.com/chart?{0}".format(url),
-            "{0}-date".format(title))
+    fname = retrieve_chart(
+        "http://chart.apis.google.com/chart?{0}".format(url),
+        "{0}-date".format(title),
+    )
 
-        msg += """\
+    msg += """\
 <!-- {0} -->
-<img src=\"{1}\" alt=\"{2}\" /><br />""".format(url, fname, title)
+<img src=\"{1}\" alt=\"{2}\" /><br />""".format(
+        url, fname, title
+    )
 
-        rf.close()
+    rf.close()
 
-        print(msg)
-        if summary_file:
-                print(msg, file=summary_file)
+    print(msg)
+    if summary_file:
+        print(msg, file=summary_file)
 
-def report_by_ip(data, title, summary_file = None):
-        total = 0
-        rf = prefix_raw_open(title, "ip")
 
-        for i, n in (sorted(data.items(), key=lambda k_v: (k_v[1], k_v[0]))):
-                total += n
-                print(n, i, file=rf)
-                #print(n, host_cache_lookup(i))
+def report_by_ip(data, title, summary_file=None):
+    total = 0
+    rf = prefix_raw_open(title, "ip")
 
-        print("<p>Distinct IP addresses: <b>{0:d}</b></p>".format(len(data.keys())))
-        print("<p>Total {0} retrievals: <b>{1:d}</b></p>".format(title, total))
+    for i, n in sorted(data.items(), key=lambda k_v: (k_v[1], k_v[0])):
+        total += n
+        print(n, i, file=rf)
+        # print(n, host_cache_lookup(i))
 
-        rf.close()
+    print("<p>Distinct IP addresses: <b>{0:d}</b></p>".format(len(data.keys())))
+    print("<p>Total {0} retrievals: <b>{1:d}</b></p>".format(title, total))
 
-        if summary_file:
-                print("<p>Distinct IP addresses: <b>{0:d}</b></p>".format(len(data.keys())), file=summary_file)
-                print("<p>Total {0} retrievals: <b>{1:d}</b></p>".format(title, total), file=summary_file)
+    rf.close()
 
-def report_by_country(data, title, summary_file = None):
-        total = 0
-        chart_data = ""
-        chart_ccs = ""
-        chart_max = 0
+    if summary_file:
+        print(
+            "<p>Distinct IP addresses: <b>{0:d}</b></p>".format(
+                len(data.keys())
+            ),
+            file=summary_file,
+        )
+        print(
+            "<p>Total {0} retrievals: <b>{1:d}</b></p>".format(title, total),
+            file=summary_file,
+        )
 
-        for n in data.values():
-                if n > chart_max:
-                        chart_max = n
 
-        chart_max = max(math.log(chart_max), 1)
+def report_by_country(data, title, summary_file=None):
+    total = 0
+    chart_data = ""
+    chart_ccs = ""
+    chart_max = 0
 
-        rf = prefix_raw_open(title, "country")
-        for i, n in (sorted(data.items(), key=lambda k_v: (k_v[1], k_v[0]))):
-                total += n
-                print(n, i, file=rf)
-                if i == None:
-                        continue
+    for n in data.values():
+        if n > chart_max:
+            chart_max = n
 
-                if chart_ccs == "":
-                        chart_ccs = "{0}".format(i)
-                else:
-                        chart_ccs += "{0}".format(i)
+    chart_max = max(math.log(chart_max), 1)
 
-                if chart_data == "":
-                        chart_data += "{0:d}".format(math.log(n) // chart_max * 100)
-                else:
-                        chart_data += ",{0:d}".format(math.log(n) // chart_max * 100)
+    rf = prefix_raw_open(title, "country")
+    for i, n in sorted(data.items(), key=lambda k_v: (k_v[1], k_v[0])):
+        total += n
+        print(n, i, file=rf)
+        if i == None:
+            continue
 
-        rf.close()
+        if chart_ccs == "":
+            chart_ccs = "{0}".format(i)
+        else:
+            chart_ccs += "{0}".format(i)
 
-        # colours from blue flare:  013476 b0d2ff
+        if chart_data == "":
+            chart_data += "{0:d}".format(math.log(n) // chart_max * 100)
+        else:
+            chart_data += ",{0:d}".format(math.log(n) // chart_max * 100)
 
-        map_regions = [ "world", "asia", "europe", "south_america",
-            "middle_east", "africa" ]
+    rf.close()
 
-        msg = """\
+    # colours from blue flare:  013476 b0d2ff
+
+    map_regions = [
+        "world",
+        "asia",
+        "europe",
+        "south_america",
+        "middle_east",
+        "africa",
+    ]
+
+    msg = """\
 <h3>Requests by country</h3>
 <script type="text/javascript">
         var tabView_{0} = new YAHOO.widget.TabView('{1}-country');
 </script>
 <div id="{2}-country" class="yui-navset">
   <ul class="yui-nav">
-""".format(title, title, title)
+""".format(
+        title, title, title
+    )
 
-        sel = "class=\"selected\""
-        for r in map_regions:
-                msg += """<li {0}><a href="#{1}-{2}"><em>{3}</em></a></li>""".format(sel, title, r, r)
-                sel = ""
+    sel = 'class="selected"'
+    for r in map_regions:
+        msg += """<li {0}><a href="#{1}-{2}"><em>{3}</em></a></li>""".format(
+            sel, title, r, r
+        )
+        sel = ""
 
-        msg += """\
+    msg += """\
   </ul>
   <div class="yui-content">"""
 
-        for r in map_regions:
-                url = "chs=440x220&cht=t&chtm={0}&chld={1}&chd=t:{2}&chco=ffffff,b0d2ff,013476".format(r, chart_ccs, chart_data)
-                print("<!-- {0} -->".format(url))
-                fname = retrieve_chart("http://chart.apis.google.com/chart?{0}".format(url),
-                    "{0}-{1}-map".format(title, r))
-                msg += """<div id="{0}-{1}"><img src="{2}" alt="{3}" /></div>""".format(title, r, fname, title)
+    for r in map_regions:
+        url = "chs=440x220&cht=t&chtm={0}&chld={1}&chd=t:{2}&chco=ffffff,b0d2ff,013476".format(
+            r, chart_ccs, chart_data
+        )
+        print("<!-- {0} -->".format(url))
+        fname = retrieve_chart(
+            "http://chart.apis.google.com/chart?{0}".format(url),
+            "{0}-{1}-map".format(title, r),
+        )
+        msg += """<div id="{0}-{1}"><img src="{2}" alt="{3}" /></div>""".format(
+            title, r, fname, title
+        )
 
-        msg += """\
+    msg += """\
   </div>
 </div>
 <small>Color intensity linear in log of requests.</small>"""
 
+    print(msg)
+    if summary_file:
+        print(msg, file=summary_file)
 
-        print(msg)
-        if summary_file:
-                print(msg, file=summary_file)
 
-def report_by_raw_agent(data, title, summary_file = None):
-        rf = prefix_raw_open(title, "country")
-        for i, n in (sorted(data.items(), key=lambda k_v: (k_v[1], k_v[0]))):
-                print(i, n, file=rf)
+def report_by_raw_agent(data, title, summary_file=None):
+    rf = prefix_raw_open(title, "country")
+    for i, n in sorted(data.items(), key=lambda k_v: (k_v[1], k_v[0])):
+        print(i, n, file=rf)
 
-        rf.close()
-
+    rf.close()
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/an_search.py
+++ b/src/util/log-scripts/an_search.py
@@ -51,26 +51,35 @@ search_by_failure = {}
 
 pkg_pat = re.compile(r"/search/(?P<mversion>\d+)/(?P<keywords>.*)")
 
-def emit_search_report(summary_file, searchtype, label, results):
-        print("<pre>")
-        for i, n in results:
-                print(i, n)
-        print("</pre>")
 
-        if summary_file:
-                print("""
+def emit_search_report(summary_file, searchtype, label, results):
+    print("<pre>")
+    for i, n in results:
+        print(i, n)
+    print("</pre>")
+
+    if summary_file:
+        print(
+            """
                         <h3>Top 25 {searchtype} searches</h3>
                         <div id="search-{searchtype}-container">
                         <table id="search-{searchtype}-table">
                         <thead><tr><th>Term</th><th>{label}</th></tr></thead>
-                """.format(label=label, searchtype=searchtype), file=summary_file)
+                """.format(
+                label=label, searchtype=searchtype
+            ),
+            file=summary_file,
+        )
 
-                for i, n in results[:25]:
-                        print("<tr><td>{0}</td><td>{1}</td></tr>".format(i, n),
-                file=summary_file)
+        for i, n in results[:25]:
+            print(
+                "<tr><td>{0}</td><td>{1}</td></tr>".format(i, n),
+                file=summary_file,
+            )
 
-                print("</table></div>", file=summary_file)
-                print("""
+        print("</table></div>", file=summary_file)
+        print(
+            """
 <script type="text/javascript">
         var myDataSource =
             new YAHOO.util.DataSource(YAHOO.util.Dom.get(
@@ -92,90 +101,100 @@ def emit_search_report(summary_file, searchtype, label, results):
             myColumnDefs, myDataSource,
             {sortedBy:{key:"{label}", dir:YAHOO.widget.DataTable.CLASS_DESC}});
 </script>
-                """.format(label=label, searchtype=searchtype), file=summary_file)
-
+                """.format(
+                label=label, searchtype=searchtype
+            ),
+            file=summary_file,
+        )
 
 
 def report_search_by_failure():
-        sfi = sorted(search_by_failure.items(), reverse=True, key=lambda k_v: (k_v[1],k_v[0]))
-        emit_search_report(summary_file, "failed", "Misses", sfi)
+    sfi = sorted(
+        search_by_failure.items(),
+        reverse=True,
+        key=lambda k_v: (k_v[1], k_v[0]),
+    )
+    emit_search_report(summary_file, "failed", "Misses", sfi)
 
 
 def report_search_by_success():
-        ssi = sorted(search_by_success.items(), reverse=True, key=lambda k_v1: (k_v1[1],k_v1[0]))
-        emit_search_report(summary_file, "successful", "Hits", ssi)
+    ssi = sorted(
+        search_by_success.items(),
+        reverse=True,
+        key=lambda k_v1: (k_v1[1], k_v1[0]),
+    )
+    emit_search_report(summary_file, "successful", "Hits", ssi)
 
 
 def count_search(mg, d):
-        try:
-                search_by_date[d.date().isoformat()] += 1
-        except KeyError:
-                search_by_date[d.date().isoformat()] = 1
-        try:
-                search_by_ip[mg["ip"]] += 1
-        except KeyError:
-                search_by_ip[mg["ip"]] = 1
+    try:
+        search_by_date[d.date().isoformat()] += 1
+    except KeyError:
+        search_by_date[d.date().isoformat()] = 1
+    try:
+        search_by_ip[mg["ip"]] += 1
+    except KeyError:
+        search_by_ip[mg["ip"]] = 1
 
+    pm = pkg_pat.search(mg["uri"])
+    if pm != None:
+        pg = pm.groupdict()
 
-        pm = pkg_pat.search(mg["uri"])
-        if pm != None:
-                pg = pm.groupdict()
+        kw = unquote(pg["keywords"])
 
-                kw = unquote(pg["keywords"])
+        if mg["response"] == "200":
+            if mg["subcode"] == "-":
+                # A zero-length response is a failed search
+                # (4 Aug - ...).  Consequence of the migration
+                # to CherryPy; will be unneeded once
+                # http://defect.opensolaris.org/bz/show_bug.cgi?id=3238
+                # is fixed.
+                try:
+                    search_by_failure[kw] += 1
+                except KeyError:
+                    search_by_failure[kw] = 1
+            else:
+                try:
+                    search_by_success[kw] += 1
+                except KeyError:
+                    search_by_success[kw] = 1
+        elif mg["response"] == "404":
+            try:
+                search_by_failure[kw] += 1
+            except KeyError:
+                search_by_failure[kw] = 1
 
-                if mg["response"] == "200":
-                        if mg["subcode"] == "-":
-                                # A zero-length response is a failed search
-                                # (4 Aug - ...).  Consequence of the migration
-                                # to CherryPy; will be unneeded once
-                                # http://defect.opensolaris.org/bz/show_bug.cgi?id=3238
-                                # is fixed.
-                                try:
-                                        search_by_failure[kw] += 1
-                                except KeyError:
-                                        search_by_failure[kw] = 1
-                        else:
-                                try:
-                                        search_by_success[kw] += 1
-                                except KeyError:
-                                        search_by_success[kw] = 1
-                elif mg["response"] == "404":
-                        try:
-                                search_by_failure[kw] += 1
-                        except KeyError:
-                                search_by_failure[kw] = 1
+        # XXX should measure downtime via 503, other failure responses
 
-                # XXX should measure downtime via 503, other failure responses
+    agent = pkg_agent_pat.search(mg["agent"])
+    if agent == None:
+        return
 
+    ag = agent.groupdict()
 
-        agent = pkg_agent_pat.search(mg["agent"])
-        if agent == None:
-                return
+    try:
+        search_by_arch[ag["arch"]] += 1
+    except KeyError:
+        search_by_arch[ag["arch"]] = 1
 
-        ag = agent.groupdict()
-
-        try:
-                search_by_arch[ag["arch"]] += 1
-        except KeyError:
-                search_by_arch[ag["arch"]] = 1
 
 opts, args = getopt.getopt(sys.argv[1:], "a:b:sw:")
 
 for opt, arg in opts:
-        if opt == "-a":
-                try:
-                        after = datetime.datetime(*(time.strptime(arg, "%Y-%b-%d")[0:6]))
-                except ValueError:
-                        after = datetime.datetime(*(time.strptime(arg, "%Y-%m-%d")[0:6]))
+    if opt == "-a":
+        try:
+            after = datetime.datetime(*(time.strptime(arg, "%Y-%b-%d")[0:6]))
+        except ValueError:
+            after = datetime.datetime(*(time.strptime(arg, "%Y-%m-%d")[0:6]))
 
-        if opt == "-b":
-                before = arg
+    if opt == "-b":
+        before = arg
 
-        if opt == "-s":
-                summary_file = prefix_summary_open("search")
+    if opt == "-s":
+        summary_file = prefix_summary_open("search")
 
-        if opt == "-w":
-                active_window = arg
+    if opt == "-w":
+        active_window = arg
 
 host_cache_set_file_name()
 host_cache_load()
@@ -184,49 +203,49 @@ lastdate = None
 lastdatetime = None
 
 for l in fileinput.input(args):
-        m = comb_log_pat.search(l)
-        if not m:
-                continue
+    m = comb_log_pat.search(l)
+    if not m:
+        continue
 
-        mg = m.groupdict()
+    mg = m.groupdict()
 
-        d = None
+    d = None
 
-        if lastdatetime and mg["date"] == lastdate:
-                d = lastdatetime
-        else:
-                d = datetime.datetime(*(time.strptime(mg["date"], "%d/%b/%Y")[0:6]))
-                lastdate = mg["date"]
-                lastdatetime = d
+    if lastdatetime and mg["date"] == lastdate:
+        d = lastdatetime
+    else:
+        d = datetime.datetime(*(time.strptime(mg["date"], "%d/%b/%Y")[0:6]))
+        lastdate = mg["date"]
+        lastdatetime = d
 
-        if after and d < after:
-                continue
+    if after and d < after:
+        continue
 
-        count_search(mg, d)
+    count_search(mg, d)
 
 host_cache_save()
 search_by_country = ip_to_country(search_by_ip)
 
-report_section_begin("Search", summary_file = summary_file)
-report_cols_begin(summary_file = summary_file)
-report_col_begin("l", summary_file = summary_file)
-report_by_date(search_by_date, "search", summary_file = summary_file)
-report_by_ip(search_by_ip, "search", summary_file = summary_file)
-report_col_end("l", summary_file = summary_file)
-report_col_begin("r", summary_file = summary_file)
-report_by_country(search_by_country, "search", summary_file = summary_file)
-report_col_end("r", summary_file = summary_file)
-report_cols_end(summary_file = summary_file)
+report_section_begin("Search", summary_file=summary_file)
+report_cols_begin(summary_file=summary_file)
+report_col_begin("l", summary_file=summary_file)
+report_by_date(search_by_date, "search", summary_file=summary_file)
+report_by_ip(search_by_ip, "search", summary_file=summary_file)
+report_col_end("l", summary_file=summary_file)
+report_col_begin("r", summary_file=summary_file)
+report_by_country(search_by_country, "search", summary_file=summary_file)
+report_col_end("r", summary_file=summary_file)
+report_cols_end(summary_file=summary_file)
 
-report_cols_begin(summary_file = summary_file)
-report_col_begin("l", summary_file = summary_file)
+report_cols_begin(summary_file=summary_file)
+report_col_begin("l", summary_file=summary_file)
 report_search_by_failure()
-report_col_end("l", summary_file = summary_file)
-report_col_begin("r", summary_file = summary_file)
+report_col_end("l", summary_file=summary_file)
+report_col_begin("r", summary_file=summary_file)
 report_search_by_success()
-report_col_end("r", summary_file = summary_file)
-report_cols_end(summary_file = summary_file)
-report_section_end(summary_file = summary_file)
+report_col_end("r", summary_file=summary_file)
+report_cols_end(summary_file=summary_file)
+report_section_end(summary_file=summary_file)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/config.py
+++ b/src/util/log-scripts/config.py
@@ -27,15 +27,17 @@
 import os
 from six.moves import configparser
 
-CFGFILE="site-config"
+CFGFILE = "site-config"
+
 
 def get(option, default=None):
-        cfg = configparser.ConfigParser()
-        cfg.read(CFGFILE)
-        value = cfg.get("default", option)
-        if not value:
-                return default
-        return value
+    cfg = configparser.ConfigParser()
+    cfg.read(CFGFILE)
+    value = cfg.get("default", option)
+    if not value:
+        return default
+    return value
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/in_footer.py
+++ b/src/util/log-scripts/in_footer.py
@@ -34,4 +34,4 @@ footer = """
 print(footer)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/in_header.py
+++ b/src/util/log-scripts/in_header.py
@@ -111,9 +111,11 @@ header = """
 	</head>
 	<body class="yui-skin-sam">
 	<h1><img src="http://{0}/logo" alt="{1}"/> {2} Statistics</h1>
-""".format(hostname, hostname, hostname)
+""".format(
+    hostname, hostname, hostname
+)
 
 print(header)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/log.py
+++ b/src/util/log-scripts/log.py
@@ -26,7 +26,9 @@
 
 from __future__ import division
 from __future__ import print_function
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 import os
 import getopt
 import re
@@ -44,91 +46,96 @@ hosts = {}
 
 
 def process(l):
-        """Process one Apache common log line."""
-        ex = r"([\d\.]*) - - \[([^\]]*)\] \"([A-Z]*) (.*) HTTP/1\..\" (\d\d\d) (\d*)"
-        m = re.match(ex, l)
+    """Process one Apache common log line."""
+    ex = (
+        r"([\d\.]*) - - \[([^\]]*)\] \"([A-Z]*) (.*) HTTP/1\..\" (\d\d\d) (\d*)"
+    )
+    m = re.match(ex, l)
 
-        totals["dl"] += int(m.group(6))
-        hosts[m.group(1)] = 1
+    totals["dl"] += int(m.group(6))
+    hosts[m.group(1)] = 1
 
-        if m.group(5) == "200":
-                try:
-                        codes_200[m.group(1)].append(int(m.group(6)))
-                except KeyError:
-                        codes_200[m.group(1)] = [ int(m.group(6)) ]
+    if m.group(5) == "200":
+        try:
+            codes_200[m.group(1)].append(int(m.group(6)))
+        except KeyError:
+            codes_200[m.group(1)] = [int(m.group(6))]
 
-        elif m.group(5) == "206":
-                try:
-                        codes_206[m.group(1)].append(int(m.group(6)))
-                except KeyError:
-                        codes_206[m.group(1)] = [ int(m.group(6)) ]
+    elif m.group(5) == "206":
+        try:
+            codes_206[m.group(1)].append(int(m.group(6)))
+        except KeyError:
+            codes_206[m.group(1)] = [int(m.group(6))]
 
-        else:
-                try:
-                        codes_other[m.group(1)].append(m.group(5))
-                except KeyError:
-                        codes_other[m.group(1)] = [m.group(5)]
+    else:
+        try:
+            codes_other[m.group(1)].append(m.group(5))
+        except KeyError:
+            codes_other[m.group(1)] = [m.group(5)]
+
 
 def dlunits(codes, size):
-        n = 0
+    n = 0
 
-        for k in codes.keys():
-                if sum(codes[k]) >= size:
-                        n +=1
+    for k in codes.keys():
+        if sum(codes[k]) >= size:
+            n += 1
 
-        return n
+    return n
+
 
 def dls_linked(codes_200, codes_206, size):
-        linked = 0
-        for k in codes_206.keys():
-                if k in codes_200.keys():
-                        total = sum(codes_200[k]) + sum(codes_206[k])
-                        if total > size:
-                                linked += total//size
+    linked = 0
+    for k in codes_206.keys():
+        if k in codes_200.keys():
+            total = sum(codes_200[k]) + sum(codes_206[k])
+            if total > size:
+                linked += total // size
 
-                        if total > 10 * size:
-                                try:
-                                        host = socket.gethostbyaddr(k)[0],
-                                        print(host)
-                                except:
-                                        pass
+            if total > 10 * size:
+                try:
+                    host = (socket.gethostbyaddr(k)[0],)
+                    print(host)
+                except:
+                    pass
 
-        return linked
+    return linked
+
 
 if __name__ == "__main__":
-        opts, pargs = getopt.getopt(sys.argv[1:], "f:s:")
+    opts, pargs = getopt.getopt(sys.argv[1:], "f:s:")
 
-        size = None
-        fname = None
+    size = None
+    fname = None
 
-        for opt, arg in opts:
-                if opt == "-f":
-                        fname = arg
-                if opt == "-s":
-                        size = int(arg)
+    for opt, arg in opts:
+        if opt == "-f":
+            fname = arg
+        if opt == "-s":
+            size = int(arg)
 
-        assert not fname == None
+    assert not fname == None
 
-        lg = open(fname)
+    lg = open(fname)
 
-        for l in lg.readlines():
-                process(l)
+    for l in lg.readlines():
+        process(l)
 
-        print("distinct hosts:  {0:d}".format(len(hosts.keys())))
-        print("200 requests:  {0:d}".format(len(codes_200.keys())))
-        print("206 requests:  {0:d}".format(len(codes_206.keys())))
-        print("other requests:  {0:d}".format(len(codes_other.keys())))
+    print("distinct hosts:  {0:d}".format(len(hosts.keys())))
+    print("200 requests:  {0:d}".format(len(codes_200.keys())))
+    print("206 requests:  {0:d}".format(len(codes_206.keys())))
+    print("other requests:  {0:d}".format(len(codes_other.keys())))
 
-        if not size:
-                sys.exit(0)
+    if not size:
+        sys.exit(0)
 
-        print("200 units: {0:d}".format(dlunits(codes_200, size)))
-        print("206 units: {0:d}".format(dlunits(codes_206, size)))
+    print("200 units: {0:d}".format(dlunits(codes_200, size)))
+    print("206 units: {0:d}".format(dlunits(codes_206, size)))
 
-        print("linked units: {0:d}".format(dls_linked(codes_200, codes_206, size)))
+    print("linked units: {0:d}".format(dls_linked(codes_200, codes_206, size)))
 
-        print("total units: {0:d}".format(totals["dl"] // size))
+    print("total units: {0:d}".format(totals["dl"] // size))
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/log-scripts/translate.py
+++ b/src/util/log-scripts/translate.py
@@ -37,68 +37,68 @@ import time
 # 1.2.3.4 - - [12/Aug/2008:19:21:28 -0700] "GET /manifest/0/SUNWkos@0.5.11%2C5.11-0.94%3A20080721T212150Z HTTP/1.1" 200 19748 "-" "pkg/d974bb176266 (sunos i86pc; 5.11 snv_86; full)"
 
 if len(sys.argv) != 3:
-        print("Usage: {0} <in file> <out file>".format(sys.argv[0]))
-        sys.exit(2)
+    print("Usage: {0} <in file> <out file>".format(sys.argv[0]))
+    sys.exit(2)
 
 infile = open(sys.argv[1], "r")
 outfile = open(sys.argv[2], "w")
 
 gi = GeoIP.new(GeoIP.GEOIP_MEMORY_CACHE)
 
-ops = ["1p.png", "filelist", "catalog", "manifest", "search", "file"] 
+ops = ["1p.png", "filelist", "catalog", "manifest", "search", "file"]
 
 cnt = {}
 for x in ops:
-        cnt[x] = 0
+    cnt[x] = 0
 
 while True:
-        line = infile.readline()
-        if len(line) == 0: # EOF
-                break
+    line = infile.readline()
+    if len(line) == 0:  # EOF
+        break
 
-        #print("line: [{0}]".format(line))
+    # print("line: [{0}]".format(line))
 
-        fields = line.split()
-        (ip, d, fullop) = (fields[0], fields[3], fields[6])
-        del fields
+    fields = line.split()
+    (ip, d, fullop) = (fields[0], fields[3], fields[6])
+    del fields
 
-        # Get country code and translate ip -> md5 of ip
-        cc = gi.country_code_by_addr(ip)
-        ip = md5.md5(ip)
-        ip = ip.hexdigest()
+    # Get country code and translate ip -> md5 of ip
+    cc = gi.country_code_by_addr(ip)
+    ip = md5.md5(ip)
+    ip = ip.hexdigest()
 
-        # Goofy date -> UTS
-        d = time.mktime(time.strptime(d[1:], "%d/%b/%Y:%H:%M:%S"))
-        d = str(d).split(".")[0]
+    # Goofy date -> UTS
+    d = time.mktime(time.strptime(d[1:], "%d/%b/%Y:%H:%M:%S"))
+    d = str(d).split(".")[0]
 
-        # Figure out op and opargs
-        opflds = fullop.split("/")
-        op = opflds[1]
-        if "1p.png" in op:
-                op = op[0:op.find("?")]
-        if op not in ops:
-                continue
-        # only interested in catalog/0 operations
-        if op == "catalog" and opflds[2] != "0":
-                continue
-        opargs = ""
-        if op == "search":
-                opargs = "/".join(opflds[3:])
-        if op == "file":
-                opargs = opflds[3]
+    # Figure out op and opargs
+    opflds = fullop.split("/")
+    op = opflds[1]
+    if "1p.png" in op:
+        op = op[0 : op.find("?")]
+    if op not in ops:
+        continue
+    # only interested in catalog/0 operations
+    if op == "catalog" and opflds[2] != "0":
+        continue
+    opargs = ""
+    if op == "search":
+        opargs = "/".join(opflds[3:])
+    if op == "file":
+        opargs = opflds[3]
 
-        # TODO: also need to grab size
+    # TODO: also need to grab size
 
-        cnt[op] += 1
+    cnt[op] += 1
 
-        print("{0} {1} {2} {3} {4}".format(ip, cc, d, op, opargs), file=outfile)
+    print("{0} {1} {2} {3} {4}".format(ip, cc, d, op, opargs), file=outfile)
 
 infile.close()
 outfile.close()
 
 for x in ops:
-        print("# {0}: {1:d}".format(x, cnt[x]))
+    print("# {0}: {1:d}".format(x, cnt[x]))
 
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/publish/pkgdiff.py
+++ b/src/util/publish/pkgdiff.py
@@ -25,7 +25,9 @@
 #
 
 from __future__ import print_function
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 import getopt
 import gettext
 import locale
@@ -45,354 +47,392 @@ from collections import defaultdict
 from itertools import product
 from pkg.client.pkgdefs import EXIT_OK, EXIT_OOPS, EXIT_BADOPT, EXIT_PARTIAL
 
+
 def usage(errmsg="", exitcode=EXIT_BADOPT):
-        """Emit a usage message and optionally prefix it with a more specific
-        error message.  Causes program to exit."""
+    """Emit a usage message and optionally prefix it with a more specific
+    error message.  Causes program to exit."""
 
-        if errmsg:
-                print("pkgdiff: {0}".format(errmsg), file=sys.stderr)
+    if errmsg:
+        print("pkgdiff: {0}".format(errmsg), file=sys.stderr)
 
-        print(_("""\
+    print(
+        _(
+            """\
 Usage:
         pkgdiff [-i attribute]... [-o attribute]
             [-t action_name[,action_name]...]...
-            [-v name=value]... (file1 | -) (file2 | -)"""))
-        sys.exit(exitcode)
+            [-v name=value]... (file1 | -) (file2 | -)"""
+        )
+    )
+    sys.exit(exitcode)
+
 
 def error(text, exitcode=EXIT_PARTIAL):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        print("pkgdiff: {0}".format(text), file=sys.stderr)
+    print("pkgdiff: {0}".format(text), file=sys.stderr)
 
-        if exitcode != None:
-                sys.exit(exitcode)
+    if exitcode != None:
+        sys.exit(exitcode)
+
 
 def main_func():
+    ignoreattrs = []
+    onlyattrs = []
+    onlytypes = []
+    varattrs = defaultdict(set)
+    cmp_policy = CMP_ALL
 
-        ignoreattrs = []
-        onlyattrs = []
-        onlytypes = []
-        varattrs = defaultdict(set)
-        cmp_policy = CMP_ALL
+    try:
+        opts, pargs = getopt.getopt(sys.argv[1:], "i:o:t:uv:?", ["help"])
+        for opt, arg in opts:
+            if opt == "-i":
+                ignoreattrs.append("timestamp")
+                ignoreattrs.append(arg)
+                if arg == "hash":
+                    ignoreattrs.extend(
+                        ["chash", "pkg.content-hash", "elfhash", "timestamp"]
+                    )
+                if arg == "size":
+                    ignoreattrs.extend(["pkg.csize", "pkg.size"])
+            elif opt == "-o":
+                onlyattrs.append(arg)
+            elif opt == "-t":
+                onlytypes.extend(arg.split(","))
+            elif opt == "-u":
+                cmp_policy = CMP_UNSIGNED
+            elif opt == "-v":
+                args = arg.split("=")
+                if len(args) != 2:
+                    usage(_("variant option incorrect {0}").format(arg))
+                if not args[0].startswith("variant."):
+                    args[0] = "variant." + args[0]
+                varattrs[args[0]].add(args[1])
+            elif opt in ("--help", "-?"):
+                usage(exitcode=EXIT_OK)
 
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "i:o:t:uv:?", ["help"])
-                for opt, arg in opts:
-                        if opt == "-i":
-                                ignoreattrs.append('timestamp')
-                                ignoreattrs.append(arg)
-                                if arg == 'hash':
-                                        ignoreattrs.extend([
-                                            'chash', 'pkg.content-hash',
-                                            'elfhash', 'timestamp'])
-                                if arg == 'size':
-                                        ignoreattrs.extend([
-                                            'pkg.csize', 'pkg.size'])
-                        elif opt == "-o":
-                                onlyattrs.append(arg)
-                        elif opt == "-t":
-                                onlytypes.extend(arg.split(","))
-                        elif opt == "-u":
-                                cmp_policy = CMP_UNSIGNED
-                        elif opt == "-v":
-                                args = arg.split("=")
-                                if len(args) != 2:
-                                        usage(_("variant option incorrect {0}").format(
-                                            arg))
-                                if not args[0].startswith("variant."):
-                                        args[0] = "variant." + args[0]
-                                varattrs[args[0]].add(args[1])
-                        elif opt in ("--help", "-?"):
-                                usage(exitcode=EXIT_OK)
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
 
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
+    if len(pargs) != 2:
+        usage(_("two manifest arguments are required"))
 
-        if len(pargs) != 2:
-                usage(_("two manifest arguments are required"))
+    if pargs[0] == "-" and pargs[1] == "-":
+        usage(_("only one manifest argument can be stdin"))
 
-        if (pargs[0] == "-" and pargs[1] == "-"):
-                usage(_("only one manifest argument can be stdin"))
+    if ignoreattrs and onlyattrs:
+        usage(_("-i and -o options may not be used at the same time."))
 
-        if ignoreattrs and onlyattrs:
-                usage(_("-i and -o options may not be used at the same time."))
+    for v in varattrs:
+        if len(varattrs[v]) > 1:
+            usage(_("For any variant, only one value may be " "specified."))
+        varattrs[v] = varattrs[v].pop()
 
-        for v in varattrs:
-                if len(varattrs[v]) > 1:
-                        usage(_("For any variant, only one value may be "
-                            "specified."))
-                varattrs[v] = varattrs[v].pop()
+    ignoreattrs = set(ignoreattrs)
+    onlyattrs = set(onlyattrs)
+    onlytypes = set(onlytypes)
 
-        ignoreattrs = set(ignoreattrs)
-        onlyattrs = set(onlyattrs)
-        onlytypes = set(onlytypes)
+    utypes = set(
+        t for t in onlytypes if t == "generic" or t not in pkg.actions.types
+    )
 
-        utypes = set(
-            t
-            for t in onlytypes
-            if t == "generic" or t not in pkg.actions.types
+    if utypes:
+        usage(
+            _(
+                "unknown action types: {0}".format(
+                    apx.list_to_lang(list(utypes))
+                )
+            )
         )
 
-        if utypes:
-                usage(_("unknown action types: {0}".format(
-                    apx.list_to_lang(list(utypes)))))
+    manifest1 = manifest.Manifest()
+    manifest2 = manifest.Manifest()
+    try:
+        # This assumes that both pargs are not '-'.
+        for p, m in zip(pargs, (manifest1, manifest2)):
+            if p == "-":
+                m.set_content(content=sys.stdin.read())
+            else:
+                m.set_content(pathname=p)
+    except (pkg.actions.ActionError, apx.InvalidPackageErrors) as e:
+        error(_("Action error in file {p}: {e}").format(**locals()))
+    except (EnvironmentError, apx.ApiException) as e:
+        error(e)
 
-        manifest1 = manifest.Manifest()
-        manifest2 = manifest.Manifest()
-        try:
-                # This assumes that both pargs are not '-'.
-                for p, m in zip(pargs, (manifest1, manifest2)):
-                        if p == "-":
-                                m.set_content(content=sys.stdin.read())
-                        else:
-                                m.set_content(pathname=p)
-        except (pkg.actions.ActionError, apx.InvalidPackageErrors) as e:
-                error(_("Action error in file {p}: {e}").format(**locals()))
-        except (EnvironmentError, apx.ApiException) as e:
-                error(e)
+    #
+    # manifest filtering
+    #
 
-        #
-        # manifest filtering
-        #
+    # filter action type
+    if onlytypes:
+        for m in (manifest1, manifest2):
+            # Must pass complete list of actions to set_content, not
+            # a generator, to avoid clobbering manifest contents.
+            m.set_content(content=list(m.gen_actions_by_types(onlytypes)))
 
-        # filter action type
-        if onlytypes:
-                for m in (manifest1, manifest2):
-                        # Must pass complete list of actions to set_content, not
-                        # a generator, to avoid clobbering manifest contents.
-                        m.set_content(content=list(m.gen_actions_by_types(
-                            onlytypes)))
+    # filter variant
+    v1 = manifest1.get_all_variants()
+    v2 = manifest2.get_all_variants()
+    for vname in varattrs:
+        for _path, v, m in zip(pargs, (v1, v2), (manifest1, manifest2)):
+            if vname not in v:
+                continue
+            filt = varattrs[vname]
+            if filt not in v[vname]:
+                usage(
+                    _(
+                        "Manifest {path} doesn't support "
+                        "variant {vname}={filt}".format(**locals())
+                    )
+                )
 
-        # filter variant
+            # remove the variant tag
+            def rip(a):
+                a.attrs.pop(vname, None)
+                return a
+
+            m.set_content(
+                [
+                    rip(a)
+                    for a in m.gen_actions(
+                        excludes=[variant.Variants({vname: filt}).allow_action]
+                    )
+                ]
+            )
+            m[vname] = filt
+
+    if varattrs:
+        # need to rebuild these if we're filtering variants
         v1 = manifest1.get_all_variants()
         v2 = manifest2.get_all_variants()
-        for vname in varattrs:
-                for _path, v, m in zip(pargs, (v1, v2), (manifest1, manifest2)):
-                        if vname not in v:
-                                continue
-                        filt = varattrs[vname]
-                        if filt not in v[vname]:
-                                usage(_("Manifest {path} doesn't support "
-                                    "variant {vname}={filt}".format(**locals())))
-                        # remove the variant tag
-                        def rip(a):
-                                a.attrs.pop(vname, None)
-                                return a
-                        m.set_content([
-                            rip(a)
-                            for a in m.gen_actions(excludes=[
-                            variant.Variants({vname: filt}).allow_action])
-                        ])
-                        m[vname] = filt
 
-        if varattrs:
-                # need to rebuild these if we're filtering variants
-                v1 = manifest1.get_all_variants()
-                v2 = manifest2.get_all_variants()
+    # we need to be a little clever about variants, since
+    # we can have multiple actions w/ the same key attributes
+    # in each manifest in that case.  First, make sure any variants
+    # of the same name have the same values defined.
+    for k in set(v1.keys()) & set(v2.keys()):
+        if v1[k] != v2[k]:
+            error(
+                _("Manifests support different variants " "{v1} {v2}").format(
+                    v1=v1, v2=v2
+                )
+            )
 
-        # we need to be a little clever about variants, since
-        # we can have multiple actions w/ the same key attributes
-        # in each manifest in that case.  First, make sure any variants
-        # of the same name have the same values defined.
-        for k in set(v1.keys()) & set(v2.keys()):
-                if v1[k] != v2[k]:
-                        error(_("Manifests support different variants "
-                            "{v1} {v2}").format(v1=v1, v2=v2))
+    # Now, get a list of all possible variant values, including None
+    # across all variants and both manifests
+    v_values = dict()
 
-        # Now, get a list of all possible variant values, including None
-        # across all variants and both manifests
-        v_values = dict()
+    for v in v1:
+        v1[v].add(None)
+        for a in v1[v]:
+            v_values.setdefault(v, set()).add((v, a))
 
-        for v in v1:
-                v1[v].add(None)
-                for a in v1[v]:
-                        v_values.setdefault(v, set()).add((v, a))
+    for v in v2:
+        v2[v].add(None)
+        for a in v2[v]:
+            v_values.setdefault(v, set()).add((v, a))
 
-        for v in v2:
-                v2[v].add(None)
-                for a in v2[v]:
-                        v_values.setdefault(v, set()).add((v, a))
+    diffs = []
 
-        diffs = []
+    for tup in product(*v_values.values()):
+        # build excludes closure to examine only actions exactly
+        # matching current variant values... this is needed to
+        # avoid confusing manifest difference code w/ multiple
+        # actions w/ same key attribute values or getting dups
+        # in output
+        def allow(a, publisher=None):
+            for k, v in tup:
+                if v is not None:
+                    if k not in a.attrs or a.attrs[k] != v:
+                        return False
+                elif k in a.attrs:
+                    return False
+            return True
 
-        for tup in product(*v_values.values()):
-                # build excludes closure to examine only actions exactly
-                # matching current variant values... this is needed to
-                # avoid confusing manifest difference code w/ multiple
-                # actions w/ same key attribute values or getting dups
-                # in output
-                def allow(a, publisher=None):
-                        for k, v in tup:
-                                if v is not None:
-                                        if k not in a.attrs or a.attrs[k] != v:
-                                                return False
-                                elif k in a.attrs:
-                                        return False
-                        return True
+        a, c, r = manifest2.difference(
+            manifest1, [allow], [allow], cmp_policy=cmp_policy
+        )
+        diffs += a
+        diffs += c
+        diffs += r
 
-                a, c, r = manifest2.difference(manifest1, [allow], [allow],
-                    cmp_policy=cmp_policy)
-                diffs += a
-                diffs += c
-                diffs += r
+    # License action still causes spurious diffs... check again for now.
+    real_diffs = [
+        (a, b)
+        for a, b in diffs
+        if a is None or b is None or a.different(b, cmp_policy=cmp_policy)
+    ]
 
-        # License action still causes spurious diffs... check again for now.
-        real_diffs = [
-            (a, b)
-            for a, b in diffs
-            if a is None or b is None or a.different(b, cmp_policy=cmp_policy)
-        ]
+    if not real_diffs:
+        return 0
 
-        if not real_diffs:
-                return 0
+    # define some ordering functions so that output is easily readable
+    # First, a human version of action comparison that works across
+    # variants and action changes...
+    def compare(a, b):
+        # pull the relevant action out of the old value, new
+        # value tuples
+        a = a[0] if a[0] else a[1]
+        b = b[0] if b[0] else b[1]
 
-        # define some ordering functions so that output is easily readable
-        # First, a human version of action comparison that works across
-        # variants and action changes...
-        def compare(a, b):
-                # pull the relevant action out of the old value, new
-                # value tuples
-                a = a[0] if a[0] else a[1]
-                b = b[0] if b[0] else b[1]
+        if (
+            hasattr(a, "key_attr")
+            and hasattr(b, "key_attr")
+            and a.key_attr == b.key_attr
+        ):
+            res = misc.cmp(a.attrs[a.key_attr], b.attrs[b.key_attr])
+            if res != NotImplemented:
+                return res
+            # sort by variant
+            res = misc.cmp(
+                sorted(list(a.get_variant_template())),
+                sorted(list(b.get_variant_template())),
+            )
+            if res != NotImplemented:
+                return res
+        else:
+            res = misc.cmp(a.ordinality, b.ordinality)
+            if res != NotImplemented:
+                return res
+        # Fall back to a simple string compare if we have
+        # differing types (indicated by the above NotImplemented
+        # return values.
+        return misc.cmp(str(a), str(b))
 
-                if hasattr(a, "key_attr") and hasattr(b, "key_attr") and \
-                    a.key_attr == b.key_attr:
-                        res = misc.cmp(a.attrs[a.key_attr], b.attrs[b.key_attr])
-                        if res != NotImplemented:
-                                return res
-                        # sort by variant
-                        res = misc.cmp(sorted(list(a.get_variant_template())),
-                            sorted(list(b.get_variant_template())))
-                        if res != NotImplemented:
-                                return res
+    # sort and....
+    diffs = sorted(diffs, key=cmp_to_key(compare))
+
+    # handle list attributes
+    def attrval(attrs, k, elide_iter=tuple()):
+        def q(s):
+            if " " in s or s == "":
+                return '"{0}"'.format(s)
+            else:
+                return s
+
+        v = attrs[k]
+        if isinstance(v, list) or isinstance(v, set):
+            out = " ".join(
+                [
+                    "{0}={1}".format(k, q(lmt))
+                    for lmt in sorted(v)
+                    if lmt not in elide_iter
+                ]
+            )
+        elif " " in v or v == "":
+            out = k + '="' + v + '"'
+        else:
+            out = k + "=" + v
+        return out
+
+    # figure out when to print diffs
+    def conditional_print(s, a):
+        if onlyattrs:
+            if not set(a.attrs.keys()) & onlyattrs:
+                return False
+        elif ignoreattrs:
+            if not set(a.attrs.keys()) - ignoreattrs:
+                return False
+
+        print("{0} {1}".format(s, a))
+        return True
+
+    different = False
+
+    for old, new in diffs:
+        if not new:
+            different |= conditional_print("-", old)
+        elif not old:
+            different |= conditional_print("+", new)
+        else:
+            s = []
+
+            if not onlyattrs:
+                if hasattr(old, "hash") and "hash" not in ignoreattrs:
+                    if old.hash != new.hash:
+                        s.append("  - {0}".format(old.hash))
+                        s.append("  + {0}".format(new.hash))
+                attrdiffs = set(new.differences(old)) - ignoreattrs
+                attrsames = sorted(
+                    list(
+                        set(list(old.attrs.keys()) + list(new.attrs.keys()))
+                        - set(new.differences(old))
+                    )
+                )
+            else:
+                if hasattr(old, "hash") and "hash" in onlyattrs:
+                    if old.hash != new.hash:
+                        s.append("  - {0}".format(old.hash))
+                        s.append("  + {0}".format(new.hash))
+                attrdiffs = set(new.differences(old)) & onlyattrs
+                attrsames = sorted(
+                    list(
+                        set(list(old.attrs.keys()) + list(new.attrs.keys()))
+                        - set(new.differences(old))
+                    )
+                )
+
+            for a in sorted(attrdiffs):
+                if (
+                    a in old.attrs
+                    and a in new.attrs
+                    and isinstance(old.attrs[a], list)
+                    and isinstance(new.attrs[a], list)
+                ):
+                    elide_set = set(old.attrs[a]) & set(new.attrs[a])
                 else:
-                        res = misc.cmp(a.ordinality, b.ordinality)
-                        if res != NotImplemented:
-                                return res
-                # Fall back to a simple string compare if we have
-                # differing types (indicated by the above NotImplemented
-                # return values.
-                return misc.cmp(str(a), str(b))
+                    elide_set = set()
+                if a in old.attrs:
+                    diff_str = attrval(old.attrs, a, elide_iter=elide_set)
+                    if diff_str:
+                        s.append("  - {0}".format(diff_str))
+                if a in new.attrs:
+                    diff_str = attrval(new.attrs, a, elide_iter=elide_set)
+                    if diff_str:
+                        s.append("  + {0}".format(diff_str))
+            # print out part of action that is the same
+            if s:
+                different = True
+                print(
+                    "{0} {1} {2}".format(
+                        old.name,
+                        attrval(old.attrs, old.key_attr),
+                        " ".join(
+                            (
+                                "{0}".format(attrval(old.attrs, v))
+                                for v in attrsames
+                                if v != old.key_attr
+                            )
+                        ),
+                    )
+                )
 
-        # sort and....
-        diffs = sorted(diffs, key=cmp_to_key(compare))
+                for l in s:
+                    print(l)
 
-        # handle list attributes
-        def attrval(attrs, k, elide_iter=tuple()):
-                def q(s):
-                        if " " in s or s == "":
-                                return '"{0}"'.format(s)
-                        else:
-                                return s
+    return int(different)
 
-                v = attrs[k]
-                if isinstance(v, list) or isinstance(v, set):
-                        out = " ".join([
-                            "{0}={1}".format(k, q(lmt))
-                            for lmt in sorted(v)
-                            if lmt not in elide_iter
-                        ])
-                elif " " in v or v == "":
-                        out = k + "=\"" + v + "\""
-                else:
-                        out = k + "=" + v
-                return out
-
-        # figure out when to print diffs
-        def conditional_print(s, a):
-                if onlyattrs:
-                        if not set(a.attrs.keys()) & onlyattrs:
-                                return False
-                elif ignoreattrs:
-                        if not set(a.attrs.keys()) - ignoreattrs:
-                                return False
-
-                print("{0} {1}".format(s, a))
-                return True
-
-        different = False
-
-        for old, new in diffs:
-                if not new:
-                        different |= conditional_print("-", old)
-                elif not old:
-                        different |= conditional_print("+", new)
-                else:
-                        s = []
-
-                        if not onlyattrs:
-                                if (hasattr(old, "hash") and
-                                    "hash" not in ignoreattrs):
-                                        if old.hash != new.hash:
-                                                s.append("  - {0}".format(old.hash))
-                                                s.append("  + {0}".format(new.hash))
-                                attrdiffs = (set(new.differences(old)) -
-                                    ignoreattrs)
-                                attrsames = sorted( list(set(list(old.attrs.keys()) +
-                                    list(new.attrs.keys())) -
-                                    set(new.differences(old))))
-                        else:
-                                if hasattr(old, "hash") and "hash" in onlyattrs:
-                                        if old.hash != new.hash:
-                                                s.append("  - {0}".format(old.hash))
-                                                s.append("  + {0}".format(new.hash))
-                                attrdiffs = (set(new.differences(old)) &
-                                    onlyattrs)
-                                attrsames = sorted(list(set(list(old.attrs.keys()) +
-                                    list(new.attrs.keys())) -
-                                    set(new.differences(old))))
-
-                        for a in sorted(attrdiffs):
-                                if a in old.attrs and a in new.attrs and \
-                                    isinstance(old.attrs[a], list) and \
-                                    isinstance(new.attrs[a], list):
-                                        elide_set = (set(old.attrs[a]) &
-                                            set(new.attrs[a]))
-                                else:
-                                        elide_set = set()
-                                if a in old.attrs:
-                                        diff_str = attrval(old.attrs, a,
-                                            elide_iter=elide_set)
-                                        if diff_str:
-                                                s.append("  - {0}".format(diff_str))
-                                if a in new.attrs:
-                                        diff_str = attrval(new.attrs, a,
-                                            elide_iter=elide_set)
-                                        if diff_str:
-                                                s.append("  + {0}".format(diff_str))
-                        # print out part of action that is the same
-                        if s:
-                                different = True
-                                print("{0} {1} {2}".format(old.name,
-                                    attrval(old.attrs, old.key_attr),
-                                    " ".join(("{0}".format(attrval(old.attrs,v))
-                                    for v in attrsames if v != old.key_attr))))
-
-                                for l in s:
-                                        print(l)
-
-        return int(different)
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
-        try:
-                exit_code = main_func()
-        except (PipeError, KeyboardInterrupt):
-                exit_code = EXIT_OOPS
-        except SystemExit as __e:
-                exit_code = __e
-        except Exception as __e:
-                traceback.print_exc()
-                error(misc.get_traceback_message(), exitcode=None)
-                exit_code = 99
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
+    try:
+        exit_code = main_func()
+    except (PipeError, KeyboardInterrupt):
+        exit_code = EXIT_OOPS
+    except SystemExit as __e:
+        exit_code = __e
+    except Exception as __e:
+        traceback.print_exc()
+        error(misc.get_traceback_message(), exitcode=None)
+        exit_code = 99
 
-        sys.exit(exit_code)
+    sys.exit(exit_code)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/publish/pkgfmt.py
+++ b/src/util/publish/pkgfmt.py
@@ -25,7 +25,9 @@
 #
 
 from __future__ import print_function
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 
 # Prefixes should be ordered alphabetically with most specific first.
 DRIVER_ALIAS_PREFIXES = (
@@ -56,35 +58,35 @@ DRIVER_ALIAS_PREFIXES = (
 # 7) key attribute tags come first
 
 try:
-        import copy
-        import errno
-        import getopt
-        import gettext
-        import locale
-        import operator
-        import os
-        import re
-        import six
-        import sys
-        import tempfile
-        import traceback
-        import warnings
-        from difflib import unified_diff
-        from functools import cmp_to_key
-        from six.moves import cStringIO
+    import copy
+    import errno
+    import getopt
+    import gettext
+    import locale
+    import operator
+    import os
+    import re
+    import six
+    import sys
+    import tempfile
+    import traceback
+    import warnings
+    from difflib import unified_diff
+    from functools import cmp_to_key
+    from six.moves import cStringIO
 
-        import pkg
-        import pkg.actions
-        import pkg.misc as misc
-        import pkg.portable
-        from pkg.misc import emsg, PipeError
-        from pkg.actions.generic import quote_attr_value
-        from pkg.actions.depend import known_types as dep_types
-        from pkg.client.pkgdefs import (EXIT_OK, EXIT_OOPS, EXIT_BADOPT,
-            EXIT_PARTIAL)
+    import pkg
+    import pkg.actions
+    import pkg.misc as misc
+    import pkg.portable
+    from pkg.misc import emsg, PipeError
+    from pkg.actions.generic import quote_attr_value
+    from pkg.actions.depend import known_types as dep_types
+    from pkg.client.pkgdefs import EXIT_OK, EXIT_OOPS, EXIT_BADOPT, EXIT_PARTIAL
 except KeyboardInterrupt:
-        import sys
-        sys.exit(EXIT_OOPS)
+    import sys
+
+    sys.exit(EXIT_OOPS)
 
 FMT_V1 = "v1"
 FMT_V2 = "v2"
@@ -96,679 +98,715 @@ opt_strip = False
 opt_format = FMT_V2
 orig_opt_format = None
 
+
 def usage(errmsg="", exitcode=EXIT_BADOPT):
-        """Emit a usage message and optionally prefix it with a more specific
-        error message.  Causes program to exit."""
+    """Emit a usage message and optionally prefix it with a more specific
+    error message.  Causes program to exit."""
 
-        if errmsg:
-                error(errmsg)
+    if errmsg:
+        error(errmsg)
 
-        print(_("""\
+    print(
+        _(
+            """\
 Usage:
-        pkgfmt [-cdsu] [-f v1|v2] [file1] ... """), file=sys.stderr)
+        pkgfmt [-cdsu] [-f v1|v2] [file1] ... """
+        ),
+        file=sys.stderr,
+    )
 
-        sys.exit(exitcode)
+    sys.exit(exitcode)
+
 
 def error(text, exitcode=EXIT_OOPS):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        # If we get passed something like an Exception, we can convert
-        # it down to a string.
-        text = str(text)
+    # If we get passed something like an Exception, we can convert
+    # it down to a string.
+    text = str(text)
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        emsg(ws + "pkgfmt: error: " + text_nows)
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    emsg(ws + "pkgfmt: error: " + text_nows)
 
-        if exitcode != None:
-                sys.exit(exitcode)
+    if exitcode != None:
+        sys.exit(exitcode)
+
 
 def read_line(f):
-        """Generates the lines in the file as tuples containing
-        (action, prepended macro, list of prepended comment lines);
-        handles continuation lines, transforms, etc."""
+    """Generates the lines in the file as tuples containing
+    (action, prepended macro, list of prepended comment lines);
+    handles continuation lines, transforms, etc."""
 
-        accumulate = ""
-        wrap_accumulate = ""
-        noncomment_line_seen = False
+    accumulate = ""
+    wrap_accumulate = ""
+    noncomment_line_seen = False
+    comments = []
+
+    for l in f:
+        line = l.strip()
+        wrap_line = l
+        # Preserve line continuations for transforms for V2,
+        # but force standard leading space formatting.
+        if line.endswith("\\"):
+            accumulate += line[:-1]
+            wrap_accumulate += re.sub(r"^\s+", "    ", wrap_line.rstrip(" \t"))
+            continue
+        elif accumulate:
+            line = accumulate + line
+            wrap_line = wrap_accumulate + re.sub(r"^\s+", "    ", wrap_line)
+            accumulate = ""
+            wrap_accumulate = ""
+
+        if not line or line[0] == "#":
+            comments.append(line)
+            continue
+
+        if not noncomment_line_seen:
+            noncomment_line_seen = True
+            yield None, "", comments
+            comments = []
+
+        if line.startswith("$("):
+            cp = line.index(")")
+            macro = line[: cp + 1]
+            actstr = line[cp + 1 :]
+        else:
+            macro = ""
+            actstr = line
+
+        if actstr[0] == "<" and actstr[-1] == ">":
+            if opt_format == FMT_V2:
+                yield None, wrap_line.rstrip(), comments
+            else:
+                yield None, macro + actstr, comments
+
+            comments = []
+            macro = ""
+            continue
+
+        try:
+            act = pkg.actions.fromstr(actstr)
+
+            # For formatting purposes, treat dependency actions that
+            # do not yet have a valid type as invalid.
+            if act.name == "depend" and act.attrs.get("type") not in dep_types:
+                raise pkg.actions.InvalidActionError(
+                    act,
+                    _("Unknown type '{0}' in depend " "action").format(
+                        act.attrs.get("type")
+                    ),
+                )
+        except (
+            pkg.actions.MalformedActionError,
+            pkg.actions.UnknownActionError,
+            pkg.actions.InvalidActionError,
+        ):
+            # cannot convert; treat as special macro
+            yield None, macro + actstr, comments
+        else:
+            yield act, macro, comments
+
         comments = []
 
-        for l in f:
-                line = l.strip()
-                wrap_line = l
-                # Preserve line continuations for transforms for V2,
-                # but force standard leading space formatting.
-                if line.endswith("\\"):
-                        accumulate += line[:-1]
-                        wrap_accumulate += re.sub(r"^\s+", "    ",
-                            wrap_line.rstrip(" \t"))
-                        continue
-                elif accumulate:
-                        line = accumulate + line
-                        wrap_line = wrap_accumulate + re.sub(r"^\s+", "    ",
-                            wrap_line)
-                        accumulate = ""
-                        wrap_accumulate = ""
+    if comments:
+        yield None, "", comments
 
-                if not line or line[0] == "#":
-                        comments.append(line)
-                        continue
-
-                if not noncomment_line_seen:
-                        noncomment_line_seen = True
-                        yield None, "", comments
-                        comments = []
-
-                if line.startswith("$("):
-                        cp = line.index(")")
-                        macro = line[:cp + 1]
-                        actstr = line[cp + 1:]
-                else:
-                        macro = ""
-                        actstr = line
-
-                if actstr[0] == "<" and actstr[-1] == ">":
-                        if opt_format == FMT_V2:
-                                yield None, wrap_line.rstrip(), comments
-                        else:
-                                yield None, macro + actstr, comments
-
-                        comments = []
-                        macro = ""
-                        continue
-
-                try:
-                        act = pkg.actions.fromstr(actstr)
-
-                        # For formatting purposes, treat dependency actions that
-                        # do not yet have a valid type as invalid.
-                        if (act.name == "depend" and
-                            act.attrs.get("type") not in dep_types):
-                                raise pkg.actions.InvalidActionError(act,
-                                    _("Unknown type '{0}' in depend "
-                                      "action").format(act.attrs.get("type")))
-                except (pkg.actions.MalformedActionError,
-                    pkg.actions.UnknownActionError,
-                    pkg.actions.InvalidActionError):
-                        # cannot convert; treat as special macro
-                        yield None, macro + actstr, comments
-                else:
-                        yield act, macro, comments
-
-                comments = []
-
-        if comments:
-                yield None, "", comments
 
 def cmplines(a, b):
-        """Compare two line tuples for sorting"""
-        # we know that all lines that reach here have actions
-        # make set actions first
-        # depend actions last
-        # rest in alpha order
+    """Compare two line tuples for sorting"""
+    # we know that all lines that reach here have actions
+    # make set actions first
+    # depend actions last
+    # rest in alpha order
 
-        def typeord(a):
-                if a.name == "set":
-                        return 1
-                if opt_format == FMT_V2:
-                        if a.name in ("driver", "group", "user"):
-                                return 3
-                        if a.name in ("legacy", "license"):
-                                return 4
-                if a.name == "depend":
-                        return 5
-                return 2
-
-        c = misc.cmp(typeord(a[0]), typeord(b[0]))
-        if c:
-                return c
-
-        if opt_format != FMT_V2:
-                c = misc.cmp(a[0].name, b[0].name)
-                if c:
-                        return c
-
-        # Place set pkg.fmri actions first among set actions.
-        if a[0].name == "set" and a[0].attrs["name"] == "pkg.fmri":
-                return -1
-        if b[0].name == "set" and b[0].attrs["name"] == "pkg.fmri":
-                return 1
-
-        # Place set actions with names that start with pkg. before any
-        # remaining set actions.
-        if a[0].name == "set" and a[0].attrs["name"].startswith("pkg.") and \
-            not (b[0].name != "set" or b[0].attrs["name"].startswith("pkg.")):
-                return -1
-        if b[0].name == "set" and b[0].attrs["name"].startswith("pkg.") and \
-            not (a[0].name != "set" or a[0].attrs["name"].startswith("pkg.")):
-                return 1
-
+    def typeord(a):
+        if a.name == "set":
+            return 1
         if opt_format == FMT_V2:
-                # Place set pkg.summary actions second and pkg.description
-                # options third.
-                for attr in ("pkg.summary", "pkg.description"):
-                        if (a[0].name == "set" and
-                            a[0].attrs["name"] == attr and
-                            not b[0].attrs["name"] == attr):
-                                return -1
-                        if (b[0].name == "set" and
-                            b[0].attrs["name"] == attr and
-                            not a[0].attrs["name"] == attr):
-                                return 1
+            if a.name in ("driver", "group", "user"):
+                return 3
+            if a.name in ("legacy", "license"):
+                return 4
+        if a.name == "depend":
+            return 5
+        return 2
 
-        # Sort actions based on key attribute (if applicable).
-        key_attr = a[0].key_attr
-        if key_attr and key_attr == b[0].key_attr:
-                a_sk = b_sk = None
-                if opt_format == FMT_V2:
-                        if "path" in a[0].attrs and "path" in b[0].attrs:
-                                # This ensures filesystem actions are sorted by
-                                # path and link and hardlink actions are sorted
-                                # by path and then target (when compared against
-                                # each other).
-                                if "target" in a[0].attrs and \
-                                    "target" in b[0].attrs:
-                                        a_sk = operator.itemgetter("path",
-                                            "target")(a[0].attrs)
-                                        b_sk = operator.itemgetter("path",
-                                            "target")(b[0].attrs)
-                                else:
-                                        a_sk = a[0].attrs["path"]
-                                        b_sk = b[0].attrs["path"]
-                        elif a[0].name == "depend" and b[0].name == "depend":
-                                a_sk = operator.itemgetter("type", "fmri")(
-                                    a[0].attrs)
-                                b_sk = operator.itemgetter("type", "fmri")(
-                                    b[0].attrs)
+    c = misc.cmp(typeord(a[0]), typeord(b[0]))
+    if c:
+        return c
 
-                # If not using alternate format, or if no sort key has been
-                # determined, fallback to sorting on key attribute.
-                if not a_sk:
-                        a_sk = a[0].attrs[key_attr]
-                if not b_sk:
-                        b_sk = b[0].attrs[key_attr]
+    if opt_format != FMT_V2:
+        c = misc.cmp(a[0].name, b[0].name)
+        if c:
+            return c
 
-                c = misc.cmp(a_sk, b_sk)
-                # misc.cmp returns NotImplemented for uncomparable types in
-                # Python 3. Sort them based on stringified key attribute.
-                if c is NotImplemented:
-                        c = misc.cmp(str(a_sk), str(b_sk))
-                        if c:
-                                return c
-                elif c:
-                        return c
+    # Place set pkg.fmri actions first among set actions.
+    if a[0].name == "set" and a[0].attrs["name"] == "pkg.fmri":
+        return -1
+    if b[0].name == "set" and b[0].attrs["name"] == "pkg.fmri":
+        return 1
 
-        # No key attribute or key attribute sorting provides equal placement, so
-        # sort based on stringified action.
-        return misc.cmp(str(a[0]), str(b[0]))
+    # Place set actions with names that start with pkg. before any
+    # remaining set actions.
+    if (
+        a[0].name == "set"
+        and a[0].attrs["name"].startswith("pkg.")
+        and not (b[0].name != "set" or b[0].attrs["name"].startswith("pkg."))
+    ):
+        return -1
+    if (
+        b[0].name == "set"
+        and b[0].attrs["name"].startswith("pkg.")
+        and not (a[0].name != "set" or a[0].attrs["name"].startswith("pkg."))
+    ):
+        return 1
+
+    if opt_format == FMT_V2:
+        # Place set pkg.summary actions second and pkg.description
+        # options third.
+        for attr in ("pkg.summary", "pkg.description"):
+            if (
+                a[0].name == "set"
+                and a[0].attrs["name"] == attr
+                and not b[0].attrs["name"] == attr
+            ):
+                return -1
+            if (
+                b[0].name == "set"
+                and b[0].attrs["name"] == attr
+                and not a[0].attrs["name"] == attr
+            ):
+                return 1
+
+    # Sort actions based on key attribute (if applicable).
+    key_attr = a[0].key_attr
+    if key_attr and key_attr == b[0].key_attr:
+        a_sk = b_sk = None
+        if opt_format == FMT_V2:
+            if "path" in a[0].attrs and "path" in b[0].attrs:
+                # This ensures filesystem actions are sorted by
+                # path and link and hardlink actions are sorted
+                # by path and then target (when compared against
+                # each other).
+                if "target" in a[0].attrs and "target" in b[0].attrs:
+                    a_sk = operator.itemgetter("path", "target")(a[0].attrs)
+                    b_sk = operator.itemgetter("path", "target")(b[0].attrs)
+                else:
+                    a_sk = a[0].attrs["path"]
+                    b_sk = b[0].attrs["path"]
+            elif a[0].name == "depend" and b[0].name == "depend":
+                a_sk = operator.itemgetter("type", "fmri")(a[0].attrs)
+                b_sk = operator.itemgetter("type", "fmri")(b[0].attrs)
+
+        # If not using alternate format, or if no sort key has been
+        # determined, fallback to sorting on key attribute.
+        if not a_sk:
+            a_sk = a[0].attrs[key_attr]
+        if not b_sk:
+            b_sk = b[0].attrs[key_attr]
+
+        c = misc.cmp(a_sk, b_sk)
+        # misc.cmp returns NotImplemented for uncomparable types in
+        # Python 3. Sort them based on stringified key attribute.
+        if c is NotImplemented:
+            c = misc.cmp(str(a_sk), str(b_sk))
+            if c:
+                return c
+        elif c:
+            return c
+
+    # No key attribute or key attribute sorting provides equal placement, so
+    # sort based on stringified action.
+    return misc.cmp(str(a[0]), str(b[0]))
+
 
 def write_line(line, fileobj):
-        """Write out a manifest line"""
-        # write out any comments w/o changes
-        global opt_unwrap
+    """Write out a manifest line"""
+    # write out any comments w/o changes
+    global opt_unwrap
 
-        comments = "\n".join(line[2])
-        act = line[0]
-        out = line[1] + act.name
+    comments = "\n".join(line[2])
+    act = line[0]
+    out = line[1] + act.name
 
-        sattrs = act.attrs
+    sattrs = act.attrs
 
-        ahash = None
-        try:
-                ahash = act.hash
-                if ahash and ahash != "NOHASH":
-                        if "=" not in ahash and " " not in ahash and \
-                            '"' not in ahash:
-                                out += " " + ahash
-                        else:
-                                sattrs = copy.copy(act.attrs)
-                                sattrs["hash"] = ahash
-                                ahash = None
-        except AttributeError:
-                # No hash to stash.
-                pass
+    ahash = None
+    try:
+        ahash = act.hash
+        if ahash and ahash != "NOHASH":
+            if "=" not in ahash and " " not in ahash and '"' not in ahash:
+                out += " " + ahash
+            else:
+                sattrs = copy.copy(act.attrs)
+                sattrs["hash"] = ahash
+                ahash = None
+    except AttributeError:
+        # No hash to stash.
+        pass
 
-        if opt_strip:
-                sattrs = dict((k, v) for k, v in six.iteritems(sattrs)
-                     if not k.startswith('pkg.depend.') and
-                        not k.startswith('pkg.debug'))
+    if opt_strip:
+        sattrs = dict(
+            (k, v)
+            for k, v in six.iteritems(sattrs)
+            if not k.startswith("pkg.depend.") and not k.startswith("pkg.debug")
+        )
 
-        # high order bits in sorting
-        def kvord(a):
-                # Variants should always be last attribute.
-                if a[0].startswith("variant."):
-                        return 7
-                # Facets should always be before variants.
-                if a[0].startswith("facet."):
-                        return 6
-                # List attributes should be before facets and variants.
-                if isinstance(a[1], list):
-                        return 5
+    # high order bits in sorting
+    def kvord(a):
+        # Variants should always be last attribute.
+        if a[0].startswith("variant."):
+            return 7
+        # Facets should always be before variants.
+        if a[0].startswith("facet."):
+            return 6
+        # List attributes should be before facets and variants.
+        if isinstance(a[1], list):
+            return 5
 
-                # note closure hack...
-                if opt_format == FMT_V2:
-                        if act.name == "depend":
-                                # For depend actions, type should always come
-                                # first even though it's not the key attribute,
-                                # and fmri should always come after type.
-                                if a[0] == "fmri":
-                                        return 1
-                                elif a[0] == "type":
-                                        return 0
-                        elif act.name == "driver":
-                                # For driver actions, attributes should be in
-                                # this order: name, perms, clone_perms, privs,
-                                # policy, devlink, alias.
-                                if a[0] == "alias":
-                                        return 6
-                                elif a[0] == "devlink":
-                                        return 5
-                                elif a[0] == "policy":
-                                        return 4
-                                elif a[0] == "privs":
-                                        return 3
-                                elif a[0] == "clone_perms":
-                                        return 2
-                                elif a[0] == "perms":
-                                        return 1
-                        elif act.name != "user":
-                                # Place target after path, owner before group,
-                                # and all immediately after the action's key
-                                # attribute.
-                                if a[0] == "mode":
-                                        return 3
-                                elif a[0] == "group":
-                                        return 2
-                                elif a[0] == "owner" or a[0] == "target":
-                                        return 1
-
-                # Any other attributes should come just before list, facet,
-                # and variant attributes.
-                if a[0] != act.key_attr:
-                        return 4
-
-                # No special order for all other cases.
-                return 0
-
-        # actual key function
-        def key_func(a):
-                return (kvord(a), a[0])
-
-        JOIN_TOK = " \\\n    "
-        def grow(a, b, rem_values, force_nl=False):
-                if opt_unwrap or not force_nl:
-                        lastnl = a.rfind("\n")
-                        if lastnl == -1:
-                                lastnl = 0
-
-                        if opt_format == FMT_V2 and rem_values == 1:
-                                # If outputting the last attribute value, then
-                                # use full line length.
-                                max_len = 80
-                        else:
-                                # If V1 format, or there are more attributes to
-                                # output, then account for line-continuation
-                                # marker.
-                                max_len = 78
-
-                        # Note this length comparison doesn't include the space
-                        # used to append the second part of the string.
-                        if opt_unwrap or (len(a) - lastnl + len(b) < max_len):
-                                return a + " " + b
-                return a + JOIN_TOK + b
-
-        def get_alias_key(v):
-                """This function parses an alias attribute value into a list
-                of numeric values (e.g. hex -> int) and strings that can be
-                sensibly compared for sorting."""
-
-                alias = None
-                prefix = None
-                for pfx in DRIVER_ALIAS_PREFIXES:
-                        if v.startswith(pfx):
-                                # Strip known prefixes before attempting
-                                # to create list of sort values.
-                                alias = v.replace(pfx, "")
-                                prefix = pfx
-                                break
-
-                if alias is None:
-                        # alias didn't start with known prefix; use
-                        # raw value for sorting.
-                        return [v]
-
-                entry = [prefix]
-                for part in alias.split(","):
-                        for comp in part.split("."):
-                                try:
-                                        cval = int(comp, 16)
-                                except ValueError:
-                                        cval = comp
-                                entry.append(cval)
-                return entry
-
-        def cmp_aliases(a, b):
-                if opt_format == FMT_V1:
-                        # Simple comparison for V1 format.
-                        return misc.cmp(a, b)
-                # For V2 format, order aliases by interpreted value.
-                c = misc.cmp(get_alias_key(a), get_alias_key(b))
-                # misc.cmp returns NotImplemented for uncomparable types in
-                # Python 3. Instead fallback to using the string of the key
-                # generated from the alias and sort alphabetically. This
-                # maintains the python 2 sorting behaviour.
-                if c is NotImplemented:
-                    c = -misc.cmp(str(get_alias_key(a)), str(get_alias_key(b)))
-                return c
-
-        def astr(aout):
-                # Number of attribute values for first line and remaining.
-                first_line = True
-                first_attr_count = 0
-                rem_attr_count = 0
-
-                # Total number of remaining attribute values to output.
-                total_count = sum(len(act.attrlist(k)) for k in sattrs)
-                rem_count = total_count
-
-                # Now build the action output string an attribute at a time.
-                for k, v in sorted(six.iteritems(sattrs), key=key_func):
-                        # Newline breaks are only forced when there is more than
-                        # one value for an attribute.
-                        if not (isinstance(v, list) or isinstance(v, set)):
-                                nv = [v]
-                                use_force_nl = False
-                        else:
-                                nv = v
-                                use_force_nl = True
-
-                        cmp_attrs = None
-                        if k == "alias":
-                                cmp_attrs = cmp_to_key(cmp_aliases)
-                        for lmt in sorted(nv, key=cmp_attrs):
-                                force_nl = use_force_nl and \
-                                    (k == "alias" or (opt_format == FMT_V2 and
-                                    k.startswith("pkg.debug")))
-
-                                aout = grow(aout, "=".join((k,
-                                    quote_attr_value(lmt))), rem_count,
-                                    force_nl=force_nl)
-
-                                # Must be done for each value.
-                                if first_line and JOIN_TOK in aout:
-                                        first_line = False
-                                        first_attr_count = \
-                                            (total_count - rem_count)
-                                        if ahash and ahash != "NOHASH":
-                                                first_attr_count += 1
-                                        rem_attr_count = rem_count
-
-                                rem_count -= 1
-
-                return first_attr_count, rem_attr_count, aout
-
-        first_attr_count, rem_attr_count, output = astr(out)
-        if opt_format == FMT_V2 and not opt_unwrap:
-                outlines = output.split(JOIN_TOK)
-
-                # If wrapping only resulted in two lines, and the second line
-                # only has one attribute and the first line had zero attributes,
-                # unwrap the action.
-                if first_attr_count < 2 and rem_attr_count == 1 and \
-                    len(outlines) == 2 and first_attr_count == 0:
-                        opt_unwrap = True
-                        output = astr(out)[-1]
-                        opt_unwrap = False
-
-        if comments:
-                print(comments, file=fileobj)
-
-        if (opt_strip and act.name == 'set' and
-            act.attrs['name'].startswith('pkg.debug')):
-                return
-
+        # note closure hack...
         if opt_format == FMT_V2:
-                # Force 'dir' actions to use four spaces at beginning of lines
-                # so they line up with other filesystem actions such as file,
-                # link, etc.
-                output = re.sub(r"^dir ", "dir  ", output)
-        print(output, file=fileobj)
+            if act.name == "depend":
+                # For depend actions, type should always come
+                # first even though it's not the key attribute,
+                # and fmri should always come after type.
+                if a[0] == "fmri":
+                    return 1
+                elif a[0] == "type":
+                    return 0
+            elif act.name == "driver":
+                # For driver actions, attributes should be in
+                # this order: name, perms, clone_perms, privs,
+                # policy, devlink, alias.
+                if a[0] == "alias":
+                    return 6
+                elif a[0] == "devlink":
+                    return 5
+                elif a[0] == "policy":
+                    return 4
+                elif a[0] == "privs":
+                    return 3
+                elif a[0] == "clone_perms":
+                    return 2
+                elif a[0] == "perms":
+                    return 1
+            elif act.name != "user":
+                # Place target after path, owner before group,
+                # and all immediately after the action's key
+                # attribute.
+                if a[0] == "mode":
+                    return 3
+                elif a[0] == "group":
+                    return 2
+                elif a[0] == "owner" or a[0] == "target":
+                    return 1
+
+        # Any other attributes should come just before list, facet,
+        # and variant attributes.
+        if a[0] != act.key_attr:
+            return 4
+
+        # No special order for all other cases.
+        return 0
+
+    # actual key function
+    def key_func(a):
+        return (kvord(a), a[0])
+
+    JOIN_TOK = " \\\n    "
+
+    def grow(a, b, rem_values, force_nl=False):
+        if opt_unwrap or not force_nl:
+            lastnl = a.rfind("\n")
+            if lastnl == -1:
+                lastnl = 0
+
+            if opt_format == FMT_V2 and rem_values == 1:
+                # If outputting the last attribute value, then
+                # use full line length.
+                max_len = 80
+            else:
+                # If V1 format, or there are more attributes to
+                # output, then account for line-continuation
+                # marker.
+                max_len = 78
+
+            # Note this length comparison doesn't include the space
+            # used to append the second part of the string.
+            if opt_unwrap or (len(a) - lastnl + len(b) < max_len):
+                return a + " " + b
+        return a + JOIN_TOK + b
+
+    def get_alias_key(v):
+        """This function parses an alias attribute value into a list
+        of numeric values (e.g. hex -> int) and strings that can be
+        sensibly compared for sorting."""
+
+        alias = None
+        prefix = None
+        for pfx in DRIVER_ALIAS_PREFIXES:
+            if v.startswith(pfx):
+                # Strip known prefixes before attempting
+                # to create list of sort values.
+                alias = v.replace(pfx, "")
+                prefix = pfx
+                break
+
+        if alias is None:
+            # alias didn't start with known prefix; use
+            # raw value for sorting.
+            return [v]
+
+        entry = [prefix]
+        for part in alias.split(","):
+            for comp in part.split("."):
+                try:
+                    cval = int(comp, 16)
+                except ValueError:
+                    cval = comp
+                entry.append(cval)
+        return entry
+
+    def cmp_aliases(a, b):
+        if opt_format == FMT_V1:
+            # Simple comparison for V1 format.
+            return misc.cmp(a, b)
+        # For V2 format, order aliases by interpreted value.
+        c = misc.cmp(get_alias_key(a), get_alias_key(b))
+        # misc.cmp returns NotImplemented for uncomparable types in
+        # Python 3. Instead fallback to using the string of the key
+        # generated from the alias and sort alphabetically. This
+        # maintains the python 2 sorting behaviour.
+        if c is NotImplemented:
+            c = -misc.cmp(str(get_alias_key(a)), str(get_alias_key(b)))
+        return c
+
+    def astr(aout):
+        # Number of attribute values for first line and remaining.
+        first_line = True
+        first_attr_count = 0
+        rem_attr_count = 0
+
+        # Total number of remaining attribute values to output.
+        total_count = sum(len(act.attrlist(k)) for k in sattrs)
+        rem_count = total_count
+
+        # Now build the action output string an attribute at a time.
+        for k, v in sorted(six.iteritems(sattrs), key=key_func):
+            # Newline breaks are only forced when there is more than
+            # one value for an attribute.
+            if not (isinstance(v, list) or isinstance(v, set)):
+                nv = [v]
+                use_force_nl = False
+            else:
+                nv = v
+                use_force_nl = True
+
+            cmp_attrs = None
+            if k == "alias":
+                cmp_attrs = cmp_to_key(cmp_aliases)
+            for lmt in sorted(nv, key=cmp_attrs):
+                force_nl = use_force_nl and (
+                    k == "alias"
+                    or (opt_format == FMT_V2 and k.startswith("pkg.debug"))
+                )
+
+                aout = grow(
+                    aout,
+                    "=".join((k, quote_attr_value(lmt))),
+                    rem_count,
+                    force_nl=force_nl,
+                )
+
+                # Must be done for each value.
+                if first_line and JOIN_TOK in aout:
+                    first_line = False
+                    first_attr_count = total_count - rem_count
+                    if ahash and ahash != "NOHASH":
+                        first_attr_count += 1
+                    rem_attr_count = rem_count
+
+                rem_count -= 1
+
+        return first_attr_count, rem_attr_count, aout
+
+    first_attr_count, rem_attr_count, output = astr(out)
+    if opt_format == FMT_V2 and not opt_unwrap:
+        outlines = output.split(JOIN_TOK)
+
+        # If wrapping only resulted in two lines, and the second line
+        # only has one attribute and the first line had zero attributes,
+        # unwrap the action.
+        if (
+            first_attr_count < 2
+            and rem_attr_count == 1
+            and len(outlines) == 2
+            and first_attr_count == 0
+        ):
+            opt_unwrap = True
+            output = astr(out)[-1]
+            opt_unwrap = False
+
+    if comments:
+        print(comments, file=fileobj)
+
+    if (
+        opt_strip
+        and act.name == "set"
+        and act.attrs["name"].startswith("pkg.debug")
+    ):
+        return
+
+    if opt_format == FMT_V2:
+        # Force 'dir' actions to use four spaces at beginning of lines
+        # so they line up with other filesystem actions such as file,
+        # link, etc.
+        output = re.sub(r"^dir ", "dir  ", output)
+    print(output, file=fileobj)
+
 
 def main_func():
-        global opt_unwrap
-        global opt_check
-        global opt_diffs
-        global opt_strip
-        global opt_format
-        global orig_opt_format
+    global opt_unwrap
+    global opt_check
+    global opt_diffs
+    global opt_strip
+    global opt_format
+    global orig_opt_format
 
-        env_format = os.environ.get("PKGFMT_OUTPUT")
-        if env_format:
-                opt_format = orig_opt_format = env_format
+    env_format = os.environ.get("PKGFMT_OUTPUT")
+    if env_format:
+        opt_format = orig_opt_format = env_format
 
-        ret = 0
-        opt_set = set()
+    ret = 0
+    opt_set = set()
 
+    try:
+        opts, pargs = getopt.getopt(sys.argv[1:], "cdf:su?h", ["help"])
+        for opt, arg in opts:
+            opt_set.add(opt)
+            if opt == "-c":
+                opt_check = True
+            elif opt == "-d":
+                opt_diffs = True
+            elif opt == "-f":
+                opt_format = orig_opt_format = arg
+            elif opt == "-s":
+                opt_strip = True
+            elif opt == "-u":
+                opt_unwrap = True
+            elif opt in ("-h", "--help", "-?"):
+                usage(exitcode=EXIT_OK)
+    except getopt.GetoptError as e:
+        if e.opt == "f":
+            usage(exitcode=EXIT_BADOPT)
+        else:
+            usage(_("illegal global option -- {0}").format(e.opt))
+    if len(opt_set - set(["-f"])) > 1:
+        usage(_("only one of [cdu] may be specified"))
+    if opt_format not in (FMT_V1, FMT_V2):
+        usage(_("unsupported format '{0}'").format(opt_format))
+
+    def difference(in_file):
+        whole_f1 = in_file.readlines()
+        f2 = cStringIO()
+        fmt_file(cStringIO("".join(whole_f1)), f2)
+        f2.seek(0)
+        whole_f2 = f2.readlines()
+
+        if whole_f1 == whole_f2:
+            if opt_diffs:
+                return 0, ""
+            return 0, "".join(whole_f2)
+        elif opt_diffs:
+            return 1, "".join(unified_diff(whole_f2, whole_f1))
+        return 1, "".join(whole_f2)
+
+    flist = pargs
+    if not flist:
         try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "cdf:su?h", ["help"])
-                for opt, arg in opts:
-                        opt_set.add(opt)
-                        if opt == "-c":
-                                opt_check = True
-                        elif opt == "-d":
-                                opt_diffs = True
-                        elif opt == "-f":
-                                opt_format = orig_opt_format = arg
-                        elif opt == "-s":
-                                opt_strip = True
-                        elif opt == "-u":
-                                opt_unwrap = True
-                        elif opt in ("-h", "--help", "-?"):
-                                usage(exitcode=EXIT_OK)
-        except getopt.GetoptError as e:
-                if e.opt == 'f':
-                        usage(exitcode=EXIT_BADOPT)
-                else:
-                        usage(_("illegal global option -- {0}").format(e.opt))
-        if len(opt_set - set(["-f"])) > 1:
-                usage(_("only one of [cdu] may be specified"))
-        if opt_format not in (FMT_V1, FMT_V2):
-                usage(_("unsupported format '{0}'").format(opt_format))
+            in_file = cStringIO()
+            in_file.write(sys.stdin.read())
+            in_file.seek(0)
 
-        def difference(in_file):
-                whole_f1 = in_file.readlines()
-                f2 = cStringIO()
-                fmt_file(cStringIO("".join(whole_f1)), f2)
-                f2.seek(0)
-                whole_f2 = f2.readlines()
+            ret, formatted = difference(in_file)
+            if ret == 1 and opt_check:
+                # Manifest was different; if user didn't specify
+                # a format explicitly, try V1 format.
+                if not orig_opt_format:
+                    opt_format = FMT_V1
+                    in_file.seek(0)
+                    rcode, formatted = difference(in_file)
+                    opt_format = FMT_V2
+                    if rcode == 0:
+                        # Manifest is in V1 format.
+                        return 0
 
-                if whole_f1 == whole_f2:
-                        if opt_diffs:
-                                return 0, ""
-                        return 0, "".join(whole_f2)
-                elif opt_diffs:
-                        return 1, "".join(unified_diff(whole_f2,
-                            whole_f1))
-                return 1, "".join(whole_f2)
+                error(_("manifest is not in pkgfmt form"))
+            elif ret == 1 and not opt_diffs:
+                # Treat as successful exit if not checking
+                # formatting or displaying diffs.
+                ret = 0
 
-        flist = pargs
-        if not flist:
-                try:
-                        in_file = cStringIO()
-                        in_file.write(sys.stdin.read())
-                        in_file.seek(0)
-
-                        ret, formatted = difference(in_file)
-                        if ret == 1 and opt_check:
-                                # Manifest was different; if user didn't specify
-                                # a format explicitly, try V1 format.
-                                if not orig_opt_format:
-                                        opt_format = FMT_V1
-                                        in_file.seek(0)
-                                        rcode, formatted = difference(in_file)
-                                        opt_format = FMT_V2
-                                        if rcode == 0:
-                                                # Manifest is in V1 format.
-                                                return 0
-
-                                error(_("manifest is not in pkgfmt form"))
-                        elif ret == 1 and not opt_diffs:
-                                # Treat as successful exit if not checking
-                                # formatting or displaying diffs.
-                                ret = 0
-
-                        # Display formatted version (explicit 'end' needed to
-                        # prevent output of extra newline) even if manifest
-                        # didn't need formatting for the stdin case.  (The
-                        # assumption is that it might be used in a pipeline.)
-                        if formatted:
-                                print(formatted, end="")
-                except EnvironmentError as e:
-                        if e.errno == errno.EPIPE:
-                                # User closed input or output (i.e. killed piped
-                                # program before all input was read or output
-                                # was written).
-                                return 1
-                return ret
-
-        ret = 0
-        tname = None
-        for fname in flist:
-                try:
-                        # force path to be absolute; gives better diagnostics if
-                        # something goes wrong.
-                        path = os.path.abspath(fname)
-
-                        with open(fname, "r") as f:
-                                rcode, formatted = difference(f)
-                        if rcode == 0:
-                                continue
-
-                        if opt_check:
-                                # Manifest was different; if user didn't specify
-                                # a format explicitly, try V1 format.
-                                if not orig_opt_format:
-                                        opt_format = FMT_V1
-                                        with open(fname, "r") as f:
-                                                rcode, formatted = difference(f)
-                                        opt_format = FMT_V2
-                                        if rcode == 0:
-                                                # Manifest is in V1 format.
-                                                continue
-
-                                ret = 1
-                                if orig_opt_format:
-                                        error(_(
-                                            "{0} is not in pkgfmt {1} form; "
-                                            "run `pkgfmt -f {1}` on the file "
-                                            "to reformat the manifest "
-                                            "in-place")
-                                            .format(fname, opt_format),
-                                            exitcode=None)
-                                else:
-                                        error(_("{0} is not in pkgfmt form; "
-                                            "run pkgfmt on the file without "
-                                            "-c or -d to reformat the manifest "
-                                            "in-place") .format(fname),
-                                            exitcode=None)
-                                continue
-                        elif opt_diffs:
-                                # Display differences (explicit 'end' needed to
-                                # prevent output of extra newline).
-                                ret = 1
-                                print(formatted, end=" ")
-                                continue
-                        elif ret != 1:
-                                # Treat as successful exit if not checking
-                                # formatting or displaying diffs.
-                                ret = 0
-
-                        # Replace manifest with formatted version.
-                        pathdir = os.path.dirname(path)
-                        tfd, tname = tempfile.mkstemp(dir=pathdir)
-                        with os.fdopen(tfd, "w") as t:
-                                t.write(formatted)
-
-                        try:
-                                # Ensure existing mode is preserved.
-                                mode = os.stat(fname).st_mode
-                                os.chmod(tname, mode)
-                                os.rename(tname, fname)
-                        except EnvironmentError as e:
-                                error(str(e), exitcode=EXIT_OOPS)
-                except (EnvironmentError, IOError) as e:
-                        error(str(e), exitcode=EXIT_OOPS)
-                finally:
-                        if tname:
-                                try:
-                                        pkg.portable.remove(tname)
-                                except EnvironmentError as e:
-                                        if e.errno != errno.ENOENT:
-                                                raise
-
+            # Display formatted version (explicit 'end' needed to
+            # prevent output of extra newline) even if manifest
+            # didn't need formatting for the stdin case.  (The
+            # assumption is that it might be used in a pipeline.)
+            if formatted:
+                print(formatted, end="")
+        except EnvironmentError as e:
+            if e.errno == errno.EPIPE:
+                # User closed input or output (i.e. killed piped
+                # program before all input was read or output
+                # was written).
+                return 1
         return ret
 
-def fmt_file(in_file, out_file):
-        lines = []
-        saw_action = False
-        trailing_comments = []
+    ret = 0
+    tname = None
+    for fname in flist:
+        try:
+            # force path to be absolute; gives better diagnostics if
+            # something goes wrong.
+            path = os.path.abspath(fname)
 
-        for tp in read_line(in_file):
-                if tp[0] is None:
-                        if saw_action and not tp[1]:
-                                # Comments without a macro or transform
-                                # nearby will be placed at the end if
-                                # found after actions.
-                                trailing_comments.extend(tp[2])
-                                continue
+            with open(fname, "r") as f:
+                rcode, formatted = difference(f)
+            if rcode == 0:
+                continue
 
-                        # Any other comments, transforms, or unparseables
-                        # will simply be printed back out wherever they
-                        # were found before or after actions.
-                        for l in tp[2]:
-                                print(l, file=out_file)
-                        if tp[1]:
-                                print(tp[1], file=out_file)
+            if opt_check:
+                # Manifest was different; if user didn't specify
+                # a format explicitly, try V1 format.
+                if not orig_opt_format:
+                    opt_format = FMT_V1
+                    with open(fname, "r") as f:
+                        rcode, formatted = difference(f)
+                    opt_format = FMT_V2
+                    if rcode == 0:
+                        # Manifest is in V1 format.
+                        continue
+
+                ret = 1
+                if orig_opt_format:
+                    error(
+                        _(
+                            "{0} is not in pkgfmt {1} form; "
+                            "run `pkgfmt -f {1}` on the file "
+                            "to reformat the manifest "
+                            "in-place"
+                        ).format(fname, opt_format),
+                        exitcode=None,
+                    )
                 else:
-                        lines.append(tp)
-                        saw_action = True
+                    error(
+                        _(
+                            "{0} is not in pkgfmt form; "
+                            "run pkgfmt on the file without "
+                            "-c or -d to reformat the manifest "
+                            "in-place"
+                        ).format(fname),
+                        exitcode=None,
+                    )
+                continue
+            elif opt_diffs:
+                # Display differences (explicit 'end' needed to
+                # prevent output of extra newline).
+                ret = 1
+                print(formatted, end=" ")
+                continue
+            elif ret != 1:
+                # Treat as successful exit if not checking
+                # formatting or displaying diffs.
+                ret = 0
 
-        lines.sort(key=cmp_to_key(cmplines))
-        for l in lines:
-                write_line(l, out_file)
-        out_file.writelines("\n".join(trailing_comments))
-        if trailing_comments:
-                # Ensure file ends with newline.
-                out_file.write("\n")
+            # Replace manifest with formatted version.
+            pathdir = os.path.dirname(path)
+            tfd, tname = tempfile.mkstemp(dir=pathdir)
+            with os.fdopen(tfd, "w") as t:
+                t.write(formatted)
+
+            try:
+                # Ensure existing mode is preserved.
+                mode = os.stat(fname).st_mode
+                os.chmod(tname, mode)
+                os.rename(tname, fname)
+            except EnvironmentError as e:
+                error(str(e), exitcode=EXIT_OOPS)
+        except (EnvironmentError, IOError) as e:
+            error(str(e), exitcode=EXIT_OOPS)
+        finally:
+            if tname:
+                try:
+                    pkg.portable.remove(tname)
+                except EnvironmentError as e:
+                    if e.errno != errno.ENOENT:
+                        raise
+
+    return ret
+
+
+def fmt_file(in_file, out_file):
+    lines = []
+    saw_action = False
+    trailing_comments = []
+
+    for tp in read_line(in_file):
+        if tp[0] is None:
+            if saw_action and not tp[1]:
+                # Comments without a macro or transform
+                # nearby will be placed at the end if
+                # found after actions.
+                trailing_comments.extend(tp[2])
+                continue
+
+            # Any other comments, transforms, or unparseables
+            # will simply be printed back out wherever they
+            # were found before or after actions.
+            for l in tp[2]:
+                print(l, file=out_file)
+            if tp[1]:
+                print(tp[1], file=out_file)
+        else:
+            lines.append(tp)
+            saw_action = True
+
+    lines.sort(key=cmp_to_key(cmplines))
+    for l in lines:
+        write_line(l, out_file)
+    out_file.writelines("\n".join(trailing_comments))
+    if trailing_comments:
+        # Ensure file ends with newline.
+        out_file.write("\n")
 
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
-        try:
-                __ret = main_func()
-        except (PipeError, KeyboardInterrupt):
-                # We don't want to display any messages here to prevent
-                # possible further broken pipe (EPIPE) errors.
-                __ret = 1
-        except SystemExit as _e:
-                raise _e
-        except:
-                traceback.print_exc()
-                error(misc.get_traceback_message(), exitcode=None)
-                __ret = 99
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
+    try:
+        __ret = main_func()
+    except (PipeError, KeyboardInterrupt):
+        # We don't want to display any messages here to prevent
+        # possible further broken pipe (EPIPE) errors.
+        __ret = 1
+    except SystemExit as _e:
+        raise _e
+    except:
+        traceback.print_exc()
+        error(misc.get_traceback_message(), exitcode=None)
+        __ret = 99
 
-        sys.exit(__ret)
+    sys.exit(__ret)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/publish/pkglint.py
+++ b/src/util/publish/pkglint.py
@@ -24,7 +24,9 @@
 # Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
 #
 
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 import codecs
 import logging
 import six
@@ -51,301 +53,369 @@ import pkg.client.transport.exception as tx
 
 logger = None
 
-def error(message=""):
-        """Emit an error message prefixed by the command name. """
-        misc.emsg("pkglint: {0}".format(message))
 
-        if logger is not None:
-                logger.error(_("Error: {0}").format(message))
+def error(message=""):
+    """Emit an error message prefixed by the command name."""
+    misc.emsg("pkglint: {0}".format(message))
+
+    if logger is not None:
+        logger.error(_("Error: {0}").format(message))
+
 
 def msg(message):
-        logger.info(message)
+    logger.info(message)
+
 
 def debug(message):
-        logger.debug(message)
+    logger.debug(message)
+
 
 def main_func():
-        """Start pkglint."""
+    """Start pkglint."""
 
-        global logger
+    global logger
 
-        usage = \
-            _("\n"
-            "        %prog [-b build_no] [-c cache_dir] [-f file]\n"
-            "            [-l uri ...] [-p regexp] [-r uri ...] [-v]\n"
-            "            [-e extension_path ...]\n"
-            "            manifest ...\n"
-            "        %prog -L")
-        parser = OptionParser(usage=usage)
+    usage = _(
+        "\n"
+        "        %prog [-b build_no] [-c cache_dir] [-f file]\n"
+        "            [-l uri ...] [-p regexp] [-r uri ...] [-v]\n"
+        "            [-e extension_path ...]\n"
+        "            manifest ...\n"
+        "        %prog -L"
+    )
+    parser = OptionParser(usage=usage)
 
-        parser.add_option("-b", dest="release", metavar="build_no",
-            help=_("build to use from lint and reference repositories"))
-        parser.add_option("-c", dest="cache", metavar="dir",
-            help=_("directory to use as a repository cache"))
-        parser.add_option("-f", dest="config", metavar="file",
-            help=_("specify an alternative pkglintrc file"))
-        parser.add_option("-l", dest="lint_uris", metavar="uri",
-            action="append", help=_("lint repository URI"))
-        parser.add_option("-L", dest="list_checks",
-            action="store_true",
-            help=_("list checks configured for this session and exit"))
-        parser.add_option("-p", dest="pattern", metavar="regexp",
-            help=_("pattern to match FMRIs in lint URI"))
-        parser.add_option("-r", dest="ref_uris", metavar="uri",
-            action="append", help=_("reference repository URI"))
-        parser.add_option("-e", dest="extension_path", metavar="dir",
-            action="append", help=_("extension_path"))
-        parser.add_option("-v", dest="verbose", action="store_true",
-            help=_("produce verbose output, overriding settings in pkglintrc"))
+    parser.add_option(
+        "-b",
+        dest="release",
+        metavar="build_no",
+        help=_("build to use from lint and reference repositories"),
+    )
+    parser.add_option(
+        "-c",
+        dest="cache",
+        metavar="dir",
+        help=_("directory to use as a repository cache"),
+    )
+    parser.add_option(
+        "-f",
+        dest="config",
+        metavar="file",
+        help=_("specify an alternative pkglintrc file"),
+    )
+    parser.add_option(
+        "-l",
+        dest="lint_uris",
+        metavar="uri",
+        action="append",
+        help=_("lint repository URI"),
+    )
+    parser.add_option(
+        "-L",
+        dest="list_checks",
+        action="store_true",
+        help=_("list checks configured for this session and exit"),
+    )
+    parser.add_option(
+        "-p",
+        dest="pattern",
+        metavar="regexp",
+        help=_("pattern to match FMRIs in lint URI"),
+    )
+    parser.add_option(
+        "-r",
+        dest="ref_uris",
+        metavar="uri",
+        action="append",
+        help=_("reference repository URI"),
+    )
+    parser.add_option(
+        "-e",
+        dest="extension_path",
+        metavar="dir",
+        action="append",
+        help=_("extension_path"),
+    )
+    parser.add_option(
+        "-v",
+        dest="verbose",
+        action="store_true",
+        help=_("produce verbose output, overriding settings in pkglintrc"),
+    )
 
-        opts, args = parser.parse_args(sys.argv[1:])
+    opts, args = parser.parse_args(sys.argv[1:])
 
-        # without a cache option, we can't access repositories, so expect
-        # local manifests.
-        if not (opts.cache or opts.list_checks) and not args:
-                parser.error(
-                    _("Required -c option missing, no local manifests provided."
-                    ))
+    # without a cache option, we can't access repositories, so expect
+    # local manifests.
+    if not (opts.cache or opts.list_checks) and not args:
+        parser.error(
+            _("Required -c option missing, no local manifests provided.")
+        )
 
-        pattern = opts.pattern
-        opts.ref_uris = _make_list(opts.ref_uris)
-        opts.lint_uris = _make_list(opts.lint_uris)
+    pattern = opts.pattern
+    opts.ref_uris = _make_list(opts.ref_uris)
+    opts.lint_uris = _make_list(opts.lint_uris)
 
-        logger = logging.getLogger("pkglint")
-        ch = logging.StreamHandler(sys.stdout)
+    logger = logging.getLogger("pkglint")
+    ch = logging.StreamHandler(sys.stdout)
 
-        if opts.verbose:
-                logger.setLevel(logging.DEBUG)
-                ch.setLevel(logging.DEBUG)
+    if opts.verbose:
+        logger.setLevel(logging.DEBUG)
+        ch.setLevel(logging.DEBUG)
 
-        else:
-                logger.setLevel(logging.INFO)
-                ch.setLevel(logging.INFO)
+    else:
+        logger.setLevel(logging.INFO)
+        ch.setLevel(logging.INFO)
 
-        logger.addHandler(ch)
+    logger.addHandler(ch)
 
-        lint_logger = log.PlainLogFormatter()
-        try:
-                if not opts.list_checks:
-                        msg(_("Lint engine setup..."))
-                lint_engine = engine.LintEngine(lint_logger,
-                    config_file=opts.config, verbose=opts.verbose,
-                    extension_path=opts.extension_path)
+    lint_logger = log.PlainLogFormatter()
+    try:
+        if not opts.list_checks:
+            msg(_("Lint engine setup..."))
+        lint_engine = engine.LintEngine(
+            lint_logger,
+            config_file=opts.config,
+            verbose=opts.verbose,
+            extension_path=opts.extension_path,
+        )
 
-                if opts.list_checks:
-                        list_checks(lint_engine.checkers,
-                            lint_engine.excluded_checkers, opts.verbose)
-                        return EXIT_OK
+        if opts.list_checks:
+            list_checks(
+                lint_engine.checkers,
+                lint_engine.excluded_checkers,
+                opts.verbose,
+            )
+            return EXIT_OK
 
-                if (opts.lint_uris or opts.ref_uris) and not opts.cache:
-                        parser.error(
-                            _("Required -c option missing when using "
-                            "repositories."))
-
-                manifests = []
-                if len(args) >= 1:
-                        manifests = read_manifests(args, lint_logger)
-                        if None in manifests or \
-                            lint_logger.produced_lint_msgs():
-                                error(_("Fatal error in manifest - exiting."))
-                                return EXIT_OOPS
-                lint_engine.setup(ref_uris=opts.ref_uris,
-                    lint_uris=opts.lint_uris,
-                    lint_manifests=manifests,
-                    cache=opts.cache,
-                    pattern=pattern,
-                    release=opts.release)
-
-                msg(_("Starting lint run..."))
-
-                lint_engine.execute()
-                lint_engine.teardown()
-                lint_logger.close()
-
-        except engine.LintEngineSetupException as err:
-                # errors during setup are likely to be caused by bad
-                # input or configuration, not lint errors in manifests.
-                error(err)
-                return EXIT_BADOPT
-
-        except engine.LintEngineException as err:
-                error(err)
-                return EXIT_OOPS
-
-        if lint_logger.produced_lint_msgs():
-                return EXIT_OOPS
-        else:
-                return EXIT_OK
-
-def list_checks(checkers, exclude, verbose=False):
-        """Prints a human-readable version of configured checks."""
-
-        # used for justifying output
-        width = 28
-
-        def get_method_desc(method, verbose):
-                if "pkglint_desc" in method.__dict__ and not verbose:
-                        return method.pkglint_desc
-                else:
-                        return "{0}.{1}.{2}".format(method.__self__.__class__.__module__,
-                            method.__self__.__class__.__name__,
-                            method.__func__.__name__)
-
-        def emit(name, value):
-                msg("{0} {1}".format(name.ljust(width), value))
-
-        def print_list(items):
-                k = list(items.keys())
-                k.sort()
-                for lint_id in k:
-                        emit(lint_id, items[lint_id])
-
-        include_items = {}
-        exclude_items = {}
-
-        for checker in checkers:
-                for m, lint_id in checker.included_checks:
-                        include_items[lint_id] = get_method_desc(m, verbose)
-
-        for checker in exclude:
-                for m, lint_id in checker.excluded_checks:
-                        exclude_items[lint_id] = get_method_desc(m, verbose)
-                for m, lint_id in checker.included_checks:
-                        exclude_items[lint_id] = get_method_desc(m, verbose)
-
-        for checker in checkers:
-                for m, lint_id in checker.excluded_checks:
-                        exclude_items[lint_id] = get_method_desc(m, verbose)
-
-        if include_items or exclude_items:
-                if verbose:
-                        emit(_("NAME"), _("METHOD"))
-                else:
-                        emit(_("NAME"), _("DESCRIPTION"))
-                print_list(include_items)
-
-                if exclude_items:
-                        msg(_("\nExcluded checks:"))
-                        print_list(exclude_items)
-
-def read_manifests(names, lint_logger):
-        """Read a list of filenames, return a list of Manifest objects."""
+        if (opts.lint_uris or opts.ref_uris) and not opts.cache:
+            parser.error(
+                _("Required -c option missing when using " "repositories.")
+            )
 
         manifests = []
-        for filename in names:
-                data = None
-                # borrowed code from publish.py
-                lines = []      # giant string of all input lines
-                linecnts = []   # tuples of starting line no., ending line no
-                linecounter = 0 # running total
-                try:
-                        f = codecs.open(filename, "rb", "utf-8")
-                        data = f.read()
-                except UnicodeDecodeError as e:
-                        lint_logger.critical(_("Invalid file {file}: "
-                            "manifest not encoded in UTF-8: {err}").format(
-                            file=filename, err=e),
-                            msgid="lint.manifest002")
-                        continue
-                except IOError as e:
-                        lint_logger.critical(_("Unable to read manifest file "
-                            "{file}: {err}").format(file=filename, err=e),
-                            msgid="lint.manifest001")
-                        continue
-                lines.append(data)
-                linecnt = len(data.splitlines())
-                linecnts.append((linecounter, linecounter + linecnt))
-                linecounter += linecnt
+        if len(args) >= 1:
+            manifests = read_manifests(args, lint_logger)
+            if None in manifests or lint_logger.produced_lint_msgs():
+                error(_("Fatal error in manifest - exiting."))
+                return EXIT_OOPS
+        lint_engine.setup(
+            ref_uris=opts.ref_uris,
+            lint_uris=opts.lint_uris,
+            lint_manifests=manifests,
+            cache=opts.cache,
+            pattern=pattern,
+            release=opts.release,
+        )
 
-                manifest = pkg.manifest.Manifest()
-                try:
-                        manifest.set_content(content="\n".join(lines))
-                except pkg.actions.ActionError as e:
-                        lineno = e.lineno
-                        for i, tup in enumerate(linecnts):
-                                if lineno > tup[0] and lineno <= tup[1]:
-                                        lineno -= tup[0]
-                                        break
-                        else:
-                                lineno = "???"
+        msg(_("Starting lint run..."))
 
-                        lint_logger.critical(
-                            _("Error in {file} line: {ln}: {err} ").format(
-                            file=filename,
-                            ln=lineno,
-                            err=str(e)), "lint.manifest002")
-                        manifest = None
-                except InvalidPackageErrors as e:
-                        lint_logger.critical(
-                            _("Error in file {file}: {err}").format(
-                            file=filename,
-                            err=str(e)), "lint.manifest002")
-                        manifest = None
+        lint_engine.execute()
+        lint_engine.teardown()
+        lint_logger.close()
 
-                if manifest and "pkg.fmri" in manifest:
-                        try:
-                                manifest.fmri = \
-                                    pkg.fmri.PkgFmri(manifest["pkg.fmri"])
-                        except fmri.IllegalFmri as e:
-                                lint_logger.critical(
-                                    _("Error in file {file}: "
-                                    "{err}").format(
-                                    file=filename, err=e),
-                                    "lint.manifest002")
-                        if manifest.fmri:
-                                if not manifest.fmri.version:
-                                        lint_logger.critical(
-                                            _("Error in file {0}: "
-                                            "pkg.fmri does not include a "
-                                            "version string").format(filename),
-                                            "lint.manifest003")
-                                else:
-                                        manifests.append(manifest)
+    except engine.LintEngineSetupException as err:
+        # errors during setup are likely to be caused by bad
+        # input or configuration, not lint errors in manifests.
+        error(err)
+        return EXIT_BADOPT
 
-                elif manifest:
-                        lint_logger.critical(
-                            _("Manifest {0} does not declare fmri.").format(filename),
-                            "lint.manifest003")
+    except engine.LintEngineException as err:
+        error(err)
+        return EXIT_OOPS
+
+    if lint_logger.produced_lint_msgs():
+        return EXIT_OOPS
+    else:
+        return EXIT_OK
+
+
+def list_checks(checkers, exclude, verbose=False):
+    """Prints a human-readable version of configured checks."""
+
+    # used for justifying output
+    width = 28
+
+    def get_method_desc(method, verbose):
+        if "pkglint_desc" in method.__dict__ and not verbose:
+            return method.pkglint_desc
+        else:
+            return "{0}.{1}.{2}".format(
+                method.__self__.__class__.__module__,
+                method.__self__.__class__.__name__,
+                method.__func__.__name__,
+            )
+
+    def emit(name, value):
+        msg("{0} {1}".format(name.ljust(width), value))
+
+    def print_list(items):
+        k = list(items.keys())
+        k.sort()
+        for lint_id in k:
+            emit(lint_id, items[lint_id])
+
+    include_items = {}
+    exclude_items = {}
+
+    for checker in checkers:
+        for m, lint_id in checker.included_checks:
+            include_items[lint_id] = get_method_desc(m, verbose)
+
+    for checker in exclude:
+        for m, lint_id in checker.excluded_checks:
+            exclude_items[lint_id] = get_method_desc(m, verbose)
+        for m, lint_id in checker.included_checks:
+            exclude_items[lint_id] = get_method_desc(m, verbose)
+
+    for checker in checkers:
+        for m, lint_id in checker.excluded_checks:
+            exclude_items[lint_id] = get_method_desc(m, verbose)
+
+    if include_items or exclude_items:
+        if verbose:
+            emit(_("NAME"), _("METHOD"))
+        else:
+            emit(_("NAME"), _("DESCRIPTION"))
+        print_list(include_items)
+
+        if exclude_items:
+            msg(_("\nExcluded checks:"))
+            print_list(exclude_items)
+
+
+def read_manifests(names, lint_logger):
+    """Read a list of filenames, return a list of Manifest objects."""
+
+    manifests = []
+    for filename in names:
+        data = None
+        # borrowed code from publish.py
+        lines = []  # giant string of all input lines
+        linecnts = []  # tuples of starting line no., ending line no
+        linecounter = 0  # running total
+        try:
+            f = codecs.open(filename, "rb", "utf-8")
+            data = f.read()
+        except UnicodeDecodeError as e:
+            lint_logger.critical(
+                _(
+                    "Invalid file {file}: "
+                    "manifest not encoded in UTF-8: {err}"
+                ).format(file=filename, err=e),
+                msgid="lint.manifest002",
+            )
+            continue
+        except IOError as e:
+            lint_logger.critical(
+                _("Unable to read manifest file " "{file}: {err}").format(
+                    file=filename, err=e
+                ),
+                msgid="lint.manifest001",
+            )
+            continue
+        lines.append(data)
+        linecnt = len(data.splitlines())
+        linecnts.append((linecounter, linecounter + linecnt))
+        linecounter += linecnt
+
+        manifest = pkg.manifest.Manifest()
+        try:
+            manifest.set_content(content="\n".join(lines))
+        except pkg.actions.ActionError as e:
+            lineno = e.lineno
+            for i, tup in enumerate(linecnts):
+                if lineno > tup[0] and lineno <= tup[1]:
+                    lineno -= tup[0]
+                    break
+            else:
+                lineno = "???"
+
+            lint_logger.critical(
+                _("Error in {file} line: {ln}: {err} ").format(
+                    file=filename, ln=lineno, err=str(e)
+                ),
+                "lint.manifest002",
+            )
+            manifest = None
+        except InvalidPackageErrors as e:
+            lint_logger.critical(
+                _("Error in file {file}: {err}").format(
+                    file=filename, err=str(e)
+                ),
+                "lint.manifest002",
+            )
+            manifest = None
+
+        if manifest and "pkg.fmri" in manifest:
+            try:
+                manifest.fmri = pkg.fmri.PkgFmri(manifest["pkg.fmri"])
+            except fmri.IllegalFmri as e:
+                lint_logger.critical(
+                    _("Error in file {file}: " "{err}").format(
+                        file=filename, err=e
+                    ),
+                    "lint.manifest002",
+                )
+            if manifest.fmri:
+                if not manifest.fmri.version:
+                    lint_logger.critical(
+                        _(
+                            "Error in file {0}: "
+                            "pkg.fmri does not include a "
+                            "version string"
+                        ).format(filename),
+                        "lint.manifest003",
+                    )
                 else:
-                        manifests.append(None)
-        return manifests
+                    manifests.append(manifest)
+
+        elif manifest:
+            lint_logger.critical(
+                _("Manifest {0} does not declare fmri.").format(filename),
+                "lint.manifest003",
+            )
+        else:
+            manifests.append(None)
+    return manifests
+
 
 def _make_list(opt):
-        """Makes a list out of opt, and returns it."""
+    """Makes a list out of opt, and returns it."""
 
-        if isinstance(opt, list):
-                return opt
-        elif opt is None:
-                return []
-        else:
-                return [opt]
+    if isinstance(opt, list):
+        return opt
+    elif opt is None:
+        return []
+    else:
+        return [opt]
 
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
-        try:
-                __ret = main_func()
-        except (PipeError, KeyboardInterrupt):
-                # We don't want to display any messages here to prevent
-                # possible further broken pipe (EPIPE) errors.
-                __ret = EXIT_BADOPT
-        except SystemExit as __e:
-                __ret = __e.code
-        except (apx.InvalidDepotResponseException, tx.TransportFailures) as __e:
-                error(__e)
-                __ret = EXIT_BADOPT
-        except:
-                traceback.print_exc()
-                error(misc.get_traceback_message())
-                __ret = 99
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
+    try:
+        __ret = main_func()
+    except (PipeError, KeyboardInterrupt):
+        # We don't want to display any messages here to prevent
+        # possible further broken pipe (EPIPE) errors.
+        __ret = EXIT_BADOPT
+    except SystemExit as __e:
+        __ret = __e.code
+    except (apx.InvalidDepotResponseException, tx.TransportFailures) as __e:
+        error(__e)
+        __ret = EXIT_BADOPT
+    except:
+        traceback.print_exc()
+        error(misc.get_traceback_message())
+        __ret = 99
 
-        sys.exit(__ret)
+    sys.exit(__ret)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/publish/pkgmerge.py
+++ b/src/util/publish/pkgmerge.py
@@ -24,86 +24,94 @@
 #
 
 from __future__ import print_function
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 
 try:
-        import calendar
-        import collections
-        import getopt
-        import gettext
-        import itertools
-        import locale
-        import os
-        import shutil
-        import six
-        import sys
-        import tempfile
-        import traceback
+    import calendar
+    import collections
+    import getopt
+    import gettext
+    import itertools
+    import locale
+    import os
+    import shutil
+    import six
+    import sys
+    import tempfile
+    import traceback
 
-        import pkg.actions as actions
-        import pkg.fmri
-        import pkg.client.api_errors as apx
-        import pkg.client.progress as progress
-        import pkg.client.publisher as publisher
-        import pkg.client.transport.transport as transport
-        import pkg.manifest as manifest
-        import pkg.misc as misc
-        import pkg.publish.transaction as trans
+    import pkg.actions as actions
+    import pkg.fmri
+    import pkg.client.api_errors as apx
+    import pkg.client.progress as progress
+    import pkg.client.publisher as publisher
+    import pkg.client.transport.transport as transport
+    import pkg.manifest as manifest
+    import pkg.misc as misc
+    import pkg.publish.transaction as trans
 
-        from functools import reduce
-        from pkg.misc import PipeError, emsg, msg
-        from six.moves.urllib.parse import quote
-        from pkg.client.pkgdefs import (EXIT_OK, EXIT_OOPS, EXIT_BADOPT,
-            EXIT_PARTIAL)
+    from functools import reduce
+    from pkg.misc import PipeError, emsg, msg
+    from six.moves.urllib.parse import quote
+    from pkg.client.pkgdefs import EXIT_OK, EXIT_OOPS, EXIT_BADOPT, EXIT_PARTIAL
 except KeyboardInterrupt:
-        import sys
-        sys.exit(EXIT_OOPS)
+    import sys
+
+    sys.exit(EXIT_OOPS)
+
 
 class PkgmergeException(Exception):
-        """An exception raised if something goes wrong during the merging
-        process."""
-        pass
+    """An exception raised if something goes wrong during the merging
+    process."""
+
+    pass
 
 
-catalog_dict   = {}    # hash table of catalogs by source uri
-fmri_cache     = {}
+catalog_dict = {}  # hash table of catalogs by source uri
+fmri_cache = {}
 manifest_cache = {}
-null_manifest  = manifest.Manifest()
-tmpdir         = None
-dry_run        = False
-xport          = None
-dest_xport     = None
-pubs           = set()
-target_pub     = None
+null_manifest = manifest.Manifest()
+tmpdir = None
+dry_run = False
+xport = None
+dest_xport = None
+pubs = set()
+target_pub = None
+
 
 def cleanup():
-        """To be called at program finish."""
+    """To be called at program finish."""
 
-        if tmpdir:
-                shutil.rmtree(tmpdir, ignore_errors=True)
+    if tmpdir:
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
-        if dry_run:
-                return
+    if dry_run:
+        return
 
-        # Attempt to kick off a refresh of target repository for each
-        # publisher before exiting.
-        for pfx in pubs:
-                target_pub.prefix = pfx
-                try:
-                        dest_xport.publish_refresh_packages(target_pub)
-                except apx.TransportError:
-                        # If this fails, ignore it as this was a last
-                        # ditch attempt anyway.
-                        break
+    # Attempt to kick off a refresh of target repository for each
+    # publisher before exiting.
+    for pfx in pubs:
+        target_pub.prefix = pfx
+        try:
+            dest_xport.publish_refresh_packages(target_pub)
+        except apx.TransportError:
+            # If this fails, ignore it as this was a last
+            # ditch attempt anyway.
+            break
+
 
 def usage(errmsg="", exitcode=2):
-        """Emit a usage message and optionally prefix it with a more specific
-        error message.  Causes program to exit."""
+    """Emit a usage message and optionally prefix it with a more specific
+    error message.  Causes program to exit."""
 
-        if errmsg:
-                emsg("pkgmerge: {0}".format(errmsg))
+    if errmsg:
+        emsg("pkgmerge: {0}".format(errmsg))
 
-        msg(_("""\
+    msg(
+        _(
+            """\
 Usage:
         pkgmerge [-n] -d dest_repo -s variant=value[,...],src_repo ...
             [-p publisher_prefix ... ] [pkg_fmri_pattern ...]
@@ -139,864 +147,912 @@ Environment:
         TMPDIR, TEMP, TMP
                 The absolute path of the directory where temporary data should
                 be stored during program execution.
-"""))
+"""
+        )
+    )
 
-        sys.exit(exitcode)
+    sys.exit(exitcode)
+
 
 def error(text, exitcode=EXIT_OOPS):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        emsg("pkgmerge: {0}".format(text))
+    emsg("pkgmerge: {0}".format(text))
 
-        if exitcode != None:
-                sys.exit(exitcode)
+    if exitcode != None:
+        sys.exit(exitcode)
+
 
 def get_tracker():
-        try:
-                progresstracker = \
-                    progress.FancyUNIXProgressTracker()
-        except progress.ProgressTrackerException:
-                progresstracker = progress.CommandLineProgressTracker()
-        return progresstracker
+    try:
+        progresstracker = progress.FancyUNIXProgressTracker()
+    except progress.ProgressTrackerException:
+        progresstracker = progress.CommandLineProgressTracker()
+    return progresstracker
+
 
 def load_catalog(repouri, pub):
-        """Load catalog from specified uri"""
-        # Pull catalog only from this host
-        pub.repository.origins = [repouri]
-        pub.refresh(full_refresh=True, immediate=True)
+    """Load catalog from specified uri"""
+    # Pull catalog only from this host
+    pub.repository.origins = [repouri]
+    pub.refresh(full_refresh=True, immediate=True)
 
-        catalog_dict[repouri.uri] = dict(
-            (name, [
-                entry
-                for entry in pub.catalog.fmris_by_version(name)
-            ])
-            for name in pub.catalog.names()
-        )
+    catalog_dict[repouri.uri] = dict(
+        (name, [entry for entry in pub.catalog.fmris_by_version(name)])
+        for name in pub.catalog.names()
+    )
 
-        # Discard catalog.
-        pub.remove_meta_root()
-        # XXX At the moment, the only way to force the publisher object to
-        # discard its copy of a catalog is to set repository.
-        pub.repository = pub.repository
+    # Discard catalog.
+    pub.remove_meta_root()
+    # XXX At the moment, the only way to force the publisher object to
+    # discard its copy of a catalog is to set repository.
+    pub.repository = pub.repository
+
 
 def get_all_pkg_names(repouri):
-        return list(catalog_dict[repouri.uri].keys())
+    return list(catalog_dict[repouri.uri].keys())
+
 
 def get_manifest(repouri, fmri):
-        """Fetch the manifest for package-fmri 'fmri' from the source
-        in 'repouri'... return as Manifest object."""
+    """Fetch the manifest for package-fmri 'fmri' from the source
+    in 'repouri'... return as Manifest object."""
 
-        # support null manifests to keep lists ordered for merge
-        if not fmri:
-                return null_manifest
+    # support null manifests to keep lists ordered for merge
+    if not fmri:
+        return null_manifest
 
-        mfst_str = xport.get_manifest(fmri, pub=repouri, content_only=True)
-        m = manifest.Manifest(fmri)
-        m.set_content(content=mfst_str)
-        return m
+    mfst_str = xport.get_manifest(fmri, pub=repouri, content_only=True)
+    m = manifest.Manifest(fmri)
+    m.set_content(content=mfst_str)
+    return m
+
 
 def main_func():
-        global dry_run, tmpdir, xport, dest_xport, target_pub
+    global dry_run, tmpdir, xport, dest_xport, target_pub
 
-        dest_repo     = None
-        source_list   = []
-        variant_list  = []
-        pub_list      = []
-        use_pub_list  = False
+    dest_repo = None
+    source_list = []
+    variant_list = []
+    pub_list = []
+    use_pub_list = False
 
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "d:np:s:?",
-                    ["help"])
-                for opt, arg in opts:
-                        if opt == "-d":
-                                dest_repo = misc.parse_uri(arg)
-                        elif opt == "-n":
-                                dry_run = True
-                        elif opt == "-s":
-                                s = arg.split(",")
-                                if len(s) < 2:
-                                        usage("-s option must specify "
-                                            "variant=value,repo_uri")
+    try:
+        opts, pargs = getopt.getopt(sys.argv[1:], "d:np:s:?", ["help"])
+        for opt, arg in opts:
+            if opt == "-d":
+                dest_repo = misc.parse_uri(arg)
+            elif opt == "-n":
+                dry_run = True
+            elif opt == "-s":
+                s = arg.split(",")
+                if len(s) < 2:
+                    usage("-s option must specify " "variant=value,repo_uri")
 
-                                # All but last part should be variant.
-                                src_vars = {}
-                                for v in s[:-1]:
-                                        try:
-                                                vname, vval = v.split("=")
-                                        except ValueError:
-                                                usage("-s option must specify "
-                                                    "variant=value,repo_uri")
-
-                                        if not vname.startswith("variant."):
-                                                vname = "variant.{0}".format(vname)
-                                        src_vars[vname] = vval
-
-                                variant_list.append(src_vars)
-                                source_list.append(publisher.RepositoryURI(
-                                    misc.parse_uri(s[-1])))
-                        elif opt == "-p":
-                                use_pub_list = True
-                                pub_list.append(arg)
-
-                        if opt in ("--help", "-?"):
-                                usage(exitcode=0)
-        except getopt.GetoptError as e:
-                usage(_("illegal option -- {0}").format(e.opt))
-
-        if not source_list:
-                usage(_("At least one variant name, value, and package source "
-                   "must be provided using -s."))
-
-        if not dest_repo:
-                usage(_("A destination package repository must be provided "
-                    "using -d."))
-
-        # Determine the unique set of variants across all sources.
-        variants = set()
-        vcombos = collections.defaultdict(set)
-        for src_vars in variant_list:
-                for v, vval in six.iteritems(src_vars):
-                        variants.add(v)
-                        vcombos[v].add((v, vval))
-
-        # merge_fmris() expects this to be a list. Sort it to make sure
-        # combo is determinstic in the later construction.
-        variants = sorted(variants, reverse=True)
-
-        # Require that the user specified the same variants for all sources.
-        for i, src_vars in enumerate(variant_list):
-                missing = set(v for v in variants if v not in variant_list[i])
-                if missing:
-                        missing = ", ".join(missing)
-                        source = source_list[i]
-                        usage(_("Source {source} missing values for "
-                            "variants: {missing}").format(**locals()))
-
-        # Require that each unique variant combination has a source.
-        for combo in itertools.product(*vcombos.values()):
-                found = False
-                for i, src in enumerate(source_list):
-                        for vname, vval in combo:
-                                if variant_list[i].get(vname,
-                                    None) != vval:
-                                        found = False
-                                        break
-                        else:
-                                found = True
-                                break
-
-                if not found:
-                        combo = " ".join(
-                            "{0}={1}".format(vname, vval)
-                            for vname, vval in combo
+                # All but last part should be variant.
+                src_vars = {}
+                for v in s[:-1]:
+                    try:
+                        vname, vval = v.split("=")
+                    except ValueError:
+                        usage(
+                            "-s option must specify " "variant=value,repo_uri"
                         )
-                        usage(_("No source was specified for variant "
-                            "combination {combo}.").format(**locals()))
 
-        # initialize transport
-        # we use a single endpoint for now, since the transport code
-        # uses publisher as a unique key... so we just flop the repo
-        # list as needed to access the different catalogs/manifests/files.
-        temp_root = misc.config_temp_root()
+                    if not vname.startswith("variant."):
+                        vname = "variant.{0}".format(vname)
+                    src_vars[vname] = vval
 
-        tmpdir = tempfile.mkdtemp(dir=temp_root, prefix="pkgmerge")
-        xport, xport_cfg = transport.setup_transport()
-        xport_cfg.incoming_root = tmpdir
-
-        # we don't use the publisher returned by setup_publisher, as that only
-        # returns one of the publishers in source_list.  Instead we use
-        # xport_cfg to access all publishers.
-        transport.setup_publisher(source_list,
-            "pkgmerge", xport, xport_cfg, remote_prefix=True)
-        cat_dir = tempfile.mkdtemp(dir=tmpdir)
-
-        # we must have at least one matching publisher if -p was used.
-        known_pubs = set([pub.prefix for pub in xport_cfg.gen_publishers()])
-        if pub_list and len(set(pub_list).intersection(known_pubs)) == 0:
-                error(_("no publishers from source repositories match "
-                    "the given -p options."))
-
-        errors = set()
-        tracker = get_tracker()
-
-        # iterate over all publishers in our source repositories.  If errors
-        # are encountered for a given publisher, we accumulate those, and
-        # skip to the next publisher.
-        for pub in xport_cfg.gen_publishers():
-
-                if use_pub_list:
-                        if pub.prefix not in pub_list:
-                                continue
-                        else:
-                                # remove publishers from pub_list as we go, so
-                                # that when we're finished, any remaining
-                                # publishers in pub_list suggest superfluous
-                                # -p options, which will cause us to exit with
-                                # an error.
-                                pub_list.remove(pub.prefix)
-
-                pub.meta_root = cat_dir
-                pub.transport = xport
-
-                # Use separate transport for destination repository in case
-                # source and destination have identical publisher configuration.
-                dest_xport, dest_xport_cfg = transport.setup_transport()
-                dest_xport_cfg.incoming_root = tmpdir
-
-                # retrieve catalogs for all specified repositories
-                for s in source_list:
-                        load_catalog(s, pub)
-
-                # determine the list of packages we'll be processing
-                if not pargs:
-                        # use the latest versions and merge everything
-                        fmri_arguments = list(set(
-                            name
-                            for s in source_list
-                            for name in get_all_pkg_names(s)
-                        ))
-                        exclude_args = []
-                else:
-                        fmri_arguments = [
-                            f
-                            for f in pargs
-                            if not f.startswith("!")
-                        ]
-
-                        exclude_args = [
-                            f[1:]
-                            for f in pargs
-                            if f.startswith("!")
-                        ]
-
-                # build fmris to be merged
-                masterlist = [
-                    build_merge_list(fmri_arguments, exclude_args,
-                        catalog_dict[s.uri])
-                    for s in source_list
-                ]
-
-                # check for unmatched patterns
-                in_none = reduce(lambda x, y: x & y,
-                    (set(u) for d, u in masterlist))
-                if in_none:
-                        errors.add(
-                            _("The following pattern(s) did not match any "
-                            "packages in any of the specified repositories for "
-                            "publisher {pub_name}:"
-                            "\n{patterns}").format(patterns="\n".join(in_none),
-                            pub_name=pub.prefix))
-                        continue
-
-                # generate set of all package names to be processed, and dict
-                # of lists indexed by order in source_list; if that repo has no
-                # fmri for this pkg then use None.
-                allpkgs = set(name for d, u in masterlist for name in d)
-
-                processdict = {}
-                for p in allpkgs:
-                        for d, u in masterlist:
-                                processdict.setdefault(p, []).append(
-                                    d.setdefault(p, None))
-
-                # check to make sure all fmris are at same version modulo
-                # timestamp
-                for entry in processdict:
-                        if len(set([
-                                str(a).rsplit(":")[0]
-                                for a in processdict[entry]
-                                if a is not None
-                            ])) > 1:
-                                errors.add(
-                                    _("fmris matching the following patterns do"
-                                    " not have matching versions across all "
-                                    "repositories for publisher {pubs}: "
-                                    "{patterns}").format(pub=pub.prefix,
-                                    patterns=processdict[entry]))
-                                continue
-
-                target_pub = transport.setup_publisher(dest_repo,
-                    pub.prefix, dest_xport, dest_xport_cfg,
-                    remote_prefix=True)
-
-                tracker.republish_set_goal(len(processdict), 0, 0)
-                # republish packages for this publisher. If we encounter any
-                # publication errors, we move on to the next publisher.
-                try:
-                        pkg_tmpdir = tempfile.mkdtemp(dir=tmpdir)
-                        republish_packages(pub, target_pub,
-                            processdict, source_list, variant_list, variants,
-                            tracker, xport, dest_repo, dest_xport, pkg_tmpdir,
-                            dry_run=dry_run)
-                except (trans.TransactionError, PkgmergeException) as e:
-                        errors.add(str(e))
-                        tracker.reset()
-                        continue
-                finally:
-                        # if we're handling an exception, this still gets called
-                        # in spite of the 'continue' that the handler ends with.
-                        if os.path.exists(pkg_tmpdir):
-                                shutil.rmtree(pkg_tmpdir)
-
-                tracker.republish_done(dryrun=dry_run)
-                tracker.reset()
-
-        # If -p options were supplied, we should have processed all of them
-        # by now. Remaining entries suggest -p options that were not merged.
-        if use_pub_list and pub_list:
-                errors.add(_("the following publishers were not found in "
-                    "source repositories: {0}").format(" ".join(pub_list)))
-
-        # If we have encountered errors for some publishers, print them now
-        # and exit.
-        tracker.flush()
-        for message in errors:
-                error(message, exitcode=None)
-        if errors:
-                exit(EXIT_OOPS)
-
-        return EXIT_OK
-
-def republish_packages(pub, target_pub, processdict, source_list, variant_list,
-        variants, tracker, xport, dest_repo, dest_xport, pkg_tmpdir,
-        dry_run=False):
-        """Republish packages for publisher pub to dest_repo.
-
-        If we try to republish a package that we have already published,
-        an exception is raise.
-
-        pub             the publisher from source_list that we are republishing
-        target_pub      the destination publisher
-        processdict     a dict indexed by package name of the pkgs to merge
-        source_list     a list of source respositories
-        variant_list    a list of dicts containing variant names/values
-        variants        the unique set of variants across all sources.
-        tracker         a progress tracker
-        xport           the transport handling our source repositories
-        dest_repo       our destination repository
-        dest_xport      the transport handling our destination repository
-        pkg_tmpdir      a temporary dir used when downloading pkg content
-                        which may be deleted and recreated by this method.
-
-        dry_run         True if we should not actually publish
-        """
-
-        def get_basename(pfmri):
-                open_time = pfmri.get_timestamp()
-                return "{0:d}_{0}".format(
-                    calendar.timegm(open_time.utctimetuple()),
-                    quote(str(pfmri), ""))
-
-        for entry in processdict:
-                man, retrievals = merge_fmris(source_list,
-                    processdict[entry], variant_list, variants)
-
-                # Determine total bytes to retrieve for this package; this must
-                # be done using the retrievals dict since they are coalesced by
-                # hash.
-                getbytes = sum(
-                    misc.get_pkg_otw_size(a)
-                    for i, uri in enumerate(source_list)
-                    for a in retrievals[i]
+                variant_list.append(src_vars)
+                source_list.append(
+                    publisher.RepositoryURI(misc.parse_uri(s[-1]))
                 )
+            elif opt == "-p":
+                use_pub_list = True
+                pub_list.append(arg)
 
-                # Determine total bytes to send for this package; this must be
-                # done using the manifest since retrievals are coalesced based
-                # on hash, but sends are not.
-                f = man.fmri
-                target_pub.prefix = f.publisher
-                sendbytes = dest_xport.get_transfer_size(target_pub,
-                    man.gen_actions())
+            if opt in ("--help", "-?"):
+                usage(exitcode=0)
+    except getopt.GetoptError as e:
+        usage(_("illegal option -- {0}").format(e.opt))
 
-                tracker.republish_start_pkg(f, getbytes=getbytes,
-                    sendbytes=sendbytes)
+    if not source_list:
+        usage(
+            _(
+                "At least one variant name, value, and package source "
+                "must be provided using -s."
+            )
+        )
 
-                if dry_run:
-                        # Dry-run; attempt a merge of everything but don't
-                        # write any data or publish packages.
-                        continue
+    if not dest_repo:
+        usage(
+            _("A destination package repository must be provided " "using -d.")
+        )
 
-                # Retrieve package data from each package source.
-                for i, uri in enumerate(source_list):
-                        pub.repository.origins = [uri]
-                        mfile = xport.multi_file_ni(pub, pkg_tmpdir,
-                            decompress=True, progtrack=tracker)
-                        for a in retrievals[i]:
-                                mfile.add_action(a)
-                        mfile.wait_files()
+    # Determine the unique set of variants across all sources.
+    variants = set()
+    vcombos = collections.defaultdict(set)
+    for src_vars in variant_list:
+        for v, vval in six.iteritems(src_vars):
+            variants.add(v)
+            vcombos[v].add((v, vval))
 
-                trans_id = get_basename(f)
-                pkg_name = f.get_fmri()
-                pubs.add(target_pub.prefix)
-                # Publish merged package.
-                t = trans.Transaction(dest_repo,
-                    pkg_name=pkg_name, trans_id=trans_id,
-                    xport=dest_xport, pub=target_pub,
-                    progtrack=tracker)
+    # merge_fmris() expects this to be a list. Sort it to make sure
+    # combo is determinstic in the later construction.
+    variants = sorted(variants, reverse=True)
 
-                # Remove any previous failed attempt to
-                # to republish this package.
-                try:
-                        t.close(abandon=True)
-                except:
-                        # It might not exist already.
-                        pass
+    # Require that the user specified the same variants for all sources.
+    for i, src_vars in enumerate(variant_list):
+        missing = set(v for v in variants if v not in variant_list[i])
+        if missing:
+            missing = ", ".join(missing)
+            source = source_list[i]
+            usage(
+                _(
+                    "Source {source} missing values for " "variants: {missing}"
+                ).format(**locals())
+            )
 
-                t.open()
-                for a in man.gen_actions():
-                        if (a.name == "set" and
-                            a.attrs["name"] == "pkg.fmri"):
-                                # To be consistent with the
-                                # server, the fmri can't be
-                                # added to the manifest.
-                                continue
+    # Require that each unique variant combination has a source.
+    for combo in itertools.product(*vcombos.values()):
+        found = False
+        for i, src in enumerate(source_list):
+            for vname, vval in combo:
+                if variant_list[i].get(vname, None) != vval:
+                    found = False
+                    break
+            else:
+                found = True
+                break
 
-                        if hasattr(a, "hash"):
-                                fname = os.path.join(pkg_tmpdir,
-                                    a.hash)
-                                a.data = lambda: open(
-                                    fname, "rb")
-                        t.add(a)
+        if not found:
+            combo = " ".join(
+                "{0}={1}".format(vname, vval) for vname, vval in combo
+            )
+            usage(
+                _(
+                    "No source was specified for variant "
+                    "combination {combo}."
+                ).format(**locals())
+            )
 
-                # Always defer catalog update.
-                t.close(add_to_catalog=False)
+    # initialize transport
+    # we use a single endpoint for now, since the transport code
+    # uses publisher as a unique key... so we just flop the repo
+    # list as needed to access the different catalogs/manifests/files.
+    temp_root = misc.config_temp_root()
 
-                # Done with this package.
-                tracker.republish_end_pkg(f)
+    tmpdir = tempfile.mkdtemp(dir=temp_root, prefix="pkgmerge")
+    xport, xport_cfg = transport.setup_transport()
+    xport_cfg.incoming_root = tmpdir
 
-                # Dump retrieved package data after each republication and
-                # recreate the directory for the next package.
+    # we don't use the publisher returned by setup_publisher, as that only
+    # returns one of the publishers in source_list.  Instead we use
+    # xport_cfg to access all publishers.
+    transport.setup_publisher(
+        source_list, "pkgmerge", xport, xport_cfg, remote_prefix=True
+    )
+    cat_dir = tempfile.mkdtemp(dir=tmpdir)
+
+    # we must have at least one matching publisher if -p was used.
+    known_pubs = set([pub.prefix for pub in xport_cfg.gen_publishers()])
+    if pub_list and len(set(pub_list).intersection(known_pubs)) == 0:
+        error(
+            _(
+                "no publishers from source repositories match "
+                "the given -p options."
+            )
+        )
+
+    errors = set()
+    tracker = get_tracker()
+
+    # iterate over all publishers in our source repositories.  If errors
+    # are encountered for a given publisher, we accumulate those, and
+    # skip to the next publisher.
+    for pub in xport_cfg.gen_publishers():
+        if use_pub_list:
+            if pub.prefix not in pub_list:
+                continue
+            else:
+                # remove publishers from pub_list as we go, so
+                # that when we're finished, any remaining
+                # publishers in pub_list suggest superfluous
+                # -p options, which will cause us to exit with
+                # an error.
+                pub_list.remove(pub.prefix)
+
+        pub.meta_root = cat_dir
+        pub.transport = xport
+
+        # Use separate transport for destination repository in case
+        # source and destination have identical publisher configuration.
+        dest_xport, dest_xport_cfg = transport.setup_transport()
+        dest_xport_cfg.incoming_root = tmpdir
+
+        # retrieve catalogs for all specified repositories
+        for s in source_list:
+            load_catalog(s, pub)
+
+        # determine the list of packages we'll be processing
+        if not pargs:
+            # use the latest versions and merge everything
+            fmri_arguments = list(
+                set(name for s in source_list for name in get_all_pkg_names(s))
+            )
+            exclude_args = []
+        else:
+            fmri_arguments = [f for f in pargs if not f.startswith("!")]
+
+            exclude_args = [f[1:] for f in pargs if f.startswith("!")]
+
+        # build fmris to be merged
+        masterlist = [
+            build_merge_list(fmri_arguments, exclude_args, catalog_dict[s.uri])
+            for s in source_list
+        ]
+
+        # check for unmatched patterns
+        in_none = reduce(lambda x, y: x & y, (set(u) for d, u in masterlist))
+        if in_none:
+            errors.add(
+                _(
+                    "The following pattern(s) did not match any "
+                    "packages in any of the specified repositories for "
+                    "publisher {pub_name}:"
+                    "\n{patterns}"
+                ).format(patterns="\n".join(in_none), pub_name=pub.prefix)
+            )
+            continue
+
+        # generate set of all package names to be processed, and dict
+        # of lists indexed by order in source_list; if that repo has no
+        # fmri for this pkg then use None.
+        allpkgs = set(name for d, u in masterlist for name in d)
+
+        processdict = {}
+        for p in allpkgs:
+            for d, u in masterlist:
+                processdict.setdefault(p, []).append(d.setdefault(p, None))
+
+        # check to make sure all fmris are at same version modulo
+        # timestamp
+        for entry in processdict:
+            if (
+                len(
+                    set(
+                        [
+                            str(a).rsplit(":")[0]
+                            for a in processdict[entry]
+                            if a is not None
+                        ]
+                    )
+                )
+                > 1
+            ):
+                errors.add(
+                    _(
+                        "fmris matching the following patterns do"
+                        " not have matching versions across all "
+                        "repositories for publisher {pubs}: "
+                        "{patterns}"
+                    ).format(pub=pub.prefix, patterns=processdict[entry])
+                )
+                continue
+
+        target_pub = transport.setup_publisher(
+            dest_repo,
+            pub.prefix,
+            dest_xport,
+            dest_xport_cfg,
+            remote_prefix=True,
+        )
+
+        tracker.republish_set_goal(len(processdict), 0, 0)
+        # republish packages for this publisher. If we encounter any
+        # publication errors, we move on to the next publisher.
+        try:
+            pkg_tmpdir = tempfile.mkdtemp(dir=tmpdir)
+            republish_packages(
+                pub,
+                target_pub,
+                processdict,
+                source_list,
+                variant_list,
+                variants,
+                tracker,
+                xport,
+                dest_repo,
+                dest_xport,
+                pkg_tmpdir,
+                dry_run=dry_run,
+            )
+        except (trans.TransactionError, PkgmergeException) as e:
+            errors.add(str(e))
+            tracker.reset()
+            continue
+        finally:
+            # if we're handling an exception, this still gets called
+            # in spite of the 'continue' that the handler ends with.
+            if os.path.exists(pkg_tmpdir):
                 shutil.rmtree(pkg_tmpdir)
-                os.mkdir(pkg_tmpdir)
+
+        tracker.republish_done(dryrun=dry_run)
+        tracker.reset()
+
+    # If -p options were supplied, we should have processed all of them
+    # by now. Remaining entries suggest -p options that were not merged.
+    if use_pub_list and pub_list:
+        errors.add(
+            _(
+                "the following publishers were not found in "
+                "source repositories: {0}"
+            ).format(" ".join(pub_list))
+        )
+
+    # If we have encountered errors for some publishers, print them now
+    # and exit.
+    tracker.flush()
+    for message in errors:
+        error(message, exitcode=None)
+    if errors:
+        exit(EXIT_OOPS)
+
+    return EXIT_OK
+
+
+def republish_packages(
+    pub,
+    target_pub,
+    processdict,
+    source_list,
+    variant_list,
+    variants,
+    tracker,
+    xport,
+    dest_repo,
+    dest_xport,
+    pkg_tmpdir,
+    dry_run=False,
+):
+    """Republish packages for publisher pub to dest_repo.
+
+    If we try to republish a package that we have already published,
+    an exception is raise.
+
+    pub             the publisher from source_list that we are republishing
+    target_pub      the destination publisher
+    processdict     a dict indexed by package name of the pkgs to merge
+    source_list     a list of source respositories
+    variant_list    a list of dicts containing variant names/values
+    variants        the unique set of variants across all sources.
+    tracker         a progress tracker
+    xport           the transport handling our source repositories
+    dest_repo       our destination repository
+    dest_xport      the transport handling our destination repository
+    pkg_tmpdir      a temporary dir used when downloading pkg content
+                    which may be deleted and recreated by this method.
+
+    dry_run         True if we should not actually publish
+    """
+
+    def get_basename(pfmri):
+        open_time = pfmri.get_timestamp()
+        return "{0:d}_{0}".format(
+            calendar.timegm(open_time.utctimetuple()), quote(str(pfmri), "")
+        )
+
+    for entry in processdict:
+        man, retrievals = merge_fmris(
+            source_list, processdict[entry], variant_list, variants
+        )
+
+        # Determine total bytes to retrieve for this package; this must
+        # be done using the retrievals dict since they are coalesced by
+        # hash.
+        getbytes = sum(
+            misc.get_pkg_otw_size(a)
+            for i, uri in enumerate(source_list)
+            for a in retrievals[i]
+        )
+
+        # Determine total bytes to send for this package; this must be
+        # done using the manifest since retrievals are coalesced based
+        # on hash, but sends are not.
+        f = man.fmri
+        target_pub.prefix = f.publisher
+        sendbytes = dest_xport.get_transfer_size(target_pub, man.gen_actions())
+
+        tracker.republish_start_pkg(f, getbytes=getbytes, sendbytes=sendbytes)
+
+        if dry_run:
+            # Dry-run; attempt a merge of everything but don't
+            # write any data or publish packages.
+            continue
+
+        # Retrieve package data from each package source.
+        for i, uri in enumerate(source_list):
+            pub.repository.origins = [uri]
+            mfile = xport.multi_file_ni(
+                pub, pkg_tmpdir, decompress=True, progtrack=tracker
+            )
+            for a in retrievals[i]:
+                mfile.add_action(a)
+            mfile.wait_files()
+
+        trans_id = get_basename(f)
+        pkg_name = f.get_fmri()
+        pubs.add(target_pub.prefix)
+        # Publish merged package.
+        t = trans.Transaction(
+            dest_repo,
+            pkg_name=pkg_name,
+            trans_id=trans_id,
+            xport=dest_xport,
+            pub=target_pub,
+            progtrack=tracker,
+        )
+
+        # Remove any previous failed attempt to
+        # to republish this package.
+        try:
+            t.close(abandon=True)
+        except:
+            # It might not exist already.
+            pass
+
+        t.open()
+        for a in man.gen_actions():
+            if a.name == "set" and a.attrs["name"] == "pkg.fmri":
+                # To be consistent with the
+                # server, the fmri can't be
+                # added to the manifest.
+                continue
+
+            if hasattr(a, "hash"):
+                fname = os.path.join(pkg_tmpdir, a.hash)
+                a.data = lambda: open(fname, "rb")
+            t.add(a)
+
+        # Always defer catalog update.
+        t.close(add_to_catalog=False)
+
+        # Done with this package.
+        tracker.republish_end_pkg(f)
+
+        # Dump retrieved package data after each republication and
+        # recreate the directory for the next package.
+        shutil.rmtree(pkg_tmpdir)
+        os.mkdir(pkg_tmpdir)
+
 
 def merge_fmris(source_list, fmri_list, variant_list, variants):
-        """Merge a list of manifests representing multiple variants,
-        returning the merged manifest and a list of lists of actions to
-        retrieve from each source"""
+    """Merge a list of manifests representing multiple variants,
+    returning the merged manifest and a list of lists of actions to
+    retrieve from each source"""
 
-        # Merge each variant one at a time.
-        merged = {}
-        # where to find files...
-        hash_source = {}
+    # Merge each variant one at a time.
+    merged = {}
+    # where to find files...
+    hash_source = {}
 
-        for i, variant in enumerate(variants):
-                # Build the unique list of remaining variant combinations to
-                # use for merging this variant.
-                combos = set(
-                    tuple(
-                        (vname, src_vars[vname])
-                        for vname in variants[i + 1:]
-                    )
-                    for src_vars in variant_list
-                )
+    for i, variant in enumerate(variants):
+        # Build the unique list of remaining variant combinations to
+        # use for merging this variant.
+        combos = set(
+            tuple((vname, src_vars[vname]) for vname in variants[i + 1 :])
+            for src_vars in variant_list
+        )
 
-                if not combos:
-                        # If there are no other variants to combine, then simply
-                        # combine all manifests.
-                        combos = [()]
+        if not combos:
+            # If there are no other variants to combine, then simply
+            # combine all manifests.
+            combos = [()]
 
-                # Perform the variant merge for each unique combination of
-                # remaining variants.  For example, a pkgmerge of:
-                #   -s arch=sparc,debug=false,flavor=32,...
-                #   -s arch=sparc,debug=false,flavor=64,...
-                #   -s arch=sparc,debug=true,flavor=32,...
-                #   -s arch=sparc,debug=true,flavor=64,...
-                #   -s arch=i386,debug=false,flavor=32,...
-                #   -s arch=i386,debug=false,flavor=64,...
-                #   -s arch=i386,debug=true,flavor=32,...
-                #   -s arch=i386,debug=true,flavor=64,...
-                #
-                # ...would produce the following combinations for each variant:
-                #   variant.arch
-                #     debug=false, flavor=32
-                #     debug=false, flavor=64
-                #     debug=true, flavor=32
-                #     debug=true, flavor=64
-                #   variant.debug
-                #     flavor=32
-                #     flavor=64
-                #   variant.flavor
-                #
-                for combo in combos:
-                        # Build the list of sources, fmris, and variant values
-                        # involved in this particular combo merge.
-                        slist = []
-                        flist = []
-                        vlist = []
-                        sindex = []
-                        new_fmri = None
-                        for j, src in enumerate(source_list):
-                                if combo:
-                                        # If filtering on a specific combination
-                                        # then skip this source if any of the
-                                        # combination parameters don't match.
-                                        skip = False
-                                        for vname, vval in combo:
-                                                if variant_list[j].get(vname,
-                                                    None) != vval:
-                                                        skip = True
-                                                        break
+        # Perform the variant merge for each unique combination of
+        # remaining variants.  For example, a pkgmerge of:
+        #   -s arch=sparc,debug=false,flavor=32,...
+        #   -s arch=sparc,debug=false,flavor=64,...
+        #   -s arch=sparc,debug=true,flavor=32,...
+        #   -s arch=sparc,debug=true,flavor=64,...
+        #   -s arch=i386,debug=false,flavor=32,...
+        #   -s arch=i386,debug=false,flavor=64,...
+        #   -s arch=i386,debug=true,flavor=32,...
+        #   -s arch=i386,debug=true,flavor=64,...
+        #
+        # ...would produce the following combinations for each variant:
+        #   variant.arch
+        #     debug=false, flavor=32
+        #     debug=false, flavor=64
+        #     debug=true, flavor=32
+        #     debug=true, flavor=64
+        #   variant.debug
+        #     flavor=32
+        #     flavor=64
+        #   variant.flavor
+        #
+        for combo in combos:
+            # Build the list of sources, fmris, and variant values
+            # involved in this particular combo merge.
+            slist = []
+            flist = []
+            vlist = []
+            sindex = []
+            new_fmri = None
+            for j, src in enumerate(source_list):
+                if combo:
+                    # If filtering on a specific combination
+                    # then skip this source if any of the
+                    # combination parameters don't match.
+                    skip = False
+                    for vname, vval in combo:
+                        if variant_list[j].get(vname, None) != vval:
+                            skip = True
+                            break
 
-                                        if skip:
-                                                continue
+                    if skip:
+                        continue
 
-                                # Skip this source if it doesn't have a matching
-                                # package to merge, or if it has already been
-                                # merged with another package.
-                                pfmri = fmri_list[j]
-                                if not pfmri or \
-                                    merged.get(id(pfmri), None) == null_manifest:
-                                        continue
+                # Skip this source if it doesn't have a matching
+                # package to merge, or if it has already been
+                # merged with another package.
+                pfmri = fmri_list[j]
+                if not pfmri or merged.get(id(pfmri), None) == null_manifest:
+                    continue
 
-                                # The newest FMRI in the set of manifests being
-                                # merged will be used as the new FMRI of the
-                                # merged package.
-                                if new_fmri is None or pfmri.version > new_fmri.version:
-                                        new_fmri = pfmri
+                # The newest FMRI in the set of manifests being
+                # merged will be used as the new FMRI of the
+                # merged package.
+                if new_fmri is None or pfmri.version > new_fmri.version:
+                    new_fmri = pfmri
 
-                                sindex.append(j)
-                                slist.append(src)
-                                flist.append(pfmri)
-                                vlist.append(variant_list[j][variant])
+                sindex.append(j)
+                slist.append(src)
+                flist.append(pfmri)
+                vlist.append(variant_list[j][variant])
 
-                        if not flist:
-                                # Nothing to merge for this combination.
-                                continue
+            if not flist:
+                # Nothing to merge for this combination.
+                continue
 
-                        # Build the list of manifests to be merged.
-                        mlist = []
-                        for j, s, f in zip(sindex, slist, flist):
-                                if id(f) in merged:
-                                        # Manifest already merged before, use
-                                        # the merged version.
-                                        m = merged[id(f)]
-                                else:
-                                        # Manifest not yet merged, retrieve
-                                        # from source; record those w/ payloads
-                                        # so we know from where to get them..
-                                        m = get_manifest(s, f)
-                                        for a in m.gen_actions():
-                                                if a.has_payload:
-                                                        hash_source.setdefault(a.hash, j)
-                                mlist.append(m)
+            # Build the list of manifests to be merged.
+            mlist = []
+            for j, s, f in zip(sindex, slist, flist):
+                if id(f) in merged:
+                    # Manifest already merged before, use
+                    # the merged version.
+                    m = merged[id(f)]
+                else:
+                    # Manifest not yet merged, retrieve
+                    # from source; record those w/ payloads
+                    # so we know from where to get them..
+                    m = get_manifest(s, f)
+                    for a in m.gen_actions():
+                        if a.has_payload:
+                            hash_source.setdefault(a.hash, j)
+                mlist.append(m)
 
-                        m = __merge_fmris(new_fmri, mlist, flist, vlist,
-                            variant)
+            m = __merge_fmris(new_fmri, mlist, flist, vlist, variant)
 
-                        for f in flist:
-                                if id(f) == id(new_fmri):
-                                        # This FMRI was used for the merged
-                                        # manifest; any future merges should
-                                        # use the merged manifest for this
-                                        # FMRI.
-                                        merged[id(f)] = m
-                                else:
-                                        # This package has been merged with
-                                        # another so shouldn't be retrieved
-                                        # or merged again.
-                                        merged[id(f)] = null_manifest
+            for f in flist:
+                if id(f) == id(new_fmri):
+                    # This FMRI was used for the merged
+                    # manifest; any future merges should
+                    # use the merged manifest for this
+                    # FMRI.
+                    merged[id(f)] = m
+                else:
+                    # This package has been merged with
+                    # another so shouldn't be retrieved
+                    # or merged again.
+                    merged[id(f)] = null_manifest
 
-        # Merge process should have resulted in a single non-null manifest.
-        m = [v for v in merged.values() if v != null_manifest]
-        assert len(m) == 1
-        m = m[0]
+    # Merge process should have resulted in a single non-null manifest.
+    m = [v for v in merged.values() if v != null_manifest]
+    assert len(m) == 1
+    m = m[0]
 
-        # Finally, build a list of actions to retrieve based on position in
-        # source_list.
+    # Finally, build a list of actions to retrieve based on position in
+    # source_list.
 
-        retrievals = [list() for i in source_list]
+    retrievals = [list() for i in source_list]
 
-        for a in m.gen_actions():
-                if a.has_payload:
-                        source = hash_source.pop(a.hash, None)
-                        if source is not None:
-                                retrievals[source].append(a)
-        return m, retrievals
+    for a in m.gen_actions():
+        if a.has_payload:
+            source = hash_source.pop(a.hash, None)
+            if source is not None:
+                retrievals[source].append(a)
+    return m, retrievals
 
 
 def __merge_fmris(new_fmri, manifest_list, fmri_list, variant_list, variant):
-        """Private merge implementation."""
+    """Private merge implementation."""
 
-        # Remove variant tags, package variant metadata, and signatures
-        # from manifests since we're reassigning.  This allows merging
-        # pre-tagged, already merged pkgs, or signed packages.
+    # Remove variant tags, package variant metadata, and signatures
+    # from manifests since we're reassigning.  This allows merging
+    # pre-tagged, already merged pkgs, or signed packages.
 
-        blended_actions = []
-        blend_names = set([variant, variant[8:]])
+    blended_actions = []
+    blend_names = set([variant, variant[8:]])
 
-        for j, m in enumerate(manifest_list):
-                deleted_count = 0
-                vval = variant_list[j]
-                for i, a in enumerate(m.actions[:]):
-                        if a.name == "signature" or \
-                            (a.name == "set" and a.attrs["name"] == "pkg.fmri"):
-                                # signatures and pkg.fmri actions are no longer
-                                # valid after merging
-                                del m.actions[i - deleted_count]
-                                deleted_count += 1
-                                continue
+    for j, m in enumerate(manifest_list):
+        deleted_count = 0
+        vval = variant_list[j]
+        for i, a in enumerate(m.actions[:]):
+            if a.name == "signature" or (
+                a.name == "set" and a.attrs["name"] == "pkg.fmri"
+            ):
+                # signatures and pkg.fmri actions are no longer
+                # valid after merging
+                del m.actions[i - deleted_count]
+                deleted_count += 1
+                continue
 
-                        if variant in a.attrs:
-                                if a.attrs[variant] != vval:
-                                        # we have an already merged
-                                        # manifest; filter out actions
-                                        # for other variants
-                                        del m.actions[i - deleted_count]
-                                        deleted_count += 1
-                                        continue
-                                else:
-                                        del a.attrs[variant]
+            if variant in a.attrs:
+                if a.attrs[variant] != vval:
+                    # we have an already merged
+                    # manifest; filter out actions
+                    # for other variants
+                    del m.actions[i - deleted_count]
+                    deleted_count += 1
+                    continue
+                else:
+                    del a.attrs[variant]
 
-                        if a.name == "set" and a.attrs["name"] == variant:
-                                if vval not in a.attrlist("value"):
-                                        raise PkgmergeException(
-                                            _("package {pkg} is tagged as "
-                                            "not supporting {var_name} "
-                                            "{var_value}").format(
-                                            pkg=fmri_list[j],
-                                            var_name=variant,
-                                            var_value=vval))
-                                del m.actions[i - deleted_count]
-                                deleted_count += 1
-                        # checking if we're supposed to blend this action
-                        # for this variant.  Handle prepended "variant.".
-                        if blend_names & set(a.attrlist("pkg.merge.blend")):
-                                blended_actions.append((j, a))
+            if a.name == "set" and a.attrs["name"] == variant:
+                if vval not in a.attrlist("value"):
+                    raise PkgmergeException(
+                        _(
+                            "package {pkg} is tagged as "
+                            "not supporting {var_name} "
+                            "{var_value}"
+                        ).format(
+                            pkg=fmri_list[j], var_name=variant, var_value=vval
+                        )
+                    )
+                del m.actions[i - deleted_count]
+                deleted_count += 1
+            # checking if we're supposed to blend this action
+            # for this variant.  Handle prepended "variant.".
+            if blend_names & set(a.attrlist("pkg.merge.blend")):
+                blended_actions.append((j, a))
 
-        # add blended actions to other manifests
-        for j, m in enumerate(manifest_list):
-                for k, a in blended_actions:
-                        if k != j:
-                                m.actions.append(a)
+    # add blended actions to other manifests
+    for j, m in enumerate(manifest_list):
+        for k, a in blended_actions:
+            if k != j:
+                m.actions.append(a)
 
-        # Like the unix utility comm, except that this function
-        # takes an arbitrary number of manifests and compares them,
-        # returning a tuple consisting of each manifest's actions
-        # that are not the same for all manifests, followed by a
-        # list of actions that are the same in each manifest.
-        try:
-                action_lists = list(manifest.Manifest.comm(manifest_list))
-        except manifest.ManifestDuplicateError as e:
-                raise PkgmergeException(e)
+    # Like the unix utility comm, except that this function
+    # takes an arbitrary number of manifests and compares them,
+    # returning a tuple consisting of each manifest's actions
+    # that are not the same for all manifests, followed by a
+    # list of actions that are the same in each manifest.
+    try:
+        action_lists = list(manifest.Manifest.comm(manifest_list))
+    except manifest.ManifestDuplicateError as e:
+        raise PkgmergeException(e)
 
-        # Declare new package FMRI.
-        action_lists[-1].insert(0,
-            actions.fromstr("set name=pkg.fmri value={0}".format(new_fmri)))
+    # Declare new package FMRI.
+    action_lists[-1].insert(
+        0, actions.fromstr("set name=pkg.fmri value={0}".format(new_fmri))
+    )
 
-        for a_list, v in zip(action_lists[:-1], variant_list):
-                for a in a_list:
-                        a.attrs[variant] = v
-        # discard any blend tags for this variant from common list
-        for a in action_lists[-1]:
-                blend_attrs = set(a.attrlist("pkg.merge.blend"))
-                match = blend_names & blend_attrs
-                for m in list(match):
-                        if len(blend_attrs) == 1:
-                                del a.attrs["pkg.merge.blend"]
-                        else:
-                                a.attrlist("pkg.merge.blend").remove(m)
-        # combine actions into single list
-        allactions = reduce(lambda a, b: a + b, action_lists)
+    for a_list, v in zip(action_lists[:-1], variant_list):
+        for a in a_list:
+            a.attrs[variant] = v
+    # discard any blend tags for this variant from common list
+    for a in action_lists[-1]:
+        blend_attrs = set(a.attrlist("pkg.merge.blend"))
+        match = blend_names & blend_attrs
+        for m in list(match):
+            if len(blend_attrs) == 1:
+                del a.attrs["pkg.merge.blend"]
+            else:
+                a.attrlist("pkg.merge.blend").remove(m)
+    # combine actions into single list
+    allactions = reduce(lambda a, b: a + b, action_lists)
 
-        # figure out which variants are actually there for this pkg
-        actual_variant_list = [
-            v
-            for m, v in zip(manifest_list, variant_list)
-        ]
+    # figure out which variants are actually there for this pkg
+    actual_variant_list = [v for m, v in zip(manifest_list, variant_list)]
 
-        # add set action to document which variants are supported
-        allactions.append(actions.fromstr("set name={0} {1}".format(variant,
-            " ".join([
-                "value={0}".format(a)
-                for a in actual_variant_list
-            ])
-        )))
+    # add set action to document which variants are supported
+    allactions.append(
+        actions.fromstr(
+            "set name={0} {1}".format(
+                variant,
+                " ".join(["value={0}".format(a) for a in actual_variant_list]),
+            )
+        )
+    )
 
-        allactions.sort()
+    allactions.sort()
 
-        m = manifest.Manifest(pfmri=new_fmri)
-        m.set_content(content=allactions)
-        return m
+    m = manifest.Manifest(pfmri=new_fmri)
+    m.set_content(content=allactions)
+    return m
+
 
 def build_merge_list(include, exclude, cat):
-        """Given a list of patterns to include and a list of patterns
-        to exclude, return a dictionary of fmris to be included,
-        along w/ a list of include patterns that don't match"""
+    """Given a list of patterns to include and a list of patterns
+    to exclude, return a dictionary of fmris to be included,
+    along w/ a list of include patterns that don't match"""
 
-        include_dict, include_misses = match_user_fmris(include, cat)
-        exclude_dict, ignored = match_user_fmris(exclude, cat)
+    include_dict, include_misses = match_user_fmris(include, cat)
+    exclude_dict, ignored = match_user_fmris(exclude, cat)
 
-        for pkg_name in include_dict:
-                if pkg_name in exclude_dict:
-                        include_dict[pkg_name] -= exclude_dict[pkg_name]
+    for pkg_name in include_dict:
+        if pkg_name in exclude_dict:
+            include_dict[pkg_name] -= exclude_dict[pkg_name]
 
-        return dict((k, sorted(list(v), reverse=True)[0])
-                    for k,v in six.iteritems(include_dict)
-                    if v), include_misses
+    return (
+        dict(
+            (k, sorted(list(v), reverse=True)[0])
+            for k, v in six.iteritems(include_dict)
+            if v
+        ),
+        include_misses,
+    )
+
 
 def match_user_fmris(patterns, cat):
-        """Given a user-specified list of patterns, return a dictionary
-        of matching fmri sets:
+    """Given a user-specified list of patterns, return a dictionary
+    of matching fmri sets:
 
-        {pkgname: [fmri, ... ]
-         pkgname: [fmri, ... ]
-         ...
-        }
+    {pkgname: [fmri, ... ]
+     pkgname: [fmri, ... ]
+     ...
+    }
 
-        Note that patterns starting w/ pkg:/ require an exact match;
-        patterns containing '*' will using fnmatch rules; the default
-        trailing match rules are used for remaining patterns.
-        """
+    Note that patterns starting w/ pkg:/ require an exact match;
+    patterns containing '*' will using fnmatch rules; the default
+    trailing match rules are used for remaining patterns.
+    """
 
-        matchers = []
-        fmris    = []
-        versions = []
+    matchers = []
+    fmris = []
+    versions = []
 
-        # ignore dups
-        patterns = list(set(patterns))
+    # ignore dups
+    patterns = list(set(patterns))
 
-        # figure out which kind of matching rules to employ
-        latest_pats = set()
-        for pat in patterns:
-                try:
-                        parts = pat.split("@", 1)
-                        pat_stem = parts[0]
-                        pat_ver = None
-                        if len(parts) > 1:
-                                pat_ver = parts[1]
+    # figure out which kind of matching rules to employ
+    latest_pats = set()
+    for pat in patterns:
+        try:
+            parts = pat.split("@", 1)
+            pat_stem = parts[0]
+            pat_ver = None
+            if len(parts) > 1:
+                pat_ver = parts[1]
 
-                        if "*" in pat_stem or "?" in pat_stem:
-                                matcher = pkg.fmri.glob_match
-                        elif pat_stem.startswith("pkg:/") or \
-                            pat_stem.startswith("/"):
-                                matcher = pkg.fmri.exact_name_match
-                        else:
-                                matcher = pkg.fmri.fmri_match
+            if "*" in pat_stem or "?" in pat_stem:
+                matcher = pkg.fmri.glob_match
+            elif pat_stem.startswith("pkg:/") or pat_stem.startswith("/"):
+                matcher = pkg.fmri.exact_name_match
+            else:
+                matcher = pkg.fmri.fmri_match
 
-                        if matcher == pkg.fmri.glob_match:
-                                fmri = pkg.fmri.MatchingPkgFmri(pat_stem)
-                        else:
-                                fmri = pkg.fmri.PkgFmri(pat_stem)
+            if matcher == pkg.fmri.glob_match:
+                fmri = pkg.fmri.MatchingPkgFmri(pat_stem)
+            else:
+                fmri = pkg.fmri.PkgFmri(pat_stem)
 
-                        if not pat_ver:
-                                # Do nothing.
-                                pass
-                        elif "*" in pat_ver or "?" in pat_ver or \
-                            pat_ver == "latest":
-                                fmri.version = \
-                                    pkg.version.MatchingVersion(pat_ver)
-                        else:
-                                fmri.version = \
-                                    pkg.version.Version(pat_ver)
+            if not pat_ver:
+                # Do nothing.
+                pass
+            elif "*" in pat_ver or "?" in pat_ver or pat_ver == "latest":
+                fmri.version = pkg.version.MatchingVersion(pat_ver)
+            else:
+                fmri.version = pkg.version.Version(pat_ver)
 
-                        if pat_ver and \
-                            getattr(fmri.version, "match_latest", None):
-                                latest_pats.add(pat)
+            if pat_ver and getattr(fmri.version, "match_latest", None):
+                latest_pats.add(pat)
 
-                        matchers.append(matcher)
-                        versions.append(fmri.version)
-                        fmris.append(fmri)
-                except (pkg.fmri.FmriError,
-                    pkg.version.VersionError) as e:
-                        raise PkgmergeException(str(e))
+            matchers.append(matcher)
+            versions.append(fmri.version)
+            fmris.append(fmri)
+        except (pkg.fmri.FmriError, pkg.version.VersionError) as e:
+            raise PkgmergeException(str(e))
 
-        # Create a dictionary of patterns, with each value being a
-        # dictionary of pkg names & fmris that match that pattern.
-        ret = dict(zip(patterns, [dict() for i in patterns]))
+    # Create a dictionary of patterns, with each value being a
+    # dictionary of pkg names & fmris that match that pattern.
+    ret = dict(zip(patterns, [dict() for i in patterns]))
 
-        for name in cat.keys():
-                for pat, matcher, fmri, version in \
-                    zip(patterns, matchers, fmris, versions):
-                        if not matcher(name, fmri.pkg_name):
-                                continue # name doesn't match
-                        for ver, pfmris in cat[name]:
-                                if version and not ver.is_successor(version,
-                                    pkg.version.CONSTRAINT_AUTO):
-                                        continue # version doesn't match
-                                for f in pfmris:
-                                        ret[pat].setdefault(f.pkg_name,
-                                            []).append(f)
+    for name in cat.keys():
+        for pat, matcher, fmri, version in zip(
+            patterns, matchers, fmris, versions
+        ):
+            if not matcher(name, fmri.pkg_name):
+                continue  # name doesn't match
+            for ver, pfmris in cat[name]:
+                if version and not ver.is_successor(
+                    version, pkg.version.CONSTRAINT_AUTO
+                ):
+                    continue  # version doesn't match
+                for f in pfmris:
+                    ret[pat].setdefault(f.pkg_name, []).append(f)
 
-        # Discard all but the newest version of each match.
-        if latest_pats:
-                # Rebuild ret based on latest version of every package.
-                latest = {}
-                nret = {}
-                for p in patterns:
-                        if p not in latest_pats or not ret[p]:
-                                nret[p] = ret[p]
-                                continue
+    # Discard all but the newest version of each match.
+    if latest_pats:
+        # Rebuild ret based on latest version of every package.
+        latest = {}
+        nret = {}
+        for p in patterns:
+            if p not in latest_pats or not ret[p]:
+                nret[p] = ret[p]
+                continue
 
-                        nret[p] = {}
-                        for pkg_name in ret[p]:
-                                nret[p].setdefault(pkg_name, [])
-                                for f in ret[p][pkg_name]:
-                                        nver = latest.get(f.pkg_name, None)
-                                        latest[f.pkg_name] = max(nver,
-                                            f.version)
-                                        if f.version == latest[f.pkg_name]:
-                                                # Allow for multiple FMRIs of
-                                                # the same latest version.
-                                                nret[p][pkg_name] = [
-                                                    e
-                                                    for e in nret[p][pkg_name]
-                                                    if e.version == f.version
-                                                ]
-                                                nret[p][pkg_name].append(f)
+            nret[p] = {}
+            for pkg_name in ret[p]:
+                nret[p].setdefault(pkg_name, [])
+                for f in ret[p][pkg_name]:
+                    nver = latest.get(f.pkg_name, None)
+                    latest[f.pkg_name] = max(nver, f.version)
+                    if f.version == latest[f.pkg_name]:
+                        # Allow for multiple FMRIs of
+                        # the same latest version.
+                        nret[p][pkg_name] = [
+                            e
+                            for e in nret[p][pkg_name]
+                            if e.version == f.version
+                        ]
+                        nret[p][pkg_name].append(f)
 
-                # Assign new version of ret and discard latest list.
-                ret = nret
-                del latest
+        # Assign new version of ret and discard latest list.
+        ret = nret
+        del latest
 
-        # merge patterns together and create sets
-        merge_dict = {}
-        for d in ret.values():
-                merge_dict.update(d)
+    # merge patterns together and create sets
+    merge_dict = {}
+    for d in ret.values():
+        merge_dict.update(d)
 
-        for k in merge_dict:
-                merge_dict[k] = set(merge_dict[k])
+    for k in merge_dict:
+        merge_dict[k] = set(merge_dict[k])
 
-        unmatched_patterns = [
-            p
-            for p in ret
-            if not ret[p]
-        ]
+    unmatched_patterns = [p for p in ret if not ret[p]]
 
-        return merge_dict, unmatched_patterns
+    return merge_dict, unmatched_patterns
 
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        # Make all warnings be errors.
-        import warnings
-        warnings.simplefilter('error')
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
-        try:
-                __ret = main_func()
-        except (pkg.actions.ActionError, trans.TransactionError,
-            RuntimeError, pkg.fmri.FmriError, apx.ApiException) as __e:
-                print("pkgmerge: {0}".format(__e), file=sys.stderr)
-                __ret = EXIT_OOPS
-        except (PipeError, KeyboardInterrupt):
-                __ret = EXIT_OOPS
-        except SystemExit as __e:
-                raise __e
-        except EnvironmentError as __e:
-                error(str(apx._convert_error(__e)))
-                __ret = EXIT_OOPS
-        except Exception as __e:
-                traceback.print_exc()
-                error(misc.get_traceback_message(), exitcode=None)
-                __ret = 99
-        finally:
-                cleanup()
+    # Make all warnings be errors.
+    import warnings
 
-        sys.exit(__ret)
+    warnings.simplefilter("error")
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
+    try:
+        __ret = main_func()
+    except (
+        pkg.actions.ActionError,
+        trans.TransactionError,
+        RuntimeError,
+        pkg.fmri.FmriError,
+        apx.ApiException,
+    ) as __e:
+        print("pkgmerge: {0}".format(__e), file=sys.stderr)
+        __ret = EXIT_OOPS
+    except (PipeError, KeyboardInterrupt):
+        __ret = EXIT_OOPS
+    except SystemExit as __e:
+        raise __e
+    except EnvironmentError as __e:
+        error(str(apx._convert_error(__e)))
+        __ret = EXIT_OOPS
+    except Exception as __e:
+        traceback.print_exc()
+        error(misc.get_traceback_message(), exitcode=None)
+        __ret = 99
+    finally:
+        cleanup()
+
+    sys.exit(__ret)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/publish/pkgmogrify.py
+++ b/src/util/publish/pkgmogrify.py
@@ -24,7 +24,9 @@
 #
 
 from __future__ import print_function
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 import getopt
 import gettext
 import locale
@@ -40,134 +42,149 @@ from pkg.client.pkgdefs import EXIT_OK, EXIT_OOPS, EXIT_BADOPT, EXIT_PARTIAL
 
 
 def usage(errmsg="", exitcode=EXIT_BADOPT):
-        """Emit a usage message and optionally prefix it with a more specific
-        error message.  Causes program to exit."""
+    """Emit a usage message and optionally prefix it with a more specific
+    error message.  Causes program to exit."""
 
-        if errmsg:
-                print("pkgmogrify: {0}".format(errmsg), file=sys.stderr)
+    if errmsg:
+        print("pkgmogrify: {0}".format(errmsg), file=sys.stderr)
 
-        print(_("""\
+    print(
+        _(
+            """\
 Usage:
         pkgmogrify [-vi] [-I includedir ...] [-D macro=value ...]
-            [-O outputfile] [-P printfile] [inputfile ...]"""))
-        sys.exit(exitcode)
+            [-O outputfile] [-P printfile] [inputfile ...]"""
+        )
+    )
+    sys.exit(exitcode)
+
 
 def error(text, exitcode=EXIT_OOPS):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        print("pkgmogrify: {0}".format(text), file=sys.stderr)
-        if exitcode != None:
-                sys.exit(exitcode)
+    print("pkgmogrify: {0}".format(text), file=sys.stderr)
+    if exitcode != None:
+        sys.exit(exitcode)
+
 
 def main_func():
-        outfilename = None
-        printfilename = None
-        verbose = False
-        ignoreincludes = False
-        includes = []
-        macros = {}
-        printinfo = []
-        output = []
+    outfilename = None
+    printfilename = None
+    verbose = False
+    ignoreincludes = False
+    includes = []
+    macros = {}
+    printinfo = []
+    output = []
 
-        try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "ivD:I:O:P:?", ["help"])
-                for opt, arg in opts:
-                        if opt == "-D":
-                                if "=" not in arg:
-                                        error(_("macros must be of form name=value"))
-                                a = arg.split("=", 1)
-                                if a[0] == "":
-                                        error(_("macros must be of form name=value"))
-                                macros.update([("$({0})".format(a[0]), a[1])])
-                        if opt == "-i":
-                                ignoreincludes = True
-                        if opt == "-I":
-                                includes.append(arg)
-                        if opt == "-O":
-                                outfilename = arg
-                        if opt == "-P":
-                                printfilename = arg
-                        if opt == "-v":
-                                verbose = True
-                        if opt in ("--help", "-?"):
-                                usage(exitcode=EXIT_OK)
+    try:
+        opts, pargs = getopt.getopt(sys.argv[1:], "ivD:I:O:P:?", ["help"])
+        for opt, arg in opts:
+            if opt == "-D":
+                if "=" not in arg:
+                    error(_("macros must be of form name=value"))
+                a = arg.split("=", 1)
+                if a[0] == "":
+                    error(_("macros must be of form name=value"))
+                macros.update([("$({0})".format(a[0]), a[1])])
+            if opt == "-i":
+                ignoreincludes = True
+            if opt == "-I":
+                includes.append(arg)
+            if opt == "-O":
+                outfilename = arg
+            if opt == "-P":
+                printfilename = arg
+            if opt == "-v":
+                verbose = True
+            if opt in ("--help", "-?"):
+                usage(exitcode=EXIT_OK)
 
-        except getopt.GetoptError as e:
-                usage(_("illegal global option -- {0}").format(e.opt))
+    except getopt.GetoptError as e:
+        usage(_("illegal global option -- {0}").format(e.opt))
 
-        try:
-                mog.process_mog(pargs, ignoreincludes, verbose, includes,
-                    macros, printinfo, output, error_cb=error)
-        except RuntimeError as e:
-                sys.exit(EXIT_OOPS)
+    try:
+        mog.process_mog(
+            pargs,
+            ignoreincludes,
+            verbose,
+            includes,
+            macros,
+            printinfo,
+            output,
+            error_cb=error,
+        )
+    except RuntimeError as e:
+        sys.exit(EXIT_OOPS)
 
-        try:
-                if printfilename == None:
-                        printfile = sys.stdout
+    try:
+        if printfilename == None:
+            printfile = sys.stdout
+        else:
+            printfile = open(printfilename, "w")
+
+        for p in printinfo:
+            print("{0}".format(p), file=printfile)
+
+    except IOError as e:
+        error(_("Cannot write extra data {0}").format(e))
+
+    try:
+        if outfilename == None:
+            outfile = sys.stdout
+        else:
+            outfile = open(outfilename, "w")
+
+        emitted = set()
+        for comment, actionlist, prepended_macro in output:
+            if comment:
+                for l in comment:
+                    print("{0}".format(l), file=outfile)
+
+            for i, action in enumerate(actionlist):
+                if action is None:
+                    continue
+                if prepended_macro is None:
+                    s = "{0}".format(action)
                 else:
-                        printfile = open(printfilename, "w")
+                    s = "{0}{1}".format(prepended_macro, action)
+                # The first action is the original action and
+                # should be printed; later actions are all
+                # emitted and should only be printed if not
+                # duplicates.
+                if i == 0:
+                    print(s, file=outfile)
+                elif s not in emitted:
+                    print(s, file=outfile)
+                    emitted.add(s)
+    except IOError as e:
+        error(_("Cannot write output {0}").format(e))
 
-                for p in printinfo:
-                        print("{0}".format(p), file=printfile)
+    return 0
 
-        except IOError as e:
-                error(_("Cannot write extra data {0}").format(e))
-
-        try:
-                if outfilename == None:
-                        outfile = sys.stdout
-                else:
-                        outfile = open(outfilename, "w")
-
-                emitted = set()
-                for comment, actionlist, prepended_macro in output:
-                        if comment:
-                                for l in comment:
-                                        print("{0}".format(l), file=outfile)
-
-                        for i, action in enumerate(actionlist):
-                                if action is None:
-                                        continue
-                                if prepended_macro is None:
-                                        s = "{0}".format(action)
-                                else:
-                                        s = "{0}{1}".format(prepended_macro, action)
-                                # The first action is the original action and
-                                # should be printed; later actions are all
-                                # emitted and should only be printed if not
-                                # duplicates.
-                                if i == 0:
-                                        print(s, file=outfile)
-                                elif s not in emitted:
-                                        print(s, file=outfile)
-                                        emitted.add(s)
-        except IOError as e:
-                error(_("Cannot write output {0}").format(e))
-
-        return 0
 
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        # Make all warnings be errors.
-        warnings.simplefilter('error')
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
-        try:
-                exit_code = main_func()
-        except (PipeError, KeyboardInterrupt):
-                exit_code = EXIT_OOPS
-        except SystemExit as __e:
-                exit_code = __e
-        except Exception as __e:
-                traceback.print_exc()
-                error(misc.get_traceback_message(), exitcode=None)
-                exit_code = 99
+    # Make all warnings be errors.
+    warnings.simplefilter("error")
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
+    try:
+        exit_code = main_func()
+    except (PipeError, KeyboardInterrupt):
+        exit_code = EXIT_OOPS
+    except SystemExit as __e:
+        exit_code = __e
+    except Exception as __e:
+        traceback.print_exc()
+        error(misc.get_traceback_message(), exitcode=None)
+        exit_code = 99
 
-        sys.exit(exit_code)
+    sys.exit(exit_code)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/publish/pkgsurf.py
+++ b/src/util/publish/pkgsurf.py
@@ -66,7 +66,9 @@
 # change. It runs a catalog rebuild as the last step to regain catalog integrity
 # within the repo.
 
-import pkg.site_paths; pkg.site_paths.init()
+import pkg.site_paths
+
+pkg.site_paths.init()
 import getopt
 import gettext
 import locale
@@ -102,53 +104,61 @@ repo_modified = False
 repo_finished = False
 repo_uri = None
 
+
 def error(text, cmd=None):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        if cmd:
-                text = "\n{0}: {1}".format(cmd, text)
+    if cmd:
+        text = "\n{0}: {1}".format(cmd, text)
 
-        else:
-                text = "\n{0}: {1}".format(PKG_CLIENT_NAME, text)
+    else:
+        text = "\n{0}: {1}".format(PKG_CLIENT_NAME, text)
 
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    emsg(ws + text_nows)
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        emsg(ws + text_nows)
 
 def cleanup(no_msg=False):
-        """Remove temporary directories. Print error msg in case operation
-        was not finished."""
+    """Remove temporary directories. Print error msg in case operation
+    was not finished."""
 
-        global temp_root
+    global temp_root
 
-        if repo_modified and not repo_finished and not no_msg:
-                error(_("""
+    if repo_modified and not repo_finished and not no_msg:
+        error(
+            _(
+                """
 The target repository has been modified but the operation did not finish
 successfully. It is now in an inconsistent state.
 
 To re-try the operation, run the following commands:
   /usr/bin/pkgrepo rebuild -s {repo}
   {argv}
-""").format(repo=repo_uri, argv=" ".join(sys.argv)))
+"""
+            ).format(repo=repo_uri, argv=" ".join(sys.argv))
+        )
 
-        if temp_root:
-                shutil.rmtree(temp_root)
-                temp_root = None
+    if temp_root:
+        shutil.rmtree(temp_root)
+        temp_root = None
+
 
 def usage(usage_error=None, cmd=None, retcode=pkgdefs.EXIT_BADOPT):
-        """Emit a usage message and optionally prefix it with a more specific
-        error message.  Causes program to exit."""
+    """Emit a usage message and optionally prefix it with a more specific
+    error message.  Causes program to exit."""
 
-        if usage_error:
-                error(usage_error, cmd=cmd)
+    if usage_error:
+        error(usage_error, cmd=cmd)
 
-        emsg(_("""\
+    emsg(
+        _(
+            """\
 Usage:
         pkgsurf -s target_path -r ref_uri [-n] [-p publisher ...]
             [-i name ...] [-c pattern ...]
@@ -174,717 +184,805 @@ Options:
                         filesystem-based repository.
 
         -?/--help       Print this message.
-"""))
+"""
+        )
+    )
 
+    sys.exit(retcode)
 
-        sys.exit(retcode)
 
 def abort(err=None, retcode=pkgdefs.EXIT_OOPS):
-        """To be called when a fatal error is encountered."""
+    """To be called when a fatal error is encountered."""
 
-        if err:
-                # Clear any possible output first.
-                msg("")
-                error(err)
+    if err:
+        # Clear any possible output first.
+        msg("")
+        error(err)
 
-        cleanup()
-        sys.exit(retcode)
+    cleanup()
+    sys.exit(retcode)
+
 
 def fetch_catalog(src_pub, xport, temp_root):
-        """Fetch the catalog from src_uri."""
+    """Fetch the catalog from src_uri."""
 
-        if not src_pub.meta_root:
-                # Create a temporary directory for catalog.
-                cat_dir = tempfile.mkdtemp(dir=temp_root)
-                src_pub.meta_root = cat_dir
+    if not src_pub.meta_root:
+        # Create a temporary directory for catalog.
+        cat_dir = tempfile.mkdtemp(dir=temp_root)
+        src_pub.meta_root = cat_dir
 
-        src_pub.transport = xport
-        src_pub.refresh(full_refresh=True, immediate=True)
+    src_pub.transport = xport
+    src_pub.refresh(full_refresh=True, immediate=True)
 
-        return src_pub.catalog
+    return src_pub.catalog
+
 
 def get_latest(cat):
-        """ Get latest packages (surface) from given catalog.
-        Returns a dict of the form:
-                { pkg-name: pkg-fmri, ... }
-        """
-        matching, ref, unmatched = cat.get_matching_fmris(["*@latest"])
+    """Get latest packages (surface) from given catalog.
+    Returns a dict of the form:
+            { pkg-name: pkg-fmri, ... }
+    """
+    matching, ref, unmatched = cat.get_matching_fmris(["*@latest"])
 
-        del ref
+    del ref
 
-        matches = {}
-        for m in matching:
-                matches[m] = matching[m][0]
+    matches = {}
+    for m in matching:
+        matches[m] = matching[m][0]
 
-        return matches
+    return matches
+
 
 def get_matching_pkgs(cat, patterns):
-        """Get the matching pkg FMRIs from catalog 'cat' based on the input
-        patterns 'patterns'."""
+    """Get the matching pkg FMRIs from catalog 'cat' based on the input
+    patterns 'patterns'."""
 
-        versions = set()
-        for p in patterns:
-                if "@" in p:
-                     versions.add(p)
+    versions = set()
+    for p in patterns:
+        if "@" in p:
+            versions.add(p)
 
-        if versions:
-                msg = _("Packages specified to not be reversioned cannot "
-                    "contain versions:\n\t")
-                msg += "\n\t".join(versions)
-                abort(msg)
+    if versions:
+        msg = _(
+            "Packages specified to not be reversioned cannot "
+            "contain versions:\n\t"
+        )
+        msg += "\n\t".join(versions)
+        abort(msg)
 
-        matching, ref, unmatched = cat.get_matching_fmris(patterns)
+    matching, ref, unmatched = cat.get_matching_fmris(patterns)
 
-        if unmatched:
-                msg = _("The specified packages were not found in the "
-                    "repository:\n\t")
-                msg += "\n\t".join(unmatched)
-                abort(msg)
+    if unmatched:
+        msg = _(
+            "The specified packages were not found in the " "repository:\n\t"
+        )
+        msg += "\n\t".join(unmatched)
+        abort(msg)
 
-        return list(matching.keys())
+    return list(matching.keys())
+
 
 def get_manifest(repo, pub, pfmri):
-        """ Retrieve a manifest with FMRI 'pfmri' of publisher 'pub' from
-        repository object 'repo'. """
+    """Retrieve a manifest with FMRI 'pfmri' of publisher 'pub' from
+    repository object 'repo'."""
 
-        path = repo.manifest(pfmri, pub)
-        mani = manifest.Manifest(pfmri)
-        try:
-                mani.set_content(pathname=path)
-        except Exception as e:
-                abort(err=_("Can not open manifest file {file}: {err}\n"
-                    "Please run 'pkgrepo verify -s {rroot}' to check the "
-                    "integrity of the repository.").format(
-                    file=path, err=str(e), rroot=repo.root))
-        return mani
+    path = repo.manifest(pfmri, pub)
+    mani = manifest.Manifest(pfmri)
+    try:
+        mani.set_content(pathname=path)
+    except Exception as e:
+        abort(
+            err=_(
+                "Can not open manifest file {file}: {err}\n"
+                "Please run 'pkgrepo verify -s {rroot}' to check the "
+                "integrity of the repository."
+            ).format(file=path, err=str(e), rroot=repo.root)
+        )
+    return mani
+
 
 def get_tracker():
-        try:
-                progresstracker = \
-                    progress.FancyUNIXProgressTracker()
-        except progress.ProgressTrackerException:
-                progresstracker = progress.CommandLineProgressTracker()
-        progresstracker.set_major_phase(progresstracker.PHASE_UTILITY)
-        return progresstracker
+    try:
+        progresstracker = progress.FancyUNIXProgressTracker()
+    except progress.ProgressTrackerException:
+        progresstracker = progress.CommandLineProgressTracker()
+    progresstracker.set_major_phase(progresstracker.PHASE_UTILITY)
+    return progresstracker
+
 
 def subs_undef_fmri_str(fmri_str, latest_ref_pkgs):
-        """ Substitute correct dependency FMRI if no counterpart can be found in
-        the reference manifest. Use the original FMRI in case the current
-        version of dependency pkg in the repo is still a successor of the
-        specified dependency FMRI, otherwise substitute the complete version of
-        the pkg currently present in the repo."""
+    """Substitute correct dependency FMRI if no counterpart can be found in
+    the reference manifest. Use the original FMRI in case the current
+    version of dependency pkg in the repo is still a successor of the
+    specified dependency FMRI, otherwise substitute the complete version of
+    the pkg currently present in the repo."""
 
-        dpfmri = fmri.PkgFmri(fmri_str)
-        ndpfmri = latest_ref_pkgs[dpfmri.get_name()]
+    dpfmri = fmri.PkgFmri(fmri_str)
+    ndpfmri = latest_ref_pkgs[dpfmri.get_name()]
 
-        if ndpfmri.is_successor(dpfmri):
-                return fmri_str
+    if ndpfmri.is_successor(dpfmri):
+        return fmri_str
 
-        return ndpfmri.get_short_fmri(anarchy=True)
+    return ndpfmri.get_short_fmri(anarchy=True)
 
-def get_dep_fmri_str(fmri_str, pkg, act, latest_ref_pkgs, reversioned_pkgs,
-    ref_xport):
-        """Get the adjusted dependency FMRI of package 'pkg' specified in
-        action 'act' based on if the FMRI belongs to a reversioned package or
-        not. 'fmri_str' contains the original FMRI string from the manifest to
-        be adjusted. This has to be passed in separately since in case of
-        require-any or group-any dependencies, an action can contain multiple
-        FMRIs. """
 
-        dpfmri = fmri.PkgFmri(fmri_str)
+def get_dep_fmri_str(
+    fmri_str, pkg, act, latest_ref_pkgs, reversioned_pkgs, ref_xport
+):
+    """Get the adjusted dependency FMRI of package 'pkg' specified in
+    action 'act' based on if the FMRI belongs to a reversioned package or
+    not. 'fmri_str' contains the original FMRI string from the manifest to
+    be adjusted. This has to be passed in separately since in case of
+    require-any or group-any dependencies, an action can contain multiple
+    FMRIs."""
 
-        # Versionless dependencies don't need to be changed.
-        if not dpfmri.version:
-                return fmri_str
+    dpfmri = fmri.PkgFmri(fmri_str)
 
-        # Dep package hasn't been changed, no adjustment necessary.
-        if dpfmri.get_pkg_stem() not in reversioned_pkgs:
-                return fmri_str
+    # Versionless dependencies don't need to be changed.
+    if not dpfmri.version:
+        return fmri_str
 
-        # Find the dependency action of the reference package
-        # and replace the current version with it.
-        try:
-                ref_mani = ref_xport.get_manifest(latest_ref_pkgs[pkg])
-        except KeyError:
-                # This package is not in the ref repo so we just substitute the
-                # dependency.
-                return subs_undef_fmri_str(fmri_str, latest_ref_pkgs)
+    # Dep package hasn't been changed, no adjustment necessary.
+    if dpfmri.get_pkg_stem() not in reversioned_pkgs:
+        return fmri_str
 
-        for ra in ref_mani.gen_actions_by_type("depend"):
-                # Any difference other than the FMRI means we
-                # can't use this action as a reference.
-                diffs = act.differences(ra)
-                if "fmri" in diffs:
-                        diffs.remove("fmri")
-                if diffs:
-                        continue
-
-                fmris = ra.attrlist("fmri")
-
-                for rf in fmris:
-                        rpfmri = fmri.PkgFmri(rf)
-                        if rpfmri.get_pkg_stem() != dpfmri.get_pkg_stem():
-                                continue
-
-                        # Only substitute dependency if it actually
-                        # changed.
-                        if not rpfmri.version \
-                            or rpfmri.get_version() != dpfmri.get_version():
-                                return rf
-
-                        return fmri_str
-
-        # If a varcet changed we might not find the matching action.
+    # Find the dependency action of the reference package
+    # and replace the current version with it.
+    try:
+        ref_mani = ref_xport.get_manifest(latest_ref_pkgs[pkg])
+    except KeyError:
+        # This package is not in the ref repo so we just substitute the
+        # dependency.
         return subs_undef_fmri_str(fmri_str, latest_ref_pkgs)
 
+    for ra in ref_mani.gen_actions_by_type("depend"):
+        # Any difference other than the FMRI means we
+        # can't use this action as a reference.
+        diffs = act.differences(ra)
+        if "fmri" in diffs:
+            diffs.remove("fmri")
+        if diffs:
+            continue
+
+        fmris = ra.attrlist("fmri")
+
+        for rf in fmris:
+            rpfmri = fmri.PkgFmri(rf)
+            if rpfmri.get_pkg_stem() != dpfmri.get_pkg_stem():
+                continue
+
+            # Only substitute dependency if it actually
+            # changed.
+            if (
+                not rpfmri.version
+                or rpfmri.get_version() != dpfmri.get_version()
+            ):
+                return rf
+
+            return fmri_str
+
+    # If a varcet changed we might not find the matching action.
+    return subs_undef_fmri_str(fmri_str, latest_ref_pkgs)
+
+
 def adjust_dep_action(pkg, act, latest_ref_pkgs, reversioned_pkgs, ref_xport):
-        """Adjust dependency FMRIs of action 'act' if it is of type depend.
-        The adjusted action will reference only FMRIs which are present in the
-        reversioned repo. """
+    """Adjust dependency FMRIs of action 'act' if it is of type depend.
+    The adjusted action will reference only FMRIs which are present in the
+    reversioned repo."""
 
-        modified = False
+    modified = False
 
-        # Drop signatures (changed dependency will void signature value).
-        if act.name == "signature":
-                return
-        # Ignore anything other than depend actions.
-        elif act.name != "depend":
-                return act
+    # Drop signatures (changed dependency will void signature value).
+    if act.name == "signature":
+        return
+    # Ignore anything other than depend actions.
+    elif act.name != "depend":
+        return act
 
-        # require-any and group-any deps are a list so convert every dep FMRI
-        # into a list.
-        fmris = act.attrlist("fmri")
+    # require-any and group-any deps are a list so convert every dep FMRI
+    # into a list.
+    fmris = act.attrlist("fmri")
 
-        new_dep = []
-        for f in fmris:
-                new_f = get_dep_fmri_str(f, pkg, act, latest_ref_pkgs,
-                    reversioned_pkgs, ref_xport)
-                if not modified and f != new_f:
-                        modified = True
-                new_dep.append(new_f)
+    new_dep = []
+    for f in fmris:
+        new_f = get_dep_fmri_str(
+            f, pkg, act, latest_ref_pkgs, reversioned_pkgs, ref_xport
+        )
+        if not modified and f != new_f:
+            modified = True
+        new_dep.append(new_f)
 
-        if not modified:
-                return act
+    if not modified:
+        return act
 
-        if len(new_dep) == 1:
-                new_dep = new_dep[0]
+    if len(new_dep) == 1:
+        new_dep = new_dep[0]
 
-        nact = actions.fromstr(str(act))
-        nact.attrs["fmri"] = new_dep
+    nact = actions.fromstr(str(act))
+    nact.attrs["fmri"] = new_dep
 
-        return nact
+    return nact
+
 
 def use_ref(a, deps, ignores):
-        """Determine if the given action indicates that the pkg can be
-        reversioned."""
+    """Determine if the given action indicates that the pkg can be
+    reversioned."""
 
-        if a.name == "set" and "name" in a.attrs:
-                if a.attrs["name"] in ignores:
-                        return True
-                # We ignore the pkg FMRI because this is what
-                # will always change.
-                if a.attrs["name"] == "pkg.fmri":
-                        return True
+    if a.name == "set" and "name" in a.attrs:
+        if a.attrs["name"] in ignores:
+            return True
+        # We ignore the pkg FMRI because this is what
+        # will always change.
+        if a.attrs["name"] == "pkg.fmri":
+            return True
 
-        # Signature will always change.
-        if a.name == "signature":
-                return True
-
-        if a.name == "depend":
-                # TODO: support dependency lists
-                # For now, treat as content change.
-                if not isinstance(a.attrs["fmri"], six.string_types):
-                        return False
-                dpfmri = fmri.PkgFmri(a.attrs["fmri"])
-                deps.add(dpfmri.get_pkg_stem())
-                return True
-
-        return False
-
-def do_reversion(pub, ref_pub, target_repo, ref_xport, changes, ignores,
-    cmp_policy, ref_repo, ref, ref_xport_cfg):
-        """Do the repo reversion.
-        Return 'True' if repo got modified, 'False' otherwise."""
-
-        global temp_root, tracker, dry_run, repo_finished, repo_modified
-
-        target_cat = target_repo.get_catalog(pub=pub)
-        ref_cat = fetch_catalog(ref_pub, ref_xport, temp_root)
-
-        latest_pkgs = get_latest(target_cat)
-        latest_ref_pkgs = get_latest(ref_cat)
-
-        no_revs = get_matching_pkgs(target_cat, changes)
-
-        # We use bulk prefetching for faster transport of the manifests.
-        # Prefetch requires an intent which it sends to the server. Here
-        # we just use operation=reversion for all FMRIs.
-        intent = "operation=reversion;"
-        # use list() to force the zip() to evaluate
-        ref_pkgs = list(zip(latest_ref_pkgs.values(), repeat(intent)))
-
-        # Retrieve reference manifests.
-        # Try prefetching manifests in bulk first for faster, parallel
-        # transport. Retryable errors during prefetch are ignored and
-        # manifests are retrieved again during the "Reading" phase.
-        ref_xport.prefetch_manifests(ref_pkgs, progtrack=tracker)
-
-        # Need to change the output of mfst_fetch since otherwise we
-        # would see "Download Manifests x/y" twice, once from the
-        # prefetch and once from the actual manifest analysis.
-        tracker.mfst_fetch = progress.GoalTrackerItem(_("Analyzing Manifests"))
-
-        tracker.manifest_fetch_start(len(latest_pkgs))
-
-        reversioned_pkgs = set()
-        depend_changes = {}
-        dups = 0   # target pkg has equal version to ref pkg
-        new_p = 0  # target pkg not in ref
-        sucs = 0   # ref pkg is successor to pkg in targ
-        nrevs = 0  # pkgs requested to not be reversioned by user
-        manifest_errors = set()
-
-        for p in latest_pkgs:
-                # First check if the package is in the list of FMRIs the user
-                # doesn't want to reversion.
-                if p in no_revs:
-                        nrevs += 1
-                        tracker.manifest_fetch_progress(completion=True)
-                        continue
-
-                # Check if the package is in the ref repo, if not: ignore.
-                if p not in latest_ref_pkgs:
-                        new_p += 1
-                        tracker.manifest_fetch_progress(completion=True)
-                        continue
-
-                pfmri = latest_pkgs[p]
-                # Ignore if latest package is the same in targ and ref.
-                if pfmri == latest_ref_pkgs[p]:
-                        dups += 1
-                        tracker.manifest_fetch_progress(completion=True)
-                        continue
-
-                # Ignore packages where ref version is higher.
-                if latest_ref_pkgs[p].is_successor(pfmri):
-                        sucs += 1
-                        tracker.manifest_fetch_progress(completion=True)
-                        continue
-
-                # Pull the manifests for target and ref repo.
-                dm = get_manifest(target_repo, pub, pfmri)
-                rm = ref_xport.get_manifest(latest_ref_pkgs[p])
-                tracker.manifest_fetch_progress(completion=True)
-
-                tdeps = set()
-                rdeps = set()
-
-                # Diff target and ref manifest.
-                # action only in targ, action only in ref, common action
-                try:
-                        ta, ra, ca = manifest.Manifest.comm([dm, rm],
-                             cmp_policy=cmp_policy)
-                except manifest.ManifestDuplicateError as e:
-                        manifest_errors.add(e)
-                        continue
-
-                # Check for manifest changes.
-                if not all(use_ref(a, tdeps, ignores) for a in ta) \
-                    or not all(use_ref(a, rdeps, ignores) for a in ra):
-                        continue
-
-                # Both dep lists should be equally long in case deps have just
-                # changed. If not, it means a dep has been added or removed and
-                # that means content change.
-                if len(tdeps) != len(rdeps):
-                        continue
-
-                # If len is not different we still have to make sure that
-                # entries have the same pkg stem. The test above just saves time
-                # in some cases.
-                if not all(td in rdeps for td in tdeps):
-                        continue
-
-                # Pkg only contains dependency change. Keep for further
-                # analysis.
-                if tdeps:
-                        depend_changes[pfmri.get_pkg_stem(
-                            anarchy=True)] = tdeps
-                        continue
-
-                # Pkg passed all checks and can be reversioned.
-                reversioned_pkgs.add(pfmri.get_pkg_stem(anarchy=True))
-
-        tracker.manifest_fetch_done()
-
-        # No point continuing if errors in the manifests have
-        # been detected.
-        if manifest_errors:
-                errmsg = ''.join(str(i) for i in manifest_errors)
-                abort(err=_("Manifest error(s) found:\n{}").format(errmsg))
-
-        def has_changed(pstem, seen=None, depth=0):
-                """Determine if a package or any of its dependencies has
-                changed.
-                Function will check if a dependency had a content change. If it
-                only had a dependency change, analyze its dependencies
-                recursively. Only if the whole dependency chain didn't have any
-                content change it is safe to reversion the package.
-
-                Note about circular dependencies: The function keeps track of
-                pkgs it already processed by stuffing them into the set 'seen'.
-                However, 'seen' gets updated before the child dependencies of
-                the current pkg are examined. This works if 'seen' is only used
-                for one dependency chain since the function immediately comes
-                back with a True result if a pkg has changed further down the
-                tree. However, if 'seen' is re-used between runs, it will
-                return prematurely, likely returning wrong results. """
-
-                MAX_DEPTH = 100
-
-                if not seen:
-                        seen = set()
-
-                if pstem in seen:
-                        return False
-
-                depth += 1
-                if depth > MAX_DEPTH:
-                        # Let's make sure we don't run into any
-                        # recursion limits. If the dep chain is too deep
-                        # just treat as changed pkg.
-                        error(_("Dependency chain depth of >{md:d} detected for"
-                            " {p}.").format(md=MAX_DEPTH, p=p))
-                        return True
-
-                # Pkg has no change at all.
-                if pstem in reversioned_pkgs:
-                        return False
-
-                # Pkg must have content change, if it had no change it would be
-                # in reversioned_pkgs, and if it had just a dep change it would
-                # be in depend_changes.
-                if pstem not in depend_changes:
-                        return True
-
-                # We need to update 'seen' here, otherwise we won't find this
-                # entry in case of a circular dependency.
-                seen.add(pstem)
-
-                return any(
-                    has_changed(d, seen, depth)
-                    for d in depend_changes[pstem]
-                )
-
-        # Check if packages which just have a dep change can be reversioned by
-        # checking if child dependencies also have no content change.
-        dep_revs = 0
-        for p in depend_changes:
-                if not has_changed(p):
-                        dep_revs += 1
-                        reversioned_pkgs.add(p)
-
-        status = []
-        if cmp_policy == CMP_UNSIGNED:
-                status.append((_("WARNING: Signature changes in file content "
-                    "ignored in resurfacing")))
-        status.append((_("Packages to process:"), str(len(latest_pkgs))))
-        status.append((_("New packages:"), str(new_p)))
-        status.append((_("Unmodified packages:"), str(dups)))
-        if sucs:
-                # This only happens if reference repo is ahead of target repo,
-                # so only show if it actually happened.
-                status.append((_("Packages with successors in "
-                    "reference repo:"), str(sucs)))
-        if nrevs:
-                # This only happens if user specified pkgs to not revert,
-                # so only show if it actually happened.
-                status.append((_("Packages not to be reversioned by user "
-                    "request:"), str(nrevs)))
-        status.append((_("Packages with no content change:"),
-            str(len(reversioned_pkgs) - dep_revs)))
-        status.append((_("Packages which only have dependency change:"),
-            str(len(depend_changes))))
-        status.append((_("Packages with unchanged dependency chain:"),
-            str(dep_revs)))
-        status.append((_("Packages to be reversioned:"),
-            str(len(reversioned_pkgs))))
-
-        rjust_status = max(len(s[0]) for s in status)
-        rjust_value = max(len(s[1]) for s in status)
-        for s in status:
-                msg("{0} {1}".format(s[0].rjust(rjust_status),
-                    s[1].rjust(rjust_value)))
-
-        if not reversioned_pkgs:
-                msg(_("\nNo packages to reversion."))
-                return False
-
-        if dry_run:
-                msg(_("\nReversioning packages (dry-run)."))
-        else:
-                msg(_("\nReversioning packages."))
-
-        # Start the main pass. Reversion packages from reversioned_pkgs to the
-        # version in the ref repo. For packages which don't get reversioned,
-        # check if the dependency versions are still correct, fix if necessary.
-        tracker.reversion_start(len(latest_pkgs), len(reversioned_pkgs))
-
-        for p in latest_pkgs:
-                tracker.reversion_add_progress(pfmri, pkgs=1)
-                modified = False
-
-                # Get the pkg fmri (pfmri) of the latest version based on if it
-                # has been reversioned or not.
-                stem = latest_pkgs[p].get_pkg_stem(anarchy=True)
-                if stem in reversioned_pkgs:
-                        tracker.reversion_add_progress(pfmri, reversioned=1)
-                        if dry_run:
-                                continue
-                        pfmri = latest_ref_pkgs[p]
-                        # Retrieve manifest from ref repo and replace the one in
-                        # the target repo. We don't have to adjust depndencies
-                        # for these packages because they will not depend on
-                        # anything we'll reversion.
-                        rmani = ref_xport.get_manifest(pfmri)
-
-                        if cmp_policy == CMP_UNSIGNED:
-                                # Files with different signed content hash
-                                # values can have equivalent unsigned content
-                                # hash. CMP_UNSIGNED relaxes comparison
-                                # constraints and allows this case to compare
-                                # as equal. The reversioned manifest may
-                                # reference file data that is not present in
-                                # the target repository, so ensure that any
-                                # missing file data is added to the target
-                                # repository.
-                                add_missing_files(target_repo, pub,
-                                    latest_pkgs[p], pfmri, rmani, ref, ref_repo,
-                                    ref_xport, ref_xport_cfg, ref_pub)
-
-                        opath = target_repo.manifest(latest_pkgs[p], pub)
-                        os.remove(opath)
-                        path = target_repo.manifest(pfmri, pub)
-                        try:
-                                repo_modified = True
-                                repo_finished = False
-                                portable.rename(rmani.pathname, path)
-                        except OSError as e:
-                                abort(err=_("Could not reversion manifest "
-                                    "{path}: {err}").format(path=path,
-                                    err=str(e)))
-                        continue
-
-                # For packages we don't reversion we have to check if they
-                # depend on a reversioned package.
-                # Since the version of this dependency might be removed from the
-                # repo, we have to adjust the dep version to the one of the
-                # reversioned pkg.
-                pfmri = latest_pkgs[p]
-                omani = get_manifest(target_repo, pub, pfmri)
-                mani = manifest.Manifest(pfmri)
-                for act in omani.gen_actions():
-                        nact = adjust_dep_action(p, act, latest_ref_pkgs,
-                            reversioned_pkgs, ref_xport)
-                        if nact:
-                                mani.add_action(nact, misc.EmptyI)
-                                if nact is not act:
-                                        modified = True
-
-                # Only touch manifest if something actually changed.
-                if modified:
-                        tracker.reversion_add_progress(pfmri, adjusted=1)
-                        if not dry_run:
-                                path = target_repo.manifest(pfmri, pub)
-                                repo_modified = True
-                                repo_finished = False
-                                mani.store(path)
-        tracker.reversion_done()
-
+    # Signature will always change.
+    if a.name == "signature":
         return True
 
-def add_missing_files(target_repo, pub, latest_pkg, pfmri, rmani, ref, ref_repo,
-    ref_xport, ref_xport_cfg, ref_pub):
-        """Add missing data from reference repository to target repository."""
+    if a.name == "depend":
+        # TODO: support dependency lists
+        # For now, treat as content change.
+        if not isinstance(a.attrs["fmri"], six.string_types):
+            return False
+        dpfmri = fmri.PkgFmri(a.attrs["fmri"])
+        deps.add(dpfmri.get_pkg_stem())
+        return True
 
-        tmani = get_manifest(target_repo, pub, latest_pkg)
-        trstore = target_repo.get_pub_rstore(pub)
+    return False
 
-        thashes = frozenset(
-                ta.hash for ta in tmani.gen_actions() if ta.has_payload)
-        rhashes = frozenset(
-                ra.hash for ra in rmani.gen_actions() if ra.has_payload)
-        possible = rhashes - thashes
 
-        if ref.scheme == "file":
-                for h in possible:
-                        try:
-                                target_repo.file(h)
-                                continue
-                        except (sr.RepositoryUnsupportedOperationError,
-                            sr.RepositoryFileNotFoundError):
-                                pass
+def do_reversion(
+    pub,
+    ref_pub,
+    target_repo,
+    ref_xport,
+    changes,
+    ignores,
+    cmp_policy,
+    ref_repo,
+    ref,
+    ref_xport_cfg,
+):
+    """Do the repo reversion.
+    Return 'True' if repo got modified, 'False' otherwise."""
 
-                        try:
-                                trstore.copy_file(h, ref_repo.file(h))
-                        except (EnvironmentError,
-                            sr.RepositoryFileNotFoundError) as e:
-                                abort(err=_("Could not reversion file "
-                                    "{path}: {err}").format(path=h, err=str(e)))
-                return
+    global temp_root, tracker, dry_run, repo_finished, repo_modified
 
-        pkgdir = ref_xport_cfg.get_pkg_dir(pfmri)
-        mfile = ref_xport.multi_file_ni(ref_pub, pkgdir)
+    target_cat = target_repo.get_catalog(pub=pub)
+    ref_cat = fetch_catalog(ref_pub, ref_xport, temp_root)
 
-        downloaded = set()
-        for a in rmani.gen_actions():
-                if (a.has_payload and a.hash in possible and
-                    a.hash not in downloaded):
-                        try:
-                                target_repo.file(a.hash)
-                        except (sr.RepositoryUnsupportedOperationError,
-                            sr.RepositoryFileNotFoundError):
-                                downloaded.add(a.hash)
-                                mfile.add_action(a)
-        mfile.wait_files()
+    latest_pkgs = get_latest(target_cat)
+    latest_ref_pkgs = get_latest(ref_cat)
 
-        for h in downloaded:
-                src_path = os.path.join(pkgdir, h)
-                try:
-                        trstore.insert_file(h, src_path)
-                except (EnvironmentError,
-                    sr.RepositoryFileNotFoundError) as e:
-                        abort(err=_("Could not reversion file "
-                        "{path}: {err}").format(path=h, err=str(e)))
+    no_revs = get_matching_pkgs(target_cat, changes)
+
+    # We use bulk prefetching for faster transport of the manifests.
+    # Prefetch requires an intent which it sends to the server. Here
+    # we just use operation=reversion for all FMRIs.
+    intent = "operation=reversion;"
+    # use list() to force the zip() to evaluate
+    ref_pkgs = list(zip(latest_ref_pkgs.values(), repeat(intent)))
+
+    # Retrieve reference manifests.
+    # Try prefetching manifests in bulk first for faster, parallel
+    # transport. Retryable errors during prefetch are ignored and
+    # manifests are retrieved again during the "Reading" phase.
+    ref_xport.prefetch_manifests(ref_pkgs, progtrack=tracker)
+
+    # Need to change the output of mfst_fetch since otherwise we
+    # would see "Download Manifests x/y" twice, once from the
+    # prefetch and once from the actual manifest analysis.
+    tracker.mfst_fetch = progress.GoalTrackerItem(_("Analyzing Manifests"))
+
+    tracker.manifest_fetch_start(len(latest_pkgs))
+
+    reversioned_pkgs = set()
+    depend_changes = {}
+    dups = 0  # target pkg has equal version to ref pkg
+    new_p = 0  # target pkg not in ref
+    sucs = 0  # ref pkg is successor to pkg in targ
+    nrevs = 0  # pkgs requested to not be reversioned by user
+    manifest_errors = set()
+
+    for p in latest_pkgs:
+        # First check if the package is in the list of FMRIs the user
+        # doesn't want to reversion.
+        if p in no_revs:
+            nrevs += 1
+            tracker.manifest_fetch_progress(completion=True)
+            continue
+
+        # Check if the package is in the ref repo, if not: ignore.
+        if p not in latest_ref_pkgs:
+            new_p += 1
+            tracker.manifest_fetch_progress(completion=True)
+            continue
+
+        pfmri = latest_pkgs[p]
+        # Ignore if latest package is the same in targ and ref.
+        if pfmri == latest_ref_pkgs[p]:
+            dups += 1
+            tracker.manifest_fetch_progress(completion=True)
+            continue
+
+        # Ignore packages where ref version is higher.
+        if latest_ref_pkgs[p].is_successor(pfmri):
+            sucs += 1
+            tracker.manifest_fetch_progress(completion=True)
+            continue
+
+        # Pull the manifests for target and ref repo.
+        dm = get_manifest(target_repo, pub, pfmri)
+        rm = ref_xport.get_manifest(latest_ref_pkgs[p])
+        tracker.manifest_fetch_progress(completion=True)
+
+        tdeps = set()
+        rdeps = set()
+
+        # Diff target and ref manifest.
+        # action only in targ, action only in ref, common action
+        try:
+            ta, ra, ca = manifest.Manifest.comm([dm, rm], cmp_policy=cmp_policy)
+        except manifest.ManifestDuplicateError as e:
+            manifest_errors.add(e)
+            continue
+
+        # Check for manifest changes.
+        if not all(use_ref(a, tdeps, ignores) for a in ta) or not all(
+            use_ref(a, rdeps, ignores) for a in ra
+        ):
+            continue
+
+        # Both dep lists should be equally long in case deps have just
+        # changed. If not, it means a dep has been added or removed and
+        # that means content change.
+        if len(tdeps) != len(rdeps):
+            continue
+
+        # If len is not different we still have to make sure that
+        # entries have the same pkg stem. The test above just saves time
+        # in some cases.
+        if not all(td in rdeps for td in tdeps):
+            continue
+
+        # Pkg only contains dependency change. Keep for further
+        # analysis.
+        if tdeps:
+            depend_changes[pfmri.get_pkg_stem(anarchy=True)] = tdeps
+            continue
+
+        # Pkg passed all checks and can be reversioned.
+        reversioned_pkgs.add(pfmri.get_pkg_stem(anarchy=True))
+
+    tracker.manifest_fetch_done()
+
+    # No point continuing if errors in the manifests have
+    # been detected.
+    if manifest_errors:
+        errmsg = "".join(str(i) for i in manifest_errors)
+        abort(err=_("Manifest error(s) found:\n{}").format(errmsg))
+
+    def has_changed(pstem, seen=None, depth=0):
+        """Determine if a package or any of its dependencies has
+        changed.
+        Function will check if a dependency had a content change. If it
+        only had a dependency change, analyze its dependencies
+        recursively. Only if the whole dependency chain didn't have any
+        content change it is safe to reversion the package.
+
+        Note about circular dependencies: The function keeps track of
+        pkgs it already processed by stuffing them into the set 'seen'.
+        However, 'seen' gets updated before the child dependencies of
+        the current pkg are examined. This works if 'seen' is only used
+        for one dependency chain since the function immediately comes
+        back with a True result if a pkg has changed further down the
+        tree. However, if 'seen' is re-used between runs, it will
+        return prematurely, likely returning wrong results."""
+
+        MAX_DEPTH = 100
+
+        if not seen:
+            seen = set()
+
+        if pstem in seen:
+            return False
+
+        depth += 1
+        if depth > MAX_DEPTH:
+            # Let's make sure we don't run into any
+            # recursion limits. If the dep chain is too deep
+            # just treat as changed pkg.
+            error(
+                _(
+                    "Dependency chain depth of >{md:d} detected for" " {p}."
+                ).format(md=MAX_DEPTH, p=p)
+            )
+            return True
+
+        # Pkg has no change at all.
+        if pstem in reversioned_pkgs:
+            return False
+
+        # Pkg must have content change, if it had no change it would be
+        # in reversioned_pkgs, and if it had just a dep change it would
+        # be in depend_changes.
+        if pstem not in depend_changes:
+            return True
+
+        # We need to update 'seen' here, otherwise we won't find this
+        # entry in case of a circular dependency.
+        seen.add(pstem)
+
+        return any(has_changed(d, seen, depth) for d in depend_changes[pstem])
+
+    # Check if packages which just have a dep change can be reversioned by
+    # checking if child dependencies also have no content change.
+    dep_revs = 0
+    for p in depend_changes:
+        if not has_changed(p):
+            dep_revs += 1
+            reversioned_pkgs.add(p)
+
+    status = []
+    if cmp_policy == CMP_UNSIGNED:
+        status.append(
+            (
+                _(
+                    "WARNING: Signature changes in file content "
+                    "ignored in resurfacing"
+                )
+            )
+        )
+    status.append((_("Packages to process:"), str(len(latest_pkgs))))
+    status.append((_("New packages:"), str(new_p)))
+    status.append((_("Unmodified packages:"), str(dups)))
+    if sucs:
+        # This only happens if reference repo is ahead of target repo,
+        # so only show if it actually happened.
+        status.append(
+            (_("Packages with successors in " "reference repo:"), str(sucs))
+        )
+    if nrevs:
+        # This only happens if user specified pkgs to not revert,
+        # so only show if it actually happened.
+        status.append(
+            (
+                _("Packages not to be reversioned by user " "request:"),
+                str(nrevs),
+            )
+        )
+    status.append(
+        (
+            _("Packages with no content change:"),
+            str(len(reversioned_pkgs) - dep_revs),
+        )
+    )
+    status.append(
+        (
+            _("Packages which only have dependency change:"),
+            str(len(depend_changes)),
+        )
+    )
+    status.append(
+        (_("Packages with unchanged dependency chain:"), str(dep_revs))
+    )
+    status.append(
+        (_("Packages to be reversioned:"), str(len(reversioned_pkgs)))
+    )
+
+    rjust_status = max(len(s[0]) for s in status)
+    rjust_value = max(len(s[1]) for s in status)
+    for s in status:
+        msg("{0} {1}".format(s[0].rjust(rjust_status), s[1].rjust(rjust_value)))
+
+    if not reversioned_pkgs:
+        msg(_("\nNo packages to reversion."))
+        return False
+
+    if dry_run:
+        msg(_("\nReversioning packages (dry-run)."))
+    else:
+        msg(_("\nReversioning packages."))
+
+    # Start the main pass. Reversion packages from reversioned_pkgs to the
+    # version in the ref repo. For packages which don't get reversioned,
+    # check if the dependency versions are still correct, fix if necessary.
+    tracker.reversion_start(len(latest_pkgs), len(reversioned_pkgs))
+
+    for p in latest_pkgs:
+        tracker.reversion_add_progress(pfmri, pkgs=1)
+        modified = False
+
+        # Get the pkg fmri (pfmri) of the latest version based on if it
+        # has been reversioned or not.
+        stem = latest_pkgs[p].get_pkg_stem(anarchy=True)
+        if stem in reversioned_pkgs:
+            tracker.reversion_add_progress(pfmri, reversioned=1)
+            if dry_run:
+                continue
+            pfmri = latest_ref_pkgs[p]
+            # Retrieve manifest from ref repo and replace the one in
+            # the target repo. We don't have to adjust depndencies
+            # for these packages because they will not depend on
+            # anything we'll reversion.
+            rmani = ref_xport.get_manifest(pfmri)
+
+            if cmp_policy == CMP_UNSIGNED:
+                # Files with different signed content hash
+                # values can have equivalent unsigned content
+                # hash. CMP_UNSIGNED relaxes comparison
+                # constraints and allows this case to compare
+                # as equal. The reversioned manifest may
+                # reference file data that is not present in
+                # the target repository, so ensure that any
+                # missing file data is added to the target
+                # repository.
+                add_missing_files(
+                    target_repo,
+                    pub,
+                    latest_pkgs[p],
+                    pfmri,
+                    rmani,
+                    ref,
+                    ref_repo,
+                    ref_xport,
+                    ref_xport_cfg,
+                    ref_pub,
+                )
+
+            opath = target_repo.manifest(latest_pkgs[p], pub)
+            os.remove(opath)
+            path = target_repo.manifest(pfmri, pub)
+            try:
+                repo_modified = True
+                repo_finished = False
+                portable.rename(rmani.pathname, path)
+            except OSError as e:
+                abort(
+                    err=_(
+                        "Could not reversion manifest " "{path}: {err}"
+                    ).format(path=path, err=str(e))
+                )
+            continue
+
+        # For packages we don't reversion we have to check if they
+        # depend on a reversioned package.
+        # Since the version of this dependency might be removed from the
+        # repo, we have to adjust the dep version to the one of the
+        # reversioned pkg.
+        pfmri = latest_pkgs[p]
+        omani = get_manifest(target_repo, pub, pfmri)
+        mani = manifest.Manifest(pfmri)
+        for act in omani.gen_actions():
+            nact = adjust_dep_action(
+                p, act, latest_ref_pkgs, reversioned_pkgs, ref_xport
+            )
+            if nact:
+                mani.add_action(nact, misc.EmptyI)
+                if nact is not act:
+                    modified = True
+
+        # Only touch manifest if something actually changed.
+        if modified:
+            tracker.reversion_add_progress(pfmri, adjusted=1)
+            if not dry_run:
+                path = target_repo.manifest(pfmri, pub)
+                repo_modified = True
+                repo_finished = False
+                mani.store(path)
+    tracker.reversion_done()
+
+    return True
+
+
+def add_missing_files(
+    target_repo,
+    pub,
+    latest_pkg,
+    pfmri,
+    rmani,
+    ref,
+    ref_repo,
+    ref_xport,
+    ref_xport_cfg,
+    ref_pub,
+):
+    """Add missing data from reference repository to target repository."""
+
+    tmani = get_manifest(target_repo, pub, latest_pkg)
+    trstore = target_repo.get_pub_rstore(pub)
+
+    thashes = frozenset(ta.hash for ta in tmani.gen_actions() if ta.has_payload)
+    rhashes = frozenset(ra.hash for ra in rmani.gen_actions() if ra.has_payload)
+    possible = rhashes - thashes
+
+    if ref.scheme == "file":
+        for h in possible:
+            try:
+                target_repo.file(h)
+                continue
+            except (
+                sr.RepositoryUnsupportedOperationError,
+                sr.RepositoryFileNotFoundError,
+            ):
+                pass
+
+            try:
+                trstore.copy_file(h, ref_repo.file(h))
+            except (EnvironmentError, sr.RepositoryFileNotFoundError) as e:
+                abort(
+                    err=_("Could not reversion file " "{path}: {err}").format(
+                        path=h, err=str(e)
+                    )
+                )
+        return
+
+    pkgdir = ref_xport_cfg.get_pkg_dir(pfmri)
+    mfile = ref_xport.multi_file_ni(ref_pub, pkgdir)
+
+    downloaded = set()
+    for a in rmani.gen_actions():
+        if a.has_payload and a.hash in possible and a.hash not in downloaded:
+            try:
+                target_repo.file(a.hash)
+            except (
+                sr.RepositoryUnsupportedOperationError,
+                sr.RepositoryFileNotFoundError,
+            ):
+                downloaded.add(a.hash)
+                mfile.add_action(a)
+    mfile.wait_files()
+
+    for h in downloaded:
+        src_path = os.path.join(pkgdir, h)
+        try:
+            trstore.insert_file(h, src_path)
+        except (EnvironmentError, sr.RepositoryFileNotFoundError) as e:
+            abort(
+                err=_("Could not reversion file " "{path}: {err}").format(
+                    path=h, err=str(e)
+                )
+            )
+
 
 def main_func():
+    global temp_root, repo_modified, repo_finished, repo_uri, tracker
+    global dry_run
 
-        global temp_root, repo_modified, repo_finished, repo_uri, tracker
-        global dry_run
+    global_settings.client_name = PKG_CLIENT_NAME
 
-        global_settings.client_name = PKG_CLIENT_NAME
+    try:
+        opts, pargs = getopt.getopt(sys.argv[1:], "?c:i:np:r:s:u", ["help"])
+    except getopt.GetoptError as e:
+        usage(_("illegal option -- {0}").format(e.opt))
 
+    dry_run = False
+    ref_repo_uri = None
+    repo_uri = os.getenv("PKG_REPO", None)
+    changes = set()
+    ignores = set()
+    publishers = set()
+    cmp_policy = CMP_ALL
+
+    processed_pubs = 0
+
+    for opt, arg in opts:
+        if opt == "-c":
+            changes.add(arg)
+        elif opt == "-i":
+            ignores.add(arg)
+        elif opt == "-n":
+            dry_run = True
+        elif opt == "-p":
+            publishers.add(arg)
+        elif opt == "-r":
+            ref_repo_uri = misc.parse_uri(arg)
+        elif opt == "-s":
+            repo_uri = misc.parse_uri(arg)
+        elif opt == "-u":
+            cmp_policy = CMP_UNSIGNED
+        elif opt == "-?" or opt == "--help":
+            usage(retcode=pkgdefs.EXIT_OK)
+
+    if pargs:
+        usage(_("Unexpected argument(s): {0}").format(" ".join(pargs)))
+
+    if not repo_uri:
+        usage(_("A target repository must be provided."))
+
+    if not ref_repo_uri:
+        usage(_("A reference repository must be provided."))
+
+    target = publisher.RepositoryURI(misc.parse_uri(repo_uri))
+    if target.scheme != "file":
+        abort(err=_("Target repository must be filesystem-based."))
+    try:
+        target_repo = sr.Repository(
+            read_only=dry_run, root=target.get_pathname()
+        )
+    except sr.RepositoryError as e:
+        abort(str(e))
+
+    # Use the tmp directory in target repo for efficient file rename since
+    # files are in the same file system.
+    temp_root = target_repo.temp_root
+    if not os.path.exists(temp_root):
+        os.makedirs(temp_root)
+
+    ref_incoming_dir = tempfile.mkdtemp(dir=temp_root)
+    ref_pkg_root = tempfile.mkdtemp(dir=temp_root)
+
+    ref_xport, ref_xport_cfg = transport.setup_transport()
+    ref_xport_cfg.incoming_root = ref_incoming_dir
+    ref_xport_cfg.pkg_root = ref_pkg_root
+    transport.setup_publisher(
+        ref_repo_uri, "ref", ref_xport, ref_xport_cfg, remote_prefix=True
+    )
+
+    ref_repo = None
+    ref = publisher.RepositoryURI(misc.parse_uri(ref_repo_uri))
+    if ref.scheme == "file":
         try:
-                opts, pargs = getopt.getopt(sys.argv[1:], "?c:i:np:r:s:u",
-                    ["help"])
-        except getopt.GetoptError as e:
-                usage(_("illegal option -- {0}").format(e.opt))
-
-        dry_run = False
-        ref_repo_uri = None
-        repo_uri = os.getenv("PKG_REPO", None)
-        changes = set()
-        ignores = set()
-        publishers = set()
-        cmp_policy = CMP_ALL
-
-        processed_pubs = 0
-
-        for opt, arg in opts:
-                if opt == "-c":
-                        changes.add(arg)
-                elif opt == "-i":
-                        ignores.add(arg)
-                elif opt == "-n":
-                        dry_run = True
-                elif opt == "-p":
-                        publishers.add(arg)
-                elif opt == "-r":
-                        ref_repo_uri = misc.parse_uri(arg)
-                elif opt == "-s":
-                        repo_uri = misc.parse_uri(arg)
-                elif opt == "-u":
-                        cmp_policy = CMP_UNSIGNED
-                elif opt == "-?" or opt == "--help":
-                        usage(retcode=pkgdefs.EXIT_OK)
-
-        if pargs:
-                usage(_("Unexpected argument(s): {0}").format(" ".join(pargs)))
-
-        if not repo_uri:
-                usage(_("A target repository must be provided."))
-
-        if not ref_repo_uri:
-                usage(_("A reference repository must be provided."))
-
-        target = publisher.RepositoryURI(misc.parse_uri(repo_uri))
-        if target.scheme != "file":
-                abort(err=_("Target repository must be filesystem-based."))
-        try:
-                target_repo = sr.Repository(read_only=dry_run,
-                    root=target.get_pathname())
+            # It is possible that the client does not
+            # have write access to the reference repo
+            # so open it read-only to prevent the
+            # attempt to create a lock file in it.
+            ref_repo = sr.Repository(read_only=True, root=ref.get_pathname())
         except sr.RepositoryError as e:
-                abort(str(e))
+            abort(str(e))
 
-        # Use the tmp directory in target repo for efficient file rename since
-        # files are in the same file system.
-        temp_root = target_repo.temp_root
-        if not os.path.exists(temp_root):
-                os.makedirs(temp_root)
+    tracker = get_tracker()
 
-        ref_incoming_dir = tempfile.mkdtemp(dir=temp_root)
-        ref_pkg_root = tempfile.mkdtemp(dir=temp_root)
+    for pub in target_repo.publishers:
+        if publishers and pub not in publishers and "*" not in publishers:
+            continue
 
-        ref_xport, ref_xport_cfg = transport.setup_transport()
-        ref_xport_cfg.incoming_root = ref_incoming_dir
-        ref_xport_cfg.pkg_root = ref_pkg_root
-        transport.setup_publisher(ref_repo_uri, "ref", ref_xport,
-            ref_xport_cfg, remote_prefix=True)
+        msg(_("Processing packages for publisher {0} ...").format(pub))
+        # Find the matching pub in the ref repo.
+        for ref_pub in ref_xport_cfg.gen_publishers():
+            if ref_pub.prefix == pub:
+                found = True
+                break
+        else:
+            txt = _(
+                "Publisher {0} not found in reference " "repository."
+            ).format(pub)
+            if publishers:
+                abort(err=txt)
+            else:
+                txt += _(" Skipping.")
+                msg(txt)
+            continue
 
-        ref_repo = None
-        ref = publisher.RepositoryURI(misc.parse_uri(ref_repo_uri))
-        if ref.scheme == "file":
-                try:
-                        # It is possible that the client does not
-                        # have write access to the reference repo
-                        # so open it read-only to prevent the
-                        # attempt to create a lock file in it.
-                        ref_repo = sr.Repository(read_only=True,
-                            root=ref.get_pathname())
-                except sr.RepositoryError as e:
-                        abort(str(e))
+        processed_pubs += 1
 
-        tracker = get_tracker()
+        rev = do_reversion(
+            pub,
+            ref_pub,
+            target_repo,
+            ref_xport,
+            changes,
+            ignores,
+            cmp_policy,
+            ref_repo,
+            ref,
+            ref_xport_cfg,
+        )
 
-        for pub in target_repo.publishers:
-                if publishers and pub not in publishers \
-                    and '*' not in publishers:
-                        continue
+        # If anything was reversioned rebuild the catalog and index
+        # to reflect those changes.
+        if rev and not dry_run:
+            msg(_("Rebuilding repository catalog."))
+            target_repo.rebuild(pub=pub, build_index=True)
+        repo_finished = True
 
-                msg(_("Processing packages for publisher {0} ...").format(pub))
-                # Find the matching pub in the ref repo.
-                for ref_pub in ref_xport_cfg.gen_publishers():
-                        if ref_pub.prefix == pub:
-                                found = True
-                                break
-                else:
-                        txt = _("Publisher {0} not found in reference "
-                            "repository.").format(pub)
-                        if publishers:
-                                abort(err=txt)
-                        else:
-                                txt += _(" Skipping.")
-                                msg(txt)
-                        continue
-
-                processed_pubs += 1
-
-                rev = do_reversion(pub, ref_pub, target_repo, ref_xport,
-                    changes, ignores, cmp_policy, ref_repo, ref, ref_xport_cfg)
-
-                # If anything was reversioned rebuild the catalog and index
-                # to reflect those changes.
-                if rev and not dry_run:
-                        msg(_("Rebuilding repository catalog."))
-                        target_repo.rebuild(pub=pub, build_index=True)
-                repo_finished = True
-
-        ret = pkgdefs.EXIT_OK
-        if processed_pubs == 0:
-                msg(_("No matching publishers could be found."))
-                ret = pkgdefs.EXIT_OOPS
-        cleanup()
-        return ret
+    ret = pkgdefs.EXIT_OK
+    if processed_pubs == 0:
+        msg(_("No matching publishers could be found."))
+        ret = pkgdefs.EXIT_OOPS
+    cleanup()
+    return ret
 
 
 #
@@ -892,40 +990,39 @@ def main_func():
 # so that we can more easily detect these in testing of the CLI commands.
 #
 if __name__ == "__main__":
-        misc.setlocale(locale.LC_ALL, "", error)
-        gettext.install("pkg", "/usr/share/locale")
-        misc.set_fd_limits(printer=error)
+    misc.setlocale(locale.LC_ALL, "", error)
+    gettext.install("pkg", "/usr/share/locale")
+    misc.set_fd_limits(printer=error)
 
-        if six.PY3:
-                # disable ResourceWarning: unclosed file
-                warnings.filterwarnings("ignore", category=ResourceWarning)
-        try:
-                __ret = main_func()
-        except PipeError:
-                # We don't want to display any messages here to prevent
-                # possible further broken pipe (EPIPE) errors.
-                cleanup(no_msg =True)
-                __ret = pkgdefs.EXIT_OOPS
-        except (KeyboardInterrupt, api_errors.CanceledException):
-                cleanup()
-                __ret = pkgdefs.EXIT_OOPS
-        except (actions.ActionError, RuntimeError,
-            api_errors.ApiException) as _e:
-                error(_e)
-                cleanup()
-                __ret = pkgdefs.EXIT_OOPS
-        except EnvironmentError as _e:
-                error(api_errors._convert_error(_e))
-                cleanup()
-                __ret = pkgdefs.EXIT_OOPS
-        except SystemExit as _e:
-                cleanup()
-                raise _e
-        except:
-                traceback.print_exc()
-                error(misc.get_traceback_message())
-                __ret = 99
-        sys.exit(__ret)
+    if six.PY3:
+        # disable ResourceWarning: unclosed file
+        warnings.filterwarnings("ignore", category=ResourceWarning)
+    try:
+        __ret = main_func()
+    except PipeError:
+        # We don't want to display any messages here to prevent
+        # possible further broken pipe (EPIPE) errors.
+        cleanup(no_msg=True)
+        __ret = pkgdefs.EXIT_OOPS
+    except (KeyboardInterrupt, api_errors.CanceledException):
+        cleanup()
+        __ret = pkgdefs.EXIT_OOPS
+    except (actions.ActionError, RuntimeError, api_errors.ApiException) as _e:
+        error(_e)
+        cleanup()
+        __ret = pkgdefs.EXIT_OOPS
+    except EnvironmentError as _e:
+        error(api_errors._convert_error(_e))
+        cleanup()
+        __ret = pkgdefs.EXIT_OOPS
+    except SystemExit as _e:
+        cleanup()
+        raise _e
+    except:
+        traceback.print_exc()
+        error(misc.get_traceback_message())
+        __ret = 99
+    sys.exit(__ret)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/publish/update_file_layout.py
+++ b/src/util/publish/update_file_layout.py
@@ -42,87 +42,92 @@ from pkg.misc import emsg, PipeError, setlocale
 
 logger = global_settings.logger
 
+
 def error(text, cmd=None):
-        """Emit an error message prefixed by the command name """
+    """Emit an error message prefixed by the command name"""
 
-        if cmd:
-                text = "{0}: {1}".format(cmd, text)
-                pkg_cmd = "pkg.migrate "
-        else:
-                pkg_cmd = "pkg.migrate: "
+    if cmd:
+        text = "{0}: {1}".format(cmd, text)
+        pkg_cmd = "pkg.migrate "
+    else:
+        pkg_cmd = "pkg.migrate: "
 
-                # If we get passed something like an Exception, we can convert
-                # it down to a string.
-                text = str(text)
+        # If we get passed something like an Exception, we can convert
+        # it down to a string.
+        text = str(text)
 
-        # If the message starts with whitespace, assume that it should come
-        # *before* the command-name prefix.
-        text_nows = text.lstrip()
-        ws = text[:len(text) - len(text_nows)]
+    # If the message starts with whitespace, assume that it should come
+    # *before* the command-name prefix.
+    text_nows = text.lstrip()
+    ws = text[: len(text) - len(text_nows)]
 
-        # This has to be a constant value as we can't reliably get our actual
-        # program name on all platforms.
-        logger.error(ws + pkg_cmd + text_nows)
+    # This has to be a constant value as we can't reliably get our actual
+    # program name on all platforms.
+    logger.error(ws + pkg_cmd + text_nows)
+
 
 def main_func():
-        if len(sys.argv) != 2:
-                emsg(_("pkg.migrate takes a single directory as a parameter."))
-                return 2
-        
-        dir_loc = os.path.abspath(sys.argv[1])
+    if len(sys.argv) != 2:
+        emsg(_("pkg.migrate takes a single directory as a parameter."))
+        return 2
 
-        if not os.path.isdir(dir_loc):
-                emsg(_("The argument must be a directory to migrate from older "
-                    "layouts to the current\npreferred layout."))
-                return 2
+    dir_loc = os.path.abspath(sys.argv[1])
 
-        fm = file_manager.FileManager(root=dir_loc, readonly=False)
-        try:
-                for f in fm.walk():
-                        # A non-readonly FileManager will move a file under a
-                        # non-preferred layout to the preferred layout during a
-                        # lookup.
-                        fm.lookup(f)
-        except file_manager.UnrecognizedFilePaths as e:
-                emsg(e)
-                return 1
-        return 0
+    if not os.path.isdir(dir_loc):
+        emsg(
+            _(
+                "The argument must be a directory to migrate from older "
+                "layouts to the current\npreferred layout."
+            )
+        )
+        return 2
+
+    fm = file_manager.FileManager(root=dir_loc, readonly=False)
+    try:
+        for f in fm.walk():
+            # A non-readonly FileManager will move a file under a
+            # non-preferred layout to the preferred layout during a
+            # lookup.
+            fm.lookup(f)
+    except file_manager.UnrecognizedFilePaths as e:
+        emsg(e)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-        setlocale(locale.LC_ALL, "")
-        gettext.install("pkg", "/usr/share/locale")
+    setlocale(locale.LC_ALL, "")
+    gettext.install("pkg", "/usr/share/locale")
 
-        traceback_str = misc.get_traceback_message()
+    traceback_str = misc.get_traceback_message()
 
+    try:
+        # Out of memory errors can be raised as EnvironmentErrors with
+        # an errno of ENOMEM, so in order to handle those exceptions
+        # with other errnos, we nest this try block and have the outer
+        # one handle the other instances.
         try:
-                # Out of memory errors can be raised as EnvironmentErrors with
-                # an errno of ENOMEM, so in order to handle those exceptions
-                # with other errnos, we nest this try block and have the outer
-                # one handle the other instances.
-                try:
-                        __ret = main_func()
-                except (MemoryError, EnvironmentError) as __e:
-                        if isinstance(__e, EnvironmentError) and \
-                            __e.errno != errno.ENOMEM:
-                                raise
-                        if __img:
-                                __img.history.abort(RESULT_FAILED_OUTOFMEMORY)
-                        error("\n" + misc.out_of_memory())
-                        __ret = 1
-        except SystemExit as __e:
+            __ret = main_func()
+        except (MemoryError, EnvironmentError) as __e:
+            if isinstance(__e, EnvironmentError) and __e.errno != errno.ENOMEM:
                 raise
-        except (PipeError, KeyboardInterrupt):
-                if __img:
-                        __img.history.abort(RESULT_CANCELED)
-                # We don't want to display any messages here to prevent
-                # possible further broken pipe (EPIPE) errors.
-                __ret = 1
-        except:
-                traceback.print_exc()
-                error(traceback_str)
-                __ret = 99
-        sys.exit(__ret)
+            if __img:
+                __img.history.abort(RESULT_FAILED_OUTOFMEMORY)
+            error("\n" + misc.out_of_memory())
+            __ret = 1
+    except SystemExit as __e:
+        raise
+    except (PipeError, KeyboardInterrupt):
+        if __img:
+            __img.history.abort(RESULT_CANCELED)
+        # We don't want to display any messages here to prevent
+        # possible further broken pipe (EPIPE) errors.
+        __ret = 1
+    except:
+        traceback.print_exc()
+        error(traceback_str)
+        __ret = 99
+    sys.exit(__ret)
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker

--- a/src/util/qual-simulator/depot.py
+++ b/src/util/qual-simulator/depot.py
@@ -25,6 +25,7 @@
 #
 
 from __future__ import division
+
 # pylint is picky about this message:
 # old-division; pylint: disable=W1619
 import math
@@ -84,135 +85,149 @@ CSPEED_FARAWAY = 3500
 
 
 class RepositoryURI(object):
-        def __init__(self, label, speed, cspeed, error_rate=ERROR_FREE,
-            error_type=ERROR_T_NET, modality=MODAL_SINGLE):
-                """Create a RepositoryURI object.  The 'speed' argument
-                gives the speed in kB/s.  The 'cspeed' argument gives the
-                connect time in milliseconds.  The 'error_rate' variable
-                defines how often errors occur.  The error_type is
-                defined by 'error_type'.  The 'modality' argument
-                defines the different speed distributions."""
+    def __init__(
+        self,
+        label,
+        speed,
+        cspeed,
+        error_rate=ERROR_FREE,
+        error_type=ERROR_T_NET,
+        modality=MODAL_SINGLE,
+    ):
+        """Create a RepositoryURI object.  The 'speed' argument
+        gives the speed in kB/s.  The 'cspeed' argument gives the
+        connect time in milliseconds.  The 'error_rate' variable
+        defines how often errors occur.  The error_type is
+        defined by 'error_type'.  The 'modality' argument
+        defines the different speed distributions."""
 
-                # Production members
-                self.uri = "http://" + label
-                self.priority = 1
+        # Production members
+        self.uri = "http://" + label
+        self.priority = 1
 
-                # Simulator members
-                self.label = label
-                self.speed = speed * 1024
-                self.cspeed = cspeed / 1000.0
-                self.maxtx = 10000.0
-                self.warmtx = 1000.0
-                self.minspeed = .1
-                self.__tx = 0
-                self.__error_rate = error_rate / 1000.0
-                self.__error_type = error_type
-                self.__response_modality = modality
-                self.__decay = 0.9
-                self.__proxy = None
-                self.__system = None
-                self.aggregate_decay = 1
+        # Simulator members
+        self.label = label
+        self.speed = speed * 1024
+        self.cspeed = cspeed / 1000.0
+        self.maxtx = 10000.0
+        self.warmtx = 1000.0
+        self.minspeed = 0.1
+        self.__tx = 0
+        self.__error_rate = error_rate / 1000.0
+        self.__error_type = error_type
+        self.__response_modality = modality
+        self.__decay = 0.9
+        self.__proxy = None
+        self.__system = None
+        self.aggregate_decay = 1
 
-                self.stats = stats.RepoStats(self)
+        self.stats = stats.RepoStats(self)
 
-        def __get_proxy(self):
-                return self.__proxy
+    def __get_proxy(self):
+        return self.__proxy
 
-        def __set_proxy(self, val):
-                self.__proxy = val
+    def __set_proxy(self, val):
+        self.__proxy = val
 
-        def __get_system(self):
-                return self.__system
+    def __get_system(self):
+        return self.__system
 
-        def __set_system(self, val):
-                self.__system = val
+    def __set_system(self, val):
+        self.__system = val
 
-        proxy = property(__get_proxy, __set_proxy, None, "Proxy of the "
-            "repository URI.")
+    proxy = property(
+        __get_proxy, __set_proxy, None, "Proxy of the " "repository URI."
+    )
 
-        system = property(__get_system, __set_system, None, "System publisher "
-            "of the repository URI.")
+    system = property(
+        __get_system,
+        __set_system,
+        None,
+        "System publisher " "of the repository URI.",
+    )
 
-        def key(self):
-                """Returns a value that can be used to identify this RepoURI
-                uniquely for the transport system.  Normally, this would be done
-                using __hash__() however, TransportRepoURI objects are not
-                guaranteed to be immutable.
+    def key(self):
+        """Returns a value that can be used to identify this RepoURI
+        uniquely for the transport system.  Normally, this would be done
+        using __hash__() however, TransportRepoURI objects are not
+        guaranteed to be immutable.
 
-                The key is a (uri, proxy) tuple, where the proxy is
-                the proxy used to reach that URI.  Note that in the transport
-                system, we may choose to override the proxy value here."""
+        The key is a (uri, proxy) tuple, where the proxy is
+        the proxy used to reach that URI.  Note that in the transport
+        system, we may choose to override the proxy value here."""
 
-                u = self.uri
-                p = self.__proxy
+        u = self.uri
+        p = self.__proxy
 
-                if self.uri:
-                        u = self.uri.rstrip("/")
-                return (u, p)
+        if self.uri:
+            u = self.uri.rstrip("/")
+        return (u, p)
 
-        def speed_single(self, size):
-                """Implements a depot that runs at a single speed."""
+    def speed_single(self, size):
+        """Implements a depot that runs at a single speed."""
 
-                return size / random.gauss(self.speed, self.speed / 4)
+        return size / random.gauss(self.speed, self.speed / 4)
 
-        def speed_increasing(self, size):
-                """Depot's speed gradually increases over time."""
+    def speed_increasing(self, size):
+        """Depot's speed gradually increases over time."""
 
-                s = min(self.minspeed + (self.__tx / self.warmtx), 1) * \
-                    random.gauss(self.speed, self.speed / 4)
+        s = min(self.minspeed + (self.__tx / self.warmtx), 1) * random.gauss(
+            self.speed, self.speed / 4
+        )
 
-                return size / s
+        return size / s
 
-        def speed_decay(self, size):
-                """Depot gets slower as time goes on."""
+    def speed_decay(self, size):
+        """Depot gets slower as time goes on."""
 
-                if random.uniform(0., 1.) < 0.05:
-                        self.aggregate_decay *= self.__decay
+        if random.uniform(0.0, 1.0) < 0.05:
+            self.aggregate_decay *= self.__decay
 
-                return size / (self.aggregate_decay *
-                    random.gauss(self.speed, self.speed / 4))
+        return size / (
+            self.aggregate_decay * random.gauss(self.speed, self.speed / 4)
+        )
 
-        def request(self, rc, size=None):
-                """Simulate a transport request using RepoChooser 'rc'.
-                Size is given in the 'size' argument."""
+    def request(self, rc, size=None):
+        """Simulate a transport request using RepoChooser 'rc'.
+        Size is given in the 'size' argument."""
 
-                errors = 0
+        errors = 0
 
-                if not size:
-                        size = random.randint(1, 1000) * 1024
+        if not size:
+            size = random.randint(1, 1000) * 1024
 
-                if not rc[self.key()].used:
-                        rc[self.key()].record_connection(self.cspeed)
-                else:
-                        conn_choose = (1 / self.maxtx) * \
-                            math.exp(-1 / self.maxtx)
-                        if random.random() < conn_choose:
-                                rc[self.key()].record_connection(self.cspeed)
+        if not rc[self.key()].used:
+            rc[self.key()].record_connection(self.cspeed)
+        else:
+            conn_choose = (1 / self.maxtx) * math.exp(-1 / self.maxtx)
+            if random.random() < conn_choose:
+                rc[self.key()].record_connection(self.cspeed)
 
-                rc[self.key()].record_tx()
-                self.__tx += 1
+        rc[self.key()].record_tx()
+        self.__tx += 1
 
-                if random.random() < self.__error_rate:
-                        if self.__error_type == ERROR_T_DECAYABLE:
-                                rc[self.key()].record_error(decayable=True)
-                        elif self.__error_type == ERROR_T_CONTENT:
-                                rc[self.key()].record_error(content=True)
-                        else:
-                                rc[self.key()].record_error()
-                        return (1, size, None)
+        if random.random() < self.__error_rate:
+            if self.__error_type == ERROR_T_DECAYABLE:
+                rc[self.key()].record_error(decayable=True)
+            elif self.__error_type == ERROR_T_CONTENT:
+                rc[self.key()].record_error(content=True)
+            else:
+                rc[self.key()].record_error()
+            return (1, size, None)
 
-                if self.__response_modality == MODAL_SINGLE:
-                        time = self.speed_single(size)
-                elif self.__response_modality == MODAL_DECAY:
-                        time = self.speed_decay(size)
-                elif self.__response_modality == MODAL_INCREASING:
-                        time = self.speed_increasing(size)
-                else:
-                        raise RuntimeError("no modality")
+        if self.__response_modality == MODAL_SINGLE:
+            time = self.speed_single(size)
+        elif self.__response_modality == MODAL_DECAY:
+            time = self.speed_decay(size)
+        elif self.__response_modality == MODAL_INCREASING:
+            time = self.speed_increasing(size)
+        else:
+            raise RuntimeError("no modality")
 
-                rc[self.key()].record_progress(size, time)
+        rc[self.key()].record_progress(size, time)
 
-                return (errors, size, time)
+        return (errors, size, time)
+
 
 # Vim hints
-# vim:ts=8:sw=8:et:fdm=marker
+# vim:ts=4:sw=4:et:fdm=marker


### PR DESCRIPTION
Oracle have recently completely reformatted the upstream pkg5 repository to PEP8 style, using four spaces for indentation. We should do something similar to make it easier to pull in changes and compare the two.

I've opted to use [Black](https://black.readthedocs.io/) to automate this, and also added a CI check so that we keep things in that format. It's not exactly the same as the Oracle reformatting but it's close enough.

There were a couple of places I turned off the formatter (via `#fmt` comments) - I did not like how it reformatted the tables in some of the brand code, and it actually broke some of the testsuite by using a python 3.6+ feature when the test passes a particular file to python 2.7 on purpose, to exercise the foreign python version dependency resolver.

I've also added a `.git-blame-ignore-revs` file containing the big reformatting git hash. Github will automatically use this when showing blame information in its web interface, and the file can be used with the `git` tool via
```
git blame --ignore-revs-file .git-blame-ignore-revs
```
and configured automatically for a checked out repository via:
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

A full testsuite run is successful following this change:

```
# Ran 1069 tests in 1907.912s - skipped 1 tests.

======================================================================
BASELINE MATCH
======================================================================
```